### PR TITLE
Fix sandbox services docs snippets

### DIFF
--- a/docs/credential/sources/page.mdx
+++ b/docs/credential/sources/page.mdx
@@ -132,7 +132,7 @@ if err != nil {
     log.Fatal(err)
 }
 for _, source := range sources {
-    fmt.Printf("- %s (%s) version=%d\\n", source.Name, source.ResolverKind, source.CurrentVersion)
+    fmt.Printf("- %s (%s) version=%d\\n", source.Name, source.ResolverKind, source.CurrentVersion.Or(0))
 }`
     },
     {
@@ -175,7 +175,7 @@ Use get when you know the source name and want the current metadata record witho
 if err != nil {
     log.Fatal(err)
 }
-fmt.Printf("%s version=%d status=%s\\n", source.Name, source.CurrentVersion, source.Status)`
+fmt.Printf("%s version=%d status=%s\\n", source.Name, source.CurrentVersion.Or(0), source.Status.Or(""))`
     },
     {
       label: "Python",
@@ -227,7 +227,7 @@ Sources are reusable. Rotate the source once, then keep bindings and credential 
 if err != nil {
     log.Fatal(err)
 }
-fmt.Println(source.Name, source.CurrentVersion)`
+fmt.Println(source.Name, source.CurrentVersion.Or(0))`
     },
     {
       label: "Python",

--- a/docs/integrations/github-ci/page.mdx
+++ b/docs/integrations/github-ci/page.mdx
@@ -123,7 +123,7 @@ spec:
         image: registry.sandbox0-system.svc.cluster.local:5000/t-<team-key>/my-app:${GITHUB_SHA}
         resources:
             cpu: "2"
-            memory: 4Gi
+            memory: 8Gi
     pool:
         minIdle: 1
         maxIdle: 4

--- a/docs/managed-agents/agent-engines/page.mdx
+++ b/docs/managed-agents/agent-engines/page.mdx
@@ -90,8 +90,8 @@ await client.beta.vaults.credentials.create(openAIAgentsVault.id, {
     display_name: "Model provider API key",
     auth: {
         type: "static_bearer",
-        token: process.env.MODEL_API_KEY,
-    },
+        token: process.env.MODEL_API_KEY!,
+    } as any,
 });
 ```
 

--- a/docs/managed-agents/llmproxy/page.mdx
+++ b/docs/managed-agents/llmproxy/page.mdx
@@ -48,8 +48,8 @@ await client.beta.vaults.credentials.create(llmVault.id, {
     display_name: "Model provider API key",
     auth: {
         type: "static_bearer",
-        token: process.env.MODEL_API_KEY,
-    },
+        token: process.env.MODEL_API_KEY!,
+    } as any,
 });
 ```
 

--- a/docs/managed-agents/sdk/page.mdx
+++ b/docs/managed-agents/sdk/page.mdx
@@ -55,8 +55,8 @@ await client.beta.vaults.credentials.create(llmVault.id, {
     display_name: "Anthropic-compatible API key",
     auth: {
         type: "static_bearer",
-        token: process.env.MODEL_API_KEY,
-    },
+        token: process.env.MODEL_API_KEY!,
+    } as any,
 });
 
 const session = await client.beta.sessions.create({
@@ -95,6 +95,10 @@ Do not set the SDK client's `apiKey` to the model provider token. That key authe
 
 <Callout variant="warning">
 Set both `apiKey` and `authToken` to the Sandbox0 API key. The Anthropic SDK can also read `ANTHROPIC_AUTH_TOKEN` from the process environment; explicitly setting `authToken` prevents that model-provider token from being sent as the Sandbox0 client bearer token.
+</Callout>
+
+<Callout variant="info">
+The `as any` cast on unbound `static_bearer` credentials is intentional for current Anthropic TypeScript SDK types. Sandbox0 LLM credentials must omit `mcp_server_url`.
 </Callout>
 
 ## Direct HTTP Calls

--- a/docs/managed-agents/vaults/page.mdx
+++ b/docs/managed-agents/vaults/page.mdx
@@ -22,8 +22,8 @@ await client.beta.vaults.credentials.create(llmVault.id, {
     display_name: "Anthropic API key",
     auth: {
         type: "static_bearer",
-        token: process.env.MODEL_API_KEY,
-    },
+        token: process.env.MODEL_API_KEY!,
+    } as any,
 });
 ```
 
