### PR TITLE
Add OIDC web login handoff

### DIFF
--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -206,6 +206,12 @@ paths:
           schema:
             type: string
           required: false
+        - name: web_login
+          in: query
+          schema:
+            type: boolean
+          required: false
+          description: When true, the OIDC callback redirects to return_url with a short-lived login_code for server-side exchange.
       responses:
         "302":
           description: Redirect to OIDC provider
@@ -239,7 +245,7 @@ paths:
             type: string
       responses:
         "302":
-          description: Redirect to local CLI return_url with token query parameters when return_url is localhost
+          description: Redirect to local CLI return_url with token query parameters, or to a web return_url with login_code when web_login was requested
         "200":
           description: Tokens issued
           content:
@@ -254,6 +260,36 @@ paths:
                 $ref: "#/components/schemas/ErrorEnvelope"
         "401":
           description: OIDC authorization failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+  /auth/web-login/exchange:
+    post:
+      tags: [auth]
+      summary: Exchange web login code
+      description: Exchanges a short-lived, one-time browser login handoff code for Sandbox0 tokens.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WebLoginExchangeRequest"
+      responses:
+        "200":
+          description: Login code exchanged
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessLoginResponse"
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "401":
+          description: Invalid or expired login code
           content:
             application/json:
               schema:
@@ -3421,6 +3457,16 @@ components:
         refresh_token:
           type: string
       required: [refresh_token]
