### PR TITLE
Add sandbox deletion lifecycle controller

### DIFF
--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -297,6 +297,8 @@ func main() {
 		managerMetrics,
 	)
 	sandboxService.SetCredentialStore(credentialStore)
+	sandboxLifecycleController := service.NewSandboxLifecycleController(k8sClient, podLister, sandboxService, logger)
+	podInformer.Informer().AddEventHandler(sandboxLifecycleController.ResourceEventHandler())
 	operator.SetSandboxProbeRunner(sandboxService)
 	staticAuth := make([]egressauthruntime.StaticAuthConfig, 0, len(cfg.EgressAuthStaticAuth))
 	for _, entry := range cfg.EgressAuthStaticAuth {
@@ -445,6 +447,12 @@ func main() {
 	go func() {
 		if err := cleanupController.Start(ctx); err != nil && err != context.Canceled {
 			logger.Error("Cleanup controller failed", zap.Error(err))
+		}
+	}()
+
+	go func() {
+		if err := sandboxLifecycleController.Run(ctx, 2); err != nil && err != context.Canceled {
+			logger.Error("Sandbox lifecycle controller failed", zap.Error(err))
 		}
 	}()
 

--- a/manager/pkg/service/sandbox_lifecycle_controller.go
+++ b/manager/pkg/service/sandbox_lifecycle_controller.go
@@ -1,0 +1,402 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/client-go/util/workqueue"
+)
+
+const (
+	sandboxCleanupFinalizer             = "sandbox0.ai/sandbox-cleanup"
+	defaultSandboxLifecycleResyncPeriod = 30 * time.Second
+)
+
+// SandboxLifecycleInfo carries the durable identity needed to clean sandbox-scoped state.
+type SandboxLifecycleInfo struct {
+	Namespace string
+	PodName   string
+	SandboxID string
+	TeamID    string
+}
+
+// SandboxDeletionCleaner cleans external state for a deleted sandbox.
+type SandboxDeletionCleaner interface {
+	CleanupDeletedSandbox(ctx context.Context, info SandboxLifecycleInfo) error
+}
+
+type sandboxLifecycleQueueItem struct {
+	Namespace string
+	PodName   string
+	SandboxID string
+	TeamID    string
+	Deleted   bool
+}
+
+// SandboxLifecycleController reconciles sandbox deletion side effects from Pod lifecycle state.
+type SandboxLifecycleController struct {
+	k8sClient      kubernetes.Interface
+	podLister      corelisters.PodLister
+	cleaner        SandboxDeletionCleaner
+	logger         *zap.Logger
+	queue          workqueue.TypedRateLimitingInterface[sandboxLifecycleQueueItem]
+	resyncInterval time.Duration
+}
+
+func NewSandboxLifecycleController(
+	k8sClient kubernetes.Interface,
+	podLister corelisters.PodLister,
+	cleaner SandboxDeletionCleaner,
+	logger *zap.Logger,
+) *SandboxLifecycleController {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	return &SandboxLifecycleController{
+		k8sClient:      k8sClient,
+		podLister:      podLister,
+		cleaner:        cleaner,
+		logger:         logger,
+		queue:          workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[sandboxLifecycleQueueItem]()),
+		resyncInterval: defaultSandboxLifecycleResyncPeriod,
+	}
+}
+
+func (c *SandboxLifecycleController) ResourceEventHandler() cache.ResourceEventHandlerFuncs {
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc:    c.handlePodUpsert,
+		UpdateFunc: func(_, newObj any) { c.handlePodUpsert(newObj) },
+		DeleteFunc: c.handlePodDelete,
+	}
+}
+
+func (c *SandboxLifecycleController) Run(ctx context.Context, workers int) error {
+	if c == nil {
+		return nil
+	}
+	if workers <= 0 {
+		workers = 1
+	}
+	if c.queue == nil {
+		c.queue = workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[sandboxLifecycleQueueItem]())
+	}
+
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	c.logger.Info("Starting sandbox lifecycle controller", zap.Int("workers", workers))
+	c.enqueueActiveSandboxes()
+	for i := 0; i < workers; i++ {
+		go wait.UntilWithContext(ctx, c.runWorker, time.Second)
+	}
+
+	ticker := time.NewTicker(c.resyncInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			c.logger.Info("Sandbox lifecycle controller stopped")
+			return ctx.Err()
+		case <-ticker.C:
+			c.enqueueActiveSandboxes()
+		}
+	}
+}
+
+func (c *SandboxLifecycleController) handlePodUpsert(obj any) {
+	pod := extractPod(obj)
+	if info, ok := sandboxLifecycleInfoFromPod(pod); ok {
+		c.queue.Add(sandboxLifecycleItemFromInfo(info, false))
+	}
+}
+
+func (c *SandboxLifecycleController) handlePodDelete(obj any) {
+	pod := extractPod(obj)
+	if pod == nil {
+		return
+	}
+	if info, ok := sandboxLifecycleInfoFromPod(pod); ok {
+		c.queue.Add(sandboxLifecycleItemFromInfo(info, true))
+	}
+}
+
+func (c *SandboxLifecycleController) enqueueActiveSandboxes() {
+	if c == nil || c.podLister == nil {
+		return
+	}
+	pods, err := c.podLister.List(labels.Everything())
+	if err != nil {
+		c.logger.Warn("Failed to list pods for sandbox lifecycle reconcile", zap.Error(err))
+		return
+	}
+	for _, pod := range pods {
+		if info, ok := sandboxLifecycleInfoFromPod(pod); ok {
+			c.queue.Add(sandboxLifecycleItemFromInfo(info, false))
+		}
+	}
+}
+
+func (c *SandboxLifecycleController) runWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
+	}
+}
+
+func (c *SandboxLifecycleController) processNextWorkItem(ctx context.Context) bool {
+	item, shutdown := c.queue.Get()
+	if shutdown {
+		return false
+	}
+
+	defer c.queue.Done(item)
+	if err := c.reconcile(ctx, item); err != nil {
+		c.logger.Warn("Sandbox lifecycle reconcile failed, requeueing",
+			zap.String("sandboxID", item.SandboxID),
+			zap.String("namespace", item.Namespace),
+			zap.Error(err),
+		)
+		c.queue.AddRateLimited(item)
+		return true
+	}
+	c.queue.Forget(item)
+	return true
+}
+
+func (c *SandboxLifecycleController) reconcile(ctx context.Context, item sandboxLifecycleQueueItem) error {
+	if c == nil || c.cleaner == nil {
+		return nil
+	}
+	if item.Namespace == "" || item.PodName == "" {
+		return nil
+	}
+
+	pod, err := c.k8sClient.CoreV1().Pods(item.Namespace).Get(ctx, item.PodName, metav1.GetOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return c.cleanupDeletedSandbox(ctx, item)
+		}
+		return fmt.Errorf("get sandbox pod: %w", err)
+	}
+
+	info, ok := sandboxLifecycleInfoFromPod(pod)
+	if !ok {
+		return nil
+	}
+	item = sandboxLifecycleItemFromInfo(info, item.Deleted)
+	if pod.DeletionTimestamp == nil && !item.Deleted {
+		if !hasSandboxCleanupFinalizer(pod) {
+			if err := c.ensurePodCleanupFinalizer(ctx, pod.Namespace, pod.Name); err != nil {
+				return fmt.Errorf("ensure sandbox cleanup finalizer: %w", err)
+			}
+		}
+		return nil
+	}
+
+	if err := c.cleanupDeletedSandbox(ctx, item); err != nil {
+		return err
+	}
+	if !hasSandboxCleanupFinalizer(pod) {
+		return nil
+	}
+	if err := c.removeSandboxCleanupFinalizer(ctx, pod.Namespace, pod.Name); err != nil {
+		return fmt.Errorf("remove sandbox cleanup finalizer: %w", err)
+	}
+	return nil
+}
+
+func (c *SandboxLifecycleController) ensurePodCleanupFinalizer(ctx context.Context, namespace, name string) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		pod, err := c.k8sClient.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+		if pod.DeletionTimestamp != nil || hasSandboxCleanupFinalizer(pod) {
+			return nil
+		}
+		if _, ok := sandboxLifecycleInfoFromPod(pod); !ok {
+			return nil
+		}
+		updated := pod.DeepCopy()
+		ensureSandboxCleanupFinalizer(updated)
+		_, err = c.k8sClient.CoreV1().Pods(namespace).Update(ctx, updated, metav1.UpdateOptions{})
+		return err
+	})
+}
+
+func (c *SandboxLifecycleController) cleanupDeletedSandbox(ctx context.Context, item sandboxLifecycleQueueItem) error {
+	info := SandboxLifecycleInfo{
+		Namespace: item.Namespace,
+		PodName:   item.PodName,
+		SandboxID: item.SandboxID,
+		TeamID:    item.TeamID,
+	}
+	if info.SandboxID == "" {
+		info.SandboxID = info.PodName
+	}
+	return c.cleaner.CleanupDeletedSandbox(ctx, info)
+}
+
+func (c *SandboxLifecycleController) removeSandboxCleanupFinalizer(ctx context.Context, namespace, name string) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		pod, err := c.k8sClient.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+		if !hasSandboxCleanupFinalizer(pod) {
+			return nil
+		}
+		updated := pod.DeepCopy()
+		updated.Finalizers = removeFinalizer(updated.Finalizers, sandboxCleanupFinalizer)
+		_, err = c.k8sClient.CoreV1().Pods(namespace).Update(ctx, updated, metav1.UpdateOptions{})
+		return err
+	})
+}
+
+// CleanupDeletedSandbox implements SandboxDeletionCleaner for SandboxService.
+func (s *SandboxService) CleanupDeletedSandbox(ctx context.Context, info SandboxLifecycleInfo) error {
+	if s == nil {
+		return nil
+	}
+	logger := s.logger
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	sandboxID := strings.TrimSpace(info.SandboxID)
+	if sandboxID == "" {
+		sandboxID = strings.TrimSpace(info.PodName)
+	}
+	if sandboxID == "" {
+		return nil
+	}
+
+	var errs []error
+	if s.networkProvider != nil && info.Namespace != "" {
+		if err := s.networkProvider.RemoveSandboxPolicy(ctx, info.Namespace, sandboxID); err != nil {
+			errs = append(errs, fmt.Errorf("remove network policy: %w", err))
+		}
+	}
+	if s.credentialStore != nil {
+		teamID := strings.TrimSpace(info.TeamID)
+		if teamID == "" {
+			logger.Warn("Skipping credential binding cleanup for sandbox without team ID",
+				zap.String("sandboxID", sandboxID),
+				zap.String("namespace", info.Namespace),
+			)
+		} else if err := s.credentialStore.DeleteBindings(ctx, teamID, sandboxID); err != nil {
+			errs = append(errs, fmt.Errorf("delete credential bindings: %w", err))
+		}
+	}
+	s.powerStateLocks.Delete(sandboxID)
+	s.powerStateReconcilers.Delete(sandboxID)
+	return errors.Join(errs...)
+}
+
+func (s *SandboxService) ensureSandboxDeletionFinalizer(ctx context.Context, pod *corev1.Pod) (*corev1.Pod, error) {
+	if s == nil || pod == nil || s.k8sClient == nil || hasSandboxCleanupFinalizer(pod) || pod.DeletionTimestamp != nil {
+		return pod, nil
+	}
+	var updated *corev1.Pod
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current, err := s.k8sClient.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if hasSandboxCleanupFinalizer(current) || current.DeletionTimestamp != nil {
+			updated = current
+			return nil
+		}
+		updated = current.DeepCopy()
+		ensureSandboxCleanupFinalizer(updated)
+		updated, err = s.k8sClient.CoreV1().Pods(updated.Namespace).Update(ctx, updated, metav1.UpdateOptions{})
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return updated, nil
+}
+
+func sandboxLifecycleItemFromInfo(info SandboxLifecycleInfo, deleted bool) sandboxLifecycleQueueItem {
+	return sandboxLifecycleQueueItem{
+		Namespace: info.Namespace,
+		PodName:   info.PodName,
+		SandboxID: info.SandboxID,
+		TeamID:    info.TeamID,
+		Deleted:   deleted,
+	}
+}
+
+func sandboxLifecycleInfoFromPod(pod *corev1.Pod) (SandboxLifecycleInfo, bool) {
+	if pod == nil || pod.Labels == nil {
+		return SandboxLifecycleInfo{}, false
+	}
+	if pod.Labels[controller.LabelPoolType] != controller.PoolTypeActive {
+		return SandboxLifecycleInfo{}, false
+	}
+	sandboxID := strings.TrimSpace(pod.Labels[controller.LabelSandboxID])
+	if sandboxID == "" {
+		return SandboxLifecycleInfo{}, false
+	}
+	teamID := ""
+	if pod.Annotations != nil {
+		teamID = strings.TrimSpace(pod.Annotations[controller.AnnotationTeamID])
+	}
+	return SandboxLifecycleInfo{
+		Namespace: pod.Namespace,
+		PodName:   pod.Name,
+		SandboxID: sandboxID,
+		TeamID:    teamID,
+	}, true
+}
+
+func ensureSandboxCleanupFinalizer(pod *corev1.Pod) {
+	if pod == nil || hasSandboxCleanupFinalizer(pod) {
+		return
+	}
+	pod.Finalizers = append(pod.Finalizers, sandboxCleanupFinalizer)
+}
+
+func hasSandboxCleanupFinalizer(pod *corev1.Pod) bool {
+	if pod == nil {
+		return false
+	}
+	for _, finalizer := range pod.Finalizers {
+		if finalizer == sandboxCleanupFinalizer {
+			return true
+		}
+	}
+	return false
+}
+
+func removeFinalizer(finalizers []string, target string) []string {
+	if len(finalizers) == 0 {
+		return nil
+	}
+	out := finalizers[:0]
+	for _, finalizer := range finalizers {
+		if finalizer != target {
+			out = append(out, finalizer)
+		}
+	}
+	return out
+}

