### PR TITLE
Fix GCS workload identity and stale sandbox cleanup

### DIFF
--- a/ctld/internal/ctld/power/controller.go
+++ b/ctld/internal/ctld/power/controller.go
@@ -19,6 +19,7 @@ import (
 var ErrNotImplemented = errors.New("ctld power resolver not implemented")
 var ErrSandboxNotFound = errors.New("sandbox not found")
 var ErrPodNotFound = errors.New("pod not found")
+var ErrRuntimeTargetNotFound = errors.New("runtime target not found")
 
 const defaultPauseUsageTimeout = 2 * time.Second
 

--- a/ctld/internal/ctld/power/pod_resolver.go
+++ b/ctld/internal/ctld/power/pod_resolver.go
@@ -285,7 +285,7 @@ func (r *PodResolver) findKataSandboxCgroupDir(root string) (string, error) {
 		return "", err
 	}
 	if found == "" {
-		return "", fmt.Errorf("kata sandbox cgroup not found under %s; ensure sandbox_cgroup_only=true", root)
+		return "", fmt.Errorf("%w: kata sandbox cgroup not found under %s; ensure sandbox_cgroup_only=true", ErrRuntimeTargetNotFound, root)
 	}
 	return found, nil
 }
@@ -341,7 +341,7 @@ func (r *PodResolver) validateGVisorSandboxCgroup(pod *corev1.Pod, podCgroupDir 
 	if hasRuntimeProcessesInCgroupTree(procRoot, podCgroupDir, isGVisorProcess) {
 		return nil
 	}
-	return fmt.Errorf("resolve gvisor sandbox cgroup for sandbox pod %s/%s: gvisor sandbox processes not found under %s", pod.Namespace, pod.Name, podCgroupDir)
+	return fmt.Errorf("%w: resolve gvisor sandbox cgroup for sandbox pod %s/%s: gvisor sandbox processes not found under %s", ErrRuntimeTargetNotFound, pod.Namespace, pod.Name, podCgroupDir)
 }
 
 func hasRuntimeProcessesInCgroupTree(procRoot, root string, match func(string, int) bool) bool {
@@ -566,7 +566,7 @@ func findPodCgroupDir(root, uid string) (string, error) {
 		return "", err
 	}
 	if found == "" {
-		return "", fmt.Errorf("pod cgroup not found under %s", root)
+		return "", fmt.Errorf("%w: pod cgroup not found under %s", ErrRuntimeTargetNotFound, root)
 	}
 	return found, nil
 }

--- a/ctld/internal/ctld/power/pod_resolver_test.go
+++ b/ctld/internal/ctld/power/pod_resolver_test.go
@@ -335,6 +335,7 @@ func TestPodResolverResolveRequiresGVisorSandboxProcesses(t *testing.T) {
 	resolver := NewPodResolver(client, "node-a", root)
 	_, err := resolver.Resolve(&http.Request{}, "sandbox-8")
 	require.Error(t, err)
+	require.ErrorIs(t, err, ErrRuntimeTargetNotFound)
 	assert.Contains(t, err.Error(), "gvisor sandbox processes not found")
 }
 

