### PR TITLE
Make SSH keys team-scoped in regional auth

### DIFF
--- a/pkg/gateway/http/handlers/user.go
+++ b/pkg/gateway/http/handlers/user.go
@@ -49,8 +49,8 @@ type userRepository interface {
 	GetUserIdentitiesByUserID(ctx context.Context, userID string) ([]*identity.UserIdentity, error)
 	DeleteUserIdentity(ctx context.Context, id string) error
 	CreateUserSSHPublicKey(ctx context.Context, key *identity.UserSSHPublicKey) error
-	ListUserSSHPublicKeysByUserID(ctx context.Context, userID string) ([]*identity.UserSSHPublicKey, error)
-	DeleteUserSSHPublicKey(ctx context.Context, userID, keyID string) error
+	ListUserSSHPublicKeysByTeamAndUserID(ctx context.Context, teamID, userID string) ([]*identity.UserSSHPublicKey, error)
+	DeleteUserSSHPublicKeyByTeamAndUserID(ctx context.Context, teamID, userID, keyID string) error
 }
 
 // UserHandler handles user endpoints
@@ -256,8 +256,12 @@ func (h *UserHandler) ListUserSSHPublicKeys(c *gin.Context) {
 		spec.JSONError(c, http.StatusUnauthorized, spec.CodeUnauthorized, "not authenticated")
 		return
 	}
+	if strings.TrimSpace(authCtx.TeamID) == "" {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "no team selected")
+		return
+	}
 
