### PR TITLE
Allow ROX mounts for fresh volume roots

### DIFF
--- a/storage-proxy/pkg/volume/manager.go
+++ b/storage-proxy/pkg/volume/manager.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"crypto/subtle"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -88,6 +89,13 @@ type directMountLease struct {
 	SessionID string
 	InFlight  int
 	LastUsed  time.Time
+}
+
+var errVolumeRootNotFound = errors.New("volume root not found")
+
+type volumeRootMeta interface {
+	Lookup(ctx meta.Context, parent meta.Ino, name string, inode *meta.Ino, attr *meta.Attr, checkPerm bool) syscall.Errno
+	Mkdir(ctx meta.Context, parent meta.Ino, name string, mode uint16, cumask uint16, copysgid uint8, inode *meta.Ino, attr *meta.Attr) syscall.Errno
 }
 
 // Manager manages JuiceFS volumes
@@ -174,12 +182,7 @@ func (m *Manager) MountVolume(ctx context.Context, s3Prefix, volumeID, teamID st
 	m.logger.WithField("volume_id", volumeID).Info("Mounting volume")
 
 	// 1. Initialize JuiceFS metadata client
-	metaConf := meta.DefaultConf()
-	metaConf.Retries = m.config.JuiceFSMetaRetries
-	if metaConf.Retries == 0 {
-		metaConf.Retries = 10
-	}
-	metaConf.ReadOnly = readOnly
+	metaConf := buildMetaConf(m.config, readOnly)
 
 	metaClient := meta.NewClient(m.config.MetaURL, metaConf)
 
@@ -254,7 +257,7 @@ func (m *Manager) MountVolume(ctx context.Context, s3Prefix, volumeID, teamID st
 	if err != nil {
 		return "", "", time.Time{}, fmt.Errorf("volume path: %w", err)
 	}
-	rootInode, err := ensureVolumeRoot(metaClient, rootPath)
+	rootInode, err := resolveMountRoot(metaClient, rootPath, readOnly, m.ensureWritableVolumeRoot)
 	if err != nil {
 		return "", "", time.Time{}, fmt.Errorf("ensure volume root: %w", err)
 	}
@@ -341,10 +344,66 @@ func (m *Manager) AuthenticateMountSession(volumeID, sessionID, sessionSecret st
 	}, nil
 }
 
+func buildMetaConf(cfg *config.StorageProxyConfig, readOnly bool) *meta.Config {
+	metaConf := meta.DefaultConf()
+	if cfg != nil {
+		metaConf.Retries = cfg.JuiceFSMetaRetries
+	}
+	if metaConf.Retries == 0 {
+		metaConf.Retries = 10
+	}
+	metaConf.ReadOnly = readOnly
+	return metaConf
+}
+
+func resolveMountRoot(metaClient volumeRootMeta, path string, readOnly bool, ensureWritable func(string) (meta.Ino, error)) (meta.Ino, error) {
+	if !readOnly {
+		return ensureVolumeRoot(metaClient, path)
+	}
+
+	rootInode, err := lookupVolumeRoot(metaClient, path)
+	if err == nil {
+		return rootInode, nil
+	}
+	if !errors.Is(err, errVolumeRootNotFound) {
+		return 0, err
+	}
+	if ensureWritable == nil {
+		return 0, err
+	}
+	return ensureWritable(path)
+}
+
+func (m *Manager) ensureWritableVolumeRoot(path string) (meta.Ino, error) {
+	if m == nil || m.config == nil {
+		return 0, fmt.Errorf("storage proxy config is not available")
+	}
+
+	metaClient := meta.NewClient(m.config.MetaURL, buildMetaConf(m.config, false))
+	defer func() {
+		if err := metaClient.Shutdown(); err != nil && m.logger != nil {
+			m.logger.WithError(err).Warn("Failed to shutdown writable metadata client after root initialization")
+		}
+	}()
+	if _, err := metaClient.Load(true); err != nil {
+		return 0, fmt.Errorf("load writable metadata: %w", err)
+	}
+
+	return ensureVolumeRoot(metaClient, path)
+}
+
+func lookupVolumeRoot(metaClient volumeRootMeta, path string) (meta.Ino, error) {
+	return resolveVolumeRoot(metaClient, path, false)
+}
+
 // Use meta client directly to create the internal root path.
 // This avoids FUSE/VFS semantics (handles/permissions) and keeps it
 // consistent with snapshot operations which also use meta clients.
-func ensureVolumeRoot(metaClient meta.Meta, path string) (meta.Ino, error) {
+func ensureVolumeRoot(metaClient volumeRootMeta, path string) (meta.Ino, error) {
+	return resolveVolumeRoot(metaClient, path, true)
+}
+
+func resolveVolumeRoot(metaClient volumeRootMeta, path string, createMissing bool) (meta.Ino, error) {
 	if metaClient == nil {
 		return 0, fmt.Errorf("meta client is nil")
 	}
@@ -363,6 +422,9 @@ func ensureVolumeRoot(metaClient meta.Meta, path string) (meta.Ino, error) {
 		var next meta.Ino
 		errno := metaClient.Lookup(jfsCtx, current, part, &next, &attr, false)
 		if errno == syscall.ENOENT {
+			if !createMissing {
+				return 0, fmt.Errorf("%w: %s", errVolumeRootNotFound, part)
+			}
 			errno = metaClient.Mkdir(jfsCtx, current, part, 0o755, 0, 0, &next, &attr)
 			if errno != 0 && errno != syscall.EEXIST {
 				return 0, fmt.Errorf("mkdir %s: %s", part, errno.Error())

--- a/storage-proxy/pkg/volume/manager_test.go
+++ b/storage-proxy/pkg/volume/manager_test.go
@@ -2,9 +2,11 @@ package volume
 
 import (
 	"context"
+	"syscall"
 	"testing"
 	"time"
 
+	"github.com/juicedata/juicefs/pkg/meta"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
 	"github.com/sirupsen/logrus"
 )
@@ -259,6 +261,132 @@ func TestAcquireDirectVolumeFileMount_ReusesSessionUntilIdleCleanup(t *testing.T
 	if _, ok := mgr.volumes[volumeID]; ok {
 		t.Fatalf("volume %s should be unmounted after idle cleanup", volumeID)
 	}
+}
+
+func TestResolveMountRootReadOnlyUsesWritableFallbackForMissingRoot(t *testing.T) {
+	readOnlyMeta := newFakeVolumeRootMeta()
+	fallbackCalled := false
+	var fallbackPath string
+
+	rootInode, err := resolveMountRoot(readOnlyMeta, "vol-rox", true, func(path string) (meta.Ino, error) {
+		fallbackCalled = true
+		fallbackPath = path
+		return meta.Ino(42), nil
+	})
+	if err != nil {
+		t.Fatalf("resolveMountRoot returned error: %v", err)
+	}
+	if rootInode != meta.Ino(42) {
+		t.Fatalf("root inode = %d, want 42", rootInode)
+	}
+	if !fallbackCalled || fallbackPath != "vol-rox" {
+		t.Fatalf("writable fallback called=%v path=%q, want vol-rox", fallbackCalled, fallbackPath)
+	}
+	if readOnlyMeta.mkdirCalls != 0 {
+		t.Fatalf("read-only meta mkdir calls = %d, want 0", readOnlyMeta.mkdirCalls)
+	}
+}
+
+func TestResolveMountRootReadOnlyUsesExistingRoot(t *testing.T) {
+	readOnlyMeta := newFakeVolumeRootMeta()
+	readOnlyMeta.addChild(meta.RootInode, "vol-rox", meta.Ino(43))
+	fallbackCalled := false
+
+	rootInode, err := resolveMountRoot(readOnlyMeta, "vol-rox", true, func(path string) (meta.Ino, error) {
+		fallbackCalled = true
+		return 0, nil
+	})
+	if err != nil {
+		t.Fatalf("resolveMountRoot returned error: %v", err)
+	}
+	if rootInode != meta.Ino(43) {
+		t.Fatalf("root inode = %d, want 43", rootInode)
+	}
+	if fallbackCalled {
+		t.Fatal("writable fallback should not be called when read-only lookup finds the root")
+	}
+	if readOnlyMeta.mkdirCalls != 0 {
+		t.Fatalf("read-only meta mkdir calls = %d, want 0", readOnlyMeta.mkdirCalls)
+	}
+}
+
+func TestResolveMountRootReadWriteCreatesMissingRoot(t *testing.T) {
+	writableMeta := newFakeVolumeRootMeta()
+
+	rootInode, err := resolveMountRoot(writableMeta, "vol-rwo", false, nil)
+	if err != nil {
+		t.Fatalf("resolveMountRoot returned error: %v", err)
+	}
+	if rootInode == 0 {
+		t.Fatal("root inode = 0, want created inode")
+	}
+	if writableMeta.mkdirCalls != 1 {
+		t.Fatalf("mkdir calls = %d, want 1", writableMeta.mkdirCalls)
+	}
+}
+
+type fakeVolumeRootMeta struct {
+	children   map[meta.Ino]map[string]meta.Ino
+	nextInode  meta.Ino
+	mkdirCalls int
+	mkdirErr   syscall.Errno
+}
+
+func newFakeVolumeRootMeta() *fakeVolumeRootMeta {
+	return &fakeVolumeRootMeta{
+		children:  map[meta.Ino]map[string]meta.Ino{meta.RootInode: {}},
+		nextInode: meta.RootInode,
+	}
+}
+
+func (f *fakeVolumeRootMeta) addChild(parent meta.Ino, name string, inode meta.Ino) {
+	if f.children[parent] == nil {
+		f.children[parent] = make(map[string]meta.Ino)
+	}
+	f.children[parent][name] = inode
+	if f.children[inode] == nil {
+		f.children[inode] = make(map[string]meta.Ino)
+	}
+	if inode > f.nextInode {
+		f.nextInode = inode
+	}
+}
+
+func (f *fakeVolumeRootMeta) Lookup(_ meta.Context, parent meta.Ino, name string, inode *meta.Ino, attr *meta.Attr, _ bool) syscall.Errno {
+	children := f.children[parent]
+	if len(children) == 0 {
+		return syscall.ENOENT
+	}
+	next, ok := children[name]
+	if !ok {
+		return syscall.ENOENT
+	}
+	*inode = next
+	if attr != nil {
+		attr.Typ = meta.TypeDirectory
+	}
+	return 0
+}
+
+func (f *fakeVolumeRootMeta) Mkdir(_ meta.Context, parent meta.Ino, name string, _ uint16, _ uint16, _ uint8, inode *meta.Ino, attr *meta.Attr) syscall.Errno {
+	f.mkdirCalls++
+	if f.mkdirErr != 0 {
+		return f.mkdirErr
+	}
+	if f.children[parent] == nil {
+		f.children[parent] = make(map[string]meta.Ino)
+	}
+	if existing, ok := f.children[parent][name]; ok {
+		*inode = existing
+		return syscall.EEXIST
+	}
+	f.nextInode++
+	f.addChild(parent, name, f.nextInode)
+	*inode = f.nextInode
+	if attr != nil {
+		attr.Typ = meta.TypeDirectory
+	}
+	return 0
 }
 
 func TestCleanupIdleDirectVolumeFileMounts_SkipsInflightRequests(t *testing.T) {

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -515,6 +515,7 @@ func assertTemplateNamespaceIngressBaselineLifecycle(env *framework.ScenarioEnv,
 		templateNamespaceBaselineDenyPolicyName,
 		templateNamespaceBaselineAllowPolicyName,
 	} {
+		originalUID := templateNamespaceNetworkPolicyUID(env, templateNamespace, policyName)
 		Expect(framework.Kubectl(
 			env.TestCtx.Context,
 			env.Config.Kubeconfig,
@@ -525,14 +526,7 @@ func assertTemplateNamespaceIngressBaselineLifecycle(env *framework.ScenarioEnv,
 			templateNamespace,
 			"--ignore-not-found=false",
 		)).To(Succeed())
-		Expect(framework.KubectlWaitForDelete(
-			env.TestCtx.Context,
-			env.Config.Kubeconfig,
-			templateNamespace,
-			"networkpolicy",
-			policyName,
-			"30s",
-		)).To(Succeed())
+		assertTemplateNamespaceNetworkPolicyOriginalUIDGoneEventually(env, templateNamespace, policyName, originalUID)
 	}
 
 	updated := *created
@@ -547,6 +541,50 @@ func assertTemplateNamespaceIngressBaselineLifecycle(env *framework.ScenarioEnv,
 	Expect(*updatedResp.Spec.Description).To(Equal(desc))
 
 	assertTemplateNamespaceBaselinePoliciesEventually(env, templateNamespace)
+}
+
+func templateNamespaceNetworkPolicyUID(env *framework.ScenarioEnv, namespace, policyName string) string {
+	output, err := framework.KubectlOutput(
+		env.TestCtx.Context,
+		env.Config.Kubeconfig,
+		"get",
+		"networkpolicy",
+		policyName,
+		"--namespace",
+		namespace,
+		"-o",
+		"jsonpath={.metadata.uid}",
+	)
+	Expect(err).NotTo(HaveOccurred())
+	uid := strings.TrimSpace(output)
+	Expect(uid).NotTo(BeEmpty(), "expected networkpolicy %s/%s to have a uid", namespace, policyName)
+	return uid
+}
+
+func assertTemplateNamespaceNetworkPolicyOriginalUIDGoneEventually(env *framework.ScenarioEnv, namespace, policyName, originalUID string) {
+	Eventually(func() error {
+		output, err := framework.KubectlOutput(
+			env.TestCtx.Context,
+			env.Config.Kubeconfig,
+			"get",
+			"networkpolicy",
+			policyName,
+			"--namespace",
+			namespace,
+			"--ignore-not-found=true",
+			"-o",
+			"jsonpath={.metadata.uid}",
+		)
+		if err != nil {
+			return err
+		}
+
+		currentUID := strings.TrimSpace(output)
+		if currentUID == originalUID {
+			return fmt.Errorf("networkpolicy %s/%s still has original uid %s", namespace, policyName, originalUID)
+		}
+		return nil
+	}).WithTimeout(30 * time.Second).WithPolling(1 * time.Second).Should(Succeed())
 }
 
 func assertTemplateNamespaceBaselinePoliciesEventually(env *framework.ScenarioEnv, namespace string) {


### PR DESCRIPTION
## Summary
- Resolve existing ROX volume roots with a read-only metadata lookup before mounting.
- Initialize missing ROX logical roots through a short-lived writable metadata client, while keeping the mounted volume context read-only.
- Add volume manager tests for read-only existing roots, read-only fallback initialization, and read-write creation.

Closes #187

## Testing
- go test ./storage-proxy/pkg/volume -count=1
- make proto
- go test ./storage-proxy/pkg/volume ./storage-proxy/pkg/grpc ./storage-proxy/pkg/http ./storage-proxy/pkg/snapshot -count=1
- pre-push hook: make manifests, make proto, make apispec, go fmt ./..., go mod tidy, go mod vendor, golangci-lint run ./...
