### PR TITLE
Implement copy-on-write S0FS volume fork

### DIFF
--- a/ctld/internal/ctld/portal/manager.go
+++ b/ctld/internal/ctld/portal/manager.go
@@ -342,7 +342,10 @@ func (m *Manager) Bind(ctx context.Context, req ctldapi.BindVolumePortalRequest)
 		VolumeID:    req.SandboxVolumeID,
 		WALPath:     filepath.Join(cacheDir, "engine.wal"),
 		ObjectStore: remoteStore,
-		HeadStore:   db.NewS0FSHeadStore(m.repo),
+		ObjectStoreForVolume: func(volumeID string) (objectstore.Store, error) {
+			return m.createObjectStore(req.TeamID, volumeID)
+		},
+		HeadStore: db.NewS0FSHeadStore(m.repo),
 	})
 	if err != nil {
 		return ctldapi.BindVolumePortalResponse{}, fmt.Errorf("open local s0fs engine: %w", err)
@@ -520,7 +523,10 @@ func (m *Manager) AttachOwner(ctx context.Context, req ctldapi.AttachVolumeOwner
 		VolumeID:    req.SandboxVolumeID,
 		WALPath:     filepath.Join(cacheDir, "engine.wal"),
 		ObjectStore: remoteStore,
-		HeadStore:   db.NewS0FSHeadStore(m.repo),
+		ObjectStoreForVolume: func(volumeID string) (objectstore.Store, error) {
+			return m.createObjectStore(req.TeamID, volumeID)
+		},
+		HeadStore: db.NewS0FSHeadStore(m.repo),
 	})
 	if err != nil {
 		return ctldapi.AttachVolumeOwnerResponse{}, fmt.Errorf("open local s0fs engine: %w", err)

--- a/storage-proxy/pkg/s0fs/engine.go
+++ b/storage-proxy/pkg/s0fs/engine.go
@@ -48,7 +48,7 @@ func Open(ctx context.Context, cfg Config) (*Engine, error) {
 	}
 
 	state, err := loadCurrentState(cfg)
-	materializer := NewMaterializer(cfg.VolumeID, cfg.ObjectStore, cfg.HeadStore)
+	materializer := NewMaterializer(cfg.VolumeID, cfg.ObjectStore, cfg.HeadStore, cfg.ObjectStoreForVolume)
 	var latestManifest *Manifest
 	if materializer != nil {
 		latestState, manifest, latestErr := materializer.LoadLatestState(ctx)

--- a/storage-proxy/pkg/s0fs/materializer.go
+++ b/storage-proxy/pkg/s0fs/materializer.go
@@ -37,21 +37,27 @@ type Manifest struct {
 }
 
 type Materializer struct {
-	volumeID  string
-	store     objectstore.Store
-	headStore HeadStore
-	cache     *segmentCache
+	volumeID             string
+	store                objectstore.Store
+	objectStoreForVolume ObjectStoreResolver
+	headStore            HeadStore
+	cache                *segmentCache
 }
 
-func NewMaterializer(volumeID string, store objectstore.Store, headStore HeadStore) *Materializer {
+func NewMaterializer(volumeID string, store objectstore.Store, headStore HeadStore, resolvers ...ObjectStoreResolver) *Materializer {
 	if store == nil {
 		return nil
 	}
+	var resolver ObjectStoreResolver
+	if len(resolvers) > 0 {
+		resolver = resolvers[0]
+	}
 	return &Materializer{
-		volumeID:  volumeID,
-		store:     store,
-		headStore: headStore,
-		cache:     newSegmentCache(defaultSegmentCacheMaxBytes),
+		volumeID:             volumeID,
+		store:                store,
+		objectStoreForVolume: resolver,
+		headStore:            headStore,
+		cache:                newSegmentCache(defaultSegmentCacheMaxBytes),
 	}
 }
 
@@ -75,6 +81,7 @@ func (m *Materializer) Materialize(ctx context.Context, state *SnapshotState, ex
 
 	inline := cloneState(state)
 	normalizeState(inline)
+	defaultSegmentVolumeIDs(inline, m.volumeID)
 
 	nextSeq := checkpointSequence(inline)
 	if nextSeq == 0 {
@@ -84,7 +91,7 @@ func (m *Materializer) Materialize(ctx context.Context, state *SnapshotState, ex
 		return nil, fmt.Errorf("%w: manifest seq %d must advance beyond %d", ErrCommittedHeadConflict, nextSeq, expectedManifestSeq)
 	}
 
-	segment, fileExtents, err := buildSegment(nextSeq, inline)
+	segment, fileExtents, err := buildSegment(nextSeq, m.volumeID, inline)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +113,7 @@ func (m *Materializer) Materialize(ctx context.Context, state *SnapshotState, ex
 		if err := m.putBytes(ctx, segment.Key, segment.Payload); err != nil {
 			return nil, err
 		}
-		m.cache.put(segment.Key, segment.Payload)
+		m.cache.put(segmentCacheKey(segment.VolumeID, segment.Key), segment.Payload)
 	}
 	if err := m.putJSON(ctx, manifestKey(nextSeq), manifest); err != nil {
 		return nil, err
@@ -142,12 +149,17 @@ func (m *Materializer) ReadSegmentRange(segment *Segment, off, limit int64) ([]b
 	if off < 0 {
 		return nil, fmt.Errorf("%w: negative segment offset", ErrInvalidInput)
 	}
+	volumeID, store, err := m.storeForSegment(segment)
+	if err != nil {
+		return nil, err
+	}
+	cacheKey := segmentCacheKey(volumeID, segment.Key)
 
 	if segment.Length > 0 && int64(segment.Length) <= defaultSegmentCacheMaxBytes {
-		if payload, ok := m.cache.get(segment.Key); ok {
+		if payload, ok := m.cache.get(cacheKey); ok {
 			return cloneByteRange(payload, off, limit), nil
 		}
-		reader, err := m.store.Get(segment.Key, 0, int64(segment.Length))
+		reader, err := store.Get(segment.Key, 0, int64(segment.Length))
 		if err != nil {
 			return nil, err
 		}
@@ -159,11 +171,11 @@ func (m *Materializer) ReadSegmentRange(segment *Segment, off, limit int64) ([]b
 		if closeErr != nil {
 			return nil, closeErr
 		}
-		m.cache.put(segment.Key, payload)
+		m.cache.put(cacheKey, payload)
 		return cloneByteRange(payload, off, limit), nil
 	}
 
-	reader, err := m.store.Get(segment.Key, off, limit)
+	reader, err := store.Get(segment.Key, off, limit)
 	if err != nil {
 		return nil, err
 	}
@@ -226,13 +238,14 @@ func (m *Materializer) LoadLatestState(ctx context.Context) (*SnapshotState, *Ma
 }
 
 type materializedSegment struct {
-	ID      string
-	Key     string
-	Payload []byte
-	SHA256  string
+	ID       string
+	VolumeID string
+	Key      string
+	Payload  []byte
+	SHA256   string
 }
 
-func buildSegment(manifestSeq uint64, state *SnapshotState) (*materializedSegment, map[uint64][]FileExtent, error) {
+func buildSegment(manifestSeq uint64, volumeID string, state *SnapshotState) (*materializedSegment, map[uint64][]FileExtent, error) {
 	segmentID := fmt.Sprintf("%020d-0", manifestSeq)
 	segmentKey := fmt.Sprintf("%s/%s.bin", segmentDir, segmentID)
 
@@ -265,10 +278,11 @@ func buildSegment(manifestSeq uint64, state *SnapshotState) (*materializedSegmen
 
 	sum := sha256.Sum256(buf.Bytes())
 	segment := &materializedSegment{
-		ID:      segmentID,
-		Key:     segmentKey,
-		Payload: buf.Bytes(),
-		SHA256:  hex.EncodeToString(sum[:]),
+		ID:       segmentID,
+		VolumeID: volumeID,
+		Key:      segmentKey,
+		Payload:  buf.Bytes(),
+		SHA256:   hex.EncodeToString(sum[:]),
 	}
 	return segment, files, nil
 }
@@ -314,10 +328,11 @@ func buildManifestState(state *SnapshotState, segment *materializedSegment, hotF
 	}
 	if segment != nil && len(segment.Payload) > 0 {
 		manifestState.Segments[segment.ID] = &Segment{
-			ID:     segment.ID,
-			Key:    segment.Key,
-			Length: uint64(len(segment.Payload)),
-			SHA256: segment.SHA256,
+			ID:       segment.ID,
+			VolumeID: segment.VolumeID,
+			Key:      segment.Key,
+			Length:   uint64(len(segment.Payload)),
+			SHA256:   segment.SHA256,
 		}
 	}
 	return manifestState, nil
@@ -377,6 +392,11 @@ func (m *Materializer) loadManifestByKey(ctx context.Context, key string) (*Mani
 		return nil, fmt.Errorf("materialized manifest %s has no state", key)
 	}
 	normalizeState(manifest.State)
+	sourceVolumeID := manifest.VolumeID
+	if strings.TrimSpace(sourceVolumeID) == "" {
+		sourceVolumeID = m.volumeID
+	}
+	defaultSegmentVolumeIDs(manifest.State, sourceVolumeID)
 	return &manifest, nil
 }
 
@@ -406,6 +426,45 @@ func cloneByteRange(payload []byte, off, limit int64) []byte {
 		end = off + limit
 	}
 	return append([]byte(nil), payload[off:end]...)
+}
+
+func (m *Materializer) storeForSegment(segment *Segment) (string, objectstore.Store, error) {
+	if segment == nil {
+		return "", nil, fmt.Errorf("%w: segment is required", ErrInvalidInput)
+	}
+	volumeID := strings.TrimSpace(segment.VolumeID)
+	if volumeID == "" {
+		volumeID = m.volumeID
+	}
+	if volumeID == "" || volumeID == m.volumeID {
+		return m.volumeID, m.store, nil
+	}
+	if m.objectStoreForVolume == nil {
+		return "", nil, fmt.Errorf("%w: segment %s belongs to volume %s but no object store resolver is configured", ErrInvalidInput, segment.ID, volumeID)
+	}
+	store, err := m.objectStoreForVolume(volumeID)
+	if err != nil {
+		return "", nil, err
+	}
+	if store == nil {
+		return "", nil, fmt.Errorf("%w: object store resolver returned nil for volume %s", ErrInvalidInput, volumeID)
+	}
+	return volumeID, store, nil
+}
+
+func segmentCacheKey(volumeID, key string) string {
+	return volumeID + "\x00" + key
+}
+
+func defaultSegmentVolumeIDs(state *SnapshotState, volumeID string) {
+	if state == nil {
+		return
+	}
+	for _, segment := range state.Segments {
+		if segment != nil && strings.TrimSpace(segment.VolumeID) == "" {
+			segment.VolumeID = volumeID
+		}
+	}
 }
 
 type segmentCache struct {

--- a/storage-proxy/pkg/s0fs/materializer_test.go
+++ b/storage-proxy/pkg/s0fs/materializer_test.go
@@ -741,6 +741,169 @@ func TestEngineColdSmallFileReadsUseSegmentCache(t *testing.T) {
 	}
 }
 
+func TestEngineForkStateReadsParentSegmentsAndWritesChildSegments(t *testing.T) {
+	ctx := context.Background()
+	base := objectstore.NewMemoryStore("s0fs-fork-state-test-" + t.Name())
+	sourceStore := &recordingStore{Store: objectstore.Prefix(base, "sandboxvolumes/team-a/source/s0fs/")}
+	childStore := &recordingStore{Store: objectstore.Prefix(base, "sandboxvolumes/team-a/child/s0fs/")}
+	heads := newMemoryHeadStore()
+	resolver := func(volumeID string) (objectstore.Store, error) {
+		switch volumeID {
+		case "source":
+			return sourceStore, nil
+		case "child":
+			return childStore, nil
+		default:
+			return nil, ErrNotFound
+		}
+	}
+
+	source, err := Open(ctx, Config{
+		VolumeID:             "source",
+		WALPath:              filepath.Join(t.TempDir(), "source.wal"),
+		ObjectStore:          sourceStore,
+		ObjectStoreForVolume: resolver,
+		HeadStore:            heads,
+	})
+	if err != nil {
+		t.Fatalf("Open(source) error = %v", err)
+	}
+	defer source.Close()
+
+	node, err := source.CreateFile(RootInode, "pkg.txt", 0o644)
+	if err != nil {
+		t.Fatalf("CreateFile(source) error = %v", err)
+	}
+	if _, err := source.Write(node.Inode, 0, []byte("parent-data")); err != nil {
+		t.Fatalf("Write(source) error = %v", err)
+	}
+	if _, err := source.SyncMaterialize(ctx); err != nil {
+		t.Fatalf("SyncMaterialize(source) error = %v", err)
+	}
+
+	sourceState, _, err := NewMaterializer("source", sourceStore, heads, resolver).LoadLatestState(ctx)
+	if err != nil {
+		t.Fatalf("LoadLatestState(source) error = %v", err)
+	}
+	forkState, err := PrepareForkState(sourceState, "source")
+	if err != nil {
+		t.Fatalf("PrepareForkState() error = %v", err)
+	}
+	if len(forkState.Data) != 0 {
+		t.Fatalf("fork state data = %+v, want empty", forkState.Data)
+	}
+	for _, segment := range forkState.Segments {
+		if segment.VolumeID != "source" {
+			t.Fatalf("fork segment volume = %q, want source", segment.VolumeID)
+		}
+	}
+
+	child, err := Open(ctx, Config{
+		VolumeID:             "child",
+		WALPath:              filepath.Join(t.TempDir(), "child.wal"),
+		ObjectStore:          childStore,
+		ObjectStoreForVolume: resolver,
+		HeadStore:            heads,
+	})
+	if err != nil {
+		t.Fatalf("Open(child) error = %v", err)
+	}
+	defer child.Close()
+	if err := child.ReplaceState(forkState); err != nil {
+		t.Fatalf("ReplaceState(child) error = %v", err)
+	}
+	if _, err := child.SyncMaterialize(ctx); err != nil {
+		t.Fatalf("SyncMaterialize(child fork) error = %v", err)
+	}
+
+	sourceStore.resetCalls()
+	childStore.resetCalls()
+	childNode, err := child.Lookup(RootInode, "pkg.txt")
+	if err != nil {
+		t.Fatalf("Lookup(child) error = %v", err)
+	}
+	payload, err := child.Read(childNode.Inode, 0, childNode.Size)
+	if err != nil {
+		t.Fatalf("Read(child inherited) error = %v", err)
+	}
+	if string(payload) != "parent-data" {
+		t.Fatalf("Read(child inherited) = %q, want parent-data", payload)
+	}
+	if !hasSegmentGet(sourceStore.calls()) {
+		t.Fatalf("source segment reads = %+v, want inherited segment read", sourceStore.calls())
+	}
+	if hasSegmentGet(childStore.calls()) {
+		t.Fatalf("child segment reads = %+v, want no child segment read for inherited data", childStore.calls())
+	}
+
+	if _, err := child.Write(childNode.Inode, 0, []byte("child-data")); err != nil {
+		t.Fatalf("Write(child) error = %v", err)
+	}
+	if _, err := child.SyncMaterialize(ctx); err != nil {
+		t.Fatalf("SyncMaterialize(child write) error = %v", err)
+	}
+	childState, _, err := NewMaterializer("child", childStore, heads, resolver).LoadLatestState(ctx)
+	if err != nil {
+		t.Fatalf("LoadLatestState(child) error = %v", err)
+	}
+	var childSegmentCount int
+	for _, segment := range childState.Segments {
+		if segment.VolumeID == "child" {
+			childSegmentCount++
+		}
+	}
+	if childSegmentCount == 0 {
+		t.Fatalf("child segments = %+v, want at least one child-owned segment", childState.Segments)
+	}
+
+	sourceNode, err := source.Lookup(RootInode, "pkg.txt")
+	if err != nil {
+		t.Fatalf("Lookup(source) after child write error = %v", err)
+	}
+	sourcePayload, err := source.Read(sourceNode.Inode, 0, sourceNode.Size)
+	if err != nil {
+		t.Fatalf("Read(source) after child write error = %v", err)
+	}
+	if string(sourcePayload) != "parent-data" {
+		t.Fatalf("Read(source) after child write = %q, want parent-data", sourcePayload)
+	}
+}
+
+func TestMaterializerSegmentCacheIsVolumeQualified(t *testing.T) {
+	base := objectstore.NewMemoryStore("s0fs-segment-cache-volume-test-" + t.Name())
+	sourceA := objectstore.Prefix(base, "sandboxvolumes/team-a/source-a/s0fs/")
+	sourceB := objectstore.Prefix(base, "sandboxvolumes/team-a/source-b/s0fs/")
+	child := objectstore.Prefix(base, "sandboxvolumes/team-a/child/s0fs/")
+	if err := sourceA.Put("segments/shared.bin", bytes.NewReader([]byte("alpha"))); err != nil {
+		t.Fatalf("Put(source-a) error = %v", err)
+	}
+	if err := sourceB.Put("segments/shared.bin", bytes.NewReader([]byte("bravo"))); err != nil {
+		t.Fatalf("Put(source-b) error = %v", err)
+	}
+	materializer := NewMaterializer("child", child, nil, func(volumeID string) (objectstore.Store, error) {
+		switch volumeID {
+		case "source-a":
+			return sourceA, nil
+		case "source-b":
+			return sourceB, nil
+		default:
+			return nil, ErrNotFound
+		}
+	})
+
+	first, err := materializer.ReadSegmentRange(&Segment{ID: "shared", VolumeID: "source-a", Key: "segments/shared.bin", Length: 5}, 0, 5)
+	if err != nil {
+		t.Fatalf("ReadSegmentRange(source-a) error = %v", err)
+	}
+	second, err := materializer.ReadSegmentRange(&Segment{ID: "shared", VolumeID: "source-b", Key: "segments/shared.bin", Length: 5}, 0, 5)
+	if err != nil {
+		t.Fatalf("ReadSegmentRange(source-b) error = %v", err)
+	}
+	if string(first) != "alpha" || string(second) != "bravo" {
+		t.Fatalf("segment reads = %q/%q, want alpha/bravo", first, second)
+	}
+}
+
 func TestCreateSnapshotHydratesColdFilesInline(t *testing.T) {
 	ctx := context.Background()
 	store := newPrefixedRecordingStore(t, "vol-snapshot")
@@ -795,6 +958,15 @@ func newPrefixedRecordingStore(t *testing.T, volumeID string) *recordingStore {
 	return &recordingStore{Store: objectstore.Prefix(base, "sandboxvolumes/team-a/"+volumeID+"/s0fs/")}
 }
 
+func hasSegmentGet(calls []getCall) bool {
+	for _, call := range calls {
+		if strings.HasPrefix(call.key, segmentDir+"/") {
+			return true
+		}
+	}
+	return false
+}
+
 func fileName(i int) string {
 	return strings.Join([]string{"file", string(rune('a' + (i % 26))), string(rune('0' + (i % 10))), ".txt"}, "")
 }
@@ -816,7 +988,7 @@ func TestMaterializerBuildSegmentProducesRoundTrippableLayout(t *testing.T) {
 			3: []byte("world"),
 		},
 	}
-	segment, files, err := buildSegment(7, state)
+	segment, files, err := buildSegment(7, "vol-1", state)
 	if err != nil {
 		t.Fatalf("buildSegment() error = %v", err)
 	}

--- a/storage-proxy/pkg/s0fs/snapshot.go
+++ b/storage-proxy/pkg/s0fs/snapshot.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 )
 
 var ErrSnapshotNotFound = fmt.Errorf("%w: snapshot not found", ErrNotFound)
@@ -126,6 +127,42 @@ func cloneState(state *SnapshotState) *SnapshotState {
 		clone.Segments[segmentID] = cloneSegment(segment)
 	}
 	return clone
+}
+
+// PrepareForkState returns a child-ready metadata snapshot that keeps cold file
+// segments addressed to the source volume instead of inlining file contents.
+func PrepareForkState(state *SnapshotState, sourceVolumeID string) (*SnapshotState, error) {
+	sourceVolumeID = strings.TrimSpace(sourceVolumeID)
+	if sourceVolumeID == "" {
+		return nil, fmt.Errorf("%w: source volume id is required", ErrInvalidInput)
+	}
+	if state == nil {
+		return nil, fmt.Errorf("%w: source state is required", ErrInvalidInput)
+	}
+	clone := cloneState(state)
+	normalizeState(clone)
+	for inode, payload := range clone.Data {
+		if len(payload) > 0 {
+			return nil, fmt.Errorf("%w: source state has inline data for inode %d", ErrInvalidInput, inode)
+		}
+	}
+	for inode, extents := range clone.ColdFiles {
+		if clone.Nodes[inode] == nil {
+			delete(clone.ColdFiles, inode)
+			continue
+		}
+		for _, extent := range extents {
+			segment := clone.Segments[extent.SegmentID]
+			if segment == nil {
+				return nil, fmt.Errorf("%w: missing source segment %s", ErrInvalidInput, extent.SegmentID)
+			}
+			if strings.TrimSpace(segment.VolumeID) == "" {
+				segment.VolumeID = sourceVolumeID
+			}
+		}
+	}
+	clone.Data = make(map[uint64][]byte)
+	return clone, nil
 }
 
 func (s *SnapshotState) Lookup(parent uint64, name string) (*Node, error) {

--- a/storage-proxy/pkg/s0fs/types.go
+++ b/storage-proxy/pkg/s0fs/types.go
@@ -17,13 +17,16 @@ const (
 )
 
 type Config struct {
-	VolumeID            string
-	WALPath             string
-	ObjectStore         objectstore.Store
-	HeadStore           HeadStore
-	MaterializeInterval time.Duration
-	WALSyncHook         func()
+	VolumeID             string
+	WALPath              string
+	ObjectStore          objectstore.Store
+	ObjectStoreForVolume ObjectStoreResolver
+	HeadStore            HeadStore
+	MaterializeInterval  time.Duration
+	WALSyncHook          func()
 }
+
+type ObjectStoreResolver func(volumeID string) (objectstore.Store, error)
 
 type SnapshotState struct {
 	NextSeq   uint64                       `json:"next_seq"`
@@ -42,10 +45,11 @@ type FileExtent struct {
 }
 
 type Segment struct {
-	ID     string `json:"id"`
-	Key    string `json:"key"`
-	Length uint64 `json:"length"`
-	SHA256 string `json:"sha256,omitempty"`
+	ID       string `json:"id"`
+	VolumeID string `json:"volume_id,omitempty"`
+	Key      string `json:"key"`
+	Length   uint64 `json:"length"`
+	SHA256   string `json:"sha256,omitempty"`
 }
 
 type Node struct {

--- a/storage-proxy/pkg/snapshot/manager.go
+++ b/storage-proxy/pkg/snapshot/manager.go
@@ -268,20 +268,6 @@ func (m *Manager) ForkVolume(ctx context.Context, req *ForkVolumeRequest) (*db.S
 		"team_id":          req.TeamID,
 	}).Info("Forking volume")
 
-	// 0. Distributed flush coordination (if coordinator is set)
-	m.mu.RLock()
-	coordinator := m.coordinator
-	m.mu.RUnlock()
-
-	if coordinator != nil {
-		m.logger.WithField("volume_id", req.SourceVolumeID).Info("Coordinating flush across all instances")
-		if err := coordinator.CoordinateFlush(ctx, req.SourceVolumeID); err != nil {
-			m.logger.WithError(err).Error("Distributed flush coordination failed")
-			return nil, fmt.Errorf("distributed flush coordination: %w", err)
-		}
-		m.logger.WithField("volume_id", req.SourceVolumeID).Info("Distributed flush coordination completed")
-	}
-
 	vol, err := m.forkS0FSVolume(ctx, req)
 	if err != nil {
 		if metrics != nil {

--- a/storage-proxy/pkg/snapshot/manager_s0fs_test.go
+++ b/storage-proxy/pkg/snapshot/manager_s0fs_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"errors"
 	"io"
 	"path/filepath"
 	"testing"
@@ -77,10 +78,12 @@ func TestS0FSSnapshotCreateRestoreAndDelete(t *testing.T) {
 	}
 }
 
-func TestS0FSForkVolumeCopiesState(t *testing.T) {
+func TestS0FSForkVolumeUsesCopyOnWriteState(t *testing.T) {
 	t.Parallel()
 
 	mgr, repo, _, engine := newS0FSSnapshotTestManager(t, "vol-1")
+	coordinator := &failingFlushCoordinator{}
+	mgr.SetFlushCoordinator(coordinator)
 	writeS0FSFile(t, engine, "fork.txt", "seed")
 
 	forked, err := mgr.ForkVolume(context.Background(), &ForkVolumeRequest{
@@ -97,6 +100,33 @@ func TestS0FSForkVolumeCopiesState(t *testing.T) {
 	if _, ok := repo.volumes[forked.ID]; !ok {
 		t.Fatalf("forked volume not persisted: %+v", repo.volumes)
 	}
+	if coordinator.called {
+		t.Fatal("ForkVolume called distributed flush coordinator")
+	}
+
+	forkCfg := mgr.s0fsConfig("team-1", forked.ID)
+	forkState, _, err := s0fs.NewMaterializer(forked.ID, forkCfg.ObjectStore, forkCfg.HeadStore, forkCfg.ObjectStoreForVolume).LoadLatestState(context.Background())
+	if err != nil {
+		t.Fatalf("LoadLatestState(forked) error = %v", err)
+	}
+	if len(forkState.Data) != 0 {
+		t.Fatalf("forked materialized data = %+v, want empty", forkState.Data)
+	}
+	if len(forkState.Segments) == 0 {
+		t.Fatal("forked materialized state has no inherited segments")
+	}
+	for _, segment := range forkState.Segments {
+		if segment.VolumeID != "vol-1" {
+			t.Fatalf("forked segment volume = %q, want vol-1", segment.VolumeID)
+		}
+	}
+	childSegments, _, _, err := forkCfg.ObjectStore.List("segments/", "", "", "", 100)
+	if err != nil {
+		t.Fatalf("List(child segments) error = %v", err)
+	}
+	if len(childSegments) != 0 {
+		t.Fatalf("child segment objects after fork = %+v, want none", childSegments)
+	}
 
 	forkedEngine, err := s0fs.Open(context.Background(), mgr.s0fsConfig("team-1", forked.ID))
 	if err != nil {
@@ -108,15 +138,27 @@ func TestS0FSForkVolumeCopiesState(t *testing.T) {
 		t.Fatalf("forked file = %q, want seed", got)
 	}
 	writeS0FSFile(t, forkedEngine, "fork.txt", "forked")
+	if _, err := forkedEngine.SyncMaterialize(context.Background()); err != nil {
+		t.Fatalf("SyncMaterialize(forked) error = %v", err)
+	}
 	if got := readS0FSFile(t, engine, "fork.txt"); got != "seed" {
 		t.Fatalf("source file after fork mutation = %q, want seed", got)
 	}
 
 	freshForked := openFreshS0FSEngine(t, mgr, "team-1", forked.ID)
 	defer freshForked.Close()
-	if got := readS0FSFile(t, freshForked, "fork.txt"); got != "seed" {
-		t.Fatalf("fresh forked file = %q, want seed", got)
+	if got := readS0FSFile(t, freshForked, "fork.txt"); got != "forked" {
+		t.Fatalf("fresh forked file = %q, want forked", got)
 	}
+}
+
+type failingFlushCoordinator struct {
+	called bool
+}
+
+func (f *failingFlushCoordinator) CoordinateFlush(context.Context, string) error {
+	f.called = true
+	return errors.New("distributed flush should not be called for fork")
 }
 
 func TestExportSnapshotArchiveS0FS(t *testing.T) {

--- a/storage-proxy/pkg/snapshot/s0fs.go
+++ b/storage-proxy/pkg/snapshot/s0fs.go
@@ -84,6 +84,9 @@ func (m *Manager) s0fsConfig(teamID, volumeID string) s0fs.Config {
 	if repo, ok := any(m.repo).(s0fsHeadRepository); ok {
 		cfg.HeadStore = &snapshotHeadStore{repo: repo}
 	}
+	cfg.ObjectStoreForVolume = func(sourceVolumeID string) (objectstore.Store, error) {
+		return m.s0fsObjectStore(teamID, sourceVolumeID)
+	}
 	return cfg
 }
 
@@ -275,14 +278,20 @@ func snapshotSizeBytes(state *s0fs.SnapshotState) int64 {
 	return size
 }
 
-func resolveS0FSForkState(ctx context.Context, source *s0fs.Engine) (*s0fs.SnapshotState, error) {
-	if source == nil {
-		return nil, fmt.Errorf("source engine is nil")
-	}
+func (m *Manager) resolveS0FSForkState(ctx context.Context, teamID, sourceVolumeID string) (*s0fs.SnapshotState, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	return source.ExportState()
+	cfg := m.s0fsConfig(teamID, sourceVolumeID)
+	materializer := s0fs.NewMaterializer(sourceVolumeID, cfg.ObjectStore, cfg.HeadStore, cfg.ObjectStoreForVolume)
+	if materializer == nil || !materializer.Enabled() {
+		return nil, fmt.Errorf("%w: s0fs materializer is not configured", s0fs.ErrInvalidInput)
+	}
+	state, _, err := materializer.LoadLatestState(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return s0fs.PrepareForkState(state, sourceVolumeID)
 }
 
 func (m *Manager) openS0FSSnapshotArchiveSession(ctx context.Context, volumeID, snapshotID string) (*snapshotArchiveSession, fsmeta.Ino, *fsmeta.Attr, error) {
@@ -368,19 +377,18 @@ func (m *Manager) forkS0FSVolume(ctx context.Context, req *ForkVolumeRequest) (*
 		return nil, ErrVolumeNotFound
 	}
 
-	sourceEngine, closeSource, err := m.openS0FSEngine(ctx, sourceVol.TeamID, req.SourceVolumeID)
-	if err != nil {
-		return nil, err
-	}
-	defer closeSource()
-
 	if m.volMgr != nil {
 		if volCtx, getErr := m.volMgr.GetVolume(req.SourceVolumeID); getErr == nil && volCtx != nil {
 			_ = volCtx.FlushAll("")
+			if volCtx.IsS0FS() {
+				if _, err := volCtx.S0FS.SyncMaterialize(ctx); err != nil {
+					return nil, err
+				}
+			}
 		}
 	}
 
-	state, err := resolveS0FSForkState(ctx, sourceEngine)
+	state, err := m.resolveS0FSForkState(ctx, sourceVol.TeamID, req.SourceVolumeID)
 	if err != nil {
 		return nil, err
 	}

--- a/storage-proxy/pkg/volume/s0fs_backend.go
+++ b/storage-proxy/pkg/volume/s0fs_backend.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
+	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/objectstore"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/s0fs"
@@ -45,7 +46,10 @@ func (b *S0FSBackend) MountVolume(ctx context.Context, req BackendMountRequest) 
 		VolumeID:    req.VolumeID,
 		WALPath:     filepath.Join(cacheDir, "engine.wal"),
 		ObjectStore: remoteStore,
-		HeadStore:   b.headStore,
+		ObjectStoreForVolume: func(volumeID string) (objectstore.Store, error) {
+			return b.createObjectStorageForVolume(req, volumeID)
+		},
+		HeadStore: b.headStore,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("open s0fs engine: %w", err)
@@ -83,6 +87,10 @@ func (b *S0FSBackend) UnmountVolume(ctx context.Context, volCtx *VolumeContext) 
 }
 
 func (b *S0FSBackend) createObjectStorage(req BackendMountRequest) (objectstore.Store, error) {
+	return b.createObjectStorageForVolume(req, req.VolumeID)
+}
+
+func (b *S0FSBackend) createObjectStorageForVolume(req BackendMountRequest, volumeID string) (objectstore.Store, error) {
 	if b == nil || b.config == nil || strings.TrimSpace(b.config.S3Bucket) == "" {
 		return nil, nil
 	}
@@ -99,9 +107,16 @@ func (b *S0FSBackend) createObjectStorage(req BackendMountRequest) (objectstore.
 	if err != nil {
 		return nil, err
 	}
-	prefix := strings.Trim(req.S3Prefix, "/")
+	prefix := ""
+	if volumeID == req.VolumeID {
+		prefix = strings.Trim(req.S3Prefix, "/")
+	}
 	if prefix == "" {
-		prefix = strings.Trim(req.VolumeID, "/")
+		var err error
+		prefix, err = naming.S3VolumePrefix(req.TeamID, volumeID)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return objectstore.Prefix(store, prefix+"/s0fs/"), nil
 }


### PR DESCRIPTION
## Summary
- implement copy-on-write S0FS volume forks by keeping forked manifests pointed at source volume segments
- resolve inherited cold segments through per-volume object-store resolvers in storage-proxy and ctld
- cover COW fork behavior, segment cache isolation, and fork coordinator bypass with targeted tests

Closes #276

## Testing
- make proto
- go test ./storage-proxy/pkg/... ./ctld/internal/ctld/...