### PR TITLE
Add managed-agent auth introspection and persistent procd volume credentials

### DIFF
--- a/cluster-gateway/pkg/http/handlers_context.go
+++ b/cluster-gateway/pkg/http/handlers_context.go
@@ -44,9 +44,9 @@ func (s *Server) createContext(c *gin.Context) {
 	if err != nil {
 		return
 	}
-	client := &http.Client{Timeout: s.cfg.ProxyTimeout.Duration}
-	if client.Timeout == 0 {
-		client.Timeout = 10 * time.Second
+	proxyTimeout := s.cfg.ProxyTimeout.Duration
+	if proxyTimeout == 0 {
+		proxyTimeout = 10 * time.Second
 	}
 	reqURL := *procdURL
 	reqURL.Path = "/api/v1/contexts"
@@ -55,11 +55,18 @@ func (s *Server) createContext(c *gin.Context) {
 		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "proxy initialization failed")
 		return
 	}
+	upReq, cancel := proxy.ApplyRequestTimeout(upReq, proxyTimeout)
+	defer cancel()
 	upReq.Header = c.Request.Header.Clone()
 	requestModifier(upReq)
 
+	client := &http.Client{}
 	resp, err := client.Do(upReq)
 	if err != nil {
+		if proxy.IsTimeoutError(err) {
+			spec.JSONError(c, http.StatusGatewayTimeout, spec.CodeUnavailable, "sandbox process request timed out")
+			return
+		}
 		spec.JSONError(c, http.StatusBadGateway, spec.CodeUnavailable, "failed to connect to sandbox process")
 		return
 	}

--- a/cluster-gateway/pkg/http/handlers_exposure.go
+++ b/cluster-gateway/pkg/http/handlers_exposure.go
@@ -93,6 +93,7 @@ func (s *Server) handlePublicExposureNoRoute(c *gin.Context) {
 		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "invalid sandbox address")
 		return
 	}
+	c.Request = proxy.WithUpstreamTimeoutDisabledRequest(c.Request)
 	proxyTimeout := s.cfg.ProxyTimeout.Duration
 	if proxyTimeout == 0 {
 		proxyTimeout = 10 * time.Second

--- a/cluster-gateway/pkg/http/server.go
+++ b/cluster-gateway/pkg/http/server.go
@@ -295,6 +295,7 @@ func (s *Server) setupRoutes() {
 	}))
 	s.router.Use(middleware.Recovery(s.logger))
 	s.router.Use(s.requestLogger.Logger())
+	s.router.Use(gatewaymiddleware.UpstreamTimeoutWhitelist())
 
 	// Health check endpoints (no auth required)
 	s.router.GET("/healthz", s.healthCheck)

