### PR TITLE
Repair stuck idle template pods

### DIFF
--- a/manager/pkg/controller/pool_manager.go
+++ b/manager/pkg/controller/pool_manager.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
@@ -55,6 +56,8 @@ const (
 	AnnotationWebhookStateVolumeID         = "sandbox0.ai/webhook-state-volume-id"
 	AnnotationTemplateSpecHash             = "sandbox0.ai/template-spec-hash"
 	AnnotationClusterAutoscalerSafeToEvict = "cluster-autoscaler.kubernetes.io/safe-to-evict"
+
+	unhealthyIdlePodRepairGracePeriod = 2 * time.Minute
 )
 
 // ClaimedSandboxPodAnnotations returns manager-owned metadata for active sandbox
@@ -127,7 +130,13 @@ func (pm *PoolManager) ReconcilePool(ctx context.Context, template *v1alpha1.San
 		return fmt.Errorf("drain stale idle pods: %w", err)
 	}
 
-	// 4. Check if replicas match minIdle
+	// 4. Repair current-hash idle pods that are stuck and will keep the
+	// ReplicaSet from creating replacements.
+	if err := pm.repairUnhealthyIdlePods(ctx, template, desiredTemplateHash); err != nil {
+		return fmt.Errorf("repair unhealthy idle pods: %w", err)
+	}
+
+	// 5. Check if replicas match minIdle
 	if rs.Spec.Replicas == nil || *rs.Spec.Replicas != template.Spec.Pool.MinIdle {
 		pm.logger.Info("Updating ReplicaSet replicas",
 			zap.String("template", template.Name),
@@ -305,7 +314,100 @@ func (pm *PoolManager) drainStaleIdlePods(ctx context.Context, template *v1alpha
 	return nil
 }
 
+func (pm *PoolManager) repairUnhealthyIdlePods(ctx context.Context, template *v1alpha1.SandboxTemplate, desiredTemplateHash string) error {
+	pods, err := pm.podLister.Pods(template.Namespace).List(labels.SelectorFromSet(map[string]string{
+		LabelTemplateID: template.Name,
+		LabelPoolType:   PoolTypeIdle,
+	}))
+	if err != nil {
+		return err
+	}
+
+	now := time.Now()
+	repaired := 0
+	for _, pod := range pods {
+		if pod.Annotations[AnnotationTemplateSpecHash] != desiredTemplateHash {
+			continue
+		}
+		if !shouldRepairUnhealthyIdlePod(pod, now) {
+			continue
+		}
+		deleted, err := pm.deleteUnhealthyIdlePodWithRetry(ctx, template.Namespace, pod.Name, desiredTemplateHash)
+		if err != nil {
+			return err
+		}
+		if deleted {
+			repaired++
+		}
+	}
+
+	if repaired > 0 {
+		pm.recorder.Eventf(template, corev1.EventTypeNormal, "UnhealthyIdlePodsRepaired",
+			"Deleted %d unhealthy idle pod(s) so the ReplicaSet can recreate them", repaired)
+		pm.logger.Info("Repaired unhealthy idle pods",
+			zap.String("template", template.Name),
+			zap.Int("count", repaired),
+			zap.String("desiredHash", desiredTemplateHash),
+		)
+	}
+	return nil
+}
+
+func shouldRepairUnhealthyIdlePod(pod *corev1.Pod, now time.Time) bool {
+	if pod == nil || pod.DeletionTimestamp != nil || IsPodReady(pod) {
+		return false
+	}
+	switch pod.Status.Phase {
+	case corev1.PodSucceeded, corev1.PodFailed:
+		return true
+	}
+	if pod.CreationTimestamp.IsZero() {
+		return false
+	}
+	return now.Sub(pod.CreationTimestamp.Time) >= unhealthyIdlePodRepairGracePeriod
+}
+
+func (pm *PoolManager) deleteUnhealthyIdlePodWithRetry(ctx context.Context, namespace, podName, desiredTemplateHash string) (bool, error) {
+	deleted := false
+	retryErr := retry.OnError(retry.DefaultRetry, func(err error) bool {
+		return errors.IsConflict(err) || errors.IsInvalid(err)
+	}, func() error {
+		pod, err := pm.k8sClient.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+		if err != nil {
+			if errors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+
+		if pod.Labels[LabelPoolType] != PoolTypeIdle ||
+			pod.Annotations[AnnotationTemplateSpecHash] != desiredTemplateHash ||
+			!shouldRepairUnhealthyIdlePod(pod, time.Now()) {
+			return nil
+		}
+
+		uid := pod.UID
+		resourceVersion := pod.ResourceVersion
+		err = pm.k8sClient.CoreV1().Pods(namespace).Delete(ctx, podName, metav1.DeleteOptions{
+			Preconditions: &metav1.Preconditions{
+				UID:             &uid,
+				ResourceVersion: &resourceVersion,
+			},
+		})
+		if err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+		deleted = err == nil
+		return nil
+	})
+	if retryErr != nil {
+		return false, retryErr
+	}
+	return deleted, nil
+}
+
 func (pm *PoolManager) deleteStaleIdlePodWithRetry(ctx context.Context, namespace, podName, desiredTemplateHash string) (bool, error) {
+	deleted := false
 	// Retry small transient races while still validating the pod is stale+idle.
 	retryErr := retry.OnError(retry.DefaultRetry, func(err error) bool {
 		return errors.IsConflict(err) || errors.IsInvalid(err)
@@ -334,12 +436,13 @@ func (pm *PoolManager) deleteStaleIdlePodWithRetry(ctx context.Context, namespac
 		if err != nil && !errors.IsNotFound(err) {
 			return err
 		}
+		deleted = err == nil
 		return nil
 	})
 	if retryErr != nil {
 		return false, retryErr
 	}
-	return false, nil
+	return deleted, nil
 }
 
 // TemplateSpecHash returns the pod spec hash used to identify current idle pods.

--- a/manager/pkg/controller/pool_manager_test.go
+++ b/manager/pkg/controller/pool_manager_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 	"github.com/stretchr/testify/assert"
@@ -153,6 +154,139 @@ func TestDrainStaleIdlePodsSkipsClaimedActivePods(t *testing.T) {
 	}
 
 	err := pm.drainStaleIdlePods(context.Background(), template, "new-hash")
+	require.NoError(t, err)
+	assert.Equal(t, 0, deleteActions)
+}
+
+func TestRepairUnhealthyIdlePodsDeletesStuckCurrentHashIdlePod(t *testing.T) {
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "template-a",
+			Namespace: "default",
+		},
+	}
+
+	stuckPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "idle-stuck",
+			Namespace:         "default",
+			UID:               types.UID("uid-stuck"),
+			ResourceVersion:   "31",
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-unhealthyIdlePodRepairGracePeriod - time.Second)),
+			Labels: map[string]string{
+				LabelTemplateID: "template-a",
+				LabelPoolType:   PoolTypeIdle,
+			},
+			Annotations: map[string]string{
+				AnnotationTemplateSpecHash: "new-hash",
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+		},
+	}
+	readyPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "idle-ready",
+			Namespace:         "default",
+			UID:               types.UID("uid-ready"),
+			ResourceVersion:   "32",
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-unhealthyIdlePodRepairGracePeriod - time.Second)),
+			Labels: map[string]string{
+				LabelTemplateID: "template-a",
+				LabelPoolType:   PoolTypeIdle,
+			},
+			Annotations: map[string]string{
+				AnnotationTemplateSpecHash: "new-hash",
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+
+	client := fake.NewSimpleClientset(stuckPod, readyPod)
+	podIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	require.NoError(t, podIndexer.Add(stuckPod))
+	require.NoError(t, podIndexer.Add(readyPod))
+	podLister := corelisters.NewPodLister(podIndexer)
+
+	deleteActions := 0
+	client.PrependReactor("delete", "pods", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		delAction, ok := action.(k8stesting.DeleteAction)
+		require.True(t, ok)
+		deleteActions++
+		opts := delAction.GetDeleteOptions()
+		require.NotNil(t, opts.Preconditions)
+		require.NotNil(t, opts.Preconditions.UID)
+		require.NotNil(t, opts.Preconditions.ResourceVersion)
+		assert.Equal(t, types.UID("uid-stuck"), *opts.Preconditions.UID)
+		assert.Equal(t, "31", *opts.Preconditions.ResourceVersion)
+		return false, nil, nil
+	})
+
+	pm := &PoolManager{
+		k8sClient: client,
+		podLister: podLister,
+		recorder:  record.NewFakeRecorder(10),
+		logger:    zap.NewNop(),
+	}
+
+	err := pm.repairUnhealthyIdlePods(context.Background(), template, "new-hash")
+	require.NoError(t, err)
+	assert.Equal(t, 1, deleteActions)
+}
+
+func TestRepairUnhealthyIdlePodsKeepsRecentlyCreatedPod(t *testing.T) {
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "template-a",
+			Namespace: "default",
+		},
+	}
+
+	recentPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "idle-recent",
+			Namespace:         "default",
+			UID:               types.UID("uid-recent"),
+			ResourceVersion:   "41",
+			CreationTimestamp: metav1.NewTime(time.Now()),
+			Labels: map[string]string{
+				LabelTemplateID: "template-a",
+				LabelPoolType:   PoolTypeIdle,
+			},
+			Annotations: map[string]string{
+				AnnotationTemplateSpecHash: "new-hash",
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+		},
+	}
+
+	client := fake.NewSimpleClientset(recentPod)
+	podIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	require.NoError(t, podIndexer.Add(recentPod))
+	podLister := corelisters.NewPodLister(podIndexer)
+
+	deleteActions := 0
+	client.PrependReactor("delete", "pods", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		deleteActions++
+		return false, nil, nil
+	})
+
+	pm := &PoolManager{
+		k8sClient: client,
+		podLister: podLister,
+		recorder:  record.NewFakeRecorder(10),
+		logger:    zap.NewNop(),
+	}
+
+	err := pm.repairUnhealthyIdlePods(context.Background(), template, "new-hash")
 	require.NoError(t, err)
 	assert.Equal(t, 0, deleteActions)
 }

