### PR TITLE
Add function runtime autoscaler

### DIFF
--- a/docs/function/page.mdx
+++ b/docs/function/page.mdx
@@ -22,7 +22,7 @@ The `production` alias is the serving pointer used by the function host. Creatin
 
 Function traffic is handled by `function-gateway`. The gateway resolves the host to a function, loads the `production` revision, enforces the revision's service route policy, and proxies the request to the service port.
 
-Function serving is revision-first. The gateway does not proxy production traffic to the mutable source sandbox. When no reusable runtime exists, the gateway claims a new runtime sandbox from the revision's template, mounts the revision-owned volumes, starts the service runtime command or binds to the referenced warm process, and reuses that runtime for later requests. Changes made to the source sandbox after publishing require a new revision before they affect the function host.
+Function serving is revision-first. The gateway does not proxy production traffic to the mutable source sandbox. When no reusable runtime exists, the gateway claims a new runtime sandbox from the revision's template, mounts the revision-owned volumes, starts the service runtime command or binds to the referenced warm process, and reuses runtime instances for later requests. The runtime pool scales out up to the function's `max_active` setting when local in-flight requests reach the soft `target_concurrency` target. Changes made to the source sandbox after publishing require a new revision before they affect the function host.
 
 ## Publishable Services
 

--- a/docs/function/publish/page.mdx
+++ b/docs/function/publish/page.mdx
@@ -200,6 +200,7 @@ Creating a function creates the stable function record, revision 1, and the `pro
     sandbox.ID,
     "api",
     sandbox0.WithFunctionName("my-api"),
+    sandbox0.WithFunctionAutoscaling(sandbox0.FunctionAutoscaling(1, 4, 20, 300)),
 )
 if err != nil {
     log.Fatal(err)
@@ -209,10 +210,18 @@ fmt.Printf("function URL: %s\\n", result.Function.URL)`
     {
       label: "Python",
       language: "python",
-      code: `result = client.functions.create_from_sandbox(
+      code: `from sandbox0 import FunctionAutoscaling
+
+result = client.functions.create_from_sandbox(
     sandbox.id,
     "api",
     name="my-api",
+    autoscaling=FunctionAutoscaling(
+        min_warm=1,
+        max_active=4,
+        target_concurrency=20,
+        scale_down_after_seconds=300,
+    ),
 )
 print(f"function URL: {result.function.url}")`
     },
@@ -222,14 +231,27 @@ print(f"function URL: {result.function.url}")`
       code: `const result = await client.functions.createFromSandbox(
     sandbox.id,
     'api',
-    { name: 'my-api' },
+    {
+        name: 'my-api',
+        autoscaling: {
+            minWarm: 1,
+            maxActive: 4,
+            targetConcurrency: 20,
+            scaleDownAfterSeconds: 300,
+        },
+    },
 );
 console.log('function URL:', result.function.url);`
     },
     {
       label: "CLI",
       language: "bash",
-      code: `s0 function create sb_abc123 api --name my-api`
+      code: `s0 function create sb_abc123 api \\
+    --name my-api \\
+    --min-warm 1 \\
+    --max-active 4 \\
+    --target-concurrency 20 \\
+    --scale-down-after-seconds 300`
     }
   ]}
 />

--- a/docs/function/runtime/page.mdx
+++ b/docs/function/runtime/page.mdx
@@ -1,6 +1,86 @@
 # Function Runtime
 
-Function runtime state describes the currently restored sandbox serving a function revision. Function Gateway serves production traffic from revision runtime sandboxes, not from the mutable source sandbox. When no reusable runtime exists, Function Gateway restores a runtime sandbox from the revision's template and revision-owned volumes.
+Function runtime state describes the restored sandbox pool serving a function revision. Function Gateway serves production traffic from revision runtime sandboxes, not from the mutable source sandbox. When no reusable runtime exists, Function Gateway restores a runtime sandbox from the revision's template and revision-owned volumes.
+
+## Autoscaling
+
+Function Gateway maintains a runtime pool for the active revision. Each runtime instance is a restored sandbox plus the process context serving the published service. Requests are routed to ready instances using local in-flight request counts and the function's autoscaling settings.
+
+| Setting | Meaning |
+|---------|---------|
+| `min_warm` | Minimum ready runtime sandboxes kept after traffic has created capacity |
+| `max_active` | Hard upper bound for active runtime sandboxes for the function |
+| `target_concurrency` | Soft per-runtime in-flight request target used for routing and scale-out |
+| `scale_down_after_seconds` | Idle time before extra runtime sandboxes above `min_warm` are removed |
+
+`target_concurrency` is not a strong distributed single-instance concurrency semaphore. Multiple Function Gateway replicas can still route to the same runtime at the same time. The hard limit is `max_active`, which bounds the runtime pool size.
+
+## Update Autoscaling
+
+<Endpoint method="PUT">
+/api/v1/functions/{'{id}'}
+</Endpoint>
+
+Autoscaling updates change the runtime pool policy for the function. The gateway uses the new `target_concurrency` for routing and scale-out decisions, and `max_active` remains the hard pool-size limit.
+
+<Tabs
+  tabs={[
+    {
+      label: "Go",
+      language: "go",
+      code: `fn, err := client.UpdateFunctionWithOptions(
+    ctx,
+    functionID,
+    sandbox0.WithFunctionUpdateAutoscaling(sandbox0.FunctionAutoscaling(1, 4, 20, 300)),
+)
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Printf("max active=%d\\n", fn.Autoscaling.MaxActive)`
+    },
+    {
+      label: "Python",
+      language: "python",
+      code: `from sandbox0 import FunctionAutoscaling
+from sandbox0.apispec.models.function_update_request import FunctionUpdateRequest
+
+fn = client.functions.update(
+    function_id,
+    FunctionUpdateRequest(
+        autoscaling=FunctionAutoscaling(
+            min_warm=1,
+            max_active=4,
+            target_concurrency=20,
+            scale_down_after_seconds=300,
+        ),
+    ),
+)
+print(f"max active={fn.autoscaling.max_active}")`
+    },
+    {
+      label: "TypeScript",
+      language: "typescript",
+      code: `const fn = await client.functions.update(functionId, {
+    autoscaling: {
+        minWarm: 1,
+        maxActive: 4,
+        targetConcurrency: 20,
+        scaleDownAfterSeconds: 300,
+    },
+});
+console.log('max active=', fn.autoscaling.maxActive);`
+    },
+    {
+      label: "CLI",
+      language: "bash",
+      code: `s0 function update fn_abc123 \\
+    --min-warm 1 \\
+    --max-active 4 \\
+    --target-concurrency 20 \\
+    --scale-down-after-seconds 300`
+    }
+  ]}
+/>
 
 ## Startup Readiness
 
@@ -12,11 +92,11 @@ When readiness does not pass before the timeout, the request returns `503` and t
 
 | State | Meaning |
 |-------|---------|
-| `idle` | No restored runtime sandbox is currently recorded for the active revision |
-| `active` | A restored runtime sandbox is recorded for the active revision |
+| `idle` | No ready runtime sandbox is currently recorded for the active revision |
+| `active` | At least one ready runtime sandbox is recorded for the active revision |
 | `disabled` | The function is disabled and does not serve host traffic |
 
-`restart` and `recycle` both delete the current restored runtime sandbox when one exists and clear the runtime mapping. The next function request starts a fresh runtime from the active revision.
+`restart` and `recycle` both delete the current restored runtime pool when one exists and clear the runtime mapping. The next function request starts fresh runtime instances from the active revision.
 
 ## Get Runtime Status
 

