### PR TITLE
Route mounted RWO volume APIs to ctld owner

### DIFF
--- a/ctld/cmd/ctld/main.go
+++ b/ctld/cmd/ctld/main.go
@@ -12,14 +12,18 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgxpool"
 	ctldportal "github.com/sandbox0-ai/sandbox0/ctld/internal/ctld/portal"
 	ctldpower "github.com/sandbox0-ai/sandbox0/ctld/internal/ctld/power"
 	ctldserver "github.com/sandbox0-ai/sandbox0/ctld/internal/ctld/server"
+	apiconfig "github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
+	"github.com/sandbox0-ai/sandbox0/pkg/dbpool"
 	"github.com/sandbox0-ai/sandbox0/pkg/k8s"
 	"github.com/sandbox0-ai/sandbox0/pkg/observability"
 	httpobs "github.com/sandbox0-ai/sandbox0/pkg/observability/http"
 	"github.com/sandbox0-ai/sandbox0/pkg/sandboxprobe"
+	storagedb "github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
 	"go.uber.org/zap"
 )
 
@@ -37,6 +41,8 @@ var (
 	defaultSandboxTTL      time.Duration
 	portalRoot             = "/var/lib/sandbox0/ctld"
 	csiSocket              = "/var/lib/kubelet/plugins/volume.sandbox0.ai/csi.sock"
+	podName                = os.Getenv("POD_NAME")
+	podNamespace           = os.Getenv("POD_NAMESPACE")
 )
 
 func main() {
@@ -84,10 +90,27 @@ func main() {
 		}
 	}
 
+	storageCfg := apiconfig.LoadStorageProxyConfig()
+	var repo *storagedb.Repository
+	var dbPool *pgxpool.Pool
+	if storageCfg.DatabaseURL != "" {
+		dbPool, err = initPortalDatabase(ctx, storageCfg, obsProvider)
+		if err != nil {
+			log.Printf("ctld volume registry disabled: %v", err)
+		} else {
+			repo = storagedb.NewRepository(dbPool)
+			defer dbPool.Close()
+		}
+	}
+
 	portalManager := ctldportal.NewManager(ctldportal.Config{
-		NodeName: nodeName,
-		RootDir:  portalRoot,
-		Logger:   zapLogger,
+		NodeName:      nodeName,
+		RootDir:       portalRoot,
+		Logger:        zapLogger,
+		StorageConfig: storageCfg,
+		Repository:    repo,
+		PodName:       podName,
+		PodNamespace:  podNamespace,
 	})
 	csiServer := ctldportal.NewCSIServer(nodeName, portalManager)
 	go func() {
@@ -172,6 +195,29 @@ func buildPowerController(ctx context.Context, obsProvider *observability.Provid
 		}()
 	}
 	return controller
