### PR TITLE
Return not found for missing sandbox updates

### DIFF
--- a/manager/pkg/http/handlers_sandbox.go
+++ b/manager/pkg/http/handlers_sandbox.go
@@ -203,12 +203,6 @@ func (s *Server) updateSandbox(c *gin.Context) {
 
 	sandbox, err := s.sandboxService.GetSandbox(c.Request.Context(), sandboxID)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			spec.JSONSuccess(c, http.StatusOK, gin.H{
-				"message": "sandbox terminated successfully",
-			})
-			return
-		}
 		spec.JSONError(c, http.StatusNotFound, spec.CodeNotFound, fmt.Sprintf("sandbox not found: %v", err))
 		return
 	}


### PR DESCRIPTION
## Summary
- return a 404 error envelope when `PUT /api/v1/sandboxes/{id}` targets a missing sandbox
- remove the misleading delete-success response from the update handler

Fixes #221

## Tests
- go test ./manager/pkg/http ./manager/pkg/service
- git diff --check
- pre-push hook: make manifests, make proto, make apispec, go fmt ./..., go mod tidy, go mod vendor, golangci-lint run ./...