### PR TITLE
feat: add volume file clone API

### DIFF
--- a/cluster-gateway/pkg/http/handlers_volume_files.go
+++ b/cluster-gateway/pkg/http/handlers_volume_files.go
@@ -49,6 +49,18 @@ func (s *Server) handleVolumeFileMove(c *gin.Context) {
 	s.proxyToStorageProxy(c)
 }
 
+// handleVolumeFileClone handles volume file clone operations.
+// Route: /api/v1/sandboxvolumes/:id/files/clone
+func (s *Server) handleVolumeFileClone(c *gin.Context) {
+	id, ok := requireVolumeID(c)
+	if !ok {
+		return
+	}
+
+	c.Request.URL.Path = "/sandboxvolumes/" + id + "/files/clone"
+	s.proxyToStorageProxy(c)
+}
+
 // handleVolumeFileStat handles volume file stat operations.
 // Route: /api/v1/sandboxvolumes/:id/files/stat
 func (s *Server) handleVolumeFileStat(c *gin.Context) {

--- a/cluster-gateway/pkg/http/handlers_volume_files_test.go
+++ b/cluster-gateway/pkg/http/handlers_volume_files_test.go
@@ -97,6 +97,7 @@ func newVolumeFileRouteTestServer(t *testing.T) (string, *internalauth.Generator
 			files.DELETE("", server.authMiddleware.RequirePermission(gatewayauthn.PermSandboxVolumeFileWrite), server.handleVolumeFileOperation)
 			files.GET("/watch", server.authMiddleware.RequirePermission(gatewayauthn.PermSandboxVolumeFileRead), server.handleVolumeFileWatch)
 			files.POST("/move", server.authMiddleware.RequirePermission(gatewayauthn.PermSandboxVolumeFileWrite), server.handleVolumeFileMove)
+			files.POST("/clone", server.authMiddleware.RequirePermission(gatewayauthn.PermSandboxVolumeFileWrite), server.handleVolumeFileClone)
 			files.GET("/stat", server.authMiddleware.RequirePermission(gatewayauthn.PermSandboxVolumeFileRead), server.handleVolumeFileStat)
 			files.GET("/list", server.authMiddleware.RequirePermission(gatewayauthn.PermSandboxVolumeFileRead), server.handleVolumeFileList)
 		}
@@ -158,6 +159,15 @@ func TestVolumeFileRoutesProxyToStorageProxy(t *testing.T) {
 			permission:   gatewayauthn.PermSandboxVolumeFileWrite,
 			wantPath:     "/sandboxvolumes/vol-1/files/move",
 			wantBodyPart: "/b.txt",
+		},
+		{
+			name:         "clone file proxies json body",
+			method:       http.MethodPost,
+			path:         "/api/v1/sandboxvolumes/vol-1/files/clone",
+			body:         `{"entries":[{"source_volume_id":"src-1","source_path":"/a.txt","target_path":"/b.txt"}]}`,
+			permission:   gatewayauthn.PermSandboxVolumeFileWrite,
+			wantPath:     "/sandboxvolumes/vol-1/files/clone",
+			wantBodyPart: "src-1",
 		},
 		{
 			name:       "stat preserves query",

--- a/cluster-gateway/pkg/http/server.go
+++ b/cluster-gateway/pkg/http/server.go
@@ -420,6 +420,7 @@ func (s *Server) setupRoutes() {
 				files.DELETE("", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxVolumeFileWrite), s.handleVolumeFileOperation)
 				files.GET("/watch", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxVolumeFileRead), s.handleVolumeFileWatch)
 				files.POST("/move", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxVolumeFileWrite), s.handleVolumeFileMove)
+				files.POST("/clone", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxVolumeFileWrite), s.handleVolumeFileClone)
 				files.GET("/stat", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxVolumeFileRead), s.handleVolumeFileStat)
 				files.GET("/list", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxVolumeFileRead), s.handleVolumeFileList)
 			}

--- a/docs/volume/http/page.mdx
+++ b/docs/volume/http/page.mdx
@@ -335,6 +335,71 @@ curl -X POST \
 
 ---
 
+## Clone Files
+
+Clone regular files from one Volume into another Volume without routing file bytes through the client. The storage layer uses copy-on-write metadata clones when possible and falls back to server-side copy when `mode` is `cow_or_copy`.
+
+<Endpoint method="POST">
+/api/v1/sandboxvolumes/{'{id}'}/files/clone
+</Endpoint>
+
+### Request Body
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `mode` | string | `cow_or_copy`, `cow_required`, or `copy`. Defaults to `cow_or_copy` |
+| `atomic` | boolean | Must be `true` when provided |
+| `entries` | array | Files to clone into the target Volume |
+
+Each entry contains:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `source_volume_id` | string | Source Volume ID in the same team |
+| `source_path` | string | Source regular file path |
+| `target_path` | string | Destination file path in the target Volume |
+| `overwrite` | boolean | Replace an existing destination file |
+| `create_parents` | boolean | Create missing destination parent directories |
+
+```bash
+curl -X POST \
+    "$SANDBOX0_BASE_URL/api/v1/sandboxvolumes/vol_workspace/files/clone" \
+    -H "Authorization: Bearer $SANDBOX0_API_KEY" \
+    -H "Content-Type: application/json" \
+    -d '{
+        "mode": "cow_or_copy",
+        "entries": [
+            {
+                "source_volume_id": "vol_assets",
+                "source_path": "/uploads/data.csv",
+                "target_path": "/workspace/data.csv",
+                "create_parents": true
+            }
+        ]
+    }'
+```
+
+Example response:
+
+```json
+{
+    "success": true,
+    "data": {
+        "entries": [
+            {
+                "source_volume_id": "vol_assets",
+                "source_path": "/uploads/data.csv",
+                "target_path": "/workspace/data.csv",
+                "mode": "cow",
+                "size_bytes": 1048576
+            }
+        ]
+    }
+}
+```
+
+---
+
 ## Delete File or Directory
 
 Delete a file or recursively delete a directory.

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -2498,6 +2498,39 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SuccessMovedResponse"
+  /api/v1/sandboxvolumes/{id}/files/clone:
+    post:
+      tags: [files]
+      summary: Clone files from sandbox volumes into a target volume
+      description: |
+        Clones one or more regular files into the target sandbox volume. The
+        storage layer uses copy-on-write metadata clones when possible and can
+        fall back to server-side copy when requested.
+      security:
+        - bearerAuth: []
+      x-upstream-service: storage-proxy
+      x-upstream-path: /sandboxvolumes/{id}/files/clone
+      parameters:
+        - $ref: "#/components/parameters/SandboxVolumeID"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CloneVolumeFilesRequest"
+      responses:
+        "200":
+          description: Files cloned
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessCloneVolumeFilesResponse"
+        "412":
+          description: COW clone unavailable when cow_required was requested
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
   /api/v1/sandboxvolumes/{id}/files/watch:
     get:
       tags: [files]
@@ -3304,6 +3337,18 @@ components:
               properties:
                 moved:
                   type: boolean
+    SuccessCloneVolumeFilesResponse:
+      allOf:
+        - $ref: "#/components/schemas/SuccessEnvelope"
+        - type: object
+          properties:
+            data:
+              type: object
+              properties:
+                entries:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/CloneVolumeFileResult"
     SuccessResizedResponse:
       allOf:
         - $ref: "#/components/schemas/SuccessEnvelope"
@@ -4713,6 +4758,61 @@ components:
         destination:
           type: string
       required: [source, destination]