--- a/function-gateway/pkg/http/autoscaler.go
+++ b/function-gateway/pkg/http/autoscaler.go
@@ -1,0 +1,399 @@
+// Function autoscaling intentionally treats per-instance concurrency as a soft
+// routing and scale-out signal. Sandbox0 does not currently enforce a strong
+// distributed single-instance concurrency semaphore; max_active remains the hard
+// pool-level capacity boundary and target_concurrency is best-effort per gateway
+// replica until a future serving-path admission mechanism is added.
+package http
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	mgr "github.com/sandbox0-ai/sandbox0/manager/pkg/service"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/functions"
+	"go.uber.org/zap"
+)
+
+const functionAutoscalerScaleDownInterval = 30 * time.Second
+
+type functionAutoscaler struct {
+	server *Server
+	logger *zap.Logger
+
+	mu       sync.Mutex
+	inflight map[string]int
+}
+
+type functionRuntimeLease struct {
+	Sandbox  *mgr.Sandbox
+	Revision *functions.Revision
+	Instance *functions.RuntimeInstance
+
+	release func()
+}
+
+func newFunctionAutoscaler(server *Server) *functionAutoscaler {
+	logger := zap.NewNop()
+	if server != nil && server.logger != nil {
+		logger = server.logger
+	}
+	return &functionAutoscaler{
+		server:   server,
+		logger:   logger,
+		inflight: make(map[string]int),
+	}
+}
+
+func (l *functionRuntimeLease) Done() {
+	if l != nil && l.release != nil {
+		l.release()
+		l.release = nil
+	}
+}
+
+func (a *functionAutoscaler) Run(ctx context.Context) {
+	if a == nil || a.server == nil || a.server.functionRepo == nil {
+		return
+	}
+	ticker := time.NewTicker(functionAutoscalerScaleDownInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			a.scaleDownIdleRuntimes(ctx)
+		}
+	}
+}
+
+func (a *functionAutoscaler) scaleDownIdleRuntimes(ctx context.Context) {
+	instances, err := a.server.functionRepo.ListRuntimeScaleDownCandidates(ctx, 50)
+	if err != nil {
+		a.logger.Warn("Failed to list function runtime scale-down candidates", zap.Error(err))
+		return
+	}
+	for _, inst := range instances {
+		if inst == nil || strings.TrimSpace(inst.SandboxID) == "" {
+			continue
+		}
+		if a.hasLocalInflight(inst.SandboxID) {
+			continue
+		}
+		if err := a.server.functionRepo.MarkRuntimeInstanceDraining(ctx, inst.TeamID, inst.FunctionID, inst.RevisionID, inst.ID); err != nil {
+			if !errorsIsFunctionNotFound(err) {
+				a.logger.Warn("Failed to mark function runtime instance draining",
+					zap.String("function_id", inst.FunctionID),
+					zap.String("revision_id", inst.RevisionID),
+					zap.String("runtime_instance_id", inst.ID),
+					zap.Error(err),
+				)
+			}
+			continue
+		}
+		deleteCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		err := a.server.deleteSandboxViaClusterGateway(deleteCtx, inst.SandboxID, inst.TeamID, "")
+		cancel()
+		if err != nil {
+			a.markRuntimeInstanceFailed(context.Background(), &functions.Function{ID: inst.FunctionID, TeamID: inst.TeamID}, &functions.Revision{ID: inst.RevisionID, FunctionID: inst.FunctionID, TeamID: inst.TeamID}, inst, err)
+			a.logger.Warn("Failed to delete idle function runtime sandbox",
+				zap.String("function_id", inst.FunctionID),
+				zap.String("revision_id", inst.RevisionID),
+				zap.String("runtime_instance_id", inst.ID),
+				zap.String("runtime_sandbox_id", inst.SandboxID),
+				zap.Error(err),
+			)
+			continue
+		}
+		if err := a.server.functionRepo.DeleteRuntimeInstance(ctx, inst.TeamID, inst.FunctionID, inst.RevisionID, inst.ID); err != nil && !errorsIsFunctionNotFound(err) {
+			a.logger.Warn("Failed to delete scaled-down function runtime instance",
+				zap.String("function_id", inst.FunctionID),
+				zap.String("revision_id", inst.RevisionID),
+				zap.String("runtime_instance_id", inst.ID),
+				zap.Error(err),
+			)
+		}
+	}
+}
+
+func (a *functionAutoscaler) acquire(ctx context.Context, fn *functions.Function, rev *functions.Revision, service mgr.SandboxAppService) (*functionRuntimeLease, *functions.Revision, error) {
+	if a == nil || a.server == nil || a.server.functionRepo == nil {
+		return nil, rev, fmt.Errorf("function repository is not configured")
+	}
+	if fn == nil || rev == nil {
+		return nil, rev, fmt.Errorf("function revision is missing")
+	}
+	cfg := functions.NormalizeAutoscaling(fn.Autoscaling)
+	latest, err := a.server.functionRepo.GetRevision(ctx, fn.TeamID, fn.ID, rev.ID)
+	if err == nil {
+		rev = latest
+	} else if err != nil && !errorsIsFunctionNotFound(err) {
+		return nil, rev, err
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < 2; attempt++ {
+		instances, err := a.server.functionRepo.ListRuntimeInstances(ctx, fn.TeamID, fn.ID, rev.ID)
+		if err != nil {
+			return nil, rev, err
+		}
+		if inst, release := a.reserveReady(instances, cfg, false); inst != nil {
+			lease, err := a.acquireExistingInstance(ctx, fn, rev, inst, service, release)
+			if err == nil {
+				return lease, rev, nil
+			}
+			lastErr = err
+			continue
+		}
+		if activeRuntimeInstanceCount(instances) < cfg.MaxActive {
+			lease, updated, err := a.createRuntimeInstance(ctx, fn, rev, service, cfg)
+			if err == nil {
+				return lease, updated, nil
+			}
+			lastErr = err
+			continue
+		}
+		if inst, release := a.reserveReady(instances, cfg, true); inst != nil {
+			lease, err := a.acquireExistingInstance(ctx, fn, rev, inst, service, release)
+			if err == nil {
+				return lease, rev, nil
+			}
+			lastErr = err
+		}
+	}
+	if lastErr != nil {
+		return nil, rev, lastErr
+	}
+	return nil, rev, fmt.Errorf("function runtime capacity is unavailable")
+}
+
+func (a *functionAutoscaler) reserveReady(instances []*functions.RuntimeInstance, cfg functions.Autoscaling, allowOverTarget bool) (*functions.RuntimeInstance, func()) {
+	cfg = functions.NormalizeAutoscaling(cfg)
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	var selected *functions.RuntimeInstance
+	selectedInflight := 0
+	for _, inst := range instances {
+		if !runtimeInstanceReady(inst) {
+			continue
+		}
+		current := a.inflight[inst.SandboxID]
+		if !allowOverTarget && current >= cfg.TargetConcurrency {
+			continue
+		}
+		if selected == nil || current < selectedInflight {
+			selected = inst
+			selectedInflight = current
+		}
+	}
+	if selected == nil {
+		return nil, nil
+	}
+	a.inflight[selected.SandboxID]++
+	return selected, a.releaseFunc(selected.SandboxID)
+}
+
+func (a *functionAutoscaler) releaseFunc(sandboxID string) func() {
+	return func() {
+		a.mu.Lock()
+		defer a.mu.Unlock()
+		current := a.inflight[sandboxID]
+		if current <= 1 {
+			delete(a.inflight, sandboxID)
+			return
+		}
+		a.inflight[sandboxID] = current - 1
+	}
+}
+
+func (a *functionAutoscaler) hasLocalInflight(sandboxID string) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.inflight[sandboxID] > 0
+}
+
+func (a *functionAutoscaler) acquireExistingInstance(ctx context.Context, fn *functions.Function, rev *functions.Revision, inst *functions.RuntimeInstance, service mgr.SandboxAppService, release func()) (*functionRuntimeLease, error) {
+	if inst == nil {
+		if release != nil {
+			release()
+		}
+		return nil, fmt.Errorf("function runtime instance is missing")
+	}
+	lease, err := a.prepareInstance(ctx, fn, rev, inst, service, release)
+	if err != nil {
+		return nil, err
+	}
+	if err := a.server.functionRepo.MarkRuntimeInstanceUsed(ctx, fn.TeamID, fn.ID, rev.ID, inst.ID); err != nil {
+		lease.Done()
+		return nil, err
+	}
+	return lease, nil
+}
+
+func (a *functionAutoscaler) createRuntimeInstance(ctx context.Context, fn *functions.Function, rev *functions.Revision, service mgr.SandboxAppService, cfg functions.Autoscaling) (*functionRuntimeLease, *functions.Revision, error) {
+	lock := a.server.revisionRuntimeLock(rev.ID)
+	lock.Lock()
+	defer lock.Unlock()
+
+	currentRev := rev
+	var lease *functionRuntimeLease
+	err := a.server.withRevisionRuntimeDistributedLock(ctx, rev.ID, func(runCtx context.Context) error {
+		latest, err := a.server.functionRepo.GetRevision(runCtx, fn.TeamID, fn.ID, rev.ID)
+		if err == nil {
+			currentRev = latest
+		} else if err != nil && !errorsIsFunctionNotFound(err) {
+			return err
+		}
+
+		instances, err := a.server.functionRepo.ListRuntimeInstances(runCtx, fn.TeamID, fn.ID, currentRev.ID)
+		if err != nil {
+			return err
+		}
+		if inst, release := a.reserveReady(instances, cfg, false); inst != nil {
+			selected, err := a.acquireExistingInstance(runCtx, fn, currentRev, inst, service, release)
+			if err != nil {
+				return err
+			}
+			lease = selected
+			return nil
+		}
+		if activeRuntimeInstanceCount(instances) >= cfg.MaxActive {
+			if inst, release := a.reserveReady(instances, cfg, true); inst != nil {
+				selected, err := a.acquireExistingInstance(runCtx, fn, currentRev, inst, service, release)
+				if err != nil {
+					return err
+				}
+				lease = selected
+				return nil
+			}
+			return fmt.Errorf("function runtime capacity is starting")
+		}
+
+		claim, err := a.server.claimFunctionSandboxViaClusterGateway(runCtx, fn, currentRev, service)
+		if err != nil {
+			return err
+		}
+		inst, err := a.server.functionRepo.CreateRuntimeInstance(runCtx, &functions.RuntimeInstance{
+			TeamID:     fn.TeamID,
+			FunctionID: fn.ID,
+			RevisionID: currentRev.ID,
+			SandboxID:  claim.SandboxID,
+			State:      functions.RuntimeInstanceStateStarting,
+		})
+		if err != nil {
+			a.server.deleteFunctionRuntimeSandboxBestEffort(fn, currentRev, claim.SandboxID, "runtime instance registration failed")
+			return err
+		}
+		release := a.reserveSandbox(claim.SandboxID)
+		selected, err := a.prepareInstance(runCtx, fn, currentRev, inst, service, release)
+		if err != nil {
+			a.markRuntimeInstanceFailed(context.Background(), fn, currentRev, inst, err)
+			a.server.deleteFunctionRuntimeSandboxBestEffort(fn, currentRev, claim.SandboxID, "runtime startup failed")
+			return err
+		}
+		lease = selected
+		currentRev.RuntimeSandboxID = &selected.Instance.SandboxID
+		currentRev.RuntimeContextID = selected.Instance.ContextID
+		now := time.Now().UTC()
+		currentRev.RuntimeUpdatedAt = &now
+		return nil
+	})
+	if err != nil {
+		if lease != nil {
+			lease.Done()
+		}
+		return nil, currentRev, err
+	}
+	return lease, currentRev, nil
+}
+
+func (a *functionAutoscaler) reserveSandbox(sandboxID string) func() {
+	a.mu.Lock()
+	a.inflight[sandboxID]++
+	a.mu.Unlock()
+	return a.releaseFunc(sandboxID)
+}
+
+func (a *functionAutoscaler) prepareInstance(ctx context.Context, fn *functions.Function, rev *functions.Revision, inst *functions.RuntimeInstance, service mgr.SandboxAppService, release func()) (*functionRuntimeLease, error) {
+	sandboxID := strings.TrimSpace(inst.SandboxID)
+	if sandboxID == "" {
+		if release != nil {
+			release()
+		}
+		return nil, fmt.Errorf("function runtime instance is missing sandbox id")
+	}
+	sandbox, err := a.server.getSandboxFromClusterGateway(ctx, sandboxID)
+	if err != nil {
+		if release != nil {
+			release()
+		}
+		if isPublishNotFound(err) {
+			a.markRuntimeInstanceFailed(context.Background(), fn, rev, inst, err)
+		}
+		return nil, err
+	}
+	instanceRev := *rev
+	instanceRev.RuntimeSandboxID = &sandbox.ID
+	instanceRev.RuntimeContextID = inst.ContextID
+	contextID, err := a.server.ensureFunctionServiceRuntime(ctx, fn, &instanceRev, sandbox, service)
+	if err != nil {
+		if release != nil {
+			release()
+		}
+		a.markRuntimeInstanceFailed(context.Background(), fn, rev, inst, err)
+		return nil, err
+	}
+	ready, err := a.server.functionRepo.MarkRuntimeInstanceReady(ctx, fn.TeamID, fn.ID, rev.ID, inst.ID, sandbox.ID, contextID)
+	if err != nil {
+		if release != nil {
+			release()
+		}
+		return nil, err
+	}
+	return &functionRuntimeLease{
+		Sandbox:  sandbox,
+		Revision: rev,
+		Instance: ready,
+		release:  release,
+	}, nil
+}
+
+func (a *functionAutoscaler) markRuntimeInstanceFailed(ctx context.Context, fn *functions.Function, rev *functions.Revision, inst *functions.RuntimeInstance, err error) {
+	if a == nil || a.server == nil || a.server.functionRepo == nil || fn == nil || rev == nil || inst == nil {
+		return
+	}
+	message := ""
+	if err != nil {
+		message = err.Error()
+	}
+	if markErr := a.server.functionRepo.MarkRuntimeInstanceFailed(ctx, fn.TeamID, fn.ID, rev.ID, inst.ID, message); markErr != nil && !errorsIsFunctionNotFound(markErr) {
+		a.logger.Warn("Failed to mark function runtime instance failed",
+			zap.String("function_id", fn.ID),
+			zap.String("revision_id", rev.ID),
+			zap.String("runtime_instance_id", inst.ID),
+			zap.Error(markErr),
+		)
+	}
+}
+
+func runtimeInstanceReady(inst *functions.RuntimeInstance) bool {
+	return inst != nil && inst.State == functions.RuntimeInstanceStateReady && strings.TrimSpace(inst.SandboxID) != ""
+}
+
+func activeRuntimeInstanceCount(instances []*functions.RuntimeInstance) int {
+	count := 0
+	for _, inst := range instances {
+		if inst == nil {
+			continue
+		}
+		switch inst.State {
+		case functions.RuntimeInstanceStateStarting, functions.RuntimeInstanceStateReady, functions.RuntimeInstanceStateDraining:
+			count++
+		}
+	}
+	return count
+}

