### PR TITLE
Make ctld pause/resume reconciliation asynchronous

### DIFF
--- a/ctld/cmd/ctld/main.go
+++ b/ctld/cmd/ctld/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -22,13 +23,18 @@ import (
 )
 
 var (
-	mountsAllowed = 5
-	httpAddr      = ":8095"
-	kubeconfig    = ""
-	cgroupRoot    = "/host-sys/fs/cgroup"
-	criEndpoint   = "/host-run/containerd/containerd.sock"
-	procRoot      = "/proc"
-	nodeName      = os.Getenv("NODE_NAME")
+	mountsAllowed          = 5
+	httpAddr               = ":8095"
+	kubeconfig             = ""
+	cgroupRoot             = "/host-sys/fs/cgroup"
+	criEndpoint            = "/host-run/containerd/containerd.sock"
+	procRoot               = "/proc"
+	nodeName               = os.Getenv("NODE_NAME")
+	pauseMinMemoryRequest  = "10Mi"
+	pauseMinMemoryLimit    = "32Mi"
+	pauseMemoryBufferRatio = "1.1"
+	pauseMinCPU            = "10m"
+	defaultSandboxTTL      time.Duration
 )
 
 func main() {
@@ -39,6 +45,11 @@ func main() {
 	flag.StringVar(&criEndpoint, "cri-endpoint", "/host-run/containerd/containerd.sock", "host CRI socket used to read pod sandbox stats")
 	flag.StringVar(&procRoot, "proc-root", "/proc", "host proc root used to inspect sandbox processes")
 	flag.StringVar(&nodeName, "node-name", os.Getenv("NODE_NAME"), "current node name used to validate local sandbox ownership")
+	flag.StringVar(&pauseMinMemoryRequest, "pause-min-memory-request", "10Mi", "minimum memory request to apply to paused sandbox pods")
+	flag.StringVar(&pauseMinMemoryLimit, "pause-min-memory-limit", "32Mi", "minimum memory limit to apply to paused sandbox pods")
+	flag.StringVar(&pauseMemoryBufferRatio, "pause-memory-buffer-ratio", "1.1", "memory limit multiplier applied to paused sandbox working set")
+	flag.StringVar(&pauseMinCPU, "pause-min-cpu", "10m", "minimum CPU request and limit to apply to paused sandbox pods")
+	flag.DurationVar(&defaultSandboxTTL, "default-sandbox-ttl", 0, "default sandbox TTL restored on resume when no original TTL is recorded")
 	flag.Parse()
 
 	log.Println("Starting ctld")
@@ -154,9 +165,30 @@ func buildPowerController(ctx context.Context, obsProvider *observability.Provid
 	}
 	resolver := ctldpower.NewPodResolver(k8sClient, nodeName, cgroupRoot)
 	resolver.ProcRoot = procRoot
+	controller := ctldpower.NewController(resolver, nil)
+	if obsProvider != nil {
+		controller.HTTPClient = obsProvider.HTTP.NewClient(httpobs.Config{Timeout: 2 * time.Second})
+	}
+	controller.StatsProvider = ctldpower.NewCRIStatsProvider(criEndpoint)
+
 	if podCache, err := ctldpower.NewNodePodCache(k8sClient, nodeName, 0); err != nil {
 		log.Printf("ctld pod cache disabled: %v", err)
 	} else {
+		ratio, err := strconv.ParseFloat(pauseMemoryBufferRatio, 64)
+		if err != nil || ratio <= 0 {
+			log.Printf("invalid pause memory buffer ratio %q, using default 1.1", pauseMemoryBufferRatio)
+			ratio = 1.1
+		}
+		powerReconciler := ctldpower.NewPowerReconciler(k8sClient, podCache.PodLister(), resolver, controller, ctldpower.PowerReconcilerConfig{
+			PauseMinMemoryRequest:  pauseMinMemoryRequest,
+			PauseMinMemoryLimit:    pauseMinMemoryLimit,
+			PauseMemoryBufferRatio: ratio,
+			PauseMinCPU:            pauseMinCPU,
+			DefaultSandboxTTL:      defaultSandboxTTL,
+		})
+		if err := podCache.AddEventHandler(powerReconciler.EventHandler()); err != nil {
+			log.Printf("ctld power reconciler disabled: add pod handler: %v", err)
+		}
 		podCache.Start(ctx)
 		resolver.SetPodCache(podCache.PodLister(), podCache.PodIndexer())
 		go func() {
@@ -165,12 +197,9 @@ func buildPowerController(ctx context.Context, obsProvider *observability.Provid
 			if !podCache.WaitForSync(syncCtx) && ctx.Err() == nil {
 				log.Printf("ctld pod cache did not sync before timeout; live kubernetes lookups remain enabled")
 			}
+			powerReconciler.EnqueueAll()
+			powerReconciler.Run(ctx, 1)
 		}()
 	}
-	controller := ctldpower.NewController(resolver, nil)
-	if obsProvider != nil {
-		controller.HTTPClient = obsProvider.HTTP.NewClient(httpobs.Config{Timeout: 2 * time.Second})
-	}
-	controller.StatsProvider = ctldpower.NewCRIStatsProvider(criEndpoint)
 	return controller
 }

--- a/ctld/internal/ctld/power/controller.go
+++ b/ctld/internal/ctld/power/controller.go
@@ -123,11 +123,22 @@ func (c *Controller) Pause(r *http.Request, sandboxID string) (ctldapi.PauseResp
 	if status != http.StatusOK {
 		return errResp, status
 	}
+	ctx := context.Background()
+	if r != nil {
+		ctx = r.Context()
+	}
+	return c.PauseTarget(ctx, sandboxID, target)
+}
+
+func (c *Controller) PauseTarget(ctx context.Context, sandboxID string, target Target) (ctldapi.PauseResponse, int) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	log.Printf("ctld pause start sandbox=%s runtime=%s cgroup=%s", sandboxID, target.Runtime, target.CgroupDir)
 	if err := c.FS.Freeze(target.CgroupDir); err != nil {
 		return ctldapi.PauseResponse{Paused: false, Error: fmt.Sprintf("freeze cgroup: %v", err)}, http.StatusInternalServerError
 	}
-	usage, err := c.pauseUsage(r.Context(), target)
+	usage, err := c.pauseUsage(ctx, target)
 	if err != nil {
 		return ctldapi.PauseResponse{Paused: false, Error: err.Error()}, http.StatusInternalServerError
 	}
@@ -143,6 +154,10 @@ func (c *Controller) Resume(r *http.Request, sandboxID string) (ctldapi.ResumeRe
 	if status != http.StatusOK {
 		return ctldapi.ResumeResponse{Resumed: false, Error: pauseErr.Error}, status
 	}
+	return c.ResumeTarget(sandboxID, target)
+}
+
+func (c *Controller) ResumeTarget(sandboxID string, target Target) (ctldapi.ResumeResponse, int) {
 	log.Printf("ctld resume start sandbox=%s runtime=%s cgroup=%s", sandboxID, target.Runtime, target.CgroupDir)
 	if err := c.FS.Thaw(target.CgroupDir); err != nil {
 		return ctldapi.ResumeResponse{Resumed: false, Error: fmt.Sprintf("thaw cgroup: %v", err)}, http.StatusInternalServerError

--- a/ctld/internal/ctld/power/pod_cache.go
+++ b/ctld/internal/ctld/power/pod_cache.go
@@ -85,6 +85,14 @@ func (c *PodCache) PodIndexer() cache.Indexer {
 	return c.informer.GetIndexer()
 }
 
+func (c *PodCache) AddEventHandler(handler cache.ResourceEventHandler) error {
+	if c == nil || c.informer == nil {
+		return errors.New("pod informer is not configured")
+	}
+	_, err := c.informer.AddEventHandler(handler)
+	return err
+}
+
 func podSandboxIDIndexFunc(obj interface{}) ([]string, error) {
 	accessor, err := meta.Accessor(obj)
 	if err != nil {

--- a/ctld/internal/ctld/power/reconciler.go
+++ b/ctld/internal/ctld/power/reconciler.go
@@ -1,0 +1,619 @@
+package power
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
+	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/client-go/util/workqueue"
+)
+
+const (
+	powerStateActive   = "active"
+	powerStatePaused   = "paused"
+	powerPhaseStable   = "stable"
+	powerPhasePausing  = "pausing"
+	powerPhaseResuming = "resuming"
+
+	defaultPauseMinMemoryRequest  = "10Mi"
+	defaultPauseMinMemoryLimit    = "32Mi"
+	defaultPauseMemoryBufferRatio = 1.1
+	defaultPauseMinCPU            = "10m"
+)
+
+type PowerReconcilerConfig struct {
+	PauseMinMemoryRequest  string
+	PauseMinMemoryLimit    string
+	PauseMemoryBufferRatio float64
+	PauseMinCPU            string
+	DefaultSandboxTTL      time.Duration
+}
+
+type PowerReconciler struct {
+	k8sClient  kubernetes.Interface
+	podLister  corelisters.PodLister
+	resolver   *PodResolver
+	controller *Controller
+	cfg        PowerReconcilerConfig
+	queue      workqueue.TypedRateLimitingInterface[string]
+}
+
+type powerState struct {
+	Desired            string
+	DesiredGeneration  int64
+	Observed           string
+	ObservedGeneration int64
+	Phase              string
+}
+
+type pausedState struct {
+	Resources   map[string]containerResources `json:"resources"`
+	OriginalTTL *int32                        `json:"original_ttl,omitempty"`
+}
+
+type containerResources struct {
+	Requests corev1.ResourceList `json:"requests,omitempty"`
+	Limits   corev1.ResourceList `json:"limits,omitempty"`
+}
+
+type sandboxConfig struct {
+	TTL *int32 `json:"ttl,omitempty"`
+}
+
+func NewPowerReconciler(k8sClient kubernetes.Interface, podLister corelisters.PodLister, resolver *PodResolver, controller *Controller, cfg PowerReconcilerConfig) *PowerReconciler {
+	cfg = normalizePowerReconcilerConfig(cfg)
+	return &PowerReconciler{
+		k8sClient:  k8sClient,
+		podLister:  podLister,
+		resolver:   resolver,
+		controller: controller,
+		cfg:        cfg,
+		queue:      workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
+	}
+}
+
+func normalizePowerReconcilerConfig(cfg PowerReconcilerConfig) PowerReconcilerConfig {
+	if strings.TrimSpace(cfg.PauseMinMemoryRequest) == "" {
+		cfg.PauseMinMemoryRequest = defaultPauseMinMemoryRequest
+	}
+	if strings.TrimSpace(cfg.PauseMinMemoryLimit) == "" {
+		cfg.PauseMinMemoryLimit = defaultPauseMinMemoryLimit
+	}
+	if cfg.PauseMemoryBufferRatio <= 0 {
+		cfg.PauseMemoryBufferRatio = defaultPauseMemoryBufferRatio
+	}
+	if strings.TrimSpace(cfg.PauseMinCPU) == "" {
+		cfg.PauseMinCPU = defaultPauseMinCPU
+	}
+	return cfg
+}
+
+func (r *PowerReconciler) EventHandler() cache.ResourceEventHandler {
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc: r.enqueueObject,
+		UpdateFunc: func(_, newObj interface{}) {
+			r.enqueueObject(newObj)
+		},
+		DeleteFunc: r.enqueueObject,
+	}
+}
+
+func (r *PowerReconciler) EnqueueAll() {
+	if r == nil || r.podLister == nil {
+		return
+	}
+	pods, err := r.podLister.List(labels.Everything())
+	if err != nil {
+		log.Printf("ctld power reconciler list pods: %v", err)
+		return
+	}
+	for _, pod := range pods {
+		r.enqueuePod(pod)
+	}
+}
+
+func (r *PowerReconciler) Run(ctx context.Context, workers int) {
+	if r == nil || r.queue == nil {
+		return
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if workers <= 0 {
+		workers = 1
+	}
+	defer r.queue.ShutDown()
+	for i := 0; i < workers; i++ {
+		go func() {
+			for r.processNext(ctx) {
+			}
+		}()
+	}
+
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			r.EnqueueAll()
+		}
+	}
+}
+
+func (r *PowerReconciler) processNext(ctx context.Context) bool {
+	key, shutdown := r.queue.Get()
+	if shutdown {
+		return false
+	}
+	defer r.queue.Done(key)
+
+	if err := r.reconcileKey(ctx, key); err != nil {
+		log.Printf("ctld power reconcile failed key=%s err=%v", key, err)
+		r.queue.AddRateLimited(key)
+		return true
+	}
+	r.queue.Forget(key)
+	return true
+}
+
+func (r *PowerReconciler) enqueueObject(obj interface{}) {
+	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		obj = tombstone.Obj
+	}
+	pod, ok := obj.(*corev1.Pod)
+	if !ok || pod == nil {
+		return
+	}
+	r.enqueuePod(pod)
+}
+
+func (r *PowerReconciler) enqueuePod(pod *corev1.Pod) {
+	if r == nil || r.queue == nil || pod == nil {
+		return
+	}
+	if pod.Labels[controller.LabelSandboxID] == "" {
+		return
+	}
+	key, err := cache.MetaNamespaceKeyFunc(pod)
+	if err != nil {
+		return
+	}
+	r.queue.Add(key)
+}
+
+func (r *PowerReconciler) reconcileKey(ctx context.Context, key string) error {
+	if r == nil || r.podLister == nil {
+		return nil
+	}
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return err
+	}
+	pod, err := r.podLister.Pods(namespace).Get(name)
+	if errors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	return r.reconcilePod(ctx, pod.DeepCopy())
+}
+
+func (r *PowerReconciler) reconcilePod(ctx context.Context, pod *corev1.Pod) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if pod == nil || pod.Labels[controller.LabelSandboxID] == "" {
+		return nil
+	}
+	if pod.DeletionTimestamp != nil {
+		return r.thawDeletingPod(ctx, pod)
+	}
+	if pod.Labels[controller.LabelPoolType] != controller.PoolTypeActive {
+		return nil
+	}
+	state := powerStateFromAnnotations(pod.Annotations)
+	if state.Desired == state.Observed && state.Phase == powerPhaseStable {
+		return nil
+	}
+	switch state.Desired {
+	case powerStatePaused:
+		return r.reconcilePause(ctx, pod, state)
+	case powerStateActive:
+		return r.reconcileResume(ctx, pod, state)
+	default:
+		return nil
+	}
+}
+
+func (r *PowerReconciler) reconcilePause(ctx context.Context, pod *corev1.Pod, state powerState) error {
+	target, err := r.resolvePodTarget(pod)
+	if err != nil {
+		return err
+	}
+	sandboxID := pod.Labels[controller.LabelSandboxID]
+	resp, status := r.controller.PauseTarget(ctx, sandboxID, target)
+	if status != http.StatusOK || !resp.Paused {
+		return fmt.Errorf("pause target: status=%d error=%s", status, resp.Error)
+	}
+	requeue, err := r.recordPaused(ctx, pod, state.DesiredGeneration, resp.ResourceUsage)
+	if err != nil {
+		return err
+	}
+	if requeue {
+		r.enqueuePod(pod)
+	}
+	return nil
+}
+
+func (r *PowerReconciler) reconcileResume(ctx context.Context, pod *corev1.Pod, state powerState) error {
+	target, err := r.resolvePodTarget(pod)
+	if err != nil {
+		return err
+	}
+	if err := r.restoreResourcesBeforeResume(ctx, pod); err != nil {
+		return err
+	}
+	sandboxID := pod.Labels[controller.LabelSandboxID]
+	resp, status := r.controller.ResumeTarget(sandboxID, target)
+	if status != http.StatusOK || !resp.Resumed {
+		return fmt.Errorf("resume target: status=%d error=%s", status, resp.Error)
+	}
+	requeue, err := r.recordActive(ctx, pod, state.DesiredGeneration)
+	if err != nil {
+		return err
+	}
+	if requeue {
+		r.enqueuePod(pod)
+	}
+	return nil
+}
+
+func (r *PowerReconciler) thawDeletingPod(ctx context.Context, pod *corev1.Pod) error {
+	target, err := r.resolvePodTarget(pod)
+	if errors.IsNotFound(err) || errors.IsGone(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	frozen, err := r.controller.FS.IsFrozen(target.CgroupDir)
+	if err != nil || !frozen {
+		return nil
+	}
+	sandboxID := pod.Labels[controller.LabelSandboxID]
+	resp, status := r.controller.ResumeTarget(sandboxID, target)
+	if status != http.StatusOK || !resp.Resumed {
+		return fmt.Errorf("thaw deleting pod: status=%d error=%s", status, resp.Error)
+	}
+	return nil
+}
+
+func (r *PowerReconciler) resolvePodTarget(pod *corev1.Pod) (Target, error) {
+	if r == nil || r.resolver == nil {
+		return Target{}, ErrNotImplemented
+	}
+	return r.resolver.resolvePodTarget(pod, pod.Labels[controller.LabelSandboxID])
+}
+
+func (r *PowerReconciler) recordPaused(ctx context.Context, actionPod *corev1.Pod, observedGeneration int64, usage *ctldapi.SandboxResourceUsage) (bool, error) {
+	var requeue bool
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current, err := r.k8sClient.CoreV1().Pods(actionPod.Namespace).Get(ctx, actionPod.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		updated := current.DeepCopy()
+		if updated.Annotations == nil {
+			updated.Annotations = map[string]string{}
+		}
+		if updated.Annotations[controller.AnnotationPausedState] == "" {
+			stateJSON, err := marshalPausedState(actionPod)
+			if err != nil {
+				return err
+			}
+			updated.Annotations[controller.AnnotationPausedState] = stateJSON
+		}
+		updated.Annotations[controller.AnnotationPaused] = "true"
+		if updated.Annotations[controller.AnnotationPausedAt] == "" {
+			updated.Annotations[controller.AnnotationPausedAt] = time.Now().UTC().Format(time.RFC3339)
+		}
+		delete(updated.Annotations, controller.AnnotationExpiresAt)
+
+		observed := powerStatePaused
+		currentState := powerStateFromAnnotations(updated.Annotations)
+		currentState.Observed = observed
+		currentState.ObservedGeneration = observedGeneration
+		currentState.Phase = phaseFor(currentState.Desired, observed)
+		applyPowerStateAnnotations(updated.Annotations, currentState)
+
+		_, err = r.k8sClient.CoreV1().Pods(updated.Namespace).Update(ctx, updated, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+		requeue = currentState.Desired != observed || currentState.DesiredGeneration != observedGeneration
+		return nil
+	})
+	if err != nil {
+		return false, err
+	}
+	if err := r.applyPausedResources(ctx, actionPod, usageWorkingSet(usage)); err != nil {
+		log.Printf("ctld failed to resize paused sandbox %s/%s: %v", actionPod.Namespace, actionPod.Name, err)
+	}
+	return requeue, nil
+}
+
+func (r *PowerReconciler) recordActive(ctx context.Context, actionPod *corev1.Pod, observedGeneration int64) (bool, error) {
+	var requeue bool
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current, err := r.k8sClient.CoreV1().Pods(actionPod.Namespace).Get(ctx, actionPod.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		updated := current.DeepCopy()
+		if updated.Annotations == nil {
+			updated.Annotations = map[string]string{}
+		}
+		ttl := pausedStateOriginalTTL(updated)
+		if ttl == nil && r.cfg.DefaultSandboxTTL > 0 {
+			ttlValue := int32(r.cfg.DefaultSandboxTTL.Seconds())
+			ttl = &ttlValue
+		}
+		setExpirationAnnotation(updated.Annotations, time.Now().UTC(), ttl)
+		delete(updated.Annotations, controller.AnnotationPaused)
+		delete(updated.Annotations, controller.AnnotationPausedAt)
+		delete(updated.Annotations, controller.AnnotationPausedState)
+
+		observed := powerStateActive
+		currentState := powerStateFromAnnotations(updated.Annotations)
+		currentState.Observed = observed
+		currentState.ObservedGeneration = observedGeneration
+		currentState.Phase = phaseFor(currentState.Desired, observed)
+		applyPowerStateAnnotations(updated.Annotations, currentState)
+
+		_, err = r.k8sClient.CoreV1().Pods(updated.Namespace).Update(ctx, updated, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+		requeue = currentState.Desired != observed || currentState.DesiredGeneration != observedGeneration
+		return nil
+	})
+	return requeue, err
+}
+
+func (r *PowerReconciler) applyPausedResources(ctx context.Context, pod *corev1.Pod, workingSet int64) error {
+	if pod == nil {
+		return nil
+	}
+	minCPU := parseQuantityOrDefault(r.cfg.PauseMinCPU, defaultPauseMinCPU)
+	var newRequestMemory resource.Quantity
+	var newLimitMemory resource.Quantity
+	if workingSet > 0 {
+		reqBytes := workingSet
+		minReq := parseQuantityOrDefault(r.cfg.PauseMinMemoryRequest, defaultPauseMinMemoryRequest)
+		if reqBytes < minReq.Value() {
+			reqBytes = minReq.Value()
+		}
+		newRequestMemory = *resource.NewQuantity(reqBytes, resource.BinarySI)
+
+		limitBytes := int64(float64(workingSet) * r.cfg.PauseMemoryBufferRatio)
+		minLimit := parseQuantityOrDefault(r.cfg.PauseMinMemoryLimit, defaultPauseMinMemoryLimit)
+		if limitBytes < minLimit.Value() {
+			limitBytes = minLimit.Value()
+		}
+		newLimitMemory = *resource.NewQuantity(limitBytes, resource.BinarySI)
+	}
+	if newLimitMemory.IsZero() && minCPU.IsZero() {
+		return nil
+	}
+	resizePod, err := r.k8sClient.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	if !applyPausedResourceTargets(resizePod, newRequestMemory, newLimitMemory, minCPU) {
+		return nil
+	}
+	_, err = r.k8sClient.CoreV1().Pods(pod.Namespace).UpdateResize(ctx, pod.Name, resizePod, metav1.UpdateOptions{})
+	return err
+}
+
+func (r *PowerReconciler) restoreResourcesBeforeResume(ctx context.Context, pod *corev1.Pod) error {
+	if pod == nil || pod.Annotations[controller.AnnotationPausedState] == "" {
+		return nil
+	}
+	var state pausedState
+	if err := json.Unmarshal([]byte(pod.Annotations[controller.AnnotationPausedState]), &state); err != nil || len(state.Resources) == 0 {
+		return nil
+	}
+	resizePod, err := r.k8sClient.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	changed := false
+	for i := range resizePod.Spec.Containers {
+		container := &resizePod.Spec.Containers[i]
+		orig, ok := state.Resources[container.Name]
+		if !ok {
+			continue
+		}
+		container.Resources.Requests = orig.Requests
+		container.Resources.Limits = orig.Limits
+		changed = true
+	}
+	if !changed {
+		return nil
+	}
+	_, err = r.k8sClient.CoreV1().Pods(pod.Namespace).UpdateResize(ctx, pod.Name, resizePod, metav1.UpdateOptions{})
+	return err
+}
+
+func marshalPausedState(pod *corev1.Pod) (string, error) {
+	state := pausedState{Resources: map[string]containerResources{}}
+	if pod != nil {
+		for _, container := range pod.Spec.Containers {
+			state.Resources[container.Name] = containerResources{
+				Requests: container.Resources.Requests.DeepCopy(),
+				Limits:   container.Resources.Limits.DeepCopy(),
+			}
+		}
+		if raw := pod.Annotations[controller.AnnotationConfig]; raw != "" {
+			var cfg sandboxConfig
+			if err := json.Unmarshal([]byte(raw), &cfg); err == nil {
+				state.OriginalTTL = cfg.TTL
+			}
+		}
+	}
+	data, err := json.Marshal(state)
+	if err != nil {
+		return "", fmt.Errorf("marshal paused state: %w", err)
+	}
+	return string(data), nil
+}
+
+func pausedStateOriginalTTL(pod *corev1.Pod) *int32 {
+	if pod == nil || pod.Annotations[controller.AnnotationPausedState] == "" {
+		return nil
+	}
+	var state pausedState
+	if err := json.Unmarshal([]byte(pod.Annotations[controller.AnnotationPausedState]), &state); err != nil {
+		return nil
+	}
+	return state.OriginalTTL
+}
+
+func applyPausedResourceTargets(pod *corev1.Pod, newRequestMemory, newLimitMemory, minCPU resource.Quantity) bool {
+	if pod == nil {
+		return false
+	}
+	for i := range pod.Spec.Containers {
+		container := &pod.Spec.Containers[i]
+		if container.Name != "procd" {
+			continue
+		}
+		if container.Resources.Requests == nil {
+			container.Resources.Requests = corev1.ResourceList{}
+		}
+		if !newRequestMemory.IsZero() {
+			container.Resources.Requests[corev1.ResourceMemory] = newRequestMemory
+		}
+		container.Resources.Requests[corev1.ResourceCPU] = minCPU
+		if container.Resources.Limits == nil {
+			container.Resources.Limits = corev1.ResourceList{}
+		}
+		if !newLimitMemory.IsZero() {
+			container.Resources.Limits[corev1.ResourceMemory] = newLimitMemory
+		}
+		container.Resources.Limits[corev1.ResourceCPU] = minCPU
+		return true
+	}
+	return false
+}
+
+func usageWorkingSet(usage *ctldapi.SandboxResourceUsage) int64 {
+	if usage == nil {
+		return 0
+	}
+	return usage.ContainerMemoryWorkingSet
+}
+
+func parseQuantityOrDefault(raw, fallback string) resource.Quantity {
+	quantity, err := resource.ParseQuantity(raw)
+	if err == nil {
+		return quantity
+	}
+	return resource.MustParse(fallback)
+}
+
+func powerStateFromAnnotations(annotations map[string]string) powerState {
+	legacyObserved := powerStateActive
+	if annotations[controller.AnnotationPaused] == "true" {
+		legacyObserved = powerStatePaused
+	}
+	state := powerState{
+		Desired:            normalizePowerState(annotations[controller.AnnotationPowerStateDesired], legacyObserved),
+		DesiredGeneration:  parseInt64Annotation(annotations, controller.AnnotationPowerStateDesiredGeneration),
+		Observed:           normalizePowerState(annotations[controller.AnnotationPowerStateObserved], legacyObserved),
+		ObservedGeneration: parseInt64Annotation(annotations, controller.AnnotationPowerStateObservedGeneration),
+	}
+	state.Phase = normalizePowerPhase(annotations[controller.AnnotationPowerStatePhase], state.Desired, state.Observed)
+	return state
+}
+
+func normalizePowerState(raw, fallback string) string {
+	switch strings.TrimSpace(raw) {
+	case powerStateActive:
+		return powerStateActive
+	case powerStatePaused:
+		return powerStatePaused
+	default:
+		return fallback
+	}
+}
+
+func normalizePowerPhase(raw, desired, observed string) string {
+	switch strings.TrimSpace(raw) {
+	case powerPhaseStable:
+		return powerPhaseStable
+	case powerPhasePausing:
+		return powerPhasePausing
+	case powerPhaseResuming:
+		return powerPhaseResuming
+	}
+	return phaseFor(desired, observed)
+}
+
+func phaseFor(desired, observed string) string {
+	if desired == observed {
+		return powerPhaseStable
+	}
+	if desired == powerStatePaused {
+		return powerPhasePausing
+	}
+	return powerPhaseResuming
+}
+
+func applyPowerStateAnnotations(annotations map[string]string, state powerState) {
+	annotations[controller.AnnotationPowerStateDesired] = state.Desired
+	annotations[controller.AnnotationPowerStateDesiredGeneration] = strconv.FormatInt(state.DesiredGeneration, 10)
+	annotations[controller.AnnotationPowerStateObserved] = state.Observed
+	annotations[controller.AnnotationPowerStateObservedGeneration] = strconv.FormatInt(state.ObservedGeneration, 10)
+	annotations[controller.AnnotationPowerStatePhase] = state.Phase
+}
+
+func parseInt64Annotation(annotations map[string]string, key string) int64 {
+	raw := strings.TrimSpace(annotations[key])
+	if raw == "" {
+		return 0
+	}
+	value, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || value < 0 {
+		return 0
+	}
+	return value
+}
+
+func setExpirationAnnotation(annotations map[string]string, now time.Time, ttl *int32) {
+	if ttl == nil || *ttl <= 0 {
+		delete(annotations, controller.AnnotationExpiresAt)
+		return
+	}
+	annotations[controller.AnnotationExpiresAt] = now.Add(time.Duration(*ttl) * time.Second).Format(time.RFC3339)
+}

--- a/ctld/internal/ctld/power/reconciler_test.go
+++ b/ctld/internal/ctld/power/reconciler_test.go
@@ -1,0 +1,225 @@
+package power
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/sandbox0-ai/sandbox0/ctld/internal/ctld/cgroup"
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestPowerReconcilerPausesDesiredPausedPod(t *testing.T) {
+	const uid = "pod-uid-1"
+	root := t.TempDir()
+	cgroupDir := writeReconcilerTestCgroup(t, root, uid, "0", 40*1024*1024)
+	pod := newReconcilerTestPod(uid, map[string]string{
+		controller.AnnotationConfig:                       `{"ttl":120}`,
+		controller.AnnotationExpiresAt:                    time.Now().UTC().Add(time.Minute).Format(time.RFC3339),
+		controller.AnnotationPowerStateDesired:            powerStatePaused,
+		controller.AnnotationPowerStateDesiredGeneration:  "1",
+		controller.AnnotationPowerStateObserved:           powerStateActive,
+		controller.AnnotationPowerStateObservedGeneration: "0",
+		controller.AnnotationPowerStatePhase:              powerPhasePausing,
+	})
+	client := fake.NewSimpleClientset(pod)
+	reconciler := newReconcilerForTest(client, root)
+
+	require.NoError(t, reconciler.reconcilePod(context.Background(), pod))
+
+	assert.Equal(t, "1", readReconcilerTestFile(t, filepath.Join(cgroupDir, "cgroup.freeze")))
+	updated, err := client.CoreV1().Pods("default").Get(context.Background(), "sandbox-1", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "true", updated.Annotations[controller.AnnotationPaused])
+	assert.NotEmpty(t, updated.Annotations[controller.AnnotationPausedAt])
+	assert.Empty(t, updated.Annotations[controller.AnnotationExpiresAt])
+
+	state := powerStateFromAnnotations(updated.Annotations)
+	assert.Equal(t, powerStatePaused, state.Desired)
+	assert.Equal(t, powerStatePaused, state.Observed)
+	assert.Equal(t, int64(1), state.ObservedGeneration)
+	assert.Equal(t, powerPhaseStable, state.Phase)
+
+	var saved pausedState
+	require.NoError(t, json.Unmarshal([]byte(updated.Annotations[controller.AnnotationPausedState]), &saved))
+	require.NotNil(t, saved.OriginalTTL)
+	assert.Equal(t, int32(120), *saved.OriginalTTL)
+	assert.Equal(t, resource.MustParse("128Mi"), saved.Resources["procd"].Requests[corev1.ResourceMemory])
+
+	procd := updated.Spec.Containers[0]
+	requestMemory := procd.Resources.Requests[corev1.ResourceMemory]
+	limitMemory := procd.Resources.Limits[corev1.ResourceMemory]
+	assert.Equal(t, resource.MustParse("10m"), procd.Resources.Requests[corev1.ResourceCPU])
+	assert.Equal(t, int64(40*1024*1024), requestMemory.Value())
+	assert.Equal(t, int64(80*1024*1024), limitMemory.Value())
+}
+
+func TestPowerReconcilerResumesDesiredActivePod(t *testing.T) {
+	const uid = "pod-uid-2"
+	root := t.TempDir()
+	cgroupDir := writeReconcilerTestCgroup(t, root, uid, "1", 20*1024*1024)
+	originalTTL := int32(90)
+	pausedStateJSON := mustMarshalReconcilerPausedState(t, pausedState{
+		Resources: map[string]containerResources{
+			"procd": {
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("128Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("200m"),
+					corev1.ResourceMemory: resource.MustParse("256Mi"),
+				},
+			},
+		},
+		OriginalTTL: &originalTTL,
+	})
+	pod := newReconcilerTestPod(uid, map[string]string{
+		controller.AnnotationPaused:                       "true",
+		controller.AnnotationPausedAt:                     time.Now().UTC().Add(-time.Minute).Format(time.RFC3339),
+		controller.AnnotationPausedState:                  pausedStateJSON,
+		controller.AnnotationPowerStateDesired:            powerStateActive,
+		controller.AnnotationPowerStateDesiredGeneration:  "2",
+		controller.AnnotationPowerStateObserved:           powerStatePaused,
+		controller.AnnotationPowerStateObservedGeneration: "1",
+		controller.AnnotationPowerStatePhase:              powerPhaseResuming,
+	})
+	pod.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("10m"),
+			corev1.ResourceMemory: resource.MustParse("32Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("10m"),
+			corev1.ResourceMemory: resource.MustParse("64Mi"),
+		},
+	}
+	client := fake.NewSimpleClientset(pod)
+	reconciler := newReconcilerForTest(client, root)
+
+	require.NoError(t, reconciler.reconcilePod(context.Background(), pod))
+
+	assert.Equal(t, "0", readReconcilerTestFile(t, filepath.Join(cgroupDir, "cgroup.freeze")))
+	updated, err := client.CoreV1().Pods("default").Get(context.Background(), "sandbox-1", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, updated.Annotations[controller.AnnotationPaused])
+	assert.Empty(t, updated.Annotations[controller.AnnotationPausedAt])
+	assert.Empty(t, updated.Annotations[controller.AnnotationPausedState])
+	assert.NotEmpty(t, updated.Annotations[controller.AnnotationExpiresAt])
+
+	state := powerStateFromAnnotations(updated.Annotations)
+	assert.Equal(t, powerStateActive, state.Desired)
+	assert.Equal(t, powerStateActive, state.Observed)
+	assert.Equal(t, int64(2), state.ObservedGeneration)
+	assert.Equal(t, powerPhaseStable, state.Phase)
+
+	procd := updated.Spec.Containers[0]
+	assert.Equal(t, resource.MustParse("100m"), procd.Resources.Requests[corev1.ResourceCPU])
+	assert.Equal(t, resource.MustParse("128Mi"), procd.Resources.Requests[corev1.ResourceMemory])
+	assert.Equal(t, resource.MustParse("200m"), procd.Resources.Limits[corev1.ResourceCPU])
+	assert.Equal(t, resource.MustParse("256Mi"), procd.Resources.Limits[corev1.ResourceMemory])
+}
+
+func TestPowerReconcilerResumesInFlightPauseCancellation(t *testing.T) {
+	const uid = "pod-uid-3"
+	root := t.TempDir()
+	cgroupDir := writeReconcilerTestCgroup(t, root, uid, "1", 20*1024*1024)
+	pod := newReconcilerTestPod(uid, map[string]string{
+		controller.AnnotationPowerStateDesired:            powerStateActive,
+		controller.AnnotationPowerStateDesiredGeneration:  "3",
+		controller.AnnotationPowerStateObserved:           powerStateActive,
+		controller.AnnotationPowerStateObservedGeneration: "1",
+		controller.AnnotationPowerStatePhase:              powerPhaseResuming,
+	})
+	client := fake.NewSimpleClientset(pod)
+	reconciler := newReconcilerForTest(client, root)
+
+	require.NoError(t, reconciler.reconcilePod(context.Background(), pod))
+
+	assert.Equal(t, "0", readReconcilerTestFile(t, filepath.Join(cgroupDir, "cgroup.freeze")))
+	updated, err := client.CoreV1().Pods("default").Get(context.Background(), "sandbox-1", metav1.GetOptions{})
+	require.NoError(t, err)
+	state := powerStateFromAnnotations(updated.Annotations)
+	assert.Equal(t, powerStateActive, state.Desired)
+	assert.Equal(t, powerStateActive, state.Observed)
+	assert.Equal(t, int64(3), state.ObservedGeneration)
+	assert.Equal(t, powerPhaseStable, state.Phase)
+}
+
+func newReconcilerForTest(client kubernetes.Interface, cgroupRoot string) *PowerReconciler {
+	resolver := NewPodResolver(client, "node-a", cgroupRoot)
+	controller := NewController(resolver, &cgroup.FS{SettleTimeout: 100 * time.Millisecond, PollInterval: time.Millisecond})
+	return NewPowerReconciler(client, nil, resolver, controller, PowerReconcilerConfig{
+		PauseMinMemoryRequest:  "10Mi",
+		PauseMinMemoryLimit:    "32Mi",
+		PauseMemoryBufferRatio: 2,
+		PauseMinCPU:            "10m",
+	})
+}
+
+func newReconcilerTestPod(uid string, annotations map[string]string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sandbox-1",
+			Namespace: "default",
+			UID:       types.UID(uid),
+			Labels: map[string]string{
+				controller.LabelSandboxID: "sandbox-1",
+				controller.LabelPoolType:  controller.PoolTypeActive,
+			},
+			Annotations: annotations,
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "node-a",
+			Containers: []corev1.Container{{
+				Name: "procd",
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("100m"),
+						corev1.ResourceMemory: resource.MustParse("128Mi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("200m"),
+						corev1.ResourceMemory: resource.MustParse("256Mi"),
+					},
+				},
+			}},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+}
+
+func writeReconcilerTestCgroup(t *testing.T, root, uid, frozen string, memoryCurrent int64) string {
+	t.Helper()
+	dir := filepath.Join(root, "kubepods", "pod"+uid)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "cgroup.freeze"), []byte(frozen), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "memory.current"), []byte(strconv.FormatInt(memoryCurrent, 10)), 0o644))
+	return dir
+}
+
+func readReconcilerTestFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return string(data)
+}
+
+func mustMarshalReconcilerPausedState(t *testing.T, state pausedState) string {
+	t.Helper()
+	data, err := json.Marshal(state)
+	require.NoError(t, err)
+	return string(data)
+}

