### PR TITLE
Document function autoscaling defaults

### DIFF
--- a/docs/function/autoscaling/page.mdx
+++ b/docs/function/autoscaling/page.mdx
@@ -1,0 +1,95 @@
+# Function Autoscaling
+
+Function Gateway maintains a runtime pool for the active revision. Each runtime instance is a restored sandbox plus the process context serving the published service. Requests are routed to ready instances using local in-flight request counts and the function's autoscaling settings.
+
+`autoscaling` is optional when creating or updating a function. When omitted, Sandbox0 uses the defaults below. When provided, the autoscaling object must include all four fields.
+
+| Setting | Default | Accepted Value | Meaning |
+|---------|---------|----------------|---------|
+| `min_warm` | `0` | `>= 0` | Minimum ready runtime sandboxes kept after traffic has created capacity |
+| `max_active` | `20` | `>= 1` | Hard upper bound for active runtime sandboxes for the function |
+| `target_concurrency` | `80` | `>= 1` | Soft per-runtime in-flight request target used for routing and scale-out |
+| `scale_down_after_seconds` | `300` | `>= 30` | Idle time before extra runtime sandboxes above `min_warm` are removed |
+
+`target_concurrency` is not a strong distributed single-instance concurrency semaphore. Multiple Function Gateway replicas can still route to the same runtime at the same time. The hard limit is `max_active`, which bounds the runtime pool size.
+
+`min_warm` controls retained ready capacity after the runtime pool has been created. Use `min_warm: 0` for scale-to-zero behavior, or a positive value when the function should keep warm runtime sandboxes once capacity exists.
+
+## Update Autoscaling
+
+<Endpoint method="PUT">
+/api/v1/functions/{'{id}'}
+</Endpoint>
+
+Autoscaling updates change the runtime pool policy for the function. The gateway uses the new `target_concurrency` for routing and scale-out decisions, and `max_active` remains the hard pool-size limit.
+
+<Tabs
+  tabs={[
+    {
+      label: "Go",
+      language: "go",
+      code: `fn, err := client.UpdateFunctionWithOptions(
+    ctx,
+    functionID,
+    sandbox0.WithFunctionUpdateAutoscaling(sandbox0.FunctionAutoscaling(1, 4, 20, 300)),
+)
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Printf("max active=%d\\n", fn.Autoscaling.MaxActive)`
+    },
+    {
+      label: "Python",
+      language: "python",
+      code: `from sandbox0 import FunctionAutoscaling
+from sandbox0.apispec.models.function_update_request import FunctionUpdateRequest
+
+fn = client.functions.update(
+    function_id,
+    FunctionUpdateRequest(
+        autoscaling=FunctionAutoscaling(
+            min_warm=1,
+            max_active=4,
+            target_concurrency=20,
+            scale_down_after_seconds=300,
+        ),
+    ),
+)
+print(f"max active={fn.autoscaling.max_active}")`
+    },
+    {
+      label: "TypeScript",
+      language: "typescript",
+      code: `const fn = await client.functions.update(functionId, {
+    autoscaling: {
+        minWarm: 1,
+        maxActive: 4,
+        targetConcurrency: 20,
+        scaleDownAfterSeconds: 300,
+    },
+});
+console.log('max active=', fn.autoscaling.maxActive);`
+    },
+    {
+      label: "CLI",
+      language: "bash",
+      code: `s0 function update fn_abc123 \\
+    --min-warm 1 \\
+    --max-active 4 \\
+    --target-concurrency 20 \\
+    --scale-down-after-seconds 300`
+    }
+  ]}
+/>
+
+## Next Steps
+
+<CardGroup>
+  <Card title="Runtime" href="/docs/function/runtime" cta="Continue">
+    Inspect, restart, and recycle function runtime sandboxes.
+  </Card>
+
+  <Card title="Publish Functions" href="/docs/function/publish" cta="Continue">
+    Configure a publishable service and create a function from it.
+  </Card>
+</CardGroup>

--- a/docs/function/page.mdx
+++ b/docs/function/page.mdx
@@ -51,6 +51,10 @@ Use Sandbox Services route policy for path matching, allowed methods, bearer/hea
     Publish new revisions, promote them, and roll back with aliases.
   </Card>
 
+  <Card title="Autoscaling" href="/docs/function/autoscaling" cta="Continue">
+    Tune warm runtime capacity, scale-out targets, and scale-down behavior.
+  </Card>
+
   <Card title="Runtime" href="/docs/function/runtime" cta="Continue">
     Inspect, restart, disable, and delete function runtimes.
   </Card>

