### PR TITLE
Wait for function runtime health checks

### DIFF
--- a/docs/function/runtime/page.mdx
+++ b/docs/function/runtime/page.mdx
@@ -2,6 +2,12 @@
 
 Function runtime state describes the currently restored sandbox serving a function revision. Function Gateway serves production traffic from revision runtime sandboxes, not from the mutable source sandbox. When no reusable runtime exists, Function Gateway restores a runtime sandbox from the revision's template and revision-owned volumes.
 
+## Startup Readiness
+
+After Function Gateway starts a restored runtime context, it waits up to 30 seconds before sending user traffic. If the published service has `health_check.path`, the gateway polls that path with `GET` every 200 ms and considers the runtime ready only after the endpoint returns HTTP `2xx`. If no health check is configured, the gateway falls back to waiting for the service port to accept TCP connections.
+
+When readiness does not pass before the timeout, the request returns `503` and the gateway records a startup error that includes the health check URL plus the last HTTP status or request error.
+
 ## Runtime States
 
 | State | Meaning |

--- a/docs/sandbox/services/page.mdx
+++ b/docs/sandbox/services/page.mdx
@@ -19,6 +19,10 @@ Services are also the source model for Sandbox0 Functions. A publishable service
 
 Service runtime supports `cmd`, `warm_process`, and `manual`. Use `cmd` when Function Gateway should create a new command context for a restored function runtime. Use `warm_process` when the template already starts a long-lived process and the service should bind to that existing context. For Functions, `warm_process_name` must reference a `cmd` warm process alias or context ID; REPL warm processes are not valid HTTP service runtimes.
 
+### Health Check
+
+`health_check.path` is the service readiness path. For restored Function runtimes, Function Gateway polls this path with `GET` and waits for HTTP `2xx` before proxying traffic. Services without `health_check.path` use TCP listen readiness as a fallback.
+
 ### Ingress
 
 | Field | Type | Description |

