### PR TITLE
Fix manager power reconcile for deleting pods

### DIFF
--- a/manager/pkg/service/sandbox_service.go
+++ b/manager/pkg/service/sandbox_service.go
@@ -2020,6 +2020,14 @@ func annotationValue(annotations map[string]string, key string) string {
 	return annotations[key]
 }
 
+func shouldReconcileSandboxPowerState(pod *corev1.Pod) bool {
+	if pod == nil || pod.DeletionTimestamp != nil {
+		return false
+	}
+	state := sandboxPowerStateFromAnnotations(pod.Annotations)
+	return state.Phase != SandboxPowerPhaseStable || state.Desired != state.Observed
+}
+
 func hasExplicitSandboxPowerStateAnnotations(annotations map[string]string) bool {
 	if len(annotations) == 0 {
 		return false
@@ -2237,17 +2245,14 @@ func (s *SandboxService) reconcilePendingSandboxPowerStates(ctx context.Context)
 		return
 	}
 	for _, pod := range pods {
-		if pod == nil {
+		if !shouldReconcileSandboxPowerState(pod) {
 			continue
 		}
 		sandboxID := strings.TrimSpace(pod.Labels[controller.LabelSandboxID])
 		if sandboxID == "" {
 			continue
 		}
-		state := sandboxPowerStateFromAnnotations(pod.Annotations)
-		if state.Phase != SandboxPowerPhaseStable || state.Desired != state.Observed {
-			s.triggerSandboxPowerStateReconcile(sandboxID)
-		}
+		s.triggerSandboxPowerStateReconcile(sandboxID)
 	}
 }
 
@@ -2261,8 +2266,7 @@ func (s *SandboxService) finishSandboxPowerStateReconcile(sandboxID string) {
 	if err != nil {
 		return
 	}
-	state := sandboxPowerStateFromAnnotations(pod.Annotations)
-	if state.Phase != SandboxPowerPhaseStable || state.Desired != state.Observed {
+	if shouldReconcileSandboxPowerState(pod) {
 		s.triggerSandboxPowerStateReconcile(sandboxID)
 	}
 }
@@ -2278,6 +2282,9 @@ func (s *SandboxService) reconcileSandboxPowerState(sandboxID string) {
 				zap.String("sandboxID", sandboxID),
 				zap.Error(err),
 			)
+			return
+		}
+		if pod.DeletionTimestamp != nil {
 			return
 		}
 

--- a/manager/pkg/service/sandbox_service_power_state_test.go
+++ b/manager/pkg/service/sandbox_service_power_state_test.go
@@ -207,6 +207,37 @@ func TestReconcileSandboxPowerStateUsesConfiguredExecutor(t *testing.T) {
 	})
 }
 
+func TestShouldReconcileSandboxPowerStateSkipsDeletingPod(t *testing.T) {
+	pending := newPowerStatePod(SandboxPowerStatePaused, SandboxPowerStateActive, SandboxPowerPhasePausing)
+	assert.True(t, shouldReconcileSandboxPowerState(pending))
+
+	stable := newPowerStatePod(SandboxPowerStatePaused, SandboxPowerStatePaused, SandboxPowerPhaseStable)
+	assert.False(t, shouldReconcileSandboxPowerState(stable))
+
+	deleting := newPowerStatePod(SandboxPowerStatePaused, SandboxPowerStateActive, SandboxPowerPhasePausing)
+	deletedAt := metav1.NewTime(time.Now())
+	deleting.DeletionTimestamp = &deletedAt
+	assert.False(t, shouldReconcileSandboxPowerState(deleting))
+}
+
+func TestReconcileSandboxPowerStateSkipsDeletingPod(t *testing.T) {
+	pod := newPowerStatePod(SandboxPowerStatePaused, SandboxPowerStateActive, SandboxPowerPhasePausing)
+	deletedAt := metav1.NewTime(time.Now())
+	pod.DeletionTimestamp = &deletedAt
+	executor := &recordingPowerExecutor{}
+	svc := &SandboxService{
+		k8sClient: fake.NewSimpleClientset(pod),
+		podLister: newTestPodLister(t, pod),
+		logger:    zap.NewNop(),
+	}
+	svc.SetPowerExecutor(executor)
+
+	svc.reconcileSandboxPowerState("sandbox-1")
+
+	assert.Empty(t, executor.pauseCalls)
+	assert.Empty(t, executor.resumeCalls)
+}
+
 func TestStartPowerStateReconcilerTriggersPendingTransitions(t *testing.T) {
 	pod := newPowerStatePod(SandboxPowerStatePaused, SandboxPowerStateActive, SandboxPowerPhasePausing)
 	pauseCalled := make(chan struct{})


### PR DESCRIPTION
## Summary
- Skip power-state reconciliation for pods that already have a deletion timestamp
- Prevent pending power-state loops from re-enqueueing deleting pods
- Add regression coverage for deleting pods with pending power-state annotations

## Testing
- go test ./manager/pkg/service -count=1
- go test ./manager/pkg/... -count=1
- pre-push hook: make manifests, make proto, make apispec, go fmt ./..., go mod tidy, go mod vendor, golangci-lint run ./...