### PR TITLE
Sync s0fs WAL on dirty close

### DIFF
--- a/ctld/internal/ctld/portal/session_test.go
+++ b/ctld/internal/ctld/portal/session_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -193,6 +194,64 @@ func TestLocalSessionReadCacheTracksSmallWrites(t *testing.T) {
 	}
 }
 
+func TestLocalSessionReleaseSyncsDirtyWrites(t *testing.T) {
+	counter := &walSyncCounter{}
+	engine, err := s0fs.Open(context.Background(), s0fs.Config{
+		VolumeID:    "vol-1",
+		WALPath:     filepath.Join(t.TempDir(), "volume.wal"),
+		WALSyncHook: counter.Hook,
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer engine.Close()
+
+	mgr := newLocalVolumeManager()
+	volCtx := &volume.VolumeContext{
+		VolumeID:  "vol-1",
+		TeamID:    "team-a",
+		Backend:   volume.BackendS0FS,
+		S0FS:      engine,
+		Access:    volume.AccessModeRWO,
+		MountedAt: time.Now().UTC(),
+		RootInode: 1,
+		RootPath:  "/",
+	}
+	mgr.add(volCtx)
+	session := newLocalSession("vol-1", mgr, nil)
+
+	createResp, err := session.Create(context.Background(), &pb.CreateRequest{
+		VolumeId: "ignored-by-local-session",
+		Parent:   s0fs.RootInode,
+		Name:     "data.txt",
+		Mode:     0o644,
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if _, err := session.Write(context.Background(), &pb.WriteRequest{
+		VolumeId: "ignored-by-local-session",
+		Inode:    createResp.Inode,
+		HandleId: createResp.HandleId,
+		Data:     []byte("persist"),
+	}); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	if got := counter.Load(); got != 0 {
+		t.Fatalf("sync count after Write() = %d, want 0", got)
+	}
+	if _, err := session.Release(context.Background(), &pb.ReleaseRequest{
+		VolumeId: "ignored-by-local-session",
+		Inode:    createResp.Inode,
+		HandleId: createResp.HandleId,
+	}); err != nil {
+		t.Fatalf("Release() error = %v", err)
+	}
+	if got := counter.Load(); got != 1 {
+		t.Fatalf("sync count after Release() = %d, want 1", got)
+	}
+}
+
 func TestLocalSessionReadCacheResizesOnTruncate(t *testing.T) {
 	engine, err := s0fs.Open(context.Background(), s0fs.Config{
 		VolumeID: "vol-1",
@@ -240,6 +299,18 @@ func TestLocalSessionReadCacheResizesOnTruncate(t *testing.T) {
 	if got := string(session.readCache[localReadCacheKey("vol-1", node.Inode)]); got != "abc" {
 		t.Fatalf("read cache after truncate = %q, want abc", got)
 	}
+}
+
+type walSyncCounter struct {
+	count atomic.Int64
+}
+
+func (c *walSyncCounter) Hook() {
+	c.count.Add(1)
+}
+
+func (c *walSyncCounter) Load() int64 {
+	return c.count.Load()
 }
 
 func TestLocalSessionReadCacheDisabledForRWX(t *testing.T) {

--- a/storage-proxy/pkg/fsserver/server.go
+++ b/storage-proxy/pkg/fsserver/server.go
@@ -227,6 +227,19 @@ func (s *FileSystemServer) clearDirtyWrite(volumeID string, handleID uint64) {
 	delete(s.dirtyWriteHandles, key)
 }
 
+func (s *FileSystemServer) syncS0FSHandle(volCtx *volume.VolumeContext, inode uint64) error {
+	if volCtx == nil || volCtx.S0FS == nil {
+		return nil
+	}
+	if inode == 0 {
+		return nil
+	}
+	if err := volCtx.S0FS.Fsync(inode); err != nil {
+		return mapS0FSError(err)
+	}
+	return nil
+}
+
 func (s *FileSystemServer) recordRemoteSyncChange(ctx context.Context, change *volsync.RemoteChange) context.Context {
 	if s.syncRecorder == nil || change == nil {
 		return ctx
@@ -1423,6 +1436,12 @@ func (s *FileSystemServer) Flush(ctx context.Context, req *pb.FlushRequest) (*pb
 		return nil, err
 	}
 	if isS0FSVolume(volCtx) {
+		if dirty, ok := s.peekDirtyWrite(req.VolumeId, req.HandleId); ok {
+			if err := s.syncS0FSHandle(volCtx, dirty.inode); err != nil {
+				return nil, err
+			}
+			s.clearDirtyWrite(req.VolumeId, req.HandleId)
+		}
 		return &pb.Empty{}, nil
 	}
 
@@ -1455,12 +1474,13 @@ func (s *FileSystemServer) Fsync(ctx context.Context, req *pb.FsyncRequest) (*pb
 		inode, ok := volCtx.HandleInode(req.HandleId)
 		if dirty, dirtyOK := s.peekDirtyWrite(req.VolumeId, req.HandleId); dirtyOK {
 			inode = dirty.inode
+			ok = true
 		}
-		if !ok && inode == 0 {
+		if !ok || inode == 0 {
 			return &pb.Empty{}, nil
 		}
-		if err := volCtx.S0FS.Fsync(inode); err != nil {
-			return nil, mapS0FSError(err)
+		if err := s.syncS0FSHandle(volCtx, inode); err != nil {
+			return nil, err
 		}
 		s.clearDirtyWrite(req.VolumeId, req.HandleId)
 		return &pb.Empty{}, nil
@@ -1500,10 +1520,18 @@ func (s *FileSystemServer) Release(ctx context.Context, req *pb.ReleaseRequest) 
 		return nil, err
 	}
 	if isS0FSVolume(volCtx) {
+		var syncErr error
+		if dirty, ok := s.peekDirtyWrite(req.VolumeId, req.HandleId); ok {
+			syncErr = s.syncS0FSHandle(volCtx, dirty.inode)
+		}
 		if inode, remaining, unlinked, ok := volCtx.ReleaseFileHandle(req.HandleId); ok && remaining == 0 && unlinked {
 			_ = volCtx.S0FS.Forget(inode)
 		}
-		s.takeDirtyWrite(req.VolumeId, req.HandleId)
+		if syncErr != nil {
+			s.clearDirtyWrite(req.VolumeId, req.HandleId)
+			return nil, syncErr
+		}
+		s.clearDirtyWrite(req.VolumeId, req.HandleId)
 		return &pb.Empty{}, nil
 	}
 

--- a/storage-proxy/pkg/fsserver/server_s0fs_test.go
+++ b/storage-proxy/pkg/fsserver/server_s0fs_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"path/filepath"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -180,6 +181,102 @@ func TestS0FSOpenTruncatesExistingFile(t *testing.T) {
 	}
 	if attrResp.Size != 2 {
 		t.Fatalf("GetAttr() size = %d, want 2", attrResp.Size)
+	}
+}
+
+func TestS0FSFlushSyncsDirtyWrites(t *testing.T) {
+	t.Parallel()
+
+	volCtx, syncs := newMountedS0FSVolumeContextWithSyncCounter(t, "vol-1", "team-a")
+	server := newTestFileSystemServer(&fakeVolumeManager{
+		volumes: map[string]*volume.VolumeContext{
+			"vol-1": volCtx,
+		},
+	}, nil, nil)
+	ctx := authContext("team-a", "")
+
+	createResp, err := server.Create(ctx, &pb.CreateRequest{
+		VolumeId: "vol-1",
+		Parent:   1,
+		Name:     "flush.txt",
+		Mode:     0o644,
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if _, err := server.Write(ctx, &pb.WriteRequest{
+		VolumeId: "vol-1",
+		Inode:    createResp.Inode,
+		Offset:   0,
+		Data:     []byte("hello"),
+		HandleId: createResp.HandleId,
+	}); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	if got := syncs.Load(); got != 0 {
+		t.Fatalf("sync count after Write() = %d, want 0", got)
+	}
+	if _, err := server.Flush(ctx, &pb.FlushRequest{
+		VolumeId: "vol-1",
+		HandleId: createResp.HandleId,
+	}); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+	if got := syncs.Load(); got != 1 {
+		t.Fatalf("sync count after Flush() = %d, want 1", got)
+	}
+	if _, err := server.Flush(ctx, &pb.FlushRequest{
+		VolumeId: "vol-1",
+		HandleId: createResp.HandleId,
+	}); err != nil {
+		t.Fatalf("second Flush() error = %v", err)
+	}
+	if got := syncs.Load(); got != 1 {
+		t.Fatalf("sync count after second Flush() = %d, want 1", got)
+	}
+}
+
+func TestS0FSReleaseSyncsDirtyWritesWithoutExplicitFsync(t *testing.T) {
+	t.Parallel()
+
+	volCtx, syncs := newMountedS0FSVolumeContextWithSyncCounter(t, "vol-1", "team-a")
+	server := newTestFileSystemServer(&fakeVolumeManager{
+		volumes: map[string]*volume.VolumeContext{
+			"vol-1": volCtx,
+		},
+	}, nil, nil)
+	ctx := authContext("team-a", "")
+
+	createResp, err := server.Create(ctx, &pb.CreateRequest{
+		VolumeId: "vol-1",
+		Parent:   1,
+		Name:     "release.txt",
+		Mode:     0o644,
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if _, err := server.Write(ctx, &pb.WriteRequest{
+		VolumeId: "vol-1",
+		Inode:    createResp.Inode,
+		Offset:   0,
+		Data:     []byte("hello"),
+		HandleId: createResp.HandleId,
+	}); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	if got := syncs.Load(); got != 0 {
+		t.Fatalf("sync count after Write() = %d, want 0", got)
+	}
+	if _, err := server.Release(ctx, &pb.ReleaseRequest{
+		VolumeId: "vol-1",
+		Inode:    createResp.Inode,
+		HandleId: createResp.HandleId,
+	}); err != nil {
+		t.Fatalf("Release() error = %v", err)
+	}
+	if got := syncs.Load(); got != 1 {
+		t.Fatalf("sync count after Release() = %d, want 1", got)
 	}
 }
 
@@ -589,9 +686,30 @@ func TestS0FSMutationRedirectsWhenRemotePrimary(t *testing.T) {
 func newMountedS0FSVolumeContext(t *testing.T, volumeID, teamID string) *volume.VolumeContext {
 	t.Helper()
 
+	volCtx, _ := newMountedS0FSVolumeContextWithSyncCounter(t, volumeID, teamID)
+	return volCtx
+}
+
+type walSyncCounter struct {
+	count atomic.Int64
+}
+
+func (c *walSyncCounter) Hook() {
+	c.count.Add(1)
+}
+
+func (c *walSyncCounter) Load() int64 {
+	return c.count.Load()
+}
+
+func newMountedS0FSVolumeContextWithSyncCounter(t *testing.T, volumeID, teamID string) (*volume.VolumeContext, *walSyncCounter) {
+	t.Helper()
+
+	counter := &walSyncCounter{}
 	engine, err := s0fs.Open(context.Background(), s0fs.Config{
-		VolumeID: volumeID,
-		WALPath:  filepath.Join(t.TempDir(), "engine.wal"),
+		VolumeID:    volumeID,
+		WALPath:     filepath.Join(t.TempDir(), "engine.wal"),
+		WALSyncHook: counter.Hook,
 	})
 	if err != nil {
 		t.Fatalf("open s0fs engine: %v", err)
@@ -608,7 +726,7 @@ func newMountedS0FSVolumeContext(t *testing.T, volumeID, teamID string) *volume.
 		MountedAt: time.Now(),
 		RootInode: 1,
 		RootPath:  "/",
-	}
+	}, counter
 }
 
 type recordingBroadcaster struct {

--- a/storage-proxy/pkg/s0fs/engine.go
+++ b/storage-proxy/pkg/s0fs/engine.go
@@ -41,7 +41,7 @@ func Open(ctx context.Context, cfg Config) (*Engine, error) {
 		return nil, fmt.Errorf("%w: volume id is required", ErrInvalidInput)
 	}
 
-	walFile, records, err := openWAL(cfg.WALPath)
+	walFile, records, err := openWAL(cfg.WALPath, cfg.WALSyncHook)
 	if err != nil {
 		return nil, err
 	}

--- a/storage-proxy/pkg/s0fs/types.go
+++ b/storage-proxy/pkg/s0fs/types.go
@@ -21,6 +21,7 @@ type Config struct {
 	WALPath             string
 	ObjectStore         objectstore.Store
 	MaterializeInterval time.Duration
+	WALSyncHook         func()
 }
 
 type SnapshotState struct {

--- a/storage-proxy/pkg/s0fs/wal.go
+++ b/storage-proxy/pkg/s0fs/wal.go
@@ -11,11 +11,12 @@ import (
 )
 
 type wal struct {
-	path string
-	file *os.File
+	path   string
+	file   *os.File
+	onSync func()
 }
 
-func openWAL(path string) (*wal, []walRecord, error) {
+func openWAL(path string, onSync func()) (*wal, []walRecord, error) {
 	if path == "" {
 		return nil, nil, fmt.Errorf("%w: wal path is required", ErrInvalidInput)
 	}
@@ -32,7 +33,7 @@ func openWAL(path string) (*wal, []walRecord, error) {
 	if err != nil {
 		return nil, nil, fmt.Errorf("open wal: %w", err)
 	}
-	return &wal{path: path, file: file}, records, nil
+	return &wal{path: path, file: file, onSync: onSync}, records, nil
 }
 
 func readWAL(path string) ([]walRecord, error) {
@@ -86,6 +87,9 @@ func (w *wal) sync() error {
 	}
 	if err := w.file.Sync(); err != nil {
 		return fmt.Errorf("sync wal: %w", err)
+	}
+	if w.onSync != nil {
+		w.onSync()
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

This PR tightens the mounted s0fs durability boundary for dirty file handles:

- keep ordinary `write()` on the fast write-return path;
- sync the s0fs WAL when FUSE `Flush` sees a dirty write handle;
- sync the s0fs WAL when FUSE `Release`/close sees a dirty write handle and the application did not explicitly fsync;
- keep S3 materialization asynchronous, preserving the existing background/owner materialize model;
- add focused fsserver and ctld portal tests that assert dirty close triggers WAL sync.

## Tests

- `go test ./storage-proxy/pkg/s0fs ./storage-proxy/pkg/fsserver`
- `go test ./ctld/internal/ctld/portal`
- `go test ./storage-proxy/... ./ctld/internal/ctld/...`
- pre-push hook passed: manifests/proto/apispec/fmt/tidy/vendor/golangci-lint.