### PR TITLE
Fix managed-agents docs guidance

### DIFF
--- a/docs/managed-agents/agent-engines/page.mdx
+++ b/docs/managed-agents/agent-engines/page.mdx
@@ -44,6 +44,20 @@ const codexVault = await client.beta.vaults.create({
 });
 ```
 
+Add the model provider token to the selected LLM vault:
+
+```typescript
+await client.beta.vaults.credentials.create(codexVault.id, {
+    display_name: "Model provider API key",
+    auth: {
+        type: "static_bearer",
+        token: process.env.MODEL_API_KEY,
+    },
+});
+```
+
+Use `claudeVault.id` instead of `codexVault.id` when the session should run the Claude engine. LLM credentials must be unbound `static_bearer` credentials; do not set `mcp_server_url` for the model provider token.
+
 Attach exactly one LLM vault to the session:
 
 ```typescript

--- a/docs/managed-agents/agents/page.mdx
+++ b/docs/managed-agents/agents/page.mdx
@@ -83,6 +83,14 @@ If the MCP server needs credentials, attach a vault to the session. The agent de
 
 <CardGrid>
   <LinkCard
+    title="Environments"
+    href="/docs/managed-agents/environments"
+    cta="Prepare"
+  >
+    Define packages and network policy before creating sessions
+  </LinkCard>
+
+  <LinkCard
     title="Sessions"
     href="/docs/managed-agents/sessions"
     cta="Run"

--- a/docs/managed-agents/compatibility/page.mdx
+++ b/docs/managed-agents/compatibility/page.mdx
@@ -30,7 +30,6 @@ Official reference: [Claude Managed Agents quickstart](https://platform.claude.c
 | LLM token | Stored in an LLM vault and projected by Sandbox0 credential policy. |
 | Agent engine | Selected by `sandbox0.managed_agents.engine` on the LLM vault. |
 | Sandbox claim | Runtime setup claims or resumes a Sandbox0 sandbox and mounts a persistent workspace volume. |
-| Sandbox TTL | Controlled by deployment runtime config. `sandbox0.managed_agents.hard_ttl_seconds` session metadata is rejected. |
 | Claude engine | Requires an Anthropic-compatible endpoint. |
 | Codex engine | Requires an OpenAI-compatible endpoint. |
 | Anthropic pre-built skills | Not supported. Use Sandbox0 custom skills. |
@@ -113,18 +112,18 @@ For application code, prefer SDK methods over hardcoded endpoint paths.
 
 <CardGrid>
   <LinkCard
-    title="Overview"
-    href="/docs/managed-agents"
-    cta="Read"
+    title="Credential"
+    href="/docs/credential"
+    cta="Secure"
   >
-    Understand how Managed Agents map onto Sandbox0 primitives
+    Use Sandbox0 credentials for authenticated outbound access
   </LinkCard>
 
   <LinkCard
-    title="SDK Usage"
-    href="/docs/managed-agents/sdk"
-    cta="Run"
+    title="Template"
+    href="/docs/template"
+    cta="Prepare"
   >
-    Use the official Anthropic SDK with the Sandbox0 Managed Agents endpoint
+    Define runtime images, packages, and warm pools
   </LinkCard>
 </CardGrid>

--- a/docs/managed-agents/sessions/page.mdx
+++ b/docs/managed-agents/sessions/page.mdx
@@ -75,7 +75,7 @@ Sandbox0 keeps session state and event history outside the sandbox. The sandbox 
 - Creating or resuming work ensures a sandbox exists for the session.
 - The workspace is backed by a Sandbox0 volume mounted at `/workspace`.
 - The runtime sandbox uses auto-resume.
-- Sandbox TTL is configured by the Managed Agents deployment. Session metadata such as `sandbox0.managed_agents.hard_ttl_seconds` is rejected.
+- Runtime sandbox lifetime is managed by the Managed Agents deployment.
 - The selected agent engine is resolved from the attached LLM vault; if no engine is selected, the default is `claude`.
 
 ## Next

--- a/skills/sandbox0/SKILL.md
+++ b/skills/sandbox0/SKILL.md
@@ -44,3 +44,14 @@ This skill is intentionally thin. Do not rely on local bundled docs for product 
 - Prefer s0 CLI- and SDK-oriented guidance over internal implementation details.
 - Recommend concrete compositions when helpful, for example `REPL + Volume` for persistent coding sessions.
 - Use architecture detail only when it changes the user's design choice, security model, persistence model, networking, or deployment tradeoff.
+
+## Source Repositories
+
+- Sandbox0 core: https://github.com/sandbox0-ai/sandbox0
+- CLI: https://github.com/sandbox0-ai/s0
+- Go SDK: https://github.com/sandbox0-ai/sdk-go
+- JavaScript SDK: https://github.com/sandbox0-ai/sdk-js
+- Python SDK: https://github.com/sandbox0-ai/sdk-py
+- Managed Agents examples and runtime work: https://github.com/sandbox0-ai/managed-agents
+
+When reporting issues, include a minimal reproduction and relevant logs, but remove API keys, tokens, kubeconfigs, customer data, private repository URLs, and any other sensitive personal or organizational information.


### PR DESCRIPTION
## Summary
- add LLM credential creation to the agent engine docs so users know where to pass the model token
- add Environments to the agents next steps
- remove hard_ttl_seconds guidance from sessions and compatibility docs
- point compatibility next steps to the following Credential and Template chapters
- add source repository links and issue redaction guidance to the Sandbox0 skill

## Verification
- `rg -n "hard_ttl_seconds|Sandbox TTL|ttl" docs/managed-agents` returned no matches
- `SANDBOX0_ROOT=/Users/huangzhihao/sandbox0/workspace/sandbox0 npm run build` in sandbox0-cloud
- pre-push hook completed with `0 issues`
