### PR TITLE
Add function runtime observability

### DIFF
--- a/docs/function/runtime/page.mdx
+++ b/docs/function/runtime/page.mdx
@@ -88,13 +88,45 @@ After Function Gateway starts a restored runtime context, it waits up to 30 seco
 
 When readiness does not pass before the timeout, the request returns `503` and the gateway records a startup error that includes the health check URL plus the last HTTP status or request error.
 
+## Observability
+
+Function Gateway emits Sandbox0 standard observability signals: Prometheus
+metrics, OpenTelemetry spans, and structured JSON logs. Function request metrics
+include `team_id`, `function_id`, `revision_id`, `route_id`, method, status,
+latency, and response size. Runtime metrics cover warm reuse, cold restore,
+startup latency, startup failures, lifecycle phase transitions, and scale-down
+results.
+
+Gateway request logs and runtime lifecycle logs include function, revision,
+route, runtime instance, runtime sandbox, and trace identifiers. Use runtime
+status for the current lifecycle view, Function Gateway logs for serving-path
+events, and sandbox/process logs for application output from the runtime
+sandbox.
+
 ## Runtime States
+
+`state` remains a compatibility summary for existing clients. Use `phase` and
+`readiness_state` for debugging startup and restore behavior.
 
 | State | Meaning |
 |-------|---------|
 | `idle` | No ready runtime sandbox is currently recorded for the active revision |
 | `active` | At least one ready runtime sandbox is recorded for the active revision |
 | `disabled` | The function is disabled and does not serve host traffic |
+
+| Phase | Meaning |
+|-------|---------|
+| `idle` | No active restore or ready runtime is recorded |
+| `provisioning` | Function Gateway is claiming a restored runtime sandbox |
+| `starting` | The runtime sandbox exists and the service process/readiness check is starting |
+| `ready` | At least one runtime instance is ready for traffic |
+| `draining` | Runtime instances are being removed and should not receive new traffic |
+| `failed` | The latest runtime startup attempt failed; inspect `last_error` and `recent_events` |
+| `disabled` | The function is disabled |
+
+Runtime status includes `last_error`, `last_error_at`, `startup_duration_ms`,
+per-instance readiness fields, and recent lifecycle events so startup failures
+can be diagnosed without searching gateway logs.
 
 `restart` and `recycle` both delete the current restored runtime pool when one exists and clear the runtime mapping. The next function request starts fresh runtime instances from the active revision.
 

--- a/function-gateway/pkg/http/autoscaler.go
+++ b/function-gateway/pkg/http/autoscaler.go
@@ -94,11 +94,14 @@ func (a *functionAutoscaler) scaleDownIdleRuntimes(ctx context.Context) {
 			}
 			continue
 		}
