### PR TITLE
Fix SSH endpoint routing

### DIFF
--- a/infra-operator/internal/controller/pkg/common/common.go
+++ b/infra-operator/internal/controller/pkg/common/common.go
@@ -359,7 +359,7 @@ func ResolveSSHEndpoint(infra *infrav1alpha1.Sandbox0Infra, fallbackPort int32) 
 		return "", 0, false
 	}
 
-	return fmt.Sprintf("ssh.%s.%s", regionLabel, rootDomain), port, true
+	return fmt.Sprintf("%s.ssh.%s", regionLabel, rootDomain), port, true
 }
 
 func ResolveServiceAnnotations(config *infrav1alpha1.ServiceNetworkConfig) map[string]string {

--- a/infra-operator/internal/controller/services/clustergateway/clustergateway_test.go
+++ b/infra-operator/internal/controller/services/clustergateway/clustergateway_test.go
@@ -484,8 +484,8 @@ func TestBuildConfigPublishesSSHEndpoint(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildConfig returned error: %v", err)
 	}
-	if cfg.SSHEndpointHost != "ssh.aws-us-east-1.sandbox0.app" {
-		t.Fatalf("ssh endpoint host = %q, want %q", cfg.SSHEndpointHost, "ssh.aws-us-east-1.sandbox0.app")
+	if cfg.SSHEndpointHost != "aws-us-east-1.ssh.sandbox0.app" {
+		t.Fatalf("ssh endpoint host = %q, want %q", cfg.SSHEndpointHost, "aws-us-east-1.ssh.sandbox0.app")
 	}
 	if cfg.SSHEndpointPort != 30222 {
 		t.Fatalf("ssh endpoint port = %d, want %d", cfg.SSHEndpointPort, 30222)

--- a/infra-operator/internal/controller/services/regionalgateway/regionalgateway_registry_test.go
+++ b/infra-operator/internal/controller/services/regionalgateway/regionalgateway_registry_test.go
@@ -438,8 +438,8 @@ func TestBuildConfigPublishesSSHEndpoint(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildConfig returned error: %v", err)
 	}
-	if cfg.SSHEndpointHost != "ssh.aws-us-east-1.sandbox0.app" {
-		t.Fatalf("ssh endpoint host = %q, want %q", cfg.SSHEndpointHost, "ssh.aws-us-east-1.sandbox0.app")
+	if cfg.SSHEndpointHost != "aws-us-east-1.ssh.sandbox0.app" {
+		t.Fatalf("ssh endpoint host = %q, want %q", cfg.SSHEndpointHost, "aws-us-east-1.ssh.sandbox0.app")
 	}
 	if cfg.SSHEndpointPort != 30222 {
 		t.Fatalf("ssh endpoint port = %d, want %d", cfg.SSHEndpointPort, 30222)

--- a/pkg/gateway/public/routes.go
+++ b/pkg/gateway/public/routes.go
@@ -136,6 +136,23 @@ func RegisterIdentityRoutes(router gin.IRouter, deps Deps) {
 	}
 }
 
+// RegisterUserSSHKeyRoutes mounts the user SSH key surface without the full
+// identity and team management API. Federated regional gateways use this to
+// keep SSH gateway authorization data region-local while global-gateway remains
+// the identity entrypoint.
+func RegisterUserSSHKeyRoutes(router gin.IRouter, deps Deps) {
+	userHandler := handlers.NewUserHandler(deps.IdentityRepo, deps.Logger)
+
+	sshKeys := router.Group("/users/me/ssh-keys")
+	sshKeys.Use(deps.AuthMiddleware.Authenticate())
+	sshKeys.Use(deps.AuthMiddleware.RequireJWTAuth())
+	{
+		sshKeys.GET("", userHandler.ListUserSSHPublicKeys)
+		sshKeys.POST("", userHandler.CreateUserSSHPublicKey)
+		sshKeys.DELETE("/:id", userHandler.DeleteUserSSHPublicKey)
+	}
+}
+
 // RegisterAPIKeyRoutes mounts home-region API key management routes.
 func RegisterAPIKeyRoutes(router gin.IRouter, deps Deps) {
 	if deps.APIKeyRepo != nil {

--- a/pkg/gateway/public/routes_test.go
+++ b/pkg/gateway/public/routes_test.go
@@ -48,6 +48,29 @@ func TestRegisterAPIKeyRoutesOnlyMountsRegionalAPIKeySurface(t *testing.T) {
 	}
 }
 
+func TestRegisterUserSSHKeyRoutesMountsSSHKeysOnly(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.New()
+	RegisterUserSSHKeyRoutes(router, testDeps())
+
+	if !hasRoute(router, "GET", "/users/me/ssh-keys") {
+		t.Fatal("expected SSH key routes to include list")
+	}
+	if !hasRoute(router, "POST", "/users/me/ssh-keys") {
+		t.Fatal("expected SSH key routes to include create")
+	}
+	if !hasRoute(router, "DELETE", "/users/me/ssh-keys/:id") {
+		t.Fatal("expected SSH key routes to include delete")
+	}
+	if hasRoute(router, "GET", "/users/me") {
+		t.Fatal("expected SSH key routes to omit full user profile")
+	}
+	if hasRoute(router, "POST", "/auth/login") {
+		t.Fatal("expected SSH key routes to omit /auth/login")
+	}
+}
+
 func testDeps() Deps {
 	logger := zap.NewNop()
 	jwtIssuer := authn.NewIssuer("test", "secret", time.Minute, time.Hour)

--- a/pkg/sshgateway/connection_test.go
+++ b/pkg/sshgateway/connection_test.go
@@ -8,11 +8,11 @@ import (
 )
 
 func TestBuildConnectionInfo(t *testing.T) {
-	info := BuildConnectionInfo("ssh.aws-us-east-1.sandbox0.app", 30222, "sb_123")
+	info := BuildConnectionInfo("aws-us-east-1.ssh.sandbox0.app", 30222, "sb_123")
 	if info == nil {
 		t.Fatal("expected connection info")
 	}
-	if info.Host != "ssh.aws-us-east-1.sandbox0.app" {
+	if info.Host != "aws-us-east-1.ssh.sandbox0.app" {
 		t.Fatalf("host = %q", info.Host)
 	}
 	if info.Port != 30222 {
@@ -41,14 +41,14 @@ func TestSandboxToAPIIncludesSSHInfo(t *testing.T) {
 		HardExpiresAt: now,
 	}
 
-	payload := SandboxToAPI(sandbox, BuildConnectionInfo("ssh.aws-us-east-1.sandbox0.app", 30222, sandbox.ID))
+	payload := SandboxToAPI(sandbox, BuildConnectionInfo("aws-us-east-1.ssh.sandbox0.app", 30222, sandbox.ID))
 	if payload == nil {
 		t.Fatal("expected payload")
 	}
 	if payload.Ssh == nil {
 		t.Fatal("expected ssh payload")
 	}
-	if payload.Ssh.Host != "ssh.aws-us-east-1.sandbox0.app" {
+	if payload.Ssh.Host != "aws-us-east-1.ssh.sandbox0.app" {
 		t.Fatalf("ssh host = %q", payload.Ssh.Host)
 	}
 	if payload.Ssh.Port != 30222 {

--- a/regional-gateway/pkg/http/server.go
+++ b/regional-gateway/pkg/http/server.go
@@ -381,6 +381,7 @@ func (s *Server) setupPublicRoutes() {
 		return
 	}
 
+	public.RegisterUserSSHKeyRoutes(s.router, deps)
 	public.RegisterAPIKeyRoutes(s.router, deps)
 }
 

--- a/regional-gateway/pkg/http/server_public_routes_test.go
+++ b/regional-gateway/pkg/http/server_public_routes_test.go
@@ -41,6 +41,15 @@ func TestSetupPublicRoutesFederatedMountsRegionalAPIKeysOnly(t *testing.T) {
 	if !hasRoute(server.router, "GET", "/api-keys") {
 		t.Fatal("expected federated mode to mount /api-keys")
 	}
+	if !hasRoute(server.router, "GET", "/users/me/ssh-keys") {
+		t.Fatal("expected federated mode to mount SSH key list route")
+	}
+	if !hasRoute(server.router, "POST", "/users/me/ssh-keys") {
+		t.Fatal("expected federated mode to mount SSH key create route")
+	}
+	if !hasRoute(server.router, "DELETE", "/users/me/ssh-keys/:id") {
+		t.Fatal("expected federated mode to mount SSH key delete route")
+	}
 	if hasRoute(server.router, "POST", "/auth/login") {
 		t.Fatal("expected federated mode to omit /auth/login")
 	}

--- a/skills/sandbox0/references/docs-src/managed-agents/claude-sdk/page.mdx
+++ b/skills/sandbox0/references/docs-src/managed-agents/claude-sdk/page.mdx
@@ -60,6 +60,8 @@ const session = await client.beta.sessions.create({
     environment_id: environment.id,
     title: `Sandbox0 demo ${suffix}`,
     metadata: {
+        // Optional hard TTL. Managed Agents disables soft TTL and pauses/resumes itself; this defaults to 3600 seconds.
+        // Set this to "0" only if the session should have no hard cost cap.
         "sandbox0.managed_agents.hard_ttl_seconds": "3600",
     },
     vault_ids: [llmVault.id],

--- a/skills/sandbox0/references/docs-src/sandbox/ssh/page.mdx
+++ b/skills/sandbox0/references/docs-src/sandbox/ssh/page.mdx
@@ -10,7 +10,7 @@ SSH access targets the sandbox procd runtime in the main sandbox container. Temp
 
 | Part | Value | Example |
 |------|-------|---------|
-| Gateway host | Returned by the sandbox detail `ssh.host` field | `ssh.aws-us-east-1.sandbox0.example.com` |
+| Gateway host | Returned by the sandbox detail `ssh.host` field | `aws-us-east-1.ssh.sandbox0.example.com` |
 | SSH port | Returned by the sandbox detail `ssh.port` field | `22` |
 | SSH username | Target sandbox ID | `rs-abc123-default-x7k9m` |
 | Authentication | SSH public key uploaded to the current user | `ssh-ed25519 AAAA...` |
@@ -23,7 +23,7 @@ Most clients should read the connection info from `GET /api/v1/sandboxes/{'{id}'
 ```json
 {
   "ssh": {
-    "host": "ssh.aws-us-east-1.sandbox0.example.com",
+    "host": "aws-us-east-1.ssh.sandbox0.example.com",
     "port": 22,
     "username": "rs-abc123-default-x7k9m"
   }
@@ -112,13 +112,13 @@ curl "$SANDBOX0_BASE_URL/api/v1/sandboxes/$SANDBOX_ID" \
 Use the returned values with `ssh`:
 
 ```bash
-ssh -p 22 rs-abc123-default-x7k9m@ssh.aws-us-east-1.sandbox0.example.com
+ssh -p 22 rs-abc123-default-x7k9m@aws-us-east-1.ssh.sandbox0.example.com
 ```
 
 Run a one-shot remote command instead of opening an interactive shell:
 
 ```bash
-ssh -p 22 rs-abc123-default-x7k9m@ssh.aws-us-east-1.sandbox0.example.com 'uname -a'
+ssh -p 22 rs-abc123-default-x7k9m@aws-us-east-1.ssh.sandbox0.example.com 'uname -a'
 ```
 
 If the sandbox is paused, `ssh-gateway` asks the control plane to resume it before attaching the session.
@@ -132,19 +132,19 @@ Use standard `scp` to upload or download files. The default OpenSSH mode is supp
 Upload a local file:
 
 ```bash
-scp -P 22 ./build.log rs-abc123-default-x7k9m@ssh.aws-us-east-1.sandbox0.example.com:/workspace/build.log
+scp -P 22 ./build.log rs-abc123-default-x7k9m@aws-us-east-1.ssh.sandbox0.example.com:/workspace/build.log
 ```
 
 Download a file from the sandbox:
 
 ```bash
-scp -P 22 rs-abc123-default-x7k9m@ssh.aws-us-east-1.sandbox0.example.com:/workspace/output.txt ./output.txt
+scp -P 22 rs-abc123-default-x7k9m@aws-us-east-1.ssh.sandbox0.example.com:/workspace/output.txt ./output.txt
 ```
 
 Because `scp` runs over the SFTP subsystem here, `sftp` clients work too:
 
 ```bash
-sftp -P 22 rs-abc123-default-x7k9m@ssh.aws-us-east-1.sandbox0.example.com
+sftp -P 22 rs-abc123-default-x7k9m@aws-us-east-1.ssh.sandbox0.example.com
 ```
 
 ---

--- a/skills/sandbox0/references/docs-src/self-hosted/configuration/page.mdx
+++ b/skills/sandbox0/references/docs-src/self-hosted/configuration/page.mdx
@@ -105,7 +105,7 @@ Enable `spec.services.sshGateway` when you want a region-scoped SSH entrypoint t
 The routing model is intentionally simple:
 
 - One `ssh-gateway` per region
-- One fixed host or load balancer address per region
+- One fixed DNS-only host or TCP proxy address per region, for example `aws-us-east-1.ssh.sandbox0.app`
 - SSH username is the target sandbox ID
 - User authentication uses SSH public keys uploaded to the gateway API
 


### PR DESCRIPTION
## Summary
- publish SSH endpoints as <region>.ssh.<rootDomain> so SSH can stay out of sandbox wildcard HTTP routing
- expose user SSH key routes from federated regional-gateway so ssh-gateway can authorize against region-local keys
- update SSH endpoint tests and docs

## Testing
- go test ./infra-operator/... ./pkg/sshgateway ./pkg/gateway/... ./regional-gateway/... -count=1
- pre-push hook: make manifests, make proto, make apispec, go fmt ./..., go mod tidy, go mod vendor, golangci-lint run ./...