### PR TITLE
sync: flush replay payloads before journal capture

### DIFF
--- a/skills/sandbox0/references/docs-src/volume/sync/page.mdx
+++ b/skills/sandbox0/references/docs-src/volume/sync/page.mdx
@@ -148,6 +148,20 @@ Avoid:
 
 When Sandbox0 detects a namespace that is unsafe for one of your attached platforms, it reports a sync conflict instead of silently creating a broken checkout on another machine.
 
+## Supported Workspace Types
+
+Today, `s0 sync` supports only regular files and directories.
+
+That means the synced workspace should not rely on:
+
+- symlinks
+- named pipes
+- sockets
+- device nodes
+- hard links coming from bootstrap archives
+
+If the local workspace, a bootstrap archive, or a remote replay contains one of those entry types, `s0 sync` reports an explicit unsupported-type error instead of silently producing a partial checkout.
+
 ## Conflicts and Recovery
 
 Most of the time, Volume Sync should feel automatic. When there is a problem, the operator flow is:
@@ -221,6 +235,12 @@ List journal entries after a known sequence:
 /api/v1/sandboxvolumes/{'{id}'}/sync/changes?after=42&limit=256
 </Endpoint>
 
+For regular-file writes that include `content_ref`, download the replay payload bytes separately:
+
+<Endpoint method="GET">
+/api/v1/sandboxvolumes/{'{id}'}/sync/replay-payload?content_ref=sha256:...
+</Endpoint>
+
 Submit local replica changes:
 
 <Endpoint method="POST">
@@ -232,6 +252,12 @@ Persist the highest applied cursor:
 <Endpoint method="PUT">
 /api/v1/sandboxvolumes/{'{id}'}/sync/replicas/{'{replica_id}'}/cursor
 </Endpoint>
+
+In steady-state replay:
+
+- `sync/changes` provides journal metadata such as `event_type`, `entry_kind`, `mode`, and `content_ref`
+- `sync/replay-payload` provides the immutable bytes for a regular-file write when `content_ref` is present
+- replicas persist their applied cursor separately through the replica cursor endpoint
 
 The server retains sync history for a bounded window. If a replica falls behind that retained journal floor, it must bootstrap again from the current Volume state.
 

--- a/storage-proxy/pkg/grpc/server.go
+++ b/storage-proxy/pkg/grpc/server.go
@@ -140,6 +140,27 @@ func (s *FileSystemServer) takeDirtyWrite(volumeID string, handleID uint64) (dir
 	return dirty, ok
 }
 
