### PR TITLE
Add netd MITM CA trust material for agent sidecars

### DIFF
--- a/infra-operator/api/config/manager.go
+++ b/infra-operator/api/config/manager.go
@@ -90,6 +90,10 @@ type ManagerConfig struct {
 	// +optional
 	// +kubebuilder:default="500ms"
 	NetdPolicyApplyPollInterval metav1.Duration `yaml:"netd_policy_apply_poll_interval" json:"netdPolicyApplyPollInterval"`
+	// +optional
+	NetdMITMCASecretName string `yaml:"netd_mitm_ca_secret_name" json:"-"`
+	// +optional
+	NetdMITMCASecretNamespace string `yaml:"netd_mitm_ca_secret_namespace" json:"-"`
 
 	// Pause/Resume
 	// +optional

--- a/infra-operator/internal/controller/services/manager/manager.go
+++ b/infra-operator/internal/controller/services/manager/manager.go
@@ -29,6 +29,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/pkg/common"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/database"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/internalauth"
+	netdservice "github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/netd"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/registry"
 	infraplan "github.com/sandbox0-ai/sandbox0/infra-operator/internal/plan"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/runtimeconfig"
@@ -285,6 +286,14 @@ func (r *Reconciler) buildConfig(ctx context.Context, infra *infrav1alpha1.Sandb
 	cfg.SandboxPodPlacement = compiledPlan.Manager.SandboxPodPlacement
 	cfg.DefaultClusterId = compiledPlan.Manager.DefaultClusterID
 	cfg.RegionID = compiledPlan.Manager.RegionID
+	if cfg.NetworkPolicyProvider == "netd" {
+		secretName, err := netdservice.EnsureMITMCASecret(ctx, r.Resources, infra, common.GetServiceLabels(infra.Name, "netd"))
+		if err != nil {
+			return nil, fmt.Errorf("ensure netd MITM CA secret: %w", err)
+		}
+		cfg.NetdMITMCASecretName = secretName
+		cfg.NetdMITMCASecretNamespace = infra.Namespace
+	}
 
 	cfg.ManagerImage = fmt.Sprintf("%s:%s", imageRepo, imageTag)
 

--- a/infra-operator/internal/controller/services/manager/manager_test.go
+++ b/infra-operator/internal/controller/services/manager/manager_test.go
@@ -1,11 +1,24 @@
 package manager
 
 import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	infrav1alpha1 "github.com/sandbox0-ai/sandbox0/infra-operator/api/v1alpha1"
+	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/pkg/common"
 	infraplan "github.com/sandbox0-ai/sandbox0/infra-operator/internal/plan"
 )
 
@@ -67,5 +80,168 @@ func TestCompilePlanSandboxPodPlacementPrefersSharedPlacement(t *testing.T) {
 	}
 	if len(placement.Tolerations) != 1 || placement.Tolerations[0].Key != "sandbox0.ai/sandbox" {
 		t.Fatalf("expected shared tolerations, got %#v", placement.Tolerations)
+	}
+}
+
+func TestBuildConfigPropagatesNetdMITMCASecretName(t *testing.T) {
+	t.Run("uses explicit secret name", func(t *testing.T) {
+		reconciler := newManagerTestReconciler(t)
+		if err := reconciler.Resources.Client.Create(context.Background(), newValidMITMCASecret(t, "sandbox0-system", "custom-netd-ca")); err != nil {
+			t.Fatalf("seed explicit netd mitm ca secret: %v", err)
+		}
+		infra := &infrav1alpha1.Sandbox0Infra{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "demo",
+				Namespace: "sandbox0-system",
+			},
+			Spec: infrav1alpha1.Sandbox0InfraSpec{
+				Database: &infrav1alpha1.DatabaseConfig{
+					Type: infrav1alpha1.DatabaseTypeBuiltin,
+					Builtin: &infrav1alpha1.BuiltinDatabaseConfig{
+						Enabled:  true,
+						Port:     5432,
+						Username: "sandbox0",
+						Database: "sandbox0",
+						SSLMode:  "disable",
+					},
+				},
+				Services: &infrav1alpha1.ServicesConfig{
+					Netd: &infrav1alpha1.NetdServiceConfig{
+						EnabledServiceConfig: infrav1alpha1.EnabledServiceConfig{Enabled: true},
+						MITMCASecretName:     "custom-netd-ca",
+					},
+				},
+			},
+		}
+
+		cfg, err := reconciler.buildConfig(context.Background(), infra, "sandbox0/manager", "test", infraplan.Compile(infra))
+		if err != nil {
+			t.Fatalf("buildConfig returned error: %v", err)
+		}
+		if cfg.NetdMITMCASecretName != "custom-netd-ca" {
+			t.Fatalf("netd mitm ca secret = %q, want custom-netd-ca", cfg.NetdMITMCASecretName)
+		}
+		if cfg.NetdMITMCASecretNamespace != "sandbox0-system" {
+			t.Fatalf("netd mitm ca secret namespace = %q, want sandbox0-system", cfg.NetdMITMCASecretNamespace)
+		}
+	})
+
+	t.Run("derives managed secret name when netd is enabled", func(t *testing.T) {
+		reconciler := newManagerTestReconciler(t)
+		infra := &infrav1alpha1.Sandbox0Infra{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "demo",
+				Namespace: "sandbox0-system",
+			},
+			Spec: infrav1alpha1.Sandbox0InfraSpec{
+				Database: &infrav1alpha1.DatabaseConfig{
+					Type: infrav1alpha1.DatabaseTypeBuiltin,
+					Builtin: &infrav1alpha1.BuiltinDatabaseConfig{
+						Enabled:  true,
+						Port:     5432,
+						Username: "sandbox0",
+						Database: "sandbox0",
+						SSLMode:  "disable",
+					},
+				},
+				Services: &infrav1alpha1.ServicesConfig{
+					Netd: &infrav1alpha1.NetdServiceConfig{
+						EnabledServiceConfig: infrav1alpha1.EnabledServiceConfig{Enabled: true},
+					},
+				},
+			},
+		}
+
+		cfg, err := reconciler.buildConfig(context.Background(), infra, "sandbox0/manager", "test", infraplan.Compile(infra))
+		if err != nil {
+			t.Fatalf("buildConfig returned error: %v", err)
+		}
+		if cfg.NetdMITMCASecretName != "demo-netd-mitm-ca" {
+			t.Fatalf("netd mitm ca secret = %q, want demo-netd-mitm-ca", cfg.NetdMITMCASecretName)
+		}
+		if cfg.NetdMITMCASecretNamespace != "sandbox0-system" {
+			t.Fatalf("netd mitm ca secret namespace = %q, want sandbox0-system", cfg.NetdMITMCASecretNamespace)
+		}
+
+		secret := &corev1.Secret{}
+		if err := reconciler.Resources.Client.Get(context.Background(), types.NamespacedName{
+			Namespace: "sandbox0-system",
+			Name:      "demo-netd-mitm-ca",
+		}, secret); err != nil {
+			t.Fatalf("expected managed netd mitm ca secret to be created: %v", err)
+		}
+	})
+}
+
+func newManagerTestReconciler(t *testing.T) *Reconciler {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+	if err := infrav1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add infra scheme: %v", err)
+	}
+
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "demo-sandbox0-database-credentials",
+				Namespace: "sandbox0-system",
+			},
+			Data: map[string][]byte{
+				"username": []byte("sandbox0"),
+				"password": []byte("db-password"),
+				"database": []byte("sandbox0"),
+				"port":     []byte("5432"),
+			},
+		}).
+		Build()
+	return NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
+}
+
+func newValidMITMCASecret(t *testing.T, namespace, name string) *corev1.Secret {
+	t.Helper()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate RSA key: %v", err)
+	}
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		t.Fatalf("generate serial: %v", err)
+	}
+
+	now := time.Now().UTC()
+	template := &x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			CommonName:   "test-netd-mitm-ca",
+			Organization: []string{"sandbox0"},
+		},
+		NotBefore:             now.Add(-time.Hour),
+		NotAfter:              now.Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		MaxPathLenZero:        true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"ca.crt": pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
+			"ca.key": pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privateKey)}),
+		},
 	}
 }

