### PR TITLE
Make sandbox webhooks durable

### DIFF
--- a/infra-operator/api/config/manager.go
+++ b/infra-operator/api/config/manager.go
@@ -137,7 +137,9 @@ type ManagerConfig struct {
 	// Procd config injected into sandbox pods
 	// +optional
 	// +kubebuilder:default={}
-	ProcdConfig ProcdConfig `yaml:"procd_config" json:"procdConfig"`
+	ProcdConfig          ProcdConfig `yaml:"procd_config" json:"procdConfig"`
+	StorageProxyBaseURL  string      `yaml:"storage_proxy_base_url" json:"-"`
+	StorageProxyHTTPPort int         `yaml:"storage_proxy_http_port" json:"-"`
 
 	// Registry config for image pull secret provisioning
 	// +optional

--- a/infra-operator/api/config/procd.go
+++ b/infra-operator/api/config/procd.go
@@ -79,6 +79,9 @@ type ProcdConfig struct {
 	// +optional
 	// +kubebuilder:default="500ms"
 	WebhookBaseBackoff metav1.Duration `yaml:"webhook_base_backoff" json:"webhookBaseBackoff"`
+	// +optional
+	// +kubebuilder:default="/var/lib/sandbox0/procd/webhook-outbox"
+	WebhookOutboxDir string `yaml:"webhook_outbox_dir" json:"webhookOutboxDir"`
 
 	setKeys map[string]bool `yaml:"-" json:"-"`
 }
@@ -148,7 +151,7 @@ var (
 // LoadProcdConfig returns the procd configuration.
 func LoadProcdConfig() *ProcdConfig {
 	procdCfgOnce.Do(func() {
-		cfg := ProcdConfig{}
+		cfg := ProcdConfig{WebhookOutboxDir: "/var/lib/sandbox0/procd/webhook-outbox"}
 		if err := applyProcdEnvOverrides(&cfg); err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to apply procd env overrides: %v\n", err)
 		}

--- a/infra-operator/internal/plan/plan.go
+++ b/infra-operator/internal/plan/plan.go
@@ -524,9 +524,13 @@ func compileManagerRuntimeConfig(managerPlan *ManagerPlan, infra *infrav1alpha1.
 	if infrav1alpha1.IsStorageProxyEnabled(infra) {
 		cfg.ProcdConfig.StorageProxyBaseURL = fmt.Sprintf("%s-storage-proxy.%s.svc.cluster.local", infra.Name, infra.Namespace)
 		cfg.ProcdConfig.StorageProxyPort = int(common.ResolveServicePort(storageProxyServiceConfig, int32(storageProxyConfig.GRPCPort)))
+		cfg.StorageProxyBaseURL = cfg.ProcdConfig.StorageProxyBaseURL
+		cfg.StorageProxyHTTPPort = storageProxyHTTPPort(infra)
 	} else {
 		cfg.ProcdConfig.StorageProxyBaseURL = ""
 		cfg.ProcdConfig.StorageProxyPort = 0
+		cfg.StorageProxyBaseURL = ""
+		cfg.StorageProxyHTTPPort = 0
 	}
 	if infra.Spec.PublicExposure != nil {
 		cfg.PublicRootDomain = infra.Spec.PublicExposure.RootDomain

--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -243,6 +243,7 @@ func main() {
 	// Initialize internal auth generator for procd communication
 	var internalTokenGenerator service.TokenGenerator
 	var procdTokenGenerator service.TokenGenerator
+	var storageProxyAdminTokenGenerator service.TokenGenerator
 	privateKey, err := internalauth.LoadEd25519PrivateKeyFromFile(internalauth.DefaultInternalJWTPrivateKeyPath)
 	if err != nil {
 		logger.Warn("Failed to load internal auth private key, pause/resume will not work",
@@ -257,6 +258,7 @@ func main() {
 		})
 		internalTokenGenerator = service.NewInternalTokenGenerator(internalAuthGen)
 		procdTokenGenerator = service.NewProcdTokenGenerator(internalAuthGen)
+		storageProxyAdminTokenGenerator = service.NewStorageProxyAdminTokenGenerator(internalAuthGen)
 		logger.Info("Internal auth generators initialized for procd communication")
 	}
 
@@ -301,6 +303,18 @@ func main() {
 		managerMetrics,
 	)
 	sandboxService.SetCredentialStore(credentialStore)
+	if cfg.StorageProxyBaseURL != "" && cfg.StorageProxyHTTPPort > 0 && storageProxyAdminTokenGenerator != nil {
+		storageProxyBaseURL := fmt.Sprintf("http://%s:%d", strings.TrimSpace(cfg.StorageProxyBaseURL), cfg.StorageProxyHTTPPort)
+		sandboxService.SetWebhookStateVolumeClient(service.NewStorageProxyVolumeClient(service.StorageProxyVolumeClientConfig{
+			BaseURL:        storageProxyBaseURL,
+			HTTPClient:     obsProvider.HTTP.NewClient(httpobs.Config{Timeout: cfg.ProcdClientTimeout.Duration}),
+			TokenGenerator: storageProxyAdminTokenGenerator,
+		}))
+		logger.Info("Webhook state volumes enabled", zap.String("storageProxyBaseURL", storageProxyBaseURL))
+	} else {
+		logger.Warn("Webhook state volumes disabled; sandbox claims with webhooks will fail until storage-proxy is configured")
+	}
+	sandboxService.SetDeletionWebhookEmitter(service.NewHTTPSandboxDeletionWebhookEmitter(obsProvider.HTTP.NewClient(httpobs.Config{Timeout: cfg.ProcdClientTimeout.Duration})))
 	sandboxLifecycleController := service.NewSandboxLifecycleController(k8sClient, podLister, sandboxService, logger)
 	podInformer.Informer().AddEventHandler(sandboxLifecycleController.ResourceEventHandler())
 	operator.SetSandboxProbeRunner(sandboxService)

--- a/manager/cmd/procd/main.go
+++ b/manager/cmd/procd/main.go
@@ -78,6 +78,7 @@ func main() {
 		MaxRetries:     cfg.WebhookMaxRetries,
 		BaseBackoff:    cfg.WebhookBaseBackoff.Duration,
 		RequestTimeout: cfg.WebhookRequestTimeout.Duration,
+		OutboxDir:      cfg.WebhookOutboxDir,
 	}, logger)
 
 	contextManager.SetExitHandler(func(event process.ExitEvent) {
@@ -95,10 +96,12 @@ func main() {
 			"stderr_preview": event.StderrPreview,
 			"state":          event.State,
 		}
-		webhookDispatcher.Enqueue(webhook.Event{
+		if _, err := webhookDispatcher.Enqueue(webhook.Event{
 			EventType: eventType,
 			Payload:   payload,
-		})
+		}); err != nil {
+			logger.Warn("Failed to enqueue process exit webhook", zap.Error(err))
+		}
 	})
 
 	contextManager.SetStartHandler(func(event process.StartEvent) {
@@ -117,10 +120,12 @@ func main() {
 		if event.Config.Term != "" {
 			payload["term"] = event.Config.Term
 		}
-		webhookDispatcher.Enqueue(webhook.Event{
+		if _, err := webhookDispatcher.Enqueue(webhook.Event{
 			EventType: webhook.EventTypeProcessStarted,
 			Payload:   payload,
-		})
+		}); err != nil {
+			logger.Warn("Failed to enqueue process start webhook", zap.Error(err))
+		}
 	})
 
 	// Create shared token provider for storage-proxy communication
@@ -205,13 +210,15 @@ func main() {
 
 		cleanupCancel()
 
-		webhookDispatcher.Enqueue(webhook.Event{
+		if _, err := webhookDispatcher.Enqueue(webhook.Event{
 			EventType: webhook.EventTypeSandboxKilled,
 			Payload: map[string]any{
 				"signal": sig.String(),
 				"reason": "shutdown",
 			},
-		})
+		}); err != nil {
+			logger.Warn("Failed to enqueue sandbox killed webhook", zap.Error(err))
+		}
 
 		// Graceful shutdown
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/manager/pkg/controller/pool_manager.go
+++ b/manager/pkg/controller/pool_manager.go
@@ -52,6 +52,7 @@ const (
 	AnnotationNetworkPolicyHash            = "sandbox0.ai/network-policy-hash"
 	AnnotationNetworkPolicyAppliedHash     = "sandbox0.ai/network-policy-applied-hash"
 	AnnotationSandboxID                    = "sandbox0.ai/sandbox-id"
+	AnnotationWebhookStateVolumeID         = "sandbox0.ai/webhook-state-volume-id"
 	AnnotationTemplateSpecHash             = "sandbox0.ai/template-spec-hash"
 	AnnotationClusterAutoscalerSafeToEvict = "cluster-autoscaler.kubernetes.io/safe-to-evict"
 )

--- a/manager/pkg/service/sandbox_lifecycle_controller.go
+++ b/manager/pkg/service/sandbox_lifecycle_controller.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -29,10 +30,14 @@ const (
 
 // SandboxLifecycleInfo carries the durable identity needed to clean sandbox-scoped state.
 type SandboxLifecycleInfo struct {
-	Namespace string
-	PodName   string
-	SandboxID string
-	TeamID    string
+	Namespace            string
+	PodName              string
+	SandboxID            string
+	TeamID               string
+	UserID               string
+	WebhookURL           string
+	WebhookSecret        string
+	WebhookStateVolumeID string
 }
 
 // SandboxDeletionCleaner cleans external state for a deleted sandbox.
@@ -41,11 +46,15 @@ type SandboxDeletionCleaner interface {
 }
 
 type sandboxLifecycleQueueItem struct {
-	Namespace string
-	PodName   string
-	SandboxID string
-	TeamID    string
-	Deleted   bool
+	Namespace            string
+	PodName              string
+	SandboxID            string
+	TeamID               string
+	UserID               string
+	WebhookURL           string
+	WebhookSecret        string
+	WebhookStateVolumeID string
+	Deleted              bool
 }
 
 // SandboxLifecycleController reconciles sandbox deletion side effects from Pod lifecycle state.
@@ -242,10 +251,14 @@ func (c *SandboxLifecycleController) ensurePodCleanupFinalizer(ctx context.Conte
 
 func (c *SandboxLifecycleController) cleanupDeletedSandbox(ctx context.Context, item sandboxLifecycleQueueItem) error {
 	info := SandboxLifecycleInfo{
-		Namespace: item.Namespace,
-		PodName:   item.PodName,
-		SandboxID: item.SandboxID,
-		TeamID:    item.TeamID,
+		Namespace:            item.Namespace,
+		PodName:              item.PodName,
+		SandboxID:            item.SandboxID,
+		TeamID:               item.TeamID,
+		UserID:               item.UserID,
+		WebhookURL:           item.WebhookURL,
+		WebhookSecret:        item.WebhookSecret,
+		WebhookStateVolumeID: item.WebhookStateVolumeID,
 	}
 	if info.SandboxID == "" {
 		info.SandboxID = info.PodName
@@ -290,6 +303,11 @@ func (s *SandboxService) CleanupDeletedSandbox(ctx context.Context, info Sandbox
 	}
 
 	var errs []error
+	if s.deletionWebhookEmitter != nil && strings.TrimSpace(info.WebhookURL) != "" {
+		if err := s.deletionWebhookEmitter.EmitSandboxDeleted(ctx, info); err != nil {
+			errs = append(errs, fmt.Errorf("emit sandbox.deleted webhook: %w", err))
+		}
+	}
 	if s.networkProvider != nil && info.Namespace != "" {
 		if err := s.networkProvider.RemoveSandboxPolicy(ctx, info.Namespace, sandboxID); err != nil {
 			errs = append(errs, fmt.Errorf("remove network policy: %w", err))
@@ -305,6 +323,9 @@ func (s *SandboxService) CleanupDeletedSandbox(ctx context.Context, info Sandbox
 		} else if err := s.credentialStore.DeleteBindings(ctx, teamID, sandboxID); err != nil {
 			errs = append(errs, fmt.Errorf("delete credential bindings: %w", err))
 		}
+	}
+	if err := s.deleteWebhookStateVolume(ctx, info); err != nil {
+		errs = append(errs, fmt.Errorf("delete webhook state volume: %w", err))
 	}
 	s.powerStateLocks.Delete(sandboxID)
 	s.powerStateReconcilers.Delete(sandboxID)
@@ -338,11 +359,15 @@ func (s *SandboxService) ensureSandboxDeletionFinalizer(ctx context.Context, pod
 
 func sandboxLifecycleItemFromInfo(info SandboxLifecycleInfo, deleted bool) sandboxLifecycleQueueItem {
 	return sandboxLifecycleQueueItem{
-		Namespace: info.Namespace,
-		PodName:   info.PodName,
-		SandboxID: info.SandboxID,
-		TeamID:    info.TeamID,
-		Deleted:   deleted,
+		Namespace:            info.Namespace,
+		PodName:              info.PodName,
+		SandboxID:            info.SandboxID,
+		TeamID:               info.TeamID,
+		UserID:               info.UserID,
+		WebhookURL:           info.WebhookURL,
+		WebhookSecret:        info.WebhookSecret,
+		WebhookStateVolumeID: info.WebhookStateVolumeID,
+		Deleted:              deleted,
 	}
 }
 
@@ -358,14 +383,31 @@ func sandboxLifecycleInfoFromPod(pod *corev1.Pod) (SandboxLifecycleInfo, bool) {
 		return SandboxLifecycleInfo{}, false
 	}
 	teamID := ""
+	userID := ""
+	webhookURL := ""
+	webhookSecret := ""
+	webhookStateVolumeID := ""
 	if pod.Annotations != nil {
 		teamID = strings.TrimSpace(pod.Annotations[controller.AnnotationTeamID])
+		userID = strings.TrimSpace(pod.Annotations[controller.AnnotationUserID])
+		webhookStateVolumeID = strings.TrimSpace(pod.Annotations[controller.AnnotationWebhookStateVolumeID])
+		if configJSON := strings.TrimSpace(pod.Annotations[controller.AnnotationConfig]); configJSON != "" {
+			var cfg SandboxConfig
+			if err := json.Unmarshal([]byte(configJSON), &cfg); err == nil && cfg.Webhook != nil {
+				webhookURL = strings.TrimSpace(cfg.Webhook.URL)
+				webhookSecret = strings.TrimSpace(cfg.Webhook.Secret)
+			}
+		}
 	}
 	return SandboxLifecycleInfo{
-		Namespace: pod.Namespace,
-		PodName:   pod.Name,
-		SandboxID: sandboxID,
-		TeamID:    teamID,
+		Namespace:            pod.Namespace,
+		PodName:              pod.Name,
+		SandboxID:            sandboxID,
+		TeamID:               teamID,
+		UserID:               userID,
+		WebhookURL:           webhookURL,
+		WebhookSecret:        webhookSecret,
+		WebhookStateVolumeID: webhookStateVolumeID,
 	}, true
 }
 

--- a/manager/pkg/service/sandbox_lifecycle_controller_test.go
+++ b/manager/pkg/service/sandbox_lifecycle_controller_test.go
@@ -27,6 +27,16 @@ type deleteRecordingBindingStore struct {
 	deleteCalls int
 }
 
+type recordingSystemVolumeClient struct {
+	created []string
+	deleted []string
+}
+
+type recordingDeletionWebhookEmitter struct {
+	calls []SandboxLifecycleInfo
+	err   error
+}
+
 func (c *recordingSandboxCleaner) CleanupDeletedSandbox(_ context.Context, info SandboxLifecycleInfo) error {
 	c.calls = append(c.calls, info)
 	return c.err
@@ -51,6 +61,22 @@ func (s *deleteRecordingBindingStore) GetSourceByRef(context.Context, string, st
 
 func (s *deleteRecordingBindingStore) GetSourceVersion(context.Context, int64, int64) (*egressauth.CredentialSourceVersion, error) {
 	return nil, nil
+}
+
+func (c *recordingSystemVolumeClient) Create(_ context.Context, _, _, sandboxID, kind string) (string, error) {
+	id := sandboxID + "-" + kind
+	c.created = append(c.created, id)
+	return id, nil
+}
+
+func (c *recordingSystemVolumeClient) Delete(_ context.Context, _, _, _, volumeID string) error {
+	c.deleted = append(c.deleted, volumeID)
+	return nil
+}
+
+func (e *recordingDeletionWebhookEmitter) EmitSandboxDeleted(_ context.Context, info SandboxLifecycleInfo) error {
+	e.calls = append(e.calls, info)
+	return e.err
 }
 
 func TestSandboxLifecycleControllerCleansAndRemovesFinalizer(t *testing.T) {
@@ -184,6 +210,57 @@ func TestSandboxServiceCleanupDeletedSandboxRemovesExternalState(t *testing.T) {
 	}
 	if store.deleteCalls != 1 {
 		t.Fatalf("DeleteBindings calls = %d, want 1", store.deleteCalls)
+	}
+}
+
+func TestSandboxServiceCleanupDeletedSandboxEmitsWebhookAndDeletesStateVolume(t *testing.T) {
+	volumeClient := &recordingSystemVolumeClient{}
+	emitter := &recordingDeletionWebhookEmitter{}
+	svc := &SandboxService{
+		webhookStateVolumes:    volumeClient,
+		deletionWebhookEmitter: emitter,
+		logger:                 zap.NewNop(),
+	}
+
+	err := svc.CleanupDeletedSandbox(context.Background(), SandboxLifecycleInfo{
+		Namespace:            "ns-a",
+		PodName:              "sandbox-a",
+		SandboxID:            "sandbox-a",
+		TeamID:               "team-a",
+		UserID:               "user-a",
+		WebhookURL:           "https://example.test/webhook",
+		WebhookSecret:        "secret",
+		WebhookStateVolumeID: "volume-a",
+	})
+	if err != nil {
+		t.Fatalf("CleanupDeletedSandbox() error = %v", err)
+	}
+	if len(emitter.calls) != 1 {
+		t.Fatalf("webhook calls = %d, want 1", len(emitter.calls))
+	}
+	if emitter.calls[0].WebhookSecret != "secret" {
+		t.Fatalf("webhook secret = %q, want secret", emitter.calls[0].WebhookSecret)
+	}
+	if len(volumeClient.deleted) != 1 || volumeClient.deleted[0] != "volume-a" {
+		t.Fatalf("deleted volumes = %#v, want volume-a", volumeClient.deleted)
+	}
+}
+
+func TestSandboxLifecycleInfoFromPodIncludesWebhookMetadata(t *testing.T) {
+	pod := newLifecycleTestPod()
+	pod.Annotations[controller.AnnotationUserID] = "user-a"
+	pod.Annotations[controller.AnnotationWebhookStateVolumeID] = "volume-a"
+	pod.Annotations[controller.AnnotationConfig] = `{"webhook":{"url":"https://example.test/webhook","secret":"secret"}}`
+
+	info, ok := sandboxLifecycleInfoFromPod(pod)
+	if !ok {
+		t.Fatal("expected lifecycle info")
+	}
+	if info.UserID != "user-a" || info.WebhookStateVolumeID != "volume-a" {
+		t.Fatalf("unexpected lifecycle metadata: %#v", info)
+	}
+	if info.WebhookURL != "https://example.test/webhook" || info.WebhookSecret != "secret" {
+		t.Fatalf("unexpected webhook metadata: %#v", info)
 	}
 }
 

--- a/manager/pkg/service/sandbox_service.go
+++ b/manager/pkg/service/sandbox_service.go
@@ -124,6 +124,8 @@ type SandboxService struct {
 	autoScaler             AutoScalerInterface
 	credentialStore        egressauth.BindingStore
 	powerExecutor          SandboxPowerExecutor
+	webhookStateVolumes    SandboxSystemVolumeClient
+	deletionWebhookEmitter SandboxDeletionWebhookEmitter
 	powerStateLocks        sync.Map
 	powerStateReconcilers  sync.Map
 }
@@ -255,6 +257,16 @@ func (s *SandboxService) SetPowerExecutor(executor SandboxPowerExecutor) {
 		return
 	}
 	s.powerExecutor = executor
+}
+
+// SetWebhookStateVolumeClient injects the system volume client used for durable webhook state.
+func (s *SandboxService) SetWebhookStateVolumeClient(client SandboxSystemVolumeClient) {
+	s.webhookStateVolumes = client
+}
+
+// SetDeletionWebhookEmitter injects the emitter for manager-owned sandbox deletion events.
+func (s *SandboxService) SetDeletionWebhookEmitter(emitter SandboxDeletionWebhookEmitter) {
+	s.deletionWebhookEmitter = emitter
 }
 
 func (s *SandboxService) sandboxPowerExecutor() SandboxPowerExecutor {

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -170,6 +170,9 @@ func normalizeClaimMounts(mounts []ClaimMount) ([]ClaimMount, error) {
 		if !filepath.IsAbs(cleanMountPoint) || cleanMountPoint == string(filepath.Separator) || strings.Contains(cleanMountPoint, "..") {
 			return nil, fmt.Errorf("%w: mounts[%d].mount_point is invalid", ErrInvalidClaimRequest, i)
 		}
+		if cleanMountPoint == webhookStateMountPoint || strings.HasPrefix(cleanMountPoint, webhookStateMountPoint+string(filepath.Separator)) {
+			return nil, fmt.Errorf("%w: mounts[%d].mount_point uses a sandbox0 reserved path", ErrInvalidClaimRequest, i)
+		}
 		if _, exists := seenVolumes[mount.SandboxVolumeID]; exists {
 			return nil, fmt.Errorf("%w: duplicate sandboxvolume_id %q in claim mounts", ErrInvalidClaimRequest, mount.SandboxVolumeID)
 		}
@@ -209,7 +212,15 @@ func toBootstrapMountStatuses(in []BootstrapMountStatus) []BootstrapMountStatus 
 		return nil
 	}
 	out := make([]BootstrapMountStatus, 0, len(in))
-	out = append(out, in...)
+	for _, status := range in {
+		if filepath.Clean(status.MountPoint) == webhookStateMountPoint {
+			continue
+		}
+		out = append(out, status)
+	}
+	if len(out) == 0 {
+		return nil
+	}
 	return out
 }
 
@@ -428,6 +439,25 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 			zap.String("sandboxID", pod.Name),
 		)
 
+		stateVolume, err := s.prepareWebhookStateVolume(ctx, req, pod.Name)
+		if err != nil {
+			return fmt.Errorf("prepare webhook state volume: %w", err)
+		}
+		rollbackStateVolume := func() {
+			if stateVolume == nil {
+				return
+			}
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			if err := s.webhookStateVolumes.Delete(cleanupCtx, req.TeamID, req.UserID, pod.Name, stateVolume.VolumeID); err != nil && s.logger != nil {
+				s.logger.Warn("Failed to roll back webhook state volume",
+					zap.String("sandboxID", pod.Name),
+					zap.String("volumeID", stateVolume.VolumeID),
+					zap.Error(err),
+				)
+			}
+		}
+
 		// Update pod labels and annotations
 		pod = pod.DeepCopy()
 
@@ -449,6 +479,11 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 		pod.Annotations[controller.AnnotationUserID] = req.UserID
 		pod.Annotations[controller.AnnotationClaimedAt] = s.clock.Now().Format(time.RFC3339)
 		pod.Annotations[controller.AnnotationClaimType] = "hot"
+		if stateVolume != nil {
+			pod.Annotations[controller.AnnotationWebhookStateVolumeID] = stateVolume.VolumeID
+		} else {
+			delete(pod.Annotations, controller.AnnotationWebhookStateVolumeID)
+		}
 
 		// Set expiration annotations. Explicit 0 disables TTLs; omitted TTL uses the configured default.
 		persistedConfig := s.claimConfigForPersistence(req.Config)
@@ -479,6 +514,7 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 		// Update the pod
 		updatedPod, updateErr := s.k8sClient.CoreV1().Pods(pod.Namespace).Update(ctx, pod, metav1.UpdateOptions{})
 		if updateErr != nil {
+			rollbackStateVolume()
 			if rollbackErr := rollbackBindings(ctx); rollbackErr != nil {
 				s.logger.Warn("Failed to roll back credential bindings after hot-claim update failure",
 					zap.String("sandboxID", pod.Name),
@@ -551,6 +587,24 @@ func (s *SandboxService) createNewPod(ctx context.Context, template *v1alpha1.Sa
 	if err := s.ensureDataPlaneReadyCapacity(spec); err != nil {
 		return nil, err
 	}
+	stateVolume, err := s.prepareWebhookStateVolume(ctx, req, podName)
+	if err != nil {
+		return nil, fmt.Errorf("prepare webhook state volume: %w", err)
+	}
+	rollbackStateVolume := func() {
+		if stateVolume == nil {
+			return
+		}
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := s.webhookStateVolumes.Delete(cleanupCtx, req.TeamID, req.UserID, podName, stateVolume.VolumeID); err != nil && s.logger != nil {
+			s.logger.Warn("Failed to roll back webhook state volume",
+				zap.String("sandboxID", podName),
+				zap.String("volumeID", stateVolume.VolumeID),
+				zap.Error(err),
+			)
+		}
+	}
 
 	if err := controller.EnsureProcdConfigSecret(ctx, s.k8sClient, s.secretLister, template); err != nil {
 		return nil, fmt.Errorf("ensure procd config secret: %w", err)
@@ -566,6 +620,9 @@ func (s *SandboxService) createNewPod(ctx context.Context, template *v1alpha1.Sa
 		controller.AnnotationClaimedAt: s.clock.Now().Format(time.RFC3339),
 		controller.AnnotationClaimType: "cold",
 	})
+	if stateVolume != nil {
+		annotations[controller.AnnotationWebhookStateVolumeID] = stateVolume.VolumeID
+	}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      podName,
@@ -612,6 +669,7 @@ func (s *SandboxService) createNewPod(ctx context.Context, template *v1alpha1.Sa
 	// Create the pod
 	createdPod, err := s.k8sClient.CoreV1().Pods(template.ObjectMeta.Namespace).Create(ctx, pod, metav1.CreateOptions{})
 	if err != nil {
+		rollbackStateVolume()
 		if rollbackErr := rollbackBindings(ctx); rollbackErr != nil {
 			s.logger.Warn("Failed to clean up staged credential bindings after create failure",
 				zap.String("sandboxID", pod.Name),
@@ -731,21 +789,37 @@ func (s *SandboxService) initializeProcd(
 
 	webhookInfo := s.getWebhookInfo(req)
 	var webhookConfig *InitializeWebhook
+	mounts := req.Mounts
 	if webhookInfo != nil {
 		webhookConfig = &InitializeWebhook{
 			URL:      webhookInfo.URL,
 			Secret:   webhookInfo.Secret,
 			WatchDir: webhookInfo.WatchDir,
 		}
+		if pod.Annotations != nil {
+			if volumeID := strings.TrimSpace(pod.Annotations[controller.AnnotationWebhookStateVolumeID]); volumeID != "" {
+				mounts = appendWebhookStateMount(mounts, &webhookStateVolume{
+					VolumeID: volumeID,
+					Mount: ClaimMount{
+						SandboxVolumeID: volumeID,
+						MountPoint:      webhookStateMountPoint,
+					},
+				})
+			}
+		}
 	}
 
+	initWaitTimeout := claimMountWaitTimeout(req)
+	if len(mounts) > len(req.Mounts) && initWaitTimeout == 0 {
+		initWaitTimeout = 30 * time.Second
+	}
 	initReq := InitializeRequest{
 		SandboxID:          sandboxID,
 		TeamID:             teamID,
 		Webhook:            webhookConfig,
-		Mounts:             toInitializeMountRequests(req.Mounts),
-		WaitForMounts:      req.WaitForMounts,
-		MountWaitTimeoutMs: int32(claimMountWaitTimeout(req) / time.Millisecond),
+		Mounts:             toInitializeMountRequests(mounts),
+		WaitForMounts:      req.WaitForMounts || len(mounts) > len(req.Mounts),
+		MountWaitTimeoutMs: int32(initWaitTimeout / time.Millisecond),
 	}
 
 	var initErr error
@@ -754,8 +828,8 @@ func (s *SandboxService) initializeProcd(
 	if timeout == 0 {
 		timeout = 6 * time.Second
 	}
-	if waitTimeout := claimMountWaitTimeout(req); waitTimeout > timeout {
-		timeout = waitTimeout + time.Second
+	if initWaitTimeout > timeout {
+		timeout = initWaitTimeout + time.Second
 	}
 
 	initCtx, cancel := context.WithTimeout(ctx, timeout)

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -623,6 +623,20 @@ func TestValidateClaimMountsNormalizesMountPoint(t *testing.T) {
 	}
 }
 
+func TestValidateClaimMountsRejectsWebhookStatePath(t *testing.T) {
+	req := &ClaimRequest{
+		Mounts: []ClaimMount{{SandboxVolumeID: "vol-1", MountPoint: webhookStateMountPoint + "/custom"}},
+	}
+
+	err := validateClaimMounts(req)
+	if err == nil {
+		t.Fatal("expected reserved mount point validation error")
+	}
+	if !errors.Is(err, ErrInvalidClaimRequest) {
+		t.Fatalf("expected ErrInvalidClaimRequest, got %v", err)
+	}
+}
+
 func TestClaimMountWaitTimeoutDefaultsWhenEnabled(t *testing.T) {
 	got := claimMountWaitTimeout(&ClaimRequest{WaitForMounts: true})
 	if got != 30*time.Second {

--- a/manager/pkg/service/sandbox_webhook_state.go
+++ b/manager/pkg/service/sandbox_webhook_state.go
@@ -1,0 +1,242 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
+)
+
+const (
+	webhookStateMountPoint = "/var/lib/sandbox0/procd"
+	webhookStateVolumeKind = "webhook-state"
+)
+
+// SandboxSystemVolumeClient creates and deletes manager-owned sandbox volumes.
+type SandboxSystemVolumeClient interface {
+	Create(ctx context.Context, teamID, userID, sandboxID, kind string) (string, error)
+	Delete(ctx context.Context, teamID, userID, sandboxID, volumeID string) error
+}
+
+type StorageProxyVolumeClient struct {
+	baseURL        string
+	httpClient     *http.Client
+	tokenGenerator TokenGenerator
+}
+
+type StorageProxyVolumeClientConfig struct {
+	BaseURL        string
+	HTTPClient     *http.Client
+	TokenGenerator TokenGenerator
+}
+
+func NewStorageProxyVolumeClient(cfg StorageProxyVolumeClientConfig) *StorageProxyVolumeClient {
+	httpClient := cfg.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 10 * time.Second}
+	}
+	return &StorageProxyVolumeClient{
+		baseURL:        strings.TrimRight(strings.TrimSpace(cfg.BaseURL), "/"),
+		httpClient:     httpClient,
+		tokenGenerator: cfg.TokenGenerator,
+	}
+}
+
+func (c *StorageProxyVolumeClient) Create(ctx context.Context, teamID, userID, sandboxID, kind string) (string, error) {
+	if c == nil || c.baseURL == "" {
+		return "", fmt.Errorf("storage-proxy volume client is not configured")
+	}
+	token, err := c.generateToken(teamID, userID, sandboxID)
+	if err != nil {
+		return "", err
+	}
+	body := map[string]any{
+		"cache_size":  "64M",
+		"buffer_size": "8M",
+		"access_mode": "RWO",
+	}
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return "", err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/sandboxvolumes", bytes.NewReader(payload))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Internal-Token", token)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("create %s volume: %w", kind, err)
+	}
+	defer resp.Body.Close()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("read create volume response: %w", err)
+	}
+	volume, apiErr, err := spec.DecodeResponse[struct {
+		ID string `json:"id"`
+	}](bytes.NewReader(data))
+	if err != nil {
+		return "", fmt.Errorf("decode create volume response: %w", err)
+	}
+	if apiErr != nil {
+		return "", fmt.Errorf("create %s volume failed: %s", kind, apiErr.Message)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("create %s volume failed with status %d", kind, resp.StatusCode)
+	}
+	if volume == nil || strings.TrimSpace(volume.ID) == "" {
+		return "", fmt.Errorf("create %s volume returned no id", kind)
+	}
+	return volume.ID, nil
+}
+
+func (c *StorageProxyVolumeClient) Delete(ctx context.Context, teamID, userID, sandboxID, volumeID string) error {
+	if c == nil || c.baseURL == "" || strings.TrimSpace(volumeID) == "" {
+		return nil
+	}
+	token, err := c.generateToken(teamID, userID, sandboxID)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.baseURL+"/sandboxvolumes/"+volumeID+"?force=true", nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("X-Internal-Token", token)
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("delete webhook state volume: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+	data, _ := io.ReadAll(resp.Body)
+	_, apiErr, decodeErr := spec.DecodeResponse[map[string]bool](bytes.NewReader(data))
+	if decodeErr == nil && apiErr != nil {
+		return fmt.Errorf("delete webhook state volume failed: %s", apiErr.Message)
+	}
+	return fmt.Errorf("delete webhook state volume failed with status %d", resp.StatusCode)
+}
+
+func (c *StorageProxyVolumeClient) generateToken(teamID, userID, sandboxID string) (string, error) {
+	if c.tokenGenerator == nil {
+		return "", fmt.Errorf("storage-proxy token generator not configured")
+	}
+	return c.tokenGenerator.GenerateToken(teamID, userID, sandboxID)
+}
+
+type webhookStateVolume struct {
+	VolumeID string
+	Mount    ClaimMount
+}
+
+func (s *SandboxService) prepareWebhookStateVolume(ctx context.Context, req *ClaimRequest, sandboxID string) (*webhookStateVolume, error) {
+	if s == nil || s.getWebhookInfo(req) == nil {
+		return nil, nil
+	}
+	if s.webhookStateVolumes == nil {
+		return nil, fmt.Errorf("webhook state volume client is not configured")
+	}
+	volumeID, err := s.webhookStateVolumes.Create(ctx, req.TeamID, req.UserID, sandboxID, webhookStateVolumeKind)
+	if err != nil {
+		return nil, err
+	}
+	return &webhookStateVolume{
+		VolumeID: volumeID,
+		Mount: ClaimMount{
+			SandboxVolumeID: volumeID,
+			MountPoint:      webhookStateMountPoint,
+		},
+	}, nil
+}
+
+func (s *SandboxService) deleteWebhookStateVolume(ctx context.Context, info SandboxLifecycleInfo) error {
+	volumeID := strings.TrimSpace(info.WebhookStateVolumeID)
+	if volumeID == "" || s == nil || s.webhookStateVolumes == nil {
+		return nil
+	}
+	return s.webhookStateVolumes.Delete(ctx, info.TeamID, info.UserID, info.SandboxID, volumeID)
+}
+
+func appendWebhookStateMount(mounts []ClaimMount, state *webhookStateVolume) []ClaimMount {
+	if state == nil {
+		return mounts
+	}
+	out := make([]ClaimMount, 0, len(mounts)+1)
+	out = append(out, mounts...)
+	out = append(out, state.Mount)
+	return out
+}
+
+// SandboxDeletionWebhookEmitter emits manager-owned sandbox deletion lifecycle events.
+type SandboxDeletionWebhookEmitter interface {
+	EmitSandboxDeleted(ctx context.Context, info SandboxLifecycleInfo) error
+}
+
+type HTTPSandboxDeletionWebhookEmitter struct {
+	httpClient *http.Client
+}
+
+func NewHTTPSandboxDeletionWebhookEmitter(httpClient *http.Client) *HTTPSandboxDeletionWebhookEmitter {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 10 * time.Second}
+	}
+	return &HTTPSandboxDeletionWebhookEmitter{httpClient: httpClient}
+}
+
+func (e *HTTPSandboxDeletionWebhookEmitter) EmitSandboxDeleted(ctx context.Context, info SandboxLifecycleInfo) error {
+	url := strings.TrimSpace(info.WebhookURL)
+	if e == nil || url == "" {
+		return nil
+	}
+	event := map[string]any{
+		"event_id":   "evt_sandbox_deleted_" + info.SandboxID,
+		"event_type": "sandbox.deleted",
+		"timestamp":  time.Now().UTC(),
+		"sandbox_id": info.SandboxID,
+		"team_id":    info.TeamID,
+		"payload": map[string]any{
+			"reason": "pod_deleted",
+		},
+	}
+	body, err := json.Marshal(event)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if info.WebhookSecret != "" {
+		req.Header.Set("X-Sandbox0-Signature", signWebhookPayload(info.WebhookSecret, body))
+	}
+	resp, err := e.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("emit sandbox.deleted webhook: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("emit sandbox.deleted webhook failed with status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func signWebhookPayload(secret string, payload []byte) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(payload)
+	return hex.EncodeToString(mac.Sum(nil))
+}

--- a/manager/pkg/service/token_generator.go
+++ b/manager/pkg/service/token_generator.go
@@ -43,3 +43,24 @@ func (g *ProcdTokenGenerator) GenerateToken(teamID, userID, sandboxID string) (s
 		SandboxID:   sandboxID,
 	})
 }
+
+// StorageProxyAdminTokenGenerator generates manager tokens for storage-proxy volume lifecycle calls.
+type StorageProxyAdminTokenGenerator struct {
+	generator *internalauth.Generator
+}
+
+func NewStorageProxyAdminTokenGenerator(generator *internalauth.Generator) *StorageProxyAdminTokenGenerator {
+	return &StorageProxyAdminTokenGenerator{generator: generator}
+}
+
+func (g *StorageProxyAdminTokenGenerator) GenerateToken(teamID, userID, sandboxID string) (string, error) {
+	return g.generator.Generate("storage-proxy", teamID, userID, internalauth.GenerateOptions{
+		Permissions: []string{
+			"sandboxvolume:create",
+			"sandboxvolume:read",
+			"sandboxvolume:write",
+			"sandboxvolume:delete",
+		},
+		SandboxID: sandboxID,
+	})
+}

--- a/manager/procd/pkg/http/handlers/initialize.go
+++ b/manager/procd/pkg/http/handlers/initialize.go
@@ -122,13 +122,15 @@ func (h *InitializeHandler) Initialize(w http.ResponseWriter, r *http.Request) {
 
 	if webhookURL != "" {
 		h.readyOnce.Do(func() {
-			h.dispatcher.Enqueue(webhook.Event{
+			if _, err := h.dispatcher.Enqueue(webhook.Event{
 				EventType: webhook.EventTypeSandboxReady,
 				Payload: map[string]any{
 					"http_port":  h.httpPort,
 					"sandbox_id": req.SandboxID,
 				},
-			})
+			}); err != nil && h.logger != nil {
+				h.logger.Warn("Failed to enqueue sandbox ready webhook", zap.Error(err))
+			}
 		})
 	}
 
@@ -197,10 +199,12 @@ func (h *InitializeHandler) configureWebhookWatch(webhookURL, watchDir string) {
 		if event.OldPath != "" {
 			payload["old_path"] = event.OldPath
 		}
-		h.dispatcher.Enqueue(webhook.Event{
+		if _, err := h.dispatcher.Enqueue(webhook.Event{
 			EventType: webhook.EventTypeFileModified,
 			Payload:   payload,
-		})
+		}); err != nil && h.logger != nil {
+			h.logger.Warn("Failed to enqueue file webhook", zap.Error(err))
+		}
 	})
 	if err != nil {
 		if h.logger != nil {

--- a/manager/procd/pkg/http/handlers/sandbox.go
+++ b/manager/procd/pkg/http/handlers/sandbox.go
@@ -68,12 +68,14 @@ func (h *SandboxHandler) Pause(w http.ResponseWriter, r *http.Request) {
 		zap.Int64("memory_working_set", resourceUsage.ContainerMemoryWorkingSet),
 	)
 	if h.dispatcher != nil {
-		h.dispatcher.Enqueue(webhook.Event{
+		if _, err := h.dispatcher.Enqueue(webhook.Event{
 			EventType: webhook.EventTypeSandboxPaused,
 			Payload: map[string]any{
 				"resource_usage": resourceUsage,
 			},
-		})
+		}); err != nil {
+			h.logger.Warn("Failed to enqueue sandbox paused webhook", zap.Error(err))
+		}
 	}
 	writeJSON(w, http.StatusOK, PauseAllResponse{
 		Paused:        true,
@@ -109,12 +111,14 @@ func (h *SandboxHandler) Resume(w http.ResponseWriter, r *http.Request) {
 
 	h.logger.Info("All contexts resumed successfully")
 	if h.dispatcher != nil {
-		h.dispatcher.Enqueue(webhook.Event{
+		if _, err := h.dispatcher.Enqueue(webhook.Event{
 			EventType: webhook.EventTypeSandboxResumed,
 			Payload: map[string]any{
 				"resumed": true,
 			},
-		})
+		}); err != nil {
+			h.logger.Warn("Failed to enqueue sandbox resumed webhook", zap.Error(err))
+		}
 	}
 	writeJSON(w, http.StatusOK, ResumeAllResponse{
 		Resumed: true,

--- a/manager/procd/pkg/http/handlers/webhook.go
+++ b/manager/procd/pkg/http/handlers/webhook.go
@@ -53,7 +53,11 @@ func (h *WebhookHandler) Publish(w http.ResponseWriter, r *http.Request) {
 		EventType: webhook.EventTypeAgentEvent,
 		Payload:   payload,
 	}
-	h.dispatcher.Enqueue(event)
+	eventID, err := h.dispatcher.Enqueue(event)
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, "webhook_enqueue_failed", err.Error())
+		return
+	}
 
-	writeJSON(w, http.StatusAccepted, PublishResponse{EventID: event.EventID})
+	writeJSON(w, http.StatusAccepted, PublishResponse{EventID: eventID})
 }

--- a/manager/procd/pkg/webhook/dispatcher.go
+++ b/manager/procd/pkg/webhook/dispatcher.go
@@ -7,9 +7,14 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"math"
 	"math/rand"
 	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
 	"sync"
 	"time"
 
@@ -61,18 +66,17 @@ type Options struct {
 	MaxRetries     int
 	BaseBackoff    time.Duration
 	RequestTimeout time.Duration
+	OutboxDir      string
 }
 
-// Dispatcher sends webhook events asynchronously.
-// Guarantee: on graceful shutdown, Shutdown drains the in-memory queue and
-// attempts delivery with configured retries. It cannot guarantee delivery for
-// SIGKILL, node crash, or forced termination, and events may be dropped if the
-// queue is full or retries are exhausted.
+// Dispatcher sends webhook events asynchronously. When OutboxDir is configured,
+// Enqueue only succeeds after the signed delivery record is durably written.
 type Dispatcher struct {
 	logger *zap.Logger
 	client *http.Client
 
 	queue chan Event
+	wake  chan struct{}
 
 	mu         sync.RWMutex
 	config     Config
@@ -83,6 +87,23 @@ type Dispatcher struct {
 	enqueueMu  sync.Mutex
 	closed     bool
 	workerDone chan struct{}
+}
+
+var (
+	ErrDispatcherClosed = errors.New("webhook dispatcher closed")
+	ErrQueueFull        = errors.New("webhook queue full")
+)
+
+type deliveryRecord struct {
+	Event         Event           `json:"event"`
+	TargetURL     string          `json:"target_url"`
+	Body          json.RawMessage `json:"body"`
+	Signature     string          `json:"signature,omitempty"`
+	Attempts      int             `json:"attempts"`
+	NextAttemptAt time.Time       `json:"next_attempt_at"`
+	CreatedAt     time.Time       `json:"created_at"`
+	UpdatedAt     time.Time       `json:"updated_at"`
+	LastError     string          `json:"last_error,omitempty"`
 }
 
 // NewDispatcher creates a new dispatcher.
@@ -104,6 +125,7 @@ func NewDispatcher(options Options, logger *zap.Logger) *Dispatcher {
 		logger:     logger,
 		client:     &http.Client{Timeout: options.RequestTimeout},
 		queue:      make(chan Event, options.QueueSize),
+		wake:       make(chan struct{}, 1),
 		options:    options,
 		randSeed:   rand.New(rand.NewSource(time.Now().UnixNano())),
 		workerDone: make(chan struct{}),
@@ -138,8 +160,8 @@ func (d *Dispatcher) Identity() (string, string) {
 	return d.sandbox, d.teamID
 }
 
-// Enqueue sends an event to the dispatcher queue.
-func (d *Dispatcher) Enqueue(event Event) {
+// Enqueue sends an event to the dispatcher queue and returns its event ID.
+func (d *Dispatcher) Enqueue(event Event) (string, error) {
 	if event.EventID == "" {
 		event.EventID = "evt_" + uuid.NewString()
 	}
@@ -149,16 +171,24 @@ func (d *Dispatcher) Enqueue(event Event) {
 	d.fillIdentity(&event)
 
 	if !d.isConfigured() {
-		return
+		return event.EventID, nil
 	}
 
 	d.enqueueMu.Lock()
+	defer d.enqueueMu.Unlock()
 	if d.closed {
-		d.enqueueMu.Unlock()
-		return
+		return event.EventID, ErrDispatcherClosed
 	}
+	if d.options.OutboxDir != "" {
+		if err := d.enqueueDurable(event); err != nil {
+			return event.EventID, err
+		}
+		return event.EventID, nil
+	}
+
 	select {
 	case d.queue <- event:
+		return event.EventID, nil
 	default:
 		if d.logger != nil {
 			d.logger.Warn("Webhook queue full, dropping event",
@@ -166,14 +196,35 @@ func (d *Dispatcher) Enqueue(event Event) {
 				zap.String("event_type", string(event.EventType)),
 			)
 		}
+		return event.EventID, ErrQueueFull
 	}
-	d.enqueueMu.Unlock()
 }
 
 func (d *Dispatcher) worker() {
 	defer close(d.workerDone)
+	if d.options.OutboxDir != "" {
+		d.durableWorker()
+		return
+	}
 	for event := range d.queue {
 		d.sendWithRetry(event)
+	}
+}
+
+func (d *Dispatcher) durableWorker() {
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	for {
+		_ = d.drainOutbox()
+		select {
+		case <-d.wake:
+			continue
+		case <-ticker.C:
+			continue
+		case <-d.queue:
+			return
+		}
 	}
 }
 
@@ -247,6 +298,214 @@ func (d *Dispatcher) sendOnce(cfg Config, event Event) (int, error) {
 	}
 	defer resp.Body.Close()
 	return resp.StatusCode, nil
+}
+
+func (d *Dispatcher) enqueueDurable(event Event) error {
+	cfg := d.getConfig()
+	body, err := json.Marshal(event)
+	if err != nil {
+		return err
+	}
+	record := deliveryRecord{
+		Event:         event,
+		TargetURL:     cfg.URL,
+		Body:          append([]byte(nil), body...),
+		CreatedAt:     time.Now().UTC(),
+		UpdatedAt:     time.Now().UTC(),
+		NextAttemptAt: time.Time{},
+	}
+	if cfg.Secret != "" {
+		record.Signature = signPayload(cfg.Secret, body)
+	}
+	if err := d.writeRecord(record); err != nil {
+		return err
+	}
+	d.wakeWorker()
+	return nil
+}
+
+func (d *Dispatcher) writeRecord(record deliveryRecord) error {
+	if record.Event.EventID == "" {
+		return fmt.Errorf("missing event id")
+	}
+	if err := os.MkdirAll(d.options.OutboxDir, 0o700); err != nil {
+		return fmt.Errorf("create webhook outbox: %w", err)
+	}
+	path := d.recordPath(record.Event.EventID)
+	if _, err := os.Stat(path); err == nil {
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("stat webhook outbox record: %w", err)
+	}
+
+	data, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(d.options.OutboxDir, "."+record.Event.EventID+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("create webhook outbox temp: %w", err)
+	}
+	tmpName := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpName)
+		}
+	}()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write webhook outbox temp: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync webhook outbox temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close webhook outbox temp: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("commit webhook outbox record: %w", err)
+	}
+	cleanup = false
+	if dir, err := os.Open(d.options.OutboxDir); err == nil {
+		_ = dir.Sync()
+		_ = dir.Close()
+	}
+	return nil
+}
+
+func (d *Dispatcher) drainOutbox() error {
+	if d.options.OutboxDir == "" {
+		return nil
+	}
+	entries, err := filepath.Glob(filepath.Join(d.options.OutboxDir, "*.json"))
+	if err != nil {
+		return err
+	}
+	sort.Strings(entries)
+	now := time.Now().UTC()
+	for _, path := range entries {
+		record, err := readRecord(path)
+		if err != nil {
+			d.moveBadRecord(path, err)
+			continue
+		}
+		if !record.NextAttemptAt.IsZero() && record.NextAttemptAt.After(now) {
+			continue
+		}
+		status, err := d.sendRecord(record)
+		if err == nil && status >= 200 && status < 300 {
+			if removeErr := os.Remove(path); removeErr != nil && d.logger != nil {
+				d.logger.Warn("Failed to remove delivered webhook outbox record",
+					zap.String("path", path),
+					zap.Error(removeErr),
+				)
+			}
+			continue
+		}
+		if !shouldRetry(status, err) {
+			d.moveFailedRecord(path, record, status, err)
+			continue
+		}
+		record.Attempts++
+		record.UpdatedAt = now
+		record.NextAttemptAt = now.Add(d.backoffForAttempt(record.Attempts))
+		if err != nil {
+			record.LastError = err.Error()
+		} else {
+			record.LastError = fmt.Sprintf("http status %d", status)
+		}
+		if saveErr := writeRecordFile(path, record); saveErr != nil && d.logger != nil {
+			d.logger.Warn("Failed to update webhook outbox retry state",
+				zap.String("event_id", record.Event.EventID),
+				zap.Error(saveErr),
+			)
+		}
+	}
+	return nil
+}
+
+func readRecord(path string) (deliveryRecord, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return deliveryRecord{}, err
+	}
+	var record deliveryRecord
+	if err := json.Unmarshal(data, &record); err != nil {
+		return deliveryRecord{}, err
+	}
+	if record.TargetURL == "" || len(record.Body) == 0 || record.Event.EventID == "" {
+		return deliveryRecord{}, fmt.Errorf("invalid webhook outbox record")
+	}
+	return record, nil
+}
+
+func writeRecordFile(path string, record deliveryRecord) error {
+	data, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+func (d *Dispatcher) sendRecord(record deliveryRecord) (int, error) {
+	req, err := http.NewRequest(http.MethodPost, record.TargetURL, bytes.NewReader(record.Body))
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if record.Signature != "" {
+		req.Header.Set("X-Sandbox0-Signature", record.Signature)
+	}
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode, nil
+}
+
+func (d *Dispatcher) wakeWorker() {
+	select {
+	case d.wake <- struct{}{}:
+	default:
+	}
+}
+
+func (d *Dispatcher) moveBadRecord(path string, cause error) {
+	if d.logger != nil {
+		d.logger.Warn("Invalid webhook outbox record",
+			zap.String("path", path),
+			zap.Error(cause),
+		)
+	}
+	_ = os.MkdirAll(filepath.Join(d.options.OutboxDir, "bad"), 0o700)
+	_ = os.Rename(path, filepath.Join(d.options.OutboxDir, "bad", filepath.Base(path)))
+}
+
+func (d *Dispatcher) moveFailedRecord(path string, record deliveryRecord, status int, cause error) {
+	if d.logger != nil {
+		fields := []zap.Field{
+			zap.String("event_id", record.Event.EventID),
+			zap.String("event_type", string(record.Event.EventType)),
+			zap.Int("status", status),
+		}
+		if cause != nil {
+			fields = append(fields, zap.Error(cause))
+		}
+		d.logger.Warn("Webhook delivery permanently failed", fields...)
+	}
+	_ = os.MkdirAll(filepath.Join(d.options.OutboxDir, "failed"), 0o700)
+	_ = os.Rename(path, filepath.Join(d.options.OutboxDir, "failed", filepath.Base(path)))
+}
+
+func (d *Dispatcher) recordPath(eventID string) string {
+	return filepath.Join(d.options.OutboxDir, eventID+".json")
 }
 
 func (d *Dispatcher) fillIdentity(event *Event) {

--- a/manager/procd/pkg/webhook/dispatcher_test.go
+++ b/manager/procd/pkg/webhook/dispatcher_test.go
@@ -1,0 +1,176 @@
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+func TestDispatcherDurablyStoresBeforeDelivery(t *testing.T) {
+	outboxDir := t.TempDir()
+	dispatcher := NewDispatcher(Options{
+		OutboxDir:      outboxDir,
+		RequestTimeout: 10 * time.Millisecond,
+		BaseBackoff:    10 * time.Millisecond,
+	}, zap.NewNop())
+	t.Cleanup(func() {
+		_ = dispatcher.Shutdown(context.Background())
+	})
+	dispatcher.SetIdentity("sandbox-1", "team-1")
+	dispatcher.SetConfig("http://127.0.0.1:1/webhook", "secret")
+
+	eventID, err := dispatcher.Enqueue(Event{
+		EventID:   "evt-durable",
+		EventType: EventTypeAgentEvent,
+		Payload:   map[string]any{"ok": true},
+	})
+	if err != nil {
+		t.Fatalf("Enqueue() error = %v", err)
+	}
+	if eventID != "evt-durable" {
+		t.Fatalf("eventID = %q, want evt-durable", eventID)
+	}
+
+	record := readTestRecord(t, filepath.Join(outboxDir, "evt-durable.json"))
+	if record.TargetURL != "http://127.0.0.1:1/webhook" {
+		t.Fatalf("target URL = %q", record.TargetURL)
+	}
+	if record.Signature == "" {
+		t.Fatal("expected stored signed payload")
+	}
+	if record.Event.SandboxID != "sandbox-1" || record.Event.TeamID != "team-1" {
+		t.Fatalf("identity not filled: %#v", record.Event)
+	}
+}
+
+func TestDispatcherDurableOutboxReplaysAfterRestart(t *testing.T) {
+	outboxDir := t.TempDir()
+	first := NewDispatcher(Options{
+		OutboxDir:      outboxDir,
+		RequestTimeout: 10 * time.Millisecond,
+		BaseBackoff:    10 * time.Millisecond,
+	}, zap.NewNop())
+	first.SetConfig("http://127.0.0.1:1/webhook", "")
+	if _, err := first.Enqueue(Event{EventID: "evt-replay", EventType: EventTypeAgentEvent}); err != nil {
+		t.Fatalf("first Enqueue() error = %v", err)
+	}
+	_ = first.Shutdown(context.Background())
+
+	var (
+		mu       sync.Mutex
+		received []Event
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var event Event
+		if err := json.NewDecoder(r.Body).Decode(&event); err != nil {
+			t.Errorf("decode event: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		mu.Lock()
+		received = append(received, event)
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	record := readTestRecord(t, filepath.Join(outboxDir, "evt-replay.json"))
+	record.TargetURL = server.URL
+	writeTestRecord(t, filepath.Join(outboxDir, "evt-replay.json"), record)
+
+	second := NewDispatcher(Options{
+		OutboxDir:      outboxDir,
+		RequestTimeout: time.Second,
+		BaseBackoff:    10 * time.Millisecond,
+	}, zap.NewNop())
+	defer second.Shutdown(context.Background())
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		count := len(received)
+		mu.Unlock()
+		if count == 1 {
+			if _, err := os.Stat(filepath.Join(outboxDir, "evt-replay.json")); os.IsNotExist(err) {
+				return
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	t.Fatalf("received %d events, want 1", len(received))
+}
+
+func TestDispatcherDurableOutboxDeduplicatesPendingEventID(t *testing.T) {
+	outboxDir := t.TempDir()
+	dispatcher := NewDispatcher(Options{
+		OutboxDir:      outboxDir,
+		RequestTimeout: 10 * time.Millisecond,
+		BaseBackoff:    time.Hour,
+	}, zap.NewNop())
+	t.Cleanup(func() {
+		_ = dispatcher.Shutdown(context.Background())
+	})
+	dispatcher.SetConfig("http://127.0.0.1:1/webhook", "")
+
+	if _, err := dispatcher.Enqueue(Event{
+		EventID:   "evt-same",
+		EventType: EventTypeAgentEvent,
+		Payload:   map[string]any{"value": "first"},
+	}); err != nil {
+		t.Fatalf("first Enqueue() error = %v", err)
+	}
+	if _, err := dispatcher.Enqueue(Event{
+		EventID:   "evt-same",
+		EventType: EventTypeAgentEvent,
+		Payload:   map[string]any{"value": "second"},
+	}); err != nil {
+		t.Fatalf("second Enqueue() error = %v", err)
+	}
+
+	files, err := filepath.Glob(filepath.Join(outboxDir, "*.json"))
+	if err != nil {
+		t.Fatalf("glob outbox: %v", err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("record count = %d, want 1 (%#v)", len(files), files)
+	}
+	record := readTestRecord(t, files[0])
+	if string(record.Body) == "" {
+		t.Fatal("expected stored body")
+	}
+	if got := record.Event.Payload.(map[string]any)["value"]; got != "first" {
+		t.Fatalf("payload value = %v, want first", got)
+	}
+}
+
+func readTestRecord(t *testing.T, path string) deliveryRecord {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for {
+		record, err := readRecord(path)
+		if err == nil {
+			return record
+		}
+		if !os.IsNotExist(err) || time.Now().After(deadline) {
+			t.Fatalf("read record %s: %v", path, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func writeTestRecord(t *testing.T, path string, record deliveryRecord) {
+	t.Helper()
+	if err := writeRecordFile(path, record); err != nil {
+		t.Fatalf("write record %s: %v", path, err)
+	}
+}

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -4096,6 +4096,8 @@ components:
               required: [sandbox_id, exposed_ports]
     WebhookConfig:
       type: object
+      description: |
+        Per-sandbox webhook configuration. Sandbox0 delivers webhook events at least once and consumers should deduplicate by event_id. For sandbox lifecycle events, procd persists signed delivery records to a manager-owned SandboxVolume outside the workspace before dispatch; manager also emits sandbox.deleted during pod deletion cleanup.
       properties:
         url:
           description: Required when webhook is enabled. Target URL that receives event callbacks.

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -1493,7 +1493,9 @@ type SandboxConfig struct {
 	HardTtl      *int32                `json:"hard_ttl,omitempty"`
 	Network      *SandboxNetworkPolicy `json:"network,omitempty"`
 	Ttl          *int32                `json:"ttl,omitempty"`
-	Webhook      *WebhookConfig        `json:"webhook,omitempty"`
+
+	// Webhook Per-sandbox webhook configuration. Sandbox0 delivers webhook events at least once and consumers should deduplicate by event_id. For sandbox lifecycle events, procd persists signed delivery records to a manager-owned SandboxVolume outside the workspace before dispatch; manager also emits sandbox.deleted during pod deletion cleanup.
+	Webhook *WebhookConfig `json:"webhook,omitempty"`
 }
 
 // SandboxNetworkPolicy defines model for SandboxNetworkPolicy.
@@ -2662,7 +2664,7 @@ type WebLoginExchangeRequest struct {
 	ReturnUrl string `json:"return_url"`
 }
 
-// WebhookConfig defines model for WebhookConfig.
+// WebhookConfig Per-sandbox webhook configuration. Sandbox0 delivers webhook events at least once and consumers should deduplicate by event_id. For sandbox lifecycle events, procd persists signed delivery records to a manager-owned SandboxVolume outside the workspace before dispatch; manager also emits sandbox.deleted during pod deletion cleanup.
 type WebhookConfig struct {
 	// Secret Optional. Shared secret used to sign webhook payloads.
 	Secret *string `json:"secret,omitempty"`

--- a/skills/sandbox0/references/docs-src/sandbox/webhooks/page.mdx
+++ b/skills/sandbox0/references/docs-src/sandbox/webhooks/page.mdx
@@ -20,6 +20,18 @@ Webhooks are configured per-sandbox at creation time. Each sandbox can have its 
 `secret` is optional. For quick debugging, you can leave it empty and use services like <DocLink href="https://webhook.site" newTab>webhook.site</DocLink> to inspect incoming events directly.
 </Callout>
 
+## Delivery Guarantees
+
+Webhook events are delivered at least once. Your endpoint should return a `2xx` status only after it has durably recorded the event, and should deduplicate by `event_id`.
+
+When a sandbox is created with a webhook, Sandbox0 creates a manager-owned SandboxVolume for webhook delivery state and mounts it at a reserved procd path outside the workspace. Procd writes signed delivery records to that volume before acknowledging the internal publish request, then retries delivery from the outbox until the endpoint accepts the event.
+
+Sandbox deletion has an additional manager-level path. If the sandbox pod is deleted directly, or procd exits before it can emit `sandbox.killed`, manager emits `sandbox.deleted` from the pod finalizer cleanup path.
+
+<Callout variant="info">
+Webhook delivery is eventually consistent. Temporary endpoint outages, procd container restarts, and manager restarts can cause retries. Consumers must treat repeated `event_id` values as duplicate deliveries.
+</Callout>
+
 ---
 
 ## Event Types
@@ -32,6 +44,7 @@ Webhooks are configured per-sandbox at creation time. Each sandbox can have its 
 | `sandbox.paused` | Sandbox has been paused |
 | `sandbox.resumed` | Sandbox has been resumed |
 | `sandbox.killed` | Sandbox has been killed |
+| `sandbox.deleted` | Sandbox pod has been deleted and manager is cleaning sandbox-scoped state |
 
 ### Process Events
 
@@ -250,6 +263,8 @@ done`
 ## Triggering Webhook Events
 
 ### Sandbox Events
+
+`sandbox.ready` is emitted after initialization. `sandbox.paused` and `sandbox.resumed` are emitted when pause and resume requests complete. `sandbox.killed` is emitted by procd during graceful shutdown, and `sandbox.deleted` is emitted by manager when the sandbox pod deletion cleanup runs.
 
 <Tabs
   tabs={[

--- a/tests/e2e/cases/api_fullmode.go
+++ b/tests/e2e/cases/api_fullmode.go
@@ -12,6 +12,7 @@ func registerApiFullModeSuite(envProvider func() *framework.ScenarioEnv) {
 		includePoolReadinessGate:  true,
 		includeNetworkPolicy:      true,
 		includeVolumeLifecycle:    true,
+		includeWebhookLifecycle:   true,
 		includeMeteringAssertions: true,
 	})
 }

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -31,6 +31,7 @@ type apiModeSuiteOptions struct {
 	includePoolReadinessGate  bool
 	includeNetworkPolicy      bool
 	includeVolumeLifecycle    bool
+	includeWebhookLifecycle   bool
 	includeMeteringAssertions bool
 	expectStorageUnavailable  bool
 	expectNetworkUnavailable  bool
@@ -236,6 +237,14 @@ func registerApiModeSuite(envProvider func() *framework.ScenarioEnv, opts apiMod
 			})
 		}
 
+		if opts.includeWebhookLifecycle {
+			Context("sandbox webhooks", func() {
+				It("delivers lifecycle events through durable state volume and pod deletion", func() {
+					assertSandboxWebhookDurabilityLifecycle(env, session)
+				})
+			})
+		}
+
 		if opts.expectStorageUnavailable || opts.expectNetworkUnavailable {
 			Context("missing services", func() {
 				It("returns expected degraded-mode errors", func() {
@@ -408,6 +417,182 @@ func runTemplateLifecycleAssertions(env *framework.ScenarioEnv, session *e2eutil
 
 	err = session.DeleteTemplate(env.TestCtx.Context, GinkgoT(), name)
 	Expect(err).NotTo(HaveOccurred())
+}
+
+func assertSandboxWebhookDurabilityLifecycle(env *framework.ScenarioEnv, session *e2eutils.Session) {
+	receiverName := "sandbox0-e2e-webhook"
+	cleanup := setupWebhookReceiver(env, receiverName)
+	defer cleanup()
+
+	webhookURL := fmt.Sprintf("http://%s.%s.svc.cluster.local:8080/events", receiverName, env.Infra.Namespace)
+	webhookSecret := "e2e-secret"
+	template := "default"
+	claimReq := apispec.ClaimRequest{
+		Template: &template,
+		Config: &apispec.SandboxConfig{
+			Webhook: &apispec.WebhookConfig{
+				Url:    &webhookURL,
+				Secret: &webhookSecret,
+			},
+		},
+	}
+
+	claimResp, err := session.ClaimSandboxWithRequest(env.TestCtx.Context, GinkgoT(), claimReq)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(claimResp).NotTo(BeNil())
+	Expect(claimResp.BootstrapMounts).To(BeNil())
+	sandboxID := claimResp.SandboxId
+	defer func() {
+		_ = session.DeleteSandbox(env.TestCtx.Context, GinkgoT(), sandboxID)
+	}()
+
+	volumeID, err := framework.KubectlGetJSONPath(
+		env.TestCtx.Context,
+		env.Config.Kubeconfig,
+		env.Infra.Namespace,
+		"pod",
+		claimResp.PodName,
+		"{.metadata.annotations.sandbox0\\.ai/webhook-state-volume-id}",
+	)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(strings.TrimSpace(volumeID)).NotTo(BeEmpty())
+
+	Eventually(func() error {
+		events := readWebhookReceiverEvents(env, receiverName)
+		if !strings.Contains(events, `"event_type":"sandbox.ready"`) {
+			return fmt.Errorf("missing sandbox.ready event: %s", events)
+		}
+		return nil
+	}).WithTimeout(90 * time.Second).WithPolling(3 * time.Second).Should(Succeed())
+
+	Expect(framework.Kubectl(
+		env.TestCtx.Context,
+		env.Config.Kubeconfig,
+		"delete",
+		"pod",
+		claimResp.PodName,
+		"--namespace",
+		env.Infra.Namespace,
+		"--wait=true",
+	)).To(Succeed())
+	sandboxID = ""
+
+	Eventually(func() error {
+		events := readWebhookReceiverEvents(env, receiverName)
+		if !strings.Contains(events, `"event_type":"sandbox.deleted"`) {
+			return fmt.Errorf("missing sandbox.deleted event: %s", events)
+		}
+		return nil
+	}).WithTimeout(90 * time.Second).WithPolling(3 * time.Second).Should(Succeed())
+}
+
+func setupWebhookReceiver(env *framework.ScenarioEnv, name string) func() {
+	manifest := fmt.Sprintf(`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: %[1]s-script
+  namespace: %[2]s
+data:
+  server.py: |
+    from http.server import BaseHTTPRequestHandler, HTTPServer
+    from pathlib import Path
+
+    events = Path("/data/events.jsonl")
+    events.parent.mkdir(parents=True, exist_ok=True)
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            length = int(self.headers.get("content-length", "0"))
+            body = self.rfile.read(length)
+            with events.open("ab") as f:
+                f.write(body + b"\n")
+            self.send_response(204)
+            self.end_headers()
+
+        def log_message(self, fmt, *args):
+            return
+
+    HTTPServer(("0.0.0.0", 8080), Handler).serve_forever()
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: %[1]s
+  namespace: %[2]s
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: %[1]s
+  template:
+    metadata:
+      labels:
+        app: %[1]s
+    spec:
+      containers:
+        - name: receiver
+          image: python:3.12-alpine
+          imagePullPolicy: IfNotPresent
+          command: ["python", "/app/server.py"]
+          ports:
+            - containerPort: 8080
+          volumeMounts:
+            - name: script
+              mountPath: /app
+              readOnly: true
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: script
+          configMap:
+            name: %[1]s-script
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: %[1]s
+  namespace: %[2]s
+spec:
+  selector:
+    app: %[1]s
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+`, name, env.Infra.Namespace)
+	Expect(framework.ApplyManifestContent(env.TestCtx.Context, env.Config.Kubeconfig, "sandbox0-e2e-webhook-", manifest)).To(Succeed())
+	Expect(framework.WaitForDeployment(env.TestCtx.Context, env.Config.Kubeconfig, env.Infra.Namespace, name, "3m")).To(Succeed())
+	return func() {
+		_ = framework.Kubectl(env.TestCtx.Context, env.Config.Kubeconfig, "delete", "service", name, "--namespace", env.Infra.Namespace, "--ignore-not-found=true")
+		_ = framework.Kubectl(env.TestCtx.Context, env.Config.Kubeconfig, "delete", "deployment", name, "--namespace", env.Infra.Namespace, "--ignore-not-found=true")
+		_ = framework.Kubectl(env.TestCtx.Context, env.Config.Kubeconfig, "delete", "configmap", name+"-script", "--namespace", env.Infra.Namespace, "--ignore-not-found=true")
+	}
+}
+
+func readWebhookReceiverEvents(env *framework.ScenarioEnv, name string) string {
+	podName, err := framework.KubectlGetJSONPath(
+		env.TestCtx.Context,
+		env.Config.Kubeconfig,
+		env.Infra.Namespace,
+		"pod",
+		"-l=app="+name,
+		"{.items[0].metadata.name}",
+	)
+	Expect(err).NotTo(HaveOccurred())
+	output, err := framework.KubectlExecOutput(
+		env.TestCtx.Context,
+		env.Config.Kubeconfig,
+		env.Infra.Namespace,
+		strings.TrimSpace(podName),
+		"sh",
+		"-c",
+		"cat /data/events.jsonl 2>/dev/null || true",
+	)
+	Expect(err).NotTo(HaveOccurred())
+	return output
 }
 
 func assertTemplateStatusCountersEventually(env *framework.ScenarioEnv, session *e2eutils.Session) {

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -445,11 +445,13 @@ func assertSandboxWebhookDurabilityLifecycle(env *framework.ScenarioEnv, session
 	defer func() {
 		_ = session.DeleteSandbox(env.TestCtx.Context, GinkgoT(), sandboxID)
 	}()
+	sandboxNamespace, err := naming.TemplateNamespaceForBuiltin(template)
+	Expect(err).NotTo(HaveOccurred())
 
 	volumeID, err := framework.KubectlGetJSONPath(
 		env.TestCtx.Context,
 		env.Config.Kubeconfig,
-		env.Infra.Namespace,
+		sandboxNamespace,
 		"pod",
 		claimResp.PodName,
 		"{.metadata.annotations.sandbox0\\.ai/webhook-state-volume-id}",
@@ -472,7 +474,7 @@ func assertSandboxWebhookDurabilityLifecycle(env *framework.ScenarioEnv, session
 		"pod",
 		claimResp.PodName,
 		"--namespace",
-		env.Infra.Namespace,
+		sandboxNamespace,
 		"--wait=true",
 	)).To(Succeed())
 	sandboxID = ""


### PR DESCRIPTION
## Summary
- Add a procd durable webhook outbox that stores signed delivery records before acknowledging publish requests and replays them after restart.
- Create and bootstrap-mount a manager-owned webhook state SandboxVolume at a reserved procd path for sandbox claims with webhooks.
- Emit `sandbox.deleted` from manager sandbox lifecycle cleanup and clean up the annotated webhook state volume on the direct cleanup path.
- Update webhook docs/OpenAPI and add unit plus e2e coverage for durable lifecycle delivery.

Closes #227
Refs #228

## Testing
- `make proto`
- `make apispec`
- `git diff --check`
- `go test ./pkg/apispec ./manager/pkg/service ./manager/procd/pkg/webhook ./manager/procd/pkg/http/handlers ./manager/cmd/procd ./manager/cmd/manager ./infra-operator/internal/plan ./infra-operator/internal/runtimeconfig ./infra-operator/api/config ./manager/pkg/controller ./tests/e2e/cases ./tests/e2e/utils`
- pre-push hook: `make manifests`, `make proto`, `make apispec`, `go fmt ./...`, `go mod tidy`, `go mod vendor`, `golangci-lint run ./...`