### PR TITLE
Fix website docs latest redirects

### DIFF
--- a/sandbox0-ui/apps/website/scripts/finalize_docs_build.mjs
+++ b/sandbox0-ui/apps/website/scripts/finalize_docs_build.mjs
@@ -27,14 +27,64 @@ const shouldDownloadBundles =
  */
 
 async function main() {
-  if (!shouldDownloadBundles) {
-    console.log("skipping docs bundle hydration");
-    return;
-  }
-
   const manifest = /** @type {DocsVersionsManifest} */ (
     JSON.parse(await fs.readFile(generatedManifestPath, "utf8"))
   );
+  await fs.mkdir(outDir, { recursive: true });
+
+  if (shouldDownloadBundles) {
+    await hydrateReleaseDocsBundles(manifest);
+  } else {
+    console.log("skipping docs bundle hydration");
+  }
+
+  await writeLegacyDocsRedirects();
+}
+
+/**
+ * @param {string} repo
+ * @param {string} token
+ * @returns {Promise<Array<{ tag_name: string; prerelease: boolean; draft: boolean; assets?: Array<{ name: string; browser_download_url: string }> }>>}
+ */
+async function fetchGithubReleases(repo, token) {
+  const releases = [];
+
+  for (let page = 1; page <= 5; page += 1) {
+    const url = new URL(`https://api.github.com/repos/${repo}/releases`);
+    url.searchParams.set("per_page", "100");
+    url.searchParams.set("page", String(page));
+
+    const response = await fetch(url, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        "User-Agent": "sandbox0-docs-bundle-fetcher",
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`GitHub API ${response.status}`);
+    }
+
+    const pageItems = await response.json();
+    if (!Array.isArray(pageItems) || pageItems.length === 0) {
+      break;
+    }
+
+    releases.push(...pageItems);
+    if (pageItems.length < 100) {
+      break;
+    }
+  }
+
+  return releases;
+}
+
+/**
+ * @param {DocsVersionsManifest} manifest
+ * @returns {Promise<void>}
+ */
+async function hydrateReleaseDocsBundles(manifest) {
   const releases = await fetchGithubReleases(githubRepo, githubToken);
   const releaseAssetByTag = new Map();
 
@@ -53,8 +103,6 @@ async function main() {
       releaseAssetByTag.set(release.tag_name, asset.browser_download_url);
     }
   }
