### PR TITLE
Trust netd MITM CA in procd runtimes

### DIFF
--- a/docs/credential/egress-auth/page.mdx
+++ b/docs/credential/egress-auth/page.mdx
@@ -55,18 +55,12 @@ In this example, `{{token}}` refers to the `token` key inside a `static_headers`
 
 ## HTTPS Trust Material
 
-When a credential rule uses TLS interception such as `protocol: https`, `protocol: grpc`, or `protocol: tls` with `tlsMode: terminate-reoriginate`, Sandbox0 provides the netd MITM CA to sandbox containers as read-only trust material:
+When a credential rule uses TLS interception such as `protocol: https`, `protocol: grpc`, or `protocol: tls` with `tlsMode: terminate-reoriginate`, Sandbox0 provides the netd MITM CA to sandbox containers and configures procd-managed processes to trust it automatically.
 
 - File: `/var/run/sandbox0/netd/mitm-ca.crt`
 - Env: `SANDBOX0_NETD_MITM_CA_FILE=/var/run/sandbox0/netd/mitm-ca.crt`
 
-Sandbox0 does not automatically modify the container trust store. Templates and runtimes must opt in if they need to trust the intercepted certificate chain.
-
-Common examples:
-
-- Node.js or Claude Code: `NODE_EXTRA_CA_CERTS=$SANDBOX0_NETD_MITM_CA_FILE`
-- Python `requests`: `REQUESTS_CA_BUNDLE=$SANDBOX0_NETD_MITM_CA_FILE`
-- `curl`: `CURL_CA_BUNDLE=$SANDBOX0_NETD_MITM_CA_FILE`
+At procd startup, Sandbox0 writes a combined CA bundle containing the image's system roots plus the netd MITM CA, then exports it through common TLS environment variables such as `SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`, and `AWS_CA_BUNDLE`. Applications normally do not need to handle the MITM CA themselves.
 
 ## Example Policy
 

--- a/docs/sandbox/network/page.mdx
+++ b/docs/sandbox/network/page.mdx
@@ -30,7 +30,7 @@ Use `trafficRules` for new policies. Legacy `allowed*` and `denied*` fields stil
 </Callout>
 
 <Callout variant="info">
-If a credential rule uses `tlsMode: terminate-reoriginate`, Sandbox0 exposes the netd MITM CA as `SANDBOX0_NETD_MITM_CA_FILE`, but it does not automatically update the container trust store. Templates and app runtimes must opt in, for example with `NODE_EXTRA_CA_CERTS` or `REQUESTS_CA_BUNDLE`.
+If a credential rule uses `tlsMode: terminate-reoriginate`, Sandbox0 exposes the netd MITM CA as `SANDBOX0_NETD_MITM_CA_FILE` and configures procd-managed processes with a combined CA bundle through common TLS environment variables.
 </Callout>
 
 ## Traffic Rule Fields

--- a/manager/cmd/procd/main.go
+++ b/manager/cmd/procd/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/file"
 	procdhttp "github.com/sandbox0-ai/sandbox0/manager/procd/pkg/http"
 	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/process"
+	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/trust"
 	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/webhook"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"github.com/sandbox0-ai/sandbox0/pkg/observability"
@@ -47,6 +48,11 @@ func main() {
 		zap.Int("http_port", cfg.HTTPPort),
 		zap.String("root_path", cfg.RootPath),
 	)
