### PR TITLE
storage-proxy: fallback ctld owner resolution to ready ctld pods

### DIFF
--- a/storage-proxy/pkg/http/ctld_owner.go
+++ b/storage-proxy/pkg/http/ctld_owner.go
@@ -3,6 +3,7 @@ package http
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
@@ -25,6 +26,12 @@ type kubernetesVolumeCtldResolver struct {
 	port      int
 }
 
+const (
+	ctldNameLabel     = "app.kubernetes.io/name"
+	ctldInstanceLabel = "app.kubernetes.io/instance"
+	ctldComponentName = "ctld"
+)
+
 func newKubernetesVolumeCtldResolver(client kubernetes.Interface, selfPodID string) volumeCtldResolver {
 	if client == nil || strings.TrimSpace(selfPodID) == "" {
 		return nil
@@ -40,23 +47,34 @@ func (r *kubernetesVolumeCtldResolver) ResolveLocalCtldURL(ctx context.Context) 
 	if r == nil || r.client == nil {
 		return "", fmt.Errorf("ctld resolver unavailable")
 	}
-	pod, err := resolveKubernetesPod(ctx, r.client, r.selfPodID)
+	selfPod, err := resolveKubernetesPod(ctx, r.client, r.selfPodID)
 	if err != nil {
 		return "", err
 	}
-	if pod == nil || pod.Spec.NodeName == "" {
+	if selfPod == nil {
+		return "", fmt.Errorf("storage-proxy pod %q not found", r.selfPodID)
+	}
+	if selfPod.Spec.NodeName == "" {
 		return "", fmt.Errorf("storage-proxy pod %q is not scheduled", r.selfPodID)
 	}
-	node, err := r.client.CoreV1().Nodes().Get(ctx, pod.Spec.NodeName, metav1.GetOptions{})
+
+	candidates, err := r.listCtldCandidates(ctx, selfPod)
 	if err != nil {
 		return "", err
 	}
-	for _, address := range node.Status.Addresses {
-		if address.Type == corev1.NodeInternalIP && strings.TrimSpace(address.Address) != "" {
-			return fmt.Sprintf("http://%s:%d", address.Address, r.port), nil
+	for _, candidate := range candidates {
+		if candidate.Spec.NodeName == selfPod.Spec.NodeName {
+			if addr, ok := podInternalURL(candidate, r.port); ok {
+				return addr, nil
+			}
 		}
 	}
-	return "", fmt.Errorf("node %s has no internal ip", node.Name)
+	for _, candidate := range candidates {
+		if addr, ok := podInternalURL(candidate, r.port); ok {
+			return addr, nil
+		}
+	}
+	return "", fmt.Errorf("no ready ctld pod available for storage-proxy pod %q", r.selfPodID)
 }
 
 func resolveKubernetesPod(ctx context.Context, client kubernetes.Interface, podID string) (*corev1.Pod, error) {
@@ -78,6 +96,63 @@ func resolveKubernetesPod(ctx context.Context, client kubernetes.Interface, podI
 		return nil, fmt.Errorf("pod %q not found", podID)
 	}
 	return &pods.Items[0], nil
+}
+
+func (r *kubernetesVolumeCtldResolver) listCtldCandidates(ctx context.Context, selfPod *corev1.Pod) ([]corev1.Pod, error) {
+	if r == nil || r.client == nil || selfPod == nil {
+		return nil, fmt.Errorf("ctld resolver unavailable")
+	}
+
+	labelSelector := ctldNameLabel + "=" + ctldComponentName
+	if instance := strings.TrimSpace(selfPod.Labels[ctldInstanceLabel]); instance != "" {
+		labelSelector += "," + ctldInstanceLabel + "=" + instance
+	}
+
+	pods, err := r.client.CoreV1().Pods(selfPod.Namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	candidates := make([]corev1.Pod, 0, len(pods.Items))
+	for _, pod := range pods.Items {
+		if isReadyCtldPod(&pod) {
+			candidates = append(candidates, pod)
+		}
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].Spec.NodeName == candidates[j].Spec.NodeName {
+			return candidates[i].Name < candidates[j].Name
+		}
+		if candidates[i].Spec.NodeName == selfPod.Spec.NodeName {
+			return true
+		}
+		if candidates[j].Spec.NodeName == selfPod.Spec.NodeName {
+			return false
+		}
+		return candidates[i].Name < candidates[j].Name
+	})
+	return candidates, nil
+}
+
+func isReadyCtldPod(pod *corev1.Pod) bool {
+	if pod == nil || pod.DeletionTimestamp != nil || pod.Status.Phase != corev1.PodRunning || strings.TrimSpace(pod.Status.PodIP) == "" {
+		return false
+	}
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodReady {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+func podInternalURL(pod corev1.Pod, port int) (string, bool) {
+	if strings.TrimSpace(pod.Status.PodIP) == "" {
+		return "", false
+	}
+	return fmt.Sprintf("http://%s:%d", pod.Status.PodIP, port), true
 }
 
 func (s *Server) ensureCtldVolumeOwner(ctx context.Context, volumeRecord *db.SandboxVolume) error {

--- a/storage-proxy/pkg/http/ctld_owner_test.go
+++ b/storage-proxy/pkg/http/ctld_owner_test.go
@@ -1,0 +1,121 @@
+package http
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestKubernetesVolumeCtldResolverPrefersLocalCtldPod(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1 scheme: %v", err)
+	}
+
+	client := k8sfake.NewSimpleClientset(
+		newResolverPod("sandbox0-system", "storage-proxy-a", "node-system", "10.24.0.4", map[string]string{
+			ctldInstanceLabel: "fullmode",
+		}, false),
+		newResolverPod("sandbox0-system", "fullmode-ctld-system", "node-system", "10.24.0.4", map[string]string{
+			ctldNameLabel:     ctldComponentName,
+			ctldInstanceLabel: "fullmode",
+		}, true),
+		newResolverPod("sandbox0-system", "fullmode-ctld-sandbox", "node-sandbox", "10.24.15.221", map[string]string{
+			ctldNameLabel:     ctldComponentName,
+			ctldInstanceLabel: "fullmode",
+		}, true),
+	)
+
+	resolver := newKubernetesVolumeCtldResolver(client, "sandbox0-system/storage-proxy-a")
+	got, err := resolver.ResolveLocalCtldURL(context.Background())
+	if err != nil {
+		t.Fatalf("ResolveLocalCtldURL() error = %v", err)
+	}
+	if got != "http://10.24.0.4:8095" {
+		t.Fatalf("ResolveLocalCtldURL() = %q, want %q", got, "http://10.24.0.4:8095")
+	}
+}
+
+func TestKubernetesVolumeCtldResolverFallsBackToReadyCtldPod(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1 scheme: %v", err)
+	}
+
+	client := k8sfake.NewSimpleClientset(
+		newResolverPod("sandbox0-system", "storage-proxy-a", "node-system", "10.24.0.4", map[string]string{
+			ctldInstanceLabel: "fullmode",
+		}, false),
+		newResolverPod("sandbox0-system", "fullmode-ctld-not-ready", "node-system", "10.24.0.4", map[string]string{
+			ctldNameLabel:     ctldComponentName,
+			ctldInstanceLabel: "fullmode",
+		}, false),
+		newResolverPod("sandbox0-system", "fullmode-ctld-sandbox", "node-sandbox", "10.24.15.221", map[string]string{
+			ctldNameLabel:     ctldComponentName,
+			ctldInstanceLabel: "fullmode",
+		}, true),
+	)
+
+	resolver := newKubernetesVolumeCtldResolver(client, "sandbox0-system/storage-proxy-a")
+	got, err := resolver.ResolveLocalCtldURL(context.Background())
+	if err != nil {
+		t.Fatalf("ResolveLocalCtldURL() error = %v", err)
+	}
+	if got != "http://10.24.15.221:8095" {
+		t.Fatalf("ResolveLocalCtldURL() = %q, want %q", got, "http://10.24.15.221:8095")
+	}
+}
+
+func TestKubernetesVolumeCtldResolverFiltersToMatchingInstance(t *testing.T) {
+	client := k8sfake.NewSimpleClientset(
+		newResolverPod("sandbox0-system", "storage-proxy-a", "node-system", "10.24.0.4", map[string]string{
+			ctldInstanceLabel: "fullmode",
+		}, false),
+		newResolverPod("sandbox0-system", "other-ctld", "node-sandbox-a", "10.24.15.200", map[string]string{
+			ctldNameLabel:     ctldComponentName,
+			ctldInstanceLabel: "other",
+		}, true),
+		newResolverPod("sandbox0-system", "fullmode-ctld-sandbox", "node-sandbox-b", "10.24.15.221", map[string]string{
+			ctldNameLabel:     ctldComponentName,
+			ctldInstanceLabel: "fullmode",
+		}, true),
+	)
+
+	resolver := newKubernetesVolumeCtldResolver(client, "sandbox0-system/storage-proxy-a")
+	got, err := resolver.ResolveLocalCtldURL(context.Background())
+	if err != nil {
+		t.Fatalf("ResolveLocalCtldURL() error = %v", err)
+	}
+	if got != "http://10.24.15.221:8095" {
+		t.Fatalf("ResolveLocalCtldURL() = %q, want %q", got, "http://10.24.15.221:8095")
+	}
+}
+
+func newResolverPod(namespace, name, nodeName, podIP string, labels map[string]string, ready bool) *corev1.Pod {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			Labels:    labels,
+		},
+		Spec: corev1.PodSpec{
+			NodeName: nodeName,
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			PodIP: podIP,
+		},
+	}
+	pod.Status.Conditions = []corev1.PodCondition{{
+		Type:   corev1.PodReady,
+		Status: corev1.ConditionFalse,
+	}}
+	if ready {
+		pod.Status.Conditions[0].Status = corev1.ConditionTrue
+	}
+	return pod
+}


### PR DESCRIPTION
## Summary
- make storage-proxy prefer a ready local ctld pod but fall back to any ready ctld pod in the same deployment instance
- stop assuming storage-proxy always runs on a node that also runs ctld
- add resolver regression tests covering local preference, remote fallback, and instance scoping

## Why
managed-agents team asset store backfill exposed a production topology mismatch: storage-proxy was resolving ctld on its own system node (`<node-ip>:8095`), while ctld currently runs only on sandbox nodes. That breaks first-writer owner attach for newly created volumes.

## Testing
- `go test ./storage-proxy/pkg/http/...`
- `go test ./storage-proxy/...`