### PR TITLE
restructure function docs

### DIFF
--- a/docs/function/page.mdx
+++ b/docs/function/page.mdx
@@ -1,9 +1,9 @@
-# Function
+# Functions
 
-Sandbox0 Functions publish a sandbox service behind a stable function domain. A function has immutable revisions and a mutable `production` alias, so deleting the source sandbox does not delete the function identity or its domain.
+Sandbox0 Functions publish a Sandbox Service behind a stable function domain. A function keeps its identity, slug, and host across revisions, so callers can keep using the same URL while you publish new sandbox-backed code.
 
 <Callout variant="info">
-Functions are created from Sandbox Services, not from uploaded ZIP files or container images. The first function API only needs a `sandbox_id` and `service_id`; the gateway snapshots the service configuration and restore mounts into a revision.
+Functions are created from Sandbox Services, not from uploaded ZIP files or container images. Publish starts from a `sandbox_id` and `service_id`; Sandbox0 snapshots the service configuration and restore mounts into an immutable revision.
 </Callout>
 
 ## Model
@@ -11,182 +11,45 @@ Functions are created from Sandbox Services, not from uploaded ZIP files or cont
 | Object | Description |
 |--------|-------------|
 | Sandbox Service | A named port, ingress routes, and restartable runtime inside a sandbox |
-| Function | Stable function identity, slug, and fixed domain under `sandbox0.site` |
-| Revision | Immutable snapshot of the source sandbox service plus snapshots of the SandboxVolume mounts needed to restore it |
-| Alias | Mutable pointer from a name such as `production` to one revision |
+| Function | Stable function identity, slug, and host under the configured function domain |
+| Revision | Immutable snapshot of the source service plus the SandboxVolume restore mounts needed to restore it |
+| Alias | Mutable pointer from a name such as `production` to a revision |
+| Runtime | Restored sandbox and process context currently serving a function revision, when the source sandbox is gone |
 
-Only publishable sandbox services can become function revisions. A service is publishable when it is public and has a restartable runtime.
+The `production` alias is the serving pointer used by the function host. Creating a function creates revision 1 and points `production` at it. Creating another revision can either promote it immediately or leave it available for a later alias update.
 
-When the source sandbox was claimed with SandboxVolume mounts, publish creates a snapshot for each mounted volume, immediately materializes revision-owned volumes from those snapshots, and records those volume IDs on the revision. If the source sandbox is later deleted, `function-gateway` claims a new runtime sandbox from the same template, mounts the revision-owned volumes, starts the service runtime, and continues serving the stable function host.
+## How Serving Works
 
-## Sandbox Services
+Function traffic is handled by `function-gateway`. The gateway resolves the host to a function, loads the `production` revision, enforces the revision's service route policy, and proxies the request to the service port.
 
-<Endpoint method="GET">
-/api/v1/sandboxes/{'{id}'}/services
-</Endpoint>
+If the source sandbox still exists, the gateway routes to that sandbox and resumes it when needed. If the source sandbox has been deleted, the gateway claims a new runtime sandbox from the revision's template, mounts the revision-owned volumes, starts the service runtime command or warm process, and reuses that runtime for later requests.
 
-The response includes `publishable` and `publish_blockers` for each service.
+## Publishable Services
 
-<Endpoint method="PUT">
-/api/v1/sandboxes/{'{id}'}/services
-</Endpoint>
+Only publishable Sandbox Services can become function revisions. A service is publishable when it is public and has a restartable runtime:
 
-Example service:
+| Blocker | Meaning |
+|---------|---------|
+| `not_public` | The service does not expose public ingress routes |
+| `missing_runtime` | The service has no restartable runtime |
+| `manual_runtime` | The service runtime is manual and cannot be started by Function Gateway |
+| `missing_command` | A `cmd` runtime is missing its command |
+| `missing_warm_process_name` | A `warm_process` runtime is missing its warm process name |
 
