### PR TITLE
Add end-to-end observability coverage

### DIFF
--- a/cluster-gateway/pkg/http/server.go
+++ b/cluster-gateway/pkg/http/server.go
@@ -81,7 +81,8 @@ func NewServer(
 
 	// Create observable HTTP client for proxy
 	httpClient := obsProvider.HTTP.NewClient(httpobs.Config{
-		Timeout: proxyTimeout,
+		Timeout:       proxyTimeout,
+		BaseTransport: httpobs.InternalServiceTransport(),
 	})
 
 	var proxy2Mgr *proxy.Router

--- a/cluster-gateway/pkg/http/server.go
+++ b/cluster-gateway/pkg/http/server.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sandbox0-ai/sandbox0/cluster-gateway/pkg/client"
 	"github.com/sandbox0-ai/sandbox0/cluster-gateway/pkg/middleware"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
@@ -291,7 +290,9 @@ func (s *Server) Handler() http.Handler {
 func (s *Server) setupRoutes() {
 	// Global middleware (order matters)
 	s.router.Use(httpobs.GinMiddleware(httpobs.ServerConfig{
-		Tracer: s.obsProvider.Tracer(),
+		ServiceName: "cluster-gateway",
+		Tracer:      s.obsProvider.Tracer(),
+		Registry:    s.obsProvider.MetricsRegistryOrNil(),
 	}))
 	s.router.Use(middleware.Recovery(s.logger))
 	s.router.Use(s.requestLogger.Logger())
@@ -302,7 +303,7 @@ func (s *Server) setupRoutes() {
 	s.router.GET("/metadata", gatewayhandlers.GatewayMetadata("cluster-gateway", gatewayhandlers.GatewayModeDirect))
 
 	// Metrics endpoint
-	s.router.GET("/metrics", gin.WrapH(promhttp.Handler()))
+	s.router.GET("/metrics", gin.WrapH(s.obsProvider.MetricsHandler()))
 
 	if authModeEnabled(s.cfg.AuthMode, authModePublic) {
 		public.RegisterRoutes(s.router, public.Deps{

--- a/ctld/cmd/ctld/main.go
+++ b/ctld/cmd/ctld/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"flag"
-	"log"
+	"fmt"
 	"net/http"
 	"os"
 	"syscall"
@@ -15,6 +15,10 @@ import (
 	ctldpower "github.com/sandbox0-ai/sandbox0/ctld/internal/ctld/power"
 	ctldserver "github.com/sandbox0-ai/sandbox0/ctld/internal/ctld/server"
 	"github.com/sandbox0-ai/sandbox0/pkg/k8s"
+	"github.com/sandbox0-ai/sandbox0/pkg/observability"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"k8s.io/client-go/kubernetes"
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 )
 
@@ -38,25 +42,45 @@ func main() {
 	flag.StringVar(&nodeName, "node-name", os.Getenv("NODE_NAME"), "current node name used to validate local sandbox ownership")
 	flag.Parse()
 
-	log.Println("Starting ctld")
-	defer func() { log.Println("Stopped ctld") }()
+	logger, err := initLogger()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to initialize logger: %v\n", err)
+		os.Exit(1)
+	}
+	defer logger.Sync()
 
-	httpServer := newHTTPServer(httpAddr, buildPowerController())
+	obsProvider, err := observability.New(observability.Config{
+		ServiceName: "ctld",
+		Logger:      logger,
+		TraceExporter: observability.TraceExporterConfig{
+			Type:     os.Getenv("OTEL_EXPORTER_TYPE"),
+			Endpoint: os.Getenv("OTEL_EXPORTER_ENDPOINT"),
+		},
+	})
+	if err != nil {
+		logger.Fatal("Failed to initialize observability", zap.Error(err))
+	}
+	defer obsProvider.Shutdown(context.Background())
+
+	logger.Info("Starting ctld")
+	defer func() { logger.Info("Stopped ctld") }()
+
+	httpServer := newHTTPServerWithObservability(httpAddr, buildPowerController(obsProvider), logger, obsProvider)
 	go func() {
 		if err := httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			log.Fatalf("ctld http server failed: %v", err)
+			logger.Fatal("ctld http server failed", zap.Error(err))
 		}
 	}()
 
-	log.Println("Starting FS watcher.")
+	logger.Info("Starting FS watcher")
 	watcher, err := ctldfuseplugin.NewFSWatcher(pluginapi.DevicePluginPath)
 	if err != nil {
-		log.Println("Failed to created FS watcher.")
+		logger.Error("Failed to create FS watcher", zap.Error(err))
 		os.Exit(1)
 	}
 	defer watcher.Close()
 
-	log.Println("Starting OS watcher.")
+	logger.Info("Starting OS watcher")
 	sigs := ctldfuseplugin.NewOSWatcher(syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 
 	restart := true
@@ -71,7 +95,7 @@ L:
 
 			devicePlugin = ctldfuseplugin.NewDevicePlugin(mountsAllowed)
 			if err := devicePlugin.Serve(); err != nil {
-				log.Println("Could not contact Kubelet, retrying. Did you enable the device plugin feature gate?")
+				logger.Warn("Could not contact Kubelet, retrying")
 			} else {
 				restart = false
 			}
@@ -80,20 +104,20 @@ L:
 		select {
 		case event := <-watcher.Events:
 			if event.Name == pluginapi.KubeletSocket && event.Op&fsnotify.Create == fsnotify.Create {
-				log.Printf("inotify: %s created, restarting.", pluginapi.KubeletSocket)
+				logger.Info("Kubelet socket created, restarting", zap.String("socket", pluginapi.KubeletSocket))
 				restart = true
 			}
 
 		case err := <-watcher.Errors:
-			log.Printf("inotify: %s", err)
+			logger.Warn("FS watcher error", zap.Error(err))
 
 		case s := <-sigs:
 			switch s {
 			case syscall.SIGHUP:
-				log.Println("Received SIGHUP, restarting.")
+				logger.Info("Received SIGHUP, restarting")
 				restart = true
 			default:
-				log.Printf("Received signal \"%v\", shutting down.", s)
+				logger.Info("Received shutdown signal", zap.String("signal", s.String()))
 				if devicePlugin != nil {
 					devicePlugin.Stop()
 				}
@@ -107,18 +131,56 @@ L:
 }
 
 func newHTTPServer(addr string, controller ctldserver.Controller) *http.Server {
-	return &http.Server{Addr: addr, Handler: ctldserver.NewMux(controller)}
+	return newHTTPServerWithObservability(addr, controller, nil, nil)
 }
 
-func buildPowerController() ctldserver.Controller {
-	k8sClient, err := k8s.NewClient(kubeconfig)
+func newHTTPServerWithObservability(addr string, controller ctldserver.Controller, logger *zap.Logger, obsProvider *observability.Provider) *http.Server {
+	return &http.Server{Addr: addr, Handler: ctldserver.NewMuxWithObservability(controller, logger, obsProvider)}
+}
+
+func buildPowerController(obsProvider *observability.Provider) ctldserver.Controller {
+	var (
+		k8sClient kubernetes.Interface
+		err       error
+	)
+	if obsProvider != nil {
+		k8sClient, err = k8s.NewClientWithObservability(kubeconfig, obsProvider)
+	} else {
+		k8sClient, err = k8s.NewClient(kubeconfig)
+	}
 	if err != nil {
-		log.Printf("ctld power control disabled: build kubernetes client: %v", err)
+		fmt.Printf("ctld power control disabled: build kubernetes client: %v\n", err)
 		return ctldserver.NotImplementedController{}
 	}
 	resolver := ctldpower.NewPodResolver(k8sClient, nodeName, cgroupRoot)
 	resolver.ProcRoot = procRoot
 	controller := ctldpower.NewController(resolver, nil)
 	controller.StatsProvider = ctldpower.NewCRIStatsProvider(criEndpoint)
+	if obsProvider != nil {
+		controller.SetMetrics(ctldpower.NewMetrics(obsProvider.MetricsRegistryOrNil()))
+	}
 	return controller
+}
+
+func initLogger() (*zap.Logger, error) {
+	cfg := zap.Config{
+		Level:       zap.NewAtomicLevelAt(zapcore.InfoLevel),
+		Development: false,
+		Encoding:    "json",
+		EncoderConfig: zapcore.EncoderConfig{
+			TimeKey:        "ts",
+			LevelKey:       "level",
+			CallerKey:      "caller",
+			MessageKey:     "msg",
+			StacktraceKey:  "stacktrace",
+			LineEnding:     zapcore.DefaultLineEnding,
+			EncodeLevel:    zapcore.LowercaseLevelEncoder,
+			EncodeTime:     zapcore.ISO8601TimeEncoder,
+			EncodeDuration: zapcore.SecondsDurationEncoder,
+			EncodeCaller:   zapcore.ShortCallerEncoder,
+		},
+		OutputPaths:      []string{"stdout"},
+		ErrorOutputPaths: []string{"stderr"},
+	}
+	return cfg.Build()
 }

--- a/ctld/internal/ctld/power/controller.go
+++ b/ctld/internal/ctld/power/controller.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"time"
 
 	"github.com/sandbox0-ai/sandbox0/ctld/internal/ctld/cgroup"
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
@@ -35,6 +36,7 @@ type Controller struct {
 	Resolver      Resolver
 	FS            *cgroup.FS
 	StatsProvider SandboxStatsProvider
+	metrics       *Metrics
 }
 
 func NewController(resolver Resolver, fs *cgroup.FS) *Controller {
@@ -44,19 +46,32 @@ func NewController(resolver Resolver, fs *cgroup.FS) *Controller {
 	return &Controller{Resolver: resolver, FS: fs}
 }
 
+func (c *Controller) SetMetrics(metrics *Metrics) {
+	if c == nil {
+		return
+	}
+	c.metrics = metrics
+}
+
 func (c *Controller) Pause(r *http.Request, sandboxID string) (ctldapi.PauseResponse, int) {
+	start := time.Now()
 	target, status, errResp := c.resolveTarget(r, sandboxID)
 	if status != http.StatusOK {
+		c.metrics.observeOperation("pause", http.StatusText(status), time.Since(start))
 		return errResp, status
 	}
 	log.Printf("ctld pause start sandbox=%s runtime=%s cgroup=%s", sandboxID, target.Runtime, target.CgroupDir)
 	if err := c.FS.Freeze(target.CgroupDir); err != nil {
+		c.metrics.observeOperation("pause", "error", time.Since(start))
 		return ctldapi.PauseResponse{Paused: false, Error: fmt.Sprintf("freeze cgroup: %v", err)}, http.StatusInternalServerError
 	}
 	usage, err := c.pauseUsage(r.Context(), target)
 	if err != nil {
+		c.metrics.observeOperation("pause", "error", time.Since(start))
 		return ctldapi.PauseResponse{Paused: false, Error: err.Error()}, http.StatusInternalServerError
 	}
+	c.metrics.observeOperation("pause", "success", time.Since(start))
+	c.metrics.recordPauseUsage(usage.ContainerMemoryUsage, usage.ContainerMemoryWorkingSet, usage.TotalMemoryRSS)
 	log.Printf("ctld pause complete sandbox=%s runtime=%s working_set=%d usage=%d", sandboxID, target.Runtime, usage.ContainerMemoryWorkingSet, usage.ContainerMemoryUsage)
 	return ctldapi.PauseResponse{
 		Paused:        true,
@@ -65,14 +80,18 @@ func (c *Controller) Pause(r *http.Request, sandboxID string) (ctldapi.PauseResp
 }
 
 func (c *Controller) Resume(r *http.Request, sandboxID string) (ctldapi.ResumeResponse, int) {
+	start := time.Now()
 	target, status, pauseErr := c.resolveTarget(r, sandboxID)
 	if status != http.StatusOK {
+		c.metrics.observeOperation("resume", http.StatusText(status), time.Since(start))
 		return ctldapi.ResumeResponse{Resumed: false, Error: pauseErr.Error}, status
 	}
 	log.Printf("ctld resume start sandbox=%s runtime=%s cgroup=%s", sandboxID, target.Runtime, target.CgroupDir)
 	if err := c.FS.Thaw(target.CgroupDir); err != nil {
+		c.metrics.observeOperation("resume", "error", time.Since(start))
 		return ctldapi.ResumeResponse{Resumed: false, Error: fmt.Sprintf("thaw cgroup: %v", err)}, http.StatusInternalServerError
 	}
+	c.metrics.observeOperation("resume", "success", time.Since(start))
 	log.Printf("ctld resume complete sandbox=%s runtime=%s", sandboxID, target.Runtime)
 	return ctldapi.ResumeResponse{Resumed: true}, http.StatusOK
 }

--- a/ctld/internal/ctld/power/metrics.go
+++ b/ctld/internal/ctld/power/metrics.go
@@ -1,0 +1,54 @@
+package power
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type Metrics struct {
+	operationsTotal    *prometheus.CounterVec
+	operationDuration  *prometheus.HistogramVec
+	resourceUsageBytes *prometheus.GaugeVec
+}
+
+func NewMetrics(registry prometheus.Registerer) *Metrics {
+	if registry == nil {
+		return nil
+	}
+
+	factory := promauto.With(registry)
+	return &Metrics{
+		operationsTotal: factory.NewCounterVec(prometheus.CounterOpts{
+			Name: "ctld_power_operations_total",
+			Help: "Total number of ctld pause/resume operations",
+		}, []string{"operation", "status"}),
+		operationDuration: factory.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "ctld_power_operation_duration_seconds",
+			Help:    "Duration of ctld pause/resume operations",
+			Buckets: prometheus.DefBuckets,
+		}, []string{"operation"}),
+		resourceUsageBytes: factory.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "ctld_power_resource_usage_bytes",
+			Help: "Latest sandbox resource usage reported during ctld pause",
+		}, []string{"metric"}),
+	}
+}
+
+func (m *Metrics) observeOperation(operation, status string, duration time.Duration) {
+	if m == nil {
+		return
+	}
+	m.operationsTotal.WithLabelValues(operation, status).Inc()
+	m.operationDuration.WithLabelValues(operation).Observe(duration.Seconds())
+}
+
+func (m *Metrics) recordPauseUsage(usageBytes, workingSetBytes, rssBytes int64) {
+	if m == nil {
+		return
+	}
+	m.resourceUsageBytes.WithLabelValues("container_memory_usage").Set(float64(usageBytes))
+	m.resourceUsageBytes.WithLabelValues("container_memory_working_set").Set(float64(workingSetBytes))
+	m.resourceUsageBytes.WithLabelValues("total_memory_rss").Set(float64(rssBytes))
+}

--- a/ctld/internal/ctld/server/server.go
+++ b/ctld/internal/ctld/server/server.go
@@ -6,6 +6,9 @@ import (
 	"strings"
 
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
+	"github.com/sandbox0-ai/sandbox0/pkg/observability"
+	httpobs "github.com/sandbox0-ai/sandbox0/pkg/observability/http"
+	"go.uber.org/zap"
 )
 
 type Controller interface {
@@ -24,6 +27,10 @@ func (NotImplementedController) Resume(_ *http.Request, _ string) (ctldapi.Resum
 }
 
 func NewMux(controller Controller) http.Handler {
+	return NewMuxWithObservability(controller, nil, nil)
+}
+
+func NewMuxWithObservability(controller Controller, logger *zap.Logger, obsProvider *observability.Provider) http.Handler {
 	if controller == nil {
 		controller = NotImplementedController{}
 	}
@@ -36,6 +43,9 @@ func NewMux(controller Controller) http.Handler {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))
 	})
+	if obsProvider != nil {
+		mux.Handle("/metrics", obsProvider.MetricsHandler())
+	}
 	mux.HandleFunc("/api/v1/sandboxes/", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			w.WriteHeader(http.StatusMethodNotAllowed)
@@ -64,5 +74,13 @@ func NewMux(controller Controller) http.Handler {
 			w.WriteHeader(http.StatusNotFound)
 		}
 	})
-	return mux
+	if obsProvider == nil {
+		return mux
+	}
+	return httpobs.ServerMiddleware(httpobs.ServerConfig{
+		ServiceName: "ctld",
+		Tracer:      obsProvider.Tracer(),
+		Logger:      logger,
+		Registry:    obsProvider.MetricsRegistryOrNil(),
+	})(mux)
 }

--- a/global-gateway/pkg/http/server.go
+++ b/global-gateway/pkg/http/server.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	cachepkg "github.com/sandbox0-ai/sandbox0/pkg/cache"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/apikey"
 	gatewaybuiltin "github.com/sandbox0-ai/sandbox0/pkg/gateway/auth/builtin"
@@ -150,14 +149,16 @@ func (s *Server) Handler() stdhttp.Handler {
 
 func (s *Server) setupRoutes() {
 	s.router.Use(httpobs.GinMiddleware(httpobs.ServerConfig{
-		Tracer: s.obsProvider.Tracer(),
+		ServiceName: "global-gateway",
+		Tracer:      s.obsProvider.Tracer(),
+		Registry:    s.obsProvider.MetricsRegistryOrNil(),
 	}))
 	s.router.Use(gatewaymiddleware.Recovery(s.logger))
 	s.router.Use(s.requestLogger.Logger())
 
 	s.router.GET("/healthz", s.healthCheck)
 	s.router.GET("/readyz", s.readinessCheck)
-	s.router.GET("/metrics", gin.WrapH(promhttp.Handler()))
+	s.router.GET("/metrics", gin.WrapH(s.obsProvider.MetricsHandler()))
 	s.router.GET("/metadata", handlers.GatewayMetadata("global-gateway", handlers.GatewayModeGlobal))
 
 	public.RegisterIdentityRoutes(s.router, public.Deps{

--- a/infra-operator/internal/controller/pkg/common/common.go
+++ b/infra-operator/internal/controller/pkg/common/common.go
@@ -29,6 +29,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -171,6 +172,10 @@ func (r *ResourceManager) ApplyDeployment(ctx context.Context, infra *infrav1alp
 			return err
 		}
 
+		if deploymentMatchesDesired(current, desired) {
+			return nil
+		}
+
 		current.Labels = desired.Labels
 		current.Annotations = desired.Annotations
 		current.Spec = desired.Spec
@@ -289,6 +294,10 @@ func (r *ResourceManager) ApplyDaemonSet(ctx context.Context, infra *infrav1alph
 		}
 		if err != nil {
 			return err
+		}
+
+		if daemonSetMatchesDesired(current, desired) {
+			return nil
 		}
 
 		current.Labels = desired.Labels
@@ -463,6 +472,20 @@ func MergeLabels(base map[string]string, overrides map[string]string) map[string
 		out[key] = value
 	}
 	return out
+}
+
+func deploymentMatchesDesired(current, desired *appsv1.Deployment) bool {
+	return apiequality.Semantic.DeepEqual(current.Labels, desired.Labels) &&
+		apiequality.Semantic.DeepEqual(current.Annotations, desired.Annotations) &&
+		apiequality.Semantic.DeepEqual(current.Spec, desired.Spec) &&
+		apiequality.Semantic.DeepEqual(current.OwnerReferences, desired.OwnerReferences)
+}
+
+func daemonSetMatchesDesired(current, desired *appsv1.DaemonSet) bool {
+	return apiequality.Semantic.DeepEqual(current.Labels, desired.Labels) &&
+		apiequality.Semantic.DeepEqual(current.Annotations, desired.Annotations) &&
+		apiequality.Semantic.DeepEqual(current.Spec, desired.Spec) &&
+		apiequality.Semantic.DeepEqual(current.OwnerReferences, desired.OwnerReferences)
 }
 
 func CloneStringMap(src map[string]string) map[string]string {

--- a/infra-operator/internal/controller/pkg/common/common.go
+++ b/infra-operator/internal/controller/pkg/common/common.go
@@ -476,16 +476,46 @@ func MergeLabels(base map[string]string, overrides map[string]string) map[string
 
 func deploymentMatchesDesired(_ *runtime.Scheme, current, desired *appsv1.Deployment) bool {
 	return apiequality.Semantic.DeepEqual(current.Labels, desired.Labels) &&
-		apiequality.Semantic.DeepEqual(current.Annotations, desired.Annotations) &&
+		annotationsMatchDesired(current.Annotations, desired.Annotations, deploymentManagedAnnotations) &&
 		apiequality.Semantic.DeepDerivative(desired.Spec, current.Spec) &&
 		apiequality.Semantic.DeepEqual(current.OwnerReferences, desired.OwnerReferences)
 }
 
 func daemonSetMatchesDesired(_ *runtime.Scheme, current, desired *appsv1.DaemonSet) bool {
 	return apiequality.Semantic.DeepEqual(current.Labels, desired.Labels) &&
-		apiequality.Semantic.DeepEqual(current.Annotations, desired.Annotations) &&
+		annotationsMatchDesired(current.Annotations, desired.Annotations, daemonSetManagedAnnotations) &&
 		apiequality.Semantic.DeepDerivative(desired.Spec, current.Spec) &&
 		apiequality.Semantic.DeepEqual(current.OwnerReferences, desired.OwnerReferences)
+}
+
+var deploymentManagedAnnotations = map[string]struct{}{
+	"deployment.kubernetes.io/revision": {},
+}
+
+var daemonSetManagedAnnotations = map[string]struct{}{
+	"deprecated.daemonset.template.generation": {},
+}
+
+func annotationsMatchDesired(current, desired map[string]string, ignored map[string]struct{}) bool {
+	return apiequality.Semantic.DeepDerivative(filterAnnotations(desired, ignored), filterAnnotations(current, ignored))
+}
+
+func filterAnnotations(in map[string]string, ignored map[string]struct{}) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		if _, skip := ignored[k]; skip {
+			continue
+		}
+		out[k] = v
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func CloneStringMap(src map[string]string) map[string]string {

--- a/infra-operator/internal/controller/pkg/common/common.go
+++ b/infra-operator/internal/controller/pkg/common/common.go
@@ -172,7 +172,7 @@ func (r *ResourceManager) ApplyDeployment(ctx context.Context, infra *infrav1alp
 			return err
 		}
 
-		if deploymentMatchesDesired(current, desired) {
+		if deploymentMatchesDesired(r.Scheme, current, desired) {
 			return nil
 		}
 
@@ -296,7 +296,7 @@ func (r *ResourceManager) ApplyDaemonSet(ctx context.Context, infra *infrav1alph
 			return err
 		}
 
-		if daemonSetMatchesDesired(current, desired) {
+		if daemonSetMatchesDesired(r.Scheme, current, desired) {
 			return nil
 		}
 
@@ -474,17 +474,17 @@ func MergeLabels(base map[string]string, overrides map[string]string) map[string
 	return out
 }
 
-func deploymentMatchesDesired(current, desired *appsv1.Deployment) bool {
+func deploymentMatchesDesired(_ *runtime.Scheme, current, desired *appsv1.Deployment) bool {
 	return apiequality.Semantic.DeepEqual(current.Labels, desired.Labels) &&
 		apiequality.Semantic.DeepEqual(current.Annotations, desired.Annotations) &&
-		apiequality.Semantic.DeepEqual(current.Spec, desired.Spec) &&
+		apiequality.Semantic.DeepDerivative(desired.Spec, current.Spec) &&
 		apiequality.Semantic.DeepEqual(current.OwnerReferences, desired.OwnerReferences)
 }
 
-func daemonSetMatchesDesired(current, desired *appsv1.DaemonSet) bool {
+func daemonSetMatchesDesired(_ *runtime.Scheme, current, desired *appsv1.DaemonSet) bool {
 	return apiequality.Semantic.DeepEqual(current.Labels, desired.Labels) &&
 		apiequality.Semantic.DeepEqual(current.Annotations, desired.Annotations) &&
-		apiequality.Semantic.DeepEqual(current.Spec, desired.Spec) &&
+		apiequality.Semantic.DeepDerivative(desired.Spec, current.Spec) &&
 		apiequality.Semantic.DeepEqual(current.OwnerReferences, desired.OwnerReferences)
 }
 

--- a/infra-operator/internal/controller/pkg/common/common.go
+++ b/infra-operator/internal/controller/pkg/common/common.go
@@ -91,12 +91,6 @@ type ServiceDefinition struct {
 
 // ReconcileDeployment creates or updates a deployment.
 func (r *ResourceManager) ReconcileDeployment(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, name string, labels map[string]string, replicas int32, def ServiceDefinition) error {
-	deploy := &appsv1.Deployment{}
-	err := r.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: infra.Namespace}, deploy)
-	if err != nil && !errors.IsNotFound(err) {
-		return err
-	}
-
 	defaultResources := corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("100m"),
@@ -155,13 +149,34 @@ func (r *ResourceManager) ReconcileDeployment(ctx context.Context, infra *infrav
 		return err
 	}
 
-	if errors.IsNotFound(err) {
-		return r.Client.Create(ctx, desiredDeploy)
+	return r.ApplyDeployment(ctx, infra, desiredDeploy)
+}
+
+// ApplyDeployment creates or updates a deployment using fresh reads on each retry
+// so controller-driven status/resourceVersion updates do not cause reconcile
+// loops to fail on optimistic concurrency conflicts.
+func (r *ResourceManager) ApplyDeployment(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, desired *appsv1.Deployment) error {
+	if err := ctrl.SetControllerReference(infra, desired, r.Scheme); err != nil {
+		return err
 	}
 
-	deploy.Spec = desiredDeploy.Spec
-	deploy.Labels = desiredLabels
-	return r.Client.Update(ctx, deploy)
+	key := types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current := &appsv1.Deployment{}
+		err := r.Client.Get(ctx, key, current)
+		if errors.IsNotFound(err) {
+			return r.Client.Create(ctx, desired.DeepCopy())
+		}
+		if err != nil {
+			return err
+		}
+
+		current.Labels = desired.Labels
+		current.Annotations = desired.Annotations
+		current.Spec = desired.Spec
+		current.OwnerReferences = desired.OwnerReferences
+		return r.Client.Update(ctx, current)
+	})
 }
 
 // EnsureDeploymentReady validates deployment readiness before reporting success.

--- a/infra-operator/internal/controller/pkg/common/common_test.go
+++ b/infra-operator/internal/controller/pkg/common/common_test.go
@@ -383,3 +383,71 @@ func TestApplyDeploymentUpdatesExistingObject(t *testing.T) {
 		t.Fatalf("expected deployment owner reference, got %#v", got.OwnerReferences)
 	}
 }
+
+func TestDeploymentMatchesDesired(t *testing.T) {
+	replicas := int32(1)
+	desired := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "demo",
+			Namespace:   "sandbox0-system",
+			Labels:      map[string]string{"app": "demo"},
+			Annotations: map[string]string{"config": "abc"},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "infra.sandbox0.ai/v1alpha1",
+				Kind:       "Sandbox0Infra",
+				Name:       "demo",
+			}},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "demo"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "demo"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "demo", Image: "demo:latest"}}},
+			},
+		},
+	}
+
+	current := desired.DeepCopy()
+	if !deploymentMatchesDesired(current, desired) {
+		t.Fatal("expected identical deployment to match desired state")
+	}
+
+	current.Spec.Template.Spec.Containers[0].Image = "demo:new"
+	if deploymentMatchesDesired(current, desired) {
+		t.Fatal("expected deployment with changed pod template to require update")
+	}
+}
+
+func TestDaemonSetMatchesDesired(t *testing.T) {
+	desired := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "demo",
+			Namespace:   "sandbox0-system",
+			Labels:      map[string]string{"app": "demo"},
+			Annotations: map[string]string{"config": "abc"},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "infra.sandbox0.ai/v1alpha1",
+				Kind:       "Sandbox0Infra",
+				Name:       "demo",
+			}},
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "demo"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "demo"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "demo", Image: "demo:latest"}}},
+			},
+		},
+	}
+
+	current := desired.DeepCopy()
+	if !daemonSetMatchesDesired(current, desired) {
+		t.Fatal("expected identical daemonset to match desired state")
+	}
+
+	current.Labels["config"] = "new"
+	if daemonSetMatchesDesired(current, desired) {
+		t.Fatal("expected daemonset with changed labels to require update")
+	}
+}

