### PR TITLE
Add sandbox pod logs API

### DIFF
--- a/cluster-gateway/pkg/http/handlers_sandbox.go
+++ b/cluster-gateway/pkg/http/handlers_sandbox.go
@@ -3,12 +3,14 @@ package http
 import (
 	"errors"
 	"net/http"
+	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"github.com/sandbox0-ai/sandbox0/cluster-gateway/pkg/client"
 	"github.com/sandbox0-ai/sandbox0/cluster-gateway/pkg/middleware"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+	"github.com/sandbox0-ai/sandbox0/pkg/proxy"
 	sharedssh "github.com/sandbox0-ai/sandbox0/pkg/sshgateway"
 	"go.uber.org/zap"
 )
@@ -106,8 +108,16 @@ func (s *Server) getSandboxLogs(c *gin.Context) {
 
 	// Rewrite path to manager API
 	c.Request.URL.Path = "/api/v1/sandboxes/" + sandboxID + "/logs"
+	if sandboxLogsFollowRequested(c) {
+		c.Request = proxy.WithUpstreamTimeoutDisabledRequest(c.Request)
+	}
 
 	s.proxyToManager(c)
+}
+
+func sandboxLogsFollowRequested(c *gin.Context) bool {
+	follow, err := strconv.ParseBool(c.Query("follow"))
+	return err == nil && follow
 }
 
 // updateSandbox updates sandbox configuration

--- a/cluster-gateway/pkg/http/handlers_sandbox.go
+++ b/cluster-gateway/pkg/http/handlers_sandbox.go
@@ -96,6 +96,20 @@ func (s *Server) getSandboxStatus(c *gin.Context) {
 	s.proxyToManager(c)
 }
 
+// getSandboxLogs gets sandbox pod logs
+func (s *Server) getSandboxLogs(c *gin.Context) {
+	sandboxID := c.Param("id")
+	if sandboxID == "" {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "sandbox_id is required")
+		return
+	}
+
+	// Rewrite path to manager API
+	c.Request.URL.Path = "/api/v1/sandboxes/" + sandboxID + "/logs"
+
+	s.proxyToManager(c)
+}
+
 // updateSandbox updates sandbox configuration
 func (s *Server) updateSandbox(c *gin.Context) {
 	sandboxID := c.Param("id")

--- a/cluster-gateway/pkg/http/handlers_sandbox_logs_test.go
+++ b/cluster-gateway/pkg/http/handlers_sandbox_logs_test.go
@@ -1,0 +1,96 @@
+package http
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sandbox0-ai/sandbox0/cluster-gateway/pkg/client"
+	"github.com/sandbox0-ai/sandbox0/cluster-gateway/pkg/middleware"
+	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
+	gatewayauthn "github.com/sandbox0-ai/sandbox0/pkg/gateway/authn"
+	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+	"github.com/sandbox0-ai/sandbox0/pkg/proxy"
+	"go.uber.org/zap"
+)
+
+func TestSandboxLogsFollowDisablesManagerProxyTimeout(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	manager := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		_, _ = io.WriteString(w, "stream logs")
+	}))
+	defer manager.Close()
+
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate ed25519 keypair: %v", err)
+	}
+	logger := zap.NewNop()
+	proxy2Mgr, err := proxy.NewRouter(manager.URL, logger, 20*time.Millisecond)
+	if err != nil {
+		t.Fatalf("create manager proxy: %v", err)
+	}
+	validator := internalauth.NewValidator(internalauth.ValidatorConfig{
+		Target:             "cluster-gateway",
+		PublicKey:          publicKey,
+		AllowedCallers:     []string{"regional-gateway"},
+		ClockSkewTolerance: 5 * time.Second,
+	})
+	incomingGen := internalauth.NewGenerator(internalauth.GeneratorConfig{
+		Caller:     "regional-gateway",
+		PrivateKey: privateKey,
+		TTL:        time.Minute,
+	})
+	server := &Server{
+		cfg:             &config.ClusterGatewayConfig{AuthMode: authModeInternal, ManagerURL: manager.URL},
+		proxy2Mgr:       proxy2Mgr,
+		managerClient:   &client.ManagerClient{},
+		authMiddleware:  middleware.NewInternalAuthMiddleware(validator, logger),
+		logger:          logger,
+		internalAuthGen: internalauth.NewGenerator(internalauth.GeneratorConfig{Caller: "cluster-gateway", PrivateKey: privateKey, TTL: time.Minute}),
+	}
+	server.router = gin.New()
+	v1 := server.router.Group("/api/v1")
+	v1.Use(server.authMiddleware.Authenticate())
+	sandboxes := v1.Group("/sandboxes")
+	sandboxes.Use(server.managerUpstreamMiddleware())
+	sandboxes.GET("/:id/logs", server.authMiddleware.RequirePermission(gatewayauthn.PermSandboxRead), server.getSandboxLogs)
+	gateway := httptest.NewServer(server.router)
+	defer gateway.Close()
+
+	token, err := incomingGen.Generate("cluster-gateway", "team-1", "user-1", internalauth.GenerateOptions{
+		Permissions: []string{gatewayauthn.PermSandboxRead},
+	})
+	if err != nil {
+		t.Fatalf("generate internal token: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodGet, gateway.URL+"/api/v1/sandboxes/sandbox-1/logs?follow=true", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set(internalauth.DefaultTokenHeader, token)
+	resp, err := gateway.Client().Do(req)
+	if err != nil {
+		t.Fatalf("GET logs: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if string(body) != "stream logs" {
+		t.Fatalf("body = %q, want %q", string(body), "stream logs")
+	}
+}

--- a/cluster-gateway/pkg/http/server.go
+++ b/cluster-gateway/pkg/http/server.go
@@ -340,6 +340,7 @@ func (s *Server) setupRoutes() {
 			sandboxes.POST("", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxCreate), s.createSandbox)
 			sandboxes.GET("/:id", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxRead), s.getSandbox)
 			sandboxes.GET("/:id/status", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxRead), s.getSandboxStatus)
+			sandboxes.GET("/:id/logs", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxRead), s.getSandboxLogs)
 			sandboxes.PUT("/:id", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxWrite), s.updateSandbox)
 			sandboxes.DELETE("/:id", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxDelete), s.deleteSandbox)
 			sandboxes.POST("/:id/pause", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxWrite), s.pauseSandbox)

--- a/cluster-gateway/pkg/http/server_metering_routes_test.go
+++ b/cluster-gateway/pkg/http/server_metering_routes_test.go
@@ -100,6 +100,19 @@ func TestSetupRoutesMountsMetadataEndpoint(t *testing.T) {
 	}
 }
 
