### PR TITLE
Gate sandbox scheduling on data-plane readiness

### DIFF
--- a/infra-operator/chart/samples/multi-cluster/data-plane.yaml
+++ b/infra-operator/chart/samples/multi-cluster/data-plane.yaml
@@ -88,6 +88,7 @@ spec:
   # Shared placement for sandbox template Pods plus node-local helpers such as
   # netd and ctld. In production, point this at your dedicated sandbox
   # node pool and pair it with services.manager.config.sandboxRuntimeClassName.
+  # infra-operator manages sandbox0.ai/data-plane-ready; do not include it here.
   # The example below targets a Kata node pool; adjust labels and tolerations
   # for your cluster.
   #sandboxNodePlacement:

--- a/infra-operator/chart/samples/single-cluster/fullmode.yaml
+++ b/infra-operator/chart/samples/single-cluster/fullmode.yaml
@@ -88,6 +88,7 @@ spec:
         maxIdle: 5
   # Shared placement for sandbox template Pods plus node-local helpers such as
   # netd and ctld.
+  # infra-operator manages sandbox0.ai/data-plane-ready; do not include it here.
   #sandboxNodePlacement:
   #  nodeSelector:
   #    sandbox0.ai/node-role: sandbox

--- a/infra-operator/chart/samples/single-cluster/network-policy.yaml
+++ b/infra-operator/chart/samples/single-cluster/network-policy.yaml
@@ -52,6 +52,7 @@ spec:
         maxIdle: 5
   # Shared placement for sandbox template Pods plus node-local helpers such as
   # netd and ctld.
+  # infra-operator manages sandbox0.ai/data-plane-ready; do not include it here.
   #sandboxNodePlacement:
   #  nodeSelector:
   #    sandbox0.ai/node-role: sandbox

