### PR TITLE
Thaw partially paused sandboxes before termination

### DIFF
--- a/manager/pkg/service/power_executor_ctld_test.go
+++ b/manager/pkg/service/power_executor_ctld_test.go
@@ -157,6 +157,114 @@ func TestCtldPowerExecutorCallsCtldResumeAfterRestoringState(t *testing.T) {
 	assert.Equal(t, SandboxPowerStateActive, updated.Annotations[controller.AnnotationPowerStateObserved])
 }
 
+func TestCtldPowerExecutorResumesPartiallyPausedPod(t *testing.T) {
+	resumeCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resumeCalls++
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/sandboxes/sandbox-1/resume", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"resumed":true}`))
+	}))
+	defer server.Close()
+	target, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sandbox-1",
+			Namespace: "default",
+			Labels:    map[string]string{"sandbox0.ai/sandbox-id": "sandbox-1"},
+			Annotations: map[string]string{
+				controller.AnnotationPowerStateDesired:           SandboxPowerStatePaused,
+				controller.AnnotationPowerStateDesiredGeneration: "2",
+				controller.AnnotationPowerStateObserved:          SandboxPowerStateActive,
+				controller.AnnotationPowerStatePhase:             SandboxPowerPhasePausing,
+			},
+		},
+		Spec: corev1.PodSpec{NodeName: "node-1"},
+		Status: corev1.PodStatus{Conditions: []corev1.PodCondition{{
+			Type:    corev1.PodConditionType("sandbox0.ai/live"),
+			Status:  corev1.ConditionUnknown,
+			Reason:  "SandboxPaused",
+			Message: "sandbox cgroup is frozen",
+		}}},
+	}
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+		Status:     corev1.NodeStatus{Addresses: []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "10.0.0.12"}}},
+	}
+	transport := &rewriteTransport{base: server.Client().Transport, target: target}
+
+	svc := &SandboxService{
+		k8sClient:  fake.NewSimpleClientset(pod, node),
+		ctldClient: NewCtldClientWithHTTPClient(&http.Client{Transport: transport}),
+		config:     SandboxServiceConfig{CtldEnabled: true, CtldPort: 8095, PauseMinCPU: "10m", PauseMemoryBufferRatio: 1.1},
+		logger:     zap.NewNop(),
+		clock:      systemTime{},
+	}
+	svc.SetPowerExecutor(&ctldSandboxPowerExecutor{service: svc})
+
+	resp, err := svc.ResumeSandbox(context.Background(), "sandbox-1")
+	require.NoError(t, err)
+	assert.True(t, resp.Resumed)
+	assert.Equal(t, 1, resumeCalls)
+
+	updated, err := svc.k8sClient.CoreV1().Pods("default").Get(context.Background(), "sandbox-1", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, SandboxPowerStateActive, updated.Annotations[controller.AnnotationPowerStateDesired])
+	assert.Equal(t, SandboxPowerStateActive, updated.Annotations[controller.AnnotationPowerStateObserved])
+	assert.Equal(t, SandboxPowerPhaseStable, updated.Annotations[controller.AnnotationPowerStatePhase])
+}
+
+func TestTerminateSandboxThawsFrozenPodBeforeDelete(t *testing.T) {
+	resumeCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resumeCalls++
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/sandboxes/sandbox-1/resume", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"resumed":true}`))
+	}))
+	defer server.Close()
+	target, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sandbox-1",
+			Namespace: "default",
+			Labels:    map[string]string{"sandbox0.ai/sandbox-id": "sandbox-1"},
+			Annotations: map[string]string{
+				controller.AnnotationPowerStateDesired:  SandboxPowerStatePaused,
+				controller.AnnotationPowerStateObserved: SandboxPowerStateActive,
+				controller.AnnotationPowerStatePhase:    SandboxPowerPhasePausing,
+			},
+		},
+		Spec: corev1.PodSpec{NodeName: "node-1"},
+		Status: corev1.PodStatus{Conditions: []corev1.PodCondition{{
+			Type:    corev1.PodConditionType("sandbox0.ai/live"),
+			Status:  corev1.ConditionUnknown,
+			Reason:  "SandboxPaused",
+			Message: "sandbox cgroup is frozen",
+		}}},
+	}
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+		Status:     corev1.NodeStatus{Addresses: []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "10.0.0.12"}}},
+	}
+	transport := &rewriteTransport{base: server.Client().Transport, target: target}
+	svc := &SandboxService{
+		k8sClient:  fake.NewSimpleClientset(pod, node),
+		podLister:  newTestPodLister(t, pod),
+		ctldClient: NewCtldClientWithHTTPClient(&http.Client{Transport: transport}),
+		config:     SandboxServiceConfig{CtldEnabled: true, CtldPort: 8095},
+		logger:     zap.NewNop(),
+	}
+
+	err = svc.TerminateSandbox(context.Background(), "sandbox-1")
+	require.NoError(t, err)
+	assert.Equal(t, 1, resumeCalls)
+}
+
 func TestCtldPowerExecutorResumeFailureKeepsPausedStateAuthoritative(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)

