### PR TITLE
Standardize docs next steps

### DIFF
--- a/docs/credential/egress-auth/page.mdx
+++ b/docs/credential/egress-auth/page.mdx
@@ -404,28 +404,12 @@ For supported protocols, auth material is resolved and injected by the egress pa
 
 ## Next Steps
 
-<CardGrid>
-  <LinkCard
-    title="Sandbox Network"
-    href="/docs/sandbox/network"
-    cta="Learn More"
-  >
-    Define the traffic allow and deny policy around `trafficRules`
-  </LinkCard>
+<NextSteps>
+  <NextStep title="Overview" href="/docs/template">
+    Define reusable sandbox environments before creating or scaling sandboxes.
+  </NextStep>
 
-  <LinkCard
-    title="Template Configuration"
-    href="/docs/template/configuration"
-    cta="Learn More"
-  >
-    Set default egress auth policy at template level with `spec.network`
-  </LinkCard>
-
-  <LinkCard
-    title="Self-Hosted Configuration"
-    href="/docs/self-hosted/configuration"
-    cta="Learn More"
-  >
-    Carry the same network and credential policy model into private deployments
-  </LinkCard>
-</CardGrid>
+  <NextStep title="Custom Images" href="/docs/template/images">
+    Build and reference custom container images for sandbox templates.
+  </NextStep>
+</NextSteps>

--- a/docs/credential/page.mdx
+++ b/docs/credential/page.mdx
@@ -48,28 +48,12 @@ That public shape is `SandboxNetworkPolicy` in all three places.
 
 ## Next Steps
 
-<CardGrid>
-  <LinkCard
-    title="Sources"
-    href="/docs/credential/sources"
-    cta="Learn More"
-  >
-    Create and manage reusable credential sources
-  </LinkCard>
+<NextSteps>
+  <NextStep title="Sources" href="/docs/credential/sources">
+    Create reusable credential sources for runtime projection.
+  </NextStep>
 
-  <LinkCard
-    title="Egress Auth"
-    href="/docs/credential/egress-auth"
-    cta="Learn More"
-  >
-    Bind sources and inject outbound auth for matching destinations
-  </LinkCard>
-
-  <LinkCard
-    title="Sandbox Network"
-    href="/docs/sandbox/network"
-    cta="Learn More"
-  >
-    Control traffic allow and deny behavior with `trafficRules`
-  </LinkCard>
-</CardGrid>
+  <NextStep title="Egress Auth" href="/docs/credential/egress-auth">
+    Inject destination-scoped outbound credentials through network policy.
+  </NextStep>
+</NextSteps>