+func TestSetupRoutesMountsSandboxLogsEndpoint(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	server, _, _ := testMeteringRouteServer(t, "public")
+	server.requestLogger = middleware.NewRequestLogger(zap.NewNop())
+	server.obsProvider = newTestMeteringObservability(t)
+	server.setupRoutes()
+
+	if !hasRoute(server.router, "GET", "/api/v1/sandboxes/:id/logs") {
+		t.Fatal("expected sandbox logs route to be mounted")
+	}
+}
+
 func TestSetupMeteringRoutesDoesNotRequireManagerUpstream(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/infra-operator/chart/files/clusterrole.yaml
+++ b/infra-operator/chart/files/clusterrole.yaml
@@ -29,6 +29,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+- apiGroups:
   - admissionregistration.k8s.io
   resources:
   - mutatingwebhookconfigurations

--- a/infra-operator/internal/controller/pkg/rbac/rbac.go
+++ b/infra-operator/internal/controller/pkg/rbac/rbac.go
@@ -64,6 +64,11 @@ func (r *Reconciler) ReconcileManagerRBAC(ctx context.Context, infra *infrav1alp
 			Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
 		},
 		{
+			APIGroups: []string{""},
+			Resources: []string{"pods/log"},
+			Verbs:     []string{"get"},
+		},
+		{
 			APIGroups: []string{"apps"},
 			Resources: []string{"replicasets", "deployments"},
 			Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},

--- a/infra-operator/internal/controller/pkg/rbac/rbac_test.go
+++ b/infra-operator/internal/controller/pkg/rbac/rbac_test.go
@@ -90,6 +90,43 @@ func TestReconcileManagerRBACIncludesPodResize(t *testing.T) {
 	assert.True(t, found, "expected manager cluster role to include pods/resize permissions")
 }
 
+func TestReconcileManagerRBACIncludesPodLogsReadPermission(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, rbacv1.AddToScheme(scheme))
+	require.NoError(t, infrav1alpha1.AddToScheme(scheme))
+
+	infra := &infrav1alpha1.Sandbox0Infra{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "sandbox0-system",
+		},
+	}
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(infra).Build()
+	reconciler := NewReconciler(&common.ResourceManager{
+		Client: client,
+		Scheme: scheme,
+	})
+
+	require.NoError(t, reconciler.ReconcileManagerRBAC(context.Background(), infra))
+
+	role := &rbacv1.ClusterRole{}
+	require.NoError(t, client.Get(context.Background(), types.NamespacedName{Name: "demo-manager"}, role))
+
+	found := false
+	for _, rule := range role.Rules {
+		if !contains(rule.APIGroups, "") {
+			continue
+		}
+		if !contains(rule.Resources, "pods/log") {
+			continue
+		}
+		assert.ElementsMatch(t, []string{"get"}, rule.Verbs)
+		found = true
+	}
+	assert.True(t, found, "expected manager cluster role to include pods/log read permission")
+}
+
 func TestReconcileCtldRBACIncludesPodReadPermissions(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))

--- a/infra-operator/internal/controller/sandbox0infra_controller.go
+++ b/infra-operator/internal/controller/sandbox0infra_controller.go
@@ -85,6 +85,7 @@ type Sandbox0InfraReconciler struct {
 //+kubebuilder:rbac:groups=infra.sandbox0.ai,resources=sandbox0infras/finalizers,verbs=update
 //+kubebuilder:rbac:groups=apps,resources=deployments;statefulsets;daemonsets;replicasets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=services;secrets;configmaps;persistentvolumeclaims;serviceaccounts;pods;pods/exec;pods/resize;pods/status;nodes;events;namespaces;endpoints,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=core,resources=pods/log,verbs=get
 //+kubebuilder:rbac:groups=discovery.k8s.io,resources=endpointslices,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses;networkpolicies,verbs=get;list;watch;create;update;patch;delete

--- a/manager/pkg/http/handlers_sandbox.go
+++ b/manager/pkg/http/handlers_sandbox.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
 
@@ -302,7 +303,12 @@ func (s *Server) getSandboxLogs(c *gin.Context) {
 		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
 		return
 	}
-	limitBytes, err := parseBoundedInt64Query(c, "limit_bytes", service.DefaultSandboxLogLimitBytes, service.MaxSandboxLogLimitBytes)
+	limitBytes, err := parseOptionalBoundedInt64Query(c, "limit_bytes", service.MaxSandboxLogLimitBytes)
+	if err != nil {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
+		return
+	}
+	follow, err := parseBoolQuery(c, "follow")
 	if err != nil {
 		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
 		return
@@ -323,40 +329,98 @@ func (s *Server) getSandboxLogs(c *gin.Context) {
 		return
 	}
 
-	logs, err := s.sandboxService.GetSandboxLogs(c.Request.Context(), sandboxID, claims.TeamID, &service.SandboxLogsOptions{
+	options := &service.SandboxLogsOptions{
 		Container:    c.Query("container"),
 		TailLines:    tailLines,
 		LimitBytes:   limitBytes,
 		Previous:     previous,
 		Timestamps:   timestamps,
 		SinceSeconds: sinceSeconds,
-	})
+	}
+	if follow {
+		s.streamSandboxLogs(c, sandboxID, claims.TeamID, options)
+		return
+	}
+
+	logs, err := s.sandboxService.GetSandboxLogs(c.Request.Context(), sandboxID, claims.TeamID, options)
 	if err != nil {
-		s.logger.Error("Failed to get sandbox logs",
-			zap.String("sandboxID", sandboxID),
-			zap.String("teamID", claims.TeamID),
-			zap.Error(err),
-		)
-		switch {
-		case errors.Is(err, service.ErrSandboxTeamMismatch):
-			spec.JSONError(c, http.StatusForbidden, spec.CodeForbidden, err.Error())
-		case errors.Is(err, service.ErrSandboxLogContainerNotFound):
-			spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
-		case apierrors.IsNotFound(err):
-			spec.JSONError(c, http.StatusNotFound, spec.CodeNotFound, fmt.Sprintf("sandbox not found: %v", err))
-		default:
-			spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, fmt.Sprintf("failed to get sandbox logs: %v", err))
-		}
+		s.writeSandboxLogsError(c, sandboxID, claims.TeamID, err)
 		return
 	}
 
 	spec.JSONSuccess(c, http.StatusOK, logs)
 }
 
