### PR TITLE
manager: finish template cleanup after namespace delete request

### DIFF
--- a/manager/pkg/service/template_service.go
+++ b/manager/pkg/service/template_service.go
@@ -191,9 +191,12 @@ func (s *TemplateService) DeleteTemplate(ctx context.Context, id string) error {
 		return fmt.Errorf("resolve template namespace cleanup: %w", err)
 	}
 	if deleteNamespace {
-		// Delete the namespace first so a transient namespace cleanup failure leaves
-		// the template visible for the scheduler's orphan retry path.
-		return s.deleteTemplateNamespace(ctx, existing.Namespace)
+		// Request namespace deletion first, then continue deleting the template CR
+		// and matching pods so terminating namespaces do not keep stale template
+		// objects around while the single-cluster reconciler is still looping.
+		if err := s.deleteTemplateNamespace(ctx, existing.Namespace); err != nil {
+			return err
+		}
 	}
 
 	err = s.crdClient.Sandbox0V1alpha1().SandboxTemplates(existing.Namespace).Delete(ctx, id, metav1.DeleteOptions{})

--- a/manager/pkg/service/template_service_test.go
+++ b/manager/pkg/service/template_service_test.go
@@ -285,17 +285,22 @@ func TestDeleteLastTeamTemplateDeletesManagedNamespace(t *testing.T) {
 	require.NoError(t, err)
 
 	template := teamTemplate(namespace, "demo", "team-123")
+	pod := templatePod(namespace, "demo-pod", "demo", controller.PoolTypeActive)
 	k8sClient := fake.NewSimpleClientset(
 		managedNamespace(namespace),
-		templatePod(namespace, "demo-pod", "demo", controller.PoolTypeActive),
+		pod,
 	)
-	service, _ := newTemplateServiceForDeleteTests(k8sClient, template)
+	service, crdClient := newTemplateServiceForDeleteTests(k8sClient, template)
 
 	err = service.DeleteTemplate(ctx, "demo")
 	require.NoError(t, err)
 
 	_, err = k8sClient.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
 	require.True(t, apierrors.IsNotFound(err), "last team template should remove managed namespace")
+	_, err = crdClient.Sandbox0V1alpha1().SandboxTemplates(namespace).Get(ctx, "demo", metav1.GetOptions{})
+	require.True(t, apierrors.IsNotFound(err), "last team template CRD should be deleted")
+	_, err = k8sClient.CoreV1().Pods(namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+	require.True(t, apierrors.IsNotFound(err), "last team template pod should be deleted")
 }
 
 func managedNamespace(name string) *corev1.Namespace {


### PR DESCRIPTION
## Summary
- continue deleting the template CR and template pods after requesting managed namespace deletion
- prevent stale template objects from lingering in terminating team namespaces during single-cluster cleanup
- extend the delete-template service test to assert namespace, CR, and pod cleanup together

## Context
PR #258 hit a single-cluster e2e timeout while waiting for team template namespace cleanup. The failing stack was blocked in `deleteTeamTemplateAndWaitForNamespaceCleanup`, and manager logs showed namespace deletion had been requested but template resources were still left behind in terminating namespaces.

## Testing
- `go test ./manager/pkg/service -run 'TestDelete(LastTeamTemplateDeletesManagedNamespace|TeamTemplateKeepsSharedNamespaceAndDeletesTemplatePods|TemplateKeepsUnmanagedNamespaceAndDeletesTemplatePods|TemplateCleansPodsWhenCRDAlreadyGone)'`