### PR TITLE
Fix ctld pause cleanup deadlock

### DIFF
--- a/ctld/internal/ctld/power/controller.go
+++ b/ctld/internal/ctld/power/controller.go
@@ -20,6 +20,8 @@ var ErrNotImplemented = errors.New("ctld power resolver not implemented")
 var ErrSandboxNotFound = errors.New("sandbox not found")
 var ErrPodNotFound = errors.New("pod not found")
 
+const defaultPauseUsageTimeout = 2 * time.Second
+
 type Target struct {
 	SandboxID    string
 	Runtime      string
@@ -41,10 +43,11 @@ type SandboxStatsProvider interface {
 }
 
 type Controller struct {
-	Resolver      Resolver
-	FS            *cgroup.FS
-	StatsProvider SandboxStatsProvider
-	HTTPClient    *http.Client
+	Resolver          Resolver
+	FS                *cgroup.FS
+	StatsProvider     SandboxStatsProvider
+	PauseUsageTimeout time.Duration
+	HTTPClient        *http.Client
 }
 
 func NewController(resolver Resolver, fs *cgroup.FS) *Controller {
@@ -138,10 +141,20 @@ func (c *Controller) PauseTarget(ctx context.Context, sandboxID string, target T
 	if err := c.FS.Freeze(target.CgroupDir); err != nil {
 		return ctldapi.PauseResponse{Paused: false, Error: fmt.Sprintf("freeze cgroup: %v", err)}, http.StatusInternalServerError
 	}
+	paused := false
+	defer func() {
+		if paused {
+			return
+		}
+		if err := c.FS.Thaw(target.CgroupDir); err != nil {
+			log.Printf("ctld pause rollback thaw failed sandbox=%s runtime=%s cgroup=%s error=%v", sandboxID, target.Runtime, target.CgroupDir, err)
+		}
+	}()
 	usage, err := c.pauseUsage(ctx, target)
 	if err != nil {
 		return ctldapi.PauseResponse{Paused: false, Error: err.Error()}, http.StatusInternalServerError
 	}
+	paused = true
 	log.Printf("ctld pause complete sandbox=%s runtime=%s working_set=%d usage=%d", sandboxID, target.Runtime, usage.ContainerMemoryWorkingSet, usage.ContainerMemoryUsage)
 	return ctldapi.PauseResponse{
 		Paused:        true,
@@ -196,6 +209,9 @@ func mapResolveResult(target Target, err error) (Target, int, ctldapi.PauseRespo
 }
 
 func (c *Controller) pauseUsage(ctx context.Context, target Target) (*ctldapi.SandboxResourceUsage, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	fallback, fallbackErr := c.cgroupPauseUsage(target.CgroupDir)
 	if c == nil || c.StatsProvider == nil {
 		if fallbackErr != nil {
@@ -204,7 +220,9 @@ func (c *Controller) pauseUsage(ctx context.Context, target Target) (*ctldapi.Sa
 		return fallback, nil
 	}
 
-	statsUsage, statsErr := c.StatsProvider.SandboxResourceUsage(ctx, target)
+	statsCtx, cancel := context.WithTimeout(ctx, c.pauseUsageTimeout())
+	defer cancel()
+	statsUsage, statsErr := c.StatsProvider.SandboxResourceUsage(statsCtx, target)
 	usage := mergeSandboxResourceUsage(fallback, statsUsage)
 	if usage != nil {
 		return usage, nil
@@ -219,6 +237,13 @@ func (c *Controller) pauseUsage(ctx context.Context, target Target) (*ctldapi.Sa
 		return nil, fmt.Errorf("collect sandbox usage from cri stats: %w", statsErr)
 	}
 	return nil, fmt.Errorf("read settled memory.current: %w", fallbackErr)
+}
+
+func (c *Controller) pauseUsageTimeout() time.Duration {
+	if c != nil && c.PauseUsageTimeout > 0 {
+		return c.PauseUsageTimeout
+	}
+	return defaultPauseUsageTimeout
 }
 
 func (c *Controller) cgroupPauseUsage(dir string) (*ctldapi.SandboxResourceUsage, error) {

--- a/ctld/internal/ctld/power/controller_test.go
+++ b/ctld/internal/ctld/power/controller_test.go
@@ -42,6 +42,13 @@ func (p staticStatsProvider) SandboxResourceUsage(_ context.Context, _ Target) (
 	return p.usage, p.err
 }
 
+type blockingStatsProvider struct{}
+
+func (blockingStatsProvider) SandboxResourceUsage(ctx context.Context, _ Target) (*ctldapi.SandboxResourceUsage, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
 func TestControllerPauseAndResume(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "cgroup.freeze"), []byte("0\n"), 0o644))
@@ -79,6 +86,40 @@ func TestControllerPausePrefersCRIStatsWhenAvailable(t *testing.T) {
 	assert.Equal(t, int64(300), resp.ResourceUsage.TotalMemoryRSS)
 	assert.Equal(t, 8, resp.ResourceUsage.TotalThreadCount)
 	assert.Equal(t, int64(123), resp.ResourceUsage.ContainerMemoryLimit)
+}
+
+func TestControllerPauseFallsBackWhenStatsProviderTimesOut(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "cgroup.freeze"), []byte("0\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "memory.current"), []byte("123\n"), 0o644))
+	controller := NewController(staticResolver{target: Target{SandboxID: "sandbox-1", CgroupDir: dir, PodNamespace: "default", PodName: "sandbox", PodUID: "uid-1"}}, &cgroup.FS{SettleTimeout: 100 * time.Millisecond, PollInterval: time.Millisecond})
+	controller.StatsProvider = blockingStatsProvider{}
+	controller.PauseUsageTimeout = 10 * time.Millisecond
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sandboxes/sandbox-1/pause", nil)
+
+	resp, status := controller.Pause(req, "sandbox-1")
+
+	assert.Equal(t, http.StatusOK, status)
+	assert.True(t, resp.Paused)
+	assert.Equal(t, int64(123), resp.ResourceUsage.ContainerMemoryWorkingSet)
+	state, err := os.ReadFile(filepath.Join(dir, "cgroup.freeze"))
+	require.NoError(t, err)
+	assert.Equal(t, "1", string(state))
+}
+
+func TestControllerPauseThawsWhenUsageFails(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "cgroup.freeze"), []byte("0\n"), 0o644))
+	controller := NewController(staticResolver{target: Target{SandboxID: "sandbox-1", CgroupDir: dir}}, &cgroup.FS{SettleTimeout: 100 * time.Millisecond, PollInterval: time.Millisecond})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sandboxes/sandbox-1/pause", nil)
+
+	resp, status := controller.Pause(req, "sandbox-1")
+
+	assert.Equal(t, http.StatusInternalServerError, status)
+	assert.False(t, resp.Paused)
+	state, err := os.ReadFile(filepath.Join(dir, "cgroup.freeze"))
+	require.NoError(t, err)
+	assert.Equal(t, "0", string(state))
 }
 
 func TestControllerMapsResolverErrors(t *testing.T) {

--- a/manager/pkg/controller/cleanup_controller.go
+++ b/manager/pkg/controller/cleanup_controller.go
@@ -143,6 +143,10 @@ func (cc *CleanupController) cleanupExpired(ctx context.Context, template *v1alp
 	expiredCount := 0
 
 	for _, pod := range pods {
+		if pod.DeletionTimestamp != nil {
+			continue
+		}
+
 		// Hard expiry: delete even if paused.
 		if hardExpiresAtStr := pod.Annotations[AnnotationHardExpiresAt]; hardExpiresAtStr != "" {
 			hardExpiresAt, err := time.Parse(time.RFC3339, hardExpiresAtStr)

--- a/manager/pkg/controller/cleanup_controller_test.go
+++ b/manager/pkg/controller/cleanup_controller_test.go
@@ -83,3 +83,55 @@ func TestCleanupExpiredRequestsPauseDesiredState(t *testing.T) {
 		t.Fatal("expected pause-requested event")
 	}
 }
+
+func TestCleanupExpiredSkipsDeletingPod(t *testing.T) {
+	now := time.Date(2026, time.April, 15, 19, 31, 0, 0, time.UTC)
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: "tpl-default",
+		},
+	}
+	deletedAt := metav1.NewTime(now.Add(-time.Minute))
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "sandbox-1",
+			Namespace:         "tpl-default",
+			DeletionTimestamp: &deletedAt,
+			Labels: map[string]string{
+				LabelTemplateID: "default",
+				LabelPoolType:   PoolTypeActive,
+			},
+			Annotations: map[string]string{
+				AnnotationExpiresAt: now.Add(-time.Minute).Format(time.RFC3339),
+			},
+		},
+	}
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+	})
+	require.NoError(t, indexer.Add(pod))
+
+	pauseRequester := &recordingPauseRequester{}
+	recorder := record.NewFakeRecorder(1)
+	controller := NewCleanupController(
+		nil,
+		corelisters.NewPodLister(indexer),
+		nil,
+		recorder,
+		staticCleanupClock{now: now},
+		pauseRequester,
+		nil,
+		zap.NewNop(),
+		time.Minute,
+	)
+
+	require.NoError(t, controller.cleanupExpired(context.Background(), template))
+
+	assert.Empty(t, pauseRequester.calls)
+	select {
+	case event := <-recorder.Events:
+		t.Fatalf("unexpected event: %s", event)
+	default:
+	}
+}


### PR DESCRIPTION
## Summary
- Roll back ctld cgroup freeze when pause usage collection fails, so failed pauses do not leave sandboxes frozen.
- Bound pause stats collection with a short timeout and fall back to cgroup memory usage when CRI stats hangs.
- Skip cleanup pause requests for pods that are already deleting.

## Testing
- go test ./ctld/internal/ctld/power ./manager/pkg/controller
- go test ./ctld/... ./manager/pkg/controller
- git push pre-push hook: make manifests, make proto, make apispec, go fmt ./..., go mod tidy, go mod vendor, golangci-lint run ./...