### PR TITLE
Add sandbox public gateway policy

### DIFF
--- a/cluster-gateway/pkg/http/handlers_exposure.go
+++ b/cluster-gateway/pkg/http/handlers_exposure.go
@@ -40,7 +40,7 @@ func (s *Server) handlePublicExposureNoRoute(c *gin.Context) {
 		return
 	}
 
-	sandbox, err := s.managerClient.GetSandboxInternal(c.Request.Context(), sandboxID)
+	sandbox, err := s.getSandboxForPublicExposure(c, sandboxID)
 	if err != nil {
 		s.logger.Warn("Failed to get sandbox for public exposure",
 			zap.String("sandbox_id", sandboxID),
@@ -54,19 +54,47 @@ func (s *Server) handlePublicExposureNoRoute(c *gin.Context) {
 		}
 		return
 	}
-	policy, ok := findExposedPortPolicy(sandbox, port)
-	if !ok {
-		spec.JSONError(c, http.StatusForbidden, spec.CodeForbidden, "port is not exposed")
-		return
+	var route *mgr.PublicGatewayRoute
+	var policy mgr.ExposedPortConfig
+	if sandbox.PublicGateway != nil && sandbox.PublicGateway.Enabled {
+		match := matchPublicGatewayRoute(sandbox.PublicGateway, port, c.Request.URL.Path, c.Request.Method)
+		if !match.pathMatched {
+			spec.JSONError(c, http.StatusNotFound, spec.CodeNotFound, "route is not exposed")
+			return
+		}
+		route = match.route
+		if c.Request.Method == http.MethodOptions && route.CORS != nil {
+			if !s.enforcePublicGatewayRoute(c, sandboxID, route) {
+				return
+			}
+		}
+		if !match.methodAllowed {
+			spec.JSONError(c, http.StatusMethodNotAllowed, spec.CodeForbidden, "method is not allowed")
+			return
+		}
+		if !s.enforcePublicGatewayRoute(c, sandboxID, route) {
+			return
+		}
+	} else {
+		var ok bool
+		policy, ok = findExposedPortPolicy(sandbox, port)
+		if !ok {
+			spec.JSONError(c, http.StatusForbidden, spec.CodeForbidden, "port is not exposed")
+			return
+		}
 	}
 	if sandboxWantsPaused(sandbox) {
 		// Resume precedence:
-		// sandbox.auto_resume must be true, then per-port exposed_ports[].resume must be true.
+		// sandbox.auto_resume must be true, then the matching public route or exposed port resume gate must be true.
 		if !sandbox.AutoResume {
 			spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox is paused and auto_resume is disabled")
 			return
 		}
-		if !policy.Resume {
+		resumeAllowed := policy.Resume
+		if route != nil {
+			resumeAllowed = route.Resume
+		}
+		if !resumeAllowed {
 			spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox is paused and resume is disabled")
 			return
 		}
@@ -89,10 +117,13 @@ func (s *Server) handlePublicExposureNoRoute(c *gin.Context) {
 		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "invalid sandbox address")
 		return
 	}
-	c.Request = proxy.WithUpstreamTimeoutDisabledRequest(c.Request)
 	proxyTimeout := s.cfg.ProxyTimeout.Duration
 	if proxyTimeout == 0 {
 		proxyTimeout = 10 * time.Second
+	}
+	proxyTimeout = publicGatewayProxyTimeout(proxyTimeout, route)
+	if !publicGatewayHasTimeout(route) {
+		c.Request = proxy.WithUpstreamTimeoutDisabledRequest(c.Request)
 	}
 	router, err := proxy.NewRouter(targetURL.String(), s.logger, proxyTimeout, proxy.WithHTTPClient(s.outboundHTTPClient()))
 	if err != nil {

--- a/cluster-gateway/pkg/http/handlers_public_gateway.go
+++ b/cluster-gateway/pkg/http/handlers_public_gateway.go
@@ -1,0 +1,37 @@
+package http
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
+	"go.uber.org/zap"
+)
+
+func (s *Server) getPublicGateway(c *gin.Context) {
+	sandboxID := c.Param("id")
+	if sandboxID == "" {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "sandbox_id is required")
+		return
+	}
+
+	s.logger.Debug("Getting public gateway",
+		zap.String("sandboxID", sandboxID),
+	)
+	c.Request.URL.Path = "/api/v1/sandboxes/" + sandboxID + "/public-gateway"
+	s.proxyToManager(c)
+}
+
+func (s *Server) updatePublicGateway(c *gin.Context) {
+	sandboxID := c.Param("id")
+	if sandboxID == "" {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "sandbox_id is required")
+		return
+	}
+
+	s.logger.Debug("Updating public gateway",
+		zap.String("sandboxID", sandboxID),
+	)
+	c.Request.URL.Path = "/api/v1/sandboxes/" + sandboxID + "/public-gateway"
+	s.proxyToManager(c)
+}

--- a/cluster-gateway/pkg/http/public_gateway_policy.go
+++ b/cluster-gateway/pkg/http/public_gateway_policy.go
@@ -1,0 +1,286 @@
+package http
+
+import (
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"fmt"
+	nethttp "net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	mgr "github.com/sandbox0-ai/sandbox0/manager/pkg/service"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
+	"golang.org/x/time/rate"
+)
+
+type publicGatewayMatch struct {
+	route         *mgr.PublicGatewayRoute
+	pathMatched   bool
+	methodAllowed bool
+}
+
+func (s *Server) getSandboxForPublicExposure(c *gin.Context, sandboxID string) (*mgr.Sandbox, error) {
+	if s.exposureSandboxCache != nil {
+		if sandbox, ok := s.exposureSandboxCache.Get(sandboxID); ok {
+			return sandbox, nil
+		}
+	}
+	sandbox, err := s.managerClient.GetSandboxInternal(c.Request.Context(), sandboxID)
+	if err != nil {
+		return nil, err
+	}
+	if s.exposureSandboxCache != nil {
+		s.exposureSandboxCache.Set(sandboxID, sandbox)
+	}
+	return sandbox, nil
+}
+
+func matchPublicGatewayRoute(cfg *mgr.PublicGatewayConfig, port int, path string, method string) publicGatewayMatch {
+	if cfg == nil || !cfg.Enabled {
+		return publicGatewayMatch{}
+	}
+	requestMethod := strings.ToUpper(strings.TrimSpace(method))
+	var best *mgr.PublicGatewayRoute
+	bestLen := -1
+	for i := range cfg.Routes {
+		route := &cfg.Routes[i]
+		if route.Port != port {
+			continue
+		}
+		prefix := route.PathPrefix
+		if prefix == "" {
+			prefix = "/"
+		}
+		if !pathMatchesPrefix(path, prefix) {
+			continue
+		}
+		if len(prefix) > bestLen {
+			best = route
+			bestLen = len(prefix)
+		}
+	}
+	if best == nil {
+		return publicGatewayMatch{}
+	}
+	return publicGatewayMatch{
+		route:         best,
+		pathMatched:   true,
+		methodAllowed: publicGatewayMethodAllowed(best, requestMethod),
+	}
+}
+
+func pathMatchesPrefix(path, prefix string) bool {
+	if prefix == "" || prefix == "/" {
+		return true
+	}
+	if path == prefix {
+		return true
+	}
+	return strings.HasPrefix(path, strings.TrimRight(prefix, "/")+"/")
+}
+
+func publicGatewayMethodAllowed(route *mgr.PublicGatewayRoute, method string) bool {
+	if route == nil || len(route.Methods) == 0 {
+		return true
+	}
+	for _, allowed := range route.Methods {
+		if allowed == "*" || strings.EqualFold(allowed, method) {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *Server) enforcePublicGatewayRoute(c *gin.Context, sandboxID string, route *mgr.PublicGatewayRoute) bool {
+	if route == nil {
+		return true
+	}
+	if handled := s.handlePublicGatewayCORS(c, route); handled {
+		return false
+	}
+	if !s.authorizePublicGatewayRoute(c, route) {
+		return false
+	}
+	if !s.allowPublicGatewayRate(c, sandboxID, route) {
+		spec.JSONError(c, nethttp.StatusTooManyRequests, spec.CodeUnavailable, "rate limit exceeded")
+		return false
+	}
+	if route.RewritePrefix != nil {
+		rewritePublicGatewayPath(c, route.PathPrefix, *route.RewritePrefix)
+	}
+	return true
+}
+
+func (s *Server) handlePublicGatewayCORS(c *gin.Context, route *mgr.PublicGatewayRoute) bool {
+	cors := route.CORS
+	if cors == nil {
+		return false
+	}
+	origin := c.GetHeader("Origin")
+	if origin == "" {
+		return false
+	}
+	if !originAllowed(origin, cors.AllowedOrigins) {
+		if c.Request.Method == nethttp.MethodOptions {
+			spec.JSONError(c, nethttp.StatusForbidden, spec.CodeForbidden, "origin is not allowed")
+			return true
+		}
+		return false
+	}
+	c.Header("Access-Control-Allow-Origin", allowedOriginHeader(origin, cors.AllowedOrigins))
+	c.Header("Vary", "Origin")
+	if cors.AllowCredentials {
+		c.Header("Access-Control-Allow-Credentials", "true")
+	}
+	if len(cors.ExposeHeaders) > 0 {
+		c.Header("Access-Control-Expose-Headers", strings.Join(cors.ExposeHeaders, ", "))
+	}
+	if c.Request.Method != nethttp.MethodOptions {
+		return false
+	}
+	requestMethod := strings.ToUpper(strings.TrimSpace(c.GetHeader("Access-Control-Request-Method")))
+	if requestMethod != "" && !publicGatewayCORSMethodAllowed(route, requestMethod) {
+		spec.JSONError(c, nethttp.StatusMethodNotAllowed, spec.CodeForbidden, "method is not allowed")
+		return true
+	}
+	allowedMethods := cors.AllowedMethods
+	if len(allowedMethods) == 0 {
+		allowedMethods = route.Methods
+	}
+	if len(allowedMethods) > 0 {
+		c.Header("Access-Control-Allow-Methods", strings.Join(allowedMethods, ", "))
+	}
+	if len(cors.AllowedHeaders) > 0 {
+		c.Header("Access-Control-Allow-Headers", strings.Join(cors.AllowedHeaders, ", "))
+	}
+	if cors.MaxAgeSeconds > 0 {
+		c.Header("Access-Control-Max-Age", strconv.Itoa(cors.MaxAgeSeconds))
+	}
+	c.Status(nethttp.StatusNoContent)
+	return true
+}
+
+func publicGatewayCORSMethodAllowed(route *mgr.PublicGatewayRoute, method string) bool {
+	if route == nil || route.CORS == nil || len(route.CORS.AllowedMethods) == 0 {
+		return publicGatewayMethodAllowed(route, method)
+	}
+	for _, allowed := range route.CORS.AllowedMethods {
+		if allowed == "*" || strings.EqualFold(allowed, method) {
+			return true
+		}
+	}
+	return false
+}
+
+func originAllowed(origin string, allowed []string) bool {
+	for _, candidate := range allowed {
+		if candidate == "*" || strings.EqualFold(candidate, origin) {
+			return true
+		}
+	}
+	return false
+}
+
+func allowedOriginHeader(origin string, allowed []string) string {
+	for _, candidate := range allowed {
+		if candidate == "*" {
+			return "*"
+		}
+		if strings.EqualFold(candidate, origin) {
+			return origin
+		}
+	}
+	return ""
+}
+
+func (s *Server) authorizePublicGatewayRoute(c *gin.Context, route *mgr.PublicGatewayRoute) bool {
+	if route.Auth == nil || route.Auth.Mode == "" || route.Auth.Mode == mgr.PublicGatewayAuthModeNone {
+		return true
+	}
+	switch route.Auth.Mode {
+	case mgr.PublicGatewayAuthModeBearer:
+		token := strings.TrimSpace(c.GetHeader("Authorization"))
+		const prefix = "Bearer "
+		if !strings.HasPrefix(token, prefix) {
+			spec.JSONError(c, nethttp.StatusUnauthorized, spec.CodeUnauthorized, "missing bearer token")
+			return false
+		}
+		if !sha256HexMatches(strings.TrimSpace(strings.TrimPrefix(token, prefix)), route.Auth.BearerTokenSHA256) {
+			spec.JSONError(c, nethttp.StatusUnauthorized, spec.CodeUnauthorized, "invalid bearer token")
+			return false
+		}
+	case mgr.PublicGatewayAuthModeHeader:
+		if !sha256HexMatches(c.GetHeader(route.Auth.HeaderName), route.Auth.HeaderValueSHA256) {
+			spec.JSONError(c, nethttp.StatusUnauthorized, spec.CodeUnauthorized, "invalid header credential")
+			return false
+		}
+	default:
+		spec.JSONError(c, nethttp.StatusForbidden, spec.CodeForbidden, "unsupported route auth")
+		return false
+	}
+	return true
+}
+
+func sha256HexMatches(value, expectedHex string) bool {
+	expected, err := hex.DecodeString(strings.TrimSpace(expectedHex))
+	if err != nil || len(expected) != sha256.Size {
+		return false
+	}
+	sum := sha256.Sum256([]byte(value))
+	return subtle.ConstantTimeCompare(sum[:], expected) == 1
+}
+
+func (s *Server) allowPublicGatewayRate(c *gin.Context, sandboxID string, route *mgr.PublicGatewayRoute) bool {
+	if route.RateLimit == nil {
+		return true
+	}
+	key := fmt.Sprintf("%s:%s:%d:%d", sandboxID, route.ID, route.RateLimit.RPS, route.RateLimit.Burst)
+	limiter := rate.NewLimiter(rate.Limit(route.RateLimit.RPS), route.RateLimit.Burst)
+	actual, _ := s.publicGatewayLimiters.LoadOrStore(key, limiter)
+	if !actual.(*rate.Limiter).Allow() {
+		c.Header("Retry-After", "1")
+		return false
+	}
+	return true
+}
+
+func publicGatewayProxyTimeout(defaultTimeout time.Duration, route *mgr.PublicGatewayRoute) time.Duration {
+	if route != nil && route.TimeoutSeconds > 0 {
+		return time.Duration(route.TimeoutSeconds) * time.Second
+	}
+	return defaultTimeout
+}
+
+func publicGatewayHasTimeout(route *mgr.PublicGatewayRoute) bool {
+	return route != nil && route.TimeoutSeconds > 0
+}
+
+func rewritePublicGatewayPath(c *gin.Context, matchedPrefix, rewritePrefix string) {
+	req := c.Request
+	if req == nil || req.URL == nil {
+		return
+	}
+	prefix := matchedPrefix
+	if prefix == "" {
+		prefix = "/"
+	}
+	suffix := strings.TrimPrefix(req.URL.Path, prefix)
+	if prefix != "/" && req.URL.Path != prefix && suffix == req.URL.Path {
+		return
+	}
+	req.URL.Path = joinGatewayPath(rewritePrefix, suffix)
+	req.URL.RawPath = ""
+}
+
+func joinGatewayPath(prefix, suffix string) string {
+	if prefix == "" {
+		prefix = "/"
+	}
+	if suffix == "" {
+		return prefix
+	}
+	return strings.TrimRight(prefix, "/") + "/" + strings.TrimLeft(suffix, "/")
+}

--- a/cluster-gateway/pkg/http/public_gateway_policy_test.go
+++ b/cluster-gateway/pkg/http/public_gateway_policy_test.go
@@ -1,0 +1,233 @@
+package http
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sandbox0-ai/sandbox0/cluster-gateway/pkg/client"
+	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
+	mgr "github.com/sandbox0-ai/sandbox0/manager/pkg/service"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
+	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestPublicGatewayProxiesAuthorizedRouteWithRewrite(t *testing.T) {
+	upstreamHits := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits++
+		if r.URL.Path != "/v1/users" {
+			t.Fatalf("upstream path = %q, want /v1/users", r.URL.Path)
+		}
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	port := serverPort(t, upstream.URL)
+	tokenHash := sha256Hex("secret-token")
+	rewritePrefix := "/v1"
+	gateway := newPublicGatewayExposureTestServer(t, &mgr.Sandbox{
+		ID:           "sb-demo",
+		TeamID:       "team-1",
+		InternalAddr: "http://127.0.0.1:1",
+		AutoResume:   true,
+		PublicGateway: &mgr.PublicGatewayConfig{
+			Enabled: true,
+			Routes: []mgr.PublicGatewayRoute{{
+				ID:            "api",
+				Port:          port,
+				PathPrefix:    "/api",
+				Methods:       []string{http.MethodGet},
+				RewritePrefix: &rewritePrefix,
+				Auth: &mgr.PublicGatewayAuth{
+					Mode:              mgr.PublicGatewayAuthModeBearer,
+					BearerTokenSHA256: tokenHash,
+				},
+			}},
+		},
+	})
+
+	gatewayServer := httptest.NewServer(gateway)
+	defer gatewayServer.Close()
+	req := newGatewayRequest(t, http.MethodGet, gatewayServer.URL, fmt.Sprintf("sb-demo--p%d.aws-us-east-1.sandbox0.app", port), "/api/users")
+	req.Header.Set("Authorization", "Bearer secret-token")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("gateway request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	if upstreamHits != 1 {
+		t.Fatalf("upstream hits = %d, want 1", upstreamHits)
+	}
+}
+
+func TestPublicGatewayRejectsDisallowedMethod(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("upstream should not be called")
+	}))
+	defer upstream.Close()
+
+	port := serverPort(t, upstream.URL)
+	gateway := newPublicGatewayExposureTestServer(t, &mgr.Sandbox{
+		ID:           "sb-demo",
+		TeamID:       "team-1",
+		InternalAddr: "http://127.0.0.1:1",
+		AutoResume:   true,
+		PublicGateway: &mgr.PublicGatewayConfig{
+			Enabled: true,
+			Routes: []mgr.PublicGatewayRoute{{
+				ID:         "api",
+				Port:       port,
+				PathPrefix: "/api",
+				Methods:    []string{http.MethodGet},
+			}},
+		},
+	})
+
+	gatewayServer := httptest.NewServer(gateway)
+	defer gatewayServer.Close()
+	req := newGatewayRequest(t, http.MethodPost, gatewayServer.URL, fmt.Sprintf("sb-demo--p%d.aws-us-east-1.sandbox0.app", port), "/api/users")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("gateway request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+}
+
+func TestPublicGatewayHandlesCORSPreflight(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("upstream should not be called")
+	}))
+	defer upstream.Close()
+
+	port := serverPort(t, upstream.URL)
+	gateway := newPublicGatewayExposureTestServer(t, &mgr.Sandbox{
+		ID:           "sb-demo",
+		TeamID:       "team-1",
+		InternalAddr: "http://127.0.0.1:1",
+		AutoResume:   true,
+		PublicGateway: &mgr.PublicGatewayConfig{
+			Enabled: true,
+			Routes: []mgr.PublicGatewayRoute{{
+				ID:         "api",
+				Port:       port,
+				PathPrefix: "/api",
+				Methods:    []string{http.MethodGet},
+				CORS: &mgr.PublicGatewayCORS{
+					AllowedOrigins: []string{"https://app.example"},
+					AllowedMethods: []string{http.MethodGet},
+					AllowedHeaders: []string{"Authorization"},
+					MaxAgeSeconds:  60,
+				},
+			}},
+		},
+	})
+
+	gatewayServer := httptest.NewServer(gateway)
+	defer gatewayServer.Close()
+	req := newGatewayRequest(t, http.MethodOptions, gatewayServer.URL, fmt.Sprintf("sb-demo--p%d.aws-us-east-1.sandbox0.app", port), "/api/users")
+	req.Header.Set("Origin", "https://app.example")
+	req.Header.Set("Access-Control-Request-Method", http.MethodGet)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("gateway request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Access-Control-Allow-Origin"); got != "https://app.example" {
+		t.Fatalf("Access-Control-Allow-Origin = %q", got)
+	}
+}
+
+func newPublicGatewayExposureTestServer(t *testing.T, sandbox *mgr.Sandbox) http.Handler {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	manager := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/internal/v1/sandboxes/sb-demo" {
+			spec.WriteError(w, http.StatusNotFound, spec.CodeNotFound, "not found")
+			return
+		}
+		_ = spec.WriteSuccess(w, http.StatusOK, sandbox)
+	}))
+	t.Cleanup(manager.Close)
+
+	_, privateKey, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	gen := internalauth.NewGenerator(internalauth.GeneratorConfig{
+		Caller:     "cluster-gateway",
+		PrivateKey: privateKey,
+		TTL:        time.Minute,
+	})
+
+	s := &Server{
+		cfg: &config.ClusterGatewayConfig{
+			GatewayConfig: config.GatewayConfig{
+				PublicExposureEnabled: true,
+				PublicRootDomain:      "sandbox0.app",
+				PublicRegionID:        "aws-us-east-1",
+			},
+			ProxyTimeout: metav1.Duration{Duration: 10 * time.Second},
+		},
+		logger:        zap.NewNop(),
+		managerClient: client.NewManagerClient(manager.URL, gen, zap.NewNop(), time.Second),
+	}
+	router := gin.New()
+	router.NoRoute(s.handlePublicExposureNoRoute)
+	return router
+}
+
+func serverPort(t *testing.T, rawURL string) int {
+	t.Helper()
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	_, portString, err := net.SplitHostPort(parsed.Host)
+	if err != nil {
+		t.Fatalf("split host port: %v", err)
+	}
+	port, err := strconv.Atoi(portString)
+	if err != nil {
+		t.Fatalf("parse port: %v", err)
+	}
+	return port
+}
+
+func newGatewayRequest(t *testing.T, method, baseURL, host, path string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(method, baseURL+path, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Host = host
+	return req
+}
+
+func sha256Hex(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return fmt.Sprintf("%x", sum[:])
+}

--- a/cluster-gateway/pkg/http/server.go
+++ b/cluster-gateway/pkg/http/server.go
@@ -346,6 +346,8 @@ func (s *Server) setupRoutes() {
 			sandboxes.PUT("/:id/exposed-ports", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxWrite), s.updateExposedPorts)
 			sandboxes.DELETE("/:id/exposed-ports", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxWrite), s.clearExposedPorts)
 			sandboxes.DELETE("/:id/exposed-ports/:port", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxWrite), s.deleteExposedPort)
