### PR TITLE
Optimize ctld address resolution for sandbox claim

### DIFF
--- a/manager/pkg/service/power_executor.go
+++ b/manager/pkg/service/power_executor.go
@@ -54,19 +54,37 @@ func (s *SandboxService) ctldAddressForPod(ctx context.Context, pod *corev1.Pod)
 	if pod == nil {
 		return "", fmt.Errorf("pod is nil")
 	}
-	if s.k8sClient == nil {
-		return "", fmt.Errorf("kubernetes client is not configured")
+	if pod.Status.HostIP != "" {
+		return fmt.Sprintf("http://%s:%d", pod.Status.HostIP, s.config.CtldPort), nil
 	}
 	if pod.Spec.NodeName == "" {
 		return "", fmt.Errorf("sandbox pod %s/%s is not scheduled", pod.Namespace, pod.Name)
+	}
+
+	if s.nodeLister != nil {
+		node, err := s.nodeLister.Get(pod.Spec.NodeName)
+		if err == nil {
+			return ctldAddressForNode(node, s.config.CtldPort)
+		}
+	}
+
+	if s.k8sClient == nil {
+		return "", fmt.Errorf("kubernetes client is not configured")
 	}
 	node, err := s.k8sClient.CoreV1().Nodes().Get(ctx, pod.Spec.NodeName, metav1.GetOptions{})
 	if err != nil {
 		return "", fmt.Errorf("get node %s: %w", pod.Spec.NodeName, err)
 	}
+	return ctldAddressForNode(node, s.config.CtldPort)
+}
+
+func ctldAddressForNode(node *corev1.Node, port int) (string, error) {
+	if node == nil {
+		return "", fmt.Errorf("node is nil")
+	}
 	for _, address := range node.Status.Addresses {
 		if address.Type == corev1.NodeInternalIP && address.Address != "" {
-			return fmt.Sprintf("http://%s:%d", address.Address, s.config.CtldPort), nil
+			return fmt.Sprintf("http://%s:%d", address.Address, port), nil
 		}
 	}
 	return "", fmt.Errorf("node %s has no internal ip", node.Name)

--- a/manager/pkg/service/power_executor_ctld_test.go
+++ b/manager/pkg/service/power_executor_ctld_test.go
@@ -25,6 +25,38 @@ func TestNewSandboxServiceUsesCtldExecutorWhenEnabled(t *testing.T) {
 	assert.Equal(t, 15*time.Second, svc.ctldClient.httpClient.Timeout)
 }
 
+func TestCtldAddressForPodUsesHostIPWithoutK8sClient(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "sandbox-1", Namespace: "default"},
+		Status:     corev1.PodStatus{HostIP: "10.24.15.221"},
+	}
+	svc := &SandboxService{
+		config: SandboxServiceConfig{CtldPort: 8095},
+	}
+
+	address, err := svc.ctldAddressForPod(context.Background(), pod)
+	require.NoError(t, err)
+	assert.Equal(t, "http://10.24.15.221:8095", address)
+}
+
+func TestCtldAddressForPodUsesNodeCacheBeforeLiveGet(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "sandbox-1", Namespace: "default"},
+		Spec:       corev1.PodSpec{NodeName: "node-a"},
+	}
+	k8sClient := fake.NewSimpleClientset()
+	svc := &SandboxService{
+		k8sClient:  k8sClient,
+		nodeLister: newClaimTestNodeLister(t, newClaimTestNode("node-a", "10.0.0.1")),
+		config:     SandboxServiceConfig{CtldPort: 8095},
+	}
+
+	address, err := svc.ctldAddressForPod(context.Background(), pod)
+	require.NoError(t, err)
+	assert.Equal(t, "http://10.0.0.1:8095", address)
+	assert.Empty(t, k8sClient.Actions())
+}
+
 func TestCtldPowerExecutorRequestsPauseAsDesiredState(t *testing.T) {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Summary
- Resolve ctld addresses from Pod HostIP before looking up Nodes.
- Use the manager Node informer cache before falling back to a live Node GET.
- Keep write/resourceVersion-sensitive manager and ctld paths on live Kubernetes reads; ctld pod resolution was already cache-first.

Closes #289

## Testing
- go test ./manager/pkg/service ./ctld/internal/ctld/power
- pre-push hook: make manifests, make proto, make apispec, go fmt ./..., go mod tidy, go mod vendor, golangci-lint run ./...