### PR TITLE
Fix system admin API key public template scope

### DIFF
--- a/cluster-gateway/pkg/http/handlers_internal.go
+++ b/cluster-gateway/pkg/http/handlers_internal.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"errors"
 	"net/http"
 	"strings"
 
@@ -11,6 +12,12 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"go.uber.org/zap"
 )
+
+var errManagerTokenTeamIDRequired = errors.New("team_id is required for team-scoped manager token")
+
+type managerTokenOptions struct {
+	systemScopeForSystemAdmin bool
+}
 
 // === Internal API Handlers (for scheduler) ===
 
@@ -103,21 +110,47 @@ func (s *Server) proxyInternalTemplateRequest(c *gin.Context) {
 }
 
 func (s *Server) generateManagerToken(authCtx *authn.AuthContext, claims *internalauth.Claims, permissions []string) (string, error) {
+	return s.generateManagerTokenWithOptions(authCtx, claims, permissions, managerTokenOptions{})
+}
+
+func (s *Server) generateTemplateManagerToken(authCtx *authn.AuthContext, claims *internalauth.Claims, permissions []string) (string, error) {
+	return s.generateManagerTokenWithOptions(authCtx, claims, permissions, managerTokenOptions{
+		systemScopeForSystemAdmin: true,
+	})
+}
+
+func (s *Server) generateManagerTokenWithOptions(authCtx *authn.AuthContext, claims *internalauth.Claims, permissions []string, tokenOpts managerTokenOptions) (string, error) {
 	opts := internalauth.GenerateOptions{
 		Permissions: permissions,
 	}
-	if claims != nil && claims.IsSystem {
-		return s.internalAuthGen.GenerateSystem("manager", opts)
-	}
-	if authCtx != nil && authCtx.IsSystemAdmin && strings.TrimSpace(authCtx.TeamID) == "" {
-		return s.internalAuthGen.GenerateSystem("manager", opts)
+	if authCtx != nil {
+		opts.UserID = authCtx.UserID
 	}
 
 	teamID := ""
 	userID := ""
 	if authCtx != nil {
-		teamID = authCtx.TeamID
+		teamID = strings.TrimSpace(authCtx.TeamID)
 		userID = authCtx.UserID
 	}
+	if shouldGenerateSystemManagerToken(authCtx, claims, teamID, tokenOpts) {
+		return s.internalAuthGen.GenerateSystem("manager", opts)
+	}
+	if teamID == "" {
+		return "", errManagerTokenTeamIDRequired
+	}
 	return s.internalAuthGen.Generate("manager", teamID, userID, opts)
+}
+
+func shouldGenerateSystemManagerToken(authCtx *authn.AuthContext, claims *internalauth.Claims, teamID string, opts managerTokenOptions) bool {
+	if claims != nil && claims.IsSystem {
+		return true
+	}
+	if authCtx == nil || !authCtx.IsSystemAdmin {
+		return false
+	}
+	if teamID == "" {
+		return true
+	}
+	return opts.systemScopeForSystemAdmin && authCtx.AuthMethod == authn.AuthMethodAPIKey
 }

--- a/cluster-gateway/pkg/http/handlers_manager_token_test.go
+++ b/cluster-gateway/pkg/http/handlers_manager_token_test.go
@@ -32,3 +32,90 @@ func TestGenerateManagerTokenUsesSystemTokenForTeamlessSystemAdmin(t *testing.T)
 		t.Fatalf("TeamID = %q, want empty", claims.TeamID)
 	}
 }
