### PR TITLE
Handle terminating sandboxes for functions

### DIFF
--- a/docs/sandbox/page.mdx
+++ b/docs/sandbox/page.mdx
@@ -331,7 +331,7 @@ List all sandboxes with optional filters.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `status` | string | Filter by status (`starting`, `running`, `failed`, `completed`) |
+| `status` | string | Filter by status (`starting`, `running`, `failed`, `completed`, `terminating`) |
 | `template_id` | string | Filter by template ID |
 | `paused` | boolean | Filter by paused state independently of `status` |
 | `limit` | integer | Max results per page (default: 50, max: 200) |

--- a/function-gateway/pkg/http/runtime.go
+++ b/function-gateway/pkg/http/runtime.go
@@ -400,12 +400,19 @@ func functionSandboxWantsPaused(sandbox *mgr.Sandbox) bool {
 	return sandbox.Paused
 }
 
+func functionSandboxCanServeSource(sandbox *mgr.Sandbox) bool {
+	if sandbox == nil {
+		return false
+	}
+	return sandbox.Status == mgr.SandboxStatusRunning
+}
+
 func (s *Server) resolveFunctionSandbox(ctx context.Context, fn *functions.Function, rev *functions.Revision, service mgr.SandboxAppService) (*mgr.Sandbox, *functions.Revision, error) {
 	sourceSandbox, err := s.getSandboxFromClusterGateway(ctx, rev.SourceSandboxID)
-	if err == nil {
+	if err == nil && functionSandboxCanServeSource(sourceSandbox) {
 		return sourceSandbox, rev, nil
 	}
-	if !isPublishNotFound(err) {
+	if err != nil && !isPublishNotFound(err) {
 		return nil, rev, err
 	}
 	return s.ensureRestoredFunctionSandbox(ctx, fn, rev, service)

--- a/function-gateway/pkg/http/runtime_test.go
+++ b/function-gateway/pkg/http/runtime_test.go
@@ -85,6 +85,25 @@ func TestRewriteFunctionPath(t *testing.T) {
 	}
 }
 
+func TestFunctionSandboxCanServeSourceRequiresRunning(t *testing.T) {
+	if !functionSandboxCanServeSource(&mgr.Sandbox{Status: mgr.SandboxStatusRunning}) {
+		t.Fatal("running sandbox should serve source function traffic")
+	}
+
+	for _, status := range []string{
+		mgr.SandboxStatusStarting,
+		mgr.SandboxStatusFailed,
+		mgr.SandboxStatusCompleted,
+		mgr.SandboxStatusTerminating,
+	} {
+		t.Run(status, func(t *testing.T) {
+			if functionSandboxCanServeSource(&mgr.Sandbox{Status: status}) {
+				t.Fatalf("status %q should not serve source function traffic", status)
+			}
+		})
+	}
+}
+
 func TestDecodeFunctionContextResponseAcceptsGatewayEnvelope(t *testing.T) {
 	out, err := decodeFunctionContextResponse(strings.NewReader(`{"success":true,"data":{"id":"ctx-a","running":true}}`))
 	if err != nil {

--- a/manager/pkg/service/sandbox_service.go
+++ b/manager/pkg/service/sandbox_service.go
@@ -45,6 +45,7 @@ const (
 	SandboxStatusRunning      = "running"
 	SandboxStatusFailed       = "failed"
 	SandboxStatusCompleted    = "completed"
+	SandboxStatusTerminating  = "terminating"
 	SandboxPowerStateActive   = "active"
 	SandboxPowerStatePaused   = "paused"
 	SandboxPowerPhaseStable   = "stable"

--- a/manager/pkg/service/sandbox_service_lifecycle.go
+++ b/manager/pkg/service/sandbox_service_lifecycle.go
@@ -223,7 +223,7 @@ func (s *SandboxService) getSandboxPod(ctx context.Context, sandboxID string) (*
 
 // podToSandbox converts a pod to a sandbox object
 func (s *SandboxService) podToSandbox(ctx context.Context, pod *corev1.Pod, sandboxID string) *Sandbox {
-	status := s.podPhaseToSandboxStatus(pod.Status.Phase)
+	status := s.podToSandboxStatus(pod)
 
 	// Parse timestamps
 	claimedAt := parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationClaimedAt)

--- a/manager/pkg/service/sandbox_service_list.go
+++ b/manager/pkg/service/sandbox_service_list.go
@@ -73,8 +73,7 @@ func (s *SandboxService) ListSandboxes(ctx context.Context, req *ListSandboxesRe
 			continue
 		}
 
-		// Get status from pod phase
-		status := s.podPhaseToSandboxStatus(pod.Status.Phase)
+		status := s.podToSandboxStatus(pod)
 
 		// Filter by status if specified
 		if req.Status != "" && status != req.Status {

--- a/manager/pkg/service/sandbox_service_list_test.go
+++ b/manager/pkg/service/sandbox_service_list_test.go
@@ -295,6 +295,61 @@ func TestListSandboxes_IncludesPowerState(t *testing.T) {
 	assert.False(t, resp.Sandboxes[0].Paused)
 }
 
+func TestListSandboxes_TerminatingPodStatus(t *testing.T) {
+	now := time.Now()
+	pod := createTestPod("sandbox-terminating", "team-a", "template-1", controller.PoolTypeActive, now, now.Add(time.Hour), false)
+	deletionTime := metav1.NewTime(now.Add(time.Minute))
+	pod.DeletionTimestamp = &deletionTime
+	pod.Finalizers = []string{"test.sandbox0.ai/finalizer"}
+
+	svc := &SandboxService{
+		k8sClient: fake.NewSimpleClientset(),
+		podLister: newTestPodLister(t, pod),
+		clock:     systemTime{},
+		logger:    zap.NewNop(),
+	}
+
+	all, err := svc.ListSandboxes(context.Background(), &ListSandboxesRequest{
+		TeamID: "team-a",
+		Limit:  50,
+	})
+	require.NoError(t, err)
+	require.Len(t, all.Sandboxes, 1)
+	assert.Equal(t, SandboxStatusTerminating, all.Sandboxes[0].Status)
+
+	running, err := svc.ListSandboxes(context.Background(), &ListSandboxesRequest{
+		TeamID: "team-a",
+		Status: SandboxStatusRunning,
+		Limit:  50,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, running.Sandboxes)
+
+	terminating, err := svc.ListSandboxes(context.Background(), &ListSandboxesRequest{
+		TeamID: "team-a",
+		Status: SandboxStatusTerminating,
+		Limit:  50,
+	})
+	require.NoError(t, err)
+	require.Len(t, terminating.Sandboxes, 1)
+	assert.Equal(t, "sandbox-terminating", terminating.Sandboxes[0].ID)
+}
+
+func TestPodToSandboxStatusTreatsDeletionAsTerminating(t *testing.T) {
+	now := metav1.Now()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			DeletionTimestamp: &now,
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+		},
+	}
+
+	svc := &SandboxService{}
+	assert.Equal(t, SandboxStatusTerminating, svc.podToSandboxStatus(pod))
+}
+
 func createTestPod(name, teamID, templateID, poolType string, createdAt, expiresAt time.Time, paused bool) *corev1.Pod {
 	return createTestPodWithPhase(name, teamID, templateID, poolType, createdAt, expiresAt, paused, corev1.PodRunning)
 }

--- a/manager/pkg/service/sandbox_service_pod.go
+++ b/manager/pkg/service/sandbox_service_pod.go
@@ -269,6 +269,17 @@ func (s *SandboxService) probeSandboxPodOrFailure(ctx context.Context, pod *core
 	return result
 }
 
+// podToSandboxStatus converts pod state to sandbox status.
+func (s *SandboxService) podToSandboxStatus(pod *corev1.Pod) string {
+	if pod == nil {
+		return SandboxStatusPending
+	}
+	if pod.DeletionTimestamp != nil {
+		return SandboxStatusTerminating
+	}
+	return s.podPhaseToSandboxStatus(pod.Status.Phase)
+}
+
 // podPhaseToSandboxStatus converts pod phase to sandbox status
 func (s *SandboxService) podPhaseToSandboxStatus(phase corev1.PodPhase) string {
 	switch phase {

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -1162,7 +1162,7 @@ paths:
           description: Filter by sandbox status
           schema:
             type: string
-            enum: [starting, running, failed, completed]
+            enum: [starting, running, failed, completed, terminating]
         - name: template_id
           in: query
           description: Filter by template ID
@@ -4609,7 +4609,7 @@ components:
           type: string
         status:
           type: string
-          enum: [starting, running, failed, completed]
+          enum: [starting, running, failed, completed, terminating]
         paused:
           type: boolean
         power_state:

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -170,10 +170,11 @@ const (
 
 // Defines values for SandboxSummaryStatus.
 const (
-	SandboxSummaryStatusCompleted SandboxSummaryStatus = "completed"
-	SandboxSummaryStatusFailed    SandboxSummaryStatus = "failed"
-	SandboxSummaryStatusRunning   SandboxSummaryStatus = "running"
-	SandboxSummaryStatusStarting  SandboxSummaryStatus = "starting"
+	SandboxSummaryStatusCompleted   SandboxSummaryStatus = "completed"
+	SandboxSummaryStatusFailed      SandboxSummaryStatus = "failed"
+	SandboxSummaryStatusRunning     SandboxSummaryStatus = "running"
+	SandboxSummaryStatusStarting    SandboxSummaryStatus = "starting"
+	SandboxSummaryStatusTerminating SandboxSummaryStatus = "terminating"
 )
 
 // Defines values for SuccessAPIKeyListResponseSuccess.
@@ -524,10 +525,11 @@ const (
 
 // Defines values for GetApiV1SandboxesParamsStatus.
 const (
-	GetApiV1SandboxesParamsStatusCompleted GetApiV1SandboxesParamsStatus = "completed"
-	GetApiV1SandboxesParamsStatusFailed    GetApiV1SandboxesParamsStatus = "failed"
-	GetApiV1SandboxesParamsStatusRunning   GetApiV1SandboxesParamsStatus = "running"
-	GetApiV1SandboxesParamsStatusStarting  GetApiV1SandboxesParamsStatus = "starting"
+	GetApiV1SandboxesParamsStatusCompleted   GetApiV1SandboxesParamsStatus = "completed"
+	GetApiV1SandboxesParamsStatusFailed      GetApiV1SandboxesParamsStatus = "failed"
+	GetApiV1SandboxesParamsStatusRunning     GetApiV1SandboxesParamsStatus = "running"
+	GetApiV1SandboxesParamsStatusStarting    GetApiV1SandboxesParamsStatus = "starting"
+	GetApiV1SandboxesParamsStatusTerminating GetApiV1SandboxesParamsStatus = "terminating"
 )
 
 // APIKey defines model for APIKey.

--- a/pkg/gateway/functionapi/handler.go
+++ b/pkg/gateway/functionapi/handler.go
@@ -9,6 +9,7 @@ import (
 	neturl "net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -51,6 +52,8 @@ type Handler struct {
 	volumeStore   RevisionVolumeStore
 	runtime       RuntimeController
 	logger        *zap.Logger
+
+	revisionPublishLocks sync.Map
 }
 
 func New(repo *functions.Repository, cfg Config, lookup SandboxLookup, volumeStore RevisionVolumeStore, runtime RuntimeController, logger *zap.Logger) *Handler {
@@ -65,6 +68,19 @@ func New(repo *functions.Repository, cfg Config, lookup SandboxLookup, volumeSto
 		runtime:       runtime,
 		logger:        logger,
 	}
+}
+
+func (h *Handler) tryLockFunctionRevisionPublish(teamID, functionID string) (func(), bool) {
+	key := teamID + ":" + functionID
+	newLock := &sync.Mutex{}
+	actual, _ := h.revisionPublishLocks.LoadOrStore(key, newLock)
+	lock := actual.(*sync.Mutex)
+	if !lock.TryLock() {
+		return nil, false
+	}
+	return func() {
+		lock.Unlock()
+	}, true
 }
 
 func (h *Handler) RegisterRoutes(group *gin.RouterGroup, require PermissionMiddleware) {
@@ -362,6 +378,22 @@ func (h *Handler) createFunctionRevision(c *gin.Context) {
 		return
 	}
 
+	fn, err := h.repo.GetFunction(c.Request.Context(), authCtx.TeamID, c.Param("id"))
+	if err != nil {
+		if errors.Is(err, functions.ErrNotFound) {
+			spec.JSONError(c, http.StatusNotFound, spec.CodeNotFound, "function not found")
+			return
+		}
+		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to get function")
+		return
+	}
+	unlockRevisionPublish, ok := h.tryLockFunctionRevisionPublish(authCtx.TeamID, fn.ID)
+	if !ok {
+		spec.JSONError(c, http.StatusConflict, spec.CodeConflict, "function revision publish already in progress")
+		return
+	}
+	defer unlockRevisionPublish()
+
 	sandbox, serviceSnapshot, err := h.loadPublishableService(c.Request.Context(), authCtx, req.Source)
 	if err != nil {
 		h.writePublishError(c, err)
@@ -390,7 +422,7 @@ func (h *Handler) createFunctionRevision(c *gin.Context) {
 		promote = *req.Promote
 	}
 
-	rev, err = h.repo.CreateRevision(c.Request.Context(), authCtx.TeamID, c.Param("id"), rev, promote, userID)
+	rev, err = h.repo.CreateRevision(c.Request.Context(), authCtx.TeamID, fn.ID, rev, promote, userID)
 	if err != nil {
 		if errors.Is(err, functions.ErrNotFound) {
 			spec.JSONError(c, http.StatusNotFound, spec.CodeNotFound, "function not found")

--- a/pkg/gateway/functionapi/handler_test.go
+++ b/pkg/gateway/functionapi/handler_test.go
@@ -1,0 +1,30 @@
+package functionapi
+
+import "testing"
+
+func TestTryLockFunctionRevisionPublishSerializesFunction(t *testing.T) {
+	handler := &Handler{}
+
+	release, ok := handler.tryLockFunctionRevisionPublish("team-a", "function-a")
+	if !ok {
+		t.Fatal("first publish lock attempt failed")
+	}
+	if secondRelease, ok := handler.tryLockFunctionRevisionPublish("team-a", "function-a"); ok {
+		secondRelease()
+		t.Fatal("second publish lock attempt for same function succeeded")
+	}
+
+	otherRelease, ok := handler.tryLockFunctionRevisionPublish("team-a", "function-b")
+	if !ok {
+		t.Fatal("publish lock for different function failed")
+	}
+	otherRelease()
+
+	release()
+
+	reacquired, ok := handler.tryLockFunctionRevisionPublish("team-a", "function-a")
+	if !ok {
+		t.Fatal("publish lock was not reusable after release")
+	}
+	reacquired()
+}


### PR DESCRIPTION
## Summary
- map deleting pods to a sandbox `terminating` status and expose it in the API/docs
- avoid routing function traffic to non-running source sandboxes so deleting sources fall back to restored runtimes
- serialize revision publishing per function in-process to avoid concurrent revision number races

## Tests
- `GOTOOLCHAIN=go1.25.0+auto go test ./manager/pkg/service ./pkg/gateway/functionapi ./function-gateway/pkg/http ./pkg/apispec`
- Remote kind fullmode deploy on Aliyun ECS: `Sandbox0Infra Ready 10/10`
- Remote terminating status case: held a deleting pod with a finalizer; GET returned `status=terminating`, list `status=terminating` returned count 1
- Remote revision publish concurrency: 24 concurrent publishes returned `2x201 + 22x409 + 0x500`
- Remote function cold concurrency while source sandbox was deleting: 32 concurrent function requests returned `32x200`; function-gateway latencies were about 4.1-4.4s

Remote ECS was stopped after validation.