### PR TITLE
Use existing card components for docs next steps

### DIFF
--- a/docs/credential/egress-auth/page.mdx
+++ b/docs/credential/egress-auth/page.mdx
@@ -404,12 +404,12 @@ For supported protocols, auth material is resolved and injected by the egress pa
 
 ## Next Steps
 
-<NextSteps>
-  <NextStep title="Overview" href="/docs/template">
+<CardGroup>
+  <Card title="Overview" href="/docs/template" cta="Continue">
     Define reusable sandbox environments before creating or scaling sandboxes.
-  </NextStep>
+  </Card>
 
-  <NextStep title="Custom Images" href="/docs/template/images">
+  <Card title="Custom Images" href="/docs/template/images" cta="Continue">
     Build and reference custom container images for sandbox templates.
-  </NextStep>
-</NextSteps>
+  </Card>
+</CardGroup>

--- a/docs/credential/page.mdx
+++ b/docs/credential/page.mdx
@@ -48,12 +48,12 @@ That public shape is `SandboxNetworkPolicy` in all three places.
 
 ## Next Steps
 
-<NextSteps>
-  <NextStep title="Sources" href="/docs/credential/sources">
+<CardGroup>
+  <Card title="Sources" href="/docs/credential/sources" cta="Continue">
     Create reusable credential sources for runtime projection.
-  </NextStep>
+  </Card>
 
-  <NextStep title="Egress Auth" href="/docs/credential/egress-auth">
+  <Card title="Egress Auth" href="/docs/credential/egress-auth" cta="Continue">
     Inject destination-scoped outbound credentials through network policy.
-  </NextStep>
-</NextSteps>
+  </Card>
+</CardGroup>

--- a/docs/credential/sources/page.mdx
+++ b/docs/credential/sources/page.mdx
@@ -324,12 +324,12 @@ console.log('deleted github-source');`
 
 ## Next Steps
 
-<NextSteps>
-  <NextStep title="Egress Auth" href="/docs/credential/egress-auth">
+<CardGroup>
+  <Card title="Egress Auth" href="/docs/credential/egress-auth" cta="Continue">
     Inject destination-scoped outbound credentials through network policy.
-  </NextStep>
+  </Card>
 
-  <NextStep title="Overview" href="/docs/template">
+  <Card title="Overview" href="/docs/template" cta="Continue">
     Define reusable sandbox environments before creating or scaling sandboxes.
-  </NextStep>
-</NextSteps>
+  </Card>
+</CardGroup>

--- a/docs/function/page.mdx
+++ b/docs/function/page.mdx
@@ -181,12 +181,12 @@ Inspect and recycle the active restored runtime:
 
 ## Next Steps
 
-<NextSteps>
-  <NextStep title="Overview" href="/docs/managed-agents">
+<CardGroup>
+  <Card title="Overview" href="/docs/managed-agents" cta="Continue">
     Move from sandbox primitives to durable managed agent sessions.
-  </NextStep>
+  </Card>
 
-  <NextStep title="SDK Usage" href="/docs/managed-agents/sdk">
+  <Card title="SDK Usage" href="/docs/managed-agents/sdk" cta="Continue">
     Point the official SDK at Sandbox0 and create the first managed session.
-  </NextStep>
-</NextSteps>
+  </Card>
+</CardGroup>

--- a/docs/get-started/concepts/page.mdx
+++ b/docs/get-started/concepts/page.mdx
@@ -86,12 +86,12 @@ This keeps each agent worker simple while allowing safe parallel execution.
 
 ## Next Steps
 
-<NextSteps>
-  <NextStep title="Overview" href="/docs/sandbox">
+<CardGroup>
+  <Card title="Overview" href="/docs/sandbox" cta="Continue">
     Learn the sandbox lifecycle and the runtime APIs available to each isolated environment.
-  </NextStep>
+  </Card>
 
-  <NextStep title="Pause And Resume" href="/docs/sandbox/pause-resume">
+  <Card title="Pause And Resume" href="/docs/sandbox/pause-resume" cta="Continue">
     Control sandbox power state and resume behavior before wiring long-lived workflows.
-  </NextStep>
-</NextSteps>
+  </Card>
+</CardGroup>

--- a/docs/get-started/page.mdx
+++ b/docs/get-started/page.mdx
@@ -380,12 +380,12 @@ s0 sandbox files cat /tmp/hello.txt -s sb_abc123
 
 ## Next Steps
 
-<NextSteps>
-  <NextStep title="Concepts" href="/docs/get-started/concepts">
+<CardGroup>
+  <Card title="Concepts" href="/docs/get-started/concepts" cta="Continue">
     Understand the runtime, storage, networking, and control-plane concepts before implementation.
-  </NextStep>
+  </Card>
 
-  <NextStep title="Overview" href="/docs/sandbox">
+  <Card title="Overview" href="/docs/sandbox" cta="Continue">
     Learn the sandbox lifecycle and the runtime APIs available to each isolated environment.
-  </NextStep>
-</NextSteps>
+  </Card>
+</CardGroup>

--- a/docs/integrations/github-ci/page.mdx
+++ b/docs/integrations/github-ci/page.mdx
@@ -142,12 +142,12 @@ If your workflow also updates templates, it will need a role with template write
 
 ## Next Steps
 
-<NextSteps>
-  <NextStep title="Overview" href="/docs/self-hosted">
+<CardGroup>
+  <Card title="Overview" href="/docs/self-hosted" cta="Continue">
     Plan a private Sandbox0 deployment and its required services.
-  </NextStep>
+  </Card>
 
-  <NextStep title="Install" href="/docs/self-hosted/install">
+  <Card title="Install" href="/docs/self-hosted/install" cta="Continue">
     Install the operator and create the first self-hosted environment.
-  </NextStep>
-</NextSteps>
+  </Card>
+</CardGroup>

--- a/docs/integrations/page.mdx
+++ b/docs/integrations/page.mdx
@@ -16,12 +16,12 @@ This section is intended for operational integrations such as CI/CD pipelines, b
 
 ## Next Steps
 
-<NextSteps>
-  <NextStep title="GitHub CI" href="/docs/integrations/github-ci">
+<CardGroup>
+  <Card title="GitHub CI" href="/docs/integrations/github-ci" cta="Continue">
     Build Sandbox0 templates from GitHub Actions and CI pipelines.
-  </NextStep>
+  </Card>
 
-  <NextStep title="Overview" href="/docs/self-hosted">
+  <Card title="Overview" href="/docs/self-hosted" cta="Continue">
     Plan a private Sandbox0 deployment and its required services.
-  </NextStep>
-</NextSteps>
+  </Card>
+</CardGroup>

--- a/docs/managed-agents/agent-engines/page.mdx
+++ b/docs/managed-agents/agent-engines/page.mdx
@@ -154,12 +154,12 @@ Do not use `sandbox0.managed_agents.engine` as session metadata. Reserved `sandb
 
 ## Next Steps
 