--- a/manager/pkg/service/sandbox_lifecycle_controller_test.go
+++ b/manager/pkg/service/sandbox_lifecycle_controller_test.go
@@ -1,0 +1,256 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
+	"github.com/sandbox0-ai/sandbox0/pkg/egressauth"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+)
+
+type recordingSandboxCleaner struct {
+	calls []SandboxLifecycleInfo
+	err   error
+}
+
+type deleteRecordingBindingStore struct {
+	deleteCalls int
+}
+
+func (c *recordingSandboxCleaner) CleanupDeletedSandbox(_ context.Context, info SandboxLifecycleInfo) error {
+	c.calls = append(c.calls, info)
+	return c.err
+}
+
+func (s *deleteRecordingBindingStore) GetBindings(context.Context, string, string) (*egressauth.BindingRecord, error) {
+	return nil, nil
+}
+
+func (s *deleteRecordingBindingStore) UpsertBindings(context.Context, *egressauth.BindingRecord) error {
+	return nil
+}
+
+func (s *deleteRecordingBindingStore) DeleteBindings(context.Context, string, string) error {
+	s.deleteCalls++
+	return nil
+}
+
+func (s *deleteRecordingBindingStore) GetSourceByRef(context.Context, string, string) (*egressauth.CredentialSource, error) {
+	return nil, nil
+}
+
+func (s *deleteRecordingBindingStore) GetSourceVersion(context.Context, int64, int64) (*egressauth.CredentialSourceVersion, error) {
+	return nil, nil
+}
+
+func TestSandboxLifecycleControllerCleansAndRemovesFinalizer(t *testing.T) {
+	deletionTime := metav1.NewTime(time.Now().UTC())
+	pod := newLifecycleTestPod()
+	pod.Finalizers = []string{sandboxCleanupFinalizer}
+	pod.DeletionTimestamp = &deletionTime
+	client := fake.NewSimpleClientset(pod.DeepCopy())
+	cleaner := &recordingSandboxCleaner{}
+	controller := NewSandboxLifecycleController(client, nil, cleaner, zap.NewNop())
+
+	err := controller.reconcile(context.Background(), sandboxLifecycleItemFromInfo(SandboxLifecycleInfo{
+		Namespace: pod.Namespace,
+		PodName:   pod.Name,
+		SandboxID: pod.Name,
+		TeamID:    "team-a",
+	}, false))
+	if err != nil {
+		t.Fatalf("reconcile() error = %v", err)
+	}
+	if len(cleaner.calls) != 1 {
+		t.Fatalf("cleanup calls = %d, want 1", len(cleaner.calls))
+	}
+	if got := cleaner.calls[0].SandboxID; got != pod.Name {
+		t.Fatalf("cleanup sandboxID = %q, want %q", got, pod.Name)
+	}
+	updated, err := client.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get updated pod: %v", err)
+	}
+	if hasSandboxCleanupFinalizer(updated) {
+		t.Fatal("sandbox cleanup finalizer was not removed")
+	}
+}
+
+func TestSandboxLifecycleControllerRetriesCleanupBeforeRemovingFinalizer(t *testing.T) {
+	deletionTime := metav1.NewTime(time.Now().UTC())
+	pod := newLifecycleTestPod()
+	pod.Finalizers = []string{sandboxCleanupFinalizer}
+	pod.DeletionTimestamp = &deletionTime
+	client := fake.NewSimpleClientset(pod.DeepCopy())
+	cleaner := &recordingSandboxCleaner{err: errors.New("cleanup failed")}
+	controller := NewSandboxLifecycleController(client, nil, cleaner, zap.NewNop())
+
+	err := controller.reconcile(context.Background(), sandboxLifecycleItemFromInfo(SandboxLifecycleInfo{
+		Namespace: pod.Namespace,
+		PodName:   pod.Name,
+		SandboxID: pod.Name,
+		TeamID:    "team-a",
+	}, false))
+	if err == nil {
+		t.Fatal("reconcile() error = nil, want cleanup failure")
+	}
+	updated, getErr := client.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+	if getErr != nil {
+		t.Fatalf("get updated pod: %v", getErr)
+	}
+	if !hasSandboxCleanupFinalizer(updated) {
+		t.Fatal("sandbox cleanup finalizer was removed before cleanup succeeded")
+	}
+}
+
+func TestSandboxLifecycleControllerBackfillsCleanupFinalizer(t *testing.T) {
+	pod := newLifecycleTestPod()
+	client := fake.NewSimpleClientset(pod.DeepCopy())
+	cleaner := &recordingSandboxCleaner{}
+	controller := NewSandboxLifecycleController(client, nil, cleaner, zap.NewNop())
+
+	err := controller.reconcile(context.Background(), sandboxLifecycleItemFromInfo(SandboxLifecycleInfo{
+		Namespace: pod.Namespace,
+		PodName:   pod.Name,
+		SandboxID: pod.Name,
+		TeamID:    "team-a",
+	}, false))
+	if err != nil {
+		t.Fatalf("reconcile() error = %v", err)
+	}
+	if len(cleaner.calls) != 0 {
+		t.Fatalf("cleanup calls = %d, want 0 for non-deleting pod", len(cleaner.calls))
+	}
+	updated, err := client.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get updated pod: %v", err)
+	}
+	if !hasSandboxCleanupFinalizer(updated) {
+		t.Fatal("sandbox cleanup finalizer was not backfilled")
+	}
+}
+
+func TestSandboxLifecycleControllerCleansLegacyDeleteEvent(t *testing.T) {
+	cleaner := &recordingSandboxCleaner{}
+	controller := NewSandboxLifecycleController(fake.NewSimpleClientset(), nil, cleaner, zap.NewNop())
+
+	err := controller.reconcile(context.Background(), sandboxLifecycleQueueItem{
+		Namespace: "ns-a",
+		PodName:   "sandbox-a",
+		SandboxID: "sandbox-a",
+		TeamID:    "team-a",
+		Deleted:   true,
+	})
+	if err != nil {
+		t.Fatalf("reconcile() error = %v", err)
+	}
+	if len(cleaner.calls) != 1 {
+		t.Fatalf("cleanup calls = %d, want 1", len(cleaner.calls))
+	}
+}
+
+func TestSandboxServiceCleanupDeletedSandboxRemovesExternalState(t *testing.T) {
+	removed := make([]string, 0, 1)
+	store := &deleteRecordingBindingStore{}
+	svc := &SandboxService{
+		networkProvider: &assertingNetworkProvider{removeFunc: func(namespace, sandboxID string) {
+			removed = append(removed, namespace+"/"+sandboxID)
+		}},
+		credentialStore: store,
+		logger:          zap.NewNop(),
+	}
+
+	err := svc.CleanupDeletedSandbox(context.Background(), SandboxLifecycleInfo{
+		Namespace: "ns-a",
+		PodName:   "sandbox-a",
+		SandboxID: "sandbox-a",
+		TeamID:    "team-a",
+	})
+	if err != nil {
+		t.Fatalf("CleanupDeletedSandbox() error = %v", err)
+	}
+	if len(removed) != 1 || removed[0] != "ns-a/sandbox-a" {
+		t.Fatalf("network removals = %#v, want ns-a/sandbox-a", removed)
+	}
+	if store.deleteCalls != 1 {
+		t.Fatalf("DeleteBindings calls = %d, want 1", store.deleteCalls)
+	}
+}
+
+func TestTerminateSandboxRequestsPodDeleteWithoutExternalCleanup(t *testing.T) {
+	pod := newLifecycleTestPod()
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	if err := indexer.Add(pod.DeepCopy()); err != nil {
+		t.Fatalf("add pod to indexer: %v", err)
+	}
+	client := fake.NewSimpleClientset(pod.DeepCopy())
+	removed := make([]string, 0, 1)
+	store := &deleteRecordingBindingStore{}
+	svc := &SandboxService{
+		k8sClient: client,
+		podLister: corelisters.NewPodLister(indexer),
+		networkProvider: &assertingNetworkProvider{removeFunc: func(namespace, sandboxID string) {
+			removed = append(removed, namespace+"/"+sandboxID)
+		}},
+		credentialStore: store,
+		logger:          zap.NewNop(),
+	}
+
+	if err := svc.TerminateSandbox(context.Background(), pod.Name); err != nil {
+		t.Fatalf("TerminateSandbox() error = %v", err)
+	}
+	if len(removed) != 0 {
+		t.Fatalf("network removals = %#v, want none before lifecycle controller cleanup", removed)
+	}
+	if store.deleteCalls != 0 {
+		t.Fatalf("DeleteBindings calls = %d, want 0 before lifecycle controller cleanup", store.deleteCalls)
+	}
+	if _, err := client.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{}); !k8serrors.IsNotFound(err) {
+		t.Fatalf("pod get error = %v, want not found after delete", err)
+	}
+
+	sawFinalizerUpdate := false
+	for _, action := range client.Actions() {
+		if action.GetVerb() != "update" || action.GetResource().Resource != "pods" {
+			continue
+		}
+		updateAction, ok := action.(k8stesting.UpdateAction)
+		if !ok {
+			continue
+		}
+		updatedPod, ok := updateAction.GetObject().(*corev1.Pod)
+		if ok && hasSandboxCleanupFinalizer(updatedPod) {
+			sawFinalizerUpdate = true
+			break
+		}
+	}
+	if !sawFinalizerUpdate {
+		t.Fatal("TerminateSandbox did not add sandbox cleanup finalizer before deleting the pod")
+	}
+}
+
+func newLifecycleTestPod() *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sandbox-a",
+			Namespace: "ns-a",
+			Labels: map[string]string{
+				controller.LabelPoolType:  controller.PoolTypeActive,
+				controller.LabelSandboxID: "sandbox-a",
+			},
+			Annotations: map[string]string{
+				controller.AnnotationTeamID: "team-a",
+			},
+		},
+	}
+}

