### PR TITLE
fix: restore gcp regional gateway routing

### DIFF
--- a/infra-operator/internal/controller/pkg/common/common.go
+++ b/infra-operator/internal/controller/pkg/common/common.go
@@ -343,14 +343,8 @@ func (r *ResourceManager) ReconcileServicePorts(ctx context.Context, infra *infr
 		return fmt.Errorf("service %q requires at least one port", name)
 	}
 
-	svc := &corev1.Service{}
-	err := r.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: infra.Namespace}, svc)
-	if err != nil && !errors.IsNotFound(err) {
-		return err
-	}
-
 	desiredLabels := EnsureManagedLabels(labels, name)
-	desiredSvc := &corev1.Service{
+	desiredSvc := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
 			Namespace:   infra.Namespace,
@@ -364,18 +358,25 @@ func (r *ResourceManager) ReconcileServicePorts(ctx context.Context, infra *infr
 		},
 	}
 
-	if err := ctrl.SetControllerReference(infra, desiredSvc, r.Scheme); err != nil {
+	if err := ctrl.SetControllerReference(infra, &desiredSvc, r.Scheme); err != nil {
 		return err
 	}
 
-	if errors.IsNotFound(err) {
-		return r.Client.Create(ctx, desiredSvc)
-	}
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		svc := &corev1.Service{}
+		err := r.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: infra.Namespace}, svc)
+		if errors.IsNotFound(err) {
+			return r.Client.Create(ctx, desiredSvc.DeepCopy())
+		}
+		if err != nil {
+			return err
+		}
 
-	svc.Spec = desiredSvc.Spec
-	svc.Labels = desiredLabels
-	svc.Annotations = CloneStringMap(annotations)
-	return r.Client.Update(ctx, svc)
+		svc.Spec = desiredSvc.Spec
+		svc.Labels = desiredLabels
+		svc.Annotations = CloneStringMap(annotations)
+		return r.Client.Update(ctx, svc)
+	})
 }
 
 // BuildServicePort returns a ServicePort with a target port.

