### PR TITLE
Make docs GitHub links version-aware

### DIFF
--- a/sandbox0-ui/apps/website/src/components/docs/MDXComponents.tsx
+++ b/sandbox0-ui/apps/website/src/components/docs/MDXComponents.tsx
@@ -16,6 +16,7 @@ import {
 } from "./DocsLanding";
 import { Sandbox0InfraReference } from "./Sandbox0InfraReference";
 import { DocsLink } from "./DocsLink";
+import { GitHubApplyCommand, GitHubRawLink, S0Install } from "./VersionedGitHub";
 import type { MDXComponents } from "mdx/types";
 
 function cx(...classes: Array<string | undefined | null | false>) {
@@ -410,6 +411,9 @@ export const mdxComponents: MDXComponents = {
   TerminalBlock,
   Endpoint,
   DocLink: DocsLink,
+  GitHubRawLink,
+  GitHubApplyCommand,
+  S0Install,
   
   // Landing Page Components
   DocsHero,

--- a/sandbox0-ui/apps/website/src/components/docs/VersionedGitHub.tsx
+++ b/sandbox0-ui/apps/website/src/components/docs/VersionedGitHub.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { PixelCodeBlock } from "./PixelCodeBlock";
+import { DocsLink } from "./DocsLink";
+import {
+  getResolvedDocsVersionFromPathname,
+  toGitHubRawHref,
+  toGitHubReadmeHref,
+  toGitHubReleaseHref,
+} from "./versioning";
+
+type RepoName = "sandbox0" | "s0";
+
+function repoSlug(repo: RepoName): string {
+  return `sandbox0-ai/${repo}`;
+}
+
+export function GitHubRawLink({
+  repo,
+  path,
+  children,
+}: {
+  repo: RepoName;
+  path: string;
+  children: React.ReactNode;
+}) {
+  const pathname = usePathname();
+  const version = getResolvedDocsVersionFromPathname(pathname);
+  const href = toGitHubRawHref(repoSlug(repo), version, path);
+
+  return (
+    <DocsLink href={href} newTab>
+      {children}
+    </DocsLink>
+  );
+}
+
+export function GitHubApplyCommand({
+  repo,
+  path,
+}: {
+  repo: RepoName;
+  path: string;
+}) {
+  const pathname = usePathname();
+  const version = getResolvedDocsVersionFromPathname(pathname);
+  const href = toGitHubRawHref(repoSlug(repo), version, path);
+
+  return (
+    <PixelCodeBlock language="bash" scale="md" className="mb-6">
+      {`kubectl apply -f ${href}`}
+    </PixelCodeBlock>
+  );
+}
+
+export function S0Install() {
+  const pathname = usePathname();
+  const version = getResolvedDocsVersionFromPathname(pathname);
+  const shellInstallHref = toGitHubRawHref(repoSlug("s0"), version, "scripts/install.sh");
+  const powershellInstallHref = toGitHubRawHref(repoSlug("s0"), version, "scripts/install.ps1");
+  const releaseHref = toGitHubReleaseHref(repoSlug("s0"), version);
+  const readmeHref = toGitHubReadmeHref(repoSlug("s0"), version, "installation");
+
+  return (
+    <>
+      <p className="mb-4 leading-relaxed text-muted">macOS and Linux:</p>
+      <PixelCodeBlock language="bash" scale="md" className="mb-6">
+        {`curl -fsSL ${shellInstallHref} | bash`}
+      </PixelCodeBlock>
+
+      <p className="mb-4 leading-relaxed text-muted">Windows PowerShell:</p>
+      <PixelCodeBlock language="powershell" scale="md" className="mb-6">
+        {`irm ${powershellInstallHref} | iex`}
+      </PixelCodeBlock>
+
+      <p className="mb-4 leading-relaxed text-muted">Or with Go:</p>
+      <PixelCodeBlock language="bash" scale="md" className="mb-6">
+        {"go install github.com/sandbox0-ai/s0/cmd/s0@latest"}
+      </PixelCodeBlock>
+
+      <p className="mb-4 leading-relaxed text-muted">
+        Manual release archives are available from{" "}
+        <DocsLink href={releaseHref} newTab>
+          GitHub Releases
+        </DocsLink>
+        . See the{" "}
+        <DocsLink href={readmeHref} newTab>
+          s0 README
+        </DocsLink>{" "}
+        for platform-specific manual install steps.
+      </p>
+    </>
+  );
+}

--- a/sandbox0-ui/apps/website/src/components/docs/versioning.ts
+++ b/sandbox0-ui/apps/website/src/components/docs/versioning.ts
@@ -74,6 +74,58 @@ export function getResolvedDocsVersionFromPathname(pathname?: string | null): st
   return getDocsVersionFromPathname(pathname) ?? DOCS_DEFAULT_VERSION;
 }
 
+function getDocsVersionEntry(version: string): DocsVersion | undefined {
+  return defaultDocsVersionsManifest.versions.find((entry) => entry.id === version);
+}
+
+export function resolveDocsVersionTarget(version: string): string {
+  const seen = new Set<string>();
+  let current = version;
+
+  while (!seen.has(current)) {
+    seen.add(current);
+    const target = getDocsVersionEntry(current)?.target;
+    if (!target) {
+      return current;
+    }
+    current = target;
+  }
+
+  return version;
+}
+
+export function resolveGitHubRefForDocsVersion(version: string): string {
+  const target = resolveDocsVersionTarget(version);
+  return target === "next" || target === "latest" ? "main" : target;
+}
+
+export function toGitHubRawHref(repo: string, version: string, filePath: string): string {
+  const ref = resolveGitHubRefForDocsVersion(version);
+  const normalizedPath = filePath.replace(/^\/+/, "");
+  return `https://raw.githubusercontent.com/${repo}/${ref}/${normalizedPath}`;
+}
+
+export function toGitHubReleaseHref(repo: string, version: string): string {
+  const ref = resolveGitHubRefForDocsVersion(version);
+  if (DOCS_VERSION_PATTERN.test(ref)) {
+    return `https://github.com/${repo}/releases/tag/${ref}`;
+  }
+  return `https://github.com/${repo}/releases/latest`;
+}
+
+export function toGitHubReadmeHref(
+  repo: string,
+  version: string,
+  anchor?: string
+): string {
+  const ref = resolveGitHubRefForDocsVersion(version);
+  const suffix = anchor ? `#${anchor}` : "";
+  if (ref === "main") {
+    return `https://github.com/${repo}${suffix}`;
+  }
+  return `https://github.com/${repo}/blob/${ref}/README.md${suffix}`;
+}
+
 export function getDocsContentPathFromPathname(pathname?: string | null): string {
   if (!pathname?.startsWith("/docs")) {
     return "/get-started";

--- a/skills/sandbox0/references/docs-src/get-started/page.mdx
+++ b/skills/sandbox0/references/docs-src/get-started/page.mdx
@@ -35,13 +35,7 @@ Get your first sandbox running in minutes.
 
 ### Install s0 CLI (Required)
 
-Install from <DocLink href="https://github.com/sandbox0-ai/s0/releases" newTab>GitHub Releases</DocLink>.
-
-Or with Go (requires Go 1.21+):
-
-```bash
-go install github.com/sandbox0-ai/s0/cmd/s0@latest
-```
+<S0Install />
 
 ### Install SDK
 

--- a/skills/sandbox0/references/docs-src/self-hosted/configuration/page.mdx
+++ b/skills/sandbox0/references/docs-src/self-hosted/configuration/page.mdx
@@ -35,12 +35,12 @@ A `Sandbox0Infra` spec is easier to reason about when you split it into five lay
 
 Official sample manifests:
 
-- <DocLink href="https://raw.githubusercontent.com/sandbox0-ai/sandbox0/main/infra-operator/chart/samples/single-cluster/minimal.yaml" newTab>single-cluster/minimal.yaml</DocLink>
-- <DocLink href="https://raw.githubusercontent.com/sandbox0-ai/sandbox0/main/infra-operator/chart/samples/single-cluster/fullmode.yaml" newTab>single-cluster/fullmode.yaml</DocLink>
-- <DocLink href="https://raw.githubusercontent.com/sandbox0-ai/sandbox0/main/infra-operator/chart/samples/single-cluster/volumes.yaml" newTab>single-cluster/volumes.yaml</DocLink>
-- <DocLink href="https://raw.githubusercontent.com/sandbox0-ai/sandbox0/main/infra-operator/chart/samples/single-cluster/network-policy.yaml" newTab>single-cluster/network-policy.yaml</DocLink>
-- <DocLink href="https://raw.githubusercontent.com/sandbox0-ai/sandbox0/main/infra-operator/chart/samples/multi-cluster/control-plane.yaml" newTab>multi-cluster/control-plane.yaml</DocLink>
-- <DocLink href="https://raw.githubusercontent.com/sandbox0-ai/sandbox0/main/infra-operator/chart/samples/multi-cluster/data-plane.yaml" newTab>multi-cluster/data-plane.yaml</DocLink>
+- <GitHubRawLink repo="sandbox0" path="infra-operator/chart/samples/single-cluster/minimal.yaml">single-cluster/minimal.yaml</GitHubRawLink>
+- <GitHubRawLink repo="sandbox0" path="infra-operator/chart/samples/single-cluster/fullmode.yaml">single-cluster/fullmode.yaml</GitHubRawLink>
+- <GitHubRawLink repo="sandbox0" path="infra-operator/chart/samples/single-cluster/volumes.yaml">single-cluster/volumes.yaml</GitHubRawLink>
+- <GitHubRawLink repo="sandbox0" path="infra-operator/chart/samples/single-cluster/network-policy.yaml">single-cluster/network-policy.yaml</GitHubRawLink>
+- <GitHubRawLink repo="sandbox0" path="infra-operator/chart/samples/multi-cluster/control-plane.yaml">multi-cluster/control-plane.yaml</GitHubRawLink>
+- <GitHubRawLink repo="sandbox0" path="infra-operator/chart/samples/multi-cluster/data-plane.yaml">multi-cluster/data-plane.yaml</GitHubRawLink>
 
 ## What Usually Changes First
 

--- a/skills/sandbox0/references/docs-src/self-hosted/install/page.mdx
+++ b/skills/sandbox0/references/docs-src/self-hosted/install/page.mdx
@@ -67,20 +67,20 @@ kubectl get crd sandbox0infras.infra.sandbox0.ai
 
 Pick one official sample from source based on your target mode:
 
-- <DocLink href="https://raw.githubusercontent.com/sandbox0-ai/sandbox0/main/infra-operator/chart/samples/single-cluster/minimal.yaml" newTab>single-cluster/minimal.yaml</DocLink>
-- <DocLink href="https://raw.githubusercontent.com/sandbox0-ai/sandbox0/main/infra-operator/chart/samples/single-cluster/volumes.yaml" newTab>single-cluster/volumes.yaml</DocLink>
-- <DocLink href="https://raw.githubusercontent.com/sandbox0-ai/sandbox0/main/infra-operator/chart/samples/single-cluster/network-policy.yaml" newTab>single-cluster/network-policy.yaml</DocLink>
-- <DocLink href="https://raw.githubusercontent.com/sandbox0-ai/sandbox0/main/infra-operator/chart/samples/single-cluster/fullmode.yaml" newTab>single-cluster/fullmode.yaml</DocLink>
-- <DocLink href="https://raw.githubusercontent.com/sandbox0-ai/sandbox0/main/infra-operator/chart/samples/multi-cluster/control-plane.yaml" newTab>multi-cluster/control-plane.yaml</DocLink>
-- <DocLink href="https://raw.githubusercontent.com/sandbox0-ai/sandbox0/main/infra-operator/chart/samples/multi-cluster/data-plane.yaml" newTab>multi-cluster/data-plane.yaml</DocLink>
+- <GitHubRawLink repo="sandbox0" path="infra-operator/chart/samples/single-cluster/minimal.yaml">single-cluster/minimal.yaml</GitHubRawLink>
+- <GitHubRawLink repo="sandbox0" path="infra-operator/chart/samples/single-cluster/volumes.yaml">single-cluster/volumes.yaml</GitHubRawLink>
+- <GitHubRawLink repo="sandbox0" path="infra-operator/chart/samples/single-cluster/network-policy.yaml">single-cluster/network-policy.yaml</GitHubRawLink>
+- <GitHubRawLink repo="sandbox0" path="infra-operator/chart/samples/single-cluster/fullmode.yaml">single-cluster/fullmode.yaml</GitHubRawLink>
+- <GitHubRawLink repo="sandbox0" path="infra-operator/chart/samples/multi-cluster/control-plane.yaml">multi-cluster/control-plane.yaml</GitHubRawLink>
+- <GitHubRawLink repo="sandbox0" path="infra-operator/chart/samples/multi-cluster/data-plane.yaml">multi-cluster/data-plane.yaml</GitHubRawLink>
 
 Apply the one you selected:
 
-```bash
-# Default recommended mode: `fullmode` (Linux nodes only).
-# For local macOS/Windows testing, use `single-cluster/minimal.yaml` instead.
-kubectl apply -f https://raw.githubusercontent.com/sandbox0-ai/sandbox0/main/infra-operator/chart/samples/single-cluster/fullmode.yaml
-```
+<Callout variant="info">
+Default recommended mode: `fullmode` (Linux nodes only). For local macOS/Windows testing, use `single-cluster/minimal.yaml` instead.
+</Callout>
+
+<GitHubApplyCommand repo="sandbox0" path="infra-operator/chart/samples/single-cluster/fullmode.yaml" />
 
 Watch status:
 
@@ -103,7 +103,11 @@ ADMIN_PASSWORD="$(kubectl get secret admin-password -n sandbox0-system -o jsonpa
 printf 'username: %s\npassword: %s\n' 'admin@example.com' "$ADMIN_PASSWORD"
 ```
 
-## 4) Configure the API URL and Create a Token
+## 4) Install `s0`
+
+<S0Install />
+
+## 5) Configure the API URL and Create a Token
 
 For the local `kind` setup above, the API endpoint is `http://localhost:30080`.
 
@@ -222,9 +226,9 @@ kubectl get crd sandbox0infras.infra.sandbox0.ai
 
 Use the official `gVisor` sample, then switch `internal-gateway` to `LoadBalancer`:
 
-```bash
-kubectl apply -f https://raw.githubusercontent.com/sandbox0-ai/sandbox0/main/infra-operator/chart/samples/single-cluster/fullmode-gke-gvisor.yaml
+<GitHubApplyCommand repo="sandbox0" path="infra-operator/chart/samples/single-cluster/fullmode-gke-gvisor.yaml" />
 
+```bash
 kubectl patch sandbox0infra fullmode -n sandbox0-system --type merge -p \
     '{"spec":{"services":{"internalGateway":{"service":{"type":"LoadBalancer","port":80}}}}}'
 ```


### PR DESCRIPTION
## Summary
- add a docs version helper that resolves the active docs version to a GitHub ref or release target
- add reusable MDX components for versioned raw-file links, `kubectl apply` snippets, and `s0` install commands
- replace hardcoded `main` and `releases/latest` links in the high-risk docs pages under `skills/sandbox0/references/docs-src`

Closes #34

## Testing
- `npm run docs:generate:content -w @sandbox0/website`
- `npm run build -w @sandbox0/website` *(fails in current environment because the installed `next` rejects `next.config.ts`; docs generation and version manifest preparation both completed before that failure)*