--- a/docs/credential/sources/page.mdx
+++ b/docs/credential/sources/page.mdx
@@ -324,28 +324,12 @@ console.log('deleted github-source');`
 
 ## Next Steps
 
-<CardGrid>
-  <LinkCard
-    title="Egress Auth"
-    href="/docs/credential/egress-auth"
-    cta="Learn More"
-  >
-    Bind sources and apply outbound auth to matching traffic
-  </LinkCard>
+<NextSteps>
+  <NextStep title="Egress Auth" href="/docs/credential/egress-auth">
+    Inject destination-scoped outbound credentials through network policy.
+  </NextStep>
 
-  <LinkCard
-    title="Template Configuration"
-    href="/docs/template/configuration"
-    cta="Learn More"
-  >
-    Set default credential bindings and egress auth at template level
-  </LinkCard>
-
-  <LinkCard
-    title="Sandbox Network"
-    href="/docs/sandbox/network"
-    cta="Learn More"
-  >
-    Keep traffic allow and deny policy separate from outbound auth
-  </LinkCard>
-</CardGrid>
+  <NextStep title="Overview" href="/docs/template">
+    Define reusable sandbox environments before creating or scaling sandboxes.
+  </NextStep>
+</NextSteps>

--- a/docs/function/page.mdx
+++ b/docs/function/page.mdx
@@ -178,3 +178,15 @@ Inspect and recycle the active restored runtime:
 </Endpoint>
 
 `restart` and `recycle` both delete the current restored runtime sandbox when one exists and clear the runtime mapping. The next function request starts a fresh runtime from the active revision.
+
+## Next Steps
+
+<NextSteps>
+  <NextStep title="Overview" href="/docs/managed-agents">
+    Move from sandbox primitives to durable managed agent sessions.
+  </NextStep>
+
+  <NextStep title="SDK Usage" href="/docs/managed-agents/sdk">
+    Point the official SDK at Sandbox0 and create the first managed session.
+  </NextStep>
+</NextSteps>

--- a/docs/get-started/concepts/page.mdx
+++ b/docs/get-started/concepts/page.mdx
@@ -84,32 +84,14 @@ This keeps each agent worker simple while allowing safe parallel execution.
 - Skipping checkpoint persistence until task end.
 - Over-permissive auth/network settings in early prototypes that leak into production.
 
-## What to Learn Next
+## Next Steps
 
-If this mental model is clear, move to implementation details:
+<NextSteps>
+  <NextStep title="Overview" href="/docs/sandbox">
+    Learn the sandbox lifecycle and the runtime APIs available to each isolated environment.
+  </NextStep>
 
-<CardGrid>
-  <LinkCard
-    title="Sandbox"
-    href="/docs/sandbox"
-    cta="View Docs"
-  >
-    Lifecycle, contexts, files, network, gateway policy, and runtime operations
-  </LinkCard>
-
-  <LinkCard
-    title="Template"
-    href="/docs/template"
-    cta="Learn More"
-  >
-    Define stable execution environments and warm pools
-  </LinkCard>
-
-  <LinkCard
-    title="Volume"
-    href="/docs/volume"
-    cta="Learn More"
-  >
-    Persist agent data across sandbox lifecycles
-  </LinkCard>
-</CardGrid>
+  <NextStep title="Pause And Resume" href="/docs/sandbox/pause-resume">
+    Control sandbox power state and resume behavior before wiring long-lived workflows.
+  </NextStep>
+</NextSteps>

--- a/docs/get-started/page.mdx
+++ b/docs/get-started/page.mdx
@@ -380,20 +380,12 @@ s0 sandbox files cat /tmp/hello.txt -s sb_abc123
 
 ## Next Steps
 
-<CardGrid>
-  <LinkCard
-    title="Core Concepts"
-    href="/docs/get-started/concepts"
-    cta="Learn More"
-  >
-    Learn about sandbox lifecycle, contexts, templates, and volumes
-  </LinkCard>
+<NextSteps>
+  <NextStep title="Concepts" href="/docs/get-started/concepts">
+    Understand the runtime, storage, networking, and control-plane concepts before implementation.
+  </NextStep>
 
-  <LinkCard
-    title="Sandbox API"
-    href="/docs/sandbox"
-    cta="View Docs"
-  >
-    Complete sandbox lifecycle and management documentation
-  </LinkCard>
-</CardGrid>
+  <NextStep title="Overview" href="/docs/sandbox">
+    Learn the sandbox lifecycle and the runtime APIs available to each isolated environment.
+  </NextStep>
+</NextSteps>

--- a/docs/integrations/github-ci/page.mdx
+++ b/docs/integrations/github-ci/page.mdx
@@ -142,20 +142,12 @@ If your workflow also updates templates, it will need a role with template write
 
 ## Next Steps
 
-<CardGrid>
-  <LinkCard
-    title="Custom Images"
-    href="/docs/template/images"
-    cta="Learn More"
-  >
-    Choose the image reference and registry flow your template should use
-  </LinkCard>
+<NextSteps>
+  <NextStep title="Overview" href="/docs/self-hosted">
+    Plan a private Sandbox0 deployment and its required services.
+  </NextStep>
 
-  <LinkCard
-    title="Template Configuration"
-    href="/docs/template/configuration"
-    cta="Configure"
-  >
-    Wire the pushed image into a complete Sandbox0 template definition
-  </LinkCard>
-</CardGrid>
+  <NextStep title="Install" href="/docs/self-hosted/install">
+    Install the operator and create the first self-hosted environment.
+  </NextStep>
+</NextSteps>

--- a/docs/integrations/page.mdx
+++ b/docs/integrations/page.mdx
@@ -16,20 +16,12 @@ This section is intended for operational integrations such as CI/CD pipelines, b
 
 ## Next Steps
 
-<CardGrid>
-  <LinkCard
-    title="GitHub CI"
-    href="/docs/integrations/github-ci"
-    cta="Start"
-  >
-    Build and push template images from GitHub Actions
-  </LinkCard>
+<NextSteps>
+  <NextStep title="GitHub CI" href="/docs/integrations/github-ci">
+    Build Sandbox0 templates from GitHub Actions and CI pipelines.
+  </NextStep>
 
-  <LinkCard
-    title="Custom Images"
-    href="/docs/template/images"
-    cta="Learn More"
-  >
-    Understand how pushed image references are used in templates
-  </LinkCard>
-</CardGrid>
+  <NextStep title="Overview" href="/docs/self-hosted">
+    Plan a private Sandbox0 deployment and its required services.
+  </NextStep>
+</NextSteps>

--- a/docs/managed-agents/agent-engines/page.mdx
+++ b/docs/managed-agents/agent-engines/page.mdx
@@ -152,30 +152,14 @@ Agent engine behavior can be configured by deployment defaults and internal engi
 Do not use `sandbox0.managed_agents.engine` as session metadata. Reserved `sandbox0.managed_agents.*` keys are only supported on vault metadata today.
 </Callout>
 
-## Next
+## Next Steps
 
-<CardGrid>
-  <LinkCard
-    title="Vaults"
-    href="/docs/managed-agents/vaults"
-    cta="Configure"
-  >
-    Store engine metadata and model credentials
-  </LinkCard>
+<NextSteps>
+  <NextStep title="LLMProxy" href="/docs/managed-agents/llmproxy">
+    Translate Anthropic-compatible model providers for OpenAI-compatible engines.
+  </NextStep>
 
-  <LinkCard
-    title="Compatibility"
-    href="/docs/managed-agents/compatibility"
-    cta="Check"
-  >
-    Review the current differences from hosted Claude Managed Agents
-  </LinkCard>
-
-  <LinkCard
-    title="LLMProxy"
-    href="/docs/managed-agents/llmproxy"
-    cta="Translate"
-  >
-    Use Anthropic-compatible providers with OpenAI-compatible engines
-  </LinkCard>
-</CardGrid>
+  <NextStep title="Compatibility" href="/docs/managed-agents/compatibility">
+    Review supported behavior and current compatibility boundaries.
+  </NextStep>
+</NextSteps>

--- a/docs/managed-agents/agents/page.mdx
+++ b/docs/managed-agents/agents/page.mdx
@@ -79,30 +79,14 @@ If the MCP server needs credentials, attach a vault to the session. The agent de
 - The agent model defaults to the Claude engine unless a session attaches an LLM vault that selects another supported engine.
 - The agent object is copied into the session snapshot. Later agent updates do not mutate existing sessions.
 
-## Next
+## Next Steps
 
-<CardGrid>
-  <LinkCard
-    title="Environments"
-    href="/docs/managed-agents/environments"
-    cta="Prepare"
-  >
-    Define packages and network policy before creating sessions
-  </LinkCard>
+<NextSteps>
+  <NextStep title="Environments" href="/docs/managed-agents/environments">
+    Prepare reusable environments with packages and network policy.
+  </NextStep>
 
-  <LinkCard
-    title="Sessions"
-    href="/docs/managed-agents/sessions"
-    cta="Run"
-  >
-    Bind an agent snapshot to an environment and vaults
-  </LinkCard>
-
-  <LinkCard
-    title="Agent Engines"
-    href="/docs/managed-agents/agent-engines"
-    cta="Choose"
-  >
-    Select the runtime adapter with LLM vault metadata
-  </LinkCard>
-</CardGrid>
+  <NextStep title="Sessions" href="/docs/managed-agents/sessions">
+    Create sessions that bind an agent snapshot to an environment and vaults.
+  </NextStep>
+</NextSteps>

--- a/docs/managed-agents/compatibility/page.mdx
+++ b/docs/managed-agents/compatibility/page.mdx
@@ -118,20 +118,12 @@ For application code, prefer SDK methods over hardcoded endpoint paths.
 
 ## Next Steps
 
-<CardGrid>
-  <LinkCard
-    title="Credential"
-    href="/docs/credential"
-    cta="Secure"
-  >
-    Use Sandbox0 credentials for authenticated outbound access
-  </LinkCard>
+<NextSteps>
+  <NextStep title="Overview" href="/docs/credential">
+    Learn the credential model used by sandbox egress auth and managed agent vaults.
+  </NextStep>
 
-  <LinkCard
-    title="Template"
-    href="/docs/template"
-    cta="Prepare"
-  >
-    Define runtime images, packages, and warm pools
-  </LinkCard>
-</CardGrid>
+  <NextStep title="Sources" href="/docs/credential/sources">
+    Create reusable credential sources for runtime projection.
+  </NextStep>
+</NextSteps>

--- a/docs/managed-agents/environments/page.mdx
+++ b/docs/managed-agents/environments/page.mdx
@@ -69,22 +69,14 @@ The final policy is enforced by Sandbox0 network policy and credential projectio
 - Reserved `sandbox0.managed_agents.*` metadata keys are not accepted on environments.
 - Updating an environment does not retroactively rebuild already pinned session artifacts.
 
-## Next
+## Next Steps
 
-<CardGrid>
-  <LinkCard
-    title="Sessions"
-    href="/docs/managed-agents/sessions"
-    cta="Run"
-  >
-    Create a session with this environment
-  </LinkCard>
+<NextSteps>
+  <NextStep title="Sessions" href="/docs/managed-agents/sessions">
+    Create sessions that bind an agent snapshot to an environment and vaults.
+  </NextStep>
 
-  <LinkCard
-    title="Vaults"
-    href="/docs/managed-agents/vaults"
-    cta="Secure"
-  >
-    Add credentials to limited network sessions
-  </LinkCard>
-</CardGrid>
+  <NextStep title="Events" href="/docs/managed-agents/events">
+    Append user input, stream agent output, and interpret retry lifecycle events.
+  </NextStep>
+</NextSteps>

--- a/docs/managed-agents/events/page.mdx
+++ b/docs/managed-agents/events/page.mdx
@@ -99,22 +99,14 @@ await client.beta.sessions.events.send(session.id, {
 - Runtime callbacks are signed before being appended to the session log.
 - Event streaming is compatible with the SDK surface and backed by Sandbox0 session events.
 
-## Next
+## Next Steps
 
-<CardGrid>
-  <LinkCard
-    title="Sessions"
-    href="/docs/managed-agents/sessions"
-    cta="Review"
-  >
-    Understand session lifecycle and resources
-  </LinkCard>
+<NextSteps>
+  <NextStep title="Vaults" href="/docs/managed-agents/vaults">
+    Store model and external service credentials outside agent code.
+  </NextStep>
 
-  <LinkCard
-    title="Compatibility"
-    href="/docs/managed-agents/compatibility"
-    cta="Compare"
-  >
-    Check supported event and lifecycle behavior
-  </LinkCard>
-</CardGrid>
+  <NextStep title="Agent Engines" href="/docs/managed-agents/agent-engines">
+    Choose the runtime adapter that should execute each managed session.
+  </NextStep>
+</NextSteps>

--- a/docs/managed-agents/llmproxy/page.mdx
+++ b/docs/managed-agents/llmproxy/page.mdx
@@ -74,22 +74,14 @@ The Managed Agents gateway does not call the model provider directly. It stores 
 - For private deployments, prefer an internal LLMProxy service URL when runtime pods and LLMProxy run in the same cluster.
 - LLMProxy is a translation layer, not a session store. Managed Agents session truth and event history remain in Sandbox0.
 
-## Next
+## Next Steps
 
-<CardGrid>
-  <LinkCard
-    title="Agent Engines"
-    href="/docs/managed-agents/agent-engines"
-    cta="Choose"
-  >
-    Decide whether the session should use Claude, Codex, or OpenAI Agents
-  </LinkCard>
+<NextSteps>
+  <NextStep title="Compatibility" href="/docs/managed-agents/compatibility">
+    Review supported behavior and current compatibility boundaries.
+  </NextStep>
 
-  <LinkCard
-    title="Vaults"
-    href="/docs/managed-agents/vaults"
-    cta="Secure"
-  >
-    Store the provider token and engine metadata in an LLM vault
-  </LinkCard>
-</CardGrid>
+  <NextStep title="Overview" href="/docs/credential">
+    Learn the credential model used by sandbox egress auth and managed agent vaults.
+  </NextStep>
+</NextSteps>

--- a/docs/managed-agents/page.mdx
+++ b/docs/managed-agents/page.mdx
@@ -89,38 +89,14 @@ The official Claude Managed Agents documentation is still the canonical SDK refe
 - [Sessions](https://platform.claude.com/docs/en/managed-agents/sessions)
 - [Vaults](https://platform.claude.com/docs/en/managed-agents/vaults)
 
-## Next
+## Next Steps
 
-<CardGrid>
-  <LinkCard
-    title="SDK Usage"
-    href="/docs/managed-agents/sdk"
-    cta="Connect"
-  >
-    Point the official SDK at Sandbox0 and run the first session
-  </LinkCard>
+<NextSteps>
+  <NextStep title="SDK Usage" href="/docs/managed-agents/sdk">
+    Point the official SDK at Sandbox0 and create the first managed session.
+  </NextStep>
 
-  <LinkCard
-    title="Agents"
-    href="/docs/managed-agents/agents"
-    cta="Define"
-  >
-    Create versioned agent definitions with tools and skills
-  </LinkCard>
-
-  <LinkCard
-    title="Vaults"
-    href="/docs/managed-agents/vaults"
-    cta="Secure"
-  >
-    Store LLM and external service credentials outside agent code
-  </LinkCard>
-
-  <LinkCard
-    title="Agent Engines"
-    href="/docs/managed-agents/agent-engines"
-    cta="Choose"
-  >
-    Compare Claude, Codex, and OpenAI Agents execution models
-  </LinkCard>
-</CardGrid>
+  <NextStep title="Agents" href="/docs/managed-agents/agents">
+    Define versioned agents with prompts, tools, MCP servers, and skills.
+  </NextStep>
+</NextSteps>

--- a/docs/managed-agents/sdk/page.mdx
+++ b/docs/managed-agents/sdk/page.mdx
@@ -114,22 +114,14 @@ curl -fsS "https://agents.sandbox0.ai/v1/sessions" \
     }'
 ```
 