--- a/infra-operator/internal/controller/pkg/common/common.go
+++ b/infra-operator/internal/controller/pkg/common/common.go
@@ -339,11 +339,27 @@ func (r *ResourceManager) ReconcileService(ctx context.Context, infra *infrav1al
 
 // ReconcileServicePorts creates or updates a service with multiple ports.
 func (r *ResourceManager) ReconcileServicePorts(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, name string, labels map[string]string, serviceType corev1.ServiceType, annotations map[string]string, ports []corev1.ServicePort) error {
+	return r.reconcileServicePorts(ctx, infra, name, labels, serviceType, annotations, ports, nil)
+}
+
+func (r *ResourceManager) ReconcileServicePortsWithSpecMutator(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, name string, labels map[string]string, serviceType corev1.ServiceType, annotations map[string]string, ports []corev1.ServicePort, mutate func(*corev1.ServiceSpec)) error {
+	return r.reconcileServicePorts(ctx, infra, name, labels, serviceType, annotations, ports, mutate)
+}
+
+func (r *ResourceManager) reconcileServicePorts(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, name string, labels map[string]string, serviceType corev1.ServiceType, annotations map[string]string, ports []corev1.ServicePort, mutate func(*corev1.ServiceSpec)) error {
 	if len(ports) == 0 {
 		return fmt.Errorf("service %q requires at least one port", name)
 	}
 
 	desiredLabels := EnsureManagedLabels(labels, name)
+	desiredSpec := corev1.ServiceSpec{
+		Type:     serviceType,
+		Selector: labels,
+		Ports:    ports,
+	}
+	if mutate != nil {
+		mutate(&desiredSpec)
+	}
 	desiredSvc := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
@@ -351,11 +367,7 @@ func (r *ResourceManager) ReconcileServicePorts(ctx context.Context, infra *infr
 			Labels:      desiredLabels,
 			Annotations: CloneStringMap(annotations),
 		},
-		Spec: corev1.ServiceSpec{
-			Type:     serviceType,
-			Selector: labels,
-			Ports:    ports,
-		},
+		Spec: desiredSpec,
 	}
 
 	if err := ctrl.SetControllerReference(infra, &desiredSvc, r.Scheme); err != nil {

--- a/infra-operator/internal/controller/services/regionalgateway/regionalgateway.go
+++ b/infra-operator/internal/controller/services/regionalgateway/regionalgateway.go
@@ -27,6 +27,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	apiconfig "github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
@@ -260,15 +261,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 		return err
 	}
 	if serviceType == corev1.ServiceTypeLoadBalancer {
-		service := &corev1.Service{}
-		if err := r.Resources.Client.Get(ctx, types.NamespacedName{Name: serviceName, Namespace: infra.Namespace}, service); err != nil {
-			return err
-		}
-		if service.Spec.ExternalTrafficPolicy != corev1.ServiceExternalTrafficPolicyLocal {
-			service.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyLocal
-			if err := r.Resources.Client.Update(ctx, service); err != nil {
+		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			service := &corev1.Service{}
+			if err := r.Resources.Client.Get(ctx, types.NamespacedName{Name: serviceName, Namespace: infra.Namespace}, service); err != nil {
 				return err
 			}
+			if service.Spec.ExternalTrafficPolicy == corev1.ServiceExternalTrafficPolicyLocal {
+				return nil
+			}
+			service.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyLocal
+			return r.Resources.Client.Update(ctx, service)
+		}); err != nil {
+			return err
 		}
 	}
 

--- a/infra-operator/internal/controller/services/regionalgateway/regionalgateway.go
+++ b/infra-operator/internal/controller/services/regionalgateway/regionalgateway.go
@@ -229,7 +229,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 	serviceType := common.ResolveServiceType(serviceConfig)
 	servicePort := common.ResolveServicePort(serviceConfig, httpPort)
 	serviceAnnotations := common.ResolveServiceAnnotations(serviceConfig)
-	if err := r.Resources.ReconcileService(ctx, infra, serviceName, labels, serviceType, serviceAnnotations, servicePort, httpPort); err != nil {
+	servicePortName := "http"
+	if tlsEnabled {
+		servicePortName = "https"
+	}
+	if err := r.Resources.ReconcileServicePorts(ctx, infra, serviceName, labels, serviceType, serviceAnnotations, []corev1.ServicePort{
+		common.BuildServicePort(servicePortName, servicePort, httpPort, serviceType),
+	}); err != nil {
 		return err
 	}
 

--- a/infra-operator/internal/controller/services/regionalgateway/regionalgateway.go
+++ b/infra-operator/internal/controller/services/regionalgateway/regionalgateway.go
@@ -19,6 +19,7 @@ package regionalgateway
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -31,6 +32,7 @@ import (
 	apiconfig "github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
 	infrav1alpha1 "github.com/sandbox0-ai/sandbox0/infra-operator/api/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/pkg/common"
+	webhookcerts "github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/pkg/webhook"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/database"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/internalauth"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/registry"
@@ -91,6 +93,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 		resources = infra.Spec.Services.RegionalGateway.Resources
 		serviceConfig = infra.Spec.Services.RegionalGateway.Service
 	}
+	tlsEnabled := strings.TrimSpace(config.TLSCertPath) != "" && strings.TrimSpace(config.TLSKeyPath) != ""
 
 	volumeMounts := []corev1.VolumeMount{
 		{
@@ -133,6 +136,38 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 	if needEnterpriseLicense {
 		volumeMounts, volumes = common.AppendEnterpriseLicenseVolume(infra, config.LicenseFile, volumeMounts, volumes)
 	}
+	if tlsEnabled {
+		tlsSecretName := fmt.Sprintf("%s-regional-gateway-tls", infra.Name)
+		dnsNames := regionalGatewayTLSDNSNames(config)
+		if len(dnsNames) == 0 {
+			return fmt.Errorf("regional-gateway TLS enabled but no DNS names were derived")
+		}
+		if err := webhookcerts.NewReconciler(r.Resources).ReconcileCertSecret(ctx, infra, tlsSecretName, labels, dnsNames); err != nil {
+			return err
+		}
+		volumeMounts = append(volumeMounts,
+			corev1.VolumeMount{
+				Name:      "gateway-tls",
+				MountPath: "/tls/tls.crt",
+				SubPath:   corev1.TLSCertKey,
+				ReadOnly:  true,
+			},
+			corev1.VolumeMount{
+				Name:      "gateway-tls",
+				MountPath: "/tls/tls.key",
+				SubPath:   corev1.TLSPrivateKeyKey,
+				ReadOnly:  true,
+			},
+		)
+		volumes = append(volumes, corev1.Volume{
+			Name: "gateway-tls",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: tlsSecretName,
+				},
+			},
+		})
+	}
 
 	envVars := []corev1.EnvVar{
 		{
@@ -166,8 +201,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 		LivenessProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{
-					Path: "/healthz",
-					Port: intstr.FromString("http"),
+					Path:   "/healthz",
+					Port:   intstr.FromString("http"),
+					Scheme: probeSchemeForTLS(tlsEnabled),
 				},
 			},
 			InitialDelaySeconds: 10,
@@ -176,8 +212,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 		ReadinessProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{
-					Path: "/readyz",
-					Port: intstr.FromString("http"),
+					Path:   "/readyz",
+					Port:   intstr.FromString("http"),
+					Scheme: probeSchemeForTLS(tlsEnabled),
 				},
 			},
 			InitialDelaySeconds: 5,
@@ -309,6 +346,12 @@ func (r *Reconciler) buildConfig(ctx context.Context, infra *infrav1alpha1.Sandb
 		cfg.PublicRootDomain = infra.Spec.PublicExposure.RootDomain
 		cfg.PublicRegionID = infra.Spec.PublicExposure.RegionID
 	}
+	if base := strings.TrimSpace(cfg.BaseURL); base != "" {
+		if parsed, err := url.Parse(base); err == nil && strings.EqualFold(parsed.Scheme, "https") {
+			cfg.TLSCertPath = "/tls/tls.crt"
+			cfg.TLSKeyPath = "/tls/tls.key"
+		}
+	}
 
 	registryEnvVars, err := r.applyRegistryConfig(infra, cfg)
 	if err != nil {
@@ -329,6 +372,28 @@ func defaultFederatedGlobalJWTIssuer(infra *infrav1alpha1.Sandbox0Infra) string 
 
 func sharedUserJWTSecretName(infra *infrav1alpha1.Sandbox0Infra) string {
 	return fmt.Sprintf("%s-user-jwt", infra.Name)
+}
+
+func regionalGatewayTLSDNSNames(cfg *apiconfig.RegionalGatewayConfig) []string {
+	if cfg == nil {
+		return nil
+	}
+	base := strings.TrimSpace(cfg.BaseURL)
+	if base == "" {
+		return nil
+	}
+	parsed, err := url.Parse(base)
+	if err != nil || parsed.Hostname() == "" {
+		return nil
+	}
+	return []string{parsed.Hostname()}
+}
+
+func probeSchemeForTLS(enabled bool) corev1.URIScheme {
+	if enabled {
+		return corev1.URISchemeHTTPS
+	}
+	return corev1.URISchemeHTTP
 }
 
 func (r *Reconciler) applyRegistryConfig(infra *infrav1alpha1.Sandbox0Infra, cfg *apiconfig.RegionalGatewayConfig) ([]corev1.EnvVar, error) {

--- a/infra-operator/internal/controller/services/regionalgateway/regionalgateway.go
+++ b/infra-operator/internal/controller/services/regionalgateway/regionalgateway.go
@@ -94,6 +94,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 		serviceConfig = infra.Spec.Services.RegionalGateway.Service
 	}
 	tlsEnabled := strings.TrimSpace(config.TLSCertPath) != "" && strings.TrimSpace(config.TLSKeyPath) != ""
+	containerPortName := "http"
+	if tlsEnabled {
+		containerPortName = "https"
+	}
 
 	volumeMounts := []corev1.VolumeMount{
 		{
@@ -189,7 +193,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 		TargetPort: httpPort,
 		Ports: []corev1.ContainerPort{
 			{
-				Name:          "http",
+				Name:          containerPortName,
 				ContainerPort: httpPort,
 			},
 		},
@@ -202,7 +206,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{
 					Path:   "/healthz",
-					Port:   intstr.FromString("http"),
+					Port:   intstr.FromString(containerPortName),
 					Scheme: probeSchemeForTLS(tlsEnabled),
 				},
 			},
@@ -213,7 +217,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{
 					Path:   "/readyz",
-					Port:   intstr.FromString("http"),
+					Port:   intstr.FromString(containerPortName),
 					Scheme: probeSchemeForTLS(tlsEnabled),
 				},
 			},
@@ -230,11 +234,28 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 	servicePort := common.ResolveServicePort(serviceConfig, httpPort)
 	serviceAnnotations := common.ResolveServiceAnnotations(serviceConfig)
 	servicePortName := "http"
+	serviceTargetPort := intstr.FromInt(int(httpPort))
+	var serviceAppProtocol *string
 	if tlsEnabled {
 		servicePortName = "https"
+		serviceTargetPort = intstr.FromString(containerPortName)
+		appProtocol := "HTTPS"
+		serviceAppProtocol = &appProtocol
 	}
 	if err := r.Resources.ReconcileServicePorts(ctx, infra, serviceName, labels, serviceType, serviceAnnotations, []corev1.ServicePort{
-		common.BuildServicePort(servicePortName, servicePort, httpPort, serviceType),
+		{
+			Name:        servicePortName,
+			Port:        servicePort,
+			TargetPort:  serviceTargetPort,
+			Protocol:    corev1.ProtocolTCP,
+			AppProtocol: serviceAppProtocol,
+			NodePort: func() int32 {
+				if serviceType == corev1.ServiceTypeNodePort {
+					return servicePort
+				}
+				return 0
+			}(),
+		},
 	}); err != nil {
 		return err
 	}

--- a/infra-operator/internal/controller/services/regionalgateway/regionalgateway.go
+++ b/infra-operator/internal/controller/services/regionalgateway/regionalgateway.go
@@ -259,6 +259,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 	}); err != nil {
 		return err
 	}
+	if serviceType == corev1.ServiceTypeLoadBalancer {
+		service := &corev1.Service{}
+		if err := r.Resources.Client.Get(ctx, types.NamespacedName{Name: serviceName, Namespace: infra.Namespace}, service); err != nil {
+			return err
+		}
+		if service.Spec.ExternalTrafficPolicy != corev1.ServiceExternalTrafficPolicyLocal {
+			service.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyLocal
+			if err := r.Resources.Client.Update(ctx, service); err != nil {
+				return err
+			}
+		}
+	}
 
 	// Create ingress if enabled
 	if infra.Spec.Services != nil && infra.Spec.Services.RegionalGateway != nil &&

--- a/infra-operator/internal/controller/services/regionalgateway/regionalgateway.go
+++ b/infra-operator/internal/controller/services/regionalgateway/regionalgateway.go
@@ -27,7 +27,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	apiconfig "github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
@@ -243,7 +242,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 		appProtocol := "HTTPS"
 		serviceAppProtocol = &appProtocol
 	}
