### PR TITLE
docs: clarify README command example

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Claim a sandbox, run stateful code, and run a one-shot command:
 
 ```python
 import os
-from sandbox0 import Client, CmdOptions
+from sandbox0 import Client
 from sandbox0.apispec.models.sandbox_config import SandboxConfig
 
 client = Client(
@@ -101,10 +101,7 @@ with client.sandboxes.open(
     second = sandbox.run("python", "print(x + 1)")
     print(second.output_raw, end="")
 
-    result = sandbox.cmd(
-        "list workspace",
-        CmdOptions(command=["sh", "-lc", "pwd && ls -la"]),
-    )
+    result = sandbox.cmd("sh -lc 'pwd && ls -la'")
     print(result.output_raw, end="")
 ```
 


### PR DESCRIPTION
## Summary
- Replace the README `sandbox.cmd` example with a command string that is actually executed directly
- Remove the now-unused `CmdOptions` import from the quickstart snippet

## Testing
- npx prettier --check README.md
- README Python code block compile check with local sdk-py
- shlex split check for `sh -lc 'pwd && ls -la'`\n- git diff --check\n- pre-push hook: make manifests, make proto, make apispec, go fmt ./..., go mod tidy, go mod vendor, golangci-lint run ./...