--- a/infra-operator/internal/controller/pkg/rbac/rbac.go
+++ b/infra-operator/internal/controller/pkg/rbac/rbac.go
@@ -183,11 +183,18 @@ func (r *Reconciler) ReconcileCtldRBAC(ctx context.Context, infra *infrav1alpha1
 		return err
 	}
 
-	rules := []rbacv1.PolicyRule{{
-		APIGroups: []string{""},
-		Resources: []string{"pods"},
-		Verbs:     []string{"get", "list", "watch"},
-	}}
+	rules := []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{""},
+			Resources: []string{"pods"},
+			Verbs:     []string{"get", "list", "watch", "update", "patch"},
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{"pods/resize"},
+			Verbs:     []string{"update", "patch"},
+		},
+	}
 
 	if err := r.reconcileClusterRole(ctx, name, labels, rules); err != nil {
 		return err

--- a/infra-operator/internal/controller/pkg/rbac/rbac_test.go
+++ b/infra-operator/internal/controller/pkg/rbac/rbac_test.go
@@ -155,10 +155,20 @@ func TestReconcileCtldRBACIncludesPodReadPermissions(t *testing.T) {
 		if !contains(rule.Resources, "pods") {
 			continue
 		}
-		assert.ElementsMatch(t, []string{"get", "list", "watch"}, rule.Verbs)
+		assert.ElementsMatch(t, []string{"get", "list", "watch", "update", "patch"}, rule.Verbs)
 		found = true
 	}
-	assert.True(t, found, "expected ctld cluster role to include pod read permissions")
+	assert.True(t, found, "expected ctld cluster role to include pod reconcile permissions")
+
+	found = false
+	for _, rule := range role.Rules {
+		if !contains(rule.Resources, "pods/resize") {
+			continue
+		}
+		assert.ElementsMatch(t, []string{"update", "patch"}, rule.Verbs)
+		found = true
+	}
+	assert.True(t, found, "expected ctld cluster role to include pod resize permissions")
 }
 
 func contains(values []string, target string) bool {

--- a/infra-operator/internal/controller/services/fuseplugin/fuseplugin.go
+++ b/infra-operator/internal/controller/services/fuseplugin/fuseplugin.go
@@ -40,6 +40,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 	}
 
 	nodeSelector, tolerations := common.ResolveSandboxNodePlacement(infra)
