### PR TITLE
Fix SandboxVolume direct file consistency

### DIFF
--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -475,6 +475,11 @@ func (s *SandboxService) bindVolumePortal(ctx context.Context, pod *corev1.Pod, 
 	if pod == nil {
 		return nil, fmt.Errorf("pod is nil")
 	}
+	if preparer, ok := s.volumeMetadata.(SandboxVolumeBindPreparer); ok && preparer != nil {
+		if err := preparer.PrepareForBind(ctx, teamID, userID, volumeID); err != nil {
+			return nil, fmt.Errorf("prepare volume %s for ctld bind: %w", volumeID, err)
+		}
+	}
 	ctldAddress, err := s.ctldAddressForPod(ctx, pod)
 	if err != nil {
 		return nil, err

--- a/manager/pkg/service/sandbox_webhook_state.go
+++ b/manager/pkg/service/sandbox_webhook_state.go
@@ -38,6 +38,12 @@ type SandboxVolumeMetadataClient interface {
 	Get(ctx context.Context, teamID, userID, volumeID string) (*SandboxVolumeInfo, error)
 }
 
+// SandboxVolumeBindPreparer drains transient direct file owners before ctld
+// becomes the node-local owner for a sandbox volume portal.
+type SandboxVolumeBindPreparer interface {
+	PrepareForBind(ctx context.Context, teamID, userID, volumeID string) error
+}
+
 type StorageProxyVolumeClient struct {
 	baseURL        string
 	httpClient     *http.Client
@@ -55,7 +61,7 @@ type StorageProxyVolumeClientConfig struct {
 func NewStorageProxyVolumeClient(cfg StorageProxyVolumeClientConfig) *StorageProxyVolumeClient {
 	httpClient := cfg.HTTPClient
 	if httpClient == nil {
-		httpClient = &http.Client{Timeout: 10 * time.Second}
+		httpClient = &http.Client{Timeout: 35 * time.Second}
 	}
 	clusterID := strings.TrimSpace(cfg.ClusterID)
 	if clusterID == "" {
@@ -185,6 +191,46 @@ func (c *StorageProxyVolumeClient) Get(ctx context.Context, teamID, userID, volu
 		return nil, fmt.Errorf("get sandbox volume returned no id")
 	}
 	return volume, nil
+}
+
+func (c *StorageProxyVolumeClient) PrepareForBind(ctx context.Context, teamID, userID, volumeID string) error {
+	if c == nil || c.baseURL == "" {
+		return fmt.Errorf("storage-proxy volume client is not configured")
+	}
+	volumeID = strings.TrimSpace(volumeID)
+	if volumeID == "" {
+		return fmt.Errorf("volume id is required")
+	}
+	token, err := c.generateToken(teamID, userID, "")
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/internal/v1/sandboxvolumes/"+url.PathEscape(volumeID)+"/prepare-bind", nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("X-Internal-Token", token)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("prepare sandbox volume bind: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read prepare bind response: %w", err)
+	}
+	_, apiErr, err := spec.DecodeResponse[map[string]bool](bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("decode prepare bind response: %w", err)
+	}
+	if apiErr != nil {
+		return fmt.Errorf("prepare sandbox volume bind failed: %s", apiErr.Message)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("prepare sandbox volume bind failed with status %d", resp.StatusCode)
+	}
+	return nil
 }
 
 func (c *StorageProxyVolumeClient) MarkSandboxForCleanup(ctx context.Context, teamID, userID, sandboxID, reason string) error {

--- a/manager/pkg/service/sandbox_webhook_state_test.go
+++ b/manager/pkg/service/sandbox_webhook_state_test.go
@@ -44,3 +44,26 @@ func TestStorageProxyVolumeClientDefaultsClusterID(t *testing.T) {
 		t.Fatalf("clusterID = %q, want %q", gotClusterID, naming.DefaultClusterID)
 	}
 }
+
+func TestStorageProxyVolumeClientPrepareForBind(t *testing.T) {
+	var sawToken string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/internal/v1/sandboxvolumes/vol-1/prepare-bind" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		sawToken = r.Header.Get("X-Internal-Token")
+		_ = spec.WriteSuccess(w, http.StatusOK, map[string]bool{"prepared": true})
+	}))
+	defer server.Close()
+
+	client := NewStorageProxyVolumeClient(StorageProxyVolumeClientConfig{
+		BaseURL:        server.URL,
+		TokenGenerator: staticTokenGenerator{},
+	})
+	if err := client.PrepareForBind(t.Context(), "team-1", "user-1", "vol-1"); err != nil {
+		t.Fatalf("PrepareForBind returned error: %v", err)
+	}
+	if sawToken == "" {
+		t.Fatal("PrepareForBind did not send an internal token")
+	}
+}

--- a/storage-proxy/pkg/fsserver/server.go
+++ b/storage-proxy/pkg/fsserver/server.go
@@ -675,6 +675,22 @@ func (s *FileSystemServer) Open(ctx context.Context, req *pb.OpenRequest) (*pb.O
 		if err := checkS0FSAccess(node, req.Actor, s0fsOpenAccessMask(req.Flags)); err != nil {
 			return nil, err
 		}
+		if req.Flags&uint32(syscall.O_TRUNC) != 0 {
+			if err := volCtx.S0FS.Truncate(req.Inode, 0); err != nil {
+				return nil, mapS0FSError(err)
+			}
+			path := s.resolveS0FSEventPath(volCtx, req.Inode)
+			eventType := pb.WatchEventType_WATCH_EVENT_TYPE_WRITE
+			if path == "" {
+				eventType = pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE
+			}
+			s.publishEvent(ctx, &pb.WatchEvent{
+				VolumeId:  req.VolumeId,
+				EventType: eventType,
+				Path:      path,
+				Inode:     req.Inode,
+			})
+		}
 		return &pb.OpenResponse{HandleId: volCtx.OpenFileHandle(node.Inode)}, nil
 	}
 
@@ -760,9 +776,15 @@ func (s *FileSystemServer) Write(ctx context.Context, req *pb.WriteRequest) (*pb
 				return nil, mapS0FSError(err)
 			}
 			s.markDirtyWrite(req.VolumeId, req.Inode, req.HandleId)
+			path := s.resolveS0FSEventPath(volCtx, req.Inode)
+			eventType := pb.WatchEventType_WATCH_EVENT_TYPE_WRITE
+			if path == "" {
+				eventType = pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE
+			}
 			s.publishEvent(runCtx, &pb.WatchEvent{
 				VolumeId:  req.VolumeId,
-				EventType: pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE,
+				EventType: eventType,
+				Path:      path,
 				Inode:     req.Inode,
 			})
 			return &pb.WriteResponse{BytesWritten: int64(len(req.Data))}, nil
@@ -808,6 +830,7 @@ func (s *FileSystemServer) Create(ctx context.Context, req *pb.CreateRequest) (*
 			if err := ensureLazyRootPosixIdentity(volCtx, req.Actor, fsmeta.Ino(req.Parent)); err != nil {
 				return nil, fserror.New(fserror.Internal, err.Error())
 			}
+			path := s.resolveS0FSChildEventPath(volCtx, req.Parent, req.Name)
 			node, err := volCtx.S0FS.CreateFile(req.Parent, req.Name, req.Mode)
 			if err != nil {
 				return nil, mapS0FSError(err)
@@ -821,9 +844,14 @@ func (s *FileSystemServer) Create(ctx context.Context, req *pb.CreateRequest) (*
 					return nil, mapS0FSError(err)
 				}
 			}
+			eventType := pb.WatchEventType_WATCH_EVENT_TYPE_CREATE
+			if path == "" {
+				eventType = pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE
+			}
 			s.publishEvent(runCtx, &pb.WatchEvent{
 				VolumeId:  req.VolumeId,
-				EventType: pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE,
+				EventType: eventType,
+				Path:      path,
 				Inode:     node.Inode,
 			})
 			return s0fsNodeResponse(node, volCtx.OpenFileHandle(node.Inode)), nil
@@ -886,6 +914,7 @@ func (s *FileSystemServer) Mkdir(ctx context.Context, req *pb.MkdirRequest) (*pb
 			if err := ensureLazyRootPosixIdentity(volCtx, req.Actor, fsmeta.Ino(req.Parent)); err != nil {
 				return nil, fserror.New(fserror.Internal, err.Error())
 			}
+			path := s.resolveS0FSChildEventPath(volCtx, req.Parent, req.Name)
 			node, err := volCtx.S0FS.Mkdir(req.Parent, req.Name, req.Mode)
 			if err != nil {
 				return nil, mapS0FSError(err)
@@ -899,9 +928,14 @@ func (s *FileSystemServer) Mkdir(ctx context.Context, req *pb.MkdirRequest) (*pb
 					return nil, mapS0FSError(err)
 				}
 			}
+			eventType := pb.WatchEventType_WATCH_EVENT_TYPE_CREATE
+			if path == "" {
+				eventType = pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE
+			}
 			s.publishEvent(runCtx, &pb.WatchEvent{
 				VolumeId:  req.VolumeId,
-				EventType: pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE,
+				EventType: eventType,
+				Path:      path,
 				Inode:     node.Inode,
 			})
 			return s0fsNodeResponse(node, 0), nil
@@ -1009,6 +1043,7 @@ func mapErrnoToCode(errno syscall.Errno) fserror.Code {
 func (s *FileSystemServer) Unlink(ctx context.Context, req *pb.UnlinkRequest) (*pb.Empty, error) {
 	return withAuthorizedVolumeMutation(s, ctx, req.VolumeId, func(runCtx context.Context, volCtx *volume.VolumeContext) (*pb.Empty, error) {
 		if isS0FSVolume(volCtx) {
+			path := s.resolveS0FSChildEventPath(volCtx, req.Parent, req.Name)
 			inode, err := volCtx.S0FS.UnlinkWithInode(req.Parent, req.Name)
 			if err != nil {
 				return nil, mapS0FSError(err)
@@ -1016,9 +1051,14 @@ func (s *FileSystemServer) Unlink(ctx context.Context, req *pb.UnlinkRequest) (*
 			if !volCtx.MarkUnlinkedFileIfOpen(inode) {
 				_ = volCtx.S0FS.Forget(inode)
 			}
+			eventType := pb.WatchEventType_WATCH_EVENT_TYPE_REMOVE
+			if path == "" {
+				eventType = pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE
+			}
 			s.publishEvent(runCtx, &pb.WatchEvent{
 				VolumeId:  req.VolumeId,
-				EventType: pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE,
+				EventType: eventType,
+				Path:      path,
 			})
 			return &pb.Empty{}, nil
 		}
@@ -1172,12 +1212,20 @@ func (s *FileSystemServer) ReleaseDir(ctx context.Context, req *pb.ReleaseDirReq
 func (s *FileSystemServer) Rename(ctx context.Context, req *pb.RenameRequest) (*pb.Empty, error) {
 	return withAuthorizedVolumeMutation(s, ctx, req.VolumeId, func(runCtx context.Context, volCtx *volume.VolumeContext) (*pb.Empty, error) {
 		if isS0FSVolume(volCtx) {
+			oldPath := s.resolveS0FSChildEventPath(volCtx, req.OldParent, req.OldName)
+			newPath := s.resolveS0FSChildEventPath(volCtx, req.NewParent, req.NewName)
 			if err := volCtx.S0FS.Rename(req.OldParent, req.OldName, req.NewParent, req.NewName); err != nil {
 				return nil, mapS0FSError(err)
 			}
+			eventType := pb.WatchEventType_WATCH_EVENT_TYPE_RENAME
+			if oldPath == "" && newPath == "" {
+				eventType = pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE
+			}
 			s.publishEvent(runCtx, &pb.WatchEvent{
 				VolumeId:  req.VolumeId,
-				EventType: pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE,
+				EventType: eventType,
+				Path:      newPath,
+				OldPath:   oldPath,
 			})
 			return &pb.Empty{}, nil
 		}
@@ -1230,6 +1278,7 @@ func (s *FileSystemServer) SetAttr(ctx context.Context, req *pb.SetAttrRequest) 
 			if attr == nil {
 				attr = &pb.GetAttrResponse{}
 			}
+			path := s.resolveS0FSEventPath(volCtx, req.Inode)
 			if req.Valid&uint32(fsmeta.SetAttrMode) != 0 {
 				if err := volCtx.S0FS.SetMode(req.Inode, attr.Mode&0o7777); err != nil {
 					return nil, mapS0FSError(err)
@@ -1261,9 +1310,16 @@ func (s *FileSystemServer) SetAttr(ctx context.Context, req *pb.SetAttrRequest) 
 			if err != nil {
 				return nil, mapS0FSError(err)
 			}
+			eventType := pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE
+			if req.Valid&uint32(fsmeta.SetAttrMode) != 0 && path != "" {
+				eventType = pb.WatchEventType_WATCH_EVENT_TYPE_CHMOD
+			} else if path != "" {
+				eventType = pb.WatchEventType_WATCH_EVENT_TYPE_WRITE
+			}
 			s.publishEvent(runCtx, &pb.WatchEvent{
 				VolumeId:  req.VolumeId,
-				EventType: pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE,
+				EventType: eventType,
+				Path:      path,
 				Inode:     req.Inode,
 			})
 			return &pb.SetAttrResponse{Attr: s0fsAttr(updated)}, nil
@@ -1453,12 +1509,18 @@ func (s *FileSystemServer) Release(ctx context.Context, req *pb.ReleaseRequest) 
 func (s *FileSystemServer) Rmdir(ctx context.Context, req *pb.RmdirRequest) (*pb.Empty, error) {
 	return withAuthorizedVolumeMutation(s, ctx, req.VolumeId, func(runCtx context.Context, volCtx *volume.VolumeContext) (*pb.Empty, error) {
 		if isS0FSVolume(volCtx) {
+			path := s.resolveS0FSChildEventPath(volCtx, req.Parent, req.Name)
 			if err := volCtx.S0FS.RemoveDir(req.Parent, req.Name); err != nil {
 				return nil, mapS0FSError(err)
 			}
+			eventType := pb.WatchEventType_WATCH_EVENT_TYPE_REMOVE
+			if path == "" {
+				eventType = pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE
+			}
 			s.publishEvent(runCtx, &pb.WatchEvent{
 				VolumeId:  req.VolumeId,
-				EventType: pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE,
+				EventType: eventType,
+				Path:      path,
 			})
 			return &pb.Empty{}, nil
 		}
@@ -1552,6 +1614,7 @@ func (s *FileSystemServer) Symlink(ctx context.Context, req *pb.SymlinkRequest) 
 			if err := ensureLazyRootPosixIdentity(volCtx, req.Actor, fsmeta.Ino(req.Parent)); err != nil {
 				return nil, fserror.New(fserror.Internal, err.Error())
 			}
+			path := s.resolveS0FSChildEventPath(volCtx, req.Parent, req.Name)
 			node, err := volCtx.S0FS.Symlink(req.Parent, req.Name, req.Target, 0o777)
 			if err != nil {
 				return nil, mapS0FSError(err)
@@ -1565,9 +1628,14 @@ func (s *FileSystemServer) Symlink(ctx context.Context, req *pb.SymlinkRequest) 
 					return nil, mapS0FSError(err)
 				}
 			}
+			eventType := pb.WatchEventType_WATCH_EVENT_TYPE_CREATE
+			if path == "" {
+				eventType = pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE
+			}
 			s.publishEvent(runCtx, &pb.WatchEvent{
 				VolumeId:  req.VolumeId,
-				EventType: pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE,
+				EventType: eventType,
+				Path:      path,
 				Inode:     node.Inode,
 			})
 			return s0fsNodeResponse(node, 0), nil
@@ -2098,6 +2166,70 @@ func resolveInodePath(volCtx *volume.VolumeContext, inode uint64) string {
 		return ""
 	}
 	return trimVolumeRoot(volCtx, paths[0])
+}
+
+func (s *FileSystemServer) resolveS0FSEventPath(volCtx *volume.VolumeContext, inode uint64) string {
+	if s == nil || (s.eventBroadcaster == nil && s.syncRecorder == nil) {
+		return ""
+	}
+	return resolveS0FSInodePath(volCtx, inode)
+}
+
+func (s *FileSystemServer) resolveS0FSChildEventPath(volCtx *volume.VolumeContext, parent uint64, name string) string {
+	if s == nil || (s.eventBroadcaster == nil && s.syncRecorder == nil) {
+		return ""
+	}
+	parentPath := resolveS0FSInodePath(volCtx, parent)
+	if parentPath == "" || name == "" {
+		return ""
+	}
+	if parentPath == "/" {
+		return "/" + name
+	}
+	return parentPath + "/" + name
+}
+
+func resolveS0FSInodePath(volCtx *volume.VolumeContext, inode uint64) string {
+	if volCtx == nil || volCtx.S0FS == nil || inode == 0 {
+		return ""
+	}
+	if inode == s0fs.RootInode {
+		return "/"
+	}
+	state, err := volCtx.S0FS.ExportState()
+	if err != nil || state == nil {
+		return ""
+	}
+	visited := make(map[uint64]struct{})
+	var walk func(parent uint64, parentPath string) (string, bool)
+	walk = func(parent uint64, parentPath string) (string, bool) {
+		if _, ok := visited[parent]; ok {
+			return "", false
+		}
+		visited[parent] = struct{}{}
+		for name, child := range state.Children[parent] {
+			childPath := parentPath + "/" + name
+			if parentPath == "/" {
+				childPath = "/" + name
+			}
+			if child == inode {
+				return childPath, true
+			}
+			node := state.Nodes[child]
+			if node == nil || node.Type != s0fs.TypeDirectory {
+				continue
+			}
+			if path, ok := walk(child, childPath); ok {
+				return path, true
+			}
+		}
+		return "", false
+	}
+	path, ok := walk(s0fs.RootInode, "/")
+	if !ok {
+		return ""
+	}
+	return path
 }
 
 func resolveChildPath(volCtx *volume.VolumeContext, parent uint64, name string) string {

--- a/storage-proxy/pkg/fsserver/server_s0fs_test.go
+++ b/storage-proxy/pkg/fsserver/server_s0fs_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/fserror"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/fsmeta"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/notify"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/router"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/s0fs"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volume"
@@ -187,6 +188,154 @@ func TestS0FSDirectoryAndSetAttr(t *testing.T) {
 		Name:     "dir",
 	}); err != nil {
 		t.Fatalf("Rmdir() error = %v", err)
+	}
+}
+
+func TestS0FSOpenTruncateShrinksExistingFile(t *testing.T) {
+	t.Parallel()
+
+	volCtx := newMountedS0FSVolumeContext(t, "vol-1", "team-a")
+	server := newTestFileSystemServer(&fakeVolumeManager{
+		volumes: map[string]*volume.VolumeContext{
+			"vol-1": volCtx,
+		},
+	}, nil, nil)
+	ctx := authContext("team-a", "")
+
+	createResp, err := server.Create(ctx, &pb.CreateRequest{
+		VolumeId: "vol-1",
+		Parent:   1,
+		Name:     "overwrite.txt",
+		Mode:     0o644,
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if _, err := server.Write(ctx, &pb.WriteRequest{
+		VolumeId: "vol-1",
+		Inode:    createResp.Inode,
+		Offset:   0,
+		Data:     []byte("abcdef"),
+		HandleId: createResp.HandleId,
+	}); err != nil {
+		t.Fatalf("Write(initial) error = %v", err)
+	}
+	if _, err := server.Release(ctx, &pb.ReleaseRequest{
+		VolumeId: "vol-1",
+		Inode:    createResp.Inode,
+		HandleId: createResp.HandleId,
+	}); err != nil {
+		t.Fatalf("Release(initial) error = %v", err)
+	}
+
+	openResp, err := server.Open(ctx, &pb.OpenRequest{
+		VolumeId: "vol-1",
+		Inode:    createResp.Inode,
+		Flags:    uint32(syscall.O_WRONLY | syscall.O_TRUNC),
+	})
+	if err != nil {
+		t.Fatalf("Open(O_TRUNC) error = %v", err)
+	}
+	if _, err := server.Write(ctx, &pb.WriteRequest{
+		VolumeId: "vol-1",
+		Inode:    createResp.Inode,
+		Offset:   0,
+		Data:     []byte("xy"),
+		HandleId: openResp.HandleId,
+	}); err != nil {
+		t.Fatalf("Write(overwrite) error = %v", err)
+	}
+	if _, err := server.Release(ctx, &pb.ReleaseRequest{
+		VolumeId: "vol-1",
+		Inode:    createResp.Inode,
+		HandleId: openResp.HandleId,
+	}); err != nil {
+		t.Fatalf("Release(overwrite) error = %v", err)
+	}
+
+	attr, err := server.GetAttr(ctx, &pb.GetAttrRequest{
+		VolumeId: "vol-1",
+		Inode:    createResp.Inode,
+	})
+	if err != nil {
+		t.Fatalf("GetAttr() error = %v", err)
+	}
+	if attr.Size != 2 {
+		t.Fatalf("size after overwrite = %d, want 2", attr.Size)
+	}
+	readResp, err := server.Read(ctx, &pb.ReadRequest{
+		VolumeId: "vol-1",
+		Inode:    createResp.Inode,
+		Offset:   0,
+		Size:     16,
+	})
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if !bytes.Equal(readResp.Data, []byte("xy")) {
+		t.Fatalf("Read() data = %q, want xy", readResp.Data)
+	}
+}
+
+func TestS0FSWritePublishesResolvedWatchPath(t *testing.T) {
+	t.Parallel()
+
+	volCtx := newMountedS0FSVolumeContext(t, "vol-1", "team-a")
+	hub := notify.NewHub(nil, 16)
+	server := newTestFileSystemServer(&fakeVolumeManager{
+		volumes: map[string]*volume.VolumeContext{
+			"vol-1": volCtx,
+		},
+	}, nil, hub)
+	ctx := authContext("team-a", "")
+
+	dirResp, err := server.Mkdir(ctx, &pb.MkdirRequest{
+		VolumeId: "vol-1",
+		Parent:   1,
+		Name:     "dir",
+		Mode:     0o755,
+	})
+	if err != nil {
+		t.Fatalf("Mkdir() error = %v", err)
+	}
+	createResp, err := server.Create(ctx, &pb.CreateRequest{
+		VolumeId: "vol-1",
+		Parent:   dirResp.Inode,
+		Name:     "watch.txt",
+		Mode:     0o644,
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	_, events, cancel := hub.Subscribe(&pb.WatchRequest{
+		VolumeId:    "vol-1",
+		PathPrefix:  "/dir",
+		Recursive:   true,
+		IncludeSelf: true,
+	})
+	defer cancel()
+
+	if _, err := server.Write(ctx, &pb.WriteRequest{
+		VolumeId: "vol-1",
+		Inode:    createResp.Inode,
+		Offset:   0,
+		Data:     []byte("payload"),
+		HandleId: createResp.HandleId,
+	}); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	select {
+	case event := <-events:
+		if event.EventType != pb.WatchEventType_WATCH_EVENT_TYPE_WRITE {
+			t.Fatalf("event type = %v, want write", event.EventType)
+		}
+		if event.Path != "/dir/watch.txt" {
+			t.Fatalf("event path = %q, want /dir/watch.txt", event.Path)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for watch event")
 	}
 }
 

--- a/storage-proxy/pkg/http/handlers_sandboxvolume.go
+++ b/storage-proxy/pkg/http/handlers_sandboxvolume.go
@@ -353,6 +353,72 @@ func (s *Server) deleteSandboxVolumeRecord(ctx context.Context, id string, force
 	return vol, nil
 }
 
+func (s *Server) prepareSandboxVolumeBind(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		_ = spec.WriteError(w, http.StatusBadRequest, spec.CodeBadRequest, "id is required")
+		return
+	}
+	if _, err := s.loadAuthorizedVolume(r.Context(), id); err != nil {
+		s.writeVolumeFileError(w, err)
+		return
+	}
+
+	if r.Header.Get(volumeFileAffinityRoutedPodHeader) == "" {
+		targetURL, ownerPodID, err := s.resolveRemoteVolumeOwnerURL(r.Context(), id)
+		if err != nil {
+			s.writeVolumeFileError(w, err)
+			return
+		}
+		if targetURL != nil {
+			s.proxyVolumeRequestToOwner(w, r, targetURL, ownerPodID)
+			return
+		}
+	}
+
+	if s.volMgr == nil {
+		s.writeVolumeFileError(w, errVolumeFileUnavailable)
+		return
+	}
+
+	deadline := time.NewTimer(30 * time.Second)
+	defer deadline.Stop()
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		cleaned, err := s.volMgr.CleanupIdleDirectVolumeFileMount(r.Context(), id)
+		if err != nil {
+			s.logger.WithError(err).WithField("volume_id", id).Warn("Failed to cleanup direct volume mount before bind")
+			s.writeVolumeFileError(w, err)
+			return
+		}
+		mounts, err := s.repo.GetActiveMounts(r.Context(), id, 15)
+		if err != nil {
+			s.logger.WithError(err).WithField("volume_id", id).Error("Failed to check active mounts before bind")
+			_ = spec.WriteError(w, http.StatusInternalServerError, spec.CodeInternal, "failed to check active mounts")
+			return
+		}
+		if len(mounts) == 0 {
+			_ = spec.WriteSuccess(w, http.StatusOK, map[string]bool{"prepared": true})
+			return
+		}
+		if cleaned {
+			continue
+		}
+
+		select {
+		case <-r.Context().Done():
+			_ = spec.WriteError(w, http.StatusServiceUnavailable, spec.CodeUnavailable, r.Context().Err().Error())
+			return
+		case <-deadline.C:
+			_ = spec.WriteError(w, http.StatusConflict, spec.CodeConflict, "volume has active direct file operations")
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
 func (s *Server) isOwnedSandboxVolume(ctx context.Context, id string) bool {
 	if s == nil || s.repo == nil {
 		return false

--- a/storage-proxy/pkg/http/handlers_volume_files_test.go
+++ b/storage-proxy/pkg/http/handlers_volume_files_test.go
@@ -651,6 +651,68 @@ func TestHandleVolumeFileStatPrefersLocalOwnerPod(t *testing.T) {
 	}
 }
 
+func TestHandleVolumeFileStatReleasesDirectMountAfterRequest(t *testing.T) {
+	fileRPC := &fakeHTTPVolumeFileRPC{
+		lookupFunc: func(_ context.Context, req *pb.LookupRequest) (*pb.NodeResponse, error) {
+			if req.Parent == 1 && req.Name == "report.txt" {
+				return &pb.NodeResponse{Inode: 3, Attr: volumeFileAttr(12)}, nil
+			}
+			return nil, fserror.New(fserror.NotFound, "missing")
+		},
+	}
+	server, volMgr := newVolumeFileTestServer(fileRPC)
+
+	req := httptest.NewRequest(http.MethodGet, "/sandboxvolumes/vol-1/files/stat?path=/report.txt", nil)
+	req.SetPathValue("id", "vol-1")
+	req = req.WithContext(internalauth.WithClaims(req.Context(), &internalauth.Claims{TeamID: "team-a"}))
+	recorder := httptest.NewRecorder()
+
+	server.handleVolumeFileStat(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+	if volMgr.releaseCalls != 1 {
+		t.Fatalf("release calls = %d, want 1", volMgr.releaseCalls)
+	}
+	if volMgr.cleanupCalls != 1 || volMgr.lastCleanupVolume != "vol-1" {
+		t.Fatalf("cleanup = (%d, %q), want (1, vol-1)", volMgr.cleanupCalls, volMgr.lastCleanupVolume)
+	}
+}
+
+func TestPrepareSandboxVolumeBindCleansLocalDirectOwner(t *testing.T) {
+	fileRPC := &fakeHTTPVolumeFileRPC{}
+	server, volMgr := newVolumeFileTestServer(fileRPC)
+	repo := server.repo.(*fakeHTTPRepo)
+	repo.activeMounts["vol-1"] = []*db.VolumeMount{{
+		VolumeID:  "vol-1",
+		ClusterID: "cluster-a",
+		PodID:     "local-pod",
+		MountedAt: time.Unix(20, 0),
+	}}
+	volMgr.cleanupDirectFunc = func(_ context.Context, volumeID string) (bool, error) {
+		delete(repo.activeMounts, volumeID)
+		return true, nil
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/internal/v1/sandboxvolumes/vol-1/prepare-bind", nil)
+	req.SetPathValue("id", "vol-1")
+	req = req.WithContext(internalauth.WithClaims(req.Context(), &internalauth.Claims{TeamID: "team-a"}))
+	recorder := httptest.NewRecorder()
+
+	server.prepareSandboxVolumeBind(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+	if volMgr.cleanupCalls != 1 || volMgr.lastCleanupVolume != "vol-1" {
+		t.Fatalf("cleanup = (%d, %q), want (1, vol-1)", volMgr.cleanupCalls, volMgr.lastCleanupVolume)
+	}
+	if len(repo.activeMounts["vol-1"]) != 0 {
+		t.Fatalf("active mounts after prepare = %+v, want empty", repo.activeMounts["vol-1"])
+	}
+}
+
 func TestPrepareOrProxyVolumeFileRequestReroutesAfterMountConflict(t *testing.T) {
 	remoteSeen := make(chan struct{}, 1)
 	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/storage-proxy/pkg/http/server.go
+++ b/storage-proxy/pkg/http/server.go
@@ -178,6 +178,7 @@ func NewServer(logger *logrus.Logger, cfg *config.StorageProxyConfig, k8sClient 
 	s.mux.HandleFunc("PUT /internal/v1/sandboxvolumes/owned/cleanup", s.markOwnedSandboxVolumesForCleanup)
 	s.mux.HandleFunc("PUT /internal/v1/sandboxvolumes/owned/{id}/cleanup-attempt", s.markOwnedSandboxVolumeCleanupAttempt)
 	s.mux.HandleFunc("DELETE /internal/v1/sandboxvolumes/owned/{id}", s.deleteOwnedSandboxVolume)
+	s.mux.HandleFunc("POST /internal/v1/sandboxvolumes/{id}/prepare-bind", s.prepareSandboxVolumeBind)
 
 	// Snapshot handlers
 	s.mux.HandleFunc("POST /sandboxvolumes/{volume_id}/snapshots", s.createSnapshot)

--- a/storage-proxy/pkg/http/volume_affinity.go
+++ b/storage-proxy/pkg/http/volume_affinity.go
@@ -185,7 +185,14 @@ func (s *Server) prepareVolumeFileMount(ctx context.Context, volumeID string) (f
 			return func() {}, err
 		}
 	}
-	return cleanup, nil
+	return func() {
+		cleanup()
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if _, err := s.volMgr.CleanupIdleDirectVolumeFileMount(cleanupCtx, volumeID); err != nil && s.logger != nil {
+			s.logger.WithError(err).WithField("volume_id", volumeID).Warn("Failed to release direct volume file mount after request")
+		}
+	}, nil
 }
 
 func (s *Server) proxyVolumeRequestToOwnerIfNeeded(w http.ResponseWriter, r *http.Request, volumeID string) (bool, error) {

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -1823,6 +1823,15 @@ func assertVolumeLifecycle(env *framework.ScenarioEnv, session *e2eutils.Session
 	Expect(status).To(Equal(http.StatusOK))
 	Expect(directBody).To(Equal(directContent))
 
+	overwriteContent := []byte("short")
+	status, err = session.WriteVolumeFile(env.TestCtx.Context, GinkgoT(), volumeID, directFilePath, overwriteContent, "")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+	overwrittenBody, status, err := session.ReadVolumeFile(env.TestCtx.Context, GinkgoT(), volumeID, directFilePath)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+	Expect(overwrittenBody).To(Equal(overwriteContent))
+
 	snapReq := apispec.CreateSnapshotRequest{
 		Name: "e2e-snap",
 	}


### PR DESCRIPTION
Closes #247

## Summary
- drain transient storage-proxy direct volume mounts before manager binds a SandboxVolume into ctld
- release direct file mounts after each HTTP direct file request so storage-proxy does not remain the RWO owner
- make S0FS honor O_TRUNC and publish resolved watch paths for S0FS file events
- add focused unit tests plus an e2e assertion for direct file overwrite truncation

## Tests
- make proto
- go test ./manager/pkg/service ./storage-proxy/pkg/fsserver ./storage-proxy/pkg/http ./ctld/internal/ctld/portal ./tests/e2e/cases
- go test ./... (fails only when local e2e tries to create kind: Docker daemon unavailable at unix:///var/run/docker.sock)
