### PR TITLE
fix function warm process runtime binding

### DIFF
--- a/docs/function/page.mdx
+++ b/docs/function/page.mdx
@@ -22,7 +22,7 @@ The `production` alias is the serving pointer used by the function host. Creatin
 
 Function traffic is handled by `function-gateway`. The gateway resolves the host to a function, loads the `production` revision, enforces the revision's service route policy, and proxies the request to the service port.
 
-If the source sandbox still exists, the gateway routes to that sandbox and resumes it when needed. If the source sandbox has been deleted, the gateway claims a new runtime sandbox from the revision's template, mounts the revision-owned volumes, starts the service runtime command or warm process, and reuses that runtime for later requests.
+If the source sandbox still exists, the gateway routes to that sandbox and resumes it when needed. If the source sandbox has been deleted, the gateway claims a new runtime sandbox from the revision's template, mounts the revision-owned volumes, starts the service runtime command or binds to the referenced warm process, and reuses that runtime for later requests.
 
 ## Publishable Services
 
@@ -35,6 +35,8 @@ Only publishable Sandbox Services can become function revisions. A service is pu
 | `manual_runtime` | The service runtime is manual and cannot be started by Function Gateway |
 | `missing_command` | A `cmd` runtime is missing its command |
 | `missing_warm_process_name` | A `warm_process` runtime is missing its warm process name |
+
+For Functions, a `warm_process` runtime must reference an existing `cmd` warm process alias or context ID. REPL warm processes are interactive execution contexts and cannot serve HTTP traffic.
 
 Use Sandbox Services route policy for path matching, allowed methods, bearer/header auth, CORS, rate limits, path rewrite, and upstream timeout. Functions reuse the same route model.
 

--- a/docs/sandbox/services/page.mdx
+++ b/docs/sandbox/services/page.mdx
@@ -15,6 +15,10 @@ Services are also the source model for Sandbox0 Functions. A publishable service
 | `ingress` | object | Public exposure and route policy |
 | `health_check` | object | Optional readiness path |
 
+### Runtime
+
+Service runtime supports `cmd`, `warm_process`, and `manual`. Use `cmd` when Function Gateway should create a new command context for a restored function runtime. Use `warm_process` when the template already starts a long-lived process and the service should bind to that existing context. For Functions, `warm_process_name` must reference a `cmd` warm process alias or context ID; REPL warm processes are not valid HTTP service runtimes.
+
 ### Ingress
 
 | Field | Type | Description |

