### PR TITLE
Filter sandbox logs to process output only

### DIFF
--- a/manager/pkg/http/handlers_sandbox.go
+++ b/manager/pkg/http/handlers_sandbox.go
@@ -285,7 +285,7 @@ func (s *Server) getSandboxStatus(c *gin.Context) {
 	spec.JSONSuccess(c, http.StatusOK, status)
 }
 
-// getSandboxLogs gets sandbox pod logs.
+// getSandboxLogs gets sandbox process logs.
 func (s *Server) getSandboxLogs(c *gin.Context) {
 	sandboxID := c.Param("id")
 	if sandboxID == "" {

--- a/manager/pkg/http/handlers_sandbox_logs_test.go
+++ b/manager/pkg/http/handlers_sandbox_logs_test.go
@@ -55,7 +55,7 @@ func TestGetSandboxLogsReturnsOK(t *testing.T) {
 	assert.Equal(t, "sandbox-1", recorder.Header().Get("X-Sandbox-ID"))
 	assert.Equal(t, "procd", recorder.Header().Get("X-Sandbox-Log-Container"))
 	assert.Equal(t, "true", recorder.Header().Get("X-Sandbox-Log-Previous"))
-	assert.Equal(t, "fake logs", recorder.Body.String())
+	assert.Empty(t, recorder.Body.String())
 }
 
 func TestGetSandboxLogsStreamsWhenFollowTrue(t *testing.T) {
@@ -93,7 +93,7 @@ func TestGetSandboxLogsStreamsWhenFollowTrue(t *testing.T) {
 	assert.Equal(t, "sandbox-1", recorder.Header().Get("X-Sandbox-ID"))
 	assert.Equal(t, "procd", recorder.Header().Get("X-Sandbox-Log-Container"))
 	assert.Equal(t, "false", recorder.Header().Get("X-Sandbox-Log-Previous"))
-	assert.Equal(t, "fake logs", recorder.Body.String())
+	assert.Empty(t, recorder.Body.String())
 }
 
 func TestGetSandboxLogsRejectsInvalidTailLines(t *testing.T) {

--- a/manager/pkg/service/sandbox_process_log_filter.go
+++ b/manager/pkg/service/sandbox_process_log_filter.go
@@ -1,0 +1,102 @@
+package service
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/process"
+)
+
+const maxSandboxProcessLogScanBytes = int(MaxSandboxLogLimitBytes) + process.DefaultContainerLogMaxLineBytes
+
+type sandboxProcessLogReadCloser struct {
+	source  io.ReadCloser
+	scanner *bufio.Scanner
+	buffer  []byte
+}
+
+func newSandboxProcessLogReadCloser(source io.ReadCloser) io.ReadCloser {
+	scanner := bufio.NewScanner(source)
+	scanner.Buffer(make([]byte, 0, process.DefaultContainerLogMaxLineBytes), maxSandboxProcessLogScanBytes)
+	return &sandboxProcessLogReadCloser{
+		source:  source,
+		scanner: scanner,
+	}
+}
+
+func (r *sandboxProcessLogReadCloser) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	for len(r.buffer) == 0 {
+		if !r.scanner.Scan() {
+			if err := r.scanner.Err(); err != nil {
+				return 0, fmt.Errorf("filter sandbox process logs: %w", err)
+			}
+			return 0, io.EOF
+		}
+
+		line := r.scanner.Bytes()
+		if !isSandboxProcessLogLine(line) {
+			continue
+		}
+		r.buffer = append(r.buffer[:0], line...)
+		r.buffer = append(r.buffer, '\n')
+	}
+
+	n := copy(p, r.buffer)
+	r.buffer = r.buffer[n:]
+	return n, nil
+}
+
+func (r *sandboxProcessLogReadCloser) Close() error {
+	return r.source.Close()
+}
+
+func isSandboxProcessLogLine(line []byte) bool {
+	payload := bytes.TrimSpace(stripKubernetesLogTimestamp(line))
+	if len(payload) == 0 {
+		return false
+	}
+
+	var event sandboxProcessLogEvent
+	if err := json.Unmarshal(payload, &event); err != nil {
+		return false
+	}
+	if event.Message != process.ContainerLogProcessOutputMessage || event.Data == nil {
+		return false
+	}
+	switch event.Source {
+	case string(process.OutputSourceStdout), string(process.OutputSourceStderr), string(process.OutputSourcePTY):
+		return true
+	default:
+		return false
+	}
+}
+
+func stripKubernetesLogTimestamp(line []byte) []byte {
+	trimmed := bytes.TrimLeft(line, " \t")
+	if bytes.HasPrefix(trimmed, []byte("{")) {
+		return trimmed
+	}
+
+	idx := bytes.IndexByte(trimmed, ' ')
+	if idx <= 0 {
+		return trimmed
+	}
+	if _, err := time.Parse(time.RFC3339Nano, string(trimmed[:idx])); err != nil {
+		return trimmed
+	}
+	return trimmed[idx+1:]
+}
+
+type sandboxProcessLogEvent struct {
+	Message string  `json:"message"`
+	Source  string  `json:"source"`
+	Data    *string `json:"data"`
+}

--- a/manager/pkg/service/sandbox_process_log_filter_test.go
+++ b/manager/pkg/service/sandbox_process_log_filter_test.go
@@ -1,0 +1,36 @@
+package service
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSandboxProcessLogReadCloserFiltersProcdLogs(t *testing.T) {
+	processLine := `{"message":"sandbox process output","process_id":"ctx-1","process_type":"cmd","source":"stdout","data":"hello"}`
+	timestampedProcessLine := `2026-04-17T12:34:56.789123456Z {"message":"sandbox process output","process_id":"ctx-1","process_type":"cmd","source":"stderr","data":"failed"}`
+	input := strings.Join([]string{
+		`{"level":"info","ts":"2026-04-17T12:34:56Z","msg":"procd started"}`,
+		processLine,
+		`plain procd log line`,
+		timestampedProcessLine,
+		`{"message":"sandbox process output","process_id":"ctx-1","process_type":"cmd","source":"prompt","data":""}`,
+		`{"message":"user output","source":"stdout","data":"ignored"}`,
+	}, "\n")
+
+	filtered := newSandboxProcessLogReadCloser(io.NopCloser(strings.NewReader(input)))
+	data, err := io.ReadAll(filtered)
+	require.NoError(t, err)
+	require.NoError(t, filtered.Close())
+
+	assert.Equal(t, processLine+"\n"+timestampedProcessLine+"\n", string(data))
+}
+
+func TestIsSandboxProcessLogLineRejectsMissingData(t *testing.T) {
+	line := []byte(`{"message":"sandbox process output","process_id":"ctx-1","process_type":"cmd","source":"stdout"}`)
+
+	assert.False(t, isSandboxProcessLogLine(line))
+}

--- a/manager/pkg/service/sandbox_service_logs.go
+++ b/manager/pkg/service/sandbox_service_logs.go
@@ -25,7 +25,7 @@ var (
 	ErrSandboxLogContainerNotFound = errors.New("sandbox log container not found")
 )
 
-// SandboxLogsOptions controls a bounded snapshot read from Kubernetes pod logs.
+// SandboxLogsOptions controls a bounded snapshot read from sandbox process logs.
 type SandboxLogsOptions struct {
 	Container    string `json:"container"`
 	TailLines    int64  `json:"tail_lines"`
@@ -53,7 +53,7 @@ type SandboxLogsStream struct {
 	Body      io.ReadCloser
 }
 
-// GetSandboxLogs returns a bounded snapshot of logs from one container in the sandbox pod.
+// GetSandboxLogs returns a bounded snapshot of sandbox process logs from one container in the sandbox pod.
 func (s *SandboxService) GetSandboxLogs(ctx context.Context, sandboxID, teamID string, opts *SandboxLogsOptions) (*SandboxLogsResponse, error) {
 	stream, err := s.openSandboxLogs(ctx, sandboxID, teamID, opts, false, true)
 	if err != nil {
@@ -62,10 +62,10 @@ func (s *SandboxService) GetSandboxLogs(ctx context.Context, sandboxID, teamID s
 	data, readErr := io.ReadAll(stream.Body)
 	closeErr := stream.Body.Close()
 	if readErr != nil {
-		return nil, fmt.Errorf("read sandbox pod logs: %w", readErr)
+		return nil, fmt.Errorf("read sandbox process logs: %w", readErr)
 	}
 	if closeErr != nil {
-		return nil, fmt.Errorf("close sandbox pod logs: %w", closeErr)
+		return nil, fmt.Errorf("close sandbox process logs: %w", closeErr)
 	}
 
 	return &SandboxLogsResponse{
@@ -77,7 +77,7 @@ func (s *SandboxService) GetSandboxLogs(ctx context.Context, sandboxID, teamID s
 	}, nil
 }
 
-// StreamSandboxLogs returns a followable stream of logs from one container in the sandbox pod.
+// StreamSandboxLogs returns a followable stream of sandbox process logs from one container in the sandbox pod.
 func (s *SandboxService) StreamSandboxLogs(ctx context.Context, sandboxID, teamID string, opts *SandboxLogsOptions) (*SandboxLogsStream, error) {
 	return s.openSandboxLogs(ctx, sandboxID, teamID, opts, true, false)
 }
@@ -124,7 +124,7 @@ func (s *SandboxService) openSandboxLogs(ctx context.Context, sandboxID, teamID 
 		PodName:   pod.Name,
 		Container: options.Container,
 		Previous:  options.Previous,
-		Body:      stream,
+		Body:      newSandboxProcessLogReadCloser(stream),
 	}, nil
 }
 

--- a/manager/pkg/service/sandbox_service_logs_test.go
+++ b/manager/pkg/service/sandbox_service_logs_test.go
@@ -39,7 +39,7 @@ func TestGetSandboxLogsUsesBoundedPodLogOptions(t *testing.T) {
 	assert.Equal(t, "sandbox-1", resp.PodName)
 	assert.Equal(t, "procd", resp.Container)
 	assert.True(t, resp.Previous)
-	assert.Equal(t, "fake logs", resp.Logs)
+	assert.Empty(t, resp.Logs)
 
 	logOptions := findPodLogOptions(t, client.Actions())
 	require.NotNil(t, logOptions)
@@ -71,7 +71,7 @@ func TestStreamSandboxLogsUsesFollowWithoutDefaultLimit(t *testing.T) {
 	data, err := io.ReadAll(stream.Body)
 	require.NoError(t, err)
 	require.NoError(t, stream.Body.Close())
-	assert.Equal(t, "fake logs", string(data))
+	assert.Empty(t, string(data))
 
 	logOptions := findPodLogOptions(t, client.Actions())
 	require.NotNil(t, logOptions)

--- a/manager/procd/pkg/process/container_log_forwarder.go
+++ b/manager/procd/pkg/process/container_log_forwarder.go
@@ -9,7 +9,11 @@ import (
 	"sync"
 )
 
-const DefaultContainerLogMaxLineBytes = 4096
+const (
+	DefaultContainerLogMaxLineBytes = 4096
+	// ContainerLogProcessOutputMessage marks container log lines emitted from sandbox process output.
+	ContainerLogProcessOutputMessage = "sandbox process output"
+)
 
 var (
 	defaultOutputForwarderMu sync.RWMutex
@@ -148,7 +152,7 @@ func (f *ContainerLogForwarder) forwardLocked(desc ProcessDescriptor, source Out
 
 func (f *ContainerLogForwarder) writeLineLocked(desc ProcessDescriptor, source OutputSource, data []byte, truncated bool) {
 	line := containerLogLine{
-		Message:     "sandbox process output",
+		Message:     ContainerLogProcessOutputMessage,
 		ProcessID:   desc.ProcessID,
 		ProcessType: desc.ProcessType,
 		PID:         desc.PID,

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -1344,11 +1344,14 @@ paths:
   /api/v1/sandboxes/{id}/logs:
     get:
       tags: [sandboxes]
-      summary: Get sandbox pod logs
+      summary: Get sandbox process logs
       description: |
-        Returns Kubernetes container logs for the sandbox pod.
+        Returns sandbox process output mirrored through the sandbox main container.
+        Procd service logs are filtered out and remain available through Kubernetes pod logs.
         When `follow=false`, the response is a bounded text/plain snapshot.
         When `follow=true`, the response is a text/plain stream until the client disconnects.
+        Kubernetes log selection parameters such as `tail_lines` and `limit_bytes`
+        are applied before procd service log filtering.
       security:
         - bearerAuth: []
       x-upstream-service: manager
@@ -1363,7 +1366,7 @@ paths:
             default: procd
         - name: tail_lines
           in: query
-          description: Maximum number of log lines to return from the end of the log.
+          description: Maximum number of Kubernetes log lines read from the end of the log before procd service log filtering.
           schema:
             type: integer
             format: int64
@@ -1406,7 +1409,7 @@ paths:
             minimum: 1
       responses:
         "200":
-          description: Sandbox pod logs
+          description: Sandbox process logs
           headers:
             X-Sandbox-ID:
               description: Sandbox ID for the returned log payload.

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -2781,7 +2781,7 @@ type GetApiV1SandboxesIdLogsParams struct {
 	// Container Pod container name. Defaults to the sandbox main container.
 	Container *string `form:"container,omitempty" json:"container,omitempty"`
 
-	// TailLines Maximum number of log lines to return from the end of the log.
+	// TailLines Maximum number of Kubernetes log lines read from the end of the log before procd service log filtering.
 	TailLines *int64 `form:"tail_lines,omitempty" json:"tail_lines,omitempty"`
 
 	// LimitBytes Maximum response log payload bytes read from Kubernetes. Defaults only apply when follow is false.

--- a/skills/sandbox0/references/docs-src/sandbox/page.mdx
+++ b/skills/sandbox0/references/docs-src/sandbox/page.mdx
@@ -255,7 +255,7 @@ console.log('Status:', status.status);`
 
 ## Get Sandbox Logs
 
-Read pod logs for sandbox startup and container diagnostics. Snapshot and streaming requests return `text/plain`.
+Read sandbox process output. Procd service logs are filtered out of this API and remain available from Kubernetes pod logs. Snapshot and streaming requests return `text/plain`.
 
 <Endpoint method="GET">
 /api/v1/sandboxes/{'{id}'}/logs
@@ -266,8 +266,8 @@ Read pod logs for sandbox startup and container diagnostics. Snapshot and stream
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `container` | string | Pod container name (default: `procd`) |
-| `tail_lines` | integer | Number of lines from the end of the log (default: 200, max: 5000) |
-| `limit_bytes` | integer | Maximum log bytes returned (default: 1048576 for snapshot responses, max: 8388608) |
+| `tail_lines` | integer | Number of Kubernetes log lines read from the end of the log before procd service log filtering (default: 200, max: 5000) |
+| `limit_bytes` | integer | Maximum Kubernetes log bytes read before procd service log filtering (default: 1048576 for snapshot responses, max: 8388608) |
 | `follow` | boolean | Stream logs as `text/plain` until the client disconnects |
 | `previous` | boolean | Return logs from the previously terminated container instance |
 | `timestamps` | boolean | Include Kubernetes log timestamps when available |


### PR DESCRIPTION
## Summary
- Filter sandbox log API responses to only procd-forwarded sandbox process output events.
- Keep procd service logs available in Kubernetes pod logs while removing them from sandbox log snapshots and streams.
- Document the API behavior and regenerate API spec code.

Closes #219

## Testing
- `GOTOOLCHAIN=go1.25.0+auto go test ./manager/pkg/service ./manager/pkg/http ./manager/procd/pkg/process ./manager/cmd/procd`
- `make apispec`
- Remote kind: synced `/root/infra`, ran `make test-again`, waited for `sandbox0-system` pods Ready, claimed a default sandbox, executed a CMD context that wrote stdout and stderr, and verified `/api/v1/sandboxes/{id}/logs` returned only `sandbox process output` JSON lines containing the expected stdout/stderr tokens.