### PR TITLE
Improve Managed Agents engine docs

### DIFF
--- a/docs/managed-agents/agent-engines/page.mdx
+++ b/docs/managed-agents/agent-engines/page.mdx
@@ -1,20 +1,34 @@
 # Agent Engines
 
-Agent engine is the Sandbox0 name for the runtime adapter that executes an agent inside the per-session sandbox.
+An agent engine is the Sandbox0 runtime adapter behind a Managed Agents session.
 
-The public API still uses the Claude Managed Agents object model. The agent engine decides which local wrapper runs in the sandbox, how model credentials are projected, and how tool events are mapped back to the Managed Agents event stream.
+The public API still uses the Claude Managed Agents object model. The engine decides where the agent loop runs, which model API shape it expects, how credentials are projected, and how tool events are mapped back to the Managed Agents event stream.
 
 Official references:
 
 - [Claude Managed Agents quickstart](https://platform.claude.com/docs/en/managed-agents/quickstart)
 - [Claude Managed Agents agent setup](https://platform.claude.com/docs/en/managed-agents/agent-setup)
 
+## Execution Models
+
+Sandbox0 supports two execution models.
+
+| Model | How it works | Engines |
+|-------|--------------|---------|
+| Agent in sandbox | The agent runtime process runs inside the per-session Sandbox0 sandbox. The sandbox contains the agent process, workspace, tools, and engine state. | `claude`, `codex` |
+| Sandbox as tool | A resident runtime service runs the agent loop outside the sandbox. The sandbox is claimed lazily and exposed to the agent as tools such as `bash`. | `openai-agents` |
+
+Use agent in sandbox when you want the agent process itself to live with the workspace. This is the most direct fit for coding agents that expect local files, shell commands, home-directory state, and long-lived process state inside the sandbox.
+
+Use sandbox as tool when you want to embed an agent into a product workflow or control plane. The agent harness stays in a managed runtime service, while Sandbox0 provides isolated tool execution only when the agent needs to inspect files or run commands.
+
 ## Supported Engines
 
-| Engine | Runtime adapter | Model API shape |
-|--------|-----------------|-----------------|
-| `claude` | Claude Agent SDK wrapper | Anthropic-compatible |
-| `codex` | Codex app-server wrapper | OpenAI-compatible |
+| Engine | Execution model | Runtime adapter | Model API shape | Best fit |
+|--------|-----------------|-----------------|-----------------|----------|
+| `claude` | Agent in sandbox | Claude Agent SDK wrapper | Anthropic-compatible | Claude Code style coding agents and Anthropic-compatible providers |
+| `codex` | Agent in sandbox | Codex app-server wrapper | OpenAI-compatible | Codex app-server sessions that should keep Codex state inside the workspace |
+| `openai-agents` | Sandbox as tool | Resident OpenAI Agents Python runtime | OpenAI Responses-compatible | Product copilots and agent workflows built on the OpenAI Agents SDK |
 
 ## Select An Engine
 
@@ -31,7 +45,7 @@ const claudeVault = await client.beta.vaults.create({
 });
 ```
 
-For Codex:
+For `codex`:
 
 ```typescript
 const codexVault = await client.beta.vaults.create({
@@ -44,10 +58,23 @@ const codexVault = await client.beta.vaults.create({
 });
 ```
 
+For `openai-agents`:
+
+```typescript
+const openAIAgentsVault = await client.beta.vaults.create({
+    display_name: "OpenAI Agents LLM",
+    metadata: {
+        "sandbox0.managed_agents.role": "llm",
+        "sandbox0.managed_agents.engine": "openai-agents",
+        "sandbox0.managed_agents.llm_base_url": "https://api.openai.com/v1",
+    },
+});
+```
+
 Add the model provider token to the selected LLM vault:
 
 ```typescript
-await client.beta.vaults.credentials.create(codexVault.id, {
+await client.beta.vaults.credentials.create(openAIAgentsVault.id, {
     display_name: "Model provider API key",
     auth: {
         type: "static_bearer",
@@ -56,7 +83,7 @@ await client.beta.vaults.credentials.create(codexVault.id, {
 });
 ```
 
-Use `claudeVault.id` instead of `codexVault.id` when the session should run the Claude engine. LLM credentials must be unbound `static_bearer` credentials; do not set `mcp_server_url` for the model provider token.
+Use the vault id for the engine you want. LLM credentials must be unbound `static_bearer` credentials; do not set `mcp_server_url` for the model provider token.
 
 Attach exactly one LLM vault to the session:
 
@@ -64,7 +91,7 @@ Attach exactly one LLM vault to the session:
 const session = await client.beta.sessions.create({
     agent: agent.id,
     environment_id: environment.id,
-    vault_ids: [codexVault.id],
+    vault_ids: [openAIAgentsVault.id],
 });
 ```
 
@@ -72,7 +99,7 @@ If no LLM vault selects an engine, Sandbox0 defaults to `claude`.
 
 ## Claude Engine
 
-The Claude engine expects an Anthropic-compatible API. Use it for Claude Agent SDK behavior and Anthropic-compatible provider endpoints.
+The Claude engine runs the Claude Agent SDK wrapper inside the session sandbox. It expects an Anthropic-compatible API. Use it when the provider already exposes the Anthropic Messages API shape and you want Claude Code style behavior.
 
 Sandbox0 sets compatibility environment values such as `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, and `ANTHROPIC_BASE_URL`, then injects the real credential through egress auth for the configured LLM host.
 
@@ -81,6 +108,29 @@ Sandbox0 sets compatibility environment values such as `ANTHROPIC_API_KEY`, `ANT
 The Codex engine launches Codex app-server inside the session sandbox. It expects an OpenAI-compatible model endpoint. Sandbox0 stores Codex home and thread state under the session workspace so runtime state stays session-scoped.
 
 For Minimax-compatible endpoints, Sandbox0 detects the provider from the LLM base URL and configures Codex provider settings accordingly.
+
+## OpenAI Agents Engine
+
+The `openai-agents` engine uses a resident Python runtime service built on the official OpenAI Agents SDK. The runtime receives the session snapshot from the Managed Agents gateway, runs the agent loop in the runtime service, and claims a Sandbox0 sandbox only when the agent needs sandbox tools.
+
+This is the sandbox as tool model. The session still has durable Managed Agents event history, but the agent process is not the same process as the sandbox. The sandbox is an isolated tool target for commands and workspace work.
+
+The engine expects an OpenAI Responses-compatible endpoint. For Anthropic-compatible providers, place [LLMProxy](/docs/managed-agents/llmproxy) in front of the provider and store the proxy URL as the LLM vault base URL.
+
+```typescript
+const zaiViaLLMProxyVault = await client.beta.vaults.create({
+    display_name: "Z.ai through LLMProxy",
+    metadata: {
+        "sandbox0.managed_agents.role": "llm",
+        "sandbox0.managed_agents.engine": "openai-agents",
+        "sandbox0.managed_agents.llm_base_url": "https://llmproxy.sandbox0.ai/claude2codex/https://api.z.ai/api/anthropic",
+    },
+});
+```
+
+<Callout variant="info">
+For self-hosted deployments, configure the OpenAI Agents runtime callback base URL to an internal gateway URL when possible. The runtime sends session events back to the Managed Agents gateway; routing that callback through a public edge can introduce avoidable policy and timeout failures.
+</Callout>
 
 ## Engine Configuration
 
@@ -107,5 +157,13 @@ Do not use `sandbox0.managed_agents.engine` as session metadata. Reserved `sandb
     cta="Check"
   >
     Review the current differences from hosted Claude Managed Agents
+  </LinkCard>
+
+  <LinkCard
+    title="LLMProxy"
+    href="/docs/managed-agents/llmproxy"
+    cta="Translate"
+  >
+    Use Anthropic-compatible providers with OpenAI-compatible engines
   </LinkCard>
 </CardGrid>

--- a/docs/managed-agents/compatibility/page.mdx
+++ b/docs/managed-agents/compatibility/page.mdx
@@ -19,7 +19,8 @@ Official reference: [Claude Managed Agents quickstart](https://platform.claude.c
 | Custom skills | Supported through uploaded skill versions |
 | MCP servers | Supported for URL MCP servers and vault-backed credentials |
 | GitHub repository resources | Supported at session creation |
-| Agent engines | Supported for `claude` and `codex` |
+| Agent engines | Supported for `claude`, `codex`, and `openai-agents` |
+| LLMProxy | Supported as an optional protocol translator for OpenAI-compatible engines |
 
 ## Current Differences
 
@@ -32,6 +33,8 @@ Official reference: [Claude Managed Agents quickstart](https://platform.claude.c
 | Sandbox claim | Runtime setup claims or resumes a Sandbox0 sandbox and mounts a persistent workspace volume. |
 | Claude engine | Requires an Anthropic-compatible endpoint. |
 | Codex engine | Requires an OpenAI-compatible endpoint. |
+| OpenAI Agents engine | Requires an OpenAI Responses-compatible endpoint and uses Sandbox0 as a tool target. |
+| LLMProxy | Optional. Use it when an OpenAI-compatible engine needs to call an Anthropic-compatible provider. |
 | Anthropic pre-built skills | Not supported. Use Sandbox0 custom skills. |
 | Multi-agent threads | Not implemented in the current backend surface. |
 | Outcomes and memory research preview | Not implemented in the current backend surface. |
@@ -101,6 +104,8 @@ Sandbox0 stores the session and event log outside the sandbox. Sandbox attachmen
 | Interrupt | Interrupts the active wrapper run and moves local session truth back toward idle. |
 | Delete | Rejects active running sessions. Delete after interrupting and reaching idle. |
 | Archive | Makes the session read-only for new input events. |
+
+`claude` and `codex` use agent in sandbox behavior. `openai-agents` uses sandbox as tool behavior, so the resident runtime can start a run before a Sandbox0 sandbox is claimed.
 
 ## Version Drift
 

--- a/docs/managed-agents/llmproxy/page.mdx
+++ b/docs/managed-agents/llmproxy/page.mdx
@@ -1,0 +1,95 @@
+# LLMProxy
+
+LLMProxy is a protocol translation layer for model providers. It is useful when the agent engine expects one API shape, but the model provider exposes another API shape.
+
+In Managed Agents, the most common case is `openai-agents`: the engine uses the OpenAI Agents SDK and expects an OpenAI Responses-compatible endpoint. Some model providers expose an Anthropic-compatible Messages endpoint instead. LLMProxy can translate between those surfaces.
+
+## When To Use It
+
+Use LLMProxy when:
+
+- The selected engine is `openai-agents` or another OpenAI-compatible runtime.
+- The model provider exposes an Anthropic-compatible endpoint.
+- You want to keep using Sandbox0 LLM vaults for token storage and credential projection.
+
+Do not add LLMProxy just because a provider is non-OpenAI. If the selected engine is `claude` and the provider already exposes an Anthropic-compatible endpoint, point the LLM vault directly at that provider.
+
+## URL Shape
+
+The hosted Sandbox0 LLMProxy supports `claude2codex`, which presents an OpenAI Responses-compatible surface to the client and forwards to an Anthropic-compatible upstream.
+
+Start with the provider's Anthropic-compatible base URL:
+
+```text
+https://api.z.ai/api/anthropic
+```
+
+Prefix it with the LLMProxy route:
+
+```text
+https://llmproxy.sandbox0.ai/claude2codex/https://api.z.ai/api/anthropic
+```
+
+Use that full URL as `sandbox0.managed_agents.llm_base_url` on the LLM vault.
+
+## OpenAI Agents Example
+
+```typescript
+const llmVault = await client.beta.vaults.create({
+    display_name: "OpenAI Agents via LLMProxy",
+    metadata: {
+        "sandbox0.managed_agents.role": "llm",
+        "sandbox0.managed_agents.engine": "openai-agents",
+        "sandbox0.managed_agents.llm_base_url": "https://llmproxy.sandbox0.ai/claude2codex/https://api.z.ai/api/anthropic",
+    },
+});
+
+await client.beta.vaults.credentials.create(llmVault.id, {
+    display_name: "Model provider API key",
+    auth: {
+        type: "static_bearer",
+        token: process.env.MODEL_API_KEY,
+    },
+});
+```
+
+The `MODEL_API_KEY` value is the upstream provider token. The SDK client still authenticates to Sandbox0 Managed Agents with a Sandbox0 API key.
+
+## Request Path
+
+```mermaid
+flowchart LR
+    runtime[OpenAI Agents runtime] --> proxy[LLMProxy claude2codex route]
+    proxy --> provider[Anthropic-compatible provider]
+    provider --> proxy
+    proxy --> runtime
+```
+
+The Managed Agents gateway does not call the model provider directly. It stores the vault credential and passes resolved engine configuration to the runtime. The runtime calls the LLM base URL for the selected engine.
+
+## Operational Notes
+
+- Store provider tokens in LLM vault credentials, not in application config.
+- Keep the Sandbox0 Managed Agents API URL separate from the LLM base URL.
+- For private deployments, prefer an internal LLMProxy service URL when runtime pods and LLMProxy run in the same cluster.
+- LLMProxy is a translation layer, not a session store. Managed Agents session truth and event history remain in Sandbox0.
+
+## Next
+
+<CardGrid>
+  <LinkCard
+    title="Agent Engines"
+    href="/docs/managed-agents/agent-engines"
+    cta="Choose"
+  >
+    Decide whether the session should use Claude, Codex, or OpenAI Agents
+  </LinkCard>
+
+  <LinkCard
+    title="Vaults"
+    href="/docs/managed-agents/vaults"
+    cta="Secure"
+  >
+    Store the provider token and engine metadata in an LLM vault
+  </LinkCard>
+</CardGrid>

--- a/docs/managed-agents/page.mdx
+++ b/docs/managed-agents/page.mdx
@@ -20,7 +20,19 @@ Managed Agents sit above raw sandboxes. A sandbox gives an agent processes, file
 | Events | Append-only interaction log for user input, agent output, tools, status, and errors |
 | Vault | Credential container attached to a session |
 | Resource | File or repository materialized into the session workspace |
-| Agent engine | Sandbox0 runtime adapter that runs the agent implementation inside the sandbox |
+| Agent engine | Runtime adapter that runs the session as agent in sandbox or sandbox as tool |
+| LLMProxy | Optional protocol translator for model providers with a different API shape |
+
+## Engine Models
+
+Managed Agents can execute in two ways:
+
+| Model | What users should expect | Engines |
+|-------|--------------------------|---------|
+| Agent in sandbox | The agent runtime process lives inside the per-session sandbox with the workspace and engine state. | `claude`, `codex` |
+| Sandbox as tool | A resident runtime service owns the agent loop and uses Sandbox0 as an isolated tool target. | `openai-agents` |
+
+Both models use the same Managed Agents API and durable event stream. Choose the model by selecting an agent engine through the LLM vault.
 
 ## Architecture
 
@@ -29,16 +41,20 @@ flowchart TD
     sdk[Official Anthropic SDK] --> gateway[managed-agent gateway]
     gateway --> pg[(PostgreSQL session and event truth)]
     gateway --> sandbox0[Sandbox0 API]
-    sandbox0 --> runtime[Sandbox0 sandbox]
-    runtime --> wrapper[agent wrapper warm process]
+    sandbox0 --> runtime[Sandbox0 sandbox or tool sandbox]
+    gateway --> resident[resident runtime for sandbox-as-tool engines]
+    runtime --> wrapper[agent-in-sandbox wrapper]
     wrapper --> callbacks[Signed runtime callbacks]
+    resident --> callbacks
     callbacks --> gateway
     wrapper --> llm[model provider API]
+    resident --> llmproxy[optional LLMProxy]
+    llmproxy --> llm
     gateway --> credentials[credential sources and network policy]
     credentials --> runtime
 ```
 
-Session truth lives outside the sandbox. The sandbox is the execution attachment for a session, not the source of truth for session state.
+Session truth lives outside the sandbox. The sandbox is an execution attachment for a session, not the source of truth for session state.
 
 ## Request Flow
 
@@ -47,8 +63,8 @@ Session truth lives outside the sandbox. The sandbox is the execution attachment
 3. Create an LLM vault with `sandbox0.managed_agents.role = llm` and the target agent engine.
 4. Create a session that references the agent, environment, and vault ids.
 5. Send `user.message` events.
-6. Sandbox0 claims or resumes a sandbox, mounts the workspace, applies network policy, injects credentials, and starts the selected agent engine.
-7. The wrapper emits callbacks. The gateway appends events to the durable session log.
+6. Sandbox0 starts the selected agent engine. Agent-in-sandbox engines claim or resume a sandbox immediately; sandbox-as-tool engines claim a sandbox when a tool needs one.
+7. The engine emits callbacks. The gateway appends events to the durable session log.
 8. The client lists or streams events until the session becomes idle, requires action, or terminates.
 
 ## Sandbox0-Specific Boundaries
@@ -59,6 +75,7 @@ The public object model follows Claude Managed Agents where practical. The backe
 - The SDK `apiKey` is a Sandbox0 API key.
 - The LLM token is stored in a vault and projected by Sandbox0 credential policy.
 - The agent engine is selected through LLM vault metadata.
+- `claude` and `codex` run agent in sandbox; `openai-agents` uses sandbox as tool.
 - The sandbox workspace is persistent across turns through a Sandbox0 volume.
 - Network policy and credential injection are enforced by Sandbox0.
 
@@ -97,5 +114,13 @@ The official Claude Managed Agents documentation is still the canonical SDK refe
     cta="Secure"
   >
     Store LLM and external service credentials outside agent code
+  </LinkCard>
+
+  <LinkCard
+    title="Agent Engines"
+    href="/docs/managed-agents/agent-engines"
+    cta="Choose"
+  >
+    Compare Claude, Codex, and OpenAI Agents execution models
   </LinkCard>
 </CardGrid>

--- a/docs/managed-agents/sessions/page.mdx
+++ b/docs/managed-agents/sessions/page.mdx
@@ -77,6 +77,8 @@ Sandbox0 keeps session state and event history outside the sandbox. The sandbox 
 - The runtime sandbox uses auto-resume.
 - Runtime sandbox lifetime is managed by the Managed Agents deployment.
 - The selected agent engine is resolved from the attached LLM vault; if no engine is selected, the default is `claude`.
+- `claude` and `codex` run the agent process inside the sandbox.
+- `openai-agents` runs the agent loop in a resident runtime and uses Sandbox0 as a sandbox tool.
 
 ## Next
 

--- a/docs/managed-agents/vaults/page.mdx
+++ b/docs/managed-agents/vaults/page.mdx
@@ -30,7 +30,7 @@ await client.beta.vaults.credentials.create(llmVault.id, {
 | Metadata key | Required | Meaning |
 |--------------|----------|---------|
 | `sandbox0.managed_agents.role` | Yes | Must be `llm` for an LLM vault |
-| `sandbox0.managed_agents.engine` | Yes | `claude` or `codex` |
+| `sandbox0.managed_agents.engine` | Yes | `claude`, `codex`, or `openai-agents` |
 | `sandbox0.managed_agents.llm_base_url` | No | Model provider base URL |
 
 The LLM credential must be an unbound `static_bearer` credential. Do not set `mcp_server_url` on LLM credentials.
@@ -88,8 +88,11 @@ Sandbox0 injects credentials through egress auth and compatibility environment v
 |--------|---------------------------|
 | `claude` | `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BASE_URL` |
 | `codex` | `CODEX_API_KEY`, `OPENAI_API_KEY`, and `openai_base_url` engine config |
+| `openai-agents` | `OPENAI_API_KEY`, `OPENAI_BASE_URL`, and `openai_base_url` engine config |
 
 The environment variables may contain placeholders. The real token is projected by Sandbox0-managed credential policy when the sandbox contacts the configured host.
+
+For `openai-agents`, the runtime expects an OpenAI Responses-compatible base URL. If the provider exposes an Anthropic-compatible endpoint, use [LLMProxy](/docs/managed-agents/llmproxy) and store the LLMProxy URL in `sandbox0.managed_agents.llm_base_url`.
 
 ## Next
 
@@ -99,7 +102,15 @@ The environment variables may contain placeholders. The real token is projected 
     href="/docs/managed-agents/agent-engines"
     cta="Choose"
   >
-    Use LLM vault metadata to select Claude or Codex runtime behavior
+    Use LLM vault metadata to select Claude, Codex, or OpenAI Agents runtime behavior
+  </LinkCard>
+
+  <LinkCard
+    title="LLMProxy"
+    href="/docs/managed-agents/llmproxy"
+    cta="Translate"
+  >
+    Adapt Anthropic-compatible providers for OpenAI-compatible engines
   </LinkCard>
 
   <LinkCard

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -90,6 +90,10 @@
           "title": "Agent Engines"
         },
         {
+          "slug": "llmproxy",
+          "title": "LLMProxy"
+        },
+        {
           "slug": "compatibility",
           "title": "Compatibility"
         }


### PR DESCRIPTION
## Summary
- explain the two Managed Agents execution models: agent in sandbox and sandbox as tool
- document the `openai-agents` engine alongside `claude` and `codex`
- add an LLMProxy page and link it from engine and vault docs
- update compatibility, sessions, vaults, and manifest entries for the new engine/page

## Testing
- `node -e ...` manifest page existence check
- `npm run docs:generate:content -w @sandbox0-cloud/website --engine-strict=false`
- `git diff --check`
- pre-push hook: `make manifests`, `make proto`, `make apispec`, `go fmt ./...`, `go mod tidy`, `go mod vendor`, `golangci-lint run ./...`

Note: attempted `npm run build -w @sandbox0-cloud/website --engine-strict=false` from the local `sandbox0-cloud` checkout, but that checkout currently fails before docs rendering because local website dependencies do not include `@anthropic-ai/sdk` for existing Copilot code.