+func (s *Server) streamSandboxLogs(c *gin.Context, sandboxID, teamID string, options *service.SandboxLogsOptions) {
+	stream, err := s.sandboxService.StreamSandboxLogs(c.Request.Context(), sandboxID, teamID, options)
+	if err != nil {
+		s.writeSandboxLogsError(c, sandboxID, teamID, err)
+		return
+	}
+	defer stream.Body.Close()
+
+	c.Header("Content-Type", "text/plain; charset=utf-8")
+	c.Header("Cache-Control", "no-cache")
+	c.Header("X-Accel-Buffering", "no")
+	c.Header("X-Sandbox-ID", stream.SandboxID)
+	c.Header("X-Sandbox-Pod-Name", stream.PodName)
+	c.Header("X-Sandbox-Log-Container", stream.Container)
+	c.Status(http.StatusOK)
+	c.Writer.Flush()
+
+	if _, err := io.Copy(flushingResponseWriter{ResponseWriter: c.Writer}, stream.Body); err != nil && !errors.Is(err, context.Canceled) {
+		s.logger.Debug("Sandbox log stream ended with error",
+			zap.String("sandboxID", sandboxID),
+			zap.String("teamID", teamID),
+			zap.Error(err),
+		)
+	}
+}
+
+func (s *Server) writeSandboxLogsError(c *gin.Context, sandboxID, teamID string, err error) {
+	s.logger.Error("Failed to get sandbox logs",
+		zap.String("sandboxID", sandboxID),
+		zap.String("teamID", teamID),
+		zap.Error(err),
+	)
+	switch {
+	case errors.Is(err, service.ErrSandboxTeamMismatch):
+		spec.JSONError(c, http.StatusForbidden, spec.CodeForbidden, err.Error())
+	case errors.Is(err, service.ErrSandboxLogContainerNotFound):
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
+	case apierrors.IsNotFound(err):
+		spec.JSONError(c, http.StatusNotFound, spec.CodeNotFound, fmt.Sprintf("sandbox not found: %v", err))
+	default:
+		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, fmt.Sprintf("failed to get sandbox logs: %v", err))
+	}
+}
+
+type flushingResponseWriter struct {
+	gin.ResponseWriter
+}
+
+func (w flushingResponseWriter) Write(data []byte) (int, error) {
+	n, err := w.ResponseWriter.Write(data)
+	w.Flush()
+	return n, err
+}
+
 func parseBoundedInt64Query(c *gin.Context, name string, defaultValue, maxValue int64) (int64, error) {
 	raw := c.Query(name)
 	if raw == "" {
 		return defaultValue, nil
+	}
+	value, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || value < 1 || value > maxValue {
+		return 0, fmt.Errorf("%s must be between 1 and %d", name, maxValue)
+	}
+	return value, nil
+}
+
+func parseOptionalBoundedInt64Query(c *gin.Context, name string, maxValue int64) (int64, error) {
+	raw := c.Query(name)
+	if raw == "" {
+		return 0, nil
 	}
 	value, err := strconv.ParseInt(raw, 10, 64)
 	if err != nil || value < 1 || value > maxValue {

--- a/manager/pkg/http/handlers_sandbox.go
+++ b/manager/pkg/http/handlers_sandbox.go
@@ -283,6 +283,112 @@ func (s *Server) getSandboxStatus(c *gin.Context) {
 	spec.JSONSuccess(c, http.StatusOK, status)
 }
 
+// getSandboxLogs gets sandbox pod logs.
+func (s *Server) getSandboxLogs(c *gin.Context) {
+	sandboxID := c.Param("id")
+	if sandboxID == "" {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "sandbox_id is required")
+		return
+	}
+
+	claims := internalauth.ClaimsFromContext(c.Request.Context())
+	if claims == nil {
+		spec.JSONError(c, http.StatusUnauthorized, spec.CodeUnauthorized, "missing authentication")
+		return
+	}
+
+	tailLines, err := parseBoundedInt64Query(c, "tail_lines", service.DefaultSandboxLogTailLines, service.MaxSandboxLogTailLines)
+	if err != nil {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
+		return
+	}
+	limitBytes, err := parseBoundedInt64Query(c, "limit_bytes", service.DefaultSandboxLogLimitBytes, service.MaxSandboxLogLimitBytes)
+	if err != nil {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
+		return
+	}
+	previous, err := parseBoolQuery(c, "previous")
+	if err != nil {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
+		return
+	}
+	timestamps, err := parseBoolQuery(c, "timestamps")
+	if err != nil {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
+		return
+	}
+	sinceSeconds, err := parseOptionalPositiveInt64Query(c, "since_seconds")
+	if err != nil {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
+		return
+	}
+
+	logs, err := s.sandboxService.GetSandboxLogs(c.Request.Context(), sandboxID, claims.TeamID, &service.SandboxLogsOptions{
+		Container:    c.Query("container"),
+		TailLines:    tailLines,
+		LimitBytes:   limitBytes,
+		Previous:     previous,
+		Timestamps:   timestamps,
+		SinceSeconds: sinceSeconds,
+	})
+	if err != nil {
+		s.logger.Error("Failed to get sandbox logs",
+			zap.String("sandboxID", sandboxID),
+			zap.String("teamID", claims.TeamID),
+			zap.Error(err),
+		)
+		switch {
+		case errors.Is(err, service.ErrSandboxTeamMismatch):
+			spec.JSONError(c, http.StatusForbidden, spec.CodeForbidden, err.Error())
+		case errors.Is(err, service.ErrSandboxLogContainerNotFound):
+			spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
+		case apierrors.IsNotFound(err):
+			spec.JSONError(c, http.StatusNotFound, spec.CodeNotFound, fmt.Sprintf("sandbox not found: %v", err))
+		default:
+			spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, fmt.Sprintf("failed to get sandbox logs: %v", err))
+		}
+		return
+	}
+
+	spec.JSONSuccess(c, http.StatusOK, logs)
+}
+
+func parseBoundedInt64Query(c *gin.Context, name string, defaultValue, maxValue int64) (int64, error) {
+	raw := c.Query(name)
+	if raw == "" {
+		return defaultValue, nil
+	}
+	value, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || value < 1 || value > maxValue {
+		return 0, fmt.Errorf("%s must be between 1 and %d", name, maxValue)
+	}
+	return value, nil
+}
+
+func parseOptionalPositiveInt64Query(c *gin.Context, name string) (*int64, error) {
+	raw := c.Query(name)
+	if raw == "" {
+		return nil, nil
+	}
+	value, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || value < 1 {
+		return nil, fmt.Errorf("%s must be greater than 0", name)
+	}
+	return &value, nil
+}
+
+func parseBoolQuery(c *gin.Context, name string) (bool, error) {
+	raw := c.Query(name)
+	if raw == "" {
+		return false, nil
+	}
+	value, err := strconv.ParseBool(raw)
+	if err != nil {
+		return false, fmt.Errorf("%s must be a boolean", name)
+	}
+	return value, nil
+}
+
 // terminateSandbox terminates a sandbox
 func (s *Server) terminateSandbox(c *gin.Context) {
 	sandboxID := c.Param("id")

--- a/manager/pkg/http/handlers_sandbox_logs_test.go
+++ b/manager/pkg/http/handlers_sandbox_logs_test.go
@@ -60,6 +60,43 @@ func TestGetSandboxLogsReturnsOK(t *testing.T) {
 	assert.Equal(t, "fake logs", payload.Logs)
 }
 
+func TestGetSandboxLogsStreamsWhenFollowTrue(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	pod := newHTTPLogsTestPod("sandbox-1", "team-1")
+	sandboxService := service.NewSandboxService(
+		fake.NewSimpleClientset(pod),
+		newHTTPTestPodLister(t, pod),
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		service.SandboxServiceConfig{},
+		zap.NewNop(),
+		nil,
+	)
+	server := &Server{sandboxService: sandboxService, logger: zap.NewNop()}
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sandboxes/sandbox-1/logs?follow=true&tail_lines=10", nil)
+	req = req.WithContext(internalauth.WithClaims(req.Context(), &internalauth.Claims{TeamID: "team-1", UserID: "user-1"}))
+	ctx.Request = req
+	ctx.Params = gin.Params{{Key: "id", Value: "sandbox-1"}}
+
+	server.getSandboxLogs(ctx)
+
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	assert.Contains(t, recorder.Header().Get("Content-Type"), "text/plain")
+	assert.Equal(t, "sandbox-1", recorder.Header().Get("X-Sandbox-ID"))
+	assert.Equal(t, "procd", recorder.Header().Get("X-Sandbox-Log-Container"))
+	assert.Equal(t, "fake logs", recorder.Body.String())
+}
+
 func TestGetSandboxLogsRejectsInvalidTailLines(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/manager/pkg/http/handlers_sandbox_logs_test.go
+++ b/manager/pkg/http/handlers_sandbox_logs_test.go
@@ -1,0 +1,99 @@
+package http
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/service"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
+	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestGetSandboxLogsReturnsOK(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	pod := newHTTPLogsTestPod("sandbox-1", "team-1")
+	sandboxService := service.NewSandboxService(
+		fake.NewSimpleClientset(pod),
+		newHTTPTestPodLister(t, pod),
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		service.SandboxServiceConfig{},
+		zap.NewNop(),
+		nil,
+	)
+	server := &Server{sandboxService: sandboxService, logger: zap.NewNop()}
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sandboxes/sandbox-1/logs?tail_lines=10&limit_bytes=1024&previous=true&timestamps=true&since_seconds=30", nil)
+	req = req.WithContext(internalauth.WithClaims(req.Context(), &internalauth.Claims{TeamID: "team-1", UserID: "user-1"}))
+	ctx.Request = req
+	ctx.Params = gin.Params{{Key: "id", Value: "sandbox-1"}}
+
+	server.getSandboxLogs(ctx)
+
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	payload, apiErr, err := spec.DecodeResponse[service.SandboxLogsResponse](bytes.NewReader(recorder.Body.Bytes()))
+	require.NoError(t, err)
+	require.Nil(t, apiErr)
+	require.NotNil(t, payload)
+	assert.Equal(t, "sandbox-1", payload.SandboxID)
+	assert.Equal(t, "procd", payload.Container)
+	assert.True(t, payload.Previous)
+	assert.Equal(t, "fake logs", payload.Logs)
+}
+
+func TestGetSandboxLogsRejectsInvalidTailLines(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	server := &Server{logger: zap.NewNop()}
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sandboxes/sandbox-1/logs?tail_lines=5001", nil)
+	req = req.WithContext(internalauth.WithClaims(req.Context(), &internalauth.Claims{TeamID: "team-1", UserID: "user-1"}))
+	ctx.Request = req
+	ctx.Params = gin.Params{{Key: "id", Value: "sandbox-1"}}
+
+	server.getSandboxLogs(ctx)
+
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	_, apiErr, err := spec.DecodeResponse[service.SandboxLogsResponse](bytes.NewReader(recorder.Body.Bytes()))
+	require.NoError(t, err)
+	require.NotNil(t, apiErr)
+	assert.Equal(t, spec.CodeBadRequest, apiErr.Code)
+}
+
+func newHTTPLogsTestPod(sandboxID, teamID string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sandboxID,
+			Namespace: "default",
+			Labels: map[string]string{
+				controller.LabelSandboxID: sandboxID,
+			},
+			Annotations: map[string]string{
+				controller.AnnotationTeamID: teamID,
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: service.DefaultSandboxLogContainer}},
+		},
+	}
+}

