### PR TITLE
Route function runtime traffic through cluster gateway

### DIFF
--- a/cluster-gateway/pkg/http/handlers_internal_function_proxy.go
+++ b/cluster-gateway/pkg/http/handlers_internal_function_proxy.go
@@ -1,0 +1,197 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sandbox0-ai/sandbox0/cluster-gateway/pkg/client"
+	"github.com/sandbox0-ai/sandbox0/cluster-gateway/pkg/middleware"
+	mgr "github.com/sandbox0-ai/sandbox0/manager/pkg/service"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
+	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+	"github.com/sandbox0-ai/sandbox0/pkg/proxy"
+	"go.uber.org/zap"
+)
+
+const internalFunctionRuntimeReadinessTimeout = 500 * time.Millisecond
+
+func (s *Server) proxyInternalFunctionRuntime(c *gin.Context) {
+	_, _, targetURL, ok := s.resolveInternalFunctionRuntimeTarget(c)
+	if !ok {
+		return
+	}
+
+	proxyPath := c.Param("path")
+	if proxyPath == "" {
+		proxyPath = "/"
+	}
+	if !strings.HasPrefix(proxyPath, "/") {
+		proxyPath = "/" + proxyPath
+	}
+	c.Request.URL.Path = proxyPath
+	c.Request.URL.RawPath = ""
+	c.Request = proxy.WithUpstreamTimeoutDisabledRequest(c.Request)
+
+	proxyTimeout := s.cfg.ProxyTimeout.Duration
+	if proxyTimeout == 0 {
+		proxyTimeout = 10 * time.Second
+	}
+	router, err := proxy.NewRouter(
+		targetURL.String(),
+		s.logger,
+		proxyTimeout,
+		proxy.WithHTTPClient(s.outboundHTTPClient()),
+		proxy.WithRequestModifier(stripInternalFunctionProxyHeaders),
+	)
+	if err != nil {
+		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "proxy initialization failed")
+		return
+	}
+	router.ProxyToTarget(c)
+}
+
+func (s *Server) checkInternalFunctionRuntimeReadiness(c *gin.Context) {
+	_, _, targetURL, ok := s.resolveInternalFunctionRuntimeTarget(c)
+	if !ok {
+		return
+	}
+
+	healthPath := strings.TrimSpace(c.Query("health_path"))
+	var err error
+	if healthPath != "" {
+		err = s.checkInternalFunctionRuntimeHTTPReadiness(c.Request.Context(), targetURL, healthPath)
+	} else {
+		err = checkInternalFunctionRuntimeTCPReadiness(c.Request.Context(), targetURL.Host)
+	}
+	if err != nil {
+		spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, err.Error())
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+func (s *Server) resolveInternalFunctionRuntimeTarget(c *gin.Context) (*mgr.Sandbox, mgr.SandboxAppService, *url.URL, bool) {
+	authCtx := middleware.GetAuthContext(c)
+	if authCtx == nil || strings.TrimSpace(authCtx.TeamID) == "" {
+		spec.JSONError(c, http.StatusUnauthorized, spec.CodeUnauthorized, "missing internal team context")
+		return nil, mgr.SandboxAppService{}, nil, false
+	}
+
+	sandboxID := strings.TrimSpace(c.Param("id"))
+	serviceID := strings.TrimSpace(c.Param("service_id"))
+	if sandboxID == "" || serviceID == "" {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "sandbox_id and service_id are required")
+		return nil, mgr.SandboxAppService{}, nil, false
+	}
+	if s.managerClient == nil {
+		spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "manager client unavailable")
+		return nil, mgr.SandboxAppService{}, nil, false
+	}
+
+	sandbox, err := s.managerClient.GetSandboxInternal(c.Request.Context(), sandboxID)
+	if err != nil {
+		s.logger.Warn("Failed to get function runtime sandbox from manager",
+			zap.String("sandbox_id", sandboxID),
+			zap.Error(err),
+		)
+		if errors.Is(err, client.ErrSandboxNotFound) {
+			spec.JSONError(c, http.StatusNotFound, spec.CodeNotFound, "sandbox not found")
+			return nil, mgr.SandboxAppService{}, nil, false
+		}
+		spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "manager service unavailable")
+		return nil, mgr.SandboxAppService{}, nil, false
+	}
+	if sandbox.TeamID != authCtx.TeamID {
+		spec.JSONError(c, http.StatusForbidden, spec.CodeForbidden, "sandbox belongs to a different team")
+		return nil, mgr.SandboxAppService{}, nil, false
+	}
+	if sandboxWantsPaused(sandbox) {
+		spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox is paused")
+		return nil, mgr.SandboxAppService{}, nil, false
+	}
+	service, ok := sandboxServiceByID(sandbox.Services, serviceID)
+	if !ok {
+		spec.JSONError(c, http.StatusNotFound, spec.CodeNotFound, "service not found")
+		return nil, mgr.SandboxAppService{}, nil, false
+	}
+	if basePort, parseErr := portFromURL(sandbox.InternalAddr); parseErr == nil && basePort == service.Port {
+		spec.JSONError(c, http.StatusForbidden, spec.CodeForbidden, "reserved port is not exposable")
+		return nil, mgr.SandboxAppService{}, nil, false
+	}
+	targetURL, err := withPort(sandbox.InternalAddr, service.Port)
+	if err != nil {
+		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "invalid sandbox address")
+		return nil, mgr.SandboxAppService{}, nil, false
+	}
+	return sandbox, service, targetURL, true
+}
+
+func sandboxServiceByID(services []mgr.SandboxAppService, serviceID string) (mgr.SandboxAppService, bool) {
+	for _, service := range services {
+		if service.ID == serviceID {
+			return service, true
+		}
+	}
+	return mgr.SandboxAppService{}, false
+}
+
+func (s *Server) checkInternalFunctionRuntimeHTTPReadiness(ctx context.Context, targetURL *url.URL, healthPath string) error {
+	healthURL := *targetURL
+	if !strings.HasPrefix(healthPath, "/") {
+		healthPath = "/" + healthPath
+	}
+	healthURL.Path = healthPath
+	healthURL.RawPath = ""
+	healthURL.RawQuery = ""
+	healthURL.ForceQuery = false
+	healthURL.Fragment = ""
+
+	attemptCtx, cancel := context.WithTimeout(ctx, internalFunctionRuntimeReadinessTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(attemptCtx, http.MethodGet, healthURL.String(), nil)
+	if err != nil {
+		return err
+	}
+	healthClient := *s.outboundHTTPClient()
+	healthClient.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	resp, err := healthClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("health check request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("health check returned HTTP %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func checkInternalFunctionRuntimeTCPReadiness(ctx context.Context, address string) error {
+	if strings.TrimSpace(address) == "" {
+		return fmt.Errorf("function service target address is empty")
+	}
+	attemptCtx, cancel := context.WithTimeout(ctx, internalFunctionRuntimeReadinessTimeout)
+	defer cancel()
+	dialer := net.Dialer{Timeout: internalFunctionRuntimeReadinessTimeout}
+	conn, err := dialer.DialContext(attemptCtx, "tcp", address)
+	if err != nil {
+		return fmt.Errorf("function service did not accept TCP connections on %s: %w", address, err)
+	}
+	_ = conn.Close()
+	return nil
+}
+
+func stripInternalFunctionProxyHeaders(req *http.Request) {
+	req.Header.Del(internalauth.DefaultTokenHeader)
+	req.Header.Del(internalauth.TeamIDHeader)
+	req.Header.Del("X-User-ID")
+	req.Header.Del("X-Auth-Method")
+}

--- a/cluster-gateway/pkg/http/handlers_internal_function_proxy_test.go
+++ b/cluster-gateway/pkg/http/handlers_internal_function_proxy_test.go
@@ -1,0 +1,342 @@
+package http
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+	"github.com/sandbox0-ai/sandbox0/cluster-gateway/pkg/client"
+	clustermiddleware "github.com/sandbox0-ai/sandbox0/cluster-gateway/pkg/middleware"
+	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
+	mgr "github.com/sandbox0-ai/sandbox0/manager/pkg/service"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/authn"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
+	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+	"github.com/sandbox0-ai/sandbox0/pkg/proxy"
+	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestInternalFunctionRuntimeProxyRoutesToPrivateService(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	app := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(120 * time.Millisecond)
+		if r.URL.Path != "/private" {
+			t.Errorf("upstream path = %s", r.URL.Path)
+		}
+		if r.URL.RawQuery != "q=1" {
+			t.Errorf("upstream query = %q", r.URL.RawQuery)
+		}
+		if got := r.Header.Get(internalauth.DefaultTokenHeader); got != "" {
+			t.Errorf("upstream received internal token header %q", got)
+		}
+		if got := r.Header.Get(internalauth.TeamIDHeader); got != "" {
+			t.Errorf("upstream received internal team header %q", got)
+		}
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer app.Close()
+	appPort, err := portFromURL(app.URL)
+	if err != nil {
+		t.Fatalf("parse app port: %v", err)
+	}
+
+	sandbox := &mgr.Sandbox{
+		ID:           "sb_test",
+		TeamID:       "team-1",
+		InternalAddr: testInternalAddrWithPort(t, app.URL, 49983),
+		Services: []mgr.SandboxAppService{{
+			ID:   "api",
+			Port: appPort,
+		}},
+	}
+	clusterGateway, token := newInternalFunctionProxyTestGateway(t, sandbox, 50*time.Millisecond)
+	defer clusterGateway.Close()
+
+	req, err := http.NewRequest(http.MethodGet, clusterGateway.URL+"/internal/v1/functions/runtime/sandboxes/sb_test/services/api/proxy/private?q=1", nil)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	req.Header.Set(internalauth.DefaultTokenHeader, token)
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want %d, body = %s", resp.StatusCode, http.StatusOK, string(body))
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if string(body) != "ok" {
+		t.Fatalf("body = %q, want ok", string(body))
+	}
+}
+
+func TestInternalFunctionRuntimeProxySupportsWebSocket(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	app := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get(internalauth.DefaultTokenHeader); got != "" {
+			t.Errorf("upstream received internal token header %q", got)
+		}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade: %v", err)
+			return
+		}
+		defer conn.Close()
+		mt, payload, err := conn.ReadMessage()
+		if err != nil {
+			t.Errorf("read message: %v", err)
+			return
+		}
+		if err := conn.WriteMessage(mt, append([]byte("echo:"), payload...)); err != nil {
+			t.Errorf("write message: %v", err)
+		}
+	}))
+	defer app.Close()
+	appPort, err := portFromURL(app.URL)
+	if err != nil {
+		t.Fatalf("parse app port: %v", err)
+	}
+
+	sandbox := &mgr.Sandbox{
+		ID:           "sb_test",
+		TeamID:       "team-1",
+		InternalAddr: testInternalAddrWithPort(t, app.URL, 49983),
+		Services: []mgr.SandboxAppService{{
+			ID:   "api",
+			Port: appPort,
+		}},
+	}
+	clusterGateway, token := newInternalFunctionProxyTestGateway(t, sandbox, time.Second, time.Second)
+	defer clusterGateway.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(clusterGateway.URL, "http") + "/internal/v1/functions/runtime/sandboxes/sb_test/services/api/proxy/ws"
+	conn, resp, err := websocket.DefaultDialer.Dial(wsURL, http.Header{internalauth.DefaultTokenHeader: []string{token}})
+	if err != nil {
+		if resp != nil && resp.Body != nil {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("dial error = %v, status = %d, body = %s", err, resp.StatusCode, string(body))
+		}
+		t.Fatalf("dial error = %v", err)
+	}
+	defer conn.Close()
+
+	if err := conn.WriteMessage(websocket.TextMessage, []byte("ping")); err != nil {
+		t.Fatalf("write message: %v", err)
+	}
+	_, payload, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("read message: %v", err)
+	}
+	if string(payload) != "echo:ping" {
+		t.Fatalf("payload = %q", string(payload))
+	}
+}
+
+func TestInternalFunctionRuntimeReadinessFallsBackToTCP(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var requests int32
+	app := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requests, 1)
+		http.NotFound(w, r)
+	}))
+	defer app.Close()
+	appPort, err := portFromURL(app.URL)
+	if err != nil {
+		t.Fatalf("parse app port: %v", err)
+	}
+
+	sandbox := &mgr.Sandbox{
+		ID:           "sb_test",
+		TeamID:       "team-1",
+		InternalAddr: testInternalAddrWithPort(t, app.URL, 49983),
+		Services: []mgr.SandboxAppService{{
+			ID:   "api",
+			Port: appPort,
+		}},
+	}
+	clusterGateway, token := newInternalFunctionProxyTestGateway(t, sandbox, time.Second, time.Second)
+	defer clusterGateway.Close()
+
+	req, err := http.NewRequest(http.MethodGet, clusterGateway.URL+"/internal/v1/functions/runtime/sandboxes/sb_test/services/api/readiness", nil)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	req.Header.Set(internalauth.DefaultTokenHeader, token)
+	resp, err := clusterGateway.Client().Do(req)
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want %d, body = %s", resp.StatusCode, http.StatusNoContent, string(body))
+	}
+	if got := atomic.LoadInt32(&requests); got != 0 {
+		t.Fatalf("health requests = %d, want TCP fallback without HTTP requests", got)
+	}
+}
+
+func TestInternalFunctionRuntimeReadinessUsesHTTPHealth(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var requests int32
+	app := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/ready" {
+			t.Errorf("path = %s, want /ready", r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		if atomic.AddInt32(&requests, 1) == 1 {
+			http.Error(w, "starting", http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer app.Close()
+	appPort, err := portFromURL(app.URL)
+	if err != nil {
+		t.Fatalf("parse app port: %v", err)
+	}
+
+	sandbox := &mgr.Sandbox{
+		ID:           "sb_test",
+		TeamID:       "team-1",
+		InternalAddr: testInternalAddrWithPort(t, app.URL, 49983),
+		Services: []mgr.SandboxAppService{{
+			ID:   "api",
+			Port: appPort,
+		}},
+	}
+	clusterGateway, token := newInternalFunctionProxyTestGateway(t, sandbox, time.Second, time.Second)
+	defer clusterGateway.Close()
+
+	readinessURL := clusterGateway.URL + "/internal/v1/functions/runtime/sandboxes/sb_test/services/api/readiness?health_path=/ready"
+	for attempt, wantStatus := range []int{http.StatusServiceUnavailable, http.StatusNoContent} {
+		req, err := http.NewRequest(http.MethodGet, readinessURL, nil)
+		if err != nil {
+			t.Fatalf("create request: %v", err)
+		}
+		req.Header.Set(internalauth.DefaultTokenHeader, token)
+		resp, err := clusterGateway.Client().Do(req)
+		if err != nil {
+			t.Fatalf("Do() attempt %d error = %v", attempt+1, err)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if resp.StatusCode != wantStatus {
+			t.Fatalf("attempt %d status = %d, want %d, body = %s", attempt+1, resp.StatusCode, wantStatus, string(body))
+		}
+	}
+	if got := atomic.LoadInt32(&requests); got != 2 {
+		t.Fatalf("health requests = %d, want 2", got)
+	}
+}
+
+func newInternalFunctionProxyTestGateway(t *testing.T, sandbox *mgr.Sandbox, proxyTimeout time.Duration, writeTimeoutOverride ...time.Duration) (*httptest.Server, string) {
+	t.Helper()
+
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate ed25519 keypair: %v", err)
+	}
+	logger := zap.NewNop()
+	manager := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/internal/v1/sandboxes/"+sandbox.ID {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Header.Get(internalauth.DefaultTokenHeader) == "" {
+			http.Error(w, "missing internal token", http.StatusUnauthorized)
+			return
+		}
+		_ = spec.WriteSuccess(w, http.StatusOK, sandbox)
+	}))
+	t.Cleanup(manager.Close)
+
+	managerProxy, err := proxy.NewRouter(manager.URL, logger, time.Second)
+	if err != nil {
+		t.Fatalf("create manager proxy: %v", err)
+	}
+	internalAuthGen := internalauth.NewGenerator(internalauth.GeneratorConfig{
+		Caller:     internalauth.ServiceClusterGateway,
+		PrivateKey: privateKey,
+		TTL:        time.Minute,
+	})
+	managerClient := client.NewManagerClient(manager.URL, internalAuthGen, logger, time.Second)
+	managerClient.SetHTTPClient(manager.Client())
+	clusterValidator := internalauth.NewValidator(internalauth.ValidatorConfig{
+		Target:             internalauth.ServiceClusterGateway,
+		PublicKey:          publicKey,
+		AllowedCallers:     []string{internalauth.ServiceFunctionGateway},
+		ClockSkewTolerance: 5 * time.Second,
+	})
+	server := &Server{
+		cfg: &config.ClusterGatewayConfig{
+			ManagerURL:   manager.URL,
+			ProxyTimeout: metav1.Duration{Duration: proxyTimeout},
+		},
+		proxy2Mgr:       managerProxy,
+		managerClient:   managerClient,
+		authMiddleware:  clustermiddleware.NewInternalAuthMiddleware(clusterValidator, logger),
+		internalAuthGen: internalAuthGen,
+		logger:          logger,
+		httpClient:      manager.Client(),
+	}
+	server.router = gin.New()
+	server.setupInternalControlPlaneRoutes()
+
+	clusterGateway := httptest.NewUnstartedServer(server.router)
+	writeTimeout := 50 * time.Millisecond
+	if len(writeTimeoutOverride) > 0 {
+		writeTimeout = writeTimeoutOverride[0]
+	}
+	clusterGateway.Config.WriteTimeout = writeTimeout
+	clusterGateway.Start()
+
+	functionGatewayToken, err := internalauth.NewGenerator(internalauth.GeneratorConfig{
+		Caller:     internalauth.ServiceFunctionGateway,
+		PrivateKey: privateKey,
+		TTL:        time.Minute,
+	}).Generate(internalauth.ServiceClusterGateway, sandbox.TeamID, "user-1", internalauth.GenerateOptions{
+		Permissions: []string{authn.PermSandboxRead},
+	})
+	if err != nil {
+		clusterGateway.Close()
+		t.Fatalf("generate function-gateway token: %v", err)
+	}
+	return clusterGateway, functionGatewayToken
+}
+
+func testInternalAddrWithPort(t *testing.T, raw string, port int) string {
+	t.Helper()
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse URL: %v", err)
+	}
+	parsed.Host = net.JoinHostPort(parsed.Hostname(), strconv.Itoa(port))
+	return parsed.String()
+}

