### PR TITLE
docs: refresh cloud-first sandbox0 docs

### DIFF
--- a/docs/credential/page.mdx
+++ b/docs/credential/page.mdx
@@ -2,11 +2,15 @@
 
 Credential features let Sandbox0 authenticate outbound traffic without placing raw secret material inside the sandbox process.
 
+<Callout variant="info">
+Credential sources are team-scoped objects. In Sandbox0 Cloud, sign in with `s0 auth login`, select the correct current team, and create API keys only when you need SDK or raw HTTP access.
+</Callout>
+
 ## The Three Objects
 
 | Object | What it stores | Where it lives |
 |-------|----------------|----------------|
-| `credential source` | Secret material such as tokens, headers, client certificates, or username/password pairs | Credential source API |
+| `credential source` | Secret material such as tokens, headers, client certificates, or username/password pairs | Team-scoped credential source API |
 | `credential binding` | A stable local `ref` plus projection rules that map a source into a runtime auth shape | `network.credentialBindings` |
 | `credential rule` | Destination match rules that decide when outbound auth should be injected | `network.egress.credentialRules` |
 

--- a/docs/credential/sources/page.mdx
+++ b/docs/credential/sources/page.mdx
@@ -2,6 +2,8 @@
 
 Credential sources store the secret material that later gets projected into outbound auth flows.
 
+Sources are created once per team and then referenced by `sourceRef` from sandbox or template network policy.
+
 The API surface is:
 
 | Method | Path | Purpose |
@@ -286,7 +288,7 @@ s0 credential update github-source -f github-source-rotated.yaml`
 /api/v1/credential-sources/{'{name}'}
 </Endpoint>
 
-Delete only succeeds after no sandbox credential binding still references the source.
+Delete only succeeds after no sandbox or template credential binding still references the source.
 
 <Tabs
   tabs={[

--- a/docs/get-started/page.mdx
+++ b/docs/get-started/page.mdx
@@ -1,6 +1,6 @@
 # Get Started
 
-Sandbox0 provides isolated execution environments for AI Agents with persistent storage, session state maintenance, sub-200ms cold starts, and easy self-hosted deployment.
+Sandbox0 provides isolated execution environments for AI agents with persistent storage, session state maintenance, and fast warm claims. Sandbox0 Cloud uses `https://api.sandbox0.ai` for sandboxes, templates, volumes, and credentials. Managed Agents uses `https://agents.sandbox0.ai`.
 
 ## What is Sandbox0?
 
@@ -30,7 +30,7 @@ Get your first sandbox running in minutes.
 
 ### Prerequisites
 
-- A self-hosted deployment
+- A Sandbox0 account
 - `s0` CLI installed
 
 ### Install s0 CLI (Required)
@@ -79,18 +79,27 @@ Manual release archives are available from <DocLink href="https://github.com/san
 
 ### Authenticate
 
-Set up your credentials. Configure the base URL for your [self-hosted deployment](/docs/self-hosted):
+For Sandbox0 Cloud, sign in with `s0 auth login`. That is enough for interactive CLI usage.
 
-First, create an API key to use as `SANDBOX0_TOKEN`:
+If you want to use the SDKs or raw HTTP API, create a team-scoped API key and export it as `SANDBOX0_TOKEN`:
 
 ```bash
 # Login with your account (stores session in ~/.s0/config.yaml)
 s0 auth login
 
-# Create a 30-day admin API key and export it
-export SANDBOX0_TOKEN="$(s0 apikey create --name test-apikey --role admin --expires-in 30d --raw)"
-export SANDBOX0_BASE_URL="http://localhost:30080"
+# If the server did not auto-select a team yet:
+# s0 team list
+# s0 team create --name my-team --home-region <region-id>
+# s0 team use <team-id>
+
+# Create a 30-day API key for SDK and automation usage.
+export SANDBOX0_TOKEN="$(s0 apikey create --name sdk-quickstart --role developer --expires-in 30d --raw)"
+export SANDBOX0_BASE_URL="https://api.sandbox0.ai"
 ```
