### PR TITLE
Force delete stale idle sandbox pods

### DIFF
--- a/manager/pkg/controller/pool_manager.go
+++ b/manager/pkg/controller/pool_manager.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	appslisters "k8s.io/client-go/listers/apps/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
@@ -124,7 +125,7 @@ func (pm *PoolManager) ReconcilePool(ctx context.Context, template *v1alpha1.San
 	}
 
 	// 3. Drain stale idle pods atomically with delete preconditions.
-	if err := pm.drainStaleIdlePods(ctx, template, desiredTemplateHash); err != nil {
+	if err := pm.drainStaleIdlePods(ctx, template, desiredTemplateHash, rs.UID); err != nil {
 		return fmt.Errorf("drain stale idle pods: %w", err)
 	}
 
@@ -271,7 +272,7 @@ func (pm *PoolManager) reconcileReplicaSetTemplate(
 	return updatedRS, nil
 }
 
-func (pm *PoolManager) drainStaleIdlePods(ctx context.Context, template *v1alpha1.SandboxTemplate, desiredTemplateHash string) error {
+func (pm *PoolManager) drainStaleIdlePods(ctx context.Context, template *v1alpha1.SandboxTemplate, desiredTemplateHash string, currentReplicaSetUID types.UID) error {
 	pods, err := pm.podLister.Pods(template.Namespace).List(labels.SelectorFromSet(map[string]string{
 		LabelTemplateID: template.Name,
 		LabelPoolType:   PoolTypeIdle,
@@ -284,15 +285,15 @@ func (pm *PoolManager) drainStaleIdlePods(ctx context.Context, template *v1alpha
 	now := time.Now()
 	for _, pod := range pods {
 		if pod.DeletionTimestamp != nil {
-			if pm.forceDeleteStaleDeletingIdlePod(ctx, template, pod, now) {
+			if pm.forceDeleteStaleDeletingIdlePod(ctx, template, pod, now, currentReplicaSetUID) {
 				drained++
 			}
 			continue
 		}
-		if pod.Annotations[AnnotationTemplateSpecHash] == desiredTemplateHash {
+		if pod.Annotations[AnnotationTemplateSpecHash] == desiredTemplateHash && idlePodOwnedByReplicaSet(pod, currentReplicaSetUID) {
 			continue
 		}
-		deleted, err := pm.deleteStaleIdlePodWithRetry(ctx, template.Namespace, pod.Name, desiredTemplateHash)
+		deleted, err := pm.deleteStaleIdlePodWithRetry(ctx, template.Namespace, pod.Name, desiredTemplateHash, currentReplicaSetUID)
 		if err != nil {
 			return err
 		}
@@ -303,7 +304,7 @@ func (pm *PoolManager) drainStaleIdlePods(ctx context.Context, template *v1alpha
 
 	if drained > 0 {
 		pm.recorder.Eventf(template, corev1.EventTypeNormal, "StaleIdlePodsDrained",
-			"Drained %d stale idle pod(s) with outdated template hash", drained)
+			"Drained %d stale idle pod(s) with outdated template hash or owner", drained)
 		pm.logger.Info("Drained stale idle pods",
 			zap.String("template", template.Name),
 			zap.Int("count", drained),
@@ -313,11 +314,12 @@ func (pm *PoolManager) drainStaleIdlePods(ctx context.Context, template *v1alpha
 	return nil
 }
 
-func (pm *PoolManager) forceDeleteStaleDeletingIdlePod(ctx context.Context, template *v1alpha1.SandboxTemplate, pod *corev1.Pod, now time.Time) bool {
+func (pm *PoolManager) forceDeleteStaleDeletingIdlePod(ctx context.Context, template *v1alpha1.SandboxTemplate, pod *corev1.Pod, now time.Time, currentReplicaSetUID types.UID) bool {
 	if pod == nil || pod.DeletionTimestamp == nil {
 		return false
 	}
-	if now.Sub(pod.DeletionTimestamp.Time) < staleDeletingPodForceDeleteAfter {
+	staleOwner := !idlePodOwnedByReplicaSet(pod, currentReplicaSetUID)
+	if !staleOwner && now.Sub(pod.DeletionTimestamp.Time) < staleDeletingPodForceDeleteAfter {
 		return false
 	}
 	if pm.k8sClient == nil {
@@ -338,6 +340,7 @@ func (pm *PoolManager) forceDeleteStaleDeletingIdlePod(ctx context.Context, temp
 	}
 	pm.logger.Warn("Force deleting stale terminating idle pod",
 		zap.String("pod", pod.Name),
+		zap.Bool("staleOwner", staleOwner),
 		zap.Time("deletionTimestamp", pod.DeletionTimestamp.Time),
 	)
 	if err := pm.k8sClient.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, deleteOptions); err != nil {
@@ -355,7 +358,7 @@ func (pm *PoolManager) forceDeleteStaleDeletingIdlePod(ctx context.Context, temp
 	return true
 }
 
-func (pm *PoolManager) deleteStaleIdlePodWithRetry(ctx context.Context, namespace, podName, desiredTemplateHash string) (bool, error) {
+func (pm *PoolManager) deleteStaleIdlePodWithRetry(ctx context.Context, namespace, podName, desiredTemplateHash string, currentReplicaSetUID types.UID) (bool, error) {
 	// Retry small transient races while still validating the pod is stale+idle.
 	deleted := false
 	retryErr := retry.OnError(retry.DefaultRetry, func(err error) bool {
@@ -369,19 +372,28 @@ func (pm *PoolManager) deleteStaleIdlePodWithRetry(ctx context.Context, namespac
 			return err
 		}
 
-		// If pod has been claimed or already updated to latest hash, skip delete.
-		if pod.Labels[LabelPoolType] != PoolTypeIdle || pod.Annotations[AnnotationTemplateSpecHash] == desiredTemplateHash {
+		if pod.Labels[LabelPoolType] != PoolTypeIdle {
+			return nil
+		}
+		staleHash := pod.Annotations[AnnotationTemplateSpecHash] != desiredTemplateHash
+		staleOwner := !idlePodOwnedByReplicaSet(pod, currentReplicaSetUID)
+		if !staleHash && !staleOwner {
 			return nil
 		}
 
 		uid := pod.UID
 		resourceVersion := pod.ResourceVersion
-		err = pm.k8sClient.CoreV1().Pods(namespace).Delete(ctx, podName, metav1.DeleteOptions{
+		deleteOptions := metav1.DeleteOptions{
 			Preconditions: &metav1.Preconditions{
 				UID:             &uid,
 				ResourceVersion: &resourceVersion,
 			},
-		})
+		}
+		if staleOwner {
+			gracePeriodSeconds := int64(0)
+			deleteOptions.GracePeriodSeconds = &gracePeriodSeconds
+		}
+		err = pm.k8sClient.CoreV1().Pods(namespace).Delete(ctx, podName, deleteOptions)
 		if err != nil && !errors.IsNotFound(err) {
 			return err
 		}
@@ -392,6 +404,14 @@ func (pm *PoolManager) deleteStaleIdlePodWithRetry(ctx context.Context, namespac
 		return false, retryErr
 	}
 	return deleted, nil
+}
+
+func idlePodOwnedByReplicaSet(pod *corev1.Pod, replicaSetUID types.UID) bool {
+	if pod == nil || replicaSetUID == "" {
+		return true
+	}
+	controllerRef := metav1.GetControllerOf(pod)
+	return controllerRef != nil && controllerRef.UID == replicaSetUID
 }
 
 // TemplateSpecHash returns the pod spec hash used to identify current idle pods.

--- a/manager/pkg/controller/pool_manager.go
+++ b/manager/pkg/controller/pool_manager.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
@@ -280,7 +281,14 @@ func (pm *PoolManager) drainStaleIdlePods(ctx context.Context, template *v1alpha
 	}
 
 	drained := 0
+	now := time.Now()
 	for _, pod := range pods {
+		if pod.DeletionTimestamp != nil {
+			if pm.forceDeleteStaleDeletingIdlePod(ctx, template, pod, now) {
+				drained++
+			}
+			continue
+		}
 		if pod.Annotations[AnnotationTemplateSpecHash] == desiredTemplateHash {
 			continue
 		}
@@ -305,8 +313,51 @@ func (pm *PoolManager) drainStaleIdlePods(ctx context.Context, template *v1alpha
 	return nil
 }
 
+func (pm *PoolManager) forceDeleteStaleDeletingIdlePod(ctx context.Context, template *v1alpha1.SandboxTemplate, pod *corev1.Pod, now time.Time) bool {
+	if pod == nil || pod.DeletionTimestamp == nil {
+		return false
+	}
+	if now.Sub(pod.DeletionTimestamp.Time) < staleDeletingPodForceDeleteAfter {
+		return false
+	}
+	if pm.k8sClient == nil {
+		pm.logger.Warn("Kubernetes client not configured, skipping stale deleting idle pod force delete",
+			zap.String("pod", pod.Name),
+			zap.Time("deletionTimestamp", pod.DeletionTimestamp.Time),
+		)
+		return false
+	}
+
+	gracePeriodSeconds := int64(0)
+	uid := pod.UID
+	deleteOptions := metav1.DeleteOptions{
+		GracePeriodSeconds: &gracePeriodSeconds,
+		Preconditions: &metav1.Preconditions{
+			UID: &uid,
+		},
+	}
+	pm.logger.Warn("Force deleting stale terminating idle pod",
+		zap.String("pod", pod.Name),
+		zap.Time("deletionTimestamp", pod.DeletionTimestamp.Time),
+	)
+	if err := pm.k8sClient.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, deleteOptions); err != nil {
+		if errors.IsNotFound(err) {
+			return false
+		}
+		pm.logger.Error("Failed to force delete stale terminating idle pod",
+			zap.String("pod", pod.Name),
+			zap.Error(err),
+		)
+		return false
+	}
+	pm.recorder.Eventf(template, corev1.EventTypeWarning, "StaleDeletingIdlePodForceDeleted",
+		"Force deleted stale terminating idle pod %s", pod.Name)
+	return true
+}
+
 func (pm *PoolManager) deleteStaleIdlePodWithRetry(ctx context.Context, namespace, podName, desiredTemplateHash string) (bool, error) {
 	// Retry small transient races while still validating the pod is stale+idle.
+	deleted := false
 	retryErr := retry.OnError(retry.DefaultRetry, func(err error) bool {
 		return errors.IsConflict(err) || errors.IsInvalid(err)
 	}, func() error {
@@ -334,12 +385,13 @@ func (pm *PoolManager) deleteStaleIdlePodWithRetry(ctx context.Context, namespac
 		if err != nil && !errors.IsNotFound(err) {
 			return err
 		}
+		deleted = err == nil
 		return nil
 	})
 	if retryErr != nil {
 		return false, retryErr
 	}
-	return false, nil
+	return deleted, nil
 }
 
 // TemplateSpecHash returns the pod spec hash used to identify current idle pods.

--- a/manager/pkg/controller/pool_manager_test.go
+++ b/manager/pkg/controller/pool_manager_test.go
@@ -106,7 +106,7 @@ func TestDrainStaleIdlePodsUsesDeletePreconditions(t *testing.T) {
 		logger:    zap.NewNop(),
 	}
 
-	err := pm.drainStaleIdlePods(context.Background(), template, "new-hash")
+	err := pm.drainStaleIdlePods(context.Background(), template, "new-hash", "")
 	require.NoError(t, err)
 	assert.Equal(t, 1, deleteActions)
 }
@@ -164,7 +164,7 @@ func TestDrainStaleIdlePodsForceDeletesStaleDeletingPods(t *testing.T) {
 		logger:    zap.NewNop(),
 	}
 
-	err := pm.drainStaleIdlePods(context.Background(), template, "new-hash")
+	err := pm.drainStaleIdlePods(context.Background(), template, "new-hash", "")
 	require.NoError(t, err)
 	assert.Equal(t, 1, deleteActions)
 	select {
@@ -173,6 +173,97 @@ func TestDrainStaleIdlePodsForceDeletesStaleDeletingPods(t *testing.T) {
 	default:
 		t.Fatal("expected stale idle force-delete event")
 	}
+}
+
+func TestDrainStaleIdlePodsDeletesPodsFromOldReplicaSet(t *testing.T) {
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "template-a",
+			Namespace: "default",
+		},
+	}
+	controllerRef := true
+	oldOwner := metav1.OwnerReference{
+		APIVersion: "apps/v1",
+		Kind:       "ReplicaSet",
+		Name:       "old-rs",
+		UID:        types.UID("old-rs-uid"),
+		Controller: &controllerRef,
+	}
+	currentOwner := metav1.OwnerReference{
+		APIVersion: "apps/v1",
+		Kind:       "ReplicaSet",
+		Name:       "current-rs",
+		UID:        types.UID("current-rs-uid"),
+		Controller: &controllerRef,
+	}
+
+	oldPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "idle-old-owner",
+			Namespace:       "default",
+			UID:             types.UID("uid-old-owner"),
+			ResourceVersion: "41",
+			Labels: map[string]string{
+				LabelTemplateID: "template-a",
+				LabelPoolType:   PoolTypeIdle,
+			},
+			Annotations: map[string]string{
+				AnnotationTemplateSpecHash: "new-hash",
+			},
+			OwnerReferences: []metav1.OwnerReference{oldOwner},
+		},
+	}
+	currentPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "idle-current-owner",
+			Namespace:       "default",
+			UID:             types.UID("uid-current-owner"),
+			ResourceVersion: "42",
+			Labels: map[string]string{
+				LabelTemplateID: "template-a",
+				LabelPoolType:   PoolTypeIdle,
+			},
+			Annotations: map[string]string{
+				AnnotationTemplateSpecHash: "new-hash",
+			},
+			OwnerReferences: []metav1.OwnerReference{currentOwner},
+		},
+	}
+
+	client := fake.NewSimpleClientset(oldPod, currentPod)
+	podIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	require.NoError(t, podIndexer.Add(oldPod))
+	require.NoError(t, podIndexer.Add(currentPod))
+	podLister := corelisters.NewPodLister(podIndexer)
+
+	deleteActions := 0
+	client.PrependReactor("delete", "pods", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		delAction, ok := action.(k8stesting.DeleteAction)
+		require.True(t, ok)
+		deleteActions++
+		assert.Equal(t, "idle-old-owner", delAction.GetName())
+		opts := delAction.GetDeleteOptions()
+		require.NotNil(t, opts.GracePeriodSeconds)
+		assert.Equal(t, int64(0), *opts.GracePeriodSeconds)
+		require.NotNil(t, opts.Preconditions)
+		require.NotNil(t, opts.Preconditions.UID)
+		require.NotNil(t, opts.Preconditions.ResourceVersion)
+		assert.Equal(t, types.UID("uid-old-owner"), *opts.Preconditions.UID)
+		assert.Equal(t, "41", *opts.Preconditions.ResourceVersion)
+		return false, nil, nil
+	})
+
+	pm := &PoolManager{
+		k8sClient: client,
+		podLister: podLister,
+		recorder:  record.NewFakeRecorder(10),
+		logger:    zap.NewNop(),
+	}
+
+	err := pm.drainStaleIdlePods(context.Background(), template, "new-hash", types.UID("current-rs-uid"))
+	require.NoError(t, err)
+	assert.Equal(t, 1, deleteActions)
 }
 
 func TestDrainStaleIdlePodsSkipsClaimedActivePods(t *testing.T) {
@@ -217,7 +308,7 @@ func TestDrainStaleIdlePodsSkipsClaimedActivePods(t *testing.T) {
 		logger:    zap.NewNop(),
 	}
 
-	err := pm.drainStaleIdlePods(context.Background(), template, "new-hash")
+	err := pm.drainStaleIdlePods(context.Background(), template, "new-hash", "")
 	require.NoError(t, err)
 	assert.Equal(t, 0, deleteActions)
 }

--- a/manager/pkg/controller/pool_manager_test.go
+++ b/manager/pkg/controller/pool_manager_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 	"github.com/stretchr/testify/assert"
@@ -108,6 +109,70 @@ func TestDrainStaleIdlePodsUsesDeletePreconditions(t *testing.T) {
 	err := pm.drainStaleIdlePods(context.Background(), template, "new-hash")
 	require.NoError(t, err)
 	assert.Equal(t, 1, deleteActions)
+}
+
+func TestDrainStaleIdlePodsForceDeletesStaleDeletingPods(t *testing.T) {
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "template-a",
+			Namespace: "default",
+		},
+	}
+
+	deletedAt := metav1.NewTime(time.Now().Add(-30 * time.Minute))
+	staleDeletingPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "idle-terminating",
+			Namespace:         "default",
+			UID:               types.UID("uid-terminating"),
+			ResourceVersion:   "31",
+			DeletionTimestamp: &deletedAt,
+			Labels: map[string]string{
+				LabelTemplateID: "template-a",
+				LabelPoolType:   PoolTypeIdle,
+			},
+			Annotations: map[string]string{
+				AnnotationTemplateSpecHash: "new-hash",
+			},
+		},
+	}
+
+	client := fake.NewSimpleClientset(staleDeletingPod)
+	podIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	require.NoError(t, podIndexer.Add(staleDeletingPod))
+	podLister := corelisters.NewPodLister(podIndexer)
+
+	deleteActions := 0
+	client.PrependReactor("delete", "pods", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		delAction, ok := action.(k8stesting.DeleteAction)
+		require.True(t, ok)
+		deleteActions++
+		opts := delAction.GetDeleteOptions()
+		require.NotNil(t, opts.GracePeriodSeconds)
+		assert.Equal(t, int64(0), *opts.GracePeriodSeconds)
+		require.NotNil(t, opts.Preconditions)
+		require.NotNil(t, opts.Preconditions.UID)
+		assert.Equal(t, types.UID("uid-terminating"), *opts.Preconditions.UID)
+		return false, nil, nil
+	})
+
+	recorder := record.NewFakeRecorder(10)
+	pm := &PoolManager{
+		k8sClient: client,
+		podLister: podLister,
+		recorder:  recorder,
+		logger:    zap.NewNop(),
+	}
+
+	err := pm.drainStaleIdlePods(context.Background(), template, "new-hash")
+	require.NoError(t, err)
+	assert.Equal(t, 1, deleteActions)
+	select {
+	case event := <-recorder.Events:
+		assert.Contains(t, event, "StaleDeletingIdlePodForceDeleted")
+	default:
+		t.Fatal("expected stale idle force-delete event")
+	}
 }
 
 func TestDrainStaleIdlePodsSkipsClaimedActivePods(t *testing.T) {

--- a/manager/pkg/service/template_service.go
+++ b/manager/pkg/service/template_service.go
@@ -300,7 +300,14 @@ func (s *TemplateService) deleteTemplatePods(ctx context.Context, namespace, tem
 		if poolType != controller.PoolTypeIdle && poolType != controller.PoolTypeActive {
 			continue
 		}
-		if err := s.k8sClient.CoreV1().Pods(namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+		deleteOptions := metav1.DeleteOptions{}
+		if poolType == controller.PoolTypeIdle {
+			gracePeriodSeconds := int64(0)
+			uid := pod.UID
+			deleteOptions.GracePeriodSeconds = &gracePeriodSeconds
+			deleteOptions.Preconditions = &metav1.Preconditions{UID: &uid}
+		}
+		if err := s.k8sClient.CoreV1().Pods(namespace).Delete(ctx, pod.Name, deleteOptions); err != nil && !errors.IsNotFound(err) {
 			return fmt.Errorf("delete template pod %s/%s: %w", namespace, pod.Name, err)
 		}
 	}

--- a/manager/pkg/service/template_service_test.go
+++ b/manager/pkg/service/template_service_test.go
@@ -17,8 +17,10 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 	corelisters "k8s.io/client-go/listers/core/v1"
+	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -301,6 +303,48 @@ func TestDeleteLastTeamTemplateDeletesManagedNamespace(t *testing.T) {
 	require.True(t, apierrors.IsNotFound(err), "last team template CRD should be deleted")
 	_, err = k8sClient.CoreV1().Pods(namespace).Get(ctx, pod.Name, metav1.GetOptions{})
 	require.True(t, apierrors.IsNotFound(err), "last team template pod should be deleted")
+}
+
+func TestDeleteTemplateForceDeletesIdleTemplatePods(t *testing.T) {
+	ctx := context.Background()
+	namespace, err := naming.TemplateNamespaceForTeam("team-123")
+	require.NoError(t, err)
+
+	template := teamTemplate(namespace, "demo", "team-123")
+	idlePod := templatePod(namespace, "idle-pod", "demo", controller.PoolTypeIdle)
+	idlePod.UID = types.UID("idle-uid")
+	activePod := templatePod(namespace, "active-pod", "demo", controller.PoolTypeActive)
+	activePod.UID = types.UID("active-uid")
+	k8sClient := fake.NewSimpleClientset(
+		managedNamespace(namespace),
+		idlePod,
+		activePod,
+	)
+	service, _ := newTemplateServiceForDeleteTests(k8sClient, template)
+
+	deleteOptionsByPod := map[string]metav1.DeleteOptions{}
+	k8sClient.PrependReactor("delete", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		deleteAction, ok := action.(k8stesting.DeleteAction)
+		require.True(t, ok)
+		deleteOptionsByPod[deleteAction.GetName()] = deleteAction.GetDeleteOptions()
+		return false, nil, nil
+	})
+
+	err = service.DeleteTemplate(ctx, "demo")
+	require.NoError(t, err)
+
+	idleOptions, ok := deleteOptionsByPod["idle-pod"]
+	require.True(t, ok, "idle pod should be deleted")
+	require.NotNil(t, idleOptions.GracePeriodSeconds)
+	assert.Equal(t, int64(0), *idleOptions.GracePeriodSeconds)
+	require.NotNil(t, idleOptions.Preconditions)
+	require.NotNil(t, idleOptions.Preconditions.UID)
+	assert.Equal(t, types.UID("idle-uid"), *idleOptions.Preconditions.UID)
+
+	activeOptions, ok := deleteOptionsByPod["active-pod"]
+	require.True(t, ok, "active pod should be deleted")
+	assert.Nil(t, activeOptions.GracePeriodSeconds)
+	assert.Nil(t, activeOptions.Preconditions)
 }
 
 func managedNamespace(name string) *corev1.Namespace {


### PR DESCRIPTION
## Summary
- Force delete idle sandbox pods that have been terminating longer than the existing stale pod threshold.
- Drain idle sandbox pods that still belong to an old ReplicaSet, even when the template hash is unchanged.
- Force delete idle sandbox pods during template deletion so team template namespace cleanup is not blocked by lingering idle pods.
- Keep the fix scoped to sandbox pool pods and preserve UID preconditions for deletion.
- Return the actual stale idle delete result so drain events reflect successful deletes.

## Testing
- go test ./manager/pkg/controller
- go test ./manager/pkg/controller ./manager/pkg/service
- git push pre-push hook: make manifests, make proto, make apispec, go fmt ./..., go mod tidy, go mod vendor, golangci-lint run ./...