### PR TITLE
Auto-generate cluster-local MITM CA for netd

### DIFF
--- a/infra-operator/api/v1alpha1/sandbox0infra_types.go
+++ b/infra-operator/api/v1alpha1/sandbox0infra_types.go
@@ -836,8 +836,8 @@ type EgressBrokerServiceConfig struct {
 // NetdServiceConfig defines configuration for netd service
 type NetdServiceConfig struct {
 	BaseServiceConfig `json:",inline"`
-	// MITMCASecretName mounts a secret containing cluster-local MITM CA material for HTTPS interception.
-	// Expected keys are ca.crt and ca.key.
+	// MITMCASecretName overrides the operator-managed cluster-local MITM CA secret for HTTPS interception.
+	// Expected keys are ca.crt and ca.key. When unset, infra-operator generates and reuses a managed secret.
 	// +optional
 	MITMCASecretName string `json:"mitmCaSecretName,omitempty"`
 	// RuntimeClassName specifies the Kubernetes runtime class for the netd daemonset.

--- a/infra-operator/chart/crds/infra.sandbox0.ai_sandbox0infras.yaml
+++ b/infra-operator/chart/crds/infra.sandbox0.ai_sandbox0infras.yaml
@@ -2208,8 +2208,8 @@ spec:
                         type: object
                       mitmCaSecretName:
                         description: |-
-                          MITMCASecretName mounts a secret containing cluster-local MITM CA material for HTTPS interception.
-                          Expected keys are ca.crt and ca.key.
+                          MITMCASecretName overrides the operator-managed cluster-local MITM CA secret for HTTPS interception.
+                          Expected keys are ca.crt and ca.key. When unset, infra-operator generates and reuses a managed secret.
                         type: string
                       nodeSelector:
                         additionalProperties:

--- a/infra-operator/chart/samples/single-cluster/fullmode.yaml
+++ b/infra-operator/chart/samples/single-cluster/fullmode.yaml
@@ -118,7 +118,8 @@ spec:
       enabled: true
       # Keep netd on a regular host runtime such as runc; do not run netd on gVisor or Kata.
       # runtimeClassName: runc
-      # For HTTPS/gRPC auth injection, point this at a secret containing ca.crt and ca.key.
+      # By default infra-operator manages a cluster-local MITM CA secret for HTTPS/gRPC auth injection.
+      # Set this only when you want to provide your own secret containing ca.crt and ca.key.
       # mitmCaSecretName: netd-mitm-ca
       config:
         egressAuthEnabled: true

--- a/infra-operator/chart/samples/single-cluster/network-policy.yaml
+++ b/infra-operator/chart/samples/single-cluster/network-policy.yaml
@@ -78,7 +78,8 @@ spec:
       enabled: true
       # Keep netd on a regular host runtime such as runc; do not run netd on gVisor or Kata.
       # runtimeClassName: runc
-      # For HTTPS/gRPC auth injection, point this at a secret containing ca.crt and ca.key.
+      # By default infra-operator manages a cluster-local MITM CA secret for HTTPS/gRPC auth injection.
+      # Set this only when you want to provide your own secret containing ca.crt and ca.key.
       # mitmCaSecretName: netd-mitm-ca
       config:
         egressAuthEnabled: true

--- a/infra-operator/internal/controller/services/netd/mitm_ca.go
+++ b/infra-operator/internal/controller/services/netd/mitm_ca.go
@@ -1,0 +1,137 @@
+package netd
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	infrav1alpha1 "github.com/sandbox0-ai/sandbox0/infra-operator/api/v1alpha1"
+)
+
+const (
+	mitmCACertKey = "ca.crt"
+	mitmCAKeyKey  = "ca.key"
+)
+
+func managedMITMCASecretName(infra *infrav1alpha1.Sandbox0Infra) string {
+	return fmt.Sprintf("%s-netd-mitm-ca", infra.Name)
+}
+
+func (r *Reconciler) reconcileManagedMITMCASecret(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, name string, labels map[string]string) error {
+	secret := &corev1.Secret{}
+	getErr := r.Resources.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: infra.Namespace}, secret)
+	if getErr != nil && !apierrors.IsNotFound(getErr) {
+		return getErr
+	}
+
+	if getErr == nil && validateMITMCASecret(secret) == nil {
+		return nil
+	}
+
+	certPEM, keyPEM, err := generateManagedMITMCA(infra)
+	if err != nil {
+		return err
+	}
+
+	desired := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: infra.Namespace,
+			Labels:    labels,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			mitmCACertKey: certPEM,
+			mitmCAKeyKey:  keyPEM,
+		},
+	}
+	if err := ctrl.SetControllerReference(infra, desired, r.Resources.Scheme); err != nil {
+		return err
+	}
+
+	if apierrors.IsNotFound(getErr) {
+		return r.Resources.Client.Create(ctx, desired)
+	}
+
+	secret.Type = desired.Type
+	secret.Data = desired.Data
+	secret.Labels = desired.Labels
+	secret.OwnerReferences = desired.OwnerReferences
+	return r.Resources.Client.Update(ctx, secret)
+}
+
+func validateMITMCASecret(secret *corev1.Secret) error {
+	certPEM := secret.Data[mitmCACertKey]
+	keyPEM := secret.Data[mitmCAKeyKey]
+	if len(certPEM) == 0 || len(keyPEM) == 0 {
+		return fmt.Errorf("missing MITM CA data")
+	}
+	if _, err := tls.X509KeyPair(certPEM, keyPEM); err != nil {
+		return fmt.Errorf("load MITM CA key pair: %w", err)
+	}
+
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		return fmt.Errorf("decode MITM CA cert PEM")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return fmt.Errorf("parse MITM CA cert: %w", err)
+	}
+	if !cert.IsCA {
+		return fmt.Errorf("MITM certificate is not a CA")
+	}
+	return nil
+}
+
+func generateManagedMITMCA(infra *infrav1alpha1.Sandbox0Infra) ([]byte, []byte, error) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate MITM CA key: %w", err)
+	}
+
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate MITM CA serial: %w", err)
+	}
+
+	commonName := "sandbox0-netd-mitm-ca"
+	if infra != nil && infra.Name != "" {
+		commonName = fmt.Sprintf("sandbox0-netd-mitm-ca.%s", infra.Name)
+	}
+	now := time.Now().UTC()
+	template := &x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			CommonName:   commonName,
+			Organization: []string{"sandbox0"},
+		},
+		NotBefore:             now.Add(-time.Hour),
+		NotAfter:              now.AddDate(10, 0, 0),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		MaxPathLenZero:        true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create MITM CA cert: %w", err)
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privateKey)})
+	return certPEM, keyPEM, nil
+}