--- a/function-gateway/pkg/http/runtime.go
+++ b/function-gateway/pkg/http/runtime.go
@@ -32,6 +32,8 @@ import (
 const defaultFunctionAutoResumeTimeout = 30 * time.Second
 const defaultFunctionRuntimeStartTimeout = 30 * time.Second
 const functionRuntimeRestoreLockPrefix = "function-runtime-restore:"
+const functionServiceReadinessProbeInterval = 200 * time.Millisecond
+const functionServiceReadinessTCPTimeout = 500 * time.Millisecond
 
 type functionRouteMatch struct {
 	route         *mgr.SandboxAppServiceRoute
@@ -640,7 +642,7 @@ func (s *Server) ensureFunctionServiceRuntime(ctx context.Context, fn *functions
 	}
 	startCtx, cancel := context.WithTimeout(ctx, defaultFunctionRuntimeStartTimeout)
 	defer cancel()
-	if err := waitForFunctionServicePort(startCtx, sandbox.InternalAddr, service.Port); err != nil {
+	if err := s.waitForFunctionServiceReadiness(startCtx, sandbox.InternalAddr, service); err != nil {
 		return "", err
 	}
 	return contextID, nil
@@ -922,6 +924,52 @@ func isFunctionRuntimeStatus(err error, status int) bool {
 	return false
 }
 
+func (s *Server) waitForFunctionServiceReadiness(ctx context.Context, internalAddr string, service mgr.SandboxAppService) error {
+	if service.HealthCheck != nil && strings.TrimSpace(service.HealthCheck.Path) != "" {
+		return s.waitForFunctionServiceHTTPHealth(ctx, internalAddr, service.Port, service.HealthCheck.Path)
+	}
+	return waitForFunctionServicePort(ctx, internalAddr, service.Port)
+}
+
+func (s *Server) waitForFunctionServiceHTTPHealth(ctx context.Context, internalAddr string, port int, healthPath string) error {
+	healthURL, err := functionServiceHealthURL(internalAddr, port, healthPath)
+	if err != nil {
+		return err
+	}
+	healthClient := *s.outboundHTTPClient()
+	healthClient.CheckRedirect = func(_ *nethttp.Request, _ []*nethttp.Request) error {
+		return nethttp.ErrUseLastResponse
+	}
+	ticker := time.NewTicker(functionServiceReadinessProbeInterval)
+	defer ticker.Stop()
+	var lastErr error
+	for {
+		req, err := nethttp.NewRequestWithContext(ctx, nethttp.MethodGet, healthURL.String(), nil)
+		if err != nil {
+			return err
+		}
+		resp, err := healthClient.Do(req)
+		if err == nil {
+			if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+				_ = resp.Body.Close()
+				return nil
+			}
+			lastErr = fmt.Errorf("health check returned HTTP %d", resp.StatusCode)
+			_ = resp.Body.Close()
+		} else {
+			lastErr = err
+		}
+		select {
+		case <-ctx.Done():
+			if lastErr == nil {
+				lastErr = ctx.Err()
+			}
+			return fmt.Errorf("function service health check %s did not return HTTP 2xx before timeout: %w", healthURL.String(), lastErr)
+		case <-ticker.C:
+		}
+	}
+}
+
 func waitForFunctionServicePort(ctx context.Context, internalAddr string, port int) error {
 	targetURL, err := withPort(internalAddr, port)
 	if err != nil {
@@ -931,11 +979,11 @@ func waitForFunctionServicePort(ctx context.Context, internalAddr string, port i
 	if address == "" {
 		return fmt.Errorf("function service target address is empty")
 	}
-	ticker := time.NewTicker(200 * time.Millisecond)
+	ticker := time.NewTicker(functionServiceReadinessProbeInterval)
 	defer ticker.Stop()
 	var lastErr error
 	for {
-		conn, err := net.DialTimeout("tcp", address, 500*time.Millisecond)
+		conn, err := net.DialTimeout("tcp", address, functionServiceReadinessTCPTimeout)
 		if err == nil {
 			_ = conn.Close()
 			return nil
@@ -947,6 +995,26 @@ func waitForFunctionServicePort(ctx context.Context, internalAddr string, port i
 		case <-ticker.C:
 		}
 	}
+}
+
+func functionServiceHealthURL(internalAddr string, port int, healthPath string) (*url.URL, error) {
+	targetURL, err := withPort(internalAddr, port)
+	if err != nil {
+		return nil, err
+	}
+	path := strings.TrimSpace(healthPath)
+	if path == "" {
+		return nil, fmt.Errorf("function service health check path is empty")
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	targetURL.Path = path
+	targetURL.RawPath = ""
+	targetURL.RawQuery = ""
+	targetURL.ForceQuery = false
+	targetURL.Fragment = ""
+	return targetURL, nil
 }
 
 func (s *Server) resumeSandboxViaClusterGateway(ctx context.Context, sandboxID, teamID, userID string) error {

--- a/function-gateway/pkg/http/runtime_test.go
+++ b/function-gateway/pkg/http/runtime_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -267,6 +268,111 @@ func TestWithRevisionRuntimeDistributedLockFallsBackWithoutLocker(t *testing.T) 
 
 	if !called {
 		t.Fatal("callback was not called")
+	}
+}
+
+func TestWaitForFunctionServiceReadinessFallsBackToTCP(t *testing.T) {
+	var requests int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requests, 1)
+		http.NotFound(w, r)
+	}))
+	defer upstream.Close()
+	port, err := portFromURL(upstream.URL)
+	if err != nil {
+		t.Fatalf("parse upstream port: %v", err)
+	}
+
+	service := mgr.SandboxAppService{Port: port}
+	if err := (&Server{}).waitForFunctionServiceReadiness(context.Background(), upstream.URL, service); err != nil {
+		t.Fatalf("waitForFunctionServiceReadiness() error = %v", err)
+	}
+	if got := atomic.LoadInt32(&requests); got != 0 {
+		t.Fatalf("health requests = %d, want TCP fallback without HTTP requests", got)
+	}
+}
+
+func TestWaitForFunctionServiceReadinessHTTPHealthSuccess(t *testing.T) {
+	var requests int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/ready" {
+			t.Errorf("path = %s, want /ready", r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		if atomic.AddInt32(&requests, 1) == 1 {
+			http.Error(w, "starting", http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+	port, err := portFromURL(upstream.URL)
+	if err != nil {
+		t.Fatalf("parse upstream port: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	service := mgr.SandboxAppService{
+		Port:        port,
+		HealthCheck: &mgr.SandboxAppServiceHealth{Path: "/ready"},
+	}
+	if err := (&Server{}).waitForFunctionServiceReadiness(ctx, upstream.URL, service); err != nil {
+		t.Fatalf("waitForFunctionServiceReadiness() error = %v", err)
+	}
+	if got := atomic.LoadInt32(&requests); got < 2 {
+		t.Fatalf("health requests = %d, want retry before success", got)
+	}
+}
+
+func TestWaitForFunctionServiceReadinessHTTPHealthFailure(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not ready", http.StatusInternalServerError)
+	}))
+	defer upstream.Close()
+	port, err := portFromURL(upstream.URL)
+	if err != nil {
+		t.Fatalf("parse upstream port: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	service := mgr.SandboxAppService{
+		Port:        port,
+		HealthCheck: &mgr.SandboxAppServiceHealth{Path: "/ready"},
+	}
+	err = (&Server{}).waitForFunctionServiceReadiness(ctx, upstream.URL, service)
+	if err == nil {
+		t.Fatal("waitForFunctionServiceReadiness() error = nil, want health failure")
+	}
+	if !strings.Contains(err.Error(), "HTTP 500") || !strings.Contains(err.Error(), "did not return HTTP 2xx") {
+		t.Fatalf("error = %q, want readable HTTP readiness failure", err.Error())
+	}
+}
+
+func TestWaitForFunctionServiceReadinessHTTPHealthTimeout(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer upstream.Close()
+	port, err := portFromURL(upstream.URL)
+	if err != nil {
+		t.Fatalf("parse upstream port: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	service := mgr.SandboxAppService{
+		Port:        port,
+		HealthCheck: &mgr.SandboxAppServiceHealth{Path: "/ready"},
+	}
+	err = (&Server{}).waitForFunctionServiceReadiness(ctx, upstream.URL, service)
+	if err == nil {
+		t.Fatal("waitForFunctionServiceReadiness() error = nil, want timeout")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) || !strings.Contains(err.Error(), "did not return HTTP 2xx") {
+		t.Fatalf("error = %q, want readiness timeout with context deadline", err.Error())
 	}
 }
 


### PR DESCRIPTION
## Summary
- Wait for configured `health_check.path` to return HTTP 2xx before serving restored Function runtime traffic.
- Keep TCP listen readiness as the fallback when no health check is configured.
- Document startup readiness behavior and add tests for TCP fallback, HTTP success, HTTP failure, and timeout.

## Validation
- `go test ./function-gateway/pkg/http`
- `GOTOOLCHAIN=go1.25.0+auto go test -race -cover ./function-gateway/...`