### PR TITLE
feat: hand off RWO volume owners to bind ctlds

### DIFF
--- a/ctld/cmd/ctld/main.go
+++ b/ctld/cmd/ctld/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -243,7 +244,7 @@ func (c combinedController) UnbindVolumePortal(r *http.Request, req ctldapi.Unbi
 	}
 	resp, err := c.Portal.Unbind(r.Context(), req)
 	if err != nil {
-		return ctldapi.UnbindVolumePortalResponse{Error: err.Error()}, http.StatusBadRequest
+		return ctldapi.UnbindVolumePortalResponse{Error: err.Error()}, volumePortalErrorStatus(err)
 	}
 	return resp, http.StatusOK
 }
@@ -254,7 +255,7 @@ func (c combinedController) AttachVolumeOwner(r *http.Request, req ctldapi.Attac
 	}
 	resp, err := c.Portal.AttachOwner(r.Context(), req)
 	if err != nil {
-		return ctldapi.AttachVolumeOwnerResponse{Error: err.Error()}, http.StatusBadRequest
+		return ctldapi.AttachVolumeOwnerResponse{Error: err.Error()}, volumePortalErrorStatus(err)
 	}
 	return resp, http.StatusOK
 }
@@ -265,7 +266,7 @@ func (c combinedController) PrepareVolumePortalHandoff(r *http.Request, req ctld
 	}
 	resp, err := c.Portal.PrepareHandoff(r.Context(), req)
 	if err != nil {
-		return ctldapi.PrepareVolumePortalHandoffResponse{Error: err.Error()}, http.StatusBadRequest
+		return ctldapi.PrepareVolumePortalHandoffResponse{Error: err.Error()}, volumePortalErrorStatus(err)
 	}
 	return resp, http.StatusOK
 }
@@ -276,7 +277,7 @@ func (c combinedController) CompleteVolumePortalHandoff(r *http.Request, req ctl
 	}
 	resp, err := c.Portal.CompleteHandoff(r.Context(), req)
 	if err != nil {
-		return ctldapi.CompleteVolumePortalHandoffResponse{Error: err.Error()}, http.StatusBadRequest
+		return ctldapi.CompleteVolumePortalHandoffResponse{Error: err.Error()}, volumePortalErrorStatus(err)
 	}
 	return resp, http.StatusOK
 }
@@ -287,9 +288,27 @@ func (c combinedController) AbortVolumePortalHandoff(r *http.Request, req ctldap
 	}
 	resp, err := c.Portal.AbortHandoff(r.Context(), req)
 	if err != nil {
-		return ctldapi.AbortVolumePortalHandoffResponse{Error: err.Error()}, http.StatusBadRequest
+		return ctldapi.AbortVolumePortalHandoffResponse{Error: err.Error()}, volumePortalErrorStatus(err)
 	}
 	return resp, http.StatusOK
+}
+
+func volumePortalErrorStatus(err error) int {
+	if err == nil {
+		return http.StatusOK
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return http.StatusRequestTimeout
+	}
+	message := strings.ToLower(strings.TrimSpace(err.Error()))
+	switch {
+	case strings.Contains(message, "already has an active owner"),
+		strings.Contains(message, "actively bound to a portal"),
+		strings.Contains(message, "handoff already in progress"):
+		return http.StatusConflict
+	default:
+		return http.StatusBadRequest
+	}
 }
 
 func (c combinedController) MountedVolumeHandler() http.Handler {

--- a/ctld/cmd/ctld/main.go
+++ b/ctld/cmd/ctld/main.go
@@ -112,6 +112,7 @@ func main() {
 		PodName:       podName,
 		PodNamespace:  podNamespace,
 	})
