### PR TITLE
s0fs: move committed heads from object storage to postgres

### DIFF
--- a/ctld/internal/ctld/portal/manager.go
+++ b/ctld/internal/ctld/portal/manager.go
@@ -43,6 +43,7 @@ type Manager struct {
 	mu              sync.Mutex
 	portals         map[string]*portalMount
 	portalsByTarget map[string]*portalMount
+	boundVolumes    map[string]*boundVolume
 	volumes         *localVolumeManager
 }
 
@@ -59,6 +60,15 @@ type portalMount struct {
 	volumeID  string
 	teamID    string
 	mountedAt time.Time
+}
+
+type boundVolume struct {
+	volumeID  string
+	teamID    string
+	access    volume.AccessMode
+	mountedAt time.Time
+	refCount  int
+	volCtx    *volume.VolumeContext
 
 	heartbeatCancel context.CancelFunc
 	heartbeatDone   chan struct{}
@@ -109,6 +119,7 @@ func NewManager(cfg Config) *Manager {
 		heartbeatInterval: heartbeatInterval,
 		portals:           make(map[string]*portalMount),
 		portalsByTarget:   make(map[string]*portalMount),
+		boundVolumes:      make(map[string]*boundVolume),
 		volumes:           newLocalVolumeManager(),
 	}
 	manager.volumeAPI = newMountedVolumeAPIHandler(storageConfig, cfg.Repository, manager.volumes, l)
@@ -234,6 +245,10 @@ func (m *Manager) Bind(ctx context.Context, req ctldapi.BindVolumePortalRequest)
 	if err != nil {
 		return ctldapi.BindVolumePortalResponse{}, err
 	}
+	accessMode, err := validateBindableAccessMode(volumeRecord.AccessMode)
+	if err != nil {
+		return ctldapi.BindVolumePortalResponse{}, err
+	}
 
 	key := portalKey(req.PodUID, portalName)
 	m.mu.Lock()
@@ -246,12 +261,42 @@ func (m *Manager) Bind(ctx context.Context, req ctldapi.BindVolumePortalRequest)
 		return ctldapi.BindVolumePortalResponse{}, fmt.Errorf("volume portal already bound to %s", pm.volumeID)
 	}
 	if pm.volumeID == req.SandboxVolumeID {
-		return ctldapi.BindVolumePortalResponse{
-			SandboxVolumeID: pm.volumeID,
-			MountPoint:      pm.mountPath,
-			MountedAt:       pm.mountedAt.Format(time.RFC3339),
-		}, nil
+		return boundResponse(pm), nil
 	}
+
+	mountedAt := time.Now().UTC()
+	m.mu.Lock()
+	pm = m.portals[key]
+	if pm == nil {
+		m.mu.Unlock()
+		return ctldapi.BindVolumePortalResponse{}, fmt.Errorf("volume portal %s for pod %s is not published", portalName, req.PodUID)
+	}
+	if pm.volumeID != "" {
+		response := boundResponse(pm)
+		m.mu.Unlock()
+		if response.SandboxVolumeID != req.SandboxVolumeID {
+			return ctldapi.BindVolumePortalResponse{}, fmt.Errorf("volume portal already bound to %s", response.SandboxVolumeID)
+		}
+		return response, nil
+	}
+	if bound := m.boundVolumes[req.SandboxVolumeID]; bound != nil {
+		if accessMode != volume.AccessModeROX {
+			conflictPath := boundMountPath(m.portals, req.SandboxVolumeID, key)
+			m.mu.Unlock()
+			return ctldapi.BindVolumePortalResponse{}, fmt.Errorf("volume %s is already bound to %s", req.SandboxVolumeID, conflictPath)
+		}
+		m.attachPortalLocked(pm, req.SandboxVolumeID, volumeRecord.TeamID, mountedAt)
+		bound.refCount++
+		response := boundResponse(pm)
+		m.mu.Unlock()
+		return response, nil
+	}
+	if existing := findBoundPortalForVolume(m.portals, req.SandboxVolumeID, key); existing != nil {
+		conflictPath := existing.mountPath
+		m.mu.Unlock()
+		return ctldapi.BindVolumePortalResponse{}, fmt.Errorf("volume %s is already bound to %s", req.SandboxVolumeID, conflictPath)
+	}
+	m.mu.Unlock()
 
 	cacheDir := filepath.Join(m.rootDir, "volumes", safePath(req.TeamID), safePath(req.SandboxVolumeID))
 	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
@@ -275,15 +320,13 @@ func (m *Manager) Bind(ctx context.Context, req ctldapi.BindVolumePortalRequest)
 		TeamID:    volumeRecord.TeamID,
 		Backend:   volume.BackendS0FS,
 		S0FS:      engine,
-		Access:    volume.NormalizeAccessMode(volumeRecord.AccessMode),
-		MountedAt: time.Now().UTC(),
+		Access:    accessMode,
+		MountedAt: mountedAt,
 		RootInode: 1,
 		RootPath:  "/",
 		CacheDir:  cacheDir,
 	}
 