+
+func TestGenerateTemplateManagerTokenUsesSystemScopeForSystemAdminAPIKey(t *testing.T) {
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	server := &Server{internalAuthGen: internalauth.NewGenerator(internalauth.GeneratorConfig{Caller: "cluster-gateway", PrivateKey: privateKey, TTL: time.Minute})}
+
+	token, err := server.generateTemplateManagerToken(&authn.AuthContext{
+		AuthMethod:    authn.AuthMethodAPIKey,
+		TeamID:        "team-1",
+		UserID:        "admin-user",
+		IsSystemAdmin: true,
+	}, nil, []string{authn.PermTemplateCreate})
+	if err != nil {
+		t.Fatalf("generateTemplateManagerToken: %v", err)
+	}
+	claims, err := internalauth.NewValidator(internalauth.ValidatorConfig{Target: "manager", PublicKey: publicKey}).Validate(token)
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if !claims.IsSystemToken() {
+		t.Fatalf("expected system token, got team_id=%q", claims.TeamID)
+	}
+	if claims.TeamID != "" {
+		t.Fatalf("TeamID = %q, want empty", claims.TeamID)
+	}
+	if claims.UserID != "admin-user" {
+		t.Fatalf("UserID = %q, want admin-user", claims.UserID)
+	}
+}
+
+func TestGenerateTemplateManagerTokenKeepsSelectedTeamForSystemAdminJWT(t *testing.T) {
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	server := &Server{internalAuthGen: internalauth.NewGenerator(internalauth.GeneratorConfig{Caller: "cluster-gateway", PrivateKey: privateKey, TTL: time.Minute})}
+
+	token, err := server.generateTemplateManagerToken(&authn.AuthContext{
+		AuthMethod:    authn.AuthMethodJWT,
+		TeamID:        "team-1",
+		UserID:        "admin-user",
+		IsSystemAdmin: true,
+	}, nil, []string{authn.PermTemplateCreate})
+	if err != nil {
+		t.Fatalf("generateTemplateManagerToken: %v", err)
+	}
+	claims, err := internalauth.NewValidator(internalauth.ValidatorConfig{Target: "manager", PublicKey: publicKey}).Validate(token)
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if claims.IsSystemToken() {
+		t.Fatalf("selected-team JWT should remain team scoped")
+	}
+	if claims.TeamID != "team-1" {
+		t.Fatalf("TeamID = %q, want team-1", claims.TeamID)
+	}
+}
+
+func TestGenerateManagerTokenKeepsSystemAdminAPIKeyTeamScopedByDefault(t *testing.T) {
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	server := &Server{internalAuthGen: internalauth.NewGenerator(internalauth.GeneratorConfig{Caller: "cluster-gateway", PrivateKey: privateKey, TTL: time.Minute})}
+
+	token, err := server.generateManagerToken(&authn.AuthContext{
+		AuthMethod:    authn.AuthMethodAPIKey,
+		TeamID:        "team-1",
+		UserID:        "admin-user",
+		IsSystemAdmin: true,
+	}, nil, []string{authn.PermSandboxCreate})
+	if err != nil {
+		t.Fatalf("generateManagerToken: %v", err)
+	}
+	claims, err := internalauth.NewValidator(internalauth.ValidatorConfig{Target: "manager", PublicKey: publicKey}).Validate(token)
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if claims.IsSystemToken() {
+		t.Fatalf("default manager token should remain team scoped")
+	}
+	if claims.TeamID != "team-1" {
+		t.Fatalf("TeamID = %q, want team-1", claims.TeamID)
+	}
+}