--- a/cluster-gateway/pkg/http/server.go
+++ b/cluster-gateway/pkg/http/server.go
@@ -518,6 +518,8 @@ func (s *Server) setupInternalControlPlaneRoutes() {
 		internal.GET("/sandboxes/:id", s.getInternalSandbox)
 		internal.DELETE("/sandboxes/:id", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxDelete), s.deleteInternalSandbox)
 		internal.POST("/sandboxes/:id/resume", s.resumeInternalSandbox)
+		internal.Any("/functions/runtime/sandboxes/:id/services/:service_id/proxy/*path", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxRead), s.proxyInternalFunctionRuntime)
+		internal.GET("/functions/runtime/sandboxes/:id/services/:service_id/readiness", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxRead), s.checkInternalFunctionRuntimeReadiness)
 
 		// Template management (→ Manager)
 		internal.GET("/templates", s.proxyInternalTemplateRequest)

--- a/docs/function/page.mdx
+++ b/docs/function/page.mdx
@@ -20,7 +20,7 @@ The `production` alias is the serving pointer used by the function host. Creatin
 
 ## How Serving Works
 
-Function traffic is handled by `function-gateway`. The gateway resolves the host to a function, loads the `production` revision, enforces the revision's service route policy, and proxies the request to the service port.
+Function traffic is handled by `function-gateway`. The gateway resolves the host to a function, loads the `production` revision, enforces the revision's service route policy, then proxies through the owning `cluster-gateway` to the runtime sandbox service port. `function-gateway` is regional and does not rely on direct access to cluster-internal sandbox IPs.
 
 Function serving is revision-first. The gateway does not proxy production traffic to the mutable source sandbox. When no reusable runtime exists, the gateway claims a new runtime sandbox from the revision's template, mounts the revision-owned volumes, starts the service runtime command or binds to the referenced warm process, and reuses runtime instances for later requests. The runtime pool scales out up to the function's `max_active` setting when local in-flight requests reach the soft `target_concurrency` target. Changes made to the source sandbox after publishing require a new revision before they affect the function host.
 

