### PR TITLE
Implement shard-aware multi-cluster routing and capacity signals

### DIFF
--- a/cluster-gateway/pkg/http/handlers_internal.go
+++ b/cluster-gateway/pkg/http/handlers_internal.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/sandbox0-ai/sandbox0/cluster-gateway/pkg/middleware"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/authn"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"go.uber.org/zap"
@@ -15,15 +16,14 @@ import (
 // getClusterSummary proxies cluster summary request to manager
 func (s *Server) getClusterSummary(c *gin.Context) {
 	authCtx := middleware.GetAuthContext(c)
+	claims := internalauth.ClaimsFromContext(c.Request.Context())
 
 	// Generate internal token for manager
 	perms := s.cfg.SchedulerPermissions
 	if len(perms) == 0 {
 		perms = []string{"*:*"}
 	}
-	internalToken, err := s.internalAuthGen.Generate("manager", authCtx.TeamID, authCtx.UserID, internalauth.GenerateOptions{
-		Permissions: perms,
-	})
+	internalToken, err := s.generateManagerToken(authCtx, claims, perms)
 	if err != nil {
 		s.logger.Error("Failed to generate internal token for manager",
 			zap.String("team_id", authCtx.TeamID),
@@ -47,15 +47,14 @@ func (s *Server) getClusterSummary(c *gin.Context) {
 // getTemplateStats proxies template stats request to manager
 func (s *Server) getTemplateStats(c *gin.Context) {
 	authCtx := middleware.GetAuthContext(c)
+	claims := internalauth.ClaimsFromContext(c.Request.Context())
 
 	// Generate internal token for manager
 	perms := s.cfg.SchedulerPermissions
 	if len(perms) == 0 {
 		perms = []string{"*:*"}
 	}
-	internalToken, err := s.internalAuthGen.Generate("manager", authCtx.TeamID, authCtx.UserID, internalauth.GenerateOptions{
-		Permissions: perms,
-	})
+	internalToken, err := s.generateManagerToken(authCtx, claims, perms)
 	if err != nil {
 		s.logger.Error("Failed to generate internal token for manager",
 			zap.String("team_id", authCtx.TeamID),
@@ -74,4 +73,21 @@ func (s *Server) getTemplateStats(c *gin.Context) {
 
 	// Forward to manager
 	s.proxy2Mgr.ProxyToTarget(c)
+}
+
+func (s *Server) generateManagerToken(authCtx *authn.AuthContext, claims *internalauth.Claims, permissions []string) (string, error) {
+	opts := internalauth.GenerateOptions{
+		Permissions: permissions,
+	}
+	if claims != nil && claims.IsSystem {
+		return s.internalAuthGen.GenerateSystem("manager", opts)
+	}
+
+	teamID := ""
+	userID := ""
+	if authCtx != nil {
+		teamID = authCtx.TeamID
+		userID = authCtx.UserID
+	}
+	return s.internalAuthGen.Generate("manager", teamID, userID, opts)
 }

--- a/cluster-gateway/pkg/http/handlers_internal_cluster_summary_test.go
+++ b/cluster-gateway/pkg/http/handlers_internal_cluster_summary_test.go
@@ -1,0 +1,250 @@
+package http
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	clustermiddleware "github.com/sandbox0-ai/sandbox0/cluster-gateway/pkg/middleware"
+	clusterconfig "github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
+	managerv1alpha1 "github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
+	managercontroller "github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
+	managerhttp "github.com/sandbox0-ai/sandbox0/manager/pkg/http"
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/service"
+	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+	"github.com/sandbox0-ai/sandbox0/pkg/observability"
+	"github.com/sandbox0-ai/sandbox0/pkg/proxy"
+	schedulerclient "github.com/sandbox0-ai/sandbox0/scheduler/pkg/client"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestClusterSummaryProxyExposesSandboxCapacitySignals(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	configPath := writeClusterSummaryManagerConfig(t, `
+default_cluster_id: cluster-a
+sandbox_pod_placement:
+  node_selector:
+    sandbox0.ai/node-role: sandbox
+`)
+	t.Setenv("CONFIG_PATH", configPath)
+
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate ed25519 keypair: %v", err)
+	}
+
+	logger := zap.NewNop()
+	obsProvider := newTestObservabilityProvider(t, "cluster-summary-test")
+
+	clusterService := service.NewClusterService(
+		nil,
+		newClusterSummaryTestPodLister(t,
+			newClusterSummaryTestPod("ns-a", "idle-running", "template-a", "idle", corev1.PodRunning),
+			newClusterSummaryTestPod("ns-a", "active-running", "template-a", "active", corev1.PodRunning),
+			newClusterSummaryTestPod("ns-a", "active-pending", "template-a", "active", corev1.PodPending),
+		),
+		newClusterSummaryTestNodeLister(t,
+			newClusterSummaryTestNode("node-sandbox", map[string]string{"sandbox0.ai/node-role": "sandbox"}),
+			newClusterSummaryTestNode("node-system", map[string]string{"sandbox0.ai/node-role": "system"}),
+		),
+		staticClusterSummaryTemplateLister{},
+		logger,
+	)
+
+	managerValidator := internalauth.NewValidator(internalauth.ValidatorConfig{
+		Target:             "manager",
+		PublicKey:          publicKey,
+		AllowedCallers:     []string{"cluster-gateway"},
+		ClockSkewTolerance: 5 * time.Second,
+	})
+	managerServer := managerhttp.NewServer(
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		false,
+		clusterService,
+		managerValidator,
+		logger,
+		0,
+		obsProvider,
+		"",
+		"",
+	)
+	manager := httptest.NewServer(managerServer.Handler())
+	defer manager.Close()
+
+	proxy2Mgr, err := proxy.NewRouter(manager.URL, logger, time.Second)
+	if err != nil {
+		t.Fatalf("create manager proxy: %v", err)
+	}
+
+	clusterValidator := internalauth.NewValidator(internalauth.ValidatorConfig{
+		Target:             "cluster-gateway",
+		PublicKey:          publicKey,
+		AllowedCallers:     []string{"scheduler"},
+		ClockSkewTolerance: 5 * time.Second,
+	})
+	clusterServer := &Server{
+		cfg: &clusterconfig.ClusterGatewayConfig{
+			AuthMode: authModeInternal,
+		},
+		proxy2Mgr:       proxy2Mgr,
+		authMiddleware:  clustermiddleware.NewInternalAuthMiddleware(clusterValidator, logger),
+		internalAuthGen: internalauth.NewGenerator(internalauth.GeneratorConfig{Caller: "cluster-gateway", PrivateKey: privateKey, TTL: time.Minute}),
+		logger:          logger,
+	}
+	clusterServer.router = gin.New()
+	internal := clusterServer.router.Group("/internal/v1")
+	internal.Use(clusterServer.authMiddleware.Authenticate())
+	internal.GET("/cluster/summary", clusterServer.getClusterSummary)
+
+	clusterGateway := httptest.NewServer(clusterServer.router)
+	defer clusterGateway.Close()
+
+	schedulerClient := schedulerclient.NewClusterGatewayClient(
+		internalauth.NewGenerator(internalauth.GeneratorConfig{Caller: "scheduler", PrivateKey: privateKey, TTL: time.Minute}),
+		logger,
+		obsProvider,
+	)
+
+	summary, err := schedulerClient.GetClusterSummary(context.Background(), clusterGateway.URL)
+	if err != nil {
+		t.Fatalf("GetClusterSummary() error = %v", err)
+	}
+
+	if summary.ClusterID != "cluster-a" {
+		t.Fatalf("ClusterID = %q, want %q", summary.ClusterID, "cluster-a")
+	}
+	if summary.NodeCount != 2 {
+		t.Fatalf("NodeCount = %d, want 2", summary.NodeCount)
+	}
+	if summary.TotalNodeCount != 2 {
+		t.Fatalf("TotalNodeCount = %d, want 2", summary.TotalNodeCount)
+	}
+	if summary.SandboxNodeCount != 1 {
+		t.Fatalf("SandboxNodeCount = %d, want 1", summary.SandboxNodeCount)
+	}
+	if summary.IdlePodCount != 1 {
+		t.Fatalf("IdlePodCount = %d, want 1", summary.IdlePodCount)
+	}
+	if summary.ActivePodCount != 2 {
+		t.Fatalf("ActivePodCount = %d, want 2", summary.ActivePodCount)
+	}
+	if summary.PendingActivePodCount != 1 {
+		t.Fatalf("PendingActivePodCount = %d, want 1", summary.PendingActivePodCount)
+	}
+	if summary.TotalPodCount != 3 {
+		t.Fatalf("TotalPodCount = %d, want 3", summary.TotalPodCount)
+	}
+}
+
+func newTestObservabilityProvider(t *testing.T, serviceName string) *observability.Provider {
+	t.Helper()
+	provider, err := observability.New(observability.Config{
+		ServiceName:    serviceName,
+		Logger:         zap.NewNop(),
+		DisableTracing: true,
+		DisableMetrics: true,
+		DisableLogging: true,
+		TraceExporter: observability.TraceExporterConfig{
+			Type: "noop",
+		},
+	})
+	if err != nil {
+		t.Fatalf("new observability provider: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = provider.Shutdown(context.Background())
+	})
+	return provider
+}
+
+func writeClusterSummaryManagerConfig(t *testing.T, contents string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "manager.yaml")
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}
+
+func newClusterSummaryTestPodLister(t *testing.T, pods ...*corev1.Pod) corelisters.PodLister {
+	t.Helper()
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+	})
+	for _, pod := range pods {
+		if pod == nil {
+			continue
+		}
+		if err := indexer.Add(pod); err != nil {
+			t.Fatalf("add pod: %v", err)
+		}
+	}
+	return corelisters.NewPodLister(indexer)
+}
+
+func newClusterSummaryTestNodeLister(t *testing.T, nodes ...*corev1.Node) corelisters.NodeLister {
+	t.Helper()
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	for _, node := range nodes {
+		if node == nil {
+			continue
+		}
+		if err := indexer.Add(node); err != nil {
+			t.Fatalf("add node: %v", err)
+		}
+	}
+	return corelisters.NewNodeLister(indexer)
+}
+
+func newClusterSummaryTestPod(namespace, name, templateID, poolType string, phase corev1.PodPhase) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			Labels: map[string]string{
+				"sandbox0.ai/template-id": templateID,
+				"sandbox0.ai/pool-type":   poolType,
+			},
+		},
+		Status: corev1.PodStatus{Phase: phase},
+	}
+}
+
+func newClusterSummaryTestNode(name string, labels map[string]string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
+	}
+}
+
+type staticClusterSummaryTemplateLister struct{}
+
+func (staticClusterSummaryTemplateLister) List() ([]*managerv1alpha1.SandboxTemplate, error) {
+	return nil, nil
+}
+
+func (staticClusterSummaryTemplateLister) Get(namespace, name string) (*managerv1alpha1.SandboxTemplate, error) {
+	return nil, nil
+}
+
+var _ managercontroller.TemplateLister = staticClusterSummaryTemplateLister{}

--- a/manager/pkg/service/cluster_service.go
+++ b/manager/pkg/service/cluster_service.go
@@ -12,23 +12,27 @@ import (
 	corelisters "k8s.io/client-go/listers/core/v1"
 )
 
