### PR TITLE
Use selected team for platform API key regional tokens

### DIFF
--- a/pkg/gateway/middleware/auth.go
+++ b/pkg/gateway/middleware/auth.go
@@ -120,14 +120,18 @@ func (m *AuthMiddleware) authenticateAPIKey(c *gin.Context, keyValue string) (*a
 	}
 	permissions := authn.ExpandRolesPermissions(apiKey.Roles)
 	isSystemAdmin := false
+	teamID := strings.TrimSpace(apiKey.TeamID)
 	if scope == apikey.ScopePlatform {
 		permissions = []string{"*"}
 		isSystemAdmin = true
+		teamID = strings.TrimSpace(c.GetHeader(internalauth.TeamIDHeader))
+	} else if selectedTeamID := strings.TrimSpace(c.GetHeader(internalauth.TeamIDHeader)); selectedTeamID != "" && selectedTeamID != teamID {
+		return nil, ErrSelectedTeamForbidden
 	}
 
 	return &authn.AuthContext{
 		AuthMethod:    authn.AuthMethodAPIKey,
-		TeamID:        apiKey.TeamID,
+		TeamID:        teamID,
 		UserID:        userID,
 		APIKeyID:      apiKey.ID,
 		IsSystemAdmin: isSystemAdmin,

--- a/pkg/gateway/middleware/auth_test.go
+++ b/pkg/gateway/middleware/auth_test.go
@@ -150,7 +150,7 @@ func TestAuthMiddleware_APIKeyFallsBackToCreatorUserID(t *testing.T) {
 	}
 }
 
