### PR TITLE
Add storage-proxy object store metrics

### DIFF
--- a/pkg/observability/metrics/storage_proxy.go
+++ b/pkg/observability/metrics/storage_proxy.go
@@ -1,6 +1,8 @@
 package metrics
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
@@ -22,6 +24,10 @@ type StorageProxyMetrics struct {
 	S3OperationsTotal *prometheus.CounterVec
 	S3BytesTotal      *prometheus.CounterVec
 	S3Duration        *prometheus.HistogramVec
+
+	ObjectStoreRequestsTotal   *prometheus.CounterVec
+	ObjectStoreRequestDuration *prometheus.HistogramVec
+	ObjectStoreBytesTotal      *prometheus.CounterVec
 
 	GRPCRequestsTotal   *prometheus.CounterVec
 	GRPCRequestDuration *prometheus.HistogramVec
@@ -127,6 +133,19 @@ func NewStorageProxy(registry prometheus.Registerer) *StorageProxyMetrics {
 			Help:    "Duration of S3 operations in seconds",
 			Buckets: prometheus.DefBuckets,
 		}, []string{"operation", "volume_id"}),
+		ObjectStoreRequestsTotal: factory.NewCounterVec(prometheus.CounterOpts{
+			Name: "storage_proxy_object_store_requests_total",
+			Help: "Total number of object store provider requests made by storage-proxy",
+		}, []string{"provider", "bucket", "prefix_class", "operation", "status"}),
+		ObjectStoreRequestDuration: factory.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "storage_proxy_object_store_request_duration_seconds",
+			Help:    "Duration of object store provider requests made by storage-proxy",
+			Buckets: prometheus.DefBuckets,
+		}, []string{"provider", "bucket", "prefix_class", "operation", "status"}),
+		ObjectStoreBytesTotal: factory.NewCounterVec(prometheus.CounterOpts{
+			Name: "storage_proxy_object_store_bytes_total",
+			Help: "Total bytes transferred through object store provider requests made by storage-proxy",
+		}, []string{"provider", "bucket", "prefix_class", "operation", "direction"}),
 		GRPCRequestsTotal: factory.NewCounterVec(prometheus.CounterOpts{
 			Name: "storage_proxy_grpc_requests_total",
 			Help: "Total number of gRPC requests",
@@ -294,4 +313,23 @@ func NewStorageProxy(registry prometheus.Registerer) *StorageProxyMetrics {
 			Help: "Total number of background volume sync maintenance task runs",
 		}, []string{"task", "status"}),
 	}
+}
+
+func (m *StorageProxyMetrics) ObserveObjectStoreRequest(provider, bucket, prefixClass, operation, status string, duration time.Duration) {
+	if m == nil {
+		return
+	}
+	if m.ObjectStoreRequestsTotal != nil {
+		m.ObjectStoreRequestsTotal.WithLabelValues(provider, bucket, prefixClass, operation, status).Inc()
+	}
+	if m.ObjectStoreRequestDuration != nil {
+		m.ObjectStoreRequestDuration.WithLabelValues(provider, bucket, prefixClass, operation, status).Observe(duration.Seconds())
+	}
+}
+
+func (m *StorageProxyMetrics) ObserveObjectStoreBytes(provider, bucket, prefixClass, operation, direction string, bytes int64) {
+	if m == nil || bytes <= 0 || m.ObjectStoreBytesTotal == nil {
+		return
+	}
+	m.ObjectStoreBytesTotal.WithLabelValues(provider, bucket, prefixClass, operation, direction).Add(float64(bytes))
 }

--- a/storage-proxy/cmd/storage-proxy/main.go
+++ b/storage-proxy/cmd/storage-proxy/main.go
@@ -135,12 +135,13 @@ func main() {
 	}
 
 	// Initialize JuiceFS filesystem if not already initialized