-// ClusterSummary represents the cluster capacity and status
+// ClusterSummary represents cluster-level sandbox capacity and demand signals.
 type ClusterSummary struct {
-	ClusterID      string `json:"cluster_id"`
-	NodeCount      int    `json:"node_count"`
-	IdlePodCount   int32  `json:"idle_pod_count"`
-	ActivePodCount int32  `json:"active_pod_count"`
-	TotalPodCount  int32  `json:"total_pod_count"`
+	ClusterID             string `json:"cluster_id"`
+	NodeCount             int    `json:"node_count"`
+	TotalNodeCount        int    `json:"total_node_count"`
+	SandboxNodeCount      int    `json:"sandbox_node_count"`
+	IdlePodCount          int32  `json:"idle_pod_count"`
+	ActivePodCount        int32  `json:"active_pod_count"`
+	PendingActivePodCount int32  `json:"pending_active_pod_count"`
+	TotalPodCount         int32  `json:"total_pod_count"`
 }
 
-// TemplateStat represents statistics for a single template
+// TemplateStat represents per-template sandbox demand signals.
 type TemplateStat struct {
-	TemplateID  string `json:"template_id"`
-	Namespace   string `json:"namespace"`
-	IdleCount   int32  `json:"idle_count"`
-	ActiveCount int32  `json:"active_count"`
-	MinIdle     int32  `json:"min_idle"`
-	MaxIdle     int32  `json:"max_idle"`
+	TemplateID         string `json:"template_id"`
+	Namespace          string `json:"namespace"`
+	IdleCount          int32  `json:"idle_count"`
+	ActiveCount        int32  `json:"active_count"`
+	PendingActiveCount int32  `json:"pending_active_count"`
+	MinIdle            int32  `json:"min_idle"`
+	MaxIdle            int32  `json:"max_idle"`
 }
 
 // TemplateStats represents statistics for all templates
@@ -73,6 +77,7 @@ func (s *ClusterService) GetClusterSummary(ctx context.Context) (*ClusterSummary
 		return nil, err
 	}
 	nodeCount := len(nodes)
+	sandboxNodeCount := countSandboxEligibleNodes(nodes, cfg.SandboxPodPlacement.NodeSelector)
 
 	// Get all sandbox-related pods
 	idlePods, err := s.podLister.List(labels.SelectorFromSet(map[string]string{
@@ -100,18 +105,25 @@ func (s *ClusterService) GetClusterSummary(ctx context.Context) (*ClusterSummary
 	}
 
 	activeCount := int32(0)
+	pendingActiveCount := int32(0)
 	for _, pod := range activePods {
-		if pod.Status.Phase == corev1.PodRunning {
+		if pod.Status.Phase == corev1.PodRunning || pod.Status.Phase == corev1.PodPending {
 			activeCount++
+			if pod.Status.Phase == corev1.PodPending {
+				pendingActiveCount++
+			}
 		}
 	}
 
 	return &ClusterSummary{
-		ClusterID:      cfg.DefaultClusterId,
-		NodeCount:      nodeCount,
-		IdlePodCount:   idleCount,
-		ActivePodCount: activeCount,
-		TotalPodCount:  idleCount + activeCount,
+		ClusterID:             cfg.DefaultClusterId,
+		NodeCount:             nodeCount,
+		TotalNodeCount:        nodeCount,
+		SandboxNodeCount:      sandboxNodeCount,
+		IdlePodCount:          idleCount,
+		ActivePodCount:        activeCount,
+		PendingActivePodCount: pendingActiveCount,
+		TotalPodCount:         idleCount + activeCount,
 	}, nil
 }
 
@@ -164,21 +176,52 @@ func (s *ClusterService) GetTemplateStats(ctx context.Context) (*TemplateStats, 
 		}
 
 		activeCount := int32(0)
+		pendingActiveCount := int32(0)
 		for _, pod := range activePods {
-			if pod.Status.Phase == corev1.PodRunning {
+			if pod.Status.Phase == corev1.PodRunning || pod.Status.Phase == corev1.PodPending {
 				activeCount++
+				if pod.Status.Phase == corev1.PodPending {
+					pendingActiveCount++
+				}
 			}
 		}
 
 		stats.Templates = append(stats.Templates, TemplateStat{
-			TemplateID:  template.Name,
-			Namespace:   template.Namespace,
-			IdleCount:   idleCount,
-			ActiveCount: activeCount,
-			MinIdle:     template.Spec.Pool.MinIdle,
-			MaxIdle:     template.Spec.Pool.MaxIdle,
+			TemplateID:         template.Name,
+			Namespace:          template.Namespace,
+			IdleCount:          idleCount,
+			ActiveCount:        activeCount,
+			PendingActiveCount: pendingActiveCount,
+			MinIdle:            template.Spec.Pool.MinIdle,
+			MaxIdle:            template.Spec.Pool.MaxIdle,
 		})
 	}
 
 	return stats, nil
+}
+
+func countSandboxEligibleNodes(nodes []*corev1.Node, selector map[string]string) int {
+	if len(selector) == 0 {
+		return len(nodes)
+	}
+
+	count := 0
+	for _, node := range nodes {
+		if nodeMatchesSelector(node, selector) {
+			count++
+		}
+	}
+	return count
+}
+
+func nodeMatchesSelector(node *corev1.Node, selector map[string]string) bool {
+	if node == nil {
+		return false
+	}
+	for key, value := range selector {
+		if node.Labels[key] != value {
+			return false
+		}
+	}
+	return true
 }

--- a/manager/pkg/service/cluster_service_test.go
+++ b/manager/pkg/service/cluster_service_test.go
@@ -1,0 +1,233 @@
+package service
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestGetClusterSummaryCountsSandboxEligibleNodesAndPendingActivePods(t *testing.T) {
+	configPath := writeClusterServiceManagerConfig(t, `
+default_cluster_id: cluster-a
+sandbox_pod_placement:
+  node_selector:
+    sandbox0.ai/node-role: sandbox
+`)
+	t.Setenv("CONFIG_PATH", configPath)
+
+	svc := &ClusterService{
+		podLister: newClusterServicePodLister(t,
+			newClusterServicePod("ns-a", "idle-running", "template-a", controller.PoolTypeIdle, corev1.PodRunning),
+			newClusterServicePod("ns-a", "idle-pending", "template-a", controller.PoolTypeIdle, corev1.PodPending),
+			newClusterServicePod("ns-a", "active-running", "template-a", controller.PoolTypeActive, corev1.PodRunning),
+			newClusterServicePod("ns-a", "active-pending-1", "template-a", controller.PoolTypeActive, corev1.PodPending),
+			newClusterServicePod("ns-a", "active-pending-2", "template-a", controller.PoolTypeActive, corev1.PodPending),
+			newClusterServicePod("ns-a", "active-failed", "template-a", controller.PoolTypeActive, corev1.PodFailed),
+		),
+		nodeLister: newClusterServiceNodeLister(t,
+			newClusterServiceNode("node-sandbox-a", map[string]string{"sandbox0.ai/node-role": "sandbox"}),
+			newClusterServiceNode("node-sandbox-b", map[string]string{"sandbox0.ai/node-role": "sandbox"}),
+			newClusterServiceNode("node-system", map[string]string{"sandbox0.ai/node-role": "system"}),
+		),
+		logger: zap.NewNop(),
+	}
+
+	summary, err := svc.GetClusterSummary(context.Background())
+	if err != nil {
+		t.Fatalf("GetClusterSummary() error = %v", err)
+	}
+
+	if summary.ClusterID != "cluster-a" {
+		t.Fatalf("ClusterID = %q, want %q", summary.ClusterID, "cluster-a")
+	}
+	if summary.NodeCount != 3 {
+		t.Fatalf("NodeCount = %d, want 3", summary.NodeCount)
+	}
+	if summary.TotalNodeCount != 3 {
+		t.Fatalf("TotalNodeCount = %d, want 3", summary.TotalNodeCount)
+	}
+	if summary.SandboxNodeCount != 2 {
+		t.Fatalf("SandboxNodeCount = %d, want 2", summary.SandboxNodeCount)
+	}
+	if summary.IdlePodCount != 2 {
+		t.Fatalf("IdlePodCount = %d, want 2", summary.IdlePodCount)
+	}
+	if summary.ActivePodCount != 3 {
+		t.Fatalf("ActivePodCount = %d, want 3", summary.ActivePodCount)
+	}
+	if summary.PendingActivePodCount != 2 {
+		t.Fatalf("PendingActivePodCount = %d, want 2", summary.PendingActivePodCount)
+	}
+	if summary.TotalPodCount != 5 {
+		t.Fatalf("TotalPodCount = %d, want 5", summary.TotalPodCount)
+	}
+}
+
+func TestGetClusterSummaryWithoutSandboxSelectorTreatsAllNodesAsEligible(t *testing.T) {
+	configPath := writeClusterServiceManagerConfig(t, `
+default_cluster_id: cluster-a
+`)
+	t.Setenv("CONFIG_PATH", configPath)
+
+	svc := &ClusterService{
+		podLister: newClusterServicePodLister(t),
+		nodeLister: newClusterServiceNodeLister(t,
+			newClusterServiceNode("node-a", map[string]string{"sandbox0.ai/node-role": "sandbox"}),
+			newClusterServiceNode("node-b", map[string]string{"sandbox0.ai/node-role": "system"}),
+		),
+		logger: zap.NewNop(),
+	}
+
+	summary, err := svc.GetClusterSummary(context.Background())
+	if err != nil {
+		t.Fatalf("GetClusterSummary() error = %v", err)
+	}
+
+	if summary.SandboxNodeCount != 2 {
+		t.Fatalf("SandboxNodeCount = %d, want 2", summary.SandboxNodeCount)
+	}
+}
+
+func TestGetTemplateStatsCountsPendingActivePods(t *testing.T) {
+	svc := &ClusterService{
+		podLister: newClusterServicePodLister(t,
+			newClusterServicePod("ns-a", "idle-running", "template-a", controller.PoolTypeIdle, corev1.PodRunning),
+			newClusterServicePod("ns-a", "idle-pending", "template-a", controller.PoolTypeIdle, corev1.PodPending),
+			newClusterServicePod("ns-a", "active-running", "template-a", controller.PoolTypeActive, corev1.PodRunning),
+			newClusterServicePod("ns-a", "active-pending", "template-a", controller.PoolTypeActive, corev1.PodPending),
+			newClusterServicePod("ns-a", "active-other-template", "template-b", controller.PoolTypeActive, corev1.PodPending),
+			newClusterServicePod("ns-a", "active-failed", "template-a", controller.PoolTypeActive, corev1.PodFailed),
+		),
+		templateLister: staticTemplateLister{
+			templates: []*v1alpha1.SandboxTemplate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "template-a",
+						Namespace: "ns-a",
+					},
+					Spec: v1alpha1.SandboxTemplateSpec{
+						Pool: v1alpha1.PoolStrategy{
+							MinIdle: 2,
+							MaxIdle: 6,
+						},
+					},
+				},
+			},
+		},
+		logger: zap.NewNop(),
+	}
+
+	stats, err := svc.GetTemplateStats(context.Background())
+	if err != nil {
+		t.Fatalf("GetTemplateStats() error = %v", err)
+	}
+	if len(stats.Templates) != 1 {
+		t.Fatalf("len(Templates) = %d, want 1", len(stats.Templates))
+	}
+
+	stat := stats.Templates[0]
+	if stat.TemplateID != "template-a" {
+		t.Fatalf("TemplateID = %q, want %q", stat.TemplateID, "template-a")
+	}
+	if stat.IdleCount != 2 {
+		t.Fatalf("IdleCount = %d, want 2", stat.IdleCount)
+	}
+	if stat.ActiveCount != 2 {
+		t.Fatalf("ActiveCount = %d, want 2", stat.ActiveCount)
+	}
+	if stat.PendingActiveCount != 1 {
+		t.Fatalf("PendingActiveCount = %d, want 1", stat.PendingActiveCount)
+	}
+	if stat.MinIdle != 2 || stat.MaxIdle != 6 {
+		t.Fatalf("pool = (%d,%d), want (2,6)", stat.MinIdle, stat.MaxIdle)
+	}
+}
+
+type staticTemplateLister struct {
+	templates []*v1alpha1.SandboxTemplate
+}
+
+func (l staticTemplateLister) List() ([]*v1alpha1.SandboxTemplate, error) {
+	return l.templates, nil
+}
+
+func (l staticTemplateLister) Get(namespace, name string) (*v1alpha1.SandboxTemplate, error) {
+	for _, template := range l.templates {
+		if template.Namespace == namespace && template.Name == name {
+			return template, nil
+		}
+	}
+	return nil, nil
+}
+
+func writeClusterServiceManagerConfig(t *testing.T, contents string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "manager.yaml")
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}
+
+func newClusterServicePodLister(t *testing.T, pods ...*corev1.Pod) corelisters.PodLister {
+	t.Helper()
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+	})
+	for _, pod := range pods {
+		if pod == nil {
+			continue
+		}
+		if err := indexer.Add(pod); err != nil {
+			t.Fatalf("add pod: %v", err)
+		}
+	}
+	return corelisters.NewPodLister(indexer)
+}
+
+func newClusterServiceNodeLister(t *testing.T, nodes ...*corev1.Node) corelisters.NodeLister {
+	t.Helper()
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	for _, node := range nodes {
+		if node == nil {
+			continue
+		}
+		if err := indexer.Add(node); err != nil {
+			t.Fatalf("add node: %v", err)
+		}
+	}
+	return corelisters.NewNodeLister(indexer)
+}
+
+func newClusterServicePod(namespace, name, templateID, poolType string, phase corev1.PodPhase) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			Labels: map[string]string{
+				controller.LabelTemplateID: templateID,
+				controller.LabelPoolType:   poolType,
+			},
+		},
+		Status: corev1.PodStatus{Phase: phase},
+	}
+}
+
+func newClusterServiceNode(name string, labels map[string]string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
+	}
+}

