### PR TITLE
Remove cluster-gateway procd address cache

### DIFF
--- a/cluster-gateway/pkg/http/handlers_context.go
+++ b/cluster-gateway/pkg/http/handlers_context.go
@@ -268,93 +268,55 @@ func (s *Server) contextWebSocket(c *gin.Context) {
 	wsProxy.Proxy(procdURL)(c)
 }
 
-type sandboxAddrCacheKey struct {
-	teamID    string
-	sandboxID string
-}
-
-func sandboxCacheKey(teamID, sandboxID string) sandboxAddrCacheKey {
-	return sandboxAddrCacheKey{
-		teamID:    teamID,
-		sandboxID: sandboxID,
-	}
-}
-
 // getProcdURL resolves the procd URL for a sandbox
-// Uses in-memory cache to reduce manager API calls and improve performance
 func (s *Server) getProcdURL(c *gin.Context, sandboxID string) (*url.URL, error) {
 	authCtx := middleware.GetAuthContext(c)
-	cacheKey := sandboxCacheKey(authCtx.TeamID, sandboxID)
 
-	// Try to get from cache first
-	var addr *url.URL
-	if cached, ok := s.sandboxAddrCache.Get(cacheKey); ok {
-		addr = cached
-		s.logger.Debug("Sandbox cache hit",
+	sandbox, err := s.managerClient.GetSandbox(c.Request.Context(), sandboxID, authCtx.UserID, authCtx.TeamID)
+	if err != nil {
+		s.logger.Error("Failed to get sandbox from manager",
 			zap.String("sandbox_id", sandboxID),
+			zap.Error(err),
 		)
-	} else {
-		// Cache miss - fetch from manager
-		s.logger.Debug("Sandbox cache miss, fetching from manager",
-			zap.String("sandbox_id", sandboxID),
-		)
-
-		sandbox, err := s.managerClient.GetSandbox(c.Request.Context(), sandboxID, authCtx.UserID, authCtx.TeamID)
-		if err != nil {
-			s.logger.Error("Failed to get sandbox from manager",
-				zap.String("sandbox_id", sandboxID),
-				zap.Error(err),
-			)
-			if errors.Is(err, client.ErrSandboxNotFound) {
-				spec.JSONError(c, http.StatusNotFound, spec.CodeNotFound, "sandbox not found")
-			} else {
-				spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "manager service unavailable")
-			}
-			return nil, err
+		if errors.Is(err, client.ErrSandboxNotFound) {
+			spec.JSONError(c, http.StatusNotFound, spec.CodeNotFound, "sandbox not found")
+		} else {
+			spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "manager service unavailable")
 		}
-
-		// Verify team ownership
-		if sandbox.TeamID != authCtx.TeamID {
-			spec.JSONError(c, http.StatusForbidden, spec.CodeForbidden, "sandbox belongs to a different team")
-			return nil, errors.New("sandbox belongs to a different team")
-		}
-		if sandboxWantsPaused(sandbox) && !sandbox.AutoResume {
-			spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox is paused and auto_resume is disabled")
-			return nil, errors.New("sandbox auto_resume is disabled")
-		}
-		if sandboxWantsPaused(sandbox) {
-			resumeCtx, cancel := context.WithTimeout(c.Request.Context(), defaultAutoResumeTimeout)
-			defer cancel()
-			if err := s.managerClient.ResumeSandbox(resumeCtx, sandboxID, authCtx.UserID, authCtx.TeamID); err != nil {
-				s.logger.Warn("Resume sandbox failed",
-					zap.String("sandbox_id", sandboxID),
-					zap.Error(err),
-				)
-				spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox is waking up")
-				return nil, err
-			}
-		}
-
-		// Parse procd address
-		addr, err = url.Parse(sandbox.InternalAddr)
-		if err != nil {
-			s.logger.Error("Invalid procd address",
-				zap.String("sandbox_id", sandboxID),
-				zap.String("procd_address", sandbox.InternalAddr),
-				zap.Error(err),
-			)
-			spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "invalid procd address")
-			return nil, err
-		}
-
-		// Store in cache for future requests
-		s.sandboxAddrCache.Set(cacheKey, addr)
-		s.logger.Debug("Sandbox cached",
-			zap.String("sandbox_id", sandboxID),
-			zap.String("internal_addr", addr.String()),
-		)
+		return nil, err
 	}
 
+	if sandbox.TeamID != authCtx.TeamID {
+		spec.JSONError(c, http.StatusForbidden, spec.CodeForbidden, "sandbox belongs to a different team")
+		return nil, errors.New("sandbox belongs to a different team")
+	}
+	if sandboxWantsPaused(sandbox) && !sandbox.AutoResume {
+		spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox is paused and auto_resume is disabled")
+		return nil, errors.New("sandbox auto_resume is disabled")
+	}
+	if sandboxWantsPaused(sandbox) {
+		resumeCtx, cancel := context.WithTimeout(c.Request.Context(), defaultAutoResumeTimeout)
+		defer cancel()
+		if err := s.managerClient.ResumeSandbox(resumeCtx, sandboxID, authCtx.UserID, authCtx.TeamID); err != nil {
+			s.logger.Warn("Resume sandbox failed",
+				zap.String("sandbox_id", sandboxID),
+				zap.Error(err),
+			)
+			spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox is waking up")
+			return nil, err
+		}
+	}
+
+	addr, err := url.Parse(sandbox.InternalAddr)
+	if err != nil {
+		s.logger.Error("Invalid procd address",
+			zap.String("sandbox_id", sandboxID),
+			zap.String("procd_address", sandbox.InternalAddr),
+			zap.Error(err),
+		)
+		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "invalid procd address")
+		return nil, err
+	}
 	return addr, nil
 }
 