+			sandboxes.GET("/:id/public-gateway", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxRead), s.getPublicGateway)
+			sandboxes.PUT("/:id/public-gateway", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxWrite), s.updatePublicGateway)
 
 			// === Process/Context Management (→ Procd) ===
 			contexts := sandboxes.Group("/:id/contexts")

--- a/cluster-gateway/pkg/http/server.go
+++ b/cluster-gateway/pkg/http/server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -14,6 +15,8 @@ import (
 	"github.com/sandbox0-ai/sandbox0/cluster-gateway/pkg/client"
 	"github.com/sandbox0-ai/sandbox0/cluster-gateway/pkg/middleware"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
+	mgr "github.com/sandbox0-ai/sandbox0/manager/pkg/service"
+	"github.com/sandbox0-ai/sandbox0/pkg/cache"
 	gatewayapikey "github.com/sandbox0-ai/sandbox0/pkg/gateway/apikey"
 	gatewaybuiltin "github.com/sandbox0-ai/sandbox0/pkg/gateway/auth/builtin"
 	gatewayoidc "github.com/sandbox0-ai/sandbox0/pkg/gateway/auth/oidc"
@@ -34,28 +37,30 @@ import (
 
 // Server represents the HTTP server for cluster-gateway
 type Server struct {
-	router             *gin.Engine
-	cfg                *config.ClusterGatewayConfig
-	proxy2Mgr          *proxy.Router
-	proxy2sp           *proxy.Router
-	managerClient      *client.ManagerClient
-	authMiddleware     *middleware.InternalAuthMiddleware
-	publicAuth         *gatewaymiddleware.AuthMiddleware
-	compositeAuth      *middleware.CompositeAuthMiddleware
-	publicIdentityRepo *gatewayidentity.Repository
-	publicAPIKeyRepo   *gatewayapikey.Repository
-	rateLimiter        *gatewaymiddleware.RateLimiter
-	externalLimiter    *middleware.ExternalRateLimiter
-	publicBuiltin      *gatewaybuiltin.Provider
-	publicOIDC         *gatewayoidc.Manager
-	publicJWT          *gatewayauthn.Issuer
-	requestLogger      *middleware.RequestLogger
-	logger             *zap.Logger
-	meteringHandler    *gatewayhandlers.MeteringHandler
-	internalAuthGen    *internalauth.Generator
-	entitlements       licensing.Entitlements
-	obsProvider        *observability.Provider
-	httpClient         *http.Client
+	router                *gin.Engine
+	cfg                   *config.ClusterGatewayConfig
+	proxy2Mgr             *proxy.Router
+	proxy2sp              *proxy.Router
+	managerClient         *client.ManagerClient
+	authMiddleware        *middleware.InternalAuthMiddleware
+	publicAuth            *gatewaymiddleware.AuthMiddleware
+	compositeAuth         *middleware.CompositeAuthMiddleware
+	publicIdentityRepo    *gatewayidentity.Repository
+	publicAPIKeyRepo      *gatewayapikey.Repository
+	rateLimiter           *gatewaymiddleware.RateLimiter
+	externalLimiter       *middleware.ExternalRateLimiter
+	publicBuiltin         *gatewaybuiltin.Provider
+	publicOIDC            *gatewayoidc.Manager
+	publicJWT             *gatewayauthn.Issuer
+	requestLogger         *middleware.RequestLogger
+	logger                *zap.Logger
+	meteringHandler       *gatewayhandlers.MeteringHandler
+	internalAuthGen       *internalauth.Generator
+	entitlements          licensing.Entitlements
+	obsProvider           *observability.Provider
+	httpClient            *http.Client
+	exposureSandboxCache  *cache.Cache[string, *mgr.Sandbox]
+	publicGatewayLimiters sync.Map
 }
 
 // NewServer creates a new HTTP server
@@ -259,6 +264,11 @@ func NewServer(
 		entitlements:       entitlements,
 		obsProvider:        obsProvider,
 		httpClient:         httpClient,
+		exposureSandboxCache: cache.New[string, *mgr.Sandbox](cache.Config{
+			MaxSize:         4096,
+			TTL:             5 * time.Second,
+			CleanupInterval: 5 * time.Second,
+		}),
 	}
 
 	server.setupRoutes()

--- a/manager/pkg/http/handlers_public_gateway.go
+++ b/manager/pkg/http/handlers_public_gateway.go
@@ -1,0 +1,107 @@
+package http
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/service"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
+	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+	"go.uber.org/zap"
+)
+
+func (s *Server) getPublicGateway(c *gin.Context) {
+	sandboxID := c.Param("id")
+	if sandboxID == "" {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "sandbox_id is required")
+		return
+	}
+
+	claims := internalauth.ClaimsFromContext(c.Request.Context())
+	if claims == nil {
+		spec.JSONError(c, http.StatusUnauthorized, spec.CodeUnauthorized, "missing authentication")
+		return
+	}
+
+	sandbox, err := s.sandboxService.GetSandbox(c.Request.Context(), sandboxID)
+	if err != nil {
+		s.logger.Error("Failed to get sandbox public gateway",
+			zap.String("sandboxID", sandboxID),
+			zap.Error(err),
+		)
+		spec.JSONError(c, http.StatusNotFound, spec.CodeNotFound, fmt.Sprintf("sandbox not found: %v", err))
+		return
+	}
+	if sandbox.TeamID != claims.TeamID {
+		spec.JSONError(c, http.StatusForbidden, spec.CodeForbidden, "sandbox belongs to a different team")
+		return
+	}
+
+	cfg := sandbox.PublicGateway
+	if cfg == nil {
+		cfg = &service.PublicGatewayConfig{}
+	}
+	spec.JSONSuccess(c, http.StatusOK, gin.H{
+		"sandbox_id":      sandboxID,
+		"public_gateway":  cfg,
+		"exposure_domain": s.getExposureDomain(),
+	})
+}
+
+func (s *Server) updatePublicGateway(c *gin.Context) {
+	sandboxID := c.Param("id")
+	if sandboxID == "" {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "sandbox_id is required")
+		return
+	}
+
+	claims := internalauth.ClaimsFromContext(c.Request.Context())
+	if claims == nil {
+		spec.JSONError(c, http.StatusUnauthorized, spec.CodeUnauthorized, "missing authentication")
+		return
+	}
+
+	var req service.PublicGatewayConfig
+	if err := c.ShouldBindJSON(&req); err != nil {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, fmt.Sprintf("invalid request: %v", err))
+		return
+	}
+
+	sandbox, err := s.sandboxService.GetSandbox(c.Request.Context(), sandboxID)
+	if err != nil {
+		spec.JSONError(c, http.StatusNotFound, spec.CodeNotFound, fmt.Sprintf("sandbox not found: %v", err))
+		return
+	}
+	if sandbox.TeamID != claims.TeamID {
+		spec.JSONError(c, http.StatusForbidden, spec.CodeForbidden, "sandbox belongs to a different team")
+		return
+	}
+	if !sandbox.AutoResume && service.PublicGatewayHasResumeRoute(&req) {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest,
+			"cannot set resume=true on public gateway routes when sandbox auto_resume is disabled")
+		return
+	}
+
+	updated, err := s.sandboxService.UpdateSandbox(c.Request.Context(), sandboxID, &service.SandboxUpdateConfig{
+		PublicGateway: &req,
+	})
+	if err != nil {
+		s.logger.Error("Failed to update sandbox public gateway",
+			zap.String("sandboxID", sandboxID),
+			zap.Error(err),
+		)
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, fmt.Sprintf("failed to update public gateway: %v", err))
+		return
+	}
+
+	cfg := updated.PublicGateway
+	if cfg == nil {
+		cfg = &service.PublicGatewayConfig{}
+	}
+	spec.JSONSuccess(c, http.StatusOK, gin.H{
+		"sandbox_id":      sandboxID,
+		"public_gateway":  cfg,
+		"exposure_domain": s.getExposureDomain(),
+	})
+}