--- a/pkg/observability/metrics/scheduler.go
+++ b/pkg/observability/metrics/scheduler.go
@@ -11,10 +11,12 @@ type SchedulerMetrics struct {
 	ReconcileDuration      prometheus.Histogram
 	TemplateAllocations    *prometheus.GaugeVec
 	ClusterCapacity        *prometheus.GaugeVec
+	ClusterSummaryAge      *prometheus.GaugeVec
 	TemplateSyncStatus     *prometheus.GaugeVec
 	OrphansRemoved         *prometheus.CounterVec
 	LastReconcileTimestamp prometheus.Gauge
 	CapacityClamps         *prometheus.CounterVec
+	RoutingDecisions       *prometheus.CounterVec
 }
 
 // NewScheduler registers and returns scheduler metrics.
@@ -53,7 +55,14 @@ func NewScheduler(registry prometheus.Registerer) *SchedulerMetrics {
 				Name: "scheduler_cluster_capacity",
 				Help: "Cluster capacity metrics",
 			},
-			[]string{"cluster_id", "metric"}, // metric: nodes, idle_pods, active_pods, total_pods
+			[]string{"cluster_id", "metric"}, // metric: nodes, total_nodes, sandbox_nodes, idle_pods, active_pods, pending_active_pods, total_pods, available_headroom
+		),
+		ClusterSummaryAge: factory.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "scheduler_cluster_summary_age_seconds",
+				Help: "Age of the cached cluster summary in seconds",
+			},
+			[]string{"cluster_id"},
 		),
 		TemplateSyncStatus: factory.NewGaugeVec(
 			prometheus.GaugeOpts{
@@ -81,6 +90,13 @@ func NewScheduler(registry prometheus.Registerer) *SchedulerMetrics {
 				Help: "Total number of times allocations were clamped by cluster capacity",
 			},
 			[]string{"cluster_id", "template_id"},
+		),
+		RoutingDecisions: factory.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "scheduler_routing_decisions_total",
+				Help: "Total number of scheduler shard routing decisions by reason",
+			},
+			[]string{"cluster_id", "reason"},
 		),
 	}
 }