-<NextSteps>
-  <NextStep title="LLMProxy" href="/docs/managed-agents/llmproxy">
+<CardGroup>
+  <Card title="LLMProxy" href="/docs/managed-agents/llmproxy" cta="Continue">
     Translate Anthropic-compatible model providers for OpenAI-compatible engines.
-  </NextStep>
+  </Card>
 
-  <NextStep title="Compatibility" href="/docs/managed-agents/compatibility">
+  <Card title="Compatibility" href="/docs/managed-agents/compatibility" cta="Continue">
     Review supported behavior and current compatibility boundaries.
-  </NextStep>
-</NextSteps>
+  </Card>
+</CardGroup>

--- a/docs/managed-agents/agents/page.mdx
+++ b/docs/managed-agents/agents/page.mdx
@@ -81,12 +81,12 @@ If the MCP server needs credentials, attach a vault to the session. The agent de
 
 ## Next Steps
 
-<NextSteps>
-  <NextStep title="Environments" href="/docs/managed-agents/environments">
+<CardGroup>
+  <Card title="Environments" href="/docs/managed-agents/environments" cta="Continue">
     Prepare reusable environments with packages and network policy.
-  </NextStep>
+  </Card>
 
-  <NextStep title="Sessions" href="/docs/managed-agents/sessions">
+  <Card title="Sessions" href="/docs/managed-agents/sessions" cta="Continue">
     Create sessions that bind an agent snapshot to an environment and vaults.
-  </NextStep>
-</NextSteps>
+  </Card>
+</CardGroup>

--- a/docs/managed-agents/compatibility/page.mdx
+++ b/docs/managed-agents/compatibility/page.mdx
@@ -118,12 +118,12 @@ For application code, prefer SDK methods over hardcoded endpoint paths.
 
 ## Next Steps
 