+	args := ctldArgs(infra)
 
 	desired := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -67,7 +68,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 							Name:            "ctld",
 							Image:           image,
 							ImagePullPolicy: pullPolicy,
-							Args:            []string{"-http-addr=:8095", "-cgroup-root=/host-sys/fs/cgroup", "-cri-endpoint=/host-run/containerd/containerd.sock"},
+							Args:            args,
 							Env: []corev1.EnvVar{
 								{
 									Name:  "SERVICE",
@@ -149,4 +150,48 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 	}
 
 	return r.Resources.ApplyDaemonSet(ctx, infra, desired)
+}
+
+func ctldArgs(infra *infrav1alpha1.Sandbox0Infra) []string {
+	cfg := ctldManagerConfig(infra)
+	pauseMinMemoryRequest := "10Mi"
+	pauseMinMemoryLimit := "32Mi"
+	pauseMemoryBufferRatio := "1.1"
+	pauseMinCPU := "10m"
+	defaultTTL := "0s"
+	if cfg != nil {
+		pauseMinMemoryRequest = stringOrDefault(cfg.PauseMinMemoryRequest, pauseMinMemoryRequest)
+		pauseMinMemoryLimit = stringOrDefault(cfg.PauseMinMemoryLimit, pauseMinMemoryLimit)
+		pauseMemoryBufferRatio = stringOrDefault(cfg.PauseMemoryBufferRatio, pauseMemoryBufferRatio)
+		pauseMinCPU = stringOrDefault(cfg.PauseMinCPU, pauseMinCPU)
+		if cfg.DefaultSandboxTTL.Duration > 0 {
+			defaultTTL = cfg.DefaultSandboxTTL.Duration.String()
+		}
+	}
+
+	args := []string{
+		"-http-addr=:8095",
+		"-cgroup-root=/host-sys/fs/cgroup",
+		"-cri-endpoint=/host-run/containerd/containerd.sock",
+		fmt.Sprintf("-pause-min-memory-request=%s", pauseMinMemoryRequest),
+		fmt.Sprintf("-pause-min-memory-limit=%s", pauseMinMemoryLimit),
+		fmt.Sprintf("-pause-memory-buffer-ratio=%s", pauseMemoryBufferRatio),
+		fmt.Sprintf("-pause-min-cpu=%s", pauseMinCPU),
+		fmt.Sprintf("-default-sandbox-ttl=%s", defaultTTL),
+	}
+	return args
+}
+
+func ctldManagerConfig(infra *infrav1alpha1.Sandbox0Infra) *infrav1alpha1.ManagerConfig {
+	if infra == nil || infra.Spec.Services == nil || infra.Spec.Services.Manager == nil {
+		return nil
+	}
+	return infra.Spec.Services.Manager.Config
+}
+
+func stringOrDefault(value, fallback string) string {
+	if value == "" {
+		return fallback
+	}
+	return value
 }

