### PR TITLE
Fix idle pod claim race during template rollout

### DIFF
--- a/manager/pkg/controller/pool_manager.go
+++ b/manager/pkg/controller/pool_manager.go
@@ -92,7 +92,7 @@ func (pm *PoolManager) ReconcilePool(ctx context.Context, template *v1alpha1.San
 		zap.Int32("minIdle", template.Spec.Pool.MinIdle),
 	)
 
-	desiredTemplateHash, err := templateSpecHash(template)
+	desiredTemplateHash, err := TemplateSpecHash(template)
 	if err != nil {
 		return fmt.Errorf("compute template hash: %w", err)
 	}
@@ -162,7 +162,7 @@ func (pm *PoolManager) getOrCreateReplicaSet(ctx context.Context, template *v1al
 
 	// Create new ReplicaSet
 	pm.logger.Info("Creating new ReplicaSet", zap.String("name", rsName))
-	hash, err := templateSpecHash(template)
+	hash, err := TemplateSpecHash(template)
 	if err != nil {
 		return nil, fmt.Errorf("compute template hash: %w", err)
 	}
@@ -329,7 +329,8 @@ func (pm *PoolManager) deleteStaleIdlePodWithRetry(ctx context.Context, namespac
 	return false, nil
 }
 
-func templateSpecHash(template *v1alpha1.SandboxTemplate) (string, error) {
+// TemplateSpecHash returns the pod spec hash used to identify current idle pods.
+func TemplateSpecHash(template *v1alpha1.SandboxTemplate) (string, error) {
 	podSpec := v1alpha1.BuildPodSpec(template)
 	payload := struct {
 		PodSpec corev1.PodSpec `json:"podSpec"`

--- a/manager/pkg/controller/pool_manager_test.go
+++ b/manager/pkg/controller/pool_manager_test.go
@@ -220,7 +220,7 @@ sandbox_pod_placement:
 `)
 	t.Setenv("CONFIG_PATH", configA)
 
-	hashA, err := templateSpecHash(template)
+	hashA, err := TemplateSpecHash(template)
 	require.NoError(t, err)
 
 	configB := writeManagerConfig(t, `
@@ -231,7 +231,7 @@ sandbox_pod_placement:
 `)
 	t.Setenv("CONFIG_PATH", configB)
 
-	hashB, err := templateSpecHash(template)
+	hashB, err := TemplateSpecHash(template)
 	require.NoError(t, err)
 
 	assert.NotEqual(t, hashA, hashB)

--- a/manager/pkg/service/sandbox_service.go
+++ b/manager/pkg/service/sandbox_service.go
@@ -642,7 +642,11 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 // claimIdlePod claims an idle pod from the pool
 func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.SandboxTemplate, req *ClaimRequest) (*corev1.Pod, error) {
 	var claimedPod *corev1.Pod
-	err := retry.OnError(claimIdlePodBackoff, k8serrors.IsConflict, func() error {
+	desiredTemplateHash, err := controller.TemplateSpecHash(template)
+	if err != nil {
+		return nil, fmt.Errorf("compute template hash: %w", err)
+	}
+	err = retry.OnError(claimIdlePodBackoff, k8serrors.IsConflict, func() error {
 		// Get all idle pods for this template
 		pods, listErr := s.podLister.Pods(template.Namespace).List(labels.SelectorFromSet(map[string]string{
 			controller.LabelTemplateID: template.Name,
@@ -655,7 +659,7 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 		// Filter hot-claimable pods to Kubernetes-ready instances only.
 		var readyPods []*corev1.Pod
 		for _, pod := range pods {
-			if controller.IsPodReady(pod) && s.podDataPlaneReady(pod) {
+			if s.isHotClaimableIdlePod(pod, desiredTemplateHash) {
 				readyPods = append(readyPods, pod)
 			}
 		}
@@ -729,6 +733,9 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 					zap.Error(rollbackErr),
 				)
 			}
+			if isIdlePodLostDuringClaim(updateErr) {
+				return errNoIdlePod
+			}
 			return updateErr
 		}
 
@@ -753,6 +760,28 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 		return nil, err
 	}
 	return claimedPod, nil
+}
+
+func (s *SandboxService) isHotClaimableIdlePod(pod *corev1.Pod, desiredTemplateHash string) bool {
+	if pod == nil || pod.DeletionTimestamp != nil {
+		return false
+	}
+	if pod.Annotations[controller.AnnotationTemplateSpecHash] != desiredTemplateHash {
+		return false
+	}
+	return controller.IsPodReady(pod) && s.podDataPlaneReady(pod)
+}
+
+func isIdlePodLostDuringClaim(err error) bool {
+	if k8serrors.IsNotFound(err) {
+		return true
+	}
+	if !k8serrors.IsInvalid(err) {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "metadata.finalizers") &&
+		strings.Contains(msg, "no new finalizers can be added if the object is being deleted")
 }
 
 // createNewPod creates a new pod for cold start

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -23,9 +23,12 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/sandboxprobe"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	corelisters "k8s.io/client-go/listers/core/v1"
+	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -90,6 +93,93 @@ func TestClaimIdlePodClaimsReadyPod(t *testing.T) {
 	}
 	if got := pod.Labels[controller.LabelPoolType]; got != controller.PoolTypeActive {
 		t.Fatalf("pool-type = %q, want %q", got, controller.PoolTypeActive)
+	}
+}
+
+func TestClaimIdlePodRequiresCurrentTemplateHash(t *testing.T) {
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "template-a",
+			Namespace: "ns-a",
+		},
+	}
+	readyPod := newClaimTestPod("ns-a", "idle-ready", "template-a", true)
+	readyPod.Annotations[controller.AnnotationTemplateSpecHash] = "stale"
+
+	client := fake.NewSimpleClientset(readyPod.DeepCopy())
+	svc := &SandboxService{
+		k8sClient: client,
+		podLister: newClaimTestPodLister(t, readyPod),
+		clock:     systemTime{},
+		logger:    zap.NewNop(),
+	}
+
+	pod, err := svc.claimIdlePod(context.Background(), template, &ClaimRequest{TeamID: "team-a", UserID: "user-a"})
+	if err != nil {
+		t.Fatalf("claimIdlePod() error = %v", err)
+	}
+	if pod != nil {
+		t.Fatalf("claimIdlePod() = %s, want nil for stale template hash", pod.Name)
+	}
+}
+
+func TestClaimIdlePodSkipsDeletingPod(t *testing.T) {
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "template-a",
+			Namespace: "ns-a",
+		},
+	}
+	readyPod := newClaimTestPod("ns-a", "idle-ready", "template-a", true)
+	deletedAt := metav1.NewTime(time.Now().UTC())
+	readyPod.DeletionTimestamp = &deletedAt
+
+	client := fake.NewSimpleClientset(readyPod.DeepCopy())
+	svc := &SandboxService{
+		k8sClient: client,
+		podLister: newClaimTestPodLister(t, readyPod),
+		clock:     systemTime{},
+		logger:    zap.NewNop(),
+	}
+
+	pod, err := svc.claimIdlePod(context.Background(), template, &ClaimRequest{TeamID: "team-a", UserID: "user-a"})
+	if err != nil {
+		t.Fatalf("claimIdlePod() error = %v", err)
+	}
+	if pod != nil {
+		t.Fatalf("claimIdlePod() = %s, want nil for deleting pod", pod.Name)
+	}
+}
+
+func TestClaimIdlePodFallsBackWhenPodStartsDeletingDuringClaim(t *testing.T) {
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "template-a",
+			Namespace: "ns-a",
+		},
+	}
+	readyPod := newClaimTestPod("ns-a", "idle-ready", "template-a", true)
+
+	client := fake.NewSimpleClientset(readyPod.DeepCopy())
+	client.PrependReactor("update", "pods", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, &apierrors.StatusError{ErrStatus: metav1.Status{
+			Reason:  metav1.StatusReasonInvalid,
+			Message: `Pod "idle-ready" is invalid: metadata.finalizers: Forbidden: no new finalizers can be added if the object is being deleted, found new finalizers []string{"sandbox0.ai/sandbox-cleanup"}`,
+		}}
+	})
+	svc := &SandboxService{
+		k8sClient: client,
+		podLister: newClaimTestPodLister(t, readyPod),
+		clock:     systemTime{},
+		logger:    zap.NewNop(),
+	}
+
+	pod, err := svc.claimIdlePod(context.Background(), template, &ClaimRequest{TeamID: "team-a", UserID: "user-a"})
+	if err != nil {
+		t.Fatalf("claimIdlePod() error = %v", err)
+	}
+	if pod != nil {
+		t.Fatalf("claimIdlePod() = %s, want nil to trigger cold fallback", pod.Name)
 	}
 }
 
@@ -599,6 +689,9 @@ func newClaimTestPod(namespace, name, templateID string, ready bool) *corev1.Pod
 				controller.LabelTemplateID: templateID,
 				controller.LabelPoolType:   controller.PoolTypeIdle,
 			},
+			Annotations: map[string]string{
+				controller.AnnotationTemplateSpecHash: claimTestTemplateHash(templateID),
+			},
 			ResourceVersion: "1",
 		},
 		Status: corev1.PodStatus{
@@ -612,6 +705,13 @@ func newClaimTestPod(namespace, name, templateID string, ready bool) *corev1.Pod
 			},
 		},
 	}
+}
+
+func claimTestTemplateHash(templateID string) string {
+	hash, _ := controller.TemplateSpecHash(&v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: templateID},
+	})
+	return hash
 }
 
 func newClaimReadyTestPod(namespace, name, templateID string) *corev1.Pod {

--- a/pkg/naming/core.go
+++ b/pkg/naming/core.go
@@ -13,12 +13,12 @@ import (
 const (
 	dnsLabelMaxLen   = 63
 	podRandSuffixLen = 5
-	replicaSetMaxLen = dnsLabelMaxLen - 1 - podRandSuffixLen
 	// Exposure host label format: <sandboxName>--p<port>.
 	// Keep sandbox name shorter than full DNS label to reserve suffix budget.
 	exposurePortDelimiter = "--p"
 	maxPortDigits         = 5
 	sandboxNameMaxLen     = dnsLabelMaxLen - len(exposurePortDelimiter) - maxPortDigits
+	replicaSetMaxLen      = sandboxNameMaxLen - 1 - podRandSuffixLen
 	defaultClusterID      = "default"
 	nameHashLength        = 8
 	clusterKeyMaxLen      = 32

--- a/pkg/naming/naming_test.go
+++ b/pkg/naming/naming_test.go
@@ -34,6 +34,34 @@ func TestReplicasetAndSandboxNames(t *testing.T) {
 	}
 }
 
+func TestSandboxNameForLongTeamTemplateFitsExposureHostLabel(t *testing.T) {
+	templateName := TemplateNameForCluster(ScopeTeam, "team-a", "e2e-fullmode-rc-123456789")
+	sandboxName, err := SandboxName(DefaultClusterID, templateName, "abcde")
+	if err != nil {
+		t.Fatalf("SandboxName: %v", err)
+	}
+	if len(sandboxName) > sandboxNameMaxLen {
+		t.Fatalf("sandbox name too long: %d", len(sandboxName))
+	}
+	if _, err := BuildExposureHostLabel(sandboxName, 65535); err != nil {
+		t.Fatalf("BuildExposureHostLabel: %v", err)
+	}
+}
+
+func TestReplicasetNameFitsSandboxExposureBudget(t *testing.T) {
+	rsName, err := ReplicasetName(DefaultClusterID, strings.Repeat("long-template-", 8))
+	if err != nil {
+		t.Fatalf("ReplicasetName: %v", err)
+	}
+	maxReplicaSetNameForExposure := sandboxNameMaxLen - 1 - podRandSuffixLen
+	if len(rsName) > maxReplicaSetNameForExposure {
+		t.Fatalf("replicaset name too long for exposure-safe pods: %d > %d", len(rsName), maxReplicaSetNameForExposure)
+	}
+	if _, err := BuildExposureHostLabel(rsName+"-abcde", 65535); err != nil {
+		t.Fatalf("BuildExposureHostLabel: %v", err)
+	}
+}
+
 func TestExposureHostLabel(t *testing.T) {
 	sandboxName := "rs-mfwha2dbfzzsayjaomxwg2dbon2gc-zd0b8631-abcde"
 	label, err := BuildExposureHostLabel(sandboxName, 3000)

--- a/pkg/template/http/handlers.go
+++ b/pkg/template/http/handlers.go
@@ -240,6 +240,10 @@ func (h *Handler) CreateTemplate(c *gin.Context) {
 		spec.JSONError(c, http.StatusForbidden, spec.CodeForbidden, err.Error())
 		return
 	}
+	if err := validateTemplateClaimNameBudget(scope, teamID, req.TemplateID, req.Spec); err != nil {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
+		return
+	}
 
 	templateID := req.TemplateID
 
@@ -323,6 +327,10 @@ func (h *Handler) UpdateTemplate(c *gin.Context) {
 	}
 	if err := validateTemplateImagesForClaims(req.Spec, claims, h.PrivateRegistryHosts); err != nil {
 		spec.JSONError(c, http.StatusForbidden, spec.CodeForbidden, err.Error())
+		return
+	}
+	if err := validateTemplateClaimNameBudget(scope, teamID, templateID, req.Spec); err != nil {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
 		return
 	}
 

--- a/pkg/template/http/handlers_test.go
+++ b/pkg/template/http/handlers_test.go
@@ -673,6 +673,41 @@ func TestUpdateTemplate_RejectsImagePullPolicyForRegularTeam(t *testing.T) {
 	}
 }
 
+func TestCreateTemplate_RejectsUnclaimableNameBudget(t *testing.T) {
+	t.Parallel()
+
+	store := &testTemplateStore{}
+	h := &Handler{Store: store, Logger: zap.NewNop()}
+
+	router := gin.New()
+	router.Use(withClaims(&internalauth.Claims{IsSystem: true}))
+	router.POST("/api/v1/templates", h.CreateTemplate)
+
+	clusterID := strings.Repeat("a", naming.ClusterIDMaxLen+1)
+	body := []byte(`{
+		"template_id":"demo",
+		"spec":{
+			"clusterId":"` + clusterID + `",
+			"mainContainer":{"image":"ubuntu:22.04","resources":{"cpu":"1","memory":"4Gi"}},
+			"pool":{"minIdle":0,"maxIdle":1}
+		}
+	}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/templates", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusBadRequest, rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "cannot generate claimable sandbox names") {
+		t.Fatalf("expected claimable name budget error, got %s", rec.Body.String())
+	}
+	if store.createCalled {
+		t.Fatalf("expected create not called for unclaimable name budget")
+	}
+}
+
 func TestValidateTemplateSpecForClaims_WildcardPermissionRejected(t *testing.T) {
 	t.Parallel()
 
@@ -695,6 +730,30 @@ func TestValidateTemplateSpecForClaims_WildcardPermissionRejected(t *testing.T) 
 	})
 	if err == nil {
 		t.Fatalf("expected wildcard permission to be rejected")
+	}
+}
+
+func TestValidateTemplateClaimNameBudget_AllowsMaxLengthTemplateID(t *testing.T) {
+	t.Parallel()
+
+	err := validateTemplateClaimNameBudget(naming.ScopeTeam, "team-1", strings.Repeat("a", 255), validTemplateSpec())
+	if err != nil {
+		t.Fatalf("validateTemplateClaimNameBudget: %v", err)
+	}
+}
+
+func TestValidateTemplateClaimNameBudget_RejectsUnclaimableClusterID(t *testing.T) {
+	t.Parallel()
+
+	spec := validTemplateSpec()
+	clusterID := strings.Repeat("a", naming.ClusterIDMaxLen+1)
+	spec.ClusterId = &clusterID
+	err := validateTemplateClaimNameBudget(naming.ScopePublic, "", "demo", spec)
+	if err == nil {
+		t.Fatalf("expected unclaimable naming budget error")
+	}
+	if !strings.Contains(err.Error(), "cannot generate claimable sandbox names") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/pkg/template/http/template_validation.go
+++ b/pkg/template/http/template_validation.go
@@ -102,6 +102,19 @@ func validateTemplateSpec(spec v1alpha1.SandboxTemplateSpec) error {
 	return nil
 }
 
+func validateTemplateClaimNameBudget(scope, teamID, templateID string, spec v1alpha1.SandboxTemplateSpec) error {
+	clusterTemplateID := naming.TemplateNameForCluster(scope, teamID, templateID)
+	clusterID := naming.ClusterIDOrDefault(spec.ClusterId)
+	sandboxName, err := naming.SandboxName(clusterID, clusterTemplateID, strings.Repeat("a", 5))
+	if err != nil {
+		return fmt.Errorf("template_id cannot generate claimable sandbox names: %w", err)
+	}
+	if _, err := naming.BuildExposureHostLabel(sandboxName, 65535); err != nil {
+		return fmt.Errorf("template_id cannot generate claimable sandbox exposure labels: %w", err)
+	}
+	return nil
+}
+
 func validateWarmProcesses(processes []v1alpha1.WarmProcessSpec) error {
 	for i, proc := range processes {
 		field := fmt.Sprintf("spec.warmProcesses[%d]", i)

--- a/pkg/template/reconciler/multicluster.go
+++ b/pkg/template/reconciler/multicluster.go
@@ -147,6 +147,18 @@ func (r *MultiClusterReconciler) GetTemplateStatsAge(clusterID string) (time.Dur
 	return r.since(updatedAt), true
 }
 
+// GetTemplateStatsUpdatedAt returns the timestamp for the latest template stats snapshot.
+func (r *MultiClusterReconciler) GetTemplateStatsUpdatedAt(clusterID string) (time.Time, bool) {
+	r.statsMu.RLock()
+	defer r.statsMu.RUnlock()
+
+	updatedAt, ok := r.templateStatsAt[clusterID]
+	if !ok || updatedAt.IsZero() {
+		return time.Time{}, false
+	}
+	return updatedAt, true
+}
+
 // GetClusterSummary returns the cached cluster summary for a shard.
 func (r *MultiClusterReconciler) GetClusterSummary(clusterID string) (*ClusterSummary, bool) {
 	r.cacheMu.RLock()

--- a/scheduler/pkg/http/handlers_sandbox.go
+++ b/scheduler/pkg/http/handlers_sandbox.go
@@ -216,7 +216,7 @@ func (s *Server) selectClusterForTemplate(c *gin.Context, templateID, teamID str
 	clusterTemplateID := naming.TemplateNameForCluster(tpl.Scope, tpl.TeamID, tpl.TemplateID)
 	maxAge := s.cfg.ReconcileInterval.Duration * 2
 
-	selected, selectedBy := s.selectClusterByIdleWithAllocations(allocations, clusterMap, clusterTemplateID, maxAge)
+	selected, selectedBy := s.selectClusterByIdleWithAllocations(allocations, clusterMap, tpl, clusterTemplateID, maxAge)
 	if selected == nil {
 		selected = s.selectClusterByHeadroomWithAllocations(allocations, clusterMap, maxAge)
 		if selected != nil {
@@ -257,7 +257,7 @@ func (s *Server) selectClusterForTemplate(c *gin.Context, templateID, teamID str
 	return selected, tpl, selectedBy, nil
 }
 
-func (s *Server) selectClusterByIdleWithAllocations(allocations []*template.TemplateAllocation, clusterMap map[string]*template.Cluster, clusterTemplateID string, maxAge time.Duration) (*template.Cluster, string) {
+func (s *Server) selectClusterByIdleWithAllocations(allocations []*template.TemplateAllocation, clusterMap map[string]*template.Cluster, tpl *template.Template, clusterTemplateID string, maxAge time.Duration) (*template.Cluster, string) {
 	var selected *template.Cluster
 	var selectedAlloc *template.TemplateAllocation
 	var bestIdle int32 = -1
@@ -272,6 +272,16 @@ func (s *Server) selectClusterByIdleWithAllocations(allocations []*template.Temp
 		s.recordClusterSummaryAge(cluster.ClusterID)
 		if !ok || age > maxAge {
 			continue
+		}
+		cutoff, ok := idleStatsFreshAfter(tpl, alloc)
+		if !ok {
+			continue
+		}
+		if !cutoff.IsZero() {
+			statsUpdatedAt, ok := s.reconciler.GetTemplateStatsUpdatedAt(cluster.ClusterID)
+			if !ok || statsUpdatedAt.Before(cutoff) {
+				continue
+			}
 		}
 
 		idleCount, ok := s.reconciler.GetTemplateIdleCount(cluster.ClusterID, clusterTemplateID)
@@ -294,6 +304,22 @@ func (s *Server) selectClusterByIdleWithAllocations(allocations []*template.Temp
 		return nil, ""
 	}
 	return selected, "idle"
+}
+
+func idleStatsFreshAfter(tpl *template.Template, alloc *template.TemplateAllocation) (time.Time, bool) {
+	if tpl == nil {
+		return time.Time{}, true
+	}
+	if tpl.UpdatedAt.IsZero() {
+		if alloc != nil && alloc.LastSyncedAt != nil {
+			return *alloc.LastSyncedAt, true
+		}
+		return time.Time{}, true
+	}
+	if alloc == nil || alloc.LastSyncedAt == nil || alloc.LastSyncedAt.Before(tpl.UpdatedAt) {
+		return time.Time{}, false
+	}
+	return *alloc.LastSyncedAt, true
 }
 
 func (s *Server) selectClusterByHeadroomWithAllocations(allocations []*template.TemplateAllocation, clusterMap map[string]*template.Cluster, maxAge time.Duration) *template.Cluster {

--- a/scheduler/pkg/http/handlers_sandbox_test.go
+++ b/scheduler/pkg/http/handlers_sandbox_test.go
@@ -157,6 +157,106 @@ func TestSelectClusterForTemplateUsesHeadroomWhenIdleStatsAreStale(t *testing.T)
 	}
 }
 
+func TestSelectClusterForTemplateUsesHeadroomWhenIdleStatsPredateTemplateSync(t *testing.T) {
+	syncedAt := time.Date(2026, 4, 14, 16, 54, 3, 0, time.UTC)
+	tpl := newRoutingTemplate("tmpl-a")
+	tpl.UpdatedAt = syncedAt.Add(-time.Second)
+	clusterTemplateID := naming.TemplateNameForCluster(tpl.Scope, tpl.TeamID, tpl.TemplateID)
+	clusterAAlloc := newRoutingAllocation("cluster-a", 2, 4)
+	clusterAAlloc.LastSyncedAt = &syncedAt
+	server := newRoutingTestServer(
+		tpl,
+		[]*template.TemplateAllocation{
+			clusterAAlloc,
+			newRoutingAllocation("cluster-b", 2, 4),
+		},
+		[]*template.Cluster{
+			newRoutingCluster("cluster-a", 5),
+			newRoutingCluster("cluster-b", 1),
+		},
+		&fakeRoutingReconciler{
+			templateIdle: map[string]map[string]int32{
+				"cluster-a": {clusterTemplateID: 5},
+			},
+			templateStatsAge: map[string]time.Duration{
+				"cluster-a": time.Second,
+			},
+			templateStatsUpdatedAt: map[string]time.Time{
+				"cluster-a": syncedAt.Add(-time.Millisecond),
+			},
+			clusterSummaries: map[string]*templreconciler.ClusterSummary{
+				"cluster-a": {SandboxNodeCount: 1, TotalNodeCount: 1, TotalPodCount: 9},
+				"cluster-b": {SandboxNodeCount: 3, TotalNodeCount: 3, TotalPodCount: 10},
+			},
+			clusterSummaryAge: map[string]time.Duration{
+				"cluster-a": time.Second,
+				"cluster-b": time.Second,
+			},
+		},
+	)
+
+	selected, _, selectedBy, err := server.selectClusterForTemplate(newRoutingContext(), "tmpl-a", "team-a")
+	if err != nil {
+		t.Fatalf("selectClusterForTemplate() error = %v", err)
+	}
+	if selected == nil || selected.ClusterID != "cluster-b" {
+		t.Fatalf("selected cluster = %v, want cluster-b", clusterID(selected))
+	}
+	if selectedBy != "headroom" {
+		t.Fatalf("selectedBy = %q, want %q", selectedBy, "headroom")
+	}
+}
+
+func TestSelectClusterForTemplateUsesHeadroomWhenTemplateUpdateIsUnsynced(t *testing.T) {
+	syncedAt := time.Date(2026, 4, 14, 16, 54, 3, 0, time.UTC)
+	tpl := newRoutingTemplate("tmpl-a")
+	tpl.UpdatedAt = syncedAt.Add(time.Second)
+	clusterTemplateID := naming.TemplateNameForCluster(tpl.Scope, tpl.TeamID, tpl.TemplateID)
+	clusterAAlloc := newRoutingAllocation("cluster-a", 2, 4)
+	clusterAAlloc.LastSyncedAt = &syncedAt
+	server := newRoutingTestServer(
+		tpl,
+		[]*template.TemplateAllocation{
+			clusterAAlloc,
+			newRoutingAllocation("cluster-b", 2, 4),
+		},
+		[]*template.Cluster{
+			newRoutingCluster("cluster-a", 5),
+			newRoutingCluster("cluster-b", 1),
+		},
+		&fakeRoutingReconciler{
+			templateIdle: map[string]map[string]int32{
+				"cluster-a": {clusterTemplateID: 5},
+			},
+			templateStatsAge: map[string]time.Duration{
+				"cluster-a": time.Second,
+			},
+			templateStatsUpdatedAt: map[string]time.Time{
+				"cluster-a": syncedAt.Add(2 * time.Second),
+			},
+			clusterSummaries: map[string]*templreconciler.ClusterSummary{
+				"cluster-a": {SandboxNodeCount: 1, TotalNodeCount: 1, TotalPodCount: 9},
+				"cluster-b": {SandboxNodeCount: 3, TotalNodeCount: 3, TotalPodCount: 10},
+			},
+			clusterSummaryAge: map[string]time.Duration{
+				"cluster-a": time.Second,
+				"cluster-b": time.Second,
+			},
+		},
+	)
+
+	selected, _, selectedBy, err := server.selectClusterForTemplate(newRoutingContext(), "tmpl-a", "team-a")
+	if err != nil {
+		t.Fatalf("selectClusterForTemplate() error = %v", err)
+	}
+	if selected == nil || selected.ClusterID != "cluster-b" {
+		t.Fatalf("selected cluster = %v, want cluster-b", clusterID(selected))
+	}
+	if selectedBy != "headroom" {
+		t.Fatalf("selectedBy = %q, want %q", selectedBy, "headroom")
+	}
+}
+
 func TestSelectClusterForTemplateFallsBackToWeight(t *testing.T) {
 	tpl := newRoutingTemplate("tmpl-a")
 	server := newRoutingTestServer(
@@ -702,10 +802,11 @@ func (r *fakeRoutingClusterRepo) DeleteCluster(ctx context.Context, clusterID st
 }
 
 type fakeRoutingReconciler struct {
-	templateIdle      map[string]map[string]int32
-	templateStatsAge  map[string]time.Duration
-	clusterSummaries  map[string]*templreconciler.ClusterSummary
-	clusterSummaryAge map[string]time.Duration
+	templateIdle           map[string]map[string]int32
+	templateStatsAge       map[string]time.Duration
+	templateStatsUpdatedAt map[string]time.Time
+	clusterSummaries       map[string]*templreconciler.ClusterSummary
+	clusterSummaryAge      map[string]time.Duration
 }
 
 func (r *fakeRoutingReconciler) TriggerReconcile(ctx context.Context) {}
@@ -725,6 +826,14 @@ func (r *fakeRoutingReconciler) GetTemplateIdleCount(clusterID, templateID strin
 func (r *fakeRoutingReconciler) GetTemplateStatsAge(clusterID string) (time.Duration, bool) {
 	age, ok := r.templateStatsAge[clusterID]
 	return age, ok
+}
+
+func (r *fakeRoutingReconciler) GetTemplateStatsUpdatedAt(clusterID string) (time.Time, bool) {
+	if r.templateStatsUpdatedAt == nil {
+		return time.Time{}, false
+	}
+	updatedAt, ok := r.templateStatsUpdatedAt[clusterID]
+	return updatedAt, ok
 }
 
 func (r *fakeRoutingReconciler) GetClusterSummary(clusterID string) (*templreconciler.ClusterSummary, bool) {

--- a/scheduler/pkg/http/server.go
+++ b/scheduler/pkg/http/server.go
@@ -55,6 +55,7 @@ type Reconciler interface {
 	TriggerReconcile(ctx context.Context)
 	GetTemplateIdleCount(clusterID, templateID string) (int32, bool)
 	GetTemplateStatsAge(clusterID string) (time.Duration, bool)
+	GetTemplateStatsUpdatedAt(clusterID string) (time.Time, bool)
 	GetClusterSummary(clusterID string) (*templreconciler.ClusterSummary, bool)
 	GetClusterSummaryAge(clusterID string) (time.Duration, bool)
 }

--- a/scheduler/pkg/reconciler/reconciler.go
+++ b/scheduler/pkg/reconciler/reconciler.go
@@ -72,6 +72,11 @@ func (r *Reconciler) GetTemplateStatsAge(clusterID string) (time.Duration, bool)
 	return r.inner.GetTemplateStatsAge(clusterID)
 }
 
+// GetTemplateStatsUpdatedAt returns when the latest template stats snapshot was collected.
+func (r *Reconciler) GetTemplateStatsUpdatedAt(clusterID string) (time.Time, bool) {
+	return r.inner.GetTemplateStatsUpdatedAt(clusterID)
+}
+
 // GetClusterSummary returns the cached cluster summary for a shard.
 func (r *Reconciler) GetClusterSummary(clusterID string) (*templreconciler.ClusterSummary, bool) {
 	return r.inner.GetClusterSummary(clusterID)

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -42,6 +42,35 @@ const (
 	templateNamespaceBaselineProcdPort       = 49983
 )
 
+type e2ePodList struct {
+	Items []e2ePod `json:"items"`
+}
+
+type e2ePod struct {
+	Metadata e2ePodMetadata `json:"metadata"`
+	Status   e2ePodStatus   `json:"status"`
+}
+
+type e2ePodMetadata struct {
+	Name              string            `json:"name"`
+	Annotations       map[string]string `json:"annotations"`
+	DeletionTimestamp *metav1.Time      `json:"deletionTimestamp,omitempty"`
+}
+
+type e2ePodStatus struct {
+	Conditions []e2ePodCondition `json:"conditions"`
+}
+
+type e2ePodCondition struct {
+	Type   string `json:"type"`
+	Status string `json:"status"`
+}
+
+type idlePoolPodInfo struct {
+	Name             string
+	TemplateSpecHash string
+}
+
 func registerApiModeSuite(envProvider func() *framework.ScenarioEnv, opts apiModeSuiteOptions) {
 	Describe(opts.describe, Ordered, func() {
 		var (
@@ -103,6 +132,10 @@ func registerApiModeSuite(envProvider func() *framework.ScenarioEnv, opts apiMod
 			if opts.includePoolReadinessGate {
 				It("gates pooled capacity on sandbox0-managed pod readiness", func() {
 					assertTemplatePoolReadinessGate(env, session, opts.templateNamePrefix)
+				})
+
+				It("falls back to cold start while stale idle pods drain during template rollout", func() {
+					assertTemplateRolloutClaimFallsBackToColdStart(env, session, opts.templateNamePrefix)
 				})
 			}
 		})
@@ -489,6 +522,169 @@ func assertTemplatePoolReadinessGate(env *framework.ScenarioEnv, session *e2euti
 		}
 		return nil
 	}).WithTimeout(2 * time.Minute).WithPolling(3 * time.Second).Should(Succeed())
+}
+
+func assertTemplateRolloutClaimFallsBackToColdStart(env *framework.ScenarioEnv, session *e2eutils.Session, templateNamePrefix string) {
+	templates, err := session.ListTemplates(env.TestCtx.Context, GinkgoT())
+	Expect(err).NotTo(HaveOccurred())
+	Expect(templates).NotTo(BeEmpty())
+
+	name := fmt.Sprintf("%s-rollout-cold-%d", templateNamePrefix, time.Now().UnixNano())
+	templateReq := e2eutils.CloneTemplateForCreate(templates[0], name)
+	Expect(templateReq.Spec.Pool).NotTo(BeNil())
+	Expect(templateReq.Spec.MainContainer).NotTo(BeNil())
+	templateReq.Spec.MainContainer.Resources = apispec.ResourceQuota{
+		Cpu:    ptr("500m"),
+		Memory: ptr("2Gi"),
+	}
+	templateReq.Spec.Pool.MinIdle = 1
+	templateReq.Spec.Pool.MaxIdle = 1
+	templateReq.Spec.WarmProcesses = ptr(rolloutClaimWarmProcesses("before"))
+
+	created, err := session.CreateTemplate(env.TestCtx.Context, GinkgoT(), templateReq)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(created).NotTo(BeNil())
+	defer func() {
+		Expect(session.DeleteTemplate(env.TestCtx.Context, GinkgoT(), name)).To(Succeed())
+	}()
+
+	templateNamespace, err := naming.TemplateNamespaceForTeam(expectStringPtr(created.TeamId, "team id"))
+	Expect(err).NotTo(HaveOccurred())
+	templateNameForCluster := naming.TemplateNameForCluster(naming.ScopeTeam, expectStringPtr(created.TeamId, "team id"), name)
+	staleIdlePod := waitForReadyIdlePoolPodEventually(env, templateNamespace, templateNameForCluster)
+	Expect(staleIdlePod.TemplateSpecHash).NotTo(BeEmpty())
+
+	updated := *created
+	Expect(updated.Spec.Pool).NotTo(BeNil())
+	updated.Spec.Pool.MinIdle = 0
+	updated.Spec.Pool.MaxIdle = 0
+	updated.Spec.WarmProcesses = ptr(rolloutClaimWarmProcesses("after"))
+	updatedResp, err := session.UpdateTemplate(env.TestCtx.Context, GinkgoT(), name, apispec.TemplateUpdateRequest{
+		Spec: updated.Spec,
+	})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(updatedResp).NotTo(BeNil())
+
+	waitForPodDeletingOrGoneEventually(env, templateNamespace, staleIdlePod.Name)
+
+	claimResp, err := session.ClaimSandbox(env.TestCtx.Context, GinkgoT(), name)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(claimResp).NotTo(BeNil())
+	defer func() {
+		Expect(session.DeleteSandbox(env.TestCtx.Context, GinkgoT(), claimResp.SandboxId)).To(Succeed())
+	}()
+
+	sandbox := waitForSandboxPodReadyEventually(env, session, claimResp.SandboxId, templateNamespace)
+	Expect(sandbox.PodName).NotTo(Equal(staleIdlePod.Name))
+	Expect(podAnnotationEventually(env, templateNamespace, sandbox.PodName, "sandbox0.ai/claim-type")).To(Equal("cold"))
+}
+
+func rolloutClaimWarmProcesses(marker string) []apispec.WarmProcessSpec {
+	return []apispec.WarmProcessSpec{{
+		Alias:   ptr("rollout-cold-start"),
+		Type:    apispec.WarmProcessSpecTypeCmd,
+		Command: ptr([]string{"/bin/sh", "-lc", "touch /tmp/rollout-warm; sleep 3600"}),
+		EnvVars: ptr(map[string]string{"E2E_ROLLOUT_MARKER": marker}),
+	}}
+}
+
+func waitForReadyIdlePoolPodEventually(env *framework.ScenarioEnv, namespace, templateNameForCluster string) idlePoolPodInfo {
+	var selected idlePoolPodInfo
+	Eventually(func() error {
+		output, err := framework.KubectlOutput(
+			env.TestCtx.Context,
+			env.Config.Kubeconfig,
+			"get", "pods",
+			"--namespace", namespace,
+			"--selector", fmt.Sprintf("sandbox0.ai/template-id=%s,sandbox0.ai/pool-type=idle", templateNameForCluster),
+			"-o", "json",
+		)
+		if err != nil {
+			return err
+		}
+
+		var pods e2ePodList
+		if err := json.Unmarshal([]byte(output), &pods); err != nil {
+			return err
+		}
+		for _, pod := range pods.Items {
+			if pod.Metadata.DeletionTimestamp != nil || !podHasCondition(pod, "sandbox0.ai/ready", "True") {
+				continue
+			}
+			templateHash := pod.Metadata.Annotations["sandbox0.ai/template-spec-hash"]
+			if strings.TrimSpace(templateHash) == "" {
+				return fmt.Errorf("ready idle pod %s is missing template spec hash", pod.Metadata.Name)
+			}
+			selected = idlePoolPodInfo{Name: pod.Metadata.Name, TemplateSpecHash: templateHash}
+			return nil
+		}
+		return fmt.Errorf("ready idle pod for template %s not found", templateNameForCluster)
+	}).WithTimeout(2 * time.Minute).WithPolling(3 * time.Second).Should(Succeed())
+	return selected
+}
+
+func waitForPodDeletingOrGoneEventually(env *framework.ScenarioEnv, namespace, podName string) {
+	Eventually(func() error {
+		output, err := framework.KubectlOutput(
+			env.TestCtx.Context,
+			env.Config.Kubeconfig,
+			"get", "pod", podName,
+			"--namespace", namespace,
+			"--ignore-not-found=true",
+			"-o", "json",
+		)
+		if err != nil {
+			return err
+		}
+		if strings.TrimSpace(output) == "" {
+			return nil
+		}
+
+		var pod e2ePod
+		if err := json.Unmarshal([]byte(output), &pod); err != nil {
+			return err
+		}
+		if pod.Metadata.DeletionTimestamp == nil {
+			return fmt.Errorf("pod %s is not deleting yet", podName)
+		}
+		return nil
+	}).WithTimeout(2 * time.Minute).WithPolling(500 * time.Millisecond).Should(Succeed())
+}
+
+func podAnnotationEventually(env *framework.ScenarioEnv, namespace, podName, annotation string) string {
+	var value string
+	Eventually(func() error {
+		output, err := framework.KubectlOutput(
+			env.TestCtx.Context,
+			env.Config.Kubeconfig,
+			"get", "pod", podName,
+			"--namespace", namespace,
+			"-o", "json",
+		)
+		if err != nil {
+			return err
+		}
+
+		var pod e2ePod
+		if err := json.Unmarshal([]byte(output), &pod); err != nil {
+			return err
+		}
+		value = strings.TrimSpace(pod.Metadata.Annotations[annotation])
+		if value == "" {
+			return fmt.Errorf("pod %s annotation %s is not set", podName, annotation)
+		}
+		return nil
+	}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
+	return value
+}
+
+func podHasCondition(pod e2ePod, conditionType, status string) bool {
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == conditionType && condition.Status == status {
+			return true
+		}
+	}
+	return false
 }
 
 func assertTemplateNamespaceIngressBaselineLifecycle(env *framework.ScenarioEnv, session *e2eutils.Session, templateNamePrefix string) {

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -524,12 +524,12 @@ func assertTemplatePoolReadinessGate(env *framework.ScenarioEnv, session *e2euti
 	}).WithTimeout(2 * time.Minute).WithPolling(3 * time.Second).Should(Succeed())
 }
 
-func assertTemplateRolloutClaimFallsBackToColdStart(env *framework.ScenarioEnv, session *e2eutils.Session, templateNamePrefix string) {
+func assertTemplateRolloutClaimFallsBackToColdStart(env *framework.ScenarioEnv, session *e2eutils.Session, _ string) {
 	templates, err := session.ListTemplates(env.TestCtx.Context, GinkgoT())
 	Expect(err).NotTo(HaveOccurred())
 	Expect(templates).NotTo(BeEmpty())
 
-	name := fmt.Sprintf("%s-rc-%d", templateNamePrefix, time.Now().UnixNano()%1_000_000_000)
+	name := fmt.Sprintf("rc-%d", time.Now().UnixNano()%1_000_000_000)
 	templateReq := e2eutils.CloneTemplateForCreate(templates[0], name)
 	Expect(templateReq.Spec.Pool).NotTo(BeNil())
 	Expect(templateReq.Spec.MainContainer).NotTo(BeNil())

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -524,12 +524,12 @@ func assertTemplatePoolReadinessGate(env *framework.ScenarioEnv, session *e2euti
 	}).WithTimeout(2 * time.Minute).WithPolling(3 * time.Second).Should(Succeed())
 }
 
-func assertTemplateRolloutClaimFallsBackToColdStart(env *framework.ScenarioEnv, session *e2eutils.Session, _ string) {
+func assertTemplateRolloutClaimFallsBackToColdStart(env *framework.ScenarioEnv, session *e2eutils.Session, templateNamePrefix string) {
 	templates, err := session.ListTemplates(env.TestCtx.Context, GinkgoT())
 	Expect(err).NotTo(HaveOccurred())
 	Expect(templates).NotTo(BeEmpty())
 
-	name := fmt.Sprintf("rc-%d", time.Now().UnixNano()%1_000_000_000)
+	name := fmt.Sprintf("%s-rc-%d", templateNamePrefix, time.Now().UnixNano()%1_000_000_000)
 	templateReq := e2eutils.CloneTemplateForCreate(templates[0], name)
 	Expect(templateReq.Spec.Pool).NotTo(BeNil())
 	Expect(templateReq.Spec.MainContainer).NotTo(BeNil())

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -529,7 +529,7 @@ func assertTemplateRolloutClaimFallsBackToColdStart(env *framework.ScenarioEnv, 
 	Expect(err).NotTo(HaveOccurred())
 	Expect(templates).NotTo(BeEmpty())
 
-	name := fmt.Sprintf("%s-rollout-cold-%d", templateNamePrefix, time.Now().UnixNano())
+	name := fmt.Sprintf("%s-rc-%d", templateNamePrefix, time.Now().UnixNano()%1_000_000_000)
 	templateReq := e2eutils.CloneTemplateForCreate(templates[0], name)
 	Expect(templateReq.Spec.Pool).NotTo(BeNil())
 	Expect(templateReq.Spec.MainContainer).NotTo(BeNil())


### PR DESCRIPTION
## Summary
- Reuse the manager pod template hash for hot-claim eligibility and skip deleting or stale-hash idle pods.
- Treat idle pod deletion races, including finalizer-forbidden validation, as idle misses so claims fall back to cold start.
- Make scheduler ignore idle stats collected before the latest template allocation sync, avoiding `selected_by=idle` during rollout drains.

Closes #192

## Testing
- `go test ./manager/pkg/controller ./manager/pkg/service -count=1`
- `go test ./scheduler/pkg/http ./scheduler/pkg/reconciler ./pkg/template/reconciler -count=1`
- `git push` pre-push hook: `make manifests`, `make proto`, `make apispec`, `go fmt ./...`, `go mod tidy`, `go mod vendor`, `golangci-lint run ./...` (0 issues)
- `go test ./... -count=1` was also attempted, but the existing full-suite run is blocked locally by missing generated `storage-proxy/proto/fs` imports for some packages, `TestPTYRunner_FastCommandOutputReliableRepeat`, Docker daemon unavailable for kind e2e, and missing `/config/internal_jwt_public.key` in an integration manager test.