### PR TITLE
Treat multi-cluster regions as global-managed by default

### DIFF
--- a/infra-operator/api/config/regional_gateway.go
+++ b/infra-operator/api/config/regional_gateway.go
@@ -45,7 +45,7 @@ type RegionalGatewayConfig struct {
 
 	// Scheduler configuration (optional, for multi-cluster mode)
 	// +optional
-	SchedulerEnabled bool `yaml:"scheduler_enabled" json:"schedulerEnabled"`
+	SchedulerEnabled bool `yaml:"scheduler_enabled" json:"-"`
 	// +optional
 	SchedulerURL string `yaml:"scheduler_url" json:"schedulerUrl"`
 	// License file path used to unlock enterprise features.

--- a/infra-operator/chart/samples/multi-cluster/control-plane.yaml
+++ b/infra-operator/chart/samples/multi-cluster/control-plane.yaml
@@ -1,5 +1,5 @@
 # Example: Regional multi-cluster control plane (regional-gateway + scheduler)
-# Deploy the global-service layer separately when running self-hosted multi-region.
+# This sample assumes a separate global-service layer handles bootstrap user auth.
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -69,12 +69,7 @@ spec:
         type: NodePort
         port: 30080
       config:
-        schedulerEnabled: true
+        authMode: federated_global
     scheduler:
       enabled: true
       replicas: 1
-  initUser:
-    email: "admin@example.com"
-    # passwordSecret:
-    #   name: admin-password
-    #   key: password

--- a/infra-operator/internal/controller/services/clustergateway/clustergateway.go
+++ b/infra-operator/internal/controller/services/clustergateway/clustergateway.go
@@ -270,7 +270,7 @@ func (r *Reconciler) buildConfig(ctx context.Context, infra *infrav1alpha1.Sandb
 		cfg.StorageProxyURL = ""
 	}
 
-	if infra.Spec.InitUser != nil {
+	if infra.Spec.InitUser != nil && clusterGatewayPublicAuthEnabled(cfg.AuthMode) {
 		secretRef := common.ResolveSecretKeyRef(infra.Spec.InitUser.PasswordSecret, "admin-password", "password")
 		password, err := common.GetSecretValue(ctx, r.Resources.Client, infra.Namespace, secretRef)
 		if err != nil {

--- a/infra-operator/internal/controller/services/clustergateway/clustergateway_test.go
+++ b/infra-operator/internal/controller/services/clustergateway/clustergateway_test.go
@@ -85,3 +85,73 @@ func TestBuildConfigUsesStorageProxyServicePortForDerivedURL(t *testing.T) {
 		t.Fatalf("expected storage proxy url to use service port, got %q", cfg.StorageProxyURL)
 	}
 }
+
+func TestBuildConfigSkipsInitUserForInternalOnlyClusterGateway(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+	if err := infrav1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add infra scheme: %v", err)
+	}
+
+	infra := &infrav1alpha1.Sandbox0Infra{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "sandbox0-system",
+		},
+		Spec: infrav1alpha1.Sandbox0InfraSpec{
+			InitUser: &infrav1alpha1.InitUserConfig{
+				Email: "admin@example.com",
+			},
+			Database: &infrav1alpha1.DatabaseConfig{
+				Type: infrav1alpha1.DatabaseTypeBuiltin,
+				Builtin: &infrav1alpha1.BuiltinDatabaseConfig{
+					Enabled:  true,
+					Port:     5432,
+					Username: "sandbox0",
+					Database: "sandbox0",
+					SSLMode:  "disable",
+				},
+			},
+			Services: &infrav1alpha1.ServicesConfig{
+				ClusterGateway: &infrav1alpha1.ClusterGatewayServiceConfig{
+					WorkloadServiceConfig: infrav1alpha1.WorkloadServiceConfig{
+						EnabledServiceConfig: infrav1alpha1.EnabledServiceConfig{Enabled: true},
+					},
+					Config: &infrav1alpha1.ClusterGatewayConfig{
+						AuthMode: "internal",
+					},
+				},
+			},
+		},
+	}
+
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(
+			infra.DeepCopy(),
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "demo-sandbox0-database-credentials",
+					Namespace: infra.Namespace,
+				},
+				Data: map[string][]byte{
+					"username": []byte("sandbox0"),
+					"password": []byte("db-password"),
+					"database": []byte("sandbox0"),
+					"port":     []byte("5432"),
+				},
+			},
+		).
+		Build()
+
+	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
+	cfg, err := reconciler.buildConfig(context.Background(), infra)
+	if err != nil {
+		t.Fatalf("buildConfig returned error: %v", err)
+	}
+	if cfg.BuiltInAuth.InitUser != nil {
+		t.Fatalf("expected init user to be omitted for internal-only cluster gateway, got %#v", cfg.BuiltInAuth.InitUser)
+	}
+}

