### PR TITLE
Fix REPL WebSocket input newline handling

### DIFF
--- a/manager/procd/pkg/http/handlers/context.go
+++ b/manager/procd/pkg/http/handlers/context.go
@@ -869,13 +869,8 @@ func (h *ContextHandler) WebSocket(w http.ResponseWriter, r *http.Request) {
 			case "input":
 				setPendingRequestID(msg.RequestID)
 				if msg.Data != "" {
-					input := msg.Data
-					if ctx.Type == process.ProcessTypeREPL {
-						if !strings.HasSuffix(input, "\n") && !strings.HasSuffix(input, "\r") {
-							input += "\n"
-						}
-					}
-					_ = h.manager.WriteInput(id, []byte(input))
+					// WebSocket input is a byte stream; callers include newlines when submitting a line.
+					_ = h.manager.WriteInput(id, []byte(msg.Data))
 				}
 			case "resize":
 				if msg.Rows == 0 || msg.Cols == 0 {

--- a/manager/procd/pkg/http/handlers/context_test.go
+++ b/manager/procd/pkg/http/handlers/context_test.go
@@ -444,3 +444,46 @@ func TestWebSocketSendsProcessDoneMessage(t *testing.T) {
 		t.Fatalf("state = %v, want %q", got, process.ProcessStateCrashed)
 	}
 }
+
+func TestWebSocketInputPassesREPLBytesWithoutAppendingNewline(t *testing.T) {
+	outputCh := make(chan process.ProcessOutput)
+	written := make(chan string, 1)
+	proc := &fakeProcess{
+		outputCh: outputCh,
+		onWrite: func(data []byte) {
+			written <- string(data)
+		},
+	}
+	handler, ctx := newHandlerWithContext(proc, process.ProcessTypeREPL)
+
+	router := mux.NewRouter()
+	router.HandleFunc("/contexts/{id}/ws", handler.WebSocket)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	wsURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("url.Parse() error = %v", err)
+	}
+	wsURL.Scheme = "ws"
+	wsURL.Path = "/contexts/" + ctx.ID + "/ws"
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL.String(), nil)
+	if err != nil {
+		t.Fatalf("Dial() error = %v", err)
+	}
+	defer conn.Close()
+
+	if err := conn.WriteJSON(wsControlMessage{Type: "input", Data: "e"}); err != nil {
+		t.Fatalf("WriteJSON() error = %v", err)
+	}
+
+	select {
+	case got := <-written:
+		if got != "e" {
+			t.Fatalf("input = %q, want %q", got, "e")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for WebSocket input")
+	}
+}

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -1644,6 +1644,7 @@ paths:
     post:
       tags: [contexts]
       summary: Send input to context
+      description: Writes input to the context stdin exactly as provided. For REPL contexts, include a trailing newline to submit a line for execution.
       security:
         - bearerAuth: []
       x-upstream-service: procd
@@ -1668,7 +1669,7 @@ paths:
     post:
       tags: [contexts]
       summary: Execute context input (sync)
-      description: Sends input and blocks until the context completes or times out.
+      description: Sends input and blocks until the context completes or times out. For REPL contexts, the server appends a trailing newline when the input does not already end in \n or \r.
       security:
         - bearerAuth: []
       x-upstream-service: procd
@@ -1761,6 +1762,7 @@ paths:
       summary: Context WebSocket (I/O)
       description: |
         Upgrades to WebSocket for streaming I/O.
+        WebSocket input data is written to stdin exactly as provided; include "\n" when submitting a REPL line.
         Client messages (JSON):
         - { "type": "input", "data": "ls\n", "request_id": "req-1" }
         - { "type": "resize", "rows": 24, "cols": 80 }
@@ -4495,6 +4497,7 @@ components:
       properties:
         data:
           type: string
+          description: Input bytes encoded as a string. The /input endpoint writes this value exactly as provided. The /exec endpoint appends a trailing newline for REPL contexts when missing.
       required: [data]
     ContextExecResponse:
       type: object
@@ -4709,6 +4712,7 @@ components:
           enum: [input]
         data:
           type: string
