### PR TITLE
Add platform-scoped API keys

### DIFF
--- a/cluster-gateway/pkg/http/handlers_internal.go
+++ b/cluster-gateway/pkg/http/handlers_internal.go
@@ -109,7 +109,7 @@ func (s *Server) generateManagerToken(authCtx *authn.AuthContext, claims *intern
 	if claims != nil && claims.IsSystem {
 		return s.internalAuthGen.GenerateSystem("manager", opts)
 	}
-	if authCtx != nil && authCtx.IsSystemAdmin && strings.TrimSpace(authCtx.TeamID) == "" {
+	if authCtx != nil && authCtx.IsSystemAdmin && (strings.TrimSpace(authCtx.TeamID) == "" || authCtx.AuthMethod == authn.AuthMethodAPIKey) {
 		return s.internalAuthGen.GenerateSystem("manager", opts)
 	}
 

--- a/cluster-gateway/pkg/http/handlers_manager_token_test.go
+++ b/cluster-gateway/pkg/http/handlers_manager_token_test.go
@@ -32,3 +32,36 @@ func TestGenerateManagerTokenUsesSystemTokenForTeamlessSystemAdmin(t *testing.T)
 		t.Fatalf("TeamID = %q, want empty", claims.TeamID)
 	}
 }
+
+func TestGenerateManagerTokenUsesSystemTokenForPlatformAPIKey(t *testing.T) {
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	server := &Server{internalAuthGen: internalauth.NewGenerator(internalauth.GeneratorConfig{Caller: "cluster-gateway", PrivateKey: privateKey, TTL: time.Minute})}
+
+	token, err := server.generateManagerToken(&authn.AuthContext{
+		AuthMethod:    authn.AuthMethodAPIKey,
+		TeamID:        "team-1",
+		UserID:        "user-1",
+		APIKeyID:      "key-1",
+		IsSystemAdmin: true,
+		Permissions:   []string{"*"},
+	}, nil, []string{authn.PermTemplateCreate})
+	if err != nil {
+		t.Fatalf("generateManagerToken: %v", err)
+	}
+	claims, err := internalauth.NewValidator(internalauth.ValidatorConfig{Target: "manager", PublicKey: publicKey}).Validate(token)
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if !claims.IsSystemToken() {
+		t.Fatalf("expected system token, got team_id=%q", claims.TeamID)
+	}
+	if claims.TeamID != "" {
+		t.Fatalf("TeamID = %q, want empty", claims.TeamID)
+	}
+	if len(claims.Permissions) != 1 || claims.Permissions[0] != authn.PermTemplateCreate {
+		t.Fatalf("Permissions = %v, want [%s]", claims.Permissions, authn.PermTemplateCreate)
+	}
+}

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -1032,7 +1032,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorEnvelope"
         "403":
-          description: Requested roles exceed caller permissions
+          description: Requested roles exceed caller permissions, or platform scope requires a system admin user session
           content:
             application/json:
               schema:
@@ -3805,6 +3805,9 @@ components:
           type: string
         name:
           type: string
+        scope:
+          type: string
+          description: "API key scope. team keys use roles for team-scoped access. platform keys grant system admin access and can only be created or managed by system admin user sessions."
         roles:
           type: array
           items:
@@ -3831,6 +3834,7 @@ components:
         - team_id
         - created_by
         - name
+        - scope
         - roles
         - is_active
         - expires_at
@@ -3841,6 +3845,9 @@ components:
       properties:
         name:
           type: string
+        scope:
+          type: string
+          description: "API key scope: team or platform. Defaults to team. platform keys grant system admin access, require a system admin user session, and do not support roles."
         roles:
           type: array
           description: "Requested API key roles. Supported roles: admin, developer, builder, viewer. The roles must not grant permissions outside the authenticated caller's permissions."
@@ -3857,6 +3864,8 @@ components:
           type: string
         name:
           type: string
+        scope:
+          type: string
         roles:
           type: array
           items:
@@ -3871,7 +3880,7 @@ components:
         created_at:
           type: string
           format: date-time
-      required: [id, name, roles, team_id, expires_at, created_at]
+      required: [id, name, scope, roles, team_id, expires_at, created_at]
     CurrentAPIKeyResponse:
       type: object
       properties:
@@ -3880,6 +3889,8 @@ components:
         team_id:
           type: string
         created_by:
+          type: string
+        scope:
           type: string
         roles:
           type: array
@@ -3894,7 +3905,7 @@ components:
         expires_at:
           type: string
           format: date-time
-      required: [id, team_id, created_by, roles, permissions, is_active, expires_at]
+      required: [id, team_id, created_by, scope, roles, permissions, is_active, expires_at]
     SuccessCreateAPIKeyResponse:
       allOf:
         - $ref: "#/components/schemas/SuccessEnvelope"

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -566,10 +566,13 @@ type APIKey struct {
 	LastUsedAt *time.Time `json:"last_used_at,omitempty"`
 	Name       string     `json:"name"`
 	Roles      []string   `json:"roles"`
-	TeamId     string     `json:"team_id"`
-	UpdatedAt  time.Time  `json:"updated_at"`
-	UsageCount *int64     `json:"usage_count,omitempty"`
-	UserId     *string    `json:"user_id"`
+
+	// Scope API key scope. team keys use roles for team-scoped access. platform keys grant system admin access and can only be created or managed by system admin user sessions.
+	Scope      string    `json:"scope"`
+	TeamId     string    `json:"team_id"`
+	UpdatedAt  time.Time `json:"updated_at"`
+	UsageCount *int64    `json:"usage_count,omitempty"`
+	UserId     *string   `json:"user_id"`
 }
 
 // AddTeamMemberRequest defines model for AddTeamMemberRequest.
@@ -746,6 +749,9 @@ type CreateAPIKeyRequest struct {
 
 	// Roles Requested API key roles. Supported roles: admin, developer, builder, viewer. The roles must not grant permissions outside the authenticated caller's permissions.
 	Roles *[]string `json:"roles,omitempty"`
+
+	// Scope API key scope: team or platform. Defaults to team. platform keys grant system admin access, require a system admin user session, and do not support roles.
+	Scope *string `json:"scope,omitempty"`
 }
 
 // CreateAPIKeyResponse defines model for CreateAPIKeyResponse.