--- a/infra-operator/internal/controller/services/regionalgateway/regionalgateway.go
+++ b/infra-operator/internal/controller/services/regionalgateway/regionalgateway.go
@@ -229,7 +229,11 @@ func (r *Reconciler) buildConfig(ctx context.Context, infra *infrav1alpha1.Sandb
 	}
 	cfg.DefaultClusterGatewayURL = compiledPlan.RegionalGateway.DefaultClusterGatewayURL
 
-	if infra.Spec.InitUser != nil {
+	authMode := strings.TrimSpace(strings.ToLower(cfg.AuthMode))
+	if authMode == "" {
+		authMode = "self_hosted"
+	}
+	if infra.Spec.InitUser != nil && authMode != "federated_global" {
 		secretRef := common.ResolveSecretKeyRef(infra.Spec.InitUser.PasswordSecret, "admin-password", "password")
 		password, err := common.GetSecretValue(ctx, r.Resources.Client, infra.Namespace, secretRef)
 		if err != nil {

--- a/infra-operator/internal/controller/services/regionalgateway/regionalgateway_registry_test.go
+++ b/infra-operator/internal/controller/services/regionalgateway/regionalgateway_registry_test.go
@@ -193,3 +193,68 @@ func TestBuildConfigUsesCompiledPlanForDefaultClusterGatewayURL(t *testing.T) {
 		t.Fatalf("expected cluster gateway URL %q, got %q", compiled.RegionalGateway.DefaultClusterGatewayURL, got)
 	}
 }
+
+func TestBuildConfigSkipsInitUserForFederatedGlobalAuth(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add corev1 scheme: %v", err)
+	}
+	if err := infrav1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add infra scheme: %v", err)
+	}
+
+	infra := &infrav1alpha1.Sandbox0Infra{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "s0cp",
+			Namespace: "sandbox0-system",
+		},
+		Spec: infrav1alpha1.Sandbox0InfraSpec{
+			InitUser: &infrav1alpha1.InitUserConfig{
+				Email: "admin@example.com",
+			},
+			Database: &infrav1alpha1.DatabaseConfig{
+				Type: infrav1alpha1.DatabaseTypeExternal,
+				External: &infrav1alpha1.ExternalDatabaseConfig{
+					Host:     "postgres.example.internal",
+					Port:     5432,
+					Database: "sandbox0",
+					Username: "sandbox0",
+					PasswordSecret: infrav1alpha1.SecretKeyRef{
+						Name: "regional-db",
+						Key:  "password",
+					},
+				},
+			},
+			Services: &infrav1alpha1.ServicesConfig{
+				RegionalGateway: &infrav1alpha1.RegionalGatewayServiceConfig{
+					WorkloadServiceConfig: infrav1alpha1.WorkloadServiceConfig{
+						EnabledServiceConfig: infrav1alpha1.EnabledServiceConfig{Enabled: true},
+					},
+					Config: &infrav1alpha1.RegionalGatewayConfig{
+						AuthMode: "federated_global",
+					},
+				},
+			},
+		},
+	}
+	dbSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "regional-db",
+			Namespace: "sandbox0-system",
+		},
+		Data: map[string][]byte{
+			"password": []byte("secret"),
+		},
+	}
+
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(dbSecret).Build()
+	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
+
+	cfg, _, err := reconciler.buildConfig(context.Background(), infra, infraplan.Compile(infra))
+	if err != nil {
+		t.Fatalf("buildConfig returned error: %v", err)
+	}
+	if cfg.BuiltInAuth.InitUser != nil {
+		t.Fatalf("expected init user to be omitted for federated_global mode, got %#v", cfg.BuiltInAuth.InitUser)
+	}
+}

