### PR TITLE
Skip no-op HTTP volume materialization

### DIFF
--- a/storage-proxy/pkg/http/handlers_volume_files.go
+++ b/storage-proxy/pkg/http/handlers_volume_files.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -451,13 +452,16 @@ func (s *Server) writeVolumeFile(w http.ResponseWriter, r *http.Request, volumeI
 	defer cleanup()
 
 	if r.URL.Query().Get("mkdir") == "true" {
-		if err := s.mkdirVolumePath(ctx, volumeID, logicalPath, r.URL.Query().Get("recursive") == "true"); err != nil {
+		changed, err := s.mkdirVolumePath(ctx, volumeID, logicalPath, r.URL.Query().Get("recursive") == "true")
+		if err != nil {
 			s.writeVolumeFileError(w, err)
 			return
 		}
-		if err := s.finalizeVolumeFileMutation(ctx, volumeID); err != nil {
-			s.writeVolumeFileError(w, err)
-			return
+		if changed {
+			if err := s.finalizeVolumeFileMutation(ctx, volumeID); err != nil {
+				s.writeVolumeFileError(w, err)
+				return
+			}
 		}
 		_ = spec.WriteSuccess(w, http.StatusCreated, map[string]bool{"created": true})
 		return
@@ -473,13 +477,16 @@ func (s *Server) writeVolumeFile(w http.ResponseWriter, r *http.Request, volumeI
 		return
 	}
 
-	if err := s.writeVolumePath(ctx, volumeID, logicalPath, data); err != nil {
+	changed, err := s.writeVolumePath(ctx, volumeID, logicalPath, data)
+	if err != nil {
 		s.writeVolumeFileError(w, err)
 		return
 	}
-	if err := s.finalizeVolumeFileMutation(ctx, volumeID); err != nil {
-		s.writeVolumeFileError(w, err)
-		return
+	if changed {
+		if err := s.finalizeVolumeFileMutation(ctx, volumeID); err != nil {
+			s.writeVolumeFileError(w, err)
+			return
+		}
 	}
 
 	_ = spec.WriteSuccess(w, http.StatusOK, map[string]bool{"written": true})
@@ -681,24 +688,24 @@ func (s *Server) ensureVolumeParent(ctx context.Context, volumeID, raw string, r
 	return current, base, nil
 }
 
-func (s *Server) mkdirVolumePath(ctx context.Context, volumeID, raw string, recursive bool) error {
+func (s *Server) mkdirVolumePath(ctx context.Context, volumeID, raw string, recursive bool) (bool, error) {
 	resolved, err := s.lookupVolumePath(ctx, volumeID, raw, false)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if resolved.Exists {
 		if attrModeIsDir(resolved.Attr.Mode) && recursive {
-			return nil
+			return false, nil
 		}
 		if attrModeIsDir(resolved.Attr.Mode) {
-			return errPathAlreadyExists
+			return false, errPathAlreadyExists
 		}
-		return errPathNotDir
+		return false, errPathNotDir
 	}
 
 	parent, base, err := s.ensureVolumeParent(ctx, volumeID, raw, recursive)
 	if err != nil {
-		return err
+		return false, err
 	}
 	_, err = s.fileRPC.Mkdir(ctx, &pb.MkdirRequest{
 		VolumeId: volumeID,
@@ -710,17 +717,17 @@ func (s *Server) mkdirVolumePath(ctx context.Context, volumeID, raw string, recu
 	})
 	if err != nil {
 		if fserror.CodeOf(err) == fserror.AlreadyExists && recursive {
-			return nil
+			return false, nil
 		}
-		return translateVolumeRPCError(err)
+		return false, translateVolumeRPCError(err)
 	}
-	return nil
+	return true, nil
 }
 
-func (s *Server) writeVolumePath(ctx context.Context, volumeID, raw string, data []byte) error {
+func (s *Server) writeVolumePath(ctx context.Context, volumeID, raw string, data []byte) (bool, error) {
 	resolved, err := s.lookupVolumePath(ctx, volumeID, raw, false)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	var (
@@ -730,7 +737,12 @@ func (s *Server) writeVolumePath(ctx context.Context, volumeID, raw string, data
 
 	if resolved.Exists {
 		if attrModeIsDir(resolved.Attr.Mode) {
-			return errPathNotDir
+			return false, errPathNotDir
+		}
+		if same, err := s.volumeFileContentMatches(ctx, volumeID, resolved, data); err != nil {
+			return false, err
+		} else if same {
+			return false, nil
 		}
 		openResp, err := s.fileRPC.Open(ctx, &pb.OpenRequest{
 			VolumeId: volumeID,
@@ -739,14 +751,14 @@ func (s *Server) writeVolumePath(ctx context.Context, volumeID, raw string, data
 			Actor:    volumeFileActor(ctx),
 		})
 		if err != nil {
-			return translateVolumeRPCError(err)
+			return false, translateVolumeRPCError(err)
 		}
 		inode = resolved.Inode
 		handleID = openResp.HandleId
 	} else {
 		parent, base, err := s.ensureVolumeParent(ctx, volumeID, raw, true)
 		if err != nil {
-			return err
+			return false, err
 		}
 		nodeResp, err := s.fileRPC.Create(ctx, &pb.CreateRequest{
 			VolumeId: volumeID,
@@ -758,7 +770,7 @@ func (s *Server) writeVolumePath(ctx context.Context, volumeID, raw string, data
 			Actor:    volumeFileActor(ctx),
 		})
 		if err != nil {
-			return translateVolumeRPCError(err)
+			return false, translateVolumeRPCError(err)
 		}
 		inode = nodeResp.Inode
 		handleID = nodeResp.HandleId
@@ -777,7 +789,7 @@ func (s *Server) writeVolumePath(ctx context.Context, volumeID, raw string, data
 	}()
 
 	if len(data) == 0 {
-		return nil
+		return true, nil
 	}
 	_, err = s.fileRPC.Write(ctx, &pb.WriteRequest{
 		VolumeId: volumeID,
@@ -788,9 +800,9 @@ func (s *Server) writeVolumePath(ctx context.Context, volumeID, raw string, data
 		Actor:    volumeFileActor(ctx),
 	})
 	if err != nil {
-		return translateVolumeRPCError(err)
+		return false, translateVolumeRPCError(err)
 	}
-	return nil
+	return true, nil
 }
 
 func (s *Server) moveVolumePath(ctx context.Context, volumeID, src, dst string) error {
@@ -920,6 +932,32 @@ func (s *Server) openVolumeDir(ctx context.Context, volumeID string, inode uint6
 		})
 	}
 	return openResp.HandleId, release, nil
+}
+
+func (s *Server) volumeFileContentMatches(ctx context.Context, volumeID string, resolved *volumeResolvedPath, expected []byte) (bool, error) {
+	if resolved == nil || !resolved.Exists || resolved.Attr == nil {
+		return false, nil
+	}
+	if attrModeIsDir(resolved.Attr.Mode) || resolved.Attr.Size != uint64(len(expected)) {
+		return false, nil
+	}
+	handleID, releaseFile, err := s.openVolumeFile(ctx, volumeID, resolved.Inode, uint32(syscall.O_RDONLY))
+	if err != nil {
+		return false, err
+	}
+	defer releaseFile()
+	readResp, err := s.fileRPC.Read(ctx, &pb.ReadRequest{
+		VolumeId: volumeID,
+		Inode:    resolved.Inode,
+		Offset:   0,
+		Size:     int64(resolved.Attr.Size),
+		HandleId: handleID,
+		Actor:    volumeFileActor(ctx),
+	})
+	if err != nil {
+		return false, translateVolumeRPCError(err)
+	}
+	return bytes.Equal(readResp.Data, expected), nil
 }
 
 func cleanVolumePath(raw string, allowRoot bool) (string, error) {

--- a/storage-proxy/pkg/http/handlers_volume_files_test.go
+++ b/storage-proxy/pkg/http/handlers_volume_files_test.go
@@ -519,6 +519,73 @@ func TestWriteVolumeFileWritesExistingPath(t *testing.T) {
 	}
 }
 
+func TestWriteVolumeFileSkipsSyncWhenContentUnchanged(t *testing.T) {
+	const payload = "hello world"
+	var wrote *pb.WriteRequest
+	fileRPC := &fakeHTTPVolumeFileRPC{
+		lookupFunc: func(_ context.Context, req *pb.LookupRequest) (*pb.NodeResponse, error) {
+			if req.Parent == 1 && req.Name == "hello.txt" {
+				return &pb.NodeResponse{Inode: 3, Attr: volumeFileAttr(len(payload))}, nil
+			}
+			return nil, fserror.New(fserror.NotFound, "missing")
+		},
+		openFunc: func(_ context.Context, req *pb.OpenRequest) (*pb.OpenResponse, error) {
+			return &pb.OpenResponse{HandleId: 15}, nil
+		},
+		readFunc: func(_ context.Context, req *pb.ReadRequest) (*pb.ReadResponse, error) {
+			return &pb.ReadResponse{Data: []byte(payload)}, nil
+		},
+		writeFunc: func(_ context.Context, req *pb.WriteRequest) (*pb.WriteResponse, error) {
+			wrote = req
+			return &pb.WriteResponse{BytesWritten: int64(len(req.Data))}, nil
+		},
+	}
+	server, volMgr := newVolumeFileTestServer(fileRPC)
+
+	req := httptest.NewRequest(http.MethodPost, "/sandboxvolumes/vol-1/files?path=/hello.txt", bytes.NewReader([]byte(payload)))
+	req.SetPathValue("id", "vol-1")
+	req = req.WithContext(internalauth.WithClaims(req.Context(), &internalauth.Claims{TeamID: "team-a"}))
+	recorder := httptest.NewRecorder()
+
+	server.handleVolumeFileOperation(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+	if wrote != nil {
+		t.Fatalf("unexpected write request: %+v", wrote)
+	}
+	if volMgr.syncCalls != 0 {
+		t.Fatalf("SyncDirectVolumeFileMount() calls = %d, want 0", volMgr.syncCalls)
+	}
+}
+
+func TestWriteVolumeFileMkdirRecursiveExistingDirSkipsSync(t *testing.T) {
+	fileRPC := &fakeHTTPVolumeFileRPC{
+		lookupFunc: func(_ context.Context, req *pb.LookupRequest) (*pb.NodeResponse, error) {
+			if req.Parent == 1 && req.Name == "skills" {
+				return &pb.NodeResponse{Inode: 3, Attr: volumeDirAttr()}, nil
+			}
+			return nil, fserror.New(fserror.NotFound, "missing")
+		},
+	}
+	server, volMgr := newVolumeFileTestServer(fileRPC)
+
+	req := httptest.NewRequest(http.MethodPost, "/sandboxvolumes/vol-1/files?path=/skills&mkdir=true&recursive=true", nil)
+	req.SetPathValue("id", "vol-1")
+	req = req.WithContext(internalauth.WithClaims(req.Context(), &internalauth.Claims{TeamID: "team-a"}))
+	recorder := httptest.NewRecorder()
+
+	server.handleVolumeFileOperation(recorder, req)
+
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusCreated)
+	}
+	if volMgr.syncCalls != 0 {
+		t.Fatalf("SyncDirectVolumeFileMount() calls = %d, want 0", volMgr.syncCalls)
+	}
+}
+
 func TestDeleteVolumeFileUnlinksResolvedPath(t *testing.T) {
 	var unlinked *pb.UnlinkRequest
 	fileRPC := &fakeHTTPVolumeFileRPC{


### PR DESCRIPTION
## Summary
- avoid `SyncMaterialize` for HTTP `mkdir=true&recursive=true` requests that discover the directory already exists
- avoid `SyncMaterialize` for HTTP file overwrites when the existing file content already matches the requested payload
- cover both no-op paths with storage-proxy HTTP tests

## Test
- `go test ./storage-proxy/pkg/http -run 'Test(WriteVolumeFileWritesExistingPath|WriteVolumeFileSkipsSyncWhenContentUnchanged|WriteVolumeFileMkdirRecursiveExistingDirSkipsSync|DeleteVolumeFileUnlinksResolvedPath|HandleVolumeFileMoveRenamesPath)$'`
- `go test ./storage-proxy/pkg/http ./storage-proxy/pkg/volume ./storage-proxy/pkg/s0fs`
- pre-push checks: `make manifests`, `make proto`, `make apispec`, `go fmt ./...`, `go mod tidy`, `go mod vendor`, `golangci-lint run ./...`

## Context
This fixes the sandbox0 side of the managed-agents custom skill failure. Repeated bootstrap writes were reissuing HTTP volume `mkdir -p` and same-content file writes; storage-proxy treated both as mutations and forced another `SyncMaterialize`, which could surface `s0fs committed head conflict` even though the request was semantically a no-op.