--- a/function-gateway/pkg/http/autoscaler_test.go
+++ b/function-gateway/pkg/http/autoscaler_test.go
@@ -1,0 +1,91 @@
+package http
+
+import (
+	"testing"
+
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/functions"
+)
+
+func TestFunctionAutoscalerReserveReadyHonorsTargetConcurrency(t *testing.T) {
+	autoscaler := newFunctionAutoscaler(&Server{})
+	instances := []*functions.RuntimeInstance{
+		{
+			ID:        "inst-a",
+			SandboxID: "sandbox-a",
+			State:     functions.RuntimeInstanceStateReady,
+		},
+		{
+			ID:        "inst-b",
+			SandboxID: "sandbox-b",
+			State:     functions.RuntimeInstanceStateReady,
+		},
+	}
+	cfg := functions.Autoscaling{MaxActive: 2, TargetConcurrency: 1, ScaleDownAfterSeconds: 300}
+
+	first, firstRelease := autoscaler.reserveReady(instances, cfg, false)
+	if first == nil {
+		t.Fatal("first reservation is nil")
+	}
+	defer firstRelease()
+	second, secondRelease := autoscaler.reserveReady(instances, cfg, false)
+	if second == nil {
+		t.Fatal("second reservation is nil")
+	}
+	defer secondRelease()
+	if first.SandboxID == second.SandboxID {
+		t.Fatalf("second reservation used %q, want the other ready runtime", second.SandboxID)
+	}
+	third, thirdRelease := autoscaler.reserveReady(instances, cfg, false)
+	if third != nil {
+		thirdRelease()
+		t.Fatalf("third reservation = %+v, want nil when all local runtimes hit target", third)
+	}
+}
+
+func TestFunctionAutoscalerReserveReadyCanOverflowSoftTarget(t *testing.T) {
+	autoscaler := newFunctionAutoscaler(&Server{})
+	instances := []*functions.RuntimeInstance{{
+		ID:        "inst-a",
+		SandboxID: "sandbox-a",
+		State:     functions.RuntimeInstanceStateReady,
+	}}
+	cfg := functions.Autoscaling{MaxActive: 1, TargetConcurrency: 1, ScaleDownAfterSeconds: 300}
+
+	first, firstRelease := autoscaler.reserveReady(instances, cfg, false)
+	if first == nil {
+		t.Fatal("first reservation is nil")
+	}
+	defer firstRelease()
+	second, secondRelease := autoscaler.reserveReady(instances, cfg, true)
+	if second == nil {
+		t.Fatal("second reservation is nil with allowOverTarget")
+	}
+	defer secondRelease()
+	if second.SandboxID != "sandbox-a" {
+		t.Fatalf("second sandbox = %q, want sandbox-a", second.SandboxID)
+	}
+}
+
+func TestFunctionAutoscalerTracksLocalInflight(t *testing.T) {
+	autoscaler := newFunctionAutoscaler(&Server{})
+	release := autoscaler.reserveSandbox("sandbox-a")
+	if !autoscaler.hasLocalInflight("sandbox-a") {
+		t.Fatal("hasLocalInflight() = false, want true")
+	}
+	release()
+	if autoscaler.hasLocalInflight("sandbox-a") {
+		t.Fatal("hasLocalInflight() = true after release, want false")
+	}
+}
+
+func TestActiveRuntimeInstanceCountIncludesAllocatedCapacity(t *testing.T) {
+	instances := []*functions.RuntimeInstance{
+		{State: functions.RuntimeInstanceStateStarting},
+		{State: functions.RuntimeInstanceStateReady},
+		{State: functions.RuntimeInstanceStateDraining},
+		{State: functions.RuntimeInstanceStateFailed},
+	}
+	if got := activeRuntimeInstanceCount(instances); got != 3 {
+		t.Fatalf("activeRuntimeInstanceCount() = %d, want 3", got)
+	}
+}

--- a/function-gateway/pkg/http/runtime.go
+++ b/function-gateway/pkg/http/runtime.go
@@ -95,11 +95,17 @@ func (s *Server) serveFunctionRevision(c *gin.Context, fn *functions.Function, r
 		return
 	}
 
-	sandbox, rev, err := s.resolveFunctionSandbox(c.Request.Context(), fn, rev, service)
+	lease, rev, err := s.acquireFunctionRuntime(c.Request.Context(), fn, rev, service)
 	if err != nil {
 		s.writeFunctionRuntimeError(c, fn, rev, "function sandbox is not available", err)
 		return
 	}
