### PR TITLE
Adjust sandbox pod scheduling resources

### DIFF
--- a/manager/pkg/apis/sandbox0/v1alpha1/helpers.go
+++ b/manager/pkg/apis/sandbox0/v1alpha1/helpers.go
@@ -21,6 +21,13 @@ const (
 	netdMITMCAEnvVar    = "SANDBOX0_NETD_MITM_CA_FILE"
 	netdMITMCADir       = "/var/run/sandbox0/netd"
 	netdMITMCACertPath  = netdMITMCADir + "/mitm-ca.crt"
+
+	// Template resources remain hard limits; requests reserve a smaller baseline
+	// so warm pools and cold-start sandboxes can be packed efficiently.
+	defaultSandboxCPURequestRatioMillis    = int64(100)
+	defaultSandboxMemoryRequestRatioMillis = int64(250)
+	minSandboxCPURequestMilli              = int64(10)
+	minSandboxMemoryRequestBytes           = int64(64 * 1024 * 1024)
 )
 
 // buildPodSpec builds a pod spec from a template
@@ -264,12 +271,14 @@ func buildResourceRequirements(quota ResourceQuota) corev1.ResourceRequirements 
 	requests := corev1.ResourceList{}
 	limits := corev1.ResourceList{}
 	if quota.CPU.Sign() > 0 {
-		requests[corev1.ResourceCPU] = quota.CPU.DeepCopy()
-		limits[corev1.ResourceCPU] = quota.CPU.DeepCopy()
+		limit := quota.CPU.DeepCopy()
+		requests[corev1.ResourceCPU] = scaledCPURequest(limit)
+		limits[corev1.ResourceCPU] = limit
 	}
 	if quota.Memory.Sign() > 0 {
-		requests[corev1.ResourceMemory] = quota.Memory.DeepCopy()
-		limits[corev1.ResourceMemory] = quota.Memory.DeepCopy()
+		limit := quota.Memory.DeepCopy()
+		requests[corev1.ResourceMemory] = scaledMemoryRequest(limit)
+		limits[corev1.ResourceMemory] = limit
 	}
 	if len(requests) == 0 {
 		requests = nil
@@ -278,6 +287,32 @@ func buildResourceRequirements(quota ResourceQuota) corev1.ResourceRequirements 
 		limits = nil
 	}
 	return corev1.ResourceRequirements{Requests: requests, Limits: limits}
+}
+
+func scaledCPURequest(limit resource.Quantity) resource.Quantity {
+	limitMilli := limit.MilliValue()
+	requestMilli := scaleResource(limitMilli, defaultSandboxCPURequestRatioMillis, minSandboxCPURequestMilli)
+	return *resource.NewMilliQuantity(requestMilli, resource.DecimalSI)
+}
+
+func scaledMemoryRequest(limit resource.Quantity) resource.Quantity {
+	limitBytes := limit.Value()
+	requestBytes := scaleResource(limitBytes, defaultSandboxMemoryRequestRatioMillis, minSandboxMemoryRequestBytes)
+	return *resource.NewQuantity(requestBytes, resource.BinarySI)
+}
+
+func scaleResource(limit, ratioMillis, minimum int64) int64 {
+	if limit <= 0 {
+		return 0
+	}
+	request := (limit*ratioMillis + 999) / 1000
+	if request < minimum {
+		request = minimum
+	}
+	if request > limit {
+		return limit
+	}
+	return request
 }
 
 func appendProcdConfigEnvVars(envVars []corev1.EnvVar) []corev1.EnvVar {

--- a/manager/pkg/apis/sandbox0/v1alpha1/helpers_test.go
+++ b/manager/pkg/apis/sandbox0/v1alpha1/helpers_test.go
@@ -204,6 +204,42 @@ manager_image: sandbox0/manager:test
 	}
 }
 