--- a/tests/e2e/scenarios/single-cluster/scenarios.go
+++ b/tests/e2e/scenarios/single-cluster/scenarios.go
@@ -35,24 +35,9 @@ func LoadScenarios(cfg framework.Config) ([]framework.Scenario, error) {
 		if err != nil {
 			return nil, err
 		}
-		scenario.InfraNamespace = scenarioNamespace(cfg.InfraNamespace, relativePath)
-		for i := range scenario.Secrets {
-			scenario.Secrets[i].Namespace = scenario.InfraNamespace
-		}
-		for i := range scenario.Rollouts {
-			scenario.Rollouts[i].Namespace = scenario.InfraNamespace
-		}
 		scenarios = append(scenarios, scenario)
 	}
 	return scenarios, nil
-}
-
-func scenarioNamespace(baseNamespace, relativePath string) string {
-	base := strings.TrimSuffix(filepath.Base(relativePath), filepath.Ext(relativePath))
-	if strings.TrimSpace(baseNamespace) == "" {
-		baseNamespace = "sandbox0-system"
-	}
-	return strings.TrimSpace(baseNamespace) + "-" + base
 }
 
 func selectScenarioManifestPaths() ([]string, error) {

--- a/tests/e2e/scenarios/single-cluster/scenarios_test.go
+++ b/tests/e2e/scenarios/single-cluster/scenarios_test.go
@@ -33,7 +33,7 @@ func TestSelectScenarioManifestPathsReturnsErrorForNoMatches(t *testing.T) {
 	}
 }
 