--- a/function-gateway/pkg/http/runtime.go
+++ b/function-gateway/pkg/http/runtime.go
@@ -39,9 +39,18 @@ type functionRouteMatch struct {
 }
 
 type functionContextResponse struct {
-	ID      string `json:"id"`
-	Running bool   `json:"running"`
-	Paused  bool   `json:"paused"`
+	ID      string            `json:"id"`
+	Type    string            `json:"type"`
+	Alias   string            `json:"alias"`
+	Command []string          `json:"command,omitempty"`
+	CWD     string            `json:"cwd"`
+	EnvVars map[string]string `json:"env_vars"`
+	Running bool              `json:"running"`
+	Paused  bool              `json:"paused"`
+}
+
+type functionContextListResponse struct {
+	Contexts []functionContextResponse `json:"contexts"`
 }
 
 type functionRuntimeHTTPError struct {
@@ -600,7 +609,7 @@ func (s *Server) ensureFunctionServiceRuntime(ctx context.Context, fn *functions
 	if rev.RuntimeContextID != nil && strings.TrimSpace(*rev.RuntimeContextID) != "" {
 		contextID := strings.TrimSpace(*rev.RuntimeContextID)
 		current, err := s.getFunctionRuntimeContext(ctx, sandbox.ID, fn.TeamID, rev.CreatedBy, contextID)
-		if err == nil && (current.Running || current.Paused) {
+		if err == nil && functionRuntimeContextCanServe(current, service) {
 			return contextID, nil
 		}
 		if err != nil && !isFunctionRuntimeStatus(err, nethttp.StatusNotFound) {
@@ -646,6 +655,9 @@ func (s *Server) startFunctionServiceRuntime(ctx context.Context, sandboxID, tea
 	if service.Runtime == nil {
 		return "", fmt.Errorf("function service runtime is missing")
 	}
+	if service.Runtime.Type == mgr.SandboxAppServiceRuntimeWarmProcess {
+		return s.resolveFunctionWarmProcessRuntimeContext(ctx, sandboxID, teamID, userID, service.Runtime.WarmProcessName)
+	}
 	payload := map[string]any{
 		"cwd":      service.Runtime.CWD,
 		"env_vars": service.Runtime.EnvVars,
@@ -654,12 +666,6 @@ func (s *Server) startFunctionServiceRuntime(ctx context.Context, sandboxID, tea
 	case mgr.SandboxAppServiceRuntimeCMD:
 		payload["type"] = "cmd"
 		payload["cmd"] = map[string]any{"command": service.Runtime.Command}
-	case mgr.SandboxAppServiceRuntimeWarmProcess:
-		if strings.TrimSpace(service.Runtime.WarmProcessName) == "" {
-			return "", fmt.Errorf("warm_process_name is required for warm process functions")
-		}
-		payload["type"] = "repl"
-		payload["repl"] = map[string]any{"alias": strings.TrimSpace(service.Runtime.WarmProcessName)}
 	default:
 		return "", fmt.Errorf("unsupported function service runtime type %q", service.Runtime.Type)
 	}
@@ -686,6 +692,80 @@ func (s *Server) startFunctionServiceRuntime(ctx context.Context, sandboxID, tea
 	return out.ID, nil
 }
 
+func (s *Server) resolveFunctionWarmProcessRuntimeContext(ctx context.Context, sandboxID, teamID, userID, warmProcessName string) (string, error) {
+	contexts, err := s.getFunctionRuntimeContexts(ctx, sandboxID, teamID, userID)
+	if err != nil {
+		return "", err
+	}
+	selected, err := selectFunctionWarmProcessContext(contexts, warmProcessName)
+	if err != nil {
+		return "", err
+	}
+	return selected.ID, nil
+}
+
+func (s *Server) getFunctionRuntimeContexts(ctx context.Context, sandboxID, teamID, userID string) ([]functionContextResponse, error) {
+	resp, err := s.doFunctionRuntimeContextRequest(ctx, nethttp.MethodGet, sandboxID, teamID, userID, "", nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != nethttp.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, functionRuntimeHTTPError{status: resp.StatusCode, body: strings.TrimSpace(string(body))}
+	}
+	out, err := decodeFunctionContextListResponse(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	return out.Contexts, nil
+}
+
+func functionRuntimeContextCanServe(current *functionContextResponse, service mgr.SandboxAppService) bool {
+	if current == nil || (!current.Running && !current.Paused) || service.Runtime == nil {
+		return false
+	}
+	if service.Runtime.Type != mgr.SandboxAppServiceRuntimeWarmProcess {
+		return true
+	}
+	_, err := selectFunctionWarmProcessContext([]functionContextResponse{*current}, service.Runtime.WarmProcessName)
+	return err == nil
+}
+
+func selectFunctionWarmProcessContext(contexts []functionContextResponse, warmProcessName string) (*functionContextResponse, error) {
+	name := strings.TrimSpace(warmProcessName)
+	if name == "" {
+		return nil, fmt.Errorf("warm_process_name is required for warm process functions")
+	}
+	for i := range contexts {
+		if strings.TrimSpace(contexts[i].Alias) == name {
+			return validateFunctionWarmProcessContext(&contexts[i], name)
+		}
+	}
+	for i := range contexts {
+		if strings.TrimSpace(contexts[i].ID) == name {
+			return validateFunctionWarmProcessContext(&contexts[i], name)
+		}
+	}
+	return nil, fmt.Errorf("warm process %q was not found", name)
+}
+
+func validateFunctionWarmProcessContext(ctx *functionContextResponse, warmProcessName string) (*functionContextResponse, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("warm process %q was not found", warmProcessName)
+	}
+	if strings.TrimSpace(ctx.ID) == "" {
+		return nil, fmt.Errorf("warm process %q context id is empty", warmProcessName)
+	}
+	if strings.TrimSpace(ctx.Type) != "cmd" {
+		return nil, fmt.Errorf("warm process %q must reference a cmd context, got %q", warmProcessName, ctx.Type)
+	}
+	if !ctx.Running && !ctx.Paused {
+		return nil, fmt.Errorf("warm process %q is not running", warmProcessName)
+	}
+	return ctx, nil
+}
+
 func decodeFunctionContextResponse(r io.Reader) (*functionContextResponse, error) {
 	body, err := io.ReadAll(r)
 	if err != nil {
@@ -709,6 +789,35 @@ func decodeFunctionContextResponse(r io.Reader) (*functionContextResponse, error
 		return envelope.Data, nil
 	}
 	var out functionContextResponse
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func decodeFunctionContextListResponse(r io.Reader) (*functionContextListResponse, error) {
+	body, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+	var envelope struct {
+		Success bool                         `json:"success"`
+		Data    *functionContextListResponse `json:"data,omitempty"`
+		Error   *spec.Error                  `json:"error,omitempty"`
+	}
+	if err := json.Unmarshal(body, &envelope); err == nil && (envelope.Success || envelope.Data != nil || envelope.Error != nil) {
+		if envelope.Error != nil {
+			return nil, errors.New(envelope.Error.Message)
+		}
+		if !envelope.Success {
+			return nil, fmt.Errorf("context list response was not successful")
+		}
+		if envelope.Data == nil {
+			return nil, fmt.Errorf("context list response missing data")
+		}
+		return envelope.Data, nil
+	}
+	var out functionContextListResponse
 	if err := json.Unmarshal(body, &out); err != nil {
 		return nil, err
 	}

--- a/function-gateway/pkg/http/runtime_test.go
+++ b/function-gateway/pkg/http/runtime_test.go
@@ -1,6 +1,8 @@
 package http
 
 import (
+	"context"
+	"crypto/ed25519"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -8,11 +10,13 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
 	mgr "github.com/sandbox0-ai/sandbox0/manager/pkg/service"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/functions"
+	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"go.uber.org/zap"
 )
 
@@ -121,6 +125,121 @@ func TestDecodeFunctionContextResponseAcceptsRawContextBody(t *testing.T) {
 	}
 	if out.ID != "ctx-a" || out.Running || !out.Paused {
 		t.Fatalf("decoded context = %+v, want paused ctx-a", out)
+	}
+}
+
+func TestDecodeFunctionContextListResponseAcceptsGatewayEnvelope(t *testing.T) {
+	out, err := decodeFunctionContextListResponse(strings.NewReader(`{"success":true,"data":{"contexts":[{"id":"ctx-a","type":"cmd","alias":"api","running":true}]}}`))
+	if err != nil {
+		t.Fatalf("decodeFunctionContextListResponse() error = %v", err)
+	}
+	if len(out.Contexts) != 1 || out.Contexts[0].ID != "ctx-a" || out.Contexts[0].Type != "cmd" || out.Contexts[0].Alias != "api" || !out.Contexts[0].Running {
+		t.Fatalf("decoded contexts = %+v, want running cmd ctx-a", out.Contexts)
+	}
+}
+
+func TestDecodeFunctionContextListResponseAcceptsRawListBody(t *testing.T) {
+	out, err := decodeFunctionContextListResponse(strings.NewReader(`{"contexts":[{"id":"ctx-a","type":"cmd","alias":"api","paused":true}]}`))
+	if err != nil {
+		t.Fatalf("decodeFunctionContextListResponse() error = %v", err)
+	}
+	if len(out.Contexts) != 1 || out.Contexts[0].ID != "ctx-a" || out.Contexts[0].Type != "cmd" || out.Contexts[0].Alias != "api" || !out.Contexts[0].Paused {
+		t.Fatalf("decoded contexts = %+v, want paused cmd ctx-a", out.Contexts)
+	}
+}
+
+func TestSelectFunctionWarmProcessContextRequiresCMD(t *testing.T) {
+	contexts := []functionContextResponse{
+		{ID: "ctx-repl", Type: "repl", Alias: "node", Running: true},
+		{ID: "ctx-api", Type: "cmd", Alias: "api", Running: true},
+	}
+
+	selected, err := selectFunctionWarmProcessContext(contexts, "api")
+	if err != nil {
+		t.Fatalf("selectFunctionWarmProcessContext() error = %v", err)
+	}
+	if selected.ID != "ctx-api" {
+		t.Fatalf("selected context = %+v, want ctx-api", selected)
+	}
+
+	if _, err := selectFunctionWarmProcessContext(contexts, "node"); err == nil {
+		t.Fatal("selectFunctionWarmProcessContext() error = nil, want repl rejection")
+	}
+}
+
+func TestSelectFunctionWarmProcessContextRejectsStoppedContext(t *testing.T) {
+	_, err := selectFunctionWarmProcessContext([]functionContextResponse{
+		{ID: "ctx-api", Type: "cmd", Alias: "api"},
+	}, "api")
+	if err == nil {
+		t.Fatal("selectFunctionWarmProcessContext() error = nil, want stopped context rejection")
+	}
+}
+
+func TestFunctionRuntimeContextCanServeWarmProcess(t *testing.T) {
+	service := mgr.SandboxAppService{
+		Runtime: &mgr.SandboxAppServiceRuntime{
+			Type:            mgr.SandboxAppServiceRuntimeWarmProcess,
+			WarmProcessName: "api",
+		},
+	}
+	if !functionRuntimeContextCanServe(&functionContextResponse{ID: "ctx-api", Type: "cmd", Alias: "api", Running: true}, service) {
+		t.Fatal("running cmd warm process should serve")
+	}
+	if functionRuntimeContextCanServe(&functionContextResponse{ID: "ctx-api", Type: "repl", Alias: "api", Running: true}, service) {
+		t.Fatal("repl warm process should not serve function traffic")
+	}
+}
+
+func TestStartFunctionServiceRuntimeWarmProcessUsesExistingCMDContext(t *testing.T) {
+	_, privateKey, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate ed25519 keypair: %v", err)
+	}
+
+	clusterGateway := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+			http.Error(w, "unexpected method", http.StatusInternalServerError)
+			return
+		}
+		if r.URL.Path != "/api/v1/sandboxes/sb_test/contexts" {
+			t.Errorf("path = %s, want /api/v1/sandboxes/sb_test/contexts", r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		if r.Header.Get(internalauth.DefaultTokenHeader) == "" {
+			t.Error("internal auth header is empty")
+			http.Error(w, "missing token", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"contexts":[{"id":"ctx-api","type":"cmd","alias":"api","running":true}]}`))
+	}))
+	defer clusterGateway.Close()
+
+	server := &Server{
+		cfg: &config.FunctionGatewayConfig{
+			DefaultClusterGatewayURL: clusterGateway.URL,
+		},
+		internalAuthGen: internalauth.NewGenerator(internalauth.GeneratorConfig{
+			Caller:     internalauth.ServiceFunctionGateway,
+			PrivateKey: privateKey,
+			TTL:        time.Minute,
+		}),
+		httpClient: clusterGateway.Client(),
+	}
+	contextID, err := server.startFunctionServiceRuntime(context.Background(), "sb_test", "team-1", "user-1", mgr.SandboxAppService{
+		Runtime: &mgr.SandboxAppServiceRuntime{
+			Type:            mgr.SandboxAppServiceRuntimeWarmProcess,
+			WarmProcessName: "api",
+		},
+	})
+	if err != nil {
+		t.Fatalf("startFunctionServiceRuntime() error = %v", err)
+	}
+	if contextID != "ctx-api" {
+		t.Fatalf("contextID = %q, want ctx-api", contextID)
 	}
 }
 

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -4014,10 +4014,12 @@ components:
         type:
           type: string
           enum: [warm_process, cmd, manual]
+          description: Runtime strategy for restarting a service when it is restored as a function runtime.
         command:
           type: array
           items:
             type: string
+          description: Process argv used when type is cmd.
         cwd:
           type: string
         env_vars:
@@ -4026,6 +4028,7 @@ components:
             type: string
         warm_process_name:
           type: string
+          description: Warm process alias or context ID used when type is warm_process. Function runtimes require this to reference an existing cmd warm process.
       required: [type]
     SandboxAppServiceIngress:
       type: object

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -1632,14 +1632,19 @@ type SandboxAppServiceRouteRateLimit struct {
 
 // SandboxAppServiceRuntime defines model for SandboxAppServiceRuntime.
 type SandboxAppServiceRuntime struct {
-	Command         *[]string                    `json:"command,omitempty"`
-	Cwd             *string                      `json:"cwd,omitempty"`
-	EnvVars         *map[string]string           `json:"env_vars,omitempty"`
-	Type            SandboxAppServiceRuntimeType `json:"type"`
-	WarmProcessName *string                      `json:"warm_process_name,omitempty"`
+	// Command Process argv used when type is cmd.
+	Command *[]string          `json:"command,omitempty"`
+	Cwd     *string            `json:"cwd,omitempty"`
+	EnvVars *map[string]string `json:"env_vars,omitempty"`
+
+	// Type Runtime strategy for restarting a service when it is restored as a function runtime.
+	Type SandboxAppServiceRuntimeType `json:"type"`
+
+	// WarmProcessName Warm process alias or context ID used when type is warm_process. Function runtimes require this to reference an existing cmd warm process.
+	WarmProcessName *string `json:"warm_process_name,omitempty"`
 }
 
-// SandboxAppServiceRuntimeType defines model for SandboxAppServiceRuntime.Type.
+// SandboxAppServiceRuntimeType Runtime strategy for restarting a service when it is restored as a function runtime.
 type SandboxAppServiceRuntimeType string
 
 // SandboxAppServiceView defines model for SandboxAppServiceView.


### PR DESCRIPTION
## Summary
- Bind Function warm_process service runtimes to existing procd contexts instead of creating a new REPL context.
- Require the referenced warm process context to be cmd and running or paused before reusing it.
- Document the Function/service runtime semantics and sync generated apispec comments.

## Root Cause
Function Gateway treated service runtime warm_process as a REPL alias and POSTed a new repl context. A publishable HTTP service needs to reuse the template-started long-lived cmd context that owns the listening port.

## Validation
- make -j$(nproc) apispec
- env GOWORK=off go test ./function-gateway/... ./manager/pkg/service ./manager/cmd/procd
- git diff --check