### PR TITLE
fix function runtime gc

### DIFF
--- a/cluster-gateway/pkg/http/function_runtime_headers_test.go
+++ b/cluster-gateway/pkg/http/function_runtime_headers_test.go
@@ -1,0 +1,42 @@
+package http
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/sandbox0-ai/sandbox0/pkg/functionruntime"
+	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+)
+
+func TestSanitizeFunctionRuntimeClaimHeadersClearsUntrustedCaller(t *testing.T) {
+	header := http.Header{}
+	functionruntime.SetHeaders(header, functionruntime.Metadata{
+		OwnerKind:                 functionruntime.OwnerKind,
+		FunctionID:                "fn-1",
+		FunctionRevisionID:        "rev-1",
+		FunctionRuntimeInstanceID: "inst-1",
+	})
+
+	sanitizeFunctionRuntimeClaimHeaders(header, &internalauth.Claims{Caller: internalauth.ServiceRegionalGateway})
+
+	if metadata := functionruntime.FromHeaders(header); metadata != nil {
+		t.Fatalf("metadata headers were not cleared: %#v", metadata)
+	}
+}
+
+func TestSanitizeFunctionRuntimeClaimHeadersPreservesFunctionGatewayCaller(t *testing.T) {
+	header := http.Header{}
+	functionruntime.SetHeaders(header, functionruntime.Metadata{
+		OwnerKind:                 functionruntime.OwnerKind,
+		FunctionID:                "fn-1",
+		FunctionRevisionID:        "rev-1",
+		FunctionRuntimeInstanceID: "inst-1",
+	})
+
+	sanitizeFunctionRuntimeClaimHeaders(header, &internalauth.Claims{Caller: internalauth.ServiceFunctionGateway})
+
+	metadata := functionruntime.FromHeaders(header)
+	if metadata == nil || metadata.FunctionID != "fn-1" {
+		t.Fatalf("metadata headers were not preserved: %#v", metadata)
+	}
+}

--- a/cluster-gateway/pkg/http/handlers_sandbox.go
+++ b/cluster-gateway/pkg/http/handlers_sandbox.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/sandbox0-ai/sandbox0/cluster-gateway/pkg/client"
 	"github.com/sandbox0-ai/sandbox0/cluster-gateway/pkg/middleware"
+	"github.com/sandbox0-ai/sandbox0/pkg/functionruntime"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"github.com/sandbox0-ai/sandbox0/pkg/proxy"
@@ -45,8 +46,21 @@ func (s *Server) proxyToManager(c *gin.Context) {
 func (s *Server) createSandbox(c *gin.Context) {
 	// Rewrite path for manager
 	c.Request.URL.Path = "/api/v1/sandboxes"
+	sanitizeFunctionRuntimeClaimHeaders(c.Request.Header, internalauth.ClaimsFromContext(c.Request.Context()))
 
 	s.proxyToManager(c)
+}
+
+func sanitizeFunctionRuntimeClaimHeaders(header http.Header, claims *internalauth.Claims) {
+	if claims == nil {
+		functionruntime.ClearHeaders(header)
+		return
+	}
+	switch claims.Caller {
+	case internalauth.ServiceFunctionGateway, internalauth.ServiceScheduler:
+	default:
+		functionruntime.ClearHeaders(header)
+	}
 }
 
 // listSandboxes lists all sandboxes for the authenticated team

--- a/docs/function/runtime/page.mdx
+++ b/docs/function/runtime/page.mdx
@@ -52,6 +52,12 @@ can be diagnosed without searching gateway logs.
 
 `restart` and `recycle` both delete the current restored runtime pool when one exists and clear the runtime mapping. The next function request starts fresh runtime instances from the active revision.
 
+## Runtime Cleanup
+
+Runtime sandboxes created for Function revisions carry Sandbox0 ownership metadata for the function, revision, and runtime instance that claimed them. Function Gateway periodically reconciles runtime instances and retries cleanup for sandboxes that belong to deleted or disabled functions, inactive revisions, failed startups, stale starting attempts, and runtime instances that are already draining.
+
+Cleanup is idempotent. A missing sandbox is treated as already deleted, and the runtime instance record is kept until the gateway has confirmed deletion so later GC runs can retry failed cleanup.
+
 ## Get Runtime Status
 
 <Endpoint method="GET">

--- a/function-gateway/pkg/http/autoscaler.go
+++ b/function-gateway/pkg/http/autoscaler.go
@@ -176,6 +176,7 @@ func (a *functionAutoscaler) cleanupRuntimeInstance(ctx context.Context, inst *f
 		return
 	}
 	a.server.observeRuntimeScaleDown(inst, "success", nil, time.Since(cleanupStarted))
+	a.server.recordRuntimeLifecycleEvent(ctx, &functions.Function{ID: inst.FunctionID, TeamID: inst.TeamID}, &functions.Revision{ID: inst.RevisionID, FunctionID: inst.FunctionID, TeamID: inst.TeamID}, inst, functions.RuntimePhaseIdle, functions.RuntimeReadinessStateUnknown, "runtime_gc_deleted", nil, time.Since(cleanupStarted))
 	if err := a.server.functionRepo.DeleteRuntimeInstance(ctx, inst.TeamID, inst.FunctionID, inst.RevisionID, inst.ID); err != nil && !errorsIsFunctionNotFound(err) {
 		a.logger.Warn("Failed to delete cleaned-up function runtime instance",
 			zap.String("function_id", inst.FunctionID),
@@ -185,7 +186,6 @@ func (a *functionAutoscaler) cleanupRuntimeInstance(ctx context.Context, inst *f
 		)
 		return
 	}
-	a.server.recordRuntimeLifecycleEvent(ctx, &functions.Function{ID: inst.FunctionID, TeamID: inst.TeamID}, &functions.Revision{ID: inst.RevisionID, FunctionID: inst.FunctionID, TeamID: inst.TeamID}, inst, functions.RuntimePhaseIdle, functions.RuntimeReadinessStateUnknown, "runtime_gc_deleted", nil, time.Since(cleanupStarted))
 }
 
 func (a *functionAutoscaler) acquire(ctx context.Context, fn *functions.Function, rev *functions.Revision, service mgr.SandboxAppService) (*functionRuntimeLease, *functions.Revision, error) {

--- a/function-gateway/pkg/http/autoscaler.go
+++ b/function-gateway/pkg/http/autoscaler.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	mgr "github.com/sandbox0-ai/sandbox0/manager/pkg/service"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/functions"
 	"go.uber.org/zap"
@@ -66,6 +67,7 @@ func (a *functionAutoscaler) Run(ctx context.Context) {
 			return
 		case <-ticker.C:
 			a.scaleDownIdleRuntimes(ctx)
+			a.cleanupRuntimeInstances(ctx)
 		}
 	}
 }
@@ -121,6 +123,69 @@ func (a *functionAutoscaler) scaleDownIdleRuntimes(ctx context.Context) {
 			)
 		}
 	}