--- a/cluster-gateway/pkg/http/handlers_context_test.go
+++ b/cluster-gateway/pkg/http/handlers_context_test.go
@@ -14,14 +14,13 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/sandbox0-ai/sandbox0/cluster-gateway/pkg/client"
 	mgr "github.com/sandbox0-ai/sandbox0/manager/pkg/service"
-	"github.com/sandbox0-ai/sandbox0/pkg/cache"
 	gatewayauthn "github.com/sandbox0-ai/sandbox0/pkg/gateway/authn"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"go.uber.org/zap"
 )
 
-func TestGetProcdURLCacheIsScopedByTeam(t *testing.T) {
+func TestGetProcdURLFetchesManagerForEachRequest(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	managerURL, managerSpy, tokenGen, cleanup := newGetProcdURLTestManager(t)
@@ -29,21 +28,23 @@ func TestGetProcdURLCacheIsScopedByTeam(t *testing.T) {
 
 	server := &Server{
 		managerClient: client.NewManagerClient(managerURL, tokenGen, zap.NewNop(), time.Second),
-		sandboxAddrCache: cache.New[sandboxAddrCacheKey, *url.URL](cache.Config{
-			MaxSize:         16,
-			TTL:             time.Minute,
-			CleanupInterval: time.Minute,
-		}),
-		logger: zap.NewNop(),
+		logger:        zap.NewNop(),
 	}
-	defer server.sandboxAddrCache.Close()
 
 	addr, rec := mustGetProcdURL(t, server, "team-a", "user-a", "sb-1")
 	if rec.Code != http.StatusOK {
-		t.Fatalf("team A status = %d, want %d", rec.Code, http.StatusOK)
+		t.Fatalf("first team A status = %d, want %d", rec.Code, http.StatusOK)
 	}
 	if got := addr.String(); got != "http://127.0.0.1:7777" {
-		t.Fatalf("team A procd url = %q, want %q", got, "http://127.0.0.1:7777")
+		t.Fatalf("first team A procd url = %q, want %q", got, "http://127.0.0.1:7777")
+	}
+
+	addr, rec = mustGetProcdURL(t, server, "team-a", "user-a", "sb-1")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("second team A status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if got := addr.String(); got != "http://127.0.0.1:7777" {
+		t.Fatalf("second team A procd url = %q, want %q", got, "http://127.0.0.1:7777")
 	}
 
 	addr, rec = mustGetProcdURL(t, server, "team-b", "user-b", "sb-1")
@@ -53,8 +54,97 @@ func TestGetProcdURLCacheIsScopedByTeam(t *testing.T) {
 	if rec.Code != http.StatusForbidden {
 		t.Fatalf("team B status = %d, want %d", rec.Code, http.StatusForbidden)
 	}
-	if got := managerSpy.teamIDs(); len(got) != 2 || got[0] != "team-a" || got[1] != "team-b" {
-		t.Fatalf("manager team ids = %#v, want [team-a team-b]", got)
+	if got := managerSpy.teamIDs(); len(got) != 3 || got[0] != "team-a" || got[1] != "team-a" || got[2] != "team-b" {
+		t.Fatalf("manager team ids = %#v, want [team-a team-a team-b]", got)
+	}
+}
+
+func TestGetProcdURLRechecksPausedStateAfterSuccessfulAccess(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate keypair: %v", err)
+	}
+	validator := internalauth.NewValidator(internalauth.ValidatorConfig{
+		Target:             "manager",
+		PublicKey:          publicKey,
+		AllowedCallers:     []string{"cluster-gateway"},
+		ClockSkewTolerance: 5 * time.Second,
+	})
+	tokenGen := internalauth.NewGenerator(internalauth.GeneratorConfig{
+		Caller:     "cluster-gateway",
+		PrivateKey: privateKey,
+		TTL:        time.Minute,
+	})
+
+	var getCalls int
+	var resumeCalls int
+	manager := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, err := validator.Validate(r.Header.Get(internalauth.DefaultTokenHeader)); err != nil {
+			t.Fatalf("validate token: %v", err)
+		}
+		switch {
+		case r.Method == http.MethodGet:
+			getCalls++
+			sandbox := mgr.Sandbox{
+				ID:           "sb-1",
+				TeamID:       "team-a",
+				UserID:       "user-a",
+				InternalAddr: "http://127.0.0.1:7777",
+				Status:       mgr.SandboxStatusRunning,
+				AutoResume:   true,
+			}
+			if getCalls == 2 {
+				sandbox.Paused = true
+				sandbox.PowerState = mgr.SandboxPowerState{
+					Desired:            mgr.SandboxPowerStatePaused,
+					DesiredGeneration:  3,
+					Observed:           mgr.SandboxPowerStatePaused,
+					ObservedGeneration: 3,
+					Phase:              mgr.SandboxPowerPhaseStable,
+				}
+			}
+			_ = spec.WriteSuccess(w, http.StatusOK, sandbox)
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/sandboxes/sb-1/resume":
+			resumeCalls++
+			_ = spec.WriteSuccess(w, http.StatusOK, mgr.ResumeSandboxResponse{
+				SandboxID: "sb-1",
+				Resumed:   true,
+				PowerState: mgr.SandboxPowerState{
+					Desired:            mgr.SandboxPowerStateActive,
+					DesiredGeneration:  4,
+					Observed:           mgr.SandboxPowerStateActive,
+					ObservedGeneration: 4,
+					Phase:              mgr.SandboxPowerPhaseStable,
+				},
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(map[string]any{"success": false})
+		}
+	}))
+	defer manager.Close()
+
+	server := &Server{
+		managerClient: client.NewManagerClient(manager.URL, tokenGen, zap.NewNop(), time.Second),
+		logger:        zap.NewNop(),
+	}
+
+	addr, _ := mustGetProcdURL(t, server, "team-a", "user-a", "sb-1")
+	if addr == nil || addr.String() != "http://127.0.0.1:7777" {
+		t.Fatalf("first addr = %v, want http://127.0.0.1:7777", addr)
+	}
+
+	addr, _ = mustGetProcdURL(t, server, "team-a", "user-a", "sb-1")
+	if addr == nil || addr.String() != "http://127.0.0.1:7777" {
+		t.Fatalf("second addr = %v, want http://127.0.0.1:7777", addr)
+	}
+	if getCalls != 2 {
+		t.Fatalf("getCalls = %d, want 2", getCalls)
+	}
+	if resumeCalls != 1 {
+		t.Fatalf("resumeCalls = %d, want 1", resumeCalls)
 	}
 }
 
@@ -122,14 +212,8 @@ func TestGetProcdURLPausedSandboxReturnsWakingUp(t *testing.T) {
 
 	server := &Server{
 		managerClient: client.NewManagerClient(manager.URL, tokenGen, zap.NewNop(), time.Second),
-		sandboxAddrCache: cache.New[sandboxAddrCacheKey, *url.URL](cache.Config{
-			MaxSize:         16,
-			TTL:             time.Minute,
-			CleanupInterval: time.Minute,
-		}),
-		logger: zap.NewNop(),
+		logger:        zap.NewNop(),
 	}
-	defer server.sandboxAddrCache.Close()
 
 	addr, _ := mustGetProcdURL(t, server, "team-a", "user-a", "sb-1")
 	if addr == nil || addr.String() != "http://127.0.0.1:7777" {

--- a/cluster-gateway/pkg/http/handlers_internal_sandboxes.go
+++ b/cluster-gateway/pkg/http/handlers_internal_sandboxes.go
@@ -67,9 +67,5 @@ func (s *Server) resumeInternalSandbox(c *gin.Context) {
 		return
 	}
 
-	if s.sandboxAddrCache != nil {
-		s.sandboxAddrCache.Delete(sandboxCacheKey(authCtx.TeamID, sandboxID))
-	}
-
 	spec.JSONSuccess(c, http.StatusOK, gin.H{"message": "sandbox resume requested"})
 }

--- a/cluster-gateway/pkg/http/handlers_sandbox.go
+++ b/cluster-gateway/pkg/http/handlers_sandbox.go
@@ -130,13 +130,6 @@ func (s *Server) updateSandbox(c *gin.Context) {
 	}
 
 	s.proxyToManager(c)
-
-	// Invalidate cache after update to ensure fresh data on next access
-	authCtx := middleware.GetAuthContext(c)
-	s.sandboxAddrCache.Delete(sandboxCacheKey(authCtx.TeamID, sandboxID))
-	s.logger.Debug("Invalidated sandbox cache after update",
-		zap.String("sandbox_id", sandboxID),
-	)
 }
 
 // deleteSandbox deletes a sandbox
@@ -148,13 +141,6 @@ func (s *Server) deleteSandbox(c *gin.Context) {
 	}
 
 	s.proxyToManager(c)
-
-	// Invalidate cache after deletion
-	authCtx := middleware.GetAuthContext(c)
-	s.sandboxAddrCache.Delete(sandboxCacheKey(authCtx.TeamID, sandboxID))
-	s.logger.Debug("Invalidated sandbox cache after deletion",
-		zap.String("sandbox_id", sandboxID),
-	)
 }
 
 // pauseSandbox pauses a sandbox
@@ -166,13 +152,6 @@ func (s *Server) pauseSandbox(c *gin.Context) {
 	}
 
 	s.proxyToManager(c)
-
-	// Invalidate cache after state change
-	authCtx := middleware.GetAuthContext(c)
-	s.sandboxAddrCache.Delete(sandboxCacheKey(authCtx.TeamID, sandboxID))
-	s.logger.Debug("Invalidated sandbox cache after pause",
-		zap.String("sandbox_id", sandboxID),
-	)
 }
 
 // resumeSandbox resumes a paused sandbox
