### PR TITLE
Add conservative S0FS object garbage collection

### DIFF
--- a/storage-proxy/pkg/db/repository.go
+++ b/storage-proxy/pkg/db/repository.go
@@ -282,6 +282,45 @@ func (r *Repository) ListSandboxVolumesByTeam(ctx context.Context, teamID string
 	return volumes, nil
 }
 
+// ListSandboxVolumesBySource retrieves volumes forked from a source volume.
+func (r *Repository) ListSandboxVolumesBySource(ctx context.Context, sourceVolumeID string) ([]*SandboxVolume, error) {
+	rows, err := r.pool.Query(ctx, `
+		SELECT
+			id, team_id, user_id,
+			source_volume_id,
+			default_posix_uid, default_posix_gid,
+			access_mode,
+			created_at, updated_at
+		FROM sandbox_volumes
+		WHERE source_volume_id = $1
+		ORDER BY created_at DESC
+	`, sourceVolumeID)
+	if err != nil {
+		return nil, fmt.Errorf("query sandbox volumes by source: %w", err)
+	}
+	defer rows.Close()
+
+	var volumes []*SandboxVolume
+	for rows.Next() {
+		var v SandboxVolume
+		err := rows.Scan(
+			&v.ID, &v.TeamID, &v.UserID,
+			&v.SourceVolumeID,
+			&v.DefaultPosixUID, &v.DefaultPosixGID,
+			&v.AccessMode,
+			&v.CreatedAt, &v.UpdatedAt,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("scan sandbox volume by source: %w", err)
+		}
+		volumes = append(volumes, &v)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate sandbox volumes by source: %w", err)
+	}
+	return volumes, nil
+}
+
 // DeleteSandboxVolume deletes a sandbox volume record
 func (r *Repository) DeleteSandboxVolume(ctx context.Context, id string) error {
 	return r.deleteSandboxVolume(ctx, r.pool, id)

--- a/storage-proxy/pkg/db/repository_s0fs_head_test.go
+++ b/storage-proxy/pkg/db/repository_s0fs_head_test.go
@@ -109,6 +109,49 @@ func TestS0FSHeadStoreAdapterMapsConflicts(t *testing.T) {
 	}
 }
 