--- a/infra-operator/internal/controller/sandbox0infra_controller.go
+++ b/infra-operator/internal/controller/sandbox0infra_controller.go
@@ -39,7 +39,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	controller "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	infrav1alpha1 "github.com/sandbox0-ai/sandbox0/infra-operator/api/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/pkg/common"
@@ -51,6 +53,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/internalauth"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/manager"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/netd"
+	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/nodereadiness"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/regionalgateway"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/registry"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/scheduler"
@@ -239,13 +242,14 @@ func (r *Sandbox0InfraReconciler) reconcileComponentPlan(ctx context.Context, in
 	storageProxyReconciler := storageproxy.NewReconciler(resources)
 	fusePluginReconciler := fuseplugin.NewReconciler(resources)
 	netdReconciler := netd.NewReconciler(resources)
+	nodeReadinessReconciler := nodereadiness.NewReconciler(resources)
 	rbacReconciler := rbac.NewReconciler(resources)
 
 	if err := r.cleanupDisabledServiceResources(ctx, infra, compiledPlan.Cleanup, dbReconciler, storageReconciler, registryReconciler); err != nil {
 		return ctrl.Result{RequeueAfter: requeueInterval}, err
 	}
 
-	steps, err := r.bindWorkflowSteps(infra, compiledPlan, resources, imageRepo, imageTag, authReconciler, dbReconciler, storageReconciler, registryReconciler, globalGatewayReconciler, regionalGatewayReconciler, sshGatewayReconciler, schedulerReconciler, clusterGatewayReconciler, managerReconciler, storageProxyReconciler, fusePluginReconciler, netdReconciler, rbacReconciler)
+	steps, err := r.bindWorkflowSteps(infra, compiledPlan, resources, imageRepo, imageTag, authReconciler, dbReconciler, storageReconciler, registryReconciler, globalGatewayReconciler, regionalGatewayReconciler, sshGatewayReconciler, schedulerReconciler, clusterGatewayReconciler, managerReconciler, storageProxyReconciler, fusePluginReconciler, netdReconciler, nodeReadinessReconciler, rbacReconciler)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -270,11 +274,12 @@ func (r *Sandbox0InfraReconciler) bindWorkflowSteps(
 	storageProxyReconciler *storageproxy.Reconciler,
 	fusePluginReconciler *fuseplugin.Reconciler,
 	netdReconciler *netd.Reconciler,
+	nodeReadinessReconciler *nodereadiness.Reconciler,
 	rbacReconciler *rbac.Reconciler,
 ) ([]reconcileStep, error) {
 	steps := make([]reconcileStep, 0, len(compiledPlan.Workflow.Steps))
 	for _, planned := range compiledPlan.Workflow.Steps {
-		run, err := r.workflowStepRunner(infra, compiledPlan, resources, imageRepo, imageTag, planned.Name, authReconciler, dbReconciler, storageReconciler, registryReconciler, globalGatewayReconciler, regionalGatewayReconciler, sshGatewayReconciler, schedulerReconciler, clusterGatewayReconciler, managerReconciler, storageProxyReconciler, fusePluginReconciler, netdReconciler, rbacReconciler)
+		run, err := r.workflowStepRunner(infra, compiledPlan, resources, imageRepo, imageTag, planned.Name, authReconciler, dbReconciler, storageReconciler, registryReconciler, globalGatewayReconciler, regionalGatewayReconciler, sshGatewayReconciler, schedulerReconciler, clusterGatewayReconciler, managerReconciler, storageProxyReconciler, fusePluginReconciler, netdReconciler, nodeReadinessReconciler, rbacReconciler)
 		if err != nil {
 			return nil, err
 		}
@@ -309,6 +314,7 @@ func (r *Sandbox0InfraReconciler) workflowStepRunner(
 	storageProxyReconciler *storageproxy.Reconciler,
 	fusePluginReconciler *fuseplugin.Reconciler,
 	netdReconciler *netd.Reconciler,
+	nodeReadinessReconciler *nodereadiness.Reconciler,
 	rbacReconciler *rbac.Reconciler,
 ) (func(context.Context) error, error) {
 	switch name {
@@ -392,6 +398,10 @@ func (r *Sandbox0InfraReconciler) workflowStepRunner(
 	case "netd":
 		return func(ctx context.Context) error {
 			return netdReconciler.Reconcile(ctx, imageRepo, imageTag, compiledPlan)
+		}, nil
+	case "data-plane-node-readiness":
+		return func(ctx context.Context) error {
+			return nodeReadinessReconciler.Reconcile(ctx, infra, compiledPlan)
 		}, nil
 	case "storage-proxy-rbac":
 		return func(ctx context.Context) error { return rbacReconciler.ReconcileStorageProxyRBAC(ctx, infra) }, nil
@@ -866,6 +876,7 @@ func isReadyPod(pod *corev1.Pod) bool {
 func (r *Sandbox0InfraReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&infrav1alpha1.Sandbox0Infra{}).
+		Watches(&corev1.Pod{}, handler.EnqueueRequestsFromMapFunc(r.requestsForManagedDataPlanePod)).
 		Owns(&appsv1.Deployment{}).
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&appsv1.DaemonSet{}).
@@ -879,4 +890,23 @@ func (r *Sandbox0InfraReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			RateLimiter: workqueue.NewTypedItemExponentialFailureRateLimiter[ctrl.Request](retryBaseDelay, retryMaxDelay),
 		}).
 		Complete(r)
+}
+
+func (r *Sandbox0InfraReconciler) requestsForManagedDataPlanePod(_ context.Context, obj client.Object) []reconcile.Request {
+	if obj == nil {
+		return nil
+	}
+	labels := obj.GetLabels()
+	if labels["app.kubernetes.io/managed-by"] != "sandbox0infra-operator" {
+		return nil
+	}
+	component := labels["app.kubernetes.io/component"]
+	if component != "netd" && component != "ctld" {
+		return nil
+	}
+	instance := labels["app.kubernetes.io/instance"]
+	if instance == "" {
+		return nil
+	}
+	return []reconcile.Request{{NamespacedName: types.NamespacedName{Namespace: obj.GetNamespace(), Name: instance}}}
 }

--- a/infra-operator/internal/controller/services/nodereadiness/nodereadiness.go
+++ b/infra-operator/internal/controller/services/nodereadiness/nodereadiness.go
@@ -1,0 +1,190 @@
+package nodereadiness
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	infrav1alpha1 "github.com/sandbox0-ai/sandbox0/infra-operator/api/v1alpha1"
+	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/pkg/common"
+	infraplan "github.com/sandbox0-ai/sandbox0/infra-operator/internal/plan"
+	"github.com/sandbox0-ai/sandbox0/pkg/dataplane"
+)
+
+const (
+	labelManagedBy = "app.kubernetes.io/managed-by"
+	labelInstance  = "app.kubernetes.io/instance"
+	labelComponent = "app.kubernetes.io/component"
+)
+
+type Reconciler struct {
+	Resources *common.ResourceManager
+}
+
+func NewReconciler(resources *common.ResourceManager) *Reconciler {
+	return &Reconciler{Resources: resources}
+}
+
+func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, compiledPlan *infraplan.InfraPlan) error {
+	if r == nil || r.Resources == nil || r.Resources.Client == nil {
+		return fmt.Errorf("node readiness reconciler is not configured")
+	}
+	if infra == nil {
+		return fmt.Errorf("infra is required")
+	}
+	if compiledPlan == nil {
+		compiledPlan = infraplan.Compile(infra)
+	}
+	if !compiledPlan.Components.EnableManager {
+		return nil
+	}
+
+	nodeSelector, _ := common.ResolveSandboxNodePlacement(infra)
+	requireNetd := compiledPlan.Components.EnableNetd
+	requireCtld := compiledPlan.Components.EnableFusePlugin
+
+	podList := &corev1.PodList{}
+	if err := r.Resources.Client.List(ctx, podList,
+		client.InNamespace(compiledPlan.Scope.Namespace),
+		client.MatchingLabels{
+			labelManagedBy: "sandbox0infra-operator",
+			labelInstance:  compiledPlan.Scope.Name,
+		},
+	); err != nil {
+		return fmt.Errorf("list data-plane daemon pods: %w", err)
+	}
+	netdReadyByNode := readyPodsByNode(podList.Items, "netd")
+	ctldReadyByNode := readyPodsByNode(podList.Items, "ctld")
+
+	nodeList := &corev1.NodeList{}
+	if err := r.Resources.Client.List(ctx, nodeList); err != nil {
+		return fmt.Errorf("list nodes: %w", err)
+	}
+
+	matchedNodes := 0
+	readyNodes := 0
+	for i := range nodeList.Items {
+		node := &nodeList.Items[i]
+		if !nodeMatchesSelector(node, nodeSelector) {
+			continue
+		}
+		matchedNodes++
+
+		netdReady := !requireNetd || netdReadyByNode[node.Name]
+		ctldReady := !requireCtld || ctldReadyByNode[node.Name]
+		ready := netdReady && ctldReady
+		if ready {
+			readyNodes++
+		}
+
+		if err := r.patchNodeReadiness(ctx, node, ready, requireNetd, netdReady, requireCtld, ctldReady); err != nil {
+			return err
+		}
+	}
+
+	if matchedNodes == 0 {
+		return fmt.Errorf("no nodes match sandbox placement")
+	}
+	if readyNodes == 0 {
+		return fmt.Errorf("sandbox0 data-plane nodes are not ready: 0/%d ready", matchedNodes)
+	}
+	return nil
+}
+
+func (r *Reconciler) patchNodeReadiness(
+	ctx context.Context,
+	node *corev1.Node,
+	dataPlaneReady bool,
+	requireNetd bool,
+	netdReady bool,
+	requireCtld bool,
+	ctldReady bool,
+) error {
+	if node == nil {
+		return nil
+	}
+	original := node.DeepCopy()
+	if node.Labels == nil {
+		node.Labels = make(map[string]string)
+	}
+
+	setBoolLabel(node.Labels, dataplane.NodeDataPlaneReadyLabel, dataPlaneReady)
+	setOptionalBoolLabel(node.Labels, dataplane.NodeNetdReadyLabel, requireNetd, netdReady)
+	setOptionalBoolLabel(node.Labels, dataplane.NodeCtldReadyLabel, requireCtld, ctldReady)
+
+	if labelsEqual(original.Labels, node.Labels) {
+		return nil
+	}
+	if err := r.Resources.Client.Patch(ctx, node, client.MergeFrom(original)); err != nil {
+		return fmt.Errorf("patch node %s data-plane readiness: %w", node.Name, err)
+	}
+	return nil
+}
+
+func readyPodsByNode(pods []corev1.Pod, component string) map[string]bool {
+	out := make(map[string]bool)
+	for i := range pods {
+		pod := &pods[i]
+		if pod.Spec.NodeName == "" || pod.Labels[labelComponent] != component {
+			continue
+		}
+		if podReady(pod) {
+			out[pod.Spec.NodeName] = true
+		}
+	}
+	return out
+}
+
+func podReady(pod *corev1.Pod) bool {
+	if pod == nil || pod.DeletionTimestamp != nil || pod.Status.Phase != corev1.PodRunning {
+		return false
+	}
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+func nodeMatchesSelector(node *corev1.Node, selector map[string]string) bool {
+	if node == nil {
+		return false
+	}
+	for key, value := range selector {
+		if node.Labels[key] != value {
+			return false
+		}
+	}
+	return true
+}
+
+func setBoolLabel(labels map[string]string, key string, ready bool) {
+	if ready {
+		labels[key] = dataplane.ReadyLabelValue
+		return
+	}
+	labels[key] = dataplane.NotReadyLabelValue
+}
+
+func setOptionalBoolLabel(labels map[string]string, key string, required bool, ready bool) {
+	if !required {
+		delete(labels, key)
+		return
+	}
+	setBoolLabel(labels, key, ready)
+}
+
+func labelsEqual(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for key, aValue := range a {
+		if b[key] != aValue {
+			return false
+		}
+	}
+	return true
+}

--- a/infra-operator/internal/controller/services/nodereadiness/nodereadiness_test.go
+++ b/infra-operator/internal/controller/services/nodereadiness/nodereadiness_test.go
@@ -1,0 +1,189 @@
+package nodereadiness
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	infrav1alpha1 "github.com/sandbox0-ai/sandbox0/infra-operator/api/v1alpha1"
+	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/pkg/common"
+	infraplan "github.com/sandbox0-ai/sandbox0/infra-operator/internal/plan"
+	"github.com/sandbox0-ai/sandbox0/pkg/dataplane"
+)
+
+func TestReconcileLabelsNodesFromComponentReadiness(t *testing.T) {
+	infra := newNodeReadinessInfra()
+	nodeA := newNodeReadinessNode("node-a", map[string]string{"sandbox0.ai/node-role": "sandbox"})
+	nodeB := newNodeReadinessNode("node-b", map[string]string{"sandbox0.ai/node-role": "sandbox"})
+	nodeSystem := newNodeReadinessNode("node-system", map[string]string{"sandbox0.ai/node-role": "system"})
+	client, scheme := newNodeReadinessClient(t,
+		nodeA,
+		nodeB,
+		nodeSystem,
+		newNodeReadinessPod(infra.Namespace, infra.Name, "netd", "netd-a", "node-a", true),
+		newNodeReadinessPod(infra.Namespace, infra.Name, "ctld", "ctld-a", "node-a", true),
+		newNodeReadinessPod(infra.Namespace, infra.Name, "netd", "netd-b", "node-b", true),
+		newNodeReadinessPod(infra.Namespace, infra.Name, "ctld", "ctld-b", "node-b", false),
+	)
+	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
+
+	if err := reconciler.Reconcile(context.Background(), infra, infraplan.Compile(infra)); err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+
+	gotNodeA := getNodeReadinessNode(t, client, "node-a")
+	assertNodeReadinessLabels(t, gotNodeA, dataplane.ReadyLabelValue, dataplane.ReadyLabelValue, dataplane.ReadyLabelValue)
+
+	gotNodeB := getNodeReadinessNode(t, client, "node-b")
+	assertNodeReadinessLabels(t, gotNodeB, dataplane.NotReadyLabelValue, dataplane.ReadyLabelValue, dataplane.NotReadyLabelValue)
+
+	gotSystem := getNodeReadinessNode(t, client, "node-system")
+	if _, ok := gotSystem.Labels[dataplane.NodeDataPlaneReadyLabel]; ok {
+		t.Fatalf("system node data-plane label = %q, want absent", gotSystem.Labels[dataplane.NodeDataPlaneReadyLabel])
+	}
+}
+
+func TestReconcileReturnsErrorAndClearsReadinessWhenNoNodeReady(t *testing.T) {
+	infra := newNodeReadinessInfra()
+	node := newNodeReadinessNode("node-a", map[string]string{"sandbox0.ai/node-role": "sandbox"})
+	client, scheme := newNodeReadinessClient(t,
+		node,
+		newNodeReadinessPod(infra.Namespace, infra.Name, "netd", "netd-a", "node-a", true),
+	)
+	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
+
+	err := reconciler.Reconcile(context.Background(), infra, infraplan.Compile(infra))
+	if err == nil {
+		t.Fatal("Reconcile() error = nil, want data-plane readiness error")
+	}
+	if !strings.Contains(err.Error(), "0/1 ready") {
+		t.Fatalf("Reconcile() error = %v, want 0/1 ready", err)
+	}
+
+	gotNode := getNodeReadinessNode(t, client, "node-a")
+	assertNodeReadinessLabels(t, gotNode, dataplane.NotReadyLabelValue, dataplane.ReadyLabelValue, dataplane.NotReadyLabelValue)
+}
+
+func TestReconcileDeletesDisabledComponentReadinessLabels(t *testing.T) {
+	infra := newNodeReadinessInfra()
+	infra.Spec.Services.Netd.Enabled = false
+	node := newNodeReadinessNode("node-a", map[string]string{
+		"sandbox0.ai/node-role":           "sandbox",
+		dataplane.NodeDataPlaneReadyLabel: dataplane.NotReadyLabelValue,
+		dataplane.NodeNetdReadyLabel:      dataplane.ReadyLabelValue,
+		dataplane.NodeCtldReadyLabel:      dataplane.NotReadyLabelValue,
+	})
+	client, scheme := newNodeReadinessClient(t,
+		node,
+		newNodeReadinessPod(infra.Namespace, infra.Name, "ctld", "ctld-a", "node-a", true),
+	)
+	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
+
+	if err := reconciler.Reconcile(context.Background(), infra, infraplan.Compile(infra)); err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+
+	gotNode := getNodeReadinessNode(t, client, "node-a")
+	if got := gotNode.Labels[dataplane.NodeDataPlaneReadyLabel]; got != dataplane.ReadyLabelValue {
+		t.Fatalf("data-plane label = %q, want %q", got, dataplane.ReadyLabelValue)
+	}
+	if _, ok := gotNode.Labels[dataplane.NodeNetdReadyLabel]; ok {
+		t.Fatalf("netd label = %q, want absent when netd is disabled", gotNode.Labels[dataplane.NodeNetdReadyLabel])
+	}
+	if got := gotNode.Labels[dataplane.NodeCtldReadyLabel]; got != dataplane.ReadyLabelValue {
+		t.Fatalf("ctld label = %q, want %q", got, dataplane.ReadyLabelValue)
+	}
+}
+
+func newNodeReadinessInfra() *infrav1alpha1.Sandbox0Infra {
+	return &infrav1alpha1.Sandbox0Infra{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "sandbox0-system"},
+		Spec: infrav1alpha1.Sandbox0InfraSpec{
+			SandboxNodePlacement: &infrav1alpha1.SandboxNodePlacementConfig{
+				NodeSelector: map[string]string{"sandbox0.ai/node-role": "sandbox"},
+			},
+			Services: &infrav1alpha1.ServicesConfig{
+				Manager: &infrav1alpha1.ManagerServiceConfig{
+					WorkloadServiceConfig: infrav1alpha1.WorkloadServiceConfig{
+						EnabledServiceConfig: infrav1alpha1.EnabledServiceConfig{Enabled: true},
+					},
+				},
+				Netd: &infrav1alpha1.NetdServiceConfig{
+					EnabledServiceConfig: infrav1alpha1.EnabledServiceConfig{Enabled: true},
+				},
+			},
+		},
+	}
+}
+
+func newNodeReadinessClient(t *testing.T, objects ...ctrlclient.Object) (ctrlclient.Client, *runtime.Scheme) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1 scheme: %v", err)
+	}
+	if err := infrav1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add infra scheme: %v", err)
+	}
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+	return client, scheme
+}
+
+func newNodeReadinessNode(name string, labels map[string]string) *corev1.Node {
+	return &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels}}
+}
+
+func newNodeReadinessPod(namespace, instance, component, name, nodeName string, ready bool) *corev1.Pod {
+	status := corev1.ConditionFalse
+	if ready {
+		status = corev1.ConditionTrue
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				labelManagedBy: "sandbox0infra-operator",
+				labelInstance:  instance,
+				labelComponent: component,
+			},
+		},
+		Spec: corev1.PodSpec{NodeName: nodeName},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{{
+				Type:   corev1.PodReady,
+				Status: status,
+			}},
+		},
+	}
+}
+
+func getNodeReadinessNode(t *testing.T, client ctrlclient.Client, name string) *corev1.Node {
+	t.Helper()
+	node := &corev1.Node{}
+	if err := client.Get(context.Background(), types.NamespacedName{Name: name}, node); err != nil {
+		t.Fatalf("get node %s: %v", name, err)
+	}
+	return node
+}
+
+func assertNodeReadinessLabels(t *testing.T, node *corev1.Node, dataPlane, netd, ctld string) {
+	t.Helper()
+	if got := node.Labels[dataplane.NodeDataPlaneReadyLabel]; got != dataPlane {
+		t.Fatalf("node %s data-plane label = %q, want %q", node.Name, got, dataPlane)
+	}
+	if got := node.Labels[dataplane.NodeNetdReadyLabel]; got != netd {
+		t.Fatalf("node %s netd label = %q, want %q", node.Name, got, netd)
+	}
+	if got := node.Labels[dataplane.NodeCtldReadyLabel]; got != ctld {
+		t.Fatalf("node %s ctld label = %q, want %q", node.Name, got, ctld)
+	}
+}

