### PR TITLE
Document sandbox gateway policy

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -48,6 +48,10 @@
           "title": "Ports"
         },
         {
+          "slug": "gateway-policy",
+          "title": "Gateway Policy"
+        },
+        {
           "slug": "webhooks",
           "title": "Webhooks"
         }

--- a/docs/sandbox/gateway-policy/page.mdx
+++ b/docs/sandbox/gateway-policy/page.mdx
@@ -1,0 +1,360 @@
+# Gateway Policy
+
+Gateway policy adds request-level controls to sandbox public traffic. Use it when a sandbox needs a public HTTP endpoint with path routing, method filtering, auth, CORS, rate limits, upstream timeout, and route-level resume behavior.
+
+<Callout variant="info">
+`exposed_ports` makes ports publicly reachable. `public_gateway` controls how HTTP requests are accepted and proxied after public access reaches the sandbox gateway.
+</Callout>
+
+## Policy Model
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `enabled` | boolean | Enables request-level gateway enforcement |
+| `routes` | array | Ordered public gateway routes |
+
+### Route Model
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Stable route ID. Must be unique in the policy |
+| `port` | integer | Sandbox port to proxy to |
+| `path_prefix` | string | Request path prefix to match. Defaults to `/` |
+| `methods` | string array | Allowed HTTP methods. Empty allows every method |
+| `rewrite_prefix` | string or null | Optional path prefix replacement before proxying |
+| `auth` | object | Optional request authentication |
+| `cors` | object | Optional CORS policy |
+| `rate_limit` | object | Optional per-route rate limit |
+| `timeout_seconds` | integer | Optional upstream timeout in seconds |
+| `resume` | boolean | Whether this route may resume a paused sandbox when `auto_resume` is enabled |
+
+### Auth Model
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `mode` | string | `none`, `bearer`, or `header` |
+| `bearer_token_sha256` | string | SHA-256 hex digest for bearer token auth |
+| `header_name` | string | Header name for header auth |
+| `header_value_sha256` | string | SHA-256 hex digest for header value auth |
+
+<Callout variant="warning">
+Gateway auth stores SHA-256 digests, not plaintext tokens. Hash secret values before sending the policy.
+</Callout>
+
+## Get Gateway Policy
+
+<Endpoint method="GET">
+/api/v1/sandboxes/{'{id}'}/public-gateway
+</Endpoint>
+
+<Tabs
+  tabs={[
+    {
+      label: "Go",
+      language: "go",
+      code: `policy, err := sandbox.GetPublicGateway(ctx)
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Printf("enabled: %v\\n", policy.PublicGateway.Enabled)
+fmt.Printf("exposure domain: %s\\n", policy.ExposureDomain)
+for _, route := range policy.PublicGateway.Routes {
+    fmt.Printf("%s -> port %d\\n", route.ID, route.Port)
+}`
+    },
+    {
+      label: "Python",
+      language: "python",
+      code: `policy = sandbox.get_public_gateway()
+print(f"enabled: {policy.public_gateway.enabled}")
+print(f"exposure domain: {policy.exposure_domain}")
+for route in policy.public_gateway.routes:
+    print(f"{route.id} -> port {route.port}")`
+    },
+    {
+      label: "TypeScript",
+      language: "typescript",
+      code: `const policy = await sandbox.getPublicGateway();
+console.log('enabled:', policy.publicGateway.enabled);
+console.log('exposure domain:', policy.exposureDomain);
+for (const route of policy.publicGateway.routes ?? []) {
+    console.log(\`\${route.id} -> port \${route.port}\`);
+}`
+    },
+    {
+      label: "CLI",
+      language: "bash",
+      code: `s0 sandbox gateway get -s sb_abc123`
+    }
+  ]}
+/>
+
+---
+
+## Update Gateway Policy
+
+<Endpoint method="PUT">
+/api/v1/sandboxes/{'{id}'}/public-gateway
+</Endpoint>
+
+The update replaces the full gateway policy. Include every route that should remain active.
+
+<Tabs
+  tabs={[
+    {
+      label: "Go",
+      language: "go",
+      code: `tokenHash := sha256.Sum256([]byte(os.Getenv("PUBLIC_API_TOKEN")))
+
+resp, err := sandbox.UpdatePublicGateway(ctx, apispec.PublicGatewayConfig{
+    Enabled: true,
+    Routes: []apispec.PublicGatewayRoute{
+        {
+            ID:         "api",
+            Port:       8080,
+            PathPrefix: apispec.NewOptString("/api"),
+            Methods:    []string{"GET", "POST"},
+            Auth: apispec.NewOptPublicGatewayAuth(apispec.PublicGatewayAuth{
+                Mode:              apispec.PublicGatewayAuthModeBearer,
+                BearerTokenSHA256: apispec.NewOptString(hex.EncodeToString(tokenHash[:])),
+            }),
+            RateLimit: apispec.NewOptPublicGatewayRateLimit(apispec.PublicGatewayRateLimit{
+                Rps:   20,
+                Burst: 40,
+            }),
+            TimeoutSeconds: apispec.NewOptInt32(30),
+            Resume:         true,
+        },
+    },
+})
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Printf("routes: %d\\n", len(resp.PublicGateway.Routes))`
+    },
+    {
+      label: "Python",
+      language: "python",
+      code: `import hashlib
+import os
+
+from sandbox0.apispec.models.public_gateway_auth import PublicGatewayAuth
+from sandbox0.apispec.models.public_gateway_auth_mode import PublicGatewayAuthMode
+from sandbox0.apispec.models.public_gateway_config import PublicGatewayConfig
+from sandbox0.apispec.models.public_gateway_rate_limit import PublicGatewayRateLimit
+from sandbox0.apispec.models.public_gateway_route import PublicGatewayRoute
+
+token_hash = hashlib.sha256(os.environ["PUBLIC_API_TOKEN"].encode()).hexdigest()
+
+resp = sandbox.update_public_gateway(PublicGatewayConfig(
+    enabled=True,
+    routes=[
+        PublicGatewayRoute(
+            id="api",
+            port=8080,
+            path_prefix="/api",
+            methods=["GET", "POST"],
+            auth=PublicGatewayAuth(
+                mode=PublicGatewayAuthMode.BEARER,
+                bearer_token_sha256=token_hash,
+            ),
+            rate_limit=PublicGatewayRateLimit(rps=20, burst=40),
+            timeout_seconds=30,
+            resume=True,
+        ),
+    ],
+))
+print(f"routes: {len(resp.public_gateway.routes)}")`
+    },
+    {
+      label: "TypeScript",
+      language: "typescript",
+      code: `import { createHash } from 'node:crypto';
+
+const tokenHash = createHash('sha256')
+    .update(process.env.PUBLIC_API_TOKEN!)
+    .digest('hex');
+
+const policy = {
+    enabled: true,
+    routes: [
+        {
+            id: 'api',
+            port: 8080,
+            pathPrefix: '/api',
+            methods: ['GET', 'POST'],
+            auth: {
+                mode: 'bearer',
+                bearerTokenSha256: tokenHash,
+            },
+            rateLimit: {
+                rps: 20,
+                burst: 40,
+            },
+            timeoutSeconds: 30,
+            resume: true,
+        },
+    ],
+};
+
+const resp = await sandbox.updatePublicGateway(policy);
+console.log('routes:', resp.publicGateway.routes?.length ?? 0);`
+    },
+    {
+      label: "CLI",
+      language: "bash",
+      code: `TOKEN_HASH="$(printf %s "$PUBLIC_API_TOKEN" | sha256sum | awk '{print $1}')"
+
+cat > gateway.yaml <<EOF
+enabled: true
+routes:
+  - id: api
+    port: 8080
+    path_prefix: /api
+    methods: [GET, POST]
+    auth:
+      mode: bearer
+      bearer_token_sha256: "$TOKEN_HASH"
+    rate_limit:
+      rps: 20
+      burst: 40
+    timeout_seconds: 30
+    resume: true
+EOF
+
+s0 sandbox gateway update -s sb_abc123 -f gateway.yaml`
+    }
+  ]}
+/>
+
+---
+
+## Set Policy At Claim Time
+
+You can attach the gateway policy when claiming a sandbox. This is useful when the sandbox starts a known HTTP service during boot.
+
+<Tabs
+  tabs={[
+    {
+      label: "Go",
+      language: "go",
+      code: `sandbox, err := client.ClaimSandbox(ctx, "default",
+    sandbox0.WithSandboxAutoResume(true),
+    sandbox0.WithSandboxPublicGateway(apispec.PublicGatewayConfig{
+        Enabled: true,
+        Routes: []apispec.PublicGatewayRoute{
+            {
+                ID:         "web",
+                Port:       3000,
+                PathPrefix: apispec.NewOptString("/"),
+                Resume:     true,
+            },
+        },
+    }),
+)
+if err != nil {
+    log.Fatal(err)
+}`
+    },
+    {
+      label: "Python",
+      language: "python",
+      code: `from sandbox0.apispec.models.sandbox_config import SandboxConfig
+
+sandbox = client.claim_sandbox(
+    template="default",
+    config=SandboxConfig.from_dict({
+        "auto_resume": True,
+        "public_gateway": {
+            "enabled": True,
+            "routes": [
+                {
+                    "id": "web",
+                    "port": 3000,
+                    "path_prefix": "/",
+                    "resume": True,
+                },
+            ],
+        },
+    }),
+)`
+    },
+    {
+      label: "TypeScript",
+      language: "typescript",
+      code: `const sandbox = await client.sandboxes.claim('default', {
+    autoResume: true,
+    publicGateway: {
+        enabled: true,
+        routes: [
+            {
+                id: 'web',
+                port: 3000,
+                pathPrefix: '/',
+                resume: true,
+            },
+        ],
+    },
+});`
+    },
+    {
+      label: "CLI",
+      language: "bash",
+      code: `cat > sandbox.yaml <<EOF
+template: default
+config:
+  auto_resume: true
+  public_gateway:
+    enabled: true
+    routes:
+      - id: web
+        port: 3000
+        path_prefix: /
+        resume: true
+EOF
+
+s0 sandbox create -f sandbox.yaml`
+    }
+  ]}
+/>
+
+---
+
+## Clear Gateway Policy
+
+Clearing the policy disables request-level gateway enforcement for public traffic.
+
+<Tabs
+  tabs={[
+    {
+      label: "Go",
+      language: "go",
+      code: `_, err := sandbox.ClearPublicGateway(ctx)
+if err != nil {
+    log.Fatal(err)
+}`
+    },
+    {
+      label: "Python",
+      language: "python",
+      code: `sandbox.clear_public_gateway()`
+    },
+    {
+      label: "TypeScript",
+      language: "typescript",
+      code: `await sandbox.clearPublicGateway();`
+    },
+    {
+      label: "CLI",
+      language: "bash",
+      code: `s0 sandbox gateway clear -s sb_abc123`
+    }
+  ]}
+/>
+
+## Behavior Notes
+
+- If `public_gateway.enabled` is `true`, public HTTP traffic must match a configured route.
+- If `methods` is empty, every HTTP method is allowed for that route.
+- `resume` is evaluated with sandbox `auto_resume`. A route with `resume: false` will not resume a paused sandbox.
+- Public URLs are still derived from the deployment exposure domain. Use `s0 sandbox gateway get` or the SDK response to inspect the current `exposure_domain`.

