### PR TITLE
Release idle ctld volume owners before volume restore/fork/delete

### DIFF
--- a/ctld/cmd/ctld/main.go
+++ b/ctld/cmd/ctld/main.go
@@ -271,6 +271,18 @@ func (c combinedController) AttachVolumeOwner(r *http.Request, req ctldapi.Attac
 	return resp, http.StatusOK
 }
 
+func (c combinedController) ReleaseVolumeOwner(r *http.Request, req ctldapi.ReleaseVolumeOwnerRequest) (ctldapi.ReleaseVolumeOwnerResponse, int) {
+	if c.Portal == nil {
+		return ctldapi.ReleaseVolumeOwnerResponse{Error: "ctld volume owners not implemented"}, http.StatusNotImplemented
+	}
+	resp, err := c.Portal.ReleaseOwner(r.Context(), req)
+	if err != nil {
+		resp.Error = err.Error()
+		return resp, volumePortalErrorStatus(err)
+	}
+	return resp, http.StatusOK
+}
+
 func (c combinedController) PrepareVolumePortalHandoff(r *http.Request, req ctldapi.PrepareVolumePortalHandoffRequest) (ctldapi.PrepareVolumePortalHandoffResponse, int) {
 	if c.Portal == nil {
 		return ctldapi.PrepareVolumePortalHandoffResponse{Error: "ctld volume portal handoff not implemented"}, http.StatusNotImplemented
@@ -315,6 +327,7 @@ func volumePortalErrorStatus(err error) int {
 	switch {
 	case strings.Contains(message, "already has an active owner"),
 		strings.Contains(message, "actively bound to a portal"),
+		strings.Contains(message, "still has active file requests"),
 		strings.Contains(message, "already bound to"),
 		strings.Contains(message, "handoff already in progress"):
 		return http.StatusConflict
@@ -339,6 +352,7 @@ type volumePortalHandler interface {
 	Unbind(ctx context.Context, req ctldapi.UnbindVolumePortalRequest) (ctldapi.UnbindVolumePortalResponse, error)
 	CheckPublished(ctx context.Context, req ctldapi.CheckVolumePortalsRequest) (ctldapi.CheckVolumePortalsResponse, error)
 	AttachOwner(ctx context.Context, req ctldapi.AttachVolumeOwnerRequest) (ctldapi.AttachVolumeOwnerResponse, error)
+	ReleaseOwner(ctx context.Context, req ctldapi.ReleaseVolumeOwnerRequest) (ctldapi.ReleaseVolumeOwnerResponse, error)
 	PrepareHandoff(ctx context.Context, req ctldapi.PrepareVolumePortalHandoffRequest) (ctldapi.PrepareVolumePortalHandoffResponse, error)
 	CompleteHandoff(ctx context.Context, req ctldapi.CompleteVolumePortalHandoffRequest) (ctldapi.CompleteVolumePortalHandoffResponse, error)
 	AbortHandoff(ctx context.Context, req ctldapi.AbortVolumePortalHandoffRequest) (ctldapi.AbortVolumePortalHandoffResponse, error)

--- a/ctld/cmd/ctld/main_test.go
+++ b/ctld/cmd/ctld/main_test.go
@@ -128,10 +128,28 @@ func TestBindVolumePortalReturnsConflictForAlreadyBoundPortal(t *testing.T) {
 	assert.Equal(t, http.StatusConflict, rec.Code)
 }
 
+func TestReleaseVolumeOwnerReturnsConflictForBusyOwner(t *testing.T) {
+	server := newHTTPServer(":0", combinedController{
+		Controller: ctldserver.NotImplementedController{},
+		Portal: fakeVolumePortalHandler{
+			releaseErr:  fmt.Errorf("volume vol-1 is actively bound to a portal"),
+			releaseResp: ctldapi.ReleaseVolumeOwnerResponse{Busy: true},
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/volume-portals/owners/release", strings.NewReader(`{"sandboxvolume_id":"vol-1"}`))
+	rec := httptest.NewRecorder()
+	server.Handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusConflict, rec.Code)
+}
+
 type fakeVolumePortalHandler struct {
 	mountedHandler http.Handler
 	bindErr        error
 	prepareErr     error
+	releaseResp    ctldapi.ReleaseVolumeOwnerResponse
+	releaseErr     error
 }
 
 func (f fakeVolumePortalHandler) Bind(_ context.Context, _ ctldapi.BindVolumePortalRequest) (ctldapi.BindVolumePortalResponse, error) {
@@ -151,6 +169,16 @@ func (f fakeVolumePortalHandler) CheckPublished(_ context.Context, _ ctldapi.Che
 
 func (f fakeVolumePortalHandler) AttachOwner(_ context.Context, _ ctldapi.AttachVolumeOwnerRequest) (ctldapi.AttachVolumeOwnerResponse, error) {
 	return ctldapi.AttachVolumeOwnerResponse{Attached: true}, nil
+}
+
+func (f fakeVolumePortalHandler) ReleaseOwner(_ context.Context, _ ctldapi.ReleaseVolumeOwnerRequest) (ctldapi.ReleaseVolumeOwnerResponse, error) {
+	if f.releaseErr != nil {
+		return f.releaseResp, f.releaseErr
+	}
+	if f.releaseResp.Released || f.releaseResp.Busy || f.releaseResp.Error != "" {
+		return f.releaseResp, nil
+	}
+	return ctldapi.ReleaseVolumeOwnerResponse{Released: true}, nil
 }
 
 func (f fakeVolumePortalHandler) PrepareHandoff(_ context.Context, _ ctldapi.PrepareVolumePortalHandoffRequest) (ctldapi.PrepareVolumePortalHandoffResponse, error) {

--- a/ctld/internal/ctld/portal/manager.go
+++ b/ctld/internal/ctld/portal/manager.go
@@ -583,6 +583,38 @@ func (m *Manager) AttachOwner(ctx context.Context, req ctldapi.AttachVolumeOwner
 	return ctldapi.AttachVolumeOwnerResponse{Attached: true}, nil
 }
 
+func (m *Manager) ReleaseOwner(ctx context.Context, req ctldapi.ReleaseVolumeOwnerRequest) (ctldapi.ReleaseVolumeOwnerResponse, error) {
+	if err := ctx.Err(); err != nil {
+		return ctldapi.ReleaseVolumeOwnerResponse{}, err
+	}
+	volumeID := strings.TrimSpace(req.SandboxVolumeID)
+	if volumeID == "" {
+		return ctldapi.ReleaseVolumeOwnerResponse{}, fmt.Errorf("sandboxvolume_id is required")
+	}
+	m.mu.Lock()
+	bound := m.boundVolumes[volumeID]
+	if bound == nil {
+		m.mu.Unlock()
+		return ctldapi.ReleaseVolumeOwnerResponse{Released: true}, nil
+	}
+	if bound.refCount > 0 {
+		m.mu.Unlock()
+		err := fmt.Errorf("volume %s is actively bound to a portal", volumeID)
+		return ctldapi.ReleaseVolumeOwnerResponse{Busy: true, Error: err.Error()}, err
+	}
+	if ok, reason := m.volumes.canReleaseOwnerOnly(volumeID); !ok {
+		m.mu.Unlock()
+		err := fmt.Errorf("volume %s %s", volumeID, reason)
+		return ctldapi.ReleaseVolumeOwnerResponse{Busy: true, Error: err.Error()}, err
+	}
+	if err := m.releaseOwnerOnlyVolumeLocked(ctx, volumeID, bound); err != nil {
+		m.mu.Unlock()
+		return ctldapi.ReleaseVolumeOwnerResponse{}, err
+	}
+	m.mu.Unlock()
+	return ctldapi.ReleaseVolumeOwnerResponse{Released: true}, nil
+}
+
 func (m *Manager) PrepareHandoff(ctx context.Context, req ctldapi.PrepareVolumePortalHandoffRequest) (ctldapi.PrepareVolumePortalHandoffResponse, error) {
 	volumeID := strings.TrimSpace(req.SandboxVolumeID)
 	if volumeID == "" {
@@ -678,6 +710,15 @@ func (m *Manager) releaseOwnerOnlyVolume(ctx context.Context, volumeID string) e
 		m.mu.Unlock()
 		return nil
 	}
+	if err := m.releaseOwnerOnlyVolumeLocked(ctx, volumeID, bound); err != nil {
+		m.mu.Unlock()
+		return err
+	}
+	m.mu.Unlock()
+	return nil
+}
+
+func (m *Manager) releaseOwnerOnlyVolumeLocked(ctx context.Context, volumeID string, bound *boundVolume) error {
 	if bound.materializeCancel != nil {
 		bound.materializeCancel()
 		bound.materializeCancel = nil
@@ -688,12 +729,10 @@ func (m *Manager) releaseOwnerOnlyVolume(ctx context.Context, volumeID string) e
 		<-done
 	}
 	if err := m.volumes.UnmountVolume(ctx, volumeID, ""); err != nil {
-		m.mu.Unlock()
 		return err
 	}
 	delete(m.boundVolumes, volumeID)
 	m.unregisterOwner(bound)
-	m.mu.Unlock()
 	return nil
 }
 

--- a/ctld/internal/ctld/portal/manager_shared_test.go
+++ b/ctld/internal/ctld/portal/manager_shared_test.go
@@ -161,6 +161,90 @@ func TestCleanupIdleOwnerOnlyVolumesKeepsOwnerOnMaterializeFailure(t *testing.T)
 	}
 }
 
+func TestReleaseOwnerRemovesOwnerOnlyVolumeBeforeIdleTTL(t *testing.T) {
+	mgr := &Manager{
+		ownerOnlyIdleTTL: time.Minute,
+		boundVolumes:     make(map[string]*boundVolume),
+		volumes:          newLocalVolumeManager(),
+	}
+	volCtx := &volume.VolumeContext{VolumeID: "vol-1"}
+	mgr.volumes.add(volCtx)
+	mgr.boundVolumes["vol-1"] = &boundVolume{
+		volumeID: "vol-1",
+		refCount: 0,
+		volCtx:   volCtx,
+	}
+
+	resp, err := mgr.ReleaseOwner(context.Background(), ctldapi.ReleaseVolumeOwnerRequest{SandboxVolumeID: "vol-1"})
+	if err != nil {
+		t.Fatalf("ReleaseOwner() error = %v", err)
+	}
+	if !resp.Released || resp.Busy {
+		t.Fatalf("ReleaseOwner() response = %+v, want released", resp)
+	}
+	if _, ok := mgr.boundVolumes["vol-1"]; ok {
+		t.Fatal("bound volume still present after ReleaseOwner")
+	}
+	if _, err := mgr.volumes.GetVolume("vol-1"); err == nil {
+		t.Fatal("GetVolume() after ReleaseOwner error = nil, want volume removed")
+	}
+}
+
+func TestReleaseOwnerReturnsBusyForActivePortal(t *testing.T) {
+	mgr := &Manager{
+		boundVolumes: make(map[string]*boundVolume),
+		volumes:      newLocalVolumeManager(),
+	}
+	volCtx := &volume.VolumeContext{VolumeID: "vol-1"}
+	mgr.volumes.add(volCtx)
+	mgr.boundVolumes["vol-1"] = &boundVolume{
+		volumeID: "vol-1",
+		refCount: 1,
+		volCtx:   volCtx,
+	}
+
+	resp, err := mgr.ReleaseOwner(context.Background(), ctldapi.ReleaseVolumeOwnerRequest{SandboxVolumeID: "vol-1"})
+	if err == nil {
+		t.Fatal("ReleaseOwner() error = nil, want busy error")
+	}
+	if !resp.Busy || resp.Released {
+		t.Fatalf("ReleaseOwner() response = %+v, want busy", resp)
+	}
+	if _, ok := mgr.boundVolumes["vol-1"]; !ok {
+		t.Fatal("bound volume removed after busy ReleaseOwner")
+	}
+}
+
+func TestReleaseOwnerReturnsBusyForInFlightDirectRequest(t *testing.T) {
+	mgr := &Manager{
+		boundVolumes: make(map[string]*boundVolume),
+		volumes:      newLocalVolumeManager(),
+	}
+	volCtx := &volume.VolumeContext{VolumeID: "vol-1"}
+	mgr.volumes.add(volCtx)
+	release, err := mgr.volumes.acquire(context.Background(), "vol-1")
+	if err != nil {
+		t.Fatalf("acquire() error = %v", err)
+	}
+	defer release()
+	mgr.boundVolumes["vol-1"] = &boundVolume{
+		volumeID: "vol-1",
+		refCount: 0,
+		volCtx:   volCtx,
+	}
+
+	resp, err := mgr.ReleaseOwner(context.Background(), ctldapi.ReleaseVolumeOwnerRequest{SandboxVolumeID: "vol-1"})
+	if err == nil {
+		t.Fatal("ReleaseOwner() error = nil, want busy error")
+	}
+	if !resp.Busy || resp.Released {
+		t.Fatalf("ReleaseOwner() response = %+v, want busy", resp)
+	}
+	if _, ok := mgr.boundVolumes["vol-1"]; !ok {
+		t.Fatal("bound volume removed after in-flight ReleaseOwner")
+	}
+}
+
 func TestNewManagerDefaultsClusterID(t *testing.T) {
 	mgr := NewManager(Config{
 		StorageConfig: &apiconfig.StorageProxyConfig{},

--- a/ctld/internal/ctld/portal/session.go
+++ b/ctld/internal/ctld/portal/session.go
@@ -176,6 +176,22 @@ func (m *localVolumeManager) canCleanupOwnerOnly(volumeID string, cutoff time.Ti
 	return !state.lastAccess.After(cutoff)
 }
 
+func (m *localVolumeManager) canReleaseOwnerOnly(volumeID string) (bool, string) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	state := m.requests[volumeID]
+	if state == nil {
+		return true, ""
+	}
+	if state.transferring {
+		return false, "handoff already in progress"
+	}
+	if state.inFlight > 0 {
+		return false, "still has active file requests"
+	}
+	return true, ""
+}
+
 func (m *localVolumeManager) MountVolume(_ context.Context, _ string, volumeID string, _ string, _ volume.AccessMode) (string, time.Time, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()

--- a/ctld/internal/ctld/server/server.go
+++ b/ctld/internal/ctld/server/server.go
@@ -22,6 +22,7 @@ type VolumePortalController interface {
 	UnbindVolumePortal(r *http.Request, req ctldapi.UnbindVolumePortalRequest) (ctldapi.UnbindVolumePortalResponse, int)
 	CheckVolumePortals(r *http.Request, req ctldapi.CheckVolumePortalsRequest) (ctldapi.CheckVolumePortalsResponse, int)
 	AttachVolumeOwner(r *http.Request, req ctldapi.AttachVolumeOwnerRequest) (ctldapi.AttachVolumeOwnerResponse, int)
+	ReleaseVolumeOwner(r *http.Request, req ctldapi.ReleaseVolumeOwnerRequest) (ctldapi.ReleaseVolumeOwnerResponse, int)
 	PrepareVolumePortalHandoff(r *http.Request, req ctldapi.PrepareVolumePortalHandoffRequest) (ctldapi.PrepareVolumePortalHandoffResponse, int)
 	CompleteVolumePortalHandoff(r *http.Request, req ctldapi.CompleteVolumePortalHandoffRequest) (ctldapi.CompleteVolumePortalHandoffResponse, int)
 	AbortVolumePortalHandoff(r *http.Request, req ctldapi.AbortVolumePortalHandoffRequest) (ctldapi.AbortVolumePortalHandoffResponse, int)
@@ -153,6 +154,28 @@ func NewMux(controller Controller) http.Handler {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		resp, status := volumeController.AttachVolumeOwner(r, req)
+		w.WriteHeader(status)
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+	mux.HandleFunc("/api/v1/volume-portals/owners/release", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		volumeController, ok := controller.(VolumePortalController)
+		if !ok {
+			w.WriteHeader(http.StatusNotImplemented)
+			_ = json.NewEncoder(w).Encode(ctldapi.ReleaseVolumeOwnerResponse{Error: "ctld volume owners not implemented"})
+			return
+		}
+		var req ctldapi.ReleaseVolumeOwnerRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(ctldapi.ReleaseVolumeOwnerResponse{Error: err.Error()})
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		resp, status := volumeController.ReleaseVolumeOwner(r, req)
 		w.WriteHeader(status)
 		_ = json.NewEncoder(w).Encode(resp)
 	})

--- a/pkg/ctldapi/types.go
+++ b/pkg/ctldapi/types.go
@@ -125,3 +125,13 @@ type AttachVolumeOwnerResponse struct {
 	Attached bool   `json:"attached"`
 	Error    string `json:"error,omitempty"`
 }
+
+type ReleaseVolumeOwnerRequest struct {
+	SandboxVolumeID string `json:"sandboxvolume_id"`
+}
+
+type ReleaseVolumeOwnerResponse struct {
+	Released bool   `json:"released"`
+	Busy     bool   `json:"busy,omitempty"`
+	Error    string `json:"error,omitempty"`
+}

--- a/storage-proxy/pkg/http/ctld_owner.go
+++ b/storage-proxy/pkg/http/ctld_owner.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -15,6 +16,8 @@ import (
 )
 
 const defaultCtldPort = 8095
+
+var errCtldOwnerBusy = errors.New("ctld volume owner is busy")
 
 type volumeCtldResolver interface {
 	ResolveLocalCtldURL(ctx context.Context) (string, error)
@@ -188,6 +191,54 @@ func (s *Server) ensureCtldVolumeOwner(ctx context.Context, volumeRecord *db.San
 			return nil
 		}
 		return err
+	}
+	return nil
+}
+
+func (s *Server) releaseReleasableCtldVolumeOwners(ctx context.Context, volumeID string) error {
+	if s == nil || s.repo == nil || s.podResolver == nil || strings.TrimSpace(volumeID) == "" {
+		return nil
+	}
+	if err := s.waitForVolumeHandoff(ctx, volumeID); err != nil {
+		return err
+	}
+	heartbeatTimeout := 15
+	if s.cfg != nil && s.cfg.HeartbeatTimeout > 0 {
+		heartbeatTimeout = s.cfg.HeartbeatTimeout
+	}
+	mounts, err := s.repo.GetActiveMounts(ctx, volumeID, heartbeatTimeout)
+	if err != nil {
+		return err
+	}
+	for _, mount := range mounts {
+		if mount == nil || strings.TrimSpace(mount.PodID) == "" {
+			continue
+		}
+		if s.selfClusterID != "" && mount.ClusterID != "" && mount.ClusterID != s.selfClusterID {
+			continue
+		}
+		if volume.DecodeMountOptions(mount.MountOptions).OwnerKind != volume.OwnerKindCtld {
+			continue
+		}
+		ownerURL, err := s.resolveVolumeMountURL(ctx, mount)
+		if err != nil {
+			return err
+		}
+		if ownerURL == nil {
+			continue
+		}
+		resp, err := postCtldJSON[ctldapi.ReleaseVolumeOwnerResponse](ctx, ownerURL.String(), "/api/v1/volume-portals/owners/release", ctldapi.ReleaseVolumeOwnerRequest{
+			SandboxVolumeID: volumeID,
+		})
+		if err != nil {
+			if isCtldConflictError(err) || (resp != nil && resp.Busy) {
+				return fmt.Errorf("%w: %v", errCtldOwnerBusy, err)
+			}
+			return err
+		}
+		if resp != nil && resp.Busy {
+			return fmt.Errorf("%w: %s", errCtldOwnerBusy, strings.TrimSpace(resp.Error))
+		}
 	}
 	return nil
 }

--- a/storage-proxy/pkg/http/ctld_owner_test.go
+++ b/storage-proxy/pkg/http/ctld_owner_test.go
@@ -2,120 +2,242 @@ package http
 
 import (
 	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
 	"testing"
 
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
+	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volume"
+	"github.com/sirupsen/logrus"
 )
 
-func TestKubernetesVolumeCtldResolverPrefersLocalCtldPod(t *testing.T) {
-	scheme := runtime.NewScheme()
-	if err := corev1.AddToScheme(scheme); err != nil {
-		t.Fatalf("add corev1 scheme: %v", err)
+func TestReleaseReleasableCtldVolumeOwnersCallsOwningCtld(t *testing.T) {
+	releaseCalls := 0
+	ctldServer, ownerPort := newReleaseOwnerTestServer(t, http.StatusOK, ctldapi.ReleaseVolumeOwnerResponse{Released: true}, &releaseCalls)
+	defer ctldServer.Close()
+
+	repo := newFakeHTTPRepo()
+	repo.activeMounts["vol-1"] = []*db.VolumeMount{ctldOwnerMount(t, "vol-1", "cluster-a", "sandbox0-system/ctld-a", ownerPort)}
+	server := &Server{
+		repo:          repo,
+		podResolver:   &fakeVolumeFilePodResolver{urls: map[string]string{"sandbox0-system/ctld-a": ctldServer.URL}},
+		selfClusterID: "cluster-a",
 	}
 
-	client := k8sfake.NewSimpleClientset(
-		newResolverPod("sandbox0-system", "storage-proxy-a", "node-system", "10.24.0.4", map[string]string{
-			ctldInstanceLabel: "fullmode",
-		}, false),
-		newResolverPod("sandbox0-system", "fullmode-ctld-system", "node-system", "10.24.0.4", map[string]string{
-			ctldNameLabel:     ctldComponentName,
-			ctldInstanceLabel: "fullmode",
-		}, true),
-		newResolverPod("sandbox0-system", "fullmode-ctld-sandbox", "node-sandbox", "10.24.15.221", map[string]string{
-			ctldNameLabel:     ctldComponentName,
-			ctldInstanceLabel: "fullmode",
-		}, true),
-	)
-
-	resolver := newKubernetesVolumeCtldResolver(client, "sandbox0-system/storage-proxy-a")
-	got, err := resolver.ResolveLocalCtldURL(context.Background())
-	if err != nil {
-		t.Fatalf("ResolveLocalCtldURL() error = %v", err)
+	if err := server.releaseReleasableCtldVolumeOwners(context.Background(), "vol-1"); err != nil {
+		t.Fatalf("releaseReleasableCtldVolumeOwners() error = %v", err)
 	}
-	if got != "http://10.24.0.4:8095" {
-		t.Fatalf("ResolveLocalCtldURL() = %q, want %q", got, "http://10.24.0.4:8095")
+	if releaseCalls != 1 {
+		t.Fatalf("release calls = %d, want 1", releaseCalls)
 	}
 }
 
-func TestKubernetesVolumeCtldResolverFallsBackToReadyCtldPod(t *testing.T) {
-	scheme := runtime.NewScheme()
-	if err := corev1.AddToScheme(scheme); err != nil {
-		t.Fatalf("add corev1 scheme: %v", err)
+func TestRestoreSnapshotReleasesCtldOwnerBeforeRestore(t *testing.T) {
+	releaseCalls := 0
+	ctldServer, ownerPort := newReleaseOwnerTestServer(t, http.StatusOK, ctldapi.ReleaseVolumeOwnerResponse{Released: true}, &releaseCalls)
+	defer ctldServer.Close()
+
+	repo := newFakeHTTPRepo()
+	repo.getActiveFunc = func(_ context.Context, volumeID string, _ int) ([]*db.VolumeMount, error) {
+		if releaseCalls > 0 {
+			return nil, nil
+		}
+		return []*db.VolumeMount{ctldOwnerMount(t, volumeID, "cluster-a", "sandbox0-system/ctld-a", ownerPort)}, nil
+	}
+	snapshotMgr := &fakeHTTPSnapshotManager{}
+	server := &Server{
+		logger:        logrus.New(),
+		repo:          repo,
+		snapshotMgr:   snapshotMgr,
+		podResolver:   &fakeVolumeFilePodResolver{urls: map[string]string{"sandbox0-system/ctld-a": ctldServer.URL}},
+		selfClusterID: "cluster-a",
 	}
 
-	client := k8sfake.NewSimpleClientset(
-		newResolverPod("sandbox0-system", "storage-proxy-a", "node-system", "10.24.0.4", map[string]string{
-			ctldInstanceLabel: "fullmode",
-		}, false),
-		newResolverPod("sandbox0-system", "fullmode-ctld-not-ready", "node-system", "10.24.0.4", map[string]string{
-			ctldNameLabel:     ctldComponentName,
-			ctldInstanceLabel: "fullmode",
-		}, false),
-		newResolverPod("sandbox0-system", "fullmode-ctld-sandbox", "node-sandbox", "10.24.15.221", map[string]string{
-			ctldNameLabel:     ctldComponentName,
-			ctldInstanceLabel: "fullmode",
-		}, true),
-	)
+	req := httptest.NewRequest(http.MethodPost, "/sandboxvolumes/vol-1/snapshots/snap-1/restore", nil)
+	req.SetPathValue("volume_id", "vol-1")
+	req.SetPathValue("snapshot_id", "snap-1")
+	req = req.WithContext(internalauth.WithClaims(req.Context(), &internalauth.Claims{TeamID: "team-1", UserID: "user-1"}))
+	recorder := httptest.NewRecorder()
 
-	resolver := newKubernetesVolumeCtldResolver(client, "sandbox0-system/storage-proxy-a")
-	got, err := resolver.ResolveLocalCtldURL(context.Background())
-	if err != nil {
-		t.Fatalf("ResolveLocalCtldURL() error = %v", err)
+	server.restoreSnapshot(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
 	}
-	if got != "http://10.24.15.221:8095" {
-		t.Fatalf("ResolveLocalCtldURL() = %q, want %q", got, "http://10.24.15.221:8095")
+	if releaseCalls != 1 {
+		t.Fatalf("release calls = %d, want 1", releaseCalls)
+	}
+	if snapshotMgr.lastRestore == nil || snapshotMgr.lastRestore.VolumeID != "vol-1" {
+		t.Fatalf("RestoreSnapshot request = %+v, want volume vol-1", snapshotMgr.lastRestore)
 	}
 }
 
-func TestKubernetesVolumeCtldResolverFiltersToMatchingInstance(t *testing.T) {
-	client := k8sfake.NewSimpleClientset(
-		newResolverPod("sandbox0-system", "storage-proxy-a", "node-system", "10.24.0.4", map[string]string{
-			ctldInstanceLabel: "fullmode",
-		}, false),
-		newResolverPod("sandbox0-system", "other-ctld", "node-sandbox-a", "10.24.15.200", map[string]string{
-			ctldNameLabel:     ctldComponentName,
-			ctldInstanceLabel: "other",
-		}, true),
-		newResolverPod("sandbox0-system", "fullmode-ctld-sandbox", "node-sandbox-b", "10.24.15.221", map[string]string{
-			ctldNameLabel:     ctldComponentName,
-			ctldInstanceLabel: "fullmode",
-		}, true),
-	)
+func TestForkVolumeReleasesCtldOwnerBeforeFork(t *testing.T) {
+	releaseCalls := 0
+	ctldServer, ownerPort := newReleaseOwnerTestServer(t, http.StatusOK, ctldapi.ReleaseVolumeOwnerResponse{Released: true}, &releaseCalls)
+	defer ctldServer.Close()
 
-	resolver := newKubernetesVolumeCtldResolver(client, "sandbox0-system/storage-proxy-a")
-	got, err := resolver.ResolveLocalCtldURL(context.Background())
-	if err != nil {
-		t.Fatalf("ResolveLocalCtldURL() error = %v", err)
+	repo := newFakeHTTPRepo()
+	repo.getActiveFunc = func(_ context.Context, volumeID string, _ int) ([]*db.VolumeMount, error) {
+		if releaseCalls > 0 {
+			return nil, nil
+		}
+		return []*db.VolumeMount{ctldOwnerMount(t, volumeID, "cluster-a", "sandbox0-system/ctld-a", ownerPort)}, nil
 	}
-	if got != "http://10.24.15.221:8095" {
-		t.Fatalf("ResolveLocalCtldURL() = %q, want %q", got, "http://10.24.15.221:8095")
+	snapshotMgr := &captureForkSnapshotManager{fakeHTTPSnapshotManager: &fakeHTTPSnapshotManager{}}
+	server := &Server{
+		logger:        logrus.New(),
+		repo:          repo,
+		snapshotMgr:   snapshotMgr,
+		podResolver:   &fakeVolumeFilePodResolver{urls: map[string]string{"sandbox0-system/ctld-a": ctldServer.URL}},
+		selfClusterID: "cluster-a",
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/sandboxvolumes/vol-1/fork", nil)
+	req.SetPathValue("id", "vol-1")
+	req = req.WithContext(internalauth.WithClaims(req.Context(), &internalauth.Claims{TeamID: "team-1", UserID: "user-1"}))
+	recorder := httptest.NewRecorder()
+
+	server.forkVolume(recorder, req)
+
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusCreated)
+	}
+	if releaseCalls != 1 {
+		t.Fatalf("release calls = %d, want 1", releaseCalls)
+	}
+	if snapshotMgr.lastFork == nil || snapshotMgr.lastFork.SourceVolumeID != "vol-1" {
+		t.Fatalf("ForkVolume request = %+v, want source vol-1", snapshotMgr.lastFork)
 	}
 }
 
-func newResolverPod(namespace, name, nodeName, podIP string, labels map[string]string, ready bool) *corev1.Pod {
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      name,
-			Labels:    labels,
-		},
-		Spec: corev1.PodSpec{
-			NodeName: nodeName,
-		},
-		Status: corev1.PodStatus{
-			Phase: corev1.PodRunning,
-			PodIP: podIP,
-		},
+func TestDeleteSandboxVolumeReleasesCtldOwnerBeforeActiveMountCheck(t *testing.T) {
+	releaseCalls := 0
+	ctldServer, ownerPort := newReleaseOwnerTestServer(t, http.StatusOK, ctldapi.ReleaseVolumeOwnerResponse{Released: true}, &releaseCalls)
+	defer ctldServer.Close()
+
+	repo := newFakeHTTPRepo()
+	repo.volumes["vol-1"] = &db.SandboxVolume{ID: "vol-1", TeamID: "team-1", UserID: "user-1"}
+	repo.getActiveFunc = func(_ context.Context, volumeID string, _ int) ([]*db.VolumeMount, error) {
+		if releaseCalls > 0 {
+			return nil, nil
+		}
+		return []*db.VolumeMount{ctldOwnerMount(t, volumeID, "cluster-a", "sandbox0-system/ctld-a", ownerPort)}, nil
 	}
-	pod.Status.Conditions = []corev1.PodCondition{{
-		Type:   corev1.PodReady,
-		Status: corev1.ConditionFalse,
-	}}
-	if ready {
-		pod.Status.Conditions[0].Status = corev1.ConditionTrue
+	server := &Server{
+		logger:        logrus.New(),
+		repo:          repo,
+		snapshotMgr:   &fakeHTTPSnapshotManager{},
+		podResolver:   &fakeVolumeFilePodResolver{urls: map[string]string{"sandbox0-system/ctld-a": ctldServer.URL}},
+		selfClusterID: "cluster-a",
 	}
-	return pod
+
+	req := httptest.NewRequest(http.MethodDelete, "/sandboxvolumes/vol-1", nil)
+	req.SetPathValue("id", "vol-1")
+	req = req.WithContext(internalauth.WithClaims(req.Context(), &internalauth.Claims{TeamID: "team-1", UserID: "user-1"}))
+	recorder := httptest.NewRecorder()
+
+	server.deleteSandboxVolume(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+	if releaseCalls != 1 {
+		t.Fatalf("release calls = %d, want 1", releaseCalls)
+	}
+	if len(repo.deletedVolume) != 1 || repo.deletedVolume[0] != "vol-1" {
+		t.Fatalf("deleted volume = %v, want [vol-1]", repo.deletedVolume)
+	}
+}
+
+func TestRestoreSnapshotReturnsConflictWhenCtldOwnerIsBusy(t *testing.T) {
+	ctldServer, ownerPort := newReleaseOwnerTestServer(t, http.StatusConflict, ctldapi.ReleaseVolumeOwnerResponse{Busy: true, Error: "volume vol-1 is actively bound to a portal"}, nil)
+	defer ctldServer.Close()
+
+	repo := newFakeHTTPRepo()
+	repo.activeMounts["vol-1"] = []*db.VolumeMount{ctldOwnerMount(t, "vol-1", "cluster-a", "sandbox0-system/ctld-a", ownerPort)}
+	snapshotMgr := &fakeHTTPSnapshotManager{}
+	server := &Server{
+		logger:        logrus.New(),
+		repo:          repo,
+		snapshotMgr:   snapshotMgr,
+		podResolver:   &fakeVolumeFilePodResolver{urls: map[string]string{"sandbox0-system/ctld-a": ctldServer.URL}},
+		selfClusterID: "cluster-a",
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/sandboxvolumes/vol-1/snapshots/snap-1/restore", nil)
+	req.SetPathValue("volume_id", "vol-1")
+	req.SetPathValue("snapshot_id", "snap-1")
+	req = req.WithContext(internalauth.WithClaims(req.Context(), &internalauth.Claims{TeamID: "team-1", UserID: "user-1"}))
+	recorder := httptest.NewRecorder()
+
+	server.restoreSnapshot(recorder, req)
+
+	if recorder.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusConflict)
+	}
+	if snapshotMgr.lastRestore != nil {
+		t.Fatalf("RestoreSnapshot request = %+v, want nil when owner is busy", snapshotMgr.lastRestore)
+	}
+	_, apiErr, err := spec.DecodeResponse[map[string]any](recorder.Body)
+	if err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if apiErr == nil || apiErr.Message != "ctld-mounted volumes must be unmounted before snapshot or restore" {
+		t.Fatalf("api error = %+v, want ctld-mounted conflict", apiErr)
+	}
+}
+
+func ctldOwnerMount(t *testing.T, volumeID, clusterID, podID string, ownerPort int) *db.VolumeMount {
+	t.Helper()
+	return &db.VolumeMount{
+		VolumeID:  volumeID,
+		ClusterID: clusterID,
+		PodID:     podID,
+		MountOptions: mustMountOptionsRaw(t, volume.MountOptions{
+			AccessMode: volume.AccessModeRWO,
+			OwnerKind:  volume.OwnerKindCtld,
+			OwnerPort:  ownerPort,
+		}),
+	}
+}
+
+func newReleaseOwnerTestServer(t *testing.T, status int, resp ctldapi.ReleaseVolumeOwnerResponse, calls *int) (*httptest.Server, int) {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/volume-portals/owners/release" {
+			t.Fatalf("ctld release path = %q, want /api/v1/volume-portals/owners/release", r.URL.Path)
+		}
+		if calls != nil {
+			*calls = *calls + 1
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	return server, mustHTTPServerPort(t, server)
+}
+
+func mustHTTPServerPort(t *testing.T, server *httptest.Server) int {
+	t.Helper()
+	parsed, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	_, port, err := net.SplitHostPort(parsed.Host)
+	if err != nil {
+		t.Fatalf("split test server host: %v", err)
+	}
+	parsedPort, err := strconv.Atoi(port)
+	if err != nil {
+		t.Fatalf("parse test server port: %v", err)
+	}
+	return parsedPort
 }

--- a/storage-proxy/pkg/http/handlers_metering_test.go
+++ b/storage-proxy/pkg/http/handlers_metering_test.go
@@ -235,6 +235,7 @@ type fakeHTTPSnapshotManager struct {
 	exportBody           []byte
 	lastCreate           *snapshot.CreateSnapshotRequest
 	lastCreateVolume     *snapshot.CreateVolumeFromSnapshotRequest
+	lastRestore          *snapshot.RestoreSnapshotRequest
 	lastExport           *snapshot.ExportSnapshotRequest
 	lastCompatibility    *snapshot.ListSnapshotCompatibilityIssuesRequest
 	casefoldEntries      []snapshot.SnapshotCasefoldCollision
@@ -289,6 +290,7 @@ func (f *fakeHTTPSnapshotManager) ExportSnapshotArchive(ctx context.Context, req
 }
 
 func (f *fakeHTTPSnapshotManager) RestoreSnapshot(ctx context.Context, req *snapshot.RestoreSnapshotRequest) error {
+	f.lastRestore = req
 	return nil
 }
 

--- a/storage-proxy/pkg/http/handlers_sandboxvolume.go
+++ b/storage-proxy/pkg/http/handlers_sandboxvolume.go
@@ -285,6 +285,19 @@ func (s *Server) deleteSandboxVolume(w http.ResponseWriter, r *http.Request) {
 			s.logger.WithError(err).WithField("volume_id", id).Warn("Failed to cleanup idle direct volume mount before delete")
 		}
 	}
+	if !force {
+		if err := s.releaseReleasableCtldVolumeOwners(r.Context(), id); err != nil {
+			status, code := http.StatusInternalServerError, spec.CodeInternal
+			message := "failed to release ctld volume owner"
+			if errors.Is(err, errCtldOwnerBusy) {
+				status, code = http.StatusConflict, spec.CodeConflict
+				message = "volume has active mounts"
+			}
+			s.logger.WithError(err).WithField("volume_id", id).Warn("Failed to release ctld volume owner before delete")
+			_ = spec.WriteError(w, status, code, message)
+			return
+		}
+	}
 	mounts, err := s.repo.GetActiveMounts(r.Context(), id, heartbeatTimeout)
 	if err != nil {
 		s.logger.WithError(err).Error("Failed to check active mounts")
@@ -354,6 +367,14 @@ func (s *Server) deleteSandboxVolumeRecord(ctx context.Context, id string, force
 	if !force && s.volMgr != nil {
 		if _, err := s.volMgr.CleanupIdleDirectVolumeFileMount(ctx, id); err != nil {
 			s.logger.WithError(err).WithField("volume_id", id).Warn("Failed to cleanup idle direct volume mount before delete")
+		}
+	}
+	if !force {
+		if err := s.releaseReleasableCtldVolumeOwners(ctx, id); err != nil {
+			if errors.Is(err, errCtldOwnerBusy) {
+				return nil, errVolumeHasActiveMounts
+			}
+			return nil, fmt.Errorf("release ctld volume owner: %w", err)
 		}
 	}
 	mounts, err := s.repo.GetActiveMounts(ctx, id, heartbeatTimeout)
@@ -783,21 +804,37 @@ func (s *Server) forkVolume(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	vol, err := s.snapshotMgr.ForkVolume(r.Context(), &snapshot.ForkVolumeRequest{
-		SourceVolumeID:  id,
-		TeamID:          claims.TeamID,
-		UserID:          claims.UserID,
-		AccessMode:      req.AccessMode,
-		DefaultPosixUID: req.DefaultPosixUID,
-		DefaultPosixGID: req.DefaultPosixGID,
-	})
+	run := func(runCtx context.Context) (*db.SandboxVolume, error) {
+		if err := s.releaseReleasableCtldVolumeOwners(runCtx, id); err != nil {
+			return nil, err
+		}
+		return s.snapshotMgr.ForkVolume(runCtx, &snapshot.ForkVolumeRequest{
+			SourceVolumeID:  id,
+			TeamID:          claims.TeamID,
+			UserID:          claims.UserID,
+			AccessMode:      req.AccessMode,
+			DefaultPosixUID: req.DefaultPosixUID,
+			DefaultPosixGID: req.DefaultPosixGID,
+		})
+	}
+	var vol *db.SandboxVolume
+	var err error
+	if s.barrier != nil {
+		err = s.barrier.WithExclusive(r.Context(), id, func(runCtx context.Context) error {
+			var runErr error
+			vol, runErr = run(runCtx)
+			return runErr
+		})
+	} else {
+		vol, err = run(r.Context())
+	}
 	if err != nil {
 		switch {
 		case errors.Is(err, snapshot.ErrVolumeNotFound):
 			_ = spec.WriteError(w, http.StatusNotFound, spec.CodeNotFound, "volume not found")
 		case errors.Is(err, snapshot.ErrInvalidAccessMode):
 			_ = spec.WriteError(w, http.StatusBadRequest, spec.CodeBadRequest, "invalid access_mode")
-		case errors.Is(err, snapshot.ErrMountedCtldOwner):
+		case errors.Is(err, snapshot.ErrMountedCtldOwner), errors.Is(err, errCtldOwnerBusy):
 			_ = spec.WriteError(w, http.StatusConflict, spec.CodeConflict, "volume has active ctld mounts")
 		case errors.Is(err, snapshot.ErrCloneFailed):
 			_ = spec.WriteError(w, http.StatusInternalServerError, spec.CodeInternal, "clone operation failed")

--- a/storage-proxy/pkg/http/handlers_snapshot.go
+++ b/storage-proxy/pkg/http/handlers_snapshot.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -174,14 +175,29 @@ func (s *Server) restoreSnapshot(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := s.snapshotMgr.RestoreSnapshot(r.Context(), &snapshot.RestoreSnapshotRequest{
-		VolumeID:   volumeID,
-		SnapshotID: snapshotID,
-		TeamID:     claims.TeamID,
-		UserID:     claims.UserID,
-	})
+	run := func(ctx context.Context) error {
+		if err := s.releaseReleasableCtldVolumeOwners(ctx, volumeID); err != nil {
+			return err
+		}
+		return s.snapshotMgr.RestoreSnapshot(ctx, &snapshot.RestoreSnapshotRequest{
+			VolumeID:   volumeID,
+			SnapshotID: snapshotID,
+			TeamID:     claims.TeamID,
+			UserID:     claims.UserID,
+		})
+	}
+	var err error
+	if s.barrier != nil {
+		err = s.barrier.WithExclusive(r.Context(), volumeID, run)
+	} else {
+		err = run(r.Context())
+	}
 
 	if err != nil {
+		if errors.Is(err, errCtldOwnerBusy) {
+			s.handleSnapshotError(w, snapshot.ErrMountedCtldOwner)
+			return
+		}
 		s.handleSnapshotError(w, err)
 		return
 	}

--- a/storage-proxy/pkg/http/volume_handoff.go
+++ b/storage-proxy/pkg/http/volume_handoff.go
@@ -244,6 +244,8 @@ func postCtldJSON[T any](ctx context.Context, baseURL, path string, request any)
 		switch typed := any(&out).(type) {
 		case *ctldapi.AttachVolumeOwnerResponse:
 			message = typed.Error
+		case *ctldapi.ReleaseVolumeOwnerResponse:
+			message = typed.Error
 		case *ctldapi.PrepareVolumePortalHandoffResponse:
 			message = typed.Error
 		case *ctldapi.CompleteVolumePortalHandoffResponse:


### PR DESCRIPTION
## Summary

- Add a ctld internal owner release endpoint for owner-only SandboxVolume mounts left behind by direct HTTP file access.
- Release releasable ctld owners before volume restore, fork, public delete, and internal owned-volume cleanup.
- Keep active sandbox portal mounts protected: ctld returns conflict when a volume is bound to a portal, has in-flight file requests, or is in handoff.

## Root cause

RWO direct SandboxVolume file APIs attach a ctld owner so the owning ctld can serve file operations efficiently across repeated requests. After an HTTP request completes, that owner can remain active until idle cleanup, so restore/fork/delete see an active `OwnerKindCtld` mount and return transient conflicts even though no sandbox portal is using the volume.

## Validation

- `make proto`
- `go test ./ctld/internal/ctld/portal ./ctld/internal/ctld/server ./ctld/cmd/ctld`
- `go test ./storage-proxy/pkg/http`
- `go test ./storage-proxy/pkg/snapshot ./storage-proxy/pkg/volume ./storage-proxy/pkg/coordinator ./storage-proxy/pkg/fsserver`
- `go test ./manager/pkg/service`
- `go test ./cluster-gateway/pkg/http`

I also started `go test ./...`; it passed through the touched services and most repository packages, then stopped producing output near the final packages for over 16 minutes. I interrupted that full run and am relying on CI plus remote kind validation for the full matrix.