--- a/docs/function/runtime/page.mdx
+++ b/docs/function/runtime/page.mdx
@@ -6,9 +6,11 @@ Runtime pool size and scale-out behavior are configured on the function's autosc
 
 ## Startup Readiness
 
-After Function Gateway starts a restored runtime context, it waits up to 30 seconds before sending user traffic. If the published service has `health_check.path`, the gateway polls that path with `GET` every 200 ms and considers the runtime ready only after the endpoint returns HTTP `2xx`. If no health check is configured, the gateway falls back to waiting for the service port to accept TCP connections.
+After Function Gateway starts a restored runtime context, it waits up to 30 seconds before sending user traffic. Function Gateway polls the owning `cluster-gateway` every 200 ms so readiness checks run inside the target cluster. On each poll, if the published service has `health_check.path`, the cluster gateway checks that path with `GET` and considers the runtime ready only after the endpoint returns HTTP `2xx`. If no health check is configured, the cluster gateway falls back to waiting for the service port to accept TCP connections.
 
-When readiness does not pass before the timeout, the request returns `503` and the gateway records a startup error that includes the health check URL plus the last HTTP status or request error.
+When readiness does not pass before the timeout, the request returns `503` and the gateway records a startup error with the last readiness status or request error.
+
+Runtime serving traffic goes from regional `function-gateway` to the runtime sandbox's owning `cluster-gateway`, and only the cluster-local gateway connects to the sandbox service IP. HTTP responses, streaming HTTP responses such as SSE, and WebSocket upgrades use the same gateway chain. Route `timeout_seconds` still bounds the upstream request when configured, while streaming responses and WebSocket upgrades keep the downstream connection open for long-running output.
 
 ## Observability
 

