### PR TITLE
Use COW state for snapshot volume creation

### DIFF
--- a/docs/volume/snapshots/page.mdx
+++ b/docs/volume/snapshots/page.mdx
@@ -6,6 +6,7 @@ A Snapshot is a point-in-time, read-only copy of a Volume. Snapshots are designe
 
 - **Instant Creation**: Built on Copy-on-Write semantics, snapshot creation is near-instant
 - **Space Efficiency**: Built on s0fs clone semantics (Copy-on-Write), so snapshots avoid full data copies
+- **Efficient Restores**: Creating a Volume with `snapshot_id` reuses unchanged snapshot segments instead of copying them
 - **Fast Recovery**: Restore operations quickly roll data back to a known state
 - **Version Traceability**: Snapshot names and descriptions support release workflows
 

--- a/storage-proxy/pkg/s0fs/engine.go
+++ b/storage-proxy/pkg/s0fs/engine.go
@@ -1,7 +1,6 @@
 package s0fs
 
 import (
-	"bytes"
 	"cmp"
 	"context"
 	"errors"
@@ -535,6 +534,16 @@ func (e *Engine) ExportState() (*SnapshotState, error) {
 }
 
 func (e *Engine) SyncMaterialize(ctx context.Context) (*Manifest, error) {
+	return e.syncMaterialize(ctx, false)
+}
+
+// EnsureMaterialized writes any inline file data to immutable segments even if
+// the engine was reopened from a persisted head and is not currently dirty.
+func (e *Engine) EnsureMaterialized(ctx context.Context) (*Manifest, error) {
+	return e.syncMaterialize(ctx, true)
+}
+
+func (e *Engine) syncMaterialize(ctx context.Context, force bool) (*Manifest, error) {
 	e.materializeMu.Lock()
 	defer e.materializeMu.Unlock()
 
@@ -543,7 +552,7 @@ func (e *Engine) SyncMaterialize(ctx context.Context) (*Manifest, error) {
 		e.mu.RUnlock()
 		return nil, err
 	}
-	if e.materializer == nil || !e.materializer.Enabled() || !e.dirty {
+	if e.materializer == nil || !e.materializer.Enabled() || (!e.dirty && (!force || !e.needsMaterializationLocked())) {
 		e.mu.RUnlock()
 		return nil, nil
 	}
@@ -636,10 +645,7 @@ func (e *Engine) CreateSnapshot(snapshotID string) (*SnapshotState, error) {
 	if snapshotID == "" {
 		return nil, fmt.Errorf("%w: snapshot id is required", ErrInvalidInput)
 	}
-	state, err := e.exportStateLocked()
-	if err != nil {
-		return nil, err
-	}
+	state := e.snapshotStateLocked()
 	if err := saveSnapshotState(snapshotFilePath(e.wal.path, snapshotID), e.volumeID, "snapshot:"+snapshotID, state, e.encryption); err != nil {
 		return nil, err
 	}
@@ -1028,6 +1034,26 @@ func (e *Engine) markDirtyLocked() {
 	e.dirtyAt = time.Now().UTC()
 }
 
+func (e *Engine) needsMaterializationLocked() bool {
+	for _, payload := range e.data {
+		if len(payload) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func (e *Engine) snapshotStateLocked() *SnapshotState {
+	state := cloneState(e.currentStateLocked())
+	for inode := range state.ColdFiles {
+		if state.Nodes[inode] == nil {
+			delete(state.ColdFiles, inode)
+		}
+	}
+	pruneUnreferencedSegments(state)
+	return state
+}
+
 func (e *Engine) exportStateLocked() (*SnapshotState, error) {
 	state := cloneState(e.currentStateLocked())
 	if len(state.ColdFiles) == 0 {
@@ -1125,48 +1151,7 @@ func (e *Engine) mutableFileDataLocked(inode uint64) ([]byte, error) {
 }
 
 func (e *Engine) readColdRangeLocked(inode uint64, offset uint64, size uint64) ([]byte, error) {
-	if e.materializer == nil || !e.materializer.Enabled() {
-		return nil, fmt.Errorf("%w: cold data resolver is not configured", ErrInvalidInput)
-	}
-	extents := e.coldFiles[inode]
-	if len(extents) == 0 {
-		return nil, nil
-	}
-	var out bytes.Buffer
-	remaining := size
-	rangeStart := offset
-	rangeEnd := offset + size
-	fileOffset := uint64(0)
-
-	for _, extent := range extents {
-		extentStart := fileOffset
-		extentEnd := fileOffset + extent.Length
-		if rangeEnd <= extentStart || rangeStart >= extentEnd {
-			fileOffset = extentEnd
-			continue
-		}
-
-		readStart := maxUint64(rangeStart, extentStart)
-		readEnd := minUint64(rangeEnd, extentEnd)
-		segment := e.segments[extent.SegmentID]
-		if segment == nil {
-			return nil, fmt.Errorf("%w: missing segment %s", ErrInvalidInput, extent.SegmentID)
-		}
-		segmentOffset := extent.Offset + (readStart - extentStart)
-		chunk, err := e.materializer.ReadSegmentRange(segment, int64(segmentOffset), int64(readEnd-readStart))
-		if err != nil {
-			return nil, fmt.Errorf("read cold segment %s: %w", segment.Key, err)
-		}
-		if _, err := out.Write(chunk); err != nil {
-			return nil, fmt.Errorf("assemble cold file data: %w", err)
-		}
-		remaining -= uint64(len(chunk))
-		if remaining == 0 {
-			break
-		}
-		fileOffset = extentEnd
-	}
-	return out.Bytes(), nil
+	return readColdRange(e.materializer, e.coldFiles[inode], e.segments, offset, size)
 }
 
 func minUint64(a, b uint64) uint64 {

--- a/storage-proxy/pkg/s0fs/materializer_test.go
+++ b/storage-proxy/pkg/s0fs/materializer_test.go
@@ -1095,7 +1095,7 @@ func TestPrepareForkStatePreservesInlineData(t *testing.T) {
 	}
 }
 
-func TestCreateSnapshotHydratesColdFilesInline(t *testing.T) {
+func TestCreateSnapshotPreservesColdSegments(t *testing.T) {
 	ctx := context.Background()
 	store := newPrefixedRecordingStore(t, "vol-snapshot")
 	heads := newMemoryHeadStore()
@@ -1127,16 +1127,25 @@ func TestCreateSnapshotHydratesColdFilesInline(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateSnapshot() error = %v", err)
 	}
-	if len(state.ColdFiles) != 0 {
-		t.Fatalf("snapshot cold files = %+v, want inline data", state.ColdFiles)
+	if len(state.Data) != 0 {
+		t.Fatalf("snapshot inline data = %+v, want none", state.Data)
+	}
+	if len(state.ColdFiles) == 0 {
+		t.Fatal("snapshot state has no cold files")
+	}
+	for _, segment := range state.Segments {
+		if segment.VolumeID != "vol-snapshot" {
+			t.Fatalf("snapshot segment volume = %q, want vol-snapshot", segment.VolumeID)
+		}
 	}
 	snapNode, err := state.Lookup(RootInode, "snap.txt")
 	if err != nil {
 		t.Fatalf("snapshot Lookup() error = %v", err)
 	}
-	payload, err := state.Read(snapNode.Inode, 0, snapNode.Size)
+	reader := NewSnapshotReader(state, engine.materializer)
+	payload, err := reader.Read(snapNode.Inode, 0, snapNode.Size)
 	if err != nil {
-		t.Fatalf("SnapshotState.Read() error = %v", err)
+		t.Fatalf("SnapshotReader.Read() error = %v", err)
 	}
 	if string(payload) != "snapshot-data" {
 		t.Fatalf("snapshot data = %q, want snapshot-data", payload)

--- a/storage-proxy/pkg/s0fs/snapshot.go
+++ b/storage-proxy/pkg/s0fs/snapshot.go
@@ -169,6 +169,41 @@ func PrepareForkState(state *SnapshotState, sourceVolumeID string) (*SnapshotSta
 	return clone, nil
 }
 
+// SnapshotReader reads a snapshot state that may contain cold segment
+// references. Detached SnapshotState.Read only supports inline data.
+type SnapshotReader struct {
+	state        *SnapshotState
+	materializer *Materializer
+}
+
+func NewSnapshotReader(state *SnapshotState, materializer *Materializer) *SnapshotReader {
+	return &SnapshotReader{state: state, materializer: materializer}
+}
+
+func (r *SnapshotReader) Read(inode uint64, offset uint64, size uint64) ([]byte, error) {
+	if r == nil || r.state == nil {
+		return nil, ErrNotFound
+	}
+	node := r.state.Nodes[inode]
+	if node == nil {
+		return nil, ErrNotFound
+	}
+	if node.Type == TypeDirectory {
+		return nil, ErrIsDir
+	}
+	if payload := r.state.Data[inode]; len(payload) > 0 || len(r.state.ColdFiles[inode]) == 0 {
+		if offset >= uint64(len(payload)) {
+			return nil, nil
+		}
+		end := offset + size
+		if end > uint64(len(payload)) {
+			end = uint64(len(payload))
+		}
+		return slices.Clone(payload[offset:end]), nil
+	}
+	return readColdRange(r.materializer, r.state.ColdFiles[inode], r.state.Segments, offset, size)
+}
+
 func (s *SnapshotState) Lookup(parent uint64, name string) (*Node, error) {
 	if s == nil {
 		return nil, ErrNotFound
@@ -253,4 +288,69 @@ func (s *SnapshotState) Read(inode uint64, offset uint64, size uint64) ([]byte, 
 		end = uint64(len(payload))
 	}
 	return slices.Clone(payload[offset:end]), nil
+}
+
+func readColdRange(materializer *Materializer, extents []FileExtent, segments map[string]*Segment, offset uint64, size uint64) ([]byte, error) {
+	if materializer == nil || !materializer.Enabled() {
+		return nil, fmt.Errorf("%w: cold data resolver is not configured", ErrInvalidInput)
+	}
+	if len(extents) == 0 {
+		return nil, nil
+	}
+	var out []byte
+	remaining := size
+	rangeStart := offset
+	rangeEnd := offset + size
+	fileOffset := uint64(0)
+
+	for _, extent := range extents {
+		extentStart := fileOffset
+		extentEnd := fileOffset + extent.Length
+		if rangeEnd <= extentStart || rangeStart >= extentEnd {
+			fileOffset = extentEnd
+			continue
+		}
+
+		readStart := maxUint64(rangeStart, extentStart)
+		readEnd := minUint64(rangeEnd, extentEnd)
+		segment := segments[extent.SegmentID]
+		if segment == nil {
+			return nil, fmt.Errorf("%w: missing segment %s", ErrInvalidInput, extent.SegmentID)
+		}
+		segmentOffset := extent.Offset + (readStart - extentStart)
+		chunk, err := materializer.ReadSegmentRange(segment, int64(segmentOffset), int64(readEnd-readStart))
+		if err != nil {
+			return nil, fmt.Errorf("read cold segment %s: %w", segment.Key, err)
+		}
+		out = append(out, chunk...)
+		remaining -= uint64(len(chunk))
+		if remaining == 0 {
+			break
+		}
+		fileOffset = extentEnd
+	}
+	return out, nil
+}
+
+func pruneUnreferencedSegments(state *SnapshotState) {
+	if state == nil {
+		return
+	}
+	if len(state.ColdFiles) == 0 {
+		state.Segments = make(map[string]*Segment)
+		return
+	}
+	live := make(map[string]struct{})
+	for _, extents := range state.ColdFiles {
+		for _, extent := range extents {
+			if extent.SegmentID != "" {
+				live[extent.SegmentID] = struct{}{}
+			}
+		}
+	}
+	for segmentID := range state.Segments {
+		if _, ok := live[segmentID]; !ok {
+			delete(state.Segments, segmentID)
+		}
+	}
 }

--- a/storage-proxy/pkg/snapshot/manager_s0fs_test.go
+++ b/storage-proxy/pkg/snapshot/manager_s0fs_test.go
@@ -167,6 +167,77 @@ func TestS0FSForkVolumeUsesCopyOnWriteState(t *testing.T) {
 	}
 }
 
+func TestS0FSCreateVolumeFromSnapshotUsesCopyOnWriteState(t *testing.T) {
+	t.Parallel()
+
+	mgr, _, _, engine := newS0FSSnapshotTestManager(t, "vol-snapshot-source")
+	writeS0FSFile(t, engine, "snapshot.txt", "seed")
+
+	snap, err := mgr.CreateSnapshot(context.Background(), &CreateSnapshotRequest{
+		VolumeID: "vol-snapshot-source",
+		Name:     "snap-cow",
+		TeamID:   "team-1",
+		UserID:   "user-1",
+	})
+	if err != nil {
+		t.Fatalf("CreateSnapshot() error = %v", err)
+	}
+
+	child, err := mgr.CreateVolumeFromSnapshot(context.Background(), &CreateVolumeFromSnapshotRequest{
+		SnapshotID: snap.ID,
+		TeamID:     "team-1",
+		UserID:     "user-2",
+	})
+	if err != nil {
+		t.Fatalf("CreateVolumeFromSnapshot() error = %v", err)
+	}
+	if child == nil || child.ID == "" {
+		t.Fatalf("child volume = %+v", child)
+	}
+
+	childCfg, err := mgr.s0fsConfig("team-1", child.ID)
+	if err != nil {
+		t.Fatalf("s0fsConfig(child) error = %v", err)
+	}
+	childMaterializer := s0fs.NewMaterializer(child.ID, childCfg.ObjectStore, childCfg.HeadStore, childCfg.ObjectStoreForVolume)
+	childMaterializer.SetEncryption(childCfg.Encryption)
+	childState, _, err := childMaterializer.LoadLatestState(context.Background())
+	if err != nil {
+		t.Fatalf("LoadLatestState(child) error = %v", err)
+	}
+	if len(childState.Data) != 0 {
+		t.Fatalf("child materialized data = %+v, want empty", childState.Data)
+	}
+	if len(childState.Segments) == 0 {
+		t.Fatal("child materialized state has no inherited segments")
+	}
+	for _, segment := range childState.Segments {
+		if segment.VolumeID != "vol-snapshot-source" {
+			t.Fatalf("child segment volume = %q, want vol-snapshot-source", segment.VolumeID)
+		}
+	}
+	childSegments, _, _, err := childCfg.ObjectStore.List("segments/", "", "", "", 100)
+	if err != nil {
+		t.Fatalf("List(child segments) error = %v", err)
+	}
+	if len(childSegments) != 0 {
+		t.Fatalf("child segment objects after create from snapshot = %+v, want none", childSegments)
+	}
+
+	childEngine := openFreshS0FSEngine(t, mgr, "team-1", child.ID)
+	defer childEngine.Close()
+	if got := readS0FSFile(t, childEngine, "snapshot.txt"); got != "seed" {
+		t.Fatalf("child file = %q, want seed", got)
+	}
+	writeS0FSFile(t, childEngine, "snapshot.txt", "child")
+	if _, err := childEngine.SyncMaterialize(context.Background()); err != nil {
+		t.Fatalf("SyncMaterialize(child) error = %v", err)
+	}
+	if got := readS0FSFile(t, engine, "snapshot.txt"); got != "seed" {
+		t.Fatalf("source file after child mutation = %q, want seed", got)
+	}
+}
+
 func TestS0FSGarbageCollectsObjectsAfterSnapshotDelete(t *testing.T) {
 	t.Parallel()
 

--- a/storage-proxy/pkg/snapshot/s0fs.go
+++ b/storage-proxy/pkg/snapshot/s0fs.go
@@ -237,11 +237,14 @@ func (m *s0fsArchiveMeta) ReadLink(_ fsmeta.Context, inode fsmeta.Ino, target *[
 }
 
 type s0fsArchiveReader struct {
-	state *s0fs.SnapshotState
+	reader *s0fs.SnapshotReader
 }
 
 func (r *s0fsArchiveReader) ReadFile(ctx context.Context, inode fsmeta.Ino, size uint64, w io.Writer) error {
-	data, err := r.state.Read(uint64(inode), 0, size)
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	data, err := r.reader.Read(uint64(inode), 0, size)
 	if err != nil {
 		return err
 	}
@@ -333,6 +336,8 @@ func (m *Manager) openS0FSSnapshotArchiveSession(ctx context.Context, volumeID, 
 	if err != nil {
 		return nil, 0, nil, err
 	}
+	materializer := s0fs.NewMaterializer(volumeID, cfg.ObjectStore, cfg.HeadStore, cfg.ObjectStoreForVolume)
+	materializer.SetEncryption(cfg.Encryption)
 	rootAttr := &fsmeta.Attr{}
 	metaView := &s0fsArchiveMeta{state: state}
 	if errno := metaView.GetAttr(fsmeta.Background(), fsmeta.RootInode, rootAttr); errno != 0 {
@@ -340,7 +345,7 @@ func (m *Manager) openS0FSSnapshotArchiveSession(ctx context.Context, volumeID, 
 	}
 	return &snapshotArchiveSession{
 		meta:   metaView,
-		reader: &s0fsArchiveReader{state: state},
+		reader: &s0fsArchiveReader{reader: s0fs.NewSnapshotReader(state, materializer)},
 	}, fsmeta.RootInode, rootAttr, nil
 }
 
@@ -366,6 +371,9 @@ func (m *Manager) createS0FSSnapshot(ctx context.Context, req *CreateSnapshotReq
 		if volCtx, getErr := m.volMgr.GetVolume(req.VolumeID); getErr == nil && volCtx != nil {
 			_ = volCtx.FlushAll("")
 		}
+	}
+	if _, err := engine.EnsureMaterialized(ctx); err != nil {
+		return nil, err
 	}
 
 	snapshotID := uuid.New().String()


### PR DESCRIPTION
## Summary
- preserve s0fs cold segment metadata in snapshots instead of hydrating all cold data inline
- materialize source data before snapshot creation so volumes created with `snapshot_id` inherit source segments like forked volumes
- add snapshot archive cold-segment reads and regression coverage for COW create-from-snapshot behavior

## Validation
- `go test ./storage-proxy/pkg/s0fs ./storage-proxy/pkg/snapshot -run 'TestCreateSnapshotPreservesColdSegments|TestEngineForkStateReadsParentSegmentsAndWritesChildSegments|TestS0FSForkVolumeUsesCopyOnWriteState|TestS0FSCreateVolumeFromSnapshotUsesCopyOnWriteState|TestS0FSSnapshotCreateRestoreAndDelete|TestExportSnapshotArchiveS0FS|TestS0FSGarbageCollectsObjectsAfterSnapshotDelete'`
- `go test ./storage-proxy/pkg/s0fs ./storage-proxy/pkg/snapshot ./storage-proxy/pkg/http`
- `go test ./storage-proxy/pkg/...`
- remote kind manual check: login, create source volume, write file, create snapshot, create child volume with `snapshot_id`, read child payload, then list RustFS objects. Result: source volume had `segments=1`; child volume had `segments=0` and `manifests=1`.