### PR TITLE
Scope team slugs to owner

### DIFF
--- a/pkg/gateway/identity/team_repository_test.go
+++ b/pkg/gateway/identity/team_repository_test.go
@@ -1,0 +1,42 @@
+package identity
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestTeamRepositoryScopesSlugUniquenessToOwner(t *testing.T) {
+	pool, _ := newGatewayIdentityTestPool(t)
+	if pool == nil {
+		return
+	}
+
+	ctx := context.Background()
+	repo := NewRepository(pool)
+	ownerA := &User{Email: "team-owner-a@example.com", Name: "Owner A"}
+	ownerB := &User{Email: "team-owner-b@example.com", Name: "Owner B"}
+	if err := repo.CreateUser(ctx, ownerA); err != nil {
+		t.Fatalf("create owner A: %v", err)
+	}
+	if err := repo.CreateUser(ctx, ownerB); err != nil {
+		t.Fatalf("create owner B: %v", err)
+	}
+
+	ownerAID := ownerA.ID
+	ownerBID := ownerB.ID
+	teamA := &Team{Name: "GCP US East 4", Slug: "gcp-us-east-4", OwnerID: &ownerAID}
+	if err := repo.CreateTeam(ctx, teamA); err != nil {
+		t.Fatalf("create team A: %v", err)
+	}
+
+	teamB := &Team{Name: "GCP US East 4", Slug: "gcp-us-east-4", OwnerID: &ownerBID}
+	if err := repo.CreateTeam(ctx, teamB); err != nil {
+		t.Fatalf("create team B with same slug for another owner: %v", err)
+	}
+
+	duplicate := &Team{Name: "Duplicate", Slug: "gcp-us-east-4", OwnerID: &ownerAID}
+	if err := repo.CreateTeam(ctx, duplicate); !errors.Is(err, ErrTeamAlreadyExists) {
+		t.Fatalf("duplicate owner slug error = %v, want %v", err, ErrTeamAlreadyExists)
+	}
+}

--- a/pkg/gateway/migrations/00001_init_schema.sql
+++ b/pkg/gateway/migrations/00001_init_schema.sql
@@ -21,7 +21,7 @@ CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
 CREATE TABLE IF NOT EXISTS teams (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     name VARCHAR(255) NOT NULL,
-    slug VARCHAR(255) UNIQUE,
+    slug VARCHAR(255),
     owner_id UUID REFERENCES users(id) ON DELETE SET NULL,
     home_region_id TEXT,
     created_at TIMESTAMPTZ DEFAULT NOW(),
@@ -30,6 +30,7 @@ CREATE TABLE IF NOT EXISTS teams (
 
 CREATE INDEX IF NOT EXISTS idx_teams_owner_id ON teams(owner_id);
 CREATE INDEX IF NOT EXISTS idx_teams_slug ON teams(slug);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_teams_owner_slug ON teams(owner_id, slug);
 CREATE INDEX IF NOT EXISTS idx_teams_home_region_id ON teams(home_region_id);
 
 -- Team members table
@@ -191,6 +192,7 @@ DROP INDEX IF EXISTS idx_user_identities_user_id;
 DROP INDEX IF EXISTS idx_team_members_user_id;
 DROP INDEX IF EXISTS idx_team_members_team_id;
 DROP INDEX IF EXISTS idx_teams_home_region_id;
+DROP INDEX IF EXISTS idx_teams_owner_slug;
 DROP INDEX IF EXISTS idx_teams_slug;
 DROP INDEX IF EXISTS idx_teams_owner_id;
 DROP INDEX IF EXISTS idx_users_email;

--- a/pkg/gateway/migrations/00001_init_schema.sql
+++ b/pkg/gateway/migrations/00001_init_schema.sql
@@ -21,7 +21,7 @@ CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
 CREATE TABLE IF NOT EXISTS teams (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     name VARCHAR(255) NOT NULL,
-    slug VARCHAR(255),
+    slug VARCHAR(255) UNIQUE,
     owner_id UUID REFERENCES users(id) ON DELETE SET NULL,
     home_region_id TEXT,
     created_at TIMESTAMPTZ DEFAULT NOW(),
@@ -30,7 +30,6 @@ CREATE TABLE IF NOT EXISTS teams (
 
 CREATE INDEX IF NOT EXISTS idx_teams_owner_id ON teams(owner_id);
 CREATE INDEX IF NOT EXISTS idx_teams_slug ON teams(slug);
-CREATE UNIQUE INDEX IF NOT EXISTS idx_teams_owner_slug ON teams(owner_id, slug);
 CREATE INDEX IF NOT EXISTS idx_teams_home_region_id ON teams(home_region_id);
 
 -- Team members table
@@ -192,7 +191,6 @@ DROP INDEX IF EXISTS idx_user_identities_user_id;
 DROP INDEX IF EXISTS idx_team_members_user_id;
 DROP INDEX IF EXISTS idx_team_members_team_id;
 DROP INDEX IF EXISTS idx_teams_home_region_id;
-DROP INDEX IF EXISTS idx_teams_owner_slug;
 DROP INDEX IF EXISTS idx_teams_slug;
 DROP INDEX IF EXISTS idx_teams_owner_id;
 DROP INDEX IF EXISTS idx_users_email;

--- a/pkg/gateway/migrations/00006_scope_team_slugs_by_owner.sql
+++ b/pkg/gateway/migrations/00006_scope_team_slugs_by_owner.sql
@@ -1,0 +1,6 @@
+-- Scope human-readable team slugs to their owning user instead of the global
+-- gateway database. Team IDs remain the authorization boundary; slugs are only
+-- a user-facing handle.
+ALTER TABLE teams DROP CONSTRAINT IF EXISTS teams_slug_key;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_teams_owner_slug ON teams(owner_id, slug);

--- a/pkg/gateway/migrations/00006_scope_team_slugs_by_owner.sql
+++ b/pkg/gateway/migrations/00006_scope_team_slugs_by_owner.sql
@@ -1,6 +1,29 @@
--- Scope human-readable team slugs to their owning user instead of the global
--- gateway database. Team IDs remain the authorization boundary; slugs are only
--- a user-facing handle.
-ALTER TABLE teams DROP CONSTRAINT IF EXISTS teams_slug_key;
+-- +goose Up
+ALTER TABLE IF EXISTS teams
+    DROP CONSTRAINT IF EXISTS teams_slug_key;
 
-CREATE UNIQUE INDEX IF NOT EXISTS idx_teams_owner_slug ON teams(owner_id, slug);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_teams_owner_slug
+    ON teams(owner_id, slug)
+    WHERE slug IS NOT NULL;
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_teams_owner_slug;
+
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM teams
+        WHERE slug IS NOT NULL
+        GROUP BY slug
+        HAVING COUNT(*) > 1
+    ) THEN
+        RAISE EXCEPTION 'cannot restore globally unique team slugs while duplicate slugs exist';
+    END IF;
+END;
+$$;
+-- +goose StatementEnd
+
+ALTER TABLE IF EXISTS teams
+    ADD CONSTRAINT teams_slug_key UNIQUE (slug);


### PR DESCRIPTION
## Summary
- Replace the global `teams.slug` unique constraint with an owner-scoped unique index.
- Add an upgrade migration for existing gateway databases.
- Add repository coverage for same-slug teams owned by different users.

Closes #190

## Testing
- `go test ./pkg/gateway/identity ./pkg/gateway/http/handlers ./pkg/gateway/public -count=1`
- pre-push hook completed: `make manifests`, `make proto`, `make apispec`, `go fmt ./...`, `go mod tidy`, `go mod vendor`, `golangci-lint run ./...`