### PR TITLE
Add sandbox claim phase metrics

### DIFF
--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -201,14 +201,19 @@ type ClaimResponse struct {
 func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*ClaimResponse, error) {
 	start := time.Now()
 	metrics := s.metrics
+	phaseStarted := time.Now()
 	canonicalTemplateID, err := naming.CanonicalTemplateID(req.Template)
+	s.observeClaimPhase(req.Template, "unknown", "canonicalize_template", phaseStarted, err)
 	if err != nil {
 		return nil, err
 	}
 	req.Template = canonicalTemplateID
+	phaseStarted = time.Now()
 	if err := validateClaimMounts(req); err != nil {
+		s.observeClaimPhase(req.Template, "unknown", "validate_claim_mounts", phaseStarted, err)
 		return nil, err
 	}
+	s.observeClaimPhase(req.Template, "unknown", "validate_claim_mounts", phaseStarted, nil)
 	s.logger.Info("Claiming sandbox",
 		zap.String("template", req.Template),
 		zap.String("teamID", req.TeamID),
@@ -216,6 +221,7 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 
 	// Resolve tenant template name:
 	// prefer team-scoped template, fall back to public, and always enforce ownership checks.
+	phaseStarted = time.Now()
 	resolvedName := req.Template
 	var template *v1alpha1.SandboxTemplate
 
@@ -223,6 +229,7 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 		privateName := naming.TemplateNameForCluster(naming.ScopeTeam, req.TeamID, req.Template)
 		privateNamespace, nsErr := naming.TemplateNamespaceForTeam(req.TeamID)
 		if nsErr != nil {
+			s.observeClaimPhase(req.Template, "unknown", "resolve_template", phaseStarted, nsErr)
 			return nil, fmt.Errorf("resolve template namespace for %s: %w", privateName, nsErr)
 		}
 		t, getErr := s.templateLister.Get(privateNamespace, privateName)
@@ -235,10 +242,12 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 	if template == nil {
 		publicNamespace, nsErr := naming.TemplateNamespaceForBuiltin(req.Template)
 		if nsErr != nil {
+			s.observeClaimPhase(req.Template, "unknown", "resolve_template", phaseStarted, nsErr)
 			return nil, fmt.Errorf("resolve template namespace for %s: %w", req.Template, nsErr)
 		}
 		template, err = s.templateLister.Get(publicNamespace, req.Template)
 		if err != nil {
+			s.observeClaimPhase(req.Template, "unknown", "resolve_template", phaseStarted, err)
 			if k8serrors.IsNotFound(err) {
 				return nil, fmt.Errorf("template %s not found in namespace %s", req.Template, publicNamespace)
 			}
@@ -253,18 +262,33 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 			teamID = template.Annotations["sandbox0.ai/template-team-id"]
 		}
 		if teamID != "" && teamID != req.TeamID {
-			return nil, fmt.Errorf("forbidden: template belongs to a different team")
+			err := fmt.Errorf("forbidden: template belongs to a different team")
+			s.observeClaimPhase(req.Template, "unknown", "resolve_template", phaseStarted, err)
+			return nil, err
 		}
 	}
+	s.observeClaimPhase(req.Template, "unknown", "resolve_template", phaseStarted, nil)
 
+	phaseStarted = time.Now()
 	if err := validateClaimMountsForTemplate(req, template); err != nil {
+		s.observeClaimPhase(req.Template, "unknown", "validate_template_mounts", phaseStarted, err)
 		return nil, err
 	}
+	s.observeClaimPhase(req.Template, "unknown", "validate_template_mounts", phaseStarted, nil)
 
 	_ = resolvedName // reserved for audit/debugging (name used is template.ObjectMeta.Name)
 
 	// Try to claim an idle pod first
+	phaseStarted = time.Now()
 	pod, err := s.claimIdlePod(ctx, template, req)
+	claimIdleType := "hot"
+	if pod == nil {
+		claimIdleType = "cold"
+	}
+	if err != nil {
+		claimIdleType = "unknown"
+	}
+	s.observeClaimPhase(req.Template, claimIdleType, "claim_idle_pod", phaseStarted, err)
 	if err != nil {
 		if metrics != nil {
 			metrics.SandboxClaimsTotal.WithLabelValues(req.Template, "error").Inc()
@@ -301,7 +325,9 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 			}()
 		}
 
+		phaseStarted = time.Now()
 		pod, err = s.createNewPod(ctx, template, req)
+		s.observeClaimPhase(req.Template, claimType, "create_new_pod", phaseStarted, err)
 		if err != nil {
 			if metrics != nil {
 				metrics.SandboxClaimsTotal.WithLabelValues(req.Template, "error").Inc()
@@ -315,7 +341,9 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 	// already selected a Kubernetes-ready idle pod; cold claims use the faster
 	// claim-ready path below and let Kubernetes PodReady catch up asynchronously.
 	if claimType == "cold" {
+		phaseStarted = time.Now()
 		readyPod, err := s.waitForPodClaimReady(ctx, pod.Namespace, pod.Name)
+		s.observeClaimPhase(req.Template, claimType, "wait_for_pod_claim_ready", phaseStarted, err)
 		if err != nil {
 			s.requestSandboxDeletionAfterClaimFailure(pod, "claim readiness failed")
 			if metrics != nil {
@@ -327,7 +355,9 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 		s.refreshSandboxProbeConditionsAsync(pod)
 	}
 
+	phaseStarted = time.Now()
 	portalMounts, err := s.bindVolumePortals(ctx, pod, req, template)
+	s.observeClaimPhase(req.Template, claimType, "bind_volume_portals", phaseStarted, err)
 	if err != nil {
 		s.requestSandboxDeletionAfterClaimFailure(pod, "volume portal bind failed")
 		if metrics != nil {
@@ -335,15 +365,20 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 		}
 		return nil, fmt.Errorf("bind volume portals: %w", err)
 	}
+	phaseStarted = time.Now()
 	if err := s.bindWebhookStatePortal(ctx, pod, req); err != nil {
+		s.observeClaimPhase(req.Template, claimType, "bind_webhook_state_portal", phaseStarted, err)
 		s.requestSandboxDeletionAfterClaimFailure(pod, "webhook state portal bind failed")
 		if metrics != nil {
 			metrics.SandboxClaimsTotal.WithLabelValues(req.Template, "error").Inc()
 		}
 		return nil, fmt.Errorf("bind webhook state portal: %w", err)
 	}
+	s.observeClaimPhase(req.Template, claimType, "bind_webhook_state_portal", phaseStarted, nil)
 
+	phaseStarted = time.Now()
 	procdAddress, err := s.prodAddress(ctx, pod)
+	s.observeClaimPhase(req.Template, claimType, "resolve_procd_address", phaseStarted, err)
 	if err != nil {
 		s.requestSandboxDeletionAfterClaimFailure(pod, "procd address resolution failed")
 		if metrics != nil {
@@ -351,13 +386,16 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 		}
 		return nil, fmt.Errorf("get procd address: %w", err)
 	}
+	phaseStarted = time.Now()
 	if _, err := s.initializeProcd(ctx, pod, req, procdAddress); err != nil {
+		s.observeClaimPhase(req.Template, claimType, "initialize_procd", phaseStarted, err)
 		s.requestSandboxDeletionAfterClaimFailure(pod, "procd initialization failed")
 		if metrics != nil {
 			metrics.SandboxClaimsTotal.WithLabelValues(req.Template, "error").Inc()
 		}
 		return nil, fmt.Errorf("initialize procd: %w", err)
 	}
+	s.observeClaimPhase(req.Template, claimType, "initialize_procd", phaseStarted, nil)
 
 	if metrics != nil {
 		metrics.SandboxClaimsTotal.WithLabelValues(req.Template, "success").Inc()
@@ -373,6 +411,20 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 		ClusterId:       template.Spec.ClusterId,
 		BootstrapMounts: portalMounts,
 	}, nil
+}
+
+func (s *SandboxService) observeClaimPhase(template, claimType, phase string, started time.Time, err error) {
+	if s == nil || s.metrics == nil || s.metrics.SandboxClaimPhaseDuration == nil {
+		return
+	}
+	if claimType == "" {
+		claimType = "unknown"
+	}
+	status := "success"
+	if err != nil {
+		status = "error"
+	}
+	s.metrics.SandboxClaimPhaseDuration.WithLabelValues(template, claimType, phase, status).Observe(time.Since(started).Seconds())
 }
 
 func validateClaimMountsForTemplate(req *ClaimRequest, template *v1alpha1.SandboxTemplate) error {

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -14,6 +14,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/network"
@@ -21,6 +23,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/dataplane"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
+	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
 	"github.com/sandbox0-ai/sandbox0/pkg/sandboxprobe"
 	"github.com/sandbox0-ai/sandbox0/pkg/volumeportal"
 	"go.uber.org/zap"
@@ -461,6 +464,33 @@ func TestClaimSandboxCleansColdPodWhenClaimReadinessFails(t *testing.T) {
 	}
 	if len(pods.Items) != 0 {
 		t.Fatalf("pods after failed cold claim = %d, want 0", len(pods.Items))
+	}
+}
+
+func TestObserveClaimPhaseRecordsMetric(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	svc := &SandboxService{metrics: obsmetrics.NewManager(registry)}
+
+	svc.observeClaimPhase("managed-agents", "cold", "wait_for_pod_claim_ready", time.Now().Add(-20*time.Millisecond), nil)
+
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("gather metrics: %v", err)
+	}
+	metric := findMetric(families, "manager_sandbox_claim_phase_duration_seconds", map[string]string{
+		"template": "managed-agents",
+		"type":     "cold",
+		"phase":    "wait_for_pod_claim_ready",
+		"status":   "success",
+	})
+	if metric == nil || metric.GetHistogram() == nil {
+		t.Fatal("claim phase histogram metric not found")
+	}
+	if got := metric.GetHistogram().GetSampleCount(); got != 1 {
+		t.Fatalf("claim phase sample count = %d, want 1", got)
+	}
+	if got := metric.GetHistogram().GetSampleSum(); got <= 0 {
+		t.Fatalf("claim phase sample sum = %f, want > 0", got)
 	}
 }
 
@@ -1054,4 +1084,37 @@ func splitTestServerAddress(t *testing.T, server *httptest.Server) (string, int)
 		t.Fatalf("parse server port: %v", err)
 	}
 	return host, port
+}
+
+func findMetric(families []*dto.MetricFamily, name string, labels map[string]string) *dto.Metric {
+	for _, family := range families {
+		if family.GetName() != name {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			if metricLabelsMatch(metric, labels) {
+				return metric
+			}
+		}
+	}
+	return nil
+}
+
+func metricLabelsMatch(metric *dto.Metric, labels map[string]string) bool {
+	if metric == nil {
+		return false
+	}
+	for wantName, wantValue := range labels {
+		found := false
+		for _, label := range metric.GetLabel() {
+			if label.GetName() == wantName && label.GetValue() == wantValue {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/observability/metrics/manager.go
+++ b/pkg/observability/metrics/manager.go
@@ -7,17 +7,18 @@ import (
 
 // ManagerMetrics holds Prometheus metrics for the manager service.
 type ManagerMetrics struct {
-	TemplatesTotal       prometheus.Gauge
-	IdlePodsTotal        *prometheus.GaugeVec
-	ActivePodsTotal      *prometheus.GaugeVec
-	SandboxClaimsTotal   *prometheus.CounterVec
-	SandboxClaimDuration *prometheus.HistogramVec
-	PodsCleanedTotal     *prometheus.CounterVec
-	ReconcileTotal       *prometheus.CounterVec
-	ReconcileDuration    *prometheus.HistogramVec
-	MeteringEventsTotal  *prometheus.CounterVec
-	MeteringWindowsTotal *prometheus.CounterVec
-	MeteringErrorsTotal  *prometheus.CounterVec
+	TemplatesTotal            prometheus.Gauge
+	IdlePodsTotal             *prometheus.GaugeVec
+	ActivePodsTotal           *prometheus.GaugeVec
+	SandboxClaimsTotal        *prometheus.CounterVec
+	SandboxClaimDuration      *prometheus.HistogramVec
+	SandboxClaimPhaseDuration *prometheus.HistogramVec
+	PodsCleanedTotal          *prometheus.CounterVec
+	ReconcileTotal            *prometheus.CounterVec
+	ReconcileDuration         *prometheus.HistogramVec
+	MeteringEventsTotal       *prometheus.CounterVec
+	MeteringWindowsTotal      *prometheus.CounterVec
+	MeteringErrorsTotal       *prometheus.CounterVec
 }
 
 // NewManager registers and returns manager metrics.
@@ -51,6 +52,11 @@ func NewManager(registry prometheus.Registerer) *ManagerMetrics {
 			Help:    "Duration of sandbox claim operations",
 			Buckets: prometheus.DefBuckets,
 		}, []string{"template", "type"}), // type: "hot" (from pool) or "cold" (new pod)
+		SandboxClaimPhaseDuration: factory.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "manager_sandbox_claim_phase_duration_seconds",
+			Help:    "Duration of sandbox claim phases",
+			Buckets: []float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 30, 60, 120},
+		}, []string{"template", "type", "phase", "status"}), // type: "hot", "cold", or "unknown"
 		PodsCleanedTotal: factory.NewCounterVec(prometheus.CounterOpts{
 			Name: "manager_pods_cleaned_total",
 			Help: "Total number of pods cleaned up",


### PR DESCRIPTION
## Summary
- add a manager_sandbox_claim_phase_duration_seconds histogram for ClaimSandbox sub-phases
- record hot/cold claim stages including idle claim, cold pod creation, claim readiness, volume portal bind, webhook bind, procd address resolution, and procd initialization
- add a unit test for the new phase histogram

## Testing
- go test ./manager/pkg/service ./pkg/observability/metrics
- pre-push hook: make manifests, make proto, make apispec, go fmt ./..., go mod tidy, go mod vendor, golangci-lint run ./...