--- a/function-gateway/pkg/http/runtime.go
+++ b/function-gateway/pkg/http/runtime.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	nethttp "net/http"
 	"net/url"
 	"strconv"
@@ -35,7 +34,6 @@ const defaultFunctionAutoResumeTimeout = 30 * time.Second
 const defaultFunctionRuntimeStartTimeout = 30 * time.Second
 const functionRuntimeRestoreLockPrefix = "function-runtime-restore:"
 const functionServiceReadinessProbeInterval = 200 * time.Millisecond
-const functionServiceReadinessTCPTimeout = 500 * time.Millisecond
 
 type functionRouteMatch struct {
 	route         *mgr.SandboxAppServiceRoute
@@ -146,35 +144,13 @@ func (s *Server) serveFunctionRevision(c *gin.Context, fn *functions.Function, r
 		}
 	}
 
-	if basePort, parseErr := portFromURL(sandbox.InternalAddr); parseErr == nil && basePort == service.Port {
-		spec.JSONError(c, nethttp.StatusForbidden, spec.CodeForbidden, "reserved port is not exposable")
-		return
-	}
-	targetURL, err := withPort(sandbox.InternalAddr, service.Port)
-	if err != nil {
-		spec.JSONError(c, nethttp.StatusInternalServerError, spec.CodeInternal, "invalid sandbox address")
-		return
-	}
-	proxyTimeout := s.cfg.ProxyTimeout.Duration
-	if proxyTimeout == 0 {
-		proxyTimeout = 30 * time.Second
-	}
-	proxyTimeout = functionRouteProxyTimeout(proxyTimeout, match.route)
-	if !functionRouteHasTimeout(match.route) {
-		c.Request = proxy.WithUpstreamTimeoutDisabledRequest(c.Request)
-	}
-	router, err := proxy.NewRouter(targetURL.String(), s.logger, proxyTimeout, proxy.WithHTTPClient(s.outboundHTTPClient()))
-	if err != nil {
-		spec.JSONError(c, nethttp.StatusInternalServerError, spec.CodeInternal, "proxy initialization failed")
-		return
-	}
 	proxyCtx, proxySpan := s.startFunctionSpan(c.Request.Context(), "function.proxy", fn, rev,
 		attribute.String("sandbox0.function_route_id", routeID),
 		attribute.String("sandbox0.runtime_sandbox_id", sandbox.ID),
 		attribute.Int("sandbox0.service_port", service.Port),
 	)
 	c.Request = c.Request.WithContext(proxyCtx)