+}
+
+func initPortalDatabase(ctx context.Context, cfg *apiconfig.StorageProxyConfig, obsProvider *observability.Provider) (*pgxpool.Pool, error) {
+	if cfg == nil || cfg.DatabaseURL == "" {
+		return nil, nil
+	}
+	schema := cfg.DatabaseSchema
+	if schema == "" {
+		schema = "storage_proxy"
+	}
+	var modifier func(*pgxpool.Config) error
+	if obsProvider != nil {
+		modifier = obsProvider.Pgx.ConfigModifier()
+	}
+	return dbpool.New(ctx, dbpool.Options{
+		DatabaseURL:     cfg.DatabaseURL,
+		MaxConns:        int32(cfg.DatabaseMaxConns),
+		MinConns:        int32(cfg.DatabaseMinConns),
+		DefaultMaxConns: 5,
+		DefaultMinConns: 1,
+		Schema:          schema,
+		ConfigModifier:  modifier,
+	})
 }
 
 type combinedController struct {

--- a/ctld/cmd/ctld/main.go
+++ b/ctld/cmd/ctld/main.go
@@ -222,10 +222,13 @@ func initPortalDatabase(ctx context.Context, cfg *apiconfig.StorageProxyConfig, 
 
 type combinedController struct {
 	ctldserver.Controller
-	Portal *ctldportal.Manager
+	Portal volumePortalHandler
 }
 
 func (c combinedController) BindVolumePortal(r *http.Request, req ctldapi.BindVolumePortalRequest) (ctldapi.BindVolumePortalResponse, int) {
+	if c.Portal == nil {
+		return ctldapi.BindVolumePortalResponse{Error: "ctld volume portals not implemented"}, http.StatusNotImplemented
+	}
 	resp, err := c.Portal.Bind(r.Context(), req)
 	if err != nil {
 		return ctldapi.BindVolumePortalResponse{Error: err.Error()}, http.StatusBadRequest
@@ -234,6 +237,9 @@ func (c combinedController) BindVolumePortal(r *http.Request, req ctldapi.BindVo
 }
 
 func (c combinedController) UnbindVolumePortal(r *http.Request, req ctldapi.UnbindVolumePortalRequest) (ctldapi.UnbindVolumePortalResponse, int) {
+	if c.Portal == nil {
+		return ctldapi.UnbindVolumePortalResponse{Error: "ctld volume portals not implemented"}, http.StatusNotImplemented
+	}
 	resp, err := c.Portal.Unbind(r.Context(), req)
 	if err != nil {
 		return ctldapi.UnbindVolumePortalResponse{Error: err.Error()}, http.StatusBadRequest
@@ -241,6 +247,19 @@ func (c combinedController) UnbindVolumePortal(r *http.Request, req ctldapi.Unbi
 	return resp, http.StatusOK
 }
 
+func (c combinedController) MountedVolumeHandler() http.Handler {
+	if c.Portal == nil {
+		return nil
+	}
+	return c.Portal.MountedVolumeHandler()
+}
+
 func (c combinedController) Probe(r *http.Request, sandboxID string, kind sandboxprobe.Kind) (sandboxprobe.Response, int) {
 	return c.Controller.Probe(r, sandboxID, kind)
+}
+
+type volumePortalHandler interface {
+	Bind(ctx context.Context, req ctldapi.BindVolumePortalRequest) (ctldapi.BindVolumePortalResponse, error)
+	Unbind(ctx context.Context, req ctldapi.UnbindVolumePortalRequest) (ctldapi.UnbindVolumePortalResponse, error)
+	MountedVolumeHandler() http.Handler
 }

--- a/ctld/cmd/ctld/main_test.go
+++ b/ctld/cmd/ctld/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -59,4 +60,39 @@ func TestCtldPauseResumeStubsReturnNotImplemented(t *testing.T) {
 		assert.False(t, resp.Resumed)
 		assert.Equal(t, "ctld resume not implemented", resp.Error)
 	})
+}
+
+func TestCombinedControllerRoutesMountedVolumeAPIToPortalHandler(t *testing.T) {
+	portal := fakeVolumePortalHandler{
+		mountedHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/sandboxvolumes/vol-1/files", r.URL.Path)
+			w.WriteHeader(http.StatusNoContent)
+		}),
+	}
+	server := newHTTPServer(":0", combinedController{
+		Controller: ctldserver.NotImplementedController{},
+		Portal:     portal,
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/sandboxvolumes/vol-1/files?path=/hello.txt", nil)
+	rec := httptest.NewRecorder()
+	server.Handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+}
+
+type fakeVolumePortalHandler struct {
+	mountedHandler http.Handler
+}
+
+func (f fakeVolumePortalHandler) Bind(_ context.Context, _ ctldapi.BindVolumePortalRequest) (ctldapi.BindVolumePortalResponse, error) {
+	return ctldapi.BindVolumePortalResponse{}, nil
+}
+
+func (f fakeVolumePortalHandler) Unbind(_ context.Context, _ ctldapi.UnbindVolumePortalRequest) (ctldapi.UnbindVolumePortalResponse, error) {
+	return ctldapi.UnbindVolumePortalResponse{}, nil
+}
+
+func (f fakeVolumePortalHandler) MountedVolumeHandler() http.Handler {
+	return f.mountedHandler
 }

--- a/ctld/internal/ctld/portal/manager.go
+++ b/ctld/internal/ctld/portal/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,6 +17,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 	"github.com/sandbox0-ai/sandbox0/pkg/volumefuse"
 	"github.com/sandbox0-ai/sandbox0/pkg/volumeportal"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/objectstore"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/s0fs"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volume"
@@ -26,11 +28,17 @@ import (
 const defaultRootDir = "/var/lib/sandbox0/ctld"
 
 type Manager struct {
-	nodeName string
-	rootDir  string
-	logger   *zap.Logger
-	logrus   *logrus.Logger
-	storage  *apiconfig.StorageProxyConfig
+	nodeName          string
+	rootDir           string
+	logger            *zap.Logger
+	logrus            *logrus.Logger
+	storage           *apiconfig.StorageProxyConfig
+	repo              *db.Repository
+	clusterID         string
+	podName           string
+	podNamespace      string
+	heartbeatInterval time.Duration
+	volumeAPI         http.Handler
 
 	mu              sync.Mutex
 	portals         map[string]*portalMount
@@ -52,6 +60,9 @@ type portalMount struct {
 	teamID    string
 	mountedAt time.Time
 
+	heartbeatCancel context.CancelFunc
+	heartbeatDone   chan struct{}
+
 	materializeCancel context.CancelFunc
 	materializeDone   chan struct{}
 }
@@ -61,6 +72,9 @@ type Config struct {
 	RootDir       string
 	Logger        *zap.Logger
 	StorageConfig *apiconfig.StorageProxyConfig
+	Repository    *db.Repository
+	PodName       string
+	PodNamespace  string
 }
 
 func NewManager(cfg Config) *Manager {
@@ -78,16 +92,34 @@ func NewManager(cfg Config) *Manager {
 	if storageConfig == nil {
 		storageConfig = apiconfig.LoadStorageProxyConfig()
 	}
-	return &Manager{
-		nodeName:        strings.TrimSpace(cfg.NodeName),
-		rootDir:         rootDir,
-		logger:          logger,
-		logrus:          l,
-		storage:         storageConfig,
-		portals:         make(map[string]*portalMount),
-		portalsByTarget: make(map[string]*portalMount),
-		volumes:         newLocalVolumeManager(),
+	heartbeatInterval, _ := time.ParseDuration(storageConfig.HeartbeatInterval)
+	if heartbeatInterval <= 0 {
+		heartbeatInterval = 5 * time.Second
 	}
+	manager := &Manager{
+		nodeName:          strings.TrimSpace(cfg.NodeName),
+		rootDir:           rootDir,
+		logger:            logger,
+		logrus:            l,
+		storage:           storageConfig,
+		repo:              cfg.Repository,
+		clusterID:         strings.TrimSpace(storageConfig.DefaultClusterId),
+		podName:           strings.TrimSpace(cfg.PodName),
+		podNamespace:      strings.TrimSpace(cfg.PodNamespace),
+		heartbeatInterval: heartbeatInterval,
+		portals:           make(map[string]*portalMount),
+		portalsByTarget:   make(map[string]*portalMount),
+		volumes:           newLocalVolumeManager(),
+	}
+	manager.volumeAPI = newMountedVolumeAPIHandler(storageConfig, cfg.Repository, manager.volumes, l)
+	return manager
+}
+
+func (m *Manager) MountedVolumeHandler() http.Handler {
+	if m == nil {
+		return nil
+	}
+	return m.volumeAPI
 }
 
 func (m *Manager) PublishPortal(ctx context.Context, req publishRequest) error {
@@ -195,6 +227,13 @@ func (m *Manager) Bind(ctx context.Context, req ctldapi.BindVolumePortalRequest)
 	if req.PodUID == "" || req.SandboxVolumeID == "" || req.TeamID == "" {
 		return ctldapi.BindVolumePortalResponse{}, fmt.Errorf("pod_uid, sandboxvolume_id and team_id are required")
 	}
+	volumeRecord, err := m.validateBindableVolume(ctx, ctldBindContext{
+		volumeID: req.SandboxVolumeID,
+		teamID:   req.TeamID,
+	})
+	if err != nil {
+		return ctldapi.BindVolumePortalResponse{}, err
+	}
 
 	key := portalKey(req.PodUID, portalName)
 	m.mu.Lock()
@@ -232,10 +271,10 @@ func (m *Manager) Bind(ctx context.Context, req ctldapi.BindVolumePortalRequest)
 	}
 	volCtx := &volume.VolumeContext{
 		VolumeID:  req.SandboxVolumeID,
-		TeamID:    req.TeamID,
+		TeamID:    volumeRecord.TeamID,
 		Backend:   volume.BackendS0FS,
 		S0FS:      engine,
-		Access:    volume.AccessModeRWO,
+		Access:    volume.NormalizeAccessMode(volumeRecord.AccessMode),
 		MountedAt: time.Now().UTC(),
 		RootInode: 1,
 		RootPath:  "/",
@@ -268,8 +307,18 @@ func (m *Manager) Bind(ctx context.Context, req ctldapi.BindVolumePortalRequest)
 	m.volumes.add(volCtx)
 	pm.fs.SetSession(session)
 	pm.volumeID = req.SandboxVolumeID
-	pm.teamID = req.TeamID
+	pm.teamID = volumeRecord.TeamID
 	pm.mountedAt = mountedAt
+	if err := m.registerOwner(ctx, pm, volCtx.Access); err != nil {
+		pm.fs.SetSession(unboundSession{})
+		pm.volumeID = ""
+		pm.teamID = ""
+		pm.mountedAt = time.Time{}
+		m.volumes.remove(req.SandboxVolumeID)
+		m.mu.Unlock()
+		_ = engine.Close()
+		return ctldapi.BindVolumePortalResponse{}, fmt.Errorf("register ctld volume owner: %w", err)
+	}
 	m.startMaterializer(pm, engine)
 	m.mu.Unlock()
 
@@ -304,6 +353,7 @@ func (m *Manager) Unbind(ctx context.Context, req ctldapi.UnbindVolumePortalRequ
 
 func (m *Manager) unbindLockedSnapshot(pm *portalMount) error {
 	volumeID := pm.volumeID
+	m.unregisterOwner(pm, volumeID)
 	pm.fs.SetSession(unboundSession{})
 	pm.volumeID = ""
 	pm.teamID = ""

--- a/ctld/internal/ctld/portal/registry.go
+++ b/ctld/internal/ctld/portal/registry.go
@@ -51,15 +51,23 @@ func (m *Manager) validateBindableVolume(ctx context.Context, req ctldBindContex
 	}
 	selfPodID := m.ownerPodID()
 	for _, mount := range mounts {
-		if mount == nil {
-			continue
-		}
-		if mount.ClusterID == m.clusterID && mount.PodID == selfPodID {
+		if !isConflictingMountForCtldBind(mount, m.clusterID, selfPodID) {
 			continue
 		}
 		return nil, fmt.Errorf("volume %s already has an active owner on %s/%s", req.volumeID, mount.ClusterID, mount.PodID)
 	}
 	return vol, nil
+}
+
+func isConflictingMountForCtldBind(mount *db.VolumeMount, selfClusterID, selfPodID string) bool {
+	if mount == nil {
+		return false
+	}
+	if mount.ClusterID == selfClusterID && mount.PodID == selfPodID {
+		return false
+	}
+	opts := volume.DecodeMountOptions(mount.MountOptions)
+	return opts.OwnerKind != volume.OwnerKindStorageProxy
 }
 
 type ctldBindContext struct {

--- a/ctld/internal/ctld/portal/registry.go
+++ b/ctld/internal/ctld/portal/registry.go
@@ -1,0 +1,148 @@
+package portal
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volume"
+	"go.uber.org/zap"
+)
+
+func (m *Manager) ownerPodID() string {
+	switch {
+	case m == nil:
+		return ""
+	case m.podNamespace != "" && m.podName != "":
+		return m.podNamespace + "/" + m.podName
+	case m.podName != "":
+		return m.podName
+	default:
+		return ""
+	}
+}
+
+func (m *Manager) validateBindableVolume(ctx context.Context, req ctldBindContext) (*db.SandboxVolume, error) {
+	if m == nil || m.repo == nil {
+		return nil, fmt.Errorf("ctld volume registry unavailable")
+	}
+	vol, err := m.repo.GetSandboxVolume(ctx, req.volumeID)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(vol.TeamID) != strings.TrimSpace(req.teamID) {
+		return nil, fmt.Errorf("volume %s does not belong to team %s", req.volumeID, req.teamID)
+	}
+	if volume.NormalizeAccessMode(vol.AccessMode) != volume.AccessModeRWO {
+		return nil, fmt.Errorf("ctld volume portal only supports RWO volumes, got %s", vol.AccessMode)
+	}
+
+	heartbeatTimeout := 15
+	if m.storage != nil && m.storage.HeartbeatTimeout > 0 {
+		heartbeatTimeout = m.storage.HeartbeatTimeout
+	}
+	mounts, err := m.repo.GetActiveMounts(ctx, req.volumeID, heartbeatTimeout)
+	if err != nil {
+		return nil, err
+	}
+	selfPodID := m.ownerPodID()
+	for _, mount := range mounts {
+		if mount == nil {
+			continue
+		}
+		if mount.ClusterID == m.clusterID && mount.PodID == selfPodID {
+			continue
+		}
+		return nil, fmt.Errorf("volume %s already has an active owner on %s/%s", req.volumeID, mount.ClusterID, mount.PodID)
+	}
+	return vol, nil
+}
+
+type ctldBindContext struct {
+	volumeID string
+	teamID   string
+}
+
+func (m *Manager) registerOwner(ctx context.Context, pm *portalMount, accessMode volume.AccessMode) error {
+	if m == nil || m.repo == nil || pm == nil || pm.volumeID == "" {
+		return fmt.Errorf("ctld volume registry unavailable")
+	}
+	ownerPodID := m.ownerPodID()
+	if ownerPodID == "" {
+		return fmt.Errorf("ctld pod identity unavailable")
+	}
+
+	opts := volume.MountOptions{
+		AccessMode:   accessMode,
+		OwnerKind:    volume.OwnerKindCtld,
+		OwnerPort:    8095,
+		NodeName:     m.nodeName,
+		PodNamespace: m.podNamespace,
+	}
+	rawOpts, err := json.Marshal(opts)
+	if err != nil {
+		return err
+	}
+	rawMsg := json.RawMessage(rawOpts)
+	mount := &db.VolumeMount{
+		ID:            uuid.NewString(),
+		VolumeID:      pm.volumeID,
+		ClusterID:     m.clusterID,
+		PodID:         ownerPodID,
+		LastHeartbeat: time.Now().UTC(),
+		MountedAt:     pm.mountedAt,
+		MountOptions:  &rawMsg,
+	}
+	if err := m.repo.CreateMount(ctx, mount); err != nil {
+		return err
+	}
+
+	interval := m.heartbeatInterval
+	if interval <= 0 {
+		interval = 5 * time.Second
+	}
+	heartbeatCtx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	pm.heartbeatCancel = cancel
+	pm.heartbeatDone = done
+	go func(volumeID string) {
+		defer close(done)
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-heartbeatCtx.Done():
+				return
+			case <-ticker.C:
+				if err := m.repo.UpdateMountHeartbeat(context.Background(), volumeID, m.clusterID, ownerPodID); err != nil && m.logger != nil {
+					m.logger.Warn("ctld volume owner heartbeat failed", zap.String("volume_id", volumeID), zap.Error(err))
+				}
+			}
+		}
+	}(pm.volumeID)
+	return nil
+}
+
+func (m *Manager) unregisterOwner(pm *portalMount, volumeID string) {
+	if m == nil || pm == nil {
+		return
+	}
+	if pm.heartbeatCancel != nil {
+		pm.heartbeatCancel()
+		pm.heartbeatCancel = nil
+	}
+	if pm.heartbeatDone != nil {
+		<-pm.heartbeatDone
+		pm.heartbeatDone = nil
+	}
+	if m.repo == nil || volumeID == "" {
+		return
+	}
+	if err := m.repo.DeleteMount(context.Background(), volumeID, m.clusterID, m.ownerPodID()); err != nil && m.logger != nil {
+		m.logger.Warn("ctld volume owner unregister failed", zap.String("volume_id", volumeID), zap.Error(err))
+	}
+}

--- a/ctld/internal/ctld/portal/registry_test.go
+++ b/ctld/internal/ctld/portal/registry_test.go
@@ -1,0 +1,45 @@
+package portal
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volume"
+)
+
+func TestIsConflictingMountForCtldBindIgnoresStorageProxyOwners(t *testing.T) {
+	mount := &db.VolumeMount{
+		VolumeID:     "vol-1",
+		ClusterID:    "cluster-a",
+		PodID:        "storage-proxy-1",
+		MountOptions: mustRegistryMountOptions(t, volume.MountOptions{OwnerKind: volume.OwnerKindStorageProxy, AccessMode: volume.AccessModeRWO}),
+	}
+
+	if isConflictingMountForCtldBind(mount, "cluster-a", "ctld-1") {
+		t.Fatal("expected storage-proxy owner to be ignored during ctld bind")
+	}
+}
+
+func TestIsConflictingMountForCtldBindBlocksCtldOwners(t *testing.T) {
+	mount := &db.VolumeMount{
+		VolumeID:     "vol-1",
+		ClusterID:    "cluster-a",
+		PodID:        "sandbox0-system/ctld-node-a",
+		MountOptions: mustRegistryMountOptions(t, volume.MountOptions{OwnerKind: volume.OwnerKindCtld, AccessMode: volume.AccessModeRWO}),
+	}
+
+	if !isConflictingMountForCtldBind(mount, "cluster-a", "sandbox0-system/ctld-node-b") {
+		t.Fatal("expected ctld owner to block a different ctld bind")
+	}
+}
+
+func mustRegistryMountOptions(t *testing.T, opts volume.MountOptions) *json.RawMessage {
+	t.Helper()
+	raw, err := json.Marshal(opts)
+	if err != nil {
+		t.Fatalf("marshal mount options: %v", err)
+	}
+	msg := json.RawMessage(raw)
+	return &msg
+}

--- a/ctld/internal/ctld/portal/session.go
+++ b/ctld/internal/ctld/portal/session.go
@@ -44,8 +44,14 @@ func (m *localVolumeManager) remove(volumeID string) (*volume.VolumeContext, boo
 	return volCtx, ok
 }
 
-func (m *localVolumeManager) MountVolume(context.Context, string, string, string, volume.AccessMode) (string, time.Time, error) {
-	return "", time.Time{}, fmt.Errorf("ctld portal does not support remote mount")
+func (m *localVolumeManager) MountVolume(_ context.Context, _ string, volumeID string, _ string, _ volume.AccessMode) (string, time.Time, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	volCtx := m.volumes[volumeID]
+	if volCtx == nil {
+		return "", time.Time{}, fmt.Errorf("volume %s not mounted", volumeID)
+	}
+	return "local-" + volumeID, time.Now().UTC(), nil
 }
 
 func (m *localVolumeManager) UnmountVolume(_ context.Context, volumeID, _ string) error {
@@ -61,6 +67,36 @@ func (m *localVolumeManager) UnmountVolume(_ context.Context, volumeID, _ string
 
 func (m *localVolumeManager) AckInvalidate(string, string, string, bool, string) error {
 	return nil
+}
+
+func (m *localVolumeManager) AcquireDirectVolumeFileMount(ctx context.Context, volumeID string, mountFn func(context.Context) (string, error)) (func(), error) {
+	m.mu.RLock()
+	volCtx := m.volumes[volumeID]
+	m.mu.RUnlock()
+	if volCtx == nil {
+		return nil, fmt.Errorf("volume %s not mounted", volumeID)
+	}
+	if mountFn != nil {
+		if _, err := mountFn(ctx); err != nil {
+			return nil, err
+		}
+	}
+	return func() {}, nil
+}
+
+func (m *localVolumeManager) CleanupIdleDirectVolumeFileMount(context.Context, string) (bool, error) {
+	return false, nil
+}
+
+func (m *localVolumeManager) SyncDirectVolumeFileMount(_ context.Context, volumeID string) error {
+	m.mu.RLock()
+	volCtx := m.volumes[volumeID]
+	m.mu.RUnlock()
+	if volCtx == nil || volCtx.S0FS == nil {
+		return fmt.Errorf("volume %s not mounted", volumeID)
+	}
+	_, err := volCtx.S0FS.SyncMaterialize(context.Background())
+	return err
 }
 
 func (m *localVolumeManager) GetVolume(volumeID string) (*volume.VolumeContext, error) {

--- a/ctld/internal/ctld/portal/volume_api.go
+++ b/ctld/internal/ctld/portal/volume_api.go
@@ -1,0 +1,58 @@
+package portal
+
+import (
+	"net/http"
+	"strings"
+
+	apiconfig "github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
+	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
+	fsserver "github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/fsserver"
+	sphttp "github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/http"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/notify"
+	"github.com/sirupsen/logrus"
+)
+
+const volumeFileAffinityTeamHeader = "X-Sandbox0-Volume-Team-Id"
+
+func newMountedVolumeAPIHandler(storageCfg *apiconfig.StorageProxyConfig, repo *db.Repository, volumes *localVolumeManager, logger *logrus.Logger) http.Handler {
+	if repo == nil || volumes == nil || logger == nil {
+		return nil
+	}
+
+	queueSize := 256
+	if storageCfg != nil && storageCfg.WatchEventQueueSize > 0 {
+		queueSize = storageCfg.WatchEventQueueSize
+	}
+	eventHub := notify.NewHub(logger, queueSize)
+	fileRPC := fsserver.NewFileSystemServer(volumes, repo, eventHub, notify.NewLocalBroadcaster(eventHub), logger, nil, nil)
+	server := sphttp.NewServer(logger, storageCfg, nil, repo, nil, "", nil, nil, nil, nil, volumes, fileRPC, eventHub)
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !isMountedVolumeAPIPath(r.URL.Path) {
+			http.NotFound(w, r)
+			return
+		}
+
+		teamID := strings.TrimSpace(r.Header.Get(volumeFileAffinityTeamHeader))
+		if teamID == "" {
+			http.Error(w, "missing team id", http.StatusUnauthorized)
+			return
+		}
+
+		claims := &internalauth.Claims{
+			Caller:   internalauth.ServiceStorageProxy,
+			Target:   internalauth.ServiceCtld,
+			TeamID:   teamID,
+			IsSystem: true,
+		}
+		server.ServeHTTP(w, r.WithContext(internalauth.WithClaims(r.Context(), claims)))
+	})
+}
+
+func isMountedVolumeAPIPath(path string) bool {
+	if !strings.HasPrefix(path, "/sandboxvolumes/") {
+		return false
+	}
+	return strings.Contains(path, "/files")
+}

--- a/ctld/internal/ctld/server/server.go
+++ b/ctld/internal/ctld/server/server.go
@@ -22,6 +22,10 @@ type VolumePortalController interface {
 	UnbindVolumePortal(r *http.Request, req ctldapi.UnbindVolumePortalRequest) (ctldapi.UnbindVolumePortalResponse, int)
 }
 
+type MountedVolumeController interface {
+	MountedVolumeHandler() http.Handler
+}
+
 type NotImplementedController struct{}
 
 func (NotImplementedController) Pause(_ *http.Request, _ string) (ctldapi.PauseResponse, int) {
@@ -54,6 +58,11 @@ func NewMux(controller Controller) http.Handler {
 		_, _ = w.Write([]byte("ok"))
 	})
 	mux.Handle("/metrics", promhttp.Handler())
+	if mountedController, ok := controller.(MountedVolumeController); ok {
+		if mountedHandler := mountedController.MountedVolumeHandler(); mountedHandler != nil {
+			mux.Handle("/sandboxvolumes/", mountedHandler)
+		}
+	}
 	mux.HandleFunc("/api/v1/volume-portals/bind", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			w.WriteHeader(http.StatusMethodNotAllowed)

--- a/infra-operator/internal/controller/services/ctld/ctld.go
+++ b/infra-operator/internal/controller/services/ctld/ctld.go
@@ -16,6 +16,7 @@ import (
 
 	infrav1alpha1 "github.com/sandbox0-ai/sandbox0/infra-operator/api/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/pkg/common"
+	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/database"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/storage"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/runtimeconfig"
 	"github.com/sandbox0-ai/sandbox0/pkg/volumeportal"
@@ -106,6 +107,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 									Name: "NODE_NAME",
 									ValueFrom: &corev1.EnvVarSource{
 										FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
+									},
+								},
+								{
+									Name: "POD_NAME",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
+									},
+								},
+								{
+									Name: "POD_NAMESPACE",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"},
 									},
 								},
 							},
@@ -313,6 +326,11 @@ func (r *Reconciler) buildStorageConfig(ctx context.Context, infra *infrav1alpha
 	cfg := &apiconfig.StorageProxyConfig{}
 	if infra != nil && infra.Spec.Services != nil && infra.Spec.Services.StorageProxy != nil {
 		cfg = runtimeconfig.ToStorageProxy(infra.Spec.Services.StorageProxy.Config)
+	}
+	if infra != nil && infra.Spec.Database != nil && r != nil && r.Resources != nil && r.Resources.Client != nil {
+		if dsn, err := database.GetDatabaseDSN(ctx, r.Resources.Client, infra); err == nil {
+			cfg.DatabaseURL = dsn
+		}
 	}
 	if infra == nil || infra.Spec.Storage == nil {
 		return cfg, nil

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -468,12 +468,26 @@ func (s *SandboxService) bindWebhookStatePortal(ctx context.Context, pod *corev1
 	return err
 }
 
+func (s *SandboxService) prepareVolumePortalBind(ctx context.Context, teamID, userID, volumeID string) error {
+	if s == nil || s.volumeMetadata == nil {
+		return nil
+	}
+	preparer, ok := s.volumeMetadata.(SandboxVolumePortalPreparationClient)
+	if !ok {
+		return nil
+	}
+	return preparer.PrepareForVolumePortalBind(ctx, teamID, userID, volumeID)
+}
+
 func (s *SandboxService) bindVolumePortal(ctx context.Context, pod *corev1.Pod, teamID, userID, ownerTeamID, volumeID, mountPoint, portalName string) (*ctldapi.BindVolumePortalResponse, error) {
 	if s == nil || s.ctldClient == nil {
 		return nil, fmt.Errorf("ctld client is not configured")
 	}
 	if pod == nil {
 		return nil, fmt.Errorf("pod is nil")
+	}
+	if err := s.prepareVolumePortalBind(ctx, teamID, userID, volumeID); err != nil {
+		return nil, fmt.Errorf("prepare volume portal bind: %w", err)
 	}
 	ctldAddress, err := s.ctldAddressForPod(ctx, pod)
 	if err != nil {

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -715,6 +715,8 @@ func TestValidateVolumePortalAccessAllowsROXOnlyForReadOnlyTemplateMount(t *test
 type fakeVolumeMetadataClient struct {
 	accessMode string
 	err        error
+	prepared   []string
+	prepareErr error
 }
 
 func (c fakeVolumeMetadataClient) Get(_ context.Context, teamID, userID, volumeID string) (*SandboxVolumeInfo, error) {
@@ -727,6 +729,29 @@ func (c fakeVolumeMetadataClient) Get(_ context.Context, teamID, userID, volumeI
 		UserID:     userID,
 		AccessMode: c.accessMode,
 	}, nil
+}
+
+func (c *fakeVolumeMetadataClient) PrepareForVolumePortalBind(_ context.Context, teamID, userID, volumeID string) error {
+	if c == nil {
+		return nil
+	}
+	c.prepared = append(c.prepared, teamID+":"+userID+":"+volumeID)
+	return c.prepareErr
+}
+
+func TestPrepareVolumePortalBindUsesPreparationClientWhenAvailable(t *testing.T) {
+	metadata := &fakeVolumeMetadataClient{}
+	svc := &SandboxService{volumeMetadata: metadata}
+
+	if err := svc.prepareVolumePortalBind(context.Background(), "team-a", "user-a", "vol-1"); err != nil {
+		t.Fatalf("prepareVolumePortalBind() error = %v", err)
+	}
+	if len(metadata.prepared) != 1 {
+		t.Fatalf("prepared calls = %d, want 1", len(metadata.prepared))
+	}
+	if metadata.prepared[0] != "team-a:user-a:vol-1" {
+		t.Fatalf("prepared call = %q, want %q", metadata.prepared[0], "team-a:user-a:vol-1")
+	}
 }
 
 func newClaimTestPodLister(t *testing.T, pods ...*corev1.Pod) corelisters.PodLister {

--- a/manager/pkg/service/sandbox_webhook_state.go
+++ b/manager/pkg/service/sandbox_webhook_state.go
@@ -38,6 +38,10 @@ type SandboxVolumeMetadataClient interface {
 	Get(ctx context.Context, teamID, userID, volumeID string) (*SandboxVolumeInfo, error)
 }
 
+type SandboxVolumePortalPreparationClient interface {
+	PrepareForVolumePortalBind(ctx context.Context, teamID, userID, volumeID string) error
+}
+
 type StorageProxyVolumeClient struct {
 	baseURL        string
 	httpClient     *http.Client
@@ -185,6 +189,40 @@ func (c *StorageProxyVolumeClient) Get(ctx context.Context, teamID, userID, volu
 		return nil, fmt.Errorf("get sandbox volume returned no id")
 	}
 	return volume, nil
+}
+
+func (c *StorageProxyVolumeClient) PrepareForVolumePortalBind(ctx context.Context, teamID, userID, volumeID string) error {
+	if c == nil || c.baseURL == "" {
+		return fmt.Errorf("storage-proxy volume client is not configured")
+	}
+	volumeID = strings.TrimSpace(volumeID)
+	if volumeID == "" {
+		return fmt.Errorf("volume id is required")
+	}
+	token, err := c.generateToken(teamID, userID, "")
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, c.baseURL+"/internal/v1/sandboxvolumes/"+url.PathEscape(volumeID)+"/prepare-portal-bind", nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("X-Internal-Token", token)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("prepare sandbox volume for portal bind: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+	data, _ := io.ReadAll(resp.Body)
+	_, apiErr, decodeErr := spec.DecodeResponse[map[string]any](bytes.NewReader(data))
+	if decodeErr == nil && apiErr != nil {
+		return fmt.Errorf("prepare sandbox volume for portal bind failed: %s", apiErr.Message)
+	}
+	return fmt.Errorf("prepare sandbox volume for portal bind failed with status %d", resp.StatusCode)
 }
 
 func (c *StorageProxyVolumeClient) MarkSandboxForCleanup(ctx context.Context, teamID, userID, sandboxID, reason string) error {

--- a/manager/pkg/service/sandbox_webhook_state_test.go
+++ b/manager/pkg/service/sandbox_webhook_state_test.go
@@ -44,3 +44,31 @@ func TestStorageProxyVolumeClientDefaultsClusterID(t *testing.T) {
 		t.Fatalf("clusterID = %q, want %q", gotClusterID, naming.DefaultClusterID)
 	}
 }
+
+func TestStorageProxyVolumeClientPrepareForPortalBind(t *testing.T) {
+	var gotMethod, gotPath, gotToken string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotToken = r.Header.Get("X-Internal-Token")
+		_ = spec.WriteSuccess(w, http.StatusOK, map[string]any{"prepared": true})
+	}))
+	defer server.Close()
+
+	client := NewStorageProxyVolumeClient(StorageProxyVolumeClientConfig{
+		BaseURL:        server.URL,
+		TokenGenerator: staticTokenGenerator{},
+	})
+	if err := client.PrepareForVolumePortalBind(t.Context(), "team-1", "user-1", "vol-1"); err != nil {
+		t.Fatalf("PrepareForVolumePortalBind() error = %v", err)
+	}
+	if gotMethod != http.MethodPut {
+		t.Fatalf("method = %q, want %q", gotMethod, http.MethodPut)
+	}
+	if gotPath != "/internal/v1/sandboxvolumes/vol-1/prepare-portal-bind" {
+		t.Fatalf("path = %q, want %q", gotPath, "/internal/v1/sandboxvolumes/vol-1/prepare-portal-bind")
+	}
+	if gotToken == "" {
+		t.Fatal("expected internal token header to be set")
+	}
+}

--- a/storage-proxy/pkg/coordinator/coordinator.go
+++ b/storage-proxy/pkg/coordinator/coordinator.go
@@ -267,6 +267,12 @@ func (c *Coordinator) RegisterMount(ctx context.Context, volumeID string, option
 
 	normalizedOptions := options
 	normalizedOptions.AccessMode = volume.NormalizeAccessMode(string(options.AccessMode))
+	if normalizedOptions.OwnerKind == "" {
+		normalizedOptions.OwnerKind = volume.OwnerKindStorageProxy
+	}
+	if normalizedOptions.OwnerPort == 0 && c.config != nil && c.config.HTTPPort > 0 {
+		normalizedOptions.OwnerPort = c.config.HTTPPort
+	}
 	rawOptions, err := json.Marshal(normalizedOptions)
 	if err != nil {
 		return fmt.Errorf("marshal mount options: %w", err)

--- a/storage-proxy/pkg/http/handlers_sandboxvolume.go
+++ b/storage-proxy/pkg/http/handlers_sandboxvolume.go
@@ -608,6 +608,49 @@ func (s *Server) deleteOwnedSandboxVolume(w http.ResponseWriter, r *http.Request
 	_ = spec.WriteSuccess(w, http.StatusOK, map[string]bool{"deleted": true})
 }
 
+func (s *Server) prepareSandboxVolumeForPortalBind(w http.ResponseWriter, r *http.Request) {
+	claims, ok := s.requireManagerInternal(w, r)
+	if !ok {
+		return
+	}
+
+	id := strings.TrimSpace(r.PathValue("id"))
+	if id == "" {
+		_ = spec.WriteError(w, http.StatusBadRequest, spec.CodeBadRequest, "id is required")
+		return
+	}
+
+	vol, err := s.repo.GetSandboxVolume(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			_ = spec.WriteError(w, http.StatusNotFound, spec.CodeNotFound, "not found")
+			return
+		}
+		s.logger.WithError(err).WithField("volume_id", id).Error("Failed to get sandbox volume before portal bind preparation")
+		_ = spec.WriteError(w, http.StatusInternalServerError, spec.CodeInternal, "internal server error")
+		return
+	}
+	if !claims.IsSystemToken() && claims.TeamID != "" && vol.TeamID != claims.TeamID {
+		_ = spec.WriteError(w, http.StatusNotFound, spec.CodeNotFound, "not found")
+		return
+	}
+
+	cleaned := false
+	if s.volMgr != nil {
+		cleaned, err = s.volMgr.CleanupIdleDirectVolumeFileMount(r.Context(), id)
+		if err != nil {
+			s.logger.WithError(err).WithField("volume_id", id).Warn("Failed to cleanup direct volume mount before portal bind")
+			_ = spec.WriteError(w, http.StatusInternalServerError, spec.CodeInternal, "failed to cleanup direct volume mount")
+			return
+		}
+	}
+
+	_ = spec.WriteSuccess(w, http.StatusOK, map[string]any{
+		"prepared": true,
+		"cleaned":  cleaned,
+	})
+}
+
 func (s *Server) forkVolume(w http.ResponseWriter, r *http.Request) {
 	claims := internalauth.ClaimsFromContext(r.Context())
 	if claims == nil {

--- a/storage-proxy/pkg/http/handlers_sandboxvolume_test.go
+++ b/storage-proxy/pkg/http/handlers_sandboxvolume_test.go
@@ -215,6 +215,42 @@ func TestMarkOwnedSandboxVolumesForCleanupIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestPrepareSandboxVolumeForPortalBindCleansIdleDirectMount(t *testing.T) {
+	repo := newFakeHTTPRepo()
+	repo.volumes["vol-1"] = &db.SandboxVolume{ID: "vol-1", TeamID: "team-1", UserID: "user-1"}
+	volMgr := &fakeHTTPVolumeMountManager{
+		cleanupDirectFunc: func(context.Context, string) (bool, error) {
+			return true, nil
+		},
+	}
+	server := &Server{
+		logger: logrus.New(),
+		repo:   repo,
+		volMgr: volMgr,
+	}
+
+	req := httptest.NewRequest(http.MethodPut, "/internal/v1/sandboxvolumes/vol-1/prepare-portal-bind", nil)
+	req.SetPathValue("id", "vol-1")
+	req = req.WithContext(internalauth.WithClaims(req.Context(), &internalauth.Claims{
+		Caller: internalauth.ServiceManager,
+		TeamID: "team-1",
+		UserID: "user-1",
+	}))
+	recorder := httptest.NewRecorder()
+
+	server.prepareSandboxVolumeForPortalBind(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	if volMgr.cleanupCalls != 1 {
+		t.Fatalf("cleanup calls = %d, want 1", volMgr.cleanupCalls)
+	}
+	if volMgr.lastCleanupVolume != "vol-1" {
+		t.Fatalf("cleanup volume = %q, want %q", volMgr.lastCleanupVolume, "vol-1")
+	}
+}
+
 func TestForkVolumePassesDefaultPosixIdentity(t *testing.T) {
 	snapshotMgr := &captureForkSnapshotManager{fakeHTTPSnapshotManager: &fakeHTTPSnapshotManager{}}
 	server := &Server{

--- a/storage-proxy/pkg/http/handlers_volume_files.go
+++ b/storage-proxy/pkg/http/handlers_volume_files.go
@@ -262,14 +262,15 @@ func (s *Server) handleVolumeFileWatch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, err := s.loadAuthorizedVolume(r.Context(), volumeID); err != nil {
+	volumeRecord, err := s.loadAuthorizedVolume(r.Context(), volumeID)
+	if err != nil {
 		s.writeVolumeFileError(w, err)
 		return
 	}
 	if err := httpproxy.DisableResponseDeadlines(w); err != nil {
 		s.logger.WithError(err).WithField("volume_id", volumeID).Debug("Failed to disable volume file watch response deadlines")
 	}
-	proxied, err := s.proxyVolumeRequestToOwnerIfNeeded(w, r, volumeID)
+	proxied, err := s.proxyVolumeRequestToOwnerIfNeeded(w, r, volumeRecord)
 	if err != nil {
 		s.writeVolumeFileError(w, err)
 		return
@@ -519,7 +520,7 @@ func (s *Server) prepareVolumeFileRequest(ctx context.Context, volumeID string) 
 	if err != nil {
 		return ctx, nil, func() {}, err
 	}
-	cleanup, err := s.prepareVolumeFileMount(ctx, volumeID)
+	cleanup, err := s.prepareVolumeFileMount(ctx, volumeID, volumeRecord.TeamID)
 	if err != nil {
 		return ctx, nil, func() {}, err
 	}

--- a/storage-proxy/pkg/http/handlers_volume_files_test.go
+++ b/storage-proxy/pkg/http/handlers_volume_files_test.go
@@ -3,11 +3,13 @@ package http
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"syscall"
 	"testing"
 	"time"
@@ -40,6 +42,16 @@ type fakeHTTPVolumeMountManager struct {
 
 type fakeVolumeFilePodResolver struct {
 	urls map[string]string
+}
+
+func mustMountOptionsRaw(t *testing.T, opts volume.MountOptions) *json.RawMessage {
+	t.Helper()
+	raw, err := json.Marshal(opts)
+	if err != nil {
+		t.Fatalf("marshal mount options: %v", err)
+	}
+	msg := json.RawMessage(raw)
+	return &msg
 }
 
 func (f *fakeVolumeFilePodResolver) ResolvePodURL(_ context.Context, podID string) (*url.URL, error) {
@@ -627,6 +639,74 @@ func TestHandleVolumeFileStatProxiesToRemoteOwnerPod(t *testing.T) {
 		}
 	default:
 		t.Fatal("expected request to be proxied to remote owner")
+	}
+}
+
+func TestHandleVolumeFileStatPrefersCtldOwnerAndPropagatesTeamHeader(t *testing.T) {
+	remoteSeen := make(chan *http.Request, 1)
+	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case remoteSeen <- r.Clone(r.Context()):
+		default:
+		}
+		_, _ = io.WriteString(w, `{"success":true,"data":{"name":"proxied.txt","path":"/proxied.txt","type":"file","size":7}}`)
+	}))
+	defer remote.Close()
+	remoteURL, err := url.Parse(remote.URL)
+	if err != nil {
+		t.Fatalf("parse remote url: %v", err)
+	}
+	remotePort, err := strconv.Atoi(remoteURL.Port())
+	if err != nil {
+		t.Fatalf("parse remote port: %v", err)
+	}
+
+	fileRPC := &fakeHTTPVolumeFileRPC{}
+	server, volMgr := newVolumeFileTestServer(fileRPC)
+	repo := server.repo.(*fakeHTTPRepo)
+	repo.activeMounts["vol-1"] = []*db.VolumeMount{
+		{
+			VolumeID:     "vol-1",
+			ClusterID:    "cluster-a",
+			PodID:        "local-pod",
+			MountedAt:    time.Unix(20, 0),
+			MountOptions: mustMountOptionsRaw(t, volume.MountOptions{AccessMode: volume.AccessModeRWO, OwnerKind: volume.OwnerKindStorageProxy}),
+		},
+		{
+			VolumeID:     "vol-1",
+			ClusterID:    "cluster-a",
+			PodID:        "sandbox0-system/ctld-node-a",
+			MountedAt:    time.Unix(10, 0),
+			MountOptions: mustMountOptionsRaw(t, volume.MountOptions{AccessMode: volume.AccessModeRWO, OwnerKind: volume.OwnerKindCtld, OwnerPort: remotePort}),
+		},
+	}
+	server.podResolver = &fakeVolumeFilePodResolver{
+		urls: map[string]string{"sandbox0-system/ctld-node-a": "http://127.0.0.1"},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/sandboxvolumes/vol-1/files/stat?path=/docs/report.txt", nil)
+	req.SetPathValue("id", "vol-1")
+	req = req.WithContext(internalauth.WithClaims(req.Context(), &internalauth.Claims{TeamID: "team-a"}))
+	recorder := httptest.NewRecorder()
+
+	server.handleVolumeFileStat(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+	if volMgr.acquireCalls != 0 {
+		t.Fatalf("AcquireDirectVolumeFileMount() calls = %d, want 0", volMgr.acquireCalls)
+	}
+	select {
+	case seen := <-remoteSeen:
+		if got := seen.Header.Get(volumeFileAffinityRoutedPodHeader); got != "sandbox0-system/ctld-node-a" {
+			t.Fatalf("routed pod header = %q, want %q", got, "sandbox0-system/ctld-node-a")
+		}
+		if got := seen.Header.Get(volumeFileAffinityTeamHeader); got != "team-a" {
+			t.Fatalf("team header = %q, want %q", got, "team-a")
+		}
+	default:
+		t.Fatal("expected request to be proxied to ctld owner")
 	}
 }
 

--- a/storage-proxy/pkg/http/server.go
+++ b/storage-proxy/pkg/http/server.go
@@ -182,6 +182,7 @@ func NewServer(logger *logrus.Logger, cfg *config.StorageProxyConfig, k8sClient 
 	s.mux.HandleFunc("PUT /internal/v1/sandboxvolumes/owned/cleanup", s.markOwnedSandboxVolumesForCleanup)
 	s.mux.HandleFunc("PUT /internal/v1/sandboxvolumes/owned/{id}/cleanup-attempt", s.markOwnedSandboxVolumeCleanupAttempt)
 	s.mux.HandleFunc("DELETE /internal/v1/sandboxvolumes/owned/{id}", s.deleteOwnedSandboxVolume)
+	s.mux.HandleFunc("PUT /internal/v1/sandboxvolumes/{id}/prepare-portal-bind", s.prepareSandboxVolumeForPortalBind)
 
 	// Snapshot handlers
 	s.mux.HandleFunc("POST /sandboxvolumes/{volume_id}/snapshots", s.createSnapshot)

--- a/storage-proxy/pkg/http/volume_affinity.go
+++ b/storage-proxy/pkg/http/volume_affinity.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -13,6 +14,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volume"
 	pb "github.com/sandbox0-ai/sandbox0/storage-proxy/proto/fs"
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -20,6 +22,7 @@ import (
 )
 
 const volumeFileAffinityRoutedPodHeader = "X-Sandbox0-Volume-Routed-Pod"
+const volumeFileAffinityTeamHeader = "X-Sandbox0-Volume-Team-Id"
 
 type volumeFilePodResolver interface {
 	ResolvePodURL(ctx context.Context, podID string) (*url.URL, error)
@@ -122,7 +125,7 @@ func (s *Server) prepareOrProxyVolumeFileRequest(w http.ResponseWriter, r *http.
 		return r.Context(), nil, func() {}, true
 	}
 
-	proxied, err := s.proxyVolumeRequestToOwnerIfNeeded(w, r, volumeID)
+	proxied, err := s.proxyVolumeRequestToOwnerIfNeeded(w, r, volumeRecord)
 	if err != nil {
 		s.writeVolumeFileError(w, err)
 		return r.Context(), nil, func() {}, true
@@ -137,11 +140,11 @@ func (s *Server) prepareOrProxyVolumeFileRequest(w http.ResponseWriter, r *http.
 		return r.Context(), nil, func() {}, true
 	}
 
-	cleanup, err := s.prepareVolumeFileMount(r.Context(), volumeID)
+	cleanup, err := s.prepareVolumeFileMount(r.Context(), volumeID, volumeRecord.TeamID)
 	if err != nil {
 		var redirectErr *volumeOwnerRedirectError
 		if errors.As(err, &redirectErr) && redirectErr != nil && redirectErr.TargetURL != nil && r.Header.Get(volumeFileAffinityRoutedPodHeader) == "" {
-			s.proxyVolumeRequestToOwner(w, r, redirectErr.TargetURL, redirectErr.PodID)
+			s.proxyVolumeRequestToOwner(w, r, redirectErr.TargetURL, redirectErr.PodID, volumeRecord.TeamID)
 			return r.Context(), volumeRecord, func() {}, true
 		}
 		s.writeVolumeFileError(w, err)
@@ -151,7 +154,7 @@ func (s *Server) prepareOrProxyVolumeFileRequest(w http.ResponseWriter, r *http.
 	return withVolumeFileActor(r.Context(), actor), volumeRecord, cleanup, false
 }
 
-func (s *Server) prepareVolumeFileMount(ctx context.Context, volumeID string) (func(), error) {
+func (s *Server) prepareVolumeFileMount(ctx context.Context, volumeID, teamID string) (func(), error) {
 	if s.volMgr == nil || s.fileRPC == nil {
 		return func() {}, errVolumeFileUnavailable
 	}
@@ -188,15 +191,15 @@ func (s *Server) prepareVolumeFileMount(ctx context.Context, volumeID string) (f
 	return cleanup, nil
 }
 
-func (s *Server) proxyVolumeRequestToOwnerIfNeeded(w http.ResponseWriter, r *http.Request, volumeID string) (bool, error) {
-	if s == nil || s.repo == nil || s.podResolver == nil || volumeID == "" {
+func (s *Server) proxyVolumeRequestToOwnerIfNeeded(w http.ResponseWriter, r *http.Request, volumeRecord *db.SandboxVolume) (bool, error) {
+	if s == nil || s.repo == nil || s.podResolver == nil || volumeRecord == nil || volumeRecord.ID == "" {
 		return false, nil
 	}
 	if r != nil && r.Header.Get(volumeFileAffinityRoutedPodHeader) != "" {
 		return false, nil
 	}
 
-	targetURL, ownerPodID, err := s.resolveRemoteVolumeOwnerURL(r.Context(), volumeID)
+	targetURL, ownerPodID, err := s.resolveRemoteVolumeOwnerURL(r.Context(), volumeRecord.ID)
 	if err != nil {
 		return false, err
 	}
@@ -204,7 +207,7 @@ func (s *Server) proxyVolumeRequestToOwnerIfNeeded(w http.ResponseWriter, r *htt
 		return false, nil
 	}
 
-	s.proxyVolumeRequestToOwner(w, r, targetURL, ownerPodID)
+	s.proxyVolumeRequestToOwner(w, r, targetURL, ownerPodID, volumeRecord.TeamID)
 	return true, nil
 }
 
@@ -222,7 +225,11 @@ func (s *Server) resolveRemoteVolumeOwnerURL(ctx context.Context, volumeID strin
 		return nil, "", err
 	}
 	owner := s.selectPreferredVolumeOwner(mounts)
-	if owner == nil || owner.PodID == "" || owner.PodID == s.selfPodID {
+	if owner == nil || owner.PodID == "" {
+		return nil, "", nil
+	}
+	ownerOpts := volume.DecodeMountOptions(owner.MountOptions)
+	if ownerOpts.OwnerKind != volume.OwnerKindCtld && owner.PodID == s.selfPodID {
 		return nil, "", nil
 	}
 
@@ -230,11 +237,23 @@ func (s *Server) resolveRemoteVolumeOwnerURL(ctx context.Context, volumeID strin
 	if err != nil {
 		return nil, "", err
 	}
+	if targetURL == nil {
+		return nil, "", nil
+	}
+	targetURL = cloneURL(targetURL)
+	ownerPort := ownerOpts.OwnerPort
+	if ownerPort == 0 && ownerOpts.OwnerKind == volume.OwnerKindCtld {
+		ownerPort = 8095
+	}
+	if ownerPort > 0 {
+		targetURL.Host = hostWithPort(targetURL.Host, ownerPort)
+	}
 	return targetURL, owner.PodID, nil
 }
 
 func (s *Server) selectPreferredVolumeOwner(mounts []*db.VolumeMount) *db.VolumeMount {
 	var chosen *db.VolumeMount
+	bestScore := int(^uint(0) >> 1)
 	for _, mount := range mounts {
 		if mount == nil || mount.PodID == "" {
 			continue
@@ -242,25 +261,48 @@ func (s *Server) selectPreferredVolumeOwner(mounts []*db.VolumeMount) *db.Volume
 		if s.selfClusterID != "" && mount.ClusterID != "" && mount.ClusterID != s.selfClusterID {
 			continue
 		}
-		if mount.PodID == s.selfPodID {
-			return mount
-		}
-		if chosen == nil {
+		score := s.volumeOwnerPriority(mount)
+		if chosen == nil || score < bestScore ||
+			(score == bestScore && mount.MountedAt.Before(chosen.MountedAt)) ||
+			(score == bestScore && mount.MountedAt.Equal(chosen.MountedAt) && mount.PodID < chosen.PodID) {
 			chosen = mount
-			continue
-		}
-		if mount.MountedAt.Before(chosen.MountedAt) {
-			chosen = mount
-			continue
-		}
-		if mount.MountedAt.Equal(chosen.MountedAt) && mount.PodID < chosen.PodID {
-			chosen = mount
+			bestScore = score
 		}
 	}
 	return chosen
 }
 
-func (s *Server) proxyVolumeRequestToOwner(w http.ResponseWriter, r *http.Request, targetURL *url.URL, ownerPodID string) {
+func (s *Server) volumeOwnerPriority(mount *db.VolumeMount) int {
+	if mount == nil {
+		return 100
+	}
+	opts := volume.DecodeMountOptions(mount.MountOptions)
+	if opts.OwnerKind == volume.OwnerKindCtld {
+		return 0
+	}
+	if mount.PodID == s.selfPodID {
+		return 1
+	}
+	return 2
+}
+
+func cloneURL(in *url.URL) *url.URL {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	return &out
+}
+
+func hostWithPort(hostport string, port int) string {
+	host := hostport
+	if parsedHost, _, err := net.SplitHostPort(hostport); err == nil {
+		host = parsedHost
+	}
+	return net.JoinHostPort(host, fmt.Sprintf("%d", port))
+}
+
+func (s *Server) proxyVolumeRequestToOwner(w http.ResponseWriter, r *http.Request, targetURL *url.URL, ownerPodID, teamID string) {
 	if targetURL == nil {
 		s.writeVolumeFileError(w, errVolumeFileUnavailable)
 		return
@@ -272,6 +314,9 @@ func (s *Server) proxyVolumeRequestToOwner(w http.ResponseWriter, r *http.Reques
 			req.URL.Host = targetURL.Host
 			req.Host = targetURL.Host
 			req.Header.Set(volumeFileAffinityRoutedPodHeader, ownerPodID)
+			if strings.TrimSpace(teamID) != "" {
+				req.Header.Set(volumeFileAffinityTeamHeader, teamID)
+			}
 		},
 		Transport: &http.Transport{
 			MaxIdleConns:        50,

--- a/storage-proxy/pkg/volume/access_mode.go
+++ b/storage-proxy/pkg/volume/access_mode.go
@@ -1,6 +1,9 @@
 package volume
 
-import "strings"
+import (
+	"encoding/json"
+	"strings"
+)
 
 // AccessMode describes how a volume can be mounted across storage-proxy instances.
 type AccessMode string
@@ -14,9 +17,18 @@ const (
 	AccessModeRWX AccessMode = "RWX"
 )
 
+const (
+	OwnerKindStorageProxy = "storage-proxy"
+	OwnerKindCtld         = "ctld"
+)
+
 // MountOptions describes how a volume is mounted by an instance.
 type MountOptions struct {
-	AccessMode AccessMode `json:"access_mode,omitempty"`
+	AccessMode   AccessMode `json:"access_mode,omitempty"`
+	OwnerKind    string     `json:"owner_kind,omitempty"`
+	OwnerPort    int        `json:"owner_port,omitempty"`
+	NodeName     string     `json:"node_name,omitempty"`
+	PodNamespace string     `json:"pod_namespace,omitempty"`
 }
 
 // NormalizeAccessMode normalizes the input and applies the default mode (RWO).
@@ -46,4 +58,28 @@ func ParseAccessMode(value string) (AccessMode, bool) {
 	default:
 		return "", false
 	}
+}
+
+func NormalizeOwnerKind(value string) string {
+	switch strings.TrimSpace(value) {
+	case OwnerKindCtld:
+		return OwnerKindCtld
+	case OwnerKindStorageProxy:
+		return OwnerKindStorageProxy
+	default:
+		return ""
+	}
+}
+
+func DecodeMountOptions(raw *json.RawMessage) MountOptions {
+	if raw == nil || len(*raw) == 0 {
+		return MountOptions{}
+	}
+	var opts MountOptions
+	if err := json.Unmarshal(*raw, &opts); err != nil {
+		return MountOptions{}
+	}
+	opts.AccessMode = NormalizeAccessMode(string(opts.AccessMode))
+	opts.OwnerKind = NormalizeOwnerKind(opts.OwnerKind)
+	return opts
 }

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -1922,6 +1922,17 @@ func assertClaimMountedVolumeWritable(env *framework.ScenarioEnv, session *e2eut
 	Expect(*claimResp.BootstrapMounts).NotTo(BeEmpty())
 	Expect((*claimResp.BootstrapMounts)[0].State).To(Equal(apispec.MountStatusStateMounted))
 
+	apiPath := "/api-after-claim.txt"
+	apiContent := []byte(fmt.Sprintf("api write after claim %d", time.Now().UnixNano()))
+	status, err = session.WriteVolumeFile(env.TestCtx.Context, GinkgoT(), volumeID, apiPath, apiContent, "")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+
+	Eventually(func() ([]byte, error) {
+		body, _, readErr := session.ReadFile(env.TestCtx.Context, GinkgoT(), sandboxID, mountPoint+apiPath)
+		return body, readErr
+	}).WithTimeout(90 * time.Second).WithPolling(2 * time.Second).Should(Equal(apiContent))
+
 	latePath := "/late-after-claim.txt"
 	lateContent := fmt.Sprintf("late write after claim %d", time.Now().UnixNano())
 	processType := apispec.ProcessTypeCmd


### PR DESCRIPTION
## Summary
- register mounted RWO ctld portals in the shared volume owner registry and keep heartbeats alive while bound
- expose mounted volume file APIs from ctld using the same local S0FS engine as the sandbox mount
- make storage-proxy prefer ctld owners for mounted volumes and proxy volume file requests instead of direct-mounting locally
- extend mounted-volume regression coverage to assert both `pod -> volume API` and `volume API -> pod` consistency

## Why
Mounted sandbox volumes were still split between two engines:
- sandbox pod mount path -> ctld local S0FS
- volume API -> storage-proxy direct mount

That allowed `ctld -> object store -> volume API` visibility while leaving `volume API -> mounted sandbox view` broken. This PR closes that gap by enforcing a single active owner for mounted RWO volumes.

## Validation
- `go test ./storage-proxy/pkg/http ./ctld/internal/ctld/portal ./ctld/internal/ctld/server ./ctld/cmd/ctld ./infra-operator/internal/controller/services/ctld ./tests/e2e/cases`
- `go test ./storage-proxy/... ./ctld/... ./infra-operator/...`

## Notes
- I also wrote `/Users/huangzhihao/sandbox0/workspace/s0-volume.md` to pin the target architecture and acceptance criteria for this round.
- Local kind validation is blocked in this environment because Docker daemon access is unavailable. PR E2E should exercise the real kind path.