--- a/infra-operator/internal/controller/services/fuseplugin/fuseplugin_test.go
+++ b/infra-operator/internal/controller/services/fuseplugin/fuseplugin_test.go
@@ -3,6 +3,7 @@ package fuseplugin
 import (
 	"context"
 	"testing"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -118,6 +119,45 @@ func reconcileFusePluginDaemonSet(t *testing.T, infra *infrav1alpha1.Sandbox0Inf
 	}
 
 	return ds
+}
+
+func TestReconcilePassesDefaultPauseConfigToCtld(t *testing.T) {
+	ds := reconcileFusePluginDaemonSet(t, newFusePluginTestInfra())
+	args := ds.Spec.Template.Spec.Containers[0].Args
+	assertContainsArg(t, args, "-pause-min-memory-request=10Mi")
+	assertContainsArg(t, args, "-pause-min-memory-limit=32Mi")
+	assertContainsArg(t, args, "-pause-memory-buffer-ratio=1.1")
+	assertContainsArg(t, args, "-pause-min-cpu=10m")
+	assertContainsArg(t, args, "-default-sandbox-ttl=0s")
+}
+
+func TestReconcilePassesPauseConfigToCtld(t *testing.T) {
+	infra := newFusePluginTestInfra()
+	infra.Spec.Services.Manager.Config = &infrav1alpha1.ManagerConfig{
+		PauseMinMemoryRequest:  "24Mi",
+		PauseMinMemoryLimit:    "96Mi",
+		PauseMemoryBufferRatio: "1.4",
+		PauseMinCPU:            "25m",
+		DefaultSandboxTTL:      metav1.Duration{Duration: 5 * time.Minute},
+	}
+
+	ds := reconcileFusePluginDaemonSet(t, infra)
+	args := ds.Spec.Template.Spec.Containers[0].Args
+	assertContainsArg(t, args, "-pause-min-memory-request=24Mi")
+	assertContainsArg(t, args, "-pause-min-memory-limit=96Mi")
+	assertContainsArg(t, args, "-pause-memory-buffer-ratio=1.4")
+	assertContainsArg(t, args, "-pause-min-cpu=25m")
+	assertContainsArg(t, args, "-default-sandbox-ttl=5m0s")
+}
+
+func assertContainsArg(t *testing.T, args []string, want string) {
+	t.Helper()
+	for _, arg := range args {
+		if arg == want {
+			return
+		}
+	}
+	t.Fatalf("expected args to contain %q, got %#v", want, args)
 }
 
 func newFusePluginTestInfra() *infrav1alpha1.Sandbox0Infra {

--- a/manager/pkg/service/ctld_client.go
+++ b/manager/pkg/service/ctld_client.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
 	"github.com/sandbox0-ai/sandbox0/pkg/sandboxprobe"
 )
 
