### PR TITLE
Reduce mounted volume file API overhead in procd

### DIFF
--- a/manager/procd/pkg/http/handlers/file.go
+++ b/manager/procd/pkg/http/handlers/file.go
@@ -1,30 +1,72 @@
 package handlers
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/gorilla/websocket"
 	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/file"
+	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/volume"
 	"github.com/sandbox0-ai/sandbox0/pkg/proxy"
 	"go.uber.org/zap"
 )
 
+type fileManager interface {
+	ReadFile(path string) ([]byte, error)
+	WriteFile(path string, data []byte, perm os.FileMode) error
+	Stat(path string) (*file.FileInfo, error)
+	ListDir(path string) ([]*file.FileInfo, error)
+	MakeDir(path string, perm os.FileMode, recursive bool) error
+	Move(src, dst string) error
+	Remove(path string) error
+	SubscribeWatch(path string, recursive bool, handler func(file.WatchEvent)) (*file.Watcher, func() error, error)
+	GetRootPath() string
+}
+
+type mountedPathResolver interface {
+	ResolveMountedPath(path string) (*volume.MountedPath, bool)
+}
+
+type internalTokenProvider interface {
+	GetInternalToken() string
+}
+
 // FileHandler handles file-related HTTP requests.
 type FileHandler struct {
-	manager  *file.Manager
-	logger   *zap.Logger
-	upgrader websocket.Upgrader
+	manager             fileManager
+	volumeResolver      mountedPathResolver
+	storageProxyBaseURL string
+	storageProxyPort    int
+	tokenProvider       internalTokenProvider
+	httpClient          *http.Client
+	logger              *zap.Logger
+	upgrader            websocket.Upgrader
 }
 
 // NewFileHandler creates a new file handler.
