### PR TITLE
Make function serving revision-first

### DIFF
--- a/docs/function/page.mdx
+++ b/docs/function/page.mdx
@@ -14,7 +14,7 @@ Functions are created from Sandbox Services, not from uploaded ZIP files or cont
 | Function | Stable function identity, slug, and host under the configured function domain |
 | Revision | Immutable snapshot of the source service plus the SandboxVolume restore mounts needed to restore it |
 | Alias | Mutable pointer from a name such as `production` to a revision |
-| Runtime | Restored sandbox and process context currently serving a function revision, when the source sandbox is gone |
+| Runtime | Restored sandbox and process context currently serving a function revision |
 
 The `production` alias is the serving pointer used by the function host. Creating a function creates revision 1 and points `production` at it. Creating another revision can either promote it immediately or leave it available for a later alias update.
 
@@ -22,7 +22,7 @@ The `production` alias is the serving pointer used by the function host. Creatin
 
 Function traffic is handled by `function-gateway`. The gateway resolves the host to a function, loads the `production` revision, enforces the revision's service route policy, and proxies the request to the service port.
 
-If the source sandbox still exists, the gateway routes to that sandbox and resumes it when needed. If the source sandbox has been deleted, the gateway claims a new runtime sandbox from the revision's template, mounts the revision-owned volumes, starts the service runtime command or binds to the referenced warm process, and reuses that runtime for later requests.
+Function serving is revision-first. The gateway does not proxy production traffic to the mutable source sandbox. When no reusable runtime exists, the gateway claims a new runtime sandbox from the revision's template, mounts the revision-owned volumes, starts the service runtime command or binds to the referenced warm process, and reuses that runtime for later requests. Changes made to the source sandbox after publishing require a new revision before they affect the function host.
 
 ## Publishable Services
 

--- a/docs/function/runtime/page.mdx
+++ b/docs/function/runtime/page.mdx
@@ -1,6 +1,6 @@
 # Function Runtime
 
-Function runtime state describes the currently restored sandbox serving a function revision. When the source sandbox still exists, Function Gateway routes to it directly. When the source sandbox is gone, Function Gateway restores a runtime sandbox from the revision's template and revision-owned volumes.
+Function runtime state describes the currently restored sandbox serving a function revision. Function Gateway serves production traffic from revision runtime sandboxes, not from the mutable source sandbox. When no reusable runtime exists, Function Gateway restores a runtime sandbox from the revision's template and revision-owned volumes.
 
 ## Runtime States
 

--- a/function-gateway/pkg/http/runtime.go
+++ b/function-gateway/pkg/http/runtime.go
@@ -409,21 +409,7 @@ func functionSandboxWantsPaused(sandbox *mgr.Sandbox) bool {
 	return sandbox.Paused
 }
 
-func functionSandboxCanServeSource(sandbox *mgr.Sandbox) bool {
-	if sandbox == nil {
-		return false
-	}
-	return sandbox.Status == mgr.SandboxStatusRunning
-}
-
 func (s *Server) resolveFunctionSandbox(ctx context.Context, fn *functions.Function, rev *functions.Revision, service mgr.SandboxAppService) (*mgr.Sandbox, *functions.Revision, error) {
-	sourceSandbox, err := s.getSandboxFromClusterGateway(ctx, rev.SourceSandboxID)
-	if err == nil && functionSandboxCanServeSource(sourceSandbox) {
-		return sourceSandbox, rev, nil
-	}
-	if err != nil && !isPublishNotFound(err) {
-		return nil, rev, err
-	}
 	return s.ensureRestoredFunctionSandbox(ctx, fn, rev, service)
 }
 

--- a/function-gateway/pkg/http/runtime_test.go
+++ b/function-gateway/pkg/http/runtime_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -89,22 +90,55 @@ func TestRewriteFunctionPath(t *testing.T) {
 	}
 }
 
