### PR TITLE
Fix CTLD source mounts for volume file clone

### DIFF
--- a/ctld/internal/ctld/portal/manager.go
+++ b/ctld/internal/ctld/portal/manager.go
@@ -125,7 +125,7 @@ func NewManager(cfg Config) *Manager {
 		boundVolumes:      make(map[string]*boundVolume),
 		volumes:           newLocalVolumeManager(),
 	}
-	manager.volumeAPI = newMountedVolumeAPIHandler(storageConfig, cfg.Repository, manager.volumes, l)
+	manager.volumeAPI = newMountedVolumeAPIHandler(storageConfig, cfg.Repository, manager.volumes, l, manager)
 	return manager
 }
 

--- a/ctld/internal/ctld/portal/session.go
+++ b/ctld/internal/ctld/portal/session.go
@@ -36,6 +36,8 @@ type localVolumeRequestState struct {
 	cond         *sync.Cond
 }
 
+var errLocalVolumeNotMounted = errors.New("local volume not mounted")
+
 func newLocalVolumeManager() *localVolumeManager {
 	return &localVolumeManager{
 		volumes:  make(map[string]*volume.VolumeContext),
@@ -76,7 +78,7 @@ func (m *localVolumeManager) acquire(ctx context.Context, volumeID string) (func
 		state := m.requests[volumeID]
 		if volCtx == nil || state == nil {
 			m.mu.Unlock()
-			return nil, fmt.Errorf("volume %s not mounted", volumeID)
+			return nil, fmt.Errorf("%w: %s", errLocalVolumeNotMounted, volumeID)
 		}
 		if state.transferring && state.done != nil {
 			done := state.done
@@ -218,16 +220,19 @@ func (m *localVolumeManager) AckInvalidate(string, string, string, bool, string)
 
 func (m *localVolumeManager) AcquireDirectVolumeFileMount(ctx context.Context, volumeID string, mountFn func(context.Context) (string, error)) (func(), error) {
 	release, err := m.acquire(ctx, volumeID)
-	if err != nil {
+	if err == nil {
+		return release, nil
+	}
+	if !errors.Is(err, errLocalVolumeNotMounted) {
 		return nil, err
 	}
-	if mountFn != nil {
-		if _, err := mountFn(ctx); err != nil {
-			release()
-			return nil, err
-		}
+	if mountFn == nil {
+		return nil, err
 	}
-	return release, nil
+	if _, err := mountFn(ctx); err != nil {
+		return nil, err
+	}
+	return m.acquire(ctx, volumeID)
 }
 
 func (m *localVolumeManager) CleanupIdleDirectVolumeFileMount(context.Context, string) (bool, error) {

--- a/ctld/internal/ctld/portal/session_test.go
+++ b/ctld/internal/ctld/portal/session_test.go
@@ -227,6 +227,27 @@ func TestLocalVolumeManagerPrepareHandoffDrainsInflightAndBlocksNewAcquires(t *t
 	}
 }
 
+func TestLocalVolumeManagerAcquireDirectMountMountsMissingVolume(t *testing.T) {
+	mgr := newLocalVolumeManager()
+	mountCalls := 0
+
+	release, err := mgr.AcquireDirectVolumeFileMount(context.Background(), "vol-source", func(context.Context) (string, error) {
+		mountCalls++
+		mgr.add(&volume.VolumeContext{VolumeID: "vol-source"})
+		return "local-vol-source", nil
+	})
+	if err != nil {
+		t.Fatalf("AcquireDirectVolumeFileMount() error = %v", err)
+	}
+	defer release()
+	if mountCalls != 1 {
+		t.Fatalf("mountFn calls = %d, want 1", mountCalls)
+	}
+	if _, err := mgr.GetVolume("vol-source"); err != nil {
+		t.Fatalf("GetVolume() error = %v", err)
+	}
+}
+
 func TestLocalSessionReadCacheTracksSmallWrites(t *testing.T) {
 	engine, err := s0fs.Open(context.Background(), s0fs.Config{
 		VolumeID: "vol-1",

--- a/ctld/internal/ctld/portal/volume_api.go
+++ b/ctld/internal/ctld/portal/volume_api.go
@@ -1,21 +1,58 @@
 package portal
 
 import (
+	"context"
 	"net/http"
 	"strings"
 
 	apiconfig "github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
+	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
 	fsserver "github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/fsserver"
 	sphttp "github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/http"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/notify"
+	pb "github.com/sandbox0-ai/sandbox0/storage-proxy/proto/fs"
 	"github.com/sirupsen/logrus"
 )
 
 const volumeFileAffinityTeamHeader = "X-Sandbox0-Volume-Team-Id"
 
-func newMountedVolumeAPIHandler(storageCfg *apiconfig.StorageProxyConfig, repo *db.Repository, volumes *localVolumeManager, logger *logrus.Logger) http.Handler {
+type mountedVolumeOwnerAttacher interface {
+	AttachOwner(ctx context.Context, req ctldapi.AttachVolumeOwnerRequest) (ctldapi.AttachVolumeOwnerResponse, error)
+}
+
+type mountedVolumeFileRPC struct {
+	*fsserver.FileSystemServer
+	volumes  *localVolumeManager
+	attacher mountedVolumeOwnerAttacher
+}
+
+func (r *mountedVolumeFileRPC) MountVolume(ctx context.Context, req *pb.MountVolumeRequest) (*pb.MountVolumeResponse, error) {
+	if r == nil || r.FileSystemServer == nil {
+		return nil, nil
+	}
+	if req == nil || strings.TrimSpace(req.VolumeId) == "" {
+		return r.FileSystemServer.MountVolume(ctx, req)
+	}
+	if r.volumes != nil {
+		if _, err := r.volumes.GetVolume(req.VolumeId); err == nil {
+			return r.FileSystemServer.MountVolume(ctx, req)
+		}
+	}
+	claims := internalauth.ClaimsFromContext(ctx)
+	if r.attacher != nil && claims != nil && strings.TrimSpace(claims.TeamID) != "" {
+		if _, err := r.attacher.AttachOwner(ctx, ctldapi.AttachVolumeOwnerRequest{
+			TeamID:          claims.TeamID,
+			SandboxVolumeID: req.VolumeId,
+		}); err != nil {
+			return nil, err
+		}
+	}
+	return r.FileSystemServer.MountVolume(ctx, req)
+}
+
+func newMountedVolumeAPIHandler(storageCfg *apiconfig.StorageProxyConfig, repo *db.Repository, volumes *localVolumeManager, logger *logrus.Logger, attacher mountedVolumeOwnerAttacher) http.Handler {
 	if repo == nil || volumes == nil || logger == nil {
 		return nil
 	}
@@ -25,7 +62,8 @@ func newMountedVolumeAPIHandler(storageCfg *apiconfig.StorageProxyConfig, repo *
 		queueSize = storageCfg.WatchEventQueueSize
 	}
 	eventHub := notify.NewHub(logger, queueSize)
-	fileRPC := fsserver.NewFileSystemServer(volumes, repo, eventHub, notify.NewLocalBroadcaster(eventHub), logger, nil, nil)
+	fs := fsserver.NewFileSystemServer(volumes, repo, eventHub, notify.NewLocalBroadcaster(eventHub), logger, nil, nil)
+	fileRPC := &mountedVolumeFileRPC{FileSystemServer: fs, volumes: volumes, attacher: attacher}
 	server := sphttp.NewServer(logger, storageCfg, nil, repo, nil, "", nil, nil, nil, nil, volumes, fileRPC, eventHub)
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/ctld/internal/ctld/portal/volume_api_test.go
+++ b/ctld/internal/ctld/portal/volume_api_test.go
@@ -1,0 +1,84 @@
+package portal
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
+	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
+	fsserver "github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/fsserver"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volume"
+	pb "github.com/sandbox0-ai/sandbox0/storage-proxy/proto/fs"
+	"github.com/sirupsen/logrus"
+)
+
+type fakeMountedVolumeRepo struct {
+	volumes map[string]*db.SandboxVolume
+}
+
+func (r *fakeMountedVolumeRepo) GetSandboxVolume(_ context.Context, id string) (*db.SandboxVolume, error) {
+	if r != nil && r.volumes != nil {
+		if vol, ok := r.volumes[id]; ok {
+			return vol, nil
+		}
+	}
+	return nil, db.ErrNotFound
+}
+
+func (r *fakeMountedVolumeRepo) GetSandboxVolumeOwner(context.Context, string) (*db.SandboxVolumeOwner, error) {
+	return nil, db.ErrNotFound
+}
+
+type fakeMountedVolumeAttacher struct {
+	volumes *localVolumeManager
+	calls   int
+	lastReq ctldapi.AttachVolumeOwnerRequest
+}
+
+func (a *fakeMountedVolumeAttacher) AttachOwner(_ context.Context, req ctldapi.AttachVolumeOwnerRequest) (ctldapi.AttachVolumeOwnerResponse, error) {
+	a.calls++
+	a.lastReq = req
+	a.volumes.add(&volume.VolumeContext{
+		VolumeID: req.SandboxVolumeID,
+		TeamID:   req.TeamID,
+		Access:   volume.AccessModeRWO,
+	})
+	return ctldapi.AttachVolumeOwnerResponse{Attached: true}, nil
+}
+
+func TestMountedVolumeFileRPCMountVolumeAttachesMissingSourceVolume(t *testing.T) {
+	mgr := newLocalVolumeManager()
+	repo := &fakeMountedVolumeRepo{volumes: map[string]*db.SandboxVolume{
+		"vol-source": {
+			ID:         "vol-source",
+			TeamID:     "team-a",
+			AccessMode: string(volume.AccessModeRWO),
+		},
+	}}
+	attacher := &fakeMountedVolumeAttacher{volumes: mgr}
+	logger := logrus.New()
+	fs := fsserver.NewFileSystemServer(mgr, repo, nil, nil, logger, nil, nil)
+	rpc := &mountedVolumeFileRPC{FileSystemServer: fs, volumes: mgr, attacher: attacher}
+	ctx := internalauth.WithClaims(context.Background(), &internalauth.Claims{
+		TeamID:   "team-a",
+		IsSystem: true,
+	})
+
+	resp, err := rpc.MountVolume(ctx, &pb.MountVolumeRequest{VolumeId: "vol-source"})
+	if err != nil {
+		t.Fatalf("MountVolume() error = %v", err)
+	}
+	if resp == nil || resp.MountSessionId != "local-vol-source" {
+		t.Fatalf("MountVolume() response = %+v, want local session", resp)
+	}
+	if attacher.calls != 1 {
+		t.Fatalf("AttachOwner() calls = %d, want 1", attacher.calls)
+	}
+	if attacher.lastReq.TeamID != "team-a" || attacher.lastReq.SandboxVolumeID != "vol-source" {
+		t.Fatalf("AttachOwner() request = %+v", attacher.lastReq)
+	}
+	if _, err := mgr.GetVolume("vol-source"); err != nil {
+		t.Fatalf("source volume was not mounted locally: %v", err)
+	}
+}

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -227,6 +227,10 @@ func registerApiModeSuite(envProvider func() *framework.ScenarioEnv, opts apiMod
 					assertClaimMountedVolumeWritable(env, session)
 				})
 
+				It("clones files into claim-mounted volumes", func() {
+					assertClaimMountedVolumeCrossVolumeClone(env, session)
+				})
+
 				It("rejects mounting an active RWO volume into a second sandbox", func() {
 					assertClaimMountedRWOVolumeConflict(env, session)
 				})
@@ -2024,6 +2028,75 @@ func assertClaimMountedVolumeWritable(env *framework.ScenarioEnv, session *e2eut
 			return body, readErr
 		}).WithTimeout(90 * time.Second).WithPolling(2 * time.Second).Should(Equal(expected))
 	}
+}
+
+func assertClaimMountedVolumeCrossVolumeClone(env *framework.ScenarioEnv, session *e2eutils.Session) {
+	sourceVolume, status, err := session.CreateSandboxVolume(env.TestCtx.Context, GinkgoT(), apispec.CreateSandboxVolumeRequest{})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusCreated))
+	Expect(sourceVolume).NotTo(BeNil())
+	sourceVolumeID := expectStringPtr(sourceVolume.Id, "source volume id")
+	DeferCleanup(func() {
+		deleteSandboxVolumeForCleanup(env, session, sourceVolumeID)
+	})
+
+	targetVolume, status, err := session.CreateSandboxVolume(env.TestCtx.Context, GinkgoT(), apispec.CreateSandboxVolumeRequest{})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusCreated))
+	Expect(targetVolume).NotTo(BeNil())
+	targetVolumeID := expectStringPtr(targetVolume.Id, "target volume id")
+	DeferCleanup(func() {
+		deleteSandboxVolumeForCleanup(env, session, targetVolumeID)
+	})
+
+	sourcePath := "/assets/source.txt"
+	sourceContent := []byte(fmt.Sprintf("cross volume clone %d", time.Now().UnixNano()))
+	status, err = session.WriteVolumeFile(env.TestCtx.Context, GinkgoT(), sourceVolumeID, sourcePath, sourceContent, "")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+
+	mountPoint := "/workspace/claim-clone"
+	templateID := createVolumePortalTemplate(env, session, mountPoint)
+	claimReq := apispec.ClaimRequest{
+		Template: &templateID,
+		Mounts: &[]apispec.ClaimMountRequest{{
+			SandboxvolumeId: targetVolumeID,
+			MountPoint:      mountPoint,
+		}},
+	}
+	claimResp, err := session.ClaimSandboxWithRequest(env.TestCtx.Context, GinkgoT(), claimReq)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(claimResp).NotTo(BeNil())
+	sandboxID := claimResp.SandboxId
+	DeferCleanup(func() {
+		_ = session.DeleteSandbox(env.TestCtx.Context, GinkgoT(), sandboxID)
+	})
+	Expect(claimResp.BootstrapMounts).NotTo(BeNil())
+	Expect(*claimResp.BootstrapMounts).NotTo(BeEmpty())
+	Expect((*claimResp.BootstrapMounts)[0].State).To(Equal(apispec.MountStatusStateMounted))
+
+	createParents := true
+	mode := apispec.CloneVolumeFilesRequestModeCowOrCopy
+	targetPath := "/cloned/from-source.txt"
+	entries, status, err := session.CloneVolumeFiles(env.TestCtx.Context, GinkgoT(), targetVolumeID, apispec.CloneVolumeFilesRequest{
+		Mode: &mode,
+		Entries: []apispec.CloneVolumeFileEntry{{
+			SourceVolumeId: sourceVolumeID,
+			SourcePath:     sourcePath,
+			TargetPath:     targetPath,
+			CreateParents:  &createParents,
+		}},
+	})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+	Expect(entries).To(HaveLen(1))
+	Expect(entries[0].SourceVolumeId).To(Equal(sourceVolumeID))
+	Expect(entries[0].TargetPath).To(Equal(targetPath))
+
+	Eventually(func() ([]byte, error) {
+		body, _, readErr := session.ReadFile(env.TestCtx.Context, GinkgoT(), sandboxID, mountPoint+targetPath)
+		return body, readErr
+	}).WithTimeout(90 * time.Second).WithPolling(2 * time.Second).Should(Equal(sourceContent))
 }
 
 func deleteSandboxVolumeForCleanup(env *framework.ScenarioEnv, session *e2eutils.Session, volumeID string) {

--- a/tests/e2e/utils/volume.go
+++ b/tests/e2e/utils/volume.go
@@ -179,3 +179,23 @@ func (s *Session) ReadVolumeFile(ctx context.Context, t ContractT, volumeID, fil
 	}
 	return body, status, nil
 }
+
+func (s *Session) CloneVolumeFiles(ctx context.Context, t ContractT, volumeID string, req apispec.CloneVolumeFilesRequest) ([]apispec.CloneVolumeFileResult, int, error) {
+	specPath := "/api/v1/sandboxvolumes/{id}/files/clone"
+	requestPath := "/api/v1/sandboxvolumes/" + volumeID + "/files/clone"
+	status, body, err := s.doJSONSpecRequest(t, ctx, http.MethodPost, specPath, requestPath, req, true)
+	if err != nil {
+		return nil, status, err
+	}
+	if status != http.StatusOK {
+		return nil, status, fmt.Errorf("clone volume files failed with status %d: %s", status, formatAPIError(body))
+	}
+	var resp apispec.SuccessCloneVolumeFilesResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, status, err
+	}
+	if !bool(resp.Success) || resp.Data == nil || resp.Data.Entries == nil {
+		return nil, status, fmt.Errorf("clone volume files response missing entries")
+	}
+	return *resp.Data.Entries, status, nil
+}


### PR DESCRIPTION
## Summary
- attach missing source volumes into CTLD mounted-volume API before local file RPC mount
- let CTLD local direct file mounts invoke mountFn for missing volumes without bypassing handoff errors
- add unit coverage and an e2e scenario for cross-volume clone into a claim-mounted target volume

Refs sandbox0-ai/managed-agents#73

## Testing
- make proto
- go test ./ctld/internal/ctld/portal
- go test ./storage-proxy/pkg/http
- go test ./tests/e2e/utils
- go test ./ctld/...
- go test ./storage-proxy/...
- go test ./tests/e2e/... -run '^$'\n- go test ./... -run '^$'\n- pre-push hook: make manifests, make proto, make apispec, go fmt ./..., go mod tidy, go mod vendor, golangci-lint run ./...