--- a/cluster-gateway/pkg/http/handlers_sandbox.go
+++ b/cluster-gateway/pkg/http/handlers_sandbox.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/sandbox0-ai/sandbox0/cluster-gateway/pkg/client"
@@ -19,14 +20,28 @@ import (
 
 // proxyToManager proxies a request to manager with internal authentication
 func (s *Server) proxyToManager(c *gin.Context) {
+	s.proxyToManagerWithOptions(c, managerTokenOptions{})
+}
+
+func (s *Server) proxyTemplateToManager(c *gin.Context) {
+	s.proxyToManagerWithOptions(c, managerTokenOptions{
+		systemScopeForSystemAdmin: true,
+	})
+}
+
+func (s *Server) proxyToManagerWithOptions(c *gin.Context, tokenOpts managerTokenOptions) {
 	authCtx := middleware.GetAuthContext(c)
 	claims := internalauth.ClaimsFromContext(c.Request.Context())
+	teamID := ""
+	if authCtx != nil {
+		teamID = authCtx.TeamID
+	}
 
 	// Generate internal token for manager
-	internalToken, err := s.generateManagerToken(authCtx, claims, nil)
+	internalToken, err := s.generateManagerTokenWithOptions(authCtx, claims, nil, tokenOpts)
 	if err != nil {
 		s.logger.Error("Failed to generate internal token for manager",
-			zap.String("team_id", authCtx.TeamID),
+			zap.String("team_id", teamID),
 			zap.Error(err),
 		)
 		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "internal authentication failed")
@@ -34,7 +49,11 @@ func (s *Server) proxyToManager(c *gin.Context) {
 	}
 
 	// Set headers
-	c.Request.Header.Set(internalauth.TeamIDHeader, authCtx.TeamID)
+	forwardedTeamID := teamID
+	if shouldGenerateSystemManagerToken(authCtx, claims, strings.TrimSpace(teamID), tokenOpts) {
+		forwardedTeamID = ""
+	}
+	c.Request.Header.Set(internalauth.TeamIDHeader, forwardedTeamID)
 	c.Request.Header.Set(internalauth.DefaultTokenHeader, internalToken)
 
 	// Forward to manager

--- a/cluster-gateway/pkg/http/handlers_template.go
+++ b/cluster-gateway/pkg/http/handlers_template.go
@@ -13,7 +13,7 @@ import (
 func (s *Server) listTemplates(c *gin.Context) {
 	// Forward to manager
 	c.Request.URL.Path = "/api/v1/templates"
-	s.proxyToManager(c)
+	s.proxyTemplateToManager(c)
 }
 
 // getTemplate gets a template by ID
@@ -25,13 +25,13 @@ func (s *Server) getTemplate(c *gin.Context) {
 	}
 
 	c.Request.URL.Path = "/api/v1/templates/" + templateID
-	s.proxyToManager(c)
+	s.proxyTemplateToManager(c)
 }
 
 // createTemplate creates a new template
 func (s *Server) createTemplate(c *gin.Context) {
 	c.Request.URL.Path = "/api/v1/templates"
-	s.proxyToManager(c)
+	s.proxyTemplateToManager(c)
 }
 
 // updateTemplate updates an existing template
@@ -43,7 +43,7 @@ func (s *Server) updateTemplate(c *gin.Context) {
 	}
 
 	c.Request.URL.Path = "/api/v1/templates/" + templateID
-	s.proxyToManager(c)
+	s.proxyTemplateToManager(c)
 }
 
 // deleteTemplate deletes a template
@@ -55,5 +55,5 @@ func (s *Server) deleteTemplate(c *gin.Context) {
 	}
 
 	c.Request.URL.Path = "/api/v1/templates/" + templateID
-	s.proxyToManager(c)
+	s.proxyTemplateToManager(c)
 }

