### PR TITLE
Add lifecycle ownership and GC for manager-created volumes

### DIFF
--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -309,6 +309,7 @@ func main() {
 			BaseURL:        storageProxyBaseURL,
 			HTTPClient:     obsProvider.HTTP.NewClient(httpobs.Config{Timeout: cfg.ProcdClientTimeout.Duration}),
 			TokenGenerator: storageProxyAdminTokenGenerator,
+			ClusterID:      cfg.DefaultClusterId,
 		}))
 		logger.Info("Webhook state volumes enabled", zap.String("storageProxyBaseURL", storageProxyBaseURL))
 	} else {
@@ -475,6 +476,7 @@ func main() {
 	}()
 
 	go sandboxService.StartPowerStateReconciler(ctx, cfg.ResyncPeriod.Duration)
+	go sandboxService.StartSystemVolumeReconciler(ctx, cfg.ResyncPeriod.Duration)
 
 	// Start HTTP server
 	go func() {

--- a/manager/pkg/service/sandbox_lifecycle_controller_test.go
+++ b/manager/pkg/service/sandbox_lifecycle_controller_test.go
@@ -30,6 +30,8 @@ type deleteRecordingBindingStore struct {
 type recordingSystemVolumeClient struct {
 	created []string
 	deleted []string
+	marked  []string
+	list    []SandboxSystemVolume
 }
 
 type recordingDeletionWebhookEmitter struct {
@@ -72,6 +74,15 @@ func (c *recordingSystemVolumeClient) Create(_ context.Context, _, _, sandboxID,
 func (c *recordingSystemVolumeClient) Delete(_ context.Context, _, _, _, volumeID string) error {
 	c.deleted = append(c.deleted, volumeID)
 	return nil
+}
+
+func (c *recordingSystemVolumeClient) MarkSandboxForCleanup(_ context.Context, _, _, sandboxID, reason string) error {
+	c.marked = append(c.marked, sandboxID+":"+reason)
+	return nil
+}
+
+func (c *recordingSystemVolumeClient) List(_ context.Context) ([]SandboxSystemVolume, error) {
+	return c.list, nil
 }
 
 func (e *recordingDeletionWebhookEmitter) EmitSandboxDeleted(_ context.Context, info SandboxLifecycleInfo) error {
@@ -213,7 +224,7 @@ func TestSandboxServiceCleanupDeletedSandboxRemovesExternalState(t *testing.T) {
 	}
 }
 
-func TestSandboxServiceCleanupDeletedSandboxEmitsWebhookAndDeletesStateVolume(t *testing.T) {
+func TestSandboxServiceCleanupDeletedSandboxEmitsWebhookAndMarksStateVolumeForCleanup(t *testing.T) {
 	volumeClient := &recordingSystemVolumeClient{}
 	emitter := &recordingDeletionWebhookEmitter{}
 	svc := &SandboxService{
@@ -241,8 +252,8 @@ func TestSandboxServiceCleanupDeletedSandboxEmitsWebhookAndDeletesStateVolume(t 
 	if emitter.calls[0].WebhookSecret != "secret" {
 		t.Fatalf("webhook secret = %q, want secret", emitter.calls[0].WebhookSecret)
 	}
-	if len(volumeClient.deleted) != 1 || volumeClient.deleted[0] != "volume-a" {
-		t.Fatalf("deleted volumes = %#v, want volume-a", volumeClient.deleted)
+	if len(volumeClient.marked) != 1 || volumeClient.marked[0] != "sandbox-a:sandbox_deleted" {
+		t.Fatalf("marked volumes = %#v, want sandbox-a:sandbox_deleted", volumeClient.marked)
 	}
 }
 
@@ -261,6 +272,90 @@ func TestSandboxLifecycleInfoFromPodIncludesWebhookMetadata(t *testing.T) {
 	}
 	if info.WebhookURL != "https://example.test/webhook" || info.WebhookSecret != "secret" {
 		t.Fatalf("unexpected webhook metadata: %#v", info)
+	}
+}
+
+func TestSystemVolumeReconcilerMarksOrphanedOwnedVolume(t *testing.T) {
+	volumeClient := &recordingSystemVolumeClient{
+		list: []SandboxSystemVolume{{
+			VolumeID:       "volume-a",
+			TeamID:         "team-a",
+			UserID:         "user-a",
+			OwnerSandboxID: "sandbox-a",
+			OwnerClusterID: "cluster-a",
+			Purpose:        "webhook-state",
+		}},
+	}
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	svc := &SandboxService{
+		podLister:           corelisters.NewPodLister(indexer),
+		webhookStateVolumes: volumeClient,
+		clock:               systemTime{},
+		logger:              zap.NewNop(),
+	}
+
+	if err := svc.reconcileSystemVolumes(context.Background()); err != nil {
+		t.Fatalf("reconcileSystemVolumes() error = %v", err)
+	}
+	if len(volumeClient.marked) != 1 || volumeClient.marked[0] != "sandbox-a:orphaned_sandbox" {
+		t.Fatalf("marked = %#v, want sandbox-a:orphaned_sandbox", volumeClient.marked)
+	}
+}
+
+func TestSystemVolumeReconcilerKeepsActiveOwnedVolume(t *testing.T) {
+	volumeClient := &recordingSystemVolumeClient{
+		list: []SandboxSystemVolume{{
+			VolumeID:       "volume-a",
+			TeamID:         "team-a",
+			UserID:         "user-a",
+			OwnerSandboxID: "sandbox-a",
+			OwnerClusterID: "cluster-a",
+			Purpose:        "webhook-state",
+		}},
+	}
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	if err := indexer.Add(newLifecycleTestPod()); err != nil {
+		t.Fatalf("add pod to indexer: %v", err)
+	}
+	svc := &SandboxService{
+		podLister:           corelisters.NewPodLister(indexer),
+		webhookStateVolumes: volumeClient,
+		clock:               systemTime{},
+		logger:              zap.NewNop(),
+	}
+
+	if err := svc.reconcileSystemVolumes(context.Background()); err != nil {
+		t.Fatalf("reconcileSystemVolumes() error = %v", err)
+	}
+	if len(volumeClient.marked) != 0 {
+		t.Fatalf("marked = %#v, want none", volumeClient.marked)
+	}
+}
+
+func TestSystemVolumeReconcilerDeletesCleanupRequestedVolume(t *testing.T) {
+	cleanupRequestedAt := time.Now().Add(-time.Minute)
+	volumeClient := &recordingSystemVolumeClient{
+		list: []SandboxSystemVolume{{
+			VolumeID:           "volume-a",
+			TeamID:             "team-a",
+			UserID:             "user-a",
+			OwnerSandboxID:     "sandbox-a",
+			OwnerClusterID:     "cluster-a",
+			Purpose:            "webhook-state",
+			CleanupRequestedAt: &cleanupRequestedAt,
+		}},
+	}
+	svc := &SandboxService{
+		webhookStateVolumes: volumeClient,
+		clock:               systemTime{},
+		logger:              zap.NewNop(),
+	}
+
+	if err := svc.reconcileSystemVolumes(context.Background()); err != nil {
+		t.Fatalf("reconcileSystemVolumes() error = %v", err)
+	}
+	if len(volumeClient.deleted) != 1 || volumeClient.deleted[0] != "volume-a" {
+		t.Fatalf("deleted = %#v, want volume-a", volumeClient.deleted)
 	}
 }
 

--- a/manager/pkg/service/sandbox_system_volume_reconciler.go
+++ b/manager/pkg/service/sandbox_system_volume_reconciler.go
@@ -1,0 +1,112 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+const (
+	defaultSandboxSystemVolumeReconcileInterval = 30 * time.Second
+	defaultSandboxSystemVolumeCleanupDelay      = 15 * time.Second
+)
+
+// StartSystemVolumeReconciler garbage-collects manager-owned volumes whose
+// sandbox lifecycle cleanup was skipped or interrupted.
+func (s *SandboxService) StartSystemVolumeReconciler(ctx context.Context, interval time.Duration) {
+	if s == nil || s.webhookStateVolumes == nil {
+		return
+	}
+	if interval <= 0 {
+		interval = defaultSandboxSystemVolumeReconcileInterval
+	}
+	logger := s.logger
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	logger.Info("Starting sandbox system volume reconciler", zap.Duration("interval", interval))
+	if err := s.reconcileSystemVolumes(ctx); err != nil {
+		logger.Warn("Sandbox system volume reconcile failed", zap.Error(err))
+	}
+	wait.UntilWithContext(ctx, func(ctx context.Context) {
+		if err := s.reconcileSystemVolumes(ctx); err != nil {
+			logger.Warn("Sandbox system volume reconcile failed", zap.Error(err))
+		}
+	}, interval)
+}
+
+func (s *SandboxService) reconcileSystemVolumes(ctx context.Context) error {
+	if s == nil || s.webhookStateVolumes == nil {
+		return nil
+	}
+	volumes, err := s.webhookStateVolumes.List(ctx)
+	if err != nil {
+		return fmt.Errorf("list system volumes: %w", err)
+	}
+	now := time.Now().UTC()
+	if s.clock != nil {
+		now = s.clock.Now()
+	}
+	for _, volume := range volumes {
+		sandboxID := volume.OwnerSandboxID
+		if sandboxID == "" || volume.VolumeID == "" {
+			continue
+		}
+		if volume.CleanupRequestedAt != nil {
+			if now.Sub(*volume.CleanupRequestedAt) < defaultSandboxSystemVolumeCleanupDelay {
+				continue
+			}
+			if err := s.webhookStateVolumes.Delete(ctx, volume.TeamID, volume.UserID, sandboxID, volume.VolumeID); err != nil {
+				if s.logger != nil {
+					s.logger.Warn("Failed to delete system volume marked for cleanup",
+						zap.String("sandboxID", sandboxID),
+						zap.String("volumeID", volume.VolumeID),
+						zap.String("purpose", volume.Purpose),
+						zap.Error(err),
+					)
+				}
+			}
+			continue
+		}
+		if s.systemVolumeOwnerPodActive(sandboxID) {
+			continue
+		}
+		if err := s.webhookStateVolumes.MarkSandboxForCleanup(ctx, volume.TeamID, volume.UserID, sandboxID, "orphaned_sandbox"); err != nil {
+			if s.logger != nil {
+				s.logger.Warn("Failed to mark orphaned system volume for cleanup",
+					zap.String("sandboxID", sandboxID),
+					zap.String("volumeID", volume.VolumeID),
+					zap.String("purpose", volume.Purpose),
+					zap.Error(err),
+				)
+			}
+		}
+	}
+	return nil
+}
+
+func (s *SandboxService) systemVolumeOwnerPodActive(sandboxID string) bool {
+	if s == nil || s.podLister == nil || sandboxID == "" {
+		return true
+	}
+	pods, err := s.podLister.List(labels.SelectorFromSet(map[string]string{
+		controller.LabelSandboxID: sandboxID,
+	}))
+	if err != nil {
+		return true
+	}
+	for _, pod := range pods {
+		if pod == nil || pod.DeletionTimestamp != nil || pod.Labels == nil {
+			continue
+		}
+		if pod.Labels[controller.LabelPoolType] == controller.PoolTypeActive {
+			return true
+		}
+	}
+	return false
+}

--- a/manager/pkg/service/sandbox_webhook_state.go
+++ b/manager/pkg/service/sandbox_webhook_state.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -23,20 +24,24 @@ const (
 
 // SandboxSystemVolumeClient creates and deletes manager-owned sandbox volumes.
 type SandboxSystemVolumeClient interface {
-	Create(ctx context.Context, teamID, userID, sandboxID, kind string) (string, error)
+	Create(ctx context.Context, teamID, userID, sandboxID, purpose string) (string, error)
+	MarkSandboxForCleanup(ctx context.Context, teamID, userID, sandboxID, reason string) error
 	Delete(ctx context.Context, teamID, userID, sandboxID, volumeID string) error
+	List(ctx context.Context) ([]SandboxSystemVolume, error)
 }
 
 type StorageProxyVolumeClient struct {
 	baseURL        string
 	httpClient     *http.Client
 	tokenGenerator TokenGenerator
+	clusterID      string
 }
 
 type StorageProxyVolumeClientConfig struct {
 	BaseURL        string
 	HTTPClient     *http.Client
 	TokenGenerator TokenGenerator
+	ClusterID      string
 }
 
 func NewStorageProxyVolumeClient(cfg StorageProxyVolumeClientConfig) *StorageProxyVolumeClient {
@@ -48,18 +53,36 @@ func NewStorageProxyVolumeClient(cfg StorageProxyVolumeClientConfig) *StoragePro
 		baseURL:        strings.TrimRight(strings.TrimSpace(cfg.BaseURL), "/"),
 		httpClient:     httpClient,
 		tokenGenerator: cfg.TokenGenerator,
+		clusterID:      strings.TrimSpace(cfg.ClusterID),
 	}
 }
 
-func (c *StorageProxyVolumeClient) Create(ctx context.Context, teamID, userID, sandboxID, kind string) (string, error) {
+type SandboxSystemVolume struct {
+	VolumeID           string
+	TeamID             string
+	UserID             string
+	OwnerSandboxID     string
+	OwnerClusterID     string
+	Purpose            string
+	CleanupRequestedAt *time.Time
+}
+
+func (c *StorageProxyVolumeClient) Create(ctx context.Context, teamID, userID, sandboxID, purpose string) (string, error) {
 	if c == nil || c.baseURL == "" {
 		return "", fmt.Errorf("storage-proxy volume client is not configured")
+	}
+	if c.clusterID == "" {
+		return "", fmt.Errorf("storage-proxy volume client cluster id is not configured")
 	}
 	token, err := c.generateToken(teamID, userID, sandboxID)
 	if err != nil {
 		return "", err
 	}
 	body := map[string]any{
+		"sandbox_id":  sandboxID,
+		"cluster_id":  c.clusterID,
+		"purpose":     purpose,
+		"user_id":     userID,
 		"cache_size":  "64M",
 		"buffer_size": "8M",
 		"access_mode": "RWO",
@@ -68,7 +91,7 @@ func (c *StorageProxyVolumeClient) Create(ctx context.Context, teamID, userID, s
 	if err != nil {
 		return "", err
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/sandboxvolumes", bytes.NewReader(payload))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/internal/v1/sandboxvolumes/owned", bytes.NewReader(payload))
 	if err != nil {
 		return "", err
 	}
@@ -77,29 +100,73 @@ func (c *StorageProxyVolumeClient) Create(ctx context.Context, teamID, userID, s
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("create %s volume: %w", kind, err)
+		return "", fmt.Errorf("create %s volume: %w", purpose, err)
 	}
 	defer resp.Body.Close()
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", fmt.Errorf("read create volume response: %w", err)
 	}
-	volume, apiErr, err := spec.DecodeResponse[struct {
-		ID string `json:"id"`
+	owned, apiErr, err := spec.DecodeResponse[struct {
+		Volume struct {
+			ID string `json:"id"`
+		} `json:"volume"`
 	}](bytes.NewReader(data))
 	if err != nil {
 		return "", fmt.Errorf("decode create volume response: %w", err)
 	}
 	if apiErr != nil {
-		return "", fmt.Errorf("create %s volume failed: %s", kind, apiErr.Message)
+		return "", fmt.Errorf("create %s volume failed: %s", purpose, apiErr.Message)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return "", fmt.Errorf("create %s volume failed with status %d", kind, resp.StatusCode)
+		return "", fmt.Errorf("create %s volume failed with status %d", purpose, resp.StatusCode)
 	}
-	if volume == nil || strings.TrimSpace(volume.ID) == "" {
-		return "", fmt.Errorf("create %s volume returned no id", kind)
+	if owned == nil || strings.TrimSpace(owned.Volume.ID) == "" {
+		return "", fmt.Errorf("create %s volume returned no id", purpose)
 	}
-	return volume.ID, nil
+	return owned.Volume.ID, nil
+}
+
+func (c *StorageProxyVolumeClient) MarkSandboxForCleanup(ctx context.Context, teamID, userID, sandboxID, reason string) error {
+	if c == nil || c.baseURL == "" {
+		return nil
+	}
+	if c.clusterID == "" {
+		return fmt.Errorf("storage-proxy volume client cluster id is not configured")
+	}
+	token, err := c.generateToken(teamID, userID, sandboxID)
+	if err != nil {
+		return err
+	}
+	body := map[string]any{
+		"sandbox_id": sandboxID,
+		"cluster_id": c.clusterID,
+		"reason":     reason,
+	}
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, c.baseURL+"/internal/v1/sandboxvolumes/owned/cleanup", bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Internal-Token", token)
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("mark sandbox system volumes for cleanup: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+	data, _ := io.ReadAll(resp.Body)
+	_, apiErr, decodeErr := spec.DecodeResponse[map[string]any](bytes.NewReader(data))
+	if decodeErr == nil && apiErr != nil {
+		return fmt.Errorf("mark sandbox system volumes for cleanup failed: %s", apiErr.Message)
+	}
+	return fmt.Errorf("mark sandbox system volumes for cleanup failed with status %d", resp.StatusCode)
 }
 
 func (c *StorageProxyVolumeClient) Delete(ctx context.Context, teamID, userID, sandboxID, volumeID string) error {
@@ -110,7 +177,7 @@ func (c *StorageProxyVolumeClient) Delete(ctx context.Context, teamID, userID, s
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.baseURL+"/sandboxvolumes/"+volumeID+"?force=true", nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.baseURL+"/internal/v1/sandboxvolumes/owned/"+volumeID, nil)
 	if err != nil {
 		return err
 	}
@@ -129,6 +196,71 @@ func (c *StorageProxyVolumeClient) Delete(ctx context.Context, teamID, userID, s
 		return fmt.Errorf("delete webhook state volume failed: %s", apiErr.Message)
 	}
 	return fmt.Errorf("delete webhook state volume failed with status %d", resp.StatusCode)
+}
+
+func (c *StorageProxyVolumeClient) List(ctx context.Context) ([]SandboxSystemVolume, error) {
+	if c == nil || c.baseURL == "" {
+		return nil, fmt.Errorf("storage-proxy volume client is not configured")
+	}
+	if c.clusterID == "" {
+		return nil, fmt.Errorf("storage-proxy volume client cluster id is not configured")
+	}
+	token, err := c.generateToken("", "", "")
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/internal/v1/sandboxvolumes/owned?cluster_id="+url.QueryEscape(c.clusterID), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("X-Internal-Token", token)
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("list sandbox system volumes: %w", err)
+	}
+	defer resp.Body.Close()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read list system volumes response: %w", err)
+	}
+	owned, apiErr, err := spec.DecodeResponse[[]struct {
+		Volume struct {
+			ID     string `json:"id"`
+			TeamID string `json:"team_id"`
+			UserID string `json:"user_id"`
+		} `json:"volume"`
+		Owner struct {
+			OwnerSandboxID     string     `json:"owner_sandbox_id"`
+			OwnerClusterID     string     `json:"owner_cluster_id"`
+			Purpose            string     `json:"purpose"`
+			CleanupRequestedAt *time.Time `json:"cleanup_requested_at,omitempty"`
+		} `json:"owner"`
+	}](bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("decode list system volumes response: %w", err)
+	}
+	if apiErr != nil {
+		return nil, fmt.Errorf("list sandbox system volumes failed: %s", apiErr.Message)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("list sandbox system volumes failed with status %d", resp.StatusCode)
+	}
+	if owned == nil {
+		return nil, nil
+	}
+	out := make([]SandboxSystemVolume, 0, len(*owned))
+	for _, item := range *owned {
+		out = append(out, SandboxSystemVolume{
+			VolumeID:           item.Volume.ID,
+			TeamID:             item.Volume.TeamID,
+			UserID:             item.Volume.UserID,
+			OwnerSandboxID:     item.Owner.OwnerSandboxID,
+			OwnerClusterID:     item.Owner.OwnerClusterID,
+			Purpose:            item.Owner.Purpose,
+			CleanupRequestedAt: item.Owner.CleanupRequestedAt,
+		})
+	}
+	return out, nil
 }
 
 func (c *StorageProxyVolumeClient) generateToken(teamID, userID, sandboxID string) (string, error) {
@@ -164,11 +296,13 @@ func (s *SandboxService) prepareWebhookStateVolume(ctx context.Context, req *Cla
 }
 
 func (s *SandboxService) deleteWebhookStateVolume(ctx context.Context, info SandboxLifecycleInfo) error {
-	volumeID := strings.TrimSpace(info.WebhookStateVolumeID)
-	if volumeID == "" || s == nil || s.webhookStateVolumes == nil {
+	if s == nil || s.webhookStateVolumes == nil || strings.TrimSpace(info.SandboxID) == "" {
 		return nil
 	}
-	return s.webhookStateVolumes.Delete(ctx, info.TeamID, info.UserID, info.SandboxID, volumeID)
+	if strings.TrimSpace(info.WebhookStateVolumeID) == "" && strings.TrimSpace(info.WebhookURL) == "" {
+		return nil
+	}
+	return s.webhookStateVolumes.MarkSandboxForCleanup(ctx, info.TeamID, info.UserID, info.SandboxID, "sandbox_deleted")
 }
 
 func appendWebhookStateMount(mounts []ClaimMount, state *webhookStateVolume) []ClaimMount {

--- a/manager/pkg/service/sandbox_webhook_state.go
+++ b/manager/pkg/service/sandbox_webhook_state.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
+	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 )
 
 const (
@@ -49,11 +50,15 @@ func NewStorageProxyVolumeClient(cfg StorageProxyVolumeClientConfig) *StoragePro
 	if httpClient == nil {
 		httpClient = &http.Client{Timeout: 10 * time.Second}
 	}
+	clusterID := strings.TrimSpace(cfg.ClusterID)
+	if clusterID == "" {
+		clusterID = naming.DefaultClusterID
+	}
 	return &StorageProxyVolumeClient{
 		baseURL:        strings.TrimRight(strings.TrimSpace(cfg.BaseURL), "/"),
 		httpClient:     httpClient,
 		tokenGenerator: cfg.TokenGenerator,
-		clusterID:      strings.TrimSpace(cfg.ClusterID),
+		clusterID:      clusterID,
 	}
 }
 

--- a/manager/pkg/service/sandbox_webhook_state_test.go
+++ b/manager/pkg/service/sandbox_webhook_state_test.go
@@ -1,0 +1,46 @@
+package service
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
+	"github.com/sandbox0-ai/sandbox0/pkg/naming"
+)
+
+func TestStorageProxyVolumeClientDefaultsClusterID(t *testing.T) {
+	var gotClusterID string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/internal/v1/sandboxvolumes/owned" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		var req struct {
+			ClusterID string `json:"cluster_id"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		gotClusterID = req.ClusterID
+		_ = spec.WriteSuccess(w, http.StatusCreated, map[string]any{
+			"volume": map[string]string{"id": "vol-1"},
+		})
+	}))
+	defer server.Close()
+
+	client := NewStorageProxyVolumeClient(StorageProxyVolumeClientConfig{
+		BaseURL:        server.URL,
+		TokenGenerator: staticTokenGenerator{},
+	})
+	volumeID, err := client.Create(t.Context(), "team-1", "user-1", "sandbox-1", webhookStateVolumeKind)
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	if volumeID != "vol-1" {
+		t.Fatalf("volumeID = %q, want vol-1", volumeID)
+	}
+	if gotClusterID != naming.DefaultClusterID {
+		t.Fatalf("clusterID = %q, want %q", gotClusterID, naming.DefaultClusterID)
+	}
+}

--- a/manager/pkg/service/token_generator.go
+++ b/manager/pkg/service/token_generator.go
@@ -54,6 +54,17 @@ func NewStorageProxyAdminTokenGenerator(generator *internalauth.Generator) *Stor
 }
 
 func (g *StorageProxyAdminTokenGenerator) GenerateToken(teamID, userID, sandboxID string) (string, error) {
+	if teamID == "" {
+		return g.generator.GenerateSystem("storage-proxy", internalauth.GenerateOptions{
+			Permissions: []string{
+				"sandboxvolume:create",
+				"sandboxvolume:read",
+				"sandboxvolume:write",
+				"sandboxvolume:delete",
+			},
+			SandboxID: sandboxID,
+		})
+	}
 	return g.generator.Generate("storage-proxy", teamID, userID, internalauth.GenerateOptions{
 		Permissions: []string{
 			"sandboxvolume:create",

--- a/storage-proxy/migrations/00007_add_sandbox_volume_owners.sql
+++ b/storage-proxy/migrations/00007_add_sandbox_volume_owners.sql
@@ -1,0 +1,38 @@
+-- +goose Up
+CREATE TABLE IF NOT EXISTS sandbox_volume_owners (
+    volume_id TEXT PRIMARY KEY REFERENCES sandbox_volumes(id) ON DELETE CASCADE,
+    owner_kind TEXT NOT NULL DEFAULT 'sandbox',
+    owner_sandbox_id TEXT NOT NULL,
+    owner_cluster_id TEXT NOT NULL,
+    purpose TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    cleanup_requested_at TIMESTAMPTZ,
+    cleanup_reason TEXT,
+    last_cleanup_attempt_at TIMESTAMPTZ,
+    last_cleanup_error TEXT,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_sandbox_volume_owners_live_owner_purpose
+    ON sandbox_volume_owners(owner_cluster_id, owner_sandbox_id, purpose)
+    WHERE cleanup_requested_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_sandbox_volume_owners_cluster_sandbox
+    ON sandbox_volume_owners(owner_cluster_id, owner_sandbox_id);
+
+CREATE INDEX IF NOT EXISTS idx_sandbox_volume_owners_pending_cleanup
+    ON sandbox_volume_owners(owner_cluster_id, cleanup_requested_at)
+    WHERE cleanup_requested_at IS NOT NULL;
+
+DROP TRIGGER IF EXISTS update_sandbox_volume_owners_updated_at ON sandbox_volume_owners;
+CREATE TRIGGER update_sandbox_volume_owners_updated_at
+    BEFORE UPDATE ON sandbox_volume_owners
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+-- +goose Down
+DROP TRIGGER IF EXISTS update_sandbox_volume_owners_updated_at ON sandbox_volume_owners;
+DROP INDEX IF EXISTS idx_sandbox_volume_owners_pending_cleanup;
+DROP INDEX IF EXISTS idx_sandbox_volume_owners_cluster_sandbox;
+DROP INDEX IF EXISTS idx_sandbox_volume_owners_live_owner_purpose;
+DROP TABLE IF EXISTS sandbox_volume_owners;

--- a/storage-proxy/pkg/db/models.go
+++ b/storage-proxy/pkg/db/models.go
@@ -27,6 +27,32 @@ type SandboxVolume struct {
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
+const (
+	SandboxVolumeOwnerKindSandbox = "sandbox"
+)
+
+// SandboxVolumeOwner stores durable lifecycle ownership for manager-created
+// system volumes.
+type SandboxVolumeOwner struct {
+	VolumeID             string     `json:"volume_id"`
+	OwnerKind            string     `json:"owner_kind"`
+	OwnerSandboxID       string     `json:"owner_sandbox_id"`
+	OwnerClusterID       string     `json:"owner_cluster_id"`
+	Purpose              string     `json:"purpose"`
+	CreatedAt            time.Time  `json:"created_at"`
+	CleanupRequestedAt   *time.Time `json:"cleanup_requested_at,omitempty"`
+	CleanupReason        *string    `json:"cleanup_reason,omitempty"`
+	LastCleanupAttemptAt *time.Time `json:"last_cleanup_attempt_at,omitempty"`
+	LastCleanupError     *string    `json:"last_cleanup_error,omitempty"`
+	UpdatedAt            time.Time  `json:"updated_at"`
+}
+
+// OwnedSandboxVolume combines volume metadata with its system ownership row.
+type OwnedSandboxVolume struct {
+	Volume SandboxVolume      `json:"volume"`
+	Owner  SandboxVolumeOwner `json:"owner"`
+}
+
 // Snapshot represents a point-in-time copy of a SandboxVolume
 type Snapshot struct {
 	ID       string `json:"id"`

--- a/storage-proxy/pkg/db/repository.go
+++ b/storage-proxy/pkg/db/repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
@@ -225,6 +226,10 @@ func (r *Repository) ListSandboxVolumesByTeam(ctx context.Context, teamID string
 			created_at, updated_at
 		FROM sandbox_volumes
 		WHERE team_id = $1
+			AND NOT EXISTS (
+				SELECT 1 FROM sandbox_volume_owners
+				WHERE sandbox_volume_owners.volume_id = sandbox_volumes.id
+			)
 		ORDER BY created_at DESC
 	`, teamID)
 	if err != nil {
@@ -275,6 +280,189 @@ func (r *Repository) deleteSandboxVolume(ctx context.Context, db DB, id string) 
 	}
 
 	return nil
+}
+
+// CreateSandboxVolumeOwnerTx creates durable ownership metadata for a system volume.
+func (r *Repository) CreateSandboxVolumeOwnerTx(ctx context.Context, tx pgx.Tx, owner *SandboxVolumeOwner) error {
+	_, err := tx.Exec(ctx, `
+		INSERT INTO sandbox_volume_owners (
+			volume_id, owner_kind, owner_sandbox_id, owner_cluster_id, purpose,
+			created_at, cleanup_requested_at, cleanup_reason,
+			last_cleanup_attempt_at, last_cleanup_error, updated_at
+		) VALUES (
+			$1, $2, $3, $4, $5,
+			$6, $7, $8,
+			$9, $10, $11
+		)
+	`,
+		owner.VolumeID, owner.OwnerKind, owner.OwnerSandboxID, owner.OwnerClusterID, owner.Purpose,
+		owner.CreatedAt, owner.CleanupRequestedAt, owner.CleanupReason,
+		owner.LastCleanupAttemptAt, owner.LastCleanupError, owner.UpdatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("create sandbox volume owner: %w", err)
+	}
+	return nil
+}
+
+// GetSandboxVolumeOwner retrieves ownership metadata for a volume.
+func (r *Repository) GetSandboxVolumeOwner(ctx context.Context, volumeID string) (*SandboxVolumeOwner, error) {
+	var owner SandboxVolumeOwner
+	err := r.pool.QueryRow(ctx, `
+		SELECT
+			volume_id, owner_kind, owner_sandbox_id, owner_cluster_id, purpose,
+			created_at, cleanup_requested_at, cleanup_reason,
+			last_cleanup_attempt_at, last_cleanup_error, updated_at
+		FROM sandbox_volume_owners
+		WHERE volume_id = $1
+	`, volumeID).Scan(
+		&owner.VolumeID, &owner.OwnerKind, &owner.OwnerSandboxID, &owner.OwnerClusterID, &owner.Purpose,
+		&owner.CreatedAt, &owner.CleanupRequestedAt, &owner.CleanupReason,
+		&owner.LastCleanupAttemptAt, &owner.LastCleanupError, &owner.UpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("query sandbox volume owner: %w", err)
+	}
+	return &owner, nil
+}
+
+// GetOwnedSandboxVolumeByOwner retrieves a live system volume for a sandbox and purpose.
+func (r *Repository) GetOwnedSandboxVolumeByOwner(ctx context.Context, clusterID, sandboxID, purpose string) (*OwnedSandboxVolume, error) {
+	rows, err := r.queryOwnedSandboxVolumes(ctx, `
+		WHERE o.owner_cluster_id = $1
+			AND o.owner_sandbox_id = $2
+			AND o.purpose = $3
+			AND o.cleanup_requested_at IS NULL
+		ORDER BY o.created_at DESC
+		LIMIT 1
+	`, clusterID, sandboxID, purpose)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			return nil, fmt.Errorf("query owned sandbox volume: %w", err)
+		}
+		return nil, ErrNotFound
+	}
+	owned, err := scanOwnedSandboxVolume(rows)
+	if err != nil {
+		return nil, err
+	}
+	return owned, nil
+}
+
+// ListOwnedSandboxVolumes lists manager-created system volumes for a cluster.
+func (r *Repository) ListOwnedSandboxVolumes(ctx context.Context, clusterID string, cleanupRequested *bool) ([]*OwnedSandboxVolume, error) {
+	where := "WHERE o.owner_cluster_id = $1"
+	args := []any{clusterID}
+	if cleanupRequested != nil {
+		if *cleanupRequested {
+			where += " AND o.cleanup_requested_at IS NOT NULL"
+		} else {
+			where += " AND o.cleanup_requested_at IS NULL"
+		}
+	}
+	rows, err := r.queryOwnedSandboxVolumes(ctx, where+" ORDER BY o.created_at ASC", args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var owned []*OwnedSandboxVolume
+	for rows.Next() {
+		item, err := scanOwnedSandboxVolume(rows)
+		if err != nil {
+			return nil, err
+		}
+		owned = append(owned, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("query owned sandbox volumes: %w", err)
+	}
+	return owned, nil
+}
+
+// MarkOwnedSandboxVolumesForCleanup marks all live system volumes for a sandbox.
+func (r *Repository) MarkOwnedSandboxVolumesForCleanup(ctx context.Context, clusterID, sandboxID, reason string) (int64, error) {
+	cmdTag, err := r.pool.Exec(ctx, `
+		UPDATE sandbox_volume_owners
+		SET cleanup_requested_at = COALESCE(cleanup_requested_at, NOW()),
+			cleanup_reason = COALESCE(NULLIF($3, ''), cleanup_reason),
+			updated_at = NOW()
+		WHERE owner_cluster_id = $1
+			AND owner_sandbox_id = $2
+			AND cleanup_requested_at IS NULL
+	`, clusterID, sandboxID, reason)
+	if err != nil {
+		return 0, fmt.Errorf("mark owned sandbox volumes for cleanup: %w", err)
+	}
+	return cmdTag.RowsAffected(), nil
+}
+
+// MarkOwnedSandboxVolumeCleanupAttempt records the result of a cleanup attempt.
+func (r *Repository) MarkOwnedSandboxVolumeCleanupAttempt(ctx context.Context, volumeID string, cleanupErr error) error {
+	var errText *string
+	if cleanupErr != nil {
+		value := strings.TrimSpace(cleanupErr.Error())
+		errText = &value
+	}
+	cmdTag, err := r.pool.Exec(ctx, `
+		UPDATE sandbox_volume_owners
+		SET last_cleanup_attempt_at = NOW(),
+			last_cleanup_error = $2,
+			updated_at = NOW()
+		WHERE volume_id = $1
+	`, volumeID, errText)
+	if err != nil {
+		return fmt.Errorf("mark owned sandbox volume cleanup attempt: %w", err)
+	}
+	if cmdTag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *Repository) queryOwnedSandboxVolumes(ctx context.Context, suffix string, args ...any) (pgx.Rows, error) {
+	rows, err := r.pool.Query(ctx, `
+		SELECT
+			v.id, v.team_id, v.user_id,
+			v.source_volume_id,
+			v.default_posix_uid, v.default_posix_gid,
+			v.cache_size, v.prefetch, v.buffer_size, v.writeback, v.access_mode,
+			v.created_at, v.updated_at,
+			o.volume_id, o.owner_kind, o.owner_sandbox_id, o.owner_cluster_id, o.purpose,
+			o.created_at, o.cleanup_requested_at, o.cleanup_reason,
+			o.last_cleanup_attempt_at, o.last_cleanup_error, o.updated_at
+		FROM sandbox_volume_owners o
+		JOIN sandbox_volumes v ON v.id = o.volume_id
+		`+suffix, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query owned sandbox volumes: %w", err)
+	}
+	return rows, nil
+}
+
+func scanOwnedSandboxVolume(rows pgx.Rows) (*OwnedSandboxVolume, error) {
+	var item OwnedSandboxVolume
+	err := rows.Scan(
+		&item.Volume.ID, &item.Volume.TeamID, &item.Volume.UserID,
+		&item.Volume.SourceVolumeID,
+		&item.Volume.DefaultPosixUID, &item.Volume.DefaultPosixGID,
+		&item.Volume.CacheSize, &item.Volume.Prefetch, &item.Volume.BufferSize, &item.Volume.Writeback, &item.Volume.AccessMode,
+		&item.Volume.CreatedAt, &item.Volume.UpdatedAt,
+		&item.Owner.VolumeID, &item.Owner.OwnerKind, &item.Owner.OwnerSandboxID, &item.Owner.OwnerClusterID, &item.Owner.Purpose,
+		&item.Owner.CreatedAt, &item.Owner.CleanupRequestedAt, &item.Owner.CleanupReason,
+		&item.Owner.LastCleanupAttemptAt, &item.Owner.LastCleanupError, &item.Owner.UpdatedAt,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("scan owned sandbox volume: %w", err)
+	}
+	return &item, nil
 }
 
 // ============================================================

--- a/storage-proxy/pkg/grpc/server.go
+++ b/storage-proxy/pkg/grpc/server.go
@@ -56,6 +56,7 @@ type volumeManager interface {
 // VolumeRepository provides volume metadata lookup for access mode enforcement.
 type VolumeRepository interface {
 	GetSandboxVolume(ctx context.Context, id string) (*db.SandboxVolume, error)
+	GetSandboxVolumeOwner(ctx context.Context, volumeID string) (*db.SandboxVolumeOwner, error)
 }
 
 type syncRecorder interface {
@@ -538,6 +539,15 @@ func (s *FileSystemServer) authorizeVolumeMount(ctx context.Context, volumeID st
 	if vol.TeamID != claims.TeamID {
 		s.logUnauthorizedVolumeAccess(volumeID, claims.TeamID, vol.TeamID, "mount")
 		return nil, status.Error(codes.PermissionDenied, "access denied to volume")
+	}
+	owner, err := s.volumeRepo.GetSandboxVolumeOwner(ctx, volumeID)
+	if err != nil && !errors.Is(err, db.ErrNotFound) {
+		s.logger.WithError(err).WithField("volume_id", volumeID).Error("Failed to load sandbox volume owner")
+		return nil, status.Error(codes.Internal, "failed to load sandbox volume owner")
+	}
+	if owner != nil && !claims.IsSystemToken() && claims.SandboxID != owner.OwnerSandboxID {
+		s.logUnauthorizedVolumeAccess(volumeID, claims.TeamID, vol.TeamID, "mount_owned")
+		return nil, status.Error(codes.PermissionDenied, "access denied to system volume")
 	}
 	return vol, nil
 }

--- a/storage-proxy/pkg/grpc/server_auth_test.go
+++ b/storage-proxy/pkg/grpc/server_auth_test.go
@@ -519,6 +519,7 @@ func TestRenameRejectsNamespaceIncompatibleTargetBeforeMutation(t *testing.T) {
 
 type fakeVolumeRepo struct {
 	volumes map[string]*db.SandboxVolume
+	owners  map[string]*db.SandboxVolumeOwner
 	err     error
 }
 
@@ -528,6 +529,16 @@ func (r *fakeVolumeRepo) GetSandboxVolume(_ context.Context, id string) (*db.San
 	}
 	if vol, ok := r.volumes[id]; ok {
 		return vol, nil
+	}
+	return nil, db.ErrNotFound
+}
+
+func (r *fakeVolumeRepo) GetSandboxVolumeOwner(_ context.Context, volumeID string) (*db.SandboxVolumeOwner, error) {
+	if r.owners == nil {
+		return nil, db.ErrNotFound
+	}
+	if owner, ok := r.owners[volumeID]; ok {
+		return owner, nil
 	}
 	return nil, db.ErrNotFound
 }

--- a/storage-proxy/pkg/http/handlers_metering_test.go
+++ b/storage-proxy/pkg/http/handlers_metering_test.go
@@ -21,6 +21,7 @@ import (
 
 type fakeHTTPRepo struct {
 	volumes        map[string]*db.SandboxVolume
+	owners         map[string]*db.SandboxVolumeOwner
 	activeMounts   map[string][]*db.VolumeMount
 	getActiveFunc  func(context.Context, string, int) ([]*db.VolumeMount, error)
 	deletedMounts  []db.VolumeMount
@@ -31,6 +32,7 @@ type fakeHTTPRepo struct {
 func newFakeHTTPRepo() *fakeHTTPRepo {
 	return &fakeHTTPRepo{
 		volumes:      make(map[string]*db.SandboxVolume),
+		owners:       make(map[string]*db.SandboxVolumeOwner),
 		activeMounts: make(map[string][]*db.VolumeMount),
 	}
 }
@@ -45,14 +47,37 @@ func (r *fakeHTTPRepo) CreateSandboxVolumeTx(ctx context.Context, tx pgx.Tx, vol
 	return nil
 }
 
+func (r *fakeHTTPRepo) CreateSandboxVolumeOwnerTx(ctx context.Context, tx pgx.Tx, owner *db.SandboxVolumeOwner) error {
+	r.owners[owner.VolumeID] = owner
+	return nil
+}
+
 func (r *fakeHTTPRepo) ListSandboxVolumesByTeam(ctx context.Context, teamID string) ([]*db.SandboxVolume, error) {
 	var volumes []*db.SandboxVolume
 	for _, volume := range r.volumes {
-		if volume.TeamID == teamID {
+		if volume.TeamID == teamID && r.owners[volume.ID] == nil {
 			volumes = append(volumes, volume)
 		}
 	}
 	return volumes, nil
+}
+
+func (r *fakeHTTPRepo) ListOwnedSandboxVolumes(ctx context.Context, clusterID string, cleanupRequested *bool) ([]*db.OwnedSandboxVolume, error) {
+	var owned []*db.OwnedSandboxVolume
+	for volumeID, owner := range r.owners {
+		if owner.OwnerClusterID != clusterID {
+			continue
+		}
+		if cleanupRequested != nil && (*cleanupRequested != (owner.CleanupRequestedAt != nil)) {
+			continue
+		}
+		volume := r.volumes[volumeID]
+		if volume == nil {
+			continue
+		}
+		owned = append(owned, &db.OwnedSandboxVolume{Volume: *volume, Owner: *owner})
+	}
+	return owned, nil
 }
 
 func (r *fakeHTTPRepo) GetSandboxVolume(ctx context.Context, id string) (*db.SandboxVolume, error) {
@@ -61,6 +86,27 @@ func (r *fakeHTTPRepo) GetSandboxVolume(ctx context.Context, id string) (*db.San
 		return nil, db.ErrNotFound
 	}
 	return volume, nil
+}
+
+func (r *fakeHTTPRepo) GetSandboxVolumeOwner(ctx context.Context, volumeID string) (*db.SandboxVolumeOwner, error) {
+	owner, ok := r.owners[volumeID]
+	if !ok {
+		return nil, db.ErrNotFound
+	}
+	return owner, nil
+}
+
+func (r *fakeHTTPRepo) GetOwnedSandboxVolumeByOwner(ctx context.Context, clusterID, sandboxID, purpose string) (*db.OwnedSandboxVolume, error) {
+	for volumeID, owner := range r.owners {
+		if owner.OwnerClusterID == clusterID && owner.OwnerSandboxID == sandboxID && owner.Purpose == purpose && owner.CleanupRequestedAt == nil {
+			volume := r.volumes[volumeID]
+			if volume == nil {
+				continue
+			}
+			return &db.OwnedSandboxVolume{Volume: *volume, Owner: *owner}, nil
+		}
+	}
+	return nil, db.ErrNotFound
 }
 
 func (r *fakeHTTPRepo) GetActiveMounts(ctx context.Context, volumeID string, heartbeatTimeout int) ([]*db.VolumeMount, error) {
@@ -81,7 +127,40 @@ func (r *fakeHTTPRepo) DeleteMount(ctx context.Context, volumeID, clusterID, pod
 
 func (r *fakeHTTPRepo) DeleteSandboxVolumeTx(ctx context.Context, tx pgx.Tx, id string) error {
 	delete(r.volumes, id)
+	delete(r.owners, id)
 	r.deletedVolume = append(r.deletedVolume, id)
+	return nil
+}
+
+func (r *fakeHTTPRepo) MarkOwnedSandboxVolumesForCleanup(ctx context.Context, clusterID, sandboxID, reason string) (int64, error) {
+	now := time.Now().UTC()
+	var marked int64
+	for _, owner := range r.owners {
+		if owner.OwnerClusterID != clusterID || owner.OwnerSandboxID != sandboxID || owner.CleanupRequestedAt != nil {
+			continue
+		}
+		owner.CleanupRequestedAt = &now
+		if reason != "" {
+			owner.CleanupReason = &reason
+		}
+		marked++
+	}
+	return marked, nil
+}
+
+func (r *fakeHTTPRepo) MarkOwnedSandboxVolumeCleanupAttempt(ctx context.Context, volumeID string, cleanupErr error) error {
+	owner := r.owners[volumeID]
+	if owner == nil {
+		return db.ErrNotFound
+	}
+	now := time.Now().UTC()
+	owner.LastCleanupAttemptAt = &now
+	if cleanupErr != nil {
+		msg := cleanupErr.Error()
+		owner.LastCleanupError = &msg
+	} else {
+		owner.LastCleanupError = nil
+	}
 	return nil
 }
 

--- a/storage-proxy/pkg/http/handlers_sandboxvolume.go
+++ b/storage-proxy/pkg/http/handlers_sandboxvolume.go
@@ -1,11 +1,13 @@
 package http
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -27,6 +29,32 @@ type createSandboxVolumeRequest struct {
 	DefaultPosixUID *int64 `json:"default_posix_uid,omitempty"`
 	DefaultPosixGID *int64 `json:"default_posix_gid,omitempty"`
 }
+
+type createOwnedSandboxVolumeRequest struct {
+	SandboxID       string `json:"sandbox_id"`
+	ClusterID       string `json:"cluster_id"`
+	Purpose         string `json:"purpose"`
+	UserID          string `json:"user_id,omitempty"`
+	CacheSize       string `json:"cache_size"`
+	Prefetch        int    `json:"prefetch"`
+	BufferSize      string `json:"buffer_size"`
+	Writeback       bool   `json:"writeback"`
+	AccessMode      string `json:"access_mode"`
+	DefaultPosixUID *int64 `json:"default_posix_uid,omitempty"`
+	DefaultPosixGID *int64 `json:"default_posix_gid,omitempty"`
+}
+
+type markOwnedSandboxVolumesForCleanupRequest struct {
+	SandboxID string `json:"sandbox_id"`
+	ClusterID string `json:"cluster_id"`
+	Reason    string `json:"reason,omitempty"`
+}
+
+type markOwnedSandboxVolumeCleanupAttemptRequest struct {
+	Error string `json:"error,omitempty"`
+}
+
+var errVolumeHasActiveMounts = errors.New("volume has active mounts")
 
 type forkSandboxVolumeRequest struct {
 	CacheSize       *string `json:"cache_size"`
@@ -188,6 +216,11 @@ func (s *Server) getSandboxVolume(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if s.isOwnedSandboxVolume(r.Context(), id) {
+		_ = spec.WriteError(w, http.StatusNotFound, spec.CodeNotFound, "not found")
+		return
+	}
+
 	// Check if the volume belongs to the requesting team
 	if vol.TeamID != claims.TeamID {
 		s.logger.WithField("vol_team", vol.TeamID).WithField("req_team", claims.TeamID).Warn("Unauthorized access attempt to sandbox volume")
@@ -228,6 +261,11 @@ func (s *Server) deleteSandboxVolume(w http.ResponseWriter, r *http.Request) {
 	if vol.TeamID != claims.TeamID {
 		s.logger.WithField("vol_team", vol.TeamID).WithField("req_team", claims.TeamID).Warn("Unauthorized delete attempt to sandbox volume")
 		_ = spec.WriteError(w, http.StatusNotFound, spec.CodeNotFound, "not found") // Don't reveal existence
+		return
+	}
+
+	if s.isOwnedSandboxVolume(r.Context(), id) {
+		_ = spec.WriteError(w, http.StatusNotFound, spec.CodeNotFound, "not found")
 		return
 	}
 
@@ -292,6 +330,314 @@ func (s *Server) deleteSandboxVolume(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.logger.WithField("volume_id", id).WithField("team_id", vol.TeamID).Info("Sandbox volume deleted")
+	_ = spec.WriteSuccess(w, http.StatusOK, map[string]bool{"deleted": true})
+}
+
+func (s *Server) deleteSandboxVolumeRecord(ctx context.Context, id string, force bool) (*db.SandboxVolume, error) {
+	vol, err := s.repo.GetSandboxVolume(ctx, id)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return nil, db.ErrNotFound
+		}
+		return nil, fmt.Errorf("get sandbox volume: %w", err)
+	}
+
+	const heartbeatTimeout = 15
+	if !force && s.volMgr != nil {
+		if _, err := s.volMgr.CleanupIdleDirectVolumeFileMount(ctx, id); err != nil {
+			s.logger.WithError(err).WithField("volume_id", id).Warn("Failed to cleanup idle direct volume mount before delete")
+		}
+	}
+	mounts, err := s.repo.GetActiveMounts(ctx, id, heartbeatTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("check active mounts: %w", err)
+	}
+	if len(mounts) > 0 && !force {
+		return nil, errVolumeHasActiveMounts
+	}
+	if len(mounts) > 0 && force {
+		for _, mount := range mounts {
+			if err := s.repo.DeleteMount(ctx, id, mount.ClusterID, mount.PodID); err != nil {
+				return nil, fmt.Errorf("cleanup mount records: %w", err)
+			}
+		}
+	}
+	if err := s.repo.WithTx(ctx, func(tx pgx.Tx) error {
+		if err := s.repo.DeleteSandboxVolumeTx(ctx, tx, id); err != nil {
+			return err
+		}
+		if err := s.appendMeteringEventTx(ctx, tx, volumeDeletedEvent(s.regionID, vol)); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return vol, nil
+}
+
+func (s *Server) isOwnedSandboxVolume(ctx context.Context, id string) bool {
+	if s == nil || s.repo == nil {
+		return false
+	}
+	_, err := s.repo.GetSandboxVolumeOwner(ctx, id)
+	return err == nil
+}
+
+func (s *Server) requireManagerInternal(w http.ResponseWriter, r *http.Request) (*internalauth.Claims, bool) {
+	claims := internalauth.ClaimsFromContext(r.Context())
+	if claims == nil {
+		_ = spec.WriteError(w, http.StatusUnauthorized, spec.CodeUnauthorized, "unauthorized")
+		return nil, false
+	}
+	if claims.Caller != internalauth.ServiceManager {
+		_ = spec.WriteError(w, http.StatusForbidden, spec.CodeForbidden, "manager token is required")
+		return nil, false
+	}
+	return claims, true
+}
+
+func (s *Server) createOwnedSandboxVolume(w http.ResponseWriter, r *http.Request) {
+	claims, ok := s.requireManagerInternal(w, r)
+	if !ok {
+		return
+	}
+	if claims.TeamID == "" {
+		_ = spec.WriteError(w, http.StatusBadRequest, spec.CodeBadRequest, "team_id is required")
+		return
+	}
+
+	var req createOwnedSandboxVolumeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		_ = spec.WriteError(w, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
+		return
+	}
+	req.SandboxID = strings.TrimSpace(req.SandboxID)
+	req.ClusterID = strings.TrimSpace(req.ClusterID)
+	req.Purpose = strings.TrimSpace(req.Purpose)
+	if req.SandboxID == "" || req.ClusterID == "" || req.Purpose == "" {
+		_ = spec.WriteError(w, http.StatusBadRequest, spec.CodeBadRequest, "sandbox_id, cluster_id and purpose are required")
+		return
+	}
+	if claims.SandboxID != "" && claims.SandboxID != req.SandboxID {
+		_ = spec.WriteError(w, http.StatusForbidden, spec.CodeForbidden, "sandbox_id does not match token")
+		return
+	}
+
+	if existing, err := s.repo.GetOwnedSandboxVolumeByOwner(r.Context(), req.ClusterID, req.SandboxID, req.Purpose); err == nil {
+		_ = spec.WriteSuccess(w, http.StatusOK, existing)
+		return
+	} else if !errors.Is(err, db.ErrNotFound) {
+		s.logger.WithError(err).Error("Failed to check existing owned sandbox volume")
+		_ = spec.WriteError(w, http.StatusInternalServerError, spec.CodeInternal, "internal server error")
+		return
+	}
+
+	if req.CacheSize == "" {
+		req.CacheSize = "64M"
+	}
+	if req.BufferSize == "" {
+		req.BufferSize = "8M"
+	}
+	defaultZeroPosixIdentity(&req.DefaultPosixUID, &req.DefaultPosixGID)
+	accessMode, ok := volume.ParseAccessMode(req.AccessMode)
+	if req.AccessMode == "" {
+		accessMode = volume.AccessModeRWO
+		ok = true
+	}
+	if !ok {
+		_ = spec.WriteError(w, http.StatusBadRequest, spec.CodeBadRequest, "invalid access_mode")
+		return
+	}
+	if err := validateDefaultPosixIdentity(req.DefaultPosixUID, req.DefaultPosixGID); err != nil {
+		_ = spec.WriteError(w, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
+		return
+	}
+	userID := strings.TrimSpace(claims.UserID)
+	if userID == "" {
+		userID = strings.TrimSpace(req.UserID)
+	}
+	if userID == "" {
+		userID = "system"
+	}
+
+	now := time.Now().UTC()
+	vol := &db.SandboxVolume{
+		ID:              uuid.New().String(),
+		TeamID:          claims.TeamID,
+		UserID:          userID,
+		DefaultPosixUID: req.DefaultPosixUID,
+		DefaultPosixGID: req.DefaultPosixGID,
+		CacheSize:       req.CacheSize,
+		Prefetch:        req.Prefetch,
+		BufferSize:      req.BufferSize,
+		Writeback:       req.Writeback,
+		AccessMode:      string(accessMode),
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	owner := &db.SandboxVolumeOwner{
+		VolumeID:       vol.ID,
+		OwnerKind:      db.SandboxVolumeOwnerKindSandbox,
+		OwnerSandboxID: req.SandboxID,
+		OwnerClusterID: req.ClusterID,
+		Purpose:        req.Purpose,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+
+	if err := s.repo.WithTx(r.Context(), func(tx pgx.Tx) error {
+		if err := s.repo.CreateSandboxVolumeTx(r.Context(), tx, vol); err != nil {
+			return err
+		}
+		if err := s.repo.CreateSandboxVolumeOwnerTx(r.Context(), tx, owner); err != nil {
+			return err
+		}
+		if err := s.appendMeteringEventTx(r.Context(), tx, volumeCreatedEvent(s.regionID, vol)); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		if existing, getErr := s.repo.GetOwnedSandboxVolumeByOwner(r.Context(), req.ClusterID, req.SandboxID, req.Purpose); getErr == nil {
+			_ = spec.WriteSuccess(w, http.StatusOK, existing)
+			return
+		}
+		s.logger.WithError(err).Error("Failed to create owned sandbox volume")
+		_ = spec.WriteError(w, http.StatusInternalServerError, spec.CodeInternal, "internal server error")
+		return
+	}
+
+	_ = spec.WriteSuccess(w, http.StatusCreated, &db.OwnedSandboxVolume{
+		Volume: *vol,
+		Owner:  *owner,
+	})
+}
+
+func (s *Server) listOwnedSandboxVolumes(w http.ResponseWriter, r *http.Request) {
+	claims, ok := s.requireManagerInternal(w, r)
+	if !ok {
+		return
+	}
+	if !claims.IsSystemToken() {
+		_ = spec.WriteError(w, http.StatusForbidden, spec.CodeForbidden, "system token is required")
+		return
+	}
+	clusterID := strings.TrimSpace(r.URL.Query().Get("cluster_id"))
+	if clusterID == "" {
+		_ = spec.WriteError(w, http.StatusBadRequest, spec.CodeBadRequest, "cluster_id is required")
+		return
+	}
+	var cleanupRequested *bool
+	switch strings.TrimSpace(r.URL.Query().Get("cleanup_requested")) {
+	case "true":
+		value := true
+		cleanupRequested = &value
+	case "false":
+		value := false
+		cleanupRequested = &value
+	}
+	owned, err := s.repo.ListOwnedSandboxVolumes(r.Context(), clusterID, cleanupRequested)
+	if err != nil {
+		s.logger.WithError(err).Error("Failed to list owned sandbox volumes")
+		_ = spec.WriteError(w, http.StatusInternalServerError, spec.CodeInternal, "internal server error")
+		return
+	}
+	_ = spec.WriteSuccess(w, http.StatusOK, owned)
+}
+
+func (s *Server) markOwnedSandboxVolumesForCleanup(w http.ResponseWriter, r *http.Request) {
+	claims, ok := s.requireManagerInternal(w, r)
+	if !ok {
+		return
+	}
+	var req markOwnedSandboxVolumesForCleanupRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		_ = spec.WriteError(w, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
+		return
+	}
+	req.SandboxID = strings.TrimSpace(req.SandboxID)
+	req.ClusterID = strings.TrimSpace(req.ClusterID)
+	if req.SandboxID == "" || req.ClusterID == "" {
+		_ = spec.WriteError(w, http.StatusBadRequest, spec.CodeBadRequest, "sandbox_id and cluster_id are required")
+		return
+	}
+	if !claims.IsSystemToken() && claims.SandboxID != "" && claims.SandboxID != req.SandboxID {
+		_ = spec.WriteError(w, http.StatusForbidden, spec.CodeForbidden, "sandbox_id does not match token")
+		return
+	}
+	marked, err := s.repo.MarkOwnedSandboxVolumesForCleanup(r.Context(), req.ClusterID, req.SandboxID, strings.TrimSpace(req.Reason))
+	if err != nil {
+		s.logger.WithError(err).Error("Failed to mark owned sandbox volumes for cleanup")
+		_ = spec.WriteError(w, http.StatusInternalServerError, spec.CodeInternal, "internal server error")
+		return
+	}
+	_ = spec.WriteSuccess(w, http.StatusOK, map[string]any{"marked": marked})
+}
+
+func (s *Server) markOwnedSandboxVolumeCleanupAttempt(w http.ResponseWriter, r *http.Request) {
+	claims, ok := s.requireManagerInternal(w, r)
+	if !ok {
+		return
+	}
+	if !claims.IsSystemToken() {
+		_ = spec.WriteError(w, http.StatusForbidden, spec.CodeForbidden, "system token is required")
+		return
+	}
+	id := strings.TrimSpace(r.PathValue("id"))
+	if id == "" {
+		_ = spec.WriteError(w, http.StatusBadRequest, spec.CodeBadRequest, "id is required")
+		return
+	}
+	var req markOwnedSandboxVolumeCleanupAttemptRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+		_ = spec.WriteError(w, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
+		return
+	}
+	var cleanupErr error
+	if msg := strings.TrimSpace(req.Error); msg != "" {
+		cleanupErr = errors.New(msg)
+	}
+	if err := s.repo.MarkOwnedSandboxVolumeCleanupAttempt(r.Context(), id, cleanupErr); err != nil && !errors.Is(err, db.ErrNotFound) {
+		s.logger.WithError(err).Error("Failed to mark owned sandbox volume cleanup attempt")
+		_ = spec.WriteError(w, http.StatusInternalServerError, spec.CodeInternal, "internal server error")
+		return
+	}
+	_ = spec.WriteSuccess(w, http.StatusOK, map[string]bool{"updated": true})
+}
+
+func (s *Server) deleteOwnedSandboxVolume(w http.ResponseWriter, r *http.Request) {
+	claims, ok := s.requireManagerInternal(w, r)
+	if !ok {
+		return
+	}
+	id := strings.TrimSpace(r.PathValue("id"))
+	if id == "" {
+		_ = spec.WriteError(w, http.StatusBadRequest, spec.CodeBadRequest, "id is required")
+		return
+	}
+	owner, err := s.repo.GetSandboxVolumeOwner(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			_ = spec.WriteSuccess(w, http.StatusOK, map[string]bool{"deleted": true})
+			return
+		}
+		s.logger.WithError(err).Error("Failed to get sandbox volume owner")
+		_ = spec.WriteError(w, http.StatusInternalServerError, spec.CodeInternal, "internal server error")
+		return
+	}
+	if !claims.IsSystemToken() && claims.SandboxID != "" && claims.SandboxID != owner.OwnerSandboxID {
+		_ = spec.WriteError(w, http.StatusForbidden, spec.CodeForbidden, "sandbox_id does not match token")
+		return
+	}
+	if _, err := s.deleteSandboxVolumeRecord(r.Context(), id, false); err != nil {
+		_ = s.repo.MarkOwnedSandboxVolumeCleanupAttempt(r.Context(), id, err)
+		status, code := http.StatusInternalServerError, spec.CodeInternal
+		if errors.Is(err, errVolumeHasActiveMounts) {
+			status, code = http.StatusConflict, spec.CodeConflict
+		}
+		_ = spec.WriteError(w, status, code, err.Error())
+		return
+	}
 	_ = spec.WriteSuccess(w, http.StatusOK, map[string]bool{"deleted": true})
 }
 

--- a/storage-proxy/pkg/http/handlers_sandboxvolume_test.go
+++ b/storage-proxy/pkg/http/handlers_sandboxvolume_test.go
@@ -123,6 +123,99 @@ func TestCreateSandboxVolumeRejectsPartialDefaultPosixIdentity(t *testing.T) {
 	}
 }
 
+func TestCreateOwnedSandboxVolumeStoresOwnerMetadata(t *testing.T) {
+	repo := newFakeHTTPRepo()
+	server := &Server{
+		logger:       logrus.New(),
+		repo:         repo,
+		meteringRepo: &fakeHTTPMeteringWriter{},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/internal/v1/sandboxvolumes/owned", bytes.NewReader([]byte(`{"sandbox_id":"sandbox-a","cluster_id":"cluster-a","purpose":"webhook-state"}`)))
+	req = req.WithContext(internalauth.WithClaims(req.Context(), &internalauth.Claims{
+		Caller:    internalauth.ServiceManager,
+		TeamID:    "team-1",
+		UserID:    "user-1",
+		SandboxID: "sandbox-a",
+	}))
+	recorder := httptest.NewRecorder()
+
+	server.createOwnedSandboxVolume(recorder, req)
+
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusCreated, recorder.Body.String())
+	}
+	if len(repo.createdVolumes) != 1 {
+		t.Fatalf("created volumes = %d, want 1", len(repo.createdVolumes))
+	}
+	volumeID := repo.createdVolumes[0].ID
+	owner := repo.owners[volumeID]
+	if owner == nil {
+		t.Fatalf("owner for volume %q was not stored", volumeID)
+	}
+	if owner.OwnerSandboxID != "sandbox-a" || owner.OwnerClusterID != "cluster-a" || owner.Purpose != "webhook-state" {
+		t.Fatalf("unexpected owner: %#v", owner)
+	}
+}
+
+func TestOwnedSandboxVolumeIsHiddenFromPublicVolumeAPI(t *testing.T) {
+	repo := newFakeHTTPRepo()
+	server := &Server{logger: logrus.New(), repo: repo}
+	repo.volumes["vol-owned"] = &db.SandboxVolume{ID: "vol-owned", TeamID: "team-1", UserID: "user-1"}
+	repo.owners["vol-owned"] = &db.SandboxVolumeOwner{
+		VolumeID:       "vol-owned",
+		OwnerKind:      db.SandboxVolumeOwnerKindSandbox,
+		OwnerSandboxID: "sandbox-a",
+		OwnerClusterID: "cluster-a",
+		Purpose:        "webhook-state",
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/sandboxvolumes/vol-owned", nil)
+	req.SetPathValue("id", "vol-owned")
+	req = req.WithContext(internalauth.WithClaims(req.Context(), &internalauth.Claims{TeamID: "team-1", UserID: "user-1"}))
+	recorder := httptest.NewRecorder()
+
+	server.getSandboxVolume(recorder, req)
+
+	if recorder.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusNotFound)
+	}
+}
+
+func TestMarkOwnedSandboxVolumesForCleanupIsIdempotent(t *testing.T) {
+	repo := newFakeHTTPRepo()
+	server := &Server{logger: logrus.New(), repo: repo}
+	repo.volumes["vol-owned"] = &db.SandboxVolume{ID: "vol-owned", TeamID: "team-1", UserID: "user-1"}
+	repo.owners["vol-owned"] = &db.SandboxVolumeOwner{
+		VolumeID:       "vol-owned",
+		OwnerKind:      db.SandboxVolumeOwnerKindSandbox,
+		OwnerSandboxID: "sandbox-a",
+		OwnerClusterID: "cluster-a",
+		Purpose:        "webhook-state",
+	}
+
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest(http.MethodPut, "/internal/v1/sandboxvolumes/owned/cleanup", bytes.NewReader([]byte(`{"sandbox_id":"sandbox-a","cluster_id":"cluster-a","reason":"sandbox_deleted"}`)))
+		req = req.WithContext(internalauth.WithClaims(req.Context(), &internalauth.Claims{
+			Caller:    internalauth.ServiceManager,
+			TeamID:    "team-1",
+			UserID:    "user-1",
+			SandboxID: "sandbox-a",
+		}))
+		recorder := httptest.NewRecorder()
+
+		server.markOwnedSandboxVolumesForCleanup(recorder, req)
+
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("iteration %d status = %d, want %d", i, recorder.Code, http.StatusOK)
+		}
+	}
+
+	if repo.owners["vol-owned"].CleanupRequestedAt == nil {
+		t.Fatal("cleanup_requested_at was not set")
+	}
+}
+
 func TestForkVolumePassesDefaultPosixIdentity(t *testing.T) {
 	snapshotMgr := &captureForkSnapshotManager{fakeHTTPSnapshotManager: &fakeHTTPSnapshotManager{}}
 	server := &Server{

--- a/storage-proxy/pkg/http/handlers_volume_files.go
+++ b/storage-proxy/pkg/http/handlers_volume_files.go
@@ -530,6 +530,9 @@ func (s *Server) loadAuthorizedVolume(ctx context.Context, volumeID string) (*db
 	if volumeRecord.TeamID != claims.TeamID {
 		return nil, errVolumeNotFound
 	}
+	if s.isOwnedSandboxVolume(ctx, volumeID) {
+		return nil, errVolumeNotFound
+	}
 	return volumeRecord, nil
 }
 

--- a/storage-proxy/pkg/http/server.go
+++ b/storage-proxy/pkg/http/server.go
@@ -30,11 +30,17 @@ import (
 type volumeRepository interface {
 	WithTx(ctx context.Context, fn func(pgx.Tx) error) error
 	CreateSandboxVolumeTx(ctx context.Context, tx pgx.Tx, volume *db.SandboxVolume) error
+	CreateSandboxVolumeOwnerTx(ctx context.Context, tx pgx.Tx, owner *db.SandboxVolumeOwner) error
 	ListSandboxVolumesByTeam(ctx context.Context, teamID string) ([]*db.SandboxVolume, error)
+	ListOwnedSandboxVolumes(ctx context.Context, clusterID string, cleanupRequested *bool) ([]*db.OwnedSandboxVolume, error)
 	GetSandboxVolume(ctx context.Context, id string) (*db.SandboxVolume, error)
+	GetSandboxVolumeOwner(ctx context.Context, volumeID string) (*db.SandboxVolumeOwner, error)
+	GetOwnedSandboxVolumeByOwner(ctx context.Context, clusterID, sandboxID, purpose string) (*db.OwnedSandboxVolume, error)
 	GetActiveMounts(ctx context.Context, volumeID string, heartbeatTimeout int) ([]*db.VolumeMount, error)
 	DeleteMount(ctx context.Context, volumeID, clusterID, podID string) error
 	DeleteSandboxVolumeTx(ctx context.Context, tx pgx.Tx, id string) error
+	MarkOwnedSandboxVolumesForCleanup(ctx context.Context, clusterID, sandboxID, reason string) (int64, error)
+	MarkOwnedSandboxVolumeCleanupAttempt(ctx context.Context, volumeID string, cleanupErr error) error
 }
 
 type meteringWriter interface {
@@ -165,6 +171,13 @@ func NewServer(logger *logrus.Logger, cfg *config.StorageProxyConfig, k8sClient 
 	s.mux.HandleFunc("GET /sandboxvolumes/{id}/files/list", s.handleVolumeFileList)
 	s.mux.HandleFunc("POST /sandboxvolumes/{id}/files/move", s.handleVolumeFileMove)
 	s.mux.HandleFunc("GET /sandboxvolumes/{id}/files/watch", s.handleVolumeFileWatch)
+
+	// Internal manager-owned SandboxVolume lifecycle handlers.
+	s.mux.HandleFunc("POST /internal/v1/sandboxvolumes/owned", s.createOwnedSandboxVolume)
+	s.mux.HandleFunc("GET /internal/v1/sandboxvolumes/owned", s.listOwnedSandboxVolumes)
+	s.mux.HandleFunc("PUT /internal/v1/sandboxvolumes/owned/cleanup", s.markOwnedSandboxVolumesForCleanup)
+	s.mux.HandleFunc("PUT /internal/v1/sandboxvolumes/owned/{id}/cleanup-attempt", s.markOwnedSandboxVolumeCleanupAttempt)
+	s.mux.HandleFunc("DELETE /internal/v1/sandboxvolumes/owned/{id}", s.deleteOwnedSandboxVolume)
 
 	// Snapshot handlers
 	s.mux.HandleFunc("POST /sandboxvolumes/{volume_id}/snapshots", s.createSnapshot)


### PR DESCRIPTION
## Summary
- Add durable ownership metadata for manager-created SandboxVolumes and hide system-owned volumes from public storage-proxy APIs.
- Add manager/storage-proxy internal owned-volume APIs for idempotent create, cleanup marking, cleanup attempts, listing, and deletion.
- Add a manager system volume reconciler that marks orphaned owned volumes and deletes cleanup-requested volumes after a delay.

Closes #228

## Testing
- go test ./storage-proxy/pkg/db ./storage-proxy/pkg/http ./storage-proxy/pkg/grpc ./storage-proxy/pkg/auth ./manager/pkg/service ./manager/pkg/controller
- git push pre-push hook: make manifests; make proto; make apispec; go fmt ./...; go mod tidy; go mod vendor; golangci-lint run ./...
- Remote kind: rsync worktree to kind:/root/infra; make test-again; verified sandbox0-system pods all Running with 0 restarts
- Remote kind live smoke: created a manager-owned volume through storage-proxy internal API, verified public get/list hide it, verified owned list sees it, marked cleanup, then deleted it