### PR TITLE
Unify service observability instrumentation

### DIFF
--- a/cluster-gateway/cmd/cluster-gateway/main.go
+++ b/cluster-gateway/cmd/cluster-gateway/main.go
@@ -144,17 +144,15 @@ func initLogger(level string) (*zap.Logger, error) {
 
 func initDatabase(ctx context.Context, cfg *config.ClusterGatewayConfig, logger *zap.Logger, obsProvider *observability.Provider) *pgxpool.Pool {
 	pool, err := dbpool.New(ctx, dbpool.Options{
-		DatabaseURL: cfg.DatabaseURL,
-		MaxConns:    int32(cfg.DatabaseMaxConns),
-		MinConns:    int32(cfg.DatabaseMinConns),
-		Schema:      "shared_gateway",
+		DatabaseURL:    cfg.DatabaseURL,
+		MaxConns:       int32(cfg.DatabaseMaxConns),
+		MinConns:       int32(cfg.DatabaseMinConns),
+		Schema:         "shared_gateway",
+		ConfigModifier: obsProvider.Pgx.ConfigModifier(),
 	})
 	if err != nil {
 		logger.Fatal("Failed to connect to database", zap.Error(err))
 	}
-
-	// Wrap pool with observability
-	obsProvider.Pgx.WrapPool(pool)
 
 	logger.Info("Database connection established",
 		zap.Int32("max_conns", pool.Config().MaxConns),

--- a/cluster-gateway/pkg/client/manager.go
+++ b/cluster-gateway/pkg/client/manager.go
@@ -49,6 +49,14 @@ func NewManagerClient(baseURL string, internalAuthGen *internalauth.Generator, l
 	}
 }
 
+// SetHTTPClient replaces the underlying HTTP client.
+func (c *ManagerClient) SetHTTPClient(httpClient *http.Client) {
+	if c == nil || httpClient == nil {
+		return
+	}
+	c.httpClient = httpClient
+}
+
 // GetSandbox retrieves sandbox information from manager
 func (c *ManagerClient) GetSandbox(ctx context.Context, sandboxID, userID, teamID string) (*mgr.Sandbox, error) {
 	// Generate internal token for manager

--- a/cluster-gateway/pkg/http/handlers_context.go
+++ b/cluster-gateway/pkg/http/handlers_context.go
@@ -62,8 +62,7 @@ func (s *Server) createContext(c *gin.Context) {
 	upReq.Header = c.Request.Header.Clone()
 	requestModifier(upReq)
 
-	client := &http.Client{}
-	resp, err := client.Do(upReq)
+	resp, err := s.outboundHTTPClient().Do(upReq)
 	if err != nil {
 		if proxy.IsTimeoutError(err) {
 			spec.JSONError(c, http.StatusGatewayTimeout, spec.CodeUnavailable, "sandbox process request timed out")
@@ -420,7 +419,13 @@ func (s *Server) proxyToProcd(c *gin.Context, procdURL *url.URL) {
 	if proxyTimeout == 0 {
 		proxyTimeout = 10 * time.Second
 	}
-	router, err := proxy.NewRouter(procdURL.String(), s.logger, proxyTimeout, proxy.WithRequestModifier(requestModifier))
+	router, err := proxy.NewRouter(
+		procdURL.String(),
+		s.logger,
+		proxyTimeout,
+		proxy.WithRequestModifier(requestModifier),
+		proxy.WithHTTPClient(s.outboundHTTPClient()),
+	)
 	if err != nil {
 		s.logger.Error("Failed to create procd proxy router",
 			zap.String("procd_url", procdURL.String()),

--- a/cluster-gateway/pkg/http/handlers_exposure.go
+++ b/cluster-gateway/pkg/http/handlers_exposure.go
@@ -94,7 +94,7 @@ func (s *Server) handlePublicExposureNoRoute(c *gin.Context) {
 	if proxyTimeout == 0 {
 		proxyTimeout = 10 * time.Second
 	}
-	router, err := proxy.NewRouter(targetURL.String(), s.logger, proxyTimeout)
+	router, err := proxy.NewRouter(targetURL.String(), s.logger, proxyTimeout, proxy.WithHTTPClient(s.outboundHTTPClient()))
 	if err != nil {
 		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "proxy initialization failed")
 		return

--- a/cluster-gateway/pkg/http/server.go
+++ b/cluster-gateway/pkg/http/server.go
@@ -59,6 +59,7 @@ type Server struct {
 	entitlements       licensing.Entitlements
 	sandboxAddrCache   *cache.Cache[sandboxAddrCacheKey, *url.URL]
 	obsProvider        *observability.Provider
+	httpClient         *http.Client
 }
 
 // NewServer creates a new HTTP server
@@ -166,6 +167,7 @@ func NewServer(
 	var managerClient *client.ManagerClient
 	if strings.TrimSpace(cfg.ManagerURL) != "" {
 		managerClient = client.NewManagerClient(cfg.ManagerURL, internalAuthGen, logger, proxyTimeout)
+		managerClient.SetHTTPClient(httpClient)
 	}
 
 	// Create sandbox cache to reduce manager API calls
@@ -275,6 +277,7 @@ func NewServer(
 		entitlements:       entitlements,
 		sandboxAddrCache:   sandboxAddrCache,
 		obsProvider:        obsProvider,
+		httpClient:         httpClient,
 	}
 
 	server.setupRoutes()
@@ -287,12 +290,17 @@ func (s *Server) Handler() http.Handler {
 	return s.router
 }
 
+func (s *Server) outboundHTTPClient() *http.Client {
+	if s != nil && s.httpClient != nil {
+		return s.httpClient
+	}
+	return &http.Client{}
+}
+
 // setupRoutes configures all HTTP routes
 func (s *Server) setupRoutes() {
 	// Global middleware (order matters)
-	s.router.Use(httpobs.GinMiddleware(httpobs.ServerConfig{
-		Tracer: s.obsProvider.Tracer(),
-	}))
+	s.router.Use(httpobs.GinMiddleware(s.obsProvider.HTTPServerConfig(nil)))
 	s.router.Use(middleware.Recovery(s.logger))
 	s.router.Use(s.requestLogger.Logger())
 	s.router.Use(gatewaymiddleware.UpstreamTimeoutWhitelist())

--- a/ctld/cmd/ctld/main.go
+++ b/ctld/cmd/ctld/main.go
@@ -15,6 +15,9 @@ import (
 	ctldpower "github.com/sandbox0-ai/sandbox0/ctld/internal/ctld/power"
 	ctldserver "github.com/sandbox0-ai/sandbox0/ctld/internal/ctld/server"
 	"github.com/sandbox0-ai/sandbox0/pkg/k8s"
+	"github.com/sandbox0-ai/sandbox0/pkg/observability"
+	httpobs "github.com/sandbox0-ai/sandbox0/pkg/observability/http"
+	"go.uber.org/zap"
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 )
 
@@ -44,7 +47,33 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	httpServer := newHTTPServer(httpAddr, buildPowerController(ctx))
+	zapLogger, err := zap.NewProduction()
+	if err != nil {
+		log.Printf("ctld observability disabled: create zap logger: %v", err)
+	}
+	var obsProvider *observability.Provider
+	if zapLogger != nil {
+		defer zapLogger.Sync()
+		obsProvider, err = observability.New(observability.Config{
+			ServiceName: "ctld",
+			Logger:      zapLogger,
+			TraceExporter: observability.TraceExporterConfig{
+				Type:     os.Getenv("OTEL_EXPORTER_TYPE"),
+				Endpoint: os.Getenv("OTEL_EXPORTER_ENDPOINT"),
+			},
+		})
+		if err != nil {
+			log.Printf("ctld observability disabled: %v", err)
+			obsProvider = nil
+		} else {
+			defer obsProvider.Shutdown(ctx)
+		}
+	}
+
+	httpServer := newHTTPServer(httpAddr, buildPowerController(ctx, obsProvider))
+	if obsProvider != nil {
+		httpServer.Handler = httpobs.ServerMiddleware(obsProvider.HTTPServerConfig(zapLogger))(httpServer.Handler)
+	}
 	go func() {
 		if err := httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			log.Fatalf("ctld http server failed: %v", err)
@@ -114,11 +143,11 @@ func newHTTPServer(addr string, controller ctldserver.Controller) *http.Server {
 	return &http.Server{Addr: addr, Handler: ctldserver.NewMux(controller)}
 }
 
-func buildPowerController(ctx context.Context) ctldserver.Controller {
+func buildPowerController(ctx context.Context, obsProvider *observability.Provider) ctldserver.Controller {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	k8sClient, err := k8s.NewClient(kubeconfig)
+	k8sClient, err := k8s.NewClientWithObservability(kubeconfig, obsProvider)
 	if err != nil {
 		log.Printf("ctld power control disabled: build kubernetes client: %v", err)
 		return ctldserver.NotImplementedController{}
@@ -139,6 +168,9 @@ func buildPowerController(ctx context.Context) ctldserver.Controller {
 		}()
 	}
 	controller := ctldpower.NewController(resolver, nil)
+	if obsProvider != nil {
+		controller.HTTPClient = obsProvider.HTTP.NewClient(httpobs.Config{Timeout: 2 * time.Second})
+	}
 	controller.StatsProvider = ctldpower.NewCRIStatsProvider(criEndpoint)
 	return controller
 }

--- a/ctld/internal/ctld/server/server.go
+++ b/ctld/internal/ctld/server/server.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
 	"github.com/sandbox0-ai/sandbox0/pkg/sandboxprobe"
 )
@@ -47,6 +48,7 @@ func NewMux(controller Controller) http.Handler {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))
 	})
+	mux.Handle("/metrics", promhttp.Handler())
 	mux.HandleFunc("/api/v1/sandboxes/", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			w.WriteHeader(http.StatusMethodNotAllowed)

--- a/global-gateway/cmd/global-gateway/main.go
+++ b/global-gateway/cmd/global-gateway/main.go
@@ -133,16 +133,16 @@ func initDatabase(
 	}
 
 	pool, err := dbpool.New(ctx, dbpool.Options{
-		DatabaseURL: cfg.DatabaseURL,
-		MaxConns:    int32(cfg.DatabaseMaxConns),
-		MinConns:    int32(cfg.DatabaseMinConns),
-		Schema:      schema,
+		DatabaseURL:    cfg.DatabaseURL,
+		MaxConns:       int32(cfg.DatabaseMaxConns),
+		MinConns:       int32(cfg.DatabaseMinConns),
+		Schema:         schema,
+		ConfigModifier: obsProvider.Pgx.ConfigModifier(),
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	obsProvider.Pgx.WrapPool(pool)
 	logger.Info("Database connection established",
 		zap.String("schema", schema),
 		zap.Int32("max_conns", pool.Config().MaxConns),

--- a/global-gateway/pkg/http/server.go
+++ b/global-gateway/pkg/http/server.go
@@ -47,6 +47,7 @@ type Server struct {
 	obsProvider     *observability.Provider
 	logger          *zap.Logger
 	proxyTimeout    time.Duration
+	httpClient      *stdhttp.Client
 	regionProxies   map[string]*proxy.Router
 	regionProxiesMu sync.RWMutex
 	regionRoutes    *cachepkg.Cache[string, tenantdir.Region]
@@ -133,6 +134,7 @@ func NewServer(
 		obsProvider:     obsProvider,
 		logger:          logger,
 		proxyTimeout:    effectiveProxyTimeout(cfg.ServerWriteTimeout.Duration),
+		httpClient:      obsProvider.HTTP.NewClient(httpobs.Config{Timeout: effectiveProxyTimeout(cfg.ServerWriteTimeout.Duration)}),
 		regionProxies:   make(map[string]*proxy.Router),
 		regionRoutes: cachepkg.New[string, tenantdir.Region](cachepkg.Config{
 			MaxSize: regionRouteCacheMaxEntries,
@@ -149,9 +151,7 @@ func (s *Server) Handler() stdhttp.Handler {
 }
 
 func (s *Server) setupRoutes() {
-	s.router.Use(httpobs.GinMiddleware(httpobs.ServerConfig{
-		Tracer: s.obsProvider.Tracer(),
-	}))
+	s.router.Use(httpobs.GinMiddleware(s.obsProvider.HTTPServerConfig(nil)))
 	s.router.Use(gatewaymiddleware.Recovery(s.logger))
 	s.router.Use(s.requestLogger.Logger())
 	s.router.Use(gatewaymiddleware.UpstreamTimeoutWhitelist())
@@ -329,7 +329,7 @@ func (s *Server) getRegionProxy(targetURL string) (*proxy.Router, error) {
 		return existing, nil
 	}
 
-	router, err := proxy.NewRouter(normalizedTargetURL, s.logger, s.proxyTimeout)
+	router, err := proxy.NewRouter(normalizedTargetURL, s.logger, s.proxyTimeout, proxy.WithHTTPClient(s.httpClient))
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/pkg/sftp v1.13.5
 	github.com/pressly/goose/v3 v3.26.0
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/quic-go/quic-go v0.56.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.11.1
@@ -234,7 +235,6 @@ require (
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/pquerna/ffjson v0.0.0-20190930134022-aa0246cd15f7 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/qingstor/qingstor-sdk-go/v4 v4.4.0 // indirect

--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/metering"
 	"github.com/sandbox0-ai/sandbox0/pkg/migrate"
 	"github.com/sandbox0-ai/sandbox0/pkg/observability"
+	httpobs "github.com/sandbox0-ai/sandbox0/pkg/observability/http"
 	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
 	templmigrations "github.com/sandbox0-ai/sandbox0/pkg/template/migrations"
 	templreconciler "github.com/sandbox0-ai/sandbox0/pkg/template/reconciler"
@@ -276,8 +277,10 @@ func main() {
 		CtldEnabled:            cfg.CtldEnabled,
 		CtldPort:               cfg.CtldPort,
 		CtldClientTimeout:      cfg.CtldClientTimeout.Duration,
+		CtldHTTPClient:         obsProvider.HTTP.NewClient(httpobs.Config{Timeout: cfg.CtldClientTimeout.Duration}),
 		ProcdPort:              cfg.ProcdConfig.HTTPPort,
 		ProcdClientTimeout:     cfg.ProcdClientTimeout.Duration,
+		ProcdHTTPClient:        obsProvider.HTTP.NewClient(httpobs.Config{Timeout: cfg.ProcdClientTimeout.Duration}),
 		ProcdInitTimeout:       cfg.ProcdInitTimeout.Duration,
 	}
 
@@ -566,17 +569,15 @@ func runEgressAuthMigrations(ctx context.Context, pool *pgxpool.Pool, logger *za
 // initDatabase initializes the database connection pool
 func initDatabase(ctx context.Context, databaseURL string, maxConns, minConns int32, logger *zap.Logger, obsProvider *observability.Provider) (*pgxpool.Pool, error) {
 	pool, err := dbpool.New(ctx, dbpool.Options{
-		DatabaseURL: databaseURL,
-		MaxConns:    maxConns,
-		MinConns:    minConns,
-		Schema:      "scheduler",
+		DatabaseURL:    databaseURL,
+		MaxConns:       maxConns,
+		MinConns:       minConns,
+		Schema:         "scheduler",
+		ConfigModifier: obsProvider.Pgx.ConfigModifier(),
 	})
 	if err != nil {
 		return nil, err
 	}
-
-	// Wrap pool with observability
-	obsProvider.Pgx.WrapPool(pool)
 
 	logger.Info("Database connection established",
 		zap.Int32("max_conns", pool.Config().MaxConns),

--- a/manager/pkg/http/server.go
+++ b/manager/pkg/http/server.go
@@ -85,9 +85,7 @@ func NewServer(
 	gin.SetMode(gin.ReleaseMode)
 
 	router := gin.New()
-	router.Use(httpobs.GinMiddleware(httpobs.ServerConfig{
-		Tracer: obsProvider.Tracer(),
-	}))
+	router.Use(httpobs.GinMiddleware(obsProvider.HTTPServerConfig(nil)))
 	router.Use(gin.Recovery())
 	router.Use(requestLogger(logger))
 

--- a/manager/pkg/service/sandbox_service.go
+++ b/manager/pkg/service/sandbox_service.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"net/http"
 	"sync"
 	"time"
 
@@ -95,8 +96,10 @@ type SandboxServiceConfig struct {
 	CtldEnabled            bool
 	CtldPort               int
 	CtldClientTimeout      time.Duration
+	CtldHTTPClient         *http.Client
 	ProcdPort              int
 	ProcdClientTimeout     time.Duration
+	ProcdHTTPClient        *http.Client
 	ProcdInitTimeout       time.Duration
 }
 
@@ -184,6 +187,15 @@ func NewSandboxService(
 	if networkProvider == nil {
 		networkProvider = network.NewNoopProvider()
 	}
+	ctldClient := NewCtldClient(CtldClientConfig{Timeout: config.CtldClientTimeout})
+	if config.CtldHTTPClient != nil {
+		ctldClient = NewCtldClientWithHTTPClient(config.CtldHTTPClient)
+	}
+	procdClient := NewProcdClient(ProcdClientConfig{Timeout: config.ProcdClientTimeout})
+	if config.ProcdHTTPClient != nil {
+		procdClient = NewProcdClientWithHTTPClient(config.ProcdHTTPClient)
+	}
+
 	service := &SandboxService{
 		k8sClient:              k8sClient,
 		podLister:              podLister,
@@ -193,8 +205,8 @@ func NewSandboxService(
 		templateLister:         templateLister,
 		NetworkPolicyService:   networkPolicyService,
 		networkProvider:        networkProvider,
-		ctldClient:             NewCtldClient(CtldClientConfig{Timeout: config.CtldClientTimeout}),
-		procdClient:            NewProcdClient(ProcdClientConfig{Timeout: config.ProcdClientTimeout}),
+		ctldClient:             ctldClient,
+		procdClient:            procdClient,
 		internalTokenGenerator: internalTokenGenerator,
 		procdTokenGenerator:    procdTokenGenerator,
 		clock:                  clock,

--- a/manager/procd/pkg/http/server.go
+++ b/manager/procd/pkg/http/server.go
@@ -112,9 +112,7 @@ func NewServer(
 
 func (s *Server) setupRoutes() {
 	// Global middleware (applied to all routes)
-	s.router.Use(httpobs.ServerMiddleware(httpobs.ServerConfig{
-		Tracer: s.obsProvider.Tracer(),
-	}))
+	s.router.Use(httpobs.ServerMiddleware(s.obsProvider.HTTPServerConfig(nil)))
 	s.router.Use(s.loggingMiddleware)
 	s.router.Use(s.recoveryMiddleware)
 

--- a/netd/cmd/netd/main.go
+++ b/netd/cmd/netd/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
 	"github.com/sandbox0-ai/sandbox0/netd/pkg/daemon"
+	"github.com/sandbox0-ai/sandbox0/pkg/observability"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -34,7 +35,20 @@ func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
-	daemon := daemon.New(cfg, logger)
+	obsProvider, err := observability.New(observability.Config{
+		ServiceName: "netd",
+		Logger:      logger,
+		TraceExporter: observability.TraceExporterConfig{
+			Type:     os.Getenv("OTEL_EXPORTER_TYPE"),
+			Endpoint: os.Getenv("OTEL_EXPORTER_ENDPOINT"),
+		},
+	})
+	if err != nil {
+		logger.Fatal("Failed to initialize observability", zap.Error(err))
+	}
+	defer obsProvider.Shutdown(ctx)
+
+	daemon := daemon.New(cfg, logger, obsProvider)
 	if err := daemon.Run(ctx); err != nil {
 		logger.Fatal("netd exited with error", zap.Error(err))
 	}

--- a/netd/pkg/daemon/daemon.go
+++ b/netd/pkg/daemon/daemon.go
@@ -22,6 +22,8 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/dbpool"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	meteringpkg "github.com/sandbox0-ai/sandbox0/pkg/metering"
+	"github.com/sandbox0-ai/sandbox0/pkg/observability"
+	httpobs "github.com/sandbox0-ai/sandbox0/pkg/observability/http"
 	"go.uber.org/zap"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -33,16 +35,18 @@ type Daemon struct {
 	healthServer  *http.Server
 	metricsServer *http.Server
 	proxyServer   *proxy.Server
+	obsProvider   *observability.Provider
 	ready         atomic.Bool
 }
 
-func New(cfg *config.NetdConfig, logger *zap.Logger) *Daemon {
+func New(cfg *config.NetdConfig, logger *zap.Logger, obsProvider *observability.Provider) *Daemon {
 	if logger == nil {
 		logger = zap.NewNop()
 	}
 	return &Daemon{
-		cfg:    cfg,
-		logger: logger,
+		cfg:         cfg,
+		logger:      logger,
+		obsProvider: obsProvider,
 	}
 }
 
@@ -93,6 +97,9 @@ func (d *Daemon) runNetd(ctx context.Context, cancel context.CancelFunc, proxyEx
 	if err != nil {
 		return err
 	}
+	if d.obsProvider != nil {
+		d.obsProvider.K8s.WrapConfig(k8sConfig)
+	}
 	client, err := kubernetes.NewForConfig(k8sConfig)
 	if err != nil {
 		return fmt.Errorf("create k8s client: %w", err)
@@ -114,6 +121,7 @@ func (d *Daemon) runNetd(ctx context.Context, cancel context.CancelFunc, proxyEx
 			DatabaseURL:     d.cfg.DatabaseURL,
 			DefaultMaxConns: 5,
 			DefaultMinConns: 1,
+			ConfigModifier:  d.dbConfigModifier(),
 		})
 		if err != nil {
 			return fmt.Errorf("create netd database pool: %w", err)
@@ -204,10 +212,11 @@ func (d *Daemon) runNetd(ctx context.Context, cancel context.CancelFunc, proxyEx
 			PrivateKey: privateKey,
 			TTL:        30 * time.Second,
 		})
-		proxyOpts = append(proxyOpts, proxy.WithEgressAuthResolver(proxy.NewHTTPEgressAuthResolver(
+		proxyOpts = append(proxyOpts, proxy.WithEgressAuthResolver(proxy.NewHTTPEgressAuthResolverWithHTTPClient(
 			d.cfg.EgressAuthResolverURL,
 			d.cfg.EgressAuthResolverTimeout.Duration,
 			netdEgressAuthTokenProvider{generator: tokenGenerator},
+			d.egressAuthHTTPClient(),
 		)))
 	}
 	proxyServer, err := proxy.NewServer(d.cfg, policyStore, tracker, usageAggregator, d.logger, proxyOpts...)
@@ -273,6 +282,28 @@ func (d *Daemon) runNetd(ctx context.Context, cancel context.CancelFunc, proxyEx
 	case <-ctx.Done():
 		return ctx.Err()
 	}
+}
+
+func (d *Daemon) dbConfigModifier() func(*pgxpool.Config) error {
+	if d == nil || d.obsProvider == nil {
+		return nil
+	}
+	return d.obsProvider.Pgx.ConfigModifier()
+}
+
+func (d *Daemon) egressAuthHTTPClient() *http.Client {
+	if d == nil || d.obsProvider == nil {
+		timeout := 2 * time.Second
+		if d != nil && d.cfg != nil && d.cfg.EgressAuthResolverTimeout.Duration > 0 {
+			timeout = d.cfg.EgressAuthResolverTimeout.Duration
+		}
+		return &http.Client{Timeout: timeout}
+	}
+	timeout := d.cfg.EgressAuthResolverTimeout.Duration
+	if timeout <= 0 {
+		timeout = 2 * time.Second
+	}
+	return d.obsProvider.HTTP.NewClient(httpobs.Config{Timeout: timeout})
 }
 
 type netdEgressAuthTokenProvider struct {

--- a/netd/pkg/proxy/egress_broker_client.go
+++ b/netd/pkg/proxy/egress_broker_client.go
@@ -24,6 +24,10 @@ type EgressAuthTokenProvider interface {
 }
 
 func NewHTTPEgressAuthResolver(baseURL string, timeout time.Duration, tokenProvider EgressAuthTokenProvider) egressAuthResolver {
+	return NewHTTPEgressAuthResolverWithHTTPClient(baseURL, timeout, tokenProvider, nil)
+}
+
+func NewHTTPEgressAuthResolverWithHTTPClient(baseURL string, timeout time.Duration, tokenProvider EgressAuthTokenProvider, client *http.Client) egressAuthResolver {
 	baseURL = strings.TrimSpace(baseURL)
 	if baseURL == "" {
 		return noopEgressAuthResolver{}
@@ -31,12 +35,13 @@ func NewHTTPEgressAuthResolver(baseURL string, timeout time.Duration, tokenProvi
 	if timeout <= 0 {
 		timeout = 2 * time.Second
 	}
+	if client == nil {
+		client = &http.Client{Timeout: timeout}
+	}
 	return &httpEgressAuthResolver{
 		baseURL:       strings.TrimRight(baseURL, "/"),
 		tokenProvider: tokenProvider,
-		client: &http.Client{
-			Timeout: timeout,
-		},
+		client:        client,
 	}
 }
 

--- a/pkg/dbpool/dbpool.go
+++ b/pkg/dbpool/dbpool.go
@@ -19,6 +19,7 @@ type Options struct {
 	MaxConnLifetime time.Duration
 	MaxConnIdleTime time.Duration
 	Schema          string
+	ConfigModifier  func(*pgxpool.Config) error
 }
 
 // New creates a pgx pool and validates connectivity.
@@ -68,6 +69,11 @@ func New(ctx context.Context, opts Options) (*pgxpool.Pool, error) {
 	}
 	if opts.MaxConnIdleTime > 0 {
 		poolConfig.MaxConnIdleTime = opts.MaxConnIdleTime
+	}
+	if opts.ConfigModifier != nil {
+		if err := opts.ConfigModifier(poolConfig); err != nil {
+			return nil, fmt.Errorf("apply pool config modifier: %w", err)
+		}
 	}
 
 	pool, err := pgxpool.NewWithConfig(ctx, poolConfig)

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -60,8 +60,9 @@ func NewClientWithObservability(kubeconfigPath string, obsProvider *observabilit
 		return nil, err
 	}
 
-	// Wrap config with observability
-	obsProvider.K8s.WrapConfig(config)
+	if obsProvider != nil {
+		obsProvider.K8s.WrapConfig(config)
+	}
 
 	return kubernetes.NewForConfig(config)
 }

--- a/pkg/observability/config.go
+++ b/pkg/observability/config.go
@@ -33,7 +33,7 @@ type Config struct {
 
 // TraceExporterConfig configures the trace exporter
 type TraceExporterConfig struct {
-	// Type of exporter: "otlp", "stdout", or "noop" (default: "stdout")
+	// Type of exporter: "otlp", "stdout", or "noop" (default: "noop")
 	Type string
 
 	// Endpoint for the exporter
@@ -66,7 +66,7 @@ func (c *Config) setDefaults() {
 		c.TraceSampleRate = 1.0
 	}
 	if c.TraceExporter.Type == "" {
-		c.TraceExporter.Type = "stdout"
+		c.TraceExporter.Type = "noop"
 	}
 	if c.TraceExporter.Timeout == 0 {
 		c.TraceExporter.Timeout = 10 * time.Second

--- a/pkg/observability/config_test.go
+++ b/pkg/observability/config_test.go
@@ -1,0 +1,36 @@
+package observability
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestConfigDefaultsTraceExporterToNoop(t *testing.T) {
+	cfg := Config{
+		ServiceName: "test-service",
+		Logger:      zap.NewNop(),
+	}
+
+	cfg.setDefaults()
+
+	if cfg.TraceExporter.Type != "noop" {
+		t.Fatalf("TraceExporter.Type = %q, want noop", cfg.TraceExporter.Type)
+	}
+}
+
+func TestConfigKeepsExplicitTraceExporter(t *testing.T) {
+	cfg := Config{
+		ServiceName: "test-service",
+		Logger:      zap.NewNop(),
+		TraceExporter: TraceExporterConfig{
+			Type: "stdout",
+		},
+	}
+
+	cfg.setDefaults()
+
+	if cfg.TraceExporter.Type != "stdout" {
+		t.Fatalf("TraceExporter.Type = %q, want stdout", cfg.TraceExporter.Type)
+	}
+}

--- a/pkg/observability/http/adapter.go
+++ b/pkg/observability/http/adapter.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/sandbox0-ai/sandbox0/pkg/observability/internal/promutil"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 )
@@ -18,11 +18,13 @@ type Adapter struct {
 
 // AdapterConfig configures the HTTP adapter
 type AdapterConfig struct {
-	ServiceName string
-	Tracer      trace.Tracer
-	Logger      *zap.Logger
-	Registry    prometheus.Registerer
-	Disabled    bool
+	ServiceName    string
+	Tracer         trace.Tracer
+	Logger         *zap.Logger
+	Registry       prometheus.Registerer
+	DisableMetrics bool
+	DisableLogging bool
+	Disabled       bool
 }
 
 // Config holds configuration for creating an observable HTTP client
@@ -39,7 +41,7 @@ type Config struct {
 // NewAdapter creates a new HTTP adapter
 func NewAdapter(cfg AdapterConfig) Adapter {
 	var m *metrics
-	if !cfg.Disabled && cfg.Registry != nil {
+	if !cfg.Disabled && !cfg.DisableMetrics && cfg.Registry != nil {
 		m = newMetrics(cfg.ServiceName, cfg.Registry)
 	}
 
@@ -85,6 +87,20 @@ func (a Adapter) NewTransport(base http.RoundTripper) http.RoundTripper {
 	}
 }
 
+// ServerConfig returns the base server middleware config for this adapter.
+func (a Adapter) ServerConfig(logger *zap.Logger) ServerConfig {
+	cfg := ServerConfig{
+		ServiceName:    a.config.ServiceName,
+		Tracer:         a.config.Tracer,
+		Registry:       a.config.Registry,
+		Logger:         logger,
+		DisableLogging: logger == nil || a.config.DisableLogging,
+		DisableMetrics: a.config.DisableMetrics,
+		Disabled:       a.config.Disabled,
+	}
+	return cfg
+}
+
 // metrics holds Prometheus metrics for HTTP client
 type metrics struct {
 	requestsTotal   *prometheus.CounterVec
@@ -95,43 +111,48 @@ type metrics struct {
 }
 
 func newMetrics(serviceName string, registry prometheus.Registerer) *metrics {
-	factory := promauto.With(registry)
+	prefix := promutil.MetricPrefix(serviceName)
 
 	return &metrics{
-		requestsTotal: factory.NewCounterVec(
+		requestsTotal: promutil.RegisterCounterVec(
+			registry,
 			prometheus.CounterOpts{
-				Name: serviceName + "_http_client_requests_total",
+				Name: prefix + "_http_client_requests_total",
 				Help: "Total number of HTTP client requests",
 			},
 			[]string{"method", "host", "status"},
 		),
-		requestDuration: factory.NewHistogramVec(
+		requestDuration: promutil.RegisterHistogramVec(
+			registry,
 			prometheus.HistogramOpts{
-				Name:    serviceName + "_http_client_request_duration_seconds",
+				Name:    prefix + "_http_client_request_duration_seconds",
 				Help:    "HTTP client request duration in seconds",
 				Buckets: []float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
 			},
 			[]string{"method", "host"},
 		),
-		requestSize: factory.NewHistogramVec(
+		requestSize: promutil.RegisterHistogramVec(
+			registry,
 			prometheus.HistogramOpts{
-				Name:    serviceName + "_http_client_request_size_bytes",
+				Name:    prefix + "_http_client_request_size_bytes",
 				Help:    "HTTP client request size in bytes",
 				Buckets: prometheus.ExponentialBuckets(100, 10, 7),
 			},
 			[]string{"method", "host"},
 		),
-		responseSize: factory.NewHistogramVec(
+		responseSize: promutil.RegisterHistogramVec(
+			registry,
 			prometheus.HistogramOpts{
-				Name:    serviceName + "_http_client_response_size_bytes",
+				Name:    prefix + "_http_client_response_size_bytes",
 				Help:    "HTTP client response size in bytes",
 				Buckets: prometheus.ExponentialBuckets(100, 10, 7),
 			},
 			[]string{"method", "host"},
 		),
-		activeRequests: factory.NewGaugeVec(
+		activeRequests: promutil.RegisterGaugeVec(
+			registry,
 			prometheus.GaugeOpts{
-				Name: serviceName + "_http_client_active_requests",
+				Name: prefix + "_http_client_active_requests",
 				Help: "Number of active HTTP client requests",
 			},
 			[]string{"method", "host"},

--- a/pkg/observability/http/server.go
+++ b/pkg/observability/http/server.go
@@ -5,9 +5,13 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sandbox0-ai/sandbox0/pkg/observability/internal/promutil"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -18,13 +22,18 @@ import (
 
 // ServerConfig configures HTTP server observability middleware.
 type ServerConfig struct {
-	Tracer   trace.Tracer
-	Logger   *zap.Logger
-	Disabled bool
+	ServiceName    string
+	Tracer         trace.Tracer
+	Logger         *zap.Logger
+	Registry       prometheus.Registerer
+	DisableMetrics bool
+	DisableLogging bool
+	Disabled       bool
 }
 
 // ServerMiddleware returns net/http middleware with tracing and optional logging.
 func ServerMiddleware(cfg ServerConfig) func(http.Handler) http.Handler {
+	metrics := newServerMetricsFromConfig(cfg)
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if cfg.Disabled {
@@ -39,6 +48,7 @@ func ServerMiddleware(cfg ServerConfig) func(http.Handler) http.Handler {
 
 			ctx := otel.GetTextMapPropagator().Extract(r.Context(), propagation.HeaderCarrier(r.Header))
 			start := time.Now()
+			route := normalizeRoute(r.URL.Path)
 
 			spanName := fmt.Sprintf("HTTP %s %s", r.Method, r.URL.Path)
 			ctx, span := tracer.Start(ctx, spanName,
@@ -53,6 +63,14 @@ func ServerMiddleware(cfg ServerConfig) func(http.Handler) http.Handler {
 			)
 			defer span.End()
 
+			if metrics != nil {
+				metrics.activeRequests.WithLabelValues(r.Method, route).Inc()
+				defer metrics.activeRequests.WithLabelValues(r.Method, route).Dec()
+				if r.ContentLength > 0 {
+					metrics.requestSize.WithLabelValues(r.Method, route).Observe(float64(r.ContentLength))
+				}
+			}
+
 			wrapped := &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
 			next.ServeHTTP(wrapped, r.WithContext(ctx))
 
@@ -62,7 +80,16 @@ func ServerMiddleware(cfg ServerConfig) func(http.Handler) http.Handler {
 				span.SetStatus(codes.Error, fmt.Sprintf("HTTP %d", status))
 			}
 
-			if cfg.Logger != nil {
+			if metrics != nil {
+				statusLabel := strconv.Itoa(status)
+				metrics.requestsTotal.WithLabelValues(r.Method, route, statusLabel).Inc()
+				metrics.requestDuration.WithLabelValues(r.Method, route).Observe(time.Since(start).Seconds())
+				if wrapped.bytesWritten > 0 {
+					metrics.responseSize.WithLabelValues(r.Method, route).Observe(float64(wrapped.bytesWritten))
+				}
+			}
+
+			if !cfg.DisableLogging && cfg.Logger != nil {
 				level := zap.InfoLevel
 				if status >= 500 {
 					level = zap.ErrorLevel
@@ -72,6 +99,7 @@ func ServerMiddleware(cfg ServerConfig) func(http.Handler) http.Handler {
 				cfg.Logger.Log(level, "HTTP request",
 					zap.String("method", r.Method),
 					zap.String("path", r.URL.Path),
+					zap.String("route", route),
 					zap.Int("status", status),
 					zap.Duration("latency", time.Since(start)),
 					zap.String("client_ip", r.RemoteAddr),
@@ -85,6 +113,7 @@ func ServerMiddleware(cfg ServerConfig) func(http.Handler) http.Handler {
 
 // GinMiddleware returns gin middleware with tracing and optional logging.
 func GinMiddleware(cfg ServerConfig) gin.HandlerFunc {
+	metrics := newServerMetricsFromConfig(cfg)
 	return func(c *gin.Context) {
 		if cfg.Disabled {
 			c.Next()
@@ -98,6 +127,7 @@ func GinMiddleware(cfg ServerConfig) gin.HandlerFunc {
 
 		ctx := otel.GetTextMapPropagator().Extract(c.Request.Context(), propagation.HeaderCarrier(c.Request.Header))
 		start := time.Now()
+		initialRoute := normalizeRoute(c.Request.URL.Path)
 
 		spanName := fmt.Sprintf("HTTP %s %s", c.Request.Method, c.Request.URL.Path)
 		ctx, span := tracer.Start(ctx, spanName,
@@ -113,21 +143,38 @@ func GinMiddleware(cfg ServerConfig) gin.HandlerFunc {
 		defer span.End()
 
 		c.Request = c.Request.WithContext(ctx)
+		if metrics != nil {
+			metrics.activeRequests.WithLabelValues(c.Request.Method, initialRoute).Inc()
+			defer metrics.activeRequests.WithLabelValues(c.Request.Method, initialRoute).Dec()
+			if c.Request.ContentLength > 0 {
+				metrics.requestSize.WithLabelValues(c.Request.Method, initialRoute).Observe(float64(c.Request.ContentLength))
+			}
+		}
 		c.Next()
 
 		status := c.Writer.Status()
 		route := c.FullPath()
-		if route != "" {
-			span.SetAttributes(attribute.String("http.route", route))
-			span.SetName(fmt.Sprintf("HTTP %s %s", c.Request.Method, route))
+		if route == "" {
+			route = initialRoute
 		}
+		span.SetAttributes(attribute.String("http.route", route))
+		span.SetName(fmt.Sprintf("HTTP %s %s", c.Request.Method, route))
 
 		span.SetAttributes(attribute.Int("http.status_code", status))
 		if status >= 400 {
 			span.SetStatus(codes.Error, fmt.Sprintf("HTTP %d", status))
 		}
 
-		if cfg.Logger != nil {
+		if metrics != nil {
+			statusLabel := strconv.Itoa(status)
+			metrics.requestsTotal.WithLabelValues(c.Request.Method, route, statusLabel).Inc()
+			metrics.requestDuration.WithLabelValues(c.Request.Method, route).Observe(time.Since(start).Seconds())
+			if size := c.Writer.Size(); size > 0 {
+				metrics.responseSize.WithLabelValues(c.Request.Method, route).Observe(float64(size))
+			}
+		}
+
+		if !cfg.DisableLogging && cfg.Logger != nil {
 			level := zap.InfoLevel
 			if status >= 500 {
 				level = zap.ErrorLevel
@@ -137,6 +184,7 @@ func GinMiddleware(cfg ServerConfig) gin.HandlerFunc {
 			cfg.Logger.Log(level, "HTTP request",
 				zap.String("method", c.Request.Method),
 				zap.String("path", c.Request.URL.Path),
+				zap.String("route", route),
 				zap.Int("status", status),
 				zap.Duration("latency", time.Since(start)),
 				zap.String("client_ip", c.ClientIP()),
@@ -149,12 +197,19 @@ func GinMiddleware(cfg ServerConfig) gin.HandlerFunc {
 
 type responseWriter struct {
 	http.ResponseWriter
-	statusCode int
+	statusCode   int
+	bytesWritten int
 }
 
 func (rw *responseWriter) WriteHeader(code int) {
 	rw.statusCode = code
 	rw.ResponseWriter.WriteHeader(code)
+}
+
+func (rw *responseWriter) Write(p []byte) (int, error) {
+	n, err := rw.ResponseWriter.Write(p)
+	rw.bytesWritten += n
+	return n, err
 }
 
 func (rw *responseWriter) Unwrap() http.ResponseWriter {
@@ -180,4 +235,91 @@ func (rw *responseWriter) Push(target string, opts *http.PushOptions) error {
 		return pusher.Push(target, opts)
 	}
 	return http.ErrNotSupported
+}
+
+type serverMetrics struct {
+	requestsTotal   *prometheus.CounterVec
+	requestDuration *prometheus.HistogramVec
+	requestSize     *prometheus.HistogramVec
+	responseSize    *prometheus.HistogramVec
+	activeRequests  *prometheus.GaugeVec
+}
+
+func newServerMetricsFromConfig(cfg ServerConfig) *serverMetrics {
+	if cfg.DisableMetrics || cfg.Registry == nil || strings.TrimSpace(cfg.ServiceName) == "" {
+		return nil
+	}
+	prefix := promutil.MetricPrefix(cfg.ServiceName)
+	return &serverMetrics{
+		requestsTotal: promutil.RegisterCounterVec(cfg.Registry, prometheus.CounterOpts{
+			Name: prefix + "_http_server_requests_total",
+			Help: "Total number of HTTP server requests",
+		}, []string{"method", "route", "status"}),
+		requestDuration: promutil.RegisterHistogramVec(cfg.Registry, prometheus.HistogramOpts{
+			Name:    prefix + "_http_server_request_duration_seconds",
+			Help:    "HTTP server request duration in seconds",
+			Buckets: []float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
+		}, []string{"method", "route"}),
+		requestSize: promutil.RegisterHistogramVec(cfg.Registry, prometheus.HistogramOpts{
+			Name:    prefix + "_http_server_request_size_bytes",
+			Help:    "HTTP server request size in bytes",
+			Buckets: prometheus.ExponentialBuckets(100, 10, 7),
+		}, []string{"method", "route"}),
+		responseSize: promutil.RegisterHistogramVec(cfg.Registry, prometheus.HistogramOpts{
+			Name:    prefix + "_http_server_response_size_bytes",
+			Help:    "HTTP server response size in bytes",
+			Buckets: prometheus.ExponentialBuckets(100, 10, 7),
+		}, []string{"method", "route"}),
+		activeRequests: promutil.RegisterGaugeVec(cfg.Registry, prometheus.GaugeOpts{
+			Name: prefix + "_http_server_active_requests",
+			Help: "Number of active HTTP server requests",
+		}, []string{"method", "route"}),
+	}
+}
+
+func normalizeRoute(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "/"
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	for i, part := range parts {
+		if part == "" {
+			continue
+		}
+		if strings.HasPrefix(part, ":") || strings.HasPrefix(part, "{") {
+			continue
+		}
+		if isLikelyRouteID(part) {
+			parts[i] = "{id}"
+		}
+	}
+	return "/" + strings.Join(parts, "/")
+}
+
+func isLikelyRouteID(segment string) bool {
+	if segment == "" {
+		return false
+	}
+	if _, err := strconv.Atoi(segment); err == nil {
+		return true
+	}
+	if len(segment) < 8 {
+		return false
+	}
+	hasDigit := false
+	for _, r := range segment {
+		if r >= '0' && r <= '9' {
+			hasDigit = true
+			continue
+		}
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || r == '-' || r == '_' {
+			continue
+		}
+		return false
+	}
+	return hasDigit
 }

--- a/pkg/observability/http/server_test.go
+++ b/pkg/observability/http/server_test.go
@@ -1,0 +1,115 @@
+package http
+
+import (
+	stdhttp "net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"go.opentelemetry.io/otel/trace/noop"
+)
+
+func TestGinMiddlewareRecordsServerMetrics(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	registry := prometheus.NewRegistry()
+	router := gin.New()
+	router.Use(GinMiddleware(ServerConfig{
+		ServiceName: "cluster-gateway",
+		Tracer:      noop.NewTracerProvider().Tracer("test"),
+		Registry:    registry,
+	}))
+	router.POST("/api/v1/sandboxes/:id", func(c *gin.Context) {
+		c.String(stdhttp.StatusCreated, "ok")
+	})
+
+	req := httptest.NewRequest(stdhttp.MethodPost, "/api/v1/sandboxes/sandbox-12345678", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	got, ok := metricValue(t, registry, "cluster_gateway_http_server_requests_total", map[string]string{
+		"method": "POST",
+		"route":  "/api/v1/sandboxes/:id",
+		"status": "201",
+	})
+	if !ok || got != 1 {
+		t.Fatalf("server request metric = %v, ok=%v; want 1", got, ok)
+	}
+}
+
+func TestServerMiddlewareNormalizesUnknownRoutes(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	handler := ServerMiddleware(ServerConfig{
+		ServiceName: "procd",
+		Tracer:      noop.NewTracerProvider().Tracer("test"),
+		Registry:    registry,
+	})(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+		w.WriteHeader(stdhttp.StatusAccepted)
+	}))
+
+	req := httptest.NewRequest(stdhttp.MethodPost, "/api/v1/contexts/ctx-12345678/restart", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	got, ok := metricValue(t, registry, "procd_http_server_requests_total", map[string]string{
+		"method": "POST",
+		"route":  "/api/v1/contexts/{id}/restart",
+		"status": "202",
+	})
+	if !ok || got != 1 {
+		t.Fatalf("server request metric = %v, ok=%v; want 1", got, ok)
+	}
+}
+
+func TestOutboundHostLabelCollapsesIPAddresses(t *testing.T) {
+	req := httptest.NewRequest(stdhttp.MethodGet, "http://10.0.0.12:8080/api/v1/sandboxes", nil)
+	if got := outboundHostLabel(req); got != "ip" {
+		t.Fatalf("outboundHostLabel(ip) = %q, want ip", got)
+	}
+
+	req = httptest.NewRequest(stdhttp.MethodGet, "http://manager:8080/api/v1/sandboxes", nil)
+	if got := outboundHostLabel(req); got != "manager" {
+		t.Fatalf("outboundHostLabel(service) = %q, want manager", got)
+	}
+}
+
+func metricValue(t *testing.T, registry *prometheus.Registry, name string, labels map[string]string) (float64, bool) {
+	t.Helper()
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("gather metrics: %v", err)
+	}
+	for _, family := range families {
+		if family.GetName() != name {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			if labelsMatch(metric, labels) {
+				if metric.Counter != nil {
+					return metric.Counter.GetValue(), true
+				}
+				if metric.Gauge != nil {
+					return metric.Gauge.GetValue(), true
+				}
+			}
+		}
+	}
+	return 0, false
+}
+
+func labelsMatch(metric *dto.Metric, labels map[string]string) bool {
+	for wantName, wantValue := range labels {
+		found := false
+		for _, label := range metric.GetLabel() {
+			if label.GetName() == wantName && label.GetValue() == wantValue {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/observability/http/transport.go
+++ b/pkg/observability/http/transport.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"time"
 
@@ -31,10 +32,7 @@ func (t *observableTransport) RoundTrip(req *http.Request) (*http.Response, erro
 	start := time.Now()
 
 	method := req.Method
-	host := req.URL.Host
-	if host == "" {
-		host = req.Host
-	}
+	host := outboundHostLabel(req)
 
 	// Track active requests
 	if t.metrics != nil {
@@ -59,14 +57,15 @@ func (t *observableTransport) RoundTrip(req *http.Request) (*http.Response, erro
 	// Inject trace context into HTTP headers
 	otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(req.Header))
 
-	// Log request start
-	t.config.Logger.Debug("HTTP request started",
-		zap.String("method", method),
-		zap.String("url", req.URL.String()),
-		zap.String("host", host),
-		zap.String("trace_id", span.SpanContext().TraceID().String()),
-		zap.String("span_id", span.SpanContext().SpanID().String()),
-	)
+	if !t.config.DisableLogging && t.config.Logger != nil {
+		t.config.Logger.Debug("HTTP request started",
+			zap.String("method", method),
+			zap.String("url", req.URL.String()),
+			zap.String("host", host),
+			zap.String("trace_id", span.SpanContext().TraceID().String()),
+			zap.String("span_id", span.SpanContext().SpanID().String()),
+		)
+	}
 
 	// Record request size
 	if t.metrics != nil && req.ContentLength > 0 {
@@ -89,13 +88,15 @@ func (t *observableTransport) RoundTrip(req *http.Request) (*http.Response, erro
 			t.metrics.requestDuration.WithLabelValues(method, host).Observe(duration.Seconds())
 		}
 
-		t.config.Logger.Error("HTTP request failed",
-			zap.String("method", method),
-			zap.String("url", req.URL.String()),
-			zap.Duration("duration", duration),
-			zap.Error(err),
-			zap.String("trace_id", span.SpanContext().TraceID().String()),
-		)
+		if !t.config.DisableLogging && t.config.Logger != nil {
+			t.config.Logger.Error("HTTP request failed",
+				zap.String("method", method),
+				zap.String("url", req.URL.String()),
+				zap.Duration("duration", duration),
+				zap.Error(err),
+				zap.String("trace_id", span.SpanContext().TraceID().String()),
+			)
+		}
 
 		return nil, err
 	}
@@ -132,14 +133,33 @@ func (t *observableTransport) RoundTrip(req *http.Request) (*http.Response, erro
 		logLevel = zap.WarnLevel
 	}
 
-	t.config.Logger.Log(logLevel, "HTTP request completed",
-		zap.String("method", method),
-		zap.String("url", req.URL.String()),
-		zap.Int("status", statusCode),
-		zap.Duration("duration", duration),
-		zap.Int64("response_size", resp.ContentLength),
-		zap.String("trace_id", span.SpanContext().TraceID().String()),
-	)
+	if !t.config.DisableLogging && t.config.Logger != nil {
+		t.config.Logger.Log(logLevel, "HTTP request completed",
+			zap.String("method", method),
+			zap.String("url", req.URL.String()),
+			zap.Int("status", statusCode),
+			zap.Duration("duration", duration),
+			zap.Int64("response_size", resp.ContentLength),
+			zap.String("trace_id", span.SpanContext().TraceID().String()),
+		)
+	}
 
 	return resp, nil
+}
+
+func outboundHostLabel(req *http.Request) string {
+	if req == nil || req.URL == nil {
+		return "unknown"
+	}
+	host := req.URL.Hostname()
+	if host == "" {
+		host = req.Host
+	}
+	if host == "" {
+		return "unknown"
+	}
+	if parsed := net.ParseIP(host); parsed != nil {
+		return "ip"
+	}
+	return host
 }

--- a/pkg/observability/internal/promutil/promutil.go
+++ b/pkg/observability/internal/promutil/promutil.go
@@ -1,0 +1,85 @@
+package promutil
+
+import (
+	"strings"
+	"unicode"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// MetricPrefix converts a service name into a valid Prometheus metric prefix.
+func MetricPrefix(serviceName string) string {
+	serviceName = strings.TrimSpace(serviceName)
+	if serviceName == "" {
+		return "sandbox0"
+	}
+
+	var b strings.Builder
+	for _, r := range serviceName {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(unicode.ToLower(r))
+		case r >= '0' && r <= '9':
+			if b.Len() == 0 {
+				b.WriteByte('_')
+			}
+			b.WriteRune(r)
+		case r == '_' || r == ':':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	prefix := strings.TrimRight(b.String(), "_")
+	if prefix == "" {
+		return "sandbox0"
+	}
+	return prefix
+}
+
+func RegisterCounterVec(registry prometheus.Registerer, opts prometheus.CounterOpts, labels []string) *prometheus.CounterVec {
+	collector := prometheus.NewCounterVec(opts, labels)
+	if registry == nil {
+		return collector
+	}
+	if err := registry.Register(collector); err != nil {
+		if already, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			if existing, ok := already.ExistingCollector.(*prometheus.CounterVec); ok {
+				return existing
+			}
+		}
+	}
+	return collector
+}
+
+func RegisterGaugeVec(registry prometheus.Registerer, opts prometheus.GaugeOpts, labels []string) *prometheus.GaugeVec {
+	collector := prometheus.NewGaugeVec(opts, labels)
+	if registry == nil {
+		return collector
+	}
+	if err := registry.Register(collector); err != nil {
+		if already, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			if existing, ok := already.ExistingCollector.(*prometheus.GaugeVec); ok {
+				return existing
+			}
+		}
+	}
+	return collector
+}
+
+func RegisterHistogramVec(registry prometheus.Registerer, opts prometheus.HistogramOpts, labels []string) *prometheus.HistogramVec {
+	collector := prometheus.NewHistogramVec(opts, labels)
+	if registry == nil {
+		return collector
+	}
+	if err := registry.Register(collector); err != nil {
+		if already, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			if existing, ok := already.ExistingCollector.(*prometheus.HistogramVec); ok {
+				return existing
+			}
+		}
+	}
+	return collector
+}

--- a/pkg/observability/internal/promutil/promutil_test.go
+++ b/pkg/observability/internal/promutil/promutil_test.go
@@ -1,0 +1,24 @@
+package promutil
+
+import "testing"
+
+func TestMetricPrefix(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "hyphenated service", in: "cluster-gateway", want: "cluster_gateway"},
+		{name: "mixed case", in: "StorageProxy", want: "storageproxy"},
+		{name: "leading digit", in: "9service", want: "_9service"},
+		{name: "empty", in: "", want: "sandbox0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := MetricPrefix(tt.in); got != tt.want {
+				t.Fatalf("MetricPrefix(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/observability/k8s/adapter.go
+++ b/pkg/observability/k8s/adapter.go
@@ -3,13 +3,16 @@ package k8s
 import (
 	"fmt"
 	"net/http"
+	"os"
+	"path/filepath"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/sandbox0-ai/sandbox0/pkg/observability/internal/promutil"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 // Adapter provides observable Kubernetes clients
@@ -20,11 +23,13 @@ type Adapter struct {
 
 // AdapterConfig configures the K8s adapter
 type AdapterConfig struct {
-	ServiceName string
-	Tracer      trace.Tracer
-	Logger      *zap.Logger
-	Registry    prometheus.Registerer
-	Disabled    bool
+	ServiceName    string
+	Tracer         trace.Tracer
+	Logger         *zap.Logger
+	Registry       prometheus.Registerer
+	DisableMetrics bool
+	DisableLogging bool
+	Disabled       bool
 }
 
 // Config holds configuration for creating an observable K8s client
@@ -43,7 +48,7 @@ type Config struct {
 // NewAdapter creates a new K8s adapter
 func NewAdapter(cfg AdapterConfig) Adapter {
 	var m *metrics
-	if !cfg.Disabled && cfg.Registry != nil {
+	if !cfg.Disabled && !cfg.DisableMetrics && cfg.Registry != nil {
 		m = newMetrics(cfg.ServiceName, cfg.Registry)
 	}
 
@@ -143,27 +148,30 @@ type metrics struct {
 }
 
 func newMetrics(serviceName string, registry prometheus.Registerer) *metrics {
-	factory := promauto.With(registry)
+	prefix := promutil.MetricPrefix(serviceName)
 
 	return &metrics{
-		requestsTotal: factory.NewCounterVec(
+		requestsTotal: promutil.RegisterCounterVec(
+			registry,
 			prometheus.CounterOpts{
-				Name: serviceName + "_k8s_client_requests_total",
+				Name: prefix + "_k8s_client_requests_total",
 				Help: "Total number of Kubernetes API requests",
 			},
 			[]string{"verb", "resource", "status"},
 		),
-		requestDuration: factory.NewHistogramVec(
+		requestDuration: promutil.RegisterHistogramVec(
+			registry,
 			prometheus.HistogramOpts{
-				Name:    serviceName + "_k8s_client_request_duration_seconds",
+				Name:    prefix + "_k8s_client_request_duration_seconds",
 				Help:    "Kubernetes API request duration in seconds",
 				Buckets: []float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5},
 			},
 			[]string{"verb", "resource"},
 		),
-		activeRequests: factory.NewGaugeVec(
+		activeRequests: promutil.RegisterGaugeVec(
+			registry,
 			prometheus.GaugeOpts{
-				Name: serviceName + "_k8s_client_active_requests",
+				Name: prefix + "_k8s_client_active_requests",
 				Help: "Number of active Kubernetes API requests",
 			},
 			[]string{"verb", "resource"},
@@ -181,11 +189,21 @@ func buildRestConfig(kubeconfigPath string) (*rest.Config, error) {
 		}
 	}
 
-	// Try kubeconfig file
+	if kubeconfigPath == "" {
+		home, err := os.UserHomeDir()
+		if err == nil {
+			kubeconfigPath = filepath.Join(home, ".kube", "config")
+		}
+	}
+
 	if kubeconfigPath != "" {
-		// Import from k8s package or implement inline
-		// For now, return a simple implementation
-		return nil, fmt.Errorf("kubeconfig loading not yet implemented in observability package")
+		if _, err := os.Stat(kubeconfigPath); err == nil {
+			config, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+			if err != nil {
+				return nil, fmt.Errorf("build kubeconfig from %s: %w", kubeconfigPath, err)
+			}
+			return config, nil
+		}
 	}
 
 	return nil, fmt.Errorf("no Kubernetes config found")

--- a/pkg/observability/k8s/transport.go
+++ b/pkg/observability/k8s/transport.go
@@ -57,13 +57,14 @@ func (t *observableTransport) RoundTrip(req *http.Request) (*http.Response, erro
 	// Inject trace context
 	otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(req.Header))
 
-	// Log request start
-	t.config.Logger.Debug("K8s API request started",
-		zap.String("verb", verb),
-		zap.String("resource", resource),
-		zap.String("path", req.URL.Path),
-		zap.String("trace_id", span.SpanContext().TraceID().String()),
-	)
+	if !t.config.DisableLogging && t.config.Logger != nil {
+		t.config.Logger.Debug("K8s API request started",
+			zap.String("verb", verb),
+			zap.String("resource", resource),
+			zap.String("path", req.URL.Path),
+			zap.String("trace_id", span.SpanContext().TraceID().String()),
+		)
+	}
 
 	// Execute request
 	req = req.WithContext(ctx)
@@ -81,13 +82,15 @@ func (t *observableTransport) RoundTrip(req *http.Request) (*http.Response, erro
 			t.metrics.requestDuration.WithLabelValues(verb, resource).Observe(duration.Seconds())
 		}
 
-		t.config.Logger.Error("K8s API request failed",
-			zap.String("verb", verb),
-			zap.String("resource", resource),
-			zap.Duration("duration", duration),
-			zap.Error(err),
-			zap.String("trace_id", span.SpanContext().TraceID().String()),
-		)
+		if !t.config.DisableLogging && t.config.Logger != nil {
+			t.config.Logger.Error("K8s API request failed",
+				zap.String("verb", verb),
+				zap.String("resource", resource),
+				zap.Duration("duration", duration),
+				zap.Error(err),
+				zap.String("trace_id", span.SpanContext().TraceID().String()),
+			)
+		}
 
 		return nil, err
 	}
@@ -118,13 +121,15 @@ func (t *observableTransport) RoundTrip(req *http.Request) (*http.Response, erro
 		logLevel = zap.WarnLevel
 	}
 
-	t.config.Logger.Log(logLevel, "K8s API request completed",
-		zap.String("verb", verb),
-		zap.String("resource", resource),
-		zap.Int("status", statusCode),
-		zap.Duration("duration", duration),
-		zap.String("trace_id", span.SpanContext().TraceID().String()),
-	)
+	if !t.config.DisableLogging && t.config.Logger != nil {
+		t.config.Logger.Log(logLevel, "K8s API request completed",
+			zap.String("verb", verb),
+			zap.String("resource", resource),
+			zap.Int("status", statusCode),
+			zap.Duration("duration", duration),
+			zap.String("trace_id", span.SpanContext().TraceID().String()),
+		)
+	}
 
 	return resp, nil
 }
@@ -144,19 +149,17 @@ func extractK8sResource(path string) string {
 		return "unknown"
 	}
 
-	// Look for common resource types in reverse order
-	for i := len(parts) - 1; i >= 0; i-- {
-		part := parts[i]
-		// Skip common non-resource parts
-		if part == "namespaces" || part == "api" || part == "apis" ||
-			strings.HasPrefix(part, "v") && len(part) <= 3 {
-			continue
+	for i, part := range parts {
+		if part == "namespaces" && i+2 < len(parts) {
+			return parts[i+2]
 		}
-		// Skip namespace names (they come after "namespaces")
-		if i > 0 && parts[i-1] == "namespaces" {
-			continue
-		}
-		return part
+	}
+
+	if len(parts) >= 3 && parts[0] == "api" {
+		return parts[2]
+	}
+	if len(parts) >= 4 && parts[0] == "apis" {
+		return parts[3]
 	}
 
 	return "unknown"

--- a/pkg/observability/k8s/transport_test.go
+++ b/pkg/observability/k8s/transport_test.go
@@ -1,0 +1,25 @@
+package k8s
+
+import "testing"
+
+func TestExtractK8sResource(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "core namespaced collection", path: "/api/v1/namespaces/default/pods", want: "pods"},
+		{name: "core namespaced object", path: "/api/v1/namespaces/default/pods/sandbox-123", want: "pods"},
+		{name: "group namespaced object", path: "/apis/apps/v1/namespaces/default/replicasets/rs-123", want: "replicasets"},
+		{name: "core cluster collection", path: "/api/v1/nodes", want: "nodes"},
+		{name: "group cluster collection", path: "/apis/storage.k8s.io/v1/storageclasses", want: "storageclasses"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractK8sResource(tt.path); got != tt.want {
+				t.Fatalf("extractK8sResource(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/observability/pgx/adapter.go
+++ b/pkg/observability/pgx/adapter.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/sandbox0-ai/sandbox0/pkg/observability/internal/promutil"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 )
@@ -19,11 +19,13 @@ type Adapter struct {
 
 // AdapterConfig configures the Pgx adapter
 type AdapterConfig struct {
-	ServiceName string
-	Tracer      trace.Tracer
-	Logger      *zap.Logger
-	Registry    prometheus.Registerer
-	Disabled    bool
+	ServiceName    string
+	Tracer         trace.Tracer
+	Logger         *zap.Logger
+	Registry       prometheus.Registerer
+	DisableMetrics bool
+	DisableLogging bool
+	Disabled       bool
 }
 
 // Config holds configuration for creating an observable pgx pool
@@ -47,7 +49,7 @@ type Config struct {
 // NewAdapter creates a new Pgx adapter
 func NewAdapter(cfg AdapterConfig) Adapter {
 	var m *metrics
-	if !cfg.Disabled && cfg.Registry != nil {
+	if !cfg.Disabled && !cfg.DisableMetrics && cfg.Registry != nil {
 		m = newMetrics(cfg.ServiceName, cfg.Registry)
 	}
 
@@ -92,13 +94,7 @@ func (a Adapter) NewPool(ctx context.Context, cfg Config) (*pgxpool.Pool, error)
 		}
 	}
 
-	// Attach observable tracer
-	if !a.config.Disabled {
-		poolConfig.ConnConfig.Tracer = &observableTracer{
-			config:  a.config,
-			metrics: a.metrics,
-		}
-	}
+	a.ConfigurePool(poolConfig)
 
 	// Create pool
 	pool, err := pgxpool.NewWithConfig(ctx, poolConfig)
@@ -121,20 +117,34 @@ func (a Adapter) NewPool(ctx context.Context, cfg Config) (*pgxpool.Pool, error)
 	return pool, nil
 }
 
-// WrapPool wraps an existing pgx pool with observability instrumentation
+// ConfigurePool attaches query tracing to a pgx pool config before the pool is created.
+func (a Adapter) ConfigurePool(poolConfig *pgxpool.Config) {
+	if poolConfig == nil || a.config.Disabled {
+		return
+	}
+	poolConfig.ConnConfig.Tracer = &observableTracer{
+		config:  a.config,
+		metrics: a.metrics,
+	}
+}
+
+// ConfigModifier returns a dbpool.Options-compatible modifier.
+func (a Adapter) ConfigModifier() func(*pgxpool.Config) error {
+	return func(poolConfig *pgxpool.Config) error {
+		a.ConfigurePool(poolConfig)
+		return nil
+	}
+}
+
+// WrapPool cannot retrofit pgx query tracing onto an already-created pool.
+// Use ConfigurePool or ConfigModifier before pgxpool.NewWithConfig instead.
 func (a Adapter) WrapPool(pool *pgxpool.Pool) {
 	if pool == nil || a.config.Disabled {
 		return
 	}
-
-	// Get the pool config and attach observable tracer
-	config := pool.Config()
-	config.ConnConfig.Tracer = &observableTracer{
-		config:  a.config,
-		metrics: a.metrics,
+	if !a.config.DisableLogging && a.config.Logger != nil {
+		a.config.Logger.Warn("PostgreSQL pool was already created; query tracing was not attached")
 	}
-
-	a.config.Logger.Debug("PostgreSQL pool wrapped with observability")
 }
 
 // metrics holds Prometheus metrics for pgx
@@ -147,41 +157,46 @@ type metrics struct {
 }
 
 func newMetrics(serviceName string, registry prometheus.Registerer) *metrics {
-	factory := promauto.With(registry)
+	prefix := promutil.MetricPrefix(serviceName)
 
 	return &metrics{
-		queriesTotal: factory.NewCounterVec(
+		queriesTotal: promutil.RegisterCounterVec(
+			registry,
 			prometheus.CounterOpts{
-				Name: serviceName + "_pgx_queries_total",
+				Name: prefix + "_pgx_queries_total",
 				Help: "Total number of PostgreSQL queries",
 			},
 			[]string{"operation", "status"},
 		),
-		queryDuration: factory.NewHistogramVec(
+		queryDuration: promutil.RegisterHistogramVec(
+			registry,
 			prometheus.HistogramOpts{
-				Name:    serviceName + "_pgx_query_duration_seconds",
+				Name:    prefix + "_pgx_query_duration_seconds",
 				Help:    "PostgreSQL query duration in seconds",
 				Buckets: []float64{.0001, .0005, .001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5},
 			},
 			[]string{"operation"},
 		),
-		activeQueries: factory.NewGaugeVec(
+		activeQueries: promutil.RegisterGaugeVec(
+			registry,
 			prometheus.GaugeOpts{
-				Name: serviceName + "_pgx_active_queries",
+				Name: prefix + "_pgx_active_queries",
 				Help: "Number of active PostgreSQL queries",
 			},
 			[]string{"operation"},
 		),
-		rowsAffected: factory.NewCounterVec(
+		rowsAffected: promutil.RegisterCounterVec(
+			registry,
 			prometheus.CounterOpts{
-				Name: serviceName + "_pgx_rows_affected_total",
+				Name: prefix + "_pgx_rows_affected_total",
 				Help: "Total number of rows affected by PostgreSQL queries",
 			},
 			[]string{"operation"},
 		),
-		poolConnections: factory.NewGaugeVec(
+		poolConnections: promutil.RegisterGaugeVec(
+			registry,
 			prometheus.GaugeOpts{
-				Name: serviceName + "_pgx_pool_connections",
+				Name: prefix + "_pgx_pool_connections",
 				Help: "Number of connections in the pool",
 			},
 			[]string{"state"}, // idle, acquired, constructing

--- a/pkg/observability/pgx/tracer.go
+++ b/pkg/observability/pgx/tracer.go
@@ -3,6 +3,7 @@ package pgx
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -48,12 +49,13 @@ func (t *observableTracer) TraceQueryStart(ctx context.Context, conn *pgx.Conn, 
 	ctx = context.WithValue(ctx, queryStartKey{}, start)
 	ctx = context.WithValue(ctx, queryOperationKey{}, operation)
 
-	// Log query start
-	t.config.Logger.Debug("PostgreSQL query started",
-		zap.String("operation", operation),
-		zap.String("sql", truncateSQL(data.SQL)),
-		zap.String("trace_id", span.SpanContext().TraceID().String()),
-	)
+	if !t.config.DisableLogging && t.config.Logger != nil {
+		t.config.Logger.Debug("PostgreSQL query started",
+			zap.String("operation", operation),
+			zap.String("sql", truncateSQL(data.SQL)),
+			zap.String("trace_id", span.SpanContext().TraceID().String()),
+		)
+	}
 
 	return ctx
 }
@@ -91,12 +93,14 @@ func (t *observableTracer) TraceQueryEnd(ctx context.Context, conn *pgx.Conn, da
 			t.metrics.queryDuration.WithLabelValues(operation).Observe(duration.Seconds())
 		}
 
-		t.config.Logger.Error("PostgreSQL query failed",
-			zap.String("operation", operation),
-			zap.Duration("duration", duration),
-			zap.Error(data.Err),
-			zap.String("trace_id", span.SpanContext().TraceID().String()),
-		)
+		if !t.config.DisableLogging && t.config.Logger != nil {
+			t.config.Logger.Error("PostgreSQL query failed",
+				zap.String("operation", operation),
+				zap.Duration("duration", duration),
+				zap.Error(data.Err),
+				zap.String("trace_id", span.SpanContext().TraceID().String()),
+			)
+		}
 
 		return
 	}
@@ -112,12 +116,14 @@ func (t *observableTracer) TraceQueryEnd(ctx context.Context, conn *pgx.Conn, da
 		t.metrics.rowsAffected.WithLabelValues(operation).Add(float64(data.CommandTag.RowsAffected()))
 	}
 
-	t.config.Logger.Debug("PostgreSQL query completed",
-		zap.String("operation", operation),
-		zap.Duration("duration", duration),
-		zap.Int64("rows_affected", data.CommandTag.RowsAffected()),
-		zap.String("trace_id", span.SpanContext().TraceID().String()),
-	)
+	if !t.config.DisableLogging && t.config.Logger != nil {
+		t.config.Logger.Debug("PostgreSQL query completed",
+			zap.String("operation", operation),
+			zap.Duration("duration", duration),
+			zap.Int64("rows_affected", data.CommandTag.RowsAffected()),
+			zap.String("trace_id", span.SpanContext().TraceID().String()),
+		)
+	}
 }
 
 // Context keys for storing span metadata
@@ -127,32 +133,11 @@ type queryOperationKey struct{}
 
 // inferOperation extracts the SQL operation type from the query
 func inferOperation(sql string) string {
-	// Simple heuristic: look at the first word
-	for i, ch := range sql {
-		if ch == ' ' || ch == '\n' || ch == '\t' {
-			op := sql[:i]
-			// Normalize common operations
-			switch op {
-			case "SELECT", "select":
-				return "SELECT"
-			case "INSERT", "insert":
-				return "INSERT"
-			case "UPDATE", "update":
-				return "UPDATE"
-			case "DELETE", "delete":
-				return "DELETE"
-			case "BEGIN", "begin":
-				return "BEGIN"
-			case "COMMIT", "commit":
-				return "COMMIT"
-			case "ROLLBACK", "rollback":
-				return "ROLLBACK"
-			default:
-				return op
-			}
-		}
+	fields := strings.Fields(strings.TrimSpace(sql))
+	if len(fields) == 0 {
+		return "UNKNOWN"
 	}
-	return "UNKNOWN"
+	return strings.ToUpper(fields[0])
 }
 
 // truncateSQL truncates SQL statements for logging/tracing

--- a/pkg/observability/pgx/tracer_test.go
+++ b/pkg/observability/pgx/tracer_test.go
@@ -1,0 +1,20 @@
+package pgx
+
+import "testing"
+
+func TestInferOperationTrimsLeadingWhitespace(t *testing.T) {
+	tests := []struct {
+		sql  string
+		want string
+	}{
+		{sql: "\n\tselect * from sandboxes", want: "SELECT"},
+		{sql: " insert into sandboxes(id) values($1)", want: "INSERT"},
+		{sql: "", want: "UNKNOWN"},
+	}
+
+	for _, tt := range tests {
+		if got := inferOperation(tt.sql); got != tt.want {
+			t.Fatalf("inferOperation(%q) = %q, want %q", tt.sql, got, tt.want)
+		}
+	}
+}

--- a/pkg/observability/provider.go
+++ b/pkg/observability/provider.go
@@ -82,27 +82,33 @@ func New(cfg Config) (*Provider, error) {
 
 	// Initialize client adapters
 	p.HTTP = httpobs.NewAdapter(httpobs.AdapterConfig{
-		ServiceName: cfg.ServiceName,
-		Tracer:      p.tracer,
-		Logger:      cfg.Logger,
-		Registry:    cfg.MetricsRegistry,
-		Disabled:    cfg.DisableTracing && cfg.DisableMetrics && cfg.DisableLogging,
+		ServiceName:    cfg.ServiceName,
+		Tracer:         p.tracer,
+		Logger:         cfg.Logger,
+		Registry:       cfg.MetricsRegistry,
+		DisableMetrics: cfg.DisableMetrics,
+		DisableLogging: cfg.DisableLogging,
+		Disabled:       cfg.DisableTracing && cfg.DisableMetrics && cfg.DisableLogging,
 	})
 
 	p.K8s = k8sobs.NewAdapter(k8sobs.AdapterConfig{
-		ServiceName: cfg.ServiceName,
-		Tracer:      p.tracer,
-		Logger:      cfg.Logger,
-		Registry:    cfg.MetricsRegistry,
-		Disabled:    cfg.DisableTracing && cfg.DisableMetrics && cfg.DisableLogging,
+		ServiceName:    cfg.ServiceName,
+		Tracer:         p.tracer,
+		Logger:         cfg.Logger,
+		Registry:       cfg.MetricsRegistry,
+		DisableMetrics: cfg.DisableMetrics,
+		DisableLogging: cfg.DisableLogging,
+		Disabled:       cfg.DisableTracing && cfg.DisableMetrics && cfg.DisableLogging,
 	})
 
 	p.Pgx = pgxobs.NewAdapter(pgxobs.AdapterConfig{
-		ServiceName: cfg.ServiceName,
-		Tracer:      p.tracer,
-		Logger:      cfg.Logger,
-		Registry:    cfg.MetricsRegistry,
-		Disabled:    cfg.DisableTracing && cfg.DisableMetrics && cfg.DisableLogging,
+		ServiceName:    cfg.ServiceName,
+		Tracer:         p.tracer,
+		Logger:         cfg.Logger,
+		Registry:       cfg.MetricsRegistry,
+		DisableMetrics: cfg.DisableMetrics,
+		DisableLogging: cfg.DisableLogging,
+		Disabled:       cfg.DisableTracing && cfg.DisableMetrics && cfg.DisableLogging,
 	})
 
 	cfg.Logger.Info("Observability provider initialized",
@@ -138,6 +144,22 @@ func (p *Provider) MetricsRegistryOrNil() prometheus.Registerer {
 		return nil
 	}
 	return p.MetricsRegistry
+}
+
+// HTTPServerConfig returns server middleware config using this provider.
+func (p *Provider) HTTPServerConfig(logger *zap.Logger) httpobs.ServerConfig {
+	if p == nil {
+		return httpobs.ServerConfig{Disabled: true}
+	}
+	return httpobs.ServerConfig{
+		ServiceName:    p.config.ServiceName,
+		Tracer:         p.tracer,
+		Logger:         logger,
+		Registry:       p.MetricsRegistryOrNil(),
+		DisableMetrics: p.config.DisableMetrics,
+		DisableLogging: p.config.DisableLogging || logger == nil,
+		Disabled:       p.config.DisableTracing && p.config.DisableMetrics && p.config.DisableLogging,
+	}
 }
 
 // initTracing initializes OpenTelemetry tracing with the configured exporter

--- a/pkg/observability/zapexporter.go
+++ b/pkg/observability/zapexporter.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.uber.org/zap"
 )
@@ -77,16 +76,7 @@ func (e *zapSpanExporter) logSpan(span sdktrace.ReadOnlySpan) {
 		fields = append(fields, zap.Any("event", eventFields))
 	}
 
-	// Log with appropriate level based on status
-	msg := "trace_span"
-	switch span.Status().Code {
-	case codes.Error:
-		e.logger.Error(msg, fields...)
-	case codes.Ok:
-		e.logger.Info(msg, fields...)
-	default:
-		e.logger.Debug(msg, fields...)
-	}
+	e.logger.Info("trace_span", fields...)
 }
 
 // attributeToZapField converts an OTEL attribute to a zap field

--- a/regional-gateway/cmd/regional-gateway/main.go
+++ b/regional-gateway/cmd/regional-gateway/main.go
@@ -139,17 +139,15 @@ func initLogger(level string) (*zap.Logger, error) {
 // initDatabase initializes the database connection pool
 func initDatabase(ctx context.Context, cfg *config.RegionalGatewayConfig, logger *zap.Logger, obsProvider *observability.Provider) (*pgxpool.Pool, error) {
 	pool, err := dbpool.New(ctx, dbpool.Options{
-		DatabaseURL: cfg.DatabaseURL,
-		MaxConns:    int32(cfg.DatabaseMaxConns),
-		MinConns:    int32(cfg.DatabaseMinConns),
-		Schema:      "shared_gateway",
+		DatabaseURL:    cfg.DatabaseURL,
+		MaxConns:       int32(cfg.DatabaseMaxConns),
+		MinConns:       int32(cfg.DatabaseMinConns),
+		Schema:         "shared_gateway",
+		ConfigModifier: obsProvider.Pgx.ConfigModifier(),
 	})
 	if err != nil {
 		return nil, err
 	}
-
-	// Wrap pool with observability
-	obsProvider.Pgx.WrapPool(pool)
 
 	logger.Info("Database connection established",
 		zap.Int32("max_conns", pool.Config().MaxConns),

--- a/regional-gateway/pkg/http/cluster_cache.go
+++ b/regional-gateway/pkg/http/cluster_cache.go
@@ -40,7 +40,7 @@ func (s *Server) getClusterGatewayProxy(targetURL string) (*proxy.Router, error)
 		return p, nil
 	}
 
-	p, err := proxy.NewRouter(targetURL, s.logger, s.cfg.ProxyTimeout.Duration)
+	p, err := proxy.NewRouter(targetURL, s.logger, s.cfg.ProxyTimeout.Duration, proxy.WithHTTPClient(s.outboundHTTPClient()))
 	if err != nil {
 		return nil, err
 	}
@@ -108,8 +108,7 @@ func (s *Server) refreshClusterCache(ctx context.Context, authCtx *authn.AuthCon
 	}
 	req.Header.Set("X-Auth-Method", string(authCtx.AuthMethod))
 
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	resp, err := s.outboundHTTPClient().Do(req)
 	if err != nil {
 		return fmt.Errorf("list clusters: %w", err)
 	}

--- a/regional-gateway/pkg/http/internal_ssh.go
+++ b/regional-gateway/pkg/http/internal_ssh.go
@@ -187,7 +187,7 @@ func (s *Server) getSandboxFromClusterGateway(ctx context.Context, clusterGatewa
 	req, cancel := proxy.ApplyRequestTimeout(req, s.cfg.ProxyTimeout.Duration)
 	defer cancel()
 
-	resp, err := (&http.Client{}).Do(req)
+	resp, err := s.outboundHTTPClient().Do(req)
 	if err != nil {
 		return nil, http.StatusServiceUnavailable, fmt.Errorf("call cluster-gateway sandbox endpoint: %w", err)
 	}
@@ -237,7 +237,7 @@ func (s *Server) resumeSandboxViaClusterGateway(ctx context.Context, clusterGate
 	req, cancel := proxy.ApplyRequestTimeout(req, s.cfg.ProxyTimeout.Duration)
 	defer cancel()
 
-	resp, err := (&http.Client{}).Do(req)
+	resp, err := s.outboundHTTPClient().Do(req)
 	if err != nil {
 		return fmt.Errorf("call cluster-gateway resume endpoint: %w", err)
 	}

--- a/regional-gateway/pkg/http/server.go
+++ b/regional-gateway/pkg/http/server.go
@@ -49,6 +49,7 @@ type Server struct {
 	internalAuthGen      *internalauth.Generator
 	meteringHandler      *gatewayhandlers.MeteringHandler
 	obsProvider          *observability.Provider
+	httpClient           *http.Client
 
 	clusterGatewayProxies   map[string]*proxy.Router
 	clusterGatewayProxiesMu sync.RWMutex
@@ -237,6 +238,7 @@ func NewServer(
 		internalAuthGen:       internalAuthGen,
 		meteringHandler:       gatewayhandlers.NewMeteringHandler(meteringRepo, cfg.RegionID, logger),
 		obsProvider:           obsProvider,
+		httpClient:            httpClient,
 		clusterGatewayProxies: make(map[string]*proxy.Router),
 		clusterCache:          make(map[string]string),
 		entitlements:          publicEntitlements,
@@ -253,12 +255,17 @@ func NewServer(
 	return server, nil
 }
 
+func (s *Server) outboundHTTPClient() *http.Client {
+	if s != nil && s.httpClient != nil {
+		return s.httpClient
+	}
+	return &http.Client{}
+}
+
 // setupRoutes configures all HTTP routes
 func (s *Server) setupRoutes() {
 	// Global middleware (order matters)
-	s.router.Use(httpobs.GinMiddleware(httpobs.ServerConfig{
-		Tracer: s.obsProvider.Tracer(),
-	}))
+	s.router.Use(httpobs.GinMiddleware(s.obsProvider.HTTPServerConfig(nil)))
 	s.router.Use(middleware.Recovery(s.logger))
 	s.router.Use(s.requestLogger.Logger())
 	s.router.Use(middleware.UpstreamTimeoutWhitelist())

--- a/scheduler/cmd/scheduler/main.go
+++ b/scheduler/cmd/scheduler/main.go
@@ -255,13 +255,11 @@ func initDatabase(ctx context.Context, cfg *config.SchedulerConfig, logger *zap.
 		MaxConnLifetime: maxConnLifetime,
 		MaxConnIdleTime: maxConnIdleTime,
 		Schema:          "scheduler",
+		ConfigModifier:  obsProvider.Pgx.ConfigModifier(),
 	})
 	if err != nil {
 		return nil, err
 	}
-
-	// Wrap pool with observability
-	obsProvider.Pgx.WrapPool(pool)
 
 	logger.Info("Connected to database",
 		zap.Int32("max_conns", pool.Config().MaxConns),

--- a/scheduler/pkg/http/server.go
+++ b/scheduler/pkg/http/server.go
@@ -41,6 +41,7 @@ type Server struct {
 	logger          *zap.Logger
 	obsProvider     *observability.Provider
 	metrics         *obsmetrics.SchedulerMetrics
+	httpClient      *http.Client
 
 	clusterGatewayProxies   map[string]*proxy.Router
 	clusterGatewayProxiesMu sync.RWMutex
@@ -98,9 +99,7 @@ func NewServer(
 
 	// Create router
 	router := gin.New()
-	router.Use(httpobs.GinMiddleware(httpobs.ServerConfig{
-		Tracer: obsProvider.Tracer(),
-	}))
+	router.Use(httpobs.GinMiddleware(obsProvider.HTTPServerConfig(nil)))
 	router.Use(gin.Recovery())
 	router.Use(requestLogger(logger))
 	router.Use(gatewaymiddleware.UpstreamTimeoutWhitelist())
@@ -117,6 +116,7 @@ func NewServer(
 		logger:                logger,
 		obsProvider:           obsProvider,
 		metrics:               metrics,
+		httpClient:            obsProvider.HTTP.NewClient(httpobs.Config{Timeout: cfg.ProxyTimeout.Duration}),
 		clusterGatewayProxies: make(map[string]*proxy.Router),
 		clusterCache:          make(map[string]*template.Cluster),
 	}
@@ -387,7 +387,7 @@ func (s *Server) getClusterGatewayProxy(targetURL string) (*proxy.Router, error)
 		proxyTimeout = 10 * time.Second
 	}
 
-	p, err := proxy.NewRouter(targetURL, s.logger, proxyTimeout)
+	p, err := proxy.NewRouter(targetURL, s.logger, proxyTimeout, proxy.WithHTTPClient(s.httpClient))
 	if err != nil {
 		return nil, err
 	}

--- a/ssh-gateway/cmd/ssh-gateway/main.go
+++ b/ssh-gateway/cmd/ssh-gateway/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
@@ -15,6 +16,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"github.com/sandbox0-ai/sandbox0/pkg/migrate"
 	"github.com/sandbox0-ai/sandbox0/pkg/observability"
+	httpobs "github.com/sandbox0-ai/sandbox0/pkg/observability/http"
 	sshserver "github.com/sandbox0-ai/sandbox0/ssh-gateway/pkg/server"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -86,11 +88,13 @@ func main() {
 
 	repo := identity.NewRepository(pool)
 	resolver := sshserver.NewRegionalSandboxResolver(cfg.RegionalGatewayURL, controlPlaneAuthGen, logger, cfg.ResumeTimeout.Duration)
+	resolver.SetHTTPClient(obsProvider.HTTP.NewClient(httpobs.Config{Timeout: cfg.ResumeTimeout.Duration}))
 	authorizer := sshserver.NewAuthenticator(repo, resolver, cfg.ResumeTimeout.Duration, cfg.ResumePollInterval.Duration, logger)
 	server, err := sshserver.NewServer(cfg, authorizer, dataPlaneAuthGen, logger)
 	if err != nil {
 		logger.Fatal("Failed to create ssh-gateway server", zap.Error(err))
 	}
+	server.SetHTTPClient(obsProvider.HTTP.NewClient(httpobs.Config{Timeout: 10 * time.Second}))
 
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
@@ -152,15 +156,15 @@ func initLogger(level string) (*zap.Logger, error) {
 
 func initDatabase(ctx context.Context, cfg *config.SSHGatewayConfig, logger *zap.Logger, obsProvider *observability.Provider) (*pgxpool.Pool, error) {
 	pool, err := dbpool.New(ctx, dbpool.Options{
-		DatabaseURL: cfg.DatabaseURL,
-		MaxConns:    int32(cfg.DatabaseMaxConns),
-		MinConns:    int32(cfg.DatabaseMinConns),
-		Schema:      "shared_gateway",
+		DatabaseURL:    cfg.DatabaseURL,
+		MaxConns:       int32(cfg.DatabaseMaxConns),
+		MinConns:       int32(cfg.DatabaseMinConns),
+		Schema:         "shared_gateway",
+		ConfigModifier: obsProvider.Pgx.ConfigModifier(),
 	})
 	if err != nil {
 		return nil, err
 	}
-	obsProvider.Pgx.WrapPool(pool)
 	logger.Info("Database connection established",
 		zap.Int32("max_conns", pool.Config().MaxConns),
 		zap.Int32("min_conns", pool.Config().MinConns),

--- a/ssh-gateway/pkg/server/regional.go
+++ b/ssh-gateway/pkg/server/regional.go
@@ -38,6 +38,14 @@ func NewRegionalSandboxResolver(baseURL string, internalAuthGen *internalauth.Ge
 	}
 }
 
+// SetHTTPClient replaces the resolver HTTP client.
+func (r *RegionalSandboxResolver) SetHTTPClient(httpClient *http.Client) {
+	if r == nil || httpClient == nil {
+		return
+	}
+	r.httpClient = httpClient
+}
+
 func (r *RegionalSandboxResolver) ResolveSandbox(ctx context.Context, sandboxID string, grants []sharedssh.AuthorizedGrant) (*sharedssh.ResolvedTarget, error) {
 	if strings.TrimSpace(r.baseURL) == "" {
 		return nil, fmt.Errorf("regional gateway URL is required")

--- a/ssh-gateway/pkg/server/server.go
+++ b/ssh-gateway/pkg/server/server.go
@@ -110,6 +110,14 @@ func NewServer(cfg *config.SSHGatewayConfig, authorizer SessionAuthorizer, dataP
 	return server, nil
 }
 
+// SetHTTPClient replaces the HTTP client used for procd requests.
+func (s *Server) SetHTTPClient(httpClient *http.Client) {
+	if s == nil || httpClient == nil {
+		return
+	}
+	s.httpClient = httpClient
+}
+
 func parseHostSigner(hostKey []byte) (ssh.Signer, error) {
 	hostSigner, err := ssh.ParsePrivateKey(hostKey)
 	if err == nil {

--- a/storage-proxy/cmd/storage-proxy/main.go
+++ b/storage-proxy/cmd/storage-proxy/main.go
@@ -324,7 +324,10 @@ func main() {
 
 	// Create gRPC server
 	grpcServer := grpc.NewServer(
-		grpc.UnaryInterceptor(grpcInterceptor),
+		grpc.ChainUnaryInterceptor(
+			storageProxyUnaryMetricsInterceptor(storageProxyMetrics, zapLogger),
+			grpcInterceptor,
+		),
 	)
 
 	// Register FileSystem service
@@ -388,9 +391,7 @@ func main() {
 		idleTimeout = 60 * time.Second
 	}
 
-	httpHandler := httpobs.ServerMiddleware(httpobs.ServerConfig{
-		Tracer: obsProvider.Tracer(),
-	})(httpSrv)
+	httpHandler := httpobs.ServerMiddleware(obsProvider.HTTPServerConfig(nil))(httpSrv)
 
 	httpServer := &http.Server{
 		Addr:         httpAddr,
@@ -464,13 +465,11 @@ func initDatabase(ctx context.Context, databaseURL string, cfg *config.StoragePr
 		DefaultMaxConns: 30,
 		DefaultMinConns: 5,
 		Schema:          schema,
+		ConfigModifier:  obsProvider.Pgx.ConfigModifier(),
 	})
 	if err != nil {
 		return nil, err
 	}
-
-	// Wrap pool with observability
-	obsProvider.Pgx.WrapPool(pool)
 
 	logger.Info("Database connection established",
 		zap.Int32("max_conns", pool.Config().MaxConns),
@@ -482,6 +481,37 @@ func initDatabase(ctx context.Context, databaseURL string, cfg *config.StoragePr
 
 type zapLoggerAdapter struct {
 	logger *zap.Logger
+}
+
+func storageProxyUnaryMetricsInterceptor(metrics *obsmetrics.StorageProxyMetrics, logger *zap.Logger) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		start := time.Now()
+		resp, err := handler(ctx, req)
+		if metrics != nil && metrics.GRPCRequestsTotal != nil && metrics.GRPCRequestDuration != nil {
+			status := "success"
+			if err != nil {
+				status = "error"
+			}
+			method := "unknown"
+			if info != nil && info.FullMethod != "" {
+				method = info.FullMethod
+			}
+			metrics.GRPCRequestsTotal.WithLabelValues(method, status).Inc()
+			metrics.GRPCRequestDuration.WithLabelValues(method).Observe(time.Since(start).Seconds())
+		}
+		if err != nil && logger != nil {
+			method := "unknown"
+			if info != nil && info.FullMethod != "" {
+				method = info.FullMethod
+			}
+			logger.Warn("gRPC request failed",
+				zap.String("method", method),
+				zap.Duration("duration", time.Since(start)),
+				zap.Error(err),
+			)
+		}
+		return resp, err
+	}
 }
 
 func (z *zapLoggerAdapter) Printf(format string, args ...any) {


### PR DESCRIPTION
## Summary
- Add reusable observability helpers for stable Prometheus metric names, duplicate-safe registration, HTTP server metrics, K8s resource labels, and pgx pool config instrumentation.
- Wire unified observability into API servers, outbound HTTP/proxy clients, DB pools, K8s clients, storage-proxy gRPC calls, netd, ssh-gateway, and ctld.
- Add focused tests for HTTP server metrics, host label cardinality, K8s resource extraction, pgx operation inference, and metric prefix sanitization.

Closes #207

## Testing
- make proto
- go test ./pkg/observability/... ./pkg/dbpool ./pkg/k8s ./cluster-gateway/pkg/client ./cluster-gateway/pkg/http ./regional-gateway/pkg/http ./global-gateway/pkg/http ./scheduler/pkg/http ./manager/pkg/http ./manager/procd/pkg/http ./manager/procd/pkg/volume ./manager/pkg/service ./ssh-gateway/pkg/server ./storage-proxy/cmd/storage-proxy ./netd/pkg/daemon ./netd/pkg/proxy ./ctld/cmd/ctld ./ctld/internal/ctld/server -count=1
- go test ./cluster-gateway/cmd/cluster-gateway ./regional-gateway/cmd/regional-gateway ./scheduler/cmd/scheduler ./global-gateway/cmd/global-gateway ./manager/cmd/manager ./ssh-gateway/cmd/ssh-gateway ./netd/cmd/netd -count=1
- go test ./manager/procd/pkg/process -count=1
- git push pre-push hook: make manifests, make proto, make apispec, go fmt ./..., go mod tidy, go mod vendor, golangci-lint run ./...

## Notes
- go test ./... was also attempted. Normal package tests ran, but the command fails in this local environment because tests/e2e cannot connect to Docker for kind, and tests/integration/internal/tests/manager requires /config/internal_jwt_public.key. A non-tests run also surfaced the known flaky manager/procd/pkg/process PTY repeat test once; the package passed on immediate rerun.