### PR TITLE
Add release-aligned docs bundle publishing

### DIFF
--- a/.github/workflows/pr-quick-check.yml
+++ b/.github/workflows/pr-quick-check.yml
@@ -22,6 +22,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: sandbox0-ui/package-lock.json
+
       - name: Restore infra build cache
         uses: ./.github/actions/restore-infra-build-cache
         with:
@@ -60,6 +72,17 @@ jobs:
         run: |
           make proto manifests apispec
           git diff --exit-code
+
+      - name: Install website dependencies
+        run: npm ci --prefix sandbox0-ui
+
+      - name: Verify docs bundle generation
+        shell: bash
+        run: |
+          export SOURCE_DATE_EPOCH="$(git log -1 --format=%ct)"
+          SANDBOX0_DOCS_VERSION=pr-check npm run build:docs-bundle --prefix sandbox0-ui
+          test -f sandbox0-ui/apps/website/dist/docs-bundles/sandbox0-docs-bundle-pr-check.tar.gz
+          test -f sandbox0-ui/apps/website/dist/docs-bundles/sandbox0-docs-bundle-pr-check.tar.gz.sha256
 
       - name: Verify go.mod/go.sum are tidy
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ env:
   IMAGE_REPO: sandbox0ai/infra
   HELM_REPO_URL: https://charts.sandbox0.ai
   HELM_REPO_DOMAIN: charts.sandbox0.ai
+  DOCS_BUNDLE_PREFIX: sandbox0-docs-bundle
 
 permissions:
   contents: write
@@ -242,19 +243,79 @@ jobs:
           git push origin gh-pages
           popd
 
+  publish-docs-bundle:
+    name: Publish docs bundle artifact
+    runs-on: ubuntu-latest
+    needs: prepare-release
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: sandbox0-ui/package-lock.json
+
+      - name: Install website dependencies
+        run: npm ci --prefix sandbox0-ui
+
+      - name: Build release-aligned docs bundle
+        env:
+          SANDBOX0_DOCS_VERSION: ${{ needs.prepare-release.outputs.version }}
+        run: |
+          export SOURCE_DATE_EPOCH="$(git log -1 --format=%ct)"
+          npm run build:docs-bundle --prefix sandbox0-ui
+          test -f "sandbox0-ui/apps/website/dist/docs-bundles/${DOCS_BUNDLE_PREFIX}-${SANDBOX0_DOCS_VERSION}.tar.gz"
+          test -f "sandbox0-ui/apps/website/dist/docs-bundles/${DOCS_BUNDLE_PREFIX}-${SANDBOX0_DOCS_VERSION}.tar.gz.sha256"
+
+      - name: Upload docs bundle artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-bundle-release-assets
+          path: |
+            sandbox0-ui/apps/website/dist/docs-bundles/${{ env.DOCS_BUNDLE_PREFIX }}-${{ needs.prepare-release.outputs.version }}.tar.gz
+            sandbox0-ui/apps/website/dist/docs-bundles/${{ env.DOCS_BUNDLE_PREFIX }}-${{ needs.prepare-release.outputs.version }}.tar.gz.sha256
+          if-no-files-found: error
+
+  publish-github-release:
+    name: Publish GitHub release metadata
+    runs-on: ubuntu-latest
+    needs:
+      - prepare-release
+      - publish-helm
+      - publish-docs-bundle
+    steps:
+      - name: Download docs bundle release assets
+        uses: actions/download-artifact@v4
+        with:
+          name: docs-bundle-release-assets
+          path: .release-assets
+
       - name: Create or update GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="${GITHUB_REF_NAME}"
+          VERSION="${{ needs.prepare-release.outputs.version }}"
           OWNER_LOWER="${GITHUB_REPOSITORY_OWNER,,}"
