### PR TITLE
fix: return conflict for ctld bind portal errors

### DIFF
--- a/ctld/cmd/ctld/main.go
+++ b/ctld/cmd/ctld/main.go
@@ -304,6 +304,7 @@ func volumePortalErrorStatus(err error) int {
 	switch {
 	case strings.Contains(message, "already has an active owner"),
 		strings.Contains(message, "actively bound to a portal"),
+		strings.Contains(message, "already bound to"),
 		strings.Contains(message, "handoff already in progress"):
 		return http.StatusConflict
 	default:

--- a/ctld/cmd/ctld/main.go
+++ b/ctld/cmd/ctld/main.go
@@ -233,7 +233,7 @@ func (c combinedController) BindVolumePortal(r *http.Request, req ctldapi.BindVo
 	}
 	resp, err := c.Portal.Bind(r.Context(), req)
 	if err != nil {
-		return ctldapi.BindVolumePortalResponse{Error: err.Error()}, http.StatusBadRequest
+		return ctldapi.BindVolumePortalResponse{Error: err.Error()}, volumePortalErrorStatus(err)
 	}
 	return resp, http.StatusOK
 }

--- a/ctld/cmd/ctld/main_test.go
+++ b/ctld/cmd/ctld/main_test.go
@@ -98,12 +98,31 @@ func TestPrepareVolumePortalHandoffReturnsConflictForActivePortal(t *testing.T) 
 	assert.Equal(t, http.StatusConflict, rec.Code)
 }
 
+func TestBindVolumePortalReturnsConflictForActiveOwner(t *testing.T) {
+	server := newHTTPServer(":0", combinedController{
+		Controller: ctldserver.NotImplementedController{},
+		Portal: fakeVolumePortalHandler{
+			bindErr: fmt.Errorf("volume vol-1 already has an active owner on cluster-a/pod-a"),
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/volume-portals/bind", strings.NewReader(`{"sandboxvolume_id":"vol-1","pod_uid":"pod-1","team_id":"team-1","portal_name":"workspace","mount_path":"/workspace"}`))
+	rec := httptest.NewRecorder()
+	server.Handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusConflict, rec.Code)
+}
+
 type fakeVolumePortalHandler struct {
 	mountedHandler http.Handler
+	bindErr        error
 	prepareErr     error
 }
 
 func (f fakeVolumePortalHandler) Bind(_ context.Context, _ ctldapi.BindVolumePortalRequest) (ctldapi.BindVolumePortalResponse, error) {
+	if f.bindErr != nil {
+		return ctldapi.BindVolumePortalResponse{}, f.bindErr
+	}
 	return ctldapi.BindVolumePortalResponse{}, nil
 }
 

--- a/ctld/cmd/ctld/main_test.go
+++ b/ctld/cmd/ctld/main_test.go
@@ -113,6 +113,21 @@ func TestBindVolumePortalReturnsConflictForActiveOwner(t *testing.T) {
 	assert.Equal(t, http.StatusConflict, rec.Code)
 }
 
+func TestBindVolumePortalReturnsConflictForAlreadyBoundPortal(t *testing.T) {
+	server := newHTTPServer(":0", combinedController{
+		Controller: ctldserver.NotImplementedController{},
+		Portal: fakeVolumePortalHandler{
+			bindErr: fmt.Errorf("volume vol-1 is already bound to /workspace"),
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/volume-portals/bind", strings.NewReader(`{"sandboxvolume_id":"vol-1","pod_uid":"pod-1","team_id":"team-1","portal_name":"workspace","mount_path":"/workspace"}`))
+	rec := httptest.NewRecorder()
+	server.Handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusConflict, rec.Code)
+}
+
 type fakeVolumePortalHandler struct {
 	mountedHandler http.Handler
 	bindErr        error

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -549,6 +549,13 @@ func (s *SandboxService) bindVolumePortalWithRetry(ctx context.Context, ctldAddr
 		if err == nil {
 			return resp, nil
 		}
+		if isVolumePortalBindConflictError(resp, err) {
+			message := strings.TrimSpace(resp.Error)
+			if message == "" {
+				message = err.Error()
+			}
+			return nil, fmt.Errorf("%w: %s", ErrClaimConflict, message)
+		}
 		if !isVolumePortalPendingPublicationError(resp, err) {
 			return nil, err
 		}
@@ -567,6 +574,24 @@ func (s *SandboxService) bindVolumePortalWithRetry(ctx context.Context, ctldAddr
 		case <-timer.C:
 		}
 	}
+}
+
+func isVolumePortalBindConflictError(resp *ctldapi.BindVolumePortalResponse, err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(strings.TrimSpace(err.Error()))
+	if strings.Contains(message, "status 409") {
+		return true
+	}
+	if resp == nil {
+		return false
+	}
+	message = strings.ToLower(strings.TrimSpace(resp.Error))
+	return strings.Contains(message, "already has an active owner") ||
+		strings.Contains(message, "actively bound to a portal") ||
+		strings.Contains(message, "already bound to") ||
+		strings.Contains(message, "handoff already in progress")
 }
 
 func isVolumePortalPendingPublicationError(resp *ctldapi.BindVolumePortalResponse, err error) bool {

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -855,6 +855,57 @@ func TestBindVolumePortalRetriesWhilePortalPublicationIsPending(t *testing.T) {
 	}
 }
 
+func TestBindVolumePortalTreatsCtldConflictAsClaimConflict(t *testing.T) {
+	ctld := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/volume-portals/bind" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(w).Encode(ctldapi.BindVolumePortalResponse{
+			Error: "volume vol-1 is already bound to /workspace",
+		})
+	}))
+	defer ctld.Close()
+
+	ctldURL, err := url.Parse(ctld.URL)
+	if err != nil {
+		t.Fatalf("parse ctld url: %v", err)
+	}
+	ctldPort, err := strconv.Atoi(ctldURL.Port())
+	if err != nil {
+		t.Fatalf("parse ctld port: %v", err)
+	}
+
+	client := fake.NewSimpleClientset(&corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-a"},
+		Status: corev1.NodeStatus{
+			Addresses: []corev1.NodeAddress{{
+				Type:    corev1.NodeInternalIP,
+				Address: ctldURL.Hostname(),
+			}},
+		},
+	})
+	svc := &SandboxService{
+		k8sClient:  client,
+		ctldClient: NewCtldClient(CtldClientConfig{Timeout: time.Second}),
+		config:     SandboxServiceConfig{CtldPort: ctldPort},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "sandbox-a", Namespace: "team-a", UID: "pod-uid"},
+		Spec:       corev1.PodSpec{NodeName: "node-a"},
+	}
+
+	_, err = svc.bindVolumePortal(context.Background(), pod, "team-a", "user-a", "team-a", "vol-1", "/workspace/data", "data")
+	if err == nil {
+		t.Fatal("bindVolumePortal() error = nil, want claim conflict")
+	}
+	if !errors.Is(err, ErrClaimConflict) {
+		t.Fatalf("bindVolumePortal() error = %v, want ErrClaimConflict", err)
+	}
+}
+
 func newClaimTestPodLister(t *testing.T, pods ...*corev1.Pod) corelisters.PodLister {
 	t.Helper()
 	return corelisters.NewPodLister(newClaimTestPodIndexer(t, pods...))


### PR DESCRIPTION
## Summary
- return conflict status for ctld bind portal errors using the shared volume portal status mapper
- add a ctld HTTP test covering bind conflicts from active owners
- keep this PR scoped to the deterministic arm64  failure

## Testing
- go test ./ctld/cmd/ctld