-	router.ProxyToTarget(c)
+	s.proxyFunctionRequestToRuntime(c, fn, rev, sandbox, service, match.route)
 	status := c.Writer.Status()
 	proxySpan.SetAttributes(attribute.Int("http.status_code", status))
 	if status >= 500 {
@@ -416,6 +392,85 @@ func functionRouteHasTimeout(route *mgr.SandboxAppServiceRoute) bool {
 	return route != nil && route.TimeoutSeconds > 0
 }
 
+func (s *Server) proxyFunctionRequestToRuntime(c *gin.Context, fn *functions.Function, rev *functions.Revision, sandbox *mgr.Sandbox, service mgr.SandboxAppService, route *mgr.SandboxAppServiceRoute) {
+	if sandbox == nil {
+		spec.JSONError(c, nethttp.StatusServiceUnavailable, spec.CodeUnavailable, "function sandbox is not available")
+		return
+	}
+	if strings.TrimSpace(service.ID) == "" {
+		spec.JSONError(c, nethttp.StatusServiceUnavailable, spec.CodeUnavailable, "function service is invalid")
+		return
+	}
+	if basePort, parseErr := portFromURL(sandbox.InternalAddr); parseErr == nil && basePort == service.Port {
+		spec.JSONError(c, nethttp.StatusForbidden, spec.CodeForbidden, "reserved port is not exposable")
+		return
+	}
+	clusterGatewayURL, err := s.clusterGatewayURLForSandbox(c.Request.Context(), sandbox.ID)
+	if err != nil || strings.TrimSpace(clusterGatewayURL) == "" {
+		spec.JSONError(c, nethttp.StatusServiceUnavailable, spec.CodeUnavailable, "cluster gateway is not configured")
+		return
+	}
+	if s.internalAuthGen == nil {
+		spec.JSONError(c, nethttp.StatusInternalServerError, spec.CodeInternal, "internal authentication is not configured")
+		return
+	}
+	token, err := s.internalAuthGen.Generate(internalauth.ServiceClusterGateway, fn.TeamID, rev.CreatedBy, internalauth.GenerateOptions{
+		Permissions: []string{authn.PermSandboxRead},
+	})
+	if err != nil {
+		spec.JSONError(c, nethttp.StatusInternalServerError, spec.CodeInternal, "internal authentication failed")
+		return
+	}
+
+	c.Request.URL.Path = functionRuntimeProxyPath(sandbox.ID, service.ID, c.Request.URL.Path)
+	c.Request.URL.RawPath = ""
+	c.Request = proxy.WithStreamingResponseDeadlinesDisabledRequest(c.Request)
+	proxyTimeout := s.cfg.ProxyTimeout.Duration
+	if proxyTimeout == 0 {
+		proxyTimeout = 30 * time.Second
+	}
+	proxyTimeout = functionRouteProxyTimeout(proxyTimeout, route)
+	if !functionRouteHasTimeout(route) {
+		c.Request = proxy.WithUpstreamTimeoutDisabledRequest(c.Request)
+	}
+
+	router, err := proxy.NewRouter(
+		strings.TrimRight(clusterGatewayURL, "/"),
+		s.logger,
+		proxyTimeout,
+		proxy.WithHTTPClient(s.outboundHTTPClient()),
+		proxy.WithRequestModifier(func(req *nethttp.Request) {
+			req.Header.Set(internalauth.DefaultTokenHeader, token)
+			req.Header.Set("X-Team-ID", fn.TeamID)
+			if strings.TrimSpace(rev.CreatedBy) != "" {
+				req.Header.Set("X-User-ID", rev.CreatedBy)
+			}
+			req.Header.Set("X-Auth-Method", string(authn.AuthMethodInternal))
+		}),
+	)
+	if err != nil {
+		spec.JSONError(c, nethttp.StatusInternalServerError, spec.CodeInternal, "proxy initialization failed")
+		return
+	}
+	router.ProxyToTarget(c)
+}
+
+func functionRuntimeProxyPath(sandboxID, serviceID, requestPath string) string {
+	if requestPath == "" {
+		requestPath = "/"
+	}
+	if !strings.HasPrefix(requestPath, "/") {
+		requestPath = "/" + requestPath
+	}
+	return "/internal/v1/functions/runtime/sandboxes/" + url.PathEscape(sandboxID) +
+		"/services/" + url.PathEscape(serviceID) + "/proxy" + requestPath
+}
+
+func functionRuntimeReadinessPath(sandboxID, serviceID string) string {
+	return "/internal/v1/functions/runtime/sandboxes/" + url.PathEscape(sandboxID) +
+		"/services/" + url.PathEscape(serviceID) + "/readiness"
+}
+
 func rewriteFunctionPath(c *gin.Context, matchedPrefix, rewritePrefix string) {
 	original := c.Request.URL.Path
 	matchedPrefix = strings.TrimRight(matchedPrefix, "/")
@@ -611,7 +666,7 @@ func (s *Server) ensureFunctionServiceRuntime(ctx context.Context, fn *functions
 	}
 	startCtx, cancel := context.WithTimeout(ctx, defaultFunctionRuntimeStartTimeout)
 	defer cancel()
-	if err := s.waitForFunctionServiceReadiness(startCtx, sandbox.InternalAddr, service); err != nil {
+	if err := s.waitForFunctionServiceReadiness(startCtx, sandbox.ID, fn.TeamID, rev.CreatedBy, service); err != nil {
 		return "", err
 	}
 	return contextID, nil
@@ -893,37 +948,50 @@ func isFunctionRuntimeStatus(err error, status int) bool {
 	return false
 }
 
-func (s *Server) waitForFunctionServiceReadiness(ctx context.Context, internalAddr string, service mgr.SandboxAppService) error {
-	if service.HealthCheck != nil && strings.TrimSpace(service.HealthCheck.Path) != "" {
-		return s.waitForFunctionServiceHTTPHealth(ctx, internalAddr, service.Port, service.HealthCheck.Path)
+func (s *Server) waitForFunctionServiceReadiness(ctx context.Context, sandboxID, teamID, userID string, service mgr.SandboxAppService) error {
+	if strings.TrimSpace(service.ID) == "" {
+		return fmt.Errorf("function service id is required for readiness")
 	}
-	return waitForFunctionServicePort(ctx, internalAddr, service.Port)
-}
-
-func (s *Server) waitForFunctionServiceHTTPHealth(ctx context.Context, internalAddr string, port int, healthPath string) error {
-	healthURL, err := functionServiceHealthURL(internalAddr, port, healthPath)
+	clusterGatewayURL, err := s.clusterGatewayURLForSandbox(ctx, sandboxID)
+	if err != nil || clusterGatewayURL == "" {
+		return fmt.Errorf("cluster gateway is not configured")
+	}
+	if s.internalAuthGen == nil {
+		return fmt.Errorf("internal auth generator is not configured")
+	}
+	readinessURL, err := url.Parse(strings.TrimRight(clusterGatewayURL, "/") + functionRuntimeReadinessPath(sandboxID, service.ID))
 	if err != nil {
 		return err
 	}
-	healthClient := *s.outboundHTTPClient()
-	healthClient.CheckRedirect = func(_ *nethttp.Request, _ []*nethttp.Request) error {
-		return nethttp.ErrUseLastResponse
+	if service.HealthCheck != nil && strings.TrimSpace(service.HealthCheck.Path) != "" {
+		q := readinessURL.Query()
+		q.Set("health_path", strings.TrimSpace(service.HealthCheck.Path))
+		readinessURL.RawQuery = q.Encode()
 	}
+
 	ticker := time.NewTicker(functionServiceReadinessProbeInterval)
 	defer ticker.Stop()
 	var lastErr error
 	for {
-		req, err := nethttp.NewRequestWithContext(ctx, nethttp.MethodGet, healthURL.String(), nil)
+		req, err := nethttp.NewRequestWithContext(ctx, nethttp.MethodGet, readinessURL.String(), nil)
 		if err != nil {
 			return err
 		}
-		resp, err := healthClient.Do(req)
+		token, err := s.internalAuthGen.Generate(internalauth.ServiceClusterGateway, teamID, userID, internalauth.GenerateOptions{
+			Permissions: []string{authn.PermSandboxRead},
+		})
+		if err != nil {
+			return fmt.Errorf("generate internal token: %w", err)
+		}
+		req.Header.Set(internalauth.DefaultTokenHeader, token)
+		resp, err := s.outboundHTTPClient().Do(req)
 		if err == nil {
 			if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 				_ = resp.Body.Close()
 				return nil
 			}
-			lastErr = fmt.Errorf("health check returned HTTP %d", resp.StatusCode)
+			body, _ := io.ReadAll(resp.Body)
+			lastErr = fmt.Errorf("readiness check returned HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 			_ = resp.Body.Close()
 		} else {
 			lastErr = err
@@ -933,57 +1001,10 @@ func (s *Server) waitForFunctionServiceHTTPHealth(ctx context.Context, internalA
 			if lastErr == nil {
 				lastErr = ctx.Err()
 			}
-			return fmt.Errorf("function service health check %s did not return HTTP 2xx before timeout: %w", healthURL.String(), lastErr)
+			return fmt.Errorf("function service readiness did not pass before timeout: %w", lastErr)
 		case <-ticker.C:
 		}
 	}
-}
-
-func waitForFunctionServicePort(ctx context.Context, internalAddr string, port int) error {
-	targetURL, err := withPort(internalAddr, port)
-	if err != nil {
-		return err
-	}
-	address := targetURL.Host
-	if address == "" {
-		return fmt.Errorf("function service target address is empty")
-	}
-	ticker := time.NewTicker(functionServiceReadinessProbeInterval)
-	defer ticker.Stop()
-	var lastErr error
-	for {
-		conn, err := net.DialTimeout("tcp", address, functionServiceReadinessTCPTimeout)
-		if err == nil {
-			_ = conn.Close()
-			return nil
-		}
-		lastErr = err
-		select {
-		case <-ctx.Done():
-			return fmt.Errorf("function service did not start listening on %s: %w", address, lastErr)
-		case <-ticker.C:
-		}
-	}
-}
-
-func functionServiceHealthURL(internalAddr string, port int, healthPath string) (*url.URL, error) {
-	targetURL, err := withPort(internalAddr, port)
-	if err != nil {
-		return nil, err
-	}
-	path := strings.TrimSpace(healthPath)
-	if path == "" {
-		return nil, fmt.Errorf("function service health check path is empty")
-	}
-	if !strings.HasPrefix(path, "/") {
-		path = "/" + path
-	}
-	targetURL.Path = path
-	targetURL.RawPath = ""
-	targetURL.RawQuery = ""
-	targetURL.ForceQuery = false
-	targetURL.Fragment = ""
-	return targetURL, nil
 }
 
 func (s *Server) resumeSandboxViaClusterGateway(ctx context.Context, sandboxID, teamID, userID string) error {
@@ -1031,19 +1052,6 @@ func (s *Server) writeFunctionRuntimeError(c *gin.Context, fn *functions.Functio
 		"source_sandbox_id": rev.SourceSandboxID,
 		"source_service_id": rev.SourceServiceID,
 	})
-}
-
-func withPort(raw string, port int) (*url.URL, error) {
-	base, err := url.Parse(raw)
-	if err != nil {
-		return nil, err
-	}
-	host := base.Hostname()
-	if host == "" {
-		return nil, fmt.Errorf("empty host")
-	}
-	base.Host = net.JoinHostPort(host, strconv.Itoa(port))
-	return base, nil
 }
 
 func portFromURL(raw string) (int, error) {

--- a/function-gateway/pkg/http/runtime_test.go
+++ b/function-gateway/pkg/http/runtime_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -88,6 +89,109 @@ func TestRewriteFunctionPath(t *testing.T) {
 	rewriteFunctionPath(ctx, "/api", "/")
 	if got := ctx.Request.URL.Path; got != "/v1/users" {
 		t.Fatalf("path = %q, want /v1/users", got)
+	}
+}
+
+func TestFunctionRuntimeProxyPath(t *testing.T) {
+	path := functionRuntimeProxyPath("sb_test", "api", "/v1/users")
+	want := "/internal/v1/functions/runtime/sandboxes/sb_test/services/api/proxy/v1/users"
+	if path != want {
+		t.Fatalf("path = %q, want %q", path, want)
+	}
+
+	root := functionRuntimeProxyPath("sb_test", "api", "")
+	if root != "/internal/v1/functions/runtime/sandboxes/sb_test/services/api/proxy/" {
+		t.Fatalf("root path = %q", root)
+	}
+}
+
+func TestFunctionRuntimeProxyUsesClusterGatewayForServing(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	publicKey, privateKey, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate ed25519 keypair: %v", err)
+	}
+	validator := internalauth.NewValidator(internalauth.ValidatorConfig{
+		Target:         internalauth.ServiceClusterGateway,
+		PublicKey:      publicKey,
+		AllowedCallers: []string{internalauth.ServiceFunctionGateway},
+	})
+
+	clusterGateway := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/internal/v1/functions/runtime/sandboxes/sb_test/services/api/proxy/stream" {
+			t.Errorf("cluster-gateway path = %s", r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		if r.URL.RawQuery != "q=1" {
+			t.Errorf("cluster-gateway raw query = %q", r.URL.RawQuery)
+		}
+		claims, err := validator.Validate(r.Header.Get(internalauth.DefaultTokenHeader))
+		if err != nil {
+			t.Errorf("validate internal token: %v", err)
+			http.Error(w, "bad token", http.StatusUnauthorized)
+			return
+		}
+		if claims.TeamID != "team-1" || claims.UserID != "user-1" {
+			t.Errorf("claims = team %q user %q", claims.TeamID, claims.UserID)
+		}
+		time.Sleep(120 * time.Millisecond)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: ok\n\n")
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+	}))
+	defer clusterGateway.Close()
+
+	server := &Server{
+		cfg: &config.FunctionGatewayConfig{
+			DefaultClusterGatewayURL: clusterGateway.URL,
+		},
+		internalAuthGen: internalauth.NewGenerator(internalauth.GeneratorConfig{
+			Caller:     internalauth.ServiceFunctionGateway,
+			PrivateKey: privateKey,
+			TTL:        time.Minute,
+		}),
+		httpClient: clusterGateway.Client(),
+		logger:     zap.NewNop(),
+	}
+	fn := &functions.Function{ID: "fn-1", TeamID: "team-1"}
+	rev := &functions.Revision{ID: "rev-1", FunctionID: "fn-1", TeamID: "team-1", CreatedBy: "user-1"}
+	sandbox := &mgr.Sandbox{
+		ID:           "sb_test",
+		TeamID:       "team-1",
+		InternalAddr: "http://203.0.113.1:49983",
+	}
+	service := mgr.SandboxAppService{ID: "api", Port: 3000}
+	route := &mgr.SandboxAppServiceRoute{ID: "api", TimeoutSeconds: 1}
+
+	engine := gin.New()
+	engine.GET("/*path", func(c *gin.Context) {
+		server.proxyFunctionRequestToRuntime(c, fn, rev, sandbox, service, route)
+	})
+	functionGateway := httptest.NewUnstartedServer(engine)
+	functionGateway.Config.WriteTimeout = 50 * time.Millisecond
+	functionGateway.Start()
+	defer functionGateway.Close()
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get(functionGateway.URL + "/stream?q=1")
+	if err != nil {
+		t.Fatalf("GET() error = %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want %d, body = %s", resp.StatusCode, http.StatusOK, string(body))
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if string(body) != "data: ok\n\n" {
+		t.Fatalf("body = %q", string(body))
 	}
 }
 
@@ -271,34 +375,35 @@ func TestWithRevisionRuntimeDistributedLockFallsBackWithoutLocker(t *testing.T) 
 	}
 }
 
-func TestWaitForFunctionServiceReadinessFallsBackToTCP(t *testing.T) {
-	var requests int32
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&requests, 1)
-		http.NotFound(w, r)
-	}))
-	defer upstream.Close()
-	port, err := portFromURL(upstream.URL)
+func TestWaitForFunctionServiceReadinessUsesClusterGatewayTCPFallback(t *testing.T) {
+	publicKey, privateKey, err := ed25519.GenerateKey(nil)
 	if err != nil {
-		t.Fatalf("parse upstream port: %v", err)
+		t.Fatalf("generate ed25519 keypair: %v", err)
 	}
+	validator := internalauth.NewValidator(internalauth.ValidatorConfig{
+		Target:         internalauth.ServiceClusterGateway,
+		PublicKey:      publicKey,
+		AllowedCallers: []string{internalauth.ServiceFunctionGateway},
+	})
 
-	service := mgr.SandboxAppService{Port: port}
-	if err := (&Server{}).waitForFunctionServiceReadiness(context.Background(), upstream.URL, service); err != nil {
-		t.Fatalf("waitForFunctionServiceReadiness() error = %v", err)
-	}
-	if got := atomic.LoadInt32(&requests); got != 0 {
-		t.Fatalf("health requests = %d, want TCP fallback without HTTP requests", got)
-	}
-}
-
-func TestWaitForFunctionServiceReadinessHTTPHealthSuccess(t *testing.T) {
 	var requests int32
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/ready" {
-			t.Errorf("path = %s, want /ready", r.URL.Path)
+	clusterGateway := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/internal/v1/functions/runtime/sandboxes/sb_test/services/api/readiness" {
+			t.Errorf("path = %s", r.URL.Path)
 			http.NotFound(w, r)
 			return
+		}
+		if got := r.URL.Query().Get("health_path"); got != "" {
+			t.Errorf("health_path = %q, want empty TCP fallback", got)
+		}
+		claims, err := validator.Validate(r.Header.Get(internalauth.DefaultTokenHeader))
+		if err != nil {
+			t.Errorf("validate internal token: %v", err)
+			http.Error(w, "bad token", http.StatusUnauthorized)
+			return
+		}
+		if claims.TeamID != "team-1" || claims.UserID != "user-1" {
+			t.Errorf("claims = team %q user %q", claims.TeamID, claims.UserID)
 		}
 		if atomic.AddInt32(&requests, 1) == 1 {
 			http.Error(w, "starting", http.StatusServiceUnavailable)
@@ -306,72 +411,142 @@ func TestWaitForFunctionServiceReadinessHTTPHealthSuccess(t *testing.T) {
 		}
 		w.WriteHeader(http.StatusNoContent)
 	}))
