### PR TITLE
Remove API key type from public contract

### DIFF
--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -3692,8 +3692,6 @@ components:
           type: string
         name:
           type: string
-        type:
-          type: string
         roles:
           type: array
           items:
@@ -3720,7 +3718,6 @@ components:
         - team_id
         - created_by
         - name
-        - type
         - roles
         - is_active
         - expires_at
@@ -3731,9 +3728,6 @@ components:
       properties:
         name:
           type: string
-        type:
-          type: string
-          enum: [user, service]
         roles:
           type: array
           items:
@@ -3741,15 +3735,13 @@ components:
         expires_in:
           type: string
           description: "30d, 90d, 180d, 365d, or never"
-      required: [name, type]
+      required: [name]
     CreateAPIKeyResponse:
       type: object
       properties:
         id:
           type: string
         name:
-          type: string
-        type:
           type: string
         roles:
           type: array
@@ -3765,7 +3757,7 @@ components:
         created_at:
           type: string
           format: date-time
-      required: [id, name, type, roles, team_id, expires_at, created_at]
+      required: [id, name, roles, team_id, expires_at, created_at]
     CurrentAPIKeyResponse:
       type: object
       properties:
@@ -3774,8 +3766,6 @@ components:
         team_id:
           type: string
         created_by:
-          type: string
-        type:
           type: string
         roles:
           type: array
@@ -3790,7 +3780,7 @@ components:
         expires_at:
           type: string
           format: date-time
-      required: [id, team_id, created_by, type, roles, permissions, is_active, expires_at]
+      required: [id, team_id, created_by, roles, permissions, is_active, expires_at]
     SuccessCreateAPIKeyResponse:
       allOf:
         - $ref: "#/components/schemas/SuccessEnvelope"

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -27,12 +27,6 @@ const (
 	ChangeRequestEntryKindFile      ChangeRequestEntryKind = "file"
 )
 
