### PR TITLE
Make sandbox pause and resume synchronous

### DIFF
--- a/cluster-gateway/pkg/client/manager.go
+++ b/cluster-gateway/pkg/client/manager.go
@@ -146,7 +146,7 @@ func (c *ManagerClient) GetSandboxInternal(ctx context.Context, sandboxID string
 	return sandbox, nil
 }
 
-// ResumeSandbox asks manager to resume a paused sandbox.
+// ResumeSandbox asks manager to resume a paused sandbox and waits for it to become active.
 func (c *ManagerClient) ResumeSandbox(ctx context.Context, sandboxID, userID, teamID string) error {
 	token, err := c.internalAuthGen.Generate("manager", teamID, userID, internalauth.GenerateOptions{})
 	if err != nil {
@@ -170,7 +170,7 @@ func (c *ManagerClient) ResumeSandbox(ctx context.Context, sandboxID, userID, te
 	if resp.StatusCode == http.StatusNotFound {
 		return fmt.Errorf("%w: %s", ErrSandboxNotFound, sandboxID)
 	}
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
+	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		var payload map[string]any
 		_ = json.Unmarshal(body, &payload)

--- a/cluster-gateway/pkg/http/handlers_context.go
+++ b/cluster-gateway/pkg/http/handlers_context.go
@@ -19,6 +19,8 @@ import (
 	"go.uber.org/zap"
 )
 
+const defaultAutoResumeTimeout = 2 * time.Minute
+
 // === Process/Context Management Handlers (→ Procd) ===
 
 // createContext creates a new context in a sandbox
@@ -322,20 +324,16 @@ func (s *Server) getProcdURL(c *gin.Context, sandboxID string) (*url.URL, error)
 			return nil, errors.New("sandbox auto_resume is disabled")
 		}
 		if sandboxWantsPaused(sandbox) {
-			if sandbox.PowerState.Desired != mgr.SandboxPowerStateActive {
-				resumeCtx, cancel := context.WithTimeout(c.Request.Context(), 45*time.Second)
-				defer cancel()
-				if err := s.managerClient.ResumeSandbox(resumeCtx, sandboxID, authCtx.UserID, authCtx.TeamID); err != nil {
-					s.logger.Warn("Resume sandbox failed",
-						zap.String("sandbox_id", sandboxID),
-						zap.Error(err),
-					)
-					spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox is waking up")
-					return nil, err
-				}
+			resumeCtx, cancel := context.WithTimeout(c.Request.Context(), defaultAutoResumeTimeout)
+			defer cancel()
+			if err := s.managerClient.ResumeSandbox(resumeCtx, sandboxID, authCtx.UserID, authCtx.TeamID); err != nil {
+				s.logger.Warn("Resume sandbox failed",
+					zap.String("sandbox_id", sandboxID),
+					zap.Error(err),
+				)
+				spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox is waking up")
+				return nil, err
 			}
-			spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox is waking up")
-			return nil, errors.New("sandbox is waking up")
 		}
 
 		// Parse procd address

--- a/cluster-gateway/pkg/http/handlers_context_test.go
+++ b/cluster-gateway/pkg/http/handlers_context_test.go
@@ -108,9 +108,9 @@ func TestGetProcdURLPausedSandboxReturnsWakingUp(t *testing.T) {
 				PowerState: mgr.SandboxPowerState{
 					Desired:            mgr.SandboxPowerStateActive,
 					DesiredGeneration:  4,
-					Observed:           mgr.SandboxPowerStatePaused,
-					ObservedGeneration: 3,
-					Phase:              mgr.SandboxPowerPhaseResuming,
+					Observed:           mgr.SandboxPowerStateActive,
+					ObservedGeneration: 4,
+					Phase:              mgr.SandboxPowerPhaseStable,
 				},
 			})
 		default:
@@ -131,12 +131,9 @@ func TestGetProcdURLPausedSandboxReturnsWakingUp(t *testing.T) {
 	}
 	defer server.sandboxAddrCache.Close()
 
-	addr, rec := mustGetProcdURL(t, server, "team-a", "user-a", "sb-1")
-	if addr != nil {
-		t.Fatalf("expected nil addr, got %q", addr.String())
-	}
-	if rec.Code != http.StatusServiceUnavailable {
-		t.Fatalf("status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+	addr, _ := mustGetProcdURL(t, server, "team-a", "user-a", "sb-1")
+	if addr == nil || addr.String() != "http://127.0.0.1:7777" {
+		t.Fatalf("addr = %v, want http://127.0.0.1:7777", addr)
 	}
 	if resumeCalls != 1 {
 		t.Fatalf("resumeCalls = %d, want 1", resumeCalls)

--- a/cluster-gateway/pkg/http/handlers_exposure.go
+++ b/cluster-gateway/pkg/http/handlers_exposure.go
@@ -70,17 +70,13 @@ func (s *Server) handlePublicExposureNoRoute(c *gin.Context) {
 			spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox is paused and resume is disabled")
 			return
 		}
-		if sandbox.PowerState.Desired != mgr.SandboxPowerStateActive {
-			resumeCtx, cancel := context.WithTimeout(c.Request.Context(), 45*time.Second)
-			defer cancel()
-			if err := s.managerClient.ResumeSandbox(resumeCtx, sandboxID, "", sandbox.TeamID); err != nil {
-				s.logger.Warn("Auto resume failed", zap.String("sandbox_id", sandboxID), zap.Error(err))
-				spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox is waking up")
-				return
-			}
+		resumeCtx, cancel := context.WithTimeout(c.Request.Context(), defaultAutoResumeTimeout)
+		defer cancel()
+		if err := s.managerClient.ResumeSandbox(resumeCtx, sandboxID, "", sandbox.TeamID); err != nil {
+			s.logger.Warn("Auto resume failed", zap.String("sandbox_id", sandboxID), zap.Error(err))
+			spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox is waking up")
+			return
 		}
-		spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox is waking up")
-		return
 	}
 
 	if basePort, parseErr := portFromURL(sandbox.InternalAddr); parseErr == nil && basePort == port {

--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -448,6 +448,8 @@ func main() {
 		}
 	}()
 
+	go sandboxService.StartPowerStateReconciler(ctx, cfg.ResyncPeriod.Duration)
+
 	// Start HTTP server
 	go func() {
 		if err := httpServer.Start(ctx); err != nil && err != http.ErrServerClosed {

--- a/manager/pkg/http/handlers_sandbox.go
+++ b/manager/pkg/http/handlers_sandbox.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -345,17 +346,13 @@ func (s *Server) pauseSandbox(c *gin.Context) {
 		return
 	}
 
-	resp, err := s.sandboxService.RequestPauseSandbox(c.Request.Context(), sandboxID)
+	resp, err := s.sandboxService.PauseSandboxAndWait(c.Request.Context(), sandboxID)
 	if err != nil {
-		s.logger.Error("Failed to pause sandbox",
-			zap.String("sandboxID", sandboxID),
-			zap.Error(err),
-		)
-		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, fmt.Sprintf("failed to pause sandbox: %v", err))
+		s.writeSandboxPowerTransitionError(c, "pause", sandboxID, err)
 		return
 	}
 
-	spec.JSONSuccess(c, http.StatusAccepted, resp)
+	spec.JSONSuccess(c, http.StatusOK, resp)
 }
 
 // resumeSandbox resumes a sandbox
@@ -385,17 +382,31 @@ func (s *Server) resumeSandbox(c *gin.Context) {
 		return
 	}
 
-	resp, err := s.sandboxService.RequestResumeSandbox(c.Request.Context(), sandboxID)
+	resp, err := s.sandboxService.ResumeSandboxAndWait(c.Request.Context(), sandboxID)
 	if err != nil {
-		s.logger.Error("Failed to resume sandbox",
-			zap.String("sandboxID", sandboxID),
-			zap.Error(err),
-		)
-		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, fmt.Sprintf("failed to resume sandbox: %v", err))
+		s.writeSandboxPowerTransitionError(c, "resume", sandboxID, err)
 		return
 	}
 
-	spec.JSONSuccess(c, http.StatusAccepted, resp)
+	spec.JSONSuccess(c, http.StatusOK, resp)
+}
+
+func (s *Server) writeSandboxPowerTransitionError(c *gin.Context, action, sandboxID string, err error) {
+	s.logger.Error("Failed to change sandbox power state",
+		zap.String("action", action),
+		zap.String("sandboxID", sandboxID),
+		zap.Error(err),
+	)
+	switch {
+	case errors.Is(err, service.ErrSandboxPowerTransitionSuperseded):
+		spec.JSONError(c, http.StatusConflict, spec.CodeConflict, fmt.Sprintf("sandbox %s was superseded by a newer power transition", action))
+	case errors.Is(err, context.DeadlineExceeded):
+		spec.JSONError(c, http.StatusGatewayTimeout, spec.CodeUnavailable, fmt.Sprintf("timed out waiting for sandbox to %s", action))
+	case errors.Is(err, context.Canceled):
+		spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, fmt.Sprintf("canceled while waiting for sandbox to %s", action))
+	default:
+		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, fmt.Sprintf("failed to %s sandbox: %v", action, err))
+	}
 }
 
 // refreshSandbox refreshes sandbox TTL

--- a/manager/pkg/service/sandbox_service.go
+++ b/manager/pkg/service/sandbox_service.go
@@ -83,7 +83,12 @@ var errNoIdlePod = errors.New("no idle pod available")
 var ErrInvalidClaimRequest = errors.New("invalid claim request")
 var errSandboxPowerStateStale = errors.New("sandbox power state changed during execution")
 
+// ErrSandboxPowerTransitionSuperseded is returned when a newer pause/resume request replaces the requested transition.
+var ErrSandboxPowerTransitionSuperseded = errors.New("sandbox power transition superseded")
+
 const defaultPodReadyTimeout = 30 * time.Second
+const defaultSandboxPowerTransitionTimeout = 2 * time.Minute
+const defaultSandboxPowerPollInterval = 100 * time.Millisecond
 
 // claimIdlePodBackoff is the retry backoff for claiming idle pods.
 // Designed to balance between:
@@ -2060,6 +2065,35 @@ func (s *SandboxService) requestSandboxPowerState(ctx context.Context, sandboxID
 	return state, nil
 }
 
+func (s *SandboxService) waitForSandboxPowerState(ctx context.Context, sandboxID, target string, generation int64) (SandboxPowerState, error) {
+	var state SandboxPowerState
+	err := wait.PollUntilContextCancel(ctx, defaultSandboxPowerPollInterval, true, func(ctx context.Context) (bool, error) {
+		pod, err := s.getSandboxPodForPowerState(ctx, sandboxID)
+		if err != nil {
+			return false, err
+		}
+		state = sandboxPowerStateFromAnnotations(pod.Annotations)
+		if generation > 0 && (state.Desired != target || state.DesiredGeneration != generation) {
+			return false, fmt.Errorf("%w: %w", ErrSandboxPowerTransitionSuperseded, staleSandboxPowerStateError(state))
+		}
+		return state.Desired == target && state.Observed == target && state.Phase == SandboxPowerPhaseStable, nil
+	})
+	if err != nil {
+		if ctx.Err() != nil {
+			return state, ctx.Err()
+		}
+		return state, err
+	}
+	return state, nil
+}
+
+func sandboxPowerTransitionContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if _, ok := ctx.Deadline(); ok {
+		return context.WithCancel(ctx)
+	}
+	return context.WithTimeout(ctx, defaultSandboxPowerTransitionTimeout)
+}
+
 func (s *SandboxService) triggerSandboxPowerStateReconcile(sandboxID string) {
 	if _, loaded := s.powerStateReconcilers.LoadOrStore(sandboxID, struct{}{}); loaded {
 		return
@@ -2068,6 +2102,48 @@ func (s *SandboxService) triggerSandboxPowerStateReconcile(sandboxID string) {
 		defer s.finishSandboxPowerStateReconcile(sandboxID)
 		s.reconcileSandboxPowerState(sandboxID)
 	}()
+}
+
+// StartPowerStateReconciler periodically reconciles power transitions left pending by another manager replica.
+func (s *SandboxService) StartPowerStateReconciler(ctx context.Context, interval time.Duration) {
+	if interval <= 0 {
+		interval = 30 * time.Second
+	}
+	s.reconcilePendingSandboxPowerStates(ctx)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.reconcilePendingSandboxPowerStates(ctx)
+		}
+	}
+}
+
+func (s *SandboxService) reconcilePendingSandboxPowerStates(ctx context.Context) {
+	if ctx.Err() != nil || s.podLister == nil {
+		return
+	}
+	pods, err := s.podLister.List(labels.Everything())
+	if err != nil {
+		s.logger.Warn("Failed to list sandboxes for power state reconcile", zap.Error(err))
+		return
+	}
+	for _, pod := range pods {
+		if pod == nil {
+			continue
+		}
+		sandboxID := strings.TrimSpace(pod.Labels[controller.LabelSandboxID])
+		if sandboxID == "" {
+			continue
+		}
+		state := sandboxPowerStateFromAnnotations(pod.Annotations)
+		if state.Phase != SandboxPowerPhaseStable || state.Desired != state.Observed {
+			s.triggerSandboxPowerStateReconcile(sandboxID)
+		}
+	}
 }
 
 func (s *SandboxService) finishSandboxPowerStateReconcile(sandboxID string) {
@@ -2544,7 +2620,18 @@ func (s *SandboxService) pauseSandboxLocal(ctx context.Context, sandboxID string
 		return nil, fmt.Errorf("procd pause failed: %s", pauseResp.Error)
 	}
 
-	return s.completePausedSandbox(ctx, pod, sandboxID, pauseResp.ResourceUsage, expected)
+	completedResp, err := s.completePausedSandbox(ctx, pod, sandboxID, pauseResp.ResourceUsage, expected)
+	if err != nil && errors.Is(err, errSandboxPowerStateStale) && completedResp != nil && completedResp.PowerState.Desired == SandboxPowerStateActive {
+		resumeResp, resumeErr := s.procdClient.Resume(ctx, procdAddress, internalToken, procdToken)
+		if resumeErr != nil {
+			return completedResp, fmt.Errorf("resume procd after stale pause: %w", resumeErr)
+		}
+		if !resumeResp.Resumed {
+			return completedResp, fmt.Errorf("procd resume after stale pause failed: %s", resumeResp.Error)
+		}
+		return &PauseSandboxResponse{SandboxID: sandboxID, Paused: false, PowerState: completedResp.PowerState, ResourceUsage: pauseResp.ResourceUsage}, nil
+	}
+	return completedResp, err
 }
 
 // RequestPauseSandbox records a desired paused state and reconciles it asynchronously.