+func TestListSandboxVolumesBySource(t *testing.T) {
+	repo := newS0FSCommittedHeadTestRepository(t)
+	if repo == nil {
+		return
+	}
+
+	ctx := context.Background()
+	sourceID := "vol-" + uuid.NewString()
+	childID := "vol-" + uuid.NewString()
+	unrelatedID := "vol-" + uuid.NewString()
+	createTestSandboxVolume(t, repo, sourceID)
+	now := time.Now().UTC()
+	if err := repo.CreateSandboxVolume(ctx, &SandboxVolume{
+		ID:             childID,
+		TeamID:         "team-1",
+		UserID:         "user-1",
+		SourceVolumeID: &sourceID,
+		AccessMode:     "RWO",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}); err != nil {
+		t.Fatalf("CreateSandboxVolume(child) error = %v", err)
+	}
+	if err := repo.CreateSandboxVolume(ctx, &SandboxVolume{
+		ID:         unrelatedID,
+		TeamID:     "team-1",
+		UserID:     "user-1",
+		AccessMode: "RWO",
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}); err != nil {
+		t.Fatalf("CreateSandboxVolume(unrelated) error = %v", err)
+	}
+
+	children, err := repo.ListSandboxVolumesBySource(ctx, sourceID)
+	if err != nil {
+		t.Fatalf("ListSandboxVolumesBySource() error = %v", err)
+	}
+	if len(children) != 1 || children[0].ID != childID {
+		t.Fatalf("children = %+v, want child %s", children, childID)
+	}
+}
+
 func TestAcquireMountRejectsConflictingRWOMount(t *testing.T) {
 	repo := newS0FSCommittedHeadTestRepository(t)
 	if repo == nil {

--- a/storage-proxy/pkg/http/handlers_metering_test.go
+++ b/storage-proxy/pkg/http/handlers_metering_test.go
@@ -232,14 +232,15 @@ func (f *fakeHTTPMeteringWriter) UpsertProducerWatermarkTx(ctx context.Context, 
 }
 
 type fakeHTTPSnapshotManager struct {
-	exportBody          []byte
-	lastCreate          *snapshot.CreateSnapshotRequest
-	lastCreateVolume    *snapshot.CreateVolumeFromSnapshotRequest
-	lastExport          *snapshot.ExportSnapshotRequest
-	lastCompatibility   *snapshot.ListSnapshotCompatibilityIssuesRequest
-	casefoldEntries     []snapshot.SnapshotCasefoldCollision
-	compatibilityIssues []pathnorm.CompatibilityIssue
-	deletedSnapshot     []string
+	exportBody           []byte
+	lastCreate           *snapshot.CreateSnapshotRequest
+	lastCreateVolume     *snapshot.CreateVolumeFromSnapshotRequest
+	lastExport           *snapshot.ExportSnapshotRequest
+	lastCompatibility    *snapshot.ListSnapshotCompatibilityIssuesRequest
+	casefoldEntries      []snapshot.SnapshotCasefoldCollision
+	compatibilityIssues  []pathnorm.CompatibilityIssue
+	deletedSnapshot      []string
+	cleanedVolumeObjects []string
 }
 
 func (f *fakeHTTPSnapshotManager) CreateSnapshotSimple(ctx context.Context, req *snapshot.CreateSnapshotRequest) (*db.Snapshot, error) {
@@ -296,6 +297,13 @@ func (f *fakeHTTPSnapshotManager) DeleteSnapshot(ctx context.Context, volumeID, 
 	return nil
 }
 
+func (f *fakeHTTPSnapshotManager) DeleteVolumeObjectsIfUnreferenced(ctx context.Context, volume *db.SandboxVolume) error {
+	if volume != nil {
+		f.cleanedVolumeObjects = append(f.cleanedVolumeObjects, volume.ID)
+	}
+	return nil
+}
+
 func (f *fakeHTTPSnapshotManager) ForkVolume(ctx context.Context, req *snapshot.ForkVolumeRequest) (*db.SandboxVolume, error) {
 	return nil, nil
 }
@@ -316,12 +324,13 @@ func (f *fakeHTTPSnapshotManager) CreateVolumeFromSnapshot(ctx context.Context, 
 func TestCreateSandboxVolumeRecordsMetering(t *testing.T) {
 	repo := newFakeHTTPRepo()
 	meteringWriter := &fakeHTTPMeteringWriter{}
+	snapshotMgr := &fakeHTTPSnapshotManager{}
 	server := &Server{
 		logger:       logrus.New(),
 		repo:         repo,
 		meteringRepo: meteringWriter,
 		regionID:     "aws-us-east-1",
-		snapshotMgr:  &fakeHTTPSnapshotManager{},
+		snapshotMgr:  snapshotMgr,
 	}
 
 	req := httptest.NewRequest(http.MethodPost, "/sandboxvolumes", bytes.NewBufferString(`{}`))
@@ -382,12 +391,13 @@ func TestDeleteSandboxVolumeForceRecordsMetering(t *testing.T) {
 		PodID:     "pod-a",
 	}}
 	meteringWriter := &fakeHTTPMeteringWriter{}
+	snapshotMgr := &fakeHTTPSnapshotManager{}
 	server := &Server{
 		logger:       logrus.New(),
 		repo:         repo,
 		meteringRepo: meteringWriter,
 		regionID:     "aws-us-east-1",
-		snapshotMgr:  &fakeHTTPSnapshotManager{},
+		snapshotMgr:  snapshotMgr,
 	}
 
 	req := httptest.NewRequest(http.MethodDelete, "/sandboxvolumes/vol-1?force=true", nil)
@@ -408,6 +418,9 @@ func TestDeleteSandboxVolumeForceRecordsMetering(t *testing.T) {
 	}
 	if len(repo.deletedVolume) != 1 || repo.deletedVolume[0] != "vol-1" {
 		t.Fatalf("deleted volume = %v, want [vol-1]", repo.deletedVolume)
+	}
+	if len(snapshotMgr.cleanedVolumeObjects) != 1 || snapshotMgr.cleanedVolumeObjects[0] != "vol-1" {
+		t.Fatalf("cleaned volume objects = %v, want [vol-1]", snapshotMgr.cleanedVolumeObjects)
 	}
 	if len(meteringWriter.events) != 1 {
 		t.Fatalf("event count = %d, want 1", len(meteringWriter.events))

--- a/storage-proxy/pkg/http/handlers_sandboxvolume.go
+++ b/storage-proxy/pkg/http/handlers_sandboxvolume.go
@@ -336,6 +336,7 @@ func (s *Server) deleteSandboxVolume(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	s.cleanupDeletedSandboxVolumeObjects(r.Context(), vol)
 	s.logger.WithField("volume_id", id).WithField("team_id", vol.TeamID).Info("Sandbox volume deleted")
 	_ = spec.WriteSuccess(w, http.StatusOK, map[string]bool{"deleted": true})
 }
@@ -380,7 +381,17 @@ func (s *Server) deleteSandboxVolumeRecord(ctx context.Context, id string, force
 	}); err != nil {
 		return nil, err
 	}
+	s.cleanupDeletedSandboxVolumeObjects(ctx, vol)
 	return vol, nil
+}
+
+func (s *Server) cleanupDeletedSandboxVolumeObjects(ctx context.Context, vol *db.SandboxVolume) {
+	if s == nil || s.snapshotMgr == nil || vol == nil {
+		return
+	}
+	if err := s.snapshotMgr.DeleteVolumeObjectsIfUnreferenced(ctx, vol); err != nil {
+		s.logger.WithError(err).WithField("volume_id", vol.ID).Warn("Failed to clean up deleted sandbox volume objects")
+	}
 }
 
 func (s *Server) isOwnedSandboxVolume(ctx context.Context, id string) bool {

--- a/storage-proxy/pkg/http/server.go
+++ b/storage-proxy/pkg/http/server.go
@@ -61,6 +61,7 @@ type snapshotManager interface {
 	ExportSnapshotArchive(ctx context.Context, req *snapshot.ExportSnapshotRequest, w io.Writer) error
 	RestoreSnapshot(ctx context.Context, req *snapshot.RestoreSnapshotRequest) error
 	DeleteSnapshot(ctx context.Context, volumeID, snapshotID, teamID string) error
+	DeleteVolumeObjectsIfUnreferenced(ctx context.Context, volume *db.SandboxVolume) error
 	ForkVolume(ctx context.Context, req *snapshot.ForkVolumeRequest) (*db.SandboxVolume, error)
 	CreateVolumeFromSnapshot(ctx context.Context, req *snapshot.CreateVolumeFromSnapshotRequest) (*db.SandboxVolume, error)
 }

--- a/storage-proxy/pkg/s0fs/gc.go
+++ b/storage-proxy/pkg/s0fs/gc.go
@@ -1,0 +1,169 @@
+package s0fs
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/objectstore"
+)
+
+// GarbageCollectionPlan is a precomputed list of immutable S0FS objects that
+// are not referenced by the retained states and can be deleted by a caller that
+// has already established the required consistency guards.
+type GarbageCollectionPlan struct {
+	store        objectstore.Store
+	Segments     []string
+	Manifests    []string
+	LiveSegments int
+}
+
+type GarbageCollectionResult struct {
+	DeletedSegments  []string
+	DeletedManifests []string
+}
+
+// PlanGarbageCollection lists S0FS segment and manifest objects that are not
+// referenced by the supplied retained states.
+func (m *Materializer) PlanGarbageCollection(ctx context.Context, retainedStates []*SnapshotState, retainedManifests map[string]struct{}) (*GarbageCollectionPlan, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if !m.Enabled() {
+		return nil, fmt.Errorf("%w: materializer is not configured", ErrInvalidInput)
+	}
+	liveSegments := liveSegmentKeysForVolume(m.volumeID, retainedStates...)
+	segmentObjects, err := listObjectKeys(ctx, m.store, segmentDir+"/")
+	if err != nil {
+		return nil, err
+	}
+	manifestObjects, err := listObjectKeys(ctx, m.store, manifestDir+"/")
+	if err != nil {
+		return nil, err
+	}
+
+	plan := &GarbageCollectionPlan{
+		store:        m.store,
+		LiveSegments: len(liveSegments),
+	}
+	for _, key := range segmentObjects {
+		if _, ok := liveSegments[key]; ok {
+			continue
+		}
+		plan.Segments = append(plan.Segments, key)
+	}
+	for _, key := range manifestObjects {
+		if _, ok := retainedManifests[key]; ok {
+			continue
+		}
+		plan.Manifests = append(plan.Manifests, key)
+	}
+	return plan, nil
+}
+
+func (p *GarbageCollectionPlan) Apply(ctx context.Context) (*GarbageCollectionResult, error) {
+	result := &GarbageCollectionResult{}
+	if p == nil || p.store == nil {
+		return result, nil
+	}
+	for _, key := range p.Segments {
+		if err := ctx.Err(); err != nil {
+			return result, err
+		}
+		if err := p.store.Delete(key); err != nil {
+			return result, fmt.Errorf("delete s0fs segment %s: %w", key, err)
+		}
+		result.DeletedSegments = append(result.DeletedSegments, key)
+	}
+	for _, key := range p.Manifests {
+		if err := ctx.Err(); err != nil {
+			return result, err
+		}
+		if err := p.store.Delete(key); err != nil {
+			return result, fmt.Errorf("delete s0fs manifest %s: %w", key, err)
+		}
+		result.DeletedManifests = append(result.DeletedManifests, key)
+	}
+	return result, nil
+}
+
+// DeleteAllObjects removes every object visible through the supplied store.
+func DeleteAllObjects(ctx context.Context, store objectstore.Store) ([]string, error) {
+	if store == nil {
+		return nil, nil
+	}
+	keys, err := listObjectKeys(ctx, store, "")
+	if err != nil {
+		return nil, err
+	}
+	for _, key := range keys {
+		if err := ctx.Err(); err != nil {
+			return keys, err
+		}
+		if err := store.Delete(key); err != nil {
+			return keys, fmt.Errorf("delete s0fs object %s: %w", key, err)
+		}
+	}
+	return keys, nil
+}
+
+func liveSegmentKeysForVolume(volumeID string, states ...*SnapshotState) map[string]struct{} {
+	volumeID = strings.TrimSpace(volumeID)
+	live := make(map[string]struct{})
+	for _, state := range states {
+		if state == nil {
+			continue
+		}
+		for _, extents := range state.ColdFiles {
+			for _, extent := range extents {
+				segment := state.Segments[extent.SegmentID]
+				if segment == nil || strings.TrimSpace(segment.Key) == "" {
+					continue
+				}
+				segmentVolumeID := strings.TrimSpace(segment.VolumeID)
+				if segmentVolumeID == "" {
+					segmentVolumeID = volumeID
+				}
+				if segmentVolumeID != volumeID {
+					continue
+				}
+				live[segment.Key] = struct{}{}
+			}
+		}
+	}
+	return live
+}
+
+func listObjectKeys(ctx context.Context, store objectstore.Store, prefix string) ([]string, error) {
+	var (
+		keys       []string
+		startAfter string
+		token      string
+	)
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		objects, hasMore, nextToken, err := store.List(prefix, startAfter, token, "", 1000)
+		if err != nil {
+			return nil, fmt.Errorf("list s0fs objects %q: %w", prefix, err)
+		}
+		for _, object := range objects {
+			key := strings.TrimLeft(strings.TrimSpace(object.Key), "/")
+			if key == "" {
+				continue
+			}
+			keys = append(keys, key)
+		}
+		if !hasMore {
+			break
+		}
+		if len(objects) > 0 {
+			startAfter = objects[len(objects)-1].Key
+		}
+		token = nextToken
+	}
+	sort.Strings(keys)
+	return keys, nil
+}

--- a/storage-proxy/pkg/s0fs/materializer_test.go
+++ b/storage-proxy/pkg/s0fs/materializer_test.go
@@ -1143,6 +1143,92 @@ func TestCreateSnapshotHydratesColdFilesInline(t *testing.T) {
 	}
 }
 
+func TestMaterializerGarbageCollectionPlanDeletesUnreferencedObjects(t *testing.T) {
+	ctx := context.Background()
+	store := newPrefixedRecordingStore(t, "vol-gc-plan")
+	heads := newMemoryHeadStore()
+	engine, err := Open(ctx, Config{
+		VolumeID:    "vol-gc-plan",
+		WALPath:     filepath.Join(t.TempDir(), "engine.wal"),
+		ObjectStore: store,
+		HeadStore:   heads,
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer engine.Close()
+
+	node, err := engine.CreateFile(RootInode, "state.txt", 0o644)
+	if err != nil {
+		t.Fatalf("CreateFile() error = %v", err)
+	}
+	if _, err := engine.Write(node.Inode, 0, []byte("old")); err != nil {
+		t.Fatalf("Write(old) error = %v", err)
+	}
+	if _, err := engine.SyncMaterialize(ctx); err != nil {
+		t.Fatalf("SyncMaterialize(old) error = %v", err)
+	}
+	if err := engine.Truncate(node.Inode, 0); err != nil {
+		t.Fatalf("Truncate() error = %v", err)
+	}
+	if _, err := engine.Write(node.Inode, 0, []byte("new")); err != nil {
+		t.Fatalf("Write(new) error = %v", err)
+	}
+	latest, err := engine.SyncMaterialize(ctx)
+	if err != nil {
+		t.Fatalf("SyncMaterialize(new) error = %v", err)
+	}
+
+	retained := map[string]struct{}{
+		manifestKey(latest.ManifestSeq): {},
+	}
+	plan, err := engine.materializer.PlanGarbageCollection(ctx, []*SnapshotState{latest.State}, retained)
+	if err != nil {
+		t.Fatalf("PlanGarbageCollection() error = %v", err)
+	}
+	if got, want := plan.Segments, []string{"segments/00000000000000000002-0.bin"}; !equalStrings(got, want) {
+		t.Fatalf("plan segments = %v, want %v", got, want)
+	}
+	if got, want := plan.Manifests, []string{"manifests/00000000000000000002.json"}; !equalStrings(got, want) {
+		t.Fatalf("plan manifests = %v, want %v", got, want)
+	}
+	if _, err := plan.Apply(ctx); err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	if _, err := store.Head("segments/00000000000000000002-0.bin"); err == nil {
+		t.Fatal("old segment still exists after GC")
+	}
+	if _, err := store.Head("manifests/00000000000000000002.json"); err == nil {
+		t.Fatal("old manifest still exists after GC")
+	}
+	if _, err := store.Head("segments/00000000000000000004-0.bin"); err != nil {
+		t.Fatalf("current segment missing after GC: %v", err)
+	}
+	if _, err := store.Head("manifests/00000000000000000004.json"); err != nil {
+		t.Fatalf("current manifest missing after GC: %v", err)
+	}
+}
+
+func TestLiveSegmentKeysForVolumeIgnoresChildOwnedSegments(t *testing.T) {
+	state := &SnapshotState{
+		ColdFiles: map[uint64][]FileExtent{
+			2: {{SegmentID: "parent"}},
+			3: {{SegmentID: "child"}},
+		},
+		Segments: map[string]*Segment{
+			"parent": {ID: "parent", VolumeID: "vol-parent", Key: "segments/parent.bin"},
+			"child":  {ID: "child", VolumeID: "vol-child", Key: "segments/child.bin"},
+		},
+	}
+	live := liveSegmentKeysForVolume("vol-parent", state)
+	if _, ok := live["segments/parent.bin"]; !ok {
+		t.Fatal("parent segment was not marked live")
+	}
+	if _, ok := live["segments/child.bin"]; ok {
+		t.Fatal("child-owned segment was marked live for parent volume")
+	}
+}
+
 func newPrefixedRecordingStore(t *testing.T, volumeID string) *recordingStore {
 	t.Helper()
 	base := objectstore.NewMemoryStore("s0fs-tests")
@@ -1160,6 +1246,18 @@ func hasSegmentGet(calls []getCall) bool {
 
 func fileName(i int) string {
 	return strings.Join([]string{"file", string(rune('a' + (i % 26))), string(rune('0' + (i % 10))), ".txt"}, "")
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func TestMaterializerBuildSegmentProducesRoundTrippableLayout(t *testing.T) {

--- a/storage-proxy/pkg/snapshot/manager.go
+++ b/storage-proxy/pkg/snapshot/manager.go
@@ -468,6 +468,15 @@ func (m *Manager) DeleteSnapshot(ctx context.Context, volumeID, snapshotID, team
 	if cleanupErr := m.deleteS0FSSnapshot(ctx, volumeID, snapshotID); cleanupErr != nil {
 		m.logger.WithError(cleanupErr).Warn("Failed to delete s0fs snapshot state")
 	}
+	if gcResult, gcErr := m.garbageCollectS0FSVolumeObjects(ctx, volumeID, teamID); gcErr != nil {
+		m.logger.WithError(gcErr).Warn("Failed to garbage collect unreferenced s0fs objects")
+	} else if gcResult != nil && (len(gcResult.DeletedSegments) > 0 || len(gcResult.DeletedManifests) > 0) {
+		m.logger.WithFields(logrus.Fields{
+			"volume_id": volumeID,
+			"segments":  len(gcResult.DeletedSegments),
+			"manifests": len(gcResult.DeletedManifests),
+		}).Info("Garbage collected unreferenced s0fs objects after snapshot delete")
+	}
 
 	// Record success metrics
 	if metrics != nil {

--- a/storage-proxy/pkg/snapshot/manager_s0fs_test.go
+++ b/storage-proxy/pkg/snapshot/manager_s0fs_test.go
@@ -8,11 +8,13 @@ import (
 	"errors"
 	"io"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/objectstore"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/s0fs"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volume"
 	"github.com/sirupsen/logrus"
@@ -165,6 +167,111 @@ func TestS0FSForkVolumeUsesCopyOnWriteState(t *testing.T) {
 	}
 }
 
+func TestS0FSGarbageCollectsObjectsAfterSnapshotDelete(t *testing.T) {
+	t.Parallel()
+
+	mgr, _, _, engine := newS0FSSnapshotTestManager(t, "vol-gc-delete")
+	writeS0FSFile(t, engine, "state.txt", "old")
+	if _, err := engine.SyncMaterialize(context.Background()); err != nil {
+		t.Fatalf("SyncMaterialize(old) error = %v", err)
+	}
+	snap, err := mgr.CreateSnapshot(context.Background(), &CreateSnapshotRequest{
+		VolumeID: "vol-gc-delete",
+		Name:     "snap-old",
+		TeamID:   "team-1",
+		UserID:   "user-1",
+	})
+	if err != nil {
+		t.Fatalf("CreateSnapshot() error = %v", err)
+	}
+	writeS0FSFile(t, engine, "state.txt", "new")
+	if _, err := engine.SyncMaterialize(context.Background()); err != nil {
+		t.Fatalf("SyncMaterialize(new) error = %v", err)
+	}
+
+	if err := mgr.DeleteSnapshot(context.Background(), "vol-gc-delete", snap.ID, "team-1"); err != nil {
+		t.Fatalf("DeleteSnapshot() error = %v", err)
+	}
+	cfg, err := mgr.s0fsConfig("team-1", "vol-gc-delete")
+	if err != nil {
+		t.Fatalf("s0fsConfig() error = %v", err)
+	}
+	if got, want := listS0FSKeys(t, cfg.ObjectStore, "segments/"), []string{"segments/00000000000000000005-0.bin"}; !sameStrings(got, want) {
+		t.Fatalf("segments after GC = %v, want %v", got, want)
+	}
+	if got, want := listS0FSKeys(t, cfg.ObjectStore, "manifests/"), []string{"manifests/00000000000000000005.json"}; !sameStrings(got, want) {
+		t.Fatalf("manifests after GC = %v, want %v", got, want)
+	}
+}
+
+func TestS0FSGarbageCollectionSkipsWhenForkExists(t *testing.T) {
+	t.Parallel()
+
+	mgr, repo, _, engine := newS0FSSnapshotTestManager(t, "vol-gc-fork-source")
+	writeS0FSFile(t, engine, "state.txt", "old")
+	if _, err := engine.SyncMaterialize(context.Background()); err != nil {
+		t.Fatalf("SyncMaterialize(old) error = %v", err)
+	}
+	snap, err := mgr.CreateSnapshot(context.Background(), &CreateSnapshotRequest{
+		VolumeID: "vol-gc-fork-source",
+		Name:     "snap-old",
+		TeamID:   "team-1",
+		UserID:   "user-1",
+	})
+	if err != nil {
+		t.Fatalf("CreateSnapshot() error = %v", err)
+	}
+	sourceID := "vol-gc-fork-source"
+	repo.volumes["vol-gc-child"] = &db.SandboxVolume{
+		ID:             "vol-gc-child",
+		TeamID:         "team-1",
+		UserID:         "user-1",
+		SourceVolumeID: &sourceID,
+		AccessMode:     string(volume.AccessModeRWO),
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}
+	writeS0FSFile(t, engine, "state.txt", "new")
+	if _, err := engine.SyncMaterialize(context.Background()); err != nil {
+		t.Fatalf("SyncMaterialize(new) error = %v", err)
+	}
+
+	if err := mgr.DeleteSnapshot(context.Background(), "vol-gc-fork-source", snap.ID, "team-1"); err != nil {
+		t.Fatalf("DeleteSnapshot() error = %v", err)
+	}
+	cfg, err := mgr.s0fsConfig("team-1", "vol-gc-fork-source")
+	if err != nil {
+		t.Fatalf("s0fsConfig() error = %v", err)
+	}
+	if got, want := listS0FSKeys(t, cfg.ObjectStore, "segments/"), []string{
+		"segments/00000000000000000003-0.bin",
+		"segments/00000000000000000005-0.bin",
+	}; !sameStrings(got, want) {
+		t.Fatalf("segments with fork child = %v, want %v", got, want)
+	}
+}
+
+func TestS0FSDeleteVolumeObjectsIfUnreferencedDeletesPrefix(t *testing.T) {
+	t.Parallel()
+
+	mgr, repo, _, engine := newS0FSSnapshotTestManager(t, "vol-gc-volume-delete")
+	writeS0FSFile(t, engine, "state.txt", "payload")
+	if _, err := engine.SyncMaterialize(context.Background()); err != nil {
+		t.Fatalf("SyncMaterialize() error = %v", err)
+	}
+	vol := repo.volumes["vol-gc-volume-delete"]
+	if err := mgr.DeleteVolumeObjectsIfUnreferenced(context.Background(), vol); err != nil {
+		t.Fatalf("DeleteVolumeObjectsIfUnreferenced() error = %v", err)
+	}
+	cfg, err := mgr.s0fsConfig("team-1", "vol-gc-volume-delete")
+	if err != nil {
+		t.Fatalf("s0fsConfig() error = %v", err)
+	}
+	if keys := listS0FSKeys(t, cfg.ObjectStore, ""); len(keys) != 0 {
+		t.Fatalf("objects after volume cleanup = %v, want none", keys)
+	}
+}
+
 type failingFlushCoordinator struct {
 	called bool
 }
@@ -245,7 +352,7 @@ func newS0FSSnapshotTestManager(t *testing.T, volumeID string) (*Manager, *fakeR
 			DefaultClusterId:      "test-cluster",
 			RestoreRemountTimeout: "100ms",
 			ObjectStorageType:     "mem",
-			S3Bucket:              "snapshot-tests",
+			S3Bucket:              "snapshot-tests-" + sanitizeTestObjectStoreName(t.Name()),
 		},
 		logger:    logrus.New(),
 		clusterID: "test-cluster",
@@ -265,6 +372,11 @@ func newS0FSSnapshotTestManager(t *testing.T, volumeID string) (*Manager, *fakeR
 	})
 	volMgr.ctx.S0FS = engine
 	return mgr, repo, volMgr, engine
+}
+
+func sanitizeTestObjectStoreName(name string) string {
+	replacer := strings.NewReplacer("/", "-", " ", "-", "\t", "-")
+	return replacer.Replace(name)
 }
 
 func writeS0FSFile(t *testing.T, engine *s0fs.Engine, name, value string) {
@@ -342,4 +454,38 @@ func openFreshS0FSEngine(t *testing.T, mgr *Manager, teamID, volumeID string) *s
 		t.Fatalf("Open(fresh %s) error = %v", volumeID, err)
 	}
 	return engine
+}
+
+func listS0FSKeys(t *testing.T, store objectstore.Store, prefix string) []string {
+	t.Helper()
+	var keys []string
+	var startAfter, token string
+	for {
+		objects, hasMore, nextToken, err := store.List(prefix, startAfter, token, "", 1000)
+		if err != nil {
+			t.Fatalf("List(%q) error = %v", prefix, err)
+		}
+		for _, object := range objects {
+			keys = append(keys, object.Key)
+		}
+		if !hasMore {
+			return keys
+		}
+		if len(objects) > 0 {
+			startAfter = objects[len(objects)-1].Key
+		}
+		token = nextToken
+	}
+}
+
+func sameStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/storage-proxy/pkg/snapshot/manager_test.go
+++ b/storage-proxy/pkg/snapshot/manager_test.go
@@ -101,6 +101,16 @@ func (r *fakeRepo) ListSnapshotsByVolume(ctx context.Context, volumeID string) (
 	return snaps, nil
 }
 
+func (r *fakeRepo) ListSandboxVolumesBySource(ctx context.Context, sourceVolumeID string) ([]*db.SandboxVolume, error) {
+	var volumes []*db.SandboxVolume
+	for _, volume := range r.volumes {
+		if volume.SourceVolumeID != nil && *volume.SourceVolumeID == sourceVolumeID {
+			volumes = append(volumes, volume)
+		}
+	}
+	return volumes, nil
+}
+
 func (r *fakeRepo) GetSnapshot(ctx context.Context, id string) (*db.Snapshot, error) {
 	s, ok := r.snapshots[id]
 	if !ok {

--- a/storage-proxy/pkg/snapshot/s0fs.go
+++ b/storage-proxy/pkg/snapshot/s0fs.go
@@ -31,6 +31,10 @@ type activeMountRepository interface {
 	GetActiveMounts(ctx context.Context, volumeID string, heartbeatTimeout int) ([]*db.VolumeMount, error)
 }
 
+type sourceVolumeRepository interface {
+	ListSandboxVolumesBySource(ctx context.Context, sourceVolumeID string) ([]*db.SandboxVolume, error)
+}
+
 type snapshotHeadStore struct {
 	repo s0fsHeadRepository
 }
@@ -658,3 +662,186 @@ func (m *Manager) deleteS0FSSnapshot(ctx context.Context, volumeID, snapshotID s
 	}
 	return nil
 }
+
+func (m *Manager) DeleteVolumeObjectsIfUnreferenced(ctx context.Context, vol *db.SandboxVolume) error {
+	if vol == nil || strings.TrimSpace(vol.ID) == "" || strings.TrimSpace(vol.TeamID) == "" {
+		return nil
+	}
+	safe, err := m.canCollectS0FSVolume(ctx, vol.ID)
+	if err != nil {
+		return err
+	}
+	if !safe {
+		m.logger.WithField("volume_id", vol.ID).Info("Skipping s0fs volume object cleanup because references may still exist")
+		return nil
+	}
+	store, err := m.s0fsObjectStore(vol.TeamID, vol.ID)
+	if err != nil {
+		return err
+	}
+	deleted, err := s0fs.DeleteAllObjects(ctx, store)
+	if err != nil {
+		return err
+	}
+	if err := cleanupS0FSVolume(vol.ID, m.config); err != nil {
+		return err
+	}
+	if len(deleted) > 0 {
+		m.logger.WithFields(map[string]any{
+			"volume_id": vol.ID,
+			"objects":   len(deleted),
+		}).Info("Deleted unreferenced s0fs volume objects")
+	}
+	return nil
+}
+
+func (m *Manager) garbageCollectS0FSVolumeObjects(ctx context.Context, volumeID, teamID string) (*s0fs.GarbageCollectionResult, error) {
+	if strings.TrimSpace(volumeID) == "" || strings.TrimSpace(teamID) == "" {
+		return nil, nil
+	}
+	safe, err := m.canCollectS0FSVolume(ctx, volumeID)
+	if err != nil {
+		return nil, err
+	}
+	if !safe {
+		return nil, nil
+	}
+
+	cfg, err := m.s0fsConfig(teamID, volumeID)
+	if err != nil {
+		return nil, err
+	}
+	materializer := s0fs.NewMaterializer(volumeID, cfg.ObjectStore, cfg.HeadStore, cfg.ObjectStoreForVolume)
+	materializer.SetEncryption(cfg.Encryption)
+	if materializer == nil || !materializer.Enabled() {
+		return nil, nil
+	}
+
+	latestState, latestManifest, err := materializer.LoadLatestState(ctx)
+	if err != nil {
+		if errors.Is(err, s0fs.ErrMaterializedManifestNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	retainedStates := []*s0fs.SnapshotState{latestState}
+	snapshots, err := m.repo.ListSnapshotsByVolume(ctx, volumeID)
+	if err != nil {
+		return nil, err
+	}
+	for _, snapshot := range snapshots {
+		state, err := s0fs.LoadSnapshot(ctx, cfg, snapshot.ID)
+		if err != nil {
+			if errors.Is(err, s0fs.ErrSnapshotNotFound) {
+				continue
+			}
+			return nil, err
+		}
+		retainedStates = append(retainedStates, state)
+	}
+
+	retainedManifests := map[string]struct{}{
+		s0fsLegacyLatestManifestKey: {},
+	}
+	if latestManifest.ManifestSeq > 0 {
+		retainedManifests[s0fsManifestKey(latestManifest.ManifestSeq)] = struct{}{}
+	}
+	headBefore, err := m.currentS0FSManifestKey(ctx, volumeID, latestManifest)
+	if err != nil {
+		return nil, err
+	}
+	retainedManifests[headBefore] = struct{}{}
+
+	plan, err := materializer.PlanGarbageCollection(ctx, retainedStates, retainedManifests)
+	if err != nil {
+		return nil, err
+	}
+	if len(plan.Segments) == 0 && len(plan.Manifests) == 0 {
+		return &s0fs.GarbageCollectionResult{}, nil
+	}
+
+	safe, err = m.canCollectS0FSVolume(ctx, volumeID)
+	if err != nil {
+		return nil, err
+	}
+	if !safe {
+		return nil, nil
+	}
+	headAfter, err := m.currentS0FSManifestKey(ctx, volumeID, latestManifest)
+	if err != nil {
+		return nil, err
+	}
+	if headAfter != headBefore {
+		m.logger.WithFields(map[string]any{
+			"volume_id":   volumeID,
+			"head_before": headBefore,
+			"head_after":  headAfter,
+		}).Info("Skipping s0fs garbage collection because committed head changed")
+		return nil, nil
+	}
+	result, err := plan.Apply(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(result.DeletedSegments) > 0 || len(result.DeletedManifests) > 0 {
+		m.logger.WithFields(map[string]any{
+			"volume_id": volumeID,
+			"segments":  len(result.DeletedSegments),
+			"manifests": len(result.DeletedManifests),
+		}).Info("Deleted unreferenced s0fs objects")
+	}
+	return result, nil
+}
+
+func (m *Manager) canCollectS0FSVolume(ctx context.Context, volumeID string) (bool, error) {
+	if repo, ok := any(m.repo).(sourceVolumeRepository); ok && repo != nil {
+		children, err := repo.ListSandboxVolumesBySource(ctx, volumeID)
+		if err != nil {
+			return false, err
+		}
+		if len(children) > 0 {
+			return false, nil
+		}
+	} else {
+		return false, nil
+	}
+	if repo, ok := any(m.repo).(activeMountRepository); ok && repo != nil {
+		mounts, err := repo.GetActiveMounts(ctx, volumeID, m.heartbeatTimeout())
+		if err != nil {
+			return false, err
+		}
+		if len(mounts) > 0 {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func (m *Manager) currentS0FSManifestKey(ctx context.Context, volumeID string, fallback *s0fs.Manifest) (string, error) {
+	if repo, ok := any(m.repo).(s0fsHeadRepository); ok && repo != nil {
+		head, err := repo.GetS0FSCommittedHead(ctx, volumeID)
+		if err == nil && strings.TrimSpace(head.ManifestKey) != "" {
+			return head.ManifestKey, nil
+		}
+		if err != nil && !errors.Is(err, db.ErrNotFound) {
+			return "", err
+		}
+	}
+	if fallback != nil && fallback.ManifestSeq > 0 {
+		return s0fsManifestKey(fallback.ManifestSeq), nil
+	}
+	return s0fsLegacyLatestManifestKey, nil
+}
+
+func (m *Manager) heartbeatTimeout() int {
+	if m != nil && m.config != nil && m.config.HeartbeatTimeout > 0 {
+		return m.config.HeartbeatTimeout
+	}
+	return 15
+}
+
+func s0fsManifestKey(seq uint64) string {
+	return fmt.Sprintf("manifests/%020d.json", seq)
+}
+
+const s0fsLegacyLatestManifestKey = "manifests/latest.json"


### PR DESCRIPTION
## Summary

- add conservative S0FS object garbage collection planning and delete helpers for stale segments/manifests
- run GC after snapshot deletion only when the volume has no active mounts and no fork children, and the committed head remains stable before deletion
- clean deleted volume S0FS object prefixes when no fork children can still reference source segments
- add repository support for finding fork children plus unit, manager, HTTP, and DB coverage

Closes #331.

## Consistency and performance notes

This intentionally avoids hot write paths. Snapshot delete and volume delete are low-frequency control-plane operations. GC skips when active mounts exist or when fork children exist, so multi-replica and copy-on-write references are preserved until a broader async GC design can track descendant references safely.

## Tests

- `go test ./storage-proxy/pkg/s0fs`
- `go test ./storage-proxy/pkg/snapshot`
- `go test ./storage-proxy/pkg/http`
- `go test ./storage-proxy/pkg/db`
- `go test ./storage-proxy/... -timeout=5m`
- `go test ./tests/integration/... -timeout=10m`

Note: `make test storage-proxy` and a targeted `go test -race -cover` run were stopped locally after more than 6 minutes without package output; PR CI should run the full race/cover path.
