### PR TITLE
Fix SandboxVolume direct file consistency

### DIFF
--- a/storage-proxy/pkg/fsserver/server.go
+++ b/storage-proxy/pkg/fsserver/server.go
@@ -665,17 +665,12 @@ func (s *FileSystemServer) Open(ctx context.Context, req *pb.OpenRequest) (*pb.O
 		return nil, err
 	}
 	if isS0FSVolume(volCtx) {
-		node, err := volCtx.S0FS.GetAttr(req.Inode)
-		if err != nil {
-			return nil, mapS0FSError(err)
+		if req.Flags&uint32(syscall.O_TRUNC) != 0 {
+			return withAuthorizedVolumeMutation(s, ctx, req.VolumeId, func(runCtx context.Context, volCtx *volume.VolumeContext) (*pb.OpenResponse, error) {
+				return s.openS0FS(runCtx, volCtx, req)
+			})
 		}
-		if node.Type == s0fs.TypeDirectory {
-			return nil, fserror.New(fserror.FailedPrecondition, "inode is a directory")
-		}
-		if err := checkS0FSAccess(node, req.Actor, s0fsOpenAccessMask(req.Flags)); err != nil {
-			return nil, err
-		}
-		return &pb.OpenResponse{HandleId: volCtx.OpenFileHandle(node.Inode)}, nil
+		return s.openS0FS(ctx, volCtx, req)
 	}
 
 	inode := mapInode(volCtx, req.Inode)
@@ -760,9 +755,15 @@ func (s *FileSystemServer) Write(ctx context.Context, req *pb.WriteRequest) (*pb
 				return nil, mapS0FSError(err)
 			}
 			s.markDirtyWrite(req.VolumeId, req.Inode, req.HandleId)
-			s.publishEvent(runCtx, &pb.WatchEvent{
+			path := resolveInodePath(volCtx, req.Inode)
+			eventType := pb.WatchEventType_WATCH_EVENT_TYPE_WRITE
+			if path == "" {
+				eventType = pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE
+			}
+			s.publishEvent(suppressSyncRecord(runCtx), &pb.WatchEvent{
 				VolumeId:  req.VolumeId,
-				EventType: pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE,
+				EventType: eventType,
+				Path:      path,
 				Inode:     req.Inode,
 			})
 			return &pb.WriteResponse{BytesWritten: int64(len(req.Data))}, nil
@@ -808,6 +809,7 @@ func (s *FileSystemServer) Create(ctx context.Context, req *pb.CreateRequest) (*
 			if err := ensureLazyRootPosixIdentity(volCtx, req.Actor, fsmeta.Ino(req.Parent)); err != nil {
 				return nil, fserror.New(fserror.Internal, err.Error())
 			}
+			path := resolveChildPath(volCtx, req.Parent, req.Name)
 			node, err := volCtx.S0FS.CreateFile(req.Parent, req.Name, req.Mode)
 			if err != nil {
 				return nil, mapS0FSError(err)
@@ -821,9 +823,17 @@ func (s *FileSystemServer) Create(ctx context.Context, req *pb.CreateRequest) (*
 					return nil, mapS0FSError(err)
 				}
 			}
+			if path == "" {
+				path = resolveInodePath(volCtx, node.Inode)
+			}
+			eventType := pb.WatchEventType_WATCH_EVENT_TYPE_CREATE
+			if path == "" {
+				eventType = pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE
+			}
 			s.publishEvent(runCtx, &pb.WatchEvent{
 				VolumeId:  req.VolumeId,
-				EventType: pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE,
+				EventType: eventType,
+				Path:      path,
 				Inode:     node.Inode,
 			})
 			return s0fsNodeResponse(node, volCtx.OpenFileHandle(node.Inode)), nil
@@ -886,6 +896,7 @@ func (s *FileSystemServer) Mkdir(ctx context.Context, req *pb.MkdirRequest) (*pb
 			if err := ensureLazyRootPosixIdentity(volCtx, req.Actor, fsmeta.Ino(req.Parent)); err != nil {
 				return nil, fserror.New(fserror.Internal, err.Error())
 			}
+			path := resolveChildPath(volCtx, req.Parent, req.Name)
 			node, err := volCtx.S0FS.Mkdir(req.Parent, req.Name, req.Mode)
 			if err != nil {
 				return nil, mapS0FSError(err)
@@ -899,9 +910,17 @@ func (s *FileSystemServer) Mkdir(ctx context.Context, req *pb.MkdirRequest) (*pb
 					return nil, mapS0FSError(err)
 				}
 			}
+			if path == "" {
+				path = resolveInodePath(volCtx, node.Inode)
+			}
+			eventType := pb.WatchEventType_WATCH_EVENT_TYPE_CREATE
+			if path == "" {
+				eventType = pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE
+			}
 			s.publishEvent(runCtx, &pb.WatchEvent{
 				VolumeId:  req.VolumeId,
-				EventType: pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE,
+				EventType: eventType,
+				Path:      path,
 				Inode:     node.Inode,
 			})
 			return s0fsNodeResponse(node, 0), nil
@@ -1005,10 +1024,41 @@ func mapErrnoToCode(errno syscall.Errno) fserror.Code {
 	}
 }
 
+func (s *FileSystemServer) openS0FS(ctx context.Context, volCtx *volume.VolumeContext, req *pb.OpenRequest) (*pb.OpenResponse, error) {
+	node, err := volCtx.S0FS.GetAttr(req.Inode)
+	if err != nil {
+		return nil, mapS0FSError(err)
+	}
+	if node.Type == s0fs.TypeDirectory {
+		return nil, fserror.New(fserror.FailedPrecondition, "inode is a directory")
+	}
+	if err := checkS0FSAccess(node, req.Actor, s0fsOpenAccessMask(req.Flags)); err != nil {
+		return nil, err
+	}
+	if req.Flags&uint32(syscall.O_TRUNC) != 0 {
+		if err := volCtx.S0FS.Truncate(req.Inode, 0); err != nil {
+			return nil, mapS0FSError(err)
+		}
+		path := resolveInodePath(volCtx, req.Inode)
+		eventType := pb.WatchEventType_WATCH_EVENT_TYPE_WRITE
+		if path == "" {
+			eventType = pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE
+		}
+		s.publishEvent(suppressSyncRecord(ctx), &pb.WatchEvent{
+			VolumeId:  req.VolumeId,
+			EventType: eventType,
+			Path:      path,
+			Inode:     req.Inode,
+		})
+	}
+	return &pb.OpenResponse{HandleId: volCtx.OpenFileHandle(node.Inode)}, nil
+}
+
 // Unlink implements FUSE unlink
 func (s *FileSystemServer) Unlink(ctx context.Context, req *pb.UnlinkRequest) (*pb.Empty, error) {
 	return withAuthorizedVolumeMutation(s, ctx, req.VolumeId, func(runCtx context.Context, volCtx *volume.VolumeContext) (*pb.Empty, error) {
 		if isS0FSVolume(volCtx) {
+			path := resolveChildPath(volCtx, req.Parent, req.Name)
 			inode, err := volCtx.S0FS.UnlinkWithInode(req.Parent, req.Name)
 			if err != nil {
 				return nil, mapS0FSError(err)
@@ -1016,9 +1066,15 @@ func (s *FileSystemServer) Unlink(ctx context.Context, req *pb.UnlinkRequest) (*
 			if !volCtx.MarkUnlinkedFileIfOpen(inode) {
 				_ = volCtx.S0FS.Forget(inode)
 			}
+			eventType := pb.WatchEventType_WATCH_EVENT_TYPE_REMOVE
+			if path == "" {
+				eventType = pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE
+			}
 			s.publishEvent(runCtx, &pb.WatchEvent{
 				VolumeId:  req.VolumeId,
-				EventType: pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE,
+				EventType: eventType,
+				Path:      path,
+				Inode:     inode,
 			})
 			return &pb.Empty{}, nil
 		}
@@ -1172,12 +1228,20 @@ func (s *FileSystemServer) ReleaseDir(ctx context.Context, req *pb.ReleaseDirReq
 func (s *FileSystemServer) Rename(ctx context.Context, req *pb.RenameRequest) (*pb.Empty, error) {
 	return withAuthorizedVolumeMutation(s, ctx, req.VolumeId, func(runCtx context.Context, volCtx *volume.VolumeContext) (*pb.Empty, error) {
 		if isS0FSVolume(volCtx) {
+			oldPath := resolveChildPath(volCtx, req.OldParent, req.OldName)
+			newPath := resolveChildPath(volCtx, req.NewParent, req.NewName)
 			if err := volCtx.S0FS.Rename(req.OldParent, req.OldName, req.NewParent, req.NewName); err != nil {
 				return nil, mapS0FSError(err)
 			}
+			eventType := pb.WatchEventType_WATCH_EVENT_TYPE_RENAME
+			if oldPath == "" && newPath == "" {
+				eventType = pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE
+			}
 			s.publishEvent(runCtx, &pb.WatchEvent{
 				VolumeId:  req.VolumeId,
-				EventType: pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE,
+				EventType: eventType,
+				Path:      newPath,
+				OldPath:   oldPath,
 			})
 			return &pb.Empty{}, nil
 		}
@@ -1230,6 +1294,7 @@ func (s *FileSystemServer) SetAttr(ctx context.Context, req *pb.SetAttrRequest) 
 			if attr == nil {
 				attr = &pb.GetAttrResponse{}
 			}
+			path := resolveInodePath(volCtx, req.Inode)
 			if req.Valid&uint32(fsmeta.SetAttrMode) != 0 {
 				if err := volCtx.S0FS.SetMode(req.Inode, attr.Mode&0o7777); err != nil {
 					return nil, mapS0FSError(err)
@@ -1261,9 +1326,19 @@ func (s *FileSystemServer) SetAttr(ctx context.Context, req *pb.SetAttrRequest) 
 			if err != nil {
 				return nil, mapS0FSError(err)
 			}
+			eventType := pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE
+			if req.Valid&uint32(fsmeta.SetAttrMode) != 0 {
+				eventType = pb.WatchEventType_WATCH_EVENT_TYPE_CHMOD
+			} else if path != "" {
+				eventType = pb.WatchEventType_WATCH_EVENT_TYPE_WRITE
+			}
+			if path == "" {
+				eventType = pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE
+			}
 			s.publishEvent(runCtx, &pb.WatchEvent{
 				VolumeId:  req.VolumeId,
-				EventType: pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE,
+				EventType: eventType,
+				Path:      path,
 				Inode:     req.Inode,
 			})
 			return &pb.SetAttrResponse{Attr: s0fsAttr(updated)}, nil
@@ -1453,12 +1528,18 @@ func (s *FileSystemServer) Release(ctx context.Context, req *pb.ReleaseRequest) 
 func (s *FileSystemServer) Rmdir(ctx context.Context, req *pb.RmdirRequest) (*pb.Empty, error) {
 	return withAuthorizedVolumeMutation(s, ctx, req.VolumeId, func(runCtx context.Context, volCtx *volume.VolumeContext) (*pb.Empty, error) {
 		if isS0FSVolume(volCtx) {
+			path := resolveChildPath(volCtx, req.Parent, req.Name)
 			if err := volCtx.S0FS.RemoveDir(req.Parent, req.Name); err != nil {
 				return nil, mapS0FSError(err)
 			}
+			eventType := pb.WatchEventType_WATCH_EVENT_TYPE_REMOVE
+			if path == "" {
+				eventType = pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE
+			}
 			s.publishEvent(runCtx, &pb.WatchEvent{
 				VolumeId:  req.VolumeId,
-				EventType: pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE,
+				EventType: eventType,
+				Path:      path,
 			})
 			return &pb.Empty{}, nil
 		}
@@ -1552,6 +1633,7 @@ func (s *FileSystemServer) Symlink(ctx context.Context, req *pb.SymlinkRequest) 
 			if err := ensureLazyRootPosixIdentity(volCtx, req.Actor, fsmeta.Ino(req.Parent)); err != nil {
 				return nil, fserror.New(fserror.Internal, err.Error())
 			}
+			path := resolveChildPath(volCtx, req.Parent, req.Name)
 			node, err := volCtx.S0FS.Symlink(req.Parent, req.Name, req.Target, 0o777)
 			if err != nil {
 				return nil, mapS0FSError(err)
@@ -1565,9 +1647,17 @@ func (s *FileSystemServer) Symlink(ctx context.Context, req *pb.SymlinkRequest) 
 					return nil, mapS0FSError(err)
 				}
 			}
+			if path == "" {
+				path = resolveInodePath(volCtx, node.Inode)
+			}
+			eventType := pb.WatchEventType_WATCH_EVENT_TYPE_CREATE
+			if path == "" {
+				eventType = pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE
+			}
 			s.publishEvent(runCtx, &pb.WatchEvent{
 				VolumeId:  req.VolumeId,
-				EventType: pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE,
+				EventType: eventType,
+				Path:      path,
 				Inode:     node.Inode,
 			})
 			return s0fsNodeResponse(node, 0), nil
@@ -2093,6 +2183,16 @@ func resolveInodePath(volCtx *volume.VolumeContext, inode uint64) string {
 	if volCtx == nil {
 		return ""
 	}
+	if isS0FSVolume(volCtx) {
+		path, ok := volCtx.S0FS.Path(inode)
+		if !ok {
+			return ""
+		}
+		return path
+	}
+	if volCtx.Meta == nil {
+		return ""
+	}
 	paths := volCtx.Meta.GetPaths(fsmeta.Background(), fsmeta.Ino(inode))
 	if len(paths) == 0 {
 		return ""
@@ -2102,6 +2202,16 @@ func resolveInodePath(volCtx *volume.VolumeContext, inode uint64) string {
 
 func resolveChildPath(volCtx *volume.VolumeContext, parent uint64, name string) string {
 	if volCtx == nil {
+		return ""
+	}
+	if isS0FSVolume(volCtx) {
+		path, ok := volCtx.S0FS.ChildPath(parent, name)
+		if !ok {
+			return ""
+		}
+		return path
+	}
+	if volCtx.Meta == nil {
 		return ""
 	}
 	parentPaths := volCtx.Meta.GetPaths(fsmeta.Background(), fsmeta.Ino(parent))

--- a/storage-proxy/pkg/fsserver/server_s0fs_test.go
+++ b/storage-proxy/pkg/fsserver/server_s0fs_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/s0fs"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volume"
 	pb "github.com/sandbox0-ai/sandbox0/storage-proxy/proto/fs"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestS0FSFileLifecycle(t *testing.T) {
@@ -102,6 +103,132 @@ func TestS0FSFileLifecycle(t *testing.T) {
 		HandleId: createResp.HandleId,
 	}); err != nil {
 		t.Fatalf("Release() error = %v", err)
+	}
+}
+
+func TestS0FSOpenTruncatesExistingFile(t *testing.T) {
+	t.Parallel()
+
+	volCtx := newMountedS0FSVolumeContext(t, "vol-1", "team-a")
+	server := newTestFileSystemServer(&fakeVolumeManager{
+		volumes: map[string]*volume.VolumeContext{
+			"vol-1": volCtx,
+		},
+	}, nil, nil)
+	ctx := authContext("team-a", "")
+
+	createResp, err := server.Create(ctx, &pb.CreateRequest{
+		VolumeId: "vol-1",
+		Parent:   1,
+		Name:     "truncate.txt",
+		Mode:     0o644,
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if _, err := server.Write(ctx, &pb.WriteRequest{
+		VolumeId: "vol-1",
+		Inode:    createResp.Inode,
+		Offset:   0,
+		Data:     []byte("abcdef"),
+		HandleId: createResp.HandleId,
+	}); err != nil {
+		t.Fatalf("Write(initial) error = %v", err)
+	}
+	if _, err := server.Release(ctx, &pb.ReleaseRequest{
+		VolumeId: "vol-1",
+		Inode:    createResp.Inode,
+		HandleId: createResp.HandleId,
+	}); err != nil {
+		t.Fatalf("Release(initial) error = %v", err)
+	}
+
+	openResp, err := server.Open(ctx, &pb.OpenRequest{
+		VolumeId: "vol-1",
+		Inode:    createResp.Inode,
+		Flags:    uint32(syscall.O_WRONLY | syscall.O_TRUNC),
+	})
+	if err != nil {
+		t.Fatalf("Open(O_TRUNC) error = %v", err)
+	}
+	if _, err := server.Write(ctx, &pb.WriteRequest{
+		VolumeId: "vol-1",
+		Inode:    createResp.Inode,
+		Offset:   0,
+		Data:     []byte("xy"),
+		HandleId: openResp.HandleId,
+	}); err != nil {
+		t.Fatalf("Write(after truncate) error = %v", err)
+	}
+
+	readResp, err := server.Read(ctx, &pb.ReadRequest{
+		VolumeId: "vol-1",
+		Inode:    createResp.Inode,
+		Offset:   0,
+		Size:     16,
+		HandleId: openResp.HandleId,
+	})
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if string(readResp.Data) != "xy" {
+		t.Fatalf("Read() data = %q, want xy", readResp.Data)
+	}
+	attrResp, err := server.GetAttr(ctx, &pb.GetAttrRequest{VolumeId: "vol-1", Inode: createResp.Inode})
+	if err != nil {
+		t.Fatalf("GetAttr() error = %v", err)
+	}
+	if attrResp.Size != 2 {
+		t.Fatalf("GetAttr() size = %d, want 2", attrResp.Size)
+	}
+}
+
+func TestS0FSWatchEventsIncludePaths(t *testing.T) {
+	t.Parallel()
+
+	volCtx := newMountedS0FSVolumeContext(t, "vol-1", "team-a")
+	broadcaster := &recordingBroadcaster{}
+	server := NewFileSystemServer(&fakeVolumeManager{
+		volumes: map[string]*volume.VolumeContext{
+			"vol-1": volCtx,
+		},
+	}, nil, nil, broadcaster, nil, nil, nil)
+	ctx := authContext("team-a", "")
+
+	createResp, err := server.Create(ctx, &pb.CreateRequest{
+		VolumeId: "vol-1",
+		Parent:   1,
+		Name:     "hello.txt",
+		Mode:     0o644,
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if _, err := server.Write(ctx, &pb.WriteRequest{
+		VolumeId: "vol-1",
+		Inode:    createResp.Inode,
+		Offset:   0,
+		Data:     []byte("hello"),
+		HandleId: createResp.HandleId,
+	}); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	var sawCreate, sawWrite bool
+	for _, event := range broadcaster.events {
+		switch event.EventType {
+		case pb.WatchEventType_WATCH_EVENT_TYPE_CREATE:
+			if event.Path == "/hello.txt" {
+				sawCreate = true
+			}
+		case pb.WatchEventType_WATCH_EVENT_TYPE_WRITE:
+			if event.Path == "/hello.txt" {
+				sawWrite = true
+			}
+		}
+	}
+	if !sawCreate || !sawWrite {
+		t.Fatalf("events = %+v, want create and write for /hello.txt", broadcaster.events)
 	}
 }
 
@@ -482,6 +609,21 @@ func newMountedS0FSVolumeContext(t *testing.T, volumeID, teamID string) *volume.
 		RootInode: 1,
 		RootPath:  "/",
 	}
+}
+
+type recordingBroadcaster struct {
+	events []*pb.WatchEvent
+}
+
+func (b *recordingBroadcaster) Publish(_ context.Context, event *pb.WatchEvent) {
+	if event == nil {
+		return
+	}
+	clone, ok := proto.Clone(event).(*pb.WatchEvent)
+	if !ok {
+		return
+	}
+	b.events = append(b.events, clone)
 }
 
 func assertEntryNames(t *testing.T, entries []*pb.DirEntry, want []string) {

--- a/storage-proxy/pkg/http/handlers_volume_files.go
+++ b/storage-proxy/pkg/http/handlers_volume_files.go
@@ -247,6 +247,10 @@ func (s *Server) handleVolumeFileMove(w http.ResponseWriter, r *http.Request) {
 		s.writeVolumeFileError(w, err)
 		return
 	}
+	if err := s.finalizeVolumeFileMutation(ctx, volumeID); err != nil {
+		s.writeVolumeFileError(w, err)
+		return
+	}
 
 	_ = spec.WriteSuccess(w, http.StatusOK, map[string]bool{"moved": true})
 }
@@ -450,6 +454,10 @@ func (s *Server) writeVolumeFile(w http.ResponseWriter, r *http.Request, volumeI
 			s.writeVolumeFileError(w, err)
 			return
 		}
+		if err := s.finalizeVolumeFileMutation(ctx, volumeID); err != nil {
+			s.writeVolumeFileError(w, err)
+			return
+		}
 		_ = spec.WriteSuccess(w, http.StatusCreated, map[string]bool{"created": true})
 		return
 	}
@@ -465,6 +473,10 @@ func (s *Server) writeVolumeFile(w http.ResponseWriter, r *http.Request, volumeI
 	}
 
 	if err := s.writeVolumePath(ctx, volumeID, logicalPath, data); err != nil {
+		s.writeVolumeFileError(w, err)
+		return
+	}
+	if err := s.finalizeVolumeFileMutation(ctx, volumeID); err != nil {
 		s.writeVolumeFileError(w, err)
 		return
 	}
@@ -489,6 +501,10 @@ func (s *Server) deleteVolumeFile(w http.ResponseWriter, r *http.Request, volume
 			s.writeVolumeFileError(w, err)
 			return
 		}
+		if err := s.finalizeVolumeFileMutation(ctx, volumeID); err != nil {
+			s.writeVolumeFileError(w, err)
+			return
+		}
 	}
 
 	_ = spec.WriteSuccess(w, http.StatusOK, map[string]bool{"deleted": true})
@@ -508,6 +524,17 @@ func (s *Server) prepareVolumeFileRequest(ctx context.Context, volumeID string) 
 		return ctx, nil, func() {}, err
 	}
 	return withVolumeFileActor(ctx, actor), volumeRecord, cleanup, nil
+}
+
+func (s *Server) finalizeVolumeFileMutation(ctx context.Context, volumeID string) error {
+	if s == nil || s.volMgr == nil {
+		return nil
+	}
+	syncer, ok := s.volMgr.(directVolumeMountSyncer)
+	if !ok {
+		return nil
+	}
+	return syncer.SyncDirectVolumeFileMount(ctx, volumeID)
 }
 
 func (s *Server) loadAuthorizedVolume(ctx context.Context, volumeID string) (*db.SandboxVolume, error) {

--- a/storage-proxy/pkg/http/handlers_volume_files_test.go
+++ b/storage-proxy/pkg/http/handlers_volume_files_test.go
@@ -33,6 +33,9 @@ type fakeHTTPVolumeMountManager struct {
 	cleanupCalls      int
 	lastCleanupVolume string
 	cleanupDirectFunc func(context.Context, string) (bool, error)
+	syncCalls         int
+	lastSyncVolume    string
+	syncFunc          func(context.Context, string) error
 }
 
 type fakeVolumeFilePodResolver struct {
@@ -81,6 +84,15 @@ func (f *fakeHTTPVolumeMountManager) CleanupIdleDirectVolumeFileMount(ctx contex
 		return f.cleanupDirectFunc(ctx, volumeID)
 	}
 	return false, nil
+}
+
+func (f *fakeHTTPVolumeMountManager) SyncDirectVolumeFileMount(ctx context.Context, volumeID string) error {
+	f.syncCalls++
+	f.lastSyncVolume = volumeID
+	if f.syncFunc != nil {
+		return f.syncFunc(ctx, volumeID)
+	}
+	return nil
 }
 
 type fakeHTTPVolumeFileRPC struct {
@@ -465,6 +477,9 @@ func TestWriteVolumeFileWritesExistingPath(t *testing.T) {
 			if req.Inode != 3 {
 				t.Fatalf("Open inode = %d, want 3", req.Inode)
 			}
+			if req.Flags&uint32(syscall.O_TRUNC) == 0 {
+				t.Fatalf("Open flags = %#x, want O_TRUNC", req.Flags)
+			}
 			return &pb.OpenResponse{HandleId: 15}, nil
 		},
 		writeFunc: func(_ context.Context, req *pb.WriteRequest) (*pb.WriteResponse, error) {
@@ -472,7 +487,7 @@ func TestWriteVolumeFileWritesExistingPath(t *testing.T) {
 			return &pb.WriteResponse{BytesWritten: int64(len(req.Data))}, nil
 		},
 	}
-	server, _ := newVolumeFileTestServer(fileRPC)
+	server, volMgr := newVolumeFileTestServer(fileRPC)
 
 	req := httptest.NewRequest(http.MethodPost, "/sandboxvolumes/vol-1/files?path=/hello.txt", bytes.NewReader([]byte("hello world")))
 	req.SetPathValue("id", "vol-1")
@@ -486,6 +501,9 @@ func TestWriteVolumeFileWritesExistingPath(t *testing.T) {
 	}
 	if wrote == nil || string(wrote.Data) != "hello world" || wrote.HandleId != 15 {
 		t.Fatalf("unexpected write request: %+v", wrote)
+	}
+	if volMgr.syncCalls != 1 || volMgr.lastSyncVolume != "vol-1" {
+		t.Fatalf("SyncDirectVolumeFileMount() got calls=%d volume=%q, want 1 vol-1", volMgr.syncCalls, volMgr.lastSyncVolume)
 	}
 }
 
@@ -503,7 +521,7 @@ func TestDeleteVolumeFileUnlinksResolvedPath(t *testing.T) {
 			return &pb.Empty{}, nil
 		},
 	}
-	server, _ := newVolumeFileTestServer(fileRPC)
+	server, volMgr := newVolumeFileTestServer(fileRPC)
 
 	req := httptest.NewRequest(http.MethodDelete, "/sandboxvolumes/vol-1/files?path=/hello.txt", nil)
 	req.SetPathValue("id", "vol-1")
@@ -517,6 +535,9 @@ func TestDeleteVolumeFileUnlinksResolvedPath(t *testing.T) {
 	}
 	if unlinked == nil || unlinked.Parent != 1 || unlinked.Name != "hello.txt" {
 		t.Fatalf("unexpected unlink request: %+v", unlinked)
+	}
+	if volMgr.syncCalls != 1 || volMgr.lastSyncVolume != "vol-1" {
+		t.Fatalf("SyncDirectVolumeFileMount() got calls=%d volume=%q, want 1 vol-1", volMgr.syncCalls, volMgr.lastSyncVolume)
 	}
 }
 
@@ -540,7 +561,7 @@ func TestHandleVolumeFileMoveRenamesPath(t *testing.T) {
 			return &pb.Empty{}, nil
 		},
 	}
-	server, _ := newVolumeFileTestServer(fileRPC)
+	server, volMgr := newVolumeFileTestServer(fileRPC)
 
 	req := httptest.NewRequest(http.MethodPost, "/sandboxvolumes/vol-1/files/move", bytes.NewReader([]byte(`{"source":"/docs/report.txt","destination":"/archive/report-old.txt"}`)))
 	req.SetPathValue("id", "vol-1")
@@ -554,6 +575,9 @@ func TestHandleVolumeFileMoveRenamesPath(t *testing.T) {
 	}
 	if renamed == nil || renamed.OldParent != 2 || renamed.OldName != "report.txt" || renamed.NewParent != 4 || renamed.NewName != "report-old.txt" {
 		t.Fatalf("unexpected rename request: %+v", renamed)
+	}
+	if volMgr.syncCalls != 1 || volMgr.lastSyncVolume != "vol-1" {
+		t.Fatalf("SyncDirectVolumeFileMount() got calls=%d volume=%q, want 1 vol-1", volMgr.syncCalls, volMgr.lastSyncVolume)
 	}
 }
 

--- a/storage-proxy/pkg/http/server.go
+++ b/storage-proxy/pkg/http/server.go
@@ -83,6 +83,10 @@ type volumeMountManager interface {
 	CleanupIdleDirectVolumeFileMount(ctx context.Context, volumeID string) (bool, error)
 }
 
+type directVolumeMountSyncer interface {
+	SyncDirectVolumeFileMount(ctx context.Context, volumeID string) error
+}
+
 type volumeFileRPC interface {
 	MountVolume(ctx context.Context, req *pb.MountVolumeRequest) (*pb.MountVolumeResponse, error)
 	GetAttr(ctx context.Context, req *pb.GetAttrRequest) (*pb.GetAttrResponse, error)

--- a/storage-proxy/pkg/s0fs/engine.go
+++ b/storage-proxy/pkg/s0fs/engine.go
@@ -199,6 +199,31 @@ func (e *Engine) ReadDir(inode uint64) ([]DirEntry, error) {
 	return entries, nil
 }
 
+func (e *Engine) Path(inode uint64) (string, bool) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	if err := e.checkOpen(); err != nil {
+		return "", false
+	}
+	return e.pathLocked(inode)
+}
+
+func (e *Engine) ChildPath(parent uint64, name string) (string, bool) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	if err := e.checkOpen(); err != nil {
+		return "", false
+	}
+	parentPath, ok := e.pathLocked(parent)
+	if !ok || name == "" {
+		return "", false
+	}
+	if parentPath == "/" {
+		return "/" + name, true
+	}
+	return parentPath + "/" + name, true
+}
+
 func (e *Engine) CreateFile(parent uint64, name string, mode uint32) (*Node, error) {
 	return e.create(parent, name, TypeFile, mode, "")
 }
@@ -1103,6 +1128,53 @@ func (e *Engine) fileNodeLocked(inode uint64) (*Node, error) {
 		return nil, ErrIsDir
 	}
 	return node, nil
+}
+
+func (e *Engine) pathLocked(target uint64) (string, bool) {
+	if target == RootInode {
+		return "/", true
+	}
+	if e.nodes[target] == nil {
+		return "", false
+	}
+
+	type frame struct {
+		inode uint64
+		path  string
+	}
+	queue := []frame{{inode: RootInode, path: "/"}}
+	seen := map[uint64]struct{}{RootInode: {}}
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		children := e.children[current.inode]
+		if len(children) == 0 {
+			continue
+		}
+		names := make([]string, 0, len(children))
+		for name := range children {
+			names = append(names, name)
+		}
+		slices.Sort(names)
+		for _, name := range names {
+			child := children[name]
+			childPath := current.path + name
+			if current.path != "/" {
+				childPath = current.path + "/" + name
+			}
+			if child == target {
+				return childPath, true
+			}
+			if _, ok := seen[child]; ok {
+				continue
+			}
+			seen[child] = struct{}{}
+			if node := e.nodes[child]; node != nil && node.Type == TypeDirectory {
+				queue = append(queue, frame{inode: child, path: childPath})
+			}
+		}
+	}
+	return "", false
 }
 
 func (e *Engine) collectUnlinkedLocked() {

--- a/storage-proxy/pkg/volume/manager.go
+++ b/storage-proxy/pkg/volume/manager.go
@@ -613,6 +613,21 @@ func (m *Manager) RefreshDirectVolumeFileMount(ctx context.Context, volumeID str
 	return err
 }
 
+func (m *Manager) SyncDirectVolumeFileMount(ctx context.Context, volumeID string) error {
+	m.mu.RLock()
+	lease := m.directMounts[volumeID]
+	m.mu.RUnlock()
+	if lease == nil {
+		return nil
+	}
+	volCtx, err := m.GetVolume(volumeID)
+	if err != nil || volCtx == nil || volCtx.S0FS == nil {
+		return err
+	}
+	_, err = volCtx.S0FS.SyncMaterialize(ctx)
+	return err
+}
+
 func (m *Manager) releaseDirectVolumeFileMount(volumeID, sessionID string) func() {
 	return func() {
 		m.mu.Lock()


### PR DESCRIPTION
## Summary
- make S0FS `O_TRUNC` actually truncate file content and emit pathful watch events
- synchronously materialize direct volume file mutations before returning so preseeded data is visible to ctld-mounted sandboxes
- add S0FS path resolution plus focused tests for truncate, watch payloads, and direct mutation sync

Closes #247

## Testing
- `make proto`
- `go test ./storage-proxy/pkg/s0fs ./storage-proxy/pkg/fsserver ./storage-proxy/pkg/http ./storage-proxy/pkg/volume`
- `go test ./storage-proxy/pkg/...`
- `go test ./ctld/... ./manager/pkg/service ./manager/pkg/apis/sandbox0/v1alpha1`
- pre-push hook: `make manifests`, `make proto`, `make apispec`, `go fmt ./...`, `go mod tidy`, `go mod vendor`, `golangci-lint run ./...`