-	if err := r.Resources.ReconcileServicePorts(ctx, infra, serviceName, labels, serviceType, serviceAnnotations, []corev1.ServicePort{
+	if err := r.Resources.ReconcileServicePortsWithSpecMutator(ctx, infra, serviceName, labels, serviceType, serviceAnnotations, []corev1.ServicePort{
 		{
 			Name:        servicePortName,
 			Port:        servicePort,
@@ -257,23 +256,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 				return 0
 			}(),
 		},
+	}, func(spec *corev1.ServiceSpec) {
+		if serviceType == corev1.ServiceTypeLoadBalancer {
+			spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyLocal
+		}
 	}); err != nil {
 		return err
-	}
-	if serviceType == corev1.ServiceTypeLoadBalancer {
-		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			service := &corev1.Service{}
-			if err := r.Resources.Client.Get(ctx, types.NamespacedName{Name: serviceName, Namespace: infra.Namespace}, service); err != nil {
-				return err
-			}
-			if service.Spec.ExternalTrafficPolicy == corev1.ServiceExternalTrafficPolicyLocal {
-				return nil
-			}
-			service.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyLocal
-			return r.Resources.Client.Update(ctx, service)
-		}); err != nil {
-			return err
-		}
 	}
 
 	// Create ingress if enabled

