### PR TITLE
Add default home region fallback for global team creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Key features of Sandbox0:
 - Hot Sandbox Pool: Pre-creates idle Pods for millisecond-level startup times.
 - Persistent Storage: Persistent Volumes based on JuiceFS, supporting snapshot/restore/fork.
 - Network Control: netd implements node-level L4/L7 policy enforcement.
+- Egress Auth: outbound credentials can be resolved and injected on the egress path, so raw secret material does not need to live inside the sandbox process.
 - Process Management: procd acts as the sandbox's PID=1, supporting REPL processes requiring session persistence (e.g., bash, python, node, redis-cli) and one-time Cmd processes.
 - Self-hosting Friendly: Complete private deployment solution.
 - Modular Installation: From a minimal mode with only 2 services to a single-cluster full mode, and multi-cluster horizontal scaling.
@@ -28,6 +29,7 @@ It can serve as an E2B alternative, suitable for general agents, coding agents, 
 - Persistent volumes decoupled from sandbox lifetime through `storage-proxy`, so agent workspaces, caches, checkpoints, and generated artifacts can outlive any single pod.
 - Snapshot, restore, and fork-oriented volume workflows built on JuiceFS plus object storage and PostgreSQL metadata, which is exactly what long-running agent systems need for recovery and reuse.
 - Node-level network control through `netd`, which watches sandbox policy, transparently redirects traffic, and applies L4/L7 enforcement close to the workload.
+- Egress auth that resolves credential bindings outside the sandbox and injects outbound auth at the network edge, which is a safer fit for untrusted agent code than placing raw API keys or client certificates in the sandbox environment.
 - Runtime-agnostic sandboxing via template `runtimeClassName`, so the same system can run on a standard Kubernetes runtime in development and move to stronger isolation such as gVisor or Kata in production.
 - A deployment model that scales from a simple single-cluster setup to multi-cluster regional routing with `regional-gateway` and `scheduler`.
 - Operator-first lifecycle management, so installation, reconciliation, and upgrades follow a repeatable Kubernetes-native path instead of bespoke scripts.