--- a/manager/pkg/service/sandbox_service.go
+++ b/manager/pkg/service/sandbox_service.go
@@ -591,7 +591,7 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 	if claimType == "cold" {
 		readyPod, err := s.waitForPodClaimReady(ctx, pod.Namespace, pod.Name)
 		if err != nil {
-			s.cleanupFailedColdClaim(pod, "claim readiness failed")
+			s.requestSandboxDeletionAfterClaimFailure(pod, "claim readiness failed")
 			if metrics != nil {
 				metrics.SandboxClaimsTotal.WithLabelValues(req.Template, "error").Inc()
 			}
@@ -603,9 +603,7 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 
 	procdAddress, err := s.prodAddress(ctx, pod)
 	if err != nil {
-		if claimType == "cold" {
-			s.cleanupFailedColdClaim(pod, "procd address resolution failed")
-		}
+		s.requestSandboxDeletionAfterClaimFailure(pod, "procd address resolution failed")
 		if metrics != nil {
 			metrics.SandboxClaimsTotal.WithLabelValues(req.Template, "error").Inc()
 		}
@@ -613,9 +611,7 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 	}
 	initResp, err := s.initializeProcd(ctx, pod, req, procdAddress)
 	if err != nil {
-		if claimType == "cold" {
-			s.cleanupFailedColdClaim(pod, "procd initialization failed")
-		}
+		s.requestSandboxDeletionAfterClaimFailure(pod, "procd initialization failed")
 		if metrics != nil {
 			metrics.SandboxClaimsTotal.WithLabelValues(req.Template, "error").Inc()
 		}
@@ -678,6 +674,7 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 		// Change pool type from idle to active
 		pod.Labels[controller.LabelPoolType] = controller.PoolTypeActive
 		pod.Labels[controller.LabelSandboxID] = pod.Name
+		ensureSandboxCleanupFinalizer(pod)
 
 		// Remove owner reference (so it's no longer managed by ReplicaSet)
 		pod.OwnerReferences = nil
@@ -731,6 +728,7 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 		}
 
 		if applyErr := s.applyNetworkProvider(ctx, updatedPod, req.TeamID, policySpecFromState(networkState)); applyErr != nil {
+			s.requestSandboxDeletionAfterClaimFailure(updatedPod, "network policy apply failed")
 			return fmt.Errorf("apply network policy: %w", applyErr)
 		}
 
@@ -780,6 +778,9 @@ func (s *SandboxService) createNewPod(ctx context.Context, template *v1alpha1.Sa
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      podName,
 			Namespace: template.Namespace,
+			Finalizers: []string{
+				sandboxCleanupFinalizer,
+			},
 			Labels: map[string]string{
 				controller.LabelTemplateID: template.Name,
 				controller.LabelPoolType:   controller.PoolTypeActive,
@@ -829,7 +830,7 @@ func (s *SandboxService) createNewPod(ctx context.Context, template *v1alpha1.Sa
 	}
 
 	if err := s.applyNetworkProvider(ctx, createdPod, req.TeamID, policySpecFromState(networkState)); err != nil {
-		s.cleanupFailedColdClaim(createdPod, "network policy apply failed")
+		s.requestSandboxDeletionAfterClaimFailure(createdPod, "network policy apply failed")
 		return nil, fmt.Errorf("apply network policy: %w", err)
 	}
 
@@ -842,7 +843,7 @@ func (s *SandboxService) createNewPod(ctx context.Context, template *v1alpha1.Sa
 	return createdPod, nil
 }
 
-func (s *SandboxService) cleanupFailedColdClaim(pod *corev1.Pod, reason string) {
+func (s *SandboxService) requestSandboxDeletionAfterClaimFailure(pod *corev1.Pod, reason string) {
 	if s == nil || pod == nil || pod.Name == "" || pod.Namespace == "" || s.k8sClient == nil {
 		return
 	}
@@ -853,11 +854,11 @@ func (s *SandboxService) cleanupFailedColdClaim(pod *corev1.Pod, reason string) 
 		logger = zap.NewNop()
 	}
 
-	if s.networkProvider != nil {
-		if err := s.networkProvider.RemoveSandboxPolicy(cleanupCtx, pod.Namespace, pod.Name); err != nil {
-			logger.Warn("Network provider cleanup failed after cold claim failure",
-				zap.String("provider", s.networkProvider.Name()),
+	if !hasSandboxCleanupFinalizer(pod) {
+		if _, err := s.ensureSandboxDeletionFinalizer(cleanupCtx, pod); err != nil {
+			logger.Warn("Failed to ensure sandbox cleanup finalizer after claim failure",
 				zap.String("sandboxID", pod.Name),
+				zap.String("namespace", pod.Namespace),
 				zap.String("reason", reason),
 				zap.Error(err),
 			)
@@ -865,16 +866,9 @@ func (s *SandboxService) cleanupFailedColdClaim(pod *corev1.Pod, reason string) 
 	}
 
 	if err := s.k8sClient.CoreV1().Pods(pod.Namespace).Delete(cleanupCtx, pod.Name, metav1.DeleteOptions{}); err != nil && !k8serrors.IsNotFound(err) {
-		logger.Warn("Delete pod failed after cold claim failure",
+		logger.Warn("Delete pod failed after claim failure",
 			zap.String("sandboxID", pod.Name),
 			zap.String("namespace", pod.Namespace),
-			zap.String("reason", reason),
-			zap.Error(err),
-		)
-	}
-	if err := s.deleteCredentialBindings(cleanupCtx, pod); err != nil {
-		logger.Warn("Credential binding cleanup failed after cold claim failure",
-			zap.String("sandboxID", pod.Name),
 			zap.String("reason", reason),
 			zap.Error(err),
 		)
@@ -1083,13 +1077,6 @@ func cloneBindingRecord(record *egressauth.BindingRecord) *egressauth.BindingRec
 	cloned := *record
 	cloned.Bindings = cloneStoreCredentialBindings(record.Bindings)
 	return &cloned
-}
-
-func (s *SandboxService) deleteCredentialBindings(ctx context.Context, pod *corev1.Pod) error {
-	if s.credentialStore == nil || pod == nil {
-		return nil
-	}
-	return s.credentialStore.DeleteBindings(ctx, sandboxTeamID(pod), pod.Name)
 }
 
 func (s *SandboxService) loadCredentialBindings(ctx context.Context, pod *corev1.Pod) ([]v1alpha1.CredentialBinding, error) {
@@ -1394,31 +1381,21 @@ func (s *SandboxService) TerminateSandbox(ctx context.Context, sandboxID string)
 		return fmt.Errorf("get pod: %w", err)
 	}
 
-	// Note: Network policies are stored in pod annotations
-	// They are automatically deleted when the pod is deleted
-	if s.networkProvider != nil {
-		if err := s.networkProvider.RemoveSandboxPolicy(ctx, pod.Namespace, pod.Name); err != nil {
-			s.logger.Warn("Network provider remove failed",
-				zap.String("provider", s.networkProvider.Name()),
-				zap.String("sandboxID", pod.Name),
-				zap.Error(err),
-			)
-		}
+	pod, err = s.ensureSandboxDeletionFinalizer(ctx, pod)
+	if err != nil {
+		return fmt.Errorf("ensure sandbox cleanup finalizer: %w", err)
 	}
 
-	// Delete the pod
 	err = s.k8sClient.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{})
+	if k8serrors.IsNotFound(err) {
+		s.logger.Info("Sandbox already terminated", zap.String("sandboxID", sandboxID))
+		return nil
+	}
 	if err != nil {
 		return fmt.Errorf("delete pod: %w", err)
 	}
-	if err := s.deleteCredentialBindings(ctx, pod); err != nil {
-		s.logger.Warn("Credential binding cleanup failed",
-			zap.String("sandboxID", pod.Name),
-			zap.Error(err),
-		)
-	}
 
-	s.logger.Info("Sandbox terminated", zap.String("sandboxID", sandboxID), zap.String("pod", pod.Name))
+	s.logger.Info("Sandbox termination requested", zap.String("sandboxID", sandboxID), zap.String("pod", pod.Name))
 
 	return nil
 }

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -92,6 +92,53 @@ func TestClaimIdlePodClaimsReadyPod(t *testing.T) {
 	}
 }
 
+func TestClaimIdlePodRequestsDeleteAfterNetworkApplyFailure(t *testing.T) {
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "template-a",
+			Namespace: "ns-a",
+		},
+	}
+	readyPod := newClaimTestPod("ns-a", "idle-ready", "template-a", true)
+	applyErr := errors.New("apply failed")
+	removed := make([]string, 0, 1)
+	client := fake.NewSimpleClientset(readyPod.DeepCopy())
+	svc := &SandboxService{
+		k8sClient:            client,
+		podLister:            newClaimTestPodLister(t, readyPod),
+		NetworkPolicyService: NewNetworkPolicyService(zap.NewNop()),
+		networkProvider: &assertingNetworkProvider{
+			applyErr: applyErr,
+			removeFunc: func(namespace, sandboxID string) {
+				removed = append(removed, namespace+"/"+sandboxID)
+			},
+		},
+		clock:  systemTime{},
+		logger: zap.NewNop(),
+	}
+
+	pod, err := svc.claimIdlePod(context.Background(), template, &ClaimRequest{TeamID: "team-a", UserID: "user-a"})
+	if err == nil {
+		t.Fatal("claimIdlePod() error = nil, want network apply failure")
+	}
+	if !errors.Is(err, applyErr) {
+		t.Fatalf("claimIdlePod() error = %v, want wrapped apply failure", err)
+	}
+	if pod != nil {
+		t.Fatalf("claimIdlePod() pod = %s, want nil on failure", pod.Name)
+	}
+	pods, err := client.CoreV1().Pods("ns-a").List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list pods: %v", err)
+	}
+	if len(pods.Items) != 0 {
+		t.Fatalf("pods after failed hot claim = %d, want 0", len(pods.Items))
+	}
+	if len(removed) != 0 {
+		t.Fatalf("network policy removals = %d, want 0; lifecycle controller owns delete cleanup", len(removed))
+	}
+}
+
 func TestWaitForPodReadyWaitsUntilReady(t *testing.T) {
 	pod := newClaimTestPod("ns-a", "cold-pod", "template-a", false)
 	indexer := newClaimTestPodIndexer(t, pod)
@@ -199,7 +246,7 @@ func TestWaitForPodClaimReadyUsesSandboxReadinessWithoutPodReady(t *testing.T) {
 	}
 }
 
-func TestCreateNewPodCleansUpAfterNetworkApplyFailure(t *testing.T) {
+func TestCreateNewPodRequestsDeleteAfterNetworkApplyFailure(t *testing.T) {
 	withClaimTestPublicKey(t)
 
 	template := &v1alpha1.SandboxTemplate{
@@ -243,8 +290,8 @@ func TestCreateNewPodCleansUpAfterNetworkApplyFailure(t *testing.T) {
 	if len(pods.Items) != 0 {
 		t.Fatalf("pods after failed cold claim = %d, want 0", len(pods.Items))
 	}
-	if len(removed) != 1 {
-		t.Fatalf("network policy removals = %d, want 1", len(removed))
+	if len(removed) != 0 {
+		t.Fatalf("network policy removals = %d, want 0; lifecycle controller owns delete cleanup", len(removed))
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add a manager sandbox lifecycle controller that watches active sandbox Pod lifecycle events and retries delete cleanup through a workqueue.
- Add a sandbox cleanup finalizer, backfill it on existing active Pods, and remove it only after cleanup succeeds.
- Move claim-failure and TerminateSandbox paths to request Pod deletion while the lifecycle controller owns network, credential binding, and power-state cleanup.

Closes #183

## Testing
- git diff --check
- go test ./manager/pkg/service ./manager/pkg/controller ./manager/cmd/manager -count=1
- go test ./manager/pkg/... ./manager/cmd/manager -count=1
- pre-push hook passed: make manifests, make proto, make apispec, go fmt ./..., go mod tidy, go mod vendor, golangci-lint run ./...
- go test ./manager/... -count=1 currently fails in existing procd packages because manager/procd/pkg/volume/grpc_fs.go imports github.com/sandbox0-ai/sandbox0/storage-proxy/proto/fs, which is not present in this checkout.