### PR TITLE
fix(ui): restore heading children typing

### DIFF
--- a/components/ui/src/components/PixelHeading.tsx
+++ b/components/ui/src/components/PixelHeading.tsx
@@ -7,6 +7,7 @@ export type PixelHeadingTone = "site" | "docs";
 export type PixelHeadingAs = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
 
 export interface PixelHeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {
+  children?: React.ReactNode;
   /**
    * Which semantic heading tag to render.
    * Defaults to `h2`.
@@ -63,4 +64,3 @@ export function PixelHeading({
     </Tag>
   );
 }
-


### PR DESCRIPTION
## Summary
- add the missing `children` prop to `PixelHeadingProps`
- keep the shared UI typings compatible with the split `sandbox0-cloud` website build

Refs sandbox0-ai/sandbox0-cloud#13

## Testing
- npm run build:website in `sandbox0-cloud`