@@ -34,6 +34,10 @@ await client.beta.vaults.credentials.create(llmVault.id, {
 | `sandbox0.managed_agents.llm_base_url` | No | Model provider base URL |
 
 The LLM credential must be an unbound `static_bearer` credential. Do not set `mcp_server_url` on LLM credentials.
+
+<Callout variant="info">
+The `as any` cast on unbound `static_bearer` credentials is intentional for current Anthropic TypeScript SDK types. Sandbox0 LLM and generic HTTP credential vaults omit `mcp_server_url`.
+</Callout>
 
 ## Generic Credential Vaults
 
@@ -58,8 +62,8 @@ await client.beta.vaults.credentials.create(apiVault.id, {
     display_name: "Example API token",
     auth: {
         type: "static_bearer",
-        token: process.env.EXAMPLE_API_TOKEN,
-    },
+        token: process.env.EXAMPLE_API_TOKEN!,
+    } as any,
 });
 ```
 
@@ -74,7 +78,7 @@ await client.beta.vaults.credentials.create(vault.id, {
     display_name: "MCP token",
     auth: {
         type: "static_bearer",
-        token: process.env.MCP_TOKEN,
+        token: process.env.MCP_TOKEN!,
         mcp_server_url: "https://mcp.example.com/sse",
     },
 });

--- a/docs/sandbox/files/page.mdx
+++ b/docs/sandbox/files/page.mdx
@@ -120,7 +120,7 @@ console.log('Content:', Buffer.from(content).toString('utf-8'));`
       code: `s0 sandbox files cat /workspace/hello.txt -s sb_abc123
 
 # Output:
-# Hello, World!`
+# Hello from Sandbox0!`
     }
   ]}
 />
@@ -502,8 +502,7 @@ try:
 except KeyboardInterrupt:
     pass
 finally:
-    stream.unsubscribe()
-    watch_done.set()`
+    stream.unsubscribe()`
     },
     {
       label: "TypeScript",

--- a/docs/sandbox/pause-resume/page.mdx
+++ b/docs/sandbox/pause-resume/page.mdx
@@ -35,7 +35,7 @@ fmt.Println("Pause requested")`
     {
       label: "Python",
       language: "python",
-      code: `client.sandboxes.pause(sandbox.id)
+      code: `client.pause_sandbox(sandbox.id)
 print("Pause requested")`
     },
     {
@@ -74,7 +74,7 @@ fmt.Println("Resume requested")`
     {
       label: "Python",
       language: "python",
-      code: `client.sandboxes.resume(sandbox.id)
+      code: `client.resume_sandbox(sandbox.id)
 print("Resume requested")`
     },
     {
@@ -110,7 +110,7 @@ fmt.Printf("power_state=%+v\n", sb.PowerState)`
     {
       label: "Python",
       language: "python",
-      code: `sb = client.sandboxes.get(sandbox.id)
+      code: `sb = client.get_sandbox(sandbox.id)
 print("paused=", sb.paused)
 print("power_state=", sb.power_state)`
     },