@@ -65,6 +67,8 @@ flowchart TD
 ```
 
 Most users start with a single-cluster deployment and only move to multi-cluster when they need regional scale-out. For deeper architecture and deployment details, see <https://sandbox0.ai/docs/self-hosted>.
+
+In multi-region deployments backed by `global-gateway`, operators can set `default_home_region_id` in the global-gateway config so newly created teams inherit a routable home region even when the create request omits `home_region_id`.
 
 ## Claim A Sandbox
 

--- a/global-gateway/pkg/http/server.go
+++ b/global-gateway/pkg/http/server.go
@@ -131,15 +131,16 @@ func (s *Server) setupRoutes() {
 	s.router.GET("/metadata", handlers.GatewayMetadata("global-gateway", handlers.GatewayModeGlobal))
 
 	public.RegisterIdentityRoutes(s.router, public.Deps{
-		IdentityRepo:            s.identityRepo,
-		AuthMiddleware:          s.authMiddleware,
-		BuiltinProvider:         s.builtinProvider,
-		OIDCManager:             s.oidcManager,
-		Entitlements:            s.entitlements,
-		JWTIssuer:               s.jwtIssuer,
-		RegionRepo:              s.regionRepo,
-		RequireCreateHomeRegion: true,
-		Logger:                  s.logger,
+		IdentityRepo:              s.identityRepo,
+		AuthMiddleware:            s.authMiddleware,
+		BuiltinProvider:           s.builtinProvider,
+		OIDCManager:               s.oidcManager,
+		Entitlements:              s.entitlements,
+		JWTIssuer:                 s.jwtIssuer,
+		RegionRepo:                s.regionRepo,
+		RequireCreateHomeRegion:   true,
+		DefaultCreateHomeRegionID: s.cfg.DefaultHomeRegionID,
+		Logger:                    s.logger,
 	})
 
 	tenantHandler := handlers.NewTenantHandler(s.tenantResolver, s.jwtIssuer, s.cfg.RegionTokenTTL.Duration, s.logger)

--- a/infra-operator/api/config/global_gateway.go
+++ b/infra-operator/api/config/global_gateway.go
@@ -34,6 +34,10 @@ type GlobalGatewayConfig struct {
 	// +kubebuilder:default="5m"
 	RegionTokenTTL metav1.Duration `yaml:"region_token_ttl" json:"regionTokenTTL"`
 
+	// DefaultHomeRegionID is used for new teams when create requests omit home_region_id.
+	// +optional
+	DefaultHomeRegionID string `yaml:"default_home_region_id" json:"defaultHomeRegionId"`
+
 	// License file path used to unlock enterprise SSO features.
 	// +optional
 	LicenseFile string `yaml:"license_file" json:"-"`
@@ -56,18 +60,19 @@ type GlobalGatewayConfig struct {
 }
 
 type globalGatewayConfigYAML struct {
-	HTTPPort           int    `yaml:"http_port"`
-	LogLevel           string `yaml:"log_level"`
-	DatabaseURL        string `yaml:"database_url"`
-	DatabaseMaxConns   int    `yaml:"database_max_conns"`
-	DatabaseMinConns   int    `yaml:"database_min_conns"`
-	DatabaseSchema     string `yaml:"database_schema"`
-	RegionTokenTTL     string `yaml:"region_token_ttl"`
-	LicenseFile        string `yaml:"license_file"`
-	ShutdownTimeout    string `yaml:"shutdown_timeout"`
-	ServerReadTimeout  string `yaml:"server_read_timeout"`
-	ServerWriteTimeout string `yaml:"server_write_timeout"`
-	ServerIdleTimeout  string `yaml:"server_idle_timeout"`
+	HTTPPort            int    `yaml:"http_port"`
+	LogLevel            string `yaml:"log_level"`
+	DatabaseURL         string `yaml:"database_url"`
+	DatabaseMaxConns    int    `yaml:"database_max_conns"`
+	DatabaseMinConns    int    `yaml:"database_min_conns"`
+	DatabaseSchema      string `yaml:"database_schema"`
+	RegionTokenTTL      string `yaml:"region_token_ttl"`
+	DefaultHomeRegionID string `yaml:"default_home_region_id"`
+	LicenseFile         string `yaml:"license_file"`
+	ShutdownTimeout     string `yaml:"shutdown_timeout"`
+	ServerReadTimeout   string `yaml:"server_read_timeout"`
+	ServerWriteTimeout  string `yaml:"server_write_timeout"`
+	ServerIdleTimeout   string `yaml:"server_idle_timeout"`
 
 	JWTSecret                string               `yaml:"jwt_secret"`
 	JWTIssuer                string               `yaml:"jwt_issuer"`
@@ -137,6 +142,7 @@ func applyGlobalGatewayYAML(cfg *GlobalGatewayConfig, raw globalGatewayConfigYAM
 	cfg.DatabaseMinConns = raw.DatabaseMinConns
 	cfg.DatabaseSchema = raw.DatabaseSchema
 	cfg.LicenseFile = raw.LicenseFile
+	cfg.DefaultHomeRegionID = raw.DefaultHomeRegionID
 	cfg.JWTSecret = raw.JWTSecret
 	cfg.JWTIssuer = raw.JWTIssuer
 	cfg.RateLimitRPS = raw.RateLimitRPS

--- a/infra-operator/api/config/global_gateway_test.go
+++ b/infra-operator/api/config/global_gateway_test.go
@@ -14,6 +14,7 @@ func TestLoadGlobalGatewayConfigExpandsEnvAndParsesDurations(t *testing.T) {
 	t.Setenv("TEST_DATABASE_URL", "postgres://cloud:test@localhost:5432/cloud")
 	configYAML := `database_url: ${TEST_DATABASE_URL}
 region_token_ttl: 7m
+default_home_region_id: aws/us-east-1
 shutdown_timeout: 31s
 jwt_access_token_ttl: 20m
 oidc_state_cleanup_interval: 2m
@@ -32,6 +33,9 @@ oidc_state_cleanup_interval: 2m
 	}
 	if cfg.RegionTokenTTL.Duration != 7*time.Minute {
 		t.Fatalf("unexpected region token ttl %s", cfg.RegionTokenTTL.Duration)
+	}
+	if cfg.DefaultHomeRegionID != "aws/us-east-1" {
+		t.Fatalf("unexpected default home region id %q", cfg.DefaultHomeRegionID)
 	}
 	if cfg.ShutdownTimeout.Duration != 31*time.Second {
 		t.Fatalf("unexpected shutdown timeout %s", cfg.ShutdownTimeout.Duration)

--- a/infra-operator/chart/crds/infra.sandbox0.ai_sandbox0infras.yaml
+++ b/infra-operator/chart/crds/infra.sandbox0.ai_sandbox0infras.yaml
@@ -1147,6 +1147,10 @@ spec:
                           databaseSchema:
                             default: global_gateway
                             type: string
+                          defaultHomeRegionId:
+                            description: DefaultHomeRegionID is used for new teams
+                              when create requests omit home_region_id.
+                            type: string
                           defaultTeamName:
                             default: Personal Team
                             description: Identity and Teams

--- a/infra-operator/internal/controller/services/globalgateway/globalgateway_test.go
+++ b/infra-operator/internal/controller/services/globalgateway/globalgateway_test.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	apiconfig "github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
 	infrav1alpha1 "github.com/sandbox0-ai/sandbox0/infra-operator/api/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/pkg/common"
 )
