### PR TITLE
Validate cluster IDs and public template admin flows

### DIFF
--- a/cluster-gateway/pkg/http/handlers_internal.go
+++ b/cluster-gateway/pkg/http/handlers_internal.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/sandbox0-ai/sandbox0/cluster-gateway/pkg/middleware"
@@ -106,6 +107,9 @@ func (s *Server) generateManagerToken(authCtx *authn.AuthContext, claims *intern
 		Permissions: permissions,
 	}
 	if claims != nil && claims.IsSystem {
+		return s.internalAuthGen.GenerateSystem("manager", opts)
+	}
+	if authCtx != nil && authCtx.IsSystemAdmin && strings.TrimSpace(authCtx.TeamID) == "" {
 		return s.internalAuthGen.GenerateSystem("manager", opts)
 	}
 

--- a/cluster-gateway/pkg/http/handlers_manager_token_test.go
+++ b/cluster-gateway/pkg/http/handlers_manager_token_test.go
@@ -1,0 +1,34 @@
+package http
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"testing"
+	"time"
+
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/authn"
+	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+)
+
+func TestGenerateManagerTokenUsesSystemTokenForTeamlessSystemAdmin(t *testing.T) {
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	server := &Server{internalAuthGen: internalauth.NewGenerator(internalauth.GeneratorConfig{Caller: "cluster-gateway", PrivateKey: privateKey, TTL: time.Minute})}
+
+	token, err := server.generateManagerToken(&authn.AuthContext{IsSystemAdmin: true}, nil, []string{authn.PermTemplateCreate})
+	if err != nil {
+		t.Fatalf("generateManagerToken: %v", err)
+	}
+	claims, err := internalauth.NewValidator(internalauth.ValidatorConfig{Target: "manager", PublicKey: publicKey}).Validate(token)
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if !claims.IsSystemToken() {
+		t.Fatalf("expected system token, got team_id=%q", claims.TeamID)
+	}
+	if claims.TeamID != "" {
+		t.Fatalf("TeamID = %q, want empty", claims.TeamID)
+	}
+}