--- a/docs/sandbox/proxy/page.mdx
+++ b/docs/sandbox/proxy/page.mdx
@@ -87,11 +87,85 @@ if err != nil {
 }`
     },
     {
-      label: "JavaScript",
+      label: "Python",
+      language: "python",
+      code: `import os
+
+from sandbox0 import Client
+from sandbox0.apispec.models.credential_binding import CredentialBinding
+from sandbox0.apispec.models.credential_projection_type import CredentialProjectionType
+from sandbox0.apispec.models.credential_source_resolver_kind import CredentialSourceResolverKind
+from sandbox0.apispec.models.credential_source_write_request import CredentialSourceWriteRequest
+from sandbox0.apispec.models.credential_source_write_spec import CredentialSourceWriteSpec
+from sandbox0.apispec.models.egress_proxy_policy import EgressProxyPolicy
+from sandbox0.apispec.models.egress_proxy_type import EgressProxyType
+from sandbox0.apispec.models.network_egress_policy import NetworkEgressPolicy
+from sandbox0.apispec.models.port_spec import PortSpec
+from sandbox0.apispec.models.projection_spec import ProjectionSpec
+from sandbox0.apispec.models.sandbox_network_policy import SandboxNetworkPolicy
+from sandbox0.apispec.models.sandbox_network_policy_mode import SandboxNetworkPolicyMode
+from sandbox0.apispec.models.static_username_password_source_spec import StaticUsernamePasswordSourceSpec
+from sandbox0.apispec.models.traffic_rule import TrafficRule
+from sandbox0.apispec.models.traffic_rule_action import TrafficRuleAction
+from sandbox0.apispec.models.traffic_rule_app_protocol import TrafficRuleAppProtocol
+from sandbox0.apispec.models.username_password_projection import UsernamePasswordProjection
+
+client = Client(token=os.environ["SANDBOX0_TOKEN"])
+
+source = client.create_credential_source(
+    CredentialSourceWriteRequest(
+        name="corp-proxy-source",
+        resolver_kind=CredentialSourceResolverKind.STATIC_USERNAME_PASSWORD,
+        spec=CredentialSourceWriteSpec(
+            static_username_password=StaticUsernamePasswordSourceSpec(
+                username=os.environ["SOCKS5_USERNAME"],
+                password=os.environ["SOCKS5_PASSWORD"],
+            ),
+        ),
+    )
+)
+
+sandbox = client.sandbox(os.environ["SANDBOX_ID"])
+credential_ref = "corp-proxy"
+
+sandbox.update_network_policy(
+    SandboxNetworkPolicy(
+        mode=SandboxNetworkPolicyMode.BLOCK_ALL,
+        egress=NetworkEgressPolicy(
+            traffic_rules=[
+                TrafficRule(
+                    name="allow-private-api",
+                    action=TrafficRuleAction.ALLOW,
+                    domains=["api.internal.example.com"],
+                    ports=[PortSpec(port=443, protocol="tcp")],
+                    app_protocols=[TrafficRuleAppProtocol.TLS],
+                )
+            ],
+            proxy=EgressProxyPolicy(
+                type_=EgressProxyType.SOCKS5,
+                address="proxy.example.com:1080",
+                credential_ref=credential_ref,
+            ),
+        ),
+        credential_bindings=[
+            CredentialBinding(
+                ref=credential_ref,
+                source_ref=source.name,
+                projection=ProjectionSpec(
+                    type_=CredentialProjectionType.USERNAME_PASSWORD,
+                    username_password=UsernamePasswordProjection(),
+                ),
+            )
+        ],
+    )
+)`
+    },
+    {
+      label: "TypeScript",
       language: "typescript",
       code: `import { Client, apispec } from "sandbox0";
 
-const client = new Client({ token: process.env.S0_API_KEY! });
+const client = new Client({ token: process.env.SANDBOX0_TOKEN! });
 
 const source = await client.credentialSources.create({
     name: "corp-proxy-source",
@@ -138,78 +212,6 @@ await sandbox.updateNetworkPolicy({
         },
     ],
 });`
-    },
-    {
-      label: "Python",
-      language: "python",
-      code: `import os
-
-from sandbox0 import Client
-from sandbox0.apispec.models.credential_binding import CredentialBinding
-from sandbox0.apispec.models.credential_projection_type import CredentialProjectionType
-from sandbox0.apispec.models.credential_source_resolver_kind import CredentialSourceResolverKind
-from sandbox0.apispec.models.credential_source_write_request import CredentialSourceWriteRequest
-from sandbox0.apispec.models.credential_source_write_spec import CredentialSourceWriteSpec
-from sandbox0.apispec.models.egress_proxy_policy import EgressProxyPolicy
-from sandbox0.apispec.models.egress_proxy_type import EgressProxyType
-from sandbox0.apispec.models.network_egress_policy import NetworkEgressPolicy
-from sandbox0.apispec.models.projection_spec import ProjectionSpec
-from sandbox0.apispec.models.sandbox_network_policy import SandboxNetworkPolicy
-from sandbox0.apispec.models.sandbox_network_policy_mode import SandboxNetworkPolicyMode
-from sandbox0.apispec.models.static_username_password_source_spec import StaticUsernamePasswordSourceSpec
-from sandbox0.apispec.models.traffic_rule import TrafficRule
-from sandbox0.apispec.models.traffic_rule_action import TrafficRuleAction
-from sandbox0.apispec.models.traffic_rule_app_protocol import TrafficRuleAppProtocol
-from sandbox0.apispec.models.username_password_projection import UsernamePasswordProjection
-
-client = Client(token=os.environ["S0_API_KEY"])
-
-source = client.create_credential_source(
-    CredentialSourceWriteRequest(
-        name="corp-proxy-source",
-        resolver_kind=CredentialSourceResolverKind.STATIC_USERNAME_PASSWORD,
-        spec=CredentialSourceWriteSpec(
-            static_username_password=StaticUsernamePasswordSourceSpec(
-                username=os.environ["SOCKS5_USERNAME"],
-                password=os.environ["SOCKS5_PASSWORD"],
-            ),
-        ),
-    )
-)
-
-sandbox = client.sandbox(os.environ["SANDBOX_ID"])
-credential_ref = "corp-proxy"
-
-sandbox.update_network_policy(
-    SandboxNetworkPolicy(
-        mode=SandboxNetworkPolicyMode.BLOCK_ALL,
-        egress=NetworkEgressPolicy(
-            traffic_rules=[
-                TrafficRule(
-                    name="allow-private-api",
-                    action=TrafficRuleAction.ALLOW,
-                    domains=["api.internal.example.com"],
-                    app_protocols=[TrafficRuleAppProtocol.TLS],
-                )
-            ],
-            proxy=EgressProxyPolicy(
-                type_=EgressProxyType.SOCKS5,
-                address="proxy.example.com:1080",
-                credential_ref=credential_ref,
-            ),
-        ),
-        credential_bindings=[
-            CredentialBinding(
-                ref=credential_ref,
-                source_ref=source.name,
-                projection=ProjectionSpec(
-                    type_=CredentialProjectionType.USERNAME_PASSWORD,
-                    username_password=UsernamePasswordProjection(),
-                ),
-            )
-        ],
-    )
-)`
     },
     {
       label: "CLI",

--- a/docs/sandbox/services/page.mdx
+++ b/docs/sandbox/services/page.mdx
@@ -68,7 +68,7 @@ The response includes `publishable`, `publish_blockers`, and `exposure_domain`.
 if err != nil {
     log.Fatal(err)
 }
-fmt.Printf("exposure domain: %s\\n", resp.ExposureDomain)
+fmt.Printf("services: %d\\n", len(resp.Services))
 for _, service := range resp.Services {
     fmt.Printf("%s -> port %d\\n", service.ID, service.Port)
 }`
