### PR TITLE
Fix Function routing and volume snapshots

### DIFF
--- a/cluster-gateway/pkg/http/server.go
+++ b/cluster-gateway/pkg/http/server.go
@@ -38,6 +38,8 @@ import (
 	"go.uber.org/zap"
 )
 
+const functionVolumeSnapshotTimeout = 2 * time.Minute
+
 // Server represents the HTTP server for cluster-gateway
 type Server struct {
 	router                 *gin.Engine
@@ -244,6 +246,9 @@ func NewServer(
 		meteringRepo = metering.NewRepository(pool)
 	}
 	meteringHandler := gatewayhandlers.NewMeteringHandler(meteringRepo, cfg.RegionID, logger)
+	snapshotHTTPClient := obsProvider.HTTP.NewClient(httpobs.Config{
+		Timeout: functionVolumeSnapshotTimeout,
+	})
 	functionHandler := functionapi.New(
 		functions.NewRepository(pool),
 		functionapi.Config{
@@ -265,6 +270,7 @@ func NewServer(
 			}
 			return sandbox, nil
 		},
+		functionapi.NewHTTPStorageProxyVolumeSnapshotter(cfg.StorageProxyURL, internalAuthGen, snapshotHTTPClient, logger),
 		logger,
 	)
 

--- a/docs/function/page.mdx
+++ b/docs/function/page.mdx
@@ -12,12 +12,12 @@ Functions are created from Sandbox Services, not from uploaded ZIP files or cont
 |--------|-------------|
 | Sandbox Service | A named port, ingress routes, and restartable runtime inside a sandbox |
 | Function | Stable function identity, slug, and fixed domain under `sandbox0.site` |
-| Revision | Immutable snapshot of the source sandbox service plus the SandboxVolume mounts needed to restore it |
+| Revision | Immutable snapshot of the source sandbox service plus snapshots of the SandboxVolume mounts needed to restore it |
 | Alias | Mutable pointer from a name such as `production` to one revision |
 
 Only publishable sandbox services can become function revisions. A service is publishable when it is public and has a restartable runtime.
 
-When the source sandbox was claimed with SandboxVolume mounts, those mount references are captured on the revision. If the source sandbox is later deleted, `function-gateway` claims a new runtime sandbox from the same template, mounts the captured volumes, starts the service runtime, and continues serving the stable function host.
+When the source sandbox was claimed with SandboxVolume mounts, publish creates a snapshot for each mounted volume, immediately materializes revision-owned volumes from those snapshots, and records those volume IDs on the revision. If the source sandbox is later deleted, `function-gateway` claims a new runtime sandbox from the same template, mounts the revision-owned volumes, starts the service runtime, and continues serving the stable function host.
 
 ## Sandbox Services
 
@@ -121,4 +121,4 @@ Move an alias:
 
 Function traffic is handled by `function-gateway` on the fixed function host. The gateway resolves the `production` alias, enforces the revision's service route policy, and proxies to the service port.
 
-If the source sandbox still exists, the gateway resumes it when needed and routes to that sandbox. If the source sandbox has been deleted, the gateway restores a function runtime sandbox from the revision's template and captured mounts, starts the service runtime command or warm process, stores the runtime sandbox/context on the revision, and reuses that runtime until sandbox0 scales it down.
+If the source sandbox still exists, the gateway resumes it when needed and routes to that sandbox. If the source sandbox has been deleted, the gateway restores a function runtime sandbox from the revision's template and revision-owned volumes, starts the service runtime command or warm process, stores the runtime sandbox/context on the revision, and reuses that runtime until sandbox0 scales it down.

--- a/function-gateway/pkg/http/cluster_route.go
+++ b/function-gateway/pkg/http/cluster_route.go
@@ -1,0 +1,102 @@
+package http
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
+	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+	"github.com/sandbox0-ai/sandbox0/pkg/naming"
+)
+
+type schedulerCluster struct {
+	ClusterID         string `json:"cluster_id"`
+	ClusterGatewayURL string `json:"cluster_gateway_url"`
+	Enabled           bool   `json:"enabled"`
+}
+
+type schedulerClusterListResponse struct {
+	Clusters []schedulerCluster `json:"clusters"`
+	Count    int                `json:"count"`
+}
+
+func (s *Server) defaultClusterGatewayURL() string {
+	return strings.TrimRight(strings.TrimSpace(s.cfg.DefaultClusterGatewayURL), "/")
+}
+
+func (s *Server) schedulerURL() string {
+	return strings.TrimRight(strings.TrimSpace(s.cfg.SchedulerURL), "/")
+}
+
+func (s *Server) clusterGatewayURLForSandbox(ctx context.Context, sandboxID string) (string, error) {
+	defaultURL := s.defaultClusterGatewayURL()
+	if s.schedulerURL() == "" {
+		if defaultURL == "" {
+			return "", fmt.Errorf("cluster gateway is not configured")
+		}
+		return defaultURL, nil
+	}
+	parsed, err := naming.ParseSandboxName(sandboxID)
+	if err != nil {
+		if defaultURL == "" {
+			return "", err
+		}
+		return defaultURL, nil
+	}
+	clusters, err := s.listSchedulerClusters(ctx)
+	if err != nil {
+		return "", err
+	}
+	for _, cluster := range clusters {
+		if cluster.Enabled && cluster.ClusterID == parsed.ClusterID && strings.TrimSpace(cluster.ClusterGatewayURL) != "" {
+			return strings.TrimRight(strings.TrimSpace(cluster.ClusterGatewayURL), "/"), nil
+		}
+	}
+	return "", fmt.Errorf("cluster %q not found", parsed.ClusterID)
+}
+
+func (s *Server) listSchedulerClusters(ctx context.Context) ([]schedulerCluster, error) {
+	if s.internalAuthGen == nil {
+		return nil, fmt.Errorf("internal auth generator is not configured")
+	}
+	base, err := url.Parse(s.schedulerURL())
+	if err != nil {
+		return nil, err
+	}
+	base.Path = strings.TrimRight(base.Path, "/") + "/api/v1/clusters"
+	q := base.Query()
+	q.Set("enabled", "true")
+	base.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	token, err := s.internalAuthGen.GenerateSystem(internalauth.ServiceScheduler, internalauth.GenerateOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("generate scheduler token: %w", err)
+	}
+	req.Header.Set(internalauth.DefaultTokenHeader, token)
+	resp, err := s.outboundHTTPClient().Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("list clusters failed: %s", resp.Status)
+	}
+	result, apiErr, err := spec.DecodeResponse[schedulerClusterListResponse](resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if apiErr != nil {
+		return nil, fmt.Errorf("list clusters failed: %s", apiErr.Message)
+	}
+	if result == nil {
+		return nil, nil
+	}
+	return result.Clusters, nil
+}