--- a/infra-operator/internal/controller/pkg/common/common_test.go
+++ b/infra-operator/internal/controller/pkg/common/common_test.go
@@ -409,17 +409,60 @@ func TestDeploymentMatchesDesired(t *testing.T) {
 	}
 
 	current := desired.DeepCopy()
-	if !deploymentMatchesDesired(current, desired) {
+	if !deploymentMatchesDesired(nil, current, desired) {
 		t.Fatal("expected identical deployment to match desired state")
 	}
 
 	current.Spec.Template.Spec.Containers[0].Image = "demo:new"
-	if deploymentMatchesDesired(current, desired) {
+	if deploymentMatchesDesired(nil, current, desired) {
 		t.Fatal("expected deployment with changed pod template to require update")
 	}
 }
 
+func TestDeploymentMatchesDesiredWithDefaultedFields(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add appsv1 scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1 scheme: %v", err)
+	}
+
+	replicas := int32(1)
+	desired := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "sandbox0-system",
+			Labels:    map[string]string{"app": "demo"},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "demo"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "demo"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "demo", Image: "demo:latest"}}},
+			},
+		},
+	}
+
+	current := desired.DeepCopy()
+	current.Spec.Template.Spec.DNSPolicy = corev1.DNSClusterFirst
+	current.Spec.Template.Spec.Containers[0].ImagePullPolicy = corev1.PullIfNotPresent
+
+	if !deploymentMatchesDesired(scheme, current, desired) {
+		t.Fatal("expected deployment with server-defaulted fields to match desired state")
+	}
+}
+
 func TestDaemonSetMatchesDesired(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add appsv1 scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1 scheme: %v", err)
+	}
+
 	desired := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "demo",
@@ -442,12 +485,45 @@ func TestDaemonSetMatchesDesired(t *testing.T) {
 	}
 
 	current := desired.DeepCopy()
-	if !daemonSetMatchesDesired(current, desired) {
+	if !daemonSetMatchesDesired(scheme, current, desired) {
 		t.Fatal("expected identical daemonset to match desired state")
 	}
 
 	current.Labels["config"] = "new"
-	if daemonSetMatchesDesired(current, desired) {
+	if daemonSetMatchesDesired(scheme, current, desired) {
 		t.Fatal("expected daemonset with changed labels to require update")
+	}
+}
+
+func TestDaemonSetMatchesDesiredWithDefaultedFields(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add appsv1 scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1 scheme: %v", err)
+	}
+
+	desired := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "sandbox0-system",
+			Labels:    map[string]string{"app": "demo"},
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "demo"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "demo"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "demo", Image: "demo:latest"}}},
+			},
+		},
+	}
+
+	current := desired.DeepCopy()
+	current.Spec.Template.Spec.DNSPolicy = corev1.DNSClusterFirstWithHostNet
+	current.Spec.Template.Spec.Containers[0].ImagePullPolicy = corev1.PullIfNotPresent
+
+	if !daemonSetMatchesDesired(scheme, current, desired) {
+		t.Fatal("expected daemonset with server-defaulted fields to match desired state")
 	}
 }

--- a/infra-operator/internal/controller/pkg/common/common_test.go
+++ b/infra-operator/internal/controller/pkg/common/common_test.go
@@ -454,6 +454,33 @@ func TestDeploymentMatchesDesiredWithDefaultedFields(t *testing.T) {
 	}
 }
 
+func TestDeploymentMatchesDesiredWithControllerManagedAnnotations(t *testing.T) {
+	replicas := int32(1)
+	desired := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "demo",
+			Namespace:   "sandbox0-system",
+			Labels:      map[string]string{"app": "demo"},
+			Annotations: map[string]string{"config": "abc"},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "demo"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "demo"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "demo", Image: "demo:latest"}}},
+			},
+		},
+	}
+
+	current := desired.DeepCopy()
+	current.Annotations["deployment.kubernetes.io/revision"] = "7"
+
+	if !deploymentMatchesDesired(nil, current, desired) {
+		t.Fatal("expected deployment with controller-managed annotations to match desired state")
+	}
+}
+
 func TestDaemonSetMatchesDesired(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := appsv1.AddToScheme(scheme); err != nil {
@@ -525,5 +552,30 @@ func TestDaemonSetMatchesDesiredWithDefaultedFields(t *testing.T) {
 
 	if !daemonSetMatchesDesired(scheme, current, desired) {
 		t.Fatal("expected daemonset with server-defaulted fields to match desired state")
+	}
+}
+
+func TestDaemonSetMatchesDesiredWithControllerManagedAnnotations(t *testing.T) {
+	desired := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "demo",
+			Namespace:   "sandbox0-system",
+			Labels:      map[string]string{"app": "demo"},
+			Annotations: map[string]string{"config": "abc"},
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "demo"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "demo"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "demo", Image: "demo:latest"}}},
+			},
+		},
+	}
+
+	current := desired.DeepCopy()
+	current.Annotations["deprecated.daemonset.template.generation"] = "3"
+
+	if !daemonSetMatchesDesired(nil, current, desired) {
+		t.Fatal("expected daemonset with controller-managed annotations to match desired state")
 	}
 }

--- a/infra-operator/internal/controller/pkg/common/common_test.go
+++ b/infra-operator/internal/controller/pkg/common/common_test.go
@@ -278,3 +278,108 @@ func TestApplyDaemonSetUpdatesExistingObject(t *testing.T) {
 		t.Fatalf("expected daemonset owner reference, got %#v", got.OwnerReferences)
 	}
 }