--- a/infra-operator/internal/controller/services/regionalgateway/regionalgateway_registry_test.go
+++ b/infra-operator/internal/controller/services/regionalgateway/regionalgateway_registry_test.go
@@ -19,6 +19,117 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+func TestReconcileEnablesTLSForHTTPSBaseURL(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add core scheme: %v", err)
+	}
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add apps scheme: %v", err)
+	}
+	if err := infrav1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add infra scheme: %v", err)
+	}
+
+	infra := &infrav1alpha1.Sandbox0Infra{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "sandbox0-system",
+		},
+		Spec: infrav1alpha1.Sandbox0InfraSpec{
+			Region: "gcp-ue4",
+			Database: &infrav1alpha1.DatabaseConfig{
+				Type: infrav1alpha1.DatabaseTypeExternal,
+				External: &infrav1alpha1.ExternalDatabaseConfig{
+					Host:     "postgres.example.internal",
+					Port:     5432,
+					Database: "sandbox0",
+					Username: "sandbox0",
+					PasswordSecret: infrav1alpha1.SecretKeyRef{
+						Name: "regional-db",
+						Key:  "password",
+					},
+				},
+			},
+			Services: &infrav1alpha1.ServicesConfig{
+				RegionalGateway: &infrav1alpha1.RegionalGatewayServiceConfig{
+					WorkloadServiceConfig: infrav1alpha1.WorkloadServiceConfig{
+						EnabledServiceConfig: infrav1alpha1.EnabledServiceConfig{Enabled: true},
+						Replicas:             1,
+					},
+					ServiceExposureConfig: infrav1alpha1.ServiceExposureConfig{
+						Service: &infrav1alpha1.ServiceNetworkConfig{
+							Type: "LoadBalancer",
+							Port: 443,
+						},
+					},
+					Config: &infrav1alpha1.RegionalGatewayConfig{
+						AuthMode: "federated_global",
+						GatewayConfig: infrav1alpha1.GatewayConfig{
+							BaseURL:         "https://gcp-ue4.sandbox0.ai",
+							JWTIssuer:       "https://api.sandbox0.ai",
+							JWTPublicKeyPEM: "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEA2LS/8P8G8l6hFGxqfQ4WdSx7sY9qsK0kGugHgdGX6lY=\n-----END PUBLIC KEY-----",
+						},
+					},
+				},
+				ClusterGateway: &infrav1alpha1.ClusterGatewayServiceConfig{
+					WorkloadServiceConfig: infrav1alpha1.WorkloadServiceConfig{
+						EnabledServiceConfig: infrav1alpha1.EnabledServiceConfig{Enabled: true},
+					},
+				},
+			},
+			PublicExposure: &infrav1alpha1.PublicExposureConfig{
+				Enabled:    true,
+				RootDomain: "sandbox0.app",
+				RegionID:   "gcp-ue4",
+			},
+		},
+	}
+
+	dbSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "regional-db",
+			Namespace: infra.Namespace,
+		},
+		Data: map[string][]byte{
+			"password": []byte("db-password"),
+		},
+	}
+
+	reconciler, client := newRegionalGatewayTestReconciler(t, infra.DeepCopy(), dbSecret)
+
+	if err := reconciler.Reconcile(context.Background(), infra, "sandbox0ai/infra", "latest", nil); err != nil && !strings.Contains(err.Error(), "not ready") {
+		t.Fatalf("reconcile returned unexpected error: %v", err)
+	}
+
+	secret := &corev1.Secret{}
+	if err := client.Get(context.Background(), types.NamespacedName{Name: "demo-regional-gateway-tls", Namespace: infra.Namespace}, secret); err != nil {
+		t.Fatalf("get tls secret: %v", err)
+	}
+	if secret.Type != corev1.SecretTypeTLS {
+		t.Fatalf("expected tls secret type, got %q", secret.Type)
+	}
+
+	service := &corev1.Service{}
+	if err := client.Get(context.Background(), types.NamespacedName{Name: "demo-regional-gateway", Namespace: infra.Namespace}, service); err != nil {
+		t.Fatalf("get regional gateway service: %v", err)
+	}
+	if service.Spec.Ports[0].Port != 443 {
+		t.Fatalf("expected external service port 443, got %d", service.Spec.Ports[0].Port)
+	}
+
+	deployment := &appsv1.Deployment{}
+	if err := client.Get(context.Background(), types.NamespacedName{Name: "demo-regional-gateway", Namespace: infra.Namespace}, deployment); err != nil {
+		t.Fatalf("get regional gateway deployment: %v", err)
+	}
+	if deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Scheme != corev1.URISchemeHTTPS {
+		t.Fatalf("expected https readiness probe, got %s", deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Scheme)
+	}
+	if !hasVolume(deployment.Spec.Template.Spec.Volumes, "gateway-tls") {
+		t.Fatal("expected gateway-tls volume to be mounted")
+	}
+}
+
 func TestApplyRegistryConfigBuiltin(t *testing.T) {
 	r := &Reconciler{}
 	infra := &infrav1alpha1.Sandbox0Infra{
@@ -575,4 +686,13 @@ func newRegionalGatewayTestReconciler(t *testing.T, objects ...runtime.Object) (
 		Build()
 
 	return NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{})), client
+}
+
+func hasVolume(volumes []corev1.Volume, name string) bool {
+	for _, volume := range volumes {
+		if volume.Name == name {
+			return true
+		}
+	}
+	return false
 }

