### PR TITLE
Clean template namespaces on template delete

### DIFF
--- a/manager/pkg/service/template_service.go
+++ b/manager/pkg/service/template_service.go
@@ -17,8 +17,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
+)
+
+const (
+	managerNamespaceLabelKey   = "app.kubernetes.io/managed-by"
+	managerNamespaceLabelValue = "sandbox0-manager"
 )
 
 // TemplateService handles template operations
@@ -179,14 +185,122 @@ func (s *TemplateService) DeleteTemplate(ctx context.Context, id string) error {
 		}
 		return fmt.Errorf("resolve template namespace: %w", err)
 	}
-	err = s.crdClient.Sandbox0V1alpha1().SandboxTemplates(existing.Namespace).Delete(ctx, id, metav1.DeleteOptions{})
+
+	deleteNamespace, err := s.shouldDeleteNamespaceForTemplate(ctx, existing)
 	if err != nil {
-		if errors.IsNotFound(err) {
-			return nil // Already deleted
-		}
-		return fmt.Errorf("delete template: %w", err)
+		return fmt.Errorf("resolve template namespace cleanup: %w", err)
+	}
+	if deleteNamespace {
+		// Delete the namespace first so a transient namespace cleanup failure leaves
+		// the template visible for the scheduler's orphan retry path.
+		return s.deleteTemplateNamespace(ctx, existing.Namespace)
 	}
 
+	err = s.crdClient.Sandbox0V1alpha1().SandboxTemplates(existing.Namespace).Delete(ctx, id, metav1.DeleteOptions{})
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return fmt.Errorf("delete template: %w", err)
+		}
+	}
+
+	if err := s.deleteTemplatePods(ctx, existing.Namespace, id); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *TemplateService) shouldDeleteNamespaceForTemplate(ctx context.Context, template *v1alpha1.SandboxTemplate) (bool, error) {
+	if template == nil || template.Namespace == "" || s.k8sClient == nil || s.crdClient == nil {
+		return false, nil
+	}
+
+	managed, err := s.isManagedTemplateNamespace(ctx, template.Namespace)
+	if err != nil {
+		return false, err
+	}
+	if !managed {
+		return false, nil
+	}
+
+	hasOtherTemplates, err := s.namespaceHasOtherTemplates(ctx, template.Namespace, template.Name)
+	if err != nil {
+		return false, err
+	}
+	return !hasOtherTemplates, nil
+}
+
+func (s *TemplateService) isManagedTemplateNamespace(ctx context.Context, namespace string) (bool, error) {
+	ns, err := s.k8sClient.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("get namespace %s: %w", namespace, err)
+	}
+	if ns.Labels[managerNamespaceLabelKey] != managerNamespaceLabelValue {
+		s.logger.Info("Skipping template namespace cleanup for unmanaged namespace",
+			zap.String("namespace", namespace),
+		)
+		return false, nil
+	}
+	return true, nil
+}
+
+func (s *TemplateService) namespaceHasOtherTemplates(ctx context.Context, namespace, deletingName string) (bool, error) {
+	templates, err := s.crdClient.Sandbox0V1alpha1().SandboxTemplates(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("list templates in namespace %s: %w", namespace, err)
+	}
+	for _, template := range templates.Items {
+		if template.Name != deletingName {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (s *TemplateService) deleteTemplateNamespace(ctx context.Context, namespace string) error {
+	if namespace == "" || s.k8sClient == nil {
+		return nil
+	}
+	if err := s.k8sClient.CoreV1().Namespaces().Delete(ctx, namespace, metav1.DeleteOptions{}); err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("delete template namespace %s: %w", namespace, err)
+	}
+	s.logger.Info("Template namespace deletion requested",
+		zap.String("namespace", namespace),
+	)
+	return nil
+}
+
+func (s *TemplateService) deleteTemplatePods(ctx context.Context, namespace, templateID string) error {
+	if namespace == "" || templateID == "" || s.k8sClient == nil {
+		return nil
+	}
+	selector := labels.Set{controller.LabelTemplateID: templateID}.AsSelector().String()
+	pods, err := s.k8sClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: selector})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("list template pods in namespace %s: %w", namespace, err)
+	}
+
+	for _, pod := range pods.Items {
+		poolType := pod.Labels[controller.LabelPoolType]
+		if poolType != controller.PoolTypeIdle && poolType != controller.PoolTypeActive {
+			continue
+		}
+		if err := s.k8sClient.CoreV1().Pods(namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+			return fmt.Errorf("delete template pod %s/%s: %w", namespace, pod.Name, err)
+		}
+	}
 	return nil
 }
 
