### PR TITLE
Preserve deadlines for long-lived gateway streams

### DIFF
--- a/cluster-gateway/pkg/http/server.go
+++ b/cluster-gateway/pkg/http/server.go
@@ -284,6 +284,7 @@ func (s *Server) setupRoutes() {
 	s.router.Use(httpobs.GinMiddleware(s.obsProvider.HTTPServerConfig(nil)))
 	s.router.Use(middleware.Recovery(s.logger))
 	s.router.Use(s.requestLogger.Logger())
+	s.router.Use(gatewaymiddleware.MarkLongLivedRequests())
 	s.router.Use(gatewaymiddleware.UpstreamTimeoutWhitelist())
 
 	// Health check endpoints (no auth required)

--- a/global-gateway/pkg/http/server.go
+++ b/global-gateway/pkg/http/server.go
@@ -154,6 +154,7 @@ func (s *Server) setupRoutes() {
 	s.router.Use(httpobs.GinMiddleware(s.obsProvider.HTTPServerConfig(nil)))
 	s.router.Use(gatewaymiddleware.Recovery(s.logger))
 	s.router.Use(s.requestLogger.Logger())
+	s.router.Use(gatewaymiddleware.MarkLongLivedRequests())
 	s.router.Use(gatewaymiddleware.UpstreamTimeoutWhitelist())
 
 	s.router.GET("/healthz", s.healthCheck)

--- a/manager/pkg/http/handlers_sandbox.go
+++ b/manager/pkg/http/handlers_sandbox.go
@@ -352,7 +352,7 @@ func (s *Server) getSandboxLogs(c *gin.Context) {
 }
 
 func (s *Server) streamSandboxLogs(c *gin.Context, sandboxID, teamID string, options *service.SandboxLogsOptions) {
-	if err := proxy.DisableResponseWriteDeadline(c.Writer); err != nil {
+	if err := proxy.DisableResponseDeadlines(c.Writer); err != nil {
 		s.logger.Debug("Failed to disable sandbox log stream response deadlines",
 			zap.String("sandboxID", sandboxID),
 			zap.String("teamID", teamID),

--- a/manager/procd/pkg/http/handlers/context.go
+++ b/manager/procd/pkg/http/handlers/context.go
@@ -726,6 +726,9 @@ func (h *ContextHandler) WebSocket(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer conn.Close()
+	if err := proxy.DisableConnectionDeadlines(conn.UnderlyingConn()); err != nil {
+		h.logger.Debug("Failed to clear context websocket connection deadlines", zap.String("context_id", id), zap.Error(err))
+	}
 
 	closeDone := make(chan struct{})
 	var closeOnce sync.Once

--- a/manager/procd/pkg/http/handlers/file.go
+++ b/manager/procd/pkg/http/handlers/file.go
@@ -197,6 +197,9 @@ func (h *FileHandler) Watch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer conn.Close()
+	if err := proxy.DisableConnectionDeadlines(conn.UnderlyingConn()); err != nil {
+		h.logger.Debug("Failed to clear file watch websocket connection deadlines", zap.Error(err))
+	}
 
 	// Active watchers for this connection
 	type watchSubscription struct {

--- a/pkg/gateway/middleware/long_lived.go
+++ b/pkg/gateway/middleware/long_lived.go
@@ -1,0 +1,45 @@
+package middleware
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sandbox0-ai/sandbox0/pkg/proxy"
+)
+
+// MarkLongLivedRequests tags streaming API routes so gateway server deadlines
+// and upstream proxy timeouts can be relaxed for those requests only.
+func MarkLongLivedRequests() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if RequestShouldBeLongLived(c.Request) {
+			c.Request = proxy.WithLongLivedRequestRequest(c.Request)
+		}
+		c.Next()
+	}
+}
+
+// RequestShouldBeLongLived reports whether the incoming request is expected to
+// hold the connection open for an extended period.
+func RequestShouldBeLongLived(req *http.Request) bool {
+	if req == nil {
+		return false
+	}
+	if proxy.IsWebSocketUpgrade(req) {
+		return true
+	}
+	return isSandboxLogsFollowRequest(req)
+}
+
+func isSandboxLogsFollowRequest(req *http.Request) bool {
+	if req.Method != http.MethodGet || req.URL == nil {
+		return false
+	}
+	path := req.URL.Path
+	if !strings.HasPrefix(path, "/api/v1/sandboxes/") || !strings.HasSuffix(path, "/logs") {
+		return false
+	}
+	follow, err := strconv.ParseBool(req.URL.Query().Get("follow"))
+	return err == nil && follow
+}

--- a/pkg/gateway/middleware/long_lived_test.go
+++ b/pkg/gateway/middleware/long_lived_test.go
@@ -1,0 +1,49 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRequestShouldBeLongLived(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *http.Request
+		want bool
+	}{
+		{
+			name: "sandbox logs follow stream",
+			req:  httptest.NewRequest(http.MethodGet, "/api/v1/sandboxes/sb_123/logs?follow=true", nil),
+			want: true,
+		},
+		{
+			name: "sandbox logs snapshot",
+			req:  httptest.NewRequest(http.MethodGet, "/api/v1/sandboxes/sb_123/logs", nil),
+			want: false,
+		},
+		{
+			name: "websocket context stream",
+			req: func() *http.Request {
+				req := httptest.NewRequest(http.MethodGet, "/api/v1/sandboxes/sb_123/contexts/ctx_123/ws", nil)
+				req.Header.Set("Connection", "Upgrade")
+				req.Header.Set("Upgrade", "websocket")
+				return req
+			}(),
+			want: true,
+		},
+		{
+			name: "non-stream sandbox get",
+			req:  httptest.NewRequest(http.MethodGet, "/api/v1/sandboxes/sb_123", nil),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := RequestShouldBeLongLived(tt.req); got != tt.want {
+				t.Fatalf("RequestShouldBeLongLived() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/proxy/request_timeout.go
+++ b/pkg/proxy/request_timeout.go
@@ -9,6 +9,7 @@ import (
 )
 
 type upstreamTimeoutDisabledKey struct{}
+type longLivedRequestKey struct{}
 
 // WithUpstreamTimeoutDisabled marks a request context so gateway upstream calls
 // should not apply the default proxy timeout.
@@ -19,12 +20,27 @@ func WithUpstreamTimeoutDisabled(ctx context.Context) context.Context {
 	return context.WithValue(ctx, upstreamTimeoutDisabledKey{}, true)
 }
 
+// WithLongLivedRequest marks a request context as a long-lived streaming route.
+// Long-lived requests also bypass the default upstream proxy timeout.
+func WithLongLivedRequest(ctx context.Context) context.Context {
+	ctx = WithUpstreamTimeoutDisabled(ctx)
+	return context.WithValue(ctx, longLivedRequestKey{}, true)
+}
+
 // WithUpstreamTimeoutDisabledRequest applies the no-timeout marker to a request.
 func WithUpstreamTimeoutDisabledRequest(req *http.Request) *http.Request {
 	if req == nil {
 		return nil
 	}
 	return req.WithContext(WithUpstreamTimeoutDisabled(req.Context()))
+}
+
+// WithLongLivedRequestRequest applies the long-lived request marker to a request.
+func WithLongLivedRequestRequest(req *http.Request) *http.Request {
+	if req == nil {
+		return nil
+	}
+	return req.WithContext(WithLongLivedRequest(req.Context()))
 }
 
 // UpstreamTimeoutDisabled reports whether upstream timeout enforcement is disabled.
@@ -34,6 +50,16 @@ func UpstreamTimeoutDisabled(ctx context.Context) bool {
 	}
 	disabled, _ := ctx.Value(upstreamTimeoutDisabledKey{}).(bool)
 	return disabled
+}
+
+// LongLivedRequest reports whether the request should be treated as a
+// long-lived route that is allowed to keep the downstream connection open.
+func LongLivedRequest(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	longLived, _ := ctx.Value(longLivedRequestKey{}).(bool)
+	return longLived
 }
 
 // EffectiveUpstreamTimeout returns the timeout to apply for an upstream request.

--- a/pkg/proxy/router_test.go
+++ b/pkg/proxy/router_test.go
@@ -130,3 +130,52 @@ func TestRouterProxyToTargetClearsWriteDeadlineWhenStreaming(t *testing.T) {
 		t.Fatalf("body = %q, want %q", body, "late stream\n")
 	}
 }
+
+func TestRouterProxyToTargetClearsDeadlinesWhenLongLivedRequestMarked(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(120 * time.Millisecond)
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		_, _ = io.WriteString(w, "long lived\n")
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+	}))
+	defer upstream.Close()
+
+	router, err := NewRouter(upstream.URL, zap.NewNop(), time.Second)
+	if err != nil {
+		t.Fatalf("NewRouter() error = %v", err)
+	}
+
+	engine := gin.New()
+	engine.GET("/", func(c *gin.Context) {
+		c.Request = WithLongLivedRequestRequest(c.Request)
+		router.ProxyToTarget(c)
+	})
+
+	server := httptest.NewUnstartedServer(engine)
+	server.Config.ReadTimeout = 50 * time.Millisecond
+	server.Config.WriteTimeout = 50 * time.Millisecond
+	server.Start()
+	defer server.Close()
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get(server.URL + "/")
+	if err != nil {
+		t.Fatalf("GET() error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if body := string(bodyBytes); body != "long lived\n" {
+		t.Fatalf("body = %q, want %q", body, "long lived\n")
+	}
+}

--- a/pkg/proxy/streaming.go
+++ b/pkg/proxy/streaming.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"errors"
+	"net"
 	"net/http"
 	"time"
 )
@@ -36,13 +37,22 @@ func DisableResponseDeadlines(w http.ResponseWriter) error {
 	return errors.Join(errs...)
 }
 
+// DisableConnectionDeadlines clears read and write deadlines on a hijacked or
+// upgraded connection used for long-lived streams.
+func DisableConnectionDeadlines(conn net.Conn) error {
+	if conn == nil {
+		return nil
+	}
+	return conn.SetDeadline(time.Time{})
+}
+
 // PrepareStreamingProxyResponse clears downstream server deadlines when a
 // proxied request is allowed to outlive the ordinary upstream timeout.
 func PrepareStreamingProxyResponse(w http.ResponseWriter, req *http.Request) error {
 	if req == nil {
 		return DisableResponseWriteDeadline(w)
 	}
-	if IsWebSocketUpgrade(req) {
+	if IsWebSocketUpgrade(req) || LongLivedRequest(req.Context()) {
 		return DisableResponseDeadlines(w)
 	}
 	if UpstreamTimeoutDisabled(req.Context()) {

--- a/pkg/proxy/websocket.go
+++ b/pkg/proxy/websocket.go
@@ -106,6 +106,9 @@ func (p *WebSocketProxy) Proxy(targetURL *url.URL) gin.HandlerFunc {
 			return
 		}
 		defer downstreamConn.Close()
+		if err := DisableConnectionDeadlines(downstreamConn); err != nil {
+			p.logger.Debug("Failed to clear hijacked downstream connection deadlines", zap.Error(err))
+		}
 
 		if err := resp.Write(downstreamConn); err != nil {
 			p.logger.Error("Failed to write downstream WebSocket handshake", zap.Error(err))

--- a/regional-gateway/pkg/http/server.go
+++ b/regional-gateway/pkg/http/server.go
@@ -268,6 +268,7 @@ func (s *Server) setupRoutes() {
 	s.router.Use(httpobs.GinMiddleware(s.obsProvider.HTTPServerConfig(nil)))
 	s.router.Use(middleware.Recovery(s.logger))
 	s.router.Use(s.requestLogger.Logger())
+	s.router.Use(middleware.MarkLongLivedRequests())
 	s.router.Use(middleware.UpstreamTimeoutWhitelist())
 
 	// Health check endpoints (no auth required)

--- a/storage-proxy/pkg/http/handlers_volume_files.go
+++ b/storage-proxy/pkg/http/handlers_volume_files.go
@@ -296,6 +296,9 @@ func (s *Server) handleVolumeFileWatch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer conn.Close()
+	if err := httpproxy.DisableConnectionDeadlines(conn.UnderlyingConn()); err != nil {
+		s.logger.WithError(err).WithField("volume_id", volumeID).Debug("Failed to clear volume file watch websocket deadlines")
+	}
 
 	type watchSubscription struct {
 		cancel func()


### PR DESCRIPTION
## Summary
- add a shared long-lived request marker middleware and apply it across regional, cluster, and global gateways
- make long-lived requests clear downstream read/write deadlines in addition to bypassing upstream proxy timeouts
- clear websocket connection deadlines after upgrade in procd and storage-proxy, and treat followed sandbox logs as long-lived streams

## Why
`logs --follow` and `exec --stream` were still dropping after roughly 130 seconds even after the GCLB backend timeout was raised. Repro confirmed the drop still happened when bypassing GCLB with `kubectl port-forward`, which narrowed the issue to gateway/server-side HTTP deadlines rather than ingress.

## Validation
- reproduced before the change:
  - `s0 sandbox logs <sandbox> --follow` dropped at about 130s both through the public endpoint and through a direct `port-forward` to `regional-gateway`
  - `s0 sandbox exec <sandbox> --stream -- ...sleep 150...` dropped at about 134s both through the public endpoint and through `port-forward`
  - SSH over the separate `ssh-gateway` path completed a 150s sleep successfully
- ran:
  - `go test ./pkg/proxy ./pkg/gateway/middleware ./global-gateway/pkg/http ./regional-gateway/pkg/http ./cluster-gateway/pkg/http ./manager/pkg/http ./manager/procd/pkg/http/handlers`
- push hook also passed:
  - `make manifests`
  - `make proto`
  - `make apispec`
  - `go fmt ./...`
  - `go mod tidy`
  - `go mod vendor`
  - `golangci-lint run ./...`

## Notes
- I included `global-gateway` in the same shared middleware path so API-key-routed long-lived requests do not retain different timeout behavior from regional/cluster routes.
- I did not separately run `go test ./storage-proxy/pkg/http` before the hook because that package can depend on generated protobuf artifacts in local workspace state, but the relevant file was included in the successful repo-wide push hook path.