--- a/manager/pkg/http/handlers_sandbox.go
+++ b/manager/pkg/http/handlers_sandbox.go
@@ -224,6 +224,20 @@ func (s *Server) updateSandbox(c *gin.Context) {
 				return
 			}
 		}
+		if service.PublicGatewayHasResumeRoute(sandbox.PublicGateway) {
+			spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest,
+				"cannot disable auto_resume while public gateway routes have resume=true; remove or update those routes first")
+			return
+		}
+	}
+	resultAutoResume := sandbox.AutoResume
+	if req.Config.AutoResume != nil {
+		resultAutoResume = *req.Config.AutoResume
+	}
+	if !resultAutoResume && req.Config.PublicGateway != nil && service.PublicGatewayHasResumeRoute(req.Config.PublicGateway) {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest,
+			"cannot set resume=true on public gateway routes when sandbox auto_resume is disabled")
+		return
 	}
 
 	updated, err := s.sandboxService.UpdateSandbox(c.Request.Context(), sandboxID, req.Config)

--- a/manager/pkg/http/server.go
+++ b/manager/pkg/http/server.go
@@ -157,6 +157,8 @@ func (s *Server) setupRoutes() {
 			sandboxes.PUT("/:id/exposed-ports", s.updateExposedPorts)
 			sandboxes.DELETE("/:id/exposed-ports", s.clearExposedPorts)
 			sandboxes.DELETE("/:id/exposed-ports/:port", s.deleteExposedPort)
+			sandboxes.GET("/:id/public-gateway", s.getPublicGateway)
+			sandboxes.PUT("/:id/public-gateway", s.updatePublicGateway)
 			sandboxes.POST("/:id/pause", s.pauseSandbox)
 			sandboxes.POST("/:id/resume", s.resumeSandbox)
 			sandboxes.POST("/:id/refresh", s.refreshSandbox)

--- a/manager/pkg/service/public_gateway.go
+++ b/manager/pkg/service/public_gateway.go
@@ -1,0 +1,270 @@
+package service
+
+import (
+	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
+)
+
+const (
+	PublicGatewayAuthModeNone   = "none"
+	PublicGatewayAuthModeBearer = "bearer"
+	PublicGatewayAuthModeHeader = "header"
+)
+
+const (
+	maxPublicGatewayRoutes        = 32
+	maxPublicGatewayMethods       = 16
+	maxPublicGatewayAllowedValues = 32
+)
+
+var publicGatewayRouteIDPattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`)
+var httpMethodPattern = regexp.MustCompile(`^[A-Z][A-Z0-9_-]*$`)
+
+// PublicGatewayConfig controls request-level policy for sandbox public traffic.
+type PublicGatewayConfig struct {
+	Enabled bool                 `json:"enabled"`
+	Routes  []PublicGatewayRoute `json:"routes,omitempty"`
+}
+
+// PublicGatewayRoute defines one public route on an exposed sandbox port.
+type PublicGatewayRoute struct {
+	ID             string                  `json:"id"`
+	Port           int                     `json:"port"`
+	PathPrefix     string                  `json:"path_prefix,omitempty"`
+	Methods        []string                `json:"methods,omitempty"`
+	RewritePrefix  *string                 `json:"rewrite_prefix,omitempty"`
+	Auth           *PublicGatewayAuth      `json:"auth,omitempty"`
+	CORS           *PublicGatewayCORS      `json:"cors,omitempty"`
+	RateLimit      *PublicGatewayRateLimit `json:"rate_limit,omitempty"`
+	TimeoutSeconds int                     `json:"timeout_seconds,omitempty"`
+	Resume         bool                    `json:"resume"`
+}
+
+// PublicGatewayAuth controls inbound authentication for one public route.
+type PublicGatewayAuth struct {
+	Mode              string `json:"mode"`
+	BearerTokenSHA256 string `json:"bearer_token_sha256,omitempty"`
+	HeaderName        string `json:"header_name,omitempty"`
+	HeaderValueSHA256 string `json:"header_value_sha256,omitempty"`
+}
+
+// PublicGatewayCORS controls CORS responses for browser-facing public routes.
+type PublicGatewayCORS struct {
+	AllowedOrigins   []string `json:"allowed_origins,omitempty"`
+	AllowedMethods   []string `json:"allowed_methods,omitempty"`
+	AllowedHeaders   []string `json:"allowed_headers,omitempty"`
+	ExposeHeaders    []string `json:"expose_headers,omitempty"`
+	AllowCredentials bool     `json:"allow_credentials,omitempty"`
+	MaxAgeSeconds    int      `json:"max_age_seconds,omitempty"`
+}
+
+// PublicGatewayRateLimit controls per-route request limiting at cluster-gateway.
+type PublicGatewayRateLimit struct {
+	RPS   int `json:"rps"`
+	Burst int `json:"burst"`
+}
+
+func normalizePublicGatewayConfig(cfg *PublicGatewayConfig) (*PublicGatewayConfig, error) {
+	if cfg == nil {
+		return nil, nil
+	}
+	out := *cfg
+	if len(out.Routes) > maxPublicGatewayRoutes {
+		return nil, fmt.Errorf("public_gateway.routes exceeds limit %d", maxPublicGatewayRoutes)
+	}
+	seen := make(map[string]struct{}, len(out.Routes))
+	for i := range out.Routes {
+		route, err := normalizePublicGatewayRoute(out.Routes[i])
+		if err != nil {
+			return nil, fmt.Errorf("public_gateway.routes[%d]: %w", i, err)
+		}
+		if _, ok := seen[route.ID]; ok {
+			return nil, fmt.Errorf("public_gateway.routes[%d]: duplicate id %q", i, route.ID)
+		}
+		seen[route.ID] = struct{}{}
+		out.Routes[i] = route
+	}
+	return &out, nil
+}
+
+func PublicGatewayHasResumeRoute(cfg *PublicGatewayConfig) bool {
+	if cfg == nil {
+		return false
+	}
+	for _, route := range cfg.Routes {
+		if route.Resume {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizePublicGatewayRoute(route PublicGatewayRoute) (PublicGatewayRoute, error) {
+	route.ID = strings.ToLower(strings.TrimSpace(route.ID))
+	if !publicGatewayRouteIDPattern.MatchString(route.ID) {
+		return route, fmt.Errorf("id must be a DNS label")
+	}
+	if route.Port <= 0 || route.Port > 65535 {
+		return route, fmt.Errorf("port must be between 1 and 65535")
+	}
+	route.PathPrefix = normalizeGatewayPathPrefix(route.PathPrefix)
+	if route.RewritePrefix != nil {
+		rewrite := normalizeGatewayRewritePrefix(*route.RewritePrefix)
+		route.RewritePrefix = &rewrite
+	}
+	methods, err := normalizeGatewayMethods(route.Methods)
+	if err != nil {
+		return route, err
+	}
+	route.Methods = methods
+	if route.Auth != nil {
+		auth, err := normalizePublicGatewayAuth(*route.Auth)
+		if err != nil {
+			return route, err
+		}
+		route.Auth = &auth
+	}
+	if route.CORS != nil {
+		cors, err := normalizePublicGatewayCORS(*route.CORS)
+		if err != nil {
+			return route, err
+		}
+		route.CORS = &cors
+	}
+	if route.RateLimit != nil {
+		if route.RateLimit.RPS <= 0 {
+			return route, fmt.Errorf("rate_limit.rps must be greater than 0")
+		}
+		if route.RateLimit.Burst <= 0 {
+			return route, fmt.Errorf("rate_limit.burst must be greater than 0")
+		}
+	}
+	if route.TimeoutSeconds < 0 {
+		return route, fmt.Errorf("timeout_seconds must be greater than or equal to 0")
+	}
+	return route, nil
+}
+
+func normalizeGatewayPathPrefix(prefix string) string {
+	prefix = strings.TrimSpace(prefix)
+	if prefix == "" {
+		return "/"
+	}
+	if !strings.HasPrefix(prefix, "/") {
+		prefix = "/" + prefix
+	}
+	return prefix
+}
+
+func normalizeGatewayRewritePrefix(prefix string) string {
+	prefix = strings.TrimSpace(prefix)
+	if prefix == "" {
+		return "/"
+	}
+	if !strings.HasPrefix(prefix, "/") {
+		prefix = "/" + prefix
+	}
+	return prefix
+}
+
+func normalizeGatewayMethods(methods []string) ([]string, error) {
+	if len(methods) > maxPublicGatewayMethods {
+		return nil, fmt.Errorf("methods exceeds limit %d", maxPublicGatewayMethods)
+	}
+	if len(methods) == 0 {
+		return nil, nil
+	}
+	out := make([]string, 0, len(methods))
+	seen := make(map[string]struct{}, len(methods))
+	for _, method := range methods {
+		method = strings.ToUpper(strings.TrimSpace(method))
+		if method == "" {
+			return nil, fmt.Errorf("methods cannot contain empty values")
+		}
+		if method != "*" && !httpMethodPattern.MatchString(method) {
+			return nil, fmt.Errorf("invalid method %q", method)
+		}
+		if _, ok := seen[method]; ok {
+			continue
+		}
+		seen[method] = struct{}{}
+		out = append(out, method)
+	}
+	return out, nil
+}
+
+func normalizePublicGatewayAuth(auth PublicGatewayAuth) (PublicGatewayAuth, error) {
+	auth.Mode = strings.ToLower(strings.TrimSpace(auth.Mode))
+	if auth.Mode == "" {
+		auth.Mode = PublicGatewayAuthModeNone
+	}
+	switch auth.Mode {
+	case PublicGatewayAuthModeNone:
+		auth.BearerTokenSHA256 = ""
+		auth.HeaderName = ""
+		auth.HeaderValueSHA256 = ""
+	case PublicGatewayAuthModeBearer:
+		if strings.TrimSpace(auth.BearerTokenSHA256) == "" {
+			return auth, fmt.Errorf("auth.bearer_token_sha256 is required for bearer auth")
+		}
+		auth.BearerTokenSHA256 = strings.ToLower(strings.TrimSpace(auth.BearerTokenSHA256))
+		auth.HeaderName = ""
+		auth.HeaderValueSHA256 = ""
+	case PublicGatewayAuthModeHeader:
+		auth.HeaderName = http.CanonicalHeaderKey(strings.TrimSpace(auth.HeaderName))
+		auth.HeaderValueSHA256 = strings.ToLower(strings.TrimSpace(auth.HeaderValueSHA256))
+		if auth.HeaderName == "" || auth.HeaderValueSHA256 == "" {
+			return auth, fmt.Errorf("auth.header_name and auth.header_value_sha256 are required for header auth")
+		}
+	default:
+		return auth, fmt.Errorf("unsupported auth.mode %q", auth.Mode)
+	}
+	return auth, nil
+}
+
+func normalizePublicGatewayCORS(cors PublicGatewayCORS) (PublicGatewayCORS, error) {
+	var err error
+	cors.AllowedOrigins, err = normalizeNonEmptyValues("cors.allowed_origins", cors.AllowedOrigins)
+	if err != nil {
+		return cors, err
+	}
+	cors.AllowedMethods, err = normalizeGatewayMethods(cors.AllowedMethods)
+	if err != nil {
+		return cors, fmt.Errorf("cors.allowed_methods: %w", err)
+	}
+	cors.AllowedHeaders, err = normalizeNonEmptyValues("cors.allowed_headers", cors.AllowedHeaders)
+	if err != nil {
+		return cors, err
+	}
+	cors.ExposeHeaders, err = normalizeNonEmptyValues("cors.expose_headers", cors.ExposeHeaders)
+	if err != nil {
+		return cors, err
+	}
+	if cors.MaxAgeSeconds < 0 {
+		return cors, fmt.Errorf("cors.max_age_seconds must be greater than or equal to 0")
+	}
+	return cors, nil
+}
+
+func normalizeNonEmptyValues(field string, values []string) ([]string, error) {
+	if len(values) > maxPublicGatewayAllowedValues {
+		return nil, fmt.Errorf("%s exceeds limit %d", field, maxPublicGatewayAllowedValues)
+	}
+	out := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return nil, fmt.Errorf("%s cannot contain empty values", field)
+		}
+		key := strings.ToLower(value)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, value)
+	}
+	return out, nil
+}

--- a/manager/pkg/service/public_gateway.go
+++ b/manager/pkg/service/public_gateway.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"encoding/hex"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -210,6 +211,9 @@ func normalizePublicGatewayAuth(auth PublicGatewayAuth) (PublicGatewayAuth, erro
 			return auth, fmt.Errorf("auth.bearer_token_sha256 is required for bearer auth")
 		}
 		auth.BearerTokenSHA256 = strings.ToLower(strings.TrimSpace(auth.BearerTokenSHA256))
+		if !validSHA256Hex(auth.BearerTokenSHA256) {
+			return auth, fmt.Errorf("auth.bearer_token_sha256 must be a hex encoded SHA-256 digest")
+		}
 		auth.HeaderName = ""
 		auth.HeaderValueSHA256 = ""
 	case PublicGatewayAuthModeHeader:
@@ -218,10 +222,21 @@ func normalizePublicGatewayAuth(auth PublicGatewayAuth) (PublicGatewayAuth, erro
 		if auth.HeaderName == "" || auth.HeaderValueSHA256 == "" {
 			return auth, fmt.Errorf("auth.header_name and auth.header_value_sha256 are required for header auth")
 		}
+		if !validSHA256Hex(auth.HeaderValueSHA256) {
+			return auth, fmt.Errorf("auth.header_value_sha256 must be a hex encoded SHA-256 digest")
+		}
 	default:
 		return auth, fmt.Errorf("unsupported auth.mode %q", auth.Mode)
 	}
 	return auth, nil
+}
+
+func validSHA256Hex(value string) bool {
+	if len(value) != 64 {
+		return false
+	}
+	decoded, err := hex.DecodeString(value)
+	return err == nil && len(decoded) == 32
 }
 
 func normalizePublicGatewayCORS(cors PublicGatewayCORS) (PublicGatewayCORS, error) {

--- a/manager/pkg/service/sandbox_service.go
+++ b/manager/pkg/service/sandbox_service.go
@@ -20,21 +20,22 @@ import (
 
 // Sandbox represents a sandbox instance
 type Sandbox struct {
-	ID            string              `json:"id"`
-	TemplateID    string              `json:"template_id"`
-	TeamID        string              `json:"team_id"`
-	UserID        string              `json:"user_id"`
-	InternalAddr  string              `json:"internal_addr"`
-	Status        string              `json:"status"`
-	Paused        bool                `json:"paused"`
-	PowerState    SandboxPowerState   `json:"power_state"`
-	AutoResume    bool                `json:"auto_resume"`
-	ExposedPorts  []ExposedPortConfig `json:"exposed_ports,omitempty"`
-	PodName       string              `json:"pod_name"`
-	ExpiresAt     time.Time           `json:"expires_at"`
-	HardExpiresAt time.Time           `json:"hard_expires_at"`
-	ClaimedAt     time.Time           `json:"claimed_at"`
-	CreatedAt     time.Time           `json:"created_at"`
+	ID            string               `json:"id"`
+	TemplateID    string               `json:"template_id"`
+	TeamID        string               `json:"team_id"`
+	UserID        string               `json:"user_id"`
+	InternalAddr  string               `json:"internal_addr"`
+	Status        string               `json:"status"`
+	Paused        bool                 `json:"paused"`
+	PowerState    SandboxPowerState    `json:"power_state"`
+	AutoResume    bool                 `json:"auto_resume"`
+	ExposedPorts  []ExposedPortConfig  `json:"exposed_ports,omitempty"`
+	PublicGateway *PublicGatewayConfig `json:"public_gateway,omitempty"`
+	PodName       string               `json:"pod_name"`
+	ExpiresAt     time.Time            `json:"expires_at"`
+	HardExpiresAt time.Time            `json:"hard_expires_at"`
+	ClaimedAt     time.Time            `json:"claimed_at"`
+	CreatedAt     time.Time            `json:"created_at"`
 }
 
 // SandboxStatus represents possible sandbox statuses

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -56,24 +56,26 @@ type BootstrapMountStatus struct {
 
 // SandboxConfig represents sandbox configuration
 type SandboxConfig struct {
-	EnvVars      map[string]string              `json:"env_vars,omitempty"`
-	TTL          *int32                         `json:"ttl,omitempty"`      // Time-to-live in seconds (0 disables)
-	HardTTL      *int32                         `json:"hard_ttl,omitempty"` // Hard time-to-live in seconds (0 disables)
-	Network      *v1alpha1.SandboxNetworkPolicy `json:"network,omitempty"`
-	Webhook      *WebhookConfig                 `json:"webhook,omitempty"`
-	AutoResume   *bool                          `json:"auto_resume,omitempty"`
-	ExposedPorts []ExposedPortConfig            `json:"exposed_ports,omitempty"`
+	EnvVars       map[string]string              `json:"env_vars,omitempty"`
+	TTL           *int32                         `json:"ttl,omitempty"`      // Time-to-live in seconds (0 disables)
+	HardTTL       *int32                         `json:"hard_ttl,omitempty"` // Hard time-to-live in seconds (0 disables)
+	Network       *v1alpha1.SandboxNetworkPolicy `json:"network,omitempty"`
+	Webhook       *WebhookConfig                 `json:"webhook,omitempty"`
+	AutoResume    *bool                          `json:"auto_resume,omitempty"`
+	ExposedPorts  []ExposedPortConfig            `json:"exposed_ports,omitempty"`
+	PublicGateway *PublicGatewayConfig           `json:"public_gateway,omitempty"`
 }
 
 // SandboxUpdateConfig represents sandbox configuration fields that can be updated at runtime.
 // Unlike SandboxConfig, env_vars and webhook are excluded as they only affect new processes
 // or require restart to take effect.
 type SandboxUpdateConfig struct {
-	TTL          *int32                         `json:"ttl,omitempty"`
-	HardTTL      *int32                         `json:"hard_ttl,omitempty"`
-	Network      *v1alpha1.SandboxNetworkPolicy `json:"network,omitempty"`
-	AutoResume   *bool                          `json:"auto_resume,omitempty"`
-	ExposedPorts []ExposedPortConfig            `json:"exposed_ports,omitempty"`
+	TTL           *int32                         `json:"ttl,omitempty"`
+	HardTTL       *int32                         `json:"hard_ttl,omitempty"`
+	Network       *v1alpha1.SandboxNetworkPolicy `json:"network,omitempty"`
+	AutoResume    *bool                          `json:"auto_resume,omitempty"`
+	ExposedPorts  []ExposedPortConfig            `json:"exposed_ports,omitempty"`
+	PublicGateway *PublicGatewayConfig           `json:"public_gateway,omitempty"`
 }
 
 type ExposedPortConfig struct {
@@ -212,6 +214,19 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 	if err := validateClaimMounts(req); err != nil {
 		s.observeClaimPhase(req.Template, "unknown", "validate_claim_mounts", phaseStarted, err)
 		return nil, err
+	}
+	if req.Config != nil && req.Config.PublicGateway != nil {
+		publicGateway, err := normalizePublicGatewayConfig(req.Config.PublicGateway)
+		if err != nil {
+			s.observeClaimPhase(req.Template, "unknown", "validate_claim_mounts", phaseStarted, err)
+			return nil, err
+		}
+		if req.Config.AutoResume != nil && !*req.Config.AutoResume && PublicGatewayHasResumeRoute(publicGateway) {
+			err := fmt.Errorf("cannot set resume=true on public gateway routes when sandbox auto_resume is disabled")
+			s.observeClaimPhase(req.Template, "unknown", "validate_claim_mounts", phaseStarted, err)
+			return nil, err
+		}
+		req.Config.PublicGateway = publicGateway
 	}
 	s.observeClaimPhase(req.Template, "unknown", "validate_claim_mounts", phaseStarted, nil)
 	s.logger.Info("Claiming sandbox",

--- a/manager/pkg/service/sandbox_service_lifecycle.go
+++ b/manager/pkg/service/sandbox_service_lifecycle.go
@@ -125,6 +125,13 @@ func (s *SandboxService) UpdateSandbox(ctx context.Context, sandboxID string, cf
 		if cfg.ExposedPorts != nil {
 			merged.ExposedPorts = cfg.ExposedPorts
 		}
+		if cfg.PublicGateway != nil {
+			publicGateway, err := normalizePublicGatewayConfig(cfg.PublicGateway)
+			if err != nil {
+				return err
+			}
+			merged.PublicGateway = publicGateway
+		}
 
 		if cfg.Network != nil {
 			if s.NetworkPolicyService == nil {
@@ -245,6 +252,7 @@ func (s *SandboxService) podToSandbox(ctx context.Context, pod *corev1.Pod, sand
 		PowerState:    powerState,
 		AutoResume:    autoResume,
 		ExposedPorts:  cfg.ExposedPorts,
+		PublicGateway: cfg.PublicGateway,
 		PodName:       pod.Name,
 		ExpiresAt:     expiresAt,
 		HardExpiresAt: hardExpiresAt,

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -1697,6 +1697,67 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorEnvelope"
+  /api/v1/sandboxes/{id}/public-gateway:
+    get:
+      tags: [sandboxes]
+      summary: Get sandbox public gateway policy
+      security:
+        - bearerAuth: []
+      x-upstream-service: manager
+      x-upstream-path: /api/v1/sandboxes/{id}/public-gateway
+      parameters:
+        - $ref: "#/components/parameters/SandboxID"
+      responses:
+        "200":
+          description: Public gateway policy
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessPublicGatewayResponse"
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+    put:
+      tags: [sandboxes]
+      summary: Update sandbox public gateway policy
+      description: |
+        Replaces the request-level public gateway policy for sandbox public traffic.
+        When enabled, matching routes control method, path, authentication, CORS,
+        per-route rate limits, timeout, rewrite, and paused sandbox auto-resume.
+      security:
+        - bearerAuth: []
+      x-upstream-service: manager
+      x-upstream-path: /api/v1/sandboxes/{id}/public-gateway
+      parameters:
+        - $ref: "#/components/parameters/SandboxID"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PublicGatewayConfig"
+      responses:
+        "200":
+          description: Public gateway policy updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessPublicGatewayResponse"
+        "400":
+          description: Invalid public gateway policy
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
   /api/v1/sandboxes/{id}/contexts:
     post:
       tags: [contexts]
@@ -3654,6 +3715,8 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/ExposedPortConfig"
+        public_gateway:
+          $ref: "#/components/schemas/PublicGatewayConfig"
     ExposedPortConfig:
       type: object
       properties:
@@ -3681,6 +3744,122 @@ components:
           items:
             $ref: "#/components/schemas/ExposedPortConfig"
       required: [ports]
+    PublicGatewayConfig:
+      type: object
+      properties:
+        enabled:
+          type: boolean
+          description: Enables request-level public gateway enforcement for sandbox public traffic.
+        routes:
+          type: array
+          maxItems: 32
+          items:
+            $ref: "#/components/schemas/PublicGatewayRoute"
+      required: [enabled]
+    PublicGatewayRoute:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Stable route id. Must be a DNS label and unique within the sandbox policy.
+        port:
+          type: integer
+          format: int32
+        path_prefix:
+          type: string
+          default: /
+          description: Request path prefix matched before proxying to the sandbox port.
+        methods:
+          type: array
+          description: Allowed HTTP methods. Empty allows every method.
+          items:
+            type: string
+        rewrite_prefix:
+          type: string
+          nullable: true
+          description: Optional replacement prefix applied before proxying.
+        auth:
+          $ref: "#/components/schemas/PublicGatewayAuth"
+        cors:
+          $ref: "#/components/schemas/PublicGatewayCORS"
+        rate_limit:
+          $ref: "#/components/schemas/PublicGatewayRateLimit"
+        timeout_seconds:
+          type: integer
+          format: int32
+          description: Per-route upstream timeout in seconds. Zero disables the route override.
+        resume:
+          type: boolean
+          description: |
+            Route-level resume gate for public gateway traffic. Evaluated only when
+            sandbox auto_resume is true.
+      required: [id, port, resume]
+    PublicGatewayAuth:
+      type: object
+      properties:
+        mode:
+          type: string
+          enum: [none, bearer, header]
+          default: none
+        bearer_token_sha256:
+          type: string
+          description: Hex SHA-256 of the accepted bearer token. Required when mode is bearer.
+        header_name:
+          type: string
+          description: Required header name when mode is header.
+        header_value_sha256:
+          type: string
+          description: Hex SHA-256 of the required header value when mode is header.
+      required: [mode]
+    PublicGatewayCORS:
+      type: object
+      properties:
+        allowed_origins:
+          type: array
+          items:
+            type: string
+        allowed_methods:
+          type: array
+          items:
+            type: string
+        allowed_headers:
+          type: array
+          items:
+            type: string
+        expose_headers:
+          type: array
+          items:
+            type: string
+        allow_credentials:
+          type: boolean
+        max_age_seconds:
+          type: integer
+          format: int32
+    PublicGatewayRateLimit:
+      type: object
+      properties:
+        rps:
+          type: integer
+          format: int32
+        burst:
+          type: integer
+          format: int32
+      required: [rps, burst]
+    SuccessPublicGatewayResponse:
+      allOf:
+        - $ref: "#/components/schemas/SuccessEnvelope"
+        - type: object
+          properties:
+            data:
+              type: object
+              properties:
+                sandbox_id:
+                  type: string
+                public_gateway:
+                  $ref: "#/components/schemas/PublicGatewayConfig"
+                exposure_domain:
+                  type: string
+              required: [sandbox_id, public_gateway]
     SuccessExposedPortsResponse:
       allOf:
         - $ref: "#/components/schemas/SuccessEnvelope"
@@ -3789,6 +3968,8 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/ExposedPortConfig"
+        public_gateway:
+          $ref: "#/components/schemas/PublicGatewayConfig"
         pod_name:
           type: string
         ssh:
@@ -3857,6 +4038,8 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/ExposedPortConfig"
+        public_gateway:
+          $ref: "#/components/schemas/PublicGatewayConfig"
     SandboxUpdateRequest:
       type: object
       properties:

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -108,6 +108,13 @@ const (
 	ProcessTypeRepl ProcessType = "repl"
 )
 
+// Defines values for PublicGatewayAuthMode.
+const (
+	Bearer PublicGatewayAuthMode = "bearer"
+	Header PublicGatewayAuthMode = "header"
+	None   PublicGatewayAuthMode = "none"
+)
+
 // Defines values for REPLReadyMode.
 const (
 	PromptToken  REPLReadyMode = "prompt_token"
@@ -277,6 +284,11 @@ const (
 	SuccessPauseSandboxResponseSuccessTrue SuccessPauseSandboxResponseSuccess = true
 )
 
+// Defines values for SuccessPublicGatewayResponseSuccess.
+const (
+	SuccessPublicGatewayResponseSuccessTrue SuccessPublicGatewayResponseSuccess = true
+)
+
 // Defines values for SuccessRefreshResponseSuccess.
 const (
 	SuccessRefreshResponseSuccessTrue SuccessRefreshResponseSuccess = true
@@ -404,7 +416,7 @@ const (
 
 // Defines values for SuccessWrittenResponseSuccess.
 const (
-	SuccessWrittenResponseSuccessTrue SuccessWrittenResponseSuccess = true
+	True SuccessWrittenResponseSuccess = true
 )
 
 // Defines values for TrafficRuleAction.
@@ -1136,6 +1148,72 @@ type ProjectionSpec struct {
 	UsernamePassword *UsernamePasswordProjection `json:"usernamePassword,omitempty"`
 }
 
+// PublicGatewayAuth defines model for PublicGatewayAuth.
+type PublicGatewayAuth struct {
+	// BearerTokenSha256 Hex SHA-256 of the accepted bearer token. Required when mode is bearer.
+	BearerTokenSha256 *string `json:"bearer_token_sha256,omitempty"`
+
+	// HeaderName Required header name when mode is header.
+	HeaderName *string `json:"header_name,omitempty"`
+
+	// HeaderValueSha256 Hex SHA-256 of the required header value when mode is header.
+	HeaderValueSha256 *string               `json:"header_value_sha256,omitempty"`
+	Mode              PublicGatewayAuthMode `json:"mode"`
+}
+
+// PublicGatewayAuthMode defines model for PublicGatewayAuth.Mode.
+type PublicGatewayAuthMode string
+
+// PublicGatewayCORS defines model for PublicGatewayCORS.
+type PublicGatewayCORS struct {
+	AllowCredentials *bool     `json:"allow_credentials,omitempty"`
+	AllowedHeaders   *[]string `json:"allowed_headers,omitempty"`
+	AllowedMethods   *[]string `json:"allowed_methods,omitempty"`
+	AllowedOrigins   *[]string `json:"allowed_origins,omitempty"`
+	ExposeHeaders    *[]string `json:"expose_headers,omitempty"`
+	MaxAgeSeconds    *int32    `json:"max_age_seconds,omitempty"`
+}
+
+// PublicGatewayConfig defines model for PublicGatewayConfig.
+type PublicGatewayConfig struct {
+	// Enabled Enables request-level public gateway enforcement for sandbox public traffic.
+	Enabled bool                  `json:"enabled"`
+	Routes  *[]PublicGatewayRoute `json:"routes,omitempty"`
+}
+
+// PublicGatewayRateLimit defines model for PublicGatewayRateLimit.
+type PublicGatewayRateLimit struct {
+	Burst int32 `json:"burst"`
+	Rps   int32 `json:"rps"`
+}
+
+// PublicGatewayRoute defines model for PublicGatewayRoute.
+type PublicGatewayRoute struct {
+	Auth *PublicGatewayAuth `json:"auth,omitempty"`
+	Cors *PublicGatewayCORS `json:"cors,omitempty"`
+
+	// Id Stable route id. Must be a DNS label and unique within the sandbox policy.
+	Id string `json:"id"`
+
+	// Methods Allowed HTTP methods. Empty allows every method.
+	Methods *[]string `json:"methods,omitempty"`
+
+	// PathPrefix Request path prefix matched before proxying to the sandbox port.
+	PathPrefix *string                 `json:"path_prefix,omitempty"`
+	Port       int32                   `json:"port"`
+	RateLimit  *PublicGatewayRateLimit `json:"rate_limit,omitempty"`
+
+	// Resume Route-level resume gate for public gateway traffic. Evaluated only when
+	// sandbox auto_resume is true.
+	Resume bool `json:"resume"`
+
+	// RewritePrefix Optional replacement prefix applied before proxying.
+	RewritePrefix *string `json:"rewrite_prefix"`
+
+	// TimeoutSeconds Per-route upstream timeout in seconds. Zero disables the route override.
+	TimeoutSeconds *int32 `json:"timeout_seconds,omitempty"`
+}
+
 // REPLConfig defines model for REPLConfig.
 type REPLConfig struct {
 	Candidates  []ExecCandidate   `json:"candidates"`
@@ -1282,6 +1360,7 @@ type Sandbox struct {
 	Paused        bool                  `json:"paused"`
 	PodName       string                `json:"pod_name"`
 	PowerState    SandboxPowerState     `json:"power_state"`
+	PublicGateway *PublicGatewayConfig  `json:"public_gateway,omitempty"`
 	Ssh           *SandboxSSHConnection `json:"ssh,omitempty"`
 	Status        string                `json:"status"`
 	TeamId        string                `json:"team_id"`
@@ -1293,12 +1372,13 @@ type Sandbox struct {
 type SandboxConfig struct {
 	// AutoResume Sandbox-level resume gate for paused sandboxes. When false, any inbound request
 	// (API or public exposure) must not auto resume the sandbox.
-	AutoResume   *bool                 `json:"auto_resume,omitempty"`
-	EnvVars      *map[string]string    `json:"env_vars,omitempty"`
-	ExposedPorts *[]ExposedPortConfig  `json:"exposed_ports,omitempty"`
-	HardTtl      *int32                `json:"hard_ttl,omitempty"`
-	Network      *SandboxNetworkPolicy `json:"network,omitempty"`
-	Ttl          *int32                `json:"ttl,omitempty"`
+	AutoResume    *bool                 `json:"auto_resume,omitempty"`
+	EnvVars       *map[string]string    `json:"env_vars,omitempty"`
+	ExposedPorts  *[]ExposedPortConfig  `json:"exposed_ports,omitempty"`
+	HardTtl       *int32                `json:"hard_ttl,omitempty"`
+	Network       *SandboxNetworkPolicy `json:"network,omitempty"`
+	PublicGateway *PublicGatewayConfig  `json:"public_gateway,omitempty"`
+	Ttl           *int32                `json:"ttl,omitempty"`
 
 	// Webhook Per-sandbox webhook configuration. Sandbox0 delivers webhook events at least once and consumers should deduplicate by event_id. For sandbox lifecycle events, procd persists signed delivery records to a manager-owned SandboxVolume outside the workspace before dispatch; manager also emits sandbox.deleted during pod deletion cleanup.
 	Webhook *WebhookConfig `json:"webhook,omitempty"`
@@ -1458,11 +1538,12 @@ type SandboxTemplateStatus struct {
 type SandboxUpdateConfig struct {
 	// AutoResume Sandbox-level resume gate for paused sandboxes. When false, any inbound request
 	// (API or public exposure) must not auto resume the sandbox.
-	AutoResume   *bool                 `json:"auto_resume,omitempty"`
-	ExposedPorts *[]ExposedPortConfig  `json:"exposed_ports,omitempty"`
-	HardTtl      *int32                `json:"hard_ttl,omitempty"`
-	Network      *SandboxNetworkPolicy `json:"network,omitempty"`
-	Ttl          *int32                `json:"ttl,omitempty"`
+	AutoResume    *bool                 `json:"auto_resume,omitempty"`
+	ExposedPorts  *[]ExposedPortConfig  `json:"exposed_ports,omitempty"`
+	HardTtl       *int32                `json:"hard_ttl,omitempty"`
+	Network       *SandboxNetworkPolicy `json:"network,omitempty"`
+	PublicGateway *PublicGatewayConfig  `json:"public_gateway,omitempty"`
+	Ttl           *int32                `json:"ttl,omitempty"`
 }
 
 // SandboxUpdateRequest defines model for SandboxUpdateRequest.
@@ -1790,6 +1871,19 @@ type SuccessPauseSandboxResponse struct {
 
 // SuccessPauseSandboxResponseSuccess defines model for SuccessPauseSandboxResponse.Success.
 type SuccessPauseSandboxResponseSuccess bool
+
+// SuccessPublicGatewayResponse defines model for SuccessPublicGatewayResponse.
+type SuccessPublicGatewayResponse struct {
+	Data *struct {
+		ExposureDomain *string             `json:"exposure_domain,omitempty"`
+		PublicGateway  PublicGatewayConfig `json:"public_gateway"`
+		SandboxId      string              `json:"sandbox_id"`
+	} `json:"data,omitempty"`
+	Success SuccessPublicGatewayResponseSuccess `json:"success"`
+}
+
+// SuccessPublicGatewayResponseSuccess defines model for SuccessPublicGatewayResponse.Success.
+type SuccessPublicGatewayResponseSuccess bool
 
 // SuccessRefreshResponse defines model for SuccessRefreshResponse.
 type SuccessRefreshResponse struct {
@@ -2438,6 +2532,9 @@ type PostApiV1SandboxesIdFilesMoveJSONRequestBody = MoveFileRequest
 
 // PutApiV1SandboxesIdNetworkJSONRequestBody defines body for PutApiV1SandboxesIdNetwork for application/json ContentType.
 type PutApiV1SandboxesIdNetworkJSONRequestBody = SandboxNetworkPolicy
+
+// PutApiV1SandboxesIdPublicGatewayJSONRequestBody defines body for PutApiV1SandboxesIdPublicGateway for application/json ContentType.
+type PutApiV1SandboxesIdPublicGatewayJSONRequestBody = PublicGatewayConfig
 
 // PostApiV1SandboxesIdRefreshJSONRequestBody defines body for PostApiV1SandboxesIdRefresh for application/json ContentType.
 type PostApiV1SandboxesIdRefreshJSONRequestBody = SandboxRefreshRequest


### PR DESCRIPTION
## Summary
- Add a sandbox public gateway policy API for request-level public traffic control.
- Persist public gateway policy in sandbox config and expose GET/PUT management routes.
- Enforce route path/method matching, bearer/header auth hashes, CORS, per-route rate limits, timeout, rewrite, and resume gates in cluster-gateway.

## Testing
- go generate ./pkg/apispec && git diff --exit-code -- pkg/apispec/types.gen.go pkg/apispec/openapi.yaml
- go test ./cluster-gateway/... ./manager/pkg/service ./manager/pkg/http ./pkg/apispec
- go test ./... (fails only when local e2e tries to create kind because Docker daemon is unavailable on this machine)
- pre-push hook: make manifests, make proto, make apispec, go fmt ./..., go mod tidy, go mod vendor, golangci-lint run ./...
