### PR TITLE
Fix S0FS hard link handling

### DIFF
--- a/storage-proxy/pkg/fsserver/server.go
+++ b/storage-proxy/pkg/fsserver/server.go
@@ -1756,6 +1756,24 @@ func (s *FileSystemServer) Readlink(ctx context.Context, req *pb.ReadlinkRequest
 // Link implements FUSE link (create hard link)
 func (s *FileSystemServer) Link(ctx context.Context, req *pb.LinkRequest) (*pb.NodeResponse, error) {
 	return withAuthorizedVolumeMutation(s, ctx, req.VolumeId, func(runCtx context.Context, volCtx *volume.VolumeContext) (*pb.NodeResponse, error) {
+		if isS0FSVolume(volCtx) {
+			path := resolveChildPath(volCtx, req.NewParent, req.NewName)
+			node, err := volCtx.S0FS.Link(req.Inode, req.NewParent, req.NewName)
+			if err != nil {
+				return nil, mapS0FSError(err)
+			}
+			eventType := pb.WatchEventType_WATCH_EVENT_TYPE_CREATE
+			if path == "" {
+				eventType = pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE
+			}
+			s.publishEvent(runCtx, &pb.WatchEvent{
+				VolumeId:  req.VolumeId,
+				EventType: eventType,
+				Path:      path,
+				Inode:     node.Inode,
+			})
+			return s0fsNodeResponse(node, 0), nil
+		}
 		inode := mapInode(volCtx, req.Inode)
 		newParent := mapInode(volCtx, req.NewParent)
 		path := resolveChildPath(volCtx, uint64(newParent), req.NewName)

--- a/storage-proxy/pkg/fsserver/server_s0fs_test.go
+++ b/storage-proxy/pkg/fsserver/server_s0fs_test.go
@@ -683,6 +683,78 @@ func TestS0FSMutationRedirectsWhenRemotePrimary(t *testing.T) {
 	}
 }
 
+func TestS0FSLinkCreatesHardLink(t *testing.T) {
+	t.Parallel()
+
+	volCtx := newMountedS0FSVolumeContext(t, "vol-1", "team-a")
+	server := newTestFileSystemServer(&fakeVolumeManager{
+		volumes: map[string]*volume.VolumeContext{
+			"vol-1": volCtx,
+		},
+	}, nil, nil)
+	ctx := authContext("team-a", "")
+
+	createResp, err := server.Create(ctx, &pb.CreateRequest{
+		VolumeId: "vol-1",
+		Parent:   1,
+		Name:     "source.txt",
+		Mode:     0o644,
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if _, err := server.Write(ctx, &pb.WriteRequest{
+		VolumeId: "vol-1",
+		Inode:    createResp.Inode,
+		Offset:   0,
+		Data:     []byte("payload"),
+		HandleId: createResp.HandleId,
+	}); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	linkResp, err := server.Link(ctx, &pb.LinkRequest{
+		VolumeId:  "vol-1",
+		Inode:     createResp.Inode,
+		NewParent: 1,
+		NewName:   "linked.txt",
+	})
+	if err != nil {
+		t.Fatalf("Link() error = %v", err)
+	}
+	if linkResp.Inode != createResp.Inode {
+		t.Fatalf("Link() inode = %d, want source inode %d", linkResp.Inode, createResp.Inode)
+	}
+
+	lookupResp, err := server.Lookup(ctx, &pb.LookupRequest{
+		VolumeId: "vol-1",
+		Parent:   1,
+		Name:     "linked.txt",
+	})
+	if err != nil {
+		t.Fatalf("Lookup(linked) error = %v", err)
+	}
+	if lookupResp.Inode != createResp.Inode {
+		t.Fatalf("Lookup(linked) inode = %d, want source inode %d", lookupResp.Inode, createResp.Inode)
+	}
+	if lookupResp.Attr == nil || lookupResp.Attr.Nlink != 2 {
+		t.Fatalf("Lookup(linked) nlink = %#v, want 2", lookupResp.Attr)
+	}
+
+	readResp, err := server.Read(ctx, &pb.ReadRequest{
+		VolumeId: "vol-1",
+		Inode:    lookupResp.Inode,
+		Offset:   0,
+		Size:     32,
+	})
+	if err != nil {
+		t.Fatalf("Read(linked) error = %v", err)
+	}
+	if string(readResp.Data) != "payload" {
+		t.Fatalf("Read(linked) data = %q, want payload", readResp.Data)
+	}
+}
+
 func newMountedS0FSVolumeContext(t *testing.T, volumeID, teamID string) *volume.VolumeContext {
 	t.Helper()
 

--- a/storage-proxy/pkg/s0fs/engine.go
+++ b/storage-proxy/pkg/s0fs/engine.go
@@ -240,6 +240,42 @@ func (e *Engine) Symlink(parent uint64, name, target string, mode uint32) (*Node
 	return e.create(parent, name, TypeSymlink, mode, target)
 }
 
+func (e *Engine) Link(inode uint64, newParent uint64, newName string) (*Node, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if err := e.checkOpen(); err != nil {
+		return nil, err
+	}
+	if newName == "" {
+		return nil, fmt.Errorf("%w: empty link name", ErrInvalidInput)
+	}
+	node, ok := e.nodes[inode]
+	if !ok || node == nil {
+		return nil, ErrNotFound
+	}
+	if node.Type == TypeDirectory {
+		return nil, ErrIsDir
+	}
+	if err := e.ensureDirLocked(newParent); err != nil {
+		return nil, err
+	}
+	if _, exists := e.children[newParent][newName]; exists {
+		return nil, ErrExists
+	}
+	record := e.newRecord("link")
+	record.Inode = inode
+	record.NewParent = newParent
+	record.NewName = newName
+	if err := e.wal.append(record); err != nil {
+		return nil, err
+	}
+	if err := e.apply(record); err != nil {
+		return nil, err
+	}
+	e.markDirtyLocked()
+	return cloneNode(e.nodes[inode]), nil
+}
+
 func (e *Engine) Write(inode uint64, offset uint64, payload []byte) (int, error) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -771,6 +807,8 @@ func (e *Engine) apply(record walRecord) error {
 		return e.applyCreate(record)
 	case "write":
 		return e.applyWrite(record)
+	case "link":
+		return e.applyLink(record)
 	case "rmdir":
 		return e.applyRemoveDir(record)
 	case "rename":
@@ -820,6 +858,29 @@ func (e *Engine) applyCreate(record walRecord) error {
 	if record.Inode >= e.nextInode {
 		e.nextInode = record.Inode + 1
 	}
+	return nil
+}
+
+func (e *Engine) applyLink(record walRecord) error {
+	if record.Inode == 0 || record.NewParent == 0 || record.NewName == "" {
+		return fmt.Errorf("%w: invalid link record", ErrInvalidInput)
+	}
+	node := e.nodes[record.Inode]
+	if node == nil {
+		return ErrNotFound
+	}
+	if node.Type == TypeDirectory {
+		return ErrIsDir
+	}
+	if err := e.ensureDirLocked(record.NewParent); err != nil {
+		return err
+	}
+	if _, exists := e.children[record.NewParent][record.NewName]; exists {
+		return ErrExists
+	}
+	e.children[record.NewParent][record.NewName] = record.Inode
+	node.Nlink++
+	node.Ctime = time.Unix(0, record.TimeUnix).UTC()
 	return nil
 }
 

--- a/storage-proxy/pkg/s0fs/engine_test.go
+++ b/storage-proxy/pkg/s0fs/engine_test.go
@@ -171,6 +171,51 @@ func TestEngineRejectsDuplicateDentry(t *testing.T) {
 	}
 }
 
+func TestEngineLinkReplay(t *testing.T) {
+	walPath := filepath.Join(t.TempDir(), "volume.wal")
+	engine, err := Open(context.Background(), Config{VolumeID: "vol-1", WALPath: walPath})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	node, err := engine.CreateFile(RootInode, "source.txt", 0o644)
+	if err != nil {
+		t.Fatalf("CreateFile() error = %v", err)
+	}
+	if _, err := engine.Write(node.Inode, 0, []byte("payload")); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	linked, err := engine.Link(node.Inode, RootInode, "linked.txt")
+	if err != nil {
+		t.Fatalf("Link() error = %v", err)
+	}
+	if linked.Inode != node.Inode || linked.Nlink != 2 {
+		t.Fatalf("Link() node = %#v, want same inode with nlink 2", linked)
+	}
+	if err := engine.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	replayed, err := Open(context.Background(), Config{VolumeID: "vol-1", WALPath: walPath})
+	if err != nil {
+		t.Fatalf("Open(replay) error = %v", err)
+	}
+	defer replayed.Close()
+	replayedNode, err := replayed.Lookup(RootInode, "linked.txt")
+	if err != nil {
+		t.Fatalf("Lookup(linked) error = %v", err)
+	}
+	if replayedNode.Inode != node.Inode || replayedNode.Nlink != 2 {
+		t.Fatalf("Lookup(linked) node = %#v, want same inode with nlink 2", replayedNode)
+	}
+	data, err := replayed.Read(replayedNode.Inode, 0, 1024)
+	if err != nil {
+		t.Fatalf("Read(linked) error = %v", err)
+	}
+	if !bytes.Equal(data, []byte("payload")) {
+		t.Fatalf("Read(linked) data = %q, want payload", data)
+	}
+}
+
 func TestEngineDirectoryOperationsReplay(t *testing.T) {
 	walPath := filepath.Join(t.TempDir(), "volume.wal")
 	engine, err := Open(context.Background(), Config{VolumeID: "vol-1", WALPath: walPath})


### PR DESCRIPTION
## Summary
- Add S0FS hard-link support and WAL replay handling.
- Route fsserver `Link` requests through S0FS instead of the legacy VFS fallback.
- Add engine and fsserver regression tests for hard links.

Refs #274

## Testing
- `go test ./storage-proxy/pkg/s0fs ./storage-proxy/pkg/fsserver`
- pre-push hook: `make manifests`, `make proto`, `make apispec`, `go fmt ./...`, `go mod tidy`, `go mod vendor`, `golangci-lint run ./...`