--- a/docs/sandbox/page.mdx
+++ b/docs/sandbox/page.mdx
@@ -62,8 +62,9 @@ Claim a sandbox from a template. The sandbox is created from a pre-warmed pool f
 | `webhook` | object | Webhook configuration |
 | `auto_resume` | boolean | Auto-resume when accessed (default: true) |
 | `exposed_ports` | array | Ports to expose publicly |
+| `public_gateway` | object | Request-level gateway policy for public sandbox traffic |
 
-See [Network](/docs/sandbox/network) for traffic control and [Credential](/docs/credential) for outbound auth and secret handling.
+See [Network](/docs/sandbox/network) for traffic control, [Gateway Policy](/docs/sandbox/gateway-policy) for public HTTP controls, and [Credential](/docs/credential) for outbound auth and secret handling.
 
 ### TTL vs Hard TTL
 
@@ -407,6 +408,7 @@ Only the following fields can be updated at runtime:
 | `network` | object | Network policy configuration |
 | `auto_resume` | boolean | Auto-resume when accessed |
 | `exposed_ports` | array | Ports to expose publicly |
+| `public_gateway` | object | Request-level gateway policy for public sandbox traffic |
 
 <Callout variant="warning">
 <code>env_vars</code> and <code>webhook</code> cannot be updated at runtime. These fields only take effect when the sandbox is created. To use different environment variables, create a new sandbox.
@@ -632,5 +634,13 @@ console.log('Sandbox deleted');`
     cta="Learn More"
   >
     Control network access and egress rules
+  </LinkCard>
+
+  <LinkCard
+    title="Gateway Policy"
+    href="/docs/sandbox/gateway-policy"
+    cta="Learn More"
+  >
+    Control public HTTP routes, auth, CORS, and rate limits
   </LinkCard>
 </CardGrid>


### PR DESCRIPTION
## Summary
- add sandbox Gateway Policy documentation with Go, Python, TypeScript, and CLI examples
- link Gateway Policy from sandbox overview and docs manifest
- document public gateway auth, route, CORS, rate limit, timeout, and resume behavior

## Testing
- git diff --check
- pre-push hook: make manifests, make proto, make apispec, go fmt ./..., go mod tidy, go mod vendor, golangci-lint run ./...