--- a/function-gateway/pkg/http/handlers_functions.go
+++ b/function-gateway/pkg/http/handlers_functions.go
@@ -14,8 +14,8 @@ import (
 )
 
 func (s *Server) getSandboxFromClusterGateway(ctx context.Context, sandboxID string) (*mgr.Sandbox, error) {
-	clusterGatewayURL := strings.TrimRight(strings.TrimSpace(s.cfg.DefaultClusterGatewayURL), "/")
-	if clusterGatewayURL == "" {
+	clusterGatewayURL, err := s.clusterGatewayURLForSandbox(ctx, sandboxID)
+	if err != nil || clusterGatewayURL == "" {
 		return nil, publishError{status: http.StatusServiceUnavailable, code: spec.CodeUnavailable, message: "cluster gateway is not configured"}
 	}
 

--- a/function-gateway/pkg/http/runtime.go
+++ b/function-gateway/pkg/http/runtime.go
@@ -474,25 +474,35 @@ func isPublishNotFound(err error) bool {
 }
 
 func (s *Server) claimFunctionSandboxViaClusterGateway(ctx context.Context, fn *functions.Function, rev *functions.Revision, service mgr.SandboxAppService) (*mgr.ClaimResponse, error) {
-	clusterGatewayURL := strings.TrimRight(strings.TrimSpace(s.cfg.DefaultClusterGatewayURL), "/")
+	clusterGatewayURL := s.defaultClusterGatewayURL()
+	targetService := internalauth.ServiceClusterGateway
+	requestPath := "/api/v1/sandboxes"
+	if schedulerURL := s.schedulerURL(); schedulerURL != "" {
+		clusterGatewayURL = schedulerURL
+		targetService = internalauth.ServiceScheduler
+	}
 	if clusterGatewayURL == "" {
 		return nil, fmt.Errorf("cluster gateway is not configured")
 	}
 	autoResume := true
 	runtimeService := service
 	runtimeService.Ingress = mgr.SandboxAppServiceIngress{}
+	claimMounts, err := s.claimMountsFromRevision(rev)
+	if err != nil {
+		return nil, err
+	}
 	payload, err := json.Marshal(mgr.ClaimRequest{
 		Template: rev.SourceTemplateID,
 		Config: &mgr.SandboxConfig{
 			AutoResume: &autoResume,
 			Services:   []mgr.SandboxAppService{runtimeService},
 		},
-		Mounts: claimMountsFromRevision(rev.RestoreMounts),
+		Mounts: claimMounts,
 	})
 	if err != nil {
 		return nil, err
 	}
-	token, err := s.internalAuthGen.Generate(internalauth.ServiceClusterGateway, fn.TeamID, rev.CreatedBy, internalauth.GenerateOptions{
+	token, err := s.internalAuthGen.Generate(targetService, fn.TeamID, rev.CreatedBy, internalauth.GenerateOptions{
 		Permissions: []string{
 			authn.PermSandboxCreate,
 			authn.PermSandboxRead,
@@ -504,7 +514,7 @@ func (s *Server) claimFunctionSandboxViaClusterGateway(ctx context.Context, fn *
 	if err != nil {
 		return nil, fmt.Errorf("generate internal token: %w", err)
 	}
-	req, err := nethttp.NewRequestWithContext(ctx, nethttp.MethodPost, clusterGatewayURL+"/api/v1/sandboxes", bytes.NewReader(payload))
+	req, err := nethttp.NewRequestWithContext(ctx, nethttp.MethodPost, clusterGatewayURL+requestPath, bytes.NewReader(payload))
 	if err != nil {
 		return nil, err
 	}
@@ -533,18 +543,27 @@ func (s *Server) claimFunctionSandboxViaClusterGateway(ctx context.Context, fn *
 	return claim, nil
 }
 
-func claimMountsFromRevision(mounts []functions.RestoreMount) []mgr.ClaimMount {
+func (s *Server) claimMountsFromRevision(rev *functions.Revision) ([]mgr.ClaimMount, error) {
+	mounts := rev.RestoreMounts
 	if len(mounts) == 0 {
-		return nil
+		return nil, nil
 	}
 	out := make([]mgr.ClaimMount, 0, len(mounts))
 	for _, mount := range mounts {
+		volumeID := strings.TrimSpace(mount.SandboxVolumeID)
+		mountPoint := strings.TrimSpace(mount.MountPoint)
+		if volumeID == "" {
+			return nil, fmt.Errorf("function revision restore mount is missing sandbox volume id")
+		}
+		if mountPoint == "" {
+			return nil, fmt.Errorf("function revision restore mount is missing mount point")
+		}
 		out = append(out, mgr.ClaimMount{
-			SandboxVolumeID: strings.TrimSpace(mount.SandboxVolumeID),
-			MountPoint:      strings.TrimSpace(mount.MountPoint),
+			SandboxVolumeID: volumeID,
+			MountPoint:      mountPoint,
 		})
 	}
-	return out
+	return out, nil
 }
 
 func (s *Server) ensureFunctionServiceRuntime(ctx context.Context, fn *functions.Function, rev *functions.Revision, sandbox *mgr.Sandbox, service mgr.SandboxAppService) (string, error) {
@@ -670,8 +689,8 @@ func decodeFunctionContextResponse(r io.Reader) (*functionContextResponse, error
 }
 
 func (s *Server) doFunctionRuntimeContextRequest(ctx context.Context, method, sandboxID, teamID, userID, contextID string, body io.Reader) (*nethttp.Response, error) {
-	clusterGatewayURL := strings.TrimRight(strings.TrimSpace(s.cfg.DefaultClusterGatewayURL), "/")
-	if clusterGatewayURL == "" {
+	clusterGatewayURL, err := s.clusterGatewayURLForSandbox(ctx, sandboxID)
+	if err != nil || clusterGatewayURL == "" {
 		return nil, fmt.Errorf("cluster gateway is not configured")
 	}
 	token, err := s.internalAuthGen.Generate(internalauth.ServiceClusterGateway, teamID, userID, internalauth.GenerateOptions{
@@ -717,8 +736,8 @@ func (s *Server) deleteFunctionRuntimeSandboxBestEffort(fn *functions.Function, 
 }
 
 func (s *Server) deleteSandboxViaClusterGateway(ctx context.Context, sandboxID, teamID, userID string) error {
-	clusterGatewayURL := strings.TrimRight(strings.TrimSpace(s.cfg.DefaultClusterGatewayURL), "/")
-	if clusterGatewayURL == "" {
+	clusterGatewayURL, err := s.clusterGatewayURLForSandbox(ctx, sandboxID)
+	if err != nil || clusterGatewayURL == "" {
 		return fmt.Errorf("cluster gateway is not configured")
 	}
 	if s.internalAuthGen == nil {
@@ -783,8 +802,8 @@ func waitForFunctionServicePort(ctx context.Context, internalAddr string, port i
 }
 
 func (s *Server) resumeSandboxViaClusterGateway(ctx context.Context, sandboxID, teamID, userID string) error {
-	clusterGatewayURL := strings.TrimRight(strings.TrimSpace(s.cfg.DefaultClusterGatewayURL), "/")
-	if clusterGatewayURL == "" {
+	clusterGatewayURL, err := s.clusterGatewayURLForSandbox(ctx, sandboxID)
+	if err != nil || clusterGatewayURL == "" {
 		return fmt.Errorf("cluster gateway is not configured")
 	}
 	token, err := s.internalAuthGen.Generate(internalauth.ServiceClusterGateway, teamID, userID, internalauth.GenerateOptions{})

--- a/function-gateway/pkg/http/runtime_test.go
+++ b/function-gateway/pkg/http/runtime_test.go
@@ -105,6 +105,40 @@ func TestDecodeFunctionContextResponseAcceptsRawContextBody(t *testing.T) {
 	}
 }
 
+func TestClaimMountsFromRevisionUsesPreparedVolume(t *testing.T) {
+	server := &Server{}
+	mounts, err := server.claimMountsFromRevision(&functions.Revision{
+		RestoreMounts: []functions.RestoreMount{{
+			SandboxVolumeID:       "revision-volume",
+			SourceSandboxVolumeID: "source-volume",
+			SnapshotID:            "snapshot-1",
+			MountPoint:            "/workspace/data",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("claimMountsFromRevision() error = %v", err)
+	}
+	if len(mounts) != 1 {
+		t.Fatalf("mount count = %d, want 1", len(mounts))
+	}
+	if mounts[0].SandboxVolumeID != "revision-volume" || mounts[0].MountPoint != "/workspace/data" {
+		t.Fatalf("mount = %+v, want prepared revision volume", mounts[0])
+	}
+}
+
+func TestClaimMountsFromRevisionRequiresPreparedVolume(t *testing.T) {
+	server := &Server{}
+	_, err := server.claimMountsFromRevision(&functions.Revision{
+		RestoreMounts: []functions.RestoreMount{{
+			SnapshotID: "snapshot-1",
+			MountPoint: "/workspace/data",
+		}},
+	})
+	if err == nil {
+		t.Fatal("claimMountsFromRevision() error = nil, want missing volume error")
+	}
+}
+
 func TestFunctionDomainAPIRouteUsesFunctionDispatch(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/infra-operator/api/config/function_gateway.go
+++ b/infra-operator/api/config/function_gateway.go
@@ -33,6 +33,9 @@ type FunctionGatewayConfig struct {
 	// DefaultClusterGatewayURL is used to read source sandboxes from the region's
 	// data plane. Scheduler-aware cluster routing can replace this later.
 	DefaultClusterGatewayURL string `yaml:"default_cluster_gateway_url" json:"-"`
+	// SchedulerURL enables scheduler-aware routing for multi-cluster function runtime operations.
+	// +optional
+	SchedulerURL string `yaml:"scheduler_url" json:"-"`
 
 	// FunctionRootDomain is the DNS root for function hosts.
 	// +optional

--- a/infra-operator/internal/controller/services/functiongateway/functiongateway.go
+++ b/infra-operator/internal/controller/services/functiongateway/functiongateway.go
@@ -218,6 +218,9 @@ func (r *Reconciler) buildConfig(ctx context.Context, compiledPlan *infraplan.In
 		cfg.DatabaseURL = dsn
 	}
 	cfg.DefaultClusterGatewayURL = compiledPlan.FunctionGateway.DefaultClusterGatewayURL
+	if compiledPlan.Components.EnableScheduler {
+		cfg.SchedulerURL = compiledPlan.Services.Scheduler.URL
+	}
 	if strings.TrimSpace(cfg.InternalAuthCaller) == "" {
 		cfg.InternalAuthCaller = pkginternalauth.ServiceFunctionGateway
 	}

--- a/infra-operator/internal/plan/plan.go
+++ b/infra-operator/internal/plan/plan.go
@@ -700,11 +700,11 @@ func compileFunctionGatewayPlan(infra *infrav1alpha1.Sandbox0Infra, compiled *In
 	if svc.Config != nil {
 		plan.Config = runtimeconfig.ToFunctionGateway(svc.Config)
 	}
-	compileFunctionGatewayRuntimeConfig(&plan, infra)
+	compileFunctionGatewayRuntimeConfig(&plan, infra, compiled)
 	return plan
 }
 
-func compileFunctionGatewayRuntimeConfig(plan *FunctionGatewayPlan, infra *infrav1alpha1.Sandbox0Infra) {
+func compileFunctionGatewayRuntimeConfig(plan *FunctionGatewayPlan, infra *infrav1alpha1.Sandbox0Infra, compiled *InfraPlan) {
 	if plan == nil || infra == nil {
 		return
 	}
@@ -714,6 +714,9 @@ func compileFunctionGatewayRuntimeConfig(plan *FunctionGatewayPlan, infra *infra
 		plan.Config = cfg
 	}
 	cfg.DefaultClusterGatewayURL = plan.DefaultClusterGatewayURL
+	if compiled != nil && compiled.Components.EnableScheduler {
+		cfg.SchedulerURL = compiled.Services.Scheduler.URL
+	}
 	if cfg.HTTPPort == 0 {
 		cfg.HTTPPort = functionGatewayHTTPPort(infra)
 	}

--- a/manager/pkg/controller/pool_manager.go
+++ b/manager/pkg/controller/pool_manager.go
@@ -26,9 +26,10 @@ import (
 
 const (
 	// Labels
-	LabelTemplateID = "sandbox0.ai/template-id"
-	LabelPoolType   = "sandbox0.ai/pool-type"
-	LabelSandboxID  = "sandbox0.ai/sandbox-id"
+	LabelTemplateID        = "sandbox0.ai/template-id"
+	LabelTemplateLogicalID = "sandbox0.ai/template-logical-id"
+	LabelPoolType          = "sandbox0.ai/pool-type"
+	LabelSandboxID         = "sandbox0.ai/sandbox-id"
 
 	// Pool types
 	PoolTypeIdle   = "idle"
@@ -61,6 +62,18 @@ const (
 
 	unhealthyIdlePodRepairGracePeriod = 2 * time.Minute
 )
+
+func TemplateLogicalID(template *v1alpha1.SandboxTemplate) string {
+	if template == nil {
+		return ""
+	}
+	if template.Labels != nil {
+		if logicalID := template.Labels[LabelTemplateLogicalID]; logicalID != "" {
+			return logicalID
+		}
+	}
+	return template.Name
+}
 
 // ClaimedSandboxPodAnnotations returns manager-owned metadata for active sandbox
 // pods. Idle pool pods intentionally do not carry these annotations.
@@ -300,8 +313,9 @@ func (pm *PoolManager) buildPodTemplate(template *v1alpha1.SandboxTemplate, spec
 	return corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				LabelTemplateID: template.Name,
-				LabelPoolType:   PoolTypeIdle,
+				LabelTemplateID:        template.Name,
+				LabelTemplateLogicalID: TemplateLogicalID(template),
+				LabelPoolType:          PoolTypeIdle,
 			},
 			Annotations: annotations,
 		},

--- a/manager/pkg/controller/pool_manager_test.go
+++ b/manager/pkg/controller/pool_manager_test.go
@@ -32,6 +32,9 @@ func TestBuildPodTemplateIncludesTemplateHash(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "template-a",
 			Namespace: "default",
+			Labels: map[string]string{
+				LabelTemplateLogicalID: "logical-a",
+			},
 		},
 	}
 
@@ -41,6 +44,8 @@ func TestBuildPodTemplateIncludesTemplateHash(t *testing.T) {
 	assert.Equal(t, "hash-v1", got.Annotations[AnnotationTemplateSpecHash])
 	assert.NotContains(t, got.Annotations, AnnotationClusterAutoscalerSafeToEvict)
 	assert.Equal(t, PoolTypeIdle, got.Labels[LabelPoolType])
+	assert.Equal(t, "template-a", got.Labels[LabelTemplateID])
+	assert.Equal(t, "logical-a", got.Labels[LabelTemplateLogicalID])
 }
 
 func TestDrainStaleIdlePodsUsesDeletePreconditions(t *testing.T) {

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -921,9 +921,10 @@ func (s *SandboxService) createNewPod(ctx context.Context, template *v1alpha1.Sa
 				sandboxCleanupFinalizer,
 			},
 			Labels: map[string]string{
-				controller.LabelTemplateID: template.Name,
-				controller.LabelPoolType:   controller.PoolTypeActive,
-				controller.LabelSandboxID:  podName,
+				controller.LabelTemplateID:        template.Name,
+				controller.LabelTemplateLogicalID: controller.TemplateLogicalID(template),
+				controller.LabelPoolType:          controller.PoolTypeActive,
+				controller.LabelSandboxID:         podName,
 			},
 			Annotations: annotations,
 		},

--- a/manager/pkg/service/sandbox_service_lifecycle.go
+++ b/manager/pkg/service/sandbox_service_lifecycle.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
@@ -244,7 +245,7 @@ func (s *SandboxService) podToSandbox(ctx context.Context, pod *corev1.Pod, sand
 
 	return &Sandbox{
 		ID:            sandboxID,
-		TemplateID:    pod.Labels[controller.LabelTemplateID],
+		TemplateID:    sandboxTemplateIDFromLabels(pod.Labels),
 		TeamID:        pod.Annotations[controller.AnnotationTeamID],
 		UserID:        pod.Annotations[controller.AnnotationUserID],
 		InternalAddr:  internalAddr,
@@ -260,6 +261,16 @@ func (s *SandboxService) podToSandbox(ctx context.Context, pod *corev1.Pod, sand
 		ClaimedAt:     claimedAt,
 		CreatedAt:     createdAt,
 	}
+}
+
+func sandboxTemplateIDFromLabels(labels map[string]string) string {
+	if labels == nil {
+		return ""
+	}
+	if logicalID := strings.TrimSpace(labels[controller.LabelTemplateLogicalID]); logicalID != "" {
+		return logicalID
+	}
+	return labels[controller.LabelTemplateID]
 }
 
 func parseRFC3339AnnotationTime(annotations map[string]string, key string) time.Time {

--- a/manager/pkg/service/sandbox_service_list.go
+++ b/manager/pkg/service/sandbox_service_list.go
@@ -82,7 +82,7 @@ func (s *SandboxService) ListSandboxes(ctx context.Context, req *ListSandboxesRe
 		}
 
 		// Filter by template_id if specified
-		templateID := pod.Labels[controller.LabelTemplateID]
+		templateID := sandboxTemplateIDFromLabels(pod.Labels)
 		if req.TemplateID != "" && templateID != req.TemplateID {
 			continue
 		}

--- a/manager/pkg/service/sandbox_service_power_state_test.go
+++ b/manager/pkg/service/sandbox_service_power_state_test.go
@@ -165,7 +165,8 @@ func TestPodToSandboxIncludesPowerState(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "sandbox-1",
 			Labels: map[string]string{
-				controller.LabelTemplateID: "template-1",
+				controller.LabelTemplateID:        "t-team-template-1",
+				controller.LabelTemplateLogicalID: "template-1",
 			},
 			Annotations: map[string]string{
 				controller.AnnotationTeamID:                       "team-1",
@@ -192,6 +193,7 @@ func TestPodToSandboxIncludesPowerState(t *testing.T) {
 	assert.Equal(t, int64(3), sandbox.PowerState.ObservedGeneration)
 	assert.Equal(t, SandboxPowerPhaseResuming, sandbox.PowerState.Phase)
 	assert.True(t, sandbox.Paused)
+	assert.Equal(t, "template-1", sandbox.TemplateID)
 }
 
 func TestRequestPauseSandboxRecordsDesiredPausedState(t *testing.T) {

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -4026,6 +4026,13 @@ components:
       properties:
         sandboxvolume_id:
           type: string
+          description: Revision-owned SandboxVolume prepared when the function revision was published.
+        source_sandboxvolume_id:
+          type: string
+          description: Source SandboxVolume captured when the function revision was published.
+        snapshot_id:
+          type: string
+          description: Immutable source volume snapshot captured for this function revision.
         mount_point:
           type: string
       required: [sandboxvolume_id, mount_point]
@@ -5006,6 +5013,9 @@ components:
     CreateSandboxVolumeRequest:
       type: object
       properties:
+        snapshot_id:
+          type: string
+          description: Optional snapshot ID used to initialize the new volume from immutable snapshot state.
         default_posix_uid:
           type: integer
           format: int64

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -725,6 +725,9 @@ type CreateSandboxVolumeRequest struct {
 
 	// DefaultPosixUid Default POSIX UID used by external volume access paths that do not carry caller identity. Defaults to 0 when omitted on create.
 	DefaultPosixUid *int64 `json:"default_posix_uid,omitempty"`
+
+	// SnapshotId Optional snapshot ID used to initialize the new volume from immutable snapshot state.
+	SnapshotId *string `json:"snapshot_id,omitempty"`
 }
 
 // CreateSnapshotRequest defines model for CreateSnapshotRequest.
@@ -977,8 +980,16 @@ type FunctionRecord struct {
 
 // FunctionRestoreMount defines model for FunctionRestoreMount.
 type FunctionRestoreMount struct {
-	MountPoint      string `json:"mount_point"`
+	MountPoint string `json:"mount_point"`
+
+	// SandboxvolumeId Revision-owned SandboxVolume prepared when the function revision was published.
 	SandboxvolumeId string `json:"sandboxvolume_id"`
+
+	// SnapshotId Immutable source volume snapshot captured for this function revision.
+	SnapshotId *string `json:"snapshot_id,omitempty"`
+
+	// SourceSandboxvolumeId Source SandboxVolume captured when the function revision was published.
+	SourceSandboxvolumeId *string `json:"source_sandboxvolume_id,omitempty"`
 }
 
 // FunctionRevision defines model for FunctionRevision.

--- a/pkg/gateway/functionapi/handler.go
+++ b/pkg/gateway/functionapi/handler.go
@@ -31,16 +31,22 @@ type Config struct {
 
 type SandboxLookup func(ctx context.Context, sandboxID string) (*mgr.Sandbox, error)
 
+type RevisionVolumeStore interface {
+	PrepareRestoreMounts(ctx context.Context, authCtx *authn.AuthContext, sandbox *mgr.Sandbox) ([]functions.RestoreMount, error)
+	DeleteRestoreMounts(ctx context.Context, authCtx *authn.AuthContext, sandbox *mgr.Sandbox, mounts []functions.RestoreMount) error
+}
+
 type PermissionMiddleware func(permission string) gin.HandlerFunc
 
 type Handler struct {
 	repo          *functions.Repository
 	cfg           Config
 	sandboxLookup SandboxLookup
+	volumeStore   RevisionVolumeStore
 	logger        *zap.Logger
 }
 
-func New(repo *functions.Repository, cfg Config, lookup SandboxLookup, logger *zap.Logger) *Handler {
+func New(repo *functions.Repository, cfg Config, lookup SandboxLookup, volumeStore RevisionVolumeStore, logger *zap.Logger) *Handler {
 	if logger == nil {
 		logger = zap.NewNop()
 	}
@@ -48,6 +54,7 @@ func New(repo *functions.Repository, cfg Config, lookup SandboxLookup, logger *z
 		repo:          repo,
 		cfg:           cfg,
 		sandboxLookup: lookup,
+		volumeStore:   volumeStore,
 		logger:        logger,
 	}
 }
@@ -202,7 +209,18 @@ func (h *Handler) createFunction(c *gin.Context) {
 
 	userID := principalID(authCtx)
 	fn := functions.NewFunction(authCtx.TeamID, name, userID)
-	rev, err := functions.NewRevision(authCtx.TeamID, sandbox.ID, serviceSnapshot.ID, sandbox.TemplateID, serviceSnapshot, restoreMountsFromSandbox(sandbox), userID)
+	restoreMounts, err := h.prepareRestoreMounts(c.Request.Context(), authCtx, sandbox)
+	if err != nil {
+		h.writePublishError(c, err)
+		return
+	}
+	cleanupRestoreMounts := true
+	defer func() {
+		if cleanupRestoreMounts {
+			h.deletePreparedRestoreMounts(context.Background(), authCtx, sandbox, restoreMounts, "function create failed")
+		}
+	}()
+	rev, err := functions.NewRevision(authCtx.TeamID, sandbox.ID, serviceSnapshot.ID, sandbox.TemplateID, serviceSnapshot, restoreMounts, userID)
 	if err != nil {
 		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to create revision snapshot")
 		return
@@ -218,6 +236,7 @@ func (h *Handler) createFunction(c *gin.Context) {
 		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to create function")
 		return
 	}
+	cleanupRestoreMounts = false
 
 	spec.JSONSuccess(c, http.StatusCreated, gin.H{
 		"function": h.functionRecord(fn),
@@ -276,7 +295,18 @@ func (h *Handler) createFunctionRevision(c *gin.Context) {
 	}
 
 	userID := principalID(authCtx)
-	rev, err := functions.NewRevision(authCtx.TeamID, sandbox.ID, serviceSnapshot.ID, sandbox.TemplateID, serviceSnapshot, restoreMountsFromSandbox(sandbox), userID)
+	restoreMounts, err := h.prepareRestoreMounts(c.Request.Context(), authCtx, sandbox)
+	if err != nil {
+		h.writePublishError(c, err)
+		return
+	}
+	cleanupRestoreMounts := true
+	defer func() {
+		if cleanupRestoreMounts {
+			h.deletePreparedRestoreMounts(context.Background(), authCtx, sandbox, restoreMounts, "revision create failed")
+		}
+	}()
+	rev, err := functions.NewRevision(authCtx.TeamID, sandbox.ID, serviceSnapshot.ID, sandbox.TemplateID, serviceSnapshot, restoreMounts, userID)
 	if err != nil {
 		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to create revision snapshot")
 		return
@@ -295,6 +325,7 @@ func (h *Handler) createFunctionRevision(c *gin.Context) {
 		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to create revision")
 		return
 	}
+	cleanupRestoreMounts = false
 	spec.JSONSuccess(c, http.StatusCreated, gin.H{"revision": rev, "promoted": promote})
 }
 
@@ -374,18 +405,35 @@ func findSandboxService(sandbox *mgr.Sandbox, serviceID string) (mgr.SandboxAppS
 	return mgr.SandboxAppService{}, false
 }
 
-func restoreMountsFromSandbox(sandbox *mgr.Sandbox) []functions.RestoreMount {
+func (h *Handler) prepareRestoreMounts(ctx context.Context, authCtx *authn.AuthContext, sandbox *mgr.Sandbox) ([]functions.RestoreMount, error) {
 	if sandbox == nil || len(sandbox.Mounts) == 0 {
-		return nil
+		return nil, nil
 	}
-	mounts := make([]functions.RestoreMount, 0, len(sandbox.Mounts))
-	for _, mount := range sandbox.Mounts {
-		mounts = append(mounts, functions.RestoreMount{
-			SandboxVolumeID: strings.TrimSpace(mount.SandboxVolumeID),
-			MountPoint:      strings.TrimSpace(mount.MountPoint),
-		})
+	if h.volumeStore == nil {
+		return nil, publishError{status: http.StatusServiceUnavailable, code: spec.CodeUnavailable, message: "function revision volume store is not configured"}
 	}
-	return mounts
+	mounts, err := h.volumeStore.PrepareRestoreMounts(ctx, authCtx, sandbox)
+	if err != nil {
+		h.logger.Warn("Failed to prepare function restore mounts",
+			zap.String("sandbox_id", sandbox.ID),
+			zap.Error(err),
+		)
+		return nil, publishError{status: http.StatusServiceUnavailable, code: spec.CodeUnavailable, message: "failed to prepare function volumes"}
+	}
+	return mounts, nil
+}
+
+func (h *Handler) deletePreparedRestoreMounts(ctx context.Context, authCtx *authn.AuthContext, sandbox *mgr.Sandbox, mounts []functions.RestoreMount, reason string) {
+	if h == nil || h.volumeStore == nil || len(mounts) == 0 {
+		return
+	}
+	if err := h.volumeStore.DeleteRestoreMounts(ctx, authCtx, sandbox, mounts); err != nil {
+		h.logger.Warn("Failed to clean up prepared function restore mounts",
+			zap.String("sandbox_id", sandbox.ID),
+			zap.String("reason", reason),
+			zap.Error(err),
+		)
+	}
 }
 
 func (h *Handler) functionRecord(fn *functions.Function) functionRecord {

--- a/pkg/gateway/functionapi/snapshotter.go
+++ b/pkg/gateway/functionapi/snapshotter.go
@@ -1,0 +1,303 @@
+package functionapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	mgr "github.com/sandbox0-ai/sandbox0/manager/pkg/service"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/authn"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/functions"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
+	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+	"go.uber.org/zap"
+)
+
+type ClusterGatewayURLResolver func(ctx context.Context, sandboxID string) (string, error)
+
+type HTTPVolumeSnapshotter struct {
+	resolveClusterGatewayURL ClusterGatewayURLResolver
+	internalAuthGen          *internalauth.Generator
+	httpClient               *http.Client
+	targetService            string
+	pathPrefix               string
+	logger                   *zap.Logger
+}
+
+type volumeSnapshotResponse struct {
+	ID       string `json:"id"`
+	VolumeID string `json:"volume_id"`
+}
+
+type sandboxVolumeResponse struct {
+	ID string `json:"id"`
+}
+
+func NewHTTPVolumeSnapshotter(resolve ClusterGatewayURLResolver, internalAuthGen *internalauth.Generator, httpClient *http.Client, logger *zap.Logger) *HTTPVolumeSnapshotter {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	return &HTTPVolumeSnapshotter{
+		resolveClusterGatewayURL: resolve,
+		internalAuthGen:          internalAuthGen,
+		httpClient:               httpClient,
+		targetService:            internalauth.ServiceClusterGateway,
+		pathPrefix:               "/api/v1",
+		logger:                   logger,
+	}
+}
+
+func NewHTTPStorageProxyVolumeSnapshotter(storageProxyURL string, internalAuthGen *internalauth.Generator, httpClient *http.Client, logger *zap.Logger) *HTTPVolumeSnapshotter {
+	s := NewHTTPVolumeSnapshotter(StaticClusterGatewayURLResolver(storageProxyURL), internalAuthGen, httpClient, logger)
+	s.targetService = internalauth.ServiceStorageProxy
+	s.pathPrefix = ""
+	return s
+}
+
+func StaticClusterGatewayURLResolver(clusterGatewayURL string) ClusterGatewayURLResolver {
+	return func(context.Context, string) (string, error) {
+		clusterGatewayURL := strings.TrimRight(strings.TrimSpace(clusterGatewayURL), "/")
+		if clusterGatewayURL == "" {
+			return "", fmt.Errorf("cluster gateway is not configured")
+		}
+		return clusterGatewayURL, nil
+	}
+}
+
+func (s *HTTPVolumeSnapshotter) PrepareRestoreMounts(ctx context.Context, authCtx *authn.AuthContext, sandbox *mgr.Sandbox) ([]functions.RestoreMount, error) {
+	if sandbox == nil || len(sandbox.Mounts) == 0 {
+		return nil, nil
+	}
+	if s == nil || s.resolveClusterGatewayURL == nil {
+		return nil, fmt.Errorf("volume snapshotter is not configured")
+	}
+	clusterGatewayURL, err := s.resolveClusterGatewayURL(ctx, sandbox.ID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]functions.RestoreMount, 0, len(sandbox.Mounts))
+	for _, mount := range sandbox.Mounts {
+		volumeID := strings.TrimSpace(mount.SandboxVolumeID)
+		mountPoint := strings.TrimSpace(mount.MountPoint)
+		if volumeID == "" || mountPoint == "" {
+			continue
+		}
+		snapshotID, err := s.createSnapshot(ctx, clusterGatewayURL, authCtx, volumeID, sandbox.ID)
+		if err != nil {
+			_ = s.DeleteRestoreMounts(context.Background(), authCtx, sandbox, out)
+			return nil, err
+		}
+		revisionVolumeID, err := s.createVolumeFromSnapshot(ctx, clusterGatewayURL, authCtx, snapshotID)
+		if err != nil {
+			_ = s.DeleteRestoreMounts(context.Background(), authCtx, sandbox, out)
+			return nil, err
+		}
+		out = append(out, functions.RestoreMount{
+			SandboxVolumeID:       revisionVolumeID,
+			SourceSandboxVolumeID: volumeID,
+			SnapshotID:            snapshotID,
+			MountPoint:            mountPoint,
+		})
+	}
+	return out, nil
+}
+
+func (s *HTTPVolumeSnapshotter) DeleteRestoreMounts(ctx context.Context, authCtx *authn.AuthContext, sandbox *mgr.Sandbox, mounts []functions.RestoreMount) error {
+	if len(mounts) == 0 {
+		return nil
+	}
+	if s == nil || s.resolveClusterGatewayURL == nil {
+		return fmt.Errorf("volume snapshotter is not configured")
+	}
+	sandboxID := ""
+	if sandbox != nil {
+		sandboxID = sandbox.ID
+	}
+	clusterGatewayURL, err := s.resolveClusterGatewayURL(ctx, sandboxID)
+	if err != nil {
+		return err
+	}
+	var firstErr error
+	for _, mount := range mounts {
+		volumeID := strings.TrimSpace(mount.SandboxVolumeID)
+		if volumeID == "" {
+			continue
+		}
+		if err := s.deleteVolume(ctx, clusterGatewayURL, authCtx, volumeID); err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			s.logger.Warn("Function revision volume cleanup failed",
+				zap.String("volume_id", volumeID),
+				zap.Error(err),
+			)
+		}
+	}
+	return firstErr
+}
+
+func (s *HTTPVolumeSnapshotter) createSnapshot(ctx context.Context, clusterGatewayURL string, authCtx *authn.AuthContext, volumeID, sandboxID string) (string, error) {
+	if s.internalAuthGen == nil {
+		return "", fmt.Errorf("internal auth generator is not configured")
+	}
+	teamID := ""
+	userID := ""
+	permissions := []string{authn.PermSandboxVolumeCreate, authn.PermSandboxVolumeRead, authn.PermSandboxVolumeWrite}
+	if authCtx != nil {
+		teamID = authCtx.TeamID
+		userID = principalID(authCtx)
+	}
+	payload, err := json.Marshal(map[string]string{
+		"name":        "function-" + strings.TrimSpace(sandboxID),
+		"description": "Function revision volume snapshot",
+	})
+	if err != nil {
+		return "", err
+	}
+	targetService := s.targetService
+	if targetService == "" {
+		targetService = internalauth.ServiceClusterGateway
+	}
+	token, err := s.internalAuthGen.Generate(targetService, teamID, userID, internalauth.GenerateOptions{Permissions: permissions})
+	if err != nil {
+		return "", fmt.Errorf("generate internal token: %w", err)
+	}
+	pathPrefix := strings.TrimRight(s.pathPrefix, "/")
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimRight(clusterGatewayURL, "/")+pathPrefix+"/sandboxvolumes/"+url.PathEscape(volumeID)+"/snapshots", bytes.NewReader(payload))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set(internalauth.DefaultTokenHeader, token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		s.logger.Warn("Function volume snapshot failed",
+			zap.String("volume_id", volumeID),
+			zap.Int("status", resp.StatusCode),
+			zap.String("body", strings.TrimSpace(string(body))),
+		)
+		return "", fmt.Errorf("snapshot volume %s: %s", volumeID, resp.Status)
+	}
+	snapshot, apiErr, err := spec.DecodeResponse[volumeSnapshotResponse](resp.Body)
+	if err != nil {
+		return "", err
+	}
+	if apiErr != nil {
+		return "", fmt.Errorf("snapshot volume %s: %s", volumeID, apiErr.Message)
+	}
+	if snapshot == nil || strings.TrimSpace(snapshot.ID) == "" {
+		return "", fmt.Errorf("snapshot volume %s: empty snapshot id", volumeID)
+	}
+	return strings.TrimSpace(snapshot.ID), nil
+}
+
+func (s *HTTPVolumeSnapshotter) createVolumeFromSnapshot(ctx context.Context, clusterGatewayURL string, authCtx *authn.AuthContext, snapshotID string) (string, error) {
+	if s.internalAuthGen == nil {
+		return "", fmt.Errorf("internal auth generator is not configured")
+	}
+	teamID := ""
+	userID := ""
+	if authCtx != nil {
+		teamID = authCtx.TeamID
+		userID = principalID(authCtx)
+	}
+	payload, err := json.Marshal(map[string]string{
+		"snapshot_id": strings.TrimSpace(snapshotID),
+	})
+	if err != nil {
+		return "", err
+	}
+	targetService := s.targetService
+	if targetService == "" {
+		targetService = internalauth.ServiceClusterGateway
+	}
+	token, err := s.internalAuthGen.Generate(targetService, teamID, userID, internalauth.GenerateOptions{
+		Permissions: []string{authn.PermSandboxVolumeCreate, authn.PermSandboxVolumeRead, authn.PermSandboxVolumeWrite},
+	})
+	if err != nil {
+		return "", fmt.Errorf("generate internal token: %w", err)
+	}
+	pathPrefix := strings.TrimRight(s.pathPrefix, "/")
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimRight(clusterGatewayURL, "/")+pathPrefix+"/sandboxvolumes", bytes.NewReader(payload))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set(internalauth.DefaultTokenHeader, token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		s.logger.Warn("Function revision volume materialization failed",
+			zap.String("snapshot_id", snapshotID),
+			zap.Int("status", resp.StatusCode),
+			zap.String("body", strings.TrimSpace(string(body))),
+		)
+		return "", fmt.Errorf("create volume from snapshot %s: %s", snapshotID, resp.Status)
+	}
+	volume, apiErr, err := spec.DecodeResponse[sandboxVolumeResponse](resp.Body)
+	if err != nil {
+		return "", err
+	}
+	if apiErr != nil {
+		return "", fmt.Errorf("create volume from snapshot %s: %s", snapshotID, apiErr.Message)
+	}
+	if volume == nil || strings.TrimSpace(volume.ID) == "" {
+		return "", fmt.Errorf("create volume from snapshot %s: empty volume id", snapshotID)
+	}
+	return strings.TrimSpace(volume.ID), nil
+}
+
+func (s *HTTPVolumeSnapshotter) deleteVolume(ctx context.Context, clusterGatewayURL string, authCtx *authn.AuthContext, volumeID string) error {
+	if s.internalAuthGen == nil {
+		return fmt.Errorf("internal auth generator is not configured")
+	}
+	teamID := ""
+	userID := ""
+	if authCtx != nil {
+		teamID = authCtx.TeamID
+		userID = principalID(authCtx)
+	}
+	targetService := s.targetService
+	if targetService == "" {
+		targetService = internalauth.ServiceClusterGateway
+	}
+	token, err := s.internalAuthGen.Generate(targetService, teamID, userID, internalauth.GenerateOptions{
+		Permissions: []string{authn.PermSandboxVolumeDelete, authn.PermSandboxVolumeRead},
+	})
+	if err != nil {
+		return fmt.Errorf("generate internal token: %w", err)
+	}
+	pathPrefix := strings.TrimRight(s.pathPrefix, "/")
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, strings.TrimRight(clusterGatewayURL, "/")+pathPrefix+"/sandboxvolumes/"+url.PathEscape(volumeID), nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set(internalauth.DefaultTokenHeader, token)
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound || (resp.StatusCode >= 200 && resp.StatusCode < 300) {
+		return nil
+	}
+	body, _ := io.ReadAll(resp.Body)
+	return fmt.Errorf("delete volume %s: %s: %s", volumeID, resp.Status, strings.TrimSpace(string(body)))
+}

--- a/pkg/gateway/functions/models.go
+++ b/pkg/gateway/functions/models.go
@@ -37,8 +37,10 @@ type Revision struct {
 }
 
 type RestoreMount struct {
-	SandboxVolumeID string `json:"sandboxvolume_id"`
-	MountPoint      string `json:"mount_point"`
+	SandboxVolumeID       string `json:"sandboxvolume_id"`
+	SourceSandboxVolumeID string `json:"source_sandboxvolume_id,omitempty"`
+	SnapshotID            string `json:"snapshot_id,omitempty"`
+	MountPoint            string `json:"mount_point"`
 }
 
 type Alias struct {

--- a/regional-gateway/pkg/http/function_lookup.go
+++ b/regional-gateway/pkg/http/function_lookup.go
@@ -1,0 +1,78 @@
+package http
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	mgr "github.com/sandbox0-ai/sandbox0/manager/pkg/service"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/functionapi"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
+	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+	"github.com/sandbox0-ai/sandbox0/pkg/naming"
+	"go.uber.org/zap"
+)
+
+func (s *Server) resolveFunctionClusterGatewayURL(ctx context.Context, sandboxID string) (string, error) {
+	if s.schedulerRouter == nil {
+		return strings.TrimRight(strings.TrimSpace(s.cfg.DefaultClusterGatewayURL), "/"), nil
+	}
+	parsed, err := naming.ParseSandboxName(sandboxID)
+	if err != nil {
+		return "", err
+	}
+	return s.getClusterGatewayURLForCluster(ctx, parsed.ClusterID, nil)
+}
+
+func (s *Server) functionSandboxLookup(ctx context.Context, sandboxID string) (*mgr.Sandbox, error) {
+	clusterGatewayURL, err := s.resolveFunctionClusterGatewayURL(ctx, sandboxID)
+	if err != nil {
+		return nil, functionapi.SandboxNotFoundError()
+	}
+	clusterGatewayURL = strings.TrimRight(strings.TrimSpace(clusterGatewayURL), "/")
+	if clusterGatewayURL == "" {
+		return nil, functionapi.SandboxUnavailableError("cluster gateway is not configured")
+	}
+	if s.internalAuthGen == nil {
+		return nil, functionapi.SandboxUnavailableError("internal auth generator is not configured")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, clusterGatewayURL+"/internal/v1/sandboxes/"+url.PathEscape(sandboxID), nil)
+	if err != nil {
+		return nil, functionapi.SandboxUnavailableError("failed to create cluster gateway request")
+	}
+	token, err := s.internalAuthGen.GenerateSystem(internalauth.ServiceClusterGateway, internalauth.GenerateOptions{})
+	if err != nil {
+		return nil, functionapi.SandboxUnavailableError("failed to generate internal token")
+	}
+	req.Header.Set(internalauth.DefaultTokenHeader, token)
+	resp, err := s.outboundHTTPClient().Do(req)
+	if err != nil {
+		return nil, functionapi.SandboxUnavailableError("cluster gateway unavailable")
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, functionapi.SandboxNotFoundError()
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		s.logger.Warn("Function sandbox lookup failed",
+			zap.String("sandbox_id", sandboxID),
+			zap.Int("status", resp.StatusCode),
+			zap.String("body", strings.TrimSpace(string(body))),
+		)
+		return nil, functionapi.SandboxUnavailableError("sandbox unavailable")
+	}
+	sandbox, apiErr, err := spec.DecodeResponse[mgr.Sandbox](resp.Body)
+	if err != nil {
+		return nil, functionapi.SandboxUnavailableError("failed to decode sandbox response")
+	}
+	if apiErr != nil {
+		return nil, functionapi.SandboxUnavailableError(apiErr.Message)
+	}
+	if sandbox == nil {
+		return nil, functionapi.SandboxUnavailableError("sandbox response was empty")
+	}
+	return sandbox, nil
+}

--- a/regional-gateway/pkg/http/server.go
+++ b/regional-gateway/pkg/http/server.go
@@ -34,6 +34,8 @@ import (
 	"go.uber.org/zap"
 )
 
+const functionVolumeSnapshotTimeout = 2 * time.Minute
+
 // Server represents the HTTP server for regional-gateway
 type Server struct {
 	router               *gin.Engine
@@ -264,6 +266,13 @@ func (s *Server) outboundHTTPClient() *http.Client {
 	return &http.Client{}
 }
 
+func (s *Server) functionSnapshotHTTPClient() *http.Client {
+	if s != nil && s.obsProvider != nil {
+		return s.obsProvider.HTTP.NewClient(httpobs.Config{Timeout: functionVolumeSnapshotTimeout})
+	}
+	return &http.Client{Timeout: functionVolumeSnapshotTimeout}
+}
+
 // setupRoutes configures all HTTP routes
 func (s *Server) setupRoutes() {
 	// Global middleware (order matters)
@@ -339,7 +348,8 @@ func (s *Server) setupRoutes() {
 					PublicRegionID:           s.cfg.PublicRegionID,
 					RegionID:                 s.cfg.RegionID,
 				},
-				functionapi.NewClusterGatewaySandboxLookup(s.cfg.DefaultClusterGatewayURL, s.internalAuthGen, s.outboundHTTPClient(), s.logger),
+				s.functionSandboxLookup,
+				functionapi.NewHTTPVolumeSnapshotter(s.resolveFunctionClusterGatewayURL, s.internalAuthGen, s.functionSnapshotHTTPClient(), s.logger),
 				s.logger,
 			)
 			functionHandler.RegisterRoutes(functionRoutes, s.authMiddleware.RequirePermission)

--- a/scheduler/cmd/scheduler/main.go
+++ b/scheduler/cmd/scheduler/main.go
@@ -118,7 +118,7 @@ func main() {
 
 	// Create internal auth validator (for validating requests from regional-gateway)
 	validatorConfig := internalauth.DefaultValidatorConfig("scheduler", publicKey)
-	validatorConfig.AllowedCallers = []string{"regional-gateway"}
+	validatorConfig.AllowedCallers = []string{"regional-gateway", "function-gateway"}
 	authValidator := internalauth.NewValidator(validatorConfig)
 
 	logger.Info("Internal authentication enabled",

--- a/storage-proxy/pkg/http/handlers_metering_test.go
+++ b/storage-proxy/pkg/http/handlers_metering_test.go
@@ -234,6 +234,7 @@ func (f *fakeHTTPMeteringWriter) UpsertProducerWatermarkTx(ctx context.Context, 
 type fakeHTTPSnapshotManager struct {
 	exportBody          []byte
 	lastCreate          *snapshot.CreateSnapshotRequest
+	lastCreateVolume    *snapshot.CreateVolumeFromSnapshotRequest
 	lastExport          *snapshot.ExportSnapshotRequest
 	lastCompatibility   *snapshot.ListSnapshotCompatibilityIssuesRequest
 	casefoldEntries     []snapshot.SnapshotCasefoldCollision
@@ -297,6 +298,19 @@ func (f *fakeHTTPSnapshotManager) DeleteSnapshot(ctx context.Context, volumeID, 
 
 func (f *fakeHTTPSnapshotManager) ForkVolume(ctx context.Context, req *snapshot.ForkVolumeRequest) (*db.SandboxVolume, error) {
 	return nil, nil
+}
+
+func (f *fakeHTTPSnapshotManager) CreateVolumeFromSnapshot(ctx context.Context, req *snapshot.CreateVolumeFromSnapshotRequest) (*db.SandboxVolume, error) {
+	f.lastCreateVolume = req
+	return &db.SandboxVolume{
+		ID:              "vol-from-snapshot",
+		TeamID:          req.TeamID,
+		UserID:          req.UserID,
+		DefaultPosixUID: req.DefaultPosixUID,
+		DefaultPosixGID: req.DefaultPosixGID,
+		AccessMode:      req.AccessMode,
+		CreatedAt:       time.Date(2026, 3, 25, 3, 30, 0, 0, time.UTC),
+	}, nil
 }
 
 func TestCreateSandboxVolumeRecordsMetering(t *testing.T) {

--- a/storage-proxy/pkg/http/handlers_sandboxvolume.go
+++ b/storage-proxy/pkg/http/handlers_sandboxvolume.go
@@ -21,6 +21,7 @@ import (
 )
 
 type createSandboxVolumeRequest struct {
+	SnapshotID      string `json:"snapshot_id,omitempty"`
 	AccessMode      string `json:"access_mode"`
 	DefaultPosixUID *int64 `json:"default_posix_uid,omitempty"`
 	DefaultPosixGID *int64 `json:"default_posix_gid,omitempty"`
@@ -112,6 +113,35 @@ func (s *Server) createSandboxVolume(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := validateDefaultPosixIdentity(req.DefaultPosixUID, req.DefaultPosixGID); err != nil {
 		_ = spec.WriteError(w, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
+		return
+	}
+
+	if strings.TrimSpace(req.SnapshotID) != "" {
+		if s.snapshotMgr == nil {
+			_ = spec.WriteError(w, http.StatusInternalServerError, spec.CodeInternal, "snapshot manager is not configured")
+			return
+		}
+		vol, err := s.snapshotMgr.CreateVolumeFromSnapshot(r.Context(), &snapshot.CreateVolumeFromSnapshotRequest{
+			SnapshotID:      strings.TrimSpace(req.SnapshotID),
+			TeamID:          teamId,
+			UserID:          userId,
+			AccessMode:      string(accessMode),
+			DefaultPosixUID: req.DefaultPosixUID,
+			DefaultPosixGID: req.DefaultPosixGID,
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, snapshot.ErrSnapshotNotFound), errors.Is(err, snapshot.ErrVolumeNotFound):
+				_ = spec.WriteError(w, http.StatusNotFound, spec.CodeNotFound, "snapshot not found")
+			case errors.Is(err, snapshot.ErrInvalidAccessMode):
+				_ = spec.WriteError(w, http.StatusBadRequest, spec.CodeBadRequest, "invalid access_mode")
+			default:
+				s.logger.WithError(err).Error("Failed to create sandbox volume from snapshot")
+				_ = spec.WriteError(w, http.StatusInternalServerError, spec.CodeInternal, "internal server error")
+			}
+			return
+		}
+		_ = spec.WriteSuccess(w, http.StatusCreated, vol)
 		return
 	}
 

--- a/storage-proxy/pkg/http/handlers_sandboxvolume_test.go
+++ b/storage-proxy/pkg/http/handlers_sandboxvolume_test.go
@@ -107,6 +107,40 @@ func TestCreateSandboxVolumeDefaultsPosixIdentityToRoot(t *testing.T) {
 	}
 }
 
+func TestCreateSandboxVolumeFromSnapshot(t *testing.T) {
+	repo := newFakeHTTPRepo()
+	snapshotMgr := &fakeHTTPSnapshotManager{}
+	server := &Server{
+		repo:        repo,
+		snapshotMgr: snapshotMgr,
+		logger:      logrus.New(),
+	}
+	ctx := internalauth.WithClaims(context.Background(), &internalauth.Claims{
+		TeamID: "team-1",
+		UserID: "user-1",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/sandboxvolumes", bytes.NewReader([]byte(`{"snapshot_id":"snap-1","default_posix_uid":1001,"default_posix_gid":1002}`))).WithContext(ctx)
+	recorder := httptest.NewRecorder()
+
+	server.createSandboxVolume(recorder, req)
+
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if snapshotMgr.lastCreateVolume == nil {
+		t.Fatal("expected snapshot-backed volume create request")
+	}
+	if snapshotMgr.lastCreateVolume.SnapshotID != "snap-1" {
+		t.Fatalf("snapshot_id = %q, want snap-1", snapshotMgr.lastCreateVolume.SnapshotID)
+	}
+	if snapshotMgr.lastCreateVolume.DefaultPosixUID == nil || *snapshotMgr.lastCreateVolume.DefaultPosixUID != 1001 {
+		t.Fatalf("default_posix_uid = %v, want 1001", snapshotMgr.lastCreateVolume.DefaultPosixUID)
+	}
+	if len(repo.volumes) != 0 {
+		t.Fatalf("expected handler to delegate snapshot-backed create, repo volumes = %d", len(repo.volumes))
+	}
+}
+
 func TestCreateSandboxVolumeRejectsPartialDefaultPosixIdentity(t *testing.T) {
 	server := &Server{
 		logger:       logrus.New(),

--- a/storage-proxy/pkg/http/server.go
+++ b/storage-proxy/pkg/http/server.go
@@ -62,6 +62,7 @@ type snapshotManager interface {
 	RestoreSnapshot(ctx context.Context, req *snapshot.RestoreSnapshotRequest) error
 	DeleteSnapshot(ctx context.Context, volumeID, snapshotID, teamID string) error
 	ForkVolume(ctx context.Context, req *snapshot.ForkVolumeRequest) (*db.SandboxVolume, error)
+	CreateVolumeFromSnapshot(ctx context.Context, req *snapshot.CreateVolumeFromSnapshotRequest) (*db.SandboxVolume, error)
 }
 
 type volumeMutationBarrier interface {

--- a/storage-proxy/pkg/s0fs/materializer_test.go
+++ b/storage-proxy/pkg/s0fs/materializer_test.go
@@ -1067,6 +1067,34 @@ func TestMaterializerSegmentCacheIsVolumeQualified(t *testing.T) {
 	}
 }
 
+func TestPrepareForkStatePreservesInlineData(t *testing.T) {
+	now := time.Now()
+	state := &SnapshotState{
+		NextSeq:   3,
+		NextInode: 3,
+		Nodes: map[uint64]*Node{
+			RootInode: {Inode: RootInode, Type: TypeDirectory, Mode: 0o755, Nlink: 2, Atime: now, Mtime: now, Ctime: now},
+			2:         {Inode: 2, Type: TypeFile, Mode: 0o644, Nlink: 1, Size: 6, Atime: now, Mtime: now, Ctime: now},
+		},
+		Children: map[uint64]map[string]uint64{
+			RootInode: {"inline.txt": 2},
+		},
+		Data: map[uint64][]byte{
+			2: []byte("inline"),
+		},
+		ColdFiles: map[uint64][]FileExtent{},
+		Segments:  map[string]*Segment{},
+	}
+
+	forkState, err := PrepareForkState(state, "source")
+	if err != nil {
+		t.Fatalf("PrepareForkState() error = %v", err)
+	}
+	if got := string(forkState.Data[2]); got != "inline" {
+		t.Fatalf("fork inline data = %q, want inline", got)
+	}
+}
+
 func TestCreateSnapshotHydratesColdFilesInline(t *testing.T) {
 	ctx := context.Background()
 	store := newPrefixedRecordingStore(t, "vol-snapshot")

--- a/storage-proxy/pkg/s0fs/snapshot.go
+++ b/storage-proxy/pkg/s0fs/snapshot.go
@@ -140,7 +140,7 @@ func cloneState(state *SnapshotState) *SnapshotState {
 }
 
 // PrepareForkState returns a child-ready metadata snapshot that keeps cold file
-// segments addressed to the source volume instead of inlining file contents.
+// segments addressed to the source volume while preserving inline file data.
 func PrepareForkState(state *SnapshotState, sourceVolumeID string) (*SnapshotState, error) {
 	sourceVolumeID = strings.TrimSpace(sourceVolumeID)
 	if sourceVolumeID == "" {
@@ -151,11 +151,6 @@ func PrepareForkState(state *SnapshotState, sourceVolumeID string) (*SnapshotSta
 	}
 	clone := cloneState(state)
 	normalizeState(clone)
-	for inode, payload := range clone.Data {
-		if len(payload) > 0 {
-			return nil, fmt.Errorf("%w: source state has inline data for inode %d", ErrInvalidInput, inode)
-		}
-	}
 	for inode, extents := range clone.ColdFiles {
 		if clone.Nodes[inode] == nil {
 			delete(clone.ColdFiles, inode)
@@ -171,7 +166,6 @@ func PrepareForkState(state *SnapshotState, sourceVolumeID string) (*SnapshotSta
 			}
 		}
 	}
-	clone.Data = make(map[uint64][]byte)
 	return clone, nil
 }
 

--- a/storage-proxy/pkg/snapshot/manager.go
+++ b/storage-proxy/pkg/snapshot/manager.go
@@ -178,6 +178,17 @@ type ForkVolumeRequest struct {
 	DefaultPosixGID *int64
 }
 
+// CreateVolumeFromSnapshotRequest contains parameters for creating a volume
+// initialized from an immutable snapshot.
+type CreateVolumeFromSnapshotRequest struct {
+	SnapshotID      string
+	TeamID          string
+	UserID          string
+	AccessMode      string
+	DefaultPosixUID *int64
+	DefaultPosixGID *int64
+}
+
 // CreateSnapshot creates a new snapshot of a volume using the s0fs snapshot engine.
 func (m *Manager) CreateSnapshot(ctx context.Context, req *CreateSnapshotRequest) (*db.Snapshot, error) {
 	startTime := time.Now()
@@ -187,14 +198,6 @@ func (m *Manager) CreateSnapshot(ctx context.Context, req *CreateSnapshotRequest
 		"name":      req.Name,
 	}).Info("Creating snapshot")
 
-	ctldMounted, err := m.hasMountedCtldOwner(ctx, req.VolumeID)
-	if err != nil {
-		return nil, err
-	}
-	if ctldMounted {
-		return nil, ErrMountedCtldOwner
-	}
-
 	// 0. Distributed flush coordination (if coordinator is set)
 	// This ensures all storage-proxy instances that have this volume mounted
 	// flush their local caches to S3 before we create the snapshot.
@@ -202,7 +205,11 @@ func (m *Manager) CreateSnapshot(ctx context.Context, req *CreateSnapshotRequest
 	coordinator := m.coordinator
 	m.mu.RUnlock()
 
-	if coordinator != nil {
+	storageProxyMounted, err := m.hasMountedStorageProxyOwner(ctx, req.VolumeID)
+	if err != nil {
+		return nil, err
+	}
+	if coordinator != nil && storageProxyMounted {
 		m.logger.WithField("volume_id", req.VolumeID).Info("Coordinating flush across all instances")
 		if err := coordinator.CoordinateFlush(ctx, req.VolumeID); err != nil {
 			m.logger.WithError(err).Error("Distributed flush coordination failed")
@@ -281,6 +288,31 @@ func (m *Manager) ForkVolume(ctx context.Context, req *ForkVolumeRequest) (*db.S
 		metrics.SnapshotOperationDuration.WithLabelValues("fork").Observe(time.Since(startTime).Seconds())
 	}
 
+	return vol, nil
+}
+
+// CreateVolumeFromSnapshot creates a new SandboxVolume initialized from a
+// snapshot's immutable state.
+func (m *Manager) CreateVolumeFromSnapshot(ctx context.Context, req *CreateVolumeFromSnapshotRequest) (*db.SandboxVolume, error) {
+	startTime := time.Now()
+	metrics := m.metrics
+	m.logger.WithFields(logrus.Fields{
+		"snapshot_id": req.SnapshotID,
+		"team_id":     req.TeamID,
+	}).Info("Creating volume from snapshot")
+
+	vol, err := m.createS0FSVolumeFromSnapshot(ctx, req)
+	if err != nil {
+		if metrics != nil {
+			metrics.SnapshotOperationsTotal.WithLabelValues("create_volume_from_snapshot", "failure").Inc()
+			metrics.SnapshotOperationDuration.WithLabelValues("create_volume_from_snapshot").Observe(time.Since(startTime).Seconds())
+		}
+		return nil, err
+	}
+	if metrics != nil {
+		metrics.SnapshotOperationsTotal.WithLabelValues("create_volume_from_snapshot", "success").Inc()
+		metrics.SnapshotOperationDuration.WithLabelValues("create_volume_from_snapshot").Observe(time.Since(startTime).Seconds())
+	}
 	return vol, nil
 }
 
@@ -511,6 +543,22 @@ func volumeForkedEvent(regionID, clusterID string, volume *db.SandboxVolume) *me
 		Producer:    "storage-proxy.volume",
 		RegionID:    regionID,
 		EventType:   meteringpkg.EventTypeVolumeForked,
+		SubjectType: meteringpkg.SubjectTypeVolume,
+		SubjectID:   volume.ID,
+		TeamID:      volume.TeamID,
+		UserID:      volume.UserID,
+		VolumeID:    volume.ID,
+		ClusterID:   clusterID,
+		OccurredAt:  volume.CreatedAt,
+	}
+}
+
+func volumeCreatedEvent(regionID, clusterID string, volume *db.SandboxVolume) *meteringpkg.Event {
+	return &meteringpkg.Event{
+		EventID:     fmt.Sprintf("volume/%s/created/%d", volume.ID, volume.CreatedAt.UTC().UnixNano()),
+		Producer:    "storage-proxy.volume",
+		RegionID:    regionID,
+		EventType:   meteringpkg.EventTypeVolumeCreated,
 		SubjectType: meteringpkg.SubjectTypeVolume,
 		SubjectID:   volume.ID,
 		TeamID:      volume.TeamID,

--- a/storage-proxy/pkg/snapshot/manager_test.go
+++ b/storage-proxy/pkg/snapshot/manager_test.go
@@ -613,7 +613,7 @@ func TestRestoreSnapshot_BeginInvalidateError(t *testing.T) {
 	}
 }
 
-func TestCreateSnapshot_RejectsMountedCtldOwner(t *testing.T) {
+func TestCreateSnapshot_AllowsMountedCtldOwner(t *testing.T) {
 	repo := newFakeRepo()
 	repo.volumes["vol1"] = &db.SandboxVolume{ID: "vol1", TeamID: "team1"}
 	repo.activeMounts["vol1"] = []*db.VolumeMount{{
@@ -621,15 +621,23 @@ func TestCreateSnapshot_RejectsMountedCtldOwner(t *testing.T) {
 		MountOptions: rawMountOptions(t, volume.MountOptions{AccessMode: volume.AccessModeRWO, OwnerKind: volume.OwnerKindCtld}),
 	}}
 	mgr := newTestManager(repo, nil)
+	coordinator := &failingFlushCoordinator{}
+	mgr.SetFlushCoordinator(coordinator)
 
-	_, err := mgr.CreateSnapshot(context.Background(), &CreateSnapshotRequest{
+	snapshot, err := mgr.CreateSnapshot(context.Background(), &CreateSnapshotRequest{
 		VolumeID: "vol1",
 		Name:     "snap1",
 		TeamID:   "team1",
 		UserID:   "user1",
 	})
-	if !errors.Is(err, ErrMountedCtldOwner) {
-		t.Fatalf("CreateSnapshot() error = %v, want %v", err, ErrMountedCtldOwner)
+	if err != nil {
+		t.Fatalf("CreateSnapshot() error = %v", err)
+	}
+	if snapshot == nil || snapshot.VolumeID != "vol1" {
+		t.Fatalf("CreateSnapshot() snapshot = %#v", snapshot)
+	}
+	if coordinator.called {
+		t.Fatal("CreateSnapshot called distributed flush coordinator for ctld-owned mount")
 	}
 }
 

--- a/storage-proxy/pkg/snapshot/s0fs.go
+++ b/storage-proxy/pkg/snapshot/s0fs.go
@@ -97,8 +97,16 @@ func (m *Manager) s0fsConfig(teamID, volumeID string) (s0fs.Config, error) {
 }
 
 func (m *Manager) hasMountedCtldOwner(ctx context.Context, volumeID string) (bool, error) {
+	return m.hasMountedOwnerKind(ctx, volumeID, volume.OwnerKindCtld)
+}
+
+func (m *Manager) hasMountedStorageProxyOwner(ctx context.Context, volumeID string) (bool, error) {
+	return m.hasMountedOwnerKind(ctx, volumeID, volume.OwnerKindStorageProxy)
+}
+
+func (m *Manager) hasMountedOwnerKind(ctx context.Context, volumeID, ownerKind string) (bool, error) {
 	repo, ok := any(m.repo).(activeMountRepository)
-	if !ok || repo == nil || volumeID == "" {
+	if !ok || repo == nil || volumeID == "" || ownerKind == "" {
 		return false, nil
 	}
 	heartbeatTimeout := 15
@@ -110,7 +118,7 @@ func (m *Manager) hasMountedCtldOwner(ctx context.Context, volumeID string) (boo
 		return false, fmt.Errorf("get active mounts: %w", err)
 	}
 	for _, mount := range mounts {
-		if volume.DecodeMountOptions(mount.MountOptions).OwnerKind == volume.OwnerKindCtld {
+		if volume.DecodeMountOptions(mount.MountOptions).OwnerKind == ownerKind {
 			return true, nil
 		}
 	}
@@ -490,6 +498,107 @@ func (m *Manager) forkS0FSVolume(ctx context.Context, req *ForkVolumeRequest) (*
 	_ = closeTarget()
 
 	if err := m.appendMeteringEvent(ctx, volumeForkedEvent(m.regionID(), m.clusterID, newVol)); err != nil {
+		return nil, err
+	}
+	success = true
+	return newVol, nil
+}
+
+func (m *Manager) createS0FSVolumeFromSnapshot(ctx context.Context, req *CreateVolumeFromSnapshotRequest) (*db.SandboxVolume, error) {
+	snapshotRecord, err := m.repo.GetSnapshot(ctx, strings.TrimSpace(req.SnapshotID))
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return nil, ErrSnapshotNotFound
+		}
+		return nil, err
+	}
+	if snapshotRecord.TeamID != req.TeamID {
+		return nil, ErrSnapshotNotFound
+	}
+
+	sourceVol, err := m.repo.GetSandboxVolume(ctx, snapshotRecord.VolumeID)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return nil, ErrVolumeNotFound
+		}
+		return nil, err
+	}
+	if sourceVol.TeamID != req.TeamID {
+		return nil, ErrVolumeNotFound
+	}
+
+	accessMode := volume.AccessModeRWO
+	if strings.TrimSpace(req.AccessMode) != "" {
+		parsedMode, ok := volume.ParseAccessMode(req.AccessMode)
+		if !ok {
+			return nil, ErrInvalidAccessMode
+		}
+		accessMode = parsedMode
+	}
+
+	cfg, err := m.s0fsConfig(snapshotRecord.TeamID, snapshotRecord.VolumeID)
+	if err != nil {
+		return nil, err
+	}
+	state, err := s0fs.LoadSnapshot(ctx, cfg, snapshotRecord.ID)
+	if err != nil {
+		return nil, err
+	}
+	forkState, err := s0fs.PrepareForkState(state, snapshotRecord.VolumeID)
+	if err != nil {
+		return nil, err
+	}
+
+	newVolumeID := uuid.New().String()
+	now := time.Now()
+	sourceID := snapshotRecord.VolumeID
+	newVol := &db.SandboxVolume{
+		ID:              newVolumeID,
+		TeamID:          req.TeamID,
+		UserID:          req.UserID,
+		SourceVolumeID:  &sourceID,
+		DefaultPosixUID: req.DefaultPosixUID,
+		DefaultPosixGID: req.DefaultPosixGID,
+		AccessMode:      string(accessMode),
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+
+	if err := m.repo.WithTx(ctx, func(tx pgx.Tx) error {
+		return m.repo.CreateSandboxVolumeTx(ctx, tx, newVol)
+	}); err != nil {
+		return nil, err
+	}
+	success := false
+	defer func() {
+		if success {
+			return
+		}
+		_ = cleanupS0FSVolume(newVolumeID, m.config)
+		_ = m.repo.WithTx(context.Background(), func(tx pgx.Tx) error {
+			err := m.repo.DeleteSandboxVolumeTx(context.Background(), tx, newVolumeID)
+			if errors.Is(err, db.ErrNotFound) {
+				return nil
+			}
+			return err
+		})
+	}()
+
+	targetEngine, closeTarget, err := m.openS0FSEngine(ctx, req.TeamID, newVolumeID)
+	if err != nil {
+		return nil, err
+	}
+	if err := targetEngine.ReplaceState(forkState); err != nil {
+		closeTarget()
+		return nil, err
+	}
+	if _, err := targetEngine.SyncMaterialize(ctx); err != nil {
+		closeTarget()
+		return nil, err
+	}
+	_ = closeTarget()
+
+	if err := m.appendMeteringEvent(ctx, volumeCreatedEvent(m.regionID(), m.clusterID, newVol)); err != nil {
 		return nil, err
 	}
 	success = true

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -192,6 +192,9 @@ func registerApiModeSuite(envProvider func() *framework.ScenarioEnv, opts apiMod
 				It("publishes a sandbox service without capturing function /api routes", func() {
 					assertFunctionAPIRoutesReachUserService(env, session, sandboxID)
 				})
+				It("restores a runtime sandbox from revision volume snapshots", func() {
+					assertFunctionRuntimeRestoreUsesVolumeSnapshot(env, session)
+				})
 			})
 		}
 
@@ -1785,6 +1788,105 @@ func assertFunctionAPIRoutesReachUserService(env *framework.ScenarioEnv, session
 	}).WithTimeout(60 * time.Second).WithPolling(2 * time.Second).Should(Succeed())
 }
 
+func assertFunctionRuntimeRestoreUsesVolumeSnapshot(env *framework.ScenarioEnv, session *e2eutils.Session) {
+	volume, status, err := session.CreateSandboxVolume(env.TestCtx.Context, GinkgoT(), apispec.CreateSandboxVolumeRequest{})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusCreated))
+	Expect(volume).NotTo(BeNil())
+	volumeID := expectStringPtr(volume.Id, "volume id")
+	DeferCleanup(func() {
+		deleteSandboxVolumeForCleanup(env, session, volumeID)
+	})
+
+	mountPoint := "/workspace/function-data"
+	templateID := createVolumePortalTemplate(env, session, mountPoint)
+	seedPath := "/message.txt"
+	seedContent := []byte("function snapshot content\n")
+	status, err = session.WriteVolumeFile(env.TestCtx.Context, GinkgoT(), volumeID, seedPath, seedContent, "")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+
+	claimReq := apispec.ClaimRequest{
+		Template: &templateID,
+		Mounts: &[]apispec.ClaimMountRequest{{
+			SandboxvolumeId: volumeID,
+			MountPoint:      mountPoint,
+		}},
+	}
+	claimResp, err := session.ClaimSandboxWithRequest(env.TestCtx.Context, GinkgoT(), claimReq)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(claimResp).NotTo(BeNil())
+	sourceSandboxID := claimResp.SandboxId
+	DeferCleanup(func() {
+		_ = session.DeleteSandbox(env.TestCtx.Context, GinkgoT(), sourceSandboxID)
+	})
+
+	sourceTemplate, err := session.GetTemplate(env.TestCtx.Context, GinkgoT(), templateID)
+	Expect(err).NotTo(HaveOccurred())
+	templateNamespace, err := naming.TemplateNamespaceForTeam(expectStringPtr(sourceTemplate.TeamId, "team id"))
+	Expect(err).NotTo(HaveOccurred())
+	sourceSandbox := waitForSandboxPodReadyEventually(env, session, sourceSandboxID, templateNamespace)
+	Expect(sourceSandbox.PodName).NotTo(BeEmpty())
+
+	const serviceID = "function-volume"
+	const servicePort int32 = 18081
+	startCommand := fmt.Sprintf("nohup python3 -m http.server %d --bind 0.0.0.0 -d %s >/tmp/s0-function-volume.log 2>&1 &", servicePort, shellQuote(mountPoint))
+	_, err = execInSandboxPod(env, templateNamespace, sourceSandbox.PodName, startCommand)
+	Expect(err).NotTo(HaveOccurred())
+
+	pathPrefix := "/"
+	cwd := mountPoint
+	command := []string{"/bin/sh", "-lc", fmt.Sprintf("python3 -m http.server %d --bind 0.0.0.0 -d %s", servicePort, shellQuote(mountPoint))}
+	_, _, updateStatus, err := session.UpdateSandboxServices(env.TestCtx.Context, GinkgoT(), sourceSandboxID, []apispec.SandboxAppService{{
+		Id:   serviceID,
+		Port: servicePort,
+		Runtime: &apispec.SandboxAppServiceRuntime{
+			Type:    apispec.SandboxAppServiceRuntimeTypeCmd,
+			Command: &command,
+			Cwd:     &cwd,
+		},
+		Ingress: apispec.SandboxAppServiceIngress{
+			Public: true,
+			Routes: &[]apispec.SandboxAppServiceRoute{{
+				Id:         "root",
+				PathPrefix: &pathPrefix,
+				Resume:     true,
+			}},
+		},
+	}})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(updateStatus).To(Equal(http.StatusOK))
+
+	functionName := fmt.Sprintf("e2e-function-volume-%d", time.Now().UnixNano())
+	fn, createStatus, err := session.CreateFunctionFromSandbox(env.TestCtx.Context, GinkgoT(), sourceSandboxID, serviceID, functionName)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(createStatus).To(Equal(http.StatusCreated))
+	Expect(fn).NotTo(BeNil())
+	Expect(fn.Host).NotTo(BeEmpty())
+
+	_, err = execInSandboxPod(env, templateNamespace, sourceSandbox.PodName, fmt.Sprintf("printf 'mutated live content\\n' > %s", shellQuote(mountPoint+seedPath)))
+	Expect(err).NotTo(HaveOccurred())
+	Expect(session.DeleteSandbox(env.TestCtx.Context, GinkgoT(), sourceSandboxID)).To(Succeed())
+
+	functionGatewayURL, cleanup, err := functionGatewayBaseURL(env)
+	Expect(err).NotTo(HaveOccurred())
+	defer cleanup()
+
+	Eventually(func() error {
+		status, body, err := requestFunctionHost(env.TestCtx.Context, functionGatewayURL, fn.Host, seedPath)
+		if err != nil {
+			return err
+		}
+		if status != http.StatusOK {
+			return fmt.Errorf("function restore status %d body %q", status, body)
+		}
+		if body != string(seedContent) {
+			return fmt.Errorf("function restore body = %q, want %q", body, string(seedContent))
+		}
+		return nil
+	}).WithTimeout(90 * time.Second).WithPolling(2 * time.Second).Should(Succeed())
+}
+
 func functionGatewayBaseURL(env *framework.ScenarioEnv) (string, func(), error) {
 	serviceName := env.Infra.Name + "-function-gateway"
 	port, err := framework.GetServicePort(env.TestCtx.Context, env.Config.Kubeconfig, env.Infra.Namespace, serviceName)
@@ -1965,9 +2067,11 @@ func assertVolumeLifecycle(env *framework.ScenarioEnv, session *e2eutils.Session
 	Expect(status).To(Equal(http.StatusOK))
 	Expect(directBody).To(Equal(directContent))
 
-	_, status, err = session.CreateSnapshot(env.TestCtx.Context, GinkgoT(), volumeID, apispec.CreateSnapshotRequest{Name: "direct-mounted"})
-	Expect(err).To(HaveOccurred())
-	Expect(status).To(Equal(http.StatusConflict))
+	directSnapshot, status, err := session.CreateSnapshot(env.TestCtx.Context, GinkgoT(), volumeID, apispec.CreateSnapshotRequest{Name: "direct-mounted"})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusCreated))
+	Expect(directSnapshot).NotTo(BeNil())
+	Expect(directSnapshot.Id).NotTo(BeEmpty())
 
 	snapshotVolume, status, err := session.CreateSandboxVolume(env.TestCtx.Context, GinkgoT(), createReq)
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## Summary

Fixes #317.

This PR makes Function restore safe for multi-cluster regions and immutable volume-backed revisions:

- routes Function publish/runtime sandbox operations through scheduler-aware cluster resolution when configured
- keeps single-cluster deployments on direct cluster-gateway routing
- snapshots mounted SandboxVolumes when publishing Function revisions
- lets `POST /api/v1/sandboxvolumes` initialize a new volume from `snapshot_id`
- materializes Function runtime volumes from revision snapshots before claiming the restored runtime sandbox
- adds Function e2e coverage for source sandbox deletion and volume snapshot immutability
- updates Function docs for snapshot-backed restore behavior

## Validation

- `make proto`
- `make apispec`
- `go test ./pkg/gateway/functionapi ./function-gateway/pkg/http ./regional-gateway/pkg/http ./cluster-gateway/pkg/http ./storage-proxy/pkg/http ./storage-proxy/pkg/snapshot ./scheduler/pkg/http ./infra-operator/internal/plan ./infra-operator/internal/controller/services/functiongateway ./tests/e2e/cases`

I also started `go test ./...`, but stopped it after it began creating a local kind e2e cluster via `tests/e2e/scenarios`; the local kind cluster was deleted. Remote manual e2e will be run separately while PR CI runs.