@@ -41,14 +40,6 @@ func NewCtldClientWithHTTPClient(httpClient *http.Client) *CtldClient {
 		httpClient = &http.Client{Timeout: defaultCtldClientTimeout}
 	}
 	return &CtldClient{httpClient: httpClient}
-}
-
-func (c *CtldClient) Pause(ctx context.Context, ctldAddress, sandboxID string) (*ctldapi.PauseResponse, error) {
-	return doCtldRequest[ctldapi.PauseResponse](ctx, c.httpClient, ctldAddress, sandboxID, "/pause")
-}
-
-func (c *CtldClient) Resume(ctx context.Context, ctldAddress, sandboxID string) (*ctldapi.ResumeResponse, error) {
-	return doCtldRequest[ctldapi.ResumeResponse](ctx, c.httpClient, ctldAddress, sandboxID, "/resume")
 }
 
 func (c *CtldClient) Probe(ctx context.Context, ctldAddress, sandboxID string, kind sandboxprobe.Kind) (*sandboxprobe.Response, error) {

--- a/manager/pkg/service/ctld_client_test.go
+++ b/manager/pkg/service/ctld_client_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
 	"github.com/sandbox0-ai/sandbox0/pkg/sandboxprobe"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -19,39 +18,6 @@ func TestNewCtldClientUsesDefaultTimeout(t *testing.T) {
 
 	require.NotNil(t, client.httpClient)
 	assert.Equal(t, 15*time.Second, client.httpClient.Timeout)
-}
-
-func TestCtldClientPause(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Equal(t, "/api/v1/sandboxes/sandbox-1/pause", r.URL.Path)
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"paused":true,"resource_usage":{"container_memory_working_set":123}}`))
-	}))
-	defer server.Close()
-
-	client := NewCtldClient(CtldClientConfig{})
-	resp, err := client.Pause(context.Background(), server.URL, "sandbox-1")
-	require.NoError(t, err)
-	assert.True(t, resp.Paused)
-	assert.Equal(t, int64(123), resp.ResourceUsage.ContainerMemoryWorkingSet)
-}
-
-func TestCtldClientResumeReturnsDecodedBodyOnFailure(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/api/v1/sandboxes/sandbox-1/resume", r.URL.Path)
-		w.WriteHeader(http.StatusNotImplemented)
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(ctldapi.ResumeResponse{Resumed: false, Error: "not implemented"})
-	}))
-	defer server.Close()
-
-	client := NewCtldClient(CtldClientConfig{})
-	resp, err := client.Resume(context.Background(), server.URL, "sandbox-1")
-	require.Error(t, err)
-	require.NotNil(t, resp)
-	assert.False(t, resp.Resumed)
-	assert.Equal(t, "not implemented", resp.Error)
 }
 
 func TestCtldClientProbeReturnsDecodedBodyOnFailure(t *testing.T) {

--- a/manager/pkg/service/power_executor.go
+++ b/manager/pkg/service/power_executor.go
@@ -2,16 +2,14 @@ package service
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
-	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // SandboxPowerExecutor executes pause and resume transitions for a sandbox.
-// The default implementation stays manager-local today and will be replaced by ctld later.
+// The manager-local implementation executes transitions directly; ctld mode records desired state for node-local reconciliation.
 type SandboxPowerExecutor interface {
 	Pause(ctx context.Context, sandboxID string) (*PauseSandboxResponse, error)
 	Resume(ctx context.Context, sandboxID string) (*ResumeSandboxResponse, error)
@@ -45,85 +43,11 @@ func (e *localSandboxPowerExecutor) Resume(ctx context.Context, sandboxID string
 }
 
 func (e *ctldSandboxPowerExecutor) Pause(ctx context.Context, sandboxID string) (*PauseSandboxResponse, error) {
-	pod, err := e.service.getSandboxPodForPowerState(ctx, sandboxID)
-	if err != nil {
-		return nil, fmt.Errorf("get pod: %w", err)
-	}
-	expected := currentSandboxPowerExpectation(pod.Annotations, SandboxPowerStatePaused)
-	ctldAddress, err := e.service.ctldAddressForSandbox(ctx, sandboxID)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := e.service.ctldClient.Pause(ctx, ctldAddress, sandboxID)
-	if err != nil {
-		return nil, err
-	}
-	if !resp.Paused {
-		return nil, fmt.Errorf("ctld pause failed: %s", resp.Error)
-	}
-	pauseResp, err := e.service.completePausedSandbox(ctx, pod, sandboxID, sandboxUsageFromCtld(resp.ResourceUsage), expected)
-	if err != nil && errors.Is(err, errSandboxPowerStateStale) {
-		freshPod, getErr := e.service.getSandboxPodForPowerState(ctx, sandboxID)
-		if getErr == nil {
-			current := sandboxPowerStateFromAnnotations(freshPod.Annotations)
-			if current.Desired == SandboxPowerStateActive {
-				_, _ = e.service.ctldClient.Resume(ctx, ctldAddress, sandboxID)
-				return &PauseSandboxResponse{SandboxID: sandboxID, Paused: false, PowerState: current}, nil
-			}
-		}
-	}
-	return pauseResp, err
+	return e.service.RequestPauseSandbox(ctx, sandboxID)
 }
 
 func (e *ctldSandboxPowerExecutor) Resume(ctx context.Context, sandboxID string) (*ResumeSandboxResponse, error) {
-	pod, err := e.service.getSandboxPodForPowerState(ctx, sandboxID)
-	if err != nil {
-		return nil, fmt.Errorf("get pod: %w", err)
-	}
-	expected := currentSandboxPowerExpectation(pod.Annotations, SandboxPowerStateActive)
-	prep, resp, err := e.service.prepareSandboxResume(ctx, pod, sandboxID, expected)
-	if err != nil {
-		return nil, err
-	}
-	if resp != nil {
-		return resp, nil
-	}
-	ctldAddress, err := e.service.ctldAddressForPod(ctx, prep.Pod)
-	if err != nil {
-		return nil, err
-	}
-	ctldResp, err := e.service.ctldClient.Resume(ctx, ctldAddress, sandboxID)
-	if err != nil {
-		return nil, err
-	}
-	if !ctldResp.Resumed {
-		return nil, fmt.Errorf("ctld resume failed: %s", ctldResp.Error)
-	}
-	powerState, err := e.service.completeSandboxResume(ctx, sandboxID, expected)
-	if err != nil {
-		return nil, err
-	}
-	return &ResumeSandboxResponse{SandboxID: sandboxID, Resumed: true, PowerState: powerState, RestoredMemory: prep.RestoredMemory}, nil
-}
-
-func sandboxUsageFromCtld(in *ctldapi.SandboxResourceUsage) *SandboxResourceUsage {
-	if in == nil {
-		return nil
-	}
-	return &SandboxResourceUsage{
-		ContainerMemoryUsage:      in.ContainerMemoryUsage,
-		ContainerMemoryLimit:      in.ContainerMemoryLimit,
-		ContainerMemoryWorkingSet: in.ContainerMemoryWorkingSet,
-		TotalMemoryRSS:            in.TotalMemoryRSS,
-		TotalMemoryVMS:            in.TotalMemoryVMS,
-		TotalOpenFiles:            in.TotalOpenFiles,
-		TotalThreadCount:          in.TotalThreadCount,
-		TotalIOReadBytes:          in.TotalIOReadBytes,
-		TotalIOWriteBytes:         in.TotalIOWriteBytes,
-		ContextCount:              in.ContextCount,
-		RunningContextCount:       in.RunningContextCount,
-		PausedContextCount:        in.PausedContextCount,
-	}
+	return e.service.RequestResumeSandbox(ctx, sandboxID)
 }
 
 func (s *SandboxService) ctldAddressForSandbox(ctx context.Context, sandboxID string) (string, error) {

--- a/manager/pkg/service/power_executor_ctld_test.go
+++ b/manager/pkg/service/power_executor_ctld_test.go
@@ -2,9 +2,6 @@ package service
 
 import (
 	"context"
-	"net/http"
-	"net/http/httptest"
-	"net/url"
 	"testing"
 	"time"
 
@@ -13,23 +10,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
 )
-
-type rewriteTransport struct {
-	base   http.RoundTripper
-	target *url.URL
-}
-
-func (t *rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	clone := req.Clone(req.Context())
-	clone.URL.Scheme = t.target.Scheme
-	clone.URL.Host = t.target.Host
-	clone.Host = t.target.Host
-	return t.base.RoundTrip(clone)
-}
 
 func TestCtldAddressForSandboxUsesNodeInternalIP(t *testing.T) {
 	pod := &corev1.Pod{
@@ -61,185 +45,105 @@ func TestNewSandboxServiceUsesCtldExecutorWhenEnabled(t *testing.T) {
 	assert.Equal(t, 15*time.Second, svc.ctldClient.httpClient.Timeout)
 }
 
-func TestCtldPowerExecutorCallsCtldPause(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Equal(t, "/api/v1/sandboxes/sandbox-1/pause", r.URL.Path)
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"paused":true,"resource_usage":{"container_memory_working_set":456}}`))
-	}))
-	defer server.Close()
-	target, err := url.Parse(server.URL)
-	require.NoError(t, err)
+func TestCtldPowerExecutorRequestsPauseAsDesiredState(t *testing.T) {
 	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "sandbox-1", Namespace: "default", Labels: map[string]string{"sandbox0.ai/sandbox-id": "sandbox-1"}},