--- a/infra-operator/internal/controller/services/netd/mitm_ca.go
+++ b/infra-operator/internal/controller/services/netd/mitm_ca.go
@@ -10,15 +10,19 @@ import (
 	"encoding/pem"
 	"fmt"
 	"math/big"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	infrav1alpha1 "github.com/sandbox0-ai/sandbox0/infra-operator/api/v1alpha1"
+	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/pkg/common"
 )
 
 const (
@@ -30,9 +34,49 @@ func managedMITMCASecretName(infra *infrav1alpha1.Sandbox0Infra) string {
 	return fmt.Sprintf("%s-netd-mitm-ca", infra.Name)
 }
 
-func (r *Reconciler) reconcileManagedMITMCASecret(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, name string, labels map[string]string) error {
+func ResolveMITMCASecretName(infra *infrav1alpha1.Sandbox0Infra) string {
+	if infra == nil {
+		return ""
+	}
+	if infra.Spec.Services != nil && infra.Spec.Services.Netd != nil {
+		if secretName := strings.TrimSpace(infra.Spec.Services.Netd.MITMCASecretName); secretName != "" {
+			return secretName
+		}
+	}
+	if infra.Name == "" {
+		return ""
+	}
+	return managedMITMCASecretName(infra)
+}
+
+func EnsureMITMCASecret(ctx context.Context, resources *common.ResourceManager, infra *infrav1alpha1.Sandbox0Infra, labels map[string]string) (string, error) {
+	if infra == nil || infra.Spec.Services == nil || infra.Spec.Services.Netd == nil {
+		return "", nil
+	}
+	if resources == nil || resources.Client == nil || resources.Scheme == nil {
+		return "", fmt.Errorf("resource manager with client and scheme is required")
+	}
+
+	if secretName := strings.TrimSpace(infra.Spec.Services.Netd.MITMCASecretName); secretName != "" {
+		if err := validateExistingMITMCASecret(ctx, resources.Client, infra.Namespace, secretName); err != nil {
+			return "", err
+		}
+		return secretName, nil
+	}
+
+	if infra.Name == "" {
+		return "", nil
+	}
+	secretName := managedMITMCASecretName(infra)
+	if err := reconcileManagedMITMCASecret(ctx, resources.Client, resources.Scheme, infra, secretName, labels); err != nil {
+		return "", err
+	}
+	return secretName, nil
+}
+
+func reconcileManagedMITMCASecret(ctx context.Context, client ctrlclient.Client, scheme *runtime.Scheme, infra *infrav1alpha1.Sandbox0Infra, name string, labels map[string]string) error {
 	secret := &corev1.Secret{}
-	getErr := r.Resources.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: infra.Namespace}, secret)
+	getErr := client.Get(ctx, types.NamespacedName{Name: name, Namespace: infra.Namespace}, secret)
 	if getErr != nil && !apierrors.IsNotFound(getErr) {
 		return getErr
 	}
@@ -58,19 +102,30 @@ func (r *Reconciler) reconcileManagedMITMCASecret(ctx context.Context, infra *in
 			mitmCAKeyKey:  keyPEM,
 		},
 	}
