### PR TITLE
Add gateway metadata and global home-region validation

### DIFF
--- a/cluster-gateway/pkg/http/server.go
+++ b/cluster-gateway/pkg/http/server.go
@@ -298,6 +298,7 @@ func (s *Server) setupRoutes() {
 	// Health check endpoints (no auth required)
 	s.router.GET("/healthz", s.healthCheck)
 	s.router.GET("/readyz", s.readinessCheck)
+	s.router.GET("/metadata", gatewayhandlers.GatewayMetadata("cluster-gateway", gatewayhandlers.GatewayModeDirect))
 
 	// Metrics endpoint
 	s.router.GET("/metrics", gin.WrapH(promhttp.Handler()))

--- a/cluster-gateway/pkg/http/server_metering_routes_test.go
+++ b/cluster-gateway/pkg/http/server_metering_routes_test.go
@@ -55,6 +55,19 @@ func TestSetupRoutesMountsMeteringEndpointsInPublicMode(t *testing.T) {
 	}
 }
 
+func TestSetupRoutesMountsMetadataEndpoint(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	server, _, _ := testMeteringRouteServer(t, "public")
+	server.requestLogger = middleware.NewRequestLogger(zap.NewNop())
+	server.obsProvider = newTestMeteringObservability(t)
+	server.setupRoutes()
+
+	if !hasRoute(server.router, "GET", "/metadata") {
+		t.Fatal("expected /metadata route to be mounted")
+	}
+}
+
 func TestSetupMeteringRoutesDoesNotRequireManagerUpstream(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/global-gateway/pkg/http/server.go
+++ b/global-gateway/pkg/http/server.go
@@ -128,15 +128,18 @@ func (s *Server) setupRoutes() {
 	s.router.GET("/healthz", s.healthCheck)
 	s.router.GET("/readyz", s.readinessCheck)
 	s.router.GET("/metrics", gin.WrapH(promhttp.Handler()))
+	s.router.GET("/metadata", handlers.GatewayMetadata("global-gateway", handlers.GatewayModeGlobal))
 
 	public.RegisterIdentityRoutes(s.router, public.Deps{
-		IdentityRepo:    s.identityRepo,
-		AuthMiddleware:  s.authMiddleware,
-		BuiltinProvider: s.builtinProvider,
-		OIDCManager:     s.oidcManager,
-		Entitlements:    s.entitlements,
-		JWTIssuer:       s.jwtIssuer,
-		Logger:          s.logger,
+		IdentityRepo:            s.identityRepo,
+		AuthMiddleware:          s.authMiddleware,
+		BuiltinProvider:         s.builtinProvider,
+		OIDCManager:             s.oidcManager,
+		Entitlements:            s.entitlements,
+		JWTIssuer:               s.jwtIssuer,
+		RegionRepo:              s.regionRepo,
+		RequireCreateHomeRegion: true,
+		Logger:                  s.logger,
 	})
 
 	tenantHandler := handlers.NewTenantHandler(s.tenantResolver, s.jwtIssuer, s.cfg.RegionTokenTTL.Duration, s.logger)

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -67,6 +67,17 @@ paths:
             text/plain:
               schema:
                 type: string
+  /metadata:
+    get:
+      tags: [health]
+      summary: Gateway metadata
+      responses:
+        "200":
+          description: Gateway metadata
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessGatewayMetadataResponse"
   /auth/providers:
     get:
       tags: [auth]
@@ -2489,6 +2500,22 @@ components:
                 timestamp:
                   type: integer
                   format: int64
+    GatewayMetadata:
+      type: object
+      properties:
+        gateway_mode:
+          type: string
+          enum: [direct, global]
+        service:
+          type: string
+      required: [gateway_mode, service]
+    SuccessGatewayMetadataResponse:
+      allOf:
+        - $ref: "#/components/schemas/SuccessEnvelope"
+        - type: object
+          properties:
+            data:
+              $ref: "#/components/schemas/GatewayMetadata"
     SuccessMessageResponse:
       allOf:
         - $ref: "#/components/schemas/SuccessEnvelope"

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -86,6 +86,12 @@ const (
 	Symlink FileInfoType = "symlink"
 )
 
+// Defines values for GatewayMetadataGatewayMode.
+const (
+	Direct GatewayMetadataGatewayMode = "direct"
+	Global GatewayMetadataGatewayMode = "global"
+)
+
 // Defines values for ProcessType.
 const (
 	Cmd  ProcessType = "cmd"
@@ -195,6 +201,11 @@ const (
 // Defines values for SuccessFileStatResponseSuccess.
 const (
 	SuccessFileStatResponseSuccessTrue SuccessFileStatResponseSuccess = true
+)
+
+// Defines values for SuccessGatewayMetadataResponseSuccess.
+const (
+	SuccessGatewayMetadataResponseSuccessTrue SuccessGatewayMetadataResponseSuccess = true
 )
 
 // Defines values for SuccessHealthResponseSuccess.
@@ -364,7 +375,7 @@ const (
 
 // Defines values for SuccessWrittenResponseSuccess.
 const (
-	True SuccessWrittenResponseSuccess = true
+	SuccessWrittenResponseSuccessTrue SuccessWrittenResponseSuccess = true
 )
 
 // Defines values for TrafficRuleAction.
@@ -782,6 +793,15 @@ type ForkVolumeRequest struct {
 	Prefetch   *int              `json:"prefetch,omitempty"`
 	Writeback  *bool             `json:"writeback,omitempty"`
 }
+
+// GatewayMetadata defines model for GatewayMetadata.
+type GatewayMetadata struct {
+	GatewayMode GatewayMetadataGatewayMode `json:"gateway_mode"`
+	Service     string                     `json:"service"`
+}
+
+// GatewayMetadataGatewayMode defines model for GatewayMetadata.GatewayMode.
+type GatewayMetadataGatewayMode string
 
 // HTTPHeadersProjection defines model for HTTPHeadersProjection.
 type HTTPHeadersProjection struct {
@@ -1519,6 +1539,15 @@ type SuccessFileStatResponse struct {
 
 // SuccessFileStatResponseSuccess defines model for SuccessFileStatResponse.Success.
 type SuccessFileStatResponseSuccess bool
+
+// SuccessGatewayMetadataResponse defines model for SuccessGatewayMetadataResponse.
+type SuccessGatewayMetadataResponse struct {
+	Data    *GatewayMetadata                      `json:"data,omitempty"`
+	Success SuccessGatewayMetadataResponseSuccess `json:"success"`
+}
+
+// SuccessGatewayMetadataResponseSuccess defines model for SuccessGatewayMetadataResponse.Success.
+type SuccessGatewayMetadataResponseSuccess bool
 
 // SuccessHealthResponse defines model for SuccessHealthResponse.
 type SuccessHealthResponse struct {

--- a/pkg/gateway/http/handlers/metadata.go
+++ b/pkg/gateway/http/handlers/metadata.go
@@ -1,0 +1,28 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
+)
+
+const (
+	GatewayModeDirect = "direct"
+	GatewayModeGlobal = "global"
+)
+
+type GatewayMetadataResponse struct {
+	GatewayMode string `json:"gateway_mode"`
+	Service     string `json:"service"`
+}
+
+// GatewayMetadata returns a handler that reports the public gateway mode for the current entrypoint.
+func GatewayMetadata(service, gatewayMode string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		spec.JSONSuccess(c, http.StatusOK, GatewayMetadataResponse{
+			GatewayMode: gatewayMode,
+			Service:     service,
+		})
+	}
+}

--- a/pkg/gateway/http/handlers/metadata_test.go
+++ b/pkg/gateway/http/handlers/metadata_test.go
@@ -1,0 +1,27 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestGatewayMetadata(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.New()
+	router.GET("/metadata", GatewayMetadata("global-gateway", GatewayModeGlobal))
+
+	req := httptest.NewRequest(http.MethodGet, "/metadata", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if body := rec.Body.String(); body == "" {
+		t.Fatal("expected response body")
+	}
+}

--- a/pkg/gateway/http/handlers/team.go
+++ b/pkg/gateway/http/handlers/team.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"strings"
@@ -9,21 +10,58 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/identity"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/middleware"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/tenantdir"
 	"go.uber.org/zap"
 )
 
-// TeamHandler handles team endpoints
-type TeamHandler struct {
-	repo   *identity.Repository
-	logger *zap.Logger
+type teamRepository interface {
+	GetTeamsByUserID(ctx context.Context, userID string) ([]*identity.Team, error)
+	CreateTeam(ctx context.Context, team *identity.Team) error
+	GetTeamMember(ctx context.Context, teamID, userID string) (*identity.TeamMember, error)
+	GetTeamByID(ctx context.Context, id string) (*identity.Team, error)
+	UpdateTeam(ctx context.Context, team *identity.Team) error
+	DeleteTeam(ctx context.Context, id string) error
+	GetTeamMembers(ctx context.Context, teamID string) ([]*identity.TeamMemberWithUser, error)
+	GetUserByEmail(ctx context.Context, email string) (*identity.User, error)
+	AddTeamMember(ctx context.Context, member *identity.TeamMember) error
+	UpdateTeamMemberRole(ctx context.Context, teamID, userID, role string) error
+	RemoveTeamMember(ctx context.Context, teamID, userID string) error
 }
 
-// NewTeamHandler creates a new team handler
-func NewTeamHandler(repo *identity.Repository, logger *zap.Logger) *TeamHandler {
-	return &TeamHandler{
+// TeamRegionLookup resolves region directory entries for team validation.
+type TeamRegionLookup interface {
+	GetRegion(ctx context.Context, regionID string) (*tenantdir.Region, error)
+}
+
+// TeamHandler handles team endpoints
+type TeamHandler struct {
+	repo                      teamRepository
+	logger                    *zap.Logger
+	requireHomeRegionOnCreate bool
+	regionLookup              TeamRegionLookup
+}
+
+// TeamHandlerOption configures TeamHandler behavior.
+type TeamHandlerOption func(*TeamHandler)
+
+// WithCreateHomeRegionRequired requires create requests to include a valid, routable home region.
+func WithCreateHomeRegionRequired(regionLookup TeamRegionLookup) TeamHandlerOption {
+	return func(h *TeamHandler) {
+		h.requireHomeRegionOnCreate = true
+		h.regionLookup = regionLookup
+	}
+}
+
+// NewTeamHandler creates a new team handler.
+func NewTeamHandler(repo teamRepository, logger *zap.Logger, opts ...TeamHandlerOption) *TeamHandler {
+	handler := &TeamHandler{
 		repo:   repo,
 		logger: logger,
 	}
+	for _, opt := range opts {
+		opt(handler)
+	}
+	return handler
 }
 
 // ListTeams returns all teams the current user belongs to
@@ -65,11 +103,39 @@ func (h *TeamHandler) CreateTeam(c *gin.Context) {
 		return
 	}
 
+	homeRegionID := normalizeOptionalString(req.HomeRegionID)
+	if h.requireHomeRegionOnCreate {
+		if homeRegionID == nil {
+			spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "home_region_id is required")
+			return
+		}
+		if h.regionLookup == nil {
+			h.logger.Error("Missing home region lookup for required create validation")
+			spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to resolve home region")
+			return
+		}
+
+		region, err := h.regionLookup.GetRegion(c.Request.Context(), *homeRegionID)
+		if err != nil {
+			if errors.Is(err, tenantdir.ErrRegionNotFound) {
+				spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "home region not found")
+				return
+			}
+			h.logger.Error("Failed to resolve home region", zap.Error(err))
+			spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to resolve home region")
+			return
+		}
+		if !region.Enabled || strings.TrimSpace(region.RegionalGatewayURL) == "" {
+			spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "home region is not routable")
+			return
+		}
+	}
+
 	team := &identity.Team{
 		Name:         req.Name,
 		Slug:         req.Slug,
 		OwnerID:      &authCtx.UserID,
-		HomeRegionID: normalizeOptionalString(req.HomeRegionID),
+		HomeRegionID: homeRegionID,
 	}
 
 	if err := h.repo.CreateTeam(c.Request.Context(), team); err != nil {

--- a/pkg/gateway/http/handlers/team_test.go
+++ b/pkg/gateway/http/handlers/team_test.go
@@ -1,0 +1,252 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/authn"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/identity"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/tenantdir"
+	"go.uber.org/zap"
+)
+
+type stubTeamRepository struct {
+	createdTeam     *identity.Team
+	addedTeamMember *identity.TeamMember
+}
+
+func (s *stubTeamRepository) GetTeamsByUserID(context.Context, string) ([]*identity.Team, error) {
+	return nil, nil
+}
+
+func (s *stubTeamRepository) CreateTeam(_ context.Context, team *identity.Team) error {
+	copyTeam := *team
+	copyTeam.ID = "team-1"
+	s.createdTeam = &copyTeam
+	team.ID = copyTeam.ID
+	return nil
+}
+
+func (s *stubTeamRepository) GetTeamMember(context.Context, string, string) (*identity.TeamMember, error) {
+	return nil, identity.ErrMemberNotFound
+}
+
+func (s *stubTeamRepository) GetTeamByID(context.Context, string) (*identity.Team, error) {
+	return nil, identity.ErrTeamNotFound
+}
+
+func (s *stubTeamRepository) UpdateTeam(context.Context, *identity.Team) error {
+	return nil
+}
+
+func (s *stubTeamRepository) DeleteTeam(context.Context, string) error {
+	return nil
+}
+
+func (s *stubTeamRepository) GetTeamMembers(context.Context, string) ([]*identity.TeamMemberWithUser, error) {
+	return nil, nil
+}
+
+func (s *stubTeamRepository) GetUserByEmail(context.Context, string) (*identity.User, error) {
+	return nil, identity.ErrUserNotFound
+}
+
+func (s *stubTeamRepository) AddTeamMember(_ context.Context, member *identity.TeamMember) error {
+	copyMember := *member
+	s.addedTeamMember = &copyMember
+	return nil
+}
+
+func (s *stubTeamRepository) UpdateTeamMemberRole(context.Context, string, string, string) error {
+	return nil
+}
+
+func (s *stubTeamRepository) RemoveTeamMember(context.Context, string, string) error {
+	return nil
+}
+
+type stubTeamRegionLookup struct {
+	region *tenantdir.Region
+	err    error
+}
+
+func (s *stubTeamRegionLookup) GetRegion(context.Context, string) (*tenantdir.Region, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.region, nil
+}
+
+func TestTeamHandlerCreateTeamRequiresHomeRegionInGlobalMode(t *testing.T) {
+	t.Setenv("GIN_MODE", "release")
+	gin.SetMode(gin.ReleaseMode)
+
+	repo := &stubTeamRepository{}
+	handler := NewTeamHandler(repo, zap.NewNop(), WithCreateHomeRegionRequired(&stubTeamRegionLookup{
+		region: &tenantdir.Region{
+			ID:                 "aws/us-east-1",
+			RegionalGatewayURL: "https://use1.example.com",
+			Enabled:            true,
+		},
+	}))
+
+	rec := performCreateTeamRequest(t, handler, map[string]any{
+		"name": "Example Team",
+	})
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+
+	_, apiErr, err := spec.DecodeResponse[map[string]any](rec.Body)
+	if err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if apiErr == nil || apiErr.Message != "home_region_id is required" {
+		t.Fatalf("unexpected api error: %#v", apiErr)
+	}
+	if repo.createdTeam != nil {
+		t.Fatal("team should not be created")
+	}
+}
+
+func TestTeamHandlerCreateTeamRejectsUnknownHomeRegionInGlobalMode(t *testing.T) {
+	t.Setenv("GIN_MODE", "release")
+	gin.SetMode(gin.ReleaseMode)
+
+	repo := &stubTeamRepository{}
+	handler := NewTeamHandler(repo, zap.NewNop(), WithCreateHomeRegionRequired(&stubTeamRegionLookup{
+		err: tenantdir.ErrRegionNotFound,
+	}))
+
+	rec := performCreateTeamRequest(t, handler, map[string]any{
+		"name":           "Example Team",
+		"home_region_id": "aws/us-east-1",
+	})
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+
+	_, apiErr, err := spec.DecodeResponse[map[string]any](rec.Body)
+	if err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if apiErr == nil || apiErr.Message != "home region not found" {
+		t.Fatalf("unexpected api error: %#v", apiErr)
+	}
+	if repo.createdTeam != nil {
+		t.Fatal("team should not be created")
+	}
+}
+
+func TestTeamHandlerCreateTeamRejectsUnroutableHomeRegionInGlobalMode(t *testing.T) {
+	t.Setenv("GIN_MODE", "release")
+	gin.SetMode(gin.ReleaseMode)
+
+	repo := &stubTeamRepository{}
+	handler := NewTeamHandler(repo, zap.NewNop(), WithCreateHomeRegionRequired(&stubTeamRegionLookup{
+		region: &tenantdir.Region{
+			ID:                 "aws/us-east-1",
+			RegionalGatewayURL: "",
+			Enabled:            true,
+		},
+	}))
+
+	rec := performCreateTeamRequest(t, handler, map[string]any{
+		"name":           "Example Team",
+		"home_region_id": "aws/us-east-1",
+	})
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+
+	_, apiErr, err := spec.DecodeResponse[map[string]any](rec.Body)
+	if err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if apiErr == nil || apiErr.Message != "home region is not routable" {
+		t.Fatalf("unexpected api error: %#v", apiErr)
+	}
+	if repo.createdTeam != nil {
+		t.Fatal("team should not be created")
+	}
+}
+
+func TestTeamHandlerCreateTeamAllowsMissingHomeRegionWithoutGlobalRequirement(t *testing.T) {
+	t.Setenv("GIN_MODE", "release")
+	gin.SetMode(gin.ReleaseMode)
+
+	repo := &stubTeamRepository{}
+	handler := NewTeamHandler(repo, zap.NewNop())
+
+	rec := performCreateTeamRequest(t, handler, map[string]any{
+		"name": "Example Team",
+	})
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	if repo.createdTeam == nil {
+		t.Fatal("expected team to be created")
+	}
+	if repo.createdTeam.HomeRegionID != nil {
+		t.Fatalf("expected nil home region, got %#v", repo.createdTeam.HomeRegionID)
+	}
+	if repo.addedTeamMember == nil || repo.addedTeamMember.TeamID != "team-1" {
+		t.Fatalf("expected creator to be added as team member, got %#v", repo.addedTeamMember)
+	}
+}
+
+func performCreateTeamRequest(t *testing.T, handler *TeamHandler, body map[string]any) *httptest.ResponseRecorder {
+	t.Helper()
+
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("auth_context", &authn.AuthContext{
+			AuthMethod: authn.AuthMethodJWT,
+			UserID:     "user-1",
+			TeamID:     "team-0",
+			TeamRole:   "admin",
+		})
+		c.Next()
+	})
+	router.POST("/teams", handler.CreateTeam)
+
+	rawBody, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/teams", bytes.NewReader(rawBody))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestTeamHandlerCreateTeamReturnsInternalErrorWhenRegionLookupFails(t *testing.T) {
+	t.Setenv("GIN_MODE", "release")
+	gin.SetMode(gin.ReleaseMode)
+
+	repo := &stubTeamRepository{}
+	handler := NewTeamHandler(repo, zap.NewNop(), WithCreateHomeRegionRequired(&stubTeamRegionLookup{
+		err: errors.New("db offline"),
+	}))
+
+	rec := performCreateTeamRequest(t, handler, map[string]any{
+		"name":           "Example Team",
+		"home_region_id": "aws/us-east-1",
+	})
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusInternalServerError, rec.Body.String())
+	}
+}

--- a/pkg/gateway/public/routes.go
+++ b/pkg/gateway/public/routes.go
@@ -9,20 +9,23 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/http/handlers"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/identity"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/middleware"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/tenantdir"
 	"github.com/sandbox0-ai/sandbox0/pkg/licensing"
 	licensinghttp "github.com/sandbox0-ai/sandbox0/pkg/licensing/http"
 	"go.uber.org/zap"
 )
 
 type Deps struct {
-	IdentityRepo    *identity.Repository
-	APIKeyRepo      *apikey.Repository
-	AuthMiddleware  *middleware.AuthMiddleware
-	BuiltinProvider *builtin.Provider
-	OIDCManager     *oidc.Manager
-	Entitlements    licensing.Entitlements
-	JWTIssuer       *authn.Issuer
-	Logger          *zap.Logger
+	IdentityRepo            *identity.Repository
+	APIKeyRepo              *apikey.Repository
+	AuthMiddleware          *middleware.AuthMiddleware
+	BuiltinProvider         *builtin.Provider
+	OIDCManager             *oidc.Manager
+	Entitlements            licensing.Entitlements
+	JWTIssuer               *authn.Issuer
+	RegionRepo              *tenantdir.Repository
+	RequireCreateHomeRegion bool
+	Logger                  *zap.Logger
 }
 
 // RegisterRoutes mounts the full self-hosted public surface.
@@ -41,7 +44,11 @@ func RegisterIdentityRoutes(router gin.IRouter, deps Deps) {
 		deps.Logger,
 	)
 	userHandler := handlers.NewUserHandler(deps.IdentityRepo, deps.Logger)
-	teamHandler := handlers.NewTeamHandler(deps.IdentityRepo, deps.Logger)
+	teamOpts := make([]handlers.TeamHandlerOption, 0, 1)
+	if deps.RequireCreateHomeRegion {
+		teamOpts = append(teamOpts, handlers.WithCreateHomeRegionRequired(deps.RegionRepo))
+	}
+	teamHandler := handlers.NewTeamHandler(deps.IdentityRepo, deps.Logger, teamOpts...)
 
 	// ===== Public Auth Routes (no authentication required) =====
 	auth := router.Group("/auth")

--- a/regional-gateway/pkg/http/server.go
+++ b/regional-gateway/pkg/http/server.go
@@ -242,6 +242,7 @@ func (s *Server) setupRoutes() {
 	// Health check endpoints (no auth required)
 	s.router.GET("/healthz", s.healthCheck)
 	s.router.GET("/readyz", s.readinessCheck)
+	s.router.GET("/metadata", gatewayhandlers.GatewayMetadata("regional-gateway", gatewayhandlers.GatewayModeDirect))
 
 	// Metrics endpoint
 	s.router.GET("/metrics", gin.WrapH(promhttp.Handler()))


### PR DESCRIPTION
## Summary
- add a public `/metadata` endpoint that reports gateway mode for global, regional, and cluster entrypoints
- require a valid, enabled, routable `home_region_id` when creating teams through global-gateway
- add handler and gateway tests for metadata and global-only team validation

Refs sandbox0-ai/s0#6

## Testing
- go test ./pkg/gateway/http/handlers ./pkg/gateway/public ./global-gateway/pkg/http ./regional-gateway/pkg/http ./cluster-gateway/pkg/http