### PR TITLE
Prevent API key role escalation

### DIFF
--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -1031,6 +1031,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorEnvelope"
+        "403":
+          description: Requested roles exceed caller permissions
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
   /api-keys/current:
     get:
       tags: [api-keys]
@@ -3837,6 +3843,7 @@ components:
           type: string
         roles:
           type: array
+          description: "Requested API key roles. Supported roles: admin, developer, builder, viewer. The roles must not grant permissions outside the authenticated caller's permissions."
           items:
             type: string
         expires_in:

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -741,9 +741,11 @@ type ContextStatsResponse struct {
 // CreateAPIKeyRequest defines model for CreateAPIKeyRequest.
 type CreateAPIKeyRequest struct {
 	// ExpiresIn 30d, 90d, 180d, 365d, or never
-	ExpiresIn *string   `json:"expires_in,omitempty"`
-	Name      string    `json:"name"`
-	Roles     *[]string `json:"roles,omitempty"`
+	ExpiresIn *string `json:"expires_in,omitempty"`
+	Name      string  `json:"name"`
+
+	// Roles Requested API key roles. Supported roles: admin, developer, builder, viewer. The roles must not grant permissions outside the authenticated caller's permissions.
+	Roles *[]string `json:"roles,omitempty"`
 }
 
 // CreateAPIKeyResponse defines model for CreateAPIKeyResponse.

--- a/pkg/gateway/http/handlers/apikey.go
+++ b/pkg/gateway/http/handlers/apikey.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/apikey"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/authn"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/identity"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/middleware"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
@@ -155,9 +156,14 @@ func (h *APIKeyHandler) CreateAPIKey(c *gin.Context) {
 	}
 
 	// Default roles if not provided
-	roles := req.Roles
-	if len(roles) == 0 {
-		roles = []string{"developer"}
+	roles, err := normalizeCreateAPIKeyRoles(req.Roles)
+	if err != nil {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
+		return
+	}
+	if !canGrantAPIKeyRoles(authCtx, roles) {
+		spec.JSONError(c, http.StatusForbidden, spec.CodeForbidden, "cannot create API key with roles that grant permissions outside the caller's permissions")
+		return
 	}
 
 	regionID := h.regionID
@@ -284,4 +290,62 @@ func (h *APIKeyHandler) DeactivateAPIKey(c *gin.Context) {
 	}
 
 	spec.JSONSuccess(c, http.StatusOK, gin.H{"message": "API key deactivated"})
+}
+
+func normalizeCreateAPIKeyRoles(roles []string) ([]string, error) {
+	if len(roles) == 0 {
+		return []string{"developer"}, nil
+	}
+
+	normalized := make([]string, 0, len(roles))
+	seen := make(map[string]struct{}, len(roles))
+	for _, role := range roles {
+		role = strings.TrimSpace(role)
+		if role == "" {
+			return nil, errors.New("role cannot be empty")
+		}
+		if _, ok := authn.RolePermissions[role]; !ok {
+			return nil, errors.New("unsupported role: " + role)
+		}
+		if _, ok := seen[role]; ok {
+			continue
+		}
+		seen[role] = struct{}{}
+		normalized = append(normalized, role)
+	}
+	if len(normalized) == 0 {
+		return nil, errors.New("at least one role is required")
+	}
+	return normalized, nil
+}
+
+func canGrantAPIKeyRoles(authCtx *authn.AuthContext, roles []string) bool {
+	if authCtx == nil {
+		return false
+	}
+
+	callerPermissions := append([]string(nil), authCtx.Permissions...)
+	if len(callerPermissions) == 0 && authCtx.TeamRole != "" {
+		callerPermissions = authn.ExpandRolePermissions(authCtx.TeamRole)
+	}
+	if hasWildcardPermission(callerPermissions) {
+		return true
+	}
+
+	caller := &authn.AuthContext{Permissions: callerPermissions}
+	for _, permission := range authn.ExpandRolesPermissions(roles) {
+		if !caller.HasPermission(permission) {
+			return false
+		}
+	}
+	return true
+}
+
+func hasWildcardPermission(permissions []string) bool {
+	for _, permission := range permissions {
+		if permission == "*" || permission == "*:*" {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/gateway/http/handlers/apikey_test.go
+++ b/pkg/gateway/http/handlers/apikey_test.go
@@ -1,0 +1,196 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/authn"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
+	"go.uber.org/zap"
+)
+
+func TestNormalizeCreateAPIKeyRoles(t *testing.T) {
+	tests := []struct {
+		name    string
+		roles   []string
+		want    []string
+		wantErr bool
+	}{
+		{
+			name:  "defaults to developer",
+			roles: nil,
+			want:  []string{"developer"},
+		},
+		{
+			name:  "trims and deduplicates roles",
+			roles: []string{" admin ", "developer", "admin"},
+			want:  []string{"admin", "developer"},
+		},
+		{
+			name:    "rejects empty role",
+			roles:   []string{"viewer", " "},
+			wantErr: true,
+		},
+		{
+			name:    "rejects unsupported role",
+			roles:   []string{"owner"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeCreateAPIKeyRoles(tt.roles)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("normalize roles: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("roles = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCanGrantAPIKeyRolesRequiresPermissionSubset(t *testing.T) {
+	tests := []struct {
+		name       string
+		callerRole string
+		keyRoles   []string
+		want       bool
+	}{
+		{name: "admin can grant admin", callerRole: "admin", keyRoles: []string{"admin"}, want: true},
+		{name: "admin can grant viewer", callerRole: "admin", keyRoles: []string{"viewer"}, want: true},
+		{name: "developer cannot grant admin", callerRole: "developer", keyRoles: []string{"admin"}, want: false},
+		{name: "developer can grant builder", callerRole: "developer", keyRoles: []string{"builder"}, want: true},
+		{name: "developer can grant viewer", callerRole: "developer", keyRoles: []string{"viewer"}, want: true},
+		{name: "builder can grant builder", callerRole: "builder", keyRoles: []string{"builder"}, want: true},
+		{name: "builder cannot grant viewer", callerRole: "builder", keyRoles: []string{"viewer"}, want: false},
+		{name: "viewer can grant viewer", callerRole: "viewer", keyRoles: []string{"viewer"}, want: true},
+		{name: "viewer cannot grant builder", callerRole: "viewer", keyRoles: []string{"builder"}, want: false},
+		{name: "viewer cannot grant default developer", callerRole: "viewer", keyRoles: []string{"developer"}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			authCtx := &authn.AuthContext{
+				TeamRole:    tt.callerRole,
+				Permissions: authn.ExpandRolePermissions(tt.callerRole),
+			}
+			if got := canGrantAPIKeyRoles(authCtx, tt.keyRoles); got != tt.want {
+				t.Fatalf("canGrantAPIKeyRoles() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCanGrantAPIKeyRolesAllowsWildcardPermissions(t *testing.T) {
+	authCtx := &authn.AuthContext{Permissions: []string{"*"}}
+	if !canGrantAPIKeyRoles(authCtx, []string{"admin"}) {
+		t.Fatal("expected wildcard permissions to grant admin API key roles")
+	}
+}
+
+func TestCreateAPIKeyRejectsRoleEscalation(t *testing.T) {
+	t.Setenv("GIN_MODE", "release")
+	gin.SetMode(gin.ReleaseMode)
+
+	authCtx := &authn.AuthContext{
+		AuthMethod:  authn.AuthMethodJWT,
+		TeamID:      "team-1",
+		UserID:      "user-1",
+		TeamRole:    "viewer",
+		Permissions: authn.ExpandRolePermissions("viewer"),
+	}
+	rec := performCreateAPIKeyRequest(t, authCtx, map[string]any{
+		"name":  "admin-key",
+		"roles": []string{"admin"},
+	})
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusForbidden, rec.Body.String())
+	}
+	_, apiErr, err := spec.DecodeResponse[map[string]any](rec.Body)
+	if err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if apiErr == nil || apiErr.Code != spec.CodeForbidden {
+		t.Fatalf("unexpected api error: %#v", apiErr)
+	}
+}
+
+func TestCreateAPIKeyRejectsDefaultDeveloperEscalation(t *testing.T) {
+	t.Setenv("GIN_MODE", "release")
+	gin.SetMode(gin.ReleaseMode)
+
+	authCtx := &authn.AuthContext{
+		AuthMethod:  authn.AuthMethodJWT,
+		TeamID:      "team-1",
+		UserID:      "user-1",
+		TeamRole:    "viewer",
+		Permissions: authn.ExpandRolePermissions("viewer"),
+	}
+	rec := performCreateAPIKeyRequest(t, authCtx, map[string]any{
+		"name": "default-key",
+	})
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusForbidden, rec.Body.String())
+	}
+}
+
+func TestCreateAPIKeyRejectsUnsupportedRole(t *testing.T) {
+	t.Setenv("GIN_MODE", "release")
+	gin.SetMode(gin.ReleaseMode)
+
+	authCtx := &authn.AuthContext{
+		AuthMethod:  authn.AuthMethodJWT,
+		TeamID:      "team-1",
+		UserID:      "user-1",
+		TeamRole:    "admin",
+		Permissions: authn.ExpandRolePermissions("admin"),
+	}
+	rec := performCreateAPIKeyRequest(t, authCtx, map[string]any{
+		"name":  "owner-key",
+		"roles": []string{"owner"},
+	})
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+}
+
+func performCreateAPIKeyRequest(t *testing.T, authCtx *authn.AuthContext, body map[string]any) *httptest.ResponseRecorder {
+	t.Helper()
+
+	handler := &APIKeyHandler{
+		regionID: "aws-us-east-1",
+		logger:   zap.NewNop(),
+	}
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("auth_context", authCtx)
+		c.Next()
+	})
+	router.POST("/api-keys", handler.CreateAPIKey)
+
+	rawBody, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api-keys", bytes.NewReader(rawBody))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	return rec
+}


### PR DESCRIPTION
## Summary
- Validate requested API key roles before key creation.
- Reject unsupported roles with 400 and role grants outside caller permissions with 403.
- Update OpenAPI and generated API spec types for the new 403 behavior.

## Testing
- go test ./pkg/gateway/...
- go test ./regional-gateway/pkg/http ./global-gateway/pkg/http ./cluster-gateway/pkg/http
- pre-push hook: make manifests, make proto, make apispec, go fmt ./..., go mod tidy, go mod vendor, golangci-lint run ./...