-	mountedAt := time.Now().UTC()
-	session := newLocalSession(req.SandboxVolumeID, m.volumes, m.logrus)
 	m.mu.Lock()
 	pm = m.portals[key]
 	if pm == nil {
@@ -292,17 +335,26 @@ func (m *Manager) Bind(ctx context.Context, req ctldapi.BindVolumePortalRequest)
 		return ctldapi.BindVolumePortalResponse{}, fmt.Errorf("volume portal %s for pod %s is not published", portalName, req.PodUID)
 	}
 	if pm.volumeID != "" {
-		boundVolumeID := pm.volumeID
-		response := ctldapi.BindVolumePortalResponse{
-			SandboxVolumeID: boundVolumeID,
-			MountPoint:      pm.mountPath,
-			MountedAt:       pm.mountedAt.Format(time.RFC3339),
-		}
+		response := boundResponse(pm)
 		m.mu.Unlock()
 		_ = engine.Close()
-		if boundVolumeID != req.SandboxVolumeID {
-			return ctldapi.BindVolumePortalResponse{}, fmt.Errorf("volume portal already bound to %s", boundVolumeID)
+		if response.SandboxVolumeID != req.SandboxVolumeID {
+			return ctldapi.BindVolumePortalResponse{}, fmt.Errorf("volume portal already bound to %s", response.SandboxVolumeID)
 		}
+		return response, nil
+	}
+	if bound := m.boundVolumes[req.SandboxVolumeID]; bound != nil {
+		if accessMode != volume.AccessModeROX {
+			conflictPath := boundMountPath(m.portals, req.SandboxVolumeID, key)
+			m.mu.Unlock()
+			_ = engine.Close()
+			return ctldapi.BindVolumePortalResponse{}, fmt.Errorf("volume %s is already bound to %s", req.SandboxVolumeID, conflictPath)
+		}
+		m.attachPortalLocked(pm, req.SandboxVolumeID, volumeRecord.TeamID, mountedAt)
+		bound.refCount++
+		response := boundResponse(pm)
+		m.mu.Unlock()
+		_ = engine.Close()
 		return response, nil
 	}
 	if existing := findBoundPortalForVolume(m.portals, req.SandboxVolumeID, key); existing != nil {
@@ -311,29 +363,30 @@ func (m *Manager) Bind(ctx context.Context, req ctldapi.BindVolumePortalRequest)
 		_ = engine.Close()
 		return ctldapi.BindVolumePortalResponse{}, fmt.Errorf("volume %s is already bound to %s", req.SandboxVolumeID, conflictPath)
 	}
+	bound := &boundVolume{
+		volumeID:  req.SandboxVolumeID,
+		teamID:    volumeRecord.TeamID,
+		access:    accessMode,
+		mountedAt: mountedAt,
+		refCount:  1,
+		volCtx:    volCtx,
+	}
+	m.boundVolumes[req.SandboxVolumeID] = bound
 	m.volumes.add(volCtx)
-	pm.fs.SetSession(session)
-	pm.volumeID = req.SandboxVolumeID
-	pm.teamID = volumeRecord.TeamID
-	pm.mountedAt = mountedAt
-	if err := m.registerOwner(ctx, pm, volCtx.Access); err != nil {
-		pm.fs.SetSession(unboundSession{})
-		pm.volumeID = ""
-		pm.teamID = ""
-		pm.mountedAt = time.Time{}
+	m.attachPortalLocked(pm, req.SandboxVolumeID, volumeRecord.TeamID, mountedAt)
+	if err := m.registerOwner(ctx, bound); err != nil {
+		m.clearPortalLocked(pm)
+		delete(m.boundVolumes, req.SandboxVolumeID)
 		m.volumes.remove(req.SandboxVolumeID)
 		m.mu.Unlock()
 		_ = engine.Close()
 		return ctldapi.BindVolumePortalResponse{}, fmt.Errorf("register ctld volume owner: %w", err)
 	}
-	m.startMaterializer(pm, engine)
+	m.startMaterializer(bound)
+	response := boundResponse(pm)
 	m.mu.Unlock()
 
-	return ctldapi.BindVolumePortalResponse{
-		SandboxVolumeID: req.SandboxVolumeID,
-		MountPoint:      pm.mountPath,
-		MountedAt:       pm.mountedAt.Format(time.RFC3339),
-	}, nil
+	return response, nil
 }
 
 func (m *Manager) Unbind(ctx context.Context, req ctldapi.UnbindVolumePortalRequest) (ctldapi.UnbindVolumePortalResponse, error) {
@@ -360,21 +413,27 @@ func (m *Manager) Unbind(ctx context.Context, req ctldapi.UnbindVolumePortalRequ
 
 func (m *Manager) unbindLockedSnapshot(pm *portalMount) error {
 	volumeID := pm.volumeID
-	m.unregisterOwner(pm, volumeID)
-	pm.fs.SetSession(unboundSession{})
-	pm.volumeID = ""
-	pm.teamID = ""
-	pm.mountedAt = time.Time{}
-	if pm.materializeCancel != nil {
-		pm.materializeCancel()
-		pm.materializeCancel = nil
-	}
-	if pm.materializeDone != nil {
-		<-pm.materializeDone
-		pm.materializeDone = nil
-	}
+	m.clearPortalLocked(pm)
 	if volumeID == "" {
 		return nil
+	}
+	bound := m.boundVolumes[volumeID]
+	if bound == nil {
+		return nil
+	}
+	if bound.refCount > 1 {
+		bound.refCount--
+		return nil
+	}
+	delete(m.boundVolumes, volumeID)
+	m.unregisterOwner(bound)
+	if bound.materializeCancel != nil {
+		bound.materializeCancel()
+		bound.materializeCancel = nil
+	}
+	if bound.materializeDone != nil {
+		<-bound.materializeDone
+		bound.materializeDone = nil
 	}
 	return m.volumes.UnmountVolume(context.Background(), volumeID, "")
 }
@@ -428,14 +487,14 @@ func (m *Manager) createObjectStore(teamID, volumeID string) (objectstore.Store,
 	return objectstore.Prefix(store, prefix+"/s0fs/"), nil
 }
 
-func (m *Manager) startMaterializer(pm *portalMount, engine *s0fs.Engine) {
-	if pm == nil || engine == nil {
+func (m *Manager) startMaterializer(bound *boundVolume) {
+	if bound == nil || bound.volCtx == nil || bound.volCtx.S0FS == nil {
 		return
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
-	pm.materializeCancel = cancel
-	pm.materializeDone = done
+	bound.materializeCancel = cancel
+	bound.materializeDone = done
 	go func(volumeID string) {
 		defer close(done)
 		ticker := time.NewTicker(2 * time.Second)
@@ -445,12 +504,54 @@ func (m *Manager) startMaterializer(pm *portalMount, engine *s0fs.Engine) {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				if _, err := engine.SyncMaterialize(ctx); err != nil && m.logger != nil {
+				if _, err := bound.volCtx.S0FS.SyncMaterialize(ctx); err != nil && m.logger != nil {
 					m.logger.Warn("ctld volume materialize failed", zap.String("volume_id", volumeID), zap.Error(err))
 				}
 			}
 		}
-	}(pm.volumeID)
+	}(bound.volumeID)
+}
+
+func (m *Manager) attachPortalLocked(pm *portalMount, volumeID, teamID string, mountedAt time.Time) {
+	if pm == nil {
+		return
+	}
+	if pm.fs != nil {
+		pm.fs.SetSession(newLocalSession(volumeID, m.volumes, m.logrus))
+	}
+	pm.volumeID = volumeID
+	pm.teamID = teamID
+	pm.mountedAt = mountedAt
+}
+
+func (m *Manager) clearPortalLocked(pm *portalMount) {
+	if pm == nil {
+		return
+	}
+	if pm.fs != nil {
+		pm.fs.SetSession(unboundSession{})
+	}
+	pm.volumeID = ""
+	pm.teamID = ""
+	pm.mountedAt = time.Time{}
+}
+
+func boundResponse(pm *portalMount) ctldapi.BindVolumePortalResponse {
+	if pm == nil {
+		return ctldapi.BindVolumePortalResponse{}
+	}
+	return ctldapi.BindVolumePortalResponse{
+		SandboxVolumeID: pm.volumeID,
+		MountPoint:      pm.mountPath,
+		MountedAt:       pm.mountedAt.Format(time.RFC3339),
+	}
+}
+
+func boundMountPath(portals map[string]*portalMount, volumeID, exceptKey string) string {
+	if existing := findBoundPortalForVolume(portals, volumeID, exceptKey); existing != nil {
+		return existing.mountPath
+	}
+	return volumeID
 }
 
 func safePath(value string) string {

--- a/ctld/internal/ctld/portal/manager.go
+++ b/ctld/internal/ctld/portal/manager.go
@@ -305,6 +305,12 @@ func (m *Manager) Bind(ctx context.Context, req ctldapi.BindVolumePortalRequest)
 		}
 		return response, nil
 	}
+	if existing := findBoundPortalForVolume(m.portals, req.SandboxVolumeID, key); existing != nil {
+		conflictPath := existing.mountPath
+		m.mu.Unlock()
+		_ = engine.Close()
+		return ctldapi.BindVolumePortalResponse{}, fmt.Errorf("volume %s is already bound to %s", req.SandboxVolumeID, conflictPath)
+	}
 	m.volumes.add(volCtx)
 	pm.fs.SetSession(session)
 	pm.volumeID = req.SandboxVolumeID

--- a/ctld/internal/ctld/portal/manager.go
+++ b/ctld/internal/ctld/portal/manager.go
@@ -265,6 +265,7 @@ func (m *Manager) Bind(ctx context.Context, req ctldapi.BindVolumePortalRequest)
 		VolumeID:    req.SandboxVolumeID,
 		WALPath:     filepath.Join(cacheDir, "engine.wal"),
 		ObjectStore: remoteStore,
+		HeadStore:   db.NewS0FSHeadStore(m.repo),
 	})
 	if err != nil {
 		return ctldapi.BindVolumePortalResponse{}, fmt.Errorf("open local s0fs engine: %w", err)

--- a/ctld/internal/ctld/portal/manager_shared_test.go
+++ b/ctld/internal/ctld/portal/manager_shared_test.go
@@ -1,0 +1,68 @@
+package portal
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sandbox0-ai/sandbox0/pkg/volumefuse"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volume"
+)
+
+func TestUnbindLockedSnapshotKeepsSharedVolumeUntilLastPortal(t *testing.T) {
+	mgr := &Manager{
+		portals:      make(map[string]*portalMount),
+		boundVolumes: make(map[string]*boundVolume),
+		volumes:      newLocalVolumeManager(),
+	}
+	volCtx := &volume.VolumeContext{
+		VolumeID: "vol-1",
+	}
+	mgr.volumes.add(volCtx)
+	mgr.boundVolumes["vol-1"] = &boundVolume{
+		volumeID: "vol-1",
+		refCount: 2,
+		volCtx:   volCtx,
+	}
+
+	pmA := &portalMount{
+		mountPath: "/workspace/a",
+		volumeID:  "vol-1",
+		teamID:    "team-a",
+		mountedAt: time.Now().UTC(),
+		fs:        volumefuse.New("portal-a", time.Second, unboundSession{}),
+	}
+	pmB := &portalMount{
+		mountPath: "/workspace/b",
+		volumeID:  "vol-1",
+		teamID:    "team-a",
+		mountedAt: time.Now().UTC(),
+		fs:        volumefuse.New("portal-b", time.Second, unboundSession{}),
+	}
+
+	if err := mgr.unbindLockedSnapshot(pmA); err != nil {
+		t.Fatalf("unbindLockedSnapshot(first) error = %v", err)
+	}
+	if pmA.volumeID != "" {
+		t.Fatalf("first portal volumeID = %q, want cleared", pmA.volumeID)
+	}
+	bound := mgr.boundVolumes["vol-1"]
+	if bound == nil {
+		t.Fatal("bound volume removed after first unbind, want shared binding to remain")
+	}
+	if bound.refCount != 1 {
+		t.Fatalf("bound refCount after first unbind = %d, want 1", bound.refCount)
+	}
+	if _, err := mgr.volumes.GetVolume("vol-1"); err != nil {
+		t.Fatalf("GetVolume() after first unbind error = %v, want mounted volume to remain", err)
+	}
+
+	if err := mgr.unbindLockedSnapshot(pmB); err != nil {
+		t.Fatalf("unbindLockedSnapshot(last) error = %v", err)
+	}
+	if _, ok := mgr.boundVolumes["vol-1"]; ok {
+		t.Fatal("bound volume still present after last unbind")
+	}
+	if _, err := mgr.volumes.GetVolume("vol-1"); err == nil {
+		t.Fatal("GetVolume() after last unbind error = nil, want volume removed")
+	}
+}

--- a/ctld/internal/ctld/portal/registry.go
+++ b/ctld/internal/ctld/portal/registry.go
@@ -70,6 +70,21 @@ func isConflictingMountForCtldBind(mount *db.VolumeMount, selfClusterID, selfPod
 	return opts.OwnerKind != volume.OwnerKindStorageProxy
 }
 
+func findBoundPortalForVolume(portals map[string]*portalMount, volumeID, exceptKey string) *portalMount {
+	if strings.TrimSpace(volumeID) == "" {
+		return nil
+	}
+	for key, pm := range portals {
+		if key == exceptKey || pm == nil {
+			continue
+		}
+		if pm.volumeID == volumeID {
+			return pm
+		}
+	}
+	return nil
+}
+
 type ctldBindContext struct {
 	volumeID string
 	teamID   string
@@ -105,7 +120,11 @@ func (m *Manager) registerOwner(ctx context.Context, pm *portalMount, accessMode
 		MountedAt:     pm.mountedAt,
 		MountOptions:  &rawMsg,
 	}
-	if err := m.repo.CreateMount(ctx, mount); err != nil {
+	heartbeatTimeout := 15
+	if m.storage != nil && m.storage.HeartbeatTimeout > 0 {
+		heartbeatTimeout = m.storage.HeartbeatTimeout
+	}
+	if err := m.repo.AcquireMount(ctx, mount, heartbeatTimeout); err != nil {
 		return err
 	}
 

--- a/ctld/internal/ctld/portal/registry.go
+++ b/ctld/internal/ctld/portal/registry.go
@@ -37,8 +37,12 @@ func (m *Manager) validateBindableVolume(ctx context.Context, req ctldBindContex
 	if strings.TrimSpace(vol.TeamID) != strings.TrimSpace(req.teamID) {
 		return nil, fmt.Errorf("volume %s does not belong to team %s", req.volumeID, req.teamID)
 	}
-	if volume.NormalizeAccessMode(vol.AccessMode) != volume.AccessModeRWO {
-		return nil, fmt.Errorf("ctld volume portal only supports RWO volumes, got %s", vol.AccessMode)
+	accessMode, err := validateBindableAccessMode(vol.AccessMode)
+	if err != nil {
+		return nil, err
+	}
+	if accessMode == volume.AccessModeROX {
+		return vol, nil
 	}
 
 	heartbeatTimeout := 15
@@ -57,6 +61,18 @@ func (m *Manager) validateBindableVolume(ctx context.Context, req ctldBindContex
 		return nil, fmt.Errorf("volume %s already has an active owner on %s/%s", req.volumeID, mount.ClusterID, mount.PodID)
 	}
 	return vol, nil
+}
+
+func validateBindableAccessMode(raw string) (volume.AccessMode, error) {
+	accessMode := volume.NormalizeAccessMode(raw)
+	switch accessMode {
+	case volume.AccessModeRWO, volume.AccessModeROX:
+		return accessMode, nil
+	case volume.AccessModeRWX:
+		return "", fmt.Errorf("ctld volume portal does not support RWX volumes")
+	default:
+		return "", fmt.Errorf("ctld volume portal does not support access_mode %q", raw)
+	}
 }
 
 func isConflictingMountForCtldBind(mount *db.VolumeMount, selfClusterID, selfPodID string) bool {
@@ -90,8 +106,8 @@ type ctldBindContext struct {
 	teamID   string
 }
 
-func (m *Manager) registerOwner(ctx context.Context, pm *portalMount, accessMode volume.AccessMode) error {
-	if m == nil || m.repo == nil || pm == nil || pm.volumeID == "" {
+func (m *Manager) registerOwner(ctx context.Context, bound *boundVolume) error {
+	if m == nil || m.repo == nil || bound == nil || bound.volumeID == "" {
 		return fmt.Errorf("ctld volume registry unavailable")
 	}
 	ownerPodID := m.ownerPodID()
@@ -100,7 +116,7 @@ func (m *Manager) registerOwner(ctx context.Context, pm *portalMount, accessMode
 	}
 
 	opts := volume.MountOptions{
-		AccessMode:   accessMode,
+		AccessMode:   bound.access,
 		OwnerKind:    volume.OwnerKindCtld,
 		OwnerPort:    8095,
 		NodeName:     m.nodeName,
@@ -113,11 +129,11 @@ func (m *Manager) registerOwner(ctx context.Context, pm *portalMount, accessMode
 	rawMsg := json.RawMessage(rawOpts)
 	mount := &db.VolumeMount{
 		ID:            uuid.NewString(),
-		VolumeID:      pm.volumeID,
+		VolumeID:      bound.volumeID,
 		ClusterID:     m.clusterID,
 		PodID:         ownerPodID,
 		LastHeartbeat: time.Now().UTC(),
-		MountedAt:     pm.mountedAt,
+		MountedAt:     bound.mountedAt,
 		MountOptions:  &rawMsg,
 	}
 	heartbeatTimeout := 15
@@ -134,8 +150,8 @@ func (m *Manager) registerOwner(ctx context.Context, pm *portalMount, accessMode
 	}
 	heartbeatCtx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
-	pm.heartbeatCancel = cancel
-	pm.heartbeatDone = done
+	bound.heartbeatCancel = cancel
+	bound.heartbeatDone = done
 	go func(volumeID string) {
 		defer close(done)
 		ticker := time.NewTicker(interval)
@@ -150,26 +166,26 @@ func (m *Manager) registerOwner(ctx context.Context, pm *portalMount, accessMode
 				}
 			}
 		}
-	}(pm.volumeID)
+	}(bound.volumeID)
 	return nil
 }
 
-func (m *Manager) unregisterOwner(pm *portalMount, volumeID string) {
-	if m == nil || pm == nil {
+func (m *Manager) unregisterOwner(bound *boundVolume) {
+	if m == nil || bound == nil {
 		return
 	}
-	if pm.heartbeatCancel != nil {
-		pm.heartbeatCancel()
-		pm.heartbeatCancel = nil
+	if bound.heartbeatCancel != nil {
+		bound.heartbeatCancel()
+		bound.heartbeatCancel = nil
 	}
-	if pm.heartbeatDone != nil {
-		<-pm.heartbeatDone
-		pm.heartbeatDone = nil
+	if bound.heartbeatDone != nil {
+		<-bound.heartbeatDone
+		bound.heartbeatDone = nil
 	}
-	if m.repo == nil || volumeID == "" {
+	if m.repo == nil || bound.volumeID == "" {
 		return
 	}
-	if err := m.repo.DeleteMount(context.Background(), volumeID, m.clusterID, m.ownerPodID()); err != nil && m.logger != nil {
-		m.logger.Warn("ctld volume owner unregister failed", zap.String("volume_id", volumeID), zap.Error(err))
+	if err := m.repo.DeleteMount(context.Background(), bound.volumeID, m.clusterID, m.ownerPodID()); err != nil && m.logger != nil {
+		m.logger.Warn("ctld volume owner unregister failed", zap.String("volume_id", bound.volumeID), zap.Error(err))
 	}
 }

--- a/ctld/internal/ctld/portal/registry_test.go
+++ b/ctld/internal/ctld/portal/registry_test.go
@@ -56,6 +56,22 @@ func TestFindBoundPortalForVolumeIgnoresExcludedPortal(t *testing.T) {
 	}
 }
 
+func TestValidateBindableAccessModeAllowsROX(t *testing.T) {
+	accessMode, err := validateBindableAccessMode("ROX")
+	if err != nil {
+		t.Fatalf("validateBindableAccessMode(ROX) error = %v", err)
+	}
+	if accessMode != volume.AccessModeROX {
+		t.Fatalf("validateBindableAccessMode(ROX) = %s, want %s", accessMode, volume.AccessModeROX)
+	}
+}
+
+func TestValidateBindableAccessModeRejectsRWX(t *testing.T) {
+	if _, err := validateBindableAccessMode("RWX"); err == nil {
+		t.Fatal("validateBindableAccessMode(RWX) error = nil, want rejection")
+	}
+}
+
 func mustRegistryMountOptions(t *testing.T, opts volume.MountOptions) *json.RawMessage {
 	t.Helper()
 	raw, err := json.Marshal(opts)

--- a/ctld/internal/ctld/portal/registry_test.go
+++ b/ctld/internal/ctld/portal/registry_test.go
@@ -34,6 +34,28 @@ func TestIsConflictingMountForCtldBindBlocksCtldOwners(t *testing.T) {
 	}
 }
 
+func TestFindBoundPortalForVolumeReturnsOtherPortal(t *testing.T) {
+	portals := map[string]*portalMount{
+		"portal-a": {mountPath: "/workspace/a", volumeID: "vol-1"},
+		"portal-b": {mountPath: "/workspace/b", volumeID: "vol-2"},
+	}
+
+	pm := findBoundPortalForVolume(portals, "vol-1", "portal-b")
+	if pm == nil || pm.mountPath != "/workspace/a" {
+		t.Fatalf("findBoundPortalForVolume() = %+v, want /workspace/a", pm)
+	}
+}
+
+func TestFindBoundPortalForVolumeIgnoresExcludedPortal(t *testing.T) {
+	portals := map[string]*portalMount{
+		"portal-a": {mountPath: "/workspace/a", volumeID: "vol-1"},
+	}
+
+	if pm := findBoundPortalForVolume(portals, "vol-1", "portal-a"); pm != nil {
+		t.Fatalf("findBoundPortalForVolume() = %+v, want nil", pm)
+	}
+}
+
 func mustRegistryMountOptions(t *testing.T, opts volume.MountOptions) *json.RawMessage {
 	t.Helper()
 	raw, err := json.Marshal(opts)

--- a/ctld/internal/ctld/portal/session.go
+++ b/ctld/internal/ctld/portal/session.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"slices"
 	"strconv"
 	"sync"
@@ -62,7 +63,15 @@ func (m *localVolumeManager) UnmountVolume(_ context.Context, volumeID, _ string
 	if _, err := volCtx.S0FS.SyncMaterialize(context.Background()); err != nil {
 		return err
 	}
-	return volCtx.S0FS.Close()
+	if err := volCtx.S0FS.Close(); err != nil {
+		return err
+	}
+	if volCtx.CacheDir != "" {
+		if err := os.RemoveAll(volCtx.CacheDir); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (m *localVolumeManager) AckInvalidate(string, string, string, bool, string) error {

--- a/ctld/internal/ctld/portal/session_test.go
+++ b/ctld/internal/ctld/portal/session_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"os"
 	"path/filepath"
 	"sync/atomic"
 	"testing"
@@ -249,6 +250,37 @@ func TestLocalSessionReleaseSyncsDirtyWrites(t *testing.T) {
 	}
 	if got := counter.Load(); got != 1 {
 		t.Fatalf("sync count after Release() = %d, want 1", got)
+	}
+}
+
+func TestLocalVolumeManagerUnmountRemovesCacheDir(t *testing.T) {
+	cacheDir := filepath.Join(t.TempDir(), "volume-cache")
+	engine, err := s0fs.Open(context.Background(), s0fs.Config{
+		VolumeID: "vol-1",
+		WALPath:  filepath.Join(cacheDir, "engine.wal"),
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+
+	mgr := newLocalVolumeManager()
+	mgr.add(&volume.VolumeContext{
+		VolumeID:  "vol-1",
+		TeamID:    "team-a",
+		Backend:   volume.BackendS0FS,
+		S0FS:      engine,
+		Access:    volume.AccessModeRWO,
+		MountedAt: time.Now().UTC(),
+		RootInode: 1,
+		RootPath:  "/",
+		CacheDir:  cacheDir,
+	})
+
+	if err := mgr.UnmountVolume(context.Background(), "vol-1", ""); err != nil {
+		t.Fatalf("UnmountVolume() error = %v", err)
+	}
+	if _, err := os.Stat(cacheDir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("cache dir stat error = %v, want not exist", err)
 	}
 }
 

--- a/manager/pkg/http/handlers_sandbox.go
+++ b/manager/pkg/http/handlers_sandbox.go
@@ -48,6 +48,10 @@ func (s *Server) claimSandbox(c *gin.Context) {
 			spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
 			return
 		}
+		if errors.Is(err, service.ErrClaimConflict) {
+			spec.JSONError(c, http.StatusConflict, spec.CodeConflict, err.Error())
+			return
+		}
 		if errors.Is(err, service.ErrDataPlaneNotReady) {
 			c.Header("Retry-After", "1")
 			spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, err.Error())

--- a/manager/pkg/service/sandbox_service.go
+++ b/manager/pkg/service/sandbox_service.go
@@ -63,6 +63,7 @@ type SandboxPowerState struct {
 // errNoIdlePod is returned when no idle pod is available for claiming.
 var errNoIdlePod = errors.New("no idle pod available")
 var ErrInvalidClaimRequest = errors.New("invalid claim request")
+var ErrClaimConflict = errors.New("claim conflict")
 var ErrDataPlaneNotReady = errors.New("data plane not ready")
 var errSandboxPowerStateStale = errors.New("sandbox power state changed during execution")
 

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -487,6 +487,9 @@ func (s *SandboxService) bindVolumePortal(ctx context.Context, pod *corev1.Pod, 
 		return nil, fmt.Errorf("pod is nil")
 	}
 	if err := s.prepareVolumePortalBind(ctx, teamID, userID, volumeID); err != nil {
+		if errors.Is(err, ErrVolumePortalBindConflict) {
+			return nil, fmt.Errorf("%w: %v", ErrClaimConflict, err)
+		}
 		return nil, fmt.Errorf("prepare volume portal bind: %w", err)
 	}
 	ctldAddress, err := s.ctldAddressForPod(ctx, pod)

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -754,6 +754,23 @@ func TestPrepareVolumePortalBindUsesPreparationClientWhenAvailable(t *testing.T)
 	}
 }
 
+func TestBindVolumePortalTreatsPreparationConflictAsClaimConflict(t *testing.T) {
+	metadata := &fakeVolumeMetadataClient{prepareErr: ErrVolumePortalBindConflict}
+	svc := &SandboxService{
+		ctldClient:     &CtldClient{},
+		volumeMetadata: metadata,
+	}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "sandbox-a", Namespace: "team-a", UID: "pod-uid"}}
+
+	_, err := svc.bindVolumePortal(context.Background(), pod, "team-a", "user-a", "team-a", "vol-1", "/workspace/data", "data")
+	if err == nil {
+		t.Fatal("bindVolumePortal() error = nil, want claim conflict")
+	}
+	if !errors.Is(err, ErrClaimConflict) {
+		t.Fatalf("bindVolumePortal() error = %v, want ErrClaimConflict", err)
+	}
+}
+
 func newClaimTestPodLister(t *testing.T, pods ...*corev1.Pod) corelisters.PodLister {
 	t.Helper()
 	return corelisters.NewPodLister(newClaimTestPodIndexer(t, pods...))

--- a/manager/pkg/service/sandbox_webhook_state.go
+++ b/manager/pkg/service/sandbox_webhook_state.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -23,6 +24,8 @@ const (
 	webhookStateMountPoint = volumeportal.WebhookStateMountPath
 	webhookStateVolumeKind = "webhook-state"
 )
+
+var ErrVolumePortalBindConflict = errors.New("volume portal bind conflict")
 
 // SandboxSystemVolumeClient creates and deletes manager-owned sandbox volumes.
 type SandboxSystemVolumeClient interface {
@@ -220,7 +223,13 @@ func (c *StorageProxyVolumeClient) PrepareForVolumePortalBind(ctx context.Contex
 	data, _ := io.ReadAll(resp.Body)
 	_, apiErr, decodeErr := spec.DecodeResponse[map[string]any](bytes.NewReader(data))
 	if decodeErr == nil && apiErr != nil {
+		if resp.StatusCode == http.StatusConflict {
+			return fmt.Errorf("%w: %s", ErrVolumePortalBindConflict, apiErr.Message)
+		}
 		return fmt.Errorf("prepare sandbox volume for portal bind failed: %s", apiErr.Message)
+	}
+	if resp.StatusCode == http.StatusConflict {
+		return fmt.Errorf("%w: status %d", ErrVolumePortalBindConflict, resp.StatusCode)
 	}
 	return fmt.Errorf("prepare sandbox volume for portal bind failed with status %d", resp.StatusCode)
 }

--- a/manager/pkg/service/sandbox_webhook_state_test.go
+++ b/manager/pkg/service/sandbox_webhook_state_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -70,5 +71,24 @@ func TestStorageProxyVolumeClientPrepareForPortalBind(t *testing.T) {
 	}
 	if gotToken == "" {
 		t.Fatal("expected internal token header to be set")
+	}
+}
+
+func TestStorageProxyVolumeClientPrepareForPortalBindConflict(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = spec.WriteError(w, http.StatusConflict, spec.CodeConflict, "volume has active mounts")
+	}))
+	defer server.Close()
+
+	client := NewStorageProxyVolumeClient(StorageProxyVolumeClientConfig{
+		BaseURL:        server.URL,
+		TokenGenerator: staticTokenGenerator{},
+	})
+	err := client.PrepareForVolumePortalBind(t.Context(), "team-1", "user-1", "vol-1")
+	if err == nil {
+		t.Fatal("PrepareForVolumePortalBind() error = nil, want conflict")
+	}
+	if !errors.Is(err, ErrVolumePortalBindConflict) {
+		t.Fatalf("PrepareForVolumePortalBind() error = %v, want ErrVolumePortalBindConflict", err)
 	}
 }

--- a/storage-proxy/cmd/storage-proxy/main.go
+++ b/storage-proxy/cmd/storage-proxy/main.go
@@ -126,7 +126,7 @@ func main() {
 	}
 
 	// Create volume manager
-	volMgr := volume.NewManager(logrusLogger, cfg)
+	volMgr := volume.NewManager(logrusLogger, cfg, repo)
 	volMgr.SetMetrics(storageProxyMetrics)
 	directVolumeFileIdleTTL := buildDirectVolumeFileIdleTTL(cfg)
 	directVolumeFileCleanupInterval := buildDirectVolumeFileCleanupInterval(cfg, directVolumeFileIdleTTL)

--- a/storage-proxy/migrations/00011_add_s0fs_committed_heads.sql
+++ b/storage-proxy/migrations/00011_add_s0fs_committed_heads.sql
@@ -1,0 +1,22 @@
+-- +goose Up
+CREATE TABLE IF NOT EXISTS sandbox_volume_s0fs_heads (
+    volume_id TEXT PRIMARY KEY REFERENCES sandbox_volumes(id) ON DELETE CASCADE,
+    manifest_seq BIGINT NOT NULL,
+    checkpoint_seq BIGINT NOT NULL,
+    manifest_key TEXT NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_sandbox_volume_s0fs_heads_updated_at
+    ON sandbox_volume_s0fs_heads(updated_at DESC);
+
+DROP TRIGGER IF EXISTS update_sandbox_volume_s0fs_heads_updated_at ON sandbox_volume_s0fs_heads;
+CREATE TRIGGER update_sandbox_volume_s0fs_heads_updated_at
+    BEFORE UPDATE ON sandbox_volume_s0fs_heads
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+-- +goose Down
+DROP TRIGGER IF EXISTS update_sandbox_volume_s0fs_heads_updated_at ON sandbox_volume_s0fs_heads;
+DROP INDEX IF EXISTS idx_sandbox_volume_s0fs_heads_updated_at;
+DROP TABLE IF EXISTS sandbox_volume_s0fs_heads;

--- a/storage-proxy/pkg/coordinator/coordinator.go
+++ b/storage-proxy/pkg/coordinator/coordinator.go
@@ -256,15 +256,6 @@ func (c *Coordinator) RegisterMount(ctx context.Context, volumeID string, option
 		return nil
 	}
 
-	// Register in memory first to ensure local tracking even if DB fails
-	// This is critical for multi-replica coordination - the volume is mounted
-	// locally regardless of DB state, and we need to track it for heartbeats
-	// and flush coordination.
-	c.mountedVolumes[volumeID] = struct{}{}
-	if metrics != nil {
-		metrics.CoordinatorMountsActive.Inc()
-	}
-
 	normalizedOptions := options
 	normalizedOptions.AccessMode = volume.NormalizeAccessMode(string(options.AccessMode))
 	if normalizedOptions.OwnerKind == "" {
@@ -289,18 +280,24 @@ func (c *Coordinator) RegisterMount(ctx context.Context, volumeID string, option
 		MountOptions:  &rawMsg,
 	}
 
-	if err := c.repo.CreateMount(ctx, mount); err != nil {
+	heartbeatTimeout := c.config.HeartbeatTimeout
+	if heartbeatTimeout == 0 {
+		heartbeatTimeout = HeartbeatTimeout
+	}
+	if err := c.repo.AcquireMount(ctx, mount, heartbeatTimeout); err != nil {
 		if metrics != nil {
 			metrics.CoordinatorMountRegistrations.WithLabelValues("failure").Inc()
 		}
-		// Note: We still track locally even if DB registration fails
-		// This ensures heartbeat updates and flush coordination work
 		c.logger.WithFields(logrus.Fields{
 			"volume_id":  volumeID,
 			"cluster_id": c.clusterID,
 			"pod_id":     c.podID,
-		}).WithError(err).Warn("Failed to register mount in DB, but tracking locally")
-		return fmt.Errorf("create mount: %w", err)
+		}).WithError(err).Warn("Failed to acquire mount in DB")
+		return fmt.Errorf("acquire mount: %w", err)
+	}
+	c.mountedVolumes[volumeID] = struct{}{}
+	if metrics != nil {
+		metrics.CoordinatorMountsActive.Inc()
 	}
 
 	if metrics != nil {

--- a/storage-proxy/pkg/coordinator/coordinator_test.go
+++ b/storage-proxy/pkg/coordinator/coordinator_test.go
@@ -19,6 +19,7 @@ import (
 
 // Mock implementations using simple Go structs
 type MockRepository struct {
+	acquireMountFunc             func(ctx context.Context, mount *db.VolumeMount, heartbeatTimeout int) error
 	createMountFunc              func(ctx context.Context, mount *db.VolumeMount) error
 	updateMountHeartbeatFunc     func(ctx context.Context, volumeID, clusterID, podID string) error
 	deleteMountFunc              func(ctx context.Context, volumeID, clusterID, podID string) error
@@ -32,6 +33,16 @@ type MockRepository struct {
 	createFlushResponseFunc      func(ctx context.Context, resp *db.FlushResponse) error
 	countCompletedFlushesFunc    func(ctx context.Context, coordID string) (int, error)
 	getFlushResponsesFunc        func(ctx context.Context, coordID string) ([]*db.FlushResponse, error)
+}
+
+func (m *MockRepository) AcquireMount(ctx context.Context, mount *db.VolumeMount, heartbeatTimeout int) error {
+	if m.acquireMountFunc != nil {
+		return m.acquireMountFunc(ctx, mount, heartbeatTimeout)
+	}
+	if m.createMountFunc != nil {
+		return m.createMountFunc(ctx, mount)
+	}
+	return nil
 }
 
 func (m *MockRepository) CreateMount(ctx context.Context, mount *db.VolumeMount) error {
@@ -266,13 +277,13 @@ func TestRegisterMount_DatabaseError(t *testing.T) {
 		t.Fatal("Expected error, got nil")
 	}
 
-	// Should still track internally even if DB fails
+	// Failed mount acquisition must not leave local tracking behind.
 	coord.mu.RLock()
 	_, exists := coord.mountedVolumes[volumeID]
 	coord.mu.RUnlock()
 
-	if !exists {
-		t.Error("Volume should be tracked internally even on DB error")
+	if exists {
+		t.Error("Volume should not be tracked internally when mount acquisition fails")
 	}
 }
 

--- a/storage-proxy/pkg/db/models.go
+++ b/storage-proxy/pkg/db/models.go
@@ -22,6 +22,15 @@ type SandboxVolume struct {
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
+// S0FSCommittedHead stores the current committed immutable manifest pointer for one volume.
+type S0FSCommittedHead struct {
+	VolumeID      string    `json:"volume_id"`
+	ManifestSeq   uint64    `json:"manifest_seq"`
+	CheckpointSeq uint64    `json:"checkpoint_seq"`
+	ManifestKey   string    `json:"manifest_key"`
+	UpdatedAt     time.Time `json:"updated_at"`
+}
+
 const (
 	SandboxVolumeOwnerKindSandbox = "sandbox"
 )

--- a/storage-proxy/pkg/db/repository.go
+++ b/storage-proxy/pkg/db/repository.go
@@ -13,6 +13,7 @@ import (
 
 var (
 	ErrNotFound = errors.New("not found")
+	ErrConflict = errors.New("conflict")
 )
 
 // CoordinatorRepository defines the database operations needed by coordinator

--- a/storage-proxy/pkg/db/repository.go
+++ b/storage-proxy/pkg/db/repository.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -20,6 +21,7 @@ var (
 // This interface is implemented by *Repository
 type CoordinatorRepository interface {
 	// Mount operations
+	AcquireMount(ctx context.Context, mount *VolumeMount, heartbeatTimeout int) error
 	CreateMount(ctx context.Context, mount *VolumeMount) error
 	UpdateMountHeartbeat(ctx context.Context, volumeID, clusterID, podID string) error
 	DeleteMount(ctx context.Context, volumeID, clusterID, podID string) error
@@ -35,6 +37,32 @@ type CoordinatorRepository interface {
 	CreateFlushResponse(ctx context.Context, resp *FlushResponse) error
 	CountCompletedFlushes(ctx context.Context, coordID string) (int, error)
 	GetFlushResponses(ctx context.Context, coordID string) ([]*FlushResponse, error)
+}
+
+type mountOptionsEnvelope struct {
+	AccessMode string `json:"access_mode"`
+}
+
+func normalizeMountAccessMode(value string) string {
+	switch strings.ToUpper(strings.TrimSpace(value)) {
+	case "ROX":
+		return "ROX"
+	case "RWX":
+		return "RWX"
+	default:
+		return "RWO"
+	}
+}
+
+func decodeMountAccessMode(raw *json.RawMessage) string {
+	if raw == nil || len(*raw) == 0 {
+		return "RWO"
+	}
+	var opts mountOptionsEnvelope
+	if err := json.Unmarshal(*raw, &opts); err != nil {
+		return "RWO"
+	}
+	return normalizeMountAccessMode(opts.AccessMode)
 }
 
 // Repository provides database access for storage-proxy
@@ -620,9 +648,55 @@ func (r *Repository) deleteSnapshot(ctx context.Context, db DB, id string) error
 // Volume Mount Repository Methods (for cross-cluster coordination)
 // ============================================================
 
+// AcquireMount atomically enforces the volume access mode and upserts the active mount row.
+func (r *Repository) AcquireMount(ctx context.Context, mount *VolumeMount, heartbeatTimeout int) error {
+	if mount == nil {
+		return fmt.Errorf("mount is required")
+	}
+	if heartbeatTimeout <= 0 {
+		heartbeatTimeout = 15
+	}
+	return r.WithTx(ctx, func(tx pgx.Tx) error {
+		var accessMode string
+		if err := tx.QueryRow(ctx, `SELECT access_mode FROM sandbox_volumes WHERE id = $1 FOR UPDATE`, mount.VolumeID).Scan(&accessMode); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return ErrNotFound
+			}
+			return fmt.Errorf("lock sandbox volume: %w", err)
+		}
+		activeMounts, err := r.getActiveMounts(ctx, tx, mount.VolumeID, heartbeatTimeout)
+		if err != nil {
+			return err
+		}
+		switch normalizeMountAccessMode(accessMode) {
+		case "RWO":
+			for _, active := range activeMounts {
+				if active.ClusterID == mount.ClusterID && active.PodID == mount.PodID {
+					continue
+				}
+				return fmt.Errorf("%w: volume %s already mounted on another instance", ErrConflict, mount.VolumeID)
+			}
+		case "ROX":
+			for _, active := range activeMounts {
+				if decodeMountAccessMode(active.MountOptions) != "ROX" {
+					return fmt.Errorf("%w: volume %s already mounted read-write", ErrConflict, mount.VolumeID)
+				}
+			}
+		case "RWX":
+		default:
+			return fmt.Errorf("invalid access_mode %q", accessMode)
+		}
+		return r.createMount(ctx, tx, mount)
+	})
+}
+
 // CreateMount creates a volume mount record
 func (r *Repository) CreateMount(ctx context.Context, mount *VolumeMount) error {
-	_, err := r.pool.Exec(ctx, `
+	return r.createMount(ctx, r.pool, mount)
+}
+
+func (r *Repository) createMount(ctx context.Context, db DB, mount *VolumeMount) error {
+	_, err := db.Exec(ctx, `
 		INSERT INTO sandbox_volume_mounts (
 			id, volume_id, cluster_id, pod_id,
 			last_heartbeat, mounted_at, mount_options
@@ -691,7 +765,11 @@ func (r *Repository) DeleteMountByPodID(ctx context.Context, clusterID, podID st
 
 // GetActiveMounts retrieves active mounts for a volume (heartbeat within threshold)
 func (r *Repository) GetActiveMounts(ctx context.Context, volumeID string, heartbeatTimeout int) ([]*VolumeMount, error) {
-	rows, err := r.pool.Query(ctx, `
+	return r.getActiveMounts(ctx, r.pool, volumeID, heartbeatTimeout)
+}
+
+func (r *Repository) getActiveMounts(ctx context.Context, db DB, volumeID string, heartbeatTimeout int) ([]*VolumeMount, error) {
+	rows, err := db.Query(ctx, `
 		SELECT
 			id, volume_id, cluster_id, pod_id,
 			last_heartbeat, mounted_at, mount_options

--- a/storage-proxy/pkg/db/repository_s0fs_head.go
+++ b/storage-proxy/pkg/db/repository_s0fs_head.go
@@ -1,0 +1,165 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/s0fs"
+)
+
+// GetS0FSCommittedHead returns the committed immutable manifest pointer for a volume.
+func (r *Repository) GetS0FSCommittedHead(ctx context.Context, volumeID string) (*S0FSCommittedHead, error) {
+	return r.getS0FSCommittedHead(ctx, r.pool, volumeID, false)
+}
+
+func (r *Repository) getS0FSCommittedHead(ctx context.Context, db DB, volumeID string, forUpdate bool) (*S0FSCommittedHead, error) {
+	query := `
+		SELECT volume_id, manifest_seq, checkpoint_seq, manifest_key, updated_at
+		FROM sandbox_volume_s0fs_heads
+		WHERE volume_id = $1
+	`
+	if forUpdate {
+		query += " FOR UPDATE"
+	}
+
+	var head S0FSCommittedHead
+	err := db.QueryRow(ctx, query, volumeID).Scan(
+		&head.VolumeID,
+		&head.ManifestSeq,
+		&head.CheckpointSeq,
+		&head.ManifestKey,
+		&head.UpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get s0fs committed head: %w", err)
+	}
+	return &head, nil
+}
+
+// CompareAndSwapS0FSCommittedHead advances the committed manifest pointer only
+// when the current manifest sequence matches expectedManifestSeq. expected 0
+// inserts a new head when none exists.
+func (r *Repository) CompareAndSwapS0FSCommittedHead(ctx context.Context, volumeID string, expectedManifestSeq uint64, head *S0FSCommittedHead) error {
+	if head == nil {
+		return fmt.Errorf("compare and swap s0fs committed head: head is required")
+	}
+	if strings.TrimSpace(volumeID) == "" {
+		return fmt.Errorf("compare and swap s0fs committed head: volume id is required")
+	}
+	if head.VolumeID == "" {
+		head.VolumeID = volumeID
+	}
+	if head.VolumeID != volumeID {
+		return fmt.Errorf("compare and swap s0fs committed head: volume id mismatch")
+	}
+	if head.ManifestSeq == 0 {
+		return fmt.Errorf("compare and swap s0fs committed head: manifest sequence must be non-zero")
+	}
+	if head.ManifestKey == "" {
+		return fmt.Errorf("compare and swap s0fs committed head: manifest key is required")
+	}
+
+	return r.WithTx(ctx, func(tx pgx.Tx) error {
+		existing, err := r.getS0FSCommittedHead(ctx, tx, volumeID, true)
+		switch {
+		case errors.Is(err, ErrNotFound):
+			if expectedManifestSeq != 0 {
+				return ErrConflict
+			}
+			updatedAt := head.UpdatedAt
+			if updatedAt.IsZero() {
+				updatedAt = time.Now().UTC()
+			}
+			_, err := tx.Exec(ctx, `
+				INSERT INTO sandbox_volume_s0fs_heads (
+					volume_id, manifest_seq, checkpoint_seq, manifest_key, updated_at
+				) VALUES ($1, $2, $3, $4, $5)
+			`, volumeID, int64(head.ManifestSeq), int64(head.CheckpointSeq), head.ManifestKey, updatedAt)
+			if err != nil {
+				return fmt.Errorf("insert s0fs committed head: %w", err)
+			}
+			return nil
+		case err != nil:
+			return err
+		}
+
+		if existing.ManifestSeq != expectedManifestSeq {
+			return ErrConflict
+		}
+		if head.ManifestSeq <= existing.ManifestSeq {
+			return ErrConflict
+		}
+
+		updatedAt := head.UpdatedAt
+		if updatedAt.IsZero() {
+			updatedAt = time.Now().UTC()
+		}
+		_, err = tx.Exec(ctx, `
+			UPDATE sandbox_volume_s0fs_heads
+			SET manifest_seq = $2,
+				checkpoint_seq = $3,
+				manifest_key = $4,
+				updated_at = $5
+			WHERE volume_id = $1
+		`, volumeID, int64(head.ManifestSeq), int64(head.CheckpointSeq), head.ManifestKey, updatedAt)
+		if err != nil {
+			return fmt.Errorf("update s0fs committed head: %w", err)
+		}
+		return nil
+	})
+}
+
+type S0FSHeadStore struct {
+	repo *Repository
+}
+
+func NewS0FSHeadStore(repo *Repository) *S0FSHeadStore {
+	if repo == nil {
+		return nil
+	}
+	return &S0FSHeadStore{repo: repo}
+}
+
+func (s *S0FSHeadStore) LoadCommittedHead(ctx context.Context, volumeID string) (*s0fs.CommittedHead, error) {
+	if s == nil || s.repo == nil {
+		return nil, s0fs.ErrCommittedHeadNotFound
+	}
+	head, err := s.repo.GetS0FSCommittedHead(ctx, volumeID)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return nil, s0fs.ErrCommittedHeadNotFound
+		}
+		return nil, err
+	}
+	return &s0fs.CommittedHead{
+		VolumeID:      head.VolumeID,
+		ManifestSeq:   head.ManifestSeq,
+		CheckpointSeq: head.CheckpointSeq,
+		ManifestKey:   head.ManifestKey,
+		UpdatedAt:     head.UpdatedAt,
+	}, nil
+}
+
+func (s *S0FSHeadStore) CompareAndSwapCommittedHead(ctx context.Context, volumeID string, expectedManifestSeq uint64, head *s0fs.CommittedHead) error {
+	if s == nil || s.repo == nil {
+		return s0fs.ErrCommittedHeadNotFound
+	}
+	err := s.repo.CompareAndSwapS0FSCommittedHead(ctx, volumeID, expectedManifestSeq, &S0FSCommittedHead{
+		VolumeID:      head.VolumeID,
+		ManifestSeq:   head.ManifestSeq,
+		CheckpointSeq: head.CheckpointSeq,
+		ManifestKey:   head.ManifestKey,
+		UpdatedAt:     head.UpdatedAt,
+	})
+	if errors.Is(err, ErrConflict) {
+		return s0fs.ErrCommittedHeadConflict
+	}
+	return err
+}

--- a/storage-proxy/pkg/db/repository_s0fs_head_test.go
+++ b/storage-proxy/pkg/db/repository_s0fs_head_test.go
@@ -1,0 +1,157 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sandbox0-ai/sandbox0/pkg/dbpool"
+	"github.com/sandbox0-ai/sandbox0/pkg/migrate"
+	storagemigrations "github.com/sandbox0-ai/sandbox0/storage-proxy/migrations"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/s0fs"
+)
+
+func TestS0FSCommittedHeadCompareAndSwapLifecycle(t *testing.T) {
+	repo := newS0FSCommittedHeadTestRepository(t)
+	if repo == nil {
+		return
+	}
+
+	ctx := context.Background()
+	volumeID := "vol-" + uuid.NewString()
+	createTestSandboxVolume(t, repo, volumeID)
+
+	headOne := &S0FSCommittedHead{
+		VolumeID:      volumeID,
+		ManifestSeq:   7,
+		CheckpointSeq: 7,
+		ManifestKey:   "manifests/00000000000000000007.json",
+		UpdatedAt:     time.Now().UTC(),
+	}
+	if err := repo.CompareAndSwapS0FSCommittedHead(ctx, volumeID, 0, headOne); err != nil {
+		t.Fatalf("CompareAndSwapS0FSCommittedHead(insert) error = %v", err)
+	}
+
+	loaded, err := repo.GetS0FSCommittedHead(ctx, volumeID)
+	if err != nil {
+		t.Fatalf("GetS0FSCommittedHead() error = %v", err)
+	}
+	if loaded.ManifestSeq != headOne.ManifestSeq || loaded.ManifestKey != headOne.ManifestKey {
+		t.Fatalf("loaded head = %+v, want %+v", loaded, headOne)
+	}
+
+	headTwo := &S0FSCommittedHead{
+		VolumeID:      volumeID,
+		ManifestSeq:   9,
+		CheckpointSeq: 9,
+		ManifestKey:   "manifests/00000000000000000009.json",
+		UpdatedAt:     time.Now().UTC(),
+	}
+	if err := repo.CompareAndSwapS0FSCommittedHead(ctx, volumeID, 0, headTwo); err != ErrConflict {
+		t.Fatalf("CompareAndSwapS0FSCommittedHead(stale insert) err = %v, want %v", err, ErrConflict)
+	}
+	if err := repo.CompareAndSwapS0FSCommittedHead(ctx, volumeID, headOne.ManifestSeq, headTwo); err != nil {
+		t.Fatalf("CompareAndSwapS0FSCommittedHead(update) error = %v", err)
+	}
+	loaded, err = repo.GetS0FSCommittedHead(ctx, volumeID)
+	if err != nil {
+		t.Fatalf("GetS0FSCommittedHead(after update) error = %v", err)
+	}
+	if loaded.ManifestSeq != headTwo.ManifestSeq || loaded.ManifestKey != headTwo.ManifestKey {
+		t.Fatalf("loaded head after update = %+v, want %+v", loaded, headTwo)
+	}
+}
+
+func TestS0FSHeadStoreAdapterMapsConflicts(t *testing.T) {
+	repo := newS0FSCommittedHeadTestRepository(t)
+	if repo == nil {
+		return
+	}
+
+	ctx := context.Background()
+	volumeID := "vol-" + uuid.NewString()
+	createTestSandboxVolume(t, repo, volumeID)
+	store := NewS0FSHeadStore(repo)
+
+	first := &s0fs.CommittedHead{
+		VolumeID:      volumeID,
+		ManifestSeq:   3,
+		CheckpointSeq: 3,
+		ManifestKey:   "manifests/00000000000000000003.json",
+		UpdatedAt:     time.Now().UTC(),
+	}
+	if err := store.CompareAndSwapCommittedHead(ctx, volumeID, 0, first); err != nil {
+		t.Fatalf("CompareAndSwapCommittedHead(first) error = %v", err)
+	}
+
+	second := &s0fs.CommittedHead{
+		VolumeID:      volumeID,
+		ManifestSeq:   4,
+		CheckpointSeq: 4,
+		ManifestKey:   "manifests/00000000000000000004.json",
+		UpdatedAt:     time.Now().UTC(),
+	}
+	if err := store.CompareAndSwapCommittedHead(ctx, volumeID, 0, second); err != s0fs.ErrCommittedHeadConflict {
+		t.Fatalf("CompareAndSwapCommittedHead(conflict) err = %v, want %v", err, s0fs.ErrCommittedHeadConflict)
+	}
+
+	loaded, err := store.LoadCommittedHead(ctx, volumeID)
+	if err != nil {
+		t.Fatalf("LoadCommittedHead() error = %v", err)
+	}
+	if loaded.ManifestSeq != first.ManifestSeq || loaded.ManifestKey != first.ManifestKey {
+		t.Fatalf("loaded committed head = %+v, want %+v", loaded, first)
+	}
+}
+
+func newS0FSCommittedHeadTestRepository(t *testing.T) *Repository {
+	t.Helper()
+
+	dbURL := os.Getenv("INTEGRATION_DATABASE_URL")
+	if dbURL == "" {
+		dbURL = os.Getenv("TEST_DATABASE_URL")
+	}
+	if dbURL == "" {
+		t.Skip("missing INTEGRATION_DATABASE_URL or TEST_DATABASE_URL")
+		return nil
+	}
+
+	ctx := context.Background()
+	schema := fmt.Sprintf("storage_proxy_s0fs_head_test_%s", strings.ReplaceAll(uuid.NewString(), "-", ""))
+	pool, err := dbpool.New(ctx, dbpool.Options{
+		DatabaseURL: dbURL,
+		Schema:      schema,
+	})
+	if err != nil {
+		t.Fatalf("connect test database: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE", schema))
+		pool.Close()
+	})
+
+	if err := migrate.Up(ctx, pool, ".", migrate.WithBaseFS(storagemigrations.FS), migrate.WithSchema(schema)); err != nil {
+		t.Fatalf("migrate storage-proxy schema: %v", err)
+	}
+	return NewRepository(pool)
+}
+
+func createTestSandboxVolume(t *testing.T, repo *Repository, volumeID string) {
+	t.Helper()
+
+	now := time.Now().UTC()
+	if err := repo.CreateSandboxVolume(context.Background(), &SandboxVolume{
+		ID:         volumeID,
+		TeamID:     "team-1",
+		UserID:     "user-1",
+		AccessMode: "RWO",
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}); err != nil {
+		t.Fatalf("CreateSandboxVolume(%s) error = %v", volumeID, err)
+	}
+}

--- a/storage-proxy/pkg/db/repository_s0fs_head_test.go
+++ b/storage-proxy/pkg/db/repository_s0fs_head_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -108,6 +109,90 @@ func TestS0FSHeadStoreAdapterMapsConflicts(t *testing.T) {
 	}
 }
 
+func TestAcquireMountRejectsConflictingRWOMount(t *testing.T) {
+	repo := newS0FSCommittedHeadTestRepository(t)
+	if repo == nil {
+		return
+	}
+
+	ctx := context.Background()
+	volumeID := "vol-" + uuid.NewString()
+	createTestSandboxVolume(t, repo, volumeID)
+
+	first := &VolumeMount{
+		ID:            uuid.NewString(),
+		VolumeID:      volumeID,
+		ClusterID:     "cluster-a",
+		PodID:         "pod-a",
+		LastHeartbeat: time.Now().UTC(),
+		MountedAt:     time.Now().UTC(),
+		MountOptions:  mustMountOptionsRaw(t, "RWO"),
+	}
+	if err := repo.AcquireMount(ctx, first, 15); err != nil {
+		t.Fatalf("AcquireMount(first) error = %v", err)
+	}
+
+	second := &VolumeMount{
+		ID:            uuid.NewString(),
+		VolumeID:      volumeID,
+		ClusterID:     "cluster-b",
+		PodID:         "pod-b",
+		LastHeartbeat: time.Now().UTC(),
+		MountedAt:     time.Now().UTC(),
+		MountOptions:  mustMountOptionsRaw(t, "RWO"),
+	}
+	if err := repo.AcquireMount(ctx, second, 15); err != ErrConflict {
+		t.Fatalf("AcquireMount(second) err = %v, want %v", err, ErrConflict)
+	}
+}
+
+func TestAcquireMountAllowsROXSharing(t *testing.T) {
+	repo := newS0FSCommittedHeadTestRepository(t)
+	if repo == nil {
+		return
+	}
+
+	ctx := context.Background()
+	volumeID := "vol-" + uuid.NewString()
+	now := time.Now().UTC()
+	if err := repo.CreateSandboxVolume(ctx, &SandboxVolume{
+		ID:         volumeID,
+		TeamID:     "team-1",
+		UserID:     "user-1",
+		AccessMode: "ROX",
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}); err != nil {
+		t.Fatalf("CreateSandboxVolume(%s) error = %v", volumeID, err)
+	}
+
+	first := &VolumeMount{
+		ID:            uuid.NewString(),
+		VolumeID:      volumeID,
+		ClusterID:     "cluster-a",
+		PodID:         "pod-a",
+		LastHeartbeat: time.Now().UTC(),
+		MountedAt:     time.Now().UTC(),
+		MountOptions:  mustMountOptionsRaw(t, "ROX"),
+	}
+	if err := repo.AcquireMount(ctx, first, 15); err != nil {
+		t.Fatalf("AcquireMount(first) error = %v", err)
+	}
+
+	second := &VolumeMount{
+		ID:            uuid.NewString(),
+		VolumeID:      volumeID,
+		ClusterID:     "cluster-b",
+		PodID:         "pod-b",
+		LastHeartbeat: time.Now().UTC(),
+		MountedAt:     time.Now().UTC(),
+		MountOptions:  mustMountOptionsRaw(t, "ROX"),
+	}
+	if err := repo.AcquireMount(ctx, second, 15); err != nil {
+		t.Fatalf("AcquireMount(second) error = %v", err)
+	}
+}
+
 func newS0FSCommittedHeadTestRepository(t *testing.T) *Repository {
 	t.Helper()
 
@@ -154,4 +239,18 @@ func createTestSandboxVolume(t *testing.T, repo *Repository, volumeID string) {
 	}); err != nil {
 		t.Fatalf("CreateSandboxVolume(%s) error = %v", volumeID, err)
 	}
+}
+
+func mustMountOptionsRaw(t *testing.T, accessMode string) *json.RawMessage {
+	t.Helper()
+	raw, err := json.Marshal(struct {
+		AccessMode string `json:"access_mode"`
+	}{
+		AccessMode: accessMode,
+	})
+	if err != nil {
+		t.Fatalf("marshal mount options: %v", err)
+	}
+	msg := json.RawMessage(raw)
+	return &msg
 }

--- a/storage-proxy/pkg/http/handlers_sandboxvolume.go
+++ b/storage-proxy/pkg/http/handlers_sandboxvolume.go
@@ -644,6 +644,19 @@ func (s *Server) prepareSandboxVolumeForPortalBind(w http.ResponseWriter, r *htt
 			return
 		}
 	}
+	if volume.NormalizeAccessMode(vol.AccessMode) == volume.AccessModeRWO {
+		const heartbeatTimeout = 15
+		mounts, err := s.repo.GetActiveMounts(r.Context(), id, heartbeatTimeout)
+		if err != nil {
+			s.logger.WithError(err).WithField("volume_id", id).Warn("Failed to check active mounts before portal bind")
+			_ = spec.WriteError(w, http.StatusInternalServerError, spec.CodeInternal, "failed to check active mounts")
+			return
+		}
+		if len(mounts) > 0 {
+			_ = spec.WriteError(w, http.StatusConflict, spec.CodeConflict, "volume has active mounts")
+			return
+		}
+	}
 
 	_ = spec.WriteSuccess(w, http.StatusOK, map[string]any{
 		"prepared": true,

--- a/storage-proxy/pkg/http/handlers_sandboxvolume_test.go
+++ b/storage-proxy/pkg/http/handlers_sandboxvolume_test.go
@@ -251,6 +251,35 @@ func TestPrepareSandboxVolumeForPortalBindCleansIdleDirectMount(t *testing.T) {
 	}
 }
 
+func TestPrepareSandboxVolumeForPortalBindRejectsActiveRWOMounts(t *testing.T) {
+	repo := newFakeHTTPRepo()
+	repo.volumes["vol-1"] = &db.SandboxVolume{ID: "vol-1", TeamID: "team-1", UserID: "user-1", AccessMode: "RWO"}
+	repo.activeMounts["vol-1"] = []*db.VolumeMount{{
+		VolumeID:  "vol-1",
+		ClusterID: "cluster-a",
+		PodID:     "sandbox0-system/ctld-a",
+	}}
+	server := &Server{
+		logger: logrus.New(),
+		repo:   repo,
+	}
+
+	req := httptest.NewRequest(http.MethodPut, "/internal/v1/sandboxvolumes/vol-1/prepare-portal-bind", nil)
+	req.SetPathValue("id", "vol-1")
+	req = req.WithContext(internalauth.WithClaims(req.Context(), &internalauth.Claims{
+		Caller: internalauth.ServiceManager,
+		TeamID: "team-1",
+		UserID: "user-1",
+	}))
+	recorder := httptest.NewRecorder()
+
+	server.prepareSandboxVolumeForPortalBind(recorder, req)
+
+	if recorder.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusConflict, recorder.Body.String())
+	}
+}
+
 func TestForkVolumePassesDefaultPosixIdentity(t *testing.T) {
 	snapshotMgr := &captureForkSnapshotManager{fakeHTTPSnapshotManager: &fakeHTTPSnapshotManager{}}
 	server := &Server{

--- a/storage-proxy/pkg/http/handlers_snapshot.go
+++ b/storage-proxy/pkg/http/handlers_snapshot.go
@@ -236,6 +236,8 @@ func (s *Server) handleSnapshotError(w http.ResponseWriter, err error) {
 		_ = spec.WriteError(w, http.StatusInternalServerError, spec.CodeInternal, "clone operation failed")
 	case errors.Is(err, snapshot.ErrRemountTimeout):
 		_ = spec.WriteError(w, http.StatusGatewayTimeout, spec.CodeInternal, "remount timeout")
+	case errors.Is(err, snapshot.ErrMountedCtldOwner):
+		_ = spec.WriteError(w, http.StatusConflict, spec.CodeConflict, "ctld-mounted volumes must be unmounted before snapshot or restore")
 	default:
 		s.logger.WithError(err).Error("Snapshot operation failed")
 		_ = spec.WriteError(w, http.StatusInternalServerError, spec.CodeInternal, "internal server error")

--- a/storage-proxy/pkg/http/handlers_volume_files.go
+++ b/storage-proxy/pkg/http/handlers_volume_files.go
@@ -227,6 +227,12 @@ func (s *Server) handleVolumeFileMove(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	ctx, _, cleanup, handled := s.prepareOrProxyVolumeFileRequest(w, r, volumeID)
+	if handled {
+		return
+	}
+	defer cleanup()
+
 	var req volumeFileMoveRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		_ = spec.WriteError(w, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
@@ -236,12 +242,6 @@ func (s *Server) handleVolumeFileMove(w http.ResponseWriter, r *http.Request) {
 		_ = spec.WriteError(w, http.StatusBadRequest, spec.CodeBadRequest, "source and destination are required")
 		return
 	}
-
-	ctx, _, cleanup, handled := s.prepareOrProxyVolumeFileRequest(w, r, volumeID)
-	if handled {
-		return
-	}
-	defer cleanup()
 
 	if err := s.moveVolumePath(ctx, volumeID, req.Source, req.Destination); err != nil {
 		s.writeVolumeFileError(w, err)

--- a/storage-proxy/pkg/http/handlers_volume_files_test.go
+++ b/storage-proxy/pkg/http/handlers_volume_files_test.go
@@ -593,6 +593,84 @@ func TestHandleVolumeFileMoveRenamesPath(t *testing.T) {
 	}
 }
 
+func TestHandleVolumeFileMoveProxiesBodyToCtldOwner(t *testing.T) {
+	remoteSeen := make(chan struct {
+		header http.Header
+		body   []byte
+	}, 1)
+	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read proxied body: %v", err)
+		}
+		select {
+		case remoteSeen <- struct {
+			header http.Header
+			body   []byte
+		}{
+			header: r.Header.Clone(),
+			body:   body,
+		}:
+		default:
+		}
+		_ = spec.WriteSuccess(w, http.StatusOK, map[string]bool{"moved": true})
+	}))
+	defer remote.Close()
+	remoteURL, err := url.Parse(remote.URL)
+	if err != nil {
+		t.Fatalf("parse remote url: %v", err)
+	}
+	remotePort, err := strconv.Atoi(remoteURL.Port())
+	if err != nil {
+		t.Fatalf("parse remote port: %v", err)
+	}
+
+	fileRPC := &fakeHTTPVolumeFileRPC{}
+	server, volMgr := newVolumeFileTestServer(fileRPC)
+	repo := server.repo.(*fakeHTTPRepo)
+	repo.activeMounts["vol-1"] = []*db.VolumeMount{
+		{
+			VolumeID:     "vol-1",
+			ClusterID:    "cluster-a",
+			PodID:        "sandbox0-system/ctld-node-a",
+			MountedAt:    time.Unix(10, 0),
+			MountOptions: mustMountOptionsRaw(t, volume.MountOptions{AccessMode: volume.AccessModeRWO, OwnerKind: volume.OwnerKindCtld, OwnerPort: remotePort}),
+		},
+	}
+	server.podResolver = &fakeVolumeFilePodResolver{
+		urls: map[string]string{"sandbox0-system/ctld-node-a": "http://127.0.0.1"},
+	}
+
+	reqBody := []byte(`{"source":"/docs/report.txt","destination":"/archive/report-old.txt"}`)
+	req := httptest.NewRequest(http.MethodPost, "/sandboxvolumes/vol-1/files/move", bytes.NewReader(reqBody))
+	req.SetPathValue("id", "vol-1")
+	req = req.WithContext(internalauth.WithClaims(req.Context(), &internalauth.Claims{TeamID: "team-a"}))
+	recorder := httptest.NewRecorder()
+
+	server.handleVolumeFileMove(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+	if volMgr.acquireCalls != 0 {
+		t.Fatalf("AcquireDirectVolumeFileMount() calls = %d, want 0", volMgr.acquireCalls)
+	}
+	select {
+	case seen := <-remoteSeen:
+		if got := seen.header.Get(volumeFileAffinityRoutedPodHeader); got != "sandbox0-system/ctld-node-a" {
+			t.Fatalf("routed pod header = %q, want %q", got, "sandbox0-system/ctld-node-a")
+		}
+		if got := seen.header.Get(volumeFileAffinityTeamHeader); got != "team-a" {
+			t.Fatalf("team header = %q, want %q", got, "team-a")
+		}
+		if !bytes.Equal(seen.body, reqBody) {
+			t.Fatalf("proxied body = %q, want %q", string(seen.body), string(reqBody))
+		}
+	default:
+		t.Fatal("expected move request to be proxied to ctld owner")
+	}
+}
+
 func TestHandleVolumeFileStatProxiesToRemoteOwnerPod(t *testing.T) {
 	remoteSeen := make(chan *http.Request, 1)
 	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/storage-proxy/pkg/objectstore/store.go
+++ b/storage-proxy/pkg/objectstore/store.go
@@ -139,10 +139,20 @@ func Prefix(store Store, prefix string) Store {
 	}
 }
 
+var sharedMemoryNamespaces sync.Map
+
 func NewMemoryStore(namespace string) Store {
+	namespace = strings.TrimSpace(namespace)
+	state := &memoryStoreState{
+		objects: make(map[string][]byte),
+	}
+	if namespace != "" {
+		shared, _ := sharedMemoryNamespaces.LoadOrStore(namespace, state)
+		state = shared.(*memoryStoreState)
+	}
 	return &memoryStore{
-		namespace: strings.TrimSpace(namespace),
-		objects:   make(map[string][]byte),
+		namespace: namespace,
+		state:     state,
 	}
 }
 
@@ -641,9 +651,13 @@ func (s *prefixedStore) prefixed(key string) string {
 }
 
 type memoryStore struct {
-	mu        sync.RWMutex
 	namespace string
-	objects   map[string][]byte
+	state     *memoryStoreState
+}
+
+type memoryStoreState struct {
+	mu      sync.RWMutex
+	objects map[string][]byte
 }
 
 func (s *memoryStore) String() string {
@@ -658,9 +672,9 @@ func (s *memoryStore) Create() error {
 }
 
 func (s *memoryStore) Get(key string, off, limit int64) (io.ReadCloser, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	payload, ok := s.objects[strings.TrimLeft(key, "/")]
+	s.state.mu.RLock()
+	defer s.state.mu.RUnlock()
+	payload, ok := s.state.objects[strings.TrimLeft(key, "/")]
 	if !ok {
 		return nil, errors.New("object not found")
 	}
@@ -680,16 +694,16 @@ func (s *memoryStore) Put(key string, in io.Reader) error {
 	if err != nil {
 		return err
 	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.objects[strings.TrimLeft(key, "/")] = payload
+	s.state.mu.Lock()
+	defer s.state.mu.Unlock()
+	s.state.objects[strings.TrimLeft(key, "/")] = payload
 	return nil
 }
 
 func (s *memoryStore) Delete(key string) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	delete(s.objects, strings.TrimLeft(key, "/"))
+	s.state.mu.Lock()
+	defer s.state.mu.Unlock()
+	delete(s.state.objects, strings.TrimLeft(key, "/"))
 	return nil
 }
 
@@ -697,9 +711,9 @@ func (s *memoryStore) Head(key string) (Info, error) {
 	if strings.TrimSpace(key) == "" {
 		return Info{}, nil
 	}
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	payload, ok := s.objects[strings.TrimLeft(key, "/")]
+	s.state.mu.RLock()
+	defer s.state.mu.RUnlock()
+	payload, ok := s.state.objects[strings.TrimLeft(key, "/")]
 	if !ok {
 		return Info{}, errors.New("object not found")
 	}
@@ -710,12 +724,12 @@ func (s *memoryStore) Head(key string) (Info, error) {
 }
 
 func (s *memoryStore) List(prefix, startAfter, _ string, _ string, limit int64) ([]Info, bool, string, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	s.state.mu.RLock()
+	defer s.state.mu.RUnlock()
 	prefix = strings.TrimLeft(prefix, "/")
 	startAfter = strings.TrimLeft(startAfter, "/")
-	keys := make([]string, 0, len(s.objects))
-	for key := range s.objects {
+	keys := make([]string, 0, len(s.state.objects))
+	for key := range s.state.objects {
 		if strings.HasPrefix(key, prefix) && key > startAfter {
 			keys = append(keys, key)
 		}
@@ -731,7 +745,7 @@ func (s *memoryStore) List(prefix, startAfter, _ string, _ string, limit int64) 
 	}
 	objects := make([]Info, 0, max)
 	for _, key := range keys[:max] {
-		objects = append(objects, Info{Key: key, Size: int64(len(s.objects[key]))})
+		objects = append(objects, Info{Key: key, Size: int64(len(s.state.objects[key]))})
 	}
 	return objects, hasMore, nextToken, nil
 }

--- a/storage-proxy/pkg/objectstore/store_test.go
+++ b/storage-proxy/pkg/objectstore/store_test.go
@@ -88,3 +88,28 @@ func TestCountingReaderForPreservesReadSeeker(t *testing.T) {
 		t.Fatalf("BytesRead() after seek = %d, want 4", reader.BytesRead())
 	}
 }
+
+func TestNewMemoryStoreSharesNamespace(t *testing.T) {
+	t.Parallel()
+
+	first := NewMemoryStore("shared-test")
+	second := NewMemoryStore("shared-test")
+
+	if err := first.Put("objects/one.txt", bytes.NewReader([]byte("alpha"))); err != nil {
+		t.Fatalf("first.Put() error = %v", err)
+	}
+
+	reader, err := second.Get("objects/one.txt", 0, -1)
+	if err != nil {
+		t.Fatalf("second.Get() error = %v", err)
+	}
+	defer reader.Close()
+
+	payload, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("io.ReadAll() error = %v", err)
+	}
+	if got := string(payload); got != "alpha" {
+		t.Fatalf("payload = %q, want alpha", got)
+	}
+}

--- a/storage-proxy/pkg/s0fs/engine.go
+++ b/storage-proxy/pkg/s0fs/engine.go
@@ -28,6 +28,7 @@ type Engine struct {
 
 	materializer            *Materializer
 	mutationVersion         uint64
+	lastCommittedManifest   uint64
 	lastMaterializedVersion uint64
 	dirty                   bool
 	dirtyAt                 time.Time
@@ -47,17 +48,19 @@ func Open(ctx context.Context, cfg Config) (*Engine, error) {
 	}
 
 	state, err := loadCurrentState(cfg)
-	if cfg.ObjectStore != nil {
-		materializer := NewMaterializer(cfg.ObjectStore)
-		if materializer != nil {
-			latestState, _, latestErr := materializer.LoadLatestState(ctx)
-			switch {
-			case latestErr == nil && shouldUseMaterializedState(state, err, latestState, len(records)):
-				state = latestState
-				err = nil
-			case errors.Is(err, ErrSnapshotNotFound) && latestErr != nil && !errors.Is(latestErr, ErrMaterializedManifestNotFound):
-				err = latestErr
-			}
+	materializer := NewMaterializer(cfg.VolumeID, cfg.ObjectStore, cfg.HeadStore)
+	var latestManifest *Manifest
+	if materializer != nil {
+		latestState, manifest, latestErr := materializer.LoadLatestState(ctx)
+		switch {
+		case latestErr == nil && shouldUseMaterializedState(state, err, latestState, len(records)):
+			state = latestState
+			err = nil
+			latestManifest = manifest
+		case latestErr == nil:
+			latestManifest = manifest
+		case errors.Is(err, ErrSnapshotNotFound) && latestErr != nil && !errors.Is(latestErr, ErrMaterializedManifestNotFound):
+			err = latestErr
 		}
 	}
 	if err != nil && !errors.Is(err, ErrSnapshotNotFound) && !errors.Is(err, ErrMaterializedManifestNotFound) {
@@ -99,7 +102,10 @@ func Open(ctx context.Context, cfg Config) (*Engine, error) {
 		data:         state.Data,
 		coldFiles:    state.ColdFiles,
 		segments:     state.Segments,
-		materializer: NewMaterializer(cfg.ObjectStore),
+		materializer: materializer,
+	}
+	if latestManifest != nil {
+		e.lastCommittedManifest = latestManifest.ManifestSeq
 	}
 
 	for _, record := range records {
@@ -502,17 +508,17 @@ func (e *Engine) SyncMaterialize(ctx context.Context) (*Manifest, error) {
 		e.mu.RUnlock()
 		return nil, err
 	}
-	volumeID := e.volumeID
+	expectedManifestSeq := e.lastCommittedManifest
 	e.mu.RUnlock()
 
-	manifest, err := e.materializer.Materialize(ctx, volumeID, state)
+	manifest, err := e.materializer.Materialize(ctx, state, expectedManifestSeq)
 	if err != nil || manifest == nil {
 		return manifest, err
 	}
 
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	if e.mutationVersion == version {
+	if e.mutationVersion == version && e.lastCommittedManifest == expectedManifestSeq {
 		if manifest.State != nil {
 			e.replaceStateLocked(cloneState(manifest.State))
 		}
@@ -522,6 +528,7 @@ func (e *Engine) SyncMaterialize(ctx context.Context) (*Manifest, error) {
 		if err := e.wal.reset(); err != nil {
 			return nil, err
 		}
+		e.lastCommittedManifest = manifest.ManifestSeq
 		e.lastMaterializedVersion = version
 		e.dirty = false
 	}
@@ -541,7 +548,7 @@ func (e *Engine) RefreshMaterialized(ctx context.Context) (bool, error) {
 	currentNextSeq := e.nextSeq
 	e.mu.RUnlock()
 
-	state, _, err := e.materializer.LoadLatestState(ctx)
+	state, manifest, err := e.materializer.LoadLatestState(ctx)
 	if errors.Is(err, ErrMaterializedManifestNotFound) {
 		return false, nil
 	}
@@ -566,6 +573,9 @@ func (e *Engine) RefreshMaterialized(ctx context.Context) (bool, error) {
 	}
 	if err := e.wal.reset(); err != nil {
 		return false, err
+	}
+	if manifest != nil {
+		e.lastCommittedManifest = manifest.ManifestSeq
 	}
 	return true, nil
 }

--- a/storage-proxy/pkg/s0fs/engine.go
+++ b/storage-proxy/pkg/s0fs/engine.go
@@ -609,6 +609,13 @@ func (e *Engine) RestoreSnapshot(snapshotID string) error {
 	if err != nil {
 		return err
 	}
+	minNextSeq := e.nextSeq + 1
+	if committedNext := e.lastCommittedManifest + 2; committedNext > minNextSeq {
+		minNextSeq = committedNext
+	}
+	if state.NextSeq < minNextSeq {
+		state.NextSeq = minNextSeq
+	}
 	e.replaceStateLocked(state)
 	if err := e.persistCurrentStateLocked(); err != nil {
 		return err

--- a/storage-proxy/pkg/s0fs/errors.go
+++ b/storage-proxy/pkg/s0fs/errors.go
@@ -3,11 +3,13 @@ package s0fs
 import "errors"
 
 var (
-	ErrClosed       = errors.New("s0fs engine is closed")
-	ErrExists       = errors.New("entry already exists")
-	ErrInvalidInput = errors.New("invalid input")
-	ErrIsDir        = errors.New("inode is a directory")
-	ErrNotEmpty     = errors.New("directory is not empty")
-	ErrNotDir       = errors.New("inode is not a directory")
-	ErrNotFound     = errors.New("entry not found")
+	ErrClosed                = errors.New("s0fs engine is closed")
+	ErrCommittedHeadConflict = errors.New("s0fs committed head conflict")
+	ErrCommittedHeadNotFound = errors.New("s0fs committed head not found")
+	ErrExists                = errors.New("entry already exists")
+	ErrInvalidInput          = errors.New("invalid input")
+	ErrIsDir                 = errors.New("inode is a directory")
+	ErrNotEmpty              = errors.New("directory is not empty")
+	ErrNotDir                = errors.New("inode is not a directory")
+	ErrNotFound              = errors.New("entry not found")
 )

--- a/storage-proxy/pkg/s0fs/head_store.go
+++ b/storage-proxy/pkg/s0fs/head_store.go
@@ -1,0 +1,24 @@
+package s0fs
+
+import (
+	"context"
+	"time"
+)
+
+// CommittedHead points to the current committed immutable manifest for one volume.
+type CommittedHead struct {
+	VolumeID      string
+	ManifestSeq   uint64
+	CheckpointSeq uint64
+	ManifestKey   string
+	UpdatedAt     time.Time
+}
+
+// HeadStore stores committed manifest pointers outside the object store hot path.
+// CompareAndSwapCommittedHead must insert when expectedManifestSeq is zero and no
+// row exists, and otherwise only advance the committed head when the existing
+// manifest sequence exactly matches expectedManifestSeq.
+type HeadStore interface {
+	LoadCommittedHead(ctx context.Context, volumeID string) (*CommittedHead, error)
+	CompareAndSwapCommittedHead(ctx context.Context, volumeID string, expectedManifestSeq uint64, head *CommittedHead) error
+}

--- a/storage-proxy/pkg/s0fs/materializer.go
+++ b/storage-proxy/pkg/s0fs/materializer.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -36,17 +37,21 @@ type Manifest struct {
 }
 
 type Materializer struct {
-	store objectstore.Store
-	cache *segmentCache
+	volumeID  string
+	store     objectstore.Store
+	headStore HeadStore
+	cache     *segmentCache
 }
 
-func NewMaterializer(store objectstore.Store) *Materializer {
+func NewMaterializer(volumeID string, store objectstore.Store, headStore HeadStore) *Materializer {
 	if store == nil {
 		return nil
 	}
 	return &Materializer{
-		store: store,
-		cache: newSegmentCache(defaultSegmentCacheMaxBytes),
+		volumeID:  volumeID,
+		store:     store,
+		headStore: headStore,
+		cache:     newSegmentCache(defaultSegmentCacheMaxBytes),
 	}
 }
 
@@ -54,14 +59,14 @@ func (m *Materializer) Enabled() bool {
 	return m != nil && m.store != nil
 }
 
-func (m *Materializer) Materialize(ctx context.Context, volumeID string, state *SnapshotState) (*Manifest, error) {
+func (m *Materializer) Materialize(ctx context.Context, state *SnapshotState, expectedManifestSeq uint64) (*Manifest, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
 	if !m.Enabled() {
 		return nil, nil
 	}
-	if volumeID == "" {
+	if m.volumeID == "" {
 		return nil, fmt.Errorf("%w: volume id is required", ErrInvalidInput)
 	}
 	if state == nil {
@@ -71,9 +76,12 @@ func (m *Materializer) Materialize(ctx context.Context, volumeID string, state *
 	inline := cloneState(state)
 	normalizeState(inline)
 
-	nextSeq, err := m.nextManifestSequence(ctx)
-	if err != nil {
-		return nil, err
+	nextSeq := checkpointSequence(inline)
+	if nextSeq == 0 {
+		return nil, fmt.Errorf("%w: manifest sequence must be non-zero", ErrInvalidInput)
+	}
+	if nextSeq <= expectedManifestSeq {
+		return nil, fmt.Errorf("%w: manifest seq %d must advance beyond %d", ErrCommittedHeadConflict, nextSeq, expectedManifestSeq)
 	}
 
 	segment, fileExtents, err := buildSegment(nextSeq, inline)
@@ -87,7 +95,7 @@ func (m *Materializer) Materialize(ctx context.Context, volumeID string, state *
 	}
 	manifest := &Manifest{
 		Version:       1,
-		VolumeID:      volumeID,
+		VolumeID:      m.volumeID,
 		ManifestSeq:   nextSeq,
 		CheckpointSeq: checkpointSequence(inline),
 		CreatedAt:     time.Now().UTC(),
@@ -103,7 +111,18 @@ func (m *Materializer) Materialize(ctx context.Context, volumeID string, state *
 	if err := m.putJSON(ctx, manifestKey(nextSeq), manifest); err != nil {
 		return nil, err
 	}
-	if err := m.putJSON(ctx, manifestLatestKey, manifest); err != nil {
+	if m.headStore != nil {
+		head := &CommittedHead{
+			VolumeID:      m.volumeID,
+			ManifestSeq:   manifest.ManifestSeq,
+			CheckpointSeq: manifest.CheckpointSeq,
+			ManifestKey:   manifestKey(manifest.ManifestSeq),
+			UpdatedAt:     manifest.CreatedAt,
+		}
+		if err := m.headStore.CompareAndSwapCommittedHead(ctx, m.volumeID, expectedManifestSeq, head); err != nil {
+			return nil, err
+		}
+	} else if err := m.putJSON(ctx, manifestLatestKey, manifest); err != nil {
 		return nil, err
 	}
 
@@ -166,18 +185,35 @@ func (m *Materializer) LoadLatestManifest(ctx context.Context) (*Manifest, error
 	if !m.Enabled() {
 		return nil, ErrMaterializedManifestNotFound
 	}
-	if _, err := m.store.Head(manifestLatestKey); err != nil {
-		return nil, ErrMaterializedManifestNotFound
+	if m.headStore != nil {
+		head, err := m.headStore.LoadCommittedHead(ctx, m.volumeID)
+		switch {
+		case err == nil:
+			return m.loadManifestByKey(ctx, head.ManifestKey)
+		case !errors.Is(err, ErrCommittedHeadNotFound):
+			return nil, err
+		}
+
+		manifest, err := m.loadLegacyLatestManifest(ctx)
+		if err != nil {
+			return nil, err
+		}
+		head = &CommittedHead{
+			VolumeID:      m.volumeID,
+			ManifestSeq:   manifest.ManifestSeq,
+			CheckpointSeq: manifest.CheckpointSeq,
+			ManifestKey:   manifestKey(manifest.ManifestSeq),
+			UpdatedAt:     manifest.CreatedAt,
+		}
+		if err := m.headStore.CompareAndSwapCommittedHead(ctx, m.volumeID, 0, head); err != nil {
+			if errors.Is(err, ErrCommittedHeadConflict) {
+				return m.LoadLatestManifest(ctx)
+			}
+			return nil, err
+		}
+		return manifest, nil
 	}
-	var manifest Manifest
-	if err := m.getJSON(ctx, manifestLatestKey, &manifest); err != nil {
-		return nil, err
-	}
-	if manifest.State == nil {
-		return nil, fmt.Errorf("materialized manifest %s has no state", manifestLatestKey)
-	}
-	normalizeState(manifest.State)
-	return &manifest, nil
+	return m.loadLegacyLatestManifest(ctx)
 }
 
 func (m *Materializer) LoadLatestState(ctx context.Context) (*SnapshotState, *Manifest, error) {
@@ -298,18 +334,6 @@ func checkpointSequence(state *SnapshotState) uint64 {
 	return state.NextSeq - 1
 }
 
-func (m *Materializer) nextManifestSequence(ctx context.Context) (uint64, error) {
-	manifest, err := m.LoadLatestManifest(ctx)
-	switch {
-	case err == nil:
-		return manifest.ManifestSeq + 1, nil
-	case errors.Is(err, ErrMaterializedManifestNotFound):
-		return 1, nil
-	default:
-		return 0, err
-	}
-}
-
 func (m *Materializer) putJSON(ctx context.Context, key string, value any) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -339,6 +363,28 @@ func (m *Materializer) getJSON(ctx context.Context, key string, value any) error
 		return fmt.Errorf("decode %s: %w", key, err)
 	}
 	return nil
+}
+
+func (m *Materializer) loadManifestByKey(ctx context.Context, key string) (*Manifest, error) {
+	if strings.TrimSpace(key) == "" {
+		return nil, ErrMaterializedManifestNotFound
+	}
+	var manifest Manifest
+	if err := m.getJSON(ctx, key, &manifest); err != nil {
+		return nil, err
+	}
+	if manifest.State == nil {
+		return nil, fmt.Errorf("materialized manifest %s has no state", key)
+	}
+	normalizeState(manifest.State)
+	return &manifest, nil
+}
+
+func (m *Materializer) loadLegacyLatestManifest(ctx context.Context) (*Manifest, error) {
+	if _, err := m.store.Head(manifestLatestKey); err != nil {
+		return nil, ErrMaterializedManifestNotFound
+	}
+	return m.loadManifestByKey(ctx, manifestLatestKey)
 }
 
 func (m *Materializer) putBytes(ctx context.Context, key string, payload []byte) error {

--- a/storage-proxy/pkg/s0fs/materializer_test.go
+++ b/storage-proxy/pkg/s0fs/materializer_test.go
@@ -14,6 +14,46 @@ import (
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/objectstore"
 )
 
+type memoryHeadStore struct {
+	mu    sync.Mutex
+	heads map[string]*CommittedHead
+}
+
+func newMemoryHeadStore() *memoryHeadStore {
+	return &memoryHeadStore{heads: make(map[string]*CommittedHead)}
+}
+
+func (s *memoryHeadStore) LoadCommittedHead(_ context.Context, volumeID string) (*CommittedHead, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	head := s.heads[volumeID]
+	if head == nil {
+		return nil, ErrCommittedHeadNotFound
+	}
+	clone := *head
+	return &clone, nil
+}
+
+func (s *memoryHeadStore) CompareAndSwapCommittedHead(_ context.Context, volumeID string, expectedManifestSeq uint64, head *CommittedHead) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	current := s.heads[volumeID]
+	if current == nil {
+		if expectedManifestSeq != 0 {
+			return ErrCommittedHeadConflict
+		}
+		clone := *head
+		s.heads[volumeID] = &clone
+		return nil
+	}
+	if current.ManifestSeq != expectedManifestSeq || head.ManifestSeq <= current.ManifestSeq {
+		return ErrCommittedHeadConflict
+	}
+	clone := *head
+	s.heads[volumeID] = &clone
+	return nil
+}
+
 type getCall struct {
 	key   string
 	off   int64
@@ -77,12 +117,14 @@ func (s *recordingStore) resetCalls() {
 func TestEngineMaterializeRecoversViaColdRangeRead(t *testing.T) {
 	ctx := context.Background()
 	store := newPrefixedRecordingStore(t, "vol-1")
+	heads := newMemoryHeadStore()
 	walPath := filepath.Join(t.TempDir(), "engine.wal")
 
 	engine, err := Open(ctx, Config{
 		VolumeID:    "vol-1",
 		WALPath:     walPath,
 		ObjectStore: store,
+		HeadStore:   heads,
 	})
 	if err != nil {
 		t.Fatalf("Open() error = %v", err)
@@ -112,6 +154,7 @@ func TestEngineMaterializeRecoversViaColdRangeRead(t *testing.T) {
 		VolumeID:    "vol-1",
 		WALPath:     walPath,
 		ObjectStore: store,
+		HeadStore:   heads,
 	})
 	if err != nil {
 		t.Fatalf("Open(recovered) error = %v", err)
@@ -147,12 +190,14 @@ func TestEngineMaterializeRecoversViaColdRangeRead(t *testing.T) {
 func TestEngineRecoversFromManifestAndRetainedWAL(t *testing.T) {
 	ctx := context.Background()
 	store := newPrefixedRecordingStore(t, "vol-1")
+	heads := newMemoryHeadStore()
 	walPath := filepath.Join(t.TempDir(), "engine.wal")
 
 	engine, err := Open(ctx, Config{
 		VolumeID:    "vol-1",
 		WALPath:     walPath,
 		ObjectStore: store,
+		HeadStore:   heads,
 	})
 	if err != nil {
 		t.Fatalf("Open() error = %v", err)
@@ -187,6 +232,7 @@ func TestEngineRecoversFromManifestAndRetainedWAL(t *testing.T) {
 		VolumeID:    "vol-1",
 		WALPath:     walPath,
 		ObjectStore: store,
+		HeadStore:   heads,
 	})
 	if err != nil {
 		t.Fatalf("Open(recovered) error = %v", err)
@@ -213,11 +259,13 @@ func TestEngineRecoversFromManifestAndRetainedWAL(t *testing.T) {
 func TestEngineRefreshMaterializedLoadsNewerManifest(t *testing.T) {
 	ctx := context.Background()
 	store := newPrefixedRecordingStore(t, "vol-refresh")
+	heads := newMemoryHeadStore()
 
 	reader, err := Open(ctx, Config{
 		VolumeID:    "vol-refresh",
 		WALPath:     filepath.Join(t.TempDir(), "reader.wal"),
 		ObjectStore: store,
+		HeadStore:   heads,
 	})
 	if err != nil {
 		t.Fatalf("Open(reader) error = %v", err)
@@ -231,6 +279,7 @@ func TestEngineRefreshMaterializedLoadsNewerManifest(t *testing.T) {
 		VolumeID:    "vol-refresh",
 		WALPath:     filepath.Join(t.TempDir(), "writer.wal"),
 		ObjectStore: store,
+		HeadStore:   heads,
 	})
 	if err != nil {
 		t.Fatalf("Open(writer) error = %v", err)
@@ -272,12 +321,14 @@ func TestEngineRefreshMaterializedLoadsNewerManifest(t *testing.T) {
 func TestEngineOpenPrefersNewerMaterializedManifestOverStaleHead(t *testing.T) {
 	ctx := context.Background()
 	store := newPrefixedRecordingStore(t, "vol-stale-head")
+	heads := newMemoryHeadStore()
 	staleWALPath := filepath.Join(t.TempDir(), "stale.wal")
 
 	stale, err := Open(ctx, Config{
 		VolumeID:    "vol-stale-head",
 		WALPath:     staleWALPath,
 		ObjectStore: store,
+		HeadStore:   heads,
 	})
 	if err != nil {
 		t.Fatalf("Open(stale) error = %v", err)
@@ -290,6 +341,7 @@ func TestEngineOpenPrefersNewerMaterializedManifestOverStaleHead(t *testing.T) {
 		VolumeID:    "vol-stale-head",
 		WALPath:     filepath.Join(t.TempDir(), "writer.wal"),
 		ObjectStore: store,
+		HeadStore:   heads,
 	})
 	if err != nil {
 		t.Fatalf("Open(writer) error = %v", err)
@@ -312,6 +364,7 @@ func TestEngineOpenPrefersNewerMaterializedManifestOverStaleHead(t *testing.T) {
 		VolumeID:    "vol-stale-head",
 		WALPath:     staleWALPath,
 		ObjectStore: store,
+		HeadStore:   heads,
 	})
 	if err != nil {
 		t.Fatalf("Open(reopened) error = %v", err)
@@ -334,12 +387,14 @@ func TestEngineOpenPrefersNewerMaterializedManifestOverStaleHead(t *testing.T) {
 func TestMaterializerCoalescesSmallFilesAndKeepsManifestMonotonic(t *testing.T) {
 	ctx := context.Background()
 	store := newPrefixedRecordingStore(t, "vol-1")
+	heads := newMemoryHeadStore()
 	walPath := filepath.Join(t.TempDir(), "engine.wal")
 
 	engine, err := Open(ctx, Config{
 		VolumeID:    "vol-1",
 		WALPath:     walPath,
 		ObjectStore: store,
+		HeadStore:   heads,
 	})
 	if err != nil {
 		t.Fatalf("Open() error = %v", err)
@@ -359,8 +414,11 @@ func TestMaterializerCoalescesSmallFilesAndKeepsManifestMonotonic(t *testing.T) 
 	if err != nil {
 		t.Fatalf("SyncMaterialize(first) error = %v", err)
 	}
-	if first == nil || first.ManifestSeq != 1 {
-		t.Fatalf("first manifest = %+v, want seq 1", first)
+	if first == nil {
+		t.Fatal("first manifest is nil")
+	}
+	if first.ManifestSeq != first.CheckpointSeq {
+		t.Fatalf("first manifest seq/checkpoint = %d/%d, want equal", first.ManifestSeq, first.CheckpointSeq)
 	}
 
 	node, err := engine.CreateFile(RootInode, "tail.txt", 0o644)
@@ -374,23 +432,26 @@ func TestMaterializerCoalescesSmallFilesAndKeepsManifestMonotonic(t *testing.T) 
 	if err != nil {
 		t.Fatalf("SyncMaterialize(second) error = %v", err)
 	}
-	if second == nil || second.ManifestSeq != 2 {
-		t.Fatalf("second manifest = %+v, want seq 2", second)
+	if second == nil {
+		t.Fatal("second manifest is nil")
+	}
+	if second.ManifestSeq <= first.ManifestSeq {
+		t.Fatalf("second manifest seq = %d, want > %d", second.ManifestSeq, first.ManifestSeq)
 	}
 
-	materializer := NewMaterializer(store)
+	materializer := NewMaterializer("vol-1", store, heads)
 	latest, err := materializer.LoadLatestManifest(ctx)
 	if err != nil {
 		t.Fatalf("LoadLatestManifest() error = %v", err)
 	}
-	if latest.ManifestSeq != 2 {
-		t.Fatalf("latest manifest seq = %d, want 2", latest.ManifestSeq)
+	if latest.ManifestSeq != second.ManifestSeq {
+		t.Fatalf("latest manifest seq = %d, want %d", latest.ManifestSeq, second.ManifestSeq)
 	}
-	if _, err := store.Head(manifestKey(1)); err != nil {
-		t.Fatalf("Head(manifest 1) error = %v", err)
+	if _, err := store.Head(manifestKey(first.ManifestSeq)); err != nil {
+		t.Fatalf("Head(manifest %d) error = %v", first.ManifestSeq, err)
 	}
-	if _, err := store.Head(manifestKey(2)); err != nil {
-		t.Fatalf("Head(manifest 2) error = %v", err)
+	if _, err := store.Head(manifestKey(second.ManifestSeq)); err != nil {
+		t.Fatalf("Head(manifest %d) error = %v", second.ManifestSeq, err)
 	}
 
 	objects, _, _, err := store.List("", "", "", "", 1000)
@@ -405,12 +466,14 @@ func TestMaterializerCoalescesSmallFilesAndKeepsManifestMonotonic(t *testing.T) 
 func TestMaterializerRetainsColdFilesAndWritesOnlyHotData(t *testing.T) {
 	ctx := context.Background()
 	store := newPrefixedRecordingStore(t, "vol-retain")
+	heads := newMemoryHeadStore()
 	walPath := filepath.Join(t.TempDir(), "engine.wal")
 
 	engine, err := Open(ctx, Config{
 		VolumeID:    "vol-retain",
 		WALPath:     walPath,
 		ObjectStore: store,
+		HeadStore:   heads,
 	})
 	if err != nil {
 		t.Fatalf("Open() error = %v", err)
@@ -452,8 +515,11 @@ func TestMaterializerRetainsColdFilesAndWritesOnlyHotData(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SyncMaterialize(second) error = %v", err)
 	}
-	if second == nil || second.ManifestSeq != 2 {
-		t.Fatalf("second manifest = %+v, want seq 2", second)
+	if second == nil {
+		t.Fatal("second manifest is nil")
+	}
+	if second.ManifestSeq <= first.ManifestSeq {
+		t.Fatalf("second manifest seq = %d, want > %d", second.ManifestSeq, first.ManifestSeq)
 	}
 	if len(second.State.Segments) != 2 {
 		t.Fatalf("second manifest segment count = %d, want 2", len(second.State.Segments))
@@ -485,15 +551,116 @@ func TestMaterializerRetainsColdFilesAndWritesOnlyHotData(t *testing.T) {
 	}
 }
 
+func TestMaterializerWithCommittedHeadStoreSkipsLegacyLatestObject(t *testing.T) {
+	ctx := context.Background()
+	store := newPrefixedRecordingStore(t, "vol-headstore")
+	heads := newMemoryHeadStore()
+	walPath := filepath.Join(t.TempDir(), "engine.wal")
+
+	engine, err := Open(ctx, Config{
+		VolumeID:    "vol-headstore",
+		WALPath:     walPath,
+		ObjectStore: store,
+		HeadStore:   heads,
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer engine.Close()
+
+	node, err := engine.CreateFile(RootInode, "hello.txt", 0o644)
+	if err != nil {
+		t.Fatalf("CreateFile() error = %v", err)
+	}
+	if _, err := engine.Write(node.Inode, 0, []byte("hello")); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	manifest, err := engine.SyncMaterialize(ctx)
+	if err != nil {
+		t.Fatalf("SyncMaterialize() error = %v", err)
+	}
+	if manifest == nil {
+		t.Fatal("SyncMaterialize() returned nil manifest")
+	}
+
+	if _, err := store.Head(manifestLatestKey); err == nil {
+		t.Fatalf("Head(%s) unexpectedly succeeded", manifestLatestKey)
+	}
+	for _, call := range store.putCalls() {
+		if call.key == manifestLatestKey {
+			t.Fatalf("legacy latest manifest Put call = %+v, want none", call)
+		}
+	}
+	head, err := heads.LoadCommittedHead(ctx, "vol-headstore")
+	if err != nil {
+		t.Fatalf("LoadCommittedHead() error = %v", err)
+	}
+	if head.ManifestSeq != manifest.ManifestSeq || head.ManifestKey != manifestKey(manifest.ManifestSeq) {
+		t.Fatalf("committed head = %+v, want manifest seq %d key %s", head, manifest.ManifestSeq, manifestKey(manifest.ManifestSeq))
+	}
+}
+
+func TestEngineSyncMaterializeDetectsCommittedHeadConflicts(t *testing.T) {
+	ctx := context.Background()
+	store := newPrefixedRecordingStore(t, "vol-conflict")
+	heads := newMemoryHeadStore()
+
+	first, err := Open(ctx, Config{
+		VolumeID:    "vol-conflict",
+		WALPath:     filepath.Join(t.TempDir(), "first.wal"),
+		ObjectStore: store,
+		HeadStore:   heads,
+	})
+	if err != nil {
+		t.Fatalf("Open(first) error = %v", err)
+	}
+	defer first.Close()
+	second, err := Open(ctx, Config{
+		VolumeID:    "vol-conflict",
+		WALPath:     filepath.Join(t.TempDir(), "second.wal"),
+		ObjectStore: store,
+		HeadStore:   heads,
+	})
+	if err != nil {
+		t.Fatalf("Open(second) error = %v", err)
+	}
+	defer second.Close()
+
+	firstNode, err := first.CreateFile(RootInode, "first.txt", 0o644)
+	if err != nil {
+		t.Fatalf("CreateFile(first) error = %v", err)
+	}
+	if _, err := first.Write(firstNode.Inode, 0, []byte("one")); err != nil {
+		t.Fatalf("Write(first) error = %v", err)
+	}
+
+	secondNode, err := second.CreateFile(RootInode, "second.txt", 0o644)
+	if err != nil {
+		t.Fatalf("CreateFile(second) error = %v", err)
+	}
+	if _, err := second.Write(secondNode.Inode, 0, []byte("two")); err != nil {
+		t.Fatalf("Write(second) error = %v", err)
+	}
+
+	if _, err := first.SyncMaterialize(ctx); err != nil {
+		t.Fatalf("SyncMaterialize(first) error = %v", err)
+	}
+	if _, err := second.SyncMaterialize(ctx); !errors.Is(err, ErrCommittedHeadConflict) {
+		t.Fatalf("SyncMaterialize(second) err = %v, want %v", err, ErrCommittedHeadConflict)
+	}
+}
+
 func TestEngineColdSmallFileReadsUseSegmentCache(t *testing.T) {
 	ctx := context.Background()
 	store := newPrefixedRecordingStore(t, "vol-cache")
+	heads := newMemoryHeadStore()
 	walPath := filepath.Join(t.TempDir(), "engine.wal")
 
 	engine, err := Open(ctx, Config{
 		VolumeID:    "vol-cache",
 		WALPath:     walPath,
 		ObjectStore: store,
+		HeadStore:   heads,
 	})
 	if err != nil {
 		t.Fatalf("Open() error = %v", err)
@@ -531,6 +698,7 @@ func TestEngineColdSmallFileReadsUseSegmentCache(t *testing.T) {
 		VolumeID:    "vol-cache",
 		WALPath:     walPath,
 		ObjectStore: store,
+		HeadStore:   heads,
 	})
 	if err != nil {
 		t.Fatalf("Open(recovered) error = %v", err)
@@ -576,12 +744,14 @@ func TestEngineColdSmallFileReadsUseSegmentCache(t *testing.T) {
 func TestCreateSnapshotHydratesColdFilesInline(t *testing.T) {
 	ctx := context.Background()
 	store := newPrefixedRecordingStore(t, "vol-snapshot")
+	heads := newMemoryHeadStore()
 	walPath := filepath.Join(t.TempDir(), "engine.wal")
 
 	engine, err := Open(ctx, Config{
 		VolumeID:    "vol-snapshot",
 		WALPath:     walPath,
 		ObjectStore: store,
+		HeadStore:   heads,
 	})
 	if err != nil {
 		t.Fatalf("Open() error = %v", err)

--- a/storage-proxy/pkg/s0fs/types.go
+++ b/storage-proxy/pkg/s0fs/types.go
@@ -20,6 +20,7 @@ type Config struct {
 	VolumeID            string
 	WALPath             string
 	ObjectStore         objectstore.Store
+	HeadStore           HeadStore
 	MaterializeInterval time.Duration
 	WALSyncHook         func()
 }

--- a/storage-proxy/pkg/snapshot/manager.go
+++ b/storage-proxy/pkg/snapshot/manager.go
@@ -74,6 +74,7 @@ var (
 	ErrVolumeBusy                = errors.New("volume is busy, try again later")
 	ErrRemountTimeout            = errors.New("remount timeout")
 	ErrInvalidAccessMode         = errors.New("invalid access mode")
+	ErrMountedCtldOwner          = errors.New("snapshot operations require ctld-mounted volumes to be unmounted")
 	errPathNotFound              = errors.New("path not found")
 )
 
@@ -190,6 +191,14 @@ func (m *Manager) CreateSnapshot(ctx context.Context, req *CreateSnapshotRequest
 		"volume_id": req.VolumeID,
 		"name":      req.Name,
 	}).Info("Creating snapshot")
+
+	ctldMounted, err := m.hasMountedCtldOwner(ctx, req.VolumeID)
+	if err != nil {
+		return nil, err
+	}
+	if ctldMounted {
+		return nil, ErrMountedCtldOwner
+	}
 
 	// 0. Distributed flush coordination (if coordinator is set)
 	// This ensures all storage-proxy instances that have this volume mounted
@@ -344,6 +353,14 @@ func (m *Manager) RestoreSnapshot(ctx context.Context, req *RestoreSnapshotReque
 		"volume_id":   req.VolumeID,
 		"snapshot_id": req.SnapshotID,
 	}).Info("Restoring snapshot")
+
+	ctldMounted, err := m.hasMountedCtldOwner(ctx, req.VolumeID)
+	if err != nil {
+		return err
+	}
+	if ctldMounted {
+		return ErrMountedCtldOwner
+	}
 
 	// 1. Get snapshot and verify ownership
 	snapshot, err := m.repo.GetSnapshot(ctx, req.SnapshotID)

--- a/storage-proxy/pkg/snapshot/manager_s0fs_test.go
+++ b/storage-proxy/pkg/snapshot/manager_s0fs_test.go
@@ -57,6 +57,11 @@ func TestS0FSSnapshotCreateRestoreAndDelete(t *testing.T) {
 	if !volMgr.beginCalled || !volMgr.waitCalled {
 		t.Fatalf("invalidate coordination = begin:%v wait:%v", volMgr.beginCalled, volMgr.waitCalled)
 	}
+	fresh := openFreshS0FSEngine(t, mgr, "team-1", "vol-1")
+	defer fresh.Close()
+	if got := readS0FSFile(t, fresh, "state.txt"); got != "alpha" {
+		t.Fatalf("fresh engine read after restore = %q, want alpha", got)
+	}
 
 	if err := mgr.DeleteSnapshot(context.Background(), "vol-1", snap.ID, "team-1"); err != nil {
 		t.Fatalf("DeleteSnapshot() error = %v", err)
@@ -102,6 +107,12 @@ func TestS0FSForkVolumeCopiesState(t *testing.T) {
 	writeS0FSFile(t, forkedEngine, "fork.txt", "forked")
 	if got := readS0FSFile(t, engine, "fork.txt"); got != "seed" {
 		t.Fatalf("source file after fork mutation = %q, want seed", got)
+	}
+
+	freshForked := openFreshS0FSEngine(t, mgr, "team-1", forked.ID)
+	defer freshForked.Close()
+	if got := readS0FSFile(t, freshForked, "fork.txt"); got != "seed" {
+		t.Fatalf("fresh forked file = %q, want seed", got)
 	}
 }
 
@@ -160,35 +171,37 @@ func newS0FSSnapshotTestManager(t *testing.T, volumeID string) (*Manager, *fakeR
 		UpdatedAt:  time.Now(),
 	}
 
-	engine, err := s0fs.Open(context.Background(), s0fs.Config{
-		VolumeID: volumeID,
-		WALPath:  filepath.Join(cacheDir, "s0fs", volumeID, "engine.wal"),
-	})
+	volMgr := &fakeVolumeProvider{
+		ctx: &volume.VolumeContext{
+			VolumeID:  volumeID,
+			TeamID:    "team-1",
+			Backend:   volume.BackendS0FS,
+			RootInode: 1,
+		},
+	}
+	mgr := &Manager{
+		repo:   repo,
+		volMgr: volMgr,
+		config: &config.StorageProxyConfig{
+			CacheDir:              cacheDir,
+			DefaultClusterId:      "test-cluster",
+			RestoreRemountTimeout: "100ms",
+			ObjectStorageType:     "mem",
+			S3Bucket:              "snapshot-tests",
+		},
+		logger:    logrus.New(),
+		clusterID: "test-cluster",
+		podID:     "test-pod",
+		locks:     make(map[string]time.Time),
+	}
+	engine, err := s0fs.Open(context.Background(), mgr.s0fsConfig("team-1", volumeID))
 	if err != nil {
 		t.Fatalf("Open(s0fs) error = %v", err)
 	}
 	t.Cleanup(func() {
 		_ = engine.Close()
 	})
-
-	volMgr := &fakeVolumeProvider{
-		ctx: &volume.VolumeContext{
-			VolumeID:  volumeID,
-			TeamID:    "team-1",
-			Backend:   volume.BackendS0FS,
-			S0FS:      engine,
-			RootInode: 1,
-		},
-	}
-	mgr := &Manager{
-		repo:      repo,
-		volMgr:    volMgr,
-		config:    &config.StorageProxyConfig{CacheDir: cacheDir, DefaultClusterId: "test-cluster", RestoreRemountTimeout: "100ms"},
-		logger:    logrus.New(),
-		clusterID: "test-cluster",
-		podID:     "test-pod",
-		locks:     make(map[string]time.Time),
-	}
+	volMgr.ctx.S0FS = engine
 	return mgr, repo, volMgr, engine
 }
 
@@ -253,4 +266,15 @@ func untarSnapshotArchive(t *testing.T, payload []byte) map[string][]byte {
 		files[header.Name] = body
 	}
 	return files
+}
+
+func openFreshS0FSEngine(t *testing.T, mgr *Manager, teamID, volumeID string) *s0fs.Engine {
+	t.Helper()
+	cfg := mgr.s0fsConfig(teamID, volumeID)
+	cfg.WALPath = filepath.Join(t.TempDir(), "s0fs", volumeID, "engine.wal")
+	engine, err := s0fs.Open(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("Open(fresh %s) error = %v", volumeID, err)
+	}
+	return engine
 }

--- a/storage-proxy/pkg/snapshot/manager_s0fs_test.go
+++ b/storage-proxy/pkg/snapshot/manager_s0fs_test.go
@@ -38,6 +38,9 @@ func TestS0FSSnapshotCreateRestoreAndDelete(t *testing.T) {
 	}
 
 	writeS0FSFile(t, engine, "state.txt", "beta")
+	if _, err := engine.SyncMaterialize(context.Background()); err != nil {
+		t.Fatalf("SyncMaterialize() before restore error = %v", err)
+	}
 	if got := readS0FSFile(t, engine, "state.txt"); got != "beta" {
 		t.Fatalf("Read() before restore = %q, want beta", got)
 	}

--- a/storage-proxy/pkg/snapshot/manager_test.go
+++ b/storage-proxy/pkg/snapshot/manager_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"os"
@@ -58,16 +59,20 @@ func seedS0FSSnapshot(t *testing.T, mgr *Manager, teamID, volumeID, snapshotID s
 }
 
 type fakeRepo struct {
-	volumes   map[string]*db.SandboxVolume
-	snapshots map[string]*db.Snapshot
-	deleted   []string
-	deleteErr error
+	volumes      map[string]*db.SandboxVolume
+	snapshots    map[string]*db.Snapshot
+	heads        map[string]*db.S0FSCommittedHead
+	activeMounts map[string][]*db.VolumeMount
+	deleted      []string
+	deleteErr    error
 }
 
 func newFakeRepo() *fakeRepo {
 	return &fakeRepo{
-		volumes:   make(map[string]*db.SandboxVolume),
-		snapshots: make(map[string]*db.Snapshot),
+		volumes:      make(map[string]*db.SandboxVolume),
+		snapshots:    make(map[string]*db.Snapshot),
+		heads:        make(map[string]*db.S0FSCommittedHead),
+		activeMounts: make(map[string][]*db.VolumeMount),
 	}
 }
 
@@ -153,6 +158,43 @@ func (r *fakeRepo) DeleteSnapshotTx(ctx context.Context, tx pgx.Tx, id string) e
 func (r *fakeRepo) DeleteSandboxVolumeTx(ctx context.Context, tx pgx.Tx, id string) error {
 	delete(r.volumes, id)
 	return nil
+}
+
+func (r *fakeRepo) GetS0FSCommittedHead(_ context.Context, volumeID string) (*db.S0FSCommittedHead, error) {
+	head, ok := r.heads[volumeID]
+	if !ok {
+		return nil, db.ErrNotFound
+	}
+	copy := *head
+	return &copy, nil
+}
+
+func (r *fakeRepo) CompareAndSwapS0FSCommittedHead(_ context.Context, volumeID string, expectedManifestSeq uint64, head *db.S0FSCommittedHead) error {
+	current, ok := r.heads[volumeID]
+	if !ok {
+		if expectedManifestSeq != 0 {
+			return db.ErrConflict
+		}
+	} else if current.ManifestSeq != expectedManifestSeq {
+		return db.ErrConflict
+	}
+	copy := *head
+	r.heads[volumeID] = &copy
+	return nil
+}
+
+func (r *fakeRepo) GetActiveMounts(_ context.Context, volumeID string, _ int) ([]*db.VolumeMount, error) {
+	return r.activeMounts[volumeID], nil
+}
+
+func rawMountOptions(t *testing.T, opts volume.MountOptions) *json.RawMessage {
+	t.Helper()
+	payload, err := json.Marshal(opts)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	msg := json.RawMessage(payload)
+	return &msg
 }
 
 type fakeVolumeProvider struct {
@@ -751,6 +793,46 @@ func TestRestoreSnapshot_BeginInvalidateError(t *testing.T) {
 	}
 	if volMgr.waitCalled {
 		t.Fatalf("expected WaitForInvalidate not to be called")
+	}
+}
+
+func TestCreateSnapshot_RejectsMountedCtldOwner(t *testing.T) {
+	repo := newFakeRepo()
+	repo.volumes["vol1"] = &db.SandboxVolume{ID: "vol1", TeamID: "team1"}
+	repo.activeMounts["vol1"] = []*db.VolumeMount{{
+		VolumeID:     "vol1",
+		MountOptions: rawMountOptions(t, volume.MountOptions{AccessMode: volume.AccessModeRWO, OwnerKind: volume.OwnerKindCtld}),
+	}}
+	mgr := newTestManager(repo, nil)
+
+	_, err := mgr.CreateSnapshot(context.Background(), &CreateSnapshotRequest{
+		VolumeID: "vol1",
+		Name:     "snap1",
+		TeamID:   "team1",
+		UserID:   "user1",
+	})
+	if !errors.Is(err, ErrMountedCtldOwner) {
+		t.Fatalf("CreateSnapshot() error = %v, want %v", err, ErrMountedCtldOwner)
+	}
+}
+
+func TestRestoreSnapshot_RejectsMountedCtldOwner(t *testing.T) {
+	repo := newFakeRepo()
+	repo.snapshots["snap1"] = &db.Snapshot{ID: "snap1", VolumeID: "vol1", TeamID: "team1"}
+	repo.activeMounts["vol1"] = []*db.VolumeMount{{
+		VolumeID:     "vol1",
+		MountOptions: rawMountOptions(t, volume.MountOptions{AccessMode: volume.AccessModeRWO, OwnerKind: volume.OwnerKindCtld}),
+	}}
+	mgr := newTestManager(repo, nil)
+
+	err := mgr.RestoreSnapshot(context.Background(), &RestoreSnapshotRequest{
+		VolumeID:   "vol1",
+		SnapshotID: "snap1",
+		TeamID:     "team1",
+		UserID:     "user1",
+	})
+	if !errors.Is(err, ErrMountedCtldOwner) {
+		t.Fatalf("RestoreSnapshot() error = %v, want %v", err, ErrMountedCtldOwner)
 	}
 }
 

--- a/storage-proxy/pkg/snapshot/manager_test.go
+++ b/storage-proxy/pkg/snapshot/manager_test.go
@@ -170,6 +170,9 @@ func (r *fakeRepo) GetS0FSCommittedHead(_ context.Context, volumeID string) (*db
 }
 
 func (r *fakeRepo) CompareAndSwapS0FSCommittedHead(_ context.Context, volumeID string, expectedManifestSeq uint64, head *db.S0FSCommittedHead) error {
+	if _, ok := r.volumes[volumeID]; !ok {
+		return db.ErrNotFound
+	}
 	current, ok := r.heads[volumeID]
 	if !ok {
 		if expectedManifestSeq != 0 {

--- a/storage-proxy/pkg/snapshot/s0fs.go
+++ b/storage-proxy/pkg/snapshot/s0fs.go
@@ -402,20 +402,6 @@ func (m *Manager) forkS0FSVolume(ctx context.Context, req *ForkVolumeRequest) (*
 	}
 
 	newVolumeID := uuid.New().String()
-	targetEngine, closeTarget, err := m.openS0FSEngine(ctx, req.TeamID, newVolumeID)
-	if err != nil {
-		return nil, err
-	}
-	if err := targetEngine.ReplaceState(state); err != nil {
-		closeTarget()
-		return nil, err
-	}
-	if _, err := targetEngine.SyncMaterialize(ctx); err != nil {
-		closeTarget()
-		return nil, err
-	}
-	_ = closeTarget()
-
 	now := time.Now()
 	sourceID := sourceVol.ID
 	newVol := &db.SandboxVolume{
@@ -434,12 +420,43 @@ func (m *Manager) forkS0FSVolume(ctx context.Context, req *ForkVolumeRequest) (*
 		if err := m.repo.CreateSandboxVolumeTx(ctx, tx, newVol); err != nil {
 			return err
 		}
-		return m.appendMeteringEventTx(ctx, tx, volumeForkedEvent(m.regionID(), m.clusterID, newVol))
+		return nil
 	}); err != nil {
-		_ = cleanupS0FSVolume(newVolumeID, m.config)
 		return nil, err
 	}
+	success := false
+	defer func() {
+		if success {
+			return
+		}
+		_ = cleanupS0FSVolume(newVolumeID, m.config)
+		_ = m.repo.WithTx(context.Background(), func(tx pgx.Tx) error {
+			err := m.repo.DeleteSandboxVolumeTx(context.Background(), tx, newVolumeID)
+			if errors.Is(err, db.ErrNotFound) {
+				return nil
+			}
+			return err
+		})
+	}()
 
+	targetEngine, closeTarget, err := m.openS0FSEngine(ctx, req.TeamID, newVolumeID)
+	if err != nil {
+		return nil, err
+	}
+	if err := targetEngine.ReplaceState(state); err != nil {
+		closeTarget()
+		return nil, err
+	}
+	if _, err := targetEngine.SyncMaterialize(ctx); err != nil {
+		closeTarget()
+		return nil, err
+	}
+	_ = closeTarget()
+
+	if err := m.appendMeteringEvent(ctx, volumeForkedEvent(m.regionID(), m.clusterID, newVol)); err != nil {
+		return nil, err
+	}
+	success = true
 	return newVol, nil
 }
 

--- a/storage-proxy/pkg/snapshot/s0fs.go
+++ b/storage-proxy/pkg/snapshot/s0fs.go
@@ -22,6 +22,56 @@ import (
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volume"
 )
 
+type s0fsHeadRepository interface {
+	GetS0FSCommittedHead(ctx context.Context, volumeID string) (*db.S0FSCommittedHead, error)
+	CompareAndSwapS0FSCommittedHead(ctx context.Context, volumeID string, expectedManifestSeq uint64, head *db.S0FSCommittedHead) error
+}
+
+type activeMountRepository interface {
+	GetActiveMounts(ctx context.Context, volumeID string, heartbeatTimeout int) ([]*db.VolumeMount, error)
+}
+
+type snapshotHeadStore struct {
+	repo s0fsHeadRepository
+}
+
+func (s *snapshotHeadStore) LoadCommittedHead(ctx context.Context, volumeID string) (*s0fs.CommittedHead, error) {
+	if s == nil || s.repo == nil {
+		return nil, s0fs.ErrCommittedHeadNotFound
+	}
+	head, err := s.repo.GetS0FSCommittedHead(ctx, volumeID)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return nil, s0fs.ErrCommittedHeadNotFound
+		}
+		return nil, err
+	}
+	return &s0fs.CommittedHead{
+		VolumeID:      head.VolumeID,
+		ManifestSeq:   head.ManifestSeq,
+		CheckpointSeq: head.CheckpointSeq,
+		ManifestKey:   head.ManifestKey,
+		UpdatedAt:     head.UpdatedAt,
+	}, nil
+}
+
+func (s *snapshotHeadStore) CompareAndSwapCommittedHead(ctx context.Context, volumeID string, expectedManifestSeq uint64, head *s0fs.CommittedHead) error {
+	if s == nil || s.repo == nil {
+		return s0fs.ErrCommittedHeadNotFound
+	}
+	err := s.repo.CompareAndSwapS0FSCommittedHead(ctx, volumeID, expectedManifestSeq, &db.S0FSCommittedHead{
+		VolumeID:      head.VolumeID,
+		ManifestSeq:   head.ManifestSeq,
+		CheckpointSeq: head.CheckpointSeq,
+		ManifestKey:   head.ManifestKey,
+		UpdatedAt:     head.UpdatedAt,
+	})
+	if errors.Is(err, db.ErrConflict) {
+		return s0fs.ErrCommittedHeadConflict
+	}
+	return err
+}
+
 func (m *Manager) s0fsConfig(teamID, volumeID string) s0fs.Config {
 	cfg := s0fs.Config{
 		VolumeID: volumeID,
@@ -31,7 +81,31 @@ func (m *Manager) s0fsConfig(teamID, volumeID string) s0fs.Config {
 	if err == nil {
 		cfg.ObjectStore = store
 	}
+	if repo, ok := any(m.repo).(s0fsHeadRepository); ok {
+		cfg.HeadStore = &snapshotHeadStore{repo: repo}
+	}
 	return cfg
+}
+
+func (m *Manager) hasMountedCtldOwner(ctx context.Context, volumeID string) (bool, error) {
+	repo, ok := any(m.repo).(activeMountRepository)
+	if !ok || repo == nil || volumeID == "" {
+		return false, nil
+	}
+	heartbeatTimeout := 15
+	if m.config != nil && m.config.HeartbeatTimeout > 0 {
+		heartbeatTimeout = m.config.HeartbeatTimeout
+	}
+	mounts, err := repo.GetActiveMounts(ctx, volumeID, heartbeatTimeout)
+	if err != nil {
+		return false, fmt.Errorf("get active mounts: %w", err)
+	}
+	for _, mount := range mounts {
+		if volume.DecodeMountOptions(mount.MountOptions).OwnerKind == volume.OwnerKindCtld {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func (m *Manager) s0fsObjectStore(teamID, volumeID string) (objectstore.Store, error) {
@@ -336,6 +410,10 @@ func (m *Manager) forkS0FSVolume(ctx context.Context, req *ForkVolumeRequest) (*
 		closeTarget()
 		return nil, err
 	}
+	if _, err := targetEngine.SyncMaterialize(ctx); err != nil {
+		closeTarget()
+		return nil, err
+	}
 	_ = closeTarget()
 
 	now := time.Now()
@@ -373,6 +451,9 @@ func (m *Manager) restoreS0FSSnapshot(ctx context.Context, req *RestoreSnapshotR
 	defer closeFn()
 
 	if err := engine.RestoreSnapshot(req.SnapshotID); err != nil {
+		return err
+	}
+	if _, err := engine.SyncMaterialize(ctx); err != nil {
 		return err
 	}
 	if m.volMgr != nil {

--- a/storage-proxy/pkg/volume/backend_test.go
+++ b/storage-proxy/pkg/volume/backend_test.go
@@ -35,7 +35,7 @@ func (b *fakeBackend) UnmountVolume(_ context.Context, _ *VolumeContext) error {
 
 func TestManagerMountUsesBackend(t *testing.T) {
 	backend := &fakeBackend{}
-	mgr := NewManagerWithBackend(logrus.New(), &config.StorageProxyConfig{}, backend)
+	mgr := NewManagerWithBackend(logrus.New(), &config.StorageProxyConfig{}, nil, backend)
 
 	sessionID, mountedAt, err := mgr.MountVolume(context.Background(), "team/team-a", "vol-1", "team-a", AccessModeRWO)
 	if err != nil {
@@ -74,7 +74,7 @@ func TestManagerMountUsesBackend(t *testing.T) {
 
 func TestManagerUnmountUsesBackend(t *testing.T) {
 	backend := &fakeBackend{}
-	mgr := NewManagerWithBackend(logrus.New(), &config.StorageProxyConfig{}, backend)
+	mgr := NewManagerWithBackend(logrus.New(), &config.StorageProxyConfig{}, nil, backend)
 
 	sessionID, _, err := mgr.MountVolume(context.Background(), "", "vol-1", "team-a", AccessModeRWO)
 	if err != nil {

--- a/storage-proxy/pkg/volume/manager.go
+++ b/storage-proxy/pkg/volume/manager.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
 	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/fsmeta"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/legacyfs"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/s0fs"
@@ -100,16 +101,16 @@ type Manager struct {
 }
 
 // NewManager creates a new volume manager
-func NewManager(logger *logrus.Logger, cfg *config.StorageProxyConfig) *Manager {
+func NewManager(logger *logrus.Logger, cfg *config.StorageProxyConfig, repo *db.Repository) *Manager {
 	return NewManagerWithBackends(logger, cfg, map[string]Backend{
-		BackendS0FS: NewS0FSBackend(logger, cfg),
+		BackendS0FS: NewS0FSBackend(logger, cfg, repo),
 	}, DefaultBackendType())
 }
 
 // NewManagerWithBackend creates a manager with an explicit storage backend.
-func NewManagerWithBackend(logger *logrus.Logger, cfg *config.StorageProxyConfig, backend Backend) *Manager {
+func NewManagerWithBackend(logger *logrus.Logger, cfg *config.StorageProxyConfig, repo *db.Repository, backend Backend) *Manager {
 	if backend == nil {
-		return NewManager(logger, cfg)
+		return NewManager(logger, cfg, repo)
 	}
 	return NewManagerWithBackends(logger, cfg, map[string]Backend{"default": backend}, "default")
 }

--- a/storage-proxy/pkg/volume/manager.go
+++ b/storage-proxy/pkg/volume/manager.go
@@ -159,13 +159,6 @@ func (m *Manager) MountVolume(ctx context.Context, s3Prefix, volumeID, teamID st
 		return "", time.Time{}, fmt.Errorf("missing team id for volume mount")
 	}
 
-	// Validate mount with coordinator if available.
-	if m.registrar != nil {
-		if err := m.registrar.ValidateMount(ctx, volumeID, accessMode); err != nil {
-			return "", time.Time{}, err
-		}
-	}
-
 	// Check if already mounted
 	if existing, exists := m.volumes[volumeID]; exists {
 		if existing.TeamID != "" && existing.TeamID != teamID {
@@ -187,8 +180,21 @@ func (m *Manager) MountVolume(ctx context.Context, s3Prefix, volumeID, teamID st
 
 	m.logger.WithField("volume_id", volumeID).Info("Mounting volume")
 
+	registeredMount := false
+	if m.registrar != nil {
+		if err := m.registrar.RegisterMount(ctx, volumeID, MountOptions{
+			AccessMode: accessMode,
+		}); err != nil {
+			return "", time.Time{}, err
+		}
+		registeredMount = true
+	}
+
 	backend, err := m.selectBackend()
 	if err != nil {
+		if registeredMount {
+			_ = m.registrar.UnregisterMount(ctx, volumeID)
+		}
 		return "", time.Time{}, err
 	}
 
@@ -201,6 +207,9 @@ func (m *Manager) MountVolume(ctx context.Context, s3Prefix, volumeID, teamID st
 		Metrics:    m.metrics,
 	})
 	if err != nil {
+		if registeredMount {
+			_ = m.registrar.UnregisterMount(ctx, volumeID)
+		}
 		return "", time.Time{}, err
 	}
 
@@ -212,15 +221,6 @@ func (m *Manager) MountVolume(ctx context.Context, s3Prefix, volumeID, teamID st
 		ID:        sessionID,
 		TeamID:    teamID,
 		CreatedAt: sessionTime,
-	}
-
-	// 7. Register mount for distributed coordination (if registrar is set)
-	if m.registrar != nil {
-		if err := m.registrar.RegisterMount(ctx, volumeID, MountOptions{
-			AccessMode: accessMode,
-		}); err != nil {
-			m.logger.WithError(err).Warn("Failed to register mount for coordination")
-		}
 	}
 
 	m.logger.WithFields(logrus.Fields{

--- a/storage-proxy/pkg/volume/manager_test.go
+++ b/storage-proxy/pkg/volume/manager_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAcquireDirectVolumeFileMount_ReusesSessionUntilIdleCleanup(t *testing.T) {
-	mgr := NewManager(logrus.New(), &config.StorageProxyConfig{})
+	mgr := NewManager(logrus.New(), &config.StorageProxyConfig{}, nil)
 	volumeID := "vol-direct"
 	mgr.volumes[volumeID] = &VolumeContext{VolumeID: volumeID}
 
@@ -200,7 +200,7 @@ func (f *fakeVolumeRootMeta) Mkdir(_ fsmeta.Context, parent fsmeta.Ino, name str
 }
 
 func TestCleanupIdleDirectVolumeFileMounts_SkipsInflightRequests(t *testing.T) {
-	mgr := NewManager(logrus.New(), &config.StorageProxyConfig{})
+	mgr := NewManager(logrus.New(), &config.StorageProxyConfig{}, nil)
 	volumeID := "vol-busy"
 	sessionID := "direct-session-1"
 	mgr.volumes[volumeID] = &VolumeContext{VolumeID: volumeID}
@@ -226,7 +226,7 @@ func TestCleanupIdleDirectVolumeFileMounts_SkipsInflightRequests(t *testing.T) {
 }
 
 func TestCleanupIdleDirectVolumeFileMount_SkipsInflightLease(t *testing.T) {
-	mgr := NewManager(logrus.New(), &config.StorageProxyConfig{})
+	mgr := NewManager(logrus.New(), &config.StorageProxyConfig{}, nil)
 	volumeID := "vol-busy-single"
 	sessionID := "direct-session-1"
 
@@ -253,7 +253,7 @@ func TestCleanupIdleDirectVolumeFileMount_SkipsInflightLease(t *testing.T) {
 }
 
 func TestBeginInvalidate_IgnoresDirectSessions(t *testing.T) {
-	mgr := NewManager(logrus.New(), &config.StorageProxyConfig{})
+	mgr := NewManager(logrus.New(), &config.StorageProxyConfig{}, nil)
 	volumeID := "vol-invalidate"
 	mgr.mountSessions[volumeID] = map[string]*MountSession{
 		"remote-session": {ID: "remote-session", CreatedAt: time.Now()},

--- a/storage-proxy/pkg/volume/s0fs_backend.go
+++ b/storage-proxy/pkg/volume/s0fs_backend.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/objectstore"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/s0fs"
 	"github.com/sirupsen/logrus"
@@ -15,14 +16,16 @@ import (
 
 // S0FSBackend mounts the in-process active volume engine.
 type S0FSBackend struct {
-	logger *logrus.Logger
-	config *config.StorageProxyConfig
+	logger    *logrus.Logger
+	config    *config.StorageProxyConfig
+	headStore s0fs.HeadStore
 }
 
-func NewS0FSBackend(logger *logrus.Logger, cfg *config.StorageProxyConfig) *S0FSBackend {
+func NewS0FSBackend(logger *logrus.Logger, cfg *config.StorageProxyConfig, repo *db.Repository) *S0FSBackend {
 	return &S0FSBackend{
-		logger: logger,
-		config: cfg,
+		logger:    logger,
+		config:    cfg,
+		headStore: db.NewS0FSHeadStore(repo),
 	}
 }
 
@@ -42,6 +45,7 @@ func (b *S0FSBackend) MountVolume(ctx context.Context, req BackendMountRequest) 
 		VolumeID:    req.VolumeID,
 		WALPath:     filepath.Join(cacheDir, "engine.wal"),
 		ObjectStore: remoteStore,
+		HeadStore:   b.headStore,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("open s0fs engine: %w", err)

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -231,6 +231,14 @@ func registerApiModeSuite(envProvider func() *framework.ScenarioEnv, opts apiMod
 					assertClaimMountedRWOVolumeConflict(env, session)
 				})
 
+				It("allows ROX volumes to be mounted read-only across sandboxes", func() {
+					assertClaimMountedROXVolumeSharedReadOnly(env, session)
+				})
+
+				It("rejects RWX volumes for sandbox mounts", func() {
+					assertClaimMountedRWXVolumeRejected(env, session)
+				})
+
 				It("rejects invalid bootstrap mount requests at claim time", func() {
 					assertClaimBootstrapMountValidation(env, session)
 				})
@@ -1719,14 +1727,24 @@ func execInSandboxPod(env *framework.ScenarioEnv, namespace, podName, script str
 }
 
 func createVolumePortalTemplate(env *framework.ScenarioEnv, session *e2eutils.Session, mountPath string) string {
+	return createVolumePortalTemplateWithReadOnly(env, session, mountPath, false)
+}
+
+func createReadOnlyVolumePortalTemplate(env *framework.ScenarioEnv, session *e2eutils.Session, mountPath string) string {
+	return createVolumePortalTemplateWithReadOnly(env, session, mountPath, true)
+}
+
+func createVolumePortalTemplateWithReadOnly(env *framework.ScenarioEnv, session *e2eutils.Session, mountPath string, readOnly bool) string {
 	templateID := fmt.Sprintf("volume-portal-%d", time.Now().UnixNano())
 	base, err := session.GetTemplate(env.TestCtx.Context, GinkgoT(), "default")
 	Expect(err).NotTo(HaveOccurred())
 
 	req := e2eutils.CloneTemplateForCreate(*base, templateID)
+	readOnlyValue := readOnly
 	req.Spec.VolumeMounts = &[]apispec.VolumeMountSpec{{
 		Name:      "data",
 		MountPath: mountPath,
+		ReadOnly:  &readOnlyValue,
 	}}
 
 	created, err := session.CreateTemplate(env.TestCtx.Context, GinkgoT(), req)
@@ -2047,6 +2065,87 @@ func assertClaimMountedRWOVolumeConflict(env *framework.ScenarioEnv, session *e2
 	_, status, err = session.ClaimSandboxDetailed(env.TestCtx.Context, GinkgoT(), claimReq)
 	Expect(err).To(HaveOccurred())
 	Expect(status).To(Equal(http.StatusConflict))
+}
+
+func assertClaimMountedROXVolumeSharedReadOnly(env *framework.ScenarioEnv, session *e2eutils.Session) {
+	accessMode := apispec.ROX
+	volume, status, err := session.CreateSandboxVolume(env.TestCtx.Context, GinkgoT(), apispec.CreateSandboxVolumeRequest{
+		AccessMode: &accessMode,
+	})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusCreated))
+	Expect(volume).NotTo(BeNil())
+	volumeID := expectStringPtr(volume.Id, "volume id")
+	DeferCleanup(func() {
+		deleteSandboxVolumeForCleanup(env, session, volumeID)
+	})
+
+	seedPath := "/shared-seed.txt"
+	seedContent := []byte("shared-rox-seed")
+	status, err = session.WriteVolumeFile(env.TestCtx.Context, GinkgoT(), volumeID, seedPath, seedContent, "")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+
+	mountPoint := "/workspace/claim-rox"
+	templateID := createReadOnlyVolumePortalTemplate(env, session, mountPoint)
+	claimReq := apispec.ClaimRequest{
+		Template: &templateID,
+		Mounts: &[]apispec.ClaimMountRequest{{
+			SandboxvolumeId: volumeID,
+			MountPoint:      mountPoint,
+		}},
+	}
+
+	firstClaim, err := session.ClaimSandboxWithRequest(env.TestCtx.Context, GinkgoT(), claimReq)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(firstClaim).NotTo(BeNil())
+	firstSandboxID := firstClaim.SandboxId
+	DeferCleanup(func() {
+		_ = session.DeleteSandbox(env.TestCtx.Context, GinkgoT(), firstSandboxID)
+	})
+
+	secondClaim, err := session.ClaimSandboxWithRequest(env.TestCtx.Context, GinkgoT(), claimReq)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(secondClaim).NotTo(BeNil())
+	secondSandboxID := secondClaim.SandboxId
+	DeferCleanup(func() {
+		_ = session.DeleteSandbox(env.TestCtx.Context, GinkgoT(), secondSandboxID)
+	})
+
+	for _, sandboxID := range []string{firstSandboxID, secondSandboxID} {
+		Eventually(func() ([]byte, error) {
+			body, _, readErr := session.ReadFile(env.TestCtx.Context, GinkgoT(), sandboxID, mountPoint+seedPath)
+			return body, readErr
+		}).WithTimeout(20 * time.Second).WithPolling(1 * time.Second).Should(Equal(seedContent))
+	}
+}
+
+func assertClaimMountedRWXVolumeRejected(env *framework.ScenarioEnv, session *e2eutils.Session) {
+	accessMode := apispec.RWX
+	volume, status, err := session.CreateSandboxVolume(env.TestCtx.Context, GinkgoT(), apispec.CreateSandboxVolumeRequest{
+		AccessMode: &accessMode,
+	})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusCreated))
+	Expect(volume).NotTo(BeNil())
+	volumeID := expectStringPtr(volume.Id, "volume id")
+	DeferCleanup(func() {
+		deleteSandboxVolumeForCleanup(env, session, volumeID)
+	})
+
+	mountPoint := "/workspace/claim-rwx"
+	templateID := createVolumePortalTemplate(env, session, mountPoint)
+	claimReq := apispec.ClaimRequest{
+		Template: &templateID,
+		Mounts: &[]apispec.ClaimMountRequest{{
+			SandboxvolumeId: volumeID,
+			MountPoint:      mountPoint,
+		}},
+	}
+
+	_, status, err = session.ClaimSandboxDetailed(env.TestCtx.Context, GinkgoT(), claimReq)
+	Expect(err).To(HaveOccurred())
+	Expect(status).To(Equal(http.StatusBadRequest))
 }
 
 func assertVolumeSyncBackendLifecycle(env *framework.ScenarioEnv, session *e2eutils.Session) {

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -227,6 +227,10 @@ func registerApiModeSuite(envProvider func() *framework.ScenarioEnv, opts apiMod
 					assertClaimMountedVolumeWritable(env, session)
 				})
 
+				It("rejects mounting an active RWO volume into a second sandbox", func() {
+					assertClaimMountedRWOVolumeConflict(env, session)
+				})
+
 				It("rejects invalid bootstrap mount requests at claim time", func() {
 					assertClaimBootstrapMountValidation(env, session)
 				})
@@ -2010,6 +2014,39 @@ func assertClaimBootstrapMountValidation(env *framework.ScenarioEnv, session *e2
 	_, status, err := session.ClaimSandboxDetailed(env.TestCtx.Context, GinkgoT(), claimReq)
 	Expect(err).To(HaveOccurred())
 	Expect(status).To(Equal(http.StatusBadRequest))
+}
+
+func assertClaimMountedRWOVolumeConflict(env *framework.ScenarioEnv, session *e2eutils.Session) {
+	volume, status, err := session.CreateSandboxVolume(env.TestCtx.Context, GinkgoT(), apispec.CreateSandboxVolumeRequest{})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusCreated))
+	Expect(volume).NotTo(BeNil())
+	volumeID := expectStringPtr(volume.Id, "volume id")
+	DeferCleanup(func() {
+		deleteSandboxVolumeForCleanup(env, session, volumeID)
+	})
+
+	mountPoint := "/workspace/claim-rwo-conflict"
+	templateID := createVolumePortalTemplate(env, session, mountPoint)
+	claimReq := apispec.ClaimRequest{
+		Template: &templateID,
+		Mounts: &[]apispec.ClaimMountRequest{{
+			SandboxvolumeId: volumeID,
+			MountPoint:      mountPoint,
+		}},
+	}
+
+	firstClaim, err := session.ClaimSandboxWithRequest(env.TestCtx.Context, GinkgoT(), claimReq)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(firstClaim).NotTo(BeNil())
+	firstSandboxID := firstClaim.SandboxId
+	DeferCleanup(func() {
+		_ = session.DeleteSandbox(env.TestCtx.Context, GinkgoT(), firstSandboxID)
+	})
+
+	_, status, err = session.ClaimSandboxDetailed(env.TestCtx.Context, GinkgoT(), claimReq)
+	Expect(err).To(HaveOccurred())
+	Expect(status).To(Equal(http.StatusConflict))
 }
 
 func assertVolumeSyncBackendLifecycle(env *framework.ScenarioEnv, session *e2eutils.Session) {


### PR DESCRIPTION
Closes #261

## Summary
- add a committed-head abstraction to `s0fs` so the engine no longer depends on mutable object-store head updates in the hot path
- persist committed S0FS manifest heads in PostgreSQL with compare-and-swap semantics and wire storage-proxy/ctld mounts through that head store
- keep immutable manifest objects in object storage, bootstrap legacy `manifests/latest.json` into PG on first read, and add unit/integration coverage for head advancement and conflict detection

## Why
`issue #54` was exposing a deeper S0FS v1 problem: we were treating object storage as the hot committed head store by repeatedly overwriting `manifests/latest.json`. This PR moves the committed pointer into PG while keeping `s0fs` itself PG-agnostic through an injected interface.

## Tests
- `go test ./storage-proxy/pkg/s0fs`
- `go test ./storage-proxy/pkg/db`
- `go test ./storage-proxy/pkg/volume`
- `go test ./storage-proxy/cmd/storage-proxy ./ctld/internal/ctld/portal`
- `go test ./tests/integration/internal/tests/storage-proxy`
- `go test ./tests/e2e/utils`
- remote kind deploy succeeded via `/root/Makefile:test-again`
- remote kind manual volume validation in progress
