### PR TITLE
Refactor SSH keys as region-local state

### DIFF
--- a/global-gateway/pkg/http/server_test.go
+++ b/global-gateway/pkg/http/server_test.go
@@ -11,7 +11,11 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
 	cachepkg "github.com/sandbox0-ai/sandbox0/pkg/cache"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/authn"
+	gatewaymiddleware "github.com/sandbox0-ai/sandbox0/pkg/gateway/middleware"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/tenantdir"
+	"github.com/sandbox0-ai/sandbox0/pkg/licensing"
+	"github.com/sandbox0-ai/sandbox0/pkg/observability"
 	"github.com/sandbox0-ai/sandbox0/pkg/proxy"
 	"go.uber.org/zap"
 )
@@ -28,6 +32,51 @@ func (s *stubRegionDirectory) GetRegion(_ context.Context, _ string) (*tenantdir
 		return nil, s.err
 	}
 	return s.region, nil
+}
+
+func TestGlobalGatewaySetupRoutesOmitsRegionLocalSSHKeys(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	logger := zap.NewNop()
+	jwtIssuer := authn.NewIssuer("test", "secret", time.Minute, time.Hour)
+	obsProvider, err := observability.New(observability.Config{
+		ServiceName:    "global-gateway-test",
+		Logger:         logger,
+		DisableTracing: true,
+		DisableMetrics: true,
+		DisableLogging: true,
+	})
+	if err != nil {
+		t.Fatalf("create observability provider: %v", err)
+	}
+
+	server := &Server{
+		router:         gin.New(),
+		logger:         logger,
+		authMiddleware: gatewaymiddleware.NewAuthMiddleware(nil, "secret", jwtIssuer, logger),
+		requestLogger:  gatewaymiddleware.NewRequestLogger(logger),
+		jwtIssuer:      jwtIssuer,
+		entitlements:   licensing.NewStaticEntitlements(),
+		obsProvider:    obsProvider,
+		proxyTimeout:   time.Second,
+		regionProxies:  make(map[string]*proxy.Router),
+	}
+	server.setupRoutes()
+
+	if globalHasRoute(server.router, http.MethodGet, "/users/me/ssh-keys") {
+		t.Fatal("expected global-gateway routes to omit region-local SSH key list")
+	}
+	if globalHasRoute(server.router, http.MethodPost, "/users/me/ssh-keys") {
+		t.Fatal("expected global-gateway routes to omit region-local SSH key create")
+	}
+	if globalHasRoute(server.router, http.MethodDelete, "/users/me/ssh-keys/:id") {
+		t.Fatal("expected global-gateway routes to omit region-local SSH key delete")
+	}
+	if !globalHasRoute(server.router, http.MethodGet, "/users/me") {
+		t.Fatal("expected global-gateway routes to include global user profile")
+	}
+	if !globalHasRoute(server.router, http.MethodGet, "/regions") {
+		t.Fatal("expected global-gateway routes to include region directory")
+	}
 }
 
 func TestGlobalGatewayResolveRoutableRegionCachesLookups(t *testing.T) {
@@ -53,6 +102,15 @@ func TestGlobalGatewayResolveRoutableRegionCachesLookups(t *testing.T) {
 	if dir.calls != 1 {
 		t.Fatalf("expected one backing lookup, got %d", dir.calls)
 	}
+}
+
+func globalHasRoute(router *gin.Engine, method, path string) bool {
+	for _, route := range router.Routes() {
+		if route.Method == method && route.Path == path {
+			return true
+		}
+	}
+	return false
 }
 
 func TestGlobalGatewayResolveRoutableRegionExpiresCache(t *testing.T) {

--- a/pkg/gateway/identity/ssh_public_key_repository_test.go
+++ b/pkg/gateway/identity/ssh_public_key_repository_test.go
@@ -70,6 +70,81 @@ func TestUserSSHPublicKeyRepositoryLifecycle(t *testing.T) {
 	}
 }
 
+func TestUserSSHPublicKeyRepositoryAllowsFederatedUserID(t *testing.T) {
+	pool, schema := newGatewayIdentityTestPool(t)
+	if pool == nil {
+		return
+	}
+
+	ctx := context.Background()
+	repo := NewRepository(pool)
+	userID := uuid.NewString()
+	publicKey, keyType, fingerprint, comment, err := NormalizeAuthorizedSSHPublicKey("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ4dLZLZOA/asaP+5QO6t81jzbe5G4jrI2F+jbjL6TY8 sandbox0-e2e")
+	if err != nil {
+		t.Fatalf("normalize ssh public key: %v", err)
+	}
+
+	key := &UserSSHPublicKey{
+		UserID:            userID,
+		Name:              "Federated laptop",
+		PublicKey:         publicKey,
+		KeyType:           keyType,
+		FingerprintSHA256: fingerprint,
+		Comment:           comment,
+	}
+	if err := repo.CreateUserSSHPublicKey(ctx, key); err != nil {
+		t.Fatalf("create ssh public key for federated user: %v", err)
+	}
+
+	keys, err := repo.ListUserSSHPublicKeysByUserID(ctx, userID)
+	if err != nil {
+		t.Fatalf("list federated user ssh public keys: %v", err)
+	}
+	if len(keys) != 1 {
+		t.Fatalf("keys len = %d, want 1 (schema %s)", len(keys), schema)
+	}
+}
+
+func TestDeleteUserRemovesSSHPublicKeys(t *testing.T) {
+	pool, _ := newGatewayIdentityTestPool(t)
+	if pool == nil {
+		return
+	}
+
+	ctx := context.Background()
+	repo := NewRepository(pool)
+	user := &User{
+		Email: "delete-ssh-user@example.com",
+		Name:  "Delete SSH User",
+	}
+	if err := repo.CreateUser(ctx, user); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	publicKey, keyType, fingerprint, comment, err := NormalizeAuthorizedSSHPublicKey("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ4dLZLZOA/asaP+5QO6t81jzbe5G4jrI2F+jbjL6TY8 sandbox0-e2e")
+	if err != nil {
+		t.Fatalf("normalize ssh public key: %v", err)
+	}
+	key := &UserSSHPublicKey{
+		UserID:            user.ID,
+		Name:              "Laptop",
+		PublicKey:         publicKey,
+		KeyType:           keyType,
+		FingerprintSHA256: fingerprint,
+		Comment:           comment,
+	}
+	if err := repo.CreateUserSSHPublicKey(ctx, key); err != nil {
+		t.Fatalf("create ssh public key: %v", err)
+	}
+
+	if err := repo.DeleteUser(ctx, user.ID); err != nil {
+		t.Fatalf("delete user: %v", err)
+	}
+	if _, err := repo.GetUserSSHPublicKeyByFingerprint(ctx, fingerprint); err != ErrSSHPublicKeyNotFound {
+		t.Fatalf("get ssh public key after user delete err = %v, want %v", err, ErrSSHPublicKeyNotFound)
+	}
+}
+
 func newGatewayIdentityTestPool(t *testing.T) (*pgxpool.Pool, string) {
 	t.Helper()
 

--- a/pkg/gateway/identity/user_repository.go
+++ b/pkg/gateway/identity/user_repository.go
@@ -138,12 +138,24 @@ func (r *Repository) UpdateUserPassword(ctx context.Context, userID, passwordHas
 
 // DeleteUser deletes a user.
 func (r *Repository) DeleteUser(ctx context.Context, id string) error {
-	result, err := r.pool.Exec(ctx, `DELETE FROM users WHERE id = $1`, id)
+	tx, err := r.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	result, err := tx.Exec(ctx, `DELETE FROM users WHERE id = $1`, id)
 	if err != nil {
 		return fmt.Errorf("delete user: %w", err)
 	}
 	if result.RowsAffected() == 0 {
 		return ErrUserNotFound
+	}
+	if _, err := tx.Exec(ctx, `DELETE FROM user_ssh_public_keys WHERE user_id = $1`, id); err != nil {
+		return fmt.Errorf("delete user ssh public keys: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit tx: %w", err)
 	}
 	return nil
 }

--- a/pkg/gateway/migrations/00003_make_user_ssh_public_keys_region_local.sql
+++ b/pkg/gateway/migrations/00003_make_user_ssh_public_keys_region_local.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+ALTER TABLE IF EXISTS user_ssh_public_keys
+    DROP CONSTRAINT IF EXISTS user_ssh_public_keys_user_id_fkey;
+
+-- +goose Down
+DELETE FROM user_ssh_public_keys
+WHERE NOT EXISTS (
+    SELECT 1 FROM users WHERE users.id = user_ssh_public_keys.user_id
+);
+
+ALTER TABLE IF EXISTS user_ssh_public_keys
+    ADD CONSTRAINT user_ssh_public_keys_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE;

--- a/pkg/gateway/public/routes.go
+++ b/pkg/gateway/public/routes.go
@@ -32,6 +32,7 @@ type Deps struct {
 // RegisterRoutes mounts the full self-hosted public surface.
 func RegisterRoutes(router gin.IRouter, deps Deps) {
 	RegisterIdentityRoutes(router, deps)
+	RegisterUserSSHKeyRoutes(router, deps)
 	RegisterAPIKeyRoutes(router, deps)
 }
 
@@ -112,9 +113,6 @@ func RegisterIdentityRoutes(router gin.IRouter, deps Deps) {
 		users.PUT("/me", userHandler.UpdateCurrentUser)
 		users.GET("/me/identities", userHandler.GetUserIdentities)
 		users.DELETE("/me/identities/:id", userHandler.DeleteUserIdentity)
-		users.GET("/me/ssh-keys", userHandler.ListUserSSHPublicKeys)
-		users.POST("/me/ssh-keys", userHandler.CreateUserSSHPublicKey)
-		users.DELETE("/me/ssh-keys/:id", userHandler.DeleteUserSSHPublicKey)
 	}
 
 	// ===== Team Management Routes =====

--- a/pkg/gateway/public/routes_test.go
+++ b/pkg/gateway/public/routes_test.go
@@ -11,7 +11,36 @@ import (
 	"go.uber.org/zap"
 )
 
-func TestRegisterIdentityRoutesOmitsRegionalAPIKeys(t *testing.T) {
+func TestRegisterRoutesMountsSelfHostedPublicSurface(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.New()
+	RegisterRoutes(router, testDeps())
+
+	if !hasRoute(router, "POST", "/auth/login") {
+		t.Fatal("expected full public routes to include /auth/login")
+	}
+	if !hasRoute(router, "GET", "/users/me") {
+		t.Fatal("expected full public routes to include /users/me")
+	}
+	if !hasRoute(router, "GET", "/teams") {
+		t.Fatal("expected full public routes to include /teams")
+	}
+	if !hasRoute(router, "GET", "/users/me/ssh-keys") {
+		t.Fatal("expected full public routes to include SSH key list")
+	}
+	if !hasRoute(router, "POST", "/users/me/ssh-keys") {
+		t.Fatal("expected full public routes to include SSH key create")
+	}
+	if !hasRoute(router, "DELETE", "/users/me/ssh-keys/:id") {
+		t.Fatal("expected full public routes to include SSH key delete")
+	}
+	if !hasRoute(router, "GET", "/api-keys") {
+		t.Fatal("expected full public routes to include /api-keys")
+	}
+}
+
+func TestRegisterIdentityRoutesOmitsRegionalStateRoutes(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	router := gin.New()
@@ -19,6 +48,15 @@ func TestRegisterIdentityRoutesOmitsRegionalAPIKeys(t *testing.T) {
 
 	if hasRoute(router, "GET", "/api-keys") {
 		t.Fatal("expected identity routes to omit /api-keys")
+	}
+	if hasRoute(router, "GET", "/users/me/ssh-keys") {
+		t.Fatal("expected identity routes to omit SSH key list")
+	}
+	if hasRoute(router, "POST", "/users/me/ssh-keys") {
+		t.Fatal("expected identity routes to omit SSH key create")
+	}
+	if hasRoute(router, "DELETE", "/users/me/ssh-keys/:id") {
+		t.Fatal("expected identity routes to omit SSH key delete")
 	}
 	if !hasRoute(router, "GET", "/users/me") {
 		t.Fatal("expected identity routes to include /users/me")

--- a/regional-gateway/pkg/http/server_public_routes_test.go
+++ b/regional-gateway/pkg/http/server_public_routes_test.go
@@ -30,9 +30,18 @@ func TestSetupPublicRoutesSelfHostedMountsIdentityAndAPIKeys(t *testing.T) {
 	if !hasRoute(server.router, "GET", "/api-keys") {
 		t.Fatal("expected self-hosted mode to mount /api-keys")
 	}
+	if !hasRoute(server.router, "GET", "/users/me/ssh-keys") {
+		t.Fatal("expected self-hosted mode to mount SSH key list route")
+	}
+	if !hasRoute(server.router, "POST", "/users/me/ssh-keys") {
+		t.Fatal("expected self-hosted mode to mount SSH key create route")
+	}
+	if !hasRoute(server.router, "DELETE", "/users/me/ssh-keys/:id") {
+		t.Fatal("expected self-hosted mode to mount SSH key delete route")
+	}
 }
 
-func TestSetupPublicRoutesFederatedMountsRegionalAPIKeysOnly(t *testing.T) {
+func TestSetupPublicRoutesFederatedMountsRegionalStateOnly(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	server := testPublicRouteServer(edgeAuthModeFederatedGlobal)


### PR DESCRIPTION
## Summary
- Keep `/users/me/ssh-keys` out of global identity routes and mount it only through the full self-hosted surface or regional state surface.
- Drop the region-local SSH key `users` foreign key so federated regional gateways can store global JWT user IDs without creating local user rows.
- Explicitly delete SSH keys when deleting a self-hosted user, replacing the old FK cascade.
- Add route and repository regression coverage for global, regional, and federated SSH key behavior.

## Testing
- `go test ./pkg/gateway/public ./regional-gateway/pkg/http ./global-gateway/pkg/http ./cluster-gateway/pkg/http ./pkg/gateway/identity ./pkg/gateway/http/handlers ./ssh-gateway/pkg/server -count=1`
- `git diff --check`
- pre-push hook: `make manifests`, `make proto`, `make apispec`, `go fmt ./...`, `go mod tidy`, `go mod vendor`, `golangci-lint run ./...`