### PR TITLE
Set the first created team as the default

### DIFF
--- a/pkg/gateway/http/handlers/team.go
+++ b/pkg/gateway/http/handlers/team.go
@@ -16,7 +16,7 @@ import (
 
 type teamRepository interface {
 	GetTeamsByUserID(ctx context.Context, userID string) ([]*identity.Team, error)
-	CreateTeam(ctx context.Context, team *identity.Team) error
+	CreateTeamForUser(ctx context.Context, userID string, team *identity.Team) (bool, error)
 	GetTeamMember(ctx context.Context, teamID, userID string) (*identity.TeamMember, error)
 	GetTeamByID(ctx context.Context, id string) (*identity.Team, error)
 	UpdateTeam(ctx context.Context, team *identity.Team) error
@@ -122,7 +122,7 @@ func (h *TeamHandler) CreateTeam(c *gin.Context) {
 		HomeRegionID: homeRegionID,
 	}
 
-	if err := h.repo.CreateTeam(c.Request.Context(), team); err != nil {
+	if _, err := h.repo.CreateTeamForUser(c.Request.Context(), authCtx.UserID, team); err != nil {
 		if errors.Is(err, identity.ErrTeamAlreadyExists) {
 			spec.JSONError(c, http.StatusConflict, spec.CodeConflict, "team with this slug already exists")
 			return
@@ -130,16 +130,6 @@ func (h *TeamHandler) CreateTeam(c *gin.Context) {
 		h.logger.Error("Failed to create team", zap.Error(err))
 		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to create team")
 		return
-	}
-
-	// Add creator as admin member
-	member := &identity.TeamMember{
-		TeamID: team.ID,
-		UserID: authCtx.UserID,
-		Role:   "admin",
-	}
-	if err := h.repo.AddTeamMember(c.Request.Context(), member); err != nil {
-		h.logger.Warn("Failed to add creator as member", zap.Error(err))
 	}
 
 	spec.JSONSuccess(c, http.StatusCreated, team)

--- a/pkg/gateway/http/handlers/team_test.go
+++ b/pkg/gateway/http/handlers/team_test.go
@@ -18,20 +18,21 @@ import (
 )
 
 type stubTeamRepository struct {
-	createdTeam     *identity.Team
-	addedTeamMember *identity.TeamMember
+	createdTeam      *identity.Team
+	createTeamUserID string
 }
 
 func (s *stubTeamRepository) GetTeamsByUserID(context.Context, string) ([]*identity.Team, error) {
 	return nil, nil
 }
 
-func (s *stubTeamRepository) CreateTeam(_ context.Context, team *identity.Team) error {
+func (s *stubTeamRepository) CreateTeamForUser(_ context.Context, userID string, team *identity.Team) (bool, error) {
 	copyTeam := *team
 	copyTeam.ID = "team-1"
 	s.createdTeam = &copyTeam
+	s.createTeamUserID = userID
 	team.ID = copyTeam.ID
-	return nil
+	return true, nil
 }
 
 func (s *stubTeamRepository) GetTeamMember(context.Context, string, string) (*identity.TeamMember, error) {
@@ -59,8 +60,6 @@ func (s *stubTeamRepository) GetUserByEmail(context.Context, string) (*identity.
 }
 
 func (s *stubTeamRepository) AddTeamMember(_ context.Context, member *identity.TeamMember) error {
-	copyMember := *member
-	s.addedTeamMember = &copyMember
 	return nil
 }
 
@@ -203,8 +202,8 @@ func TestTeamHandlerCreateTeamAllowsMissingHomeRegionWithoutGlobalRequirement(t 
 	if repo.createdTeam.HomeRegionID != nil {
 		t.Fatalf("expected nil home region, got %#v", repo.createdTeam.HomeRegionID)
 	}
-	if repo.addedTeamMember == nil || repo.addedTeamMember.TeamID != "team-1" {
-		t.Fatalf("expected creator to be added as team member, got %#v", repo.addedTeamMember)
+	if repo.createTeamUserID != "user-1" {
+		t.Fatalf("expected CreateTeamForUser to receive user-1, got %q", repo.createTeamUserID)
 	}
 }
 

--- a/pkg/gateway/identity/team_repository.go
+++ b/pkg/gateway/identity/team_repository.go
@@ -30,6 +30,91 @@ func (r *Repository) CreateTeam(ctx context.Context, team *Team) error {
 	return nil
 }
 
+// CreateTeamForUser creates a team, adds the creator as an admin member, and
+// sets it as the user's default team only when it is their first team.
+func (r *Repository) CreateTeamForUser(ctx context.Context, userID string, team *Team) (setAsDefault bool, err error) {
+	if team.Slug == "" {
+		team.Slug = generateSlug(team.Name)
+	}
+
+	tx, err := r.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return false, fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback(ctx)
+		}
+	}()
+
+	var lockedUserID string
+	if err = tx.QueryRow(ctx, `
+		SELECT id
+		FROM users
+		WHERE id = $1
+		FOR UPDATE
+	`, userID).Scan(&lockedUserID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return false, ErrUserNotFound
+		}
+		return false, fmt.Errorf("lock user: %w", err)
+	}
+
+	var hasExistingTeam bool
+	if err = tx.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM team_members
+			WHERE user_id = $1
+		)
+	`, userID).Scan(&hasExistingTeam); err != nil {
+		return false, fmt.Errorf("check existing teams: %w", err)
+	}
+
+	if err = tx.QueryRow(ctx, `
+		INSERT INTO teams (name, slug, owner_id, home_region_id)
+		VALUES ($1, $2, $3, $4)
+		RETURNING id, created_at, updated_at
+	`, team.Name, team.Slug, team.OwnerID, team.HomeRegionID).Scan(&team.ID, &team.CreatedAt, &team.UpdatedAt); err != nil {
+		if isDuplicateKeyError(err) {
+			return false, ErrTeamAlreadyExists
+		}
+		return false, fmt.Errorf("insert team: %w", err)
+	}
+
+	member := &TeamMember{
+		TeamID: team.ID,
+		UserID: userID,
+		Role:   "admin",
+	}
+	if err = tx.QueryRow(ctx, `
+		INSERT INTO team_members (team_id, user_id, role)
+		VALUES ($1, $2, $3)
+		RETURNING id, joined_at
+	`, member.TeamID, member.UserID, member.Role).Scan(&member.ID, &member.JoinedAt); err != nil {
+		if isDuplicateKeyError(err) {
+			return false, ErrAlreadyMember
+		}
+		return false, fmt.Errorf("insert team member: %w", err)
+	}
+
+	if !hasExistingTeam {
+		if _, err = tx.Exec(ctx, `
+			UPDATE users
+			SET default_team_id = $2
+			WHERE id = $1
+		`, userID, team.ID); err != nil {
+			return false, fmt.Errorf("update user default team: %w", err)
+		}
+		setAsDefault = true
+	}
+
+	if err = tx.Commit(ctx); err != nil {
+		return false, fmt.Errorf("commit tx: %w", err)
+	}
+	return setAsDefault, nil
+}
+
 // GetTeamByID retrieves a team by ID.
 func (r *Repository) GetTeamByID(ctx context.Context, id string) (*Team, error) {
 	var team Team

--- a/tests/integration/internal/tests/cluster-gateway/auth_test.go
+++ b/tests/integration/internal/tests/cluster-gateway/auth_test.go
@@ -282,6 +282,24 @@ func TestClusterGatewayIntegration_PublicAuthTeamsAcceptHomeRegionID(t *testing.
 		t.Fatalf("expected created team home region aws/us-east-1, got %#v", createBody.Data.HomeRegionID)
 	}
 
+	userResp, _ := doGatewayRequestWithBearer(t, env.server.Client(), http.MethodGet, env.server.URL+"/users/me", tokens.AccessToken, nil)
+	defer userResp.Body.Close()
+	if userResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected user profile ok, got %d", userResp.StatusCode)
+	}
+
+	var userBody struct {
+		Data struct {
+			DefaultTeamID *string `json:"default_team_id"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(userResp.Body).Decode(&userBody); err != nil {
+		t.Fatalf("decode user response: %v", err)
+	}
+	if userBody.Data.DefaultTeamID == nil || *userBody.Data.DefaultTeamID != team.ID {
+		t.Fatalf("expected existing default team %q to be preserved, got %#v", team.ID, userBody.Data.DefaultTeamID)
+	}
+
 	updateResp, _ := doGatewayRequestWithBearer(t, env.server.Client(), http.MethodPut, env.server.URL+"/teams/"+createBody.Data.ID, tokens.AccessToken, map[string]any{
 		"home_region_id": "aws/us-west-2",
 	})
@@ -318,5 +336,73 @@ func TestClusterGatewayIntegration_PublicAuthTeamsAcceptHomeRegionID(t *testing.
 	}
 	if getBody.Data.HomeRegionID == nil || *getBody.Data.HomeRegionID != "aws/us-east-1" {
 		t.Fatalf("expected persisted team home region aws/us-east-1, got %#v", getBody.Data.HomeRegionID)
+	}
+}
+
+func TestClusterGatewayIntegration_CreateFirstTeamSetsDefaultTeam(t *testing.T) {
+	dbPool, identityRepo, _, _ := newGatewayTestDB(t)
+
+	keys := gatewayKeyPair{}
+	keys.privateKey, keys.publicKey = writeClusterGatewayKeys(t)
+
+	managerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(managerServer.Close)
+
+	env := newGatewayPublicTestEnv(t, managerServer.URL, "", dbPool, "test-jwt-secret", "cluster-gateway", keys)
+
+	user := &gatewayidentity.User{
+		Email:         "first-team@example.com",
+		Name:          "First Team User",
+		PasswordHash:  "x",
+		EmailVerified: true,
+		IsAdmin:       false,
+	}
+	ctx := context.Background()
+	if err := identityRepo.CreateUser(ctx, user); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	issuer := authn.NewIssuer("cluster-gateway", "test-jwt-secret", time.Minute, time.Hour)
+	tokens, err := issuer.IssueTokenPair(user.ID, "", "", user.Email, user.Name, user.IsAdmin)
+	if err != nil {
+		t.Fatalf("issue token pair: %v", err)
+	}
+
+	resp, _ := doGatewayRequestWithBearer(t, env.server.Client(), http.MethodPost, env.server.URL+"/teams", tokens.AccessToken, map[string]any{
+		"name":           "First Regional Team",
+		"home_region_id": "aws/us-east-1",
+	})
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected created, got %d", resp.StatusCode)
+	}
+
+	var createBody struct {
+		Data struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&createBody); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+
+	userResp, _ := doGatewayRequestWithBearer(t, env.server.Client(), http.MethodGet, env.server.URL+"/users/me", tokens.AccessToken, nil)
+	defer userResp.Body.Close()
+	if userResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected user profile ok, got %d", userResp.StatusCode)
+	}
+
+	var userBody struct {
+		Data struct {
+			DefaultTeamID *string `json:"default_team_id"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(userResp.Body).Decode(&userBody); err != nil {
+		t.Fatalf("decode user response: %v", err)
+	}
+	if userBody.Data.DefaultTeamID == nil || *userBody.Data.DefaultTeamID != createBody.Data.ID {
+		t.Fatalf("expected first created team %q to become default, got %#v", createBody.Data.ID, userBody.Data.DefaultTeamID)
 	}
 }


### PR DESCRIPTION
## Summary
- create teams through a single transactional repository path that always adds the creator as an admin member
- set `default_team_id` only when the user is creating their first team
- cover both first-team auto-selection and preserving an existing default team in integration tests

## Testing
- go test ./pkg/gateway/http/handlers ./pkg/gateway/identity
- go test ./tests/integration/internal/tests/cluster-gateway -run 'TestClusterGatewayIntegration_(PublicAuthTeamsAcceptHomeRegionID|CreateFirstTeamSetsDefaultTeam)'