### PR TITLE
refactor(dashboard): run dashboard at site root

### DIFF
--- a/sandbox0-ui/apps/dashboard/next.config.ts
+++ b/sandbox0-ui/apps/dashboard/next.config.ts
@@ -1,7 +1,6 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  basePath: "/dashboard",
   transpilePackages: ["@sandbox0/ui", "@sandbox0/dashboard-core"],
 };
 

--- a/sandbox0-ui/apps/dashboard/src/app/api/auth/login/route.ts
+++ b/sandbox0-ui/apps/dashboard/src/app/api/auth/login/route.ts
@@ -6,14 +6,10 @@ import {
   setDashboardAuthCookies,
 } from "@sandbox0/dashboard-core";
 
-function redirectURL(
-  requestURL: string,
-  basePath: string,
-  error?: string,
-): URL {
+function redirectURL(requestURL: string, error?: string): URL {
   const value = error
-    ? `${basePath}?login_error=${encodeURIComponent(error)}`
-    : basePath;
+    ? `/?login_error=${encodeURIComponent(error)}`
+    : "/";
   return new URL(value, requestURL);
 }
 
@@ -25,11 +21,7 @@ export async function POST(request: Request) {
 
   if (!email || !password) {
     return NextResponse.redirect(
-      redirectURL(
-        request.url,
-        config.dashboardBasePath,
-        "email and password are required",
-      ),
+      redirectURL(request.url, "email and password are required"),
       { status: 303 },
     );
   }
@@ -37,19 +29,12 @@ export async function POST(request: Request) {
   const result = await exchangeBuiltinLogin(config, email, password);
   if (!result.tokens) {
     return NextResponse.redirect(
-      redirectURL(
-        request.url,
-        config.dashboardBasePath,
-        result.error ?? "login failed",
-      ),
+      redirectURL(request.url, result.error ?? "login failed"),
       { status: 303 },
     );
   }
 
-  const response = NextResponse.redirect(
-    redirectURL(request.url, config.dashboardBasePath),
-    { status: 303 },
-  );
+  const response = NextResponse.redirect(redirectURL(request.url), { status: 303 });
   setDashboardAuthCookies(response, config, result.tokens);
   return response;
 }

--- a/sandbox0-ui/apps/dashboard/src/app/api/auth/logout/route.ts
+++ b/sandbox0-ui/apps/dashboard/src/app/api/auth/logout/route.ts
@@ -8,8 +8,8 @@ import {
   resolveDashboardRuntimeConfig,
 } from "@sandbox0/dashboard-core";
 
-function redirectURL(requestURL: string, basePath: string): URL {
-  return new URL(basePath, requestURL);
+function redirectURL(requestURL: string): URL {
+  return new URL("/", requestURL);
 }
 
 export async function POST(request: Request) {
@@ -22,7 +22,7 @@ export async function POST(request: Request) {
   await forwardLogout(config, accessToken);
 
   const response = NextResponse.redirect(
-    redirectURL(request.url, config.dashboardBasePath),
+    redirectURL(request.url),
     {
       status: 303,
     },

--- a/sandbox0-ui/apps/dashboard/src/app/api/auth/oidc/[provider]/callback/route.ts
+++ b/sandbox0-ui/apps/dashboard/src/app/api/auth/oidc/[provider]/callback/route.ts
@@ -6,19 +6,15 @@ import {
   setDashboardAuthCookies,
 } from "@sandbox0/dashboard-core";
 
-function dashboardURL(
-  requestURL: string,
-  basePath: string,
-  error?: string,
-): URL {
+function dashboardURL(requestURL: string, error?: string): URL {
   const value = error
-    ? `${basePath}?login_error=${encodeURIComponent(error)}`
-    : basePath;
+    ? `/?login_error=${encodeURIComponent(error)}`
+    : "/";
   return new URL(value, requestURL);
 }
 
 // This callback assumes the control plane OIDC base URL is configured to point
-// at the public dashboard auth surface, for example /dashboard/api/auth/...
+// at the public dashboard auth surface, for example /api/auth/...
 // The route then proxies the callback to the actual control-plane service and
 // converts the returned token pair into dashboard cookies.
 export async function GET(
@@ -31,21 +27,14 @@ export async function GET(
   const result = await exchangeOIDCCallback(config, provider, rawQuery);
   if (!result.tokens) {
     return NextResponse.redirect(
-      dashboardURL(
-        request.url,
-        config.dashboardBasePath,
-        result.error ?? "oidc callback failed",
-      ),
+      dashboardURL(request.url, result.error ?? "oidc callback failed"),
       { status: 303 },
     );
   }
 
-  const response = NextResponse.redirect(
-    dashboardURL(request.url, config.dashboardBasePath),
-    {
-      status: 303,
-    },
-  );
+  const response = NextResponse.redirect(dashboardURL(request.url), {
+    status: 303,
+  });
   setDashboardAuthCookies(response, config, result.tokens);
   return response;
 }

--- a/sandbox0-ui/apps/dashboard/src/app/api/auth/oidc/[provider]/login/route.ts
+++ b/sandbox0-ui/apps/dashboard/src/app/api/auth/oidc/[provider]/login/route.ts
@@ -5,14 +5,10 @@ import {
   resolveOIDCLoginLocation,
 } from "@sandbox0/dashboard-core";
 
-function dashboardURL(
-  requestURL: string,
-  basePath: string,
-  error?: string,
-): URL {
+function dashboardURL(requestURL: string, error?: string): URL {
   const value = error
-    ? `${basePath}?login_error=${encodeURIComponent(error)}`
-    : basePath;
+    ? `/?login_error=${encodeURIComponent(error)}`
+    : "/";
   return new URL(value, requestURL);
 }
 
@@ -25,11 +21,7 @@ export async function GET(
   const result = await resolveOIDCLoginLocation(config, provider);
   if (!result.location) {
     return NextResponse.redirect(
-      dashboardURL(
-        request.url,
-        config.dashboardBasePath,
-        result.error ?? "oidc login failed",
-      ),
+      dashboardURL(request.url, result.error ?? "oidc login failed"),
       { status: 303 },
     );
   }

--- a/sandbox0-ui/apps/dashboard/src/app/api/auth/refresh/route.ts
+++ b/sandbox0-ui/apps/dashboard/src/app/api/auth/refresh/route.ts
@@ -11,10 +11,9 @@ import {
 
 function refreshRedirectURL(
   requestURL: string,
-  basePath: string,
   error?: string,
 ): URL {
-  const url = new URL(basePath, requestURL);
+  const url = new URL("/", requestURL);
   url.searchParams.set("refreshed", "1");
   if (error) {
     url.searchParams.set("login_error", error);
@@ -29,11 +28,7 @@ export async function GET(request: Request) {
 
   if (!refreshToken) {
     const response = NextResponse.redirect(
-      refreshRedirectURL(
-        request.url,
-        config.dashboardBasePath,
-        "session expired, please sign in again",
-      ),
+      refreshRedirectURL(request.url, "session expired, please sign in again"),
       { status: 303 },
     );
     clearDashboardAuthCookies(response, config);
@@ -45,7 +40,6 @@ export async function GET(request: Request) {
     const response = NextResponse.redirect(
       refreshRedirectURL(
         request.url,
-        config.dashboardBasePath,
         result.error ?? "session expired, please sign in again",
       ),
       { status: 303 },
@@ -54,10 +48,9 @@ export async function GET(request: Request) {
     return response;
   }
 
-  const response = NextResponse.redirect(
-    refreshRedirectURL(request.url, config.dashboardBasePath),
-    { status: 303 },
-  );
+  const response = NextResponse.redirect(refreshRedirectURL(request.url), {
+    status: 303,
+  });
   setDashboardAuthCookies(response, config, result.tokens);
   return response;
 }

--- a/sandbox0-ui/apps/dashboard/src/app/api/team/select/route.ts
+++ b/sandbox0-ui/apps/dashboard/src/app/api/team/select/route.ts
@@ -13,11 +13,10 @@ import {
 
 function dashboardURL(
   requestURL: string,
-  basePath: string,
   error?: string,
   switched?: boolean,
 ): URL {
-  const url = new URL(basePath, requestURL);
+  const url = new URL("/", requestURL);
   if (switched) {
     url.searchParams.set("team_switched", "1");
   }
@@ -37,11 +36,7 @@ export async function POST(request: Request) {
 
   if (!teamID) {
     return NextResponse.redirect(
-      dashboardURL(
-        request.url,
-        config.dashboardBasePath,
-        "team_id is required",
-      ),
+      dashboardURL(request.url, "team_id is required"),
       { status: 303 },
     );
   }
@@ -60,7 +55,6 @@ export async function POST(request: Request) {
       const response = NextResponse.redirect(
         dashboardURL(
           request.url,
-          config.dashboardBasePath,
           refreshed.error ?? "session expired, please sign in again",
         ),
         { status: 303 },
@@ -74,11 +68,7 @@ export async function POST(request: Request) {
 
   if (!accessToken) {
     const response = NextResponse.redirect(
-      dashboardURL(
-        request.url,
-        config.dashboardBasePath,
-        "browser session not found, please sign in again",
-      ),
+      dashboardURL(request.url, "browser session not found, please sign in again"),
       { status: 303 },
     );
     clearDashboardAuthCookies(response, config);
@@ -97,23 +87,14 @@ export async function POST(request: Request) {
 
   if (!updateResult.ok) {
     return NextResponse.redirect(
-      dashboardURL(
-        request.url,
-        config.dashboardBasePath,
-        updateResult.error ?? "failed to switch active team",
-      ),
+      dashboardURL(request.url, updateResult.error ?? "failed to switch active team"),
       { status: 303 },
     );
   }
 
   if (!refreshToken) {
     return NextResponse.redirect(
-      dashboardURL(
-        request.url,
-        config.dashboardBasePath,
-        "team updated but browser session could not be refreshed",
-        true,
-      ),
+      dashboardURL(request.url, "team updated but browser session could not be refreshed", true),
       { status: 303 },
     );
   }
@@ -123,7 +104,6 @@ export async function POST(request: Request) {
     const response = NextResponse.redirect(
       dashboardURL(
         request.url,
-        config.dashboardBasePath,
         finalRefresh.error ?? "team updated but session refresh failed",
         true,
       ),
@@ -135,10 +115,9 @@ export async function POST(request: Request) {
     return response;
   }
 
-  const response = NextResponse.redirect(
-    dashboardURL(request.url, config.dashboardBasePath, undefined, true),
-    { status: 303 },
-  );
+  const response = NextResponse.redirect(dashboardURL(request.url, undefined, true), {
+    status: 303,
+  });
   setDashboardAuthCookies(response, config, finalRefresh.tokens);
   return response;
 }

--- a/sandbox0-ui/apps/dashboard/src/app/page.tsx
+++ b/sandbox0-ui/apps/dashboard/src/app/page.tsx
@@ -64,7 +64,7 @@ export default async function DashboardHome({
   );
 
   if (!session.authenticated && refreshToken && !refreshed && !loginError) {
-    redirect(`${config.dashboardBasePath}/api/auth/refresh`);
+    redirect("/api/auth/refresh");
   }
 
   return (
@@ -107,13 +107,13 @@ export default async function DashboardHome({
               Unified <span className="text-accent">control plane</span>
             </PixelHeading>
             <p className="mt-4 max-w-2xl text-sm leading-7 text-muted">
-              This dashboard runs as the same-domain <code>/dashboard</code>{" "}
-              product surface while adapting to either a single-cluster
-              deployment or a global-directory plus regional-gateway topology.
+              This dashboard runs as a dedicated control-plane site while
+              adapting to either a single-cluster deployment or a
+              global-directory plus regional-gateway topology.
             </p>
             <div className="mt-6 flex flex-wrap gap-3">
               <a
-                href={`${config.dashboardBasePath}/api/session`}
+                href="/api/session"
                 className="inline-flex items-center justify-center border border-foreground/20 bg-surface px-3 py-1.5 text-xs text-foreground transition-colors hover:bg-foreground hover:text-background"
               >
                 View session JSON
@@ -167,7 +167,7 @@ export default async function DashboardHome({
                     {oidcProviders.map((provider) => (
                       <a
                         key={provider.id}
-                        href={`${config.dashboardBasePath}/api/auth/oidc/${provider.id}/login`}
+                        href={`/api/auth/oidc/${provider.id}/login`}
                         className="inline-flex w-full items-center justify-center border border-foreground/20 bg-surface px-4 py-3 text-sm text-foreground transition-colors hover:bg-foreground hover:text-background"
                       >
                         Continue with {provider.name}
@@ -178,7 +178,7 @@ export default async function DashboardHome({
 
                 {builtinProvider && (
                   <form
-                    action={`${config.dashboardBasePath}/api/auth/login`}
+                    action="/api/auth/login"
                     method="post"
                     className="space-y-3 border border-foreground/10 bg-surface/60 p-4"
                   >
@@ -306,7 +306,7 @@ export default async function DashboardHome({
               </p>
               {session.authenticated && session.teams.length > 1 && (
                 <form
-                  action={`${config.dashboardBasePath}/api/team/select`}
+                  action="/api/team/select"
                   method="post"
                   className="pt-2"
                 >
@@ -421,7 +421,7 @@ export default async function DashboardHome({
 
             {session.authenticated && (
               <form
-                action={`${config.dashboardBasePath}/api/auth/logout`}
+                action="/api/auth/logout"
                 method="post"
                 className="mt-6"
               >

--- a/sandbox0-ui/components/dashboard-core/src/auth.test.ts
+++ b/sandbox0-ui/components/dashboard-core/src/auth.test.ts
@@ -15,7 +15,6 @@ import type { DashboardRuntimeConfig } from "./types";
 
 const singleClusterConfig: DashboardRuntimeConfig = {
   mode: "single-cluster",
-  dashboardBasePath: "/dashboard",
   siteURL: "https://sandbox0.ai",
   singleClusterURL: "https://single.example.com",
 };
@@ -116,7 +115,7 @@ test("setDashboardAuthCookies stores dashboard auth cookies", () => {
   assert.equal(accessCookie?.value, "access-token");
   assert.equal(refreshCookie?.value, "refresh-token");
   assert.equal(accessCookie?.httpOnly, true);
-  assert.equal(accessCookie?.path, "/dashboard");
+  assert.equal(accessCookie?.path, "/");
 });
 
 test("clearDashboardAuthCookies expires dashboard auth cookies", () => {

--- a/sandbox0-ui/components/dashboard-core/src/auth.ts
+++ b/sandbox0-ui/components/dashboard-core/src/auth.ts
@@ -10,6 +10,8 @@ interface LoginResponse {
   expires_at: number;
 }
 
+const dashboardHomePath = "/";
+
 export const dashboardAccessTokenCookieName = "sandbox0_access_token";
 export const dashboardRefreshTokenCookieName = "sandbox0_refresh_token";
 
@@ -237,7 +239,7 @@ export async function resolveOIDCLoginLocation(
     const response = await fetchImpl(
       joinURL(
         baseURL,
-        `/auth/oidc/${encodeURIComponent(providerID)}/login?return_url=${encodeURIComponent(config.dashboardBasePath)}`,
+        `/auth/oidc/${encodeURIComponent(providerID)}/login?return_url=${encodeURIComponent(dashboardHomePath)}`,
       ),
       {
         method: "GET",
@@ -310,14 +312,14 @@ export function setDashboardAuthCookies(
     httpOnly: true,
     sameSite: "lax",
     secure,
-    path: config.dashboardBasePath,
+    path: dashboardHomePath,
     maxAge,
   });
   response.cookies.set(dashboardRefreshTokenCookieName, tokens.refresh_token, {
     httpOnly: true,
     sameSite: "lax",
     secure,
-    path: config.dashboardBasePath,
+    path: dashboardHomePath,
   });
 }
 
@@ -331,14 +333,14 @@ export function clearDashboardAuthCookies(
     httpOnly: true,
     sameSite: "lax",
     secure,
-    path: config.dashboardBasePath,
+    path: dashboardHomePath,
     maxAge: 0,
   });
   response.cookies.set(dashboardRefreshTokenCookieName, "", {
     httpOnly: true,
     sameSite: "lax",
     secure,
-    path: config.dashboardBasePath,
+    path: dashboardHomePath,
     maxAge: 0,
   });
 }

--- a/sandbox0-ui/components/dashboard-core/src/config.test.ts
+++ b/sandbox0-ui/components/dashboard-core/src/config.test.ts
@@ -9,7 +9,6 @@ test("resolveDashboardRuntimeConfig defaults to single-cluster in development", 
   });
 
   assert.equal(config.mode, "single-cluster");
-  assert.equal(config.dashboardBasePath, "/dashboard");
   assert.equal(config.siteURL, "http://localhost:4300");
   assert.equal(config.singleClusterURL, "http://localhost:30080");
 });

--- a/sandbox0-ui/components/dashboard-core/src/config.ts
+++ b/sandbox0-ui/components/dashboard-core/src/config.ts
@@ -3,8 +3,6 @@ import type {
   DashboardRuntimeConfig,
 } from "./types";
 
-const defaultDashboardBasePath = "/dashboard";
-
 function normalizeMode(value: string | undefined): DashboardControlPlaneMode {
   if (value === "global-directory") {
     return value;
@@ -29,7 +27,6 @@ export function resolveDashboardRuntimeConfig(
   if (mode === "global-directory") {
     return {
       mode,
-      dashboardBasePath: defaultDashboardBasePath,
       siteURL,
       globalDirectoryURL:
         env.SANDBOX0_DASHBOARD_GLOBAL_DIRECTORY_URL ??
@@ -40,7 +37,6 @@ export function resolveDashboardRuntimeConfig(
 
   return {
     mode,
-    dashboardBasePath: defaultDashboardBasePath,
     siteURL,
     singleClusterURL:
       env.SANDBOX0_DASHBOARD_SINGLE_CLUSTER_URL ??

--- a/sandbox0-ui/components/dashboard-core/src/session.test.ts
+++ b/sandbox0-ui/components/dashboard-core/src/session.test.ts
@@ -6,14 +6,12 @@ import { readBearerToken, resolveDashboardSession } from "./session";
 
 const singleClusterConfig: DashboardRuntimeConfig = {
   mode: "single-cluster",
-  dashboardBasePath: "/dashboard",
   siteURL: "https://sandbox0.ai",
   singleClusterURL: "https://single.example.com",
 };
 
 const globalDirectoryConfig: DashboardRuntimeConfig = {
   mode: "global-directory",
-  dashboardBasePath: "/dashboard",
   siteURL: "https://sandbox0.ai",
   globalDirectoryURL: "https://global.example.com",
 };

--- a/sandbox0-ui/components/dashboard-core/src/session.ts
+++ b/sandbox0-ui/components/dashboard-core/src/session.ts
@@ -141,7 +141,6 @@ export async function resolveDashboardSession(
   const baseSession: DashboardSession = {
     authenticated: false,
     mode: config.mode,
-    dashboardBasePath: config.dashboardBasePath,
     siteURL: config.siteURL,
     configuredGlobalURL: config.globalDirectoryURL,
     configuredRegionalURL:

--- a/sandbox0-ui/components/dashboard-core/src/types.ts
+++ b/sandbox0-ui/components/dashboard-core/src/types.ts
@@ -2,7 +2,6 @@ export type DashboardControlPlaneMode = "single-cluster" | "global-directory";
 
 export interface DashboardRuntimeConfig {
   mode: DashboardControlPlaneMode;
-  dashboardBasePath: string;
   siteURL: string;
   singleClusterURL?: string;
   globalDirectoryURL?: string;
@@ -62,7 +61,6 @@ export interface DashboardTemplateSummary {
 export interface DashboardSession {
   authenticated: boolean;
   mode: DashboardControlPlaneMode;
-  dashboardBasePath: string;
   siteURL: string;
   configuredGlobalURL?: string;
   configuredRegionalURL?: string;

--- a/sandbox0-ui/package.json
+++ b/sandbox0-ui/package.json
@@ -2,6 +2,10 @@
   "name": "sandbox0-ui",
   "private": true,
   "packageManager": "npm@11.4.2",
+  "engines": {
+    "node": ">=24 <25",
+    "npm": ">=11 <12"
+  },
   "workspaces": [
     "apps/*",
     "components/*"


### PR DESCRIPTION
## Summary
- remove the baked-in `/dashboard` subpath from the shared dashboard core
- update the OSS dashboard app to run at the site root and keep auth/session routes at `/api/...`
- align the sandbox0-ui workspace engine requirement with the cloud dashboard workspace

## Testing
- `./node_modules/.bin/tsc -p components/dashboard-core/tsconfig.json --noEmit`
- `./node_modules/.bin/tsc -p apps/dashboard/tsconfig.json --noEmit`
- `tsx --test` could not be run in the sandbox because the local IPC pipe creation is blocked