-		Spec:       corev1.PodSpec{NodeName: "node-1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sandbox-1",
+			Namespace: "default",
+			Labels: map[string]string{
+				controller.LabelSandboxID: "sandbox-1",
+			},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
 	}
-	node := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
-		Status:     corev1.NodeStatus{Addresses: []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "10.0.0.12"}}},
-	}
-	transport := &rewriteTransport{base: server.Client().Transport, target: target}
-
 	svc := &SandboxService{
-		k8sClient:  fake.NewSimpleClientset(pod, node),
-		ctldClient: NewCtldClientWithHTTPClient(&http.Client{Transport: transport}),
-		config:     SandboxServiceConfig{CtldEnabled: true, CtldPort: 8095, PauseMinCPU: "10m", PauseMemoryBufferRatio: 1.1},
-		logger:     zap.NewNop(),
-		clock:      systemTime{},
+		k8sClient: fake.NewSimpleClientset(pod),
+		podLister: newTestPodLister(t, pod),
+		config:    SandboxServiceConfig{CtldEnabled: true, CtldPort: 8095},
+		logger:    zap.NewNop(),
+		clock:     systemTime{},
 	}
 	svc.SetPowerExecutor(&ctldSandboxPowerExecutor{service: svc})
 
 	resp, err := svc.PauseSandbox(context.Background(), "sandbox-1")
 	require.NoError(t, err)
 	assert.True(t, resp.Paused)
-	assert.Equal(t, int64(456), resp.ResourceUsage.ContainerMemoryWorkingSet)
+	assert.Equal(t, SandboxPowerStatePaused, resp.PowerState.Desired)
+	assert.Equal(t, SandboxPowerStateActive, resp.PowerState.Observed)
+	assert.Equal(t, SandboxPowerPhasePausing, resp.PowerState.Phase)
 
 	updated, err := svc.k8sClient.CoreV1().Pods("default").Get(context.Background(), "sandbox-1", metav1.GetOptions{})
 	require.NoError(t, err)
-	assert.Equal(t, "true", updated.Annotations[controller.AnnotationPaused])
-	assert.NotEmpty(t, updated.Annotations[controller.AnnotationPausedState])
-	assert.Equal(t, SandboxPowerStatePaused, updated.Annotations[controller.AnnotationPowerStateObserved])
-}
-
-func TestCtldPowerExecutorCallsCtldResumeAfterRestoringState(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Equal(t, "/api/v1/sandboxes/sandbox-1/resume", r.URL.Path)
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"resumed":true}`))
-	}))
-	defer server.Close()
-	target, err := url.Parse(server.URL)
-	require.NoError(t, err)
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "sandbox-1",
-			Namespace: "default",
-			Labels:    map[string]string{"sandbox0.ai/sandbox-id": "sandbox-1"},
-			Annotations: map[string]string{
-				controller.AnnotationPaused:      "true",
-				controller.AnnotationPausedAt:    time.Now().UTC().Format(time.RFC3339),
-				controller.AnnotationPausedState: `{"resources":{"procd":{"requests":{"cpu":"100m","memory":"128Mi"},"limits":{"cpu":"200m","memory":"256Mi"}}}}`,
-			},
-		},
-		Spec: corev1.PodSpec{
-			NodeName: "node-1",
-			Containers: []corev1.Container{{
-				Name: "procd",
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("10m"), corev1.ResourceMemory: resource.MustParse("64Mi")},
-					Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("10m"), corev1.ResourceMemory: resource.MustParse("96Mi")},
-				},
-			}},
-		},
-	}
-	node := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
-		Status:     corev1.NodeStatus{Addresses: []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "10.0.0.12"}}},
-	}
-	transport := &rewriteTransport{base: server.Client().Transport, target: target}
-
-	svc := &SandboxService{
-		k8sClient:  fake.NewSimpleClientset(pod, node),
-		ctldClient: NewCtldClientWithHTTPClient(&http.Client{Transport: transport}),
-		config:     SandboxServiceConfig{CtldEnabled: true, CtldPort: 8095, PauseMinCPU: "10m", PauseMemoryBufferRatio: 1.1},
-		logger:     zap.NewNop(),
-		clock:      systemTime{},
-	}
-	svc.SetPowerExecutor(&ctldSandboxPowerExecutor{service: svc})
-
-	resp, err := svc.ResumeSandbox(context.Background(), "sandbox-1")
-	require.NoError(t, err)
-	assert.True(t, resp.Resumed)
-
-	updated, err := svc.k8sClient.CoreV1().Pods("default").Get(context.Background(), "sandbox-1", metav1.GetOptions{})
-	require.NoError(t, err)
+	state := sandboxPowerStateFromAnnotations(updated.Annotations)
+	assert.Equal(t, SandboxPowerStatePaused, state.Desired)
+	assert.Equal(t, SandboxPowerStateActive, state.Observed)
+	assert.Equal(t, SandboxPowerPhasePausing, state.Phase)
 	assert.Empty(t, updated.Annotations[controller.AnnotationPaused])
 	assert.Empty(t, updated.Annotations[controller.AnnotationPausedState])
-	assert.Equal(t, SandboxPowerStateActive, updated.Annotations[controller.AnnotationPowerStateObserved])
 }
 
-func TestCtldPowerExecutorResumesPartiallyPausedPod(t *testing.T) {
-	resumeCalls := 0
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		resumeCalls++
-		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Equal(t, "/api/v1/sandboxes/sandbox-1/resume", r.URL.Path)
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"resumed":true}`))
-	}))
-	defer server.Close()
-	target, err := url.Parse(server.URL)
-	require.NoError(t, err)
+func TestCtldPowerExecutorRequestsResumeAsDesiredState(t *testing.T) {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "sandbox-1",
 			Namespace: "default",
-			Labels:    map[string]string{"sandbox0.ai/sandbox-id": "sandbox-1"},
+			Labels: map[string]string{
+				controller.LabelSandboxID: "sandbox-1",
+			},
 			Annotations: map[string]string{
-				controller.AnnotationPowerStateDesired:           SandboxPowerStatePaused,
-				controller.AnnotationPowerStateDesiredGeneration: "2",
-				controller.AnnotationPowerStateObserved:          SandboxPowerStateActive,
-				controller.AnnotationPowerStatePhase:             SandboxPowerPhasePausing,
+				controller.AnnotationPaused:                       "true",
+				controller.AnnotationPausedAt:                     time.Now().UTC().Format(time.RFC3339),
+				controller.AnnotationPausedState:                  `{"resources":{"procd":{"requests":{"cpu":"100m","memory":"128Mi"},"limits":{"cpu":"200m","memory":"256Mi"}}}}`,
+				controller.AnnotationPowerStateDesired:            SandboxPowerStatePaused,
+				controller.AnnotationPowerStateDesiredGeneration:  "2",
+				controller.AnnotationPowerStateObserved:           SandboxPowerStatePaused,
+				controller.AnnotationPowerStateObservedGeneration: "2",
+				controller.AnnotationPowerStatePhase:              SandboxPowerPhaseStable,
 			},
 		},
-		Spec: corev1.PodSpec{NodeName: "node-1"},
-		Status: corev1.PodStatus{Conditions: []corev1.PodCondition{{
-			Type:    corev1.PodConditionType("sandbox0.ai/live"),
-			Status:  corev1.ConditionUnknown,
-			Reason:  "SandboxPaused",
-			Message: "sandbox cgroup is frozen",
-		}}},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
 	}
-	node := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
-		Status:     corev1.NodeStatus{Addresses: []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "10.0.0.12"}}},
-	}
-	transport := &rewriteTransport{base: server.Client().Transport, target: target}
-
 	svc := &SandboxService{
-		k8sClient:  fake.NewSimpleClientset(pod, node),
-		ctldClient: NewCtldClientWithHTTPClient(&http.Client{Transport: transport}),
-		config:     SandboxServiceConfig{CtldEnabled: true, CtldPort: 8095, PauseMinCPU: "10m", PauseMemoryBufferRatio: 1.1},
-		logger:     zap.NewNop(),
-		clock:      systemTime{},
+		k8sClient: fake.NewSimpleClientset(pod),
+		podLister: newTestPodLister(t, pod),
+		config:    SandboxServiceConfig{CtldEnabled: true, CtldPort: 8095},
+		logger:    zap.NewNop(),
+		clock:     systemTime{},
 	}
 	svc.SetPowerExecutor(&ctldSandboxPowerExecutor{service: svc})
 
 	resp, err := svc.ResumeSandbox(context.Background(), "sandbox-1")
 	require.NoError(t, err)
 	assert.True(t, resp.Resumed)
-	assert.Equal(t, 1, resumeCalls)
+	assert.Equal(t, SandboxPowerStateActive, resp.PowerState.Desired)
+	assert.Equal(t, SandboxPowerStatePaused, resp.PowerState.Observed)
+	assert.Equal(t, SandboxPowerPhaseResuming, resp.PowerState.Phase)
 
 	updated, err := svc.k8sClient.CoreV1().Pods("default").Get(context.Background(), "sandbox-1", metav1.GetOptions{})
 	require.NoError(t, err)
-	assert.Equal(t, SandboxPowerStateActive, updated.Annotations[controller.AnnotationPowerStateDesired])
-	assert.Equal(t, SandboxPowerStateActive, updated.Annotations[controller.AnnotationPowerStateObserved])
-	assert.Equal(t, SandboxPowerPhaseStable, updated.Annotations[controller.AnnotationPowerStatePhase])
+	state := sandboxPowerStateFromAnnotations(updated.Annotations)
+	assert.Equal(t, SandboxPowerStateActive, state.Desired)
+	assert.Equal(t, SandboxPowerStatePaused, state.Observed)
+	assert.Equal(t, SandboxPowerPhaseResuming, state.Phase)
+	assert.Equal(t, "true", updated.Annotations[controller.AnnotationPaused])
+	assert.NotEmpty(t, updated.Annotations[controller.AnnotationPausedState])
 }
 