-	if err := ctrl.SetControllerReference(infra, desired, r.Resources.Scheme); err != nil {
+	if err := ctrl.SetControllerReference(infra, desired, scheme); err != nil {
 		return err
 	}
 
 	if apierrors.IsNotFound(getErr) {
-		return r.Resources.Client.Create(ctx, desired)
+		return client.Create(ctx, desired)
 	}
 
 	secret.Type = desired.Type
 	secret.Data = desired.Data
 	secret.Labels = desired.Labels
 	secret.OwnerReferences = desired.OwnerReferences
-	return r.Resources.Client.Update(ctx, secret)
+	return client.Update(ctx, secret)
+}
+
+func validateExistingMITMCASecret(ctx context.Context, client ctrlclient.Client, namespace, name string) error {
+	secret := &corev1.Secret{}
+	if err := client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, secret); err != nil {
+		return fmt.Errorf("get MITM CA secret %s/%s: %w", namespace, name, err)
+	}
+	if err := validateMITMCASecret(secret); err != nil {
+		return fmt.Errorf("validate MITM CA secret %s/%s: %w", namespace, name, err)
+	}
+	return nil
 }
 
 func validateMITMCASecret(secret *corev1.Secret) error {

--- a/infra-operator/internal/controller/services/netd/netd.go
+++ b/infra-operator/internal/controller/services/netd/netd.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"strings"
 
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
@@ -292,19 +291,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 }
 
 func (r *Reconciler) resolveMITMCASecretName(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, labels map[string]string) (string, error) {
-	if infra == nil || infra.Spec.Services == nil || infra.Spec.Services.Netd == nil {
-		return "", nil
-	}
-
-	if secretName := strings.TrimSpace(infra.Spec.Services.Netd.MITMCASecretName); secretName != "" {
-		return secretName, nil
-	}
-
-	secretName := managedMITMCASecretName(infra)
-	if err := r.reconcileManagedMITMCASecret(ctx, infra, secretName, labels); err != nil {
-		return "", err
-	}
-	return secretName, nil
+	return EnsureMITMCASecret(ctx, r.Resources, infra, labels)
 }
 
 func resolveClusterDNSCIDR(ctx context.Context, client ctrlclient.Client, logger logr.Logger) (string, error) {

--- a/infra-operator/internal/controller/services/netd/netd_test.go
+++ b/infra-operator/internal/controller/services/netd/netd_test.go
@@ -92,7 +92,7 @@ func TestReconcileFallsBackToLegacyNetdPlacement(t *testing.T) {
 func TestReconcileMountsExplicitMITMCASecret(t *testing.T) {
 	infra := newNetdTestInfra()
 	infra.Spec.Services.Netd.MITMCASecretName = "netd-mitm-ca"
-	client, scheme := newNetdTestClient(t, infra.DeepCopy())
+	client, scheme := newNetdTestClient(t, infra.DeepCopy(), newExplicitMITMCASecret(t, infra, "netd-mitm-ca"))
 
 	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
 	if err := reconciler.Reconcile(context.Background(), infra, "ghcr.io/sandbox0-ai/sandbox0", "latest", nil); err != nil {
@@ -194,7 +194,7 @@ func TestReconcileRepairsInvalidManagedMITMCASecret(t *testing.T) {
 func TestReconcileExplicitMITMCASecretSkipsManagedSecret(t *testing.T) {
 	infra := newNetdTestInfra()
 	infra.Spec.Services.Netd.MITMCASecretName = "custom-mitm-ca"
-	client, scheme := newNetdTestClient(t, infra.DeepCopy())
+	client, scheme := newNetdTestClient(t, infra.DeepCopy(), newExplicitMITMCASecret(t, infra, "custom-mitm-ca"))
 	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
 
 	if err := reconciler.Reconcile(context.Background(), infra, "ghcr.io/sandbox0-ai/sandbox0", "latest", nil); err != nil {
@@ -350,6 +350,27 @@ func assertValidManagedMITMCASecret(t *testing.T, secret *corev1.Secret) {
 	}
 	if !cert.IsCA {
 		t.Fatalf("expected managed certificate to be a CA")
+	}
+}
+
+func newExplicitMITMCASecret(t *testing.T, infra *infrav1alpha1.Sandbox0Infra, name string) *corev1.Secret {
+	t.Helper()
+
+	certPEM, keyPEM, err := generateManagedMITMCA(infra)
+	if err != nil {
+		t.Fatalf("generate explicit mitm ca secret: %v", err)
+	}
+
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: infra.Namespace,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			mitmCACertKey: certPEM,
+			mitmCAKeyKey:  keyPEM,
+		},
 	}
 }
 

--- a/manager/pkg/apis/sandbox0/v1alpha1/helpers.go
+++ b/manager/pkg/apis/sandbox0/v1alpha1/helpers.go
@@ -13,6 +13,11 @@ import (
 const (
 	procdBinVolumeName = "procd-bin"
 	procdConfigVolume  = "procd-config"
+	netdMITMCAVolume   = "netd-mitm-ca"
+	netdMITMCACertKey  = "ca.crt"
+	netdMITMCAEnvVar   = "SANDBOX0_NETD_MITM_CA_FILE"
+	netdMITMCADir      = "/var/run/sandbox0/netd"
+	netdMITMCACertPath = netdMITMCADir + "/mitm-ca.crt"
 )
 
 // buildPodSpec builds a pod spec from a template
@@ -26,6 +31,7 @@ func BuildPodSpec(template *SandboxTemplate, restart bool) corev1.PodSpec {
 	}
 
 	applyProcdSecretVolume(&spec, template)
+	applyNetdMITMCATrustMaterial(&spec)
 	applyProcdInit(&spec)
 	applyFuseResource(&spec)
 	applyDefaultSandboxPlacement(&spec)
@@ -346,6 +352,85 @@ func applyProcdInit(spec *corev1.PodSpec) {
 			},
 		},
 	})
+}
+
+func applyNetdMITMCATrustMaterial(spec *corev1.PodSpec) {
+	if spec == nil {
+		return
+	}
+
+	cfg := config.LoadManagerConfig()
+	if cfg == nil || cfg.NetdMITMCASecretName == "" {
+		return
+	}
+
+	volumeFound := false
+	for i := range spec.Volumes {
+		if spec.Volumes[i].Name != netdMITMCAVolume {
+			continue
+		}
+		volumeFound = true
+		spec.Volumes[i].Secret = &corev1.SecretVolumeSource{
+			SecretName: cfg.NetdMITMCASecretName,
+			Items: []corev1.KeyToPath{
+				{
+					Key:  netdMITMCACertKey,
+					Path: "mitm-ca.crt",
+				},
+			},
+		}
+		break
+	}
+	if !volumeFound {
+		spec.Volumes = append(spec.Volumes, corev1.Volume{
+			Name: netdMITMCAVolume,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: cfg.NetdMITMCASecretName,
+					Items: []corev1.KeyToPath{
+						{
+							Key:  netdMITMCACertKey,
+							Path: "mitm-ca.crt",
+						},
+					},
+				},
+			},
+		})
+	}
+
+	for i := range spec.Containers {
+		ensureContainerEnvVar(&spec.Containers[i], corev1.EnvVar{
+			Name:  netdMITMCAEnvVar,
+			Value: netdMITMCACertPath,
+		})
+		ensureContainerVolumeMount(&spec.Containers[i], corev1.VolumeMount{
+			Name:      netdMITMCAVolume,
+			MountPath: netdMITMCADir,
+			ReadOnly:  true,
+		})
+	}
+}
+
+func ensureContainerEnvVar(container *corev1.Container, envVar corev1.EnvVar) {
+	for i := range container.Env {
+		if container.Env[i].Name != envVar.Name {
+			continue
+		}
+		container.Env[i] = envVar
+		return
+	}
+	container.Env = append(container.Env, envVar)
+}
+
+func ensureContainerVolumeMount(container *corev1.Container, mount corev1.VolumeMount) {
+	for i := range container.VolumeMounts {
+		if container.VolumeMounts[i].Name != mount.Name {
+			continue
+		}
+		container.VolumeMounts[i] = mount
+		return
+	}
+	container.VolumeMounts = append(container.VolumeMounts, mount)
 }
 
 // applyProcdSecretVolume mounts the procd config Secret into the pod spec.

