### PR TITLE
Optimize s0fs materialization and cold reads

### DIFF
--- a/storage-proxy/pkg/s0fs/engine.go
+++ b/storage-proxy/pkg/s0fs/engine.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"slices"
 	"sync"
@@ -498,7 +497,7 @@ func (e *Engine) SyncMaterialize(ctx context.Context) (*Manifest, error) {
 		return nil, nil
 	}
 	version := e.mutationVersion
-	state, err := e.exportStateLocked()
+	state, err := e.materializeStateLocked()
 	if err != nil {
 		e.mu.RUnlock()
 		return nil, err
@@ -514,6 +513,9 @@ func (e *Engine) SyncMaterialize(ctx context.Context) (*Manifest, error) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	if e.mutationVersion == version {
+		if manifest.State != nil {
+			e.replaceStateLocked(cloneState(manifest.State))
+		}
 		if err := e.persistCurrentStateLocked(); err != nil {
 			return nil, err
 		}
@@ -959,6 +961,19 @@ func (e *Engine) exportStateLocked() (*SnapshotState, error) {
 	return state, nil
 }
 
+func (e *Engine) materializeStateLocked() (*SnapshotState, error) {
+	state := cloneState(e.currentStateLocked())
+	if len(state.ColdFiles) == 0 {
+		return state, nil
+	}
+	for inode := range state.ColdFiles {
+		if state.Nodes[inode] == nil {
+			delete(state.ColdFiles, inode)
+		}
+	}
+	return state, nil
+}
+
 func (e *Engine) readFileLocked(node *Node, inode uint64, offset uint64, size uint64) ([]byte, error) {
 	if node == nil {
 		return nil, ErrNotFound
@@ -1049,17 +1064,9 @@ func (e *Engine) readColdRangeLocked(inode uint64, offset uint64, size uint64) (
 			return nil, fmt.Errorf("%w: missing segment %s", ErrInvalidInput, extent.SegmentID)
 		}
 		segmentOffset := extent.Offset + (readStart - extentStart)
-		reader, err := e.materializer.store.Get(segment.Key, int64(segmentOffset), int64(readEnd-readStart))
+		chunk, err := e.materializer.ReadSegmentRange(segment, int64(segmentOffset), int64(readEnd-readStart))
 		if err != nil {
 			return nil, fmt.Errorf("read cold segment %s: %w", segment.Key, err)
-		}
-		chunk, readErr := io.ReadAll(reader)
-		closeErr := reader.Close()
-		if readErr != nil {
-			return nil, fmt.Errorf("read cold segment payload %s: %w", segment.Key, readErr)
-		}
-		if closeErr != nil {
-			return nil, fmt.Errorf("close cold segment reader %s: %w", segment.Key, closeErr)
 		}
 		if _, err := out.Write(chunk); err != nil {
 			return nil, fmt.Errorf("assemble cold file data: %w", err)

--- a/storage-proxy/pkg/s0fs/materializer.go
+++ b/storage-proxy/pkg/s0fs/materializer.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/objectstore"
@@ -20,6 +21,8 @@ const (
 	manifestDir       = "manifests"
 	segmentDir        = "segments"
 )
+
+const defaultSegmentCacheMaxBytes int64 = 64 << 20
 
 var ErrMaterializedManifestNotFound = errors.New("materialized manifest not found")
 
@@ -34,13 +37,17 @@ type Manifest struct {
 
 type Materializer struct {
 	store objectstore.Store
+	cache *segmentCache
 }
 
 func NewMaterializer(store objectstore.Store) *Materializer {
 	if store == nil {
 		return nil
 	}
-	return &Materializer{store: store}
+	return &Materializer{
+		store: store,
+		cache: newSegmentCache(defaultSegmentCacheMaxBytes),
+	}
 }
 
 func (m *Materializer) Enabled() bool {
@@ -62,9 +69,7 @@ func (m *Materializer) Materialize(ctx context.Context, volumeID string, state *
 	}
 
 	inline := cloneState(state)
-	if len(inline.ColdFiles) > 0 {
-		return nil, fmt.Errorf("%w: materializer requires inline file data", ErrInvalidInput)
-	}
+	normalizeState(inline)
 
 	nextSeq, err := m.nextManifestSequence(ctx)
 	if err != nil {
@@ -76,21 +81,9 @@ func (m *Materializer) Materialize(ctx context.Context, volumeID string, state *
 		return nil, err
 	}
 
-	manifestState := &SnapshotState{
-		NextSeq:   inline.NextSeq,
-		NextInode: inline.NextInode,
-		Nodes:     cloneNodeMap(inline.Nodes),
-		Children:  cloneChildrenMap(inline.Children),
-		Data:      nil,
-		ColdFiles: fileExtents,
-		Segments: map[string]*Segment{
-			segment.ID: &Segment{
-				ID:     segment.ID,
-				Key:    segment.Key,
-				Length: uint64(len(segment.Payload)),
-				SHA256: segment.SHA256,
-			},
-		},
+	manifestState, err := buildManifestState(inline, segment, fileExtents)
+	if err != nil {
+		return nil, err
 	}
 	manifest := &Manifest{
 		Version:       1,
@@ -105,6 +98,7 @@ func (m *Materializer) Materialize(ctx context.Context, volumeID string, state *
 		if err := m.putBytes(ctx, segment.Key, segment.Payload); err != nil {
 			return nil, err
 		}
+		m.cache.put(segment.Key, segment.Payload)
 	}
 	if err := m.putJSON(ctx, manifestKey(nextSeq), manifest); err != nil {
 		return nil, err
@@ -114,6 +108,55 @@ func (m *Materializer) Materialize(ctx context.Context, volumeID string, state *
 	}
 
 	return manifest, nil
+}
+
+func (m *Materializer) ReadSegmentRange(segment *Segment, off, limit int64) ([]byte, error) {
+	if !m.Enabled() {
+		return nil, fmt.Errorf("%w: materializer is not configured", ErrInvalidInput)
+	}
+	if segment == nil || segment.Key == "" {
+		return nil, fmt.Errorf("%w: segment is required", ErrInvalidInput)
+	}
+	if limit == 0 {
+		return nil, nil
+	}
+	if off < 0 {
+		return nil, fmt.Errorf("%w: negative segment offset", ErrInvalidInput)
+	}
+
+	if segment.Length > 0 && int64(segment.Length) <= defaultSegmentCacheMaxBytes {
+		if payload, ok := m.cache.get(segment.Key); ok {
+			return cloneByteRange(payload, off, limit), nil
+		}
+		reader, err := m.store.Get(segment.Key, 0, int64(segment.Length))
+		if err != nil {
+			return nil, err
+		}
+		payload, readErr := io.ReadAll(reader)
+		closeErr := reader.Close()
+		if readErr != nil {
+			return nil, readErr
+		}
+		if closeErr != nil {
+			return nil, closeErr
+		}
+		m.cache.put(segment.Key, payload)
+		return cloneByteRange(payload, off, limit), nil
+	}
+
+	reader, err := m.store.Get(segment.Key, off, limit)
+	if err != nil {
+		return nil, err
+	}
+	payload, readErr := io.ReadAll(reader)
+	closeErr := reader.Close()
+	if readErr != nil {
+		return nil, readErr
+	}
+	if closeErr != nil {
+		return nil, closeErr
+	}
+	return payload, nil
 }
 
 func (m *Materializer) LoadLatestManifest(ctx context.Context) (*Manifest, error) {
@@ -194,6 +237,56 @@ func buildSegment(manifestSeq uint64, state *SnapshotState) (*materializedSegmen
 	return segment, files, nil
 }
 
+func buildManifestState(state *SnapshotState, segment *materializedSegment, hotFiles map[uint64][]FileExtent) (*SnapshotState, error) {
+	manifestState := &SnapshotState{
+		NextSeq:   state.NextSeq,
+		NextInode: state.NextInode,
+		Nodes:     cloneNodeMap(state.Nodes),
+		Children:  cloneChildrenMap(state.Children),
+		Data:      make(map[uint64][]byte),
+		ColdFiles: make(map[uint64][]FileExtent),
+		Segments:  make(map[string]*Segment),
+	}
+
+	hotInodes := make(map[uint64]struct{}, len(state.Data))
+	for inode := range state.Data {
+		hotInodes[inode] = struct{}{}
+	}
+
+	for inode, extents := range state.ColdFiles {
+		if _, hot := hotInodes[inode]; hot {
+			continue
+		}
+		if state.Nodes[inode] == nil {
+			continue
+		}
+		manifestState.ColdFiles[inode] = append([]FileExtent(nil), extents...)
+		for _, extent := range extents {
+			existing := state.Segments[extent.SegmentID]
+			if existing == nil {
+				return nil, fmt.Errorf("%w: missing retained segment %s", ErrInvalidInput, extent.SegmentID)
+			}
+			manifestState.Segments[extent.SegmentID] = cloneSegment(existing)
+		}
+	}
+
+	for inode, extents := range hotFiles {
+		if state.Nodes[inode] == nil {
+			continue
+		}
+		manifestState.ColdFiles[inode] = append([]FileExtent(nil), extents...)
+	}
+	if segment != nil && len(segment.Payload) > 0 {
+		manifestState.Segments[segment.ID] = &Segment{
+			ID:     segment.ID,
+			Key:    segment.Key,
+			Length: uint64(len(segment.Payload)),
+			SHA256: segment.SHA256,
+		}
+	}
+	return manifestState, nil
+}
+
 func manifestKey(seq uint64) string {
 	return fmt.Sprintf("%s/%020d.json", manifestDir, seq)
 }
@@ -256,6 +349,70 @@ func (m *Materializer) putBytes(ctx context.Context, key string, payload []byte)
 		return fmt.Errorf("put %s: %w", key, err)
 	}
 	return nil
+}
+
+func cloneByteRange(payload []byte, off, limit int64) []byte {
+	if off > int64(len(payload)) {
+		off = int64(len(payload))
+	}
+	end := int64(len(payload))
+	if limit >= 0 && off+limit < end {
+		end = off + limit
+	}
+	return append([]byte(nil), payload[off:end]...)
+}
+
+type segmentCache struct {
+	mu       sync.Mutex
+	maxBytes int64
+	size     int64
+	entries  map[string][]byte
+	order    []string
+}
+
+func newSegmentCache(maxBytes int64) *segmentCache {
+	if maxBytes <= 0 {
+		maxBytes = defaultSegmentCacheMaxBytes
+	}
+	return &segmentCache{
+		maxBytes: maxBytes,
+		entries:  make(map[string][]byte),
+	}
+}
+
+func (c *segmentCache) get(key string) ([]byte, bool) {
+	if c == nil || key == "" {
+		return nil, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	payload, ok := c.entries[key]
+	return payload, ok
+}
+
+func (c *segmentCache) put(key string, payload []byte) {
+	if c == nil || key == "" || int64(len(payload)) > c.maxBytes {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if existing, ok := c.entries[key]; ok {
+		c.size -= int64(len(existing))
+	} else {
+		c.order = append(c.order, key)
+	}
+	c.entries[key] = append([]byte(nil), payload...)
+	c.size += int64(len(payload))
+
+	for c.size > c.maxBytes && len(c.order) > 0 {
+		evict := c.order[0]
+		c.order = c.order[1:]
+		if evicted, ok := c.entries[evict]; ok {
+			delete(c.entries, evict)
+			c.size -= int64(len(evicted))
+		}
+	}
 }
 
 func cloneNodeMap(nodes map[uint64]*Node) map[uint64]*Node {

--- a/storage-proxy/pkg/s0fs/materializer_test.go
+++ b/storage-proxy/pkg/s0fs/materializer_test.go
@@ -20,11 +20,17 @@ type getCall struct {
 	limit int64
 }
 
+type putCall struct {
+	key  string
+	size int
+}
+
 type recordingStore struct {
 	objectstore.Store
 
 	mu   sync.Mutex
 	gets []getCall
+	puts []putCall
 }
 
 func (s *recordingStore) Get(key string, off, limit int64) (io.ReadCloser, error) {
@@ -34,12 +40,38 @@ func (s *recordingStore) Get(key string, off, limit int64) (io.ReadCloser, error
 	return s.Store.Get(key, off, limit)
 }
 
+func (s *recordingStore) Put(key string, in io.Reader) error {
+	payload, err := io.ReadAll(in)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	s.puts = append(s.puts, putCall{key: key, size: len(payload)})
+	s.mu.Unlock()
+	return s.Store.Put(key, bytes.NewReader(payload))
+}
+
 func (s *recordingStore) calls() []getCall {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	out := make([]getCall, len(s.gets))
 	copy(out, s.gets)
 	return out
+}
+
+func (s *recordingStore) putCalls() []putCall {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]putCall, len(s.puts))
+	copy(out, s.puts)
+	return out
+}
+
+func (s *recordingStore) resetCalls() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.gets = nil
+	s.puts = nil
 }
 
 func TestEngineMaterializeRecoversViaColdRangeRead(t *testing.T) {
@@ -107,8 +139,8 @@ func TestEngineMaterializeRecoversViaColdRangeRead(t *testing.T) {
 	if segmentRead == nil {
 		t.Fatal("expected a cold segment Get call")
 	}
-	if segmentRead.off != 6 || segmentRead.limit != 5 {
-		t.Fatalf("segment range read = %+v, want off=6 limit=5", *segmentRead)
+	if segmentRead.off != 0 || segmentRead.limit != 11 {
+		t.Fatalf("segment cache read = %+v, want full segment read", *segmentRead)
 	}
 }
 
@@ -367,6 +399,223 @@ func TestMaterializerCoalescesSmallFilesAndKeepsManifestMonotonic(t *testing.T) 
 	}
 	if len(objects) >= 12 {
 		t.Fatalf("object count = %d, want < 12 for 64 files", len(objects))
+	}
+}
+
+func TestMaterializerRetainsColdFilesAndWritesOnlyHotData(t *testing.T) {
+	ctx := context.Background()
+	store := newPrefixedRecordingStore(t, "vol-retain")
+	walPath := filepath.Join(t.TempDir(), "engine.wal")
+
+	engine, err := Open(ctx, Config{
+		VolumeID:    "vol-retain",
+		WALPath:     walPath,
+		ObjectStore: store,
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer engine.Close()
+
+	baseA, err := engine.CreateFile(RootInode, "a.txt", 0o644)
+	if err != nil {
+		t.Fatalf("CreateFile(a) error = %v", err)
+	}
+	if _, err := engine.Write(baseA.Inode, 0, []byte("alpha")); err != nil {
+		t.Fatalf("Write(a) error = %v", err)
+	}
+	baseB, err := engine.CreateFile(RootInode, "b.txt", 0o644)
+	if err != nil {
+		t.Fatalf("CreateFile(b) error = %v", err)
+	}
+	if _, err := engine.Write(baseB.Inode, 0, []byte("bravo")); err != nil {
+		t.Fatalf("Write(b) error = %v", err)
+	}
+	first, err := engine.SyncMaterialize(ctx)
+	if err != nil {
+		t.Fatalf("SyncMaterialize(first) error = %v", err)
+	}
+	if first == nil || len(first.State.Segments) != 1 {
+		t.Fatalf("first manifest segments = %+v", first)
+	}
+	firstSegmentID := first.State.ColdFiles[baseA.Inode][0].SegmentID
+	store.resetCalls()
+
+	tail, err := engine.CreateFile(RootInode, "tail.txt", 0o644)
+	if err != nil {
+		t.Fatalf("CreateFile(tail) error = %v", err)
+	}
+	if _, err := engine.Write(tail.Inode, 0, []byte("tail")); err != nil {
+		t.Fatalf("Write(tail) error = %v", err)
+	}
+	second, err := engine.SyncMaterialize(ctx)
+	if err != nil {
+		t.Fatalf("SyncMaterialize(second) error = %v", err)
+	}
+	if second == nil || second.ManifestSeq != 2 {
+		t.Fatalf("second manifest = %+v, want seq 2", second)
+	}
+	if len(second.State.Segments) != 2 {
+		t.Fatalf("second manifest segment count = %d, want 2", len(second.State.Segments))
+	}
+	if got := second.State.ColdFiles[baseA.Inode][0].SegmentID; got != firstSegmentID {
+		t.Fatalf("a.txt segment = %s, want retained %s", got, firstSegmentID)
+	}
+	if got := second.State.ColdFiles[tail.Inode][0].SegmentID; got == firstSegmentID {
+		t.Fatalf("tail.txt reused base segment %s", got)
+	}
+
+	var segmentGets int
+	for _, call := range store.calls() {
+		if strings.HasPrefix(call.key, segmentDir+"/") {
+			segmentGets++
+		}
+	}
+	if segmentGets != 0 {
+		t.Fatalf("segment Get calls during incremental materialize = %d, want 0", segmentGets)
+	}
+	var segmentPuts []putCall
+	for _, call := range store.putCalls() {
+		if strings.HasPrefix(call.key, segmentDir+"/") {
+			segmentPuts = append(segmentPuts, call)
+		}
+	}
+	if len(segmentPuts) != 1 || segmentPuts[0].size != len("tail") {
+		t.Fatalf("segment Put calls = %+v, want one hot segment of size 4", segmentPuts)
+	}
+}
+
+func TestEngineColdSmallFileReadsUseSegmentCache(t *testing.T) {
+	ctx := context.Background()
+	store := newPrefixedRecordingStore(t, "vol-cache")
+	walPath := filepath.Join(t.TempDir(), "engine.wal")
+
+	engine, err := Open(ctx, Config{
+		VolumeID:    "vol-cache",
+		WALPath:     walPath,
+		ObjectStore: store,
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	for _, item := range []struct {
+		name string
+		body string
+	}{
+		{name: "a.txt", body: "alpha"},
+		{name: "b.txt", body: "bravo"},
+		{name: "c.txt", body: "charlie"},
+	} {
+		node, err := engine.CreateFile(RootInode, item.name, 0o644)
+		if err != nil {
+			t.Fatalf("CreateFile(%s) error = %v", item.name, err)
+		}
+		if _, err := engine.Write(node.Inode, 0, []byte(item.body)); err != nil {
+			t.Fatalf("Write(%s) error = %v", item.name, err)
+		}
+	}
+	if _, err := engine.SyncMaterialize(ctx); err != nil {
+		t.Fatalf("SyncMaterialize() error = %v", err)
+	}
+	if err := engine.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	if err := os.Remove(headStatePath(walPath)); err != nil {
+		t.Fatalf("Remove(head) error = %v", err)
+	}
+	if err := os.Remove(walPath); err != nil {
+		t.Fatalf("Remove(wal) error = %v", err)
+	}
+
+	recovered, err := Open(ctx, Config{
+		VolumeID:    "vol-cache",
+		WALPath:     walPath,
+		ObjectStore: store,
+	})
+	if err != nil {
+		t.Fatalf("Open(recovered) error = %v", err)
+	}
+	defer recovered.Close()
+	store.resetCalls()
+
+	for _, item := range []struct {
+		name string
+		body string
+	}{
+		{name: "a.txt", body: "alpha"},
+		{name: "b.txt", body: "bravo"},
+		{name: "c.txt", body: "charlie"},
+	} {
+		node, err := recovered.Lookup(RootInode, item.name)
+		if err != nil {
+			t.Fatalf("Lookup(%s) error = %v", item.name, err)
+		}
+		payload, err := recovered.Read(node.Inode, 0, node.Size)
+		if err != nil {
+			t.Fatalf("Read(%s) error = %v", item.name, err)
+		}
+		if string(payload) != item.body {
+			t.Fatalf("Read(%s) = %q, want %q", item.name, payload, item.body)
+		}
+	}
+
+	var segmentGets []getCall
+	for _, call := range store.calls() {
+		if strings.HasPrefix(call.key, segmentDir+"/") {
+			segmentGets = append(segmentGets, call)
+		}
+	}
+	if len(segmentGets) != 1 {
+		t.Fatalf("segment Get calls = %+v, want exactly one cached segment read", segmentGets)
+	}
+	if segmentGets[0].off != 0 || segmentGets[0].limit <= 0 {
+		t.Fatalf("segment cache read = %+v, want full segment read", segmentGets[0])
+	}
+}
+
+func TestCreateSnapshotHydratesColdFilesInline(t *testing.T) {
+	ctx := context.Background()
+	store := newPrefixedRecordingStore(t, "vol-snapshot")
+	walPath := filepath.Join(t.TempDir(), "engine.wal")
+
+	engine, err := Open(ctx, Config{
+		VolumeID:    "vol-snapshot",
+		WALPath:     walPath,
+		ObjectStore: store,
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer engine.Close()
+
+	node, err := engine.CreateFile(RootInode, "snap.txt", 0o644)
+	if err != nil {
+		t.Fatalf("CreateFile() error = %v", err)
+	}
+	if _, err := engine.Write(node.Inode, 0, []byte("snapshot-data")); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	if _, err := engine.SyncMaterialize(ctx); err != nil {
+		t.Fatalf("SyncMaterialize() error = %v", err)
+	}
+
+	state, err := engine.CreateSnapshot("snap-1")
+	if err != nil {
+		t.Fatalf("CreateSnapshot() error = %v", err)
+	}
+	if len(state.ColdFiles) != 0 {
+		t.Fatalf("snapshot cold files = %+v, want inline data", state.ColdFiles)
+	}
+	snapNode, err := state.Lookup(RootInode, "snap.txt")
+	if err != nil {
+		t.Fatalf("snapshot Lookup() error = %v", err)
+	}
+	payload, err := state.Read(snapNode.Inode, 0, snapNode.Size)
+	if err != nil {
+		t.Fatalf("SnapshotState.Read() error = %v", err)
+	}
+	if string(payload) != "snapshot-data" {
+		t.Fatalf("snapshot data = %q, want snapshot-data", payload)
 	}
 }
 

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -1962,6 +1962,34 @@ func assertClaimMountedVolumeWritable(env *framework.ScenarioEnv, session *e2eut
 		body, _, readErr := session.ReadVolumeFile(env.TestCtx.Context, GinkgoT(), volumeID, latePath)
 		return body, readErr
 	}).WithTimeout(90 * time.Second).WithPolling(2 * time.Second).Should(Equal([]byte(lateContent)))
+
+	batchReq := apispec.CreateContextRequest{
+		Type: &processType,
+		Cmd: &apispec.CreateCMDContextRequest{
+			Command: []string{
+				"/bin/sh",
+				"-lc",
+				`set -eu; mkdir -p /workspace/claim-writable/small-batch; i=0; while [ "$i" -lt 16 ]; do name=$(printf "file-%02d.txt" "$i"); body=$(printf "batch-%02d" "$i"); printf "%s" "$body" > "/workspace/claim-writable/small-batch/$name"; i=$((i + 1)); done; sync`,
+			},
+		},
+		TtlSec: &ttlSec,
+	}
+	batchCtxResp, status, err := session.CreateContext(env.TestCtx.Context, GinkgoT(), sandboxID, batchReq)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusCreated))
+	Expect(batchCtxResp).NotTo(BeNil())
+	DeferCleanup(func() {
+		_, _ = session.DeleteContext(env.TestCtx.Context, GinkgoT(), sandboxID, batchCtxResp.Id)
+	})
+
+	for _, index := range []int{0, 7, 15} {
+		path := fmt.Sprintf("/small-batch/file-%02d.txt", index)
+		expected := []byte(fmt.Sprintf("batch-%02d", index))
+		Eventually(func() ([]byte, error) {
+			body, _, readErr := session.ReadVolumeFile(env.TestCtx.Context, GinkgoT(), volumeID, path)
+			return body, readErr
+		}).WithTimeout(90 * time.Second).WithPolling(2 * time.Second).Should(Equal(expected))
+	}
 }
 
 func deleteSandboxVolumeForCleanup(env *framework.ScenarioEnv, session *e2eutils.Session, volumeID string) {


### PR DESCRIPTION
## Summary

Closes #252.

This PR changes s0fs materialization from full data rewrite on every dirty flush to a retained-cold-data model:

- retain unchanged cold file extents across materializations instead of hydrating and rewriting them;
- write a new segment only for hot/modified file data;
- switch the owner engine to the materialized cold manifest state after a successful materialize;
- add a bounded per-engine segment cache so small-file cold reads from the same packed segment avoid one S3 range GET per file;
- keep snapshot/fork/export paths using inline hydrated state so snapshots and forks do not reference source-volume segments;
- extend e2e mounted-volume coverage with a small-file batch written inside the sandbox and read back through the volume API.

## Tests

- `go test ./storage-proxy/pkg/s0fs`
- `go test ./storage-proxy/pkg/snapshot`
- `go test ./storage-proxy/pkg/fsserver ./storage-proxy/pkg/http`
- `go test ./tests/e2e/cases ./tests/e2e/utils`
- `go test ./ctld/internal/ctld/...`
- `go test ./storage-proxy/...`
- `go test ./...` partially passed all non-e2e packages; local e2e failed before running specs because local Docker is unavailable: `Cannot connect to the Docker daemon at unix:///var/run/docker.sock`.
- pre-push hook passed: manifests/proto/apispec/fmt/tidy/vendor/golangci-lint.