+	if lease == nil || lease.Sandbox == nil {
+		spec.JSONError(c, nethttp.StatusServiceUnavailable, spec.CodeUnavailable, "function sandbox is not available")
+		return
+	}
+	defer lease.Done()
+	sandbox := lease.Sandbox
 	if sandbox.TeamID != fn.TeamID {
 		spec.JSONError(c, nethttp.StatusServiceUnavailable, spec.CodeUnavailable, "function sandbox is invalid")
 		return
@@ -413,85 +419,23 @@ func functionSandboxWantsPaused(sandbox *mgr.Sandbox) bool {
 }
 
 func (s *Server) resolveFunctionSandbox(ctx context.Context, fn *functions.Function, rev *functions.Revision, service mgr.SandboxAppService) (*mgr.Sandbox, *functions.Revision, error) {
-	return s.ensureRestoredFunctionSandbox(ctx, fn, rev, service)
+	lease, updated, err := s.acquireFunctionRuntime(ctx, fn, rev, service)
+	if err != nil {
+		return nil, updated, err
+	}
+	if lease == nil {
+		return nil, updated, fmt.Errorf("function runtime lease is empty")
+	}
+	defer lease.Done()
+	return lease.Sandbox, updated, nil
 }
 
-func (s *Server) ensureRestoredFunctionSandbox(ctx context.Context, fn *functions.Function, rev *functions.Revision, service mgr.SandboxAppService) (*mgr.Sandbox, *functions.Revision, error) {
-	lock := s.revisionRuntimeLock(rev.ID)
-	lock.Lock()
-	defer lock.Unlock()
-
-	currentRev := rev
-	var sandbox *mgr.Sandbox
-	err := s.withRevisionRuntimeDistributedLock(ctx, rev.ID, func(runCtx context.Context) error {
-		var restoreErr error
-		sandbox, currentRev, restoreErr = s.ensureRestoredFunctionSandboxLocked(runCtx, fn, currentRev, service)
-		return restoreErr
-	})
-	if err != nil {
-		return nil, currentRev, err
+func (s *Server) acquireFunctionRuntime(ctx context.Context, fn *functions.Function, rev *functions.Revision, service mgr.SandboxAppService) (*functionRuntimeLease, *functions.Revision, error) {
+	autoscaler := s.autoscaler
+	if autoscaler == nil {
+		autoscaler = newFunctionAutoscaler(s)
 	}
-	return sandbox, currentRev, nil
-}
-
-func (s *Server) ensureRestoredFunctionSandboxLocked(ctx context.Context, fn *functions.Function, rev *functions.Revision, service mgr.SandboxAppService) (*mgr.Sandbox, *functions.Revision, error) {
-	latest, err := s.functionRepo.GetRevision(ctx, fn.TeamID, fn.ID, rev.ID)
-	if err == nil {
-		rev = latest
-	} else if err != nil && !errorsIsFunctionNotFound(err) {
-		return nil, rev, err
-	}
-
-	if rev.RuntimeSandboxID != nil && strings.TrimSpace(*rev.RuntimeSandboxID) != "" {
-		sandbox, err := s.getSandboxFromClusterGateway(ctx, strings.TrimSpace(*rev.RuntimeSandboxID))
-		if err == nil {
-			contextID, runtimeErr := s.ensureFunctionServiceRuntime(ctx, fn, rev, sandbox, service)
-			if runtimeErr != nil {
-				return nil, rev, runtimeErr
-			}
-			if rev.RuntimeContextID == nil || strings.TrimSpace(*rev.RuntimeContextID) != contextID {
-				updated, updateErr := s.functionRepo.SetRevisionRuntime(ctx, fn.TeamID, fn.ID, rev.ID, sandbox.ID, contextID)
-				if updateErr != nil {
-					return nil, rev, updateErr
-				}
-				rev = updated
-			}
-			return sandbox, rev, nil
-		}
-		if !isPublishNotFound(err) {
-			return nil, rev, err
-		}
-		if clearErr := s.functionRepo.ClearRevisionRuntime(ctx, fn.TeamID, fn.ID, rev.ID); clearErr != nil && !errorsIsFunctionNotFound(clearErr) {
-			s.logger.Warn("Failed to clear stale function runtime sandbox",
-				zap.String("function_id", fn.ID),
-				zap.String("revision_id", rev.ID),
-				zap.String("runtime_sandbox_id", strings.TrimSpace(*rev.RuntimeSandboxID)),
-				zap.Error(clearErr),
-			)
-		}
-		rev.RuntimeSandboxID = nil
-		rev.RuntimeContextID = nil
-		rev.RuntimeUpdatedAt = nil
-	}
-
-	claim, err := s.claimFunctionSandboxViaClusterGateway(ctx, fn, rev, service)
-	if err != nil {
-		return nil, rev, err
-	}
-	sandbox, err := s.getSandboxFromClusterGateway(ctx, claim.SandboxID)
-	if err != nil {
-		return nil, rev, err
-	}
-	contextID, err := s.ensureFunctionServiceRuntime(ctx, fn, rev, sandbox, service)
-	if err != nil {
-		s.deleteFunctionRuntimeSandboxBestEffort(fn, rev, sandbox.ID, "runtime startup failed")
-		return nil, rev, err
-	}
-	updated, err := s.functionRepo.SetRevisionRuntime(ctx, fn.TeamID, fn.ID, rev.ID, sandbox.ID, contextID)
-	if err != nil {
-		return nil, rev, err
-	}
-	return sandbox, updated, nil
+	return autoscaler.acquire(ctx, fn, rev, service)
 }
 
 func (s *Server) withRevisionRuntimeDistributedLock(ctx context.Context, revisionID string, fn func(context.Context) error) error {

--- a/function-gateway/pkg/http/server.go
+++ b/function-gateway/pkg/http/server.go
@@ -46,6 +46,7 @@ type Server struct {
 	routeLimiter        ratelimit.Limiter
 	runtimeLocks        sync.Map
 	runtimeRestoreLocks runtimeRestoreLocker
+	autoscaler          *functionAutoscaler
 	logger              *zap.Logger
 }
 
@@ -118,6 +119,7 @@ func NewServer(
 		runtimeRestoreLocks: pglock.New(pool),
 		logger:              logger,
 	}
+	server.autoscaler = newFunctionAutoscaler(server)
 
 	server.setupRoutes()
 	return server, nil
@@ -153,6 +155,11 @@ func (s *Server) Start(ctx context.Context) error {
 		ReadTimeout:  durationOrDefault(s.cfg.ServerReadTimeout.Duration, 30*time.Second),
 		WriteTimeout: durationOrDefault(s.cfg.ServerWriteTimeout.Duration, 60*time.Second),
 		IdleTimeout:  durationOrDefault(s.cfg.ServerIdleTimeout.Duration, 120*time.Second),
+	}
+	if s.autoscaler != nil {
+		autoscalerCtx, cancelAutoscaler := context.WithCancel(ctx)
+		defer cancelAutoscaler()
+		go s.autoscaler.Run(autoscalerCtx)
 	}
 
 	errChan := make(chan error, 1)

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -1945,7 +1945,7 @@ paths:
     post:
       tags: [functions]
       summary: Restart active function runtime
-      description: Deletes the current restored runtime sandbox when one exists and clears the runtime mapping; the next function request starts a fresh runtime.
+      description: Deletes the current restored runtime pool when one exists and clears the runtime mapping; the next function request starts fresh runtime instances.
       security:
         - bearerAuth: []
       parameters:
@@ -1965,7 +1965,7 @@ paths:
     post:
       tags: [functions]
       summary: Recycle active function runtime
-      description: Deletes the current restored runtime sandbox when one exists and clears the runtime mapping; the next function request starts a fresh runtime.
+      description: Deletes the current restored runtime pool when one exists and clears the runtime mapping; the next function request starts fresh runtime instances.
       security:
         - bearerAuth: []
       parameters:
@@ -4124,6 +4124,8 @@ components:
           description: Function display name. Defaults to the source service name or ID when omitted.
         source:
           $ref: "#/components/schemas/FunctionSourceRequest"
+        autoscaling:
+          $ref: "#/components/schemas/FunctionAutoscaling"
       required: [source]
     FunctionRevisionCreateRequest:
       type: object
@@ -4144,6 +4146,8 @@ components:
         enabled:
           type: boolean
           description: Whether the function host should serve traffic. Disabled functions do not restore runtime sandboxes.
+        autoscaling:
+          $ref: "#/components/schemas/FunctionAutoscaling"
     FunctionAliasUpdateRequest:
       type: object
       properties:
@@ -4168,6 +4172,8 @@ components:
           type: string
         enabled:
           type: boolean
+        autoscaling:
+          $ref: "#/components/schemas/FunctionAutoscaling"
         created_by:
           type: string
         created_at:
@@ -4180,7 +4186,36 @@ components:
           type: string
           format: date-time
           description: Set when the function has been soft-deleted. Deleted functions are hidden from normal list/get APIs and do not serve traffic.
-      required: [id, team_id, name, slug, domain_label, enabled, created_at, updated_at]
+      required: [id, team_id, name, slug, domain_label, enabled, autoscaling, created_at, updated_at]
+    FunctionAutoscaling:
+      type: object
+      description: Function runtime pool autoscaling settings. target_concurrency is a soft routing and scale-out signal; it is not a strong distributed per-instance concurrency semaphore.
+      properties:
+        min_warm:
+          type: integer
+          format: int32
+          minimum: 0
+          default: 0
+          description: Minimum ready runtime sandboxes the autoscaler keeps after traffic has created capacity.
+        max_active:
+          type: integer
+          format: int32
+          minimum: 1
+          default: 20
+          description: Hard upper bound for active runtime sandboxes for the function.
+        target_concurrency:
+          type: integer
+          format: int32
+          minimum: 1
+          default: 80
+          description: Soft per-runtime in-flight request target used for routing and scale-out.
+        scale_down_after_seconds:
+          type: integer
+          format: int32
+          minimum: 30
+          default: 300
+          description: Idle time before the autoscaler removes extra runtime sandboxes above min_warm.
+      required: [min_warm, max_active, target_concurrency, scale_down_after_seconds]
     FunctionRecord:
       allOf:
         - $ref: "#/components/schemas/Function"
@@ -4268,6 +4303,47 @@ components:
     FunctionRuntimeState:
       type: string
       enum: [disabled, idle, active]
+    FunctionRuntimeInstanceState:
+      type: string
+      enum: [starting, ready, draining, failed]
+    FunctionRuntimeInstance:
+      type: object
+      properties:
+        id:
+          type: string
+        team_id:
+          type: string
+        function_id:
+          type: string
+        revision_id:
+          type: string
+        sandbox_id:
+          type: string
+        context_id:
+          type: string
+        state:
+          $ref: "#/components/schemas/FunctionRuntimeInstanceState"
+        last_error:
+          type: string
+        ready_at:
+          type: string
+          format: date-time
+        last_used_at:
+          type: string
+          format: date-time
+        draining_at:
+          type: string
+          format: date-time
+        failed_at:
+          type: string
+          format: date-time
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      required: [id, team_id, function_id, revision_id, sandbox_id, state, created_at, updated_at]
     FunctionRuntimeStatus:
       type: object
       properties:
@@ -4280,17 +4356,23 @@ components:
           format: int32
         state:
           $ref: "#/components/schemas/FunctionRuntimeState"
+        autoscaling:
+          $ref: "#/components/schemas/FunctionAutoscaling"
         runtime_sandbox_id:
           type: string
-          description: Current restored runtime sandbox, if one exists.
+          description: Compatibility summary for one current restored runtime sandbox, if one exists. Use instances for the full runtime pool.
         runtime_context_id:
           type: string
-          description: Current runtime process context, if one exists.
+          description: Compatibility summary for one current runtime process context, if one exists. Use instances for the full runtime pool.
         runtime_updated_at:
           type: string
           format: date-time
           description: Last time the runtime mapping was updated.
-      required: [function_id, revision_id, revision_number, state]
+        instances:
+          type: array
+          items:
+            $ref: "#/components/schemas/FunctionRuntimeInstance"
+      required: [function_id, revision_id, revision_number, state, autoscaling]
     SuccessFunctionResponse:
       allOf:
         - $ref: "#/components/schemas/SuccessEnvelope"

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -96,6 +96,14 @@ const (
 	Symlink FileInfoType = "symlink"
 )
 
+// Defines values for FunctionRuntimeInstanceState.
+const (
+	FunctionRuntimeInstanceStateDraining FunctionRuntimeInstanceState = "draining"
+	FunctionRuntimeInstanceStateFailed   FunctionRuntimeInstanceState = "failed"
+	FunctionRuntimeInstanceStateReady    FunctionRuntimeInstanceState = "ready"
+	FunctionRuntimeInstanceStateStarting FunctionRuntimeInstanceState = "starting"
+)
+
 // Defines values for FunctionRuntimeState.
 const (
 	FunctionRuntimeStateActive   FunctionRuntimeState = "active"
@@ -525,11 +533,11 @@ const (
 
 // Defines values for GetApiV1SandboxesParamsStatus.
 const (
-	GetApiV1SandboxesParamsStatusCompleted   GetApiV1SandboxesParamsStatus = "completed"
-	GetApiV1SandboxesParamsStatusFailed      GetApiV1SandboxesParamsStatus = "failed"
-	GetApiV1SandboxesParamsStatusRunning     GetApiV1SandboxesParamsStatus = "running"
-	GetApiV1SandboxesParamsStatusStarting    GetApiV1SandboxesParamsStatus = "starting"
-	GetApiV1SandboxesParamsStatusTerminating GetApiV1SandboxesParamsStatus = "terminating"
+	Completed   GetApiV1SandboxesParamsStatus = "completed"
+	Failed      GetApiV1SandboxesParamsStatus = "failed"
+	Running     GetApiV1SandboxesParamsStatus = "running"
+	Starting    GetApiV1SandboxesParamsStatus = "starting"
+	Terminating GetApiV1SandboxesParamsStatus = "terminating"
 )
 
 // APIKey defines model for APIKey.
@@ -972,9 +980,12 @@ type ForkVolumeRequest struct {
 
 // Function defines model for Function.
 type Function struct {
-	ActiveRevisionId *string   `json:"active_revision_id,omitempty"`
-	CreatedAt        time.Time `json:"created_at"`
-	CreatedBy        *string   `json:"created_by,omitempty"`
+	ActiveRevisionId *string `json:"active_revision_id,omitempty"`
+
+	// Autoscaling Function runtime pool autoscaling settings. target_concurrency is a soft routing and scale-out signal; it is not a strong distributed per-instance concurrency semaphore.
+	Autoscaling FunctionAutoscaling `json:"autoscaling"`
+	CreatedAt   time.Time           `json:"created_at"`
+	CreatedBy   *string             `json:"created_by,omitempty"`
 
 	// DeletedAt Set when the function has been soft-deleted. Deleted functions are hidden from normal list/get APIs and do not serve traffic.
 	DeletedAt   *time.Time `json:"deleted_at,omitempty"`
@@ -1002,8 +1013,26 @@ type FunctionAliasUpdateRequest struct {
 	RevisionNumber int32 `json:"revision_number"`
 }
 
+// FunctionAutoscaling Function runtime pool autoscaling settings. target_concurrency is a soft routing and scale-out signal; it is not a strong distributed per-instance concurrency semaphore.
+type FunctionAutoscaling struct {
+	// MaxActive Hard upper bound for active runtime sandboxes for the function.
+	MaxActive int32 `json:"max_active"`
+
+	// MinWarm Minimum ready runtime sandboxes the autoscaler keeps after traffic has created capacity.
+	MinWarm int32 `json:"min_warm"`
+
+	// ScaleDownAfterSeconds Idle time before the autoscaler removes extra runtime sandboxes above min_warm.
+	ScaleDownAfterSeconds int32 `json:"scale_down_after_seconds"`
+
+	// TargetConcurrency Soft per-runtime in-flight request target used for routing and scale-out.
+	TargetConcurrency int32 `json:"target_concurrency"`
+}
+
 // FunctionCreateRequest defines model for FunctionCreateRequest.
 type FunctionCreateRequest struct {
+	// Autoscaling Function runtime pool autoscaling settings. target_concurrency is a soft routing and scale-out signal; it is not a strong distributed per-instance concurrency semaphore.
+	Autoscaling *FunctionAutoscaling `json:"autoscaling,omitempty"`
+
 	// Name Function display name. Defaults to the source service name or ID when omitted.
 	Name   *string               `json:"name,omitempty"`
 	Source FunctionSourceRequest `json:"source"`
@@ -1011,9 +1040,12 @@ type FunctionCreateRequest struct {
 
 // FunctionRecord defines model for FunctionRecord.
 type FunctionRecord struct {
-	ActiveRevisionId *string   `json:"active_revision_id,omitempty"`
-	CreatedAt        time.Time `json:"created_at"`
-	CreatedBy        *string   `json:"created_by,omitempty"`
+	ActiveRevisionId *string `json:"active_revision_id,omitempty"`
+
+	// Autoscaling Function runtime pool autoscaling settings. target_concurrency is a soft routing and scale-out signal; it is not a strong distributed per-instance concurrency semaphore.
+	Autoscaling FunctionAutoscaling `json:"autoscaling"`
+	CreatedAt   time.Time           `json:"created_at"`
+	CreatedBy   *string             `json:"created_by,omitempty"`
 
 	// DeletedAt Set when the function has been soft-deleted. Deleted functions are hidden from normal list/get APIs and do not serve traffic.
 	DeletedAt   *time.Time `json:"deleted_at,omitempty"`
@@ -1077,19 +1109,43 @@ type FunctionRevisionCreateRequest struct {
 	Source  FunctionSourceRequest `json:"source"`
 }
 
+// FunctionRuntimeInstance defines model for FunctionRuntimeInstance.
+type FunctionRuntimeInstance struct {
+	ContextId  *string                      `json:"context_id,omitempty"`
+	CreatedAt  time.Time                    `json:"created_at"`
+	DrainingAt *time.Time                   `json:"draining_at,omitempty"`
+	FailedAt   *time.Time                   `json:"failed_at,omitempty"`
+	FunctionId string                       `json:"function_id"`
+	Id         string                       `json:"id"`
+	LastError  *string                      `json:"last_error,omitempty"`
+	LastUsedAt *time.Time                   `json:"last_used_at,omitempty"`
+	ReadyAt    *time.Time                   `json:"ready_at,omitempty"`
+	RevisionId string                       `json:"revision_id"`
+	SandboxId  string                       `json:"sandbox_id"`
+	State      FunctionRuntimeInstanceState `json:"state"`
+	TeamId     string                       `json:"team_id"`
+	UpdatedAt  time.Time                    `json:"updated_at"`
+}
+
+// FunctionRuntimeInstanceState defines model for FunctionRuntimeInstanceState.
+type FunctionRuntimeInstanceState string
+
 // FunctionRuntimeState defines model for FunctionRuntimeState.
 type FunctionRuntimeState string
 
 // FunctionRuntimeStatus defines model for FunctionRuntimeStatus.
 type FunctionRuntimeStatus struct {
-	FunctionId     string `json:"function_id"`
-	RevisionId     string `json:"revision_id"`
-	RevisionNumber int32  `json:"revision_number"`
+	// Autoscaling Function runtime pool autoscaling settings. target_concurrency is a soft routing and scale-out signal; it is not a strong distributed per-instance concurrency semaphore.
+	Autoscaling    FunctionAutoscaling        `json:"autoscaling"`
+	FunctionId     string                     `json:"function_id"`
+	Instances      *[]FunctionRuntimeInstance `json:"instances,omitempty"`
+	RevisionId     string                     `json:"revision_id"`
+	RevisionNumber int32                      `json:"revision_number"`
 
-	// RuntimeContextId Current runtime process context, if one exists.
+	// RuntimeContextId Compatibility summary for one current runtime process context, if one exists. Use instances for the full runtime pool.
 	RuntimeContextId *string `json:"runtime_context_id,omitempty"`
 
-	// RuntimeSandboxId Current restored runtime sandbox, if one exists.
+	// RuntimeSandboxId Compatibility summary for one current restored runtime sandbox, if one exists. Use instances for the full runtime pool.
 	RuntimeSandboxId *string `json:"runtime_sandbox_id,omitempty"`
 
 	// RuntimeUpdatedAt Last time the runtime mapping was updated.
@@ -1105,6 +1161,9 @@ type FunctionSourceRequest struct {
 
 // FunctionUpdateRequest defines model for FunctionUpdateRequest.
 type FunctionUpdateRequest struct {
+	// Autoscaling Function runtime pool autoscaling settings. target_concurrency is a soft routing and scale-out signal; it is not a strong distributed per-instance concurrency semaphore.
+	Autoscaling *FunctionAutoscaling `json:"autoscaling,omitempty"`
+
 	// Enabled Whether the function host should serve traffic. Disabled functions do not restore runtime sandboxes.
 	Enabled *bool `json:"enabled,omitempty"`
 

--- a/pkg/gateway/functionapi/handler.go
+++ b/pkg/gateway/functionapi/handler.go
@@ -182,8 +182,9 @@ type functionSourceRequest struct {
 }
 
 type createFunctionRequest struct {
-	Name   string                `json:"name"`
-	Source functionSourceRequest `json:"source"`
+	Name        string                 `json:"name"`
+	Source      functionSourceRequest  `json:"source"`
+	Autoscaling *functions.Autoscaling `json:"autoscaling,omitempty"`
 }
 
 type createFunctionRevisionRequest struct {
@@ -192,8 +193,9 @@ type createFunctionRevisionRequest struct {
 }
 
 type updateFunctionRequest struct {
-	Name    *string `json:"name,omitempty"`
-	Enabled *bool   `json:"enabled,omitempty"`
+	Name        *string                `json:"name,omitempty"`
+	Enabled     *bool                  `json:"enabled,omitempty"`
+	Autoscaling *functions.Autoscaling `json:"autoscaling,omitempty"`
 }
 
 type setFunctionAliasRequest struct {
@@ -246,6 +248,9 @@ func (h *Handler) createFunction(c *gin.Context) {
 
 	userID := principalID(authCtx)
 	fn := functions.NewFunction(authCtx.TeamID, name, userID)
+	if req.Autoscaling != nil {
+		fn.Autoscaling = functions.NormalizeAutoscaling(*req.Autoscaling)
+	}
 	restoreMounts, err := h.prepareRestoreMounts(c.Request.Context(), authCtx, sandbox)
 	if err != nil {
 		h.writePublishError(c, err)
@@ -310,7 +315,7 @@ func (h *Handler) updateFunction(c *gin.Context) {
 		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, fmt.Sprintf("invalid request: %v", err))
 		return
 	}
-	fn, err := h.repo.UpdateFunction(c.Request.Context(), authCtx.TeamID, c.Param("id"), req.Name, req.Enabled)
+	fn, err := h.repo.UpdateFunction(c.Request.Context(), authCtx.TeamID, c.Param("id"), req.Name, req.Enabled, req.Autoscaling)
 	if err != nil {
 		if errors.Is(err, functions.ErrNotFound) {
 			spec.JSONError(c, http.StatusNotFound, spec.CodeNotFound, "function not found")
@@ -492,7 +497,12 @@ func (h *Handler) getFunctionRuntime(c *gin.Context) {
 	if !ok {
 		return
 	}
-	spec.JSONSuccess(c, http.StatusOK, gin.H{"runtime": runtimeStatus(fn, rev)})
+	instances, err := h.repo.ListRuntimeInstances(c.Request.Context(), fn.TeamID, fn.ID, rev.ID)
+	if err != nil {
+		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to list function runtime instances")
+		return
+	}
+	spec.JSONSuccess(c, http.StatusOK, gin.H{"runtime": runtimeStatus(fn, rev, instances)})
 }
 
 func (h *Handler) restartFunctionRuntime(c *gin.Context) {
@@ -509,7 +519,31 @@ func (h *Handler) clearFunctionRuntime(c *gin.Context) {
 	if !ok {
 		return
 	}
-	if h.runtime != nil && rev.RuntimeSandboxID != nil && strings.TrimSpace(*rev.RuntimeSandboxID) != "" {
+	instances, err := h.repo.ListRuntimeInstances(c.Request.Context(), fn.TeamID, fn.ID, rev.ID)
+	if err != nil {
+		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to list function runtime instances")
+		return
+	}
+	deletedLegacy := false
+	for _, inst := range instances {
+		if inst == nil || strings.TrimSpace(inst.SandboxID) == "" || h.runtime == nil {
+			continue
+		}
+		if err := h.runtime.DeleteRuntimeSandbox(c.Request.Context(), authCtx, strings.TrimSpace(inst.SandboxID)); err != nil {
+			h.logger.Warn("Failed to delete function runtime sandbox",
+				zap.String("function_id", fn.ID),
+				zap.String("revision_id", rev.ID),
+				zap.String("runtime_sandbox_id", strings.TrimSpace(inst.SandboxID)),
+				zap.Error(err),
+			)
+			spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "failed to recycle function runtime")
+			return
+		}
+		if rev.RuntimeSandboxID != nil && strings.TrimSpace(*rev.RuntimeSandboxID) == strings.TrimSpace(inst.SandboxID) {
+			deletedLegacy = true
+		}
+	}
+	if len(instances) == 0 && h.runtime != nil && rev.RuntimeSandboxID != nil && strings.TrimSpace(*rev.RuntimeSandboxID) != "" {
 		if err := h.runtime.DeleteRuntimeSandbox(c.Request.Context(), authCtx, strings.TrimSpace(*rev.RuntimeSandboxID)); err != nil {
 			h.logger.Warn("Failed to delete function runtime sandbox",
 				zap.String("function_id", fn.ID),
@@ -520,6 +554,14 @@ func (h *Handler) clearFunctionRuntime(c *gin.Context) {
 			spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "failed to recycle function runtime")
 			return
 		}
+		deletedLegacy = true
+	}
+	if !deletedLegacy && rev.RuntimeSandboxID != nil && strings.TrimSpace(*rev.RuntimeSandboxID) != "" {
+		h.logger.Warn("Legacy function runtime mapping did not match runtime pool instances",
+			zap.String("function_id", fn.ID),
+			zap.String("revision_id", rev.ID),
+			zap.String("runtime_sandbox_id", strings.TrimSpace(*rev.RuntimeSandboxID)),
+		)
 	}
 	if err := h.repo.ClearRevisionRuntime(c.Request.Context(), fn.TeamID, fn.ID, rev.ID); err != nil && !errors.Is(err, functions.ErrNotFound) {
 		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to clear function runtime")
@@ -528,7 +570,7 @@ func (h *Handler) clearFunctionRuntime(c *gin.Context) {
 	rev.RuntimeSandboxID = nil
 	rev.RuntimeContextID = nil
 	rev.RuntimeUpdatedAt = nil
-	spec.JSONSuccess(c, http.StatusOK, gin.H{"runtime": runtimeStatus(fn, rev)})
+	spec.JSONSuccess(c, http.StatusOK, gin.H{"runtime": runtimeStatus(fn, rev, nil)})
 }
 
 func (h *Handler) loadPublishableService(ctx context.Context, authCtx *authn.AuthContext, source functionSourceRequest) (*mgr.Sandbox, mgr.SandboxAppService, error) {
@@ -637,10 +679,11 @@ func (h *Handler) loadActiveFunctionRevision(c *gin.Context) (*functions.Functio
 	return fn, rev, true
 }
 
-func runtimeStatus(fn *functions.Function, rev *functions.Revision) functions.RuntimeStatus {
+func runtimeStatus(fn *functions.Function, rev *functions.Revision, instances []*functions.RuntimeInstance) functions.RuntimeStatus {
 	status := functions.RuntimeStatus{}
 	if fn != nil {
 		status.FunctionID = fn.ID
+		status.Autoscaling = functions.NormalizeAutoscaling(fn.Autoscaling)
 	}
 	if rev != nil {
 		status.RevisionID = rev.ID
@@ -649,15 +692,34 @@ func runtimeStatus(fn *functions.Function, rev *functions.Revision) functions.Ru
 		status.RuntimeContextID = rev.RuntimeContextID
 		status.RuntimeUpdatedAt = rev.RuntimeUpdatedAt
 	}
+	if len(instances) > 0 {
+		status.Instances = make([]functions.RuntimeInstance, 0, len(instances))
+		for _, inst := range instances {
+			if inst != nil {
+				status.Instances = append(status.Instances, *inst)
+			}
+		}
+	}
 	switch {
 	case fn != nil && !fn.Enabled:
 		status.State = functions.RuntimeStateDisabled
+	case hasReadyFunctionRuntimeInstance(instances):
+		status.State = functions.RuntimeStateActive
 	case rev != nil && rev.RuntimeSandboxID != nil && strings.TrimSpace(*rev.RuntimeSandboxID) != "":
 		status.State = functions.RuntimeStateActive
 	default:
 		status.State = functions.RuntimeStateIdle
 	}
 	return status
+}
+
+func hasReadyFunctionRuntimeInstance(instances []*functions.RuntimeInstance) bool {
+	for _, inst := range instances {
+		if inst != nil && inst.State == functions.RuntimeInstanceStateReady {
+			return true
+		}
+	}
+	return false
 }
 
 func (h *Handler) cleanupDeletedFunctionResources(authCtx *authn.AuthContext, revisions []*functions.Revision) {
@@ -670,12 +732,43 @@ func (h *Handler) cleanupDeletedFunctionResources(authCtx *authn.AuthContext, re
 		if rev == nil {
 			continue
 		}
-		if h.runtime != nil && rev.RuntimeSandboxID != nil && strings.TrimSpace(*rev.RuntimeSandboxID) != "" {
-			if err := h.runtime.DeleteRuntimeSandbox(ctx, authCtx, strings.TrimSpace(*rev.RuntimeSandboxID)); err != nil {
+		runtimeSandboxIDs := map[string]struct{}{}
+		if h.repo != nil {
+			instances, err := h.repo.ListRuntimeInstances(ctx, rev.TeamID, rev.FunctionID, rev.ID)
+			if err != nil {
+				h.logger.Warn("Failed to list deleted function runtime instances",
+					zap.String("function_id", rev.FunctionID),
+					zap.String("revision_id", rev.ID),
+					zap.Error(err),
+				)
+			}
+			for _, inst := range instances {
+				if inst != nil && strings.TrimSpace(inst.SandboxID) != "" {
+					runtimeSandboxIDs[strings.TrimSpace(inst.SandboxID)] = struct{}{}
+				}
+			}
+		}
+		if rev.RuntimeSandboxID != nil && strings.TrimSpace(*rev.RuntimeSandboxID) != "" {
+			runtimeSandboxIDs[strings.TrimSpace(*rev.RuntimeSandboxID)] = struct{}{}
+		}
+		for sandboxID := range runtimeSandboxIDs {
+			if h.runtime == nil {
+				continue
+			}
+			if err := h.runtime.DeleteRuntimeSandbox(ctx, authCtx, sandboxID); err != nil {
 				h.logger.Warn("Failed to clean up deleted function runtime sandbox",
 					zap.String("function_id", rev.FunctionID),
 					zap.String("revision_id", rev.ID),
-					zap.String("runtime_sandbox_id", strings.TrimSpace(*rev.RuntimeSandboxID)),
+					zap.String("runtime_sandbox_id", sandboxID),
+					zap.Error(err),
+				)
+			}
+		}
+		if h.repo != nil {
+			if err := h.repo.ClearRevisionRuntime(ctx, rev.TeamID, rev.FunctionID, rev.ID); err != nil && !errors.Is(err, functions.ErrNotFound) {
+				h.logger.Warn("Failed to clear deleted function runtime mapping",
+					zap.String("function_id", rev.FunctionID),
+					zap.String("revision_id", rev.ID),
 					zap.Error(err),
 				)
 			}

--- a/pkg/gateway/functions/models.go
+++ b/pkg/gateway/functions/models.go
@@ -7,18 +7,31 @@ import (
 
 const ProductionAlias = "production"
 
+const (
+	DefaultMinWarm               = 0
+	DefaultMaxActive             = 20
+	DefaultTargetConcurrency     = 80
+	DefaultScaleDownAfterSeconds = 300
+	MaximumMinWarm               = 100
+	MaximumMaxActive             = 1000
+	MaximumTargetConcurrency     = 1000
+	MaximumScaleDownAfterSeconds = 86400
+	MinimumScaleDownAfterSeconds = 30
+)
+
 type Function struct {
-	ID               string     `json:"id"`
-	TeamID           string     `json:"team_id"`
-	Name             string     `json:"name"`
-	Slug             string     `json:"slug"`
-	DomainLabel      string     `json:"domain_label"`
-	ActiveRevisionID *string    `json:"active_revision_id,omitempty"`
-	Enabled          bool       `json:"enabled"`
-	CreatedBy        string     `json:"created_by,omitempty"`
-	CreatedAt        time.Time  `json:"created_at"`
-	UpdatedAt        time.Time  `json:"updated_at"`
-	DeletedAt        *time.Time `json:"deleted_at,omitempty"`
+	ID               string      `json:"id"`
+	TeamID           string      `json:"team_id"`
+	Name             string      `json:"name"`
+	Slug             string      `json:"slug"`
+	DomainLabel      string      `json:"domain_label"`
+	ActiveRevisionID *string     `json:"active_revision_id,omitempty"`
+	Enabled          bool        `json:"enabled"`
+	Autoscaling      Autoscaling `json:"autoscaling"`
+	CreatedBy        string      `json:"created_by,omitempty"`
+	CreatedAt        time.Time   `json:"created_at"`
+	UpdatedAt        time.Time   `json:"updated_at"`
+	DeletedAt        *time.Time  `json:"deleted_at,omitempty"`
 }
 
 type Revision struct {
@@ -54,6 +67,57 @@ type Alias struct {
 	UpdatedAt      time.Time `json:"updated_at"`
 }
 
+type Autoscaling struct {
+	MinWarm               int `json:"min_warm"`
+	MaxActive             int `json:"max_active"`
+	TargetConcurrency     int `json:"target_concurrency"`
+	ScaleDownAfterSeconds int `json:"scale_down_after_seconds"`
+}
+
+func DefaultAutoscaling() Autoscaling {
+	return Autoscaling{
+		MinWarm:               DefaultMinWarm,
+		MaxActive:             DefaultMaxActive,
+		TargetConcurrency:     DefaultTargetConcurrency,
+		ScaleDownAfterSeconds: DefaultScaleDownAfterSeconds,
+	}
+}
+
+func NormalizeAutoscaling(value Autoscaling) Autoscaling {
+	defaults := DefaultAutoscaling()
+	if value.MinWarm < 0 {
+		value.MinWarm = defaults.MinWarm
+	}
+	if value.MaxActive <= 0 {
+		value.MaxActive = defaults.MaxActive
+	}
+	if value.TargetConcurrency <= 0 {
+		value.TargetConcurrency = defaults.TargetConcurrency
+	}
+	if value.ScaleDownAfterSeconds <= 0 {
+		value.ScaleDownAfterSeconds = defaults.ScaleDownAfterSeconds
+	}
+	if value.MinWarm > MaximumMinWarm {
+		value.MinWarm = MaximumMinWarm
+	}
+	if value.MaxActive > MaximumMaxActive {
+		value.MaxActive = MaximumMaxActive
+	}
+	if value.TargetConcurrency > MaximumTargetConcurrency {
+		value.TargetConcurrency = MaximumTargetConcurrency
+	}
+	if value.ScaleDownAfterSeconds < MinimumScaleDownAfterSeconds {
+		value.ScaleDownAfterSeconds = MinimumScaleDownAfterSeconds
+	}
+	if value.ScaleDownAfterSeconds > MaximumScaleDownAfterSeconds {
+		value.ScaleDownAfterSeconds = MaximumScaleDownAfterSeconds
+	}
+	if value.MinWarm > value.MaxActive {
+		value.MinWarm = value.MaxActive
+	}
+	return value
+}
+
 type RuntimeState string
 
 const (
@@ -62,12 +126,40 @@ const (
 	RuntimeStateActive   RuntimeState = "active"
 )
 
+type RuntimeInstanceState string
+
+const (
+	RuntimeInstanceStateStarting RuntimeInstanceState = "starting"
+	RuntimeInstanceStateReady    RuntimeInstanceState = "ready"
+	RuntimeInstanceStateDraining RuntimeInstanceState = "draining"
+	RuntimeInstanceStateFailed   RuntimeInstanceState = "failed"
+)
+
+type RuntimeInstance struct {
+	ID         string               `json:"id"`
+	TeamID     string               `json:"team_id"`
+	FunctionID string               `json:"function_id"`
+	RevisionID string               `json:"revision_id"`
+	SandboxID  string               `json:"sandbox_id"`
+	ContextID  *string              `json:"context_id,omitempty"`
+	State      RuntimeInstanceState `json:"state"`
+	LastError  *string              `json:"last_error,omitempty"`
+	ReadyAt    *time.Time           `json:"ready_at,omitempty"`
+	LastUsedAt *time.Time           `json:"last_used_at,omitempty"`
+	DrainingAt *time.Time           `json:"draining_at,omitempty"`
+	FailedAt   *time.Time           `json:"failed_at,omitempty"`
+	CreatedAt  time.Time            `json:"created_at"`
+	UpdatedAt  time.Time            `json:"updated_at"`
+}
+
 type RuntimeStatus struct {
-	FunctionID       string       `json:"function_id"`
-	RevisionID       string       `json:"revision_id"`
-	RevisionNumber   int          `json:"revision_number"`
-	State            RuntimeState `json:"state"`
-	RuntimeSandboxID *string      `json:"runtime_sandbox_id,omitempty"`
-	RuntimeContextID *string      `json:"runtime_context_id,omitempty"`
-	RuntimeUpdatedAt *time.Time   `json:"runtime_updated_at,omitempty"`
+	FunctionID       string            `json:"function_id"`
+	RevisionID       string            `json:"revision_id"`
+	RevisionNumber   int               `json:"revision_number"`
+	State            RuntimeState      `json:"state"`
+	Autoscaling      Autoscaling       `json:"autoscaling"`
+	RuntimeSandboxID *string           `json:"runtime_sandbox_id,omitempty"`
+	RuntimeContextID *string           `json:"runtime_context_id,omitempty"`
+	RuntimeUpdatedAt *time.Time        `json:"runtime_updated_at,omitempty"`
+	Instances        []RuntimeInstance `json:"instances,omitempty"`
 }

--- a/pkg/gateway/functions/repository.go
+++ b/pkg/gateway/functions/repository.go
@@ -40,6 +40,7 @@ func (r *Repository) CreateFunctionWithRevision(ctx context.Context, fn *Functio
 	fn.CreatedAt = now
 	fn.UpdatedAt = now
 	fn.CreatedBy = createdBy
+	fn.Autoscaling = NormalizeAutoscaling(fn.Autoscaling)
 	rev.FunctionID = fn.ID
 	rev.TeamID = fn.TeamID
 	rev.RevisionNumber = 1
@@ -134,7 +135,7 @@ func (r *Repository) ListFunctions(ctx context.Context, teamID string) ([]*Funct
 		return nil, fmt.Errorf("function repository is not configured")
 	}
 	rows, err := r.pool.Query(ctx, `
-		SELECT id, team_id, name, slug, domain_label, active_revision_id, enabled, created_by, created_at, updated_at, deleted_at
+		SELECT id, team_id, name, slug, domain_label, active_revision_id, enabled, autoscaling, created_by, created_at, updated_at, deleted_at
 		FROM functions
 		WHERE team_id = $1 AND deleted_at IS NULL
 		ORDER BY updated_at DESC, created_at DESC
@@ -162,13 +163,13 @@ func (r *Repository) GetFunction(ctx context.Context, teamID, ref string) (*Func
 	var row pgx.Row
 	if id, err := uuid.Parse(ref); err == nil {
 		row = r.pool.QueryRow(ctx, `
-			SELECT id, team_id, name, slug, domain_label, active_revision_id, enabled, created_by, created_at, updated_at, deleted_at
+			SELECT id, team_id, name, slug, domain_label, active_revision_id, enabled, autoscaling, created_by, created_at, updated_at, deleted_at
 			FROM functions
 			WHERE team_id = $1 AND deleted_at IS NULL AND (id = $2 OR slug = $3)
 		`, teamID, id, ref)
 	} else {
 		row = r.pool.QueryRow(ctx, `
-			SELECT id, team_id, name, slug, domain_label, active_revision_id, enabled, created_by, created_at, updated_at, deleted_at
+			SELECT id, team_id, name, slug, domain_label, active_revision_id, enabled, autoscaling, created_by, created_at, updated_at, deleted_at
 			FROM functions
 			WHERE team_id = $1 AND deleted_at IS NULL AND slug = $2
 		`, teamID, ref)
@@ -185,7 +186,7 @@ func (r *Repository) GetFunctionByDomainLabel(ctx context.Context, domainLabel s
 		return nil, fmt.Errorf("function repository is not configured")
 	}
 	row := r.pool.QueryRow(ctx, `
-		SELECT id, team_id, name, slug, domain_label, active_revision_id, enabled, created_by, created_at, updated_at, deleted_at
+		SELECT id, team_id, name, slug, domain_label, active_revision_id, enabled, autoscaling, created_by, created_at, updated_at, deleted_at
 		FROM functions
 		WHERE domain_label = $1 AND deleted_at IS NULL
 	`, domainLabel)
@@ -308,7 +309,12 @@ func (r *Repository) ClearRevisionRuntime(ctx context.Context, teamID, functionI
 	if r == nil || r.pool == nil {
 		return fmt.Errorf("function repository is not configured")
 	}
-	tag, err := r.pool.Exec(ctx, `
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+	tag, err := tx.Exec(ctx, `
 		UPDATE functions_revisions
 		SET runtime_sandbox_id = NULL, runtime_context_id = NULL, runtime_updated_at = NULL
 		WHERE team_id = $1 AND function_id = $2 AND id = $3
@@ -319,10 +325,277 @@ func (r *Repository) ClearRevisionRuntime(ctx context.Context, teamID, functionI
 	if tag.RowsAffected() == 0 {
 		return ErrNotFound
 	}
+	if _, err := tx.Exec(ctx, `
+		DELETE FROM function_runtime_instances
+		WHERE team_id = $1 AND function_id = $2 AND revision_id = $3
+	`, teamID, functionID, revisionID); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
+func (r *Repository) ListRuntimeInstances(ctx context.Context, teamID, functionID, revisionID string) ([]*RuntimeInstance, error) {
+	if r == nil || r.pool == nil {
+		return nil, fmt.Errorf("function repository is not configured")
+	}
+	rows, err := r.pool.Query(ctx, `
+		SELECT id, team_id, function_id, revision_id, sandbox_id, context_id, state, last_error,
+			ready_at, last_used_at, draining_at, failed_at, created_at, updated_at
+		FROM function_runtime_instances
+		WHERE team_id = $1 AND function_id = $2 AND revision_id = $3
+		ORDER BY
+			CASE state
+				WHEN 'ready' THEN 0
+				WHEN 'starting' THEN 1
+				WHEN 'draining' THEN 2
+				ELSE 3
+			END,
+			COALESCE(last_used_at, ready_at, created_at) ASC
+	`, teamID, functionID, revisionID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []*RuntimeInstance
+	for rows.Next() {
+		inst, err := scanRuntimeInstance(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, inst)
+	}
+	return out, rows.Err()
+}
+
+func (r *Repository) CreateRuntimeInstance(ctx context.Context, inst *RuntimeInstance) (*RuntimeInstance, error) {
+	if r == nil || r.pool == nil {
+		return nil, fmt.Errorf("function repository is not configured")
+	}
+	if inst == nil {
+		return nil, fmt.Errorf("runtime instance is nil")
+	}
+	if inst.ID == "" {
+		inst.ID = uuid.NewString()
+	}
+	if inst.State == "" {
+		inst.State = RuntimeInstanceStateStarting
+	}
+	row := r.pool.QueryRow(ctx, `
+		INSERT INTO function_runtime_instances (
+			id, team_id, function_id, revision_id, sandbox_id, context_id, state, last_error,
+			ready_at, last_used_at, draining_at, failed_at
+		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
+		RETURNING id, team_id, function_id, revision_id, sandbox_id, context_id, state, last_error,
+			ready_at, last_used_at, draining_at, failed_at, created_at, updated_at
+	`, inst.ID, inst.TeamID, inst.FunctionID, inst.RevisionID, inst.SandboxID, inst.ContextID, inst.State, inst.LastError,
+		inst.ReadyAt, inst.LastUsedAt, inst.DrainingAt, inst.FailedAt)
+	created, err := scanRuntimeInstance(row)
+	if err != nil {
+		return nil, err
+	}
+	return created, nil
+}
+
+func (r *Repository) MarkRuntimeInstanceReady(ctx context.Context, teamID, functionID, revisionID, instanceID, sandboxID, contextID string) (*RuntimeInstance, error) {
+	if r == nil || r.pool == nil {
+		return nil, fmt.Errorf("function repository is not configured")
+	}
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback(ctx)
+	row := tx.QueryRow(ctx, `
+		UPDATE function_runtime_instances
+		SET sandbox_id = $5, context_id = $6, state = 'ready', last_error = NULL,
+			ready_at = COALESCE(ready_at, NOW()), last_used_at = NOW(), draining_at = NULL, failed_at = NULL
+		WHERE team_id = $1 AND function_id = $2 AND revision_id = $3 AND id = $4
+		RETURNING id, team_id, function_id, revision_id, sandbox_id, context_id, state, last_error,
+			ready_at, last_used_at, draining_at, failed_at, created_at, updated_at
+	`, teamID, functionID, revisionID, instanceID, sandboxID, contextID)
+	inst, err := scanRuntimeInstance(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	if _, err := tx.Exec(ctx, `
+		UPDATE functions_revisions
+		SET runtime_sandbox_id = $4, runtime_context_id = $5, runtime_updated_at = NOW()
+		WHERE team_id = $1 AND function_id = $2 AND id = $3
+	`, teamID, functionID, revisionID, sandboxID, contextID); err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+	return inst, nil
+}
+
+func (r *Repository) MarkRuntimeInstanceUsed(ctx context.Context, teamID, functionID, revisionID, instanceID string) error {
+	if r == nil || r.pool == nil {
+		return fmt.Errorf("function repository is not configured")
+	}
+	tag, err := r.pool.Exec(ctx, `
+		UPDATE function_runtime_instances
+		SET last_used_at = NOW()
+		WHERE team_id = $1 AND function_id = $2 AND revision_id = $3 AND id = $4
+	`, teamID, functionID, revisionID, instanceID)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
 	return nil
 }
 
-func (r *Repository) UpdateFunction(ctx context.Context, teamID, functionRef string, name *string, enabled *bool) (*Function, error) {
+func (r *Repository) MarkRuntimeInstanceDraining(ctx context.Context, teamID, functionID, revisionID, instanceID string) error {
+	if r == nil || r.pool == nil {
+		return fmt.Errorf("function repository is not configured")
+	}
+	tag, err := r.pool.Exec(ctx, `
+		UPDATE function_runtime_instances
+		SET state = 'draining', draining_at = NOW()
+		WHERE team_id = $1 AND function_id = $2 AND revision_id = $3 AND id = $4
+	`, teamID, functionID, revisionID, instanceID)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *Repository) MarkRuntimeInstanceFailed(ctx context.Context, teamID, functionID, revisionID, instanceID, message string) error {
+	if r == nil || r.pool == nil {
+		return fmt.Errorf("function repository is not configured")
+	}
+	message = strings.TrimSpace(message)
+	tag, err := r.pool.Exec(ctx, `
+		UPDATE function_runtime_instances
+		SET state = 'failed', last_error = NULLIF($5, ''), failed_at = NOW()
+		WHERE team_id = $1 AND function_id = $2 AND revision_id = $3 AND id = $4
+	`, teamID, functionID, revisionID, instanceID, message)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *Repository) DeleteRuntimeInstance(ctx context.Context, teamID, functionID, revisionID, instanceID string) error {
+	if r == nil || r.pool == nil {
+		return fmt.Errorf("function repository is not configured")
+	}
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+
+	var currentSandboxID *string
+	if err := tx.QueryRow(ctx, `
+		SELECT runtime_sandbox_id
+		FROM functions_revisions
+		WHERE team_id = $1 AND function_id = $2 AND id = $3
+		FOR UPDATE
+	`, teamID, functionID, revisionID).Scan(&currentSandboxID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrNotFound
+		}
+		return err
+	}
+
+	var deletedSandboxID string
+	if err := tx.QueryRow(ctx, `
+		DELETE FROM function_runtime_instances
+		WHERE team_id = $1 AND function_id = $2 AND revision_id = $3 AND id = $4
+		RETURNING sandbox_id
+	`, teamID, functionID, revisionID, instanceID).Scan(&deletedSandboxID); errors.Is(err, pgx.ErrNoRows) {
+		return ErrNotFound
+	} else if err != nil {
+		return err
+	}
+
+	if currentSandboxID != nil && strings.TrimSpace(*currentSandboxID) == strings.TrimSpace(deletedSandboxID) {
+		var replacementSandboxID *string
+		var replacementContextID *string
+		err := tx.QueryRow(ctx, `
+			SELECT sandbox_id, context_id
+			FROM function_runtime_instances
+			WHERE team_id = $1 AND function_id = $2 AND revision_id = $3 AND state = 'ready'
+			ORDER BY COALESCE(last_used_at, ready_at, created_at) DESC
+			LIMIT 1
+		`, teamID, functionID, revisionID).Scan(&replacementSandboxID, &replacementContextID)
+		if errors.Is(err, pgx.ErrNoRows) {
+			replacementSandboxID = nil
+			replacementContextID = nil
+		} else if err != nil {
+			return err
+		}
+		if _, err := tx.Exec(ctx, `
+			UPDATE functions_revisions
+			SET runtime_sandbox_id = $4, runtime_context_id = $5,
+				runtime_updated_at = CASE WHEN $4::text IS NULL THEN NULL ELSE NOW() END
+			WHERE team_id = $1 AND function_id = $2 AND id = $3
+		`, teamID, functionID, revisionID, replacementSandboxID, replacementContextID); err != nil {
+			return err
+		}
+	}
+	return tx.Commit(ctx)
+}
+
+func (r *Repository) ListRuntimeScaleDownCandidates(ctx context.Context, limit int) ([]*RuntimeInstance, error) {
+	if r == nil || r.pool == nil {
+		return nil, fmt.Errorf("function repository is not configured")
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := r.pool.Query(ctx, `
+		WITH ready_instances AS (
+			SELECT i.id, i.team_id, i.function_id, i.revision_id, i.sandbox_id, i.context_id, i.state, i.last_error,
+				i.ready_at, i.last_used_at, i.draining_at, i.failed_at, i.created_at, i.updated_at,
+				GREATEST(COALESCE((f.autoscaling->>'min_warm')::int, $2), 0) AS min_warm,
+				GREATEST(COALESCE((f.autoscaling->>'scale_down_after_seconds')::int, $3), $4) AS scale_down_after_seconds,
+				COUNT(*) OVER (PARTITION BY i.revision_id) AS ready_count,
+				ROW_NUMBER() OVER (PARTITION BY i.revision_id ORDER BY COALESCE(i.last_used_at, i.ready_at, i.created_at) ASC) AS idle_rank
+			FROM function_runtime_instances i
+			JOIN functions f ON f.id = i.function_id
+			WHERE i.state = 'ready'
+				AND f.deleted_at IS NULL
+				AND f.active_revision_id = i.revision_id
+		)
+		SELECT id, team_id, function_id, revision_id, sandbox_id, context_id, state, last_error,
+			ready_at, last_used_at, draining_at, failed_at, created_at, updated_at
+		FROM ready_instances
+		WHERE ready_count > min_warm
+			AND idle_rank <= ready_count - min_warm
+			AND COALESCE(last_used_at, ready_at, created_at) < NOW() - make_interval(secs => scale_down_after_seconds)
+		ORDER BY COALESCE(last_used_at, ready_at, created_at) ASC
+		LIMIT $1
+	`, limit, DefaultMinWarm, DefaultScaleDownAfterSeconds, MinimumScaleDownAfterSeconds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []*RuntimeInstance
+	for rows.Next() {
+		inst, err := scanRuntimeInstance(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, inst)
+	}
+	return out, rows.Err()
+}
+
+func (r *Repository) UpdateFunction(ctx context.Context, teamID, functionRef string, name *string, enabled *bool, autoscaling *Autoscaling) (*Function, error) {
 	if r == nil || r.pool == nil {
 		return nil, fmt.Errorf("function repository is not configured")
 	}
@@ -338,12 +611,20 @@ func (r *Repository) UpdateFunction(ctx context.Context, teamID, functionRef str
 	if enabled != nil {
 		nextEnabled = *enabled
 	}
+	nextAutoscaling := fn.Autoscaling
+	if autoscaling != nil {
+		nextAutoscaling = NormalizeAutoscaling(*autoscaling)
+	}
+	autoscalingBytes, err := json.Marshal(nextAutoscaling)
+	if err != nil {
+		return nil, err
+	}
 	row := r.pool.QueryRow(ctx, `
 		UPDATE functions
-		SET name = $3, enabled = $4, updated_at = NOW()
+		SET name = $3, enabled = $4, autoscaling = $5, updated_at = NOW()
 		WHERE team_id = $1 AND id = $2 AND deleted_at IS NULL
-		RETURNING id, team_id, name, slug, domain_label, active_revision_id, enabled, created_by, created_at, updated_at, deleted_at
-	`, teamID, fn.ID, nextName, nextEnabled)
+		RETURNING id, team_id, name, slug, domain_label, active_revision_id, enabled, autoscaling, created_by, created_at, updated_at, deleted_at
+	`, teamID, fn.ID, nextName, nextEnabled, autoscalingBytes)
 	updated, err := scanFunction(row)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, ErrNotFound
@@ -367,7 +648,7 @@ func (r *Repository) DeleteFunction(ctx context.Context, teamID, functionRef str
 		UPDATE functions
 		SET enabled = FALSE, deleted_at = NOW(), updated_at = NOW()
 		WHERE team_id = $1 AND id = $2 AND deleted_at IS NULL
-		RETURNING id, team_id, name, slug, domain_label, active_revision_id, enabled, created_by, created_at, updated_at, deleted_at
+		RETURNING id, team_id, name, slug, domain_label, active_revision_id, enabled, autoscaling, created_by, created_at, updated_at, deleted_at
 	`, teamID, fn.ID)
 	deleted, err := scanFunction(row)
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -481,6 +762,7 @@ func NewFunction(teamID, name, userID string) *Function {
 		Slug:        slug,
 		DomainLabel: DomainLabel(slug, teamID),
 		Enabled:     true,
+		Autoscaling: DefaultAutoscaling(),
 		CreatedBy:   userID,
 	}
 }
@@ -502,11 +784,16 @@ func NewRevision(teamID, sandboxID, serviceID, templateID string, snapshot any, 
 }
 
 func insertFunction(ctx context.Context, tx pgx.Tx, fn *Function) error {
-	_, err := tx.Exec(ctx, `
+	fn.Autoscaling = NormalizeAutoscaling(fn.Autoscaling)
+	autoscalingBytes, err := json.Marshal(fn.Autoscaling)
+	if err != nil {
+		return err
+	}
+	_, err = tx.Exec(ctx, `
 		INSERT INTO functions (
-			id, team_id, name, slug, domain_label, active_revision_id, enabled, created_by, created_at, updated_at, deleted_at
-		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
-	`, fn.ID, fn.TeamID, fn.Name, fn.Slug, fn.DomainLabel, fn.ActiveRevisionID, fn.Enabled, fn.CreatedBy, fn.CreatedAt, fn.UpdatedAt, fn.DeletedAt)
+			id, team_id, name, slug, domain_label, active_revision_id, enabled, autoscaling, created_by, created_at, updated_at, deleted_at
+		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
+	`, fn.ID, fn.TeamID, fn.Name, fn.Slug, fn.DomainLabel, fn.ActiveRevisionID, fn.Enabled, autoscalingBytes, fn.CreatedBy, fn.CreatedAt, fn.UpdatedAt, fn.DeletedAt)
 	return err
 }
 
@@ -543,9 +830,17 @@ type rowScanner interface {
 
 func scanFunction(row rowScanner) (*Function, error) {
 	var fn Function
-	if err := row.Scan(&fn.ID, &fn.TeamID, &fn.Name, &fn.Slug, &fn.DomainLabel, &fn.ActiveRevisionID, &fn.Enabled, &fn.CreatedBy, &fn.CreatedAt, &fn.UpdatedAt, &fn.DeletedAt); err != nil {
+	var autoscalingBytes []byte
+	if err := row.Scan(&fn.ID, &fn.TeamID, &fn.Name, &fn.Slug, &fn.DomainLabel, &fn.ActiveRevisionID, &fn.Enabled, &autoscalingBytes, &fn.CreatedBy, &fn.CreatedAt, &fn.UpdatedAt, &fn.DeletedAt); err != nil {
 		return nil, err
 	}
+	fn.Autoscaling = DefaultAutoscaling()
+	if len(autoscalingBytes) > 0 {
+		if err := json.Unmarshal(autoscalingBytes, &fn.Autoscaling); err != nil {
+			return nil, err
+		}
+	}
+	fn.Autoscaling = NormalizeAutoscaling(fn.Autoscaling)
 	return &fn, nil
 }
 
@@ -555,6 +850,14 @@ func scanAlias(row rowScanner) (*Alias, error) {
 		return nil, err
 	}
 	return &alias, nil
+}
+
+func scanRuntimeInstance(row rowScanner) (*RuntimeInstance, error) {
+	var inst RuntimeInstance
+	if err := row.Scan(&inst.ID, &inst.TeamID, &inst.FunctionID, &inst.RevisionID, &inst.SandboxID, &inst.ContextID, &inst.State, &inst.LastError, &inst.ReadyAt, &inst.LastUsedAt, &inst.DrainingAt, &inst.FailedAt, &inst.CreatedAt, &inst.UpdatedAt); err != nil {
+		return nil, err
+	}
+	return &inst, nil
 }
 
 func scanRevision(row rowScanner) (*Revision, error) {

--- a/pkg/gateway/migrations/00011_add_function_autoscaler.sql
+++ b/pkg/gateway/migrations/00011_add_function_autoscaler.sql
@@ -1,0 +1,63 @@
+-- +goose Up
+ALTER TABLE functions
+    ADD COLUMN IF NOT EXISTS autoscaling JSONB NOT NULL DEFAULT '{
+        "min_warm": 0,
+        "max_active": 20,
+        "target_concurrency": 80,
+        "scale_down_after_seconds": 300
+    }'::jsonb;
+
+CREATE TABLE IF NOT EXISTS function_runtime_instances (
+    id UUID PRIMARY KEY,
+    team_id UUID NOT NULL,
+    function_id UUID NOT NULL REFERENCES functions(id) ON DELETE CASCADE,
+    revision_id UUID NOT NULL REFERENCES functions_revisions(id) ON DELETE CASCADE,
+    sandbox_id TEXT NOT NULL,
+    context_id TEXT,
+    state TEXT NOT NULL,
+    last_error TEXT,
+    ready_at TIMESTAMPTZ,
+    last_used_at TIMESTAMPTZ,
+    draining_at TIMESTAMPTZ,
+    failed_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(revision_id, sandbox_id),
+    CONSTRAINT function_runtime_instances_state_check
+        CHECK (state IN ('starting', 'ready', 'draining', 'failed'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_function_runtime_instances_revision
+    ON function_runtime_instances(revision_id, state, updated_at);
+CREATE INDEX IF NOT EXISTS idx_function_runtime_instances_function
+    ON function_runtime_instances(function_id, state, updated_at);
+CREATE INDEX IF NOT EXISTS idx_function_runtime_instances_team
+    ON function_runtime_instances(team_id, state, updated_at);
+CREATE INDEX IF NOT EXISTS idx_function_runtime_instances_idle
+    ON function_runtime_instances(revision_id, last_used_at)
+    WHERE state = 'ready';
+
+DROP TRIGGER IF EXISTS update_function_runtime_instances_updated_at ON function_runtime_instances;
+CREATE TRIGGER update_function_runtime_instances_updated_at
+    BEFORE UPDATE ON function_runtime_instances
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+INSERT INTO function_runtime_instances (
+    id, team_id, function_id, revision_id, sandbox_id, context_id, state, ready_at, last_used_at, created_at, updated_at
+)
+SELECT gen_random_uuid(), team_id, function_id, id, runtime_sandbox_id, runtime_context_id, 'ready',
+    COALESCE(runtime_updated_at, NOW()), runtime_updated_at, COALESCE(runtime_updated_at, NOW()), COALESCE(runtime_updated_at, NOW())
+FROM functions_revisions
+WHERE runtime_sandbox_id IS NOT NULL AND btrim(runtime_sandbox_id) <> ''
+ON CONFLICT (revision_id, sandbox_id) DO NOTHING;
+
+-- +goose Down
+DROP TRIGGER IF EXISTS update_function_runtime_instances_updated_at ON function_runtime_instances;
+DROP INDEX IF EXISTS idx_function_runtime_instances_idle;
+DROP INDEX IF EXISTS idx_function_runtime_instances_team;
+DROP INDEX IF EXISTS idx_function_runtime_instances_function;
+DROP INDEX IF EXISTS idx_function_runtime_instances_revision;
+DROP TABLE IF EXISTS function_runtime_instances;
+ALTER TABLE functions
+    DROP COLUMN IF EXISTS autoscaling;

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -1897,6 +1897,9 @@ func assertFunctionRuntimeRestoreUsesVolumeSnapshot(env *framework.ScenarioEnv, 
 	Expect(status).To(Equal(http.StatusOK))
 	Expect(runtimeStatus.State).To(Equal(apispec.FunctionRuntimeStateActive))
 	Expect(runtimeStatus.RuntimeSandboxId).NotTo(BeNil())
+	Expect(runtimeStatus.Instances).NotTo(BeNil())
+	Expect(*runtimeStatus.Instances).NotTo(BeEmpty())
+	Expect((*runtimeStatus.Instances)[0].State).To(Equal(apispec.FunctionRuntimeInstanceStateReady))
 	firstRuntimeSandboxID := *runtimeStatus.RuntimeSandboxId
 	Expect(firstRuntimeSandboxID).NotTo(BeEmpty())
 
@@ -1957,6 +1960,8 @@ func assertFunctionRuntimeRestoreUsesVolumeSnapshot(env *framework.ScenarioEnv, 
 	Expect(status).To(Equal(http.StatusOK))
 	Expect(runtimeStatus.State).To(Equal(apispec.FunctionRuntimeStateActive))
 	Expect(runtimeStatus.RuntimeSandboxId).NotTo(BeNil())
+	Expect(runtimeStatus.Instances).NotTo(BeNil())
+	Expect(*runtimeStatus.Instances).NotTo(BeEmpty())
 	Expect(*runtimeStatus.RuntimeSandboxId).NotTo(Equal(firstRuntimeSandboxID))
 
 	runtimeStatus, status, err = session.RecycleFunctionRuntime(env.TestCtx.Context, GinkgoT(), fn.Id)


### PR DESCRIPTION
## Summary

- Add a function runtime instance pool backed by PostgreSQL, with runtime states for starting, ready, draining, and failed.
- Route function traffic through a gateway-local autoscaler that uses soft target concurrency and a hard `max_active` runtime pool limit.
- Add autoscaling settings to the Function API, runtime status instances, docs, and generated OpenAPI types.
- Update restart/recycle/delete cleanup to operate on the full runtime pool while keeping legacy `runtime_sandbox_id` fields as compatibility summaries.

## Notes

Per-instance concurrency is intentionally best-effort for now. The autoscaler module documents that `target_concurrency` is a routing and scale-out signal, not a distributed hard semaphore.

Downstream SDK/CLI PRs:

- sandbox0-ai/sdk-go#36
- sandbox0-ai/sdk-js#30
- sandbox0-ai/sdk-py#29
- sandbox0-ai/s0#48

## Validation

- make apispec
- make proto
- GOTOOLCHAIN=go1.25.0+auto go test ./pkg/gateway/functions ./pkg/gateway/functionapi ./function-gateway/pkg/http ./tests/e2e/utils
- GOTOOLCHAIN=go1.25.0+auto go test ./pkg/gateway/... ./function-gateway/... ./tests/e2e/utils
- make test function-gateway
- GOTOOLCHAIN=go1.25.0+auto go test -race ./pkg/gateway/functions ./pkg/gateway/functionapi ./function-gateway/pkg/http
- Remote kind manual regression: TCP listen fallback, revision snapshot isolation, autoscaler scale-out, HTTP readiness, and two-gateway restore coordination.