--- a/manager/pkg/apis/sandbox0/v1alpha1/helpers_test.go
+++ b/manager/pkg/apis/sandbox0/v1alpha1/helpers_test.go
@@ -226,6 +226,77 @@ manager_image: sandbox0/manager:test
 	}
 }
 
+func TestBuildPodSpecInjectsNetdMITMCATrustMaterialIntoAllContainers(t *testing.T) {
+	configPath := writeManagerConfig(t, `
+manager_image: sandbox0/manager:test
+netd_mitm_ca_secret_name: fullmode-netd-mitm-ca
+`)
+	t.Setenv("CONFIG_PATH", configPath)
+
+	template := newTestTemplate()
+	template.Spec.Sidecars = []corev1.Container{
+		{
+			Name:  "sidecar",
+			Image: "busybox:latest",
+			Env: []corev1.EnvVar{
+				{Name: netdMITMCAEnvVar, Value: "/tmp/ignored.crt"},
+			},
+		},
+	}
+
+	spec := BuildPodSpec(template, false)
+
+	volume := findVolume(spec.Volumes, netdMITMCAVolume)
+	if volume == nil || volume.Secret == nil {
+		t.Fatalf("expected %s secret volume to be injected", netdMITMCAVolume)
+	}
+	if volume.Secret.SecretName != "fullmode-netd-mitm-ca" {
+		t.Fatalf("mitm ca secret = %q, want fullmode-netd-mitm-ca", volume.Secret.SecretName)
+	}
+	if len(volume.Secret.Items) != 1 || volume.Secret.Items[0].Key != netdMITMCACertKey || volume.Secret.Items[0].Path != "mitm-ca.crt" {
+		t.Fatalf("unexpected secret items: %#v", volume.Secret.Items)
+	}
+
+	for _, name := range []string{"procd", "sidecar"} {
+		container := findContainer(spec.Containers, name)
+		if container == nil {
+			t.Fatalf("expected container %q", name)
+		}
+
+		env := findEnvVar(container.Env, netdMITMCAEnvVar)
+		if env == nil || env.Value != netdMITMCACertPath {
+			t.Fatalf("%s env %s = %#v, want %q", name, netdMITMCAEnvVar, env, netdMITMCACertPath)
+		}
+
+		mount := findVolumeMount(container.VolumeMounts, netdMITMCAVolume)
+		if mount == nil {
+			t.Fatalf("expected %s mount on %s", netdMITMCAVolume, name)
+		}
+		if mount.MountPath != netdMITMCADir || !mount.ReadOnly {
+			t.Fatalf("%s mount = %#v, want path %q readOnly", name, mount, netdMITMCADir)
+		}
+	}
+}
+
+func TestBuildPodSpecSkipsNetdMITMCATrustMaterialWhenManagerConfigOmitsSecret(t *testing.T) {
+	configPath := writeManagerConfig(t, `
+manager_image: sandbox0/manager:test
+`)
+	t.Setenv("CONFIG_PATH", configPath)
+
+	spec := BuildPodSpec(newTestTemplate(), false)
+
+	if volume := findVolume(spec.Volumes, netdMITMCAVolume); volume != nil {
+		t.Fatalf("expected %s volume to be absent, got %#v", netdMITMCAVolume, volume)
+	}
+	if env := findEnvVar(spec.Containers[0].Env, netdMITMCAEnvVar); env != nil {
+		t.Fatalf("expected %s env to be absent, got %#v", netdMITMCAEnvVar, env)
+	}
+	if mount := findVolumeMount(spec.Containers[0].VolumeMounts, netdMITMCAVolume); mount != nil {
+		t.Fatalf("expected %s mount to be absent, got %#v", netdMITMCAVolume, mount)
+	}
+}
+
 func newTestTemplate() *SandboxTemplate {
 	return &SandboxTemplate{
 		ObjectMeta: metav1ObjectMeta("default"),
@@ -257,6 +328,42 @@ func writeManagerConfig(t *testing.T, contents string) string {
 		t.Fatalf("write manager config: %v", err)
 	}
 	return path
+}
+
+func findVolume(volumes []corev1.Volume, name string) *corev1.Volume {
+	for i := range volumes {
+		if volumes[i].Name == name {
+			return &volumes[i]
+		}
+	}
+	return nil
+}
+
+func findContainer(containers []corev1.Container, name string) *corev1.Container {
+	for i := range containers {
+		if containers[i].Name == name {
+			return &containers[i]
+		}
+	}
+	return nil
+}
+
+func findEnvVar(envVars []corev1.EnvVar, name string) *corev1.EnvVar {
+	for i := range envVars {
+		if envVars[i].Name == name {
+			return &envVars[i]
+		}
+	}
+	return nil
+}
+
+func findVolumeMount(mounts []corev1.VolumeMount, name string) *corev1.VolumeMount {
+	for i := range mounts {
+		if mounts[i].Name == name {
+			return &mounts[i]
+		}
+	}
+	return nil
 }
 
 func TestBuildPodSpecOverridesTenantStorageProxyEnvVars(t *testing.T) {

--- a/manager/pkg/controller/helpers.go
+++ b/manager/pkg/controller/helpers.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strings"
 
+	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
@@ -18,6 +20,8 @@ import (
 
 const (
 	procdInternalJWTPublicKey = "internal_jwt_public.key"
+	netdMITMCACertKey         = "ca.crt"
+	serviceAccountNamespace   = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
 )
 
 // EnsureProcdConfigSecret creates or updates the procd config Secret for a template.
@@ -99,4 +103,98 @@ func IsPodReady(pod *corev1.Pod) bool {
 		}
 	}
 	return false
+}
+
+// EnsureNetdMITMCASecret copies the manager-local netd MITM CA cert into the template namespace.
+func EnsureNetdMITMCASecret(
+	ctx context.Context,
+	client kubernetes.Interface,
+	templateNamespace string,
+) error {
+	cfg := config.LoadManagerConfig()
+	if cfg == nil || cfg.NetdMITMCASecretName == "" {
+		return nil
+	}
+	if templateNamespace == "" {
+		return fmt.Errorf("template namespace is required to ensure netd MITM CA secret")
+	}
+
+	sourceNamespace, err := resolveNetdMITMCASecretNamespace(cfg)
+	if err != nil {
+		return err
+	}
+
+	source, err := client.CoreV1().Secrets(sourceNamespace).Get(ctx, cfg.NetdMITMCASecretName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("get netd MITM CA secret %s/%s: %w", sourceNamespace, cfg.NetdMITMCASecretName, err)
+	}
+
+	certPEM := source.Data[netdMITMCACertKey]
+	if len(certPEM) == 0 {
+		return fmt.Errorf("netd MITM CA secret %s/%s missing %q", sourceNamespace, cfg.NetdMITMCASecretName, netdMITMCACertKey)
+	}
+
+	desired := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cfg.NetdMITMCASecretName,
+			Namespace: templateNamespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "sandbox0-manager",
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			netdMITMCACertKey: append([]byte(nil), certPEM...),
+		},
+	}
+
+	existing, err := client.CoreV1().Secrets(templateNamespace).Get(ctx, cfg.NetdMITMCASecretName, metav1.GetOptions{})
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("get target netd MITM CA secret: %w", err)
+		}
+		if _, err := client.CoreV1().Secrets(templateNamespace).Create(ctx, desired, metav1.CreateOptions{}); err != nil {
+			return fmt.Errorf("create target netd MITM CA secret: %w", err)
+		}
+		return nil
+	}
+
+	updated := existing.DeepCopy()
+	updated.Type = desired.Type
+	updated.Data = desired.Data
+	updated.Labels = desired.Labels
+	if reflect.DeepEqual(existing.Type, updated.Type) &&
+		reflect.DeepEqual(existing.Data, updated.Data) &&
+		reflect.DeepEqual(existing.Labels, updated.Labels) {
+		return nil
+	}
+
+	if _, err := client.CoreV1().Secrets(templateNamespace).Update(ctx, updated, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("update target netd MITM CA secret: %w", err)
+	}
+	return nil
+}
+
+func resolveNetdMITMCASecretNamespace(cfg *config.ManagerConfig) (string, error) {
+	if cfg != nil {
+		if namespace := strings.TrimSpace(cfg.NetdMITMCASecretNamespace); namespace != "" {
+			return namespace, nil
+		}
+	}
+
+	if namespace := strings.TrimSpace(os.Getenv("POD_NAMESPACE")); namespace != "" {
+		return namespace, nil
+	}
+
+	data, err := os.ReadFile(serviceAccountNamespace)
+	if err == nil {
+		if namespace := strings.TrimSpace(string(data)); namespace != "" {
+			return namespace, nil
+		}
+	}
+
+	if err != nil && !os.IsNotExist(err) {
+		return "", fmt.Errorf("read service account namespace: %w", err)
+	}
+	return "", fmt.Errorf("resolve netd MITM CA source namespace")
 }