+
+func TestApplyDeploymentUpdatesExistingObject(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add appsv1 scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1 scheme: %v", err)
+	}
+	if err := infrav1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add infra scheme: %v", err)
+	}
+
+	infra := &infrav1alpha1.Sandbox0Infra{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "sandbox0-system",
+		},
+	}
+	replicas := int32(2)
+	existing := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo-storage-proxy",
+			Namespace: infra.Namespace,
+			Labels: map[string]string{
+				"old": "label",
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "old"},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "old"},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "old",
+						Image: "old:tag",
+					}},
+				},
+			},
+		},
+	}
+
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(infra.DeepCopy(), existing).
+		Build()
+	manager := NewResourceManager(client, scheme, nil, LocalDevConfig{})
+
+	desiredReplicas := int32(1)
+	desired := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      existing.Name,
+			Namespace: existing.Namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name": "demo-storage-proxy",
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &desiredReplicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "new"},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "new"},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "storage-proxy",
+						Image: "sandbox0ai/storage-proxy:0.2.0-rc.7",
+					}},
+				},
+			},
+		},
+	}
+
+	if err := manager.ApplyDeployment(context.Background(), infra, desired); err != nil {
+		t.Fatalf("apply deployment: %v", err)
+	}
+
+	got := &appsv1.Deployment{}
+	if err := client.Get(context.Background(), types.NamespacedName{Name: existing.Name, Namespace: existing.Namespace}, got); err != nil {
+		t.Fatalf("get deployment: %v", err)
+	}
+	if got.Spec.Template.Spec.Containers[0].Image != "sandbox0ai/storage-proxy:0.2.0-rc.7" {
+		t.Fatalf("expected updated image, got %q", got.Spec.Template.Spec.Containers[0].Image)
+	}
+	if got.Spec.Template.Spec.Containers[0].Name != "storage-proxy" {
+		t.Fatalf("expected updated container, got %q", got.Spec.Template.Spec.Containers[0].Name)
+	}
+	if got.Spec.Replicas == nil || *got.Spec.Replicas != desiredReplicas {
+		t.Fatalf("expected updated replicas, got %#v", got.Spec.Replicas)
+	}
+	if got.Labels["app.kubernetes.io/name"] != "demo-storage-proxy" {
+		t.Fatalf("expected updated labels, got %#v", got.Labels)
+	}
+	if len(got.OwnerReferences) != 1 || got.OwnerReferences[0].Name != infra.Name {
+		t.Fatalf("expected deployment owner reference, got %#v", got.OwnerReferences)
+	}
+}

--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
@@ -32,6 +31,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/metering"
 	"github.com/sandbox0-ai/sandbox0/pkg/migrate"
 	"github.com/sandbox0-ai/sandbox0/pkg/observability"
+	httpobs "github.com/sandbox0-ai/sandbox0/pkg/observability/http"
 	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
 	templmigrations "github.com/sandbox0-ai/sandbox0/pkg/template/migrations"
 	templreconciler "github.com/sandbox0-ai/sandbox0/pkg/template/reconciler"
@@ -298,6 +298,12 @@ func main() {
 		logger,
 		managerMetrics,
 	)
+	sandboxService.SetCtldClient(service.NewCtldClientWithHTTPClient(obsProvider.HTTP.NewClient(httpobs.Config{
+		Timeout: cfg.CtldClientTimeout.Duration,
+	})))
+	sandboxService.SetProcdClient(service.NewProcdClientWithHTTPClient(obsProvider.HTTP.NewClient(httpobs.Config{
+		Timeout: cfg.ProcdClientTimeout.Duration,
+	})))
 	sandboxService.SetSandboxReadinessEvaluator(readinessEvaluator)
 	sandboxService.SetCredentialStore(credentialStore)
 	staticAuth := make([]egressauthruntime.StaticAuthConfig, 0, len(cfg.EgressAuthStaticAuth))
@@ -372,6 +378,7 @@ func main() {
 		sandboxService,
 		sandboxService,
 		logger,
+		managerMetrics,
 		cfg.CleanupInterval.Duration,
 	)
 
@@ -413,7 +420,7 @@ func main() {
 	)
 
 	// Start metrics server
-	go startMetricsServer(cfg.MetricsPort, logger)
+	go startMetricsServer(cfg.MetricsPort, logger, obsProvider)
 
 	// Start informers
 	logger.Info("Starting informers")
@@ -503,13 +510,19 @@ func buildKubeConfig(kubeconfig string) (*rest.Config, error) {
 }
 
 // startMetricsServer starts the Prometheus metrics server