@@ -145,6 +146,88 @@ func TestBuildConfigPopulatesDatabaseAndJWTSecret(t *testing.T) {
 		Namespace: infra.Namespace,
 	}, jwtSecret); err != nil {
 		t.Fatalf("expected jwt secret to be created: %v", err)
+	}
+}
+
+func TestBuildConfigPreservesConfiguredDefaultHomeRegionID(t *testing.T) {
+	infra := &infrav1alpha1.Sandbox0Infra{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "sandbox0-system",
+		},
+		Spec: infrav1alpha1.Sandbox0InfraSpec{
+			Database: &infrav1alpha1.DatabaseConfig{
+				Type: infrav1alpha1.DatabaseTypeBuiltin,
+				Builtin: &infrav1alpha1.BuiltinDatabaseConfig{
+					Enabled:  true,
+					Port:     5432,
+					Username: "sandbox0",
+					Database: "sandbox0",
+					SSLMode:  "disable",
+				},
+			},
+			Services: &infrav1alpha1.ServicesConfig{
+				GlobalGateway: &infrav1alpha1.GlobalGatewayServiceConfig{
+					BaseServiceConfig: infrav1alpha1.BaseServiceConfig{
+						Enabled:  true,
+						Replicas: 1,
+					},
+					Config: &apiconfig.GlobalGatewayConfig{
+						DefaultHomeRegionID: "aws/us-east-1",
+					},
+				},
+			},
+			InitUser: &infrav1alpha1.InitUserConfig{
+				Email: "admin@example.com",
+				Name:  "Admin",
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1 scheme: %v", err)
+	}
+	if err := infrav1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add infra scheme: %v", err)
+	}
+
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(
+			infra.DeepCopy(),
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "demo-sandbox0-database-credentials",
+					Namespace: infra.Namespace,
+				},
+				Data: map[string][]byte{
+					"username": []byte("sandbox0"),
+					"password": []byte("db-password"),
+					"database": []byte("sandbox0"),
+					"port":     []byte("5432"),
+				},
+			},
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "admin-password",
+					Namespace: infra.Namespace,
+				},
+				Data: map[string][]byte{
+					"password": []byte("admin-password"),
+				},
+			},
+		).
+		Build()
+
+	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
+	cfg, err := reconciler.buildConfig(context.Background(), infra)
+	if err != nil {
+		t.Fatalf("buildConfig returned error: %v", err)
+	}
+
+	if cfg.DefaultHomeRegionID != "aws/us-east-1" {
+		t.Fatalf("expected configured default home region id, got %q", cfg.DefaultHomeRegionID)
 	}
 }
 

--- a/pkg/gateway/http/handlers/team.go
+++ b/pkg/gateway/http/handlers/team.go
@@ -39,6 +39,7 @@ type TeamHandler struct {
 	logger                    *zap.Logger
 	requireHomeRegionOnCreate bool
 	regionLookup              TeamRegionLookup
+	defaultHomeRegionID       string
 }
 
 // TeamHandlerOption configures TeamHandler behavior.
@@ -49,6 +50,15 @@ func WithCreateHomeRegionRequired(regionLookup TeamRegionLookup) TeamHandlerOpti
 	return func(h *TeamHandler) {
 		h.requireHomeRegionOnCreate = true
 		h.regionLookup = regionLookup
+	}
+}
+
+// WithDefaultCreateHomeRegion assigns a default home region when create requests omit home_region_id.
+func WithDefaultCreateHomeRegion(regionLookup TeamRegionLookup, defaultHomeRegionID string) TeamHandlerOption {
+	return func(h *TeamHandler) {
+		h.requireHomeRegionOnCreate = true
+		h.regionLookup = regionLookup
+		h.defaultHomeRegionID = strings.TrimSpace(defaultHomeRegionID)
 	}
 }
 
@@ -104,6 +114,10 @@ func (h *TeamHandler) CreateTeam(c *gin.Context) {
 	}
 
 	homeRegionID := normalizeOptionalString(req.HomeRegionID)
+	if homeRegionID == nil && h.defaultHomeRegionID != "" {
+		defaultHomeRegionID := h.defaultHomeRegionID
+		homeRegionID = &defaultHomeRegionID
+	}
 	if h.requireHomeRegionOnCreate {
 		if homeRegionID == nil {
 			spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "home_region_id is required")

--- a/pkg/gateway/http/handlers/team_test.go
+++ b/pkg/gateway/http/handlers/team_test.go
@@ -73,11 +73,13 @@ func (s *stubTeamRepository) RemoveTeamMember(context.Context, string, string) e
 }
 
 type stubTeamRegionLookup struct {
-	region *tenantdir.Region
-	err    error
+	region       *tenantdir.Region
+	err          error
+	requestedIDs []string
 }
 