--- a/manager/pkg/http/server.go
+++ b/manager/pkg/http/server.go
@@ -151,6 +151,7 @@ func (s *Server) setupRoutes() {
 			sandboxes.GET("/:id", s.getSandbox)
 			sandboxes.PUT("/:id", s.requireNetworkPolicyInBody(func() any { return &updateSandboxCapabilityRequest{} }), s.updateSandbox)
 			sandboxes.GET("/:id/status", s.getSandboxStatus)
+			sandboxes.GET("/:id/logs", s.getSandboxLogs)
 			sandboxes.GET("/:id/stats", s.getSandboxStats)
 			sandboxes.GET("/:id/network", s.requireNetworkPolicyCapability(), s.getNetworkPolicy)
 			sandboxes.PUT("/:id/network", s.requireNetworkPolicyCapability(), s.updateNetworkPolicy)

--- a/manager/pkg/service/sandbox_service_logs.go
+++ b/manager/pkg/service/sandbox_service_logs.go
@@ -1,0 +1,145 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	// DefaultSandboxLogContainer is the sandbox main container created by the manager.
+	DefaultSandboxLogContainer        = "procd"
+	DefaultSandboxLogTailLines  int64 = 200
+	MaxSandboxLogTailLines      int64 = 5000
+	DefaultSandboxLogLimitBytes int64 = 1 << 20
+	MaxSandboxLogLimitBytes     int64 = 8 << 20
+)
+
+var (
+	ErrSandboxTeamMismatch         = errors.New("sandbox belongs to a different team")
+	ErrSandboxLogContainerNotFound = errors.New("sandbox log container not found")
+)
+
+// SandboxLogsOptions controls a bounded snapshot read from Kubernetes pod logs.
+type SandboxLogsOptions struct {
+	Container    string `json:"container"`
+	TailLines    int64  `json:"tail_lines"`
+	LimitBytes   int64  `json:"limit_bytes"`
+	Previous     bool   `json:"previous"`
+	Timestamps   bool   `json:"timestamps"`
+	SinceSeconds *int64 `json:"since_seconds,omitempty"`
+}
+
+// SandboxLogsResponse is the public payload returned by the sandbox logs API.
+type SandboxLogsResponse struct {
+	SandboxID string `json:"sandbox_id"`
+	PodName   string `json:"pod_name"`
+	Container string `json:"container"`
+	Previous  bool   `json:"previous"`
+	Logs      string `json:"logs"`
+}
+
+// GetSandboxLogs returns a bounded snapshot of logs from one container in the sandbox pod.
+func (s *SandboxService) GetSandboxLogs(ctx context.Context, sandboxID, teamID string, opts *SandboxLogsOptions) (*SandboxLogsResponse, error) {
+	if s.k8sClient == nil {
+		return nil, errors.New("kubernetes client is not configured")
+	}
+
+	pod, err := s.getSandboxPod(ctx, sandboxID)
+	if err != nil {
+		return nil, err
+	}
+	if teamID != "" && pod.Annotations[controller.AnnotationTeamID] != teamID {
+		return nil, ErrSandboxTeamMismatch
+	}
+
+	options := normalizeSandboxLogsOptions(opts)
+	if !podHasContainer(pod, options.Container) {
+		return nil, fmt.Errorf("%w: %s", ErrSandboxLogContainerNotFound, options.Container)
+	}
+
+	logOptions := &corev1.PodLogOptions{
+		Container:  options.Container,
+		Previous:   options.Previous,
+		Timestamps: options.Timestamps,
+		TailLines:  &options.TailLines,
+		LimitBytes: &options.LimitBytes,
+	}
+	if options.SinceSeconds != nil {
+		logOptions.SinceSeconds = options.SinceSeconds
+	}
+
+	stream, err := s.k8sClient.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, logOptions).Stream(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("stream sandbox pod logs: %w", err)
+	}
+	data, readErr := io.ReadAll(stream)
+	closeErr := stream.Close()
+	if readErr != nil {
+		return nil, fmt.Errorf("read sandbox pod logs: %w", readErr)
+	}
+	if closeErr != nil {
+		return nil, fmt.Errorf("close sandbox pod logs: %w", closeErr)
+	}
+
+	return &SandboxLogsResponse{
+		SandboxID: sandboxID,
+		PodName:   pod.Name,
+		Container: options.Container,
+		Previous:  options.Previous,
+		Logs:      string(data),
+	}, nil
+}
+
+func normalizeSandboxLogsOptions(opts *SandboxLogsOptions) SandboxLogsOptions {
+	options := SandboxLogsOptions{}
+	if opts != nil {
+		options = *opts
+	}
+	options.Container = strings.TrimSpace(options.Container)
+	if options.Container == "" {
+		options.Container = DefaultSandboxLogContainer
+	}
+	if options.TailLines == 0 {
+		options.TailLines = DefaultSandboxLogTailLines
+	} else if options.TailLines > MaxSandboxLogTailLines {
+		options.TailLines = MaxSandboxLogTailLines
+	} else if options.TailLines < 0 {
+		options.TailLines = DefaultSandboxLogTailLines
+	}
+	if options.LimitBytes == 0 {
+		options.LimitBytes = DefaultSandboxLogLimitBytes
+	} else if options.LimitBytes > MaxSandboxLogLimitBytes {
+		options.LimitBytes = MaxSandboxLogLimitBytes
+	} else if options.LimitBytes < 0 {
+		options.LimitBytes = DefaultSandboxLogLimitBytes
+	}
+	if options.SinceSeconds != nil && *options.SinceSeconds < 1 {
+		options.SinceSeconds = nil
+	}
+	return options
+}
+
+func podHasContainer(pod *corev1.Pod, name string) bool {
+	for _, container := range pod.Spec.Containers {
+		if container.Name == name {
+			return true
+		}
+	}
+	for _, container := range pod.Spec.InitContainers {
+		if container.Name == name {
+			return true
+		}
+	}
+	for _, container := range pod.Spec.EphemeralContainers {
+		if container.Name == name {
+			return true
+		}
+	}
+	return false
+}