--- a/infra-operator/internal/controller/services/netd/netd.go
+++ b/infra-operator/internal/controller/services/netd/netd.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strings"
 
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
@@ -54,7 +55,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 	nodeSelector := map[string]string(nil)
 	tolerations := []corev1.Toleration(nil)
 	if infra.Spec.Services != nil && infra.Spec.Services.Netd != nil && infra.Spec.Services.Netd.Config != nil {
-		config = infra.Spec.Services.Netd.Config
+		config = infra.Spec.Services.Netd.Config.DeepCopy()
 	}
 	if infra.Spec.Services != nil && infra.Spec.Services.Netd != nil {
 		runtimeClassName = infra.Spec.Services.Netd.RuntimeClassName
@@ -94,9 +95,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 		}
 		config.EgressBrokerURL = fmt.Sprintf("http://%s-egress-broker.%s.svc.cluster.local:%d", infra.Name, infra.Namespace, port)
 	}
-	mitmCASecretName := ""
-	if infra.Spec.Services != nil && infra.Spec.Services.Netd != nil {
-		mitmCASecretName = infra.Spec.Services.Netd.MITMCASecretName
+	mitmCASecretName, err := r.resolveMITMCASecretName(ctx, infra, labels)
+	if err != nil {
+		return err
 	}
 	if mitmCASecretName != "" {
 		if config.MITMCACertPath == "" {
@@ -112,7 +113,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 	}
 
 	ds := &appsv1.DaemonSet{}
-	err := r.Resources.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: infra.Namespace}, ds)
+	err = r.Resources.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: infra.Namespace}, ds)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
@@ -283,6 +284,22 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 
 	ds.Spec = desired.Spec
 	return r.Resources.Client.Update(ctx, ds)