-func TestTerminateSandboxThawsFrozenPodBeforeDelete(t *testing.T) {
-	resumeCalls := 0
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		resumeCalls++
-		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Equal(t, "/api/v1/sandboxes/sandbox-1/resume", r.URL.Path)
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"resumed":true}`))
-	}))
-	defer server.Close()
-	target, err := url.Parse(server.URL)
-	require.NoError(t, err)
+func TestTerminateSandboxRequestsAsyncThawBeforeDelete(t *testing.T) {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "sandbox-1",
 			Namespace: "default",
-			Labels:    map[string]string{"sandbox0.ai/sandbox-id": "sandbox-1"},
+			Labels: map[string]string{
+				controller.LabelSandboxID: "sandbox-1",
+			},
 			Annotations: map[string]string{
-				controller.AnnotationPowerStateDesired:  SandboxPowerStatePaused,
-				controller.AnnotationPowerStateObserved: SandboxPowerStateActive,
-				controller.AnnotationPowerStatePhase:    SandboxPowerPhasePausing,
+				controller.AnnotationPaused:                       "true",
+				controller.AnnotationPowerStateDesired:            SandboxPowerStatePaused,
+				controller.AnnotationPowerStateDesiredGeneration:  "2",
+				controller.AnnotationPowerStateObserved:           SandboxPowerStatePaused,
+				controller.AnnotationPowerStateObservedGeneration: "2",
+				controller.AnnotationPowerStatePhase:              SandboxPowerPhaseStable,
 			},
 		},
 		Spec: corev1.PodSpec{NodeName: "node-1"},
@@ -250,81 +154,31 @@ func TestTerminateSandboxThawsFrozenPodBeforeDelete(t *testing.T) {
 			Message: "sandbox cgroup is frozen",
 		}}},
 	}
-	node := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
-		Status:     corev1.NodeStatus{Addresses: []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "10.0.0.12"}}},
-	}
-	transport := &rewriteTransport{base: server.Client().Transport, target: target}
+	k8sClient := fake.NewSimpleClientset(pod)
 	svc := &SandboxService{
-		k8sClient:  fake.NewSimpleClientset(pod, node),
-		podLister:  newTestPodLister(t, pod),
-		ctldClient: NewCtldClientWithHTTPClient(&http.Client{Transport: transport}),
-		config:     SandboxServiceConfig{CtldEnabled: true, CtldPort: 8095},
-		logger:     zap.NewNop(),
+		k8sClient: k8sClient,
+		podLister: newTestPodLister(t, pod),
+		config:    SandboxServiceConfig{CtldEnabled: true, CtldPort: 8095},
+		logger:    zap.NewNop(),
 	}
 
-	err = svc.TerminateSandbox(context.Background(), "sandbox-1")
+	err := svc.TerminateSandbox(context.Background(), "sandbox-1")
 	require.NoError(t, err)
-	assert.Equal(t, 1, resumeCalls)
-}
 
-func TestCtldPowerExecutorResumeFailureKeepsPausedStateAuthoritative(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Equal(t, "/api/v1/sandboxes/sandbox-1/resume", r.URL.Path)
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"resumed":false,"error":"thaw failed"}`))
-	}))
-	defer server.Close()
-	target, err := url.Parse(server.URL)
-	require.NoError(t, err)
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "sandbox-1",
-			Namespace: "default",
-			Labels:    map[string]string{"sandbox0.ai/sandbox-id": "sandbox-1"},
-			Annotations: map[string]string{
-				controller.AnnotationPaused:                      "true",
-				controller.AnnotationPausedAt:                    time.Now().UTC().Format(time.RFC3339),
-				controller.AnnotationPausedState:                 `{"resources":{"procd":{"requests":{"cpu":"100m","memory":"128Mi"},"limits":{"cpu":"200m","memory":"256Mi"}}}}`,
-				controller.AnnotationPowerStateDesired:           SandboxPowerStateActive,
-				controller.AnnotationPowerStateDesiredGeneration: "4",
-				controller.AnnotationPowerStateObserved:          SandboxPowerStatePaused,
-			},
-		},
-		Spec: corev1.PodSpec{
-			NodeName: "node-1",
-			Containers: []corev1.Container{{
-				Name: "procd",
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("10m"), corev1.ResourceMemory: resource.MustParse("64Mi")},
-					Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("10m"), corev1.ResourceMemory: resource.MustParse("96Mi")},
-				},
-			}},
-		},
+	actions := k8sClient.Actions()
+	var firstUpdatedPod *corev1.Pod
+	for _, action := range actions {
+		updateAction, ok := action.(ktesting.UpdateAction)
+		if !ok || action.GetSubresource() != "" {
+			continue
+		}
+		firstUpdatedPod, _ = updateAction.GetObject().(*corev1.Pod)
+		break
 	}
-	node := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
-		Status:     corev1.NodeStatus{Addresses: []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "10.0.0.12"}}},
-	}
-	transport := &rewriteTransport{base: server.Client().Transport, target: target}
-
-	svc := &SandboxService{
-		k8sClient:  fake.NewSimpleClientset(pod, node),
-		ctldClient: NewCtldClientWithHTTPClient(&http.Client{Transport: transport}),
-		config:     SandboxServiceConfig{CtldEnabled: true, CtldPort: 8095, PauseMinCPU: "10m", PauseMemoryBufferRatio: 1.1},
-		logger:     zap.NewNop(),
-		clock:      systemTime{},
-	}
-	svc.SetPowerExecutor(&ctldSandboxPowerExecutor{service: svc})
-
-	_, err = svc.ResumeSandbox(context.Background(), "sandbox-1")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "ctld resume failed")
-
-	updated, err := svc.k8sClient.CoreV1().Pods("default").Get(context.Background(), "sandbox-1", metav1.GetOptions{})
-	require.NoError(t, err)
-	assert.Equal(t, "true", updated.Annotations[controller.AnnotationPaused])
-	assert.NotEmpty(t, updated.Annotations[controller.AnnotationPausedState])
-	assert.Equal(t, SandboxPowerStatePaused, updated.Annotations[controller.AnnotationPowerStateObserved])
+	require.NotNil(t, firstUpdatedPod)
+	state := sandboxPowerStateFromAnnotations(firstUpdatedPod.Annotations)
+	assert.Equal(t, SandboxPowerStateActive, state.Desired)
+	assert.Equal(t, SandboxPowerStatePaused, state.Observed)
+	assert.Equal(t, SandboxPowerPhaseResuming, state.Phase)
+	assert.Equal(t, "delete", actions[len(actions)-1].GetVerb())
 }