-func TestLoadScenariosUsesDistinctInfraNamespaces(t *testing.T) {
+func TestLoadScenariosUsesManifestInfraNamespace(t *testing.T) {
 	t.Setenv(singleClusterScenariosEnvVar, "minimal,volumes")
 
 	cfg := framework.Config{
@@ -48,10 +48,9 @@ func TestLoadScenariosUsesDistinctInfraNamespaces(t *testing.T) {
 		t.Fatalf("expected 2 scenarios, got %d", len(scenarios))
 	}
 
-	want := []string{"sandbox0-system-minimal", "sandbox0-system-volumes"}
 	for i, scenario := range scenarios {
-		if scenario.InfraNamespace != want[i] {
-			t.Fatalf("scenario %d namespace = %q, want %q", i, scenario.InfraNamespace, want[i])
+		if scenario.InfraNamespace != "sandbox0-system" {
+			t.Fatalf("scenario %d namespace = %q, want sandbox0-system", i, scenario.InfraNamespace)
 		}
 		for _, rollout := range scenario.Rollouts {
 			if rollout.Namespace != scenario.InfraNamespace {


### PR DESCRIPTION
## Summary
- repair current-hash idle template pods that stay unhealthy past the startup grace period so ReplicaSet can recreate them
- keep recently created Pending pods and Ready pods untouched
- remove the e2e scenario-specific namespace suffixing that was added for this failure mode

## Testing
- go test ./tests/e2e/scenarios/single-cluster -run 'TestSelectScenarioManifestPaths|TestSelectScenarioManifestPathsReturnsErrorForNoMatches|TestLoadScenariosUsesManifestInfraNamespace'\n- go test ./manager/pkg/...\n- git push pre-push hooks: make manifests, make proto, make apispec, go fmt ./..., go mod tidy, go mod vendor, golangci-lint run ./...