-func startMetricsServer(port int, logger *zap.Logger) {
-	http.Handle("/metrics", promhttp.Handler())
-
+func startMetricsServer(port int, logger *zap.Logger, obsProvider *observability.Provider) {
 	addr := fmt.Sprintf(":%d", port)
+	mux := http.NewServeMux()
+	if obsProvider != nil {
+		mux.Handle("/metrics", obsProvider.MetricsHandler())
+	} else {
+		mux.HandleFunc("/metrics", func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		})
+	}
 	logger.Info("Starting metrics server", zap.String("addr", addr))
 
-	if err := http.ListenAndServe(addr, nil); err != nil {
+	if err := http.ListenAndServe(addr, mux); err != nil {
 		logger.Error("Metrics server failed", zap.Error(err))
 	}
 }

--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -299,10 +299,12 @@ func main() {
 		managerMetrics,
 	)
 	sandboxService.SetCtldClient(service.NewCtldClientWithHTTPClient(obsProvider.HTTP.NewClient(httpobs.Config{
-		Timeout: cfg.CtldClientTimeout.Duration,
+		Timeout:       cfg.CtldClientTimeout.Duration,
+		BaseTransport: httpobs.InternalServiceTransport(),
 	})))
 	sandboxService.SetProcdClient(service.NewProcdClientWithHTTPClient(obsProvider.HTTP.NewClient(httpobs.Config{
-		Timeout: cfg.ProcdClientTimeout.Duration,
+		Timeout:       cfg.ProcdClientTimeout.Duration,
+		BaseTransport: httpobs.InternalServiceTransport(),
 	})))
 	sandboxService.SetSandboxReadinessEvaluator(readinessEvaluator)
 	sandboxService.SetCredentialStore(credentialStore)

--- a/manager/cmd/procd/main.go
+++ b/manager/cmd/procd/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/webhook"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"github.com/sandbox0-ai/sandbox0/pkg/observability"
+	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -62,9 +63,11 @@ func main() {
 		logger.Fatal("Failed to initialize observability", zap.Error(err))
 	}
 	defer obsProvider.Shutdown(context.Background())
+	procdMetrics := obsmetrics.NewProcd(obsProvider.MetricsRegistryOrNil())
 
 	// Initialize managers
 	contextManager := ctxpkg.NewManager()
+	contextManager.SetMetrics(procdMetrics)
 	contextManager.SetDefaultCleanupPolicy(ctxpkg.CleanupPolicy{
 		IdleTimeout: cfg.ContextIdleTimeout.Duration,
 		MaxLifetime: cfg.ContextMaxLifetime.Duration,
@@ -175,6 +178,7 @@ func main() {
 		webhookDispatcher,
 		logger,
 		obsProvider,
+		procdMetrics,
 	)
 
 	cleanupCtx, cleanupCancel := context.WithCancel(context.Background())

--- a/manager/pkg/controller/cleanup_controller.go
+++ b/manager/pkg/controller/cleanup_controller.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
+	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,6 +35,7 @@ type CleanupController struct {
 	sandboxPauser     SandboxPauser
 	sandboxTerminator SandboxTerminator
 	logger            *zap.Logger
+	metrics           *obsmetrics.ManagerMetrics
 	interval          time.Duration
 }
 
@@ -67,6 +69,7 @@ func NewCleanupController(
 	sandboxPauser SandboxPauser,
 	sandboxTerminator SandboxTerminator,
 	logger *zap.Logger,
+	metrics *obsmetrics.ManagerMetrics,
 	interval time.Duration,
 ) *CleanupController {
 	// Use system time as fallback if clock is nil
@@ -83,6 +86,7 @@ func NewCleanupController(
 		sandboxPauser:     sandboxPauser,
 		sandboxTerminator: sandboxTerminator,
 		logger:            logger,
+		metrics:           metrics,
 		interval:          interval,
 	}
 }
@@ -109,15 +113,26 @@ func (cc *CleanupController) Start(ctx context.Context) error {
 
 // runCleanup runs a cleanup cycle
 func (cc *CleanupController) runCleanup(ctx context.Context) error {
+	started := time.Now()
 	cc.logger.Debug("Running cleanup cycle")
+	status := "success"
+	defer func() {
+		if cc.metrics == nil {
+			return
+		}
+		cc.metrics.CleanupRunsTotal.WithLabelValues(status).Inc()
+		cc.metrics.CleanupRunDuration.Observe(time.Since(started).Seconds())
+	}()
 
 	templates, err := cc.templateLister.List()
 	if err != nil {
+		status = "error"
 		return err
 	}
 
 	for _, template := range templates {
 		if err := cc.cleanupExpired(ctx, template); err != nil {
+			status = "error"
 			cc.logger.Error("Failed to cleanup expired sandbox",
 				zap.String("template", template.Name),
 				zap.Error(err),
@@ -180,6 +195,9 @@ func (cc *CleanupController) cleanupExpired(ctx context.Context, template *v1alp
 				cc.recorder.Eventf(template, corev1.EventTypeNormal, "HardExpiredPodDeleted",
 					"Deleted hard-expired pod %s", pod.Name)
 				expiredCount++
+				if cc.metrics != nil {
+					cc.metrics.PodsCleanedTotal.WithLabelValues(template.Name, "hard_expired").Inc()
+				}
 				continue
 			}
 		}
@@ -225,6 +243,9 @@ func (cc *CleanupController) cleanupExpired(ctx context.Context, template *v1alp
 				cc.recorder.Eventf(template, corev1.EventTypeNormal, "ExpiredPodPaused",
 					"Paused expired pod %s", pod.Name)
 				expiredCount++
+				if cc.metrics != nil {
+					cc.metrics.PodsCleanedTotal.WithLabelValues(template.Name, "expired").Inc()
+				}
 			} else {
 				cc.logger.Warn("SandboxPauser not configured, skipping pause of expired pod",
 					zap.String("pod", pod.Name),

--- a/manager/pkg/http/server.go
+++ b/manager/pkg/http/server.go
@@ -86,7 +86,9 @@ func NewServer(
 
 	router := gin.New()
 	router.Use(httpobs.GinMiddleware(httpobs.ServerConfig{
-		Tracer: obsProvider.Tracer(),
+		ServiceName: "manager",
+		Tracer:      obsProvider.Tracer(),
+		Registry:    obsProvider.MetricsRegistryOrNil(),
 	}))
 	router.Use(gin.Recovery())
 	router.Use(requestLogger(logger))

--- a/manager/pkg/service/sandbox_service.go
+++ b/manager/pkg/service/sandbox_service.go
@@ -2440,7 +2440,20 @@ type expectedSandboxPowerState struct {
 
 // PauseSandbox delegates sandbox pause execution to the configured power executor.
 func (s *SandboxService) PauseSandbox(ctx context.Context, sandboxID string) (*PauseSandboxResponse, error) {
-	return s.sandboxPowerExecutor().Pause(ctx, sandboxID)
+	started := time.Now()
+	resp, err := s.sandboxPowerExecutor().Pause(ctx, sandboxID)
+	if s.metrics != nil {
+		status := "success"
+		if err != nil {
+			status = "error"
+		}
+		s.metrics.SandboxPowerTotal.WithLabelValues("pause", status).Inc()
+		s.metrics.SandboxPowerDuration.WithLabelValues("pause").Observe(time.Since(started).Seconds())
+	}
+	if err != nil {
+		s.logger.Warn("Pause sandbox failed", zap.String("sandboxID", sandboxID), zap.Error(err))
+	}
+	return resp, err
 }
 
 // pauseSandboxLocal pauses a sandbox and reduces pod resources based on actual usage.
@@ -2513,7 +2526,20 @@ func (s *SandboxService) RequestPauseSandbox(ctx context.Context, sandboxID stri
 
 // ResumeSandbox delegates sandbox resume execution to the configured power executor.
 func (s *SandboxService) ResumeSandbox(ctx context.Context, sandboxID string) (*ResumeSandboxResponse, error) {
-	return s.sandboxPowerExecutor().Resume(ctx, sandboxID)
+	started := time.Now()
+	resp, err := s.sandboxPowerExecutor().Resume(ctx, sandboxID)
+	if s.metrics != nil {
+		status := "success"
+		if err != nil {
+			status = "error"
+		}
+		s.metrics.SandboxPowerTotal.WithLabelValues("resume", status).Inc()
+		s.metrics.SandboxPowerDuration.WithLabelValues("resume").Observe(time.Since(started).Seconds())
+	}
+	if err != nil {
+		s.logger.Warn("Resume sandbox failed", zap.String("sandboxID", sandboxID), zap.Error(err))
+	}
+	return resp, err
 }
 
 // resumeSandboxLocal resumes a paused sandbox and restores original pod resources.

--- a/manager/procd/pkg/context/manager.go
+++ b/manager/procd/pkg/context/manager.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/process"
 	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/process/repl"
+	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
 )
 
 // ContextResourceUsage represents resource usage for a single context.
@@ -54,6 +55,7 @@ type Manager struct {
 	onStart              process.StartHandler
 	defaultCleanupPolicy CleanupPolicy
 	cleanupOnce          sync.Once
+	metrics              *obsmetrics.ProcdMetrics
 }
 
 // NewManager creates a new context manager.
@@ -61,6 +63,14 @@ func NewManager() *Manager {
 	return &Manager{
 		contexts: make(map[string]*Context),
 	}
+}
+
+// SetMetrics sets procd metrics for context lifecycle tracking.
+func (m *Manager) SetMetrics(metrics *obsmetrics.ProcdMetrics) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.metrics = metrics
+	m.updateContextGaugesLocked()
 }
 
 // SetExitHandler sets a global exit handler for new contexts.
@@ -98,7 +108,15 @@ func (m *Manager) StartCleanup(ctx context.Context, interval time.Duration) {
 				case <-ctx.Done():
 					return
 				case <-ticker.C:
-					m.cleanupExpired()
+					if err := m.cleanupExpired(); err != nil {
+						if m.metrics != nil {
+							m.metrics.CleanupRunsTotal.WithLabelValues("error").Inc()
+						}
+						continue
+					}
+					if m.metrics != nil {
+						m.metrics.CleanupRunsTotal.WithLabelValues("success").Inc()
+					}
 				}
 			}
 		}()
@@ -134,6 +152,7 @@ func (m *Manager) CreateContextWithPolicyAndREPLConfig(config process.ProcessCon
 	ctx.SetCleanupPolicy(policy)
 
 	m.contexts[ctx.ID] = ctx
+	m.updateContextGaugesLocked()
 	m.mu.Unlock()
 	return ctx, nil
 }
@@ -177,6 +196,7 @@ func (m *Manager) DeleteContext(id string) error {
 	_ = ctx.Stop()
 
 	delete(m.contexts, id)
+	m.updateContextGaugesLocked()
 	return nil
 }
 
@@ -214,6 +234,7 @@ func (m *Manager) PauseAll() error {
 		}
 	}
 
+	m.updateContextGaugesLocked()
 	return errors.Join(errs...)
 }
 
@@ -231,7 +252,28 @@ func (m *Manager) ResumeAll() error {
 			}
 		}
 	}
+	m.updateContextGaugesLocked()
 	return errors.Join(errs...)
+}
+
+func (m *Manager) updateContextGaugesLocked() {
+	if m.metrics == nil {
+		return
+	}
+
+	active := 0
+	paused := 0
+	for _, ctx := range m.contexts {
+		if ctx.IsRunning() {
+			active++
+		}
+		if ctx.IsPaused() {
+			paused++
+		}
+	}
+
+	m.metrics.ContextsActive.Set(float64(active))
+	m.metrics.ContextsPaused.Set(float64(paused))
 }
 
 // WriteInput writes input to a context's main process.
@@ -295,9 +337,10 @@ func (m *Manager) Cleanup() {
 	}
 
 	m.contexts = make(map[string]*Context)
+	m.updateContextGaugesLocked()
 }
 
-func (m *Manager) cleanupExpired() {
+func (m *Manager) cleanupExpired() error {
 	now := time.Now()
 	expiredIDs := make([]string, 0)
 
@@ -312,6 +355,7 @@ func (m *Manager) cleanupExpired() {
 	for _, id := range expiredIDs {
 		_ = m.DeleteContext(id)
 	}
+	return nil
 }
 
 // GetResourceUsage returns resource usage for a specific context.

--- a/manager/procd/pkg/http/handlers/context.go
+++ b/manager/procd/pkg/http/handlers/context.go
@@ -31,11 +31,15 @@ type ContextHandler struct {
 }
 
 // NewContextHandler creates a new context handler.
-func NewContextHandler(manager *ctxpkg.Manager, logger *zap.Logger, metrics *obsmetrics.ProcdMetrics) *ContextHandler {
+func NewContextHandler(manager *ctxpkg.Manager, logger *zap.Logger, metrics ...*obsmetrics.ProcdMetrics) *ContextHandler {
+	var procdMetrics *obsmetrics.ProcdMetrics
+	if len(metrics) > 0 {
+		procdMetrics = metrics[0]
+	}
 	return &ContextHandler{
 		manager: manager,
 		logger:  logger,
-		metrics: metrics,
+		metrics: procdMetrics,
 		upgrader: websocket.Upgrader{
 			ReadBufferSize:  1024,
 			WriteBufferSize: 1024,

--- a/manager/procd/pkg/http/handlers/context.go
+++ b/manager/procd/pkg/http/handlers/context.go
@@ -18,6 +18,7 @@ import (
 	ctxpkg "github.com/sandbox0-ai/sandbox0/manager/procd/pkg/context"
 	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/process"
 	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/process/repl"
+	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
 	"go.uber.org/zap"
 )
 
@@ -25,14 +26,16 @@ import (
 type ContextHandler struct {
 	manager  *ctxpkg.Manager
 	logger   *zap.Logger
+	metrics  *obsmetrics.ProcdMetrics
 	upgrader websocket.Upgrader
 }
 
 // NewContextHandler creates a new context handler.
-func NewContextHandler(manager *ctxpkg.Manager, logger *zap.Logger) *ContextHandler {
+func NewContextHandler(manager *ctxpkg.Manager, logger *zap.Logger, metrics *obsmetrics.ProcdMetrics) *ContextHandler {
 	return &ContextHandler{
 		manager: manager,
 		logger:  logger,
+		metrics: metrics,
 		upgrader: websocket.Upgrader{
 			ReadBufferSize:  1024,
 			WriteBufferSize: 1024,
@@ -41,6 +44,14 @@ func NewContextHandler(manager *ctxpkg.Manager, logger *zap.Logger) *ContextHand
 			},
 		},
 	}
+}
+
+func (h *ContextHandler) observeContextOperation(operation, processType, status string, started time.Time) {
+	if h.metrics == nil {
+		return
+	}
+	h.metrics.ContextOperationsTotal.WithLabelValues(operation, status, processType).Inc()
+	h.metrics.ContextOperationDuration.WithLabelValues(operation, processType).Observe(time.Since(started).Seconds())
 }
 
 // CreateContextRequest is the request body for creating a context.
@@ -228,13 +239,16 @@ func (h *ContextHandler) List(w http.ResponseWriter, r *http.Request) {
 
 // Create creates a new context.
 func (h *ContextHandler) Create(w http.ResponseWriter, r *http.Request) {
+	started := time.Now()
 	var req CreateContextRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		h.observeContextOperation("create", "unknown", "invalid_request", started)
 		writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
 		return
 	}
 
 	if req.IdleTimeoutSec < 0 || req.TTLSec < 0 {
+		h.observeContextOperation("create", string(req.Type), "invalid_request", started)
 		writeError(w, http.StatusBadRequest, "invalid_request", "idle_timeout_sec and ttl_sec must be >= 0")
 		return
 	}
@@ -245,10 +259,12 @@ func (h *ContextHandler) Create(w http.ResponseWriter, r *http.Request) {
 		input      string
 	)
 	if req.Repl != nil && req.Type != process.ProcessTypeREPL {
+		h.observeContextOperation("create", string(req.Type), "invalid_request", started)
 		writeError(w, http.StatusBadRequest, "invalid_request", "repl is only valid for repl contexts")
 		return
 	}
 	if req.Cmd != nil && req.Type != process.ProcessTypeCMD {
+		h.observeContextOperation("create", string(req.Type), "invalid_request", started)
 		writeError(w, http.StatusBadRequest, "invalid_request", "cmd is only valid for cmd contexts")
 		return
 	}
@@ -265,16 +281,19 @@ func (h *ContextHandler) Create(w http.ResponseWriter, r *http.Request) {
 			replConfig.Name = alias
 		}
 		if replConfig.Name == "" {
+			h.observeContextOperation("create", string(req.Type), "invalid_request", started)
 			writeError(w, http.StatusBadRequest, "invalid_request", "repl.repl_config.name is required")
 			return
 		}
 		if alias == "" {
 			alias = replConfig.Name
 		} else if alias != replConfig.Name {
+			h.observeContextOperation("create", string(req.Type), "invalid_request", started)
 			writeError(w, http.StatusBadRequest, "invalid_request", "repl.alias must match repl.repl_config.name")
 			return
 		}
 		if err := replConfig.Validate(); err != nil {
+			h.observeContextOperation("create", string(req.Type), "invalid_request", started)
 			writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
 			return
 		}
@@ -297,6 +316,12 @@ func (h *ContextHandler) Create(w http.ResponseWriter, r *http.Request) {
 		PTYSize: req.PTYSize,
 	}, replConfig, policy)
 	if err != nil {
+		h.logger.Warn("Failed to create context",
+			zap.String("type", string(req.Type)),
+			zap.String("alias", alias),
+			zap.Error(err),
+		)
+		h.observeContextOperation("create", string(req.Type), "error", started)
 		writeError(w, http.StatusInternalServerError, "create_failed", err.Error())
 		return
 	}
@@ -304,108 +329,157 @@ func (h *ContextHandler) Create(w http.ResponseWriter, r *http.Request) {
 	if req.WaitUntilDone {
 		output, execErr, aborted := h.execInputSync(ctx, input, r.Context())
 		if aborted {
+			h.observeContextOperation("create", string(req.Type), "canceled", started)
 			return
 		}
 		if execErr != nil {
+			h.observeContextOperation("create", string(req.Type), execErr.code, started)
 			writeError(w, execErr.status, execErr.code, execErr.message)
 			return
 		}
+		h.logger.Info("Created context with synchronous execution",
+			zap.String("context_id", ctx.ID),
+			zap.String("type", string(req.Type)),
+			zap.String("alias", alias),
+		)
+		h.observeContextOperation("create", string(req.Type), "success", started)
 		writeJSON(w, http.StatusCreated, newContextResponse(ctx, output))
 		return
 	}
 
+	h.logger.Info("Created context",
+		zap.String("context_id", ctx.ID),
+		zap.String("type", string(req.Type)),
+		zap.String("alias", alias),
+	)
+	h.observeContextOperation("create", string(req.Type), "success", started)
 	writeJSON(w, http.StatusCreated, newContextResponse(ctx, ""))
 }
 
 // Get gets a context by ID.
 func (h *ContextHandler) Get(w http.ResponseWriter, r *http.Request) {
+	started := time.Now()
 	vars := mux.Vars(r)
 	id := vars["id"]
 
 	ctx, err := h.manager.GetContext(id)
 	if err != nil {
 		if err == ctxpkg.ErrContextNotFound {
+			h.observeContextOperation("get", "unknown", "not_found", started)
 			writeError(w, http.StatusNotFound, "context_not_found", err.Error())
 			return
 		}
+		h.observeContextOperation("get", "unknown", "error", started)
 		writeError(w, http.StatusInternalServerError, "get_failed", err.Error())
 		return
 	}
 
+	h.observeContextOperation("get", string(ctx.Type), "success", started)
 	writeJSON(w, http.StatusOK, newContextResponse(ctx, ""))
 }
 
 // Delete deletes a context.
 func (h *ContextHandler) Delete(w http.ResponseWriter, r *http.Request) {
+	started := time.Now()
 	vars := mux.Vars(r)
 	id := vars["id"]
 
+	processType := "unknown"
+	if ctx, err := h.manager.GetContext(id); err == nil {
+		processType = string(ctx.Type)
+	}
 	err := h.manager.DeleteContext(id)
 	if err != nil {
 		if err == ctxpkg.ErrContextNotFound {
+			h.observeContextOperation("delete", processType, "not_found", started)
 			writeError(w, http.StatusNotFound, "context_not_found", err.Error())
 			return
 		}
+		h.observeContextOperation("delete", processType, "error", started)
 		writeError(w, http.StatusInternalServerError, "delete_failed", err.Error())
 		return
 	}
 
+	h.logger.Info("Deleted context", zap.String("context_id", id), zap.String("type", processType))
+	h.observeContextOperation("delete", processType, "success", started)
 	writeJSON(w, http.StatusOK, map[string]bool{"deleted": true})
 }
 
 // Restart restarts a context.
 func (h *ContextHandler) Restart(w http.ResponseWriter, r *http.Request) {
+	started := time.Now()
 	vars := mux.Vars(r)
 	id := vars["id"]
 
+	processType := "unknown"
+	if existing, err := h.manager.GetContext(id); err == nil {
+		processType = string(existing.Type)
+	}
 	ctx, err := h.manager.RestartContext(id)
 	if err != nil {
 		if err == ctxpkg.ErrContextNotFound {
+			h.observeContextOperation("restart", processType, "not_found", started)
 			writeError(w, http.StatusNotFound, "context_not_found", err.Error())
 			return
 		}
+		h.logger.Warn("Failed to restart context", zap.String("context_id", id), zap.Error(err))
+		h.observeContextOperation("restart", processType, "error", started)
 		writeError(w, http.StatusInternalServerError, "restart_failed", err.Error())
 		return
 	}
 
+	h.logger.Info("Restarted context", zap.String("context_id", id), zap.String("type", string(ctx.Type)))
+	h.observeContextOperation("restart", string(ctx.Type), "success", started)
 	writeJSON(w, http.StatusOK, newContextResponse(ctx, ""))
 }
 
 // WriteInput writes input to a context's process.
 func (h *ContextHandler) WriteInput(w http.ResponseWriter, r *http.Request) {
+	started := time.Now()
 	vars := mux.Vars(r)
 	id := vars["id"]
 
 	var req ContextInputRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		h.observeContextOperation("input", "unknown", "invalid_request", started)
 		writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
 		return
 	}
 
+	processType := "unknown"
+	if ctx, err := h.manager.GetContext(id); err == nil {
+		processType = string(ctx.Type)
+	}
 	err := h.manager.WriteInput(id, []byte(req.Data))
 	if err != nil {
 		if err == ctxpkg.ErrContextNotFound {
+			h.observeContextOperation("input", processType, "not_found", started)
 			writeError(w, http.StatusNotFound, "context_not_found", err.Error())
 			return
 		}
+		h.observeContextOperation("input", processType, "error", started)
 		writeError(w, http.StatusInternalServerError, "write_failed", err.Error())
 		return
 	}
 
+	h.observeContextOperation("input", processType, "success", started)
 	writeJSON(w, http.StatusOK, map[string]bool{"written": true})
 }
 
 // Exec executes input synchronously and returns output when complete.
 func (h *ContextHandler) Exec(w http.ResponseWriter, r *http.Request) {
+	started := time.Now()
 	vars := mux.Vars(r)
 	id := vars["id"]
 
 	var req ContextInputRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		h.observeContextOperation("exec", "unknown", "invalid_request", started)
 		writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
 		return
 	}
 	if req.Data == "" {
+		h.observeContextOperation("exec", "unknown", "invalid_request", started)
 		writeError(w, http.StatusBadRequest, "invalid_request", "data is required")
 		return
 	}
@@ -413,26 +487,32 @@ func (h *ContextHandler) Exec(w http.ResponseWriter, r *http.Request) {
 	ctx, err := h.manager.GetContext(id)
 	if err != nil {
 		if err == ctxpkg.ErrContextNotFound {
+			h.observeContextOperation("exec", "unknown", "not_found", started)
 			writeError(w, http.StatusNotFound, "context_not_found", err.Error())
 			return
 		}
+		h.observeContextOperation("exec", "unknown", "error", started)
 		writeError(w, http.StatusInternalServerError, "get_failed", err.Error())
 		return
 	}
 	if ctx.MainProcess == nil {
+		h.observeContextOperation("exec", string(ctx.Type), "process_not_running", started)
 		writeError(w, http.StatusConflict, "process_not_running", process.ErrProcessNotRunning.Error())
 		return
 	}
 
 	output, execErr, aborted := h.execInputSync(ctx, req.Data, r.Context())
 	if aborted {
+		h.observeContextOperation("exec", string(ctx.Type), "canceled", started)
 		return
 	}
 	if execErr != nil {
+		h.observeContextOperation("exec", string(ctx.Type), execErr.code, started)
 		writeError(w, execErr.status, execErr.code, execErr.message)
 		return
 	}
 
+	h.observeContextOperation("exec", string(ctx.Type), "success", started)
 	writeJSON(w, http.StatusOK, ContextExecResponse{OutputRaw: output})
 }
 

--- a/manager/procd/pkg/http/handlers/initialize.go
+++ b/manager/procd/pkg/http/handlers/initialize.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/volume"
 	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/webhook"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
 	"go.uber.org/zap"
 )
 
@@ -24,6 +25,7 @@ type InitializeHandler struct {
 	volumeManager *volume.Manager
 	httpPort      int
 	logger        *zap.Logger
+	metrics       *obsmetrics.ProcdMetrics
 	readyOnce     sync.Once
 	watchMu       sync.Mutex
 	watchPath     string
@@ -31,13 +33,14 @@ type InitializeHandler struct {
 }
 
 // NewInitializeHandler creates a new initialize handler.
-func NewInitializeHandler(dispatcher *webhook.Dispatcher, fileManager *file.Manager, volumeManager *volume.Manager, httpPort int, logger *zap.Logger) *InitializeHandler {
+func NewInitializeHandler(dispatcher *webhook.Dispatcher, fileManager *file.Manager, volumeManager *volume.Manager, httpPort int, logger *zap.Logger, metrics *obsmetrics.ProcdMetrics) *InitializeHandler {
 	return &InitializeHandler{
 		dispatcher:    dispatcher,
 		fileManager:   fileManager,
 		volumeManager: volumeManager,
 		httpPort:      httpPort,
 		logger:        logger,
+		metrics:       metrics,
 	}
 }
 
@@ -73,18 +76,29 @@ type InitializeResponse struct {
 
 // Initialize sets sandbox identity and webhook settings.
 func (h *InitializeHandler) Initialize(w http.ResponseWriter, r *http.Request) {
+	started := time.Now()
+	record := func(status string) {
+		if h.metrics == nil {
+			return
+		}
+		h.metrics.InitializeTotal.WithLabelValues(status).Inc()
+		h.metrics.InitializeDuration.Observe(time.Since(started).Seconds())
+	}
 	if h.dispatcher == nil {
+		record("unavailable")
 		writeError(w, http.StatusServiceUnavailable, "webhook_unavailable", "webhook dispatcher not configured")
 		return
 	}
 
 	var req InitializeRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		record("invalid_request")
 		writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
 		return
 	}
 
 	if req.SandboxID == "" {
+		record("invalid_request")
 		writeError(w, http.StatusBadRequest, "invalid_request", "sandbox_id is required")
 		return
 	}
@@ -95,6 +109,7 @@ func (h *InitializeHandler) Initialize(w http.ResponseWriter, r *http.Request) {
 		if teamID == "" {
 			teamID = claims.TeamID
 		} else if claims.TeamID != "" && teamID != claims.TeamID {
+			record("forbidden")
 			writeError(w, http.StatusForbidden, "forbidden", "team_id does not match token")
 			return
 		}
@@ -116,6 +131,11 @@ func (h *InitializeHandler) Initialize(w http.ResponseWriter, r *http.Request) {
 
 	bootstrapMounts, err := h.bootstrapMounts(r.Context(), req)
 	if err != nil {
+		h.logger.Warn("Failed to bootstrap mounts during initialize",
+			zap.String("sandbox_id", req.SandboxID),
+			zap.Error(err),
+		)
+		record("invalid_mount_request")
 		writeError(w, http.StatusBadRequest, "invalid_mount_request", err.Error())
 		return
 	}
@@ -132,6 +152,13 @@ func (h *InitializeHandler) Initialize(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
+	h.logger.Info("Initialized sandbox",
+		zap.String("sandbox_id", req.SandboxID),
+		zap.String("team_id", teamID),
+		zap.Int("mount_count", len(req.Mounts)),
+		zap.Bool("wait_for_mounts", req.WaitForMounts),
+	)
+	record("success")
 	writeJSON(w, http.StatusOK, InitializeResponse{
 		SandboxID:       req.SandboxID,
 		TeamID:          teamID,

--- a/manager/procd/pkg/http/handlers/initialize.go
+++ b/manager/procd/pkg/http/handlers/initialize.go
@@ -33,14 +33,18 @@ type InitializeHandler struct {
 }
 
 // NewInitializeHandler creates a new initialize handler.
-func NewInitializeHandler(dispatcher *webhook.Dispatcher, fileManager *file.Manager, volumeManager *volume.Manager, httpPort int, logger *zap.Logger, metrics *obsmetrics.ProcdMetrics) *InitializeHandler {
+func NewInitializeHandler(dispatcher *webhook.Dispatcher, fileManager *file.Manager, volumeManager *volume.Manager, httpPort int, logger *zap.Logger, metrics ...*obsmetrics.ProcdMetrics) *InitializeHandler {
+	var procdMetrics *obsmetrics.ProcdMetrics
+	if len(metrics) > 0 {
+		procdMetrics = metrics[0]
+	}
 	return &InitializeHandler{
 		dispatcher:    dispatcher,
 		fileManager:   fileManager,
 		volumeManager: volumeManager,
 		httpPort:      httpPort,
 		logger:        logger,
-		metrics:       metrics,
+		metrics:       procdMetrics,
 	}
 }
 

--- a/manager/procd/pkg/http/handlers/volume.go
+++ b/manager/procd/pkg/http/handlers/volume.go
@@ -18,11 +18,15 @@ type VolumeHandler struct {
 }
 
 // NewVolumeHandler creates a new volume handler.
-func NewVolumeHandler(manager *volume.Manager, logger *zap.Logger, metrics *obsmetrics.ProcdMetrics) *VolumeHandler {
+func NewVolumeHandler(manager *volume.Manager, logger *zap.Logger, metrics ...*obsmetrics.ProcdMetrics) *VolumeHandler {
+	var procdMetrics *obsmetrics.ProcdMetrics
+	if len(metrics) > 0 {
+		procdMetrics = metrics[0]
+	}
 	return &VolumeHandler{
 		manager: manager,
 		logger:  logger,
-		metrics: metrics,
+		metrics: procdMetrics,
 	}
 }
 

--- a/manager/procd/pkg/http/handlers/volume.go
+++ b/manager/procd/pkg/http/handlers/volume.go
@@ -3,8 +3,10 @@ package handlers
 import (
 	"encoding/json"
 	"net/http"
+	"time"
 
 	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/volume"
+	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
 	"go.uber.org/zap"
 )
 
@@ -12,72 +14,106 @@ import (
 type VolumeHandler struct {
 	manager *volume.Manager
 	logger  *zap.Logger
+	metrics *obsmetrics.ProcdMetrics
 }
 
 // NewVolumeHandler creates a new volume handler.
-func NewVolumeHandler(manager *volume.Manager, logger *zap.Logger) *VolumeHandler {
+func NewVolumeHandler(manager *volume.Manager, logger *zap.Logger, metrics *obsmetrics.ProcdMetrics) *VolumeHandler {
 	return &VolumeHandler{
 		manager: manager,
 		logger:  logger,
+		metrics: metrics,
 	}
+}
+
+func (h *VolumeHandler) observeVolumeOperation(operation, status string, started time.Time) {
+	if h.metrics == nil {
+		return
+	}
+	h.metrics.VolumeOperationsTotal.WithLabelValues(operation, status).Inc()
+	h.metrics.VolumeOperationDuration.WithLabelValues(operation).Observe(time.Since(started).Seconds())
 }
 
 // Mount mounts a SandboxVolume.
 func (h *VolumeHandler) Mount(w http.ResponseWriter, r *http.Request) {
+	started := time.Now()
 	var req volume.MountRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		h.observeVolumeOperation("mount", "invalid_request", started)
 		writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
 		return
 	}
 
 	if req.SandboxVolumeID == "" {
+		h.observeVolumeOperation("mount", "invalid_request", started)
 		writeError(w, http.StatusBadRequest, "invalid_sandboxvolume_id", "sandboxvolume_id is required")
 		return
 	}
 
 	if req.MountPoint == "" {
+		h.observeVolumeOperation("mount", "invalid_request", started)
 		writeError(w, http.StatusBadRequest, "invalid_mount_point", "mount_point is required")
 		return
 	}
 
 	resp, err := h.manager.Mount(r.Context(), &req)
 	if err != nil {
+		h.logger.Warn("Failed to mount volume",
+			zap.String("sandboxvolume_id", req.SandboxVolumeID),
+			zap.String("mount_point", req.MountPoint),
+			zap.Error(err),
+		)
 		if err == volume.ErrVolumeAlreadyMounted {
+			h.observeVolumeOperation("mount", "already_mounted", started)
 			writeError(w, http.StatusConflict, "already_mounted", err.Error())
 			return
 		}
 		if err == volume.ErrVolumeMountInProgress {
+			h.observeVolumeOperation("mount", "mount_in_progress", started)
 			writeError(w, http.StatusConflict, "mount_in_progress", err.Error())
 			return
 		}
 		if err == volume.ErrMountPointInUse {
+			h.observeVolumeOperation("mount", "mount_point_in_use", started)
 			writeError(w, http.StatusConflict, "mount_point_in_use", err.Error())
 			return
 		}
 		if err == volume.ErrInvalidMountPoint {
+			h.observeVolumeOperation("mount", "invalid_mount_point", started)
 			writeError(w, http.StatusBadRequest, "invalid_mount_point", err.Error())
 			return
 		}
+		h.observeVolumeOperation("mount", "error", started)
 		writeError(w, http.StatusInternalServerError, "mount_failed", err.Error())
 		return
 	}
 
+	h.logger.Info("Mounted volume",
+		zap.String("sandboxvolume_id", req.SandboxVolumeID),
+		zap.String("mount_point", req.MountPoint),
+		zap.String("mount_session_id", resp.MountSessionID),
+	)
+	h.observeVolumeOperation("mount", "success", started)
 	writeJSON(w, http.StatusOK, resp)
 }
 
 // Unmount unmounts a SandboxVolume.
 func (h *VolumeHandler) Unmount(w http.ResponseWriter, r *http.Request) {
+	started := time.Now()
 	var req volume.UnmountRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		h.observeVolumeOperation("unmount", "invalid_request", started)
 		writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
 		return
 	}
 
 	if req.SandboxVolumeID == "" {
+		h.observeVolumeOperation("unmount", "invalid_request", started)
 		writeError(w, http.StatusBadRequest, "invalid_sandboxvolume_id", "sandboxvolume_id is required")
 		return
 	}
 	if req.MountSessionID == "" {
+		h.observeVolumeOperation("unmount", "invalid_request", started)
 		writeError(w, http.StatusBadRequest, "invalid_mount_session_id", "mount_session_id is required")
 		return
 	}
@@ -85,23 +121,38 @@ func (h *VolumeHandler) Unmount(w http.ResponseWriter, r *http.Request) {
 	err := h.manager.Unmount(r.Context(), req.SandboxVolumeID, req.MountSessionID)
 	if err != nil {
 		if err == volume.ErrVolumeNotMounted {
+			h.observeVolumeOperation("unmount", "not_mounted", started)
 			writeJSON(w, http.StatusOK, map[string]bool{"unmounted": true})
 			return
 		}
 		if err == volume.ErrMountSessionNotFound {
+			h.observeVolumeOperation("unmount", "session_not_found", started)
 			writeJSON(w, http.StatusOK, map[string]bool{"unmounted": true})
 			return
 		}
+		h.logger.Warn("Failed to unmount volume",
+			zap.String("sandboxvolume_id", req.SandboxVolumeID),
+			zap.String("mount_session_id", req.MountSessionID),
+			zap.Error(err),
+		)
+		h.observeVolumeOperation("unmount", "error", started)
 		writeError(w, http.StatusInternalServerError, "unmount_failed", err.Error())
 		return
 	}
 
+	h.logger.Info("Unmounted volume",
+		zap.String("sandboxvolume_id", req.SandboxVolumeID),
+		zap.String("mount_session_id", req.MountSessionID),
+	)
+	h.observeVolumeOperation("unmount", "success", started)
 	writeJSON(w, http.StatusOK, map[string]bool{"unmounted": true})
 }
 
 // Status returns the status of all mounts.
 func (h *VolumeHandler) Status(w http.ResponseWriter, r *http.Request) {
+	started := time.Now()
 	status := h.manager.GetStatus()
+	h.observeVolumeOperation("status", "success", started)
 	writeJSON(w, http.StatusOK, map[string]any{
 		"mounts": status,
 	})

--- a/manager/procd/pkg/http/server.go
+++ b/manager/procd/pkg/http/server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"github.com/sandbox0-ai/sandbox0/pkg/observability"
 	httpobs "github.com/sandbox0-ai/sandbox0/pkg/observability/http"
+	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 )
@@ -59,6 +60,7 @@ type Server struct {
 	logger      *zap.Logger
 	cfg         *config.ProcdConfig
 	obsProvider *observability.Provider
+	metrics     *obsmetrics.ProcdMetrics
 
 	// Managers
 	contextManager *ctxpkg.Manager
@@ -86,6 +88,7 @@ func NewServer(
 	webhookDispatcher *webhook.Dispatcher,
 	logger *zap.Logger,
 	obsProvider *observability.Provider,
+	metrics *obsmetrics.ProcdMetrics,
 ) *Server {
 	s := &Server{
 		router:            mux.NewRouter(),
@@ -98,6 +101,7 @@ func NewServer(
 		webhookDispatcher: webhookDispatcher,
 		logger:            logger,
 		obsProvider:       obsProvider,
+		metrics:           metrics,
 	}
 
 	s.setupRoutes()
@@ -107,7 +111,9 @@ func NewServer(
 func (s *Server) setupRoutes() {
 	// Global middleware (applied to all routes)
 	s.router.Use(httpobs.ServerMiddleware(httpobs.ServerConfig{
-		Tracer: s.obsProvider.Tracer(),
+		ServiceName: "procd",
+		Tracer:      s.obsProvider.Tracer(),
+		Registry:    s.obsProvider.MetricsRegistryOrNil(),
 	}))
 	s.router.Use(s.loggingMiddleware)
 	s.router.Use(s.recoveryMiddleware)
@@ -115,6 +121,7 @@ func (s *Server) setupRoutes() {
 	// Health check endpoints (no auth required)
 	s.router.HandleFunc("/healthz", s.healthHandler).Methods("GET")
 	s.router.HandleFunc("/readyz", s.readyHandler).Methods("GET")
+	s.router.Path("/metrics").Handler(s.obsProvider.MetricsHandler()).Methods("GET")
 
 	// Local-only API (localhost access only, no auth)
 	local := s.router.PathPrefix("/api/v1").Subrouter()
@@ -137,7 +144,7 @@ func (s *Server) setupRoutes() {
 	api.HandleFunc("/sandbox/stats", sandboxHandler.Stats).Methods("GET")
 
 	// Context/Process handlers
-	contextHandler := handlers.NewContextHandler(s.contextManager, s.logger)
+	contextHandler := handlers.NewContextHandler(s.contextManager, s.logger, s.metrics)
 	api.HandleFunc("/contexts", contextHandler.List).Methods("GET")
 	api.HandleFunc("/contexts", contextHandler.Create).Methods("POST")
 	api.HandleFunc("/contexts/{id}", contextHandler.Get).Methods("GET")
@@ -151,11 +158,11 @@ func (s *Server) setupRoutes() {
 	api.HandleFunc("/contexts/{id}/ws", contextHandler.WebSocket).Methods("GET")
 
 	// Initialize handler
-	initializeHandler := handlers.NewInitializeHandler(s.webhookDispatcher, s.fileManager, s.volumeManager, s.cfg.HTTPPort, s.logger)
+	initializeHandler := handlers.NewInitializeHandler(s.webhookDispatcher, s.fileManager, s.volumeManager, s.cfg.HTTPPort, s.logger, s.metrics)
 	api.HandleFunc("/initialize", initializeHandler.Initialize).Methods("POST")
 
 	// SandboxVolume handlers
-	volumeHandler := handlers.NewVolumeHandler(s.volumeManager, s.logger)
+	volumeHandler := handlers.NewVolumeHandler(s.volumeManager, s.logger, s.metrics)
 	volumeRouter := api.PathPrefix("/sandboxvolumes").Subrouter()
 	volumeRouter.Use(s.storageProxyUpstreamMiddleware)
 	volumeRouter.HandleFunc("/mount", volumeHandler.Mount).Methods("POST")

--- a/netd/cmd/netd/main.go
+++ b/netd/cmd/netd/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
 	"github.com/sandbox0-ai/sandbox0/netd/pkg/daemon"
+	"github.com/sandbox0-ai/sandbox0/pkg/observability"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -34,7 +35,20 @@ func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
-	daemon := daemon.New(cfg, logger)
+	obsProvider, err := observability.New(observability.Config{
+		ServiceName: "netd",
+		Logger:      logger,
+		TraceExporter: observability.TraceExporterConfig{
+			Type:     os.Getenv("OTEL_EXPORTER_TYPE"),
+			Endpoint: os.Getenv("OTEL_EXPORTER_ENDPOINT"),
+		},
+	})
+	if err != nil {
+		logger.Fatal("Failed to initialize observability", zap.Error(err))
+	}
+	defer obsProvider.Shutdown(ctx)
+
+	daemon := daemon.New(cfg, logger, obsProvider)
 	if err := daemon.Run(ctx); err != nil {
 		logger.Fatal("netd exited with error", zap.Error(err))
 	}

--- a/netd/pkg/daemon/daemon.go
+++ b/netd/pkg/daemon/daemon.go
@@ -220,7 +220,8 @@ func (d *Daemon) runNetd(ctx context.Context, cancel context.CancelFunc, proxyEx
 		httpClient := (*http.Client)(nil)
 		if d.obsProvider != nil {
 			httpClient = d.obsProvider.HTTP.NewClient(httpobs.Config{
-				Timeout: d.cfg.EgressAuthResolverTimeout.Duration,
+				Timeout:       d.cfg.EgressAuthResolverTimeout.Duration,
+				BaseTransport: httpobs.InternalServiceTransport(),
 			})
 		}
 		proxyOpts = append(proxyOpts, proxy.WithEgressAuthResolver(proxy.NewHTTPEgressAuthResolverWithHTTPClient(

--- a/netd/pkg/daemon/daemon.go
+++ b/netd/pkg/daemon/daemon.go
@@ -22,6 +22,8 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/dbpool"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	meteringpkg "github.com/sandbox0-ai/sandbox0/pkg/metering"
+	"github.com/sandbox0-ai/sandbox0/pkg/observability"
+	httpobs "github.com/sandbox0-ai/sandbox0/pkg/observability/http"
 	"go.uber.org/zap"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -33,16 +35,24 @@ type Daemon struct {
 	healthServer  *http.Server
 	metricsServer *http.Server
 	proxyServer   *proxy.Server
+	obsProvider   *observability.Provider
+	metrics       *daemonMetrics
 	ready         atomic.Bool
 }
 
-func New(cfg *config.NetdConfig, logger *zap.Logger) *Daemon {
+func New(cfg *config.NetdConfig, logger *zap.Logger, obsProvider *observability.Provider) *Daemon {
 	if logger == nil {
 		logger = zap.NewNop()
 	}
+	var metrics *daemonMetrics
+	if obsProvider != nil {
+		metrics = newDaemonMetrics(obsProvider.MetricsRegistryOrNil())
+	}
 	return &Daemon{
-		cfg:    cfg,
-		logger: logger,
+		cfg:         cfg,
+		logger:      logger,
+		obsProvider: obsProvider,
+		metrics:     metrics,
 	}
 }
 
@@ -92,6 +102,9 @@ func (d *Daemon) runNetd(ctx context.Context, cancel context.CancelFunc, proxyEx
 	k8sConfig, err := rest.InClusterConfig()
 	if err != nil {
 		return err
+	}
+	if d.obsProvider != nil {
+		d.obsProvider.K8s.WrapConfig(k8sConfig)
 	}
 	client, err := kubernetes.NewForConfig(k8sConfig)
 	if err != nil {
@@ -204,9 +217,15 @@ func (d *Daemon) runNetd(ctx context.Context, cancel context.CancelFunc, proxyEx
 			PrivateKey: privateKey,
 			TTL:        30 * time.Second,
 		})
-		proxyOpts = append(proxyOpts, proxy.WithEgressAuthResolver(proxy.NewHTTPEgressAuthResolver(
+		httpClient := (*http.Client)(nil)
+		if d.obsProvider != nil {
+			httpClient = d.obsProvider.HTTP.NewClient(httpobs.Config{
+				Timeout: d.cfg.EgressAuthResolverTimeout.Duration,
+			})
+		}
+		proxyOpts = append(proxyOpts, proxy.WithEgressAuthResolver(proxy.NewHTTPEgressAuthResolverWithHTTPClient(
 			d.cfg.EgressAuthResolverURL,
-			d.cfg.EgressAuthResolverTimeout.Duration,
+			httpClient,
 			netdEgressAuthTokenProvider{generator: tokenGenerator},
 		)))
 	}
@@ -248,13 +267,18 @@ func (d *Daemon) runNetd(ctx context.Context, cancel context.CancelFunc, proxyEx
 			case <-ticker.C:
 			case <-syncTrigger:
 			}
+			started := time.Now()
 			if err := d.syncRedirect(ctx, netdWatcher, policyStore, redirectManager, patcher); err != nil {
+				d.metrics.observeRedirectSync("error", time.Since(started))
 				d.logger.Error("Failed to sync redirect rules", zap.Error(err))
 				if d.cfg.FailClosed {
 					d.ready.Store(false)
+					d.metrics.setReady(false)
 				}
 			} else {
 				d.ready.Store(true)
+				d.metrics.observeRedirectSync("success", time.Since(started))
+				d.metrics.setReady(true)
 			}
 			select {
 			case syncOnce <- struct{}{}:
@@ -298,12 +322,18 @@ func (d *Daemon) runMeteringFlushLoop(ctx context.Context, aggregator *netdmeter
 		select {
 		case <-ctx.Done():
 			if err := aggregator.Flush(context.Background()); err != nil {
+				d.metrics.observeMeteringFlush("error")
 				d.logger.Error("Failed to flush netd metering windows during shutdown", zap.Error(err))
+			} else {
+				d.metrics.observeMeteringFlush("success")
 			}
 			return
 		case <-ticker.C:
 			if err := aggregator.Flush(ctx); err != nil {
+				d.metrics.observeMeteringFlush("error")
 				d.logger.Error("Failed to flush netd metering windows", zap.Error(err))
+			} else {
+				d.metrics.observeMeteringFlush("success")
 			}
 		}
 	}
@@ -396,7 +426,11 @@ func (d *Daemon) startServers() error {
 	}
 
 	metricsMux := http.NewServeMux()
-	metricsMux.Handle("/metrics", promhttp.Handler())
+	if d.obsProvider != nil {
+		metricsMux.Handle("/metrics", d.obsProvider.MetricsHandler())
+	} else {
+		metricsMux.Handle("/metrics", promhttp.Handler())
+	}
 	d.metricsServer = &http.Server{
 		Addr:              net.JoinHostPort("", fmt.Sprintf("%d", d.cfg.MetricsPort)),
 		Handler:           metricsMux,
@@ -467,10 +501,12 @@ func (d *Daemon) handleHealth(w http.ResponseWriter, _ *http.Request) {
 
 func (d *Daemon) handleReady(w http.ResponseWriter, _ *http.Request) {
 	if !d.ready.Load() {
+		d.metrics.setReady(false)
 		w.WriteHeader(http.StatusServiceUnavailable)
 		_, _ = w.Write([]byte("not ready"))
 		return
 	}
+	d.metrics.setReady(true)
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write([]byte("ready"))
 }

--- a/netd/pkg/daemon/metrics.go
+++ b/netd/pkg/daemon/metrics.go
@@ -1,0 +1,68 @@
+package daemon
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type daemonMetrics struct {
+	redirectSyncTotal    *prometheus.CounterVec
+	redirectSyncDuration prometheus.Histogram
+	meteringFlushTotal   *prometheus.CounterVec
+	ready                prometheus.Gauge
+}
+
+func newDaemonMetrics(registry prometheus.Registerer) *daemonMetrics {
+	if registry == nil {
+		return nil
+	}
+
+	factory := promauto.With(registry)
+	return &daemonMetrics{
+		redirectSyncTotal: factory.NewCounterVec(prometheus.CounterOpts{
+			Name: "netd_redirect_sync_total",
+			Help: "Total number of redirect sync attempts",
+		}, []string{"status"}),
+		redirectSyncDuration: factory.NewHistogram(prometheus.HistogramOpts{
+			Name:    "netd_redirect_sync_duration_seconds",
+			Help:    "Duration of redirect sync runs",
+			Buckets: prometheus.DefBuckets,
+		}),
+		meteringFlushTotal: factory.NewCounterVec(prometheus.CounterOpts{
+			Name: "netd_metering_flush_total",
+			Help: "Total number of metering flush attempts",
+		}, []string{"status"}),
+		ready: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "netd_ready",
+			Help: "Whether netd is ready (1) or not ready (0)",
+		}),
+	}
+}
+
+func (m *daemonMetrics) observeRedirectSync(status string, duration time.Duration) {
+	if m == nil {
+		return
+	}
+	m.redirectSyncTotal.WithLabelValues(status).Inc()
+	m.redirectSyncDuration.Observe(duration.Seconds())
+}
+
+func (m *daemonMetrics) observeMeteringFlush(status string) {
+	if m == nil {
+		return
+	}
+	m.meteringFlushTotal.WithLabelValues(status).Inc()
+}
+
+func (m *daemonMetrics) setReady(ready bool) {
+	if m == nil {
+		return
+	}
+	if ready {
+		m.ready.Set(1)
+		return
+	}
+	m.ready.Set(0)
+}

--- a/netd/pkg/proxy/egress_broker_client.go
+++ b/netd/pkg/proxy/egress_broker_client.go
@@ -24,19 +24,23 @@ type EgressAuthTokenProvider interface {
 }
 
 func NewHTTPEgressAuthResolver(baseURL string, timeout time.Duration, tokenProvider EgressAuthTokenProvider) egressAuthResolver {
+	return NewHTTPEgressAuthResolverWithHTTPClient(baseURL, &http.Client{Timeout: timeout}, tokenProvider)
+}
+
+func NewHTTPEgressAuthResolverWithHTTPClient(baseURL string, httpClient *http.Client, tokenProvider EgressAuthTokenProvider) egressAuthResolver {
 	baseURL = strings.TrimSpace(baseURL)
 	if baseURL == "" {
 		return noopEgressAuthResolver{}
 	}
-	if timeout <= 0 {
-		timeout = 2 * time.Second
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 2 * time.Second}
+	} else if httpClient.Timeout <= 0 {
+		httpClient.Timeout = 2 * time.Second
 	}
 	return &httpEgressAuthResolver{
 		baseURL:       strings.TrimRight(baseURL, "/"),
 		tokenProvider: tokenProvider,
-		client: &http.Client{
-			Timeout: timeout,
-		},
+		client:        httpClient,
 	}
 }
 

--- a/pkg/observability/config.go
+++ b/pkg/observability/config.go
@@ -18,6 +18,10 @@ type Config struct {
 	// MetricsRegistry for Prometheus metrics (default: prometheus.DefaultRegisterer)
 	MetricsRegistry prometheus.Registerer
 
+	// MetricsGatherer is used to expose Prometheus metrics (default: derived from
+	// MetricsRegistry when possible, otherwise prometheus.DefaultGatherer).
+	MetricsGatherer prometheus.Gatherer
+
 	// TraceExporter configures where traces are sent
 	// If nil, traces are disabled
 	TraceExporter TraceExporterConfig
@@ -61,6 +65,13 @@ func (c *Config) Validate() error {
 func (c *Config) setDefaults() {
 	if c.MetricsRegistry == nil {
 		c.MetricsRegistry = prometheus.DefaultRegisterer
+	}
+	if c.MetricsGatherer == nil {
+		if gatherer, ok := c.MetricsRegistry.(prometheus.Gatherer); ok {
+			c.MetricsGatherer = gatherer
+		} else {
+			c.MetricsGatherer = prometheus.DefaultGatherer
+		}
 	}
 	if c.TraceSampleRate == 0 {
 		c.TraceSampleRate = 1.0

--- a/pkg/observability/http/adapter.go
+++ b/pkg/observability/http/adapter.go
@@ -36,6 +36,18 @@ type Config struct {
 	IdleConnTimeout     time.Duration
 }
 
+// InternalServiceTransport returns a transport suitable for intra-cluster or
+// control-plane service-to-service calls. It intentionally bypasses
+// ProxyFromEnvironment so internal service DNS names are dialed directly.
+func InternalServiceTransport() http.RoundTripper {
+	return &http.Transport{
+		Proxy:               nil,
+		MaxIdleConns:        50,
+		MaxIdleConnsPerHost: 20,
+		IdleConnTimeout:     90 * time.Second,
+	}
+}
+
 // NewAdapter creates a new HTTP adapter
 func NewAdapter(cfg AdapterConfig) Adapter {
 	var m *metrics

--- a/pkg/observability/http/adapter_test.go
+++ b/pkg/observability/http/adapter_test.go
@@ -1,0 +1,16 @@
+package http
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestInternalServiceTransportDisablesProxyFromEnvironment(t *testing.T) {
+	transport, ok := InternalServiceTransport().(*http.Transport)
+	if !ok {
+		t.Fatalf("expected *http.Transport, got %T", InternalServiceTransport())
+	}
+	if transport.Proxy != nil {
+		t.Fatal("expected internal service transport to bypass environment proxy resolution")
+	}
+}

--- a/pkg/observability/http/server.go
+++ b/pkg/observability/http/server.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -18,13 +20,54 @@ import (
 
 // ServerConfig configures HTTP server observability middleware.
 type ServerConfig struct {
-	Tracer   trace.Tracer
-	Logger   *zap.Logger
-	Disabled bool
+	ServiceName string
+	Tracer      trace.Tracer
+	Logger      *zap.Logger
+	Registry    prometheus.Registerer
+	Disabled    bool
+}
+
+type serverMetrics struct {
+	requestsTotal   *prometheus.CounterVec
+	requestDuration *prometheus.HistogramVec
+	activeRequests  *prometheus.GaugeVec
+}
+
+func newServerMetrics(serviceName string, registry prometheus.Registerer) *serverMetrics {
+	if serviceName == "" || registry == nil {
+		return nil
+	}
+
+	factory := promauto.With(registry)
+	return &serverMetrics{
+		requestsTotal: factory.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: serviceName + "_http_server_requests_total",
+				Help: "Total number of HTTP server requests",
+			},
+			[]string{"method", "route", "status"},
+		),
+		requestDuration: factory.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:    serviceName + "_http_server_request_duration_seconds",
+				Help:    "HTTP server request duration in seconds",
+				Buckets: []float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 30, 60},
+			},
+			[]string{"method", "route"},
+		),
+		activeRequests: factory.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: serviceName + "_http_server_active_requests",
+				Help: "Number of in-flight HTTP server requests",
+			},
+			[]string{"method", "route"},
+		),
+	}
 }
 
 // ServerMiddleware returns net/http middleware with tracing and optional logging.
 func ServerMiddleware(cfg ServerConfig) func(http.Handler) http.Handler {
+	metrics := newServerMetrics(cfg.ServiceName, cfg.Registry)
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if cfg.Disabled {
@@ -39,6 +82,11 @@ func ServerMiddleware(cfg ServerConfig) func(http.Handler) http.Handler {
 
 			ctx := otel.GetTextMapPropagator().Extract(r.Context(), propagation.HeaderCarrier(r.Header))
 			start := time.Now()
+			route := r.URL.Path
+			if metrics != nil {
+				metrics.activeRequests.WithLabelValues(r.Method, route).Inc()
+				defer metrics.activeRequests.WithLabelValues(r.Method, route).Dec()
+			}
 
 			spanName := fmt.Sprintf("HTTP %s %s", r.Method, r.URL.Path)
 			ctx, span := tracer.Start(ctx, spanName,
@@ -60,6 +108,11 @@ func ServerMiddleware(cfg ServerConfig) func(http.Handler) http.Handler {
 			span.SetAttributes(attribute.Int("http.status_code", status))
 			if status >= 400 {
 				span.SetStatus(codes.Error, fmt.Sprintf("HTTP %d", status))
+			}
+			if metrics != nil {
+				statusLabel := fmt.Sprintf("%d", status)
+				metrics.requestsTotal.WithLabelValues(r.Method, route, statusLabel).Inc()
+				metrics.requestDuration.WithLabelValues(r.Method, route).Observe(time.Since(start).Seconds())
 			}
 
 			if cfg.Logger != nil {
@@ -85,6 +138,7 @@ func ServerMiddleware(cfg ServerConfig) func(http.Handler) http.Handler {
 
 // GinMiddleware returns gin middleware with tracing and optional logging.
 func GinMiddleware(cfg ServerConfig) gin.HandlerFunc {
+	metrics := newServerMetrics(cfg.ServiceName, cfg.Registry)
 	return func(c *gin.Context) {
 		if cfg.Disabled {
 			c.Next()
@@ -98,6 +152,11 @@ func GinMiddleware(cfg ServerConfig) gin.HandlerFunc {
 
 		ctx := otel.GetTextMapPropagator().Extract(c.Request.Context(), propagation.HeaderCarrier(c.Request.Header))
 		start := time.Now()
+		route := c.Request.URL.Path
+		if metrics != nil {
+			metrics.activeRequests.WithLabelValues(c.Request.Method, route).Inc()
+			defer metrics.activeRequests.WithLabelValues(c.Request.Method, route).Dec()
+		}
 
 		spanName := fmt.Sprintf("HTTP %s %s", c.Request.Method, c.Request.URL.Path)
 		ctx, span := tracer.Start(ctx, spanName,
@@ -116,15 +175,20 @@ func GinMiddleware(cfg ServerConfig) gin.HandlerFunc {
 		c.Next()
 
 		status := c.Writer.Status()
-		route := c.FullPath()
-		if route != "" {
-			span.SetAttributes(attribute.String("http.route", route))
-			span.SetName(fmt.Sprintf("HTTP %s %s", c.Request.Method, route))
+		if matchedRoute := c.FullPath(); matchedRoute != "" {
+			route = matchedRoute
+			span.SetAttributes(attribute.String("http.route", matchedRoute))
+			span.SetName(fmt.Sprintf("HTTP %s %s", c.Request.Method, matchedRoute))
 		}
 
 		span.SetAttributes(attribute.Int("http.status_code", status))
 		if status >= 400 {
 			span.SetStatus(codes.Error, fmt.Sprintf("HTTP %d", status))
+		}
+		if metrics != nil {
+			statusLabel := fmt.Sprintf("%d", status)
+			metrics.requestsTotal.WithLabelValues(c.Request.Method, route, statusLabel).Inc()
+			metrics.requestDuration.WithLabelValues(c.Request.Method, route).Observe(time.Since(start).Seconds())
 		}
 
 		if cfg.Logger != nil {

--- a/pkg/observability/metrics/manager.go
+++ b/pkg/observability/metrics/manager.go
@@ -12,9 +12,13 @@ type ManagerMetrics struct {
 	ActivePodsTotal      *prometheus.GaugeVec
 	SandboxClaimsTotal   *prometheus.CounterVec
 	SandboxClaimDuration *prometheus.HistogramVec
+	SandboxPowerTotal    *prometheus.CounterVec
+	SandboxPowerDuration *prometheus.HistogramVec
 	PodsCleanedTotal     *prometheus.CounterVec
 	ReconcileTotal       *prometheus.CounterVec
 	ReconcileDuration    *prometheus.HistogramVec
+	CleanupRunsTotal     *prometheus.CounterVec
+	CleanupRunDuration   prometheus.Histogram
 	MeteringEventsTotal  *prometheus.CounterVec
 	MeteringWindowsTotal *prometheus.CounterVec
 	MeteringErrorsTotal  *prometheus.CounterVec
@@ -51,6 +55,15 @@ func NewManager(registry prometheus.Registerer) *ManagerMetrics {
 			Help:    "Duration of sandbox claim operations",
 			Buckets: prometheus.DefBuckets,
 		}, []string{"template", "type"}), // type: "hot" (from pool) or "cold" (new pod)
+		SandboxPowerTotal: factory.NewCounterVec(prometheus.CounterOpts{
+			Name: "manager_sandbox_power_total",
+			Help: "Total number of sandbox power state operations",
+		}, []string{"operation", "status"}), // operation: pause, resume
+		SandboxPowerDuration: factory.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "manager_sandbox_power_duration_seconds",
+			Help:    "Duration of sandbox power state operations",
+			Buckets: prometheus.DefBuckets,
+		}, []string{"operation"}),
 		PodsCleanedTotal: factory.NewCounterVec(prometheus.CounterOpts{
 			Name: "manager_pods_cleaned_total",
 			Help: "Total number of pods cleaned up",
@@ -64,6 +77,15 @@ func NewManager(registry prometheus.Registerer) *ManagerMetrics {
 			Help:    "Duration of reconciliation operations",
 			Buckets: prometheus.DefBuckets,
 		}, []string{"template"}),
+		CleanupRunsTotal: factory.NewCounterVec(prometheus.CounterOpts{
+			Name: "manager_cleanup_runs_total",
+			Help: "Total number of cleanup controller runs",
+		}, []string{"status"}),
+		CleanupRunDuration: factory.NewHistogram(prometheus.HistogramOpts{
+			Name:    "manager_cleanup_run_duration_seconds",
+			Help:    "Duration of manager cleanup controller runs",
+			Buckets: prometheus.DefBuckets,
+		}),
 		MeteringEventsTotal: factory.NewCounterVec(prometheus.CounterOpts{
 			Name: "manager_metering_events_total",
 			Help: "Total number of manager metering lifecycle events attempted",

--- a/pkg/observability/metrics/procd.go
+++ b/pkg/observability/metrics/procd.go
@@ -1,0 +1,68 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// ProcdMetrics holds Prometheus metrics for the procd service.
+type ProcdMetrics struct {
+	ContextOperationsTotal   *prometheus.CounterVec
+	ContextOperationDuration *prometheus.HistogramVec
+	ContextsActive           prometheus.Gauge
+	ContextsPaused           prometheus.Gauge
+	VolumeOperationsTotal    *prometheus.CounterVec
+	VolumeOperationDuration  *prometheus.HistogramVec
+	InitializeTotal          *prometheus.CounterVec
+	InitializeDuration       prometheus.Histogram
+	CleanupRunsTotal         *prometheus.CounterVec
+}
+
+func NewProcd(registry prometheus.Registerer) *ProcdMetrics {
+	if registry == nil {
+		return nil
+	}
+
+	factory := promauto.With(registry)
+	return &ProcdMetrics{
+		ContextOperationsTotal: factory.NewCounterVec(prometheus.CounterOpts{
+			Name: "procd_context_operations_total",
+			Help: "Total number of procd context operations",
+		}, []string{"operation", "status", "type"}),
+		ContextOperationDuration: factory.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "procd_context_operation_duration_seconds",
+			Help:    "Duration of procd context operations",
+			Buckets: prometheus.DefBuckets,
+		}, []string{"operation", "type"}),
+		ContextsActive: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "procd_contexts_active",
+			Help: "Number of active procd contexts",
+		}),
+		ContextsPaused: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "procd_contexts_paused",
+			Help: "Number of paused procd contexts",
+		}),
+		VolumeOperationsTotal: factory.NewCounterVec(prometheus.CounterOpts{
+			Name: "procd_volume_operations_total",
+			Help: "Total number of procd volume operations",
+		}, []string{"operation", "status"}),
+		VolumeOperationDuration: factory.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "procd_volume_operation_duration_seconds",
+			Help:    "Duration of procd volume operations",
+			Buckets: prometheus.DefBuckets,
+		}, []string{"operation"}),
+		InitializeTotal: factory.NewCounterVec(prometheus.CounterOpts{
+			Name: "procd_initialize_total",
+			Help: "Total number of procd initialize requests",
+		}, []string{"status"}),
+		InitializeDuration: factory.NewHistogram(prometheus.HistogramOpts{
+			Name:    "procd_initialize_duration_seconds",
+			Help:    "Duration of procd initialize requests",
+			Buckets: prometheus.DefBuckets,
+		}),
+		CleanupRunsTotal: factory.NewCounterVec(prometheus.CounterOpts{
+			Name: "procd_cleanup_runs_total",
+			Help: "Total number of procd cleanup loop runs",
+		}, []string{"status"}),
+	}
+}

--- a/pkg/observability/metrics/regional_gateway.go
+++ b/pkg/observability/metrics/regional_gateway.go
@@ -1,0 +1,30 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// RegionalGatewayMetrics holds Prometheus metrics for regional-gateway routing decisions.
+type RegionalGatewayMetrics struct {
+	SandboxRouteTotal *prometheus.CounterVec
+	FallbacksTotal    *prometheus.CounterVec
+}
+
+func NewRegionalGateway(registry prometheus.Registerer) *RegionalGatewayMetrics {
+	if registry == nil {
+		return nil
+	}
+
+	factory := promauto.With(registry)
+	return &RegionalGatewayMetrics{
+		SandboxRouteTotal: factory.NewCounterVec(prometheus.CounterOpts{
+			Name: "regional_gateway_sandbox_route_total",
+			Help: "Total number of sandbox routing decisions",
+		}, []string{"target", "mode"}),
+		FallbacksTotal: factory.NewCounterVec(prometheus.CounterOpts{
+			Name: "regional_gateway_fallback_total",
+			Help: "Total number of regional-gateway routing fallbacks",
+		}, []string{"from", "to", "reason"}),
+	}
+}

--- a/pkg/observability/metrics/scheduler.go
+++ b/pkg/observability/metrics/scheduler.go
@@ -17,6 +17,8 @@ type SchedulerMetrics struct {
 	LastReconcileTimestamp prometheus.Gauge
 	CapacityClamps         *prometheus.CounterVec
 	RoutingDecisions       *prometheus.CounterVec
+	TemplateIdleEvents     *prometheus.CounterVec
+	TemplateIdleRestarts   prometheus.Counter
 }
 
 // NewScheduler registers and returns scheduler metrics.
@@ -97,6 +99,19 @@ func NewScheduler(registry prometheus.Registerer) *SchedulerMetrics {
 				Help: "Total number of scheduler shard routing decisions by reason",
 			},
 			[]string{"cluster_id", "reason"},
+		),
+		TemplateIdleEvents: factory.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "scheduler_template_idle_events_total",
+				Help: "Total number of scheduler template idle listener events",
+			},
+			[]string{"status"},
+		),
+		TemplateIdleRestarts: factory.NewCounter(
+			prometheus.CounterOpts{
+				Name: "scheduler_template_idle_listener_restarts_total",
+				Help: "Total number of scheduler template idle listener restarts",
+			},
 		),
 	}
 }

--- a/pkg/observability/provider.go
+++ b/pkg/observability/provider.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/propagation"
@@ -38,6 +40,7 @@ type Provider struct {
 
 	// MetricsRegistry is the Prometheus metrics registry
 	MetricsRegistry prometheus.Registerer
+	metricsGatherer prometheus.Gatherer
 
 	// Client-specific adapters
 	HTTP httpobs.Adapter
@@ -57,6 +60,7 @@ func New(cfg Config) (*Provider, error) {
 		config:          cfg,
 		logger:          cfg.Logger,
 		MetricsRegistry: cfg.MetricsRegistry,
+		metricsGatherer: cfg.MetricsGatherer,
 	}
 
 	// Initialize tracing if not disabled
@@ -138,6 +142,25 @@ func (p *Provider) MetricsRegistryOrNil() prometheus.Registerer {
 		return nil
 	}
 	return p.MetricsRegistry
+}
+
+// MetricsGathererOrNil returns the Prometheus gatherer when metrics are enabled.
+func (p *Provider) MetricsGathererOrNil() prometheus.Gatherer {
+	if p == nil || p.config.DisableMetrics {
+		return nil
+	}
+	return p.metricsGatherer
+}
+
+// MetricsHandler returns an HTTP handler for scraping the provider's registry.
+func (p *Provider) MetricsHandler() http.Handler {
+	gatherer := prometheus.Gatherer(prometheus.DefaultGatherer)
+	if p != nil {
+		if configured := p.MetricsGathererOrNil(); configured != nil {
+			gatherer = configured
+		}
+	}
+	return promhttp.HandlerFor(gatherer, promhttp.HandlerOpts{})
 }
 
 // initTracing initializes OpenTelemetry tracing with the configured exporter

--- a/regional-gateway/pkg/http/sandbox_proxy.go
+++ b/regional-gateway/pkg/http/sandbox_proxy.go
@@ -14,6 +14,9 @@ import (
 
 func (s *Server) proxySandbox(c *gin.Context) {
 	if s.schedulerRouter == nil {
+		if s.metrics != nil {
+			s.metrics.SandboxRouteTotal.WithLabelValues("cluster-gateway", "default").Inc()
+		}
 		s.proxyToDefaultClusterGateway(c)
 		return
 	}
@@ -38,6 +41,10 @@ func (s *Server) proxySandbox(c *gin.Context) {
 
 	targetURL, err := s.getClusterGatewayURLForCluster(c.Request.Context(), parsed.ClusterID, authCtx)
 	if err != nil || targetURL == "" {
+		if s.metrics != nil {
+			s.metrics.FallbacksTotal.WithLabelValues("cluster-gateway", "scheduler", "resolve_cluster").Inc()
+			s.metrics.SandboxRouteTotal.WithLabelValues("scheduler", "fallback").Inc()
+		}
 		s.logger.Warn("Failed to resolve sandbox cluster, falling back to scheduler",
 			zap.String("sandbox_id", sandboxID),
 			zap.String("cluster_id", parsed.ClusterID),
@@ -49,6 +56,10 @@ func (s *Server) proxySandbox(c *gin.Context) {
 
 	router, err := s.getClusterGatewayProxy(targetURL)
 	if err != nil {
+		if s.metrics != nil {
+			s.metrics.FallbacksTotal.WithLabelValues("cluster-gateway", "scheduler", "build_proxy").Inc()
+			s.metrics.SandboxRouteTotal.WithLabelValues("scheduler", "fallback").Inc()
+		}
 		s.logger.Warn("Failed to create cluster-gateway proxy, falling back to scheduler",
 			zap.String("sandbox_id", sandboxID),
 			zap.String("cluster_id", parsed.ClusterID),
@@ -60,6 +71,9 @@ func (s *Server) proxySandbox(c *gin.Context) {
 	}
 
 	token, err := s.generateInternalToken(authCtx, "cluster-gateway")
+	if s.metrics != nil {
+		s.metrics.SandboxRouteTotal.WithLabelValues("cluster-gateway", "direct").Inc()
+	}
 	if err != nil {
 		s.logger.Error("Failed to generate internal token for cluster-gateway", zap.Error(err))
 		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "internal authentication failed")
@@ -93,6 +107,9 @@ func (s *Server) proxyToDefaultClusterGateway(c *gin.Context) {
 	if authCtx == nil {
 		spec.JSONError(c, http.StatusUnauthorized, spec.CodeUnauthorized, "missing authentication")
 		return
+	}
+	if s.metrics != nil {
+		s.metrics.SandboxRouteTotal.WithLabelValues("cluster-gateway", "single_cluster").Inc()
 	}
 
 	token, err := s.generateInternalToken(authCtx, "cluster-gateway")

--- a/regional-gateway/pkg/http/server.go
+++ b/regional-gateway/pkg/http/server.go
@@ -118,7 +118,8 @@ func NewServer(
 
 	// Create observable HTTP client for proxy
 	httpClient := obsProvider.HTTP.NewClient(httpobs.Config{
-		Timeout: cfg.ProxyTimeout.Duration,
+		Timeout:       cfg.ProxyTimeout.Duration,
+		BaseTransport: httpobs.InternalServiceTransport(),
 	})
 
 	// Create proxy router to cluster-gateway

--- a/regional-gateway/pkg/http/server.go
+++ b/regional-gateway/pkg/http/server.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	internalmiddleware "github.com/sandbox0-ai/sandbox0/cluster-gateway/pkg/middleware"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
 	registryprovider "github.com/sandbox0-ai/sandbox0/manager/pkg/registry"
@@ -28,6 +27,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/metering"
 	"github.com/sandbox0-ai/sandbox0/pkg/observability"
 	httpobs "github.com/sandbox0-ai/sandbox0/pkg/observability/http"
+	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
 	"github.com/sandbox0-ai/sandbox0/pkg/proxy"
 	"go.uber.org/zap"
 )
@@ -46,6 +46,7 @@ type Server struct {
 	rateLimiter          *middleware.RateLimiter
 	requestLogger        *middleware.RequestLogger
 	logger               *zap.Logger
+	metrics              *obsmetrics.RegionalGatewayMetrics
 	internalAuthGen      *internalauth.Generator
 	meteringHandler      *gatewayhandlers.MeteringHandler
 	obsProvider          *observability.Provider
@@ -234,6 +235,7 @@ func NewServer(
 		rateLimiter:           rateLimiter,
 		requestLogger:         requestLogger,
 		logger:                logger,
+		metrics:               obsmetrics.NewRegionalGateway(obsProvider.MetricsRegistryOrNil()),
 		internalAuthGen:       internalAuthGen,
 		meteringHandler:       gatewayhandlers.NewMeteringHandler(meteringRepo, cfg.RegionID, logger),
 		obsProvider:           obsProvider,
@@ -257,7 +259,9 @@ func NewServer(
 func (s *Server) setupRoutes() {
 	// Global middleware (order matters)
 	s.router.Use(httpobs.GinMiddleware(httpobs.ServerConfig{
-		Tracer: s.obsProvider.Tracer(),
+		ServiceName: "regional-gateway",
+		Tracer:      s.obsProvider.Tracer(),
+		Registry:    s.obsProvider.MetricsRegistryOrNil(),
 	}))
 	s.router.Use(middleware.Recovery(s.logger))
 	s.router.Use(s.requestLogger.Logger())
@@ -268,7 +272,7 @@ func (s *Server) setupRoutes() {
 	s.router.GET("/metadata", gatewayhandlers.GatewayMetadata("regional-gateway", gatewayhandlers.GatewayModeDirect))
 
 	// Metrics endpoint
-	s.router.GET("/metrics", gin.WrapH(promhttp.Handler()))
+	s.router.GET("/metrics", gin.WrapH(s.obsProvider.MetricsHandler()))
 
 	s.setupPublicRoutes()
 	s.setupMeteringRoutes()

--- a/scheduler/cmd/scheduler/main.go
+++ b/scheduler/cmd/scheduler/main.go
@@ -140,7 +140,7 @@ func main() {
 
 	// Start template idle listener
 	if cfg.DatabaseURL != "" {
-		schedpubsub.StartTemplateIdleListener(ctx, cfg.DatabaseURL, logger, func(event pubsub.TemplateIdleEvent) {
+		schedpubsub.StartTemplateIdleListener(ctx, cfg.DatabaseURL, logger, obsProvider.Tracer(), schedulerMetrics, func(event pubsub.TemplateIdleEvent) {
 			logger.Info("Received template idle event",
 				zap.String("cluster_id", event.ClusterID),
 				zap.String("template_id", event.TemplateID),

--- a/scheduler/pkg/client/cluster_gateway.go
+++ b/scheduler/pkg/client/cluster_gateway.go
@@ -27,7 +27,8 @@ type ClusterGatewayClient struct {
 // NewClusterGatewayClient creates a new cluster-gateway client
 func NewClusterGatewayClient(internalAuthGen *internalauth.Generator, logger *zap.Logger, obsProvider *observability.Provider) *ClusterGatewayClient {
 	httpClient := obsProvider.HTTP.NewClient(httpobs.Config{
-		Timeout: 30 * time.Second,
+		Timeout:       30 * time.Second,
+		BaseTransport: httpobs.InternalServiceTransport(),
 	})
 
 	return &ClusterGatewayClient{

--- a/scheduler/pkg/http/server.go
+++ b/scheduler/pkg/http/server.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
@@ -97,7 +96,9 @@ func NewServer(
 	// Create router
 	router := gin.New()
 	router.Use(httpobs.GinMiddleware(httpobs.ServerConfig{
-		Tracer: obsProvider.Tracer(),
+		ServiceName: "scheduler",
+		Tracer:      obsProvider.Tracer(),
+		Registry:    obsProvider.MetricsRegistryOrNil(),
 	}))
 	router.Use(gin.Recovery())
 	router.Use(requestLogger(logger))
@@ -155,7 +156,7 @@ func (s *Server) setupRoutes() {
 	s.router.GET("/readyz", s.readinessCheck)
 
 	// Metrics endpoint
-	s.router.GET("/metrics", gin.WrapH(promhttp.Handler()))
+	s.router.GET("/metrics", gin.WrapH(s.obsProvider.MetricsHandler()))
 
 	// API v1 routes
 	v1 := s.router.Group("/api/v1")

--- a/scheduler/pkg/pubsub/template_idle_listener.go
+++ b/scheduler/pkg/pubsub/template_idle_listener.go
@@ -7,7 +7,10 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
 	"github.com/sandbox0-ai/sandbox0/pkg/pubsub"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 )
 
@@ -15,7 +18,7 @@ import (
 type TemplateIdleHandler func(event pubsub.TemplateIdleEvent)
 
 // StartTemplateIdleListener starts a LISTEN loop for template idle events.
-func StartTemplateIdleListener(ctx context.Context, databaseURL string, logger *zap.Logger, handler TemplateIdleHandler) {
+func StartTemplateIdleListener(ctx context.Context, databaseURL string, logger *zap.Logger, tracer trace.Tracer, metrics *obsmetrics.SchedulerMetrics, handler TemplateIdleHandler) {
 	go func() {
 		backoff := time.Second
 		for {
@@ -23,7 +26,11 @@ func StartTemplateIdleListener(ctx context.Context, databaseURL string, logger *
 				return
 			}
 
-			if err := listenOnce(ctx, databaseURL, logger, handler); err != nil {
+			if err := listenOnce(ctx, databaseURL, logger, tracer, metrics, handler); err != nil {
+				if metrics != nil {
+					metrics.TemplateIdleRestarts.Inc()
+					metrics.TemplateIdleEvents.WithLabelValues("listener_error").Inc()
+				}
 				logger.Warn("Template idle listener stopped, retrying",
 					zap.Error(err),
 					zap.Duration("backoff", backoff),
@@ -45,16 +52,23 @@ func StartTemplateIdleListener(ctx context.Context, databaseURL string, logger *
 	}()
 }
 
-func listenOnce(ctx context.Context, databaseURL string, logger *zap.Logger, handler TemplateIdleHandler) error {
-	conn, err := pgx.Connect(ctx, databaseURL)
+func listenOnce(ctx context.Context, databaseURL string, logger *zap.Logger, tracer trace.Tracer, metrics *obsmetrics.SchedulerMetrics, handler TemplateIdleHandler) error {
+	listenCtx := ctx
+	var span trace.Span
+	if tracer != nil {
+		listenCtx, span = tracer.Start(ctx, "scheduler.template_idle_listener")
+		defer span.End()
+	}
+
+	conn, err := pgx.Connect(listenCtx, databaseURL)
 	if err != nil {
 		return fmt.Errorf("connect: %w", err)
 	}
 	defer func() {
-		_ = conn.Close(ctx)
+		_ = conn.Close(listenCtx)
 	}()
 
-	_, err = conn.Exec(ctx, "LISTEN "+pubsub.TemplateIdleChannel)
+	_, err = conn.Exec(listenCtx, "LISTEN "+pubsub.TemplateIdleChannel)
 	if err != nil {
 		return fmt.Errorf("listen: %w", err)
 	}
@@ -62,21 +76,27 @@ func listenOnce(ctx context.Context, databaseURL string, logger *zap.Logger, han
 	logger.Info("Template idle listener started")
 
 	for {
-		notification, err := conn.WaitForNotification(ctx)
+		notification, err := conn.WaitForNotification(listenCtx)
 		if err != nil {
-			if ctx.Err() != nil {
-				return ctx.Err()
+			if listenCtx.Err() != nil {
+				return listenCtx.Err()
 			}
 			return fmt.Errorf("wait for notification: %w", err)
 		}
 
 		var event pubsub.TemplateIdleEvent
 		if err := json.Unmarshal([]byte(notification.Payload), &event); err != nil {
+			if metrics != nil {
+				metrics.TemplateIdleEvents.WithLabelValues("decode_error").Inc()
+			}
 			logger.Warn("Failed to decode template idle event", zap.Error(err))
 			continue
 		}
 
 		if event.ClusterID == "" || event.TemplateID == "" {
+			if metrics != nil {
+				metrics.TemplateIdleEvents.WithLabelValues("invalid").Inc()
+			}
 			logger.Warn("Invalid template idle event payload",
 				zap.String("cluster_id", event.ClusterID),
 				zap.String("template_id", event.TemplateID),
@@ -84,6 +104,20 @@ func listenOnce(ctx context.Context, databaseURL string, logger *zap.Logger, han
 			continue
 		}
 
+		if metrics != nil {
+			metrics.TemplateIdleEvents.WithLabelValues("success").Inc()
+		}
+		if tracer != nil {
+			_, eventSpan := tracer.Start(listenCtx, "scheduler.template_idle_event",
+				trace.WithAttributes(
+					attribute.String("cluster_id", event.ClusterID),
+					attribute.String("template_id", event.TemplateID),
+					attribute.Int("idle_count", int(event.IdleCount)),
+					attribute.Int("active_count", int(event.ActiveCount)),
+				),
+			)
+			eventSpan.End()
+		}
 		if handler != nil {
 			handler(event)
 		}

--- a/storage-proxy/cmd/storage-proxy/main.go
+++ b/storage-proxy/cmd/storage-proxy/main.go
@@ -303,15 +303,17 @@ func main() {
 	})
 
 	authenticator := auth.NewGRPCAuthenticator(validator, zapLogger)
+	authenticator.SetMetrics(storageProxyMetrics)
 	grpcInterceptor = authenticator.UnaryInterceptor()
 
 	httpAuthenticator = auth.NewHTTPAuthenticator(validator, zapLogger)
+	httpAuthenticator.SetMetrics(storageProxyMetrics)
 
 	zapLogger.Info("Using internalauth validator for gRPC and HTTP authentication")
 
 	// Create gRPC server
 	grpcServer := grpc.NewServer(
-		grpc.UnaryInterceptor(grpcInterceptor),
+		grpc.ChainUnaryInterceptor(grpcInterceptor, grpcserver.UnaryMetricsInterceptor(storageProxyMetrics)),
 	)
 
 	// Register FileSystem service
@@ -359,7 +361,7 @@ func main() {
 	}
 
 	// Create HTTP server
-	httpSrv := httpserver.NewServer(logrusLogger, cfg, k8sClient, repo, meteringRepo, cfg.RegionID, httpAuthenticator, snapshotMgr, syncSvc, volumeBarrier, volMgr, fsServer, eventHub)
+	httpSrv := httpserver.NewServer(logrusLogger, cfg, k8sClient, repo, meteringRepo, cfg.RegionID, httpAuthenticator, snapshotMgr, syncSvc, volumeBarrier, volMgr, fsServer, eventHub, obsProvider, storageProxyMetrics)
 	httpAddr := fmt.Sprintf("%s:%d", cfg.HTTPAddr, cfg.HTTPPort)
 
 	readTimeout, _ := time.ParseDuration(cfg.HTTPReadTimeout)

--- a/storage-proxy/pkg/auth/interceptor.go
+++ b/storage-proxy/pkg/auth/interceptor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -15,6 +16,7 @@ import (
 type GRPCAuthenticator struct {
 	validator *internalauth.Validator
 	logger    *zap.Logger
+	metrics   *obsmetrics.StorageProxyMetrics
 }
 
 // NewGRPCAuthenticator creates a new gRPC authenticator.
@@ -23,6 +25,13 @@ func NewGRPCAuthenticator(validator *internalauth.Validator, logger *zap.Logger)
 		validator: validator,
 		logger:    logger,
 	}
+}
+
+func (a *GRPCAuthenticator) SetMetrics(metrics *obsmetrics.StorageProxyMetrics) {
+	if a == nil {
+		return
+	}
+	a.metrics = metrics
 }
 
 // UnaryInterceptor returns a gRPC unary interceptor for authentication.
@@ -47,6 +56,7 @@ func (a *GRPCAuthenticator) UnaryInterceptor() grpc.UnaryServerInterceptor {
 			)
 			return nil, status.Error(codes.Unauthenticated, err.Error())
 		}
+		a.recordAuth("grpc", "", true)
 
 		// Add claims to context for downstream handlers
 		ctx = internalauth.WithClaims(ctx, claims)
@@ -66,6 +76,7 @@ func (a *GRPCAuthenticator) authenticate(ctx context.Context) (*internalauth.Cla
 	// Extract metadata from context
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
+		a.recordAuth("grpc", "missing_metadata", false)
 		return nil, status.Error(codes.Unauthenticated, "missing metadata")
 	}
 
@@ -75,12 +86,14 @@ func (a *GRPCAuthenticator) authenticate(ctx context.Context) (*internalauth.Cla
 		tokenString = tokenHeaders[0]
 	}
 	if tokenString == "" {
+		a.recordAuth("grpc", "missing_token", false)
 		return nil, status.Error(codes.Unauthenticated, "missing authentication token")
 	}
 
 	// Validate token using internalauth
 	claims, err := a.validator.Validate(tokenString)
 	if err != nil {
+		a.recordAuth("grpc", "invalid_token", false)
 		return nil, status.Errorf(codes.Unauthenticated, "invalid token: %v", err)
 	}
 
@@ -104,8 +117,10 @@ func (a *GRPCAuthenticator) StreamInterceptor() grpc.StreamServerInterceptor {
 		// Extract and validate token
 		claims, err := a.authenticate(ss.Context())
 		if err != nil {
+			a.recordAuth("grpc_stream", "invalid_token", false)
 			return status.Error(codes.Unauthenticated, err.Error())
 		}
+		a.recordAuth("grpc_stream", "", true)
 
 		a.logger.Info("Stream request authenticated",
 			zap.String("method", info.FullMethod),
@@ -132,4 +147,16 @@ type authenticatedStream struct {
 // Context returns the authenticated context.
 func (s *authenticatedStream) Context() context.Context {
 	return s.ctx
+}
+
+func (a *GRPCAuthenticator) recordAuth(protocol, errorType string, success bool) {
+	if a == nil || a.metrics == nil {
+		return
+	}
+	status := "success"
+	if !success {
+		status = "error"
+		a.metrics.AuthenticationErrors.WithLabelValues(errorType).Inc()
+	}
+	a.metrics.AuthenticationTotal.WithLabelValues(protocol, status).Inc()
 }

--- a/storage-proxy/pkg/auth/middleware.go
+++ b/storage-proxy/pkg/auth/middleware.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
 	"go.uber.org/zap"
 )
 
@@ -11,6 +12,7 @@ import (
 type HTTPAuthenticator struct {
 	validator *internalauth.Validator
 	logger    *zap.Logger
+	metrics   *obsmetrics.StorageProxyMetrics
 }
 
 // NewHTTPAuthenticator creates a new HTTP authenticator.
@@ -19,6 +21,13 @@ func NewHTTPAuthenticator(validator *internalauth.Validator, logger *zap.Logger)
 		validator: validator,
 		logger:    logger,
 	}
+}
+
+func (a *HTTPAuthenticator) SetMetrics(metrics *obsmetrics.StorageProxyMetrics) {
+	if a == nil {
+		return
+	}
+	a.metrics = metrics
 }
 
 // Middleware returns an HTTP middleware for authentication.
@@ -32,6 +41,7 @@ func (a *HTTPAuthenticator) Middleware(next http.Handler) http.Handler {
 		}
 
 		if tokenString == "" {
+			a.recordAuth("http", "missing_token", false)
 			http.Error(w, "missing authentication token", http.StatusUnauthorized)
 			return
 		}
@@ -39,6 +49,7 @@ func (a *HTTPAuthenticator) Middleware(next http.Handler) http.Handler {
 		// Validate token
 		claims, err := a.validator.Validate(tokenString)
 		if err != nil {
+			a.recordAuth("http", "invalid_token", false)
 			a.logger.Warn("Authentication failed",
 				zap.String("method", r.Method),
 				zap.String("path", r.URL.Path),
@@ -47,6 +58,7 @@ func (a *HTTPAuthenticator) Middleware(next http.Handler) http.Handler {
 			http.Error(w, "invalid token", http.StatusUnauthorized)
 			return
 		}
+		a.recordAuth("http", "", true)
 
 		// Add claims to context
 		ctx := internalauth.WithClaims(r.Context(), claims)
@@ -60,6 +72,18 @@ func (a *HTTPAuthenticator) Middleware(next http.Handler) http.Handler {
 
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
+}
+
+func (a *HTTPAuthenticator) recordAuth(protocol, errorType string, success bool) {
+	if a == nil || a.metrics == nil {
+		return
+	}
+	status := "success"
+	if !success {
+		status = "error"
+		a.metrics.AuthenticationErrors.WithLabelValues(errorType).Inc()
+	}
+	a.metrics.AuthenticationTotal.WithLabelValues(protocol, status).Inc()
 }
 
 // HealthCheckMiddleware allows health check endpoints without authentication

--- a/storage-proxy/pkg/grpc/metrics.go
+++ b/storage-proxy/pkg/grpc/metrics.go
@@ -1,0 +1,25 @@
+package grpc
+
+import (
+	"context"
+	"time"
+
+	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/status"
+)
+
+// UnaryMetricsInterceptor records request count and latency for storage-proxy gRPC methods.
+func UnaryMetricsInterceptor(metrics *obsmetrics.StorageProxyMetrics) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		if metrics == nil {
+			return handler(ctx, req)
+		}
+
+		start := time.Now()
+		resp, err := handler(ctx, req)
+		metrics.GRPCRequestsTotal.WithLabelValues(info.FullMethod, status.Code(err).String()).Inc()
+		metrics.GRPCRequestDuration.WithLabelValues(info.FullMethod).Observe(time.Since(start).Seconds())
+		return resp, err
+	}
+}

--- a/storage-proxy/pkg/http/server.go
+++ b/storage-proxy/pkg/http/server.go
@@ -124,7 +124,19 @@ type Server struct {
 }
 
 // NewServer creates a new HTTP server
-func NewServer(logger *logrus.Logger, cfg *config.StorageProxyConfig, k8sClient kubernetes.Interface, repo volumeRepository, meteringRepo meteringWriter, regionID string, authenticator *auth.HTTPAuthenticator, snapshotMgr snapshotManager, syncMgr syncManager, barrier volumeMutationBarrier, volMgr volumeMountManager, fileRPC volumeFileRPC, eventHub *notify.Hub, obsProvider *observability.Provider, metrics *obsmetrics.StorageProxyMetrics) *Server {
+func NewServer(logger *logrus.Logger, cfg *config.StorageProxyConfig, k8sClient kubernetes.Interface, repo volumeRepository, meteringRepo meteringWriter, regionID string, authenticator *auth.HTTPAuthenticator, snapshotMgr snapshotManager, syncMgr syncManager, barrier volumeMutationBarrier, volMgr volumeMountManager, fileRPC volumeFileRPC, eventHub *notify.Hub, opts ...any) *Server {
+	var obsProvider *observability.Provider
+	var metrics *obsmetrics.StorageProxyMetrics
+	if len(opts) > 0 {
+		if provider, ok := opts[0].(*observability.Provider); ok {
+			obsProvider = provider
+		}
+	}
+	if len(opts) > 1 {
+		if storageMetrics, ok := opts[1].(*obsmetrics.StorageProxyMetrics); ok {
+			metrics = storageMetrics
+		}
+	}
 	selfPodID, err := os.Hostname()
 	if err != nil {
 		selfPodID = ""

--- a/storage-proxy/pkg/http/server.go
+++ b/storage-proxy/pkg/http/server.go
@@ -14,6 +14,8 @@ import (
 	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	meteringpkg "github.com/sandbox0-ai/sandbox0/pkg/metering"
+	"github.com/sandbox0-ai/sandbox0/pkg/observability"
+	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/auth"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/notify"
@@ -117,10 +119,12 @@ type Server struct {
 	podResolver   volumeFilePodResolver
 	selfPodID     string
 	selfClusterID string
+	obsProvider   *observability.Provider
+	metrics       *obsmetrics.StorageProxyMetrics
 }
 
 // NewServer creates a new HTTP server
-func NewServer(logger *logrus.Logger, cfg *config.StorageProxyConfig, k8sClient kubernetes.Interface, repo volumeRepository, meteringRepo meteringWriter, regionID string, authenticator *auth.HTTPAuthenticator, snapshotMgr snapshotManager, syncMgr syncManager, barrier volumeMutationBarrier, volMgr volumeMountManager, fileRPC volumeFileRPC, eventHub *notify.Hub) *Server {
+func NewServer(logger *logrus.Logger, cfg *config.StorageProxyConfig, k8sClient kubernetes.Interface, repo volumeRepository, meteringRepo meteringWriter, regionID string, authenticator *auth.HTTPAuthenticator, snapshotMgr snapshotManager, syncMgr syncManager, barrier volumeMutationBarrier, volMgr volumeMountManager, fileRPC volumeFileRPC, eventHub *notify.Hub, obsProvider *observability.Provider, metrics *obsmetrics.StorageProxyMetrics) *Server {
 	selfPodID, err := os.Hostname()
 	if err != nil {
 		selfPodID = ""
@@ -142,6 +146,8 @@ func NewServer(logger *logrus.Logger, cfg *config.StorageProxyConfig, k8sClient 
 		eventHub:      eventHub,
 		podResolver:   newKubernetesVolumeFilePodResolver(logger, k8sClient, cfg),
 		selfPodID:     selfPodID,
+		obsProvider:   obsProvider,
+		metrics:       metrics,
 	}
 	if cfg != nil {
 		s.selfClusterID = cfg.DefaultClusterId
@@ -150,7 +156,11 @@ func NewServer(logger *logrus.Logger, cfg *config.StorageProxyConfig, k8sClient 
 	// Register handlers
 	s.mux.HandleFunc("/healthz", s.handleHealth)
 	s.mux.HandleFunc("/readyz", s.handleReady)
-	s.mux.Handle("/metrics", promhttp.Handler())
+	if obsProvider != nil {
+		s.mux.Handle("/metrics", obsProvider.MetricsHandler())
+	} else {
+		s.mux.Handle("/metrics", promhttp.Handler())
+	}
 
 	// Sandbox Volume handlers
 	s.mux.HandleFunc("POST /sandboxvolumes", s.createSandboxVolume)
@@ -208,6 +218,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		"duration": time.Since(start),
 		"remote":   r.RemoteAddr,
 	}
+	if s.metrics != nil {
+		s.metrics.HTTPRequestsTotal.WithLabelValues(r.Method, r.URL.Path, statusLabel(wrapped.statusCode)).Inc()
+		s.metrics.HTTPRequestDuration.WithLabelValues(r.Method, r.URL.Path).Observe(time.Since(start).Seconds())
+		if r.ContentLength > 0 {
+			s.metrics.HTTPRequestSize.WithLabelValues(r.Method, r.URL.Path).Observe(float64(r.ContentLength))
+		}
+		if wrapped.bytesWritten > 0 {
+			s.metrics.HTTPResponseSize.WithLabelValues(r.Method, r.URL.Path).Observe(float64(wrapped.bytesWritten))
+		}
+	}
 
 	spanCtx := trace.SpanFromContext(r.Context()).SpanContext()
 	if spanCtx.IsValid() {
@@ -228,12 +248,19 @@ func (s *Server) serve(w http.ResponseWriter, r *http.Request) {
 
 type responseWriter struct {
 	http.ResponseWriter
-	statusCode int
+	statusCode   int
+	bytesWritten int
 }
 
 func (rw *responseWriter) WriteHeader(code int) {
 	rw.statusCode = code
 	rw.ResponseWriter.WriteHeader(code)
+}
+
+func (rw *responseWriter) Write(data []byte) (int, error) {
+	n, err := rw.ResponseWriter.Write(data)
+	rw.bytesWritten += n
+	return n, err
 }
 
 func (rw *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
@@ -255,6 +282,13 @@ func (rw *responseWriter) Push(target string, opts *http.PushOptions) error {
 		return pusher.Push(target, opts)
 	}
 	return http.ErrNotSupported
+}
+
+func statusLabel(code int) string {
+	if code == 0 {
+		return "unknown"
+	}
+	return http.StatusText(code)
 }
 
 // handleHealth handles health check requests


### PR DESCRIPTION
## Summary
- unify provider-backed metrics handling across gateway and control-plane HTTP servers
- add business-level observability for procd context, volume, initialize, and cleanup flows plus manager pause/resume and cleanup loops
- instrument scheduler template-idle listener, regional-gateway sandbox routing fallbacks, storage-proxy HTTP/gRPC/auth paths, and fill gaps in ctld/netd metrics

## Testing
- `go test ./pkg/observability/... -count=1`
- `go test ./manager/pkg/controller ./manager/pkg/service ./scheduler/pkg/pubsub ./regional-gateway/pkg/http ./scheduler/cmd/scheduler -count=1`
- `go test ./storage-proxy/pkg/auth -count=1`
- `go test ./manager/procd/pkg/http/handlers -run Test -count=1`
- pre-push checks passed: `make manifests`, `make proto`, `make apispec`, `go fmt ./...`, `go mod tidy`, `go mod vendor`, `golangci-lint run ./...`
- `go test ./manager/cmd/procd ./manager/procd/pkg/http/... ./manager/procd/pkg/context ./manager/procd/pkg/volume -count=1` still fails in the current repo when `github.com/sandbox0-ai/sandbox0/storage-proxy/proto/fs` is unavailable before protobuf generation
- `go test ./storage-proxy/pkg/http ./storage-proxy/cmd/storage-proxy -count=1` has the same protobuf-generation dependency in this repo state