--- a/manager/pkg/controller/helpers_test.go
+++ b/manager/pkg/controller/helpers_test.go
@@ -1,9 +1,15 @@
 package controller
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestIsPodReady(t *testing.T) {
@@ -97,4 +103,57 @@ func TestIsPodReady(t *testing.T) {
 			t.Fatal("IsPodReady() = true, want false")
 		}
 	})
+}
+
+func TestEnsureNetdMITMCASecretCopiesCertIntoTemplateNamespace(t *testing.T) {
+	configPath := writeHelpersManagerConfig(t, `
+netd_mitm_ca_secret_name: fullmode-netd-mitm-ca
+netd_mitm_ca_secret_namespace: sandbox0-system
+`)
+	t.Setenv("CONFIG_PATH", configPath)
+
+	client := fake.NewSimpleClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fullmode-netd-mitm-ca",
+			Namespace: "sandbox0-system",
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"ca.crt": []byte("test-ca"),
+			"ca.key": []byte("should-not-copy"),
+		},
+	})
+
+	err := EnsureNetdMITMCASecret(context.Background(), client, "tpl-default")
+	require.NoError(t, err)
+
+	copied, err := client.CoreV1().Secrets("tpl-default").Get(context.Background(), "fullmode-netd-mitm-ca", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, corev1.SecretTypeOpaque, copied.Type)
+	require.Equal(t, map[string][]byte{
+		"ca.crt": []byte("test-ca"),
+	}, copied.Data)
+	require.Equal(t, "sandbox0-manager", copied.Labels["app.kubernetes.io/managed-by"])
+}
+
+func TestEnsureNetdMITMCASecretNoopsWithoutConfiguredSecret(t *testing.T) {
+	configPath := writeHelpersManagerConfig(t, "{}\n")
+	t.Setenv("CONFIG_PATH", configPath)
+
+	client := fake.NewSimpleClientset()
+	err := EnsureNetdMITMCASecret(context.Background(), client, "tpl-default")
+	require.NoError(t, err)
+
+	secrets, err := client.CoreV1().Secrets("tpl-default").List(context.Background(), metav1.ListOptions{})
+	require.NoError(t, err)
+	require.Empty(t, secrets.Items)
+}
+
+func writeHelpersManagerConfig(t *testing.T, contents string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	err := os.WriteFile(path, []byte(contents), 0o600)
+	require.NoError(t, err)
+	return path
 }

