### PR TITLE
Fix init user bootstrap for OIDC deployments

### DIFF
--- a/cluster-gateway/pkg/http/server.go
+++ b/cluster-gateway/pkg/http/server.go
@@ -227,7 +227,7 @@ func NewServer(
 				logger.Warn("Failed to initialize OIDC manager", zap.Error(err))
 			}
 		}
-		if cfg.BuiltInAuth.Enabled && cfg.BuiltInAuth.InitUser != nil {
+		if cfg.BuiltInAuth.InitUser != nil && (cfg.BuiltInAuth.Enabled || oidcConfigured) {
 			if err := builtinProvider.EnsureInitUser(context.Background()); err != nil {
 				logger.Warn("Failed to ensure init user", zap.Error(err))
 			}

--- a/global-gateway/pkg/http/server.go
+++ b/global-gateway/pkg/http/server.go
@@ -88,7 +88,7 @@ func NewServer(
 			logger.Warn("Failed to initialize OIDC manager", zap.Error(err))
 		}
 	}
-	if cfg.BuiltInAuth.Enabled && cfg.BuiltInAuth.InitUser != nil {
+	if cfg.BuiltInAuth.InitUser != nil && (cfg.BuiltInAuth.Enabled || oidcConfigured) {
 		if userCount, err := identityRepo.CountUsers(context.Background()); err == nil && userCount == 0 {
 			homeRegionID := strings.TrimSpace(cfg.BuiltInAuth.InitUser.HomeRegionID)
 			if err := handlers.ValidateInitUserHomeRegion(context.Background(), regionRepo, homeRegionID); err != nil {

--- a/infra-operator/internal/controller/sandbox0infra_controller.go
+++ b/infra-operator/internal/controller/sandbox0infra_controller.go
@@ -388,8 +388,6 @@ func (r *Sandbox0InfraReconciler) workflowStepRunner(
 		return func(ctx context.Context) error {
 			return storageProxyReconciler.Reconcile(ctx, infra, imageRepo, imageTag)
 		}, nil
-	case "init-user":
-		return func(ctx context.Context) error { return r.reconcileInitUser(ctx, infra) }, nil
 	case "register-cluster":
 		return func(ctx context.Context) error { return r.registerCluster(ctx, infra) }, nil
 	default:
@@ -743,7 +741,6 @@ func managedConditionTypeSet() map[string]struct{} {
 		infrav1alpha1.ConditionTypeStorageProxyReady:    {},
 		infrav1alpha1.ConditionTypeNetdReady:            {},
 		infrav1alpha1.ConditionTypeFusePluginReady:      {},
-		infrav1alpha1.ConditionTypeInitUserReady:        {},
 		infrav1alpha1.ConditionTypeClusterRegistered:    {},
 		infrav1alpha1.ConditionTypeSecretsGenerated:     {},
 	}
@@ -763,17 +760,8 @@ func (r *Sandbox0InfraReconciler) setCondition(ctx context.Context, infra *infra
 
 // validateExternalDatabase validates connection to external database
 
-// reconcileInitUser creates the initial admin user
-func (r *Sandbox0InfraReconciler) reconcileInitUser(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra) error {
-	// This would typically call an API to create the user
-	// For now, we just log that we would create the user
-	logger := log.FromContext(ctx)
-	logger.Info("Would create init user", "email", infra.Spec.InitUser.Email)
-	return nil
-}
-
 func (r *Sandbox0InfraReconciler) ensureInitUserPasswordSecret(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra) error {
-	if infra == nil || infra.Spec.InitUser == nil {
+	if infra == nil || infra.Spec.InitUser == nil || !infraplan.InitUserPasswordSecretRequired(infra) {
 		return nil
 	}
 

--- a/infra-operator/internal/controller/services/clustergateway/clustergateway.go
+++ b/infra-operator/internal/controller/services/clustergateway/clustergateway.go
@@ -271,10 +271,14 @@ func (r *Reconciler) buildConfig(ctx context.Context, infra *infrav1alpha1.Sandb
 	}
 
 	if infra.Spec.InitUser != nil && clusterGatewayPublicAuthEnabled(cfg.AuthMode) {
-		secretRef := common.ResolveSecretKeyRef(infra.Spec.InitUser.PasswordSecret, "admin-password", "password")
-		password, err := common.GetSecretValue(ctx, r.Resources.Client, infra.Namespace, secretRef)
-		if err != nil {
-			return nil, err
+		password := ""
+		if cfg.BuiltInAuth.Enabled || !apiconfig.HasEnabledOIDCProviders(cfg.OIDCProviders) {
+			secretRef := common.ResolveSecretKeyRef(infra.Spec.InitUser.PasswordSecret, "admin-password", "password")
+			var err error
+			password, err = common.GetSecretValue(ctx, r.Resources.Client, infra.Namespace, secretRef)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		cfg.BuiltInAuth.InitUser = &apiconfig.InitUserConfig{

--- a/infra-operator/internal/controller/services/clustergateway/clustergateway_test.go
+++ b/infra-operator/internal/controller/services/clustergateway/clustergateway_test.go
@@ -155,3 +155,84 @@ func TestBuildConfigSkipsInitUserForInternalOnlyClusterGateway(t *testing.T) {
 		t.Fatalf("expected init user to be omitted for internal-only cluster gateway, got %#v", cfg.BuiltInAuth.InitUser)
 	}
 }
+
+func TestBuildConfigLeavesInitUserPasswordEmptyForOIDCOnlyBootstrap(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+	if err := infrav1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add infra scheme: %v", err)
+	}
+
+	infra := &infrav1alpha1.Sandbox0Infra{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "sandbox0-system",
+		},
+		Spec: infrav1alpha1.Sandbox0InfraSpec{
+			InitUser: &infrav1alpha1.InitUserConfig{
+				Email: "admin@example.com",
+			},
+			Database: &infrav1alpha1.DatabaseConfig{
+				Type: infrav1alpha1.DatabaseTypeBuiltin,
+				Builtin: &infrav1alpha1.BuiltinDatabaseConfig{
+					Enabled:  true,
+					Port:     5432,
+					Username: "sandbox0",
+					Database: "sandbox0",
+					SSLMode:  "disable",
+				},
+			},
+			Services: &infrav1alpha1.ServicesConfig{
+				ClusterGateway: &infrav1alpha1.ClusterGatewayServiceConfig{
+					WorkloadServiceConfig: infrav1alpha1.WorkloadServiceConfig{
+						EnabledServiceConfig: infrav1alpha1.EnabledServiceConfig{Enabled: true},
+					},
+					Config: &infrav1alpha1.ClusterGatewayConfig{
+						AuthMode: "public",
+						GatewayConfig: infrav1alpha1.GatewayConfig{
+							BuiltInAuth: infrav1alpha1.BuiltInAuthConfig{
+								Enabled: false,
+							},
+							OIDCProviders: []infrav1alpha1.OIDCProviderConfig{
+								{Enabled: true},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(
+			infra.DeepCopy(),
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "demo-sandbox0-database-credentials",
+					Namespace: infra.Namespace,
+				},
+				Data: map[string][]byte{
+					"username": []byte("sandbox0"),
+					"password": []byte("db-password"),
+					"database": []byte("sandbox0"),
+					"port":     []byte("5432"),
+				},
+			},
+		).
+		Build()
+
+	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
+	cfg, err := reconciler.buildConfig(context.Background(), infra)
+	if err != nil {
+		t.Fatalf("buildConfig returned error: %v", err)
+	}
+	if cfg.BuiltInAuth.InitUser == nil {
+		t.Fatal("expected init user config")
+	}
+	if cfg.BuiltInAuth.InitUser.Password != "" {
+		t.Fatalf("expected oidc-only init user password to be empty, got %q", cfg.BuiltInAuth.InitUser.Password)
+	}
+}

--- a/infra-operator/internal/controller/services/globalgateway/globalgateway.go
+++ b/infra-operator/internal/controller/services/globalgateway/globalgateway.go
@@ -214,10 +214,13 @@ func (r *Reconciler) buildConfig(ctx context.Context, infra *infrav1alpha1.Sandb
 	cfg.DatabaseURL = dsn
 
 	if infra.Spec.InitUser != nil {
-		secretRef := common.ResolveSecretKeyRef(infra.Spec.InitUser.PasswordSecret, "admin-password", "password")
-		password, err := common.GetSecretValue(ctx, r.Resources.Client, infra.Namespace, secretRef)
-		if err != nil {
-			return nil, err
+		password := ""
+		if cfg.BuiltInAuth.Enabled || !apiconfig.HasEnabledOIDCProviders(cfg.OIDCProviders) {
+			secretRef := common.ResolveSecretKeyRef(infra.Spec.InitUser.PasswordSecret, "admin-password", "password")
+			password, err = common.GetSecretValue(ctx, r.Resources.Client, infra.Namespace, secretRef)
+			if err != nil {
+				return nil, err
+			}
 		}
 		homeRegionID := strings.TrimSpace(infra.Spec.InitUser.HomeRegionID)
 		if homeRegionID == "" {

--- a/infra-operator/internal/controller/services/globalgateway/globalgateway_test.go
+++ b/infra-operator/internal/controller/services/globalgateway/globalgateway_test.go
@@ -229,6 +229,88 @@ func TestBuildConfigPreservesInitUserHomeRegionID(t *testing.T) {
 	}
 }
 
+func TestBuildConfigLeavesInitUserPasswordEmptyForOIDCOnlyBootstrap(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1 scheme: %v", err)
+	}
+	if err := infrav1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add infra scheme: %v", err)
+	}
+
+	infra := &infrav1alpha1.Sandbox0Infra{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "sandbox0-system",
+		},
+		Spec: infrav1alpha1.Sandbox0InfraSpec{
+			Database: &infrav1alpha1.DatabaseConfig{
+				Type: infrav1alpha1.DatabaseTypeBuiltin,
+				Builtin: &infrav1alpha1.BuiltinDatabaseConfig{
+					Enabled:  true,
+					Port:     5432,
+					Username: "sandbox0",
+					Database: "sandbox0",
+					SSLMode:  "disable",
+				},
+			},
+			Services: &infrav1alpha1.ServicesConfig{
+				GlobalGateway: &infrav1alpha1.GlobalGatewayServiceConfig{
+					WorkloadServiceConfig: infrav1alpha1.WorkloadServiceConfig{
+						EnabledServiceConfig: infrav1alpha1.EnabledServiceConfig{Enabled: true},
+						Replicas:             1,
+					},
+					Config: &infrav1alpha1.GlobalGatewayConfig{
+						GatewayConfig: infrav1alpha1.GatewayConfig{
+							BuiltInAuth: infrav1alpha1.BuiltInAuthConfig{
+								Enabled: false,
+							},
+							OIDCProviders: []infrav1alpha1.OIDCProviderConfig{
+								{Enabled: true},
+							},
+						},
+					},
+				},
+			},
+			InitUser: &infrav1alpha1.InitUserConfig{
+				Email: "admin@example.com",
+				Name:  "Admin",
+			},
+		},
+	}
+
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(
+			infra.DeepCopy(),
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "demo-sandbox0-database-credentials",
+					Namespace: infra.Namespace,
+				},
+				Data: map[string][]byte{
+					"username": []byte("sandbox0"),
+					"password": []byte("db-password"),
+					"database": []byte("sandbox0"),
+					"port":     []byte("5432"),
+				},
+			},
+		).
+		Build()
+
+	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
+	cfg, err := reconciler.buildConfig(context.Background(), infra)
+	if err != nil {
+		t.Fatalf("buildConfig returned error: %v", err)
+	}
+	if cfg.BuiltInAuth.InitUser == nil {
+		t.Fatal("expected init user config")
+	}
+	if cfg.BuiltInAuth.InitUser.Password != "" {
+		t.Fatalf("expected oidc-only init user password to be empty, got %q", cfg.BuiltInAuth.InitUser.Password)
+	}
+}
+
 func TestBuildConfigDerivesRegionFromPublicExposure(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := corev1.AddToScheme(scheme); err != nil {

--- a/infra-operator/internal/controller/services/regionalgateway/regionalgateway.go
+++ b/infra-operator/internal/controller/services/regionalgateway/regionalgateway.go
@@ -234,10 +234,14 @@ func (r *Reconciler) buildConfig(ctx context.Context, infra *infrav1alpha1.Sandb
 		authMode = "self_hosted"
 	}
 	if infra.Spec.InitUser != nil && authMode != "federated_global" {
-		secretRef := common.ResolveSecretKeyRef(infra.Spec.InitUser.PasswordSecret, "admin-password", "password")
-		password, err := common.GetSecretValue(ctx, r.Resources.Client, infra.Namespace, secretRef)
-		if err != nil {
-			return nil, nil, err
+		password := ""
+		if cfg.BuiltInAuth.Enabled || !apiconfig.HasEnabledOIDCProviders(cfg.OIDCProviders) {
+			secretRef := common.ResolveSecretKeyRef(infra.Spec.InitUser.PasswordSecret, "admin-password", "password")
+			var err error
+			password, err = common.GetSecretValue(ctx, r.Resources.Client, infra.Namespace, secretRef)
+			if err != nil {
+				return nil, nil, err
+			}
 		}
 
 		cfg.BuiltInAuth.InitUser = &apiconfig.InitUserConfig{

--- a/infra-operator/internal/controller/services/regionalgateway/regionalgateway_registry_test.go
+++ b/infra-operator/internal/controller/services/regionalgateway/regionalgateway_registry_test.go
@@ -258,3 +258,77 @@ func TestBuildConfigSkipsInitUserForFederatedGlobalAuth(t *testing.T) {
 		t.Fatalf("expected init user to be omitted for federated_global mode, got %#v", cfg.BuiltInAuth.InitUser)
 	}
 }
+
+func TestBuildConfigLeavesInitUserPasswordEmptyForOIDCOnlyBootstrap(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add corev1 scheme: %v", err)
+	}
+	if err := infrav1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add infra scheme: %v", err)
+	}
+
+	infra := &infrav1alpha1.Sandbox0Infra{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "s0cp",
+			Namespace: "sandbox0-system",
+		},
+		Spec: infrav1alpha1.Sandbox0InfraSpec{
+			InitUser: &infrav1alpha1.InitUserConfig{
+				Email: "admin@example.com",
+			},
+			Database: &infrav1alpha1.DatabaseConfig{
+				Type: infrav1alpha1.DatabaseTypeExternal,
+				External: &infrav1alpha1.ExternalDatabaseConfig{
+					Host:     "postgres.example.internal",
+					Port:     5432,
+					Database: "sandbox0",
+					Username: "sandbox0",
+					PasswordSecret: infrav1alpha1.SecretKeyRef{
+						Name: "regional-db",
+						Key:  "password",
+					},
+				},
+			},
+			Services: &infrav1alpha1.ServicesConfig{
+				RegionalGateway: &infrav1alpha1.RegionalGatewayServiceConfig{
+					WorkloadServiceConfig: infrav1alpha1.WorkloadServiceConfig{
+						EnabledServiceConfig: infrav1alpha1.EnabledServiceConfig{Enabled: true},
+					},
+					Config: &infrav1alpha1.RegionalGatewayConfig{
+						GatewayConfig: infrav1alpha1.GatewayConfig{
+							BuiltInAuth: infrav1alpha1.BuiltInAuthConfig{
+								Enabled: false,
+							},
+							OIDCProviders: []infrav1alpha1.OIDCProviderConfig{
+								{Enabled: true},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	dbSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "regional-db",
+			Namespace: "sandbox0-system",
+		},
+		Data: map[string][]byte{
+			"password": []byte("secret"),
+		},
+	}
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(dbSecret).Build()
+	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
+
+	cfg, _, err := reconciler.buildConfig(context.Background(), infra, infraplan.Compile(infra))
+	if err != nil {
+		t.Fatalf("buildConfig returned error: %v", err)
+	}
+	if cfg.BuiltInAuth.InitUser == nil {
+		t.Fatal("expected init user config")
+	}
+	if cfg.BuiltInAuth.InitUser.Password != "" {
+		t.Fatalf("expected oidc-only init user password to be empty, got %q", cfg.BuiltInAuth.InitUser.Password)
+	}
+}

--- a/infra-operator/internal/ownership/registry.go
+++ b/infra-operator/internal/ownership/registry.go
@@ -91,7 +91,7 @@ func Registry() []Entry {
 		exact("spec.publicExposure.regionId", "plan", []string{"global-gateway", "cluster-gateway", "manager"}, nil, UpdateSemanticsDeclarative, "Public DNS-safe region label feeds generated external URLs and callbacks."),
 
 		prefix("spec.cluster", "plan", []string{"manager", "netd", "status"}, []string{"InfraPlan.Manager.DefaultClusterID", "InfraPlan.Netd.ClusterID", "cluster registration"}, UpdateSemanticsDeclarative, "Cluster identity and capacity metadata propagated into manager, netd, and registration status."),
-		prefix("spec.initUser", "plan", []string{"global-gateway", "regional-gateway", "cluster-gateway", "database", "status"}, []string{"InfraPlan.Components.EnableInitUser"}, UpdateSemanticsDeclarative, "Initial admin bootstrap for self-hosted installs. Ignored for federated regional gateways and internal-only cluster gateways."),
+		prefix("spec.initUser", "plan", []string{"global-gateway", "regional-gateway", "cluster-gateway", "database"}, []string{"InfraPlan.Components.EnableInitUser"}, UpdateSemanticsDeclarative, "Initial admin bootstrap for self-hosted installs. Ignored for federated regional gateways and internal-only cluster gateways."),
 		prefix("spec.builtinTemplates", "manager", []string{"manager", "scheduler"}, nil, UpdateSemanticsDeclarative, "Builtin template seeds consumed by manager and scheduler template stores."),
 	}
 }

--- a/infra-operator/internal/plan/plan.go
+++ b/infra-operator/internal/plan/plan.go
@@ -482,9 +482,6 @@ func compileStatusPlan(compiled *InfraPlan) StatusPlan {
 	if components.EnableFusePlugin {
 		expected = append(expected, infrav1alpha1.ConditionTypeFusePluginReady)
 	}
-	if components.EnableInitUser {
-		expected = append(expected, infrav1alpha1.ConditionTypeInitUserReady)
-	}
 	if components.EnableClusterRegistration {
 		expected = append(expected, infrav1alpha1.ConditionTypeClusterRegistered)
 	}
@@ -542,7 +539,7 @@ func compileWorkflowPlan(compiled *InfraPlan) WorkflowPlan {
 	if compiled.Components.EnableGlobalGateway {
 		appendSuccessStep("global-gateway", infrav1alpha1.ConditionTypeGlobalGatewayReady, "GlobalGatewayReady", "Global gateway is ready", "GlobalGatewayFailed")
 	}
-	if compiled.Components.EnableInitUser {
+	if compiled.Components.EnableInitUser && InitUserPasswordSecretRequired(compiled.infra) {
 		appendSuccessStep("init-user-secret", infrav1alpha1.ConditionTypeSecretsGenerated, "InitUserSecretReady", "Init user password secret is ready", "InitUserSecretFailed")
 	}
 	if compiled.Components.EnableRegionalGateway && compiled.Enterprise.RegionalGateway {
@@ -579,9 +576,6 @@ func compileWorkflowPlan(compiled *InfraPlan) WorkflowPlan {
 	if compiled.Components.EnableStorageProxy {
 		appendCheckStep("storage-proxy-rbac", infrav1alpha1.ConditionTypeStorageProxyReady, "StorageProxyRBACFailed")
 		appendSuccessStep("storage-proxy", infrav1alpha1.ConditionTypeStorageProxyReady, "StorageProxyReady", "Storage proxy is ready", "StorageProxyFailed")
-	}
-	if compiled.Components.EnableInitUser {
-		appendSuccessStep("init-user", infrav1alpha1.ConditionTypeInitUserReady, "InitUserReady", "Initial admin user created", "InitUserFailed")
 	}
 	if compiled.Components.EnableClusterRegistration {
 		appendSuccessStep("register-cluster", infrav1alpha1.ConditionTypeClusterRegistered, "ClusterRegistered", "Cluster registration completed", "ClusterRegistrationFailed")
@@ -804,6 +798,46 @@ func initUserConsumerEnabled(infra *infrav1alpha1.Sandbox0Infra) bool {
 		return true
 	}
 	return false
+}
+
+func InitUserPasswordSecretRequired(infra *infrav1alpha1.Sandbox0Infra) bool {
+	if infra == nil || infra.Spec.InitUser == nil {
+		return false
+	}
+	if infrav1alpha1.IsGlobalGatewayEnabled(infra) && globalGatewayInitUserPasswordRequired(infra) {
+		return true
+	}
+	if infrav1alpha1.IsRegionalGatewayEnabled(infra) && regionalGatewayAuthMode(infra) != "federated_global" && regionalGatewayInitUserPasswordRequired(infra) {
+		return true
+	}
+	if infrav1alpha1.IsClusterGatewayEnabled(infra) && clusterGatewayPublicAuthEnabled(clusterGatewayAuthMode(infra)) && clusterGatewayInitUserPasswordRequired(infra) {
+		return true
+	}
+	return false
+}
+
+func globalGatewayInitUserPasswordRequired(infra *infrav1alpha1.Sandbox0Infra) bool {
+	if infra == nil || infra.Spec.Services == nil || infra.Spec.Services.GlobalGateway == nil || infra.Spec.Services.GlobalGateway.Config == nil {
+		return true
+	}
+	cfg := infra.Spec.Services.GlobalGateway.Config
+	return cfg.BuiltInAuth.Enabled || !hasEnabledOIDCProviders(cfg.OIDCProviders)
+}
+
+func regionalGatewayInitUserPasswordRequired(infra *infrav1alpha1.Sandbox0Infra) bool {
+	if infra == nil || infra.Spec.Services == nil || infra.Spec.Services.RegionalGateway == nil || infra.Spec.Services.RegionalGateway.Config == nil {
+		return true
+	}
+	cfg := infra.Spec.Services.RegionalGateway.Config
+	return cfg.BuiltInAuth.Enabled || !hasEnabledOIDCProviders(cfg.OIDCProviders)
+}
+
+func clusterGatewayInitUserPasswordRequired(infra *infrav1alpha1.Sandbox0Infra) bool {
+	if infra == nil || infra.Spec.Services == nil || infra.Spec.Services.ClusterGateway == nil || infra.Spec.Services.ClusterGateway.Config == nil {
+		return true
+	}
+	cfg := infra.Spec.Services.ClusterGateway.Config
+	return cfg.BuiltInAuth.Enabled || !hasEnabledOIDCProviders(cfg.OIDCProviders)
 }
 
 func regionalGatewayEnterpriseLicenseRequired(infra *infrav1alpha1.Sandbox0Infra) bool {

--- a/infra-operator/internal/plan/plan_test.go
+++ b/infra-operator/internal/plan/plan_test.go
@@ -683,7 +683,6 @@ func TestCompileTracksWorkflowRequirements(t *testing.T) {
 		"netd",
 		"storage-proxy-rbac",
 		"storage-proxy",
-		"init-user",
 		"register-cluster",
 	}
 	if len(got) != len(want) {
@@ -693,6 +692,45 @@ func TestCompileTracksWorkflowRequirements(t *testing.T) {
 		if got[i] != want[i] {
 			t.Fatalf("expected workflow step[%d]=%q, got %#v", i, want[i], got)
 		}
+	}
+}
+
+func TestCompileSkipsInitUserSecretStepForOIDCOnlyBootstrap(t *testing.T) {
+	infra := &infrav1alpha1.Sandbox0Infra{
+		Spec: infrav1alpha1.Sandbox0InfraSpec{
+			InitUser: &infrav1alpha1.InitUserConfig{
+				Email: "admin@example.com",
+			},
+			Database: &infrav1alpha1.DatabaseConfig{
+				Type: infrav1alpha1.DatabaseTypeBuiltin,
+			},
+			Services: &infrav1alpha1.ServicesConfig{
+				GlobalGateway: &infrav1alpha1.GlobalGatewayServiceConfig{
+					WorkloadServiceConfig: infrav1alpha1.WorkloadServiceConfig{
+						EnabledServiceConfig: infrav1alpha1.EnabledServiceConfig{Enabled: true},
+					},
+					Config: &infrav1alpha1.GlobalGatewayConfig{
+						GatewayConfig: infrav1alpha1.GatewayConfig{
+							BuiltInAuth: infrav1alpha1.BuiltInAuthConfig{
+								Enabled: false,
+							},
+							OIDCProviders: []infrav1alpha1.OIDCProviderConfig{
+								{Enabled: true},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	compiled := Compile(infra)
+	got := workflowStepNames(compiled.Workflow.Steps)
+	if containsString(got, "init-user-secret") {
+		t.Fatalf("expected oidc-only bootstrap to skip init-user-secret, got %#v", got)
+	}
+	if !compiled.Components.EnableInitUser {
+		t.Fatal("expected init user bootstrap to remain enabled")
 	}
 }
 

--- a/pkg/gateway/auth/builtin/provider.go
+++ b/pkg/gateway/auth/builtin/provider.go
@@ -12,23 +12,36 @@ import (
 )
 
 var (
-	ErrInvalidCredentials   = errors.New("invalid email or password")
-	ErrRegistrationDisabled = errors.New("registration is disabled")
-	ErrEmailAlreadyExists   = errors.New("email already exists")
-	ErrBuiltInAuthDisabled  = errors.New("built-in authentication is disabled")
-	ErrAdminOnlyAuth        = errors.New("only admin accounts can use built-in auth")
-	ErrPasswordTooWeak      = errors.New("password must be at least 8 characters")
+	ErrInvalidCredentials      = errors.New("invalid email or password")
+	ErrRegistrationDisabled    = errors.New("registration is disabled")
+	ErrEmailAlreadyExists      = errors.New("email already exists")
+	ErrBuiltInAuthDisabled     = errors.New("built-in authentication is disabled")
+	ErrAdminOnlyAuth           = errors.New("only admin accounts can use built-in auth")
+	ErrPasswordTooWeak         = errors.New("password must be at least 8 characters")
+	ErrInitUserPasswordMissing = errors.New("init user password is required when built-in authentication is enabled")
 )
+
+type identityStore interface {
+	GetUserByEmail(ctx context.Context, email string) (*identity.User, error)
+	CreateUserWithDefaultTeam(ctx context.Context, user *identity.User, teamName string, homeRegionID *string) (*identity.Team, *identity.TeamMember, error)
+	GetUserByID(ctx context.Context, id string) (*identity.User, error)
+	UpdateUserPassword(ctx context.Context, userID, passwordHash string) error
+	CountUsers(ctx context.Context) (int64, error)
+	CreateUser(ctx context.Context, user *identity.User) error
+	CreateTeam(ctx context.Context, team *identity.Team) error
+	AddTeamMember(ctx context.Context, member *identity.TeamMember) error
+	UpdateUser(ctx context.Context, user *identity.User) error
+}
 
 // Provider handles built-in email/password authentication
 type Provider struct {
-	repo            *identity.Repository
+	repo            identityStore
 	config          *config.BuiltInAuthConfig
 	defaultTeamName string
 }
 
 // NewProvider creates a new built-in auth provider
-func NewProvider(repo *identity.Repository, cfg *config.BuiltInAuthConfig, defaultTeamName string) *Provider {
+func NewProvider(repo identityStore, cfg *config.BuiltInAuthConfig, defaultTeamName string) *Provider {
 	return &Provider{
 		repo:            repo,
 		config:          cfg,
@@ -172,16 +185,22 @@ func (p *Provider) EnsureInitUser(ctx context.Context) error {
 		return nil
 	}
 
-	// Create initial user
-	passwordHash, err := bcrypt.GenerateFromPassword([]byte(p.config.InitUser.Password), bcrypt.DefaultCost)
-	if err != nil {
-		return fmt.Errorf("hash password: %w", err)
+	passwordHash := ""
+	if p.config.Enabled {
+		if strings.TrimSpace(p.config.InitUser.Password) == "" {
+			return ErrInitUserPasswordMissing
+		}
+		hashedPassword, err := bcrypt.GenerateFromPassword([]byte(p.config.InitUser.Password), bcrypt.DefaultCost)
+		if err != nil {
+			return fmt.Errorf("hash password: %w", err)
+		}
+		passwordHash = string(hashedPassword)
 	}
 
 	user := &identity.User{
 		Email:         p.config.InitUser.Email,
 		Name:          p.config.InitUser.Name,
-		PasswordHash:  string(passwordHash),
+		PasswordHash:  passwordHash,
 		EmailVerified: true,
 		IsAdmin:       true,
 	}

--- a/pkg/gateway/auth/builtin/provider_test.go
+++ b/pkg/gateway/auth/builtin/provider_test.go
@@ -1,0 +1,215 @@
+package builtin
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/identity"
+	"golang.org/x/crypto/bcrypt"
+)
+
+type fakeIdentityStore struct {
+	usersByID    map[string]*identity.User
+	usersByEmail map[string]*identity.User
+	teamsByID    map[string]*identity.Team
+	members      []*identity.TeamMember
+	nextID       int
+}
+
+func newFakeIdentityStore() *fakeIdentityStore {
+	return &fakeIdentityStore{
+		usersByID:    map[string]*identity.User{},
+		usersByEmail: map[string]*identity.User{},
+		teamsByID:    map[string]*identity.Team{},
+	}
+}
+
+func (f *fakeIdentityStore) next(prefix string) string {
+	f.nextID++
+	return fmt.Sprintf("%s-%d", prefix, f.nextID)
+}
+
+func (f *fakeIdentityStore) GetUserByEmail(_ context.Context, email string) (*identity.User, error) {
+	user, ok := f.usersByEmail[email]
+	if !ok {
+		return nil, identity.ErrUserNotFound
+	}
+	copy := *user
+	return &copy, nil
+}
+
+func (f *fakeIdentityStore) CreateUserWithDefaultTeam(_ context.Context, user *identity.User, teamName string, homeRegionID *string) (*identity.Team, *identity.TeamMember, error) {
+	if _, exists := f.usersByEmail[user.Email]; exists {
+		return nil, nil, identity.ErrUserAlreadyExists
+	}
+	createdUser := *user
+	createdUser.ID = f.next("user")
+	team := &identity.Team{
+		ID:           f.next("team"),
+		Name:         teamName,
+		Slug:         "user-" + createdUser.ID,
+		OwnerID:      &createdUser.ID,
+		HomeRegionID: homeRegionID,
+	}
+	member := &identity.TeamMember{
+		ID:     f.next("member"),
+		TeamID: team.ID,
+		UserID: createdUser.ID,
+		Role:   "admin",
+	}
+	createdUser.DefaultTeamID = &team.ID
+	createdUser.DefaultTeam = team
+	f.usersByID[createdUser.ID] = &createdUser
+	f.usersByEmail[createdUser.Email] = &createdUser
+	f.teamsByID[team.ID] = team
+	f.members = append(f.members, member)
+	*user = createdUser
+	return team, member, nil
+}
+
+func (f *fakeIdentityStore) GetUserByID(_ context.Context, id string) (*identity.User, error) {
+	user, ok := f.usersByID[id]
+	if !ok {
+		return nil, identity.ErrUserNotFound
+	}
+	copy := *user
+	return &copy, nil
+}
+
+func (f *fakeIdentityStore) UpdateUserPassword(_ context.Context, userID, passwordHash string) error {
+	user, ok := f.usersByID[userID]
+	if !ok {
+		return identity.ErrUserNotFound
+	}
+	user.PasswordHash = passwordHash
+	return nil
+}
+
+func (f *fakeIdentityStore) CountUsers(_ context.Context) (int64, error) {
+	return int64(len(f.usersByID)), nil
+}
+
+func (f *fakeIdentityStore) CreateUser(_ context.Context, user *identity.User) error {
+	if _, exists := f.usersByEmail[user.Email]; exists {
+		return identity.ErrUserAlreadyExists
+	}
+	createdUser := *user
+	createdUser.ID = f.next("user")
+	f.usersByID[createdUser.ID] = &createdUser
+	f.usersByEmail[createdUser.Email] = &createdUser
+	*user = createdUser
+	return nil
+}
+
+func (f *fakeIdentityStore) CreateTeam(_ context.Context, team *identity.Team) error {
+	createdTeam := *team
+	createdTeam.ID = f.next("team")
+	f.teamsByID[createdTeam.ID] = &createdTeam
+	*team = createdTeam
+	return nil
+}
+
+func (f *fakeIdentityStore) AddTeamMember(_ context.Context, member *identity.TeamMember) error {
+	createdMember := *member
+	createdMember.ID = f.next("member")
+	f.members = append(f.members, &createdMember)
+	*member = createdMember
+	return nil
+}
+
+func (f *fakeIdentityStore) UpdateUser(_ context.Context, user *identity.User) error {
+	stored, ok := f.usersByID[user.ID]
+	if !ok {
+		return identity.ErrUserNotFound
+	}
+	*stored = *user
+	f.usersByEmail[user.Email] = stored
+	return nil
+}
+
+func TestEnsureInitUserCreatesAdminWithPasswordWhenBuiltInEnabled(t *testing.T) {
+	store := newFakeIdentityStore()
+	provider := NewProvider(store, &config.BuiltInAuthConfig{
+		Enabled: true,
+		InitUser: &config.InitUserConfig{
+			Email:    "admin@example.com",
+			Name:     "Admin",
+			Password: "super-secret",
+		},
+	}, "Personal Team")
+
+	if err := provider.EnsureInitUser(context.Background()); err != nil {
+		t.Fatalf("EnsureInitUser: %v", err)
+	}
+
+	user, err := store.GetUserByEmail(context.Background(), "admin@example.com")
+	if err != nil {
+		t.Fatalf("GetUserByEmail: %v", err)
+	}
+	if !user.IsAdmin {
+		t.Fatal("expected init user to be admin")
+	}
+	if user.DefaultTeamID == nil || *user.DefaultTeamID == "" {
+		t.Fatal("expected init user to have a default team")
+	}
+	if err := bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte("super-secret")); err != nil {
+		t.Fatalf("expected stored password hash to match: %v", err)
+	}
+}
+
+func TestEnsureInitUserCreatesPasswordlessAdminWhenBuiltInAuthDisabled(t *testing.T) {
+	store := newFakeIdentityStore()
+	provider := NewProvider(store, &config.BuiltInAuthConfig{
+		Enabled: false,
+		InitUser: &config.InitUserConfig{
+			Email: "admin@example.com",
+			Name:  "Admin",
+		},
+	}, "Personal Team")
+
+	if err := provider.EnsureInitUser(context.Background()); err != nil {
+		t.Fatalf("EnsureInitUser: %v", err)
+	}
+
+	user, err := store.GetUserByEmail(context.Background(), "admin@example.com")
+	if err != nil {
+		t.Fatalf("GetUserByEmail: %v", err)
+	}
+	if !user.IsAdmin {
+		t.Fatal("expected init user to be admin")
+	}
+	if user.PasswordHash != "" {
+		t.Fatalf("expected no password hash for OIDC bootstrap user, got %q", user.PasswordHash)
+	}
+	if user.DefaultTeamID == nil || *user.DefaultTeamID == "" {
+		t.Fatal("expected init user to have a default team")
+	}
+}
+
+func TestEnsureInitUserSkipsWhenUsersAlreadyExist(t *testing.T) {
+	store := newFakeIdentityStore()
+	if err := store.CreateUser(context.Background(), &identity.User{
+		Email: "existing@example.com",
+		Name:  "Existing",
+	}); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	provider := NewProvider(store, &config.BuiltInAuthConfig{
+		Enabled: true,
+		InitUser: &config.InitUserConfig{
+			Email:    "admin@example.com",
+			Name:     "Admin",
+			Password: "super-secret",
+		},
+	}, "Personal Team")
+
+	if err := provider.EnsureInitUser(context.Background()); err != nil {
+		t.Fatalf("EnsureInitUser: %v", err)
+	}
+
+	if _, err := store.GetUserByEmail(context.Background(), "admin@example.com"); err == nil {
+		t.Fatal("expected init user bootstrap to be skipped when users already exist")
+	}
+}

--- a/regional-gateway/pkg/http/server.go
+++ b/regional-gateway/pkg/http/server.go
@@ -193,8 +193,8 @@ func NewServer(
 		}
 	}
 
-	// Ensure initial user exists (for self-hosted deployments)
-	if selfHostedAuthEnabled && cfg.BuiltInAuth.Enabled && cfg.BuiltInAuth.InitUser != nil {
+	// Ensure the bootstrap admin exists for self-hosted identity, including OIDC-only deployments.
+	if selfHostedAuthEnabled && cfg.BuiltInAuth.InitUser != nil && (cfg.BuiltInAuth.Enabled || oidcConfigured) {
 		if err := builtinProvider.EnsureInitUser(ctx); err != nil {
 			logger.Warn("Failed to ensure init user", zap.Error(err))
 		}

--- a/skills/sandbox0/references/docs-src/self-hosted/configuration/page.mdx
+++ b/skills/sandbox0/references/docs-src/self-hosted/configuration/page.mdx
@@ -24,6 +24,9 @@ A `Sandbox0Infra` spec is easier to reason about when you split it into five lay
 4. Seed templates and initial admin user.
 5. Only then tune per-service `config` blocks.
 
+`spec.initUser` is consumed by the gateway runtime, not created by the operator itself.
+In local-password mode it bootstraps the first admin credentials; in OIDC-only mode it pre-creates the admin user and default team so the first OIDC login with the same email lands on the intended admin account.
+
 ## Deployment Profiles
 
 | Profile | Typical fields | Use when |

--- a/skills/sandbox0/references/docs-src/self-hosted/install/page.mdx
+++ b/skills/sandbox0/references/docs-src/self-hosted/install/page.mdx
@@ -96,7 +96,11 @@ Expected `status.phase` lifecycle:
 
 ## 3) Initial Admin Credentials
 
-If `spec.initUser.passwordSecret` is not provided, operator generates `admin-password`.
+When local password bootstrap is enabled, if `spec.initUser.passwordSecret` is not provided, operator generates `admin-password`.
+
+When built-in auth is enabled, the gateway bootstraps the initial admin with that password on first start.
+When built-in auth is disabled but OIDC is enabled, the operator skips generating the password secret and the gateway still bootstraps the admin user and default team,
+but leaves the account passwordless so the first OIDC login for the same email can bind to that admin account.
 
 ```bash
 ADMIN_PASSWORD="$(kubectl get secret admin-password -n sandbox0-system -o jsonpath='{.data.password}' | base64 -d)"


### PR DESCRIPTION
## Summary
- remove the operator-only init-user creation step and keep initUser as gateway bootstrap config
- bootstrap init users in OIDC-only deployments without requiring a local password
- skip generating admin-password secrets when initUser is only used for OIDC bootstrap
- add coverage for plan gating and gateway config generation, and update self-hosted docs

## Testing
- go test ./infra-operator/internal/plan ./infra-operator/internal/controller/... ./global-gateway/pkg/http ./regional-gateway/pkg/http ./cluster-gateway/pkg/http ./pkg/gateway/auth/builtin