### PR TITLE
Refactor infra-operator service reconcilers to consume compiled plans

### DIFF
--- a/infra-operator/internal/controller/pkg/common/builtin_templates.go
+++ b/infra-operator/internal/controller/pkg/common/builtin_templates.go
@@ -44,9 +44,9 @@ type BuiltinTemplateOptions struct {
 }
 
 // EnsureBuiltinTemplates creates or updates builtin templates in the template store.
-func EnsureBuiltinTemplates(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, opts BuiltinTemplateOptions) error {
+func EnsureBuiltinTemplates(ctx context.Context, builtins []infrav1alpha1.BuiltinTemplateConfig, opts BuiltinTemplateOptions) error {
 	logger := log.FromContext(ctx)
-	if infra == nil || len(infra.Spec.BuiltinTemplates) == 0 {
+	if len(builtins) == 0 {
 		return nil
 	}
 	if !opts.TemplateStoreEnabled {
@@ -82,7 +82,7 @@ func EnsureBuiltinTemplates(ctx context.Context, infra *infrav1alpha1.Sandbox0In
 
 	store := templstorepg.NewStore(pool)
 
-	for _, builtin := range infra.Spec.BuiltinTemplates {
+	for _, builtin := range builtins {
 		templateID, err := naming.CanonicalTemplateID(builtin.TemplateID)
 		if err != nil {
 			return fmt.Errorf("builtin template_id is invalid: %w", err)

--- a/infra-operator/internal/controller/pkg/common/common.go
+++ b/infra-operator/internal/controller/pkg/common/common.go
@@ -329,6 +329,9 @@ func ResolveSSHEndpoint(infra *infrav1alpha1.Sandbox0Infra, fallbackPort int32) 
 	if infra == nil || infra.Spec.Services == nil || infra.Spec.Services.SSHGateway == nil || !infra.Spec.Services.SSHGateway.Enabled {
 		return "", 0, false
 	}
+	if infra.Spec.PublicExposure == nil {
+		return "", 0, false
+	}
 
 	rootDomain := strings.TrimSpace(infra.Spec.PublicExposure.RootDomain)
 	regionLabel := strings.TrimSpace(infra.Spec.PublicExposure.RegionID)

--- a/infra-operator/internal/controller/pkg/common/common.go
+++ b/infra-operator/internal/controller/pkg/common/common.go
@@ -36,7 +36,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/util/retry"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -91,8 +90,12 @@ type ServiceDefinition struct {
 
 // ReconcileDeployment creates or updates a deployment.
 func (r *ResourceManager) ReconcileDeployment(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, name string, labels map[string]string, replicas int32, def ServiceDefinition) error {
+	return r.ReconcileDeploymentWithScope(ctx, NewObjectScope(infra), name, labels, replicas, def)
+}
+
+func (r *ResourceManager) ReconcileDeploymentWithScope(ctx context.Context, scope ObjectScope, name string, labels map[string]string, replicas int32, def ServiceDefinition) error {
 	deploy := &appsv1.Deployment{}
-	err := r.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: infra.Namespace}, deploy)
+	err := r.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: scope.Namespace}, deploy)
 	if err != nil && !errors.IsNotFound(err) {
 		return err
 	}
@@ -115,7 +118,7 @@ func (r *ResourceManager) ReconcileDeployment(ctx context.Context, infra *infrav
 	desiredDeploy := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: infra.Namespace,
+			Namespace: scope.Namespace,
 			Labels:    desiredLabels,
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -151,7 +154,7 @@ func (r *ResourceManager) ReconcileDeployment(ctx context.Context, infra *infrav
 		},
 	}
 
-	if err := ctrl.SetControllerReference(infra, desiredDeploy, r.Scheme); err != nil {
+	if err := scope.SetControllerReference(desiredDeploy, r.Scheme); err != nil {
 		return err
 	}
 
@@ -166,12 +169,16 @@ func (r *ResourceManager) ReconcileDeployment(ctx context.Context, infra *infrav
 
 // EnsureDeploymentReady validates deployment readiness before reporting success.
 func (r *ResourceManager) EnsureDeploymentReady(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, name string, replicas int32) error {
+	return r.EnsureDeploymentReadyWithScope(ctx, NewObjectScope(infra), name, replicas)
+}
+
+func (r *ResourceManager) EnsureDeploymentReadyWithScope(ctx context.Context, scope ObjectScope, name string, replicas int32) error {
 	if replicas == 0 {
 		return nil
 	}
 
 	deploy := &appsv1.Deployment{}
-	if err := r.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: infra.Namespace}, deploy); err != nil {
+	if err := r.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: scope.Namespace}, deploy); err != nil {
 		return err
 	}
 
@@ -190,6 +197,10 @@ func (r *ResourceManager) EnsureDeploymentReady(ctx context.Context, infra *infr
 
 // ReconcileDaemonSet creates or updates a daemonset.
 func (r *ResourceManager) ReconcileDaemonSet(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, name string, labels map[string]string, def ServiceDefinition) error {
+	return r.ReconcileDaemonSetWithScope(ctx, NewObjectScope(infra), name, labels, def)
+}
+
+func (r *ResourceManager) ReconcileDaemonSetWithScope(ctx context.Context, scope ObjectScope, name string, labels map[string]string, def ServiceDefinition) error {
 	defaultResources := corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("100m"),
@@ -208,7 +219,7 @@ func (r *ResourceManager) ReconcileDaemonSet(ctx context.Context, infra *infrav1
 	desiredDs := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: infra.Namespace,
+			Namespace: scope.Namespace,
 			Labels:    desiredLabels,
 		},
 		Spec: appsv1.DaemonSetSpec{
@@ -250,18 +261,22 @@ func (r *ResourceManager) ReconcileDaemonSet(ctx context.Context, infra *infrav1
 		},
 	}
 
-	if err := ctrl.SetControllerReference(infra, desiredDs, r.Scheme); err != nil {
+	if err := scope.SetControllerReference(desiredDs, r.Scheme); err != nil {
 		return err
 	}
 
-	return r.ApplyDaemonSet(ctx, infra, desiredDs)
+	return r.ApplyDaemonSetWithScope(ctx, scope, desiredDs)
 }
 
 // ApplyDaemonSet creates or updates a daemonset using fresh reads on each retry
 // so controller-driven status/resourceVersion updates do not cause reconcile
 // loops to fail on optimistic concurrency conflicts.
 func (r *ResourceManager) ApplyDaemonSet(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, desired *appsv1.DaemonSet) error {
-	if err := ctrl.SetControllerReference(infra, desired, r.Scheme); err != nil {
+	return r.ApplyDaemonSetWithScope(ctx, NewObjectScope(infra), desired)
+}
+
+func (r *ResourceManager) ApplyDaemonSetWithScope(ctx context.Context, scope ObjectScope, desired *appsv1.DaemonSet) error {
+	if err := scope.SetControllerReference(desired, r.Scheme); err != nil {
 		return err
 	}
 
@@ -357,21 +372,33 @@ func ResolveServiceAnnotations(config *infrav1alpha1.ServiceNetworkConfig) map[s
 // ReconcileService creates or updates a service.
 // For NodePort type, the port is also used as NodePort.
 func (r *ResourceManager) ReconcileService(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, name string, labels map[string]string, serviceType corev1.ServiceType, annotations map[string]string, port, targetPort int32) error {
-	return r.ReconcileServicePorts(ctx, infra, name, labels, serviceType, annotations, []corev1.ServicePort{
+	return r.ReconcileServiceWithScope(ctx, NewObjectScope(infra), name, labels, serviceType, annotations, port, targetPort)
+}
+
+func (r *ResourceManager) ReconcileServiceWithScope(ctx context.Context, scope ObjectScope, name string, labels map[string]string, serviceType corev1.ServiceType, annotations map[string]string, port, targetPort int32) error {
+	return r.ReconcileServicePortsWithScope(ctx, scope, name, labels, serviceType, annotations, []corev1.ServicePort{
 		BuildServicePort("http", port, targetPort, serviceType),
 	})
 }
 
 // ReconcileServicePorts creates or updates a service with multiple ports.
 func (r *ResourceManager) ReconcileServicePorts(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, name string, labels map[string]string, serviceType corev1.ServiceType, annotations map[string]string, ports []corev1.ServicePort) error {
-	return r.reconcileServicePorts(ctx, infra, name, labels, serviceType, annotations, ports, nil)
+	return r.ReconcileServicePortsWithScope(ctx, NewObjectScope(infra), name, labels, serviceType, annotations, ports)
+}
+
+func (r *ResourceManager) ReconcileServicePortsWithScope(ctx context.Context, scope ObjectScope, name string, labels map[string]string, serviceType corev1.ServiceType, annotations map[string]string, ports []corev1.ServicePort) error {
+	return r.reconcileServicePorts(ctx, scope, name, labels, serviceType, annotations, ports, nil)
 }
 
 func (r *ResourceManager) ReconcileServicePortsWithSpecMutator(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, name string, labels map[string]string, serviceType corev1.ServiceType, annotations map[string]string, ports []corev1.ServicePort, mutate func(*corev1.ServiceSpec)) error {
-	return r.reconcileServicePorts(ctx, infra, name, labels, serviceType, annotations, ports, mutate)
+	return r.ReconcileServicePortsWithScopeAndSpecMutator(ctx, NewObjectScope(infra), name, labels, serviceType, annotations, ports, mutate)
 }
 
-func (r *ResourceManager) reconcileServicePorts(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, name string, labels map[string]string, serviceType corev1.ServiceType, annotations map[string]string, ports []corev1.ServicePort, mutate func(*corev1.ServiceSpec)) error {
+func (r *ResourceManager) ReconcileServicePortsWithScopeAndSpecMutator(ctx context.Context, scope ObjectScope, name string, labels map[string]string, serviceType corev1.ServiceType, annotations map[string]string, ports []corev1.ServicePort, mutate func(*corev1.ServiceSpec)) error {
+	return r.reconcileServicePorts(ctx, scope, name, labels, serviceType, annotations, ports, mutate)
+}
+
+func (r *ResourceManager) reconcileServicePorts(ctx context.Context, scope ObjectScope, name string, labels map[string]string, serviceType corev1.ServiceType, annotations map[string]string, ports []corev1.ServicePort, mutate func(*corev1.ServiceSpec)) error {
 	if len(ports) == 0 {
 		return fmt.Errorf("service %q requires at least one port", name)
 	}
@@ -388,20 +415,20 @@ func (r *ResourceManager) reconcileServicePorts(ctx context.Context, infra *infr
 	desiredSvc := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
-			Namespace:   infra.Namespace,
+			Namespace:   scope.Namespace,
 			Labels:      desiredLabels,
 			Annotations: CloneStringMap(annotations),
 		},
 		Spec: desiredSpec,
 	}
 
-	if err := ctrl.SetControllerReference(infra, &desiredSvc, r.Scheme); err != nil {
+	if err := scope.SetControllerReference(&desiredSvc, r.Scheme); err != nil {
 		return err
 	}
 
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		svc := &corev1.Service{}
-		err := r.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: infra.Namespace}, svc)
+		err := r.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: scope.Namespace}, svc)
 		if errors.IsNotFound(err) {
 			return r.Client.Create(ctx, desiredSvc.DeepCopy())
 		}
@@ -466,10 +493,14 @@ func CloneStringMap(src map[string]string) map[string]string {
 
 // ReconcileIngress creates or updates an ingress.
 func (r *ResourceManager) ReconcileIngress(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, serviceName string, servicePort int32, config *infrav1alpha1.IngressConfig) error {
+	return r.ReconcileIngressWithScope(ctx, NewObjectScope(infra), serviceName, servicePort, config)
+}
+
+func (r *ResourceManager) ReconcileIngressWithScope(ctx context.Context, scope ObjectScope, serviceName string, servicePort int32, config *infrav1alpha1.IngressConfig) error {
 	ingressName := serviceName
 
 	ingress := &networkingv1.Ingress{}
-	err := r.Client.Get(ctx, types.NamespacedName{Name: ingressName, Namespace: infra.Namespace}, ingress)
+	err := r.Client.Get(ctx, types.NamespacedName{Name: ingressName, Namespace: scope.Namespace}, ingress)
 	if err != nil && !errors.IsNotFound(err) {
 		return err
 	}
@@ -479,7 +510,7 @@ func (r *ResourceManager) ReconcileIngress(ctx context.Context, infra *infrav1al
 	desiredIngress := &networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ingressName,
-			Namespace: infra.Namespace,
+			Namespace: scope.Namespace,
 			Labels:    desiredLabels,
 		},
 		Spec: networkingv1.IngressSpec{
@@ -519,7 +550,7 @@ func (r *ResourceManager) ReconcileIngress(ctx context.Context, infra *infrav1al
 		}
 	}
 
-	if err := ctrl.SetControllerReference(infra, desiredIngress, r.Scheme); err != nil {
+	if err := scope.SetControllerReference(desiredIngress, r.Scheme); err != nil {
 		return err
 	}
 
@@ -534,6 +565,10 @@ func (r *ResourceManager) ReconcileIngress(ctx context.Context, infra *infrav1al
 
 // ReconcileServiceConfigMap creates or updates a configmap for a service.
 func (r *ResourceManager) ReconcileServiceConfigMap(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, name string, labels map[string]string, config any) error {
+	return r.ReconcileServiceConfigMapWithScope(ctx, NewObjectScope(infra), name, labels, config)
+}
+
+func (r *ResourceManager) ReconcileServiceConfigMapWithScope(ctx context.Context, scope ObjectScope, name string, labels map[string]string, config any) error {
 	if config == nil {
 		config = map[string]any{}
 	}
@@ -547,7 +582,7 @@ func (r *ResourceManager) ReconcileServiceConfigMap(ctx context.Context, infra *
 	desired := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: infra.Namespace,
+			Namespace: scope.Namespace,
 			Labels:    desiredLabels,
 		},
 		Data: map[string]string{
@@ -555,12 +590,12 @@ func (r *ResourceManager) ReconcileServiceConfigMap(ctx context.Context, infra *
 		},
 	}
 
-	if err := ctrl.SetControllerReference(infra, desired, r.Scheme); err != nil {
+	if err := scope.SetControllerReference(desired, r.Scheme); err != nil {
 		return err
 	}
 
 	existing := &corev1.ConfigMap{}
-	err = r.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: infra.Namespace}, existing)
+	err = r.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: scope.Namespace}, existing)
 	if err != nil && !errors.IsNotFound(err) {
 		return err
 	}
@@ -633,8 +668,12 @@ func GenerateRandomString(length int) string {
 
 // EnsureSecretValue ensures a named secret contains a key, generating if needed.
 func EnsureSecretValue(ctx context.Context, client client.Client, scheme *runtime.Scheme, infra *infrav1alpha1.Sandbox0Infra, name, key string, length int) (string, error) {
+	return EnsureSecretValueWithScope(ctx, client, scheme, NewObjectScope(infra), name, key, length)
+}
+
+func EnsureSecretValueWithScope(ctx context.Context, client client.Client, scheme *runtime.Scheme, scope ObjectScope, name, key string, length int) (string, error) {
 	secret := &corev1.Secret{}
-	err := client.Get(ctx, types.NamespacedName{Name: name, Namespace: infra.Namespace}, secret)
+	err := client.Get(ctx, types.NamespacedName{Name: name, Namespace: scope.Namespace}, secret)
 	if err != nil && !errors.IsNotFound(err) {
 		return "", err
 	}
@@ -644,14 +683,14 @@ func EnsureSecretValue(ctx context.Context, client client.Client, scheme *runtim
 		secret = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
-				Namespace: infra.Namespace,
+				Namespace: scope.Namespace,
 			},
 			Type: corev1.SecretTypeOpaque,
 			StringData: map[string]string{
 				key: value,
 			},
 		}
-		if err := ctrl.SetControllerReference(infra, secret, scheme); err != nil {
+		if err := scope.SetControllerReference(secret, scheme); err != nil {
 			return "", err
 		}
 		if err := client.Create(ctx, secret); err != nil {
@@ -677,8 +716,12 @@ func EnsureSecretValue(ctx context.Context, client client.Client, scheme *runtim
 
 // EnsureEd25519KeyPair ensures a named secret contains an Ed25519 keypair.
 func EnsureEd25519KeyPair(ctx context.Context, client client.Client, scheme *runtime.Scheme, infra *infrav1alpha1.Sandbox0Infra, name, privateKeyKey, publicKeyKey string) (string, string, error) {
+	return EnsureEd25519KeyPairWithScope(ctx, client, scheme, NewObjectScope(infra), name, privateKeyKey, publicKeyKey)
+}
+
+func EnsureEd25519KeyPairWithScope(ctx context.Context, client client.Client, scheme *runtime.Scheme, scope ObjectScope, name, privateKeyKey, publicKeyKey string) (string, string, error) {
 	secret := &corev1.Secret{}
-	err := client.Get(ctx, types.NamespacedName{Name: name, Namespace: infra.Namespace}, secret)
+	err := client.Get(ctx, types.NamespacedName{Name: name, Namespace: scope.Namespace}, secret)
 	if err != nil && !errors.IsNotFound(err) {
 		return "", "", err
 	}
@@ -699,7 +742,7 @@ func EnsureEd25519KeyPair(ctx context.Context, client client.Client, scheme *run
 		secret = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
-				Namespace: infra.Namespace,
+				Namespace: scope.Namespace,
 			},
 			Type: corev1.SecretTypeOpaque,
 			StringData: map[string]string{
@@ -707,7 +750,7 @@ func EnsureEd25519KeyPair(ctx context.Context, client client.Client, scheme *run
 				publicKeyKey:  publicKeyPEM,
 			},
 		}
-		if err := ctrl.SetControllerReference(infra, secret, scheme); err != nil {
+		if err := scope.SetControllerReference(secret, scheme); err != nil {
 			return "", "", err
 		}
 		if err := client.Create(ctx, secret); err != nil {

--- a/infra-operator/internal/controller/pkg/common/license.go
+++ b/infra-operator/internal/controller/pkg/common/license.go
@@ -74,12 +74,20 @@ func AppendEnterpriseLicenseVolume(
 	volumeMounts []corev1.VolumeMount,
 	volumes []corev1.Volume,
 ) ([]corev1.VolumeMount, []corev1.Volume) {
+	return AppendEnterpriseLicenseVolumeWithSecretRef(ResolveEnterpriseLicenseSecretRef(infra), licenseFile, volumeMounts, volumes)
+}
+
+func AppendEnterpriseLicenseVolumeWithSecretRef(
+	secretRef infrav1alpha1.SecretKeyRef,
+	licenseFile string,
+	volumeMounts []corev1.VolumeMount,
+	volumes []corev1.Volume,
+) ([]corev1.VolumeMount, []corev1.Volume) {
 	mountPath := strings.TrimSpace(licenseFile)
 	if mountPath == "" {
 		mountPath = EnterpriseLicenseDefaultPath
 	}
 
-	secretRef := ResolveEnterpriseLicenseSecretRef(infra)
 	volumeMounts = append(volumeMounts, corev1.VolumeMount{
 		Name:      "enterprise-license",
 		MountPath: mountPath,

--- a/infra-operator/internal/controller/pkg/common/object_scope.go
+++ b/infra-operator/internal/controller/pkg/common/object_scope.go
@@ -1,0 +1,41 @@
+package common
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	infrav1alpha1 "github.com/sandbox0-ai/sandbox0/infra-operator/api/v1alpha1"
+)
+
+// ObjectScope carries the minimum metadata and ownership context required for
+// reconciling namespaced child resources without exposing the full infra spec.
+type ObjectScope struct {
+	Name      string
+	Namespace string
+	owner     *infrav1alpha1.Sandbox0Infra
+}
+
+func NewObjectScope(infra *infrav1alpha1.Sandbox0Infra) ObjectScope {
+	if infra == nil {
+		return ObjectScope{}
+	}
+	return ObjectScope{
+		Name:      infra.Name,
+		Namespace: infra.Namespace,
+		owner:     infra,
+	}
+}
+
+func (s ObjectScope) SetControllerReference(obj client.Object, scheme *runtime.Scheme) error {
+	if s.owner == nil {
+		return fmt.Errorf("object scope owner is required")
+	}
+	return ctrl.SetControllerReference(s.owner, obj, scheme)
+}
+
+func (s ObjectScope) Owner() *infrav1alpha1.Sandbox0Infra {
+	return s.owner
+}

--- a/infra-operator/internal/controller/pkg/webhook/webhook_certs.go
+++ b/infra-operator/internal/controller/pkg/webhook/webhook_certs.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	ctrl "sigs.k8s.io/controller-runtime"
 
 	infrav1alpha1 "github.com/sandbox0-ai/sandbox0/infra-operator/api/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/pkg/common"
@@ -47,8 +46,12 @@ func NewReconciler(resources *common.ResourceManager) *Reconciler {
 }
 
 func (r *Reconciler) ReconcileCertSecret(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, name string, labels map[string]string, dnsNames []string) error {
+	return r.ReconcileCertSecretWithScope(ctx, common.NewObjectScope(infra), name, labels, dnsNames)
+}
+
+func (r *Reconciler) ReconcileCertSecretWithScope(ctx context.Context, scope common.ObjectScope, name string, labels map[string]string, dnsNames []string) error {
 	secret := &corev1.Secret{}
-	err := r.Resources.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: infra.Namespace}, secret)
+	err := r.Resources.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: scope.Namespace}, secret)
 	if err != nil && !errors.IsNotFound(err) {
 		return err
 	}
@@ -68,7 +71,7 @@ func (r *Reconciler) ReconcileCertSecret(ctx context.Context, infra *infrav1alph
 	desired := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: infra.Namespace,
+			Namespace: scope.Namespace,
 			Labels:    labels,
 		},
 		Type: corev1.SecretTypeTLS,
@@ -77,7 +80,7 @@ func (r *Reconciler) ReconcileCertSecret(ctx context.Context, infra *infrav1alph
 			corev1.TLSPrivateKeyKey: keyPEM,
 		},
 	}
-	if err := ctrl.SetControllerReference(infra, desired, r.Resources.Scheme); err != nil {
+	if err := scope.SetControllerReference(desired, r.Resources.Scheme); err != nil {
 		return err
 	}
 

--- a/infra-operator/internal/controller/sandbox0infra_controller.go
+++ b/infra-operator/internal/controller/sandbox0infra_controller.go
@@ -346,7 +346,7 @@ func (r *Sandbox0InfraReconciler) workflowStepRunner(
 		}, nil
 	case "regional-gateway":
 		return func(ctx context.Context) error {
-			return regionalGatewayReconciler.Reconcile(ctx, infra, imageRepo, imageTag, compiledPlan)
+			return regionalGatewayReconciler.Reconcile(ctx, imageRepo, imageTag, compiledPlan)
 		}, nil
 	case "ssh-gateway":
 		return func(ctx context.Context) error {
@@ -361,7 +361,7 @@ func (r *Sandbox0InfraReconciler) workflowStepRunner(
 		return func(ctx context.Context) error { return rbacReconciler.ReconcileSchedulerRBAC(ctx, infra) }, nil
 	case "scheduler":
 		return func(ctx context.Context) error {
-			return schedulerReconciler.Reconcile(ctx, infra, imageRepo, imageTag, compiledPlan)
+			return schedulerReconciler.Reconcile(ctx, imageRepo, imageTag, compiledPlan)
 		}, nil
 	case "cluster-gateway-enterprise-license":
 		return func(ctx context.Context) error {
@@ -370,7 +370,7 @@ func (r *Sandbox0InfraReconciler) workflowStepRunner(
 		}, nil
 	case "cluster-gateway":
 		return func(ctx context.Context) error {
-			return clusterGatewayReconciler.Reconcile(ctx, infra, imageRepo, imageTag, compiledPlan)
+			return clusterGatewayReconciler.Reconcile(ctx, imageRepo, imageTag, compiledPlan)
 		}, nil
 	case "fuse-device-plugin":
 		return func(ctx context.Context) error {
@@ -383,7 +383,7 @@ func (r *Sandbox0InfraReconciler) workflowStepRunner(
 		return func(ctx context.Context) error { return rbacReconciler.ReconcileManagerRBAC(ctx, infra) }, nil
 	case "manager":
 		return func(ctx context.Context) error {
-			return managerReconciler.Reconcile(ctx, infra, imageRepo, imageTag, compiledPlan)
+			return managerReconciler.Reconcile(ctx, imageRepo, imageTag, compiledPlan)
 		}, nil
 	case "builtin-template-pods":
 		return func(ctx context.Context) error { return r.waitBuiltinTemplatePodsReady(ctx, infra, compiledPlan) }, nil
@@ -391,7 +391,7 @@ func (r *Sandbox0InfraReconciler) workflowStepRunner(
 		return func(ctx context.Context) error { return rbacReconciler.ReconcileNetdRBAC(ctx, infra) }, nil
 	case "netd":
 		return func(ctx context.Context) error {
-			return netdReconciler.Reconcile(ctx, infra, imageRepo, imageTag, compiledPlan)
+			return netdReconciler.Reconcile(ctx, imageRepo, imageTag, compiledPlan)
 		}, nil
 	case "storage-proxy-rbac":
 		return func(ctx context.Context) error { return rbacReconciler.ReconcileStorageProxyRBAC(ctx, infra) }, nil

--- a/infra-operator/internal/controller/services/clustergateway/clustergateway.go
+++ b/infra-operator/internal/controller/services/clustergateway/clustergateway.go
@@ -69,7 +69,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 	labels := common.GetServiceLabels(infra.Name, "cluster-gateway")
 	dataPlaneSecretName, dataPlanePrivateKey, _ := internalauth.GetDataPlaneKeyRefs(infra)
 
-	config, err := r.buildConfig(ctx, infra)
+	config, err := r.buildConfig(ctx, infra, compiledPlan)
 	if err != nil {
 		return err
 	}
@@ -292,11 +292,15 @@ func probeScheme(tlsEnabled bool) corev1.URIScheme {
 	return corev1.URISchemeHTTP
 }
 
-func (r *Reconciler) buildConfig(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra) (*apiconfig.ClusterGatewayConfig, error) {
+func (r *Reconciler) buildConfig(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, compiledPlan *infraplan.InfraPlan) (*apiconfig.ClusterGatewayConfig, error) {
 	cfg := &apiconfig.ClusterGatewayConfig{}
 	if infra.Spec.Services != nil && infra.Spec.Services.ClusterGateway != nil {
 		cfg = runtimeconfig.ToClusterGateway(infra.Spec.Services.ClusterGateway.Config)
 	}
+	if compiledPlan == nil {
+		compiledPlan = infraplan.Compile(infra)
+	}
+	cfg.AuthMode = deriveClusterGatewayAuthMode(cfg.AuthMode, compiledPlan)
 	resolvedRegionID := strings.TrimSpace(cfg.RegionID)
 
 	if dsn, err := database.GetDatabaseDSN(ctx, r.Resources.Client, infra); err == nil {
@@ -311,32 +315,14 @@ func (r *Reconciler) buildConfig(ctx context.Context, infra *infrav1alpha1.Sandb
 		cfg.SSHEndpointPort = int(advertisedPort)
 	}
 
-	managerConfig := &apiconfig.ManagerConfig{}
-	if infra.Spec.Services != nil && infra.Spec.Services.Manager != nil {
-		managerConfig = runtimeconfig.ToManager(infra.Spec.Services.Manager.Config)
-	}
-	managerServiceConfig := (*infrav1alpha1.ServiceNetworkConfig)(nil)
-	if infra.Spec.Services != nil && infra.Spec.Services.Manager != nil {
-		managerServiceConfig = infra.Spec.Services.Manager.Service
-	}
-	if infrav1alpha1.IsManagerEnabled(infra) {
-		managerServicePort := common.ResolveServicePort(managerServiceConfig, int32(managerConfig.HTTPPort))
-		managerURL := fmt.Sprintf("http://%s-manager:%d", infra.Name, managerServicePort)
-		cfg.ManagerURL = managerURL
+	if compiledPlan.Components.EnableManager {
+		cfg.ManagerURL = compiledPlan.Services.Manager.URL
 	} else {
 		cfg.ManagerURL = ""
 	}
 
-	storageProxyConfig := &apiconfig.StorageProxyConfig{}
-	storageProxyServiceConfig := (*infrav1alpha1.ServiceNetworkConfig)(nil)
-	if infra.Spec.Services != nil && infra.Spec.Services.StorageProxy != nil {
-		storageProxyConfig = runtimeconfig.ToStorageProxy(infra.Spec.Services.StorageProxy.Config)
-		storageProxyServiceConfig = infra.Spec.Services.StorageProxy.Service
-	}
-	if infrav1alpha1.IsStorageProxyEnabled(infra) {
-		storageProxyHTTPPort := common.ResolveServicePort(storageProxyServiceConfig, int32(storageProxyConfig.HTTPPort))
-		storageProxyURL := fmt.Sprintf("http://%s-storage-proxy:%d", infra.Name, storageProxyHTTPPort)
-		cfg.StorageProxyURL = storageProxyURL
+	if compiledPlan.Components.EnableStorageProxy {
+		cfg.StorageProxyURL = compiledPlan.Services.StorageProxy.URL
 	} else {
 		cfg.StorageProxyURL = ""
 	}
@@ -416,6 +402,17 @@ func (r *Reconciler) buildConfig(ctx context.Context, infra *infrav1alpha1.Sandb
 func clusterGatewayPublicAuthEnabled(mode string) bool {
 	mode = strings.TrimSpace(strings.ToLower(mode))
 	return mode == "public" || mode == "both"
+}
+
+func deriveClusterGatewayAuthMode(mode string, compiledPlan *infraplan.InfraPlan) string {
+	normalized := strings.TrimSpace(strings.ToLower(mode))
+	if normalized == "" {
+		normalized = "internal"
+	}
+	if normalized == "public" && compiledPlan != nil && compiledPlan.RegionalGateway.Enabled {
+		return "both"
+	}
+	return normalized
 }
 
 func internalAuthRequiresControlPlaneKey(cfg *apiconfig.ClusterGatewayConfig) bool {

--- a/infra-operator/internal/controller/services/clustergateway/clustergateway.go
+++ b/infra-operator/internal/controller/services/clustergateway/clustergateway.go
@@ -30,8 +30,6 @@ import (
 	infrav1alpha1 "github.com/sandbox0-ai/sandbox0/infra-operator/api/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/pkg/common"
 	webhookcerts "github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/pkg/webhook"
-	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/database"
-	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/internalauth"
 	infraplan "github.com/sandbox0-ai/sandbox0/infra-operator/internal/plan"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/runtimeconfig"
 	pkginternalauth "github.com/sandbox0-ai/sandbox0/pkg/internalauth"
@@ -46,30 +44,34 @@ func NewReconciler(resources *common.ResourceManager) *Reconciler {
 }
 
 // Reconcile reconciles the cluster-gateway deployment.
-func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, imageRepo, imageTag string, compiledPlan *infraplan.InfraPlan) error {
+func (r *Reconciler) Reconcile(ctx context.Context, imageRepo, imageTag string, compiledPlan *infraplan.InfraPlan) error {
 	logger := log.FromContext(ctx)
 	if compiledPlan == nil {
-		compiledPlan = infraplan.Compile(infra)
+		return fmt.Errorf("compiled plan is required")
 	}
 
 	// Skip if not enabled
-	if infra.Spec.Services != nil && infra.Spec.Services.ClusterGateway != nil && !infra.Spec.Services.ClusterGateway.Enabled {
+	if !compiledPlan.Components.EnableClusterGateway {
 		logger.Info("Internal gateway is disabled, skipping")
 		return nil
 	}
 
-	deploymentName := fmt.Sprintf("%s-cluster-gateway", infra.Name)
+	scope := compiledPlan.Scope
+	deploymentName := fmt.Sprintf("%s-cluster-gateway", scope.Name)
 	serviceName := deploymentName
-
 	replicas := int32(1)
-	if infra.Spec.Services != nil && infra.Spec.Services.ClusterGateway != nil {
-		replicas = infra.Spec.Services.ClusterGateway.Replicas
+	var resources *corev1.ResourceRequirements
+	serviceConfig := (*infrav1alpha1.ServiceNetworkConfig)(nil)
+	if owner := scope.Owner(); owner != nil && owner.Spec.Services != nil && owner.Spec.Services.ClusterGateway != nil {
+		replicas = owner.Spec.Services.ClusterGateway.Replicas
+		resources = owner.Spec.Services.ClusterGateway.Resources
+		serviceConfig = owner.Spec.Services.ClusterGateway.Service
 	}
 
-	labels := common.GetServiceLabels(infra.Name, "cluster-gateway")
-	dataPlaneSecretName, dataPlanePrivateKey, _ := internalauth.GetDataPlaneKeyRefs(infra)
+	labels := common.GetServiceLabels(scope.Name, "cluster-gateway")
+	dataPlaneSecretName, dataPlanePrivateKey, _ := compiledPlan.DataPlaneKeyRefs()
 
-	config, err := r.buildConfig(ctx, infra, compiledPlan)
+	config, err := r.buildConfig(ctx, compiledPlan)
 	if err != nil {
 		return err
 	}
@@ -79,7 +81,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 	if err != nil {
 		return err
 	}
-	if err := r.Resources.ReconcileServiceConfigMap(ctx, infra, deploymentName, labels, config); err != nil {
+	if err := r.Resources.ReconcileServiceConfigMapWithScope(ctx, scope, deploymentName, labels, config); err != nil {
 		return err
 	}
 
@@ -87,20 +89,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 	controlPlanePublicSecretName := ""
 	controlPlanePublicKeyKey := ""
 	if needsControlPlanePublicKey {
-		controlPlaneSecretName, _, controlPlanePublicKey := internalauth.GetControlPlaneKeyRefs(infra)
-		controlPlanePublicSecretName, controlPlanePublicKeyKey = internalauth.GetControlPlanePublicKeyRef(infra)
+		controlPlaneSecretName, _, controlPlanePublicKey := compiledPlan.ControlPlaneKeyRefs()
+		controlPlanePublicSecretName, controlPlanePublicKeyKey = compiledPlan.ControlPlanePublicKeyRef()
 		if controlPlanePublicSecretName == "" {
 			controlPlanePublicSecretName = controlPlaneSecretName
 			controlPlanePublicKeyKey = controlPlanePublicKey
 		}
 	}
-	var resources *corev1.ResourceRequirements
-	serviceConfig := (*infrav1alpha1.ServiceNetworkConfig)(nil)
-	if infra.Spec.Services != nil && infra.Spec.Services.ClusterGateway != nil {
-		resources = infra.Spec.Services.ClusterGateway.Resources
-		serviceConfig = infra.Spec.Services.ClusterGateway.Service
-	}
-
 	httpPort := int32(config.HTTPPort)
 	tlsEnabled := strings.TrimSpace(config.TLSCertPath) != "" && strings.TrimSpace(config.TLSKeyPath) != ""
 
@@ -166,15 +161,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 		})
 	}
 	if needEnterpriseLicense {
-		volumeMounts, volumes = common.AppendEnterpriseLicenseVolume(infra, config.LicenseFile, volumeMounts, volumes)
+		volumeMounts, volumes = common.AppendEnterpriseLicenseVolumeWithSecretRef(compiledPlan.EnterpriseLicenseSecretRef(), config.LicenseFile, volumeMounts, volumes)
 	}
 	if tlsEnabled {
-		tlsSecretName := fmt.Sprintf("%s-cluster-gateway-tls", infra.Name)
+		tlsSecretName := fmt.Sprintf("%s-cluster-gateway-tls", scope.Name)
 		dnsNames := clusterGatewayTLSDNSNames(config)
 		if len(dnsNames) == 0 {
 			return fmt.Errorf("cluster-gateway TLS enabled but no DNS names were derived")
 		}
-		if err := webhookcerts.NewReconciler(r.Resources).ReconcileCertSecret(ctx, infra, tlsSecretName, labels, dnsNames); err != nil {
+		if err := webhookcerts.NewReconciler(r.Resources).ReconcileCertSecretWithScope(ctx, scope, tlsSecretName, labels, dnsNames); err != nil {
 			return err
 		}
 		volumeMounts = append(volumeMounts,
@@ -201,7 +196,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 		})
 	}
 
-	if err := r.Resources.ReconcileDeployment(ctx, infra, deploymentName, labels, replicas, common.ServiceDefinition{
+	if err := r.Resources.ReconcileDeploymentWithScope(ctx, scope, deploymentName, labels, replicas, common.ServiceDefinition{
 		Name:       "cluster-gateway",
 		Port:       httpPort,
 		TargetPort: httpPort,
@@ -260,11 +255,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 	}
 	servicePort := common.ResolveServicePort(serviceConfig, defaultServicePort)
 	serviceAnnotations := common.ResolveServiceAnnotations(serviceConfig)
-	if err := r.Resources.ReconcileService(ctx, infra, serviceName, labels, serviceType, serviceAnnotations, servicePort, httpPort); err != nil {
+	if err := r.Resources.ReconcileServiceWithScope(ctx, scope, serviceName, labels, serviceType, serviceAnnotations, servicePort, httpPort); err != nil {
 		return err
 	}
 
-	if err := r.Resources.EnsureDeploymentReady(ctx, infra, deploymentName, replicas); err != nil {
+	if err := r.Resources.EnsureDeploymentReadyWithScope(ctx, scope, deploymentName, replicas); err != nil {
 		return err
 	}
 
@@ -292,27 +287,31 @@ func probeScheme(tlsEnabled bool) corev1.URIScheme {
 	return corev1.URISchemeHTTP
 }
 
-func (r *Reconciler) buildConfig(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, compiledPlan *infraplan.InfraPlan) (*apiconfig.ClusterGatewayConfig, error) {
+func (r *Reconciler) buildConfig(ctx context.Context, compiledPlan *infraplan.InfraPlan) (*apiconfig.ClusterGatewayConfig, error) {
 	cfg := &apiconfig.ClusterGatewayConfig{}
-	if infra.Spec.Services != nil && infra.Spec.Services.ClusterGateway != nil {
-		cfg = runtimeconfig.ToClusterGateway(infra.Spec.Services.ClusterGateway.Config)
+	if compiledPlan != nil && compiledPlan.Components.EnableClusterGateway && compiledPlan.Services.ClusterGateway.Name != "" {
+		if compiledPlan.Scope.Owner() != nil && compiledPlan.Scope.Owner().Spec.Services != nil && compiledPlan.Scope.Owner().Spec.Services.ClusterGateway != nil {
+			cfg = runtimeconfig.ToClusterGateway(compiledPlan.Scope.Owner().Spec.Services.ClusterGateway.Config)
+		}
 	}
 	if compiledPlan == nil {
-		compiledPlan = infraplan.Compile(infra)
+		return nil, fmt.Errorf("compiled plan is required")
 	}
 	cfg.AuthMode = deriveClusterGatewayAuthMode(cfg.AuthMode, compiledPlan)
 	resolvedRegionID := strings.TrimSpace(cfg.RegionID)
 
-	if dsn, err := database.GetDatabaseDSN(ctx, r.Resources.Client, infra); err == nil {
+	if dsn, err := compiledPlan.DatabaseDSN(ctx, r.Resources.Client); err == nil {
 		cfg.DatabaseURL = dsn
 	}
-	sshPort := int32(2222)
-	if infra.Spec.Services != nil && infra.Spec.Services.SSHGateway != nil && infra.Spec.Services.SSHGateway.Config != nil && infra.Spec.Services.SSHGateway.Config.SSHPort != 0 {
-		sshPort = int32(infra.Spec.Services.SSHGateway.Config.SSHPort)
-	}
-	if sshHost, advertisedPort, ok := common.ResolveSSHEndpoint(infra, sshPort); ok {
-		cfg.SSHEndpointHost = sshHost
-		cfg.SSHEndpointPort = int(advertisedPort)
+	if owner := compiledPlan.Scope.Owner(); owner != nil {
+		sshPort := int32(2222)
+		if owner.Spec.Services != nil && owner.Spec.Services.SSHGateway != nil && owner.Spec.Services.SSHGateway.Config != nil && owner.Spec.Services.SSHGateway.Config.SSHPort != 0 {
+			sshPort = int32(owner.Spec.Services.SSHGateway.Config.SSHPort)
+		}
+		if sshHost, advertisedPort, ok := common.ResolveSSHEndpoint(owner, sshPort); ok {
+			cfg.SSHEndpointHost = sshHost
+			cfg.SSHEndpointPort = int(advertisedPort)
+		}
 	}
 
 	if compiledPlan.Components.EnableManager {
@@ -327,26 +326,26 @@ func (r *Reconciler) buildConfig(ctx context.Context, infra *infrav1alpha1.Sandb
 		cfg.StorageProxyURL = ""
 	}
 
-	if infra.Spec.InitUser != nil && clusterGatewayPublicAuthEnabled(cfg.AuthMode) {
+	if initUser := compiledPlan.InitUser(); initUser != nil && clusterGatewayPublicAuthEnabled(cfg.AuthMode) {
 		password := ""
 		if cfg.BuiltInAuth.Enabled || !apiconfig.HasEnabledOIDCProviders(cfg.OIDCProviders) {
-			secretRef := common.ResolveSecretKeyRef(infra.Spec.InitUser.PasswordSecret, "admin-password", "password")
+			secretRef := common.ResolveSecretKeyRef(initUser.PasswordSecret, "admin-password", "password")
 			var err error
-			password, err = common.GetSecretValue(ctx, r.Resources.Client, infra.Namespace, secretRef)
+			password, err = common.GetSecretValue(ctx, r.Resources.Client, compiledPlan.Scope.Namespace, secretRef)
 			if err != nil {
 				return nil, err
 			}
 		}
 
-		homeRegionID := strings.TrimSpace(infra.Spec.InitUser.HomeRegionID)
+		homeRegionID := strings.TrimSpace(initUser.HomeRegionID)
 		if homeRegionID == "" {
 			homeRegionID = resolvedRegionID
 		}
 
 		cfg.BuiltInAuth.InitUser = &apiconfig.InitUserConfig{
-			Email:        infra.Spec.InitUser.Email,
+			Email:        initUser.Email,
 			Password:     password,
-			Name:         infra.Spec.InitUser.Name,
+			Name:         initUser.Name,
 			HomeRegionID: homeRegionID,
 		}
 	}
@@ -360,8 +359,8 @@ func (r *Reconciler) buildConfig(ctx context.Context, infra *infrav1alpha1.Sandb
 			ctx,
 			r.Resources.Client,
 			r.Resources.Scheme,
-			infra,
-			fmt.Sprintf("%s-cluster-gateway-jwt", infra.Name),
+			compiledPlan.Scope.Owner(),
+			compiledPlan.ClusterGatewayJWTSecretName(),
 			"jwt_secret",
 			32,
 		)
@@ -370,18 +369,17 @@ func (r *Reconciler) buildConfig(ctx context.Context, infra *infrav1alpha1.Sandb
 		}
 		cfg.JWTSecret = jwtSecret
 	}
-
-	if strings.TrimSpace(infra.Spec.Region) != "" {
-		resolvedRegionID = strings.TrimSpace(infra.Spec.Region)
-	}
-
-	// Copy public exposure config from CRD top-level spec
-	if infra.Spec.PublicExposure != nil {
-		cfg.PublicExposureEnabled = infra.Spec.PublicExposure.Enabled
-		cfg.PublicRootDomain = infra.Spec.PublicExposure.RootDomain
-		cfg.PublicRegionID = infra.Spec.PublicExposure.RegionID
-		if resolvedRegionID == "" {
-			resolvedRegionID = strings.TrimSpace(infra.Spec.PublicExposure.RegionID)
+	if owner := compiledPlan.Scope.Owner(); owner != nil {
+		if strings.TrimSpace(owner.Spec.Region) != "" {
+			resolvedRegionID = strings.TrimSpace(owner.Spec.Region)
+		}
+		if owner.Spec.PublicExposure != nil {
+			cfg.PublicExposureEnabled = owner.Spec.PublicExposure.Enabled
+			cfg.PublicRootDomain = owner.Spec.PublicExposure.RootDomain
+			cfg.PublicRegionID = owner.Spec.PublicExposure.RegionID
+			if resolvedRegionID == "" {
+				resolvedRegionID = strings.TrimSpace(owner.Spec.PublicExposure.RegionID)
+			}
 		}
 	}
 

--- a/infra-operator/internal/controller/services/clustergateway/clustergateway_test.go
+++ b/infra-operator/internal/controller/services/clustergateway/clustergateway_test.go
@@ -235,6 +235,78 @@ func TestReconcileInternalModeMountsControlPlanePublicKey(t *testing.T) {
 	}
 }
 
+func TestReconcileRegionalGatewayPublicModeUpgradesToBoth(t *testing.T) {
+	infra := &infrav1alpha1.Sandbox0Infra{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "sandbox0-system",
+		},
+		Spec: infrav1alpha1.Sandbox0InfraSpec{
+			Database: &infrav1alpha1.DatabaseConfig{
+				Type: infrav1alpha1.DatabaseTypeBuiltin,
+				Builtin: &infrav1alpha1.BuiltinDatabaseConfig{
+					Enabled:  true,
+					Port:     5432,
+					Username: "sandbox0",
+					Database: "sandbox0",
+					SSLMode:  "disable",
+				},
+			},
+			Services: &infrav1alpha1.ServicesConfig{
+				RegionalGateway: &infrav1alpha1.RegionalGatewayServiceConfig{
+					WorkloadServiceConfig: infrav1alpha1.WorkloadServiceConfig{
+						EnabledServiceConfig: infrav1alpha1.EnabledServiceConfig{Enabled: true},
+					},
+				},
+				ClusterGateway: &infrav1alpha1.ClusterGatewayServiceConfig{
+					WorkloadServiceConfig: infrav1alpha1.WorkloadServiceConfig{
+						EnabledServiceConfig: infrav1alpha1.EnabledServiceConfig{Enabled: true},
+					},
+					Config: &infrav1alpha1.ClusterGatewayConfig{
+						AuthMode: "public",
+					},
+				},
+			},
+		},
+	}
+
+	reconciler, client := newClusterGatewayTestReconciler(t,
+		infra.DeepCopy(),
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "demo-sandbox0-database-credentials",
+				Namespace: infra.Namespace,
+			},
+			Data: map[string][]byte{
+				"username": []byte("sandbox0"),
+				"password": []byte("db-password"),
+				"database": []byte("sandbox0"),
+				"port":     []byte("5432"),
+			},
+		},
+	)
+
+	if err := reconciler.Reconcile(context.Background(), infra, "sandbox0ai/infra", "latest", nil); err != nil && !strings.Contains(err.Error(), "not ready") {
+		t.Fatalf("reconcile returned unexpected error: %v", err)
+	}
+
+	deployment := &appsv1.Deployment{}
+	if err := client.Get(context.Background(), types.NamespacedName{Name: "demo-cluster-gateway", Namespace: infra.Namespace}, deployment); err != nil {
+		t.Fatalf("get cluster gateway deployment: %v", err)
+	}
+	if !hasVolume(deployment.Spec.Template.Spec.Volumes, "internal-jwt-public-key") {
+		t.Fatal("expected regional-gateway mode to mount internal-jwt-public-key volume")
+	}
+
+	configMap := &corev1.ConfigMap{}
+	if err := client.Get(context.Background(), types.NamespacedName{Name: "demo-cluster-gateway", Namespace: infra.Namespace}, configMap); err != nil {
+		t.Fatalf("get cluster gateway configmap: %v", err)
+	}
+	if !strings.Contains(configMap.Data["config.yaml"], "auth_mode: both") {
+		t.Fatalf("expected cluster-gateway auth_mode to be promoted to both, got config %q", configMap.Data["config.yaml"])
+	}
+}
+
 func newClusterGatewayTestReconciler(t *testing.T, objects ...runtime.Object) (*Reconciler, ctrlclient.Client) {
 	t.Helper()
 
@@ -329,7 +401,7 @@ func TestBuildConfigUsesStorageProxyServicePortForDerivedURL(t *testing.T) {
 		Build()
 
 	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
-	cfg, err := reconciler.buildConfig(context.Background(), infra)
+	cfg, err := reconciler.buildConfig(context.Background(), infra, nil)
 	if err != nil {
 		t.Fatalf("buildConfig returned error: %v", err)
 	}
@@ -407,7 +479,7 @@ func TestBuildConfigPublishesSSHEndpoint(t *testing.T) {
 		Build()
 
 	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
-	cfg, err := reconciler.buildConfig(context.Background(), infra)
+	cfg, err := reconciler.buildConfig(context.Background(), infra, nil)
 	if err != nil {
 		t.Fatalf("buildConfig returned error: %v", err)
 	}
@@ -480,7 +552,7 @@ func TestBuildConfigSkipsInitUserForInternalOnlyClusterGateway(t *testing.T) {
 		Build()
 
 	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
-	cfg, err := reconciler.buildConfig(context.Background(), infra)
+	cfg, err := reconciler.buildConfig(context.Background(), infra, nil)
 	if err != nil {
 		t.Fatalf("buildConfig returned error: %v", err)
 	}
@@ -558,7 +630,7 @@ func TestBuildConfigLeavesInitUserPasswordEmptyForOIDCOnlyBootstrap(t *testing.T
 		Build()
 
 	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
-	cfg, err := reconciler.buildConfig(context.Background(), infra)
+	cfg, err := reconciler.buildConfig(context.Background(), infra, nil)
 	if err != nil {
 		t.Fatalf("buildConfig returned error: %v", err)
 	}
@@ -649,7 +721,7 @@ func TestBuildConfigDefaultsRegionIDAndInitUserHomeRegionFromPublicExposure(t *t
 		Build()
 
 	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
-	cfg, err := reconciler.buildConfig(context.Background(), infra)
+	cfg, err := reconciler.buildConfig(context.Background(), infra, nil)
 	if err != nil {
 		t.Fatalf("buildConfig returned error: %v", err)
 	}

--- a/infra-operator/internal/controller/services/clustergateway/clustergateway_test.go
+++ b/infra-operator/internal/controller/services/clustergateway/clustergateway_test.go
@@ -15,6 +15,7 @@ import (
 
 	infrav1alpha1 "github.com/sandbox0-ai/sandbox0/infra-operator/api/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/pkg/common"
+	infraplan "github.com/sandbox0-ai/sandbox0/infra-operator/internal/plan"
 )
 
 func TestReconcileEnablesTLSForHTTPSBaseURL(t *testing.T) {
@@ -85,7 +86,7 @@ func TestReconcileEnablesTLSForHTTPSBaseURL(t *testing.T) {
 		},
 	)
 
-	if err := reconciler.Reconcile(context.Background(), infra, "sandbox0ai/infra", "latest", nil); err != nil && !strings.Contains(err.Error(), "not ready") {
+	if err := reconciler.Reconcile(context.Background(), "sandbox0ai/infra", "latest", infraplan.Compile(infra)); err != nil && !strings.Contains(err.Error(), "not ready") {
 		t.Fatalf("reconcile returned unexpected error: %v", err)
 	}
 
@@ -163,7 +164,7 @@ func TestReconcilePublicModeSkipsControlPlanePublicKeyMount(t *testing.T) {
 		},
 	)
 
-	if err := reconciler.Reconcile(context.Background(), infra, "sandbox0ai/infra", "latest", nil); err != nil && !strings.Contains(err.Error(), "not ready") {
+	if err := reconciler.Reconcile(context.Background(), "sandbox0ai/infra", "latest", infraplan.Compile(infra)); err != nil && !strings.Contains(err.Error(), "not ready") {
 		t.Fatalf("reconcile returned unexpected error: %v", err)
 	}
 
@@ -222,7 +223,7 @@ func TestReconcileInternalModeMountsControlPlanePublicKey(t *testing.T) {
 		},
 	)
 
-	if err := reconciler.Reconcile(context.Background(), infra, "sandbox0ai/infra", "latest", nil); err != nil && !strings.Contains(err.Error(), "not ready") {
+	if err := reconciler.Reconcile(context.Background(), "sandbox0ai/infra", "latest", infraplan.Compile(infra)); err != nil && !strings.Contains(err.Error(), "not ready") {
 		t.Fatalf("reconcile returned unexpected error: %v", err)
 	}
 
@@ -286,7 +287,7 @@ func TestReconcileRegionalGatewayPublicModeUpgradesToBoth(t *testing.T) {
 		},
 	)
 
-	if err := reconciler.Reconcile(context.Background(), infra, "sandbox0ai/infra", "latest", nil); err != nil && !strings.Contains(err.Error(), "not ready") {
+	if err := reconciler.Reconcile(context.Background(), "sandbox0ai/infra", "latest", infraplan.Compile(infra)); err != nil && !strings.Contains(err.Error(), "not ready") {
 		t.Fatalf("reconcile returned unexpected error: %v", err)
 	}
 
@@ -401,7 +402,7 @@ func TestBuildConfigUsesStorageProxyServicePortForDerivedURL(t *testing.T) {
 		Build()
 
 	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
-	cfg, err := reconciler.buildConfig(context.Background(), infra, nil)
+	cfg, err := reconciler.buildConfig(context.Background(), infraplan.Compile(infra))
 	if err != nil {
 		t.Fatalf("buildConfig returned error: %v", err)
 	}
@@ -479,7 +480,7 @@ func TestBuildConfigPublishesSSHEndpoint(t *testing.T) {
 		Build()
 
 	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
-	cfg, err := reconciler.buildConfig(context.Background(), infra, nil)
+	cfg, err := reconciler.buildConfig(context.Background(), infraplan.Compile(infra))
 	if err != nil {
 		t.Fatalf("buildConfig returned error: %v", err)
 	}
@@ -552,7 +553,7 @@ func TestBuildConfigSkipsInitUserForInternalOnlyClusterGateway(t *testing.T) {
 		Build()
 
 	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
-	cfg, err := reconciler.buildConfig(context.Background(), infra, nil)
+	cfg, err := reconciler.buildConfig(context.Background(), infraplan.Compile(infra))
 	if err != nil {
 		t.Fatalf("buildConfig returned error: %v", err)
 	}
@@ -630,7 +631,7 @@ func TestBuildConfigLeavesInitUserPasswordEmptyForOIDCOnlyBootstrap(t *testing.T
 		Build()
 
 	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
-	cfg, err := reconciler.buildConfig(context.Background(), infra, nil)
+	cfg, err := reconciler.buildConfig(context.Background(), infraplan.Compile(infra))
 	if err != nil {
 		t.Fatalf("buildConfig returned error: %v", err)
 	}
@@ -721,7 +722,7 @@ func TestBuildConfigDefaultsRegionIDAndInitUserHomeRegionFromPublicExposure(t *t
 		Build()
 
 	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
-	cfg, err := reconciler.buildConfig(context.Background(), infra, nil)
+	cfg, err := reconciler.buildConfig(context.Background(), infraplan.Compile(infra))
 	if err != nil {
 		t.Fatalf("buildConfig returned error: %v", err)
 	}

--- a/infra-operator/internal/controller/services/manager/manager.go
+++ b/infra-operator/internal/controller/services/manager/manager.go
@@ -25,12 +25,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	apiconfig "github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
-	infrav1alpha1 "github.com/sandbox0-ai/sandbox0/infra-operator/api/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/pkg/common"
-	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/database"
-	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/internalauth"
 	netdservice "github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/netd"
-	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/registry"
 	infraplan "github.com/sandbox0-ai/sandbox0/infra-operator/internal/plan"
 	pkginternalauth "github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 )
@@ -46,10 +42,10 @@ func NewReconciler(resources *common.ResourceManager) *Reconciler {
 }
 
 // Reconcile reconciles the manager deployment.
-func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, imageRepo, imageTag string, compiledPlan *infraplan.InfraPlan) error {
+func (r *Reconciler) Reconcile(ctx context.Context, imageRepo, imageTag string, compiledPlan *infraplan.InfraPlan) error {
 	logger := log.FromContext(ctx)
 	if compiledPlan == nil {
-		compiledPlan = infraplan.Compile(infra)
+		return fmt.Errorf("compiled plan is required")
 	}
 
 	// Skip if not enabled
@@ -58,13 +54,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 		return nil
 	}
 
-	deploymentName := fmt.Sprintf("%s-manager", infra.Name)
+	scope := compiledPlan.Scope
+	deploymentName := fmt.Sprintf("%s-manager", scope.Name)
 	replicas := compiledPlan.Manager.Replicas
 
-	labels := common.GetServiceLabels(infra.Name, "manager")
-	keySecretName, privateKeyKey, publicKeyKey := internalauth.GetDataPlaneKeyRefs(infra)
+	labels := common.GetServiceLabels(scope.Name, "manager")
+	keySecretName, privateKeyKey, publicKeyKey := compiledPlan.DataPlaneKeyRefs()
 
-	config, err := r.buildConfig(ctx, infra, imageRepo, imageTag, compiledPlan)
+	config, err := r.buildConfig(ctx, imageRepo, imageTag, compiledPlan)
 	if err != nil {
 		return err
 	}
@@ -73,7 +70,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 		return err
 	}
 
-	if err := r.Resources.ReconcileServiceConfigMap(ctx, infra, deploymentName, labels, config); err != nil {
+	if err := r.Resources.ReconcileServiceConfigMapWithScope(ctx, scope, deploymentName, labels, config); err != nil {
 		return err
 	}
 
@@ -144,23 +141,23 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 		},
 	}
 
-	registryConfig := registry.ResolveRegistryConfig(infra)
-	if registryConfig != nil && registryConfig.SourceSecretName != "" && registryConfig.SourceSecretKey != "" {
+	registrySecretName, registrySecretKey := compiledPlan.ManagerRegistryCredentialsSource()
+	if registrySecretName != "" && registrySecretKey != "" {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      "registry-credentials",
 			MountPath: registryCredentialsPath,
-			SubPath:   registryConfig.SourceSecretKey,
+			SubPath:   registrySecretKey,
 			ReadOnly:  true,
 		})
 		volumes = append(volumes, corev1.Volume{
 			Name: "registry-credentials",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: registryConfig.SourceSecretName,
+					SecretName: registrySecretName,
 					Items: []corev1.KeyToPath{
 						{
-							Key:  registryConfig.SourceSecretKey,
-							Path: registryConfig.SourceSecretKey,
+							Key:  registrySecretKey,
+							Path: registrySecretKey,
 						},
 					},
 				},
@@ -169,11 +166,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 	}
 
 	// Create deployment
-	if err := r.Resources.ReconcileDeployment(ctx, infra, deploymentName, labels, replicas, common.ServiceDefinition{
+	if err := r.Resources.ReconcileDeploymentWithScope(ctx, scope, deploymentName, labels, replicas, common.ServiceDefinition{
 		Name:               "manager",
 		Port:               httpPort,
 		TargetPort:         httpPort,
-		ServiceAccountName: fmt.Sprintf("%s-manager", infra.Name),
+		ServiceAccountName: fmt.Sprintf("%s-manager", scope.Name),
 		Ports: []corev1.ContainerPort{
 			{
 				Name:          "http",
@@ -231,7 +228,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 	serviceType := common.ResolveServiceType(serviceConfig)
 	servicePort := common.ResolveServicePort(serviceConfig, httpPort)
 	serviceAnnotations := common.ResolveServiceAnnotations(serviceConfig)
-	if err := r.Resources.ReconcileServicePorts(ctx, infra, deploymentName, labels, serviceType, serviceAnnotations, []corev1.ServicePort{
+	if err := r.Resources.ReconcileServicePortsWithScope(ctx, scope, deploymentName, labels, serviceType, serviceAnnotations, []corev1.ServicePort{
 		common.BuildServicePort("http", servicePort, httpPort, serviceType),
 		common.BuildServicePort("metrics", metricsPort, metricsPort, serviceType),
 		common.BuildServicePort("webhook", webhookPort, webhookPort, serviceType),
@@ -239,13 +236,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 		return err
 	}
 
-	if err := r.Resources.EnsureDeploymentReady(ctx, infra, deploymentName, replicas); err != nil {
+	if err := r.Resources.EnsureDeploymentReadyWithScope(ctx, scope, deploymentName, replicas); err != nil {
 		return err
 	}
 
 	// Reconcile runtime resources first so dependent services do not observe a
 	// new manager port before the manager service/config have converged.
-	if err := common.EnsureBuiltinTemplates(ctx, infra, common.BuiltinTemplateOptions{
+	if err := common.EnsureBuiltinTemplates(ctx, compiledPlan.BuiltinTemplates(), common.BuiltinTemplateOptions{
 		DatabaseURL:          config.DatabaseURL,
 		DatabaseMaxConns:     config.DatabaseMaxConns,
 		DatabaseMinConns:     config.DatabaseMinConns,
@@ -259,26 +256,26 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 	return nil
 }
 
-func (r *Reconciler) buildConfig(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, imageRepo, imageTag string, compiledPlan *infraplan.InfraPlan) (*apiconfig.ManagerConfig, error) {
+func (r *Reconciler) buildConfig(ctx context.Context, imageRepo, imageTag string, compiledPlan *infraplan.InfraPlan) (*apiconfig.ManagerConfig, error) {
 	cfg := &apiconfig.ManagerConfig{}
 	if compiledPlan == nil {
-		compiledPlan = infraplan.Compile(infra)
+		return nil, fmt.Errorf("compiled plan is required")
 	}
 	if compiledPlan.Manager.Config != nil {
 		cfg = compiledPlan.Manager.Config.DeepCopy()
 	}
 
-	if dsn, err := database.GetDatabaseDSN(ctx, r.Resources.Client, infra); err == nil {
+	if dsn, err := compiledPlan.DatabaseDSN(ctx, r.Resources.Client); err == nil {
 		cfg.DatabaseURL = dsn
 	}
 
 	if cfg.NetworkPolicyProvider == "netd" {
-		secretName, err := netdservice.EnsureMITMCASecret(ctx, r.Resources, infra, common.GetServiceLabels(infra.Name, "netd"))
+		secretName, err := netdservice.EnsureMITMCASecretWithScope(ctx, r.Resources, compiledPlan.Scope, compiledPlan, common.GetServiceLabels(compiledPlan.Scope.Name, "netd"))
 		if err != nil {
 			return nil, fmt.Errorf("ensure netd MITM CA secret: %w", err)
 		}
 		cfg.NetdMITMCASecretName = secretName
-		cfg.NetdMITMCASecretNamespace = infra.Namespace
+		cfg.NetdMITMCASecretNamespace = compiledPlan.Scope.Namespace
 	}
 
 	cfg.ManagerImage = fmt.Sprintf("%s:%s", imageRepo, imageTag)

--- a/infra-operator/internal/controller/services/manager/manager.go
+++ b/infra-operator/internal/controller/services/manager/manager.go
@@ -32,7 +32,6 @@ import (
 	netdservice "github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/netd"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/registry"
 	infraplan "github.com/sandbox0-ai/sandbox0/infra-operator/internal/plan"
-	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/runtimeconfig"
 	pkginternalauth "github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 )
 
@@ -54,17 +53,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 	}
 
 	// Skip if not enabled
-	if infra.Spec.Services != nil && infra.Spec.Services.Manager != nil && !infra.Spec.Services.Manager.Enabled {
+	if !compiledPlan.Manager.Enabled {
 		logger.Info("Manager is disabled, skipping")
 		return nil
 	}
 
 	deploymentName := fmt.Sprintf("%s-manager", infra.Name)
-
-	replicas := int32(1)
-	if infra.Spec.Services != nil && infra.Spec.Services.Manager != nil {
-		replicas = infra.Spec.Services.Manager.Replicas
-	}
+	replicas := compiledPlan.Manager.Replicas
 
 	labels := common.GetServiceLabels(infra.Name, "manager")
 	keySecretName, privateKeyKey, publicKeyKey := internalauth.GetDataPlaneKeyRefs(infra)
@@ -86,12 +81,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 	metricsPort := int32(config.MetricsPort)
 	webhookPort := int32(config.WebhookPort)
 
-	var resources *corev1.ResourceRequirements
-	serviceConfig := (*infrav1alpha1.ServiceNetworkConfig)(nil)
-	if infra.Spec.Services != nil && infra.Spec.Services.Manager != nil {
-		resources = infra.Spec.Services.Manager.Resources
-		serviceConfig = infra.Spec.Services.Manager.Service
-	}
+	resources := compiledPlan.Manager.Resources
+	serviceConfig := compiledPlan.Manager.ServiceConfig
 
 	volumeMounts := []corev1.VolumeMount{
 		{
@@ -270,26 +261,17 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 
 func (r *Reconciler) buildConfig(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, imageRepo, imageTag string, compiledPlan *infraplan.InfraPlan) (*apiconfig.ManagerConfig, error) {
 	cfg := &apiconfig.ManagerConfig{}
-	if infra.Spec.Services != nil && infra.Spec.Services.Manager != nil {
-		cfg = runtimeconfig.ToManager(infra.Spec.Services.Manager.Config)
-	}
 	if compiledPlan == nil {
 		compiledPlan = infraplan.Compile(infra)
+	}
+	if compiledPlan.Manager.Config != nil {
+		cfg = compiledPlan.Manager.Config.DeepCopy()
 	}
 
 	if dsn, err := database.GetDatabaseDSN(ctx, r.Resources.Client, infra); err == nil {
 		cfg.DatabaseURL = dsn
 	}
 
-	cfg.TemplateStoreEnabled = compiledPlan.Manager.TemplateStoreEnabled
-	cfg.NetworkPolicyProvider = compiledPlan.Manager.NetworkPolicyProvider
-	cfg.SandboxPodPlacement = compiledPlan.Manager.SandboxPodPlacement
-	cfg.DefaultClusterId = compiledPlan.Manager.DefaultClusterID
-	cfg.RegionID = compiledPlan.Manager.RegionID
-	cfg.CtldEnabled = compiledPlan.Components.EnableFusePlugin
-	if cfg.CtldEnabled && cfg.CtldPort == 0 {
-		cfg.CtldPort = 8095
-	}
 	if cfg.NetworkPolicyProvider == "netd" {
 		secretName, err := netdservice.EnsureMITMCASecret(ctx, r.Resources, infra, common.GetServiceLabels(infra.Name, "netd"))
 		if err != nil {
@@ -300,107 +282,6 @@ func (r *Reconciler) buildConfig(ctx context.Context, infra *infrav1alpha1.Sandb
 	}
 
 	cfg.ManagerImage = fmt.Sprintf("%s:%s", imageRepo, imageTag)
-
-	registryConfig := registry.ResolveRegistryConfig(infra)
-	if registryConfig != nil {
-		cfg.Registry.Provider = string(registryConfig.Provider)
-		cfg.Registry.PushRegistry = registryConfig.PushRegistry
-		cfg.Registry.PullRegistry = registryConfig.PullRegistry
-		cfg.Registry.PullSecretName = registryConfig.TargetSecretName
-		cfg.Registry.Namespace = infra.Namespace
-		if registryConfig.SourceSecretName != "" {
-			cfg.Registry.PullCredentialsFile = registryCredentialsPath
-		}
-		// For builtin provider, configure auth secret for push credentials
-		if registryConfig.Provider == infrav1alpha1.RegistryProviderBuiltin {
-			cfg.Registry.Builtin = &apiconfig.RegistryBuiltinConfig{
-				AuthSecretName: fmt.Sprintf("%s-registry-auth", infra.Name),
-				UsernameKey:    "username",
-				PasswordKey:    "password",
-			}
-		}
-	}
-	if infra.Spec.Registry != nil {
-		switch infra.Spec.Registry.Provider {
-		case infrav1alpha1.RegistryProviderAWS:
-			if infra.Spec.Registry.AWS != nil {
-				cfg.Registry.AWS = &apiconfig.RegistryAWSConfig{
-					Region:           infra.Spec.Registry.AWS.Region,
-					RegistryID:       infra.Spec.Registry.AWS.RegistryID,
-					AssumeRoleARN:    infra.Spec.Registry.AWS.AssumeRoleARN,
-					ExternalID:       infra.Spec.Registry.AWS.ExternalID,
-					AccessKeySecret:  infra.Spec.Registry.AWS.CredentialsSecret.Name,
-					AccessKeyKey:     infra.Spec.Registry.AWS.CredentialsSecret.AccessKeyKey,
-					SecretKeyKey:     infra.Spec.Registry.AWS.CredentialsSecret.SecretKeyKey,
-					SessionTokenKey:  infra.Spec.Registry.AWS.CredentialsSecret.SessionTokenKey,
-					RegistryOverride: infra.Spec.Registry.AWS.Registry,
-				}
-			}
-		case infrav1alpha1.RegistryProviderGCP:
-			if infra.Spec.Registry.GCP != nil {
-				cfg.Registry.GCP = &apiconfig.RegistryGCPConfig{
-					Registry: infra.Spec.Registry.GCP.Registry,
-				}
-				if infra.Spec.Registry.GCP.ServiceAccountSecret != nil {
-					cfg.Registry.GCP.ServiceAccountSecret = infra.Spec.Registry.GCP.ServiceAccountSecret.Name
-					cfg.Registry.GCP.ServiceAccountKey = infra.Spec.Registry.GCP.ServiceAccountSecret.Key
-				}
-			}
-		case infrav1alpha1.RegistryProviderAzure:
-			if infra.Spec.Registry.Azure != nil {
-				cfg.Registry.Azure = &apiconfig.RegistryAzureConfig{
-					Registry:          infra.Spec.Registry.Azure.Registry,
-					CredentialsSecret: infra.Spec.Registry.Azure.CredentialsSecret.Name,
-					TenantIDKey:       infra.Spec.Registry.Azure.CredentialsSecret.TenantIDKey,
-					ClientIDKey:       infra.Spec.Registry.Azure.CredentialsSecret.ClientIDKey,
-					ClientSecretKey:   infra.Spec.Registry.Azure.CredentialsSecret.ClientSecretKey,
-				}
-			}
-		case infrav1alpha1.RegistryProviderAliyun:
-			if infra.Spec.Registry.Aliyun != nil {
-				cfg.Registry.Aliyun = &apiconfig.RegistryAliyunConfig{
-					Registry:          infra.Spec.Registry.Aliyun.Registry,
-					Region:            infra.Spec.Registry.Aliyun.Region,
-					InstanceID:        infra.Spec.Registry.Aliyun.InstanceID,
-					CredentialsSecret: infra.Spec.Registry.Aliyun.CredentialsSecret.Name,
-					AccessKeyKey:      infra.Spec.Registry.Aliyun.CredentialsSecret.AccessKeyKey,
-					SecretKeyKey:      infra.Spec.Registry.Aliyun.CredentialsSecret.SecretKeyKey,
-				}
-			}
-		case infrav1alpha1.RegistryProviderHarbor:
-			if infra.Spec.Registry.Harbor != nil {
-				cfg.Registry.Harbor = &apiconfig.RegistryHarborConfig{
-					Registry:          infra.Spec.Registry.Harbor.Registry,
-					CredentialsSecret: infra.Spec.Registry.Harbor.CredentialsSecret.Name,
-					UsernameKey:       infra.Spec.Registry.Harbor.CredentialsSecret.UsernameKey,
-					PasswordKey:       infra.Spec.Registry.Harbor.CredentialsSecret.PasswordKey,
-				}
-			}
-		}
-	}
-
-	storageProxyConfig := &apiconfig.StorageProxyConfig{}
-	storageProxyServiceConfig := (*infrav1alpha1.ServiceNetworkConfig)(nil)
-	if infra.Spec.Services != nil && infra.Spec.Services.StorageProxy != nil {
-		storageProxyConfig = runtimeconfig.ToStorageProxy(infra.Spec.Services.StorageProxy.Config)
-	}
-	if infra.Spec.Services != nil && infra.Spec.Services.StorageProxy != nil {
-		storageProxyServiceConfig = infra.Spec.Services.StorageProxy.Service
-	}
-
-	if infrav1alpha1.IsStorageProxyEnabled(infra) {
-		cfg.ProcdConfig.StorageProxyBaseURL = fmt.Sprintf("%s-storage-proxy.%s.svc.cluster.local", infra.Name, infra.Namespace)
-		cfg.ProcdConfig.StorageProxyPort = int(common.ResolveServicePort(storageProxyServiceConfig, int32(storageProxyConfig.GRPCPort)))
-	} else {
-		cfg.ProcdConfig.StorageProxyBaseURL = ""
-		cfg.ProcdConfig.StorageProxyPort = 0
-	}
-
-	// Copy public exposure config from CRD top-level spec for generating public URLs
-	if infra.Spec.PublicExposure != nil {
-		cfg.PublicRootDomain = infra.Spec.PublicExposure.RootDomain
-		cfg.PublicRegionID = infra.Spec.PublicExposure.RegionID
-	}
 
 	return cfg, nil
 }

--- a/infra-operator/internal/controller/services/manager/manager_test.go
+++ b/infra-operator/internal/controller/services/manager/manager_test.go
@@ -114,7 +114,7 @@ func TestBuildConfigPropagatesNetdMITMCASecretName(t *testing.T) {
 			},
 		}
 
-		cfg, err := reconciler.buildConfig(context.Background(), infra, "sandbox0/manager", "test", infraplan.Compile(infra))
+		cfg, err := reconciler.buildConfig(context.Background(), "sandbox0/manager", "test", infraplan.Compile(infra))
 		if err != nil {
 			t.Fatalf("buildConfig returned error: %v", err)
 		}
@@ -152,7 +152,7 @@ func TestBuildConfigPropagatesNetdMITMCASecretName(t *testing.T) {
 			},
 		}
 
-		cfg, err := reconciler.buildConfig(context.Background(), infra, "sandbox0/manager", "test", infraplan.Compile(infra))
+		cfg, err := reconciler.buildConfig(context.Background(), "sandbox0/manager", "test", infraplan.Compile(infra))
 		if err != nil {
 			t.Fatalf("buildConfig returned error: %v", err)
 		}
@@ -201,7 +201,7 @@ func TestBuildConfigPreservesSandboxRuntimeClassName(t *testing.T) {
 		},
 	}
 
-	cfg, err := reconciler.buildConfig(context.Background(), infra, "sandbox0/manager", "test", infraplan.Compile(infra))
+	cfg, err := reconciler.buildConfig(context.Background(), "sandbox0/manager", "test", infraplan.Compile(infra))
 	if err != nil {
 		t.Fatalf("buildConfig returned error: %v", err)
 	}
@@ -238,7 +238,7 @@ func TestBuildConfigEnablesCtldWhenManagerIsEnabled(t *testing.T) {
 		},
 	}
 
-	cfg, err := reconciler.buildConfig(context.Background(), infra, "sandbox0/manager", "test", infraplan.Compile(infra))
+	cfg, err := reconciler.buildConfig(context.Background(), "sandbox0/manager", "test", infraplan.Compile(infra))
 	if err != nil {
 		t.Fatalf("buildConfig returned error: %v", err)
 	}

--- a/infra-operator/internal/controller/services/netd/mitm_ca.go
+++ b/infra-operator/internal/controller/services/netd/mitm_ca.go
@@ -18,11 +18,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	infrav1alpha1 "github.com/sandbox0-ai/sandbox0/infra-operator/api/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/pkg/common"
+	plan "github.com/sandbox0-ai/sandbox0/infra-operator/internal/plan"
 )
 
 const (
@@ -30,8 +30,8 @@ const (
 	mitmCAKeyKey  = "ca.key"
 )
 
-func managedMITMCASecretName(infra *infrav1alpha1.Sandbox0Infra) string {
-	return fmt.Sprintf("%s-netd-mitm-ca", infra.Name)
+func managedMITMCASecretName(infraName string) string {
+	return fmt.Sprintf("%s-netd-mitm-ca", infraName)
 }
 
 func ResolveMITMCASecretName(infra *infrav1alpha1.Sandbox0Infra) string {
@@ -46,37 +46,44 @@ func ResolveMITMCASecretName(infra *infrav1alpha1.Sandbox0Infra) string {
 	if infra.Name == "" {
 		return ""
 	}
-	return managedMITMCASecretName(infra)
+	return managedMITMCASecretName(infra.Name)
 }
 
 func EnsureMITMCASecret(ctx context.Context, resources *common.ResourceManager, infra *infrav1alpha1.Sandbox0Infra, labels map[string]string) (string, error) {
-	if infra == nil || infra.Spec.Services == nil || infra.Spec.Services.Netd == nil {
+	if infra == nil {
+		return "", nil
+	}
+	return EnsureMITMCASecretWithScope(ctx, resources, common.NewObjectScope(infra), plan.Compile(infra), labels)
+}
+
+func EnsureMITMCASecretWithScope(ctx context.Context, resources *common.ResourceManager, scope common.ObjectScope, compiledPlan *plan.InfraPlan, labels map[string]string) (string, error) {
+	if compiledPlan == nil || !compiledPlan.Netd.Enabled {
 		return "", nil
 	}
 	if resources == nil || resources.Client == nil || resources.Scheme == nil {
 		return "", fmt.Errorf("resource manager with client and scheme is required")
 	}
 
-	if secretName := strings.TrimSpace(infra.Spec.Services.Netd.MITMCASecretName); secretName != "" {
-		if err := validateExistingMITMCASecret(ctx, resources.Client, infra.Namespace, secretName); err != nil {
+	secretName := compiledPlan.ResolveNetdMITMCASecretName()
+	if secretName == "" {
+		return "", nil
+	}
+	if secretName != managedMITMCASecretName(scope.Name) {
+		if err := validateExistingMITMCASecret(ctx, resources.Client, scope.Namespace, secretName); err != nil {
 			return "", err
 		}
 		return secretName, nil
 	}
 
-	if infra.Name == "" {
-		return "", nil
-	}
-	secretName := managedMITMCASecretName(infra)
-	if err := reconcileManagedMITMCASecret(ctx, resources.Client, resources.Scheme, infra, secretName, labels); err != nil {
+	if err := reconcileManagedMITMCASecret(ctx, resources.Client, resources.Scheme, scope, secretName, labels); err != nil {
 		return "", err
 	}
 	return secretName, nil
 }
 
-func reconcileManagedMITMCASecret(ctx context.Context, client ctrlclient.Client, scheme *runtime.Scheme, infra *infrav1alpha1.Sandbox0Infra, name string, labels map[string]string) error {
+func reconcileManagedMITMCASecret(ctx context.Context, client ctrlclient.Client, scheme *runtime.Scheme, scope common.ObjectScope, name string, labels map[string]string) error {
 	secret := &corev1.Secret{}
-	getErr := client.Get(ctx, types.NamespacedName{Name: name, Namespace: infra.Namespace}, secret)
+	getErr := client.Get(ctx, types.NamespacedName{Name: name, Namespace: scope.Namespace}, secret)
 	if getErr != nil && !apierrors.IsNotFound(getErr) {
 		return getErr
 	}
@@ -85,7 +92,7 @@ func reconcileManagedMITMCASecret(ctx context.Context, client ctrlclient.Client,
 		return nil
 	}
 
-	certPEM, keyPEM, err := generateManagedMITMCA(infra)
+	certPEM, keyPEM, err := generateManagedMITMCA(scope.Name)
 	if err != nil {
 		return err
 	}
@@ -93,7 +100,7 @@ func reconcileManagedMITMCASecret(ctx context.Context, client ctrlclient.Client,
 	desired := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: infra.Namespace,
+			Namespace: scope.Namespace,
 			Labels:    labels,
 		},
 		Type: corev1.SecretTypeOpaque,
@@ -102,7 +109,7 @@ func reconcileManagedMITMCASecret(ctx context.Context, client ctrlclient.Client,
 			mitmCAKeyKey:  keyPEM,
 		},
 	}
-	if err := ctrl.SetControllerReference(infra, desired, scheme); err != nil {
+	if err := scope.SetControllerReference(desired, scheme); err != nil {
 		return err
 	}
 
@@ -152,7 +159,7 @@ func validateMITMCASecret(secret *corev1.Secret) error {
 	return nil
 }
 
-func generateManagedMITMCA(infra *infrav1alpha1.Sandbox0Infra) ([]byte, []byte, error) {
+func generateManagedMITMCA(infraName string) ([]byte, []byte, error) {
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return nil, nil, fmt.Errorf("generate MITM CA key: %w", err)
@@ -164,8 +171,8 @@ func generateManagedMITMCA(infra *infrav1alpha1.Sandbox0Infra) ([]byte, []byte, 
 	}
 
 	commonName := "sandbox0-netd-mitm-ca"
-	if infra != nil && infra.Name != "" {
-		commonName = fmt.Sprintf("sandbox0-netd-mitm-ca.%s", infra.Name)
+	if infraName != "" {
+		commonName = fmt.Sprintf("sandbox0-netd-mitm-ca.%s", infraName)
 	}
 	now := time.Now().UTC()
 	template := &x509.Certificate{

--- a/infra-operator/internal/controller/services/netd/netd.go
+++ b/infra-operator/internal/controller/services/netd/netd.go
@@ -15,10 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	apiconfig "github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
-	infrav1alpha1 "github.com/sandbox0-ai/sandbox0/infra-operator/api/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/pkg/common"
-	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/database"
-	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/internalauth"
 	infraplan "github.com/sandbox0-ai/sandbox0/infra-operator/internal/plan"
 	pkginternalauth "github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 )
@@ -31,10 +28,10 @@ func NewReconciler(resources *common.ResourceManager) *Reconciler {
 	return &Reconciler{Resources: resources}
 }
 
-func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, imageRepo, imageTag string, compiledPlan *infraplan.InfraPlan) error {
+func (r *Reconciler) Reconcile(ctx context.Context, imageRepo, imageTag string, compiledPlan *infraplan.InfraPlan) error {
 	logger := log.FromContext(ctx)
 	if compiledPlan == nil {
-		compiledPlan = infraplan.Compile(infra)
+		return fmt.Errorf("compiled plan is required")
 	}
 	if !compiledPlan.Netd.Enabled {
 		logger.Info("netd is disabled, skipping")
@@ -45,8 +42,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 		return nil
 	}
 
-	name := fmt.Sprintf("%s-netd", infra.Name)
-	labels := common.GetServiceLabels(infra.Name, "netd")
+	scope := compiledPlan.Scope
+	name := fmt.Sprintf("%s-netd", scope.Name)
+	labels := common.GetServiceLabels(scope.Name, "netd")
 	image := fmt.Sprintf("%s:%s", imageRepo, imageTag)
 	pullPolicy := corev1.PullIfNotPresent
 	if r.Resources.ImagePullPolicy != nil {
@@ -76,21 +74,19 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 		}
 		config.ClusterDNSCIDR = cidr
 	}
-	if infra.Spec.Database != nil {
-		if dsn, err := database.GetDatabaseDSN(ctx, r.Resources.Client, infra); err == nil {
-			config.DatabaseURL = dsn
-		}
+	if dsn, err := compiledPlan.DatabaseDSN(ctx, r.Resources.Client); err == nil {
+		config.DatabaseURL = dsn
 	}
 	config.RegionID = compiledPlan.Netd.RegionID
 	config.ClusterID = compiledPlan.Netd.ClusterID
 	if config.EgressAuthResolverURL == "" {
 		config.EgressAuthResolverURL = compiledPlan.Netd.EgressAuthResolverURL
 	}
-	mitmCASecretName, err := r.resolveMITMCASecretName(ctx, infra, labels)
+	mitmCASecretName, err := r.resolveMITMCASecretName(ctx, compiledPlan, labels)
 	if err != nil {
 		return err
 	}
-	keySecretName, privateKeyKey, _ := internalauth.GetDataPlaneKeyRefs(infra)
+	keySecretName, privateKeyKey, _ := compiledPlan.DataPlaneKeyRefs()
 	if mitmCASecretName != "" {
 		if config.MITMCACertPath == "" {
 			config.MITMCACertPath = "/tls/ca.crt"
@@ -104,7 +100,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 		return err
 	}
 
-	if err := r.Resources.ReconcileServiceConfigMap(ctx, infra, name, labels, config); err != nil {
+	if err := r.Resources.ReconcileServiceConfigMapWithScope(ctx, scope, name, labels, config); err != nil {
 		return err
 	}
 
@@ -203,7 +199,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 	desired := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: infra.Namespace,
+			Namespace: scope.Namespace,
 		},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{
@@ -282,11 +278,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 		},
 	}
 
-	return r.Resources.ApplyDaemonSet(ctx, infra, desired)
+	return r.Resources.ApplyDaemonSetWithScope(ctx, scope, desired)
 }
 
-func (r *Reconciler) resolveMITMCASecretName(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, labels map[string]string) (string, error) {
-	return EnsureMITMCASecret(ctx, r.Resources, infra, labels)
+func (r *Reconciler) resolveMITMCASecretName(ctx context.Context, compiledPlan *infraplan.InfraPlan, labels map[string]string) (string, error) {
+	return EnsureMITMCASecretWithScope(ctx, r.Resources, compiledPlan.Scope, compiledPlan, labels)
 }
 
 func resolveClusterDNSCIDR(ctx context.Context, client ctrlclient.Client, logger logr.Logger) (string, error) {

--- a/infra-operator/internal/controller/services/netd/netd.go
+++ b/infra-operator/internal/controller/services/netd/netd.go
@@ -20,7 +20,6 @@ import (
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/database"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/internalauth"
 	infraplan "github.com/sandbox0-ai/sandbox0/infra-operator/internal/plan"
-	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/runtimeconfig"
 	pkginternalauth "github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 )
 
@@ -37,11 +36,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 	if compiledPlan == nil {
 		compiledPlan = infraplan.Compile(infra)
 	}
-	if infra.Spec.Services != nil && infra.Spec.Services.Netd != nil && !infra.Spec.Services.Netd.Enabled {
+	if !compiledPlan.Netd.Enabled {
 		logger.Info("netd is disabled, skipping")
 		return nil
 	}
-	if !infrav1alpha1.HasDataPlaneServices(infra) {
+	if !compiledPlan.Components.HasDataPlane {
 		logger.Info("Data-plane services are disabled, skipping netd")
 		return nil
 	}
@@ -55,16 +54,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 	}
 
 	config := &apiconfig.NetdConfig{}
-	runtimeClassName := (*string)(nil)
-	nodeSelector := map[string]string(nil)
-	tolerations := []corev1.Toleration(nil)
-	if infra.Spec.Services != nil && infra.Spec.Services.Netd != nil {
-		config = runtimeconfig.ToNetd(infra.Spec.Services.Netd.Config)
+	if compiledPlan.Netd.Config != nil {
+		config = compiledPlan.Netd.Config.DeepCopy()
 	}
-	if infra.Spec.Services != nil && infra.Spec.Services.Netd != nil {
-		runtimeClassName = infra.Spec.Services.Netd.RuntimeClassName
-	}
-	nodeSelector, tolerations = compiledPlan.Netd.NodeSelector, compiledPlan.Netd.Tolerations
+	runtimeClassName := compiledPlan.Netd.RuntimeClassName
+	nodeSelector := compiledPlan.Netd.NodeSelector
+	tolerations := compiledPlan.Netd.Tolerations
 	if config.NodeName == "" {
 		config.NodeName = "${NODE_NAME}"
 	}

--- a/infra-operator/internal/controller/services/netd/netd_test.go
+++ b/infra-operator/internal/controller/services/netd/netd_test.go
@@ -95,7 +95,7 @@ func TestReconcileMountsExplicitMITMCASecret(t *testing.T) {
 	client, scheme := newNetdTestClient(t, infra.DeepCopy(), newExplicitMITMCASecret(t, infra, "netd-mitm-ca"))
 
 	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
-	if err := reconciler.Reconcile(context.Background(), infra, "ghcr.io/sandbox0-ai/sandbox0", "latest", nil); err != nil {
+	if err := reconciler.Reconcile(context.Background(), "ghcr.io/sandbox0-ai/sandbox0", "latest", infraplan.Compile(infra)); err != nil {
 		t.Fatalf("reconcile returned error: %v", err)
 	}
 
@@ -107,11 +107,11 @@ func TestReconcileAutoGeneratesManagedMITMCASecret(t *testing.T) {
 	client, scheme := newNetdTestClient(t, infra.DeepCopy())
 
 	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
-	if err := reconciler.Reconcile(context.Background(), infra, "ghcr.io/sandbox0-ai/sandbox0", "latest", nil); err != nil {
+	if err := reconciler.Reconcile(context.Background(), "ghcr.io/sandbox0-ai/sandbox0", "latest", infraplan.Compile(infra)); err != nil {
 		t.Fatalf("reconcile returned error: %v", err)
 	}
 
-	secretName := managedMITMCASecretName(infra)
+	secretName := managedMITMCASecretName(infra.Name)
 	assertNetdMITMSecretMounted(t, client, infra, secretName)
 
 	secret := &corev1.Secret{}
@@ -132,11 +132,11 @@ func TestReconcileReusesManagedMITMCASecretAcrossReconciles(t *testing.T) {
 	client, scheme := newNetdTestClient(t, infra.DeepCopy())
 	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
 
-	if err := reconciler.Reconcile(context.Background(), infra, "ghcr.io/sandbox0-ai/sandbox0", "latest", nil); err != nil {
+	if err := reconciler.Reconcile(context.Background(), "ghcr.io/sandbox0-ai/sandbox0", "latest", infraplan.Compile(infra)); err != nil {
 		t.Fatalf("first reconcile returned error: %v", err)
 	}
 
-	secretName := managedMITMCASecretName(infra)
+	secretName := managedMITMCASecretName(infra.Name)
 	secret := &corev1.Secret{}
 	if err := client.Get(context.Background(), types.NamespacedName{
 		Name:      secretName,
@@ -147,7 +147,7 @@ func TestReconcileReusesManagedMITMCASecretAcrossReconciles(t *testing.T) {
 	firstCert := append([]byte(nil), secret.Data[mitmCACertKey]...)
 	firstKey := append([]byte(nil), secret.Data[mitmCAKeyKey]...)
 
-	if err := reconciler.Reconcile(context.Background(), infra, "ghcr.io/sandbox0-ai/sandbox0", "latest", nil); err != nil {
+	if err := reconciler.Reconcile(context.Background(), "ghcr.io/sandbox0-ai/sandbox0", "latest", infraplan.Compile(infra)); err != nil {
 		t.Fatalf("second reconcile returned error: %v", err)
 	}
 	if err := client.Get(context.Background(), types.NamespacedName{
@@ -165,7 +165,7 @@ func TestReconcileRepairsInvalidManagedMITMCASecret(t *testing.T) {
 	infra := newNetdTestInfra()
 	invalidSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      managedMITMCASecretName(infra),
+			Name:      managedMITMCASecretName(infra.Name),
 			Namespace: infra.Namespace,
 		},
 		Type: corev1.SecretTypeOpaque,
@@ -177,13 +177,13 @@ func TestReconcileRepairsInvalidManagedMITMCASecret(t *testing.T) {
 	client, scheme := newNetdTestClient(t, infra.DeepCopy(), invalidSecret)
 	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
 
-	if err := reconciler.Reconcile(context.Background(), infra, "ghcr.io/sandbox0-ai/sandbox0", "latest", nil); err != nil {
+	if err := reconciler.Reconcile(context.Background(), "ghcr.io/sandbox0-ai/sandbox0", "latest", infraplan.Compile(infra)); err != nil {
 		t.Fatalf("reconcile returned error: %v", err)
 	}
 
 	secret := &corev1.Secret{}
 	if err := client.Get(context.Background(), types.NamespacedName{
-		Name:      managedMITMCASecretName(infra),
+		Name:      managedMITMCASecretName(infra.Name),
 		Namespace: infra.Namespace,
 	}, secret); err != nil {
 		t.Fatalf("expected repaired secret: %v", err)
@@ -197,7 +197,7 @@ func TestReconcileExplicitMITMCASecretSkipsManagedSecret(t *testing.T) {
 	client, scheme := newNetdTestClient(t, infra.DeepCopy(), newExplicitMITMCASecret(t, infra, "custom-mitm-ca"))
 	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
 
-	if err := reconciler.Reconcile(context.Background(), infra, "ghcr.io/sandbox0-ai/sandbox0", "latest", nil); err != nil {
+	if err := reconciler.Reconcile(context.Background(), "ghcr.io/sandbox0-ai/sandbox0", "latest", infraplan.Compile(infra)); err != nil {
 		t.Fatalf("reconcile returned error: %v", err)
 	}
 
@@ -205,7 +205,7 @@ func TestReconcileExplicitMITMCASecretSkipsManagedSecret(t *testing.T) {
 
 	managedSecret := &corev1.Secret{}
 	err := client.Get(context.Background(), types.NamespacedName{
-		Name:      managedMITMCASecretName(infra),
+		Name:      managedMITMCASecretName(infra.Name),
 		Namespace: infra.Namespace,
 	}, managedSecret)
 	if !apierrors.IsNotFound(err) {
@@ -218,7 +218,7 @@ func reconcileNetdDaemonSet(t *testing.T, infra *infrav1alpha1.Sandbox0Infra) *a
 
 	client, scheme := newNetdTestClient(t, infra.DeepCopy())
 	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
-	if err := reconciler.Reconcile(context.Background(), infra, "ghcr.io/sandbox0-ai/sandbox0", "latest", nil); err != nil {
+	if err := reconciler.Reconcile(context.Background(), "ghcr.io/sandbox0-ai/sandbox0", "latest", infraplan.Compile(infra)); err != nil {
 		t.Fatalf("reconcile returned error: %v", err)
 	}
 
@@ -240,7 +240,7 @@ func TestReconcileUsesCompiledPlanForEgressAuthResolverURL(t *testing.T) {
 	compiled := infraplan.Compile(infra)
 	compiled.Netd.EgressAuthResolverURL = "http://planned-manager.sandbox0-system.svc.cluster.local:19090"
 
-	if err := reconciler.Reconcile(context.Background(), infra, "ghcr.io/sandbox0-ai/sandbox0", "latest", compiled); err != nil {
+	if err := reconciler.Reconcile(context.Background(), "ghcr.io/sandbox0-ai/sandbox0", "latest", compiled); err != nil {
 		t.Fatalf("reconcile returned error: %v", err)
 	}
 
@@ -356,7 +356,7 @@ func assertValidManagedMITMCASecret(t *testing.T, secret *corev1.Secret) {
 func newExplicitMITMCASecret(t *testing.T, infra *infrav1alpha1.Sandbox0Infra, name string) *corev1.Secret {
 	t.Helper()
 
-	certPEM, keyPEM, err := generateManagedMITMCA(infra)
+	certPEM, keyPEM, err := generateManagedMITMCA(infra.Name)
 	if err != nil {
 		t.Fatalf("generate explicit mitm ca secret: %v", err)
 	}

--- a/infra-operator/internal/controller/services/regionalgateway/regionalgateway.go
+++ b/infra-operator/internal/controller/services/regionalgateway/regionalgateway.go
@@ -37,7 +37,6 @@ import (
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/internalauth"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/registry"
 	infraplan "github.com/sandbox0-ai/sandbox0/infra-operator/internal/plan"
-	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/runtimeconfig"
 	pkginternalauth "github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 )
 
@@ -57,7 +56,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 	}
 
 	// Skip if not enabled
-	if infra.Spec.Services != nil && infra.Spec.Services.RegionalGateway != nil && !infra.Spec.Services.RegionalGateway.Enabled {
+	if !compiledPlan.RegionalGateway.Enabled {
 		logger.Info("Edge gateway is disabled, skipping")
 		return nil
 	}
@@ -65,10 +64,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 	deploymentName := fmt.Sprintf("%s-regional-gateway", infra.Name)
 	serviceName := deploymentName
 
-	replicas := int32(1)
-	if infra.Spec.Services != nil && infra.Spec.Services.RegionalGateway != nil {
-		replicas = infra.Spec.Services.RegionalGateway.Replicas
-	}
+	replicas := compiledPlan.RegionalGateway.Replicas
 
 	labels := common.GetServiceLabels(infra.Name, "regional-gateway")
 	keySecretName, privateKeyKey, publicKeyKey := internalauth.GetControlPlaneKeyRefs(infra)
@@ -87,12 +83,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 		return err
 	}
 
-	var resources *corev1.ResourceRequirements
-	serviceConfig := (*infrav1alpha1.ServiceNetworkConfig)(nil)
-	if infra.Spec.Services != nil && infra.Spec.Services.RegionalGateway != nil {
-		resources = infra.Spec.Services.RegionalGateway.Resources
-		serviceConfig = infra.Spec.Services.RegionalGateway.Service
-	}
+	resources := compiledPlan.RegionalGateway.Resources
+	serviceConfig := compiledPlan.RegionalGateway.ServiceConfig
 	tlsEnabled := strings.TrimSpace(config.TLSCertPath) != "" && strings.TrimSpace(config.TLSKeyPath) != ""
 	containerPortName := "http"
 	if tlsEnabled {
@@ -285,9 +277,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 	}
 
 	// Create ingress if enabled
-	if infra.Spec.Services != nil && infra.Spec.Services.RegionalGateway != nil &&
-		infra.Spec.Services.RegionalGateway.Ingress != nil && infra.Spec.Services.RegionalGateway.Ingress.Enabled {
-		if err := r.Resources.ReconcileIngress(ctx, infra, serviceName, servicePort, infra.Spec.Services.RegionalGateway.Ingress); err != nil {
+	if compiledPlan.RegionalGateway.IngressConfig != nil && compiledPlan.RegionalGateway.IngressConfig.Enabled {
+		if err := r.Resources.ReconcileIngress(ctx, infra, serviceName, servicePort, compiledPlan.RegionalGateway.IngressConfig); err != nil {
 			return err
 		}
 	} else {
@@ -306,11 +297,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 
 func (r *Reconciler) buildConfig(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, compiledPlan *infraplan.InfraPlan) (*apiconfig.RegionalGatewayConfig, []corev1.EnvVar, error) {
 	cfg := &apiconfig.RegionalGatewayConfig{}
-	if infra.Spec.Services != nil && infra.Spec.Services.RegionalGateway != nil {
-		cfg = runtimeconfig.ToRegionalGateway(infra.Spec.Services.RegionalGateway.Config)
-	}
 	if compiledPlan == nil {
 		compiledPlan = infraplan.Compile(infra)
+	}
+	if compiledPlan.RegionalGateway.Config != nil {
+		cfg = compiledPlan.RegionalGateway.Config.DeepCopy()
 	}
 
 	if dsn, err := database.GetDatabaseDSN(ctx, r.Resources.Client, infra); err == nil {
@@ -318,17 +309,7 @@ func (r *Reconciler) buildConfig(ctx context.Context, infra *infrav1alpha1.Sandb
 	}
 	cfg.DefaultClusterGatewayURL = compiledPlan.RegionalGateway.DefaultClusterGatewayURL
 	cfg.SchedulerEnabled = compiledPlan.Components.EnableScheduler
-	if compiledPlan.Services.Scheduler.URL != "" {
-		cfg.SchedulerURL = compiledPlan.Services.Scheduler.URL
-	}
-	sshPort := int32(2222)
-	if infra.Spec.Services != nil && infra.Spec.Services.SSHGateway != nil && infra.Spec.Services.SSHGateway.Config != nil && infra.Spec.Services.SSHGateway.Config.SSHPort != 0 {
-		sshPort = int32(infra.Spec.Services.SSHGateway.Config.SSHPort)
-	}
-	if sshHost, advertisedPort, ok := common.ResolveSSHEndpoint(infra, sshPort); ok {
-		cfg.SSHEndpointHost = sshHost
-		cfg.SSHEndpointPort = int(advertisedPort)
-	}
+	cfg.SchedulerURL = compiledPlan.Services.Scheduler.URL
 
 	authMode := strings.TrimSpace(strings.ToLower(cfg.AuthMode))
 	if authMode == "" {
@@ -394,24 +375,6 @@ func (r *Reconciler) buildConfig(ctx context.Context, infra *infrav1alpha1.Sandb
 			cfg.JWTSecret = jwtSecret
 		}
 	}
-
-	if strings.TrimSpace(infra.Spec.Region) != "" {
-		cfg.RegionID = infra.Spec.Region
-	}
-
-	// Copy public exposure config from CRD top-level spec
-	if infra.Spec.PublicExposure != nil {
-		cfg.PublicExposureEnabled = infra.Spec.PublicExposure.Enabled
-		cfg.PublicRootDomain = infra.Spec.PublicExposure.RootDomain
-		cfg.PublicRegionID = infra.Spec.PublicExposure.RegionID
-	}
-	if base := strings.TrimSpace(cfg.BaseURL); base != "" {
-		if parsed, err := url.Parse(base); err == nil && strings.EqualFold(parsed.Scheme, "https") {
-			cfg.TLSCertPath = "/tls/tls.crt"
-			cfg.TLSKeyPath = "/tls/tls.key"
-		}
-	}
-
 	registryEnvVars, err := r.applyRegistryConfig(infra, cfg)
 	if err != nil {
 		return nil, nil, err

--- a/infra-operator/internal/controller/services/regionalgateway/regionalgateway.go
+++ b/infra-operator/internal/controller/services/regionalgateway/regionalgateway.go
@@ -33,9 +33,6 @@ import (
 	infrav1alpha1 "github.com/sandbox0-ai/sandbox0/infra-operator/api/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/pkg/common"
 	webhookcerts "github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/pkg/webhook"
-	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/database"
-	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/internalauth"
-	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/registry"
 	infraplan "github.com/sandbox0-ai/sandbox0/infra-operator/internal/plan"
 	pkginternalauth "github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 )
@@ -49,10 +46,10 @@ func NewReconciler(resources *common.ResourceManager) *Reconciler {
 }
 
 // Reconcile reconciles the regional-gateway deployment.
-func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, imageRepo, imageTag string, compiledPlan *infraplan.InfraPlan) error {
+func (r *Reconciler) Reconcile(ctx context.Context, imageRepo, imageTag string, compiledPlan *infraplan.InfraPlan) error {
 	logger := log.FromContext(ctx)
 	if compiledPlan == nil {
-		compiledPlan = infraplan.Compile(infra)
+		return fmt.Errorf("compiled plan is required")
 	}
 
 	// Skip if not enabled
@@ -61,15 +58,16 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 		return nil
 	}
 
-	deploymentName := fmt.Sprintf("%s-regional-gateway", infra.Name)
+	scope := compiledPlan.Scope
+	deploymentName := fmt.Sprintf("%s-regional-gateway", scope.Name)
 	serviceName := deploymentName
 
 	replicas := compiledPlan.RegionalGateway.Replicas
 
-	labels := common.GetServiceLabels(infra.Name, "regional-gateway")
-	keySecretName, privateKeyKey, publicKeyKey := internalauth.GetControlPlaneKeyRefs(infra)
+	labels := common.GetServiceLabels(scope.Name, "regional-gateway")
+	keySecretName, privateKeyKey, publicKeyKey := compiledPlan.ControlPlaneKeyRefs()
 
-	config, registryEnvVars, err := r.buildConfig(ctx, infra, compiledPlan)
+	config, registryEnvVars, err := r.buildConfig(ctx, compiledPlan)
 	if err != nil {
 		return err
 	}
@@ -79,7 +77,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 	if err != nil {
 		return err
 	}
-	if err := r.Resources.ReconcileServiceConfigMap(ctx, infra, deploymentName, labels, config); err != nil {
+	if err := r.Resources.ReconcileServiceConfigMapWithScope(ctx, scope, deploymentName, labels, config); err != nil {
 		return err
 	}
 
@@ -150,15 +148,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 		},
 	}
 	if needEnterpriseLicense {
-		volumeMounts, volumes = common.AppendEnterpriseLicenseVolume(infra, config.LicenseFile, volumeMounts, volumes)
+		volumeMounts, volumes = common.AppendEnterpriseLicenseVolumeWithSecretRef(compiledPlan.EnterpriseLicenseSecretRef(), config.LicenseFile, volumeMounts, volumes)
 	}
 	if tlsEnabled {
-		tlsSecretName := fmt.Sprintf("%s-regional-gateway-tls", infra.Name)
+		tlsSecretName := fmt.Sprintf("%s-regional-gateway-tls", scope.Name)
 		dnsNames := regionalGatewayTLSDNSNames(config)
 		if len(dnsNames) == 0 {
 			return fmt.Errorf("regional-gateway TLS enabled but no DNS names were derived")
 		}
-		if err := webhookcerts.NewReconciler(r.Resources).ReconcileCertSecret(ctx, infra, tlsSecretName, labels, dnsNames); err != nil {
+		if err := webhookcerts.NewReconciler(r.Resources).ReconcileCertSecretWithScope(ctx, scope, tlsSecretName, labels, dnsNames); err != nil {
 			return err
 		}
 		volumeMounts = append(volumeMounts,
@@ -199,7 +197,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 
 	// Create deployment
 	httpPort := int32(config.HTTPPort)
-	if err := r.Resources.ReconcileDeployment(ctx, infra, deploymentName, labels, replicas, common.ServiceDefinition{
+	if err := r.Resources.ReconcileDeploymentWithScope(ctx, scope, deploymentName, labels, replicas, common.ServiceDefinition{
 		Name:       "regional-gateway",
 		Port:       httpPort,
 		TargetPort: httpPort,
@@ -254,7 +252,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 		appProtocol := "HTTPS"
 		serviceAppProtocol = &appProtocol
 	}
-	if err := r.Resources.ReconcileServicePortsWithSpecMutator(ctx, infra, serviceName, labels, serviceType, serviceAnnotations, []corev1.ServicePort{
+	if err := r.Resources.ReconcileServicePortsWithScopeAndSpecMutator(ctx, scope, serviceName, labels, serviceType, serviceAnnotations, []corev1.ServicePort{
 		{
 			Name:        servicePortName,
 			Port:        servicePort,
@@ -278,16 +276,16 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 
 	// Create ingress if enabled
 	if compiledPlan.RegionalGateway.IngressConfig != nil && compiledPlan.RegionalGateway.IngressConfig.Enabled {
-		if err := r.Resources.ReconcileIngress(ctx, infra, serviceName, servicePort, compiledPlan.RegionalGateway.IngressConfig); err != nil {
+		if err := r.Resources.ReconcileIngressWithScope(ctx, scope, serviceName, servicePort, compiledPlan.RegionalGateway.IngressConfig); err != nil {
 			return err
 		}
 	} else {
-		if err := r.deleteIngressIfExists(ctx, infra, serviceName); err != nil {
+		if err := r.deleteIngressIfExists(ctx, scope, serviceName); err != nil {
 			return err
 		}
 	}
 
-	if err := r.Resources.EnsureDeploymentReady(ctx, infra, deploymentName, replicas); err != nil {
+	if err := r.Resources.EnsureDeploymentReadyWithScope(ctx, scope, deploymentName, replicas); err != nil {
 		return err
 	}
 
@@ -295,16 +293,16 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 	return nil
 }
 
-func (r *Reconciler) buildConfig(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, compiledPlan *infraplan.InfraPlan) (*apiconfig.RegionalGatewayConfig, []corev1.EnvVar, error) {
+func (r *Reconciler) buildConfig(ctx context.Context, compiledPlan *infraplan.InfraPlan) (*apiconfig.RegionalGatewayConfig, []corev1.EnvVar, error) {
 	cfg := &apiconfig.RegionalGatewayConfig{}
 	if compiledPlan == nil {
-		compiledPlan = infraplan.Compile(infra)
+		return nil, nil, fmt.Errorf("compiled plan is required")
 	}
 	if compiledPlan.RegionalGateway.Config != nil {
 		cfg = compiledPlan.RegionalGateway.Config.DeepCopy()
 	}
 
-	if dsn, err := database.GetDatabaseDSN(ctx, r.Resources.Client, infra); err == nil {
+	if dsn, err := compiledPlan.DatabaseDSN(ctx, r.Resources.Client); err == nil {
 		cfg.DatabaseURL = dsn
 	}
 	cfg.DefaultClusterGatewayURL = compiledPlan.RegionalGateway.DefaultClusterGatewayURL
@@ -315,35 +313,35 @@ func (r *Reconciler) buildConfig(ctx context.Context, infra *infrav1alpha1.Sandb
 	if authMode == "" {
 		authMode = "self_hosted"
 	}
-	if infra.Spec.InitUser != nil && authMode != "federated_global" {
+	if initUser := compiledPlan.InitUser(); initUser != nil && authMode != "federated_global" {
 		password := ""
 		if cfg.BuiltInAuth.Enabled || !apiconfig.HasEnabledOIDCProviders(cfg.OIDCProviders) {
-			secretRef := common.ResolveSecretKeyRef(infra.Spec.InitUser.PasswordSecret, "admin-password", "password")
+			secretRef := common.ResolveSecretKeyRef(initUser.PasswordSecret, "admin-password", "password")
 			var err error
-			password, err = common.GetSecretValue(ctx, r.Resources.Client, infra.Namespace, secretRef)
+			password, err = common.GetSecretValue(ctx, r.Resources.Client, compiledPlan.Scope.Namespace, secretRef)
 			if err != nil {
 				return nil, nil, err
 			}
 		}
 
 		cfg.BuiltInAuth.InitUser = &apiconfig.InitUserConfig{
-			Email:    infra.Spec.InitUser.Email,
+			Email:    initUser.Email,
 			Password: password,
-			Name:     infra.Spec.InitUser.Name,
+			Name:     initUser.Name,
 		}
 	}
 
 	if authMode == "federated_global" {
 		if strings.TrimSpace(cfg.JWTIssuer) == "" {
-			cfg.JWTIssuer = defaultFederatedGlobalJWTIssuer(infra)
+			cfg.JWTIssuer = compiledPlan.DefaultFederatedGlobalJWTIssuer()
 		}
 		if strings.TrimSpace(cfg.JWTPublicKeyPEM) == "" {
 			_, publicKeyPEM, err := common.EnsureEd25519KeyPair(
 				ctx,
 				r.Resources.Client,
 				r.Resources.Scheme,
-				infra,
-				sharedUserJWTSecretName(infra),
+				compiledPlan.Scope.Owner(),
+				compiledPlan.SharedUserJWTSecretName(),
 				"jwt_private_key_pem",
 				"jwt_public_key_pem",
 			)
@@ -364,8 +362,8 @@ func (r *Reconciler) buildConfig(ctx context.Context, infra *infrav1alpha1.Sandb
 				ctx,
 				r.Resources.Client,
 				r.Resources.Scheme,
-				infra,
-				fmt.Sprintf("%s-regional-gateway-jwt", infra.Name),
+				compiledPlan.Scope.Owner(),
+				compiledPlan.RegionalGatewayJWTSecretName(),
 				"jwt_secret",
 				32,
 			)
@@ -375,25 +373,12 @@ func (r *Reconciler) buildConfig(ctx context.Context, infra *infrav1alpha1.Sandb
 			cfg.JWTSecret = jwtSecret
 		}
 	}
-	registryEnvVars, err := r.applyRegistryConfig(infra, cfg)
+	registryEnvVars, err := compiledPlan.ConfigureRegionalGatewayRegistry(cfg)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	return cfg, registryEnvVars, nil
-}
-
-func defaultFederatedGlobalJWTIssuer(infra *infrav1alpha1.Sandbox0Infra) string {
-	if infra != nil && infra.Spec.Services != nil && infra.Spec.Services.GlobalGateway != nil && infra.Spec.Services.GlobalGateway.Config != nil {
-		if issuer := strings.TrimSpace(infra.Spec.Services.GlobalGateway.Config.JWTIssuer); issuer != "" {
-			return issuer
-		}
-	}
-	return "global-gateway"
-}
-
-func sharedUserJWTSecretName(infra *infrav1alpha1.Sandbox0Infra) string {
-	return fmt.Sprintf("%s-user-jwt", infra.Name)
 }
 
 func regionalGatewayTLSDNSNames(cfg *apiconfig.RegionalGatewayConfig) []string {
@@ -419,142 +404,12 @@ func probeSchemeForTLS(enabled bool) corev1.URIScheme {
 }
 
 func (r *Reconciler) applyRegistryConfig(infra *infrav1alpha1.Sandbox0Infra, cfg *apiconfig.RegionalGatewayConfig) ([]corev1.EnvVar, error) {
-	if !infrav1alpha1.IsRegistryEnabled(infra) {
-		return nil, nil
-	}
-
-	resolved := registry.ResolveRegistryConfig(infra)
-	if resolved == nil {
-		return nil, nil
-	}
-
-	cfg.Registry.Provider = string(resolved.Provider)
-	cfg.Registry.PushRegistry = resolved.PushRegistry
-	cfg.Registry.PullRegistry = resolved.PullRegistry
-	cfg.Registry.Namespace = infra.Namespace
-
-	switch resolved.Provider {
-	case infrav1alpha1.RegistryProviderBuiltin:
-		cfg.Registry.Builtin = &apiconfig.RegistryBuiltinConfig{
-			Username: "${S0_REGISTRY_BUILTIN_USERNAME}",
-			Password: "${S0_REGISTRY_BUILTIN_PASSWORD}",
-		}
-		secretName := fmt.Sprintf("%s-registry-auth", infra.Name)
-		return []corev1.EnvVar{
-			secretEnvVar("S0_REGISTRY_BUILTIN_USERNAME", secretName, "username"),
-			secretEnvVar("S0_REGISTRY_BUILTIN_PASSWORD", secretName, "password"),
-		}, nil
-	case infrav1alpha1.RegistryProviderAWS:
-		if infra.Spec.Registry == nil || infra.Spec.Registry.AWS == nil {
-			return nil, fmt.Errorf("registry.aws configuration is required")
-		}
-		cred := infra.Spec.Registry.AWS.CredentialsSecret
-		cfg.Registry.AWS = &apiconfig.RegistryAWSConfig{
-			Region:           infra.Spec.Registry.AWS.Region,
-			RegistryID:       infra.Spec.Registry.AWS.RegistryID,
-			AssumeRoleARN:    infra.Spec.Registry.AWS.AssumeRoleARN,
-			ExternalID:       infra.Spec.Registry.AWS.ExternalID,
-			RegistryOverride: infra.Spec.Registry.AWS.Registry,
-			AccessKeyID:      "${S0_REGISTRY_AWS_ACCESS_KEY_ID}",
-			SecretAccessKey:  "${S0_REGISTRY_AWS_SECRET_ACCESS_KEY}",
-		}
-		envVars := []corev1.EnvVar{
-			secretEnvVar("S0_REGISTRY_AWS_ACCESS_KEY_ID", cred.Name, defaultString(cred.AccessKeyKey, "accessKeyId")),
-			secretEnvVar("S0_REGISTRY_AWS_SECRET_ACCESS_KEY", cred.Name, defaultString(cred.SecretKeyKey, "secretAccessKey")),
-		}
-		if strings.TrimSpace(cred.SessionTokenKey) != "" {
-			cfg.Registry.AWS.SessionToken = "${S0_REGISTRY_AWS_SESSION_TOKEN}"
-			envVars = append(envVars, secretEnvVar("S0_REGISTRY_AWS_SESSION_TOKEN", cred.Name, cred.SessionTokenKey))
-		}
-		return envVars, nil
-	case infrav1alpha1.RegistryProviderGCP:
-		if infra.Spec.Registry == nil || infra.Spec.Registry.GCP == nil {
-			return nil, fmt.Errorf("registry.gcp configuration is required")
-		}
-		cfg.Registry.GCP = &apiconfig.RegistryGCPConfig{
-			Registry: infra.Spec.Registry.GCP.Registry,
-		}
-		if infra.Spec.Registry.GCP.ServiceAccountSecret == nil {
-			return nil, nil
-		}
-		sa := infra.Spec.Registry.GCP.ServiceAccountSecret
-		cfg.Registry.GCP.ServiceAccountJSON = "${S0_REGISTRY_GCP_SERVICE_ACCOUNT_JSON}"
-		return []corev1.EnvVar{
-			secretEnvVar("S0_REGISTRY_GCP_SERVICE_ACCOUNT_JSON", sa.Name, defaultString(sa.Key, "serviceAccount.json")),
-		}, nil
-	case infrav1alpha1.RegistryProviderAzure:
-		if infra.Spec.Registry == nil || infra.Spec.Registry.Azure == nil {
-			return nil, fmt.Errorf("registry.azure configuration is required")
-		}
-		cred := infra.Spec.Registry.Azure.CredentialsSecret
-		cfg.Registry.Azure = &apiconfig.RegistryAzureConfig{
-			Registry:     infra.Spec.Registry.Azure.Registry,
-			TenantID:     "${S0_REGISTRY_AZURE_TENANT_ID}",
-			ClientID:     "${S0_REGISTRY_AZURE_CLIENT_ID}",
-			ClientSecret: "${S0_REGISTRY_AZURE_CLIENT_SECRET}",
-		}
-		return []corev1.EnvVar{
-			secretEnvVar("S0_REGISTRY_AZURE_TENANT_ID", cred.Name, defaultString(cred.TenantIDKey, "tenantId")),
-			secretEnvVar("S0_REGISTRY_AZURE_CLIENT_ID", cred.Name, defaultString(cred.ClientIDKey, "clientId")),
-			secretEnvVar("S0_REGISTRY_AZURE_CLIENT_SECRET", cred.Name, defaultString(cred.ClientSecretKey, "clientSecret")),
-		}, nil
-	case infrav1alpha1.RegistryProviderAliyun:
-		if infra.Spec.Registry == nil || infra.Spec.Registry.Aliyun == nil {
-			return nil, fmt.Errorf("registry.aliyun configuration is required")
-		}
-		cred := infra.Spec.Registry.Aliyun.CredentialsSecret
-		cfg.Registry.Aliyun = &apiconfig.RegistryAliyunConfig{
-			Registry:        infra.Spec.Registry.Aliyun.Registry,
-			Region:          infra.Spec.Registry.Aliyun.Region,
-			InstanceID:      infra.Spec.Registry.Aliyun.InstanceID,
-			AccessKeyID:     "${S0_REGISTRY_ALIYUN_ACCESS_KEY_ID}",
-			AccessKeySecret: "${S0_REGISTRY_ALIYUN_ACCESS_KEY_SECRET}",
-		}
-		return []corev1.EnvVar{
-			secretEnvVar("S0_REGISTRY_ALIYUN_ACCESS_KEY_ID", cred.Name, defaultString(cred.AccessKeyKey, "accessKeyId")),
-			secretEnvVar("S0_REGISTRY_ALIYUN_ACCESS_KEY_SECRET", cred.Name, defaultString(cred.SecretKeyKey, "accessKeySecret")),
-		}, nil
-	case infrav1alpha1.RegistryProviderHarbor:
-		if infra.Spec.Registry == nil || infra.Spec.Registry.Harbor == nil {
-			return nil, fmt.Errorf("registry.harbor configuration is required")
-		}
-		cred := infra.Spec.Registry.Harbor.CredentialsSecret
-		cfg.Registry.Harbor = &apiconfig.RegistryHarborConfig{
-			Registry: infra.Spec.Registry.Harbor.Registry,
-			Username: "${S0_REGISTRY_HARBOR_USERNAME}",
-			Password: "${S0_REGISTRY_HARBOR_PASSWORD}",
-		}
-		return []corev1.EnvVar{
-			secretEnvVar("S0_REGISTRY_HARBOR_USERNAME", cred.Name, defaultString(cred.UsernameKey, "username")),
-			secretEnvVar("S0_REGISTRY_HARBOR_PASSWORD", cred.Name, defaultString(cred.PasswordKey, "password")),
-		}, nil
-	default:
-		return nil, fmt.Errorf("unsupported registry provider for regional-gateway: %s", resolved.Provider)
-	}
+	return infraplan.Compile(infra).ConfigureRegionalGatewayRegistry(cfg)
 }
 
-func defaultString(value, fallback string) string {
-	if strings.TrimSpace(value) == "" {
-		return fallback
-	}
-	return value
-}
-
-func secretEnvVar(name, secretName, key string) corev1.EnvVar {
-	return corev1.EnvVar{
-		Name: name,
-		ValueFrom: &corev1.EnvVarSource{
-			SecretKeyRef: &corev1.SecretKeySelector{
-				LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
-				Key:                  key,
-			},
-		},
-	}
-}
-
-func (r *Reconciler) deleteIngressIfExists(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, name string) error {
+func (r *Reconciler) deleteIngressIfExists(ctx context.Context, scope common.ObjectScope, name string) error {
 	obj := &networkingv1.Ingress{}
-	err := r.Resources.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: infra.Namespace}, obj)
+	err := r.Resources.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: scope.Namespace}, obj)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil

--- a/infra-operator/internal/controller/services/regionalgateway/regionalgateway_registry_test.go
+++ b/infra-operator/internal/controller/services/regionalgateway/regionalgateway_registry_test.go
@@ -99,7 +99,7 @@ func TestReconcileEnablesTLSForHTTPSBaseURL(t *testing.T) {
 
 	reconciler, client := newRegionalGatewayTestReconciler(t, infra.DeepCopy(), dbSecret)
 
-	if err := reconciler.Reconcile(context.Background(), infra, "sandbox0ai/infra", "latest", nil); err != nil && !strings.Contains(err.Error(), "not ready") {
+	if err := reconciler.Reconcile(context.Background(), "sandbox0ai/infra", "latest", infraplan.Compile(infra)); err != nil && !strings.Contains(err.Error(), "not ready") {
 		t.Fatalf("reconcile returned unexpected error: %v", err)
 	}
 
@@ -358,7 +358,7 @@ func TestBuildConfigUsesCompiledPlanForDefaultClusterGatewayURL(t *testing.T) {
 	compiled := infraplan.Compile(infra)
 	compiled.RegionalGateway.DefaultClusterGatewayURL = "http://planned-cluster-gateway:9443"
 
-	cfg, _, err := reconciler.buildConfig(context.Background(), infra, compiled)
+	cfg, _, err := reconciler.buildConfig(context.Background(), compiled)
 	if err != nil {
 		t.Fatalf("buildConfig returned error: %v", err)
 	}
@@ -434,7 +434,7 @@ func TestBuildConfigPublishesSSHEndpoint(t *testing.T) {
 
 	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(dbSecret).Build()
 	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
-	cfg, _, err := reconciler.buildConfig(context.Background(), infra, infraplan.Compile(infra))
+	cfg, _, err := reconciler.buildConfig(context.Background(), infraplan.Compile(infra))
 	if err != nil {
 		t.Fatalf("buildConfig returned error: %v", err)
 	}
@@ -507,7 +507,7 @@ func TestBuildConfigUsesCompiledPlanForSchedulerRouting(t *testing.T) {
 	compiled := infraplan.Compile(infra)
 	compiled.Services.Scheduler = infraplan.ServiceReference{URL: "http://planned-scheduler:8080"}
 
-	cfg, _, err := reconciler.buildConfig(ctx, infra, compiled)
+	cfg, _, err := reconciler.buildConfig(ctx, compiled)
 	if err != nil {
 		t.Fatalf("buildConfig returned error: %v", err)
 	}
@@ -575,7 +575,7 @@ func TestBuildConfigSkipsInitUserForFederatedGlobalAuth(t *testing.T) {
 	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(dbSecret).Build()
 	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
 
-	cfg, _, err := reconciler.buildConfig(context.Background(), infra, infraplan.Compile(infra))
+	cfg, _, err := reconciler.buildConfig(context.Background(), infraplan.Compile(infra))
 	if err != nil {
 		t.Fatalf("buildConfig returned error: %v", err)
 	}
@@ -655,7 +655,7 @@ func TestBuildConfigLeavesInitUserPasswordEmptyForOIDCOnlyBootstrap(t *testing.T
 	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(dbSecret).Build()
 	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
 
-	cfg, _, err := reconciler.buildConfig(context.Background(), infra, infraplan.Compile(infra))
+	cfg, _, err := reconciler.buildConfig(context.Background(), infraplan.Compile(infra))
 	if err != nil {
 		t.Fatalf("buildConfig returned error: %v", err)
 	}
@@ -732,7 +732,7 @@ func TestReconcileAppliesServiceAnnotations(t *testing.T) {
 		},
 	)
 
-	if err := reconciler.Reconcile(context.Background(), infra, "sandbox0ai/infra", "latest", nil); err != nil && !strings.Contains(err.Error(), "not ready") {
+	if err := reconciler.Reconcile(context.Background(), "sandbox0ai/infra", "latest", infraplan.Compile(infra)); err != nil && !strings.Contains(err.Error(), "not ready") {
 		t.Fatalf("reconcile returned unexpected error: %v", err)
 	}
 

--- a/infra-operator/internal/controller/services/scheduler/scheduler.go
+++ b/infra-operator/internal/controller/services/scheduler/scheduler.go
@@ -29,13 +29,10 @@ import (
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/pkg/common"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/database"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/internalauth"
-	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/registry"
 	infraplan "github.com/sandbox0-ai/sandbox0/infra-operator/internal/plan"
-	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/runtimeconfig"
 	"github.com/sandbox0-ai/sandbox0/pkg/dbpool"
 	pkginternalauth "github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"github.com/sandbox0-ai/sandbox0/pkg/migrate"
-	"github.com/sandbox0-ai/sandbox0/pkg/template"
 	templmigrations "github.com/sandbox0-ai/sandbox0/pkg/template/migrations"
 	schedulerdb "github.com/sandbox0-ai/sandbox0/scheduler/pkg/db"
 )
@@ -56,17 +53,17 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 	}
 
 	// Skip if not enabled (scheduler is optional by default)
-	if infra.Spec.Services == nil || infra.Spec.Services.Scheduler == nil || !infra.Spec.Services.Scheduler.Enabled {
+	if !compiledPlan.Scheduler.Enabled {
 		logger.Info("Scheduler is disabled, skipping")
 		return nil
 	}
 
 	deploymentName := fmt.Sprintf("%s-scheduler", infra.Name)
-	replicas := infra.Spec.Services.Scheduler.Replicas
+	replicas := compiledPlan.Scheduler.Replicas
 	labels := common.GetServiceLabels(infra.Name, "scheduler")
 	keySecretName, privateKeyKey, publicKeyKey := internalauth.GetControlPlaneKeyRefs(infra)
 
-	config, err := r.buildConfig(ctx, infra)
+	config, err := r.buildConfig(ctx, infra, compiledPlan)
 	if err != nil {
 		return err
 	}
@@ -91,12 +88,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 		return err
 	}
 
-	var resources *corev1.ResourceRequirements
-	serviceConfig := (*infrav1alpha1.ServiceNetworkConfig)(nil)
-	if infra.Spec.Services != nil && infra.Spec.Services.Scheduler != nil {
-		resources = infra.Spec.Services.Scheduler.Resources
-		serviceConfig = infra.Spec.Services.Scheduler.Service
-	}
+	resources := compiledPlan.Scheduler.Resources
+	serviceConfig := compiledPlan.Scheduler.ServiceConfig
 
 	volumeMounts := []corev1.VolumeMount{
 		{
@@ -228,53 +221,23 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 	return nil
 }
 
-func (r *Reconciler) buildConfig(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra) (*apiconfig.SchedulerConfig, error) {
+func (r *Reconciler) buildConfig(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, compiledPlan *infraplan.InfraPlan) (*apiconfig.SchedulerConfig, error) {
 	cfg := &apiconfig.SchedulerConfig{}
-	if infra.Spec.Services != nil && infra.Spec.Services.Scheduler != nil {
-		cfg = runtimeconfig.ToScheduler(infra.Spec.Services.Scheduler.Config)
+	if compiledPlan != nil && compiledPlan.Scheduler.Config != nil {
+		cfg = compiledPlan.Scheduler.Config.DeepCopy()
 	}
-
 	if dsn, err := database.GetDatabaseDSN(ctx, r.Resources.Client, infra); err == nil {
 		cfg.DatabaseURL = dsn
-	}
-	if registryConfig := registry.ResolveRegistryConfig(infra); registryConfig != nil {
-		cfg.RegistryPushRegistry = registryConfig.PushRegistry
-		cfg.RegistryPullRegistry = registryConfig.PullRegistry
 	}
 
 	return cfg, nil
 }
 
-func desiredHomeCluster(infra *infrav1alpha1.Sandbox0Infra, compiledPlan *infraplan.InfraPlan) *template.Cluster {
-	if infra == nil || infra.Spec.Cluster == nil {
-		return nil
-	}
+func (r *Reconciler) ensureHomeCluster(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, compiledPlan *infraplan.InfraPlan, cfg *apiconfig.SchedulerConfig) error {
 	if compiledPlan == nil {
 		compiledPlan = infraplan.Compile(infra)
 	}
-	if compiledPlan == nil || !compiledPlan.Components.EnableScheduler || !compiledPlan.Components.EnableClusterGateway || compiledPlan.Components.EnableClusterRegistration {
-		return nil
-	}
-	if compiledPlan.Services.ClusterGateway.URL == "" {
-		return nil
-	}
-
-	name := infra.Spec.Cluster.Name
-	if name == "" {
-		name = infra.Spec.Cluster.ID
-	}
-
-	return &template.Cluster{
-		ClusterID:         infra.Spec.Cluster.ID,
-		ClusterName:       name,
-		ClusterGatewayURL: compiledPlan.Services.ClusterGateway.URL,
-		Weight:            100,
-		Enabled:           true,
-	}
-}
-
-func (r *Reconciler) ensureHomeCluster(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, compiledPlan *infraplan.InfraPlan, cfg *apiconfig.SchedulerConfig) error {
-	desired := desiredHomeCluster(infra, compiledPlan)
+	desired := compiledPlan.Scheduler.HomeCluster
 	if desired == nil {
 		return nil
 	}

--- a/infra-operator/internal/controller/services/scheduler/scheduler.go
+++ b/infra-operator/internal/controller/services/scheduler/scheduler.go
@@ -25,10 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	apiconfig "github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
-	infrav1alpha1 "github.com/sandbox0-ai/sandbox0/infra-operator/api/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/pkg/common"
-	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/database"
-	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/internalauth"
 	infraplan "github.com/sandbox0-ai/sandbox0/infra-operator/internal/plan"
 	"github.com/sandbox0-ai/sandbox0/pkg/dbpool"
 	pkginternalauth "github.com/sandbox0-ai/sandbox0/pkg/internalauth"
@@ -46,10 +43,10 @@ func NewReconciler(resources *common.ResourceManager) *Reconciler {
 }
 
 // Reconcile reconciles the scheduler deployment.
-func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, imageRepo, imageTag string, compiledPlan *infraplan.InfraPlan) error {
+func (r *Reconciler) Reconcile(ctx context.Context, imageRepo, imageTag string, compiledPlan *infraplan.InfraPlan) error {
 	logger := log.FromContext(ctx)
 	if compiledPlan == nil {
-		compiledPlan = infraplan.Compile(infra)
+		return fmt.Errorf("compiled plan is required")
 	}
 
 	// Skip if not enabled (scheduler is optional by default)
@@ -58,17 +55,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 		return nil
 	}
 
-	deploymentName := fmt.Sprintf("%s-scheduler", infra.Name)
+	scope := compiledPlan.Scope
+	deploymentName := fmt.Sprintf("%s-scheduler", scope.Name)
 	replicas := compiledPlan.Scheduler.Replicas
-	labels := common.GetServiceLabels(infra.Name, "scheduler")
-	keySecretName, privateKeyKey, publicKeyKey := internalauth.GetControlPlaneKeyRefs(infra)
+	labels := common.GetServiceLabels(scope.Name, "scheduler")
+	keySecretName, privateKeyKey, publicKeyKey := compiledPlan.ControlPlaneKeyRefs()
 
-	config, err := r.buildConfig(ctx, infra, compiledPlan)
+	config, err := r.buildConfig(ctx, compiledPlan)
 	if err != nil {
 		return err
 	}
 	common.NormalizeEnterpriseLicenseFile(&config.LicenseFile, compiledPlan.Enterprise.Scheduler)
-	if err := common.EnsureBuiltinTemplates(ctx, infra, common.BuiltinTemplateOptions{
+	if err := common.EnsureBuiltinTemplates(ctx, compiledPlan.BuiltinTemplates(), common.BuiltinTemplateOptions{
 		DatabaseURL:          config.DatabaseURL,
 		DatabaseMaxConns:     config.DatabasePool.MaxConns,
 		DatabaseMinConns:     config.DatabasePool.MinConns,
@@ -77,14 +75,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 	}); err != nil {
 		return err
 	}
-	if err := r.ensureHomeCluster(ctx, infra, compiledPlan, config); err != nil {
+	if err := r.ensureHomeCluster(ctx, compiledPlan, config); err != nil {
 		return err
 	}
 	podAnnotations, err := common.ConfigHashAnnotation(config)
 	if err != nil {
 		return err
 	}
-	if err := r.Resources.ReconcileServiceConfigMap(ctx, infra, deploymentName, labels, config); err != nil {
+	if err := r.Resources.ReconcileServiceConfigMapWithScope(ctx, scope, deploymentName, labels, config); err != nil {
 		return err
 	}
 
@@ -150,16 +148,16 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 		},
 	}
 	if compiledPlan.Enterprise.Scheduler {
-		volumeMounts, volumes = common.AppendEnterpriseLicenseVolume(infra, config.LicenseFile, volumeMounts, volumes)
+		volumeMounts, volumes = common.AppendEnterpriseLicenseVolumeWithSecretRef(compiledPlan.EnterpriseLicenseSecretRef(), config.LicenseFile, volumeMounts, volumes)
 	}
 
 	// Create deployment
 	httpPort := int32(config.HTTPPort)
-	if err := r.Resources.ReconcileDeployment(ctx, infra, deploymentName, labels, replicas, common.ServiceDefinition{
+	if err := r.Resources.ReconcileDeploymentWithScope(ctx, scope, deploymentName, labels, replicas, common.ServiceDefinition{
 		Name:               "scheduler",
 		Port:               httpPort,
 		TargetPort:         httpPort,
-		ServiceAccountName: fmt.Sprintf("%s-scheduler", infra.Name),
+		ServiceAccountName: fmt.Sprintf("%s-scheduler", scope.Name),
 		Ports: []corev1.ContainerPort{
 			{
 				Name:          "http",
@@ -209,11 +207,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 	serviceType := common.ResolveServiceType(serviceConfig)
 	servicePort := common.ResolveServicePort(serviceConfig, httpPort)
 	serviceAnnotations := common.ResolveServiceAnnotations(serviceConfig)
-	if err := r.Resources.ReconcileService(ctx, infra, deploymentName, labels, serviceType, serviceAnnotations, servicePort, httpPort); err != nil {
+	if err := r.Resources.ReconcileServiceWithScope(ctx, scope, deploymentName, labels, serviceType, serviceAnnotations, servicePort, httpPort); err != nil {
 		return err
 	}
 
-	if err := r.Resources.EnsureDeploymentReady(ctx, infra, deploymentName, replicas); err != nil {
+	if err := r.Resources.EnsureDeploymentReadyWithScope(ctx, scope, deploymentName, replicas); err != nil {
 		return err
 	}
 
@@ -221,21 +219,21 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 	return nil
 }
 
-func (r *Reconciler) buildConfig(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, compiledPlan *infraplan.InfraPlan) (*apiconfig.SchedulerConfig, error) {
+func (r *Reconciler) buildConfig(ctx context.Context, compiledPlan *infraplan.InfraPlan) (*apiconfig.SchedulerConfig, error) {
 	cfg := &apiconfig.SchedulerConfig{}
 	if compiledPlan != nil && compiledPlan.Scheduler.Config != nil {
 		cfg = compiledPlan.Scheduler.Config.DeepCopy()
 	}
-	if dsn, err := database.GetDatabaseDSN(ctx, r.Resources.Client, infra); err == nil {
+	if dsn, err := compiledPlan.DatabaseDSN(ctx, r.Resources.Client); err == nil {
 		cfg.DatabaseURL = dsn
 	}
 
 	return cfg, nil
 }
 
-func (r *Reconciler) ensureHomeCluster(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, compiledPlan *infraplan.InfraPlan, cfg *apiconfig.SchedulerConfig) error {
+func (r *Reconciler) ensureHomeCluster(ctx context.Context, compiledPlan *infraplan.InfraPlan, cfg *apiconfig.SchedulerConfig) error {
 	if compiledPlan == nil {
-		compiledPlan = infraplan.Compile(infra)
+		return fmt.Errorf("compiled plan is required")
 	}
 	desired := compiledPlan.Scheduler.HomeCluster
 	if desired == nil {

--- a/infra-operator/internal/controller/services/scheduler/scheduler_test.go
+++ b/infra-operator/internal/controller/services/scheduler/scheduler_test.go
@@ -53,7 +53,7 @@ func TestDesiredHomeClusterForCoLocatedHomeCluster(t *testing.T) {
 	}
 
 	compiled := infraplan.Compile(infra)
-	cluster := desiredHomeCluster(infra, compiled)
+	cluster := compiled.Scheduler.HomeCluster
 	if cluster == nil {
 		t.Fatal("expected desired home cluster")
 	}
@@ -107,7 +107,7 @@ func TestDesiredHomeClusterSkipsExternalRegistrationClusters(t *testing.T) {
 	if !compiled.Components.EnableClusterRegistration {
 		t.Fatal("expected external data-plane cluster registration to be enabled")
 	}
-	if cluster := desiredHomeCluster(infra, compiled); cluster != nil {
+	if cluster := compiled.Scheduler.HomeCluster; cluster != nil {
 		t.Fatalf("expected no desired home cluster, got %#v", cluster)
 	}
 }
@@ -151,10 +151,17 @@ func TestBuildConfigPropagatesRegistryHosts(t *testing.T) {
 					Port:    5000,
 				},
 			},
+			Services: &infrav1alpha1.ServicesConfig{
+				Scheduler: &infrav1alpha1.SchedulerServiceConfig{
+					WorkloadServiceConfig: infrav1alpha1.WorkloadServiceConfig{
+						EnabledServiceConfig: infrav1alpha1.EnabledServiceConfig{Enabled: true},
+					},
+				},
+			},
 		},
 	}
 
-	cfg, err := reconciler.buildConfig(context.Background(), infra)
+	cfg, err := reconciler.buildConfig(context.Background(), infra, infraplan.Compile(infra))
 	if err != nil {
 		t.Fatalf("buildConfig returned error: %v", err)
 	}

--- a/infra-operator/internal/controller/services/scheduler/scheduler_test.go
+++ b/infra-operator/internal/controller/services/scheduler/scheduler_test.go
@@ -161,7 +161,7 @@ func TestBuildConfigPropagatesRegistryHosts(t *testing.T) {
 		},
 	}
 
-	cfg, err := reconciler.buildConfig(context.Background(), infra, infraplan.Compile(infra))
+	cfg, err := reconciler.buildConfig(context.Background(), infraplan.Compile(infra))
 	if err != nil {
 		t.Fatalf("buildConfig returned error: %v", err)
 	}

--- a/infra-operator/internal/plan/plan.go
+++ b/infra-operator/internal/plan/plan.go
@@ -2,6 +2,7 @@ package plan
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -9,6 +10,9 @@ import (
 	apiconfig "github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
 	infrav1alpha1 "github.com/sandbox0-ai/sandbox0/infra-operator/api/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/pkg/common"
+	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/registry"
+	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/runtimeconfig"
+	"github.com/sandbox0-ai/sandbox0/pkg/template"
 )
 
 const (
@@ -17,11 +21,14 @@ const (
 	defaultClusterGatewayAuthMode  = "internal"
 	defaultRegionalGatewayAuthMode = "self_hosted"
 	defaultSSHGatewayPort          = 2222
+	defaultStorageProxyHTTPPort    = 8081
+	registryCredentialsPath        = "/etc/sandbox0/registry/.dockerconfigjson"
 )
 
 type InfraPlan struct {
 	Components      ComponentPlan
 	Services        ServicePlan
+	Scheduler       SchedulerPlan
 	Manager         ManagerPlan
 	Netd            NetdPlan
 	RegionalGateway RegionalGatewayPlan
@@ -76,6 +83,7 @@ type ServicePlan struct {
 	Manager        ServiceReference
 	Scheduler      ServiceReference
 	ClusterGateway ServiceReference
+	StorageProxy   ServiceReference
 }
 
 type ServiceReference struct {
@@ -84,7 +92,21 @@ type ServiceReference struct {
 	URL  string
 }
 
+type SchedulerPlan struct {
+	Enabled       bool
+	Replicas      int32
+	Resources     *corev1.ResourceRequirements
+	ServiceConfig *infrav1alpha1.ServiceNetworkConfig
+	Config        *apiconfig.SchedulerConfig
+	HomeCluster   *template.Cluster
+}
+
 type ManagerPlan struct {
+	Enabled               bool
+	Replicas              int32
+	Resources             *corev1.ResourceRequirements
+	ServiceConfig         *infrav1alpha1.ServiceNetworkConfig
+	Config                *apiconfig.ManagerConfig
 	TemplateStoreEnabled  bool
 	NetworkPolicyProvider string
 	SandboxPodPlacement   apiconfig.SandboxPodPlacementConfig
@@ -93,6 +115,9 @@ type ManagerPlan struct {
 }
 
 type NetdPlan struct {
+	Enabled               bool
+	RuntimeClassName      *string
+	Config                *apiconfig.NetdConfig
 	EgressAuthResolverURL string
 	RegionID              string
 	ClusterID             string
@@ -101,6 +126,12 @@ type NetdPlan struct {
 }
 
 type RegionalGatewayPlan struct {
+	Enabled                  bool
+	Replicas                 int32
+	Resources                *corev1.ResourceRequirements
+	ServiceConfig            *infrav1alpha1.ServiceNetworkConfig
+	IngressConfig            *infrav1alpha1.IngressConfig
+	Config                   *apiconfig.RegionalGatewayConfig
 	DefaultClusterGatewayURL string
 }
 
@@ -147,9 +178,10 @@ func Compile(infra *infrav1alpha1.Sandbox0Infra) *InfraPlan {
 	compiled := &InfraPlan{infra: infra}
 	compiled.Components = compileComponents(infra)
 	compiled.Services = compileServices(infra)
+	compiled.Scheduler = compileSchedulerPlan(infra, compiled)
 	compiled.Manager = compileManagerPlan(infra, compiled)
 	compiled.Netd = compileNetdPlan(infra, compiled)
-	compiled.RegionalGateway = compileRegionalGatewayPlan(compiled)
+	compiled.RegionalGateway = compileRegionalGatewayPlan(infra, compiled)
 	compiled.Enterprise = compileEnterpriseLicensePlan(infra, compiled)
 	compiled.Validation = compileValidationPlan(infra, compiled)
 	compiled.Cleanup = compileCleanupPlan(infra, compiled)
@@ -197,6 +229,7 @@ func compileServices(infra *infrav1alpha1.Sandbox0Infra) ServicePlan {
 		Manager:        compileManagerServiceReference(infra),
 		Scheduler:      compileSchedulerServiceReference(infra),
 		ClusterGateway: compileClusterGatewayServiceReference(infra),
+		StorageProxy:   compileStorageProxyServiceReference(infra),
 	}
 }
 
@@ -245,6 +278,74 @@ func compileClusterGatewayServiceReference(infra *infrav1alpha1.Sandbox0Infra) S
 	}
 }
 
+func compileStorageProxyServiceReference(infra *infrav1alpha1.Sandbox0Infra) ServiceReference {
+	if infra == nil || infra.Name == "" || !infrav1alpha1.IsStorageProxyEnabled(infra) {
+		return ServiceReference{}
+	}
+
+	port := common.ResolveServicePort(storageProxyServiceConfig(infra), int32(storageProxyHTTPPort(infra)))
+	name := fmt.Sprintf("%s-storage-proxy", infra.Name)
+
+	return ServiceReference{
+		Name: name,
+		Port: port,
+		URL:  fmt.Sprintf("http://%s:%d", name, port),
+	}
+}
+
+func compileSchedulerPlan(infra *infrav1alpha1.Sandbox0Infra, compiled *InfraPlan) SchedulerPlan {
+	schedulerPlan := SchedulerPlan{
+		Enabled: infrav1alpha1.IsSchedulerEnabled(infra),
+		Config:  &apiconfig.SchedulerConfig{},
+	}
+	if infra == nil || infra.Spec.Services == nil || infra.Spec.Services.Scheduler == nil {
+		return schedulerPlan
+	}
+
+	svc := infra.Spec.Services.Scheduler
+	schedulerPlan.Replicas = svc.Replicas
+	if svc.Resources != nil {
+		schedulerPlan.Resources = svc.Resources.DeepCopy()
+	}
+	if svc.Service != nil {
+		schedulerPlan.ServiceConfig = svc.Service.DeepCopy()
+	}
+	if svc.Config != nil {
+		schedulerPlan.Config = runtimeconfig.ToScheduler(svc.Config)
+	}
+	if resolvedRegistry := registry.ResolveRegistryConfig(infra); resolvedRegistry != nil {
+		schedulerPlan.Config.RegistryPushRegistry = resolvedRegistry.PushRegistry
+		schedulerPlan.Config.RegistryPullRegistry = resolvedRegistry.PullRegistry
+	}
+	schedulerPlan.HomeCluster = compileSchedulerHomeCluster(infra, compiled)
+	return schedulerPlan
+}
+
+func compileSchedulerHomeCluster(infra *infrav1alpha1.Sandbox0Infra, compiled *InfraPlan) *template.Cluster {
+	if infra == nil || infra.Spec.Cluster == nil || compiled == nil {
+		return nil
+	}
+	if !compiled.Components.EnableScheduler || !compiled.Components.EnableClusterGateway || compiled.Components.EnableClusterRegistration {
+		return nil
+	}
+	if compiled.Services.ClusterGateway.URL == "" {
+		return nil
+	}
+
+	name := infra.Spec.Cluster.Name
+	if name == "" {
+		name = infra.Spec.Cluster.ID
+	}
+
+	return &template.Cluster{
+		ClusterID:         infra.Spec.Cluster.ID,
+		ClusterName:       name,
+		ClusterGatewayURL: compiled.Services.ClusterGateway.URL,
+		Weight:            100,
+		Enabled:           true,
+	}
+}
+
 func compileManagerPlan(infra *infrav1alpha1.Sandbox0Infra, compiled *InfraPlan) ManagerPlan {
 	nodeSelector, tolerations := common.ResolveSandboxNodePlacement(infra)
 	templateStoreEnabled := clusterGatewayAuthMode(infra) != defaultClusterGatewayAuthMode
@@ -253,6 +354,8 @@ func compileManagerPlan(infra *infrav1alpha1.Sandbox0Infra, compiled *InfraPlan)
 	}
 
 	managerPlan := ManagerPlan{
+		Enabled:               infrav1alpha1.IsManagerEnabled(infra),
+		Config:                &apiconfig.ManagerConfig{},
 		TemplateStoreEnabled:  templateStoreEnabled,
 		NetworkPolicyProvider: "noop",
 		SandboxPodPlacement: apiconfig.SandboxPodPlacementConfig{
@@ -269,22 +372,161 @@ func compileManagerPlan(infra *infrav1alpha1.Sandbox0Infra, compiled *InfraPlan)
 		if infra.Spec.Cluster != nil {
 			managerPlan.DefaultClusterID = infra.Spec.Cluster.ID
 		}
+		if infra.Spec.Services != nil && infra.Spec.Services.Manager != nil {
+			svc := infra.Spec.Services.Manager
+			managerPlan.Replicas = svc.Replicas
+			if svc.Resources != nil {
+				managerPlan.Resources = svc.Resources.DeepCopy()
+			}
+			if svc.Service != nil {
+				managerPlan.ServiceConfig = svc.Service.DeepCopy()
+			}
+			if svc.Config != nil {
+				managerPlan.Config = runtimeconfig.ToManager(svc.Config)
+			}
+		}
+		compileManagerRuntimeConfig(&managerPlan, infra)
 	}
 
 	return managerPlan
 }
 
+func compileManagerRuntimeConfig(managerPlan *ManagerPlan, infra *infrav1alpha1.Sandbox0Infra) {
+	if managerPlan == nil || infra == nil {
+		return
+	}
+	cfg := managerPlan.Config
+	if cfg == nil {
+		cfg = &apiconfig.ManagerConfig{}
+		managerPlan.Config = cfg
+	}
+
+	cfg.TemplateStoreEnabled = managerPlan.TemplateStoreEnabled
+	cfg.NetworkPolicyProvider = managerPlan.NetworkPolicyProvider
+	cfg.SandboxPodPlacement = managerPlan.SandboxPodPlacement
+	cfg.DefaultClusterId = managerPlan.DefaultClusterID
+	cfg.RegionID = managerPlan.RegionID
+	cfg.CtldEnabled = managerPlan.Enabled
+	if cfg.CtldEnabled && cfg.CtldPort == 0 {
+		cfg.CtldPort = 8095
+	}
+
+	if resolvedRegistry := registry.ResolveRegistryConfig(infra); resolvedRegistry != nil {
+		cfg.Registry.Provider = string(resolvedRegistry.Provider)
+		cfg.Registry.PushRegistry = resolvedRegistry.PushRegistry
+		cfg.Registry.PullRegistry = resolvedRegistry.PullRegistry
+		cfg.Registry.PullSecretName = resolvedRegistry.TargetSecretName
+		cfg.Registry.Namespace = infra.Namespace
+		if resolvedRegistry.SourceSecretName != "" {
+			cfg.Registry.PullCredentialsFile = registryCredentialsPath
+		}
+		if resolvedRegistry.Provider == infrav1alpha1.RegistryProviderBuiltin {
+			cfg.Registry.Builtin = &apiconfig.RegistryBuiltinConfig{
+				AuthSecretName: fmt.Sprintf("%s-registry-auth", infra.Name),
+				UsernameKey:    "username",
+				PasswordKey:    "password",
+			}
+		}
+	}
+	if infra.Spec.Registry != nil {
+		switch infra.Spec.Registry.Provider {
+		case infrav1alpha1.RegistryProviderAWS:
+			if infra.Spec.Registry.AWS != nil {
+				cfg.Registry.AWS = &apiconfig.RegistryAWSConfig{
+					Region:           infra.Spec.Registry.AWS.Region,
+					RegistryID:       infra.Spec.Registry.AWS.RegistryID,
+					AssumeRoleARN:    infra.Spec.Registry.AWS.AssumeRoleARN,
+					ExternalID:       infra.Spec.Registry.AWS.ExternalID,
+					AccessKeySecret:  infra.Spec.Registry.AWS.CredentialsSecret.Name,
+					AccessKeyKey:     infra.Spec.Registry.AWS.CredentialsSecret.AccessKeyKey,
+					SecretKeyKey:     infra.Spec.Registry.AWS.CredentialsSecret.SecretKeyKey,
+					SessionTokenKey:  infra.Spec.Registry.AWS.CredentialsSecret.SessionTokenKey,
+					RegistryOverride: infra.Spec.Registry.AWS.Registry,
+				}
+			}
+		case infrav1alpha1.RegistryProviderGCP:
+			if infra.Spec.Registry.GCP != nil {
+				cfg.Registry.GCP = &apiconfig.RegistryGCPConfig{
+					Registry: infra.Spec.Registry.GCP.Registry,
+				}
+				if infra.Spec.Registry.GCP.ServiceAccountSecret != nil {
+					cfg.Registry.GCP.ServiceAccountSecret = infra.Spec.Registry.GCP.ServiceAccountSecret.Name
+					cfg.Registry.GCP.ServiceAccountKey = infra.Spec.Registry.GCP.ServiceAccountSecret.Key
+				}
+			}
+		case infrav1alpha1.RegistryProviderAzure:
+			if infra.Spec.Registry.Azure != nil {
+				cfg.Registry.Azure = &apiconfig.RegistryAzureConfig{
+					Registry:          infra.Spec.Registry.Azure.Registry,
+					CredentialsSecret: infra.Spec.Registry.Azure.CredentialsSecret.Name,
+					TenantIDKey:       infra.Spec.Registry.Azure.CredentialsSecret.TenantIDKey,
+					ClientIDKey:       infra.Spec.Registry.Azure.CredentialsSecret.ClientIDKey,
+					ClientSecretKey:   infra.Spec.Registry.Azure.CredentialsSecret.ClientSecretKey,
+				}
+			}
+		case infrav1alpha1.RegistryProviderAliyun:
+			if infra.Spec.Registry.Aliyun != nil {
+				cfg.Registry.Aliyun = &apiconfig.RegistryAliyunConfig{
+					Registry:          infra.Spec.Registry.Aliyun.Registry,
+					Region:            infra.Spec.Registry.Aliyun.Region,
+					InstanceID:        infra.Spec.Registry.Aliyun.InstanceID,
+					CredentialsSecret: infra.Spec.Registry.Aliyun.CredentialsSecret.Name,
+					AccessKeyKey:      infra.Spec.Registry.Aliyun.CredentialsSecret.AccessKeyKey,
+					SecretKeyKey:      infra.Spec.Registry.Aliyun.CredentialsSecret.SecretKeyKey,
+				}
+			}
+		case infrav1alpha1.RegistryProviderHarbor:
+			if infra.Spec.Registry.Harbor != nil {
+				cfg.Registry.Harbor = &apiconfig.RegistryHarborConfig{
+					Registry:          infra.Spec.Registry.Harbor.Registry,
+					CredentialsSecret: infra.Spec.Registry.Harbor.CredentialsSecret.Name,
+					UsernameKey:       infra.Spec.Registry.Harbor.CredentialsSecret.UsernameKey,
+					PasswordKey:       infra.Spec.Registry.Harbor.CredentialsSecret.PasswordKey,
+				}
+			}
+		}
+	}
+
+	storageProxyConfig := &apiconfig.StorageProxyConfig{}
+	storageProxyServiceConfig := (*infrav1alpha1.ServiceNetworkConfig)(nil)
+	if infra.Spec.Services != nil && infra.Spec.Services.StorageProxy != nil {
+		if infra.Spec.Services.StorageProxy.Config != nil {
+			storageProxyConfig = runtimeconfig.ToStorageProxy(infra.Spec.Services.StorageProxy.Config)
+		}
+		storageProxyServiceConfig = infra.Spec.Services.StorageProxy.Service
+	}
+	if infrav1alpha1.IsStorageProxyEnabled(infra) {
+		cfg.ProcdConfig.StorageProxyBaseURL = fmt.Sprintf("%s-storage-proxy.%s.svc.cluster.local", infra.Name, infra.Namespace)
+		cfg.ProcdConfig.StorageProxyPort = int(common.ResolveServicePort(storageProxyServiceConfig, int32(storageProxyConfig.GRPCPort)))
+	} else {
+		cfg.ProcdConfig.StorageProxyBaseURL = ""
+		cfg.ProcdConfig.StorageProxyPort = 0
+	}
+	if infra.Spec.PublicExposure != nil {
+		cfg.PublicRootDomain = infra.Spec.PublicExposure.RootDomain
+		cfg.PublicRegionID = infra.Spec.PublicExposure.RegionID
+	}
+}
+
 func compileNetdPlan(infra *infrav1alpha1.Sandbox0Infra, compiled *InfraPlan) NetdPlan {
 	nodeSelector, tolerations := common.ResolveSandboxNodePlacement(infra)
 	netdPlan := NetdPlan{
+		Enabled:      infrav1alpha1.IsNetdEnabled(infra),
 		NodeSelector: nodeSelector,
 		Tolerations:  tolerations,
+		Config:       &apiconfig.NetdConfig{},
 	}
 
 	if infra != nil {
 		netdPlan.RegionID = infra.Spec.Region
 		if infra.Spec.Cluster != nil {
 			netdPlan.ClusterID = infra.Spec.Cluster.ID
+		}
+		if infra.Spec.Services != nil && infra.Spec.Services.Netd != nil {
+			if infra.Spec.Services.Netd.Config != nil {
+				netdPlan.Config = runtimeconfig.ToNetd(infra.Spec.Services.Netd.Config)
+			}
+			netdPlan.RuntimeClassName = infra.Spec.Services.Netd.RuntimeClassName
 		}
 	}
 
@@ -299,12 +541,73 @@ func compileNetdPlan(infra *infrav1alpha1.Sandbox0Infra, compiled *InfraPlan) Ne
 	return netdPlan
 }
 
-func compileRegionalGatewayPlan(compiled *InfraPlan) RegionalGatewayPlan {
-	if compiled == nil {
-		return RegionalGatewayPlan{}
+func compileRegionalGatewayPlan(infra *infrav1alpha1.Sandbox0Infra, compiled *InfraPlan) RegionalGatewayPlan {
+	plan := RegionalGatewayPlan{
+		Enabled: infrav1alpha1.IsRegionalGatewayEnabled(infra),
+		Config:  &apiconfig.RegionalGatewayConfig{},
 	}
-	return RegionalGatewayPlan{
-		DefaultClusterGatewayURL: compiled.Services.ClusterGateway.URL,
+	if compiled != nil {
+		plan.DefaultClusterGatewayURL = compiled.Services.ClusterGateway.URL
+	}
+	if infra == nil || infra.Spec.Services == nil || infra.Spec.Services.RegionalGateway == nil {
+		return plan
+	}
+
+	svc := infra.Spec.Services.RegionalGateway
+	plan.Replicas = svc.Replicas
+	if svc.Resources != nil {
+		plan.Resources = svc.Resources.DeepCopy()
+	}
+	if svc.Service != nil {
+		plan.ServiceConfig = svc.Service.DeepCopy()
+	}
+	if svc.Ingress != nil {
+		plan.IngressConfig = svc.Ingress.DeepCopy()
+	}
+	if svc.Config != nil {
+		plan.Config = runtimeconfig.ToRegionalGateway(svc.Config)
+	}
+	compileRegionalGatewayRuntimeConfig(&plan, infra, compiled)
+	return plan
+}
+
+func compileRegionalGatewayRuntimeConfig(plan *RegionalGatewayPlan, infra *infrav1alpha1.Sandbox0Infra, compiled *InfraPlan) {
+	if plan == nil || infra == nil {
+		return
+	}
+	cfg := plan.Config
+	if cfg == nil {
+		cfg = &apiconfig.RegionalGatewayConfig{}
+		plan.Config = cfg
+	}
+
+	cfg.DefaultClusterGatewayURL = plan.DefaultClusterGatewayURL
+	if compiled != nil {
+		cfg.SchedulerEnabled = compiled.Components.EnableScheduler
+		cfg.SchedulerURL = compiled.Services.Scheduler.URL
+	}
+
+	sshPort := int32(defaultSSHGatewayPort)
+	if infra.Spec.Services != nil && infra.Spec.Services.SSHGateway != nil && infra.Spec.Services.SSHGateway.Config != nil && infra.Spec.Services.SSHGateway.Config.SSHPort != 0 {
+		sshPort = int32(infra.Spec.Services.SSHGateway.Config.SSHPort)
+	}
+	if sshHost, advertisedPort, ok := common.ResolveSSHEndpoint(infra, sshPort); ok {
+		cfg.SSHEndpointHost = sshHost
+		cfg.SSHEndpointPort = int(advertisedPort)
+	}
+	if strings.TrimSpace(infra.Spec.Region) != "" {
+		cfg.RegionID = infra.Spec.Region
+	}
+	if infra.Spec.PublicExposure != nil {
+		cfg.PublicExposureEnabled = infra.Spec.PublicExposure.Enabled
+		cfg.PublicRootDomain = infra.Spec.PublicExposure.RootDomain
+		cfg.PublicRegionID = infra.Spec.PublicExposure.RegionID
+	}
+	if base := strings.TrimSpace(cfg.BaseURL); base != "" {
+		if parsed, err := url.Parse(base); err == nil && strings.EqualFold(parsed.Scheme, "https") {
+			cfg.TLSCertPath = "/tls/tls.crt"
+			cfg.TLSKeyPath = "/tls/tls.key"
+		}
 	}
 }
 
@@ -734,6 +1037,21 @@ func schedulerHTTPPort(infra *infrav1alpha1.Sandbox0Infra) int {
 func schedulerServiceConfig(infra *infrav1alpha1.Sandbox0Infra) *infrav1alpha1.ServiceNetworkConfig {
 	if infra != nil && infra.Spec.Services != nil && infra.Spec.Services.Scheduler != nil {
 		return infra.Spec.Services.Scheduler.Service
+	}
+	return nil
+}
+
+func storageProxyHTTPPort(infra *infrav1alpha1.Sandbox0Infra) int {
+	if infra != nil && infra.Spec.Services != nil && infra.Spec.Services.StorageProxy != nil &&
+		infra.Spec.Services.StorageProxy.Config != nil && infra.Spec.Services.StorageProxy.Config.HTTPPort > 0 {
+		return infra.Spec.Services.StorageProxy.Config.HTTPPort
+	}
+	return defaultStorageProxyHTTPPort
+}
+
+func storageProxyServiceConfig(infra *infrav1alpha1.Sandbox0Infra) *infrav1alpha1.ServiceNetworkConfig {
+	if infra != nil && infra.Spec.Services != nil && infra.Spec.Services.StorageProxy != nil {
+		return infra.Spec.Services.StorageProxy.Service
 	}
 	return nil
 }

--- a/infra-operator/internal/plan/plan.go
+++ b/infra-operator/internal/plan/plan.go
@@ -26,6 +26,7 @@ const (
 )
 
 type InfraPlan struct {
+	Scope           common.ObjectScope
 	Components      ComponentPlan
 	Services        ServicePlan
 	Scheduler       SchedulerPlan
@@ -175,7 +176,7 @@ type WorkflowStepPlan struct {
 }
 
 func Compile(infra *infrav1alpha1.Sandbox0Infra) *InfraPlan {
-	compiled := &InfraPlan{infra: infra}
+	compiled := &InfraPlan{infra: infra, Scope: common.NewObjectScope(infra)}
 	compiled.Components = compileComponents(infra)
 	compiled.Services = compileServices(infra)
 	compiled.Scheduler = compileSchedulerPlan(infra, compiled)

--- a/infra-operator/internal/plan/plan_test.go
+++ b/infra-operator/internal/plan/plan_test.go
@@ -56,6 +56,31 @@ func TestCompileDerivesCrossServiceReferences(t *testing.T) {
 						HTTPPort: 18080,
 					},
 				},
+				Scheduler: &infrav1alpha1.SchedulerServiceConfig{
+					WorkloadServiceConfig: infrav1alpha1.WorkloadServiceConfig{
+						EnabledServiceConfig: infrav1alpha1.EnabledServiceConfig{Enabled: true},
+					},
+				},
+				RegionalGateway: &infrav1alpha1.RegionalGatewayServiceConfig{
+					WorkloadServiceConfig: infrav1alpha1.WorkloadServiceConfig{
+						EnabledServiceConfig: infrav1alpha1.EnabledServiceConfig{Enabled: true},
+						Replicas:             2,
+					},
+					ServiceExposureConfig: infrav1alpha1.ServiceExposureConfig{
+						Service: &infrav1alpha1.ServiceNetworkConfig{Port: 443},
+					},
+					IngressExposureConfig: infrav1alpha1.IngressExposureConfig{
+						Ingress: &infrav1alpha1.IngressConfig{
+							Enabled: true,
+							Host:    "edge.example.com",
+						},
+					},
+					Config: &infrav1alpha1.RegionalGatewayConfig{
+						GatewayConfig: infrav1alpha1.GatewayConfig{
+							BaseURL: "https://edge.example.com",
+						},
+					},
+				},
 				Netd: &infrav1alpha1.NetdServiceConfig{
 					EnabledServiceConfig: infrav1alpha1.EnabledServiceConfig{
 						Enabled: true,
@@ -97,6 +122,30 @@ func TestCompileDerivesCrossServiceReferences(t *testing.T) {
 	}
 	if len(compiled.Netd.Tolerations) != 1 || compiled.Netd.Tolerations[0].Key != "sandbox0.ai/sandbox" {
 		t.Fatalf("expected shared netd tolerations, got %#v", compiled.Netd.Tolerations)
+	}
+	if !compiled.Scheduler.Enabled {
+		t.Fatal("expected scheduler plan to be enabled")
+	}
+	if compiled.Scheduler.Config == nil || compiled.Netd.Config == nil {
+		t.Fatal("expected scheduler and netd configs to be compiled")
+	}
+	if compiled.Scheduler.HomeCluster == nil || compiled.Scheduler.HomeCluster.ClusterID != "cluster-a" {
+		t.Fatalf("expected scheduler home cluster to be compiled, got %#v", compiled.Scheduler.HomeCluster)
+	}
+	if compiled.Netd.RuntimeClassName == nil || *compiled.Netd.RuntimeClassName != sharedRuntime {
+		t.Fatalf("expected netd runtime class name %q, got %#v", sharedRuntime, compiled.Netd.RuntimeClassName)
+	}
+	if !compiled.RegionalGateway.Enabled || compiled.RegionalGateway.Replicas != 2 {
+		t.Fatalf("expected regional gateway plan to carry enablement and replicas, got %#v", compiled.RegionalGateway)
+	}
+	if compiled.RegionalGateway.Config == nil || compiled.RegionalGateway.Config.SSHEndpointHost != "" {
+		t.Fatalf("expected regional gateway config without ssh endpoint, got %#v", compiled.RegionalGateway.Config)
+	}
+	if compiled.RegionalGateway.Config == nil || compiled.RegionalGateway.Config.TLSCertPath == "" {
+		t.Fatalf("expected regional gateway TLS paths to be compiled, got %#v", compiled.RegionalGateway.Config)
+	}
+	if compiled.RegionalGateway.IngressConfig == nil || !compiled.RegionalGateway.IngressConfig.Enabled {
+		t.Fatalf("expected regional gateway ingress config to be compiled, got %#v", compiled.RegionalGateway.IngressConfig)
 	}
 }
 

--- a/infra-operator/internal/plan/runtime_access.go
+++ b/infra-operator/internal/plan/runtime_access.go
@@ -1,0 +1,265 @@
+package plan
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	apiconfig "github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
+	infrav1alpha1 "github.com/sandbox0-ai/sandbox0/infra-operator/api/v1alpha1"
+	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/pkg/common"
+	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/database"
+	controllerinternalauth "github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/internalauth"
+	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/registry"
+)
+
+func (p *InfraPlan) BuiltinTemplates() []infrav1alpha1.BuiltinTemplateConfig {
+	if p == nil || p.infra == nil || len(p.infra.Spec.BuiltinTemplates) == 0 {
+		return nil
+	}
+	out := make([]infrav1alpha1.BuiltinTemplateConfig, len(p.infra.Spec.BuiltinTemplates))
+	for i := range p.infra.Spec.BuiltinTemplates {
+		p.infra.Spec.BuiltinTemplates[i].DeepCopyInto(&out[i])
+	}
+	return out
+}
+
+func (p *InfraPlan) DatabaseDSN(ctx context.Context, kubeClient client.Client) (string, error) {
+	if p == nil || p.infra == nil {
+		return "", fmt.Errorf("compiled plan source infra is required")
+	}
+	if p.infra.Spec.Database == nil {
+		return "", fmt.Errorf("database is not configured")
+	}
+	return database.GetDatabaseDSN(ctx, kubeClient, p.infra)
+}
+
+func (p *InfraPlan) InitUser() *infrav1alpha1.InitUserConfig {
+	if p == nil || p.infra == nil || p.infra.Spec.InitUser == nil {
+		return nil
+	}
+	return p.infra.Spec.InitUser.DeepCopy()
+}
+
+func (p *InfraPlan) ControlPlaneKeyRefs() (string, string, string) {
+	if p == nil || p.infra == nil {
+		return "", "", ""
+	}
+	return controllerinternalauth.GetControlPlaneKeyRefs(p.infra)
+}
+
+func (p *InfraPlan) DataPlaneKeyRefs() (string, string, string) {
+	if p == nil || p.infra == nil {
+		return "", "", ""
+	}
+	return controllerinternalauth.GetDataPlaneKeyRefs(p.infra)
+}
+
+func (p *InfraPlan) ControlPlanePublicKeyRef() (string, string) {
+	if p == nil || p.infra == nil {
+		return "", ""
+	}
+	return controllerinternalauth.GetControlPlanePublicKeyRef(p.infra)
+}
+
+func (p *InfraPlan) EnterpriseLicenseSecretRef() infrav1alpha1.SecretKeyRef {
+	if p == nil || p.infra == nil {
+		return infrav1alpha1.SecretKeyRef{}
+	}
+	return common.ResolveEnterpriseLicenseSecretRef(p.infra)
+}
+
+func (p *InfraPlan) ManagerRegistryCredentialsSource() (string, string) {
+	resolved := p.registryConfig()
+	if resolved == nil {
+		return "", ""
+	}
+	return resolved.SourceSecretName, resolved.SourceSecretKey
+}
+
+func (p *InfraPlan) ConfigureRegionalGatewayRegistry(cfg *apiconfig.RegionalGatewayConfig) ([]corev1.EnvVar, error) {
+	if cfg == nil || p == nil || p.infra == nil || !infrav1alpha1.IsRegistryEnabled(p.infra) {
+		return nil, nil
+	}
+
+	resolved := p.registryConfig()
+	if resolved == nil {
+		return nil, nil
+	}
+
+	cfg.Registry.Provider = string(resolved.Provider)
+	cfg.Registry.PushRegistry = resolved.PushRegistry
+	cfg.Registry.PullRegistry = resolved.PullRegistry
+	cfg.Registry.Namespace = p.Scope.Namespace
+
+	switch resolved.Provider {
+	case infrav1alpha1.RegistryProviderBuiltin:
+		cfg.Registry.Builtin = &apiconfig.RegistryBuiltinConfig{
+			Username: "${S0_REGISTRY_BUILTIN_USERNAME}",
+			Password: "${S0_REGISTRY_BUILTIN_PASSWORD}",
+		}
+		secretName := fmt.Sprintf("%s-registry-auth", p.Scope.Name)
+		return []corev1.EnvVar{
+			secretEnvVar("S0_REGISTRY_BUILTIN_USERNAME", secretName, "username"),
+			secretEnvVar("S0_REGISTRY_BUILTIN_PASSWORD", secretName, "password"),
+		}, nil
+	case infrav1alpha1.RegistryProviderAWS:
+		if p.infra.Spec.Registry == nil || p.infra.Spec.Registry.AWS == nil {
+			return nil, fmt.Errorf("registry.aws configuration is required")
+		}
+		cred := p.infra.Spec.Registry.AWS.CredentialsSecret
+		cfg.Registry.AWS = &apiconfig.RegistryAWSConfig{
+			Region:           p.infra.Spec.Registry.AWS.Region,
+			RegistryID:       p.infra.Spec.Registry.AWS.RegistryID,
+			AssumeRoleARN:    p.infra.Spec.Registry.AWS.AssumeRoleARN,
+			ExternalID:       p.infra.Spec.Registry.AWS.ExternalID,
+			RegistryOverride: p.infra.Spec.Registry.AWS.Registry,
+			AccessKeyID:      "${S0_REGISTRY_AWS_ACCESS_KEY_ID}",
+			SecretAccessKey:  "${S0_REGISTRY_AWS_SECRET_ACCESS_KEY}",
+		}
+		envVars := []corev1.EnvVar{
+			secretEnvVar("S0_REGISTRY_AWS_ACCESS_KEY_ID", cred.Name, defaultString(cred.AccessKeyKey, "accessKeyId")),
+			secretEnvVar("S0_REGISTRY_AWS_SECRET_ACCESS_KEY", cred.Name, defaultString(cred.SecretKeyKey, "secretAccessKey")),
+		}
+		if strings.TrimSpace(cred.SessionTokenKey) != "" {
+			cfg.Registry.AWS.SessionToken = "${S0_REGISTRY_AWS_SESSION_TOKEN}"
+			envVars = append(envVars, secretEnvVar("S0_REGISTRY_AWS_SESSION_TOKEN", cred.Name, cred.SessionTokenKey))
+		}
+		return envVars, nil
+	case infrav1alpha1.RegistryProviderGCP:
+		if p.infra.Spec.Registry == nil || p.infra.Spec.Registry.GCP == nil {
+			return nil, fmt.Errorf("registry.gcp configuration is required")
+		}
+		cfg.Registry.GCP = &apiconfig.RegistryGCPConfig{Registry: p.infra.Spec.Registry.GCP.Registry}
+		if p.infra.Spec.Registry.GCP.ServiceAccountSecret == nil {
+			return nil, nil
+		}
+		sa := p.infra.Spec.Registry.GCP.ServiceAccountSecret
+		cfg.Registry.GCP.ServiceAccountJSON = "${S0_REGISTRY_GCP_SERVICE_ACCOUNT_JSON}"
+		return []corev1.EnvVar{
+			secretEnvVar("S0_REGISTRY_GCP_SERVICE_ACCOUNT_JSON", sa.Name, defaultString(sa.Key, "serviceAccount.json")),
+		}, nil
+	case infrav1alpha1.RegistryProviderAzure:
+		if p.infra.Spec.Registry == nil || p.infra.Spec.Registry.Azure == nil {
+			return nil, fmt.Errorf("registry.azure configuration is required")
+		}
+		cred := p.infra.Spec.Registry.Azure.CredentialsSecret
+		cfg.Registry.Azure = &apiconfig.RegistryAzureConfig{
+			Registry:     p.infra.Spec.Registry.Azure.Registry,
+			TenantID:     "${S0_REGISTRY_AZURE_TENANT_ID}",
+			ClientID:     "${S0_REGISTRY_AZURE_CLIENT_ID}",
+			ClientSecret: "${S0_REGISTRY_AZURE_CLIENT_SECRET}",
+		}
+		return []corev1.EnvVar{
+			secretEnvVar("S0_REGISTRY_AZURE_TENANT_ID", cred.Name, defaultString(cred.TenantIDKey, "tenantId")),
+			secretEnvVar("S0_REGISTRY_AZURE_CLIENT_ID", cred.Name, defaultString(cred.ClientIDKey, "clientId")),
+			secretEnvVar("S0_REGISTRY_AZURE_CLIENT_SECRET", cred.Name, defaultString(cred.ClientSecretKey, "clientSecret")),
+		}, nil
+	case infrav1alpha1.RegistryProviderAliyun:
+		if p.infra.Spec.Registry == nil || p.infra.Spec.Registry.Aliyun == nil {
+			return nil, fmt.Errorf("registry.aliyun configuration is required")
+		}
+		cred := p.infra.Spec.Registry.Aliyun.CredentialsSecret
+		cfg.Registry.Aliyun = &apiconfig.RegistryAliyunConfig{
+			Registry:        p.infra.Spec.Registry.Aliyun.Registry,
+			Region:          p.infra.Spec.Registry.Aliyun.Region,
+			InstanceID:      p.infra.Spec.Registry.Aliyun.InstanceID,
+			AccessKeyID:     "${S0_REGISTRY_ALIYUN_ACCESS_KEY_ID}",
+			AccessKeySecret: "${S0_REGISTRY_ALIYUN_ACCESS_KEY_SECRET}",
+		}
+		return []corev1.EnvVar{
+			secretEnvVar("S0_REGISTRY_ALIYUN_ACCESS_KEY_ID", cred.Name, defaultString(cred.AccessKeyKey, "accessKeyId")),
+			secretEnvVar("S0_REGISTRY_ALIYUN_ACCESS_KEY_SECRET", cred.Name, defaultString(cred.SecretKeyKey, "accessKeySecret")),
+		}, nil
+	case infrav1alpha1.RegistryProviderHarbor:
+		if p.infra.Spec.Registry == nil || p.infra.Spec.Registry.Harbor == nil {
+			return nil, fmt.Errorf("registry.harbor configuration is required")
+		}
+		cred := p.infra.Spec.Registry.Harbor.CredentialsSecret
+		cfg.Registry.Harbor = &apiconfig.RegistryHarborConfig{
+			Registry: p.infra.Spec.Registry.Harbor.Registry,
+			Username: "${S0_REGISTRY_HARBOR_USERNAME}",
+			Password: "${S0_REGISTRY_HARBOR_PASSWORD}",
+		}
+		return []corev1.EnvVar{
+			secretEnvVar("S0_REGISTRY_HARBOR_USERNAME", cred.Name, defaultString(cred.UsernameKey, "username")),
+			secretEnvVar("S0_REGISTRY_HARBOR_PASSWORD", cred.Name, defaultString(cred.PasswordKey, "password")),
+		}, nil
+	default:
+		return nil, nil
+	}
+}
+
+func (p *InfraPlan) DefaultFederatedGlobalJWTIssuer() string {
+	if p != nil && p.infra != nil && p.infra.Spec.Services != nil && p.infra.Spec.Services.GlobalGateway != nil && p.infra.Spec.Services.GlobalGateway.Config != nil {
+		if issuer := strings.TrimSpace(p.infra.Spec.Services.GlobalGateway.Config.JWTIssuer); issuer != "" {
+			return issuer
+		}
+	}
+	return "global-gateway"
+}
+
+func (p *InfraPlan) SharedUserJWTSecretName() string {
+	if p == nil {
+		return ""
+	}
+	return fmt.Sprintf("%s-user-jwt", p.Scope.Name)
+}
+
+func (p *InfraPlan) RegionalGatewayJWTSecretName() string {
+	if p == nil {
+		return ""
+	}
+	return fmt.Sprintf("%s-regional-gateway-jwt", p.Scope.Name)
+}
+
+func (p *InfraPlan) ClusterGatewayJWTSecretName() string {
+	if p == nil {
+		return ""
+	}
+	return fmt.Sprintf("%s-cluster-gateway-jwt", p.Scope.Name)
+}
+
+func (p *InfraPlan) ResolveNetdMITMCASecretName() string {
+	if p == nil || p.infra == nil {
+		return ""
+	}
+	if p.infra.Spec.Services != nil && p.infra.Spec.Services.Netd != nil {
+		if secretName := strings.TrimSpace(p.infra.Spec.Services.Netd.MITMCASecretName); secretName != "" {
+			return secretName
+		}
+	}
+	if p.Scope.Name == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s-netd-mitm-ca", p.Scope.Name)
+}
+
+func (p *InfraPlan) registryConfig() *registry.ResolvedRegistryConfig {
+	if p == nil || p.infra == nil {
+		return nil
+	}
+	return registry.ResolveRegistryConfig(p.infra)
+}
+
+func secretEnvVar(name, secretName, key string) corev1.EnvVar {
+	return corev1.EnvVar{
+		Name: name,
+		ValueFrom: &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
+				Key:                  key,
+			},
+		},
+	}
+}
+
+func defaultString(value, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return value
+}


### PR DESCRIPTION
## Summary
- remove direct `infra` parameters from the scheduler, manager, netd, regional-gateway, and cluster-gateway service reconciler entrypoints
- introduce a narrow object scope plus compiled-plan runtime accessors so service config and runtime dependencies are consumed from plan-shaped inputs instead of raw `Sandbox0Infra`
- keep the fullmode auth-mode fix for cluster-gateway and verify the refactor on remote kind

Closes #169

## Testing
- go test ./infra-operator/internal/plan ./infra-operator/internal/controller/services/scheduler ./infra-operator/internal/controller/services/manager ./infra-operator/internal/controller/services/netd ./infra-operator/internal/controller/services/clustergateway ./infra-operator/internal/controller/services/regionalgateway -count=1
- make test-again on kind
- smoke test on kind: /healthz, /auth/login, /api/v1/templates