+    WebLoginExchangeRequest:
+      type: object
+      properties:
+        login_code:
+          type: string
+          description: Short-lived one-time code returned to the web login callback.
+        return_url:
+          type: string
+          description: Exact return URL used when the login code was created.
+      required: [login_code, return_url]
     ChangePasswordRequest:
       type: object
       properties:

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -2653,6 +2653,15 @@ type WarmProcessSpec struct {
 // WarmProcessSpecType defines model for WarmProcessSpec.Type.
 type WarmProcessSpecType string
 
+// WebLoginExchangeRequest defines model for WebLoginExchangeRequest.
+type WebLoginExchangeRequest struct {
+	// LoginCode Short-lived one-time code returned to the web login callback.
+	LoginCode string `json:"login_code"`
+
+	// ReturnUrl Exact return URL used when the login code was created.
+	ReturnUrl string `json:"return_url"`
+}
+
 // WebhookConfig defines model for WebhookConfig.
 type WebhookConfig struct {
 	// Secret Optional. Shared secret used to sign webhook payloads.
@@ -2855,6 +2864,9 @@ type GetAuthOidcProviderCallbackParams struct {
 // GetAuthOidcProviderLoginParams defines parameters for GetAuthOidcProviderLogin.
 type GetAuthOidcProviderLoginParams struct {
 	ReturnUrl *string `form:"return_url,omitempty" json:"return_url,omitempty"`
+
+	// WebLogin When true, the OIDC callback redirects to return_url with a short-lived login_code for server-side exchange.
+	WebLogin *bool `form:"web_login,omitempty" json:"web_login,omitempty"`
 }
 
 // PostApiKeysJSONRequestBody defines body for PostApiKeys for application/json ContentType.
@@ -2955,6 +2967,9 @@ type PostAuthRefreshJSONRequestBody = RefreshRequest
 
 // PostAuthRegisterJSONRequestBody defines body for PostAuthRegister for application/json ContentType.
 type PostAuthRegisterJSONRequestBody = RegisterRequest
+
+// PostAuthWebLoginExchangeJSONRequestBody defines body for PostAuthWebLoginExchange for application/json ContentType.
+type PostAuthWebLoginExchangeJSONRequestBody = WebLoginExchangeRequest
 
 // PostRegionsJSONRequestBody defines body for PostRegions for application/json ContentType.
 type PostRegionsJSONRequestBody = CreateRegionRequest

--- a/pkg/gateway/auth/oidc/manager.go
+++ b/pkg/gateway/auth/oidc/manager.go
@@ -6,6 +6,8 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -17,11 +19,19 @@ import (
 
 // StateData stores OAuth state information
 type StateData struct {
-	Provider     string    `json:"provider"`
-	Nonce        string    `json:"nonce"`
-	CodeVerifier string    `json:"code_verifier"`
-	ReturnURL    string    `json:"return_url"`
-	CreatedAt    time.Time `json:"created_at"`
+	Provider        string    `json:"provider"`
+	Nonce           string    `json:"nonce"`
+	CodeVerifier    string    `json:"code_verifier"`
+	ReturnURL       string    `json:"return_url"`
+	WebLoginHandoff bool      `json:"web_login_handoff"`
+	CreatedAt       time.Time `json:"created_at"`
+}
+
+// CallbackResult contains the resolved user and post-login return metadata.
+type CallbackResult struct {
+	User            *identity.User
+	ReturnURL       string
+	WebLoginHandoff bool
 }
 
 type identityStore interface {
@@ -35,14 +45,15 @@ type identityStore interface {
 
 // Manager manages multiple OIDC providers
 type Manager struct {
-	providers       map[string]*Provider
-	providerOrder   []string
-	repo            identityStore
-	baseURL         string
-	defaultTeamName string
-	stateTTL        time.Duration
-	cleanupInterval time.Duration
-	logger          *zap.Logger
+	providers        map[string]*Provider
+	providerOrder    []string
+	repo             identityStore
+	baseURL          string
+	publicRootDomain string
+	defaultTeamName  string
+	stateTTL         time.Duration
+	cleanupInterval  time.Duration
+	logger           *zap.Logger
 
 	// State management (in-memory for simplicity, use Redis in production)
 	states   map[string]*StateData
@@ -52,15 +63,16 @@ type Manager struct {
 // NewManager creates a new OIDC manager
 func NewManager(ctx context.Context, cfg *config.GatewayConfig, repo *identity.Repository, logger *zap.Logger) (*Manager, error) {
 	m := &Manager{
-		providers:       make(map[string]*Provider),
-		providerOrder:   make([]string, 0),
-		repo:            repo,
-		baseURL:         cfg.BaseURL,
-		defaultTeamName: cfg.DefaultTeamName,
-		stateTTL:        cfg.OIDCStateTTL.Duration,
-		cleanupInterval: cfg.OIDCStateCleanupInterval.Duration,
-		logger:          logger,
-		states:          make(map[string]*StateData),
+		providers:        make(map[string]*Provider),
+		providerOrder:    make([]string, 0),
+		repo:             repo,
+		baseURL:          cfg.BaseURL,
+		publicRootDomain: cfg.PublicRootDomain,
+		defaultTeamName:  cfg.DefaultTeamName,
+		stateTTL:         cfg.OIDCStateTTL.Duration,
+		cleanupInterval:  cfg.OIDCStateCleanupInterval.Duration,
+		logger:           logger,
+		states:           make(map[string]*StateData),
 	}
 
 	// Initialize enabled providers
@@ -110,11 +122,34 @@ func (m *Manager) ListProviders() []*Provider {
 	return providers
 }
 
-// GenerateAuthURL generates an OAuth authorization URL
-func (m *Manager) GenerateAuthURL(providerID, returnURL string) (string, error) {
+type authURLConfig struct {
+	webLoginHandoff bool
+}
+
+// AuthURLOption configures OIDC authorization URL generation.
+type AuthURLOption func(*authURLConfig)
+
+// WithWebLoginHandoff requests a one-time code redirect after OIDC callback.
+func WithWebLoginHandoff() AuthURLOption {
+	return func(cfg *authURLConfig) {
+		cfg.webLoginHandoff = true
+	}
+}
+
+// GenerateAuthURL generates an OAuth authorization URL.
+func (m *Manager) GenerateAuthURL(providerID, returnURL string, opts ...AuthURLOption) (string, error) {
 	provider, err := m.GetProvider(providerID)
 	if err != nil {
 		return "", err
+	}
+	cfg := authURLConfig{}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&cfg)
+		}
+	}
+	if cfg.webLoginHandoff && !m.IsAllowedWebReturnURL(returnURL) {
+		return "", ErrInvalidReturnURL
 	}
 
 	// Generate state
@@ -128,15 +163,62 @@ func (m *Manager) GenerateAuthURL(providerID, returnURL string) (string, error) 
 	// Store state
 	m.statesMu.Lock()
 	m.states[state] = &StateData{
-		Provider:     providerID,
-		Nonce:        state,
-		CodeVerifier: verifier,
-		ReturnURL:    returnURL,
-		CreatedAt:    time.Now(),
+		Provider:        providerID,
+		Nonce:           state,
+		CodeVerifier:    verifier,
+		ReturnURL:       returnURL,
+		WebLoginHandoff: cfg.webLoginHandoff,
+		CreatedAt:       time.Now(),
 	}
 	m.statesMu.Unlock()
 
 	return provider.AuthURL(state, verifier), nil
+}
+
+// IsAllowedWebReturnURL reports whether returnURL may receive a web login code.
+func (m *Manager) IsAllowedWebReturnURL(raw string) bool {
+	parsed, err := url.Parse(raw)
+	if err != nil || !parsed.IsAbs() || parsed.Hostname() == "" {
+		return false
+	}
+	host := strings.ToLower(parsed.Hostname())
+	switch parsed.Scheme {
+	case "https":
+	case "http":
+		if !isLocalhost(host) {
+			return false
+		}
+	default:
+		return false
+	}
+	if isLocalhost(host) {
+		return true
+	}
+	if baseHost := hostFromURL(m.baseURL); baseHost != "" && host == baseHost {
+		return true
+	}
+	rootDomain := strings.ToLower(strings.TrimSpace(m.publicRootDomain))
+	if rootDomain != "" && (host == rootDomain || strings.HasSuffix(host, "."+rootDomain)) {
+		return true
+	}
+	return false
+}
+
+func hostFromURL(raw string) string {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return ""
+	}
+	return strings.ToLower(parsed.Hostname())
+}
+
+func isLocalhost(host string) bool {
+	switch strings.ToLower(strings.Trim(host, "[]")) {
+	case "localhost", "127.0.0.1", "::1":
+		return true
+	default:
+		return false
+	}
 }
 
 // ValidateState validates and consumes a state parameter
@@ -160,41 +242,45 @@ func (m *Manager) ValidateState(state string) (*StateData, error) {
 	return data, nil
 }
 
-// HandleCallback processes an OIDC callback
-func (m *Manager) HandleCallback(ctx context.Context, providerID, code, state string) (*identity.User, string, error) {
+// HandleCallback processes an OIDC callback.
+func (m *Manager) HandleCallback(ctx context.Context, providerID, code, state string) (*CallbackResult, error) {
 	// Validate state
 	stateData, err := m.ValidateState(state)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 
 	if stateData.Provider != providerID {
-		return nil, "", ErrInvalidState
+		return nil, ErrInvalidState
 	}
 
 	// Get provider
 	provider, err := m.GetProvider(providerID)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 
 	// Exchange code for token
 	token, err := provider.Exchange(ctx, code, stateData.CodeVerifier)
 	if err != nil {
-		return nil, "", fmt.Errorf("exchange code: %w", err)
+		return nil, fmt.Errorf("exchange code: %w", err)
 	}
 
 	// Verify token and get user info
 	userInfo, err := provider.VerifyToken(ctx, token)
 	if err != nil {
-		return nil, "", fmt.Errorf("verify token: %w", err)
+		return nil, fmt.Errorf("verify token: %w", err)
 	}
 
 	user, err := m.completeUserInfo(ctx, provider, userInfo)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
-	return user, stateData.ReturnURL, nil
+	return &CallbackResult{
+		User:            user,
+		ReturnURL:       stateData.ReturnURL,
+		WebLoginHandoff: stateData.WebLoginHandoff,
+	}, nil
 }
 
 // StartDeviceAuthorization begins a device authorization flow for the provider.

--- a/pkg/gateway/auth/oidc/provider.go
+++ b/pkg/gateway/auth/oidc/provider.go
@@ -21,6 +21,7 @@ var (
 	ErrProviderDisabled            = errors.New("OIDC provider is disabled")
 	ErrInvalidState                = errors.New("invalid OAuth state")
 	ErrInvalidCode                 = errors.New("invalid authorization code")
+	ErrInvalidReturnURL            = errors.New("invalid return URL")
 	ErrMissingEmail                = errors.New("email not provided by IdP")
 	ErrHomeRegionNotRoutable       = errors.New("home region is not routable")
 	ErrEmailDomainMismatch         = errors.New("email domain not allowed")

--- a/pkg/gateway/http/handlers/auth.go
+++ b/pkg/gateway/http/handlers/auth.go
@@ -2,6 +2,8 @@ package handlers
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/http"
@@ -32,6 +34,8 @@ type AuthHandler struct {
 	logger                    *zap.Logger
 }
 
+const webLoginCodeTTL = 2 * time.Minute
+
 // AuthHandlerOption configures AuthHandler behavior.
 type AuthHandlerOption func(*AuthHandler)
 
@@ -47,6 +51,8 @@ type authRepository interface {
 	CreateRefreshToken(ctx context.Context, token *identity.RefreshToken) error
 	ValidateRefreshToken(ctx context.Context, tokenHash string) (*identity.RefreshToken, error)
 	RevokeAllUserRefreshTokens(ctx context.Context, userID string) error
+	CreateWebLoginCode(ctx context.Context, code *identity.WebLoginCode) error
+	ConsumeWebLoginCode(ctx context.Context, codeHash, returnURL string) (*identity.WebLoginCode, error)
 	GetUserByID(ctx context.Context, id string) (*identity.User, error)
 	ListTeamGrantsByUserID(ctx context.Context, userID string) ([]identity.TeamGrantRecord, error)
 	CreateDeviceAuthSession(ctx context.Context, session *identity.DeviceAuthSession) error
@@ -244,6 +250,12 @@ type RefreshRequest struct {
 	RefreshToken string `json:"refresh_token" binding:"required"`
 }
 
+// WebLoginExchangeRequest exchanges a one-time browser handoff code for tokens.
+type WebLoginExchangeRequest struct {
+	LoginCode string `json:"login_code" binding:"required"`
+	ReturnURL string `json:"return_url" binding:"required"`
+}
+
 // RefreshToken refreshes an access token
 func (h *AuthHandler) RefreshToken(c *gin.Context) {
 	var req RefreshRequest
@@ -294,6 +306,50 @@ func (h *AuthHandler) RefreshToken(c *gin.Context) {
 		ExpiresAt:    tokens.ExpiresAt.Unix(),
 		User:         NewUserResponse(user),
 	})
+}
+
+// WebLoginExchange exchanges a short-lived OIDC browser handoff code for Sandbox0 tokens.
+func (h *AuthHandler) WebLoginExchange(c *gin.Context) {
+	var req WebLoginExchangeRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "invalid request body")
+		return
+	}
+	if h.oidcManager == nil || !h.oidcManager.IsAllowedWebReturnURL(req.ReturnURL) {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "invalid return URL")
+		return
+	}
+
+	code, err := h.repo.ConsumeWebLoginCode(
+		c.Request.Context(),
+		authn.HashRefreshToken(strings.TrimSpace(req.LoginCode)),
+		strings.TrimSpace(req.ReturnURL),
+	)
+	if err != nil {
+		spec.JSONError(c, http.StatusUnauthorized, spec.CodeUnauthorized, "invalid login code")
+		return
+	}
+
+	user, err := h.repo.GetUserByID(c.Request.Context(), code.UserID)
+	if err != nil {
+		spec.JSONError(c, http.StatusUnauthorized, spec.CodeUnauthorized, "user not found")
+		return
+	}
+
+	loginResponse, _, err := h.buildLoginResponse(c.Request.Context(), user)
+	if err != nil {
+		h.logger.Warn("Failed to exchange web login code", zap.Error(err))
+		status := http.StatusInternalServerError
+		apiCode := spec.CodeInternal
+		if errors.Is(err, errUserNotMemberOfSelectedTeam) {
+			status = http.StatusForbidden
+			apiCode = spec.CodeForbidden
+		}
+		spec.JSONError(c, status, apiCode, err.Error())
+		return
+	}
+
+	spec.JSONSuccess(c, http.StatusOK, loginResponse)
 }
 
 // ChangePasswordRequest is the request body for password change
@@ -385,7 +441,11 @@ func (h *AuthHandler) OIDCLogin(c *gin.Context) {
 		returnURL = "/"
 	}
 
-	authURL, err := h.oidcManager.GenerateAuthURL(providerID, returnURL)
+	authOpts := []oidc.AuthURLOption(nil)
+	if isTruthyQuery(c.Query("web_login")) {
+		authOpts = append(authOpts, oidc.WithWebLoginHandoff())
+	}
+	authURL, err := h.oidcManager.GenerateAuthURL(providerID, returnURL, authOpts...)
 	if err != nil {
 		status := http.StatusBadRequest
 		if errors.Is(err, oidc.ErrProviderNotFound) {
@@ -422,7 +482,7 @@ func (h *AuthHandler) OIDCCallback(c *gin.Context) {
 		return
 	}
 
-	user, returnURL, err := h.oidcManager.HandleCallback(c.Request.Context(), providerID, code, state)
+	callback, err := h.oidcManager.HandleCallback(c.Request.Context(), providerID, code, state)
 	if err != nil {
 		h.logger.Warn("OIDC callback failed",
 			zap.String("provider", providerID),
@@ -436,6 +496,25 @@ func (h *AuthHandler) OIDCCallback(c *gin.Context) {
 			apiCode = spec.CodeBadRequest
 		}
 		spec.JSONError(c, status, apiCode, err.Error())
+		return
+	}
+	user := callback.User
+	returnURL := callback.ReturnURL
+
+	if callback.WebLoginHandoff {
+		loginCode, expiresAt, err := h.createWebLoginCode(c.Request.Context(), user, returnURL)
+		if err != nil {
+			h.logger.Error("Failed to create web login code", zap.Error(err))
+			spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to complete oidc login")
+			return
+		}
+		redirectURL, err := buildWebLoginReturnURL(returnURL, loginCode, expiresAt)
+		if err != nil {
+			h.logger.Warn("Failed to build web login redirect URL", zap.Error(err))
+			spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to complete oidc login")
+			return
+		}
+		c.Redirect(http.StatusFound, redirectURL)
 		return
 	}
 
@@ -680,6 +759,52 @@ func (h *AuthHandler) persistRefreshToken(ctx context.Context, userID string, to
 		TokenHash: authn.HashRefreshToken(tokens.RefreshToken),
 		ExpiresAt: tokens.RefreshExpiresAt,
 	})
+}
+
+func (h *AuthHandler) createWebLoginCode(ctx context.Context, user *identity.User, returnURL string) (string, time.Time, error) {
+	loginCode, err := generateWebLoginCode()
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	expiresAt := time.Now().Add(webLoginCodeTTL)
+	if err := h.repo.CreateWebLoginCode(ctx, &identity.WebLoginCode{
+		UserID:    user.ID,
+		CodeHash:  authn.HashRefreshToken(loginCode),
+		ReturnURL: strings.TrimSpace(returnURL),
+		ExpiresAt: expiresAt,
+	}); err != nil {
+		return "", time.Time{}, err
+	}
+	return loginCode, expiresAt, nil
+}
+
+func generateWebLoginCode() (string, error) {
+	bytes := make([]byte, 32)
+	if _, err := rand.Read(bytes); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(bytes), nil
+}
+
+func buildWebLoginReturnURL(raw, loginCode string, expiresAt time.Time) (string, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", err
+	}
+	q := u.Query()
+	q.Set("login_code", loginCode)
+	q.Set("expires_unix", fmt.Sprintf("%d", expiresAt.Unix()))
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+func isTruthyQuery(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "1", "t", "true", "yes", "y", "on":
+		return true
+	default:
+		return false
+	}
 }
 
 func isLocalReturnURL(raw string) bool {

--- a/pkg/gateway/http/handlers/auth_test.go
+++ b/pkg/gateway/http/handlers/auth_test.go
@@ -21,6 +21,7 @@ type mockAuthRepository struct {
 	users              map[string]*identity.User
 	teams              map[string]*identity.Team
 	refreshTokens      map[string]*identity.RefreshToken
+	webLoginCodes      map[string]*identity.WebLoginCode
 	deviceAuthSessions map[string]*identity.DeviceAuthSession
 	teamMembers        map[string]*identity.TeamMember
 	teamGrantCalls     int
@@ -32,6 +33,7 @@ func newMockAuthRepository() *mockAuthRepository {
 		users:              map[string]*identity.User{},
 		teams:              map[string]*identity.Team{},
 		refreshTokens:      map[string]*identity.RefreshToken{},
+		webLoginCodes:      map[string]*identity.WebLoginCode{},
 		deviceAuthSessions: map[string]*identity.DeviceAuthSession{},
 		teamMembers:        map[string]*identity.TeamMember{},
 	}
@@ -68,6 +70,30 @@ func (m *mockAuthRepository) RevokeAllUserRefreshTokens(_ context.Context, userI
 		}
 	}
 	return nil
+}
+
+func (m *mockAuthRepository) CreateWebLoginCode(_ context.Context, code *identity.WebLoginCode) error {
+	if _, exists := m.webLoginCodes[code.CodeHash]; exists {
+		return errors.New("duplicate web login code hash")
+	}
+	copyCode := *code
+	if copyCode.ID == "" {
+		copyCode.ID = "web-login-code-1"
+	}
+	m.webLoginCodes[copyCode.CodeHash] = &copyCode
+	code.ID = copyCode.ID
+	return nil
+}
+
+func (m *mockAuthRepository) ConsumeWebLoginCode(_ context.Context, codeHash, returnURL string) (*identity.WebLoginCode, error) {
+	code, ok := m.webLoginCodes[codeHash]
+	if !ok || code.ReturnURL != returnURL || code.ConsumedAt != nil || time.Now().After(code.ExpiresAt) {
+		return nil, identity.ErrWebLoginCodeNotFound
+	}
+	now := time.Now()
+	code.ConsumedAt = &now
+	copyCode := *code
+	return &copyCode, nil
 }
 
 func (m *mockAuthRepository) GetUserByID(_ context.Context, id string) (*identity.User, error) {

--- a/pkg/gateway/identity/models.go
+++ b/pkg/gateway/identity/models.go
@@ -97,3 +97,14 @@ type DeviceAuthSession struct {
 	CreatedAt               time.Time  `json:"created_at"`
 	UpdatedAt               time.Time  `json:"updated_at"`
 }
+
+// WebLoginCode stores a one-time browser login handoff code.
+type WebLoginCode struct {
+	ID         string     `json:"id"`
+	CodeHash   string     `json:"-"`
+	UserID     string     `json:"user_id"`
+	ReturnURL  string     `json:"return_url"`
+	ExpiresAt  time.Time  `json:"expires_at"`
+	ConsumedAt *time.Time `json:"consumed_at,omitempty"`
+	CreatedAt  time.Time  `json:"created_at"`
+}

--- a/pkg/gateway/identity/repository.go
+++ b/pkg/gateway/identity/repository.go
@@ -29,6 +29,8 @@ var (
 	ErrDeviceAuthSessionNotFound = errors.New("device auth session not found")
 	ErrDeviceAuthSessionExpired  = errors.New("device auth session expired")
 	ErrDeviceAuthSessionConsumed = errors.New("device auth session already consumed")
+
+	ErrWebLoginCodeNotFound = errors.New("web login code not found")
 )
 
 // Repository provides database access for identity and tenancy data.

--- a/pkg/gateway/identity/web_login_code_repository.go
+++ b/pkg/gateway/identity/web_login_code_repository.go
@@ -1,0 +1,63 @@
+package identity
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// CreateWebLoginCode persists a one-time browser login handoff code.
+func (r *Repository) CreateWebLoginCode(ctx context.Context, code *WebLoginCode) error {
+	err := r.pool.QueryRow(ctx, `
+		INSERT INTO web_login_codes (code_hash, user_id, return_url, expires_at)
+		VALUES ($1, $2, $3, $4)
+		RETURNING id, created_at
+	`, code.CodeHash, code.UserID, code.ReturnURL, code.ExpiresAt,
+	).Scan(&code.ID, &code.CreatedAt)
+	if err != nil {
+		return fmt.Errorf("insert web login code: %w", err)
+	}
+	return nil
+}
+
+// ConsumeWebLoginCode consumes a non-expired code bound to the given return URL.
+func (r *Repository) ConsumeWebLoginCode(ctx context.Context, codeHash, returnURL string) (*WebLoginCode, error) {
+	var code WebLoginCode
+	err := r.pool.QueryRow(ctx, `
+		UPDATE web_login_codes
+		SET consumed_at = NOW()
+		WHERE code_hash = $1
+		  AND return_url = $2
+		  AND consumed_at IS NULL
+		  AND expires_at > NOW()
+		RETURNING id, code_hash, user_id, return_url, expires_at, consumed_at, created_at
+	`, codeHash, returnURL).Scan(
+		&code.ID,
+		&code.CodeHash,
+		&code.UserID,
+		&code.ReturnURL,
+		&code.ExpiresAt,
+		&code.ConsumedAt,
+		&code.CreatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrWebLoginCodeNotFound
+		}
+		return nil, fmt.Errorf("consume web login code: %w", err)
+	}
+	return &code, nil
+}
+
+// CleanupExpiredWebLoginCodes removes expired or already consumed handoff codes.
+func (r *Repository) CleanupExpiredWebLoginCodes(ctx context.Context) (int64, error) {
+	result, err := r.pool.Exec(ctx, `
+		DELETE FROM web_login_codes WHERE expires_at < NOW() OR consumed_at IS NOT NULL
+	`)
+	if err != nil {
+		return 0, fmt.Errorf("cleanup web login codes: %w", err)
+	}
+	return result.RowsAffected(), nil
+}

--- a/pkg/gateway/migrations/00008_add_web_login_codes.sql
+++ b/pkg/gateway/migrations/00008_add_web_login_codes.sql
@@ -1,0 +1,20 @@
+-- +goose Up
+CREATE TABLE IF NOT EXISTS web_login_codes (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    code_hash TEXT NOT NULL UNIQUE,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    return_url TEXT NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    consumed_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_web_login_codes_user_id ON web_login_codes(user_id);
+CREATE INDEX IF NOT EXISTS idx_web_login_codes_expires_at ON web_login_codes(expires_at);
+CREATE INDEX IF NOT EXISTS idx_web_login_codes_consumed_at ON web_login_codes(consumed_at);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_web_login_codes_consumed_at;
+DROP INDEX IF EXISTS idx_web_login_codes_expires_at;
+DROP INDEX IF EXISTS idx_web_login_codes_user_id;
+DROP TABLE IF EXISTS web_login_codes;

--- a/pkg/gateway/public/routes.go
+++ b/pkg/gateway/public/routes.go
@@ -71,6 +71,7 @@ func RegisterIdentityRoutes(router gin.IRouter, deps Deps) {
 		auth.POST("/login", authHandler.Login)
 		auth.POST("/register", authHandler.Register)
 		auth.POST("/refresh", authHandler.RefreshToken)
+		auth.POST("/web-login/exchange", authHandler.WebLoginExchange)
 
 		// OIDC auth
 		auth.GET(


### PR DESCRIPTION
## Summary
- add a web OIDC handoff mode that redirects trusted website return URLs with a short-lived one-time login code
- add /auth/web-login/exchange to consume the code and issue Sandbox0 tokens server-side
- persist web login codes with one-time consumption and update OpenAPI generated types

## Device login impact
- device login remains on /auth/oidc/{provider}/device/start and /auth/oidc/{provider}/device/poll
- the new handoff is only enabled when browser OIDC login explicitly passes web_login=true

## Testing
- go test ./pkg/apispec ./pkg/gateway/auth/oidc ./pkg/gateway/http/handlers ./pkg/gateway/identity ./pkg/gateway/public ./global-gateway/pkg/http -count=1
- git diff --check
- pre-push hook: make manifests, make proto, make apispec, go fmt ./..., go mod tidy, go mod vendor, golangci-lint run ./...