### PR TITLE
[codex] fix netd runtime resource lifetime

### DIFF
--- a/netd/pkg/daemon/daemon.go
+++ b/netd/pkg/daemon/daemon.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -30,13 +31,21 @@ import (
 )
 
 type Daemon struct {
-	cfg           *config.NetdConfig
-	logger        *zap.Logger
-	healthServer  *http.Server
-	metricsServer *http.Server
-	proxyServer   *proxy.Server
-	obsProvider   *observability.Provider
-	ready         atomic.Bool
+	cfg             *config.NetdConfig
+	logger          *zap.Logger
+	healthServer    *http.Server
+	metricsServer   *http.Server
+	proxyServer     *proxy.Server
+	obsProvider     *observability.Provider
+	runtimeMu       sync.Mutex
+	conntrackCloser runtimeResource
+	meteringCloser  runtimeResource
+	meteringDone    <-chan struct{}
+	ready           atomic.Bool
+}
+
+type runtimeResource interface {
+	Close()
 }
 
 func New(cfg *config.NetdConfig, logger *zap.Logger, obsProvider *observability.Provider) *Daemon {
@@ -112,10 +121,21 @@ func (d *Daemon) runNetd(ctx context.Context, cancel context.CancelFunc, proxyEx
 	if err != nil {
 		d.logger.Warn("Conntrack manager disabled", zap.Error(err))
 	}
-	defer conntrackManager.Close()
 	tracker := conntrack.NewTracker()
 	var usageAggregator *netdmetering.Aggregator
 	var meteringPool *pgxpool.Pool
+	runtimeResourcesRegistered := false
+	defer func() {
+		if runtimeResourcesRegistered {
+			return
+		}
+		if meteringPool != nil {
+			meteringPool.Close()
+		}
+		if conntrackManager != nil {
+			conntrackManager.Close()
+		}
+	}()
 	if d.cfg.DatabaseURL != "" {
 		pool, err := dbpool.New(ctx, dbpool.Options{
 			DatabaseURL:     d.cfg.DatabaseURL,
@@ -127,7 +147,6 @@ func (d *Daemon) runNetd(ctx context.Context, cancel context.CancelFunc, proxyEx
 			return fmt.Errorf("create netd database pool: %w", err)
 		}
 		meteringPool = pool
-		defer meteringPool.Close()
 		if err := meteringpkg.RunMigrations(ctx, meteringPool, &zapLoggerAdapter{logger: d.logger}); err != nil {
 			return fmt.Errorf("run metering migrations: %w", err)
 		}
@@ -170,7 +189,7 @@ func (d *Daemon) runNetd(ctx context.Context, cancel context.CancelFunc, proxyEx
 					flowsToKill = append(flowsToKill, flow)
 				}
 			}
-			if len(flowsToKill) > 0 {
+			if len(flowsToKill) > 0 && conntrackManager != nil {
 				conntrackManager.CleanupFlows(ctx, flowsToKill)
 			}
 		}
@@ -187,7 +206,9 @@ func (d *Daemon) runNetd(ctx context.Context, cancel context.CancelFunc, proxyEx
 			platformState.OnSandboxDelete(info)
 			policyStore.DeleteByKey(info.Namespace, info.Name)
 			flows := tracker.PopBySrc(info.PodIP)
-			conntrackManager.CleanupFlows(ctx, flows)
+			if conntrackManager != nil {
+				conntrackManager.CleanupFlows(ctx, flows)
+			}
 			d.logger.Info("Sandbox delete handler triggered",
 				zap.String("sandbox", info.Namespace+"/"+info.Name),
 				zap.String("pod_ip", info.PodIP),
@@ -272,12 +293,21 @@ func (d *Daemon) runNetd(ctx context.Context, cancel context.CancelFunc, proxyEx
 		}
 	}()
 
-	if usageAggregator != nil {
-		go d.runMeteringFlushLoop(ctx, usageAggregator)
-	}
-
 	select {
 	case <-syncOnce:
+		var conntrackCloser runtimeResource
+		if conntrackManager != nil {
+			conntrackCloser = conntrackManager
+		}
+		var meteringCloser runtimeResource
+		if meteringPool != nil {
+			meteringCloser = meteringPool
+		}
+		d.registerRuntimeResources(conntrackCloser, meteringCloser)
+		if usageAggregator != nil {
+			d.startMeteringFlushLoop(ctx, usageAggregator)
+		}
+		runtimeResourcesRegistered = true
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()
@@ -337,6 +367,58 @@ func (d *Daemon) runMeteringFlushLoop(ctx context.Context, aggregator *netdmeter
 				d.logger.Error("Failed to flush netd metering windows", zap.Error(err))
 			}
 		}
+	}
+}
+
+func (d *Daemon) startMeteringFlushLoop(ctx context.Context, aggregator *netdmetering.Aggregator) {
+	done := make(chan struct{})
+	d.runtimeMu.Lock()
+	d.meteringDone = done
+	d.runtimeMu.Unlock()
+
+	go func() {
+		defer close(done)
+		d.runMeteringFlushLoop(ctx, aggregator)
+	}()
+}
+
+func (d *Daemon) registerRuntimeResources(conntrackCloser runtimeResource, meteringCloser runtimeResource) {
+	d.runtimeMu.Lock()
+	defer d.runtimeMu.Unlock()
+	d.conntrackCloser = conntrackCloser
+	d.meteringCloser = meteringCloser
+}
+
+func (d *Daemon) waitForMeteringFlushLoop(ctx context.Context) {
+	d.runtimeMu.Lock()
+	done := d.meteringDone
+	d.runtimeMu.Unlock()
+	if done == nil {
+		return
+	}
+	select {
+	case <-done:
+	case <-ctx.Done():
+		d.logger.Warn("Timed out waiting for netd metering flush loop to stop", zap.Error(ctx.Err()))
+	}
+}
+
+func (d *Daemon) closeRuntimeResources() {
+	d.runtimeMu.Lock()
+	meteringCloser := d.meteringCloser
+	conntrackCloser := d.conntrackCloser
+	d.meteringCloser = nil
+	d.conntrackCloser = nil
+	d.meteringDone = nil
+	d.runtimeMu.Unlock()
+
+	closeRuntimeResource(meteringCloser)
+	closeRuntimeResource(conntrackCloser)
+}
+
+func closeRuntimeResource(resource runtimeResource) {
+	if resource != nil {
+		resource.Close()
 	}
 }
 
@@ -488,6 +570,8 @@ func (d *Daemon) shutdown(ctx context.Context) error {
 			d.logger.Error("Failed to shutdown metrics server", zap.Error(err))
 		}
 	}
+	d.waitForMeteringFlushLoop(ctx)
+	d.closeRuntimeResources()
 	return shutdownErr
 }
 

--- a/netd/pkg/daemon/daemon_lifecycle_test.go
+++ b/netd/pkg/daemon/daemon_lifecycle_test.go
@@ -1,0 +1,58 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	apiconfig "github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
+	"go.uber.org/zap"
+)
+
+type orderedRuntimeResource struct {
+	name   string
+	events chan<- string
+}
+
+func (r *orderedRuntimeResource) Close() {
+	r.events <- r.name
+}
+
+func TestShutdownClosesRuntimeResourcesAfterMeteringLoopStops(t *testing.T) {
+	events := make(chan string, 3)
+	meteringDone := make(chan struct{})
+	d := &Daemon{
+		cfg:    &apiconfig.NetdConfig{},
+		logger: zap.NewNop(),
+	}
+	d.registerRuntimeResources(
+		&orderedRuntimeResource{name: "conntrack", events: events},
+		&orderedRuntimeResource{name: "metering", events: events},
+	)
+	d.runtimeMu.Lock()
+	d.meteringDone = meteringDone
+	d.runtimeMu.Unlock()
+
+	go func() {
+		events <- "flush"
+		close(meteringDone)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := d.shutdown(ctx); err != nil {
+		t.Fatalf("shutdown: %v", err)
+	}
+
+	want := []string{"flush", "metering", "conntrack"}
+	for _, expected := range want {
+		select {
+		case got := <-events:
+			if got != expected {
+				t.Fatalf("event = %q, want %q", got, expected)
+			}
+		default:
+			t.Fatalf("missing event %q", expected)
+		}
+	}
+}


### PR DESCRIPTION
## What changed

- Keep netd runtime resources alive for the full daemon lifetime instead of closing them when `runNetd` returns after the initial redirect sync.
- Wait for the metering flush loop to finish its shutdown flush before closing the metering database pool.
- Keep the conntrack manager open until daemon shutdown and guard cleanup calls when conntrack is unavailable.
- Add a lifecycle unit test that verifies shutdown waits for metering before closing runtime resources.

## Why

`runNetd` is a setup routine: it returns after the first successful sync while netd keeps serving traffic. The previous `defer meteringPool.Close()` and `defer conntrackManager.Close()` ran at that point, leaving the metering flush loop with a closed pgx pool. In remote manual testing this produced repeated `begin transaction: closed pool` / `Failed to flush netd metering windows` logs during normal runtime.

## Validation

- `go test ./netd/pkg/daemon ./netd/pkg/metering`
- Remote Aliyun kind deployment reached `Sandbox0Infra` Ready 9/9 with the patched image.
- Remote manual SSH transparent proxy validation passed: fake key failed before policy, then succeeded with `static_ssh_private_key` + `ssh_proxy` binding.
- Remote netd logs after startup and after SSH traffic did not contain `closed pool` or `Failed to flush netd metering windows`.