-```json
-{
-    "services": [
-        {
-            "id": "api",
-            "display_name": "API",
-            "port": 8080,
-            "runtime": {
-                "type": "cmd",
-                "command": ["python3", "-m", "app.server"],
-                "cwd": "/workspace"
-            },
-            "ingress": {
-                "public": true,
-                "routes": [
-                    {
-                        "id": "api",
-                        "path_prefix": "/",
-                        "resume": true
-                    }
-                ]
-            },
-            "health_check": {
-                "path": "/healthz"
-            }
-        }
-    ]
-}
-```
-
-## Create Function
-
-<Endpoint method="POST">
-/api/v1/functions
-</Endpoint>
-
-```json
-{
-    "name": "my-api",
-    "source": {
-        "sandbox_id": "sb_abc123",
-        "service_id": "api"
-    }
-}
-```
-
-This creates:
-
-| Result | Behavior |
-|--------|----------|
-| Function | Stable ID, slug, and host |
-| Revision 1 | Snapshot of the sandbox service |
-| `production` alias | Points to revision 1 |
-
-## Lifecycle
-
-Functions can be disabled without deleting their identity, domain, aliases, or revisions:
-
-<Endpoint method="PUT">
-/api/v1/functions/{'{id}'}
-</Endpoint>
-
-```json
-{
-    "enabled": false
-}
-```
-
-Disabled functions return `503` from the function host and do not restore runtime sandboxes. Re-enable the function by setting `enabled` to `true`.
-
-Delete a function when its stable host should stop serving traffic permanently:
-
-<Endpoint method="DELETE">
-/api/v1/functions/{'{id}'}
-</Endpoint>
-
-Delete is a soft delete. The function disappears from list/get APIs, the host returns not found, and the slug/domain label stay reserved. Sandbox0 also schedules best-effort cleanup for restored runtime sandboxes and revision-owned volumes.
-
-## Revisions
-
-Create a new revision from the same or another sandbox service:
-
-<Endpoint method="POST">
-/api/v1/functions/{'{id}'}/revisions
-</Endpoint>
-
-```json
-{
-    "source": {
-        "sandbox_id": "sb_def456",
-        "service_id": "api"
-    },
-    "promote": true
-}
-```
-
-Move an alias:
-
-<Endpoint method="PUT">
-/api/v1/functions/{'{id}'}/aliases/{'{alias}'}
-</Endpoint>
-
-```json
-{
-    "revision_number": 2
-}
-```
-
-Read aliases:
-
-<Endpoint method="GET">
-/api/v1/functions/{'{id}'}/aliases
-</Endpoint>
-
-<Endpoint method="GET">
-/api/v1/functions/{'{id}'}/aliases/{'{alias}'}
-</Endpoint>
-
-Read a specific immutable revision by revision number:
-
-<Endpoint method="GET">
-/api/v1/functions/{'{id}'}/revisions/{'{revision_number}'}
-</Endpoint>
-
-## Runtime Behavior
-
-Function traffic is handled by `function-gateway` on the fixed function host. The gateway resolves the `production` alias, enforces the revision's service route policy, and proxies to the service port.
-
-If the source sandbox still exists, the gateway resumes it when needed and routes to that sandbox. If the source sandbox has been deleted, the gateway restores a function runtime sandbox from the revision's template and revision-owned volumes, starts the service runtime command or warm process, stores the runtime sandbox/context on the revision, and reuses that runtime until sandbox0 scales it down.
-
-Inspect and recycle the active restored runtime:
-
-<Endpoint method="GET">
-/api/v1/functions/{'{id}'}/runtime
-</Endpoint>
-
-<Endpoint method="POST">
-/api/v1/functions/{'{id}'}/runtime/restart
-</Endpoint>
-
-<Endpoint method="POST">
-/api/v1/functions/{'{id}'}/runtime/recycle
-</Endpoint>
-
-`restart` and `recycle` both delete the current restored runtime sandbox when one exists and clear the runtime mapping. The next function request starts a fresh runtime from the active revision.
+Use Sandbox Services route policy for path matching, allowed methods, bearer/header auth, CORS, rate limits, path rewrite, and upstream timeout. Functions reuse the same route model.
 
 ## Next Steps
 
 <CardGroup>
-  <Card title="Overview" href="/docs/managed-agents" cta="Continue">
-    Move from sandbox primitives to durable managed agent sessions.
+  <Card title="Publish Functions" href="/docs/function/publish" cta="Continue">
+    Configure a publishable service and create a function from it.
   </Card>
 