--- a/infra-operator/internal/plan/plan.go
+++ b/infra-operator/internal/plan/plan.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/pkg/common"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/registry"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/runtimeconfig"
+	"github.com/sandbox0-ai/sandbox0/pkg/dataplane"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 	"github.com/sandbox0-ai/sandbox0/pkg/template"
 )
@@ -349,6 +350,7 @@ func compileSchedulerHomeCluster(infra *infrav1alpha1.Sandbox0Infra, compiled *I
 
 func compileManagerPlan(infra *infrav1alpha1.Sandbox0Infra, compiled *InfraPlan) ManagerPlan {
 	nodeSelector, tolerations := common.ResolveSandboxNodePlacement(infra)
+	nodeSelector = withDataPlaneReadyNodeSelector(nodeSelector, compiled)
 	templateStoreEnabled := clusterGatewayAuthMode(infra) != defaultClusterGatewayAuthMode
 	if infrav1alpha1.IsRegionalGatewayEnabled(infra) && !infrav1alpha1.IsSchedulerEnabled(infra) {
 		templateStoreEnabled = true
@@ -390,6 +392,29 @@ func compileManagerPlan(infra *infrav1alpha1.Sandbox0Infra, compiled *InfraPlan)
 	}
 
 	return managerPlan
+}
+
+func withDataPlaneReadyNodeSelector(selector map[string]string, compiled *InfraPlan) map[string]string {
+	if compiled == nil || !compiled.Components.EnableManager {
+		return selector
+	}
+	out := cloneStringMap(selector)
+	if out == nil {
+		out = make(map[string]string, 1)
+	}
+	out[dataplane.NodeDataPlaneReadyLabel] = dataplane.ReadyLabelValue
+	return out
+}
+
+func cloneStringMap(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
 }
 
 func compileManagerRuntimeConfig(managerPlan *ManagerPlan, infra *infrav1alpha1.Sandbox0Infra) {
@@ -928,11 +953,14 @@ func compileWorkflowPlan(compiled *InfraPlan) WorkflowPlan {
 	if compiled.Components.EnableManager {
 		appendCheckStep("manager-rbac", infrav1alpha1.ConditionTypeManagerReady, "ManagerRBACFailed")
 		appendSuccessStep("manager", infrav1alpha1.ConditionTypeManagerReady, "ManagerReady", "Manager is ready", "ManagerFailed")
-		appendCheckStep("builtin-template-pods", infrav1alpha1.ConditionTypeManagerReady, "BuiltinTemplatePodsNotReady")
 	}
 	if compiled.Components.EnableNetd {
 		appendCheckStep("netd-rbac", infrav1alpha1.ConditionTypeNetdReady, "NetdRBACFailed")
 		appendSuccessStep("netd", infrav1alpha1.ConditionTypeNetdReady, "NetdReady", "netd is ready", "NetdFailed")
+	}
+	if compiled.Components.EnableManager {
+		appendCheckStep("data-plane-node-readiness", infrav1alpha1.ConditionTypeManagerReady, "DataPlaneNodesNotReady")
+		appendCheckStep("builtin-template-pods", infrav1alpha1.ConditionTypeManagerReady, "BuiltinTemplatePodsNotReady")
 	}
 	if compiled.Components.EnableStorageProxy {
 		appendCheckStep("storage-proxy-rbac", infrav1alpha1.ConditionTypeStorageProxyReady, "StorageProxyRBACFailed")

--- a/infra-operator/internal/plan/plan_test.go
+++ b/infra-operator/internal/plan/plan_test.go
@@ -8,6 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	infrav1alpha1 "github.com/sandbox0-ai/sandbox0/infra-operator/api/v1alpha1"
+	"github.com/sandbox0-ai/sandbox0/pkg/dataplane"
 )
 
 func TestCompileDerivesCrossServiceReferences(t *testing.T) {
@@ -120,6 +121,12 @@ func TestCompileDerivesCrossServiceReferences(t *testing.T) {
 	}
 	if got := compiled.Manager.SandboxPodPlacement.NodeSelector["sandbox0.ai/node-role"]; got != "shared" {
 		t.Fatalf("expected shared sandbox placement, got %q", got)
+	}
+	if got := compiled.Manager.SandboxPodPlacement.NodeSelector[dataplane.NodeDataPlaneReadyLabel]; got != dataplane.ReadyLabelValue {
+		t.Fatalf("expected manager sandbox placement to require data-plane-ready nodes, got %q", got)
+	}
+	if _, ok := compiled.Netd.NodeSelector[dataplane.NodeDataPlaneReadyLabel]; ok {
+		t.Fatalf("expected netd placement not to require data-plane-ready nodes, got %#v", compiled.Netd.NodeSelector)
 	}
 	if len(compiled.Netd.Tolerations) != 1 || compiled.Netd.Tolerations[0].Key != "sandbox0.ai/sandbox" {
 		t.Fatalf("expected shared netd tolerations, got %#v", compiled.Netd.Tolerations)
@@ -890,9 +897,10 @@ func TestCompileTracksWorkflowRequirements(t *testing.T) {
 		"fuse-device-plugin",
 		"manager-rbac",
 		"manager",
-		"builtin-template-pods",
 		"netd-rbac",
 		"netd",
+		"data-plane-node-readiness",
+		"builtin-template-pods",
 		"storage-proxy-rbac",
 		"storage-proxy",
 		"register-cluster",

--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -284,6 +284,7 @@ func main() {
 	sandboxService := service.NewSandboxService(
 		k8sClient,
 		podLister,
+		nodeLister,
 		sandboxIndex,
 		secretLister,
 		operator.GetTemplateLister(),

--- a/manager/pkg/http/handlers_sandbox.go
+++ b/manager/pkg/http/handlers_sandbox.go
@@ -46,6 +46,11 @@ func (s *Server) claimSandbox(c *gin.Context) {
 			spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
 			return
 		}
+		if errors.Is(err, service.ErrDataPlaneNotReady) {
+			c.Header("Retry-After", "1")
+			spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, err.Error())
+			return
+		}
 		s.logger.Error("Failed to claim sandbox",
 			zap.String("template", req.Template),
 			zap.String("teamID", req.TeamID),

--- a/manager/pkg/http/handlers_sandbox_list_test.go
+++ b/manager/pkg/http/handlers_sandbox_list_test.go
@@ -4,16 +4,22 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/service"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	corelisters "k8s.io/client-go/listers/core/v1"
@@ -44,6 +50,7 @@ func TestListSandboxesReturnsOK(t *testing.T) {
 	sandboxService := service.NewSandboxService(
 		fake.NewSimpleClientset(pod),
 		newHTTPTestPodLister(t, pod),
+		nil,
 		nil,
 		nil,
 		nil,
@@ -95,6 +102,55 @@ func TestListSandboxesReturnsOK(t *testing.T) {
 	}
 }
 
+func TestClaimSandboxReturnsUnavailableWhenDataPlaneNotReady(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	withHTTPTestManagerConfig(t, `sandbox_pod_placement:
+  node_selector:
+    sandbox0.ai/data-plane-ready: "true"
+`)
+
+	templateNamespace, err := naming.TemplateNamespaceForBuiltin("default")
+	if err != nil {
+		t.Fatalf("template namespace: %v", err)
+	}
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: templateNamespace},
+		Spec:       v1alpha1.SandboxTemplateSpec{MainContainer: v1alpha1.ContainerSpec{Image: "busybox"}},
+	}
+	sandboxService := service.NewSandboxService(
+		fake.NewSimpleClientset(),
+		newHTTPTestPodLister(t),
+		newHTTPTestNodeLister(t),
+		nil,
+		nil,
+		staticHTTPTemplateLister{templates: []*v1alpha1.SandboxTemplate{template}},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		service.SandboxServiceConfig{},
+		zap.NewNop(),
+		nil,
+	)
+
+	server := &Server{sandboxService: sandboxService, logger: zap.NewNop()}
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/sandboxes", strings.NewReader(`{"template":"default"}`))
+	request = request.WithContext(internalauth.WithClaims(request.Context(), &internalauth.Claims{TeamID: "team-1", UserID: "user-1"}))
+	ctx.Request = request
+
+	server.claimSandbox(ctx)
+
+	if recorder.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusServiceUnavailable)
+	}
+	if got := recorder.Header().Get("Retry-After"); got != "1" {
+		t.Fatalf("Retry-After = %q, want 1", got)
+	}
+}
+
 func newHTTPTestPodLister(t *testing.T, pods ...*corev1.Pod) corelisters.PodLister {
 	t.Helper()
 	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
@@ -106,4 +162,51 @@ func newHTTPTestPodLister(t *testing.T, pods ...*corev1.Pod) corelisters.PodList
 		}
 	}
 	return corelisters.NewPodLister(indexer)
+}
+
+func newHTTPTestNodeLister(t *testing.T, nodes ...*corev1.Node) corelisters.NodeLister {
+	t.Helper()
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	for _, node := range nodes {
+		if err := indexer.Add(node); err != nil {
+			t.Fatalf("add node: %v", err)
+		}
+	}
+	return corelisters.NewNodeLister(indexer)
+}
+
+type staticHTTPTemplateLister struct {
+	templates []*v1alpha1.SandboxTemplate
+}
+
+func (l staticHTTPTemplateLister) List() ([]*v1alpha1.SandboxTemplate, error) {
+	return l.templates, nil
+}
+
+func (l staticHTTPTemplateLister) Get(namespace, name string) (*v1alpha1.SandboxTemplate, error) {
+	for _, template := range l.templates {
+		if template.Namespace == namespace && template.Name == name {
+			return template, nil
+		}
+	}
+	return nil, apierrors.NewNotFound(v1alpha1.Resource("sandboxtemplate"), name)
+}
+
+func withHTTPTestManagerConfig(t *testing.T, content string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "manager-config.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write manager config: %v", err)
+	}
+	previousPath, hadPath := os.LookupEnv("CONFIG_PATH")
+	if err := os.Setenv("CONFIG_PATH", path); err != nil {
+		t.Fatalf("set CONFIG_PATH: %v", err)
+	}
+	t.Cleanup(func() {
+		if hadPath {
+			_ = os.Setenv("CONFIG_PATH", previousPath)
+			return
+		}
+		_ = os.Unsetenv("CONFIG_PATH")
+	})
 }

--- a/manager/pkg/http/server_test.go
+++ b/manager/pkg/http/server_test.go
@@ -187,7 +187,7 @@ func TestRequireNetworkPolicyInBody(t *testing.T) {
 func newTestServerForCapability(t *testing.T, provider network.Provider) *Server {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
-	sandboxService := service.NewSandboxService(nil, nil, nil, nil, nil, nil, provider, nil, nil, nil, service.SandboxServiceConfig{}, zap.NewNop(), nil)
+	sandboxService := service.NewSandboxService(nil, nil, nil, nil, nil, nil, nil, provider, nil, nil, nil, service.SandboxServiceConfig{}, zap.NewNop(), nil)
 	return &Server{sandboxService: sandboxService}
 }
 

--- a/manager/pkg/network/netd_provider.go
+++ b/manager/pkg/network/netd_provider.go
@@ -140,7 +140,7 @@ func (p *NetdProvider) waitForAppliedHashes(
 		case <-waiter.done:
 			return nil
 		case <-ctx.Done():
-			return fmt.Errorf("timeout waiting for netd policy apply for pod %s/%s", namespace, podName)
+			return fmt.Errorf("%w: timeout waiting for netd policy apply for pod %s/%s", ErrPolicyApplyTimeout, namespace, podName)
 		case <-p.tick(ticker):
 			if p.isApplied(namespace, podName, expectedNetworkHash) {
 				p.completeWaiter(key, waiter)

--- a/manager/pkg/network/provider.go
+++ b/manager/pkg/network/provider.go
@@ -2,9 +2,12 @@ package network
 
 import (
 	"context"
+	"errors"
 
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 )
+
+var ErrPolicyApplyTimeout = errors.New("network policy apply timeout")
 
 // SandboxPolicyInput contains the policy data needed by a network provider.
 type SandboxPolicyInput struct {

--- a/manager/pkg/service/cluster_service_test.go
+++ b/manager/pkg/service/cluster_service_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
+	"github.com/sandbox0-ai/sandbox0/pkg/dataplane"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -70,6 +71,49 @@ sandbox_pod_placement:
 	}
 	if summary.TotalPodCount != 4 {
 		t.Fatalf("TotalPodCount = %d, want 4", summary.TotalPodCount)
+	}
+}
+
+func TestGetClusterSummaryCountsOnlyDataPlaneReadySandboxNodes(t *testing.T) {
+	configPath := writeClusterServiceManagerConfig(t, `
+default_cluster_id: cluster-a
+sandbox_pod_placement:
+  node_selector:
+    sandbox0.ai/node-role: sandbox
+    `+dataplane.NodeDataPlaneReadyLabel+`: "true"
+`)
+	t.Setenv("CONFIG_PATH", configPath)
+
+	svc := &ClusterService{
+		podLister: newClusterServicePodLister(t),
+		nodeLister: newClusterServiceNodeLister(t,
+			newClusterServiceNode("node-ready", map[string]string{
+				"sandbox0.ai/node-role":           "sandbox",
+				dataplane.NodeDataPlaneReadyLabel: dataplane.ReadyLabelValue,
+			}),
+			newClusterServiceNode("node-not-ready", map[string]string{
+				"sandbox0.ai/node-role":           "sandbox",
+				dataplane.NodeDataPlaneReadyLabel: dataplane.NotReadyLabelValue,
+			}),
+			newClusterServiceNode("node-missing-ready", map[string]string{"sandbox0.ai/node-role": "sandbox"}),
+			newClusterServiceNode("node-system", map[string]string{
+				"sandbox0.ai/node-role":           "system",
+				dataplane.NodeDataPlaneReadyLabel: dataplane.ReadyLabelValue,
+			}),
+		),
+		logger: zap.NewNop(),
+	}
+
+	summary, err := svc.GetClusterSummary(context.Background())
+	if err != nil {
+		t.Fatalf("GetClusterSummary() error = %v", err)
+	}
+
+	if summary.NodeCount != 4 {
+		t.Fatalf("NodeCount = %d, want 4", summary.NodeCount)
+	}
+	if summary.SandboxNodeCount != 1 {
+		t.Fatalf("SandboxNodeCount = %d, want 1", summary.SandboxNodeCount)
 	}
 }
 

--- a/manager/pkg/service/power_executor_ctld_test.go
+++ b/manager/pkg/service/power_executor_ctld_test.go
@@ -52,7 +52,7 @@ func TestCtldAddressForSandboxUsesNodeInternalIP(t *testing.T) {
 }
 
 func TestNewSandboxServiceUsesCtldExecutorWhenEnabled(t *testing.T) {
-	svc := NewSandboxService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, SandboxServiceConfig{CtldEnabled: true}, zap.NewNop(), nil)
+	svc := NewSandboxService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, SandboxServiceConfig{CtldEnabled: true}, zap.NewNop(), nil)
 	_, ok := svc.powerExecutor.(*ctldSandboxPowerExecutor)
 	assert.True(t, ok)
 	assert.Equal(t, 8095, svc.config.CtldPort)

--- a/manager/pkg/service/sandbox_service.go
+++ b/manager/pkg/service/sandbox_service.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/network"
+	"github.com/sandbox0-ai/sandbox0/pkg/dataplane"
 	egressauth "github.com/sandbox0-ai/sandbox0/pkg/egressauth"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
@@ -81,6 +82,7 @@ type SandboxPowerState struct {
 // errNoIdlePod is returned when no idle pod is available for claiming.
 var errNoIdlePod = errors.New("no idle pod available")
 var ErrInvalidClaimRequest = errors.New("invalid claim request")
+var ErrDataPlaneNotReady = errors.New("data plane not ready")
 var errSandboxPowerStateStale = errors.New("sandbox power state changed during execution")
 
 // ErrSandboxPowerTransitionSuperseded is returned when a newer pause/resume request replaces the requested transition.
@@ -122,6 +124,7 @@ type SandboxServiceConfig struct {
 type SandboxService struct {
 	k8sClient              kubernetes.Interface
 	podLister              corelisters.PodLister
+	nodeLister             corelisters.NodeLister
 	sandboxIndex           *SandboxIndex
 	secretLister           corelisters.SecretLister
 	templateLister         controller.TemplateLister
@@ -175,6 +178,7 @@ type TokenGenerator interface {
 func NewSandboxService(
 	k8sClient kubernetes.Interface,
 	podLister corelisters.PodLister,
+	nodeLister corelisters.NodeLister,
 	sandboxIndex *SandboxIndex,
 	secretLister corelisters.SecretLister,
 	templateLister controller.TemplateLister,
@@ -203,6 +207,7 @@ func NewSandboxService(
 	service := &SandboxService{
 		k8sClient:              k8sClient,
 		podLister:              podLister,
+		nodeLister:             nodeLister,
 		sandboxIndex:           sandboxIndex,
 		secretLister:           secretLister,
 		templateLister:         templateLister,
@@ -650,7 +655,7 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 		// Filter hot-claimable pods to Kubernetes-ready instances only.
 		var readyPods []*corev1.Pod
 		for _, pod := range pods {
-			if controller.IsPodReady(pod) {
+			if controller.IsPodReady(pod) && s.podDataPlaneReady(pod) {
 				readyPods = append(readyPods, pod)
 			}
 		}
@@ -758,6 +763,14 @@ func (s *SandboxService) createNewPod(ctx context.Context, template *v1alpha1.Sa
 	if err != nil {
 		return nil, fmt.Errorf("generate sandbox name: %w", err)
 	}
+
+	// Build pod spec before side-effecting resources so claims fail fast when the
+	// sandbox data plane has no ready nodes to receive the pod.
+	spec := v1alpha1.BuildPodSpec(template)
+	if err := s.ensureDataPlaneReadyCapacity(spec); err != nil {
+		return nil, err
+	}
+
 	if err := controller.EnsureProcdConfigSecret(ctx, s.k8sClient, s.secretLister, template); err != nil {
 		return nil, fmt.Errorf("ensure procd config secret: %w", err)
 	}
@@ -765,8 +778,6 @@ func (s *SandboxService) createNewPod(ctx context.Context, template *v1alpha1.Sa
 		return nil, fmt.Errorf("ensure netd MITM CA secret: %w", err)
 	}
 
-	// Build pod spec from template
-	spec := v1alpha1.BuildPodSpec(template)
 	annotations := map[string]string{
 		controller.AnnotationSandboxID: podName,
 		controller.AnnotationTeamID:    req.TeamID,
@@ -873,6 +884,41 @@ func (s *SandboxService) requestSandboxDeletionAfterClaimFailure(pod *corev1.Pod
 			zap.Error(err),
 		)
 	}
+}
+
+func (s *SandboxService) podDataPlaneReady(pod *corev1.Pod) bool {
+	if pod == nil {
+		return false
+	}
+	if !dataplane.SelectorRequiresReadyNode(pod.Spec.NodeSelector) {
+		return true
+	}
+	if pod.Spec.NodeName == "" || s == nil || s.nodeLister == nil {
+		return false
+	}
+	node, err := s.nodeLister.Get(pod.Spec.NodeName)
+	if err != nil {
+		return false
+	}
+	return dataplane.NodeReady(node)
+}
+
+func (s *SandboxService) ensureDataPlaneReadyCapacity(spec corev1.PodSpec) error {
+	if !dataplane.SelectorRequiresReadyNode(spec.NodeSelector) {
+		return nil
+	}
+	if s == nil || s.nodeLister == nil {
+		return fmt.Errorf("%w: manager node cache is not configured", ErrDataPlaneNotReady)
+	}
+	selector := labels.SelectorFromSet(spec.NodeSelector)
+	nodes, err := s.nodeLister.List(selector)
+	if err != nil {
+		return fmt.Errorf("list data-plane-ready nodes: %w", err)
+	}
+	if len(nodes) == 0 {
+		return fmt.Errorf("%w: no nodes match selector %q", ErrDataPlaneNotReady, labels.Set(spec.NodeSelector).String())
+	}
+	return nil
 }
 
 type webhookInfo struct {
@@ -1285,6 +1331,9 @@ func (s *SandboxService) applyNetworkProvider(
 		NetworkPolicy: networkSpec,
 	}
 	if err := s.networkProvider.ApplySandboxPolicy(ctx, input); err != nil {
+		if errors.Is(err, network.ErrPolicyApplyTimeout) {
+			return fmt.Errorf("%w: %v", ErrDataPlaneNotReady, err)
+		}
 		return err
 	}
 	return nil

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/network"
+	"github.com/sandbox0-ai/sandbox0/pkg/dataplane"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 	"github.com/sandbox0-ai/sandbox0/pkg/sandboxprobe"
@@ -89,6 +90,37 @@ func TestClaimIdlePodClaimsReadyPod(t *testing.T) {
 	}
 	if got := pod.Labels[controller.LabelPoolType]; got != controller.PoolTypeActive {
 		t.Fatalf("pool-type = %q, want %q", got, controller.PoolTypeActive)
+	}
+}
+
+func TestClaimIdlePodRequiresDataPlaneReadyNode(t *testing.T) {
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "template-a",
+			Namespace: "ns-a",
+		},
+	}
+	readyPod := newClaimTestPod("ns-a", "idle-ready", "template-a", true)
+	readyPod.Spec.NodeName = "node-a"
+	readyPod.Spec.NodeSelector = dataplane.DataPlaneReadyNodeSelector()
+
+	node := newClaimTestNode("node-a", "10.0.0.1")
+	node.Labels = map[string]string{dataplane.NodeDataPlaneReadyLabel: dataplane.NotReadyLabelValue}
+	client := fake.NewSimpleClientset(readyPod.DeepCopy(), node.DeepCopy())
+	svc := &SandboxService{
+		k8sClient:  client,
+		podLister:  newClaimTestPodLister(t, readyPod),
+		nodeLister: newClaimTestNodeLister(t, node),
+		clock:      systemTime{},
+		logger:     zap.NewNop(),
+	}
+
+	pod, err := svc.claimIdlePod(context.Background(), template, &ClaimRequest{TeamID: "team-a", UserID: "user-a"})
+	if err != nil {
+		t.Fatalf("claimIdlePod() error = %v", err)
+	}
+	if pod != nil {
+		t.Fatalf("claimIdlePod() = %s, want nil for pod on data-plane-not-ready node", pod.Name)
 	}
 }
 
@@ -295,6 +327,44 @@ func TestCreateNewPodRequestsDeleteAfterNetworkApplyFailure(t *testing.T) {
 	}
 }
 
+func TestCreateNewPodFailsBeforeCreateWhenDataPlaneNotReady(t *testing.T) {
+	withClaimTestManagerConfig(t, `sandbox_pod_placement:
+  node_selector:
+    sandbox0.ai/data-plane-ready: "true"
+`)
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "template-a",
+			Namespace: "ns-a",
+		},
+		Spec: v1alpha1.SandboxTemplateSpec{
+			MainContainer: v1alpha1.ContainerSpec{Image: "busybox"},
+		},
+	}
+	client := fake.NewSimpleClientset()
+	svc := &SandboxService{
+		k8sClient:  client,
+		nodeLister: newClaimTestNodeLister(t),
+		clock:      systemTime{},
+		logger:     zap.NewNop(),
+	}
+
+	_, err := svc.createNewPod(context.Background(), template, &ClaimRequest{TeamID: "team-a", UserID: "user-a"})
+	if err == nil {
+		t.Fatal("createNewPod() error = nil, want data-plane-not-ready")
+	}
+	if !errors.Is(err, ErrDataPlaneNotReady) {
+		t.Fatalf("createNewPod() error = %v, want ErrDataPlaneNotReady", err)
+	}
+	pods, err := client.CoreV1().Pods("ns-a").List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list pods: %v", err)
+	}
+	if len(pods.Items) != 0 {
+		t.Fatalf("pods after data-plane-not-ready cold claim = %d, want 0", len(pods.Items))
+	}
+}
+
 func TestClaimSandboxCleansColdPodWhenClaimReadinessFails(t *testing.T) {
 	withClaimTestPublicKey(t)
 	templateNamespace, err := naming.TemplateNamespaceForBuiltin("managed-agent-claude")
@@ -459,6 +529,25 @@ func withClaimTestPublicKey(t *testing.T) {
 	t.Cleanup(func() { internalauth.DefaultInternalJWTPublicKeyPath = previousKeyPath })
 }
 
+func withClaimTestManagerConfig(t *testing.T, content string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "manager-config.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write manager config: %v", err)
+	}
+	previousPath, hadPath := os.LookupEnv("CONFIG_PATH")
+	if err := os.Setenv("CONFIG_PATH", path); err != nil {
+		t.Fatalf("set CONFIG_PATH: %v", err)
+	}
+	t.Cleanup(func() {
+		if hadPath {
+			_ = os.Setenv("CONFIG_PATH", previousPath)
+			return
+		}
+		_ = os.Unsetenv("CONFIG_PATH")
+	})
+}
+
 func newClaimTestSecretLister(t *testing.T, secrets ...*corev1.Secret) corelisters.SecretLister {
 	t.Helper()
 	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
@@ -470,6 +559,17 @@ func newClaimTestSecretLister(t *testing.T, secrets ...*corev1.Secret) coreliste
 		}
 	}
 	return corelisters.NewSecretLister(indexer)
+}
+
+func newClaimTestNodeLister(t *testing.T, nodes ...*corev1.Node) corelisters.NodeLister {
+	t.Helper()
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	for _, node := range nodes {
+		if err := indexer.Add(node); err != nil {
+			t.Fatalf("add node: %v", err)
+		}
+	}
+	return corelisters.NewNodeLister(indexer)
 }
 
 func newClaimTestPodIndexer(t *testing.T, pods ...*corev1.Pod) cache.Indexer {

--- a/manager/pkg/service/sandbox_service_network_test.go
+++ b/manager/pkg/service/sandbox_service_network_test.go
@@ -122,6 +122,21 @@ func (p *assertingNetworkProvider) RemoveSandboxPolicy(_ context.Context, namesp
 	return p.removeErr
 }
 
+func TestApplyNetworkProviderMapsTimeoutToDataPlaneNotReady(t *testing.T) {
+	svc := &SandboxService{
+		networkProvider: &assertingNetworkProvider{applyErr: network.ErrPolicyApplyTimeout},
+	}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "sandbox-a", Namespace: "ns-a"}}
+
+	err := svc.applyNetworkProvider(context.Background(), pod, "team-a", &v1alpha1.NetworkPolicySpec{})
+	if err == nil {
+		t.Fatal("applyNetworkProvider() error = nil, want data-plane-not-ready")
+	}
+	if !errors.Is(err, ErrDataPlaneNotReady) {
+		t.Fatalf("applyNetworkProvider() error = %v, want ErrDataPlaneNotReady", err)
+	}
+}
+
 func newSandboxServiceForNetworkTests(
 	t *testing.T,
 	pod *corev1.Pod,

--- a/pkg/dataplane/readiness.go
+++ b/pkg/dataplane/readiness.go
@@ -1,0 +1,29 @@
+package dataplane
+
+import corev1 "k8s.io/api/core/v1"
+
+const (
+	NodeDataPlaneReadyLabel = "sandbox0.ai/data-plane-ready"
+	NodeNetdReadyLabel      = "sandbox0.ai/netd-ready"
+	NodeCtldReadyLabel      = "sandbox0.ai/ctld-ready"
+	ReadyLabelValue         = "true"
+	NotReadyLabelValue      = "false"
+)
+
+// DataPlaneReadyNodeSelector returns the scheduling selector consumed by
+// sandbox pods that must run only on nodes with a ready sandbox0 data plane.
+func DataPlaneReadyNodeSelector() map[string]string {
+	return map[string]string{NodeDataPlaneReadyLabel: ReadyLabelValue}
+}
+
+// SelectorRequiresReadyNode reports whether a node selector is explicitly gated
+// on the sandbox0 data-plane readiness signal.
+func SelectorRequiresReadyNode(selector map[string]string) bool {
+	return selector[NodeDataPlaneReadyLabel] == ReadyLabelValue
+}
+
+// NodeReady reports whether the node currently advertises sandbox0 data-plane
+// readiness.
+func NodeReady(node *corev1.Node) bool {
+	return node != nil && node.Labels[NodeDataPlaneReadyLabel] == ReadyLabelValue
+}

--- a/skills/sandbox0/references/docs-src/self-hosted/configuration/page.mdx
+++ b/skills/sandbox0/references/docs-src/self-hosted/configuration/page.mdx
@@ -198,7 +198,7 @@ Examples:
 - `services.storageProxy.config.juicefs*` tunes JuiceFS behavior and cache sizing
 - `services.netd.config.*` controls proxy ports, policy enforcement, and node-level networking behavior
 
-Use `spec.sandboxNodePlacement` for the shared node placement consumed by sandbox template Pods, `netd`, and `ctld`. The older `services.netd.nodeSelector` and `services.netd.tolerations` fields remain as compatibility aliases when the shared placement is unset.
+Use `spec.sandboxNodePlacement` for the shared node placement consumed by sandbox template Pods, `netd`, and `ctld`. `infra-operator` owns `sandbox0.ai/data-plane-ready` and adds it to sandbox Pod placement after the required node-local components are Ready. The older `services.netd.nodeSelector` and `services.netd.tolerations` fields remain as compatibility aliases when the shared placement is unset.
 
 <Callout variant="info">
 Use the generated reference below for exact field names, defaults, enums, and required flags. Use the sample manifests for operator-friendly starting points.
@@ -221,5 +221,6 @@ The reference below is generated from the `Sandbox0Infra` CRD schema produced by
 - Enable `storageProxy` only when you need volume and snapshot features.
 - Enable `netd` only on Linux nodes and only when you need network policy enforcement.
 - Use `sandboxNodePlacement` to keep sandbox workloads and node-local sandbox services on the same node set.
+- Treat `sandbox0.ai/data-plane-ready` as operator-owned; use your own labels under `sandboxNodePlacement` and let `infra-operator` manage readiness.
 - If sandbox workloads use `gvisor` or `kata`, keep `services.netd.runtimeClassName` on a host-compatible runtime such as the cluster default runtime.
 - Keep control-plane and data-plane components in the same storage and latency domain for a given region.

--- a/ssh-gateway/pkg/server/procd.go
+++ b/ssh-gateway/pkg/server/procd.go
@@ -215,7 +215,6 @@ func (s *Server) openShell(ctx context.Context, target *SessionTarget, pty ptySp
 	}
 
 	bridge := newShellBridge(channel, wsConn)
-	bridge.start()
 	return bridge, nil
 }
 