+		a.server.recordRuntimeLifecycleEvent(ctx, &functions.Function{ID: inst.FunctionID, TeamID: inst.TeamID}, &functions.Revision{ID: inst.RevisionID, FunctionID: inst.FunctionID, TeamID: inst.TeamID}, inst, functions.RuntimePhaseDraining, inst.ReadinessState, "scale_down", nil, 0)
 		deleteCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		scaleDownStarted := time.Now()
 		err := a.server.deleteSandboxViaClusterGateway(deleteCtx, inst.SandboxID, inst.TeamID, "")
 		cancel()
 		if err != nil {
-			a.markRuntimeInstanceFailed(context.Background(), &functions.Function{ID: inst.FunctionID, TeamID: inst.TeamID}, &functions.Revision{ID: inst.RevisionID, FunctionID: inst.FunctionID, TeamID: inst.TeamID}, inst, err)
+			a.server.observeRuntimeScaleDown(inst, "error", err, time.Since(scaleDownStarted))
+			a.markRuntimeInstanceFailed(context.Background(), &functions.Function{ID: inst.FunctionID, TeamID: inst.TeamID}, &functions.Revision{ID: inst.RevisionID, FunctionID: inst.FunctionID, TeamID: inst.TeamID}, inst, err, 0)
 			a.logger.Warn("Failed to delete idle function runtime sandbox",
 				zap.String("function_id", inst.FunctionID),
 				zap.String("revision_id", inst.RevisionID),
@@ -108,6 +111,7 @@ func (a *functionAutoscaler) scaleDownIdleRuntimes(ctx context.Context) {
 			)
 			continue
 		}
+		a.server.observeRuntimeScaleDown(inst, "success", nil, time.Since(scaleDownStarted))
 		if err := a.server.functionRepo.DeleteRuntimeInstance(ctx, inst.TeamID, inst.FunctionID, inst.RevisionID, inst.ID); err != nil && !errorsIsFunctionNotFound(err) {
 			a.logger.Warn("Failed to delete scaled-down function runtime instance",
 				zap.String("function_id", inst.FunctionID),
@@ -143,24 +147,30 @@ func (a *functionAutoscaler) acquire(ctx context.Context, fn *functions.Function
 		if inst, release := a.reserveReady(instances, cfg, false); inst != nil {
 			lease, err := a.acquireExistingInstance(ctx, fn, rev, inst, service, release)
 			if err == nil {
+				a.server.observeRuntimeAcquire(fn, rev, "warm_reuse", "success", nil)
 				return lease, rev, nil
 			}
+			a.server.observeRuntimeAcquire(fn, rev, "warm_reuse", "error", err)
 			lastErr = err
 			continue
 		}
 		if activeRuntimeInstanceCount(instances) < cfg.MaxActive {
 			lease, updated, err := a.createRuntimeInstance(ctx, fn, rev, service, cfg)
 			if err == nil {
+				a.server.observeRuntimeAcquire(fn, updated, "cold_restore", "success", nil)
 				return lease, updated, nil
 			}
+			a.server.observeRuntimeAcquire(fn, rev, "cold_restore", "error", err)
 			lastErr = err
 			continue
 		}
 		if inst, release := a.reserveReady(instances, cfg, true); inst != nil {
 			lease, err := a.acquireExistingInstance(ctx, fn, rev, inst, service, release)
 			if err == nil {
+				a.server.observeRuntimeAcquire(fn, rev, "warm_reuse_over_target", "success", nil)
 				return lease, rev, nil
 			}
+			a.server.observeRuntimeAcquire(fn, rev, "warm_reuse_over_target", "error", err)
 			lastErr = err
 		}
 	}
@@ -223,7 +233,7 @@ func (a *functionAutoscaler) acquireExistingInstance(ctx context.Context, fn *fu
 		}
 		return nil, fmt.Errorf("function runtime instance is missing")
 	}
-	lease, err := a.prepareInstance(ctx, fn, rev, inst, service, release)
+	lease, err := a.prepareInstance(ctx, fn, rev, inst, service, release, time.Time{})
 	if err != nil {
 		return nil, err
 	}
@@ -242,6 +252,7 @@ func (a *functionAutoscaler) createRuntimeInstance(ctx context.Context, fn *func
 	currentRev := rev
 	var lease *functionRuntimeLease
 	err := a.server.withRevisionRuntimeDistributedLock(ctx, rev.ID, func(runCtx context.Context) error {
+		startupStarted := time.Now()
 		latest, err := a.server.functionRepo.GetRevision(runCtx, fn.TeamID, fn.ID, rev.ID)
 		if err == nil {
 			currentRev = latest
@@ -273,8 +284,11 @@ func (a *functionAutoscaler) createRuntimeInstance(ctx context.Context, fn *func
 			return fmt.Errorf("function runtime capacity is starting")
 		}
 
+		a.server.recordRuntimeLifecycleEvent(runCtx, fn, currentRev, nil, functions.RuntimePhaseProvisioning, functions.RuntimeReadinessStateChecking, "claim_runtime", nil, 0)
 		claim, err := a.server.claimFunctionSandboxViaClusterGateway(runCtx, fn, currentRev, service)
 		if err != nil {
+			a.server.observeRuntimeStartup(fn, currentRev, "error", functions.RuntimeReadinessStateFailed, time.Since(startupStarted), err)
+			a.server.recordRuntimeLifecycleEvent(runCtx, fn, currentRev, nil, functions.RuntimePhaseFailed, functions.RuntimeReadinessStateFailed, functionRuntimeErrorReason(err), err, time.Since(startupStarted))
 			return err
 		}
 		inst, err := a.server.functionRepo.CreateRuntimeInstance(runCtx, &functions.RuntimeInstance{
@@ -286,15 +300,19 @@ func (a *functionAutoscaler) createRuntimeInstance(ctx context.Context, fn *func
 		})
 		if err != nil {
 			a.server.deleteFunctionRuntimeSandboxBestEffort(fn, currentRev, claim.SandboxID, "runtime instance registration failed")
+			a.server.observeRuntimeStartup(fn, currentRev, "error", functions.RuntimeReadinessStateFailed, time.Since(startupStarted), err)
+			a.server.recordRuntimeLifecycleEvent(runCtx, fn, currentRev, nil, functions.RuntimePhaseFailed, functions.RuntimeReadinessStateFailed, functionRuntimeErrorReason(err), err, time.Since(startupStarted))
 			return err
 		}
+		a.server.recordRuntimeLifecycleEvent(runCtx, fn, currentRev, inst, functions.RuntimePhaseStarting, functions.RuntimeReadinessStateChecking, "start_runtime", nil, 0)
 		release := a.reserveSandbox(claim.SandboxID)
-		selected, err := a.prepareInstance(runCtx, fn, currentRev, inst, service, release)
+		selected, err := a.prepareInstance(runCtx, fn, currentRev, inst, service, release, startupStarted)
 		if err != nil {
-			a.markRuntimeInstanceFailed(context.Background(), fn, currentRev, inst, err)
 			a.server.deleteFunctionRuntimeSandboxBestEffort(fn, currentRev, claim.SandboxID, "runtime startup failed")
 			return err
 		}
+		a.server.observeRuntimeStartup(fn, currentRev, "success", functions.RuntimeReadinessStateReady, time.Since(startupStarted), nil)
+		a.server.recordRuntimeLifecycleEvent(runCtx, fn, currentRev, selected.Instance, functions.RuntimePhaseReady, functions.RuntimeReadinessStateReady, "runtime_ready", nil, time.Since(startupStarted))
 		lease = selected
 		currentRev.RuntimeSandboxID = &selected.Instance.SandboxID
 		currentRev.RuntimeContextID = selected.Instance.ContextID
@@ -318,7 +336,7 @@ func (a *functionAutoscaler) reserveSandbox(sandboxID string) func() {
 	return a.releaseFunc(sandboxID)
 }
 
-func (a *functionAutoscaler) prepareInstance(ctx context.Context, fn *functions.Function, rev *functions.Revision, inst *functions.RuntimeInstance, service mgr.SandboxAppService, release func()) (*functionRuntimeLease, error) {
+func (a *functionAutoscaler) prepareInstance(ctx context.Context, fn *functions.Function, rev *functions.Revision, inst *functions.RuntimeInstance, service mgr.SandboxAppService, release func(), startupStarted time.Time) (*functionRuntimeLease, error) {
 	sandboxID := strings.TrimSpace(inst.SandboxID)
 	if sandboxID == "" {
 		if release != nil {
@@ -331,9 +349,7 @@ func (a *functionAutoscaler) prepareInstance(ctx context.Context, fn *functions.
 		if release != nil {
 			release()
 		}
-		if isPublishNotFound(err) {
-			a.markRuntimeInstanceFailed(context.Background(), fn, rev, inst, err)
-		}
+		a.markRuntimeInstanceFailed(context.Background(), fn, rev, inst, err, durationSince(startupStarted))
 		return nil, err
 	}
 	instanceRev := *rev
@@ -344,10 +360,10 @@ func (a *functionAutoscaler) prepareInstance(ctx context.Context, fn *functions.
 		if release != nil {
 			release()
 		}
-		a.markRuntimeInstanceFailed(context.Background(), fn, rev, inst, err)
+		a.markRuntimeInstanceFailed(context.Background(), fn, rev, inst, err, durationSince(startupStarted))
 		return nil, err
 	}
-	ready, err := a.server.functionRepo.MarkRuntimeInstanceReady(ctx, fn.TeamID, fn.ID, rev.ID, inst.ID, sandbox.ID, contextID)
+	ready, err := a.server.functionRepo.MarkRuntimeInstanceReady(ctx, fn.TeamID, fn.ID, rev.ID, inst.ID, sandbox.ID, contextID, durationMSPtr(durationSince(startupStarted)))
 	if err != nil {
 		if release != nil {
 			release()
@@ -362,7 +378,7 @@ func (a *functionAutoscaler) prepareInstance(ctx context.Context, fn *functions.
 	}, nil
 }
 
-func (a *functionAutoscaler) markRuntimeInstanceFailed(ctx context.Context, fn *functions.Function, rev *functions.Revision, inst *functions.RuntimeInstance, err error) {
+func (a *functionAutoscaler) markRuntimeInstanceFailed(ctx context.Context, fn *functions.Function, rev *functions.Revision, inst *functions.RuntimeInstance, err error, startupDuration time.Duration) {
 	if a == nil || a.server == nil || a.server.functionRepo == nil || fn == nil || rev == nil || inst == nil {
 		return
 	}
@@ -370,7 +386,10 @@ func (a *functionAutoscaler) markRuntimeInstanceFailed(ctx context.Context, fn *
 	if err != nil {
 		message = err.Error()
 	}
-	if markErr := a.server.functionRepo.MarkRuntimeInstanceFailed(ctx, fn.TeamID, fn.ID, rev.ID, inst.ID, message); markErr != nil && !errorsIsFunctionNotFound(markErr) {
+	if startupDuration > 0 {
+		a.server.observeRuntimeStartup(fn, rev, "error", functions.RuntimeReadinessStateFailed, startupDuration, err)
+	}
+	if markErr := a.server.functionRepo.MarkRuntimeInstanceFailedWithDetails(ctx, fn.TeamID, fn.ID, rev.ID, inst.ID, message, durationMSPtr(startupDuration)); markErr != nil && !errorsIsFunctionNotFound(markErr) {
 		a.logger.Warn("Failed to mark function runtime instance failed",
 			zap.String("function_id", fn.ID),
 			zap.String("revision_id", rev.ID),
@@ -378,10 +397,18 @@ func (a *functionAutoscaler) markRuntimeInstanceFailed(ctx context.Context, fn *
 			zap.Error(markErr),
 		)
 	}
+	a.server.recordRuntimeLifecycleEvent(ctx, fn, rev, inst, functions.RuntimePhaseFailed, functions.RuntimeReadinessStateFailed, functionRuntimeErrorReason(err), err, startupDuration)
 }
 
 func runtimeInstanceReady(inst *functions.RuntimeInstance) bool {
 	return inst != nil && inst.State == functions.RuntimeInstanceStateReady && strings.TrimSpace(inst.SandboxID) != ""
+}
+
+func durationSince(start time.Time) time.Duration {
+	if start.IsZero() {
+		return 0
+	}
+	return time.Since(start)
 }
 
 func activeRuntimeInstanceCount(instances []*functions.RuntimeInstance) int {

--- a/function-gateway/pkg/http/observability.go
+++ b/function-gateway/pkg/http/observability.go
@@ -1,0 +1,295 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"net"
+	nethttp "net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/functions"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
+)
+
+func (s *Server) startFunctionSpan(ctx context.Context, name string, fn *functions.Function, rev *functions.Revision, attrs ...attribute.KeyValue) (context.Context, trace.Span) {
+	tracer := otel.Tracer("function-gateway")
+	if s != nil && s.obsProvider != nil {
+		tracer = s.obsProvider.Tracer()
+	}
+	base := functionTraceAttributes(fn, rev, "", nil)
+	base = append(base, attrs...)
+	return tracer.Start(ctx, name, trace.WithAttributes(base...))
+}
+
+func functionTraceAttributes(fn *functions.Function, rev *functions.Revision, routeID string, inst *functions.RuntimeInstance) []attribute.KeyValue {
+	attrs := make([]attribute.KeyValue, 0, 8)
+	if fn != nil {
+		attrs = append(attrs,
+			attribute.String("sandbox0.team_id", fn.TeamID),
+			attribute.String("sandbox0.function_id", fn.ID),
+		)
+	}
+	if rev != nil {
+		attrs = append(attrs,
+			attribute.String("sandbox0.function_revision_id", rev.ID),
+			attribute.Int("sandbox0.function_revision_number", rev.RevisionNumber),
+		)
+	}
+	if routeID != "" {
+		attrs = append(attrs, attribute.String("sandbox0.function_route_id", routeID))
+	}
+	if inst != nil {
+		attrs = append(attrs,
+			attribute.String("sandbox0.function_runtime_instance_id", inst.ID),
+			attribute.String("sandbox0.runtime_sandbox_id", inst.SandboxID),
+		)
+		if inst.ContextID != nil {
+			attrs = append(attrs, attribute.String("sandbox0.runtime_context_id", *inst.ContextID))
+		}
+	}
+	return attrs
+}
+
+func setFunctionSpanAttributes(ctx context.Context, fn *functions.Function, rev *functions.Revision, routeID string, inst *functions.RuntimeInstance) {
+	span := trace.SpanFromContext(ctx)
+	if !span.SpanContext().IsValid() {
+		return
+	}
+	span.SetAttributes(functionTraceAttributes(fn, rev, routeID, inst)...)
+}
+
+func (s *Server) observeFunctionRequest(c *gin.Context, fn *functions.Function, rev *functions.Revision, routeID string, inst *functions.RuntimeInstance, started time.Time) {
+	if c == nil || fn == nil || rev == nil || started.IsZero() {
+		return
+	}
+	status := c.Writer.Status()
+	if status == 0 {
+		status = nethttp.StatusOK
+	}
+	duration := time.Since(started)
+	responseSize := c.Writer.Size()
+	if s != nil && s.functionMetrics != nil {
+		s.functionMetrics.ObserveFunctionRequest(fn.TeamID, fn.ID, rev.ID, routeID, c.Request.Method, status, duration, responseSize)
+	}
+	if s != nil && s.logger != nil {
+		fields := []zap.Field{
+			zap.String("team_id", fn.TeamID),
+			zap.String("function_id", fn.ID),
+			zap.String("revision_id", rev.ID),
+			zap.Int("revision_number", rev.RevisionNumber),
+			zap.String("route_id", routeID),
+			zap.String("method", c.Request.Method),
+			zap.String("path", c.Request.URL.Path),
+			zap.Int("status", status),
+			zap.Duration("latency", duration),
+			zap.Int("response_size", responseSize),
+		}
+		if inst != nil {
+			fields = append(fields,
+				zap.String("runtime_instance_id", inst.ID),
+				zap.String("runtime_sandbox_id", inst.SandboxID),
+			)
+			if inst.ContextID != nil {
+				fields = append(fields, zap.String("runtime_context_id", *inst.ContextID))
+			}
+		}
+		spanCtx := trace.SpanFromContext(c.Request.Context()).SpanContext()
+		if spanCtx.IsValid() {
+			fields = append(fields,
+				zap.String("trace_id", spanCtx.TraceID().String()),
+				zap.String("span_id", spanCtx.SpanID().String()),
+			)
+		}
+		switch {
+		case status >= 500:
+			s.logger.Error("Function request", fields...)
+		case status >= 400:
+			s.logger.Warn("Function request", fields...)
+		default:
+			s.logger.Info("Function request", fields...)
+		}
+	}
+}
+
+func (s *Server) observeRuntimeAcquire(fn *functions.Function, rev *functions.Revision, path, result string, err error) {
+	if s == nil || s.functionMetrics == nil || fn == nil || rev == nil {
+		return
+	}
+	s.functionMetrics.ObserveRuntimeAcquire(fn.TeamID, fn.ID, rev.ID, path, result, functionRuntimeErrorReason(err))
+}
+
+func (s *Server) observeRuntimeStartup(fn *functions.Function, rev *functions.Revision, result string, readiness functions.RuntimeReadinessState, duration time.Duration, err error) {
+	if s == nil || s.functionMetrics == nil || fn == nil || rev == nil {
+		return
+	}
+	s.functionMetrics.ObserveRuntimeStartup(fn.TeamID, fn.ID, rev.ID, result, string(readiness), duration)
+	if err != nil {
+		s.functionMetrics.ObserveRuntimeStartupFailure(fn.TeamID, fn.ID, rev.ID, functionRuntimeErrorReason(err))
+	}
+}
+
+func (s *Server) observeRuntimeScaleDown(inst *functions.RuntimeInstance, result string, err error, duration time.Duration) {
+	if s == nil || s.functionMetrics == nil || inst == nil {
+		return
+	}
+	s.functionMetrics.ObserveRuntimeScaleDown(inst.TeamID, inst.FunctionID, inst.RevisionID, result, functionRuntimeErrorReason(err), duration)
+}
+
+func (s *Server) recordRuntimeLifecycleEvent(ctx context.Context, fn *functions.Function, rev *functions.Revision, inst *functions.RuntimeInstance, phase functions.RuntimePhase, readiness functions.RuntimeReadinessState, reason string, err error, duration time.Duration) {
+	if s == nil || fn == nil || rev == nil || phase == "" {
+		return
+	}
+	message := ""
+	if err != nil {
+		message = err.Error()
+	}
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		reason = functionRuntimeErrorReason(err)
+	}
+	durationMS := durationMSPtr(duration)
+	if s.functionMetrics != nil {
+		s.functionMetrics.ObserveRuntimeLifecycleEvent(fn.TeamID, fn.ID, rev.ID, string(phase), reason, duration)
+	}
+
+	var runtimeInstanceID *string
+	var runtimeSandboxID *string
+	var runtimeContextID *string
+	if inst != nil {
+		if strings.TrimSpace(inst.ID) != "" {
+			runtimeInstanceID = &inst.ID
+		}
+		if strings.TrimSpace(inst.SandboxID) != "" {
+			runtimeSandboxID = &inst.SandboxID
+		}
+		runtimeContextID = inst.ContextID
+	}
+	if s.functionRepo != nil {
+		_, appendErr := s.functionRepo.AppendRuntimeEvent(ctx, &functions.RuntimeEvent{
+			TeamID:            fn.TeamID,
+			FunctionID:        fn.ID,
+			RevisionID:        rev.ID,
+			RuntimeInstanceID: runtimeInstanceID,
+			RuntimeSandboxID:  runtimeSandboxID,
+			RuntimeContextID:  runtimeContextID,
+			Phase:             phase,
+			ReadinessState:    readiness,
+			Reason:            reason,
+			Message:           message,
+			StartupDurationMS: durationMS,
+		})
+		if appendErr != nil && s.logger != nil {
+			s.logger.Warn("Failed to append function runtime lifecycle event",
+				zap.String("function_id", fn.ID),
+				zap.String("revision_id", rev.ID),
+				zap.String("phase", string(phase)),
+				zap.Error(appendErr),
+			)
+		}
+	}
+	if s.logger != nil {
+		fields := []zap.Field{
+			zap.String("team_id", fn.TeamID),
+			zap.String("function_id", fn.ID),
+			zap.String("revision_id", rev.ID),
+			zap.String("phase", string(phase)),
+			zap.String("readiness_state", string(readiness)),
+			zap.String("reason", reason),
+		}
+		if duration > 0 {
+			fields = append(fields, zap.Duration("duration", duration))
+		}
+		if inst != nil {
+			fields = append(fields,
+				zap.String("runtime_instance_id", inst.ID),
+				zap.String("runtime_sandbox_id", inst.SandboxID),
+			)
+			if inst.ContextID != nil {
+				fields = append(fields, zap.String("runtime_context_id", *inst.ContextID))
+			}
+		}
+		spanCtx := trace.SpanFromContext(ctx).SpanContext()
+		if spanCtx.IsValid() {
+			fields = append(fields,
+				zap.String("trace_id", spanCtx.TraceID().String()),
+				zap.String("span_id", spanCtx.SpanID().String()),
+			)
+		}
+		if err != nil {
+			fields = append(fields, zap.Error(err))
+			s.logger.Warn("Function runtime lifecycle event", fields...)
+		} else {
+			s.logger.Info("Function runtime lifecycle event", fields...)
+		}
+	}
+}
+
+func functionRuntimeErrorReason(err error) string {
+	if err == nil {
+		return "none"
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "timeout"
+	}
+	if errors.Is(err, context.Canceled) {
+		return "canceled"
+	}
+	var runtimeErr functionRuntimeHTTPError
+	if errors.As(err, &runtimeErr) {
+		switch {
+		case runtimeErr.status == nethttp.StatusTooManyRequests:
+			return "upstream_rate_limited"
+		case runtimeErr.status >= 500:
+			return "upstream_5xx"
+		case runtimeErr.status >= 400:
+			return "upstream_4xx"
+		default:
+			return "upstream_status"
+		}
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return "timeout"
+	}
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "health check"):
+		return "health_check_failed"
+	case strings.Contains(msg, "did not start listening"):
+		return "tcp_readiness_failed"
+	case strings.Contains(msg, "capacity"):
+		return "capacity_unavailable"
+	case strings.Contains(msg, "not found"):
+		return "not_found"
+	default:
+		return "error"
+	}
+}
+
+func durationMSPtr(duration time.Duration) *int {
+	if duration <= 0 {
+		return nil
+	}
+	ms := int(duration.Round(time.Millisecond) / time.Millisecond)
+	if ms < 0 {
+		return nil
+	}
+	return &ms
+}
+
+func finishSpan(span trace.Span, err error) {
+	if span == nil {
+		return
+	}
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+	}
+	span.End()
+}

--- a/function-gateway/pkg/http/runtime.go
+++ b/function-gateway/pkg/http/runtime.go
@@ -26,6 +26,8 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"github.com/sandbox0-ai/sandbox0/pkg/proxy"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.uber.org/zap"
 )
 
@@ -66,6 +68,14 @@ func (e functionRuntimeHTTPError) Error() string {
 }
 
 func (s *Server) serveFunctionRevision(c *gin.Context, fn *functions.Function, rev *functions.Revision) {
+	requestStarted := time.Now()
+	routeID := ""
+	servedRevision := rev
+	var runtimeInstance *functions.RuntimeInstance
+	defer func() {
+		s.observeFunctionRequest(c, fn, servedRevision, routeID, runtimeInstance, requestStarted)
+	}()
+
 	var service mgr.SandboxAppService
 	if err := json.Unmarshal(rev.ServiceSnapshot, &service); err != nil {
 		s.logger.Warn("Failed to decode function service snapshot",
@@ -78,6 +88,10 @@ func (s *Server) serveFunctionRevision(c *gin.Context, fn *functions.Function, r
 	}
 
 	match := matchFunctionRoute(service, c.Request.URL.Path, c.Request.Method)
+	if match.route != nil {
+		routeID = strings.TrimSpace(match.route.ID)
+	}
+	setFunctionSpanAttributes(c.Request.Context(), fn, rev, routeID, nil)
 	if !match.pathMatched {
 		spec.JSONError(c, nethttp.StatusNotFound, spec.CodeNotFound, "route is not exposed")
 		return
@@ -95,16 +109,23 @@ func (s *Server) serveFunctionRevision(c *gin.Context, fn *functions.Function, r
 		return
 	}
 
-	lease, rev, err := s.acquireFunctionRuntime(c.Request.Context(), fn, rev, service)
+	acquireCtx, acquireSpan := s.startFunctionSpan(c.Request.Context(), "function.runtime.acquire", fn, rev,
+		attribute.String("sandbox0.function_route_id", routeID),
+	)
+	lease, rev, err := s.acquireFunctionRuntime(acquireCtx, fn, rev, service)
+	finishSpan(acquireSpan, err)
 	if err != nil {
 		s.writeFunctionRuntimeError(c, fn, rev, "function sandbox is not available", err)
 		return
 	}
+	servedRevision = rev
 	if lease == nil || lease.Sandbox == nil {
 		spec.JSONError(c, nethttp.StatusServiceUnavailable, spec.CodeUnavailable, "function sandbox is not available")
 		return
 	}
 	defer lease.Done()
+	runtimeInstance = lease.Instance
+	setFunctionSpanAttributes(c.Request.Context(), fn, rev, routeID, runtimeInstance)
 	sandbox := lease.Sandbox
 	if sandbox.TeamID != fn.TeamID {
 		spec.JSONError(c, nethttp.StatusServiceUnavailable, spec.CodeUnavailable, "function sandbox is invalid")
@@ -147,7 +168,19 @@ func (s *Server) serveFunctionRevision(c *gin.Context, fn *functions.Function, r
 		spec.JSONError(c, nethttp.StatusInternalServerError, spec.CodeInternal, "proxy initialization failed")
 		return
 	}
+	proxyCtx, proxySpan := s.startFunctionSpan(c.Request.Context(), "function.proxy", fn, rev,
+		attribute.String("sandbox0.function_route_id", routeID),
+		attribute.String("sandbox0.runtime_sandbox_id", sandbox.ID),
+		attribute.Int("sandbox0.service_port", service.Port),
+	)
+	c.Request = c.Request.WithContext(proxyCtx)
 	router.ProxyToTarget(c)
+	status := c.Writer.Status()
+	proxySpan.SetAttributes(attribute.Int("http.status_code", status))
+	if status >= 500 {
+		proxySpan.SetStatus(codes.Error, nethttp.StatusText(status))
+	}
+	proxySpan.End()
 }
 
 func matchFunctionRoute(service mgr.SandboxAppService, path string, method string) functionRouteMatch {

--- a/function-gateway/pkg/http/runtime.go
+++ b/function-gateway/pkg/http/runtime.go
@@ -492,14 +492,6 @@ func errorsIsFunctionNotFound(err error) bool {
 	return errors.Is(err, functions.ErrNotFound)
 }
 
-func isPublishNotFound(err error) bool {
-	var publishErr publishError
-	if errors.As(err, &publishErr) {
-		return publishErr.status == nethttp.StatusNotFound
-	}
-	return false
-}
-
 func (s *Server) claimFunctionSandboxViaClusterGateway(ctx context.Context, fn *functions.Function, rev *functions.Revision, service mgr.SandboxAppService) (*mgr.ClaimResponse, error) {
 	clusterGatewayURL := s.defaultClusterGatewayURL()
 	targetService := internalauth.ServiceClusterGateway

--- a/function-gateway/pkg/http/server.go
+++ b/function-gateway/pkg/http/server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"github.com/sandbox0-ai/sandbox0/pkg/observability"
 	httpobs "github.com/sandbox0-ai/sandbox0/pkg/observability/http"
+	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
 	"github.com/sandbox0-ai/sandbox0/pkg/pglock"
 	"go.uber.org/zap"
 )
@@ -42,6 +43,7 @@ type Server struct {
 	requestLogger       *middleware.RequestLogger
 	internalAuthGen     *internalauth.Generator
 	obsProvider         *observability.Provider
+	functionMetrics     *obsmetrics.FunctionGatewayMetrics
 	httpClient          *http.Client
 	routeLimiter        ratelimit.Limiter
 	runtimeLocks        sync.Map
@@ -114,6 +116,7 @@ func NewServer(
 		requestLogger:       middleware.NewRequestLogger(logger),
 		internalAuthGen:     internalAuthGen,
 		obsProvider:         obsProvider,
+		functionMetrics:     obsmetrics.NewFunctionGateway(obsProvider.MetricsRegistryOrNil()),
 		httpClient:          httpClient,
 		routeLimiter:        routeLimiter,
 		runtimeRestoreLocks: pglock.New(pool),

--- a/pkg/apispec/compat.go
+++ b/pkg/apispec/compat.go
@@ -1,0 +1,9 @@
+package apispec
+
+const (
+	Completed   = GetApiV1SandboxesParamsStatusCompleted
+	Failed      = GetApiV1SandboxesParamsStatusFailed
+	Running     = GetApiV1SandboxesParamsStatusRunning
+	Starting    = GetApiV1SandboxesParamsStatusStarting
+	Terminating = GetApiV1SandboxesParamsStatusTerminating
+)

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -4303,6 +4303,12 @@ components:
     FunctionRuntimeState:
       type: string
       enum: [disabled, idle, active]
+    FunctionRuntimePhase:
+      type: string
+      enum: [disabled, idle, provisioning, starting, ready, draining, failed]
+    FunctionRuntimeReadinessState:
+      type: string
+      enum: [unknown, checking, ready, failed]
     FunctionRuntimeInstanceState:
       type: string
       enum: [starting, ready, draining, failed]
@@ -4323,8 +4329,16 @@ components:
           type: string
         state:
           $ref: "#/components/schemas/FunctionRuntimeInstanceState"
+        readiness_state:
+          $ref: "#/components/schemas/FunctionRuntimeReadinessState"
+        startup_duration_ms:
+          type: integer
+          format: int32
         last_error:
           type: string
+        last_error_at:
+          type: string
+          format: date-time
         ready_at:
           type: string
           format: date-time
@@ -4343,7 +4357,39 @@ components:
         updated_at:
           type: string
           format: date-time
-      required: [id, team_id, function_id, revision_id, sandbox_id, state, created_at, updated_at]
+      required: [id, team_id, function_id, revision_id, sandbox_id, state, readiness_state, created_at, updated_at]
+    FunctionRuntimeEvent:
+      type: object
+      properties:
+        id:
+          type: string
+        team_id:
+          type: string
+        function_id:
+          type: string
+        revision_id:
+          type: string
+        runtime_instance_id:
+          type: string
+        runtime_sandbox_id:
+          type: string
+        runtime_context_id:
+          type: string
+        phase:
+          $ref: "#/components/schemas/FunctionRuntimePhase"
+        readiness_state:
+          $ref: "#/components/schemas/FunctionRuntimeReadinessState"
+        reason:
+          type: string
+        message:
+          type: string
+        startup_duration_ms:
+          type: integer
+          format: int32
+        created_at:
+          type: string
+          format: date-time
+      required: [id, team_id, function_id, revision_id, phase, readiness_state, created_at]
     FunctionRuntimeStatus:
       type: object
       properties:
@@ -4356,8 +4402,12 @@ components:
           format: int32
         state:
           $ref: "#/components/schemas/FunctionRuntimeState"
+        phase:
+          $ref: "#/components/schemas/FunctionRuntimePhase"
         autoscaling:
           $ref: "#/components/schemas/FunctionAutoscaling"
+        readiness_state:
+          $ref: "#/components/schemas/FunctionRuntimeReadinessState"
         runtime_sandbox_id:
           type: string
           description: Compatibility summary for one current restored runtime sandbox, if one exists. Use instances for the full runtime pool.
@@ -4368,11 +4418,23 @@ components:
           type: string
           format: date-time
           description: Last time the runtime mapping was updated.
+        startup_duration_ms:
+          type: integer
+          format: int32
+        last_error:
+          type: string
+        last_error_at:
+          type: string
+          format: date-time
         instances:
           type: array
           items:
             $ref: "#/components/schemas/FunctionRuntimeInstance"
-      required: [function_id, revision_id, revision_number, state, autoscaling]
+        recent_events:
+          type: array
+          items:
+            $ref: "#/components/schemas/FunctionRuntimeEvent"
+      required: [function_id, revision_id, revision_number, state, phase, autoscaling, readiness_state]
     SuccessFunctionResponse:
       allOf:
         - $ref: "#/components/schemas/SuccessEnvelope"
@@ -4536,6 +4598,9 @@ components:
         observed:
           type: string
           enum: [active, paused]
+          x-enum-varnames:
+            - SandboxPowerStateObservedActive
+            - SandboxPowerStateObservedPaused
         observed_generation:
           type: integer
           format: int64

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -104,6 +104,25 @@ const (
 	FunctionRuntimeInstanceStateStarting FunctionRuntimeInstanceState = "starting"
 )
 
+// Defines values for FunctionRuntimePhase.
+const (
+	FunctionRuntimePhaseDisabled     FunctionRuntimePhase = "disabled"
+	FunctionRuntimePhaseDraining     FunctionRuntimePhase = "draining"
+	FunctionRuntimePhaseFailed       FunctionRuntimePhase = "failed"
+	FunctionRuntimePhaseIdle         FunctionRuntimePhase = "idle"
+	FunctionRuntimePhaseProvisioning FunctionRuntimePhase = "provisioning"
+	FunctionRuntimePhaseReady        FunctionRuntimePhase = "ready"
+	FunctionRuntimePhaseStarting     FunctionRuntimePhase = "starting"
+)
+
+// Defines values for FunctionRuntimeReadinessState.
+const (
+	FunctionRuntimeReadinessStateChecking FunctionRuntimeReadinessState = "checking"
+	FunctionRuntimeReadinessStateFailed   FunctionRuntimeReadinessState = "failed"
+	FunctionRuntimeReadinessStateReady    FunctionRuntimeReadinessState = "ready"
+	FunctionRuntimeReadinessStateUnknown  FunctionRuntimeReadinessState = "unknown"
+)
+
 // Defines values for FunctionRuntimeState.
 const (
 	FunctionRuntimeStateActive   FunctionRuntimeState = "active"
@@ -533,11 +552,11 @@ const (
 
 // Defines values for GetApiV1SandboxesParamsStatus.
 const (
-	Completed   GetApiV1SandboxesParamsStatus = "completed"
-	Failed      GetApiV1SandboxesParamsStatus = "failed"
-	Running     GetApiV1SandboxesParamsStatus = "running"
-	Starting    GetApiV1SandboxesParamsStatus = "starting"
-	Terminating GetApiV1SandboxesParamsStatus = "terminating"
+	GetApiV1SandboxesParamsStatusCompleted   GetApiV1SandboxesParamsStatus = "completed"
+	GetApiV1SandboxesParamsStatusFailed      GetApiV1SandboxesParamsStatus = "failed"
+	GetApiV1SandboxesParamsStatusRunning     GetApiV1SandboxesParamsStatus = "running"
+	GetApiV1SandboxesParamsStatusStarting    GetApiV1SandboxesParamsStatus = "starting"
+	GetApiV1SandboxesParamsStatusTerminating GetApiV1SandboxesParamsStatus = "terminating"
 )
 
 // APIKey defines model for APIKey.
@@ -1109,26 +1128,52 @@ type FunctionRevisionCreateRequest struct {
 	Source  FunctionSourceRequest `json:"source"`
 }
 
+// FunctionRuntimeEvent defines model for FunctionRuntimeEvent.
+type FunctionRuntimeEvent struct {
+	CreatedAt         time.Time                     `json:"created_at"`
+	FunctionId        string                        `json:"function_id"`
+	Id                string                        `json:"id"`
+	Message           *string                       `json:"message,omitempty"`
+	Phase             FunctionRuntimePhase          `json:"phase"`
+	ReadinessState    FunctionRuntimeReadinessState `json:"readiness_state"`
+	Reason            *string                       `json:"reason,omitempty"`
+	RevisionId        string                        `json:"revision_id"`
+	RuntimeContextId  *string                       `json:"runtime_context_id,omitempty"`
+	RuntimeInstanceId *string                       `json:"runtime_instance_id,omitempty"`
+	RuntimeSandboxId  *string                       `json:"runtime_sandbox_id,omitempty"`
+	StartupDurationMs *int32                        `json:"startup_duration_ms,omitempty"`
+	TeamId            string                        `json:"team_id"`
+}
+
 // FunctionRuntimeInstance defines model for FunctionRuntimeInstance.
 type FunctionRuntimeInstance struct {
-	ContextId  *string                      `json:"context_id,omitempty"`
-	CreatedAt  time.Time                    `json:"created_at"`
-	DrainingAt *time.Time                   `json:"draining_at,omitempty"`
-	FailedAt   *time.Time                   `json:"failed_at,omitempty"`
-	FunctionId string                       `json:"function_id"`
-	Id         string                       `json:"id"`
-	LastError  *string                      `json:"last_error,omitempty"`
-	LastUsedAt *time.Time                   `json:"last_used_at,omitempty"`
-	ReadyAt    *time.Time                   `json:"ready_at,omitempty"`
-	RevisionId string                       `json:"revision_id"`
-	SandboxId  string                       `json:"sandbox_id"`
-	State      FunctionRuntimeInstanceState `json:"state"`
-	TeamId     string                       `json:"team_id"`
-	UpdatedAt  time.Time                    `json:"updated_at"`
+	ContextId         *string                       `json:"context_id,omitempty"`
+	CreatedAt         time.Time                     `json:"created_at"`
+	DrainingAt        *time.Time                    `json:"draining_at,omitempty"`
+	FailedAt          *time.Time                    `json:"failed_at,omitempty"`
+	FunctionId        string                        `json:"function_id"`
+	Id                string                        `json:"id"`
+	LastError         *string                       `json:"last_error,omitempty"`
+	LastErrorAt       *time.Time                    `json:"last_error_at,omitempty"`
+	LastUsedAt        *time.Time                    `json:"last_used_at,omitempty"`
+	ReadinessState    FunctionRuntimeReadinessState `json:"readiness_state"`
+	ReadyAt           *time.Time                    `json:"ready_at,omitempty"`
+	RevisionId        string                        `json:"revision_id"`
+	SandboxId         string                        `json:"sandbox_id"`
+	StartupDurationMs *int32                        `json:"startup_duration_ms,omitempty"`
+	State             FunctionRuntimeInstanceState  `json:"state"`
+	TeamId            string                        `json:"team_id"`
+	UpdatedAt         time.Time                     `json:"updated_at"`
 }
 
 // FunctionRuntimeInstanceState defines model for FunctionRuntimeInstanceState.
 type FunctionRuntimeInstanceState string
+
+// FunctionRuntimePhase defines model for FunctionRuntimePhase.
+type FunctionRuntimePhase string
+
+// FunctionRuntimeReadinessState defines model for FunctionRuntimeReadinessState.
+type FunctionRuntimeReadinessState string
 
 // FunctionRuntimeState defines model for FunctionRuntimeState.
 type FunctionRuntimeState string
@@ -1136,11 +1181,16 @@ type FunctionRuntimeState string
 // FunctionRuntimeStatus defines model for FunctionRuntimeStatus.
 type FunctionRuntimeStatus struct {
 	// Autoscaling Function runtime pool autoscaling settings. target_concurrency is a soft routing and scale-out signal; it is not a strong distributed per-instance concurrency semaphore.
-	Autoscaling    FunctionAutoscaling        `json:"autoscaling"`
-	FunctionId     string                     `json:"function_id"`
-	Instances      *[]FunctionRuntimeInstance `json:"instances,omitempty"`
-	RevisionId     string                     `json:"revision_id"`
-	RevisionNumber int32                      `json:"revision_number"`
+	Autoscaling    FunctionAutoscaling           `json:"autoscaling"`
+	FunctionId     string                        `json:"function_id"`
+	Instances      *[]FunctionRuntimeInstance    `json:"instances,omitempty"`
+	LastError      *string                       `json:"last_error,omitempty"`
+	LastErrorAt    *time.Time                    `json:"last_error_at,omitempty"`
+	Phase          FunctionRuntimePhase          `json:"phase"`
+	ReadinessState FunctionRuntimeReadinessState `json:"readiness_state"`
+	RecentEvents   *[]FunctionRuntimeEvent       `json:"recent_events,omitempty"`
+	RevisionId     string                        `json:"revision_id"`
+	RevisionNumber int32                         `json:"revision_number"`
 
 	// RuntimeContextId Compatibility summary for one current runtime process context, if one exists. Use instances for the full runtime pool.
 	RuntimeContextId *string `json:"runtime_context_id,omitempty"`
@@ -1149,8 +1199,9 @@ type FunctionRuntimeStatus struct {
 	RuntimeSandboxId *string `json:"runtime_sandbox_id,omitempty"`
 
 	// RuntimeUpdatedAt Last time the runtime mapping was updated.
-	RuntimeUpdatedAt *time.Time           `json:"runtime_updated_at,omitempty"`
-	State            FunctionRuntimeState `json:"state"`
+	RuntimeUpdatedAt  *time.Time           `json:"runtime_updated_at,omitempty"`
+	StartupDurationMs *int32               `json:"startup_duration_ms,omitempty"`
+	State             FunctionRuntimeState `json:"state"`
 }
 
 // FunctionSourceRequest defines model for FunctionSourceRequest.

--- a/pkg/gateway/functionapi/handler.go
+++ b/pkg/gateway/functionapi/handler.go
@@ -502,7 +502,12 @@ func (h *Handler) getFunctionRuntime(c *gin.Context) {
 		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to list function runtime instances")
 		return
 	}
-	spec.JSONSuccess(c, http.StatusOK, gin.H{"runtime": runtimeStatus(fn, rev, instances)})
+	events, err := h.repo.ListRuntimeEvents(c.Request.Context(), fn.TeamID, fn.ID, rev.ID, 20)
+	if err != nil {
+		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to list function runtime events")
+		return
+	}
+	spec.JSONSuccess(c, http.StatusOK, gin.H{"runtime": runtimeStatus(fn, rev, instances, events)})
 }
 
 func (h *Handler) restartFunctionRuntime(c *gin.Context) {
@@ -567,10 +572,24 @@ func (h *Handler) clearFunctionRuntime(c *gin.Context) {
 		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to clear function runtime")
 		return
 	}
+	if _, err := h.repo.AppendRuntimeEvent(c.Request.Context(), &functions.RuntimeEvent{
+		TeamID:         fn.TeamID,
+		FunctionID:     fn.ID,
+		RevisionID:     rev.ID,
+		Phase:          functions.RuntimePhaseIdle,
+		ReadinessState: functions.RuntimeReadinessStateUnknown,
+		Reason:         "runtime_cleared",
+	}); err != nil {
+		h.logger.Warn("Failed to append function runtime clear event",
+			zap.String("function_id", fn.ID),
+			zap.String("revision_id", rev.ID),
+			zap.Error(err),
+		)
+	}
 	rev.RuntimeSandboxID = nil
 	rev.RuntimeContextID = nil
 	rev.RuntimeUpdatedAt = nil
-	spec.JSONSuccess(c, http.StatusOK, gin.H{"runtime": runtimeStatus(fn, rev, nil)})
+	spec.JSONSuccess(c, http.StatusOK, gin.H{"runtime": runtimeStatus(fn, rev, nil, nil)})
 }
 
 func (h *Handler) loadPublishableService(ctx context.Context, authCtx *authn.AuthContext, source functionSourceRequest) (*mgr.Sandbox, mgr.SandboxAppService, error) {
@@ -679,7 +698,7 @@ func (h *Handler) loadActiveFunctionRevision(c *gin.Context) (*functions.Functio
 	return fn, rev, true
 }
 
-func runtimeStatus(fn *functions.Function, rev *functions.Revision, instances []*functions.RuntimeInstance) functions.RuntimeStatus {
+func runtimeStatus(fn *functions.Function, rev *functions.Revision, instances []*functions.RuntimeInstance, events []*functions.RuntimeEvent) functions.RuntimeStatus {
 	status := functions.RuntimeStatus{}
 	if fn != nil {
 		status.FunctionID = fn.ID
@@ -700,26 +719,135 @@ func runtimeStatus(fn *functions.Function, rev *functions.Revision, instances []
 			}
 		}
 	}
+	if len(events) > 0 {
+		status.RecentEvents = make([]functions.RuntimeEvent, 0, len(events))
+		for _, event := range events {
+			if event != nil {
+				status.RecentEvents = append(status.RecentEvents, *event)
+			}
+		}
+	}
+	latestEvent := latestRuntimeEvent(events)
+	latestFailed := latestRuntimeInstanceByState(instances, functions.RuntimeInstanceStateFailed)
+	latestReady := latestRuntimeInstanceByState(instances, functions.RuntimeInstanceStateReady)
+	if latestReady != nil {
+		status.StartupDurationMS = latestReady.StartupDurationMS
+		status.ReadinessState = latestReady.ReadinessState
+	}
+	if latestFailed != nil {
+		status.LastError = latestFailed.LastError
+		status.LastErrorAt = latestFailed.LastErrorAt
+		if status.LastErrorAt == nil {
+			status.LastErrorAt = latestFailed.FailedAt
+		}
+		if status.StartupDurationMS == nil {
+			status.StartupDurationMS = latestFailed.StartupDurationMS
+		}
+	}
+	if latestEvent != nil {
+		if status.StartupDurationMS == nil {
+			status.StartupDurationMS = latestEvent.StartupDurationMS
+		}
+		if status.LastError == nil && latestEvent.Phase == functions.RuntimePhaseFailed && strings.TrimSpace(latestEvent.Message) != "" {
+			status.LastError = &latestEvent.Message
+			status.LastErrorAt = &latestEvent.CreatedAt
+		}
+	}
 	switch {
 	case fn != nil && !fn.Enabled:
 		status.State = functions.RuntimeStateDisabled
-	case hasReadyFunctionRuntimeInstance(instances):
+		status.Phase = functions.RuntimePhaseDisabled
+		status.ReadinessState = functions.RuntimeReadinessStateUnknown
+	case latestReady != nil:
 		status.State = functions.RuntimeStateActive
+		status.Phase = functions.RuntimePhaseReady
+		status.ReadinessState = functions.RuntimeReadinessStateReady
+	case hasRuntimeInstanceState(instances, functions.RuntimeInstanceStateStarting):
+		status.State = functions.RuntimeStateIdle
+		status.Phase = functions.RuntimePhaseStarting
+		status.ReadinessState = functions.RuntimeReadinessStateChecking
+	case hasRuntimeInstanceState(instances, functions.RuntimeInstanceStateDraining):
+		status.State = functions.RuntimeStateIdle
+		status.Phase = functions.RuntimePhaseDraining
+		status.ReadinessState = functions.RuntimeReadinessStateUnknown
+	case latestFailed != nil:
+		status.State = functions.RuntimeStateIdle
+		status.Phase = functions.RuntimePhaseFailed
+		status.ReadinessState = functions.RuntimeReadinessStateFailed
+	case runtimeEventIsCurrent(latestEvent):
+		status.State = runtimeStateForPhase(latestEvent.Phase)
+		status.Phase = latestEvent.Phase
+		status.ReadinessState = latestEvent.ReadinessState
 	case rev != nil && rev.RuntimeSandboxID != nil && strings.TrimSpace(*rev.RuntimeSandboxID) != "":
 		status.State = functions.RuntimeStateActive
+		status.Phase = functions.RuntimePhaseReady
+		status.ReadinessState = functions.RuntimeReadinessStateUnknown
 	default:
 		status.State = functions.RuntimeStateIdle
+		status.Phase = functions.RuntimePhaseIdle
+		status.ReadinessState = functions.RuntimeReadinessStateUnknown
 	}
 	return status
 }
 
-func hasReadyFunctionRuntimeInstance(instances []*functions.RuntimeInstance) bool {
+func hasRuntimeInstanceState(instances []*functions.RuntimeInstance, state functions.RuntimeInstanceState) bool {
 	for _, inst := range instances {
-		if inst != nil && inst.State == functions.RuntimeInstanceStateReady {
+		if inst != nil && inst.State == state {
 			return true
 		}
 	}
 	return false
+}
+
+func latestRuntimeInstanceByState(instances []*functions.RuntimeInstance, state functions.RuntimeInstanceState) *functions.RuntimeInstance {
+	var latest *functions.RuntimeInstance
+	for _, inst := range instances {
+		if inst == nil || inst.State != state {
+			continue
+		}
+		if latest == nil || inst.UpdatedAt.After(latest.UpdatedAt) {
+			latest = inst
+		}
+	}
+	return latest
+}
+
+func latestRuntimeEvent(events []*functions.RuntimeEvent) *functions.RuntimeEvent {
+	var latest *functions.RuntimeEvent
+	for _, event := range events {
+		if event == nil {
+			continue
+		}
+		if latest == nil || event.CreatedAt.After(latest.CreatedAt) {
+			latest = event
+		}
+	}
+	return latest
+}
+
+func runtimeEventIsCurrent(event *functions.RuntimeEvent) bool {
+	if event == nil {
+		return false
+	}
+	switch event.Phase {
+	case functions.RuntimePhaseProvisioning, functions.RuntimePhaseStarting:
+		return time.Since(event.CreatedAt) <= 5*time.Minute
+	case functions.RuntimePhaseFailed, functions.RuntimePhaseIdle:
+		return true
+	default:
+		return false
+	}
+}
+
+func runtimeStateForPhase(phase functions.RuntimePhase) functions.RuntimeState {
+	switch phase {
+	case functions.RuntimePhaseDisabled:
+		return functions.RuntimeStateDisabled
+	case functions.RuntimePhaseReady:
+		return functions.RuntimeStateActive
+	default:
+		return functions.RuntimeStateIdle
+	}
 }
 
 func (h *Handler) cleanupDeletedFunctionResources(authCtx *authn.AuthContext, revisions []*functions.Revision) {

--- a/pkg/gateway/functionapi/handler_test.go
+++ b/pkg/gateway/functionapi/handler_test.go
@@ -1,6 +1,11 @@
 package functionapi
 
-import "testing"
+import (
+	"testing"
+	"time"
+
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/functions"
+)
 
 func TestTryLockFunctionRevisionPublishSerializesFunction(t *testing.T) {
 	handler := &Handler{}
@@ -27,4 +32,111 @@ func TestTryLockFunctionRevisionPublishSerializesFunction(t *testing.T) {
 		t.Fatal("publish lock was not reusable after release")
 	}
 	reacquired()
+}
+
+func TestRuntimeStatusReportsFailedInstance(t *testing.T) {
+	now := time.Now().UTC()
+	message := "health check returned HTTP 500"
+	fn := &functions.Function{ID: "fn-1", TeamID: "team-1", Enabled: true}
+	rev := &functions.Revision{ID: "rev-1", FunctionID: "fn-1", TeamID: "team-1", RevisionNumber: 2}
+	status := runtimeStatus(fn, rev, []*functions.RuntimeInstance{{
+		ID:             "inst-1",
+		TeamID:         "team-1",
+		FunctionID:     "fn-1",
+		RevisionID:     "rev-1",
+		SandboxID:      "sb-1",
+		State:          functions.RuntimeInstanceStateFailed,
+		ReadinessState: functions.RuntimeReadinessStateFailed,
+		LastError:      &message,
+		LastErrorAt:    &now,
+		FailedAt:       &now,
+		UpdatedAt:      now,
+	}}, nil)
+
+	if status.State != functions.RuntimeStateIdle {
+		t.Fatalf("state = %q, want %q", status.State, functions.RuntimeStateIdle)
+	}
+	if status.Phase != functions.RuntimePhaseFailed {
+		t.Fatalf("phase = %q, want %q", status.Phase, functions.RuntimePhaseFailed)
+	}
+	if status.ReadinessState != functions.RuntimeReadinessStateFailed {
+		t.Fatalf("readiness = %q, want %q", status.ReadinessState, functions.RuntimeReadinessStateFailed)
+	}
+	if status.LastError == nil || *status.LastError != message {
+		t.Fatalf("last_error = %v, want %q", status.LastError, message)
+	}
+}
+
+func TestRuntimeStatusReportsCurrentProvisioningEvent(t *testing.T) {
+	now := time.Now().UTC()
+	fn := &functions.Function{ID: "fn-1", TeamID: "team-1", Enabled: true}
+	rev := &functions.Revision{ID: "rev-1", FunctionID: "fn-1", TeamID: "team-1", RevisionNumber: 2}
+	status := runtimeStatus(fn, rev, nil, []*functions.RuntimeEvent{{
+		ID:             "event-1",
+		TeamID:         "team-1",
+		FunctionID:     "fn-1",
+		RevisionID:     "rev-1",
+		Phase:          functions.RuntimePhaseProvisioning,
+		ReadinessState: functions.RuntimeReadinessStateChecking,
+		Reason:         "claim_runtime",
+		CreatedAt:      now,
+	}})
+
+	if status.State != functions.RuntimeStateIdle {
+		t.Fatalf("state = %q, want %q", status.State, functions.RuntimeStateIdle)
+	}
+	if status.Phase != functions.RuntimePhaseProvisioning {
+		t.Fatalf("phase = %q, want %q", status.Phase, functions.RuntimePhaseProvisioning)
+	}
+	if status.ReadinessState != functions.RuntimeReadinessStateChecking {
+		t.Fatalf("readiness = %q, want %q", status.ReadinessState, functions.RuntimeReadinessStateChecking)
+	}
+	if len(status.RecentEvents) != 1 {
+		t.Fatalf("recent_events = %d, want 1", len(status.RecentEvents))
+	}
+}
+
+func TestRuntimeStatusReadyInstanceOverridesOlderFailure(t *testing.T) {
+	now := time.Now().UTC()
+	earlier := now.Add(-time.Minute)
+	message := "previous startup failed"
+	contextID := "ctx-1"
+	fn := &functions.Function{ID: "fn-1", TeamID: "team-1", Enabled: true}
+	rev := &functions.Revision{ID: "rev-1", FunctionID: "fn-1", TeamID: "team-1", RevisionNumber: 2}
+	status := runtimeStatus(fn, rev, []*functions.RuntimeInstance{
+		{
+			ID:             "failed",
+			TeamID:         "team-1",
+			FunctionID:     "fn-1",
+			RevisionID:     "rev-1",
+			SandboxID:      "sb-old",
+			State:          functions.RuntimeInstanceStateFailed,
+			ReadinessState: functions.RuntimeReadinessStateFailed,
+			LastError:      &message,
+			FailedAt:       &earlier,
+			UpdatedAt:      earlier,
+		},
+		{
+			ID:             "ready",
+			TeamID:         "team-1",
+			FunctionID:     "fn-1",
+			RevisionID:     "rev-1",
+			SandboxID:      "sb-ready",
+			ContextID:      &contextID,
+			State:          functions.RuntimeInstanceStateReady,
+			ReadinessState: functions.RuntimeReadinessStateReady,
+			ReadyAt:        &now,
+			UpdatedAt:      now,
+		},
+	}, nil)
+
+	if status.State != functions.RuntimeStateActive {
+		t.Fatalf("state = %q, want %q", status.State, functions.RuntimeStateActive)
+	}
+	if status.Phase != functions.RuntimePhaseReady {
+		t.Fatalf("phase = %q, want %q", status.Phase, functions.RuntimePhaseReady)
+	}
+	if status.ReadinessState != functions.RuntimeReadinessStateReady {
+		t.Fatalf("readiness = %q, want %q", status.ReadinessState, functions.RuntimeReadinessStateReady)
+	}
 }

--- a/pkg/gateway/functions/models.go
+++ b/pkg/gateway/functions/models.go
@@ -126,6 +126,18 @@ const (
 	RuntimeStateActive   RuntimeState = "active"
 )
 
+type RuntimePhase string
+
+const (
+	RuntimePhaseDisabled     RuntimePhase = "disabled"
+	RuntimePhaseIdle         RuntimePhase = "idle"
+	RuntimePhaseProvisioning RuntimePhase = "provisioning"
+	RuntimePhaseStarting     RuntimePhase = "starting"
+	RuntimePhaseReady        RuntimePhase = "ready"
+	RuntimePhaseDraining     RuntimePhase = "draining"
+	RuntimePhaseFailed       RuntimePhase = "failed"
+)
+
 type RuntimeInstanceState string
 
 const (
@@ -135,31 +147,65 @@ const (
 	RuntimeInstanceStateFailed   RuntimeInstanceState = "failed"
 )
 
+type RuntimeReadinessState string
+
+const (
+	RuntimeReadinessStateUnknown  RuntimeReadinessState = "unknown"
+	RuntimeReadinessStateChecking RuntimeReadinessState = "checking"
+	RuntimeReadinessStateReady    RuntimeReadinessState = "ready"
+	RuntimeReadinessStateFailed   RuntimeReadinessState = "failed"
+)
+
 type RuntimeInstance struct {
-	ID         string               `json:"id"`
-	TeamID     string               `json:"team_id"`
-	FunctionID string               `json:"function_id"`
-	RevisionID string               `json:"revision_id"`
-	SandboxID  string               `json:"sandbox_id"`
-	ContextID  *string              `json:"context_id,omitempty"`
-	State      RuntimeInstanceState `json:"state"`
-	LastError  *string              `json:"last_error,omitempty"`
-	ReadyAt    *time.Time           `json:"ready_at,omitempty"`
-	LastUsedAt *time.Time           `json:"last_used_at,omitempty"`
-	DrainingAt *time.Time           `json:"draining_at,omitempty"`
-	FailedAt   *time.Time           `json:"failed_at,omitempty"`
-	CreatedAt  time.Time            `json:"created_at"`
-	UpdatedAt  time.Time            `json:"updated_at"`
+	ID                string                `json:"id"`
+	TeamID            string                `json:"team_id"`
+	FunctionID        string                `json:"function_id"`
+	RevisionID        string                `json:"revision_id"`
+	SandboxID         string                `json:"sandbox_id"`
+	ContextID         *string               `json:"context_id,omitempty"`
+	State             RuntimeInstanceState  `json:"state"`
+	ReadinessState    RuntimeReadinessState `json:"readiness_state"`
+	StartupDurationMS *int                  `json:"startup_duration_ms,omitempty"`
+	LastError         *string               `json:"last_error,omitempty"`
+	LastErrorAt       *time.Time            `json:"last_error_at,omitempty"`
+	ReadyAt           *time.Time            `json:"ready_at,omitempty"`
+	LastUsedAt        *time.Time            `json:"last_used_at,omitempty"`
+	DrainingAt        *time.Time            `json:"draining_at,omitempty"`
+	FailedAt          *time.Time            `json:"failed_at,omitempty"`
+	CreatedAt         time.Time             `json:"created_at"`
+	UpdatedAt         time.Time             `json:"updated_at"`
+}
+
+type RuntimeEvent struct {
+	ID                string                `json:"id"`
+	TeamID            string                `json:"team_id"`
+	FunctionID        string                `json:"function_id"`
+	RevisionID        string                `json:"revision_id"`
+	RuntimeInstanceID *string               `json:"runtime_instance_id,omitempty"`
+	RuntimeSandboxID  *string               `json:"runtime_sandbox_id,omitempty"`
+	RuntimeContextID  *string               `json:"runtime_context_id,omitempty"`
+	Phase             RuntimePhase          `json:"phase"`
+	ReadinessState    RuntimeReadinessState `json:"readiness_state"`
+	Reason            string                `json:"reason,omitempty"`
+	Message           string                `json:"message,omitempty"`
+	StartupDurationMS *int                  `json:"startup_duration_ms,omitempty"`
+	CreatedAt         time.Time             `json:"created_at"`
 }
 
 type RuntimeStatus struct {
-	FunctionID       string            `json:"function_id"`
-	RevisionID       string            `json:"revision_id"`
-	RevisionNumber   int               `json:"revision_number"`
-	State            RuntimeState      `json:"state"`
-	Autoscaling      Autoscaling       `json:"autoscaling"`
-	RuntimeSandboxID *string           `json:"runtime_sandbox_id,omitempty"`
-	RuntimeContextID *string           `json:"runtime_context_id,omitempty"`
-	RuntimeUpdatedAt *time.Time        `json:"runtime_updated_at,omitempty"`
-	Instances        []RuntimeInstance `json:"instances,omitempty"`
+	FunctionID        string                `json:"function_id"`
+	RevisionID        string                `json:"revision_id"`
+	RevisionNumber    int                   `json:"revision_number"`
+	State             RuntimeState          `json:"state"`
+	Phase             RuntimePhase          `json:"phase"`
+	Autoscaling       Autoscaling           `json:"autoscaling"`
+	ReadinessState    RuntimeReadinessState `json:"readiness_state"`
+	RuntimeSandboxID  *string               `json:"runtime_sandbox_id,omitempty"`
+	RuntimeContextID  *string               `json:"runtime_context_id,omitempty"`
+	RuntimeUpdatedAt  *time.Time            `json:"runtime_updated_at,omitempty"`
+	StartupDurationMS *int                  `json:"startup_duration_ms,omitempty"`
+	LastError         *string               `json:"last_error,omitempty"`
+	LastErrorAt       *time.Time            `json:"last_error_at,omitempty"`
+	Instances         []RuntimeInstance     `json:"instances,omitempty"`
+	RecentEvents      []RuntimeEvent        `json:"recent_events,omitempty"`
 }

--- a/pkg/gateway/functions/repository.go
+++ b/pkg/gateway/functions/repository.go
@@ -339,7 +339,8 @@ func (r *Repository) ListRuntimeInstances(ctx context.Context, teamID, functionI
 		return nil, fmt.Errorf("function repository is not configured")
 	}
 	rows, err := r.pool.Query(ctx, `
-		SELECT id, team_id, function_id, revision_id, sandbox_id, context_id, state, last_error,
+		SELECT id, team_id, function_id, revision_id, sandbox_id, context_id, state,
+			readiness_state, startup_duration_ms, last_error, last_error_at,
 			ready_at, last_used_at, draining_at, failed_at, created_at, updated_at
 		FROM function_runtime_instances
 		WHERE team_id = $1 AND function_id = $2 AND revision_id = $3
@@ -367,6 +368,65 @@ func (r *Repository) ListRuntimeInstances(ctx context.Context, teamID, functionI
 	return out, rows.Err()
 }
 
+func (r *Repository) ListRuntimeEvents(ctx context.Context, teamID, functionID, revisionID string, limit int) ([]*RuntimeEvent, error) {
+	if r == nil || r.pool == nil {
+		return nil, fmt.Errorf("function repository is not configured")
+	}
+	if limit <= 0 {
+		limit = 20
+	}
+	rows, err := r.pool.Query(ctx, `
+		SELECT id, team_id, function_id, revision_id, runtime_instance_id, runtime_sandbox_id,
+			runtime_context_id, phase, readiness_state, reason, message, startup_duration_ms, created_at
+		FROM function_runtime_events
+		WHERE team_id = $1 AND function_id = $2 AND revision_id = $3
+		ORDER BY created_at DESC
+		LIMIT $4
+	`, teamID, functionID, revisionID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make([]*RuntimeEvent, 0, limit)
+	for rows.Next() {
+		event, err := scanRuntimeEvent(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, event)
+	}
+	return out, rows.Err()
+}
+
+func (r *Repository) AppendRuntimeEvent(ctx context.Context, event *RuntimeEvent) (*RuntimeEvent, error) {
+	if r == nil || r.pool == nil {
+		return nil, fmt.Errorf("function repository is not configured")
+	}
+	if event == nil {
+		return nil, fmt.Errorf("runtime event is nil")
+	}
+	if event.ID == "" {
+		event.ID = uuid.NewString()
+	}
+	event.Reason = strings.TrimSpace(event.Reason)
+	event.Message = strings.TrimSpace(event.Message)
+	event.ReadinessState = normalizeRuntimeReadinessState(event.ReadinessState, RuntimeInstanceState(event.Phase))
+	row := r.pool.QueryRow(ctx, `
+		INSERT INTO function_runtime_events (
+			id, team_id, function_id, revision_id, runtime_instance_id, runtime_sandbox_id,
+			runtime_context_id, phase, readiness_state, reason, message, startup_duration_ms
+		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
+		RETURNING id, team_id, function_id, revision_id, runtime_instance_id, runtime_sandbox_id,
+			runtime_context_id, phase, readiness_state, reason, message, startup_duration_ms, created_at
+	`, event.ID, event.TeamID, event.FunctionID, event.RevisionID, event.RuntimeInstanceID, event.RuntimeSandboxID,
+		event.RuntimeContextID, event.Phase, event.ReadinessState, event.Reason, event.Message, event.StartupDurationMS)
+	out, err := scanRuntimeEvent(row)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (r *Repository) CreateRuntimeInstance(ctx context.Context, inst *RuntimeInstance) (*RuntimeInstance, error) {
 	if r == nil || r.pool == nil {
 		return nil, fmt.Errorf("function repository is not configured")
@@ -383,11 +443,13 @@ func (r *Repository) CreateRuntimeInstance(ctx context.Context, inst *RuntimeIns
 	row := r.pool.QueryRow(ctx, `
 		INSERT INTO function_runtime_instances (
 			id, team_id, function_id, revision_id, sandbox_id, context_id, state, last_error,
-			ready_at, last_used_at, draining_at, failed_at
-		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
-		RETURNING id, team_id, function_id, revision_id, sandbox_id, context_id, state, last_error,
+			readiness_state, startup_duration_ms, last_error_at, ready_at, last_used_at, draining_at, failed_at
+		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
+		RETURNING id, team_id, function_id, revision_id, sandbox_id, context_id, state,
+			readiness_state, startup_duration_ms, last_error, last_error_at,
 			ready_at, last_used_at, draining_at, failed_at, created_at, updated_at
 	`, inst.ID, inst.TeamID, inst.FunctionID, inst.RevisionID, inst.SandboxID, inst.ContextID, inst.State, inst.LastError,
+		normalizeRuntimeReadinessState(inst.ReadinessState, inst.State), inst.StartupDurationMS, inst.LastErrorAt,
 		inst.ReadyAt, inst.LastUsedAt, inst.DrainingAt, inst.FailedAt)
 	created, err := scanRuntimeInstance(row)
 	if err != nil {
@@ -396,7 +458,7 @@ func (r *Repository) CreateRuntimeInstance(ctx context.Context, inst *RuntimeIns
 	return created, nil
 }
 
-func (r *Repository) MarkRuntimeInstanceReady(ctx context.Context, teamID, functionID, revisionID, instanceID, sandboxID, contextID string) (*RuntimeInstance, error) {
+func (r *Repository) MarkRuntimeInstanceReady(ctx context.Context, teamID, functionID, revisionID, instanceID, sandboxID, contextID string, startupDurationMS *int) (*RuntimeInstance, error) {
 	if r == nil || r.pool == nil {
 		return nil, fmt.Errorf("function repository is not configured")
 	}
@@ -408,11 +470,13 @@ func (r *Repository) MarkRuntimeInstanceReady(ctx context.Context, teamID, funct
 	row := tx.QueryRow(ctx, `
 		UPDATE function_runtime_instances
 		SET sandbox_id = $5, context_id = $6, state = 'ready', last_error = NULL,
+			last_error_at = NULL, readiness_state = 'ready', startup_duration_ms = COALESCE($7, startup_duration_ms),
 			ready_at = COALESCE(ready_at, NOW()), last_used_at = NOW(), draining_at = NULL, failed_at = NULL
 		WHERE team_id = $1 AND function_id = $2 AND revision_id = $3 AND id = $4
-		RETURNING id, team_id, function_id, revision_id, sandbox_id, context_id, state, last_error,
+		RETURNING id, team_id, function_id, revision_id, sandbox_id, context_id, state,
+			readiness_state, startup_duration_ms, last_error, last_error_at,
 			ready_at, last_used_at, draining_at, failed_at, created_at, updated_at
-	`, teamID, functionID, revisionID, instanceID, sandboxID, contextID)
+	`, teamID, functionID, revisionID, instanceID, sandboxID, contextID, startupDurationMS)
 	inst, err := scanRuntimeInstance(row)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, ErrNotFound
@@ -470,15 +534,21 @@ func (r *Repository) MarkRuntimeInstanceDraining(ctx context.Context, teamID, fu
 }
 
 func (r *Repository) MarkRuntimeInstanceFailed(ctx context.Context, teamID, functionID, revisionID, instanceID, message string) error {
+	return r.MarkRuntimeInstanceFailedWithDetails(ctx, teamID, functionID, revisionID, instanceID, message, nil)
+}
+
+func (r *Repository) MarkRuntimeInstanceFailedWithDetails(ctx context.Context, teamID, functionID, revisionID, instanceID, message string, startupDurationMS *int) error {
 	if r == nil || r.pool == nil {
 		return fmt.Errorf("function repository is not configured")
 	}
 	message = strings.TrimSpace(message)
 	tag, err := r.pool.Exec(ctx, `
 		UPDATE function_runtime_instances
-		SET state = 'failed', last_error = NULLIF($5, ''), failed_at = NOW()
+		SET state = 'failed', last_error = NULLIF($5, ''), last_error_at = NOW(),
+			readiness_state = 'failed', startup_duration_ms = COALESCE($6, startup_duration_ms),
+			failed_at = NOW()
 		WHERE team_id = $1 AND function_id = $2 AND revision_id = $3 AND id = $4
-	`, teamID, functionID, revisionID, instanceID, message)
+	`, teamID, functionID, revisionID, instanceID, message, startupDurationMS)
 	if err != nil {
 		return err
 	}
@@ -559,7 +629,8 @@ func (r *Repository) ListRuntimeScaleDownCandidates(ctx context.Context, limit i
 	}
 	rows, err := r.pool.Query(ctx, `
 		WITH ready_instances AS (
-			SELECT i.id, i.team_id, i.function_id, i.revision_id, i.sandbox_id, i.context_id, i.state, i.last_error,
+			SELECT i.id, i.team_id, i.function_id, i.revision_id, i.sandbox_id, i.context_id, i.state,
+				i.readiness_state, i.startup_duration_ms, i.last_error, i.last_error_at,
 				i.ready_at, i.last_used_at, i.draining_at, i.failed_at, i.created_at, i.updated_at,
 				GREATEST(COALESCE((f.autoscaling->>'min_warm')::int, $2), 0) AS min_warm,
 				GREATEST(COALESCE((f.autoscaling->>'scale_down_after_seconds')::int, $3), $4) AS scale_down_after_seconds,
@@ -571,7 +642,8 @@ func (r *Repository) ListRuntimeScaleDownCandidates(ctx context.Context, limit i
 				AND f.deleted_at IS NULL
 				AND f.active_revision_id = i.revision_id
 		)
-		SELECT id, team_id, function_id, revision_id, sandbox_id, context_id, state, last_error,
+		SELECT id, team_id, function_id, revision_id, sandbox_id, context_id, state,
+			readiness_state, startup_duration_ms, last_error, last_error_at,
 			ready_at, last_used_at, draining_at, failed_at, created_at, updated_at
 		FROM ready_instances
 		WHERE ready_count > min_warm
@@ -854,10 +926,37 @@ func scanAlias(row rowScanner) (*Alias, error) {
 
 func scanRuntimeInstance(row rowScanner) (*RuntimeInstance, error) {
 	var inst RuntimeInstance
-	if err := row.Scan(&inst.ID, &inst.TeamID, &inst.FunctionID, &inst.RevisionID, &inst.SandboxID, &inst.ContextID, &inst.State, &inst.LastError, &inst.ReadyAt, &inst.LastUsedAt, &inst.DrainingAt, &inst.FailedAt, &inst.CreatedAt, &inst.UpdatedAt); err != nil {
+	if err := row.Scan(&inst.ID, &inst.TeamID, &inst.FunctionID, &inst.RevisionID, &inst.SandboxID, &inst.ContextID, &inst.State, &inst.ReadinessState, &inst.StartupDurationMS, &inst.LastError, &inst.LastErrorAt, &inst.ReadyAt, &inst.LastUsedAt, &inst.DrainingAt, &inst.FailedAt, &inst.CreatedAt, &inst.UpdatedAt); err != nil {
 		return nil, err
 	}
+	inst.ReadinessState = normalizeRuntimeReadinessState(inst.ReadinessState, inst.State)
 	return &inst, nil
+}
+
+func scanRuntimeEvent(row rowScanner) (*RuntimeEvent, error) {
+	var event RuntimeEvent
+	if err := row.Scan(&event.ID, &event.TeamID, &event.FunctionID, &event.RevisionID, &event.RuntimeInstanceID, &event.RuntimeSandboxID, &event.RuntimeContextID, &event.Phase, &event.ReadinessState, &event.Reason, &event.Message, &event.StartupDurationMS, &event.CreatedAt); err != nil {
+		return nil, err
+	}
+	event.ReadinessState = normalizeRuntimeReadinessState(event.ReadinessState, RuntimeInstanceState(event.Phase))
+	return &event, nil
+}
+
+func normalizeRuntimeReadinessState(value RuntimeReadinessState, state RuntimeInstanceState) RuntimeReadinessState {
+	switch value {
+	case RuntimeReadinessStateUnknown, RuntimeReadinessStateChecking, RuntimeReadinessStateReady, RuntimeReadinessStateFailed:
+		return value
+	}
+	switch state {
+	case RuntimeInstanceStateStarting:
+		return RuntimeReadinessStateChecking
+	case RuntimeInstanceStateReady:
+		return RuntimeReadinessStateReady
+	case RuntimeInstanceStateFailed:
+		return RuntimeReadinessStateFailed
+	default:
+		return RuntimeReadinessStateUnknown
+	}
 }
 
 func scanRevision(row rowScanner) (*Revision, error) {

--- a/pkg/gateway/migrations/00012_add_function_runtime_status_detail.sql
+++ b/pkg/gateway/migrations/00012_add_function_runtime_status_detail.sql
@@ -1,0 +1,76 @@
+-- +goose Up
+ALTER TABLE function_runtime_instances
+    ADD COLUMN IF NOT EXISTS readiness_state TEXT NOT NULL DEFAULT 'unknown',
+    ADD COLUMN IF NOT EXISTS startup_duration_ms INTEGER,
+    ADD COLUMN IF NOT EXISTS last_error_at TIMESTAMPTZ;
+
+ALTER TABLE function_runtime_instances
+    DROP CONSTRAINT IF EXISTS function_runtime_instances_readiness_state_check;
+ALTER TABLE function_runtime_instances
+    ADD CONSTRAINT function_runtime_instances_readiness_state_check
+        CHECK (readiness_state IN ('unknown', 'checking', 'ready', 'failed'));
+
+ALTER TABLE function_runtime_instances
+    DROP CONSTRAINT IF EXISTS function_runtime_instances_startup_duration_check;
+ALTER TABLE function_runtime_instances
+    ADD CONSTRAINT function_runtime_instances_startup_duration_check
+        CHECK (startup_duration_ms IS NULL OR startup_duration_ms >= 0);
+
+UPDATE function_runtime_instances
+SET readiness_state = CASE
+    WHEN state = 'ready' THEN 'ready'
+    WHEN state = 'failed' THEN 'failed'
+    WHEN state = 'starting' THEN 'checking'
+    ELSE readiness_state
+END,
+last_error_at = CASE
+    WHEN state = 'failed' THEN COALESCE(last_error_at, failed_at, updated_at)
+    ELSE last_error_at
+END
+WHERE readiness_state = 'unknown' OR (state = 'failed' AND last_error_at IS NULL);
+
+CREATE TABLE IF NOT EXISTS function_runtime_events (
+    id UUID PRIMARY KEY,
+    team_id UUID NOT NULL,
+    function_id UUID NOT NULL REFERENCES functions(id) ON DELETE CASCADE,
+    revision_id UUID NOT NULL REFERENCES functions_revisions(id) ON DELETE CASCADE,
+    runtime_instance_id UUID REFERENCES function_runtime_instances(id) ON DELETE SET NULL,
+    runtime_sandbox_id TEXT,
+    runtime_context_id TEXT,
+    phase TEXT NOT NULL,
+    readiness_state TEXT NOT NULL DEFAULT 'unknown',
+    reason TEXT NOT NULL DEFAULT '',
+    message TEXT NOT NULL DEFAULT '',
+    startup_duration_ms INTEGER,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT function_runtime_events_phase_check
+        CHECK (phase IN ('disabled', 'idle', 'provisioning', 'starting', 'ready', 'draining', 'failed')),
+    CONSTRAINT function_runtime_events_readiness_state_check
+        CHECK (readiness_state IN ('unknown', 'checking', 'ready', 'failed')),
+    CONSTRAINT function_runtime_events_startup_duration_check
+        CHECK (startup_duration_ms IS NULL OR startup_duration_ms >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_function_runtime_events_revision
+    ON function_runtime_events(revision_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_function_runtime_events_function
+    ON function_runtime_events(function_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_function_runtime_events_instance
+    ON function_runtime_events(runtime_instance_id, created_at DESC)
+    WHERE runtime_instance_id IS NOT NULL;
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_function_runtime_events_instance;
+DROP INDEX IF EXISTS idx_function_runtime_events_function;
+DROP INDEX IF EXISTS idx_function_runtime_events_revision;
+DROP TABLE IF EXISTS function_runtime_events;
+ALTER TABLE function_runtime_instances
+    DROP CONSTRAINT IF EXISTS function_runtime_instances_startup_duration_check;
+ALTER TABLE function_runtime_instances
+    DROP CONSTRAINT IF EXISTS function_runtime_instances_readiness_state_check;
+ALTER TABLE function_runtime_instances
+    DROP COLUMN IF EXISTS last_error_at;
+ALTER TABLE function_runtime_instances
+    DROP COLUMN IF EXISTS startup_duration_ms;
+ALTER TABLE function_runtime_instances
+    DROP COLUMN IF EXISTS readiness_state;

--- a/pkg/observability/metrics/function_gateway.go
+++ b/pkg/observability/metrics/function_gateway.go
@@ -1,0 +1,156 @@
+package metrics
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sandbox0-ai/sandbox0/pkg/observability/internal/promutil"
+)
+
+// FunctionGatewayMetrics holds product-level Function serving metrics.
+type FunctionGatewayMetrics struct {
+	FunctionRequestsTotal         *prometheus.CounterVec
+	FunctionRequestDuration       *prometheus.HistogramVec
+	FunctionResponseSize          *prometheus.HistogramVec
+	RuntimeAcquireTotal           *prometheus.CounterVec
+	RuntimeStartupDuration        *prometheus.HistogramVec
+	RuntimeStartupFailuresTotal   *prometheus.CounterVec
+	RuntimeLifecycleEventsTotal   *prometheus.CounterVec
+	RuntimeLifecycleEventDuration *prometheus.HistogramVec
+	RuntimeScaleDownTotal         *prometheus.CounterVec
+	RuntimeScaleDownDuration      *prometheus.HistogramVec
+}
+
+func NewFunctionGateway(registry prometheus.Registerer) *FunctionGatewayMetrics {
+	if registry == nil {
+		return nil
+	}
+	prefix := promutil.MetricPrefix("function-gateway")
+	return &FunctionGatewayMetrics{
+		FunctionRequestsTotal: promutil.RegisterCounterVec(registry, prometheus.CounterOpts{
+			Name: prefix + "_function_requests_total",
+			Help: "Total number of function requests served by function-gateway",
+		}, []string{"team_id", "function_id", "revision_id", "route_id", "method", "status"}),
+		FunctionRequestDuration: promutil.RegisterHistogramVec(registry, prometheus.HistogramOpts{
+			Name:    prefix + "_function_request_duration_seconds",
+			Help:    "Function request duration in seconds",
+			Buckets: []float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 30, 60},
+		}, []string{"team_id", "function_id", "revision_id", "route_id", "method"}),
+		FunctionResponseSize: promutil.RegisterHistogramVec(registry, prometheus.HistogramOpts{
+			Name:    prefix + "_function_response_size_bytes",
+			Help:    "Function response size in bytes",
+			Buckets: prometheus.ExponentialBuckets(100, 10, 8),
+		}, []string{"team_id", "function_id", "revision_id", "route_id"}),
+		RuntimeAcquireTotal: promutil.RegisterCounterVec(registry, prometheus.CounterOpts{
+			Name: prefix + "_runtime_acquire_total",
+			Help: "Total number of function runtime acquire attempts",
+		}, []string{"team_id", "function_id", "revision_id", "path", "result", "reason"}),
+		RuntimeStartupDuration: promutil.RegisterHistogramVec(registry, prometheus.HistogramOpts{
+			Name:    prefix + "_runtime_startup_duration_seconds",
+			Help:    "Function runtime startup duration in seconds",
+			Buckets: []float64{.01, .025, .05, .1, .2, .5, 1, 2.5, 5, 10, 30, 60, 120},
+		}, []string{"team_id", "function_id", "revision_id", "result", "readiness"}),
+		RuntimeStartupFailuresTotal: promutil.RegisterCounterVec(registry, prometheus.CounterOpts{
+			Name: prefix + "_runtime_startup_failures_total",
+			Help: "Total number of function runtime startup failures",
+		}, []string{"team_id", "function_id", "revision_id", "reason"}),
+		RuntimeLifecycleEventsTotal: promutil.RegisterCounterVec(registry, prometheus.CounterOpts{
+			Name: prefix + "_runtime_lifecycle_events_total",
+			Help: "Total number of function runtime lifecycle events",
+		}, []string{"team_id", "function_id", "revision_id", "phase", "reason"}),
+		RuntimeLifecycleEventDuration: promutil.RegisterHistogramVec(registry, prometheus.HistogramOpts{
+			Name:    prefix + "_runtime_lifecycle_event_duration_seconds",
+			Help:    "Duration attached to function runtime lifecycle events",
+			Buckets: []float64{.01, .025, .05, .1, .2, .5, 1, 2.5, 5, 10, 30, 60, 120},
+		}, []string{"team_id", "function_id", "revision_id", "phase"}),
+		RuntimeScaleDownTotal: promutil.RegisterCounterVec(registry, prometheus.CounterOpts{
+			Name: prefix + "_runtime_scale_down_total",
+			Help: "Total number of function runtime scale-down attempts",
+		}, []string{"team_id", "function_id", "revision_id", "result", "reason"}),
+		RuntimeScaleDownDuration: promutil.RegisterHistogramVec(registry, prometheus.HistogramOpts{
+			Name:    prefix + "_runtime_scale_down_duration_seconds",
+			Help:    "Function runtime scale-down duration in seconds",
+			Buckets: prometheus.DefBuckets,
+		}, []string{"team_id", "function_id", "revision_id", "result"}),
+	}
+}
+
+func (m *FunctionGatewayMetrics) ObserveFunctionRequest(teamID, functionID, revisionID, routeID, method string, status int, duration time.Duration, responseSize int) {
+	if m == nil {
+		return
+	}
+	statusLabel := strconv.Itoa(status)
+	m.FunctionRequestsTotal.WithLabelValues(label(teamID), label(functionID), label(revisionID), label(routeID), label(method), statusLabel).Inc()
+	m.FunctionRequestDuration.WithLabelValues(label(teamID), label(functionID), label(revisionID), label(routeID), label(method)).Observe(duration.Seconds())
+	if responseSize > 0 {
+		m.FunctionResponseSize.WithLabelValues(label(teamID), label(functionID), label(revisionID), label(routeID)).Observe(float64(responseSize))
+	}
+}
+
+func (m *FunctionGatewayMetrics) ObserveRuntimeAcquire(teamID, functionID, revisionID, path, result, reason string) {
+	if m == nil {
+		return
+	}
+	m.RuntimeAcquireTotal.WithLabelValues(label(teamID), label(functionID), label(revisionID), label(path), label(result), reasonLabel(reason)).Inc()
+}
+
+func (m *FunctionGatewayMetrics) ObserveRuntimeStartup(teamID, functionID, revisionID, result, readiness string, duration time.Duration) {
+	if m == nil {
+		return
+	}
+	m.RuntimeStartupDuration.WithLabelValues(label(teamID), label(functionID), label(revisionID), label(result), label(readiness)).Observe(duration.Seconds())
+}
+
+func (m *FunctionGatewayMetrics) ObserveRuntimeStartupFailure(teamID, functionID, revisionID, reason string) {
+	if m == nil {
+		return
+	}
+	m.RuntimeStartupFailuresTotal.WithLabelValues(label(teamID), label(functionID), label(revisionID), reasonLabel(reason)).Inc()
+}
+
+func (m *FunctionGatewayMetrics) ObserveRuntimeLifecycleEvent(teamID, functionID, revisionID, phase, reason string, duration time.Duration) {
+	if m == nil {
+		return
+	}
+	m.RuntimeLifecycleEventsTotal.WithLabelValues(label(teamID), label(functionID), label(revisionID), label(phase), reasonLabel(reason)).Inc()
+	if duration > 0 {
+		m.RuntimeLifecycleEventDuration.WithLabelValues(label(teamID), label(functionID), label(revisionID), label(phase)).Observe(duration.Seconds())
+	}
+}
+
+func (m *FunctionGatewayMetrics) ObserveRuntimeScaleDown(teamID, functionID, revisionID, result, reason string, duration time.Duration) {
+	if m == nil {
+		return
+	}
+	m.RuntimeScaleDownTotal.WithLabelValues(label(teamID), label(functionID), label(revisionID), label(result), reasonLabel(reason)).Inc()
+	if duration > 0 {
+		m.RuntimeScaleDownDuration.WithLabelValues(label(teamID), label(functionID), label(revisionID), label(result)).Observe(duration.Seconds())
+	}
+}
+
+func label(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "unknown"
+	}
+	return value
+}
+
+func reasonLabel(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "none"
+	}
+	if len(value) > 80 {
+		return "other"
+	}
+	for _, r := range value {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_' || r == '-' {
+			continue
+		}
+		return "other"
+	}
+	return value
+}


### PR DESCRIPTION
## Summary
- expand function runtime status with phase, readiness, startup duration, last error metadata, per-instance readiness, and recent lifecycle events
- record runtime lifecycle events in the gateway database and surface them from runtime status
- add function-gateway metrics, spans, and structured log fields using the existing pkg/observability stack, with OpenAPI/generated types and docs updates

## Validation
- make apispec
- make proto
- go test ./pkg/apispec ./pkg/gateway/functionapi ./pkg/gateway/functions ./function-gateway/pkg/http ./pkg/observability/metrics
- GOFLAGS=-buildvcs=false go list ./... | rg -v '^github.com/sandbox0-ai/sandbox0/tests/e2e/scenarios/single-cluster$' | xargs -r go test -buildvcs=false

## Notes
- go test ./... still requires the local e2e image sandbox0ai/infra:latest; this environment does not have it, so the single-cluster e2e BeforeAll fails while loading that image.
- make proto generates storage-proxy/proto/fs/filesystem.pb.go locally; it is gitignored.