-  <Card title="SDK Usage" href="/docs/managed-agents/sdk" cta="Continue">
-    Point the official SDK at Sandbox0 and create the first managed session.
+  <Card title="Revisions And Aliases" href="/docs/function/revisions" cta="Continue">
+    Publish new revisions, promote them, and roll back with aliases.
+  </Card>
+
+  <Card title="Runtime" href="/docs/function/runtime" cta="Continue">
+    Inspect, restart, disable, and delete function runtimes.
   </Card>
 </CardGroup>

--- a/docs/function/publish/page.mdx
+++ b/docs/function/publish/page.mdx
@@ -1,0 +1,255 @@
+# Publish Functions
+
+Publish a Function by first configuring a Sandbox Service with public ingress and a restartable runtime, then creating a function from that service.
+
+## Configure a Publishable Service
+
+<Endpoint method="PUT">
+/api/v1/sandboxes/{'{id}'}/services
+</Endpoint>
+
+The update replaces the full service list. Include every service that should remain active on the sandbox.
+
+<Tabs
+  tabs={[
+    {
+      label: "Go",
+      language: "go",
+      code: `resp, err := sandbox.UpdateServices(ctx, []apispec.SandboxAppService{
+    {
+        ID:   "api",
+        Port: 8080,
+        Runtime: apispec.NewOptSandboxAppServiceRuntime(apispec.SandboxAppServiceRuntime{
+            Type:    apispec.SandboxAppServiceRuntimeTypeCmd,
+            Command: []string{"python3", "-m", "http.server", "8080", "--bind", "0.0.0.0", "-d", "/workspace/public"},
+            Cwd:     apispec.NewOptString("/workspace"),
+        }),
+        Ingress: apispec.SandboxAppServiceIngress{
+            Public: true,
+            Routes: []apispec.SandboxAppServiceRoute{
+                {
+                    ID:         "api",
+                    PathPrefix: apispec.NewOptString("/"),
+                    Methods:    []string{"GET"},
+                    Resume:     true,
+                },
+            },
+        },
+        HealthCheck: apispec.NewOptSandboxAppServiceHealth(apispec.SandboxAppServiceHealth{
+            Path: apispec.NewOptString("/"),
+        }),
+    },
+})
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Printf("services: %d\\n", len(resp.Services))`
+    },
+    {
+      label: "Python",
+      language: "python",
+      code: `from sandbox0.apispec.models.sandbox_app_service import SandboxAppService
+from sandbox0.apispec.models.sandbox_app_service_health import SandboxAppServiceHealth
+from sandbox0.apispec.models.sandbox_app_service_ingress import SandboxAppServiceIngress
+from sandbox0.apispec.models.sandbox_app_service_route import SandboxAppServiceRoute
+from sandbox0.apispec.models.sandbox_app_service_runtime import SandboxAppServiceRuntime
+from sandbox0.apispec.models.sandbox_app_service_runtime_type import SandboxAppServiceRuntimeType
+
+resp = sandbox.update_services([
+    SandboxAppService(
+        id="api",
+        port=8080,
+        runtime=SandboxAppServiceRuntime(
+            type_=SandboxAppServiceRuntimeType.CMD,
+            command=["python3", "-m", "http.server", "8080", "--bind", "0.0.0.0", "-d", "/workspace/public"],
+            cwd="/workspace",
+        ),
+        ingress=SandboxAppServiceIngress(
+            public=True,
+            routes=[
+                SandboxAppServiceRoute(
+                    id="api",
+                    path_prefix="/",
+                    methods=["GET"],
+                    resume=True,
+                ),
+            ],
+        ),
+        health_check=SandboxAppServiceHealth(path="/"),
+    ),
+])
+print(f"services: {len(resp.services)}")`
+    },
+    {
+      label: "TypeScript",
+      language: "typescript",
+      code: `const resp = await sandbox.updateServices([
+    {
+        id: 'api',
+        port: 8080,
+        runtime: {
+            type: 'cmd',
+            command: ['python3', '-m', 'http.server', '8080', '--bind', '0.0.0.0', '-d', '/workspace/public'],
+            cwd: '/workspace',
+        },
+        ingress: {
+            _public: true,
+            routes: [
+                {
+                    id: 'api',
+                    pathPrefix: '/',
+                    methods: ['GET'],
+                    resume: true,
+                },
+            ],
+        },
+        healthCheck: { path: '/' },
+    },
+]);
+console.log('services:', resp.services.length);`
+    },
+    {
+      label: "CLI",
+      language: "bash",
+      code: `cat > services.yaml <<EOF
+services:
+  - id: api
+    port: 8080
+    runtime:
+      type: cmd
+      command: ["python3", "-m", "http.server", "8080", "--bind", "0.0.0.0", "-d", "/workspace/public"]
+      cwd: /workspace
+    ingress:
+      public: true
+      routes:
+        - id: api
+          path_prefix: /
+          methods: [GET]
+          resume: true
+    health_check:
+      path: /
+EOF
+
+s0 sandbox service update --services-file services.yaml -s sb_abc123`
+    }
+  ]}
+/>
+
+## Check Publishability
+
+<Endpoint method="GET">
+/api/v1/sandboxes/{'{id}'}/services
+</Endpoint>
+
+The response includes `publishable` and `publish_blockers` for every service. A service must be publishable before it can become a function revision.
+
+<Tabs
+  tabs={[
+    {
+      label: "Go",
+      language: "go",
+      code: `resp, err := sandbox.GetServices(ctx)
+if err != nil {
+    log.Fatal(err)
+}
+for _, service := range resp.Services {
+    fmt.Printf("%s publishable=%t blockers=%v\\n", service.ID, service.Publishable, service.PublishBlockers)
+}`
+    },
+    {
+      label: "Python",
+      language: "python",
+      code: `from sandbox0.apispec.types import UNSET
+
+resp = sandbox.get_services()
+for service in resp.services:
+    blockers = [] if service.publish_blockers is UNSET else service.publish_blockers
+    print(f"{service.id} publishable={service.publishable} blockers={blockers}")`
+    },
+    {
+      label: "TypeScript",
+      language: "typescript",
+      code: `const services = await sandbox.getServices();
+for (const service of services.services) {
+    console.log(service.id, 'publishable=', service.publishable, 'blockers=', service.publishBlockers ?? []);
+}`
+    },
+    {
+      label: "CLI",
+      language: "bash",
+      code: `s0 sandbox service get -s sb_abc123`
+    }
+  ]}
+/>
+
+## Create a Function
+
+<Endpoint method="POST">
+/api/v1/functions
+</Endpoint>
+
+Creating a function creates the stable function record, revision 1, and the `production` alias.
+
+<Tabs
+  tabs={[
+    {
+      label: "Go",
+      language: "go",
+      code: `result, err := client.CreateFunctionFromSandbox(
+    ctx,
+    sandbox.ID,
+    "api",
+    sandbox0.WithFunctionName("my-api"),
+)
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Printf("function URL: %s\\n", result.Function.URL)`
+    },
+    {
+      label: "Python",
+      language: "python",
+      code: `result = client.functions.create_from_sandbox(
+    sandbox.id,
+    "api",
+    name="my-api",
+)
+print(f"function URL: {result.function.url}")`
+    },
+    {
+      label: "TypeScript",
+      language: "typescript",
+      code: `const result = await client.functions.createFromSandbox(
+    sandbox.id,
+    'api',
+    { name: 'my-api' },
+);
+console.log('function URL:', result.function.url);`
+    },
+    {
+      label: "CLI",
+      language: "bash",
+      code: `s0 function create sb_abc123 api --name my-api`
+    }
+  ]}
+/>
+
+## Invoke the Function
+
+Use the returned `url` as the stable public endpoint.
+
+```bash
+curl "$FUNCTION_URL/"
+```
+
+## Next Steps
+
+<CardGroup>
+  <Card title="Revisions And Aliases" href="/docs/function/revisions" cta="Continue">
+    Publish and promote new versions without changing the function URL.
+  </Card>
+
+  <Card title="Sandbox Services" href="/docs/sandbox/services" cta="Continue">
+    Configure route auth, CORS, rate limits, rewrite rules, and timeouts.
+  </Card>
+</CardGroup>

