### PR TITLE
Make TTL pause reconciliation declarative

### DIFF
--- a/infra-operator/api/config/manager.go
+++ b/infra-operator/api/config/manager.go
@@ -125,7 +125,7 @@ type ManagerConfig struct {
 	// +kubebuilder:default="30s"
 	ProcdClientTimeout metav1.Duration `yaml:"procd_client_timeout" json:"procdClientTimeout"`
 	// +optional
-	// +kubebuilder:default="5s"
+	// +kubebuilder:default="15s"
 	CtldClientTimeout metav1.Duration `yaml:"ctld_client_timeout" json:"-"`
 	// +optional
 	// +kubebuilder:default="6s"

--- a/manager/pkg/controller/cleanup_controller.go
+++ b/manager/pkg/controller/cleanup_controller.go
@@ -14,9 +14,9 @@ import (
 	"k8s.io/client-go/tools/record"
 )
 
-// SandboxPauser defines the interface for pausing sandboxes
-type SandboxPauser interface {
-	PauseSandboxByID(ctx context.Context, sandboxID string) error
+// SandboxPauseRequester defines the interface for declaring that a sandbox should be paused.
+type SandboxPauseRequester interface {
+	RequestPauseSandboxByID(ctx context.Context, sandboxID string) error
 }
 
 // SandboxTerminator defines the interface for terminating sandboxes.
@@ -31,7 +31,7 @@ type CleanupController struct {
 	templateLister    TemplateLister
 	recorder          record.EventRecorder
 	clock             TimeProvider
-	sandboxPauser     SandboxPauser
+	pauseRequester    SandboxPauseRequester
 	sandboxTerminator SandboxTerminator
 	logger            *zap.Logger
 	interval          time.Duration
@@ -64,7 +64,7 @@ func NewCleanupController(
 	templateLister TemplateLister,
 	recorder record.EventRecorder,
 	clock TimeProvider,
-	sandboxPauser SandboxPauser,
+	pauseRequester SandboxPauseRequester,
 	sandboxTerminator SandboxTerminator,
 	logger *zap.Logger,
 	interval time.Duration,
@@ -80,7 +80,7 @@ func NewCleanupController(
 		templateLister:    templateLister,
 		recorder:          recorder,
 		clock:             clock,
-		sandboxPauser:     sandboxPauser,
+		pauseRequester:    pauseRequester,
 		sandboxTerminator: sandboxTerminator,
 		logger:            logger,
 		interval:          interval,
@@ -206,27 +206,26 @@ func (cc *CleanupController) cleanupExpired(ctx context.Context, template *v1alp
 
 		// Check if pod is expired
 		if now.After(expiresAt) {
-			cc.logger.Info("Pausing expired pod",
+			cc.logger.Info("Requesting pause for expired pod",
 				zap.String("pod", pod.Name),
 				zap.Time("expiresAt", expiresAt),
 			)
 
-			// Pause the sandbox instead of deleting it
-			if cc.sandboxPauser != nil {
-				err := cc.sandboxPauser.PauseSandboxByID(ctx, pod.Name)
+			if cc.pauseRequester != nil {
+				err := cc.pauseRequester.RequestPauseSandboxByID(ctx, pod.Name)
 				if err != nil {
-					cc.logger.Error("Failed to pause expired pod",
+					cc.logger.Error("Failed to request pause for expired pod",
 						zap.String("pod", pod.Name),
 						zap.Error(err),
 					)
 					continue
 				}
 
-				cc.recorder.Eventf(template, corev1.EventTypeNormal, "ExpiredPodPaused",
-					"Paused expired pod %s", pod.Name)
+				cc.recorder.Eventf(template, corev1.EventTypeNormal, "ExpiredPodPauseRequested",
+					"Requested pause for expired pod %s", pod.Name)
 				expiredCount++
 			} else {
-				cc.logger.Warn("SandboxPauser not configured, skipping pause of expired pod",
+				cc.logger.Warn("Sandbox pause requester not configured, skipping pause request for expired pod",
 					zap.String("pod", pod.Name),
 				)
 			}
@@ -234,7 +233,7 @@ func (cc *CleanupController) cleanupExpired(ctx context.Context, template *v1alp
 	}
 
 	if expiredCount > 0 {
-		cc.logger.Info("Cleaned up expired pods",
+		cc.logger.Info("Processed expired pods",
 			zap.String("template", template.Name),
 			zap.Int("count", expiredCount),
 		)

--- a/manager/pkg/controller/cleanup_controller_test.go
+++ b/manager/pkg/controller/cleanup_controller_test.go
@@ -1,0 +1,85 @@
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+)
+
+type staticCleanupClock struct {
+	now time.Time
+}
+
+func (c staticCleanupClock) Now() time.Time                  { return c.now }
+func (c staticCleanupClock) Since(t time.Time) time.Duration { return c.now.Sub(t) }
+func (c staticCleanupClock) Until(t time.Time) time.Duration { return t.Sub(c.now) }
+
+type recordingPauseRequester struct {
+	calls []string
+}
+
+func (r *recordingPauseRequester) RequestPauseSandboxByID(_ context.Context, sandboxID string) error {
+	r.calls = append(r.calls, sandboxID)
+	return nil
+}
+
+func TestCleanupExpiredRequestsPauseDesiredState(t *testing.T) {
+	now := time.Date(2026, time.April, 15, 19, 31, 0, 0, time.UTC)
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: "tpl-default",
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sandbox-1",
+			Namespace: "tpl-default",
+			Labels: map[string]string{
+				LabelTemplateID: "default",
+				LabelPoolType:   PoolTypeActive,
+			},
+			Annotations: map[string]string{
+				AnnotationExpiresAt: now.Add(-time.Minute).Format(time.RFC3339),
+			},
+		},
+	}
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+	})
+	require.NoError(t, indexer.Add(pod))
+
+	pauseRequester := &recordingPauseRequester{}
+	recorder := record.NewFakeRecorder(1)
+	controller := NewCleanupController(
+		nil,
+		corelisters.NewPodLister(indexer),
+		nil,
+		recorder,
+		staticCleanupClock{now: now},
+		pauseRequester,
+		nil,
+		zap.NewNop(),
+		time.Minute,
+	)
+
+	require.NoError(t, controller.cleanupExpired(context.Background(), template))
+
+	assert.Equal(t, []string{"sandbox-1"}, pauseRequester.calls)
+	select {
+	case event := <-recorder.Events:
+		assert.Contains(t, event, "ExpiredPodPauseRequested")
+	default:
+		t.Fatal("expected pause-requested event")
+	}
+}

--- a/manager/pkg/service/ctld_client.go
+++ b/manager/pkg/service/ctld_client.go
@@ -14,6 +14,8 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/sandboxprobe"
 )
 
+const defaultCtldClientTimeout = 15 * time.Second
+
 // CtldClientConfig holds configuration for the node-local ctld client.
 type CtldClientConfig struct {
 	Timeout time.Duration
@@ -28,7 +30,7 @@ type CtldClient struct {
 func NewCtldClient(config CtldClientConfig) *CtldClient {
 	timeout := config.Timeout
 	if timeout == 0 {
-		timeout = 5 * time.Second
+		timeout = defaultCtldClientTimeout
 	}
 	return &CtldClient{httpClient: &http.Client{Timeout: timeout}}
 }
@@ -36,7 +38,7 @@ func NewCtldClient(config CtldClientConfig) *CtldClient {
 // NewCtldClientWithHTTPClient creates a ctld client with a custom HTTP client.
 func NewCtldClientWithHTTPClient(httpClient *http.Client) *CtldClient {
 	if httpClient == nil {
-		httpClient = &http.Client{Timeout: 5 * time.Second}
+		httpClient = &http.Client{Timeout: defaultCtldClientTimeout}
 	}
 	return &CtldClient{httpClient: httpClient}
 }

--- a/manager/pkg/service/ctld_client_test.go
+++ b/manager/pkg/service/ctld_client_test.go
@@ -6,12 +6,20 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
 	"github.com/sandbox0-ai/sandbox0/pkg/sandboxprobe"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestNewCtldClientUsesDefaultTimeout(t *testing.T) {
+	client := NewCtldClient(CtldClientConfig{})
+
+	require.NotNil(t, client.httpClient)
+	assert.Equal(t, 15*time.Second, client.httpClient.Timeout)
+}
 
 func TestCtldClientPause(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/manager/pkg/service/power_executor_ctld_test.go
+++ b/manager/pkg/service/power_executor_ctld_test.go
@@ -56,6 +56,9 @@ func TestNewSandboxServiceUsesCtldExecutorWhenEnabled(t *testing.T) {
 	_, ok := svc.powerExecutor.(*ctldSandboxPowerExecutor)
 	assert.True(t, ok)
 	assert.Equal(t, 8095, svc.config.CtldPort)
+	assert.Equal(t, 15*time.Second, svc.config.CtldClientTimeout)
+	require.NotNil(t, svc.ctldClient)
+	assert.Equal(t, 15*time.Second, svc.ctldClient.httpClient.Timeout)
 }
 
 func TestCtldPowerExecutorCallsCtldPause(t *testing.T) {

--- a/manager/pkg/service/sandbox_service.go
+++ b/manager/pkg/service/sandbox_service.go
@@ -179,7 +179,7 @@ func NewSandboxService(
 		config.CtldPort = 8095
 	}
 	if config.CtldClientTimeout == 0 {
-		config.CtldClientTimeout = 5 * time.Second
+		config.CtldClientTimeout = defaultCtldClientTimeout
 	}
 	if networkProvider == nil {
 		networkProvider = network.NewNoopProvider()

--- a/manager/pkg/service/sandbox_service_pause.go
+++ b/manager/pkg/service/sandbox_service_pause.go
@@ -559,11 +559,17 @@ func (s *SandboxService) ResumeSandboxAndWait(ctx context.Context, sandboxID str
 	return resp, nil
 }
 
-// PauseSandboxByID implements the SandboxPauser interface from controller package.
-// It wraps PauseSandbox and returns only the error.
-func (s *SandboxService) PauseSandboxByID(ctx context.Context, sandboxID string) error {
-	_, err := s.PauseSandbox(ctx, sandboxID)
+// RequestPauseSandboxByID records the desired paused state for controller-driven reconciliation.
+func (s *SandboxService) RequestPauseSandboxByID(ctx context.Context, sandboxID string) error {
+	_, err := s.RequestPauseSandbox(ctx, sandboxID)
 	return err
+}
+
+// PauseSandboxByID records the desired paused state for compatibility with older controller callers.
+//
+// Deprecated: use RequestPauseSandboxByID for declarative pause requests.
+func (s *SandboxService) PauseSandboxByID(ctx context.Context, sandboxID string) error {
+	return s.RequestPauseSandboxByID(ctx, sandboxID)
 }
 
 // TerminateSandboxByID implements the SandboxTerminator interface from controller package.

--- a/manager/pkg/service/sandbox_service_power_state_test.go
+++ b/manager/pkg/service/sandbox_service_power_state_test.go
@@ -157,6 +157,39 @@ func TestRequestPauseSandboxRetriesConflict(t *testing.T) {
 	assert.Equal(t, SandboxPowerPhasePausing, state.Phase)
 }
 
+func TestRequestPauseSandboxByIDRecordsDesiredState(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sandbox-1",
+			Namespace: "default",
+			Labels: map[string]string{
+				controller.LabelSandboxID: "sandbox-1",
+			},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	k8sClient := fake.NewSimpleClientset(pod)
+	executor := &recordingPowerExecutor{}
+	svc := &SandboxService{
+		k8sClient: k8sClient,
+		podLister: newTestPodLister(t, pod),
+		clock:     systemTime{},
+		logger:    zap.NewNop(),
+	}
+	svc.SetPowerExecutor(executor)
+	svc.powerStateReconcilers.Store("sandbox-1", struct{}{})
+
+	require.NoError(t, svc.RequestPauseSandboxByID(context.Background(), "sandbox-1"))
+
+	assert.Empty(t, executor.pauseCalls)
+	updated, err := k8sClient.CoreV1().Pods("default").Get(context.Background(), "sandbox-1", metav1.GetOptions{})
+	require.NoError(t, err)
+	state := sandboxPowerStateFromAnnotations(updated.Annotations)
+	assert.Equal(t, SandboxPowerStatePaused, state.Desired)
+	assert.Equal(t, SandboxPowerStateActive, state.Observed)
+	assert.Equal(t, SandboxPowerPhasePausing, state.Phase)
+}
+
 func TestSandboxPowerExecutorOverrideIsUsed(t *testing.T) {
 	executor := &recordingPowerExecutor{}
 	svc := &SandboxService{logger: zap.NewNop()}


### PR DESCRIPTION
## Summary
- Declare soft-TTL expiration as desired paused state instead of synchronously executing pause in cleanup.
- Increase default ctld client timeout from 5s to 15s.
- Add tests for declarative cleanup pause requests and ctld timeout defaults.

## Testing
- go test ./manager/pkg/service ./manager/pkg/controller ./infra-operator/api/config ./infra-operator/internal/plan ./infra-operator/internal/controller/services/manager -count=1
- go test ./manager/cmd/manager -count=1
- pre-push hook: make manifests, make proto, make apispec, go fmt ./..., go mod tidy, go mod vendor, golangci-lint run ./...