--- a/ctld/internal/ctld/power/reconciler.go
+++ b/ctld/internal/ctld/power/reconciler.go
@@ -3,6 +3,7 @@ package power
 import (
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -13,7 +14,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -208,7 +209,7 @@ func (r *PowerReconciler) reconcileKey(ctx context.Context, key string) error {
 		return err
 	}
 	pod, err := r.podLister.Pods(namespace).Get(name)
-	if errors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		return nil
 	}
 	if err != nil {
@@ -288,8 +289,14 @@ func (r *PowerReconciler) reconcileResume(ctx context.Context, pod *corev1.Pod, 
 }
 
 func (r *PowerReconciler) thawDeletingPod(ctx context.Context, pod *corev1.Pod) error {
+	if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
+		return nil
+	}
 	target, err := r.resolvePodTarget(pod)
-	if errors.IsNotFound(err) || errors.IsGone(err) {
+	if apierrors.IsNotFound(err) || apierrors.IsGone(err) {
+		return nil
+	}
+	if stderrors.Is(err, ErrRuntimeTargetNotFound) {
 		return nil
 	}
 	if err != nil {

--- a/ctld/internal/ctld/power/reconciler_test.go
+++ b/ctld/internal/ctld/power/reconciler_test.go
@@ -158,6 +158,33 @@ func TestPowerReconcilerResumesInFlightPauseCancellation(t *testing.T) {
 	assert.Equal(t, powerPhaseStable, state.Phase)
 }
 
+func TestPowerReconcilerIgnoresDeletingTerminalPod(t *testing.T) {
+	const uid = "pod-uid-deleting-terminal"
+	root := t.TempDir()
+	deletionTime := metav1.NewTime(time.Now())
+	pod := newReconcilerTestPod(uid, map[string]string{})
+	pod.DeletionTimestamp = &deletionTime
+	pod.Spec.RuntimeClassName = strPtr("gvisor")
+	pod.Status.Phase = corev1.PodFailed
+	client := fake.NewSimpleClientset(pod)
+	reconciler := newReconcilerForTest(client, root)
+
+	require.NoError(t, reconciler.reconcilePod(context.Background(), pod))
+}
+
+func TestPowerReconcilerIgnoresDeletingPodWhenRuntimeTargetGone(t *testing.T) {
+	const uid = "pod-uid-deleting-runtime-gone"
+	root := t.TempDir()
+	deletionTime := metav1.NewTime(time.Now())
+	pod := newReconcilerTestPod(uid, map[string]string{})
+	pod.DeletionTimestamp = &deletionTime
+	pod.Spec.RuntimeClassName = strPtr("gvisor")
+	client := fake.NewSimpleClientset(pod)
+	reconciler := newReconcilerForTest(client, root)
+
+	require.NoError(t, reconciler.reconcilePod(context.Background(), pod))
+}
+
 func newReconcilerForTest(client kubernetes.Interface, cgroupRoot string) *PowerReconciler {
 	resolver := NewPodResolver(client, "node-a", cgroupRoot)
 	controller := NewController(resolver, &cgroup.FS{SettleTimeout: 100 * time.Millisecond, PollInterval: time.Millisecond})

--- a/infra-operator/api/v1alpha1/sandbox0infra_types.go
+++ b/infra-operator/api/v1alpha1/sandbox0infra_types.go
@@ -454,6 +454,11 @@ type OSSCredentialsSecret struct {
 type GCSStorageConfig struct {
 	// Bucket specifies the GCS bucket name.
 	Bucket string `json:"bucket"`
+
+	// WorkloadIdentityServiceAccountEmail is the Google service account email
+	// used by storage clients through GKE Workload Identity.
+	// +optional
+	WorkloadIdentityServiceAccountEmail string `json:"workloadIdentityServiceAccountEmail,omitempty"`
 }
 
 // RegistryConfig defines container registry configuration.

--- a/infra-operator/chart/crds/infra.sandbox0.ai_sandbox0infras.yaml
+++ b/infra-operator/chart/crds/infra.sandbox0.ai_sandbox0infras.yaml
@@ -2864,6 +2864,11 @@ spec:
                       bucket:
                         description: Bucket specifies the GCS bucket name.
                         type: string
+                      workloadIdentityServiceAccountEmail:
+                        description: |-
+                          WorkloadIdentityServiceAccountEmail is the Google service account email
+                          used by storage clients through GKE Workload Identity.
+                        type: string
                     required:
                     - bucket
                     type: object

--- a/infra-operator/internal/controller/pkg/rbac/rbac.go
+++ b/infra-operator/internal/controller/pkg/rbac/rbac.go
@@ -19,6 +19,8 @@ package rbac
 import (
 	"context"
 	"fmt"
+	"reflect"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -30,6 +32,8 @@ import (
 	infrav1alpha1 "github.com/sandbox0-ai/sandbox0/infra-operator/api/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/pkg/common"
 )
+
+const gkeWorkloadIdentityAnnotation = "iam.gke.io/gcp-service-account"
 
 type Reconciler struct {
 	Resources *common.ResourceManager
@@ -48,7 +52,7 @@ func (r *Reconciler) ReconcileManagerRBAC(ctx context.Context, infra *infrav1alp
 		"app.kubernetes.io/managed-by": "sandbox0infra-operator",
 	}
 
-	if err := r.reconcileServiceAccount(ctx, infra, name, labels); err != nil {
+	if err := r.reconcileServiceAccount(ctx, infra, name, labels, nil); err != nil {
 		return err
 	}
 
@@ -106,7 +110,7 @@ func (r *Reconciler) ReconcileNetdRBAC(ctx context.Context, infra *infrav1alpha1
 		"app.kubernetes.io/managed-by": "sandbox0infra-operator",
 	}
 
-	if err := r.reconcileServiceAccount(ctx, infra, name, labels); err != nil {
+	if err := r.reconcileServiceAccount(ctx, infra, name, labels, nil); err != nil {
 		return err
 	}
 
@@ -139,7 +143,7 @@ func (r *Reconciler) ReconcileSchedulerRBAC(ctx context.Context, infra *infrav1a
 		"app.kubernetes.io/managed-by": "sandbox0infra-operator",
 	}
 
-	return r.reconcileServiceAccount(ctx, infra, name, labels)
+	return r.reconcileServiceAccount(ctx, infra, name, labels, nil)
 }
 
 // ReconcileStorageProxyRBAC reconciles RBAC for the storage-proxy service.
@@ -151,7 +155,7 @@ func (r *Reconciler) ReconcileStorageProxyRBAC(ctx context.Context, infra *infra
 		"app.kubernetes.io/managed-by": "sandbox0infra-operator",
 	}
 
-	if err := r.reconcileServiceAccount(ctx, infra, name, labels); err != nil {
+	if err := r.reconcileServiceAccount(ctx, infra, name, labels, storageWorkloadIdentityAnnotations(infra)); err != nil {
 		return err
 	}
 
@@ -179,7 +183,7 @@ func (r *Reconciler) ReconcileCtldRBAC(ctx context.Context, infra *infrav1alpha1
 		"app.kubernetes.io/managed-by": "sandbox0infra-operator",
 	}
 
-	if err := r.reconcileServiceAccount(ctx, infra, name, labels); err != nil {
+	if err := r.reconcileServiceAccount(ctx, infra, name, labels, storageWorkloadIdentityAnnotations(infra)); err != nil {
 		return err
 	}
 
@@ -204,12 +208,13 @@ func (r *Reconciler) ReconcileCtldRBAC(ctx context.Context, infra *infrav1alpha1
 }
 
 // reconcileServiceAccount creates or updates a ServiceAccount for a service.
-func (r *Reconciler) reconcileServiceAccount(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, name string, labels map[string]string) error {
+func (r *Reconciler) reconcileServiceAccount(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, name string, labels map[string]string, annotations map[string]string) error {
 	sa := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: infra.Namespace,
-			Labels:    labels,
+			Name:        name,
+			Namespace:   infra.Namespace,
+			Labels:      labels,
+			Annotations: annotations,
 		},
 	}
 
@@ -225,7 +230,42 @@ func (r *Reconciler) reconcileServiceAccount(ctx context.Context, infra *infrav1
 		return err
 	}
 
-	return nil
+	updated := found.DeepCopy()
+	updated.Labels = labels
+	if annotations != nil {
+		updated.Annotations = reconcileServiceAccountAnnotations(updated.Annotations, annotations)
+	}
+	if reflect.DeepEqual(found.Labels, updated.Labels) && reflect.DeepEqual(found.Annotations, updated.Annotations) {
+		return nil
+	}
+	return r.Resources.Client.Update(ctx, updated)
+}
+
+func storageWorkloadIdentityAnnotations(infra *infrav1alpha1.Sandbox0Infra) map[string]string {
+	if infra == nil || infra.Spec.Storage == nil || infra.Spec.Storage.Type != infrav1alpha1.StorageTypeGCS || infra.Spec.Storage.GCS == nil {
+		return map[string]string{}
+	}
+	email := strings.TrimSpace(infra.Spec.Storage.GCS.WorkloadIdentityServiceAccountEmail)
+	if email == "" {
+		return map[string]string{}
+	}
+	return map[string]string{gkeWorkloadIdentityAnnotation: email}
+}
+
+func reconcileServiceAccountAnnotations(current, desired map[string]string) map[string]string {
+	next := common.CloneStringMap(current)
+	if next == nil {
+		next = map[string]string{}
+	}
+	if value := strings.TrimSpace(desired[gkeWorkloadIdentityAnnotation]); value != "" {
+		next[gkeWorkloadIdentityAnnotation] = value
+	} else {
+		delete(next, gkeWorkloadIdentityAnnotation)
+	}
+	if len(next) == 0 {
+		return nil
+	}
+	return next
 }
 
 // reconcileClusterRole creates or updates a ClusterRole for a service.

--- a/infra-operator/internal/controller/pkg/rbac/rbac_test.go
+++ b/infra-operator/internal/controller/pkg/rbac/rbac_test.go
@@ -171,6 +171,42 @@ func TestReconcileCtldRBACIncludesPodReadPermissions(t *testing.T) {
 	assert.True(t, found, "expected ctld cluster role to include pod resize permissions")
 }
 
+func TestReconcileStorageClientRBACAppliesGCSWorkloadIdentity(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, rbacv1.AddToScheme(scheme))
+	require.NoError(t, infrav1alpha1.AddToScheme(scheme))
+
+	infra := &infrav1alpha1.Sandbox0Infra{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "sandbox0-system",
+		},
+		Spec: infrav1alpha1.Sandbox0InfraSpec{
+			Storage: &infrav1alpha1.StorageConfig{
+				Type: infrav1alpha1.StorageTypeGCS,
+				GCS: &infrav1alpha1.GCSStorageConfig{
+					Bucket:                              "demo-bucket",
+					WorkloadIdentityServiceAccountEmail: "storage@example.iam.gserviceaccount.com",
+				},
+			},
+		},
+	}
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(infra).Build()
+	reconciler := NewReconciler(&common.ResourceManager{Client: client, Scheme: scheme})
+
+	require.NoError(t, reconciler.ReconcileStorageProxyRBAC(context.Background(), infra))
+	require.NoError(t, reconciler.ReconcileCtldRBAC(context.Background(), infra))
+
+	storageProxySA := &corev1.ServiceAccount{}
+	require.NoError(t, client.Get(context.Background(), types.NamespacedName{Name: "demo-storage-proxy", Namespace: "sandbox0-system"}, storageProxySA))
+	assert.Equal(t, "storage@example.iam.gserviceaccount.com", storageProxySA.Annotations[gkeWorkloadIdentityAnnotation])
+
+	ctldSA := &corev1.ServiceAccount{}
+	require.NoError(t, client.Get(context.Background(), types.NamespacedName{Name: "demo-ctld", Namespace: "sandbox0-system"}, ctldSA))
+	assert.Equal(t, "storage@example.iam.gserviceaccount.com", ctldSA.Annotations[gkeWorkloadIdentityAnnotation])
+}
+
 func contains(values []string, target string) bool {
 	for _, value := range values {
 		if value == target {

--- a/infra-operator/internal/ownership/registry.go
+++ b/infra-operator/internal/ownership/registry.go
@@ -42,7 +42,7 @@ func Registry() []Entry {
 		exact("spec.storage.builtin.credentials", "storage", []string{"storage", "storage-proxy"}, nil, UpdateSemanticsCreateOnce, "Seeds the generated RustFS credentials secret."),
 		exact("spec.storage.builtin.statefulResourcePolicy", "storage", []string{"storage", "status"}, []string{"cleanup policy"}, UpdateSemanticsDeclarative, "Controls retain versus delete semantics when builtin storage is disabled."),
 		prefix("spec.storage.s3", "storage-proxy", []string{"storage", "storage-proxy"}, nil, UpdateSemanticsDeclarative, "External S3 settings are converted into storage and storage-proxy runtime config."),
-		prefix("spec.storage.gcs", "storage-proxy", []string{"storage", "storage-proxy"}, nil, UpdateSemanticsDeclarative, "External GCS settings are converted into storage and storage-proxy runtime config."),
+		prefix("spec.storage.gcs", "storage-proxy", []string{"storage", "storage-proxy", "ctld"}, nil, UpdateSemanticsDeclarative, "External GCS settings are converted into storage runtime config and storage client service accounts."),
 		prefix("spec.storage.oss", "storage-proxy", []string{"storage", "storage-proxy"}, nil, UpdateSemanticsDeclarative, "External OSS settings are converted into storage and storage-proxy runtime config."),
 
 		exact("spec.registry.provider", "plan", []string{"registry"}, []string{"InfraPlan.Components.EnableRegistry"}, UpdateSemanticsDeclarative, "Selects builtin versus external registry reconciliation."),

--- a/manager/pkg/controller/cleanup_controller.go
+++ b/manager/pkg/controller/cleanup_controller.go
@@ -14,6 +14,8 @@ import (
 	"k8s.io/client-go/tools/record"
 )
 
+const staleDeletingPodForceDeleteAfter = 10 * time.Minute
+
 // SandboxPauseRequester defines the interface for declaring that a sandbox should be paused.
 type SandboxPauseRequester interface {
 	RequestPauseSandboxByID(ctx context.Context, sandboxID string) error
@@ -144,6 +146,7 @@ func (cc *CleanupController) cleanupExpired(ctx context.Context, template *v1alp
 
 	for _, pod := range pods {
 		if pod.DeletionTimestamp != nil {
+			cc.forceDeleteStaleDeletingPod(ctx, template, pod, now)
 			continue
 		}
 
@@ -244,4 +247,42 @@ func (cc *CleanupController) cleanupExpired(ctx context.Context, template *v1alp
 	}
 
 	return nil
+}
+
+func (cc *CleanupController) forceDeleteStaleDeletingPod(ctx context.Context, template *v1alpha1.SandboxTemplate, pod *corev1.Pod, now time.Time) {
+	if pod == nil || pod.DeletionTimestamp == nil {
+		return
+	}
+	if now.Sub(pod.DeletionTimestamp.Time) < staleDeletingPodForceDeleteAfter {
+		return
+	}
+	if cc.k8sClient == nil {
+		cc.logger.Warn("Kubernetes client not configured, skipping stale deleting pod force delete",
+			zap.String("pod", pod.Name),
+			zap.Time("deletionTimestamp", pod.DeletionTimestamp.Time),
+		)
+		return
+	}
+
+	gracePeriodSeconds := int64(0)
+	uid := pod.UID
+	deleteOptions := metav1.DeleteOptions{
+		GracePeriodSeconds: &gracePeriodSeconds,
+		Preconditions: &metav1.Preconditions{
+			UID: &uid,
+		},
+	}
+	cc.logger.Warn("Force deleting stale terminating pod",
+		zap.String("pod", pod.Name),
+		zap.Time("deletionTimestamp", pod.DeletionTimestamp.Time),
+	)
+	if err := cc.k8sClient.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, deleteOptions); err != nil {
+		cc.logger.Error("Failed to force delete stale terminating pod",
+			zap.String("pod", pod.Name),
+			zap.Error(err),
+		)
+		return
+	}
+	cc.recorder.Eventf(template, corev1.EventTypeWarning, "StaleDeletingPodForceDeleted",
+		"Force deleted stale terminating pod %s", pod.Name)
 }

--- a/manager/pkg/controller/cleanup_controller_test.go
+++ b/manager/pkg/controller/cleanup_controller_test.go
@@ -10,7 +10,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
@@ -133,5 +136,57 @@ func TestCleanupExpiredSkipsDeletingPod(t *testing.T) {
 	case event := <-recorder.Events:
 		t.Fatalf("unexpected event: %s", event)
 	default:
+	}
+}
+
+func TestCleanupExpiredForceDeletesStaleDeletingPod(t *testing.T) {
+	now := time.Date(2026, time.April, 15, 19, 31, 0, 0, time.UTC)
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: "tpl-default",
+		},
+	}
+	deletedAt := metav1.NewTime(now.Add(-30 * time.Minute))
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "sandbox-1",
+			Namespace:         "tpl-default",
+			UID:               types.UID("pod-uid-1"),
+			DeletionTimestamp: &deletedAt,
+			Labels: map[string]string{
+				LabelTemplateID: "default",
+				LabelPoolType:   PoolTypeActive,
+			},
+		},
+	}
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+	})
+	require.NoError(t, indexer.Add(pod))
+
+	client := fake.NewSimpleClientset(pod)
+	recorder := record.NewFakeRecorder(1)
+	controller := NewCleanupController(
+		client,
+		corelisters.NewPodLister(indexer),
+		nil,
+		recorder,
+		staticCleanupClock{now: now},
+		nil,
+		nil,
+		zap.NewNop(),
+		time.Minute,
+	)
+
+	require.NoError(t, controller.cleanupExpired(context.Background(), template))
+
+	_, err := client.CoreV1().Pods("tpl-default").Get(context.Background(), "sandbox-1", metav1.GetOptions{})
+	require.True(t, apierrors.IsNotFound(err), "expected stale deleting pod to be force deleted, got %v", err)
+	select {
+	case event := <-recorder.Events:
+		assert.Contains(t, event, "StaleDeletingPodForceDeleted")
+	default:
+		t.Fatal("expected stale force-delete event")
 	}
 }


### PR DESCRIPTION
## Summary
- Add GCS workload identity support to Sandbox0Infra storage config and reconcile the storage-proxy/ctld service account annotations from infra-operator.
- Treat disappeared runtime cgroups as terminal for deleting pods in ctld power reconciliation.
- Force delete stale terminating sandbox pods after a conservative timeout with UID preconditions.

## Testing
- make manifests
- go test ./infra-operator/internal/controller/pkg/rbac ./infra-operator/internal/controller/services/ctld ./infra-operator/internal/controller/services/storageproxy
- go test ./infra-operator/internal/ownership
- go test ./ctld/internal/ctld/power ./manager/pkg/controller
- pre-push hook: make manifests, make proto, make apispec, go fmt ./..., go mod tidy, go mod vendor, golangci-lint run ./...