### PR TITLE
Document managed agent retry states

### DIFF
--- a/docs/managed-agents/agent-engines/page.mdx
+++ b/docs/managed-agents/agent-engines/page.mdx
@@ -30,6 +30,18 @@ Use sandbox as tool when you want to embed an agent into a product workflow or c
 | `codex` | Agent in sandbox | Codex app-server wrapper | OpenAI-compatible | Codex app-server sessions that should keep Codex state inside the workspace |
 | `openai-agents` | Sandbox as tool | Resident OpenAI Agents Python runtime | OpenAI Responses-compatible | Product copilots and agent workflows built on the OpenAI Agents SDK |
 
+## Retry Behavior
+
+All supported engines report observable automatic retry attempts through the same Managed Agents events: `session.error` with `error.retry_status.type = "retrying"`, `session.status_rescheduled`, then `session.status_running` if the run resumes.
+
+| Engine | Retry signal used by Sandbox0 |
+|--------|-------------------------------|
+| `claude` | Claude Agent SDK `system` messages with `subtype = "api_retry"` |
+| `codex` | Codex app-server `error` notifications with `willRetry = true` |
+| `openai-agents` | OpenAI Agents SDK runner-managed `ModelRetrySettings` policy decisions |
+
+Sandbox0 disables hidden OpenAI Python client retries for the `openai-agents` runtime and routes model retries through the OpenAI Agents SDK retry policy so retry state is visible in the session event stream.
+
 ## Select An Engine
 
 The session engine is selected by the attached LLM vault:

--- a/docs/managed-agents/compatibility/page.mdx
+++ b/docs/managed-agents/compatibility/page.mdx
@@ -34,6 +34,7 @@ Official reference: [Claude Managed Agents quickstart](https://platform.claude.c
 | Claude engine | Requires an Anthropic-compatible endpoint. |
 | Codex engine | Requires an OpenAI-compatible endpoint. |
 | OpenAI Agents engine | Requires an OpenAI Responses-compatible endpoint and uses Sandbox0 as a tool target. |
+| Retry state | Automatic retries are exposed as `session.status_rescheduled` plus `retry_status.type = "retrying"` errors when the selected engine provides a retry signal. |
 | LLMProxy | Optional. Use it when an OpenAI-compatible engine needs to call an Anthropic-compatible provider. |
 | Anthropic pre-built skills | Not supported. Use Sandbox0 custom skills. |
 | Multi-agent threads | Not implemented in the current backend surface. |
@@ -106,6 +107,8 @@ Sandbox0 stores the session and event log outside the sandbox. Sandbox attachmen
 | Archive | Makes the session read-only for new input events. |
 
 `claude` and `codex` use agent in sandbox behavior. `openai-agents` uses sandbox as tool behavior, so the resident runtime can start a run before a Sandbox0 sandbox is claimed.
+
+Sandbox0 session lifecycle includes `idle`, `running`, `rescheduling`, and `terminated`. The `rescheduling` state is transient and means the active run is waiting for an automatic retry. It is currently mapped from Claude Agent SDK `api_retry` events, Codex app-server `willRetry` errors, and OpenAI Agents SDK runner-managed retry policy decisions.
 
 ## Version Drift
 

--- a/docs/managed-agents/events/page.mdx
+++ b/docs/managed-agents/events/page.mdx
@@ -53,10 +53,25 @@ for await (const event of stream) {
 | `user.tool_confirmation` | Allow or deny a tool that requires confirmation |
 | `user.custom_tool_result` | Result for a custom tool call |
 | `session.status_running` | A run is active |
+| `session.status_rescheduled` | The active run is waiting for an automatic engine retry after a retriable error |
 | `session.status_idle` | The turn ended or the agent requires action |
 | `session.error` | Session-level error |
 
 Treat `session.status_idle` with `stop_reason.type = "end_turn"` as a normal turn completion. If the stop reason is `requires_action`, send the required confirmation or custom tool result before expecting the run to continue.
+
+## Retry Events
+
+Sandbox0 exposes automatic model retries through the normal event stream:
+
+| Sequence | Meaning |
+|----------|---------|
+| `session.error` with `error.retry_status.type = "retrying"` | The engine observed a retriable model or transport error and will retry the same run automatically |
+| `session.status_rescheduled` | The session is in the transient `rescheduling` state while the retry is pending |
+| `session.status_running` | The same run resumed and is producing output or completion events again |
+| `session.status_idle` with `stop_reason.type = "retries_exhausted"` | The retry budget was exhausted and the turn ended without success |
+| `session.status_terminated` | The error was terminal and the session is no longer active |
+
+Do not send duplicate user input when a session is `rescheduling`. Wait for either `session.status_running`, `session.status_idle`, or `session.status_terminated`.
 
 ## File-Backed Input
 

--- a/docs/managed-agents/sessions/page.mdx
+++ b/docs/managed-agents/sessions/page.mdx
@@ -66,9 +66,12 @@ Repository authorization tokens are accepted on create or update, but are not re
 |-------|---------|
 | `idle` | Ready for new input or waiting for required action |
 | `running` | The agent engine is processing events |
+| `rescheduling` | The active run hit a retriable model or transport error and Sandbox0 is waiting for the selected engine to retry automatically |
 | `terminated` | The session is no longer active |
 
 Sandbox0 keeps session state and event history outside the sandbox. The sandbox and workspace volume are runtime attachments for the session.
+
+`rescheduling` is transient. It is emitted as `session.status_rescheduled` after a `session.error` whose `error.retry_status.type` is `retrying`. When the same run resumes and produces more output, Sandbox0 emits `session.status_running` again. If the retry budget is exhausted, the run returns to `idle` with `stop_reason.type = "retries_exhausted"`; terminal non-retryable failures move the session to `terminated`.
 
 ## Sandbox0 Runtime Behavior
 
@@ -79,6 +82,7 @@ Sandbox0 keeps session state and event history outside the sandbox. The sandbox 
 - The selected agent engine is resolved from the attached LLM vault; if no engine is selected, the default is `claude`.
 - `claude` and `codex` run the agent process inside the sandbox.
 - `openai-agents` runs the agent loop in a resident runtime and uses Sandbox0 as a sandbox tool.
+- All supported engines map observable automatic retry attempts to the same session state sequence: `running`, `rescheduling`, `running`, then either `idle` or `terminated`.
 
 ## Next
 


### PR DESCRIPTION
## Summary

- Document the four Managed Agents session states, including transient `rescheduling`.
- Add event-stream guidance for `session.status_rescheduled`, retrying errors, resumed running state, and exhausted retries.
- Document retry signals for the three supported engines: Claude, Codex, and OpenAI Agents.

## Validation

- `git diff --check`

## Related implementation

Implementation PR: https://github.com/sandbox0-ai/managed-agents/pull/96