@@ -236,7 +235,6 @@ func (s *Server) openExec(ctx context.Context, target *SessionTarget, pty ptySpe
 	}
 
 	bridge := newShellBridge(channel, wsConn)
-	bridge.start()
 	return bridge, nil
 }
 

--- a/ssh-gateway/pkg/server/session.go
+++ b/ssh-gateway/pkg/server/session.go
@@ -55,32 +55,39 @@ func (s *sshSession) run() {
 				requests = nil
 				continue
 			}
-			handled, success := s.handleRequest(req)
+			handled, success, afterReply := s.handleRequest(req)
 			if req.WantReply && handled {
 				_ = req.Reply(success, nil)
+			}
+			// Start bridges after replying so fast commands cannot close the SSH
+			// channel before the client receives request success.
+			if success && afterReply != nil {
+				afterReply()
 			}
 		}
 	}
 }
 
-func (s *sshSession) handleRequest(req *ssh.Request) (handled, success bool) {
+func (s *sshSession) handleRequest(req *ssh.Request) (handled, success bool, afterReply func()) {
 	switch req.Type {
 	case "pty-req":
-		return true, s.handlePTY(req.Payload)
+		return true, s.handlePTY(req.Payload), nil
 	case "shell":
-		return true, s.handleShell()
+		success, afterReply := s.handleShell()
+		return true, success, afterReply
 	case "window-change":
-		return true, s.handleWindowChange(req.Payload)
+		return true, s.handleWindowChange(req.Payload), nil
 	case "signal":
-		return true, s.handleSignal(req.Payload)
+		return true, s.handleSignal(req.Payload), nil
 	case "subsystem":
 		return s.handleSubsystem(req)
 	case "exec":
-		return true, s.handleExec(req.Payload)
+		success, afterReply := s.handleExec(req.Payload)
+		return true, success, afterReply
 	case "eow@openssh.com":
-		return true, true
+		return true, true, nil
 	default:
-		return true, false
+		return true, false, nil
 	}
 }
 
@@ -99,9 +106,9 @@ func (s *sshSession) handlePTY(payload []byte) bool {
 	return true
 }
 
-func (s *sshSession) handleShell() bool {
+func (s *sshSession) handleShell() (bool, func()) {
 	if s.bridge != nil || s.sftpDone != nil {
-		return false
+		return false, nil
 	}
 	bridge, err := s.server.openShell(s.ctx, s.target, s.pty, s.channel)
 	if err != nil {
@@ -111,11 +118,11 @@ func (s *sshSession) handleShell() bool {
 			zap.String("user_id", s.target.UserID),
 			zap.Error(err),
 		)
-		return false
+		return false, nil
 	}
 	s.setBridge(bridge)
 	s.watchBridge("sandbox shell disconnected\n", "Sandbox shell bridge exited with error", nil)
-	return true
+	return true, bridge.start
 }
 
 func (s *sshSession) handleWindowChange(payload []byte) bool {
@@ -146,43 +153,44 @@ func (s *sshSession) handleSignal(payload []byte) bool {
 	return true
 }
 
-func (s *sshSession) handleSubsystem(req *ssh.Request) (handled, success bool) {
+func (s *sshSession) handleSubsystem(req *ssh.Request) (handled, success bool, afterReply func()) {
 	var payload sftpSubsystemRequest
 	if err := ssh.Unmarshal(req.Payload, &payload); err != nil || payload.Subsystem != "sftp" {
-		return true, false
+		return true, false, nil
 	}
 	if s.bridge != nil || s.sftpDone != nil {
-		return true, false
+		return true, false, nil
 	}
 	done := make(chan sftpExit, 1)
 	s.sftpDone = done
-	go func() {
-		result := sftpExit{}
-		if err := s.server.serveSFTP(s.channel, s.target); err != nil && !errors.Is(err, io.EOF) {
-			result.status = 1
-			result.err = err
-		}
-		done <- result
-	}()
-	return true, true
+	return true, true, func() {
+		go func() {
+			result := sftpExit{}
+			if err := s.server.serveSFTP(s.channel, s.target); err != nil && !errors.Is(err, io.EOF) {
+				result.status = 1
+				result.err = err
+			}
+			done <- result
+		}()
+	}
 }
 
-func (s *sshSession) handleExec(payload []byte) bool {
+func (s *sshSession) handleExec(payload []byte) (bool, func()) {
 	if s.bridge != nil || s.sftpDone != nil {
-		return false
+		return false, nil
 	}
 	var req execRequest
 	if err := ssh.Unmarshal(payload, &req); err != nil {
-		return false
+		return false, nil
 	}
 	command := strings.TrimSpace(req.Command)
 	if command == "" {
 		_, _ = s.channel.Stderr().Write([]byte("empty exec command\n"))
-		return false
+		return false, nil
 	}
 	if strings.HasPrefix(command, "scp ") {
 		_, _ = s.channel.Stderr().Write([]byte("legacy scp mode is not supported; use default scp/sftp mode\n"))
-		return false
+		return false, nil
 	}
 
 	bridge, err := s.server.openExec(s.ctx, s.target, s.pty, command, s.channel)
@@ -194,11 +202,11 @@ func (s *sshSession) handleExec(payload []byte) bool {
 			zap.String("command", command),
 			zap.Error(err),
 		)
-		return false
+		return false, nil
 	}
 	s.setBridge(bridge)
 	s.watchBridge("sandbox command disconnected\n", "Sandbox command bridge exited with error", []zap.Field{zap.String("command", command)})
-	return true
+	return true, bridge.start
 }
 
 func (s *sshSession) handleSFTPExit(result sftpExit) {

--- a/tests/integration/internal/tests/manager/api_test.go
+++ b/tests/integration/internal/tests/manager/api_test.go
@@ -129,6 +129,7 @@ func newManagerTestEnvWithOptions(t *testing.T, opts managerTestEnvOptions) *man
 	sandboxService := service.NewSandboxService(
 		k8sClient,
 		podLister,
+		nil,
 		sandboxIndex,
 		secretLister,
 		templateLister,


### PR DESCRIPTION
Closes #185

## Summary
- Add shared data-plane readiness labels and an infra-operator node readiness reconciler that marks sandbox placement nodes ready only when required node-local components are Ready.
- Inject the operator-owned data-plane-ready selector into manager sandbox pod placement and move builtin template pod checks after netd/node readiness to avoid scheduling before the data plane is usable.
- Make manager hot/cold claims reject data-plane-not-ready capacity with 503/Retry-After and map netd apply timeouts into the same retryable error.
- Add focused tests plus self-hosted docs/sample notes for the operator-owned readiness label.

## Testing
- go test ./pkg/dataplane ./infra-operator/internal/controller/services/nodereadiness ./infra-operator/internal/plan ./infra-operator/internal/controller ./infra-operator/internal/controller/services/manager ./infra-operator/internal/controller/services/netd ./infra-operator/internal/controller/services/fuseplugin ./manager/pkg/network ./manager/pkg/service ./manager/pkg/http ./manager/pkg/apis/sandbox0/v1alpha1 ./manager/pkg/controller ./manager/cmd/manager ./tests/integration/internal/tests/manager -count=1
- git diff --cached --check
- git push pre-push hook: make manifests, make proto, make apispec, go fmt ./..., go mod tidy, go mod vendor, golangci-lint run ./...

## Notes
- Attempted go test ./...; it is blocked by existing repo/environment issues: missing generated storage-proxy/proto/fs package during setup, TestPTYRunner_FastCommandOutputReliableRepeat returning empty output once, and local Docker daemon unavailable for kind e2e.