+          description: Input bytes encoded as a string. The WebSocket endpoint writes this value exactly as provided and does not append a newline.
         request_id:
           type: string
       required: [type]

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -696,6 +696,7 @@ type ContextExecResponse struct {
 
 // ContextInputRequest defines model for ContextInputRequest.
 type ContextInputRequest struct {
+	// Data Input bytes encoded as a string. The /input endpoint writes this value exactly as provided. The /exec endpoint appends a trailing newline for REPL contexts when missing.
 	Data string `json:"data"`
 }
 

--- a/skills/sandbox0/references/docs-src/sandbox/contexts/page.mdx
+++ b/skills/sandbox0/references/docs-src/sandbox/contexts/page.mdx
@@ -649,7 +649,7 @@ print(f"Context restarted: {result.running}")`
 
 ### Send Input
 
-Send input to a context's stdin.
+Send input to a context's stdin. The data is written exactly as provided. For REPL contexts, include a trailing newline when you want the REPL to execute the line.
 
 <Endpoint method="POST">
 /api/v1/sandboxes/{'{id}'}/contexts/{'{ctx_id}'}/input
@@ -660,7 +660,7 @@ Send input to a context's stdin.
     {
       label: "Go",
       language: "go",
-      code: `_, err = sandbox.ContextInput(ctx, ctxResp.ID, "print('hello')")
+      code: `_, err = sandbox.ContextInput(ctx, ctxResp.ID, "print('hello')\\n")
 if err != nil {
     log.Fatal(err)
 }`
@@ -668,7 +668,7 @@ if err != nil {
     {
       label: "Python",
       language: "python",
-      code: `result = sandbox.context_input(context.id, "print('hello')")
+      code: `result = sandbox.context_input(context.id, "print('hello')\\n")
 print(f"Context input: {result.success}")`
     },
     {
@@ -837,7 +837,7 @@ console.log('Context deleted');`
 
 ## WebSocket Streaming
 
-For real-time I/O, connect to a context via WebSocket.
+For real-time I/O, connect to a context via WebSocket. WebSocket input is a byte stream: `data` is written exactly as provided, so include `\n` when submitting a REPL line.
 
 <Endpoint method="GET">
 /api/v1/sandboxes/{'{id}'}/contexts/{'{ctx_id}'}/ws
@@ -975,7 +975,7 @@ await outputPromise;`
 
 ## Exec (Synchronous Execution)
 
-Execute input and wait for completion.
+Execute input and wait for completion. For REPL contexts, the server appends a trailing newline when the input does not already end in `\n` or `\r`.
 
 <Endpoint method="POST">
 /api/v1/sandboxes/{'{id}'}/contexts/{'{ctx_id}'}/exec
@@ -995,13 +995,13 @@ fmt.Print(execResult.OutputRaw)`
     {
       label: "Python",
       language: "python",
-      code: `result = sandbox.context_exec(ctx.id, "print(1 + 2)\\n")
+      code: `result = sandbox.context_exec(ctx.id, "print(1 + 2)")
 print(result.output_raw, end="")`
     },
     {
       label: "TypeScript",
       language: "typescript",
-      code: `const execResult = await sandbox.contextExec(ctx.id, "print(1 + 2)\\n");
+      code: `const execResult = await sandbox.contextExec(ctx.id, "print(1 + 2)");
 process.stdout.write(execResult.outputRaw);`
     },
     {


### PR DESCRIPTION
## Summary
- Treat context WebSocket input as a byte stream and stop appending newlines to REPL input messages
- Keep /exec newline normalization for REPL contexts
- Document /input, /exec, and WebSocket input semantics in OpenAPI and sandbox docs
- Add a regression test for single-byte REPL WebSocket input

## Testing
- go test ./manager/procd/pkg/http/handlers ./ssh-gateway/pkg/server ./manager/procd/pkg/process/... -count=1
- make -C sandbox0 apispec
- git -C sandbox0 diff --check
- sandbox0 pre-push hook: make manifests, make proto, make apispec, go fmt ./..., go mod tidy, go mod vendor, golangci-lint run ./...