--- a/pkg/template/allocator/allocator.go
+++ b/pkg/template/allocator/allocator.go
@@ -9,8 +9,10 @@ import (
 
 // ClusterSummary provides capacity inputs for allocation.
 type ClusterSummary struct {
-	NodeCount     int
-	TotalPodCount int32
+	NodeCount        int
+	TotalNodeCount   int
+	SandboxNodeCount int
+	TotalPodCount    int32
 }
 
 // Allocator distributes pool sizes across clusters.
@@ -88,7 +90,8 @@ func (a *Allocator) ComputeAllocations(tpl *template.Template, clusters []*templ
 		clampReason := ""
 
 		if hasSummary {
-			estimatedCapacity := int32(summary.NodeCount * a.podsPerNode)
+			sandboxNodeCount := summary.sandboxCapableNodeCount()
+			estimatedCapacity := int32(sandboxNodeCount * a.podsPerNode)
 			availableCapacity := estimatedCapacity - summary.TotalPodCount
 
 			if availableCapacity < 0 {
@@ -126,7 +129,8 @@ func (a *Allocator) ComputeAllocations(tpl *template.Template, clusters []*templ
 					zap.Int32("available_capacity", availableCapacity),
 					zap.Int32("estimated_capacity", estimatedCapacity),
 					zap.Int32("current_pods", summary.TotalPodCount),
-					zap.Int("nodes", summary.NodeCount),
+					zap.Int("sandbox_nodes", sandboxNodeCount),
+					zap.Int("total_nodes", summary.totalNodeCount()),
 					zap.String("reason", clampReason),
 				)
 			} else {
@@ -136,6 +140,8 @@ func (a *Allocator) ComputeAllocations(tpl *template.Template, clusters []*templ
 					zap.Int32("min_idle", minIdle),
 					zap.Int32("max_idle", maxIdle),
 					zap.Int32("available_capacity", availableCapacity),
+					zap.Int("sandbox_nodes", sandboxNodeCount),
+					zap.Int("total_nodes", summary.totalNodeCount()),
 					zap.Float64("weight_ratio", weightRatio),
 				)
 			}
@@ -175,4 +181,24 @@ func (a *Allocator) ComputeAllocations(tpl *template.Template, clusters []*templ
 	)
 
 	return allocations
+}
+
+func (s *ClusterSummary) sandboxCapableNodeCount() int {
+	if s == nil {
+		return 0
+	}
+	if s.TotalNodeCount > 0 || s.SandboxNodeCount > 0 {
+		return s.SandboxNodeCount
+	}
+	return s.NodeCount
+}
+
+func (s *ClusterSummary) totalNodeCount() int {
+	if s == nil {
+		return 0
+	}
+	if s.TotalNodeCount > 0 {
+		return s.TotalNodeCount
+	}
+	return s.NodeCount
 }

--- a/pkg/template/allocator/allocator_test.go
+++ b/pkg/template/allocator/allocator_test.go
@@ -1,0 +1,115 @@
+package allocator
+
+import (
+	"testing"
+
+	managerv1alpha1 "github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
+	"github.com/sandbox0-ai/sandbox0/pkg/template"
+	"go.uber.org/zap"
+)
+
+func TestComputeAllocationsClampsAgainstSandboxNodesOnly(t *testing.T) {
+	alloc := NewAllocator(10, zap.NewNop(), nil)
+	tpl := newAllocatorTestTemplate(20, 20)
+	clusters := []*template.Cluster{
+		{ClusterID: "cluster-a", Enabled: true, Weight: 1},
+	}
+	summaries := map[string]*ClusterSummary{
+		"cluster-a": {
+			NodeCount:        5,
+			TotalNodeCount:   5,
+			SandboxNodeCount: 2,
+			TotalPodCount:    7,
+		},
+	}
+
+	got := alloc.ComputeAllocations(tpl, clusters, summaries)
+	if len(got) != 1 {
+		t.Fatalf("len(allocations) = %d, want 1", len(got))
+	}
+
+	if got[0].MinIdle != 13 || got[0].MaxIdle != 13 {
+		t.Fatalf("allocation = (%d,%d), want (13,13)", got[0].MinIdle, got[0].MaxIdle)
+	}
+}
+
+func TestComputeAllocationsAllowsZeroSandboxCapacity(t *testing.T) {
+	alloc := NewAllocator(10, zap.NewNop(), nil)
+	tpl := newAllocatorTestTemplate(5, 8)
+	clusters := []*template.Cluster{
+		{ClusterID: "cluster-a", Enabled: true, Weight: 1},
+	}
+	summaries := map[string]*ClusterSummary{
+		"cluster-a": {
+			NodeCount:        4,
+			TotalNodeCount:   4,
+			SandboxNodeCount: 0,
+			TotalPodCount:    0,
+		},
+	}
+
+	got := alloc.ComputeAllocations(tpl, clusters, summaries)
+	if len(got) != 1 {
+		t.Fatalf("len(allocations) = %d, want 1", len(got))
+	}
+
+	if got[0].MinIdle != 0 || got[0].MaxIdle != 0 {
+		t.Fatalf("allocation = (%d,%d), want (0,0)", got[0].MinIdle, got[0].MaxIdle)
+	}
+}
+
+func TestComputeAllocationsFallsBackToLegacyNodeCount(t *testing.T) {
+	alloc := NewAllocator(10, zap.NewNop(), nil)
+	tpl := newAllocatorTestTemplate(18, 18)
+	clusters := []*template.Cluster{
+		{ClusterID: "cluster-a", Enabled: true, Weight: 1},
+	}
+	summaries := map[string]*ClusterSummary{
+		"cluster-a": {
+			NodeCount:     2,
+			TotalPodCount: 5,
+		},
+	}
+
+	got := alloc.ComputeAllocations(tpl, clusters, summaries)
+	if len(got) != 1 {
+		t.Fatalf("len(allocations) = %d, want 1", len(got))
+	}
+
+	if got[0].MinIdle != 15 || got[0].MaxIdle != 15 {
+		t.Fatalf("allocation = (%d,%d), want (15,15)", got[0].MinIdle, got[0].MaxIdle)
+	}
+}
+
+func TestComputeAllocationsWithoutSummarySkipsCapacityClamp(t *testing.T) {
+	alloc := NewAllocator(10, zap.NewNop(), nil)
+	tpl := newAllocatorTestTemplate(12, 20)
+	clusters := []*template.Cluster{
+		{ClusterID: "cluster-a", Enabled: true, Weight: 1},
+		{ClusterID: "cluster-b", Enabled: true, Weight: 3},
+	}
+
+	got := alloc.ComputeAllocations(tpl, clusters, nil)
+	if len(got) != 2 {
+		t.Fatalf("len(allocations) = %d, want 2", len(got))
+	}
+
+	if got[0].ClusterID != "cluster-a" || got[0].MinIdle != 3 || got[0].MaxIdle != 5 {
+		t.Fatalf("cluster-a allocation = (%s,%d,%d), want (cluster-a,3,5)", got[0].ClusterID, got[0].MinIdle, got[0].MaxIdle)
+	}
+	if got[1].ClusterID != "cluster-b" || got[1].MinIdle != 9 || got[1].MaxIdle != 15 {
+		t.Fatalf("cluster-b allocation = (%s,%d,%d), want (cluster-b,9,15)", got[1].ClusterID, got[1].MinIdle, got[1].MaxIdle)
+	}
+}
+
+func newAllocatorTestTemplate(minIdle, maxIdle int32) *template.Template {
+	return &template.Template{
+		TemplateID: "tmpl-a",
+		Spec: managerv1alpha1.SandboxTemplateSpec{
+			Pool: managerv1alpha1.PoolStrategy{
+				MinIdle: minIdle,
+				MaxIdle: maxIdle,
+			},
+		},
+	}
+}

--- a/pkg/template/reconciler/interfaces.go
+++ b/pkg/template/reconciler/interfaces.go
@@ -28,20 +28,24 @@ type ClusterStore interface {
 
 // ClusterSummary represents the cluster capacity and status.
 type ClusterSummary struct {
-	ClusterID      string `json:"cluster_id"`
-	NodeCount      int    `json:"node_count"`
-	IdlePodCount   int32  `json:"idle_pod_count"`
-	ActivePodCount int32  `json:"active_pod_count"`
-	TotalPodCount  int32  `json:"total_pod_count"`
+	ClusterID             string `json:"cluster_id"`
+	NodeCount             int    `json:"node_count"`
+	TotalNodeCount        int    `json:"total_node_count"`
+	SandboxNodeCount      int    `json:"sandbox_node_count"`
+	IdlePodCount          int32  `json:"idle_pod_count"`
+	ActivePodCount        int32  `json:"active_pod_count"`
+	PendingActivePodCount int32  `json:"pending_active_pod_count"`
+	TotalPodCount         int32  `json:"total_pod_count"`
 }
 
 // TemplateStat represents statistics for a single template.
 type TemplateStat struct {
-	TemplateID  string `json:"template_id"`
-	IdleCount   int32  `json:"idle_count"`
-	ActiveCount int32  `json:"active_count"`
-	MinIdle     int32  `json:"min_idle"`
-	MaxIdle     int32  `json:"max_idle"`
+	TemplateID         string `json:"template_id"`
+	IdleCount          int32  `json:"idle_count"`
+	ActiveCount        int32  `json:"active_count"`
+	PendingActiveCount int32  `json:"pending_active_count"`
+	MinIdle            int32  `json:"min_idle"`
+	MaxIdle            int32  `json:"max_idle"`
 }
 
 // TemplateStats represents statistics for all templates in a cluster.

--- a/pkg/template/reconciler/multicluster.go
+++ b/pkg/template/reconciler/multicluster.go
@@ -28,6 +28,7 @@ type MultiClusterReconciler struct {
 	podsPerNode      int
 	allocator        *allocator.Allocator
 	clusterCache     map[string]*ClusterSummary
+	clusterCacheAt   map[string]time.Time
 	cacheMu          sync.RWMutex
 	templateStats    map[string]map[string]TemplateStat
 	templateStatsAt  map[string]time.Time
@@ -64,6 +65,7 @@ func NewMultiClusterReconciler(
 		podsPerNode:     podsPerNode,
 		allocator:       allocator.NewAllocator(podsPerNode, logger, metrics),
 		clusterCache:    make(map[string]*ClusterSummary),
+		clusterCacheAt:  make(map[string]time.Time),
 		templateStats:   make(map[string]map[string]TemplateStat),
 		templateStatsAt: make(map[string]time.Time),
 		metrics:         metrics,
@@ -138,6 +140,33 @@ func (r *MultiClusterReconciler) GetTemplateStatsAge(clusterID string) (time.Dur
 	defer r.statsMu.RUnlock()
 
 	updatedAt, ok := r.templateStatsAt[clusterID]
+	if !ok || updatedAt.IsZero() {
+		return 0, false
+	}
+
+	return r.since(updatedAt), true
+}
+
+// GetClusterSummary returns the cached cluster summary for a shard.
+func (r *MultiClusterReconciler) GetClusterSummary(clusterID string) (*ClusterSummary, bool) {
+	r.cacheMu.RLock()
+	defer r.cacheMu.RUnlock()
+
+	summary, ok := r.clusterCache[clusterID]
+	if !ok || summary == nil {
+		return nil, false
+	}
+
+	copy := *summary
+	return &copy, true
+}
+
+// GetClusterSummaryAge returns age since the last summary update for a cluster.
+func (r *MultiClusterReconciler) GetClusterSummaryAge(clusterID string) (time.Duration, bool) {
+	r.cacheMu.RLock()
+	defer r.cacheMu.RUnlock()
+
+	updatedAt, ok := r.clusterCacheAt[clusterID]
 	if !ok || updatedAt.IsZero() {
 		return 0, false
 	}
@@ -272,6 +301,7 @@ func (r *MultiClusterReconciler) fetchClusterSummaries(ctx context.Context, clus
 	metrics := r.metrics
 	var wg sync.WaitGroup
 	summaries := make(map[string]*ClusterSummary)
+	summaryTimes := make(map[string]time.Time)
 	var mu sync.Mutex
 
 	for _, cluster := range clusters {
@@ -290,6 +320,7 @@ func (r *MultiClusterReconciler) fetchClusterSummaries(ctx context.Context, clus
 
 			mu.Lock()
 			summaries[c.ClusterID] = summary
+			summaryTimes[c.ClusterID] = r.now()
 			mu.Unlock()
 
 			stats, err := r.clusterClient.GetTemplateStats(ctx, c.ClusterGatewayURL)
@@ -310,10 +341,25 @@ func (r *MultiClusterReconciler) fetchClusterSummaries(ctx context.Context, clus
 			}
 
 			if metrics != nil {
+				headroom := int64(0)
+				sandboxNodeCount := summary.SandboxNodeCount
+				if summary.TotalNodeCount == 0 && summary.SandboxNodeCount == 0 {
+					sandboxNodeCount = summary.NodeCount
+				}
+				headroom = int64(int32(sandboxNodeCount*r.podsPerNode) - summary.TotalPodCount)
+				if headroom < 0 {
+					headroom = 0
+				}
+
 				metrics.ClusterCapacity.WithLabelValues(c.ClusterID, "nodes").Set(float64(summary.NodeCount))
+				metrics.ClusterCapacity.WithLabelValues(c.ClusterID, "total_nodes").Set(float64(summary.TotalNodeCount))
+				metrics.ClusterCapacity.WithLabelValues(c.ClusterID, "sandbox_nodes").Set(float64(summary.SandboxNodeCount))
 				metrics.ClusterCapacity.WithLabelValues(c.ClusterID, "idle_pods").Set(float64(summary.IdlePodCount))
 				metrics.ClusterCapacity.WithLabelValues(c.ClusterID, "active_pods").Set(float64(summary.ActivePodCount))
+				metrics.ClusterCapacity.WithLabelValues(c.ClusterID, "pending_active_pods").Set(float64(summary.PendingActivePodCount))
 				metrics.ClusterCapacity.WithLabelValues(c.ClusterID, "total_pods").Set(float64(summary.TotalPodCount))
+				metrics.ClusterCapacity.WithLabelValues(c.ClusterID, "available_headroom").Set(float64(headroom))
+				metrics.ClusterSummaryAge.WithLabelValues(c.ClusterID).Set(0)
 			}
 
 			if err := r.clusterStore.UpdateClusterLastSeen(ctx, c.ClusterID); err != nil {
@@ -329,6 +375,7 @@ func (r *MultiClusterReconciler) fetchClusterSummaries(ctx context.Context, clus
 
 	r.cacheMu.Lock()
 	r.clusterCache = summaries
+	r.clusterCacheAt = summaryTimes
 	r.cacheMu.Unlock()
 }
 
@@ -412,8 +459,10 @@ func (r *MultiClusterReconciler) computeAllocations(tpl *template.Template, clus
 	summaries := make(map[string]*allocator.ClusterSummary, len(r.clusterCache))
 	for clusterID, summary := range r.clusterCache {
 		summaries[clusterID] = &allocator.ClusterSummary{
-			NodeCount:     summary.NodeCount,
-			TotalPodCount: summary.TotalPodCount,
+			NodeCount:        summary.NodeCount,
+			TotalNodeCount:   summary.TotalNodeCount,
+			SandboxNodeCount: summary.SandboxNodeCount,
+			TotalPodCount:    summary.TotalPodCount,
 		}
 	}
 	r.cacheMu.RUnlock()

--- a/pkg/template/reconciler/multicluster_metrics_test.go
+++ b/pkg/template/reconciler/multicluster_metrics_test.go
@@ -1,0 +1,92 @@
+package reconciler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
+	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
+	"github.com/sandbox0-ai/sandbox0/pkg/template"
+	"go.uber.org/zap"
+)
+
+func TestFetchClusterSummariesPublishesCapacityMetrics(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	metrics := obsmetrics.NewScheduler(registry)
+
+	rec := NewMultiClusterReconciler(
+		nil,
+		nil,
+		fakeMetricClusterStore{},
+		&fakeMetricClusterClient{
+			summaries: map[string]*ClusterSummary{
+				"http://cluster-a": {
+					ClusterID:             "cluster-a",
+					NodeCount:             4,
+					TotalNodeCount:        4,
+					SandboxNodeCount:      3,
+					IdlePodCount:          2,
+					ActivePodCount:        5,
+					PendingActivePodCount: 2,
+					TotalPodCount:         7,
+				},
+			},
+		},
+		time.Second,
+		nil,
+		10,
+		zap.NewNop(),
+		metrics,
+	)
+
+	rec.fetchClusterSummaries(context.Background(), []*template.Cluster{
+		{
+			ClusterID:         "cluster-a",
+			ClusterGatewayURL: "http://cluster-a",
+			Enabled:           true,
+		},
+	})
+
+	if got := testutil.ToFloat64(metrics.ClusterCapacity.WithLabelValues("cluster-a", "available_headroom")); got != 23 {
+		t.Fatalf("available_headroom = %v, want 23", got)
+	}
+	if got := testutil.ToFloat64(metrics.ClusterCapacity.WithLabelValues("cluster-a", "pending_active_pods")); got != 2 {
+		t.Fatalf("pending_active_pods = %v, want 2", got)
+	}
+	if got := testutil.ToFloat64(metrics.ClusterSummaryAge.WithLabelValues("cluster-a")); got != 0 {
+		t.Fatalf("cluster_summary_age = %v, want 0", got)
+	}
+}
+
+type fakeMetricClusterStore struct{}
+
+func (fakeMetricClusterStore) ListEnabledClusters(ctx context.Context) ([]*template.Cluster, error) {
+	return nil, nil
+}
+
+func (fakeMetricClusterStore) UpdateClusterLastSeen(ctx context.Context, clusterID string) error {
+	return nil
+}
+
+type fakeMetricClusterClient struct {
+	summaries map[string]*ClusterSummary
+}
+
+func (c *fakeMetricClusterClient) GetClusterSummary(ctx context.Context, baseURL string) (*ClusterSummary, error) {
+	return c.summaries[baseURL], nil
+}
+
+func (c *fakeMetricClusterClient) GetTemplateStats(ctx context.Context, baseURL string) (*TemplateStats, error) {
+	return &TemplateStats{}, nil
+}
+
+func (c *fakeMetricClusterClient) CreateOrUpdateTemplate(ctx context.Context, baseURL string, tpl *v1alpha1.SandboxTemplate) error {
+	return nil
+}
+
+func (c *fakeMetricClusterClient) DeleteTemplate(ctx context.Context, baseURL string, templateID string) error {
+	return nil
+}

--- a/scheduler/cmd/scheduler/main.go
+++ b/scheduler/cmd/scheduler/main.go
@@ -133,7 +133,7 @@ func main() {
 	rec := reconciler.NewReconciler(templateStore, templateStore, repo, clusterGatewayClient, cfg.ReconcileInterval.Duration, clk, cfg.PodsPerNode, logger, schedulerMetrics)
 
 	// Create HTTP server
-	httpServer, err := httpserver.NewServer(cfg, repo, templateStore, templateStore, authValidator, internalAuthGen, rec, logger, obsProvider)
+	httpServer, err := httpserver.NewServer(cfg, repo, templateStore, templateStore, authValidator, internalAuthGen, rec, logger, obsProvider, schedulerMetrics)
 	if err != nil {
 		logger.Fatal("Failed to create scheduler HTTP server", zap.Error(err))
 	}

--- a/scheduler/pkg/client/cluster_gateway.go
+++ b/scheduler/pkg/client/cluster_gateway.go
@@ -39,20 +39,24 @@ func NewClusterGatewayClient(internalAuthGen *internalauth.Generator, logger *za
 
 // ClusterSummary represents the cluster capacity and status
 type ClusterSummary struct {
-	ClusterID      string `json:"cluster_id"`
-	NodeCount      int    `json:"node_count"`
-	IdlePodCount   int32  `json:"idle_pod_count"`
-	ActivePodCount int32  `json:"active_pod_count"`
-	TotalPodCount  int32  `json:"total_pod_count"`
+	ClusterID             string `json:"cluster_id"`
+	NodeCount             int    `json:"node_count"`
+	TotalNodeCount        int    `json:"total_node_count"`
+	SandboxNodeCount      int    `json:"sandbox_node_count"`
+	IdlePodCount          int32  `json:"idle_pod_count"`
+	ActivePodCount        int32  `json:"active_pod_count"`
+	PendingActivePodCount int32  `json:"pending_active_pod_count"`
+	TotalPodCount         int32  `json:"total_pod_count"`
 }
 
 // TemplateStat represents statistics for a single template
 type TemplateStat struct {
-	TemplateID  string `json:"template_id"`
-	IdleCount   int32  `json:"idle_count"`
-	ActiveCount int32  `json:"active_count"`
-	MinIdle     int32  `json:"min_idle"`
-	MaxIdle     int32  `json:"max_idle"`
+	TemplateID         string `json:"template_id"`
+	IdleCount          int32  `json:"idle_count"`
+	ActiveCount        int32  `json:"active_count"`
+	PendingActiveCount int32  `json:"pending_active_count"`
+	MinIdle            int32  `json:"min_idle"`
+	MaxIdle            int32  `json:"max_idle"`
 }
 
 // TemplateStats represents statistics for all templates in a cluster

--- a/scheduler/pkg/http/handlers_sandbox.go
+++ b/scheduler/pkg/http/handlers_sandbox.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 	"github.com/sandbox0-ai/sandbox0/pkg/template"
+	templreconciler "github.com/sandbox0-ai/sandbox0/pkg/template/reconciler"
 	"github.com/sandbox0-ai/sandbox0/scheduler/pkg/client"
 	"go.uber.org/zap"
 )
@@ -214,8 +215,49 @@ func (s *Server) selectClusterForTemplate(c *gin.Context, templateID, teamID str
 	clusterTemplateID := naming.TemplateNameForCluster(tpl.Scope, tpl.TeamID, tpl.TemplateID)
 	maxAge := s.cfg.ReconcileInterval.Duration * 2
 
+	selected, selectedBy := s.selectClusterByIdleWithAllocations(allocations, clusterMap, clusterTemplateID, maxAge)
+	if selected == nil {
+		selected = s.selectClusterByHeadroomWithAllocations(allocations, clusterMap, maxAge)
+		if selected != nil {
+			selectedBy = "headroom"
+		}
+	}
+	if selected == nil {
+		selected, err = s.selectClusterByWeightWithAllocations(allocations, clusterMap)
+		if err != nil {
+			return nil, tpl, "", err
+		}
+		if selected != nil {
+			selectedBy = "weight"
+		}
+	}
+	if selected == nil {
+		selected = s.selectClusterByFallbackWithAllocations(allocations, clusterMap)
+		if selected != nil {
+			selectedBy = "fallback"
+		}
+	}
+
+	if selected == nil {
+		s.recordRoutingDecision("", "unavailable")
+		return nil, tpl, "", nil
+	}
+
+	s.recordRoutingDecision(selected.ClusterID, selectedBy)
+
+	s.logger.Info("Sandbox route selected",
+		zap.String("template_id", tpl.TemplateID),
+		zap.String("scope", tpl.Scope),
+		zap.String("team_id", tpl.TeamID),
+		zap.String("cluster_id", selected.ClusterID),
+		zap.String("selected_by", selectedBy),
+	)
+
+	return selected, tpl, selectedBy, nil
+}
+
+func (s *Server) selectClusterByIdleWithAllocations(allocations []*template.TemplateAllocation, clusterMap map[string]*template.Cluster, clusterTemplateID string, maxAge time.Duration) (*template.Cluster, string) {
 	var selected *template.Cluster
-	selectedBy := "weight"
 	var selectedAlloc *template.TemplateAllocation
 	var bestIdle int32 = -1
 
@@ -226,6 +268,7 @@ func (s *Server) selectClusterForTemplate(c *gin.Context, templateID, teamID str
 		}
 
 		age, ok := s.reconciler.GetTemplateStatsAge(cluster.ClusterID)
+		s.recordClusterSummaryAge(cluster.ClusterID)
 		if !ok || age > maxAge {
 			continue
 		}
@@ -238,35 +281,55 @@ func (s *Server) selectClusterForTemplate(c *gin.Context, templateID, teamID str
 		if selected == nil ||
 			idleCount > bestIdle ||
 			(idleCount == bestIdle && alloc.MaxIdle > selectedAlloc.MaxIdle) ||
-			(idleCount == bestIdle && alloc.MaxIdle == selectedAlloc.MaxIdle && cluster.Weight > selected.Weight) {
+			(idleCount == bestIdle && alloc.MaxIdle == selectedAlloc.MaxIdle && cluster.Weight > selected.Weight) ||
+			(idleCount == bestIdle && alloc.MaxIdle == selectedAlloc.MaxIdle && cluster.Weight == selected.Weight && cluster.ClusterID < selected.ClusterID) {
 			selected = cluster
 			selectedAlloc = alloc
 			bestIdle = idleCount
-			selectedBy = "idle"
 		}
 	}
 
 	if selected == nil {
-		selected, err = s.selectClusterByWeightWithAllocations(allocations, clusterMap)
-		if err != nil {
-			return nil, tpl, "", err
+		return nil, ""
+	}
+	return selected, "idle"
+}
+
+func (s *Server) selectClusterByHeadroomWithAllocations(allocations []*template.TemplateAllocation, clusterMap map[string]*template.Cluster, maxAge time.Duration) *template.Cluster {
+	var selected *template.Cluster
+	var selectedAlloc *template.TemplateAllocation
+	var bestHeadroom int32 = -1
+
+	for _, alloc := range allocations {
+		cluster := clusterMap[alloc.ClusterID]
+		if cluster == nil || !cluster.Enabled {
+			continue
 		}
-		selectedBy = "weight"
+
+		age, ok := s.reconciler.GetClusterSummaryAge(cluster.ClusterID)
+		s.recordClusterSummaryAge(cluster.ClusterID)
+		if !ok || age > maxAge {
+			continue
+		}
+
+		summary, ok := s.reconciler.GetClusterSummary(cluster.ClusterID)
+		if !ok || summary == nil {
+			continue
+		}
+
+		headroom := clusterAvailableHeadroom(summary, s.cfg.PodsPerNode)
+		if selected == nil ||
+			headroom > bestHeadroom ||
+			(headroom == bestHeadroom && alloc.MaxIdle > selectedAlloc.MaxIdle) ||
+			(headroom == bestHeadroom && alloc.MaxIdle == selectedAlloc.MaxIdle && cluster.Weight > selected.Weight) ||
+			(headroom == bestHeadroom && alloc.MaxIdle == selectedAlloc.MaxIdle && cluster.Weight == selected.Weight && cluster.ClusterID < selected.ClusterID) {
+			selected = cluster
+			selectedAlloc = alloc
+			bestHeadroom = headroom
+		}
 	}
 
-	if selected == nil {
-		return nil, tpl, "", nil
-	}
-
-	s.logger.Info("Sandbox route selected",
-		zap.String("template_id", tpl.TemplateID),
-		zap.String("scope", tpl.Scope),
-		zap.String("team_id", tpl.TeamID),
-		zap.String("cluster_id", selected.ClusterID),
-		zap.String("selected_by", selectedBy),
-	)
-
-	return selected, tpl, selectedBy, nil
+	return selected
 }
 
 func (s *Server) selectClusterByWeightWithAllocations(allocations []*template.TemplateAllocation, clusterMap map[string]*template.Cluster) (*template.Cluster, error) {
@@ -304,6 +367,70 @@ func (s *Server) selectClusterByWeightWithAllocations(allocations []*template.Te
 	}
 
 	return nil, nil
+}
+
+func (s *Server) selectClusterByFallbackWithAllocations(allocations []*template.TemplateAllocation, clusterMap map[string]*template.Cluster) *template.Cluster {
+	var selected *template.Cluster
+	var selectedAlloc *template.TemplateAllocation
+
+	for _, alloc := range allocations {
+		cluster := clusterMap[alloc.ClusterID]
+		if cluster == nil || !cluster.Enabled {
+			continue
+		}
+		if selected == nil ||
+			cluster.Weight > selected.Weight ||
+			(cluster.Weight == selected.Weight && alloc.MaxIdle > selectedAlloc.MaxIdle) ||
+			(cluster.Weight == selected.Weight && alloc.MaxIdle == selectedAlloc.MaxIdle && cluster.ClusterID < selected.ClusterID) {
+			selected = cluster
+			selectedAlloc = alloc
+		}
+	}
+
+	return selected
+}
+
+func clusterAvailableHeadroom(summary *templreconciler.ClusterSummary, podsPerNode int) int32 {
+	if summary == nil {
+		return 0
+	}
+	if podsPerNode <= 0 {
+		podsPerNode = 10
+	}
+	sandboxNodeCount := summary.SandboxNodeCount
+	if summary.TotalNodeCount == 0 && summary.SandboxNodeCount == 0 {
+		sandboxNodeCount = summary.NodeCount
+	}
+	estimatedCapacity := int32(sandboxNodeCount * podsPerNode)
+	availableCapacity := estimatedCapacity - summary.TotalPodCount
+	if availableCapacity < 0 {
+		return 0
+	}
+	return availableCapacity
+}
+
+func (s *Server) recordRoutingDecision(clusterID, reason string) {
+	if s == nil || s.metrics == nil || s.metrics.RoutingDecisions == nil {
+		return
+	}
+	if clusterID == "" {
+		clusterID = "none"
+	}
+	if reason == "" {
+		reason = "unknown"
+	}
+	s.metrics.RoutingDecisions.WithLabelValues(clusterID, reason).Inc()
+}
+
+func (s *Server) recordClusterSummaryAge(clusterID string) {
+	if s == nil || s.metrics == nil || s.metrics.ClusterSummaryAge == nil || clusterID == "" {
+		return
+	}
+	age, ok := s.reconciler.GetClusterSummaryAge(clusterID)
+	if !ok {
+		return
+	}
+	s.metrics.ClusterSummaryAge.WithLabelValues(clusterID).Set(age.Seconds())
 }
 
 // listSandboxes lists all sandboxes across all enabled clusters

--- a/scheduler/pkg/http/handlers_sandbox_test.go
+++ b/scheduler/pkg/http/handlers_sandbox_test.go
@@ -1,0 +1,674 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
+	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+	"github.com/sandbox0-ai/sandbox0/pkg/naming"
+	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
+	"github.com/sandbox0-ai/sandbox0/pkg/proxy"
+	"github.com/sandbox0-ai/sandbox0/pkg/template"
+	templreconciler "github.com/sandbox0-ai/sandbox0/pkg/template/reconciler"
+	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSelectClusterForTemplatePrefersIdleCapacity(t *testing.T) {
+	tpl := newRoutingTemplate("tmpl-a")
+	clusterTemplateID := naming.TemplateNameForCluster(tpl.Scope, tpl.TeamID, tpl.TemplateID)
+	server := newRoutingTestServer(
+		tpl,
+		[]*template.TemplateAllocation{
+			newRoutingAllocation("cluster-a", 3, 5),
+			newRoutingAllocation("cluster-b", 3, 5),
+		},
+		[]*template.Cluster{
+			newRoutingCluster("cluster-a", 1),
+			newRoutingCluster("cluster-b", 10),
+		},
+		&fakeRoutingReconciler{
+			templateIdle: map[string]map[string]int32{
+				"cluster-a": {clusterTemplateID: 2},
+				"cluster-b": {clusterTemplateID: 1},
+			},
+			templateStatsAge: map[string]time.Duration{
+				"cluster-a": time.Second,
+				"cluster-b": time.Second,
+			},
+			clusterSummaries: map[string]*templreconciler.ClusterSummary{
+				"cluster-a": {SandboxNodeCount: 1, TotalNodeCount: 1, TotalPodCount: 5},
+				"cluster-b": {SandboxNodeCount: 10, TotalNodeCount: 10, TotalPodCount: 0},
+			},
+			clusterSummaryAge: map[string]time.Duration{
+				"cluster-a": time.Second,
+				"cluster-b": time.Second,
+			},
+		},
+	)
+
+	selected, _, selectedBy, err := server.selectClusterForTemplate(newRoutingContext(), "tmpl-a", "team-a")
+	if err != nil {
+		t.Fatalf("selectClusterForTemplate() error = %v", err)
+	}
+	if selected == nil || selected.ClusterID != "cluster-a" {
+		t.Fatalf("selected cluster = %v, want cluster-a", clusterID(selected))
+	}
+	if selectedBy != "idle" {
+		t.Fatalf("selectedBy = %q, want %q", selectedBy, "idle")
+	}
+}
+
+func TestSelectClusterForTemplatePrefersHeadroomWhenIdleUnavailable(t *testing.T) {
+	tpl := newRoutingTemplate("tmpl-a")
+	server := newRoutingTestServer(
+		tpl,
+		[]*template.TemplateAllocation{
+			newRoutingAllocation("cluster-a", 2, 4),
+			newRoutingAllocation("cluster-b", 2, 4),
+		},
+		[]*template.Cluster{
+			newRoutingCluster("cluster-a", 1),
+			newRoutingCluster("cluster-b", 1),
+		},
+		&fakeRoutingReconciler{
+			templateStatsAge: map[string]time.Duration{
+				"cluster-a": time.Second,
+				"cluster-b": time.Second,
+			},
+			clusterSummaries: map[string]*templreconciler.ClusterSummary{
+				"cluster-a": {SandboxNodeCount: 2, TotalNodeCount: 4, TotalPodCount: 18},
+				"cluster-b": {SandboxNodeCount: 3, TotalNodeCount: 4, TotalPodCount: 12},
+			},
+			clusterSummaryAge: map[string]time.Duration{
+				"cluster-a": time.Second,
+				"cluster-b": time.Second,
+			},
+		},
+	)
+
+	selected, _, selectedBy, err := server.selectClusterForTemplate(newRoutingContext(), "tmpl-a", "team-a")
+	if err != nil {
+		t.Fatalf("selectClusterForTemplate() error = %v", err)
+	}
+	if selected == nil || selected.ClusterID != "cluster-b" {
+		t.Fatalf("selected cluster = %v, want cluster-b", clusterID(selected))
+	}
+	if selectedBy != "headroom" {
+		t.Fatalf("selectedBy = %q, want %q", selectedBy, "headroom")
+	}
+}
+
+func TestSelectClusterForTemplateUsesHeadroomWhenIdleStatsAreStale(t *testing.T) {
+	tpl := newRoutingTemplate("tmpl-a")
+	clusterTemplateID := naming.TemplateNameForCluster(tpl.Scope, tpl.TeamID, tpl.TemplateID)
+	server := newRoutingTestServer(
+		tpl,
+		[]*template.TemplateAllocation{
+			newRoutingAllocation("cluster-a", 2, 4),
+			newRoutingAllocation("cluster-b", 2, 4),
+		},
+		[]*template.Cluster{
+			newRoutingCluster("cluster-a", 5),
+			newRoutingCluster("cluster-b", 1),
+		},
+		&fakeRoutingReconciler{
+			templateIdle: map[string]map[string]int32{
+				"cluster-a": {clusterTemplateID: 5},
+			},
+			templateStatsAge: map[string]time.Duration{
+				"cluster-a": 3 * time.Second,
+			},
+			clusterSummaries: map[string]*templreconciler.ClusterSummary{
+				"cluster-a": {SandboxNodeCount: 1, TotalNodeCount: 2, TotalPodCount: 9},
+				"cluster-b": {SandboxNodeCount: 3, TotalNodeCount: 3, TotalPodCount: 10},
+			},
+			clusterSummaryAge: map[string]time.Duration{
+				"cluster-a": time.Second,
+				"cluster-b": time.Second,
+			},
+		},
+	)
+
+	selected, _, selectedBy, err := server.selectClusterForTemplate(newRoutingContext(), "tmpl-a", "team-a")
+	if err != nil {
+		t.Fatalf("selectClusterForTemplate() error = %v", err)
+	}
+	if selected == nil || selected.ClusterID != "cluster-b" {
+		t.Fatalf("selected cluster = %v, want cluster-b", clusterID(selected))
+	}
+	if selectedBy != "headroom" {
+		t.Fatalf("selectedBy = %q, want %q", selectedBy, "headroom")
+	}
+}
+
+func TestSelectClusterForTemplateFallsBackToWeight(t *testing.T) {
+	tpl := newRoutingTemplate("tmpl-a")
+	server := newRoutingTestServer(
+		tpl,
+		[]*template.TemplateAllocation{
+			newRoutingAllocation("cluster-a", 2, 4),
+			newRoutingAllocation("cluster-b", 2, 4),
+		},
+		[]*template.Cluster{
+			newRoutingCluster("cluster-a", 0),
+			newRoutingCluster("cluster-b", 5),
+		},
+		&fakeRoutingReconciler{},
+	)
+
+	selected, _, selectedBy, err := server.selectClusterForTemplate(newRoutingContext(), "tmpl-a", "team-a")
+	if err != nil {
+		t.Fatalf("selectClusterForTemplate() error = %v", err)
+	}
+	if selected == nil || selected.ClusterID != "cluster-b" {
+		t.Fatalf("selected cluster = %v, want cluster-b", clusterID(selected))
+	}
+	if selectedBy != "weight" {
+		t.Fatalf("selectedBy = %q, want %q", selectedBy, "weight")
+	}
+}
+
+func TestSelectClusterForTemplateFallsBackWhenWeightsAreUnavailable(t *testing.T) {
+	tpl := newRoutingTemplate("tmpl-a")
+	server := newRoutingTestServer(
+		tpl,
+		[]*template.TemplateAllocation{
+			newRoutingAllocation("cluster-a", 2, 4),
+			newRoutingAllocation("cluster-b", 2, 9),
+		},
+		[]*template.Cluster{
+			newRoutingCluster("cluster-a", 0),
+			newRoutingCluster("cluster-b", 0),
+		},
+		&fakeRoutingReconciler{},
+	)
+
+	selected, _, selectedBy, err := server.selectClusterForTemplate(newRoutingContext(), "tmpl-a", "team-a")
+	if err != nil {
+		t.Fatalf("selectClusterForTemplate() error = %v", err)
+	}
+	if selected == nil || selected.ClusterID != "cluster-b" {
+		t.Fatalf("selected cluster = %v, want cluster-b", clusterID(selected))
+	}
+	if selectedBy != "fallback" {
+		t.Fatalf("selectedBy = %q, want %q", selectedBy, "fallback")
+	}
+}
+
+func TestSelectClusterForTemplateRecordsRoutingMetrics(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	metrics := obsmetrics.NewScheduler(registry)
+
+	tpl := newRoutingTemplate("tmpl-a")
+	server := newRoutingTestServerWithMetrics(
+		tpl,
+		[]*template.TemplateAllocation{
+			newRoutingAllocation("cluster-a", 2, 4),
+			newRoutingAllocation("cluster-b", 2, 4),
+		},
+		[]*template.Cluster{
+			newRoutingCluster("cluster-a", 1),
+			newRoutingCluster("cluster-b", 1),
+		},
+		&fakeRoutingReconciler{
+			clusterSummaries: map[string]*templreconciler.ClusterSummary{
+				"cluster-a": {SandboxNodeCount: 2, TotalNodeCount: 2, TotalPodCount: 10},
+				"cluster-b": {SandboxNodeCount: 3, TotalNodeCount: 3, TotalPodCount: 10},
+			},
+			clusterSummaryAge: map[string]time.Duration{
+				"cluster-a": 2 * time.Second,
+				"cluster-b": time.Second,
+			},
+		},
+		metrics,
+	)
+
+	selected, _, selectedBy, err := server.selectClusterForTemplate(newRoutingContext(), "tmpl-a", "team-a")
+	if err != nil {
+		t.Fatalf("selectClusterForTemplate() error = %v", err)
+	}
+	if selected == nil || selected.ClusterID != "cluster-b" || selectedBy != "headroom" {
+		t.Fatalf("selection = (%v,%q), want (cluster-b,headroom)", clusterID(selected), selectedBy)
+	}
+
+	if got := testutil.ToFloat64(metrics.RoutingDecisions.WithLabelValues("cluster-b", "headroom")); got != 1 {
+		t.Fatalf("routing decision metric = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(metrics.ClusterSummaryAge.WithLabelValues("cluster-a")); got != 2 {
+		t.Fatalf("cluster-a summary age = %v, want 2", got)
+	}
+	if got := testutil.ToFloat64(metrics.ClusterSummaryAge.WithLabelValues("cluster-b")); got != 1 {
+		t.Fatalf("cluster-b summary age = %v, want 1", got)
+	}
+}
+
+func TestSelectClusterForTemplateRecordsUnavailableRoutingMetric(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	metrics := obsmetrics.NewScheduler(registry)
+
+	server := newRoutingTestServerWithMetrics(
+		newRoutingTemplate("tmpl-a"),
+		[]*template.TemplateAllocation{
+			newRoutingAllocation("cluster-a", 1, 1),
+		},
+		[]*template.Cluster{
+			{ClusterID: "cluster-a", Enabled: false},
+		},
+		&fakeRoutingReconciler{},
+		metrics,
+	)
+
+	selected, _, selectedBy, err := server.selectClusterForTemplate(newRoutingContext(), "tmpl-a", "team-a")
+	if err != nil {
+		t.Fatalf("selectClusterForTemplate() error = %v", err)
+	}
+	if selected != nil || selectedBy != "" {
+		t.Fatalf("selection = (%v,%q), want (nil,\"\")", clusterID(selected), selectedBy)
+	}
+	if got := testutil.ToFloat64(metrics.RoutingDecisions.WithLabelValues("none", "unavailable")); got != 1 {
+		t.Fatalf("unavailable routing metric = %v, want 1", got)
+	}
+}
+
+func TestCreateSandboxRoutesRequestByHeadroom(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	registry := prometheus.NewRegistry()
+	metrics := obsmetrics.NewScheduler(registry)
+
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate ed25519 keypair: %v", err)
+	}
+
+	receivedA := 0
+	clusterA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedA++
+		w.Header().Set("Content-Type", "application/json")
+		if got := r.Header.Get("X-Team-ID"); got != "team-a" {
+			t.Fatalf("cluster-a X-Team-ID = %q, want team-a", got)
+		}
+		_, _ = w.Write([]byte(`{"success":true,"data":{"sandbox_id":"sb-a"}}`))
+	}))
+	defer clusterA.Close()
+
+	receivedB := 0
+	clusterB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedB++
+		w.Header().Set("Content-Type", "application/json")
+		if got := r.Header.Get("X-Team-ID"); got != "team-a" {
+			t.Fatalf("cluster-b X-Team-ID = %q, want team-a", got)
+		}
+		if got := r.Header.Get("X-Internal-Token"); got == "" {
+			t.Fatal("expected internal token header")
+		}
+		_, _ = w.Write([]byte(`{"success":true,"data":{"sandbox_id":"sb-b"}}`))
+	}))
+	defer clusterB.Close()
+
+	server := newRoutingTestServerWithMetrics(
+		newRoutingTemplate("tmpl-a"),
+		[]*template.TemplateAllocation{
+			newRoutingAllocation("cluster-a", 2, 4),
+			newRoutingAllocation("cluster-b", 2, 4),
+		},
+		[]*template.Cluster{
+			{ClusterID: "cluster-a", ClusterGatewayURL: clusterA.URL, Enabled: true, Weight: 1},
+			{ClusterID: "cluster-b", ClusterGatewayURL: clusterB.URL, Enabled: true, Weight: 1},
+		},
+		&fakeRoutingReconciler{
+			clusterSummaries: map[string]*templreconciler.ClusterSummary{
+				"cluster-a": {SandboxNodeCount: 1, TotalNodeCount: 1, TotalPodCount: 8},
+				"cluster-b": {SandboxNodeCount: 3, TotalNodeCount: 3, TotalPodCount: 15},
+			},
+			clusterSummaryAge: map[string]time.Duration{
+				"cluster-a": time.Second,
+				"cluster-b": time.Second,
+			},
+		},
+		metrics,
+	)
+	server.clusterGatewayProxies = make(map[string]*proxy.Router)
+	server.authValidator = internalauth.NewValidator(internalauth.ValidatorConfig{
+		Target:             "scheduler",
+		PublicKey:          publicKey,
+		AllowedCallers:     []string{"regional-gateway"},
+		ClockSkewTolerance: 5 * time.Second,
+	})
+	server.internalAuthGen = internalauth.NewGenerator(internalauth.GeneratorConfig{
+		Caller:     "scheduler",
+		PrivateKey: privateKey,
+		TTL:        time.Minute,
+	})
+
+	router := gin.New()
+	v1 := router.Group("/api/v1")
+	v1.Use(server.authMiddleware())
+	v1.POST("/sandboxes", server.createSandbox)
+	httpServer := httptest.NewServer(router)
+	defer httpServer.Close()
+
+	requestBody, err := json.Marshal(map[string]any{"template": "tmpl-a"})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, httpServer.URL+"/api/v1/sandboxes", bytes.NewReader(requestBody))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Internal-Token", mustGenerateSchedulerTestToken(t, privateKey, "regional-gateway", "scheduler", "team-a", "user-a"))
+	resp, err := httpServer.Client().Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if receivedA != 0 {
+		t.Fatalf("cluster-a requests = %d, want 0", receivedA)
+	}
+	if receivedB != 1 {
+		t.Fatalf("cluster-b requests = %d, want 1", receivedB)
+	}
+	if got := testutil.ToFloat64(metrics.RoutingDecisions.WithLabelValues("cluster-b", "headroom")); got != 1 {
+		t.Fatalf("routing metric = %v, want 1", got)
+	}
+}
+
+func TestCreateSandboxFallsBackWhenNoFreshSignalsExist(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate ed25519 keypair: %v", err)
+	}
+
+	receivedA := 0
+	clusterA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedA++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":true,"data":{"sandbox_id":"sb-a"}}`))
+	}))
+	defer clusterA.Close()
+
+	receivedB := 0
+	clusterB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedB++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":true,"data":{"sandbox_id":"sb-b"}}`))
+	}))
+	defer clusterB.Close()
+
+	server := newRoutingTestServerWithMetrics(
+		newRoutingTemplate("tmpl-a"),
+		[]*template.TemplateAllocation{
+			newRoutingAllocation("cluster-a", 2, 4),
+			newRoutingAllocation("cluster-b", 2, 9),
+		},
+		[]*template.Cluster{
+			{ClusterID: "cluster-a", ClusterGatewayURL: clusterA.URL, Enabled: true, Weight: 0},
+			{ClusterID: "cluster-b", ClusterGatewayURL: clusterB.URL, Enabled: true, Weight: 0},
+		},
+		&fakeRoutingReconciler{},
+		nil,
+	)
+	server.clusterGatewayProxies = make(map[string]*proxy.Router)
+	server.authValidator = internalauth.NewValidator(internalauth.ValidatorConfig{
+		Target:             "scheduler",
+		PublicKey:          publicKey,
+		AllowedCallers:     []string{"regional-gateway"},
+		ClockSkewTolerance: 5 * time.Second,
+	})
+	server.internalAuthGen = internalauth.NewGenerator(internalauth.GeneratorConfig{
+		Caller:     "scheduler",
+		PrivateKey: privateKey,
+		TTL:        time.Minute,
+	})
+
+	router := gin.New()
+	v1 := router.Group("/api/v1")
+	v1.Use(server.authMiddleware())
+	v1.POST("/sandboxes", server.createSandbox)
+	httpServer := httptest.NewServer(router)
+	defer httpServer.Close()
+
+	requestBody, err := json.Marshal(map[string]any{"template": "tmpl-a"})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, httpServer.URL+"/api/v1/sandboxes", bytes.NewReader(requestBody))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Internal-Token", mustGenerateSchedulerTestToken(t, privateKey, "regional-gateway", "scheduler", "team-a", "user-a"))
+	resp, err := httpServer.Client().Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if receivedA != 0 {
+		t.Fatalf("cluster-a requests = %d, want 0", receivedA)
+	}
+	if receivedB != 1 {
+		t.Fatalf("cluster-b requests = %d, want 1", receivedB)
+	}
+}
+
+type fakeRoutingTemplateStore struct {
+	template *template.Template
+}
+
+func (s *fakeRoutingTemplateStore) CreateTemplate(ctx context.Context, tpl *template.Template) error {
+	return errors.New("not implemented")
+}
+
+func (s *fakeRoutingTemplateStore) GetTemplate(ctx context.Context, scope, teamID, templateID string) (*template.Template, error) {
+	return s.template, nil
+}
+
+func (s *fakeRoutingTemplateStore) GetTemplateForTeam(ctx context.Context, teamID, templateID string) (*template.Template, error) {
+	if s.template == nil || s.template.TemplateID != templateID {
+		return nil, nil
+	}
+	return s.template, nil
+}
+
+func (s *fakeRoutingTemplateStore) ListTemplates(ctx context.Context) ([]*template.Template, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *fakeRoutingTemplateStore) ListVisibleTemplates(ctx context.Context, teamID string) ([]*template.Template, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *fakeRoutingTemplateStore) UpdateTemplate(ctx context.Context, tpl *template.Template) error {
+	return errors.New("not implemented")
+}
+
+func (s *fakeRoutingTemplateStore) DeleteTemplate(ctx context.Context, scope, teamID, templateID string) error {
+	return errors.New("not implemented")
+}
+
+type fakeRoutingAllocationStore struct {
+	allocations []*template.TemplateAllocation
+}
+
+func (s *fakeRoutingAllocationStore) UpsertAllocation(ctx context.Context, alloc *template.TemplateAllocation) error {
+	return errors.New("not implemented")
+}
+
+func (s *fakeRoutingAllocationStore) ListAllocationsByTemplate(ctx context.Context, scope, teamID, templateID string) ([]*template.TemplateAllocation, error) {
+	return s.allocations, nil
+}
+
+func (s *fakeRoutingAllocationStore) UpdateAllocationSyncStatus(ctx context.Context, scope, teamID, templateID, clusterID, status string, syncError *string) error {
+	return errors.New("not implemented")
+}
+
+func (s *fakeRoutingAllocationStore) DeleteAllocationsByTemplate(ctx context.Context, scope, teamID, templateID string) error {
+	return errors.New("not implemented")
+}
+
+type fakeRoutingClusterRepo struct {
+	clusters []*template.Cluster
+}
+
+func (r *fakeRoutingClusterRepo) Ping(ctx context.Context) error { return nil }
+func (r *fakeRoutingClusterRepo) CreateCluster(ctx context.Context, cluster *template.Cluster) error {
+	return errors.New("not implemented")
+}
+func (r *fakeRoutingClusterRepo) GetCluster(ctx context.Context, clusterID string) (*template.Cluster, error) {
+	for _, cluster := range r.clusters {
+		if cluster.ClusterID == clusterID {
+			return cluster, nil
+		}
+	}
+	return nil, nil
+}
+func (r *fakeRoutingClusterRepo) ListClusters(ctx context.Context) ([]*template.Cluster, error) {
+	return r.clusters, nil
+}
+func (r *fakeRoutingClusterRepo) ListEnabledClusters(ctx context.Context) ([]*template.Cluster, error) {
+	var enabled []*template.Cluster
+	for _, cluster := range r.clusters {
+		if cluster.Enabled {
+			enabled = append(enabled, cluster)
+		}
+	}
+	return enabled, nil
+}
+func (r *fakeRoutingClusterRepo) UpdateCluster(ctx context.Context, cluster *template.Cluster) error {
+	return errors.New("not implemented")
+}
+func (r *fakeRoutingClusterRepo) UpdateClusterLastSeen(ctx context.Context, clusterID string) error {
+	return errors.New("not implemented")
+}
+func (r *fakeRoutingClusterRepo) DeleteCluster(ctx context.Context, clusterID string) error {
+	return errors.New("not implemented")
+}
+
+type fakeRoutingReconciler struct {
+	templateIdle      map[string]map[string]int32
+	templateStatsAge  map[string]time.Duration
+	clusterSummaries  map[string]*templreconciler.ClusterSummary
+	clusterSummaryAge map[string]time.Duration
+}
+
+func (r *fakeRoutingReconciler) TriggerReconcile(ctx context.Context) {}
+
+func (r *fakeRoutingReconciler) GetTemplateIdleCount(clusterID, templateID string) (int32, bool) {
+	if r.templateIdle == nil {
+		return 0, false
+	}
+	byTemplate, ok := r.templateIdle[clusterID]
+	if !ok {
+		return 0, false
+	}
+	idle, ok := byTemplate[templateID]
+	return idle, ok
+}
+
+func (r *fakeRoutingReconciler) GetTemplateStatsAge(clusterID string) (time.Duration, bool) {
+	age, ok := r.templateStatsAge[clusterID]
+	return age, ok
+}
+
+func (r *fakeRoutingReconciler) GetClusterSummary(clusterID string) (*templreconciler.ClusterSummary, bool) {
+	summary, ok := r.clusterSummaries[clusterID]
+	return summary, ok
+}
+
+func (r *fakeRoutingReconciler) GetClusterSummaryAge(clusterID string) (time.Duration, bool) {
+	age, ok := r.clusterSummaryAge[clusterID]
+	return age, ok
+}
+
+func newRoutingTestServer(tpl *template.Template, allocations []*template.TemplateAllocation, clusters []*template.Cluster, reconciler *fakeRoutingReconciler) *Server {
+	return newRoutingTestServerWithMetrics(tpl, allocations, clusters, reconciler, nil)
+}
+
+func newRoutingTestServerWithMetrics(tpl *template.Template, allocations []*template.TemplateAllocation, clusters []*template.Cluster, reconciler *fakeRoutingReconciler, metrics *obsmetrics.SchedulerMetrics) *Server {
+	return &Server{
+		cfg: &config.SchedulerConfig{
+			ReconcileInterval: metav1.Duration{Duration: time.Second},
+			PodsPerNode:       10,
+		},
+		repo:            &fakeRoutingClusterRepo{clusters: clusters},
+		templateStore:   &fakeRoutingTemplateStore{template: tpl},
+		allocationStore: &fakeRoutingAllocationStore{allocations: allocations},
+		reconciler:      reconciler,
+		logger:          zap.NewNop(),
+		metrics:         metrics,
+	}
+}
+
+func newRoutingContext() *gin.Context {
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest("GET", "/api/v1/sandboxes", nil)
+	return ctx
+}
+
+func newRoutingTemplate(templateID string) *template.Template {
+	return &template.Template{
+		TemplateID: templateID,
+		Scope:      naming.ScopePublic,
+	}
+}
+
+func newRoutingAllocation(clusterID string, minIdle, maxIdle int32) *template.TemplateAllocation {
+	return &template.TemplateAllocation{
+		TemplateID: "tmpl-a",
+		ClusterID:  clusterID,
+		MinIdle:    minIdle,
+		MaxIdle:    maxIdle,
+	}
+}
+
+func newRoutingCluster(clusterID string, weight int) *template.Cluster {
+	return &template.Cluster{
+		ClusterID: clusterID,
+		Weight:    weight,
+		Enabled:   true,
+	}
+}
+
+func clusterID(cluster *template.Cluster) string {
+	if cluster == nil {
+		return "<nil>"
+	}
+	return cluster.ClusterID
+}
+
+func mustGenerateSchedulerTestToken(t *testing.T, privateKey ed25519.PrivateKey, caller, target, teamID, userID string) string {
+	t.Helper()
+	gen := internalauth.NewGenerator(internalauth.GeneratorConfig{
+		Caller:     caller,
+		PrivateKey: privateKey,
+		TTL:        time.Minute,
+	})
+	token, err := gen.Generate(target, teamID, userID, internalauth.GenerateOptions{})
+	if err != nil {
+		t.Fatalf("generate token: %v", err)
+	}
+	return token
+}