+}
+
+func (r *Reconciler) resolveMITMCASecretName(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, labels map[string]string) (string, error) {
+	if infra == nil || infra.Spec.Services == nil || infra.Spec.Services.Netd == nil {
+		return "", nil
+	}
+
+	if secretName := strings.TrimSpace(infra.Spec.Services.Netd.MITMCASecretName); secretName != "" {
+		return secretName, nil
+	}
+
+	secretName := managedMITMCASecretName(infra)
+	if err := r.reconcileManagedMITMCASecret(ctx, infra, secretName, labels); err != nil {
+		return "", err
+	}
+	return secretName, nil
 }
 
 func resolveClusterDNSCIDR(ctx context.Context, client ctrlclient.Client, logger logr.Logger) (string, error) {

--- a/infra-operator/internal/controller/services/netd/netd_test.go
+++ b/infra-operator/internal/controller/services/netd/netd_test.go
@@ -2,14 +2,19 @@ package netd
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
 	"strings"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	apiconfig "github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
@@ -82,9 +87,159 @@ func TestReconcileFallsBackToLegacyNetdPlacement(t *testing.T) {
 	}
 }
 
-func TestReconcileMountsMITMCASecret(t *testing.T) {
+func TestReconcileMountsExplicitMITMCASecret(t *testing.T) {
 	infra := newNetdTestInfra()
 	infra.Spec.Services.Netd.MITMCASecretName = "netd-mitm-ca"
+	client, scheme := newNetdTestClient(t, infra.DeepCopy())
+
+	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
+	if err := reconciler.Reconcile(context.Background(), infra, "ghcr.io/sandbox0-ai/sandbox0", "latest"); err != nil {
+		t.Fatalf("reconcile returned error: %v", err)
+	}
+
+	assertNetdMITMSecretMounted(t, client, infra, "netd-mitm-ca")
+
+	if got := infra.Spec.Services.Netd.Config.MITMCACertPath; got != "" {
+		t.Fatalf("expected input config to remain unchanged, got cert path %q", got)
+	}
+	if got := infra.Spec.Services.Netd.Config.MITMCAKeyPath; got != "" {
+		t.Fatalf("expected input config to remain unchanged, got key path %q", got)
+	}
+}
+
+func TestReconcileAutoGeneratesManagedMITMCASecret(t *testing.T) {
+	infra := newNetdTestInfra()
+	client, scheme := newNetdTestClient(t, infra.DeepCopy())
+
+	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
+	if err := reconciler.Reconcile(context.Background(), infra, "ghcr.io/sandbox0-ai/sandbox0", "latest"); err != nil {
+		t.Fatalf("reconcile returned error: %v", err)
+	}
+
+	secretName := managedMITMCASecretName(infra)
+	assertNetdMITMSecretMounted(t, client, infra, secretName)
+
+	secret := &corev1.Secret{}
+	if err := client.Get(context.Background(), types.NamespacedName{
+		Name:      secretName,
+		Namespace: infra.Namespace,
+	}, secret); err != nil {
+		t.Fatalf("expected managed secret: %v", err)
+	}
+	assertValidManagedMITMCASecret(t, secret)
+	if len(secret.OwnerReferences) != 1 || secret.OwnerReferences[0].Name != infra.Name {
+		t.Fatalf("expected secret to be owned by infra, got %#v", secret.OwnerReferences)
+	}
+}
+
+func TestReconcileReusesManagedMITMCASecretAcrossReconciles(t *testing.T) {
+	infra := newNetdTestInfra()
+	client, scheme := newNetdTestClient(t, infra.DeepCopy())
+	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
+
+	if err := reconciler.Reconcile(context.Background(), infra, "ghcr.io/sandbox0-ai/sandbox0", "latest"); err != nil {
+		t.Fatalf("first reconcile returned error: %v", err)
+	}
+
+	secretName := managedMITMCASecretName(infra)
+	secret := &corev1.Secret{}
+	if err := client.Get(context.Background(), types.NamespacedName{
+		Name:      secretName,
+		Namespace: infra.Namespace,
+	}, secret); err != nil {
+		t.Fatalf("expected managed secret after first reconcile: %v", err)
+	}
+	firstCert := append([]byte(nil), secret.Data[mitmCACertKey]...)
+	firstKey := append([]byte(nil), secret.Data[mitmCAKeyKey]...)
+
+	if err := reconciler.Reconcile(context.Background(), infra, "ghcr.io/sandbox0-ai/sandbox0", "latest"); err != nil {
+		t.Fatalf("second reconcile returned error: %v", err)
+	}
+	if err := client.Get(context.Background(), types.NamespacedName{
+		Name:      secretName,
+		Namespace: infra.Namespace,
+	}, secret); err != nil {
+		t.Fatalf("expected managed secret after second reconcile: %v", err)
+	}
+	if string(secret.Data[mitmCACertKey]) != string(firstCert) || string(secret.Data[mitmCAKeyKey]) != string(firstKey) {
+		t.Fatalf("expected managed secret to be reused across reconciles")
+	}
+}
+
+func TestReconcileRepairsInvalidManagedMITMCASecret(t *testing.T) {
+	infra := newNetdTestInfra()
+	invalidSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      managedMITMCASecretName(infra),
+			Namespace: infra.Namespace,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			mitmCACertKey: []byte("invalid cert"),
+			mitmCAKeyKey:  []byte("invalid key"),
+		},
+	}
+	client, scheme := newNetdTestClient(t, infra.DeepCopy(), invalidSecret)
+	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
+
+	if err := reconciler.Reconcile(context.Background(), infra, "ghcr.io/sandbox0-ai/sandbox0", "latest"); err != nil {
+		t.Fatalf("reconcile returned error: %v", err)
+	}
+
+	secret := &corev1.Secret{}
+	if err := client.Get(context.Background(), types.NamespacedName{
+		Name:      managedMITMCASecretName(infra),
+		Namespace: infra.Namespace,
+	}, secret); err != nil {
+		t.Fatalf("expected repaired secret: %v", err)
+	}
+	assertValidManagedMITMCASecret(t, secret)
+}
+
+func TestReconcileExplicitMITMCASecretSkipsManagedSecret(t *testing.T) {
+	infra := newNetdTestInfra()
+	infra.Spec.Services.Netd.MITMCASecretName = "custom-mitm-ca"
+	client, scheme := newNetdTestClient(t, infra.DeepCopy())
+	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
+
+	if err := reconciler.Reconcile(context.Background(), infra, "ghcr.io/sandbox0-ai/sandbox0", "latest"); err != nil {
+		t.Fatalf("reconcile returned error: %v", err)
+	}
+
+	assertNetdMITMSecretMounted(t, client, infra, "custom-mitm-ca")
+
+	managedSecret := &corev1.Secret{}
+	err := client.Get(context.Background(), types.NamespacedName{
+		Name:      managedMITMCASecretName(infra),
+		Namespace: infra.Namespace,
+	}, managedSecret)
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("expected no managed secret when explicit secret is configured, got %v", err)
+	}
+}
+
+func reconcileNetdDaemonSet(t *testing.T, infra *infrav1alpha1.Sandbox0Infra) *appsv1.DaemonSet {
+	t.Helper()
+
+	client, scheme := newNetdTestClient(t, infra.DeepCopy())
+	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
+	if err := reconciler.Reconcile(context.Background(), infra, "ghcr.io/sandbox0-ai/sandbox0", "latest"); err != nil {
+		t.Fatalf("reconcile returned error: %v", err)
+	}
+
+	ds := &appsv1.DaemonSet{}
+	if err := client.Get(context.Background(), types.NamespacedName{
+		Name:      infra.Name + "-netd",
+		Namespace: infra.Namespace,
+	}, ds); err != nil {
+		t.Fatalf("expected daemonset to be created: %v", err)
+	}
+
+	return ds
+}
+
+func newNetdTestClient(t *testing.T, objects ...ctrlclient.Object) (ctrlclient.Client, *runtime.Scheme) {
+	t.Helper()
 
 	scheme := runtime.NewScheme()
 	if err := appsv1.AddToScheme(scheme); err != nil {
@@ -99,13 +254,13 @@ func TestReconcileMountsMITMCASecret(t *testing.T) {
 
 	client := fake.NewClientBuilder().
 		WithScheme(scheme).
-		WithObjects(infra.DeepCopy()).
+		WithObjects(objects...).
 		Build()
+	return client, scheme
+}
 
-	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
-	if err := reconciler.Reconcile(context.Background(), infra, "ghcr.io/sandbox0-ai/sandbox0", "latest"); err != nil {
-		t.Fatalf("reconcile returned error: %v", err)
-	}
+func assertNetdMITMSecretMounted(t *testing.T, client ctrlclient.Client, infra *infrav1alpha1.Sandbox0Infra, secretName string) {
+	t.Helper()
 
 	ds := &appsv1.DaemonSet{}
 	if err := client.Get(context.Background(), types.NamespacedName{
@@ -117,7 +272,7 @@ func TestReconcileMountsMITMCASecret(t *testing.T) {
 	foundVolume := false
 	foundMount := false
 	for _, volume := range ds.Spec.Template.Spec.Volumes {
-		if volume.Name == "mitm-ca" && volume.Secret != nil && volume.Secret.SecretName == "netd-mitm-ca" {
+		if volume.Name == "mitm-ca" && volume.Secret != nil && volume.Secret.SecretName == secretName {
 			foundVolume = true
 		}
 	}
@@ -137,47 +292,37 @@ func TestReconcileMountsMITMCASecret(t *testing.T) {
 	}, cm); err != nil {
 		t.Fatalf("expected configmap: %v", err)
 	}
-	if !strings.Contains(cm.Data["config.yaml"], "mitm_ca_cert_path: /tls/ca.crt") {
-		t.Fatalf("expected mitm ca cert path in config, got %q", cm.Data["config.yaml"])
-	}
-	if !strings.Contains(cm.Data["config.yaml"], "mitm_ca_key_path: /tls/ca.key") {
-		t.Fatalf("expected mitm ca key path in config, got %q", cm.Data["config.yaml"])
+	if got := cm.Data["config.yaml"]; !containsMITMPaths(got) {
+		t.Fatalf("expected mitm ca paths in config, got %q", got)
 	}
 }
 
-func reconcileNetdDaemonSet(t *testing.T, infra *infrav1alpha1.Sandbox0Infra) *appsv1.DaemonSet {
+func assertValidManagedMITMCASecret(t *testing.T, secret *corev1.Secret) {
 	t.Helper()
 
-	scheme := runtime.NewScheme()
-	if err := appsv1.AddToScheme(scheme); err != nil {
-		t.Fatalf("add appsv1 scheme: %v", err)
+	if err := validateMITMCASecret(secret); err != nil {
+		t.Fatalf("expected valid managed MITM CA secret: %v", err)
 	}
-	if err := corev1.AddToScheme(scheme); err != nil {
-		t.Fatalf("add corev1 scheme: %v", err)
-	}
-	if err := infrav1alpha1.AddToScheme(scheme); err != nil {
-		t.Fatalf("add infra scheme: %v", err)
+	if _, err := tls.X509KeyPair(secret.Data[mitmCACertKey], secret.Data[mitmCAKeyKey]); err != nil {
+		t.Fatalf("expected managed secret keypair to load: %v", err)
 	}
 
-	client := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(infra.DeepCopy()).
-		Build()
-
-	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
-	if err := reconciler.Reconcile(context.Background(), infra, "ghcr.io/sandbox0-ai/sandbox0", "latest"); err != nil {
-		t.Fatalf("reconcile returned error: %v", err)
+	block, _ := pem.Decode(secret.Data[mitmCACertKey])
+	if block == nil {
+		t.Fatalf("expected managed secret certificate PEM")
 	}
-
-	ds := &appsv1.DaemonSet{}
-	if err := client.Get(context.Background(), types.NamespacedName{
-		Name:      infra.Name + "-netd",
-		Namespace: infra.Namespace,
-	}, ds); err != nil {
-		t.Fatalf("expected daemonset to be created: %v", err)
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("parse managed secret certificate: %v", err)
 	}
+	if !cert.IsCA {
+		t.Fatalf("expected managed certificate to be a CA")
+	}
+}
 
-	return ds
+func containsMITMPaths(config string) bool {
+	return strings.Contains(config, "mitm_ca_cert_path: /tls/ca.crt") &&
+		strings.Contains(config, "mitm_ca_key_path: /tls/ca.key")
 }
 
 func newNetdTestInfra() *infrav1alpha1.Sandbox0Infra {

--- a/sandbox0-ui/apps/website/src/generated/docs/sandbox0infra-schema.json
+++ b/sandbox0-ui/apps/website/src/generated/docs/sandbox0infra-schema.json
@@ -3522,7 +3522,7 @@
           "path": "spec.services.netd.mitmCaSecretName",
           "type": "string",
           "required": false,
-          "description": "MITMCASecretName mounts a secret containing cluster-local MITM CA material for HTTPS interception. Expected keys are ca.crt and ca.key."
+          "description": "MITMCASecretName overrides the operator-managed cluster-local MITM CA secret for HTTPS interception. Expected keys are ca.crt and ca.key. When unset, infra-operator generates and reuses a managed secret."
         },
         {
           "path": "spec.services.netd.nodeSelector",

--- a/skills/sandbox0/references/docs-src/sandbox/network/page.mdx
+++ b/skills/sandbox0/references/docs-src/sandbox/network/page.mdx
@@ -74,7 +74,7 @@ egress:
 ```
 
 <Callout variant="warning">
-HTTPS and gRPC interception require cluster-level support in self-hosted deployments: `egress-broker` must be enabled, `netd` egress auth must be turned on, and `netd` needs a cluster-local MITM CA secret.
+HTTPS and gRPC interception require cluster-level support in self-hosted deployments: `egress-broker` must be enabled, `netd` egress auth must be turned on, and `netd` needs a cluster-local MITM CA. `infra-operator` manages that CA by default, or you can override it with `services.netd.mitmCaSecretName`.
 </Callout>
 
 ---

--- a/skills/sandbox0/references/docs-src/self-hosted/configuration/page.mdx
+++ b/skills/sandbox0/references/docs-src/self-hosted/configuration/page.mdx
@@ -142,7 +142,6 @@ spec:
             replicas: 2
         netd:
             enabled: true
-            mitmCaSecretName: netd-mitm-ca
             config:
                 egressAuthEnabled: true
                 egressAuthFailurePolicy: fail-closed
@@ -151,7 +150,8 @@ spec:
 Operational notes:
 
 - `egressBroker` is cluster-local. It should not be placed behind a region-scoped dependency on the outbound hot path.
-- `services.netd.mitmCaSecretName` must reference a secret with `ca.crt` and `ca.key` when you use TLS interception for HTTPS or gRPC auth injection.
+- By default, `infra-operator` generates and reuses a cluster-local MITM CA secret for `netd` when `services.netd.mitmCaSecretName` is unset.
+- Set `services.netd.mitmCaSecretName` only when you want to override that behavior with your own secret containing `ca.crt` and `ca.key`.
 - `services.netd.config.egressAuthEnabled` is the cluster-level gate. `authRules` inside sandbox network policy remain the per-policy gate.
 - `fail-open` is possible for some pre-interception failures, but transparent recovery is not guaranteed once downstream TLS interception has already started.
 


### PR DESCRIPTION
## Summary
- add operator-managed MITM CA reconciliation for netd when `services.netd.mitmCaSecretName` is unset
- keep explicit secret configuration as the override path and mount whichever secret netd resolves
- update CRD/schema docs, sample manifests, and netd reconcile tests for the managed CA flow

Closes #43

## Testing
- go test ./infra-operator/internal/controller/...
- go test ./infra-operator/internal/controller/services/netd ./infra-operator/api/v1alpha1
- go test ./sandbox0-ui/apps/website/scripts
- make manifests
- go run ./sandbox0-ui/apps/website/scripts/generate_sandbox0infra_schema.go