### PR TITLE
Forward process output to container logs

### DIFF
--- a/cluster-gateway/pkg/http/handlers_sandbox.go
+++ b/cluster-gateway/pkg/http/handlers_sandbox.go
@@ -1,8 +1,12 @@
 package http
 
 import (
+	"bufio"
+	"context"
 	"errors"
+	"io"
 	"net/http"
+	"net/url"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
@@ -10,7 +14,6 @@ import (
 	"github.com/sandbox0-ai/sandbox0/cluster-gateway/pkg/middleware"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
-	"github.com/sandbox0-ai/sandbox0/pkg/proxy"
 	sharedssh "github.com/sandbox0-ai/sandbox0/pkg/sshgateway"
 	"go.uber.org/zap"
 )
@@ -109,10 +112,104 @@ func (s *Server) getSandboxLogs(c *gin.Context) {
 	// Rewrite path to manager API
 	c.Request.URL.Path = "/api/v1/sandboxes/" + sandboxID + "/logs"
 	if sandboxLogsFollowRequested(c) {
-		c.Request = proxy.WithUpstreamTimeoutDisabledRequest(c.Request)
+		s.streamSandboxLogsFromManager(c, sandboxID)
+		return
 	}
 
 	s.proxyToManager(c)
+}
+
+func (s *Server) streamSandboxLogsFromManager(c *gin.Context, sandboxID string) {
+	authCtx := middleware.GetAuthContext(c)
+	claims := internalauth.ClaimsFromContext(c.Request.Context())
+
+	internalToken, err := s.generateManagerToken(authCtx, claims, nil)
+	if err != nil {
+		s.logger.Error("Failed to generate internal token for manager",
+			zap.String("team_id", authCtx.TeamID),
+			zap.Error(err),
+		)
+		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "internal authentication failed")
+		return
+	}
+
+	managerURL, err := url.Parse(s.cfg.ManagerURL)
+	if err != nil {
+		s.logger.Error("Failed to parse manager URL", zap.Error(err))
+		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "manager upstream is invalid")
+		return
+	}
+	upstreamURL := *managerURL
+	upstreamURL.Path = "/api/v1/sandboxes/" + url.PathEscape(sandboxID) + "/logs"
+	upstreamURL.RawQuery = c.Request.URL.RawQuery
+
+	upReq, err := http.NewRequestWithContext(c.Request.Context(), http.MethodGet, upstreamURL.String(), nil)
+	if err != nil {
+		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "proxy initialization failed")
+		return
+	}
+	upReq.Header = c.Request.Header.Clone()
+	upReq.Header.Set(internalauth.TeamIDHeader, authCtx.TeamID)
+	upReq.Header.Set(internalauth.DefaultTokenHeader, internalToken)
+	upReq.Header.Set("Accept", "text/plain")
+
+	resp, err := http.DefaultClient.Do(upReq)
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return
+		}
+		s.logger.Error("Failed to connect to manager log stream",
+			zap.String("sandbox_id", sandboxID),
+			zap.String("team_id", authCtx.TeamID),
+			zap.Error(err),
+		)
+		spec.JSONError(c, http.StatusBadGateway, spec.CodeUnavailable, "failed to connect to manager log stream")
+		return
+	}
+	defer resp.Body.Close()
+
+	copyResponseHeaders(c.Writer.Header(), resp.Header)
+	c.Status(resp.StatusCode)
+	if flusher, ok := c.Writer.(http.Flusher); ok {
+		flusher.Flush()
+	}
+	if err := copyAndFlush(c.Writer, resp.Body); err != nil && !errors.Is(err, context.Canceled) {
+		s.logger.Debug("Manager log stream copy ended with error",
+			zap.String("sandbox_id", sandboxID),
+			zap.String("team_id", authCtx.TeamID),
+			zap.Error(err),
+		)
+	}
+}
+
+func copyResponseHeaders(dst, src http.Header) {
+	for key, values := range src {
+		for _, value := range values {
+			dst.Add(key, value)
+		}
+	}
+}
+
+func copyAndFlush(dst http.ResponseWriter, src io.Reader) error {
+	flusher, _ := dst.(http.Flusher)
+	reader := bufio.NewReader(src)
+	for {
+		line, readErr := reader.ReadBytes('\n')
+		if len(line) > 0 {
+			if _, err := dst.Write(line); err != nil {
+				return err
+			}
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+		if readErr != nil {
+			if errors.Is(readErr, io.EOF) {
+				return nil
+			}
+			return readErr
+		}
+	}
 }
 
 func sandboxLogsFollowRequested(c *gin.Context) bool {

--- a/cluster-gateway/pkg/http/handlers_sandbox.go
+++ b/cluster-gateway/pkg/http/handlers_sandbox.go
@@ -1,12 +1,8 @@
 package http
 
 import (
-	"bufio"
-	"context"
 	"errors"
-	"io"
 	"net/http"
-	"net/url"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
@@ -14,6 +10,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/cluster-gateway/pkg/middleware"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+	"github.com/sandbox0-ai/sandbox0/pkg/proxy"
 	sharedssh "github.com/sandbox0-ai/sandbox0/pkg/sshgateway"
 	"go.uber.org/zap"
 )
@@ -112,104 +109,11 @@ func (s *Server) getSandboxLogs(c *gin.Context) {
 	// Rewrite path to manager API
 	c.Request.URL.Path = "/api/v1/sandboxes/" + sandboxID + "/logs"
 	if sandboxLogsFollowRequested(c) {
-		s.streamSandboxLogsFromManager(c, sandboxID)
-		return
+		c.Request = proxy.WithUpstreamTimeoutDisabledRequest(c.Request)
+		c.Request.Header.Set("Accept", "text/plain")
 	}
 
 	s.proxyToManager(c)
-}
-
-func (s *Server) streamSandboxLogsFromManager(c *gin.Context, sandboxID string) {
-	authCtx := middleware.GetAuthContext(c)
-	claims := internalauth.ClaimsFromContext(c.Request.Context())
-
-	internalToken, err := s.generateManagerToken(authCtx, claims, nil)
-	if err != nil {
-		s.logger.Error("Failed to generate internal token for manager",
-			zap.String("team_id", authCtx.TeamID),
-			zap.Error(err),
-		)
-		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "internal authentication failed")
-		return
-	}
-
-	managerURL, err := url.Parse(s.cfg.ManagerURL)
-	if err != nil {
-		s.logger.Error("Failed to parse manager URL", zap.Error(err))
-		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "manager upstream is invalid")
-		return
-	}
-	upstreamURL := *managerURL
-	upstreamURL.Path = "/api/v1/sandboxes/" + url.PathEscape(sandboxID) + "/logs"
-	upstreamURL.RawQuery = c.Request.URL.RawQuery
-
-	upReq, err := http.NewRequestWithContext(c.Request.Context(), http.MethodGet, upstreamURL.String(), nil)
-	if err != nil {
-		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "proxy initialization failed")
-		return
-	}
-	upReq.Header = c.Request.Header.Clone()
-	upReq.Header.Set(internalauth.TeamIDHeader, authCtx.TeamID)
-	upReq.Header.Set(internalauth.DefaultTokenHeader, internalToken)
-	upReq.Header.Set("Accept", "text/plain")
-
-	resp, err := http.DefaultClient.Do(upReq)
-	if err != nil {
-		if errors.Is(err, context.Canceled) {
-			return
-		}
-		s.logger.Error("Failed to connect to manager log stream",
-			zap.String("sandbox_id", sandboxID),
-			zap.String("team_id", authCtx.TeamID),
-			zap.Error(err),
-		)
-		spec.JSONError(c, http.StatusBadGateway, spec.CodeUnavailable, "failed to connect to manager log stream")
-		return
-	}
-	defer resp.Body.Close()
-
-	copyResponseHeaders(c.Writer.Header(), resp.Header)
-	c.Status(resp.StatusCode)
-	if flusher, ok := c.Writer.(http.Flusher); ok {
-		flusher.Flush()
-	}
-	if err := copyAndFlush(c.Writer, resp.Body); err != nil && !errors.Is(err, context.Canceled) {
-		s.logger.Debug("Manager log stream copy ended with error",
-			zap.String("sandbox_id", sandboxID),
-			zap.String("team_id", authCtx.TeamID),
-			zap.Error(err),
-		)
-	}
-}
-
-func copyResponseHeaders(dst, src http.Header) {
-	for key, values := range src {
-		for _, value := range values {
-			dst.Add(key, value)
-		}
-	}
-}
-
-func copyAndFlush(dst http.ResponseWriter, src io.Reader) error {
-	flusher, _ := dst.(http.Flusher)
-	reader := bufio.NewReader(src)
-	for {
-		line, readErr := reader.ReadBytes('\n')
-		if len(line) > 0 {
-			if _, err := dst.Write(line); err != nil {
-				return err
-			}
-			if flusher != nil {
-				flusher.Flush()
-			}
-		}
-		if readErr != nil {
-			if errors.Is(readErr, io.EOF) {
-				return nil
-			}
-			return readErr
-		}
-	}
 }
 
 func sandboxLogsFollowRequested(c *gin.Context) bool {

--- a/cluster-gateway/pkg/http/handlers_sandbox_logs_test.go
+++ b/cluster-gateway/pkg/http/handlers_sandbox_logs_test.go
@@ -1,9 +1,9 @@
 package http
 
 import (
+	"bufio"
 	"crypto/ed25519"
 	"crypto/rand"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -22,10 +22,18 @@ import (
 func TestSandboxLogsFollowDisablesManagerProxyTimeout(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
+	unblock := make(chan struct{})
 	manager := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(100 * time.Millisecond)
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-		_, _ = io.WriteString(w, "stream logs")
+		_, _ = w.Write([]byte("stream logs\n"))
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		select {
+		case <-unblock:
+		case <-r.Context().Done():
+		}
 	}))
 	defer manager.Close()
 
@@ -86,11 +94,13 @@ func TestSandboxLogsFollowDisablesManagerProxyTimeout(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
 	}
-	body, err := io.ReadAll(resp.Body)
+	defer close(unblock)
+	reader := bufio.NewReader(resp.Body)
+	line, err := reader.ReadString('\n')
 	if err != nil {
-		t.Fatalf("read body: %v", err)
+		t.Fatalf("read stream line: %v", err)
 	}
-	if string(body) != "stream logs" {
-		t.Fatalf("body = %q, want %q", string(body), "stream logs")
+	if line != "stream logs\n" {
+		t.Fatalf("stream line = %q, want %q", line, "stream logs\n")
 	}
 }

--- a/manager/cmd/procd/main.go
+++ b/manager/cmd/procd/main.go
@@ -64,6 +64,8 @@ func main() {
 	defer obsProvider.Shutdown(context.Background())
 
 	// Initialize managers
+	configureProcessOutputForwarding(logger)
+
 	contextManager := ctxpkg.NewManager()
 	contextManager.SetDefaultCleanupPolicy(ctxpkg.CleanupPolicy{
 		IdleTimeout: cfg.ContextIdleTimeout.Duration,

--- a/manager/cmd/procd/process_output_forwarding.go
+++ b/manager/cmd/procd/process_output_forwarding.go
@@ -10,33 +10,38 @@ import (
 )
 
 const (
-	processOutputForwardingEnvVar        = "SANDBOX0_FORWARD_PROCESS_OUTPUT_TO_CONTAINER_LOGS"
-	processOutputForwardingMaxLineEnvVar = "SANDBOX0_PROCESS_OUTPUT_LOG_MAX_LINE_BYTES"
+	processOutputLogsEnvVar             = "SANDBOX0_PROCESS_LOGS"
+	processOutputLogsMaxLineBytesEnvVar = "SANDBOX0_PROCESS_LOG_MAX_BYTES"
 )
 
 func configureProcessOutputForwarding(logger *zap.Logger) {
-	enabled, err := boolEnv(processOutputForwardingEnvVar)
+	enabled, err := processOutputLogsEnabled()
 	if err != nil {
 		if logger != nil {
-			logger.Warn("Ignoring invalid process output forwarding setting",
-				zap.String("env", processOutputForwardingEnvVar),
+			logger.Warn("Ignoring invalid process log setting; defaulting to enabled",
+				zap.String("env", processOutputLogsEnvVar),
 				zap.Error(err),
+			)
+		}
+		enabled = true
+	}
+	if !enabled {
+		process.SetDefaultOutputForwarder(nil)
+		if logger != nil {
+			logger.Info("Sandbox process output forwarding disabled",
+				zap.String("env", processOutputLogsEnvVar),
 			)
 		}
 		return
 	}
-	if !enabled {
-		process.SetDefaultOutputForwarder(nil)
-		return
-	}
 
 	maxLineBytes := process.DefaultContainerLogMaxLineBytes
-	if raw := strings.TrimSpace(os.Getenv(processOutputForwardingMaxLineEnvVar)); raw != "" {
+	if raw := strings.TrimSpace(os.Getenv(processOutputLogsMaxLineBytesEnvVar)); raw != "" {
 		parsed, parseErr := strconv.Atoi(raw)
 		if parseErr != nil || parsed <= 0 {
 			if logger != nil {
 				logger.Warn("Ignoring invalid process output log line limit",
-					zap.String("env", processOutputForwardingMaxLineEnvVar),
+					zap.String("env", processOutputLogsMaxLineBytesEnvVar),
 					zap.String("value", raw),
 				)
 			}
@@ -52,16 +57,16 @@ func configureProcessOutputForwarding(logger *zap.Logger) {
 	}))
 	if logger != nil {
 		logger.Info("Sandbox process output forwarding enabled",
-			zap.String("env", processOutputForwardingEnvVar),
+			zap.String("env", processOutputLogsEnvVar),
 			zap.Int("max_line_bytes", maxLineBytes),
 		)
 	}
 }
 
-func boolEnv(name string) (bool, error) {
-	raw := strings.TrimSpace(os.Getenv(name))
+func processOutputLogsEnabled() (bool, error) {
+	raw := strings.TrimSpace(os.Getenv(processOutputLogsEnvVar))
 	if raw == "" {
-		return false, nil
+		return true, nil
 	}
 	return strconv.ParseBool(raw)
 }

--- a/manager/cmd/procd/process_output_forwarding.go
+++ b/manager/cmd/procd/process_output_forwarding.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/process"
+	"go.uber.org/zap"
+)
+
+const (
+	processOutputForwardingEnvVar        = "SANDBOX0_FORWARD_PROCESS_OUTPUT_TO_CONTAINER_LOGS"
+	processOutputForwardingMaxLineEnvVar = "SANDBOX0_PROCESS_OUTPUT_LOG_MAX_LINE_BYTES"
+)
+
+func configureProcessOutputForwarding(logger *zap.Logger) {
+	enabled, err := boolEnv(processOutputForwardingEnvVar)
+	if err != nil {
+		if logger != nil {
+			logger.Warn("Ignoring invalid process output forwarding setting",
+				zap.String("env", processOutputForwardingEnvVar),
+				zap.Error(err),
+			)
+		}
+		return
+	}
+	if !enabled {
+		process.SetDefaultOutputForwarder(nil)
+		return
+	}
+
+	maxLineBytes := process.DefaultContainerLogMaxLineBytes
+	if raw := strings.TrimSpace(os.Getenv(processOutputForwardingMaxLineEnvVar)); raw != "" {
+		parsed, parseErr := strconv.Atoi(raw)
+		if parseErr != nil || parsed <= 0 {
+			if logger != nil {
+				logger.Warn("Ignoring invalid process output log line limit",
+					zap.String("env", processOutputForwardingMaxLineEnvVar),
+					zap.String("value", raw),
+				)
+			}
+		} else {
+			maxLineBytes = parsed
+		}
+	}
+
+	process.SetDefaultOutputForwarder(process.NewContainerLogForwarder(process.ContainerLogForwarderOptions{
+		Stdout:       os.Stdout,
+		Stderr:       os.Stderr,
+		MaxLineBytes: maxLineBytes,
+	}))
+	if logger != nil {
+		logger.Info("Sandbox process output forwarding enabled",
+			zap.String("env", processOutputForwardingEnvVar),
+			zap.Int("max_line_bytes", maxLineBytes),
+		)
+	}
+}
+
+func boolEnv(name string) (bool, error) {
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return false, nil
+	}
+	return strconv.ParseBool(raw)
+}

--- a/manager/cmd/procd/process_output_forwarding_test.go
+++ b/manager/cmd/procd/process_output_forwarding_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessOutputLogsEnabledDefaultsOn(t *testing.T) {
+	t.Setenv(processOutputLogsEnvVar, "")
+
+	enabled, err := processOutputLogsEnabled()
+	require.NoError(t, err)
+	require.True(t, enabled)
+}
+
+func TestProcessOutputLogsEnabledAllowsOptOut(t *testing.T) {
+	t.Setenv(processOutputLogsEnvVar, "false")
+
+	enabled, err := processOutputLogsEnabled()
+	require.NoError(t, err)
+	require.False(t, enabled)
+}
+
+func TestProcessOutputLogsEnabledRejectsInvalidValues(t *testing.T) {
+	t.Setenv(processOutputLogsEnvVar, "disabled")
+
+	_, err := processOutputLogsEnabled()
+	require.Error(t, err)
+}

--- a/manager/pkg/apis/sandbox0/v1alpha1/helpers.go
+++ b/manager/pkg/apis/sandbox0/v1alpha1/helpers.go
@@ -22,6 +22,8 @@ const (
 	netdMITMCADir       = "/var/run/sandbox0/netd"
 	netdMITMCACertPath  = netdMITMCADir + "/mitm-ca.crt"
 
+	processOutputForwardingEnvVar = "SANDBOX0_FORWARD_PROCESS_OUTPUT_TO_CONTAINER_LOGS"
+
 	// Template resources remain hard limits; requests reserve a smaller baseline
 	// so warm pools and cold-start sandboxes can be packed efficiently.
 	defaultSandboxCPURequestRatioMillis    = int64(100)
@@ -326,6 +328,10 @@ func appendProcdConfigEnvVars(envVars []corev1.EnvVar) []corev1.EnvVar {
 		ValueFrom: &corev1.EnvVarSource{
 			FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
 		},
+	})
+	upsertProcdEnvVar(envIndex, &envVars, corev1.EnvVar{
+		Name:  processOutputForwardingEnvVar,
+		Value: "true",
 	})
 
 	cfg := config.LoadManagerConfig()

--- a/manager/pkg/apis/sandbox0/v1alpha1/helpers.go
+++ b/manager/pkg/apis/sandbox0/v1alpha1/helpers.go
@@ -22,8 +22,6 @@ const (
 	netdMITMCADir       = "/var/run/sandbox0/netd"
 	netdMITMCACertPath  = netdMITMCADir + "/mitm-ca.crt"
 
-	processOutputForwardingEnvVar = "SANDBOX0_FORWARD_PROCESS_OUTPUT_TO_CONTAINER_LOGS"
-
 	// Template resources remain hard limits; requests reserve a smaller baseline
 	// so warm pools and cold-start sandboxes can be packed efficiently.
 	defaultSandboxCPURequestRatioMillis    = int64(100)
@@ -328,10 +326,6 @@ func appendProcdConfigEnvVars(envVars []corev1.EnvVar) []corev1.EnvVar {
 		ValueFrom: &corev1.EnvVarSource{
 			FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
 		},
-	})
-	upsertProcdEnvVar(envIndex, &envVars, corev1.EnvVar{
-		Name:  processOutputForwardingEnvVar,
-		Value: "true",
 	})
 
 	cfg := config.LoadManagerConfig()

--- a/manager/pkg/apis/sandbox0/v1alpha1/helpers_test.go
+++ b/manager/pkg/apis/sandbox0/v1alpha1/helpers_test.go
@@ -441,33 +441,33 @@ procd_config:
 	}
 }
 
-func TestBuildPodSpecKeepsProcessOutputForwardingOptIn(t *testing.T) {
+func TestBuildPodSpecKeepsProcessLogsDefaultAndOptOutEnv(t *testing.T) {
 	configPath := writeManagerConfig(t, `
 manager_image: sandbox0/manager:test
 `)
 	t.Setenv("CONFIG_PATH", configPath)
 
 	template := newTestTemplate()
-	const forwardingEnvVar = "SANDBOX0_FORWARD_PROCESS_OUTPUT_TO_CONTAINER_LOGS"
+	const processLogsEnvVar = "SANDBOX0_PROCESS_LOGS"
 
 	defaultSpec := BuildPodSpec(template)
 	if len(defaultSpec.Containers) == 0 {
 		t.Fatal("expected at least one container")
 	}
-	if env := findEnvVar(defaultSpec.Containers[0].Env, forwardingEnvVar); env != nil {
-		t.Fatalf("%s = %#v, want omitted by default", forwardingEnvVar, env)
+	if env := findEnvVar(defaultSpec.Containers[0].Env, processLogsEnvVar); env != nil {
+		t.Fatalf("%s = %#v, want omitted because procd defaults it on", processLogsEnvVar, env)
 	}
 
-	template.Spec.EnvVars = map[string]string{forwardingEnvVar: "true"}
+	template.Spec.EnvVars = map[string]string{processLogsEnvVar: "false"}
 
 	spec := BuildPodSpec(template)
 	if len(spec.Containers) == 0 {
 		t.Fatal("expected at least one container")
 	}
 
-	env := findEnvVar(spec.Containers[0].Env, forwardingEnvVar)
-	if env == nil || env.Value != "true" {
-		t.Fatalf("%s = %#v, want true", forwardingEnvVar, env)
+	env := findEnvVar(spec.Containers[0].Env, processLogsEnvVar)
+	if env == nil || env.Value != "false" {
+		t.Fatalf("%s = %#v, want false", processLogsEnvVar, env)
 	}
 }
 

--- a/manager/pkg/apis/sandbox0/v1alpha1/helpers_test.go
+++ b/manager/pkg/apis/sandbox0/v1alpha1/helpers_test.go
@@ -441,25 +441,33 @@ procd_config:
 	}
 }
 
-func TestBuildPodSpecForwardsProcessOutputToContainerLogs(t *testing.T) {
+func TestBuildPodSpecKeepsProcessOutputForwardingOptIn(t *testing.T) {
 	configPath := writeManagerConfig(t, `
 manager_image: sandbox0/manager:test
 `)
 	t.Setenv("CONFIG_PATH", configPath)
 
 	template := newTestTemplate()
-	template.Spec.EnvVars = map[string]string{
-		processOutputForwardingEnvVar: "false",
+	const forwardingEnvVar = "SANDBOX0_FORWARD_PROCESS_OUTPUT_TO_CONTAINER_LOGS"
+
+	defaultSpec := BuildPodSpec(template)
+	if len(defaultSpec.Containers) == 0 {
+		t.Fatal("expected at least one container")
 	}
+	if env := findEnvVar(defaultSpec.Containers[0].Env, forwardingEnvVar); env != nil {
+		t.Fatalf("%s = %#v, want omitted by default", forwardingEnvVar, env)
+	}
+
+	template.Spec.EnvVars = map[string]string{forwardingEnvVar: "true"}
 
 	spec := BuildPodSpec(template)
 	if len(spec.Containers) == 0 {
 		t.Fatal("expected at least one container")
 	}
 
-	env := findEnvVar(spec.Containers[0].Env, processOutputForwardingEnvVar)
+	env := findEnvVar(spec.Containers[0].Env, forwardingEnvVar)
 	if env == nil || env.Value != "true" {
-		t.Fatalf("%s = %#v, want true", processOutputForwardingEnvVar, env)
+		t.Fatalf("%s = %#v, want true", forwardingEnvVar, env)
 	}
 }
 

--- a/manager/pkg/apis/sandbox0/v1alpha1/helpers_test.go
+++ b/manager/pkg/apis/sandbox0/v1alpha1/helpers_test.go
@@ -441,6 +441,28 @@ procd_config:
 	}
 }
 
+func TestBuildPodSpecForwardsProcessOutputToContainerLogs(t *testing.T) {
+	configPath := writeManagerConfig(t, `
+manager_image: sandbox0/manager:test
+`)
+	t.Setenv("CONFIG_PATH", configPath)
+
+	template := newTestTemplate()
+	template.Spec.EnvVars = map[string]string{
+		processOutputForwardingEnvVar: "false",
+	}
+
+	spec := BuildPodSpec(template)
+	if len(spec.Containers) == 0 {
+		t.Fatal("expected at least one container")
+	}
+
+	env := findEnvVar(spec.Containers[0].Env, processOutputForwardingEnvVar)
+	if env == nil || env.Value != "true" {
+		t.Fatalf("%s = %#v, want true", processOutputForwardingEnvVar, env)
+	}
+}
+
 func TestBuildPodSpecFailsClosedForStorageProxyEnvOverridesWhenManagerConfigUnset(t *testing.T) {
 	configPath := writeManagerConfig(t, `
 manager_image: sandbox0/manager:test

--- a/manager/pkg/http/handlers_sandbox.go
+++ b/manager/pkg/http/handlers_sandbox.go
@@ -348,7 +348,8 @@ func (s *Server) getSandboxLogs(c *gin.Context) {
 		return
 	}
 
-	spec.JSONSuccess(c, http.StatusOK, logs)
+	writeSandboxLogHeaders(c, logs.SandboxID, logs.PodName, logs.Container, logs.Previous)
+	c.Data(http.StatusOK, "text/plain; charset=utf-8", []byte(logs.Logs))
 }
 
 func (s *Server) streamSandboxLogs(c *gin.Context, sandboxID, teamID string, options *service.SandboxLogsOptions) {
@@ -362,19 +363,27 @@ func (s *Server) streamSandboxLogs(c *gin.Context, sandboxID, teamID string, opt
 	c.Header("Content-Type", "text/plain; charset=utf-8")
 	c.Header("Cache-Control", "no-cache")
 	c.Header("X-Accel-Buffering", "no")
-	c.Header("X-Sandbox-ID", stream.SandboxID)
-	c.Header("X-Sandbox-Pod-Name", stream.PodName)
-	c.Header("X-Sandbox-Log-Container", stream.Container)
+	writeSandboxLogHeaders(c, stream.SandboxID, stream.PodName, stream.Container, stream.Previous)
 	c.Status(http.StatusOK)
 	c.Writer.Flush()
 
-	if _, err := io.Copy(flushingResponseWriter{ResponseWriter: c.Writer}, stream.Body); err != nil && !errors.Is(err, context.Canceled) {
-		s.logger.Debug("Sandbox log stream ended with error",
-			zap.String("sandboxID", sandboxID),
-			zap.String("teamID", teamID),
-			zap.Error(err),
-		)
+	writer := flushingResponseWriter{ResponseWriter: c.Writer}
+	if _, err := io.Copy(writer, stream.Body); err != nil {
+		if !errors.Is(err, context.Canceled) {
+			s.logger.Debug("Sandbox log stream ended with error",
+				zap.String("sandboxID", sandboxID),
+				zap.String("teamID", teamID),
+				zap.Error(err),
+			)
+		}
 	}
+}
+
+func writeSandboxLogHeaders(c *gin.Context, sandboxID, podName, container string, previous bool) {
+	c.Header("X-Sandbox-ID", sandboxID)
+	c.Header("X-Sandbox-Pod-Name", podName)
+	c.Header("X-Sandbox-Log-Container", container)
+	c.Header("X-Sandbox-Log-Previous", strconv.FormatBool(previous))
 }
 
 func (s *Server) writeSandboxLogsError(c *gin.Context, sandboxID, teamID string, err error) {

--- a/manager/pkg/http/handlers_sandbox_logs_test.go
+++ b/manager/pkg/http/handlers_sandbox_logs_test.go
@@ -23,8 +23,9 @@ func TestGetSandboxLogsReturnsOK(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	pod := newHTTPLogsTestPod("sandbox-1", "team-1")
+	client := fake.NewSimpleClientset(pod)
 	sandboxService := service.NewSandboxService(
-		fake.NewSimpleClientset(pod),
+		client,
 		newHTTPTestPodLister(t, pod),
 		nil,
 		nil,
@@ -50,14 +51,11 @@ func TestGetSandboxLogsReturnsOK(t *testing.T) {
 	server.getSandboxLogs(ctx)
 
 	assert.Equal(t, http.StatusOK, recorder.Code)
-	payload, apiErr, err := spec.DecodeResponse[service.SandboxLogsResponse](bytes.NewReader(recorder.Body.Bytes()))
-	require.NoError(t, err)
-	require.Nil(t, apiErr)
-	require.NotNil(t, payload)
-	assert.Equal(t, "sandbox-1", payload.SandboxID)
-	assert.Equal(t, "procd", payload.Container)
-	assert.True(t, payload.Previous)
-	assert.Equal(t, "fake logs", payload.Logs)
+	assert.Contains(t, recorder.Header().Get("Content-Type"), "text/plain")
+	assert.Equal(t, "sandbox-1", recorder.Header().Get("X-Sandbox-ID"))
+	assert.Equal(t, "procd", recorder.Header().Get("X-Sandbox-Log-Container"))
+	assert.Equal(t, "true", recorder.Header().Get("X-Sandbox-Log-Previous"))
+	assert.Equal(t, "fake logs", recorder.Body.String())
 }
 
 func TestGetSandboxLogsStreamsWhenFollowTrue(t *testing.T) {
@@ -94,6 +92,7 @@ func TestGetSandboxLogsStreamsWhenFollowTrue(t *testing.T) {
 	assert.Contains(t, recorder.Header().Get("Content-Type"), "text/plain")
 	assert.Equal(t, "sandbox-1", recorder.Header().Get("X-Sandbox-ID"))
 	assert.Equal(t, "procd", recorder.Header().Get("X-Sandbox-Log-Container"))
+	assert.Equal(t, "false", recorder.Header().Get("X-Sandbox-Log-Previous"))
 	assert.Equal(t, "fake logs", recorder.Body.String())
 }
 

--- a/manager/pkg/service/sandbox_service_logs.go
+++ b/manager/pkg/service/sandbox_service_logs.go
@@ -35,7 +35,7 @@ type SandboxLogsOptions struct {
 	SinceSeconds *int64 `json:"since_seconds,omitempty"`
 }
 
-// SandboxLogsResponse is the public payload returned by the sandbox logs API.
+// SandboxLogsResponse carries a bounded log snapshot plus Kubernetes metadata.
 type SandboxLogsResponse struct {
 	SandboxID string `json:"sandbox_id"`
 	PodName   string `json:"pod_name"`

--- a/manager/procd/pkg/http/server.go
+++ b/manager/procd/pkg/http/server.go
@@ -186,7 +186,7 @@ func (s *Server) Start() error {
 		Addr:         addr,
 		Handler:      s.router,
 		ReadTimeout:  30 * time.Second,
-		WriteTimeout: 0, // Disabled for SSE streaming support
+		WriteTimeout: 0, // Disabled for long-running stream responses.
 		IdleTimeout:  120 * time.Second,
 	}
 

--- a/manager/procd/pkg/process/container_log_forwarder.go
+++ b/manager/procd/pkg/process/container_log_forwarder.go
@@ -1,0 +1,201 @@
+package process
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
+	"sync"
+)
+
+const DefaultContainerLogMaxLineBytes = 4096
+
+var (
+	defaultOutputForwarderMu sync.RWMutex
+	defaultOutputForwarder   OutputForwarder
+)
+
+// SetDefaultOutputForwarder configures the output forwarder inherited by new processes.
+func SetDefaultOutputForwarder(forwarder OutputForwarder) {
+	defaultOutputForwarderMu.Lock()
+	defer defaultOutputForwarderMu.Unlock()
+	defaultOutputForwarder = forwarder
+}
+
+func defaultOutputForwarderSnapshot() OutputForwarder {
+	defaultOutputForwarderMu.RLock()
+	defer defaultOutputForwarderMu.RUnlock()
+	return defaultOutputForwarder
+}
+
+// ContainerLogForwarderOptions configures process output mirroring to container logs.
+type ContainerLogForwarderOptions struct {
+	Stdout       io.Writer
+	Stderr       io.Writer
+	MaxLineBytes int
+}
+
+// ContainerLogForwarder writes bounded process output events as JSON lines.
+type ContainerLogForwarder struct {
+	mu           sync.Mutex
+	stdout       io.Writer
+	stderr       io.Writer
+	maxLineBytes int
+	streams      map[containerLogStreamKey]*containerLogLineState
+}
+
+// NewContainerLogForwarder creates a process output forwarder for pod logs.
+func NewContainerLogForwarder(opts ContainerLogForwarderOptions) *ContainerLogForwarder {
+	stdout := opts.Stdout
+	if stdout == nil {
+		stdout = os.Stdout
+	}
+	stderr := opts.Stderr
+	if stderr == nil {
+		stderr = os.Stderr
+	}
+	maxLineBytes := opts.MaxLineBytes
+	if maxLineBytes <= 0 {
+		maxLineBytes = DefaultContainerLogMaxLineBytes
+	}
+	return &ContainerLogForwarder{
+		stdout:       stdout,
+		stderr:       stderr,
+		maxLineBytes: maxLineBytes,
+		streams:      make(map[containerLogStreamKey]*containerLogLineState),
+	}
+}
+
+// ForwardOutput mirrors a process output chunk to container stdout/stderr.
+func (f *ContainerLogForwarder) ForwardOutput(desc ProcessDescriptor, output ProcessOutput) {
+	if f == nil || len(output.Data) == 0 || output.Source == OutputSourcePrompt {
+		return
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.forwardLocked(desc, output.Source, output.Data)
+}
+
+// FlushProcessOutput writes any buffered partial lines for one process.
+func (f *ContainerLogForwarder) FlushProcessOutput(desc ProcessDescriptor) {
+	if f == nil {
+		return
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for key, state := range f.streams {
+		if key.processID != desc.ProcessID {
+			continue
+		}
+		if len(state.data) > 0 {
+			f.writeLineLocked(desc, key.source, state.data, false)
+		}
+		delete(f.streams, key)
+	}
+}
+
+func (f *ContainerLogForwarder) forwardLocked(desc ProcessDescriptor, source OutputSource, data []byte) {
+	key := containerLogStreamKey{processID: desc.ProcessID, source: source}
+	state := f.streams[key]
+	if state == nil {
+		state = &containerLogLineState{}
+		f.streams[key] = state
+	}
+
+	for len(data) > 0 {
+		if state.discarding {
+			if idx := bytes.IndexByte(data, '\n'); idx >= 0 {
+				state.discarding = false
+				data = data[idx+1:]
+				continue
+			}
+			return
+		}
+
+		if idx := bytes.IndexByte(data, '\n'); idx >= 0 {
+			linePart := trimTrailingCarriageReturn(data[:idx])
+			if len(state.data)+len(linePart) > f.maxLineBytes {
+				available := f.maxLineBytes - len(state.data)
+				if available > 0 {
+					state.data = append(state.data, linePart[:available]...)
+				}
+				f.writeLineLocked(desc, source, state.data, true)
+			} else {
+				state.data = append(state.data, linePart...)
+				f.writeLineLocked(desc, source, state.data, false)
+			}
+			state.data = state.data[:0]
+			data = data[idx+1:]
+			continue
+		}
+
+		if len(state.data)+len(data) > f.maxLineBytes {
+			available := f.maxLineBytes - len(state.data)
+			if available > 0 {
+				state.data = append(state.data, data[:available]...)
+			}
+			f.writeLineLocked(desc, source, state.data, true)
+			state.data = state.data[:0]
+			state.discarding = true
+			return
+		}
+
+		state.data = append(state.data, data...)
+		return
+	}
+}
+
+func (f *ContainerLogForwarder) writeLineLocked(desc ProcessDescriptor, source OutputSource, data []byte, truncated bool) {
+	line := containerLogLine{
+		Message:     "sandbox process output",
+		ProcessID:   desc.ProcessID,
+		ProcessType: desc.ProcessType,
+		PID:         desc.PID,
+		Alias:       desc.Alias,
+		Source:      source,
+		Data:        strings.ToValidUTF8(string(data), "?"),
+		Truncated:   truncated,
+	}
+	payload, err := json.Marshal(line)
+	if err != nil {
+		return
+	}
+	payload = append(payload, '\n')
+	_, _ = f.writerForSource(source).Write(payload)
+}
+
+func (f *ContainerLogForwarder) writerForSource(source OutputSource) io.Writer {
+	if source == OutputSourceStderr {
+		return f.stderr
+	}
+	return f.stdout
+}
+
+func trimTrailingCarriageReturn(data []byte) []byte {
+	if len(data) > 0 && data[len(data)-1] == '\r' {
+		return data[:len(data)-1]
+	}
+	return data
+}
+
+type containerLogStreamKey struct {
+	processID string
+	source    OutputSource
+}
+
+type containerLogLineState struct {
+	data       []byte
+	discarding bool
+}
+
+type containerLogLine struct {
+	Message     string       `json:"message"`
+	ProcessID   string       `json:"process_id"`
+	ProcessType ProcessType  `json:"process_type"`
+	PID         int          `json:"pid,omitempty"`
+	Alias       string       `json:"alias,omitempty"`
+	Source      OutputSource `json:"source"`
+	Data        string       `json:"data"`
+	Truncated   bool         `json:"truncated,omitempty"`
+}

--- a/manager/procd/pkg/process/container_log_forwarder_test.go
+++ b/manager/procd/pkg/process/container_log_forwarder_test.go
@@ -64,6 +64,21 @@ func TestContainerLogForwarderTruncatesLongLines(t *testing.T) {
 	}
 }
 
+func TestDefaultOutputForwarderIsInheritedByNewProcesses(t *testing.T) {
+	var stdout bytes.Buffer
+	forwarder := NewContainerLogForwarder(ContainerLogForwarderOptions{Stdout: &stdout})
+	SetDefaultOutputForwarder(forwarder)
+	t.Cleanup(func() { SetDefaultOutputForwarder(nil) })
+
+	base := NewBaseProcess("ctx-default", ProcessTypeCMD, ProcessConfig{Type: ProcessTypeCMD, Alias: "helper"})
+	base.PublishOutput(ProcessOutput{Source: OutputSourceStdout, Data: []byte("ready\n")})
+
+	event := decodeContainerLogLine(t, stdout.Bytes())
+	if event.ProcessID != "ctx-default" || event.Alias != "helper" || event.Source != OutputSourceStdout || event.Data != "ready" {
+		t.Fatalf("unexpected inherited forwarder event: %#v", event)
+	}
+}
+
 func decodeContainerLogLine(t *testing.T, data []byte) containerLogLine {
 	t.Helper()
 	events := decodeContainerLogLines(t, data)

--- a/manager/procd/pkg/process/container_log_forwarder_test.go
+++ b/manager/procd/pkg/process/container_log_forwarder_test.go
@@ -1,0 +1,91 @@
+package process
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestContainerLogForwarderForwardsProcessOutput(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	forwarder := NewContainerLogForwarder(ContainerLogForwarderOptions{
+		Stdout:       &stdout,
+		Stderr:       &stderr,
+		MaxLineBytes: 64,
+	})
+	base := NewBaseProcess("ctx-test", ProcessTypeCMD, ProcessConfig{Type: ProcessTypeCMD, Alias: "worker"})
+	base.SetOutputForwarder(forwarder)
+	base.SetPID(123)
+	outputCh := base.ReadOutput()
+
+	base.PublishOutput(ProcessOutput{Source: OutputSourceStdout, Data: []byte("hello")})
+	base.PublishOutput(ProcessOutput{Source: OutputSourceStderr, Data: []byte("failed\n")})
+	base.PublishOutput(ProcessOutput{Source: OutputSourcePrompt})
+	base.CloseOutput()
+
+	select {
+	case output := <-outputCh:
+		if string(output.Data) != "hello" {
+			t.Fatalf("process output data = %q, want hello", string(output.Data))
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for process output")
+	}
+
+	stdoutEvent := decodeContainerLogLine(t, stdout.Bytes())
+	if stdoutEvent.Message != "sandbox process output" || stdoutEvent.ProcessID != "ctx-test" || stdoutEvent.ProcessType != ProcessTypeCMD || stdoutEvent.PID != 123 || stdoutEvent.Alias != "worker" || stdoutEvent.Source != OutputSourceStdout || stdoutEvent.Data != "hello" {
+		t.Fatalf("unexpected stdout event: %#v", stdoutEvent)
+	}
+	stderrEvent := decodeContainerLogLine(t, stderr.Bytes())
+	if stderrEvent.Source != OutputSourceStderr || stderrEvent.Data != "failed" {
+		t.Fatalf("unexpected stderr event: %#v", stderrEvent)
+	}
+}
+
+func TestContainerLogForwarderTruncatesLongLines(t *testing.T) {
+	var stdout bytes.Buffer
+	forwarder := NewContainerLogForwarder(ContainerLogForwarderOptions{Stdout: &stdout, MaxLineBytes: 5})
+	base := NewBaseProcess("ctx-test", ProcessTypeCMD, ProcessConfig{Type: ProcessTypeCMD})
+	base.SetOutputForwarder(forwarder)
+
+	base.PublishOutput(ProcessOutput{Source: OutputSourceStdout, Data: []byte("123456789\nnext\n")})
+
+	events := decodeContainerLogLines(t, stdout.Bytes())
+	if len(events) != 2 {
+		t.Fatalf("event count = %d, want 2: %s", len(events), stdout.String())
+	}
+	if events[0].Data != "12345" || !events[0].Truncated {
+		t.Fatalf("first event = %#v, want truncated 12345", events[0])
+	}
+	if events[1].Data != "next" || events[1].Truncated {
+		t.Fatalf("second event = %#v, want full next", events[1])
+	}
+}
+
+func decodeContainerLogLine(t *testing.T, data []byte) containerLogLine {
+	t.Helper()
+	events := decodeContainerLogLines(t, data)
+	if len(events) != 1 {
+		t.Fatalf("event count = %d, want 1: %s", len(events), string(data))
+	}
+	return events[0]
+}
+
+func decodeContainerLogLines(t *testing.T, data []byte) []containerLogLine {
+	t.Helper()
+	lines := bytes.Split(bytes.TrimSpace(data), []byte("\n"))
+	events := make([]containerLogLine, 0, len(lines))
+	for _, line := range lines {
+		if len(line) == 0 {
+			continue
+		}
+		var event containerLogLine
+		if err := json.Unmarshal(line, &event); err != nil {
+			t.Fatalf("unmarshal event %q: %v", string(line), err)
+		}
+		events = append(events, event)
+	}
+	return events
+}

--- a/manager/procd/pkg/process/process.go
+++ b/manager/procd/pkg/process/process.go
@@ -62,6 +62,24 @@ type ProcessConfig struct {
 	BufferSize int               `json:"buffer_size"` // Number of messages to buffer for the output multiplexer, default is 64 if not set
 }
 
+// ProcessDescriptor identifies the process that emitted an output event.
+type ProcessDescriptor struct {
+	ProcessID   string
+	ProcessType ProcessType
+	PID         int
+	Alias       string
+}
+
+// OutputForwarder mirrors process output to an additional diagnostic sink.
+type OutputForwarder interface {
+	ForwardOutput(ProcessDescriptor, ProcessOutput)
+}
+
+// FlushableOutputForwarder can flush buffered partial output before a process closes.
+type FlushableOutputForwarder interface {
+	FlushProcessOutput(ProcessDescriptor)
+}
+
 // ProcessOutput represents output from a process.
 type ProcessOutput struct {
 	Source OutputSource `json:"source"`
@@ -185,6 +203,7 @@ type BaseProcess struct {
 	exitCode        int
 	pty             *os.File
 	outputMultiplex *MultiplexedChannel[ProcessOutput]
+	outputForwarder OutputForwarder
 	startTime       time.Time
 
 	// cpuTracker tracks CPU time between samples for percentage calculation
@@ -214,6 +233,7 @@ func NewBaseProcess(id string, processType ProcessType, config ProcessConfig) *B
 		config:          config,
 		state:           ProcessStateCreated,
 		outputMultiplex: NewMultiplexedChannel[ProcessOutput](config.BufferSize),
+		outputForwarder: defaultOutputForwarderSnapshot(),
 		cpuTracker:      newCPUTracker(),
 		inputQueue:      make(chan []byte, config.BufferSize),
 		inputReady:      make(chan struct{}),
@@ -223,6 +243,13 @@ func NewBaseProcess(id string, processType ProcessType, config ProcessConfig) *B
 		close(bp.inputReady)
 	}
 	return bp
+}
+
+// SetOutputForwarder configures an optional diagnostic sink for process output.
+func (bp *BaseProcess) SetOutputForwarder(forwarder OutputForwarder) {
+	bp.mu.Lock()
+	defer bp.mu.Unlock()
+	bp.outputForwarder = forwarder
 }
 
 // AddExitHandler appends an exit handler to the handler chain.
@@ -581,11 +608,34 @@ func (bp *BaseProcess) NotifyStart(event StartEvent) {
 // PublishOutput publishes output to all subscribers.
 func (bp *BaseProcess) PublishOutput(output ProcessOutput) {
 	bp.outputMultiplex.Publish(output)
+	if forwarder := bp.outputForwarderSnapshot(); forwarder != nil {
+		forwarder.ForwardOutput(bp.descriptor(), output)
+	}
 }
 
 // CloseOutput closes the output channel.
 func (bp *BaseProcess) CloseOutput() {
+	if forwarder, ok := bp.outputForwarderSnapshot().(FlushableOutputForwarder); ok && forwarder != nil {
+		forwarder.FlushProcessOutput(bp.descriptor())
+	}
 	bp.outputMultiplex.Close()
+}
+
+func (bp *BaseProcess) outputForwarderSnapshot() OutputForwarder {
+	bp.mu.RLock()
+	defer bp.mu.RUnlock()
+	return bp.outputForwarder
+}
+
+func (bp *BaseProcess) descriptor() ProcessDescriptor {
+	bp.mu.RLock()
+	defer bp.mu.RUnlock()
+	return ProcessDescriptor{
+		ProcessID:   bp.id,
+		ProcessType: bp.processType,
+		PID:         bp.pid,
+		Alias:       bp.config.Alias,
+	}
 }
 
 // GetPTY returns the PTY file descriptor.

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -1304,8 +1304,9 @@ paths:
       tags: [sandboxes]
       summary: Get sandbox pod logs
       description: |
-        Returns a bounded snapshot of Kubernetes container logs for the sandbox pod.
-        Set `follow=true` to stream logs as text/plain until the client disconnects.
+        Returns Kubernetes container logs for the sandbox pod.
+        When `follow=false`, the response is a bounded text/plain snapshot.
+        When `follow=true`, the response is a text/plain stream until the client disconnects.
       security:
         - bearerAuth: []
       x-upstream-service: manager
@@ -1338,7 +1339,7 @@ paths:
             maximum: 8388608
         - name: follow
           in: query
-          description: Stream logs until the client disconnects. When true, the response content type is text/plain.
+          description: Stream logs as text/plain until the client disconnects. When false, return a text/plain snapshot.
           schema:
             type: boolean
             default: false
@@ -1364,10 +1365,24 @@ paths:
       responses:
         "200":
           description: Sandbox pod logs
-          content:
-            application/json:
+          headers:
+            X-Sandbox-ID:
+              description: Sandbox ID for the returned log payload.
               schema:
-                $ref: "#/components/schemas/SuccessSandboxLogsResponse"
+                type: string
+            X-Sandbox-Pod-Name:
+              description: Kubernetes pod name that produced the returned log payload.
+              schema:
+                type: string
+            X-Sandbox-Log-Container:
+              description: Kubernetes container name that produced the returned log payload.
+              schema:
+                type: string
+            X-Sandbox-Log-Previous:
+              description: Whether the returned payload came from a previously terminated container instance.
+              schema:
+                type: boolean
+          content:
             text/plain:
               schema:
                 type: string
@@ -4193,26 +4208,6 @@ components:
           type: string
         created_at:
           type: string
-    SandboxLogs:
-      type: object
-      properties:
-        sandbox_id:
-          type: string
-        pod_name:
-          type: string
-        container:
-          type: string
-        previous:
-          type: boolean
-        logs:
-          type: string
-          description: Log text returned by Kubernetes for the selected container.
-      required:
-        - sandbox_id
-        - pod_name
-        - container
-        - previous
-        - logs
     SuccessSandboxResponse:
       allOf:
         - $ref: "#/components/schemas/SuccessEnvelope"
@@ -4227,13 +4222,6 @@ components:
           properties:
             data:
               $ref: "#/components/schemas/SandboxStatus"
-    SuccessSandboxLogsResponse:
-      allOf:
-        - $ref: "#/components/schemas/SuccessEnvelope"
-        - type: object
-          properties:
-            data:
-              $ref: "#/components/schemas/SandboxLogs"
     SandboxSummary:
       type: object
       properties:

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -349,11 +349,6 @@ const (
 	SuccessSandboxListResponseSuccessTrue SuccessSandboxListResponseSuccess = true
 )
 
-// Defines values for SuccessSandboxLogsResponseSuccess.
-const (
-	SuccessSandboxLogsResponseSuccessTrue SuccessSandboxLogsResponseSuccess = true
-)
-
 // Defines values for SuccessSandboxNetworkPolicyResponseSuccess.
 const (
 	SuccessSandboxNetworkPolicyResponseSuccessTrue SuccessSandboxNetworkPolicyResponseSuccess = true
@@ -466,7 +461,7 @@ const (
 
 // Defines values for SuccessWrittenResponseSuccess.
 const (
-	SuccessWrittenResponseSuccessTrue SuccessWrittenResponseSuccess = true
+	True SuccessWrittenResponseSuccess = true
 )
 
 // Defines values for SyncEventType.
@@ -1491,17 +1486,6 @@ type SandboxConfig struct {
 	Webhook      *WebhookConfig        `json:"webhook,omitempty"`
 }
 
-// SandboxLogs defines model for SandboxLogs.
-type SandboxLogs struct {
-	Container string `json:"container"`
-
-	// Logs Log text returned by Kubernetes for the selected container.
-	Logs      string `json:"logs"`
-	PodName   string `json:"pod_name"`
-	Previous  bool   `json:"previous"`
-	SandboxId string `json:"sandbox_id"`
-}
-
 // SandboxNetworkPolicy defines model for SandboxNetworkPolicy.
 type SandboxNetworkPolicy struct {
 	CredentialBindings *[]CredentialBinding `json:"credentialBindings,omitempty"`
@@ -2116,15 +2100,6 @@ type SuccessSandboxListResponse struct {
 
 // SuccessSandboxListResponseSuccess defines model for SuccessSandboxListResponse.Success.
 type SuccessSandboxListResponseSuccess bool
-
-// SuccessSandboxLogsResponse defines model for SuccessSandboxLogsResponse.
-type SuccessSandboxLogsResponse struct {
-	Data    *SandboxLogs                      `json:"data,omitempty"`
-	Success SuccessSandboxLogsResponseSuccess `json:"success"`
-}
-
-// SuccessSandboxLogsResponseSuccess defines model for SuccessSandboxLogsResponse.Success.
-type SuccessSandboxLogsResponseSuccess bool
 
 // SuccessSandboxNetworkPolicyResponse defines model for SuccessSandboxNetworkPolicyResponse.
 type SuccessSandboxNetworkPolicyResponse struct {
@@ -2793,7 +2768,7 @@ type GetApiV1SandboxesIdLogsParams struct {
 	// LimitBytes Maximum response log payload bytes read from Kubernetes. Defaults only apply when follow is false.
 	LimitBytes *int64 `form:"limit_bytes,omitempty" json:"limit_bytes,omitempty"`
 
-	// Follow Stream logs until the client disconnects. When true, the response content type is text/plain.
+	// Follow Stream logs as text/plain until the client disconnects. When false, return a text/plain snapshot.
 	Follow *bool `form:"follow,omitempty" json:"follow,omitempty"`
 
 	// Previous Return logs for the previously terminated container instance.

--- a/skills/sandbox0/references/docs-src/sandbox/page.mdx
+++ b/skills/sandbox0/references/docs-src/sandbox/page.mdx
@@ -255,7 +255,7 @@ console.log('Status:', status.status);`
 
 ## Get Sandbox Logs
 
-Read bounded pod logs for sandbox startup and container diagnostics.
+Read pod logs for sandbox startup and container diagnostics. Snapshot and streaming requests return `text/plain`.
 
 <Endpoint method="GET">
 /api/v1/sandboxes/{'{id}'}/logs
@@ -278,6 +278,8 @@ Read bounded pod logs for sandbox startup and container diagnostics.
 
     curl -N -H "Authorization: Bearer $SANDBOX0_TOKEN" \
       "$SANDBOX0_BASE_URL/api/v1/sandboxes/sb_abc123/logs?follow=true&tail_lines=50"
+
+With `follow=true`, the response stays open and streams log bytes until the client disconnects.
 
 ---
 

--- a/skills/sandbox0/references/docs-src/template/warm-processes/page.mdx
+++ b/skills/sandbox0/references/docs-src/template/warm-processes/page.mdx
@@ -4,6 +4,8 @@ Use `spec.warmProcesses` when a template needs a helper process to be running be
 
 Warm processes are intended for long-running helpers such as agents, language servers, REPL sessions, and daemon-style workers. If a configured warm process exits, procd exits and Kubernetes restarts the sandbox container with the pod's restart policy.
 
+Set `SANDBOX0_FORWARD_PROCESS_OUTPUT_TO_CONTAINER_LOGS=true` in template `envVars` when warm process stdout and stderr should also appear in Kubernetes pod logs. Procd still keeps the normal process-output API as the source of truth; container logs are an extra diagnostic sink with bounded JSON lines. Set `SANDBOX0_PROCESS_OUTPUT_LOG_MAX_LINE_BYTES` to change the per-line mirror limit from the default `4096` bytes.
+
 ## Spec
 
 ```yaml
@@ -13,6 +15,8 @@ spec:
         resources:
             cpu: "1"
             memory: 2Gi
+    envVars:
+        SANDBOX0_FORWARD_PROCESS_OUTPUT_TO_CONTAINER_LOGS: "true"
     warmProcesses:
         - name: codex
           type: cmd

--- a/skills/sandbox0/references/docs-src/template/warm-processes/page.mdx
+++ b/skills/sandbox0/references/docs-src/template/warm-processes/page.mdx
@@ -4,7 +4,7 @@ Use `spec.warmProcesses` when a template needs a helper process to be running be
 
 Warm processes are intended for long-running helpers such as agents, language servers, REPL sessions, and daemon-style workers. If a configured warm process exits, procd exits and Kubernetes restarts the sandbox container with the pod's restart policy.
 
-Set `SANDBOX0_FORWARD_PROCESS_OUTPUT_TO_CONTAINER_LOGS=true` in template `envVars` when warm process stdout and stderr should also appear in Kubernetes pod logs. Procd still keeps the normal process-output API as the source of truth; container logs are an extra diagnostic sink with bounded JSON lines. Set `SANDBOX0_PROCESS_OUTPUT_LOG_MAX_LINE_BYTES` to change the per-line mirror limit from the default `4096` bytes.
+Warm process stdout and stderr are mirrored to Kubernetes pod logs by default. Procd still keeps the normal process-output API as the source of truth; container logs are an extra diagnostic sink with bounded JSON lines. Set `SANDBOX0_PROCESS_LOGS=false` in template `envVars` to disable the container-log mirror. Set `SANDBOX0_PROCESS_LOG_MAX_BYTES` to change the per-line mirror limit from the default `4096` bytes.
 
 ## Spec
 
@@ -15,8 +15,6 @@ spec:
         resources:
             cpu: "1"
             memory: 2Gi
-    envVars:
-        SANDBOX0_FORWARD_PROCESS_OUTPUT_TO_CONTAINER_LOGS: "true"
     warmProcesses:
         - name: codex
           type: cmd


### PR DESCRIPTION
## Summary
- Forward procd process stdout/stderr to sandbox container logs by default as bounded JSON lines with process and stream attribution.
- Add template env controls: `SANDBOX0_PROCESS_LOGS=false` disables forwarding, and `SANDBOX0_PROCESS_LOG_MAX_BYTES` sets the per-record truncation limit.
- Keep the existing procd process output stream as the source of truth; container logs are an additional diagnostic sink.
- Return sandbox pod log snapshots/streams as `text/plain` through manager and cluster-gateway.
- Reuse the existing manager proxy path for `follow=true` log streams, with upstream timeout disabled via the shared proxy request marker instead of a dedicated cluster-gateway HTTP client.
- Update docs for sandbox logs and warm process templates.

Closes #197

## Testing
- `go test ./cluster-gateway/pkg/http ./pkg/proxy -count=1`
- `go test ./manager/pkg/apis/sandbox0/v1alpha1 ./manager/pkg/http ./manager/pkg/service ./manager/procd/pkg/http ./manager/procd/pkg/process ./cluster-gateway/pkg/http ./pkg/proxy ./pkg/apispec ./manager/cmd/procd ./manager/procd/pkg/context ./manager/procd/pkg/process/cmd ./manager/procd/pkg/process/repl -count=1`
- `git diff --check`
- pre-push hook: `make manifests`, `make proto`, `make apispec`, `go fmt ./...`, `go mod tidy`, `go mod vendor`, `golangci-lint run ./...`
- Remote kind: rsynced the current worktree to `kind:/root/infra`, ran `make test-again`, and waited until all `sandbox0-system` pods were Ready.
- Remote kind smoke: created a default-template sandbox, ran a CMD that emitted `s0-default-stdout-197` and `s0-default-stderr-197`, and verified both markers in `kubectl -n tpl-default logs <sandbox> -c procd` as JSON lines with `source=stdout/stderr`.
- Remote kind API smoke: `GET /api/v1/sandboxes/{id}/logs?tail_lines=120` returned `Content-Type: text/plain; charset=utf-8` and included both forwarded marker lines.
- Remote kind streaming smoke: `GET /api/v1/sandboxes/{id}/logs?follow=true&tail_lines=20` streamed both marker lines until the client-side timeout disconnected.
