### PR TITLE
Fix streaming write timeouts

### DIFF
--- a/manager/pkg/http/handlers_sandbox.go
+++ b/manager/pkg/http/handlers_sandbox.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/service"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+	"github.com/sandbox0-ai/sandbox0/pkg/proxy"
 	"go.uber.org/zap"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
@@ -353,6 +354,13 @@ func (s *Server) getSandboxLogs(c *gin.Context) {
 }
 
 func (s *Server) streamSandboxLogs(c *gin.Context, sandboxID, teamID string, options *service.SandboxLogsOptions) {
+	if err := proxy.DisableResponseWriteDeadline(c.Writer); err != nil {
+		s.logger.Debug("Failed to disable sandbox log stream response deadlines",
+			zap.String("sandboxID", sandboxID),
+			zap.String("teamID", teamID),
+			zap.Error(err),
+		)
+	}
 	stream, err := s.sandboxService.StreamSandboxLogs(c.Request.Context(), sandboxID, teamID, options)
 	if err != nil {
 		s.writeSandboxLogsError(c, sandboxID, teamID, err)

--- a/manager/procd/pkg/http/handlers/context.go
+++ b/manager/procd/pkg/http/handlers/context.go
@@ -18,6 +18,7 @@ import (
 	ctxpkg "github.com/sandbox0-ai/sandbox0/manager/procd/pkg/context"
 	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/process"
 	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/process/repl"
+	"github.com/sandbox0-ai/sandbox0/pkg/proxy"
 	"go.uber.org/zap"
 )
 
@@ -716,6 +717,9 @@ func (h *ContextHandler) WebSocket(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	id := vars["id"]
 
+	if err := proxy.DisableResponseDeadlines(w); err != nil {
+		h.logger.Debug("Failed to disable context websocket response deadlines", zap.String("context_id", id), zap.Error(err))
+	}
 	conn, err := h.upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		h.logger.Error("WebSocket upgrade failed", zap.Error(err))

--- a/manager/procd/pkg/http/handlers/file.go
+++ b/manager/procd/pkg/http/handlers/file.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/file"
+	"github.com/sandbox0-ai/sandbox0/pkg/proxy"
 	"go.uber.org/zap"
 )
 
@@ -187,6 +188,9 @@ func (h *FileHandler) Move(w http.ResponseWriter, r *http.Request) {
 
 // Watch handles WebSocket file watching.
 func (h *FileHandler) Watch(w http.ResponseWriter, r *http.Request) {
+	if err := proxy.DisableResponseDeadlines(w); err != nil {
+		h.logger.Debug("Failed to disable file watch response deadlines", zap.Error(err))
+	}
 	conn, err := h.upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		h.logger.Error("WebSocket upgrade failed", zap.Error(err))

--- a/manager/procd/pkg/http/server.go
+++ b/manager/procd/pkg/http/server.go
@@ -443,6 +443,10 @@ func (rw *responseWriter) WriteHeader(code int) {
 	rw.ResponseWriter.WriteHeader(code)
 }
 
+func (rw *responseWriter) Unwrap() http.ResponseWriter {
+	return rw.ResponseWriter
+}
+
 func (rw *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	hijacker, ok := rw.ResponseWriter.(http.Hijacker)
 	if !ok {

--- a/pkg/observability/http/server.go
+++ b/pkg/observability/http/server.go
@@ -157,6 +157,10 @@ func (rw *responseWriter) WriteHeader(code int) {
 	rw.ResponseWriter.WriteHeader(code)
 }
 
+func (rw *responseWriter) Unwrap() http.ResponseWriter {
+	return rw.ResponseWriter
+}
+
 func (rw *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	hijacker, ok := rw.ResponseWriter.(http.Hijacker)
 	if !ok {

--- a/pkg/proxy/router.go
+++ b/pkg/proxy/router.go
@@ -43,6 +43,9 @@ func NewRouter(targetUrl string, logger *zap.Logger, timeout time.Duration, opts
 // ProxyToTarget creates a reverse proxy handler for target service
 func (r *Router) ProxyToTarget(c *gin.Context) {
 	if isWebSocketUpgrade(c.Request) {
+		if err := PrepareStreamingProxyResponse(c.Writer, c.Request); err != nil {
+			r.logger.Debug("Failed to disable proxy response deadlines", zap.Error(err))
+		}
 		opts := make([]Option, 0, len(r.requestModifiers))
 		for _, mod := range r.requestModifiers {
 			opts = append(opts, WithRequestModifier(mod))
@@ -52,6 +55,9 @@ func (r *Router) ProxyToTarget(c *gin.Context) {
 	}
 
 	req := c.Request
+	if err := PrepareStreamingProxyResponse(c.Writer, req); err != nil {
+		r.logger.Debug("Failed to disable proxy response deadlines", zap.Error(err))
+	}
 	cancel := context.CancelFunc(func() {})
 	if r.timeout > 0 {
 		req, cancel = ApplyRequestTimeout(c.Request, r.timeout)

--- a/pkg/proxy/router_test.go
+++ b/pkg/proxy/router_test.go
@@ -82,3 +82,51 @@ func TestRouterProxyToTargetSkipsTimeoutWhenDisabled(t *testing.T) {
 		t.Fatalf("body = %q, want %q", body, "ok")
 	}
 }
+
+func TestRouterProxyToTargetClearsWriteDeadlineWhenStreaming(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(120 * time.Millisecond)
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		_, _ = io.WriteString(w, "late stream\n")
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+	}))
+	defer upstream.Close()
+
+	router, err := NewRouter(upstream.URL, zap.NewNop(), time.Second)
+	if err != nil {
+		t.Fatalf("NewRouter() error = %v", err)
+	}
+
+	engine := gin.New()
+	engine.GET("/", func(c *gin.Context) {
+		c.Request = WithUpstreamTimeoutDisabledRequest(c.Request)
+		router.ProxyToTarget(c)
+	})
+
+	server := httptest.NewUnstartedServer(engine)
+	server.Config.WriteTimeout = 50 * time.Millisecond
+	server.Start()
+	defer server.Close()
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get(server.URL + "/")
+	if err != nil {
+		t.Fatalf("GET() error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if body := string(bodyBytes); body != "late stream\n" {
+		t.Fatalf("body = %q, want %q", body, "late stream\n")
+	}
+}

--- a/pkg/proxy/streaming.go
+++ b/pkg/proxy/streaming.go
@@ -1,0 +1,52 @@
+package proxy
+
+import (
+	"errors"
+	"net/http"
+	"time"
+)
+
+// DisableResponseWriteDeadline clears the server-managed write deadline for a
+// long-lived response. It must be called before the handler writes headers.
+func DisableResponseWriteDeadline(w http.ResponseWriter) error {
+	if w == nil {
+		return nil
+	}
+	controller := http.NewResponseController(w)
+	if err := controller.SetWriteDeadline(time.Time{}); err != nil && !errors.Is(err, http.ErrNotSupported) {
+		return err
+	}
+	return nil
+}
+
+// DisableResponseDeadlines clears server-managed read and write deadlines for
+// an upgraded long-lived connection. It must be called before hijacking.
+func DisableResponseDeadlines(w http.ResponseWriter) error {
+	if w == nil {
+		return nil
+	}
+	controller := http.NewResponseController(w)
+	var errs []error
+	if err := controller.SetReadDeadline(time.Time{}); err != nil && !errors.Is(err, http.ErrNotSupported) {
+		errs = append(errs, err)
+	}
+	if err := DisableResponseWriteDeadline(w); err != nil {
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
+}
+
+// PrepareStreamingProxyResponse clears downstream server deadlines when a
+// proxied request is allowed to outlive the ordinary upstream timeout.
+func PrepareStreamingProxyResponse(w http.ResponseWriter, req *http.Request) error {
+	if req == nil {
+		return DisableResponseWriteDeadline(w)
+	}
+	if IsWebSocketUpgrade(req) {
+		return DisableResponseDeadlines(w)
+	}
+	if UpstreamTimeoutDisabled(req.Context()) {
+		return DisableResponseWriteDeadline(w)
+	}
+	return nil
+}

--- a/pkg/proxy/websocket.go
+++ b/pkg/proxy/websocket.go
@@ -34,11 +34,14 @@ func NewWebSocketProxy(logger *zap.Logger, opts ...Option) *WebSocketProxy {
 func (p *WebSocketProxy) Proxy(targetURL *url.URL) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// Check if this is a WebSocket upgrade request
-		if !isWebSocketUpgrade(c.Request) {
+		if !IsWebSocketUpgrade(c.Request) {
 			c.JSON(http.StatusBadRequest, gin.H{
 				"error": "expected WebSocket upgrade request",
 			})
 			return
+		}
+		if err := DisableResponseDeadlines(c.Writer); err != nil {
+			p.logger.Debug("Failed to disable WebSocket response deadlines", zap.Error(err))
 		}
 
 		hijacker, ok := c.Writer.(http.Hijacker)
@@ -116,10 +119,14 @@ func (p *WebSocketProxy) Proxy(targetURL *url.URL) gin.HandlerFunc {
 	}
 }
 
-// isWebSocketUpgrade checks if the request is a WebSocket upgrade request
-func isWebSocketUpgrade(r *http.Request) bool {
+// IsWebSocketUpgrade checks if the request is a WebSocket upgrade request.
+func IsWebSocketUpgrade(r *http.Request) bool {
 	return strings.EqualFold(r.Header.Get("Upgrade"), "websocket") &&
 		strings.Contains(strings.ToLower(r.Header.Get("Connection")), "upgrade")
+}
+
+func isWebSocketUpgrade(r *http.Request) bool {
+	return IsWebSocketUpgrade(r)
 }
 
 func dialWebSocketUpstream(ctx context.Context, targetURL *url.URL) (net.Conn, error) {

--- a/storage-proxy/pkg/http/handlers_volume_files.go
+++ b/storage-proxy/pkg/http/handlers_volume_files.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+	httpproxy "github.com/sandbox0-ai/sandbox0/pkg/proxy"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
 	pb "github.com/sandbox0-ai/sandbox0/storage-proxy/proto/fs"
 	"google.golang.org/grpc/codes"
@@ -261,6 +262,9 @@ func (s *Server) handleVolumeFileWatch(w http.ResponseWriter, r *http.Request) {
 	if _, err := s.loadAuthorizedVolume(r.Context(), volumeID); err != nil {
 		s.writeVolumeFileError(w, err)
 		return
+	}
+	if err := httpproxy.DisableResponseDeadlines(w); err != nil {
+		s.logger.WithError(err).WithField("volume_id", volumeID).Debug("Failed to disable volume file watch response deadlines")
 	}
 	proxied, err := s.proxyVolumeRequestToOwnerIfNeeded(w, r, volumeID)
 	if err != nil {

--- a/storage-proxy/pkg/http/server.go
+++ b/storage-proxy/pkg/http/server.go
@@ -236,6 +236,10 @@ func (rw *responseWriter) WriteHeader(code int) {
 	rw.ResponseWriter.WriteHeader(code)
 }
 
+func (rw *responseWriter) Unwrap() http.ResponseWriter {
+	return rw.ResponseWriter
+}
+
 func (rw *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	hijacker, ok := rw.ResponseWriter.(http.Hijacker)
 	if !ok {


### PR DESCRIPTION
## Summary
- Clear server write deadlines for long-lived proxied streams when upstream timeouts are disabled.
- Clear read/write deadlines before WebSocket upgrades in proxy, procd, and storage-proxy watch paths.
- Add a regression test for a proxied stream outliving a short HTTP server WriteTimeout.

Closes #198

## Testing
- go test ./pkg/proxy -count=1
- go test ./cluster-gateway/pkg/http -run 'TestSandboxLogsFollowDisablesManagerProxyTimeout|Test.*VolumeFileWatch|Test.*Context' -count=1
- go test ./manager/pkg/http ./manager/procd/pkg/http/handlers ./storage-proxy/pkg/http -run 'Test.*Logs|TestWebSocket|Test.*Watch|TestResponseWriterHijack' -count=1
- go test ./pkg/proxy ./pkg/observability/http ./cluster-gateway/pkg/http ./regional-gateway/pkg/http ./global-gateway/pkg/http ./scheduler/pkg/http ./manager/pkg/http ./manager/procd/pkg/http ./manager/procd/pkg/http/handlers ./storage-proxy/pkg/http -count=1
- pre-push hook: make manifests, make proto, make apispec, go fmt ./..., go mod tidy, go mod vendor, golangci-lint run ./...