-	if err := initializeJuiceFS(cfg, zapLogger); err != nil {
+	if err := initializeJuiceFS(cfg, zapLogger, storageProxyMetrics); err != nil {
 		zapLogger.Fatal("Failed to initialize JuiceFS", zap.Error(err))
 	}
 
 	// Create volume manager
 	volMgr := volume.NewManager(logrusLogger, cfg)
+	volMgr.SetMetrics(storageProxyMetrics)
 	directVolumeFileIdleTTL := buildDirectVolumeFileIdleTTL(cfg)
 	directVolumeFileCleanupInterval := buildDirectVolumeFileCleanupInterval(cfg, directVolumeFileIdleTTL)
 	var syncSvc *volsync.Service
@@ -158,7 +159,7 @@ func main() {
 		syncSvc.SetMetrics(storageProxyMetrics)
 		syncSvc.SetConflictArtifactWriter(volsync.NewConflictArtifactWriter(volMgr, logrusLogger))
 		syncSvc.SetReplicaChangeApplier(volsync.NewVolumeChangeApplier(volMgr, logrusLogger))
-		replayPayloadStore, err := volsync.NewReplayPayloadStore(cfg)
+		replayPayloadStore, err := volsync.NewReplayPayloadStore(cfg, storageProxyMetrics)
 		if err != nil {
 			zapLogger.Fatal("Failed to initialize replay payload store", zap.Error(err))
 		}
@@ -635,7 +636,7 @@ func (a *volumeContextAdapter) FlushAll(path string) error {
 }
 
 // initializeJuiceFS initializes the JuiceFS filesystem if not already initialized
-func initializeJuiceFS(cfg *config.StorageProxyConfig, logger *zap.Logger) error {
+func initializeJuiceFS(cfg *config.StorageProxyConfig, logger *zap.Logger, metrics *obsmetrics.StorageProxyMetrics) error {
 	logger.Info("Checking JuiceFS initialization status")
 
 	// Skip if essential config is missing
@@ -664,6 +665,7 @@ func initializeJuiceFS(cfg *config.StorageProxyConfig, logger *zap.Logger) error
 		EncryptionKeyPath:    cfg.JuiceFSEncryptionKeyPath,
 		EncryptionPassphrase: cfg.JuiceFSEncryptionPassphrase,
 		EncryptionAlgo:       cfg.JuiceFSEncryptionAlgo,
+		Metrics:              metrics,
 	}
 
 	initializer := juicefs.NewInitializer(initConfig, logger)

--- a/storage-proxy/pkg/juicefs/init.go
+++ b/storage-proxy/pkg/juicefs/init.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/juicedata/juicefs/pkg/meta"
 	"github.com/juicedata/juicefs/pkg/object"
+	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
 	"go.uber.org/zap"
 )
 
@@ -30,6 +31,7 @@ type InitConfig struct {
 	EncryptionKeyPath    string
 	EncryptionPassphrase string
 	EncryptionAlgo       string
+	Metrics              *obsmetrics.StorageProxyMetrics
 }
 
 // Initializer handles JuiceFS filesystem initialization
@@ -243,6 +245,7 @@ func (i *Initializer) createStorage() (object.ObjectStorage, error) {
 		AccessKey:    i.config.S3AccessKey,
 		SecretKey:    i.config.S3SecretKey,
 		SessionToken: i.config.S3SessionToken,
+		Metrics:      i.config.Metrics,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create storage client: %w", err)

--- a/storage-proxy/pkg/juicefs/object_storage.go
+++ b/storage-proxy/pkg/juicefs/object_storage.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/juicedata/juicefs/pkg/object"
+	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
 )
 
 const (
@@ -21,6 +22,7 @@ type ObjectStorageConfig struct {
 	AccessKey    string
 	SecretKey    string
 	SessionToken string
+	Metrics      *obsmetrics.StorageProxyMetrics
 }
 
 func NormalizeObjectStorageType(raw string) string {
@@ -77,5 +79,6 @@ func CreateObjectStorage(cfg ObjectStorageConfig) (object.ObjectStorage, error) 
 	if err != nil {
 		return nil, fmt.Errorf("create %s storage client: %w", storageType, err)
 	}
+	store = newObservedObjectStorage(store, storageType, cfg.Bucket, cfg.Metrics)
 	return store, nil
 }

--- a/storage-proxy/pkg/juicefs/object_storage_test.go
+++ b/storage-proxy/pkg/juicefs/object_storage_test.go
@@ -1,6 +1,16 @@
 package juicefs
 
-import "testing"
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/juicedata/juicefs/pkg/object"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
+)
 
 func TestNormalizeObjectStorageTypeMapsGCS(t *testing.T) {
 	if got := NormalizeObjectStorageType("gcs"); got != ObjectStorageTypeGCS {
@@ -35,4 +45,88 @@ func TestBuildObjectStorageEndpointForS3RequiresRegionOrEndpoint(t *testing.T) {
 	if err == nil || err.Error() != "object storage region or endpoint is required for s3" {
 		t.Fatalf("unexpected error: %v", err)
 	}
+}
+
+func TestObservedObjectStorageRecordsRequestsAndBytes(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	metrics := obsmetrics.NewStorageProxy(registry)
+	base, err := object.CreateStorage("mem", "", "", "", "")
+	if err != nil {
+		t.Fatalf("CreateStorage() error = %v", err)
+	}
+	store := newObservedObjectStorage(base, "gcs", "sandbox0-data", metrics)
+	key := "sandboxvolumes-sync/team-1/vol-1/replay/sha256/hash"
+
+	if err := store.Put(key, bytes.NewReader([]byte("hello"))); err != nil {
+		t.Fatalf("Put() error = %v", err)
+	}
+	reader, err := store.Get(key, 0, -1)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if got, err := io.ReadAll(reader); err != nil || string(got) != "hello" {
+		t.Fatalf("ReadAll() = %q, %v; want hello", string(got), err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	if got := testutil.ToFloat64(metrics.ObjectStoreRequestsTotal.WithLabelValues("gs", "sandbox0-data", "volume_sync_replay", "put", "success")); got != 1 {
+		t.Fatalf("put requests = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(metrics.ObjectStoreRequestsTotal.WithLabelValues("gs", "sandbox0-data", "volume_sync_replay", "get", "success")); got != 1 {
+		t.Fatalf("get requests = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(metrics.ObjectStoreBytesTotal.WithLabelValues("gs", "sandbox0-data", "volume_sync_replay", "put", "write")); got != 5 {
+		t.Fatalf("put bytes = %v, want 5", got)
+	}
+	if got := testutil.ToFloat64(metrics.ObjectStoreBytesTotal.WithLabelValues("gs", "sandbox0-data", "volume_sync_replay", "get", "read")); got != 5 {
+		t.Fatalf("get bytes = %v, want 5", got)
+	}
+}
+
+func TestObservedObjectStorageRecordsProviderRateLimitStatus(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	metrics := obsmetrics.NewStorageProxy(registry)
+	base, err := object.CreateStorage("mem", "", "", "", "")
+	if err != nil {
+		t.Fatalf("CreateStorage() error = %v", err)
+	}
+	store := newObservedObjectStorage(&rateLimitedObjectStore{ObjectStorage: base}, "gs", "sandbox0-data", metrics)
+
+	err = store.Put("sandboxvolumes-sync/team-1/vol-1/replay/sha256/e3b0", bytes.NewReader([]byte("x")))
+	if err == nil {
+		t.Fatal("Put() error = nil, want rate limit error")
+	}
+	if got := testutil.ToFloat64(metrics.ObjectStoreRequestsTotal.WithLabelValues("gs", "sandbox0-data", "volume_sync_replay", "put", "429")); got != 1 {
+		t.Fatalf("429 put requests = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(metrics.ObjectStoreBytesTotal.WithLabelValues("gs", "sandbox0-data", "volume_sync_replay", "put", "write")); got != 1 {
+		t.Fatalf("failed put bytes = %v, want 1", got)
+	}
+}
+
+func TestClassifyObjectStorePrefix(t *testing.T) {
+	tests := map[string]string{
+		"":                                       "none",
+		".juicefs":                               "juicefs_metadata",
+		"sandboxvolumes/team-1/vol-1/chunks/0/0": "volume_data",
+		"sandboxvolumes-sync/team-1/vol-1/replay/sha256/hash": "volume_sync_replay",
+		"sandboxvolumes-sync/team-1/vol-1/other":              "volume_sync",
+		"other/key":                                           "other",
+	}
+	for key, want := range tests {
+		if got := classifyObjectStorePrefix(key); got != want {
+			t.Fatalf("classifyObjectStorePrefix(%q) = %q, want %q", key, got, want)
+		}
+	}
+}
+
+type rateLimitedObjectStore struct {
+	object.ObjectStorage
+}
+
+func (s *rateLimitedObjectStore) Put(key string, in io.Reader, getters ...object.AttrGetter) error {
+	_, _ = io.Copy(io.Discard, in)
+	return errors.New("googleapi: Error 429: rateLimitExceeded")
 }

--- a/storage-proxy/pkg/juicefs/observed_object_storage.go
+++ b/storage-proxy/pkg/juicefs/observed_object_storage.go
@@ -1,0 +1,273 @@
+package juicefs
+
+import (
+	"errors"
+	"io"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/juicedata/juicefs/pkg/object"
+	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
+)
+
+var httpStatusPattern = regexp.MustCompile(`\b(4[0-9]{2}|5[0-9]{2})\b`)
+
+type observedObjectStorage struct {
+	object.ObjectStorage
+	provider string
+	bucket   string
+	metrics  *obsmetrics.StorageProxyMetrics
+}
+
+func newObservedObjectStorage(store object.ObjectStorage, provider, bucket string, metrics *obsmetrics.StorageProxyMetrics) object.ObjectStorage {
+	if store == nil || metrics == nil {
+		return store
+	}
+	return &observedObjectStorage{
+		ObjectStorage: store,
+		provider:      nonEmptyMetricLabel(NormalizeObjectStorageType(provider), "unknown"),
+		bucket:        nonEmptyMetricLabel(bucket, "unknown"),
+		metrics:       metrics,
+	}
+}
+
+func (s *observedObjectStorage) Create() error {
+	start := time.Now()
+	err := s.ObjectStorage.Create()
+	s.observeRequest("create", "bucket", objectStoreStatus(err), start)
+	return err
+}
+
+func (s *observedObjectStorage) Get(key string, off, limit int64, getters ...object.AttrGetter) (io.ReadCloser, error) {
+	start := time.Now()
+	prefixClass := classifyObjectStorePrefix(key)
+	reader, err := s.ObjectStorage.Get(key, off, limit, getters...)
+	if err != nil {
+		s.observeRequest("get", prefixClass, objectStoreStatus(err), start)
+		return nil, err
+	}
+	return &observedObjectReadCloser{
+		ReadCloser:  reader,
+		store:       s,
+		operation:   "get",
+		prefixClass: prefixClass,
+		start:       start,
+	}, nil
+}
+
+func (s *observedObjectStorage) Put(key string, in io.Reader, getters ...object.AttrGetter) error {
+	start := time.Now()
+	prefixClass := classifyObjectStorePrefix(key)
+	counted := &countingReader{Reader: in}
+	err := s.ObjectStorage.Put(key, counted, getters...)
+	s.observeBytes("put", prefixClass, "write", counted.bytes)
+	s.observeRequest("put", prefixClass, objectStoreStatus(err), start)
+	return err
+}
+
+func (s *observedObjectStorage) Copy(dst, src string) error {
+	start := time.Now()
+	prefixClass := classifyObjectStorePrefix(dst)
+	err := s.ObjectStorage.Copy(dst, src)
+	s.observeRequest("copy", prefixClass, objectStoreStatus(err), start)
+	return err
+}
+
+func (s *observedObjectStorage) Delete(key string, getters ...object.AttrGetter) error {
+	start := time.Now()
+	prefixClass := classifyObjectStorePrefix(key)
+	err := s.ObjectStorage.Delete(key, getters...)
+	s.observeRequest("delete", prefixClass, objectStoreStatus(err), start)
+	return err
+}
+
+func (s *observedObjectStorage) Head(key string) (object.Object, error) {
+	start := time.Now()
+	prefixClass := classifyObjectStorePrefix(key)
+	obj, err := s.ObjectStorage.Head(key)
+	s.observeRequest("head", prefixClass, objectStoreStatus(err), start)
+	return obj, err
+}
+
+func (s *observedObjectStorage) List(prefix, startAfter, token, delimiter string, limit int64, followLink bool) ([]object.Object, bool, string, error) {
+	start := time.Now()
+	prefixClass := classifyObjectStorePrefix(prefix)
+	objects, hasMore, nextToken, err := s.ObjectStorage.List(prefix, startAfter, token, delimiter, limit, followLink)
+	s.observeRequest("list", prefixClass, objectStoreStatus(err), start)
+	return objects, hasMore, nextToken, err
+}
+
+func (s *observedObjectStorage) ListAll(prefix, marker string, followLink bool) (<-chan object.Object, error) {
+	start := time.Now()
+	prefixClass := classifyObjectStorePrefix(prefix)
+	ch, err := s.ObjectStorage.ListAll(prefix, marker, followLink)
+	s.observeRequest("list_all", prefixClass, objectStoreStatus(err), start)
+	return ch, err
+}
+
+func (s *observedObjectStorage) CreateMultipartUpload(key string) (*object.MultipartUpload, error) {
+	start := time.Now()
+	prefixClass := classifyObjectStorePrefix(key)
+	upload, err := s.ObjectStorage.CreateMultipartUpload(key)
+	s.observeRequest("create_multipart_upload", prefixClass, objectStoreStatus(err), start)
+	return upload, err
+}
+
+func (s *observedObjectStorage) UploadPart(key string, uploadID string, num int, body []byte) (*object.Part, error) {
+	start := time.Now()
+	prefixClass := classifyObjectStorePrefix(key)
+	part, err := s.ObjectStorage.UploadPart(key, uploadID, num, body)
+	s.observeBytes("upload_part", prefixClass, "write", int64(len(body)))
+	s.observeRequest("upload_part", prefixClass, objectStoreStatus(err), start)
+	return part, err
+}
+
+func (s *observedObjectStorage) UploadPartCopy(key string, uploadID string, num int, srcKey string, off, size int64) (*object.Part, error) {
+	start := time.Now()
+	prefixClass := classifyObjectStorePrefix(key)
+	part, err := s.ObjectStorage.UploadPartCopy(key, uploadID, num, srcKey, off, size)
+	s.observeBytes("upload_part_copy", prefixClass, "copy", size)
+	s.observeRequest("upload_part_copy", prefixClass, objectStoreStatus(err), start)
+	return part, err
+}
+
+func (s *observedObjectStorage) AbortUpload(key string, uploadID string) {
+	start := time.Now()
+	prefixClass := classifyObjectStorePrefix(key)
+	s.ObjectStorage.AbortUpload(key, uploadID)
+	s.observeRequest("abort_upload", prefixClass, "success", start)
+}
+
+func (s *observedObjectStorage) CompleteUpload(key string, uploadID string, parts []*object.Part) error {
+	start := time.Now()
+	prefixClass := classifyObjectStorePrefix(key)
+	err := s.ObjectStorage.CompleteUpload(key, uploadID, parts)
+	s.observeRequest("complete_upload", prefixClass, objectStoreStatus(err), start)
+	return err
+}
+
+func (s *observedObjectStorage) ListUploads(marker string) ([]*object.PendingPart, string, error) {
+	start := time.Now()
+	uploads, nextMarker, err := s.ObjectStorage.ListUploads(marker)
+	s.observeRequest("list_uploads", "multipart", objectStoreStatus(err), start)
+	return uploads, nextMarker, err
+}
+
+func (s *observedObjectStorage) observeRequest(operation, prefixClass, status string, start time.Time) {
+	s.metrics.ObserveObjectStoreRequest(s.provider, s.bucket, prefixClass, operation, status, time.Since(start))
+}
+
+func (s *observedObjectStorage) observeBytes(operation, prefixClass, direction string, bytes int64) {
+	s.metrics.ObserveObjectStoreBytes(s.provider, s.bucket, prefixClass, operation, direction, bytes)
+}
+
+type countingReader struct {
+	io.Reader
+	bytes int64
+}
+
+func (r *countingReader) Read(p []byte) (int, error) {
+	n, err := r.Reader.Read(p)
+	r.bytes += int64(n)
+	return n, err
+}
+
+type observedObjectReadCloser struct {
+	io.ReadCloser
+	store       *observedObjectStorage
+	operation   string
+	prefixClass string
+	start       time.Time
+	bytes       int64
+	once        sync.Once
+}
+
+func (r *observedObjectReadCloser) Read(p []byte) (int, error) {
+	n, err := r.ReadCloser.Read(p)
+	r.bytes += int64(n)
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			r.finish("success")
+		} else {
+			r.finish(objectStoreStatus(err))
+		}
+	}
+	return n, err
+}
+
+func (r *observedObjectReadCloser) Close() error {
+	err := r.ReadCloser.Close()
+	r.finish(objectStoreStatus(err))
+	return err
+}
+
+func (r *observedObjectReadCloser) finish(status string) {
+	r.once.Do(func() {
+		r.store.observeBytes(r.operation, r.prefixClass, "read", r.bytes)
+		r.store.observeRequest(r.operation, r.prefixClass, status, r.start)
+	})
+}
+
+func objectStoreStatus(err error) string {
+	if err == nil {
+		return "success"
+	}
+
+	var httpStatus interface{ HTTPStatusCode() int }
+	if errors.As(err, &httpStatus) && httpStatus.HTTPStatusCode() > 0 {
+		return httpStatusLabel(httpStatus.HTTPStatusCode())
+	}
+
+	var statusCode interface{ StatusCode() int }
+	if errors.As(err, &statusCode) && statusCode.StatusCode() > 0 {
+		return httpStatusLabel(statusCode.StatusCode())
+	}
+
+	text := strings.ToLower(err.Error())
+	if strings.Contains(text, "ratelimitexceeded") ||
+		strings.Contains(text, "rate limit") ||
+		strings.Contains(text, "too many requests") {
+		return "429"
+	}
+	if match := httpStatusPattern.FindStringSubmatch(text); len(match) == 2 {
+		return match[1]
+	}
+	return "error"
+}
+
+func httpStatusLabel(code int) string {
+	if code >= 100 && code <= 599 {
+		return strconv.Itoa(code)
+	}
+	return "error"
+}
+
+func classifyObjectStorePrefix(key string) string {
+	value := strings.TrimLeft(strings.TrimSpace(key), "/")
+	switch {
+	case value == "":
+		return "none"
+	case value == ".juicefs" || strings.HasPrefix(value, ".juicefs-"):
+		return "juicefs_metadata"
+	case strings.HasPrefix(value, "sandboxvolumes-sync/"):
+		if strings.Contains(value, "/replay/") {
+			return "volume_sync_replay"
+		}
+		return "volume_sync"
+	case strings.HasPrefix(value, "sandboxvolumes/"):
+		return "volume_data"
+	default:
+		return "other"
+	}
+}
+
+func nonEmptyMetricLabel(value, fallback string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fallback
+	}
+	return value
+}

--- a/storage-proxy/pkg/snapshot/archive.go
+++ b/storage-proxy/pkg/snapshot/archive.go
@@ -20,6 +20,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
+	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/juicefs"
 )
@@ -257,7 +258,7 @@ func (m *Manager) openArchiveSession(_ context.Context, volume *db.SandboxVolume
 		_ = metaClient.CloseSession()
 		return nil, fmt.Errorf("build s3 prefix: %w", err)
 	}
-	obj, err := createSnapshotArchiveStorage(m.config, prefix)
+	obj, err := createSnapshotArchiveStorage(m.config, prefix, m.metrics)
 	if err != nil {
 		_ = metaClient.CloseSession()
 		return nil, err
@@ -323,7 +324,7 @@ func (m *Manager) openArchiveSession(_ context.Context, volume *db.SandboxVolume
 	}, nil
 }
 
-func createSnapshotArchiveStorage(cfg *config.StorageProxyConfig, prefix string) (object.ObjectStorage, error) {
+func createSnapshotArchiveStorage(cfg *config.StorageProxyConfig, prefix string, metrics *obsmetrics.StorageProxyMetrics) (object.ObjectStorage, error) {
 	obj, err := juicefs.CreateObjectStorage(juicefs.ObjectStorageConfig{
 		Type:         cfg.ObjectStorageType,
 		Bucket:       cfg.S3Bucket,
@@ -332,6 +333,7 @@ func createSnapshotArchiveStorage(cfg *config.StorageProxyConfig, prefix string)
 		AccessKey:    cfg.S3AccessKey,
 		SecretKey:    cfg.S3SecretKey,
 		SessionToken: cfg.S3SessionToken,
+		Metrics:      metrics,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create snapshot storage: %w", err)

--- a/storage-proxy/pkg/volsync/replay_payload_store.go
+++ b/storage-proxy/pkg/volsync/replay_payload_store.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juicedata/juicefs/pkg/object"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
+	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/juicefs"
 )
@@ -34,7 +35,7 @@ func NewObjectReplayPayloadStore(store object.ObjectStorage) replayPayloadStore 
 	return &objectReplayPayloadStore{store: store}
 }
 
-func NewReplayPayloadStore(cfg *config.StorageProxyConfig) (replayPayloadStore, error) {
+func NewReplayPayloadStore(cfg *config.StorageProxyConfig, metrics *obsmetrics.StorageProxyMetrics) (replayPayloadStore, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("storage proxy config is nil")
 	}
@@ -47,6 +48,7 @@ func NewReplayPayloadStore(cfg *config.StorageProxyConfig) (replayPayloadStore, 
 		AccessKey:    cfg.S3AccessKey,
 		SecretKey:    cfg.S3SecretKey,
 		SessionToken: cfg.S3SessionToken,
+		Metrics:      metrics,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create replay payload storage: %w", err)

--- a/storage-proxy/pkg/volume/manager.go
+++ b/storage-proxy/pkg/volume/manager.go
@@ -21,6 +21,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
+	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/juicefs"
 	"github.com/sirupsen/logrus"
 )
@@ -108,6 +109,7 @@ type Manager struct {
 	invalidates      map[string]map[string]*invalidateTracker
 	logger           *logrus.Logger
 	config           *config.StorageProxyConfig
+	metrics          *obsmetrics.StorageProxyMetrics
 	registrar        MountRegistrar // Optional: for distributed coordination
 }
 
@@ -130,6 +132,12 @@ func (m *Manager) SetMountRegistrar(registrar MountRegistrar) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.registrar = registrar
+}
+
+func (m *Manager) SetMetrics(metrics *obsmetrics.StorageProxyMetrics) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.metrics = metrics
 }
 
 // MountVolume mounts a JuiceFS volume using SDK mode (in-memory, no FUSE).
@@ -983,6 +991,7 @@ func (m *Manager) createObjectStorage(_ *VolumeConfig, prefix string, _ *meta.Fo
 		AccessKey:    m.config.S3AccessKey,
 		SecretKey:    m.config.S3SecretKey,
 		SessionToken: m.config.S3SessionToken,
+		Metrics:      m.metrics,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create object storage: %w", err)


### PR DESCRIPTION
## Summary
- Add storage_proxy_object_store_* metrics for provider request count, latency, transferred bytes, and provider status labels such as 429.
- Wrap storage-proxy object store clients at creation time so JuiceFS init, volume data, replay payload, and snapshot archive paths are observable through the same low-cardinality labels.
- Add regression tests for replay-payload prefix classification, read/write byte accounting, and provider rate-limit status extraction.

Refs #231

## Testing
- make proto
- go test ./storage-proxy/pkg/juicefs
- go test ./pkg/observability/metrics
- go test ./storage-proxy/pkg/volsync ./storage-proxy/pkg/snapshot ./storage-proxy/pkg/volume
- go test ./storage-proxy/...
- go test ./pkg/observability/...
- git push pre-push hook: make manifests, make proto, make apispec, go fmt ./..., go mod tidy, go mod vendor, golangci-lint run ./...