-	defer upstream.Close()
-	port, err := portFromURL(upstream.URL)
-	if err != nil {
-		t.Fatalf("parse upstream port: %v", err)
-	}
+	defer clusterGateway.Close()
 
+	server := &Server{
+		cfg: &config.FunctionGatewayConfig{
+			DefaultClusterGatewayURL: clusterGateway.URL,
+		},
+		internalAuthGen: internalauth.NewGenerator(internalauth.GeneratorConfig{
+			Caller:     internalauth.ServiceFunctionGateway,
+			PrivateKey: privateKey,
+			TTL:        time.Minute,
+		}),
+		httpClient: clusterGateway.Client(),
+		logger:     zap.NewNop(),
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	service := mgr.SandboxAppService{
-		Port:        port,
-		HealthCheck: &mgr.SandboxAppServiceHealth{Path: "/ready"},
-	}
-	if err := (&Server{}).waitForFunctionServiceReadiness(ctx, upstream.URL, service); err != nil {
+	service := mgr.SandboxAppService{ID: "api"}
+	if err := server.waitForFunctionServiceReadiness(ctx, "sb_test", "team-1", "user-1", service); err != nil {
 		t.Fatalf("waitForFunctionServiceReadiness() error = %v", err)
 	}
 	if got := atomic.LoadInt32(&requests); got < 2 {
-		t.Fatalf("health requests = %d, want retry before success", got)
+		t.Fatalf("readiness requests = %d, want retry before success", got)
 	}
 }
 
-func TestWaitForFunctionServiceReadinessHTTPHealthFailure(t *testing.T) {
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "not ready", http.StatusInternalServerError)
-	}))
-	defer upstream.Close()
-	port, err := portFromURL(upstream.URL)
+func TestWaitForFunctionServiceReadinessPassesHealthPathToClusterGateway(t *testing.T) {
+	_, privateKey, err := ed25519.GenerateKey(nil)
 	if err != nil {
-		t.Fatalf("parse upstream port: %v", err)
+		t.Fatalf("generate ed25519 keypair: %v", err)
 	}
+	var requests int32
+	clusterGateway := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/internal/v1/functions/runtime/sandboxes/sb_test/services/api/readiness" {
+			t.Errorf("path = %s", r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.URL.Query().Get("health_path"); got != "/ready" {
+			t.Errorf("health_path = %q, want /ready", got)
+		}
+		if atomic.AddInt32(&requests, 1) == 1 {
+			http.Error(w, "starting", http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer clusterGateway.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	server := &Server{
+		cfg: &config.FunctionGatewayConfig{
+			DefaultClusterGatewayURL: clusterGateway.URL,
+		},
+		internalAuthGen: internalauth.NewGenerator(internalauth.GeneratorConfig{
+			Caller:     internalauth.ServiceFunctionGateway,
+			PrivateKey: privateKey,
+			TTL:        time.Minute,
+		}),
+		httpClient: clusterGateway.Client(),
+		logger:     zap.NewNop(),
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	service := mgr.SandboxAppService{
-		Port:        port,
+		ID:          "api",
 		HealthCheck: &mgr.SandboxAppServiceHealth{Path: "/ready"},
 	}
-	err = (&Server{}).waitForFunctionServiceReadiness(ctx, upstream.URL, service)
-	if err == nil {
-		t.Fatal("waitForFunctionServiceReadiness() error = nil, want health failure")
+	if err := server.waitForFunctionServiceReadiness(ctx, "sb_test", "team-1", "user-1", service); err != nil {
+		t.Fatalf("waitForFunctionServiceReadiness() error = %v", err)
 	}
-	if !strings.Contains(err.Error(), "HTTP 500") || !strings.Contains(err.Error(), "did not return HTTP 2xx") {
-		t.Fatalf("error = %q, want readable HTTP readiness failure", err.Error())
+	if got := atomic.LoadInt32(&requests); got < 2 {
+		t.Fatalf("readiness requests = %d, want retry before success", got)
 	}
 }
 
-func TestWaitForFunctionServiceReadinessHTTPHealthTimeout(t *testing.T) {
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+func TestWaitForFunctionServiceReadinessFailure(t *testing.T) {
+	_, privateKey, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate ed25519 keypair: %v", err)
+	}
+	clusterGateway := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not ready", http.StatusServiceUnavailable)
+	}))
+	defer clusterGateway.Close()
+
+	server := &Server{
+		cfg: &config.FunctionGatewayConfig{
+			DefaultClusterGatewayURL: clusterGateway.URL,
+		},
+		internalAuthGen: internalauth.NewGenerator(internalauth.GeneratorConfig{
+			Caller:     internalauth.ServiceFunctionGateway,
+			PrivateKey: privateKey,
+			TTL:        time.Minute,
+		}),
+		httpClient: clusterGateway.Client(),
+		logger:     zap.NewNop(),
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	err = server.waitForFunctionServiceReadiness(ctx, "sb_test", "team-1", "user-1", mgr.SandboxAppService{ID: "api"})
+	if err == nil {
+		t.Fatal("waitForFunctionServiceReadiness() error = nil, want readiness failure")
+	}
+	if !strings.Contains(err.Error(), "HTTP 503") || !strings.Contains(err.Error(), "did not pass") {
+		t.Fatalf("error = %q, want readable readiness failure", err.Error())
+	}
+}
+
+func TestWaitForFunctionServiceReadinessTimeout(t *testing.T) {
+	_, privateKey, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate ed25519 keypair: %v", err)
+	}
+	clusterGateway := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		<-r.Context().Done()
 	}))
-	defer upstream.Close()
-	port, err := portFromURL(upstream.URL)
-	if err != nil {
-		t.Fatalf("parse upstream port: %v", err)
-	}
+	defer clusterGateway.Close()
 
+	server := &Server{
+		cfg: &config.FunctionGatewayConfig{
+			DefaultClusterGatewayURL: clusterGateway.URL,
+		},
+		internalAuthGen: internalauth.NewGenerator(internalauth.GeneratorConfig{
+			Caller:     internalauth.ServiceFunctionGateway,
+			PrivateKey: privateKey,
+			TTL:        time.Minute,
+		}),
+		httpClient: clusterGateway.Client(),
+		logger:     zap.NewNop(),
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
-	service := mgr.SandboxAppService{
-		Port:        port,
-		HealthCheck: &mgr.SandboxAppServiceHealth{Path: "/ready"},
-	}
-	err = (&Server{}).waitForFunctionServiceReadiness(ctx, upstream.URL, service)
+	err = server.waitForFunctionServiceReadiness(ctx, "sb_test", "team-1", "user-1", mgr.SandboxAppService{ID: "api"})
 	if err == nil {
 		t.Fatal("waitForFunctionServiceReadiness() error = nil, want timeout")
 	}
-	if !errors.Is(err, context.DeadlineExceeded) || !strings.Contains(err.Error(), "did not return HTTP 2xx") {
+	if !errors.Is(err, context.DeadlineExceeded) || !strings.Contains(err.Error(), "did not pass") {
 		t.Fatalf("error = %q, want readiness timeout with context deadline", err.Error())
 	}
 }

--- a/pkg/proxy/request_timeout.go
+++ b/pkg/proxy/request_timeout.go
@@ -10,6 +10,7 @@ import (
 
 type upstreamTimeoutDisabledKey struct{}
 type longLivedRequestKey struct{}
+type streamingResponseDeadlinesDisabledKey struct{}
 
 // WithUpstreamTimeoutDisabled marks a request context so gateway upstream calls
 // should not apply the default proxy timeout.
@@ -27,6 +28,15 @@ func WithLongLivedRequest(ctx context.Context) context.Context {
 	return context.WithValue(ctx, longLivedRequestKey{}, true)
 }
 
+// WithStreamingResponseDeadlinesDisabled marks a request context so gateway
+// server write deadlines are cleared while still allowing an upstream timeout.
+func WithStreamingResponseDeadlinesDisabled(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, streamingResponseDeadlinesDisabledKey{}, true)
+}
+
 // WithUpstreamTimeoutDisabledRequest applies the no-timeout marker to a request.
 func WithUpstreamTimeoutDisabledRequest(req *http.Request) *http.Request {
 	if req == nil {
@@ -41,6 +51,15 @@ func WithLongLivedRequestRequest(req *http.Request) *http.Request {
 		return nil
 	}
 	return req.WithContext(WithLongLivedRequest(req.Context()))
+}
+
+// WithStreamingResponseDeadlinesDisabledRequest applies the streaming response
+// deadline marker to a request.
+func WithStreamingResponseDeadlinesDisabledRequest(req *http.Request) *http.Request {
+	if req == nil {
+		return nil
+	}
+	return req.WithContext(WithStreamingResponseDeadlinesDisabled(req.Context()))
 }
 
 // UpstreamTimeoutDisabled reports whether upstream timeout enforcement is disabled.
@@ -60,6 +79,16 @@ func LongLivedRequest(ctx context.Context) bool {
 	}
 	longLived, _ := ctx.Value(longLivedRequestKey{}).(bool)
 	return longLived
+}
+
+// StreamingResponseDeadlinesDisabled reports whether gateway server write
+// deadlines should be cleared without changing upstream timeout enforcement.
+func StreamingResponseDeadlinesDisabled(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	disabled, _ := ctx.Value(streamingResponseDeadlinesDisabledKey{}).(bool)
+	return disabled
 }
 
 // EffectiveUpstreamTimeout returns the timeout to apply for an upstream request.

--- a/pkg/proxy/router_test.go
+++ b/pkg/proxy/router_test.go
@@ -179,3 +179,84 @@ func TestRouterProxyToTargetClearsDeadlinesWhenLongLivedRequestMarked(t *testing
 		t.Fatalf("body = %q, want %q", body, "long lived\n")
 	}
 }
+
+func TestRouterProxyToTargetClearsWriteDeadlineWithoutDisablingTimeout(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(120 * time.Millisecond)
+		_, _ = io.WriteString(w, "bounded stream\n")
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+	}))
+	defer upstream.Close()
+
+	router, err := NewRouter(upstream.URL, zap.NewNop(), time.Second)
+	if err != nil {
+		t.Fatalf("NewRouter() error = %v", err)
+	}
+
+	engine := gin.New()
+	engine.GET("/", func(c *gin.Context) {
+		c.Request = WithStreamingResponseDeadlinesDisabledRequest(c.Request)
+		router.ProxyToTarget(c)
+	})
+
+	server := httptest.NewUnstartedServer(engine)
+	server.Config.WriteTimeout = 50 * time.Millisecond
+	server.Start()
+	defer server.Close()
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get(server.URL + "/")
+	if err != nil {
+		t.Fatalf("GET() error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if body := string(bodyBytes); body != "bounded stream\n" {
+		t.Fatalf("body = %q, want %q", body, "bounded stream\n")
+	}
+}
+
+func TestRouterProxyToTargetStillTimesOutWhenStreamingDeadlinesDisabled(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		_, _ = io.WriteString(w, "too late")
+	}))
+	defer upstream.Close()
+
+	router, err := NewRouter(upstream.URL, zap.NewNop(), 50*time.Millisecond)
+	if err != nil {
+		t.Fatalf("NewRouter() error = %v", err)
+	}
+
+	engine := gin.New()
+	engine.GET("/", func(c *gin.Context) {
+		c.Request = WithStreamingResponseDeadlinesDisabledRequest(c.Request)
+		router.ProxyToTarget(c)
+	})
+
+	server := httptest.NewServer(engine)
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/")
+	if err != nil {
+		t.Fatalf("GET() error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusGatewayTimeout {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusGatewayTimeout)
+	}
+}