+
+<Callout variant="info">
+If you only use the local `s0` CLI interactively, you can stop after `s0 auth login`. API keys are the standard way to authenticate SDK and HTTP requests.
+</Callout>
 
 <Tabs
   tabs={[
@@ -98,6 +107,7 @@ export SANDBOX0_BASE_URL="http://localhost:30080"
       label: "Go",
       language: "go",
       code: `import sandbox0 "github.com/sandbox0-ai/sdk-go"
+import "os"
 
 client, err := sandbox0.NewClient(
     sandbox0.WithToken(os.Getenv("SANDBOX0_TOKEN")),
@@ -112,7 +122,7 @@ import os
 
 client = Client(
     token=os.environ["SANDBOX0_TOKEN"],
-    base_url=os.environ.get("SANDBOX0_BASE_URL", "http://localhost:30080"),
+    base_url=os.environ.get("SANDBOX0_BASE_URL", "https://api.sandbox0.ai"),
 )`
     },
     {
@@ -122,7 +132,7 @@ client = Client(
 
 const client = new Client({
     token: process.env.SANDBOX0_TOKEN!,
-    baseUrl: process.env.SANDBOX0_BASE_URL || 'http://localhost:30080',
+    baseUrl: process.env.SANDBOX0_BASE_URL || 'https://api.sandbox0.ai',
 });`
     }
   ]}
@@ -130,7 +140,7 @@ const client = new Client({
 
 ### Claim Your First Sandbox
 
-Create a sandbox from the default template:
+Create a sandbox from the `default` template:
 
 <Tabs
   tabs={[
@@ -183,7 +193,7 @@ import os
 
 client = Client(
     token=os.environ["SANDBOX0_TOKEN"],
-    base_url=os.environ.get("SANDBOX0_BASE_URL", "http://localhost:30080"),
+    base_url=os.environ.get("SANDBOX0_BASE_URL", "https://api.sandbox0.ai"),
 )
 
 # Claim a sandbox from the "default" template
@@ -203,7 +213,7 @@ import { Client } from 'sandbox0';
 
 const client = new Client({
     token: process.env.SANDBOX0_TOKEN!,
-    baseUrl: process.env.SANDBOX0_BASE_URL || 'http://localhost:30080',
+    baseUrl: process.env.SANDBOX0_BASE_URL || 'https://api.sandbox0.ai',
 });
 
 // Claim a sandbox from the "default" template

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -24,6 +24,10 @@
           "title": "Overview"
         },
         {
+          "slug": "pause-resume",
+          "title": "Pause And Resume"
+        },
+        {
           "slug": "contexts",
           "title": "Contexts"
         },

--- a/docs/sandbox/page.mdx
+++ b/docs/sandbox/page.mdx
@@ -4,6 +4,10 @@ A Sandbox is an isolated execution environment where you can run code, manage fi
 
 For shell access and file copy over standard SSH clients, see [SSH](/docs/sandbox/ssh).
 
+<Callout variant="info">
+Sandbox0 Cloud clients should use `https://api.sandbox0.ai`. Set `SANDBOX0_BASE_URL` only when you are connecting to a self-hosted or private deployment.
+</Callout>
+
 ## Sandbox Model
 
 ### Key Identifiers
@@ -118,7 +122,7 @@ from sandbox0.apispec.models.sandbox_config import SandboxConfig
 
 client = Client(
     token=os.environ["SANDBOX0_TOKEN"],
-    base_url=os.environ.get("SANDBOX0_BASE_URL", "http://localhost:30080"),
+    base_url=os.environ.get("SANDBOX0_BASE_URL", "https://api.sandbox0.ai"),
 )
 
 # Claim a sandbox from the "default" template
@@ -141,7 +145,7 @@ client.delete_sandbox(sandbox.id)`
 
 const client = new Client({
     token: process.env.SANDBOX0_TOKEN!,
-    baseUrl: process.env.SANDBOX0_BASE_URL || 'http://localhost:30080',
+    baseUrl: process.env.SANDBOX0_BASE_URL || 'https://api.sandbox0.ai',
 });
 
 // Claim a sandbox from the "default" template
@@ -234,7 +238,7 @@ fmt.Printf("Status: %s\\n", status.Status.Value)`
     {
       label: "Python",
       language: "python",
-      code: `status = client.status_sandbox(sandbox.id)
+      code: `status = client.sandboxes.status(sandbox.id)
 print(f"Status: {status.status}")`
     },
     {
@@ -273,13 +277,45 @@ Read sandbox process output. Procd service logs are filtered out of this API and
 | `timestamps` | boolean | Include Kubernetes log timestamps when available |
 | `since_seconds` | integer | Return logs newer than this many seconds |
 
-    curl -H "Authorization: Bearer $SANDBOX0_TOKEN" \
-      "$SANDBOX0_BASE_URL/api/v1/sandboxes/sb_abc123/logs?tail_lines=200"
+<Tabs
+  tabs={[
+    {
+      label: "Go",
+      language: "go",
+      code: `tailLines := int64(200)
+logs, err := sandbox.GetLogs(ctx, &sandbox0.SandboxLogsOptions{
+    TailLines: &tailLines,
+})
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Print(logs.Logs)`
+    },
+    {
+      label: "Python",
+      language: "python",
+      code: `from sandbox0.sandbox_logs import SandboxLogsOptions
 
-    curl -N -H "Authorization: Bearer $SANDBOX0_TOKEN" \
-      "$SANDBOX0_BASE_URL/api/v1/sandboxes/sb_abc123/logs?follow=true&tail_lines=50"
+logs = sandbox.get_logs(SandboxLogsOptions(tail_lines=200))
+print(logs.logs, end="")`
+    },
+    {
+      label: "TypeScript",
+      language: "typescript",
+      code: `const logs = await sandbox.getLogs({ tailLines: 200 });
+process.stdout.write(logs.logs);`
+    },
+    {
+      label: "CLI",
+      language: "bash",
+      code: `s0 sandbox logs sb_abc123 --tail 200`
+    }
+  ]}
+/>
 
-With `follow=true`, the response stays open and streams log bytes until the client disconnects.
+<Callout variant="info">
+For live streaming, use `sandbox.StreamLogs(...)`, `sandbox.stream_logs(...)`, `sandbox.streamLogs(...)`, or `s0 sandbox logs --follow`.
+</Callout>
 
 ---
 
@@ -322,7 +358,7 @@ for _, sb := range sandboxes.Sandboxes {
     {
       label: "Python",
       language: "python",
-      code: `sandboxes = client.list_sandboxes(
+      code: `sandboxes = client.sandboxes.list(
     status="running",
     template_id="default",
     limit=10,
@@ -397,7 +433,7 @@ if err != nil {
       code: `from sandbox0.apispec.models.sandbox_update_config import SandboxUpdateConfig
 from sandbox0.apispec.models.sandbox_update_request import SandboxUpdateRequest
 
-client.update_sandbox(
+client.sandboxes.update(
     sandbox.id,
     SandboxUpdateRequest(config=SandboxUpdateConfig.from_dict({
         "ttl": 600,
@@ -422,90 +458,19 @@ client.update_sandbox(
 
 ---
 
-## Pause Sandbox
+## Pause And Resume
 
-Pause a sandbox to save resources. The sandbox state is preserved.
+Pause and resume is covered in a dedicated page because it affects TTL, `auto_resume`, exposed ports, SSH, and webhook behavior.
 
-<Endpoint method="POST">
-/api/v1/sandboxes/{'{id}'}/pause
-</Endpoint>
-
-<Callout variant="info">
-When a sandbox is paused, all processes are stopped but memory state is preserved.
-Use `auto_resume` to automatically resume when accessed.
-</Callout>
-
-<Tabs
-  tabs={[
-    {
-      label: "Go",
-      language: "go",
-      code: `_, err = client.PauseSandbox(ctx, sandbox.ID)
-if err != nil {
-    log.Fatal(err)
-}
-fmt.Println("Sandbox paused")`
-    },
-    {
-      label: "Python",
-      language: "python",
-      code: `client.pause_sandbox(sandbox.id)
-print("Sandbox paused")`
-    },
-    {
-      label: "TypeScript",
-      language: "typescript",
-      code: `await client.sandboxes.pause(sandbox.id);
-console.log('Sandbox paused');`
-    },
-    {
-      label: "CLI",
-      language: "bash",
-      code: `s0 sandbox pause sb_abc123`
-    }
-  ]}
-/>
-
----
-
-## Resume Sandbox
-
-Resume a paused sandbox.
-
-<Endpoint method="POST">
-/api/v1/sandboxes/{'{id}'}/resume
-</Endpoint>
-
-<Tabs
-  tabs={[
-    {
-      label: "Go",
-      language: "go",
-      code: `_, err = client.ResumeSandbox(ctx, sandbox.ID)
-if err != nil {
-    log.Fatal(err)
-}
-fmt.Println("Sandbox resumed")`
-    },
-    {
-      label: "Python",
-      language: "python",
-      code: `client.resume_sandbox(sandbox.id)
-print("Sandbox resumed")`
-    },
-    {
-      label: "TypeScript",
-      language: "typescript",
-      code: `await client.sandboxes.resume(sandbox.id);
-console.log('Sandbox resumed');`
-    },
-    {
-      label: "CLI",
-      language: "bash",
-      code: `s0 sandbox resume sb_abc123`
-    }
-  ]}
-/>
+<CardGrid>
+  <LinkCard
+    title="Pause And Resume"
+    href="/docs/sandbox/pause-resume"
+    cta="Learn More"
+  >
+    Pause sandboxes explicitly, inspect paused state, resume them, and control auto-resume behavior
+  </LinkCard>
+</CardGrid>
 
 ---
 
@@ -539,7 +504,7 @@ if err != nil {
 }
 fmt.Printf("New expires at: %s\\n", resp.ExpiresAt)
 
-// Refresh with custom duration (e.g., 1 minutes)
+// Refresh with custom duration (e.g., 1 minute)
 resp, err = client.RefreshSandbox(ctx, sandbox.ID, &apispec.SandboxRefreshRequest{
     Duration: apispec.NewOptInt32(60),
 })
@@ -554,11 +519,11 @@ fmt.Printf("New expires at: %s\\n", resp.ExpiresAt)`
       code: `from sandbox0.apispec.models.sandbox_refresh_request import SandboxRefreshRequest
 
 # Refresh with default duration (original TTL)
-resp = client.refresh_sandbox(sandbox.id)
+resp = client.sandboxes.refresh(sandbox.id)
 print(f"New expires at: {resp.expires_at}")
 
-# Refresh with custom duration (e.g., 1 minutes)
-resp = client.refresh_sandbox(sandbox.id, SandboxRefreshRequest(duration=60))
+# Refresh with custom duration (e.g., 1 minute)
+resp = client.sandboxes.refresh(sandbox.id, SandboxRefreshRequest(duration=60))
 print(f"New expires at: {resp.expires_at}")`
     },
     {
@@ -568,7 +533,7 @@ print(f"New expires at: {resp.expires_at}")`
 const resp = await client.sandboxes.refresh(sandbox.id);
 console.log('New expires at:', resp.expiresAt);
 
-// Refresh with custom duration (e.g., 1 minutes)
+// Refresh with custom duration (e.g., 1 minute)
 const resp2 = await client.sandboxes.refresh(sandbox.id, { duration: 60 });
 console.log('New expires at:', resp2.expiresAt);`
     },
@@ -578,11 +543,7 @@ console.log('New expires at:', resp2.expiresAt);`
       code: `# Refresh with default duration
 s0 sandbox refresh sb_abc123
 
-# Refresh with custom duration (e.g., 10 minutes)
-s0 sandbox refresh sb_abc123 --duration 600
-
-# Output:
-# New expires at: 2024-01-15T11:00:00Z`
+# Output includes the new expiry timestamp`
     }
   ]}
 />
@@ -611,7 +572,7 @@ fmt.Println("Sandbox deleted")`
     {
       label: "Python",
       language: "python",
-      code: `client.delete_sandbox(sandbox.id)
+      code: `client.sandboxes.delete(sandbox.id)
 print("Sandbox deleted")`
     },
     {
@@ -633,6 +594,14 @@ console.log('Sandbox deleted');`
 ## Next Steps
 
 <CardGrid>
+  <LinkCard
+    title="Pause And Resume"
+    href="/docs/sandbox/pause-resume"
+    cta="Learn More"
+  >
+    Pause sandboxes, resume them, and control `auto_resume`
+  </LinkCard>
+
   <LinkCard
     title="Contexts"
     href="/docs/sandbox/contexts"

--- a/docs/sandbox/pause-resume/page.mdx
+++ b/docs/sandbox/pause-resume/page.mdx
@@ -1,0 +1,197 @@
+# Pause And Resume
+
+Sandbox0 can pause an idle sandbox without deleting it. Pause preserves sandbox state, while resume makes the sandbox runnable again.
+
+Use this page when you need to:
+
+- pause a sandbox explicitly
+- resume a paused sandbox explicitly
+- understand how `ttl`, `auto_resume`, exposed ports, and SSH interact with pause state
+- inspect whether a pause or resume request has completed
+
+<Callout variant="info">
+Pause state is separate from `status`. Use `paused` for the simple user-facing state, and `power_state` when you need to inspect desired versus observed transition progress.
+</Callout>
+
+## Pause A Sandbox
+
+Pause a sandbox to release compute while keeping its state available for a later resume.
+
+<Endpoint method="POST">
+/api/v1/sandboxes/{'{id}'}/pause
+</Endpoint>
+
+<Tabs
+  tabs={[
+    {
+      label: "Go",
+      language: "go",
+      code: `_, err := client.PauseSandbox(ctx, sandbox.ID)
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Println("Pause requested")`
+    },
+    {
+      label: "Python",
+      language: "python",
+      code: `client.sandboxes.pause(sandbox.id)
+print("Pause requested")`
+    },
+    {
+      label: "TypeScript",
+      language: "typescript",
+      code: `await client.sandboxes.pause(sandbox.id);
+console.log("Pause requested");`
+    },
+    {
+      label: "CLI",
+      language: "bash",
+      code: `s0 sandbox pause sb_abc123`
+    }
+  ]}
+/>
+
+## Resume A Sandbox
+
+Resume a sandbox that was paused manually or by TTL expiry.
+
+<Endpoint method="POST">
+/api/v1/sandboxes/{'{id}'}/resume
+</Endpoint>
+
+<Tabs
+  tabs={[
+    {
+      label: "Go",
+      language: "go",
+      code: `_, err := client.ResumeSandbox(ctx, sandbox.ID)
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Println("Resume requested")`
+    },
+    {
+      label: "Python",
+      language: "python",
+      code: `client.sandboxes.resume(sandbox.id)
+print("Resume requested")`
+    },
+    {
+      label: "TypeScript",
+      language: "typescript",
+      code: `await client.sandboxes.resume(sandbox.id);
+console.log("Resume requested");`
+    },
+    {
+      label: "CLI",
+      language: "bash",
+      code: `s0 sandbox resume sb_abc123`
+    }
+  ]}
+/>
+
+## Inspect Pause State
+
+After requesting a pause or resume, fetch sandbox details to check whether the transition has completed.
+
+<Tabs
+  tabs={[
+    {
+      label: "Go",
+      language: "go",
+      code: `sb, err := client.GetSandbox(ctx, sandbox.ID)
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Printf("paused=%v\n", sb.Paused)
+fmt.Printf("power_state=%+v\n", sb.PowerState)`
+    },
+    {
+      label: "Python",
+      language: "python",
+      code: `sb = client.sandboxes.get(sandbox.id)
+print("paused=", sb.paused)
+print("power_state=", sb.power_state)`
+    },
+    {
+      label: "TypeScript",
+      language: "typescript",
+      code: `const sb = await client.sandboxes.get(sandbox.id);
+console.log("paused=", sb.paused);
+console.log("powerState=", sb.powerState);`
+    },
+    {
+      label: "CLI",
+      language: "bash",
+      code: `s0 sandbox get sb_abc123`
+    }
+  ]}
+/>
+
+## TTL And Auto Resume
+
+`ttl` and `hard_ttl` interact with pause differently:
+
+| Field | Behavior |
+|-------|----------|
+| `ttl` | Soft timeout. When it expires, Sandbox0 pauses the sandbox. |
+| `hard_ttl` | Hard timeout. When it expires, Sandbox0 deletes the sandbox. |
+
+`auto_resume` controls whether inbound access can wake a paused sandbox:
+
+- when `auto_resume` is `true`, supported access paths can resume the sandbox automatically
+- when `auto_resume` is `false`, you must call resume explicitly
+
+Common auto-resume entrypoints:
+
+- exposed ports configured with `resume: true`
+- SSH access through Sandbox0 SSH Gateway
+
+See [Ports](/docs/sandbox/ports) and [SSH](/docs/sandbox/ssh) for the user-facing flows.
+
+## Typical Pattern
+
+For long-running agent workflows, a common pattern is:
+
+1. claim a sandbox with `ttl` set
+2. do active work through contexts and files
+3. let idle sandboxes pause automatically
+4. resume on the next user action, SSH session, or exposed-port hit
+5. use `hard_ttl` to cap the maximum lifetime
+
+## Next Steps
+
+<CardGrid>
+  <LinkCard
+    title="Sandbox Overview"
+    href="/docs/sandbox"
+    cta="Back"
+  >
+    Core sandbox lifecycle operations and refresh behavior
+  </LinkCard>
+
+  <LinkCard
+    title="Ports"
+    href="/docs/sandbox/ports"
+    cta="Learn More"
+  >
+    Expose services and configure port-level auto-resume
+  </LinkCard>
+
+  <LinkCard
+    title="SSH"
+    href="/docs/sandbox/ssh"
+    cta="Learn More"
+  >
+    Resume paused sandboxes through SSH access
+  </LinkCard>
+
+  <LinkCard
+    title="Webhooks"
+    href="/docs/sandbox/webhooks"
+    cta="Learn More"
+  >
+    Observe `sandbox.paused` and `sandbox.resumed` events
+  </LinkCard>
+</CardGrid>

--- a/docs/self-hosted/install/page.mdx
+++ b/docs/self-hosted/install/page.mdx
@@ -129,20 +129,31 @@ go install github.com/sandbox0-ai/s0/cmd/s0@latest
 
 Manual release archives are available from <DocLink href="https://github.com/sandbox0-ai/s0/releases/latest" newTab>GitHub Releases</DocLink>. See the <DocLink href="https://github.com/sandbox0-ai/s0#installation" newTab>s0 README</DocLink> for platform-specific manual install steps.
 
-## 5) Configure the API URL and Create a Token
+## 5) Configure the API URL, Log In, and Optionally Create an API Key
 
 For the local `kind` setup above, the API endpoint is `http://localhost:30080`.
 
 That is because the `kind` config maps host port `30080`, and the sample `Sandbox0Infra` exposes `cluster-gateway` on the same NodePort.
 
-Export the base URL, log in with the initial admin account, then create an API token:
+Export the base URL, then log in with the initial admin account:
 
 ```bash
 export SANDBOX0_BASE_URL="http://localhost:30080"
 
 s0 auth login
+```
 
-unset SANDBOX0_TOKEN && export SANDBOX0_TOKEN="$(s0 apikey create --name test-apikey --role admin --expires-in 30d --raw)"
+At that point, interactive `s0` CLI usage is ready.
+
+Create an API key only if you want to use the SDKs or raw HTTP API:
+
+```bash
+# If the server did not auto-select a team yet:
+# s0 team list
+# s0 team use <team-id>
+
+unset SANDBOX0_TOKEN
+export SANDBOX0_TOKEN="$(s0 apikey create --name sdk-quickstart --role developer --expires-in 30d --raw)"
 ```
 
 After that, continue with [Get Started](/docs/get-started) to make your first Sandbox0 API request.

--- a/docs/template/page.mdx
+++ b/docs/template/page.mdx
@@ -2,6 +2,10 @@
 
 A Template is the blueprint for creating Sandboxes. It defines the container image, resource limits, warm pool size, and default network policy. Every Sandbox is created from a Template.
 
+<Callout variant="info">
+Creating, updating, and deleting team-owned templates requires team admin permissions. `developer` and `builder` roles can read templates, and `builder` is typically used for registry push workflows rather than template management.
+</Callout>
+
 ## Template Types
 
 Sandbox0 has two categories of templates:
@@ -18,6 +22,8 @@ Builtin templates use curated public images and are ready to use immediately. Cu
 ## Create Template
 
 Create a custom template for your team. The template spec is defined in a YAML file.
+
+CLI examples assume you already ran `s0 auth login` and selected the correct current team.
 
 <Endpoint method="POST">
 /api/v1/templates

--- a/docs/template/page.mdx
+++ b/docs/template/page.mdx
@@ -48,7 +48,7 @@ spec:
         image: python:3.12-slim
         resources:
             cpu: "1"
-            memory: 2Gi
+            memory: 4Gi
     pool:
         minIdle: 2
         maxIdle: 10
@@ -62,7 +62,7 @@ spec:
         image: ubuntu:24.04
         resources:
             cpu: "1"
-            memory: 2Gi
+            memory: 4Gi
     warmProcesses:
         - name: codex
           type: cmd
@@ -152,7 +152,7 @@ print(f"Template created: {tpl.template_id}")`
     spec: {
         mainContainer: {
             image: "ubuntu:24.04",
-            resources: { cpu: "1", memory: "2Gi" },
+            resources: { cpu: "1", memory: "4Gi" },
         },
         warmProcesses: [{
             name: "codex",
@@ -177,7 +177,7 @@ spec:
         image: ubuntu:24.04
         resources:
             cpu: "1"
-            memory: 2Gi
+            memory: 4Gi
     warmProcesses:
         - name: codex
           type: cmd
@@ -236,7 +236,7 @@ tpl = client.create_template(TemplateCreateRequest(
     spec=SandboxTemplateSpec.from_dict({
         "mainContainer": {
             "image": "python:3.12-slim",
-            "resources": {"cpu": "1", "memory": "2Gi"},
+            "resources": {"cpu": "1", "memory": "4Gi"},
         },
         "pool": {"minIdle": 2, "maxIdle": 10},
     }),
@@ -251,7 +251,7 @@ print(f"Template created: {tpl.template_id}")`
     spec: {
         mainContainer: {
             image: "python:3.12-slim",
-            resources: { cpu: "1", memory: "2Gi" },
+            resources: { cpu: "1", memory: "4Gi" },
         },
         pool: { minIdle: 2, maxIdle: 10 },
     },

--- a/docs/template/warm-processes/page.mdx
+++ b/docs/template/warm-processes/page.mdx
@@ -14,7 +14,7 @@ spec:
         image: ubuntu:24.04
         resources:
             cpu: "1"
-            memory: 2Gi
+            memory: 4Gi
     warmProcesses:
         - name: codex
           type: cmd
@@ -64,7 +64,7 @@ spec:
         image: ghcr.io/example/sandbox-with-helper:v1
         resources:
             cpu: "1"
-            memory: 2Gi
+            memory: 4Gi
     warmProcesses:
         - name: helper
           type: cmd

--- a/docs/volume/mounts/page.mdx
+++ b/docs/volume/mounts/page.mdx
@@ -69,6 +69,16 @@ The claim request binds existing Volumes to template-declared paths.
 
 `RWX` is not accepted for Sandbox mounts in this node-local implementation. Use direct file APIs for control-plane file operations, or use separate `RWO` volumes for write-heavy Sandbox workloads.
 
+## Correctness Guarantees
+
+Mounted `RWO` volumes use one active writable owner at a time.
+
+- the mounted sandbox path is the authoritative writer
+- direct volume file API requests are routed to that mounted owner while the mount is active
+- Sandbox0 avoids opening a second writable direct mount for the same mounted `RWO` volume
+
+This is what keeps file changes visible both from inside the sandbox and through the volume file API.
+
 ## File Operations
 
 After claim completes, use the mounted path like a normal filesystem:

--- a/docs/volume/page.mdx
+++ b/docs/volume/page.mdx
@@ -15,15 +15,13 @@ The default Sandbox filesystem is ephemeral—when a Sandbox is deleted, all its
 ## Volume and Sandbox Relationship
 
 ```mermaid
-flowchart TB
-    vol["Volume (Persistent Storage)<br/>/data/<br/>- models/<br/>- cache/<br/>- output/"]
-    sa["Sandbox A (RWX)"]
-    sb["Sandbox B (ROX)"]
-    sc["Sandbox C (RWX)"]
+flowchart LR
+    vol["Volume"]
+    sb["Sandbox mount<br/>RWO or ROX"]
+    api["Direct volume file API"]
 
-    vol --> sa
     vol --> sb
-    vol --> sc
+    vol --> api
 ```
 
 ## Access Modes
@@ -32,13 +30,23 @@ Volumes support three access modes:
 
 | Mode | Full Name | Description | Typical Use Cases |
 |------|-----------|-------------|-------------------|
-| `RWO` | Read-Write Once | Single Sandbox read-write | Database storage, exclusive workspaces |
-| `ROX` | Read-Only Cross | Multi-Sandbox read-only | Shared model files, static resource distribution |
-| `RWX` | Read-Write Cross | Multi-Sandbox read-write | Collaborative workspaces, shared caches |
+| `RWO` | Read-Write Once | One writable owner at a time | Agent workspaces, databases, exclusive write-heavy state |
+| `ROX` | Read-Only Cross | Multi-sandbox read-only distribution | Shared model files, static assets, reference datasets |
+| `RWX` | Read-Write Cross | Shared read-write volume mode for direct API workflows | Control-plane style file workflows and shared storage patterns that do not rely on sandbox mounts |
 
 <Callout variant="info">
-The default access mode is `RWO`. Sandbox mounts are declared by the template and bound at claim time. `RWO` mounts use node-local write-ahead logging for low-latency small-file workloads, while `ROX` is for read-only sharing.
+The default access mode is `RWO`. Sandbox mounts are declared by the template and bound at claim time. `RWO` mounts use node-local write-ahead logging for low-latency small-file workloads, `ROX` is for read-only sharing, and `RWX` is not accepted for sandbox mounts in the current node-local mount path.
 </Callout>
+
+## Correctness Model
+
+For mounted `RWO` volumes, Sandbox0 keeps one active writable owner at a time.
+
+- when a sandbox mounts an `RWO` volume, the node-local mount owner becomes authoritative for reads and writes
+- direct volume file API requests are routed to that mounted owner instead of opening a second writable mount
+- when the volume is not mounted into a sandbox, `storage-proxy` serves direct file API requests itself
+
+This keeps the mounted filesystem view and the direct volume API view consistent in both directions.
 
 ## Direct File Operations
 
@@ -47,7 +55,7 @@ You can operate on files in a Volume directly by volume ID, without mounting the
 This is useful for SDK workflows, developer tooling, and small control-plane style file tasks where starting or reusing a Sandbox would only add latency.
 
 <Callout variant="info">
-Direct volume file APIs still go through the normal gateway chain and team-scoped auth. Internally, `storage-proxy` lazily attaches the Volume on demand and reclaims idle direct mounts later. Sandbox mounts continue to work unchanged.
+Direct volume file APIs still go through the normal gateway chain and team-scoped auth. When a volume is already mounted into a sandbox, the API request is served by that mounted owner. When it is not mounted, `storage-proxy` lazily attaches the volume on demand and reclaims idle direct mounts later.
 </Callout>
 
 The direct file API surface mirrors the Sandbox file API:

--- a/skills/sandbox0/SKILL.md
+++ b/skills/sandbox0/SKILL.md
@@ -17,6 +17,23 @@ For exact API, CLI, SDK, and Managed Agents behavior, read the live docs first:
 
 This skill is intentionally thin. Do not rely on local bundled docs for product details.
 
+## Default Onboarding
+
+Start from Sandbox0 Cloud unless the user explicitly needs self-hosting.
+
+1. Install `s0`:
+   - macOS/Linux: `curl -fsSL https://raw.githubusercontent.com/sandbox0-ai/s0/main/scripts/install.sh | bash`
+   - Windows PowerShell: `irm https://raw.githubusercontent.com/sandbox0-ai/s0/main/scripts/install.ps1 | iex`
+2. Sign in with `s0 auth login`.
+3. If the server did not auto-select a team, use `s0 team list`, `s0 team create`, and `s0 team use`.
+4. For SDK or raw HTTP usage, create an API key:
+   - `export SANDBOX0_TOKEN="$(s0 apikey create --name sdk-quickstart --role developer --expires-in 30d --raw)"`
+   - `export SANDBOX0_BASE_URL="https://api.sandbox0.ai"`
+
+If the user is only using the interactive `s0` CLI, `s0 auth login` is usually enough and no API key export is required.
+
+Managed Agents uses `https://agents.sandbox0.ai`. Sandbox, Template, Volume, and Credential APIs use `https://api.sandbox0.ai`.
+
 ## Typical triggers
 
 - Add Sandbox0 to an AI agent project


### PR DESCRIPTION
## Summary
- refresh `get-started` and the bundled `sandbox0` skill to be cloud-first, with `s0 auth login` for CLI usage and API-key setup only for SDK/HTTP usage
- rewrite the sandbox overview around the current lifecycle, split pause/resume into its own page, and add that page to the docs manifest
- clarify credential source scope, template permission requirements, volume correctness/access-mode behavior, and self-hosted login vs API-key setup
- fix template and warm-process resource examples to match the current server-side memory validation

## Validation
- exercised CLI flows against `https://api.sandbox0.ai` using a clean temporary `s0` config: volume create/files, sandbox create/exec/logs/pause/resume/refresh, credential source create/list, sandbox network update
- validated mounted-volume docs by creating a temporary custom template with `volumeMounts`, then claiming a sandbox with `--mount` and reading the mounted file successfully
- validated representative SDK snippets against the live API with local `sdk-go`, `sdk-py`, and `sdk-js` workspaces
- confirmed template examples needed `cpu=1` with `memory=4Gi`; updated docs accordingly after hitting the live create-template validation error