### PR TITLE
Guard volume forks during ctld ownership

### DIFF
--- a/ctld/internal/ctld/portal/manager.go
+++ b/ctld/internal/ctld/portal/manager.go
@@ -610,22 +610,22 @@ func (m *Manager) CompleteHandoff(ctx context.Context, req ctldapi.CompleteVolum
 		m.mu.Unlock()
 		return ctldapi.CompleteVolumePortalHandoffResponse{Completed: true}, nil
 	}
-	delete(m.boundVolumes, volumeID)
-	m.unregisterOwner(bound)
 	if bound.materializeCancel != nil {
 		bound.materializeCancel()
 		bound.materializeCancel = nil
 	}
 	done := bound.materializeDone
 	bound.materializeDone = nil
-	m.mu.Unlock()
-
 	if done != nil {
 		<-done
 	}
 	if err := m.volumes.UnmountVolume(ctx, volumeID, ""); err != nil {
+		m.mu.Unlock()
 		return ctldapi.CompleteVolumePortalHandoffResponse{}, err
 	}
+	delete(m.boundVolumes, volumeID)
+	m.unregisterOwner(bound)
+	m.mu.Unlock()
 	return ctldapi.CompleteVolumePortalHandoffResponse{Completed: true}, nil
 }
 
@@ -668,20 +668,23 @@ func (m *Manager) releaseOwnerOnlyVolume(ctx context.Context, volumeID string) e
 		m.mu.Unlock()
 		return nil
 	}
-	delete(m.boundVolumes, volumeID)
-	m.unregisterOwner(bound)
 	if bound.materializeCancel != nil {
 		bound.materializeCancel()
 		bound.materializeCancel = nil
 	}
 	done := bound.materializeDone
 	bound.materializeDone = nil
-	m.mu.Unlock()
-
 	if done != nil {
 		<-done
 	}