+          DOCS_ARCHIVE="${DOCS_BUNDLE_PREFIX}-${VERSION}.tar.gz"
+          DOCS_CHECKSUM="${DOCS_ARCHIVE}.sha256"
           NOTES=$(cat <<EOF
           Automated release for ${TAG}.
 
           Published artifacts:
-          - Docker image: docker.io/${IMAGE_REPO}:${{ needs.prepare-release.outputs.version }}
+          - Docker image: docker.io/${IMAGE_REPO}:${VERSION}
           - Helm OCI: oci://ghcr.io/${OWNER_LOWER}/charts/infra-operator
           - Helm repo: https://sandbox0-ai.github.io/sandbox0
+          - Docs bundle: ${DOCS_ARCHIVE}
+          - Docs checksum: ${DOCS_CHECKSUM}
           EOF
           )
 
@@ -267,3 +328,9 @@ jobs:
             fi
             gh release create "${TAG}" "${args[@]}"
           fi
+
+      - name: Upload release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${GITHUB_REF_NAME}" .release-assets/* --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ test
 
 # document codes
 sandbox0-ui/apps/website/src/app/docs/docs-codes
+sandbox0-ui/apps/website/.next/
+sandbox0-ui/apps/website/out/
+sandbox0-ui/apps/website/dist/
 
 # Output of the go coverage tool
 *.out

--- a/sandbox0-ui/apps/website/package.json
+++ b/sandbox0-ui/apps/website/package.json
@@ -4,10 +4,12 @@
   "private": true,
   "scripts": {
     "docs:generate:sandbox0infra-schema": "cd ../../.. && mkdir -p .cache/go-build && GOCACHE=$PWD/.cache/go-build go run ./sandbox0-ui/apps/website/scripts/generate_sandbox0infra_schema.go",
+    "docs:bundle:pack": "cd ../../.. && mkdir -p .cache/go-build && GOCACHE=$PWD/.cache/go-build go run ./sandbox0-ui/apps/website/scripts/docsbundle -version ${SANDBOX0_DOCS_VERSION:-dev}",
     "predev": "npm run docs:generate:sandbox0infra-schema",
     "dev": "next dev --port 4300",
     "prebuild": "npm run docs:generate:sandbox0infra-schema",
     "build": "next build",
+    "docs:bundle": "npm run build && npm run docs:bundle:pack",
     "start": "next start --port 4300",
     "lint": "next lint"
   },

