### PR TITLE
Fix netd sandbox IP reconciliation

### DIFF
--- a/netd/pkg/daemon/daemon.go
+++ b/netd/pkg/daemon/daemon.go
@@ -173,25 +173,7 @@ func (d *Daemon) runNetd(ctx context.Context, cancel context.CancelFunc, proxyEx
 		platformState.OnSandboxUpsert(info)
 		changed, prevHash := policyStore.UpsertFromSandbox(info)
 		if changed && info.PodIP != "" {
-			flows := tracker.PopBySrc(info.PodIP)
-			p := policyStore.GetByIP(info.PodIP)
-			var flowsToKill []conntrack.FlowKey
-			// Only kill flows that are denied by the new policy.
-			// This prevents a race condition where a new connection established
-			// immediately after the policy update but before this handler runs
-			// would be killed if we blindly cleared all flows.
-			for _, flow := range flows {
-				proto := "tcp"
-				if flow.Proto == 17 {
-					proto = "udp"
-				}
-				if !policy.AllowEgressL4(p, net.IP(flow.DstIP.AsSlice()), int(flow.DstPort), proto) {
-					flowsToKill = append(flowsToKill, flow)
-				}
-			}
-			if len(flowsToKill) > 0 && conntrackManager != nil {
-				conntrackManager.CleanupFlows(ctx, flowsToKill)
-			}
+			cleanupDeniedTrackedFlows(ctx, tracker, conntrackManager, policyStore, info.PodIP)
 		}
 		d.logger.Info("Sandbox policy handler triggered",
 			zap.String("sandbox", info.Namespace+"/"+info.Name),
@@ -278,7 +260,7 @@ func (d *Daemon) runNetd(ctx context.Context, cancel context.CancelFunc, proxyEx
 			case <-ticker.C:
 			case <-syncTrigger:
 			}
-			if err := d.syncRedirect(ctx, netdWatcher, policyStore, redirectManager, patcher); err != nil {
+			if err := d.syncRedirect(ctx, netdWatcher, policyStore, platformState, redirectManager, patcher, tracker, conntrackManager); err != nil {
 				d.logger.Error("Failed to sync redirect rules", zap.Error(err))
 				if d.cfg.FailClosed {
 					d.ready.Store(false)
@@ -444,19 +426,39 @@ func (d *Daemon) syncRedirect(
 	ctx context.Context,
 	netdWatcher *watcher.Watcher,
 	policyStore *policy.Store,
+	platformState *platformPolicyState,
 	redirectManager redirect.Manager,
 	patcher *apply.Patcher,
+	tracker *conntrack.Tracker,
+	conntrackManager *conntrack.Manager,
 ) error {
 	if netdWatcher == nil || redirectManager == nil || patcher == nil {
 		return fmt.Errorf("missing watcher or redirect manager or patcher or policy store")
 	}
 	sandboxes := netdWatcher.ListSandboxesByNode(d.cfg.NodeName)
+	services := netdWatcher.ListServices()
+	endpoints := netdWatcher.ListEndpoints()
 	sandboxIPs := make([]string, 0, len(sandboxes))
 	for _, sandbox := range sandboxes {
 		if sandbox.PodIP == "" {
 			continue
 		}
 		sandboxIPs = append(sandboxIPs, sandbox.PodIP)
+	}
+	if policyStore != nil {
+		result := policyStore.ReconcileSandboxes(sandboxes)
+		for _, podIP := range result.RemovedIPs {
+			cleanupTrackedFlows(ctx, tracker, conntrackManager, podIP)
+		}
+		for _, change := range result.Changed {
+			if change.Initial || change.PodIP == "" {
+				continue
+			}
+			cleanupDeniedTrackedFlows(ctx, tracker, conntrackManager, policyStore, change.PodIP)
+		}
+	}
+	if platformState != nil {
+		platformState.Reconcile(sandboxes, services, endpoints)
 	}
 
 	bypassCIDRs := []string{}
@@ -495,6 +497,54 @@ func (d *Daemon) syncRedirect(
 		zap.Int("sandboxes_total", len(sandboxes)),
 	)
 	return nil
+}
+
+func cleanupTrackedFlows(
+	ctx context.Context,
+	tracker *conntrack.Tracker,
+	conntrackManager *conntrack.Manager,
+	podIP string,
+) int {
+	if tracker == nil || podIP == "" {
+		return 0
+	}
+	flows := tracker.PopBySrc(podIP)
+	if len(flows) > 0 && conntrackManager != nil {
+		conntrackManager.CleanupFlows(ctx, flows)
+	}
+	return len(flows)
+}
+
+func cleanupDeniedTrackedFlows(
+	ctx context.Context,
+	tracker *conntrack.Tracker,
+	conntrackManager *conntrack.Manager,
+	policyStore *policy.Store,
+	podIP string,
+) int {
+	if tracker == nil || policyStore == nil || podIP == "" {
+		return 0
+	}
+	flows := tracker.PopBySrc(podIP)
+	p := policyStore.GetByIP(podIP)
+	var flowsToKill []conntrack.FlowKey
+	// Only kill flows that are denied by the new policy.
+	// This prevents a race condition where a new connection established
+	// immediately after the policy update but before this handler runs
+	// would be killed if we blindly cleared all flows.
+	for _, flow := range flows {
+		proto := "tcp"
+		if flow.Proto == 17 {
+			proto = "udp"
+		}
+		if !policy.AllowEgressL4(p, net.IP(flow.DstIP.AsSlice()), int(flow.DstPort), proto) {
+			flowsToKill = append(flowsToKill, flow)
+		}
+	}
+	if len(flowsToKill) > 0 && conntrackManager != nil {
+		conntrackManager.CleanupFlows(ctx, flowsToKill)
+	}
+	return len(flowsToKill)
 }
 
 func (d *Daemon) startServers() error {

--- a/netd/pkg/daemon/platform_policy.go
+++ b/netd/pkg/daemon/platform_policy.go
@@ -118,6 +118,37 @@ func (s *platformPolicyState) OnEndpointsDelete(info *watcher.EndpointsInfo) {
 	s.rebuild()
 }
 
+func (s *platformPolicyState) Reconcile(
+	sandboxes []*watcher.SandboxInfo,
+	services []*watcher.ServiceInfo,
+	endpoints []*watcher.EndpointsInfo,
+) {
+	s.mu.Lock()
+	s.sandboxes = make(map[string]*watcher.SandboxInfo, len(sandboxes))
+	for _, info := range sandboxes {
+		if info == nil {
+			continue
+		}
+		s.sandboxes[info.Namespace+"/"+info.Name] = info
+	}
+	s.services = make(map[string]*watcher.ServiceInfo, len(services))
+	for _, info := range services {
+		if info == nil {
+			continue
+		}
+		s.services[info.Namespace+"/"+info.Name] = info
+	}
+	s.endpoints = make(map[string]*watcher.EndpointsInfo, len(endpoints))
+	for _, info := range endpoints {
+		if info == nil {
+			continue
+		}
+		s.endpoints[info.Namespace+"/"+info.Name] = info
+	}
+	s.mu.Unlock()
+	s.rebuild()
+}
+
 func (s *platformPolicyState) rebuild() {
 	if s.store == nil {
 		return

--- a/netd/pkg/policy/store.go
+++ b/netd/pkg/policy/store.go
@@ -26,6 +26,22 @@ type policyEntry struct {
 	updatedAt  time.Time
 }
 
+type SandboxPolicyChange struct {
+	Namespace  string
+	Name       string
+	PodIP      string
+	OldPodIP   string
+	PolicyHash string
+	PrevHash   string
+	Initial    bool
+}
+
+type SandboxPolicyReconcileResult struct {
+	Upserted   int
+	RemovedIPs []string
+	Changed    []SandboxPolicyChange
+}
+
 func NewStore(logger *zap.Logger) *Store {
 	if logger == nil {
 		logger = zap.NewNop()
@@ -82,6 +98,85 @@ func (s *Store) UpsertFromSandbox(info *watcher.SandboxInfo) (bool, string) {
 		zap.String("prev_hash", prevHash),
 	)
 	return changed, prevHash
+}
+
+func (s *Store) ReconcileSandboxes(sandboxes []*watcher.SandboxInfo) SandboxPolicyReconcileResult {
+	result := SandboxPolicyReconcileResult{}
+	desired := make(map[string]*policyEntry, len(sandboxes))
+	desiredInfo := make(map[string]*watcher.SandboxInfo, len(sandboxes))
+	currentKeys := make(map[string]struct{}, len(sandboxes))
+	now := time.Now()
+	for _, info := range sandboxes {
+		if info == nil || info.PodIP == "" {
+			continue
+		}
+		key := info.Namespace + "/" + info.Name
+		currentKeys[key] = struct{}{}
+		spec, err := v1alpha1.ParseNetworkPolicyFromAnnotation(info.NetworkPolicy)
+		if err != nil {
+			s.logger.Warn("Failed to parse network policy", zap.Error(err), zap.String("pod_ip", info.PodIP))
+			continue
+		}
+		compiled, err := CompileNetworkPolicy(spec)
+		if err != nil {
+			s.logger.Warn("Failed to compile network policy", zap.Error(err), zap.String("pod_ip", info.PodIP))
+			continue
+		}
+		desired[key] = &policyEntry{
+			compiled:   compiled,
+			policyHash: info.NetworkPolicyHash,
+			podIP:      info.PodIP,
+			updatedAt:  now,
+		}
+		desiredInfo[key] = info
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for key, existing := range s.byKey {
+		if _, ok := currentKeys[key]; ok {
+			continue
+		}
+		delete(s.byKey, key)
+		if existing != nil && existing.podIP != "" {
+			delete(s.byIP, existing.podIP)
+			result.RemovedIPs = append(result.RemovedIPs, existing.podIP)
+		}
+	}
+	for key, entry := range desired {
+		info := desiredInfo[key]
+		existing := s.byKey[key]
+		change := SandboxPolicyChange{
+			Namespace:  info.Namespace,
+			Name:       info.Name,
+			PodIP:      entry.podIP,
+			PolicyHash: entry.policyHash,
+			Initial:    existing == nil,
+		}
+		if existing != nil {
+			change.PrevHash = existing.policyHash
+			change.OldPodIP = existing.podIP
+		}
+		if existing == nil || existing.policyHash != entry.policyHash || existing.podIP != entry.podIP {
+			result.Changed = append(result.Changed, change)
+		}
+		if existing != nil && existing.podIP != "" && existing.podIP != entry.podIP {
+			delete(s.byIP, existing.podIP)
+			result.RemovedIPs = append(result.RemovedIPs, existing.podIP)
+		}
+		s.byKey[key] = entry
+		s.byIP[entry.podIP] = entry
+		result.Upserted++
+	}
+	if len(result.RemovedIPs) > 0 || len(result.Changed) > 0 {
+		s.logger.Info(
+			"Sandbox network policies reconciled",
+			zap.Int("upserted", result.Upserted),
+			zap.Int("changed", len(result.Changed)),
+			zap.Int("removed_ips", len(result.RemovedIPs)),
+		)
+	}
+	return result
 }
 
 func (s *Store) DeleteByKey(namespace, name string) {

--- a/netd/pkg/policy/store_test.go
+++ b/netd/pkg/policy/store_test.go
@@ -1,0 +1,57 @@
+package policy
+
+import (
+	"testing"
+
+	"github.com/sandbox0-ai/sandbox0/netd/pkg/watcher"
+	"go.uber.org/zap"
+)
+
+func TestStoreReconcileSandboxesRemovesStalePolicies(t *testing.T) {
+	store := NewStore(zap.NewNop())
+	sandboxA := testSandboxInfo("default", "sandbox-a", "10.0.0.2", "hash-a")
+	sandboxB := testSandboxInfo("default", "sandbox-b", "10.0.0.3", "hash-b")
+
+	store.ReconcileSandboxes([]*watcher.SandboxInfo{sandboxA, sandboxB})
+	if got := store.GetByIP(sandboxB.PodIP); got == nil {
+		t.Fatalf("expected sandbox-b policy before removal")
+	}
+
+	result := store.ReconcileSandboxes([]*watcher.SandboxInfo{sandboxA})
+	if got := store.GetByIP(sandboxB.PodIP); got != nil {
+		t.Fatalf("stale policy for removed sandbox still present: %#v", got)
+	}
+	if len(result.RemovedIPs) != 1 || result.RemovedIPs[0] != sandboxB.PodIP {
+		t.Fatalf("removed IPs = %#v, want [%s]", result.RemovedIPs, sandboxB.PodIP)
+	}
+}
+
+func TestStoreReconcileSandboxesRemovesOldIPOnPodIPChange(t *testing.T) {
+	store := NewStore(zap.NewNop())
+	oldSandbox := testSandboxInfo("default", "sandbox-a", "10.0.0.2", "hash-a")
+	newSandbox := testSandboxInfo("default", "sandbox-a", "10.0.0.4", "hash-a")
+
+	store.ReconcileSandboxes([]*watcher.SandboxInfo{oldSandbox})
+	result := store.ReconcileSandboxes([]*watcher.SandboxInfo{newSandbox})
+
+	if got := store.GetByIP(oldSandbox.PodIP); got != nil {
+		t.Fatalf("old pod IP policy still present: %#v", got)
+	}
+	if got := store.GetByIP(newSandbox.PodIP); got == nil {
+		t.Fatalf("new pod IP policy missing")
+	}
+	if len(result.RemovedIPs) != 1 || result.RemovedIPs[0] != oldSandbox.PodIP {
+		t.Fatalf("removed IPs = %#v, want [%s]", result.RemovedIPs, oldSandbox.PodIP)
+	}
+}
+
+func testSandboxInfo(namespace, name, podIP, hash string) *watcher.SandboxInfo {
+	return &watcher.SandboxInfo{
+		Namespace:         namespace,
+		Name:              name,
+		PodIP:             podIP,
+		NodeName:          "node-a",
+		SandboxID:         "sandbox-id-" + name,
+		NetworkPolicyHash: hash,
+	}
+}

--- a/netd/pkg/redirect/manager_test.go
+++ b/netd/pkg/redirect/manager_test.go
@@ -46,9 +46,12 @@ func TestBuildIPSetRestoreInput(t *testing.T) {
 	restore := buildIPSetRestoreInput([]string{"10.0.0.2", "10.0.0.3"})
 
 	mustContain(t, restore, "create "+ipsetName+" hash:ip family inet -exist")
-	mustContain(t, restore, "flush "+ipsetName)
-	mustContain(t, restore, "add "+ipsetName+" 10.0.0.2 -exist")
-	mustContain(t, restore, "add "+ipsetName+" 10.0.0.3 -exist")
+	mustContain(t, restore, "create "+nextIPSetName+" hash:ip family inet -exist")
+	mustContain(t, restore, "flush "+nextIPSetName)
+	mustContain(t, restore, "add "+nextIPSetName+" 10.0.0.2 -exist")
+	mustContain(t, restore, "add "+nextIPSetName+" 10.0.0.3 -exist")
+	mustContain(t, restore, "swap "+nextIPSetName+" "+ipsetName)
+	mustContain(t, restore, "destroy "+nextIPSetName)
 }
 
 func TestNatBypassRuleSpecSkipsDNATForMarkedPackets(t *testing.T) {

--- a/netd/pkg/redirect/rules.go
+++ b/netd/pkg/redirect/rules.go
@@ -12,6 +12,7 @@ const (
 	chainName         = "NETD_PREROUTING"
 	natChainName      = "NETD_NAT_PREROUTING"
 	ipsetName         = "netd-sandbox-ips"
+	nextIPSetName     = "netd-sandbox-ips-next"
 	tproxyMark        = "0x1/0x1"
 	defaultLoopback   = "127.0.0.0/8"
 	natBypassJumpMark = tproxyMark
@@ -63,10 +64,13 @@ func natBypassRuleSpec() []string {
 func buildIPSetRestoreInput(ips []string) string {
 	var buf bytes.Buffer
 	buf.WriteString(fmt.Sprintf("create %s hash:ip family inet -exist\n", ipsetName))
-	buf.WriteString(fmt.Sprintf("flush %s\n", ipsetName))
+	buf.WriteString(fmt.Sprintf("create %s hash:ip family inet -exist\n", nextIPSetName))
+	buf.WriteString(fmt.Sprintf("flush %s\n", nextIPSetName))
 	for _, ip := range ips {
-		buf.WriteString(fmt.Sprintf("add %s %s -exist\n", ipsetName, ip))
+		buf.WriteString(fmt.Sprintf("add %s %s -exist\n", nextIPSetName, ip))
 	}
+	buf.WriteString(fmt.Sprintf("swap %s %s\n", nextIPSetName, ipsetName))
+	buf.WriteString(fmt.Sprintf("destroy %s\n", nextIPSetName))
 	return buf.String()
 }
 

--- a/netd/pkg/watcher/watcher.go
+++ b/netd/pkg/watcher/watcher.go
@@ -57,6 +57,10 @@ type NodeInfo struct {
 type Watcher struct {
 	k8sClient       kubernetes.Interface
 	informerFactory informers.SharedInformerFactory
+	podInformer     cache.SharedIndexInformer
+	serviceInformer cache.SharedIndexInformer
+	sliceInformer   cache.SharedIndexInformer
+	nodeInformer    cache.SharedIndexInformer
 	logger          *zap.Logger
 
 	mu             sync.RWMutex
@@ -76,11 +80,16 @@ type Watcher struct {
 	onNodeDelete      func(*NodeInfo)
 }
 
+const podNodeIndex = "spec.nodeName"
+
 func NewWatcher(
 	k8sClient kubernetes.Interface,
 	resyncPeriod time.Duration,
 	logger *zap.Logger,
 ) *Watcher {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
 	return &Watcher{
 		k8sClient:       k8sClient,
 		informerFactory: informers.NewSharedInformerFactory(k8sClient, resyncPeriod),
@@ -133,6 +142,13 @@ func (w *Watcher) Start(ctx context.Context) error {
 	serviceInformer := w.informerFactory.Core().V1().Services().Informer()
 	endpointSliceInformer := w.informerFactory.Discovery().V1().EndpointSlices().Informer()
 	nodeInformer := w.informerFactory.Core().V1().Nodes().Informer()
+	if err := podInformer.AddIndexers(cache.Indexers{podNodeIndex: indexPodByNode}); err != nil {
+		return fmt.Errorf("add pod node indexer: %w", err)
+	}
+	w.podInformer = podInformer
+	w.serviceInformer = serviceInformer
+	w.sliceInformer = endpointSliceInformer
+	w.nodeInformer = nodeInformer
 
 	podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    w.handlePodUpsert,
@@ -173,6 +189,29 @@ func (w *Watcher) Start(ctx context.Context) error {
 }
 
 func (w *Watcher) ListSandboxesByNode(nodeName string) []*SandboxInfo {
+	if w.podInformer != nil {
+		var objects []any
+		if nodeName != "" {
+			items, err := w.podInformer.GetIndexer().ByIndex(podNodeIndex, nodeName)
+			if err != nil {
+				w.logger.Warn("Failed to list sandbox pods by node index", zap.String("node", nodeName), zap.Error(err))
+				return nil
+			}
+			objects = items
+		} else {
+			objects = w.podInformer.GetStore().List()
+		}
+		out := make([]*SandboxInfo, 0, len(objects))
+		for _, obj := range objects {
+			info := activeSandboxInfoFromPod(getPod(obj))
+			if info == nil {
+				continue
+			}
+			out = append(out, info)
+		}
+		return out
+	}
+
 	w.mu.RLock()
 	defer w.mu.RUnlock()
 	out := make([]*SandboxInfo, 0, len(w.sandboxes))
@@ -180,6 +219,43 @@ func (w *Watcher) ListSandboxesByNode(nodeName string) []*SandboxInfo {
 		if nodeName == "" || info.NodeName == nodeName {
 			out = append(out, cloneSandboxInfo(info))
 		}
+	}
+	return out
+}
+
+func (w *Watcher) ListServices() []*ServiceInfo {
+	if w.serviceInformer != nil {
+		objects := w.serviceInformer.GetStore().List()
+		out := make([]*ServiceInfo, 0, len(objects))
+		for _, obj := range objects {
+			info := serviceInfoFromService(getService(obj))
+			if info != nil {
+				out = append(out, info)
+			}
+		}
+		return out
+	}
+
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	out := make([]*ServiceInfo, 0, len(w.services))
+	for _, info := range w.services {
+		out = append(out, cloneServiceInfo(info))
+	}
+	return out
+}
+
+func (w *Watcher) ListEndpoints() []*EndpointsInfo {
+	if w.sliceInformer != nil {
+		objects := w.sliceInformer.GetStore().List()
+		return endpointsInfosFromSlices(objects)
+	}
+
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	out := make([]*EndpointsInfo, 0, len(w.endpoints))
+	for _, info := range w.endpoints {
+		out = append(out, cloneEndpointsInfo(info))
 	}
 	return out
 }
@@ -221,8 +297,9 @@ func (w *Watcher) handlePodUpsert(obj any) {
 	if pod == nil {
 		return
 	}
-	info := sandboxInfoFromPod(pod)
+	info := activeSandboxInfoFromPod(pod)
 	if info == nil {
+		w.removeCachedSandboxPod(pod, false)
 		return
 	}
 
@@ -255,23 +332,33 @@ func (w *Watcher) handlePodDelete(obj any) {
 	if pod == nil {
 		return
 	}
-	key := pod.Namespace + "/" + pod.Name
-	w.mu.RLock()
-	info := w.sandboxes[key]
-	w.mu.RUnlock()
-	if info == nil {
-		info = sandboxInfoFromPod(pod)
-	}
-	if info == nil {
+	w.removeCachedSandboxPod(pod, true)
+}
+
+func (w *Watcher) removeCachedSandboxPod(pod *corev1.Pod, allowPodFallback bool) {
+	if pod == nil {
 		return
 	}
-
+	key := pod.Namespace + "/" + pod.Name
 	w.mu.Lock()
-	if existing := w.sandboxes[key]; existing != nil {
-		if !isResourceVersionNewer(existing.ResourceVersion, info.ResourceVersion) {
+	info := w.sandboxes[key]
+	if info == nil {
+		if !allowPodFallback {
 			w.mu.Unlock()
 			return
 		}
+		info = sandboxInfoFromPod(pod)
+	}
+	if info == nil {
+		w.mu.Unlock()
+		return
+	}
+	if existing := w.sandboxes[key]; existing != nil {
+		if existing.UID != "" && info.UID != "" && existing.UID != info.UID {
+			w.mu.Unlock()
+			return
+		}
+		info = existing
 	}
 	delete(w.sandboxes, key)
 	w.mu.Unlock()
@@ -325,12 +412,6 @@ func (w *Watcher) handleServiceDelete(obj any) {
 
 	key := service.Namespace + "/" + service.Name
 	w.mu.Lock()
-	if existing := w.services[key]; existing != nil {
-		if !isResourceVersionNewer(existing.ResourceVersion, info.ResourceVersion) {
-			w.mu.Unlock()
-			return
-		}
-	}
 	delete(w.services, key)
 	w.mu.Unlock()
 
@@ -375,12 +456,6 @@ func (w *Watcher) handleEndpointSliceDelete(obj any) {
 
 	key := slice.Namespace + "/" + slice.Name
 	w.mu.Lock()
-	if existing := w.endpointSlices[key]; existing != nil {
-		if !isResourceVersionNewer(existing.ResourceVersion, entry.ResourceVersion) {
-			w.mu.Unlock()
-			return
-		}
-	}
 	delete(w.endpointSlices, key)
 	w.mu.Unlock()
 
@@ -475,12 +550,6 @@ func (w *Watcher) handleNodeDelete(obj any) {
 	}
 
 	w.mu.Lock()
-	if existing := w.nodes[node.Name]; existing != nil {
-		if !isResourceVersionNewer(existing.ResourceVersion, info.ResourceVersion) {
-			w.mu.Unlock()
-			return
-		}
-	}
 	delete(w.nodes, node.Name)
 	w.mu.Unlock()
 
@@ -516,6 +585,19 @@ func sandboxInfoFromPod(pod *corev1.Pod) *SandboxInfo {
 	}
 }
 
+func activeSandboxInfoFromPod(pod *corev1.Pod) *SandboxInfo {
+	if pod == nil || pod.DeletionTimestamp != nil {
+		return nil
+	}
+	if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
+		return nil
+	}
+	if pod.Status.PodIP == "" || pod.Spec.NodeName == "" {
+		return nil
+	}
+	return sandboxInfoFromPod(pod)
+}
+
 func serviceInfoFromService(service *corev1.Service) *ServiceInfo {
 	if service == nil {
 		return nil
@@ -528,6 +610,35 @@ func serviceInfoFromService(service *corev1.Service) *ServiceInfo {
 		Ports:           append([]corev1.ServicePort(nil), service.Spec.Ports...),
 		Labels:          cloneStringMap(service.Labels),
 	}
+}
+
+func endpointsInfosFromSlices(objects []any) []*EndpointsInfo {
+	byService := make(map[string]*EndpointsInfo)
+	for _, obj := range objects {
+		entry := endpointSliceEntryFromSlice(getEndpointSlice(obj))
+		if entry == nil || entry.ServiceName == "" {
+			continue
+		}
+		key := entry.Namespace + "/" + entry.ServiceName
+		info := byService[key]
+		if info == nil {
+			info = &EndpointsInfo{
+				Namespace: entry.Namespace,
+				Name:      entry.ServiceName,
+			}
+			byService[key] = info
+		}
+		if isResourceVersionNewer(info.ResourceVersion, entry.ResourceVersion) {
+			info.ResourceVersion = entry.ResourceVersion
+		}
+		info.Addresses = append(info.Addresses, entry.Addresses...)
+		info.Ports = append(info.Ports, entry.Ports...)
+	}
+	out := make([]*EndpointsInfo, 0, len(byService))
+	for _, info := range byService {
+		out = append(out, cloneEndpointsInfo(info))
+	}
+	return out
 }
 
 type endpointSliceEntry struct {
@@ -634,6 +745,14 @@ func getNode(obj any) *corev1.Node {
 	}
 	node, _ = tombstone.Obj.(*corev1.Node)
 	return node
+}
+
+func indexPodByNode(obj any) ([]string, error) {
+	pod := getPod(obj)
+	if pod == nil || pod.Spec.NodeName == "" {
+		return nil, nil
+	}
+	return []string{pod.Spec.NodeName}, nil
 }
 
 func cloneSandboxInfo(info *SandboxInfo) *SandboxInfo {

--- a/netd/pkg/watcher/watcher_test.go
+++ b/netd/pkg/watcher/watcher_test.go
@@ -1,0 +1,91 @@
+package watcher
+
+import (
+	"testing"
+
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestHandlePodDeleteRemovesCachedSandboxWhenResourceVersionIsEqual(t *testing.T) {
+	w := NewWatcher(nil, 0, zap.NewNop())
+	pod := testSandboxPod("sandbox-a", "uid-a", "10", "10.0.0.2", "node-a")
+
+	w.handlePodUpsert(pod)
+	w.handlePodDelete(pod.DeepCopy())
+
+	if got := w.ListSandboxesByNode("node-a"); len(got) != 0 {
+		t.Fatalf("sandboxes after equal resourceVersion delete = %#v, want empty", got)
+	}
+}
+
+func TestHandlePodUpsertRemovesDeletingSandboxFromFallbackCache(t *testing.T) {
+	w := NewWatcher(nil, 0, zap.NewNop())
+	pod := testSandboxPod("sandbox-a", "uid-a", "10", "10.0.0.2", "node-a")
+	w.handlePodUpsert(pod)
+
+	deleting := pod.DeepCopy()
+	now := metav1.Now()
+	deleting.DeletionTimestamp = &now
+	deleting.ResourceVersion = pod.ResourceVersion
+	w.handlePodUpsert(deleting)
+
+	if got := w.ListSandboxesByNode("node-a"); len(got) != 0 {
+		t.Fatalf("sandboxes after deleting update = %#v, want empty", got)
+	}
+}
+
+func TestListSandboxesByNodeUsesInformerCacheAsAuthoritativeSource(t *testing.T) {
+	w := NewWatcher(nil, 0, zap.NewNop())
+	informer := cache.NewSharedIndexInformer(nil, &corev1.Pod{}, 0, cache.Indexers{podNodeIndex: indexPodByNode})
+	w.podInformer = informer
+
+	active := testSandboxPod("sandbox-a", "uid-a", "10", "10.0.0.2", "node-a")
+	deleting := testSandboxPod("sandbox-b", "uid-b", "11", "10.0.0.3", "node-a")
+	now := metav1.Now()
+	deleting.DeletionTimestamp = &now
+	terminal := testSandboxPod("sandbox-c", "uid-c", "12", "10.0.0.4", "node-a")
+	terminal.Status.Phase = corev1.PodSucceeded
+	noIP := testSandboxPod("sandbox-d", "uid-d", "13", "", "node-a")
+	otherNode := testSandboxPod("sandbox-e", "uid-e", "14", "10.0.0.5", "node-b")
+
+	for _, pod := range []*corev1.Pod{active, deleting, terminal, noIP, otherNode} {
+		if err := informer.GetStore().Add(pod); err != nil {
+			t.Fatalf("add pod: %v", err)
+		}
+	}
+
+	got := w.ListSandboxesByNode("node-a")
+	if len(got) != 1 {
+		t.Fatalf("node-a sandboxes = %#v, want exactly active sandbox", got)
+	}
+	if got[0].Name != active.Name || got[0].PodIP != active.Status.PodIP {
+		t.Fatalf("unexpected sandbox: %#v", got[0])
+	}
+}
+
+func testSandboxPod(name, uid, resourceVersion, podIP, nodeName string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       "default",
+			Name:            name,
+			UID:             types.UID(uid),
+			ResourceVersion: resourceVersion,
+			Labels: map[string]string{
+				controller.LabelSandboxID: "sandbox-id-" + name,
+				controller.LabelPoolType:  controller.PoolTypeActive,
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: nodeName,
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			PodIP: podIP,
+		},
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #336.

This changes netd sandbox IP reconciliation so Kubernetes informer cache is treated as the authoritative source for active sandbox pods. Event handlers still provide low-latency triggers, but periodic redirect sync now reconciles policy store, platform policy, and `netd-sandbox-ips` from a current informer snapshot.

## Root cause

`netd-sandbox-ips` was rebuilt from `watcher.sandboxes`. That map was maintained incrementally from pod events. If a delete event arrived with the same resourceVersion as the cached pod, or if a pod entered deletion via update before final delete, the watcher could keep a stale sandbox entry forever. Later resyncs then faithfully re-added the old pod IP to the ipset.

## Changes

- Read active sandbox snapshots from the pod informer cache, indexed by node.
- Filter deleting, terminal, unscheduled, or IP-less pods out of active sandbox snapshots.
- Add authoritative list APIs for services and endpoints so platform policy can be rebuilt from cache snapshots.
- Add `policy.Store.ReconcileSandboxes` to upsert current sandbox policies and delete stale by-key/by-IP entries.
- Add `platformPolicyState.Reconcile` to replace platform policy inputs with a complete snapshot.
- Keep event handlers as fast-path triggers, but make sync reconcile the desired runtime state.
- Update `netd-sandbox-ips` via temporary ipset + `swap` instead of `flush` + `add`, avoiding a short empty-set window.
- Add regression tests for equal-resourceVersion delete, deleting pod updates, informer snapshot filtering, and stale policy/IP cleanup.

## Validation

- `go test ./netd/pkg/watcher ./netd/pkg/policy ./netd/pkg/daemon ./netd/pkg/redirect`
- `go test ./netd/pkg/...`
- `git diff --check`

Remote kind validation will be run separately while PR CI is running.