+	if bundlePath, err := trust.ConfigureNetdMITMCATrust(); err != nil {
+		logger.Warn("Failed to configure netd MITM CA trust", zap.Error(err))
+	} else if bundlePath != "" {
+		logger.Info("Configured netd MITM CA trust", zap.String("bundle_path", bundlePath))
+	}
 
 	// Initialize observability provider
 	obsProvider, err := observability.New(observability.Config{

--- a/manager/procd/pkg/trust/netd_mitm.go
+++ b/manager/procd/pkg/trust/netd_mitm.go
@@ -1,0 +1,82 @@
+package trust
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	NetdMITMCAFileEnv    = "SANDBOX0_NETD_MITM_CA_FILE"
+	NetdMITMCABundleEnv  = "SANDBOX0_NETD_CA_BUNDLE_FILE"
+	defaultBundlePath    = "/tmp/sandbox0/netd-ca-bundle.crt"
+	defaultBundleFileMod = 0644
+)
+
+var tlsBundleEnvVars = []string{
+	"NODE_EXTRA_CA_CERTS",
+	"SSL_CERT_FILE",
+	"REQUESTS_CA_BUNDLE",
+	"CURL_CA_BUNDLE",
+	"GIT_SSL_CAINFO",
+	"AWS_CA_BUNDLE",
+}
+
+var systemCABundleCandidates = []string{
+	"/etc/ssl/certs/ca-certificates.crt",
+	"/etc/pki/tls/certs/ca-bundle.crt",
+	"/etc/ssl/ca-bundle.pem",
+	"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",
+	"/etc/ssl/cert.pem",
+}
+
+// ConfigureNetdMITMCATrust exposes the netd MITM CA through common TLS env vars.
+func ConfigureNetdMITMCATrust() (string, error) {
+	mitmCAPath := strings.TrimSpace(os.Getenv(NetdMITMCAFileEnv))
+	if mitmCAPath == "" {
+		return "", nil
+	}
+	mitmCA, err := os.ReadFile(mitmCAPath)
+	if err != nil {
+		return "", fmt.Errorf("read netd MITM CA %s: %w", mitmCAPath, err)
+	}
+	bundlePath := strings.TrimSpace(os.Getenv(NetdMITMCABundleEnv))
+	if bundlePath == "" {
+		bundlePath = defaultBundlePath
+	}
+	bundle := buildBundle(mitmCA)
+	if err := os.MkdirAll(filepath.Dir(bundlePath), 0755); err != nil {
+		return "", fmt.Errorf("create netd CA bundle directory: %w", err)
+	}
+	if err := os.WriteFile(bundlePath, bundle, defaultBundleFileMod); err != nil {
+		return "", fmt.Errorf("write netd CA bundle %s: %w", bundlePath, err)
+	}
+	_ = os.Setenv(NetdMITMCABundleEnv, bundlePath)
+	for _, name := range tlsBundleEnvVars {
+		_ = os.Setenv(name, bundlePath)
+	}
+	return bundlePath, nil
+}
+
+func buildBundle(mitmCA []byte) []byte {
+	var bundle bytes.Buffer
+	if systemCA, ok := readFirstSystemCABundle(); ok {
+		bundle.Write(bytes.TrimSpace(systemCA))
+		bundle.WriteByte('\n')
+	}
+	bundle.Write(bytes.TrimSpace(mitmCA))
+	bundle.WriteByte('\n')
+	return bundle.Bytes()
+}
+
+func readFirstSystemCABundle() ([]byte, bool) {
+	for _, path := range systemCABundleCandidates {
+		data, err := os.ReadFile(path)
+		if err == nil && len(bytes.TrimSpace(data)) > 0 {
+			return data, true
+		}
+	}
+	return nil, false
+}

--- a/manager/procd/pkg/trust/netd_mitm_test.go
+++ b/manager/procd/pkg/trust/netd_mitm_test.go
@@ -1,0 +1,54 @@
+package trust
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestConfigureNetdMITMCATrustWritesBundleAndExportsTLSVars(t *testing.T) {
+	dir := t.TempDir()
+	mitmPath := filepath.Join(dir, "mitm-ca.crt")
+	bundlePath := filepath.Join(dir, "bundle.crt")
+	if err := os.WriteFile(mitmPath, []byte("-----BEGIN CERTIFICATE-----\nTEST\n-----END CERTIFICATE-----\n"), 0644); err != nil {
+		t.Fatalf("write mitm ca: %v", err)
+	}
+	t.Setenv(NetdMITMCAFileEnv, mitmPath)
+	t.Setenv(NetdMITMCABundleEnv, bundlePath)
+	for _, name := range tlsBundleEnvVars {
+		t.Setenv(name, "")
+	}
+
+	got, err := ConfigureNetdMITMCATrust()
+	if err != nil {
+		t.Fatalf("ConfigureNetdMITMCATrust: %v", err)
+	}
+	if got != bundlePath {
+		t.Fatalf("bundle path = %q, want %q", got, bundlePath)
+	}
+	data, err := os.ReadFile(bundlePath)
+	if err != nil {
+		t.Fatalf("read bundle: %v", err)
+	}
+	if !strings.Contains(string(data), "TEST") {
+		t.Fatalf("bundle missing MITM CA: %q", string(data))
+	}
+	for _, name := range tlsBundleEnvVars {
+		if value := os.Getenv(name); value != bundlePath {
+			t.Fatalf("%s = %q, want %q", name, value, bundlePath)
+		}
+	}
+}
+
+func TestConfigureNetdMITMCATrustNoopsWithoutCAEnv(t *testing.T) {
+	t.Setenv(NetdMITMCAFileEnv, "")
+
+	got, err := ConfigureNetdMITMCATrust()
+	if err != nil {
+		t.Fatalf("ConfigureNetdMITMCATrust: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("bundle path = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
## Summary
- build a combined system-root + netd MITM CA bundle when procd starts
- export the bundle through common TLS environment variables for procd-managed processes
- update docs to describe automatic trust handling

## Tests
- go test ./manager/procd/pkg/trust ./manager/pkg/apis/sandbox0/v1alpha1 -run 'TestConfigureNetdMITMCATrust|TestBuildPodSpecInjectsNetdMITMCATrustMaterialIntoProcdContainer|TestBuildPodSpecSkipsNetdMITMCATrustMaterialWhenManagerConfigOmitsSecret'\n- go test ./manager/cmd/procd ./manager/procd/pkg/... ./manager/pkg/apis/sandbox0/v1alpha1\n- pre-push hook: make manifests, make proto, make apispec, go fmt ./..., go mod tidy, go mod vendor, golangci-lint run ./...