-func TestFunctionSandboxCanServeSourceRequiresRunning(t *testing.T) {
-	if !functionSandboxCanServeSource(&mgr.Sandbox{Status: mgr.SandboxStatusRunning}) {
-		t.Fatal("running sandbox should serve source function traffic")
+func TestResolveFunctionSandboxDoesNotServeSourceSandbox(t *testing.T) {
+	_, privateKey, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate ed25519 keypair: %v", err)
 	}
 
-	for _, status := range []string{
-		mgr.SandboxStatusStarting,
-		mgr.SandboxStatusFailed,
-		mgr.SandboxStatusCompleted,
-		mgr.SandboxStatusTerminating,
-	} {
-		t.Run(status, func(t *testing.T) {
-			if functionSandboxCanServeSource(&mgr.Sandbox{Status: status}) {
-				t.Fatalf("status %q should not serve source function traffic", status)
-			}
-		})
+	var sourceLookups atomic.Int32
+	clusterGateway := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/internal/v1/sandboxes/source-sandbox" {
+			t.Errorf("path = %s, want source sandbox lookup path", r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		sourceLookups.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":true,"data":{"id":"source-sandbox","team_id":"team-1","status":"running"}}`))
+	}))
+	defer clusterGateway.Close()
+
+	server := &Server{
+		cfg: &config.FunctionGatewayConfig{
+			DefaultClusterGatewayURL: clusterGateway.URL,
+		},
+		functionRepo: functions.NewRepository(nil),
+		internalAuthGen: internalauth.NewGenerator(internalauth.GeneratorConfig{
+			Caller:     internalauth.ServiceFunctionGateway,
+			PrivateKey: privateKey,
+			TTL:        time.Minute,
+		}),
+		httpClient: clusterGateway.Client(),
+		logger:     zap.NewNop(),
+	}
+
+	_, _, err = server.resolveFunctionSandbox(context.Background(), &functions.Function{
+		ID:     "fn-1",
+		TeamID: "team-1",
+	}, &functions.Revision{
+		ID:               "rev-1",
+		FunctionID:       "fn-1",
+		TeamID:           "team-1",
+		SourceSandboxID:  "source-sandbox",
+		SourceTemplateID: "tmpl-1",
+		CreatedBy:        "user-1",
+	}, mgr.SandboxAppService{})
+	if err == nil || !strings.Contains(err.Error(), "function repository is not configured") {
+		t.Fatalf("resolveFunctionSandbox() error = %v, want revision runtime path", err)
+	}
+	if got := sourceLookups.Load(); got != 0 {
+		t.Fatalf("source sandbox lookups = %d, want 0", got)
 	}
 }
 

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -4218,7 +4218,7 @@ components:
           $ref: "#/components/schemas/SandboxAppService"
         runtime_sandbox_id:
           type: string