@@ -238,7 +352,7 @@ func (s *TemplateService) ensureNamespace(ctx context.Context, namespace string)
 		ObjectMeta: metav1.ObjectMeta{
 			Name: namespace,
 			Labels: map[string]string{
-				"app.kubernetes.io/managed-by": "sandbox0-manager",
+				managerNamespaceLabelKey: managerNamespaceLabelValue,
 			},
 		},
 	}

--- a/manager/pkg/service/template_service_test.go
+++ b/manager/pkg/service/template_service_test.go
@@ -7,12 +7,16 @@ import (
 
 	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
 	clientsetfake "github.com/sandbox0-ai/sandbox0/manager/pkg/generated/clientset/versioned/fake"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -49,6 +53,44 @@ func newTemplateServiceForTests() (*TemplateService, *fake.Clientset) {
 		zap.NewNop(),
 	)
 	return service, k8sClient
+}
+
+type listBackedTemplateLister struct {
+	templates []*v1alpha1.SandboxTemplate
+}
+
+func (l *listBackedTemplateLister) List() ([]*v1alpha1.SandboxTemplate, error) {
+	return l.templates, nil
+}
+
+func (l *listBackedTemplateLister) Get(namespace, name string) (*v1alpha1.SandboxTemplate, error) {
+	for _, template := range l.templates {
+		if template.Namespace == namespace && template.Name == name {
+			return template, nil
+		}
+	}
+	return nil, apierrors.NewNotFound(v1alpha1.Resource("sandboxtemplate"), name)
+}
+
+func newTemplateServiceForDeleteTests(k8sClient *fake.Clientset, templates ...*v1alpha1.SandboxTemplate) (*TemplateService, *clientsetfake.Clientset) {
+	crdObjects := make([]runtime.Object, 0, len(templates))
+	listerTemplates := make([]*v1alpha1.SandboxTemplate, 0, len(templates))
+	for _, template := range templates {
+		crdObjects = append(crdObjects, template.DeepCopy())
+		listerTemplates = append(listerTemplates, template.DeepCopy())
+	}
+	crdClient := clientsetfake.NewSimpleClientset(crdObjects...)
+	namespaceIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	service := NewTemplateService(
+		k8sClient,
+		crdClient,
+		&listBackedTemplateLister{templates: listerTemplates},
+		corelisters.NewNamespaceLister(namespaceIndexer),
+		nil,
+		config.RegistryConfig{},
+		zap.NewNop(),
+	)
+	return service, crdClient
 }
 
 func TestCreateTemplateEnsuresNamespaceBaseline(t *testing.T) {
@@ -104,4 +146,194 @@ func TestCreateTemplateFailsWhenNamespaceBaselineFails(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "ensure template namespace baseline")
 	assert.Len(t, reconciler.calls, 1)
+}
+
+func TestDeletePublicTemplateDeletesManagedNamespace(t *testing.T) {
+	ctx := context.Background()
+	namespace, err := naming.TemplateNamespaceForBuiltin("demo")
+	require.NoError(t, err)
+
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: namespace,
+		},
+	}
+	k8sClient := fake.NewSimpleClientset(managedNamespace(namespace))
+	service, _ := newTemplateServiceForDeleteTests(k8sClient, template)
+
+	err = service.DeleteTemplate(ctx, "demo")
+	require.NoError(t, err)
+
+	_, err = k8sClient.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+	require.True(t, apierrors.IsNotFound(err), "namespace should be deleted")
+}
+
+func TestDeleteMissingTemplateIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	k8sClient := fake.NewSimpleClientset()
+	service, _ := newTemplateServiceForDeleteTests(k8sClient)
+
+	err := service.DeleteTemplate(ctx, "missing")
+	require.NoError(t, err)
+}
+
+func TestDeleteTemplateKeepsUnmanagedNamespaceAndDeletesTemplatePods(t *testing.T) {
+	ctx := context.Background()
+	namespace, err := naming.TemplateNamespaceForBuiltin("demo")
+	require.NoError(t, err)
+
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: namespace,
+		},
+	}
+	targetPod := templatePod(namespace, "demo-pod", "demo", controller.PoolTypeActive)
+	otherPod := templatePod(namespace, "other-pod", "other", controller.PoolTypeActive)
+	k8sClient := fake.NewSimpleClientset(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}},
+		targetPod,
+		otherPod,
+	)
+	service, crdClient := newTemplateServiceForDeleteTests(k8sClient, template)
+
+	err = service.DeleteTemplate(ctx, "demo")
+	require.NoError(t, err)
+
+	_, err = k8sClient.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+	require.NoError(t, err, "unmanaged namespace should be preserved")
+	_, err = crdClient.Sandbox0V1alpha1().SandboxTemplates(namespace).Get(ctx, "demo", metav1.GetOptions{})
+	require.True(t, apierrors.IsNotFound(err), "template CRD should be deleted")
+	_, err = k8sClient.CoreV1().Pods(namespace).Get(ctx, "demo-pod", metav1.GetOptions{})
+	require.True(t, apierrors.IsNotFound(err), "target template pod should be deleted")
+	_, err = k8sClient.CoreV1().Pods(namespace).Get(ctx, "other-pod", metav1.GetOptions{})
+	require.NoError(t, err, "other template pod should be preserved")
+}
+
+func TestDeleteTemplateCleansPodsWhenCRDAlreadyGone(t *testing.T) {
+	ctx := context.Background()
+	namespace, err := naming.TemplateNamespaceForBuiltin("demo")
+	require.NoError(t, err)
+
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: namespace,
+		},
+	}
+	targetPod := templatePod(namespace, "demo-pod", "demo", controller.PoolTypeActive)
+	k8sClient := fake.NewSimpleClientset(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}},
+		targetPod,
+	)
+	crdClient := clientsetfake.NewSimpleClientset()
+	namespaceIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	service := NewTemplateService(
+		k8sClient,
+		crdClient,
+		&listBackedTemplateLister{templates: []*v1alpha1.SandboxTemplate{template}},
+		corelisters.NewNamespaceLister(namespaceIndexer),
+		nil,
+		config.RegistryConfig{},
+		zap.NewNop(),
+	)
+
+	err = service.DeleteTemplate(ctx, "demo")
+	require.NoError(t, err)
+
+	_, err = k8sClient.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+	require.NoError(t, err, "unmanaged namespace should be preserved")
+	_, err = k8sClient.CoreV1().Pods(namespace).Get(ctx, "demo-pod", metav1.GetOptions{})
+	require.True(t, apierrors.IsNotFound(err), "target template pod should still be deleted")
+}
+
+func TestDeleteTeamTemplateKeepsSharedNamespaceAndDeletesTemplatePods(t *testing.T) {
+	ctx := context.Background()
+	namespace, err := naming.TemplateNamespaceForTeam("team-123")
+	require.NoError(t, err)
+
+	target := teamTemplate(namespace, "demo", "team-123")
+	other := teamTemplate(namespace, "other", "team-123")
+	targetPod := templatePod(namespace, "demo-pod", "demo", controller.PoolTypeActive)
+	otherPod := templatePod(namespace, "other-pod", "other", controller.PoolTypeActive)
+	k8sClient := fake.NewSimpleClientset(
+		managedNamespace(namespace),
+		targetPod,
+		otherPod,
+	)
+	service, crdClient := newTemplateServiceForDeleteTests(k8sClient, target, other)
+
+	err = service.DeleteTemplate(ctx, "demo")
+	require.NoError(t, err)
+
+	_, err = k8sClient.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+	require.NoError(t, err, "shared team namespace should be preserved")
+	_, err = crdClient.Sandbox0V1alpha1().SandboxTemplates(namespace).Get(ctx, "demo", metav1.GetOptions{})
+	require.True(t, apierrors.IsNotFound(err), "target template CRD should be deleted")
+	_, err = crdClient.Sandbox0V1alpha1().SandboxTemplates(namespace).Get(ctx, "other", metav1.GetOptions{})
+	require.NoError(t, err, "other team template should be preserved")
+	_, err = k8sClient.CoreV1().Pods(namespace).Get(ctx, "demo-pod", metav1.GetOptions{})
+	require.True(t, apierrors.IsNotFound(err), "target template pod should be deleted")
+	_, err = k8sClient.CoreV1().Pods(namespace).Get(ctx, "other-pod", metav1.GetOptions{})
+	require.NoError(t, err, "other template pod should be preserved")
+}
+
+func TestDeleteLastTeamTemplateDeletesManagedNamespace(t *testing.T) {
+	ctx := context.Background()
+	namespace, err := naming.TemplateNamespaceForTeam("team-123")
+	require.NoError(t, err)
+
+	template := teamTemplate(namespace, "demo", "team-123")
+	k8sClient := fake.NewSimpleClientset(
+		managedNamespace(namespace),
+		templatePod(namespace, "demo-pod", "demo", controller.PoolTypeActive),
+	)
+	service, _ := newTemplateServiceForDeleteTests(k8sClient, template)
+
+	err = service.DeleteTemplate(ctx, "demo")
+	require.NoError(t, err)
+
+	_, err = k8sClient.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+	require.True(t, apierrors.IsNotFound(err), "last team template should remove managed namespace")
+}
+
+func managedNamespace(name string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				managerNamespaceLabelKey: managerNamespaceLabelValue,
+			},
+		},
+	}
+}
+
+func teamTemplate(namespace, name, teamID string) *v1alpha1.SandboxTemplate {
+	return &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"sandbox0.ai/template-scope": naming.ScopeTeam,
+			},
+			Annotations: map[string]string{
+				"sandbox0.ai/template-team-id": teamID,
+			},
+		},
+	}
+}
+
+func templatePod(namespace, name, templateID, poolType string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				controller.LabelTemplateID: templateID,
+				controller.LabelPoolType:   poolType,
+				controller.LabelSandboxID:  name,
+			},
+		},
+	}
 }