--- a/pkg/proxy/streaming.go
+++ b/pkg/proxy/streaming.go
@@ -55,7 +55,7 @@ func PrepareStreamingProxyResponse(w http.ResponseWriter, req *http.Request) err
 	if IsWebSocketUpgrade(req) || LongLivedRequest(req.Context()) {
 		return DisableResponseDeadlines(w)
 	}
-	if UpstreamTimeoutDisabled(req.Context()) {
+	if UpstreamTimeoutDisabled(req.Context()) || StreamingResponseDeadlinesDisabled(req.Context()) {
 		return DisableResponseWriteDeadline(w)
 	}
 	return nil


### PR DESCRIPTION
## Summary
- route Function Gateway serving requests through the owning cluster-gateway instead of directly dialing sandbox internal IPs
- add internal cluster-gateway function runtime proxy and readiness endpoints for private runtime services
- separate streaming response deadline clearing from upstream timeout enforcement so SSE/streaming responses can remain open while route timeouts still apply
- document the regional -> cluster-gateway -> sandbox runtime path

## Tests
- go test ./pkg/proxy ./function-gateway/pkg/http ./cluster-gateway/pkg/http
- go test ./function-gateway/... ./cluster-gateway/... ./pkg/proxy/...

## Manual test plan
- Deploy this branch to the remote kind environment.
- Publish a function from a service with HTTP route + health_check.path and verify first request restores runtime through cluster-gateway.
- Invoke normal HTTP, SSE/streaming HTTP, and WebSocket function routes.
- Verify function-gateway logs do not show direct sandbox IP proxy targets and cluster-gateway handles the internal runtime proxy/readiness paths.
- Verify a route timeout_seconds still returns 504 for a slow upstream while streaming output survives gateway server WriteTimeout.