+    CloneVolumeFilesRequest:
+      type: object
+      properties:
+        mode:
+          type: string
+          enum: [cow_or_copy, cow_required, copy]
+          default: cow_or_copy
+          description: Clone strategy. cow_or_copy prefers copy-on-write and falls back to server-side copy.
+        atomic:
+          type: boolean
+          default: true
+          description: Batch atomicity flag. Only true is currently supported.
+        entries:
+          type: array
+          minItems: 1
+          items:
+            $ref: "#/components/schemas/CloneVolumeFileEntry"
+      required: [entries]
+    CloneVolumeFileEntry:
+      type: object
+      properties:
+        source_volume_id:
+          type: string
+          description: Source sandbox volume ID. It must belong to the same team as the target volume.
+        source_path:
+          type: string
+          description: Source regular file path inside the source volume.
+        target_path:
+          type: string
+          description: Destination file path inside the target volume.
+        overwrite:
+          type: boolean
+          default: false
+          description: Replace an existing destination file. Existing directories are never overwritten.
+        create_parents:
+          type: boolean
+          default: false
+          description: Create missing parent directories under the target path.
+      required: [source_volume_id, source_path, target_path]
+    CloneVolumeFileResult:
+      type: object
+      properties:
+        source_volume_id:
+          type: string
+        source_path:
+          type: string
+        target_path:
+          type: string
+        mode:
+          type: string
+          enum: [cow, copy]
+        size_bytes:
+          type: integer
+          format: uint64
+      required: [source_volume_id, source_path, target_path, mode, size_bytes]
     FileWatchRequest:
       oneOf:
         - $ref: "#/components/schemas/FileWatchSubscribeRequest"

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -27,6 +27,19 @@ const (
 	ChangeRequestEntryKindFile      ChangeRequestEntryKind = "file"
 )
 
