### PR TITLE
Fix e2e binary response contract validation

### DIFF
--- a/tests/e2e/utils/contract_helpers.go
+++ b/tests/e2e/utils/contract_helpers.go
@@ -176,14 +176,8 @@ func normalizePayload(contentType string, payload any) (any, error) {
 	if !isJSONContentType(contentType) {
 		switch value := payload.(type) {
 		case []byte:
-			if len(value) == 0 {
-				return nil, nil
-			}
 			return string(value), nil
 		case string:
-			if strings.TrimSpace(value) == "" {
-				return nil, nil
-			}
 			return value, nil
 		default:
 			return payload, nil

--- a/tests/e2e/utils/contract_helpers_test.go
+++ b/tests/e2e/utils/contract_helpers_test.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestValidateBinaryResponseAllowsEmptyPayload(t *testing.T) {
+	t.Parallel()
+
+	ValidateResponseExample(
+		t,
+		http.MethodGet,
+		"/api/v1/sandboxvolumes/{id}/files",
+		http.StatusOK,
+		contentTypeBinary,
+		[]byte{},
+	)
+}
+
+func TestValidateBinaryResponseAllowsRawBytes(t *testing.T) {
+	t.Parallel()
+
+	ValidateResponseExample(
+		t,
+		http.MethodGet,
+		"/api/v1/sandboxvolumes/{id}/files",
+		http.StatusOK,
+		contentTypeBinary,
+		[]byte("hello"),
+	)
+}


### PR DESCRIPTION
## Summary

This PR fixes the e2e OpenAPI contract validator for raw binary responses:

- keep `application/octet-stream` payloads as strings even when the payload is empty;
- allow empty binary file reads to validate against `type: string, format: binary` instead of being normalized to `null`;
- add e2e utils coverage for empty and non-empty SandboxVolume file reads.

This was hit while running the remote kind volume e2e after the dirty-close WAL sync change: the API returned a valid `application/octet-stream` response, but the test validator normalized the empty body to `null` and failed schema validation before the scenario could continue.

## Tests

- `go test ./tests/e2e/utils`
- `go test ./storage-proxy/pkg/s0fs ./storage-proxy/pkg/fsserver ./ctld/internal/ctld/portal`
- pre-push hook passed: manifests/proto/apispec/fmt/tidy/vendor/golangci-lint