--- a/manager/pkg/service/sandbox_service_logs.go
+++ b/manager/pkg/service/sandbox_service_logs.go
@@ -44,8 +44,45 @@ type SandboxLogsResponse struct {
 	Logs      string `json:"logs"`
 }
 
+// SandboxLogsStream is an open Kubernetes pod log stream. Callers must close Body.
+type SandboxLogsStream struct {
+	SandboxID string
+	PodName   string
+	Container string
+	Previous  bool
+	Body      io.ReadCloser
+}
+
 // GetSandboxLogs returns a bounded snapshot of logs from one container in the sandbox pod.
 func (s *SandboxService) GetSandboxLogs(ctx context.Context, sandboxID, teamID string, opts *SandboxLogsOptions) (*SandboxLogsResponse, error) {
+	stream, err := s.openSandboxLogs(ctx, sandboxID, teamID, opts, false, true)
+	if err != nil {
+		return nil, err
+	}
+	data, readErr := io.ReadAll(stream.Body)
+	closeErr := stream.Body.Close()
+	if readErr != nil {
+		return nil, fmt.Errorf("read sandbox pod logs: %w", readErr)
+	}
+	if closeErr != nil {
+		return nil, fmt.Errorf("close sandbox pod logs: %w", closeErr)
+	}
+
+	return &SandboxLogsResponse{
+		SandboxID: stream.SandboxID,
+		PodName:   stream.PodName,
+		Container: stream.Container,
+		Previous:  stream.Previous,
+		Logs:      string(data),
+	}, nil
+}
+
+// StreamSandboxLogs returns a followable stream of logs from one container in the sandbox pod.
+func (s *SandboxService) StreamSandboxLogs(ctx context.Context, sandboxID, teamID string, opts *SandboxLogsOptions) (*SandboxLogsStream, error) {
+	return s.openSandboxLogs(ctx, sandboxID, teamID, opts, true, false)
+}
+
+func (s *SandboxService) openSandboxLogs(ctx context.Context, sandboxID, teamID string, opts *SandboxLogsOptions, follow bool, defaultLimit bool) (*SandboxLogsStream, error) {
 	if s.k8sClient == nil {
 		return nil, errors.New("kubernetes client is not configured")
 	}
@@ -58,17 +95,20 @@ func (s *SandboxService) GetSandboxLogs(ctx context.Context, sandboxID, teamID s
 		return nil, ErrSandboxTeamMismatch
 	}
 
-	options := normalizeSandboxLogsOptions(opts)
+	options := normalizeSandboxLogsOptions(opts, defaultLimit)
 	if !podHasContainer(pod, options.Container) {
 		return nil, fmt.Errorf("%w: %s", ErrSandboxLogContainerNotFound, options.Container)
 	}
 
 	logOptions := &corev1.PodLogOptions{
 		Container:  options.Container,
+		Follow:     follow,
 		Previous:   options.Previous,
 		Timestamps: options.Timestamps,
 		TailLines:  &options.TailLines,
-		LimitBytes: &options.LimitBytes,
+	}
+	if options.LimitBytes > 0 {
+		logOptions.LimitBytes = &options.LimitBytes
 	}
 	if options.SinceSeconds != nil {
 		logOptions.SinceSeconds = options.SinceSeconds
@@ -78,25 +118,17 @@ func (s *SandboxService) GetSandboxLogs(ctx context.Context, sandboxID, teamID s
 	if err != nil {
 		return nil, fmt.Errorf("stream sandbox pod logs: %w", err)
 	}
-	data, readErr := io.ReadAll(stream)
-	closeErr := stream.Close()
-	if readErr != nil {
-		return nil, fmt.Errorf("read sandbox pod logs: %w", readErr)
-	}
-	if closeErr != nil {
-		return nil, fmt.Errorf("close sandbox pod logs: %w", closeErr)
-	}
 
-	return &SandboxLogsResponse{
+	return &SandboxLogsStream{
 		SandboxID: sandboxID,
 		PodName:   pod.Name,
 		Container: options.Container,
 		Previous:  options.Previous,
-		Logs:      string(data),
+		Body:      stream,
 	}, nil
 }
 
-func normalizeSandboxLogsOptions(opts *SandboxLogsOptions) SandboxLogsOptions {
+func normalizeSandboxLogsOptions(opts *SandboxLogsOptions, defaultLimit bool) SandboxLogsOptions {
 	options := SandboxLogsOptions{}
 	if opts != nil {
 		options = *opts
@@ -112,12 +144,12 @@ func normalizeSandboxLogsOptions(opts *SandboxLogsOptions) SandboxLogsOptions {
 	} else if options.TailLines < 0 {
 		options.TailLines = DefaultSandboxLogTailLines
 	}
-	if options.LimitBytes == 0 {
+	if options.LimitBytes == 0 && defaultLimit {
 		options.LimitBytes = DefaultSandboxLogLimitBytes
 	} else if options.LimitBytes > MaxSandboxLogLimitBytes {
 		options.LimitBytes = MaxSandboxLogLimitBytes
 	} else if options.LimitBytes < 0 {
-		options.LimitBytes = DefaultSandboxLogLimitBytes
+		options.LimitBytes = 0
 	}
 	if options.SinceSeconds != nil && *options.SinceSeconds < 1 {
 		options.SinceSeconds = nil

--- a/manager/pkg/service/sandbox_service_logs_test.go
+++ b/manager/pkg/service/sandbox_service_logs_test.go
@@ -1,0 +1,114 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func TestGetSandboxLogsUsesBoundedPodLogOptions(t *testing.T) {
+	pod := newSandboxLogsTestPod("sandbox-1", "team-1", "procd")
+	client := fake.NewSimpleClientset(pod)
+	svc := &SandboxService{
+		k8sClient: client,
+		podLister: newTestPodLister(t, pod),
+		logger:    zap.NewNop(),
+	}
+	sinceSeconds := int64(60)
+
+	resp, err := svc.GetSandboxLogs(context.Background(), "sandbox-1", "team-1", &SandboxLogsOptions{
+		Container:    "procd",
+		TailLines:    25,
+		LimitBytes:   1024,
+		Previous:     true,
+		Timestamps:   true,
+		SinceSeconds: &sinceSeconds,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "sandbox-1", resp.SandboxID)
+	assert.Equal(t, "sandbox-1", resp.PodName)
+	assert.Equal(t, "procd", resp.Container)
+	assert.True(t, resp.Previous)
+	assert.Equal(t, "fake logs", resp.Logs)
+
+	logOptions := findPodLogOptions(t, client.Actions())
+	require.NotNil(t, logOptions)
+	assert.Equal(t, "procd", logOptions.Container)
+	assert.True(t, logOptions.Previous)
+	assert.True(t, logOptions.Timestamps)
+	require.NotNil(t, logOptions.TailLines)
+	assert.EqualValues(t, 25, *logOptions.TailLines)
+	require.NotNil(t, logOptions.LimitBytes)
+	assert.EqualValues(t, 1024, *logOptions.LimitBytes)
+	require.NotNil(t, logOptions.SinceSeconds)
+	assert.EqualValues(t, 60, *logOptions.SinceSeconds)
+}
+
+func TestGetSandboxLogsRejectsDifferentTeam(t *testing.T) {
+	pod := newSandboxLogsTestPod("sandbox-1", "team-1", "procd")
+	svc := &SandboxService{
+		k8sClient: fake.NewSimpleClientset(pod),
+		podLister: newTestPodLister(t, pod),
+		logger:    zap.NewNop(),
+	}
+
+	_, err := svc.GetSandboxLogs(context.Background(), "sandbox-1", "team-2", nil)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrSandboxTeamMismatch))
+}
+
+func TestGetSandboxLogsRejectsUnknownContainer(t *testing.T) {
+	pod := newSandboxLogsTestPod("sandbox-1", "team-1", "procd")
+	svc := &SandboxService{
+		k8sClient: fake.NewSimpleClientset(pod),
+		podLister: newTestPodLister(t, pod),
+		logger:    zap.NewNop(),
+	}
+
+	_, err := svc.GetSandboxLogs(context.Background(), "sandbox-1", "team-1", &SandboxLogsOptions{Container: "sidecar"})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrSandboxLogContainerNotFound))
+}
+
+func newSandboxLogsTestPod(sandboxID, teamID, container string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sandboxID,
+			Namespace: "default",
+			Labels: map[string]string{
+				controller.LabelSandboxID: sandboxID,
+			},
+			Annotations: map[string]string{
+				controller.AnnotationTeamID: teamID,
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: container}},
+		},
+	}
+}
+
+func findPodLogOptions(t *testing.T, actions []k8stesting.Action) *corev1.PodLogOptions {
+	t.Helper()
+	for _, action := range actions {
+		if !action.Matches("get", "pods/log") {
+			continue
+		}
+		generic, ok := action.(k8stesting.GenericAction)
+		require.True(t, ok, "pods/log action should be generic")
+		options, ok := generic.GetValue().(*corev1.PodLogOptions)
+		require.True(t, ok, "pods/log action value should be PodLogOptions")
+		return options
+	}
+	t.Fatalf("expected pods/log get action")
+	return nil
+}

--- a/manager/pkg/service/sandbox_service_logs_test.go
+++ b/manager/pkg/service/sandbox_service_logs_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"io"
 	"testing"
 
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
@@ -51,6 +52,34 @@ func TestGetSandboxLogsUsesBoundedPodLogOptions(t *testing.T) {
 	assert.EqualValues(t, 1024, *logOptions.LimitBytes)
 	require.NotNil(t, logOptions.SinceSeconds)
 	assert.EqualValues(t, 60, *logOptions.SinceSeconds)
+}
+
+func TestStreamSandboxLogsUsesFollowWithoutDefaultLimit(t *testing.T) {
+	pod := newSandboxLogsTestPod("sandbox-1", "team-1", "procd")
+	client := fake.NewSimpleClientset(pod)
+	svc := &SandboxService{
+		k8sClient: client,
+		podLister: newTestPodLister(t, pod),
+		logger:    zap.NewNop(),
+	}
+
+	stream, err := svc.StreamSandboxLogs(context.Background(), "sandbox-1", "team-1", &SandboxLogsOptions{
+		Container: "procd",
+		TailLines: 10,
+	})
+	require.NoError(t, err)
+	data, err := io.ReadAll(stream.Body)
+	require.NoError(t, err)
+	require.NoError(t, stream.Body.Close())
+	assert.Equal(t, "fake logs", string(data))
+
+	logOptions := findPodLogOptions(t, client.Actions())
+	require.NotNil(t, logOptions)
+	assert.Equal(t, "procd", logOptions.Container)
+	assert.True(t, logOptions.Follow)
+	require.NotNil(t, logOptions.TailLines)
+	assert.EqualValues(t, 10, *logOptions.TailLines)
+	assert.Nil(t, logOptions.LimitBytes)
 }
 
 func TestGetSandboxLogsRejectsDifferentTeam(t *testing.T) {

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -1305,7 +1305,7 @@ paths:
       summary: Get sandbox pod logs
       description: |
         Returns a bounded snapshot of Kubernetes container logs for the sandbox pod.
-        This endpoint does not stream or follow logs.
+        Set `follow=true` to stream logs as text/plain until the client disconnects.
       security:
         - bearerAuth: []
       x-upstream-service: manager
@@ -1329,13 +1329,19 @@ paths:
             maximum: 5000
         - name: limit_bytes
           in: query
-          description: Maximum response log payload bytes read from Kubernetes.
+          description: Maximum response log payload bytes read from Kubernetes. Defaults only apply when follow is false.
           schema:
             type: integer
             format: int64
             default: 1048576
             minimum: 1
             maximum: 8388608
+        - name: follow
+          in: query
+          description: Stream logs until the client disconnects. When true, the response content type is text/plain.
+          schema:
+            type: boolean
+            default: false
         - name: previous
           in: query
           description: Return logs for the previously terminated container instance.
@@ -1362,6 +1368,9 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SuccessSandboxLogsResponse"
+            text/plain:
+              schema:
+                type: string
         "400":
           description: Invalid log query parameters
           content:

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -1299,6 +1299,87 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorEnvelope"
+  /api/v1/sandboxes/{id}/logs:
+    get:
+      tags: [sandboxes]
+      summary: Get sandbox pod logs
+      description: |
+        Returns a bounded snapshot of Kubernetes container logs for the sandbox pod.
+        This endpoint does not stream or follow logs.
+      security:
+        - bearerAuth: []
+      x-upstream-service: manager
+      x-upstream-path: /api/v1/sandboxes/{id}/logs
+      parameters:
+        - $ref: "#/components/parameters/SandboxID"
+        - name: container
+          in: query
+          description: Pod container name. Defaults to the sandbox main container.
+          schema:
+            type: string
+            default: procd
+        - name: tail_lines
+          in: query
+          description: Maximum number of log lines to return from the end of the log.
+          schema:
+            type: integer
+            format: int64
+            default: 200
+            minimum: 1
+            maximum: 5000
+        - name: limit_bytes
+          in: query
+          description: Maximum response log payload bytes read from Kubernetes.
+          schema:
+            type: integer
+            format: int64
+            default: 1048576
+            minimum: 1
+            maximum: 8388608
+        - name: previous
+          in: query
+          description: Return logs for the previously terminated container instance.
+          schema:
+            type: boolean
+            default: false
+        - name: timestamps
+          in: query
+          description: Include Kubernetes log timestamps when available.
+          schema:
+            type: boolean
+            default: false
+        - name: since_seconds
+          in: query
+          description: Only return logs newer than this many seconds.
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+      responses:
+        "200":
+          description: Sandbox pod logs
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessSandboxLogsResponse"
+        "400":
+          description: Invalid log query parameters
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
   /api/v1/sandboxes/{id}/pause:
     post:
       tags: [sandboxes]
@@ -4103,6 +4184,26 @@ components:
           type: string
         created_at:
           type: string
+    SandboxLogs:
+      type: object
+      properties:
+        sandbox_id:
+          type: string
+        pod_name:
+          type: string
+        container:
+          type: string
+        previous:
+          type: boolean
+        logs:
+          type: string
+          description: Log text returned by Kubernetes for the selected container.
+      required:
+        - sandbox_id
+        - pod_name
+        - container
+        - previous
+        - logs
     SuccessSandboxResponse:
       allOf:
         - $ref: "#/components/schemas/SuccessEnvelope"
@@ -4117,6 +4218,13 @@ components:
           properties:
             data:
               $ref: "#/components/schemas/SandboxStatus"
+    SuccessSandboxLogsResponse:
+      allOf:
+        - $ref: "#/components/schemas/SuccessEnvelope"
+        - type: object
+          properties:
+            data:
+              $ref: "#/components/schemas/SandboxLogs"
     SandboxSummary:
       type: object
       properties:

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -2790,8 +2790,11 @@ type GetApiV1SandboxesIdLogsParams struct {
 	// TailLines Maximum number of log lines to return from the end of the log.
 	TailLines *int64 `form:"tail_lines,omitempty" json:"tail_lines,omitempty"`
 
-	// LimitBytes Maximum response log payload bytes read from Kubernetes.
+	// LimitBytes Maximum response log payload bytes read from Kubernetes. Defaults only apply when follow is false.
 	LimitBytes *int64 `form:"limit_bytes,omitempty" json:"limit_bytes,omitempty"`
+
+	// Follow Stream logs until the client disconnects. When true, the response content type is text/plain.
+	Follow *bool `form:"follow,omitempty" json:"follow,omitempty"`
 
 	// Previous Return logs for the previously terminated container instance.
 	Previous *bool `form:"previous,omitempty" json:"previous,omitempty"`

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -349,6 +349,11 @@ const (
 	SuccessSandboxListResponseSuccessTrue SuccessSandboxListResponseSuccess = true
 )
 
+// Defines values for SuccessSandboxLogsResponseSuccess.
+const (
+	SuccessSandboxLogsResponseSuccessTrue SuccessSandboxLogsResponseSuccess = true
+)
+
 // Defines values for SuccessSandboxNetworkPolicyResponseSuccess.
 const (
 	SuccessSandboxNetworkPolicyResponseSuccessTrue SuccessSandboxNetworkPolicyResponseSuccess = true
@@ -461,7 +466,7 @@ const (
 
 // Defines values for SuccessWrittenResponseSuccess.
 const (
-	True SuccessWrittenResponseSuccess = true
+	SuccessWrittenResponseSuccessTrue SuccessWrittenResponseSuccess = true
 )
 
 // Defines values for SyncEventType.
@@ -1486,6 +1491,17 @@ type SandboxConfig struct {
 	Webhook      *WebhookConfig        `json:"webhook,omitempty"`
 }
 
+// SandboxLogs defines model for SandboxLogs.
+type SandboxLogs struct {
+	Container string `json:"container"`
+
+	// Logs Log text returned by Kubernetes for the selected container.
+	Logs      string `json:"logs"`
+	PodName   string `json:"pod_name"`
+	Previous  bool   `json:"previous"`
+	SandboxId string `json:"sandbox_id"`
+}
+
 // SandboxNetworkPolicy defines model for SandboxNetworkPolicy.
 type SandboxNetworkPolicy struct {
 	CredentialBindings *[]CredentialBinding `json:"credentialBindings,omitempty"`
@@ -2100,6 +2116,15 @@ type SuccessSandboxListResponse struct {
 
 // SuccessSandboxListResponseSuccess defines model for SuccessSandboxListResponse.Success.
 type SuccessSandboxListResponseSuccess bool
+
+// SuccessSandboxLogsResponse defines model for SuccessSandboxLogsResponse.
+type SuccessSandboxLogsResponse struct {
+	Data    *SandboxLogs                      `json:"data,omitempty"`
+	Success SuccessSandboxLogsResponseSuccess `json:"success"`
+}
+
+// SuccessSandboxLogsResponseSuccess defines model for SuccessSandboxLogsResponse.Success.
+type SuccessSandboxLogsResponseSuccess bool
 
 // SuccessSandboxNetworkPolicyResponse defines model for SuccessSandboxNetworkPolicyResponse.
 type SuccessSandboxNetworkPolicyResponse struct {
@@ -2755,6 +2780,27 @@ type GetApiV1SandboxesIdFilesListParams struct {
 // GetApiV1SandboxesIdFilesStatParams defines parameters for GetApiV1SandboxesIdFilesStat.
 type GetApiV1SandboxesIdFilesStatParams struct {
 	Path FilePath `form:"path" json:"path"`
+}
+
+// GetApiV1SandboxesIdLogsParams defines parameters for GetApiV1SandboxesIdLogs.
+type GetApiV1SandboxesIdLogsParams struct {
+	// Container Pod container name. Defaults to the sandbox main container.
+	Container *string `form:"container,omitempty" json:"container,omitempty"`
+
+	// TailLines Maximum number of log lines to return from the end of the log.
+	TailLines *int64 `form:"tail_lines,omitempty" json:"tail_lines,omitempty"`
+
+	// LimitBytes Maximum response log payload bytes read from Kubernetes.
+	LimitBytes *int64 `form:"limit_bytes,omitempty" json:"limit_bytes,omitempty"`
+
+	// Previous Return logs for the previously terminated container instance.
+	Previous *bool `form:"previous,omitempty" json:"previous,omitempty"`
+
+	// Timestamps Include Kubernetes log timestamps when available.
+	Timestamps *bool `form:"timestamps,omitempty" json:"timestamps,omitempty"`
+
+	// SinceSeconds Only return logs newer than this many seconds.
+	SinceSeconds *int64 `form:"since_seconds,omitempty" json:"since_seconds,omitempty"`
 }
 
 // DeleteApiV1SandboxvolumesIdParams defines parameters for DeleteApiV1SandboxvolumesId.

--- a/regional-gateway/pkg/http/sandbox_proxy.go
+++ b/regional-gateway/pkg/http/sandbox_proxy.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"net/http"
+	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/authn"
@@ -9,6 +10,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
+	"github.com/sandbox0-ai/sandbox0/pkg/proxy"
 	"go.uber.org/zap"
 )
 
@@ -67,6 +69,9 @@ func (s *Server) proxySandbox(c *gin.Context) {
 	}
 
 	s.applyInternalHeaders(c, token, authCtx)
+	if sandboxLogsFollowRequested(c) {
+		c.Request = proxy.WithUpstreamTimeoutDisabledRequest(c.Request)
+	}
 
 	router.ProxyToTarget(c)
 }
@@ -85,6 +90,9 @@ func (s *Server) proxyToScheduler(c *gin.Context, authCtx *authn.AuthContext) {
 	}
 
 	s.applyInternalHeaders(c, token, authCtx)
+	if sandboxLogsFollowRequested(c) {
+		c.Request = proxy.WithUpstreamTimeoutDisabledRequest(c.Request)
+	}
 	s.schedulerRouter.ProxyToTarget(c)
 }
 
@@ -103,7 +111,18 @@ func (s *Server) proxyToDefaultClusterGateway(c *gin.Context) {
 	}
 
 	s.applyInternalHeaders(c, token, authCtx)
+	if sandboxLogsFollowRequested(c) {
+		c.Request = proxy.WithUpstreamTimeoutDisabledRequest(c.Request)
+	}
 	s.clusterGatewayRouter.ProxyToTarget(c)
+}
+
+func sandboxLogsFollowRequested(c *gin.Context) bool {
+	if c.Request.Method != http.MethodGet || c.Param("path") != "/logs" {
+		return false
+	}
+	follow, err := strconv.ParseBool(c.Query("follow"))
+	return err == nil && follow
 }
 
 func (s *Server) applyInternalHeaders(c *gin.Context, token string, authCtx *authn.AuthContext) {

--- a/skills/sandbox0/references/docs-src/sandbox/page.mdx
+++ b/skills/sandbox0/references/docs-src/sandbox/page.mdx
@@ -267,13 +267,17 @@ Read bounded pod logs for sandbox startup and container diagnostics.
 |-----------|------|-------------|
 | `container` | string | Pod container name (default: `procd`) |
 | `tail_lines` | integer | Number of lines from the end of the log (default: 200, max: 5000) |
-| `limit_bytes` | integer | Maximum log bytes returned (default: 1048576, max: 8388608) |
+| `limit_bytes` | integer | Maximum log bytes returned (default: 1048576 for snapshot responses, max: 8388608) |
+| `follow` | boolean | Stream logs as `text/plain` until the client disconnects |
 | `previous` | boolean | Return logs from the previously terminated container instance |
 | `timestamps` | boolean | Include Kubernetes log timestamps when available |
 | `since_seconds` | integer | Return logs newer than this many seconds |
 
     curl -H "Authorization: Bearer $SANDBOX0_TOKEN" \
       "$SANDBOX0_BASE_URL/api/v1/sandboxes/sb_abc123/logs?tail_lines=200"
+
+    curl -N -H "Authorization: Bearer $SANDBOX0_TOKEN" \
+      "$SANDBOX0_BASE_URL/api/v1/sandboxes/sb_abc123/logs?follow=true&tail_lines=50"
 
 ---
 

--- a/skills/sandbox0/references/docs-src/sandbox/page.mdx
+++ b/skills/sandbox0/references/docs-src/sandbox/page.mdx
@@ -253,6 +253,30 @@ console.log('Status:', status.status);`
 
 ---
 
+## Get Sandbox Logs
+
+Read bounded pod logs for sandbox startup and container diagnostics.
+
+<Endpoint method="GET">
+/api/v1/sandboxes/{'{id}'}/logs
+</Endpoint>
+
+### Query Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `container` | string | Pod container name (default: `procd`) |
+| `tail_lines` | integer | Number of lines from the end of the log (default: 200, max: 5000) |
+| `limit_bytes` | integer | Maximum log bytes returned (default: 1048576, max: 8388608) |
+| `previous` | boolean | Return logs from the previously terminated container instance |
+| `timestamps` | boolean | Include Kubernetes log timestamps when available |
+| `since_seconds` | integer | Return logs newer than this many seconds |
+
+    curl -H "Authorization: Bearer $SANDBOX0_TOKEN" \
+      "$SANDBOX0_BASE_URL/api/v1/sandboxes/sb_abc123/logs?tail_lines=200"
+
+---
+
 ## List Sandboxes
 
 List all sandboxes with optional filters.


### PR DESCRIPTION
## Summary
- Add `GET /api/v1/sandboxes/{id}/logs` to the hand-maintained OpenAPI contract, generated API types, and docs reference.
- Implement manager-side Kubernetes pod log retrieval with team ownership checks, container validation, bounded snapshot reads, and raw `follow=true` streaming.
- Route the endpoint through cluster-gateway and regional-gateway, preserving sandbox read permission and disabling gateway upstream timeouts for log streams.
- Add manager `pods/log` RBAC so the deployed data plane can read sandbox container logs.

Closes #195

## Testing
- `make apispec`
- `make manifests`
- `go test ./pkg/apispec ./manager/pkg/service ./manager/pkg/http ./cluster-gateway/pkg/http ./regional-gateway/pkg/http -count=1`
- pre-push hook passed: `make manifests`, `make proto`, `make apispec`, `go fmt ./...`, `go mod tidy`, `go mod vendor`, `golangci-lint run ./...`
- remote kind rebuild: `make -C infra test-e2e-destroy`, `make -C infra test-e2e-kind`, `make test-again`
- remote live smoke: login, create sandbox, verify snapshot logs return `200` JSON for `procd`, verify `follow=true` returns `200` with `text/plain; charset=utf-8` and streams until client timeout, then delete sandbox

Note: full local `go test ./... -count=1` still requires host Docker for e2e setup and `/config/internal_jwt_public.key` for manager integration tests on this machine.