-## Next
+## Next Steps
 
-<CardGrid>
-  <LinkCard
-    title="Agents"
-    href="/docs/managed-agents/agents"
-    cta="Define"
-  >
-    Configure the model, prompt, tools, MCP servers, and skills
-  </LinkCard>
+<NextSteps>
+  <NextStep title="Agents" href="/docs/managed-agents/agents">
+    Define versioned agents with prompts, tools, MCP servers, and skills.
+  </NextStep>
 
-  <LinkCard
-    title="Vaults"
-    href="/docs/managed-agents/vaults"
-    cta="Secure"
-  >
-    Store model and external service credentials
-  </LinkCard>
-</CardGrid>
+  <NextStep title="Environments" href="/docs/managed-agents/environments">
+    Prepare reusable environments with packages and network policy.
+  </NextStep>
+</NextSteps>

--- a/docs/managed-agents/sessions/page.mdx
+++ b/docs/managed-agents/sessions/page.mdx
@@ -84,22 +84,14 @@ Sandbox0 keeps session state and event history outside the sandbox. The sandbox 
 - `openai-agents` runs the agent loop in a resident runtime and uses Sandbox0 as a sandbox tool.
 - All supported engines map observable automatic retry attempts to the same session state sequence: `running`, `rescheduling`, `running`, then either `idle` or `terminated`.
 