+	go portalManager.Run(ctx)
 	csiServer := ctldportal.NewCSIServer(nodeName, portalManager)
 	go func() {
 		if err := csiServer.Serve(csiSocket); err != nil && ctx.Err() == nil {
@@ -247,6 +248,50 @@ func (c combinedController) UnbindVolumePortal(r *http.Request, req ctldapi.Unbi
 	return resp, http.StatusOK
 }
 
+func (c combinedController) AttachVolumeOwner(r *http.Request, req ctldapi.AttachVolumeOwnerRequest) (ctldapi.AttachVolumeOwnerResponse, int) {
+	if c.Portal == nil {
+		return ctldapi.AttachVolumeOwnerResponse{Error: "ctld volume owners not implemented"}, http.StatusNotImplemented
+	}
+	resp, err := c.Portal.AttachOwner(r.Context(), req)
+	if err != nil {
+		return ctldapi.AttachVolumeOwnerResponse{Error: err.Error()}, http.StatusBadRequest
+	}
+	return resp, http.StatusOK
+}
+
+func (c combinedController) PrepareVolumePortalHandoff(r *http.Request, req ctldapi.PrepareVolumePortalHandoffRequest) (ctldapi.PrepareVolumePortalHandoffResponse, int) {
+	if c.Portal == nil {
+		return ctldapi.PrepareVolumePortalHandoffResponse{Error: "ctld volume portal handoff not implemented"}, http.StatusNotImplemented
+	}
+	resp, err := c.Portal.PrepareHandoff(r.Context(), req)
+	if err != nil {
+		return ctldapi.PrepareVolumePortalHandoffResponse{Error: err.Error()}, http.StatusBadRequest
+	}
+	return resp, http.StatusOK
+}
+
+func (c combinedController) CompleteVolumePortalHandoff(r *http.Request, req ctldapi.CompleteVolumePortalHandoffRequest) (ctldapi.CompleteVolumePortalHandoffResponse, int) {
+	if c.Portal == nil {
+		return ctldapi.CompleteVolumePortalHandoffResponse{Error: "ctld volume portal handoff not implemented"}, http.StatusNotImplemented
+	}
+	resp, err := c.Portal.CompleteHandoff(r.Context(), req)
+	if err != nil {
+		return ctldapi.CompleteVolumePortalHandoffResponse{Error: err.Error()}, http.StatusBadRequest
+	}
+	return resp, http.StatusOK
+}
+
+func (c combinedController) AbortVolumePortalHandoff(r *http.Request, req ctldapi.AbortVolumePortalHandoffRequest) (ctldapi.AbortVolumePortalHandoffResponse, int) {
+	if c.Portal == nil {
+		return ctldapi.AbortVolumePortalHandoffResponse{Error: "ctld volume portal handoff not implemented"}, http.StatusNotImplemented
+	}
+	resp, err := c.Portal.AbortHandoff(r.Context(), req)
+	if err != nil {
+		return ctldapi.AbortVolumePortalHandoffResponse{Error: err.Error()}, http.StatusBadRequest
+	}
+	return resp, http.StatusOK
+}
+
 func (c combinedController) MountedVolumeHandler() http.Handler {
 	if c.Portal == nil {
 		return nil
@@ -261,5 +306,9 @@ func (c combinedController) Probe(r *http.Request, sandboxID string, kind sandbo
 type volumePortalHandler interface {
 	Bind(ctx context.Context, req ctldapi.BindVolumePortalRequest) (ctldapi.BindVolumePortalResponse, error)
 	Unbind(ctx context.Context, req ctldapi.UnbindVolumePortalRequest) (ctldapi.UnbindVolumePortalResponse, error)
+	AttachOwner(ctx context.Context, req ctldapi.AttachVolumeOwnerRequest) (ctldapi.AttachVolumeOwnerResponse, error)
+	PrepareHandoff(ctx context.Context, req ctldapi.PrepareVolumePortalHandoffRequest) (ctldapi.PrepareVolumePortalHandoffResponse, error)
+	CompleteHandoff(ctx context.Context, req ctldapi.CompleteVolumePortalHandoffRequest) (ctldapi.CompleteVolumePortalHandoffResponse, error)
+	AbortHandoff(ctx context.Context, req ctldapi.AbortVolumePortalHandoffRequest) (ctldapi.AbortVolumePortalHandoffResponse, error)
 	MountedVolumeHandler() http.Handler
 }

--- a/ctld/cmd/ctld/main_test.go
+++ b/ctld/cmd/ctld/main_test.go
@@ -3,8 +3,10 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	ctldserver "github.com/sandbox0-ai/sandbox0/ctld/internal/ctld/server"
@@ -81,8 +83,24 @@ func TestCombinedControllerRoutesMountedVolumeAPIToPortalHandler(t *testing.T) {
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 }
 
+func TestPrepareVolumePortalHandoffReturnsConflictForActivePortal(t *testing.T) {
+	server := newHTTPServer(":0", combinedController{
+		Controller: ctldserver.NotImplementedController{},
+		Portal: fakeVolumePortalHandler{
+			prepareErr: fmt.Errorf("volume vol-1 is actively bound to a portal"),
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/volume-portals/handoffs/prepare", strings.NewReader(`{"sandboxvolume_id":"vol-1"}`))
+	rec := httptest.NewRecorder()
+	server.Handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusConflict, rec.Code)
+}
+
 type fakeVolumePortalHandler struct {
 	mountedHandler http.Handler
+	prepareErr     error
 }
 
 func (f fakeVolumePortalHandler) Bind(_ context.Context, _ ctldapi.BindVolumePortalRequest) (ctldapi.BindVolumePortalResponse, error) {
@@ -98,6 +116,9 @@ func (f fakeVolumePortalHandler) AttachOwner(_ context.Context, _ ctldapi.Attach
 }
 
 func (f fakeVolumePortalHandler) PrepareHandoff(_ context.Context, _ ctldapi.PrepareVolumePortalHandoffRequest) (ctldapi.PrepareVolumePortalHandoffResponse, error) {
+	if f.prepareErr != nil {
+		return ctldapi.PrepareVolumePortalHandoffResponse{}, f.prepareErr
+	}
 	return ctldapi.PrepareVolumePortalHandoffResponse{Prepared: true}, nil
 }
 

--- a/ctld/cmd/ctld/main_test.go
+++ b/ctld/cmd/ctld/main_test.go
@@ -93,6 +93,22 @@ func (f fakeVolumePortalHandler) Unbind(_ context.Context, _ ctldapi.UnbindVolum
 	return ctldapi.UnbindVolumePortalResponse{}, nil
 }
 
+func (f fakeVolumePortalHandler) AttachOwner(_ context.Context, _ ctldapi.AttachVolumeOwnerRequest) (ctldapi.AttachVolumeOwnerResponse, error) {
+	return ctldapi.AttachVolumeOwnerResponse{Attached: true}, nil
+}
+
+func (f fakeVolumePortalHandler) PrepareHandoff(_ context.Context, _ ctldapi.PrepareVolumePortalHandoffRequest) (ctldapi.PrepareVolumePortalHandoffResponse, error) {
+	return ctldapi.PrepareVolumePortalHandoffResponse{Prepared: true}, nil
+}
+
+func (f fakeVolumePortalHandler) CompleteHandoff(_ context.Context, _ ctldapi.CompleteVolumePortalHandoffRequest) (ctldapi.CompleteVolumePortalHandoffResponse, error) {
+	return ctldapi.CompleteVolumePortalHandoffResponse{Completed: true}, nil
+}
+
+func (f fakeVolumePortalHandler) AbortHandoff(_ context.Context, _ ctldapi.AbortVolumePortalHandoffRequest) (ctldapi.AbortVolumePortalHandoffResponse, error) {
+	return ctldapi.AbortVolumePortalHandoffResponse{Aborted: true}, nil
+}
+
 func (f fakeVolumePortalHandler) MountedVolumeHandler() http.Handler {
 	return f.mountedHandler
 }

--- a/ctld/internal/ctld/portal/manager.go
+++ b/ctld/internal/ctld/portal/manager.go
@@ -115,7 +115,7 @@ func NewManager(cfg Config) *Manager {
 		logrus:            l,
 		storage:           storageConfig,
 		repo:              cfg.Repository,
-		clusterID:         strings.TrimSpace(storageConfig.DefaultClusterId),
+		clusterID:         naming.ClusterIDOrDefault(&storageConfig.DefaultClusterId),
 		podName:           strings.TrimSpace(cfg.PodName),
 		podNamespace:      strings.TrimSpace(cfg.PodNamespace),
 		heartbeatInterval: heartbeatInterval,

--- a/ctld/internal/ctld/portal/manager.go
+++ b/ctld/internal/ctld/portal/manager.go
@@ -38,6 +38,7 @@ type Manager struct {
 	podName           string
 	podNamespace      string
 	heartbeatInterval time.Duration
+	ownerOnlyIdleTTL  time.Duration
 	volumeAPI         http.Handler
 
 	mu              sync.Mutex
@@ -106,6 +107,7 @@ func NewManager(cfg Config) *Manager {
 	if heartbeatInterval <= 0 {
 		heartbeatInterval = 5 * time.Second
 	}
+	ownerOnlyIdleTTL, _ := time.ParseDuration(storageConfig.DirectVolumeFileIdleTTL)
 	manager := &Manager{
 		nodeName:          strings.TrimSpace(cfg.NodeName),
 		rootDir:           rootDir,
@@ -117,6 +119,7 @@ func NewManager(cfg Config) *Manager {
 		podName:           strings.TrimSpace(cfg.PodName),
 		podNamespace:      strings.TrimSpace(cfg.PodNamespace),
 		heartbeatInterval: heartbeatInterval,
+		ownerOnlyIdleTTL:  ownerOnlyIdleTTL,
 		portals:           make(map[string]*portalMount),
 		portalsByTarget:   make(map[string]*portalMount),
 		boundVolumes:      make(map[string]*boundVolume),
@@ -131,6 +134,26 @@ func (m *Manager) MountedVolumeHandler() http.Handler {
 		return nil
 	}
 	return m.volumeAPI
+}
+
+func (m *Manager) Run(ctx context.Context) {
+	if m == nil || m.ownerOnlyIdleTTL <= 0 {
+		return
+	}
+	interval := m.ownerOnlyIdleTTL / 2
+	if interval <= 0 || interval > 5*time.Second {
+		interval = 5 * time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			m.cleanupIdleOwnerOnlyVolumes(ctx)
+		}
+	}
 }
 
 func (m *Manager) PublishPortal(ctx context.Context, req publishRequest) error {
@@ -239,8 +262,10 @@ func (m *Manager) Bind(ctx context.Context, req ctldapi.BindVolumePortalRequest)
 		return ctldapi.BindVolumePortalResponse{}, fmt.Errorf("pod_uid, sandboxvolume_id and team_id are required")
 	}
 	volumeRecord, err := m.validateBindableVolume(ctx, ctldBindContext{
-		volumeID: req.SandboxVolumeID,
-		teamID:   req.TeamID,
+		volumeID:        req.SandboxVolumeID,
+		teamID:          req.TeamID,
+		sourceClusterID: strings.TrimSpace(req.TransferSourceClusterID),
+		sourcePodID:     strings.TrimSpace(req.TransferSourcePodID),
 	})
 	if err != nil {
 		return ctldapi.BindVolumePortalResponse{}, err
@@ -280,6 +305,13 @@ func (m *Manager) Bind(ctx context.Context, req ctldapi.BindVolumePortalRequest)
 		return response, nil
 	}
 	if bound := m.boundVolumes[req.SandboxVolumeID]; bound != nil {
+		if bound.refCount == 0 {
+			m.attachPortalLocked(pm, req.SandboxVolumeID, volumeRecord.TeamID, mountedAt)
+			bound.refCount = 1
+			response := boundResponse(pm)
+			m.mu.Unlock()
+			return response, nil
+		}
 		if accessMode != volume.AccessModeROX {
 			conflictPath := boundMountPath(m.portals, req.SandboxVolumeID, key)
 			m.mu.Unlock()
@@ -344,6 +376,14 @@ func (m *Manager) Bind(ctx context.Context, req ctldapi.BindVolumePortalRequest)
 		return response, nil
 	}
 	if bound := m.boundVolumes[req.SandboxVolumeID]; bound != nil {
+		if bound.refCount == 0 {
+			m.attachPortalLocked(pm, req.SandboxVolumeID, volumeRecord.TeamID, mountedAt)
+			bound.refCount = 1
+			response := boundResponse(pm)
+			m.mu.Unlock()
+			_ = engine.Close()
+			return response, nil
+		}
 		if accessMode != volume.AccessModeROX {
 			conflictPath := boundMountPath(m.portals, req.SandboxVolumeID, key)
 			m.mu.Unlock()
@@ -374,7 +414,7 @@ func (m *Manager) Bind(ctx context.Context, req ctldapi.BindVolumePortalRequest)
 	m.boundVolumes[req.SandboxVolumeID] = bound
 	m.volumes.add(volCtx)
 	m.attachPortalLocked(pm, req.SandboxVolumeID, volumeRecord.TeamID, mountedAt)
-	if err := m.registerOwner(ctx, bound); err != nil {
+	if err := m.registerOwner(ctx, bound, strings.TrimSpace(req.TransferSourceClusterID), strings.TrimSpace(req.TransferSourcePodID)); err != nil {
 		m.clearPortalLocked(pm)
 		delete(m.boundVolumes, req.SandboxVolumeID)
 		m.volumes.remove(req.SandboxVolumeID)
@@ -409,6 +449,204 @@ func (m *Manager) Unbind(ctx context.Context, req ctldapi.UnbindVolumePortalRequ
 		return ctldapi.UnbindVolumePortalResponse{}, err
 	}
 	return ctldapi.UnbindVolumePortalResponse{Unbound: true}, nil
+}
+
+func (m *Manager) AttachOwner(ctx context.Context, req ctldapi.AttachVolumeOwnerRequest) (ctldapi.AttachVolumeOwnerResponse, error) {
+	if err := ctx.Err(); err != nil {
+		return ctldapi.AttachVolumeOwnerResponse{}, err
+	}
+	if strings.TrimSpace(req.SandboxVolumeID) == "" || strings.TrimSpace(req.TeamID) == "" {
+		return ctldapi.AttachVolumeOwnerResponse{}, fmt.Errorf("sandboxvolume_id and team_id are required")
+	}
+	volumeRecord, err := m.validateBindableVolume(ctx, ctldBindContext{
+		volumeID: req.SandboxVolumeID,
+		teamID:   req.TeamID,
+	})
+	if err != nil {
+		return ctldapi.AttachVolumeOwnerResponse{}, err
+	}
+	accessMode, err := validateBindableAccessMode(volumeRecord.AccessMode)
+	if err != nil {
+		return ctldapi.AttachVolumeOwnerResponse{}, err
+	}
+
+	m.mu.Lock()
+	if bound := m.boundVolumes[req.SandboxVolumeID]; bound != nil {
+		m.mu.Unlock()
+		m.volumes.touch(req.SandboxVolumeID)
+		return ctldapi.AttachVolumeOwnerResponse{Attached: true}, nil
+	}
+	m.mu.Unlock()
+
+	mountedAt := time.Now().UTC()
+	cacheDir := filepath.Join(m.rootDir, "volumes", safePath(req.TeamID), safePath(req.SandboxVolumeID))
+	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
+		return ctldapi.AttachVolumeOwnerResponse{}, fmt.Errorf("create local volume dir: %w", err)
+	}
+	remoteStore, err := m.createObjectStore(req.TeamID, req.SandboxVolumeID)
+	if err != nil {
+		return ctldapi.AttachVolumeOwnerResponse{}, fmt.Errorf("create object storage: %w", err)
+	}
+	engine, err := s0fs.Open(ctx, s0fs.Config{
+		VolumeID:    req.SandboxVolumeID,
+		WALPath:     filepath.Join(cacheDir, "engine.wal"),
+		ObjectStore: remoteStore,
+		HeadStore:   db.NewS0FSHeadStore(m.repo),
+	})
+	if err != nil {
+		return ctldapi.AttachVolumeOwnerResponse{}, fmt.Errorf("open local s0fs engine: %w", err)
+	}
+	volCtx := &volume.VolumeContext{
+		VolumeID:  req.SandboxVolumeID,
+		TeamID:    volumeRecord.TeamID,
+		Backend:   volume.BackendS0FS,
+		S0FS:      engine,
+		Access:    accessMode,
+		MountedAt: mountedAt,
+		RootInode: 1,
+		RootPath:  "/",
+		CacheDir:  cacheDir,
+	}
+
+	m.mu.Lock()
+	if bound := m.boundVolumes[req.SandboxVolumeID]; bound != nil {
+		m.mu.Unlock()
+		_ = engine.Close()
+		m.volumes.touch(req.SandboxVolumeID)
+		return ctldapi.AttachVolumeOwnerResponse{Attached: true}, nil
+	}
+	bound := &boundVolume{
+		volumeID:  req.SandboxVolumeID,
+		teamID:    volumeRecord.TeamID,
+		access:    accessMode,
+		mountedAt: mountedAt,
+		refCount:  0,
+		volCtx:    volCtx,
+	}
+	m.boundVolumes[req.SandboxVolumeID] = bound
+	m.volumes.add(volCtx)
+	if err := m.registerOwner(ctx, bound, "", ""); err != nil {
+		delete(m.boundVolumes, req.SandboxVolumeID)
+		m.volumes.remove(req.SandboxVolumeID)
+		m.mu.Unlock()
+		_ = engine.Close()
+		return ctldapi.AttachVolumeOwnerResponse{}, fmt.Errorf("register ctld volume owner: %w", err)
+	}
+	m.startMaterializer(bound)
+	m.mu.Unlock()
+
+	return ctldapi.AttachVolumeOwnerResponse{Attached: true}, nil
+}
+
+func (m *Manager) PrepareHandoff(ctx context.Context, req ctldapi.PrepareVolumePortalHandoffRequest) (ctldapi.PrepareVolumePortalHandoffResponse, error) {
+	volumeID := strings.TrimSpace(req.SandboxVolumeID)
+	if volumeID == "" {
+		return ctldapi.PrepareVolumePortalHandoffResponse{}, fmt.Errorf("sandboxvolume_id is required")
+	}
+	m.mu.Lock()
+	bound := m.boundVolumes[volumeID]
+	m.mu.Unlock()
+	if bound == nil || bound.volCtx == nil || bound.volCtx.S0FS == nil {
+		return ctldapi.PrepareVolumePortalHandoffResponse{}, fmt.Errorf("volume %s is not owned by this ctld", volumeID)
+	}
+	if bound.refCount > 0 {
+		return ctldapi.PrepareVolumePortalHandoffResponse{}, fmt.Errorf("volume %s is actively bound to a portal", volumeID)
+	}
+	if err := m.volumes.prepareHandoff(ctx, volumeID); err != nil {
+		return ctldapi.PrepareVolumePortalHandoffResponse{}, err
+	}
+	if _, err := bound.volCtx.S0FS.SyncMaterialize(ctx); err != nil {
+		m.volumes.abortHandoff(volumeID)
+		return ctldapi.PrepareVolumePortalHandoffResponse{}, err
+	}
+	return ctldapi.PrepareVolumePortalHandoffResponse{Prepared: true}, nil
+}
+
+func (m *Manager) CompleteHandoff(ctx context.Context, req ctldapi.CompleteVolumePortalHandoffRequest) (ctldapi.CompleteVolumePortalHandoffResponse, error) {
+	volumeID := strings.TrimSpace(req.SandboxVolumeID)
+	if volumeID == "" {
+		return ctldapi.CompleteVolumePortalHandoffResponse{}, fmt.Errorf("sandboxvolume_id is required")
+	}
+	m.volumes.abortHandoff(volumeID)
+
+	m.mu.Lock()
+	bound := m.boundVolumes[volumeID]
+	if bound == nil {
+		m.mu.Unlock()
+		return ctldapi.CompleteVolumePortalHandoffResponse{Completed: true}, nil
+	}
+	delete(m.boundVolumes, volumeID)
+	m.unregisterOwner(bound)
+	if bound.materializeCancel != nil {
+		bound.materializeCancel()
+		bound.materializeCancel = nil
+	}
+	done := bound.materializeDone
+	bound.materializeDone = nil
+	m.mu.Unlock()
+
+	if done != nil {
+		<-done
+	}
+	if err := m.volumes.UnmountVolume(ctx, volumeID, ""); err != nil {
+		return ctldapi.CompleteVolumePortalHandoffResponse{}, err
+	}
+	return ctldapi.CompleteVolumePortalHandoffResponse{Completed: true}, nil
+}
+
+func (m *Manager) AbortHandoff(ctx context.Context, req ctldapi.AbortVolumePortalHandoffRequest) (ctldapi.AbortVolumePortalHandoffResponse, error) {
+	volumeID := strings.TrimSpace(req.SandboxVolumeID)
+	if volumeID == "" {
+		return ctldapi.AbortVolumePortalHandoffResponse{}, fmt.Errorf("sandboxvolume_id is required")
+	}
+	m.volumes.abortHandoff(volumeID)
+	return ctldapi.AbortVolumePortalHandoffResponse{Aborted: true}, nil
+}
+
+func (m *Manager) cleanupIdleOwnerOnlyVolumes(ctx context.Context) {
+	if m == nil || m.ownerOnlyIdleTTL <= 0 {
+		return
+	}
+	cutoff := time.Now().UTC().Add(-m.ownerOnlyIdleTTL)
+
+	m.mu.Lock()
+	volumeIDs := make([]string, 0, len(m.boundVolumes))
+	for volumeID, bound := range m.boundVolumes {
+		if bound == nil || bound.refCount > 0 || !m.volumes.canCleanupOwnerOnly(volumeID, cutoff) {
+			continue
+		}
+		volumeIDs = append(volumeIDs, volumeID)
+	}
+	m.mu.Unlock()
+
+	for _, volumeID := range volumeIDs {
+		if err := m.releaseOwnerOnlyVolume(ctx, volumeID); err != nil && m.logger != nil {
+			m.logger.Warn("ctld idle owner-only cleanup failed", zap.String("volume_id", volumeID), zap.Error(err))
+		}
+	}
+}
+
+func (m *Manager) releaseOwnerOnlyVolume(ctx context.Context, volumeID string) error {
+	m.mu.Lock()
+	bound := m.boundVolumes[volumeID]
+	if bound == nil || bound.refCount > 0 || !m.volumes.canCleanupOwnerOnly(volumeID, time.Now().UTC().Add(-m.ownerOnlyIdleTTL)) {
+		m.mu.Unlock()
+		return nil
+	}
+	delete(m.boundVolumes, volumeID)
+	m.unregisterOwner(bound)
+	if bound.materializeCancel != nil {
+		bound.materializeCancel()
+		bound.materializeCancel = nil
+	}
+	done := bound.materializeDone
+	bound.materializeDone = nil
+	m.mu.Unlock()
+
+	if done != nil {
+		<-done
+	}
+	return m.volumes.UnmountVolume(ctx, volumeID, "")
 }
 
 func (m *Manager) unbindLockedSnapshot(pm *portalMount) error {

--- a/ctld/internal/ctld/portal/manager_shared_test.go
+++ b/ctld/internal/ctld/portal/manager_shared_test.go
@@ -1,6 +1,7 @@
 package portal
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -64,5 +65,30 @@ func TestUnbindLockedSnapshotKeepsSharedVolumeUntilLastPortal(t *testing.T) {
 	}
 	if _, err := mgr.volumes.GetVolume("vol-1"); err == nil {
 		t.Fatal("GetVolume() after last unbind error = nil, want volume removed")
+	}
+}
+
+func TestCleanupIdleOwnerOnlyVolumesRemovesIdleOwner(t *testing.T) {
+	mgr := &Manager{
+		ownerOnlyIdleTTL: 50 * time.Millisecond,
+		boundVolumes:     make(map[string]*boundVolume),
+		volumes:          newLocalVolumeManager(),
+	}
+	volCtx := &volume.VolumeContext{VolumeID: "vol-1"}
+	mgr.volumes.add(volCtx)
+	mgr.volumes.requests["vol-1"].lastAccess = time.Now().UTC().Add(-time.Minute)
+	mgr.boundVolumes["vol-1"] = &boundVolume{
+		volumeID: "vol-1",
+		refCount: 0,
+		volCtx:   volCtx,
+	}
+
+	mgr.cleanupIdleOwnerOnlyVolumes(context.Background())
+
+	if _, ok := mgr.boundVolumes["vol-1"]; ok {
+		t.Fatal("bound volume still present after idle owner-only cleanup")
+	}
+	if _, err := mgr.volumes.GetVolume("vol-1"); err == nil {
+		t.Fatal("GetVolume() after idle owner-only cleanup error = nil, want volume removed")
 	}
 }

--- a/ctld/internal/ctld/portal/manager_shared_test.go
+++ b/ctld/internal/ctld/portal/manager_shared_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	apiconfig "github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
+	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 	"github.com/sandbox0-ai/sandbox0/pkg/volumefuse"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volume"
 )
@@ -90,5 +92,14 @@ func TestCleanupIdleOwnerOnlyVolumesRemovesIdleOwner(t *testing.T) {
 	}
 	if _, err := mgr.volumes.GetVolume("vol-1"); err == nil {
 		t.Fatal("GetVolume() after idle owner-only cleanup error = nil, want volume removed")
+	}
+}
+
+func TestNewManagerDefaultsClusterID(t *testing.T) {
+	mgr := NewManager(Config{
+		StorageConfig: &apiconfig.StorageProxyConfig{},
+	})
+	if mgr.clusterID != naming.DefaultClusterID {
+		t.Fatalf("clusterID = %q, want %q", mgr.clusterID, naming.DefaultClusterID)
 	}
 }

--- a/ctld/internal/ctld/portal/registry.go
+++ b/ctld/internal/ctld/portal/registry.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volume"
 	"go.uber.org/zap"
@@ -55,7 +56,7 @@ func (m *Manager) validateBindableVolume(ctx context.Context, req ctldBindContex
 	}
 	selfPodID := m.ownerPodID()
 	for _, mount := range mounts {
-		if req.sourceClusterID != "" && req.sourcePodID != "" && mount.ClusterID == req.sourceClusterID && mount.PodID == req.sourcePodID {
+		if isTransferSourceMount(mount, req.sourceClusterID, req.sourcePodID) {
 			continue
 		}
 		if !isConflictingMountForCtldBind(mount, m.clusterID, selfPodID) {
@@ -64,6 +65,16 @@ func (m *Manager) validateBindableVolume(ctx context.Context, req ctldBindContex
 		return nil, fmt.Errorf("volume %s already has an active owner on %s/%s", req.volumeID, mount.ClusterID, mount.PodID)
 	}
 	return vol, nil
+}
+
+func isTransferSourceMount(mount *db.VolumeMount, sourceClusterID, sourcePodID string) bool {
+	if mount == nil || strings.TrimSpace(sourcePodID) == "" {
+		return false
+	}
+	if mount.PodID != strings.TrimSpace(sourcePodID) {
+		return false
+	}
+	return naming.ClusterIDOrDefault(&mount.ClusterID) == naming.ClusterIDOrDefault(&sourceClusterID)
 }
 
 func validateBindableAccessMode(raw string) (volume.AccessMode, error) {

--- a/ctld/internal/ctld/portal/registry.go
+++ b/ctld/internal/ctld/portal/registry.go
@@ -55,6 +55,9 @@ func (m *Manager) validateBindableVolume(ctx context.Context, req ctldBindContex
 	}
 	selfPodID := m.ownerPodID()
 	for _, mount := range mounts {
+		if req.sourceClusterID != "" && req.sourcePodID != "" && mount.ClusterID == req.sourceClusterID && mount.PodID == req.sourcePodID {
+			continue
+		}
 		if !isConflictingMountForCtldBind(mount, m.clusterID, selfPodID) {
 			continue
 		}
@@ -102,11 +105,13 @@ func findBoundPortalForVolume(portals map[string]*portalMount, volumeID, exceptK
 }
 
 type ctldBindContext struct {
-	volumeID string
-	teamID   string
+	volumeID        string
+	teamID          string
+	sourceClusterID string
+	sourcePodID     string
 }
 
-func (m *Manager) registerOwner(ctx context.Context, bound *boundVolume) error {
+func (m *Manager) registerOwner(ctx context.Context, bound *boundVolume, sourceClusterID, sourcePodID string) error {
 	if m == nil || m.repo == nil || bound == nil || bound.volumeID == "" {
 		return fmt.Errorf("ctld volume registry unavailable")
 	}
@@ -140,8 +145,14 @@ func (m *Manager) registerOwner(ctx context.Context, bound *boundVolume) error {
 	if m.storage != nil && m.storage.HeartbeatTimeout > 0 {
 		heartbeatTimeout = m.storage.HeartbeatTimeout
 	}
-	if err := m.repo.AcquireMount(ctx, mount, heartbeatTimeout); err != nil {
-		return err
+	if sourceClusterID != "" && sourcePodID != "" {
+		if err := m.repo.TransferMount(ctx, bound.volumeID, sourceClusterID, sourcePodID, mount, heartbeatTimeout); err != nil {
+			return err
+		}
+	} else {
+		if err := m.repo.AcquireMount(ctx, mount, heartbeatTimeout); err != nil {
+			return err
+		}
 	}
 
 	interval := m.heartbeatInterval

--- a/ctld/internal/ctld/portal/registry_test.go
+++ b/ctld/internal/ctld/portal/registry_test.go
@@ -34,6 +34,24 @@ func TestIsConflictingMountForCtldBindBlocksCtldOwners(t *testing.T) {
 	}
 }
 
+func TestIsTransferSourceMountAllowsLegacyEmptyClusterID(t *testing.T) {
+	mount := &db.VolumeMount{
+		VolumeID:  "vol-1",
+		ClusterID: "",
+		PodID:     "sandbox0-system/ctld-node-a",
+	}
+
+	if !isTransferSourceMount(mount, "", "sandbox0-system/ctld-node-a") {
+		t.Fatal("expected legacy empty cluster ID to match transfer source")
+	}
+	if !isTransferSourceMount(mount, "default", "sandbox0-system/ctld-node-a") {
+		t.Fatal("expected normalized default cluster ID to match legacy empty cluster ID")
+	}
+	if isTransferSourceMount(mount, "", "sandbox0-system/ctld-node-b") {
+		t.Fatal("expected different transfer source pod to be rejected")
+	}
+}
+
 func TestFindBoundPortalForVolumeReturnsOtherPortal(t *testing.T) {
 	portals := map[string]*portalMount{
 		"portal-a": {mountPath: "/workspace/a", volumeID: "vol-1"},

--- a/ctld/internal/ctld/portal/session.go
+++ b/ctld/internal/ctld/portal/session.go
@@ -23,18 +23,36 @@ import (
 )
 
 type localVolumeManager struct {
-	mu      sync.RWMutex
-	volumes map[string]*volume.VolumeContext
+	mu       sync.RWMutex
+	volumes  map[string]*volume.VolumeContext
+	requests map[string]*localVolumeRequestState
+}
+
+type localVolumeRequestState struct {
+	inFlight     int
+	transferring bool
+	lastAccess   time.Time
+	done         chan struct{}
+	cond         *sync.Cond
 }
 
 func newLocalVolumeManager() *localVolumeManager {
-	return &localVolumeManager{volumes: make(map[string]*volume.VolumeContext)}
+	return &localVolumeManager{
+		volumes:  make(map[string]*volume.VolumeContext),
+		requests: make(map[string]*localVolumeRequestState),
+	}
 }
 
 func (m *localVolumeManager) add(volCtx *volume.VolumeContext) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.volumes[volCtx.VolumeID] = volCtx
+	if _, ok := m.requests[volCtx.VolumeID]; !ok {
+		state := &localVolumeRequestState{}
+		state.cond = sync.NewCond(&m.mu)
+		state.lastAccess = time.Now().UTC()
+		m.requests[volCtx.VolumeID] = state
+	}
 }
 
 func (m *localVolumeManager) remove(volumeID string) (*volume.VolumeContext, bool) {
@@ -42,7 +60,120 @@ func (m *localVolumeManager) remove(volumeID string) (*volume.VolumeContext, boo
 	defer m.mu.Unlock()
 	volCtx, ok := m.volumes[volumeID]
 	delete(m.volumes, volumeID)
+	if state := m.requests[volumeID]; state != nil {
+		if state.transferring && state.done != nil {
+			close(state.done)
+		}
+		delete(m.requests, volumeID)
+	}
 	return volCtx, ok
+}
+
+func (m *localVolumeManager) acquire(ctx context.Context, volumeID string) (func(), error) {
+	for {
+		m.mu.Lock()
+		volCtx := m.volumes[volumeID]
+		state := m.requests[volumeID]
+		if volCtx == nil || state == nil {
+			m.mu.Unlock()
+			return nil, fmt.Errorf("volume %s not mounted", volumeID)
+		}
+		if state.transferring && state.done != nil {
+			done := state.done
+			m.mu.Unlock()
+			select {
+			case <-done:
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+			continue
+		}
+		state.inFlight++
+		state.lastAccess = time.Now().UTC()
+		m.mu.Unlock()
+		return func() {
+			m.mu.Lock()
+			defer m.mu.Unlock()
+			state := m.requests[volumeID]
+			if state == nil {
+				return
+			}
+			if state.inFlight > 0 {
+				state.inFlight--
+			}
+			state.lastAccess = time.Now().UTC()
+			if state.inFlight == 0 && state.cond != nil {
+				state.cond.Broadcast()
+			}
+		}, nil
+	}
+}
+
+func (m *localVolumeManager) prepareHandoff(ctx context.Context, volumeID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	state := m.requests[volumeID]
+	if m.volumes[volumeID] == nil || state == nil {
+		return fmt.Errorf("volume %s not mounted", volumeID)
+	}
+	if state.transferring {
+		return fmt.Errorf("volume %s handoff already in progress", volumeID)
+	}
+	state.transferring = true
+	state.done = make(chan struct{})
+	for state.inFlight > 0 {
+		if err := ctx.Err(); err != nil {
+			state.transferring = false
+			close(state.done)
+			state.done = nil
+			return err
+		}
+		state.cond.Wait()
+	}
+	return nil
+}
+
+func (m *localVolumeManager) abortHandoff(volumeID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	state := m.requests[volumeID]
+	if state == nil || !state.transferring {
+		return
+	}
+	state.transferring = false
+	state.lastAccess = time.Now().UTC()
+	if state.done != nil {
+		close(state.done)
+		state.done = nil
+	}
+}
+
+func (m *localVolumeManager) touch(volumeID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	state := m.requests[volumeID]
+	if state == nil {
+		return
+	}
+	state.lastAccess = time.Now().UTC()
+}
+
+func (m *localVolumeManager) canCleanupOwnerOnly(volumeID string, cutoff time.Time) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	state := m.requests[volumeID]
+	if m.volumes[volumeID] == nil || state == nil {
+		return false
+	}
+	if state.transferring || state.inFlight > 0 {
+		return false
+	}
+	if state.lastAccess.IsZero() {
+		return false
+	}
+	return !state.lastAccess.After(cutoff)
 }
 
 func (m *localVolumeManager) MountVolume(_ context.Context, _ string, volumeID string, _ string, _ volume.AccessMode) (string, time.Time, error) {
@@ -79,18 +210,17 @@ func (m *localVolumeManager) AckInvalidate(string, string, string, bool, string)
 }
 
 func (m *localVolumeManager) AcquireDirectVolumeFileMount(ctx context.Context, volumeID string, mountFn func(context.Context) (string, error)) (func(), error) {
-	m.mu.RLock()
-	volCtx := m.volumes[volumeID]
-	m.mu.RUnlock()
-	if volCtx == nil {
-		return nil, fmt.Errorf("volume %s not mounted", volumeID)
+	release, err := m.acquire(ctx, volumeID)
+	if err != nil {
+		return nil, err
 	}
 	if mountFn != nil {
 		if _, err := mountFn(ctx); err != nil {
+			release()
 			return nil, err
 		}
 	}
-	return func() {}, nil
+	return release, nil
 }
 
 func (m *localVolumeManager) CleanupIdleDirectVolumeFileMount(context.Context, string) (bool, error) {

--- a/ctld/internal/ctld/portal/session_test.go
+++ b/ctld/internal/ctld/portal/session_test.go
@@ -130,6 +130,70 @@ func TestLocalSessionReadIntoRequiresTrackedHandleForCache(t *testing.T) {
 	}
 }
 
+func TestLocalVolumeManagerPrepareHandoffDrainsInflightAndBlocksNewAcquires(t *testing.T) {
+	mgr := newLocalVolumeManager()
+	mgr.add(&volume.VolumeContext{VolumeID: "vol-1"})
+
+	releaseExisting, err := mgr.AcquireDirectVolumeFileMount(context.Background(), "vol-1", nil)
+	if err != nil {
+		t.Fatalf("AcquireDirectVolumeFileMount(existing) error = %v", err)
+	}
+
+	prepared := make(chan error, 1)
+	go func() {
+		prepared <- mgr.prepareHandoff(context.Background(), "vol-1")
+	}()
+
+	select {
+	case err := <-prepared:
+		t.Fatalf("prepareHandoff() returned early: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	acquired := make(chan error, 1)
+	go func() {
+		release, err := mgr.AcquireDirectVolumeFileMount(context.Background(), "vol-1", nil)
+		if err == nil && release != nil {
+			release()
+		}
+		acquired <- err
+	}()
+
+	select {
+	case err := <-acquired:
+		t.Fatalf("AcquireDirectVolumeFileMount(new) returned during handoff: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	releaseExisting()
+
+	select {
+	case err := <-prepared:
+		if err != nil {
+			t.Fatalf("prepareHandoff() error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("prepareHandoff() did not complete after inflight request drained")
+	}
+
+	select {
+	case err := <-acquired:
+		t.Fatalf("AcquireDirectVolumeFileMount(new) returned before handoff abort: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	mgr.abortHandoff("vol-1")
+
+	select {
+	case err := <-acquired:
+		if err != nil {
+			t.Fatalf("AcquireDirectVolumeFileMount(new) error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("AcquireDirectVolumeFileMount(new) did not resume after handoff abort")
+	}
+}
+
 func TestLocalSessionReadCacheTracksSmallWrites(t *testing.T) {
 	engine, err := s0fs.Open(context.Background(), s0fs.Config{
 		VolumeID: "vol-1",

--- a/ctld/internal/ctld/server/server.go
+++ b/ctld/internal/ctld/server/server.go
@@ -20,6 +20,10 @@ type Controller interface {
 type VolumePortalController interface {
 	BindVolumePortal(r *http.Request, req ctldapi.BindVolumePortalRequest) (ctldapi.BindVolumePortalResponse, int)
 	UnbindVolumePortal(r *http.Request, req ctldapi.UnbindVolumePortalRequest) (ctldapi.UnbindVolumePortalResponse, int)
+	AttachVolumeOwner(r *http.Request, req ctldapi.AttachVolumeOwnerRequest) (ctldapi.AttachVolumeOwnerResponse, int)
+	PrepareVolumePortalHandoff(r *http.Request, req ctldapi.PrepareVolumePortalHandoffRequest) (ctldapi.PrepareVolumePortalHandoffResponse, int)
+	CompleteVolumePortalHandoff(r *http.Request, req ctldapi.CompleteVolumePortalHandoffRequest) (ctldapi.CompleteVolumePortalHandoffResponse, int)
+	AbortVolumePortalHandoff(r *http.Request, req ctldapi.AbortVolumePortalHandoffRequest) (ctldapi.AbortVolumePortalHandoffResponse, int)
 }
 
 type MountedVolumeController interface {
@@ -104,6 +108,94 @@ func NewMux(controller Controller) http.Handler {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		resp, status := volumeController.UnbindVolumePortal(r, req)
+		w.WriteHeader(status)
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+	mux.HandleFunc("/api/v1/volume-portals/owners/attach", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		volumeController, ok := controller.(VolumePortalController)
+		if !ok {
+			w.WriteHeader(http.StatusNotImplemented)
+			_ = json.NewEncoder(w).Encode(ctldapi.AttachVolumeOwnerResponse{Error: "ctld volume owners not implemented"})
+			return
+		}
+		var req ctldapi.AttachVolumeOwnerRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(ctldapi.AttachVolumeOwnerResponse{Error: err.Error()})
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		resp, status := volumeController.AttachVolumeOwner(r, req)
+		w.WriteHeader(status)
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+	mux.HandleFunc("/api/v1/volume-portals/handoffs/prepare", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		volumeController, ok := controller.(VolumePortalController)
+		if !ok {
+			w.WriteHeader(http.StatusNotImplemented)
+			_ = json.NewEncoder(w).Encode(ctldapi.PrepareVolumePortalHandoffResponse{Error: "ctld volume portal handoff not implemented"})
+			return
+		}
+		var req ctldapi.PrepareVolumePortalHandoffRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(ctldapi.PrepareVolumePortalHandoffResponse{Error: err.Error()})
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		resp, status := volumeController.PrepareVolumePortalHandoff(r, req)
+		w.WriteHeader(status)
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+	mux.HandleFunc("/api/v1/volume-portals/handoffs/complete", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		volumeController, ok := controller.(VolumePortalController)
+		if !ok {
+			w.WriteHeader(http.StatusNotImplemented)
+			_ = json.NewEncoder(w).Encode(ctldapi.CompleteVolumePortalHandoffResponse{Error: "ctld volume portal handoff not implemented"})
+			return
+		}
+		var req ctldapi.CompleteVolumePortalHandoffRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(ctldapi.CompleteVolumePortalHandoffResponse{Error: err.Error()})
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		resp, status := volumeController.CompleteVolumePortalHandoff(r, req)
+		w.WriteHeader(status)
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+	mux.HandleFunc("/api/v1/volume-portals/handoffs/abort", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		volumeController, ok := controller.(VolumePortalController)
+		if !ok {
+			w.WriteHeader(http.StatusNotImplemented)
+			_ = json.NewEncoder(w).Encode(ctldapi.AbortVolumePortalHandoffResponse{Error: "ctld volume portal handoff not implemented"})
+			return
+		}
+		var req ctldapi.AbortVolumePortalHandoffRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(ctldapi.AbortVolumePortalHandoffResponse{Error: err.Error()})
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		resp, status := volumeController.AbortVolumePortalHandoff(r, req)
 		w.WriteHeader(status)
 		_ = json.NewEncoder(w).Encode(resp)
 	})

--- a/infra-operator/internal/controller/pkg/rbac/rbac.go
+++ b/infra-operator/internal/controller/pkg/rbac/rbac.go
@@ -165,6 +165,11 @@ func (r *Reconciler) ReconcileStorageProxyRBAC(ctx context.Context, infra *infra
 			Resources: []string{"pods", "events"},
 			Verbs:     []string{"get", "list", "watch", "create", "patch"},
 		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{"nodes"},
+			Verbs:     []string{"get"},
+		},
 	}
 
 	if err := r.reconcileClusterRole(ctx, name, labels, rules); err != nil {

--- a/infra-operator/internal/controller/pkg/rbac/rbac_test.go
+++ b/infra-operator/internal/controller/pkg/rbac/rbac_test.go
@@ -171,6 +171,40 @@ func TestReconcileCtldRBACIncludesPodReadPermissions(t *testing.T) {
 	assert.True(t, found, "expected ctld cluster role to include pod resize permissions")
 }
 
+func TestReconcileStorageProxyRBACIncludesNodeReadPermission(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, rbacv1.AddToScheme(scheme))
+	require.NoError(t, infrav1alpha1.AddToScheme(scheme))
+
+	infra := &infrav1alpha1.Sandbox0Infra{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "sandbox0-system",
+		},
+	}
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(infra).Build()
+	reconciler := NewReconciler(&common.ResourceManager{Client: client, Scheme: scheme})
+
+	require.NoError(t, reconciler.ReconcileStorageProxyRBAC(context.Background(), infra))
+
+	role := &rbacv1.ClusterRole{}
+	require.NoError(t, client.Get(context.Background(), types.NamespacedName{Name: "demo-storage-proxy"}, role))
+
+	found := false
+	for _, rule := range role.Rules {
+		if !contains(rule.APIGroups, "") {
+			continue
+		}
+		if !contains(rule.Resources, "nodes") {
+			continue
+		}
+		assert.ElementsMatch(t, []string{"get"}, rule.Verbs)
+		found = true
+	}
+	assert.True(t, found, "expected storage-proxy cluster role to include node read permission")
+}
+
 func TestReconcileStorageClientRBACAppliesGCSWorkloadIdentity(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))

--- a/manager/pkg/service/ctld_client.go
+++ b/manager/pkg/service/ctld_client.go
@@ -60,6 +60,18 @@ func (c *CtldClient) UnbindVolumePortal(ctx context.Context, ctldAddress string,
 	return doCtldJSONRequest[ctldapi.UnbindVolumePortalResponse](ctx, c.httpClient, ctldAddress, "/api/v1/volume-portals/unbind", req)
 }
 
+func (c *CtldClient) PrepareVolumePortalHandoff(ctx context.Context, ctldAddress string, req ctldapi.PrepareVolumePortalHandoffRequest) (*ctldapi.PrepareVolumePortalHandoffResponse, error) {
+	return doCtldJSONRequest[ctldapi.PrepareVolumePortalHandoffResponse](ctx, c.httpClient, ctldAddress, "/api/v1/volume-portals/handoffs/prepare", req)
+}
+
+func (c *CtldClient) CompleteVolumePortalHandoff(ctx context.Context, ctldAddress string, req ctldapi.CompleteVolumePortalHandoffRequest) (*ctldapi.CompleteVolumePortalHandoffResponse, error) {
+	return doCtldJSONRequest[ctldapi.CompleteVolumePortalHandoffResponse](ctx, c.httpClient, ctldAddress, "/api/v1/volume-portals/handoffs/complete", req)
+}
+
+func (c *CtldClient) AbortVolumePortalHandoff(ctx context.Context, ctldAddress string, req ctldapi.AbortVolumePortalHandoffRequest) (*ctldapi.AbortVolumePortalHandoffResponse, error) {
+	return doCtldJSONRequest[ctldapi.AbortVolumePortalHandoffResponse](ctx, c.httpClient, ctldAddress, "/api/v1/volume-portals/handoffs/abort", req)
+}
+
 func doCtldRequest[T any](ctx context.Context, httpClient *http.Client, ctldAddress, sandboxID, suffix string) (*T, error) {
 	path := fmt.Sprintf("/api/v1/sandboxes/%s%s", url.PathEscape(sandboxID), suffix)
 	return doCtldPathRequest[T](ctx, httpClient, ctldAddress, path)

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -25,6 +25,11 @@ import (
 	"k8s.io/client-go/util/retry"
 )
 
+const (
+	volumePortalBindRetryWindow   = 5 * time.Second
+	volumePortalBindRetryInterval = 100 * time.Millisecond
+)
+
 // ClaimRequest represents a sandbox claim request
 type ClaimRequest struct {
 	TeamID   string
@@ -508,7 +513,7 @@ func (s *SandboxService) bindVolumePortal(ctx context.Context, pod *corev1.Pod, 
 		}
 		return nil, fmt.Errorf("prepare volume portal bind: %w", err)
 	}
-	resp, err := s.ctldClient.BindVolumePortal(ctx, ctldAddress, ctldapi.BindVolumePortalRequest{
+	resp, err := s.bindVolumePortalWithRetry(ctx, ctldAddress, ctldapi.BindVolumePortalRequest{
 		Namespace:       pod.Namespace,
 		PodName:         pod.Name,
 		PodUID:          string(pod.UID),
@@ -531,6 +536,45 @@ func (s *SandboxService) bindVolumePortal(ctx context.Context, pod *corev1.Pod, 
 		)
 	}
 	return resp, nil
+}
+
+func (s *SandboxService) bindVolumePortalWithRetry(ctx context.Context, ctldAddress string, req ctldapi.BindVolumePortalRequest) (*ctldapi.BindVolumePortalResponse, error) {
+	if s == nil || s.ctldClient == nil {
+		return nil, fmt.Errorf("ctld client is not configured")
+	}
+
+	deadline := time.Now().Add(volumePortalBindRetryWindow)
+	for {
+		resp, err := s.ctldClient.BindVolumePortal(ctx, ctldAddress, req)
+		if err == nil {
+			return resp, nil
+		}
+		if !isVolumePortalPendingPublicationError(resp, err) {
+			return nil, err
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if time.Now().After(deadline) {
+			return nil, err
+		}
+
+		timer := time.NewTimer(volumePortalBindRetryInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func isVolumePortalPendingPublicationError(resp *ctldapi.BindVolumePortalResponse, err error) bool {
+	if err == nil || resp == nil {
+		return false
+	}
+	message := strings.ToLower(strings.TrimSpace(resp.Error))
+	return strings.Contains(message, "is not published")
 }
 
 // claimIdlePod claims an idle pod from the pool

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -468,7 +468,7 @@ func (s *SandboxService) bindWebhookStatePortal(ctx context.Context, pod *corev1
 	return err
 }
 
-func (s *SandboxService) prepareVolumePortalBind(ctx context.Context, teamID, userID, volumeID string) error {
+func (s *SandboxService) prepareVolumePortalBind(ctx context.Context, req PrepareVolumePortalBindRequest) error {
 	if s == nil || s.volumeMetadata == nil {
 		return nil
 	}
@@ -476,7 +476,7 @@ func (s *SandboxService) prepareVolumePortalBind(ctx context.Context, teamID, us
 	if !ok {
 		return nil
 	}
-	return preparer.PrepareForVolumePortalBind(ctx, teamID, userID, volumeID)
+	return preparer.PrepareForVolumePortalBind(ctx, req)
 }
 
 func (s *SandboxService) bindVolumePortal(ctx context.Context, pod *corev1.Pod, teamID, userID, ownerTeamID, volumeID, mountPoint, portalName string) (*ctldapi.BindVolumePortalResponse, error) {
@@ -486,15 +486,27 @@ func (s *SandboxService) bindVolumePortal(ctx context.Context, pod *corev1.Pod, 
 	if pod == nil {
 		return nil, fmt.Errorf("pod is nil")
 	}
-	if err := s.prepareVolumePortalBind(ctx, teamID, userID, volumeID); err != nil {
+	ctldAddress, err := s.ctldAddressForPod(ctx, pod)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.prepareVolumePortalBind(ctx, PrepareVolumePortalBindRequest{
+		TeamID:         teamID,
+		UserID:         userID,
+		VolumeID:       volumeID,
+		TargetCtldAddr: ctldAddress,
+		Namespace:      pod.Namespace,
+		PodName:        pod.Name,
+		PodUID:         string(pod.UID),
+		PortalName:     volumeportal.NormalizePortalName(portalName, mountPoint),
+		MountPath:      mountPoint,
+		SandboxID:      pod.Name,
+		OwnerTeamID:    ownerTeamID,
+	}); err != nil {
 		if errors.Is(err, ErrVolumePortalBindConflict) {
 			return nil, fmt.Errorf("%w: %v", ErrClaimConflict, err)
 		}
 		return nil, fmt.Errorf("prepare volume portal bind: %w", err)
-	}
-	ctldAddress, err := s.ctldAddressForPod(ctx, pod)
-	if err != nil {
-		return nil, err
 	}
 	resp, err := s.ctldClient.BindVolumePortal(ctx, ctldAddress, ctldapi.BindVolumePortalRequest{
 		Namespace:       pod.Namespace,

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -731,11 +731,11 @@ func (c fakeVolumeMetadataClient) Get(_ context.Context, teamID, userID, volumeI
 	}, nil
 }
 
-func (c *fakeVolumeMetadataClient) PrepareForVolumePortalBind(_ context.Context, teamID, userID, volumeID string) error {
+func (c *fakeVolumeMetadataClient) PrepareForVolumePortalBind(_ context.Context, req PrepareVolumePortalBindRequest) error {
 	if c == nil {
 		return nil
 	}
-	c.prepared = append(c.prepared, teamID+":"+userID+":"+volumeID)
+	c.prepared = append(c.prepared, req.TeamID+":"+req.UserID+":"+req.VolumeID+":"+req.TargetCtldAddr+":"+req.PodUID)
 	return c.prepareErr
 }
 
@@ -743,24 +743,44 @@ func TestPrepareVolumePortalBindUsesPreparationClientWhenAvailable(t *testing.T)
 	metadata := &fakeVolumeMetadataClient{}
 	svc := &SandboxService{volumeMetadata: metadata}
 
-	if err := svc.prepareVolumePortalBind(context.Background(), "team-a", "user-a", "vol-1"); err != nil {
+	if err := svc.prepareVolumePortalBind(context.Background(), PrepareVolumePortalBindRequest{
+		TeamID:         "team-a",
+		UserID:         "user-a",
+		VolumeID:       "vol-1",
+		TargetCtldAddr: "http://ctld",
+		PodUID:         "pod-uid",
+	}); err != nil {
 		t.Fatalf("prepareVolumePortalBind() error = %v", err)
 	}
 	if len(metadata.prepared) != 1 {
 		t.Fatalf("prepared calls = %d, want 1", len(metadata.prepared))
 	}
-	if metadata.prepared[0] != "team-a:user-a:vol-1" {
-		t.Fatalf("prepared call = %q, want %q", metadata.prepared[0], "team-a:user-a:vol-1")
+	if metadata.prepared[0] != "team-a:user-a:vol-1:http://ctld:pod-uid" {
+		t.Fatalf("prepared call = %q, want %q", metadata.prepared[0], "team-a:user-a:vol-1:http://ctld:pod-uid")
 	}
 }
 
 func TestBindVolumePortalTreatsPreparationConflictAsClaimConflict(t *testing.T) {
 	metadata := &fakeVolumeMetadataClient{prepareErr: ErrVolumePortalBindConflict}
+	client := fake.NewSimpleClientset(&corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-a"},
+		Status: corev1.NodeStatus{
+			Addresses: []corev1.NodeAddress{{
+				Type:    corev1.NodeInternalIP,
+				Address: "10.0.0.8",
+			}},
+		},
+	})
 	svc := &SandboxService{
+		k8sClient:      client,
 		ctldClient:     &CtldClient{},
 		volumeMetadata: metadata,
+		config:         SandboxServiceConfig{CtldPort: 8095},
 	}
-	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "sandbox-a", Namespace: "team-a", UID: "pod-uid"}}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "sandbox-a", Namespace: "team-a", UID: "pod-uid"},
+		Spec:       corev1.PodSpec{NodeName: "node-a"},
+	}
 
 	_, err := svc.bindVolumePortal(context.Background(), pod, "team-a", "user-a", "team-a", "vol-1", "/workspace/data", "data")
 	if err == nil {

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/network"
+	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
 	"github.com/sandbox0-ai/sandbox0/pkg/dataplane"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
@@ -788,6 +789,69 @@ func TestBindVolumePortalTreatsPreparationConflictAsClaimConflict(t *testing.T) 
 	}
 	if !errors.Is(err, ErrClaimConflict) {
 		t.Fatalf("bindVolumePortal() error = %v, want ErrClaimConflict", err)
+	}
+}
+
+func TestBindVolumePortalRetriesWhilePortalPublicationIsPending(t *testing.T) {
+	var bindCalls int
+	ctld := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/volume-portals/bind" {
+			http.NotFound(w, r)
+			return
+		}
+		bindCalls++
+		w.Header().Set("Content-Type", "application/json")
+		if bindCalls < 3 {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(ctldapi.BindVolumePortalResponse{
+				Error: "volume portal data for pod pod-uid is not published",
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(ctldapi.BindVolumePortalResponse{
+			SandboxVolumeID: "vol-1",
+			MountPoint:      "/workspace/data",
+		})
+	}))
+	defer ctld.Close()
+
+	ctldURL, err := url.Parse(ctld.URL)
+	if err != nil {
+		t.Fatalf("parse ctld url: %v", err)
+	}
+	ctldPort, err := strconv.Atoi(ctldURL.Port())
+	if err != nil {
+		t.Fatalf("parse ctld port: %v", err)
+	}
+
+	client := fake.NewSimpleClientset(&corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-a"},
+		Status: corev1.NodeStatus{
+			Addresses: []corev1.NodeAddress{{
+				Type:    corev1.NodeInternalIP,
+				Address: ctldURL.Hostname(),
+			}},
+		},
+	})
+	svc := &SandboxService{
+		k8sClient:  client,
+		ctldClient: NewCtldClient(CtldClientConfig{Timeout: time.Second}),
+		config:     SandboxServiceConfig{CtldPort: ctldPort},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "sandbox-a", Namespace: "team-a", UID: "pod-uid"},
+		Spec:       corev1.PodSpec{NodeName: "node-a"},
+	}
+
+	resp, err := svc.bindVolumePortal(context.Background(), pod, "team-a", "user-a", "team-a", "vol-1", "/workspace/data", "data")
+	if err != nil {
+		t.Fatalf("bindVolumePortal() error = %v", err)
+	}
+	if resp == nil || resp.SandboxVolumeID != "vol-1" {
+		t.Fatalf("bindVolumePortal() response = %+v, want bound vol-1", resp)
+	}
+	if bindCalls != 3 {
+		t.Fatalf("bind calls = %d, want 3", bindCalls)
 	}
 }
 

--- a/manager/pkg/service/sandbox_webhook_state.go
+++ b/manager/pkg/service/sandbox_webhook_state.go
@@ -42,7 +42,22 @@ type SandboxVolumeMetadataClient interface {
 }
 
 type SandboxVolumePortalPreparationClient interface {
-	PrepareForVolumePortalBind(ctx context.Context, teamID, userID, volumeID string) error
+	PrepareForVolumePortalBind(ctx context.Context, req PrepareVolumePortalBindRequest) error
+}
+
+type PrepareVolumePortalBindRequest struct {
+	TeamID          string `json:"team_id"`
+	UserID          string `json:"user_id"`
+	VolumeID        string `json:"volume_id"`
+	TargetClusterID string `json:"target_cluster_id"`
+	TargetCtldAddr  string `json:"target_ctld_addr"`
+	Namespace       string `json:"namespace"`
+	PodName         string `json:"pod_name"`
+	PodUID          string `json:"pod_uid"`
+	PortalName      string `json:"portal_name"`
+	MountPath       string `json:"mount_path"`
+	SandboxID       string `json:"sandbox_id"`
+	OwnerTeamID     string `json:"owner_team_id"`
 }
 
 type StorageProxyVolumeClient struct {
@@ -194,25 +209,33 @@ func (c *StorageProxyVolumeClient) Get(ctx context.Context, teamID, userID, volu
 	return volume, nil
 }
 
-func (c *StorageProxyVolumeClient) PrepareForVolumePortalBind(ctx context.Context, teamID, userID, volumeID string) error {
+func (c *StorageProxyVolumeClient) PrepareForVolumePortalBind(ctx context.Context, req PrepareVolumePortalBindRequest) error {
 	if c == nil || c.baseURL == "" {
 		return fmt.Errorf("storage-proxy volume client is not configured")
 	}
-	volumeID = strings.TrimSpace(volumeID)
+	volumeID := strings.TrimSpace(req.VolumeID)
 	if volumeID == "" {
 		return fmt.Errorf("volume id is required")
 	}
-	token, err := c.generateToken(teamID, userID, "")
+	if req.TargetClusterID == "" {
+		req.TargetClusterID = c.clusterID
+	}
+	token, err := c.generateToken(req.TeamID, req.UserID, "")
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, c.baseURL+"/internal/v1/sandboxvolumes/"+url.PathEscape(volumeID)+"/prepare-portal-bind", nil)
+	payload, err := json.Marshal(req)
 	if err != nil {
 		return err
 	}
-	req.Header.Set("X-Internal-Token", token)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPut, c.baseURL+"/internal/v1/sandboxvolumes/"+url.PathEscape(volumeID)+"/prepare-portal-bind", bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("X-Internal-Token", token)
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
 		return fmt.Errorf("prepare sandbox volume for portal bind: %w", err)
 	}

--- a/manager/pkg/service/sandbox_webhook_state_test.go
+++ b/manager/pkg/service/sandbox_webhook_state_test.go
@@ -48,10 +48,14 @@ func TestStorageProxyVolumeClientDefaultsClusterID(t *testing.T) {
 
 func TestStorageProxyVolumeClientPrepareForPortalBind(t *testing.T) {
 	var gotMethod, gotPath, gotToken string
+	var gotReq PrepareVolumePortalBindRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotMethod = r.Method
 		gotPath = r.URL.Path
 		gotToken = r.Header.Get("X-Internal-Token")
+		if err := json.NewDecoder(r.Body).Decode(&gotReq); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
 		_ = spec.WriteSuccess(w, http.StatusOK, map[string]any{"prepared": true})
 	}))
 	defer server.Close()
@@ -60,7 +64,14 @@ func TestStorageProxyVolumeClientPrepareForPortalBind(t *testing.T) {
 		BaseURL:        server.URL,
 		TokenGenerator: staticTokenGenerator{},
 	})
-	if err := client.PrepareForVolumePortalBind(t.Context(), "team-1", "user-1", "vol-1"); err != nil {
+	if err := client.PrepareForVolumePortalBind(t.Context(), PrepareVolumePortalBindRequest{
+		TeamID:         "team-1",
+		UserID:         "user-1",
+		VolumeID:       "vol-1",
+		TargetCtldAddr: "http://10.0.0.1:8095",
+		PodUID:         "pod-uid",
+		MountPath:      "/workspace",
+	}); err != nil {
 		t.Fatalf("PrepareForVolumePortalBind() error = %v", err)
 	}
 	if gotMethod != http.MethodPut {
@@ -71,6 +82,12 @@ func TestStorageProxyVolumeClientPrepareForPortalBind(t *testing.T) {
 	}
 	if gotToken == "" {
 		t.Fatal("expected internal token header to be set")
+	}
+	if gotReq.TargetCtldAddr != "http://10.0.0.1:8095" {
+		t.Fatalf("targetCtldAddr = %q, want %q", gotReq.TargetCtldAddr, "http://10.0.0.1:8095")
+	}
+	if gotReq.PodUID != "pod-uid" {
+		t.Fatalf("podUID = %q, want %q", gotReq.PodUID, "pod-uid")
 	}
 }
 
@@ -84,7 +101,11 @@ func TestStorageProxyVolumeClientPrepareForPortalBindConflict(t *testing.T) {
 		BaseURL:        server.URL,
 		TokenGenerator: staticTokenGenerator{},
 	})
-	err := client.PrepareForVolumePortalBind(t.Context(), "team-1", "user-1", "vol-1")
+	err := client.PrepareForVolumePortalBind(t.Context(), PrepareVolumePortalBindRequest{
+		TeamID:   "team-1",
+		UserID:   "user-1",
+		VolumeID: "vol-1",
+	})
 	if err == nil {
 		t.Fatal("PrepareForVolumePortalBind() error = nil, want conflict")
 	}

--- a/pkg/ctldapi/types.go
+++ b/pkg/ctldapi/types.go
@@ -36,14 +36,16 @@ type ProbeResponse = sandboxprobe.Response
 // BindVolumePortalRequest binds one pre-published pod portal to a concrete
 // sandbox volume at claim time.
 type BindVolumePortalRequest struct {
-	Namespace       string `json:"namespace"`
-	PodName         string `json:"pod_name"`
-	PodUID          string `json:"pod_uid"`
-	PortalName      string `json:"portal_name,omitempty"`
-	MountPath       string `json:"mount_path"`
-	SandboxID       string `json:"sandbox_id"`
-	TeamID          string `json:"team_id"`
-	SandboxVolumeID string `json:"sandboxvolume_id"`
+	Namespace               string `json:"namespace"`
+	PodName                 string `json:"pod_name"`
+	PodUID                  string `json:"pod_uid"`
+	PortalName              string `json:"portal_name,omitempty"`
+	MountPath               string `json:"mount_path"`
+	SandboxID               string `json:"sandbox_id"`
+	TeamID                  string `json:"team_id"`
+	SandboxVolumeID         string `json:"sandboxvolume_id"`
+	TransferSourceClusterID string `json:"transfer_source_cluster_id,omitempty"`
+	TransferSourcePodID     string `json:"transfer_source_pod_id,omitempty"`
 }
 
 // BindVolumePortalResponse describes the node-local mount session created by ctld.
@@ -67,4 +69,41 @@ type UnbindVolumePortalRequest struct {
 type UnbindVolumePortalResponse struct {
 	Unbound bool   `json:"unbound"`
 	Error   string `json:"error,omitempty"`
+}
+
+type PrepareVolumePortalHandoffRequest struct {
+	SandboxVolumeID string `json:"sandboxvolume_id"`
+}
+
+type PrepareVolumePortalHandoffResponse struct {
+	Prepared bool   `json:"prepared"`
+	Error    string `json:"error,omitempty"`
+}
+
+type CompleteVolumePortalHandoffRequest struct {
+	SandboxVolumeID string `json:"sandboxvolume_id"`
+}
+
+type CompleteVolumePortalHandoffResponse struct {
+	Completed bool   `json:"completed"`
+	Error     string `json:"error,omitempty"`
+}
+
+type AbortVolumePortalHandoffRequest struct {
+	SandboxVolumeID string `json:"sandboxvolume_id"`
+}
+
+type AbortVolumePortalHandoffResponse struct {
+	Aborted bool   `json:"aborted"`
+	Error   string `json:"error,omitempty"`
+}
+
+type AttachVolumeOwnerRequest struct {
+	TeamID          string `json:"team_id"`
+	SandboxVolumeID string `json:"sandboxvolume_id"`
+}
+
+type AttachVolumeOwnerResponse struct {
+	Attached bool   `json:"attached"`
+	Error    string `json:"error,omitempty"`
 }

--- a/pkg/framework/kubectl.go
+++ b/pkg/framework/kubectl.go
@@ -275,7 +275,7 @@ type namespaceStatus struct {
 	Phase string `json:"phase"`
 }
 
-// KubectlWaitForNamespacesDeletedByLabel waits for all namespaces matching a label selector to disappear.
+// KubectlWaitForNamespacesDeletedByLabel waits for matching namespaces that are already terminating to disappear.
 func KubectlWaitForNamespacesDeletedByLabel(ctx context.Context, kubeconfig, labelSelector, timeout string) error {
 	if labelSelector == "" {
 		return fmt.Errorf("label selector is required")
@@ -297,18 +297,24 @@ func KubectlWaitForNamespacesDeletedByLabel(ctx context.Context, kubeconfig, lab
 		if err := json.Unmarshal([]byte(output), &namespaces); err != nil {
 			return fmt.Errorf("decode namespaces for selector %q: %w", labelSelector, err)
 		}
-		if len(namespaces.Items) == 0 {
+		terminating := make([]namespace, 0, len(namespaces.Items))
+		for _, item := range namespaces.Items {
+			if strings.EqualFold(strings.TrimSpace(item.Status.Phase), "Terminating") {
+				terminating = append(terminating, item)
+			}
+		}
+		if len(terminating) == 0 {
 			return nil
 		}
 
-		names := make([]string, 0, len(namespaces.Items))
-		for _, item := range namespaces.Items {
+		names := make([]string, 0, len(terminating))
+		for _, item := range terminating {
 			names = append(names, fmt.Sprintf("%s(%s)", item.Metadata.Name, item.Status.Phase))
 		}
-		fmt.Printf("Namespaces still present for selector %q: %s\n", labelSelector, strings.Join(names, ", "))
+		fmt.Printf("Namespaces still terminating for selector %q: %s\n", labelSelector, strings.Join(names, ", "))
 
 		if time.Now().After(deadline) {
-			return fmt.Errorf("timeout waiting for namespaces with selector %q to be deleted", labelSelector)
+			return fmt.Errorf("timeout waiting for terminating namespaces with selector %q to be deleted", labelSelector)
 		}
 		time.Sleep(2 * time.Second)
 	}

--- a/pkg/framework/kubectl.go
+++ b/pkg/framework/kubectl.go
@@ -258,6 +258,62 @@ type podStatus struct {
 	InitContainerStatuses []containerStatus `json:"initContainerStatuses"`
 }
 
+type namespaceList struct {
+	Items []namespace `json:"items"`
+}
+
+type namespace struct {
+	Metadata namespaceMetadata `json:"metadata"`
+	Status   namespaceStatus   `json:"status"`
+}
+
+type namespaceMetadata struct {
+	Name string `json:"name"`
+}
+
+type namespaceStatus struct {
+	Phase string `json:"phase"`
+}
+
+// KubectlWaitForNamespacesDeletedByLabel waits for all namespaces matching a label selector to disappear.
+func KubectlWaitForNamespacesDeletedByLabel(ctx context.Context, kubeconfig, labelSelector, timeout string) error {
+	if labelSelector == "" {
+		return fmt.Errorf("label selector is required")
+	}
+
+	timeoutDuration, err := time.ParseDuration(timeout)
+	if err != nil {
+		return fmt.Errorf("parse timeout %q: %w", timeout, err)
+	}
+
+	deadline := time.Now().Add(timeoutDuration)
+	for {
+		output, err := KubectlOutput(ctx, kubeconfig, "get", "namespaces", "-l", labelSelector, "-o", "json")
+		if err != nil {
+			return err
+		}
+
+		var namespaces namespaceList
+		if err := json.Unmarshal([]byte(output), &namespaces); err != nil {
+			return fmt.Errorf("decode namespaces for selector %q: %w", labelSelector, err)
+		}
+		if len(namespaces.Items) == 0 {
+			return nil
+		}
+
+		names := make([]string, 0, len(namespaces.Items))
+		for _, item := range namespaces.Items {
+			names = append(names, fmt.Sprintf("%s(%s)", item.Metadata.Name, item.Status.Phase))
+		}
+		fmt.Printf("Namespaces still present for selector %q: %s\n", labelSelector, strings.Join(names, ", "))
+
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timeout waiting for namespaces with selector %q to be deleted", labelSelector)
+		}
+		time.Sleep(2 * time.Second)
+	}
+}
+
 type containerStatus struct {
 	Name      string         `json:"name"`
 	State     containerState `json:"state"`

--- a/pkg/framework/setup.go
+++ b/pkg/framework/setup.go
@@ -6,6 +6,8 @@ import (
 	"time"
 )
 
+const managerOwnedNamespaceLabelSelector = "app.kubernetes.io/managed-by=sandbox0-manager"
+
 // SetupScenario provisions a cluster, installs the operator, and applies a sample manifest.
 func SetupScenario(cfg Config, scenario Scenario) (*ScenarioEnv, func(), error) {
 	workingCfg := cfg
@@ -120,6 +122,7 @@ func SetupScenario(cfg Config, scenario Scenario) (*ScenarioEnv, func(), error) 
 	}
 	appendCleanup(func() {
 		_ = KubectlDeleteManifest(testCtx.Context, workingCfg.Kubeconfig, scenario.ManifestPath)
+		_ = KubectlWaitForNamespacesDeletedByLabel(testCtx.Context, workingCfg.Kubeconfig, managerOwnedNamespaceLabelSelector, "2m")
 	})
 
 	return env, cleanup, nil

--- a/storage-proxy/migrations/00012_add_volume_handoffs.sql
+++ b/storage-proxy/migrations/00012_add_volume_handoffs.sql
@@ -1,0 +1,27 @@
+-- +goose Up
+CREATE TABLE IF NOT EXISTS sandbox_volume_handoffs (
+    volume_id TEXT PRIMARY KEY REFERENCES sandbox_volumes(id) ON DELETE CASCADE,
+    source_cluster_id TEXT NOT NULL,
+    source_pod_id TEXT NOT NULL,
+    target_cluster_id TEXT NOT NULL,
+    target_pod_id TEXT NOT NULL,
+    target_ctld_addr TEXT NOT NULL,
+    status TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    expires_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_sandbox_volume_handoffs_expires_at
+    ON sandbox_volume_handoffs(expires_at);
+
+DROP TRIGGER IF EXISTS update_sandbox_volume_handoffs_updated_at ON sandbox_volume_handoffs;
+CREATE TRIGGER update_sandbox_volume_handoffs_updated_at
+    BEFORE UPDATE ON sandbox_volume_handoffs
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+-- +goose Down
+DROP TRIGGER IF EXISTS update_sandbox_volume_handoffs_updated_at ON sandbox_volume_handoffs;
+DROP INDEX IF EXISTS idx_sandbox_volume_handoffs_expires_at;
+DROP TABLE IF EXISTS sandbox_volume_handoffs;

--- a/storage-proxy/pkg/db/models.go
+++ b/storage-proxy/pkg/db/models.go
@@ -89,6 +89,19 @@ type VolumeMount struct {
 	MountOptions  *json.RawMessage `json:"mount_options,omitempty"`
 }
 
+type VolumeHandoff struct {
+	VolumeID        string    `json:"volume_id"`
+	SourceClusterID string    `json:"source_cluster_id"`
+	SourcePodID     string    `json:"source_pod_id"`
+	TargetClusterID string    `json:"target_cluster_id"`
+	TargetPodID     string    `json:"target_pod_id"`
+	TargetCtldAddr  string    `json:"target_ctld_addr"`
+	Status          string    `json:"status"`
+	CreatedAt       time.Time `json:"created_at"`
+	UpdatedAt       time.Time `json:"updated_at"`
+	ExpiresAt       time.Time `json:"expires_at"`
+}
+
 // SnapshotCoordination tracks the state of a snapshot creation across clusters
 type SnapshotCoordination struct {
 	ID       string `json:"id"`

--- a/storage-proxy/pkg/db/repository.go
+++ b/storage-proxy/pkg/db/repository.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
@@ -763,6 +764,58 @@ func (r *Repository) DeleteMountByPodID(ctx context.Context, clusterID, podID st
 	return nil
 }
 
+func (r *Repository) TransferMount(ctx context.Context, volumeID, sourceClusterID, sourcePodID string, target *VolumeMount, heartbeatTimeout int) error {
+	if target == nil {
+		return fmt.Errorf("target mount is required")
+	}
+	if heartbeatTimeout <= 0 {
+		heartbeatTimeout = 15
+	}
+	if strings.TrimSpace(volumeID) == "" || strings.TrimSpace(sourceClusterID) == "" || strings.TrimSpace(sourcePodID) == "" {
+		return fmt.Errorf("volume id and source mount identity are required")
+	}
+	if strings.TrimSpace(target.ClusterID) == "" || strings.TrimSpace(target.PodID) == "" {
+		return fmt.Errorf("target mount cluster_id and pod_id are required")
+	}
+	return r.WithTx(ctx, func(tx pgx.Tx) error {
+		var accessMode string
+		if err := tx.QueryRow(ctx, `SELECT access_mode FROM sandbox_volumes WHERE id = $1 FOR UPDATE`, volumeID).Scan(&accessMode); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return ErrNotFound
+			}
+			return fmt.Errorf("lock sandbox volume: %w", err)
+		}
+		if normalizeMountAccessMode(accessMode) != "RWO" {
+			return fmt.Errorf("%w: transfer mount only supports RWO volumes", ErrConflict)
+		}
+		activeMounts, err := r.getActiveMounts(ctx, tx, volumeID, heartbeatTimeout)
+		if err != nil {
+			return err
+		}
+		foundSource := false
+		for _, active := range activeMounts {
+			if active.ClusterID == sourceClusterID && active.PodID == sourcePodID {
+				foundSource = true
+				continue
+			}
+			if active.ClusterID == target.ClusterID && active.PodID == target.PodID {
+				continue
+			}
+			return fmt.Errorf("%w: volume %s already mounted on another instance", ErrConflict, volumeID)
+		}
+		if !foundSource {
+			return ErrConflict
+		}
+		if _, err := tx.Exec(ctx, `
+			DELETE FROM sandbox_volume_mounts
+			WHERE volume_id = $1 AND cluster_id = $2 AND pod_id = $3
+		`, volumeID, sourceClusterID, sourcePodID); err != nil {
+			return fmt.Errorf("delete source mount: %w", err)
+		}
+		return r.createMount(ctx, tx, target)
+	})
+}
+
 // GetActiveMounts retrieves active mounts for a volume (heartbeat within threshold)
 func (r *Repository) GetActiveMounts(ctx context.Context, volumeID string, heartbeatTimeout int) ([]*VolumeMount, error) {
 	return r.getActiveMounts(ctx, r.pool, volumeID, heartbeatTimeout)
@@ -826,6 +879,89 @@ func (r *Repository) GetAllMounts(ctx context.Context) ([]*VolumeMount, error) {
 	}
 
 	return mounts, nil
+}
+
+func (r *Repository) UpsertVolumeHandoff(ctx context.Context, handoff *VolumeHandoff) error {
+	if handoff == nil {
+		return fmt.Errorf("handoff is required")
+	}
+	if strings.TrimSpace(handoff.VolumeID) == "" {
+		return fmt.Errorf("handoff volume_id is required")
+	}
+	if handoff.ExpiresAt.IsZero() {
+		handoff.ExpiresAt = time.Now().UTC().Add(30 * time.Second)
+	}
+	_, err := r.pool.Exec(ctx, `
+		INSERT INTO sandbox_volume_handoffs (
+			volume_id, source_cluster_id, source_pod_id, target_cluster_id, target_pod_id,
+			target_ctld_addr, status, created_at, updated_at, expires_at
+		) VALUES (
+			$1, $2, $3, $4, $5,
+			$6, $7, COALESCE($8, NOW()), COALESCE($9, NOW()), $10
+		)
+		ON CONFLICT (volume_id)
+		DO UPDATE SET
+			source_cluster_id = EXCLUDED.source_cluster_id,
+			source_pod_id = EXCLUDED.source_pod_id,
+			target_cluster_id = EXCLUDED.target_cluster_id,
+			target_pod_id = EXCLUDED.target_pod_id,
+			target_ctld_addr = EXCLUDED.target_ctld_addr,
+			status = EXCLUDED.status,
+			expires_at = EXCLUDED.expires_at,
+			updated_at = NOW()
+	`, handoff.VolumeID, handoff.SourceClusterID, handoff.SourcePodID, handoff.TargetClusterID, handoff.TargetPodID, handoff.TargetCtldAddr, handoff.Status, nullTime(handoff.CreatedAt), nullTime(handoff.UpdatedAt), handoff.ExpiresAt)
+	if err != nil {
+		return fmt.Errorf("upsert volume handoff: %w", err)
+	}
+	return nil
+}
+
+func (r *Repository) GetVolumeHandoff(ctx context.Context, volumeID string) (*VolumeHandoff, error) {
+	var handoff VolumeHandoff
+	err := r.pool.QueryRow(ctx, `
+		SELECT
+			volume_id, source_cluster_id, source_pod_id, target_cluster_id, target_pod_id,
+			target_ctld_addr, status, created_at, updated_at, expires_at
+		FROM sandbox_volume_handoffs
+		WHERE volume_id = $1
+	`, volumeID).Scan(
+		&handoff.VolumeID,
+		&handoff.SourceClusterID,
+		&handoff.SourcePodID,
+		&handoff.TargetClusterID,
+		&handoff.TargetPodID,
+		&handoff.TargetCtldAddr,
+		&handoff.Status,
+		&handoff.CreatedAt,
+		&handoff.UpdatedAt,
+		&handoff.ExpiresAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get volume handoff: %w", err)
+	}
+	return &handoff, nil
+}
+
+func (r *Repository) DeleteVolumeHandoff(ctx context.Context, volumeID string) error {
+	if strings.TrimSpace(volumeID) == "" {
+		return fmt.Errorf("volume id is required")
+	}
+	if _, err := r.pool.Exec(ctx, `
+		DELETE FROM sandbox_volume_handoffs WHERE volume_id = $1
+	`, volumeID); err != nil {
+		return fmt.Errorf("delete volume handoff: %w", err)
+	}
+	return nil
+}
+
+func nullTime(value time.Time) any {
+	if value.IsZero() {
+		return nil
+	}
+	return value
 }
 
 // DeleteStaleMounts deletes mounts with expired heartbeats

--- a/storage-proxy/pkg/http/ctld_owner.go
+++ b/storage-proxy/pkg/http/ctld_owner.go
@@ -1,0 +1,118 @@
+package http
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volume"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const defaultCtldPort = 8095
+
+type volumeCtldResolver interface {
+	ResolveLocalCtldURL(ctx context.Context) (string, error)
+}
+
+type kubernetesVolumeCtldResolver struct {
+	client    kubernetes.Interface
+	selfPodID string
+	port      int
+}
+
+func newKubernetesVolumeCtldResolver(client kubernetes.Interface, selfPodID string) volumeCtldResolver {
+	if client == nil || strings.TrimSpace(selfPodID) == "" {
+		return nil
+	}
+	return &kubernetesVolumeCtldResolver{
+		client:    client,
+		selfPodID: strings.TrimSpace(selfPodID),
+		port:      defaultCtldPort,
+	}
+}
+
+func (r *kubernetesVolumeCtldResolver) ResolveLocalCtldURL(ctx context.Context) (string, error) {
+	if r == nil || r.client == nil {
+		return "", fmt.Errorf("ctld resolver unavailable")
+	}
+	pod, err := resolveKubernetesPod(ctx, r.client, r.selfPodID)
+	if err != nil {
+		return "", err
+	}
+	if pod == nil || pod.Spec.NodeName == "" {
+		return "", fmt.Errorf("storage-proxy pod %q is not scheduled", r.selfPodID)
+	}
+	node, err := r.client.CoreV1().Nodes().Get(ctx, pod.Spec.NodeName, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	for _, address := range node.Status.Addresses {
+		if address.Type == corev1.NodeInternalIP && strings.TrimSpace(address.Address) != "" {
+			return fmt.Sprintf("http://%s:%d", address.Address, r.port), nil
+		}
+	}
+	return "", fmt.Errorf("node %s has no internal ip", node.Name)
+}
+
+func resolveKubernetesPod(ctx context.Context, client kubernetes.Interface, podID string) (*corev1.Pod, error) {
+	if client == nil || strings.TrimSpace(podID) == "" {
+		return nil, fmt.Errorf("pod resolver unavailable")
+	}
+	if strings.Contains(podID, "/") {
+		parts := strings.SplitN(podID, "/", 2)
+		return client.CoreV1().Pods(parts[0]).Get(ctx, parts[1], metav1.GetOptions{})
+	}
+	pods, err := client.CoreV1().Pods("").List(ctx, metav1.ListOptions{
+		FieldSelector: "metadata.name=" + podID,
+		Limit:         2,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(pods.Items) == 0 {
+		return nil, fmt.Errorf("pod %q not found", podID)
+	}
+	return &pods.Items[0], nil
+}
+
+func (s *Server) ensureCtldVolumeOwner(ctx context.Context, volumeRecord *db.SandboxVolume) error {
+	if s == nil || s.repo == nil || s.ctldResolver == nil || volumeRecord == nil {
+		return nil
+	}
+	if volume.NormalizeAccessMode(volumeRecord.AccessMode) != volume.AccessModeRWO {
+		return nil
+	}
+
+	heartbeatTimeout := 15
+	if s.cfg != nil && s.cfg.HeartbeatTimeout > 0 {
+		heartbeatTimeout = s.cfg.HeartbeatTimeout
+	}
+	mounts, err := s.repo.GetActiveMounts(ctx, volumeRecord.ID, heartbeatTimeout)
+	if err != nil {
+		return err
+	}
+	if owner := s.selectPreferredVolumeOwner(mounts); owner != nil {
+		return nil
+	}
+
+	ctldAddr, err := s.ctldResolver.ResolveLocalCtldURL(ctx)
+	if err != nil {
+		return err
+	}
+	if _, err := postCtldJSON[ctldapi.AttachVolumeOwnerResponse](ctx, ctldAddr, "/api/v1/volume-portals/owners/attach", ctldapi.AttachVolumeOwnerRequest{
+		TeamID:          volumeRecord.TeamID,
+		SandboxVolumeID: volumeRecord.ID,
+	}); err != nil {
+		mounts, reloadErr := s.repo.GetActiveMounts(ctx, volumeRecord.ID, heartbeatTimeout)
+		if reloadErr == nil && s.selectPreferredVolumeOwner(mounts) != nil {
+			return nil
+		}
+		return err
+	}
+	return nil
+}

--- a/storage-proxy/pkg/http/handlers_metering_test.go
+++ b/storage-proxy/pkg/http/handlers_metering_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -20,9 +21,11 @@ import (
 )
 
 type fakeHTTPRepo struct {
+	mu             sync.RWMutex
 	volumes        map[string]*db.SandboxVolume
 	owners         map[string]*db.SandboxVolumeOwner
 	activeMounts   map[string][]*db.VolumeMount
+	handoffs       map[string]*db.VolumeHandoff
 	getActiveFunc  func(context.Context, string, int) ([]*db.VolumeMount, error)
 	deletedMounts  []db.VolumeMount
 	createdVolumes []*db.SandboxVolume
@@ -34,6 +37,7 @@ func newFakeHTTPRepo() *fakeHTTPRepo {
 		volumes:      make(map[string]*db.SandboxVolume),
 		owners:       make(map[string]*db.SandboxVolumeOwner),
 		activeMounts: make(map[string][]*db.VolumeMount),
+		handoffs:     make(map[string]*db.VolumeHandoff),
 	}
 }
 
@@ -122,6 +126,50 @@ func (r *fakeHTTPRepo) DeleteMount(ctx context.Context, volumeID, clusterID, pod
 		ClusterID: clusterID,
 		PodID:     podID,
 	})
+	return nil
+}
+
+func (r *fakeHTTPRepo) TransferMount(ctx context.Context, volumeID, sourceClusterID, sourcePodID string, target *db.VolumeMount, heartbeatTimeout int) error {
+	var mounts []*db.VolumeMount
+	for _, mount := range r.activeMounts[volumeID] {
+		if mount.ClusterID == sourceClusterID && mount.PodID == sourcePodID {
+			continue
+		}
+		mounts = append(mounts, mount)
+	}
+	if target != nil {
+		mounts = append(mounts, target)
+	}
+	r.activeMounts[volumeID] = mounts
+	return nil
+}
+
+func (r *fakeHTTPRepo) UpsertVolumeHandoff(ctx context.Context, handoff *db.VolumeHandoff) error {
+	if handoff == nil {
+		return nil
+	}
+	copy := *handoff
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.handoffs[handoff.VolumeID] = &copy
+	return nil
+}
+
+func (r *fakeHTTPRepo) GetVolumeHandoff(ctx context.Context, volumeID string) (*db.VolumeHandoff, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	handoff := r.handoffs[volumeID]
+	if handoff == nil {
+		return nil, db.ErrNotFound
+	}
+	copy := *handoff
+	return &copy, nil
+}
+
+func (r *fakeHTTPRepo) DeleteVolumeHandoff(ctx context.Context, volumeID string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.handoffs, volumeID)
 	return nil
 }
 

--- a/storage-proxy/pkg/http/handlers_sandboxvolume.go
+++ b/storage-proxy/pkg/http/handlers_sandboxvolume.go
@@ -635,33 +635,83 @@ func (s *Server) prepareSandboxVolumeForPortalBind(w http.ResponseWriter, r *htt
 		return
 	}
 
-	cleaned := false
-	if s.volMgr != nil {
-		cleaned, err = s.volMgr.CleanupIdleDirectVolumeFileMount(r.Context(), id)
-		if err != nil {
-			s.logger.WithError(err).WithField("volume_id", id).Warn("Failed to cleanup direct volume mount before portal bind")
-			_ = spec.WriteError(w, http.StatusInternalServerError, spec.CodeInternal, "failed to cleanup direct volume mount")
-			return
-		}
+	var req preparePortalBindRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+		_ = spec.WriteError(w, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
+		return
 	}
-	if volume.NormalizeAccessMode(vol.AccessMode) == volume.AccessModeRWO {
-		const heartbeatTimeout = 15
-		mounts, err := s.repo.GetActiveMounts(r.Context(), id, heartbeatTimeout)
-		if err != nil {
-			s.logger.WithError(err).WithField("volume_id", id).Warn("Failed to check active mounts before portal bind")
-			_ = spec.WriteError(w, http.StatusInternalServerError, spec.CodeInternal, "failed to check active mounts")
-			return
-		}
-		if len(mounts) > 0 {
-			_ = spec.WriteError(w, http.StatusConflict, spec.CodeConflict, "volume has active mounts")
-			return
-		}
+	req.VolumeID = id
+	if req.OwnerTeamID == "" {
+		req.OwnerTeamID = vol.TeamID
 	}
 
-	_ = spec.WriteSuccess(w, http.StatusOK, map[string]any{
-		"prepared": true,
-		"cleaned":  cleaned,
-	})
+	run := func(runCtx context.Context) error {
+		cleaned := false
+		if s.volMgr != nil {
+			cleaned, err = s.volMgr.CleanupIdleDirectVolumeFileMount(runCtx, id)
+			if err != nil {
+				return fmt.Errorf("cleanup direct volume mount: %w", err)
+			}
+		}
+		if volume.NormalizeAccessMode(vol.AccessMode) != volume.AccessModeRWO {
+			_ = spec.WriteSuccess(w, http.StatusOK, map[string]any{
+				"prepared": true,
+				"cleaned":  cleaned,
+			})
+			return nil
+		}
+
+		const heartbeatTimeout = 15
+		mounts, err := s.repo.GetActiveMounts(runCtx, id, heartbeatTimeout)
+		if err != nil {
+			return fmt.Errorf("check active mounts: %w", err)
+		}
+		if len(mounts) == 0 {
+			_ = spec.WriteSuccess(w, http.StatusOK, map[string]any{
+				"prepared": true,
+				"cleaned":  cleaned,
+			})
+			return nil
+		}
+
+		source := s.selectPreferredVolumeOwner(mounts)
+		if source == nil {
+			return fmt.Errorf("%w: volume has active mounts", db.ErrConflict)
+		}
+		opts := volume.DecodeMountOptions(source.MountOptions)
+		if opts.OwnerKind != volume.OwnerKindCtld {
+			return fmt.Errorf("%w: volume has active mounts", db.ErrConflict)
+		}
+		if strings.TrimSpace(req.TargetCtldAddr) == "" {
+			return fmt.Errorf("%w: target ctld address is required for owner handoff", db.ErrConflict)
+		}
+		if err := s.executePortalBindHandoff(runCtx, vol, source, req); err != nil {
+			return err
+		}
+		_ = spec.WriteSuccess(w, http.StatusOK, map[string]any{
+			"prepared": true,
+			"cleaned":  cleaned,
+			"handoff":  true,
+		})
+		return nil
+	}
+
+	if s.barrier != nil {
+		err = s.barrier.WithExclusive(r.Context(), id, run)
+	} else {
+		err = run(r.Context())
+	}
+	if err == nil {
+		return
+	}
+	status := http.StatusInternalServerError
+	code := spec.CodeInternal
+	if errors.Is(err, db.ErrConflict) {
+		status = http.StatusConflict
+		code = spec.CodeConflict
+	}
+	s.logger.WithError(err).WithField("volume_id", id).Warn("Failed to prepare sandbox volume for portal bind")
+	_ = spec.WriteError(w, status, code, err.Error())
 }
 
 func (s *Server) forkVolume(w http.ResponseWriter, r *http.Request) {

--- a/storage-proxy/pkg/http/handlers_sync_test.go
+++ b/storage-proxy/pkg/http/handlers_sync_test.go
@@ -182,6 +182,12 @@ type fakeHTTPVolumeMutationBarrier struct {
 	lastVolumeID string
 }
 
+func (f *fakeHTTPVolumeMutationBarrier) WithShared(ctx context.Context, volumeID string, fn func(context.Context) error) error {
+	f.calls++
+	f.lastVolumeID = volumeID
+	return fn(ctx)
+}
+
 func (f *fakeHTTPVolumeMutationBarrier) WithExclusive(ctx context.Context, volumeID string, fn func(context.Context) error) error {
 	f.calls++
 	f.lastVolumeID = volumeID

--- a/storage-proxy/pkg/http/handlers_volume_files.go
+++ b/storage-proxy/pkg/http/handlers_volume_files.go
@@ -122,6 +122,24 @@ func (s *Server) handleVolumeFileOperation(w http.ResponseWriter, r *http.Reques
 	}
 }
 
+func (s *Server) withSharedVolumeFileRequest(w http.ResponseWriter, r *http.Request, volumeID string, fn func(*http.Request)) bool {
+	if fn == nil {
+		return true
+	}
+	if s == nil || s.barrier == nil || strings.TrimSpace(volumeID) == "" {
+		fn(r)
+		return true
+	}
+	if err := s.barrier.WithShared(r.Context(), volumeID, func(ctx context.Context) error {
+		fn(r.WithContext(ctx))
+		return nil
+	}); err != nil {
+		s.writeVolumeFileError(w, err)
+		return false
+	}
+	return true
+}
+
 func (s *Server) handleVolumeFileStat(w http.ResponseWriter, r *http.Request) {
 	volumeID := r.PathValue("id")
 	if volumeID == "" {
@@ -134,27 +152,29 @@ func (s *Server) handleVolumeFileStat(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx, _, cleanup, handled := s.prepareOrProxyVolumeFileRequest(w, r, volumeID)
-	if handled {
-		return
-	}
-	defer cleanup()
+	s.withSharedVolumeFileRequest(w, r, volumeID, func(lockedReq *http.Request) {
+		ctx, _, cleanup, handled := s.prepareOrProxyVolumeFileRequest(w, lockedReq, volumeID)
+		if handled {
+			return
+		}
+		defer cleanup()
 
-	resolved, err := s.lookupVolumePath(ctx, volumeID, filePath, true)
-	if err != nil {
-		s.writeVolumeFileError(w, err)
-		return
-	}
-	if !resolved.Exists {
-		s.writeVolumeFileError(w, errFileNotFound)
-		return
-	}
+		resolved, err := s.lookupVolumePath(ctx, volumeID, filePath, true)
+		if err != nil {
+			s.writeVolumeFileError(w, err)
+			return
+		}
+		if !resolved.Exists {
+			s.writeVolumeFileError(w, errFileNotFound)
+			return
+		}
 
-	name := pathpkg.Base(resolved.Clean)
-	if resolved.Clean == "/" {
-		name = "/"
-	}
-	_ = spec.WriteSuccess(w, http.StatusOK, attrToVolumeFileInfo(name, resolved.Clean, resolved.Attr))
+		name := pathpkg.Base(resolved.Clean)
+		if resolved.Clean == "/" {
+			name = "/"
+		}
+		_ = spec.WriteSuccess(w, http.StatusOK, attrToVolumeFileInfo(name, resolved.Clean, resolved.Attr))
+	})
 }
 
 func (s *Server) handleVolumeFileList(w http.ResponseWriter, r *http.Request) {
@@ -169,56 +189,58 @@ func (s *Server) handleVolumeFileList(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx, _, cleanup, handled := s.prepareOrProxyVolumeFileRequest(w, r, volumeID)
-	if handled {
-		return
-	}
-	defer cleanup()
-
-	resolved, err := s.lookupVolumePath(ctx, volumeID, dirPath, true)
-	if err != nil {
-		s.writeVolumeFileError(w, err)
-		return
-	}
-	if !resolved.Exists {
-		s.writeVolumeFileError(w, errDirNotFound)
-		return
-	}
-	if !attrModeIsDir(resolved.Attr.Mode) {
-		s.writeVolumeFileError(w, errPathNotDir)
-		return
-	}
-
-	handleID, releaseDir, err := s.openVolumeDir(ctx, volumeID, resolved.Inode)
-	if err != nil {
-		s.writeVolumeFileError(w, err)
-		return
-	}
-	defer releaseDir()
-
-	dirResp, err := s.fileRPC.ReadDir(ctx, &pb.ReadDirRequest{
-		VolumeId: volumeID,
-		Inode:    resolved.Inode,
-		HandleId: handleID,
-		Size:     16384,
-		Plus:     true,
-		Actor:    volumeFileActor(ctx),
-	})
-	if err != nil {
-		s.writeVolumeFileError(w, translateVolumeRPCError(err))
-		return
-	}
-
-	entries := make([]*volumeFileInfo, 0, len(dirResp.Entries))
-	for _, entry := range dirResp.Entries {
-		if entry == nil || entry.Name == "" || entry.Name == "." || entry.Name == ".." {
-			continue
+	s.withSharedVolumeFileRequest(w, r, volumeID, func(lockedReq *http.Request) {
+		ctx, _, cleanup, handled := s.prepareOrProxyVolumeFileRequest(w, lockedReq, volumeID)
+		if handled {
+			return
 		}
-		entryPath := joinVolumePath(resolved.Clean, entry.Name)
-		entries = append(entries, attrToVolumeFileInfo(entry.Name, entryPath, entry.Attr))
-	}
+		defer cleanup()
 
-	_ = spec.WriteSuccess(w, http.StatusOK, map[string]any{"entries": entries})
+		resolved, err := s.lookupVolumePath(ctx, volumeID, dirPath, true)
+		if err != nil {
+			s.writeVolumeFileError(w, err)
+			return
+		}
+		if !resolved.Exists {
+			s.writeVolumeFileError(w, errDirNotFound)
+			return
+		}
+		if !attrModeIsDir(resolved.Attr.Mode) {
+			s.writeVolumeFileError(w, errPathNotDir)
+			return
+		}
+
+		handleID, releaseDir, err := s.openVolumeDir(ctx, volumeID, resolved.Inode)
+		if err != nil {
+			s.writeVolumeFileError(w, err)
+			return
+		}
+		defer releaseDir()
+
+		dirResp, err := s.fileRPC.ReadDir(ctx, &pb.ReadDirRequest{
+			VolumeId: volumeID,
+			Inode:    resolved.Inode,
+			HandleId: handleID,
+			Size:     16384,
+			Plus:     true,
+			Actor:    volumeFileActor(ctx),
+		})
+		if err != nil {
+			s.writeVolumeFileError(w, translateVolumeRPCError(err))
+			return
+		}
+
+		entries := make([]*volumeFileInfo, 0, len(dirResp.Entries))
+		for _, entry := range dirResp.Entries {
+			if entry == nil || entry.Name == "" || entry.Name == "." || entry.Name == ".." {
+				continue
+			}
+			entryPath := joinVolumePath(resolved.Clean, entry.Name)
+			entries = append(entries, attrToVolumeFileInfo(entry.Name, entryPath, entry.Attr))
+		}
+
+		_ = spec.WriteSuccess(w, http.StatusOK, map[string]any{"entries": entries})
+	})
 }
 
 func (s *Server) handleVolumeFileMove(w http.ResponseWriter, r *http.Request) {
@@ -228,32 +250,34 @@ func (s *Server) handleVolumeFileMove(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx, _, cleanup, handled := s.prepareOrProxyVolumeFileRequest(w, r, volumeID)
-	if handled {
-		return
-	}
-	defer cleanup()
+	s.withSharedVolumeFileRequest(w, r, volumeID, func(lockedReq *http.Request) {
+		ctx, _, cleanup, handled := s.prepareOrProxyVolumeFileRequest(w, lockedReq, volumeID)
+		if handled {
+			return
+		}
+		defer cleanup()
 
-	var req volumeFileMoveRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		_ = spec.WriteError(w, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
-		return
-	}
-	if req.Source == "" || req.Destination == "" {
-		_ = spec.WriteError(w, http.StatusBadRequest, spec.CodeBadRequest, "source and destination are required")
-		return
-	}
+		var req volumeFileMoveRequest
+		if err := json.NewDecoder(lockedReq.Body).Decode(&req); err != nil {
+			_ = spec.WriteError(w, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
+			return
+		}
+		if req.Source == "" || req.Destination == "" {
+			_ = spec.WriteError(w, http.StatusBadRequest, spec.CodeBadRequest, "source and destination are required")
+			return
+		}
 
-	if err := s.moveVolumePath(ctx, volumeID, req.Source, req.Destination); err != nil {
-		s.writeVolumeFileError(w, err)
-		return
-	}
-	if err := s.finalizeVolumeFileMutation(ctx, volumeID); err != nil {
-		s.writeVolumeFileError(w, err)
-		return
-	}
+		if err := s.moveVolumePath(ctx, volumeID, req.Source, req.Destination); err != nil {
+			s.writeVolumeFileError(w, err)
+			return
+		}
+		if err := s.finalizeVolumeFileMutation(ctx, volumeID); err != nil {
+			s.writeVolumeFileError(w, err)
+			return
+		}
 
-	_ = spec.WriteSuccess(w, http.StatusOK, map[string]bool{"moved": true})
+		_ = spec.WriteSuccess(w, http.StatusOK, map[string]bool{"moved": true})
+	})
 }
 
 func (s *Server) handleVolumeFileWatch(w http.ResponseWriter, r *http.Request) {
@@ -395,67 +419,95 @@ func (s *Server) handleVolumeFileWatch(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) readVolumeFile(w http.ResponseWriter, r *http.Request, volumeID, logicalPath string) {
-	ctx, _, cleanup, handled := s.prepareOrProxyVolumeFileRequest(w, r, volumeID)
-	if handled {
-		return
-	}
-	defer cleanup()
+	s.withSharedVolumeFileRequest(w, r, volumeID, func(lockedReq *http.Request) {
+		ctx, _, cleanup, handled := s.prepareOrProxyVolumeFileRequest(w, lockedReq, volumeID)
+		if handled {
+			return
+		}
+		defer cleanup()
 
-	resolved, err := s.lookupVolumePath(ctx, volumeID, logicalPath, false)
-	if err != nil {
-		s.writeVolumeFileError(w, err)
-		return
-	}
-	if !resolved.Exists {
-		s.writeVolumeFileError(w, errFileNotFound)
-		return
-	}
-	if attrModeIsDir(resolved.Attr.Mode) {
-		s.writeVolumeFileError(w, errPathNotDir)
-		return
-	}
+		resolved, err := s.lookupVolumePath(ctx, volumeID, logicalPath, false)
+		if err != nil {
+			s.writeVolumeFileError(w, err)
+			return
+		}
+		if !resolved.Exists {
+			s.writeVolumeFileError(w, errFileNotFound)
+			return
+		}
+		if attrModeIsDir(resolved.Attr.Mode) {
+			s.writeVolumeFileError(w, errPathNotDir)
+			return
+		}
 
-	handleID, releaseFile, err := s.openVolumeFile(ctx, volumeID, resolved.Inode, uint32(syscall.O_RDONLY))
-	if err != nil {
-		s.writeVolumeFileError(w, err)
-		return
-	}
-	defer releaseFile()
+		handleID, releaseFile, err := s.openVolumeFile(ctx, volumeID, resolved.Inode, uint32(syscall.O_RDONLY))
+		if err != nil {
+			s.writeVolumeFileError(w, err)
+			return
+		}
+		defer releaseFile()
 
-	readResp, err := s.fileRPC.Read(ctx, &pb.ReadRequest{
-		VolumeId: volumeID,
-		Inode:    resolved.Inode,
-		Offset:   0,
-		Size:     int64(resolved.Attr.Size),
-		HandleId: handleID,
-		Actor:    volumeFileActor(ctx),
-	})
-	if err != nil {
-		s.writeVolumeFileError(w, translateVolumeRPCError(err))
-		return
-	}
-
-	if acceptsVolumeFileJSON(r) {
-		_ = spec.WriteSuccess(w, http.StatusOK, map[string]string{
-			"content":  base64.StdEncoding.EncodeToString(readResp.Data),
-			"encoding": "base64",
+		readResp, err := s.fileRPC.Read(ctx, &pb.ReadRequest{
+			VolumeId: volumeID,
+			Inode:    resolved.Inode,
+			Offset:   0,
+			Size:     int64(resolved.Attr.Size),
+			HandleId: handleID,
+			Actor:    volumeFileActor(ctx),
 		})
-		return
-	}
+		if err != nil {
+			s.writeVolumeFileError(w, translateVolumeRPCError(err))
+			return
+		}
 
-	w.Header().Set("Content-Type", "application/octet-stream")
-	_, _ = w.Write(readResp.Data)
+		if acceptsVolumeFileJSON(lockedReq) {
+			_ = spec.WriteSuccess(w, http.StatusOK, map[string]string{
+				"content":  base64.StdEncoding.EncodeToString(readResp.Data),
+				"encoding": "base64",
+			})
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = w.Write(readResp.Data)
+	})
 }
 
 func (s *Server) writeVolumeFile(w http.ResponseWriter, r *http.Request, volumeID, logicalPath string) {
-	ctx, _, cleanup, handled := s.prepareOrProxyVolumeFileRequest(w, r, volumeID)
-	if handled {
-		return
-	}
-	defer cleanup()
+	s.withSharedVolumeFileRequest(w, r, volumeID, func(lockedReq *http.Request) {
+		ctx, _, cleanup, handled := s.prepareOrProxyVolumeFileRequest(w, lockedReq, volumeID)
+		if handled {
+			return
+		}
+		defer cleanup()
 
-	if r.URL.Query().Get("mkdir") == "true" {
-		changed, err := s.mkdirVolumePath(ctx, volumeID, logicalPath, r.URL.Query().Get("recursive") == "true")
+		if lockedReq.URL.Query().Get("mkdir") == "true" {
+			changed, err := s.mkdirVolumePath(ctx, volumeID, logicalPath, lockedReq.URL.Query().Get("recursive") == "true")
+			if err != nil {
+				s.writeVolumeFileError(w, err)
+				return
+			}
+			if changed {
+				if err := s.finalizeVolumeFileMutation(ctx, volumeID); err != nil {
+					s.writeVolumeFileError(w, err)
+					return
+				}
+			}
+			_ = spec.WriteSuccess(w, http.StatusCreated, map[string]bool{"created": true})
+			return
+		}
+
+		data, err := io.ReadAll(lockedReq.Body)
+		if err != nil {
+			_ = spec.WriteError(w, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
+			return
+		}
+		if len(data) > maxVolumeFileSize {
+			s.writeVolumeFileError(w, errFileTooLarge)
+			return
+		}
+
+		changed, err := s.writeVolumePath(ctx, volumeID, logicalPath, data)
 		if err != nil {
 			s.writeVolumeFileError(w, err)
 			return
@@ -466,59 +518,37 @@ func (s *Server) writeVolumeFile(w http.ResponseWriter, r *http.Request, volumeI
 				return
 			}
 		}
-		_ = spec.WriteSuccess(w, http.StatusCreated, map[string]bool{"created": true})
-		return
-	}
 
-	data, err := io.ReadAll(r.Body)
-	if err != nil {
-		_ = spec.WriteError(w, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
-		return
-	}
-	if len(data) > maxVolumeFileSize {
-		s.writeVolumeFileError(w, errFileTooLarge)
-		return
-	}
-
-	changed, err := s.writeVolumePath(ctx, volumeID, logicalPath, data)
-	if err != nil {
-		s.writeVolumeFileError(w, err)
-		return
-	}
-	if changed {
-		if err := s.finalizeVolumeFileMutation(ctx, volumeID); err != nil {
-			s.writeVolumeFileError(w, err)
-			return
-		}
-	}
-
-	_ = spec.WriteSuccess(w, http.StatusOK, map[string]bool{"written": true})
+		_ = spec.WriteSuccess(w, http.StatusOK, map[string]bool{"written": true})
+	})
 }
 
 func (s *Server) deleteVolumeFile(w http.ResponseWriter, r *http.Request, volumeID, logicalPath string) {
-	ctx, _, cleanup, handled := s.prepareOrProxyVolumeFileRequest(w, r, volumeID)
-	if handled {
-		return
-	}
-	defer cleanup()
+	s.withSharedVolumeFileRequest(w, r, volumeID, func(lockedReq *http.Request) {
+		ctx, _, cleanup, handled := s.prepareOrProxyVolumeFileRequest(w, lockedReq, volumeID)
+		if handled {
+			return
+		}
+		defer cleanup()
 
-	resolved, err := s.lookupVolumePath(ctx, volumeID, logicalPath, false)
-	if err != nil {
-		s.writeVolumeFileError(w, err)
-		return
-	}
-	if resolved.Exists {
-		if err := s.removeVolumePath(ctx, volumeID, resolved); err != nil {
+		resolved, err := s.lookupVolumePath(ctx, volumeID, logicalPath, false)
+		if err != nil {
 			s.writeVolumeFileError(w, err)
 			return
 		}
-		if err := s.finalizeVolumeFileMutation(ctx, volumeID); err != nil {
-			s.writeVolumeFileError(w, err)
-			return
+		if resolved.Exists {
+			if err := s.removeVolumePath(ctx, volumeID, resolved); err != nil {
+				s.writeVolumeFileError(w, err)
+				return
+			}
+			if err := s.finalizeVolumeFileMutation(ctx, volumeID); err != nil {
+				s.writeVolumeFileError(w, err)
+				return
+			}
 		}
-	}
 
-	_ = spec.WriteSuccess(w, http.StatusOK, map[string]bool{"deleted": true})
+		_ = spec.WriteSuccess(w, http.StatusOK, map[string]bool{"deleted": true})
+	})
 }
 
 func (s *Server) prepareVolumeFileRequest(ctx context.Context, volumeID string) (context.Context, *db.SandboxVolume, func(), error) {

--- a/storage-proxy/pkg/http/handlers_volume_files.go
+++ b/storage-proxy/pkg/http/handlers_volume_files.go
@@ -526,6 +526,9 @@ func (s *Server) prepareVolumeFileRequest(ctx context.Context, volumeID string) 
 	if err != nil {
 		return ctx, nil, func() {}, err
 	}
+	if err := s.ensureCtldVolumeOwner(ctx, volumeRecord); err != nil {
+		return ctx, nil, func() {}, err
+	}
 	actor, err := defaultVolumeFileActor(volumeRecord)
 	if err != nil {
 		return ctx, nil, func() {}, err

--- a/storage-proxy/pkg/http/handlers_volume_files_test.go
+++ b/storage-proxy/pkg/http/handlers_volume_files_test.go
@@ -44,6 +44,12 @@ type fakeVolumeFilePodResolver struct {
 	urls map[string]string
 }
 
+type fakeHTTPSharedVolumeBarrier struct {
+	sharedCalls    int
+	exclusiveCalls int
+	lastVolumeID   string
+}
+
 func mustMountOptionsRaw(t *testing.T, opts volume.MountOptions) *json.RawMessage {
 	t.Helper()
 	raw, err := json.Marshal(opts)
@@ -63,6 +69,18 @@ func (f *fakeVolumeFilePodResolver) ResolvePodURL(_ context.Context, podID strin
 		return nil, errors.New("pod not found")
 	}
 	return url.Parse(rawURL)
+}
+
+func (f *fakeHTTPSharedVolumeBarrier) WithShared(ctx context.Context, volumeID string, fn func(context.Context) error) error {
+	f.sharedCalls++
+	f.lastVolumeID = volumeID
+	return fn(ctx)
+}
+
+func (f *fakeHTTPSharedVolumeBarrier) WithExclusive(ctx context.Context, volumeID string, fn func(context.Context) error) error {
+	f.exclusiveCalls++
+	f.lastVolumeID = volumeID
+	return fn(ctx)
 }
 
 func (f *fakeHTTPVolumeMountManager) GetVolume(volumeID string) (*volume.VolumeContext, error) {
@@ -247,6 +265,10 @@ func (f *fakeHTTPVolumeFileRPC) Release(ctx context.Context, req *pb.ReleaseRequ
 }
 
 func newVolumeFileTestServer(fileRPC *fakeHTTPVolumeFileRPC) (*Server, *fakeHTTPVolumeMountManager) {
+	return newVolumeFileTestServerWithBarrier(fileRPC, nil)
+}
+
+func newVolumeFileTestServerWithBarrier(fileRPC *fakeHTTPVolumeFileRPC, barrier volumeMutationBarrier) (*Server, *fakeHTTPVolumeMountManager) {
 	repo := newFakeHTTPRepo()
 	defaultUID := int64(1000)
 	defaultGID := int64(1000)
@@ -261,6 +283,7 @@ func newVolumeFileTestServer(fileRPC *fakeHTTPVolumeFileRPC) (*Server, *fakeHTTP
 	server := &Server{
 		logger:        logrus.New(),
 		repo:          repo,
+		barrier:       barrier,
 		volMgr:        volMgr,
 		fileRPC:       fileRPC,
 		cfg:           &config.StorageProxyConfig{HeartbeatTimeout: 15},
@@ -309,6 +332,55 @@ func TestPrepareVolumeFileRequestUsesSharedDirectMountLease(t *testing.T) {
 
 	if volMgr.releaseCalls != 1 {
 		t.Fatalf("release calls = %d, want 1", volMgr.releaseCalls)
+	}
+}
+
+func TestReadVolumeFileUsesSharedBarrier(t *testing.T) {
+	barrier := &fakeHTTPSharedVolumeBarrier{}
+	fileRPC := &fakeHTTPVolumeFileRPC{
+		lookupFunc: func(_ context.Context, req *pb.LookupRequest) (*pb.NodeResponse, error) {
+			switch {
+			case req.Parent == 1 && req.Name == "docs":
+				return &pb.NodeResponse{Inode: 2, Attr: volumeDirAttr()}, nil
+			case req.Parent == 2 && req.Name == "report.txt":
+				return &pb.NodeResponse{Inode: 3, Attr: volumeFileAttr(5)}, nil
+			default:
+				return nil, fserror.New(fserror.NotFound, "missing")
+			}
+		},
+		openFunc: func(_ context.Context, _ *pb.OpenRequest) (*pb.OpenResponse, error) {
+			return &pb.OpenResponse{HandleId: 7}, nil
+		},
+		readFunc: func(_ context.Context, _ *pb.ReadRequest) (*pb.ReadResponse, error) {
+			return &pb.ReadResponse{Data: []byte("hello")}, nil
+		},
+		releaseFunc: func(_ context.Context, _ *pb.ReleaseRequest) (*pb.Empty, error) {
+			return &pb.Empty{}, nil
+		},
+	}
+	server, _ := newVolumeFileTestServerWithBarrier(fileRPC, barrier)
+
+	req := httptest.NewRequest(http.MethodGet, "/sandboxvolumes/vol-1/files?path=/docs/report.txt", nil)
+	req.SetPathValue("id", "vol-1")
+	req = req.WithContext(internalauth.WithClaims(req.Context(), &internalauth.Claims{TeamID: "team-a"}))
+	recorder := httptest.NewRecorder()
+
+	server.handleVolumeFileOperation(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+	if body := recorder.Body.String(); body != "hello" {
+		t.Fatalf("body = %q, want %q", body, "hello")
+	}
+	if barrier.sharedCalls != 1 {
+		t.Fatalf("shared calls = %d, want 1", barrier.sharedCalls)
+	}
+	if barrier.exclusiveCalls != 0 {
+		t.Fatalf("exclusive calls = %d, want 0", barrier.exclusiveCalls)
+	}
+	if barrier.lastVolumeID != "vol-1" {
+		t.Fatalf("barrier volume = %q, want %q", barrier.lastVolumeID, "vol-1")
 	}
 }
 

--- a/storage-proxy/pkg/http/server.go
+++ b/storage-proxy/pkg/http/server.go
@@ -38,6 +38,10 @@ type volumeRepository interface {
 	GetOwnedSandboxVolumeByOwner(ctx context.Context, clusterID, sandboxID, purpose string) (*db.OwnedSandboxVolume, error)
 	GetActiveMounts(ctx context.Context, volumeID string, heartbeatTimeout int) ([]*db.VolumeMount, error)
 	DeleteMount(ctx context.Context, volumeID, clusterID, podID string) error
+	TransferMount(ctx context.Context, volumeID, sourceClusterID, sourcePodID string, target *db.VolumeMount, heartbeatTimeout int) error
+	UpsertVolumeHandoff(ctx context.Context, handoff *db.VolumeHandoff) error
+	GetVolumeHandoff(ctx context.Context, volumeID string) (*db.VolumeHandoff, error)
+	DeleteVolumeHandoff(ctx context.Context, volumeID string) error
 	DeleteSandboxVolumeTx(ctx context.Context, tx pgx.Tx, id string) error
 	MarkOwnedSandboxVolumesForCleanup(ctx context.Context, clusterID, sandboxID, reason string) (int64, error)
 	MarkOwnedSandboxVolumeCleanupAttempt(ctx context.Context, volumeID string, cleanupErr error) error
@@ -125,6 +129,7 @@ type Server struct {
 	fileRPC       volumeFileRPC
 	eventHub      volumeEventHub
 	podResolver   volumeFilePodResolver
+	ctldResolver  volumeCtldResolver
 	selfPodID     string
 	selfClusterID string
 }
@@ -151,6 +156,7 @@ func NewServer(logger *logrus.Logger, cfg *config.StorageProxyConfig, k8sClient 
 		fileRPC:       fileRPC,
 		eventHub:      eventHub,
 		podResolver:   newKubernetesVolumeFilePodResolver(logger, k8sClient, cfg),
+		ctldResolver:  newKubernetesVolumeCtldResolver(k8sClient, selfPodID),
 		selfPodID:     selfPodID,
 	}
 	if cfg != nil {

--- a/storage-proxy/pkg/http/server.go
+++ b/storage-proxy/pkg/http/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	meteringpkg "github.com/sandbox0-ai/sandbox0/pkg/metering"
+	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/auth"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/notify"
@@ -160,7 +161,7 @@ func NewServer(logger *logrus.Logger, cfg *config.StorageProxyConfig, k8sClient 
 		selfPodID:     selfPodID,
 	}
 	if cfg != nil {
-		s.selfClusterID = cfg.DefaultClusterId
+		s.selfClusterID = naming.ClusterIDOrDefault(&cfg.DefaultClusterId)
 	}
 
 	// Register handlers

--- a/storage-proxy/pkg/http/server.go
+++ b/storage-proxy/pkg/http/server.go
@@ -78,6 +78,7 @@ type syncManager interface {
 }
 
 type volumeMutationBarrier interface {
+	WithShared(ctx context.Context, volumeID string, fn func(context.Context) error) error
 	WithExclusive(ctx context.Context, volumeID string, fn func(context.Context) error) error
 }
 

--- a/storage-proxy/pkg/http/volume_affinity.go
+++ b/storage-proxy/pkg/http/volume_affinity.go
@@ -124,6 +124,14 @@ func (s *Server) prepareOrProxyVolumeFileRequest(w http.ResponseWriter, r *http.
 		s.writeVolumeFileError(w, err)
 		return r.Context(), nil, func() {}, true
 	}
+	if err := s.waitForVolumeHandoff(r.Context(), volumeID); err != nil {
+		s.writeVolumeFileError(w, err)
+		return r.Context(), nil, func() {}, true
+	}
+	if err := s.ensureCtldVolumeOwner(r.Context(), volumeRecord); err != nil {
+		s.writeVolumeFileError(w, err)
+		return r.Context(), nil, func() {}, true
+	}
 
 	proxied, err := s.proxyVolumeRequestToOwnerIfNeeded(w, r, volumeRecord)
 	if err != nil {

--- a/storage-proxy/pkg/http/volume_handoff.go
+++ b/storage-proxy/pkg/http/volume_handoff.go
@@ -19,6 +19,21 @@ import (
 
 const volumeHandoffPollInterval = 100 * time.Millisecond
 
+type ctldRequestError struct {
+	StatusCode int
+	Message    string
+}
+
+func (e *ctldRequestError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if strings.TrimSpace(e.Message) != "" {
+		return fmt.Sprintf("ctld request failed with status %d: %s", e.StatusCode, e.Message)
+	}
+	return fmt.Sprintf("ctld request failed with status %d", e.StatusCode)
+}
+
 type preparePortalBindRequest struct {
 	TeamID          string `json:"team_id"`
 	UserID          string `json:"user_id"`
@@ -101,6 +116,9 @@ func (s *Server) executePortalBindHandoff(ctx context.Context, volumeRecord *db.
 	})
 	if err != nil {
 		cleanup()
+		if isCtldConflictError(err) {
+			return fmt.Errorf("%w: %v", db.ErrConflict, err)
+		}
 		return err
 	}
 	if prepareResp == nil || !prepareResp.Prepared {
@@ -148,6 +166,9 @@ func (s *Server) executePortalBindHandoff(ctx context.Context, volumeRecord *db.
 			SandboxVolumeID: volumeRecord.ID,
 		})
 		cleanup()
+		if isCtldConflictError(err) {
+			return fmt.Errorf("%w: %v", db.ErrConflict, err)
+		}
 		return err
 	}
 
@@ -219,7 +240,27 @@ func postCtldJSON[T any](ctx context.Context, baseURL, path string, request any)
 		}
 	}
 	if resp.StatusCode != http.StatusOK {
-		return &out, fmt.Errorf("ctld request failed with status %d", resp.StatusCode)
+		message := ""
+		switch typed := any(&out).(type) {
+		case *ctldapi.AttachVolumeOwnerResponse:
+			message = typed.Error
+		case *ctldapi.PrepareVolumePortalHandoffResponse:
+			message = typed.Error
+		case *ctldapi.CompleteVolumePortalHandoffResponse:
+			message = typed.Error
+		case *ctldapi.AbortVolumePortalHandoffResponse:
+			message = typed.Error
+		case *ctldapi.BindVolumePortalResponse:
+			message = typed.Error
+		case *ctldapi.UnbindVolumePortalResponse:
+			message = typed.Error
+		}
+		return &out, &ctldRequestError{StatusCode: resp.StatusCode, Message: strings.TrimSpace(message)}
 	}
 	return &out, nil
+}
+
+func isCtldConflictError(err error) bool {
+	var reqErr *ctldRequestError
+	return errors.As(err, &reqErr) && reqErr != nil && reqErr.StatusCode == http.StatusConflict
 }

--- a/storage-proxy/pkg/http/volume_handoff.go
+++ b/storage-proxy/pkg/http/volume_handoff.go
@@ -1,0 +1,214 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volume"
+)
+
+const volumeHandoffPollInterval = 100 * time.Millisecond
+
+type preparePortalBindRequest struct {
+	TeamID          string `json:"team_id"`
+	UserID          string `json:"user_id"`
+	VolumeID        string `json:"volume_id"`
+	TargetClusterID string `json:"target_cluster_id"`
+	TargetCtldAddr  string `json:"target_ctld_addr"`
+	Namespace       string `json:"namespace"`
+	PodName         string `json:"pod_name"`
+	PodUID          string `json:"pod_uid"`
+	PortalName      string `json:"portal_name"`
+	MountPath       string `json:"mount_path"`
+	SandboxID       string `json:"sandbox_id"`
+	OwnerTeamID     string `json:"owner_team_id"`
+}
+
+func (s *Server) waitForVolumeHandoff(ctx context.Context, volumeID string) error {
+	if s == nil || s.repo == nil || strings.TrimSpace(volumeID) == "" {
+		return nil
+	}
+	for {
+		handoff, err := s.repo.GetVolumeHandoff(ctx, volumeID)
+		if err == nil && handoff != nil {
+			if !handoff.ExpiresAt.IsZero() && time.Now().After(handoff.ExpiresAt) {
+				_ = s.repo.DeleteVolumeHandoff(context.Background(), volumeID)
+				return nil
+			}
+			timer := time.NewTimer(volumeHandoffPollInterval)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return ctx.Err()
+			case <-timer.C:
+			}
+			continue
+		}
+		if errors.Is(err, db.ErrNotFound) {
+			return nil
+		}
+		return err
+	}
+}
+
+func (s *Server) executePortalBindHandoff(ctx context.Context, volumeRecord *db.SandboxVolume, sourceMount *db.VolumeMount, req preparePortalBindRequest) error {
+	if s == nil || s.repo == nil || s.podResolver == nil || volumeRecord == nil || sourceMount == nil {
+		return fmt.Errorf("volume handoff unavailable")
+	}
+	sourceURL, err := s.resolveVolumeMountURL(ctx, sourceMount)
+	if err != nil {
+		return err
+	}
+	if sourceURL == nil {
+		return fmt.Errorf("resolve source ctld owner")
+	}
+	if sameCTLDAddress(sourceURL.String(), req.TargetCtldAddr) {
+		return nil
+	}
+	targetPodID := strings.TrimSpace(req.Namespace + "/" + req.PodName)
+	if req.PodName == "" {
+		targetPodID = strings.TrimSpace(req.PodUID)
+	}
+	expiresAt := time.Now().UTC().Add(30 * time.Second)
+	if err := s.repo.UpsertVolumeHandoff(ctx, &db.VolumeHandoff{
+		VolumeID:        volumeRecord.ID,
+		SourceClusterID: sourceMount.ClusterID,
+		SourcePodID:     sourceMount.PodID,
+		TargetClusterID: strings.TrimSpace(req.TargetClusterID),
+		TargetPodID:     targetPodID,
+		TargetCtldAddr:  strings.TrimSpace(req.TargetCtldAddr),
+		Status:          "preparing",
+		ExpiresAt:       expiresAt,
+	}); err != nil {
+		return err
+	}
+	cleanup := func() {
+		_ = s.repo.DeleteVolumeHandoff(context.Background(), volumeRecord.ID)
+	}
+
+	if _, err := postCtldJSON[ctldapi.PrepareVolumePortalHandoffResponse](ctx, sourceURL.String(), "/api/v1/volume-portals/handoffs/prepare", ctldapi.PrepareVolumePortalHandoffRequest{
+		SandboxVolumeID: volumeRecord.ID,
+	}); err != nil {
+		cleanup()
+		return err
+	}
+
+	if err := s.repo.UpsertVolumeHandoff(ctx, &db.VolumeHandoff{
+		VolumeID:        volumeRecord.ID,
+		SourceClusterID: sourceMount.ClusterID,
+		SourcePodID:     sourceMount.PodID,
+		TargetClusterID: strings.TrimSpace(req.TargetClusterID),
+		TargetPodID:     targetPodID,
+		TargetCtldAddr:  strings.TrimSpace(req.TargetCtldAddr),
+		Status:          "binding",
+		ExpiresAt:       expiresAt,
+	}); err != nil {
+		_, _ = postCtldJSON[ctldapi.AbortVolumePortalHandoffResponse](context.Background(), sourceURL.String(), "/api/v1/volume-portals/handoffs/abort", ctldapi.AbortVolumePortalHandoffRequest{
+			SandboxVolumeID: volumeRecord.ID,
+		})
+		cleanup()
+		return err
+	}
+
+	_, err = postCtldJSON[ctldapi.BindVolumePortalResponse](ctx, req.TargetCtldAddr, "/api/v1/volume-portals/bind", ctldapi.BindVolumePortalRequest{
+		Namespace:               req.Namespace,
+		PodName:                 req.PodName,
+		PodUID:                  req.PodUID,
+		PortalName:              req.PortalName,
+		MountPath:               req.MountPath,
+		SandboxID:               req.SandboxID,
+		TeamID:                  req.OwnerTeamID,
+		SandboxVolumeID:         volumeRecord.ID,
+		TransferSourceClusterID: sourceMount.ClusterID,
+		TransferSourcePodID:     sourceMount.PodID,
+	})
+	if err != nil {
+		_, _ = postCtldJSON[ctldapi.AbortVolumePortalHandoffResponse](context.Background(), sourceURL.String(), "/api/v1/volume-portals/handoffs/abort", ctldapi.AbortVolumePortalHandoffRequest{
+			SandboxVolumeID: volumeRecord.ID,
+		})
+		cleanup()
+		return err
+	}
+
+	if _, err := postCtldJSON[ctldapi.CompleteVolumePortalHandoffResponse](ctx, sourceURL.String(), "/api/v1/volume-portals/handoffs/complete", ctldapi.CompleteVolumePortalHandoffRequest{
+		SandboxVolumeID: volumeRecord.ID,
+	}); err != nil {
+		cleanup()
+		return err
+	}
+	cleanup()
+	return nil
+}
+
+func (s *Server) resolveVolumeMountURL(ctx context.Context, mount *db.VolumeMount) (*url.URL, error) {
+	if s == nil || s.podResolver == nil || mount == nil || mount.PodID == "" {
+		return nil, nil
+	}
+	targetURL, err := s.podResolver.ResolvePodURL(ctx, mount.PodID)
+	if err != nil {
+		return nil, err
+	}
+	if targetURL == nil {
+		return nil, nil
+	}
+	targetURL = cloneURL(targetURL)
+	opts := volume.DecodeMountOptions(mount.MountOptions)
+	ownerPort := opts.OwnerPort
+	if ownerPort == 0 && opts.OwnerKind == volume.OwnerKindCtld {
+		ownerPort = 8095
+	}
+	if ownerPort > 0 {
+		targetURL.Host = hostWithPort(targetURL.Host, ownerPort)
+	}
+	return targetURL, nil
+}
+
+func sameCTLDAddress(left, right string) bool {
+	return strings.TrimRight(strings.TrimSpace(left), "/") == strings.TrimRight(strings.TrimSpace(right), "/")
+}
+
+func postCtldJSON[T any](ctx context.Context, baseURL, path string, request any) (*T, error) {
+	var reader io.Reader
+	if request != nil {
+		payload, err := json.Marshal(request)
+		if err != nil {
+			return nil, err
+		}
+		reader = bytes.NewReader(payload)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimRight(baseURL, "/")+path, reader)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	var out T
+	if len(body) > 0 {
+		if err := json.Unmarshal(body, &out); err != nil {
+			return nil, err
+		}
+	}
+	if resp.StatusCode != http.StatusOK {
+		return &out, fmt.Errorf("ctld request failed with status %d", resp.StatusCode)
+	}
+	return &out, nil
+}

--- a/storage-proxy/pkg/http/volume_handoff.go
+++ b/storage-proxy/pkg/http/volume_handoff.go
@@ -96,11 +96,22 @@ func (s *Server) executePortalBindHandoff(ctx context.Context, volumeRecord *db.
 		_ = s.repo.DeleteVolumeHandoff(context.Background(), volumeRecord.ID)
 	}
 
-	if _, err := postCtldJSON[ctldapi.PrepareVolumePortalHandoffResponse](ctx, sourceURL.String(), "/api/v1/volume-portals/handoffs/prepare", ctldapi.PrepareVolumePortalHandoffRequest{
+	prepareResp, err := postCtldJSON[ctldapi.PrepareVolumePortalHandoffResponse](ctx, sourceURL.String(), "/api/v1/volume-portals/handoffs/prepare", ctldapi.PrepareVolumePortalHandoffRequest{
 		SandboxVolumeID: volumeRecord.ID,
-	}); err != nil {
+	})
+	if err != nil {
 		cleanup()
 		return err
+	}
+	if prepareResp == nil || !prepareResp.Prepared {
+		_, _ = postCtldJSON[ctldapi.AbortVolumePortalHandoffResponse](context.Background(), sourceURL.String(), "/api/v1/volume-portals/handoffs/abort", ctldapi.AbortVolumePortalHandoffRequest{
+			SandboxVolumeID: volumeRecord.ID,
+		})
+		cleanup()
+		if prepareResp != nil && strings.TrimSpace(prepareResp.Error) != "" {
+			return fmt.Errorf("ctld handoff preparation did not complete: %s", prepareResp.Error)
+		}
+		return fmt.Errorf("ctld handoff preparation did not complete")
 	}
 
 	if err := s.repo.UpsertVolumeHandoff(ctx, &db.VolumeHandoff{

--- a/storage-proxy/pkg/http/volume_handoff_test.go
+++ b/storage-proxy/pkg/http/volume_handoff_test.go
@@ -248,3 +248,79 @@ func TestExecutePortalBindHandoffAbortsOnBindFailure(t *testing.T) {
 		t.Fatalf("GetVolumeHandoff() err = %v, want %v after cleanup", err, db.ErrNotFound)
 	}
 }
+
+func TestExecutePortalBindHandoffAbortsWhenPrepareDoesNotComplete(t *testing.T) {
+	repo := newFakeHTTPRepo()
+	repo.volumes["vol-1"] = &db.SandboxVolume{ID: "vol-1", TeamID: "team-a", AccessMode: string(volume.AccessModeRWO)}
+
+	var prepared int32
+	var aborted int32
+	var bindCalls int32
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/volume-portals/handoffs/prepare":
+			atomic.AddInt32(&prepared, 1)
+			_ = json.NewEncoder(w).Encode(ctldapi.PrepareVolumePortalHandoffResponse{
+				Prepared: false,
+				Error:    "volume is no longer owned by this ctld",
+			})
+		case "/api/v1/volume-portals/handoffs/abort":
+			atomic.AddInt32(&aborted, 1)
+			_ = json.NewEncoder(w).Encode(ctldapi.AbortVolumePortalHandoffResponse{Aborted: true})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer source.Close()
+	sourceURL, _ := url.Parse(source.URL)
+	sourcePort, _ := strconv.Atoi(sourceURL.Port())
+
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/volume-portals/bind" {
+			atomic.AddInt32(&bindCalls, 1)
+			_ = json.NewEncoder(w).Encode(ctldapi.BindVolumePortalResponse{SandboxVolumeID: "vol-1"})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer target.Close()
+
+	server := &Server{
+		logger:      logrus.New(),
+		repo:        repo,
+		podResolver: &fakeVolumeFilePodResolver{urls: map[string]string{"sandbox0-system/ctld-source": source.URL}},
+	}
+	sourceMount := &db.VolumeMount{
+		VolumeID:     "vol-1",
+		ClusterID:    "cluster-a",
+		PodID:        "sandbox0-system/ctld-source",
+		MountOptions: mustMountOptionsRaw(t, volume.MountOptions{AccessMode: volume.AccessModeRWO, OwnerKind: volume.OwnerKindCtld, OwnerPort: sourcePort}),
+	}
+
+	err := server.executePortalBindHandoff(context.Background(), repo.volumes["vol-1"], sourceMount, preparePortalBindRequest{
+		TargetClusterID: "cluster-b",
+		TargetCtldAddr:  target.URL,
+		Namespace:       "default",
+		PodName:         "sandbox-a",
+		PodUID:          "pod-uid",
+		PortalName:      "workspace",
+		MountPath:       "/workspace",
+		SandboxID:       "sandbox-1",
+		OwnerTeamID:     "team-a",
+	})
+	if err == nil {
+		t.Fatal("executePortalBindHandoff() error = nil, want prepare failure")
+	}
+	if got := atomic.LoadInt32(&prepared); got != 1 {
+		t.Fatalf("prepare calls = %d, want 1", got)
+	}
+	if got := atomic.LoadInt32(&aborted); got != 1 {
+		t.Fatalf("abort calls = %d, want 1", got)
+	}
+	if got := atomic.LoadInt32(&bindCalls); got != 0 {
+		t.Fatalf("bind calls = %d, want 0", got)
+	}
+	if _, err := repo.GetVolumeHandoff(context.Background(), "vol-1"); err != db.ErrNotFound {
+		t.Fatalf("GetVolumeHandoff() err = %v, want %v after cleanup", err, db.ErrNotFound)
+	}
+}

--- a/storage-proxy/pkg/http/volume_handoff_test.go
+++ b/storage-proxy/pkg/http/volume_handoff_test.go
@@ -1,0 +1,250 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
+	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volume"
+	"github.com/sirupsen/logrus"
+)
+
+type fakeCtldResolver struct {
+	url string
+	err error
+}
+
+func (f fakeCtldResolver) ResolveLocalCtldURL(context.Context) (string, error) {
+	return f.url, f.err
+}
+
+func TestEnsureCtldVolumeOwnerAttachesLocalCtldForRWOWithoutOwner(t *testing.T) {
+	repo := newFakeHTTPRepo()
+	repo.volumes["vol-1"] = &db.SandboxVolume{ID: "vol-1", TeamID: "team-a", AccessMode: string(volume.AccessModeRWO)}
+
+	var attachCalls int32
+	var attachReq ctldapi.AttachVolumeOwnerRequest
+	ctld := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/volume-portals/owners/attach" {
+			http.NotFound(w, r)
+			return
+		}
+		atomic.AddInt32(&attachCalls, 1)
+		if err := json.NewDecoder(r.Body).Decode(&attachReq); err != nil {
+			t.Fatalf("decode attach request: %v", err)
+		}
+		repo.activeMounts["vol-1"] = []*db.VolumeMount{{
+			VolumeID:     "vol-1",
+			ClusterID:    "cluster-a",
+			PodID:        "sandbox0-system/ctld-a",
+			MountOptions: mustMountOptionsRaw(t, volume.MountOptions{AccessMode: volume.AccessModeRWO, OwnerKind: volume.OwnerKindCtld}),
+		}}
+		_ = json.NewEncoder(w).Encode(ctldapi.AttachVolumeOwnerResponse{Attached: true})
+	}))
+	defer ctld.Close()
+
+	server := &Server{
+		logger:       logrus.New(),
+		repo:         repo,
+		cfg:          &config.StorageProxyConfig{HeartbeatTimeout: 15},
+		ctldResolver: fakeCtldResolver{url: ctld.URL},
+	}
+
+	if err := server.ensureCtldVolumeOwner(context.Background(), repo.volumes["vol-1"]); err != nil {
+		t.Fatalf("ensureCtldVolumeOwner() error = %v", err)
+	}
+	if got := atomic.LoadInt32(&attachCalls); got != 1 {
+		t.Fatalf("attach calls = %d, want 1", got)
+	}
+	if attachReq.TeamID != "team-a" || attachReq.SandboxVolumeID != "vol-1" {
+		t.Fatalf("attach request = %+v, want team-a/vol-1", attachReq)
+	}
+}
+
+func TestWaitForVolumeHandoffBlocksUntilDeleted(t *testing.T) {
+	repo := newFakeHTTPRepo()
+	repo.handoffs["vol-1"] = &db.VolumeHandoff{
+		VolumeID:  "vol-1",
+		Status:    "binding",
+		ExpiresAt: time.Now().UTC().Add(time.Minute),
+	}
+	server := &Server{repo: repo}
+
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() {
+		done <- server.waitForVolumeHandoff(context.Background(), "vol-1")
+	}()
+
+	time.Sleep(150 * time.Millisecond)
+	if elapsed := time.Since(start); elapsed < volumeHandoffPollInterval {
+		t.Fatalf("waitForVolumeHandoff() returned too quickly after %s", elapsed)
+	}
+	if _, ok := repo.handoffs["vol-1"]; !ok {
+		t.Fatal("handoff removed before test cleanup")
+	}
+	if err := repo.DeleteVolumeHandoff(context.Background(), "vol-1"); err != nil {
+		t.Fatalf("DeleteVolumeHandoff() error = %v", err)
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("waitForVolumeHandoff() error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("waitForVolumeHandoff() did not resume after handoff deletion")
+	}
+}
+
+func TestExecutePortalBindHandoffCompletesAndCleansRow(t *testing.T) {
+	repo := newFakeHTTPRepo()
+	repo.volumes["vol-1"] = &db.SandboxVolume{ID: "vol-1", TeamID: "team-a", AccessMode: string(volume.AccessModeRWO)}
+
+	var prepared int32
+	var completed int32
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/volume-portals/handoffs/prepare":
+			atomic.AddInt32(&prepared, 1)
+			_ = json.NewEncoder(w).Encode(ctldapi.PrepareVolumePortalHandoffResponse{Prepared: true})
+		case "/api/v1/volume-portals/handoffs/complete":
+			atomic.AddInt32(&completed, 1)
+			_ = json.NewEncoder(w).Encode(ctldapi.CompleteVolumePortalHandoffResponse{Completed: true})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer source.Close()
+	sourceURL, _ := url.Parse(source.URL)
+	sourcePort, _ := strconv.Atoi(sourceURL.Port())
+
+	var bindReq ctldapi.BindVolumePortalRequest
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/volume-portals/bind" {
+			http.NotFound(w, r)
+			return
+		}
+		if err := json.NewDecoder(r.Body).Decode(&bindReq); err != nil {
+			t.Fatalf("decode bind request: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(ctldapi.BindVolumePortalResponse{SandboxVolumeID: "vol-1"})
+	}))
+	defer target.Close()
+
+	server := &Server{
+		logger:      logrus.New(),
+		repo:        repo,
+		podResolver: &fakeVolumeFilePodResolver{urls: map[string]string{"sandbox0-system/ctld-source": source.URL}},
+	}
+	sourceMount := &db.VolumeMount{
+		VolumeID:     "vol-1",
+		ClusterID:    "cluster-a",
+		PodID:        "sandbox0-system/ctld-source",
+		MountOptions: mustMountOptionsRaw(t, volume.MountOptions{AccessMode: volume.AccessModeRWO, OwnerKind: volume.OwnerKindCtld, OwnerPort: sourcePort}),
+	}
+
+	err := server.executePortalBindHandoff(context.Background(), repo.volumes["vol-1"], sourceMount, preparePortalBindRequest{
+		TargetClusterID: "cluster-b",
+		TargetCtldAddr:  target.URL,
+		Namespace:       "default",
+		PodName:         "sandbox-a",
+		PodUID:          "pod-uid",
+		PortalName:      "workspace",
+		MountPath:       "/workspace",
+		SandboxID:       "sandbox-1",
+		OwnerTeamID:     "team-a",
+	})
+	if err != nil {
+		t.Fatalf("executePortalBindHandoff() error = %v", err)
+	}
+	if got := atomic.LoadInt32(&prepared); got != 1 {
+		t.Fatalf("prepare calls = %d, want 1", got)
+	}
+	if got := atomic.LoadInt32(&completed); got != 1 {
+		t.Fatalf("complete calls = %d, want 1", got)
+	}
+	if bindReq.TransferSourceClusterID != "cluster-a" || bindReq.TransferSourcePodID != "sandbox0-system/ctld-source" {
+		t.Fatalf("bind transfer source = %q/%q, want cluster-a/sandbox0-system/ctld-source", bindReq.TransferSourceClusterID, bindReq.TransferSourcePodID)
+	}
+	if _, err := repo.GetVolumeHandoff(context.Background(), "vol-1"); err != db.ErrNotFound {
+		t.Fatalf("GetVolumeHandoff() err = %v, want %v after cleanup", err, db.ErrNotFound)
+	}
+}
+
+func TestExecutePortalBindHandoffAbortsOnBindFailure(t *testing.T) {
+	repo := newFakeHTTPRepo()
+	repo.volumes["vol-1"] = &db.SandboxVolume{ID: "vol-1", TeamID: "team-a", AccessMode: string(volume.AccessModeRWO)}
+
+	var prepared int32
+	var aborted int32
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/volume-portals/handoffs/prepare":
+			atomic.AddInt32(&prepared, 1)
+			_ = json.NewEncoder(w).Encode(ctldapi.PrepareVolumePortalHandoffResponse{Prepared: true})
+		case "/api/v1/volume-portals/handoffs/abort":
+			atomic.AddInt32(&aborted, 1)
+			_ = json.NewEncoder(w).Encode(ctldapi.AbortVolumePortalHandoffResponse{Aborted: true})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer source.Close()
+	sourceURL, _ := url.Parse(source.URL)
+	sourcePort, _ := strconv.Atoi(sourceURL.Port())
+
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/volume-portals/bind" {
+			http.Error(w, "bind failed", http.StatusInternalServerError)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer target.Close()
+
+	server := &Server{
+		logger:      logrus.New(),
+		repo:        repo,
+		podResolver: &fakeVolumeFilePodResolver{urls: map[string]string{"sandbox0-system/ctld-source": source.URL}},
+	}
+	sourceMount := &db.VolumeMount{
+		VolumeID:     "vol-1",
+		ClusterID:    "cluster-a",
+		PodID:        "sandbox0-system/ctld-source",
+		MountOptions: mustMountOptionsRaw(t, volume.MountOptions{AccessMode: volume.AccessModeRWO, OwnerKind: volume.OwnerKindCtld, OwnerPort: sourcePort}),
+	}
+
+	err := server.executePortalBindHandoff(context.Background(), repo.volumes["vol-1"], sourceMount, preparePortalBindRequest{
+		TargetClusterID: "cluster-b",
+		TargetCtldAddr:  target.URL,
+		Namespace:       "default",
+		PodName:         "sandbox-a",
+		PodUID:          "pod-uid",
+		PortalName:      "workspace",
+		MountPath:       "/workspace",
+		SandboxID:       "sandbox-1",
+		OwnerTeamID:     "team-a",
+	})
+	if err == nil {
+		t.Fatal("executePortalBindHandoff() error = nil, want bind failure")
+	}
+	if got := atomic.LoadInt32(&prepared); got != 1 {
+		t.Fatalf("prepare calls = %d, want 1", got)
+	}
+	if got := atomic.LoadInt32(&aborted); got != 1 {
+		t.Fatalf("abort calls = %d, want 1", got)
+	}
+	if _, err := repo.GetVolumeHandoff(context.Background(), "vol-1"); err != db.ErrNotFound {
+		t.Fatalf("GetVolumeHandoff() err = %v, want %v after cleanup", err, db.ErrNotFound)
+	}
+}

--- a/storage-proxy/pkg/http/volume_handoff_test.go
+++ b/storage-proxy/pkg/http/volume_handoff_test.go
@@ -3,6 +3,7 @@ package http
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -322,5 +323,51 @@ func TestExecutePortalBindHandoffAbortsWhenPrepareDoesNotComplete(t *testing.T) 
 	}
 	if _, err := repo.GetVolumeHandoff(context.Background(), "vol-1"); err != db.ErrNotFound {
 		t.Fatalf("GetVolumeHandoff() err = %v, want %v after cleanup", err, db.ErrNotFound)
+	}
+}
+
+func TestExecutePortalBindHandoffMapsPrepareConflictToDBConflict(t *testing.T) {
+	repo := newFakeHTTPRepo()
+	repo.volumes["vol-1"] = &db.SandboxVolume{ID: "vol-1", TeamID: "team-a", AccessMode: string(volume.AccessModeRWO)}
+
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/volume-portals/handoffs/prepare" {
+			http.NotFound(w, r)
+			return
+		}
+		w.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(w).Encode(ctldapi.PrepareVolumePortalHandoffResponse{
+			Error: "volume vol-1 is actively bound to a portal",
+		})
+	}))
+	defer source.Close()
+	sourceURL, _ := url.Parse(source.URL)
+	sourcePort, _ := strconv.Atoi(sourceURL.Port())
+
+	server := &Server{
+		logger:      logrus.New(),
+		repo:        repo,
+		podResolver: &fakeVolumeFilePodResolver{urls: map[string]string{"sandbox0-system/ctld-source": source.URL}},
+	}
+	sourceMount := &db.VolumeMount{
+		VolumeID:     "vol-1",
+		ClusterID:    "cluster-a",
+		PodID:        "sandbox0-system/ctld-source",
+		MountOptions: mustMountOptionsRaw(t, volume.MountOptions{AccessMode: volume.AccessModeRWO, OwnerKind: volume.OwnerKindCtld, OwnerPort: sourcePort}),
+	}
+
+	err := server.executePortalBindHandoff(context.Background(), repo.volumes["vol-1"], sourceMount, preparePortalBindRequest{
+		TargetClusterID: "cluster-b",
+		TargetCtldAddr:  "http://127.0.0.1:65535",
+		Namespace:       "default",
+		PodName:         "sandbox-a",
+		PodUID:          "pod-uid",
+		PortalName:      "workspace",
+		MountPath:       "/workspace",
+		SandboxID:       "sandbox-1",
+		OwnerTeamID:     "team-a",
+	})
+	if !errors.Is(err, db.ErrConflict) {
+		t.Fatalf("executePortalBindHandoff() error = %v, want db.ErrConflict", err)
 	}
 }

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -1833,6 +1833,9 @@ func assertVolumeLifecycle(env *framework.ScenarioEnv, session *e2eutils.Session
 	Expect(status).To(Equal(http.StatusCreated))
 	Expect(volume).NotTo(BeNil())
 	volumeID := expectStringPtr(volume.Id, "volume id")
+	DeferCleanup(func() {
+		deleteSandboxVolumeForCleanup(env, session, volumeID)
+	})
 
 	directFilePath := "/direct-e2e/hello.txt"
 	directContent := []byte("hello direct volume api")
@@ -1845,28 +1848,37 @@ func assertVolumeLifecycle(env *framework.ScenarioEnv, session *e2eutils.Session
 	Expect(status).To(Equal(http.StatusOK))
 	Expect(directBody).To(Equal(directContent))
 
+	_, status, err = session.CreateSnapshot(env.TestCtx.Context, GinkgoT(), volumeID, apispec.CreateSnapshotRequest{Name: "direct-mounted"})
+	Expect(err).To(HaveOccurred())
+	Expect(status).To(Equal(http.StatusConflict))
+
+	snapshotVolume, status, err := session.CreateSandboxVolume(env.TestCtx.Context, GinkgoT(), createReq)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusCreated))
+	Expect(snapshotVolume).NotTo(BeNil())
+	snapshotVolumeID := expectStringPtr(snapshotVolume.Id, "snapshot volume id")
+	DeferCleanup(func() {
+		deleteSandboxVolumeForCleanup(env, session, snapshotVolumeID)
+	})
+
 	snapReq := apispec.CreateSnapshotRequest{
 		Name: "e2e-snap",
 	}
-	snapshot, status, err := session.CreateSnapshot(env.TestCtx.Context, GinkgoT(), volumeID, snapReq)
+	snapshot, status, err := session.CreateSnapshot(env.TestCtx.Context, GinkgoT(), snapshotVolumeID, snapReq)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(status).To(Equal(http.StatusCreated))
 	Expect(snapshot).NotTo(BeNil())
 	Expect(snapshot.Id).NotTo(BeEmpty())
 
-	_, status, err = session.ListSnapshots(env.TestCtx.Context, GinkgoT(), volumeID)
+	_, status, err = session.ListSnapshots(env.TestCtx.Context, GinkgoT(), snapshotVolumeID)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(status).To(Equal(http.StatusOK))
 
-	status, err = session.RestoreSnapshot(env.TestCtx.Context, GinkgoT(), volumeID, snapshot.Id)
+	status, err = session.RestoreSnapshot(env.TestCtx.Context, GinkgoT(), snapshotVolumeID, snapshot.Id)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(status).To(Equal(http.StatusOK))
 
-	status, err = session.DeleteSnapshot(env.TestCtx.Context, GinkgoT(), volumeID, snapshot.Id)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(status).To(Equal(http.StatusOK))
-
-	status, err = session.DeleteSandboxVolume(env.TestCtx.Context, GinkgoT(), volumeID)
+	status, err = session.DeleteSnapshot(env.TestCtx.Context, GinkgoT(), snapshotVolumeID, snapshot.Id)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(status).To(Equal(http.StatusOK))
 }


### PR DESCRIPTION
## Summary
- route RWO HTTP volume access through ctld owner-only attachments instead of relying on storage-proxy direct mounts when no owner exists
- add portal-bind handoff coordination so an HTTP-owned ctld volume can move to the target bind node while new HTTP requests wait instead of failing
- add owner-only idle cleanup plus tests covering handoff wait, completion, abort, and ctld attach behavior

## Details
- add ctld owner attach API and reuse owner-only ctld sessions when a same-node bind converts an HTTP-owned volume into a portal-backed mount
- persist handoff state in storage-proxy, gate new HTTP file requests on that handoff row, and transfer mount ownership to the target ctld during bind
- keep the source ctld draining in-flight requests, materialize once, then complete or abort the transfer explicitly
- retain legacy direct-path code as fallback, but RWO HTTP requests now prefer ctld ownership when resolver/config are available

## Testing
- `go test ./ctld/internal/ctld/portal ./ctld/cmd/ctld ./storage-proxy/pkg/http ./manager/pkg/service`
- `go test ./storage-proxy/pkg/db ./ctld/internal/ctld/server`

Closes #266