--- a/manager/pkg/service/sandbox_service_lifecycle.go
+++ b/manager/pkg/service/sandbox_service_lifecycle.go
@@ -52,29 +52,13 @@ func (s *SandboxService) TerminateSandbox(ctx context.Context, sandboxID string)
 }
 
 func (s *SandboxService) thawSandboxBeforeTermination(ctx context.Context, pod *corev1.Pod, sandboxID string) {
-	if s == nil || s.ctldClient == nil || !s.config.CtldEnabled || !sandboxPodMayHaveFrozenCgroup(pod) {
+	if s == nil || !s.config.CtldEnabled || !sandboxPodMayHaveFrozenCgroup(pod) {
 		return
 	}
-	ctldAddress, err := s.ctldAddressForPod(ctx, pod)
-	if err != nil {
-		s.logger.Warn("Failed to resolve ctld before sandbox termination",
+	if _, err := s.RequestResumeSandbox(ctx, sandboxID); err != nil {
+		s.logger.Warn("Failed to request sandbox thaw before termination",
 			zap.String("sandboxID", sandboxID),
 			zap.Error(err),
-		)
-		return
-	}
-	resp, err := s.ctldClient.Resume(ctx, ctldAddress, sandboxID)
-	if err != nil {
-		s.logger.Warn("Failed to thaw sandbox before termination",
-			zap.String("sandboxID", sandboxID),
-			zap.Error(err),
-		)
-		return
-	}
-	if !resp.Resumed {
-		s.logger.Warn("ctld did not thaw sandbox before termination",
-			zap.String("sandboxID", sandboxID),
-			zap.String("error", resp.Error),
 		)
 	}
 }

--- a/manager/pkg/service/sandbox_service_power.go
+++ b/manager/pkg/service/sandbox_service_power.go
@@ -238,8 +238,11 @@ func (s *SandboxService) requestSandboxPowerState(ctx context.Context, sandboxID
 			return err
 		}
 
-		state = requestedSandboxPowerState(pod.Annotations, target)
 		current := sandboxPowerStateFromAnnotations(pod.Annotations)
+		state = requestedSandboxPowerState(pod.Annotations, target)
+		if s.config.CtldEnabled {
+			state = preserveCtldInFlightPowerTransition(current, state, target)
+		}
 		if hasExplicitSandboxPowerStateAnnotations(pod.Annotations) && sandboxPowerStateEqual(current, state) {
 			return nil
 		}
@@ -250,7 +253,7 @@ func (s *SandboxService) requestSandboxPowerState(ctx context.Context, sandboxID
 		return SandboxPowerState{}, fmt.Errorf("update power state annotations: %w", err)
 	}
 
-	if state.Phase != SandboxPowerPhaseStable {
+	if state.Phase != SandboxPowerPhaseStable && s.managerExecutesPowerTransitions() {
 		s.triggerSandboxPowerStateReconcile(sandboxID)
 	}
 
@@ -279,6 +282,19 @@ func (s *SandboxService) waitForSandboxPowerState(ctx context.Context, sandboxID
 	return state, nil
 }
 
+func preserveCtldInFlightPowerTransition(current, requested SandboxPowerState, target string) SandboxPowerState {
+	if current.Phase == SandboxPowerPhaseStable || current.Observed != target {
+		return requested
+	}
+	requested.ObservedGeneration = current.ObservedGeneration
+	if target == SandboxPowerStatePaused {
+		requested.Phase = SandboxPowerPhasePausing
+	} else {
+		requested.Phase = SandboxPowerPhaseResuming
+	}
+	return requested
+}
+
 func sandboxPowerTransitionContext(ctx context.Context) (context.Context, context.CancelFunc) {
 	if _, ok := ctx.Deadline(); ok {
 		return context.WithCancel(ctx)
@@ -296,8 +312,15 @@ func (s *SandboxService) triggerSandboxPowerStateReconcile(sandboxID string) {
 	}()
 }
 
+func (s *SandboxService) managerExecutesPowerTransitions() bool {
+	return s != nil && !s.config.CtldEnabled
+}
+
 // StartPowerStateReconciler periodically reconciles power transitions left pending by another manager replica.
 func (s *SandboxService) StartPowerStateReconciler(ctx context.Context, interval time.Duration) {
+	if !s.managerExecutesPowerTransitions() {
+		return
+	}
 	if interval <= 0 {
 		interval = 30 * time.Second
 	}

--- a/manager/pkg/service/sandbox_service_power_state_test.go
+++ b/manager/pkg/service/sandbox_service_power_state_test.go
@@ -46,6 +46,116 @@ func TestCompletedSandboxPowerStateAssignsGeneration(t *testing.T) {
 	assert.Equal(t, SandboxPowerPhaseStable, state.Phase)
 }
 
+func TestCtldPowerStateRequestsPreserveInFlightTransitions(t *testing.T) {
+	tests := []struct {
+		name      string
+		current   SandboxPowerState
+		target    string
+		wantState SandboxPowerState
+	}{
+		{
+			name: "pause from stable active",
+			current: SandboxPowerState{
+				Desired:            SandboxPowerStateActive,
+				DesiredGeneration:  4,
+				Observed:           SandboxPowerStateActive,
+				ObservedGeneration: 4,
+				Phase:              SandboxPowerPhaseStable,
+			},
+			target: SandboxPowerStatePaused,
+			wantState: SandboxPowerState{
+				Desired:            SandboxPowerStatePaused,
+				DesiredGeneration:  5,
+				Observed:           SandboxPowerStateActive,
+				ObservedGeneration: 4,
+				Phase:              SandboxPowerPhasePausing,
+			},
+		},
+		{
+			name: "resume from stable paused",
+			current: SandboxPowerState{
+				Desired:            SandboxPowerStatePaused,
+				DesiredGeneration:  4,
+				Observed:           SandboxPowerStatePaused,
+				ObservedGeneration: 4,
+				Phase:              SandboxPowerPhaseStable,
+			},
+			target: SandboxPowerStateActive,
+			wantState: SandboxPowerState{
+				Desired:            SandboxPowerStateActive,
+				DesiredGeneration:  5,
+				Observed:           SandboxPowerStatePaused,
+				ObservedGeneration: 4,
+				Phase:              SandboxPowerPhaseResuming,
+			},
+		},
+		{
+			name: "resume cancels in-flight pause without claiming active is already observed",
+			current: SandboxPowerState{
+				Desired:            SandboxPowerStatePaused,
+				DesiredGeneration:  4,
+				Observed:           SandboxPowerStateActive,
+				ObservedGeneration: 3,
+				Phase:              SandboxPowerPhasePausing,
+			},
+			target: SandboxPowerStateActive,
+			wantState: SandboxPowerState{
+				Desired:            SandboxPowerStateActive,
+				DesiredGeneration:  5,
+				Observed:           SandboxPowerStateActive,
+				ObservedGeneration: 3,
+				Phase:              SandboxPowerPhaseResuming,
+			},
+		},
+		{
+			name: "pause cancels in-flight resume without claiming paused is already observed",
+			current: SandboxPowerState{
+				Desired:            SandboxPowerStateActive,
+				DesiredGeneration:  4,
+				Observed:           SandboxPowerStatePaused,
+				ObservedGeneration: 3,
+				Phase:              SandboxPowerPhaseResuming,
+			},
+			target: SandboxPowerStatePaused,
+			wantState: SandboxPowerState{
+				Desired:            SandboxPowerStatePaused,
+				DesiredGeneration:  5,
+				Observed:           SandboxPowerStatePaused,
+				ObservedGeneration: 3,
+				Phase:              SandboxPowerPhasePausing,
+			},
+		},
+		{
+			name: "duplicate in-flight pause is idempotent",
+			current: SandboxPowerState{
+				Desired:            SandboxPowerStatePaused,
+				DesiredGeneration:  4,
+				Observed:           SandboxPowerStateActive,
+				ObservedGeneration: 3,
+				Phase:              SandboxPowerPhasePausing,
+			},
+			target: SandboxPowerStatePaused,
+			wantState: SandboxPowerState{
+				Desired:            SandboxPowerStatePaused,
+				DesiredGeneration:  4,
+				Observed:           SandboxPowerStateActive,
+				ObservedGeneration: 3,
+				Phase:              SandboxPowerPhasePausing,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			annotations := powerStateAnnotations(tt.current)
+			requested := requestedSandboxPowerState(annotations, tt.target)
+			got := preserveCtldInFlightPowerTransition(tt.current, requested, tt.target)
+
+			assert.Equal(t, tt.wantState, got)
+		})
+	}
+}
+
 func TestPodToSandboxIncludesPowerState(t *testing.T) {
 	svc := &SandboxService{
 		config: SandboxServiceConfig{ProcdPort: 49983},
@@ -750,5 +860,15 @@ func newPowerStatePod(desired, observed, phase string) *corev1.Pod {
 			},
 		},
 		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+}
+
+func powerStateAnnotations(state SandboxPowerState) map[string]string {
+	return map[string]string{
+		controller.AnnotationPowerStateDesired:            state.Desired,
+		controller.AnnotationPowerStateDesiredGeneration:  strconv.FormatInt(state.DesiredGeneration, 10),
+		controller.AnnotationPowerStateObserved:           state.Observed,
+		controller.AnnotationPowerStateObservedGeneration: strconv.FormatInt(state.ObservedGeneration, 10),
+		controller.AnnotationPowerStatePhase:              state.Phase,
 	}
 }

--- a/manager/pkg/service/sandbox_service_power_state_test.go
+++ b/manager/pkg/service/sandbox_service_power_state_test.go
@@ -293,6 +293,35 @@ func TestStartPowerStateReconcilerTriggersPendingTransitions(t *testing.T) {
 	<-done
 }
 
+func TestStartPowerStateReconcilerSkipsWhenCtldEnabled(t *testing.T) {
+	pod := newPowerStatePod(SandboxPowerStatePaused, SandboxPowerStateActive, SandboxPowerPhasePausing)
+	pauseCalled := make(chan struct{})
+	svc := &SandboxService{
+		k8sClient: fake.NewSimpleClientset(pod),
+		podLister: newTestPodLister(t, pod),
+		config:    SandboxServiceConfig{CtldEnabled: true},
+		logger:    zap.NewNop(),
+	}
+	svc.SetPowerExecutor(&completingPowerExecutor{service: svc, pauseCalled: pauseCalled})
+
+	done := make(chan struct{})
+	go func() {
+		svc.StartPowerStateReconciler(context.Background(), time.Millisecond)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("StartPowerStateReconciler did not return when ctld is enabled")
+	}
+	select {
+	case <-pauseCalled:
+		t.Fatal("manager reconciler executed a ctld-owned power transition")
+	default:
+	}
+}
+
 func TestRequestResumeSandboxDoesNotBlockOnInFlightReconcile(t *testing.T) {
 	pod := newPowerStatePod(SandboxPowerStatePaused, SandboxPowerStateActive, SandboxPowerPhasePausing)
 	executor := newBlockingPowerExecutor()
@@ -330,6 +359,52 @@ func TestRequestResumeSandboxDoesNotBlockOnInFlightReconcile(t *testing.T) {
 
 	close(executor.pauseRelease)
 	<-executor.pauseFinished
+}
+
+func TestRequestResumeSandboxKeepsCtldInFlightPausePending(t *testing.T) {
+	pod := newPowerStatePod(SandboxPowerStatePaused, SandboxPowerStateActive, SandboxPowerPhasePausing)
+	svc := &SandboxService{
+		k8sClient: fake.NewSimpleClientset(pod),
+		podLister: newTestPodLister(t, pod),
+		config:    SandboxServiceConfig{CtldEnabled: true},
+		clock:     systemTime{},
+		logger:    zap.NewNop(),
+	}
+
+	resp, err := svc.RequestResumeSandbox(context.Background(), "sandbox-1")
+	require.NoError(t, err)
+	assert.Equal(t, SandboxPowerStateActive, resp.PowerState.Desired)
+	assert.Equal(t, SandboxPowerStateActive, resp.PowerState.Observed)
+	assert.Equal(t, SandboxPowerPhaseResuming, resp.PowerState.Phase)
+	assert.Equal(t, int64(1), resp.PowerState.ObservedGeneration)
+
+	updated, err := svc.k8sClient.CoreV1().Pods("default").Get(context.Background(), "sandbox-1", metav1.GetOptions{})
+	require.NoError(t, err)
+	state := sandboxPowerStateFromAnnotations(updated.Annotations)
+	assert.Equal(t, SandboxPowerPhaseResuming, state.Phase)
+}
+
+func TestRequestPauseSandboxKeepsCtldInFlightResumePending(t *testing.T) {
+	pod := newPowerStatePod(SandboxPowerStateActive, SandboxPowerStatePaused, SandboxPowerPhaseResuming)
+	svc := &SandboxService{
+		k8sClient: fake.NewSimpleClientset(pod),
+		podLister: newTestPodLister(t, pod),
+		config:    SandboxServiceConfig{CtldEnabled: true},
+		clock:     systemTime{},
+		logger:    zap.NewNop(),
+	}
+
+	resp, err := svc.RequestPauseSandbox(context.Background(), "sandbox-1")
+	require.NoError(t, err)
+	assert.Equal(t, SandboxPowerStatePaused, resp.PowerState.Desired)
+	assert.Equal(t, SandboxPowerStatePaused, resp.PowerState.Observed)
+	assert.Equal(t, SandboxPowerPhasePausing, resp.PowerState.Phase)
+	assert.Equal(t, int64(1), resp.PowerState.ObservedGeneration)
+
+	updated, err := svc.k8sClient.CoreV1().Pods("default").Get(context.Background(), "sandbox-1", metav1.GetOptions{})
+	require.NoError(t, err)
+	state := sandboxPowerStateFromAnnotations(updated.Annotations)
+	assert.Equal(t, SandboxPowerPhasePausing, state.Phase)
 }
 
 func TestPauseSandboxAndWaitReturnsAfterObservedPaused(t *testing.T) {


### PR DESCRIPTION
## Summary
- switch manager ctld pause/resume execution to desired-state annotation updates instead of node-local HTTP calls
- add a ctld power reconciler that watches local pods, freezes/thaws cgroups, updates observed power state, and handles resize/TTL restoration
- pass pause resource knobs to ctld and grant ctld pod update plus pods/resize RBAC
- preserve in-flight cancellation phases so immediate pause->resume or resume->pause races are reconciled by ctld

Closes #213

## Testing
- go test ./ctld/... ./manager/pkg/service ./manager/pkg/http ./manager/pkg/controller ./manager/cmd/manager ./infra-operator/internal/controller/... -count=1
- pre-push hook: make manifests, make proto, make apispec, go fmt ./..., go mod tidy, go mod vendor, golangci-lint run ./...