--- a/infra-operator/internal/ownership/registry.go
+++ b/infra-operator/internal/ownership/registry.go
@@ -91,7 +91,7 @@ func Registry() []Entry {
 		exact("spec.publicExposure.regionId", "plan", []string{"global-gateway", "cluster-gateway", "manager"}, nil, UpdateSemanticsDeclarative, "Public DNS-safe region label feeds generated external URLs and callbacks."),
 
 		prefix("spec.cluster", "plan", []string{"manager", "netd", "status"}, []string{"InfraPlan.Manager.DefaultClusterID", "InfraPlan.Netd.ClusterID", "cluster registration"}, UpdateSemanticsDeclarative, "Cluster identity and capacity metadata propagated into manager, netd, and registration status."),
-		prefix("spec.initUser", "plan", []string{"global-gateway", "database", "status"}, []string{"InfraPlan.Components.EnableInitUser"}, UpdateSemanticsDeclarative, "Initial admin bootstrap for self-hosted installs."),
+		prefix("spec.initUser", "plan", []string{"global-gateway", "regional-gateway", "cluster-gateway", "database", "status"}, []string{"InfraPlan.Components.EnableInitUser"}, UpdateSemanticsDeclarative, "Initial admin bootstrap for self-hosted installs. Ignored for federated regional gateways and internal-only cluster gateways."),
 		prefix("spec.builtinTemplates", "manager", []string{"manager", "scheduler"}, nil, UpdateSemanticsDeclarative, "Builtin template seeds consumed by manager and scheduler template stores."),
 	}
 }

--- a/infra-operator/internal/plan/plan.go
+++ b/infra-operator/internal/plan/plan.go
@@ -12,9 +12,10 @@ import (
 )
 
 const (
-	defaultManagerHTTPPort        = 8080
-	defaultClusterGatewayHTTPPort = 8443
-	defaultClusterGatewayAuthMode = "internal"
+	defaultManagerHTTPPort         = 8080
+	defaultClusterGatewayHTTPPort  = 8443
+	defaultClusterGatewayAuthMode  = "internal"
+	defaultRegionalGatewayAuthMode = "self_hosted"
 )
 
 type InfraPlan struct {
@@ -181,7 +182,7 @@ func compileComponents(infra *infrav1alpha1.Sandbox0Infra) ComponentPlan {
 		EnableDatabase:            enableDatabase,
 		EnableStorage:             infrav1alpha1.IsStorageEnabled(infra),
 		EnableRegistry:            infrav1alpha1.IsRegistryEnabled(infra),
-		EnableInitUser:            enableDatabase && infra != nil && infra.Spec.InitUser != nil,
+		EnableInitUser:            enableDatabase && initUserConsumerEnabled(infra),
 		EnableClusterRegistration: hasDataPlane && infra != nil && infra.Spec.Cluster != nil && infra.Spec.ControlPlane != nil,
 	}
 }
@@ -311,6 +312,9 @@ func compileValidationPlan(infra *infrav1alpha1.Sandbox0Infra, compiled *InfraPl
 	}
 	if compiled != nil && compiled.Components.EnableNetd && netdEgressAuthEnabled(infra) && !compiled.Components.EnableManager {
 		plan.FatalErrors = append(plan.FatalErrors, "netd egress auth requires manager to be enabled")
+	}
+	if infra.Spec.InitUser != nil && (compiled == nil || compiled.Components.EnableDatabase) && !initUserConsumerEnabled(infra) {
+		plan.FatalErrors = append(plan.FatalErrors, "initUser requires globalGateway, regionalGateway.authMode=self_hosted, or clusterGateway authMode public/both")
 	}
 
 	return plan
@@ -768,6 +772,38 @@ func clusterGatewayAuthMode(infra *infrav1alpha1.Sandbox0Infra) string {
 		return defaultClusterGatewayAuthMode
 	}
 	return mode