--- a/pkg/gateway/apikey/repository.go
+++ b/pkg/gateway/apikey/repository.go
@@ -22,19 +22,21 @@ var (
 
 // APIKey represents an API key stored in the database.
 type APIKey struct {
-	ID         string     `json:"id"`
-	KeyValue   string     `json:"key_value"`
-	TeamID     string     `json:"team_id"`
-	UserID     *string    `json:"user_id,omitempty"`
-	CreatedBy  string     `json:"created_by"`
-	Name       string     `json:"name"`
-	Roles      []string   `json:"roles"`
-	IsActive   bool       `json:"is_active"`
-	ExpiresAt  time.Time  `json:"expires_at"`
-	LastUsed   *time.Time `json:"last_used_at,omitempty"`
-	UsageCount int64      `json:"usage_count"`
-	CreatedAt  time.Time  `json:"created_at"`
-	UpdatedAt  time.Time  `json:"updated_at"`
+	ID        string   `json:"id"`
+	KeyValue  string   `json:"key_value"`
+	TeamID    string   `json:"team_id"`
+	UserID    *string  `json:"user_id,omitempty"`
+	CreatedBy string   `json:"created_by"`
+	Name      string   `json:"name"`
+	Roles     []string `json:"roles"`
+	IsActive  bool     `json:"is_active"`
+	// CreatorIsSystemAdmin is derived from the current creator user record.
+	CreatorIsSystemAdmin bool       `json:"-"`
+	ExpiresAt            time.Time  `json:"expires_at"`
+	LastUsed             *time.Time `json:"last_used_at,omitempty"`
+	UsageCount           int64      `json:"usage_count"`
+	CreatedAt            time.Time  `json:"created_at"`
+	UpdatedAt            time.Time  `json:"updated_at"`
 }
 
 // Repository provides database access for team-scoped API keys.
@@ -217,15 +219,17 @@ func (r *Repository) ValidateAPIKey(ctx context.Context, keyValue string) (*APIK
 	var key APIKey
 	var rolesJSON []byte
 	err := r.pool.QueryRow(ctx, `
-		SELECT id, key_value, team_id, created_by, name, roles,
-		       is_active, expires_at, last_used_at, usage_count, created_at, updated_at, user_id
-		FROM api_keys
-		WHERE key_value = $1
+		SELECT ak.id, ak.key_value, ak.team_id, ak.created_by, ak.name, ak.roles,
+		       ak.is_active, ak.expires_at, ak.last_used_at, ak.usage_count,
+		       ak.created_at, ak.updated_at, ak.user_id, COALESCE(u.is_admin, false)
+		FROM api_keys ak
+		LEFT JOIN users u ON u.id = ak.created_by
+		WHERE ak.key_value = $1
 	`, keyValue).Scan(
 		&key.ID, &key.KeyValue, &key.TeamID, &key.CreatedBy,
 		&key.Name, &rolesJSON, &key.IsActive,
 		&key.ExpiresAt, &key.LastUsed, &key.UsageCount,
-		&key.CreatedAt, &key.UpdatedAt, &key.UserID,
+		&key.CreatedAt, &key.UpdatedAt, &key.UserID, &key.CreatorIsSystemAdmin,
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {

--- a/pkg/gateway/middleware/auth.go
+++ b/pkg/gateway/middleware/auth.go
@@ -115,12 +115,22 @@ func (m *AuthMiddleware) authenticateAPIKey(c *gin.Context, keyValue string) (*a
 	}
 
 	return &authn.AuthContext{
-		AuthMethod:  authn.AuthMethodAPIKey,
-		TeamID:      apiKey.TeamID,
-		UserID:      userID,
-		APIKeyID:    apiKey.ID,
-		Permissions: authn.ExpandRolesPermissions(apiKey.Roles),
+		AuthMethod:    authn.AuthMethodAPIKey,
+		TeamID:        apiKey.TeamID,
+		UserID:        userID,
+		APIKeyID:      apiKey.ID,
+		IsSystemAdmin: apiKey.CreatorIsSystemAdmin && apiKeyHasRole(apiKey.Roles, "admin"),
+		Permissions:   authn.ExpandRolesPermissions(apiKey.Roles),
 	}, nil
+}
+
+func apiKeyHasRole(roles []string, role string) bool {
+	for _, candidate := range roles {
+		if strings.TrimSpace(candidate) == role {
+			return true
+		}
+	}
+	return false
 }
 
 // authenticateJWT validates a JWT token

--- a/pkg/gateway/middleware/auth_test.go
+++ b/pkg/gateway/middleware/auth_test.go
@@ -150,6 +150,59 @@ func TestAuthMiddleware_APIKeyFallsBackToCreatorUserID(t *testing.T) {
 	}
 }
 
+func TestAuthMiddleware_APIKeyCreatedBySystemAdminWithAdminRoleIsSystemAdmin(t *testing.T) {
+	t.Setenv("GIN_MODE", "release")
+
+	req := httptest.NewRequest("GET", "/api/v1/templates", nil)
+	req.Header.Set("Authorization", "Bearer s0_test")
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = req
+
+	middleware := NewAuthMiddleware(staticAPIKeyValidator{key: &apikey.APIKey{
+		ID:                   "key-1",
+		TeamID:               "team-1",
+		CreatedBy:            "admin-user",
+		Roles:                []string{"admin"},
+		CreatorIsSystemAdmin: true,
+	}}, "test-secret", nil, zap.NewNop())
+	authCtx, err := middleware.AuthenticateRequest(ctx)
+	if err != nil {
+		t.Fatalf("authenticate request: %v", err)
+	}
+	if !authCtx.IsSystemAdmin {
+		t.Fatalf("expected system admin API key auth context")
+	}
+	if !authCtx.HasPermission(authn.PermTemplateWrite) {
+		t.Fatalf("expected admin API key permissions")
+	}
+}
+
+func TestAuthMiddleware_APIKeyCreatedBySystemAdminRequiresAdminRoleForSystemAdmin(t *testing.T) {
+	t.Setenv("GIN_MODE", "release")
+
+	req := httptest.NewRequest("GET", "/api/v1/templates", nil)
+	req.Header.Set("Authorization", "Bearer s0_test")
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = req
+
+	middleware := NewAuthMiddleware(staticAPIKeyValidator{key: &apikey.APIKey{
+		ID:                   "key-1",
+		TeamID:               "team-1",
+		CreatedBy:            "admin-user",
+		Roles:                []string{"developer"},
+		CreatorIsSystemAdmin: true,
+	}}, "test-secret", nil, zap.NewNop())
+	authCtx, err := middleware.AuthenticateRequest(ctx)
+	if err != nil {
+		t.Fatalf("authenticate request: %v", err)
+	}
+	if authCtx.IsSystemAdmin {
+		t.Fatalf("developer API key should not inherit system admin privileges")
+	}
+}
+
 func TestAuthMiddleware_JWTAccessTokenExplicitTeamHeader(t *testing.T) {
 	t.Setenv("GIN_MODE", "release")
 

--- a/pkg/internalauth/internalauth_test.go
+++ b/pkg/internalauth/internalauth_test.go
@@ -323,6 +323,7 @@ func TestGenerateSystem(t *testing.T) {
 
 	token, err := generator.GenerateSystem("manager", GenerateOptions{
 		Permissions: []string{"*:*"},
+		UserID:      "admin-user",
 	})
 	if err != nil {
 		t.Fatalf("GenerateSystem failed: %v", err)
@@ -343,6 +344,10 @@ func TestGenerateSystem(t *testing.T) {
 
 	if claims.TeamID != "" {
 		t.Errorf("Expected empty TeamID for system token, got '%s'", claims.TeamID)
+	}
+
+	if claims.UserID != "admin-user" {
+		t.Errorf("Expected UserID 'admin-user', got '%s'", claims.UserID)
 	}
 
 	if claims.Subject != "system" {

--- a/pkg/internalauth/token.go
+++ b/pkg/internalauth/token.go
@@ -130,6 +130,7 @@ func (g *Generator) GenerateSystem(target string, opts GenerateOptions) (string,
 		ID:          generateJTI(),
 		Caller:      g.config.Caller,
 		Target:      target,
+		UserID:      opts.UserID,
 		IsSystem:    true,
 		Permissions: opts.Permissions,
 	}

--- a/regional-gateway/pkg/http/cluster_cache.go
+++ b/regional-gateway/pkg/http/cluster_cache.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -13,6 +14,12 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"github.com/sandbox0-ai/sandbox0/pkg/proxy"
 )
+
+var errInternalTokenTeamIDRequired = errors.New("team_id is required for team-scoped internal token")
+
+type internalTokenOptions struct {
+	systemScopeForSystemAdmin bool
+}
 
 type schedulerCluster struct {
 	ClusterID         string `json:"cluster_id"`
@@ -155,26 +162,53 @@ func (s *Server) buildSchedulerClustersURL() (string, error) {
 }
 
 func (s *Server) generateInternalToken(authCtx *authn.AuthContext, target string) (string, error) {
+	return s.generateInternalTokenWithOptions(authCtx, target, internalTokenOptions{})
+}
+
+func (s *Server) generateTemplateInternalToken(authCtx *authn.AuthContext, target string) (string, error) {
+	return s.generateInternalTokenWithOptions(authCtx, target, internalTokenOptions{
+		systemScopeForSystemAdmin: true,
+	})
+}
+
+func (s *Server) generateInternalTokenWithOptions(authCtx *authn.AuthContext, target string, opts internalTokenOptions) (string, error) {
 	if s.internalAuthGen == nil {
 		return "", fmt.Errorf("internal auth generator not configured")
 	}
 	if authCtx == nil {
 		return s.internalAuthGen.GenerateSystem(target, internalauth.GenerateOptions{})
 	}
-	if authCtx.TeamID == "" {
+	generateOpts := internalauth.GenerateOptions{
+		UserID:      authCtx.UserID,
+		Permissions: authCtx.Permissions,
+	}
+	teamID := strings.TrimSpace(authCtx.TeamID)
+	if shouldGenerateSystemInternalToken(authCtx, teamID, opts) {
 		return s.internalAuthGen.GenerateSystem(
 			target,
-			internalauth.GenerateOptions{
-				Permissions: authCtx.Permissions,
-			},
+			generateOpts,
 		)
+	}
+	if teamID == "" {
+		return "", errInternalTokenTeamIDRequired
 	}
 	return s.internalAuthGen.Generate(
 		target,
-		authCtx.TeamID,
+		teamID,
 		authCtx.UserID,
-		internalauth.GenerateOptions{
-			Permissions: authCtx.Permissions,
-		},
+		generateOpts,
 	)
+}
+
+func shouldGenerateSystemInternalToken(authCtx *authn.AuthContext, teamID string, opts internalTokenOptions) bool {
+	if authCtx.AuthMethod == authn.AuthMethodInternal && teamID == "" {
+		return true
+	}
+	if !authCtx.IsSystemAdmin {
+		return false
+	}
+	if teamID == "" {
+		return true
+	}
+	return opts.systemScopeForSystemAdmin && authCtx.AuthMethod == authn.AuthMethodAPIKey
 }

--- a/regional-gateway/pkg/http/cluster_cache_test.go
+++ b/regional-gateway/pkg/http/cluster_cache_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/authn"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"go.uber.org/zap"
@@ -80,5 +82,147 @@ func TestGetClusterGatewayURLForClusterRefreshesCacheWithSystemToken(t *testing.
 	}
 	if cached := server.getClusterFromCache("cluster-a"); cached != got {
 		t.Fatalf("cached cluster gateway url = %q, want %q", cached, got)
+	}
+}
+
+func TestGenerateTemplateInternalTokenUsesSystemScopeForSystemAdminAPIKey(t *testing.T) {
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate ed25519 keypair: %v", err)
+	}
+	server := &Server{
+		internalAuthGen: internalauth.NewGenerator(internalauth.GeneratorConfig{
+			Caller:     internalauth.ServiceRegionalGateway,
+			PrivateKey: privateKey,
+			TTL:        time.Minute,
+		}),
+	}
+
+	token, err := server.generateTemplateInternalToken(&authn.AuthContext{
+		AuthMethod:    authn.AuthMethodAPIKey,
+		TeamID:        "team-1",
+		UserID:        "admin-user",
+		IsSystemAdmin: true,
+		Permissions:   []string{authn.PermTemplateCreate},
+	}, internalauth.ServiceScheduler)
+	if err != nil {
+		t.Fatalf("generateTemplateInternalToken: %v", err)
+	}
+
+	claims, err := internalauth.NewValidator(internalauth.ValidatorConfig{
+		Target:    internalauth.ServiceScheduler,
+		PublicKey: publicKey,
+	}).Validate(token)
+	if err != nil {
+		t.Fatalf("validate token: %v", err)
+	}
+	if !claims.IsSystemToken() {
+		t.Fatalf("expected system token, got team_id=%q", claims.TeamID)
+	}
+	if claims.TeamID != "" {
+		t.Fatalf("TeamID = %q, want empty", claims.TeamID)
+	}
+	if claims.UserID != "admin-user" {
+		t.Fatalf("UserID = %q, want admin-user", claims.UserID)
+	}
+}
+
+func TestGenerateTemplateInternalTokenKeepsSelectedTeamForSystemAdminJWT(t *testing.T) {
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate ed25519 keypair: %v", err)
+	}
+	server := &Server{
+		internalAuthGen: internalauth.NewGenerator(internalauth.GeneratorConfig{
+			Caller:     internalauth.ServiceRegionalGateway,
+			PrivateKey: privateKey,
+			TTL:        time.Minute,
+		}),
+	}
+
+	token, err := server.generateTemplateInternalToken(&authn.AuthContext{
+		AuthMethod:    authn.AuthMethodJWT,
+		TeamID:        "team-1",
+		UserID:        "admin-user",
+		IsSystemAdmin: true,
+		Permissions:   []string{authn.PermTemplateCreate},
+	}, internalauth.ServiceScheduler)
+	if err != nil {
+		t.Fatalf("generateTemplateInternalToken: %v", err)
+	}
+
+	claims, err := internalauth.NewValidator(internalauth.ValidatorConfig{
+		Target:    internalauth.ServiceScheduler,
+		PublicKey: publicKey,
+	}).Validate(token)
+	if err != nil {
+		t.Fatalf("validate token: %v", err)
+	}
+	if claims.IsSystemToken() {
+		t.Fatalf("selected-team JWT should remain team scoped")
+	}
+	if claims.TeamID != "team-1" {
+		t.Fatalf("TeamID = %q, want team-1", claims.TeamID)
+	}
+}
+
+func TestGenerateInternalTokenKeepsSystemAdminAPIKeyTeamScopedByDefault(t *testing.T) {
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate ed25519 keypair: %v", err)
+	}
+	server := &Server{
+		internalAuthGen: internalauth.NewGenerator(internalauth.GeneratorConfig{
+			Caller:     internalauth.ServiceRegionalGateway,
+			PrivateKey: privateKey,
+			TTL:        time.Minute,
+		}),
+	}
+
+	token, err := server.generateInternalToken(&authn.AuthContext{
+		AuthMethod:    authn.AuthMethodAPIKey,
+		TeamID:        "team-1",
+		UserID:        "admin-user",
+		IsSystemAdmin: true,
+		Permissions:   []string{authn.PermSandboxCreate},
+	}, internalauth.ServiceClusterGateway)
+	if err != nil {
+		t.Fatalf("generateInternalToken: %v", err)
+	}
+
+	claims, err := internalauth.NewValidator(internalauth.ValidatorConfig{
+		Target:    internalauth.ServiceClusterGateway,
+		PublicKey: publicKey,
+	}).Validate(token)
+	if err != nil {
+		t.Fatalf("validate token: %v", err)
+	}
+	if claims.IsSystemToken() {
+		t.Fatalf("default internal token should remain team scoped")
+	}
+	if claims.TeamID != "team-1" {
+		t.Fatalf("TeamID = %q, want team-1", claims.TeamID)
+	}
+}
+
+func TestGenerateInternalTokenRejectsTeamlessNonAdmin(t *testing.T) {
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate ed25519 keypair: %v", err)
+	}
+	server := &Server{
+		internalAuthGen: internalauth.NewGenerator(internalauth.GeneratorConfig{
+			Caller:     internalauth.ServiceRegionalGateway,
+			PrivateKey: privateKey,
+			TTL:        time.Minute,
+		}),
+	}
+
+	_, err = server.generateInternalToken(&authn.AuthContext{
+		AuthMethod: authn.AuthMethodJWT,
+		UserID:     "user-1",
+	}, internalauth.ServiceScheduler)
+	if !errors.Is(err, errInternalTokenTeamIDRequired) {
+		t.Fatalf("error = %v, want %v", err, errInternalTokenTeamIDRequired)
 	}
 }

--- a/regional-gateway/pkg/http/server.go
+++ b/regional-gateway/pkg/http/server.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -287,7 +288,7 @@ func (s *Server) setupRoutes() {
 		if s.schedulerRouter != nil {
 			// Template routes go to scheduler
 			templates := api.Group("/v1/templates")
-			templates.Use(s.injectInternalTokenForTarget("scheduler"))
+			templates.Use(s.injectTemplateInternalTokenForTarget("scheduler"))
 			templates.Any("", s.schedulerRouter.ProxyToTarget)
 			templates.Any("/*path", s.schedulerRouter.ProxyToTarget)
 
@@ -444,6 +445,16 @@ func (s *Server) injectInternalToken() gin.HandlerFunc {
 
 // injectInternalTokenForTarget adds internal auth token for a specific target service
 func (s *Server) injectInternalTokenForTarget(target string) gin.HandlerFunc {
+	return s.injectInternalTokenForTargetWithOptions(target, internalTokenOptions{})
+}
+
+func (s *Server) injectTemplateInternalTokenForTarget(target string) gin.HandlerFunc {
+	return s.injectInternalTokenForTargetWithOptions(target, internalTokenOptions{
+		systemScopeForSystemAdmin: true,
+	})
+}
+
+func (s *Server) injectInternalTokenForTargetWithOptions(target string, tokenOpts internalTokenOptions) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		authCtx := middleware.GetAuthContext(c)
 		if authCtx == nil {
@@ -451,9 +462,13 @@ func (s *Server) injectInternalTokenForTarget(target string) gin.HandlerFunc {
 			return
 		}
 
-		// Generate internal token for the target service
-		token, err := s.generateInternalToken(authCtx, target)
+		// Generate internal token for the target service.
+		token, err := s.generateInternalTokenWithOptions(authCtx, target, tokenOpts)
 		if err != nil {
+			if errors.Is(err, errInternalTokenTeamIDRequired) {
+				spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "team_id is required")
+				return
+			}
 			s.logger.Error("Failed to generate internal token",
 				zap.String("target", target),
 				zap.Error(err),
@@ -466,7 +481,11 @@ func (s *Server) injectInternalTokenForTarget(target string) gin.HandlerFunc {
 		c.Request.Header.Set(internalauth.DefaultTokenHeader, token)
 
 		// Also forward team/user info in headers for logging
-		c.Request.Header.Set("X-Team-ID", authCtx.TeamID)
+		forwardedTeamID := authCtx.TeamID
+		if shouldGenerateSystemInternalToken(authCtx, strings.TrimSpace(authCtx.TeamID), tokenOpts) {
+			forwardedTeamID = ""
+		}
+		c.Request.Header.Set("X-Team-ID", forwardedTeamID)
 		c.Request.Header.Set("X-User-ID", authCtx.UserID)
 		c.Request.Header.Set("X-Auth-Method", string(authCtx.AuthMethod))
 


### PR DESCRIPTION
## Summary
- Mark admin API keys created by current system admin users as system-admin auth contexts.
- Use public/system internal token scope for template routes under system-admin identity while keeping non-template routes team-scoped.
- Reject teamless non-admin internal token generation and preserve user ID on system tokens for audit.

Closes #204

## Testing
- go test ./pkg/gateway/middleware ./pkg/internalauth ./regional-gateway/pkg/http ./cluster-gateway/pkg/http ./pkg/gateway/... -count=1
- pre-push hook: make manifests, make proto, make apispec, go fmt ./..., go mod tidy, go mod vendor, golangci-lint run ./... (0 issues)