-	return m.volumes.UnmountVolume(ctx, volumeID, "")
+	if err := m.volumes.UnmountVolume(ctx, volumeID, ""); err != nil {
+		m.mu.Unlock()
+		return err
+	}
+	delete(m.boundVolumes, volumeID)
+	m.unregisterOwner(bound)
+	m.mu.Unlock()
+	return nil
 }
 
 func (m *Manager) unbindLockedSnapshot(pm *portalMount) error {
@@ -698,8 +701,6 @@ func (m *Manager) unbindLockedSnapshot(pm *portalMount) error {
 		bound.refCount--
 		return nil
 	}
-	delete(m.boundVolumes, volumeID)
-	m.unregisterOwner(bound)
 	if bound.materializeCancel != nil {
 		bound.materializeCancel()
 		bound.materializeCancel = nil
@@ -708,7 +709,12 @@ func (m *Manager) unbindLockedSnapshot(pm *portalMount) error {
 		<-bound.materializeDone
 		bound.materializeDone = nil
 	}
-	return m.volumes.UnmountVolume(context.Background(), volumeID, "")
+	if err := m.volumes.UnmountVolume(context.Background(), volumeID, ""); err != nil {
+		return err
+	}
+	delete(m.boundVolumes, volumeID)
+	m.unregisterOwner(bound)
+	return nil
 }
 
 type publishRequest struct {

--- a/ctld/internal/ctld/portal/manager_shared_test.go
+++ b/ctld/internal/ctld/portal/manager_shared_test.go
@@ -123,6 +123,44 @@ func TestCleanupIdleOwnerOnlyVolumesRemovesIdleOwner(t *testing.T) {
 	}
 }
 
+func TestCleanupIdleOwnerOnlyVolumesKeepsOwnerOnMaterializeFailure(t *testing.T) {
+	engine, cacheDir := newDirtyConflictS0FSEngine(t, "vol-1")
+	defer engine.Close()
+
+	mgr := &Manager{
+		ownerOnlyIdleTTL: 50 * time.Millisecond,
+		boundVolumes:     make(map[string]*boundVolume),
+		volumes:          newLocalVolumeManager(),
+	}
+	volCtx := &volume.VolumeContext{
+		VolumeID:  "vol-1",
+		TeamID:    "team-a",
+		Backend:   volume.BackendS0FS,
+		S0FS:      engine,
+		Access:    volume.AccessModeRWO,
+		MountedAt: time.Now().UTC(),
+		RootInode: 1,
+		RootPath:  "/",
+		CacheDir:  cacheDir,
+	}
+	mgr.volumes.add(volCtx)
+	mgr.volumes.requests["vol-1"].lastAccess = time.Now().UTC().Add(-time.Minute)
+	mgr.boundVolumes["vol-1"] = &boundVolume{
+		volumeID: "vol-1",
+		refCount: 0,
+		volCtx:   volCtx,
+	}
+
+	mgr.cleanupIdleOwnerOnlyVolumes(context.Background())
+
+	if _, ok := mgr.boundVolumes["vol-1"]; !ok {
+		t.Fatal("bound volume removed after failed materialize, want owner to remain active")
+	}
+	if _, err := mgr.volumes.GetVolume("vol-1"); err != nil {
+		t.Fatalf("GetVolume() after failed cleanup error = %v, want mounted volume to remain", err)
+	}
+}
+
 func TestNewManagerDefaultsClusterID(t *testing.T) {
 	mgr := NewManager(Config{
 		StorageConfig: &apiconfig.StorageProxyConfig{},

--- a/ctld/internal/ctld/portal/session.go
+++ b/ctld/internal/ctld/portal/session.go
@@ -186,12 +186,18 @@ func (m *localVolumeManager) MountVolume(_ context.Context, _ string, volumeID s
 	return "local-" + volumeID, time.Now().UTC(), nil
 }
 
-func (m *localVolumeManager) UnmountVolume(_ context.Context, volumeID, _ string) error {
-	volCtx, ok := m.remove(volumeID)
-	if !ok || volCtx == nil || volCtx.S0FS == nil {
+func (m *localVolumeManager) UnmountVolume(ctx context.Context, volumeID, _ string) error {
+	m.mu.RLock()
+	volCtx, ok := m.volumes[volumeID]
+	m.mu.RUnlock()
+	if !ok || volCtx == nil {
 		return nil
 	}
-	if _, err := volCtx.S0FS.SyncMaterialize(context.Background()); err != nil {
+	if volCtx.S0FS == nil {
+		m.remove(volumeID)
+		return nil
+	}
+	if _, err := volCtx.S0FS.SyncMaterialize(ctx); err != nil {
 		return err
 	}
 	if err := volCtx.S0FS.Close(); err != nil {
@@ -202,6 +208,7 @@ func (m *localVolumeManager) UnmountVolume(_ context.Context, volumeID, _ string
 			return err
 		}
 	}
+	m.remove(volumeID)
 	return nil
 }
 

--- a/ctld/internal/ctld/portal/session_test.go
+++ b/ctld/internal/ctld/portal/session_test.go
@@ -12,10 +12,43 @@ import (
 
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/fserror"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/fsmeta"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/objectstore"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/s0fs"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volume"
 	pb "github.com/sandbox0-ai/sandbox0/storage-proxy/proto/fs"
 )
+
+type rejectingHeadStore struct{}
+
+func (rejectingHeadStore) LoadCommittedHead(context.Context, string) (*s0fs.CommittedHead, error) {
+	return nil, s0fs.ErrCommittedHeadNotFound
+}
+
+func (rejectingHeadStore) CompareAndSwapCommittedHead(context.Context, string, uint64, *s0fs.CommittedHead) error {
+	return s0fs.ErrCommittedHeadConflict
+}
+
+func newDirtyConflictS0FSEngine(t *testing.T, volumeID string) (*s0fs.Engine, string) {
+	t.Helper()
+	cacheDir := filepath.Join(t.TempDir(), volumeID+"-cache")
+	engine, err := s0fs.Open(context.Background(), s0fs.Config{
+		VolumeID:    volumeID,
+		WALPath:     filepath.Join(cacheDir, "engine.wal"),
+		ObjectStore: objectstore.NewMemoryStore(t.Name() + "-" + volumeID),
+		HeadStore:   rejectingHeadStore{},
+	})
+	if err != nil {
+		t.Fatalf("Open(%s) error = %v", volumeID, err)
+	}
+	node, err := engine.CreateFile(s0fs.RootInode, "dirty.txt", 0o644)
+	if err != nil {
+		t.Fatalf("CreateFile(%s) error = %v", volumeID, err)
+	}
+	if _, err := engine.Write(node.Inode, 0, []byte("dirty")); err != nil {
+		t.Fatalf("Write(%s) error = %v", volumeID, err)
+	}
+	return engine, cacheDir
+}
 
 func TestLocalSessionReadIntoUsesMountedS0FS(t *testing.T) {
 	engine, err := s0fs.Open(context.Background(), s0fs.Config{
@@ -345,6 +378,34 @@ func TestLocalVolumeManagerUnmountRemovesCacheDir(t *testing.T) {
 	}
 	if _, err := os.Stat(cacheDir); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("cache dir stat error = %v, want not exist", err)
+	}
+}
+
+func TestLocalVolumeManagerUnmountKeepsVolumeOnMaterializeFailure(t *testing.T) {
+	engine, cacheDir := newDirtyConflictS0FSEngine(t, "vol-1")
+	defer engine.Close()
+
+	mgr := newLocalVolumeManager()
+	mgr.add(&volume.VolumeContext{
+		VolumeID:  "vol-1",
+		TeamID:    "team-a",
+		Backend:   volume.BackendS0FS,
+		S0FS:      engine,
+		Access:    volume.AccessModeRWO,
+		MountedAt: time.Now().UTC(),
+		RootInode: 1,
+		RootPath:  "/",
+		CacheDir:  cacheDir,
+	})
+
+	if err := mgr.UnmountVolume(context.Background(), "vol-1", ""); !errors.Is(err, s0fs.ErrCommittedHeadConflict) {
+		t.Fatalf("UnmountVolume() error = %v, want %v", err, s0fs.ErrCommittedHeadConflict)
+	}
+	if _, err := mgr.GetVolume("vol-1"); err != nil {
+		t.Fatalf("GetVolume() after failed unmount error = %v, want mounted volume to remain", err)
+	}
+	if _, err := os.Stat(cacheDir); err != nil {
+		t.Fatalf("cache dir stat after failed unmount error = %v, want cache to remain", err)
 	}
 }
 

--- a/docs/managed-agents/environments/page.mdx
+++ b/docs/managed-agents/environments/page.mdx
@@ -37,9 +37,20 @@ Only `type: cloud` environments are accepted today.
 
 `unrestricted` maps to a Sandbox0 allow-all network policy. `limited` maps to a block-all policy with explicit allowed domains.
 
-## Package Artifacts
+## Package Dependencies
 
-Sandbox0 may prebuild and reuse environment artifacts for package-heavy environments. A session pins the environment artifact it was created with so package state remains stable while the session runs.
+Put repeatable project dependencies in `config.packages` instead of installing them from inside every session. For example, declare Node.js tools such as `tsx`, Python test dependencies such as `pytest==8.3.4`, or system packages that every session should have available.
+
+Package CLIs are exposed through the normal language toolchain entry points, so declared tools can be invoked by command name when the package manager installs a binary. For example, an environment with `npm: ["tsx"]` can run `tsx`, and an environment with `pip: ["pytest==8.3.4"]` can run `pytest`.
+
+Best practices:
+
+- Pin versions for packages that affect builds or tests.
+- Keep interactive or task-specific installs in the session workspace, not in the reusable environment.
+- For `limited` networking, set `allow_package_managers: true` when the environment needs to fetch packages during setup.
+- Update the environment when shared dependencies change, then create new sessions from the updated environment.
+
+Sessions created from an environment have the declared packages available at startup. A session keeps using the package set it was created with, so later environment updates do not change already-running sessions.
 
 ## Limited Networking
 
@@ -56,7 +67,6 @@ The final policy is enforced by Sandbox0 network policy and credential projectio
 ## Sandbox0 Notes
 
 - Reserved `sandbox0.managed_agents.*` metadata keys are not accepted on environments.
-- Environment packages affect the sandbox filesystem by mounting prebuilt package artifacts.
 - Updating an environment does not retroactively rebuild already pinned session artifacts.
 
 ## Next

--- a/storage-proxy/pkg/http/handlers_sandboxvolume.go
+++ b/storage-proxy/pkg/http/handlers_sandboxvolume.go
@@ -756,6 +756,8 @@ func (s *Server) forkVolume(w http.ResponseWriter, r *http.Request) {
 			_ = spec.WriteError(w, http.StatusNotFound, spec.CodeNotFound, "volume not found")
 		case errors.Is(err, snapshot.ErrInvalidAccessMode):
 			_ = spec.WriteError(w, http.StatusBadRequest, spec.CodeBadRequest, "invalid access_mode")
+		case errors.Is(err, snapshot.ErrMountedCtldOwner):
+			_ = spec.WriteError(w, http.StatusConflict, spec.CodeConflict, "volume has active ctld mounts")
 		case errors.Is(err, snapshot.ErrCloneFailed):
 			_ = spec.WriteError(w, http.StatusInternalServerError, spec.CodeInternal, "clone operation failed")
 		default:

--- a/storage-proxy/pkg/http/handlers_sandboxvolume_test.go
+++ b/storage-proxy/pkg/http/handlers_sandboxvolume_test.go
@@ -18,10 +18,14 @@ type captureForkSnapshotManager struct {
 	*fakeHTTPSnapshotManager
 	lastFork *snapshot.ForkVolumeRequest
 	forkResp *db.SandboxVolume
+	forkErr  error
 }
 
 func (m *captureForkSnapshotManager) ForkVolume(_ context.Context, req *snapshot.ForkVolumeRequest) (*db.SandboxVolume, error) {
 	m.lastFork = req
+	if m.forkErr != nil {
+		return nil, m.forkErr
+	}
 	if m.forkResp != nil {
 		return m.forkResp, nil
 	}
@@ -306,5 +310,28 @@ func TestForkVolumePassesDefaultPosixIdentity(t *testing.T) {
 	}
 	if snapshotMgr.lastFork.DefaultPosixGID == nil || *snapshotMgr.lastFork.DefaultPosixGID != 2002 {
 		t.Fatalf("fork DefaultPosixGID = %v, want 2002", snapshotMgr.lastFork.DefaultPosixGID)
+	}
+}
+
+func TestForkVolumeReturnsConflictForMountedCtldOwner(t *testing.T) {
+	snapshotMgr := &captureForkSnapshotManager{
+		fakeHTTPSnapshotManager: &fakeHTTPSnapshotManager{},
+		forkErr:                 snapshot.ErrMountedCtldOwner,
+	}
+	server := &Server{
+		logger:      logrus.New(),
+		repo:        newFakeHTTPRepo(),
+		snapshotMgr: snapshotMgr,
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/sandboxvolumes/vol-1/fork", bytes.NewReader([]byte(`{}`)))
+	req.SetPathValue("id", "vol-1")
+	req = req.WithContext(internalauth.WithClaims(req.Context(), &internalauth.Claims{TeamID: "team-1", UserID: "user-1"}))
+	recorder := httptest.NewRecorder()
+
+	server.forkVolume(recorder, req)
+
+	if recorder.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusConflict, recorder.Body.String())
 	}
 }

--- a/storage-proxy/pkg/s0fs/engine.go
+++ b/storage-proxy/pkg/s0fs/engine.go
@@ -13,10 +13,11 @@ import (
 )
 
 type Engine struct {
-	mu       sync.RWMutex
-	volumeID string
-	wal      *wal
-	closed   bool
+	mu            sync.RWMutex
+	materializeMu sync.Mutex
+	volumeID      string
+	wal           *wal
+	closed        bool
 
 	nextSeq   uint64
 	nextInode uint64
@@ -529,6 +530,9 @@ func (e *Engine) ExportState() (*SnapshotState, error) {
 }
 
 func (e *Engine) SyncMaterialize(ctx context.Context) (*Manifest, error) {
+	e.materializeMu.Lock()
+	defer e.materializeMu.Unlock()
+
 	e.mu.RLock()
 	if err := e.checkOpen(); err != nil {
 		e.mu.RUnlock()
@@ -567,6 +571,8 @@ func (e *Engine) SyncMaterialize(ctx context.Context) (*Manifest, error) {
 		e.lastCommittedManifest = manifest.ManifestSeq
 		e.lastMaterializedVersion = version
 		e.dirty = false
+	} else if manifest.ManifestSeq > e.lastCommittedManifest {
+		e.lastCommittedManifest = manifest.ManifestSeq
 	}
 	return manifest, nil
 }

--- a/storage-proxy/pkg/s0fs/materializer_test.go
+++ b/storage-proxy/pkg/s0fs/materializer_test.go
@@ -9,7 +9,9 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/objectstore"
 )
@@ -52,6 +54,33 @@ func (s *memoryHeadStore) CompareAndSwapCommittedHead(_ context.Context, volumeI
 	clone := *head
 	s.heads[volumeID] = &clone
 	return nil
+}
+
+type blockingHeadStore struct {
+	*memoryHeadStore
+	calls        atomic.Int32
+	firstEntered chan struct{}
+	releaseFirst chan struct{}
+}
+
+func newBlockingHeadStore() *blockingHeadStore {
+	return &blockingHeadStore{
+		memoryHeadStore: newMemoryHeadStore(),
+		firstEntered:    make(chan struct{}),
+		releaseFirst:    make(chan struct{}),
+	}
+}
+
+func (s *blockingHeadStore) CompareAndSwapCommittedHead(ctx context.Context, volumeID string, expectedManifestSeq uint64, head *CommittedHead) error {
+	if s.calls.Add(1) == 1 {
+		close(s.firstEntered)
+		select {
+		case <-s.releaseFirst:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return s.memoryHeadStore.CompareAndSwapCommittedHead(ctx, volumeID, expectedManifestSeq, head)
 }
 
 type getCall struct {
@@ -647,6 +676,140 @@ func TestEngineSyncMaterializeDetectsCommittedHeadConflicts(t *testing.T) {
 	}
 	if _, err := second.SyncMaterialize(ctx); !errors.Is(err, ErrCommittedHeadConflict) {
 		t.Fatalf("SyncMaterialize(second) err = %v, want %v", err, ErrCommittedHeadConflict)
+	}
+}
+
+func TestEngineSyncMaterializeSerializesSameEngineCommits(t *testing.T) {
+	ctx := context.Background()
+	store := newPrefixedRecordingStore(t, "vol-serial-materialize")
+	heads := newBlockingHeadStore()
+
+	engine, err := Open(ctx, Config{
+		VolumeID:    "vol-serial-materialize",
+		WALPath:     filepath.Join(t.TempDir(), "engine.wal"),
+		ObjectStore: store,
+		HeadStore:   heads,
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer engine.Close()
+
+	node, err := engine.CreateFile(RootInode, "data.txt", 0o644)
+	if err != nil {
+		t.Fatalf("CreateFile() error = %v", err)
+	}
+	if _, err := engine.Write(node.Inode, 0, []byte("payload")); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := engine.SyncMaterialize(ctx)
+		firstDone <- err
+	}()
+
+	select {
+	case <-heads.firstEntered:
+	case <-time.After(time.Second):
+		t.Fatal("first SyncMaterialize did not reach committed head CAS")
+	}
+
+	secondDone := make(chan error, 1)
+	go func() {
+		_, err := engine.SyncMaterialize(ctx)
+		secondDone <- err
+	}()
+
+	select {
+	case err := <-secondDone:
+		t.Fatalf("second SyncMaterialize completed before first commit finished: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(heads.releaseFirst)
+
+	select {
+	case err := <-firstDone:
+		if err != nil {
+			t.Fatalf("first SyncMaterialize error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("first SyncMaterialize did not complete")
+	}
+	select {
+	case err := <-secondDone:
+		if err != nil {
+			t.Fatalf("second SyncMaterialize error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("second SyncMaterialize did not complete")
+	}
+}
+
+func TestEngineSyncMaterializeAdvancesCommittedHeadWhenDirtyDuringCommit(t *testing.T) {
+	ctx := context.Background()
+	store := newPrefixedRecordingStore(t, "vol-dirty-during-materialize")
+	heads := newBlockingHeadStore()
+
+	engine, err := Open(ctx, Config{
+		VolumeID:    "vol-dirty-during-materialize",
+		WALPath:     filepath.Join(t.TempDir(), "engine.wal"),
+		ObjectStore: store,
+		HeadStore:   heads,
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer engine.Close()
+
+	first, err := engine.CreateFile(RootInode, "first.txt", 0o644)
+	if err != nil {
+		t.Fatalf("CreateFile(first) error = %v", err)
+	}
+	if _, err := engine.Write(first.Inode, 0, []byte("first")); err != nil {
+		t.Fatalf("Write(first) error = %v", err)
+	}
+
+	materialized := make(chan error, 1)
+	go func() {
+		_, err := engine.SyncMaterialize(ctx)
+		materialized <- err
+	}()
+
+	select {
+	case <-heads.firstEntered:
+	case <-time.After(time.Second):
+		t.Fatal("SyncMaterialize did not reach committed head CAS")
+	}
+
+	second, err := engine.CreateFile(RootInode, "second.txt", 0o644)
+	if err != nil {
+		t.Fatalf("CreateFile(second) error = %v", err)
+	}
+	if _, err := engine.Write(second.Inode, 0, []byte("second")); err != nil {
+		t.Fatalf("Write(second) error = %v", err)
+	}
+
+	close(heads.releaseFirst)
+	select {
+	case err := <-materialized:
+		if err != nil {
+			t.Fatalf("SyncMaterialize(first) error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("SyncMaterialize(first) did not complete")
+	}
+
+	if _, err := engine.SyncMaterialize(ctx); err != nil {
+		t.Fatalf("SyncMaterialize(second) error = %v", err)
+	}
+	head, err := heads.LoadCommittedHead(ctx, "vol-dirty-during-materialize")
+	if err != nil {
+		t.Fatalf("LoadCommittedHead() error = %v", err)
+	}
+	if head.ManifestSeq < 2 {
+		t.Fatalf("committed manifest seq = %d, want at least 2", head.ManifestSeq)
 	}
 }
 

--- a/storage-proxy/pkg/snapshot/manager_test.go
+++ b/storage-proxy/pkg/snapshot/manager_test.go
@@ -649,6 +649,25 @@ func TestRestoreSnapshot_RejectsMountedCtldOwner(t *testing.T) {
 	}
 }
 
+func TestForkVolume_RejectsMountedCtldOwner(t *testing.T) {
+	repo := newFakeRepo()
+	repo.volumes["vol1"] = &db.SandboxVolume{ID: "vol1", TeamID: "team1"}
+	repo.activeMounts["vol1"] = []*db.VolumeMount{{
+		VolumeID:     "vol1",
+		MountOptions: rawMountOptions(t, volume.MountOptions{AccessMode: volume.AccessModeRWO, OwnerKind: volume.OwnerKindCtld}),
+	}}
+	mgr := newTestManager(repo, nil)
+
+	_, err := mgr.ForkVolume(context.Background(), &ForkVolumeRequest{
+		SourceVolumeID: "vol1",
+		TeamID:         "team1",
+		UserID:         "user1",
+	})
+	if !errors.Is(err, ErrMountedCtldOwner) {
+		t.Fatalf("ForkVolume() error = %v, want %v", err, ErrMountedCtldOwner)
+	}
+}
+
 func TestVolumeLock(t *testing.T) {
 	repo := newFakeRepo()
 	mgr := newTestManager(repo, nil)

--- a/storage-proxy/pkg/snapshot/s0fs.go
+++ b/storage-proxy/pkg/snapshot/s0fs.go
@@ -377,6 +377,16 @@ func (m *Manager) forkS0FSVolume(ctx context.Context, req *ForkVolumeRequest) (*
 		return nil, ErrVolumeNotFound
 	}
 
+	if volume.NormalizeAccessMode(sourceVol.AccessMode) != volume.AccessModeROX {
+		ctldMounted, err := m.hasMountedCtldOwner(ctx, req.SourceVolumeID)
+		if err != nil {
+			return nil, err
+		}
+		if ctldMounted {
+			return nil, ErrMountedCtldOwner
+		}
+	}
+
 	if m.volMgr != nil {
 		if volCtx, getErr := m.volMgr.GetVolume(req.SourceVolumeID); getErr == nil && volCtx != nil {
 			_ = volCtx.FlushAll("")


### PR DESCRIPTION
## Summary
- make volume fork return conflict while a writable source volume still has a live ctld owner
- map that fork conflict to HTTP 409 so callers can retry after unmount/materialization
- update managed agents environment package docs with developer-facing package configuration guidance

## Tests
- go test ./storage-proxy/pkg/snapshot ./storage-proxy/pkg/http
- pre-push: make manifests, make proto, make apispec, go fmt ./..., go mod tidy, go mod vendor, golangci-lint run ./...