+}
+
+func regionalGatewayAuthMode(infra *infrav1alpha1.Sandbox0Infra) string {
+	if infra == nil || infra.Spec.Services == nil || infra.Spec.Services.RegionalGateway == nil {
+		return defaultRegionalGatewayAuthMode
+	}
+
+	mode := ""
+	if infra.Spec.Services.RegionalGateway.Config != nil {
+		mode = infra.Spec.Services.RegionalGateway.Config.AuthMode
+	}
+	mode = strings.TrimSpace(strings.ToLower(mode))
+	if mode == "" {
+		return defaultRegionalGatewayAuthMode
+	}
+	return mode
+}
+
+func initUserConsumerEnabled(infra *infrav1alpha1.Sandbox0Infra) bool {
+	if infra == nil || infra.Spec.InitUser == nil {
+		return false
+	}
+	if infrav1alpha1.IsGlobalGatewayEnabled(infra) {
+		return true
+	}
+	if infrav1alpha1.IsRegionalGatewayEnabled(infra) && regionalGatewayAuthMode(infra) != "federated_global" {
+		return true
+	}
+	if infrav1alpha1.IsClusterGatewayEnabled(infra) && clusterGatewayPublicAuthEnabled(clusterGatewayAuthMode(infra)) {
+		return true
+	}
+	return false
 }
 
 func regionalGatewayEnterpriseLicenseRequired(infra *infrav1alpha1.Sandbox0Infra) bool {

--- a/infra-operator/internal/plan/plan_test.go
+++ b/infra-operator/internal/plan/plan_test.go
@@ -542,6 +542,37 @@ func TestCompileTracksValidationRequirements(t *testing.T) {
 			t.Fatalf("expected netd/manager validation error, got %#v", compiled.Validation.FatalErrors)
 		}
 	})
+
+	t.Run("init user is invalid for federated regional gateways", func(t *testing.T) {
+		infra := &infrav1alpha1.Sandbox0Infra{
+			Spec: infrav1alpha1.Sandbox0InfraSpec{
+				InitUser: &infrav1alpha1.InitUserConfig{
+					Email: "admin@example.com",
+				},
+				Database: &infrav1alpha1.DatabaseConfig{
+					Type: infrav1alpha1.DatabaseTypeBuiltin,
+				},
+				Services: &infrav1alpha1.ServicesConfig{
+					RegionalGateway: &infrav1alpha1.RegionalGatewayServiceConfig{
+						WorkloadServiceConfig: infrav1alpha1.WorkloadServiceConfig{
+							EnabledServiceConfig: infrav1alpha1.EnabledServiceConfig{Enabled: true},
+						},
+						Config: &infrav1alpha1.RegionalGatewayConfig{
+							AuthMode: "federated_global",
+						},
+					},
+				},
+			},
+		}
+
+		compiled := Compile(infra)
+		if compiled.Components.EnableInitUser {
+			t.Fatal("expected init user to be disabled for federated regional gateways")
+		}
+		if !containsString(compiled.Validation.FatalErrors, "initUser requires globalGateway, regionalGateway.authMode=self_hosted, or clusterGateway authMode public/both") {
+			t.Fatalf("expected init-user topology validation error, got %#v", compiled.Validation.FatalErrors)
+		}
+	})
 }
 
 func TestCompileTracksWorkflowRequirements(t *testing.T) {


### PR DESCRIPTION
## Summary
- treat multi-cluster regional control-plane installs as global-managed by default
- stop consuming `spec.initUser` from federated regional gateways and internal-only cluster gateways
- update the multi-cluster control-plane sample and add plan/service tests for the new semantics

## Testing
- GOTOOLCHAIN=go1.25.0+auto go test ./infra-operator/internal/plan -count=1
- GOTOOLCHAIN=go1.25.0+auto go test ./infra-operator/internal/controller/services/regionalgateway -count=1
- GOTOOLCHAIN=go1.25.0+auto go test ./infra-operator/internal/controller/services/clustergateway -count=1

Refs #107