### PR TITLE
Gate sandbox readiness on volume portals

### DIFF
--- a/ctld/cmd/ctld/main.go
+++ b/ctld/cmd/ctld/main.go
@@ -249,6 +249,17 @@ func (c combinedController) UnbindVolumePortal(r *http.Request, req ctldapi.Unbi
 	return resp, http.StatusOK
 }
 
+func (c combinedController) CheckVolumePortals(r *http.Request, req ctldapi.CheckVolumePortalsRequest) (ctldapi.CheckVolumePortalsResponse, int) {
+	if c.Portal == nil {
+		return ctldapi.CheckVolumePortalsResponse{Error: "ctld volume portals not implemented"}, http.StatusNotImplemented
+	}
+	resp, err := c.Portal.CheckPublished(r.Context(), req)
+	if err != nil {
+		return ctldapi.CheckVolumePortalsResponse{Error: err.Error()}, volumePortalErrorStatus(err)
+	}
+	return resp, http.StatusOK
+}
+
 func (c combinedController) AttachVolumeOwner(r *http.Request, req ctldapi.AttachVolumeOwnerRequest) (ctldapi.AttachVolumeOwnerResponse, int) {
 	if c.Portal == nil {
 		return ctldapi.AttachVolumeOwnerResponse{Error: "ctld volume owners not implemented"}, http.StatusNotImplemented
@@ -326,6 +337,7 @@ func (c combinedController) Probe(r *http.Request, sandboxID string, kind sandbo
 type volumePortalHandler interface {
 	Bind(ctx context.Context, req ctldapi.BindVolumePortalRequest) (ctldapi.BindVolumePortalResponse, error)
 	Unbind(ctx context.Context, req ctldapi.UnbindVolumePortalRequest) (ctldapi.UnbindVolumePortalResponse, error)
+	CheckPublished(ctx context.Context, req ctldapi.CheckVolumePortalsRequest) (ctldapi.CheckVolumePortalsResponse, error)
 	AttachOwner(ctx context.Context, req ctldapi.AttachVolumeOwnerRequest) (ctldapi.AttachVolumeOwnerResponse, error)
 	PrepareHandoff(ctx context.Context, req ctldapi.PrepareVolumePortalHandoffRequest) (ctldapi.PrepareVolumePortalHandoffResponse, error)
 	CompleteHandoff(ctx context.Context, req ctldapi.CompleteVolumePortalHandoffRequest) (ctldapi.CompleteVolumePortalHandoffResponse, error)

--- a/ctld/cmd/ctld/main_test.go
+++ b/ctld/cmd/ctld/main_test.go
@@ -145,6 +145,10 @@ func (f fakeVolumePortalHandler) Unbind(_ context.Context, _ ctldapi.UnbindVolum
 	return ctldapi.UnbindVolumePortalResponse{}, nil
 }
 
+func (f fakeVolumePortalHandler) CheckPublished(_ context.Context, _ ctldapi.CheckVolumePortalsRequest) (ctldapi.CheckVolumePortalsResponse, error) {
+	return ctldapi.CheckVolumePortalsResponse{Ready: true}, nil
+}
+
 func (f fakeVolumePortalHandler) AttachOwner(_ context.Context, _ ctldapi.AttachVolumeOwnerRequest) (ctldapi.AttachVolumeOwnerResponse, error) {
 	return ctldapi.AttachVolumeOwnerResponse{Attached: true}, nil
 }

--- a/ctld/internal/ctld/portal/manager.go
+++ b/ctld/internal/ctld/portal/manager.go
@@ -451,6 +451,35 @@ func (m *Manager) Unbind(ctx context.Context, req ctldapi.UnbindVolumePortalRequ
 	return ctldapi.UnbindVolumePortalResponse{Unbound: true}, nil
 }
 
+func (m *Manager) CheckPublished(ctx context.Context, req ctldapi.CheckVolumePortalsRequest) (ctldapi.CheckVolumePortalsResponse, error) {
+	if err := ctx.Err(); err != nil {
+		return ctldapi.CheckVolumePortalsResponse{}, err
+	}
+	if strings.TrimSpace(req.PodUID) == "" {
+		return ctldapi.CheckVolumePortalsResponse{}, fmt.Errorf("pod_uid is required")
+	}
+	if len(req.Portals) == 0 {
+		return ctldapi.CheckVolumePortalsResponse{Ready: true}, nil
+	}
+
+	missing := make([]string, 0)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, portal := range req.Portals {
+		name := volumeportal.NormalizePortalName(portal.PortalName, portal.MountPath)
+		if name == "" {
+			continue
+		}
+		if m.portals[portalKey(req.PodUID, name)] == nil {
+			missing = append(missing, name)
+		}
+	}
+	return ctldapi.CheckVolumePortalsResponse{
+		Ready:   len(missing) == 0,
+		Missing: missing,
+	}, nil
+}
+
 func (m *Manager) AttachOwner(ctx context.Context, req ctldapi.AttachVolumeOwnerRequest) (ctldapi.AttachVolumeOwnerResponse, error) {
 	if err := ctx.Err(); err != nil {
 		return ctldapi.AttachVolumeOwnerResponse{}, err

--- a/ctld/internal/ctld/portal/manager_shared_test.go
+++ b/ctld/internal/ctld/portal/manager_shared_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	apiconfig "github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
+	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 	"github.com/sandbox0-ai/sandbox0/pkg/volumefuse"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volume"
@@ -67,6 +68,33 @@ func TestUnbindLockedSnapshotKeepsSharedVolumeUntilLastPortal(t *testing.T) {
 	}
 	if _, err := mgr.volumes.GetVolume("vol-1"); err == nil {
 		t.Fatal("GetVolume() after last unbind error = nil, want volume removed")
+	}
+}
+
+func TestCheckPublishedReportsMissingPortals(t *testing.T) {
+	mgr := &Manager{
+		portals: make(map[string]*portalMount),
+	}
+	mgr.portals[portalKey("pod-uid", "workspace")] = &portalMount{
+		podUID: "pod-uid",
+		name:   "workspace",
+	}
+
+	resp, err := mgr.CheckPublished(context.Background(), ctldapi.CheckVolumePortalsRequest{
+		PodUID: "pod-uid",
+		Portals: []ctldapi.VolumePortalRef{
+			{PortalName: "workspace", MountPath: "/workspace"},
+			{PortalName: "cache", MountPath: "/cache"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CheckPublished() error = %v", err)
+	}
+	if resp.Ready {
+		t.Fatal("CheckPublished() ready = true, want false")
+	}
+	if len(resp.Missing) != 1 || resp.Missing[0] != "cache" {
+		t.Fatalf("CheckPublished() missing = %v, want [cache]", resp.Missing)
 	}
 }
 

--- a/ctld/internal/ctld/server/server.go
+++ b/ctld/internal/ctld/server/server.go
@@ -20,6 +20,7 @@ type Controller interface {
 type VolumePortalController interface {
 	BindVolumePortal(r *http.Request, req ctldapi.BindVolumePortalRequest) (ctldapi.BindVolumePortalResponse, int)
 	UnbindVolumePortal(r *http.Request, req ctldapi.UnbindVolumePortalRequest) (ctldapi.UnbindVolumePortalResponse, int)
+	CheckVolumePortals(r *http.Request, req ctldapi.CheckVolumePortalsRequest) (ctldapi.CheckVolumePortalsResponse, int)
 	AttachVolumeOwner(r *http.Request, req ctldapi.AttachVolumeOwnerRequest) (ctldapi.AttachVolumeOwnerResponse, int)
 	PrepareVolumePortalHandoff(r *http.Request, req ctldapi.PrepareVolumePortalHandoffRequest) (ctldapi.PrepareVolumePortalHandoffResponse, int)
 	CompleteVolumePortalHandoff(r *http.Request, req ctldapi.CompleteVolumePortalHandoffRequest) (ctldapi.CompleteVolumePortalHandoffResponse, int)
@@ -108,6 +109,28 @@ func NewMux(controller Controller) http.Handler {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		resp, status := volumeController.UnbindVolumePortal(r, req)
+		w.WriteHeader(status)
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+	mux.HandleFunc("/api/v1/volume-portals/check", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		volumeController, ok := controller.(VolumePortalController)
+		if !ok {
+			w.WriteHeader(http.StatusNotImplemented)
+			_ = json.NewEncoder(w).Encode(ctldapi.CheckVolumePortalsResponse{Error: "ctld volume portals not implemented"})
+			return
+		}
+		var req ctldapi.CheckVolumePortalsRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(ctldapi.CheckVolumePortalsResponse{Error: err.Error()})
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		resp, status := volumeController.CheckVolumePortals(r, req)
 		w.WriteHeader(status)
 		_ = json.NewEncoder(w).Encode(resp)
 	})

--- a/manager/pkg/service/ctld_client.go
+++ b/manager/pkg/service/ctld_client.go
@@ -60,6 +60,10 @@ func (c *CtldClient) UnbindVolumePortal(ctx context.Context, ctldAddress string,
 	return doCtldJSONRequest[ctldapi.UnbindVolumePortalResponse](ctx, c.httpClient, ctldAddress, "/api/v1/volume-portals/unbind", req)
 }
 
+func (c *CtldClient) CheckVolumePortals(ctx context.Context, ctldAddress string, req ctldapi.CheckVolumePortalsRequest) (*ctldapi.CheckVolumePortalsResponse, error) {
+	return doCtldJSONRequest[ctldapi.CheckVolumePortalsResponse](ctx, c.httpClient, ctldAddress, "/api/v1/volume-portals/check", req)
+}
+
 func (c *CtldClient) PrepareVolumePortalHandoff(ctx context.Context, ctldAddress string, req ctldapi.PrepareVolumePortalHandoffRequest) (*ctldapi.PrepareVolumePortalHandoffResponse, error) {
 	return doCtldJSONRequest[ctldapi.PrepareVolumePortalHandoffResponse](ctx, c.httpClient, ctldAddress, "/api/v1/volume-portals/handoffs/prepare", req)
 }

--- a/manager/pkg/service/ctld_client_test.go
+++ b/manager/pkg/service/ctld_client_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
 	"github.com/sandbox0-ai/sandbox0/pkg/sandboxprobe"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -54,4 +55,33 @@ func TestCtldClientProbePod(t *testing.T) {
 	require.NotNil(t, resp)
 	assert.Equal(t, sandboxprobe.KindReadiness, resp.Kind)
 	assert.Equal(t, sandboxprobe.StatusPassed, resp.Status)
+}
+
+func TestCtldClientCheckVolumePortals(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/volume-portals/check", r.URL.Path)
+		var req ctldapi.CheckVolumePortalsRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		assert.Equal(t, "pod-uid", req.PodUID)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(ctldapi.CheckVolumePortalsResponse{
+			Ready:   false,
+			Missing: []string{"workspace"},
+		})
+	}))
+	defer server.Close()
+
+	client := NewCtldClient(CtldClientConfig{})
+	resp, err := client.CheckVolumePortals(context.Background(), server.URL, ctldapi.CheckVolumePortalsRequest{
+		PodUID: "pod-uid",
+		Portals: []ctldapi.VolumePortalRef{{
+			PortalName: "workspace",
+			MountPath:  "/workspace",
+		}},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.False(t, resp.Ready)
+	assert.Equal(t, []string{"workspace"}, resp.Missing)
 }

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -22,11 +22,13 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 	"github.com/sandbox0-ai/sandbox0/pkg/sandboxprobe"
+	"github.com/sandbox0-ai/sandbox0/pkg/volumeportal"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	k8stesting "k8s.io/client-go/testing"
@@ -504,6 +506,69 @@ func TestWaitForPodClaimReadyWaitsForProcdContainerRunning(t *testing.T) {
 	}
 	if !podContainerRunning(readyPod, "procd") {
 		t.Fatal("waitForPodClaimReady() returned before procd container was running")
+	}
+}
+
+func TestProbeSandboxPodReadinessRequiresPublishedVolumePortals(t *testing.T) {
+	pod := newClaimReadyTestPod("ns-a", "pod-a", "template-a")
+	pod.UID = types.UID("pod-uid")
+	pod.Spec.Volumes = []corev1.Volume{{
+		Name: "workspace",
+		VolumeSource: corev1.VolumeSource{
+			CSI: &corev1.CSIVolumeSource{
+				Driver: volumeportal.DriverName,
+				VolumeAttributes: map[string]string{
+					volumeportal.AttributePortalName: "workspace",
+					volumeportal.AttributeMountPath:  "/workspace",
+				},
+			},
+		},
+	}}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/pods/ns-a/pod-a/probes/readiness":
+			_ = json.NewEncoder(w).Encode(sandboxprobe.Passed(sandboxprobe.KindReadiness, "SandboxProbePassed", "sandbox probe passed", nil))
+		case "/api/v1/volume-portals/check":
+			var req ctldapi.CheckVolumePortalsRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode check request: %v", err)
+			}
+			if req.PodUID != "pod-uid" {
+				t.Fatalf("check pod UID = %q, want pod-uid", req.PodUID)
+			}
+			if len(req.Portals) != 1 || req.Portals[0].PortalName != "workspace" {
+				t.Fatalf("check portals = %+v, want workspace", req.Portals)
+			}
+			_ = json.NewEncoder(w).Encode(ctldapi.CheckVolumePortalsResponse{
+				Ready:   false,
+				Missing: []string{"workspace"},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	host, port := splitTestServerAddress(t, server)
+	svc := &SandboxService{
+		k8sClient:  fake.NewSimpleClientset(newClaimTestNode("node-a", host)),
+		ctldClient: NewCtldClient(CtldClientConfig{}),
+		config:     SandboxServiceConfig{CtldPort: port},
+	}
+
+	result, err := svc.ProbeSandboxPod(context.Background(), pod, sandboxprobe.KindReadiness)
+	if err != nil {
+		t.Fatalf("ProbeSandboxPod() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("ProbeSandboxPod() result = nil")
+	}
+	if result.Status != sandboxprobe.StatusFailed {
+		t.Fatalf("ProbeSandboxPod() status = %q, want failed", result.Status)
+	}
+	if result.Reason != "VolumePortalsNotReady" {
+		t.Fatalf("ProbeSandboxPod() reason = %q, want VolumePortalsNotReady", result.Reason)
 	}
 }
 

--- a/manager/pkg/service/sandbox_service_pod.go
+++ b/manager/pkg/service/sandbox_service_pod.go
@@ -7,7 +7,9 @@ import (
 	"time"
 
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
+	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
 	"github.com/sandbox0-ai/sandbox0/pkg/sandboxprobe"
+	"github.com/sandbox0-ai/sandbox0/pkg/volumeportal"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -183,10 +185,75 @@ func (s *SandboxService) ProbeSandboxPod(ctx context.Context, pod *corev1.Pod, k
 		return nil, err
 	}
 	result, err := s.ctldClient.ProbePod(ctx, ctldAddress, pod.Namespace, pod.Name, kind)
+	if err == nil && kind == sandboxprobe.KindReadiness && result != nil && result.Status == sandboxprobe.StatusPassed {
+		if portalErr := s.ensurePodVolumePortalsPublished(ctx, ctldAddress, pod); portalErr != nil {
+			failure := sandboxprobe.Failed(kind, "VolumePortalsNotReady", portalErr.Error(), nil)
+			return &failure, nil
+		}
+	}
 	if result != nil && result.Status != "" {
 		return result, nil
 	}
 	return result, err
+}
+
+func (s *SandboxService) ensurePodVolumePortalsPublished(ctx context.Context, ctldAddress string, pod *corev1.Pod) error {
+	if s == nil || s.ctldClient == nil || pod == nil {
+		return nil
+	}
+	portals := expectedVolumePortalsForPod(pod)
+	if len(portals) == 0 {
+		return nil
+	}
+	podUID := strings.TrimSpace(string(pod.UID))
+	if podUID == "" {
+		return fmt.Errorf("pod UID is not assigned")
+	}
+	resp, err := s.ctldClient.CheckVolumePortals(ctx, ctldAddress, ctldapi.CheckVolumePortalsRequest{
+		PodUID:  podUID,
+		Portals: portals,
+	})
+	if err != nil {
+		return fmt.Errorf("check volume portals: %w", err)
+	}
+	if resp == nil {
+		return fmt.Errorf("check volume portals returned no response")
+	}
+	if resp.Ready {
+		return nil
+	}
+	if len(resp.Missing) == 0 {
+		return fmt.Errorf("volume portals are not published")
+	}
+	return fmt.Errorf("volume portals are not published: %s", strings.Join(resp.Missing, ", "))
+}
+
+func expectedVolumePortalsForPod(pod *corev1.Pod) []ctldapi.VolumePortalRef {
+	if pod == nil {
+		return nil
+	}
+	portals := make([]ctldapi.VolumePortalRef, 0)
+	seen := make(map[string]struct{})
+	for _, volume := range pod.Spec.Volumes {
+		if volume.CSI == nil || volume.CSI.Driver != volumeportal.DriverName {
+			continue
+		}
+		attrs := volume.CSI.VolumeAttributes
+		mountPath := strings.TrimSpace(attrs[volumeportal.AttributeMountPath])
+		portalName := volumeportal.NormalizePortalName(attrs[volumeportal.AttributePortalName], mountPath)
+		if portalName == "" {
+			continue
+		}
+		if _, ok := seen[portalName]; ok {
+			continue
+		}
+		seen[portalName] = struct{}{}
+		portals = append(portals, ctldapi.VolumePortalRef{
+			PortalName: portalName,
+			MountPath:  mountPath,
+		})
+	}
+	return portals
 }
 
 func (s *SandboxService) probeSandboxPodOrFailure(ctx context.Context, pod *corev1.Pod, kind sandboxprobe.Kind) *sandboxprobe.Response {

--- a/pkg/ctldapi/types.go
+++ b/pkg/ctldapi/types.go
@@ -71,6 +71,24 @@ type UnbindVolumePortalResponse struct {
 	Error   string `json:"error,omitempty"`
 }
 
+// CheckVolumePortalsRequest checks that pod-local portal mounts have been
+// published by kubelet before the sandbox is considered claim-ready.
+type CheckVolumePortalsRequest struct {
+	PodUID  string            `json:"pod_uid"`
+	Portals []VolumePortalRef `json:"portals,omitempty"`
+}
+
+type VolumePortalRef struct {
+	PortalName string `json:"portal_name,omitempty"`
+	MountPath  string `json:"mount_path,omitempty"`
+}
+
+type CheckVolumePortalsResponse struct {
+	Ready   bool     `json:"ready"`
+	Missing []string `json:"missing,omitempty"`
+	Error   string   `json:"error,omitempty"`
+}
+
 type PrepareVolumePortalHandoffRequest struct {
 	SandboxVolumeID string `json:"sandboxvolume_id"`
 }


### PR DESCRIPTION
## Summary
- Add a ctld volume portal readiness check for expected pod-local CSI portals.
- Include that check in manager sandbox readiness probes, so `sandbox0.ai/ready` stays false until portals are published.
- Add coverage for ctld portal checking, the manager ctld client, and readiness failure when portals are missing.

## Testing
- `go test ./manager/pkg/service`
- `go test ./ctld/internal/ctld/portal`
- `go test ./ctld/internal/ctld/server ./ctld/cmd/ctld`
- `go test ./manager/...`
- `go test ./ctld/...`
- pre-push hook: `make manifests`, `make proto`, `make apispec`, `go fmt ./...`, `go mod tidy`, `go mod vendor`, `golangci-lint run ./...`