-## Next
+## Next Steps
 
-<CardGrid>
-  <LinkCard
-    title="Events"
-    href="/docs/managed-agents/events"
-    cta="Send"
-  >
-    Append user input and stream agent output
-  </LinkCard>
+<NextSteps>
+  <NextStep title="Events" href="/docs/managed-agents/events">
+    Append user input, stream agent output, and interpret retry lifecycle events.
+  </NextStep>
 
-  <LinkCard
-    title="Vaults"
-    href="/docs/managed-agents/vaults"
-    cta="Attach"
-  >
-    Provide model and external service credentials
-  </LinkCard>
-</CardGrid>
+  <NextStep title="Vaults" href="/docs/managed-agents/vaults">
+    Store model and external service credentials outside agent code.
+  </NextStep>
+</NextSteps>

--- a/docs/managed-agents/vaults/page.mdx
+++ b/docs/managed-agents/vaults/page.mdx
@@ -94,30 +94,14 @@ The environment variables may contain placeholders. The real token is projected 
 
 For `openai-agents`, the runtime expects an OpenAI Responses-compatible base URL. If the provider exposes an Anthropic-compatible endpoint, use [LLMProxy](/docs/managed-agents/llmproxy) and store the LLMProxy URL in `sandbox0.managed_agents.llm_base_url`.
 
-## Next
+## Next Steps
 
-<CardGrid>
-  <LinkCard
-    title="Agent Engines"
-    href="/docs/managed-agents/agent-engines"
-    cta="Choose"
-  >
-    Use LLM vault metadata to select Claude, Codex, or OpenAI Agents runtime behavior
-  </LinkCard>
+<NextSteps>
+  <NextStep title="Agent Engines" href="/docs/managed-agents/agent-engines">
+    Choose the runtime adapter that should execute each managed session.
+  </NextStep>
 
-  <LinkCard
-    title="LLMProxy"
-    href="/docs/managed-agents/llmproxy"
-    cta="Translate"
-  >
-    Adapt Anthropic-compatible providers for OpenAI-compatible engines
-  </LinkCard>
-
-  <LinkCard
-    title="Environments"
-    href="/docs/managed-agents/environments"
-    cta="Restrict"
-  >
-    Combine credentials with limited network policy
-  </LinkCard>
-</CardGrid>
+  <NextStep title="LLMProxy" href="/docs/managed-agents/llmproxy">
+    Translate Anthropic-compatible model providers for OpenAI-compatible engines.
+  </NextStep>
+</NextSteps>

--- a/docs/sandbox/contexts/page.mdx
+++ b/docs/sandbox/contexts/page.mdx
@@ -1016,28 +1016,12 @@ process.stdout.write(execResult.outputRaw);`
 
 ## Next Steps
 
-<CardGrid>
-  <LinkCard
-    title="Files"
-    href="/docs/sandbox/files"
-    cta="Learn More"
-  >
-    Read, write, and manage files in sandboxes
-  </LinkCard>
+<NextSteps>
+  <NextStep title="Files" href="/docs/sandbox/files">
+    Read, write, watch, and manage files inside a sandbox workspace.
+  </NextStep>
 
-  <LinkCard
-    title="Network Policy"
-    href="/docs/sandbox/network"
-    cta="Learn More"
-  >
-    Control network access and egress rules
-  </LinkCard>
-
-  <LinkCard
-    title="Sandbox Services"
-    href="/docs/sandbox/services"
-    cta="Learn More"
-  >
-    Expose sandbox services publicly
-  </LinkCard>
-</CardGrid>
+  <NextStep title="SSH" href="/docs/sandbox/ssh">
+    Connect to sandboxes with standard SSH clients for shell and file-copy workflows.
+  </NextStep>
+</NextSteps>

--- a/docs/sandbox/files/page.mdx
+++ b/docs/sandbox/files/page.mdx
@@ -549,28 +549,12 @@ s0 sandbox files watch /workspace --recursive -s sb_abc123`
 
 ## Next Steps
 
-<CardGrid>
-  <LinkCard
-    title="Network Policy"
-    href="/docs/sandbox/network"
-    cta="Learn More"
-  >
-    Control network access and egress rules
-  </LinkCard>
+<NextSteps>
+  <NextStep title="SSH" href="/docs/sandbox/ssh">
+    Connect to sandboxes with standard SSH clients for shell and file-copy workflows.
+  </NextStep>
 
-  <LinkCard
-    title="Sandbox Services"
-    href="/docs/sandbox/services"
-    cta="Learn More"
-  >
-    Expose sandbox services publicly
-  </LinkCard>
-
-  <LinkCard
-    title="Sandbox Webhooks"
-    href="/docs/sandbox/webhooks"
-    cta="Learn More"
-  >
-    Receive sandbox lifecycle and event callbacks
-  </LinkCard>
-</CardGrid>
+  <NextStep title="Network" href="/docs/sandbox/network">
+    Configure outbound network policy, traffic rules, and protocol-aware restrictions.
+  </NextStep>
+</NextSteps>

