### PR TITLE
Add shared Postgres advisory locks

### DIFF
--- a/function-gateway/pkg/http/runtime.go
+++ b/function-gateway/pkg/http/runtime.go
@@ -31,6 +31,7 @@ import (
 
 const defaultFunctionAutoResumeTimeout = 30 * time.Second
 const defaultFunctionRuntimeStartTimeout = 30 * time.Second
+const functionRuntimeRestoreLockPrefix = "function-runtime-restore:"
 
 type functionRouteMatch struct {
 	route         *mgr.SandboxAppServiceRoute
@@ -432,6 +433,20 @@ func (s *Server) ensureRestoredFunctionSandbox(ctx context.Context, fn *function
 	lock.Lock()
 	defer lock.Unlock()
 
+	currentRev := rev
+	var sandbox *mgr.Sandbox
+	err := s.withRevisionRuntimeDistributedLock(ctx, rev.ID, func(runCtx context.Context) error {
+		var restoreErr error
+		sandbox, currentRev, restoreErr = s.ensureRestoredFunctionSandboxLocked(runCtx, fn, currentRev, service)
+		return restoreErr
+	})
+	if err != nil {
+		return nil, currentRev, err
+	}
+	return sandbox, currentRev, nil
+}
+
+func (s *Server) ensureRestoredFunctionSandboxLocked(ctx context.Context, fn *functions.Function, rev *functions.Revision, service mgr.SandboxAppService) (*mgr.Sandbox, *functions.Revision, error) {
 	latest, err := s.functionRepo.GetRevision(ctx, fn.TeamID, fn.ID, rev.ID)
 	if err == nil {
 		rev = latest
@@ -489,6 +504,17 @@ func (s *Server) ensureRestoredFunctionSandbox(ctx context.Context, fn *function
 		return nil, rev, err
 	}
 	return sandbox, updated, nil
+}
+
+func (s *Server) withRevisionRuntimeDistributedLock(ctx context.Context, revisionID string, fn func(context.Context) error) error {
+	if fn == nil {
+		return nil
+	}
+	revisionID = strings.TrimSpace(revisionID)
+	if s == nil || s.runtimeRestoreLocks == nil || revisionID == "" {
+		return fn(ctx)
+	}
+	return s.runtimeRestoreLocks.WithExclusive(ctx, functionRuntimeRestoreLockPrefix+revisionID, fn)
 }
 
 func (s *Server) revisionRuntimeLock(revisionID string) *sync.Mutex {

--- a/function-gateway/pkg/http/runtime_test.go
+++ b/function-gateway/pkg/http/runtime_test.go
@@ -191,6 +191,51 @@ func TestFunctionRuntimeContextCanServeWarmProcess(t *testing.T) {
 	}
 }
 
+type fakeRuntimeRestoreLocker struct {
+	resources []string
+}
+
+func (f *fakeRuntimeRestoreLocker) WithExclusive(ctx context.Context, resource string, fn func(context.Context) error) error {
+	f.resources = append(f.resources, resource)
+	return fn(ctx)
+}
+
+func TestWithRevisionRuntimeDistributedLockUsesRevisionResource(t *testing.T) {
+	locker := &fakeRuntimeRestoreLocker{}
+	server := &Server{runtimeRestoreLocks: locker}
+
+	called := false
+	if err := server.withRevisionRuntimeDistributedLock(context.Background(), " rev-1 ", func(context.Context) error {
+		called = true
+		return nil
+	}); err != nil {
+		t.Fatalf("withRevisionRuntimeDistributedLock() error = %v", err)
+	}
+
+	if !called {
+		t.Fatal("callback was not called")
+	}
+	if len(locker.resources) != 1 || locker.resources[0] != "function-runtime-restore:rev-1" {
+		t.Fatalf("resources = %v, want function runtime restore revision key", locker.resources)
+	}
+}
+
+func TestWithRevisionRuntimeDistributedLockFallsBackWithoutLocker(t *testing.T) {
+	server := &Server{}
+	called := false
+
+	if err := server.withRevisionRuntimeDistributedLock(context.Background(), "rev-1", func(context.Context) error {
+		called = true
+		return nil
+	}); err != nil {
+		t.Fatalf("withRevisionRuntimeDistributedLock() error = %v", err)
+	}
+
+	if !called {
+		t.Fatal("callback was not called")
+	}
+}
+
 func TestStartFunctionServiceRuntimeWarmProcessUsesExistingCMDContext(t *testing.T) {
 	_, privateKey, err := ed25519.GenerateKey(nil)
 	if err != nil {

--- a/function-gateway/pkg/http/server.go
+++ b/function-gateway/pkg/http/server.go
@@ -23,24 +23,30 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"github.com/sandbox0-ai/sandbox0/pkg/observability"
 	httpobs "github.com/sandbox0-ai/sandbox0/pkg/observability/http"
+	"github.com/sandbox0-ai/sandbox0/pkg/pglock"
 	"go.uber.org/zap"
 )
 
+type runtimeRestoreLocker interface {
+	WithExclusive(ctx context.Context, resource string, fn func(context.Context) error) error
+}
+
 // Server represents the HTTP server for function-gateway.
 type Server struct {
-	router          *gin.Engine
-	cfg             *config.FunctionGatewayConfig
-	pool            *pgxpool.Pool
-	functionRepo    *functions.Repository
-	apiKeyRepo      *apikey.Repository
-	authMiddleware  *middleware.AuthMiddleware
-	requestLogger   *middleware.RequestLogger
-	internalAuthGen *internalauth.Generator
-	obsProvider     *observability.Provider
-	httpClient      *http.Client
-	routeLimiter    ratelimit.Limiter
-	runtimeLocks    sync.Map
-	logger          *zap.Logger
+	router              *gin.Engine
+	cfg                 *config.FunctionGatewayConfig
+	pool                *pgxpool.Pool
+	functionRepo        *functions.Repository
+	apiKeyRepo          *apikey.Repository
+	authMiddleware      *middleware.AuthMiddleware
+	requestLogger       *middleware.RequestLogger
+	internalAuthGen     *internalauth.Generator
+	obsProvider         *observability.Provider
+	httpClient          *http.Client
+	routeLimiter        ratelimit.Limiter
+	runtimeLocks        sync.Map
+	runtimeRestoreLocks runtimeRestoreLocker
+	logger              *zap.Logger
 }
 
 // NewServer creates a new HTTP server.
@@ -98,18 +104,19 @@ func NewServer(
 	}
 
 	server := &Server{
-		router:          gin.New(),
-		cfg:             cfg,
-		pool:            pool,
-		functionRepo:    functions.NewRepository(pool),
-		apiKeyRepo:      apiKeyRepo,
-		authMiddleware:  middleware.NewAuthMiddleware(apiKeyRepo, cfg.JWTSecret, jwtIssuer, logger, authMiddlewareOptions...),
-		requestLogger:   middleware.NewRequestLogger(logger),
-		internalAuthGen: internalAuthGen,
-		obsProvider:     obsProvider,
-		httpClient:      httpClient,
-		routeLimiter:    routeLimiter,
-		logger:          logger,
+		router:              gin.New(),
+		cfg:                 cfg,
+		pool:                pool,
+		functionRepo:        functions.NewRepository(pool),
+		apiKeyRepo:          apiKeyRepo,
+		authMiddleware:      middleware.NewAuthMiddleware(apiKeyRepo, cfg.JWTSecret, jwtIssuer, logger, authMiddlewareOptions...),
+		requestLogger:       middleware.NewRequestLogger(logger),
+		internalAuthGen:     internalAuthGen,
+		obsProvider:         obsProvider,
+		httpClient:          httpClient,
+		routeLimiter:        routeLimiter,
+		runtimeRestoreLocks: pglock.New(pool),
+		logger:              logger,
 	}
 
 	server.setupRoutes()

--- a/pkg/pglock/advisory.go
+++ b/pkg/pglock/advisory.go
@@ -1,0 +1,140 @@
+package pglock
+
+import (
+	"context"
+	"fmt"
+	"hash/fnv"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const defaultUnlockTimeout = 5 * time.Second
+
+// Mode selects the PostgreSQL advisory lock mode.
+type Mode int
+
+const (
+	// Exclusive blocks both shared and exclusive lockers for the same key.
+	Exclusive Mode = iota
+	// Shared allows other shared lockers and blocks exclusive lockers for the same key.
+	Shared
+)
+
+type advisoryConn interface {
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
+	Release()
+}
+
+type acquireFunc func(context.Context) (advisoryConn, error)
+
+// Locker runs callbacks while holding PostgreSQL session-level advisory locks.
+type Locker struct {
+	acquire       acquireFunc
+	unlockTimeout time.Duration
+}
+
+// Option configures a Locker.
+type Option func(*Locker)
+
+// WithUnlockTimeout sets the timeout used for best-effort unlock calls.
+func WithUnlockTimeout(timeout time.Duration) Option {
+	return func(l *Locker) {
+		if timeout > 0 {
+			l.unlockTimeout = timeout
+		}
+	}
+}
+
+// New creates a Locker backed by pgxpool. A nil pool degrades to executing
+// callbacks without locking, which keeps optional database deployments working.
+func New(pool *pgxpool.Pool, opts ...Option) *Locker {
+	var acquire acquireFunc
+	if pool != nil {
+		acquire = func(ctx context.Context) (advisoryConn, error) {
+			return pool.Acquire(ctx)
+		}
+	}
+	return newLocker(acquire, opts...)
+}
+
+func newLocker(acquire acquireFunc, opts ...Option) *Locker {
+	l := &Locker{
+		acquire:       acquire,
+		unlockTimeout: defaultUnlockTimeout,
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(l)
+		}
+	}
+	return l
+}
+
+// WithExclusive runs fn while holding an exclusive advisory lock for resource.
+func (l *Locker) WithExclusive(ctx context.Context, resource string, fn func(context.Context) error) error {
+	return l.With(ctx, resource, Exclusive, fn)
+}
+
+// WithShared runs fn while holding a shared advisory lock for resource.
+func (l *Locker) WithShared(ctx context.Context, resource string, fn func(context.Context) error) error {
+	return l.With(ctx, resource, Shared, fn)
+}
+
+// With runs fn while holding an advisory lock for resource.
+func (l *Locker) With(ctx context.Context, resource string, mode Mode, fn func(context.Context) error) error {
+	if resource == "" {
+		return runWithoutLock(ctx, fn)
+	}
+	return l.WithKey(ctx, Key(resource), mode, fn)
+}
+
+// WithKey runs fn while holding an advisory lock for key.
+func (l *Locker) WithKey(ctx context.Context, key int64, mode Mode, fn func(context.Context) error) error {
+	if fn == nil {
+		return nil
+	}
+	if l == nil || l.acquire == nil {
+		return fn(ctx)
+	}
+
+	c, err := l.acquire(ctx)
+	if err != nil {
+		return fmt.Errorf("acquire advisory lock connection: %w", err)
+	}
+	defer c.Release()
+
+	lockSQL, unlockSQL := lockStatements(mode)
+	if _, err := c.Exec(ctx, lockSQL, key); err != nil {
+		return fmt.Errorf("acquire advisory lock: %w", err)
+	}
+	defer func() {
+		unlockCtx, cancel := context.WithTimeout(context.Background(), l.unlockTimeout)
+		defer cancel()
+		_, _ = c.Exec(unlockCtx, unlockSQL, key)
+	}()
+
+	return fn(ctx)
+}
+
+// Key converts a stable resource name into a PostgreSQL advisory lock key.
+func Key(resource string) int64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(resource))
+	return int64(h.Sum64())
+}
+
+func lockStatements(mode Mode) (string, string) {
+	if mode == Shared {
+		return "SELECT pg_advisory_lock_shared($1)", "SELECT pg_advisory_unlock_shared($1)"
+	}
+	return "SELECT pg_advisory_lock($1)", "SELECT pg_advisory_unlock($1)"
+}
+
+func runWithoutLock(ctx context.Context, fn func(context.Context) error) error {
+	if fn == nil {
+		return nil
+	}
+	return fn(ctx)
+}

--- a/pkg/pglock/advisory_test.go
+++ b/pkg/pglock/advisory_test.go
@@ -1,0 +1,119 @@
+package pglock
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+type fakeConn struct {
+	execs    []fakeExec
+	released bool
+}
+
+type fakeExec struct {
+	sql  string
+	args []any
+}
+
+func (c *fakeConn) Exec(_ context.Context, sql string, arguments ...any) (pgconn.CommandTag, error) {
+	args := append([]any(nil), arguments...)
+	c.execs = append(c.execs, fakeExec{sql: sql, args: args})
+	return pgconn.CommandTag{}, nil
+}
+
+func (c *fakeConn) Release() {
+	c.released = true
+}
+
+func TestLockerWithExclusiveLocksAndUnlocks(t *testing.T) {
+	conn := &fakeConn{}
+	locker := newLocker(func(context.Context) (advisoryConn, error) {
+		return conn, nil
+	}, WithUnlockTimeout(time.Second))
+
+	called := false
+	if err := locker.WithExclusive(context.Background(), "volume-a", func(context.Context) error {
+		called = true
+		return nil
+	}); err != nil {
+		t.Fatalf("WithExclusive() error = %v", err)
+	}
+
+	if !called {
+		t.Fatal("callback was not called")
+	}
+	if !conn.released {
+		t.Fatal("connection was not released")
+	}
+	if len(conn.execs) != 2 {
+		t.Fatalf("exec count = %d, want 2", len(conn.execs))
+	}
+	if conn.execs[0].sql != "SELECT pg_advisory_lock($1)" {
+		t.Fatalf("lock sql = %q", conn.execs[0].sql)
+	}
+	if conn.execs[1].sql != "SELECT pg_advisory_unlock($1)" {
+		t.Fatalf("unlock sql = %q", conn.execs[1].sql)
+	}
+	if conn.execs[0].args[0] != Key("volume-a") || conn.execs[1].args[0] != Key("volume-a") {
+		t.Fatalf("lock args = %#v, %#v; want resource key", conn.execs[0].args, conn.execs[1].args)
+	}
+}
+
+func TestLockerWithSharedUsesSharedStatements(t *testing.T) {
+	conn := &fakeConn{}
+	locker := newLocker(func(context.Context) (advisoryConn, error) {
+		return conn, nil
+	})
+
+	if err := locker.WithShared(context.Background(), "volume-a", func(context.Context) error {
+		return nil
+	}); err != nil {
+		t.Fatalf("WithShared() error = %v", err)
+	}
+
+	if len(conn.execs) != 2 {
+		t.Fatalf("exec count = %d, want 2", len(conn.execs))
+	}
+	if conn.execs[0].sql != "SELECT pg_advisory_lock_shared($1)" {
+		t.Fatalf("lock sql = %q", conn.execs[0].sql)
+	}
+	if conn.execs[1].sql != "SELECT pg_advisory_unlock_shared($1)" {
+		t.Fatalf("unlock sql = %q", conn.execs[1].sql)
+	}
+}
+
+func TestLockerUnlocksWhenCallbackFails(t *testing.T) {
+	conn := &fakeConn{}
+	locker := newLocker(func(context.Context) (advisoryConn, error) {
+		return conn, nil
+	})
+	wantErr := errors.New("callback failed")
+
+	err := locker.WithExclusive(context.Background(), "volume-a", func(context.Context) error {
+		return wantErr
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("WithExclusive() error = %v, want %v", err, wantErr)
+	}
+	if len(conn.execs) != 2 || conn.execs[1].sql != "SELECT pg_advisory_unlock($1)" {
+		t.Fatalf("execs = %#v, want unlock after callback failure", conn.execs)
+	}
+}
+
+func TestLockerWithoutPoolRunsCallback(t *testing.T) {
+	called := false
+	locker := New(nil)
+	if err := locker.WithExclusive(context.Background(), "volume-a", func(context.Context) error {
+		called = true
+		return nil
+	}); err != nil {
+		t.Fatalf("WithExclusive() error = %v", err)
+	}
+	if !called {
+		t.Fatal("callback was not called")
+	}
+}

--- a/storage-proxy/pkg/volumelock/lock.go
+++ b/storage-proxy/pkg/volumelock/lock.go
@@ -2,14 +2,10 @@ package volumelock
 
 import (
 	"context"
-	"fmt"
-	"hash/fnv"
-	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/sandbox0-ai/sandbox0/pkg/pglock"
 )
-
-const unlockTimeout = 5 * time.Second
 
 // Barrier serializes volume mutations and bootstrap snapshots across instances.
 type Barrier interface {
@@ -19,57 +15,30 @@ type Barrier interface {
 
 // Locker implements Barrier with PostgreSQL advisory locks.
 type Locker struct {
-	pool *pgxpool.Pool
+	locks *pglock.Locker
 }
 
 func New(pool *pgxpool.Pool) *Locker {
-	return &Locker{pool: pool}
+	return &Locker{locks: pglock.New(pool)}
 }
 
 func (l *Locker) WithShared(ctx context.Context, volumeID string, fn func(context.Context) error) error {
-	return l.withLock(ctx, volumeID, true, fn)
+	if l == nil || l.locks == nil {
+		return runWithoutLock(ctx, fn)
+	}
+	return l.locks.WithShared(ctx, volumeID, fn)
 }
 
 func (l *Locker) WithExclusive(ctx context.Context, volumeID string, fn func(context.Context) error) error {
-	return l.withLock(ctx, volumeID, false, fn)
+	if l == nil || l.locks == nil {
+		return runWithoutLock(ctx, fn)
+	}
+	return l.locks.WithExclusive(ctx, volumeID, fn)
 }
 
-func (l *Locker) withLock(ctx context.Context, volumeID string, shared bool, fn func(context.Context) error) error {
+func runWithoutLock(ctx context.Context, fn func(context.Context) error) error {
 	if fn == nil {
 		return nil
 	}
-	if l == nil || l.pool == nil || volumeID == "" {
-		return fn(ctx)
-	}
-
-	conn, err := l.pool.Acquire(ctx)
-	if err != nil {
-		return fmt.Errorf("acquire advisory lock connection: %w", err)
-	}
-	defer conn.Release()
-
-	key := advisoryKey(volumeID)
-	lockSQL := "SELECT pg_advisory_lock($1)"
-	unlockSQL := "SELECT pg_advisory_unlock($1)"
-	if shared {
-		lockSQL = "SELECT pg_advisory_lock_shared($1)"
-		unlockSQL = "SELECT pg_advisory_unlock_shared($1)"
-	}
-
-	if _, err := conn.Exec(ctx, lockSQL, key); err != nil {
-		return fmt.Errorf("acquire volume advisory lock: %w", err)
-	}
-	defer func() {
-		unlockCtx, cancel := context.WithTimeout(context.Background(), unlockTimeout)
-		defer cancel()
-		_, _ = conn.Exec(unlockCtx, unlockSQL, key)
-	}()
-
 	return fn(ctx)
-}
-
-func advisoryKey(volumeID string) int64 {
-	h := fnv.New64a()
-	_, _ = h.Write([]byte(volumeID))
-	return int64(h.Sum64())
 }


### PR DESCRIPTION
## Summary
- add a shared `pkg/pglock` package for PostgreSQL advisory locks
- refactor `storage-proxy` volume locks to reuse the shared helper
- serialize function runtime restore across gateway replicas with revision-scoped advisory locks

## Why
Function runtime restore previously used only an in-process mutex, so multiple function-gateway replicas could concurrently restore the same revision. The shared advisory lock keeps the existing local mutex optimization while adding cross-replica coordination.

## Validation
- `go test ./pkg/pglock`
- `go test ./storage-proxy/pkg/volumelock`
- `go test ./function-gateway/pkg/http`
- `go test ./storage-proxy/pkg/http ./storage-proxy/pkg/fsserver ./storage-proxy/cmd/storage-proxy`
- `go test ./function-gateway/cmd/function-gateway`