--- a/docs/function/revisions/page.mdx
+++ b/docs/function/revisions/page.mdx
@@ -1,0 +1,193 @@
+# Revisions And Aliases
+
+Function revisions are immutable snapshots of a Sandbox Service. Aliases are mutable pointers to revisions. The function host serves the revision pointed to by the `production` alias.
+
+## Create a Revision
+
+<Endpoint method="POST">
+/api/v1/functions/{'{id}'}/revisions
+</Endpoint>
+
+Create a revision from the same service or from another publishable service. Set `promote` to `false` when you want to inspect the revision before moving production traffic.
+
+<Tabs
+  tabs={[
+    {
+      label: "Go",
+      language: "go",
+      code: `result, err := client.CreateFunctionRevisionFromSandbox(
+    ctx,
+    functionID,
+    sandbox.ID,
+    "api",
+    sandbox0.WithFunctionRevisionPromote(false),
+)
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Printf("revision: %d promoted=%t\\n", result.Revision.RevisionNumber, result.Promoted)`
+    },
+    {
+      label: "Python",
+      language: "python",
+      code: `result = client.functions.create_revision_from_sandbox(
+    function_id,
+    sandbox.id,
+    "api",
+    promote=False,
+)
+print(f"revision: {result.revision.revision_number} promoted={result.promoted}")`
+    },
+    {
+      label: "TypeScript",
+      language: "typescript",
+      code: `const result = await client.functions.createRevisionFromSandbox(
+    functionId,
+    sandbox.id,
+    'api',
+    { promote: false },
+);
+console.log('revision:', result.revision.revisionNumber, 'promoted=', result.promoted);`
+    },
+    {
+      label: "CLI",
+      language: "bash",
+      code: `s0 function revision create fn_abc123 sb_def456 api --promote=false`
+    }
+  ]}
+/>
+
+## List Revisions
+
+<Endpoint method="GET">
+/api/v1/functions/{'{id}'}/revisions
+</Endpoint>
+
+<Tabs
+  tabs={[
+    {
+      label: "Go",
+      language: "go",
+      code: `revisions, err := client.ListFunctionRevisions(ctx, functionID)
+if err != nil {
+    log.Fatal(err)
+}
+for _, revision := range revisions {
+    fmt.Printf("revision %d from %s/%s\\n", revision.RevisionNumber, revision.SourceSandboxID, revision.SourceServiceID)
+}`
+    },
+    {
+      label: "Python",
+      language: "python",
+      code: `revisions = client.functions.list_revisions(function_id)
+for revision in revisions:
+    print(f"revision {revision.revision_number} from {revision.source_sandbox_id}/{revision.source_service_id}")`
+    },
+    {
+      label: "TypeScript",
+      language: "typescript",
+      code: `const revisions = await client.functions.listRevisions(functionId);
+for (const revision of revisions) {
+    console.log(\`revision \${revision.revisionNumber} from \${revision.sourceSandboxId}/\${revision.sourceServiceId}\`);
+}`
+    },
+    {
+      label: "CLI",
+      language: "bash",
+      code: `s0 function revision list fn_abc123`
+    }
+  ]}
+/>
+
+## Promote Or Roll Back
+
+<Endpoint method="PUT">
+/api/v1/functions/{'{id}'}/aliases/{'{alias}'}
+</Endpoint>
+
+Move `production` to a revision number to promote or roll back traffic.
+
+<Tabs
+  tabs={[
+    {
+      label: "Go",
+      language: "go",
+      code: `alias, err := client.SetFunctionAlias(ctx, functionID, "production", 2)
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Printf("%s -> revision %d\\n", alias.Alias, alias.RevisionNumber)`
+    },
+    {
+      label: "Python",
+      language: "python",
+      code: `alias = client.functions.set_alias(function_id, "production", 2)
+print(f"{alias.alias} -> revision {alias.revision_number}")`
+    },
+    {
+      label: "TypeScript",
+      language: "typescript",
+      code: `const alias = await client.functions.setAlias(functionId, 'production', 2);
+console.log(\`\${alias.alias} -> revision \${alias.revisionNumber}\`);`
+    },
+    {
+      label: "CLI",
+      language: "bash",
+      code: `s0 function alias set fn_abc123 production 2`
+    }
+  ]}
+/>
+
+## Read Aliases
+
+<Endpoint method="GET">
+/api/v1/functions/{'{id}'}/aliases
+</Endpoint>
+
+<Tabs
+  tabs={[
+    {
+      label: "Go",
+      language: "go",
+      code: `aliases, err := client.ListFunctionAliases(ctx, functionID)
+if err != nil {
+    log.Fatal(err)
+}
+for _, alias := range aliases {
+    fmt.Printf("%s -> revision %d\\n", alias.Alias, alias.RevisionNumber)
+}`
+    },
+    {
+      label: "Python",
+      language: "python",
+      code: `aliases = client.functions.list_aliases(function_id)
+for alias in aliases:
+    print(f"{alias.alias} -> revision {alias.revision_number}")`
+    },
+    {
+      label: "TypeScript",
+      language: "typescript",
+      code: `const aliases = await client.functions.listAliases(functionId);
+for (const alias of aliases) {
+    console.log(\`\${alias.alias} -> revision \${alias.revisionNumber}\`);
+}`
+    },
+    {
+      label: "CLI",
+      language: "bash",
+      code: `s0 function alias list fn_abc123`
+    }
+  ]}
+/>
+
+## Next Steps
+
+<CardGroup>
+  <Card title="Runtime" href="/docs/function/runtime" cta="Continue">
+    Inspect and reset the runtime sandbox serving production traffic.
+  </Card>
+
+  <Card title="Publish Functions" href="/docs/function/publish" cta="Continue">
+    Create another publishable service and publish it as a revision.
+  </Card>
+</CardGroup>