--- a/cluster-gateway/pkg/middleware/compositeauth.go
+++ b/cluster-gateway/pkg/middleware/compositeauth.go
@@ -27,7 +27,7 @@ func NewCompositeAuthMiddleware(internal *InternalAuthMiddleware, public *gatewa
 
 func (m *CompositeAuthMiddleware) Authenticate() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		if m.internal != nil {
+		if m.internal != nil && m.internal.validator != nil {
 			authCtx, claims, err := m.internal.AuthenticateRequest(c)
 			if err == nil {
 				m.internal.setAuthContext(c, authCtx, claims)

--- a/cluster-gateway/pkg/middleware/compositeauth_test.go
+++ b/cluster-gateway/pkg/middleware/compositeauth_test.go
@@ -1,0 +1,77 @@
+package middleware
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/authn"
+	gatewaymiddleware "github.com/sandbox0-ai/sandbox0/pkg/gateway/middleware"
+	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+	"go.uber.org/zap"
+)
+
+func TestCompositeAuthMiddlewareFallsBackToPublicWithoutInternalValidator(t *testing.T) {
+	t.Setenv("GIN_MODE", "release")
+	gin.SetMode(gin.TestMode)
+
+	issuer := authn.NewIssuer("cluster-gateway", "test-secret", time.Minute, time.Hour)
+	tokens, err := issuer.IssueTokenPair("user-1", "user@example.com", "User", false, []authn.TeamGrant{
+		{TeamID: "team-1", TeamRole: "admin", HomeRegionID: "aws-us-east-1"},
+	})
+	if err != nil {
+		t.Fatalf("issue token pair: %v", err)
+	}
+
+	composite := NewCompositeAuthMiddleware(
+		NewInternalAuthMiddleware(nil, zap.NewNop()),
+		gatewaymiddleware.NewAuthMiddleware(nil, "test-secret", issuer, zap.NewNop()),
+		zap.NewNop(),
+	)
+
+	engine := gin.New()
+	engine.Use(composite.Authenticate())
+	engine.GET("/", func(c *gin.Context) {
+		authCtx := GetAuthContext(c)
+		if authCtx == nil {
+			t.Fatal("missing auth context")
+		}
+		c.JSON(http.StatusOK, gin.H{
+			"auth_method": authCtx.AuthMethod,
+			"team_id":     authCtx.TeamID,
+			"user_id":     authCtx.UserID,
+		})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+tokens.AccessToken)
+	req.Header.Set(internalauth.DefaultTokenHeader, "bogus-internal-token")
+	recorder := httptest.NewRecorder()
+
+	engine.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body = %s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+
+	var body struct {
+		AuthMethod string `json:"auth_method"`
+		TeamID     string `json:"team_id"`
+		UserID     string `json:"user_id"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.AuthMethod != string(authn.AuthMethodJWT) {
+		t.Fatalf("auth_method = %q, want %q", body.AuthMethod, authn.AuthMethodJWT)
+	}
+	if body.TeamID != "team-1" {
+		t.Fatalf("team_id = %q, want %q", body.TeamID, "team-1")
+	}
+	if body.UserID != "user-1" {
+		t.Fatalf("user_id = %q, want %q", body.UserID, "user-1")
+	}
+}

--- a/global-gateway/pkg/http/server.go
+++ b/global-gateway/pkg/http/server.go
@@ -154,6 +154,7 @@ func (s *Server) setupRoutes() {
 	}))
 	s.router.Use(gatewaymiddleware.Recovery(s.logger))
 	s.router.Use(s.requestLogger.Logger())
+	s.router.Use(gatewaymiddleware.UpstreamTimeoutWhitelist())
 
 	s.router.GET("/healthz", s.healthCheck)
 	s.router.GET("/readyz", s.readinessCheck)

--- a/infra-operator/chart/samples/single-cluster/fullmode.yaml
+++ b/infra-operator/chart/samples/single-cluster/fullmode.yaml
@@ -120,7 +120,7 @@ spec:
         type: NodePort
         port: 30080
       config:
-        authMode: public
+        authMode: both
     netd:
       enabled: true
       # Keep netd on a regular host runtime such as runc; do not run netd on gVisor or Kata.

--- a/infra-operator/chart/samples/single-cluster/fullmode.yaml
+++ b/infra-operator/chart/samples/single-cluster/fullmode.yaml
@@ -101,15 +101,6 @@ spec:
   #      value: gvisor
   #      effect: NoSchedule
   services:
-    regionalGateway:
-      enabled: true
-      replicas: 1
-    sshGateway:
-      enabled: true
-      replicas: 1
-      service:
-        type: NodePort
-        port: 30222
     clusterGateway:
       enabled: true
       replicas: 1
@@ -120,7 +111,7 @@ spec:
         type: NodePort
         port: 30080
       config:
-        authMode: both
+        authMode: public
     netd:
       enabled: true
       # Keep netd on a regular host runtime such as runc; do not run netd on gVisor or Kata.

--- a/infra-operator/internal/plan/plan.go
+++ b/infra-operator/internal/plan/plan.go
@@ -642,6 +642,10 @@ func compileValidationPlan(infra *infrav1alpha1.Sandbox0Infra, compiled *InfraPl
 	if compiled != nil && compiled.Components.EnableSSHGateway && !compiled.Components.EnableRegionalGateway {
 		plan.FatalErrors = append(plan.FatalErrors, "sshGateway requires regionalGateway to be enabled")
 	}
+	if compiled != nil && compiled.Components.EnableRegionalGateway && compiled.Components.EnableClusterGateway &&
+		!clusterGatewayInternalAuthEnabled(clusterGatewayAuthMode(infra)) {
+		plan.FatalErrors = append(plan.FatalErrors, "regionalGateway requires clusterGateway authMode internal/both when clusterGateway is enabled")
+	}
 	if infra.Spec.Cluster != nil && (compiled == nil || !compiled.Components.HasDataPlane) {
 		plan.FatalErrors = append(plan.FatalErrors, "cluster configuration requires at least one data-plane service")
 	}
@@ -1294,6 +1298,11 @@ func clusterGatewayEnterpriseLicenseRequired(infra *infrav1alpha1.Sandbox0Infra)
 func clusterGatewayPublicAuthEnabled(mode string) bool {
 	mode = strings.TrimSpace(strings.ToLower(mode))
 	return mode == "public" || mode == "both"
+}
+
+func clusterGatewayInternalAuthEnabled(mode string) bool {
+	mode = strings.TrimSpace(strings.ToLower(mode))
+	return mode == "internal" || mode == "both"
 }
 
 func hasEnabledOIDCProviders(providers []infrav1alpha1.OIDCProviderConfig) bool {

--- a/infra-operator/internal/plan/plan_test.go
+++ b/infra-operator/internal/plan/plan_test.go
@@ -736,6 +736,33 @@ func TestCompileTracksValidationRequirements(t *testing.T) {
 			t.Fatalf("expected init-user topology validation error, got %#v", compiled.Validation.FatalErrors)
 		}
 	})
+
+	t.Run("regional gateway requires cluster gateway internal auth", func(t *testing.T) {
+		infra := &infrav1alpha1.Sandbox0Infra{
+			Spec: infrav1alpha1.Sandbox0InfraSpec{
+				Services: &infrav1alpha1.ServicesConfig{
+					RegionalGateway: &infrav1alpha1.RegionalGatewayServiceConfig{
+						WorkloadServiceConfig: infrav1alpha1.WorkloadServiceConfig{
+							EnabledServiceConfig: infrav1alpha1.EnabledServiceConfig{Enabled: true},
+						},
+					},
+					ClusterGateway: &infrav1alpha1.ClusterGatewayServiceConfig{
+						WorkloadServiceConfig: infrav1alpha1.WorkloadServiceConfig{
+							EnabledServiceConfig: infrav1alpha1.EnabledServiceConfig{Enabled: true},
+						},
+						Config: &infrav1alpha1.ClusterGatewayConfig{
+							AuthMode: "public",
+						},
+					},
+				},
+			},
+		}
+
+		compiled := Compile(infra)
+		if !containsString(compiled.Validation.FatalErrors, "regionalGateway requires clusterGateway authMode internal/both when clusterGateway is enabled") {
+			t.Fatalf("expected regional/cluster auth mode validation error, got %#v", compiled.Validation.FatalErrors)
+		}
+	})
 }
 
 func TestCompileTracksWorkflowRequirements(t *testing.T) {

--- a/manager/pkg/apis/sandbox0/v1alpha1/helpers.go
+++ b/manager/pkg/apis/sandbox0/v1alpha1/helpers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 const (
@@ -231,6 +232,21 @@ func buildContainer(spec *ContainerSpec, template *SandboxTemplate) corev1.Conta
 	envVars = appendProcdConfigEnvVars(envVars)
 	container.Env = envVars
 	container.Command = []string{"/procd/bin/procd"}
+	container.Ports = append(container.Ports, corev1.ContainerPort{
+		Name:          "http",
+		ContainerPort: int32(procdHTTPPort()),
+	})
+	container.ReadinessProbe = &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path: "/readyz",
+				Port: intstr.FromString("http"),
+			},
+		},
+		PeriodSeconds:    1,
+		TimeoutSeconds:   1,
+		FailureThreshold: 3,
+	}
 	container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
 		Name:      procdBinVolumeName,
 		MountPath: "/procd/bin",
@@ -453,6 +469,14 @@ func appendProcdConfigEnvVars(envVars []corev1.EnvVar) []corev1.EnvVar {
 	})
 
 	return envVars
+}
+
+func procdHTTPPort() int {
+	cfg := config.LoadManagerConfig()
+	if cfg != nil && cfg.ProcdConfig.HTTPPort > 0 {
+		return cfg.ProcdConfig.HTTPPort
+	}
+	return 49983
 }
 
 func upsertProcdEnvVar(envIndex map[string]int, envVars *[]corev1.EnvVar, envVar corev1.EnvVar) {

--- a/manager/pkg/apis/sandbox0/v1alpha1/helpers_test.go
+++ b/manager/pkg/apis/sandbox0/v1alpha1/helpers_test.go
@@ -187,6 +187,35 @@ manager_image: sandbox0/manager:test
 	}
 }
 
+func TestBuildPodSpecAddsProcdReadinessProbe(t *testing.T) {
+	configPath := writeManagerConfig(t, `
+manager_image: sandbox0/manager:test
+procd_config:
+  http_port: 41000
+`)
+	t.Setenv("CONFIG_PATH", configPath)
+
+	spec := BuildPodSpec(newTestTemplate(), false)
+	if len(spec.Containers) == 0 {
+		t.Fatal("expected at least one container")
+	}
+
+	main := spec.Containers[0]
+	if main.ReadinessProbe == nil || main.ReadinessProbe.HTTPGet == nil {
+		t.Fatalf("expected procd readiness probe, got %#v", main.ReadinessProbe)
+	}
+	if main.ReadinessProbe.HTTPGet.Path != "/readyz" {
+		t.Fatalf("readiness path = %q, want /readyz", main.ReadinessProbe.HTTPGet.Path)
+	}
+	if main.ReadinessProbe.HTTPGet.Port.StrVal != "http" {
+		t.Fatalf("readiness port = %#v, want named http port", main.ReadinessProbe.HTTPGet.Port)
+	}
+	port := findContainerPort(main.Ports, "http")
+	if port == nil || port.ContainerPort != 41000 {
+		t.Fatalf("expected named http port 41000, got %#v", port)
+	}
+}
+
 func TestBuildPodSpecPreservesSidecarCommandAndProbes(t *testing.T) {
 	configPath := writeManagerConfig(t, `
 manager_image: sandbox0/manager:test
@@ -413,6 +442,15 @@ func findVolumeMount(mounts []corev1.VolumeMount, name string) *corev1.VolumeMou
 	for i := range mounts {
 		if mounts[i].Name == name {
 			return &mounts[i]
+		}
+	}
+	return nil
+}
+
+func findContainerPort(ports []corev1.ContainerPort, name string) *corev1.ContainerPort {
+	for i := range ports {
+		if ports[i].Name == name {
+			return &ports[i]
 		}
 	}
 	return nil

--- a/manager/procd/pkg/volume/grpc_fs.go
+++ b/manager/procd/pkg/volume/grpc_fs.go
@@ -2,10 +2,12 @@ package volume
 
 import (
 	"context"
+	"strings"
 	"syscall"
 	"time"
 
 	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	pb "github.com/sandbox0-ai/sandbox0/storage-proxy/proto/fs"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
@@ -16,19 +18,23 @@ import (
 type grpcFS struct {
 	fuse.RawFileSystem
 	volumeID      string
+	sessionID     string
+	sessionSecret string
 	client        pb.FileSystemClient
 	tokenProvider TokenProvider
 	cacheTTL      time.Duration
 	logger        *zap.Logger
 }
 
-func newGrpcFS(volumeID string, client pb.FileSystemClient, tokenProvider TokenProvider, cacheTTL time.Duration, logger *zap.Logger) *grpcFS {
+func newGrpcFS(volumeID, sessionID, sessionSecret string, client pb.FileSystemClient, tokenProvider TokenProvider, cacheTTL time.Duration, logger *zap.Logger) *grpcFS {
 	if cacheTTL < 0 {
 		cacheTTL = time.Second
 	}
 	return &grpcFS{
 		RawFileSystem: fuse.NewDefaultRawFileSystem(),
 		volumeID:      volumeID,
+		sessionID:     sessionID,
+		sessionSecret: sessionSecret,
 		client:        client,
 		tokenProvider: tokenProvider,
 		cacheTTL:      cacheTTL,
@@ -41,6 +47,13 @@ func (fs *grpcFS) String() string {
 }
 
 func (fs *grpcFS) withToken(ctx context.Context) (context.Context, error) {
+	if fs.sessionID != "" && fs.sessionSecret != "" {
+		return metadata.AppendToOutgoingContext(
+			ctx,
+			strings.ToLower(internalauth.VolumeSessionIDHeader), fs.sessionID,
+			strings.ToLower(internalauth.VolumeSessionSecretHeader), fs.sessionSecret,
+		), nil
+	}
 	if fs.tokenProvider == nil {
 		return nil, ErrMissingInternalToken
 	}

--- a/manager/procd/pkg/volume/grpc_fs_test.go
+++ b/manager/procd/pkg/volume/grpc_fs_test.go
@@ -9,6 +9,7 @@ import (
 	pb "github.com/sandbox0-ai/sandbox0/storage-proxy/proto/fs"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 )
 
 type staticTokenProvider struct{}
@@ -19,9 +20,13 @@ type captureFileSystemClient struct {
 	pb.FileSystemClient
 	lookupReq *pb.LookupRequest
 	writeReq  *pb.WriteRequest
+	lookupMD  metadata.MD
 }
 
-func (c *captureFileSystemClient) Lookup(_ context.Context, req *pb.LookupRequest, _ ...grpc.CallOption) (*pb.NodeResponse, error) {
+func (c *captureFileSystemClient) Lookup(ctx context.Context, req *pb.LookupRequest, _ ...grpc.CallOption) (*pb.NodeResponse, error) {
+	if md, ok := metadata.FromOutgoingContext(ctx); ok {
+		c.lookupMD = md
+	}
 	c.lookupReq = req
 	return &pb.NodeResponse{Inode: 2, Attr: &pb.GetAttrResponse{Mode: syscall.S_IFREG | 0o644}}, nil
 }
@@ -33,7 +38,7 @@ func (c *captureFileSystemClient) Write(_ context.Context, req *pb.WriteRequest,
 
 func TestGrpcFSLookupForwardsCallerActor(t *testing.T) {
 	client := &captureFileSystemClient{}
-	fs := newGrpcFS("vol-1", client, staticTokenProvider{}, 0, zap.NewNop())
+	fs := newGrpcFS("vol-1", "", "", client, staticTokenProvider{}, 0, zap.NewNop())
 	out := &fuse.EntryOut{}
 	header := &fuse.InHeader{NodeId: 1, Caller: fuse.Caller{Owner: fuse.Owner{Uid: 123, Gid: 456}, Pid: 789}}
 
@@ -53,7 +58,7 @@ func TestGrpcFSLookupForwardsCallerActor(t *testing.T) {
 
 func TestGrpcFSWriteForwardsCallerActor(t *testing.T) {
 	client := &captureFileSystemClient{}
-	fs := newGrpcFS("vol-1", client, staticTokenProvider{}, 0, zap.NewNop())
+	fs := newGrpcFS("vol-1", "", "", client, staticTokenProvider{}, 0, zap.NewNop())
 	input := &fuse.WriteIn{InHeader: fuse.InHeader{NodeId: 5, Caller: fuse.Caller{Owner: fuse.Owner{Uid: 1001, Gid: 1002}, Pid: 1003}}, Offset: 7, Fh: 11}
 
 	written, st := fs.Write(nil, input, []byte("hello"))
@@ -71,5 +76,25 @@ func TestGrpcFSWriteForwardsCallerActor(t *testing.T) {
 	}
 	if len(client.writeReq.Actor.Gids) != 1 || client.writeReq.Actor.Gids[0] != 1002 {
 		t.Fatalf("Write() gids = %v, want [1002]", client.writeReq.Actor.Gids)
+	}
+}
+
+func TestGrpcFSLookupUsesSessionCredentialWhenPresent(t *testing.T) {
+	client := &captureFileSystemClient{}
+	fs := newGrpcFS("vol-1", "session-1", "secret-1", client, staticTokenProvider{}, 0, zap.NewNop())
+	out := &fuse.EntryOut{}
+	header := &fuse.InHeader{NodeId: 1, Caller: fuse.Caller{Owner: fuse.Owner{Uid: 123, Gid: 456}, Pid: 789}}
+
+	if st := fs.Lookup(nil, header, "hello.txt", out); st != fuse.OK {
+		t.Fatalf("Lookup() status = %v, want OK", st)
+	}
+	if client.lookupMD == nil {
+		t.Fatal("Lookup() should carry outgoing metadata")
+	}
+	if got := client.lookupMD["x-volume-session-id"]; len(got) != 1 || got[0] != "session-1" {
+		t.Fatalf("x-volume-session-id = %v, want [session-1]", got)
+	}
+	if got := client.lookupMD["x-volume-session-secret"]; len(got) != 1 || got[0] != "secret-1" {
+		t.Fatalf("x-volume-session-secret = %v, want [secret-1]", got)
 	}
 }

--- a/manager/procd/pkg/volume/manager.go
+++ b/manager/procd/pkg/volume/manager.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	pb "github.com/sandbox0-ai/sandbox0/storage-proxy/proto/fs"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -23,6 +24,7 @@ type mountInfo struct {
 	mountPoint     string
 	mountedAt      time.Time
 	mountSessionID string
+	mountSecret    string
 	fuseServer     *fuse.Server
 	fs             *grpcFS
 	cancelWatch    context.CancelFunc
@@ -190,16 +192,16 @@ func (m *Manager) mount(ctx context.Context, req *MountRequest, reserved bool) (
 	}
 
 	volumeConfig := m.mergeVolumeConfig(req.VolumeConfig)
-	mountSessionID, err := m.mountVolumeRemote(ctx, client, req.SandboxVolumeID, volumeConfig)
+	mountSessionID, mountSessionSecret, err := m.mountVolumeRemote(ctx, client, req.SandboxVolumeID, volumeConfig)
 	if err != nil {
 		m.finishMountWithError(req.SandboxVolumeID, mountPoint, err)
 		return nil, err
 	}
 
-	fs := newGrpcFS(req.SandboxVolumeID, client, m.tokenProvider, m.cfg.CacheTTL, m.logger)
+	fs := newGrpcFS(req.SandboxVolumeID, mountSessionID, mountSessionSecret, client, m.tokenProvider, m.cfg.CacheTTL, m.logger)
 	server, err := m.mountFuse(fs, mountPoint)
 	if err != nil {
-		_ = m.unmountVolumeRemote(ctx, client, req.SandboxVolumeID, mountSessionID)
+		_ = m.unmountVolumeRemote(ctx, client, req.SandboxVolumeID, mountSessionID, mountSessionSecret)
 		m.finishMountWithError(req.SandboxVolumeID, mountPoint, err)
 		return nil, err
 	}
@@ -209,6 +211,7 @@ func (m *Manager) mount(ctx context.Context, req *MountRequest, reserved bool) (
 		mountPoint:     mountPoint,
 		mountedAt:      time.Now(),
 		mountSessionID: mountSessionID,
+		mountSecret:    mountSessionSecret,
 		fuseServer:     server,
 		fs:             fs,
 		watchDone:      make(chan struct{}),
@@ -272,7 +275,7 @@ func (m *Manager) Unmount(ctx context.Context, volumeID, mountSessionID string) 
 	if err != nil {
 		return err
 	}
-	if err := m.unmountVolumeRemote(ctx, client, volumeID, info.mountSessionID); err != nil {
+	if err := m.unmountVolumeRemote(ctx, client, volumeID, info.mountSessionID, info.mountSecret); err != nil {
 		return err
 	}
 
@@ -569,6 +572,17 @@ func (m *Manager) withToken(ctx context.Context) (context.Context, error) {
 	return metadata.AppendToOutgoingContext(ctx, "x-internal-token", token), nil
 }
 
+func withSessionCredential(ctx context.Context, sessionID, sessionSecret string) (context.Context, error) {
+	if strings.TrimSpace(sessionID) == "" || strings.TrimSpace(sessionSecret) == "" {
+		return nil, fmt.Errorf("missing mount session credential")
+	}
+	return metadata.AppendToOutgoingContext(
+		ctx,
+		strings.ToLower(internalauth.VolumeSessionIDHeader), sessionID,
+		strings.ToLower(internalauth.VolumeSessionSecretHeader), sessionSecret,
+	), nil
+}
+
 func (m *Manager) mergeVolumeConfig(override *VolumeConfig) *pb.VolumeConfig {
 	cacheSize := ""
 	prefetch := int32(0)
@@ -605,26 +619,32 @@ func (m *Manager) mergeVolumeConfig(override *VolumeConfig) *pb.VolumeConfig {
 	}
 }
 
-func (m *Manager) mountVolumeRemote(ctx context.Context, client pb.FileSystemClient, volumeID string, cfg *pb.VolumeConfig) (string, error) {
+func (m *Manager) mountVolumeRemote(ctx context.Context, client pb.FileSystemClient, volumeID string, cfg *pb.VolumeConfig) (string, string, error) {
 	callCtx, err := m.withToken(ctx)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	resp, err := client.MountVolume(callCtx, &pb.MountVolumeRequest{
 		VolumeId: volumeID,
 		Config:   cfg,
 	})
 	if err != nil {
-		return "", fmt.Errorf("mount volume via storage-proxy: %w", err)
+		return "", "", fmt.Errorf("mount volume via storage-proxy: %w", err)
 	}
 	if resp == nil || resp.MountSessionId == "" {
-		return "", fmt.Errorf("mount volume via storage-proxy: missing mount session id")
+		return "", "", fmt.Errorf("mount volume via storage-proxy: missing mount session id")
 	}
-	return resp.MountSessionId, nil
+	if strings.TrimSpace(resp.MountSessionSecret) == "" {
+		return "", "", fmt.Errorf("mount volume via storage-proxy: missing mount session secret")
+	}
+	return resp.MountSessionId, resp.MountSessionSecret, nil
 }
 
-func (m *Manager) unmountVolumeRemote(ctx context.Context, client pb.FileSystemClient, volumeID, mountSessionID string) error {
-	callCtx, err := m.withToken(ctx)
+func (m *Manager) unmountVolumeRemote(ctx context.Context, client pb.FileSystemClient, volumeID, mountSessionID, mountSessionSecret string) error {
+	callCtx, err := withSessionCredential(ctx, mountSessionID, mountSessionSecret)
+	if err != nil {
+		callCtx, err = m.withToken(ctx)
+	}
 	if err != nil {
 		return err
 	}
@@ -638,7 +658,7 @@ func (m *Manager) unmountVolumeRemote(ctx context.Context, client pb.FileSystemC
 	return nil
 }
 
-func (m *Manager) ackInvalidate(ctx context.Context, volumeID, mountSessionID, invalidateID string, remountErr error) {
+func (m *Manager) ackInvalidate(ctx context.Context, volumeID, mountSessionID, mountSessionSecret, invalidateID string, remountErr error) {
 	if volumeID == "" || mountSessionID == "" || invalidateID == "" {
 		return
 	}
@@ -647,7 +667,10 @@ func (m *Manager) ackInvalidate(ctx context.Context, volumeID, mountSessionID, i
 		m.logger.Warn("Failed to get storage-proxy client to ack invalidate", zap.Error(err))
 		return
 	}
-	callCtx, err := m.withToken(ctx)
+	callCtx, err := withSessionCredential(ctx, mountSessionID, mountSessionSecret)
+	if err != nil {
+		callCtx, err = m.withToken(ctx)
+	}
 	if err != nil {
 		m.logger.Warn("Failed to get internal token to ack invalidate", zap.Error(err))
 		return
@@ -714,7 +737,10 @@ func (m *Manager) startWatch(info *mountInfo, req *MountRequest) {
 	go func() {
 		defer close(info.watchDone)
 
-		callCtx, err := m.withToken(ctx)
+		callCtx, err := withSessionCredential(ctx, info.mountSessionID, info.mountSecret)
+		if err != nil {
+			callCtx, err = m.withToken(ctx)
+		}
 		if err != nil {
 			m.logger.Warn("Missing storage-proxy token for watch", zap.Error(err))
 			return
@@ -789,7 +815,7 @@ func (m *Manager) remountVolume(volumeID, mountSessionID, invalidateID string) {
 		}
 		m.mu.Unlock()
 		if invalidateID != "" {
-			m.ackInvalidate(context.Background(), volumeID, mountSessionID, invalidateID, remountErr)
+			m.ackInvalidate(context.Background(), volumeID, mountSessionID, info.mountSecret, invalidateID, remountErr)
 		}
 	}()
 
@@ -811,7 +837,7 @@ func (m *Manager) remountVolume(volumeID, mountSessionID, invalidateID string) {
 		return
 	}
 
-	fs := newGrpcFS(volumeID, client, m.tokenProvider, m.cfg.CacheTTL, m.logger)
+	fs := newGrpcFS(volumeID, info.mountSessionID, info.mountSecret, client, m.tokenProvider, m.cfg.CacheTTL, m.logger)
 	server, err := m.mountFuse(fs, mountPoint)
 	if err != nil {
 		remountErr = err

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -1031,6 +1031,26 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorEnvelope"
+  /api-keys/current:
+    get:
+      tags: [api-keys]
+      summary: Introspect current API key
+      description: Returns the identity and permissions of the currently authenticated API key.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Current API key details
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessCurrentAPIKeyResponse"
+        "401":
+          description: API key authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
   /api-keys/{id}:
     delete:
       tags: [api-keys]
@@ -3722,6 +3742,31 @@ components:
           type: string
           format: date-time
       required: [id, name, type, roles, team_id, expires_at, created_at]
+    CurrentAPIKeyResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        team_id:
+          type: string
+        created_by:
+          type: string
+        type:
+          type: string
+        roles:
+          type: array
+          items:
+            type: string
+        permissions:
+          type: array
+          items:
+            type: string
+        is_active:
+          type: boolean
+        expires_at:
+          type: string
+          format: date-time
+      required: [id, team_id, created_by, type, roles, permissions, is_active, expires_at]
     SuccessCreateAPIKeyResponse:
       allOf:
         - $ref: "#/components/schemas/SuccessEnvelope"
@@ -3729,6 +3774,16 @@ components:
           properties:
             data:
               $ref: "#/components/schemas/CreateAPIKeyResponse"
+    SuccessCurrentAPIKeyResponse:
+      allOf:
+        - $ref: "#/components/schemas/SuccessEnvelope"
+        - type: object
+          properties:
+            data:
+              type: object
+              properties:
+                api_key:
+                  $ref: "#/components/schemas/CurrentAPIKeyResponse"
     SuccessAPIKeyListResponse:
       allOf:
         - $ref: "#/components/schemas/SuccessEnvelope"

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -222,6 +222,11 @@ const (
 	SuccessCredentialSourceResponseSuccessTrue SuccessCredentialSourceResponseSuccess = true
 )
 
+// Defines values for SuccessCurrentAPIKeyResponseSuccess.
+const (
+	SuccessCurrentAPIKeyResponseSuccessTrue SuccessCurrentAPIKeyResponseSuccess = true
+)
+
 // Defines values for SuccessDeletedResponseSuccess.
 const (
 	SuccessDeletedResponseSuccessTrue SuccessDeletedResponseSuccess = true
@@ -464,7 +469,7 @@ const (
 
 // Defines values for SuccessWrittenResponseSuccess.
 const (
-	SuccessWrittenResponseSuccessTrue SuccessWrittenResponseSuccess = true
+	True SuccessWrittenResponseSuccess = true
 )
 
 // Defines values for SyncEventType.
@@ -884,6 +889,18 @@ type CredentialSourceWriteSpec struct {
 	StaticHeaders              *StaticHeadersSourceSpec              `json:"staticHeaders,omitempty"`
 	StaticTLSClientCertificate *StaticTLSClientCertificateSourceSpec `json:"staticTLSClientCertificate,omitempty"`
 	StaticUsernamePassword     *StaticUsernamePasswordSourceSpec     `json:"staticUsernamePassword,omitempty"`
+}
+
+// CurrentAPIKeyResponse defines model for CurrentAPIKeyResponse.
+type CurrentAPIKeyResponse struct {
+	CreatedBy   string    `json:"created_by"`
+	ExpiresAt   time.Time `json:"expires_at"`
+	Id          string    `json:"id"`
+	IsActive    bool      `json:"is_active"`
+	Permissions []string  `json:"permissions"`
+	Roles       []string  `json:"roles"`
+	TeamId      string    `json:"team_id"`
+	Type        string    `json:"type"`
 }
 
 // DeviceLoginPollRequest defines model for DeviceLoginPollRequest.
@@ -1849,6 +1866,17 @@ type SuccessCredentialSourceResponse struct {
 
 // SuccessCredentialSourceResponseSuccess defines model for SuccessCredentialSourceResponse.Success.
 type SuccessCredentialSourceResponseSuccess bool
+
+// SuccessCurrentAPIKeyResponse defines model for SuccessCurrentAPIKeyResponse.
+type SuccessCurrentAPIKeyResponse struct {
+	Data *struct {
+		ApiKey *CurrentAPIKeyResponse `json:"api_key,omitempty"`
+	} `json:"data,omitempty"`
+	Success SuccessCurrentAPIKeyResponseSuccess `json:"success"`
+}
+
+// SuccessCurrentAPIKeyResponseSuccess defines model for SuccessCurrentAPIKeyResponse.Success.
+type SuccessCurrentAPIKeyResponseSuccess bool
 
 // SuccessDeletedResponse defines model for SuccessDeletedResponse.
 type SuccessDeletedResponse struct {

--- a/pkg/gateway/apikey/repository.go
+++ b/pkg/gateway/apikey/repository.go
@@ -219,14 +219,14 @@ func (r *Repository) ValidateAPIKey(ctx context.Context, keyValue string) (*APIK
 	var rolesJSON []byte
 	err := r.pool.QueryRow(ctx, `
 		SELECT id, key_value, team_id, created_by, name, type, roles,
-		       is_active, expires_at, last_used_at, usage_count, created_at, updated_at
+		       is_active, expires_at, last_used_at, usage_count, created_at, updated_at, user_id
 		FROM api_keys
 		WHERE key_value = $1
 	`, keyValue).Scan(
 		&key.ID, &key.KeyValue, &key.TeamID, &key.CreatedBy,
 		&key.Name, &key.Type, &rolesJSON, &key.IsActive,
 		&key.ExpiresAt, &key.LastUsed, &key.UsageCount,
-		&key.CreatedAt, &key.UpdatedAt,
+		&key.CreatedAt, &key.UpdatedAt, &key.UserID,
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {

--- a/pkg/gateway/http/handlers/apikey.go
+++ b/pkg/gateway/http/handlers/apikey.go
@@ -79,6 +79,51 @@ type CreateAPIKeyResponse struct {
 	CreatedAt time.Time `json:"created_at"`
 }
 
+// CurrentAPIKeyResponse is returned when an API key introspects itself.
+type CurrentAPIKeyResponse struct {
+	ID          string    `json:"id"`
+	TeamID      string    `json:"team_id"`
+	CreatedBy   string    `json:"created_by"`
+	Type        string    `json:"type"`
+	Roles       []string  `json:"roles"`
+	Permissions []string  `json:"permissions"`
+	IsActive    bool      `json:"is_active"`
+	ExpiresAt   time.Time `json:"expires_at"`
+}
+
+// GetCurrentAPIKey introspects the currently authenticated API key.
+func (h *APIKeyHandler) GetCurrentAPIKey(c *gin.Context) {
+	authCtx := middleware.GetAuthContext(c)
+	if authCtx == nil || authCtx.APIKeyID == "" {
+		spec.JSONError(c, http.StatusUnauthorized, spec.CodeUnauthorized, "api key authentication required")
+		return
+	}
+
+	key, err := h.keys.GetAPIKeyByID(c.Request.Context(), authCtx.APIKeyID)
+	if err != nil {
+		if errors.Is(err, apikey.ErrNotFound) {
+			spec.JSONError(c, http.StatusNotFound, spec.CodeNotFound, "API key not found")
+			return
+		}
+		h.logger.Error("Failed to introspect current API key", zap.Error(err), zap.String("api_key_id", authCtx.APIKeyID))
+		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to introspect API key")
+		return
+	}
+
+	spec.JSONSuccess(c, http.StatusOK, gin.H{
+		"api_key": &CurrentAPIKeyResponse{
+			ID:          key.ID,
+			TeamID:      key.TeamID,
+			CreatedBy:   key.CreatedBy,
+			Type:        key.Type,
+			Roles:       key.Roles,
+			Permissions: append([]string(nil), authCtx.Permissions...),
+			IsActive:    key.IsActive,
+			ExpiresAt:   key.ExpiresAt,
+		},
+	})
+}
+
 // CreateAPIKey creates a new API key
 func (h *APIKeyHandler) CreateAPIKey(c *gin.Context) {
 	authCtx := middleware.GetAuthContext(c)

--- a/pkg/gateway/middleware/auth.go
+++ b/pkg/gateway/middleware/auth.go
@@ -109,10 +109,15 @@ func (m *AuthMiddleware) authenticateAPIKey(c *gin.Context, keyValue string) (*a
 	if err != nil {
 		return nil, err
 	}
+	userID := strings.TrimSpace(apiKey.CreatedBy)
+	if apiKey.UserID != nil && strings.TrimSpace(*apiKey.UserID) != "" {
+		userID = strings.TrimSpace(*apiKey.UserID)
+	}
 
 	return &authn.AuthContext{
 		AuthMethod:  authn.AuthMethodAPIKey,
 		TeamID:      apiKey.TeamID,
+		UserID:      userID,
 		APIKeyID:    apiKey.ID,
 		Permissions: authn.ExpandRolesPermissions(apiKey.Roles),
 	}, nil

--- a/pkg/gateway/middleware/auth_test.go
+++ b/pkg/gateway/middleware/auth_test.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -8,10 +9,19 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/apikey"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/authn"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"go.uber.org/zap"
 )
+
+type staticAPIKeyValidator struct {
+	key *apikey.APIKey
+}
+
+func (v staticAPIKeyValidator) ValidateAPIKey(context.Context, string) (*apikey.APIKey, error) {
+	return v.key, nil
+}
 
 func TestAuthMiddleware_JWTAccessToken(t *testing.T) {
 	t.Setenv("GIN_MODE", "release")
@@ -84,6 +94,59 @@ func TestAuthMiddleware_JWTRefreshTokenRejected(t *testing.T) {
 	middleware := NewAuthMiddleware(nil, "test-secret", issuer, zap.NewNop())
 	if _, err := middleware.AuthenticateRequest(ctx); err == nil {
 		t.Fatalf("expected refresh token to be rejected")
+	}
+}
+
+func TestAuthMiddleware_APIKeyCarriesOwnerUserID(t *testing.T) {
+	t.Setenv("GIN_MODE", "release")
+
+	ownerID := "user-1"
+	req := httptest.NewRequest("GET", "/api/v1/templates", nil)
+	req.Header.Set("Authorization", "Bearer s0_test")
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = req
+
+	middleware := NewAuthMiddleware(staticAPIKeyValidator{key: &apikey.APIKey{
+		ID:        "key-1",
+		TeamID:    "team-1",
+		UserID:    &ownerID,
+		CreatedBy: "creator-1",
+		Roles:     []string{"developer"},
+	}}, "test-secret", nil, zap.NewNop())
+	authCtx, err := middleware.AuthenticateRequest(ctx)
+	if err != nil {
+		t.Fatalf("authenticate request: %v", err)
+	}
+	if authCtx.UserID != ownerID {
+		t.Fatalf("user id = %q, want %q", authCtx.UserID, ownerID)
+	}
+	if authCtx.TeamID != "team-1" || authCtx.APIKeyID != "key-1" {
+		t.Fatalf("unexpected auth context: %+v", authCtx)
+	}
+}
+
+func TestAuthMiddleware_APIKeyFallsBackToCreatorUserID(t *testing.T) {
+	t.Setenv("GIN_MODE", "release")
+
+	req := httptest.NewRequest("GET", "/api/v1/templates", nil)
+	req.Header.Set("Authorization", "Bearer s0_test")
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = req
+
+	middleware := NewAuthMiddleware(staticAPIKeyValidator{key: &apikey.APIKey{
+		ID:        "key-1",
+		TeamID:    "team-1",
+		CreatedBy: "creator-1",
+		Roles:     []string{"developer"},
+	}}, "test-secret", nil, zap.NewNop())
+	authCtx, err := middleware.AuthenticateRequest(ctx)
+	if err != nil {
+		t.Fatalf("authenticate request: %v", err)
+	}
+	if authCtx.UserID != "creator-1" {
+		t.Fatalf("user id = %q, want creator-1", authCtx.UserID)
 	}
 }
 

--- a/pkg/gateway/middleware/upstream_timeout.go
+++ b/pkg/gateway/middleware/upstream_timeout.go
@@ -1,0 +1,35 @@
+package middleware
+
+import (
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sandbox0-ai/sandbox0/pkg/proxy"
+)
+
+var upstreamTimeoutWhitelistPrefixes = []string{
+	"/api/v1/sandboxes",
+	"/api/v1/sandboxvolumes",
+}
+
+// UpstreamTimeoutWhitelist disables gateway proxy timeouts for long-running API
+// routes that can legitimately outlive the default upstream timeout.
+func UpstreamTimeoutWhitelist() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if RequestPathAllowedWithoutUpstreamTimeout(c.Request.URL.Path) {
+			c.Request = proxy.WithUpstreamTimeoutDisabledRequest(c.Request)
+		}
+		c.Next()
+	}
+}
+
+// RequestPathAllowedWithoutUpstreamTimeout reports whether a request path is
+// covered by the long-running upstream timeout whitelist.
+func RequestPathAllowedWithoutUpstreamTimeout(path string) bool {
+	for _, prefix := range upstreamTimeoutWhitelistPrefixes {
+		if path == prefix || strings.HasPrefix(path, prefix+"/") {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/gateway/middleware/upstream_timeout_test.go
+++ b/pkg/gateway/middleware/upstream_timeout_test.go
@@ -1,0 +1,25 @@
+package middleware
+
+import "testing"
+
+func TestRequestPathAllowedWithoutUpstreamTimeout(t *testing.T) {
+	testCases := []struct {
+		path string
+		want bool
+	}{
+		{path: "/api/v1/sandboxes", want: true},
+		{path: "/api/v1/sandboxes/sb-1", want: true},
+		{path: "/api/v1/sandboxes/sb-1/contexts/ctx-1/exec", want: true},
+		{path: "/api/v1/sandboxvolumes", want: true},
+		{path: "/api/v1/sandboxvolumes/vol-1/snapshots/snap-1/restore", want: true},
+		{path: "/api/v1/templates", want: false},
+		{path: "/readyz", want: false},
+		{path: "/api/v1/sandboxes-extra", want: false},
+	}
+
+	for _, tc := range testCases {
+		if got := RequestPathAllowedWithoutUpstreamTimeout(tc.path); got != tc.want {
+			t.Fatalf("RequestPathAllowedWithoutUpstreamTimeout(%q) = %v, want %v", tc.path, got, tc.want)
+		}
+	}
+}

--- a/pkg/gateway/public/routes.go
+++ b/pkg/gateway/public/routes.go
@@ -141,6 +141,12 @@ func RegisterAPIKeyRoutes(router gin.IRouter, deps Deps) {
 	if deps.APIKeyRepo != nil {
 		apiKeyHandler := handlers.NewAPIKeyHandler(deps.APIKeyRepo, deps.IdentityRepo, deps.RegionID, deps.Logger)
 
+		apiKeySelf := router.Group("/api-keys")
+		apiKeySelf.Use(deps.AuthMiddleware.Authenticate())
+		{
+			apiKeySelf.GET("/current", apiKeyHandler.GetCurrentAPIKey)
+		}
+
 		// ===== API Key Management Routes =====
 		apiKeys := router.Group("/api-keys")
 		apiKeys.Use(deps.AuthMiddleware.Authenticate())

--- a/pkg/gateway/public/routes_test.go
+++ b/pkg/gateway/public/routes_test.go
@@ -37,6 +37,9 @@ func TestRegisterAPIKeyRoutesOnlyMountsRegionalAPIKeySurface(t *testing.T) {
 	if !hasRoute(router, "GET", "/api-keys") {
 		t.Fatal("expected regional routes to include /api-keys")
 	}
+	if !hasRoute(router, "GET", "/api-keys/current") {
+		t.Fatal("expected regional routes to include /api-keys/current")
+	}
 	if hasRoute(router, "GET", "/users/me") {
 		t.Fatal("expected regional API key routes to omit /users/me")
 	}

--- a/pkg/internalauth/middleware.go
+++ b/pkg/internalauth/middleware.go
@@ -20,6 +20,12 @@ const (
 
 	// TokenForProcdHeader is the header name used to pass a storage token to procd.
 	TokenForProcdHeader = "X-Token-For-Procd"
+
+	// VolumeSessionIDHeader is the header for a storage-proxy mount session identifier.
+	VolumeSessionIDHeader = "X-Volume-Session-ID"
+
+	// VolumeSessionSecretHeader is the header for a storage-proxy mount session secret.
+	VolumeSessionSecretHeader = "X-Volume-Session-Secret"
 )
 
 // TokenExtractor extracts the internal token from an HTTP request.

--- a/pkg/proxy/request_timeout.go
+++ b/pkg/proxy/request_timeout.go
@@ -1,0 +1,71 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"time"
+)
+
+type upstreamTimeoutDisabledKey struct{}
+
+// WithUpstreamTimeoutDisabled marks a request context so gateway upstream calls
+// should not apply the default proxy timeout.
+func WithUpstreamTimeoutDisabled(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, upstreamTimeoutDisabledKey{}, true)
+}
+
+// WithUpstreamTimeoutDisabledRequest applies the no-timeout marker to a request.
+func WithUpstreamTimeoutDisabledRequest(req *http.Request) *http.Request {
+	if req == nil {
+		return nil
+	}
+	return req.WithContext(WithUpstreamTimeoutDisabled(req.Context()))
+}
+
+// UpstreamTimeoutDisabled reports whether upstream timeout enforcement is disabled.
+func UpstreamTimeoutDisabled(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	disabled, _ := ctx.Value(upstreamTimeoutDisabledKey{}).(bool)
+	return disabled
+}
+
+// EffectiveUpstreamTimeout returns the timeout to apply for an upstream request.
+func EffectiveUpstreamTimeout(ctx context.Context, defaultTimeout time.Duration) time.Duration {
+	if defaultTimeout <= 0 || UpstreamTimeoutDisabled(ctx) {
+		return 0
+	}
+	return defaultTimeout
+}
+
+// ApplyRequestTimeout derives a request context with the effective upstream
+// timeout. The returned cancel func is always safe to call.
+func ApplyRequestTimeout(req *http.Request, defaultTimeout time.Duration) (*http.Request, context.CancelFunc) {
+	if req == nil {
+		return nil, func() {}
+	}
+	timeout := EffectiveUpstreamTimeout(req.Context(), defaultTimeout)
+	if timeout <= 0 {
+		return req, func() {}
+	}
+	ctx, cancel := context.WithTimeout(req.Context(), timeout)
+	return req.WithContext(ctx), cancel
+}
+
+// IsTimeoutError reports whether err was caused by an upstream timeout.
+func IsTimeoutError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
+}

--- a/pkg/proxy/router.go
+++ b/pkg/proxy/router.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httputil"
@@ -50,8 +51,16 @@ func (r *Router) ProxyToTarget(c *gin.Context) {
 		return
 	}
 
+	req := c.Request
+	cancel := context.CancelFunc(func() {})
+	if r.timeout > 0 {
+		req, cancel = ApplyRequestTimeout(c.Request, r.timeout)
+		c.Request = req
+	}
+	defer cancel()
+
 	proxy := r.createReverseProxyDirector(r.targetUrl)
-	proxy.ServeHTTP(c.Writer, c.Request)
+	proxy.ServeHTTP(c.Writer, req)
 }
 
 // createReverseProxyDirector creates an httputil.ReverseProxy with proper configuration
@@ -95,13 +104,20 @@ func (r *Router) createReverseProxyDirector(target *url.URL) *httputil.ReversePr
 		Director:  director,
 		Transport: transport,
 		ErrorHandler: func(w http.ResponseWriter, req *http.Request, err error) {
+			status := http.StatusBadGateway
+			body := `{"error": "upstream service unavailable"}`
+			if IsTimeoutError(err) {
+				status = http.StatusGatewayTimeout
+				body = `{"error": "upstream request timed out"}`
+			}
 			r.logger.Error("Proxy error",
 				zap.String("target", req.URL.String()),
+				zap.Int("status", status),
 				zap.Error(err),
 			)
 			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusBadGateway)
-			w.Write([]byte(`{"error": "upstream service unavailable"}`))
+			w.WriteHeader(status)
+			_, _ = w.Write([]byte(body))
 		},
 	}
 

--- a/pkg/proxy/router_test.go
+++ b/pkg/proxy/router_test.go
@@ -1,0 +1,84 @@
+package proxy
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+)
+
+func TestRouterProxyToTargetTimesOutByDefault(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer upstream.Close()
+
+	router, err := NewRouter(upstream.URL, zap.NewNop(), 50*time.Millisecond)
+	if err != nil {
+		t.Fatalf("NewRouter() error = %v", err)
+	}
+
+	engine := gin.New()
+	engine.GET("/", router.ProxyToTarget)
+
+	server := httptest.NewServer(engine)
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/")
+	if err != nil {
+		t.Fatalf("GET() error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusGatewayTimeout {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusGatewayTimeout)
+	}
+}
+
+func TestRouterProxyToTargetSkipsTimeoutWhenDisabled(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer upstream.Close()
+
+	router, err := NewRouter(upstream.URL, zap.NewNop(), 50*time.Millisecond)
+	if err != nil {
+		t.Fatalf("NewRouter() error = %v", err)
+	}
+
+	engine := gin.New()
+	engine.GET("/", func(c *gin.Context) {
+		c.Request = WithUpstreamTimeoutDisabledRequest(c.Request)
+		router.ProxyToTarget(c)
+	})
+
+	server := httptest.NewServer(engine)
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/")
+	if err != nil {
+		t.Fatalf("GET() error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if body := string(bodyBytes); body != "ok" {
+		t.Fatalf("body = %q, want %q", body, "ok")
+	}
+}

--- a/regional-gateway/pkg/http/cluster_cache.go
+++ b/regional-gateway/pkg/http/cluster_cache.go
@@ -91,6 +91,8 @@ func (s *Server) refreshClusterCache(ctx context.Context, authCtx *authn.AuthCon
 	if err != nil {
 		return fmt.Errorf("create scheduler request: %w", err)
 	}
+	req, cancel := proxy.ApplyRequestTimeout(req, s.cfg.ProxyTimeout.Duration)
+	defer cancel()
 
 	token, err := s.generateInternalToken(authCtx, "scheduler")
 	if err != nil {
@@ -106,7 +108,7 @@ func (s *Server) refreshClusterCache(ctx context.Context, authCtx *authn.AuthCon
 	}
 	req.Header.Set("X-Auth-Method", string(authCtx.AuthMethod))
 
-	client := &http.Client{Timeout: s.cfg.ProxyTimeout.Duration}
+	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("list clusters: %w", err)

--- a/regional-gateway/pkg/http/exposure_proxy.go
+++ b/regional-gateway/pkg/http/exposure_proxy.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
+	"github.com/sandbox0-ai/sandbox0/pkg/proxy"
 )
 
 func (s *Server) proxyPublicExposureNoRoute(c *gin.Context) {
@@ -30,6 +31,7 @@ func (s *Server) proxyPublicExposureNoRoute(c *gin.Context) {
 
 	c.Request.Header.Set("X-Sandbox-ID", sandboxID)
 	c.Request.Header.Set("X-Exposure-Port", strconv.Itoa(port))
+	c.Request = proxy.WithUpstreamTimeoutDisabledRequest(c.Request)
 
 	if s.schedulerRouter == nil {
 		s.clusterGatewayRouter.ProxyToTarget(c)

--- a/regional-gateway/pkg/http/internal_ssh.go
+++ b/regional-gateway/pkg/http/internal_ssh.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
+	"github.com/sandbox0-ai/sandbox0/pkg/proxy"
 	sharedssh "github.com/sandbox0-ai/sandbox0/pkg/sshgateway"
 	"go.uber.org/zap"
 )
@@ -160,8 +161,10 @@ func (s *Server) getSandboxFromClusterGateway(ctx context.Context, clusterGatewa
 		return nil, http.StatusInternalServerError, fmt.Errorf("generate cluster-gateway token: %w", err)
 	}
 	req.Header.Set(internalauth.DefaultTokenHeader, token)
+	req, cancel := proxy.ApplyRequestTimeout(req, s.cfg.ProxyTimeout.Duration)
+	defer cancel()
 
-	resp, err := (&http.Client{Timeout: s.cfg.ProxyTimeout.Duration}).Do(req)
+	resp, err := (&http.Client{}).Do(req)
 	if err != nil {
 		return nil, http.StatusServiceUnavailable, fmt.Errorf("call cluster-gateway sandbox endpoint: %w", err)
 	}
@@ -208,7 +211,10 @@ func (s *Server) resumeSandboxViaClusterGateway(ctx context.Context, clusterGate
 	req.Header.Set(internalauth.UserIDHeader, userID)
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := (&http.Client{Timeout: s.cfg.ProxyTimeout.Duration}).Do(req)
+	req, cancel := proxy.ApplyRequestTimeout(req, s.cfg.ProxyTimeout.Duration)
+	defer cancel()
+
+	resp, err := (&http.Client{}).Do(req)
 	if err != nil {
 		return fmt.Errorf("call cluster-gateway resume endpoint: %w", err)
 	}

--- a/regional-gateway/pkg/http/server.go
+++ b/regional-gateway/pkg/http/server.go
@@ -261,6 +261,7 @@ func (s *Server) setupRoutes() {
 	}))
 	s.router.Use(middleware.Recovery(s.logger))
 	s.router.Use(s.requestLogger.Logger())
+	s.router.Use(middleware.UpstreamTimeoutWhitelist())
 
 	// Health check endpoints (no auth required)
 	s.router.GET("/healthz", s.healthCheck)

--- a/scheduler/pkg/http/server.go
+++ b/scheduler/pkg/http/server.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
+	gatewaymiddleware "github.com/sandbox0-ai/sandbox0/pkg/gateway/middleware"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"github.com/sandbox0-ai/sandbox0/pkg/licensing"
@@ -101,6 +102,7 @@ func NewServer(
 	}))
 	router.Use(gin.Recovery())
 	router.Use(requestLogger(logger))
+	router.Use(gatewaymiddleware.UpstreamTimeoutWhitelist())
 
 	server := &Server{
 		router:                router,

--- a/storage-proxy/cmd/storage-proxy/main.go
+++ b/storage-proxy/cmd/storage-proxy/main.go
@@ -302,7 +302,20 @@ func main() {
 		ReplayDetectionEnabled: false, // Disable for high-throughput scenarios
 	})
 
-	authenticator := auth.NewGRPCAuthenticator(validator, zapLogger)
+	sessionResolver := auth.SessionClaimsResolverFunc(func(ctx context.Context, volumeID, sessionID, sessionSecret string) (*internalauth.Claims, error) {
+		principal, err := volMgr.AuthenticateMountSession(volumeID, sessionID, sessionSecret)
+		if err != nil {
+			return nil, err
+		}
+		return &internalauth.Claims{
+			Caller:    internalauth.ServiceProcd,
+			Target:    internalauth.ServiceStorageProxy,
+			TeamID:    principal.TeamID,
+			SandboxID: principal.SandboxID,
+		}, nil
+	})
+
+	authenticator := auth.NewGRPCAuthenticator(validator, sessionResolver, zapLogger)
 	grpcInterceptor = authenticator.UnaryInterceptor()
 
 	httpAuthenticator = auth.NewHTTPAuthenticator(validator, zapLogger)

--- a/storage-proxy/pkg/auth/interceptor.go
+++ b/storage-proxy/pkg/auth/interceptor.go
@@ -2,6 +2,8 @@ package auth
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"go.uber.org/zap"
@@ -13,15 +15,31 @@ import (
 
 // GRPCAuthenticator handles gRPC request authentication using internalauth.
 type GRPCAuthenticator struct {
-	validator *internalauth.Validator
-	logger    *zap.Logger
+	validator       *internalauth.Validator
+	sessionResolver SessionClaimsResolver
+	logger          *zap.Logger
+}
+
+// SessionClaimsResolver resolves volume session credentials into internalauth
+// claims for downstream request handling.
+type SessionClaimsResolver interface {
+	ResolveVolumeSessionClaims(ctx context.Context, volumeID, sessionID, sessionSecret string) (*internalauth.Claims, error)
+}
+
+// SessionClaimsResolverFunc adapts a function to SessionClaimsResolver.
+type SessionClaimsResolverFunc func(ctx context.Context, volumeID, sessionID, sessionSecret string) (*internalauth.Claims, error)
+
+// ResolveVolumeSessionClaims implements SessionClaimsResolver.
+func (f SessionClaimsResolverFunc) ResolveVolumeSessionClaims(ctx context.Context, volumeID, sessionID, sessionSecret string) (*internalauth.Claims, error) {
+	return f(ctx, volumeID, sessionID, sessionSecret)
 }
 
 // NewGRPCAuthenticator creates a new gRPC authenticator.
-func NewGRPCAuthenticator(validator *internalauth.Validator, logger *zap.Logger) *GRPCAuthenticator {
+func NewGRPCAuthenticator(validator *internalauth.Validator, sessionResolver SessionClaimsResolver, logger *zap.Logger) *GRPCAuthenticator {
 	return &GRPCAuthenticator{
-		validator: validator,
-		logger:    logger,
+		validator:       validator,
+		sessionResolver: sessionResolver,
+		logger:          logger,
 	}
 }
 
@@ -39,7 +57,7 @@ func (a *GRPCAuthenticator) UnaryInterceptor() grpc.UnaryServerInterceptor {
 		}
 
 		// Extract and validate token
-		claims, err := a.authenticate(ctx)
+		claims, err := a.authenticate(ctx, req)
 		if err != nil {
 			a.logger.Warn("Authentication failed",
 				zap.String("method", info.FullMethod),
@@ -62,7 +80,7 @@ func (a *GRPCAuthenticator) UnaryInterceptor() grpc.UnaryServerInterceptor {
 }
 
 // authenticate extracts token from gRPC metadata and validates it.
-func (a *GRPCAuthenticator) authenticate(ctx context.Context) (*internalauth.Claims, error) {
+func (a *GRPCAuthenticator) authenticate(ctx context.Context, req any) (*internalauth.Claims, error) {
 	// Extract metadata from context
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
@@ -74,17 +92,78 @@ func (a *GRPCAuthenticator) authenticate(ctx context.Context) (*internalauth.Cla
 	if tokenHeaders := md["x-internal-token"]; len(tokenHeaders) > 0 {
 		tokenString = tokenHeaders[0]
 	}
-	if tokenString == "" {
-		return nil, status.Error(codes.Unauthenticated, "missing authentication token")
-	}
+	if tokenString != "" {
+		// Validate token using internalauth.
+		claims, err := a.validator.Validate(tokenString)
+		if err == nil {
+			return claims, nil
+		}
 
-	// Validate token using internalauth
-	claims, err := a.validator.Validate(tokenString)
-	if err != nil {
+		// Allow a valid volume session credential to recover from stale JWTs.
+		if a.sessionResolver != nil {
+			sessionClaims, sessionErr := a.authenticateWithSession(ctx, req, md)
+			if sessionErr == nil {
+				return sessionClaims, nil
+			}
+		}
 		return nil, status.Errorf(codes.Unauthenticated, "invalid token: %v", err)
 	}
 
+	if a.sessionResolver != nil {
+		return a.authenticateWithSession(ctx, req, md)
+	}
+
+	return nil, status.Error(codes.Unauthenticated, "missing authentication token")
+}
+
+func (a *GRPCAuthenticator) authenticateWithSession(ctx context.Context, req any, md metadata.MD) (*internalauth.Claims, error) {
+	sessionID := firstMetadataValue(md, strings.ToLower(internalauth.VolumeSessionIDHeader))
+	sessionSecret := firstMetadataValue(md, strings.ToLower(internalauth.VolumeSessionSecretHeader))
+	if sessionID == "" || sessionSecret == "" {
+		return nil, status.Error(codes.Unauthenticated, "missing authentication token")
+	}
+
+	volumeID, err := volumeIDFromRequest(req)
+	if err != nil {
+		return nil, status.Error(codes.Unauthenticated, err.Error())
+	}
+
+	claims, err := a.sessionResolver.ResolveVolumeSessionClaims(ctx, volumeID, sessionID, sessionSecret)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "invalid session credential: %v", err)
+	}
+	if claims == nil {
+		return nil, status.Error(codes.Unauthenticated, "invalid session credential")
+	}
+
 	return claims, nil
+}
+
+func firstMetadataValue(md metadata.MD, key string) string {
+	values := md[key]
+	if len(values) == 0 {
+		return ""
+	}
+	return values[0]
+}
+
+type volumeIDRequest interface {
+	GetVolumeId() string
+}
+
+func volumeIDFromRequest(req any) (string, error) {
+	if req == nil {
+		return "", fmt.Errorf("missing request for session authentication")
+	}
+	requestWithVolumeID, ok := req.(volumeIDRequest)
+	if !ok {
+		return "", fmt.Errorf("request does not support session authentication")
+	}
+	volumeID := requestWithVolumeID.GetVolumeId()
+	if volumeID == "" {
+		return "", fmt.Errorf("missing volume id for session authentication")
+	}
+	return volumeID, nil
 }
 
 // StreamInterceptor returns a gRPC stream interceptor for authentication.
@@ -102,7 +181,7 @@ func (a *GRPCAuthenticator) StreamInterceptor() grpc.StreamServerInterceptor {
 		}
 
 		// Extract and validate token
-		claims, err := a.authenticate(ss.Context())
+		claims, err := a.authenticate(ss.Context(), nil)
 		if err != nil {
 			return status.Error(codes.Unauthenticated, err.Error())
 		}

--- a/storage-proxy/pkg/auth/interceptor_test.go
+++ b/storage-proxy/pkg/auth/interceptor_test.go
@@ -1,0 +1,131 @@
+package auth
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"strings"
+	"testing"
+
+	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+	pb "github.com/sandbox0-ai/sandbox0/storage-proxy/proto/fs"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+func newTestAuthenticator(t *testing.T, resolver SessionClaimsResolver) *GRPCAuthenticator {
+	t.Helper()
+
+	publicKey, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+
+	validator := internalauth.NewValidator(internalauth.ValidatorConfig{
+		Target:                 internalauth.ServiceStorageProxy,
+		PublicKey:              publicKey,
+		ClockSkewTolerance:     0,
+		ReplayDetectionEnabled: false,
+	})
+	return NewGRPCAuthenticator(validator, resolver, zap.NewNop())
+}
+
+func TestUnaryInterceptorAcceptsVolumeSessionCredential(t *testing.T) {
+	t.Parallel()
+
+	authenticator := newTestAuthenticator(t, SessionClaimsResolverFunc(func(_ context.Context, volumeID, sessionID, sessionSecret string) (*internalauth.Claims, error) {
+		if volumeID != "vol-1" || sessionID != "session-1" || sessionSecret != "secret-1" {
+			t.Fatalf("resolver input = (%q, %q, %q)", volumeID, sessionID, sessionSecret)
+		}
+		return &internalauth.Claims{TeamID: "team-1", Caller: internalauth.ServiceProcd}, nil
+	}))
+
+	md := metadata.Pairs(
+		strings.ToLower(internalauth.VolumeSessionIDHeader), "session-1",
+		strings.ToLower(internalauth.VolumeSessionSecretHeader), "secret-1",
+	)
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+
+	interceptor := authenticator.UnaryInterceptor()
+	_, err := interceptor(
+		ctx,
+		&pb.GetAttrRequest{VolumeId: "vol-1"},
+		&grpc.UnaryServerInfo{FullMethod: "/sandbox0.fs.FileSystem/GetAttr"},
+		func(callCtx context.Context, _ any) (any, error) {
+			claims := internalauth.ClaimsFromContext(callCtx)
+			if claims == nil || claims.TeamID != "team-1" {
+				t.Fatalf("claims = %+v, want team-1", claims)
+			}
+			return &pb.GetAttrResponse{}, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("UnaryInterceptor() error = %v", err)
+	}
+}
+
+func TestUnaryInterceptorFallsBackToSessionWhenTokenInvalid(t *testing.T) {
+	t.Parallel()
+
+	authenticator := newTestAuthenticator(t, SessionClaimsResolverFunc(func(_ context.Context, volumeID, sessionID, sessionSecret string) (*internalauth.Claims, error) {
+		if volumeID != "vol-1" || sessionID != "session-1" || sessionSecret != "secret-1" {
+			t.Fatalf("resolver input = (%q, %q, %q)", volumeID, sessionID, sessionSecret)
+		}
+		return &internalauth.Claims{TeamID: "team-1", Caller: internalauth.ServiceProcd}, nil
+	}))
+
+	md := metadata.Pairs(
+		"x-internal-token", "not-a-valid-token",
+		strings.ToLower(internalauth.VolumeSessionIDHeader), "session-1",
+		strings.ToLower(internalauth.VolumeSessionSecretHeader), "secret-1",
+	)
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+
+	interceptor := authenticator.UnaryInterceptor()
+	_, err := interceptor(
+		ctx,
+		&pb.GetAttrRequest{VolumeId: "vol-1"},
+		&grpc.UnaryServerInfo{FullMethod: "/sandbox0.fs.FileSystem/GetAttr"},
+		func(callCtx context.Context, _ any) (any, error) {
+			claims := internalauth.ClaimsFromContext(callCtx)
+			if claims == nil || claims.TeamID != "team-1" {
+				t.Fatalf("claims = %+v, want team-1", claims)
+			}
+			return &pb.GetAttrResponse{}, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("UnaryInterceptor() error = %v", err)
+	}
+}
+
+func TestUnaryInterceptorRejectsSessionAuthWithoutVolumeID(t *testing.T) {
+	t.Parallel()
+
+	authenticator := newTestAuthenticator(t, SessionClaimsResolverFunc(func(context.Context, string, string, string) (*internalauth.Claims, error) {
+		return &internalauth.Claims{TeamID: "team-1", Caller: internalauth.ServiceProcd}, nil
+	}))
+
+	md := metadata.Pairs(
+		strings.ToLower(internalauth.VolumeSessionIDHeader), "session-1",
+		strings.ToLower(internalauth.VolumeSessionSecretHeader), "secret-1",
+	)
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+
+	interceptor := authenticator.UnaryInterceptor()
+	_, err := interceptor(
+		ctx,
+		&pb.Empty{},
+		&grpc.UnaryServerInfo{FullMethod: "/sandbox0.fs.FileSystem/GetAttr"},
+		func(callCtx context.Context, _ any) (any, error) {
+			_ = callCtx
+			return &pb.Empty{}, nil
+		},
+	)
+	if status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("status code = %v, want %v (err=%v)", status.Code(err), codes.Unauthenticated, err)
+	}
+}

--- a/storage-proxy/pkg/grpc/server.go
+++ b/storage-proxy/pkg/grpc/server.go
@@ -46,7 +46,7 @@ type dirtyWriteHandle struct {
 }
 
 type volumeManager interface {
-	MountVolume(ctx context.Context, s3Prefix, volumeID, teamID string, config *volume.VolumeConfig, accessMode volume.AccessMode) (string, time.Time, error)
+	MountVolume(ctx context.Context, s3Prefix, volumeID, teamID string, config *volume.VolumeConfig, accessMode volume.AccessMode) (string, string, time.Time, error)
 	UnmountVolume(ctx context.Context, volumeID, sessionID string) error
 	AckInvalidate(volumeID, sessionID, invalidateID string, success bool, errorMessage string) error
 	GetVolume(volumeID string) (*volume.VolumeContext, error)
@@ -321,7 +321,7 @@ func (s *FileSystemServer) MountVolume(ctx context.Context, req *pb.MountVolumeR
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	sessionID, mountedAt, err := s.volMgr.MountVolume(ctx, prefix, req.VolumeId, claims.TeamID, config, accessMode)
+	sessionID, sessionSecret, mountedAt, err := s.volMgr.MountVolume(ctx, prefix, req.VolumeId, claims.TeamID, config, accessMode)
 	if err != nil {
 		s.logger.WithError(err).WithField("volume_id", req.VolumeId).Error("Failed to mount volume")
 		if strings.Contains(err.Error(), "another team") {
@@ -341,9 +341,10 @@ func (s *FileSystemServer) MountVolume(ctx context.Context, req *pb.MountVolumeR
 	}
 
 	return &pb.MountVolumeResponse{
-		VolumeId:       req.VolumeId,
-		MountedAt:      mountedAt.Unix(),
-		MountSessionId: sessionID,
+		VolumeId:           req.VolumeId,
+		MountedAt:          mountedAt.Unix(),
+		MountSessionId:     sessionID,
+		MountSessionSecret: sessionSecret,
 	}, nil
 }
 

--- a/storage-proxy/pkg/grpc/server_auth_test.go
+++ b/storage-proxy/pkg/grpc/server_auth_test.go
@@ -164,6 +164,9 @@ func TestMountVolumeTracksAuthorizedTeam(t *testing.T) {
 	if resp.MountSessionId != "session-1" {
 		t.Fatalf("MountVolume() session = %q, want %q", resp.MountSessionId, "session-1")
 	}
+	if resp.MountSessionSecret == "" {
+		t.Fatal("MountVolume() secret should not be empty")
+	}
 	if volMgr.mountCalls != 1 {
 		t.Fatalf("MountVolume() calls = %d, want 1", volMgr.mountCalls)
 	}
@@ -535,6 +538,7 @@ type fakeVolumeManager struct {
 	unmountCalls   int
 	ackCalls       int
 	mountSessionID string
+	mountSecret    string
 	mountedAt      time.Time
 	lastMount      struct {
 		s3Prefix   string
@@ -548,7 +552,7 @@ type fakeVolumeManager struct {
 	trackedSessionID string
 }
 
-func (m *fakeVolumeManager) MountVolume(_ context.Context, s3Prefix, volumeID, teamID string, config *volume.VolumeConfig, accessMode volume.AccessMode) (string, time.Time, error) {
+func (m *fakeVolumeManager) MountVolume(_ context.Context, s3Prefix, volumeID, teamID string, config *volume.VolumeConfig, accessMode volume.AccessMode) (string, string, time.Time, error) {
 	m.mountCalls++
 	m.lastMount.s3Prefix = s3Prefix
 	m.lastMount.volumeID = volumeID
@@ -559,11 +563,15 @@ func (m *fakeVolumeManager) MountVolume(_ context.Context, s3Prefix, volumeID, t
 	if sessionID == "" {
 		sessionID = "session-test"
 	}
+	sessionSecret := m.mountSecret
+	if sessionSecret == "" {
+		sessionSecret = "secret-test"
+	}
 	mountedAt := m.mountedAt
 	if mountedAt.IsZero() {
 		mountedAt = time.Unix(1700000000, 0)
 	}
-	return sessionID, mountedAt, nil
+	return sessionID, sessionSecret, mountedAt, nil
 }
 
 func (m *fakeVolumeManager) UnmountVolume(_ context.Context, _, _ string) error {

--- a/storage-proxy/pkg/volsync/mounted_volume_helpers.go
+++ b/storage-proxy/pkg/volsync/mounted_volume_helpers.go
@@ -19,7 +19,7 @@ import (
 var errLogicalPathNotFound = errors.New("logical path not found")
 
 type mountedVolumeManager interface {
-	MountVolume(ctx context.Context, s3Prefix, volumeID, teamID string, config *volume.VolumeConfig, accessMode volume.AccessMode) (string, time.Time, error)
+	MountVolume(ctx context.Context, s3Prefix, volumeID, teamID string, config *volume.VolumeConfig, accessMode volume.AccessMode) (string, string, time.Time, error)
 	UnmountVolume(ctx context.Context, volumeID, sessionID string) error
 	GetVolume(volumeID string) (*volume.VolumeContext, error)
 }
@@ -38,7 +38,7 @@ func ensureMountedVolume(ctx context.Context, volMgr mountedVolumeManager, logge
 	if err != nil {
 		return nil, "", fmt.Errorf("build s3 prefix: %w", err)
 	}
-	sessionID, _, err := volMgr.MountVolume(ctx, prefix, volumeRecord.ID, volumeRecord.TeamID, &volume.VolumeConfig{
+	sessionID, _, _, err := volMgr.MountVolume(ctx, prefix, volumeRecord.ID, volumeRecord.TeamID, &volume.VolumeConfig{
 		CacheSize:  volumeRecord.CacheSize,
 		Prefetch:   volumeRecord.Prefetch,
 		BufferSize: volumeRecord.BufferSize,

--- a/storage-proxy/pkg/volume/manager.go
+++ b/storage-proxy/pkg/volume/manager.go
@@ -2,6 +2,9 @@ package volume
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -53,9 +56,18 @@ type VolumeContext struct {
 // MountSession tracks a single mount session on this instance.
 type MountSession struct {
 	ID        string
+	Secret    string
+	TeamID    string
 	SandboxID string
 	CreatedAt time.Time
 	Scope     MountSessionScope
+}
+
+// MountSessionPrincipal captures the authorization identity resolved from a
+// mount session credential.
+type MountSessionPrincipal struct {
+	TeamID    string
+	SandboxID string
 }
 
 type MountSessionScope string
@@ -114,7 +126,7 @@ func (m *Manager) SetMountRegistrar(registrar MountRegistrar) {
 
 // MountVolume mounts a JuiceFS volume using SDK mode (in-memory, no FUSE).
 // AccessMode is enforced per storage-proxy instance (not per sandbox).
-func (m *Manager) MountVolume(ctx context.Context, s3Prefix, volumeID, teamID string, config *VolumeConfig, accessMode AccessMode) (string, time.Time, error) {
+func (m *Manager) MountVolume(ctx context.Context, s3Prefix, volumeID, teamID string, config *VolumeConfig, accessMode AccessMode) (string, string, time.Time, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -124,32 +136,39 @@ func (m *Manager) MountVolume(ctx context.Context, s3Prefix, volumeID, teamID st
 	sessionTime := time.Now()
 
 	if teamID == "" {
-		return "", time.Time{}, fmt.Errorf("missing team id for volume mount")
+		return "", "", time.Time{}, fmt.Errorf("missing team id for volume mount")
 	}
 
 	// Validate mount with coordinator if available.
 	if m.registrar != nil {
 		if err := m.registrar.ValidateMount(ctx, volumeID, accessMode); err != nil {
-			return "", time.Time{}, err
+			return "", "", time.Time{}, err
 		}
+	}
+
+	sessionSecret, err := generateMountSessionSecret()
+	if err != nil {
+		return "", "", time.Time{}, fmt.Errorf("generate mount session secret: %w", err)
 	}
 
 	// Check if already mounted
 	if existing, exists := m.volumes[volumeID]; exists {
 		if existing.TeamID != "" && existing.TeamID != teamID {
-			return "", time.Time{}, fmt.Errorf("volume %s already mounted by another team", volumeID)
+			return "", "", time.Time{}, fmt.Errorf("volume %s already mounted by another team", volumeID)
 		}
 		if existing.Access != accessMode {
-			return "", time.Time{}, fmt.Errorf("volume %s already mounted with access_mode=%s", volumeID, existing.Access)
+			return "", "", time.Time{}, fmt.Errorf("volume %s already mounted with access_mode=%s", volumeID, existing.Access)
 		}
 		if m.mountSessions[volumeID] == nil {
 			m.mountSessions[volumeID] = make(map[string]*MountSession)
 		}
 		m.mountSessions[volumeID][sessionID] = &MountSession{
 			ID:        sessionID,
+			Secret:    sessionSecret,
+			TeamID:    teamID,
 			CreatedAt: sessionTime,
 		}
-		return sessionID, sessionTime, nil
+		return sessionID, sessionSecret, sessionTime, nil
 	}
 
 	m.logger.WithField("volume_id", volumeID).Info("Mounting volume")
@@ -167,13 +186,13 @@ func (m *Manager) MountVolume(ctx context.Context, s3Prefix, volumeID, teamID st
 	// Load or create format
 	format, err := metaClient.Load(true)
 	if err != nil {
-		return "", time.Time{}, fmt.Errorf("failed to load juicefs format: %w", err)
+		return "", "", time.Time{}, fmt.Errorf("failed to load juicefs format: %w", err)
 	}
 
 	// 2. Initialize object storage
 	blob, err := m.createObjectStorage(config, s3Prefix, format)
 	if err != nil {
-		return "", time.Time{}, fmt.Errorf("failed to create object storage: %w", err)
+		return "", "", time.Time{}, fmt.Errorf("failed to create object storage: %w", err)
 	}
 
 	// 3. Initialize chunk store with local cache
@@ -233,11 +252,11 @@ func (m *Manager) MountVolume(ctx context.Context, s3Prefix, volumeID, teamID st
 	// 5. Ensure per-volume root directory exists in JuiceFS namespace
 	rootPath, err := naming.JuiceFSVolumePath(volumeID)
 	if err != nil {
-		return "", time.Time{}, fmt.Errorf("volume path: %w", err)
+		return "", "", time.Time{}, fmt.Errorf("volume path: %w", err)
 	}
 	rootInode, err := ensureVolumeRoot(metaClient, rootPath)
 	if err != nil {
-		return "", time.Time{}, fmt.Errorf("ensure volume root: %w", err)
+		return "", "", time.Time{}, fmt.Errorf("ensure volume root: %w", err)
 	}
 
 	// 6. Store volume context
@@ -258,6 +277,8 @@ func (m *Manager) MountVolume(ctx context.Context, s3Prefix, volumeID, teamID st
 	}
 	m.mountSessions[volumeID][sessionID] = &MountSession{
 		ID:        sessionID,
+		Secret:    sessionSecret,
+		TeamID:    teamID,
 		CreatedAt: sessionTime,
 	}
 
@@ -277,7 +298,47 @@ func (m *Manager) MountVolume(ctx context.Context, s3Prefix, volumeID, teamID st
 		"access_mode": accessMode,
 	}).Info("Volume mounted successfully")
 
-	return sessionID, sessionTime, nil
+	return sessionID, sessionSecret, sessionTime, nil
+}
+
+// AuthenticateMountSession validates a mount session credential for a specific
+// mounted volume and returns the principal bound to that session.
+func (m *Manager) AuthenticateMountSession(volumeID, sessionID, sessionSecret string) (*MountSessionPrincipal, error) {
+	if volumeID == "" || sessionID == "" || sessionSecret == "" {
+		return nil, fmt.Errorf("missing mount session credential")
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	volCtx, ok := m.volumes[volumeID]
+	if !ok || volCtx == nil {
+		return nil, fmt.Errorf("volume %s not mounted", volumeID)
+	}
+	sessions := m.mountSessions[volumeID]
+	if len(sessions) == 0 {
+		return nil, fmt.Errorf("mount session %s not found for volume %s", sessionID, volumeID)
+	}
+	session := sessions[sessionID]
+	if session == nil {
+		return nil, fmt.Errorf("mount session %s not found for volume %s", sessionID, volumeID)
+	}
+	if subtle.ConstantTimeCompare([]byte(session.Secret), []byte(sessionSecret)) != 1 {
+		return nil, fmt.Errorf("invalid mount session secret")
+	}
+
+	teamID := session.TeamID
+	if teamID == "" {
+		teamID = volCtx.TeamID
+	}
+	if teamID == "" {
+		return nil, fmt.Errorf("team id not found for mount session")
+	}
+
+	return &MountSessionPrincipal{
+		TeamID:    teamID,
+		SandboxID: session.SandboxID,
+	}, nil
 }
 
 // Use meta client directly to create the internal root path.
@@ -919,4 +980,12 @@ func parseSizeString(sizeStr string, defaultSize int64) int64 {
 	var size int64
 	fmt.Sscanf(numStr, "%d", &size)
 	return size * multiplier
+}
+
+func generateMountSessionSecret() (string, error) {
+	raw := make([]byte, 32)
+	if _, err := rand.Read(raw); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(raw), nil
 }

--- a/storage-proxy/pkg/volume/manager_test.go
+++ b/storage-proxy/pkg/volume/manager_test.go
@@ -434,3 +434,49 @@ func TestBeginInvalidate_IgnoresDirectSessions(t *testing.T) {
 		t.Fatal("legacy unscoped session should still require invalidate ack")
 	}
 }
+
+func TestAuthenticateMountSession(t *testing.T) {
+	mgr := NewManager(logrus.New(), &config.StorageProxyConfig{})
+	volumeID := "vol-auth"
+	sessionID := "session-auth"
+
+	mgr.volumes[volumeID] = &VolumeContext{VolumeID: volumeID, TeamID: "team-auth"}
+	mgr.mountSessions[volumeID] = map[string]*MountSession{
+		sessionID: {
+			ID:        sessionID,
+			Secret:    "secret-auth",
+			TeamID:    "team-auth",
+			SandboxID: "sandbox-auth",
+		},
+	}
+
+	principal, err := mgr.AuthenticateMountSession(volumeID, sessionID, "secret-auth")
+	if err != nil {
+		t.Fatalf("AuthenticateMountSession() error = %v", err)
+	}
+	if principal.TeamID != "team-auth" {
+		t.Fatalf("team id = %q, want team-auth", principal.TeamID)
+	}
+	if principal.SandboxID != "sandbox-auth" {
+		t.Fatalf("sandbox id = %q, want sandbox-auth", principal.SandboxID)
+	}
+}
+
+func TestAuthenticateMountSessionRejectsInvalidSecret(t *testing.T) {
+	mgr := NewManager(logrus.New(), &config.StorageProxyConfig{})
+	volumeID := "vol-auth"
+	sessionID := "session-auth"
+
+	mgr.volumes[volumeID] = &VolumeContext{VolumeID: volumeID, TeamID: "team-auth"}
+	mgr.mountSessions[volumeID] = map[string]*MountSession{
+		sessionID: {
+			ID:     sessionID,
+			Secret: "secret-auth",
+			TeamID: "team-auth",
+		},
+	}
+
+	if _, err := mgr.AuthenticateMountSession(volumeID, sessionID, "wrong-secret"); err == nil {
+		t.Fatal("AuthenticateMountSession() should reject wrong secret")
+	}
+}

--- a/storage-proxy/proto/filesystem.proto
+++ b/storage-proxy/proto/filesystem.proto
@@ -305,6 +305,7 @@ message MountVolumeResponse {
   string volume_id = 1;
   int64 mounted_at = 2;
   string mount_session_id = 3;
+  string mount_session_secret = 4;
 }
 
 message UnmountVolumeRequest {

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -189,6 +189,10 @@ func registerApiModeSuite(envProvider func() *framework.ScenarioEnv, opts apiMod
 					assertClaimBootstrapMountLifecycle(env, session)
 				})
 
+				It("keeps bootstrap mounts writable after procd token expiry", func() {
+					assertBootstrapMountWritableAfterProcdTokenExpiry(env, session)
+				})
+
 				It("shares template-declared volumes between procd and sidecars", func() {
 					assertTemplateSharedVolumeSidecarLifecycle(env, session, opts.templateNamePrefix)
 				})
@@ -1487,6 +1491,72 @@ func assertClaimBootstrapMountLifecycle(env *framework.ScenarioEnv, session *e2e
 		body, _, readErr := session.ReadFile(env.TestCtx.Context, GinkgoT(), sandboxID, mountPoint+seedPath)
 		return body, readErr
 	}).WithTimeout(20 * time.Second).WithPolling(1 * time.Second).Should(Equal(seedContent))
+}
+
+func assertBootstrapMountWritableAfterProcdTokenExpiry(env *framework.ScenarioEnv, session *e2eutils.Session) {
+	cacheSize := "512M"
+	volume, status, err := session.CreateSandboxVolume(env.TestCtx.Context, GinkgoT(), apispec.CreateSandboxVolumeRequest{CacheSize: &cacheSize})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusCreated))
+	Expect(volume).NotTo(BeNil())
+	volumeID := expectStringPtr(volume.Id, "volume id")
+	DeferCleanup(func() {
+		Expect(session.DeleteSandboxVolumeEventually(env.TestCtx.Context, GinkgoT(), volumeID, 30*time.Second)).To(Succeed())
+	})
+
+	mountWaitTimeout := int32(45000)
+	waitForMounts := true
+	templateID := "default"
+	mountPoint := "/workspace/bootstrap-token-expiry"
+	claimReq := apispec.ClaimRequest{
+		Template: &templateID,
+		Mounts: &[]apispec.ClaimMountRequest{{
+			SandboxvolumeId: volumeID,
+			MountPoint:      mountPoint,
+		}},
+		WaitForMounts:      &waitForMounts,
+		MountWaitTimeoutMs: &mountWaitTimeout,
+	}
+	claimResp, err := session.ClaimSandboxWithRequest(env.TestCtx.Context, GinkgoT(), claimReq)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(claimResp).NotTo(BeNil())
+	sandboxID := claimResp.SandboxId
+	DeferCleanup(func() {
+		_ = session.DeleteSandbox(env.TestCtx.Context, GinkgoT(), sandboxID)
+	})
+	Expect(claimResp.BootstrapMounts).NotTo(BeNil())
+	Expect(*claimResp.BootstrapMounts).NotTo(BeEmpty())
+	Expect((*claimResp.BootstrapMounts)[0].State).To(Equal(apispec.MountStatusStateMounted))
+
+	latePath := "/late-after-procd-token-expiry.txt"
+	lateContent := fmt.Sprintf("late write after procd token expiry %d", time.Now().UnixNano())
+	processType := apispec.Cmd
+	ttlSec := int32(120)
+	envVars := map[string]string{"S0_LATE_CONTENT": lateContent}
+	ctxReq := apispec.CreateContextRequest{
+		Type: &processType,
+		Cmd: &apispec.CreateCMDContextRequest{
+			Command: []string{
+				"/bin/sh",
+				"-lc",
+				"sleep 45; printf '%s' \"$S0_LATE_CONTENT\" > /workspace/bootstrap-token-expiry/late-after-procd-token-expiry.txt; sync",
+			},
+		},
+		EnvVars: &envVars,
+		TtlSec:  &ttlSec,
+	}
+	ctxResp, status, err := session.CreateContext(env.TestCtx.Context, GinkgoT(), sandboxID, ctxReq)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusCreated))
+	Expect(ctxResp).NotTo(BeNil())
+	DeferCleanup(func() {
+		_, _ = session.DeleteContext(env.TestCtx.Context, GinkgoT(), sandboxID, ctxResp.Id)
+	})
+
+	Eventually(func() ([]byte, error) {
+		body, _, readErr := session.ReadVolumeFile(env.TestCtx.Context, GinkgoT(), volumeID, latePath)
+		return body, readErr
+	}).WithTimeout(90 * time.Second).WithPolling(2 * time.Second).Should(Equal([]byte(lateContent)))
 }
 
 func assertTemplateSharedVolumeSidecarLifecycle(env *framework.ScenarioEnv, session *e2eutils.Session, templateNamePrefix string) {

--- a/tests/integration/internal/tests/storage-proxy/helpers_test.go
+++ b/tests/integration/internal/tests/storage-proxy/helpers_test.go
@@ -233,11 +233,11 @@ type integrationMountedVolumeManager struct {
 	volumes map[string]*volume.VolumeContext
 }
 
-func (m *integrationMountedVolumeManager) MountVolume(_ context.Context, _, volumeID, _ string, _ *volume.VolumeConfig, _ volume.AccessMode) (string, time.Time, error) {
+func (m *integrationMountedVolumeManager) MountVolume(_ context.Context, _, volumeID, _ string, _ *volume.VolumeConfig, _ volume.AccessMode) (string, string, time.Time, error) {
 	if _, ok := m.volumes[volumeID]; !ok {
-		return "", time.Time{}, fmt.Errorf("volume %s not found", volumeID)
+		return "", "", time.Time{}, fmt.Errorf("volume %s not found", volumeID)
 	}
-	return "session-test", time.Now().UTC(), nil
+	return "session-test", "secret-test", time.Now().UTC(), nil
 }
 
 func (m *integrationMountedVolumeManager) UnmountVolume(_ context.Context, _, _ string) error {


### PR DESCRIPTION
## Summary
- add the managed-agent API key introspection endpoint already present on this feature branch
- add persistent mount-session credentials for procd to access storage-proxy after delegated internal tokens expire
- authenticate storage-proxy gRPC calls with either internal JWTs or per-mount session credentials
- add an e2e regression that writes to a bootstrap-mounted volume after the procd token expiry window

## Testing
- go test -mod=mod ./manager/procd/pkg/volume ./storage-proxy/pkg/auth ./storage-proxy/pkg/grpc ./storage-proxy/pkg/volume ./storage-proxy/pkg/volsync ./storage-proxy/cmd/storage-proxy ./manager/cmd/procd ./tests/e2e/cases -count=1
- rsync sandbox0/ to kind:/root/infra/ and run make test-again on remote kind
- remote kind smoke: bootstrap mount volume, launch sandbox process, wait 55s without procd API calls, read process-written file through volume API: RESULT=PASS