-
-  await fs.mkdir(outDir, { recursive: true });
 
   for (const version of manifest.versions) {
     if (!version.id.startsWith("v")) {
@@ -107,43 +155,95 @@ async function main() {
   console.log("hydrated release docs bundles into out/");
 }
 
+async function writeLegacyDocsRedirects() {
+  const latestDir = path.join(outDir, "docs", "latest");
+
+  if (!(await pathExists(latestDir))) {
+    console.warn("skipping legacy docs redirects because out/docs/latest is missing");
+    return;
+  }
+
+  const htmlFiles = await collectHtmlFiles(latestDir);
+
+  for (const filePath of htmlFiles) {
+    const relativePath = path.relative(latestDir, filePath);
+    const relativeHref = toPosixPath(relativePath).replace(/\.html$/, "");
+    const legacyPath = path.join(outDir, "docs", relativePath);
+    const redirectTarget = `/docs/latest/${relativeHref}`;
+
+    await fs.mkdir(path.dirname(legacyPath), { recursive: true });
+    await fs.writeFile(legacyPath, renderRedirectHtml(redirectTarget));
+  }
+
+  console.log(`generated ${htmlFiles.length} legacy docs redirects to /docs/latest`);
+}
+
 /**
- * @param {string} repo
- * @param {string} token
- * @returns {Promise<Array<{ tag_name: string; prerelease: boolean; draft: boolean; assets?: Array<{ name: string; browser_download_url: string }> }>>}
+ * @param {string} rootDir
+ * @returns {Promise<string[]>}
  */
-async function fetchGithubReleases(repo, token) {
-  const releases = [];
+async function collectHtmlFiles(rootDir) {
+  const entries = await fs.readdir(rootDir, { withFileTypes: true });
+  const files = [];
 
-  for (let page = 1; page <= 5; page += 1) {
-    const url = new URL(`https://api.github.com/repos/${repo}/releases`);
-    url.searchParams.set("per_page", "100");
-    url.searchParams.set("page", String(page));
+  for (const entry of entries) {
+    const entryPath = path.join(rootDir, entry.name);
 
-    const response = await fetch(url, {
-      headers: {
-        Accept: "application/vnd.github+json",
-        "User-Agent": "sandbox0-docs-bundle-fetcher",
-        ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      },
-    });
-
-    if (!response.ok) {
-      throw new Error(`GitHub API ${response.status}`);
+    if (entry.isDirectory()) {
+      files.push(...(await collectHtmlFiles(entryPath)));
+      continue;
     }
 
-    const pageItems = await response.json();
-    if (!Array.isArray(pageItems) || pageItems.length === 0) {
-      break;
-    }
-
-    releases.push(...pageItems);
-    if (pageItems.length < 100) {
-      break;
+    if (entry.isFile() && entry.name.endsWith(".html")) {
+      files.push(entryPath);
     }
   }
 
-  return releases;
+  return files;
+}
+
+/**
+ * @param {string} redirectTarget
+ * @returns {string}
+ */
+function renderRedirectHtml(redirectTarget) {
+  const escapedTarget = escapeHtml(redirectTarget);
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Redirecting...</title>
+    <meta http-equiv="refresh" content="0;url=${escapedTarget}" />
+    <link rel="canonical" href="${escapedTarget}" />
+    <meta name="robots" content="noindex" />
+    <script>window.location.replace(${JSON.stringify(redirectTarget)});</script>
+  </head>
+  <body>
+    <p>Redirecting to <a href="${escapedTarget}">${escapedTarget}</a>.</p>
+  </body>
+</html>
+`;
+}
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+function escapeHtml(value) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("\"", "&quot;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+/**
+ * @param {string} filePath
+ * @returns {string}
+ */
+function toPosixPath(filePath) {
+  return filePath.split(path.sep).join("/");
 }
 
 /**

--- a/sandbox0-ui/apps/website/scripts/prepare_docs_versions.mjs
+++ b/sandbox0-ui/apps/website/scripts/prepare_docs_versions.mjs
@@ -146,8 +146,13 @@ async function fetchGithubReleases(repo, token) {
  * @returns {DocsVersionsManifest}
  */
 function buildManifest(releases, cachedManifest) {
+  const includePrerelease = process.env.DOCS_INCLUDE_PRERELEASE === "true";
   const actualVersions = releases
     .map((release) => {
+      if (release.prerelease && !includePrerelease) {
+        return null;
+      }
+
       const id = normalizeReleaseTag(release.tag_name);
       if (!id || !hasDocsBundleAsset(release)) {
         return null;

--- a/sandbox0-ui/apps/website/scripts/verify_versioned_docs_render.mjs
+++ b/sandbox0-ui/apps/website/scripts/verify_versioned_docs_render.mjs
@@ -18,6 +18,8 @@ async function main() {
     await verifyVersion(version);
   }
 
+  await verifyLegacyRedirect("get-started.html", "/docs/latest/get-started");
+
   console.log(`verified rendered docs HTML for versions: ${renderedVersions.join(", ")}`);
 }
 
@@ -58,12 +60,37 @@ async function verifyVersion(version) {
   });
 }
 
+async function verifyLegacyRedirect(relativePath, redirectTarget) {
+  const html = await readLegacyOutputHtml(relativePath);
+
+  if (!html.includes(`content="0;url=${redirectTarget}"`)) {
+    throw new Error(
+      `legacy docs redirect ${relativePath} is missing meta refresh to ${redirectTarget}`
+    );
+  }
+
+  if (!html.includes(`window.location.replace(${JSON.stringify(redirectTarget)})`)) {
+    throw new Error(
+      `legacy docs redirect ${relativePath} is missing script redirect to ${redirectTarget}`
+    );
+  }
+}
+
 async function readOutputHtml(version, relativePath) {
   const filePath = path.join(outDir, version, relativePath);
   try {
     return await fs.readFile(filePath, "utf8");
   } catch (error) {
     throw new Error(`expected rendered docs output at ${path.relative(appRoot, filePath)}: ${String(error)}`);
+  }
+}
+
+async function readLegacyOutputHtml(relativePath) {
+  const filePath = path.join(outDir, relativePath);
+  try {
+    return await fs.readFile(filePath, "utf8");
+  } catch (error) {
+    throw new Error(`expected legacy docs redirect at ${path.relative(appRoot, filePath)}: ${String(error)}`);
   }
 }
 

--- a/sandbox0-ui/apps/website/src/app/docs/[version]/[[...slug]]/page.tsx
+++ b/sandbox0-ui/apps/website/src/app/docs/[version]/[[...slug]]/page.tsx
@@ -3,19 +3,30 @@ import { defaultDocsPageSlug, docsPageSlugs, renderDocsPage } from "@/app/docs/c
 import {
   DOCS_DEFAULT_VERSION,
   getRenderedDocsVersions,
+  isDocsVersionSegment,
   isRenderedDocsVersion,
 } from "@/components/docs/versioning";
 
 export const dynamicParams = false;
 
 export function generateStaticParams() {
-  return getRenderedDocsVersions().flatMap((version) => [
+  const versionedParams = getRenderedDocsVersions().flatMap((version) => [
     { version, slug: [] as string[] },
     ...docsPageSlugs.map((pageSlug) => ({
       version,
       slug: pageSlug.split("/"),
     })),
   ]);
+
+  const legacyParams = docsPageSlugs.map((pageSlug) => {
+    const [legacyVersion, ...legacySlug] = pageSlug.split("/");
+    return {
+      version: legacyVersion,
+      slug: legacySlug,
+    };
+  });
+
+  return [...versionedParams, ...legacyParams];
 }
 
 export default async function VersionedDocsPage({
@@ -30,7 +41,11 @@ export default async function VersionedDocsPage({
   const slug = resolvedParams.slug ?? [];
 
   if (!isRenderedDocsVersion(resolvedParams.version)) {
-    notFound();
+    if (isDocsVersionSegment(resolvedParams.version)) {
+      notFound();
+    }
+
+    redirect(`/docs/${DOCS_DEFAULT_VERSION}/${[resolvedParams.version, ...slug].join("/")}`);
   }
 
   if (resolvedParams.version === DOCS_DEFAULT_VERSION && slug.length === 0) {


### PR DESCRIPTION
## Summary
- redirect legacy website docs paths like `/docs/get-started` to `/docs/latest/...` in the exported docs route
- include legacy docs slugs in `generateStaticParams()` so `output: export` no longer errors on those paths
- default docs version manifest generation to exclude prerelease tags unless `DOCS_INCLUDE_PRERELEASE=true`

## Testing
- npm run build