--- a/docs/sandbox/gateway-policy/page.mdx
+++ b/docs/sandbox/gateway-policy/page.mdx
@@ -3,3 +3,15 @@
 This page moved to [Sandbox Services](/docs/sandbox/services).
 
 Use Sandbox Services to expose named sandbox ports with public HTTP routes, auth, CORS, rate limits, upstream timeout, path rewrite, and route-level resume behavior.
+
+## Next Steps
+
+<NextSteps>
+  <NextStep title="Sandbox Services" href="/docs/sandbox/services">
+    Expose named sandbox ports through public HTTP service routes.
+  </NextStep>
+
+  <NextStep title="Network" href="/docs/sandbox/network">
+    Configure outbound network policy, traffic rules, and protocol-aware restrictions.
+  </NextStep>
+</NextSteps>

--- a/docs/sandbox/network/page.mdx
+++ b/docs/sandbox/network/page.mdx
@@ -180,7 +180,14 @@ sandbox.update_network_policy(
 
 Prefer `trafficRules` for all new policies.
 
-## Related Pages
+## Next Steps
 
-- [Credential](/docs/credential)
-- [Credential / Egress Auth](/docs/credential/egress-auth)
+<NextSteps>
+  <NextStep title="Egress Proxy" href="/docs/sandbox/proxy">
+    Route allowed TCP egress through a customer-managed SOCKS5 proxy.
+  </NextStep>
+
+  <NextStep title="Sandbox Services" href="/docs/sandbox/services">
+    Expose named sandbox ports through public HTTP service routes.
+  </NextStep>
+</NextSteps>

--- a/docs/sandbox/page.mdx
+++ b/docs/sandbox/page.mdx
@@ -462,15 +462,7 @@ client.sandboxes.update(
 
 Pause and resume is covered in a dedicated page because it affects TTL, `auto_resume`, service routes, SSH, and webhook behavior.
 
-<CardGrid>
-  <LinkCard
-    title="Pause And Resume"
-    href="/docs/sandbox/pause-resume"
-    cta="Learn More"
-  >
-    Pause sandboxes explicitly, inspect paused state, resume them, and control auto-resume behavior
-  </LinkCard>
-</CardGrid>
+See [Pause And Resume](/docs/sandbox/pause-resume) for explicit pause, state inspection, resume, and auto-resume behavior.
 
 ---
 
@@ -593,52 +585,12 @@ console.log('Sandbox deleted');`
 
 ## Next Steps
 
-<CardGrid>
-  <LinkCard
-    title="Pause And Resume"
-    href="/docs/sandbox/pause-resume"
-    cta="Learn More"
-  >
-    Pause sandboxes, resume them, and control `auto_resume`
-  </LinkCard>
+<NextSteps>
+  <NextStep title="Pause And Resume" href="/docs/sandbox/pause-resume">
+    Control sandbox power state and resume behavior before wiring long-lived workflows.
+  </NextStep>
 
-  <LinkCard
-    title="Contexts"
-    href="/docs/sandbox/contexts"
-    cta="Learn More"
-  >
-    Run commands and manage processes (REPL and Cmd)
-  </LinkCard>
-
-  <LinkCard
-    title="Files"
-    href="/docs/sandbox/files"
-    cta="Learn More"
-  >
-    Read, write, and manage files in sandboxes
-  </LinkCard>
-
-  <LinkCard
-    title="SSH"
-    href="/docs/sandbox/ssh"
-    cta="Learn More"
-  >
-    Connect with standard `ssh` and transfer files with `scp`
-  </LinkCard>
-
-  <LinkCard
-    title="Network Policy"
-    href="/docs/sandbox/network"
-    cta="Learn More"
-  >
-    Control network access and egress rules
-  </LinkCard>
-
-  <LinkCard
-    title="Sandbox Services"
-    href="/docs/sandbox/services"
-    cta="Learn More"
-  >
-    Control public HTTP routes, auth, CORS, and rate limits
-  </LinkCard>
-</CardGrid>
+  <NextStep title="Contexts" href="/docs/sandbox/contexts">
+    Run REPL and command contexts inside a sandbox and stream process output.
+  </NextStep>
+</NextSteps>

--- a/docs/sandbox/pause-resume/page.mdx
+++ b/docs/sandbox/pause-resume/page.mdx
@@ -162,36 +162,12 @@ For long-running agent workflows, a common pattern is:
 
 ## Next Steps
 
-<CardGrid>
-  <LinkCard
-    title="Sandbox Overview"
-    href="/docs/sandbox"
-    cta="Back"
-  >
-    Core sandbox lifecycle operations and refresh behavior
-  </LinkCard>
+<NextSteps>
+  <NextStep title="Contexts" href="/docs/sandbox/contexts">
+    Run REPL and command contexts inside a sandbox and stream process output.
+  </NextStep>
 
-  <LinkCard
-    title="Sandbox Services"
-    href="/docs/sandbox/services"
-    cta="Learn More"
-  >
-    Expose services and configure route-level auto-resume
-  </LinkCard>
-
-  <LinkCard
-    title="SSH"
-    href="/docs/sandbox/ssh"
-    cta="Learn More"
-  >
-    Resume paused sandboxes through SSH access
-  </LinkCard>
-
-  <LinkCard
-    title="Webhooks"
-    href="/docs/sandbox/webhooks"
-    cta="Learn More"
-  >
-    Observe `sandbox.paused` and `sandbox.resumed` events
-  </LinkCard>
-</CardGrid>
+  <NextStep title="Files" href="/docs/sandbox/files">
+    Read, write, watch, and manage files inside a sandbox workspace.
+  </NextStep>
+</NextSteps>

--- a/docs/sandbox/proxy/page.mdx
+++ b/docs/sandbox/proxy/page.mdx
@@ -242,14 +242,14 @@ s0 sandbox network update -s "$SANDBOX_ID" \\
 
 Egress proxy is a TCP routing feature. It does not proxy DNS datagrams, UDP application protocols, or QUIC. If a workload uses HTTP/3 or QUIC, configure the client to use TCP/TLS instead.
 
-<CardGroup cols={3}>
-  <Card title="Network" href="/docs/sandbox/network">
-    Configure allow and deny policy.
-  </Card>
-  <Card title="Credential Sources" href="/docs/credential/sources">
-    Store SOCKS5 credentials.
-  </Card>
-  <Card title="Egress Auth" href="/docs/credential/egress-auth">
-    Inject destination-scoped outbound credentials.
-  </Card>
-</CardGroup>
+## Next Steps
+
+<NextSteps>
+  <NextStep title="Sandbox Services" href="/docs/sandbox/services">
+    Expose named sandbox ports through public HTTP service routes.
+  </NextStep>
+
+  <NextStep title="Webhooks" href="/docs/sandbox/webhooks">
+    Receive signed sandbox lifecycle, service, and file-related events.
+  </NextStep>
+</NextSteps>

--- a/docs/sandbox/services/page.mdx
+++ b/docs/sandbox/services/page.mdx
@@ -389,3 +389,15 @@ if err != nil {
 - If `methods` is empty, every HTTP method is allowed for that route.
 - `resume` is evaluated with sandbox `auto_resume`. A route with `resume: false` will not resume a paused sandbox.
 - Public URLs are derived from the deployment exposure domain as `{sandbox_id}--p{port}.{exposure_domain}`.
+
+## Next Steps
+
+<NextSteps>
+  <NextStep title="Webhooks" href="/docs/sandbox/webhooks">
+    Receive signed sandbox lifecycle, service, and file-related events.
+  </NextStep>
+
+  <NextStep title="Overview" href="/docs/function">
+    Package sandbox services into versioned callable functions and manage runtime revisions.
+  </NextStep>
+</NextSteps>

--- a/docs/sandbox/ssh/page.mdx
+++ b/docs/sandbox/ssh/page.mdx
@@ -133,28 +133,12 @@ sftp -i ~/.ssh/sandbox0_ed25519 -P "$SSH_PORT" "$SSH_USER@$SSH_HOST"
 
 ## Next Steps
 
-<CardGrid>
-  <LinkCard
-    title="Files"
-    href="/docs/sandbox/files"
-    cta="Learn More"
-  >
-    Read, write, and manage files directly through the API
-  </LinkCard>
+<NextSteps>
+  <NextStep title="Network" href="/docs/sandbox/network">
+    Configure outbound network policy, traffic rules, and protocol-aware restrictions.
+  </NextStep>
 
-  <LinkCard
-    title="Contexts"
-    href="/docs/sandbox/contexts"
-    cta="Learn More"
-  >
-    Use REPL and command contexts for programmatic execution
-  </LinkCard>
-
-  <LinkCard
-    title="Self-Hosted Configuration"
-    href="/docs/self-hosted/configuration"
-    cta="Configure"
-  >
-    Expose and operate `ssh-gateway` in your own region deployment
-  </LinkCard>
-</CardGrid>
+  <NextStep title="Egress Proxy" href="/docs/sandbox/proxy">
+    Route allowed TCP egress through a customer-managed SOCKS5 proxy.
+  </NextStep>
+</NextSteps>

--- a/docs/sandbox/webhooks/page.mdx
+++ b/docs/sandbox/webhooks/page.mdx
@@ -544,28 +544,12 @@ s0 sandbox exec sb_abc123 -- curl -X POST http://localhost:49983/webhook/publish
 
 ## Next Steps
 
-<CardGrid>
-  <LinkCard
-    title="Sandbox Services"
-    href="/docs/sandbox/services"
-    cta="Learn More"
-  >
-    Expose sandbox services publicly
-  </LinkCard>
+<NextSteps>
+  <NextStep title="Overview" href="/docs/function">
+    Package sandbox services into versioned callable functions and manage runtime revisions.
+  </NextStep>
 
-  <LinkCard
-    title="Network Policy"
-    href="/docs/sandbox/network"
-    cta="Learn More"
-  >
-    Control network access
-  </LinkCard>
-
-  <LinkCard
-    title="Files"
-    href="/docs/sandbox/files"
-    cta="Learn More"
-  >
-    File operations and watching
-  </LinkCard>
-</CardGrid>
+  <NextStep title="Overview" href="/docs/managed-agents">
+    Move from sandbox primitives to durable managed agent sessions.
+  </NextStep>
+</NextSteps>

--- a/docs/self-hosted/configuration/page.mdx
+++ b/docs/self-hosted/configuration/page.mdx
@@ -225,3 +225,11 @@ The reference below is generated from the `Sandbox0Infra` CRD schema produced by
 - Treat `sandbox0.ai/data-plane-ready` as operator-owned; use your own labels under `sandboxNodePlacement` and let `infra-operator` manage readiness.
 - If sandbox workloads use `gvisor` or `kata`, keep `services.netd.runtimeClassName` on a host-compatible runtime such as the cluster default runtime.
 - Keep control-plane and data-plane components in the same storage and latency domain for a given region.
+
+## Next Steps
+
+<NextSteps>
+  <NextStep title="Overview" href="/docs/get-started">
+    Start with the product shape, core services, and where each API surface fits.
+  </NextStep>
+</NextSteps>

--- a/docs/self-hosted/install/page.mdx
+++ b/docs/self-hosted/install/page.mdx
@@ -350,19 +350,8 @@ Autopilot is not suitable for the full `fullmode` deployment because Sandbox0 ho
 
 ## Next Steps
 
-<CardGrid>
-  <LinkCard
-    title="Configuration"
-    href="/docs/self-hosted/configuration"
-    cta="Configure"
-  >
-    Enable `storageProxy`, `netd`, and production storage/database settings
-  </LinkCard>
-  <LinkCard
-    title="Get Started"
-    href="/docs/get-started"
-    cta="Start"
-  >
-    Use `SANDBOX0_BASE_URL` and `SANDBOX0_TOKEN` to make your first request
-  </LinkCard>
-</CardGrid>
+<NextSteps>
+  <NextStep title="Configuration" href="/docs/self-hosted/configuration">
+    Tune topology, storage, networking, and service-level configuration.
+  </NextStep>
+</NextSteps>

--- a/docs/self-hosted/page.mdx
+++ b/docs/self-hosted/page.mdx
@@ -80,20 +80,12 @@ One region should keep control plane and its managed data-plane clusters aligned
 
 ## Next Steps
 
-<CardGrid>
-  <LinkCard
-    title="Install"
-    href="/docs/self-hosted/install"
-    cta="Start"
-  >
-    Fastest path to your first running cluster
-  </LinkCard>
+<NextSteps>
+  <NextStep title="Install" href="/docs/self-hosted/install">
+    Install the operator and create the first self-hosted environment.
+  </NextStep>
 
-  <LinkCard
-    title="Configuration"
-    href="/docs/self-hosted/configuration"
-    cta="Configure"
-  >
-    Only the fields most teams actually need
-  </LinkCard>
-</CardGrid>
+  <NextStep title="Configuration" href="/docs/self-hosted/configuration">
+    Tune topology, storage, networking, and service-level configuration.
+  </NextStep>
+</NextSteps>

--- a/docs/template/configuration/page.mdx
+++ b/docs/template/configuration/page.mdx
@@ -200,36 +200,12 @@ Regular team-owned templates can declare `warmProcesses` for template-started he
 
 ## Next Steps
 
-<CardGrid>
-  <LinkCard
-    title="Volume"
-    href="/docs/volume"
-    cta="Learn More"
-  >
-    Persistent storage for your Sandboxes
-  </LinkCard>
+<NextSteps>
+  <NextStep title="Overview" href="/docs/volume">
+    Use persistent volumes to keep workspace data beyond sandbox lifetimes.
+  </NextStep>
 
-  <LinkCard
-    title="Template"
-    href="/docs/template"
-    cta="Learn More"
-  >
-    Template API workflows and end-to-end examples
-  </LinkCard>
-
-  <LinkCard
-    title="Warm Processes"
-    href="/docs/template/warm-processes"
-    cta="Learn More"
-  >
-    Start helper processes before a warm pod is claimable
-  </LinkCard>
-
-  <LinkCard
-    title="Images & Registry"
-    href="/docs/template/images"
-    cta="Learn More"
-  >
-    Configure container images and registry credentials
-  </LinkCard>
-</CardGrid>
+  <NextStep title="Mounts" href="/docs/volume/mounts">
+    Mount volumes into sandbox templates and claims with correct access modes.
+  </NextStep>
+</NextSteps>

--- a/docs/template/images/page.mdx
+++ b/docs/template/images/page.mdx
@@ -209,20 +209,12 @@ For self-hosted deployments, the `builtin` registry provider automatically provi
 
 ## Next Steps
 
-<CardGrid>
-  <LinkCard
-    title="Warm Pool"
-    href="/docs/template/pool"
-    cta="Learn More"
-  >
-    Configure minIdle and maxIdle for fast sandbox creation
-  </LinkCard>
+<NextSteps>
+  <NextStep title="Warm Pool" href="/docs/template/pool">
+    Use warm pools to reduce startup latency for common templates.
+  </NextStep>
 
-  <LinkCard
-    title="Configuration"
-    href="/docs/template/configuration"
-    cta="Learn More"
-  >
-    Advanced template settings
-  </LinkCard>
-</CardGrid>
+  <NextStep title="Warm Processes" href="/docs/template/warm-processes">
+    Pre-start REPL and command processes for lower per-request latency.
+  </NextStep>
+</NextSteps>

--- a/docs/template/page.mdx
+++ b/docs/template/page.mdx
@@ -486,44 +486,12 @@ console.log("Template deleted");`
 
 ## Next Steps
 
-<CardGrid>
-  <LinkCard
-    title="Custom Images"
-    href="/docs/template/images"
-    cta="Learn More"
-  >
-    Build and push private container images for your templates
-  </LinkCard>
+<NextSteps>
+  <NextStep title="Custom Images" href="/docs/template/images">
+    Build and reference custom container images for sandbox templates.
+  </NextStep>
 
-  <LinkCard
-    title="Warm Processes"
-    href="/docs/template/warm-processes"
-    cta="Learn More"
-  >
-    Start helper processes before a warm pod is claimable
-  </LinkCard>
-
-  <LinkCard
-    title="Warm Pool"
-    href="/docs/template/pool"
-    cta="Learn More"
-  >
-    Pre-warm idle sandboxes for sub-200ms cold start
-  </LinkCard>
-
-  <LinkCard
-    title="Configuration"
-    href="/docs/template/configuration"
-    cta="Learn More"
-  >
-    Full reference for all template spec fields
-  </LinkCard>
-
-  <LinkCard
-    title="Sandbox"
-    href="/docs/sandbox"
-    cta="Learn More"
-  >
-    Create sandboxes from templates
-  </LinkCard>
-</CardGrid>
+  <NextStep title="Warm Pool" href="/docs/template/pool">
+    Use warm pools to reduce startup latency for common templates.
+  </NextStep>
+</NextSteps>

--- a/docs/template/pool/page.mdx
+++ b/docs/template/pool/page.mdx
@@ -142,28 +142,12 @@ During the transition, the pool may temporarily drop below `minIdle`. Plan updat
 
 ## Next Steps
 
-<CardGrid>
-  <LinkCard
-    title="Warm Processes"
-    href="/docs/template/warm-processes"
-    cta="Learn More"
-  >
-    Start template-owned helpers before hot claims
-  </LinkCard>
+<NextSteps>
+  <NextStep title="Warm Processes" href="/docs/template/warm-processes">
+    Pre-start REPL and command processes for lower per-request latency.
+  </NextStep>
 
-  <LinkCard
-    title="Configuration"
-    href="/docs/template/configuration"
-    cta="Learn More"
-  >
-    Advanced template settings
-  </LinkCard>
-
-  <LinkCard
-    title="Sandbox"
-    href="/docs/sandbox"
-    cta="Learn More"
-  >
-    Claim sandboxes from a warm pool
-  </LinkCard>
-</CardGrid>
+  <NextStep title="Configuration" href="/docs/template/configuration">
+    Tune template resources, runtime behavior, mounts, and networking.
+  </NextStep>
+</NextSteps>

--- a/docs/template/warm-processes/page.mdx
+++ b/docs/template/warm-processes/page.mdx
@@ -76,20 +76,12 @@ If the helper needs persistent files, use normal sandbox volume mounts and paths
 
 ## Next Steps
 
-<CardGrid>
-  <LinkCard
-    title="Warm Pool"
-    href="/docs/template/pool"
-    cta="Learn More"
-  >
-    Keep idle pods ready for fast claims
-  </LinkCard>
+<NextSteps>
+  <NextStep title="Configuration" href="/docs/template/configuration">
+    Tune template resources, runtime behavior, mounts, and networking.
+  </NextStep>
 
-  <LinkCard
-    title="Configuration"
-    href="/docs/template/configuration"
-    cta="Learn More"
-  >
-    Template spec field reference
-  </LinkCard>
-</CardGrid>
+  <NextStep title="Overview" href="/docs/volume">
+    Use persistent volumes to keep workspace data beyond sandbox lifetimes.
+  </NextStep>
+</NextSteps>

--- a/docs/volume/fork/page.mdx
+++ b/docs/volume/fork/page.mdx
@@ -123,28 +123,12 @@ Fork does not require the source Volume to be mounted.
 
 ## Next Steps
 
-<CardGrid>
-  <LinkCard
-    title="Self Hosted"
-    href="/docs/deploy/self-hosted"
-    cta="Learn More"
-  >
-    Deploy Sandbox0 on your own infrastructure
-  </LinkCard>
+<NextSteps>
+  <NextStep title="Overview" href="/docs/integrations">
+    Connect Sandbox0 with external developer workflows.
+  </NextStep>
 
-  <LinkCard
-    title="Snapshots"
-    href="/docs/volume/snapshots"
-    cta="Learn More"
-  >
-    Create and restore volume snapshots
-  </LinkCard>
-
-  <LinkCard
-    title="Volume Overview"
-    href="/docs/volume"
-    cta="Learn More"
-  >
-    Volume lifecycle and configuration
-  </LinkCard>
-</CardGrid>
+  <NextStep title="GitHub CI" href="/docs/integrations/github-ci">
+    Build Sandbox0 templates from GitHub Actions and CI pipelines.
+  </NextStep>
+</NextSteps>

--- a/docs/volume/http/page.mdx
+++ b/docs/volume/http/page.mdx
@@ -423,28 +423,12 @@ try {
 
 ## Next Steps
 
-<CardGrid>
-  <LinkCard
-    title="Volume Mounts"
-    href="/docs/volume/mounts"
-    cta="Learn More"
-  >
-    Mount a volume into a sandbox when processes need a normal filesystem path
-  </LinkCard>
+<NextSteps>
+  <NextStep title="Snapshots" href="/docs/volume/snapshots">
+    Create and restore point-in-time volume snapshots.
+  </NextStep>
 
-  <LinkCard
-    title="Snapshots"
-    href="/docs/volume/snapshots"
-    cta="Learn More"
-  >
-    Capture and restore point-in-time volume state
-  </LinkCard>
-
-  <LinkCard
-    title="Volume Overview"
-    href="/docs/volume"
-    cta="Learn More"
-  >
-    Review volume lifecycle, access modes, and configuration
-  </LinkCard>
-</CardGrid>
+  <NextStep title="Fork" href="/docs/volume/fork">
+    Fork volumes when workflows need isolated writable branches.
+  </NextStep>
+</NextSteps>

--- a/docs/volume/mounts/page.mdx
+++ b/docs/volume/mounts/page.mdx
@@ -89,3 +89,15 @@ cat /workspace/data/hello.txt
 ```
 
 For control-plane file operations without a Sandbox, use `/api/v1/sandboxvolumes/{'{id}'}/files`.
+
+## Next Steps
+
+<NextSteps>
+  <NextStep title="HTTP" href="/docs/volume/http">
+    Use direct volume file APIs outside a running sandbox mount.
+  </NextStep>
+
+  <NextStep title="Snapshots" href="/docs/volume/snapshots">
+    Create and restore point-in-time volume snapshots.
+  </NextStep>
+</NextSteps>

--- a/docs/volume/page.mdx
+++ b/docs/volume/page.mdx
@@ -283,36 +283,12 @@ This means:
 
 ## Next Steps
 
-<CardGrid>
-  <LinkCard
-    title="Volume Mounts"
-    href="/docs/volume/mounts"
-    cta="Learn More"
-  >
-    Mount volumes to sandboxes for persistent storage
-  </LinkCard>
+<NextSteps>
+  <NextStep title="Mounts" href="/docs/volume/mounts">
+    Mount volumes into sandbox templates and claims with correct access modes.
+  </NextStep>
 
-  <LinkCard
-    title="Snapshots"
-    href="/docs/volume/snapshots"
-    cta="Learn More"
-  >
-    Create, restore, and manage volume snapshots
-  </LinkCard>
-
-  <LinkCard
-    title="Volume Fork"
-    href="/docs/volume/fork"
-    cta="Learn More"
-  >
-    Clone a volume with Copy-on-Write isolation
-  </LinkCard>
-
-  <LinkCard
-    title="Sandbox"
-    href="/docs/sandbox"
-    cta="Learn More"
-  >
-    Sandbox lifecycle and execution management
-  </LinkCard>
-</CardGrid>
+  <NextStep title="HTTP" href="/docs/volume/http">
+    Use direct volume file APIs outside a running sandbox mount.
+  </NextStep>
+</NextSteps>

--- a/docs/volume/snapshots/page.mdx
+++ b/docs/volume/snapshots/page.mdx
@@ -304,29 +304,12 @@ Deleting a snapshot does not affect current Volume data. The live Volume state r
 
 ## Next Steps
 
-<CardGrid>
-  <LinkCard
-    title="Volume Fork"
-    href="/docs/volume/fork"
-    cta="Learn More"
-  >
-    Clone a volume with Copy-on-Write isolation
-  </LinkCard>
+<NextSteps>
+  <NextStep title="Fork" href="/docs/volume/fork">
+    Fork volumes when workflows need isolated writable branches.
+  </NextStep>
 
-  <LinkCard
-    title="Volume Mounts"
-    href="/docs/volume/mounts"
-    cta="Learn More"
-  >
-    Mount volumes to sandboxes for persistent data access
-  </LinkCard>
-
-  <LinkCard
-    title="Volume Overview"
-    href="/docs/volume"
-    cta="Learn More"
-  >
-    Understand the full volume lifecycle and configuration
-  </LinkCard>
-
-</CardGrid>
+  <NextStep title="Overview" href="/docs/integrations">
+    Connect Sandbox0 with external developer workflows.
+  </NextStep>
+</NextSteps>


### PR DESCRIPTION
## What changed

- Standardized every docs page to use a single `## Next Steps` section.
- Converted next-step links to ordered `<NextSteps>` / `<NextStep>` entries.
- Sequenced manifest docs according to `docs/manifest.json`; the extra gateway-policy source page points back into the sandbox flow.

## Validation

- `node /tmp/verify-next-steps.mjs`
- `git diff --check`

Website build validation is covered by the paired sandbox0-cloud PR and PR CI.