@@ -184,13 +163,6 @@ func (s *Server) resumeSandbox(c *gin.Context) {
 	}
 
 	s.proxyToManager(c)
-
-	// Invalidate cache after state change
-	authCtx := middleware.GetAuthContext(c)
-	s.sandboxAddrCache.Delete(sandboxCacheKey(authCtx.TeamID, sandboxID))
-	s.logger.Debug("Invalidated sandbox cache after resume",
-		zap.String("sandbox_id", sandboxID),
-	)
 }
 
 // refreshSandbox refreshes sandbox TTL

--- a/cluster-gateway/pkg/http/server.go
+++ b/cluster-gateway/pkg/http/server.go
@@ -5,7 +5,6 @@ import (
 	"crypto/ed25519"
 	"fmt"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/sandbox0-ai/sandbox0/cluster-gateway/pkg/client"
 	"github.com/sandbox0-ai/sandbox0/cluster-gateway/pkg/middleware"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
-	"github.com/sandbox0-ai/sandbox0/pkg/cache"
 	gatewayapikey "github.com/sandbox0-ai/sandbox0/pkg/gateway/apikey"
 	gatewaybuiltin "github.com/sandbox0-ai/sandbox0/pkg/gateway/auth/builtin"
 	gatewayoidc "github.com/sandbox0-ai/sandbox0/pkg/gateway/auth/oidc"
@@ -57,7 +55,6 @@ type Server struct {
 	internalAuthGen    *internalauth.Generator
 	procdAuthGen       *internalauth.Generator
 	entitlements       licensing.Entitlements
-	sandboxAddrCache   *cache.Cache[sandboxAddrCacheKey, *url.URL]
 	obsProvider        *observability.Provider
 	httpClient         *http.Client
 }
@@ -170,14 +167,6 @@ func NewServer(
 		managerClient.SetHTTPClient(httpClient)
 	}
 
-	// Create sandbox cache to reduce manager API calls
-	// TTL of 2 minutes balances performance and data freshness
-	sandboxAddrCache := cache.New[sandboxAddrCacheKey, *url.URL](cache.Config{
-		MaxSize:         10000,           // Support up to 10k active sandboxes
-		TTL:             2 * time.Minute, // Cache sandbox info for 2 minutes
-		CleanupInterval: 1 * time.Minute, // Cleanup expired entries every minute
-	})
-
 	var publicIdentityRepo *gatewayidentity.Repository
 	var publicAPIKeyRepo *gatewayapikey.Repository
 	var publicAuth *gatewaymiddleware.AuthMiddleware
@@ -275,7 +264,6 @@ func NewServer(
 		internalAuthGen:    internalAuthGen,
 		procdAuthGen:       procdAuthGen,
 		entitlements:       entitlements,
-		sandboxAddrCache:   sandboxAddrCache,
 		obsProvider:        obsProvider,
 		httpClient:         httpClient,
 	}
@@ -596,11 +584,6 @@ func (s *Server) Start(ctx context.Context) error {
 	case <-ctx.Done():
 		s.logger.Info("Shutting down HTTP server")
 
-		// Close sandbox cache to stop cleanup goroutine
-		if s.sandboxAddrCache != nil {
-			s.sandboxAddrCache.Close()
-		}
-
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), s.cfg.ShutdownTimeout.Duration)
 		defer cancel()
 		return server.Shutdown(shutdownCtx)
@@ -627,18 +610,9 @@ func (s *Server) readinessCheck(c *gin.Context) {
 		}
 	}
 
-	// Include cache stats in readiness check
-	cacheStats := s.sandboxAddrCache.Stats()
-
 	spec.JSONSuccess(c, http.StatusOK, gin.H{
 		"status":    "ready",
 		"timestamp": time.Now().Unix(),
-		"sandbox_addr_cache": gin.H{
-			"size":     cacheStats.Size,
-			"hits":     cacheStats.Hits,
-			"misses":   cacheStats.Misses,
-			"hit_rate": cacheStats.HitRate,
-		},
 	})
 }
 


### PR DESCRIPTION
## Summary
- Remove the cluster-gateway procd address cache so sandbox context and file routing always re-check manager-owned lifecycle state.
- Keep auto-resume detection in `getProcdURL` before proxying to procd.
- Update tests to cover repeated manager lookups and resume after a previously successful sandbox access becomes paused.

Closes #223

## Testing
- go test ./cluster-gateway/pkg/http
- go test ./cluster-gateway/...
- pre-push hook: make manifests, make proto, make apispec, go fmt ./..., go mod tidy, go mod vendor, golangci-lint run ./...