--- a/infra-operator/internal/controller/services/regionalgateway/regionalgateway_registry_test.go
+++ b/infra-operator/internal/controller/services/regionalgateway/regionalgateway_registry_test.go
@@ -127,6 +127,9 @@ func TestReconcileEnablesTLSForHTTPSBaseURL(t *testing.T) {
 	if service.Spec.Ports[0].AppProtocol == nil || *service.Spec.Ports[0].AppProtocol != "HTTPS" {
 		t.Fatalf("expected HTTPS appProtocol, got %#v", service.Spec.Ports[0].AppProtocol)
 	}
+	if service.Spec.ExternalTrafficPolicy != corev1.ServiceExternalTrafficPolicyLocal {
+		t.Fatalf("expected externalTrafficPolicy Local, got %q", service.Spec.ExternalTrafficPolicy)
+	}
 
 	deployment := &appsv1.Deployment{}
 	if err := client.Get(context.Background(), types.NamespacedName{Name: "demo-regional-gateway", Namespace: infra.Namespace}, deployment); err != nil {

--- a/infra-operator/internal/controller/services/regionalgateway/regionalgateway_registry_test.go
+++ b/infra-operator/internal/controller/services/regionalgateway/regionalgateway_registry_test.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -117,10 +118,22 @@ func TestReconcileEnablesTLSForHTTPSBaseURL(t *testing.T) {
 	if service.Spec.Ports[0].Port != 443 {
 		t.Fatalf("expected external service port 443, got %d", service.Spec.Ports[0].Port)
 	}
+	if service.Spec.Ports[0].Name != "https" {
+		t.Fatalf("expected https service port name, got %q", service.Spec.Ports[0].Name)
+	}
+	if service.Spec.Ports[0].TargetPort.Type != intstr.String || service.Spec.Ports[0].TargetPort.StrVal != "https" {
+		t.Fatalf("expected https target port, got %#v", service.Spec.Ports[0].TargetPort)
+	}
+	if service.Spec.Ports[0].AppProtocol == nil || *service.Spec.Ports[0].AppProtocol != "HTTPS" {
+		t.Fatalf("expected HTTPS appProtocol, got %#v", service.Spec.Ports[0].AppProtocol)
+	}
 
 	deployment := &appsv1.Deployment{}
 	if err := client.Get(context.Background(), types.NamespacedName{Name: "demo-regional-gateway", Namespace: infra.Namespace}, deployment); err != nil {
 		t.Fatalf("get regional gateway deployment: %v", err)
+	}
+	if deployment.Spec.Template.Spec.Containers[0].Ports[0].Name != "https" {
+		t.Fatalf("expected https container port name, got %q", deployment.Spec.Template.Spec.Containers[0].Ports[0].Name)
 	}
 	if deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Scheme != corev1.URISchemeHTTPS {
 		t.Fatalf("expected https readiness probe, got %s", deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Scheme)

--- a/infra-operator/internal/plan/plan.go
+++ b/infra-operator/internal/plan/plan.go
@@ -243,9 +243,13 @@ func compileClusterGatewayServiceReference(infra *infrav1alpha1.Sandbox0Infra) S
 
 func compileManagerPlan(infra *infrav1alpha1.Sandbox0Infra, compiled *InfraPlan) ManagerPlan {
 	nodeSelector, tolerations := common.ResolveSandboxNodePlacement(infra)
+	templateStoreEnabled := clusterGatewayAuthMode(infra) != defaultClusterGatewayAuthMode
+	if infrav1alpha1.IsRegionalGatewayEnabled(infra) && !infrav1alpha1.IsSchedulerEnabled(infra) {
+		templateStoreEnabled = true
+	}
 
 	managerPlan := ManagerPlan{
-		TemplateStoreEnabled:  clusterGatewayAuthMode(infra) != defaultClusterGatewayAuthMode,
+		TemplateStoreEnabled:  templateStoreEnabled,
 		NetworkPolicyProvider: "noop",
 		SandboxPodPlacement: apiconfig.SandboxPodPlacementConfig{
 			NodeSelector: nodeSelector,

--- a/infra-operator/internal/plan/plan_test.go
+++ b/infra-operator/internal/plan/plan_test.go
@@ -132,6 +132,45 @@ func TestCompilePreservesExplicitNetdResolverURL(t *testing.T) {
 	}
 }
 
+func TestCompileEnablesManagerTemplateStoreForRegionalGatewayWithoutScheduler(t *testing.T) {
+	infra := &infrav1alpha1.Sandbox0Infra{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "sandbox0-system",
+		},
+		Spec: infrav1alpha1.Sandbox0InfraSpec{
+			Services: &infrav1alpha1.ServicesConfig{
+				RegionalGateway: &infrav1alpha1.RegionalGatewayServiceConfig{
+					WorkloadServiceConfig: infrav1alpha1.WorkloadServiceConfig{
+						EnabledServiceConfig: infrav1alpha1.EnabledServiceConfig{
+							Enabled: true,
+						},
+					},
+				},
+				ClusterGateway: &infrav1alpha1.ClusterGatewayServiceConfig{
+					WorkloadServiceConfig: infrav1alpha1.WorkloadServiceConfig{
+						EnabledServiceConfig: infrav1alpha1.EnabledServiceConfig{Enabled: true},
+					},
+					Config: &infrav1alpha1.ClusterGatewayConfig{
+						AuthMode: "internal",
+					},
+				},
+				Manager: &infrav1alpha1.ManagerServiceConfig{
+					WorkloadServiceConfig: infrav1alpha1.WorkloadServiceConfig{
+						EnabledServiceConfig: infrav1alpha1.EnabledServiceConfig{Enabled: true},
+					},
+				},
+			},
+		},
+	}
+
+	compiled := Compile(infra)
+
+	if !compiled.Manager.TemplateStoreEnabled {
+		t.Fatal("expected regional single-cluster mode to enable manager template store")
+	}
+}
+
 func TestCompileTracksBuiltinAndExternalBackendEnablement(t *testing.T) {
 	t.Run("builtin backends can be disabled explicitly", func(t *testing.T) {
 		infra := &infrav1alpha1.Sandbox0Infra{

--- a/regional-gateway/pkg/http/server.go
+++ b/regional-gateway/pkg/http/server.go
@@ -459,7 +459,17 @@ func (s *Server) Start(ctx context.Context) error {
 	// Start server in a goroutine
 	errChan := make(chan error, 1)
 	go func() {
-		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		var err error
+		if strings.TrimSpace(s.cfg.TLSCertPath) != "" && strings.TrimSpace(s.cfg.TLSKeyPath) != "" {
+			s.logger.Info("Gateway TLS enabled",
+				zap.String("cert_path", s.cfg.TLSCertPath),
+				zap.String("key_path", s.cfg.TLSKeyPath),
+			)
+			err = server.ListenAndServeTLS(s.cfg.TLSCertPath, s.cfg.TLSKeyPath)
+		} else {
+			err = server.ListenAndServe()
+		}
+		if err != nil && err != http.ErrServerClosed {
 			errChan <- err
 		}
 	}()


### PR DESCRIPTION
## Summary
- fix single-cluster regional mode so manager keeps template store enabled
- harden regional-gateway service reconciliation for GKE load balancers
- align regional-gateway TLS/service/probe settings with the GCP external load balancer path

## Validation
- go test ./infra-operator/internal/plan ./infra-operator/internal/controller/services/regionalgateway ./infra-operator/internal/controller/pkg/common
- verified GCP us-east4 regional-gateway backend is healthy
- verified global routing end-to-end with s0 template list, sandbox create, sandbox exec, and sandbox delete