@@ -756,6 +762,7 @@ type CreateAPIKeyResponse struct {
 	Key       *string   `json:"key,omitempty"`
 	Name      string    `json:"name"`
 	Roles     []string  `json:"roles"`
+	Scope     string    `json:"scope"`
 	TeamId    string    `json:"team_id"`
 }
 
@@ -887,6 +894,7 @@ type CurrentAPIKeyResponse struct {
 	IsActive    bool      `json:"is_active"`
 	Permissions []string  `json:"permissions"`
 	Roles       []string  `json:"roles"`
+	Scope       string    `json:"scope"`
 	TeamId      string    `json:"team_id"`
 }
 

--- a/pkg/gateway/apikey/repository.go
+++ b/pkg/gateway/apikey/repository.go
@@ -20,6 +20,11 @@ var (
 	ErrInactiveKey = errors.New("api key inactive")
 )
 
+const (
+	ScopeTeam     = "team"
+	ScopePlatform = "platform"
+)
+
 // APIKey represents an API key stored in the database.
 type APIKey struct {
 	ID         string     `json:"id"`
@@ -28,6 +33,7 @@ type APIKey struct {
 	UserID     *string    `json:"user_id,omitempty"`
 	CreatedBy  string     `json:"created_by"`
 	Name       string     `json:"name"`
+	Scope      string     `json:"scope"`
 	Roles      []string   `json:"roles"`
 	IsActive   bool       `json:"is_active"`
 	ExpiresAt  time.Time  `json:"expires_at"`
@@ -35,6 +41,21 @@ type APIKey struct {
 	UsageCount int64      `json:"usage_count"`
 	CreatedAt  time.Time  `json:"created_at"`
 	UpdatedAt  time.Time  `json:"updated_at"`
+}
+
+// NormalizeScope returns the canonical API key scope. Empty scope preserves
+// backward compatibility with keys created before scoped API keys existed.
+func NormalizeScope(scope string) (string, bool) {
+	switch strings.TrimSpace(scope) {
+	case "":
+		return ScopeTeam, true
+	case ScopeTeam:
+		return ScopeTeam, true
+	case ScopePlatform:
+		return ScopePlatform, true
+	default:
+		return "", false
+	}
 }
 
 // Repository provides database access for team-scoped API keys.
@@ -53,7 +74,12 @@ func (r *Repository) Pool() *pgxpool.Pool {
 }
 
 // CreateAPIKey creates a new API key.
-func (r *Repository) CreateAPIKey(ctx context.Context, teamID, regionID, userID, name string, roles []string, expiresAt time.Time) (*APIKey, string, error) {
+func (r *Repository) CreateAPIKey(ctx context.Context, teamID, regionID, userID, name, scope string, roles []string, expiresAt time.Time) (*APIKey, string, error) {
+	normalizedScope, ok := NormalizeScope(scope)
+	if !ok {
+		return nil, "", ErrInvalidKey
+	}
+
 	keyValue, err := NewKeyValue(regionID)
 	if err != nil {
 		return nil, "", err
@@ -67,21 +93,21 @@ func (r *Repository) CreateAPIKey(ctx context.Context, teamID, regionID, userID,
 
 	var key APIKey
 	err = r.pool.QueryRow(ctx, `
-		INSERT INTO api_keys (id, key_value, team_id, created_by, name, roles, is_active, expires_at, user_id)
-		VALUES ($1, $2, $3, $4, $5, $6, true, $7, $8)
-		RETURNING id, key_value, team_id, created_by, name, roles, is_active, expires_at, last_used_at, usage_count, created_at, updated_at
-	`, id, keyValue, teamID, userID, name, rolesJSON, expiresAt, userID,
+		INSERT INTO api_keys (id, key_value, team_id, created_by, name, roles, scope, is_active, expires_at, user_id)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, true, $8, $9)
+		RETURNING id, key_value, team_id, created_by, name, roles, scope, is_active, expires_at, last_used_at, usage_count, created_at, updated_at
+	`, id, keyValue, teamID, userID, name, rolesJSON, normalizedScope, expiresAt, userID,
 	).Scan(
 		&key.ID, &key.KeyValue, &key.TeamID, &key.CreatedBy, &key.Name,
-		&rolesJSON, &key.IsActive, &key.ExpiresAt,
+		&rolesJSON, &key.Scope, &key.IsActive, &key.ExpiresAt,
 		&key.LastUsed, &key.UsageCount, &key.CreatedAt, &key.UpdatedAt,
 	)
 	if err != nil {
 		return nil, "", fmt.Errorf("insert api key: %w", err)
 	}
 
-	if err := json.Unmarshal(rolesJSON, &key.Roles); err != nil {
-		return nil, "", fmt.Errorf("unmarshal roles: %w", err)
+	if err := normalizeAPIKeyRecord(&key, rolesJSON, false); err != nil {
+		return nil, "", err
 	}
 	return &key, keyValue, nil
 }
@@ -89,7 +115,7 @@ func (r *Repository) CreateAPIKey(ctx context.Context, teamID, regionID, userID,
 // GetAPIKeysByTeamID retrieves all API keys for a team.
 func (r *Repository) GetAPIKeysByTeamID(ctx context.Context, teamID string) ([]*APIKey, error) {
 	rows, err := r.pool.Query(ctx, `
-		SELECT id, key_value, team_id, created_by, name, roles,
+		SELECT id, key_value, team_id, created_by, name, roles, scope,
 		       is_active, expires_at, last_used_at, usage_count, created_at, updated_at
 		FROM api_keys
 		WHERE team_id = $1
@@ -106,15 +132,14 @@ func (r *Repository) GetAPIKeysByTeamID(ctx context.Context, teamID string) ([]*
 		var rolesJSON []byte
 		if err := rows.Scan(
 			&key.ID, &key.KeyValue, &key.TeamID, &key.CreatedBy, &key.Name,
-			&rolesJSON, &key.IsActive, &key.ExpiresAt,
+			&rolesJSON, &key.Scope, &key.IsActive, &key.ExpiresAt,
 			&key.LastUsed, &key.UsageCount, &key.CreatedAt, &key.UpdatedAt,
 		); err != nil {
 			return nil, fmt.Errorf("scan key: %w", err)
 		}
-		if len(rolesJSON) > 0 {
-			_ = json.Unmarshal(rolesJSON, &key.Roles)
+		if err := normalizeAPIKeyRecord(&key, rolesJSON, true); err != nil {
+			return nil, err
 		}
-		key.KeyValue = maskAPIKey(key.KeyValue)
 		keys = append(keys, &key)
 	}
 	return keys, nil
@@ -123,7 +148,7 @@ func (r *Repository) GetAPIKeysByTeamID(ctx context.Context, teamID string) ([]*
 // GetAPIKeysByUserID retrieves all API keys created by a user.
 func (r *Repository) GetAPIKeysByUserID(ctx context.Context, userID string) ([]*APIKey, error) {
 	rows, err := r.pool.Query(ctx, `
-		SELECT id, key_value, team_id, created_by, name, roles,
+		SELECT id, key_value, team_id, created_by, name, roles, scope,
 		       is_active, expires_at, last_used_at, usage_count, created_at, updated_at
 		FROM api_keys
 		WHERE user_id = $1
@@ -140,15 +165,14 @@ func (r *Repository) GetAPIKeysByUserID(ctx context.Context, userID string) ([]*
 		var rolesJSON []byte
 		if err := rows.Scan(
 			&key.ID, &key.KeyValue, &key.TeamID, &key.CreatedBy, &key.Name,
-			&rolesJSON, &key.IsActive, &key.ExpiresAt,
+			&rolesJSON, &key.Scope, &key.IsActive, &key.ExpiresAt,
 			&key.LastUsed, &key.UsageCount, &key.CreatedAt, &key.UpdatedAt,
 		); err != nil {
 			return nil, fmt.Errorf("scan key: %w", err)
 		}
-		if len(rolesJSON) > 0 {
-			_ = json.Unmarshal(rolesJSON, &key.Roles)
+		if err := normalizeAPIKeyRecord(&key, rolesJSON, true); err != nil {
+			return nil, err
 		}
-		key.KeyValue = maskAPIKey(key.KeyValue)
 		keys = append(keys, &key)
 	}
 	return keys, nil
@@ -185,13 +209,13 @@ func (r *Repository) GetAPIKeyByID(ctx context.Context, id string) (*APIKey, err
 	var key APIKey
 	var rolesJSON []byte
 	err := r.pool.QueryRow(ctx, `
-		SELECT id, key_value, team_id, created_by, name, roles,
+		SELECT id, key_value, team_id, created_by, name, roles, scope,
 		       is_active, expires_at, last_used_at, usage_count, created_at, updated_at
 		FROM api_keys
 		WHERE id = $1
 	`, id).Scan(
 		&key.ID, &key.KeyValue, &key.TeamID, &key.CreatedBy, &key.Name,
-		&rolesJSON, &key.IsActive, &key.ExpiresAt,
+		&rolesJSON, &key.Scope, &key.IsActive, &key.ExpiresAt,
 		&key.LastUsed, &key.UsageCount, &key.CreatedAt, &key.UpdatedAt,
 	)
 	if err != nil {
@@ -201,10 +225,9 @@ func (r *Repository) GetAPIKeyByID(ctx context.Context, id string) (*APIKey, err
 		return nil, fmt.Errorf("query api key: %w", err)
 	}
 
-	if len(rolesJSON) > 0 {
-		_ = json.Unmarshal(rolesJSON, &key.Roles)
+	if err := normalizeAPIKeyRecord(&key, rolesJSON, true); err != nil {
+		return nil, err
 	}
-	key.KeyValue = maskAPIKey(key.KeyValue)
 	return &key, nil
 }
 
@@ -217,13 +240,13 @@ func (r *Repository) ValidateAPIKey(ctx context.Context, keyValue string) (*APIK
 	var key APIKey
 	var rolesJSON []byte
 	err := r.pool.QueryRow(ctx, `
-		SELECT id, key_value, team_id, created_by, name, roles,
+		SELECT id, key_value, team_id, created_by, name, roles, scope,
 		       is_active, expires_at, last_used_at, usage_count, created_at, updated_at, user_id
 		FROM api_keys
 		WHERE key_value = $1
 	`, keyValue).Scan(
 		&key.ID, &key.KeyValue, &key.TeamID, &key.CreatedBy,
-		&key.Name, &rolesJSON, &key.IsActive,
+		&key.Name, &rolesJSON, &key.Scope, &key.IsActive,
 		&key.ExpiresAt, &key.LastUsed, &key.UsageCount,
 		&key.CreatedAt, &key.UpdatedAt, &key.UserID,
 	)
@@ -234,10 +257,8 @@ func (r *Repository) ValidateAPIKey(ctx context.Context, keyValue string) (*APIK
 		return nil, fmt.Errorf("query api key: %w", err)
 	}
 
-	if len(rolesJSON) > 0 {
-		if err := json.Unmarshal(rolesJSON, &key.Roles); err != nil {
-			return nil, fmt.Errorf("parse roles: %w", err)
-		}
+	if err := normalizeAPIKeyRecord(&key, rolesJSON, false); err != nil {
+		return nil, err
 	}
 	if !key.IsActive {
 		return nil, ErrInactiveKey
@@ -255,6 +276,23 @@ func (r *Repository) ValidateAPIKey(ctx context.Context, keyValue string) (*APIK
 	}()
 
 	return &key, nil
+}
+
+func normalizeAPIKeyRecord(key *APIKey, rolesJSON []byte, maskKey bool) error {
+	if len(rolesJSON) > 0 {
+		if err := json.Unmarshal(rolesJSON, &key.Roles); err != nil {
+			return fmt.Errorf("parse roles: %w", err)
+		}
+	}
+	scope, ok := NormalizeScope(key.Scope)
+	if !ok {
+		return fmt.Errorf("invalid api key scope: %s", key.Scope)
+	}
+	key.Scope = scope
+	if maskKey {
+		key.KeyValue = maskAPIKey(key.KeyValue)
+	}
+	return nil
 }
 
 func maskAPIKey(key string) string {

--- a/pkg/gateway/http/handlers/apikey.go
+++ b/pkg/gateway/http/handlers/apikey.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"strings"
@@ -17,10 +18,19 @@ import (
 
 // APIKeyHandler handles API key endpoints
 type APIKeyHandler struct {
-	keys     *apikey.Repository
+	keys     apiKeyStore
 	identity *identity.Repository
 	logger   *zap.Logger
 	regionID string
+}
+
+type apiKeyStore interface {
+	CreateAPIKey(ctx context.Context, teamID, regionID, userID, name, scope string, roles []string, expiresAt time.Time) (*apikey.APIKey, string, error)
+	GetAPIKeysByTeamID(ctx context.Context, teamID string) ([]*apikey.APIKey, error)
+	GetAPIKeysByUserID(ctx context.Context, userID string) ([]*apikey.APIKey, error)
+	GetAPIKeyByID(ctx context.Context, id string) (*apikey.APIKey, error)
+	DeleteAPIKey(ctx context.Context, id string) error
+	DeactivateAPIKey(ctx context.Context, id string) error
 }
 
 // NewAPIKeyHandler creates a new API key handler
@@ -56,6 +66,7 @@ func (h *APIKeyHandler) ListAPIKeys(c *gin.Context) {
 		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to get API keys")
 		return
 	}
+	keys = filterVisibleAPIKeys(authCtx, keys)
 
 	spec.JSONSuccess(c, http.StatusOK, gin.H{"api_keys": keys})
 }
@@ -63,6 +74,7 @@ func (h *APIKeyHandler) ListAPIKeys(c *gin.Context) {
 // CreateAPIKeyRequest is the request body for creating an API key
 type CreateAPIKeyRequest struct {
 	Name      string   `json:"name" binding:"required"`
+	Scope     string   `json:"scope"`
 	Roles     []string `json:"roles"`
 	ExpiresIn string   `json:"expires_in"` // e.g., "30d", "90d", "365d", "never"
 }
@@ -71,6 +83,7 @@ type CreateAPIKeyRequest struct {
 type CreateAPIKeyResponse struct {
 	ID        string    `json:"id"`
 	Name      string    `json:"name"`
+	Scope     string    `json:"scope"`
 	Roles     []string  `json:"roles"`
 	TeamID    string    `json:"team_id"`
 	Key       string    `json:"key,omitempty"` // Only returned on creation
@@ -83,6 +96,7 @@ type CurrentAPIKeyResponse struct {
 	ID          string    `json:"id"`
 	TeamID      string    `json:"team_id"`
 	CreatedBy   string    `json:"created_by"`
+	Scope       string    `json:"scope"`
 	Roles       []string  `json:"roles"`
 	Permissions []string  `json:"permissions"`
 	IsActive    bool      `json:"is_active"`
@@ -113,6 +127,7 @@ func (h *APIKeyHandler) GetCurrentAPIKey(c *gin.Context) {
 			ID:          key.ID,
 			TeamID:      key.TeamID,
 			CreatedBy:   key.CreatedBy,
+			Scope:       key.Scope,
 			Roles:       key.Roles,
 			Permissions: append([]string(nil), authCtx.Permissions...),
 			IsActive:    key.IsActive,
@@ -155,15 +170,34 @@ func (h *APIKeyHandler) CreateAPIKey(c *gin.Context) {
 		expiresAt = time.Now().AddDate(100, 0, 0) // ~100 years
 	}
 
-	// Default roles if not provided
-	roles, err := normalizeCreateAPIKeyRoles(req.Roles)
+	scope, err := normalizeCreateAPIKeyScope(req.Scope)
 	if err != nil {
 		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
 		return
 	}
-	if !canGrantAPIKeyRoles(authCtx, roles) {
-		spec.JSONError(c, http.StatusForbidden, spec.CodeForbidden, "cannot create API key with roles that grant permissions outside the caller's permissions")
-		return
+
+	var roles []string
+	if scope == apikey.ScopePlatform {
+		if !canManagePlatformAPIKeys(authCtx) {
+			spec.JSONError(c, http.StatusForbidden, spec.CodeForbidden, "platform API keys require system admin user access")
+			return
+		}
+		if len(req.Roles) > 0 {
+			spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "platform API keys do not support roles")
+			return
+		}
+		roles = []string{}
+	} else {
+		// Default roles if not provided
+		roles, err = normalizeCreateAPIKeyRoles(req.Roles)
+		if err != nil {
+			spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
+			return
+		}
+		if !canGrantAPIKeyRoles(authCtx, roles) {
+			spec.JSONError(c, http.StatusForbidden, spec.CodeForbidden, "cannot create API key with roles that grant permissions outside the caller's permissions")
+			return
+		}
 	}
 
 	regionID := h.regionID
@@ -188,6 +222,7 @@ func (h *APIKeyHandler) CreateAPIKey(c *gin.Context) {
 		regionID,
 		authCtx.UserID,
 		req.Name,
+		scope,
 		roles,
 		expiresAt,
 	)
@@ -201,6 +236,7 @@ func (h *APIKeyHandler) CreateAPIKey(c *gin.Context) {
 	response := &CreateAPIKeyResponse{
 		ID:        key.ID,
 		Name:      key.Name,
+		Scope:     key.Scope,
 		Roles:     key.Roles,
 		TeamID:    key.TeamID,
 		Key:       keyValue, // Full key, only shown at creation
@@ -230,6 +266,11 @@ func (h *APIKeyHandler) DeleteAPIKey(c *gin.Context) {
 		}
 		h.logger.Error("Failed to get API key", zap.Error(err))
 		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to get API key")
+		return
+	}
+
+	if key.Scope == apikey.ScopePlatform && !canManagePlatformAPIKeys(authCtx) {
+		spec.JSONError(c, http.StatusForbidden, spec.CodeForbidden, "not authorized to delete this API key")
 		return
 	}
 
@@ -274,6 +315,11 @@ func (h *APIKeyHandler) DeactivateAPIKey(c *gin.Context) {
 		return
 	}
 
+	if key.Scope == apikey.ScopePlatform && !canManagePlatformAPIKeys(authCtx) {
+		spec.JSONError(c, http.StatusForbidden, spec.CodeForbidden, "not authorized to deactivate this API key")
+		return
+	}
+
 	// Verify the key belongs to the user's team
 	if key.TeamID != authCtx.TeamID {
 		_, err := h.identity.GetTeamMember(c.Request.Context(), key.TeamID, authCtx.UserID)
@@ -290,6 +336,14 @@ func (h *APIKeyHandler) DeactivateAPIKey(c *gin.Context) {
 	}
 
 	spec.JSONSuccess(c, http.StatusOK, gin.H{"message": "API key deactivated"})
+}
+
+func normalizeCreateAPIKeyScope(scope string) (string, error) {
+	normalized, ok := apikey.NormalizeScope(scope)
+	if !ok {
+		return "", errors.New("scope must be team or platform")
+	}
+	return normalized, nil
 }
 
 func normalizeCreateAPIKeyRoles(roles []string) ([]string, error) {
@@ -339,6 +393,27 @@ func canGrantAPIKeyRoles(authCtx *authn.AuthContext, roles []string) bool {
 		}
 	}
 	return true
+}
+
+func canManagePlatformAPIKeys(authCtx *authn.AuthContext) bool {
+	return authCtx != nil && authCtx.AuthMethod == authn.AuthMethodJWT && authCtx.IsSystemAdmin
+}
+
+func filterVisibleAPIKeys(authCtx *authn.AuthContext, keys []*apikey.APIKey) []*apikey.APIKey {
+	if len(keys) == 0 {
+		return keys
+	}
+	filtered := make([]*apikey.APIKey, 0, len(keys))
+	for _, key := range keys {
+		if key == nil {
+			continue
+		}
+		if key.Scope == apikey.ScopePlatform && !canManagePlatformAPIKeys(authCtx) {
+			continue
+		}
+		filtered = append(filtered, key)
+	}
+	return filtered
 }
 
 func hasWildcardPermission(permissions []string) bool {

--- a/pkg/gateway/http/handlers/apikey_test.go
+++ b/pkg/gateway/http/handlers/apikey_test.go
@@ -2,13 +2,16 @@ package handlers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/apikey"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/authn"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"go.uber.org/zap"
@@ -62,6 +65,38 @@ func TestNormalizeCreateAPIKeyRoles(t *testing.T) {
 	}
 }
 
+func TestNormalizeCreateAPIKeyScope(t *testing.T) {
+	tests := []struct {
+		name    string
+		scope   string
+		want    string
+		wantErr bool
+	}{
+		{name: "defaults to team", want: apikey.ScopeTeam},
+		{name: "accepts team", scope: "team", want: apikey.ScopeTeam},
+		{name: "accepts platform", scope: "platform", want: apikey.ScopePlatform},
+		{name: "rejects unknown", scope: "admin", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeCreateAPIKeyScope(tt.scope)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("normalize scope: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("scope = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestCanGrantAPIKeyRolesRequiresPermissionSubset(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -98,6 +133,168 @@ func TestCanGrantAPIKeyRolesAllowsWildcardPermissions(t *testing.T) {
 	authCtx := &authn.AuthContext{Permissions: []string{"*"}}
 	if !canGrantAPIKeyRoles(authCtx, []string{"admin"}) {
 		t.Fatal("expected wildcard permissions to grant admin API key roles")
+	}
+}
+
+func TestCreateAPIKeyAllowsPlatformScopeForSystemAdminJWT(t *testing.T) {
+	t.Setenv("GIN_MODE", "release")
+	gin.SetMode(gin.ReleaseMode)
+
+	authCtx := &authn.AuthContext{
+		AuthMethod:    authn.AuthMethodJWT,
+		TeamID:        "team-1",
+		UserID:        "user-1",
+		IsSystemAdmin: true,
+		Permissions:   []string{"*"},
+	}
+	store := &fakeAPIKeyStore{}
+	rec := performCreateAPIKeyRequestWithStore(t, store, authCtx, map[string]any{
+		"name":       "platform-key",
+		"scope":      "platform",
+		"expires_in": "never",
+	})
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	if store.createdScope != apikey.ScopePlatform {
+		t.Fatalf("created scope = %q, want %q", store.createdScope, apikey.ScopePlatform)
+	}
+	if len(store.createdRoles) != 0 {
+		t.Fatalf("created roles = %v, want empty", store.createdRoles)
+	}
+	if !store.createdExpiresAt.After(time.Now().AddDate(99, 0, 0)) {
+		t.Fatalf("expected never expiration to be about 100 years out, got %s", store.createdExpiresAt)
+	}
+
+	response, apiErr, err := spec.DecodeResponse[CreateAPIKeyResponse](rec.Body)
+	if err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if apiErr != nil {
+		t.Fatalf("unexpected api error: %#v", apiErr)
+	}
+	if response.Scope != apikey.ScopePlatform || len(response.Roles) != 0 {
+		t.Fatalf("unexpected response: %#v", response)
+	}
+}
+
+func TestCreateAPIKeyRejectsPlatformScopeWithoutSystemAdminJWT(t *testing.T) {
+	t.Setenv("GIN_MODE", "release")
+	gin.SetMode(gin.ReleaseMode)
+
+	tests := []struct {
+		name    string
+		authCtx *authn.AuthContext
+	}{
+		{
+			name: "team admin jwt",
+			authCtx: &authn.AuthContext{
+				AuthMethod:  authn.AuthMethodJWT,
+				TeamID:      "team-1",
+				UserID:      "user-1",
+				TeamRole:    "admin",
+				Permissions: authn.ExpandRolePermissions("admin"),
+			},
+		},
+		{
+			name: "platform api key cannot create more platform keys",
+			authCtx: &authn.AuthContext{
+				AuthMethod:    authn.AuthMethodAPIKey,
+				TeamID:        "team-1",
+				UserID:        "user-1",
+				APIKeyID:      "key-1",
+				IsSystemAdmin: true,
+				Permissions:   []string{"*"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := performCreateAPIKeyRequest(t, tt.authCtx, map[string]any{
+				"name":  "platform-key",
+				"scope": "platform",
+			})
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusForbidden, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestCreateAPIKeyRejectsPlatformRoles(t *testing.T) {
+	t.Setenv("GIN_MODE", "release")
+	gin.SetMode(gin.ReleaseMode)
+
+	authCtx := &authn.AuthContext{
+		AuthMethod:    authn.AuthMethodJWT,
+		TeamID:        "team-1",
+		UserID:        "user-1",
+		IsSystemAdmin: true,
+		Permissions:   []string{"*"},
+	}
+	rec := performCreateAPIKeyRequest(t, authCtx, map[string]any{
+		"name":  "platform-key",
+		"scope": "platform",
+		"roles": []string{"admin"},
+	})
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+}
+
+func TestFilterVisibleAPIKeysHidesPlatformKeysOutsideSystemAdminJWT(t *testing.T) {
+	keys := []*apikey.APIKey{
+		{ID: "team-key", Scope: apikey.ScopeTeam},
+		{ID: "platform-key", Scope: apikey.ScopePlatform},
+	}
+
+	nonAdmin := &authn.AuthContext{AuthMethod: authn.AuthMethodJWT, UserID: "user-1"}
+	got := filterVisibleAPIKeys(nonAdmin, keys)
+	if len(got) != 1 || got[0].ID != "team-key" {
+		t.Fatalf("visible keys for non-admin = %#v", got)
+	}
+
+	platformAPIKey := &authn.AuthContext{AuthMethod: authn.AuthMethodAPIKey, UserID: "user-1", IsSystemAdmin: true}
+	got = filterVisibleAPIKeys(platformAPIKey, keys)
+	if len(got) != 1 || got[0].ID != "team-key" {
+		t.Fatalf("visible keys for platform api key = %#v", got)
+	}
+
+	systemAdminJWT := &authn.AuthContext{AuthMethod: authn.AuthMethodJWT, UserID: "user-1", IsSystemAdmin: true}
+	got = filterVisibleAPIKeys(systemAdminJWT, keys)
+	if len(got) != 2 {
+		t.Fatalf("visible keys for system admin jwt = %#v", got)
+	}
+}
+
+func TestDeleteAPIKeyRejectsPlatformKeyForTeamAdmin(t *testing.T) {
+	t.Setenv("GIN_MODE", "release")
+	gin.SetMode(gin.ReleaseMode)
+
+	store := &fakeAPIKeyStore{
+		key: &apikey.APIKey{
+			ID:     "key-1",
+			TeamID: "team-1",
+			Scope:  apikey.ScopePlatform,
+		},
+	}
+	authCtx := &authn.AuthContext{
+		AuthMethod:  authn.AuthMethodJWT,
+		TeamID:      "team-1",
+		UserID:      "user-1",
+		TeamRole:    "admin",
+		Permissions: authn.ExpandRolePermissions("admin"),
+	}
+	rec := performDeleteAPIKeyRequest(t, store, authCtx, "key-1")
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusForbidden, rec.Body.String())
+	}
+	if store.deletedID != "" {
+		t.Fatalf("deleted id = %q, want empty", store.deletedID)
 	}
 }
 
@@ -172,8 +369,14 @@ func TestCreateAPIKeyRejectsUnsupportedRole(t *testing.T) {
 
 func performCreateAPIKeyRequest(t *testing.T, authCtx *authn.AuthContext, body map[string]any) *httptest.ResponseRecorder {
 	t.Helper()
+	return performCreateAPIKeyRequestWithStore(t, nil, authCtx, body)
+}
+
+func performCreateAPIKeyRequestWithStore(t *testing.T, store apiKeyStore, authCtx *authn.AuthContext, body map[string]any) *httptest.ResponseRecorder {
+	t.Helper()
 
 	handler := &APIKeyHandler{
+		keys:     store,
 		regionID: "aws-us-east-1",
 		logger:   zap.NewNop(),
 	}
@@ -193,4 +396,72 @@ func performCreateAPIKeyRequest(t *testing.T, authCtx *authn.AuthContext, body m
 	rec := httptest.NewRecorder()
 	router.ServeHTTP(rec, req)
 	return rec
+}
+
+func performDeleteAPIKeyRequest(t *testing.T, store apiKeyStore, authCtx *authn.AuthContext, keyID string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	handler := &APIKeyHandler{
+		keys:   store,
+		logger: zap.NewNop(),
+	}
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("auth_context", authCtx)
+		c.Next()
+	})
+	router.DELETE("/api-keys/:id", handler.DeleteAPIKey)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api-keys/"+keyID, nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	return rec
+}
+
+type fakeAPIKeyStore struct {
+	key              *apikey.APIKey
+	createdScope     string
+	createdRoles     []string
+	createdExpiresAt time.Time
+	deletedID        string
+	deactivatedID    string
+}
+
+func (s *fakeAPIKeyStore) CreateAPIKey(_ context.Context, teamID, _ string, userID, name, scope string, roles []string, expiresAt time.Time) (*apikey.APIKey, string, error) {
+	s.createdScope = scope
+	s.createdRoles = append([]string(nil), roles...)
+	s.createdExpiresAt = expiresAt
+	return &apikey.APIKey{
+		ID:        "key-1",
+		TeamID:    teamID,
+		CreatedBy: userID,
+		Name:      name,
+		Scope:     scope,
+		Roles:     roles,
+		IsActive:  true,
+		ExpiresAt: expiresAt,
+		CreatedAt: time.Now(),
+	}, "s0_aws-us-east-1_test", nil
+}
+
+func (s *fakeAPIKeyStore) GetAPIKeysByTeamID(context.Context, string) ([]*apikey.APIKey, error) {
+	return []*apikey.APIKey{s.key}, nil
+}
+
+func (s *fakeAPIKeyStore) GetAPIKeysByUserID(context.Context, string) ([]*apikey.APIKey, error) {
+	return []*apikey.APIKey{s.key}, nil
+}
+
+func (s *fakeAPIKeyStore) GetAPIKeyByID(context.Context, string) (*apikey.APIKey, error) {
+	return s.key, nil
+}
+
+func (s *fakeAPIKeyStore) DeleteAPIKey(_ context.Context, id string) error {
+	s.deletedID = id
+	return nil
+}
+
+func (s *fakeAPIKeyStore) DeactivateAPIKey(_ context.Context, id string) error {
+	s.deactivatedID = id
+	return nil
 }

--- a/pkg/gateway/middleware/auth.go
+++ b/pkg/gateway/middleware/auth.go
@@ -114,12 +114,24 @@ func (m *AuthMiddleware) authenticateAPIKey(c *gin.Context, keyValue string) (*a
 		userID = strings.TrimSpace(*apiKey.UserID)
 	}
 
+	scope, ok := apikey.NormalizeScope(apiKey.Scope)
+	if !ok {
+		return nil, ErrInvalidToken
+	}
+	permissions := authn.ExpandRolesPermissions(apiKey.Roles)
+	isSystemAdmin := false
+	if scope == apikey.ScopePlatform {
+		permissions = []string{"*"}
+		isSystemAdmin = true
+	}
+
 	return &authn.AuthContext{
-		AuthMethod:  authn.AuthMethodAPIKey,
-		TeamID:      apiKey.TeamID,
-		UserID:      userID,
-		APIKeyID:    apiKey.ID,
-		Permissions: authn.ExpandRolesPermissions(apiKey.Roles),
+		AuthMethod:    authn.AuthMethodAPIKey,
+		TeamID:        apiKey.TeamID,
+		UserID:        userID,
+		APIKeyID:      apiKey.ID,
+		IsSystemAdmin: isSystemAdmin,
+		Permissions:   permissions,
 	}, nil
 }
 

--- a/pkg/gateway/middleware/auth_test.go
+++ b/pkg/gateway/middleware/auth_test.go
@@ -150,6 +150,39 @@ func TestAuthMiddleware_APIKeyFallsBackToCreatorUserID(t *testing.T) {
 	}
 }
 
+func TestAuthMiddleware_PlatformAPIKeySetsSystemAdmin(t *testing.T) {
+	t.Setenv("GIN_MODE", "release")
+
+	ownerID := "user-1"
+	req := httptest.NewRequest("GET", "/internal/v1/metering/status", nil)
+	req.Header.Set("Authorization", "Bearer s0_test")
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = req
+
+	middleware := NewAuthMiddleware(staticAPIKeyValidator{key: &apikey.APIKey{
+		ID:        "key-1",
+		TeamID:    "team-1",
+		UserID:    &ownerID,
+		CreatedBy: "creator-1",
+		Scope:     apikey.ScopePlatform,
+		Roles:     []string{"viewer"},
+	}}, "test-secret", nil, zap.NewNop())
+	authCtx, err := middleware.AuthenticateRequest(ctx)
+	if err != nil {
+		t.Fatalf("authenticate request: %v", err)
+	}
+	if !authCtx.IsSystemAdmin {
+		t.Fatal("expected platform API key to set system admin")
+	}
+	if !authCtx.HasPermission(authn.PermTemplateDelete) || !authCtx.HasPermission("anything:anywhere") {
+		t.Fatalf("expected wildcard permissions, got %v", authCtx.Permissions)
+	}
+	if authCtx.AuthMethod != authn.AuthMethodAPIKey || authCtx.APIKeyID != "key-1" {
+		t.Fatalf("unexpected auth context: %+v", authCtx)
+	}
+}
+
 func TestAuthMiddleware_JWTAccessTokenExplicitTeamHeader(t *testing.T) {
 	t.Setenv("GIN_MODE", "release")
 
@@ -368,6 +401,17 @@ func TestAuthMiddleware_RequireSystemAdmin(t *testing.T) {
 				AuthMethod:    authn.AuthMethodJWT,
 				UserID:        "user-1",
 				TeamID:        "team-1",
+				IsSystemAdmin: true,
+			},
+			wantStatus: http.StatusNoContent,
+		},
+		{
+			name: "platform api key allowed",
+			authCtx: &authn.AuthContext{
+				AuthMethod:    authn.AuthMethodAPIKey,
+				UserID:        "user-1",
+				TeamID:        "team-1",
+				APIKeyID:      "key-1",
 				IsSystemAdmin: true,
 			},
 			wantStatus: http.StatusNoContent,

--- a/pkg/gateway/migrations/00007_add_api_key_scope.sql
+++ b/pkg/gateway/migrations/00007_add_api_key_scope.sql
@@ -1,0 +1,16 @@
+-- +goose Up
+ALTER TABLE IF EXISTS api_keys
+    ADD COLUMN IF NOT EXISTS scope TEXT NOT NULL DEFAULT 'team';
+
+ALTER TABLE IF EXISTS api_keys
+    DROP CONSTRAINT IF EXISTS api_keys_scope_check;
+
+ALTER TABLE IF EXISTS api_keys
+    ADD CONSTRAINT api_keys_scope_check CHECK (scope IN ('team', 'platform'));
+
+-- +goose Down
+ALTER TABLE IF EXISTS api_keys
+    DROP CONSTRAINT IF EXISTS api_keys_scope_check;
+
+ALTER TABLE IF EXISTS api_keys
+    DROP COLUMN IF EXISTS scope;

--- a/regional-gateway/pkg/http/cluster_cache.go
+++ b/regional-gateway/pkg/http/cluster_cache.go
@@ -160,7 +160,7 @@ func (s *Server) generateInternalToken(authCtx *authn.AuthContext, target string
 	if authCtx == nil {
 		return s.internalAuthGen.GenerateSystem(target, internalauth.GenerateOptions{})
 	}
-	if authCtx.TeamID == "" {
+	if authCtx.TeamID == "" || (authCtx.AuthMethod == authn.AuthMethodAPIKey && authCtx.IsSystemAdmin) {
 		return s.internalAuthGen.GenerateSystem(
 			target,
 			internalauth.GenerateOptions{

--- a/regional-gateway/pkg/http/cluster_cache_test.go
+++ b/regional-gateway/pkg/http/cluster_cache_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/authn"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"go.uber.org/zap"
@@ -80,5 +81,38 @@ func TestGetClusterGatewayURLForClusterRefreshesCacheWithSystemToken(t *testing.
 	}
 	if cached := server.getClusterFromCache("cluster-a"); cached != got {
 		t.Fatalf("cached cluster gateway url = %q, want %q", cached, got)
+	}
+}
+
+func TestGenerateInternalTokenUsesSystemTokenForPlatformAPIKey(t *testing.T) {
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	server := &Server{internalAuthGen: internalauth.NewGenerator(internalauth.GeneratorConfig{Caller: "regional-gateway", PrivateKey: privateKey, TTL: time.Minute})}
+
+	token, err := server.generateInternalToken(&authn.AuthContext{
+		AuthMethod:    authn.AuthMethodAPIKey,
+		TeamID:        "team-1",
+		UserID:        "user-1",
+		APIKeyID:      "key-1",
+		IsSystemAdmin: true,
+		Permissions:   []string{"*"},
+	}, "scheduler")
+	if err != nil {
+		t.Fatalf("generateInternalToken: %v", err)
+	}
+	claims, err := internalauth.NewValidator(internalauth.ValidatorConfig{Target: "scheduler", PublicKey: publicKey}).Validate(token)
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if !claims.IsSystemToken() {
+		t.Fatalf("expected system token, got team_id=%q", claims.TeamID)
+	}
+	if claims.TeamID != "" {
+		t.Fatalf("TeamID = %q, want empty", claims.TeamID)
+	}
+	if len(claims.Permissions) != 1 || claims.Permissions[0] != "*" {
+		t.Fatalf("Permissions = %v, want [*]", claims.Permissions)
 	}
 }

--- a/regional-gateway/pkg/http/server_metering_routes_test.go
+++ b/regional-gateway/pkg/http/server_metering_routes_test.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -8,6 +9,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/apikey"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/authn"
 	gatewayhandlers "github.com/sandbox0-ai/sandbox0/pkg/gateway/http/handlers"
 	gatewaymiddleware "github.com/sandbox0-ai/sandbox0/pkg/gateway/middleware"
@@ -73,6 +75,28 @@ func TestSetupMeteringRoutesAllowsSystemAdmin(t *testing.T) {
 	}
 }
 
+func TestSetupMeteringRoutesAllowsPlatformAPIKey(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	server := testMeteringRouteServer()
+	server.authMiddleware = gatewaymiddleware.NewAuthMiddleware(staticAPIKeyValidator{key: &apikey.APIKey{
+		ID:        "key-1",
+		TeamID:    "team-1",
+		CreatedBy: "user-1",
+		Scope:     apikey.ScopePlatform,
+	}}, "secret", server.jwtIssuer, zap.NewNop())
+	server.setupMeteringRoutes()
+
+	req := httptest.NewRequest(http.MethodGet, "/internal/v1/metering/status", nil)
+	req.Header.Set("Authorization", "Bearer s0_test")
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+	}
+}
+
 func testMeteringRouteServer() *Server {
 	logger := zap.NewNop()
 	jwtIssuer := authn.NewIssuer("regional-gateway", "secret", time.Minute, time.Hour)
@@ -84,4 +108,12 @@ func testMeteringRouteServer() *Server {
 		jwtIssuer:       jwtIssuer,
 		meteringHandler: gatewayhandlers.NewMeteringHandler(nil, "aws-us-east-1", logger),
 	}
+}
+
+type staticAPIKeyValidator struct {
+	key *apikey.APIKey
+}
+
+func (v staticAPIKeyValidator) ValidateAPIKey(context.Context, string) (*apikey.APIKey, error) {
+	return v.key, nil
 }

--- a/tests/integration/internal/tests/cluster-gateway/auth_test.go
+++ b/tests/integration/internal/tests/cluster-gateway/auth_test.go
@@ -161,7 +161,7 @@ func TestClusterGatewayIntegration_PublicAuthAPIKey(t *testing.T) {
 		t.Fatalf("set team home region: %v", err)
 	}
 
-	_, keyValue, err := apiKeyRepo.CreateAPIKey(ctx, team.ID, "aws-us-east-1", user.ID, "test-key", []string{"admin"}, time.Now().Add(time.Hour))
+	_, keyValue, err := apiKeyRepo.CreateAPIKey(ctx, team.ID, "aws-us-east-1", user.ID, "test-key", gatewayapikey.ScopeTeam, []string{"admin"}, time.Now().Add(time.Hour))
 	if err != nil {
 		t.Fatalf("create api key: %v", err)
 	}
@@ -195,7 +195,7 @@ func TestClusterGatewayIntegration_APIKeyCanBeCreatedWithoutLocalTeamOrUserRow(t
 		t.Fatalf("delete local user row: %v", err)
 	}
 
-	key, keyValue, err := apiKeyRepo.CreateAPIKey(ctx, team.ID, "aws-us-east-1", user.ID, "test-key", []string{"developer"}, time.Now().Add(time.Hour))
+	key, keyValue, err := apiKeyRepo.CreateAPIKey(ctx, team.ID, "aws-us-east-1", user.ID, "test-key", gatewayapikey.ScopeTeam, []string{"developer"}, time.Now().Add(time.Hour))
 	if err != nil {
 		t.Fatalf("create api key without local team or user row: %v", err)
 	}


### PR DESCRIPTION
## Summary
- Add persisted API key scope (`team`/`platform`) with a gateway migration and API/OpenAPI response fields.
- Treat `platform` API keys as system-admin principals for existing `RequireSystemAdmin` automation routes.
- Keep platform key creation and management restricted to system admin JWT sessions, while preserving team key role-subset checks.

Closes #210

## Testing
- `make apispec`
- `make proto`
- `go test ./pkg/gateway/http/handlers ./pkg/gateway/middleware ./pkg/gateway/apikey -count=1`
- `go test ./pkg/gateway/... ./regional-gateway/pkg/http ./cluster-gateway/pkg/http ./global-gateway/pkg/http ./tests/integration/internal/tests/cluster-gateway -count=1`
- `go test $(go list ./... | rg -v '/tests/e2e|/tests/integration/internal/tests/manager') -count=1`
- `golangci-lint run ./...`
- pre-push hook: `make manifests`, `make proto`, `make apispec`, `go fmt ./...`, `go mod tidy`, `go mod vendor`, `golangci-lint run ./...`
- `go test ./... -count=1` fails locally because Docker is unavailable for kind e2e and the manager integration environment lacks `/config/internal_jwt_public.key`.