+func TestBuildPodSpecUsesReducedRequestsAndQuotaLimits(t *testing.T) {
+	configPath := writeManagerConfig(t, `
+manager_image: sandbox0/manager:test
+`)
+	t.Setenv("CONFIG_PATH", configPath)
+
+	spec := BuildPodSpec(newTestTemplate())
+	resources := spec.Containers[0].Resources
+
+	assertResourceQuantity(t, resources.Requests[corev1.ResourceCPU], "100m")
+	assertResourceQuantity(t, resources.Limits[corev1.ResourceCPU], "1")
+	assertResourceQuantity(t, resources.Requests[corev1.ResourceMemory], "256Mi")
+	assertResourceQuantity(t, resources.Limits[corev1.ResourceMemory], "1Gi")
+}
+
+func TestBuildPodSpecClampsReducedRequestsToSmallQuota(t *testing.T) {
+	configPath := writeManagerConfig(t, `
+manager_image: sandbox0/manager:test
+`)
+	t.Setenv("CONFIG_PATH", configPath)
+
+	template := newTestTemplate()
+	template.Spec.MainContainer.Resources = ResourceQuota{
+		CPU:    resource.MustParse("5m"),
+		Memory: resource.MustParse("32Mi"),
+	}
+
+	spec := BuildPodSpec(template)
+	resources := spec.Containers[0].Resources
+
+	assertResourceQuantity(t, resources.Requests[corev1.ResourceCPU], "5m")
+	assertResourceQuantity(t, resources.Limits[corev1.ResourceCPU], "5m")
+	assertResourceQuantity(t, resources.Requests[corev1.ResourceMemory], "32Mi")
+	assertResourceQuantity(t, resources.Limits[corev1.ResourceMemory], "32Mi")
+}
+
 func TestBuildPodSpecAddsSandboxReadinessGate(t *testing.T) {
 	configPath := writeManagerConfig(t, `
 manager_image: sandbox0/manager:test
@@ -355,6 +391,14 @@ func findContainerPort(ports []corev1.ContainerPort, name string) *corev1.Contai
 		}
 	}
 	return nil
+}
+
+func assertResourceQuantity(t *testing.T, got resource.Quantity, want string) {
+	t.Helper()
+	wantQuantity := resource.MustParse(want)
+	if got.Cmp(wantQuantity) != 0 {
+		t.Fatalf("resource quantity = %s, want %s", got.String(), wantQuantity.String())
+	}
 }
 
 func TestBuildPodSpecOverridesTenantStorageProxyEnvVars(t *testing.T) {

--- a/manager/pkg/controller/pool_manager.go
+++ b/manager/pkg/controller/pool_manager.go
@@ -53,7 +53,19 @@ const (
 	AnnotationNetworkPolicyAppliedHash     = "sandbox0.ai/network-policy-applied-hash"
 	AnnotationSandboxID                    = "sandbox0.ai/sandbox-id"
 	AnnotationTemplateSpecHash             = "sandbox0.ai/template-spec-hash"
+	AnnotationClusterAutoscalerSafeToEvict = "cluster-autoscaler.kubernetes.io/safe-to-evict"
 )
+
+// ClaimedSandboxPodAnnotations returns manager-owned metadata for active sandbox
+// pods. Idle pool pods intentionally do not carry these annotations.
+func ClaimedSandboxPodAnnotations(extra map[string]string) map[string]string {
+	annotations := make(map[string]string, len(extra)+1)
+	for key, value := range extra {
+		annotations[key] = value
+	}
+	annotations[AnnotationClusterAutoscalerSafeToEvict] = "false"
+	return annotations
+}
 
 // PoolManager manages the idle pool (ReplicaSet)
 type PoolManager struct {

--- a/manager/pkg/controller/pool_manager_test.go
+++ b/manager/pkg/controller/pool_manager_test.go
@@ -35,6 +35,7 @@ func TestBuildPodTemplateIncludesTemplateHash(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, got.Annotations)
 	assert.Equal(t, "hash-v1", got.Annotations[AnnotationTemplateSpecHash])
+	assert.NotContains(t, got.Annotations, AnnotationClusterAutoscalerSafeToEvict)
 	assert.Equal(t, PoolTypeIdle, got.Labels[LabelPoolType])
 }
 

--- a/manager/pkg/service/sandbox_service.go
+++ b/manager/pkg/service/sandbox_service.go
@@ -688,6 +688,7 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 		if pod.Annotations == nil {
 			pod.Annotations = make(map[string]string)
 		}
+		pod.Annotations = controller.ClaimedSandboxPodAnnotations(pod.Annotations)
 		pod.Annotations[controller.AnnotationSandboxID] = pod.Name
 		pod.Annotations[controller.AnnotationTeamID] = req.TeamID
 		pod.Annotations[controller.AnnotationUserID] = req.UserID
@@ -778,13 +779,13 @@ func (s *SandboxService) createNewPod(ctx context.Context, template *v1alpha1.Sa
 		return nil, fmt.Errorf("ensure netd MITM CA secret: %w", err)
 	}
 
-	annotations := map[string]string{
+	annotations := controller.ClaimedSandboxPodAnnotations(map[string]string{
 		controller.AnnotationSandboxID: podName,
 		controller.AnnotationTeamID:    req.TeamID,
 		controller.AnnotationUserID:    req.UserID,
 		controller.AnnotationClaimedAt: s.clock.Now().Format(time.RFC3339),
 		controller.AnnotationClaimType: "cold",
-	}
+	})
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      podName,

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -91,6 +91,9 @@ func TestClaimIdlePodClaimsReadyPod(t *testing.T) {
 	if got := pod.Labels[controller.LabelPoolType]; got != controller.PoolTypeActive {
 		t.Fatalf("pool-type = %q, want %q", got, controller.PoolTypeActive)
 	}
+	if got := pod.Annotations[controller.AnnotationClusterAutoscalerSafeToEvict]; got != "false" {
+		t.Fatalf("safe-to-evict annotation = %q, want false", got)
+	}
 }
 
 func TestClaimIdlePodRequiresDataPlaneReadyNode(t *testing.T) {
@@ -324,6 +327,35 @@ func TestCreateNewPodRequestsDeleteAfterNetworkApplyFailure(t *testing.T) {
 	}
 	if len(removed) != 0 {
 		t.Fatalf("network policy removals = %d, want 0; lifecycle controller owns delete cleanup", len(removed))
+	}
+}
+
+func TestCreateNewPodMarksColdPodNonEvictable(t *testing.T) {
+	withClaimTestPublicKey(t)
+
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "template-a",
+			Namespace: "ns-a",
+		},
+		Spec: v1alpha1.SandboxTemplateSpec{
+			MainContainer: v1alpha1.ContainerSpec{Image: "busybox"},
+		},
+	}
+	client := fake.NewSimpleClientset()
+	svc := &SandboxService{
+		k8sClient:    client,
+		secretLister: newClaimTestSecretLister(t),
+		clock:        systemTime{},
+		logger:       zap.NewNop(),
+	}
+
+	pod, err := svc.createNewPod(context.Background(), template, &ClaimRequest{TeamID: "team-a", UserID: "user-a"})
+	if err != nil {
+		t.Fatalf("createNewPod() error = %v", err)
+	}
+	if got := pod.Annotations[controller.AnnotationClusterAutoscalerSafeToEvict]; got != "false" {
+		t.Fatalf("safe-to-evict annotation = %q, want false", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Reduce sandbox pod CPU/memory requests while keeping template resources as limits.
- Add the Cluster Autoscaler non-evictable annotation only when sandboxes are claimed, for both hot and cold claims.
- Keep idle ReplicaSet pods evictable and cover the behavior with tests.

## Testing
- make proto
- go test ./manager/... -count=1
- pre-push hook: make manifests, make proto, make apispec, go fmt ./..., go mod tidy, go mod vendor, golangci-lint run ./...