+func (s *FileSystemServer) peekDirtyWrite(volumeID string, handleID uint64) (dirtyWriteHandle, bool) {
+	if s == nil {
+		return dirtyWriteHandle{}, false
+	}
+	key := dirtyWriteKey(volumeID, handleID)
+	s.dirtyWriteMu.Lock()
+	defer s.dirtyWriteMu.Unlock()
+	dirty, ok := s.dirtyWriteHandles[key]
+	return dirty, ok
+}
+
+func (s *FileSystemServer) clearDirtyWrite(volumeID string, handleID uint64) {
+	if s == nil {
+		return
+	}
+	key := dirtyWriteKey(volumeID, handleID)
+	s.dirtyWriteMu.Lock()
+	defer s.dirtyWriteMu.Unlock()
+	delete(s.dirtyWriteHandles, key)
+}
+
 func (s *FileSystemServer) recordRemoteSyncChange(ctx context.Context, change *volsync.RemoteChange) context.Context {
 	if s.syncRecorder == nil || change == nil {
 		return ctx
@@ -207,6 +228,31 @@ func captureInodeReplayState(volCtx *volume.VolumeContext, inode uint64) ([]byte
 
 func uint32Ptr(value uint32) *uint32 {
 	return &value
+}
+
+func (s *FileSystemServer) recordDirtyWriteReplayPayload(ctx context.Context, volCtx *volume.VolumeContext, volumeID string, dirty dirtyWriteHandle, warnContext string) bool {
+	if volCtx == nil {
+		return false
+	}
+	path := resolveInodePath(volCtx, uint64(mapInode(volCtx, dirty.inode)))
+	if path == "" {
+		return false
+	}
+	payload, mode, err := captureInodeReplayState(volCtx, dirty.inode)
+	if err != nil {
+		s.logger.WithError(err).WithField("volume_id", volumeID).Warn("Failed to capture replay payload for " + warnContext)
+		return false
+	}
+	s.recordRemoteSyncChange(ctx, &volsync.RemoteChange{
+		VolumeID:         volumeID,
+		EventType:        db.SyncEventWrite,
+		Path:             path,
+		EntryKind:        "file",
+		Mode:             uint32Ptr(mode),
+		ContentAvailable: true,
+		ContentBytes:     payload,
+	})
+	return true
 }
 
 // MountVolume mounts a volume
@@ -1035,50 +1081,63 @@ func (s *FileSystemServer) SetAttr(ctx context.Context, req *pb.SetAttrRequest) 
 
 // Flush implements FUSE flush
 func (s *FileSystemServer) Flush(ctx context.Context, req *pb.FlushRequest) (*pb.Empty, error) {
-	if volCtx, err := s.getAuthorizedMountedVolume(ctx, req.VolumeId); err == nil {
-		if dirty, ok := s.takeDirtyWrite(req.VolumeId, req.HandleId); ok {
-			path := resolveInodePath(volCtx, uint64(mapInode(volCtx, dirty.inode)))
-			if path != "" {
-				if payload, mode, captureErr := captureInodeReplayState(volCtx, dirty.inode); captureErr != nil {
-					s.logger.WithError(captureErr).WithField("volume_id", req.VolumeId).Warn("Failed to capture replay payload for flush")
-				} else {
-					_ = s.recordRemoteSyncChange(ctx, &volsync.RemoteChange{
-						VolumeID:         req.VolumeId,
-						EventType:        db.SyncEventWrite,
-						Path:             path,
-						EntryKind:        "file",
-						Mode:             uint32Ptr(mode),
-						ContentAvailable: true,
-						ContentBytes:     payload,
-					})
-				}
-			}
-		}
+	volCtx, err := s.getAuthorizedMountedVolume(ctx, req.VolumeId)
+	if err != nil {
+		return nil, err
+	}
+
+	dirty, ok := s.peekDirtyWrite(req.VolumeId, req.HandleId)
+	if !ok {
+		return &pb.Empty{}, nil
+	}
+
+	vfsCtx := vfs.NewLogContext(meta.Background())
+	if errno := volCtx.VFS.Flush(vfsCtx, mapInode(volCtx, dirty.inode), req.HandleId, 0); errno != 0 {
+		s.logger.WithFields(logrus.Fields{
+			"volume_id": req.VolumeId,
+			"inode":     dirty.inode,
+			"handle_id": req.HandleId,
+			"error":     errno,
+		}).Error("Flush failed")
+		return nil, status.Error(mapErrnoToCode(syscall.Errno(errno)), syscall.Errno(errno).Error())
+	}
+
+	if s.recordDirtyWriteReplayPayload(ctx, volCtx, req.VolumeId, dirty, "flush") {
+		s.clearDirtyWrite(req.VolumeId, req.HandleId)
 	}
 	return &pb.Empty{}, nil
 }
 
 // Fsync implements FUSE fsync
 func (s *FileSystemServer) Fsync(ctx context.Context, req *pb.FsyncRequest) (*pb.Empty, error) {
-	if volCtx, err := s.getAuthorizedMountedVolume(ctx, req.VolumeId); err == nil {
-		if dirty, ok := s.takeDirtyWrite(req.VolumeId, req.HandleId); ok {
-			path := resolveInodePath(volCtx, uint64(mapInode(volCtx, dirty.inode)))
-			if path != "" {
-				if payload, mode, captureErr := captureInodeReplayState(volCtx, dirty.inode); captureErr != nil {
-					s.logger.WithError(captureErr).WithField("volume_id", req.VolumeId).Warn("Failed to capture replay payload for fsync")
-				} else {
-					_ = s.recordRemoteSyncChange(ctx, &volsync.RemoteChange{
-						VolumeID:         req.VolumeId,
-						EventType:        db.SyncEventWrite,
-						Path:             path,
-						EntryKind:        "file",
-						Mode:             uint32Ptr(mode),
-						ContentAvailable: true,
-						ContentBytes:     payload,
-					})
-				}
-			}
-		}
+	volCtx, err := s.getAuthorizedMountedVolume(ctx, req.VolumeId)
+	if err != nil {
+		return nil, err
+	}
+
+	dirty, ok := s.peekDirtyWrite(req.VolumeId, req.HandleId)
+	if !ok {
+		return &pb.Empty{}, nil
+	}
+
+	datasync := 0
+	if req.Datasync {
+		datasync = 1
+	}
+	vfsCtx := vfs.NewLogContext(meta.Background())
+	if errno := volCtx.VFS.Fsync(vfsCtx, mapInode(volCtx, dirty.inode), datasync, req.HandleId); errno != 0 {
+		s.logger.WithFields(logrus.Fields{
+			"volume_id": req.VolumeId,
+			"inode":     dirty.inode,
+			"handle_id": req.HandleId,
+			"datasync":  req.Datasync,
+			"error":     errno,
+		}).Error("Fsync failed")
+		return nil, status.Error(mapErrnoToCode(syscall.Errno(errno)), syscall.Errno(errno).Error())
+	}
+
+	if s.recordDirtyWriteReplayPayload(ctx, volCtx, req.VolumeId, dirty, "fsync") {
+		s.clearDirtyWrite(req.VolumeId, req.HandleId)
 	}
 	return &pb.Empty{}, nil
 }
@@ -1094,24 +1153,8 @@ func (s *FileSystemServer) Release(ctx context.Context, req *pb.ReleaseRequest) 
 	vfsCtx := vfs.NewLogContext(meta.Background())
 	volCtx.VFS.Release(vfsCtx, mapInode(volCtx, req.Inode), req.HandleId)
 
-	if _, dirty := s.takeDirtyWrite(req.VolumeId, req.HandleId); dirty {
-		path := resolveInodePath(volCtx, uint64(mapInode(volCtx, req.Inode)))
-		if path != "" {
-			payload, mode, err := captureInodeReplayState(volCtx, req.Inode)
-			if err != nil {
-				s.logger.WithError(err).WithField("volume_id", req.VolumeId).Warn("Failed to capture replay payload for release")
-			} else {
-				_ = s.recordRemoteSyncChange(ctx, &volsync.RemoteChange{
-					VolumeID:         req.VolumeId,
-					EventType:        db.SyncEventWrite,
-					Path:             path,
-					EntryKind:        "file",
-					Mode:             uint32Ptr(mode),
-					ContentAvailable: true,
-					ContentBytes:     payload,
-				})
-			}
-		}
+	if dirty, ok := s.takeDirtyWrite(req.VolumeId, req.HandleId); ok {
+		s.recordDirtyWriteReplayPayload(ctx, volCtx, req.VolumeId, dirty, "release")
 	}
 
 	s.logger.WithFields(logrus.Fields{

--- a/tests/integration/internal/tests/storage-proxy/sync_api_test.go
+++ b/tests/integration/internal/tests/storage-proxy/sync_api_test.go
@@ -343,6 +343,13 @@ func TestSyncAPISandboxOriginatedReplayableWritesExposeReplayMetadataAndPayload(
 		t.Fatalf("BytesWritten = %d, want %d", writeResp.BytesWritten, len(payload))
 	}
 
+	if _, err := fsServer.Flush(ctx, &pb.FlushRequest{
+		VolumeId: "vol-1",
+		HandleId: createResp.HandleId,
+	}); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+
 	if _, err := fsServer.Release(ctx, &pb.ReleaseRequest{
 		VolumeId: "vol-1",
 		Inode:    createResp.Inode,


### PR DESCRIPTION
## Summary
- flush or fsync sandbox-originated dirty writes before capturing replay payload bytes for the sync journal
- keep release as the fallback capture path while only clearing dirty state after successful replay capture
- document the replay payload endpoint and the current supported workspace entry types in the volume sync docs

Refs #87

## Testing
- go test ./storage-proxy/pkg/grpc ./tests/integration/internal/tests/storage-proxy