-	keys, err := h.repo.ListUserSSHPublicKeysByUserID(c.Request.Context(), authCtx.UserID)
+	keys, err := h.repo.ListUserSSHPublicKeysByTeamAndUserID(c.Request.Context(), authCtx.TeamID, authCtx.UserID)
 	if err != nil {
 		h.logger.Error("Failed to list ssh public keys", zap.Error(err))
 		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to list ssh public keys")
@@ -276,6 +280,10 @@ func (h *UserHandler) CreateUserSSHPublicKey(c *gin.Context) {
 	authCtx := middleware.GetAuthContext(c)
 	if authCtx == nil || authCtx.UserID == "" {
 		spec.JSONError(c, http.StatusUnauthorized, spec.CodeUnauthorized, "not authenticated")
+		return
+	}
+	if strings.TrimSpace(authCtx.TeamID) == "" {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "no team selected")
 		return
 	}
 
@@ -298,6 +306,7 @@ func (h *UserHandler) CreateUserSSHPublicKey(c *gin.Context) {
 	}
 
 	key := &identity.UserSSHPublicKey{
+		TeamID:            authCtx.TeamID,
 		UserID:            authCtx.UserID,
 		Name:              name,
 		PublicKey:         publicKey,
@@ -325,6 +334,10 @@ func (h *UserHandler) DeleteUserSSHPublicKey(c *gin.Context) {
 		spec.JSONError(c, http.StatusUnauthorized, spec.CodeUnauthorized, "not authenticated")
 		return
 	}
+	if strings.TrimSpace(authCtx.TeamID) == "" {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "no team selected")
+		return
+	}
 
 	keyID := strings.TrimSpace(c.Param("id"))
 	if keyID == "" {
@@ -332,7 +345,7 @@ func (h *UserHandler) DeleteUserSSHPublicKey(c *gin.Context) {
 		return
 	}
 
-	if err := h.repo.DeleteUserSSHPublicKey(c.Request.Context(), authCtx.UserID, keyID); err != nil {
+	if err := h.repo.DeleteUserSSHPublicKeyByTeamAndUserID(c.Request.Context(), authCtx.TeamID, authCtx.UserID, keyID); err != nil {
 		if errors.Is(err, identity.ErrSSHPublicKeyNotFound) {
 			spec.JSONError(c, http.StatusNotFound, spec.CodeNotFound, "ssh public key not found")
 			return

--- a/pkg/gateway/http/handlers/user_test.go
+++ b/pkg/gateway/http/handlers/user_test.go
@@ -26,6 +26,7 @@ type fakeUserRepository struct {
 	listSSHPublicKeysErr   error
 	deleteSSHPublicKeyErr  error
 	lastDeletedSSHPublicID string
+	lastDeletedTeamID      string
 	lastDeletedUserID      string
 }
 
@@ -66,17 +67,24 @@ func (f *fakeUserRepository) CreateUserSSHPublicKey(_ context.Context, key *iden
 	return nil
 }
 
-func (f *fakeUserRepository) ListUserSSHPublicKeysByUserID(_ context.Context, userID string) ([]*identity.UserSSHPublicKey, error) {
+func (f *fakeUserRepository) ListUserSSHPublicKeysByTeamAndUserID(_ context.Context, teamID, userID string) ([]*identity.UserSSHPublicKey, error) {
 	if f.listSSHPublicKeysErr != nil {
 		return nil, f.listSSHPublicKeysErr
 	}
 	if f.user == nil || f.user.ID != userID {
 		return nil, nil
 	}
-	return f.sshKeys, nil
+	keys := make([]*identity.UserSSHPublicKey, 0, len(f.sshKeys))
+	for _, key := range f.sshKeys {
+		if key.TeamID == teamID {
+			keys = append(keys, key)
+		}
+	}
+	return keys, nil
 }
 
-func (f *fakeUserRepository) DeleteUserSSHPublicKey(_ context.Context, userID, keyID string) error {
+func (f *fakeUserRepository) DeleteUserSSHPublicKeyByTeamAndUserID(_ context.Context, teamID, userID, keyID string) error {
+	f.lastDeletedTeamID = teamID
 	f.lastDeletedUserID = userID
 	f.lastDeletedSSHPublicID = keyID
 	if f.deleteSSHPublicKeyErr != nil {
@@ -95,7 +103,7 @@ func newAuthenticatedUserContext(t *testing.T, method, target, body string) (*gi
 		req.Header.Set("Content-Type", "application/json")
 	}
 	ctx.Request = req
-	ctx.Set("auth_context", &authn.AuthContext{UserID: "user-1"})
+	ctx.Set("auth_context", &authn.AuthContext{TeamID: "team-1", UserID: "user-1"})
 	return ctx, rec
 }
 
@@ -117,6 +125,9 @@ func TestCreateUserSSHPublicKey(t *testing.T) {
 	if repo.sshKeys[0].Name != "Laptop" {
 		t.Fatalf("stored key name = %q, want %q", repo.sshKeys[0].Name, "Laptop")
 	}
+	if repo.sshKeys[0].TeamID != "team-1" {
+		t.Fatalf("stored key team_id = %q, want team-1", repo.sshKeys[0].TeamID)
+	}
 	if repo.sshKeys[0].PublicKey != "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ4dLZLZOA/asaP+5QO6t81jzbe5G4jrI2F+jbjL6TY8" {
 		t.Fatalf("stored key public_key = %q", repo.sshKeys[0].PublicKey)
 	}
@@ -133,6 +144,24 @@ func TestCreateUserSSHPublicKey(t *testing.T) {
 	}
 	if resp.Name != "Laptop" {
 		t.Fatalf("response name = %q, want %q", resp.Name, "Laptop")
+	}
+}
+
+func TestCreateUserSSHPublicKeyRequiresTeam(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	repo := &fakeUserRepository{user: &identity.User{ID: "user-1"}}
+	handler := NewUserHandler(repo, zap.NewNop())
+	ctx, rec := newAuthenticatedUserContext(t, http.MethodPost, "/users/me/ssh-keys", `{"name":"Laptop","public_key":"`+testSSHPublicKey+`"}`)
+	ctx.Set("auth_context", &authn.AuthContext{UserID: "user-1"})
+
+	handler.CreateUserSSHPublicKey(ctx)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+	if len(repo.sshKeys) != 0 {
+		t.Fatalf("stored keys = %d, want 0", len(repo.sshKeys))
 	}
 }
 
@@ -160,6 +189,7 @@ func TestListUserSSHPublicKeys(t *testing.T) {
 		user: &identity.User{ID: "user-1"},
 		sshKeys: []*identity.UserSSHPublicKey{{
 			ID:                "sshkey-1",
+			TeamID:            "team-1",
 			UserID:            "user-1",
 			Name:              "Laptop",
 			PublicKey:         "ssh-ed25519 AAAAC3Nza...",
@@ -210,8 +240,8 @@ func TestDeleteUserSSHPublicKey(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
 	}
-	if repo.lastDeletedUserID != "user-1" || repo.lastDeletedSSHPublicID != "sshkey-1" {
-		t.Fatalf("delete args = (%q, %q), want (%q, %q)", repo.lastDeletedUserID, repo.lastDeletedSSHPublicID, "user-1", "sshkey-1")
+	if repo.lastDeletedTeamID != "team-1" || repo.lastDeletedUserID != "user-1" || repo.lastDeletedSSHPublicID != "sshkey-1" {
+		t.Fatalf("delete args = (%q, %q, %q), want (%q, %q, %q)", repo.lastDeletedTeamID, repo.lastDeletedUserID, repo.lastDeletedSSHPublicID, "team-1", "user-1", "sshkey-1")
 	}
 }
 

--- a/pkg/gateway/identity/ssh_public_key.go
+++ b/pkg/gateway/identity/ssh_public_key.go
@@ -11,6 +11,7 @@ import (
 // UserSSHPublicKey stores one normalized SSH public key uploaded by a user.
 type UserSSHPublicKey struct {
 	ID                string    `json:"id"`
+	TeamID            string    `json:"team_id"`
 	UserID            string    `json:"user_id"`
 	Name              string    `json:"name"`
 	PublicKey         string    `json:"public_key"`

--- a/pkg/gateway/identity/ssh_public_key_repository.go
+++ b/pkg/gateway/identity/ssh_public_key_repository.go
@@ -8,13 +8,13 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
-// CreateUserSSHPublicKey stores one SSH public key for a user.
+// CreateUserSSHPublicKey stores one SSH public key for a user in a team.
 func (r *Repository) CreateUserSSHPublicKey(ctx context.Context, key *UserSSHPublicKey) error {
 	err := r.pool.QueryRow(ctx, `
-		INSERT INTO user_ssh_public_keys (user_id, name, public_key, key_type, fingerprint_sha256, comment)
-		VALUES ($1, $2, $3, $4, $5, $6)
+		INSERT INTO user_ssh_public_keys (team_id, user_id, name, public_key, key_type, fingerprint_sha256, comment)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
 		RETURNING id, created_at, updated_at
-	`, key.UserID, key.Name, key.PublicKey, key.KeyType, key.FingerprintSHA256, key.Comment,
+	`, key.TeamID, key.UserID, key.Name, key.PublicKey, key.KeyType, key.FingerprintSHA256, key.Comment,
 	).Scan(&key.ID, &key.CreatedAt, &key.UpdatedAt)
 	if err != nil {
 		if isDuplicateKeyError(err) {
@@ -25,14 +25,14 @@ func (r *Repository) CreateUserSSHPublicKey(ctx context.Context, key *UserSSHPub
 	return nil
 }
 
-// ListUserSSHPublicKeysByUserID lists SSH public keys uploaded by one user.
-func (r *Repository) ListUserSSHPublicKeysByUserID(ctx context.Context, userID string) ([]*UserSSHPublicKey, error) {
+// ListUserSSHPublicKeysByTeamAndUserID lists SSH public keys uploaded by one user in one team.
+func (r *Repository) ListUserSSHPublicKeysByTeamAndUserID(ctx context.Context, teamID, userID string) ([]*UserSSHPublicKey, error) {
 	rows, err := r.pool.Query(ctx, `
-		SELECT id, user_id, name, public_key, key_type, fingerprint_sha256, comment, created_at, updated_at
+		SELECT id, COALESCE(team_id, ''), user_id, name, public_key, key_type, fingerprint_sha256, comment, created_at, updated_at
 		FROM user_ssh_public_keys
-		WHERE user_id = $1
+		WHERE team_id = $1 AND user_id = $2
 		ORDER BY created_at, id
-	`, userID)
+	`, teamID, userID)
 	if err != nil {
 		return nil, fmt.Errorf("query ssh public keys: %w", err)
 	}
@@ -43,6 +43,42 @@ func (r *Repository) ListUserSSHPublicKeysByUserID(ctx context.Context, userID s
 		var key UserSSHPublicKey
 		if err := rows.Scan(
 			&key.ID,
+			&key.TeamID,
+			&key.UserID,
+			&key.Name,
+			&key.PublicKey,
+			&key.KeyType,
+			&key.FingerprintSHA256,
+			&key.Comment,
+			&key.CreatedAt,
+			&key.UpdatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan ssh public key: %w", err)
+		}
+		keys = append(keys, &key)
+	}
+	return keys, nil
+}
+
+// ListUserSSHPublicKeysByFingerprint lists team-scoped SSH public keys by normalized fingerprint.
+func (r *Repository) ListUserSSHPublicKeysByFingerprint(ctx context.Context, fingerprint string) ([]*UserSSHPublicKey, error) {
+	rows, err := r.pool.Query(ctx, `
+		SELECT id, COALESCE(team_id, ''), user_id, name, public_key, key_type, fingerprint_sha256, comment, created_at, updated_at
+		FROM user_ssh_public_keys
+		WHERE fingerprint_sha256 = $1 AND COALESCE(team_id, '') <> ''
+		ORDER BY team_id, created_at, id
+	`, fingerprint)
+	if err != nil {
+		return nil, fmt.Errorf("query ssh public keys by fingerprint: %w", err)
+	}
+	defer rows.Close()
+
+	keys := make([]*UserSSHPublicKey, 0)
+	for rows.Next() {
+		var key UserSSHPublicKey
+		if err := rows.Scan(
+			&key.ID,
+			&key.TeamID,
 			&key.UserID,
 			&key.Name,
 			&key.PublicKey,
@@ -63,11 +99,14 @@ func (r *Repository) ListUserSSHPublicKeysByUserID(ctx context.Context, userID s
 func (r *Repository) GetUserSSHPublicKeyByFingerprint(ctx context.Context, fingerprint string) (*UserSSHPublicKey, error) {
 	var key UserSSHPublicKey
 	err := r.pool.QueryRow(ctx, `
-		SELECT id, user_id, name, public_key, key_type, fingerprint_sha256, comment, created_at, updated_at
+		SELECT id, COALESCE(team_id, ''), user_id, name, public_key, key_type, fingerprint_sha256, comment, created_at, updated_at
 		FROM user_ssh_public_keys
 		WHERE fingerprint_sha256 = $1
+		ORDER BY created_at, id
+		LIMIT 1
 	`, fingerprint).Scan(
 		&key.ID,
+		&key.TeamID,
 		&key.UserID,
 		&key.Name,
 		&key.PublicKey,
@@ -86,12 +125,12 @@ func (r *Repository) GetUserSSHPublicKeyByFingerprint(ctx context.Context, finge
 	return &key, nil
 }
 
-// DeleteUserSSHPublicKey deletes one SSH public key owned by a user.
-func (r *Repository) DeleteUserSSHPublicKey(ctx context.Context, userID, keyID string) error {
+// DeleteUserSSHPublicKeyByTeamAndUserID deletes one SSH public key owned by a user in a team.
+func (r *Repository) DeleteUserSSHPublicKeyByTeamAndUserID(ctx context.Context, teamID, userID, keyID string) error {
 	result, err := r.pool.Exec(ctx, `
 		DELETE FROM user_ssh_public_keys
-		WHERE id = $1 AND user_id = $2
-	`, keyID, userID)
+		WHERE id = $1 AND team_id = $2 AND user_id = $3
+	`, keyID, teamID, userID)
 	if err != nil {
 		return fmt.Errorf("delete ssh public key: %w", err)
 	}

--- a/pkg/gateway/identity/ssh_public_key_repository_test.go
+++ b/pkg/gateway/identity/ssh_public_key_repository_test.go
@@ -35,6 +35,7 @@ func TestUserSSHPublicKeyRepositoryLifecycle(t *testing.T) {
 		t.Fatalf("normalize ssh public key: %v", err)
 	}
 	key := &UserSSHPublicKey{
+		TeamID:            "team-1",
 		UserID:            user.ID,
 		Name:              "Laptop",
 		PublicKey:         publicKey,
@@ -46,7 +47,7 @@ func TestUserSSHPublicKeyRepositoryLifecycle(t *testing.T) {
 		t.Fatalf("create ssh public key: %v", err)
 	}
 
-	keys, err := repo.ListUserSSHPublicKeysByUserID(ctx, user.ID)
+	keys, err := repo.ListUserSSHPublicKeysByTeamAndUserID(ctx, "team-1", user.ID)
 	if err != nil {
 		t.Fatalf("list ssh public keys: %v", err)
 	}
@@ -61,8 +62,19 @@ func TestUserSSHPublicKeyRepositoryLifecycle(t *testing.T) {
 	if loaded.UserID != user.ID {
 		t.Fatalf("loaded user_id = %q, want %q", loaded.UserID, user.ID)
 	}
+	if loaded.TeamID != "team-1" {
+		t.Fatalf("loaded team_id = %q, want team-1", loaded.TeamID)
+	}
 
-	if err := repo.DeleteUserSSHPublicKey(ctx, user.ID, key.ID); err != nil {
+	fingerprintKeys, err := repo.ListUserSSHPublicKeysByFingerprint(ctx, fingerprint)
+	if err != nil {
+		t.Fatalf("list ssh public keys by fingerprint: %v", err)
+	}
+	if len(fingerprintKeys) != 1 || fingerprintKeys[0].TeamID != "team-1" {
+		t.Fatalf("fingerprint keys = %+v, want one team-1 key", fingerprintKeys)
+	}
+
+	if err := repo.DeleteUserSSHPublicKeyByTeamAndUserID(ctx, "team-1", user.ID, key.ID); err != nil {
 		t.Fatalf("delete ssh public key: %v", err)
 	}
 	if _, err := repo.GetUserSSHPublicKeyByFingerprint(ctx, fingerprint); err != ErrSSHPublicKeyNotFound {
@@ -85,6 +97,7 @@ func TestUserSSHPublicKeyRepositoryAllowsFederatedUserID(t *testing.T) {
 	}
 
 	key := &UserSSHPublicKey{
+		TeamID:            "team-1",
 		UserID:            userID,
 		Name:              "Federated laptop",
 		PublicKey:         publicKey,
@@ -96,12 +109,50 @@ func TestUserSSHPublicKeyRepositoryAllowsFederatedUserID(t *testing.T) {
 		t.Fatalf("create ssh public key for federated user: %v", err)
 	}
 
-	keys, err := repo.ListUserSSHPublicKeysByUserID(ctx, userID)
+	keys, err := repo.ListUserSSHPublicKeysByTeamAndUserID(ctx, "team-1", userID)
 	if err != nil {
 		t.Fatalf("list federated user ssh public keys: %v", err)
 	}
 	if len(keys) != 1 {
 		t.Fatalf("keys len = %d, want 1 (schema %s)", len(keys), schema)
+	}
+}
+
+func TestUserSSHPublicKeyRepositoryAllowsSameFingerprintAcrossTeams(t *testing.T) {
+	pool, _ := newGatewayIdentityTestPool(t)
+	if pool == nil {
+		return
+	}
+
+	ctx := context.Background()
+	repo := NewRepository(pool)
+	userID := uuid.NewString()
+	publicKey, keyType, fingerprint, comment, err := NormalizeAuthorizedSSHPublicKey("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ4dLZLZOA/asaP+5QO6t81jzbe5G4jrI2F+jbjL6TY8 sandbox0-e2e")
+	if err != nil {
+		t.Fatalf("normalize ssh public key: %v", err)
+	}
+
+	for _, teamID := range []string{"team-1", "team-2"} {
+		key := &UserSSHPublicKey{
+			TeamID:            teamID,
+			UserID:            userID,
+			Name:              "Laptop " + teamID,
+			PublicKey:         publicKey,
+			KeyType:           keyType,
+			FingerprintSHA256: fingerprint,
+			Comment:           comment,
+		}
+		if err := repo.CreateUserSSHPublicKey(ctx, key); err != nil {
+			t.Fatalf("create ssh public key for %s: %v", teamID, err)
+		}
+	}
+
+	keys, err := repo.ListUserSSHPublicKeysByFingerprint(ctx, fingerprint)
+	if err != nil {
+		t.Fatalf("list ssh public keys by fingerprint: %v", err)
+	}
+	if len(keys) != 2 {
+		t.Fatalf("keys len = %d, want 2", len(keys))
 	}
 }
 
@@ -126,6 +177,7 @@ func TestDeleteUserRemovesSSHPublicKeys(t *testing.T) {
 		t.Fatalf("normalize ssh public key: %v", err)
 	}
 	key := &UserSSHPublicKey{
+		TeamID:            "team-1",
 		UserID:            user.ID,
 		Name:              "Laptop",
 		PublicKey:         publicKey,

--- a/pkg/gateway/migrations/00005_team_scope_user_ssh_public_keys.sql
+++ b/pkg/gateway/migrations/00005_team_scope_user_ssh_public_keys.sql
@@ -1,0 +1,28 @@
+-- +goose Up
+ALTER TABLE IF EXISTS user_ssh_public_keys
+    ADD COLUMN IF NOT EXISTS team_id TEXT;
+
+ALTER TABLE IF EXISTS user_ssh_public_keys
+    DROP CONSTRAINT IF EXISTS user_ssh_public_keys_fingerprint_sha256_key;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_user_ssh_public_keys_team_fingerprint
+    ON user_ssh_public_keys(team_id, fingerprint_sha256)
+    WHERE team_id IS NOT NULL AND team_id <> '';
+
+CREATE INDEX IF NOT EXISTS idx_user_ssh_public_keys_team_user_id
+    ON user_ssh_public_keys(team_id, user_id);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_user_ssh_public_keys_team_user_id;
+DROP INDEX IF EXISTS idx_user_ssh_public_keys_team_fingerprint;
+
+DELETE FROM user_ssh_public_keys a
+USING user_ssh_public_keys b
+WHERE a.ctid < b.ctid
+  AND a.fingerprint_sha256 = b.fingerprint_sha256;
+
+ALTER TABLE IF EXISTS user_ssh_public_keys
+    DROP COLUMN IF EXISTS team_id;
+
+ALTER TABLE IF EXISTS user_ssh_public_keys
+    ADD CONSTRAINT user_ssh_public_keys_fingerprint_sha256_key UNIQUE (fingerprint_sha256);

--- a/pkg/sshgateway/authz.go
+++ b/pkg/sshgateway/authz.go
@@ -1,0 +1,64 @@
+package sshgateway
+
+import "strings"
+
+// AuthorizedGrantsHeader carries team/user grants derived from a verified SSH key.
+// The header is only sent on the internal ssh-gateway to regional-gateway route.
+const AuthorizedGrantsHeader = "X-SSH-Key-Grants"
+
+// AuthorizedGrant identifies one team/user pair authorized by an SSH key.
+type AuthorizedGrant struct {
+	TeamID string
+	UserID string
+}
+
+// EncodeAuthorizedGrants formats SSH key grants for an internal HTTP header.
+func EncodeAuthorizedGrants(grants []AuthorizedGrant) string {
+	parts := make([]string, 0, len(grants))
+	seen := make(map[string]struct{}, len(grants))
+	for _, grant := range grants {
+		teamID := strings.TrimSpace(grant.TeamID)
+		userID := strings.TrimSpace(grant.UserID)
+		if teamID == "" || userID == "" {
+			continue
+		}
+		encoded := teamID + "=" + userID
+		if _, ok := seen[encoded]; ok {
+			continue
+		}
+		seen[encoded] = struct{}{}
+		parts = append(parts, encoded)
+	}
+	return strings.Join(parts, ",")
+}
+
+// ParseAuthorizedGrants parses SSH key grants from an internal HTTP header.
+func ParseAuthorizedGrants(raw string) []AuthorizedGrant {
+	fields := strings.Split(raw, ",")
+	grants := make([]AuthorizedGrant, 0, len(fields))
+	for _, field := range fields {
+		teamID, userID, ok := strings.Cut(strings.TrimSpace(field), "=")
+		teamID = strings.TrimSpace(teamID)
+		userID = strings.TrimSpace(userID)
+		if !ok || teamID == "" || userID == "" {
+			continue
+		}
+		grants = append(grants, AuthorizedGrant{TeamID: teamID, UserID: userID})
+	}
+	return grants
+}
+
+// UserIDForTeam returns the user authorized for teamID by the SSH key grants.
+func UserIDForTeam(grants []AuthorizedGrant, teamID string) (string, bool) {
+	teamID = strings.TrimSpace(teamID)
+	if teamID == "" {
+		return "", false
+	}
+	for _, grant := range grants {
+		if strings.TrimSpace(grant.TeamID) == teamID {
+			userID := strings.TrimSpace(grant.UserID)
+			return userID, userID != ""
+		}
+	}
+	return "", false
+}

--- a/pkg/sshgateway/authz_test.go
+++ b/pkg/sshgateway/authz_test.go
@@ -1,0 +1,26 @@
+package sshgateway
+
+import "testing"
+
+func TestEncodeParseAuthorizedGrants(t *testing.T) {
+	raw := EncodeAuthorizedGrants([]AuthorizedGrant{
+		{TeamID: " team-1 ", UserID: " user-1 "},
+		{TeamID: "team-1", UserID: "user-1"},
+		{TeamID: "team-2", UserID: "user-2"},
+		{TeamID: "", UserID: "user-3"},
+	})
+	if raw != "team-1=user-1,team-2=user-2" {
+		t.Fatalf("encoded grants = %q", raw)
+	}
+
+	grants := ParseAuthorizedGrants(raw + ",invalid,team-3=")
+	if len(grants) != 2 {
+		t.Fatalf("grants len = %d, want 2", len(grants))
+	}
+	if got, ok := UserIDForTeam(grants, "team-2"); !ok || got != "user-2" {
+		t.Fatalf("UserIDForTeam(team-2) = %q, %v", got, ok)
+	}
+	if got, ok := UserIDForTeam(grants, "team-3"); ok || got != "" {
+		t.Fatalf("UserIDForTeam(team-3) = %q, %v", got, ok)
+	}
+}

--- a/regional-gateway/pkg/http/internal_ssh.go
+++ b/regional-gateway/pkg/http/internal_ssh.go
@@ -22,9 +22,10 @@ import (
 )
 
 func (s *Server) resolveInternalSSHTarget(c *gin.Context) {
-	userID := strings.TrimSpace(c.GetHeader(internalauth.UserIDHeader))
-	if userID == "" {
-		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "user_id header is required")
+	legacyUserID := strings.TrimSpace(c.GetHeader(internalauth.UserIDHeader))
+	sshGrants := sharedssh.ParseAuthorizedGrants(c.GetHeader(sharedssh.AuthorizedGrantsHeader))
+	if legacyUserID == "" && len(sshGrants) == 0 {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "ssh authorization grants are required")
 		return
 	}
 
@@ -38,7 +39,7 @@ func (s *Server) resolveInternalSSHTarget(c *gin.Context) {
 	if err != nil {
 		s.logger.Warn("Failed to resolve cluster-gateway for SSH target",
 			zap.String("sandbox_id", sandboxID),
-			zap.String("user_id", userID),
+			zap.String("user_id", legacyUserID),
 			zap.Error(err),
 		)
 		spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "cluster gateway unavailable")
@@ -49,7 +50,7 @@ func (s *Server) resolveInternalSSHTarget(c *gin.Context) {
 	if err != nil {
 		s.logger.Warn("Failed to fetch sandbox metadata for SSH target",
 			zap.String("sandbox_id", sandboxID),
-			zap.String("user_id", userID),
+			zap.String("user_id", legacyUserID),
 			zap.String("cluster_gateway_url", targetURL),
 			zap.Error(err),
 		)
@@ -62,7 +63,8 @@ func (s *Server) resolveInternalSSHTarget(c *gin.Context) {
 		return
 	}
 
-	if _, err := s.teamMembership.GetTeamMember(c.Request.Context(), sandbox.TeamID, userID); err != nil {
+	sshUserID, err := authorizeSSHUserForSandboxTeam(c.Request.Context(), sandbox.TeamID, sshGrants, legacyUserID, s.teamMembership)
+	if err != nil {
 		if errors.Is(err, identity.ErrMemberNotFound) {
 			spec.JSONError(c, http.StatusForbidden, spec.CodeForbidden, "sandbox access denied")
 			return
@@ -70,7 +72,7 @@ func (s *Server) resolveInternalSSHTarget(c *gin.Context) {
 		s.logger.Error("Failed to authorize SSH sandbox membership",
 			zap.String("sandbox_id", sandboxID),
 			zap.String("team_id", sandbox.TeamID),
-			zap.String("user_id", userID),
+			zap.String("user_id", legacyUserID),
 			zap.Error(err),
 		)
 		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "authorization failed")
@@ -83,11 +85,11 @@ func (s *Server) resolveInternalSSHTarget(c *gin.Context) {
 			return
 		}
 		if sandbox.PowerState.Desired != mgr.SandboxPowerStateActive {
-			if err := s.resumeSandboxViaClusterGateway(c.Request.Context(), targetURL, sandboxID, sandbox.TeamID, userID); err != nil {
+			if err := s.resumeSandboxViaClusterGateway(c.Request.Context(), targetURL, sandboxID, sandbox.TeamID, sshUserID); err != nil {
 				s.logger.Warn("Failed to request SSH sandbox resume via cluster-gateway",
 					zap.String("sandbox_id", sandboxID),
 					zap.String("team_id", sandbox.TeamID),
-					zap.String("user_id", userID),
+					zap.String("user_id", sshUserID),
 					zap.String("cluster_gateway_url", targetURL),
 					zap.Error(err),
 				)
@@ -107,9 +109,30 @@ func (s *Server) resolveInternalSSHTarget(c *gin.Context) {
 	spec.JSONSuccess(c, http.StatusOK, &sharedssh.ResolvedTarget{
 		SandboxID: sandboxID,
 		TeamID:    sandbox.TeamID,
-		UserID:    userID,
+		UserID:    sshUserID,
 		ProcdURL:  sandbox.InternalAddr,
 	})
+}
+
+func authorizeSSHUserForSandboxTeam(ctx context.Context, teamID string, grants []sharedssh.AuthorizedGrant, legacyUserID string, membership teamMembershipLookup) (string, error) {
+	if userID, ok := sharedssh.UserIDForTeam(grants, teamID); ok {
+		return userID, nil
+	}
+	if len(grants) > 0 {
+		return "", identity.ErrMemberNotFound
+	}
+
+	legacyUserID = strings.TrimSpace(legacyUserID)
+	if legacyUserID == "" {
+		return "", identity.ErrMemberNotFound
+	}
+	if membership == nil {
+		return "", identity.ErrMemberNotFound
+	}
+	if _, err := membership.GetTeamMember(ctx, teamID, legacyUserID); err != nil {
+		return "", err
+	}
+	return legacyUserID, nil
 }
 
 func (s *Server) resolveClusterGatewayTarget(c *gin.Context, sandboxID string) (string, error) {

--- a/regional-gateway/pkg/http/internal_ssh_test.go
+++ b/regional-gateway/pkg/http/internal_ssh_test.go
@@ -1,0 +1,69 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/identity"
+	sharedssh "github.com/sandbox0-ai/sandbox0/pkg/sshgateway"
+)
+
+type fakeTeamMembershipLookup struct {
+	calls int
+	err   error
+}
+
+func (f *fakeTeamMembershipLookup) GetTeamMember(_ context.Context, teamID, userID string) (*identity.TeamMember, error) {
+	f.calls++
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &identity.TeamMember{TeamID: teamID, UserID: userID}, nil
+}
+
+func TestAuthorizeSSHUserForSandboxTeamUsesGrantsWithoutMembershipLookup(t *testing.T) {
+	membership := &fakeTeamMembershipLookup{err: identity.ErrMemberNotFound}
+
+	userID, err := authorizeSSHUserForSandboxTeam(context.Background(), "team-1", []sharedssh.AuthorizedGrant{
+		{TeamID: "team-1", UserID: "user-1"},
+	}, "", membership)
+	if err != nil {
+		t.Fatalf("authorizeSSHUserForSandboxTeam() error = %v", err)
+	}
+	if userID != "user-1" {
+		t.Fatalf("userID = %q, want user-1", userID)
+	}
+	if membership.calls != 0 {
+		t.Fatalf("membership calls = %d, want 0", membership.calls)
+	}
+}
+
+func TestAuthorizeSSHUserForSandboxTeamRejectsGrantForDifferentTeam(t *testing.T) {
+	membership := &fakeTeamMembershipLookup{}
+
+	_, err := authorizeSSHUserForSandboxTeam(context.Background(), "team-1", []sharedssh.AuthorizedGrant{
+		{TeamID: "team-2", UserID: "user-1"},
+	}, "", membership)
+	if !errors.Is(err, identity.ErrMemberNotFound) {
+		t.Fatalf("authorizeSSHUserForSandboxTeam() error = %v, want %v", err, identity.ErrMemberNotFound)
+	}
+	if membership.calls != 0 {
+		t.Fatalf("membership calls = %d, want 0", membership.calls)
+	}
+}
+
+func TestAuthorizeSSHUserForSandboxTeamKeepsLegacyMembershipFallback(t *testing.T) {
+	membership := &fakeTeamMembershipLookup{}
+
+	userID, err := authorizeSSHUserForSandboxTeam(context.Background(), "team-1", nil, "user-1", membership)
+	if err != nil {
+		t.Fatalf("authorizeSSHUserForSandboxTeam() error = %v", err)
+	}
+	if userID != "user-1" {
+		t.Fatalf("userID = %q, want user-1", userID)
+	}
+	if membership.calls != 1 {
+		t.Fatalf("membership calls = %d, want 1", membership.calls)
+	}
+}

--- a/ssh-gateway/pkg/server/auth.go
+++ b/ssh-gateway/pkg/server/auth.go
@@ -36,11 +36,11 @@ type SessionAuthorizer interface {
 }
 
 type identityStore interface {
-	GetUserSSHPublicKeyByFingerprint(ctx context.Context, fingerprint string) (*identity.UserSSHPublicKey, error)
+	ListUserSSHPublicKeysByFingerprint(ctx context.Context, fingerprint string) ([]*identity.UserSSHPublicKey, error)
 }
 
 type sandboxResolver interface {
-	ResolveSandbox(ctx context.Context, sandboxID, userID string) (*sharedssh.ResolvedTarget, error)
+	ResolveSandbox(ctx context.Context, sandboxID string, grants []sharedssh.AuthorizedGrant) (*sharedssh.ResolvedTarget, error)
 }
 
 // Authenticator resolves the uploaded SSH public key to a user and asks the
@@ -105,12 +105,16 @@ func (a *Authenticator) Authenticate(ctx context.Context, username string, key s
 		return nil, err
 	}
 
-	storedKey, err := a.repo.GetUserSSHPublicKeyByFingerprint(ctx, ssh.FingerprintSHA256(key))
+	storedKeys, err := a.repo.ListUserSSHPublicKeysByFingerprint(ctx, ssh.FingerprintSHA256(key))
 	if err != nil {
 		if errors.Is(err, identity.ErrSSHPublicKeyNotFound) {
 			return nil, ErrUnauthorizedSSHPublicKey
 		}
 		return nil, fmt.Errorf("lookup ssh public key: %w", err)
+	}
+	grants := authorizedGrantsFromSSHKeys(storedKeys)
+	if len(grants) == 0 {
+		return nil, ErrUnauthorizedSSHPublicKey
 	}
 
 	resolveCtx, cancel := context.WithTimeout(ctx, a.resumeTimeout)
@@ -120,15 +124,15 @@ func (a *Authenticator) Authenticate(ctx context.Context, username string, key s
 	defer ticker.Stop()
 
 	for {
-		target, err := a.resolver.ResolveSandbox(resolveCtx, sandboxID, storedKey.UserID)
+		target, err := a.resolver.ResolveSandbox(resolveCtx, sandboxID, grants)
 		if err == nil {
-			if target == nil || strings.TrimSpace(target.ProcdURL) == "" || strings.TrimSpace(target.TeamID) == "" {
+			if target == nil || strings.TrimSpace(target.ProcdURL) == "" || strings.TrimSpace(target.TeamID) == "" || strings.TrimSpace(target.UserID) == "" {
 				return nil, fmt.Errorf("regional sandbox resolver returned incomplete target")
 			}
 			return &SessionTarget{
 				Username:  username,
 				SandboxID: sandboxID,
-				UserID:    storedKey.UserID,
+				UserID:    target.UserID,
 				TeamID:    target.TeamID,
 				ProcdURL:  target.ProcdURL,
 			}, nil
@@ -148,4 +152,25 @@ func (a *Authenticator) Authenticate(ctx context.Context, username string, key s
 		}
 		return nil, err
 	}
+}
+
+func authorizedGrantsFromSSHKeys(keys []*identity.UserSSHPublicKey) []sharedssh.AuthorizedGrant {
+	grants := make([]sharedssh.AuthorizedGrant, 0, len(keys))
+	seenTeams := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		if key == nil {
+			continue
+		}
+		teamID := strings.TrimSpace(key.TeamID)
+		userID := strings.TrimSpace(key.UserID)
+		if teamID == "" || userID == "" {
+			continue
+		}
+		if _, ok := seenTeams[teamID]; ok {
+			continue
+		}
+		seenTeams[teamID] = struct{}{}
+		grants = append(grants, sharedssh.AuthorizedGrant{TeamID: teamID, UserID: userID})
+	}
+	return grants
 }

--- a/ssh-gateway/pkg/server/auth_test.go
+++ b/ssh-gateway/pkg/server/auth_test.go
@@ -15,25 +15,27 @@ import (
 const authTestPublicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ4dLZLZOA/asaP+5QO6t81jzbe5G4jrI2F+jbjL6TY8 sandbox0-e2e"
 
 type fakeIdentityStore struct {
-	key    *identity.UserSSHPublicKey
+	keys   []*identity.UserSSHPublicKey
 	keyErr error
 }
 
-func (f *fakeIdentityStore) GetUserSSHPublicKeyByFingerprint(context.Context, string) (*identity.UserSSHPublicKey, error) {
+func (f *fakeIdentityStore) ListUserSSHPublicKeysByFingerprint(context.Context, string) ([]*identity.UserSSHPublicKey, error) {
 	if f.keyErr != nil {
 		return nil, f.keyErr
 	}
-	return f.key, nil
+	return f.keys, nil
 }
 
 type fakeSandboxResolver struct {
 	targets []*sharedssh.ResolvedTarget
 	errs    []error
 	calls   int
+	grants  []sharedssh.AuthorizedGrant
 }
 
-func (f *fakeSandboxResolver) ResolveSandbox(context.Context, string, string) (*sharedssh.ResolvedTarget, error) {
+func (f *fakeSandboxResolver) ResolveSandbox(_ context.Context, _ string, grants []sharedssh.AuthorizedGrant) (*sharedssh.ResolvedTarget, error) {
 	f.calls++
+	f.grants = append([]sharedssh.AuthorizedGrant(nil), grants...)
 	if len(f.errs) > 0 {
 		err := f.errs[0]
 		if len(f.errs) > 1 {
@@ -93,10 +95,11 @@ func TestAuthenticatorAuthenticate(t *testing.T) {
 	}
 
 	repo := &fakeIdentityStore{
-		key: &identity.UserSSHPublicKey{
+		keys: []*identity.UserSSHPublicKey{{
+			TeamID:            "team-1",
 			UserID:            "user-1",
 			FingerprintSHA256: ssh.FingerprintSHA256(parsedKey),
-		},
+		}},
 	}
 	resolver := &fakeSandboxResolver{
 		targets: []*sharedssh.ResolvedTarget{{
@@ -117,6 +120,9 @@ func TestAuthenticatorAuthenticate(t *testing.T) {
 	}
 	if target.ProcdURL != "http://10.0.0.8:8091" {
 		t.Fatalf("ProcdURL = %q, want %q", target.ProcdURL, "http://10.0.0.8:8091")
+	}
+	if len(resolver.grants) != 1 || resolver.grants[0].TeamID != "team-1" || resolver.grants[0].UserID != "user-1" {
+		t.Fatalf("resolver grants = %+v", resolver.grants)
 	}
 }
 
@@ -142,10 +148,11 @@ func TestAuthenticatorAuthenticateRejectsAccessDenied(t *testing.T) {
 	}
 
 	repo := &fakeIdentityStore{
-		key: &identity.UserSSHPublicKey{
+		keys: []*identity.UserSSHPublicKey{{
+			TeamID:            "team-1",
 			UserID:            "user-1",
 			FingerprintSHA256: ssh.FingerprintSHA256(parsedKey),
-		},
+		}},
 	}
 	authenticator := NewAuthenticator(repo, &fakeSandboxResolver{errs: []error{ErrSandboxAccessDenied}}, time.Second, 10*time.Millisecond, zaptest.NewLogger(t))
 
@@ -162,10 +169,11 @@ func TestAuthenticatorAuthenticatePollsWhileSandboxWakesUp(t *testing.T) {
 	}
 
 	repo := &fakeIdentityStore{
-		key: &identity.UserSSHPublicKey{
+		keys: []*identity.UserSSHPublicKey{{
+			TeamID:            "team-1",
 			UserID:            "user-1",
 			FingerprintSHA256: ssh.FingerprintSHA256(parsedKey),
-		},
+		}},
 	}
 	resolver := &fakeSandboxResolver{
 		errs: []error{ErrSandboxWakingUp, nil},
@@ -196,7 +204,7 @@ func TestAuthenticatorAuthenticateHandlesMissingSandbox(t *testing.T) {
 		t.Fatalf("ParseAuthorizedKey() error = %v", err)
 	}
 
-	repo := &fakeIdentityStore{key: &identity.UserSSHPublicKey{UserID: "user-1"}}
+	repo := &fakeIdentityStore{keys: []*identity.UserSSHPublicKey{{TeamID: "team-1", UserID: "user-1"}}}
 	authenticator := NewAuthenticator(repo, &fakeSandboxResolver{errs: []error{ErrSandboxUnavailable}}, time.Second, 10*time.Millisecond, zaptest.NewLogger(t))
 
 	_, err = authenticator.Authenticate(context.Background(), "sb_123", parsedKey)

--- a/ssh-gateway/pkg/server/regional.go
+++ b/ssh-gateway/pkg/server/regional.go
@@ -38,12 +38,13 @@ func NewRegionalSandboxResolver(baseURL string, internalAuthGen *internalauth.Ge
 	}
 }
 
-func (r *RegionalSandboxResolver) ResolveSandbox(ctx context.Context, sandboxID, userID string) (*sharedssh.ResolvedTarget, error) {
+func (r *RegionalSandboxResolver) ResolveSandbox(ctx context.Context, sandboxID string, grants []sharedssh.AuthorizedGrant) (*sharedssh.ResolvedTarget, error) {
 	if strings.TrimSpace(r.baseURL) == "" {
 		return nil, fmt.Errorf("regional gateway URL is required")
 	}
-	if strings.TrimSpace(userID) == "" {
-		return nil, fmt.Errorf("userID is required")
+	encodedGrants := sharedssh.EncodeAuthorizedGrants(grants)
+	if encodedGrants == "" {
+		return nil, fmt.Errorf("authorized SSH key grants are required")
 	}
 
 	token, err := r.internalAuthGen.GenerateSystem(internalauth.ServiceRegionalGateway, internalauth.GenerateOptions{})
@@ -56,7 +57,7 @@ func (r *RegionalSandboxResolver) ResolveSandbox(ctx context.Context, sandboxID,
 		return nil, fmt.Errorf("create regional-gateway request: %w", err)
 	}
 	req.Header.Set(internalauth.DefaultTokenHeader, token)
-	req.Header.Set(internalauth.UserIDHeader, userID)
+	req.Header.Set(sharedssh.AuthorizedGrantsHeader, encodedGrants)
 
 	resp, err := r.httpClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
## Summary
- store regional SSH public keys with team_id and allow the same fingerprint across teams
- send SSH key-derived team/user grants from ssh-gateway to regional-gateway instead of a single user header
- authorize the regional SSH target by matching grants to the sandbox team, with legacy user header fallback for rolling deploys

## Testing
- go test ./pkg/sshgateway ./ssh-gateway/pkg/server ./pkg/gateway/identity ./pkg/gateway/http/handlers ./regional-gateway/pkg/http -count=1
- go test ./... -count=1 (passes until local kind e2e setup; fails because Docker daemon is unavailable: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)

## Deployment note
- existing unscoped regional SSH keys are intentionally not auto-authorized; they need a trusted team backfill or re-upload under the selected team