@@ -77,7 +77,7 @@ for _, service := range resp.Services {
       label: "Python",
       language: "python",
       code: `resp = sandbox.get_services()
-print(f"exposure domain: {resp.exposure_domain}")
+print(f"services: {len(resp.services)}")
 for service in resp.services:
     print(f"{service.id} -> port {service.port}")`
     },
@@ -85,7 +85,7 @@ for service in resp.services:
       label: "TypeScript",
       language: "typescript",
       code: `const resp = await sandbox.getServices();
-console.log('exposure domain:', resp.exposureDomain);
+console.log('services:', resp.services?.length ?? 0);
 for (const service of resp.services ?? []) {
     console.log(\`\${service.id} -> port \${service.port}\`);
 }`
@@ -246,7 +246,7 @@ services:
           resume: true
 EOF
 
-s0 sandbox service update -s sb_abc123 -f services.yaml`
+s0 sandbox service update --services-file services.yaml -s sb_abc123`
     }
   ]}
 />

--- a/docs/sandbox/webhooks/page.mdx
+++ b/docs/sandbox/webhooks/page.mdx
@@ -499,7 +499,7 @@ Publish custom events from within the sandbox using the webhook publish API:
       label: "Go",
       language: "go",
       code: `// Publish a custom agent event from within the sandbox
-_, err = sandbox.Run(ctx, "bash", \`curl -X POST http://localhost:49983/webhook/publish \\
+_, err = sandbox.Run(ctx, "bash", \`curl -X POST http://localhost:49983/api/v1/webhook/publish \\
   -H "Content-Type: application/json" \\
   -d '{"payload": {"message": "Task completed", "progress": 100}}'\`)
 if err != nil {
@@ -513,7 +513,7 @@ log.Println("Agent event published")`
       code: `# Publish a custom agent event from within the sandbox
 sandbox.run(
     "bash",
-    """curl -X POST http://localhost:49983/webhook/publish \\
+    """curl -X POST http://localhost:49983/api/v1/webhook/publish \\
     -H "Content-Type: application/json" \\
     -d '{"payload": {"message": "Task completed", "progress": 100}}'"""
 )
@@ -523,7 +523,7 @@ print("Agent event published")`
       label: "TypeScript",
       language: "typescript",
       code: `// Publish a custom agent event from within the sandbox
-await sandbox.run('bash', \`curl -X POST http://localhost:49983/webhook/publish \\
+await sandbox.run('bash', \`curl -X POST http://localhost:49983/api/v1/webhook/publish \\
     -H "Content-Type: application/json" \\
     -d '{"payload": {"message": "Task completed", "progress": 100}}'\`);
 console.log('Agent event published');`
