### PR TITLE
docs: add template sidecars guide

### DIFF
--- a/skills/sandbox0/references/docs-src/manifest.json
+++ b/skills/sandbox0/references/docs-src/manifest.json
@@ -80,6 +80,10 @@
           "title": "Warm Pool"
         },
         {
+          "slug": "sidecars",
+          "title": "Sidecars"
+        },
+        {
           "slug": "configuration",
           "title": "Configuration"
         }

--- a/skills/sandbox0/references/docs-src/template/configuration/page.mdx
+++ b/skills/sandbox0/references/docs-src/template/configuration/page.mdx
@@ -135,6 +135,8 @@ Commonly used sidecar fields:
 If a sidecar hosts your warm process, define readiness on the sidecar itself. A pod that is `Running` but not `Ready` does not count as available warm-pool capacity and will not be hot-claimed.
 </Callout>
 
+For end-to-end examples in Go, Python, TypeScript, and CLI, see [Template Sidecars](/docs/template/sidecars).
+
 ---
 
 ## Additional Template Fields
@@ -183,8 +185,6 @@ The following fields require a system-level token. They are not available to reg
 
 | Field | Description |
 |-------|-------------|
-| `sidecars.imagePullPolicy` | Pull policy override for sidecars. Requires system identity. |
-| `sidecars.securityContext.privileged` and related privileged settings | Privileged sidecar security settings. Require system identity. |
 | `pod.nodeSelector` | Pin sandbox pods to nodes matching specific labels. |
 | `pod.affinity` | Node and pod affinity/anti-affinity rules. |
 | `pod.tolerations` | Allow pods to be scheduled on tainted nodes. |
@@ -198,7 +198,9 @@ The following fields require a system-level token. They are not available to reg
 Attempting to set privileged fields without a system identity returns `403 Forbidden`. Contact your platform administrator if you need access to these fields.
 </Callout>
 
-Regular team-owned templates can still use non-privileged sidecars, including `command`, `args`, `env`, and Kubernetes probes such as `readinessProbe`.
+Regular team-owned templates can still use public sidecar fields such as `command`, `args`, `env`, `resources`, `securityContext.runAsUser`, `securityContext.runAsGroup`, `securityContext.capabilities.drop`, and Kubernetes probes such as `readinessProbe`.
+
+Operator-only Kubernetes-native sidecar fields that are not part of the public OpenAPI schema should not be relied on from the public SDKs.
 
 ---
 
@@ -219,6 +221,14 @@ Regular team-owned templates can still use non-privileged sidecars, including `c
     cta="Learn More"
   >
     Template API workflows and end-to-end examples
+  </LinkCard>
+
+  <LinkCard
+    title="Sidecars"
+    href="/docs/template/sidecars"
+    cta="Learn More"
+  >
+    Model warm helper processes with template-owned sidecars
   </LinkCard>
 
   <LinkCard

--- a/skills/sandbox0/references/docs-src/template/page.mdx
+++ b/skills/sandbox0/references/docs-src/template/page.mdx
@@ -13,7 +13,7 @@ Sandbox0 has two categories of templates:
 
 Builtin templates use curated public images and are ready to use immediately. Custom templates let you bring your own image, and fine-tune resources.
 
-Custom templates can also define sidecar containers. This is useful for template-owned warm processes, for example a long-running Codex agent or helper daemon. Pool capacity only counts pods that become Kubernetes-ready, so a sidecar readiness probe can gate whether a warm pod is claimable.
+Custom templates can also define sidecar containers. This is useful for template-owned warm processes, for example a long-running Codex agent or helper daemon. Pool capacity only counts pods that become Kubernetes-ready, so a sidecar readiness probe can gate whether a warm pod is claimable. See [Template Sidecars](/docs/template/sidecars) for the dedicated guide.
 
 ---
 
@@ -88,7 +88,7 @@ Use the sidecar readiness probe to express when the warm process is truly ready.
                 Memory: apispec.NewOptString("2Gi"),
             },
         }),
-        Sidecars: &[]apispec.SidecarContainerSpec{
+        Sidecars: []apispec.SidecarContainerSpec{
             {
                 Name:    "codex",
                 Image:   "ghcr.io/example/codex:latest",
@@ -498,6 +498,14 @@ console.log("Template deleted");`
     cta="Learn More"
   >
     Build and push private container images for your templates
+  </LinkCard>
+
+  <LinkCard
+    title="Sidecars"
+    href="/docs/template/sidecars"
+    cta="Learn More"
+  >
+    Model warm helper processes with template-owned sidecars
   </LinkCard>
 
   <LinkCard

--- a/skills/sandbox0/references/docs-src/template/pool/page.mdx
+++ b/skills/sandbox0/references/docs-src/template/pool/page.mdx
@@ -142,6 +142,14 @@ During the transition, the pool may temporarily drop below `minIdle`. Plan updat
 
 <CardGrid>
   <LinkCard