--- a/scheduler/pkg/http/server.go
+++ b/scheduler/pkg/http/server.go
@@ -16,10 +16,12 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/licensing"
 	"github.com/sandbox0-ai/sandbox0/pkg/observability"
 	httpobs "github.com/sandbox0-ai/sandbox0/pkg/observability/http"
+	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
 	"github.com/sandbox0-ai/sandbox0/pkg/proxy"
+	"github.com/sandbox0-ai/sandbox0/pkg/template"
 	templatehttp "github.com/sandbox0-ai/sandbox0/pkg/template/http"
+	templreconciler "github.com/sandbox0-ai/sandbox0/pkg/template/reconciler"
 	"github.com/sandbox0-ai/sandbox0/pkg/template/store"
-	"github.com/sandbox0-ai/sandbox0/scheduler/pkg/db"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 )
@@ -28,7 +30,7 @@ import (
 type Server struct {
 	router          *gin.Engine
 	cfg             *config.SchedulerConfig
-	repo            *db.Repository
+	repo            ClusterRepository
 	templateStore   store.TemplateStore
 	allocationStore store.AllocationStore
 	templateHandler *templatehttp.Handler
@@ -37,11 +39,12 @@ type Server struct {
 	reconciler      Reconciler
 	logger          *zap.Logger
 	obsProvider     *observability.Provider
+	metrics         *obsmetrics.SchedulerMetrics
 
 	clusterGatewayProxies   map[string]*proxy.Router
 	clusterGatewayProxiesMu sync.RWMutex
 
-	clusterCache   map[string]*db.Cluster
+	clusterCache   map[string]*template.Cluster
 	clusterCacheAt time.Time
 	clusterCacheMu sync.RWMutex
 }
@@ -51,12 +54,26 @@ type Reconciler interface {
 	TriggerReconcile(ctx context.Context)
 	GetTemplateIdleCount(clusterID, templateID string) (int32, bool)
 	GetTemplateStatsAge(clusterID string) (time.Duration, bool)
+	GetClusterSummary(clusterID string) (*templreconciler.ClusterSummary, bool)
+	GetClusterSummaryAge(clusterID string) (time.Duration, bool)
+}
+
+// ClusterRepository provides cluster CRUD and lookup operations.
+type ClusterRepository interface {
+	Ping(ctx context.Context) error
+	CreateCluster(ctx context.Context, cluster *template.Cluster) error
+	GetCluster(ctx context.Context, clusterID string) (*template.Cluster, error)
+	ListClusters(ctx context.Context) ([]*template.Cluster, error)
+	ListEnabledClusters(ctx context.Context) ([]*template.Cluster, error)
+	UpdateCluster(ctx context.Context, cluster *template.Cluster) error
+	UpdateClusterLastSeen(ctx context.Context, clusterID string) error
+	DeleteCluster(ctx context.Context, clusterID string) error
 }
 
 // NewServer creates a new HTTP server
 func NewServer(
 	cfg *config.SchedulerConfig,
-	repo *db.Repository,
+	repo ClusterRepository,
 	templateStore store.TemplateStore,
 	allocationStore store.AllocationStore,
 	authValidator *internalauth.Validator,
@@ -64,6 +81,7 @@ func NewServer(
 	reconciler Reconciler,
 	logger *zap.Logger,
 	obsProvider *observability.Provider,
+	metrics *obsmetrics.SchedulerMetrics,
 ) (*Server, error) {
 	if err := licensing.RequireLicenseFile(cfg.LicenseFile); err != nil {
 		return nil, fmt.Errorf("license_file is required for scheduler: %w", err)
@@ -95,8 +113,9 @@ func NewServer(
 		reconciler:            reconciler,
 		logger:                logger,
 		obsProvider:           obsProvider,
+		metrics:               metrics,
 		clusterGatewayProxies: make(map[string]*proxy.Router),
-		clusterCache:          make(map[string]*db.Cluster),
+		clusterCache:          make(map[string]*template.Cluster),
 	}
 	server.templateHandler = &templatehttp.Handler{
 		Store:           templateStore,
@@ -355,7 +374,7 @@ func (s *Server) getClusterGatewayProxy(targetURL string) (*proxy.Router, error)
 	return p, nil
 }
 
-func (s *Server) getClusterByID(ctx context.Context, clusterID string) (*db.Cluster, error) {
+func (s *Server) getClusterByID(ctx context.Context, clusterID string) (*template.Cluster, error) {
 	if clusterID == "" {
 		return nil, fmt.Errorf("cluster_id is required")
 	}
@@ -368,7 +387,7 @@ func (s *Server) getClusterByID(ctx context.Context, clusterID string) (*db.Clus
 	return s.getClusterFromCache(clusterID), nil
 }
 
-func (s *Server) getClusterFromCache(clusterID string) *db.Cluster {
+func (s *Server) getClusterFromCache(clusterID string) *template.Cluster {
 	s.clusterCacheMu.RLock()
 	defer s.clusterCacheMu.RUnlock()
 	return s.clusterCache[clusterID]
@@ -392,7 +411,7 @@ func (s *Server) refreshClusterCache(ctx context.Context) error {
 		return fmt.Errorf("list enabled clusters: %w", err)
 	}
 
-	cache := make(map[string]*db.Cluster, len(clusters))
+	cache := make(map[string]*template.Cluster, len(clusters))
 	for _, cluster := range clusters {
 		cache[cluster.ClusterID] = cluster
 	}

--- a/scheduler/pkg/reconciler/reconciler.go
+++ b/scheduler/pkg/reconciler/reconciler.go
@@ -72,6 +72,16 @@ func (r *Reconciler) GetTemplateStatsAge(clusterID string) (time.Duration, bool)
 	return r.inner.GetTemplateStatsAge(clusterID)
 }
 
+// GetClusterSummary returns the cached cluster summary for a shard.
+func (r *Reconciler) GetClusterSummary(clusterID string) (*templreconciler.ClusterSummary, bool) {
+	return r.inner.GetClusterSummary(clusterID)
+}
+
+// GetClusterSummaryAge returns age since the cluster summary cache was updated.
+func (r *Reconciler) GetClusterSummaryAge(clusterID string) (time.Duration, bool) {
+	return r.inner.GetClusterSummaryAge(clusterID)
+}
+
 // UpdateTemplateStats updates stats cache for a template in a cluster.
 func (r *Reconciler) UpdateTemplateStats(clusterID, templateID string, idleCount, activeCount int32, updatedAt time.Time) {
 	r.inner.UpdateTemplateStats(clusterID, templateID, idleCount, activeCount, updatedAt)
@@ -87,11 +97,14 @@ func (a *clusterGatewayAdapter) GetClusterSummary(ctx context.Context, baseURL s
 		return nil, err
 	}
 	return &templreconciler.ClusterSummary{
-		ClusterID:      summary.ClusterID,
-		NodeCount:      summary.NodeCount,
-		IdlePodCount:   summary.IdlePodCount,
-		ActivePodCount: summary.ActivePodCount,
-		TotalPodCount:  summary.TotalPodCount,
+		ClusterID:             summary.ClusterID,
+		NodeCount:             summary.NodeCount,
+		TotalNodeCount:        summary.TotalNodeCount,
+		SandboxNodeCount:      summary.SandboxNodeCount,
+		IdlePodCount:          summary.IdlePodCount,
+		ActivePodCount:        summary.ActivePodCount,
+		PendingActivePodCount: summary.PendingActivePodCount,
+		TotalPodCount:         summary.TotalPodCount,
 	}, nil
 }
 
@@ -105,11 +118,12 @@ func (a *clusterGatewayAdapter) GetTemplateStats(ctx context.Context, baseURL st
 	}
 	for _, stat := range stats.Templates {
 		out.Templates = append(out.Templates, templreconciler.TemplateStat{
-			TemplateID:  stat.TemplateID,
-			IdleCount:   stat.IdleCount,
-			ActiveCount: stat.ActiveCount,
-			MinIdle:     stat.MinIdle,
-			MaxIdle:     stat.MaxIdle,
+			TemplateID:         stat.TemplateID,
+			IdleCount:          stat.IdleCount,
+			ActiveCount:        stat.ActiveCount,
+			PendingActiveCount: stat.PendingActiveCount,
+			MinIdle:            stat.MinIdle,
+			MaxIdle:            stat.MaxIdle,
 		})
 	}
 	return out, nil


### PR DESCRIPTION
## Summary
- add sandbox-specific cluster capacity signals and pending active pod accounting
- clamp template allocations against sandbox-capable shard capacity
- route claims using idle -> headroom -> weight -> fallback and expose routing signals
- add unit and HTTP-path integration tests for routing, capacity and observability behavior

Closes #93

## Testing
- go test ./manager/pkg/service ./cluster-gateway/pkg/http ./pkg/template/allocator
- go test ./pkg/template/reconciler ./scheduler/pkg/http ./scheduler/pkg/reconciler