### PR DESCRIPTION
## Summary
- Delete manager-owned template namespaces when the removed SandboxTemplate is the last template in that namespace.
- Preserve shared or unmanaged namespaces and delete only idle/active pods for the removed template.
- Cover public, unmanaged, shared-team, last-team-template, and NotFound/retry deletion cases with manager service tests.

Closes #215

## Testing
- `go test ./manager/pkg/service -count=1`
- `go test ./manager/pkg/service ./manager/pkg/controller ./manager/pkg/http ./pkg/template/... ./scheduler/pkg/... -count=1`
- Remote kind deploy: `/root && make test-again`, then `Sandbox0Infra/fullmode` reached `Ready 9/9`.
- Remote kind live check: created two team templates through cluster-gateway HTTP, verified the first delete kept shared namespace `t-c56ce265` and removed a target active pod, then verified deleting the last template removed the namespace.
- Remote Ubuntu: `GOWORK=off go test ./manager/pkg/service -run TestDelete.*Template -count=1`
- Pre-push hook: `make manifests`, `make proto`, `make apispec`, `go fmt ./...`, `go mod tidy`, `go mod vendor`, `golangci-lint run ./...` (`0 issues`).
- `go test ./... -count=1` is not clean in this local checkout due existing environment/generated issues: missing `storage-proxy/proto/fs` generated package, Docker daemon unavailable for local e2e, and missing `/config/internal_jwt_public.key` for an integration manager test.