--- a/sandbox0-ui/apps/website/scripts/docsbundle/main.go
+++ b/sandbox0-ui/apps/website/scripts/docsbundle/main.go
@@ -1,0 +1,557 @@
+package main
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	docsBundleSchemaVersion = "1"
+	docsBundleKind          = "sandbox0.docs-bundle"
+	timeFormatRFC3339       = "2006-01-02T15:04:05Z"
+)
+
+type bundleManifest struct {
+	SchemaVersion   string          `json:"schemaVersion"`
+	Kind            string          `json:"kind"`
+	Sandbox0Version string          `json:"sandbox0Version"`
+	GeneratedAt     string          `json:"generatedAt"`
+	SourcePriority  []string        `json:"sourcePriority"`
+	Authority       bundleAuthority `json:"authorityBoundary"`
+	Bundle          bundleLayout    `json:"bundle"`
+	Documents       []docsDocument  `json:"documents"`
+}
+
+type bundleAuthority struct {
+	AuthoritativeSources []string `json:"authoritativeSources"`
+	BundledDocsRole      string   `json:"bundledDocsRole"`
+}
+
+type bundleLayout struct {
+	Root             string   `json:"root"`
+	SourceDocsDir    string   `json:"sourceDocsDir"`
+	GeneratedDocsDir string   `json:"generatedDocsDir,omitempty"`
+	SiteExportDir    string   `json:"siteExportDir"`
+	NavigationFiles  []string `json:"navigationFiles"`
+	ChecksumFile     string   `json:"checksumFile"`
+	ArchiveFile      string   `json:"archiveFile"`
+	ArchiveSHA256    string   `json:"archiveSha256File"`
+}
+
+type docsDocument struct {
+	Title      string `json:"title"`
+	Route      string `json:"route"`
+	SourcePath string `json:"sourcePath"`
+	SHA256     string `json:"sha256"`
+}
+
+type bundler struct {
+	repoRoot   string
+	siteDir    string
+	sourceDir  string
+	generated  string
+	exportDir  string
+	bundleRoot string
+	version    string
+	now        time.Time
+}
+
+type bundleResult struct {
+	bundleDir         string
+	archivePath       string
+	archiveSHA256Path string
+	manifestPath      string
+}
+
+func main() {
+	var (
+		version    = flag.String("version", "", "Sandbox0 release version for the docs bundle")
+		repoRoot   = flag.String("repo-root", "", "Repository root path")
+		siteDir    = flag.String("site-dir", "", "Website app root path")
+		sourceDir  = flag.String("source-dir", "", "Docs source directory")
+		generated  = flag.String("generated-dir", "", "Generated docs assets directory")
+		exportDir  = flag.String("export-dir", "", "Static website export directory")
+		bundleRoot = flag.String("bundle-root", "", "Output directory for generated docs bundles")
+	)
+	flag.Parse()
+
+	if strings.TrimSpace(*version) == "" {
+		fail(fmt.Errorf("missing required -version"))
+	}
+
+	root := strings.TrimSpace(*repoRoot)
+	if root == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			fail(err)
+		}
+		root = cwd
+	}
+
+	site := firstNonEmpty(*siteDir, filepath.Join(root, "sandbox0-ui", "apps", "website"))
+	source := firstNonEmpty(*sourceDir, filepath.Join(site, "src", "app", "docs"))
+	generatedDir := firstNonEmpty(*generated, filepath.Join(site, "src", "generated", "docs"))
+	exported := firstNonEmpty(*exportDir, filepath.Join(site, "out"))
+	outputRoot := firstNonEmpty(*bundleRoot, filepath.Join(site, "dist", "docs-bundles"))
+
+	result, err := (&bundler{
+		repoRoot:   root,
+		siteDir:    site,
+		sourceDir:  source,
+		generated:  generatedDir,
+		exportDir:  exported,
+		bundleRoot: outputRoot,
+		version:    strings.TrimSpace(*version),
+		now:        bundleTime(),
+	}).build()
+	if err != nil {
+		fail(err)
+	}
+
+	fmt.Printf("bundle_dir=%s\n", result.bundleDir)
+	fmt.Printf("manifest=%s\n", result.manifestPath)
+	fmt.Printf("archive=%s\n", result.archivePath)
+	fmt.Printf("archive_sha256=%s\n", result.archiveSHA256Path)
+}
+
+func (b *bundler) build() (*bundleResult, error) {
+	if err := requireDir(b.sourceDir); err != nil {
+		return nil, err
+	}
+	if err := requireDir(b.exportDir); err != nil {
+		return nil, err
+	}
+
+	bundleBaseName := "sandbox0-docs-bundle-" + b.version
+	bundleDir := filepath.Join(b.bundleRoot, bundleBaseName)
+	if err := os.RemoveAll(bundleDir); err != nil {
+		return nil, fmt.Errorf("remove previous bundle dir: %w", err)
+	}
+	if err := os.MkdirAll(bundleDir, 0o755); err != nil {
+		return nil, fmt.Errorf("create bundle dir: %w", err)
+	}
+
+	sourceDest := filepath.Join(bundleDir, "docs-source")
+	if err := copyDir(b.sourceDir, sourceDest); err != nil {
+		return nil, fmt.Errorf("copy docs sources: %w", err)
+	}
+
+	generatedDest := filepath.Join(bundleDir, "generated-docs")
+	generatedExists, err := dirExists(b.generated)
+	if err != nil {
+		return nil, err
+	}
+	if generatedExists {
+		if err := copyDir(b.generated, generatedDest); err != nil {
+			return nil, fmt.Errorf("copy generated docs assets: %w", err)
+		}
+	}
+
+	siteDest := filepath.Join(bundleDir, "site")
+	if err := copyDir(b.exportDir, siteDest); err != nil {
+		return nil, fmt.Errorf("copy site export: %w", err)
+	}
+
+	documents, err := collectDocuments(sourceDest)
+	if err != nil {
+		return nil, err
+	}
+
+	archivePath := filepath.Join(b.bundleRoot, bundleBaseName+".tar.gz")
+	archiveSHA256Path := archivePath + ".sha256"
+	manifest := bundleManifest{
+		SchemaVersion:   docsBundleSchemaVersion,
+		Kind:            docsBundleKind,
+		Sandbox0Version: b.version,
+		GeneratedAt:     b.now.UTC().Format(timeFormatRFC3339),
+		SourcePriority: []string{
+			"source-code",
+			"pkg/apispec/openapi.yaml",
+			"s0-cli-help-and-implementation",
+			"bundled-docs",
+			"hosted-website-docs",
+		},
+		Authority: bundleAuthority{
+			AuthoritativeSources: []string{
+				"source-code",
+				"pkg/apispec/openapi.yaml",
+				"s0-cli-help-and-implementation",
+			},
+			BundledDocsRole: "Bundled docs are release-matched reference material and must not override source code, OpenAPI, or CLI behavior when they disagree.",
+		},
+		Bundle: bundleLayout{
+			Root:             bundleBaseName,
+			SourceDocsDir:    "docs-source",
+			GeneratedDocsDir: generatedDirField(generatedExists),
+			SiteExportDir:    "site",
+			NavigationFiles:  []string{"docs-source/docs.ts", "docs-source/page.tsx", "docs-source/layout.tsx"},
+			ChecksumFile:     "SHA256SUMS",
+			ArchiveFile:      filepath.Base(archivePath),
+			ArchiveSHA256:    filepath.Base(archiveSHA256Path),
+		},
+		Documents: documents,
+	}
+
+	manifestPath := filepath.Join(bundleDir, "manifest.json")
+	if err := writeJSON(manifestPath, manifest); err != nil {
+		return nil, err
+	}
+
+	if err := os.WriteFile(filepath.Join(bundleDir, "AUTHORITY.md"), []byte(authorityMarkdown(b.version)), 0o644); err != nil {
+		return nil, fmt.Errorf("write authority note: %w", err)
+	}
+
+	if err := writeChecksums(filepath.Join(bundleDir, "SHA256SUMS"), bundleDir); err != nil {
+		return nil, err
+	}
+	if err := createTarGz(archivePath, b.bundleRoot, bundleBaseName, b.now); err != nil {
+		return nil, err
+	}
+	if err := writeArchiveSHA256(archiveSHA256Path, archivePath); err != nil {
+		return nil, err
+	}
+
+	return &bundleResult{
+		bundleDir:         bundleDir,
+		archivePath:       archivePath,
+		archiveSHA256Path: archiveSHA256Path,
+		manifestPath:      manifestPath,
+	}, nil
+}
+
+func bundleTime() time.Time {
+	sourceDateEpoch := strings.TrimSpace(os.Getenv("SOURCE_DATE_EPOCH"))
+	if sourceDateEpoch == "" {
+		return time.Now().UTC()
+	}
+	seconds, err := strconv.ParseInt(sourceDateEpoch, 10, 64)
+	if err != nil {
+		fail(fmt.Errorf("parse SOURCE_DATE_EPOCH: %w", err))
+	}
+	return time.Unix(seconds, 0).UTC()
+}
+
+func collectDocuments(sourceRoot string) ([]docsDocument, error) {
+	var documents []docsDocument
+	err := filepath.WalkDir(sourceRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if filepath.Base(path) != "page.mdx" {
+			return nil
+		}
+
+		rel, err := filepath.Rel(sourceRoot, path)
+		if err != nil {
+			return fmt.Errorf("relative path for %s: %w", path, err)
+		}
+		rel = filepath.ToSlash(rel)
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", path, err)
+		}
+		documents = append(documents, docsDocument{
+			Title:      extractTitle(data, rel),
+			Route:      docsRouteFromRelativePath(rel),
+			SourcePath: "docs-source/" + rel,
+			SHA256:     sha256Hex(data),
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("collect docs documents: %w", err)
+	}
+
+	sort.Slice(documents, func(i, j int) bool {
+		return documents[i].Route < documents[j].Route
+	})
+	return documents, nil
+}
+
+func extractTitle(data []byte, rel string) string {
+	for _, line := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "# ") {
+			return strings.TrimSpace(strings.TrimPrefix(trimmed, "# "))
+		}
+	}
+
+	parent := filepath.Base(filepath.Dir(rel))
+	if parent == "." || parent == "/" {
+		return "Docs"
+	}
+	return strings.ReplaceAll(parent, "-", " ")
+}
+
+func docsRouteFromRelativePath(rel string) string {
+	if rel == "page.mdx" {
+		return "/docs"
+	}
+	route := strings.TrimSuffix(rel, "/page.mdx")
+	return "/docs/" + strings.TrimPrefix(filepath.ToSlash(route), "/")
+}
+
+func writeJSON(path string, value any) error {
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal %s: %w", path, err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+func authorityMarkdown(version string) string {
+	return fmt.Sprintf(`# Sandbox0 Docs Authority
+
+This bundle contains the documentation payload for Sandbox0 release %s.
+
+Authority order:
+1. Source code
+2. pkg/apispec/openapi.yaml
+3. s0 CLI help and implementation
+4. This bundled docs payload
+5. Hosted website docs
+
+If bundled docs disagree with code, OpenAPI, or CLI behavior, the higher-priority source wins.
+`, version)
+}
+
+func writeChecksums(path, root string) error {
+	files, err := listBundleFiles(root)
+	if err != nil {
+		return err
+	}
+
+	var builder strings.Builder
+	for _, filePath := range files {
+		rel, err := filepath.Rel(root, filePath)
+		if err != nil {
+			return fmt.Errorf("relative path for checksum %s: %w", filePath, err)
+		}
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			return fmt.Errorf("read %s for checksum: %w", filePath, err)
+		}
+		builder.WriteString(sha256Hex(data))
+		builder.WriteString("  ")
+		builder.WriteString(filepath.ToSlash(rel))
+		builder.WriteByte('\n')
+	}
+
+	if err := os.WriteFile(path, []byte(builder.String()), 0o644); err != nil {
+		return fmt.Errorf("write checksum file: %w", err)
+	}
+	return nil
+}
+
+func listBundleFiles(root string) ([]string, error) {
+	var files []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if filepath.Base(path) == "SHA256SUMS" {
+			return nil
+		}
+		files = append(files, path)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list bundle files: %w", err)
+	}
+	sort.Strings(files)
+	return files, nil
+}
+
+func createTarGz(outPath, baseDir, bundleName string, modTime time.Time) error {
+	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
+		return fmt.Errorf("create archive dir: %w", err)
+	}
+
+	outFile, err := os.Create(outPath)
+	if err != nil {
+		return fmt.Errorf("create archive %s: %w", outPath, err)
+	}
+	defer outFile.Close()
+
+	gzipWriter, err := gzip.NewWriterLevel(outFile, gzip.BestCompression)
+	if err != nil {
+		return fmt.Errorf("create gzip writer: %w", err)
+	}
+	gzipWriter.Name = filepath.Base(outPath)
+	gzipWriter.ModTime = modTime.UTC()
+	defer gzipWriter.Close()
+
+	tarWriter := tar.NewWriter(gzipWriter)
+	defer tarWriter.Close()
+
+	root := filepath.Join(baseDir, bundleName)
+	files, err := listBundleFiles(root)
+	if err != nil {
+		return err
+	}
+
+	for _, filePath := range files {
+		rel, err := filepath.Rel(baseDir, filePath)
+		if err != nil {
+			return fmt.Errorf("relative path for archive %s: %w", filePath, err)
+		}
+		info, err := os.Stat(filePath)
+		if err != nil {
+			return fmt.Errorf("stat %s: %w", filePath, err)
+		}
+		header, err := tar.FileInfoHeader(info, "")
+		if err != nil {
+			return fmt.Errorf("tar header %s: %w", filePath, err)
+		}
+		header.Name = filepath.ToSlash(rel)
+		header.ModTime = modTime.UTC()
+		header.AccessTime = modTime.UTC()
+		header.ChangeTime = modTime.UTC()
+		header.Uid = 0
+		header.Gid = 0
+		header.Uname = "root"
+		header.Gname = "root"
+		if err := tarWriter.WriteHeader(header); err != nil {
+			return fmt.Errorf("write tar header %s: %w", filePath, err)
+		}
+
+		in, err := os.Open(filePath)
+		if err != nil {
+			return fmt.Errorf("open %s for archive: %w", filePath, err)
+		}
+		if _, err := io.Copy(tarWriter, in); err != nil {
+			in.Close()
+			return fmt.Errorf("write tar data %s: %w", filePath, err)
+		}
+		if err := in.Close(); err != nil {
+			return fmt.Errorf("close %s: %w", filePath, err)
+		}
+	}
+	return nil
+}
+
+func writeArchiveSHA256(outPath, archivePath string) error {
+	data, err := os.ReadFile(archivePath)
+	if err != nil {
+		return fmt.Errorf("read archive for checksum: %w", err)
+	}
+	content := fmt.Sprintf("%s  %s\n", sha256Hex(data), filepath.Base(archivePath))
+	if err := os.WriteFile(outPath, []byte(content), 0o644); err != nil {
+		return fmt.Errorf("write archive checksum: %w", err)
+	}
+	return nil
+}
+
+func copyDir(src, dst string) error {
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		return fmt.Errorf("create %s: %w", dst, err)
+	}
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return fmt.Errorf("relative path from %s to %s: %w", src, path, err)
+		}
+		if rel == "." {
+			return nil
+		}
+		target := filepath.Join(dst, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		return copyFile(path, target)
+	})
+}
+
+func copyFile(src, dst string) error {
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", src, err)
+	}
+	info, err := os.Stat(src)
+	if err != nil {
+		return fmt.Errorf("stat %s: %w", src, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return fmt.Errorf("create parent for %s: %w", dst, err)
+	}
+	if err := os.WriteFile(dst, data, info.Mode().Perm()); err != nil {
+		return fmt.Errorf("write %s: %w", dst, err)
+	}
+	return nil
+}
+
+func dirExists(path string) (bool, error) {
+	info, err := os.Stat(path)
+	if err == nil {
+		return info.IsDir(), nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, fmt.Errorf("stat %s: %w", path, err)
+}
+
+func requireDir(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat %s: %w", path, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%s is not a directory", path)
+	}
+	return nil
+}
+
+func generatedDirField(exists bool) string {
+	if !exists {
+		return ""
+	}
+	return "generated-docs"
+}
+
+func sha256Hex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func fail(err error) {
+	fmt.Fprintf(os.Stderr, "error: %v\n", err)
+	os.Exit(1)
+}

