### PR TITLE
fix: reduce netd platform policy log noise

### DIFF
--- a/netd/pkg/daemon/platform_policy.go
+++ b/netd/pkg/daemon/platform_policy.go
@@ -1,7 +1,10 @@
 package daemon
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"net"
+	"sort"
 	"strings"
 	"sync"
 
@@ -30,6 +33,7 @@ type platformPolicyState struct {
 	sandboxes map[string]*watcher.SandboxInfo
 	services  map[string]*watcher.ServiceInfo
 	endpoints map[string]*watcher.EndpointsInfo
+	lastHash  string
 }
 
 func newPlatformPolicyState(cfg *config.NetdConfig, store *policy.Store, logger *zap.Logger) *platformPolicyState {
@@ -158,12 +162,31 @@ func (s *platformPolicyState) rebuild() {
 	allowedCIDRs = normalizeCIDRInputs(append(allowedCIDRs, platformAllowedCIDRs...), s.logger)
 	allowedDomains = normalizeDomainInputs(append(allowedDomains, platformAllowedDomains...))
 	deniedCIDRs := normalizeCIDRInputs(platformDeniedCIDRs, s.logger)
+	deniedDomains := normalizeDomainInputs(platformDeniedDomains)
+	sort.Strings(matchedServices)
+	sort.Strings(allowedCIDRs)
+	sort.Strings(allowedDomains)
+	sort.Strings(deniedCIDRs)
+	sort.Strings(deniedDomains)
+	sandboxPodIPList := make([]string, 0, len(sandboxPodIPs))
+	for ip := range sandboxPodIPs {
+		sandboxPodIPList = append(sandboxPodIPList, ip)
+	}
+	sort.Strings(sandboxPodIPList)
+	nextHash := hashPlatformPolicyInputs(sandboxPodIPList, matchedServices, allowedCIDRs, deniedCIDRs, allowedDomains, deniedDomains)
+	s.mu.Lock()
+	if s.lastHash == nextHash {
+		s.mu.Unlock()
+		return
+	}
+	s.lastHash = nextHash
+	s.mu.Unlock()
 
 	policyRules, err := policy.BuildPlatformPolicy(
 		allowedCIDRs,
 		deniedCIDRs,
 		allowedDomains,
-		platformDeniedDomains,
+		deniedDomains,
 	)
 	if err != nil {
 		s.logger.Warn("Failed to build platform policy", zap.Error(err))
@@ -181,9 +204,21 @@ func (s *platformPolicyState) rebuild() {
 		zap.Int("allowed_cidrs", len(allowedCIDRs)),
 		zap.Int("denied_cidrs", len(deniedCIDRs)),
 		zap.Int("allowed_domains", len(allowedDomains)),
-		zap.Int("denied_domains", len(platformDeniedDomains)),
+		zap.Int("denied_domains", len(deniedDomains)),
 		zap.Strings("matched_services", matchedServices),
 	)
+}
+
+func hashPlatformPolicyInputs(parts ...[]string) string {
+	hash := sha256.New()
+	for _, values := range parts {
+		for _, value := range values {
+			_, _ = hash.Write([]byte(value))
+			_, _ = hash.Write([]byte{0})
+		}
+		_, _ = hash.Write([]byte{1})
+	}
+	return hex.EncodeToString(hash.Sum(nil))
 }
 
 func (s *platformPolicyState) snapshot() (map[string]*watcher.SandboxInfo, map[string]*watcher.ServiceInfo, map[string]*watcher.EndpointsInfo) {

--- a/netd/pkg/daemon/platform_policy_test.go
+++ b/netd/pkg/daemon/platform_policy_test.go
@@ -1,13 +1,16 @@
 package daemon
 
 import (
+	"bytes"
 	"net"
+	"strings"
 	"testing"
 
 	apiconfig "github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
 	policypkg "github.com/sandbox0-ai/sandbox0/netd/pkg/policy"
 	"github.com/sandbox0-ai/sandbox0/netd/pkg/watcher"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 func TestPlatformPolicyStateTracksSandboxPodIPs(t *testing.T) {
@@ -85,5 +88,65 @@ func TestPlatformPolicyStateAllowsClusterDNSService(t *testing.T) {
 	}
 	if !policypkg.AllowEgressL4(compiled, net.ParseIP("10.244.0.53"), 53, "udp") {
 		t.Fatalf("expected kube-dns endpoint ip to be allowed")
+	}
+}
+
+func TestPlatformPolicyStateLogsOnlyWhenEffectivePolicyChanges(t *testing.T) {
+	store := policypkg.NewStore(zap.NewNop())
+	var logBuffer bytes.Buffer
+	core := zapcore.NewCore(
+		zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
+		zapcore.AddSync(&logBuffer),
+		zap.InfoLevel,
+	)
+	logger := zap.New(core)
+	state := newPlatformPolicyState(&apiconfig.NetdConfig{}, store, logger)
+	const logPattern = "\"msg\":\"Platform policy updated\""
+	initialLogs := strings.Count(logBuffer.String(), logPattern)
+
+	sandbox := &watcher.SandboxInfo{
+		Namespace: "default",
+		Name:      "sandbox-a",
+		PodIP:     "10.0.0.2",
+	}
+	service := &watcher.ServiceInfo{
+		Namespace: "kube-system",
+		Name:      "kube-dns",
+		ClusterIP: "10.96.0.10",
+	}
+	endpoints := &watcher.EndpointsInfo{
+		Namespace: "kube-system",
+		Name:      "kube-dns",
+		Addresses: []string{"10.244.0.53"},
+	}
+
+	state.OnSandboxUpsert(sandbox)
+	if got := strings.Count(logBuffer.String(), logPattern) - initialLogs; got != 1 {
+		t.Fatalf("log count after sandbox upsert = %d, want 1", got)
+	}
+
+	state.OnSandboxUpsert(sandbox)
+	if got := strings.Count(logBuffer.String(), logPattern) - initialLogs; got != 1 {
+		t.Fatalf("log count after duplicate sandbox upsert = %d, want 1", got)
+	}
+
+	state.OnServiceUpsert(service)
+	if got := strings.Count(logBuffer.String(), logPattern) - initialLogs; got != 2 {
+		t.Fatalf("log count after service upsert = %d, want 2", got)
+	}
+
+	state.OnServiceUpsert(service)
+	if got := strings.Count(logBuffer.String(), logPattern) - initialLogs; got != 2 {
+		t.Fatalf("log count after duplicate service upsert = %d, want 2", got)
+	}
+
+	state.OnEndpointsUpsert(endpoints)
+	if got := strings.Count(logBuffer.String(), logPattern) - initialLogs; got != 3 {
+		t.Fatalf("log count after endpoints upsert = %d, want 3", got)
+	}
+
+	state.OnEndpointsUpsert(endpoints)
+	if got := strings.Count(logBuffer.String(), logPattern) - initialLogs; got != 3 {
+		t.Fatalf("log count after duplicate endpoints upsert = %d, want 3", got)
 	}
 }


### PR DESCRIPTION
## Summary
- only emit platform policy hash updates at info level when the applied hash actually changes
- drop the extra debug log path so steady-state policy sync stays quiet
- add coverage for unchanged and changed hash update cases

## Testing
- not run (change prepared earlier on this branch)