-func NewFileHandler(manager *file.Manager, logger *zap.Logger) *FileHandler {
+func NewFileHandler(manager fileManager, volumeResolver mountedPathResolver, storageProxyBaseURL string, storageProxyPort int, tokenProvider internalTokenProvider, logger *zap.Logger) *FileHandler {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
 	return &FileHandler{
-		manager: manager,
-		logger:  logger,
+		manager:             manager,
+		volumeResolver:      volumeResolver,
+		storageProxyBaseURL: storageProxyBaseURL,
+		storageProxyPort:    storageProxyPort,
+		tokenProvider:       tokenProvider,
+		httpClient:          &http.Client{},
+		logger:              logger,
 		upgrader: websocket.Upgrader{
 			ReadBufferSize:  1024,
 			WriteBufferSize: 1024,
@@ -58,16 +100,18 @@ func (h *FileHandler) Handle(w http.ResponseWriter, r *http.Request) {
 
 func (h *FileHandler) handleGet(w http.ResponseWriter, r *http.Request, path string) {
 	query := r.URL.Query()
+	if query.Has("stat") || query.Has("list") {
+		writeError(w, http.StatusBadRequest, "invalid_request", "stat/list queries are not supported")
+		return
+	}
+	if h.tryProxyMountedPath(w, r, path, "files") {
+		return
+	}
 
 	// Read file
 	data, err := h.manager.ReadFile(path)
 	if err != nil {
 		h.handleFileError(w, err)
-		return
-	}
-
-	if query.Has("stat") || query.Has("list") {
-		writeError(w, http.StatusBadRequest, "invalid_request", "stat/list queries are not supported")
 		return
 	}
 
@@ -89,6 +133,9 @@ func (h *FileHandler) Stat(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid_request", "path is required")
 		return
 	}
+	if h.tryProxyMountedPath(w, r, path, "files/stat") {
+		return
+	}
 
 	info, err := h.manager.Stat(path)
 	if err != nil {
@@ -102,6 +149,9 @@ func (h *FileHandler) List(w http.ResponseWriter, r *http.Request) {
 	path := r.URL.Query().Get("path")
 	if path == "" {
 		writeError(w, http.StatusBadRequest, "invalid_request", "path is required")
+		return
+	}
+	if h.tryProxyMountedPath(w, r, path, "files/list") {
 		return
 	}
 
@@ -125,6 +175,9 @@ func acceptsJSON(r *http.Request) bool {
 }
 
 func (h *FileHandler) handlePost(w http.ResponseWriter, r *http.Request, path string) {
+	if h.tryProxyMountedPath(w, r, path, "files") {
+		return
+	}
 	query := r.URL.Query()
 
 	if query.Get("mkdir") == "true" {
@@ -154,6 +207,9 @@ func (h *FileHandler) handlePost(w http.ResponseWriter, r *http.Request, path st
 }
 
 func (h *FileHandler) handleDelete(w http.ResponseWriter, r *http.Request, path string) {
+	if h.tryProxyMountedPath(w, r, path, "files") {
+		return
+	}
 	if err := h.manager.Remove(path); err != nil {
 		h.handleFileError(w, err)
 		return
@@ -175,6 +231,28 @@ func (h *FileHandler) Move(w http.ResponseWriter, r *http.Request) {
 
 	if req.Source == "" || req.Destination == "" {
 		writeError(w, http.StatusBadRequest, "invalid_paths", "source and destination are required")
+		return
+	}
+
+	srcMounted, srcOK := h.resolveMountedPath(req.Source)
+	dstMounted, dstOK := h.resolveMountedPath(req.Destination)
+	switch {
+	case srcOK && dstOK && srcMounted.SandboxVolumeID == dstMounted.SandboxVolumeID:
+		payload := map[string]string{
+			"source":      srcMounted.RelativePath,
+			"destination": dstMounted.RelativePath,
+		}
+		body, err := json.Marshal(payload)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "encode_failed", err.Error())
+			return
+		}
+		if err := h.proxyMountedVolumeRequest(w, r, srcMounted.SandboxVolumeID, "files/move", nil, bytes.NewReader(body)); err != nil {
+			h.handleProxyError(w, err)
+		}
+		return
+	case srcOK || dstOK:
+		writeError(w, http.StatusBadRequest, "invalid_paths", "cross-volume or mixed local-volume moves are not supported")
 		return
 	}
 
@@ -293,5 +371,141 @@ func (h *FileHandler) handleFileError(w http.ResponseWriter, err error) {
 		writeError(w, http.StatusConflict, "path_not_directory", err.Error())
 	default:
 		writeError(w, http.StatusInternalServerError, "operation_failed", err.Error())
+	}
+}
+
+func (h *FileHandler) tryProxyMountedPath(w http.ResponseWriter, r *http.Request, requestPath, endpoint string) bool {
+	mounted, ok := h.resolveMountedPath(requestPath)
+	if !ok {
+		return false
+	}
+	queryParams := r.URL.Query()
+	queryParams.Set("path", mounted.RelativePath)
+	if err := h.proxyMountedVolumeRequest(w, r, mounted.SandboxVolumeID, endpoint, queryParams, r.Body); err != nil {
+		h.handleProxyError(w, err)
+	}
+	return true
+}
+
+func (h *FileHandler) resolveMountedPath(requestPath string) (*volume.MountedPath, bool) {
+	if h.volumeResolver == nil || requestPath == "" {
+		return nil, false
+	}
+	cleanPath := filepath.Clean(requestPath)
+	if !filepath.IsAbs(cleanPath) {
+		root := "/"
+		if h.manager != nil && h.manager.GetRootPath() != "" {
+			root = h.manager.GetRootPath()
+		}
+		cleanPath = filepath.Clean(filepath.Join(root, cleanPath))
+	}
+	return h.volumeResolver.ResolveMountedPath(cleanPath)
+}
+
+func (h *FileHandler) proxyMountedVolumeRequest(w http.ResponseWriter, r *http.Request, volumeID, endpoint string, queryParams url.Values, body io.Reader) error {
+	if volumeID == "" {
+		return volume.ErrVolumeNotMounted
+	}
+	targetURL, err := h.storageProxyURL(volumeID, endpoint, queryParams)
+	if err != nil {
+		return err
+	}
+	token := ""
+	if h.tokenProvider != nil {
+		token = strings.TrimSpace(h.tokenProvider.GetInternalToken())
+	}
+	if token == "" {
+		return volume.ErrMissingInternalToken
+	}
+
+	outReq, err := http.NewRequestWithContext(r.Context(), r.Method, targetURL.String(), body)
+	if err != nil {
+		return err
+	}
+	copyProxyHeaders(outReq.Header, r.Header)
+	outReq.Header.Set("X-Internal-Token", token)
+	outReq.Host = targetURL.Host
+
+	resp, err := h.httpClient.Do(outReq)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	copyProxyHeaders(w.Header(), resp.Header)
+	w.WriteHeader(resp.StatusCode)
+	_, copyErr := io.Copy(w, resp.Body)
+	return copyErr
+}
+
+func (h *FileHandler) storageProxyURL(volumeID, endpoint string, queryParams url.Values) (*url.URL, error) {
+	baseURL := strings.TrimSpace(h.storageProxyBaseURL)
+	if baseURL == "" {
+		return nil, volume.ErrStorageProxyUnavailable
+	}
+	if !strings.Contains(baseURL, "://") {
+		baseURL = "http://" + baseURL
+	}
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, err
+	}
+	if u.Host == "" && u.Path != "" {
+		u.Host = u.Path
+		u.Path = ""
+	}
+	if h.storageProxyPort > 0 {
+		host := u.Hostname()
+		if host == "" {
+			host = u.Host
+		}
+		u.Host = net.JoinHostPort(host, strconv.Itoa(h.storageProxyPort))
+	}
+	u.Path = path.Join("/", strings.TrimPrefix(u.Path, "/"), "sandboxvolumes", volumeID, endpoint)
+	values := url.Values{}
+	for key, entries := range queryParams {
+		for _, value := range entries {
+			values.Add(key, value)
+		}
+	}
+	u.RawQuery = values.Encode()
+	return u, nil
+}
+
+func (h *FileHandler) handleProxyError(w http.ResponseWriter, err error) {
+	switch err {
+	case volume.ErrStorageProxyUnavailable:
+		writeError(w, http.StatusServiceUnavailable, "storage_proxy_unavailable", err.Error())
+	case volume.ErrMissingInternalToken:
+		writeError(w, http.StatusUnauthorized, "missing_internal_token", err.Error())
+	case volume.ErrVolumeNotMounted:
+		writeError(w, http.StatusNotFound, "volume_not_mounted", err.Error())
+	default:
+		var proxyErr *url.Error
+		if errors.As(err, &proxyErr) {
+			writeError(w, http.StatusBadGateway, "storage_proxy_request_failed", proxyErr.Error())
+			return
+		}
+		writeError(w, http.StatusBadGateway, "storage_proxy_request_failed", err.Error())
+	}
+}
+
+func copyProxyHeaders(dst, src http.Header) {
+	for key, values := range src {
+		switch {
+		case strings.EqualFold(key, "Connection"),
+			strings.EqualFold(key, "Content-Length"),
+			strings.EqualFold(key, "Keep-Alive"),
+			strings.EqualFold(key, "Proxy-Authenticate"),
+			strings.EqualFold(key, "Proxy-Authorization"),
+			strings.EqualFold(key, "TE"),
+			strings.EqualFold(key, "Trailer"),
+			strings.EqualFold(key, "Transfer-Encoding"),
+			strings.EqualFold(key, "Upgrade"):
+			continue
+		}
+		for _, value := range values {
+			dst.Add(key, value)
+		}
 	}
 }

--- a/manager/procd/pkg/http/handlers/file_test.go
+++ b/manager/procd/pkg/http/handlers/file_test.go
@@ -1,0 +1,272 @@
+package handlers
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/file"
+	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/volume"
+	"go.uber.org/zap"
+)
+
+type fakeFileManager struct {
+	rootPath   string
+	readCalls  int
+	writeCalls int
+	statCalls  int
+	moveCalls  int
+}
+
+func (m *fakeFileManager) ReadFile(string) ([]byte, error) {
+	m.readCalls++
+	return []byte("local"), nil
+}
+
+func (m *fakeFileManager) WriteFile(string, []byte, os.FileMode) error {
+	m.writeCalls++
+	return nil
+}
+
+func (m *fakeFileManager) Stat(path string) (*file.FileInfo, error) {
+	m.statCalls++
+	return &file.FileInfo{Path: path}, nil
+}
+
+func (m *fakeFileManager) ListDir(string) ([]*file.FileInfo, error) {
+	return []*file.FileInfo{{Path: "local"}}, nil
+}
+
+func (m *fakeFileManager) MakeDir(string, os.FileMode, bool) error {
+	return nil
+}
+
+func (m *fakeFileManager) Move(string, string) error {
+	m.moveCalls++
+	return nil
+}
+
+func (m *fakeFileManager) Remove(string) error {
+	return nil
+}
+
+func (m *fakeFileManager) SubscribeWatch(string, bool, func(file.WatchEvent)) (*file.Watcher, func() error, error) {
+	return &file.Watcher{ID: "watch-1"}, func() error { return nil }, nil
+}
+
+func (m *fakeFileManager) GetRootPath() string {
+	if m.rootPath == "" {
+		return "/workspace"
+	}
+	return m.rootPath
+}
+
+type fakeVolumeResolver struct {
+	paths map[string]*volume.MountedPath
+}
+
+func (r *fakeVolumeResolver) ResolveMountedPath(path string) (*volume.MountedPath, bool) {
+	if r == nil {
+		return nil, false
+	}
+	resolved, ok := r.paths[path]
+	return resolved, ok
+}
+
+type staticTokenProvider string
+
+func (p staticTokenProvider) GetInternalToken() string {
+	return string(p)
+}
+
+func newTestFileHandler(manager *fakeFileManager, resolver *fakeVolumeResolver, baseURL string) *FileHandler {
+	handler := NewFileHandler(manager, resolver, baseURL, 0, staticTokenProvider("storage-token"), zap.NewNop())
+	return handler
+}
+
+func TestFileHandlerStatProxiesMountedVolumePath(t *testing.T) {
+	storageProxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("method = %s, want GET", r.Method)
+		}
+		if got := r.Header.Get("X-Internal-Token"); got != "storage-token" {
+			t.Fatalf("X-Internal-Token = %q, want %q", got, "storage-token")
+		}
+		if got := r.URL.Path; got != "/sandboxvolumes/vol-1/files/stat" {
+			t.Fatalf("path = %q, want %q", got, "/sandboxvolumes/vol-1/files/stat")
+		}
+		if got := r.URL.Query().Get("path"); got != "/notes.txt" {
+			t.Fatalf("query path = %q, want %q", got, "/notes.txt")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"path":"/notes.txt","type":"file"}`)
+	}))
+	defer storageProxy.Close()
+
+	manager := &fakeFileManager{rootPath: "/workspace"}
+	handler := newTestFileHandler(manager, &fakeVolumeResolver{
+		paths: map[string]*volume.MountedPath{
+			"/workspace/data/notes.txt": {
+				SandboxVolumeID: "vol-1",
+				MountPoint:      "/workspace/data",
+				RelativePath:    "/notes.txt",
+			},
+		},
+	}, storageProxy.URL)
+	handler.httpClient = storageProxy.Client()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/files/stat?path=/workspace/data/notes.txt", nil)
+	recorder := httptest.NewRecorder()
+
+	handler.Stat(recorder, req)
+
+	if manager.statCalls != 0 {
+		t.Fatalf("local stat calls = %d, want 0", manager.statCalls)
+	}
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+	if got := strings.TrimSpace(recorder.Body.String()); got != `{"path":"/notes.txt","type":"file"}` {
+		t.Fatalf("body = %q", got)
+	}
+}
+
+func TestFileHandlerHandlePostProxiesMountedVolumeWrite(t *testing.T) {
+	storageProxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if got := r.URL.Path; got != "/sandboxvolumes/vol-1/files" {
+			t.Fatalf("path = %q, want %q", got, "/sandboxvolumes/vol-1/files")
+		}
+		if got := r.URL.Query().Get("path"); got != "/notes.txt" {
+			t.Fatalf("query path = %q, want %q", got, "/notes.txt")
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("ReadAll() error = %v", err)
+		}
+		if got := string(body); got != "hello" {
+			t.Fatalf("body = %q, want %q", got, "hello")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"written":true}`)
+	}))
+	defer storageProxy.Close()
+
+	manager := &fakeFileManager{rootPath: "/workspace"}
+	handler := newTestFileHandler(manager, &fakeVolumeResolver{
+		paths: map[string]*volume.MountedPath{
+			"/workspace/data/notes.txt": {
+				SandboxVolumeID: "vol-1",
+				MountPoint:      "/workspace/data",
+				RelativePath:    "/notes.txt",
+			},
+		},
+	}, storageProxy.URL)
+	handler.httpClient = storageProxy.Client()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/files?path=/workspace/data/notes.txt", strings.NewReader("hello"))
+	recorder := httptest.NewRecorder()
+
+	handler.Handle(recorder, req)
+
+	if manager.writeCalls != 0 {
+		t.Fatalf("local write calls = %d, want 0", manager.writeCalls)
+	}
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+}
+
+func TestFileHandlerMoveProxiesWhenPathsShareMountedVolume(t *testing.T) {
+	storageProxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Path; got != "/sandboxvolumes/vol-1/files/move" {
+			t.Fatalf("path = %q, want %q", got, "/sandboxvolumes/vol-1/files/move")
+		}
+		var payload map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("Decode() error = %v", err)
+		}
+		if payload["source"] != "/src.txt" || payload["destination"] != "/dst.txt" {
+			t.Fatalf("payload = %+v", payload)
+		}
+		_, _ = io.WriteString(w, `{"moved":true}`)
+	}))
+	defer storageProxy.Close()
+
+	manager := &fakeFileManager{rootPath: "/workspace"}
+	handler := newTestFileHandler(manager, &fakeVolumeResolver{
+		paths: map[string]*volume.MountedPath{
+			"/workspace/data/src.txt": {
+				SandboxVolumeID: "vol-1",
+				MountPoint:      "/workspace/data",
+				RelativePath:    "/src.txt",
+			},
+			"/workspace/data/dst.txt": {
+				SandboxVolumeID: "vol-1",
+				MountPoint:      "/workspace/data",
+				RelativePath:    "/dst.txt",
+			},
+		},
+	}, storageProxy.URL)
+	handler.httpClient = storageProxy.Client()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/files/move", strings.NewReader(`{"source":"/workspace/data/src.txt","destination":"/workspace/data/dst.txt"}`))
+	recorder := httptest.NewRecorder()
+
+	handler.Move(recorder, req)
+
+	if manager.moveCalls != 0 {
+		t.Fatalf("local move calls = %d, want 0", manager.moveCalls)
+	}
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+}
+
+func TestFileHandlerMoveRejectsMixedMountedAndLocalPaths(t *testing.T) {
+	manager := &fakeFileManager{rootPath: "/workspace"}
+	handler := newTestFileHandler(manager, &fakeVolumeResolver{
+		paths: map[string]*volume.MountedPath{
+			"/workspace/data/src.txt": {
+				SandboxVolumeID: "vol-1",
+				MountPoint:      "/workspace/data",
+				RelativePath:    "/src.txt",
+			},
+		},
+	}, "http://storage-proxy.local")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/files/move", strings.NewReader(`{"source":"/workspace/data/src.txt","destination":"/workspace/local/dst.txt"}`))
+	recorder := httptest.NewRecorder()
+
+	handler.Move(recorder, req)
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusBadRequest)
+	}
+	if manager.moveCalls != 0 {
+		t.Fatalf("local move calls = %d, want 0", manager.moveCalls)
+	}
+}
+
+func TestFileHandlerStatFallsBackToLocalFileManagerForNonMountedPath(t *testing.T) {
+	manager := &fakeFileManager{rootPath: "/workspace"}
+	handler := newTestFileHandler(manager, &fakeVolumeResolver{paths: map[string]*volume.MountedPath{}}, "http://storage-proxy.local")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/files/stat?path=/workspace/local.txt", nil)
+	recorder := httptest.NewRecorder()
+
+	handler.Stat(recorder, req)
+
+	if manager.statCalls != 1 {
+		t.Fatalf("local stat calls = %d, want 1", manager.statCalls)
+	}
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+}