--- a/cluster-gateway/pkg/http/handlers_sandbox.go
+++ b/cluster-gateway/pkg/http/handlers_sandbox.go
@@ -18,9 +18,10 @@ import (
 // proxyToManager proxies a request to manager with internal authentication
 func (s *Server) proxyToManager(c *gin.Context) {
 	authCtx := middleware.GetAuthContext(c)
+	claims := internalauth.ClaimsFromContext(c.Request.Context())
 
 	// Generate internal token for manager
-	internalToken, err := s.internalAuthGen.Generate("manager", authCtx.TeamID, authCtx.UserID, internalauth.GenerateOptions{})
+	internalToken, err := s.generateManagerToken(authCtx, claims, nil)
 	if err != nil {
 		s.logger.Error("Failed to generate internal token for manager",
 			zap.String("team_id", authCtx.TeamID),

--- a/infra-operator/api/v1alpha1/sandbox0infra_types.go
+++ b/infra-operator/api/v1alpha1/sandbox0infra_types.go
@@ -1152,7 +1152,11 @@ type PublicExposureConfig struct {
 
 // ClusterConfig defines cluster identification and capacity
 type ClusterConfig struct {
-	// ID is the unique cluster identifier
+	// ID is the unique Sandbox0 data-plane cluster identifier used in routing and sandbox names.
+	// It is separate from the provider cluster name and must stay short enough for sandbox name encoding.
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=20
+	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
 	ID string `json:"id"`
 
 	// Name is the human-readable cluster name

--- a/infra-operator/chart/crds/infra.sandbox0.ai_sandbox0infras.yaml
+++ b/infra-operator/chart/crds/infra.sandbox0.ai_sandbox0infras.yaml
@@ -118,7 +118,12 @@ spec:
                         type: object
                     type: object
                   id:
-                    description: ID is the unique cluster identifier
+                    description: |-
+                      ID is the unique Sandbox0 data-plane cluster identifier used in routing and sandbox names.
+                      It is separate from the provider cluster name and must stay short enough for sandbox name encoding.
+                    maxLength: 20
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                     type: string
                   name:
                     description: Name is the human-readable cluster name

--- a/infra-operator/internal/controller/sandbox0infra_validation.go
+++ b/infra-operator/internal/controller/sandbox0infra_validation.go
@@ -13,6 +13,7 @@ import (
 
 	infrav1alpha1 "github.com/sandbox0-ai/sandbox0/infra-operator/api/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/pkg/common"
+	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 )
 
 const (
@@ -39,9 +40,20 @@ func validateSpecSemantics(ctx context.Context, kubeClient ctrlclient.Client, in
 		errs = append(errs, validateBuiltinStorageSemantics(ctx, kubeClient, infra)...)
 		errs = append(errs, validateBuiltinRegistrySemantics(ctx, kubeClient, infra)...)
 	}
+	errs = append(errs, validateClusterSemantics(infra)...)
 	errs = append(errs, validateServiceSemantics(infra)...)
 
 	return utilerrors.NewAggregate(errs)
+}
+
+func validateClusterSemantics(infra *infrav1alpha1.Sandbox0Infra) []error {
+	if infra == nil || infra.Spec.Cluster == nil {
+		return nil
+	}
+	if err := naming.ValidateClusterID(infra.Spec.Cluster.ID); err != nil {
+		return []error{fmt.Errorf("spec.cluster.id is invalid: %w", err)}
+	}
+	return nil
 }
 
 func validateServiceSemantics(infra *infrav1alpha1.Sandbox0Infra) []error {

--- a/infra-operator/internal/controller/sandbox0infra_validation_test.go
+++ b/infra-operator/internal/controller/sandbox0infra_validation_test.go
@@ -297,6 +297,25 @@ func TestValidateSpecSemanticsRejectsInvalidNodePortServicePort(t *testing.T) {
 	}
 }
 
+func TestValidateSpecSemanticsRejectsInvalidClusterID(t *testing.T) {
+	infra := &infrav1alpha1.Sandbox0Infra{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "sandbox0-system"},
+		Spec: infrav1alpha1.Sandbox0InfraSpec{
+			Cluster: &infrav1alpha1.ClusterConfig{
+				ID: "sandbox0-gcp-use4-gke",
+			},
+		},
+	}
+
+	err := validateSpecSemantics(context.Background(), newValidationTestClient(t), infra)
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if !strings.Contains(err.Error(), "spec.cluster.id is invalid") {
+		t.Fatalf("unexpected validation error: %v", err)
+	}
+}
+
 func TestValidateSpecSemanticsAcceptsValidNodePortServicePort(t *testing.T) {
 	infra := &infrav1alpha1.Sandbox0Infra{
 		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "sandbox0-system"},

--- a/infra-operator/internal/plan/plan.go
+++ b/infra-operator/internal/plan/plan.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/pkg/common"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/registry"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/runtimeconfig"
+	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 	"github.com/sandbox0-ai/sandbox0/pkg/template"
 )
 
@@ -646,8 +647,13 @@ func compileValidationPlan(infra *infrav1alpha1.Sandbox0Infra, compiled *InfraPl
 		!clusterGatewayInternalAuthEnabled(clusterGatewayAuthMode(infra)) {
 		plan.FatalErrors = append(plan.FatalErrors, "regionalGateway requires clusterGateway authMode internal/both when clusterGateway is enabled")
 	}
-	if infra.Spec.Cluster != nil && (compiled == nil || !compiled.Components.HasDataPlane) {
-		plan.FatalErrors = append(plan.FatalErrors, "cluster configuration requires at least one data-plane service")
+	if infra.Spec.Cluster != nil {
+		if err := naming.ValidateClusterID(infra.Spec.Cluster.ID); err != nil {
+			plan.FatalErrors = append(plan.FatalErrors, fmt.Sprintf("spec.cluster.id is invalid: %v", err))
+		}
+		if compiled == nil || !compiled.Components.HasDataPlane {
+			plan.FatalErrors = append(plan.FatalErrors, "cluster configuration requires at least one data-plane service")
+		}
 	}
 	if compiled != nil && compiled.Components.EnableNetd && netdEgressAuthEnabled(infra) && !compiled.Components.EnableManager {
 		plan.FatalErrors = append(plan.FatalErrors, "netd egress auth requires manager to be enabled")

--- a/infra-operator/internal/plan/plan_test.go
+++ b/infra-operator/internal/plan/plan_test.go
@@ -1,6 +1,7 @@
 package plan
 
 import (
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -146,6 +147,30 @@ func TestCompileDerivesCrossServiceReferences(t *testing.T) {
 	}
 	if compiled.RegionalGateway.IngressConfig == nil || !compiled.RegionalGateway.IngressConfig.Enabled {
 		t.Fatalf("expected regional gateway ingress config to be compiled, got %#v", compiled.RegionalGateway.IngressConfig)
+	}
+}
+
+func TestCompileRejectsInvalidClusterID(t *testing.T) {
+	infra := &infrav1alpha1.Sandbox0Infra{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "sandbox0-system"},
+		Spec: infrav1alpha1.Sandbox0InfraSpec{
+			Cluster: &infrav1alpha1.ClusterConfig{ID: "sandbox0-gcp-use4-gke"},
+			Services: &infrav1alpha1.ServicesConfig{
+				Manager: &infrav1alpha1.ManagerServiceConfig{
+					WorkloadServiceConfig: infrav1alpha1.WorkloadServiceConfig{
+						EnabledServiceConfig: infrav1alpha1.EnabledServiceConfig{Enabled: true},
+					},
+				},
+			},
+		},
+	}
+
+	compiled := Compile(infra)
+	if len(compiled.Validation.FatalErrors) == 0 {
+		t.Fatal("expected validation error")
+	}
+	if got := compiled.Validation.FatalErrors[0]; !strings.Contains(got, "spec.cluster.id is invalid") {
+		t.Fatalf("unexpected validation error: %q", got)
 	}
 }
 

--- a/pkg/naming/core.go
+++ b/pkg/naming/core.go
@@ -28,6 +28,9 @@ const (
 
 const DefaultClusterID = defaultClusterID
 
+// ClusterIDMaxLen is the longest cluster ID that can be encoded into sandbox names.
+const ClusterIDMaxLen = clusterIDMaxLen
+
 // ClusterIDOrDefault returns the cluster ID or a default value.
 func ClusterIDOrDefault(clusterID *string) string {
 	if clusterID != nil && *clusterID != "" {
@@ -43,6 +46,20 @@ var (
 func validateDNSLabel(name string) error {
 	if errs := validation.IsDNS1123Label(name); len(errs) > 0 {
 		return fmt.Errorf("invalid DNS-1123 label '%s': %v", name, errs)
+	}
+	return nil
+}
+
+// ValidateClusterID ensures a cluster ID is safe for routing and sandbox name encoding.
+func ValidateClusterID(clusterID string) error {
+	if clusterID == "" {
+		return fmt.Errorf("clusterID is required")
+	}
+	if len(clusterID) > clusterIDMaxLen {
+		return fmt.Errorf("clusterID '%s' is too long (%d > %d)", clusterID, len(clusterID), clusterIDMaxLen)
+	}
+	if err := validateDNSLabel(clusterID); err != nil {
+		return err
 	}
 	return nil
 }
@@ -116,8 +133,8 @@ func slugWithHash(input string, maxLen int) (string, error) {
 }
 
 func encodeClusterID(clusterID string) (string, error) {
-	if clusterID == "" {
-		return "", fmt.Errorf("clusterID is empty")
+	if err := ValidateClusterID(clusterID); err != nil {
+		return "", err
 	}
 	encoded := strings.ToLower(base32NoPadding.EncodeToString([]byte(clusterID)))
 	if len(encoded) > clusterKeyMaxLen {

--- a/pkg/naming/naming_test.go
+++ b/pkg/naming/naming_test.go
@@ -1,6 +1,9 @@
 package naming
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestReplicasetAndSandboxNames(t *testing.T) {
 	clusterID := "aws-us-east-1"
@@ -99,6 +102,34 @@ func TestClusterIDFromName(t *testing.T) {
 	}
 	if err := validateDNSLabel(clusterID); err != nil {
 		t.Fatalf("cluster_id invalid: %v", err)
+	}
+}
+
+func TestValidateClusterID(t *testing.T) {
+	valid := []string{
+		"default",
+		"aws-us-east-1",
+		"cluster-a",
+		strings.Repeat("a", ClusterIDMaxLen),
+	}
+	for _, clusterID := range valid {
+		if err := ValidateClusterID(clusterID); err != nil {
+			t.Fatalf("expected clusterID %q to be valid: %v", clusterID, err)
+		}
+	}
+
+	invalid := []string{
+		"",
+		"Sandbox0-GCP-USE4-GKE",
+		"bad_name",
+		"-starts-with-dash",
+		"ends-with-dash-",
+		strings.Repeat("a", ClusterIDMaxLen+1),
+	}
+	for _, clusterID := range invalid {
+		if err := ValidateClusterID(clusterID); err == nil {
+			t.Fatalf("expected clusterID %q to be invalid", clusterID)
+		}
 	}
 }
 

--- a/pkg/template/http/handlers.go
+++ b/pkg/template/http/handlers.go
@@ -2,7 +2,9 @@ package http
 
 import (
 	"context"
+	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
@@ -65,12 +67,13 @@ func (h *Handler) ListTemplates(c *gin.Context) {
 		spec.JSONError(c, http.StatusUnauthorized, spec.CodeUnauthorized, "missing authentication")
 		return
 	}
-	if claims.TeamID == "" {
-		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "team_id is required for custom templates")
+	_, teamID, err := templateScopeForClaims(claims)
+	if err != nil {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
 		return
 	}
 
-	templates, err := h.Store.ListVisibleTemplates(c.Request.Context(), claims.TeamID)
+	templates, err := h.Store.ListVisibleTemplates(c.Request.Context(), teamID)
 	if err != nil {
 		h.Logger.Error("Failed to list templates", zap.Error(err))
 		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to list templates")
@@ -103,12 +106,18 @@ func (h *Handler) GetTemplate(c *gin.Context) {
 		spec.JSONError(c, http.StatusUnauthorized, spec.CodeUnauthorized, "missing authentication")
 		return
 	}
-	if claims.TeamID == "" {
-		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "team_id is required for custom templates")
+	scope, teamID, err := templateScopeForClaims(claims)
+	if err != nil {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
 		return
 	}
 
-	tpl, err := h.Store.GetTemplateForTeam(c.Request.Context(), claims.TeamID, templateID)
+	var tpl *template.Template
+	if scope == naming.ScopePublic {
+		tpl, err = h.Store.GetTemplate(c.Request.Context(), scope, teamID, templateID)
+	} else {
+		tpl, err = h.Store.GetTemplateForTeam(c.Request.Context(), teamID, templateID)
+	}
 	if err != nil {
 		h.Logger.Error("Failed to get template", zap.Error(err))
 		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to get template")
@@ -177,6 +186,19 @@ func templateStatKey(namespace, templateID string) string {
 	return namespace + "\x00" + templateID
 }
 
+func templateScopeForClaims(claims *internalauth.Claims) (string, string, error) {
+	if claims == nil {
+		return "", "", errors.New("missing authentication")
+	}
+	if teamID := strings.TrimSpace(claims.TeamID); teamID != "" {
+		return naming.ScopeTeam, teamID, nil
+	}
+	if claims.IsSystemToken() {
+		return naming.ScopePublic, "", nil
+	}
+	return "", "", errors.New("team_id is required for custom templates")
+}
+
 // CreateTemplate creates a new template.
 func (h *Handler) CreateTemplate(c *gin.Context) {
 	var req struct {
@@ -201,8 +223,9 @@ func (h *Handler) CreateTemplate(c *gin.Context) {
 		spec.JSONError(c, http.StatusUnauthorized, spec.CodeUnauthorized, "missing authentication")
 		return
 	}
-	if claims.TeamID == "" {
-		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "team_id is required for custom templates")
+	scope, teamID, err := templateScopeForClaims(claims)
+	if err != nil {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
 		return
 	}
 	if err := validateTemplateSpec(req.Spec); err != nil {
@@ -218,8 +241,6 @@ func (h *Handler) CreateTemplate(c *gin.Context) {
 		return
 	}
 
-	scope := "team"
-	teamID := claims.TeamID
 	templateID := req.TemplateID
 
 	existing, err := h.Store.GetTemplate(c.Request.Context(), scope, teamID, templateID)
@@ -282,8 +303,9 @@ func (h *Handler) UpdateTemplate(c *gin.Context) {
 		spec.JSONError(c, http.StatusUnauthorized, spec.CodeUnauthorized, "missing authentication")
 		return
 	}
-	if claims.TeamID == "" {
-		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "team_id is required for custom templates")
+	scope, teamID, err := templateScopeForClaims(claims)
+	if err != nil {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
 		return
 	}
 	var req TemplateRequest
@@ -303,9 +325,6 @@ func (h *Handler) UpdateTemplate(c *gin.Context) {
 		spec.JSONError(c, http.StatusForbidden, spec.CodeForbidden, err.Error())
 		return
 	}
-
-	scope := "team"
-	teamID := claims.TeamID
 
 	existing, err := h.Store.GetTemplate(c.Request.Context(), scope, teamID, templateID)
 	if err != nil {
@@ -367,13 +386,11 @@ func (h *Handler) DeleteTemplate(c *gin.Context) {
 		spec.JSONError(c, http.StatusUnauthorized, spec.CodeUnauthorized, "missing authentication")
 		return
 	}
-	if claims.TeamID == "" {
-		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "team_id is required for custom templates")
+	scope, teamID, err := templateScopeForClaims(claims)
+	if err != nil {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
 		return
 	}
-
-	scope := "team"
-	teamID := claims.TeamID
 
 	existing, err := h.Store.GetTemplate(c.Request.Context(), scope, teamID, templateID)
 	if err != nil {
@@ -472,13 +489,11 @@ func (h *Handler) GetTemplateAllocations(c *gin.Context) {
 		spec.JSONError(c, http.StatusUnauthorized, spec.CodeUnauthorized, "missing authentication")
 		return
 	}
-	if claims.TeamID == "" {
-		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "team_id is required for custom templates")
+	scope, teamID, err := templateScopeForClaims(claims)
+	if err != nil {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
 		return
 	}
-
-	scope := "team"
-	teamID := claims.TeamID
 
 	allocations, err := h.AllocationStore.ListAllocationsByTemplate(c.Request.Context(), scope, teamID, templateID)
 	if err != nil {

--- a/pkg/template/http/handlers_test.go
+++ b/pkg/template/http/handlers_test.go
@@ -27,11 +27,17 @@ type testTemplateStore struct {
 	createCalled         bool
 	updateCalled         bool
 	createdOrUpdatedID   string
+	createdScope         string
+	createdTeamID        string
+	updatedScope         string
+	updatedTeamID        string
 }
 
 func (s *testTemplateStore) CreateTemplate(_ context.Context, tpl *template.Template) error {
 	s.createCalled = true
 	s.createdOrUpdatedID = tpl.TemplateID
+	s.createdScope = tpl.Scope
+	s.createdTeamID = tpl.TeamID
 	return nil
 }
 
@@ -75,6 +81,8 @@ func (p *testTemplateStatsProvider) GetTemplateStats(context.Context) (*Template
 func (s *testTemplateStore) UpdateTemplate(_ context.Context, tpl *template.Template) error {
 	s.updateCalled = true
 	s.createdOrUpdatedID = tpl.TemplateID
+	s.updatedScope = tpl.Scope
+	s.updatedTeamID = tpl.TeamID
 	return nil
 }
 
@@ -312,6 +320,91 @@ func TestCreateTemplate_AllowsPrivilegedFieldForSystemToken(t *testing.T) {
 	}
 }
 
+func TestCreateTemplate_SystemWithoutTeamCreatesPublicTemplate(t *testing.T) {
+	t.Parallel()
+
+	store := &testTemplateStore{
+		getTemplateFn: func(_ context.Context, scope, teamID, templateID string) (*template.Template, error) {
+			if scope != naming.ScopePublic || teamID != "" || templateID != "demo" {
+				t.Fatalf("GetTemplate scope/team/id = %q/%q/%q, want public//demo", scope, teamID, templateID)
+			}
+			return nil, nil
+		},
+	}
+	h := &Handler{Store: store, Logger: zap.NewNop()}
+
+	router := gin.New()
+	router.Use(withClaims(&internalauth.Claims{
+		UserID:   "system",
+		IsSystem: true,
+	}))
+	router.POST("/api/v1/templates", h.CreateTemplate)
+
+	body := []byte(`{
+		"template_id":"demo",
+		"spec":{
+			"mainContainer":{"image":"ubuntu:22.04","resources":{"cpu":"1","memory":"4Gi"}},
+			"pool":{"minIdle":0,"maxIdle":1}
+		}
+	}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/templates", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected status %d, got %d", http.StatusCreated, rec.Code)
+	}
+	if !store.createCalled {
+		t.Fatalf("expected create to be called")
+	}
+	if store.createdScope != naming.ScopePublic || store.createdTeamID != "" {
+		t.Fatalf("created scope/team = %q/%q, want public/empty", store.createdScope, store.createdTeamID)
+	}
+}
+
+func TestGetTemplate_SystemWithoutTeamReadsPublicTemplate(t *testing.T) {
+	t.Parallel()
+
+	calledGetTemplate := false
+	calledGetTemplateForTeam := false
+	store := &testTemplateStore{
+		getTemplateFn: func(_ context.Context, scope, teamID, templateID string) (*template.Template, error) {
+			calledGetTemplate = true
+			if scope != naming.ScopePublic || teamID != "" || templateID != "demo" {
+				t.Fatalf("GetTemplate scope/team/id = %q/%q/%q, want public//demo", scope, teamID, templateID)
+			}
+			return &template.Template{TemplateID: templateID, Scope: scope, TeamID: teamID, Spec: validTemplateSpec()}, nil
+		},
+		getTemplateForTeamFn: func(context.Context, string, string) (*template.Template, error) {
+			calledGetTemplateForTeam = true
+			return nil, nil
+		},
+	}
+	h := &Handler{Store: store, Logger: zap.NewNop()}
+
+	router := gin.New()
+	router.Use(withClaims(&internalauth.Claims{
+		UserID:   "system",
+		IsSystem: true,
+	}))
+	router.GET("/api/v1/templates/:id", h.GetTemplate)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/templates/demo", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+	if !calledGetTemplate {
+		t.Fatalf("expected public GetTemplate to be called")
+	}
+	if calledGetTemplateForTeam {
+		t.Fatalf("did not expect team fallback lookup for system public template")
+	}
+}
+
 func TestCreateTemplate_RejectsMissingMainContainerImage(t *testing.T) {
 	t.Parallel()
 
@@ -447,6 +540,48 @@ func TestUpdateTemplate_AllowsWarmProcessesForRegularTeam(t *testing.T) {
 	}
 	if !store.updateCalled {
 		t.Fatalf("expected update called for warm process request")
+	}
+}
+
+func TestUpdateTemplate_SystemWithoutTeamUpdatesPublicTemplate(t *testing.T) {
+	t.Parallel()
+
+	store := &testTemplateStore{
+		getTemplateFn: func(_ context.Context, scope, teamID, templateID string) (*template.Template, error) {
+			if scope != naming.ScopePublic || teamID != "" || templateID != "demo" {
+				t.Fatalf("GetTemplate scope/team/id = %q/%q/%q, want public//demo", scope, teamID, templateID)
+			}
+			return &template.Template{TemplateID: templateID, Scope: scope, TeamID: teamID, Spec: validTemplateSpec()}, nil
+		},
+	}
+	h := &Handler{Store: store, Logger: zap.NewNop()}
+
+	router := gin.New()
+	router.Use(withClaims(&internalauth.Claims{
+		UserID:   "system",
+		IsSystem: true,
+	}))
+	router.PUT("/api/v1/templates/:id", h.UpdateTemplate)
+
+	body := []byte(`{
+		"spec":{
+			"mainContainer":{"image":"ubuntu:22.04","resources":{"cpu":"1","memory":"4Gi"}},
+			"pool":{"minIdle":0,"maxIdle":1}
+		}
+	}`)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/templates/demo", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+	if !store.updateCalled {
+		t.Fatalf("expected update to be called")
+	}
+	if store.updatedScope != naming.ScopePublic || store.updatedTeamID != "" {
+		t.Fatalf("updated scope/team = %q/%q, want public/empty", store.updatedScope, store.updatedTeamID)
 	}
 }
 
@@ -842,6 +977,19 @@ func withClaims(claims *internalauth.Claims) gin.HandlerFunc {
 		ctx := internalauth.WithClaims(c.Request.Context(), claims)
 		c.Request = c.Request.WithContext(ctx)
 		c.Next()
+	}
+}
+
+func validTemplateSpec() v1alpha1.SandboxTemplateSpec {
+	return v1alpha1.SandboxTemplateSpec{
+		MainContainer: v1alpha1.ContainerSpec{
+			Image: "ubuntu:22.04",
+			Resources: v1alpha1.ResourceQuota{
+				CPU:    resource.MustParse("1"),
+				Memory: resource.MustParse("4Gi"),
+			},
+		},
+		Pool: v1alpha1.PoolStrategy{MinIdle: 0, MaxIdle: 1},
 	}
 }
 

--- a/scheduler/pkg/client/cluster_gateway.go
+++ b/scheduler/pkg/client/cluster_gateway.go
@@ -299,28 +299,8 @@ func (c *ClusterGatewayClient) DeleteTemplate(ctx context.Context, baseURL strin
 	return nil
 }
 
-// SandboxSummary represents a summary of a sandbox for listing
-type SandboxSummary struct {
-	ID            string                    `json:"id"`
-	TemplateID    string                    `json:"template_id"`
-	Status        string                    `json:"status"`
-	Paused        bool                      `json:"paused"`
-	PowerState    apispec.SandboxPowerState `json:"power_state"`
-	ClusterID     string                    `json:"cluster_id,omitempty"`
-	CreatedAt     string                    `json:"created_at"`
-	ExpiresAt     string                    `json:"expires_at"`
-	HardExpiresAt string                    `json:"hard_expires_at"`
-}
-
-// ListSandboxesResponse represents the response from listing sandboxes
-type ListSandboxesResponse struct {
-	Sandboxes []SandboxSummary `json:"sandboxes"`
-	Count     int              `json:"count"`
-	HasMore   bool             `json:"has_more"`
-}
-
 // ListSandboxes lists sandboxes from cluster-gateway with the given query parameters
-func (c *ClusterGatewayClient) ListSandboxes(ctx context.Context, baseURL, teamID, userID, query string, permissions []string) (*ListSandboxesResponse, error) {
+func (c *ClusterGatewayClient) ListSandboxes(ctx context.Context, baseURL, teamID, userID, query string, permissions []string) (*apispec.SuccessSandboxListResponse, error) {
 	// Preserve the caller team/user context so cluster-gateway and manager
 	// can apply the same team-scoped authorization as other sandbox routes.
 	token, err := c.internalAuthGen.Generate("cluster-gateway", teamID, userID, internalauth.GenerateOptions{
@@ -361,14 +341,16 @@ func (c *ClusterGatewayClient) ListSandboxes(ctx context.Context, baseURL, teamI
 		return nil, fmt.Errorf("unexpected status code %d: %s", resp.StatusCode, string(body))
 	}
 
-	// Parse response
-	result, apiErr, err := spec.DecodeResponse[ListSandboxesResponse](resp.Body)
-	if err != nil {
+	var result apispec.SuccessSandboxListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return nil, fmt.Errorf("decode response: %w", err)
 	}
-	if apiErr != nil {
-		return nil, fmt.Errorf("cluster-gateway error: %s", apiErr.Message)
+	if !bool(result.Success) {
+		return nil, fmt.Errorf("cluster-gateway returned unsuccessful sandbox list response")
+	}
+	if result.Data == nil {
+		return nil, fmt.Errorf("cluster-gateway sandbox list response missing data")
 	}
 
-	return result, nil
+	return &result, nil
 }

--- a/scheduler/pkg/http/handlers_sandbox.go
+++ b/scheduler/pkg/http/handlers_sandbox.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/sandbox0-ai/sandbox0/pkg/apispec"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
@@ -451,7 +452,7 @@ func (s *Server) listSandboxes(c *gin.Context) {
 
 	if len(clusters) == 0 {
 		spec.JSONSuccess(c, http.StatusOK, gin.H{
-			"sandboxes": []client.SandboxSummary{},
+			"sandboxes": []apispec.SandboxSummary{},
 			"count":     0,
 			"has_more":  false,
 		})
@@ -478,7 +479,7 @@ func (s *Server) listSandboxes(c *gin.Context) {
 	// Fan-out to all clusters in parallel
 	type clusterResult struct {
 		clusterID string
-		response  *client.ListSandboxesResponse
+		response  *apispec.SuccessSandboxListResponse
 		err       error
 	}
 
@@ -513,7 +514,7 @@ func (s *Server) listSandboxes(c *gin.Context) {
 	}()
 
 	// Collect and aggregate results
-	var allSandboxes []client.SandboxSummary
+	var allSandboxes []apispec.SandboxSummary
 	for result := range results {
 		if result.err != nil {
 			s.logger.Warn("Failed to list sandboxes from cluster",
@@ -522,16 +523,24 @@ func (s *Server) listSandboxes(c *gin.Context) {
 			)
 			continue
 		}
-		// Add cluster_id to each sandbox
-		for i := range result.response.Sandboxes {
-			result.response.Sandboxes[i].ClusterID = result.clusterID
+		if result.response == nil || result.response.Data == nil {
+			s.logger.Warn("Cluster sandbox list response missing data",
+				zap.String("cluster_id", result.clusterID),
+			)
+			continue
 		}
-		allSandboxes = append(allSandboxes, result.response.Sandboxes...)
+
+		// Add cluster_id to each sandbox
+		clusterID := result.clusterID
+		for i := range result.response.Data.Sandboxes {
+			result.response.Data.Sandboxes[i].ClusterId = &clusterID
+		}
+		allSandboxes = append(allSandboxes, result.response.Data.Sandboxes...)
 	}
 
 	// Sort by created_at descending (newest first)
 	sort.Slice(allSandboxes, func(i, j int) bool {
-		return allSandboxes[i].CreatedAt > allSandboxes[j].CreatedAt
+		return allSandboxes[i].CreatedAt.After(allSandboxes[j].CreatedAt)
 	})
 
 	// Parse pagination parameters
@@ -555,7 +564,7 @@ func (s *Server) listSandboxes(c *gin.Context) {
 	// Apply pagination
 	hasMore := false
 	if offset >= totalCount {
-		allSandboxes = []client.SandboxSummary{}
+		allSandboxes = []apispec.SandboxSummary{}
 	} else {
 		end := offset + limit
 		if end > totalCount {

--- a/scheduler/pkg/http/handlers_sandbox_test.go
+++ b/scheduler/pkg/http/handlers_sandbox_test.go
@@ -571,7 +571,8 @@ func TestListSandboxesRoutesTeamScopedToken(t *testing.T) {
 		Success bool `json:"success"`
 		Data    struct {
 			Sandboxes []struct {
-				ID         string `json:"id"`
+				ID         string  `json:"id"`
+				ClusterID  *string `json:"cluster_id"`
 				PowerState struct {
 					Desired            string `json:"desired"`
 					DesiredGeneration  int64  `json:"desired_generation"`
@@ -595,6 +596,9 @@ func TestListSandboxesRoutesTeamScopedToken(t *testing.T) {
 	}
 	if body.Data.Sandboxes[0].HardExpiresAt != "2026-04-07T02:00:00Z" {
 		t.Fatalf("hard_expires_at = %q, want 2026-04-07T02:00:00Z", body.Data.Sandboxes[0].HardExpiresAt)
+	}
+	if body.Data.Sandboxes[0].ClusterID == nil || *body.Data.Sandboxes[0].ClusterID != "home" {
+		t.Fatalf("cluster_id = %v, want home", body.Data.Sandboxes[0].ClusterID)
 	}
 	if body.Data.Sandboxes[0].PowerState.Desired != "active" || body.Data.Sandboxes[0].PowerState.Phase != "stable" {
 		t.Fatalf("power_state = %+v, want active/stable", body.Data.Sandboxes[0].PowerState)


### PR DESCRIPTION
## Summary
- add shared naming validation for Sandbox0 cluster IDs and wire it into infra-operator CRD, semantic validation, and plan validation
- keep provider cluster names separate from short Sandbox0 cluster IDs before they reach sandbox name encoding
- make scheduler sandbox list fan-out decode the generated OpenAPI sandbox list response instead of a custom response struct
- allow system/admin internal tokens without a team context to manage public templates, and reuse manager-token generation for cluster-gateway manager proxy routes

## Testing
- go test ./cluster-gateway/pkg/http ./pkg/template/http ./infra-operator/... ./scheduler/... ./pkg/naming -count=1
- pre-push hook passed: make manifests, make proto, make apispec, go fmt ./..., go mod tidy, go mod vendor, golangci-lint run ./...

## Notes
- remote kind was not rerun after adding the public-template admin commit per follow-up direction.