+}
+
+func (a *functionAutoscaler) cleanupRuntimeInstances(ctx context.Context) {
+	instances, err := a.server.functionRepo.ListRuntimeCleanupCandidates(ctx, 100)
+	if err != nil {
+		a.logger.Warn("Failed to list function runtime cleanup candidates", zap.Error(err))
+		return
+	}
+	for _, inst := range instances {
+		a.cleanupRuntimeInstance(ctx, inst)
+	}
+}
+
+func (a *functionAutoscaler) cleanupRuntimeInstance(ctx context.Context, inst *functions.RuntimeInstance) {
+	if inst == nil || strings.TrimSpace(inst.SandboxID) == "" {
+		return
+	}
+	if a.hasLocalInflight(inst.SandboxID) {
+		return
+	}
+	if inst.State != functions.RuntimeInstanceStateDraining && inst.State != functions.RuntimeInstanceStateFailed {
+		if err := a.server.functionRepo.MarkRuntimeInstanceDraining(ctx, inst.TeamID, inst.FunctionID, inst.RevisionID, inst.ID); err != nil {
+			if !errorsIsFunctionNotFound(err) {
+				a.logger.Warn("Failed to mark function runtime cleanup candidate draining",
+					zap.String("function_id", inst.FunctionID),
+					zap.String("revision_id", inst.RevisionID),
+					zap.String("runtime_instance_id", inst.ID),
+					zap.Error(err),
+				)
+			}
+			return
+		}
+		inst.State = functions.RuntimeInstanceStateDraining
+		a.server.recordRuntimeLifecycleEvent(ctx, &functions.Function{ID: inst.FunctionID, TeamID: inst.TeamID}, &functions.Revision{ID: inst.RevisionID, FunctionID: inst.FunctionID, TeamID: inst.TeamID}, inst, functions.RuntimePhaseDraining, inst.ReadinessState, "runtime_gc", nil, 0)
+	}
+
+	deleteCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	cleanupStarted := time.Now()
+	err := a.server.deleteSandboxViaClusterGateway(deleteCtx, inst.SandboxID, inst.TeamID, "")
+	cancel()
+	if err != nil {
+		a.server.observeRuntimeScaleDown(inst, "error", err, time.Since(cleanupStarted))
+		a.markRuntimeInstanceFailed(context.Background(), &functions.Function{ID: inst.FunctionID, TeamID: inst.TeamID}, &functions.Revision{ID: inst.RevisionID, FunctionID: inst.FunctionID, TeamID: inst.TeamID}, inst, err, 0)
+		a.logger.Warn("Failed to delete function runtime cleanup candidate",
+			zap.String("function_id", inst.FunctionID),
+			zap.String("revision_id", inst.RevisionID),
+			zap.String("runtime_instance_id", inst.ID),
+			zap.String("runtime_sandbox_id", inst.SandboxID),
+			zap.Error(err),
+		)
+		return
+	}
+	a.server.observeRuntimeScaleDown(inst, "success", nil, time.Since(cleanupStarted))
+	if err := a.server.functionRepo.DeleteRuntimeInstance(ctx, inst.TeamID, inst.FunctionID, inst.RevisionID, inst.ID); err != nil && !errorsIsFunctionNotFound(err) {
+		a.logger.Warn("Failed to delete cleaned-up function runtime instance",
+			zap.String("function_id", inst.FunctionID),
+			zap.String("revision_id", inst.RevisionID),
+			zap.String("runtime_instance_id", inst.ID),
+			zap.Error(err),
+		)
+		return
+	}
+	a.server.recordRuntimeLifecycleEvent(ctx, &functions.Function{ID: inst.FunctionID, TeamID: inst.TeamID}, &functions.Revision{ID: inst.RevisionID, FunctionID: inst.FunctionID, TeamID: inst.TeamID}, inst, functions.RuntimePhaseIdle, functions.RuntimeReadinessStateUnknown, "runtime_gc_deleted", nil, time.Since(cleanupStarted))
 }
 
 func (a *functionAutoscaler) acquire(ctx context.Context, fn *functions.Function, rev *functions.Revision, service mgr.SandboxAppService) (*functionRuntimeLease, *functions.Revision, error) {
@@ -284,14 +349,16 @@ func (a *functionAutoscaler) createRuntimeInstance(ctx context.Context, fn *func
 			return fmt.Errorf("function runtime capacity is starting")
 		}
 
+		runtimeInstanceID := uuid.NewString()
 		a.server.recordRuntimeLifecycleEvent(runCtx, fn, currentRev, nil, functions.RuntimePhaseProvisioning, functions.RuntimeReadinessStateChecking, "claim_runtime", nil, 0)
-		claim, err := a.server.claimFunctionSandboxViaClusterGateway(runCtx, fn, currentRev, service)
+		claim, err := a.server.claimFunctionSandboxViaClusterGateway(runCtx, fn, currentRev, service, runtimeInstanceID)
 		if err != nil {
 			a.server.observeRuntimeStartup(fn, currentRev, "error", functions.RuntimeReadinessStateFailed, time.Since(startupStarted), err)
 			a.server.recordRuntimeLifecycleEvent(runCtx, fn, currentRev, nil, functions.RuntimePhaseFailed, functions.RuntimeReadinessStateFailed, functionRuntimeErrorReason(err), err, time.Since(startupStarted))
 			return err
 		}
 		inst, err := a.server.functionRepo.CreateRuntimeInstance(runCtx, &functions.RuntimeInstance{
+			ID:         runtimeInstanceID,
 			TeamID:     fn.TeamID,
 			FunctionID: fn.ID,
 			RevisionID: currentRev.ID,

--- a/function-gateway/pkg/http/autoscaler_test.go
+++ b/function-gateway/pkg/http/autoscaler_test.go
@@ -1,9 +1,25 @@
 package http
 
 import (
+	"context"
+	"crypto/ed25519"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
+	"github.com/sandbox0-ai/sandbox0/pkg/dbpool"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/functions"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/migrations"
+	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+	"github.com/sandbox0-ai/sandbox0/pkg/migrate"
+	"go.uber.org/zap"
 )
 
 func TestFunctionAutoscalerReserveReadyHonorsTargetConcurrency(t *testing.T) {
@@ -88,4 +104,138 @@ func TestActiveRuntimeInstanceCountIncludesAllocatedCapacity(t *testing.T) {
 	if got := activeRuntimeInstanceCount(instances); got != 3 {
 		t.Fatalf("activeRuntimeInstanceCount() = %d, want 3", got)
 	}
+}
+
+func TestCleanupRuntimeInstanceRecordsDeletedEventBeforeDeletingInstance(t *testing.T) {
+	ctx := context.Background()
+	pool := newFunctionAutoscalerTestPool(t)
+	repo := functions.NewRepository(pool)
+
+	teamID := uuid.NewString()
+	userID := uuid.NewString()
+	fn := functions.NewFunction(teamID, "runtime gc event", userID)
+	rev, err := functions.NewRevision(teamID, "source-sandbox", "api", "default", map[string]any{"id": "api"}, nil, userID)
+	if err != nil {
+		t.Fatalf("NewRevision() error = %v", err)
+	}
+	fn, rev, err = repo.CreateFunctionWithRevision(ctx, fn, rev, userID)
+	if err != nil {
+		t.Fatalf("CreateFunctionWithRevision() error = %v", err)
+	}
+	failedAt := time.Now().UTC().Add(-10 * time.Minute)
+	inst, err := repo.CreateRuntimeInstance(ctx, &functions.RuntimeInstance{
+		TeamID:         teamID,
+		FunctionID:     fn.ID,
+		RevisionID:     rev.ID,
+		SandboxID:      "runtime-sandbox",
+		State:          functions.RuntimeInstanceStateFailed,
+		ReadinessState: functions.RuntimeReadinessStateFailed,
+		FailedAt:       &failedAt,
+	})
+	if err != nil {
+		t.Fatalf("CreateRuntimeInstance() error = %v", err)
+	}
+
+	clusterGateway := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("method = %s, want DELETE", r.Method)
+		}
+		if r.URL.Path != "/api/v1/sandboxes/runtime-sandbox" {
+			t.Errorf("path = %s, want runtime sandbox delete path", r.URL.Path)
+		}
+		if r.Header.Get(internalauth.DefaultTokenHeader) == "" {
+			t.Error("internal auth header is empty")
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer clusterGateway.Close()
+
+	_, privateKey, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate ed25519 keypair: %v", err)
+	}
+	server := &Server{
+		cfg: &config.FunctionGatewayConfig{
+			DefaultClusterGatewayURL: clusterGateway.URL,
+		},
+		functionRepo: repo,
+		internalAuthGen: internalauth.NewGenerator(internalauth.GeneratorConfig{
+			Caller:     internalauth.ServiceFunctionGateway,
+			PrivateKey: privateKey,
+			TTL:        time.Minute,
+		}),
+		httpClient: clusterGateway.Client(),
+		logger:     zap.NewNop(),
+	}
+
+	newFunctionAutoscaler(server).cleanupRuntimeInstance(ctx, inst)
+
+	var instanceCount int
+	if err := pool.QueryRow(ctx, `SELECT COUNT(*) FROM function_runtime_instances WHERE id = $1`, inst.ID).Scan(&instanceCount); err != nil {
+		t.Fatalf("count runtime instances: %v", err)
+	}
+	if instanceCount != 0 {
+		t.Fatalf("runtime instance count = %d, want 0", instanceCount)
+	}
+
+	var eventCount int
+	var runtimeInstanceID *string
+	var runtimeSandboxID string
+	if err := pool.QueryRow(ctx, `
+		SELECT COUNT(*), MAX(runtime_instance_id::text), MAX(runtime_sandbox_id)
+		FROM function_runtime_events
+		WHERE function_id = $1 AND revision_id = $2 AND reason = 'runtime_gc_deleted'
+	`, fn.ID, rev.ID).Scan(&eventCount, &runtimeInstanceID, &runtimeSandboxID); err != nil {
+		t.Fatalf("query runtime_gc_deleted event: %v", err)
+	}
+	if eventCount != 1 {
+		t.Fatalf("runtime_gc_deleted event count = %d, want 1", eventCount)
+	}
+	if runtimeInstanceID != nil {
+		t.Fatalf("runtime_gc_deleted runtime_instance_id = %q, want null after instance deletion", *runtimeInstanceID)
+	}
+	if runtimeSandboxID != inst.SandboxID {
+		t.Fatalf("runtime_gc_deleted runtime_sandbox_id = %q, want %q", runtimeSandboxID, inst.SandboxID)
+	}
+}
+
+func newFunctionAutoscalerTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+
+	ctx := context.Background()
+	dbURL := os.Getenv("INTEGRATION_DATABASE_URL")
+	if dbURL == "" {
+		dbURL = os.Getenv("TEST_DATABASE_URL")
+	}
+	if dbURL == "" {
+		t.Skip("missing INTEGRATION_DATABASE_URL or TEST_DATABASE_URL")
+	}
+
+	schema := fmt.Sprintf("function_autoscaler_test_%s", strings.ReplaceAll(uuid.NewString(), "-", ""))
+	adminPool, err := pgxpool.New(ctx, dbURL)
+	if err != nil {
+		t.Fatalf("connect test database: %v", err)
+	}
+	t.Cleanup(adminPool.Close)
+
+	if _, err := adminPool.Exec(ctx, "CREATE SCHEMA "+schema); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+
+	pool, err := dbpool.New(ctx, dbpool.Options{
+		DatabaseURL: dbURL,
+		Schema:      schema,
+	})
+	if err != nil {
+		t.Fatalf("connect schema-scoped pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	t.Cleanup(func() {
+		_, _ = adminPool.Exec(ctx, "DROP SCHEMA IF EXISTS "+schema+" CASCADE")
+	})
+
+	if err := migrate.Up(ctx, pool, ".", migrate.WithBaseFS(migrations.FS), migrate.WithSchema(schema)); err != nil {
+		t.Fatalf("migrate gateway schema: %v", err)
+	}
+	return pool
 }

--- a/function-gateway/pkg/http/runtime.go
+++ b/function-gateway/pkg/http/runtime.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	mgr "github.com/sandbox0-ai/sandbox0/manager/pkg/service"
+	"github.com/sandbox0-ai/sandbox0/pkg/functionruntime"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/authn"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/functions"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/ratelimit"
@@ -492,7 +493,7 @@ func errorsIsFunctionNotFound(err error) bool {
 	return errors.Is(err, functions.ErrNotFound)
 }
 
-func (s *Server) claimFunctionSandboxViaClusterGateway(ctx context.Context, fn *functions.Function, rev *functions.Revision, service mgr.SandboxAppService) (*mgr.ClaimResponse, error) {
+func (s *Server) claimFunctionSandboxViaClusterGateway(ctx context.Context, fn *functions.Function, rev *functions.Revision, service mgr.SandboxAppService, runtimeInstanceID string) (*mgr.ClaimResponse, error) {
 	clusterGatewayURL := s.defaultClusterGatewayURL()
 	targetService := internalauth.ServiceClusterGateway
 	requestPath := "/api/v1/sandboxes"
@@ -539,6 +540,12 @@ func (s *Server) claimFunctionSandboxViaClusterGateway(ctx context.Context, fn *
 	}
 	req.Header.Set(internalauth.DefaultTokenHeader, token)
 	req.Header.Set("Content-Type", "application/json")
+	functionruntime.SetHeaders(req.Header, functionruntime.Metadata{
+		OwnerKind:                 functionruntime.OwnerKind,
+		FunctionID:                fn.ID,
+		FunctionRevisionID:        rev.ID,
+		FunctionRuntimeInstanceID: strings.TrimSpace(runtimeInstanceID),
+	})
 
 	resp, err := s.outboundHTTPClient().Do(req)
 	if err != nil {

--- a/function-gateway/pkg/http/runtime_test.go
+++ b/function-gateway/pkg/http/runtime_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
 	mgr "github.com/sandbox0-ai/sandbox0/manager/pkg/service"
+	"github.com/sandbox0-ai/sandbox0/pkg/functionruntime"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/functions"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"go.uber.org/zap"
@@ -140,6 +141,79 @@ func TestResolveFunctionSandboxDoesNotServeSourceSandbox(t *testing.T) {
 	}
 	if got := sourceLookups.Load(); got != 0 {
 		t.Fatalf("source sandbox lookups = %d, want 0", got)
+	}
+}
+
+func TestClaimFunctionSandboxIncludesRuntimeOwnerMetadata(t *testing.T) {
+	_, privateKey, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate ed25519 keypair: %v", err)
+	}
+
+	var got mgr.ClaimRequest
+	var gotHeader http.Header
+	clusterGateway := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/sandboxes" {
+			t.Errorf("path = %s, want sandbox claim path", r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Errorf("decode claim request: %v", err)
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		gotHeader = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"success":true,"data":{"sandbox_id":"sb-runtime","status":"starting","procd_address":"127.0.0.1:8080","pod_name":"sb-runtime","template":"tmpl-1"}}`))
+	}))
+	defer clusterGateway.Close()
+
+	server := &Server{
+		cfg: &config.FunctionGatewayConfig{
+			DefaultClusterGatewayURL: clusterGateway.URL,
+		},
+		internalAuthGen: internalauth.NewGenerator(internalauth.GeneratorConfig{
+			Caller:     internalauth.ServiceFunctionGateway,
+			PrivateKey: privateKey,
+			TTL:        time.Minute,
+		}),
+		httpClient: clusterGateway.Client(),
+		logger:     zap.NewNop(),
+	}
+
+	_, err = server.claimFunctionSandboxViaClusterGateway(context.Background(), &functions.Function{
+		ID:     "fn-1",
+		TeamID: "team-1",
+	}, &functions.Revision{
+		ID:               "rev-1",
+		FunctionID:       "fn-1",
+		TeamID:           "team-1",
+		SourceTemplateID: "tmpl-1",
+		CreatedBy:        "user-1",
+	}, mgr.SandboxAppService{}, "inst-1")
+	if err != nil {
+		t.Fatalf("claimFunctionSandboxViaClusterGateway() error = %v", err)
+	}
+	if got.Metadata != nil {
+		t.Fatal("claim request metadata should not be serialized in public JSON body")
+	}
+	metadata := functionruntime.FromHeaders(gotHeader)
+	if metadata == nil {
+		t.Fatal("runtime metadata headers are missing")
+	}
+	if metadata.OwnerKind != functionruntime.OwnerKind {
+		t.Fatalf("owner kind header = %q, want %q", metadata.OwnerKind, functionruntime.OwnerKind)
+	}
+	if metadata.FunctionID != "fn-1" {
+		t.Fatalf("function id header = %q, want fn-1", metadata.FunctionID)
+	}
+	if metadata.FunctionRevisionID != "rev-1" {
+		t.Fatalf("function revision id header = %q, want rev-1", metadata.FunctionRevisionID)
+	}
+	if metadata.FunctionRuntimeInstanceID != "inst-1" {
+		t.Fatalf("function runtime instance id header = %q, want inst-1", metadata.FunctionRuntimeInstanceID)
 	}
 }
 

--- a/manager/pkg/controller/pool_manager.go
+++ b/manager/pkg/controller/pool_manager.go
@@ -26,10 +26,13 @@ import (
 
 const (
 	// Labels
-	LabelTemplateID        = "sandbox0.ai/template-id"
-	LabelTemplateLogicalID = "sandbox0.ai/template-logical-id"
-	LabelPoolType          = "sandbox0.ai/pool-type"
-	LabelSandboxID         = "sandbox0.ai/sandbox-id"
+	LabelTemplateID         = "sandbox0.ai/template-id"
+	LabelTemplateLogicalID  = "sandbox0.ai/template-logical-id"
+	LabelPoolType           = "sandbox0.ai/pool-type"
+	LabelSandboxID          = "sandbox0.ai/sandbox-id"
+	LabelOwnerKind          = "sandbox0.ai/owner-kind"
+	LabelFunctionID         = "sandbox0.ai/function-id"
+	LabelFunctionRevisionID = "sandbox0.ai/function-revision-id"
 
 	// Pool types
 	PoolTypeIdle   = "idle"
@@ -59,6 +62,10 @@ const (
 	AnnotationWebhookStateVolumeID         = "sandbox0.ai/webhook-state-volume-id"
 	AnnotationTemplateSpecHash             = "sandbox0.ai/template-spec-hash"
 	AnnotationClusterAutoscalerSafeToEvict = "cluster-autoscaler.kubernetes.io/safe-to-evict"
+	AnnotationOwnerKind                    = "sandbox0.ai/owner-kind"
+	AnnotationFunctionID                   = "sandbox0.ai/function-id"
+	AnnotationFunctionRevisionID           = "sandbox0.ai/function-revision-id"
+	AnnotationFunctionRuntimeInstanceID    = "sandbox0.ai/function-runtime-instance-id"
 
 	unhealthyIdlePodRepairGracePeriod = 2 * time.Minute
 )

--- a/manager/pkg/http/handlers_sandbox.go
+++ b/manager/pkg/http/handlers_sandbox.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/service"
+	"github.com/sandbox0-ai/sandbox0/pkg/functionruntime"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"github.com/sandbox0-ai/sandbox0/pkg/proxy"
@@ -36,6 +37,9 @@ func (s *Server) claimSandbox(c *gin.Context) {
 	}
 	req.TeamID = claims.TeamID
 	req.UserID = claims.UserID
+	if functionRuntimeClaimMetadataAllowed(claims) {
+		req.Metadata = functionruntime.FromHeaders(c.Request.Header)
+	}
 
 	if req.Template == "" {
 		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "template is required")
@@ -67,6 +71,18 @@ func (s *Server) claimSandbox(c *gin.Context) {
 	}
 
 	spec.JSONSuccess(c, http.StatusCreated, resp)
+}
+
+func functionRuntimeClaimMetadataAllowed(claims *internalauth.Claims) bool {
+	if claims == nil {
+		return false
+	}
+	switch claims.Caller {
+	case internalauth.ServiceClusterGateway, internalauth.ServiceFunctionGateway:
+		return true
+	default:
+		return false
+	}
 }
 
 // listSandboxes lists all sandboxes for the authenticated team

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
 	"github.com/sandbox0-ai/sandbox0/pkg/dataplane"
+	"github.com/sandbox0-ai/sandbox0/pkg/functionruntime"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 	"github.com/sandbox0-ai/sandbox0/pkg/volumeportal"
 	"go.uber.org/zap"
@@ -37,12 +38,15 @@ type ClaimRequest struct {
 	Template string         `json:"template"`
 	Config   *SandboxConfig `json:"config,omitempty"`
 	Mounts   []ClaimMount   `json:"mounts,omitempty"`
+	Metadata *ClaimMetadata `json:"-"`
 }
 
 type ClaimMount struct {
 	SandboxVolumeID string `json:"sandboxvolume_id"`
 	MountPoint      string `json:"mount_point"`
 }
+
+type ClaimMetadata = functionruntime.Metadata
 
 type BootstrapMountStatus struct {
 	SandboxVolumeID     string `json:"sandboxvolume_id"`
@@ -144,6 +148,40 @@ func setHardExpirationAnnotation(annotations map[string]string, now time.Time, h
 	}
 	hardExpiresAt := now.Add(time.Duration(*hardTTL) * time.Second)
 	annotations[controller.AnnotationHardExpiresAt] = hardExpiresAt.Format(time.RFC3339)
+}
+
+func applyClaimMetadata(pod *corev1.Pod, metadata *ClaimMetadata) {
+	if pod == nil || metadata == nil {
+		return
+	}
+	ownerKind := strings.TrimSpace(metadata.OwnerKind)
+	functionID := strings.TrimSpace(metadata.FunctionID)
+	revisionID := strings.TrimSpace(metadata.FunctionRevisionID)
+	instanceID := strings.TrimSpace(metadata.FunctionRuntimeInstanceID)
+	if ownerKind == "" && functionID == "" && revisionID == "" && instanceID == "" {
+		return
+	}
+	if pod.Labels == nil {
+		pod.Labels = make(map[string]string)
+	}
+	if pod.Annotations == nil {
+		pod.Annotations = make(map[string]string)
+	}
+	if ownerKind != "" {
+		pod.Labels[controller.LabelOwnerKind] = ownerKind
+		pod.Annotations[controller.AnnotationOwnerKind] = ownerKind
+	}
+	if functionID != "" {
+		pod.Labels[controller.LabelFunctionID] = functionID
+		pod.Annotations[controller.AnnotationFunctionID] = functionID
+	}
+	if revisionID != "" {
+		pod.Labels[controller.LabelFunctionRevisionID] = revisionID
+		pod.Annotations[controller.AnnotationFunctionRevisionID] = revisionID
+	}
+	if instanceID != "" {
+		pod.Annotations[controller.AnnotationFunctionRuntimeInstanceID] = instanceID
+	}
 }
 
 func setMountsAnnotation(annotations map[string]string, mounts []ClaimMount) error {
@@ -771,6 +809,7 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 		} else {
 			delete(pod.Annotations, controller.AnnotationWebhookStateVolumeID)
 		}
+		applyClaimMetadata(pod, req.Metadata)
 
 		// Set expiration annotations. Explicit 0 disables TTLs; omitted TTL uses the configured default.
 		persistedConfig := s.claimConfigForPersistence(req.Config)
@@ -930,6 +969,7 @@ func (s *SandboxService) createNewPod(ctx context.Context, template *v1alpha1.Sa
 		},
 		Spec: spec,
 	}
+	applyClaimMetadata(pod, req.Metadata)
 
 	// Set expiration annotations. Explicit 0 disables TTLs; omitted TTL uses the configured default.
 	persistedConfig := s.claimConfigForPersistence(req.Config)

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -105,6 +105,57 @@ func TestClaimIdlePodClaimsReadyPod(t *testing.T) {
 	}
 }
 
+func TestClaimRequestDoesNotAcceptRuntimeMetadataFromJSON(t *testing.T) {
+	var req ClaimRequest
+	if err := json.Unmarshal([]byte(`{
+		"template":"template-a",
+		"metadata":{
+			"owner_kind":"function-runtime",
+			"function_id":"fn-1",
+			"function_revision_id":"rev-1",
+			"function_runtime_instance_id":"inst-1"
+		}
+	}`), &req); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if req.Metadata != nil {
+		t.Fatalf("metadata = %#v, want nil for public JSON input", req.Metadata)
+	}
+}
+
+func TestClaimIdlePodAppliesRuntimeOwnerMetadata(t *testing.T) {
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "template-a",
+			Namespace: "ns-a",
+		},
+	}
+	readyPod := newClaimTestPod("ns-a", "idle-ready", "template-a", true)
+
+	client := fake.NewSimpleClientset(readyPod.DeepCopy())
+	svc := &SandboxService{
+		k8sClient: client,
+		podLister: newClaimTestPodLister(t, readyPod),
+		clock:     systemTime{},
+		logger:    zap.NewNop(),
+	}
+
+	pod, err := svc.claimIdlePod(context.Background(), template, &ClaimRequest{
+		TeamID: "team-a",
+		UserID: "user-a",
+		Metadata: &ClaimMetadata{
+			OwnerKind:                 "function-runtime",
+			FunctionID:                "fn-1",
+			FunctionRevisionID:        "rev-1",
+			FunctionRuntimeInstanceID: "inst-1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("claimIdlePod() error = %v", err)
+	}
+	assertClaimRuntimeMetadata(t, pod)
+}
+
 func TestClaimIdlePodRequiresCurrentTemplateHash(t *testing.T) {
 	template := &v1alpha1.SandboxTemplate{
 		ObjectMeta: metav1.ObjectMeta{
@@ -383,6 +434,42 @@ func TestCreateNewPodMarksColdPodNonEvictable(t *testing.T) {
 	if got := pod.Annotations[controller.AnnotationClusterAutoscalerSafeToEvict]; got != "false" {
 		t.Fatalf("safe-to-evict annotation = %q, want false", got)
 	}
+}
+
+func TestCreateNewPodAppliesRuntimeOwnerMetadata(t *testing.T) {
+	withClaimTestPublicKey(t)
+
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "template-a",
+			Namespace: "ns-a",
+		},
+		Spec: v1alpha1.SandboxTemplateSpec{
+			MainContainer: v1alpha1.ContainerSpec{Image: "busybox"},
+		},
+	}
+	client := fake.NewSimpleClientset()
+	svc := &SandboxService{
+		k8sClient:    client,
+		secretLister: newClaimTestSecretLister(t),
+		clock:        systemTime{},
+		logger:       zap.NewNop(),
+	}
+
+	pod, err := svc.createNewPod(context.Background(), template, &ClaimRequest{
+		TeamID: "team-a",
+		UserID: "user-a",
+		Metadata: &ClaimMetadata{
+			OwnerKind:                 "function-runtime",
+			FunctionID:                "fn-1",
+			FunctionRevisionID:        "rev-1",
+			FunctionRuntimeInstanceID: "inst-1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("createNewPod() error = %v", err)
+	}
+	assertClaimRuntimeMetadata(t, pod)
 }
 
 func TestCreateNewPodFailsBeforeCreateWhenDataPlaneNotReady(t *testing.T) {
@@ -1051,6 +1138,34 @@ func newClaimTestPod(namespace, name, templateID string, ready bool) *corev1.Pod
 				},
 			},
 		},
+	}
+}
+
+func assertClaimRuntimeMetadata(t *testing.T, pod *corev1.Pod) {
+	t.Helper()
+	if pod == nil {
+		t.Fatal("pod is nil")
+	}
+	if got := pod.Labels[controller.LabelOwnerKind]; got != "function-runtime" {
+		t.Fatalf("owner kind label = %q, want function-runtime", got)
+	}
+	if got := pod.Labels[controller.LabelFunctionID]; got != "fn-1" {
+		t.Fatalf("function id label = %q, want fn-1", got)
+	}
+	if got := pod.Labels[controller.LabelFunctionRevisionID]; got != "rev-1" {
+		t.Fatalf("function revision id label = %q, want rev-1", got)
+	}
+	if got := pod.Annotations[controller.AnnotationOwnerKind]; got != "function-runtime" {
+		t.Fatalf("owner kind annotation = %q, want function-runtime", got)
+	}
+	if got := pod.Annotations[controller.AnnotationFunctionID]; got != "fn-1" {
+		t.Fatalf("function id annotation = %q, want fn-1", got)
+	}
+	if got := pod.Annotations[controller.AnnotationFunctionRevisionID]; got != "rev-1" {
+		t.Fatalf("function revision id annotation = %q, want rev-1", got)
+	}
+	if got := pod.Annotations[controller.AnnotationFunctionRuntimeInstanceID]; got != "inst-1" {
+		t.Fatalf("function runtime instance id annotation = %q, want inst-1", got)
 	}
 }
 

--- a/pkg/functionruntime/metadata.go
+++ b/pkg/functionruntime/metadata.go
@@ -1,0 +1,67 @@
+package functionruntime
+
+import (
+	"net/http"
+	"strings"
+)
+
+const OwnerKind = "function-runtime"
+
+const (
+	HeaderOwnerKind                 = "X-Sandbox0-Function-Runtime-Owner-Kind"
+	HeaderFunctionID                = "X-Sandbox0-Function-ID"
+	HeaderFunctionRevisionID        = "X-Sandbox0-Function-Revision-ID"
+	HeaderFunctionRuntimeInstanceID = "X-Sandbox0-Function-Runtime-Instance-ID"
+)
+
+type Metadata struct {
+	OwnerKind                 string
+	FunctionID                string
+	FunctionRevisionID        string
+	FunctionRuntimeInstanceID string
+}
+
+func SetHeaders(header http.Header, metadata Metadata) {
+	if header == nil {
+		return
+	}
+	setHeaderValue(header, HeaderOwnerKind, metadata.OwnerKind)
+	setHeaderValue(header, HeaderFunctionID, metadata.FunctionID)
+	setHeaderValue(header, HeaderFunctionRevisionID, metadata.FunctionRevisionID)
+	setHeaderValue(header, HeaderFunctionRuntimeInstanceID, metadata.FunctionRuntimeInstanceID)
+}
+
+func FromHeaders(header http.Header) *Metadata {
+	if header == nil {
+		return nil
+	}
+	metadata := &Metadata{
+		OwnerKind:                 strings.TrimSpace(header.Get(HeaderOwnerKind)),
+		FunctionID:                strings.TrimSpace(header.Get(HeaderFunctionID)),
+		FunctionRevisionID:        strings.TrimSpace(header.Get(HeaderFunctionRevisionID)),
+		FunctionRuntimeInstanceID: strings.TrimSpace(header.Get(HeaderFunctionRuntimeInstanceID)),
+	}
+	if metadata.OwnerKind == "" && metadata.FunctionID == "" && metadata.FunctionRevisionID == "" && metadata.FunctionRuntimeInstanceID == "" {
+		return nil
+	}
+	return metadata
+}
+
+func ClearHeaders(header http.Header) {
+	if header == nil {
+		return
+	}
+	header.Del(HeaderOwnerKind)
+	header.Del(HeaderFunctionID)
+	header.Del(HeaderFunctionRevisionID)
+	header.Del(HeaderFunctionRuntimeInstanceID)
+}
+
+func setHeaderValue(header http.Header, key, value string) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		header.Del(key)
+		return
+	}
+	header.Set(key, value)
+}

--- a/pkg/gateway/functionapi/handler.go
+++ b/pkg/gateway/functionapi/handler.go
@@ -530,9 +530,15 @@ func (h *Handler) clearFunctionRuntime(c *gin.Context) {
 		return
 	}
 	deletedLegacy := false
+	needsRuntimeDelete := false
 	for _, inst := range instances {
-		if inst == nil || strings.TrimSpace(inst.SandboxID) == "" || h.runtime == nil {
+		if inst == nil || strings.TrimSpace(inst.SandboxID) == "" {
 			continue
+		}
+		needsRuntimeDelete = true
+		if h.runtime == nil {
+			spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "function runtime cleanup is not configured")
+			return
 		}
 		if err := h.runtime.DeleteRuntimeSandbox(c.Request.Context(), authCtx, strings.TrimSpace(inst.SandboxID)); err != nil {
 			h.logger.Warn("Failed to delete function runtime sandbox",
@@ -549,6 +555,7 @@ func (h *Handler) clearFunctionRuntime(c *gin.Context) {
 		}
 	}
 	if len(instances) == 0 && h.runtime != nil && rev.RuntimeSandboxID != nil && strings.TrimSpace(*rev.RuntimeSandboxID) != "" {
+		needsRuntimeDelete = true
 		if err := h.runtime.DeleteRuntimeSandbox(c.Request.Context(), authCtx, strings.TrimSpace(*rev.RuntimeSandboxID)); err != nil {
 			h.logger.Warn("Failed to delete function runtime sandbox",
 				zap.String("function_id", fn.ID),
@@ -560,6 +567,10 @@ func (h *Handler) clearFunctionRuntime(c *gin.Context) {
 			return
 		}
 		deletedLegacy = true
+	}
+	if !needsRuntimeDelete && h.runtime == nil && rev.RuntimeSandboxID != nil && strings.TrimSpace(*rev.RuntimeSandboxID) != "" {
+		spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "function runtime cleanup is not configured")
+		return
 	}
 	if !deletedLegacy && rev.RuntimeSandboxID != nil && strings.TrimSpace(*rev.RuntimeSandboxID) != "" {
 		h.logger.Warn("Legacy function runtime mapping did not match runtime pool instances",
@@ -879,20 +890,8 @@ func (h *Handler) cleanupDeletedFunctionResources(authCtx *authn.AuthContext, re
 		if rev.RuntimeSandboxID != nil && strings.TrimSpace(*rev.RuntimeSandboxID) != "" {
 			runtimeSandboxIDs[strings.TrimSpace(*rev.RuntimeSandboxID)] = struct{}{}
 		}
-		for sandboxID := range runtimeSandboxIDs {
-			if h.runtime == nil {
-				continue
-			}
-			if err := h.runtime.DeleteRuntimeSandbox(ctx, authCtx, sandboxID); err != nil {
-				h.logger.Warn("Failed to clean up deleted function runtime sandbox",
-					zap.String("function_id", rev.FunctionID),
-					zap.String("revision_id", rev.ID),
-					zap.String("runtime_sandbox_id", sandboxID),
-					zap.Error(err),
-				)
-			}
-		}
-		if h.repo != nil {
+		runtimeCleanupComplete := h.deleteRuntimeSandboxesForRevision(ctx, authCtx, rev, runtimeSandboxIDs)
+		if h.repo != nil && runtimeCleanupComplete {
 			if err := h.repo.ClearRevisionRuntime(ctx, rev.TeamID, rev.FunctionID, rev.ID); err != nil && !errors.Is(err, functions.ErrNotFound) {
 				h.logger.Warn("Failed to clear deleted function runtime mapping",
 					zap.String("function_id", rev.FunctionID),
@@ -912,6 +911,28 @@ func (h *Handler) cleanupDeletedFunctionResources(authCtx *authn.AuthContext, re
 			}
 		}
 	}
+}
+
+func (h *Handler) deleteRuntimeSandboxesForRevision(ctx context.Context, authCtx *authn.AuthContext, rev *functions.Revision, sandboxIDs map[string]struct{}) bool {
+	if len(sandboxIDs) == 0 {
+		return true
+	}
+	if h.runtime == nil {
+		return false
+	}
+	complete := true
+	for sandboxID := range sandboxIDs {
+		if err := h.runtime.DeleteRuntimeSandbox(ctx, authCtx, sandboxID); err != nil {
+			complete = false
+			h.logger.Warn("Failed to clean up deleted function runtime sandbox",
+				zap.String("function_id", rev.FunctionID),
+				zap.String("revision_id", rev.ID),
+				zap.String("runtime_sandbox_id", sandboxID),
+				zap.Error(err),
+			)
+		}
+	}
+	return complete
 }
 
 func (h *Handler) functionRecord(fn *functions.Function) functionRecord {

--- a/pkg/gateway/functionapi/handler_test.go
+++ b/pkg/gateway/functionapi/handler_test.go
@@ -1,10 +1,14 @@
 package functionapi
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
 
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/authn"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/functions"
+	"go.uber.org/zap"
 )
 
 func TestTryLockFunctionRevisionPublishSerializesFunction(t *testing.T) {
@@ -139,4 +143,56 @@ func TestRuntimeStatusReadyInstanceOverridesOlderFailure(t *testing.T) {
 	if status.ReadinessState != functions.RuntimeReadinessStateReady {
 		t.Fatalf("readiness = %q, want %q", status.ReadinessState, functions.RuntimeReadinessStateReady)
 	}
+}
+
+func TestDeleteRuntimeSandboxesForRevisionKeepsMappingWhenDeleteFails(t *testing.T) {
+	deleteErr := errors.New("delete failed")
+	runtime := &recordingRuntimeController{errors: map[string]error{"sb-2": deleteErr}}
+	handler := &Handler{runtime: runtime, logger: zap.NewNop()}
+	rev := &functions.Revision{ID: "rev-1", FunctionID: "fn-1", TeamID: "team-1"}
+
+	complete := handler.deleteRuntimeSandboxesForRevision(context.Background(), &authn.AuthContext{TeamID: "team-1"}, rev, map[string]struct{}{
+		"sb-1": {},
+		"sb-2": {},
+	})
+
+	if complete {
+		t.Fatal("deleteRuntimeSandboxesForRevision() complete = true, want false")
+	}
+	if !runtime.deleted["sb-1"] || !runtime.deleted["sb-2"] {
+		t.Fatalf("deleted sandboxes = %#v, want both attempted", runtime.deleted)
+	}
+}
+
+func TestDeleteRuntimeSandboxesForRevisionCompletesWhenDeletesSucceed(t *testing.T) {
+	runtime := &recordingRuntimeController{}
+	handler := &Handler{runtime: runtime, logger: zap.NewNop()}
+	rev := &functions.Revision{ID: "rev-1", FunctionID: "fn-1", TeamID: "team-1"}
+
+	complete := handler.deleteRuntimeSandboxesForRevision(context.Background(), &authn.AuthContext{TeamID: "team-1"}, rev, map[string]struct{}{
+		"sb-1": {},
+	})
+
+	if !complete {
+		t.Fatal("deleteRuntimeSandboxesForRevision() complete = false, want true")
+	}
+	if !runtime.deleted["sb-1"] {
+		t.Fatalf("deleted sandboxes = %#v, want sb-1", runtime.deleted)
+	}
+}
+
+type recordingRuntimeController struct {
+	deleted map[string]bool
+	errors  map[string]error
+}
+
+func (r *recordingRuntimeController) DeleteRuntimeSandbox(_ context.Context, _ *authn.AuthContext, sandboxID string) error {
+	if r.deleted == nil {
+		r.deleted = make(map[string]bool)
+	}
+	r.deleted[sandboxID] = true
+	if r.errors != nil {
+		return r.errors[sandboxID]
+	}
+	return nil
 }

--- a/pkg/gateway/functions/models.go
+++ b/pkg/gateway/functions/models.go
@@ -8,15 +8,18 @@ import (
 const ProductionAlias = "production"
 
 const (
-	DefaultMinWarm               = 0
-	DefaultMaxActive             = 20
-	DefaultTargetConcurrency     = 80
-	DefaultScaleDownAfterSeconds = 300
-	MaximumMinWarm               = 100
-	MaximumMaxActive             = 1000
-	MaximumTargetConcurrency     = 1000
-	MaximumScaleDownAfterSeconds = 86400
-	MinimumScaleDownAfterSeconds = 30
+	DefaultMinWarm                         = 0
+	DefaultMaxActive                       = 20
+	DefaultTargetConcurrency               = 80
+	DefaultScaleDownAfterSeconds           = 300
+	DefaultFailedRuntimeRetentionSeconds   = 300
+	DefaultDrainingRuntimeRetentionSeconds = 30
+	DefaultStartingRuntimeRetentionSeconds = 600
+	MaximumMinWarm                         = 100
+	MaximumMaxActive                       = 1000
+	MaximumTargetConcurrency               = 1000
+	MaximumScaleDownAfterSeconds           = 86400
+	MinimumScaleDownAfterSeconds           = 30
 )
 
 type Function struct {

--- a/pkg/gateway/functions/repository.go
+++ b/pkg/gateway/functions/repository.go
@@ -667,6 +667,73 @@ func (r *Repository) ListRuntimeScaleDownCandidates(ctx context.Context, limit i
 	return out, rows.Err()
 }
 
+func (r *Repository) ListRuntimeCleanupCandidates(ctx context.Context, limit int) ([]*RuntimeInstance, error) {
+	if r == nil || r.pool == nil {
+		return nil, fmt.Errorf("function repository is not configured")
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := r.pool.Query(ctx, `
+		WITH candidates AS (
+			SELECT i.id, i.team_id, i.function_id, i.revision_id, i.sandbox_id, i.context_id, i.state,
+				i.readiness_state, i.startup_duration_ms, i.last_error, i.last_error_at,
+				i.ready_at, i.last_used_at, i.draining_at, i.failed_at, i.created_at, i.updated_at
+			FROM function_runtime_instances i
+			JOIN functions f ON f.id = i.function_id
+			JOIN functions_revisions r ON r.id = i.revision_id
+			WHERE f.deleted_at IS NOT NULL
+				OR f.enabled = FALSE
+				OR (
+					f.active_revision_id IS DISTINCT FROM i.revision_id
+					AND COALESCE(i.last_used_at, i.ready_at, i.updated_at, i.created_at)
+						< NOW() - make_interval(secs => GREATEST(COALESCE((f.autoscaling->>'scale_down_after_seconds')::int, $2), $3))
+				)
+				OR (
+					i.state = 'failed'
+					AND COALESCE(i.failed_at, i.updated_at, i.created_at)
+						< NOW() - make_interval(secs => $4)
+				)
+				OR (
+					i.state = 'draining'
+					AND COALESCE(i.draining_at, i.updated_at, i.created_at)
+						< NOW() - make_interval(secs => $5)
+				)
+				OR (
+					i.state = 'starting'
+					AND COALESCE(i.updated_at, i.created_at)
+						< NOW() - make_interval(secs => $6)
+				)
+		)
+		SELECT id, team_id, function_id, revision_id, sandbox_id, context_id, state,
+			readiness_state, startup_duration_ms, last_error, last_error_at,
+			ready_at, last_used_at, draining_at, failed_at, created_at, updated_at
+		FROM candidates
+		ORDER BY
+			CASE state
+				WHEN 'failed' THEN 0
+				WHEN 'draining' THEN 1
+				WHEN 'starting' THEN 2
+				ELSE 3
+			END,
+			COALESCE(failed_at, draining_at, last_used_at, ready_at, updated_at, created_at) ASC
+		LIMIT $1
+	`, limit, DefaultScaleDownAfterSeconds, MinimumScaleDownAfterSeconds, DefaultFailedRuntimeRetentionSeconds, DefaultDrainingRuntimeRetentionSeconds, DefaultStartingRuntimeRetentionSeconds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []*RuntimeInstance
+	for rows.Next() {
+		inst, err := scanRuntimeInstance(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, inst)
+	}
+	return out, rows.Err()
+}
+
 func (r *Repository) UpdateFunction(ctx context.Context, teamID, functionRef string, name *string, enabled *bool, autoscaling *Autoscaling) (*Function, error) {
 	if r == nil || r.pool == nil {
 		return nil, fmt.Errorf("function repository is not configured")

--- a/pkg/gateway/functions/repository_test.go
+++ b/pkg/gateway/functions/repository_test.go
@@ -1,0 +1,181 @@
+package functions
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/sandbox0-ai/sandbox0/pkg/dbpool"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/migrations"
+	"github.com/sandbox0-ai/sandbox0/pkg/migrate"
+)
+
+func TestListRuntimeCleanupCandidatesIncludesInactiveAndFailedRuntimes(t *testing.T) {
+	ctx := context.Background()
+	pool, _ := newGatewayFunctionsTestPool(t)
+	repo := NewRepository(pool)
+
+	teamID := uuid.NewString()
+	userID := uuid.NewString()
+	fn := NewFunction(teamID, "runtime cleanup", userID)
+	rev1, err := NewRevision(teamID, "source-sandbox-1", "svc", "tmpl", map[string]any{"id": "svc"}, nil, userID)
+	if err != nil {
+		t.Fatalf("NewRevision() error = %v", err)
+	}
+	fn, rev1, err = repo.CreateFunctionWithRevision(ctx, fn, rev1, userID)
+	if err != nil {
+		t.Fatalf("CreateFunctionWithRevision() error = %v", err)
+	}
+	rev2, err := NewRevision(teamID, "source-sandbox-2", "svc", "tmpl", map[string]any{"id": "svc"}, nil, userID)
+	if err != nil {
+		t.Fatalf("NewRevision() error = %v", err)
+	}
+	rev2, err = repo.CreateRevision(ctx, teamID, fn.ID, rev2, true, userID)
+	if err != nil {
+		t.Fatalf("CreateRevision() error = %v", err)
+	}
+
+	activeReady := createRuntimeInstanceForTest(t, ctx, repo, teamID, fn.ID, rev2.ID, "sb-active-ready", RuntimeInstanceStateReady)
+	inactiveReady := createRuntimeInstanceForTest(t, ctx, repo, teamID, fn.ID, rev1.ID, "sb-inactive-ready", RuntimeInstanceStateReady)
+	failedActive := createRuntimeInstanceForTest(t, ctx, repo, teamID, fn.ID, rev2.ID, "sb-failed-active", RuntimeInstanceStateFailed)
+
+	if _, err := pool.Exec(ctx, `
+		UPDATE function_runtime_instances
+		SET ready_at = NOW() - INTERVAL '10 minutes',
+			last_used_at = NOW() - INTERVAL '10 minutes',
+			updated_at = NOW() - INTERVAL '10 minutes'
+		WHERE id = $1
+	`, inactiveReady.ID); err != nil {
+		t.Fatalf("age inactive runtime: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		UPDATE function_runtime_instances
+		SET failed_at = NOW() - INTERVAL '10 minutes',
+			updated_at = NOW() - INTERVAL '10 minutes'
+		WHERE id = $1
+	`, failedActive.ID); err != nil {
+		t.Fatalf("age failed runtime: %v", err)
+	}
+
+	candidates, err := repo.ListRuntimeCleanupCandidates(ctx, 100)
+	if err != nil {
+		t.Fatalf("ListRuntimeCleanupCandidates() error = %v", err)
+	}
+	got := runtimeInstanceIDSet(candidates)
+	if !got[inactiveReady.ID] {
+		t.Fatalf("inactive ready runtime was not selected for cleanup: %#v", got)
+	}
+	if !got[failedActive.ID] {
+		t.Fatalf("failed active runtime was not selected for cleanup: %#v", got)
+	}
+	if got[activeReady.ID] {
+		t.Fatalf("active ready runtime was selected for cleanup: %#v", got)
+	}
+}
+
+func TestListRuntimeCleanupCandidatesIncludesDisabledFunctionRuntimeImmediately(t *testing.T) {
+	ctx := context.Background()
+	pool, _ := newGatewayFunctionsTestPool(t)
+	repo := NewRepository(pool)
+
+	teamID := uuid.NewString()
+	userID := uuid.NewString()
+	fn := NewFunction(teamID, "disabled runtime cleanup", userID)
+	rev, err := NewRevision(teamID, "source-sandbox", "svc", "tmpl", map[string]any{"id": "svc"}, nil, userID)
+	if err != nil {
+		t.Fatalf("NewRevision() error = %v", err)
+	}
+	fn, rev, err = repo.CreateFunctionWithRevision(ctx, fn, rev, userID)
+	if err != nil {
+		t.Fatalf("CreateFunctionWithRevision() error = %v", err)
+	}
+	inst := createRuntimeInstanceForTest(t, ctx, repo, teamID, fn.ID, rev.ID, "sb-disabled-ready", RuntimeInstanceStateReady)
+	disabled := false
+	if _, err := repo.UpdateFunction(ctx, teamID, fn.ID, nil, &disabled, nil); err != nil {
+		t.Fatalf("UpdateFunction() error = %v", err)
+	}
+
+	candidates, err := repo.ListRuntimeCleanupCandidates(ctx, 100)
+	if err != nil {
+		t.Fatalf("ListRuntimeCleanupCandidates() error = %v", err)
+	}
+	if got := runtimeInstanceIDSet(candidates); !got[inst.ID] {
+		t.Fatalf("disabled function runtime was not selected for cleanup: %#v", got)
+	}
+}
+
+func createRuntimeInstanceForTest(t *testing.T, ctx context.Context, repo *Repository, teamID, functionID, revisionID, sandboxID string, state RuntimeInstanceState) *RuntimeInstance {
+	t.Helper()
+	now := time.Now().UTC()
+	inst, err := repo.CreateRuntimeInstance(ctx, &RuntimeInstance{
+		TeamID:     teamID,
+		FunctionID: functionID,
+		RevisionID: revisionID,
+		SandboxID:  sandboxID,
+		State:      state,
+		ReadyAt:    &now,
+		LastUsedAt: &now,
+	})
+	if err != nil {
+		t.Fatalf("CreateRuntimeInstance(%s) error = %v", sandboxID, err)
+	}
+	return inst
+}
+
+func runtimeInstanceIDSet(instances []*RuntimeInstance) map[string]bool {
+	out := make(map[string]bool, len(instances))
+	for _, inst := range instances {
+		if inst != nil {
+			out[inst.ID] = true
+		}
+	}
+	return out
+}
+
+func newGatewayFunctionsTestPool(t *testing.T) (*pgxpool.Pool, string) {
+	t.Helper()
+
+	ctx := context.Background()
+	dbURL := os.Getenv("INTEGRATION_DATABASE_URL")
+	if dbURL == "" {
+		dbURL = os.Getenv("TEST_DATABASE_URL")
+	}
+	if dbURL == "" {
+		t.Skip("missing INTEGRATION_DATABASE_URL or TEST_DATABASE_URL")
+		return nil, ""
+	}
+
+	schema := fmt.Sprintf("gateway_functions_test_%s", strings.ReplaceAll(uuid.NewString(), "-", ""))
+	adminPool, err := pgxpool.New(ctx, dbURL)
+	if err != nil {
+		t.Fatalf("connect test database: %v", err)
+	}
+	t.Cleanup(adminPool.Close)
+
+	if _, err := adminPool.Exec(ctx, "CREATE SCHEMA "+schema); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+
+	pool, err := dbpool.New(ctx, dbpool.Options{
+		DatabaseURL: dbURL,
+		Schema:      schema,
+	})
+	if err != nil {
+		t.Fatalf("connect schema-scoped pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	t.Cleanup(func() {
+		_, _ = adminPool.Exec(ctx, "DROP SCHEMA IF EXISTS "+schema+" CASCADE")
+	})
+
+	if err := migrate.Up(ctx, pool, ".", migrate.WithBaseFS(migrations.FS), migrate.WithSchema(schema)); err != nil {
+		t.Fatalf("migrate gateway schema: %v", err)
+	}
+
+	return pool, schema
+}

--- a/scheduler/pkg/http/function_runtime_headers_test.go
+++ b/scheduler/pkg/http/function_runtime_headers_test.go
@@ -1,0 +1,42 @@
+package http
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/sandbox0-ai/sandbox0/pkg/functionruntime"
+	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+)
+
+func TestSanitizeFunctionRuntimeClaimHeadersClearsNonFunctionGatewayCaller(t *testing.T) {
+	header := http.Header{}
+	functionruntime.SetHeaders(header, functionruntime.Metadata{
+		OwnerKind:                 functionruntime.OwnerKind,
+		FunctionID:                "fn-1",
+		FunctionRevisionID:        "rev-1",
+		FunctionRuntimeInstanceID: "inst-1",
+	})
+
+	sanitizeFunctionRuntimeClaimHeaders(header, &internalauth.Claims{Caller: internalauth.ServiceRegionalGateway})
+
+	if metadata := functionruntime.FromHeaders(header); metadata != nil {
+		t.Fatalf("metadata headers were not cleared: %#v", metadata)
+	}
+}
+
+func TestSanitizeFunctionRuntimeClaimHeadersPreservesFunctionGatewayCaller(t *testing.T) {
+	header := http.Header{}
+	functionruntime.SetHeaders(header, functionruntime.Metadata{
+		OwnerKind:                 functionruntime.OwnerKind,
+		FunctionID:                "fn-1",
+		FunctionRevisionID:        "rev-1",
+		FunctionRuntimeInstanceID: "inst-1",
+	})
+
+	sanitizeFunctionRuntimeClaimHeaders(header, &internalauth.Claims{Caller: internalauth.ServiceFunctionGateway})
+
+	metadata := functionruntime.FromHeaders(header)
+	if metadata == nil || metadata.FunctionID != "fn-1" {
+		t.Fatalf("metadata headers were not preserved: %#v", metadata)
+	}
+}

--- a/scheduler/pkg/http/handlers_sandbox.go
+++ b/scheduler/pkg/http/handlers_sandbox.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/sandbox0-ai/sandbox0/pkg/apispec"
+	"github.com/sandbox0-ai/sandbox0/pkg/functionruntime"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
@@ -94,6 +95,7 @@ func (s *Server) createSandbox(c *gin.Context) {
 	if claims.UserID != "" {
 		c.Request.Header.Set("X-User-ID", claims.UserID)
 	}
+	sanitizeFunctionRuntimeClaimHeaders(c.Request.Header, claims)
 
 	c.Request.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 
@@ -110,6 +112,12 @@ func (s *Server) createSandbox(c *gin.Context) {
 	)
 
 	router.ProxyToTarget(c)
+}
+
+func sanitizeFunctionRuntimeClaimHeaders(header http.Header, claims *internalauth.Claims) {
+	if claims == nil || claims.Caller != internalauth.ServiceFunctionGateway {
+		functionruntime.ClearHeaders(header)
+	}
 }
 
 // proxySandbox routes sandbox operations to the correct cluster-gateway based on sandbox ID.


### PR DESCRIPTION
## What changed

- Added internal Function runtime ownership metadata propagation through trusted request headers instead of the public sandbox claim OpenAPI contract.
- Added scheduler and cluster-gateway header sanitization so spoofed Function runtime metadata is stripped unless the caller is the trusted Function runtime path.
- Added periodic Function Gateway runtime cleanup for deleted/disabled functions, inactive revisions, failed startups, stale starting attempts, and draining instances.
- Kept runtime DB records until sandbox deletion is confirmed so cleanup can be retried.
- Updated runtime docs and tests for owner metadata, header sanitization, retryable cleanup, and cleanup candidate selection.

## Why

The Function gap doc calls out runtime GC and resource ownership as a P1 issue: best-effort cleanup can leak orphan runtime sandboxes, inactive revisions lacked a retention policy, and cleanup ownership was unclear. Runtime sandboxes need ownership metadata, but it should remain an internal platform detail rather than a public sandbox claim field.

## Validation

- go test ./pkg/functionruntime ./manager/pkg/service ./manager/pkg/http ./function-gateway/pkg/http ./cluster-gateway/pkg/http ./scheduler/pkg/http ./pkg/gateway/functionapi ./pkg/gateway/functions ./pkg/apispec

Note: repository cleanup tests that require PostgreSQL skip unless INTEGRATION_DATABASE_URL or TEST_DATABASE_URL is set.