@@ -2558,6 +2645,26 @@ func (s *SandboxService) RequestPauseSandbox(ctx context.Context, sandboxID stri
 		Paused:     true,
 		PowerState: state,
 	}, nil
+}
+
+// PauseSandboxAndWait records a desired paused state and waits until the sandbox observes it.
+func (s *SandboxService) PauseSandboxAndWait(ctx context.Context, sandboxID string) (*PauseSandboxResponse, error) {
+	resp, err := s.RequestPauseSandbox(ctx, sandboxID)
+	if err != nil {
+		return nil, err
+	}
+	if resp.PowerState.Desired == SandboxPowerStatePaused && resp.PowerState.Observed == SandboxPowerStatePaused && resp.PowerState.Phase == SandboxPowerPhaseStable {
+		return resp, nil
+	}
+	waitCtx, cancel := sandboxPowerTransitionContext(ctx)
+	defer cancel()
+	state, err := s.waitForSandboxPowerState(waitCtx, sandboxID, SandboxPowerStatePaused, resp.PowerState.DesiredGeneration)
+	if err != nil {
+		return &PauseSandboxResponse{SandboxID: sandboxID, Paused: state.Observed == SandboxPowerStatePaused, PowerState: state}, err
+	}
+	resp.PowerState = state
+	resp.Paused = true
+	return resp, nil
 }
 
 // ResumeSandbox delegates sandbox resume execution to the configured power executor.