+    title="Sidecars"
+    href="/docs/template/sidecars"
+    cta="Learn More"
+  >
+    Gate warm-pool readiness with template-owned helper processes
+  </LinkCard>
+
+  <LinkCard
     title="Configuration"
     href="/docs/template/configuration"
     cta="Learn More"
@@ -150,10 +158,10 @@ During the transition, the pool may temporarily drop below `minIdle`. Plan updat
   </LinkCard>
 
   <LinkCard
-    title="Volumes"
-    href="/docs/volume"
+    title="Sandbox"
+    href="/docs/sandbox"
     cta="Learn More"
   >
-    Add persistent storage to your sandboxes
+    Claim sandboxes from a warm pool
   </LinkCard>
 </CardGrid>

--- a/skills/sandbox0/references/docs-src/template/sidecars/page.mdx
+++ b/skills/sandbox0/references/docs-src/template/sidecars/page.mdx
@@ -1,0 +1,241 @@
+# Template Sidecars
+
+Use `spec.sidecars` when a template needs extra containers in the same pod as the main sandbox container.
+
+This is the right model for template-owned helper processes such as:
+
+- a long-running Codex agent
+- a language server
+- a local proxy or daemon
+- a cache warmer or bootstrap helper
+
+All containers in one template pod share the same network namespace and can coordinate over localhost and shared volumes.
+
+## Public API Shape
+
+The public HTTP API and all three SDKs expose the same sidecar schema under `spec.sidecars`:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | yes | Sidecar container name. |
+| `image` | yes | Container image reference. |
+| `command` | no | Entrypoint override. |
+| `args` | no | Additional process arguments. |
+| `env` | no | Sidecar-specific environment variables. |
+| `resources` | no | CPU and memory request/limit pair used by Sandbox0's template schema. |
+| `securityContext` | no | Public subset: `runAsUser`, `runAsGroup`, `capabilities.drop`. |
+| `readinessProbe` | no | Readiness gate. Exactly one handler is required when set. |
+| `livenessProbe` | no | Liveness probe. Exactly one handler is required when set. |
+| `startupProbe` | no | Startup probe. Exactly one handler is required when set. |
+
+<Callout variant="info">
+The public OpenAPI contract does not expose raw Kubernetes-only sidecar fields such as `imagePullPolicy` or privileged security settings. Document and depend on the public schema above when using the HTTP API or SDKs.
+</Callout>
+
+---
+
+## Readiness Controls Claimability
+
+Warm-pool capacity only counts pods that are Kubernetes-ready.
+
+- A pod in `Running` phase with `Ready=False` does not count as available idle capacity.
+- A hot claim only selects idle pods that are already ready.
+- If your sidecar hosts the warm process, its readiness probe should represent actual warm readiness.
+
+Example:
+
+```yaml
+spec:
+    mainContainer:
+        image: ubuntu:24.04
+        resources:
+            cpu: "1"
+            memory: 2Gi
+    sidecars:
+        - name: codex
+          image: ghcr.io/example/codex:latest
+          command: ["sh", "-lc", "/app/start-codex.sh"]
+          readinessProbe:
+              exec:
+                  command: ["test", "-S", "/tmp/codex.sock"]
+              initialDelaySeconds: 1
+              periodSeconds: 2
+              failureThreshold: 1
+    pool:
+        minIdle: 2
+        maxIdle: 10
+```
+
+In this example, the pod is not counted as ready warm capacity until the sidecar creates `/tmp/codex.sock` and the readiness probe passes.
+
+---
+
+## Examples
+
+<Tabs
+  tabs={[
+    {
+      label: "Go",
+      language: "go",
+      code: `tpl, err := client.CreateTemplate(ctx, apispec.TemplateCreateRequest{
+    TemplateID: "my-codex-env",
+    Spec: apispec.SandboxTemplateSpec{
+        MainContainer: apispec.NewOptContainerSpec(apispec.ContainerSpec{
+            Image: "ubuntu:24.04",
+            Resources: apispec.ResourceQuota{
+                CPU:    apispec.NewOptString("1"),
+                Memory: apispec.NewOptString("2Gi"),
+            },
+        }),
+        Sidecars: []apispec.SidecarContainerSpec{
+            {
+                Name:    "codex",
+                Image:   "ghcr.io/example/codex:latest",
+                Command: []string{"sh", "-lc", "/app/start-codex.sh"},
+                ReadinessProbe: apispec.NewOptProbe(apispec.Probe{
+                    Exec:                apispec.NewOptExecAction(apispec.ExecAction{Command: []string{"test", "-S", "/tmp/codex.sock"}}),
+                    InitialDelaySeconds: apispec.NewOptInt32(1),
+                    PeriodSeconds:       apispec.NewOptInt32(2),
+                    FailureThreshold:    apispec.NewOptInt32(1),
+                }),
+            },
+        },
+        Pool: apispec.NewOptPoolStrategy(apispec.PoolStrategy{
+            MinIdle: 2,
+            MaxIdle: 10,
+        }),
+    },
+})
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Printf("Template created: %s\\n", tpl.TemplateID)`
+    },
+    {
+      label: "Python",
+      language: "python",
+      code: `from sandbox0.apispec.models.exec_action import ExecAction
+from sandbox0.apispec.models.probe import Probe
+from sandbox0.apispec.models.sandbox_template_spec import SandboxTemplateSpec
+from sandbox0.apispec.models.sidecar_container_spec import SidecarContainerSpec
+from sandbox0.apispec.models.template_create_request import TemplateCreateRequest
+
+tpl = client.create_template(TemplateCreateRequest(
+    template_id="my-codex-env",
+    spec=SandboxTemplateSpec.from_dict({
+        "mainContainer": {
+            "image": "ubuntu:24.04",
+            "resources": {"cpu": "1", "memory": "2Gi"},
+        },
+        "sidecars": [
+            SidecarContainerSpec(
+                name="codex",
+                image="ghcr.io/example/codex:latest",
+                command=["sh", "-lc", "/app/start-codex.sh"],
+                readiness_probe=Probe(
+                    exec_=ExecAction(command=["test", "-S", "/tmp/codex.sock"]),
+                    initial_delay_seconds=1,
+                    period_seconds=2,
+                    failure_threshold=1,
+                ),
+            ).to_dict()
+        ],
+        "pool": {"minIdle": 2, "maxIdle": 10},
+    }),
+))
+print(f"Template created: {tpl.template_id}")`
+    },
+    {
+      label: "TypeScript",
+      language: "typescript",
+      code: `const tpl = await client.templates.create({
+    templateId: "my-codex-env",
+    spec: {
+        mainContainer: {
+            image: "ubuntu:24.04",
+            resources: { cpu: "1", memory: "2Gi" },
+        },
+        sidecars: [
+            {
+                name: "codex",
+                image: "ghcr.io/example/codex:latest",
+                command: ["sh", "-lc", "/app/start-codex.sh"],
+                readinessProbe: {
+                    exec: { command: ["test", "-S", "/tmp/codex.sock"] },
+                    initialDelaySeconds: 1,
+                    periodSeconds: 2,
+                    failureThreshold: 1,
+                },
+            },
+        ],
+        pool: { minIdle: 2, maxIdle: 10 },
+    },
+});
+console.log("Template created:", tpl.templateId);`
+    },
+    {
+      label: "CLI",
+      language: "bash",
+      code: `cat >template.yaml <<'EOF'
+spec:
+    mainContainer:
+        image: ubuntu:24.04
+        resources:
+            cpu: "1"
+            memory: 2Gi
+    sidecars:
+        - name: codex
+          image: ghcr.io/example/codex:latest
+          command: ["sh", "-lc", "/app/start-codex.sh"]
+          readinessProbe:
+              exec:
+                  command: ["test", "-S", "/tmp/codex.sock"]
+              initialDelaySeconds: 1
+              periodSeconds: 2
+              failureThreshold: 1
+    pool:
+        minIdle: 2
+        maxIdle: 10
+EOF
+
+s0 template create --id my-codex-env --spec-file template.yaml`
+    }
+  ]}
+/>
+
+---
+
+## Validation Notes
+
+- `name` and `image` are required for every sidecar.
+- `readinessProbe`, `livenessProbe`, and `startupProbe` must define exactly one handler when present.
+- Regular team-owned templates can use standard sidecar fields such as `command`, `args`, `env`, `resources`, and probes.
+- Private image references are still checked against team ownership rules, just like `spec.mainContainer.image`.
+
+## Next Steps
+
+<CardGrid>
+  <LinkCard
+    title="Sandbox"
+    href="/docs/sandbox"
+    cta="Learn More"
+  >
+    Create sandboxes that use your template sidecars
+  </LinkCard>
+
+  <LinkCard
+    title="Configuration"
+    href="/docs/template/configuration"
+    cta="Learn More"
+  >
+    Full reference for template spec fields
+  </LinkCard>
+
+  <LinkCard
+    title="Warm Pool"
+    href="/docs/template/pool"
+    cta="Learn More"
+  >
+    Understand how readiness affects hot claims
+  </LinkCard>
+</CardGrid>


### PR DESCRIPTION
## Summary
- add a dedicated Template Sidecars docs page
- link the new page from template docs and add it to the docs manifest
- align template sidecar docs with the public OpenAPI/SDK contract and fix Next Steps links

## Testing
- not run (docs source change only)