-          description: Current restored runtime sandbox, when the source sandbox no longer exists.
+          description: Current restored runtime sandbox serving the revision, if one exists.
         runtime_context_id:
           type: string
           description: Current runtime process context inside the restored runtime sandbox.

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -1056,7 +1056,7 @@ type FunctionRevision struct {
 	// RuntimeContextId Current runtime process context inside the restored runtime sandbox.
 	RuntimeContextId *string `json:"runtime_context_id,omitempty"`
 
-	// RuntimeSandboxId Current restored runtime sandbox, when the source sandbox no longer exists.
+	// RuntimeSandboxId Current restored runtime sandbox serving the revision, if one exists.
 	RuntimeSandboxId *string `json:"runtime_sandbox_id,omitempty"`
 
 	// RuntimeUpdatedAt Last time the restored runtime sandbox mapping was updated.

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -1724,28 +1724,41 @@ func waitForSandboxPowerStateEventually(env *framework.ScenarioEnv, session *e2e
 }
 
 func assertFunctionAPIRoutesReachUserService(env *framework.ScenarioEnv, session *e2eutils.Session, sandboxID string) {
-	sandbox, status, err := session.GetSandbox(env.TestCtx.Context, GinkgoT(), sandboxID)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(status).To(Equal(http.StatusOK))
-	Expect(sandbox).NotTo(BeNil())
-	templateNamespace, err := naming.TemplateNamespaceForBuiltin(sandbox.TemplateId)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(sandbox.PodName).NotTo(BeEmpty())
-
 	const serviceID = "function-api"
 	const servicePort int32 = 18080
 	bodyValue := "function-api-route-ok"
 	script := fmt.Sprintf(
-		"set -eu; dir=/tmp/s0-function-e2e; rm -rf \"$dir\"; mkdir -p \"$dir/api/v1\"; printf '%s\\n' > \"$dir/api/v1/functions\"; printf 'function-health-ok\\n' > \"$dir/api/health\"; nohup python3 -m http.server %d --bind 0.0.0.0 -d \"$dir\" >/tmp/s0-function-e2e.log 2>&1 &\n",
-		bodyValue,
+		`from http.server import BaseHTTPRequestHandler, HTTPServer
+
+body = %q
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/api/v1/functions":
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(body.encode())
+            return
+        if self.path == "/api/health":
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"function-health-ok\n")
+            return
+        self.send_response(404)
+        self.end_headers()
+
+    def log_message(self, format, *args):
+        return
+
+HTTPServer(("0.0.0.0", %d), Handler).serve_forever()
+`,
+		bodyValue+"\n",
 		servicePort,
 	)
-	_, err = execInSandboxPod(env, templateNamespace, sandbox.PodName, script)
-	Expect(err).NotTo(HaveOccurred())
 
 	pathPrefix := "/"
-	cwd := "/tmp/s0-function-e2e"
-	command := []string{"python3", "-m", "http.server", fmt.Sprint(servicePort), "--bind", "0.0.0.0", "-d", cwd}
+	cwd := "/tmp"
+	command := []string{"python3", "-c", script}
 	_, _, updateStatus, err := session.UpdateSandboxServices(env.TestCtx.Context, GinkgoT(), sandboxID, []apispec.SandboxAppService{{
 		Id:   serviceID,
 		Port: servicePort,
@@ -1870,25 +1883,14 @@ func assertFunctionRuntimeRestoreUsesVolumeSnapshot(env *framework.ScenarioEnv, 
 
 	_, err = execInSandboxPod(env, templateNamespace, sourceSandbox.PodName, fmt.Sprintf("printf 'mutated live content\\n' > %s", shellQuote(mountPoint+seedPath)))
 	Expect(err).NotTo(HaveOccurred())
-	Expect(session.DeleteSandbox(env.TestCtx.Context, GinkgoT(), sourceSandboxID)).To(Succeed())
 
 	functionGatewayURL, cleanup, err := functionGatewayBaseURL(env)
 	Expect(err).NotTo(HaveOccurred())
 	defer cleanup()
 
-	Eventually(func() error {
-		status, body, err := requestFunctionHost(env.TestCtx.Context, functionGatewayURL, fn.Host, seedPath)
-		if err != nil {
-			return err
-		}
-		if status != http.StatusOK {
-			return fmt.Errorf("function restore status %d body %q", status, body)
-		}
-		if body != string(seedContent) {
-			return fmt.Errorf("function restore body = %q, want %q", body, string(seedContent))
-		}
-		return nil
-	}).WithTimeout(90 * time.Second).WithPolling(2 * time.Second).Should(Succeed())
+	expectFunctionBodyEventually(env, functionGatewayURL, fn.Host, seedPath, string(seedContent))
+	Expect(session.DeleteSandbox(env.TestCtx.Context, GinkgoT(), sourceSandboxID)).To(Succeed())
+	expectFunctionBodyEventually(env, functionGatewayURL, fn.Host, seedPath, string(seedContent))
 
 	runtimeStatus, status, err := session.GetFunctionRuntime(env.TestCtx.Context, GinkgoT(), fn.Id)
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## Summary
- Make function-gateway serve production functions through revision runtime restore/reuse instead of the mutable source sandbox.
- Update regression coverage so a running source sandbox is not consulted and e2e verifies source mutations/deletion do not change the published response.
- Update Function docs and OpenAPI-generated comments to describe revision-first runtime semantics.

## Root Cause
Function Gateway checked source_sandbox_id first and directly proxied to the live source sandbox when it was running. That let post-publish source filesystem or process changes affect the Function URL without creating a new revision.

## Validation
- make apispec
- go test ./function-gateway/...
- go test ./tests/e2e/cases -run TestSSHFixtureKeyConstantsAreValid
- go test ./pkg/apispec
