### PR TITLE
Fix storage-proxy replay payload write amplification

### DIFF
--- a/storage-proxy/pkg/grpc/server.go
+++ b/storage-proxy/pkg/grpc/server.go
@@ -1162,9 +1162,6 @@ func (s *FileSystemServer) Flush(ctx context.Context, req *pb.FlushRequest) (*pb
 		return nil, status.Error(mapErrnoToCode(syscall.Errno(errno)), syscall.Errno(errno).Error())
 	}
 
-	if s.recordDirtyWriteReplayPayload(ctx, volCtx, req.VolumeId, dirty, "flush") {
-		s.clearDirtyWrite(req.VolumeId, req.HandleId)
-	}
 	return &pb.Empty{}, nil
 }
 

--- a/storage-proxy/pkg/grpc/server_auth_test.go
+++ b/storage-proxy/pkg/grpc/server_auth_test.go
@@ -365,6 +365,65 @@ func TestCreatePropagatesNamespaceValidationAndRecordsRemoteChange(t *testing.T)
 	}
 }
 
+func TestFlushDefersDirtyWriteReplayPayloadUntilRelease(t *testing.T) {
+	volCtx := newMountedTestVolumeContext(t, "vol-1", "team-a")
+	recorder := &fakeSyncRecorder{}
+	server := NewFileSystemServer(&fakeVolumeManager{
+		volumes: map[string]*volume.VolumeContext{
+			"vol-1": volCtx,
+		},
+	}, nil, nil, nil, logrus.New(), recorder, nil)
+	ctx := authContext("team-a", "sandbox-1")
+
+	createResp, err := server.Create(ctx, &pb.CreateRequest{
+		VolumeId: "vol-1",
+		Parent:   uint64(meta.RootInode),
+		Name:     "hello.txt",
+		Mode:     0o644,
+		Flags:    uint32(syscall.O_RDWR),
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	recorder.remoteChanges = nil
+
+	if _, err := server.Write(ctx, &pb.WriteRequest{
+		VolumeId: "vol-1",
+		Inode:    createResp.Inode,
+		HandleId: createResp.HandleId,
+		Data:     []byte("hello"),
+	}); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	if _, err := server.Flush(ctx, &pb.FlushRequest{
+		VolumeId: "vol-1",
+		HandleId: createResp.HandleId,
+	}); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+	if len(recorder.remoteChanges) != 0 {
+		t.Fatalf("remoteChanges after Flush = %d, want 0", len(recorder.remoteChanges))
+	}
+
+	if _, err := server.Release(ctx, &pb.ReleaseRequest{
+		VolumeId: "vol-1",
+		Inode:    createResp.Inode,
+		HandleId: createResp.HandleId,
+	}); err != nil {
+		t.Fatalf("Release() error = %v", err)
+	}
+	if len(recorder.remoteChanges) != 1 {
+		t.Fatalf("remoteChanges after Release = %d, want 1", len(recorder.remoteChanges))
+	}
+	got := recorder.remoteChanges[0]
+	if got.EventType != db.SyncEventWrite || got.Path != "/hello.txt" || got.SandboxID != "sandbox-1" {
+		t.Fatalf("remoteChanges[0] = %+v, want write event for /hello.txt", got)
+	}
+	if !got.ContentAvailable || string(got.ContentBytes) != "hello" {
+		t.Fatalf("remoteChanges[0] content = available:%v bytes:%q, want hello", got.ContentAvailable, string(got.ContentBytes))
+	}
+}
+
 func TestCreateRejectsNamespaceIncompatiblePathBeforeMutation(t *testing.T) {
 	volCtx := newMountedTestVolumeContext(t, "vol-1", "team-a")
 	recorder := &fakeSyncRecorder{

--- a/storage-proxy/pkg/volsync/service.go
+++ b/storage-proxy/pkg/volsync/service.go
@@ -12,6 +12,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -77,14 +78,16 @@ type repository interface {
 
 // Service owns durable volume-sync metadata and journal behavior.
 type Service struct {
-	repo           repository
-	logger         *logrus.Logger
-	metrics        *obsmetrics.StorageProxyMetrics
-	artifactWriter conflictArtifactWriter
-	changeApplier  replicaChangeApplier
-	replayPayloads replayPayloadStore
-	barrier        volumeMutationBarrier
-	now            func() time.Time
+	repo              repository
+	logger            *logrus.Logger
+	metrics           *obsmetrics.StorageProxyMetrics
+	artifactWriter    conflictArtifactWriter
+	changeApplier     replicaChangeApplier
+	replayPayloads    replayPayloadStore
+	replayPayloadMu   sync.Mutex
+	replayPayloadRefs map[string]string
+	barrier           volumeMutationBarrier
+	now               func() time.Time
 }
 
 type conflictArtifactWriter interface {
@@ -264,7 +267,10 @@ func (s *Service) SetReplicaChangeApplier(applier replicaChangeApplier) {
 }
 
 func (s *Service) SetReplayPayloadStore(store replayPayloadStore) {
+	s.replayPayloadMu.Lock()
+	defer s.replayPayloadMu.Unlock()
 	s.replayPayloads = store
+	s.replayPayloadRefs = nil
 }
 
 func (s *Service) SetVolumeMutationBarrier(barrier volumeMutationBarrier) {
@@ -857,16 +863,8 @@ func (s *Service) RecordRemoteChange(ctx context.Context, change *RemoteChange) 
 		sizeBytes     *int64
 	)
 	if change.ContentAvailable {
-		if s.replayPayloads == nil {
-			return fmt.Errorf("replay payload storage unavailable")
-		}
 		sum := sha256.Sum256(change.ContentBytes)
 		sumHex := hex.EncodeToString(sum[:])
-		ref, err := s.replayPayloads.PutPayload(ctx, volume, sumHex, change.ContentBytes)
-		if err != nil {
-			return err
-		}
-		contentRef = &ref
 		contentSHA256 = &sumHex
 		size := int64(len(change.ContentBytes))
 		sizeBytes = &size
@@ -886,6 +884,17 @@ func (s *Service) RecordRemoteChange(ctx context.Context, change *RemoteChange) 
 		if err != nil && !errors.Is(err, db.ErrNotFound) {
 			return err
 		}
+	}
+
+	if change.ContentAvailable {
+		if s.replayPayloads == nil {
+			return fmt.Errorf("replay payload storage unavailable")
+		}
+		ref, err := s.putReplayPayloadOnce(ctx, volume, *contentSHA256, change.ContentBytes)
+		if err != nil {
+			return err
+		}
+		contentRef = &ref
 	}
 
 	return s.repo.WithTx(ctx, func(tx pgx.Tx) error {
@@ -914,6 +923,31 @@ func (s *Service) RecordRemoteChange(ctx context.Context, change *RemoteChange) 
 
 		return s.repo.CreateSyncJournalEntryTx(ctx, tx, entry)
 	})
+}
+
+func (s *Service) putReplayPayloadOnce(ctx context.Context, volume *db.SandboxVolume, contentSHA256 string, payload []byte) (string, error) {
+	cacheKey := volume.TeamID + "\x00" + volume.ID + "\x00" + contentSHA256
+
+	s.replayPayloadMu.Lock()
+	if ref, ok := s.replayPayloadRefs[cacheKey]; ok {
+		s.replayPayloadMu.Unlock()
+		return ref, nil
+	}
+	s.replayPayloadMu.Unlock()
+
+	ref, err := s.replayPayloads.PutPayload(ctx, volume, contentSHA256, payload)
+	if err != nil {
+		return "", err
+	}
+
+	s.replayPayloadMu.Lock()
+	if s.replayPayloadRefs == nil {
+		s.replayPayloadRefs = make(map[string]string)
+	}
+	s.replayPayloadRefs[cacheKey] = ref
+	s.replayPayloadMu.Unlock()
+
+	return ref, nil
 }
 
 func (s *Service) prepareReplicaEntry(ctx context.Context, tx pgx.Tx, req *AppendChangesRequest, replica *db.SyncReplica, change ChangeRequest, now time.Time) (*db.SyncJournalEntry, *db.SyncConflict, error) {

--- a/storage-proxy/pkg/volsync/service_test.go
+++ b/storage-proxy/pkg/volsync/service_test.go
@@ -3,6 +3,8 @@ package volsync
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"io"
@@ -31,14 +33,19 @@ type fakeRepo struct {
 
 type fakeReplayPayloadStore struct {
 	payloads map[string][]byte
+	puts     map[string]int
 }
 
 func newFakeReplayPayloadStore() *fakeReplayPayloadStore {
-	return &fakeReplayPayloadStore{payloads: make(map[string][]byte)}
+	return &fakeReplayPayloadStore{
+		payloads: make(map[string][]byte),
+		puts:     make(map[string]int),
+	}
 }
 
 func (f *fakeReplayPayloadStore) PutPayload(ctx context.Context, volume *db.SandboxVolume, contentSHA256 string, payload []byte) (string, error) {
 	key := volume.ID + ":" + buildReplayPayloadRef(contentSHA256)
+	f.puts[key]++
 	f.payloads[key] = append([]byte(nil), payload...)
 	return buildReplayPayloadRef(contentSHA256), nil
 }
@@ -50,6 +57,19 @@ func (f *fakeReplayPayloadStore) GetPayload(ctx context.Context, volume *db.Sand
 		return nil, ErrReplayPayloadNotFound
 	}
 	return io.NopCloser(bytes.NewReader(payload)), nil
+}
+
+func (f *fakeReplayPayloadStore) totalPuts() int {
+	var total int
+	for _, count := range f.puts {
+		total += count
+	}
+	return total
+}
+
+func testSHA256Hex(payload []byte) string {
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:])
 }
 
 func newFakeRepo() *fakeRepo {
@@ -1986,6 +2006,90 @@ func TestRecordRemoteChangeCoalescesHotWrites(t *testing.T) {
 	}
 	if len(repo.journal) != 1 {
 		t.Fatalf("journal entries = %d, want 1", len(repo.journal))
+	}
+}
+
+func TestRecordRemoteChangeCoalescesHotWritesBeforeReplayPayloadUpload(t *testing.T) {
+	repo := newFakeRepo()
+	repo.volumes["vol-1"] = &db.SandboxVolume{ID: "vol-1", TeamID: "team-1"}
+	payload := []byte("hello")
+	sumHex := testSHA256Hex(payload)
+	size := int64(len(payload))
+	mode := int64(0o644)
+	base := time.Date(2026, 3, 26, 12, 0, 0, 0, time.UTC)
+	repo.journal = []*db.SyncJournalEntry{
+		{
+			Seq:            1,
+			VolumeID:       "vol-1",
+			TeamID:         "team-1",
+			Source:         db.SyncSourceSandbox,
+			EventType:      db.SyncEventWrite,
+			Path:           "/src/main.go",
+			NormalizedPath: "/src/main.go",
+			ContentSHA256:  &sumHex,
+			SizeBytes:      &size,
+			Mode:           &mode,
+			CreatedAt:      base,
+		},
+	}
+	repo.nextSeq = 1
+	store := newFakeReplayPayloadStore()
+
+	svc := NewService(repo, logrus.New())
+	svc.SetReplayPayloadStore(store)
+	requestMode := uint32(0o644)
+	if err := svc.RecordRemoteChange(context.Background(), &RemoteChange{
+		VolumeID:         "vol-1",
+		TeamID:           "team-1",
+		SandboxID:        "sandbox-1",
+		EventType:        db.SyncEventWrite,
+		Path:             "/src/main.go",
+		Mode:             &requestMode,
+		ContentAvailable: true,
+		ContentBytes:     payload,
+		OccurredAt:       base.Add(500 * time.Millisecond),
+	}); err != nil {
+		t.Fatalf("RecordRemoteChange error = %v", err)
+	}
+	if len(repo.journal) != 1 {
+		t.Fatalf("journal entries = %d, want 1", len(repo.journal))
+	}
+	if got := store.totalPuts(); got != 0 {
+		t.Fatalf("replay payload puts = %d, want 0", got)
+	}
+}
+
+func TestRecordRemoteChangeDeduplicatesReplayPayloadUploadsByContent(t *testing.T) {
+	repo := newFakeRepo()
+	repo.volumes["vol-1"] = &db.SandboxVolume{ID: "vol-1", TeamID: "team-1"}
+	store := newFakeReplayPayloadStore()
+	payload := []byte("same payload")
+
+	svc := NewService(repo, logrus.New())
+	svc.SetReplayPayloadStore(store)
+	for _, path := range []string{"/src/a.go", "/src/b.go"} {
+		if err := svc.RecordRemoteChange(context.Background(), &RemoteChange{
+			VolumeID:         "vol-1",
+			TeamID:           "team-1",
+			SandboxID:        "sandbox-1",
+			EventType:        db.SyncEventWrite,
+			Path:             path,
+			ContentAvailable: true,
+			ContentBytes:     payload,
+			OccurredAt:       time.Now().UTC(),
+		}); err != nil {
+			t.Fatalf("RecordRemoteChange(%s) error = %v", path, err)
+		}
+	}
+
+	if len(repo.journal) != 2 {
+		t.Fatalf("journal entries = %d, want 2", len(repo.journal))
+	}
+	if got := store.totalPuts(); got != 1 {
+		t.Fatalf("replay payload puts = %d, want 1", got)
+	}
+	if repo.journal[0].ContentRef == nil || repo.journal[1].ContentRef == nil || *repo.journal[0].ContentRef != *repo.journal[1].ContentRef {
+		t.Fatalf("content refs = %#v %#v, want same ref", repo.journal[0].ContentRef, repo.journal[1].ContentRef)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Defer dirty write replay capture from Flush to Release so close-time flushes do not record stale payloads or clear the dirty handle early.
- Coalesce hot sandbox writes before uploading replay payload bytes.
- Cache successful replay payload uploads by volume/content hash to avoid repeated writes to the same content-addressed object.
- Add regression tests for Flush/Release capture, coalesced writes, and same-content upload dedupe.

Closes #231

## Testing
- make proto
- go test ./storage-proxy/pkg/volsync
- go test ./storage-proxy/pkg/grpc
- go test ./storage-proxy/...
- git push pre-push hook: make manifests, make proto, make apispec, go fmt ./..., go mod tidy, go mod vendor, golangci-lint run ./...