--- a/manager/pkg/controller/pool_manager.go
+++ b/manager/pkg/controller/pool_manager.go
@@ -142,6 +142,9 @@ func (pm *PoolManager) getOrCreateReplicaSet(ctx context.Context, template *v1al
 	if err := EnsureProcdConfigSecret(ctx, pm.k8sClient, pm.secretLister, template); err != nil {
 		return nil, fmt.Errorf("ensure procd config secret: %w", err)
 	}
+	if err := EnsureNetdMITMCASecret(ctx, pm.k8sClient, template.Namespace); err != nil {
+		return nil, fmt.Errorf("ensure netd MITM CA secret: %w", err)
+	}
 	// Try to get existing ReplicaSet
 	rs, err := pm.replicaSetLister.ReplicaSets(template.Namespace).Get(rsName)
 	if err == nil {

--- a/manager/pkg/service/sandbox_service.go
+++ b/manager/pkg/service/sandbox_service.go
@@ -561,6 +561,9 @@ func (s *SandboxService) createNewPod(ctx context.Context, template *v1alpha1.Sa
 	if err := controller.EnsureProcdConfigSecret(ctx, s.k8sClient, s.secretLister, template); err != nil {
 		return nil, fmt.Errorf("ensure procd config secret: %w", err)
 	}
+	if err := controller.EnsureNetdMITMCASecret(ctx, s.k8sClient, template.Namespace); err != nil {
+		return nil, fmt.Errorf("ensure netd MITM CA secret: %w", err)
+	}
 
 	// Build pod spec from template
 	spec := v1alpha1.BuildPodSpec(template, false)

--- a/manager/pkg/service/template_service.go
+++ b/manager/pkg/service/template_service.go
@@ -195,7 +195,10 @@ func (s *TemplateService) ensureNamespace(ctx context.Context, namespace string)
 	}
 
 	if _, err := s.namespaceLister.Get(namespace); err == nil {
-		return s.ensureRegistryPullSecret(ctx, namespace)
+		if err := s.ensureRegistryPullSecret(ctx, namespace); err != nil {
+			return err
+		}
+		return controller.EnsureNetdMITMCASecret(ctx, s.k8sClient, namespace)
 	} else if !errors.IsNotFound(err) {
 		return fmt.Errorf("get namespace %s from cache: %w", namespace, err)
 	}
@@ -214,7 +217,7 @@ func (s *TemplateService) ensureNamespace(ctx context.Context, namespace string)
 	if err := s.ensureRegistryPullSecret(ctx, namespace); err != nil {
 		return err
 	}
-	return nil
+	return controller.EnsureNetdMITMCASecret(ctx, s.k8sClient, namespace)
 }
 
 func (s *TemplateService) ensureRegistryPullSecret(ctx context.Context, namespace string) error {

--- a/skills/sandbox0/references/docs-src/agent/claude/page.mdx
+++ b/skills/sandbox0/references/docs-src/agent/claude/page.mdx
@@ -1,0 +1,259 @@
+# Claude
+
+This page shows the validated Sandbox0 pattern for running Claude Code as a sidecar.
+
+The pattern is provider-agnostic. Claude Code can target multiple providers. The original validation used z.ai as one concrete provider, but the important parts are the Sandbox0 network and trust-chain behavior, not that specific host.
+
+## What was validated
+
+The following flow was validated end to end on a remote `kind` cluster:
+
+1. create a team-scoped credential source with `s0 credential create`
+2. bind it through `network.credentialBindings`
+3. match the provider domain through `network.egress.credentialRules`
+4. use `protocol: https` with `tlsMode: terminate-reoriginate`
+5. run Claude Code inside a sidecar
+6. call the sidecar from the main container through localhost
+7. let Sandbox0 inject outbound auth at the network layer
+
+We also validated an SDK-driven loop where:
+
+- SDK-go called a Claude sidecar inside a sandbox
+- the sidecar generated Python code
+- SDK-go wrote the file into the sandbox
+- SDK-go executed the file successfully
+
+## Key requirements
+
+For this pattern to work reliably, all of the following mattered:
+
+| Requirement | Why it matters |
+|-------------|----------------|
+| `tlsMode: terminate-reoriginate` on the HTTPS credential rule | netd cannot inject HTTP headers into intercepted HTTPS traffic without TLS termination |
+| runtime trust of the netd MITM CA | Claude Code validates TLS and rejects the re-signed certificate chain by default |
+| placeholder provider token such as `ANTHROPIC_AUTH_TOKEN=dummy` when required by the client | some clients only enter the authenticated code path if a token-shaped value is present |
+| real auth delivered through `credentialBindings + credentialRules` | keeps the real provider secret out of the sandbox container |
+
+## Template pattern
+
+Use a sidecar for Claude Code and expose a small localhost interface that your main container can call.
+
+At the template level, the important pieces are:
+
+- a sidecar container that runs Claude Code or a thin wrapper around it
+- `NODE_EXTRA_CA_CERTS=/var/run/sandbox0/netd/mitm-ca.crt`
+- a non-sensitive placeholder token if the client requires API-key mode selection
+- template or claim-time network policy that defines `credentialBindings` and `egress.credentialRules`
+
+<Callout variant="warning">
+`sidecars` is currently a privileged template field. In practice, this means Claude sidecar templates are usually created as operator-managed system templates in self-hosted deployments, or provided by the platform team. Regular team-scoped template creation is not enough unless your deployment explicitly grants access to privileged template fields.
+</Callout>
+
+**Illustrative template fragment:**
+
+```yaml
+spec:
+    mainContainer:
+        image: python:3.12-slim
+        resources:
+            cpu: "1"
+            memory: 1Gi
+    sidecars:
+        - name: claude
+          image: ghcr.io/your-org/claude-sidecar:latest
+          env:
+              - name: ANTHROPIC_AUTH_TOKEN
+                value: dummy
+              - name: NODE_EXTRA_CA_CERTS
+                value: /var/run/sandbox0/netd/mitm-ca.crt
+              - name: ANTHROPIC_BASE_URL
+                value: https://your-provider.example.com
+    network:
+        mode: block-all
+        egress:
+            trafficRules:
+                - name: allow-provider-api
+                  action: allow
+                  domains:
+                      - your-provider.example.com
+                  ports:
+                      - port: 443
+                        protocol: tcp
+            credentialRules:
+                - name: claude-auth
+                  credentialRef: llm-auth
+                  protocol: https
+                  tlsMode: terminate-reoriginate
+                  domains:
+                      - your-provider.example.com
+                  ports:
+                      - port: 443
+                        protocol: tcp
+        credentialBindings:
+            - ref: llm-auth
+              sourceRef: provider-token
+              projection:
+                  type: http_headers
+                  httpHeaders:
+                      headers:
+                          - name: Authorization
+                            valueTemplate: "Bearer {{token}}"
+```
+
+<Callout variant="info">
+The exact upstream env names depend on how your Claude sidecar is packaged. The important part is that the runtime trusts `/var/run/sandbox0/netd/mitm-ca.crt` and the real provider credential is injected by Sandbox0 rather than hard-coded into the container.
+</Callout>
+
+## Create the credential source
+
+Create a team-scoped credential source from a file:
+
+```bash
+cat <<'EOF' > provider-token.yaml
+name: provider-token
+resolverKind: static_headers
+spec:
+    staticHeaders:
+        values:
+            token: <provider-token>
+EOF
+
+s0 credential create -f provider-token.yaml
+```
+
+Then create the template or apply the same network policy at sandbox claim time.
+
+## Claim-time variant
+
+If you do not want the network policy baked into the template, you can attach it when claiming the sandbox.
+
+```bash
+cat <<'EOF' > sandbox-config.yaml
+network:
+    mode: block-all
+    egress:
+        trafficRules:
+            - name: allow-provider-api
+              action: allow
+              domains: [your-provider.example.com]
+              ports:
+                  - port: 443
+                    protocol: tcp
+        credentialRules:
+            - name: claude-auth
+              credentialRef: llm-auth
+              protocol: https
+              tlsMode: terminate-reoriginate
+              domains: [your-provider.example.com]
+              ports:
+                  - port: 443
+                    protocol: tcp
+    credentialBindings:
+        - ref: llm-auth
+          sourceRef: provider-token
+          projection:
+              type: http_headers
+              httpHeaders:
+                  headers:
+                      - name: Authorization
+                        valueTemplate: "Bearer {{token}}"
+EOF
+
+s0 sandbox create -t claude-sidecar -f sandbox-config.yaml
+```
+
+## How the main container talks to Claude
+
+Keep the control path pod-local.
+
+Common pattern:
+
+- the sidecar listens on `127.0.0.1:8081`
+- the main container sends a prompt to the sidecar
+- the sidecar calls the upstream provider
+- Sandbox0 injects provider auth at egress time
+
+This keeps your app-to-sidecar interface stable even if the upstream provider changes later.
+
+## Why `dummy` can still be necessary
+
+Some provider clients or CLIs select their authenticated path only when a token-shaped env var exists. In that case:
+
+- set a non-sensitive placeholder such as `ANTHROPIC_AUTH_TOKEN=dummy`
+- let Sandbox0 inject the real `Authorization` header through netd
+
+This is a client-behavior workaround, not a Sandbox0 auth requirement.
+
+## Troubleshooting
+
+### `handshake downstream tls: EOF`
+
+This usually means the sidecar does not trust the netd MITM CA during HTTPS `terminate-reoriginate`.
+
+Check:
+
+- `NODE_EXTRA_CA_CERTS=/var/run/sandbox0/netd/mitm-ca.crt`
+- the sidecar can read `/var/run/sandbox0/netd/mitm-ca.crt`
+- the credential rule uses `tlsMode: terminate-reoriginate`
+
+### Auth resolves but requests still fail
+
+Check these separately:
+
+- `trafficRules` allow the provider domain and port
+- `credentialRules` match the same domain and protocol
+- `credentialRef` matches `credentialBindings[*].ref`
+- the provider-specific header format matches your source contents
+
+### The sidecar starts but provider requests are unauthenticated
+
+Typical causes:
+
+- missing `credentialBindings`
+- `valueTemplate` references the wrong source key
+- `protocol` or `domains` on the credential rule do not match the actual request
+
+## Improvement direction
+
+The current first cut is intentionally conservative:
+
+- Sandbox0 provides the CA file and env automatically
+- Sandbox0 does not rewrite system trust stores
+- the sidecar still opts in explicitly
+
+This is enough to support real Claude sidecars today while keeping trust behavior predictable.
+
+Likely future improvements:
+
+- official Claude sidecar templates that already wire `NODE_EXTRA_CA_CERTS`
+- provider-specific examples for common Anthropic-compatible hosts
+- more polished local sidecar contracts for prompt/response APIs
+- additional provider pages in this `Agent` section, such as Codex
+
+## Next Steps
+
+<CardGrid>
+  <LinkCard
+    title="Agent Overview"
+    href="/docs/agent"
+    cta="Learn More"
+  >
+    Understand the common sidecar pattern across providers
+  </LinkCard>
+
+  <LinkCard
+    title="Egress Auth"
+    href="/docs/credential/egress-auth"
+    cta="Learn More"
+  >
+    Configure auth bindings and HTTPS interception rules
+  </LinkCard>
+
+  <LinkCard
+    title="Sandbox Network"
+    href="/docs/sandbox/network"
+    cta="Learn More"
+  >
+    Combine traffic rules, credential rules, and trust material
+  </LinkCard>
+</CardGrid>

--- a/skills/sandbox0/references/docs-src/agent/page.mdx
+++ b/skills/sandbox0/references/docs-src/agent/page.mdx
@@ -1,0 +1,126 @@
+# Agent
+
+Sandbox0 can host agent runtimes directly in the main container, or run them as sidecars next to your application container.
+
+This section covers the second pattern: provider-facing agent components such as Claude Code today, and additional providers such as Codex later.
+
+## Why use an Agent sidecar
+
+An Agent sidecar is useful when you want to keep provider-specific tooling separate from your application process.
+
+Typical reasons:
+
+- run a provider CLI or SDK daemon in its own container
+- expose a small localhost API such as `127.0.0.1:8081`
+- keep your application container focused on business logic
+- avoid placing raw provider credentials directly in the sandbox filesystem or app environment
+
+## Recommended architecture
+
+The validated pattern is:
+
+1. Your template defines a main container and one or more sidecars.
+2. The sidecar talks to its upstream LLM provider over HTTPS.
+3. Your main container talks to the sidecar over localhost inside the same pod.
+4. Sandbox0 `credentialBindings` and `egress.credentialRules` inject outbound auth at the network layer.
+5. The sidecar opts in to netd MITM trust material when HTTPS `terminate-reoriginate` is required.
+
+```text
+main container --> localhost sidecar --> netd --> provider API
+                                  ^        |
+                                  |        +-- inject outbound auth
+                                  |
+                                  +-- trusts netd MITM CA when needed
+```
+
+## Auth model
+
+For provider-facing sidecars, separate these concerns:
+
+- **application wiring**: your main container calls the sidecar over localhost
+- **provider auth resolution**: Sandbox0 resolves auth material through `credentialBindings`
+- **destination matching**: `egress.credentialRules` decide where injection applies
+- **traffic control**: `trafficRules` still decide what egress is allowed
+
+This lets you keep the real provider secret outside the sandbox container in many flows.
+
+See [Credential](/docs/credential) and [Egress Auth](/docs/credential/egress-auth) for the underlying objects.
+
+## HTTPS trust material
+
+When a sidecar needs HTTPS auth injection with TLS interception, the client process must trust netd's MITM CA.
+
+Sandbox0 exposes stable trust material inside sandbox pods:
+
+- file: `/var/run/sandbox0/netd/mitm-ca.crt`
+- env: `SANDBOX0_NETD_MITM_CA_FILE=/var/run/sandbox0/netd/mitm-ca.crt`
+
+Sandbox0 does **not** automatically rewrite the container trust store. The sidecar runtime must opt in explicitly.
+
+Common examples:
+
+- Node.js or Claude Code: `NODE_EXTRA_CA_CERTS=/var/run/sandbox0/netd/mitm-ca.crt`
+- Python `requests`: `REQUESTS_CA_BUNDLE=/var/run/sandbox0/netd/mitm-ca.crt`
+- `curl`: `CURL_CA_BUNDLE=/var/run/sandbox0/netd/mitm-ca.crt`
+
+## Provider-agnostic guidance
+
+The pattern in this section is intentionally provider-agnostic:
+
+- Claude Code is one validated example
+- z.ai was only one provider used during validation
+- future sidecars such as Codex can follow the same pod-local control pattern
+
+What usually changes per provider is:
+
+- sidecar image and startup command
+- upstream base URL
+- whether the client insists on a placeholder API key to enter an authenticated code path
+- runtime-specific trust-store opt-in
+
+What stays the same is the Sandbox0 control surface:
+
+- template sidecars
+- `credentialBindings`
+- `egress.credentialRules`
+- `trafficRules`
+- pod-local communication between the app and sidecar
+
+## Current first cut
+
+The current platform behavior is:
+
+- Sandbox0 injects the netd MITM CA into sandbox containers as read-only trust material
+- the contract is stable at `/var/run/sandbox0/netd/mitm-ca.crt`
+- `SANDBOX0_NETD_MITM_CA_FILE` is set automatically
+- runtimes still choose whether to trust that CA
+
+This is the low-risk first cut because it avoids silently mutating every container trust store.
+
+## Next Steps
+
+<CardGrid>
+  <LinkCard
+    title="Claude"
+    href="/docs/agent/claude"
+    cta="Learn More"
+  >
+    Run Claude Code as a sidecar with provider-facing HTTPS auth
+  </LinkCard>
+
+  <LinkCard
+    title="Egress Auth"
+    href="/docs/credential/egress-auth"
+    cta="Learn More"
+  >
+    Bind provider credentials and inject outbound auth
+  </LinkCard>
+
+  <LinkCard
+    title="Template Configuration"
+    href="/docs/template/configuration"
+    cta="Learn More"
+  >
+    Configure sidecars, network policy, and pod-level settings
+  </LinkCard>
+</CardGrid>

--- a/skills/sandbox0/references/docs-src/credential/egress-auth/page.mdx
+++ b/skills/sandbox0/references/docs-src/credential/egress-auth/page.mdx
@@ -53,6 +53,21 @@ In this example, `{{token}}` refers to the `token` key inside a `static_headers`
 | `failurePolicy` | No | `fail-closed` or `fail-open` |
 | `rollout` | No | `enabled` or `disabled` |
 
+## HTTPS Trust Material
+
+When a credential rule uses TLS interception such as `protocol: https`, `protocol: grpc`, or `protocol: tls` with `tlsMode: terminate-reoriginate`, Sandbox0 provides the netd MITM CA to sandbox containers as read-only trust material:
+
+- File: `/var/run/sandbox0/netd/mitm-ca.crt`
+- Env: `SANDBOX0_NETD_MITM_CA_FILE=/var/run/sandbox0/netd/mitm-ca.crt`
+
+Sandbox0 does not automatically modify the container trust store. Templates and sidecars must opt in at the runtime level if they need to trust the intercepted certificate chain.
+
+Common examples:
+
+- Node.js or Claude Code: `NODE_EXTRA_CA_CERTS=$SANDBOX0_NETD_MITM_CA_FILE`
+- Python `requests`: `REQUESTS_CA_BUNDLE=$SANDBOX0_NETD_MITM_CA_FILE`
+- `curl`: `CURL_CA_BUNDLE=$SANDBOX0_NETD_MITM_CA_FILE`
+
 ## Example Policy
 
 This policy allows access to the GitHub API, binds a token source, and injects an `Authorization` header for matching HTTPS requests:

--- a/skills/sandbox0/references/docs-src/manifest.json
+++ b/skills/sandbox0/references/docs-src/manifest.json
@@ -46,6 +46,20 @@
       ]
     },
     {
+      "label": "AGENT",
+      "slug": "agent",
+      "pages": [
+        {
+          "slug": "",
+          "title": "Overview"
+        },
+        {
+          "slug": "claude",
+          "title": "Claude"
+        }
+      ]
+    },
+    {
       "label": "CREDENTIAL",
       "slug": "credential",
       "pages": [

--- a/skills/sandbox0/references/docs-src/sandbox/network/page.mdx
+++ b/skills/sandbox0/references/docs-src/sandbox/network/page.mdx
@@ -29,6 +29,10 @@ The same public `SandboxNetworkPolicy` shape is used in:
 Use `trafficRules` for new policies. Legacy `allowed*` and `denied*` fields still work, but they are deprecated and should not be mixed with `trafficRules`.
 </Callout>
 
+<Callout variant="info">
+If a credential rule uses `tlsMode: terminate-reoriginate`, Sandbox0 exposes the netd MITM CA as `SANDBOX0_NETD_MITM_CA_FILE`, but it does not automatically update the container trust store. Sidecars and app runtimes must opt in, for example with `NODE_EXTRA_CA_CERTS` or `REQUESTS_CA_BUNDLE`.
+</Callout>
+
 ## Traffic Rule Fields
 
 | Field | Required | Description |


### PR DESCRIPTION
## Summary
- inject netd MITM CA trust material into sandbox pods via a stable file path and env var
- ensure the source CA secret exists in the system namespace and is copied into template namespaces before pod creation
- add an Agent docs section with Claude sidecar guidance and HTTPS egress auth trust-chain notes

Closes #123

## Testing
- golangci-lint run ./infra-operator/... ./manager/...
- go test ./infra-operator/internal/controller/services/netd ./infra-operator/internal/controller/services/manager ./manager/pkg/controller ./manager/pkg/service ./manager/pkg/apis/sandbox0/v1alpha1
- remote kind: make test-again
- remote kind: s0 template list -o json
- remote kind: s0 sandbox create -t default -o json
- remote kind: s0 credential create -f provider-token.yaml
- remote kind: s0 sandbox create -t default -f sandbox-config.yaml -o json
- remote kind: verified sandbox pod mounted /var/run/sandbox0/netd/mitm-ca.crt and exposed SANDBOX0_NETD_MITM_CA_FILE