--- a/docs/function/publish/page.mdx
+++ b/docs/function/publish/page.mdx
@@ -188,7 +188,7 @@ for (const service of services.services) {
 /api/v1/functions
 </Endpoint>
 
-Creating a function creates the stable function record, revision 1, and the `production` alias.
+Creating a function creates the stable function record, revision 1, and the `production` alias. Autoscaling settings are optional; omitted values use the defaults documented in [Function Autoscaling](/docs/function/autoscaling).
 
 <Tabs
   tabs={[
@@ -269,6 +269,10 @@ curl "$FUNCTION_URL/"
 <CardGroup>
   <Card title="Revisions And Aliases" href="/docs/function/revisions" cta="Continue">
     Publish and promote new versions without changing the function URL.
+  </Card>
+
+  <Card title="Autoscaling" href="/docs/function/autoscaling" cta="Continue">
+    Tune runtime pool defaults and scale-out behavior.
   </Card>
 
   <Card title="Sandbox Services" href="/docs/sandbox/services" cta="Continue">

--- a/docs/function/revisions/page.mdx
+++ b/docs/function/revisions/page.mdx
@@ -187,6 +187,10 @@ for (const alias of aliases) {
     Inspect and reset the runtime sandbox serving production traffic.
   </Card>
 
+  <Card title="Autoscaling" href="/docs/function/autoscaling" cta="Continue">
+    Configure runtime pool size and scale-out behavior.
+  </Card>
+
   <Card title="Publish Functions" href="/docs/function/publish" cta="Continue">
     Create another publishable service and publish it as a revision.
   </Card>

--- a/docs/function/runtime/page.mdx
+++ b/docs/function/runtime/page.mdx
@@ -2,85 +2,7 @@
 
 Function runtime state describes the restored sandbox pool serving a function revision. Function Gateway serves production traffic from revision runtime sandboxes, not from the mutable source sandbox. When no reusable runtime exists, Function Gateway restores a runtime sandbox from the revision's template and revision-owned volumes.
 
-## Autoscaling
-
-Function Gateway maintains a runtime pool for the active revision. Each runtime instance is a restored sandbox plus the process context serving the published service. Requests are routed to ready instances using local in-flight request counts and the function's autoscaling settings.
-
-| Setting | Meaning |
-|---------|---------|
-| `min_warm` | Minimum ready runtime sandboxes kept after traffic has created capacity |
-| `max_active` | Hard upper bound for active runtime sandboxes for the function |
-| `target_concurrency` | Soft per-runtime in-flight request target used for routing and scale-out |
-| `scale_down_after_seconds` | Idle time before extra runtime sandboxes above `min_warm` are removed |
-
-`target_concurrency` is not a strong distributed single-instance concurrency semaphore. Multiple Function Gateway replicas can still route to the same runtime at the same time. The hard limit is `max_active`, which bounds the runtime pool size.
-
-## Update Autoscaling
-
-<Endpoint method="PUT">
-/api/v1/functions/{'{id}'}
-</Endpoint>
-
-Autoscaling updates change the runtime pool policy for the function. The gateway uses the new `target_concurrency` for routing and scale-out decisions, and `max_active` remains the hard pool-size limit.
-
-<Tabs
-  tabs={[
-    {
-      label: "Go",
-      language: "go",
-      code: `fn, err := client.UpdateFunctionWithOptions(
-    ctx,
-    functionID,
-    sandbox0.WithFunctionUpdateAutoscaling(sandbox0.FunctionAutoscaling(1, 4, 20, 300)),
-)
-if err != nil {
-    log.Fatal(err)
-}
-fmt.Printf("max active=%d\\n", fn.Autoscaling.MaxActive)`
-    },
-    {
-      label: "Python",
-      language: "python",
-      code: `from sandbox0 import FunctionAutoscaling
-from sandbox0.apispec.models.function_update_request import FunctionUpdateRequest
-
-fn = client.functions.update(
-    function_id,
-    FunctionUpdateRequest(
-        autoscaling=FunctionAutoscaling(
-            min_warm=1,
-            max_active=4,
-            target_concurrency=20,
-            scale_down_after_seconds=300,
-        ),
-    ),
-)
-print(f"max active={fn.autoscaling.max_active}")`
-    },
-    {
-      label: "TypeScript",
-      language: "typescript",
-      code: `const fn = await client.functions.update(functionId, {
-    autoscaling: {
-        minWarm: 1,
-        maxActive: 4,
-        targetConcurrency: 20,
-        scaleDownAfterSeconds: 300,
-    },
-});
-console.log('max active=', fn.autoscaling.maxActive);`
-    },
-    {
-      label: "CLI",
-      language: "bash",
-      code: `s0 function update fn_abc123 \\
-    --min-warm 1 \\
-    --max-active 4 \\
-    --target-concurrency 20 \\
-    --scale-down-after-seconds 300`
-    }
-  ]}
-/>
+Runtime pool size and scale-out behavior are configured on the function's autoscaling policy. See [Function Autoscaling](/docs/function/autoscaling) for defaults, limits, and update examples.
 
 ## Startup Readiness
 
@@ -296,6 +218,10 @@ console.log('deleted function:', fn.id);`
 ## Next Steps
 
 <CardGroup>
+  <Card title="Autoscaling" href="/docs/function/autoscaling" cta="Continue">
+    Configure runtime pool size and scale-out behavior.
+  </Card>
+
   <Card title="Revisions And Aliases" href="/docs/function/revisions" cta="Continue">
     Move production traffic between immutable function revisions.
   </Card>

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -74,6 +74,10 @@
           "title": "Revisions And Aliases"
         },
         {
+          "slug": "autoscaling",
+          "title": "Autoscaling"
+        },
+        {
           "slug": "runtime",
           "title": "Runtime"
         }


### PR DESCRIPTION
## Summary
- add a dedicated Function Autoscaling docs page
- document autoscaling defaults and accepted minimums
- move autoscaling update examples out of the runtime page and link the new page from function docs

## Validation
- git diff --check