### PR TITLE
Document local MCP support for Managed Agents

### DIFF
--- a/docs/managed-agents/agents/page.mdx
+++ b/docs/managed-agents/agents/page.mdx
@@ -12,7 +12,7 @@ Official reference: [Claude Managed Agents agent setup](https://platform.claude.
 | `model` | Model id and optional speed |
 | `system` | Stable instruction text |
 | `tools` | Built-in, MCP, and custom tool definitions |
-| `mcp_servers` | URL MCP servers available through `mcp_toolset` |
+| `mcp_servers` | URL or local stdio MCP servers available through `mcp_toolset` |
 | `skills` | Uploaded skill versions attached to the agent |
 | `metadata` | Application metadata |
 
@@ -48,12 +48,14 @@ const agent = await client.beta.agents.create({
 | Tool type | Status in Sandbox0 |
 |-----------|--------------------|
 | `agent_toolset_20260401` | Supported through the selected agent engine |
-| `mcp_toolset` | Supported for URL MCP servers |
+| `mcp_toolset` | Supported for URL and local stdio MCP servers |
 | `custom` | Supported through `agent.custom_tool_use` and `user.custom_tool_result` events |
 
 Built-in tool names include `bash`, `edit`, `read`, `write`, `glob`, `grep`, `web_fetch`, and `web_search`.
 
 ## MCP Servers
+
+URL MCP servers connect to a remote HTTP or SSE endpoint:
 
 ```typescript
 const agent = await client.beta.agents.create({
@@ -71,7 +73,33 @@ const agent = await client.beta.agents.create({
 });
 ```
 
-If the MCP server needs credentials, attach a vault to the session. The agent declares the server and toolset; the session decides which vaults are available.
+Local stdio MCP servers run inside the managed agent sandbox through the selected engine wrapper:
+
+```typescript
+const agent = await client.beta.agents.create({
+    name: "Local Docs Agent",
+    model: "claude-sonnet-4-20250514",
+    mcp_servers: [{
+        type: "stdio",
+        name: "local_docs",
+        command: "node",
+        args: ["./mcp-server.js", "--stdio"],
+        env: {
+            API_BASE_URL: "https://api.example.com",
+        },
+    }],
+    tools: [{
+        type: "mcp_toolset",
+        mcp_server_name: "local_docs",
+        default_config: {
+            enabled: true,
+            permission_policy: { type: "always_ask" },
+        },
+    }],
+});
+```
+
+Keep `env` values non-secret. If the MCP server needs credentials for outbound HTTP calls, attach a credential vault to the session and let Sandbox0 inject auth through egress policy. The agent declares the server and toolset; the session decides which vaults are available.
 
 ## Sandbox0 Notes
 

--- a/docs/managed-agents/compatibility/page.mdx
+++ b/docs/managed-agents/compatibility/page.mdx
@@ -17,7 +17,7 @@ Official reference: [Claude Managed Agents quickstart](https://platform.claude.c
 | Files | Supported for upload, metadata, download, delete, and file-backed message content |
 | Vaults and credentials | Supported for LLM credentials, MCP credentials, and Sandbox0 HTTP header credential projection |
 | Custom skills | Supported through uploaded skill versions |
-| MCP servers | Supported for URL MCP servers and vault-backed credentials |
+| MCP servers | Supported for URL MCP servers, local stdio MCP servers, and vault-backed credentials |
 | GitHub repository resources | Supported at session creation |
 | Agent engines | Supported for `claude` and `codex` |
 
@@ -48,6 +48,17 @@ The Claude wrapper maps Managed Agents tool definitions to Claude Agent SDK opti
 | Custom tools | Supported | The wrapper emits `agent.custom_tool_use` and waits for `user.custom_tool_result` |
 
 Tool confirmation events are supported. When a tool policy requires confirmation, the session emits `session.status_idle` with `stop_reason.type = "requires_action"` and the relevant event ids.
+
+## MCP Server Support
+
+Sandbox0 supports two `mcp_servers` connection types:
+
+| Type | Behavior |
+|------|----------|
+| `url` | Remote MCP server reached over HTTP or SSE |
+| `stdio` | Local MCP server process launched inside the managed agent sandbox |
+
+For `stdio` servers, put only non-secret values in `env`. Use a Managed Agents credential vault plus Sandbox0 egress auth when the local MCP server needs authenticated outbound HTTP access.
 
 ## Environment Support
 

--- a/docs/managed-agents/vaults/page.mdx
+++ b/docs/managed-agents/vaults/page.mdx
@@ -67,7 +67,7 @@ Credential vaults can use `static_bearer` or `mcp_oauth` credentials. Sandbox0 r
 
 ## MCP Credentials
 
-For MCP servers, the credential auth includes `mcp_server_url`.
+For remote URL MCP servers, the credential auth includes `mcp_server_url`.
 
 ```typescript
 await client.beta.vaults.credentials.create(vault.id, {
@@ -79,6 +79,8 @@ await client.beta.vaults.credentials.create(vault.id, {
     },
 });
 ```
+
+For local stdio MCP servers, prefer generic credential vaults with HTTP header projection. The local MCP process can use non-secret placeholder environment variables; Sandbox0 injects the real auth material when the process calls the configured external service domains.
 
 ## Runtime Injection
 


### PR DESCRIPTION
## Summary
- document `stdio` MCP server definitions for Managed Agents
- clarify compatibility status for URL and local stdio MCP servers
- explain credential guidance for local stdio MCP outbound HTTP access

## Testing
- `git diff --check`
- pre-push hook: `make manifests`, `make proto`, `make apispec`, `go fmt ./...`, `go mod tidy`, `go mod vendor`, `golangci-lint run ./...`