@@ -2919,6 +3026,26 @@ func (s *SandboxService) RequestResumeSandbox(ctx context.Context, sandboxID str
 		Resumed:    true,
 		PowerState: state,
 	}, nil
+}
+
+// ResumeSandboxAndWait records a desired active state and waits until the sandbox observes it.
+func (s *SandboxService) ResumeSandboxAndWait(ctx context.Context, sandboxID string) (*ResumeSandboxResponse, error) {
+	resp, err := s.RequestResumeSandbox(ctx, sandboxID)
+	if err != nil {
+		return nil, err
+	}
+	if resp.PowerState.Desired == SandboxPowerStateActive && resp.PowerState.Observed == SandboxPowerStateActive && resp.PowerState.Phase == SandboxPowerPhaseStable {
+		return resp, nil
+	}
+	waitCtx, cancel := sandboxPowerTransitionContext(ctx)
+	defer cancel()
+	state, err := s.waitForSandboxPowerState(waitCtx, sandboxID, SandboxPowerStateActive, resp.PowerState.DesiredGeneration)
+	if err != nil {
+		return &ResumeSandboxResponse{SandboxID: sandboxID, Resumed: state.Observed == SandboxPowerStateActive, PowerState: state}, err
+	}
+	resp.PowerState = state
+	resp.Resumed = true
+	return resp, nil
 }
 
 // PauseSandboxByID implements the SandboxPauser interface from controller package.

