### PR TITLE
Add function lifecycle APIs

### DIFF
--- a/cluster-gateway/pkg/client/manager.go
+++ b/cluster-gateway/pkg/client/manager.go
@@ -154,6 +154,42 @@ func (c *ManagerClient) GetSandboxInternal(ctx context.Context, sandboxID string
 	return sandbox, nil
 }
 
+// TerminateSandbox asks manager to terminate a sandbox after cluster-gateway
+// has authenticated and authorized the caller.
+func (c *ManagerClient) TerminateSandbox(ctx context.Context, sandboxID, userID, teamID string) error {
+	token, err := c.internalAuthGen.Generate("manager", teamID, userID, internalauth.GenerateOptions{})
+	if err != nil {
+		return fmt.Errorf("generate internal token: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/api/v1/sandboxes/%s", c.baseURL, sandboxID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set(internalauth.DefaultTokenHeader, token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("execute request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("%w: %s", ErrSandboxNotFound, sandboxID)
+	}
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_, apiErr, err := spec.DecodeResponse[map[string]any](bytes.NewReader(body))
+	if err == nil && apiErr != nil {
+		return fmt.Errorf("%w: %s", ErrManagerUnavailable, apiErr.Message)
+	}
+	return fmt.Errorf("%w: unexpected status code %d: %s", ErrManagerUnavailable, resp.StatusCode, string(body))
+}
+
 // ResumeSandbox asks manager to resume a paused sandbox and waits for it to become active.
 func (c *ManagerClient) ResumeSandbox(ctx context.Context, sandboxID, userID, teamID string) error {
 	token, err := c.internalAuthGen.Generate("manager", teamID, userID, internalauth.GenerateOptions{})

--- a/cluster-gateway/pkg/http/function_runtime_controller.go
+++ b/cluster-gateway/pkg/http/function_runtime_controller.go
@@ -1,0 +1,33 @@
+package http
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/sandbox0-ai/sandbox0/cluster-gateway/pkg/client"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/authn"
+)
+
+type localRuntimeController struct {
+	manager *client.ManagerClient
+}
+
+func newLocalRuntimeController(manager *client.ManagerClient) *localRuntimeController {
+	return &localRuntimeController{manager: manager}
+}
+
+func (c *localRuntimeController) DeleteRuntimeSandbox(ctx context.Context, authCtx *authn.AuthContext, sandboxID string) error {
+	sandboxID = strings.TrimSpace(sandboxID)
+	if sandboxID == "" {
+		return nil
+	}
+	if c == nil || c.manager == nil {
+		return fmt.Errorf("manager client is not configured")
+	}
+	if authCtx == nil || strings.TrimSpace(authCtx.TeamID) == "" {
+		return fmt.Errorf("team context is required")
+	}
+	principal := authCtx.Principal()
+	return c.manager.TerminateSandbox(ctx, sandboxID, principal.UserID, authCtx.TeamID)
+}

--- a/cluster-gateway/pkg/http/handlers_internal_sandboxes.go
+++ b/cluster-gateway/pkg/http/handlers_internal_sandboxes.go
@@ -37,6 +37,39 @@ func (s *Server) getInternalSandbox(c *gin.Context) {
 	spec.JSONSuccess(c, http.StatusOK, sandbox)
 }
 
+// deleteInternalSandbox terminates a sandbox for trusted internal callers
+// after cluster-gateway has validated the internal token permissions.
+func (s *Server) deleteInternalSandbox(c *gin.Context) {
+	authCtx := middleware.GetAuthContext(c)
+	if authCtx == nil || authCtx.TeamID == "" {
+		spec.JSONError(c, http.StatusUnauthorized, spec.CodeUnauthorized, "missing internal team context")
+		return
+	}
+
+	sandboxID := c.Param("id")
+	if sandboxID == "" {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "sandbox_id is required")
+		return
+	}
+
+	if err := s.managerClient.TerminateSandbox(c.Request.Context(), sandboxID, authCtx.UserID, authCtx.TeamID); err != nil {
+		s.logger.Warn("Internal sandbox delete failed",
+			zap.String("sandbox_id", sandboxID),
+			zap.String("team_id", authCtx.TeamID),
+			zap.String("user_id", authCtx.UserID),
+			zap.Error(err),
+		)
+		if errors.Is(err, client.ErrSandboxNotFound) {
+			spec.JSONError(c, http.StatusNotFound, spec.CodeNotFound, "sandbox not found")
+			return
+		}
+		spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox delete failed")
+		return
+	}
+
+	spec.JSONSuccess(c, http.StatusOK, gin.H{"message": "sandbox terminated successfully"})
+}
+
 // resumeInternalSandbox requests a sandbox resume for trusted internal callers
 // after the caller has already performed region-level authorization.
 func (s *Server) resumeInternalSandbox(c *gin.Context) {

--- a/cluster-gateway/pkg/http/server.go
+++ b/cluster-gateway/pkg/http/server.go
@@ -271,6 +271,7 @@ func NewServer(
 			return sandbox, nil
 		},
 		functionapi.NewHTTPStorageProxyVolumeSnapshotter(cfg.StorageProxyURL, internalAuthGen, snapshotHTTPClient, logger),
+		functionapi.NewHTTPRuntimeController(functionapi.StaticClusterGatewayURLResolver(fmt.Sprintf("http://127.0.0.1:%d", cfg.HTTPPort)), internalAuthGen, snapshotHTTPClient),
 		logger,
 	)
 

--- a/cluster-gateway/pkg/http/server.go
+++ b/cluster-gateway/pkg/http/server.go
@@ -142,7 +142,7 @@ func NewServer(
 	// Create internal auth validator (for validating tokens from regional-gateway and optionally scheduler)
 	allowedCallers := cfg.AllowedCallers
 	if len(allowedCallers) == 0 {
-		allowedCallers = []string{"regional-gateway", "scheduler", "function-gateway"}
+		allowedCallers = []string{"regional-gateway", "scheduler", "function-gateway", "cluster-gateway"}
 	}
 	var validator *internalauth.Validator
 	if authModeEnabled(cfg.AuthMode, authModeInternal) {
@@ -507,6 +507,7 @@ func (s *Server) setupInternalControlPlaneRoutes() {
 
 		// Sandbox metadata and power control (→ Manager)
 		internal.GET("/sandboxes/:id", s.getInternalSandbox)
+		internal.DELETE("/sandboxes/:id", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxDelete), s.deleteInternalSandbox)
 		internal.POST("/sandboxes/:id/resume", s.resumeInternalSandbox)
 
 		// Template management (→ Manager)

--- a/cluster-gateway/pkg/http/server.go
+++ b/cluster-gateway/pkg/http/server.go
@@ -271,7 +271,7 @@ func NewServer(
 			return sandbox, nil
 		},
 		functionapi.NewHTTPStorageProxyVolumeSnapshotter(cfg.StorageProxyURL, internalAuthGen, snapshotHTTPClient, logger),
-		functionapi.NewHTTPRuntimeController(functionapi.StaticClusterGatewayURLResolver(fmt.Sprintf("http://127.0.0.1:%d", cfg.HTTPPort)), internalAuthGen, snapshotHTTPClient),
+		newLocalRuntimeController(managerClient),
 		logger,
 	)
 

--- a/docs/function/page.mdx
+++ b/docs/function/page.mdx
@@ -42,7 +42,7 @@ Example service:
             "port": 8080,
             "runtime": {
                 "type": "cmd",
-                "command": ["/bin/sh", "-lc", "python -m app.server"],
+                "command": ["python3", "-m", "app.server"],
                 "cwd": "/workspace"
             },
             "ingress": {

--- a/docs/function/page.mdx
+++ b/docs/function/page.mdx
@@ -87,6 +87,30 @@ This creates:
 | Revision 1 | Snapshot of the sandbox service |
 | `production` alias | Points to revision 1 |
 
+## Lifecycle
+
+Functions can be disabled without deleting their identity, domain, aliases, or revisions:
+
+<Endpoint method="PUT">
+/api/v1/functions/{'{id}'}
+</Endpoint>
+
+```json
+{
+    "enabled": false
+}
+```
+
+Disabled functions return `503` from the function host and do not restore runtime sandboxes. Re-enable the function by setting `enabled` to `true`.
+
+Delete a function when its stable host should stop serving traffic permanently:
+
+<Endpoint method="DELETE">
+/api/v1/functions/{'{id}'}
+</Endpoint>
+
+Delete is a soft delete. The function disappears from list/get APIs, the host returns not found, and the slug/domain label stay reserved. Sandbox0 also schedules best-effort cleanup for restored runtime sandboxes and revision-owned volumes.
+
 ## Revisions
 
 Create a new revision from the same or another sandbox service:
@@ -117,8 +141,40 @@ Move an alias:
 }
 ```
 
+Read aliases:
+
+<Endpoint method="GET">
+/api/v1/functions/{'{id}'}/aliases
+</Endpoint>
+
+<Endpoint method="GET">
+/api/v1/functions/{'{id}'}/aliases/{'{alias}'}
+</Endpoint>
+
+Read a specific immutable revision by revision number:
+
+<Endpoint method="GET">
+/api/v1/functions/{'{id}'}/revisions/{'{revision_number}'}
+</Endpoint>
+
 ## Runtime Behavior
 
 Function traffic is handled by `function-gateway` on the fixed function host. The gateway resolves the `production` alias, enforces the revision's service route policy, and proxies to the service port.
 
 If the source sandbox still exists, the gateway resumes it when needed and routes to that sandbox. If the source sandbox has been deleted, the gateway restores a function runtime sandbox from the revision's template and revision-owned volumes, starts the service runtime command or warm process, stores the runtime sandbox/context on the revision, and reuses that runtime until sandbox0 scales it down.
+
+Inspect and recycle the active restored runtime:
+
+<Endpoint method="GET">
+/api/v1/functions/{'{id}'}/runtime
+</Endpoint>
+
+<Endpoint method="POST">
+/api/v1/functions/{'{id}'}/runtime/restart
+</Endpoint>
+
+<Endpoint method="POST">
+/api/v1/functions/{'{id}'}/runtime/recycle
+</Endpoint>
+
+`restart` and `recycle` both delete the current restored runtime sandbox when one exists and clear the runtime mapping. The next function request starts a fresh runtime from the active revision.

--- a/function-gateway/pkg/http/server.go
+++ b/function-gateway/pkg/http/server.go
@@ -209,6 +209,10 @@ func (s *Server) handleNoRoute(c *gin.Context) {
 		spec.JSONError(c, http.StatusNotFound, spec.CodeNotFound, "function not found")
 		return
 	}
+	if !fn.Enabled {
+		spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "function disabled")
+		return
+	}
 	rev, err := s.functionRepo.GetActiveRevision(c.Request.Context(), fn)
 	if err != nil {
 		spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "function revision is not available")

--- a/infra-operator/api/v1alpha1/service_api_config_types.go
+++ b/infra-operator/api/v1alpha1/service_api_config_types.go
@@ -353,7 +353,7 @@ type ClusterGatewayConfig struct {
 	// +kubebuilder:default="internal"
 	AuthMode string `json:"authMode,omitempty"`
 	// +optional
-	// +kubebuilder:default={"regional-gateway","scheduler","function-gateway"}
+	// +kubebuilder:default={"regional-gateway","scheduler","function-gateway","cluster-gateway"}
 	AllowedCallers []string `json:"allowedCallers,omitempty"`
 	// +optional
 	// +kubebuilder:default="30s"

--- a/infra-operator/chart/crds/infra.sandbox0.ai_sandbox0infras.yaml
+++ b/infra-operator/chart/crds/infra.sandbox0.ai_sandbox0infras.yaml
@@ -941,6 +941,7 @@ spec:
                             - regional-gateway
                             - scheduler
                             - function-gateway
+                            - cluster-gateway
                             items:
                               type: string
                             type: array

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -1715,6 +1715,61 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorEnvelope"
+    put:
+      tags: [functions]
+      summary: Update function lifecycle state
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/FunctionUpdateRequest"
+      responses:
+        "200":
+          description: Function updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessFunctionResponse"
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+    delete:
+      tags: [functions]
+      summary: Delete function
+      description: Soft-deletes the function, disables its host, and schedules best-effort runtime and revision volume cleanup. The function slug and domain label remain reserved.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Function deleted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessFunctionResponse"
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
   /api/v1/functions/{id}/revisions:
     get:
       tags: [functions]
@@ -1758,7 +1813,86 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SuccessFunctionRevisionCreateResponse"
+  /api/v1/functions/{id}/revisions/{revision_number}:
+    get:
+      tags: [functions]
+      summary: Get function revision
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: revision_number
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: Function revision
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessFunctionRevisionResponse"
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+  /api/v1/functions/{id}/aliases:
+    get:
+      tags: [functions]
+      summary: List function aliases
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Function aliases
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessFunctionAliasListResponse"
   /api/v1/functions/{id}/aliases/{alias}:
+    get:
+      tags: [functions]
+      summary: Get function alias
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: alias
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Function alias
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessFunctionAliasResponse"
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
     put:
       tags: [functions]
       summary: Point a function alias at a revision
@@ -1788,6 +1922,65 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SuccessFunctionAliasResponse"
+  /api/v1/functions/{id}/runtime:
+    get:
+      tags: [functions]
+      summary: Get active function runtime
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Function runtime status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessFunctionRuntimeResponse"
+  /api/v1/functions/{id}/runtime/restart:
+    post:
+      tags: [functions]
+      summary: Restart active function runtime
+      description: Deletes the current restored runtime sandbox when one exists and clears the runtime mapping; the next function request starts a fresh runtime.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Function runtime restarted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessFunctionRuntimeResponse"
+  /api/v1/functions/{id}/runtime/recycle:
+    post:
+      tags: [functions]
+      summary: Recycle active function runtime
+      description: Deletes the current restored runtime sandbox when one exists and clears the runtime mapping; the next function request starts a fresh runtime.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Function runtime recycled
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessFunctionRuntimeResponse"
   /api/v1/sandboxes/{id}/contexts:
     post:
       tags: [contexts]
@@ -3939,6 +4132,15 @@ components:
           default: true
           description: Whether to move the production alias to the new revision.
       required: [source]
+    FunctionUpdateRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Mutable function display name. Slug and domain label stay stable.
+        enabled:
+          type: boolean
+          description: Whether the function host should serve traffic. Disabled functions do not restore runtime sandboxes.
     FunctionAliasUpdateRequest:
       type: object
       properties:
@@ -3961,6 +4163,8 @@ components:
           type: string
         active_revision_id:
           type: string
+        enabled:
+          type: boolean
         created_by:
           type: string
         created_at:
@@ -3969,7 +4173,11 @@ components:
         updated_at:
           type: string
           format: date-time
-      required: [id, team_id, name, slug, domain_label, created_at, updated_at]
+        deleted_at:
+          type: string
+          format: date-time
+          description: Set when the function has been soft-deleted. Deleted functions are hidden from normal list/get APIs and do not serve traffic.
+      required: [id, team_id, name, slug, domain_label, enabled, created_at, updated_at]
     FunctionRecord:
       allOf:
         - $ref: "#/components/schemas/Function"
@@ -4054,6 +4262,32 @@ components:
           type: string
           format: date-time
       required: [function_id, alias, revision_id, revision_number, updated_at]
+    FunctionRuntimeState:
+      type: string
+      enum: [disabled, idle, active]
+    FunctionRuntimeStatus:
+      type: object
+      properties:
+        function_id:
+          type: string
+        revision_id:
+          type: string
+        revision_number:
+          type: integer
+          format: int32
+        state:
+          $ref: "#/components/schemas/FunctionRuntimeState"
+        runtime_sandbox_id:
+          type: string
+          description: Current restored runtime sandbox, if one exists.
+        runtime_context_id:
+          type: string
+          description: Current runtime process context, if one exists.
+        runtime_updated_at:
+          type: string
+          format: date-time
+          description: Last time the runtime mapping was updated.
+      required: [function_id, revision_id, revision_number, state]
     SuccessFunctionResponse:
       allOf:
         - $ref: "#/components/schemas/SuccessEnvelope"
@@ -4106,6 +4340,17 @@ components:
                   items:
                     $ref: "#/components/schemas/FunctionRevision"
               required: [revisions]
+    SuccessFunctionRevisionResponse:
+      allOf:
+        - $ref: "#/components/schemas/SuccessEnvelope"
+        - type: object
+          properties:
+            data:
+              type: object
+              properties:
+                revision:
+                  $ref: "#/components/schemas/FunctionRevision"
+              required: [revision]
     SuccessFunctionRevisionCreateResponse:
       allOf:
         - $ref: "#/components/schemas/SuccessEnvelope"
@@ -4119,6 +4364,19 @@ components:
                 promoted:
                   type: boolean
               required: [revision, promoted]
+    SuccessFunctionAliasListResponse:
+      allOf:
+        - $ref: "#/components/schemas/SuccessEnvelope"
+        - type: object
+          properties:
+            data:
+              type: object
+              properties:
+                aliases:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/FunctionAlias"
+              required: [aliases]
     SuccessFunctionAliasResponse:
       allOf:
         - $ref: "#/components/schemas/SuccessEnvelope"
@@ -4130,6 +4388,17 @@ components:
                 alias:
                   $ref: "#/components/schemas/FunctionAlias"
               required: [alias]
+    SuccessFunctionRuntimeResponse:
+      allOf:
+        - $ref: "#/components/schemas/SuccessEnvelope"
+        - type: object
+          properties:
+            data:
+              type: object
+              properties:
+                runtime:
+                  $ref: "#/components/schemas/FunctionRuntimeStatus"
+              required: [runtime]
     WebhookConfig:
       type: object
       description: |

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -64,8 +64,8 @@ const (
 
 // Defines values for EgressAuthRolloutMode.
 const (
-	Disabled EgressAuthRolloutMode = "disabled"
-	Enabled  EgressAuthRolloutMode = "enabled"
+	EgressAuthRolloutModeDisabled EgressAuthRolloutMode = "disabled"
+	EgressAuthRolloutModeEnabled  EgressAuthRolloutMode = "enabled"
 )
 
 // Defines values for EgressTLSMode.
@@ -89,6 +89,13 @@ const (
 	Dir     FileInfoType = "dir"
 	File    FileInfoType = "file"
 	Symlink FileInfoType = "symlink"
+)
+
+// Defines values for FunctionRuntimeState.
+const (
+	FunctionRuntimeStateActive   FunctionRuntimeState = "active"
+	FunctionRuntimeStateDisabled FunctionRuntimeState = "disabled"
+	FunctionRuntimeStateIdle     FunctionRuntimeState = "idle"
 )
 
 // Defines values for GatewayMetadataGatewayMode.
@@ -254,6 +261,11 @@ const (
 	SuccessFileStatResponseSuccessTrue SuccessFileStatResponseSuccess = true
 )
 
+// Defines values for SuccessFunctionAliasListResponseSuccess.
+const (
+	SuccessFunctionAliasListResponseSuccessTrue SuccessFunctionAliasListResponseSuccess = true
+)
+
 // Defines values for SuccessFunctionAliasResponseSuccess.
 const (
 	SuccessFunctionAliasResponseSuccessTrue SuccessFunctionAliasResponseSuccess = true
@@ -282,6 +294,16 @@ const (
 // Defines values for SuccessFunctionRevisionListResponseSuccess.
 const (
 	SuccessFunctionRevisionListResponseSuccessTrue SuccessFunctionRevisionListResponseSuccess = true
+)
+
+// Defines values for SuccessFunctionRevisionResponseSuccess.
+const (
+	SuccessFunctionRevisionResponseSuccessTrue SuccessFunctionRevisionResponseSuccess = true
+)
+
+// Defines values for SuccessFunctionRuntimeResponseSuccess.
+const (
+	SuccessFunctionRuntimeResponseSuccessTrue SuccessFunctionRuntimeResponseSuccess = true
 )
 
 // Defines values for SuccessGatewayMetadataResponseSuccess.
@@ -451,7 +473,7 @@ const (
 
 // Defines values for SuccessWrittenResponseSuccess.
 const (
-	SuccessWrittenResponseSuccessTrue SuccessWrittenResponseSuccess = true
+	True SuccessWrittenResponseSuccess = true
 )
 
 // Defines values for TrafficRuleAction.
@@ -933,12 +955,16 @@ type Function struct {
 	ActiveRevisionId *string   `json:"active_revision_id,omitempty"`
 	CreatedAt        time.Time `json:"created_at"`
 	CreatedBy        *string   `json:"created_by,omitempty"`
-	DomainLabel      string    `json:"domain_label"`
-	Id               string    `json:"id"`
-	Name             string    `json:"name"`
-	Slug             string    `json:"slug"`
-	TeamId           string    `json:"team_id"`
-	UpdatedAt        time.Time `json:"updated_at"`
+
+	// DeletedAt Set when the function has been soft-deleted. Deleted functions are hidden from normal list/get APIs and do not serve traffic.
+	DeletedAt   *time.Time `json:"deleted_at,omitempty"`
+	DomainLabel string     `json:"domain_label"`
+	Enabled     bool       `json:"enabled"`
+	Id          string     `json:"id"`
+	Name        string     `json:"name"`
+	Slug        string     `json:"slug"`
+	TeamId      string     `json:"team_id"`
+	UpdatedAt   time.Time  `json:"updated_at"`
 }
 
 // FunctionAlias defines model for FunctionAlias.
@@ -968,14 +994,18 @@ type FunctionRecord struct {
 	ActiveRevisionId *string   `json:"active_revision_id,omitempty"`
 	CreatedAt        time.Time `json:"created_at"`
 	CreatedBy        *string   `json:"created_by,omitempty"`
-	DomainLabel      string    `json:"domain_label"`
-	Host             string    `json:"host"`
-	Id               string    `json:"id"`
-	Name             string    `json:"name"`
-	Slug             string    `json:"slug"`
-	TeamId           string    `json:"team_id"`
-	UpdatedAt        time.Time `json:"updated_at"`
-	Url              string    `json:"url"`
+
+	// DeletedAt Set when the function has been soft-deleted. Deleted functions are hidden from normal list/get APIs and do not serve traffic.
+	DeletedAt   *time.Time `json:"deleted_at,omitempty"`
+	DomainLabel string     `json:"domain_label"`
+	Enabled     bool       `json:"enabled"`
+	Host        string     `json:"host"`
+	Id          string     `json:"id"`
+	Name        string     `json:"name"`
+	Slug        string     `json:"slug"`
+	TeamId      string     `json:"team_id"`
+	UpdatedAt   time.Time  `json:"updated_at"`
+	Url         string     `json:"url"`
 }
 
 // FunctionRestoreMount defines model for FunctionRestoreMount.
@@ -1027,10 +1057,39 @@ type FunctionRevisionCreateRequest struct {
 	Source  FunctionSourceRequest `json:"source"`
 }
 
+// FunctionRuntimeState defines model for FunctionRuntimeState.
+type FunctionRuntimeState string
+
+// FunctionRuntimeStatus defines model for FunctionRuntimeStatus.
+type FunctionRuntimeStatus struct {
+	FunctionId     string `json:"function_id"`
+	RevisionId     string `json:"revision_id"`
+	RevisionNumber int32  `json:"revision_number"`
+
+	// RuntimeContextId Current runtime process context, if one exists.
+	RuntimeContextId *string `json:"runtime_context_id,omitempty"`
+
+	// RuntimeSandboxId Current restored runtime sandbox, if one exists.
+	RuntimeSandboxId *string `json:"runtime_sandbox_id,omitempty"`
+
+	// RuntimeUpdatedAt Last time the runtime mapping was updated.
+	RuntimeUpdatedAt *time.Time           `json:"runtime_updated_at,omitempty"`
+	State            FunctionRuntimeState `json:"state"`
+}
+
 // FunctionSourceRequest defines model for FunctionSourceRequest.
 type FunctionSourceRequest struct {
 	SandboxId string `json:"sandbox_id"`
 	ServiceId string `json:"service_id"`
+}
+
+// FunctionUpdateRequest defines model for FunctionUpdateRequest.
+type FunctionUpdateRequest struct {
+	// Enabled Whether the function host should serve traffic. Disabled functions do not restore runtime sandboxes.
+	Enabled *bool `json:"enabled,omitempty"`
+
+	// Name Mutable function display name. Slug and domain label stay stable.
+	Name *string `json:"name,omitempty"`
 }
 
 // GatewayMetadata defines model for GatewayMetadata.
@@ -1999,6 +2058,17 @@ type SuccessFileStatResponse struct {
 // SuccessFileStatResponseSuccess defines model for SuccessFileStatResponse.Success.
 type SuccessFileStatResponseSuccess bool
 
+// SuccessFunctionAliasListResponse defines model for SuccessFunctionAliasListResponse.
+type SuccessFunctionAliasListResponse struct {
+	Data *struct {
+		Aliases []FunctionAlias `json:"aliases"`
+	} `json:"data,omitempty"`
+	Success SuccessFunctionAliasListResponseSuccess `json:"success"`
+}
+
+// SuccessFunctionAliasListResponseSuccess defines model for SuccessFunctionAliasListResponse.Success.
+type SuccessFunctionAliasListResponseSuccess bool
+
 // SuccessFunctionAliasResponse defines model for SuccessFunctionAliasResponse.
 type SuccessFunctionAliasResponse struct {
 	Data *struct {
@@ -2067,6 +2137,28 @@ type SuccessFunctionRevisionListResponse struct {
 
 // SuccessFunctionRevisionListResponseSuccess defines model for SuccessFunctionRevisionListResponse.Success.
 type SuccessFunctionRevisionListResponseSuccess bool
+
+// SuccessFunctionRevisionResponse defines model for SuccessFunctionRevisionResponse.
+type SuccessFunctionRevisionResponse struct {
+	Data *struct {
+		Revision FunctionRevision `json:"revision"`
+	} `json:"data,omitempty"`
+	Success SuccessFunctionRevisionResponseSuccess `json:"success"`
+}
+
+// SuccessFunctionRevisionResponseSuccess defines model for SuccessFunctionRevisionResponse.Success.
+type SuccessFunctionRevisionResponseSuccess bool
+
+// SuccessFunctionRuntimeResponse defines model for SuccessFunctionRuntimeResponse.
+type SuccessFunctionRuntimeResponse struct {
+	Data *struct {
+		Runtime FunctionRuntimeStatus `json:"runtime"`
+	} `json:"data,omitempty"`
+	Success SuccessFunctionRuntimeResponseSuccess `json:"success"`
+}
+
+// SuccessFunctionRuntimeResponseSuccess defines model for SuccessFunctionRuntimeResponse.Success.
+type SuccessFunctionRuntimeResponseSuccess bool
 
 // SuccessGatewayMetadataResponse defines model for SuccessGatewayMetadataResponse.
 type SuccessGatewayMetadataResponse struct {
@@ -2765,6 +2857,9 @@ type PutApiV1CredentialSourcesNameJSONRequestBody = CredentialSourceWriteRequest
 
 // PostApiV1FunctionsJSONRequestBody defines body for PostApiV1Functions for application/json ContentType.
 type PostApiV1FunctionsJSONRequestBody = FunctionCreateRequest
+
+// PutApiV1FunctionsIdJSONRequestBody defines body for PutApiV1FunctionsId for application/json ContentType.
+type PutApiV1FunctionsIdJSONRequestBody = FunctionUpdateRequest
 
 // PutApiV1FunctionsIdAliasesAliasJSONRequestBody defines body for PutApiV1FunctionsIdAliasesAlias for application/json ContentType.
 type PutApiV1FunctionsIdAliasesAliasJSONRequestBody = FunctionAliasUpdateRequest

--- a/pkg/gateway/functionapi/handler.go
+++ b/pkg/gateway/functionapi/handler.go
@@ -7,7 +7,9 @@ import (
 	"io"
 	"net/http"
 	neturl "net/url"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	mgr "github.com/sandbox0-ai/sandbox0/manager/pkg/service"
@@ -36,6 +38,10 @@ type RevisionVolumeStore interface {
 	DeleteRestoreMounts(ctx context.Context, authCtx *authn.AuthContext, sandbox *mgr.Sandbox, mounts []functions.RestoreMount) error
 }
 
+type RuntimeController interface {
+	DeleteRuntimeSandbox(ctx context.Context, authCtx *authn.AuthContext, sandboxID string) error
+}
+
 type PermissionMiddleware func(permission string) gin.HandlerFunc
 
 type Handler struct {
@@ -43,10 +49,11 @@ type Handler struct {
 	cfg           Config
 	sandboxLookup SandboxLookup
 	volumeStore   RevisionVolumeStore
+	runtime       RuntimeController
 	logger        *zap.Logger
 }
 
-func New(repo *functions.Repository, cfg Config, lookup SandboxLookup, volumeStore RevisionVolumeStore, logger *zap.Logger) *Handler {
+func New(repo *functions.Repository, cfg Config, lookup SandboxLookup, volumeStore RevisionVolumeStore, runtime RuntimeController, logger *zap.Logger) *Handler {
 	if logger == nil {
 		logger = zap.NewNop()
 	}
@@ -55,6 +62,7 @@ func New(repo *functions.Repository, cfg Config, lookup SandboxLookup, volumeSto
 		cfg:           cfg,
 		sandboxLookup: lookup,
 		volumeStore:   volumeStore,
+		runtime:       runtime,
 		logger:        logger,
 	}
 }
@@ -68,9 +76,17 @@ func (h *Handler) RegisterRoutes(group *gin.RouterGroup, require PermissionMiddl
 	group.GET("", require(authn.PermFunctionRead), h.listFunctions)
 	group.POST("", require(authn.PermFunctionCreate), h.createFunction)
 	group.GET("/:id", require(authn.PermFunctionRead), h.getFunction)
+	group.PUT("/:id", require(authn.PermFunctionWrite), h.updateFunction)
+	group.DELETE("/:id", require(authn.PermFunctionDelete), h.deleteFunction)
+	group.GET("/:id/aliases", require(authn.PermFunctionRead), h.listFunctionAliases)
+	group.GET("/:id/aliases/:alias", require(authn.PermFunctionRead), h.getFunctionAlias)
+	group.PUT("/:id/aliases/:alias", require(authn.PermFunctionWrite), h.setFunctionAlias)
 	group.GET("/:id/revisions", require(authn.PermFunctionRead), h.listFunctionRevisions)
 	group.POST("/:id/revisions", require(authn.PermFunctionWrite), h.createFunctionRevision)
-	group.PUT("/:id/aliases/:alias", require(authn.PermFunctionWrite), h.setFunctionAlias)
+	group.GET("/:id/revisions/:revision_number", require(authn.PermFunctionRead), h.getFunctionRevision)
+	group.GET("/:id/runtime", require(authn.PermFunctionRead), h.getFunctionRuntime)
+	group.POST("/:id/runtime/restart", require(authn.PermFunctionWrite), h.restartFunctionRuntime)
+	group.POST("/:id/runtime/recycle", require(authn.PermFunctionWrite), h.recycleFunctionRuntime)
 }
 
 func NewClusterGatewaySandboxLookup(clusterGatewayURL string, internalAuthGen *internalauth.Generator, httpClient *http.Client, logger *zap.Logger) SandboxLookup {
@@ -157,6 +173,11 @@ type createFunctionRequest struct {
 type createFunctionRevisionRequest struct {
 	Source  functionSourceRequest `json:"source"`
 	Promote *bool                 `json:"promote,omitempty"`
+}
+
+type updateFunctionRequest struct {
+	Name    *string `json:"name,omitempty"`
+	Enabled *bool   `json:"enabled,omitempty"`
 }
 
 type setFunctionAliasRequest struct {
@@ -266,6 +287,40 @@ func (h *Handler) getFunction(c *gin.Context) {
 	spec.JSONSuccess(c, http.StatusOK, gin.H{"function": h.functionRecord(fn)})
 }
 
+func (h *Handler) updateFunction(c *gin.Context) {
+	authCtx := middleware.GetAuthContext(c)
+	var req updateFunctionRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, fmt.Sprintf("invalid request: %v", err))
+		return
+	}
+	fn, err := h.repo.UpdateFunction(c.Request.Context(), authCtx.TeamID, c.Param("id"), req.Name, req.Enabled)
+	if err != nil {
+		if errors.Is(err, functions.ErrNotFound) {
+			spec.JSONError(c, http.StatusNotFound, spec.CodeNotFound, "function not found")
+			return
+		}
+		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to update function")
+		return
+	}
+	spec.JSONSuccess(c, http.StatusOK, gin.H{"function": h.functionRecord(fn)})
+}
+
+func (h *Handler) deleteFunction(c *gin.Context) {
+	authCtx := middleware.GetAuthContext(c)
+	deleted, revisions, err := h.repo.DeleteFunction(c.Request.Context(), authCtx.TeamID, c.Param("id"))
+	if err != nil {
+		if errors.Is(err, functions.ErrNotFound) {
+			spec.JSONError(c, http.StatusNotFound, spec.CodeNotFound, "function not found")
+			return
+		}
+		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to delete function")
+		return
+	}
+	go h.cleanupDeletedFunctionResources(authCtx, revisions)
+	spec.JSONSuccess(c, http.StatusOK, gin.H{"function": h.functionRecord(deleted), "message": "function deleted"})
+}
+
 func (h *Handler) listFunctionRevisions(c *gin.Context) {
 	authCtx := middleware.GetAuthContext(c)
 	revisions, err := h.repo.ListRevisions(c.Request.Context(), authCtx.TeamID, c.Param("id"))
@@ -278,6 +333,25 @@ func (h *Handler) listFunctionRevisions(c *gin.Context) {
 		return
 	}
 	spec.JSONSuccess(c, http.StatusOK, gin.H{"revisions": revisions})
+}
+
+func (h *Handler) getFunctionRevision(c *gin.Context) {
+	authCtx := middleware.GetAuthContext(c)
+	revisionNumber, err := strconv.Atoi(c.Param("revision_number"))
+	if err != nil || revisionNumber <= 0 {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "revision_number must be greater than zero")
+		return
+	}
+	rev, err := h.repo.GetRevisionByNumber(c.Request.Context(), authCtx.TeamID, c.Param("id"), revisionNumber)
+	if err != nil {
+		if errors.Is(err, functions.ErrNotFound) {
+			spec.JSONError(c, http.StatusNotFound, spec.CodeNotFound, "function revision not found")
+			return
+		}
+		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to get revision")
+		return
+	}
+	spec.JSONSuccess(c, http.StatusOK, gin.H{"revision": rev})
 }
 
 func (h *Handler) createFunctionRevision(c *gin.Context) {
@@ -351,6 +425,78 @@ func (h *Handler) setFunctionAlias(c *gin.Context) {
 		return
 	}
 	spec.JSONSuccess(c, http.StatusOK, gin.H{"alias": alias})
+}
+
+func (h *Handler) listFunctionAliases(c *gin.Context) {
+	authCtx := middleware.GetAuthContext(c)
+	aliases, err := h.repo.ListAliases(c.Request.Context(), authCtx.TeamID, c.Param("id"))
+	if err != nil {
+		if errors.Is(err, functions.ErrNotFound) {
+			spec.JSONError(c, http.StatusNotFound, spec.CodeNotFound, "function not found")
+			return
+		}
+		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to list aliases")
+		return
+	}
+	spec.JSONSuccess(c, http.StatusOK, gin.H{"aliases": aliases})
+}
+
+func (h *Handler) getFunctionAlias(c *gin.Context) {
+	authCtx := middleware.GetAuthContext(c)
+	alias, err := h.repo.GetAlias(c.Request.Context(), authCtx.TeamID, c.Param("id"), c.Param("alias"))
+	if err != nil {
+		if errors.Is(err, functions.ErrNotFound) {
+			spec.JSONError(c, http.StatusNotFound, spec.CodeNotFound, "function alias not found")
+			return
+		}
+		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to get alias")
+		return
+	}
+	spec.JSONSuccess(c, http.StatusOK, gin.H{"alias": alias})
+}
+
+func (h *Handler) getFunctionRuntime(c *gin.Context) {
+	fn, rev, ok := h.loadActiveFunctionRevision(c)
+	if !ok {
+		return
+	}
+	spec.JSONSuccess(c, http.StatusOK, gin.H{"runtime": runtimeStatus(fn, rev)})
+}
+
+func (h *Handler) restartFunctionRuntime(c *gin.Context) {
+	h.clearFunctionRuntime(c)
+}
+
+func (h *Handler) recycleFunctionRuntime(c *gin.Context) {
+	h.clearFunctionRuntime(c)
+}
+
+func (h *Handler) clearFunctionRuntime(c *gin.Context) {
+	authCtx := middleware.GetAuthContext(c)
+	fn, rev, ok := h.loadActiveFunctionRevision(c)
+	if !ok {
+		return
+	}
+	if h.runtime != nil && rev.RuntimeSandboxID != nil && strings.TrimSpace(*rev.RuntimeSandboxID) != "" {
+		if err := h.runtime.DeleteRuntimeSandbox(c.Request.Context(), authCtx, strings.TrimSpace(*rev.RuntimeSandboxID)); err != nil {
+			h.logger.Warn("Failed to delete function runtime sandbox",
+				zap.String("function_id", fn.ID),
+				zap.String("revision_id", rev.ID),
+				zap.String("runtime_sandbox_id", strings.TrimSpace(*rev.RuntimeSandboxID)),
+				zap.Error(err),
+			)
+			spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "failed to recycle function runtime")
+			return
+		}
+	}
+	if err := h.repo.ClearRevisionRuntime(c.Request.Context(), fn.TeamID, fn.ID, rev.ID); err != nil && !errors.Is(err, functions.ErrNotFound) {
+		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to clear function runtime")
+		return
+	}
+	rev.RuntimeSandboxID = nil
+	rev.RuntimeContextID = nil
+	rev.RuntimeUpdatedAt = nil
+	spec.JSONSuccess(c, http.StatusOK, gin.H{"runtime": runtimeStatus(fn, rev)})
 }
 
 func (h *Handler) loadPublishableService(ctx context.Context, authCtx *authn.AuthContext, source functionSourceRequest) (*mgr.Sandbox, mgr.SandboxAppService, error) {
@@ -433,6 +579,85 @@ func (h *Handler) deletePreparedRestoreMounts(ctx context.Context, authCtx *auth
 			zap.String("reason", reason),
 			zap.Error(err),
 		)
+	}
+}
+
+func (h *Handler) loadActiveFunctionRevision(c *gin.Context) (*functions.Function, *functions.Revision, bool) {
+	authCtx := middleware.GetAuthContext(c)
+	fn, err := h.repo.GetFunction(c.Request.Context(), authCtx.TeamID, c.Param("id"))
+	if err != nil {
+		if errors.Is(err, functions.ErrNotFound) {
+			spec.JSONError(c, http.StatusNotFound, spec.CodeNotFound, "function not found")
+			return nil, nil, false
+		}
+		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to get function")
+		return nil, nil, false
+	}
+	rev, err := h.repo.GetActiveRevision(c.Request.Context(), fn)
+	if err != nil {
+		if errors.Is(err, functions.ErrNotFound) {
+			spec.JSONError(c, http.StatusNotFound, spec.CodeNotFound, "function revision not found")
+			return nil, nil, false
+		}
+		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to get function revision")
+		return nil, nil, false
+	}
+	return fn, rev, true
+}
+
+func runtimeStatus(fn *functions.Function, rev *functions.Revision) functions.RuntimeStatus {
+	status := functions.RuntimeStatus{}
+	if fn != nil {
+		status.FunctionID = fn.ID
+	}
+	if rev != nil {
+		status.RevisionID = rev.ID
+		status.RevisionNumber = rev.RevisionNumber
+		status.RuntimeSandboxID = rev.RuntimeSandboxID
+		status.RuntimeContextID = rev.RuntimeContextID
+		status.RuntimeUpdatedAt = rev.RuntimeUpdatedAt
+	}
+	switch {
+	case fn != nil && !fn.Enabled:
+		status.State = functions.RuntimeStateDisabled
+	case rev != nil && rev.RuntimeSandboxID != nil && strings.TrimSpace(*rev.RuntimeSandboxID) != "":
+		status.State = functions.RuntimeStateActive
+	default:
+		status.State = functions.RuntimeStateIdle
+	}
+	return status
+}
+
+func (h *Handler) cleanupDeletedFunctionResources(authCtx *authn.AuthContext, revisions []*functions.Revision) {
+	if len(revisions) == 0 {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	for _, rev := range revisions {
+		if rev == nil {
+			continue
+		}
+		if h.runtime != nil && rev.RuntimeSandboxID != nil && strings.TrimSpace(*rev.RuntimeSandboxID) != "" {
+			if err := h.runtime.DeleteRuntimeSandbox(ctx, authCtx, strings.TrimSpace(*rev.RuntimeSandboxID)); err != nil {
+				h.logger.Warn("Failed to clean up deleted function runtime sandbox",
+					zap.String("function_id", rev.FunctionID),
+					zap.String("revision_id", rev.ID),
+					zap.String("runtime_sandbox_id", strings.TrimSpace(*rev.RuntimeSandboxID)),
+					zap.Error(err),
+				)
+			}
+		}
+		if h.volumeStore != nil && len(rev.RestoreMounts) > 0 {
+			sandbox := &mgr.Sandbox{ID: rev.SourceSandboxID}
+			if err := h.volumeStore.DeleteRestoreMounts(ctx, authCtx, sandbox, rev.RestoreMounts); err != nil {
+				h.logger.Warn("Failed to clean up deleted function revision volumes",
+					zap.String("function_id", rev.FunctionID),
+					zap.String("revision_id", rev.ID),
+					zap.Error(err),
+				)
+			}
+		}
 	}
 }
 

--- a/pkg/gateway/functionapi/runtime_controller.go
+++ b/pkg/gateway/functionapi/runtime_controller.go
@@ -61,7 +61,7 @@ func (c *HTTPRuntimeController) DeleteRuntimeSandbox(ctx context.Context, authCt
 	if err != nil {
 		return fmt.Errorf("generate internal token: %w", err)
 	}
-	targetURL := clusterGatewayURL + "/api/v1/sandboxes/" + url.PathEscape(sandboxID)
+	targetURL := clusterGatewayURL + "/internal/v1/sandboxes/" + url.PathEscape(sandboxID)
 	var lastErr error
 	for attempt := range 5 {
 		req, err := http.NewRequestWithContext(ctx, http.MethodDelete, targetURL, nil)

--- a/pkg/gateway/functionapi/runtime_controller.go
+++ b/pkg/gateway/functionapi/runtime_controller.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/authn"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
@@ -60,14 +61,45 @@ func (c *HTTPRuntimeController) DeleteRuntimeSandbox(ctx context.Context, authCt
 	if err != nil {
 		return fmt.Errorf("generate internal token: %w", err)
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, clusterGatewayURL+"/api/v1/sandboxes/"+url.PathEscape(sandboxID), nil)
-	if err != nil {
-		return err
+	targetURL := clusterGatewayURL + "/api/v1/sandboxes/" + url.PathEscape(sandboxID)
+	var lastErr error
+	for attempt := range 5 {
+		req, err := http.NewRequestWithContext(ctx, http.MethodDelete, targetURL, nil)
+		if err != nil {
+			return err
+		}
+		req.Header.Set(internalauth.DefaultTokenHeader, token)
+		resp, err := c.httpClient.Do(req)
+		if err == nil {
+			lastErr = deleteRuntimeSandboxResponseError(sandboxID, resp)
+			if lastErr == nil {
+				return nil
+			}
+			if !shouldRetryRuntimeSandboxDelete(resp.StatusCode) {
+				return lastErr
+			}
+		} else {
+			lastErr = err
+		}
+		if attempt == 4 {
+			break
+		}
+		delay := time.Duration(attempt+1) * 500 * time.Millisecond
+		select {
+		case <-ctx.Done():
+			if lastErr != nil {
+				return fmt.Errorf("%w: %v", ctx.Err(), lastErr)
+			}
+			return ctx.Err()
+		case <-time.After(delay):
+		}
 	}
-	req.Header.Set(internalauth.DefaultTokenHeader, token)
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return err
+	return lastErr
+}
+
+func deleteRuntimeSandboxResponseError(sandboxID string, resp *http.Response) error {
+	if resp == nil {
+		return fmt.Errorf("delete runtime sandbox %s: empty response", sandboxID)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusNotFound || (resp.StatusCode >= 200 && resp.StatusCode < 300) {
@@ -75,4 +107,8 @@ func (c *HTTPRuntimeController) DeleteRuntimeSandbox(ctx context.Context, authCt
 	}
 	body, _ := io.ReadAll(resp.Body)
 	return fmt.Errorf("delete runtime sandbox %s: %s: %s", sandboxID, resp.Status, strings.TrimSpace(string(body)))
+}
+
+func shouldRetryRuntimeSandboxDelete(statusCode int) bool {
+	return statusCode == http.StatusConflict || statusCode >= http.StatusInternalServerError
 }

--- a/pkg/gateway/functionapi/runtime_controller.go
+++ b/pkg/gateway/functionapi/runtime_controller.go
@@ -1,0 +1,78 @@
+package functionapi
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/authn"
+	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+)
+
+type HTTPRuntimeController struct {
+	resolveClusterGatewayURL ClusterGatewayURLResolver
+	internalAuthGen          *internalauth.Generator
+	httpClient               *http.Client
+}
+
+func NewHTTPRuntimeController(resolve ClusterGatewayURLResolver, internalAuthGen *internalauth.Generator, httpClient *http.Client) *HTTPRuntimeController {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &HTTPRuntimeController{
+		resolveClusterGatewayURL: resolve,
+		internalAuthGen:          internalAuthGen,
+		httpClient:               httpClient,
+	}
+}
+
+func (c *HTTPRuntimeController) DeleteRuntimeSandbox(ctx context.Context, authCtx *authn.AuthContext, sandboxID string) error {
+	sandboxID = strings.TrimSpace(sandboxID)
+	if sandboxID == "" {
+		return nil
+	}
+	if c == nil || c.resolveClusterGatewayURL == nil {
+		return fmt.Errorf("runtime controller is not configured")
+	}
+	if c.internalAuthGen == nil {
+		return fmt.Errorf("internal auth generator is not configured")
+	}
+	clusterGatewayURL, err := c.resolveClusterGatewayURL(ctx, sandboxID)
+	if err != nil {
+		return err
+	}
+	clusterGatewayURL = strings.TrimRight(strings.TrimSpace(clusterGatewayURL), "/")
+	if clusterGatewayURL == "" {
+		return fmt.Errorf("cluster gateway is not configured")
+	}
+	teamID := ""
+	userID := ""
+	if authCtx != nil {
+		teamID = authCtx.TeamID
+		userID = principalID(authCtx)
+	}
+	token, err := c.internalAuthGen.Generate(internalauth.ServiceClusterGateway, teamID, userID, internalauth.GenerateOptions{
+		Permissions: []string{authn.PermSandboxDelete, authn.PermSandboxRead},
+	})
+	if err != nil {
+		return fmt.Errorf("generate internal token: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, clusterGatewayURL+"/api/v1/sandboxes/"+url.PathEscape(sandboxID), nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set(internalauth.DefaultTokenHeader, token)
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound || (resp.StatusCode >= 200 && resp.StatusCode < 300) {
+		return nil
+	}
+	body, _ := io.ReadAll(resp.Body)
+	return fmt.Errorf("delete runtime sandbox %s: %s: %s", sandboxID, resp.Status, strings.TrimSpace(string(body)))
+}

--- a/pkg/gateway/functionapi/runtime_controller_test.go
+++ b/pkg/gateway/functionapi/runtime_controller_test.go
@@ -1,0 +1,84 @@
+package functionapi
+
+import (
+	"context"
+	"crypto/ed25519"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/authn"
+	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+)
+
+func TestHTTPRuntimeControllerDeletesSandboxThroughInternalRoute(t *testing.T) {
+	publicKey, privateKey, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	validator := internalauth.NewValidator(internalauth.ValidatorConfig{
+		Target:             internalauth.ServiceClusterGateway,
+		PublicKey:          publicKey,
+		AllowedCallers:     []string{internalauth.ServiceClusterGateway},
+		ClockSkewTolerance: time.Second,
+	})
+
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		if r.Method != http.MethodDelete {
+			t.Fatalf("method = %s, want DELETE", r.Method)
+		}
+		token := r.Header.Get(internalauth.DefaultTokenHeader)
+		if token == "" {
+			t.Fatal("missing internal auth token")
+		}
+		claims, err := validator.Validate(token)
+		if err != nil {
+			t.Fatalf("validate token: %v", err)
+		}
+		if claims.TeamID != "team-1" {
+			t.Fatalf("team id = %q, want team-1", claims.TeamID)
+		}
+		if claims.UserID != "user-1" {
+			t.Fatalf("user id = %q, want user-1", claims.UserID)
+		}
+		if !hasPermission(claims.Permissions, authn.PermSandboxDelete) {
+			t.Fatalf("token missing %s permission", authn.PermSandboxDelete)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	generator := internalauth.NewGenerator(internalauth.GeneratorConfig{
+		Caller:     internalauth.ServiceClusterGateway,
+		PrivateKey: privateKey,
+		TTL:        time.Minute,
+	})
+	controller := NewHTTPRuntimeController(
+		StaticClusterGatewayURLResolver(server.URL),
+		generator,
+		server.Client(),
+	)
+	err = controller.DeleteRuntimeSandbox(context.Background(), &authn.AuthContext{
+		TeamID:      "team-1",
+		UserID:      "user-1",
+		Permissions: []string{authn.PermSandboxDelete},
+	}, "sandbox-1")
+	if err != nil {
+		t.Fatalf("DeleteRuntimeSandbox() error = %v", err)
+	}
+	if gotPath != "/internal/v1/sandboxes/sandbox-1" {
+		t.Fatalf("path = %q, want internal sandbox route", gotPath)
+	}
+}
+
+func hasPermission(permissions []string, want string) bool {
+	for _, permission := range permissions {
+		if permission == want || permission == "*" {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/gateway/functions/models.go
+++ b/pkg/gateway/functions/models.go
@@ -8,15 +8,17 @@ import (
 const ProductionAlias = "production"
 
 type Function struct {
-	ID               string    `json:"id"`
-	TeamID           string    `json:"team_id"`
-	Name             string    `json:"name"`
-	Slug             string    `json:"slug"`
-	DomainLabel      string    `json:"domain_label"`
-	ActiveRevisionID *string   `json:"active_revision_id,omitempty"`
-	CreatedBy        string    `json:"created_by,omitempty"`
-	CreatedAt        time.Time `json:"created_at"`
-	UpdatedAt        time.Time `json:"updated_at"`
+	ID               string     `json:"id"`
+	TeamID           string     `json:"team_id"`
+	Name             string     `json:"name"`
+	Slug             string     `json:"slug"`
+	DomainLabel      string     `json:"domain_label"`
+	ActiveRevisionID *string    `json:"active_revision_id,omitempty"`
+	Enabled          bool       `json:"enabled"`
+	CreatedBy        string     `json:"created_by,omitempty"`
+	CreatedAt        time.Time  `json:"created_at"`
+	UpdatedAt        time.Time  `json:"updated_at"`
+	DeletedAt        *time.Time `json:"deleted_at,omitempty"`
 }
 
 type Revision struct {
@@ -50,4 +52,22 @@ type Alias struct {
 	RevisionNumber int       `json:"revision_number"`
 	UpdatedBy      string    `json:"updated_by,omitempty"`
 	UpdatedAt      time.Time `json:"updated_at"`
+}
+
+type RuntimeState string
+
+const (
+	RuntimeStateDisabled RuntimeState = "disabled"
+	RuntimeStateIdle     RuntimeState = "idle"
+	RuntimeStateActive   RuntimeState = "active"
+)
+
+type RuntimeStatus struct {
+	FunctionID       string       `json:"function_id"`
+	RevisionID       string       `json:"revision_id"`
+	RevisionNumber   int          `json:"revision_number"`
+	State            RuntimeState `json:"state"`
+	RuntimeSandboxID *string      `json:"runtime_sandbox_id,omitempty"`
+	RuntimeContextID *string      `json:"runtime_context_id,omitempty"`
+	RuntimeUpdatedAt *time.Time   `json:"runtime_updated_at,omitempty"`
 }

--- a/pkg/gateway/functions/repository.go
+++ b/pkg/gateway/functions/repository.go
@@ -134,9 +134,9 @@ func (r *Repository) ListFunctions(ctx context.Context, teamID string) ([]*Funct
 		return nil, fmt.Errorf("function repository is not configured")
 	}
 	rows, err := r.pool.Query(ctx, `
-		SELECT id, team_id, name, slug, domain_label, active_revision_id, created_by, created_at, updated_at
+		SELECT id, team_id, name, slug, domain_label, active_revision_id, enabled, created_by, created_at, updated_at, deleted_at
 		FROM functions
-		WHERE team_id = $1
+		WHERE team_id = $1 AND deleted_at IS NULL
 		ORDER BY updated_at DESC, created_at DESC
 	`, teamID)
 	if err != nil {
@@ -162,15 +162,15 @@ func (r *Repository) GetFunction(ctx context.Context, teamID, ref string) (*Func
 	var row pgx.Row
 	if id, err := uuid.Parse(ref); err == nil {
 		row = r.pool.QueryRow(ctx, `
-			SELECT id, team_id, name, slug, domain_label, active_revision_id, created_by, created_at, updated_at
+			SELECT id, team_id, name, slug, domain_label, active_revision_id, enabled, created_by, created_at, updated_at, deleted_at
 			FROM functions
-			WHERE team_id = $1 AND (id = $2 OR slug = $3)
+			WHERE team_id = $1 AND deleted_at IS NULL AND (id = $2 OR slug = $3)
 		`, teamID, id, ref)
 	} else {
 		row = r.pool.QueryRow(ctx, `
-			SELECT id, team_id, name, slug, domain_label, active_revision_id, created_by, created_at, updated_at
+			SELECT id, team_id, name, slug, domain_label, active_revision_id, enabled, created_by, created_at, updated_at, deleted_at
 			FROM functions
-			WHERE team_id = $1 AND slug = $2
+			WHERE team_id = $1 AND deleted_at IS NULL AND slug = $2
 		`, teamID, ref)
 	}
 	fn, err := scanFunction(row)
@@ -185,9 +185,9 @@ func (r *Repository) GetFunctionByDomainLabel(ctx context.Context, domainLabel s
 		return nil, fmt.Errorf("function repository is not configured")
 	}
 	row := r.pool.QueryRow(ctx, `
-		SELECT id, team_id, name, slug, domain_label, active_revision_id, created_by, created_at, updated_at
+		SELECT id, team_id, name, slug, domain_label, active_revision_id, enabled, created_by, created_at, updated_at, deleted_at
 		FROM functions
-		WHERE domain_label = $1
+		WHERE domain_label = $1 AND deleted_at IS NULL
 	`, domainLabel)
 	fn, err := scanFunction(row)
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -263,6 +263,28 @@ func (r *Repository) GetRevision(ctx context.Context, teamID, functionID, revisi
 	return rev, err
 }
 
+func (r *Repository) GetRevisionByNumber(ctx context.Context, teamID, functionRef string, revisionNumber int) (*Revision, error) {
+	if r == nil || r.pool == nil {
+		return nil, fmt.Errorf("function repository is not configured")
+	}
+	fn, err := r.GetFunction(ctx, teamID, functionRef)
+	if err != nil {
+		return nil, err
+	}
+	row := r.pool.QueryRow(ctx, `
+		SELECT id, function_id, team_id, revision_number, source_sandbox_id, source_service_id,
+			source_template_id, restore_mounts, service_snapshot, runtime_sandbox_id, runtime_context_id,
+			runtime_updated_at, created_by, created_at
+		FROM functions_revisions
+		WHERE function_id = $1 AND revision_number = $2
+	`, fn.ID, revisionNumber)
+	rev, err := scanRevision(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	return rev, err
+}
+
 func (r *Repository) SetRevisionRuntime(ctx context.Context, teamID, functionID, revisionID, sandboxID, contextID string) (*Revision, error) {
 	if r == nil || r.pool == nil {
 		return nil, fmt.Errorf("function repository is not configured")
@@ -298,6 +320,114 @@ func (r *Repository) ClearRevisionRuntime(ctx context.Context, teamID, functionI
 		return ErrNotFound
 	}
 	return nil
+}
+
+func (r *Repository) UpdateFunction(ctx context.Context, teamID, functionRef string, name *string, enabled *bool) (*Function, error) {
+	if r == nil || r.pool == nil {
+		return nil, fmt.Errorf("function repository is not configured")
+	}
+	fn, err := r.GetFunction(ctx, teamID, functionRef)
+	if err != nil {
+		return nil, err
+	}
+	nextName := fn.Name
+	if name != nil && strings.TrimSpace(*name) != "" {
+		nextName = strings.TrimSpace(*name)
+	}
+	nextEnabled := fn.Enabled
+	if enabled != nil {
+		nextEnabled = *enabled
+	}
+	row := r.pool.QueryRow(ctx, `
+		UPDATE functions
+		SET name = $3, enabled = $4, updated_at = NOW()
+		WHERE team_id = $1 AND id = $2 AND deleted_at IS NULL
+		RETURNING id, team_id, name, slug, domain_label, active_revision_id, enabled, created_by, created_at, updated_at, deleted_at
+	`, teamID, fn.ID, nextName, nextEnabled)
+	updated, err := scanFunction(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	return updated, err
+}
+
+func (r *Repository) DeleteFunction(ctx context.Context, teamID, functionRef string) (*Function, []*Revision, error) {
+	if r == nil || r.pool == nil {
+		return nil, nil, fmt.Errorf("function repository is not configured")
+	}
+	fn, err := r.GetFunction(ctx, teamID, functionRef)
+	if err != nil {
+		return nil, nil, err
+	}
+	revisions, err := r.ListRevisions(ctx, teamID, fn.ID)
+	if err != nil {
+		return nil, nil, err
+	}
+	row := r.pool.QueryRow(ctx, `
+		UPDATE functions
+		SET enabled = FALSE, deleted_at = NOW(), updated_at = NOW()
+		WHERE team_id = $1 AND id = $2 AND deleted_at IS NULL
+		RETURNING id, team_id, name, slug, domain_label, active_revision_id, enabled, created_by, created_at, updated_at, deleted_at
+	`, teamID, fn.ID)
+	deleted, err := scanFunction(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+	return deleted, revisions, nil
+}
+
+func (r *Repository) ListAliases(ctx context.Context, teamID, functionRef string) ([]*Alias, error) {
+	if r == nil || r.pool == nil {
+		return nil, fmt.Errorf("function repository is not configured")
+	}
+	fn, err := r.GetFunction(ctx, teamID, functionRef)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := r.pool.Query(ctx, `
+		SELECT a.function_id, a.alias, a.revision_id, r.revision_number, a.updated_by, a.updated_at
+		FROM functions_aliases a
+		JOIN functions_revisions r ON r.id = a.revision_id
+		WHERE a.function_id = $1
+		ORDER BY a.alias
+	`, fn.ID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []*Alias
+	for rows.Next() {
+		alias, err := scanAlias(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, alias)
+	}
+	return out, rows.Err()
+}
+
+func (r *Repository) GetAlias(ctx context.Context, teamID, functionRef, aliasName string) (*Alias, error) {
+	if r == nil || r.pool == nil {
+		return nil, fmt.Errorf("function repository is not configured")
+	}
+	fn, err := r.GetFunction(ctx, teamID, functionRef)
+	if err != nil {
+		return nil, err
+	}
+	row := r.pool.QueryRow(ctx, `
+		SELECT a.function_id, a.alias, a.revision_id, r.revision_number, a.updated_by, a.updated_at
+		FROM functions_aliases a
+		JOIN functions_revisions r ON r.id = a.revision_id
+		WHERE a.function_id = $1 AND a.alias = $2
+	`, fn.ID, aliasName)
+	out, err := scanAlias(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	return out, err
 }
 
 func (r *Repository) SetAlias(ctx context.Context, teamID, functionRef, alias string, revisionNumber int, updatedBy string) (*Alias, error) {
@@ -350,6 +480,7 @@ func NewFunction(teamID, name, userID string) *Function {
 		Name:        strings.TrimSpace(name),
 		Slug:        slug,
 		DomainLabel: DomainLabel(slug, teamID),
+		Enabled:     true,
 		CreatedBy:   userID,
 	}
 }
@@ -373,9 +504,9 @@ func NewRevision(teamID, sandboxID, serviceID, templateID string, snapshot any, 
 func insertFunction(ctx context.Context, tx pgx.Tx, fn *Function) error {
 	_, err := tx.Exec(ctx, `
 		INSERT INTO functions (
-			id, team_id, name, slug, domain_label, active_revision_id, created_by, created_at, updated_at
-		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
-	`, fn.ID, fn.TeamID, fn.Name, fn.Slug, fn.DomainLabel, fn.ActiveRevisionID, fn.CreatedBy, fn.CreatedAt, fn.UpdatedAt)
+			id, team_id, name, slug, domain_label, active_revision_id, enabled, created_by, created_at, updated_at, deleted_at
+		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
+	`, fn.ID, fn.TeamID, fn.Name, fn.Slug, fn.DomainLabel, fn.ActiveRevisionID, fn.Enabled, fn.CreatedBy, fn.CreatedAt, fn.UpdatedAt, fn.DeletedAt)
 	return err
 }
 
@@ -412,10 +543,18 @@ type rowScanner interface {
 
 func scanFunction(row rowScanner) (*Function, error) {
 	var fn Function
-	if err := row.Scan(&fn.ID, &fn.TeamID, &fn.Name, &fn.Slug, &fn.DomainLabel, &fn.ActiveRevisionID, &fn.CreatedBy, &fn.CreatedAt, &fn.UpdatedAt); err != nil {
+	if err := row.Scan(&fn.ID, &fn.TeamID, &fn.Name, &fn.Slug, &fn.DomainLabel, &fn.ActiveRevisionID, &fn.Enabled, &fn.CreatedBy, &fn.CreatedAt, &fn.UpdatedAt, &fn.DeletedAt); err != nil {
 		return nil, err
 	}
 	return &fn, nil
+}
+
+func scanAlias(row rowScanner) (*Alias, error) {
+	var alias Alias
+	if err := row.Scan(&alias.FunctionID, &alias.Alias, &alias.RevisionID, &alias.RevisionNumber, &alias.UpdatedBy, &alias.UpdatedAt); err != nil {
+		return nil, err
+	}
+	return &alias, nil
 }
 
 func scanRevision(row rowScanner) (*Revision, error) {

--- a/pkg/gateway/migrations/00010_add_function_lifecycle.sql
+++ b/pkg/gateway/migrations/00010_add_function_lifecycle.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+ALTER TABLE functions
+    ADD COLUMN IF NOT EXISTS enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_functions_team_id_active ON functions(team_id) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_functions_domain_label_active ON functions(domain_label) WHERE deleted_at IS NULL;
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_functions_domain_label_active;
+DROP INDEX IF EXISTS idx_functions_team_id_active;
+ALTER TABLE functions
+    DROP COLUMN IF EXISTS deleted_at,
+    DROP COLUMN IF EXISTS enabled;

--- a/regional-gateway/pkg/http/server.go
+++ b/regional-gateway/pkg/http/server.go
@@ -350,6 +350,7 @@ func (s *Server) setupRoutes() {
 				},
 				s.functionSandboxLookup,
 				functionapi.NewHTTPVolumeSnapshotter(s.resolveFunctionClusterGatewayURL, s.internalAuthGen, s.functionSnapshotHTTPClient(), s.logger),
+				functionapi.NewHTTPRuntimeController(s.resolveFunctionClusterGatewayURL, s.internalAuthGen, s.functionSnapshotHTTPClient()),
 				s.logger,
 			)
 			functionHandler.RegisterRoutes(functionRoutes, s.authMiddleware.RequirePermission)

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -1741,7 +1741,7 @@ func assertFunctionAPIRoutesReachUserService(env *framework.ScenarioEnv, session
 
 	pathPrefix := "/"
 	cwd := "/tmp/s0-function-e2e"
-	command := []string{"/bin/sh", "-lc", fmt.Sprintf("python3 -m http.server %d --bind 0.0.0.0 -d /tmp/s0-function-e2e", servicePort)}
+	command := []string{"python3", "-m", "http.server", fmt.Sprint(servicePort), "--bind", "0.0.0.0", "-d", cwd}
 	_, _, updateStatus, err := session.UpdateSandboxServices(env.TestCtx.Context, GinkgoT(), sandboxID, []apispec.SandboxAppService{{
 		Id:   serviceID,
 		Port: servicePort,
@@ -1836,7 +1836,7 @@ func assertFunctionRuntimeRestoreUsesVolumeSnapshot(env *framework.ScenarioEnv, 
 
 	pathPrefix := "/"
 	cwd := mountPoint
-	command := []string{"/bin/sh", "-lc", fmt.Sprintf("python3 -m http.server %d --bind 0.0.0.0 -d %s", servicePort, shellQuote(mountPoint))}
+	command := []string{"python3", "-m", "http.server", fmt.Sprint(servicePort), "--bind", "0.0.0.0", "-d", mountPoint}
 	_, _, updateStatus, err := session.UpdateSandboxServices(env.TestCtx.Context, GinkgoT(), sourceSandboxID, []apispec.SandboxAppService{{
 		Id:   serviceID,
 		Port: servicePort,

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -192,7 +192,7 @@ func registerApiModeSuite(envProvider func() *framework.ScenarioEnv, opts apiMod
 				It("publishes a sandbox service without capturing function /api routes", func() {
 					assertFunctionAPIRoutesReachUserService(env, session, sandboxID)
 				})
-				It("restores a runtime sandbox from revision volume snapshots", func() {
+				It("restores a runtime sandbox from revision volume snapshots and manages lifecycle APIs", func() {
 					assertFunctionRuntimeRestoreUsesVolumeSnapshot(env, session)
 				})
 			})
@@ -1511,7 +1511,7 @@ func assertCredentialSourceBindingLifecycle(env *framework.ScenarioEnv, session 
 				CredentialRef: refName,
 				Domains:       &domains,
 				Protocol:      ptrTo(apispec.EgressAuthProtocolHttps),
-				Rollout:       ptrTo(apispec.Enabled),
+				Rollout:       ptrTo(apispec.EgressAuthRolloutModeEnabled),
 			}},
 		},
 		CredentialBindings: &[]apispec.CredentialBinding{{
@@ -1882,6 +1882,111 @@ func assertFunctionRuntimeRestoreUsesVolumeSnapshot(env *framework.ScenarioEnv, 
 		}
 		if body != string(seedContent) {
 			return fmt.Errorf("function restore body = %q, want %q", body, string(seedContent))
+		}
+		return nil
+	}).WithTimeout(90 * time.Second).WithPolling(2 * time.Second).Should(Succeed())
+
+	runtimeStatus, status, err := session.GetFunctionRuntime(env.TestCtx.Context, GinkgoT(), fn.Id)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+	Expect(runtimeStatus.State).To(Equal(apispec.FunctionRuntimeStateActive))
+	Expect(runtimeStatus.RuntimeSandboxId).NotTo(BeNil())
+	firstRuntimeSandboxID := *runtimeStatus.RuntimeSandboxId
+	Expect(firstRuntimeSandboxID).NotTo(BeEmpty())
+
+	aliases, status, err := session.ListFunctionAliases(env.TestCtx.Context, GinkgoT(), fn.Id)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+	Expect(aliases).NotTo(BeEmpty())
+	Expect(aliases[0].Alias).To(Equal("production"))
+	Expect(aliases[0].RevisionNumber).To(Equal(int32(1)))
+
+	alias, status, err := session.GetFunctionAlias(env.TestCtx.Context, GinkgoT(), fn.Id, "production")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+	Expect(alias.RevisionNumber).To(Equal(int32(1)))
+
+	revision, status, err := session.GetFunctionRevision(env.TestCtx.Context, GinkgoT(), fn.Id, 1)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+	Expect(revision.Id).To(Equal(alias.RevisionId))
+	Expect(revision.RestoreMounts).NotTo(BeNil())
+	Expect(*revision.RestoreMounts).NotTo(BeEmpty())
+
+	disabled := false
+	updated, status, err := session.UpdateFunction(env.TestCtx.Context, GinkgoT(), fn.Id, apispec.FunctionUpdateRequest{Enabled: &disabled})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+	Expect(updated.Enabled).To(BeFalse())
+
+	Consistently(func() int {
+		status, _, err := requestFunctionHost(env.TestCtx.Context, functionGatewayURL, fn.Host, seedPath)
+		if err != nil {
+			return 0
+		}
+		return status
+	}).WithTimeout(5 * time.Second).WithPolling(1 * time.Second).Should(Equal(http.StatusServiceUnavailable))
+
+	runtimeStatus, status, err = session.GetFunctionRuntime(env.TestCtx.Context, GinkgoT(), fn.Id)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+	Expect(runtimeStatus.State).To(Equal(apispec.FunctionRuntimeStateDisabled))
+
+	enabled := true
+	updated, status, err = session.UpdateFunction(env.TestCtx.Context, GinkgoT(), fn.Id, apispec.FunctionUpdateRequest{Enabled: &enabled})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+	Expect(updated.Enabled).To(BeTrue())
+	expectFunctionBodyEventually(env, functionGatewayURL, fn.Host, seedPath, string(seedContent))
+
+	runtimeStatus, status, err = session.RestartFunctionRuntime(env.TestCtx.Context, GinkgoT(), fn.Id)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+	Expect(runtimeStatus.State).To(Equal(apispec.FunctionRuntimeStateIdle))
+	Expect(runtimeStatus.RuntimeSandboxId).To(BeNil())
+	expectFunctionBodyEventually(env, functionGatewayURL, fn.Host, seedPath, string(seedContent))
+
+	runtimeStatus, status, err = session.GetFunctionRuntime(env.TestCtx.Context, GinkgoT(), fn.Id)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+	Expect(runtimeStatus.State).To(Equal(apispec.FunctionRuntimeStateActive))
+	Expect(runtimeStatus.RuntimeSandboxId).NotTo(BeNil())
+	Expect(*runtimeStatus.RuntimeSandboxId).NotTo(Equal(firstRuntimeSandboxID))
+
+	runtimeStatus, status, err = session.RecycleFunctionRuntime(env.TestCtx.Context, GinkgoT(), fn.Id)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+	Expect(runtimeStatus.State).To(Equal(apispec.FunctionRuntimeStateIdle))
+	Expect(runtimeStatus.RuntimeSandboxId).To(BeNil())
+	expectFunctionBodyEventually(env, functionGatewayURL, fn.Host, seedPath, string(seedContent))
+
+	status, err = session.DeleteFunction(env.TestCtx.Context, GinkgoT(), fn.Id)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+
+	Eventually(func() error {
+		status, body, err := requestFunctionHost(env.TestCtx.Context, functionGatewayURL, fn.Host, seedPath)
+		if err != nil {
+			return err
+		}
+		if status != http.StatusNotFound {
+			return fmt.Errorf("deleted function status %d body %q", status, body)
+		}
+		return nil
+	}).WithTimeout(30 * time.Second).WithPolling(1 * time.Second).Should(Succeed())
+}
+
+func expectFunctionBodyEventually(env *framework.ScenarioEnv, functionGatewayURL, host, path, expected string) {
+	Eventually(func() error {
+		status, body, err := requestFunctionHost(env.TestCtx.Context, functionGatewayURL, host, path)
+		if err != nil {
+			return err
+		}
+		if status != http.StatusOK {
+			return fmt.Errorf("function status %d body %q", status, body)
+		}
+		if body != expected {
+			return fmt.Errorf("function body = %q, want %q", body, expected)
 		}
 		return nil
 	}).WithTimeout(90 * time.Second).WithPolling(2 * time.Second).Should(Succeed())

--- a/tests/e2e/cases/api_network_policy_ssh.go
+++ b/tests/e2e/cases/api_network_policy_ssh.go
@@ -395,7 +395,7 @@ func assertSSHTransparentEgressAuthProxy(env *framework.ScenarioEnv, session *e2
 				CredentialRef: refName,
 				Ports:         &ports,
 				Protocol:      ptrTo(apispec.EgressAuthProtocolSsh),
-				Rollout:       ptrTo(apispec.Enabled),
+				Rollout:       ptrTo(apispec.EgressAuthRolloutModeEnabled),
 			}},
 		},
 		CredentialBindings: &[]apispec.CredentialBinding{{

--- a/tests/e2e/utils/function.go
+++ b/tests/e2e/utils/function.go
@@ -38,3 +38,146 @@ func (s *Session) CreateFunctionFromSandbox(ctx context.Context, t ContractT, sa
 	}
 	return &resp.Data.Function, status, nil
 }
+
+func (s *Session) GetFunction(ctx context.Context, t ContractT, functionID string) (*apispec.FunctionRecord, int, error) {
+	specPath := "/api/v1/functions/{id}"
+	requestPath := "/api/v1/functions/" + functionID
+	status, body, err := s.doJSONSpecRequest(t, ctx, http.MethodGet, specPath, requestPath, nil, true)
+	if err != nil {
+		return nil, status, err
+	}
+	if status != http.StatusOK {
+		return nil, status, fmt.Errorf("get function failed with status %d: %s", status, formatAPIError(body))
+	}
+	var resp apispec.SuccessFunctionResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, status, err
+	}
+	if !bool(resp.Success) || resp.Data == nil {
+		return nil, status, fmt.Errorf("get function response missing data")
+	}
+	return &resp.Data.Function, status, nil
+}
+
+func (s *Session) UpdateFunction(ctx context.Context, t ContractT, functionID string, req apispec.FunctionUpdateRequest) (*apispec.FunctionRecord, int, error) {
+	specPath := "/api/v1/functions/{id}"
+	requestPath := "/api/v1/functions/" + functionID
+	status, body, err := s.doJSONSpecRequest(t, ctx, http.MethodPut, specPath, requestPath, req, true)
+	if err != nil {
+		return nil, status, err
+	}
+	if status != http.StatusOK {
+		return nil, status, fmt.Errorf("update function failed with status %d: %s", status, formatAPIError(body))
+	}
+	var resp apispec.SuccessFunctionResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, status, err
+	}
+	if !bool(resp.Success) || resp.Data == nil {
+		return nil, status, fmt.Errorf("update function response missing data")
+	}
+	return &resp.Data.Function, status, nil
+}
+
+func (s *Session) DeleteFunction(ctx context.Context, t ContractT, functionID string) (int, error) {
+	specPath := "/api/v1/functions/{id}"
+	requestPath := "/api/v1/functions/" + functionID
+	status, body, err := s.doJSONSpecRequest(t, ctx, http.MethodDelete, specPath, requestPath, nil, true)
+	if err != nil {
+		return status, err
+	}
+	if status != http.StatusOK && status != http.StatusNotFound {
+		return status, fmt.Errorf("delete function failed with status %d: %s", status, formatAPIError(body))
+	}
+	return status, nil
+}
+
+func (s *Session) ListFunctionAliases(ctx context.Context, t ContractT, functionID string) ([]apispec.FunctionAlias, int, error) {
+	specPath := "/api/v1/functions/{id}/aliases"
+	requestPath := "/api/v1/functions/" + functionID + "/aliases"
+	status, body, err := s.doJSONSpecRequest(t, ctx, http.MethodGet, specPath, requestPath, nil, true)
+	if err != nil {
+		return nil, status, err
+	}
+	if status != http.StatusOK {
+		return nil, status, fmt.Errorf("list function aliases failed with status %d: %s", status, formatAPIError(body))
+	}
+	var resp apispec.SuccessFunctionAliasListResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, status, err
+	}
+	if !bool(resp.Success) || resp.Data == nil {
+		return nil, status, fmt.Errorf("list function aliases response missing data")
+	}
+	return resp.Data.Aliases, status, nil
+}
+
+func (s *Session) GetFunctionAlias(ctx context.Context, t ContractT, functionID, alias string) (*apispec.FunctionAlias, int, error) {
+	specPath := "/api/v1/functions/{id}/aliases/{alias}"
+	requestPath := "/api/v1/functions/" + functionID + "/aliases/" + alias
+	status, body, err := s.doJSONSpecRequest(t, ctx, http.MethodGet, specPath, requestPath, nil, true)
+	if err != nil {
+		return nil, status, err
+	}
+	if status != http.StatusOK {
+		return nil, status, fmt.Errorf("get function alias failed with status %d: %s", status, formatAPIError(body))
+	}
+	var resp apispec.SuccessFunctionAliasResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, status, err
+	}
+	if !bool(resp.Success) || resp.Data == nil {
+		return nil, status, fmt.Errorf("get function alias response missing data")
+	}
+	return &resp.Data.Alias, status, nil
+}
+
+func (s *Session) GetFunctionRevision(ctx context.Context, t ContractT, functionID string, revisionNumber int32) (*apispec.FunctionRevision, int, error) {
+	specPath := "/api/v1/functions/{id}/revisions/{revision_number}"
+	requestPath := fmt.Sprintf("/api/v1/functions/%s/revisions/%d", functionID, revisionNumber)
+	status, body, err := s.doJSONSpecRequest(t, ctx, http.MethodGet, specPath, requestPath, nil, true)
+	if err != nil {
+		return nil, status, err
+	}
+	if status != http.StatusOK {
+		return nil, status, fmt.Errorf("get function revision failed with status %d: %s", status, formatAPIError(body))
+	}
+	var resp apispec.SuccessFunctionRevisionResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, status, err
+	}
+	if !bool(resp.Success) || resp.Data == nil {
+		return nil, status, fmt.Errorf("get function revision response missing data")
+	}
+	return &resp.Data.Revision, status, nil
+}
+
+func (s *Session) GetFunctionRuntime(ctx context.Context, t ContractT, functionID string) (*apispec.FunctionRuntimeStatus, int, error) {
+	return s.functionRuntimeAction(ctx, t, http.MethodGet, "/api/v1/functions/{id}/runtime", "/api/v1/functions/"+functionID+"/runtime")
+}
+
+func (s *Session) RestartFunctionRuntime(ctx context.Context, t ContractT, functionID string) (*apispec.FunctionRuntimeStatus, int, error) {
+	return s.functionRuntimeAction(ctx, t, http.MethodPost, "/api/v1/functions/{id}/runtime/restart", "/api/v1/functions/"+functionID+"/runtime/restart")
+}
+
+func (s *Session) RecycleFunctionRuntime(ctx context.Context, t ContractT, functionID string) (*apispec.FunctionRuntimeStatus, int, error) {
+	return s.functionRuntimeAction(ctx, t, http.MethodPost, "/api/v1/functions/{id}/runtime/recycle", "/api/v1/functions/"+functionID+"/runtime/recycle")
+}
+
+func (s *Session) functionRuntimeAction(ctx context.Context, t ContractT, method, specPath, requestPath string) (*apispec.FunctionRuntimeStatus, int, error) {
+	status, body, err := s.doJSONSpecRequest(t, ctx, method, specPath, requestPath, nil, true)
+	if err != nil {
+		return nil, status, err
+	}
+	if status != http.StatusOK {
+		return nil, status, fmt.Errorf("function runtime request failed with status %d: %s", status, formatAPIError(body))
+	}
+	var resp apispec.SuccessFunctionRuntimeResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, status, err
+	}
+	if !bool(resp.Success) || resp.Data == nil {
+		return nil, status, fmt.Errorf("function runtime response missing data")
+	}
+	return &resp.Data.Runtime, status, nil
+}


### PR DESCRIPTION
## Summary

Closes #319.

Adds the P1 function lifecycle management surface:

- `PUT /api/v1/functions/{id}` for mutable function metadata and `enabled` lifecycle state
- `DELETE /api/v1/functions/{id}` as a soft delete that disables the host and keeps slug/domain labels reserved
- alias list/get APIs
- revision get-by-number API
- runtime status, restart, and recycle APIs

## Behavior

- Disabled functions return `503` from the function host and do not restore runtime sandboxes.
- Deleted functions are hidden from list/get APIs and return not found from the function host.
- Runtime restart/recycle delete the current restored runtime sandbox when present, clear the runtime mapping, and let the next request start a fresh runtime from the active revision.
- Function deletion schedules best-effort cleanup of restored runtime sandboxes and revision-owned volumes.

## Implementation Notes

- Adds `enabled` and `deleted_at` columns to the region-local function registry.
- Keeps revision records immutable and function slug/domain labels stable.
- Reuses the shared `pkg/gateway/functionapi` handler in regional-gateway and cluster-gateway.
- Adds an HTTP runtime controller so regional and single-cluster deployments can delete restored runtime sandboxes through the correct cluster-gateway path.

## Tests

- `make apispec`
- `go test ./pkg/gateway/functions ./pkg/gateway/functionapi ./function-gateway/pkg/http ./cluster-gateway/pkg/http ./regional-gateway/pkg/http ./tests/e2e/cases`
- `git diff --check`

## E2E Coverage Added

The function e2e lifecycle path now covers:

- create function
- source sandbox delete and runtime restore from revision volume snapshot
- alias list/get
- revision get
- runtime status
- disable and enable
- runtime restart
- runtime recycle
- delete behavior from the function host
