### PR TITLE
Normalize OIDC issuer from discovery metadata

### DIFF
--- a/pkg/gateway/auth/oidc/provider.go
+++ b/pkg/gateway/auth/oidc/provider.go
@@ -54,11 +54,23 @@ type Provider struct {
 
 const wellKnownOIDCConfigPath = "/.well-known/openid-configuration"
 
+type discoveryMetadata struct {
+	Issuer                      string `json:"issuer"`
+	DeviceAuthorizationEndpoint string `json:"device_authorization_endpoint"`
+}
+
 // NewProvider creates a new OIDC provider
 func NewProvider(ctx context.Context, cfg *config.OIDCProviderConfig, baseURL string) (*Provider, error) {
 	// go-oidc expects an issuer URL here. Accept either the issuer URL itself
 	// or a full discovery document URL and normalize to the issuer form.
+	// When a provider publishes an issuer that differs only by a trailing slash,
+	// prefer the discovery document's issuer exactly so initialization remains
+	// compatible across OIDC providers and custom domains.
 	issuerURL := normalizeOIDCIssuerURL(cfg.DiscoveryURL)
+	metadata, err := fetchDiscoveryMetadata(ctx, cfg.DiscoveryURL)
+	if err == nil && strings.TrimSpace(metadata.Issuer) != "" {
+		issuerURL = strings.TrimSpace(metadata.Issuer)
+	}
 	oidcProvider, err := oidc.NewProvider(ctx, issuerURL)
 	if err != nil {
 		return nil, fmt.Errorf("create OIDC provider: %w", err)
@@ -87,11 +99,10 @@ func NewProvider(ctx context.Context, cfg *config.OIDCProviderConfig, baseURL st
 		ClientID: cfg.ClientID,
 	})
 
-	var metadata struct {
-		DeviceAuthorizationEndpoint string `json:"device_authorization_endpoint"`
-	}
-	if err := oidcProvider.Claims(&metadata); err != nil {
-		metadata.DeviceAuthorizationEndpoint = ""
+	if strings.TrimSpace(metadata.DeviceAuthorizationEndpoint) == "" {
+		if err := oidcProvider.Claims(&metadata); err != nil {
+			metadata.DeviceAuthorizationEndpoint = ""
+		}
 	}
 	if strings.TrimSpace(cfg.DeviceAuthorizationEndpoint) != "" {
 		metadata.DeviceAuthorizationEndpoint = strings.TrimSpace(cfg.DeviceAuthorizationEndpoint)
@@ -111,6 +122,45 @@ func NewProvider(ctx context.Context, cfg *config.OIDCProviderConfig, baseURL st
 func normalizeOIDCIssuerURL(value string) string {
 	trimmed := strings.TrimSpace(value)
 	return strings.TrimSuffix(trimmed, wellKnownOIDCConfigPath)
+}
+
+func resolveOIDCDiscoveryURL(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return ""
+	}
+	if strings.HasSuffix(trimmed, wellKnownOIDCConfigPath) {
+		return trimmed
+	}
+	return strings.TrimRight(trimmed, "/") + wellKnownOIDCConfigPath
+}
+
+func fetchDiscoveryMetadata(ctx context.Context, value string) (discoveryMetadata, error) {
+	discoveryURL := resolveOIDCDiscoveryURL(value)
+	if discoveryURL == "" {
+		return discoveryMetadata{}, errors.New("missing discovery URL")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, discoveryURL, nil)
+	if err != nil {
+		return discoveryMetadata{}, fmt.Errorf("build discovery request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return discoveryMetadata{}, fmt.Errorf("fetch discovery document: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return discoveryMetadata{}, fmt.Errorf("fetch discovery document: unexpected status %s", resp.Status)
+	}
+
+	var metadata discoveryMetadata
+	if err := json.NewDecoder(resp.Body).Decode(&metadata); err != nil {
+		return discoveryMetadata{}, fmt.Errorf("decode discovery document: %w", err)
+	}
+	return metadata, nil
 }
 
 func resolveTokenEndpointAuthStyle(method string) (oauth2.AuthStyle, error) {

--- a/pkg/gateway/auth/oidc/provider_test.go
+++ b/pkg/gateway/auth/oidc/provider_test.go
@@ -3,6 +3,7 @@ package oidc
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
 	"golang.org/x/oauth2"
 )
 
@@ -80,6 +82,120 @@ func TestNormalizeOIDCIssuerURL(t *testing.T) {
 				t.Fatalf("normalizeOIDCIssuerURL(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestResolveOIDCDiscoveryURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "keeps discovery document url",
+			input: "https://example.com/auth/v1/.well-known/openid-configuration",
+			want:  "https://example.com/auth/v1/.well-known/openid-configuration",
+		},
+		{
+			name:  "builds discovery url from issuer",
+			input: "https://example.com/auth/v1",
+			want:  "https://example.com/auth/v1/.well-known/openid-configuration",
+		},
+		{
+			name:  "trims trailing slash before appending discovery path",
+			input: "https://example.com/",
+			want:  "https://example.com/.well-known/openid-configuration",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := resolveOIDCDiscoveryURL(tt.input); got != tt.want {
+				t.Fatalf("resolveOIDCDiscoveryURL(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFetchDiscoveryMetadata(t *testing.T) {
+	t.Parallel()
+
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != wellKnownOIDCConfigPath {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                        serverURL + "/",
+			"authorization_endpoint":        serverURL + "/authorize",
+			"token_endpoint":                serverURL + "/oauth/token",
+			"jwks_uri":                      serverURL + "/jwks",
+			"device_authorization_endpoint": serverURL + "/oauth/device/code",
+		})
+	}))
+	serverURL = server.URL
+	defer server.Close()
+
+	metadata, err := fetchDiscoveryMetadata(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("fetchDiscoveryMetadata: %v", err)
+	}
+	if metadata.Issuer != serverURL+"/" {
+		t.Fatalf("unexpected issuer %q", metadata.Issuer)
+	}
+	if metadata.DeviceAuthorizationEndpoint != serverURL+"/oauth/device/code" {
+		t.Fatalf("unexpected device_authorization_endpoint %q", metadata.DeviceAuthorizationEndpoint)
+	}
+}
+
+func TestNewProviderAcceptsIssuerWithTrailingSlashFromDiscovery(t *testing.T) {
+	t.Parallel()
+
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case wellKnownOIDCConfigPath:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"issuer":                        serverURL + "/",
+				"authorization_endpoint":        serverURL + "/authorize",
+				"token_endpoint":                serverURL + "/oauth/token",
+				"jwks_uri":                      serverURL + "/jwks",
+				"device_authorization_endpoint": serverURL + "/oauth/device/code",
+			})
+		case "/jwks":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"keys":[]}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	serverURL = server.URL
+	defer server.Close()
+
+	provider, err := NewProvider(context.Background(), &config.OIDCProviderConfig{
+		ID:                         "auth0",
+		Name:                       "Auth0",
+		Enabled:                    true,
+		ClientID:                   "client-id",
+		ClientSecret:               "client-secret",
+		DiscoveryURL:               serverURL + wellKnownOIDCConfigPath,
+		TokenEndpointAuthMethod:    "client_secret_basic",
+		Scopes:                     []string{"openid", "email", "profile"},
+		DeviceAuthorizationEnabled: true,
+	}, "https://api.sandbox0.ai")
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+
+	if provider.deviceAuthorizationEndpoint != serverURL+"/oauth/device/code" {
+		t.Fatalf("unexpected device authorization endpoint %q", provider.deviceAuthorizationEndpoint)
 	}
 }
 


### PR DESCRIPTION
## Summary
- initialize OIDC providers with the issuer returned by the discovery document
- tolerate trailing-slash issuer differences without weakening host/path validation
- add regression coverage for discovery metadata loading and issuer initialization

## Testing
- go test ./pkg/gateway/auth/oidc ./pkg/gateway/http/handlers ./pkg/gateway/public -count=1