-func (s *stubTeamRegionLookup) GetRegion(context.Context, string) (*tenantdir.Region, error) {
+func (s *stubTeamRegionLookup) GetRegion(_ context.Context, regionID string) (*tenantdir.Region, error) {
+	s.requestedIDs = append(s.requestedIDs, regionID)
 	if s.err != nil {
 		return nil, s.err
 	}
@@ -203,6 +205,43 @@ func TestTeamHandlerCreateTeamAllowsMissingHomeRegionWithoutGlobalRequirement(t 
 	}
 	if repo.addedTeamMember == nil || repo.addedTeamMember.TeamID != "team-1" {
 		t.Fatalf("expected creator to be added as team member, got %#v", repo.addedTeamMember)
+	}
+}
+
+func TestTeamHandlerCreateTeamUsesDefaultHomeRegionInGlobalMode(t *testing.T) {
+	t.Setenv("GIN_MODE", "release")
+	gin.SetMode(gin.ReleaseMode)
+
+	repo := &stubTeamRepository{}
+	lookup := &stubTeamRegionLookup{
+		region: &tenantdir.Region{
+			ID:                 "aws/us-east-1",
+			RegionalGatewayURL: "https://use1.example.com",
+			Enabled:            true,
+		},
+	}
+	handler := NewTeamHandler(
+		repo,
+		zap.NewNop(),
+		WithCreateHomeRegionRequired(lookup),
+		WithDefaultCreateHomeRegion(lookup, " aws/us-east-1 "),
+	)
+
+	rec := performCreateTeamRequest(t, handler, map[string]any{
+		"name": "Example Team",
+	})
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	if repo.createdTeam == nil || repo.createdTeam.HomeRegionID == nil {
+		t.Fatalf("expected created team with default home region, got %#v", repo.createdTeam)
+	}
+	if *repo.createdTeam.HomeRegionID != "aws/us-east-1" {
+		t.Fatalf("home region = %q, want aws/us-east-1", *repo.createdTeam.HomeRegionID)
+	}
+	if len(lookup.requestedIDs) != 1 || lookup.requestedIDs[0] != "aws/us-east-1" {
+		t.Fatalf("lookup requested IDs = %#v, want aws/us-east-1", lookup.requestedIDs)
 	}
 }
 

--- a/pkg/gateway/public/routes.go
+++ b/pkg/gateway/public/routes.go
@@ -16,16 +16,17 @@ import (
 )
 
 type Deps struct {
-	IdentityRepo            *identity.Repository
-	APIKeyRepo              *apikey.Repository
-	AuthMiddleware          *middleware.AuthMiddleware
-	BuiltinProvider         *builtin.Provider
-	OIDCManager             *oidc.Manager
-	Entitlements            licensing.Entitlements
-	JWTIssuer               *authn.Issuer
-	RegionRepo              *tenantdir.Repository
-	RequireCreateHomeRegion bool
-	Logger                  *zap.Logger
+	IdentityRepo              *identity.Repository
+	APIKeyRepo                *apikey.Repository
+	AuthMiddleware            *middleware.AuthMiddleware
+	BuiltinProvider           *builtin.Provider
+	OIDCManager               *oidc.Manager
+	Entitlements              licensing.Entitlements
+	JWTIssuer                 *authn.Issuer
+	RegionRepo                *tenantdir.Repository
+	RequireCreateHomeRegion   bool
+	DefaultCreateHomeRegionID string
+	Logger                    *zap.Logger
 }
 
 // RegisterRoutes mounts the full self-hosted public surface.
@@ -48,6 +49,9 @@ func RegisterIdentityRoutes(router gin.IRouter, deps Deps) {
 	teamOpts := make([]handlers.TeamHandlerOption, 0, 1)
 	if deps.RequireCreateHomeRegion {
 		teamOpts = append(teamOpts, handlers.WithCreateHomeRegionRequired(deps.RegionRepo))
+	}
+	if deps.RequireCreateHomeRegion && deps.DefaultCreateHomeRegionID != "" {
+		teamOpts = append(teamOpts, handlers.WithDefaultCreateHomeRegion(deps.RegionRepo, deps.DefaultCreateHomeRegionID))
 	}
 	teamHandler := handlers.NewTeamHandler(deps.IdentityRepo, deps.Logger, teamOpts...)
 


### PR DESCRIPTION
## Summary
- add `default_home_region_id` to global-gateway config and CRD
- use the configured default when team creation omits `home_region_id`
- keep existing routable-region validation and document the behavior in README

## Testing
- `go test ./pkg/gateway/http/handlers ./infra-operator/api/config ./infra-operator/internal/controller/services/globalgateway`
- `go test ./global-gateway/... ./pkg/gateway/public/...`
- `make manifests`