-// Defines values for CreateAPIKeyRequestType.
-const (
-	CreateAPIKeyRequestTypeService CreateAPIKeyRequestType = "service"
-	CreateAPIKeyRequestTypeUser    CreateAPIKeyRequestType = "user"
-)
-
 // Defines values for CredentialProjectionType.
 const (
 	HttpHeaders          CredentialProjectionType = "http_headers"
@@ -573,7 +567,6 @@ type APIKey struct {
 	Name       string     `json:"name"`
 	Roles      []string   `json:"roles"`
 	TeamId     string     `json:"team_id"`
-	Type       string     `json:"type"`
 	UpdatedAt  time.Time  `json:"updated_at"`
 	UsageCount *int64     `json:"usage_count,omitempty"`
 	UserId     *string    `json:"user_id"`
@@ -747,14 +740,10 @@ type ContextStatsResponse struct {
 // CreateAPIKeyRequest defines model for CreateAPIKeyRequest.
 type CreateAPIKeyRequest struct {
 	// ExpiresIn 30d, 90d, 180d, 365d, or never
-	ExpiresIn *string                 `json:"expires_in,omitempty"`
-	Name      string                  `json:"name"`
-	Roles     *[]string               `json:"roles,omitempty"`
-	Type      CreateAPIKeyRequestType `json:"type"`
+	ExpiresIn *string   `json:"expires_in,omitempty"`
+	Name      string    `json:"name"`
+	Roles     *[]string `json:"roles,omitempty"`
 }
-
-// CreateAPIKeyRequestType defines model for CreateAPIKeyRequest.Type.
-type CreateAPIKeyRequestType string
 
 // CreateAPIKeyResponse defines model for CreateAPIKeyResponse.
 type CreateAPIKeyResponse struct {
@@ -765,7 +754,6 @@ type CreateAPIKeyResponse struct {
 	Name      string    `json:"name"`
 	Roles     []string  `json:"roles"`
 	TeamId    string    `json:"team_id"`
-	Type      string    `json:"type"`
 }
 
 // CreateCMDContextRequest defines model for CreateCMDContextRequest.
@@ -897,7 +885,6 @@ type CurrentAPIKeyResponse struct {
 	Permissions []string  `json:"permissions"`
 	Roles       []string  `json:"roles"`
 	TeamId      string    `json:"team_id"`
-	Type        string    `json:"type"`
 }
 
 // DeviceLoginPollRequest defines model for DeviceLoginPollRequest.

--- a/pkg/gateway/apikey/repository.go
+++ b/pkg/gateway/apikey/repository.go
@@ -28,7 +28,6 @@ type APIKey struct {
 	UserID     *string    `json:"user_id,omitempty"`
 	CreatedBy  string     `json:"created_by"`
 	Name       string     `json:"name"`
-	Type       string     `json:"type"`
 	Roles      []string   `json:"roles"`
 	IsActive   bool       `json:"is_active"`
 	ExpiresAt  time.Time  `json:"expires_at"`
@@ -54,7 +53,7 @@ func (r *Repository) Pool() *pgxpool.Pool {
 }
 
 // CreateAPIKey creates a new API key.
-func (r *Repository) CreateAPIKey(ctx context.Context, teamID, regionID, userID, name, keyType string, roles []string, expiresAt time.Time) (*APIKey, string, error) {
+func (r *Repository) CreateAPIKey(ctx context.Context, teamID, regionID, userID, name string, roles []string, expiresAt time.Time) (*APIKey, string, error) {
 	keyValue, err := NewKeyValue(regionID)
 	if err != nil {
 		return nil, "", err
@@ -68,13 +67,13 @@ func (r *Repository) CreateAPIKey(ctx context.Context, teamID, regionID, userID,
 
 	var key APIKey
 	err = r.pool.QueryRow(ctx, `
-		INSERT INTO api_keys (id, key_value, team_id, created_by, name, type, roles, is_active, expires_at, user_id)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, true, $8, $9)
-		RETURNING id, key_value, team_id, created_by, name, type, roles, is_active, expires_at, last_used_at, usage_count, created_at, updated_at
-	`, id, keyValue, teamID, userID, name, keyType, rolesJSON, expiresAt, userID,
+		INSERT INTO api_keys (id, key_value, team_id, created_by, name, roles, is_active, expires_at, user_id)
+		VALUES ($1, $2, $3, $4, $5, $6, true, $7, $8)
+		RETURNING id, key_value, team_id, created_by, name, roles, is_active, expires_at, last_used_at, usage_count, created_at, updated_at
+	`, id, keyValue, teamID, userID, name, rolesJSON, expiresAt, userID,
 	).Scan(
 		&key.ID, &key.KeyValue, &key.TeamID, &key.CreatedBy, &key.Name,
-		&key.Type, &rolesJSON, &key.IsActive, &key.ExpiresAt,
+		&rolesJSON, &key.IsActive, &key.ExpiresAt,
 		&key.LastUsed, &key.UsageCount, &key.CreatedAt, &key.UpdatedAt,
 	)
 	if err != nil {
@@ -90,7 +89,7 @@ func (r *Repository) CreateAPIKey(ctx context.Context, teamID, regionID, userID,
 // GetAPIKeysByTeamID retrieves all API keys for a team.
 func (r *Repository) GetAPIKeysByTeamID(ctx context.Context, teamID string) ([]*APIKey, error) {
 	rows, err := r.pool.Query(ctx, `
-		SELECT id, key_value, team_id, created_by, name, type, roles,
+		SELECT id, key_value, team_id, created_by, name, roles,
 		       is_active, expires_at, last_used_at, usage_count, created_at, updated_at
 		FROM api_keys
 		WHERE team_id = $1
@@ -107,7 +106,7 @@ func (r *Repository) GetAPIKeysByTeamID(ctx context.Context, teamID string) ([]*
 		var rolesJSON []byte
 		if err := rows.Scan(
 			&key.ID, &key.KeyValue, &key.TeamID, &key.CreatedBy, &key.Name,
-			&key.Type, &rolesJSON, &key.IsActive, &key.ExpiresAt,
+			&rolesJSON, &key.IsActive, &key.ExpiresAt,
 			&key.LastUsed, &key.UsageCount, &key.CreatedAt, &key.UpdatedAt,
 		); err != nil {
 			return nil, fmt.Errorf("scan key: %w", err)
@@ -124,7 +123,7 @@ func (r *Repository) GetAPIKeysByTeamID(ctx context.Context, teamID string) ([]*
 // GetAPIKeysByUserID retrieves all API keys created by a user.
 func (r *Repository) GetAPIKeysByUserID(ctx context.Context, userID string) ([]*APIKey, error) {
 	rows, err := r.pool.Query(ctx, `
-		SELECT id, key_value, team_id, created_by, name, type, roles,
+		SELECT id, key_value, team_id, created_by, name, roles,
 		       is_active, expires_at, last_used_at, usage_count, created_at, updated_at
 		FROM api_keys
 		WHERE user_id = $1
@@ -141,7 +140,7 @@ func (r *Repository) GetAPIKeysByUserID(ctx context.Context, userID string) ([]*
 		var rolesJSON []byte
 		if err := rows.Scan(
 			&key.ID, &key.KeyValue, &key.TeamID, &key.CreatedBy, &key.Name,
-			&key.Type, &rolesJSON, &key.IsActive, &key.ExpiresAt,
+			&rolesJSON, &key.IsActive, &key.ExpiresAt,
 			&key.LastUsed, &key.UsageCount, &key.CreatedAt, &key.UpdatedAt,
 		); err != nil {
 			return nil, fmt.Errorf("scan key: %w", err)
@@ -186,13 +185,13 @@ func (r *Repository) GetAPIKeyByID(ctx context.Context, id string) (*APIKey, err
 	var key APIKey
 	var rolesJSON []byte
 	err := r.pool.QueryRow(ctx, `
-		SELECT id, key_value, team_id, created_by, name, type, roles,
+		SELECT id, key_value, team_id, created_by, name, roles,
 		       is_active, expires_at, last_used_at, usage_count, created_at, updated_at
 		FROM api_keys
 		WHERE id = $1
 	`, id).Scan(
 		&key.ID, &key.KeyValue, &key.TeamID, &key.CreatedBy, &key.Name,
-		&key.Type, &rolesJSON, &key.IsActive, &key.ExpiresAt,
+		&rolesJSON, &key.IsActive, &key.ExpiresAt,
 		&key.LastUsed, &key.UsageCount, &key.CreatedAt, &key.UpdatedAt,
 	)
 	if err != nil {
@@ -218,13 +217,13 @@ func (r *Repository) ValidateAPIKey(ctx context.Context, keyValue string) (*APIK
 	var key APIKey
 	var rolesJSON []byte
 	err := r.pool.QueryRow(ctx, `
-		SELECT id, key_value, team_id, created_by, name, type, roles,
+		SELECT id, key_value, team_id, created_by, name, roles,
 		       is_active, expires_at, last_used_at, usage_count, created_at, updated_at, user_id
 		FROM api_keys
 		WHERE key_value = $1
 	`, keyValue).Scan(
 		&key.ID, &key.KeyValue, &key.TeamID, &key.CreatedBy,
-		&key.Name, &key.Type, &rolesJSON, &key.IsActive,
+		&key.Name, &rolesJSON, &key.IsActive,
 		&key.ExpiresAt, &key.LastUsed, &key.UsageCount,
 		&key.CreatedAt, &key.UpdatedAt, &key.UserID,
 	)

--- a/pkg/gateway/http/handlers/apikey.go
+++ b/pkg/gateway/http/handlers/apikey.go
@@ -62,7 +62,6 @@ func (h *APIKeyHandler) ListAPIKeys(c *gin.Context) {
 // CreateAPIKeyRequest is the request body for creating an API key
 type CreateAPIKeyRequest struct {
 	Name      string   `json:"name" binding:"required"`
-	Type      string   `json:"type" binding:"required,oneof=user service"`
 	Roles     []string `json:"roles"`
 	ExpiresIn string   `json:"expires_in"` // e.g., "30d", "90d", "365d", "never"
 }
@@ -71,7 +70,6 @@ type CreateAPIKeyRequest struct {
 type CreateAPIKeyResponse struct {
 	ID        string    `json:"id"`
 	Name      string    `json:"name"`
-	Type      string    `json:"type"`
 	Roles     []string  `json:"roles"`
 	TeamID    string    `json:"team_id"`
 	Key       string    `json:"key,omitempty"` // Only returned on creation
@@ -84,7 +82,6 @@ type CurrentAPIKeyResponse struct {
 	ID          string    `json:"id"`
 	TeamID      string    `json:"team_id"`
 	CreatedBy   string    `json:"created_by"`
-	Type        string    `json:"type"`
 	Roles       []string  `json:"roles"`
 	Permissions []string  `json:"permissions"`
 	IsActive    bool      `json:"is_active"`
@@ -115,7 +112,6 @@ func (h *APIKeyHandler) GetCurrentAPIKey(c *gin.Context) {
 			ID:          key.ID,
 			TeamID:      key.TeamID,
 			CreatedBy:   key.CreatedBy,
-			Type:        key.Type,
 			Roles:       key.Roles,
 			Permissions: append([]string(nil), authCtx.Permissions...),
 			IsActive:    key.IsActive,
@@ -186,7 +182,6 @@ func (h *APIKeyHandler) CreateAPIKey(c *gin.Context) {
 		regionID,
 		authCtx.UserID,
 		req.Name,
-		req.Type,
 		roles,
 		expiresAt,
 	)
@@ -200,7 +195,6 @@ func (h *APIKeyHandler) CreateAPIKey(c *gin.Context) {
 	response := &CreateAPIKeyResponse{
 		ID:        key.ID,
 		Name:      key.Name,
-		Type:      key.Type,
 		Roles:     key.Roles,
 		TeamID:    key.TeamID,
 		Key:       keyValue, // Full key, only shown at creation

--- a/pkg/gateway/migrations/00001_init_schema.sql
+++ b/pkg/gateway/migrations/00001_init_schema.sql
@@ -93,7 +93,6 @@ CREATE TABLE IF NOT EXISTS api_keys (
     team_id UUID NOT NULL,
     created_by UUID NOT NULL,
     name TEXT NOT NULL,
-    type TEXT NOT NULL CHECK (type IN ('user', 'service', 'internal')),
     roles JSONB NOT NULL DEFAULT '[]',
     is_active BOOLEAN NOT NULL DEFAULT true,
     expires_at TIMESTAMPTZ NOT NULL,

--- a/pkg/gateway/migrations/00004_remove_api_key_type.sql
+++ b/pkg/gateway/migrations/00004_remove_api_key_type.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+ALTER TABLE IF EXISTS api_keys
+    DROP COLUMN IF EXISTS type;
+
+-- +goose Down
+ALTER TABLE IF EXISTS api_keys
+    ADD COLUMN IF NOT EXISTS type TEXT NOT NULL DEFAULT 'service' CHECK (type IN ('user', 'service', 'internal'));
+
+ALTER TABLE IF EXISTS api_keys
+    ALTER COLUMN type DROP DEFAULT;

--- a/tests/integration/internal/tests/cluster-gateway/auth_test.go
+++ b/tests/integration/internal/tests/cluster-gateway/auth_test.go
@@ -161,7 +161,7 @@ func TestClusterGatewayIntegration_PublicAuthAPIKey(t *testing.T) {
 		t.Fatalf("set team home region: %v", err)
 	}
 
-	_, keyValue, err := apiKeyRepo.CreateAPIKey(ctx, team.ID, "aws-us-east-1", user.ID, "test-key", "user", []string{"admin"}, time.Now().Add(time.Hour))
+	_, keyValue, err := apiKeyRepo.CreateAPIKey(ctx, team.ID, "aws-us-east-1", user.ID, "test-key", []string{"admin"}, time.Now().Add(time.Hour))
 	if err != nil {
 		t.Fatalf("create api key: %v", err)
 	}
@@ -195,7 +195,7 @@ func TestClusterGatewayIntegration_APIKeyCanBeCreatedWithoutLocalTeamOrUserRow(t
 		t.Fatalf("delete local user row: %v", err)
 	}
 
-	key, keyValue, err := apiKeyRepo.CreateAPIKey(ctx, team.ID, "aws-us-east-1", user.ID, "test-key", "service", []string{"developer"}, time.Now().Add(time.Hour))
+	key, keyValue, err := apiKeyRepo.CreateAPIKey(ctx, team.ID, "aws-us-east-1", user.ID, "test-key", []string{"developer"}, time.Now().Add(time.Hour))
 	if err != nil {
 		t.Fatalf("create api key without local team or user row: %v", err)
 	}


### PR DESCRIPTION
## Summary
- remove API key `type` from the OpenAPI schema, generated types, handlers, and repository model
- stop reading and writing the `api_keys.type` column
- add a gateway migration to drop the column and update the initial schema for new installs
- update integration tests for the new repository API

## Testing
- `make apispec`
- `go test ./pkg/gateway/... ./cluster-gateway/pkg/http ./regional-gateway/pkg/http ./global-gateway/pkg/http -count=1`
- `go test ./tests/integration/internal/tests/cluster-gateway -run 'TestClusterGatewayIntegration_(PublicAuthAPIKey|APIKeyCanBeCreatedWithoutLocalTeamOrUserRow)$' -count=1`\n- pre-push hook: `make manifests`, `make proto`, `make apispec`, `go fmt ./...`, `go mod tidy`, `go mod vendor`, `golangci-lint run ./...`