-func TestAuthMiddleware_PlatformAPIKeySetsSystemAdmin(t *testing.T) {
+func TestAuthMiddleware_PlatformAPIKeySetsSystemAdminWithoutSelectedTeam(t *testing.T) {
 	t.Setenv("GIN_MODE", "release")
 
 	ownerID := "user-1"
@@ -180,6 +180,58 @@ func TestAuthMiddleware_PlatformAPIKeySetsSystemAdmin(t *testing.T) {
 	}
 	if authCtx.AuthMethod != authn.AuthMethodAPIKey || authCtx.APIKeyID != "key-1" {
 		t.Fatalf("unexpected auth context: %+v", authCtx)
+	}
+	if authCtx.TeamID != "" {
+		t.Fatalf("team id = %q, want empty without selected team", authCtx.TeamID)
+	}
+}
+
+func TestAuthMiddleware_PlatformAPIKeyUsesSelectedTeamHeader(t *testing.T) {
+	t.Setenv("GIN_MODE", "release")
+
+	req := httptest.NewRequest("GET", "/api/v1/sandboxes/sbox-1", nil)
+	req.Header.Set("Authorization", "Bearer s0_test")
+	req.Header.Set(internalauth.TeamIDHeader, "team-target")
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = req
+
+	middleware := NewAuthMiddleware(staticAPIKeyValidator{key: &apikey.APIKey{
+		ID:        "key-1",
+		TeamID:    "platform-owner-team",
+		CreatedBy: "creator-1",
+		Scope:     apikey.ScopePlatform,
+	}}, "test-secret", nil, zap.NewNop())
+	authCtx, err := middleware.AuthenticateRequest(ctx)
+	if err != nil {
+		t.Fatalf("authenticate request: %v", err)
+	}
+	if !authCtx.IsSystemAdmin {
+		t.Fatal("expected platform API key to set system admin")
+	}
+	if authCtx.TeamID != "team-target" {
+		t.Fatalf("team id = %q, want selected team", authCtx.TeamID)
+	}
+}
+
+func TestAuthMiddleware_TeamAPIKeyRejectsMismatchedTeamHeader(t *testing.T) {
+	t.Setenv("GIN_MODE", "release")
+
+	req := httptest.NewRequest("GET", "/api/v1/sandboxes/sbox-1", nil)
+	req.Header.Set("Authorization", "Bearer s0_test")
+	req.Header.Set(internalauth.TeamIDHeader, "team-other")
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = req
+
+	middleware := NewAuthMiddleware(staticAPIKeyValidator{key: &apikey.APIKey{
+		ID:        "key-1",
+		TeamID:    "team-1",
+		CreatedBy: "creator-1",
+		Roles:     []string{"developer"},
+	}}, "test-secret", nil, zap.NewNop())
+	if _, err := middleware.AuthenticateRequest(ctx); err != ErrSelectedTeamForbidden {
+		t.Fatalf("authenticate request error = %v, want %v", err, ErrSelectedTeamForbidden)
 	}
 }
 

--- a/regional-gateway/pkg/http/cluster_cache.go
+++ b/regional-gateway/pkg/http/cluster_cache.go
@@ -160,7 +160,7 @@ func (s *Server) generateInternalToken(authCtx *authn.AuthContext, target string
 	if authCtx == nil {
 		return s.internalAuthGen.GenerateSystem(target, internalauth.GenerateOptions{})
 	}
-	if authCtx.TeamID == "" || (authCtx.AuthMethod == authn.AuthMethodAPIKey && authCtx.IsSystemAdmin) {
+	if authCtx.TeamID == "" {
 		return s.internalAuthGen.GenerateSystem(
 			target,
 			internalauth.GenerateOptions{

--- a/regional-gateway/pkg/http/cluster_cache_test.go
+++ b/regional-gateway/pkg/http/cluster_cache_test.go
@@ -84,7 +84,7 @@ func TestGetClusterGatewayURLForClusterRefreshesCacheWithSystemToken(t *testing.
 	}
 }
 
-func TestGenerateInternalTokenUsesSystemTokenForPlatformAPIKey(t *testing.T) {
+func TestGenerateInternalTokenUsesSelectedTeamForPlatformAPIKey(t *testing.T) {
 	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatalf("GenerateKey: %v", err)
@@ -106,13 +106,42 @@ func TestGenerateInternalTokenUsesSystemTokenForPlatformAPIKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Validate: %v", err)
 	}
+	if claims.IsSystemToken() {
+		t.Fatalf("expected team-scoped token, got system token")
+	}
+	if claims.TeamID != "team-1" {
+		t.Fatalf("TeamID = %q, want team-1", claims.TeamID)
+	}
+	if len(claims.Permissions) != 1 || claims.Permissions[0] != "*" {
+		t.Fatalf("Permissions = %v, want [*]", claims.Permissions)
+	}
+}
+
+func TestGenerateInternalTokenUsesSystemTokenWithoutSelectedTeam(t *testing.T) {
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	server := &Server{internalAuthGen: internalauth.NewGenerator(internalauth.GeneratorConfig{Caller: "regional-gateway", PrivateKey: privateKey, TTL: time.Minute})}
+
+	token, err := server.generateInternalToken(&authn.AuthContext{
+		AuthMethod:    authn.AuthMethodAPIKey,
+		UserID:        "user-1",
+		APIKeyID:      "key-1",
+		IsSystemAdmin: true,
+		Permissions:   []string{"*"},
+	}, "scheduler")
+	if err != nil {
+		t.Fatalf("generateInternalToken: %v", err)
+	}
+	claims, err := internalauth.NewValidator(internalauth.ValidatorConfig{Target: "scheduler", PublicKey: publicKey}).Validate(token)
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
 	if !claims.IsSystemToken() {
 		t.Fatalf("expected system token, got team_id=%q", claims.TeamID)
 	}
 	if claims.TeamID != "" {
 		t.Fatalf("TeamID = %q, want empty", claims.TeamID)
-	}
-	if len(claims.Permissions) != 1 || claims.Permissions[0] != "*" {
-		t.Fatalf("Permissions = %v, want [*]", claims.Permissions)
 	}
 }

--- a/regional-gateway/pkg/http/handlers_credential_sources_test.go
+++ b/regional-gateway/pkg/http/handlers_credential_sources_test.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"context"
 	"crypto/ed25519"
 	"crypto/rand"
 	"io"
@@ -11,12 +12,21 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/apikey"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/authn"
 	gatewaymiddleware "github.com/sandbox0-ai/sandbox0/pkg/gateway/middleware"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"github.com/sandbox0-ai/sandbox0/pkg/proxy"
 	"go.uber.org/zap"
 )
+
+type edgeStaticAPIKeyValidator struct {
+	key *apikey.APIKey
+}
+
+func (v edgeStaticAPIKeyValidator) ValidateAPIKey(context.Context, string) (*apikey.APIKey, error) {
+	return v.key, nil
+}
 
 func TestCredentialSourcesRequireDedicatedPermissionsAtEdge(t *testing.T) {
 	gin.SetMode(gin.TestMode)
@@ -79,6 +89,71 @@ func TestCredentialSourcesRequireDedicatedPermissionsAtEdge(t *testing.T) {
 			t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusForbidden)
 		}
 	})
+}
+
+func TestCredentialSourcesRejectPlatformAPIKeyWithoutSelectedTeam(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	logger := zap.NewNop()
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate ed25519 keypair: %v", err)
+	}
+
+	called := false
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	clusterGatewayRouter, err := proxy.NewRouter(target.URL, logger, time.Second)
+	if err != nil {
+		t.Fatalf("create cluster-gateway proxy: %v", err)
+	}
+
+	server := &Server{
+		authMiddleware: gatewaymiddleware.NewAuthMiddleware(edgeStaticAPIKeyValidator{key: &apikey.APIKey{
+			ID:        "key-1",
+			TeamID:    "platform-owner-team",
+			CreatedBy: "user-1",
+			Scope:     apikey.ScopePlatform,
+		}}, "secret", nil, logger),
+		logger:               logger,
+		clusterGatewayRouter: clusterGatewayRouter,
+		internalAuthGen: internalauth.NewGenerator(internalauth.GeneratorConfig{
+			Caller:     "regional-gateway",
+			PrivateKey: privateKey,
+			TTL:        time.Minute,
+		}),
+	}
+	server.router = gin.New()
+	api := server.router.Group("/api")
+	api.Use(server.authMiddleware.Authenticate())
+	credentialSources := api.Group("/v1/credential-sources")
+	credentialSources.Use(server.requireTeamContextForTeamScopedAPI())
+	credentialSources.GET("/:name", server.authMiddleware.RequirePermission(authn.PermCredentialSourceRead), server.injectInternalToken(), server.clusterGatewayRouter.ProxyToTarget)
+	gateway := httptest.NewServer(server.router)
+	defer gateway.Close()
+
+	req, err := http.NewRequest(http.MethodGet, gateway.URL+"/api/v1/credential-sources/source-a", nil)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer s0_test")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+	if called {
+		t.Fatal("target should not be called without selected team")
+	}
 }
 
 type edgeCredentialSourceRequestSpy struct {

--- a/regional-gateway/pkg/http/server.go
+++ b/regional-gateway/pkg/http/server.go
@@ -306,6 +306,7 @@ func (s *Server) setupRoutes() {
 
 			// Sandbox creation and listing go to scheduler, others route to cluster-gateway
 			sandboxes := api.Group("/v1/sandboxes")
+			sandboxes.Use(s.requireTeamContextForTeamScopedAPI())
 			sandboxes.GET("", s.injectInternalTokenForTarget("scheduler"), s.schedulerRouter.ProxyToTarget)
 			sandboxes.POST("", s.injectInternalTokenForTarget("scheduler"), s.schedulerRouter.ProxyToTarget)
 			sandboxes.GET("/:id", s.getSandboxDetail)
@@ -324,6 +325,7 @@ func (s *Server) setupRoutes() {
 		}
 
 		credentialSources := api.Group("/v1/credential-sources")
+		credentialSources.Use(s.requireTeamContextForTeamScopedAPI())
 		{
 			credentialSources.GET("", s.authMiddleware.RequirePermission(authn.PermCredentialSourceRead), s.injectInternalToken(), s.clusterGatewayRouter.ProxyToTarget)
 			credentialSources.POST("", s.authMiddleware.RequirePermission(authn.PermCredentialSourceWrite), s.injectInternalToken(), s.clusterGatewayRouter.ProxyToTarget)
@@ -433,6 +435,9 @@ func (s *Server) handleAPINoRoute(c *gin.Context) bool {
 	if c.IsAborted() {
 		return true
 	}
+	if rejectTeamScopedPlatformAPIKeyWithoutTeam(c, authCtx) {
+		return true
+	}
 	token, err := s.generateInternalToken(authCtx, "cluster-gateway")
 	if err != nil {
 		s.logger.Error("Failed to generate internal token for cluster-gateway fallback", zap.Error(err))
@@ -441,6 +446,28 @@ func (s *Server) handleAPINoRoute(c *gin.Context) bool {
 	}
 	s.applyInternalHeaders(c, token, authCtx)
 	s.clusterGatewayRouter.ProxyToTarget(c)
+	return true
+}
+
+func (s *Server) requireTeamContextForTeamScopedAPI() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		authCtx := middleware.GetAuthContext(c)
+		if rejectTeamScopedPlatformAPIKeyWithoutTeam(c, authCtx) {
+			return
+		}
+		c.Next()
+	}
+}
+
+func rejectTeamScopedPlatformAPIKeyWithoutTeam(c *gin.Context, authCtx *authn.AuthContext) bool {
+	if authCtx == nil || authCtx.AuthMethod != authn.AuthMethodAPIKey || !authCtx.IsSystemAdmin {
+		return false
+	}
+	if strings.TrimSpace(authCtx.TeamID) != "" {
+		return false
+	}
+	spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "x-team-id is required for team-scoped platform API key requests")
+	c.Abort()
 	return true
 }
 


### PR DESCRIPTION
## Summary
- Use `X-Team-ID` as the selected team for platform-scoped API keys in regional auth context.
- Generate team-scoped internal tokens when a platform API key selected a team, and keep system tokens only when no team is selected.
- Reject team-scoped regional routes when a platform API key omits the selected team header.

Closes #225

## Testing
- go test ./pkg/gateway/middleware ./regional-gateway/pkg/http
- pre-push hook: make manifests, make proto, make apispec, go fmt ./..., go mod tidy, go mod vendor, golangci-lint run ./...