--- a/manager/pkg/service/sandbox_service_power_state_test.go
+++ b/manager/pkg/service/sandbox_service_power_state_test.go
@@ -2,11 +2,16 @@ package service
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -202,6 +207,28 @@ func TestReconcileSandboxPowerStateUsesConfiguredExecutor(t *testing.T) {
 	})
 }
 
+func TestStartPowerStateReconcilerTriggersPendingTransitions(t *testing.T) {
+	pod := newPowerStatePod(SandboxPowerStatePaused, SandboxPowerStateActive, SandboxPowerPhasePausing)
+	pauseCalled := make(chan struct{})
+	svc := &SandboxService{
+		k8sClient: fake.NewSimpleClientset(pod),
+		podLister: newTestPodLister(t, pod),
+		logger:    zap.NewNop(),
+	}
+	svc.SetPowerExecutor(&completingPowerExecutor{service: svc, pauseCalled: pauseCalled})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		svc.StartPowerStateReconciler(ctx, time.Hour)
+		close(done)
+	}()
+
+	<-pauseCalled
+	cancel()
+	<-done
+}
+
 func TestRequestResumeSandboxDoesNotBlockOnInFlightReconcile(t *testing.T) {
 	pod := newPowerStatePod(SandboxPowerStatePaused, SandboxPowerStateActive, SandboxPowerPhasePausing)
 	executor := newBlockingPowerExecutor()
@@ -239,6 +266,158 @@ func TestRequestResumeSandboxDoesNotBlockOnInFlightReconcile(t *testing.T) {
 
 	close(executor.pauseRelease)
 	<-executor.pauseFinished
+}
+
+func TestPauseSandboxAndWaitReturnsAfterObservedPaused(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sandbox-1",
+			Namespace: "default",
+			Labels: map[string]string{
+				controller.LabelSandboxID: "sandbox-1",
+			},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	svc := &SandboxService{
+		k8sClient: fake.NewSimpleClientset(pod),
+		podLister: newTestPodLister(t, pod),
+		clock:     systemTime{},
+		logger:    zap.NewNop(),
+	}
+	svc.SetPowerExecutor(&completingPowerExecutor{service: svc})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	resp, err := svc.PauseSandboxAndWait(ctx, "sandbox-1")
+	require.NoError(t, err)
+	assert.True(t, resp.Paused)
+	assert.Equal(t, SandboxPowerStatePaused, resp.PowerState.Desired)
+	assert.Equal(t, SandboxPowerStatePaused, resp.PowerState.Observed)
+	assert.Equal(t, SandboxPowerPhaseStable, resp.PowerState.Phase)
+}
+
+func TestResumeSandboxAndWaitReturnsAfterObservedActive(t *testing.T) {
+	pod := newPowerStatePod(SandboxPowerStatePaused, SandboxPowerStatePaused, SandboxPowerPhaseStable)
+	pod.Annotations[controller.AnnotationPaused] = "true"
+	svc := &SandboxService{
+		k8sClient: fake.NewSimpleClientset(pod),
+		podLister: newTestPodLister(t, pod),
+		clock:     systemTime{},
+		logger:    zap.NewNop(),
+	}
+	svc.SetPowerExecutor(&completingPowerExecutor{service: svc})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	resp, err := svc.ResumeSandboxAndWait(ctx, "sandbox-1")
+	require.NoError(t, err)
+	assert.True(t, resp.Resumed)
+	assert.Equal(t, SandboxPowerStateActive, resp.PowerState.Desired)
+	assert.Equal(t, SandboxPowerStateActive, resp.PowerState.Observed)
+	assert.Equal(t, SandboxPowerPhaseStable, resp.PowerState.Phase)
+}
+
+func TestPauseSandboxAndWaitReturnsSupersededWhenDesiredChanges(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sandbox-1",
+			Namespace: "default",
+			Labels: map[string]string{
+				controller.LabelSandboxID: "sandbox-1",
+			},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	executor := newBlockingPowerExecutor()
+	svc := &SandboxService{
+		k8sClient: fake.NewSimpleClientset(pod),
+		podLister: newTestPodLister(t, pod),
+		clock:     systemTime{},
+		logger:    zap.NewNop(),
+	}
+	svc.SetPowerExecutor(executor)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	type result struct {
+		resp *PauseSandboxResponse
+		err  error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		resp, err := svc.PauseSandboxAndWait(ctx, "sandbox-1")
+		resultCh <- result{resp: resp, err: err}
+	}()
+	<-executor.pauseStarted
+
+	_, err := svc.RequestResumeSandbox(context.Background(), "sandbox-1")
+	require.NoError(t, err)
+	close(executor.pauseRelease)
+
+	res := <-resultCh
+	require.ErrorIs(t, res.err, ErrSandboxPowerTransitionSuperseded)
+	require.NotNil(t, res.resp)
+	assert.False(t, res.resp.Paused)
+	assert.Equal(t, SandboxPowerStateActive, res.resp.PowerState.Desired)
+}
+
+func TestPauseSandboxLocalResumesProcdAfterStalePause(t *testing.T) {
+	pod := newPowerStatePod(SandboxPowerStatePaused, SandboxPowerStateActive, SandboxPowerPhasePausing)
+	pod.Annotations[controller.AnnotationTeamID] = "team-1"
+	pod.Annotations[controller.AnnotationUserID] = "user-1"
+	pod.Spec = corev1.PodSpec{Containers: []corev1.Container{{Name: "procd"}}}
+	pod.Status = corev1.PodStatus{Phase: corev1.PodRunning, PodIP: "127.0.0.1"}
+	k8sClient := fake.NewSimpleClientset(pod)
+
+	var calls []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls = append(calls, r.URL.Path)
+		switch r.URL.Path {
+		case "/api/v1/sandbox/pause":
+			current, err := k8sClient.CoreV1().Pods("default").Get(r.Context(), "sandbox-1", metav1.GetOptions{})
+			require.NoError(t, err)
+			updated := current.DeepCopy()
+			updated.Annotations[controller.AnnotationPowerStateDesired] = SandboxPowerStateActive
+			updated.Annotations[controller.AnnotationPowerStateDesiredGeneration] = "3"
+			updated.Annotations[controller.AnnotationPowerStateObserved] = SandboxPowerStateActive
+			updated.Annotations[controller.AnnotationPowerStateObservedGeneration] = "3"
+			updated.Annotations[controller.AnnotationPowerStatePhase] = SandboxPowerPhaseStable
+			_, err = k8sClient.CoreV1().Pods("default").Update(r.Context(), updated, metav1.UpdateOptions{})
+			require.NoError(t, err)
+			_ = spec.WriteSuccess(w, http.StatusOK, PauseResponse{Paused: true, ResourceUsage: &SandboxResourceUsage{ContainerMemoryWorkingSet: 128}})
+		case "/api/v1/sandbox/resume":
+			_ = spec.WriteSuccess(w, http.StatusOK, ResumeResponse{Resumed: true})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(serverURL.Port())
+	require.NoError(t, err)
+
+	svc := &SandboxService{
+		k8sClient:              k8sClient,
+		podLister:              newTestPodLister(t, pod),
+		procdClient:            NewProcdClient(ProcdClientConfig{Timeout: time.Second}),
+		internalTokenGenerator: staticTokenGenerator{},
+		procdTokenGenerator:    staticTokenGenerator{},
+		config: SandboxServiceConfig{
+			ProcdPort:              port,
+			PauseMinCPU:            "10m",
+			PauseMemoryBufferRatio: 1.1,
+		},
+		clock:  systemTime{},
+		logger: zap.NewNop(),
+	}
+
+	resp, err := svc.pauseSandboxLocal(context.Background(), "sandbox-1")
+	require.NoError(t, err)
+	assert.False(t, resp.Paused)
+	assert.Equal(t, SandboxPowerStateActive, resp.PowerState.Desired)
+	assert.Equal(t, []string{"/api/v1/sandbox/pause", "/api/v1/sandbox/resume"}, calls)
 }
 
 func TestCompletePausedSandboxRejectsStaleGeneration(t *testing.T) {
@@ -285,13 +464,23 @@ type recordingPowerExecutor struct {
 }
 
 type blockingPowerExecutor struct {
-	mu            sync.Mutex
-	pauseCalls    []string
-	resumeCalls   []string
-	pauseStarted  chan struct{}
-	pauseRelease  chan struct{}
-	pauseFinished chan struct{}
+	mu                sync.Mutex
+	pauseCalls        []string
+	resumeCalls       []string
+	pauseStarted      chan struct{}
+	pauseRelease      chan struct{}
+	pauseFinished     chan struct{}
+	pauseStartedOnce  sync.Once
+	pauseFinishedOnce sync.Once
 }
+
+type completingPowerExecutor struct {
+	service      *SandboxService
+	pauseCalled  chan struct{}
+	resumeCalled chan struct{}
+}
+
+type staticTokenGenerator struct{}
 
 func newBlockingPowerExecutor() *blockingPowerExecutor {
 	return &blockingPowerExecutor{
@@ -327,9 +516,9 @@ func (e *blockingPowerExecutor) Pause(_ context.Context, sandboxID string) (*Pau
 	e.mu.Lock()
 	e.pauseCalls = append(e.pauseCalls, sandboxID)
 	e.mu.Unlock()
-	close(e.pauseStarted)
+	e.pauseStartedOnce.Do(func() { close(e.pauseStarted) })
 	<-e.pauseRelease
-	close(e.pauseFinished)
+	e.pauseFinishedOnce.Do(func() { close(e.pauseFinished) })
 	return &PauseSandboxResponse{
 		SandboxID: sandboxID,
 		Paused:    true,
@@ -350,6 +539,59 @@ func (e *blockingPowerExecutor) Resume(_ context.Context, sandboxID string) (*Re
 			Desired: SandboxPowerStateActive,
 		},
 	}, nil
+}
+
+func (e *completingPowerExecutor) Pause(ctx context.Context, sandboxID string) (*PauseSandboxResponse, error) {
+	notifyOnce(e.pauseCalled)
+	pod, err := e.service.getSandboxPodForPowerState(ctx, sandboxID)
+	if err != nil {
+		return nil, err
+	}
+	updated := pod.DeepCopy()
+	if updated.Annotations == nil {
+		updated.Annotations = make(map[string]string)
+	}
+	updated.Annotations[controller.AnnotationPaused] = "true"
+	state := completedSandboxPowerState(updated.Annotations, SandboxPowerStatePaused)
+	applySandboxPowerStateAnnotations(updated.Annotations, state)
+	if _, err := e.service.k8sClient.CoreV1().Pods(updated.Namespace).Update(ctx, updated, metav1.UpdateOptions{}); err != nil {
+		return nil, err
+	}
+	return &PauseSandboxResponse{SandboxID: sandboxID, Paused: true, PowerState: state}, nil
+}
+
+func (e *completingPowerExecutor) Resume(ctx context.Context, sandboxID string) (*ResumeSandboxResponse, error) {
+	notifyOnce(e.resumeCalled)
+	pod, err := e.service.getSandboxPodForPowerState(ctx, sandboxID)
+	if err != nil {
+		return nil, err
+	}
+	updated := pod.DeepCopy()
+	if updated.Annotations == nil {
+		updated.Annotations = make(map[string]string)
+	}
+	delete(updated.Annotations, controller.AnnotationPaused)
+	state := completedSandboxPowerState(updated.Annotations, SandboxPowerStateActive)
+	applySandboxPowerStateAnnotations(updated.Annotations, state)
+	if _, err := e.service.k8sClient.CoreV1().Pods(updated.Namespace).Update(ctx, updated, metav1.UpdateOptions{}); err != nil {
+		return nil, err
+	}
+	return &ResumeSandboxResponse{SandboxID: sandboxID, Resumed: true, PowerState: state}, nil
+}
+
+func (staticTokenGenerator) GenerateToken(_, _, _ string) (string, error) {
+	return "token", nil
+}
+
+func notifyOnce(ch chan struct{}) {
+	if ch == nil {
+		return
+	}
+	select {
+	case <-ch:
+	default:
+		close(ch)
+	}
 }
 
 func newPowerStatePod(desired, observed, phase string) *corev1.Pod {

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -1310,12 +1310,24 @@ paths:
       parameters:
         - $ref: "#/components/parameters/SandboxID"
       responses:
-        "202":
-          description: Pause request accepted; sandbox power state will converge asynchronously
+        "200":
+          description: Sandbox paused
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/SuccessPauseSandboxResponse"
+        "409":
+          description: Pause was superseded by a newer power transition
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "504":
+          description: Timed out waiting for the sandbox to pause
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
         "404":
           description: Not found
           content:
@@ -1333,12 +1345,24 @@ paths:
       parameters:
         - $ref: "#/components/parameters/SandboxID"
       responses:
-        "202":
-          description: Resume request accepted; sandbox power state will converge asynchronously
+        "200":
+          description: Sandbox resumed
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/SuccessResumeSandboxResponse"
+        "409":
+          description: Resume was superseded by a newer power transition
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "504":
+          description: Timed out waiting for the sandbox to resume
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
         "404":
           description: Not found
           content:

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -228,14 +228,14 @@ func registerApiModeSuite(envProvider func() *framework.ScenarioEnv, opts apiMod
 
 					pausedResp, status, err := session.PauseSandbox(env.TestCtx.Context, GinkgoT(), sandboxID)
 					Expect(err).NotTo(HaveOccurred())
-					Expect(status).To(Equal(http.StatusAccepted))
+					Expect(status).To(Equal(http.StatusOK))
 					Expect(pausedResp).NotTo(BeNil())
 					Expect(pausedResp.Paused).To(BeTrue())
 					waitForSandboxPowerStateEventually(env, session, sandboxID, apispec.SandboxPowerStateObserved("paused"))
 
 					resumeResp, status, err := session.ResumeSandbox(env.TestCtx.Context, GinkgoT(), sandboxID)
 					Expect(err).NotTo(HaveOccurred())
-					Expect(status).To(Equal(http.StatusAccepted))
+					Expect(status).To(Equal(http.StatusOK))
 					Expect(resumeResp).NotTo(BeNil())
 					Expect(resumeResp.Resumed).To(BeTrue())
 					waitForSandboxPowerStateEventually(env, session, sandboxID, apispec.SandboxPowerStateObserved("active"))

--- a/tests/e2e/utils/sandbox.go
+++ b/tests/e2e/utils/sandbox.go
@@ -192,7 +192,7 @@ func (s *Session) PauseSandbox(ctx context.Context, t ContractT, sandboxID strin
 	if err != nil {
 		return nil, status, err
 	}
-	if status != http.StatusAccepted {
+	if status != http.StatusOK {
 		return nil, status, fmt.Errorf("pause sandbox failed with status %d: %s", status, formatAPIError(body))
 	}
 	var resp apispec.SuccessPauseSandboxResponse
@@ -212,7 +212,7 @@ func (s *Session) ResumeSandbox(ctx context.Context, t ContractT, sandboxID stri
 	if err != nil {
 		return nil, status, err
 	}
-	if status != http.StatusAccepted {
+	if status != http.StatusOK {
 		return nil, status, fmt.Errorf("resume sandbox failed with status %d: %s", status, formatAPIError(body))
 	}
 	var resp apispec.SuccessResumeSandboxResponse


### PR DESCRIPTION
## Summary
- Make public pause/resume wait until sandbox power state reaches the requested stable observed state.
- Keep internal desired/observed generation reconciliation, including superseded transition detection and periodic recovery for pending transitions across manager replicas.
- Make cluster-gateway auto-resume wait for resume completion before forwarding requests, and add local stale-pause compensation.

## Testing
- make apispec
- go test ./manager/pkg/... ./cluster-gateway/pkg/... -count=1
- golangci-lint run ./manager/cmd/manager ./manager/pkg/service ./manager/pkg/http ./cluster-gateway/pkg/http ./cluster-gateway/pkg/client
- pre-push hook: make manifests, make proto, make apispec, go fmt ./..., go mod tidy, go mod vendor, golangci-lint run ./...