### PR TITLE
Support bootstrap mounting existing volumes during claim

### DIFF
--- a/manager/pkg/http/handlers_sandbox.go
+++ b/manager/pkg/http/handlers_sandbox.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -40,6 +41,10 @@ func (s *Server) claimSandbox(c *gin.Context) {
 
 	resp, err := s.sandboxService.ClaimSandbox(c.Request.Context(), &req)
 	if err != nil {
+		if errors.Is(err, service.ErrInvalidClaimRequest) {
+			spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
+			return
+		}
 		s.logger.Error("Failed to claim sandbox",
 			zap.String("template", req.Template),
 			zap.String("teamID", req.TeamID),

--- a/manager/pkg/service/procd_client.go
+++ b/manager/pkg/service/procd_client.go
@@ -108,9 +108,18 @@ type StatsResponse struct {
 
 // InitializeRequest represents the procd initialize request.
 type InitializeRequest struct {
-	SandboxID string             `json:"sandbox_id"`
-	TeamID    string             `json:"team_id,omitempty"`
-	Webhook   *InitializeWebhook `json:"webhook,omitempty"`
+	SandboxID          string                   `json:"sandbox_id"`
+	TeamID             string                   `json:"team_id,omitempty"`
+	Webhook            *InitializeWebhook       `json:"webhook,omitempty"`
+	Mounts             []InitializeMountRequest `json:"mounts,omitempty"`
+	WaitForMounts      bool                     `json:"wait_for_mounts,omitempty"`
+	MountWaitTimeoutMs int32                    `json:"mount_wait_timeout_ms,omitempty"`
+}
+
+type InitializeMountRequest struct {
+	SandboxVolumeID string             `json:"sandboxvolume_id"`
+	MountPoint      string             `json:"mount_point"`
+	VolumeConfig    *MountVolumeConfig `json:"volume_config,omitempty"`
 }
 
 // InitializeWebhook represents webhook configuration for initialization.
@@ -122,8 +131,13 @@ type InitializeWebhook struct {
 
 // InitializeResponse represents the response from procd initialize API.
 type InitializeResponse struct {
-	SandboxID string `json:"sandbox_id"`
-	TeamID    string `json:"team_id,omitempty"`
+	SandboxID       string                 `json:"sandbox_id"`
+	TeamID          string                 `json:"team_id,omitempty"`
+	BootstrapMounts []BootstrapMountStatus `json:"bootstrap_mounts,omitempty"`
+}
+
+type MountStatusResponse struct {
+	Mounts []BootstrapMountStatus `json:"mounts,omitempty"`
 }
 
 // Pause calls the procd pause API and returns resource usage.
@@ -244,14 +258,11 @@ func (c *ProcdClient) Stats(ctx context.Context, procdAddress, internalToken, pr
 func (c *ProcdClient) Initialize(ctx context.Context, procdAddress string, req InitializeRequest, internalToken, procdStorageToken string) (*InitializeResponse, error) {
 	url := procdAddress + "/api/v1/initialize"
 
-	var reqBody io.Reader
-	if req != (InitializeRequest{}) {
-		jsonBody, err := json.Marshal(req)
-		if err != nil {
-			return nil, fmt.Errorf("marshal body: %w", err)
-		}
-		reqBody = bytes.NewReader(jsonBody)
+	jsonBody, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshal body: %w", err)
 	}
+	reqBody := bytes.NewReader(jsonBody)
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, reqBody)
 	if err != nil {
@@ -282,6 +293,44 @@ func (c *ProcdClient) Initialize(ctx context.Context, procdAddress string, req I
 	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("initialize failed with status %d", resp.StatusCode)
+	}
+
+	return result, nil
+}
+
+// MountStatus calls the procd sandbox volume status API.
+func (c *ProcdClient) MountStatus(ctx context.Context, procdAddress, internalToken, procdStorageToken string) (*MountStatusResponse, error) {
+	url := procdAddress + "/api/v1/sandboxvolumes/status"
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("X-Internal-Token", internalToken)
+	httpReq.Header.Set("X-Token-For-Procd", procdStorageToken)
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("do request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	result, errInfo, err := decodeProcdResponse[MountStatusResponse](respBody)
+	if err != nil {
+		return nil, fmt.Errorf("decode mount status response: %w", err)
+	}
+	if errInfo != nil {
+		return nil, fmt.Errorf("mount status failed: %s", errInfo.Message)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("mount status failed with status %d", resp.StatusCode)
 	}
 
 	return result, nil

--- a/manager/pkg/service/sandbox_service.go
+++ b/manager/pkg/service/sandbox_service.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"net"
 	"net/url"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -61,6 +62,7 @@ const (
 
 // errNoIdlePod is returned when no idle pod is available for claiming.
 var errNoIdlePod = errors.New("no idle pod available")
+var ErrInvalidClaimRequest = errors.New("invalid claim request")
 
 // claimIdlePodBackoff is the retry backoff for claiming idle pods.
 // Designed to balance between:
@@ -201,10 +203,37 @@ func (s *SandboxService) SetCredentialStore(store egressauth.BindingStore) {
 
 // ClaimRequest represents a sandbox claim request
 type ClaimRequest struct {
-	TeamID   string
-	UserID   string
-	Template string         `json:"template"`
-	Config   *SandboxConfig `json:"config,omitempty"`
+	TeamID             string
+	UserID             string
+	Template           string         `json:"template"`
+	Config             *SandboxConfig `json:"config,omitempty"`
+	Mounts             []ClaimMount   `json:"mounts,omitempty"`
+	WaitForMounts      bool           `json:"wait_for_mounts,omitempty"`
+	MountWaitTimeoutMs *int32         `json:"mount_wait_timeout_ms,omitempty"`
+}
+
+type ClaimMount struct {
+	SandboxVolumeID string             `json:"sandboxvolume_id"`
+	MountPoint      string             `json:"mount_point"`
+	VolumeConfig    *MountVolumeConfig `json:"volume_config,omitempty"`
+}
+
+type MountVolumeConfig struct {
+	CacheSize  string `json:"cache_size,omitempty"`
+	Prefetch   *int32 `json:"prefetch,omitempty"`
+	BufferSize string `json:"buffer_size,omitempty"`
+	Writeback  *bool  `json:"writeback,omitempty"`
+}
+
+type BootstrapMountStatus struct {
+	SandboxVolumeID     string `json:"sandboxvolume_id"`
+	MountPoint          string `json:"mount_point"`
+	State               string `json:"state"`
+	MountedAt           string `json:"mounted_at,omitempty"`
+	MountedDurationSecs int64  `json:"mounted_duration_sec,omitempty"`
+	MountSessionID      string `json:"mount_session_id,omitempty"`
+	ErrorCode           string `json:"error_code,omitempty"`
+	ErrorMessage        string `json:"error_message,omitempty"`
 }
 
 // SandboxConfig represents sandbox configuration
@@ -287,6 +316,68 @@ func setHardExpirationAnnotation(annotations map[string]string, now time.Time, h
 	annotations[controller.AnnotationHardExpiresAt] = hardExpiresAt.Format(time.RFC3339)
 }
 
+func validateClaimMounts(req *ClaimRequest) error {
+	if req == nil {
+		return nil
+	}
+	if req.MountWaitTimeoutMs != nil && *req.MountWaitTimeoutMs <= 0 {
+		return fmt.Errorf("%w: mount_wait_timeout_ms must be greater than zero", ErrInvalidClaimRequest)
+	}
+	seenVolumes := make(map[string]struct{}, len(req.Mounts))
+	seenMountPoints := make(map[string]string, len(req.Mounts))
+	for i := range req.Mounts {
+		mount := &req.Mounts[i]
+		if strings.TrimSpace(mount.SandboxVolumeID) == "" {
+			return fmt.Errorf("%w: mounts[%d].sandboxvolume_id is required", ErrInvalidClaimRequest, i)
+		}
+		cleanMountPoint := filepath.Clean(strings.TrimSpace(mount.MountPoint))
+		if !filepath.IsAbs(cleanMountPoint) || cleanMountPoint == string(filepath.Separator) || strings.Contains(cleanMountPoint, "..") {
+			return fmt.Errorf("%w: mounts[%d].mount_point is invalid", ErrInvalidClaimRequest, i)
+		}
+		if _, exists := seenVolumes[mount.SandboxVolumeID]; exists {
+			return fmt.Errorf("%w: duplicate sandboxvolume_id %q in claim mounts", ErrInvalidClaimRequest, mount.SandboxVolumeID)
+		}
+		if existing, exists := seenMountPoints[cleanMountPoint]; exists && existing != mount.SandboxVolumeID {
+			return fmt.Errorf("%w: duplicate mount_point %q in claim mounts", ErrInvalidClaimRequest, cleanMountPoint)
+		}
+		mount.SandboxVolumeID = strings.TrimSpace(mount.SandboxVolumeID)
+		mount.MountPoint = cleanMountPoint
+		seenVolumes[mount.SandboxVolumeID] = struct{}{}
+		seenMountPoints[cleanMountPoint] = mount.SandboxVolumeID
+	}
+	return nil
+}
+
+func claimMountWaitTimeout(req *ClaimRequest) time.Duration {
+	if req == nil || !req.WaitForMounts {
+		return 0
+	}
+	if req.MountWaitTimeoutMs != nil && *req.MountWaitTimeoutMs > 0 {
+		return time.Duration(*req.MountWaitTimeoutMs) * time.Millisecond
+	}
+	return 30 * time.Second
+}
+
+func toInitializeMountRequests(in []ClaimMount) []InitializeMountRequest {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]InitializeMountRequest, len(in))
+	for i := range in {
+		out[i] = InitializeMountRequest(in[i])
+	}
+	return out
+}
+
+func toBootstrapMountStatuses(in []BootstrapMountStatus) []BootstrapMountStatus {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]BootstrapMountStatus, 0, len(in))
+	out = append(out, in...)
+	return out
+}
+
 // WebhookConfig represents outbound webhook configuration.
 type WebhookConfig struct {
 	URL      string `json:"url"`
@@ -296,12 +387,13 @@ type WebhookConfig struct {
 
 // ClaimResponse represents a sandbox claim response
 type ClaimResponse struct {
-	SandboxID    string  `json:"sandbox_id"`
-	Status       string  `json:"status"`
-	ProcdAddress string  `json:"procd_address"`
-	PodName      string  `json:"pod_name"`
-	Template     string  `json:"template"`
-	ClusterId    *string `json:"cluster_id,omitempty"`
+	SandboxID       string                 `json:"sandbox_id"`
+	Status          string                 `json:"status"`
+	ProcdAddress    string                 `json:"procd_address"`
+	PodName         string                 `json:"pod_name"`
+	Template        string                 `json:"template"`
+	ClusterId       *string                `json:"cluster_id,omitempty"`
+	BootstrapMounts []BootstrapMountStatus `json:"bootstrap_mounts,omitempty"`
 }
 
 // ClaimSandbox claims a sandbox from the idle pool or creates a new one
@@ -313,6 +405,9 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 		return nil, err
 	}
 	req.Template = canonicalTemplateID
+	if err := validateClaimMounts(req); err != nil {
+		return nil, err
+	}
 	s.logger.Info("Claiming sandbox",
 		zap.String("template", req.Template),
 		zap.String("teamID", req.TeamID),
@@ -422,17 +517,19 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 	if err != nil {
 		return nil, fmt.Errorf("get procd address: %w", err)
 	}
-	if err := s.initializeProcd(ctx, pod, req, procdAddress); err != nil {
+	initResp, err := s.initializeProcd(ctx, pod, req, procdAddress)
+	if err != nil {
 		return nil, fmt.Errorf("initialize procd: %w", err)
 	}
 
 	return &ClaimResponse{
-		SandboxID:    pod.Name,
-		Status:       "starting",
-		ProcdAddress: procdAddress,
-		PodName:      pod.Name,
-		Template:     req.Template,
-		ClusterId:    template.Spec.ClusterId,
+		SandboxID:       pod.Name,
+		Status:          "starting",
+		ProcdAddress:    procdAddress,
+		PodName:         pod.Name,
+		Template:        req.Template,
+		ClusterId:       template.Spec.ClusterId,
+		BootstrapMounts: toBootstrapMountStatuses(initResp.BootstrapMounts),
 	}, nil
 }
 
@@ -1065,12 +1162,12 @@ func (s *SandboxService) initializeProcd(
 	pod *corev1.Pod,
 	req *ClaimRequest,
 	procdAddress string,
-) error {
+) (*InitializeResponse, error) {
 	if s.internalTokenGenerator == nil || s.procdTokenGenerator == nil {
-		return fmt.Errorf("token generators not configured, cannot authenticate with procd")
+		return nil, fmt.Errorf("token generators not configured, cannot authenticate with procd")
 	}
 	if pod == nil || req == nil {
-		return fmt.Errorf("missing sandbox context")
+		return nil, fmt.Errorf("missing sandbox context")
 	}
 
 	teamID := req.TeamID
@@ -1079,12 +1176,12 @@ func (s *SandboxService) initializeProcd(
 
 	internalToken, err := s.internalTokenGenerator.GenerateToken(teamID, userID, sandboxID)
 	if err != nil {
-		return fmt.Errorf("generate internal token: %w", err)
+		return nil, fmt.Errorf("generate internal token: %w", err)
 	}
 
 	procdToken, err := s.procdTokenGenerator.GenerateToken(teamID, userID, sandboxID)
 	if err != nil {
-		return fmt.Errorf("generate procd token: %w", err)
+		return nil, fmt.Errorf("generate procd token: %w", err)
 	}
 
 	webhookInfo := s.getWebhookInfo(req)
@@ -1098,15 +1195,22 @@ func (s *SandboxService) initializeProcd(
 	}
 
 	initReq := InitializeRequest{
-		SandboxID: sandboxID,
-		TeamID:    teamID,
-		Webhook:   webhookConfig,
+		SandboxID:          sandboxID,
+		TeamID:             teamID,
+		Webhook:            webhookConfig,
+		Mounts:             toInitializeMountRequests(req.Mounts),
+		WaitForMounts:      req.WaitForMounts,
+		MountWaitTimeoutMs: int32(claimMountWaitTimeout(req) / time.Millisecond),
 	}
 
 	var initErr error
+	var initResp *InitializeResponse
 	timeout := s.config.ProcdInitTimeout
 	if timeout == 0 {
 		timeout = 6 * time.Second
+	}
+	if waitTimeout := claimMountWaitTimeout(req); waitTimeout > timeout {
+		timeout = waitTimeout + time.Second
 	}
 
 	initCtx, cancel := context.WithTimeout(ctx, timeout)
@@ -1116,14 +1220,14 @@ func (s *SandboxService) initializeProcd(
 	defer ticker.Stop()
 
 	for {
-		_, initErr = s.procdClient.Initialize(initCtx, procdAddress, initReq, internalToken, procdToken)
+		initResp, initErr = s.procdClient.Initialize(initCtx, procdAddress, initReq, internalToken, procdToken)
 		if initErr == nil {
-			return nil
+			return initResp, nil
 		}
 
 		select {
 		case <-initCtx.Done():
-			return fmt.Errorf("initialize procd timed out after %s: %w", timeout, initErr)
+			return nil, fmt.Errorf("initialize procd timed out after %s: %w", timeout, initErr)
 		case <-ticker.C:
 			continue
 		}

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -76,6 +77,65 @@ func TestClaimIdlePodClaimsReadyPod(t *testing.T) {
 	}
 	if got := pod.Labels[controller.LabelPoolType]; got != controller.PoolTypeActive {
 		t.Fatalf("pool-type = %q, want %q", got, controller.PoolTypeActive)
+	}
+}
+
+func TestValidateClaimMountsRejectsDuplicateVolume(t *testing.T) {
+	req := &ClaimRequest{
+		Mounts: []ClaimMount{
+			{SandboxVolumeID: "vol-1", MountPoint: "/workspace/a"},
+			{SandboxVolumeID: "vol-1", MountPoint: "/workspace/b"},
+		},
+	}
+
+	err := validateClaimMounts(req)
+	if err == nil {
+		t.Fatal("expected duplicate volume validation error")
+	}
+	if !errors.Is(err, ErrInvalidClaimRequest) {
+		t.Fatalf("expected ErrInvalidClaimRequest, got %v", err)
+	}
+}
+
+func TestValidateClaimMountsRejectsDuplicateMountPoint(t *testing.T) {
+	req := &ClaimRequest{
+		Mounts: []ClaimMount{
+			{SandboxVolumeID: "vol-1", MountPoint: "/workspace/data"},
+			{SandboxVolumeID: "vol-2", MountPoint: "/workspace/data"},
+		},
+	}
+
+	err := validateClaimMounts(req)
+	if err == nil {
+		t.Fatal("expected duplicate mount point validation error")
+	}
+	if !errors.Is(err, ErrInvalidClaimRequest) {
+		t.Fatalf("expected ErrInvalidClaimRequest, got %v", err)
+	}
+}
+
+func TestValidateClaimMountsNormalizesMountPoint(t *testing.T) {
+	req := &ClaimRequest{
+		Mounts: []ClaimMount{{SandboxVolumeID: "vol-1", MountPoint: "/workspace/project/../data"}},
+	}
+
+	if err := validateClaimMounts(req); err != nil {
+		t.Fatalf("validateClaimMounts() error = %v", err)
+	}
+	if got := req.Mounts[0].MountPoint; got != "/workspace/data" {
+		t.Fatalf("mount point = %q, want %q", got, "/workspace/data")
+	}
+}
+
+func TestClaimMountWaitTimeoutDefaultsWhenEnabled(t *testing.T) {
+	got := claimMountWaitTimeout(&ClaimRequest{WaitForMounts: true})
+	if got != 30*time.Second {
+		t.Fatalf("claimMountWaitTimeout() = %s, want 30s", got)
+	}
+	custom := int32(2500)
+	got = claimMountWaitTimeout(&ClaimRequest{WaitForMounts: true, MountWaitTimeoutMs: &custom})
+	if got != 2500*time.Millisecond {
+		t.Fatalf("claimMountWaitTimeout() with override = %s, want 2500ms", got)
 	}
 }
 

--- a/manager/procd/pkg/http/handlers/initialize.go
+++ b/manager/procd/pkg/http/handlers/initialize.go
@@ -1,44 +1,60 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/file"
+	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/volume"
 	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/webhook"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"go.uber.org/zap"
 )
 
+const defaultMountWaitTimeout = 30 * time.Second
+
 // InitializeHandler handles sandbox initialization requests.
 type InitializeHandler struct {
-	dispatcher  *webhook.Dispatcher
-	fileManager *file.Manager
-	httpPort    int
-	logger      *zap.Logger
-	readyOnce   sync.Once
-	watchMu     sync.Mutex
-	watchPath   string
-	unsubscribe func() error
+	dispatcher    *webhook.Dispatcher
+	fileManager   *file.Manager
+	volumeManager *volume.Manager
+	httpPort      int
+	logger        *zap.Logger
+	readyOnce     sync.Once
+	watchMu       sync.Mutex
+	watchPath     string
+	unsubscribe   func() error
 }
 
 // NewInitializeHandler creates a new initialize handler.
-func NewInitializeHandler(dispatcher *webhook.Dispatcher, fileManager *file.Manager, httpPort int, logger *zap.Logger) *InitializeHandler {
+func NewInitializeHandler(dispatcher *webhook.Dispatcher, fileManager *file.Manager, volumeManager *volume.Manager, httpPort int, logger *zap.Logger) *InitializeHandler {
 	return &InitializeHandler{
-		dispatcher:  dispatcher,
-		fileManager: fileManager,
-		httpPort:    httpPort,
-		logger:      logger,
+		dispatcher:    dispatcher,
+		fileManager:   fileManager,
+		volumeManager: volumeManager,
+		httpPort:      httpPort,
+		logger:        logger,
 	}
 }
 
 // InitializeRequest is the request body for initializing sandbox settings.
 type InitializeRequest struct {
-	SandboxID string             `json:"sandbox_id"`
-	TeamID    string             `json:"team_id,omitempty"`
-	Webhook   *InitializeWebhook `json:"webhook,omitempty"`
+	SandboxID          string             `json:"sandbox_id"`
+	TeamID             string             `json:"team_id,omitempty"`
+	Webhook            *InitializeWebhook `json:"webhook,omitempty"`
+	Mounts             []InitializeMount  `json:"mounts,omitempty"`
+	WaitForMounts      bool               `json:"wait_for_mounts,omitempty"`
+	MountWaitTimeoutMs int32              `json:"mount_wait_timeout_ms,omitempty"`
+}
+
+type InitializeMount struct {
+	SandboxVolumeID string               `json:"sandboxvolume_id"`
+	MountPoint      string               `json:"mount_point"`
+	VolumeConfig    *volume.VolumeConfig `json:"volume_config,omitempty"`
 }
 
 // InitializeWebhook represents webhook configuration.
@@ -50,8 +66,9 @@ type InitializeWebhook struct {
 
 // InitializeResponse is returned after initialization.
 type InitializeResponse struct {
-	SandboxID string `json:"sandbox_id"`
-	TeamID    string `json:"team_id,omitempty"`
+	SandboxID       string               `json:"sandbox_id"`
+	TeamID          string               `json:"team_id,omitempty"`
+	BootstrapMounts []volume.MountStatus `json:"bootstrap_mounts,omitempty"`
 }
 
 // Initialize sets sandbox identity and webhook settings.
@@ -97,6 +114,12 @@ func (h *InitializeHandler) Initialize(w http.ResponseWriter, r *http.Request) {
 
 	h.configureWebhookWatch(strings.TrimSpace(webhookURL), strings.TrimSpace(webhookWatchDir))
 
+	bootstrapMounts, err := h.bootstrapMounts(r.Context(), req)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_mount_request", err.Error())
+		return
+	}
+
 	if webhookURL != "" {
 		h.readyOnce.Do(func() {
 			h.dispatcher.Enqueue(webhook.Event{
@@ -110,9 +133,30 @@ func (h *InitializeHandler) Initialize(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, InitializeResponse{
-		SandboxID: req.SandboxID,
-		TeamID:    teamID,
+		SandboxID:       req.SandboxID,
+		TeamID:          teamID,
+		BootstrapMounts: bootstrapMounts,
 	})
+}
+
+func (h *InitializeHandler) bootstrapMounts(ctx context.Context, req InitializeRequest) ([]volume.MountStatus, error) {
+	if h.volumeManager == nil || len(req.Mounts) == 0 {
+		return nil, nil
+	}
+	mounts := make([]volume.MountRequest, 0, len(req.Mounts))
+	for _, item := range req.Mounts {
+		mounts = append(mounts, volume.MountRequest{
+			SandboxVolumeID: item.SandboxVolumeID,
+			SandboxID:       req.SandboxID,
+			MountPoint:      item.MountPoint,
+			VolumeConfig:    item.VolumeConfig,
+		})
+	}
+	waitTimeout := time.Duration(req.MountWaitTimeoutMs) * time.Millisecond
+	if req.WaitForMounts && waitTimeout <= 0 {
+		waitTimeout = defaultMountWaitTimeout
+	}
+	return h.volumeManager.BootstrapMounts(ctx, mounts, req.WaitForMounts, waitTimeout)
 }
 
 func (h *InitializeHandler) configureWebhookWatch(webhookURL, watchDir string) {

--- a/manager/procd/pkg/http/handlers/initialize_test.go
+++ b/manager/procd/pkg/http/handlers/initialize_test.go
@@ -1,0 +1,70 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/volume"
+	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/webhook"
+	"go.uber.org/zap"
+)
+
+func TestInitializeReturnsBootstrapMountStatus(t *testing.T) {
+	dispatcher := webhook.NewDispatcher(webhook.Options{}, zap.NewNop())
+	t.Cleanup(func() {
+		_ = dispatcher.Shutdown(context.Background())
+	})
+	volumeManager := volume.NewManager(&volume.Config{}, bootstrapTestTokenProvider("token"), zap.NewNop())
+	handler := NewInitializeHandler(dispatcher, nil, volumeManager, 8080, zap.NewNop())
+
+	body, err := json.Marshal(InitializeRequest{
+		SandboxID:     "sandbox-1",
+		TeamID:        "team-1",
+		WaitForMounts: true,
+		Mounts: []InitializeMount{{
+			SandboxVolumeID: "vol-1",
+			MountPoint:      t.TempDir(),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/initialize", bytes.NewReader(body))
+	recorder := httptest.NewRecorder()
+	handler.Initialize(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("Initialize() status = %d, want %d body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+
+	var resp struct {
+		Success bool               `json:"success"`
+		Data    InitializeResponse `json:"data"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if !resp.Success {
+		t.Fatalf("expected success response: %s", recorder.Body.String())
+	}
+	if len(resp.Data.BootstrapMounts) != 1 {
+		t.Fatalf("bootstrap mounts = %d, want 1", len(resp.Data.BootstrapMounts))
+	}
+	if resp.Data.BootstrapMounts[0].State != volume.MountStateFailed {
+		t.Fatalf("bootstrap state = %q, want %q", resp.Data.BootstrapMounts[0].State, volume.MountStateFailed)
+	}
+	if resp.Data.BootstrapMounts[0].ErrorCode != "mount_failed" {
+		t.Fatalf("bootstrap error code = %q, want %q", resp.Data.BootstrapMounts[0].ErrorCode, "mount_failed")
+	}
+}
+
+type bootstrapTestTokenProvider string
+
+func (p bootstrapTestTokenProvider) GetInternalToken() string {
+	return string(p)
+}

--- a/manager/procd/pkg/http/server.go
+++ b/manager/procd/pkg/http/server.go
@@ -151,7 +151,7 @@ func (s *Server) setupRoutes() {
 	api.HandleFunc("/contexts/{id}/ws", contextHandler.WebSocket).Methods("GET")
 
 	// Initialize handler
-	initializeHandler := handlers.NewInitializeHandler(s.webhookDispatcher, s.fileManager, s.cfg.HTTPPort, s.logger)
+	initializeHandler := handlers.NewInitializeHandler(s.webhookDispatcher, s.fileManager, s.volumeManager, s.cfg.HTTPPort, s.logger)
 	api.HandleFunc("/initialize", initializeHandler.Initialize).Methods("POST")
 
 	// SandboxVolume handlers

--- a/manager/procd/pkg/volume/manager.go
+++ b/manager/procd/pkg/volume/manager.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -39,6 +40,8 @@ type Manager struct {
 	mounts      map[string]*mountInfo
 	mountPoints map[string]string
 	mounting    map[string]struct{}
+	mountStatus map[string]*MountStatus
+	statusCond  *sync.Cond
 
 	eventSink EventSink
 
@@ -48,14 +51,17 @@ type Manager struct {
 
 // NewManager creates a new volume manager.
 func NewManager(cfg *Config, tokenProvider TokenProvider, logger *zap.Logger) *Manager {
-	return &Manager{
+	mgr := &Manager{
 		cfg:           cfg,
 		tokenProvider: tokenProvider,
 		logger:        logger,
 		mounts:        make(map[string]*mountInfo),
 		mountPoints:   make(map[string]string),
 		mounting:      make(map[string]struct{}),
+		mountStatus:   make(map[string]*MountStatus),
 	}
+	mgr.statusCond = sync.NewCond(&mgr.mu)
+	return mgr
 }
 
 // SetEventSink sets the sink for volume watch events.
@@ -65,50 +71,128 @@ func (m *Manager) SetEventSink(sink EventSink) {
 	m.eventSink = sink
 }
 
+// BootstrapMounts schedules sandbox bootstrap mounts and optionally waits for them
+// to reach a terminal state.
+func (m *Manager) BootstrapMounts(ctx context.Context, reqs []MountRequest, wait bool, waitTimeout time.Duration) ([]MountStatus, error) {
+	if len(reqs) == 0 {
+		return nil, nil
+	}
+
+	prepared := make([]MountRequest, 0, len(reqs))
+	reserved := make([]string, 0, len(reqs))
+	batchMountPoints := make(map[string]string, len(reqs))
+	batchVolumes := make(map[string]struct{}, len(reqs))
+
+	m.mu.Lock()
+	for _, req := range reqs {
+		if req.SandboxVolumeID == "" {
+			m.rollbackBootstrapReservationsLocked(reserved)
+			m.mu.Unlock()
+			return nil, fmt.Errorf("missing volume id")
+		}
+		if err := m.validateMountPoint(req.MountPoint); err != nil {
+			m.rollbackBootstrapReservationsLocked(reserved)
+			m.mu.Unlock()
+			return nil, err
+		}
+
+		mountPoint := filepath.Clean(req.MountPoint)
+		if _, exists := batchVolumes[req.SandboxVolumeID]; exists {
+			m.rollbackBootstrapReservationsLocked(reserved)
+			m.mu.Unlock()
+			return nil, ErrVolumeAlreadyMounted
+		}
+		if existing, ok := batchMountPoints[mountPoint]; ok && existing != req.SandboxVolumeID {
+			m.rollbackBootstrapReservationsLocked(reserved)
+			m.mu.Unlock()
+			return nil, ErrMountPointInUse
+		}
+		if err := m.reserveMountLocked(req.SandboxVolumeID, mountPoint); err != nil {
+			m.rollbackBootstrapReservationsLocked(reserved)
+			m.mu.Unlock()
+			return nil, err
+		}
+
+		preparedReq := req
+		preparedReq.MountPoint = mountPoint
+		prepared = append(prepared, preparedReq)
+		reserved = append(reserved, req.SandboxVolumeID)
+		batchVolumes[req.SandboxVolumeID] = struct{}{}
+		batchMountPoints[mountPoint] = req.SandboxVolumeID
+		m.mountStatus[req.SandboxVolumeID] = &MountStatus{
+			SandboxVolumeID: req.SandboxVolumeID,
+			MountPoint:      mountPoint,
+			State:           MountStatePending,
+		}
+	}
+	m.statusCond.Broadcast()
+	m.mu.Unlock()
+
+	for _, req := range prepared {
+		go m.runBootstrapMount(req)
+	}
+
+	if !wait {
+		return m.snapshotStatuses(prepared), nil
+	}
+	return m.waitForMounts(ctx, prepared, waitTimeout), nil
+}
+
 // Mount mounts a sandbox volume at the specified mount point.
 func (m *Manager) Mount(ctx context.Context, req *MountRequest) (*MountResponse, error) {
+	return m.mount(ctx, req, false)
+}
+
+func (m *Manager) mount(ctx context.Context, req *MountRequest, reserved bool) (*MountResponse, error) {
 	if req == nil {
 		return nil, fmt.Errorf("missing request")
+	}
+	if req.SandboxVolumeID == "" {
+		return nil, fmt.Errorf("missing volume id")
 	}
 	if err := m.validateMountPoint(req.MountPoint); err != nil {
 		return nil, err
 	}
 	mountPoint := filepath.Clean(req.MountPoint)
 
+	if reserved {
+		m.markMountState(req.SandboxVolumeID, mountPoint, MountStateMounting, "", "")
+	}
+
 	if err := m.ensureMountPoint(mountPoint); err != nil {
+		m.finishMountWithError(req.SandboxVolumeID, mountPoint, err)
 		return nil, err
 	}
 
-	m.mu.Lock()
-	if _, ok := m.mounts[req.SandboxVolumeID]; ok {
+	if !reserved {
+		m.mu.Lock()
+		if err := m.reserveMountLocked(req.SandboxVolumeID, mountPoint); err != nil {
+			m.mu.Unlock()
+			return nil, err
+		}
 		m.mu.Unlock()
-		return nil, ErrVolumeAlreadyMounted
 	}
-	if _, ok := m.mounting[req.SandboxVolumeID]; ok {
-		m.mu.Unlock()
-		return nil, ErrVolumeMountInProgress
-	}
-	if existing, ok := m.mountPoints[mountPoint]; ok && existing != req.SandboxVolumeID {
-		m.mu.Unlock()
-		return nil, ErrMountPointInUse
-	}
-	m.mounting[req.SandboxVolumeID] = struct{}{}
-	m.mu.Unlock()
 
 	defer func() {
+		if reserved {
+			return
+		}
 		m.mu.Lock()
 		delete(m.mounting, req.SandboxVolumeID)
+		m.statusCond.Broadcast()
 		m.mu.Unlock()
 	}()
 
 	client, err := m.getClient(ctx)
 	if err != nil {
+		m.finishMountWithError(req.SandboxVolumeID, mountPoint, err)
 		return nil, err
 	}
 
 	volumeConfig := m.mergeVolumeConfig(req.VolumeConfig)
 	mountSessionID, err := m.mountVolumeRemote(ctx, client, req.SandboxVolumeID, volumeConfig)
 	if err != nil {
+		m.finishMountWithError(req.SandboxVolumeID, mountPoint, err)
 		return nil, err
 	}
 
@@ -116,6 +200,7 @@ func (m *Manager) Mount(ctx context.Context, req *MountRequest) (*MountResponse,
 	server, err := m.mountFuse(fs, mountPoint)
 	if err != nil {
 		_ = m.unmountVolumeRemote(ctx, client, req.SandboxVolumeID, mountSessionID)
+		m.finishMountWithError(req.SandboxVolumeID, mountPoint, err)
 		return nil, err
 	}
 
@@ -133,6 +218,16 @@ func (m *Manager) Mount(ctx context.Context, req *MountRequest) (*MountResponse,
 	m.mu.Lock()
 	m.mounts[req.SandboxVolumeID] = info
 	m.mountPoints[mountPoint] = req.SandboxVolumeID
+	delete(m.mounting, req.SandboxVolumeID)
+	m.mountStatus[req.SandboxVolumeID] = &MountStatus{
+		SandboxVolumeID:     req.SandboxVolumeID,
+		MountPoint:          mountPoint,
+		State:               MountStateMounted,
+		MountedAt:           info.mountedAt.Format(time.RFC3339),
+		MountedDurationSecs: 0,
+		MountSessionID:      mountSessionID,
+	}
+	m.statusCond.Broadcast()
 	m.mu.Unlock()
 
 	return &MountResponse{
@@ -184,6 +279,8 @@ func (m *Manager) Unmount(ctx context.Context, volumeID, mountSessionID string) 
 	m.mu.Lock()
 	delete(m.mounts, volumeID)
 	delete(m.mountPoints, info.mountPoint)
+	delete(m.mountStatus, volumeID)
+	m.statusCond.Broadcast()
 	m.mu.Unlock()
 
 	return nil
@@ -194,16 +291,178 @@ func (m *Manager) GetStatus() []MountStatus {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	status := make([]MountStatus, 0, len(m.mounts))
+	status := make([]MountStatus, 0, len(m.mounts)+len(m.mountStatus))
 	now := time.Now()
+	for _, entry := range m.mountStatus {
+		if entry == nil {
+			continue
+		}
+		item := *entry
+		if info, ok := m.mounts[item.SandboxVolumeID]; ok && info != nil {
+			item.MountedDurationSecs = int64(now.Sub(info.mountedAt).Seconds())
+		}
+		status = append(status, item)
+	}
 	for _, info := range m.mounts {
+		if info == nil {
+			continue
+		}
+		if _, ok := m.mountStatus[info.volumeID]; ok {
+			continue
+		}
 		status = append(status, MountStatus{
 			SandboxVolumeID:     info.volumeID,
 			MountPoint:          info.mountPoint,
+			State:               MountStateMounted,
 			MountedAt:           info.mountedAt.Format(time.RFC3339),
 			MountedDurationSecs: int64(now.Sub(info.mountedAt).Seconds()),
 			MountSessionID:      info.mountSessionID,
 		})
+	}
+	sort.Slice(status, func(i, j int) bool {
+		if status[i].MountPoint == status[j].MountPoint {
+			return status[i].SandboxVolumeID < status[j].SandboxVolumeID
+		}
+		return status[i].MountPoint < status[j].MountPoint
+	})
+	return status
+}
+
+func (m *Manager) runBootstrapMount(req MountRequest) {
+	if _, err := m.mount(context.Background(), &req, true); err != nil {
+		return
+	}
+}
+
+func (m *Manager) reserveMountLocked(volumeID, mountPoint string) error {
+	if _, ok := m.mounts[volumeID]; ok {
+		return ErrVolumeAlreadyMounted
+	}
+	if _, ok := m.mounting[volumeID]; ok {
+		return ErrVolumeMountInProgress
+	}
+	if existing, ok := m.mountPoints[mountPoint]; ok && existing != volumeID {
+		return ErrMountPointInUse
+	}
+	m.mounting[volumeID] = struct{}{}
+	return nil
+}
+
+func (m *Manager) rollbackBootstrapReservationsLocked(volumeIDs []string) {
+	for _, volumeID := range volumeIDs {
+		delete(m.mounting, volumeID)
+		delete(m.mountStatus, volumeID)
+	}
+	m.statusCond.Broadcast()
+}
+
+func (m *Manager) markMountState(volumeID, mountPoint, state, errorCode, errorMessage string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	status := m.mountStatus[volumeID]
+	if status == nil {
+		status = &MountStatus{SandboxVolumeID: volumeID, MountPoint: mountPoint}
+		m.mountStatus[volumeID] = status
+	}
+	status.MountPoint = mountPoint
+	status.State = state
+	status.ErrorCode = errorCode
+	status.ErrorMessage = errorMessage
+	m.statusCond.Broadcast()
+}
+
+func (m *Manager) finishMountWithError(volumeID, mountPoint string, err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.mounting, volumeID)
+	if status := m.mountStatus[volumeID]; status != nil {
+		status.MountPoint = mountPoint
+		status.State = MountStateFailed
+		status.ErrorCode = mountErrorCode(err)
+		status.ErrorMessage = err.Error()
+		status.MountedAt = ""
+		status.MountSessionID = ""
+		status.MountedDurationSecs = 0
+	}
+	m.statusCond.Broadcast()
+}
+
+func mountErrorCode(err error) string {
+	switch err {
+	case ErrVolumeAlreadyMounted:
+		return "already_mounted"
+	case ErrVolumeMountInProgress:
+		return "mount_in_progress"
+	case ErrMountPointInUse:
+		return "mount_point_in_use"
+	case ErrInvalidMountPoint:
+		return "invalid_mount_point"
+	default:
+		return "mount_failed"
+	}
+}
+
+func (m *Manager) waitForMounts(ctx context.Context, reqs []MountRequest, waitTimeout time.Duration) []MountStatus {
+	waitCtx := ctx
+	cancel := func() {}
+	if waitTimeout > 0 {
+		waitCtx, cancel = context.WithTimeout(ctx, waitTimeout)
+	}
+	defer cancel()
+
+	var timer *time.Timer
+	if deadline, ok := waitCtx.Deadline(); ok {
+		timer = time.AfterFunc(time.Until(deadline), func() {
+			m.mu.Lock()
+			m.statusCond.Broadcast()
+			m.mu.Unlock()
+		})
+		defer timer.Stop()
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for !m.mountsTerminalLocked(reqs) {
+		if waitCtx.Err() != nil {
+			break
+		}
+		m.statusCond.Wait()
+	}
+	return m.snapshotStatusesLocked(reqs)
+}
+
+func (m *Manager) mountsTerminalLocked(reqs []MountRequest) bool {
+	for _, req := range reqs {
+		status := m.mountStatus[req.SandboxVolumeID]
+		if status == nil {
+			return false
+		}
+		if status.State != MountStateMounted && status.State != MountStateFailed {
+			return false
+		}
+	}
+	return true
+}
+
+func (m *Manager) snapshotStatuses(reqs []MountRequest) []MountStatus {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.snapshotStatusesLocked(reqs)
+}
+
+func (m *Manager) snapshotStatusesLocked(reqs []MountRequest) []MountStatus {
+	status := make([]MountStatus, 0, len(reqs))
+	now := time.Now()
+	for _, req := range reqs {
+		entry := m.mountStatus[req.SandboxVolumeID]
+		if entry == nil {
+			continue
+		}
+		item := *entry
+		if info, ok := m.mounts[item.SandboxVolumeID]; ok && info != nil {
+			item.MountedDurationSecs = int64(now.Sub(info.mountedAt).Seconds())
+		}
+		status = append(status, item)
 	}
 	return status
 }

--- a/manager/procd/pkg/volume/manager_test.go
+++ b/manager/procd/pkg/volume/manager_test.go
@@ -1,6 +1,7 @@
 package volume
 
 import (
+	"context"
 	"testing"
 	"time"
 )
@@ -100,5 +101,41 @@ func TestStatusDuration(t *testing.T) {
 	}
 	if status[0].MountedDurationSecs < 1 {
 		t.Fatalf("expected mounted duration")
+	}
+}
+
+func TestBootstrapMountsRejectsDuplicateMountPoint(t *testing.T) {
+	manager := NewManager(&Config{}, nil, nil)
+	_, err := manager.BootstrapMounts(context.Background(), []MountRequest{
+		{SandboxVolumeID: "vol-1", MountPoint: "/tmp/one"},
+		{SandboxVolumeID: "vol-2", MountPoint: "/tmp/one"},
+	}, false, 0)
+	if err != ErrMountPointInUse {
+		t.Fatalf("BootstrapMounts() error = %v, want %v", err, ErrMountPointInUse)
+	}
+}
+
+func TestBootstrapMountsWaitReturnsFailedStatus(t *testing.T) {
+	manager := NewManager(&Config{}, staticTokenProvider{}, nil)
+	status, err := manager.BootstrapMounts(context.Background(), []MountRequest{{
+		SandboxVolumeID: "vol-1",
+		SandboxID:       "sandbox-1",
+		MountPoint:      t.TempDir(),
+	}}, true, 2*time.Second)
+	if err != nil {
+		t.Fatalf("BootstrapMounts() error = %v", err)
+	}
+	if len(status) != 1 {
+		t.Fatalf("BootstrapMounts() returned %d statuses, want 1", len(status))
+	}
+	if status[0].State != MountStateFailed {
+		t.Fatalf("status state = %q, want %q", status[0].State, MountStateFailed)
+	}
+	if status[0].ErrorCode != "mount_failed" {
+		t.Fatalf("error code = %q, want %q", status[0].ErrorCode, "mount_failed")
+	}
+	all := manager.GetStatus()
+	if len(all) != 1 || all[0].State != MountStateFailed {
+		t.Fatalf("GetStatus() = %+v, want failed bootstrap mount", all)
 	}
 }

--- a/manager/procd/pkg/volume/types.go
+++ b/manager/procd/pkg/volume/types.go
@@ -55,10 +55,20 @@ type UnmountRequest struct {
 type MountStatus struct {
 	SandboxVolumeID     string `json:"sandboxvolume_id"`
 	MountPoint          string `json:"mount_point"`
+	State               string `json:"state"`
 	MountedAt           string `json:"mounted_at"`
 	MountedDurationSecs int64  `json:"mounted_duration_sec"`
 	MountSessionID      string `json:"mount_session_id"`
+	ErrorCode           string `json:"error_code,omitempty"`
+	ErrorMessage        string `json:"error_message,omitempty"`
 }
+
+const (
+	MountStatePending  = "pending"
+	MountStateMounting = "mounting"
+	MountStateMounted  = "mounted"
+	MountStateFailed   = "failed"
+)
 
 // TokenProvider supplies the internal token for storage-proxy gRPC calls.
 type TokenProvider interface {

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -3605,7 +3605,34 @@ components:
           type: string
         config:
           $ref: "#/components/schemas/SandboxConfig"
+        mounts:
+          type: array
+          items:
+            $ref: "#/components/schemas/ClaimMountRequest"
+        wait_for_mounts:
+          type: boolean
+          default: false
+          description: |
+            When true, claim waits best-effort for requested bootstrap mounts to
+            reach a terminal state before returning. The wait is bounded by
+            `mount_wait_timeout_ms`.
+        mount_wait_timeout_ms:
+          type: integer
+          format: int32
+          description: |
+            Optional best-effort wait budget in milliseconds for bootstrap
+            mounts when `wait_for_mounts` is true.
       required: []
+    ClaimMountRequest:
+      type: object
+      properties:
+        sandboxvolume_id:
+          type: string
+        mount_point:
+          type: string
+        volume_config:
+          $ref: "#/components/schemas/VolumeConfig"
+      required: [sandboxvolume_id, mount_point]
     SandboxConfig:
       type: object
       properties:
@@ -3707,6 +3734,10 @@ components:
         cluster_id:
           type: string
           nullable: true
+        bootstrap_mounts:
+          type: array
+          items:
+            $ref: "#/components/schemas/MountStatus"
       required: [sandbox_id, status, pod_name, template]
     SuccessClaimResponse:
       allOf:
@@ -4526,6 +4557,9 @@ components:
           type: string
         mount_point:
           type: string
+        state:
+          type: string
+          enum: [pending, mounting, mounted, failed]
         mounted_at:
           type: string
         mounted_duration_sec:
@@ -4533,6 +4567,11 @@ components:
           format: int64
         mount_session_id:
           type: string
+        error_code:
+          type: string
+        error_message:
+          type: string
+      required: [sandboxvolume_id, mount_point, state]
     SuccessMountResponse:
       allOf:
         - $ref: "#/components/schemas/SuccessEnvelope"

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -107,6 +107,14 @@ const (
 	Global GatewayMetadataGatewayMode = "global"
 )
 
+// Defines values for MountStatusState.
+const (
+	MountStatusStateFailed   MountStatusState = "failed"
+	MountStatusStateMounted  MountStatusState = "mounted"
+	MountStatusStateMounting MountStatusState = "mounting"
+	MountStatusStatePending  MountStatusState = "pending"
+)
+
 // Defines values for ProcessType.
 const (
 	Cmd  ProcessType = "cmd"
@@ -507,10 +515,10 @@ const (
 
 // Defines values for GetApiV1SandboxesParamsStatus.
 const (
-	Completed GetApiV1SandboxesParamsStatus = "completed"
-	Failed    GetApiV1SandboxesParamsStatus = "failed"
-	Running   GetApiV1SandboxesParamsStatus = "running"
-	Starting  GetApiV1SandboxesParamsStatus = "starting"
+	GetApiV1SandboxesParamsStatusCompleted GetApiV1SandboxesParamsStatus = "completed"
+	GetApiV1SandboxesParamsStatusFailed    GetApiV1SandboxesParamsStatus = "failed"
+	GetApiV1SandboxesParamsStatusRunning   GetApiV1SandboxesParamsStatus = "running"
+	GetApiV1SandboxesParamsStatusStarting  GetApiV1SandboxesParamsStatus = "starting"
 )
 
 // APIKey defines model for APIKey.
@@ -605,19 +613,37 @@ type ChangeRequest struct {
 // ChangeRequestEntryKind defines model for ChangeRequest.EntryKind.
 type ChangeRequestEntryKind string
 
+// ClaimMountRequest defines model for ClaimMountRequest.
+type ClaimMountRequest struct {
+	MountPoint      string        `json:"mount_point"`
+	SandboxvolumeId string        `json:"sandboxvolume_id"`
+	VolumeConfig    *VolumeConfig `json:"volume_config,omitempty"`
+}
+
 // ClaimRequest defines model for ClaimRequest.
 type ClaimRequest struct {
-	Config   *SandboxConfig `json:"config,omitempty"`
-	Template *string        `json:"template,omitempty"`
+	Config *SandboxConfig `json:"config,omitempty"`
+
+	// MountWaitTimeoutMs Optional best-effort wait budget in milliseconds for bootstrap
+	// mounts when `wait_for_mounts` is true.
+	MountWaitTimeoutMs *int32               `json:"mount_wait_timeout_ms,omitempty"`
+	Mounts             *[]ClaimMountRequest `json:"mounts,omitempty"`
+	Template           *string              `json:"template,omitempty"`
+
+	// WaitForMounts When true, claim waits best-effort for requested bootstrap mounts to
+	// reach a terminal state before returning. The wait is bounded by
+	// `mount_wait_timeout_ms`.
+	WaitForMounts *bool `json:"wait_for_mounts,omitempty"`
 }
 
 // ClaimResponse defines model for ClaimResponse.
 type ClaimResponse struct {
-	ClusterId *string `json:"cluster_id"`
-	PodName   string  `json:"pod_name"`
-	SandboxId string  `json:"sandbox_id"`
-	Status    string  `json:"status"`
-	Template  string  `json:"template"`
+	BootstrapMounts *[]MountStatus `json:"bootstrap_mounts,omitempty"`
+	ClusterId       *string        `json:"cluster_id"`
+	PodName         string         `json:"pod_name"`
+	SandboxId       string         `json:"sandbox_id"`
+	Status          string         `json:"status"`
+	Template        string         `json:"template"`
 }
 
 // ContainerSpec defines model for ContainerSpec.
@@ -1069,12 +1095,18 @@ type MountResponse struct {
 
 // MountStatus defines model for MountStatus.
 type MountStatus struct {
-	MountPoint         *string `json:"mount_point,omitempty"`
-	MountSessionId     *string `json:"mount_session_id,omitempty"`
-	MountedAt          *string `json:"mounted_at,omitempty"`
-	MountedDurationSec *int64  `json:"mounted_duration_sec,omitempty"`
-	SandboxvolumeId    *string `json:"sandboxvolume_id,omitempty"`
+	ErrorCode          *string          `json:"error_code,omitempty"`
+	ErrorMessage       *string          `json:"error_message,omitempty"`
+	MountPoint         string           `json:"mount_point"`
+	MountSessionId     *string          `json:"mount_session_id,omitempty"`
+	MountedAt          *string          `json:"mounted_at,omitempty"`
+	MountedDurationSec *int64           `json:"mounted_duration_sec,omitempty"`
+	SandboxvolumeId    string           `json:"sandboxvolume_id"`
+	State              MountStatusState `json:"state"`
 }
+
+// MountStatusState defines model for MountStatus.State.
+type MountStatusState string
 
 // MoveFileRequest defines model for MoveFileRequest.
 type MoveFileRequest struct {

--- a/skills/sandbox0/references/docs-src/volume/mounts/page.mdx
+++ b/skills/sandbox0/references/docs-src/volume/mounts/page.mdx
@@ -122,6 +122,46 @@ s0 sandbox volume mount \\
   ]}
 />
 
+## Bootstrap Mounts During Claim
+
+If you already know which existing Volumes a sandbox should start with, you can include
+bootstrap mounts directly in the sandbox claim request.
+
+This is useful when a claimed sandbox should immediately open a pre-existing project
+workspace or dataset.
+
+The claim request accepts:
+
+- `mounts[]`: existing volumes to mount into the sandbox
+- `wait_for_mounts`: optional best-effort wait for the requested mounts to reach a terminal state
+- `mount_wait_timeout_ms`: optional wait budget for `wait_for_mounts`
+
+Cold-start note:
+
+- By default, claim-time mounts are asynchronous bootstrap work.
+- When `wait_for_mounts` is omitted or false, the claim API can return before mounts finish.
+- Use `/api/v1/sandboxes/{'{'}id{'}'}/sandboxvolumes/status` or the SDK claim response to inspect
+  mount state (`pending`, `mounting`, `mounted`, `failed`).
+
+Example request:
+
+```json
+{
+    "template": "default",
+    "mounts": [
+        {
+            "sandboxvolume_id": "vol_123",
+            "mount_point": "/workspace/data"
+        }
+    ],
+    "wait_for_mounts": true,
+    "mount_wait_timeout_ms": 30000
+}
+```
+
+The claim response now includes `bootstrap_mounts`, so callers can tell whether requested
+mounts are still pending, already mounted, or failed with an error.
+
 ## Override Performance Config at Mount Time
 
 You can specify different performance parameters than the Volume's default:

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -185,6 +185,14 @@ func registerApiModeSuite(envProvider func() *framework.ScenarioEnv, opts apiMod
 					assertVolumeLifecycle(env, session, sandboxID)
 				})
 
+				It("bootstraps an existing volume during claim", func() {
+					assertClaimBootstrapMountLifecycle(env, session)
+				})
+
+				It("rejects invalid bootstrap mount requests at claim time", func() {
+					assertClaimBootstrapMountValidation(env, session)
+				})
+
 				It("serves volume sync backend APIs", func() {
 					assertVolumeSyncBackendLifecycle(env, session)
 				})
@@ -1334,7 +1342,7 @@ func assertVolumeLifecycle(env *framework.ScenarioEnv, session *e2eutils.Session
 
 	var foundMountedVolume bool
 	for _, mount := range *statusResp.Data.Mounts {
-		if mount.SandboxvolumeId != nil && *mount.SandboxvolumeId == volumeID {
+		if mount.SandboxvolumeId == volumeID {
 			foundMountedVolume = true
 			if mount.MountSessionId != nil {
 				Expect(*mount.MountSessionId).To(Equal(mountResp.MountSessionId))
@@ -1375,6 +1383,83 @@ func assertVolumeLifecycle(env *framework.ScenarioEnv, session *e2eutils.Session
 	status, err = session.DeleteSandboxVolume(env.TestCtx.Context, GinkgoT(), volumeID)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(status).To(Equal(http.StatusOK))
+}
+
+func assertClaimBootstrapMountLifecycle(env *framework.ScenarioEnv, session *e2eutils.Session) {
+	cacheSize := "512M"
+	createReq := apispec.CreateSandboxVolumeRequest{CacheSize: &cacheSize}
+	volume, status, err := session.CreateSandboxVolume(env.TestCtx.Context, GinkgoT(), createReq)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusCreated))
+	Expect(volume).NotTo(BeNil())
+	volumeID := expectStringPtr(volume.Id, "volume id")
+	DeferCleanup(func() {
+		_, _ = session.DeleteSandboxVolume(env.TestCtx.Context, GinkgoT(), volumeID)
+	})
+
+	seedPath := "/claim-bootstrap/hello.txt"
+	seedContent := []byte("hello bootstrap claim mount")
+	status, err = session.WriteVolumeFile(env.TestCtx.Context, GinkgoT(), volumeID, seedPath, seedContent, "")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+
+	mountWaitTimeout := int32(45000)
+	waitForMounts := true
+	templateID := "default"
+	mountPoint := "/workspace/bootstrap-data"
+	claimReq := apispec.ClaimRequest{
+		Template: &templateID,
+		Mounts: &[]apispec.ClaimMountRequest{{
+			SandboxvolumeId: volumeID,
+			MountPoint:      mountPoint,
+		}},
+		WaitForMounts:      &waitForMounts,
+		MountWaitTimeoutMs: &mountWaitTimeout,
+	}
+	claimResp, err := session.ClaimSandboxWithRequest(env.TestCtx.Context, GinkgoT(), claimReq)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(claimResp).NotTo(BeNil())
+	sandboxID := claimResp.SandboxId
+	DeferCleanup(func() {
+		_ = session.DeleteSandbox(env.TestCtx.Context, GinkgoT(), sandboxID)
+	})
+	Expect(claimResp.BootstrapMounts).NotTo(BeNil())
+	Expect(*claimResp.BootstrapMounts).NotTo(BeEmpty())
+	Expect((*claimResp.BootstrapMounts)[0].State).To(Equal(apispec.MountStatusStateMounted))
+
+	Eventually(func() apispec.MountStatusState {
+		statusResp, statusCode, statusErr := session.GetSandboxVolumeStatus(env.TestCtx.Context, GinkgoT(), sandboxID)
+		if statusErr != nil || statusCode != http.StatusOK || statusResp == nil || statusResp.Data == nil || statusResp.Data.Mounts == nil {
+			return apispec.MountStatusStatePending
+		}
+		for _, mount := range *statusResp.Data.Mounts {
+			if mount.SandboxvolumeId == volumeID {
+				return mount.State
+			}
+		}
+		return apispec.MountStatusStatePending
+	}).WithTimeout(45 * time.Second).WithPolling(1 * time.Second).Should(Equal(apispec.MountStatusStateMounted))
+
+	Eventually(func() ([]byte, error) {
+		body, _, readErr := session.ReadFile(env.TestCtx.Context, GinkgoT(), sandboxID, mountPoint+seedPath)
+		return body, readErr
+	}).WithTimeout(20 * time.Second).WithPolling(1 * time.Second).Should(Equal(seedContent))
+}
+
+func assertClaimBootstrapMountValidation(env *framework.ScenarioEnv, session *e2eutils.Session) {
+	waitForMounts := true
+	templateID := "default"
+	claimReq := apispec.ClaimRequest{
+		Template: &templateID,
+		Mounts: &[]apispec.ClaimMountRequest{
+			{SandboxvolumeId: "vol-a", MountPoint: "/workspace/data"},
+			{SandboxvolumeId: "vol-b", MountPoint: "/workspace/data"},
+		},
+		WaitForMounts: &waitForMounts,
+	}
+	_, status, err := session.ClaimSandboxDetailed(env.TestCtx.Context, GinkgoT(), claimReq)
+	Expect(err).To(HaveOccurred())
+	Expect(status).To(Equal(http.StatusBadRequest))
 }
 
 func assertVolumeSyncBackendLifecycle(env *framework.ScenarioEnv, session *e2eutils.Session) {

--- a/tests/e2e/utils/sandbox.go
+++ b/tests/e2e/utils/sandbox.go
@@ -79,27 +79,34 @@ func (s *Session) ListSandboxes(ctx context.Context, t ContractT, opts *ListSand
 }
 
 func (s *Session) ClaimSandbox(ctx context.Context, t ContractT, template string) (*apispec.ClaimResponse, error) {
+	req := apispec.ClaimRequest{Template: &template}
+	return s.ClaimSandboxWithRequest(ctx, t, req)
+}
+
+func (s *Session) ClaimSandboxWithRequest(ctx context.Context, t ContractT, req apispec.ClaimRequest) (*apispec.ClaimResponse, error) {
+	resp, _, err := s.ClaimSandboxDetailed(ctx, t, req)
+	return resp, err
+}
+
+func (s *Session) ClaimSandboxDetailed(ctx context.Context, t ContractT, req apispec.ClaimRequest) (*apispec.ClaimResponse, int, error) {
 	if s.teamID == "" || s.userID == "" {
-		return nil, fmt.Errorf("team or user id missing")
-	}
-	req := apispec.ClaimRequest{
-		Template: &template,
+		return nil, 0, fmt.Errorf("team or user id missing")
 	}
 	status, body, err := s.doJSONSpecRequest(t, ctx, http.MethodPost, "/api/v1/sandboxes", "/api/v1/sandboxes", req, true)
 	if err != nil {
-		return nil, err
+		return nil, status, err
 	}
 	if status != http.StatusCreated {
-		return nil, fmt.Errorf("claim sandbox failed with status %d: %s", status, formatAPIError(body))
+		return nil, status, fmt.Errorf("claim sandbox failed with status %d: %s", status, formatAPIError(body))
 	}
 	var resp apispec.SuccessClaimResponse
 	if err := json.Unmarshal(body, &resp); err != nil {
-		return nil, err
+		return nil, status, err
 	}
 	if !resp.Success || resp.Data == nil || resp.Data.SandboxId == "" {
-		return nil, fmt.Errorf("claim sandbox response missing id")
+		return nil, status, fmt.Errorf("claim sandbox response missing id")
 	}
-	return resp.Data, nil
+	return resp.Data, status, nil
 }
 
 func (s *Session) DeleteSandbox(ctx context.Context, t ContractT, sandboxID string) error {

--- a/tests/integration/internal/tests/manager/api_test.go
+++ b/tests/integration/internal/tests/manager/api_test.go
@@ -21,6 +21,7 @@ import (
 	managerhttp "github.com/sandbox0-ai/sandbox0/manager/pkg/http"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/namespacepolicy"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/service"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 	"github.com/sandbox0-ai/sandbox0/pkg/observability"
@@ -245,6 +246,95 @@ func TestCreateTemplateLegacyEnsuresNamespaceIngressBaseline(t *testing.T) {
 	}
 }
 
+func TestClaimSandboxPassesBootstrapMountsToProcd(t *testing.T) {
+	recorder := &initializeRequestRecorder{}
+	procdServer := newInitializeRecordingProcdServer(t, recorder, service.InitializeResponse{
+		SandboxID: "initialized",
+		BootstrapMounts: []service.BootstrapMountStatus{{
+			SandboxVolumeID: "vol-1",
+			MountPoint:      "/workspace/data",
+			State:           "mounted",
+			MountSessionID:  "session-1",
+		}},
+	})
+	t.Cleanup(procdServer.Close)
+
+	procdClient := newProcdClientForURL(t, procdServer.URL)
+	privateKey, _, err := createInternalKeys()
+	utils.RequireNoError(t, err, "create procd keys")
+	procdGen := internalauth.NewGenerator(internalauth.DefaultGeneratorConfig("manager", privateKey))
+
+	env := newManagerTestEnvWithOptions(t, managerTestEnvOptions{
+		sandboxConfig: service.SandboxServiceConfig{
+			DefaultTTL:             time.Hour,
+			PauseMinMemoryRequest:  "10Mi",
+			PauseMinMemoryLimit:    "32Mi",
+			PauseMemoryBufferRatio: 1.1,
+			PauseMinCPU:            "10m",
+			ProcdPort:              49983,
+			ProcdClientTimeout:     5 * time.Second,
+			ProcdInitTimeout:       5 * time.Second,
+		},
+		internalTokenGenerator: service.NewInternalTokenGenerator(procdGen),
+		procdTokenGenerator:    service.NewProcdTokenGenerator(procdGen),
+		procdClient:            procdClient,
+	})
+
+	templateName := "claim-bootstrap"
+	resp, body := doRequest(t, env.server.Client(), http.MethodPost, env.server.URL+"/internal/v1/templates", env.token, map[string]any{
+		"metadata": map[string]any{"name": templateName},
+		"spec":     map[string]any{},
+	})
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create template status = %d, body = %s", resp.StatusCode, string(body))
+	}
+
+	namespace, err := naming.TemplateNamespaceForBuiltin(templateName)
+	utils.RequireNoError(t, err, "resolve template namespace")
+	addIdleReadyPod(t, env, namespace, "idle-bootstrap", templateName, "10.0.0.10")
+
+	resp, body = doRequest(t, env.server.Client(), http.MethodPost, env.server.URL+"/api/v1/sandboxes", env.token, map[string]any{
+		"template": templateName,
+		"mounts": []map[string]any{{
+			"sandboxvolume_id": "vol-1",
+			"mount_point":      "/workspace/data",
+		}},
+		"wait_for_mounts":       true,
+		"mount_wait_timeout_ms": 1500,
+	})
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("claim status = %d, body = %s", resp.StatusCode, string(body))
+	}
+
+	claimResp, errInfo, err := spec.DecodeResponse[service.ClaimResponse](bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("decode claim response: %v", err)
+	}
+	if errInfo != nil {
+		t.Fatalf("unexpected claim error: %+v", errInfo)
+	}
+	if claimResp == nil || len(claimResp.BootstrapMounts) != 1 {
+		t.Fatalf("bootstrap mounts = %+v, want 1 entry", claimResp)
+	}
+	if claimResp.BootstrapMounts[0].State != "mounted" {
+		t.Fatalf("claim bootstrap state = %q, want mounted", claimResp.BootstrapMounts[0].State)
+	}
+
+	initReq := recorder.Get()
+	if !initReq.WaitForMounts {
+		t.Fatal("expected wait_for_mounts to be forwarded")
+	}
+	if initReq.MountWaitTimeoutMs != 1500 {
+		t.Fatalf("mount_wait_timeout_ms = %d, want 1500", initReq.MountWaitTimeoutMs)
+	}
+	if len(initReq.Mounts) != 1 {
+		t.Fatalf("initialize mounts = %d, want 1", len(initReq.Mounts))
+	}
+	if initReq.Mounts[0].SandboxVolumeID != "vol-1" || initReq.Mounts[0].MountPoint != "/workspace/data" {
+		t.Fatalf("unexpected initialize mount payload: %+v", initReq.Mounts[0])
+	}
+}
+
 type testTemplateLister struct {
 	client clientset.Interface
 }
@@ -318,6 +408,60 @@ func addSandboxPod(t *testing.T, env *managerTestEnv, name, teamID, userID strin
 	_, err := env.k8sClient.CoreV1().Pods(pod.Namespace).Create(context.Background(), pod, metav1.CreateOptions{})
 	utils.RequireNoError(t, err, "create pod in fake client")
 	utils.RequireNoError(t, env.podIndexer.Add(pod), "add pod to indexer")
+}
+
+func addIdleReadyPod(t *testing.T, env *managerTestEnv, namespace, name, templateID, podIP string) {
+	t.Helper()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				controller.LabelTemplateID: templateID,
+				controller.LabelPoolType:   controller.PoolTypeIdle,
+			},
+			ResourceVersion: "1",
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			PodIP: podIP,
+			Conditions: []corev1.PodCondition{{
+				Type:   corev1.PodReady,
+				Status: corev1.ConditionTrue,
+			}},
+		},
+	}
+	_, err := env.k8sClient.CoreV1().Pods(namespace).Create(context.Background(), pod, metav1.CreateOptions{})
+	utils.RequireNoError(t, err, "create ready idle pod in fake client")
+	utils.RequireNoError(t, env.podIndexer.Add(pod), "add ready idle pod to indexer")
+}
+
+type initializeRequestRecorder struct {
+	request service.InitializeRequest
+}
+
+func (r *initializeRequestRecorder) Set(req service.InitializeRequest) {
+	r.request = req
+}
+
+func (r *initializeRequestRecorder) Get() service.InitializeRequest {
+	return r.request
+}
+
+func newInitializeRecordingProcdServer(t *testing.T, recorder *initializeRequestRecorder, response service.InitializeResponse) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/initialize", func(w http.ResponseWriter, r *http.Request) {
+		var req service.InitializeRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode initialize request: %v", err)
+		}
+		if recorder != nil {
+			recorder.Set(req)
+		}
+		_ = spec.WriteSuccess(w, http.StatusOK, response)
+	})
+	return httptest.NewServer(mux)
 }
 
 type rewriteTransport struct {


### PR DESCRIPTION
## Summary
- add claim-time bootstrap mounts for existing sandbox volumes
- plumb bootstrap mount requests and status through manager, procd, and the OpenAPI surface
- add unit, integration, e2e, and docs coverage for claim-time volume mounts

Closes #143

## Testing
- go test ./manager/pkg/service ./manager/procd/pkg/volume ./manager/procd/pkg/http/handlers ./tests/integration/internal/tests/manager
- ssh kind "bash -lc "export PATH=/usr/local/soft/go/bin:$PATH; cd /root && make test-again""
- direct HTTP validation on ubuntu kind: create volume -> write seed file -> claim with mounts -> verify mounted status and mounted file readback -> verify invalid duplicate mount point returns 400
- ssh kind "bash -lc 'export PATH=/usr/local/soft/go/bin:$PATH; cd /root/infra && E2E_USE_EXISTING_CLUSTER=true E2E_SKIP_OPERATOR_INSTALL=true E2E_SKIP_OPERATOR_UNINSTALL=true E2E_SINGLE_CLUSTER_SCENARIOS=fullmode go test -v -count=1 ./tests/e2e/scenarios/single-cluster/... -ginkgo.focus=claim -timeout=45m'"