-<NextSteps>
-  <NextStep title="Overview" href="/docs/credential">
+<CardGroup>
+  <Card title="Overview" href="/docs/credential" cta="Continue">
     Learn the credential model used by sandbox egress auth and managed agent vaults.
-  </NextStep>
+  </Card>
 
-  <NextStep title="Sources" href="/docs/credential/sources">
+  <Card title="Sources" href="/docs/credential/sources" cta="Continue">
     Create reusable credential sources for runtime projection.
-  </NextStep>
-</NextSteps>
+  </Card>
+</CardGroup>

--- a/docs/managed-agents/environments/page.mdx
+++ b/docs/managed-agents/environments/page.mdx
@@ -71,12 +71,12 @@ The final policy is enforced by Sandbox0 network policy and credential projectio
 
 ## Next Steps
 
-<NextSteps>
-  <NextStep title="Sessions" href="/docs/managed-agents/sessions">
+<CardGroup>
+  <Card title="Sessions" href="/docs/managed-agents/sessions" cta="Continue">
     Create sessions that bind an agent snapshot to an environment and vaults.
-  </NextStep>
+  </Card>
 
-  <NextStep title="Events" href="/docs/managed-agents/events">
+  <Card title="Events" href="/docs/managed-agents/events" cta="Continue">
     Append user input, stream agent output, and interpret retry lifecycle events.
-  </NextStep>
-</NextSteps>
+  </Card>
+</CardGroup>