--- a/manager/procd/pkg/http/server.go
+++ b/manager/procd/pkg/http/server.go
@@ -168,7 +168,14 @@ func (s *Server) setupRoutes() {
 	volumeRouter.HandleFunc("/status", volumeHandler.Status).Methods("GET")
 
 	// File handlers
-	fileHandler := handlers.NewFileHandler(s.fileManager, s.logger)
+	fileHandler := handlers.NewFileHandler(
+		s.fileManager,
+		s.volumeManager,
+		s.cfg.StorageProxyBaseURL,
+		s.cfg.StorageProxyPort,
+		s.tokenProvider,
+		s.logger,
+	)
 	api.HandleFunc("/files/watch", fileHandler.Watch).Methods("GET")
 	api.HandleFunc("/files/move", fileHandler.Move).Methods("POST")
 	api.HandleFunc("/files", fileHandler.Handle).Methods("GET", "POST", "DELETE")

--- a/manager/procd/pkg/volume/manager.go
+++ b/manager/procd/pkg/volume/manager.go
@@ -331,6 +331,48 @@ func (m *Manager) GetStatus() []MountStatus {
 	return status
 }
 
+// ResolveMountedPath returns mount metadata for an absolute sandbox path when
+// the path belongs to a mounted SandboxVolume.
+func (m *Manager) ResolveMountedPath(path string) (*MountedPath, bool) {
+	if m == nil || path == "" {
+		return nil, false
+	}
+
+	cleanPath := filepath.Clean(path)
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	var matched *mountInfo
+	for _, info := range m.mounts {
+		if info == nil || info.mountPoint == "" {
+			continue
+		}
+		if !mountedPathContains(info.mountPoint, cleanPath) {
+			continue
+		}
+		if matched == nil || len(info.mountPoint) > len(matched.mountPoint) {
+			matched = info
+		}
+	}
+	if matched == nil {
+		return nil, false
+	}
+
+	relativePath := "/"
+	if cleanPath != matched.mountPoint {
+		suffix := strings.TrimPrefix(cleanPath, matched.mountPoint)
+		suffix = strings.TrimPrefix(suffix, string(filepath.Separator))
+		relativePath = "/" + filepath.ToSlash(suffix)
+	}
+
+	return &MountedPath{
+		SandboxVolumeID: matched.volumeID,
+		MountPoint:      matched.mountPoint,
+		RelativePath:    relativePath,
+	}, true
+}
+
 func (m *Manager) runBootstrapMount(req MountRequest) {
 	if _, err := m.mount(context.Background(), &req, true); err != nil {
 		return
@@ -403,6 +445,15 @@ func mountErrorCode(err error) string {
 	default:
 		return "mount_failed"
 	}
+}
+
+func mountedPathContains(mountPoint, path string) bool {
+	cleanMount := filepath.Clean(mountPoint)
+	cleanPath := filepath.Clean(path)
+	if cleanMount == cleanPath {
+		return true
+	}
+	return strings.HasPrefix(cleanPath, cleanMount+string(filepath.Separator))
 }
 
 func (m *Manager) waitForMounts(ctx context.Context, reqs []MountRequest, waitTimeout time.Duration) []MountStatus {

--- a/manager/procd/pkg/volume/manager_test.go
+++ b/manager/procd/pkg/volume/manager_test.go
@@ -87,6 +87,50 @@ func TestJoinMountPath(t *testing.T) {
 	}
 }
 
+func TestResolveMountedPath(t *testing.T) {
+	manager := NewManager(&Config{}, nil, nil)
+	manager.mounts["vol-1"] = &mountInfo{
+		volumeID:   "vol-1",
+		mountPoint: "/workspace/data",
+	}
+	manager.mounts["vol-2"] = &mountInfo{
+		volumeID:   "vol-2",
+		mountPoint: "/workspace/data/cache",
+	}
+
+	t.Run("nested path chooses longest matching mount", func(t *testing.T) {
+		resolved, ok := manager.ResolveMountedPath("/workspace/data/cache/index.db")
+		if !ok {
+			t.Fatal("expected mounted path")
+		}
+		if resolved.SandboxVolumeID != "vol-2" {
+			t.Fatalf("SandboxVolumeID = %q, want %q", resolved.SandboxVolumeID, "vol-2")
+		}
+		if resolved.RelativePath != "/index.db" {
+			t.Fatalf("RelativePath = %q, want %q", resolved.RelativePath, "/index.db")
+		}
+	})
+
+	t.Run("exact mount root resolves to slash", func(t *testing.T) {
+		resolved, ok := manager.ResolveMountedPath("/workspace/data")
+		if !ok {
+			t.Fatal("expected mounted path")
+		}
+		if resolved.SandboxVolumeID != "vol-1" {
+			t.Fatalf("SandboxVolumeID = %q, want %q", resolved.SandboxVolumeID, "vol-1")
+		}
+		if resolved.RelativePath != "/" {
+			t.Fatalf("RelativePath = %q, want %q", resolved.RelativePath, "/")
+		}
+	})
+
+	t.Run("prefix sibling does not match mount", func(t *testing.T) {
+		if resolved, ok := manager.ResolveMountedPath("/workspace/database/file.txt"); ok {
+			t.Fatalf("unexpected mounted path: %+v", resolved)
+		}
+	})
+}
+
 func TestStatusDuration(t *testing.T) {
 	manager := NewManager(&Config{}, nil, nil)
 	now := time.Now()

--- a/manager/procd/pkg/volume/types.go
+++ b/manager/procd/pkg/volume/types.go
@@ -45,6 +45,13 @@ type MountResponse struct {
 	MountSessionID  string `json:"mount_session_id"`
 }
 
+// MountedPath describes a sandbox path owned by a mounted SandboxVolume.
+type MountedPath struct {
+	SandboxVolumeID string
+	MountPoint      string
+	RelativePath    string
+}
+
 // UnmountRequest represents a request to unmount a sandbox volume.
 type UnmountRequest struct {
 	SandboxVolumeID string `json:"sandboxvolume_id"`


### PR DESCRIPTION
## Summary
- detect when `procd` file API requests target a mounted sandbox volume path
- proxy mounted volume file reads, writes, stats, lists, and same-volume moves directly to `storage-proxy`
- keep non-volume paths on the existing local file manager path and add focused tests for mounted-path routing

Closes #238

## Testing
- `go test ./manager/procd/pkg/volume ./manager/procd/pkg/http/handlers ./manager/procd/pkg/http`
- `go test ./manager/procd/...`