--- a/docs/function/runtime/page.mdx
+++ b/docs/function/runtime/page.mdx
@@ -1,0 +1,220 @@
+# Function Runtime
+
+Function runtime state describes the currently restored sandbox serving a function revision. When the source sandbox still exists, Function Gateway routes to it directly. When the source sandbox is gone, Function Gateway restores a runtime sandbox from the revision's template and revision-owned volumes.
+
+## Runtime States
+
+| State | Meaning |
+|-------|---------|
+| `idle` | No restored runtime sandbox is currently recorded for the active revision |
+| `active` | A restored runtime sandbox is recorded for the active revision |
+| `disabled` | The function is disabled and does not serve host traffic |
+
+`restart` and `recycle` both delete the current restored runtime sandbox when one exists and clear the runtime mapping. The next function request starts a fresh runtime from the active revision.
+
+## Get Runtime Status
+
+<Endpoint method="GET">
+/api/v1/functions/{'{id}'}/runtime
+</Endpoint>
+
+<Tabs
+  tabs={[
+    {
+      label: "Go",
+      language: "go",
+      code: `runtime, err := client.GetFunctionRuntime(ctx, functionID)
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Printf("state=%s revision=%d\\n", runtime.State, runtime.RevisionNumber)`
+    },
+    {
+      label: "Python",
+      language: "python",
+      code: `runtime = client.functions.get_runtime(function_id)
+print(f"state={runtime.state} revision={runtime.revision_number}")`
+    },
+    {
+      label: "TypeScript",
+      language: "typescript",
+      code: `const runtime = await client.functions.getRuntime(functionId);
+console.log('state=', runtime.state, 'revision=', runtime.revisionNumber);`
+    },
+    {
+      label: "CLI",
+      language: "bash",
+      code: `s0 function runtime get fn_abc123`
+    }
+  ]}
+/>
+
+## Restart Runtime
+
+<Endpoint method="POST">
+/api/v1/functions/{'{id}'}/runtime/restart
+</Endpoint>
+
+<Tabs
+  tabs={[
+    {
+      label: "Go",
+      language: "go",
+      code: `runtime, err := client.RestartFunctionRuntime(ctx, functionID)
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Printf("state=%s\\n", runtime.State)`
+    },
+    {
+      label: "Python",
+      language: "python",
+      code: `runtime = client.functions.restart_runtime(function_id)
+print(f"state={runtime.state}")`
+    },
+    {
+      label: "TypeScript",
+      language: "typescript",
+      code: `const runtime = await client.functions.restartRuntime(functionId);
+console.log('state=', runtime.state);`
+    },
+    {
+      label: "CLI",
+      language: "bash",
+      code: `s0 function runtime restart fn_abc123`
+    }
+  ]}
+/>
+
+## Recycle Runtime
+
+<Endpoint method="POST">
+/api/v1/functions/{'{id}'}/runtime/recycle
+</Endpoint>
+
+<Tabs
+  tabs={[
+    {
+      label: "Go",
+      language: "go",
+      code: `runtime, err := client.RecycleFunctionRuntime(ctx, functionID)
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Printf("state=%s\\n", runtime.State)`
+    },
+    {
+      label: "Python",
+      language: "python",
+      code: `runtime = client.functions.recycle_runtime(function_id)
+print(f"state={runtime.state}")`
+    },
+    {
+      label: "TypeScript",
+      language: "typescript",
+      code: `const runtime = await client.functions.recycleRuntime(functionId);
+console.log('state=', runtime.state);`
+    },
+    {
+      label: "CLI",
+      language: "bash",
+      code: `s0 function runtime recycle fn_abc123`
+    }
+  ]}
+/>
+
+## Disable Serving
+
+<Endpoint method="PUT">
+/api/v1/functions/{'{id}'}
+</Endpoint>
+
+Disabling a function keeps its identity, domain, revisions, and aliases. Disabled functions return `503` from the function host and do not restore runtime sandboxes.
+
+<Tabs
+  tabs={[
+    {
+      label: "Go",
+      language: "go",
+      code: `fn, err := client.UpdateFunctionWithOptions(
+    ctx,
+    functionID,
+    sandbox0.WithFunctionEnabled(false),
+)
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Printf("enabled=%t\\n", fn.Enabled)`
+    },
+    {
+      label: "Python",
+      language: "python",
+      code: `from sandbox0.apispec.models.function_update_request import FunctionUpdateRequest
+
+fn = client.functions.update(function_id, FunctionUpdateRequest(enabled=False))
+print(f"enabled={fn.enabled}")`
+    },
+    {
+      label: "TypeScript",
+      language: "typescript",
+      code: `const fn = await client.functions.update(functionId, { enabled: false });
+console.log('enabled=', fn.enabled);`
+    },
+    {
+      label: "CLI",
+      language: "bash",
+      code: `s0 function update fn_abc123 --enabled=false`
+    }
+  ]}
+/>
+
+## Delete a Function
+
+<Endpoint method="DELETE">
+/api/v1/functions/{'{id}'}
+</Endpoint>
+
+Delete is a soft delete. The function disappears from normal list/get APIs, the host stops serving traffic, and the slug/domain label remain reserved. Sandbox0 schedules best-effort cleanup for restored runtime sandboxes and revision-owned volumes.
+
+<Tabs
+  tabs={[
+    {
+      label: "Go",
+      language: "go",
+      code: `fn, err := client.DeleteFunction(ctx, functionID)
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Printf("deleted function: %s\\n", fn.ID)`
+    },
+    {
+      label: "Python",
+      language: "python",
+      code: `fn = client.functions.delete(function_id)
+print(f"deleted function: {fn.id}")`
+    },
+    {
+      label: "TypeScript",
+      language: "typescript",
+      code: `const fn = await client.functions.delete(functionId);
+console.log('deleted function:', fn.id);`
+    },
+    {
+      label: "CLI",
+      language: "bash",
+      code: `s0 function delete fn_abc123`
+    }
+  ]}
+/>
+
+## Next Steps
+
+<CardGroup>
+  <Card title="Revisions And Aliases" href="/docs/function/revisions" cta="Continue">
+    Move production traffic between immutable function revisions.
+  </Card>
+
+  <Card title="Volume Snapshots" href="/docs/volume/snapshots" cta="Continue">
+    Understand the snapshot model used for revision restore mounts.
+  </Card>
+</CardGroup>

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -64,6 +64,18 @@
         {
           "slug": "",
           "title": "Overview"
+        },
+        {
+          "slug": "publish",
+          "title": "Publish Functions"
+        },
+        {
+          "slug": "revisions",
+          "title": "Revisions And Aliases"
+        },
+        {
+          "slug": "runtime",
+          "title": "Runtime"
         }
       ]
     },


### PR DESCRIPTION
## What changed

- Reworked the Functions overview into the entry page for model, serving behavior, publishability, and next steps.
- Added embedded Go, Python, TypeScript, and CLI examples in the existing docs order for publish, revision/alias, and runtime workflows.
- Updated the docs manifest to expose the new Function subpages.

## Validation

- Checked snippets against sdk-go, sdk-py, sdk-js, and s0 CLI source.
- Ran local checks: `python3 -m json.tool docs/manifest.json`, `go test ./...` in `sdk-go`, Python compileall in `sdk-py`, `npm run lint -- --pretty false` in `sdk-js`, and `go test ./internal/commands ./internal/output` in `s0`.
- Deployed the remote kind environment and exercised the Go, Python, TypeScript, and CLI function snippets end to end, including service publishability, function creation, host invocation, revisions, aliases, runtime restart/recycle, disable, and delete.