--- a/docs/managed-agents/events/page.mdx
+++ b/docs/managed-agents/events/page.mdx
@@ -101,12 +101,12 @@ await client.beta.sessions.events.send(session.id, {
 
 ## Next Steps
 
-<NextSteps>
-  <NextStep title="Vaults" href="/docs/managed-agents/vaults">
+<CardGroup>
+  <Card title="Vaults" href="/docs/managed-agents/vaults" cta="Continue">
     Store model and external service credentials outside agent code.
-  </NextStep>
+  </Card>
 
-  <NextStep title="Agent Engines" href="/docs/managed-agents/agent-engines">
+  <Card title="Agent Engines" href="/docs/managed-agents/agent-engines" cta="Continue">
     Choose the runtime adapter that should execute each managed session.
-  </NextStep>
-</NextSteps>
+  </Card>
+</CardGroup>

--- a/docs/managed-agents/llmproxy/page.mdx
+++ b/docs/managed-agents/llmproxy/page.mdx
@@ -76,12 +76,12 @@ The Managed Agents gateway does not call the model provider directly. It stores 
 
 ## Next Steps
 
-<NextSteps>
-  <NextStep title="Compatibility" href="/docs/managed-agents/compatibility">
+<CardGroup>
+  <Card title="Compatibility" href="/docs/managed-agents/compatibility" cta="Continue">
     Review supported behavior and current compatibility boundaries.
-  </NextStep>
+  </Card>
 
-  <NextStep title="Overview" href="/docs/credential">
+  <Card title="Overview" href="/docs/credential" cta="Continue">
     Learn the credential model used by sandbox egress auth and managed agent vaults.
-  </NextStep>
-</NextSteps>
+  </Card>
+</CardGroup>

--- a/docs/managed-agents/page.mdx
+++ b/docs/managed-agents/page.mdx
@@ -91,12 +91,12 @@ The official Claude Managed Agents documentation is still the canonical SDK refe
 
 ## Next Steps
 
-<NextSteps>
-  <NextStep title="SDK Usage" href="/docs/managed-agents/sdk">
+<CardGroup>
+  <Card title="SDK Usage" href="/docs/managed-agents/sdk" cta="Continue">
     Point the official SDK at Sandbox0 and create the first managed session.
-  </NextStep>
+  </Card>
 
-  <NextStep title="Agents" href="/docs/managed-agents/agents">
+  <Card title="Agents" href="/docs/managed-agents/agents" cta="Continue">
     Define versioned agents with prompts, tools, MCP servers, and skills.
-  </NextStep>
-</NextSteps>
+  </Card>
+</CardGroup>

--- a/docs/managed-agents/sdk/page.mdx
+++ b/docs/managed-agents/sdk/page.mdx
@@ -116,12 +116,12 @@ curl -fsS "https://agents.sandbox0.ai/v1/sessions" \
 
 ## Next Steps
 
-<NextSteps>
-  <NextStep title="Agents" href="/docs/managed-agents/agents">
+<CardGroup>
+  <Card title="Agents" href="/docs/managed-agents/agents" cta="Continue">
     Define versioned agents with prompts, tools, MCP servers, and skills.
-  </NextStep>
+  </Card>
 
-  <NextStep title="Environments" href="/docs/managed-agents/environments">
+  <Card title="Environments" href="/docs/managed-agents/environments" cta="Continue">
     Prepare reusable environments with packages and network policy.
-  </NextStep>
-</NextSteps>
+  </Card>
+</CardGroup>

--- a/docs/managed-agents/sessions/page.mdx
+++ b/docs/managed-agents/sessions/page.mdx
@@ -86,12 +86,12 @@ Sandbox0 keeps session state and event history outside the sandbox. The sandbox 
 
 ## Next Steps
 
-<NextSteps>
-  <NextStep title="Events" href="/docs/managed-agents/events">
+<CardGroup>
+  <Card title="Events" href="/docs/managed-agents/events" cta="Continue">
     Append user input, stream agent output, and interpret retry lifecycle events.
-  </NextStep>
+  </Card>
 
-  <NextStep title="Vaults" href="/docs/managed-agents/vaults">
+  <Card title="Vaults" href="/docs/managed-agents/vaults" cta="Continue">
     Store model and external service credentials outside agent code.
-  </NextStep>
-</NextSteps>
+  </Card>
+</CardGroup>

--- a/docs/managed-agents/vaults/page.mdx
+++ b/docs/managed-agents/vaults/page.mdx
@@ -96,12 +96,12 @@ For `openai-agents`, the runtime expects an OpenAI Responses-compatible base URL
 
 ## Next Steps
 
-<NextSteps>
-  <NextStep title="Agent Engines" href="/docs/managed-agents/agent-engines">
+<CardGroup>
+  <Card title="Agent Engines" href="/docs/managed-agents/agent-engines" cta="Continue">
     Choose the runtime adapter that should execute each managed session.
-  </NextStep>
+  </Card>
 
-  <NextStep title="LLMProxy" href="/docs/managed-agents/llmproxy">
+  <Card title="LLMProxy" href="/docs/managed-agents/llmproxy" cta="Continue">
     Translate Anthropic-compatible model providers for OpenAI-compatible engines.
-  </NextStep>
-</NextSteps>
+  </Card>
+</CardGroup>

--- a/docs/sandbox/contexts/page.mdx
+++ b/docs/sandbox/contexts/page.mdx
@@ -1016,12 +1016,12 @@ process.stdout.write(execResult.outputRaw);`
 
 ## Next Steps
 
-<NextSteps>
-  <NextStep title="Files" href="/docs/sandbox/files">
+<CardGroup>
+  <Card title="Files" href="/docs/sandbox/files" cta="Continue">
     Read, write, watch, and manage files inside a sandbox workspace.
-  </NextStep>
+  </Card>
 
-  <NextStep title="SSH" href="/docs/sandbox/ssh">
+  <Card title="SSH" href="/docs/sandbox/ssh" cta="Continue">
     Connect to sandboxes with standard SSH clients for shell and file-copy workflows.
-  </NextStep>
-</NextSteps>
+  </Card>
+</CardGroup>

--- a/docs/sandbox/files/page.mdx
+++ b/docs/sandbox/files/page.mdx
@@ -549,12 +549,12 @@ s0 sandbox files watch /workspace --recursive -s sb_abc123`
 
 ## Next Steps
 
-<NextSteps>
-  <NextStep title="SSH" href="/docs/sandbox/ssh">
+<CardGroup>
+  <Card title="SSH" href="/docs/sandbox/ssh" cta="Continue">
     Connect to sandboxes with standard SSH clients for shell and file-copy workflows.
-  </NextStep>
+  </Card>
 
-  <NextStep title="Network" href="/docs/sandbox/network">
+  <Card title="Network" href="/docs/sandbox/network" cta="Continue">
     Configure outbound network policy, traffic rules, and protocol-aware restrictions.
-  </NextStep>
-</NextSteps>
+  </Card>
+</CardGroup>

--- a/docs/sandbox/gateway-policy/page.mdx
+++ b/docs/sandbox/gateway-policy/page.mdx
@@ -6,12 +6,12 @@ Use Sandbox Services to expose named sandbox ports with public HTTP routes, auth
 
 ## Next Steps
 
-<NextSteps>
-  <NextStep title="Sandbox Services" href="/docs/sandbox/services">
+<CardGroup>
+  <Card title="Sandbox Services" href="/docs/sandbox/services" cta="Continue">
     Expose named sandbox ports through public HTTP service routes.
-  </NextStep>
+  </Card>
 
-  <NextStep title="Network" href="/docs/sandbox/network">
+  <Card title="Network" href="/docs/sandbox/network" cta="Continue">
     Configure outbound network policy, traffic rules, and protocol-aware restrictions.
-  </NextStep>
-</NextSteps>
+  </Card>
+</CardGroup>

--- a/docs/sandbox/network/page.mdx
+++ b/docs/sandbox/network/page.mdx
@@ -182,12 +182,12 @@ Prefer `trafficRules` for all new policies.
 
 ## Next Steps
 
-<NextSteps>
-  <NextStep title="Egress Proxy" href="/docs/sandbox/proxy">
+<CardGroup>
+  <Card title="Egress Proxy" href="/docs/sandbox/proxy" cta="Continue">
     Route allowed TCP egress through a customer-managed SOCKS5 proxy.
-  </NextStep>
+  </Card>
 
-  <NextStep title="Sandbox Services" href="/docs/sandbox/services">
+  <Card title="Sandbox Services" href="/docs/sandbox/services" cta="Continue">
     Expose named sandbox ports through public HTTP service routes.
-  </NextStep>
-</NextSteps>
+  </Card>
+</CardGroup>

--- a/docs/sandbox/page.mdx
+++ b/docs/sandbox/page.mdx
@@ -585,12 +585,12 @@ console.log('Sandbox deleted');`
 
 ## Next Steps
 
-<NextSteps>
-  <NextStep title="Pause And Resume" href="/docs/sandbox/pause-resume">
+<CardGroup>
+  <Card title="Pause And Resume" href="/docs/sandbox/pause-resume" cta="Continue">
     Control sandbox power state and resume behavior before wiring long-lived workflows.
-  </NextStep>
+  </Card>
 
-  <NextStep title="Contexts" href="/docs/sandbox/contexts">
+  <Card title="Contexts" href="/docs/sandbox/contexts" cta="Continue">
     Run REPL and command contexts inside a sandbox and stream process output.
-  </NextStep>
-</NextSteps>
+  </Card>
+</CardGroup>

--- a/docs/sandbox/pause-resume/page.mdx
+++ b/docs/sandbox/pause-resume/page.mdx
@@ -162,12 +162,12 @@ For long-running agent workflows, a common pattern is:
 
 ## Next Steps
 
-<NextSteps>
-  <NextStep title="Contexts" href="/docs/sandbox/contexts">
+<CardGroup>
+  <Card title="Contexts" href="/docs/sandbox/contexts" cta="Continue">
     Run REPL and command contexts inside a sandbox and stream process output.
-  </NextStep>
+  </Card>
 
-  <NextStep title="Files" href="/docs/sandbox/files">
+  <Card title="Files" href="/docs/sandbox/files" cta="Continue">
     Read, write, watch, and manage files inside a sandbox workspace.
-  </NextStep>
-</NextSteps>
+  </Card>
+</CardGroup>

--- a/docs/sandbox/proxy/page.mdx
+++ b/docs/sandbox/proxy/page.mdx
@@ -244,12 +244,12 @@ Egress proxy is a TCP routing feature. It does not proxy DNS datagrams, UDP appl
 
 ## Next Steps
 
-<NextSteps>
-  <NextStep title="Sandbox Services" href="/docs/sandbox/services">
+<CardGroup>
+  <Card title="Sandbox Services" href="/docs/sandbox/services" cta="Continue">
     Expose named sandbox ports through public HTTP service routes.
-  </NextStep>
+  </Card>
 
-  <NextStep title="Webhooks" href="/docs/sandbox/webhooks">
+  <Card title="Webhooks" href="/docs/sandbox/webhooks" cta="Continue">
     Receive signed sandbox lifecycle, service, and file-related events.
-  </NextStep>
-</NextSteps>
+  </Card>
+</CardGroup>

--- a/docs/sandbox/services/page.mdx
+++ b/docs/sandbox/services/page.mdx
@@ -392,12 +392,12 @@ if err != nil {
 
 ## Next Steps
 
-<NextSteps>
-  <NextStep title="Webhooks" href="/docs/sandbox/webhooks">
+<CardGroup>
+  <Card title="Webhooks" href="/docs/sandbox/webhooks" cta="Continue">
     Receive signed sandbox lifecycle, service, and file-related events.
-  </NextStep>
+  </Card>
 
-  <NextStep title="Overview" href="/docs/function">
+  <Card title="Overview" href="/docs/function" cta="Continue">
     Package sandbox services into versioned callable functions and manage runtime revisions.
-  </NextStep>
-</NextSteps>
+  </Card>
+</CardGroup>

--- a/docs/sandbox/ssh/page.mdx
+++ b/docs/sandbox/ssh/page.mdx
@@ -133,12 +133,12 @@ sftp -i ~/.ssh/sandbox0_ed25519 -P "$SSH_PORT" "$SSH_USER@$SSH_HOST"
 
 ## Next Steps
 
-<NextSteps>
-  <NextStep title="Network" href="/docs/sandbox/network">
+<CardGroup>
+  <Card title="Network" href="/docs/sandbox/network" cta="Continue">
     Configure outbound network policy, traffic rules, and protocol-aware restrictions.
-  </NextStep>
+  </Card>
 
-  <NextStep title="Egress Proxy" href="/docs/sandbox/proxy">
+  <Card title="Egress Proxy" href="/docs/sandbox/proxy" cta="Continue">
     Route allowed TCP egress through a customer-managed SOCKS5 proxy.
-  </NextStep>
-</NextSteps>
+  </Card>
+</CardGroup>

--- a/docs/sandbox/webhooks/page.mdx
+++ b/docs/sandbox/webhooks/page.mdx
@@ -544,12 +544,12 @@ s0 sandbox exec sb_abc123 -- curl -X POST http://localhost:49983/webhook/publish
 
 ## Next Steps
 
-<NextSteps>
-  <NextStep title="Overview" href="/docs/function">
+<CardGroup>
+  <Card title="Overview" href="/docs/function" cta="Continue">
     Package sandbox services into versioned callable functions and manage runtime revisions.
-  </NextStep>
+  </Card>
 
-  <NextStep title="Overview" href="/docs/managed-agents">
+  <Card title="Overview" href="/docs/managed-agents" cta="Continue">
     Move from sandbox primitives to durable managed agent sessions.
-  </NextStep>
-</NextSteps>
+  </Card>
+</CardGroup>

--- a/docs/self-hosted/configuration/page.mdx
+++ b/docs/self-hosted/configuration/page.mdx
@@ -228,8 +228,8 @@ The reference below is generated from the `Sandbox0Infra` CRD schema produced by
 
 ## Next Steps
 
-<NextSteps>
-  <NextStep title="Overview" href="/docs/get-started">
+<CardGroup>
+  <Card title="Overview" href="/docs/get-started" cta="Continue">
     Start with the product shape, core services, and where each API surface fits.
-  </NextStep>
-</NextSteps>
+  </Card>
+</CardGroup>

--- a/docs/self-hosted/install/page.mdx
+++ b/docs/self-hosted/install/page.mdx
@@ -350,8 +350,8 @@ Autopilot is not suitable for the full `fullmode` deployment because Sandbox0 ho
 
 ## Next Steps
 
-<NextSteps>
-  <NextStep title="Configuration" href="/docs/self-hosted/configuration">
+<CardGroup>
+  <Card title="Configuration" href="/docs/self-hosted/configuration" cta="Continue">
     Tune topology, storage, networking, and service-level configuration.
-  </NextStep>
-</NextSteps>
+  </Card>
+</CardGroup>

--- a/docs/self-hosted/page.mdx
+++ b/docs/self-hosted/page.mdx
@@ -80,12 +80,12 @@ One region should keep control plane and its managed data-plane clusters aligned
 
 ## Next Steps
 
-<NextSteps>
-  <NextStep title="Install" href="/docs/self-hosted/install">
+<CardGroup>
+  <Card title="Install" href="/docs/self-hosted/install" cta="Continue">
     Install the operator and create the first self-hosted environment.
-  </NextStep>
+  </Card>
 
-  <NextStep title="Configuration" href="/docs/self-hosted/configuration">
+  <Card title="Configuration" href="/docs/self-hosted/configuration" cta="Continue">
     Tune topology, storage, networking, and service-level configuration.
-  </NextStep>
-</NextSteps>
+  </Card>
+</CardGroup>

--- a/docs/template/configuration/page.mdx
+++ b/docs/template/configuration/page.mdx
@@ -200,12 +200,12 @@ Regular team-owned templates can declare `warmProcesses` for template-started he
 
 ## Next Steps
 
-<NextSteps>
-  <NextStep title="Overview" href="/docs/volume">
+<CardGroup>
+  <Card title="Overview" href="/docs/volume" cta="Continue">
     Use persistent volumes to keep workspace data beyond sandbox lifetimes.
-  </NextStep>
+  </Card>
 
-  <NextStep title="Mounts" href="/docs/volume/mounts">
+  <Card title="Mounts" href="/docs/volume/mounts" cta="Continue">
     Mount volumes into sandbox templates and claims with correct access modes.
-  </NextStep>
-</NextSteps>
+  </Card>
+</CardGroup>

--- a/docs/template/images/page.mdx
+++ b/docs/template/images/page.mdx
@@ -209,12 +209,12 @@ For self-hosted deployments, the `builtin` registry provider automatically provi
 
 ## Next Steps
 
-<NextSteps>
-  <NextStep title="Warm Pool" href="/docs/template/pool">
+<CardGroup>
+  <Card title="Warm Pool" href="/docs/template/pool" cta="Continue">
     Use warm pools to reduce startup latency for common templates.
-  </NextStep>
+  </Card>
 
-  <NextStep title="Warm Processes" href="/docs/template/warm-processes">
+  <Card title="Warm Processes" href="/docs/template/warm-processes" cta="Continue">
     Pre-start REPL and command processes for lower per-request latency.
-  </NextStep>
-</NextSteps>
+  </Card>
+</CardGroup>

--- a/docs/template/page.mdx
+++ b/docs/template/page.mdx
@@ -486,12 +486,12 @@ console.log("Template deleted");`
 
 ## Next Steps
 
-<NextSteps>
-  <NextStep title="Custom Images" href="/docs/template/images">
+<CardGroup>
+  <Card title="Custom Images" href="/docs/template/images" cta="Continue">
     Build and reference custom container images for sandbox templates.
-  </NextStep>
+  </Card>
 
-  <NextStep title="Warm Pool" href="/docs/template/pool">
+  <Card title="Warm Pool" href="/docs/template/pool" cta="Continue">
     Use warm pools to reduce startup latency for common templates.
-  </NextStep>
-</NextSteps>
+  </Card>
+</CardGroup>

--- a/docs/template/pool/page.mdx
+++ b/docs/template/pool/page.mdx
@@ -142,12 +142,12 @@ During the transition, the pool may temporarily drop below `minIdle`. Plan updat
 
 ## Next Steps
 
-<NextSteps>
-  <NextStep title="Warm Processes" href="/docs/template/warm-processes">
+<CardGroup>
+  <Card title="Warm Processes" href="/docs/template/warm-processes" cta="Continue">
     Pre-start REPL and command processes for lower per-request latency.
-  </NextStep>
+  </Card>
 
-  <NextStep title="Configuration" href="/docs/template/configuration">
+  <Card title="Configuration" href="/docs/template/configuration" cta="Continue">
     Tune template resources, runtime behavior, mounts, and networking.
-  </NextStep>
-</NextSteps>
+  </Card>
+</CardGroup>

--- a/docs/template/warm-processes/page.mdx
+++ b/docs/template/warm-processes/page.mdx
@@ -76,12 +76,12 @@ If the helper needs persistent files, use normal sandbox volume mounts and paths
 
 ## Next Steps
 
-<NextSteps>
-  <NextStep title="Configuration" href="/docs/template/configuration">
+<CardGroup>
+  <Card title="Configuration" href="/docs/template/configuration" cta="Continue">
     Tune template resources, runtime behavior, mounts, and networking.
-  </NextStep>
+  </Card>
 
-  <NextStep title="Overview" href="/docs/volume">
+  <Card title="Overview" href="/docs/volume" cta="Continue">
     Use persistent volumes to keep workspace data beyond sandbox lifetimes.
-  </NextStep>
-</NextSteps>
+  </Card>
+</CardGroup>

--- a/docs/volume/fork/page.mdx
+++ b/docs/volume/fork/page.mdx
@@ -123,12 +123,12 @@ Fork does not require the source Volume to be mounted.
 
 ## Next Steps
 
-<NextSteps>
-  <NextStep title="Overview" href="/docs/integrations">
+<CardGroup>
+  <Card title="Overview" href="/docs/integrations" cta="Continue">
     Connect Sandbox0 with external developer workflows.
-  </NextStep>
+  </Card>
 
-  <NextStep title="GitHub CI" href="/docs/integrations/github-ci">
+  <Card title="GitHub CI" href="/docs/integrations/github-ci" cta="Continue">
     Build Sandbox0 templates from GitHub Actions and CI pipelines.
-  </NextStep>
-</NextSteps>
+  </Card>
+</CardGroup>

--- a/docs/volume/http/page.mdx
+++ b/docs/volume/http/page.mdx
@@ -423,12 +423,12 @@ try {
 
 ## Next Steps
 
-<NextSteps>
-  <NextStep title="Snapshots" href="/docs/volume/snapshots">
+<CardGroup>
+  <Card title="Snapshots" href="/docs/volume/snapshots" cta="Continue">
     Create and restore point-in-time volume snapshots.
-  </NextStep>
+  </Card>
 
-  <NextStep title="Fork" href="/docs/volume/fork">
+  <Card title="Fork" href="/docs/volume/fork" cta="Continue">
     Fork volumes when workflows need isolated writable branches.
-  </NextStep>
-</NextSteps>
+  </Card>
+</CardGroup>

--- a/docs/volume/mounts/page.mdx
+++ b/docs/volume/mounts/page.mdx
@@ -92,12 +92,12 @@ For control-plane file operations without a Sandbox, use `/api/v1/sandboxvolumes
 
 ## Next Steps
 
-<NextSteps>
-  <NextStep title="HTTP" href="/docs/volume/http">
+<CardGroup>
+  <Card title="HTTP" href="/docs/volume/http" cta="Continue">
     Use direct volume file APIs outside a running sandbox mount.
-  </NextStep>
+  </Card>
 
-  <NextStep title="Snapshots" href="/docs/volume/snapshots">
+  <Card title="Snapshots" href="/docs/volume/snapshots" cta="Continue">
     Create and restore point-in-time volume snapshots.
-  </NextStep>
-</NextSteps>
+  </Card>
+</CardGroup>

--- a/docs/volume/page.mdx
+++ b/docs/volume/page.mdx
@@ -283,12 +283,12 @@ This means:
 
 ## Next Steps
 
-<NextSteps>
-  <NextStep title="Mounts" href="/docs/volume/mounts">
+<CardGroup>
+  <Card title="Mounts" href="/docs/volume/mounts" cta="Continue">
     Mount volumes into sandbox templates and claims with correct access modes.
-  </NextStep>
+  </Card>
 
-  <NextStep title="HTTP" href="/docs/volume/http">
+  <Card title="HTTP" href="/docs/volume/http" cta="Continue">
     Use direct volume file APIs outside a running sandbox mount.
-  </NextStep>
-</NextSteps>
+  </Card>
+</CardGroup>

--- a/docs/volume/snapshots/page.mdx
+++ b/docs/volume/snapshots/page.mdx
@@ -304,12 +304,12 @@ Deleting a snapshot does not affect current Volume data. The live Volume state r
 
 ## Next Steps
 
-<NextSteps>
-  <NextStep title="Fork" href="/docs/volume/fork">
+<CardGroup>
+  <Card title="Fork" href="/docs/volume/fork" cta="Continue">
     Fork volumes when workflows need isolated writable branches.
-  </NextStep>
+  </Card>
 
-  <NextStep title="Overview" href="/docs/integrations">
+  <Card title="Overview" href="/docs/integrations" cta="Continue">
     Connect Sandbox0 with external developer workflows.
-  </NextStep>
-</NextSteps>
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## What changed

- Replace all docs `NextSteps` / `NextStep` markup with the existing `CardGroup` / `Card` components.
- Keep every page on a `## Next Steps` section, preserving the ordered next-page flow from the manifest sequence.
- Set the next-step card CTA to `Continue` directly in MDX instead of adding new MDX aliases.

## Validation

- Verified 41 docs pages have one `## Next Steps` section using `CardGroup` / `Card`.
- `SANDBOX0_ROOT=/root/sandbox0ai/sandbox0 npm run docs:generate:content` from sandbox0-cloud website.
- `git diff --check`