--- a/sandbox0-ui/apps/website/scripts/docsbundle/main_test.go
+++ b/sandbox0-ui/apps/website/scripts/docsbundle/main_test.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBundlerBuildsReleaseAlignedBundle(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := t.TempDir()
+	siteDir := filepath.Join(repoRoot, "sandbox0-ui", "apps", "website")
+	mustWriteFile(t, filepath.Join(siteDir, "src", "app", "docs", "docs.ts"), "export const docsNavigation = [];\n")
+	mustWriteFile(t, filepath.Join(siteDir, "src", "app", "docs", "page.tsx"), "export default function Page() { return null; }\n")
+	mustWriteFile(t, filepath.Join(siteDir, "src", "app", "docs", "layout.tsx"), "export default function Layout() { return null; }\n")
+	mustWriteFile(t, filepath.Join(siteDir, "src", "app", "docs", "get-started", "page.mdx"), "# Get Started\n\nSandbox0 docs.\n")
+	mustWriteFile(t, filepath.Join(siteDir, "src", "generated", "docs", "sandbox0infra-schema.json"), "{\"ok\":true}\n")
+	mustWriteFile(t, filepath.Join(siteDir, "out", "index.html"), "<html>root</html>\n")
+	mustWriteFile(t, filepath.Join(siteDir, "out", "docs", "get-started", "index.html"), "<html>docs</html>\n")
+
+	result, err := (&bundler{
+		repoRoot:   repoRoot,
+		siteDir:    siteDir,
+		sourceDir:  filepath.Join(siteDir, "src", "app", "docs"),
+		generated:  filepath.Join(siteDir, "src", "generated", "docs"),
+		exportDir:  filepath.Join(siteDir, "out"),
+		bundleRoot: filepath.Join(siteDir, "dist", "docs-bundles"),
+		version:    "1.2.3",
+		now:        time.Date(2026, 3, 10, 12, 0, 0, 0, time.UTC),
+	}).build()
+	if err != nil {
+		t.Fatalf("build bundle: %v", err)
+	}
+
+	manifestData, err := os.ReadFile(result.manifestPath)
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+
+	var manifest bundleManifest
+	if err := json.Unmarshal(manifestData, &manifest); err != nil {
+		t.Fatalf("unmarshal manifest: %v", err)
+	}
+
+	if manifest.Sandbox0Version != "1.2.3" {
+		t.Fatalf("unexpected version: %s", manifest.Sandbox0Version)
+	}
+	if manifest.Bundle.SiteExportDir != "site" {
+		t.Fatalf("unexpected site export dir: %s", manifest.Bundle.SiteExportDir)
+	}
+	if len(manifest.Documents) != 1 {
+		t.Fatalf("expected 1 document, got %d", len(manifest.Documents))
+	}
+	if manifest.Documents[0].Route != "/docs/get-started" {
+		t.Fatalf("unexpected route: %s", manifest.Documents[0].Route)
+	}
+	if manifest.Documents[0].Title != "Get Started" {
+		t.Fatalf("unexpected title: %s", manifest.Documents[0].Title)
+	}
+
+	checksums, err := os.ReadFile(filepath.Join(result.bundleDir, "SHA256SUMS"))
+	if err != nil {
+		t.Fatalf("read checksums: %v", err)
+	}
+	if !strings.Contains(string(checksums), "manifest.json") {
+		t.Fatalf("checksum file does not reference manifest.json")
+	}
+	if !strings.Contains(string(checksums), "site/docs/get-started/index.html") {
+		t.Fatalf("checksum file does not reference site export")
+	}
+
+	authority, err := os.ReadFile(filepath.Join(result.bundleDir, "AUTHORITY.md"))
+	if err != nil {
+		t.Fatalf("read authority note: %v", err)
+	}
+	if !strings.Contains(string(authority), "pkg/apispec/openapi.yaml") {
+		t.Fatalf("authority note missing OpenAPI authority statement")
+	}
+
+	entries := tarEntries(t, result.archivePath)
+	if _, ok := entries["sandbox0-docs-bundle-1.2.3/manifest.json"]; !ok {
+		t.Fatalf("archive missing manifest.json")
+	}
+	if _, ok := entries["sandbox0-docs-bundle-1.2.3/docs-source/get-started/page.mdx"]; !ok {
+		t.Fatalf("archive missing source docs")
+	}
+	if _, ok := entries["sandbox0-docs-bundle-1.2.3/site/docs/get-started/index.html"]; !ok {
+		t.Fatalf("archive missing site export")
+	}
+	if _, ok := entries["sandbox0-docs-bundle-1.2.3/generated-docs/sandbox0infra-schema.json"]; !ok {
+		t.Fatalf("archive missing generated docs asset")
+	}
+
+	archiveSHA, err := os.ReadFile(result.archiveSHA256Path)
+	if err != nil {
+		t.Fatalf("read archive sha256: %v", err)
+	}
+	if !strings.Contains(string(archiveSHA), "sandbox0-docs-bundle-1.2.3.tar.gz") {
+		t.Fatalf("archive sha256 file missing archive name")
+	}
+}
+
+func tarEntries(t *testing.T, path string) map[string]struct{} {
+	t.Helper()
+
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open tar.gz: %v", err)
+	}
+	defer file.Close()
+
+	gzr, err := gzip.NewReader(file)
+	if err != nil {
+		t.Fatalf("create gzip reader: %v", err)
+	}
+	defer gzr.Close()
+
+	tr := tar.NewReader(gzr)
+	entries := make(map[string]struct{})
+	for {
+		header, err := tr.Next()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			t.Fatalf("read tar entry: %v", err)
+		}
+		entries[header.Name] = struct{}{}
+	}
+	return entries
+}
+
+func mustWriteFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/sandbox0-ui/apps/website/scripts/generate_sandbox0infra_schema.go
+++ b/sandbox0-ui/apps/website/scripts/generate_sandbox0infra_schema.go
@@ -62,7 +62,8 @@ func main() {
 		fail(err)
 	}
 