--- a/manager/pkg/service/sandbox_service.go
+++ b/manager/pkg/service/sandbox_service.go
@@ -1459,6 +1459,7 @@ func (s *SandboxService) TerminateSandbox(ctx context.Context, sandboxID string)
 		}
 		return fmt.Errorf("get pod: %w", err)
 	}
+	s.thawSandboxBeforeTermination(ctx, pod, sandboxID)
 
 	pod, err = s.ensureSandboxDeletionFinalizer(ctx, pod)
 	if err != nil {
@@ -1477,6 +1478,34 @@ func (s *SandboxService) TerminateSandbox(ctx context.Context, sandboxID string)
 	s.logger.Info("Sandbox termination requested", zap.String("sandboxID", sandboxID), zap.String("pod", pod.Name))
 
 	return nil
+}
+
+func (s *SandboxService) thawSandboxBeforeTermination(ctx context.Context, pod *corev1.Pod, sandboxID string) {
+	if s == nil || s.ctldClient == nil || !s.config.CtldEnabled || !sandboxPodMayHaveFrozenCgroup(pod) {
+		return
+	}
+	ctldAddress, err := s.ctldAddressForPod(ctx, pod)
+	if err != nil {
+		s.logger.Warn("Failed to resolve ctld before sandbox termination",
+			zap.String("sandboxID", sandboxID),
+			zap.Error(err),
+		)
+		return
+	}
+	resp, err := s.ctldClient.Resume(ctx, ctldAddress, sandboxID)
+	if err != nil {
+		s.logger.Warn("Failed to thaw sandbox before termination",
+			zap.String("sandboxID", sandboxID),
+			zap.Error(err),
+		)
+		return
+	}
+	if !resp.Resumed {
+		s.logger.Warn("ctld did not thaw sandbox before termination",
+			zap.String("sandboxID", sandboxID),
+			zap.String("error", resp.Error),
+		)
+	}
 }
 
 // GetSandbox gets a sandbox by ID
@@ -2026,6 +2055,25 @@ func shouldReconcileSandboxPowerState(pod *corev1.Pod) bool {
 	}
 	state := sandboxPowerStateFromAnnotations(pod.Annotations)
 	return state.Phase != SandboxPowerPhaseStable || state.Desired != state.Observed
