### PR TITLE
[codex] remove managed agents repository links

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,6 @@ Managed Agents sit above raw sandboxes. Application code uses the official Anthr
 
 - Managed Agents API: `https://agents.sandbox0.ai`
 - Documentation: <https://sandbox0.ai/docs/managed-agents>
-- Examples and runtime work: <https://github.com/sandbox0-ai/managed-agents>
 
 Use raw Sandbox0 sandboxes when you want direct control over processes, files, templates, volumes, ports, and network policy. Use Managed Agents when you want a session/event API for agent applications and want Sandbox0 to manage the runtime attachment behind that API.
 
@@ -191,7 +190,6 @@ Related repositories:
 - Go SDK: <https://github.com/sandbox0-ai/sdk-go>
 - JavaScript/TypeScript SDK: <https://github.com/sandbox0-ai/sdk-js>
 - Python SDK: <https://github.com/sandbox0-ai/sdk-py>
-- Managed Agents examples and runtime work: <https://github.com/sandbox0-ai/managed-agents>
 
 For API changes, `pkg/apispec/openapi.yaml` is the source of truth. Generated SDK code and copied OpenAPI files in other repositories should be synchronized from it rather than edited by hand.
 

--- a/skills/sandbox0/SKILL.md
+++ b/skills/sandbox0/SKILL.md
@@ -69,6 +69,5 @@ Managed Agents uses `https://agents.sandbox0.ai`. Sandbox, Template, Volume, and
 - Go SDK: https://github.com/sandbox0-ai/sdk-go
 - JavaScript SDK: https://github.com/sandbox0-ai/sdk-js
 - Python SDK: https://github.com/sandbox0-ai/sdk-py
-- Managed Agents examples and runtime work: https://github.com/sandbox0-ai/managed-agents
 
 When reporting issues, include a minimal reproduction and relevant logs, but remove API keys, tokens, kubeconfigs, customer data, private repository URLs, and any other sensitive personal or organizational information.


### PR DESCRIPTION
## Summary

- Remove public `sandbox0-ai/managed-agents` repository links from the Sandbox0 README.
- Remove the Managed Agents repository link from the bundled Sandbox0 skill source repository list.

## Why

Managed Agents is no longer intended to be presented as an open-source/public repository. The docs should keep the Managed Agents product references without advertising a source location.

## Validation

- Searched `sandbox0` and `sandbox0-cloud` for Managed Agents open-source messaging and `github.com/sandbox0-ai/managed-agents` links.
- `npm run llms:generate && npm run llms:verify` in `sandbox0-cloud/apps/website`.
- `npx tsc --noEmit` in `sandbox0-cloud/apps/website`.

`npm run build` was attempted in `sandbox0-cloud/apps/website`, but `next build` stayed in the production optimization phase for over 3 minutes without errors or progress output, so it was stopped.