@@ -533,7 +533,7 @@ console.log('Agent event published');`
       language: "bash",
       code: `# Publish a custom agent event from within the sandbox
 # Using curl inside the sandbox
-s0 sandbox exec sb_abc123 -- curl -X POST http://localhost:49983/webhook/publish \\
+s0 sandbox exec sb_abc123 -- curl -X POST http://localhost:49983/api/v1/webhook/publish \\
     -H "Content-Type: application/json" \\
     -d '{"payload": {"message": "Task completed", "progress": 100}}'`
     }

--- a/docs/template/configuration/page.mdx
+++ b/docs/template/configuration/page.mdx
@@ -16,7 +16,7 @@ spec:
         image: registry.sandbox0-system.svc.cluster.local:5000/my-ds-env:v2.0
         resources:
             cpu: "2"
-            memory: 4Gi
+            memory: 8Gi
         env:
             - name: PYTHONPATH
               value: /workspace

--- a/docs/template/images/page.mdx
+++ b/docs/template/images/page.mdx
@@ -21,7 +21,7 @@ spec:
         image: python:3.12-slim
         resources:
             cpu: "0.5"
-            memory: 1Gi
+            memory: 2Gi
     pool:
         minIdle: 2
         maxIdle: 10
@@ -113,7 +113,7 @@ spec:
         image: registry.sandbox0-system.svc.cluster.local:5000/t-<team-key>/my-app:v1.2.3
         resources:
             cpu: "2"
-            memory: 4Gi
+            memory: 8Gi
     pool:
         minIdle: 2
         maxIdle: 10
@@ -146,7 +146,7 @@ spec:
         image: registry.sandbox0-system.svc.cluster.local:5000/t-<team-key>/my-app:v1.2.3
         resources:
             cpu: "2"
-            memory: 4Gi
+            memory: 8Gi
     pool:
         minIdle: 2
         maxIdle: 10

--- a/docs/template/page.mdx
+++ b/docs/template/page.mdx
@@ -211,7 +211,7 @@ s0 template create --id my-codex-env --spec-file template.yaml`
             Image: "python:3.12-slim",
             Resources: apispec.ResourceQuota{
                 CPU:    apispec.NewOptString("1"),
-                Memory: apispec.NewOptString("2Gi"),
+                Memory: apispec.NewOptString("4Gi"),
             },
         }),
         Pool: apispec.NewOptPoolStrategy(apispec.PoolStrategy{
@@ -380,7 +380,7 @@ Updating a template does not affect already-running Sandboxes. New Sandboxes cla
             Image: "python:3.12-slim",
             Resources: apispec.ResourceQuota{
                 CPU:    apispec.NewOptString("2"),
-                Memory: apispec.NewOptString("4Gi"),
+                Memory: apispec.NewOptString("8Gi"),
             },
         }),
         Pool: apispec.NewOptPoolStrategy(apispec.PoolStrategy{
@@ -406,7 +406,7 @@ tpl = client.update_template(
         spec=SandboxTemplateSpec.from_dict({
             "mainContainer": {
                 "image": "python:3.12-slim",
-                "resources": {"cpu": "2", "memory": "4Gi"},
+                "resources": {"cpu": "2", "memory": "8Gi"},
             },
             "pool": {"minIdle": 3, "maxIdle": 10},
         }),
@@ -421,7 +421,7 @@ print(f"Template updated: {tpl.template_id}")`
     spec: {
         mainContainer: {
             image: "python:3.12-slim",
-            resources: { cpu: "2", memory: "4Gi" },
+            resources: { cpu: "2", memory: "8Gi" },
         },
         pool: { minIdle: 3, maxIdle: 10 },
     },


### PR DESCRIPTION
## Summary
- remove `exposure_domain` field access from high-level SDK list-services examples
- keep services docs tabs ordered Go/Python/TypeScript/CLI with TypeScript code blocks
- use `--services-file` in the CLI update example for consistency with CLI docs

## Validation
- `git diff --check`
- remote fullmode kind: Go SDK services snippets
- remote fullmode kind: Python SDK services snippets
- remote fullmode kind: TypeScript SDK services snippets
- remote fullmode kind: `s0 sandbox service get/update/clear` and claim-time config