+}
+
+func sandboxPodMayHaveFrozenCgroup(pod *corev1.Pod) bool {
+	if pod == nil {
+		return false
+	}
+	if pod.Annotations[controller.AnnotationPaused] == "true" {
+		return true
+	}
+	state := sandboxPowerStateFromAnnotations(pod.Annotations)
+	if state.Phase == SandboxPowerPhasePausing {
+		return true
+	}
+	for _, condition := range pod.Status.Conditions {
+		if condition.Reason == "SandboxPaused" || strings.Contains(strings.ToLower(condition.Message), "cgroup is frozen") {
+			return true
+		}
+	}
+	return false
 }
 
 func hasExplicitSandboxPowerStateAnnotations(annotations map[string]string) bool {
@@ -3003,12 +3051,15 @@ func (s *SandboxService) applyPausedResourceTargets(resizePod *corev1.Pod, newRe
 }
 
 func (s *SandboxService) prepareSandboxResume(ctx context.Context, pod *corev1.Pod, sandboxID string, expected expectedSandboxPowerState) (*resumeSandboxPreparation, *ResumeSandboxResponse, error) {
-	if pod.Annotations[controller.AnnotationPaused] != "true" {
+	if pod.Annotations[controller.AnnotationPaused] != "true" && !sandboxPodMayHaveFrozenCgroup(pod) {
 		return nil, &ResumeSandboxResponse{
 			SandboxID:  sandboxID,
 			Resumed:    true,
 			PowerState: sandboxPowerStateFromAnnotations(pod.Annotations),
 		}, nil
+	}
+	if pod.Annotations[controller.AnnotationPaused] != "true" {
+		return &resumeSandboxPreparation{Pod: pod, PowerState: sandboxPowerStateFromAnnotations(pod.Annotations)}, nil, nil
 	}
 
 	var restoredMemory string
@@ -3088,8 +3139,19 @@ func (s *SandboxService) completeSandboxResume(ctx context.Context, sandboxID st
 			return getErr
 		}
 		if currentPod.Annotations[controller.AnnotationPaused] != "true" {
-			powerState = sandboxPowerStateFromAnnotations(currentPod.Annotations)
-			return nil
+			currentState := sandboxPowerStateFromAnnotations(currentPod.Annotations)
+			if !sandboxPodMayHaveFrozenCgroup(currentPod) && currentState.Desired == SandboxPowerStateActive && currentState.Observed == SandboxPowerStateActive && currentState.Phase == SandboxPowerPhaseStable {
+				powerState = currentState
+				return nil
+			}
+			annotationPod := currentPod.DeepCopy()
+			if annotationPod.Annotations == nil {
+				annotationPod.Annotations = make(map[string]string)
+			}
+			powerState = completedSandboxPowerState(annotationPod.Annotations, SandboxPowerStateActive)
+			applySandboxPowerStateAnnotations(annotationPod.Annotations, powerState)
+			_, updateErr := s.k8sClient.CoreV1().Pods(currentPod.Namespace).Update(ctx, annotationPod, metav1.UpdateOptions{})
+			return updateErr
 		}
 		currentState, matchErr := s.matchSandboxPowerExpectation(currentPod, expected)
 		if matchErr != nil {


### PR DESCRIPTION
## Summary
- Detect sandbox pods whose cgroup may be frozen even when `sandbox0.ai/paused=true` was never recorded
- Call ctld resume for partially paused pods during resume and before sandbox termination
- Add regression coverage for partial pause resume and delete cleanup

## Context
This handles the case where ctld froze the sandbox cgroup but manager did not complete the paused annotations before the pod entered deletion.

## Testing
- go test ./manager/pkg/service -run 'Test(CtldPowerExecutorResumesPartiallyPausedPod|TerminateSandboxThawsFrozenPodBeforeDelete|CtldPowerExecutorCallsCtldResumeAfterRestoringState|CtldPowerExecutorResumeFailureKeepsPausedStateAuthoritative|ReconcileSandboxPowerStateSkipsDeletingPod)' -count=1\n- go test ./manager/pkg/service -count=1\n- go test ./manager/pkg/... -count=1\n- pre-push hook: make manifests, make proto, make apispec, go fmt ./..., go mod tidy, go mod vendor, golangci-lint run ./...