### PR TITLE
Add OIDC provider logout redirect

### DIFF
--- a/pkg/gateway/auth/oidc/manager.go
+++ b/pkg/gateway/auth/oidc/manager.go
@@ -175,6 +175,18 @@ func (m *Manager) GenerateAuthURL(providerID, returnURL string, opts ...AuthURLO
 	return provider.AuthURL(state, verifier), nil
 }
 
+// GenerateLogoutURL builds a provider logout URL for browser logout flows.
+func (m *Manager) GenerateLogoutURL(providerID, returnURL string) (string, error) {
+	provider, err := m.GetProvider(providerID)
+	if err != nil {
+		return "", err
+	}
+	if !m.IsAllowedWebReturnURL(returnURL) {
+		return "", ErrInvalidReturnURL
+	}
+	return provider.LogoutURL(returnURL)
+}
+
 // IsAllowedWebReturnURL reports whether returnURL may receive a web login code.
 func (m *Manager) IsAllowedWebReturnURL(raw string) bool {
 	parsed, err := url.Parse(raw)

--- a/pkg/gateway/auth/oidc/provider.go
+++ b/pkg/gateway/auth/oidc/provider.go
@@ -22,6 +22,7 @@ var (
 	ErrInvalidState                = errors.New("invalid OAuth state")
 	ErrInvalidCode                 = errors.New("invalid authorization code")
 	ErrInvalidReturnURL            = errors.New("invalid return URL")
+	ErrProviderLogoutNotSupported  = errors.New("OIDC provider logout is not supported")
 	ErrMissingEmail                = errors.New("email not provided by IdP")
 	ErrHomeRegionNotRoutable       = errors.New("home region is not routable")
 	ErrEmailDomainMismatch         = errors.New("email domain not allowed")
@@ -52,6 +53,7 @@ type Provider struct {
 	verifier                    *oidc.IDTokenVerifier
 	deviceVerifier              *oidc.IDTokenVerifier
 	deviceAuthorizationEndpoint string
+	endSessionEndpoint          string
 }
 
 const wellKnownOIDCConfigPath = "/.well-known/openid-configuration"
@@ -59,6 +61,7 @@ const wellKnownOIDCConfigPath = "/.well-known/openid-configuration"
 type discoveryMetadata struct {
 	Issuer                      string `json:"issuer"`
 	DeviceAuthorizationEndpoint string `json:"device_authorization_endpoint"`
+	EndSessionEndpoint          string `json:"end_session_endpoint"`
 }
 
 // NewProvider creates a new OIDC provider
@@ -125,6 +128,7 @@ func NewProvider(ctx context.Context, cfg *config.OIDCProviderConfig, baseURL st
 		verifier:                    verifier,
 		deviceVerifier:              deviceVerifier,
 		deviceAuthorizationEndpoint: strings.TrimSpace(metadata.DeviceAuthorizationEndpoint),
+		endSessionEndpoint:          strings.TrimSpace(metadata.EndSessionEndpoint),
 	}, nil
 }
 
@@ -258,6 +262,24 @@ func (p *Provider) VerifyToken(ctx context.Context, token *oauth2.Token) (*UserI
 	}
 
 	return userInfo, nil
+}
+
+// LogoutURL returns the provider logout URL when the IdP supports RP-initiated logout.
+func (p *Provider) LogoutURL(returnURL string) (string, error) {
+	if strings.TrimSpace(p.endSessionEndpoint) == "" {
+		return "", ErrProviderLogoutNotSupported
+	}
+	logoutURL, err := url.Parse(p.endSessionEndpoint)
+	if err != nil {
+		return "", fmt.Errorf("parse end session endpoint: %w", err)
+	}
+	query := logoutURL.Query()
+	query.Set("post_logout_redirect_uri", returnURL)
+	if clientID := strings.TrimSpace(p.config.ClientID); clientID != "" {
+		query.Set("client_id", clientID)
+	}
+	logoutURL.RawQuery = query.Encode()
+	return logoutURL.String(), nil
 }
 
 func (p *Provider) verifyIDToken(ctx context.Context, rawIDToken string) (*oidc.IDToken, error) {

--- a/pkg/gateway/http/handlers/auth.go
+++ b/pkg/gateway/http/handlers/auth.go
@@ -462,6 +462,35 @@ func (h *AuthHandler) OIDCLogin(c *gin.Context) {
 	c.Redirect(http.StatusFound, authURL)
 }
 
+// OIDCLogout redirects the browser to the provider logout endpoint when supported.
+func (h *AuthHandler) OIDCLogout(c *gin.Context) {
+	if h.oidcManager == nil {
+		spec.JSONError(c, http.StatusNotFound, spec.CodeNotFound, oidc.ErrProviderNotFound.Error())
+		return
+	}
+
+	providerID := c.Param("provider")
+	returnURL := c.Query("return_url")
+	if returnURL == "" {
+		returnURL = "/"
+	}
+
+	logoutURL, err := h.oidcManager.GenerateLogoutURL(providerID, returnURL)
+	if err != nil {
+		status := http.StatusBadRequest
+		code := spec.CodeBadRequest
+		switch {
+		case errors.Is(err, oidc.ErrProviderNotFound), errors.Is(err, oidc.ErrProviderLogoutNotSupported):
+			status = http.StatusNotFound
+			code = spec.CodeNotFound
+		}
+		spec.JSONError(c, status, code, err.Error())
+		return
+	}
+
+	c.Redirect(http.StatusFound, logoutURL)
+}
+
 // OIDCCallback handles OIDC callback
 func (h *AuthHandler) OIDCCallback(c *gin.Context) {
 	if h.oidcManager == nil {

--- a/pkg/gateway/public/routes.go
+++ b/pkg/gateway/public/routes.go
@@ -80,6 +80,11 @@ func RegisterIdentityRoutes(router gin.IRouter, deps Deps) {
 			authHandler.OIDCLogin,
 		)
 		auth.GET(
+			"/oidc/:provider/logout",
+			licensinghttp.RequireFeature(deps.Entitlements, licensing.FeatureSSO, deps.Logger),
+			authHandler.OIDCLogout,
+		)
+		auth.GET(
 			"/oidc/:provider/callback",
 			licensinghttp.RequireFeature(deps.Entitlements, licensing.FeatureSSO, deps.Logger),
 			authHandler.OIDCCallback,


### PR DESCRIPTION
## Summary
- add OIDC provider logout URL generation from discovery metadata
- expose `GET /auth/oidc/:provider/logout` in the gateway public routes
- let browser logout flows redirect through the provider logout endpoint before returning to the website

## Why
The website currently clears the local session and revokes Sandbox0 refresh tokens, but it does not end the upstream Auth0/OIDC provider session. That allows the browser to get silently logged back in on the next `/dashboard` visit.

This PR adds the gateway-side provider logout redirect so `sandbox0-cloud` can route browser logout through the IdP and fully terminate the SSO session.

## Validation
- `go test ./pkg/gateway/auth/oidc ./pkg/gateway/http/handlers ./pkg/gateway/public`