+// Defines values for CloneVolumeFileResultMode.
+const (
+	CloneVolumeFileResultModeCopy CloneVolumeFileResultMode = "copy"
+	CloneVolumeFileResultModeCow  CloneVolumeFileResultMode = "cow"
+)
+
+// Defines values for CloneVolumeFilesRequestMode.
+const (
+	CloneVolumeFilesRequestModeCopy        CloneVolumeFilesRequestMode = "copy"
+	CloneVolumeFilesRequestModeCowOrCopy   CloneVolumeFilesRequestMode = "cow_or_copy"
+	CloneVolumeFilesRequestModeCowRequired CloneVolumeFilesRequestMode = "cow_required"
+)
+
 // Defines values for CredentialProjectionType.
 const (
 	HttpHeaders          CredentialProjectionType = "http_headers"
@@ -172,6 +185,11 @@ const (
 // Defines values for SuccessClaimResponseSuccess.
 const (
 	SuccessClaimResponseSuccessTrue SuccessClaimResponseSuccess = true
+)
+
+// Defines values for SuccessCloneVolumeFilesResponseSuccess.
+const (
+	SuccessCloneVolumeFilesResponseSuccessTrue SuccessCloneVolumeFilesResponseSuccess = true
 )
 
 // Defines values for SuccessContextExecResponseSuccess.
@@ -446,7 +464,7 @@ const (
 
 // Defines values for SuccessWrittenResponseSuccess.
 const (
-	SuccessWrittenResponseSuccessTrue SuccessWrittenResponseSuccess = true
+	True SuccessWrittenResponseSuccess = true
 )
 
 // Defines values for SyncEventType.
@@ -656,6 +674,49 @@ type ClaimResponse struct {
 	Status          string         `json:"status"`
 	Template        string         `json:"template"`
 }
+
+// CloneVolumeFileEntry defines model for CloneVolumeFileEntry.
+type CloneVolumeFileEntry struct {
+	// CreateParents Create missing parent directories under the target path.
+	CreateParents *bool `json:"create_parents,omitempty"`
+
+	// Overwrite Replace an existing destination file. Existing directories are never overwritten.
+	Overwrite *bool `json:"overwrite,omitempty"`
+
+	// SourcePath Source regular file path inside the source volume.
+	SourcePath string `json:"source_path"`
+
+	// SourceVolumeId Source sandbox volume ID. It must belong to the same team as the target volume.
+	SourceVolumeId string `json:"source_volume_id"`
+
+	// TargetPath Destination file path inside the target volume.
+	TargetPath string `json:"target_path"`
+}
+
+// CloneVolumeFileResult defines model for CloneVolumeFileResult.
+type CloneVolumeFileResult struct {
+	Mode           CloneVolumeFileResultMode `json:"mode"`
+	SizeBytes      uint64                    `json:"size_bytes"`
+	SourcePath     string                    `json:"source_path"`
+	SourceVolumeId string                    `json:"source_volume_id"`
+	TargetPath     string                    `json:"target_path"`
+}
+
+// CloneVolumeFileResultMode defines model for CloneVolumeFileResult.Mode.
+type CloneVolumeFileResultMode string
+
+// CloneVolumeFilesRequest defines model for CloneVolumeFilesRequest.
+type CloneVolumeFilesRequest struct {
+	// Atomic Batch atomicity flag. Only true is currently supported.
+	Atomic  *bool                  `json:"atomic,omitempty"`
+	Entries []CloneVolumeFileEntry `json:"entries"`
+
+	// Mode Clone strategy. cow_or_copy prefers copy-on-write and falls back to server-side copy.
+	Mode *CloneVolumeFilesRequestMode `json:"mode,omitempty"`
+}
+
+// CloneVolumeFilesRequestMode Clone strategy. cow_or_copy prefers copy-on-write and falls back to server-side copy.
+type CloneVolumeFilesRequestMode string
 
 // ContainerSpec defines model for ContainerSpec.
 type ContainerSpec struct {
@@ -1701,6 +1762,17 @@ type SuccessClaimResponse struct {
 
 // SuccessClaimResponseSuccess defines model for SuccessClaimResponse.Success.
 type SuccessClaimResponseSuccess bool
+
+// SuccessCloneVolumeFilesResponse defines model for SuccessCloneVolumeFilesResponse.
+type SuccessCloneVolumeFilesResponse struct {
+	Data *struct {
+		Entries *[]CloneVolumeFileResult `json:"entries,omitempty"`
+	} `json:"data,omitempty"`
+	Success SuccessCloneVolumeFilesResponseSuccess `json:"success"`
+}
+
+// SuccessCloneVolumeFilesResponseSuccess defines model for SuccessCloneVolumeFilesResponse.Success.
+type SuccessCloneVolumeFilesResponseSuccess bool
 
 // SuccessContextExecResponse defines model for SuccessContextExecResponse.
 type SuccessContextExecResponse struct {
@@ -2827,6 +2899,9 @@ type PostApiV1SandboxesIdRefreshJSONRequestBody = SandboxRefreshRequest
 
 // PostApiV1SandboxvolumesJSONRequestBody defines body for PostApiV1Sandboxvolumes for application/json ContentType.
 type PostApiV1SandboxvolumesJSONRequestBody = CreateSandboxVolumeRequest
+
+// PostApiV1SandboxvolumesIdFilesCloneJSONRequestBody defines body for PostApiV1SandboxvolumesIdFilesClone for application/json ContentType.
+type PostApiV1SandboxvolumesIdFilesCloneJSONRequestBody = CloneVolumeFilesRequest
 
 // PostApiV1SandboxvolumesIdFilesMoveJSONRequestBody defines body for PostApiV1SandboxvolumesIdFilesMove for application/json ContentType.
 type PostApiV1SandboxvolumesIdFilesMoveJSONRequestBody = MoveFileRequest

--- a/storage-proxy/pkg/http/handlers_volume_files.go
+++ b/storage-proxy/pkg/http/handlers_volume_files.go
@@ -21,6 +21,8 @@ import (
 	httpproxy "github.com/sandbox0-ai/sandbox0/pkg/proxy"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/fserror"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/s0fs"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volume"
 	pb "github.com/sandbox0-ai/sandbox0/storage-proxy/proto/fs"
 )
 
@@ -41,6 +43,7 @@ var (
 	errPathNotDir            = errors.New("path is not a directory")
 	errDirectoryNotEmpty     = errors.New("directory not empty")
 	errInvalidPath           = errors.New("invalid path")
+	errCOWCloneUnavailable   = errors.New("cow clone unavailable")
 )
 
 type volumeFileInfo struct {
@@ -57,6 +60,28 @@ type volumeFileInfo struct {
 type volumeFileMoveRequest struct {
 	Source      string `json:"source"`
 	Destination string `json:"destination"`
+}
+
+type volumeFileCloneRequest struct {
+	Mode    string                 `json:"mode"`
+	Atomic  *bool                  `json:"atomic,omitempty"`
+	Entries []volumeFileCloneEntry `json:"entries"`
+}
+
+type volumeFileCloneEntry struct {
+	SourceVolumeID string `json:"source_volume_id"`
+	SourcePath     string `json:"source_path"`
+	TargetPath     string `json:"target_path"`
+	Overwrite      bool   `json:"overwrite"`
+	CreateParents  bool   `json:"create_parents"`
+}
+
+type volumeFileCloneResponseEntry struct {
+	SourceVolumeID string `json:"source_volume_id"`
+	SourcePath     string `json:"source_path"`
+	TargetPath     string `json:"target_path"`
+	Mode           string `json:"mode"`
+	SizeBytes      uint64 `json:"size_bytes"`
 }
 
 type volumeResolvedPath struct {
@@ -277,6 +302,65 @@ func (s *Server) handleVolumeFileMove(w http.ResponseWriter, r *http.Request) {
 		}
 
 		_ = spec.WriteSuccess(w, http.StatusOK, map[string]bool{"moved": true})
+	})
+}
+
+func (s *Server) handleVolumeFileClone(w http.ResponseWriter, r *http.Request) {
+	targetVolumeID := r.PathValue("id")
+	if targetVolumeID == "" {
+		_ = spec.WriteError(w, http.StatusBadRequest, spec.CodeBadRequest, "volume id is required")
+		return
+	}
+
+	s.withSharedVolumeFileRequest(w, r, targetVolumeID, func(lockedReq *http.Request) {
+		ctx, _, targetCleanup, handled := s.prepareOrProxyVolumeFileRequest(w, lockedReq, targetVolumeID)
+		if handled {
+			return
+		}
+		defer targetCleanup()
+
+		var req volumeFileCloneRequest
+		if err := json.NewDecoder(lockedReq.Body).Decode(&req); err != nil {
+			_ = spec.WriteError(w, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
+			return
+		}
+		if err := validateVolumeFileCloneRequest(&req); err != nil {
+			_ = spec.WriteError(w, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
+			return
+		}
+
+		sourceCleanups, err := s.prepareCloneSourceVolumes(ctx, targetVolumeID, req.Entries)
+		if err != nil {
+			s.writeVolumeFileError(w, err)
+			return
+		}
+		defer func() {
+			for i := len(sourceCleanups) - 1; i >= 0; i-- {
+				sourceCleanups[i]()
+			}
+		}()
+
+		results, err := s.cloneVolumeFiles(ctx, targetVolumeID, &req)
+		if err != nil {
+			s.writeVolumeFileError(w, translateS0FSCloneError(err))
+			return
+		}
+		if err := s.finalizeVolumeFileMutation(ctx, targetVolumeID); err != nil {
+			s.writeVolumeFileError(w, err)
+			return
+		}
+
+		responseEntries := make([]volumeFileCloneResponseEntry, 0, len(results))
+		for _, result := range results {
+			responseEntries = append(responseEntries, volumeFileCloneResponseEntry{
+				SourceVolumeID: result.SourceVolumeID,
+				SourcePath:     result.SourcePath,
+				TargetPath:     result.TargetPath,
+				Mode:           string(result.Mode),
+				SizeBytes:      result.SizeBytes,
+			})
+		}
+		_ = spec.WriteSuccess(w, http.StatusOK, map[string]any{"entries": responseEntries})
 	})
 }
 
@@ -848,6 +932,208 @@ func (s *Server) moveVolumePath(ctx context.Context, volumeID, src, dst string) 
 	return nil
 }
 
+func validateVolumeFileCloneRequest(req *volumeFileCloneRequest) error {
+	if req == nil {
+		return fmt.Errorf("request is required")
+	}
+	if req.Atomic != nil && !*req.Atomic {
+		return fmt.Errorf("atomic=false is not supported")
+	}
+	switch strings.TrimSpace(req.Mode) {
+	case "", "cow_or_copy", "cow_required", "copy":
+	default:
+		return fmt.Errorf("unsupported clone mode %q", req.Mode)
+	}
+	if len(req.Entries) == 0 {
+		return fmt.Errorf("entries are required")
+	}
+	for i, entry := range req.Entries {
+		if strings.TrimSpace(entry.SourceVolumeID) == "" {
+			return fmt.Errorf("entries[%d].source_volume_id is required", i)
+		}
+		if strings.TrimSpace(entry.SourcePath) == "" {
+			return fmt.Errorf("entries[%d].source_path is required", i)
+		}
+		if strings.TrimSpace(entry.TargetPath) == "" {
+			return fmt.Errorf("entries[%d].target_path is required", i)
+		}
+	}
+	return nil
+}
+
+func (s *Server) prepareCloneSourceVolumes(ctx context.Context, targetVolumeID string, entries []volumeFileCloneEntry) ([]func(), error) {
+	seen := map[string]struct{}{targetVolumeID: {}}
+	var cleanups []func()
+	for _, entry := range entries {
+		sourceVolumeID := strings.TrimSpace(entry.SourceVolumeID)
+		if _, ok := seen[sourceVolumeID]; ok {
+			continue
+		}
+		seen[sourceVolumeID] = struct{}{}
+
+		volumeRecord, err := s.loadAuthorizedVolume(ctx, sourceVolumeID)
+		if err != nil {
+			return cleanups, err
+		}
+		if err := s.waitForVolumeHandoff(ctx, sourceVolumeID); err != nil {
+			return cleanups, err
+		}
+		if err := s.ensureCtldVolumeOwner(ctx, volumeRecord); err != nil {
+			return cleanups, err
+		}
+		cleanup, err := s.prepareVolumeFileMount(ctx, sourceVolumeID, volumeRecord.TeamID)
+		if err != nil {
+			return cleanups, err
+		}
+		cleanups = append(cleanups, cleanup)
+	}
+	return cleanups, nil
+}
+
+func (s *Server) cloneVolumeFiles(ctx context.Context, targetVolumeID string, req *volumeFileCloneRequest) ([]s0fs.FileCloneResult, error) {
+	if s == nil || s.volMgr == nil {
+		return nil, errVolumeFileUnavailable
+	}
+	targetVol, err := s.volMgr.GetVolume(targetVolumeID)
+	if err != nil {
+		return nil, err
+	}
+	if targetVol == nil || !targetVol.IsS0FS() {
+		return nil, errVolumeFileUnavailable
+	}
+
+	sourceVolumes, err := s.cloneSourceVolumeContexts(targetVolumeID, req.Entries, targetVol)
+	if err != nil {
+		return nil, err
+	}
+	requestMode := strings.TrimSpace(req.Mode)
+	if requestMode == "" {
+		requestMode = "cow_or_copy"
+	}
+	if requestMode != "copy" {
+		for _, sourceVol := range sourceVolumes {
+			if sourceVol == nil || sourceVol.S0FS == nil {
+				continue
+			}
+			if _, err := sourceVol.S0FS.SyncMaterialize(ctx); err != nil && requestMode == "cow_required" {
+				return nil, fmt.Errorf("%w: materialize source volume: %v", errCOWCloneUnavailable, err)
+			}
+		}
+	}
+
+	sources := make(map[string]s0fs.FileCloneSource, len(sourceVolumes))
+	for volumeID, sourceVol := range sourceVolumes {
+		if sourceVol == nil || !sourceVol.IsS0FS() {
+			return nil, errVolumeFileUnavailable
+		}
+		sources[volumeID] = s0fs.FileCloneSource{
+			VolumeID: volumeID,
+			State:    sourceVol.S0FS.SnapshotState(),
+		}
+	}
+
+	cloneEntries := make([]s0fs.FileCloneEntry, 0, len(req.Entries))
+	for _, entry := range req.Entries {
+		sourceVolumeID := strings.TrimSpace(entry.SourceVolumeID)
+		mode := s0fs.FileCloneModeCOW
+		var data []byte
+		if requestMode == "copy" || !canCOWCloneSource(sources[sourceVolumeID].State, entry.SourcePath) {
+			if requestMode == "cow_required" {
+				return nil, fmt.Errorf("%w: source file %s is not materialized", errCOWCloneUnavailable, entry.SourcePath)
+			}
+			mode = s0fs.FileCloneModeCopy
+			payload, err := readS0FSSourceFile(sourceVolumes[sourceVolumeID], sources[sourceVolumeID].State, entry.SourcePath)
+			if err != nil {
+				return nil, err
+			}
+			data = payload
+		}
+		cloneEntries = append(cloneEntries, s0fs.FileCloneEntry{
+			SourceVolumeID: sourceVolumeID,
+			SourcePath:     entry.SourcePath,
+			TargetPath:     entry.TargetPath,
+			Overwrite:      entry.Overwrite,
+			CreateParents:  entry.CreateParents,
+			Mode:           mode,
+			Data:           data,
+		})
+	}
+
+	nextState, results, err := s0fs.CloneFilesIntoState(targetVol.S0FS.SnapshotState(), sources, cloneEntries)
+	if err != nil {
+		return nil, err
+	}
+	if err := targetVol.S0FS.ReplaceState(nextState); err != nil {
+		return nil, err
+	}
+	s.publishVolumeFileCloneEvents(targetVolumeID, results)
+	return results, nil
+}
+
+func (s *Server) publishVolumeFileCloneEvents(targetVolumeID string, results []s0fs.FileCloneResult) {
+	publisher, ok := s.eventHub.(interface {
+		Publish(*pb.WatchEvent)
+	})
+	if !ok || publisher == nil {
+		return
+	}
+	now := time.Now().UTC().Unix()
+	for _, result := range results {
+		publisher.Publish(&pb.WatchEvent{
+			VolumeId:      targetVolumeID,
+			EventType:     pb.WatchEventType_WATCH_EVENT_TYPE_CREATE,
+			Path:          result.TargetPath,
+			TimestampUnix: now,
+		})
+	}
+}
+
+func (s *Server) cloneSourceVolumeContexts(targetVolumeID string, entries []volumeFileCloneEntry, targetVol *volume.VolumeContext) (map[string]*volume.VolumeContext, error) {
+	sourceVolumes := map[string]*volume.VolumeContext{
+		targetVolumeID: targetVol,
+	}
+	for _, entry := range entries {
+		sourceVolumeID := strings.TrimSpace(entry.SourceVolumeID)
+		if _, ok := sourceVolumes[sourceVolumeID]; ok {
+			continue
+		}
+		sourceVol, err := s.volMgr.GetVolume(sourceVolumeID)
+		if err != nil {
+			return nil, err
+		}
+		sourceVolumes[sourceVolumeID] = sourceVol
+	}
+	return sourceVolumes, nil
+}
+
+func canCOWCloneSource(state *s0fs.SnapshotState, sourcePath string) bool {
+	resolved, err := s0fs.LookupPath(state, sourcePath, false)
+	if err != nil || resolved == nil || !resolved.Exists || resolved.Node == nil || resolved.Node.Type != s0fs.TypeFile {
+		return false
+	}
+	if resolved.Node.Size == 0 {
+		return true
+	}
+	return len(state.ColdFiles[resolved.Inode]) > 0
+}
+
+func readS0FSSourceFile(volCtx *volume.VolumeContext, state *s0fs.SnapshotState, sourcePath string) ([]byte, error) {
+	if volCtx == nil || volCtx.S0FS == nil {
+		return nil, errVolumeFileUnavailable
+	}
+	resolved, err := s0fs.LookupPath(state, sourcePath, false)
+	if err != nil {
+		return nil, err
+	}
+	if resolved == nil || !resolved.Exists {
+		return nil, s0fs.ErrNotFound
+	}
+	if resolved.Node == nil || resolved.Node.Type != s0fs.TypeFile {
+		return nil, s0fs.ErrIsDir
+	}
+	return volCtx.S0FS.Read(resolved.Inode, 0, resolved.Node.Size)
+}
+
 func (s *Server) removeVolumePath(ctx context.Context, volumeID string, resolved *volumeResolvedPath) error {
 	if resolved == nil || !resolved.Exists {
 		return nil
@@ -1078,6 +1364,25 @@ func translateVolumeRPCError(err error) error {
 	}
 }
 
+func translateS0FSCloneError(err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, s0fs.ErrNotFound):
+		return errFileNotFound
+	case errors.Is(err, s0fs.ErrNotDir):
+		return errPathNotDir
+	case errors.Is(err, s0fs.ErrIsDir):
+		return errPathNotDir
+	case errors.Is(err, s0fs.ErrExists):
+		return errPathAlreadyExists
+	case errors.Is(err, s0fs.ErrInvalidInput):
+		return errInvalidPath
+	default:
+		return err
+	}
+}
+
 func (s *Server) writeVolumeFileError(w http.ResponseWriter, err error) {
 	switch {
 	case err == nil:
@@ -1100,6 +1405,8 @@ func (s *Server) writeVolumeFileError(w http.ResponseWriter, err error) {
 		_ = spec.WriteError(w, http.StatusForbidden, spec.CodeForbidden, err.Error())
 	case errors.Is(err, errPathAlreadyExists), errors.Is(err, errPathNotDir), errors.Is(err, errDirectoryNotEmpty):
 		_ = spec.WriteError(w, http.StatusConflict, spec.CodeConflict, err.Error())
+	case errors.Is(err, errCOWCloneUnavailable):
+		_ = spec.WriteError(w, http.StatusPreconditionFailed, spec.CodeBadRequest, err.Error())
 	case errors.Is(err, errInvalidPath):
 		_ = spec.WriteError(w, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
 	default:

--- a/storage-proxy/pkg/http/handlers_volume_files_test.go
+++ b/storage-proxy/pkg/http/handlers_volume_files_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"path/filepath"
 	"strconv"
 	"syscall"
 	"testing"
@@ -19,6 +20,8 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/fserror"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/objectstore"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/s0fs"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volume"
 	pb "github.com/sandbox0-ai/sandbox0/storage-proxy/proto/fs"
 	"github.com/sirupsen/logrus"
@@ -38,6 +41,7 @@ type fakeHTTPVolumeMountManager struct {
 	syncCalls         int
 	lastSyncVolume    string
 	syncFunc          func(context.Context, string) error
+	volumes           map[string]*volume.VolumeContext
 }
 
 type fakeVolumeFilePodResolver struct {
@@ -84,7 +88,12 @@ func (f *fakeHTTPSharedVolumeBarrier) WithExclusive(ctx context.Context, volumeI
 }
 
 func (f *fakeHTTPVolumeMountManager) GetVolume(volumeID string) (*volume.VolumeContext, error) {
-	return nil, errors.New("not implemented")
+	if f != nil && f.volumes != nil {
+		if volCtx, ok := f.volumes[volumeID]; ok {
+			return volCtx, nil
+		}
+	}
+	return nil, errors.New("volume not mounted")
 }
 
 func (f *fakeHTTPVolumeMountManager) UnmountVolume(_ context.Context, volumeID, sessionID string) error {
@@ -303,6 +312,41 @@ func volumeFileAttr(size int) *pb.GetAttrResponse {
 		Size:      uint64(size),
 		MtimeSec:  1710000000,
 		MtimeNsec: 123,
+	}
+}
+
+func newHTTPMountedS0FSVolumeContext(t *testing.T, volumeID, teamID string, resolver s0fs.ObjectStoreResolver) *volume.VolumeContext {
+	t.Helper()
+
+	var store objectstore.Store
+	if resolver != nil {
+		var err error
+		store, err = resolver(volumeID)
+		if err != nil {
+			t.Fatalf("resolve object store: %v", err)
+		}
+	}
+	engine, err := s0fs.Open(context.Background(), s0fs.Config{
+		VolumeID:             volumeID,
+		WALPath:              filepath.Join(t.TempDir(), "engine.wal"),
+		ObjectStore:          store,
+		ObjectStoreForVolume: resolver,
+	})
+	if err != nil {
+		t.Fatalf("Open(s0fs) error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = engine.Close()
+	})
+
+	return &volume.VolumeContext{
+		VolumeID:  volumeID,
+		TeamID:    teamID,
+		Backend:   volume.BackendS0FS,
+		S0FS:      engine,
+		MountedAt: time.Now(),
+		RootInode: 1,
+		RootPath:  "/",
 	}
 }
 
@@ -703,6 +747,129 @@ func TestHandleVolumeFileMoveRenamesPath(t *testing.T) {
 	}
 }
 
+func TestHandleVolumeFileCloneCreatesCOWFile(t *testing.T) {
+	store := objectstore.NewMemoryStore("http-clone")
+	resolver := func(volumeID string) (objectstore.Store, error) {
+		return objectstore.Prefix(store, volumeID+"/s0fs/"), nil
+	}
+	source := newHTTPMountedS0FSVolumeContext(t, "vol-source", "team-a", resolver)
+	target := newHTTPMountedS0FSVolumeContext(t, "vol-1", "team-a", resolver)
+
+	sourceNode, err := source.S0FS.CreateFile(s0fs.RootInode, "asset.txt", 0o644)
+	if err != nil {
+		t.Fatalf("CreateFile(source) error = %v", err)
+	}
+	if _, err := source.S0FS.Write(sourceNode.Inode, 0, []byte("payload")); err != nil {
+		t.Fatalf("Write(source) error = %v", err)
+	}
+
+	fileRPC := &fakeHTTPVolumeFileRPC{}
+	server, volMgr := newVolumeFileTestServer(fileRPC)
+	volMgr.volumes = map[string]*volume.VolumeContext{
+		"vol-1":      target,
+		"vol-source": source,
+	}
+	repo := server.repo.(*fakeHTTPRepo)
+	defaultUID := int64(1000)
+	defaultGID := int64(1000)
+	repo.volumes["vol-source"] = &db.SandboxVolume{
+		ID:              "vol-source",
+		TeamID:          "team-a",
+		DefaultPosixUID: &defaultUID,
+		DefaultPosixGID: &defaultGID,
+		AccessMode:      string(volume.AccessModeRWX),
+	}
+
+	body := bytes.NewBufferString(`{"mode":"cow_required","entries":[{"source_volume_id":"vol-source","source_path":"/asset.txt","target_path":"/mounted/asset.txt","create_parents":true}]}`)
+	req := httptest.NewRequest(http.MethodPost, "/sandboxvolumes/vol-1/files/clone", body)
+	req.SetPathValue("id", "vol-1")
+	req = req.WithContext(internalauth.WithClaims(req.Context(), &internalauth.Claims{TeamID: "team-a"}))
+	recorder := httptest.NewRecorder()
+
+	server.handleVolumeFileClone(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if volMgr.syncCalls != 1 || volMgr.lastSyncVolume != "vol-1" {
+		t.Fatalf("SyncDirectVolumeFileMount() got calls=%d volume=%q, want 1 vol-1", volMgr.syncCalls, volMgr.lastSyncVolume)
+	}
+	parent, err := target.S0FS.Lookup(s0fs.RootInode, "mounted")
+	if err != nil {
+		t.Fatalf("Lookup(mounted) error = %v", err)
+	}
+	cloned, err := target.S0FS.Lookup(parent.Inode, "asset.txt")
+	if err != nil {
+		t.Fatalf("Lookup(cloned) error = %v", err)
+	}
+	data, err := target.S0FS.Read(cloned.Inode, 0, cloned.Size)
+	if err != nil {
+		t.Fatalf("Read(cloned) error = %v", err)
+	}
+	if string(data) != "payload" {
+		t.Fatalf("cloned data = %q, want payload", data)
+	}
+	if len(target.S0FS.SnapshotState().ColdFiles[cloned.Inode]) == 0 {
+		t.Fatal("cloned file is not backed by cold extents")
+	}
+}
+
+func TestHandleVolumeFileCloneFallsBackToCopyForHotSource(t *testing.T) {
+	source := newHTTPMountedS0FSVolumeContext(t, "vol-source", "team-a", nil)
+	target := newHTTPMountedS0FSVolumeContext(t, "vol-1", "team-a", nil)
+
+	sourceNode, err := source.S0FS.CreateFile(s0fs.RootInode, "hot.txt", 0o644)
+	if err != nil {
+		t.Fatalf("CreateFile(source) error = %v", err)
+	}
+	if _, err := source.S0FS.Write(sourceNode.Inode, 0, []byte("hot-data")); err != nil {
+		t.Fatalf("Write(source) error = %v", err)
+	}
+
+	fileRPC := &fakeHTTPVolumeFileRPC{}
+	server, volMgr := newVolumeFileTestServer(fileRPC)
+	volMgr.volumes = map[string]*volume.VolumeContext{
+		"vol-1":      target,
+		"vol-source": source,
+	}
+	repo := server.repo.(*fakeHTTPRepo)
+	defaultUID := int64(1000)
+	defaultGID := int64(1000)
+	repo.volumes["vol-source"] = &db.SandboxVolume{
+		ID:              "vol-source",
+		TeamID:          "team-a",
+		DefaultPosixUID: &defaultUID,
+		DefaultPosixGID: &defaultGID,
+		AccessMode:      string(volume.AccessModeRWX),
+	}
+
+	body := bytes.NewBufferString(`{"mode":"cow_or_copy","entries":[{"source_volume_id":"vol-source","source_path":"/hot.txt","target_path":"/hot.txt"}]}`)
+	req := httptest.NewRequest(http.MethodPost, "/sandboxvolumes/vol-1/files/clone", body)
+	req.SetPathValue("id", "vol-1")
+	req = req.WithContext(internalauth.WithClaims(req.Context(), &internalauth.Claims{TeamID: "team-a"}))
+	recorder := httptest.NewRecorder()
+
+	server.handleVolumeFileClone(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	cloned, err := target.S0FS.Lookup(s0fs.RootInode, "hot.txt")
+	if err != nil {
+		t.Fatalf("Lookup(cloned) error = %v", err)
+	}
+	data, err := target.S0FS.Read(cloned.Inode, 0, cloned.Size)
+	if err != nil {
+		t.Fatalf("Read(cloned) error = %v", err)
+	}
+	if string(data) != "hot-data" {
+		t.Fatalf("cloned data = %q, want hot-data", data)
+	}
+	if len(target.S0FS.SnapshotState().Data[cloned.Inode]) == 0 {
+		t.Fatal("fallback clone did not store inline copy data")
+	}
+}
+
 func TestHandleVolumeFileMoveProxiesBodyToCtldOwner(t *testing.T) {
 	remoteSeen := make(chan struct {
 		header http.Header
@@ -778,6 +945,84 @@ func TestHandleVolumeFileMoveProxiesBodyToCtldOwner(t *testing.T) {
 		}
 	default:
 		t.Fatal("expected move request to be proxied to ctld owner")
+	}
+}
+
+func TestHandleVolumeFileCloneProxiesBodyToCtldOwner(t *testing.T) {
+	remoteSeen := make(chan struct {
+		header http.Header
+		body   []byte
+	}, 1)
+	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read proxied body: %v", err)
+		}
+		select {
+		case remoteSeen <- struct {
+			header http.Header
+			body   []byte
+		}{
+			header: r.Header.Clone(),
+			body:   body,
+		}:
+		default:
+		}
+		_ = spec.WriteSuccess(w, http.StatusOK, map[string]any{"entries": []volumeFileCloneResponseEntry{}})
+	}))
+	defer remote.Close()
+	remoteURL, err := url.Parse(remote.URL)
+	if err != nil {
+		t.Fatalf("parse remote url: %v", err)
+	}
+	remotePort, err := strconv.Atoi(remoteURL.Port())
+	if err != nil {
+		t.Fatalf("parse remote port: %v", err)
+	}
+
+	fileRPC := &fakeHTTPVolumeFileRPC{}
+	server, volMgr := newVolumeFileTestServer(fileRPC)
+	repo := server.repo.(*fakeHTTPRepo)
+	repo.activeMounts["vol-1"] = []*db.VolumeMount{
+		{
+			VolumeID:     "vol-1",
+			ClusterID:    "cluster-a",
+			PodID:        "sandbox0-system/ctld-node-a",
+			MountedAt:    time.Unix(10, 0),
+			MountOptions: mustMountOptionsRaw(t, volume.MountOptions{AccessMode: volume.AccessModeRWO, OwnerKind: volume.OwnerKindCtld, OwnerPort: remotePort}),
+		},
+	}
+	server.podResolver = &fakeVolumeFilePodResolver{
+		urls: map[string]string{"sandbox0-system/ctld-node-a": "http://127.0.0.1"},
+	}
+
+	reqBody := []byte(`{"mode":"cow_or_copy","entries":[{"source_volume_id":"vol-source","source_path":"/data.csv","target_path":"/data.csv","create_parents":true}]}`)
+	req := httptest.NewRequest(http.MethodPost, "/sandboxvolumes/vol-1/files/clone", bytes.NewReader(reqBody))
+	req.SetPathValue("id", "vol-1")
+	req = req.WithContext(internalauth.WithClaims(req.Context(), &internalauth.Claims{TeamID: "team-a"}))
+	recorder := httptest.NewRecorder()
+
+	server.handleVolumeFileClone(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+	if volMgr.acquireCalls != 0 {
+		t.Fatalf("AcquireDirectVolumeFileMount() calls = %d, want 0", volMgr.acquireCalls)
+	}
+	select {
+	case seen := <-remoteSeen:
+		if got := seen.header.Get(volumeFileAffinityRoutedPodHeader); got != "sandbox0-system/ctld-node-a" {
+			t.Fatalf("routed pod header = %q, want %q", got, "sandbox0-system/ctld-node-a")
+		}
+		if got := seen.header.Get(volumeFileAffinityTeamHeader); got != "team-a" {
+			t.Fatalf("team header = %q, want %q", got, "team-a")
+		}
+		if !bytes.Equal(seen.body, reqBody) {
+			t.Fatalf("proxied body = %q, want %q", string(seen.body), string(reqBody))
+		}
+	default:
+		t.Fatal("expected clone request to be proxied to ctld owner")
 	}
 }
 

--- a/storage-proxy/pkg/http/server.go
+++ b/storage-proxy/pkg/http/server.go
@@ -182,6 +182,7 @@ func NewServer(logger *logrus.Logger, cfg *config.StorageProxyConfig, k8sClient 
 	s.mux.HandleFunc("GET /sandboxvolumes/{id}/files/stat", s.handleVolumeFileStat)
 	s.mux.HandleFunc("GET /sandboxvolumes/{id}/files/list", s.handleVolumeFileList)
 	s.mux.HandleFunc("POST /sandboxvolumes/{id}/files/move", s.handleVolumeFileMove)
+	s.mux.HandleFunc("POST /sandboxvolumes/{id}/files/clone", s.handleVolumeFileClone)
 	s.mux.HandleFunc("GET /sandboxvolumes/{id}/files/watch", s.handleVolumeFileWatch)
 
 	// Internal manager-owned SandboxVolume lifecycle handlers.

--- a/storage-proxy/pkg/s0fs/clone.go
+++ b/storage-proxy/pkg/s0fs/clone.go
@@ -1,0 +1,388 @@
+package s0fs
+
+import (
+	"fmt"
+	pathpkg "path"
+	"slices"
+	"strings"
+	"time"
+)
+
+type FileCloneMode string
+
+const (
+	FileCloneModeCOW  FileCloneMode = "cow"
+	FileCloneModeCopy FileCloneMode = "copy"
+)
+
+type FileCloneSource struct {
+	VolumeID string
+	State    *SnapshotState
+}
+
+type FileCloneEntry struct {
+	SourceVolumeID string
+	SourcePath     string
+	TargetPath     string
+	Overwrite      bool
+	CreateParents  bool
+	Mode           FileCloneMode
+	Data           []byte
+}
+
+type FileCloneResult struct {
+	SourceVolumeID string
+	SourcePath     string
+	TargetPath     string
+	Mode           FileCloneMode
+	SizeBytes      uint64
+}
+
+type PathLookup struct {
+	Clean  string
+	Parent uint64
+	Inode  uint64
+	Base   string
+	Node   *Node
+	Exists bool
+}
+
+// LookupPath resolves a logical absolute path against a detached snapshot state.
+func LookupPath(state *SnapshotState, raw string, allowRoot bool) (*PathLookup, error) {
+	if state == nil {
+		return nil, fmt.Errorf("%w: state is required", ErrInvalidInput)
+	}
+	normalizeState(state)
+	cleaned, err := cleanClonePath(raw, allowRoot)
+	if err != nil {
+		return nil, err
+	}
+	if cleaned == "/" {
+		node := state.Nodes[RootInode]
+		if node == nil {
+			return nil, ErrNotFound
+		}
+		return &PathLookup{
+			Clean:  cleaned,
+			Inode:  RootInode,
+			Node:   cloneNode(node),
+			Exists: true,
+		}, nil
+	}
+
+	parts := strings.Split(strings.Trim(cleaned, "/"), "/")
+	current := RootInode
+	for i, part := range parts {
+		children := state.Children[current]
+		if children == nil {
+			return nil, ErrNotDir
+		}
+		inode, ok := children[part]
+		if !ok {
+			return &PathLookup{
+				Clean:  cleaned,
+				Parent: current,
+				Base:   part,
+				Exists: false,
+			}, nil
+		}
+		node := state.Nodes[inode]
+		if node == nil {
+			return nil, ErrNotFound
+		}
+		if i == len(parts)-1 {
+			return &PathLookup{
+				Clean:  cleaned,
+				Parent: current,
+				Inode:  inode,
+				Base:   part,
+				Node:   cloneNode(node),
+				Exists: true,
+			}, nil
+		}
+		if node.Type != TypeDirectory {
+			return nil, ErrNotDir
+		}
+		current = inode
+	}
+
+	return nil, ErrInvalidInput
+}
+
+func CloneFilesIntoState(target *SnapshotState, sources map[string]FileCloneSource, entries []FileCloneEntry) (*SnapshotState, []FileCloneResult, error) {
+	if target == nil {
+		return nil, nil, fmt.Errorf("%w: target state is required", ErrInvalidInput)
+	}
+	if len(entries) == 0 {
+		return nil, nil, fmt.Errorf("%w: clone entries are required", ErrInvalidInput)
+	}
+
+	next := cloneState(target)
+	normalizeState(next)
+
+	now := time.Now().UTC()
+	results := make([]FileCloneResult, 0, len(entries))
+	for _, entry := range entries {
+		result, err := cloneFileIntoState(next, sources, entry, now)
+		if err != nil {
+			return nil, nil, err
+		}
+		results = append(results, result)
+	}
+	next.NextSeq++
+	return next, results, nil
+}
+
+func cloneFileIntoState(target *SnapshotState, sources map[string]FileCloneSource, entry FileCloneEntry, now time.Time) (FileCloneResult, error) {
+	source, ok := sources[strings.TrimSpace(entry.SourceVolumeID)]
+	if !ok || source.State == nil {
+		return FileCloneResult{}, fmt.Errorf("%w: source volume %q is unavailable", ErrInvalidInput, entry.SourceVolumeID)
+	}
+	normalizeState(source.State)
+
+	sourcePath, err := LookupPath(source.State, entry.SourcePath, false)
+	if err != nil {
+		return FileCloneResult{}, err
+	}
+	if !sourcePath.Exists {
+		return FileCloneResult{}, ErrNotFound
+	}
+	if sourcePath.Node == nil || sourcePath.Node.Type != TypeFile {
+		return FileCloneResult{}, ErrIsDir
+	}
+
+	targetParent, targetBase, err := ensureCloneParent(target, entry.TargetPath, entry.CreateParents, now)
+	if err != nil {
+		return FileCloneResult{}, err
+	}
+	if err := removeCloneDestinationIfNeeded(target, targetParent, targetBase, entry.Overwrite, now); err != nil {
+		return FileCloneResult{}, err
+	}
+
+	targetInode := allocateCloneInode(target)
+	targetNode := cloneNode(sourcePath.Node)
+	targetNode.Inode = targetInode
+	targetNode.Nlink = 1
+	targetNode.Ctime = now
+	target.Nodes[targetInode] = targetNode
+	target.Children[targetParent][targetBase] = targetInode
+
+	resultMode := entry.Mode
+	switch entry.Mode {
+	case FileCloneModeCopy:
+		target.Data[targetInode] = slices.Clone(entry.Data)
+		targetNode.Size = uint64(len(entry.Data))
+	case FileCloneModeCOW, "":
+		if err := attachColdClone(target, source, sourcePath.Inode, targetInode); err != nil {
+			return FileCloneResult{}, err
+		}
+		resultMode = FileCloneModeCOW
+	default:
+		return FileCloneResult{}, fmt.Errorf("%w: unsupported clone mode %q", ErrInvalidInput, entry.Mode)
+	}
+
+	return FileCloneResult{
+		SourceVolumeID: source.VolumeID,
+		SourcePath:     sourcePath.Clean,
+		TargetPath:     joinClonePath(parentPath(target, targetParent), targetBase),
+		Mode:           resultMode,
+		SizeBytes:      targetNode.Size,
+	}, nil
+}
+
+func attachColdClone(target *SnapshotState, source FileCloneSource, sourceInode, targetInode uint64) error {
+	sourceNode := source.State.Nodes[sourceInode]
+	if sourceNode == nil {
+		return ErrNotFound
+	}
+	extents := source.State.ColdFiles[sourceInode]
+	if sourceNode.Size > 0 && len(extents) == 0 {
+		return fmt.Errorf("%w: source file is not materialized", ErrInvalidInput)
+	}
+	if len(extents) == 0 {
+		return nil
+	}
+
+	remapped := make([]FileExtent, 0, len(extents))
+	idMap := make(map[string]string)
+	for _, extent := range extents {
+		sourceSegment := source.State.Segments[extent.SegmentID]
+		if sourceSegment == nil {
+			return fmt.Errorf("%w: missing source segment %s", ErrInvalidInput, extent.SegmentID)
+		}
+		targetSegmentID, ok := idMap[extent.SegmentID]
+		if !ok {
+			segment := cloneSegment(sourceSegment)
+			if strings.TrimSpace(segment.VolumeID) == "" {
+				segment.VolumeID = source.VolumeID
+			}
+			targetSegmentID = importCloneSegment(target, segment)
+			idMap[extent.SegmentID] = targetSegmentID
+		}
+		remapped = append(remapped, FileExtent{
+			SegmentID: targetSegmentID,
+			Offset:    extent.Offset,
+			Length:    extent.Length,
+		})
+	}
+	target.ColdFiles[targetInode] = remapped
+	return nil
+}
+
+func importCloneSegment(target *SnapshotState, segment *Segment) string {
+	if segment == nil {
+		return ""
+	}
+	if existing := target.Segments[segment.ID]; existing == nil || sameSegment(existing, segment) {
+		target.Segments[segment.ID] = segment
+		return segment.ID
+	}
+	base := strings.TrimSpace(segment.VolumeID) + "/" + segment.ID
+	candidate := base
+	for i := 1; ; i++ {
+		existing := target.Segments[candidate]
+		if existing == nil || sameSegment(existing, segment) {
+			clone := cloneSegment(segment)
+			clone.ID = candidate
+			target.Segments[candidate] = clone
+			return candidate
+		}
+		candidate = fmt.Sprintf("%s-%d", base, i)
+	}
+}
+
+func sameSegment(a, b *Segment) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.VolumeID == b.VolumeID &&
+		a.Key == b.Key &&
+		a.Length == b.Length &&
+		a.SHA256 == b.SHA256
+}
+
+func ensureCloneParent(state *SnapshotState, raw string, createParents bool, now time.Time) (uint64, string, error) {
+	cleaned, err := cleanClonePath(raw, false)
+	if err != nil {
+		return 0, "", err
+	}
+	parts := strings.Split(strings.Trim(cleaned, "/"), "/")
+	base := parts[len(parts)-1]
+	current := RootInode
+
+	for _, part := range parts[:len(parts)-1] {
+		children := state.Children[current]
+		if children == nil {
+			return 0, "", ErrNotDir
+		}
+		inode, ok := children[part]
+		if !ok {
+			if !createParents {
+				return 0, "", ErrNotFound
+			}
+			inode = allocateCloneInode(state)
+			state.Nodes[inode] = &Node{
+				Inode: inode,
+				Type:  TypeDirectory,
+				Mode:  0o755,
+				Nlink: 1,
+				Atime: now,
+				Mtime: now,
+				Ctime: now,
+			}
+			state.Children[inode] = map[string]uint64{}
+			children[part] = inode
+		}
+		node := state.Nodes[inode]
+		if node == nil {
+			return 0, "", ErrNotFound
+		}
+		if node.Type != TypeDirectory {
+			return 0, "", ErrNotDir
+		}
+		current = inode
+	}
+	return current, base, nil
+}
+
+func removeCloneDestinationIfNeeded(state *SnapshotState, parent uint64, name string, overwrite bool, now time.Time) error {
+	inode, exists := state.Children[parent][name]
+	if !exists {
+		return nil
+	}
+	node := state.Nodes[inode]
+	if node == nil {
+		delete(state.Children[parent], name)
+		return nil
+	}
+	if node.Type == TypeDirectory {
+		return ErrIsDir
+	}
+	if !overwrite {
+		return ErrExists
+	}
+	delete(state.Children[parent], name)
+	if node.Nlink > 0 {
+		node.Nlink--
+		node.Ctime = now
+	}
+	if node.Nlink == 0 {
+		delete(state.Nodes, inode)
+		delete(state.Data, inode)
+		delete(state.ColdFiles, inode)
+		delete(state.Children, inode)
+	}
+	return nil
+}
+
+func allocateCloneInode(state *SnapshotState) uint64 {
+	if state.NextInode <= RootInode {
+		state.NextInode = RootInode + 1
+	}
+	inode := state.NextInode
+	state.NextInode++
+	return inode
+}
+
+func parentPath(state *SnapshotState, inode uint64) string {
+	if inode == RootInode {
+		return "/"
+	}
+	var walk func(current uint64, prefix string) (string, bool)
+	walk = func(current uint64, prefix string) (string, bool) {
+		for name, child := range state.Children[current] {
+			childPath := joinClonePath(prefix, name)
+			if child == inode {
+				return childPath, true
+			}
+			if node := state.Nodes[child]; node != nil && node.Type == TypeDirectory {
+				if found, ok := walk(child, childPath); ok {
+					return found, true
+				}
+			}
+		}
+		return "", false
+	}
+	if found, ok := walk(RootInode, "/"); ok {
+		return found
+	}
+	return "/"
+}
+
+func cleanClonePath(raw string, allowRoot bool) (string, error) {
+	cleaned := pathpkg.Clean("/" + strings.TrimSpace(raw))
+	if cleaned == "/" && allowRoot {
+		return "/", nil
+	}
+	if cleaned == "/" {
+		return "", ErrInvalidInput
+	}
+	return cleaned, nil
+}
+
+func joinClonePath(parent, name string) string {
+	if parent == "/" {
+		return "/" + name
+	}
+	return parent + "/" + name
+}

--- a/storage-proxy/pkg/s0fs/clone_test.go
+++ b/storage-proxy/pkg/s0fs/clone_test.go
@@ -1,0 +1,188 @@
+package s0fs
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/objectstore"
+)
+
+func TestCloneFilesIntoStateCreatesCOWFile(t *testing.T) {
+	ctx := context.Background()
+	baseStore := objectstore.NewMemoryStore("clone-cow")
+	heads := newMemoryHeadStore()
+	resolver := func(volumeID string) (objectstore.Store, error) {
+		return objectstore.Prefix(baseStore, volumeID+"/s0fs/"), nil
+	}
+
+	sourceStore, _ := resolver("source")
+	source, err := Open(ctx, Config{
+		VolumeID:             "source",
+		WALPath:              filepath.Join(t.TempDir(), "source.wal"),
+		ObjectStore:          sourceStore,
+		ObjectStoreForVolume: resolver,
+		HeadStore:            heads,
+	})
+	if err != nil {
+		t.Fatalf("Open(source) error = %v", err)
+	}
+	defer source.Close()
+
+	sourceNode, err := source.CreateFile(RootInode, "asset.txt", 0o640)
+	if err != nil {
+		t.Fatalf("CreateFile(source) error = %v", err)
+	}
+	if err := source.SetOwner(sourceNode.Inode, 1000, 2000); err != nil {
+		t.Fatalf("SetOwner(source) error = %v", err)
+	}
+	if _, err := source.Write(sourceNode.Inode, 0, []byte("shared-data")); err != nil {
+		t.Fatalf("Write(source) error = %v", err)
+	}
+	if _, err := source.SyncMaterialize(ctx); err != nil {
+		t.Fatalf("SyncMaterialize(source) error = %v", err)
+	}
+
+	targetStore, _ := resolver("target")
+	target, err := Open(ctx, Config{
+		VolumeID:             "target",
+		WALPath:              filepath.Join(t.TempDir(), "target.wal"),
+		ObjectStore:          targetStore,
+		ObjectStoreForVolume: resolver,
+		HeadStore:            heads,
+	})
+	if err != nil {
+		t.Fatalf("Open(target) error = %v", err)
+	}
+	defer target.Close()
+
+	nextState, results, err := CloneFilesIntoState(target.SnapshotState(), map[string]FileCloneSource{
+		"source": {
+			VolumeID: "source",
+			State:    source.SnapshotState(),
+		},
+	}, []FileCloneEntry{{
+		SourceVolumeID: "source",
+		SourcePath:     "/asset.txt",
+		TargetPath:     "/mnt/asset.txt",
+		CreateParents:  true,
+		Mode:           FileCloneModeCOW,
+	}})
+	if err != nil {
+		t.Fatalf("CloneFilesIntoState() error = %v", err)
+	}
+	if len(results) != 1 || results[0].Mode != FileCloneModeCOW {
+		t.Fatalf("clone results = %+v, want one cow result", results)
+	}
+	if err := target.ReplaceState(nextState); err != nil {
+		t.Fatalf("ReplaceState(target) error = %v", err)
+	}
+
+	mnt, err := target.Lookup(RootInode, "mnt")
+	if err != nil {
+		t.Fatalf("Lookup(mnt) error = %v", err)
+	}
+	cloned, err := target.Lookup(mnt.Inode, "asset.txt")
+	if err != nil {
+		t.Fatalf("Lookup(cloned) error = %v", err)
+	}
+	if cloned.Mode != 0o640 || cloned.UID != 1000 || cloned.GID != 2000 {
+		t.Fatalf("cloned attrs mode=%o uid=%d gid=%d, want mode=640 uid=1000 gid=2000", cloned.Mode, cloned.UID, cloned.GID)
+	}
+	data, err := target.Read(cloned.Inode, 0, cloned.Size)
+	if err != nil {
+		t.Fatalf("Read(cloned) error = %v", err)
+	}
+	if !bytes.Equal(data, []byte("shared-data")) {
+		t.Fatalf("cloned data = %q, want shared-data", data)
+	}
+
+	if _, err := target.Write(cloned.Inode, 0, []byte("target")); err != nil {
+		t.Fatalf("Write(target clone) error = %v", err)
+	}
+	sourceData, err := source.Read(sourceNode.Inode, 0, 1024)
+	if err != nil {
+		t.Fatalf("Read(source after target write) error = %v", err)
+	}
+	if !bytes.Equal(sourceData, []byte("shared-data")) {
+		t.Fatalf("source after target write = %q, want shared-data", sourceData)
+	}
+}
+
+func TestCloneFilesIntoStateFallsBackToInlineCopy(t *testing.T) {
+	nowState := &SnapshotState{
+		NextSeq:   1,
+		NextInode: RootInode + 2,
+		Nodes: map[uint64]*Node{
+			RootInode: {Inode: RootInode, Type: TypeDirectory, Mode: 0o755, Nlink: 1},
+			2:         {Inode: 2, Type: TypeFile, Mode: 0o644, Nlink: 1, Size: 4},
+		},
+		Children: map[uint64]map[string]uint64{RootInode: {"hot.txt": 2}},
+		Data:     map[uint64][]byte{2: []byte("data")},
+	}
+	target := &SnapshotState{
+		NextSeq:   1,
+		NextInode: RootInode + 1,
+		Nodes:     map[uint64]*Node{RootInode: {Inode: RootInode, Type: TypeDirectory, Mode: 0o755, Nlink: 1}},
+		Children:  map[uint64]map[string]uint64{RootInode: {}},
+	}
+
+	next, results, err := CloneFilesIntoState(target, map[string]FileCloneSource{
+		"source": {VolumeID: "source", State: nowState},
+	}, []FileCloneEntry{{
+		SourceVolumeID: "source",
+		SourcePath:     "/hot.txt",
+		TargetPath:     "/copy.txt",
+		Mode:           FileCloneModeCopy,
+		Data:           []byte("data"),
+	}})
+	if err != nil {
+		t.Fatalf("CloneFilesIntoState(copy) error = %v", err)
+	}
+	if len(results) != 1 || results[0].Mode != FileCloneModeCopy {
+		t.Fatalf("copy results = %+v, want one copy result", results)
+	}
+	lookup, err := LookupPath(next, "/copy.txt", false)
+	if err != nil {
+		t.Fatalf("LookupPath(copy) error = %v", err)
+	}
+	if got := string(next.Data[lookup.Inode]); got != "data" {
+		t.Fatalf("copy data = %q, want data", got)
+	}
+}
+
+func TestCloneFilesIntoStateIsAtomicOnConflict(t *testing.T) {
+	source := &SnapshotState{
+		NextSeq:   1,
+		NextInode: RootInode + 2,
+		Nodes: map[uint64]*Node{
+			RootInode: {Inode: RootInode, Type: TypeDirectory, Mode: 0o755, Nlink: 1},
+			2:         {Inode: 2, Type: TypeFile, Mode: 0o644, Nlink: 1, Size: 0},
+		},
+		Children: map[uint64]map[string]uint64{RootInode: {"empty.txt": 2}},
+	}
+	target := &SnapshotState{
+		NextSeq:   1,
+		NextInode: RootInode + 2,
+		Nodes: map[uint64]*Node{
+			RootInode: {Inode: RootInode, Type: TypeDirectory, Mode: 0o755, Nlink: 1},
+			2:         {Inode: 2, Type: TypeFile, Mode: 0o644, Nlink: 1, Size: 0},
+		},
+		Children: map[uint64]map[string]uint64{RootInode: {"exists.txt": 2}},
+	}
+
+	_, _, err := CloneFilesIntoState(target, map[string]FileCloneSource{
+		"source": {VolumeID: "source", State: source},
+	}, []FileCloneEntry{
+		{SourceVolumeID: "source", SourcePath: "/empty.txt", TargetPath: "/created.txt", Mode: FileCloneModeCOW},
+		{SourceVolumeID: "source", SourcePath: "/empty.txt", TargetPath: "/exists.txt", Mode: FileCloneModeCOW},
+	})
+	if !errors.Is(err, ErrExists) {
+		t.Fatalf("CloneFilesIntoState() error = %v, want ErrExists", err)
+	}
+	if _, exists := target.Children[RootInode]["created.txt"]; exists {
+		t.Fatal("target state was mutated after failed atomic clone")
+	}
+}


### PR DESCRIPTION
## Summary
- add direct sandbox volume file clone API with COW-or-copy, COW-required, and copy modes
- implement atomic s0fs clone batches with COW metadata import and copy fallback
- expose HTTP handler, tests, OpenAPI types, and docs

Closes #283

## Testing
- go test ./pkg/apispec ./storage-proxy/pkg/s0fs ./storage-proxy/pkg/http
- go test ./storage-proxy/pkg/...
- git diff --check

Note: go test ./... still hits unrelated local environment failures in procd PTY and local kind e2e when Docker is unavailable.