### PR TITLE
Delete completed sandbox pods in cleanup controller

### DIFF
--- a/manager/pkg/controller/cleanup_controller.go
+++ b/manager/pkg/controller/cleanup_controller.go
@@ -149,6 +149,12 @@ func (cc *CleanupController) cleanupExpired(ctx context.Context, template *v1alp
 			cc.forceDeleteStaleDeletingPod(ctx, template, pod, now)
 			continue
 		}
+		if pod.Status.Phase == corev1.PodSucceeded {
+			if cc.deleteCompletedPod(ctx, template, pod) {
+				expiredCount++
+			}
+			continue
+		}
 
 		// Hard expiry: delete even if paused.
 		if hardExpiresAtStr := pod.Annotations[AnnotationHardExpiresAt]; hardExpiresAtStr != "" {
@@ -247,6 +253,45 @@ func (cc *CleanupController) cleanupExpired(ctx context.Context, template *v1alp
 	}
 
 	return nil
+}
+
+func (cc *CleanupController) deleteCompletedPod(ctx context.Context, template *v1alpha1.SandboxTemplate, pod *corev1.Pod) bool {
+	if pod == nil {
+		return false
+	}
+
+	cc.logger.Info("Deleting completed sandbox pod",
+		zap.String("pod", pod.Name),
+		zap.String("phase", string(pod.Status.Phase)),
+	)
+
+	if cc.sandboxTerminator != nil {
+		if err := cc.sandboxTerminator.TerminateSandboxByID(ctx, pod.Name); err != nil {
+			cc.logger.Error("Failed to delete completed sandbox pod",
+				zap.String("pod", pod.Name),
+				zap.Error(err),
+			)
+			return false
+		}
+	} else {
+		if cc.k8sClient == nil {
+			cc.logger.Warn("Kubernetes client not configured, skipping completed sandbox pod delete",
+				zap.String("pod", pod.Name),
+			)
+			return false
+		}
+		if err := cc.k8sClient.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{}); err != nil {
+			cc.logger.Error("Failed to delete completed sandbox pod",
+				zap.String("pod", pod.Name),
+				zap.Error(err),
+			)
+			return false
+		}
+	}
+
+	cc.recorder.Eventf(template, corev1.EventTypeNormal, "CompletedPodDeleted",
+		"Deleted completed sandbox pod %s", pod.Name)
+	return true
 }
 
 func (cc *CleanupController) forceDeleteStaleDeletingPod(ctx context.Context, template *v1alpha1.SandboxTemplate, pod *corev1.Pod, now time.Time) {

--- a/manager/pkg/controller/cleanup_controller_test.go
+++ b/manager/pkg/controller/cleanup_controller_test.go
@@ -36,6 +36,15 @@ func (r *recordingPauseRequester) RequestPauseSandboxByID(_ context.Context, san
 	return nil
 }
 
+type recordingSandboxTerminator struct {
+	calls []string
+}
+
+func (r *recordingSandboxTerminator) TerminateSandboxByID(_ context.Context, sandboxID string) error {
+	r.calls = append(r.calls, sandboxID)
+	return nil
+}
+
 func TestCleanupExpiredRequestsPauseDesiredState(t *testing.T) {
 	now := time.Date(2026, time.April, 15, 19, 31, 0, 0, time.UTC)
 	template := &v1alpha1.SandboxTemplate{
@@ -188,5 +197,109 @@ func TestCleanupExpiredForceDeletesStaleDeletingPod(t *testing.T) {
 		assert.Contains(t, event, "StaleDeletingPodForceDeleted")
 	default:
 		t.Fatal("expected stale force-delete event")
+	}
+}
+
+func TestCleanupExpiredDeletesCompletedSandboxPodViaTerminator(t *testing.T) {
+	now := time.Date(2026, time.April, 15, 19, 31, 0, 0, time.UTC)
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: "tpl-default",
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sandbox-1",
+			Namespace: "tpl-default",
+			Labels: map[string]string{
+				LabelTemplateID: "default",
+				LabelPoolType:   PoolTypeActive,
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodSucceeded,
+		},
+	}
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+	})
+	require.NoError(t, indexer.Add(pod))
+
+	terminator := &recordingSandboxTerminator{}
+	recorder := record.NewFakeRecorder(1)
+	controller := NewCleanupController(
+		nil,
+		corelisters.NewPodLister(indexer),
+		nil,
+		recorder,
+		staticCleanupClock{now: now},
+		nil,
+		terminator,
+		zap.NewNop(),
+		time.Minute,
+	)
+
+	require.NoError(t, controller.cleanupExpired(context.Background(), template))
+
+	assert.Equal(t, []string{"sandbox-1"}, terminator.calls)
+	select {
+	case event := <-recorder.Events:
+		assert.Contains(t, event, "CompletedPodDeleted")
+	default:
+		t.Fatal("expected completed-pod-deleted event")
+	}
+}
+
+func TestCleanupExpiredDeletesCompletedSandboxPodDirectlyWhenTerminatorMissing(t *testing.T) {
+	now := time.Date(2026, time.April, 15, 19, 31, 0, 0, time.UTC)
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: "tpl-default",
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sandbox-1",
+			Namespace: "tpl-default",
+			UID:       types.UID("pod-uid-1"),
+			Labels: map[string]string{
+				LabelTemplateID: "default",
+				LabelPoolType:   PoolTypeActive,
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodSucceeded,
+		},
+	}
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+	})
+	require.NoError(t, indexer.Add(pod))
+
+	client := fake.NewSimpleClientset(pod)
+	recorder := record.NewFakeRecorder(1)
+	controller := NewCleanupController(
+		client,
+		corelisters.NewPodLister(indexer),
+		nil,
+		recorder,
+		staticCleanupClock{now: now},
+		nil,
+		nil,
+		zap.NewNop(),
+		time.Minute,
+	)
+
+	require.NoError(t, controller.cleanupExpired(context.Background(), template))
+
+	_, err := client.CoreV1().Pods("tpl-default").Get(context.Background(), "sandbox-1", metav1.GetOptions{})
+	require.True(t, apierrors.IsNotFound(err), "expected completed pod to be deleted, got %v", err)
+	select {
+	case event := <-recorder.Events:
+		assert.Contains(t, event, "CompletedPodDeleted")
+	default:
+		t.Fatal("expected completed-pod-deleted event")
 	}
 }


### PR DESCRIPTION
## Summary
- delete active sandbox pods that have already reached `Succeeded` in the cleanup controller
- reuse `TerminateSandboxByID` when available so completed pod cleanup still goes through sandbox lifecycle finalizers
- add controller tests for both terminator-backed and direct-delete cleanup paths

## Testing
- `go test ./manager/pkg/controller ./manager/pkg/service`
- pre-push hook: `make manifests`, `make proto`, `make apispec`, `go fmt ./...`, `go mod tidy`, `go mod vendor`, `golangci-lint run ./...`