-	crdPath := filepath.Join(repoRoot, "infra-operator", "chart", "crds", "infra.sandbox0.ai_sandbox0infras.yaml")
+	crdRelativePath := filepath.Join("infra-operator", "chart", "crds", "infra.sandbox0.ai_sandbox0infras.yaml")
+	crdPath := filepath.Join(repoRoot, crdRelativePath)
 	outPath := filepath.Join(repoRoot, "sandbox0-ui", "apps", "website", "src", "generated", "docs", "sandbox0infra-schema.json")
 
 	data, err := os.ReadFile(crdPath)
@@ -83,7 +84,7 @@ func main() {
 		fail(err)
 	}
 
-	out := outputDoc{GeneratedFrom: filepath.ToSlash(crdPath)}
+	out := outputDoc{GeneratedFrom: filepath.ToSlash(crdRelativePath)}
 	for _, sec := range sectionSpecs {
 		node, err := lookupPath(specNode, strings.TrimPrefix(sec.Key, "spec."))
 		if err != nil {

--- a/sandbox0-ui/apps/website/src/generated/docs/sandbox0infra-schema.json
+++ b/sandbox0-ui/apps/website/src/generated/docs/sandbox0infra-schema.json
@@ -1,5 +1,5 @@
 {
-  "generatedFrom": "/Users/huangzhihao/sandbox0/workspace/sandbox0/infra-operator/chart/crds/infra.sandbox0.ai_sandbox0infras.yaml",
+  "generatedFrom": "infra-operator/chart/crds/infra.sandbox0.ai_sandbox0infras.yaml",
   "sections": [
     {
       "key": "spec.database",

--- a/sandbox0-ui/package.json
+++ b/sandbox0-ui/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "build": "npm run build:website && npm run build:dashboard",
     "build:website": "npm run build -w @sandbox0/website",
+    "build:docs-bundle": "npm run docs:bundle -w @sandbox0/website",
     "build:dashboard": "npm run build -w @sandbox0/dashboard",
     "dev:website": "npm run dev -w @sandbox0/website",
     "dev:dashboard": "npm run dev -w @sandbox0/dashboard",


### PR DESCRIPTION
## Summary
- add a release-aligned docs bundler that packages source docs, generated docs assets, static export output, manifest metadata, and checksums
- publish docs bundle assets from the release workflow and validate bundle generation in PR quick check
- make generated website schema metadata stable across worktrees by recording a repo-relative source path

Closes #9

## Testing
- `mkdir -p .cache/go-build && GOCACHE=$PWD/.cache/go-build go test ./sandbox0-ui/apps/website/scripts/...`
- `SANDBOX0_DOCS_VERSION=dev-verify npm run build:docs-bundle --prefix sandbox0-ui`