### PR TITLE
harden function public ingress

### DIFF
--- a/cluster-gateway/pkg/http/handlers_internal_function_proxy.go
+++ b/cluster-gateway/pkg/http/handlers_internal_function_proxy.go
@@ -48,6 +48,7 @@ func (s *Server) proxyInternalFunctionRuntime(c *gin.Context) {
 		s.logger,
 		proxyTimeout,
 		proxy.WithHTTPClient(s.outboundHTTPClient()),
+		proxy.WithTrustedForwardedHeaders(),
 		proxy.WithRequestModifier(stripInternalFunctionProxyHeaders),
 	)
 	if err != nil {

--- a/cluster-gateway/pkg/http/handlers_internal_function_proxy_test.go
+++ b/cluster-gateway/pkg/http/handlers_internal_function_proxy_test.go
@@ -45,6 +45,15 @@ func TestInternalFunctionRuntimeProxyRoutesToPrivateService(t *testing.T) {
 		if got := r.Header.Get(internalauth.TeamIDHeader); got != "" {
 			t.Errorf("upstream received internal team header %q", got)
 		}
+		if got := r.Header.Get("X-Forwarded-For"); !strings.HasPrefix(got, "203.0.113.10, ") {
+			t.Errorf("X-Forwarded-For = %q, want trusted client IP plus proxy hop", got)
+		}
+		if got := r.Header.Get("X-Forwarded-Host"); got != "fn.example.test" {
+			t.Errorf("X-Forwarded-Host = %q, want fn.example.test", got)
+		}
+		if got := r.Header.Get("X-Forwarded-Proto"); got != "https" {
+			t.Errorf("X-Forwarded-Proto = %q, want https", got)
+		}
 		w.Header().Set("Content-Type", "text/plain")
 		_, _ = io.WriteString(w, "ok")
 	}))
@@ -71,6 +80,9 @@ func TestInternalFunctionRuntimeProxyRoutesToPrivateService(t *testing.T) {
 		t.Fatalf("create request: %v", err)
 	}
 	req.Header.Set(internalauth.DefaultTokenHeader, token)
+	req.Header.Set("X-Forwarded-For", "203.0.113.10")
+	req.Header.Set("X-Forwarded-Host", "fn.example.test")
+	req.Header.Set("X-Forwarded-Proto", "https")
 
 	client := &http.Client{Timeout: 2 * time.Second}
 	resp, err := client.Do(req)

--- a/docs/function/page.mdx
+++ b/docs/function/page.mdx
@@ -24,6 +24,14 @@ Function traffic is handled by `function-gateway`. The gateway resolves the host
 
 Function serving is revision-first. The gateway does not proxy production traffic to the mutable source sandbox. When no reusable runtime exists, the gateway claims a new runtime sandbox from the revision's template, mounts the revision-owned volumes, starts the service runtime command or binds to the referenced warm process, and reuses runtime instances for later requests. The runtime pool scales out up to the function's `max_active` setting when local in-flight requests reach the soft `target_concurrency` target. Changes made to the source sandbox after publishing require a new revision before they affect the function host.
 
+## Public Ingress Security
+
+Function public ingress treats caller-supplied forwarding identity headers as untrusted. `function-gateway` removes `Forwarded`, `X-Forwarded-*`, `X-Real-IP`, and common CDN client-IP headers before proxying, then writes its own `X-Forwarded-For`, `X-Forwarded-Host`, and `X-Forwarded-Proto` values for the next hop. The authenticated internal hop from `function-gateway` to `cluster-gateway` is the only place where prior `X-Forwarded-*` values are preserved and extended.
+
+Function requests are rejected before runtime proxying when the declared body size exceeds 32 MiB. Chunked or streaming bodies are also bounded by the same limit while the proxy reads them.
+
+Inbound route policy controls how callers enter the Function. Outbound calls made by the runtime sandbox still use the sandbox network policy and egress auth model from the runtime template and claim path. Public ingress does not grant extra outbound access.
+
 ## Publishable Services
 
 Only publishable Sandbox Services can become function revisions. A service is publishable when it is public and has a restartable runtime:

--- a/docs/sandbox/services/page.mdx
+++ b/docs/sandbox/services/page.mdx
@@ -50,6 +50,8 @@ When `public` is true and `routes` is empty, Sandbox0 creates a default route us
 Route rate limits use the gateway rate limit backend. Self-hosted deployments default to process-local memory for simple onboarding. Configure `Sandbox0Infra.spec.redis` when multiple gateway replicas need shared Redis-backed limits.
 </Callout>
 
+For Functions, the public ingress path also normalizes forwarding headers and applies the Function request body limit before traffic reaches the runtime sandbox. Route auth, CORS, methods, rate limits, rewrites, and timeouts are ingress controls only; outbound traffic from the runtime is governed by the sandbox network policy and egress auth rules.
+
 ### Auth
 
 | Field | Type | Description |

--- a/function-gateway/pkg/http/observability.go
+++ b/function-gateway/pkg/http/observability.go
@@ -117,6 +117,13 @@ func (s *Server) observeFunctionRequest(c *gin.Context, fn *functions.Function, 
 	}
 }
 
+func (s *Server) observeFunctionIngressFailure(fn *functions.Function, rev *functions.Revision, routeID, reason string, status int) {
+	if s == nil || s.functionMetrics == nil || fn == nil || rev == nil {
+		return
+	}
+	s.functionMetrics.ObserveFunctionIngressFailure(fn.TeamID, fn.ID, rev.ID, routeID, reason, status)
+}
+
 func (s *Server) observeRuntimeAcquire(fn *functions.Function, rev *functions.Revision, path, result string, err error) {
 	if s == nil || s.functionMetrics == nil || fn == nil || rev == nil {
 		return

--- a/function-gateway/pkg/http/runtime.go
+++ b/function-gateway/pkg/http/runtime.go
@@ -35,6 +35,7 @@ const defaultFunctionAutoResumeTimeout = 30 * time.Second
 const defaultFunctionRuntimeStartTimeout = 30 * time.Second
 const functionRuntimeRestoreLockPrefix = "function-runtime-restore:"
 const functionServiceReadinessProbeInterval = 200 * time.Millisecond
+const defaultFunctionMaxRequestBodyBytes int64 = 32 << 20
 
 type functionRouteMatch struct {
 	route         *mgr.SandboxAppServiceRoute
@@ -91,20 +92,25 @@ func (s *Server) serveFunctionRevision(c *gin.Context, fn *functions.Function, r
 		routeID = strings.TrimSpace(match.route.ID)
 	}
 	setFunctionSpanAttributes(c.Request.Context(), fn, rev, routeID, nil)
+	if !s.enforceFunctionIngressRequestLimits(c, fn, rev, routeID) {
+		return
+	}
 	if !match.pathMatched {
+		s.observeFunctionIngressFailure(fn, rev, routeID, "route_not_exposed", nethttp.StatusNotFound)
 		spec.JSONError(c, nethttp.StatusNotFound, spec.CodeNotFound, "route is not exposed")
 		return
 	}
 	if c.Request.Method == nethttp.MethodOptions && match.route.CORS != nil {
-		if !s.enforceFunctionRoute(c, fn.TeamID, fn.ID, match.route) {
+		if !s.enforceFunctionRoute(c, fn, rev, routeID, match.route) {
 			return
 		}
 	}
 	if !match.methodAllowed {
+		s.observeFunctionIngressFailure(fn, rev, routeID, "method_not_allowed", nethttp.StatusMethodNotAllowed)
 		spec.JSONError(c, nethttp.StatusMethodNotAllowed, spec.CodeForbidden, "method is not allowed")
 		return
 	}
-	if !s.enforceFunctionRoute(c, fn.TeamID, fn.ID, match.route) {
+	if !s.enforceFunctionRoute(c, fn, rev, routeID, match.route) {
 		return
 	}
 
@@ -213,15 +219,40 @@ func functionRouteMethodAllowed(route *mgr.SandboxAppServiceRoute, method string
 	return false
 }
 
-func (s *Server) enforceFunctionRoute(c *gin.Context, teamID, functionID string, route *mgr.SandboxAppServiceRoute) bool {
+func (s *Server) enforceFunctionIngressRequestLimits(c *gin.Context, fn *functions.Function, rev *functions.Revision, routeID string) bool {
+	if c == nil || c.Request == nil {
+		return true
+	}
+	if c.Request.ContentLength > defaultFunctionMaxRequestBodyBytes {
+		s.observeFunctionIngressFailure(fn, rev, routeID, "request_body_too_large", nethttp.StatusRequestEntityTooLarge)
+		spec.JSONError(c, nethttp.StatusRequestEntityTooLarge, spec.CodeBadRequest, "request body too large")
+		return false
+	}
+	if c.Request.Body != nil {
+		c.Request.Body = nethttp.MaxBytesReader(c.Writer, c.Request.Body, defaultFunctionMaxRequestBodyBytes)
+	}
+	return true
+}
+
+func (s *Server) enforceFunctionRoute(c *gin.Context, fn *functions.Function, rev *functions.Revision, routeID string, route *mgr.SandboxAppServiceRoute) bool {
 	if route == nil {
 		return true
 	}
-	if handled := handleFunctionCORS(c, route); handled {
+	if handled, failureReason, status := handleFunctionCORS(c, route); handled {
+		if failureReason != "" {
+			s.observeFunctionIngressFailure(fn, rev, routeID, failureReason, status)
+		}
 		return false
 	}
-	if !authorizeFunctionRoute(c, route) {
+	authorized, failureReason, status := authorizeFunctionRoute(c, route)
+	if !authorized {
+		s.observeFunctionIngressFailure(fn, rev, routeID, failureReason, status)
 		return false
+	}
+	teamID, functionID := "", ""
+	if fn != nil {
+		teamID = fn.TeamID
+		functionID = fn.ID
 	}
 	allowed, err := s.allowFunctionRoute(c, teamID, functionID, route)
 	if err != nil {
@@ -231,10 +262,12 @@ func (s *Server) enforceFunctionRoute(c *gin.Context, teamID, functionID string,
 			zap.String("route_id", route.ID),
 			zap.Error(err),
 		)
+		s.observeFunctionIngressFailure(fn, rev, routeID, "rate_limiter_unavailable", nethttp.StatusServiceUnavailable)
 		spec.JSONError(c, nethttp.StatusServiceUnavailable, spec.CodeUnavailable, "rate limiter unavailable")
 		return false
 	}
 	if !allowed {
+		s.observeFunctionIngressFailure(fn, rev, routeID, "rate_limited", nethttp.StatusTooManyRequests)
 		spec.JSONError(c, nethttp.StatusTooManyRequests, spec.CodeUnavailable, "rate limit exceeded")
 		return false
 	}
@@ -244,21 +277,21 @@ func (s *Server) enforceFunctionRoute(c *gin.Context, teamID, functionID string,
 	return true
 }
 
-func handleFunctionCORS(c *gin.Context, route *mgr.SandboxAppServiceRoute) bool {
+func handleFunctionCORS(c *gin.Context, route *mgr.SandboxAppServiceRoute) (bool, string, int) {
 	cors := route.CORS
 	if cors == nil {
-		return false
+		return false, "", 0
 	}
 	origin := c.GetHeader("Origin")
 	if origin == "" {
-		return false
+		return false, "", 0
 	}
 	if !functionOriginAllowed(origin, cors.AllowedOrigins) {
 		if c.Request.Method == nethttp.MethodOptions {
 			spec.JSONError(c, nethttp.StatusForbidden, spec.CodeForbidden, "origin is not allowed")
-			return true
+			return true, "cors_origin_denied", nethttp.StatusForbidden
 		}
-		return false
+		return false, "", 0
 	}
 	c.Header("Access-Control-Allow-Origin", functionAllowedOriginHeader(origin, cors.AllowedOrigins))
 	c.Header("Vary", "Origin")
@@ -269,12 +302,12 @@ func handleFunctionCORS(c *gin.Context, route *mgr.SandboxAppServiceRoute) bool 
 		c.Header("Access-Control-Expose-Headers", strings.Join(cors.ExposeHeaders, ", "))
 	}
 	if c.Request.Method != nethttp.MethodOptions {
-		return false
+		return false, "", 0
 	}
 	requestMethod := strings.ToUpper(strings.TrimSpace(c.GetHeader("Access-Control-Request-Method")))
 	if requestMethod != "" && !functionRouteCORSMethodAllowed(route, requestMethod) {
 		spec.JSONError(c, nethttp.StatusMethodNotAllowed, spec.CodeForbidden, "method is not allowed")
-		return true
+		return true, "cors_method_denied", nethttp.StatusMethodNotAllowed
 	}
 	allowedMethods := cors.AllowedMethods
 	if len(allowedMethods) == 0 {
@@ -290,7 +323,7 @@ func handleFunctionCORS(c *gin.Context, route *mgr.SandboxAppServiceRoute) bool 
 		c.Header("Access-Control-Max-Age", strconv.Itoa(cors.MaxAgeSeconds))
 	}
 	c.Status(nethttp.StatusNoContent)
-	return true
+	return true, "", nethttp.StatusNoContent
 }
 
 func functionRouteCORSMethodAllowed(route *mgr.SandboxAppServiceRoute, method string) bool {
@@ -326,9 +359,9 @@ func functionAllowedOriginHeader(origin string, allowed []string) string {
 	return ""
 }
 
-func authorizeFunctionRoute(c *gin.Context, route *mgr.SandboxAppServiceRoute) bool {
+func authorizeFunctionRoute(c *gin.Context, route *mgr.SandboxAppServiceRoute) (bool, string, int) {
 	if route.Auth == nil || route.Auth.Mode == "" || route.Auth.Mode == mgr.SandboxAppServiceRouteAuthModeNone {
-		return true
+		return true, "", 0
 	}
 	switch route.Auth.Mode {
 	case mgr.SandboxAppServiceRouteAuthModeBearer:
@@ -336,22 +369,22 @@ func authorizeFunctionRoute(c *gin.Context, route *mgr.SandboxAppServiceRoute) b
 		const prefix = "Bearer "
 		if !strings.HasPrefix(token, prefix) {
 			spec.JSONError(c, nethttp.StatusUnauthorized, spec.CodeUnauthorized, "missing bearer token")
-			return false
+			return false, "auth_failed", nethttp.StatusUnauthorized
 		}
 		if !sha256HexMatches(strings.TrimSpace(strings.TrimPrefix(token, prefix)), route.Auth.BearerTokenSHA256) {
 			spec.JSONError(c, nethttp.StatusUnauthorized, spec.CodeUnauthorized, "invalid bearer token")
-			return false
+			return false, "auth_failed", nethttp.StatusUnauthorized
 		}
 	case mgr.SandboxAppServiceRouteAuthModeHeader:
 		if !sha256HexMatches(c.GetHeader(route.Auth.HeaderName), route.Auth.HeaderValueSHA256) {
 			spec.JSONError(c, nethttp.StatusUnauthorized, spec.CodeUnauthorized, "invalid header credential")
-			return false
+			return false, "auth_failed", nethttp.StatusUnauthorized
 		}
 	default:
 		spec.JSONError(c, nethttp.StatusUnauthorized, spec.CodeUnauthorized, "unsupported auth mode")
-		return false
+		return false, "auth_unsupported", nethttp.StatusUnauthorized
 	}
-	return true
+	return true, "", 0
 }
 
 func sha256HexMatches(value, expectedHex string) bool {

--- a/function-gateway/pkg/http/runtime_test.go
+++ b/function-gateway/pkg/http/runtime_test.go
@@ -64,7 +64,8 @@ func TestAuthorizeFunctionRouteBearer(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.Header.Set("Authorization", "Bearer secret")
 	ctx.Request = req
-	if !authorizeFunctionRoute(ctx, route) {
+	authorized, _, _ := authorizeFunctionRoute(ctx, route)
+	if !authorized {
 		t.Fatal("authorizeFunctionRoute returned false for valid bearer token")
 	}
 
@@ -73,11 +74,33 @@ func TestAuthorizeFunctionRouteBearer(t *testing.T) {
 	req = httptest.NewRequest(http.MethodGet, "/", nil)
 	req.Header.Set("Authorization", "Bearer wrong")
 	ctx.Request = req
-	if authorizeFunctionRoute(ctx, route) {
+	authorized, reason, status := authorizeFunctionRoute(ctx, route)
+	if authorized {
 		t.Fatal("authorizeFunctionRoute returned true for invalid bearer token")
+	}
+	if reason != "auth_failed" || status != http.StatusUnauthorized {
+		t.Fatalf("failure = (%q, %d), want auth_failed %d", reason, status, http.StatusUnauthorized)
 	}
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestFunctionIngressRequestLimitRejectsLargeContentLength(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
+	req.ContentLength = defaultFunctionMaxRequestBodyBytes + 1
+	ctx.Request = req
+
+	server := &Server{}
+	if server.enforceFunctionIngressRequestLimits(ctx, &functions.Function{ID: "fn-1", TeamID: "team-1"}, &functions.Revision{ID: "rev-1"}, "api") {
+		t.Fatal("enforceFunctionIngressRequestLimits returned true for oversized body")
+	}
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusRequestEntityTooLarge)
 	}
 }
 
@@ -137,6 +160,15 @@ func TestFunctionRuntimeProxyUsesClusterGatewayForServing(t *testing.T) {
 		if claims.TeamID != "team-1" || claims.UserID != "user-1" {
 			t.Errorf("claims = team %q user %q", claims.TeamID, claims.UserID)
 		}
+		if got := r.Header.Get("Forwarded"); got != "" {
+			t.Errorf("cluster-gateway received Forwarded = %q, want empty", got)
+		}
+		if got := r.Header.Get("X-Real-IP"); got != "" {
+			t.Errorf("cluster-gateway received X-Real-IP = %q, want empty", got)
+		}
+		if got := r.Header.Get("X-Forwarded-For"); got == "" || strings.Contains(got, "203.0.113.10") {
+			t.Errorf("cluster-gateway received X-Forwarded-For = %q, want gateway remote address only", got)
+		}
 		time.Sleep(120 * time.Millisecond)
 		w.Header().Set("Content-Type", "text/event-stream")
 		_, _ = io.WriteString(w, "data: ok\n\n")
@@ -178,9 +210,16 @@ func TestFunctionRuntimeProxyUsesClusterGatewayForServing(t *testing.T) {
 	defer functionGateway.Close()
 
 	client := &http.Client{Timeout: 2 * time.Second}
-	resp, err := client.Get(functionGateway.URL + "/stream?q=1")
+	req, err := http.NewRequest(http.MethodGet, functionGateway.URL+"/stream?q=1", nil)
 	if err != nil {
-		t.Fatalf("GET() error = %v", err)
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+	req.Header.Set("Forwarded", "for=203.0.113.10;proto=https")
+	req.Header.Set("X-Forwarded-For", "203.0.113.10")
+	req.Header.Set("X-Real-IP", "203.0.113.11")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {

--- a/function-gateway/pkg/http/server.go
+++ b/function-gateway/pkg/http/server.go
@@ -106,8 +106,13 @@ func NewServer(
 		return nil, fmt.Errorf("create function route rate limiter: %w", err)
 	}
 
+	router := gin.New()
+	if err := router.SetTrustedProxies(nil); err != nil {
+		return nil, fmt.Errorf("configure trusted proxies: %w", err)
+	}
+
 	server := &Server{
-		router:              gin.New(),
+		router:              router,
 		cfg:                 cfg,
 		pool:                pool,
 		functionRepo:        functions.NewRepository(pool),

--- a/pkg/observability/metrics/function_gateway.go
+++ b/pkg/observability/metrics/function_gateway.go
@@ -12,6 +12,7 @@ import (
 // FunctionGatewayMetrics holds product-level Function serving metrics.
 type FunctionGatewayMetrics struct {
 	FunctionRequestsTotal         *prometheus.CounterVec
+	FunctionIngressFailuresTotal  *prometheus.CounterVec
 	FunctionRequestDuration       *prometheus.HistogramVec
 	FunctionResponseSize          *prometheus.HistogramVec
 	RuntimeAcquireTotal           *prometheus.CounterVec
@@ -33,6 +34,10 @@ func NewFunctionGateway(registry prometheus.Registerer) *FunctionGatewayMetrics 
 			Name: prefix + "_function_requests_total",
 			Help: "Total number of function requests served by function-gateway",
 		}, []string{"team_id", "function_id", "revision_id", "route_id", "method", "status"}),
+		FunctionIngressFailuresTotal: promutil.RegisterCounterVec(registry, prometheus.CounterOpts{
+			Name: prefix + "_function_ingress_failures_total",
+			Help: "Total number of function ingress failures rejected before runtime proxying",
+		}, []string{"team_id", "function_id", "revision_id", "route_id", "reason", "status"}),
 		FunctionRequestDuration: promutil.RegisterHistogramVec(registry, prometheus.HistogramOpts{
 			Name:    prefix + "_function_request_duration_seconds",
 			Help:    "Function request duration in seconds",
@@ -87,6 +92,13 @@ func (m *FunctionGatewayMetrics) ObserveFunctionRequest(teamID, functionID, revi
 	if responseSize > 0 {
 		m.FunctionResponseSize.WithLabelValues(label(teamID), label(functionID), label(revisionID), label(routeID)).Observe(float64(responseSize))
 	}
+}
+
+func (m *FunctionGatewayMetrics) ObserveFunctionIngressFailure(teamID, functionID, revisionID, routeID, reason string, status int) {
+	if m == nil {
+		return
+	}
+	m.FunctionIngressFailuresTotal.WithLabelValues(label(teamID), label(functionID), label(revisionID), label(routeID), reasonLabel(reason), strconv.Itoa(status)).Inc()
 }
 
 func (m *FunctionGatewayMetrics) ObserveRuntimeAcquire(teamID, functionID, revisionID, path, result, reason string) {

--- a/pkg/proxy/headers.go
+++ b/pkg/proxy/headers.go
@@ -1,0 +1,101 @@
+package proxy
+
+import (
+	"net"
+	"net/http"
+	"strings"
+)
+
+var forwardedIdentityHeaders = []string{
+	"Forwarded",
+	"X-Forwarded-For",
+	"X-Forwarded-Host",
+	"X-Forwarded-Proto",
+	"X-Real-IP",
+	"X-Client-IP",
+	"X-Cluster-Client-IP",
+	"CF-Connecting-IP",
+	"True-Client-IP",
+	"Fastly-Client-IP",
+}
+
+var hopByHopHeaders = []string{
+	"Connection",
+	"Proxy-Connection",
+	"Keep-Alive",
+	"Proxy-Authenticate",
+	"Proxy-Authorization",
+	"Te",
+	"Trailer",
+	"Transfer-Encoding",
+	"Upgrade",
+}
+
+func setForwardedHeaders(out, in *http.Request, trustPrior bool) {
+	if out == nil || in == nil {
+		return
+	}
+	removeForwardedIdentityHeaders(out.Header)
+
+	priorFor := ""
+	priorHost := ""
+	priorProto := ""
+	if trustPrior {
+		priorFor = strings.TrimSpace(in.Header.Get("X-Forwarded-For"))
+		priorHost = strings.TrimSpace(in.Header.Get("X-Forwarded-Host"))
+		priorProto = strings.TrimSpace(in.Header.Get("X-Forwarded-Proto"))
+	}
+
+	if clientIP, _, err := net.SplitHostPort(in.RemoteAddr); err == nil && clientIP != "" {
+		if priorFor != "" {
+			clientIP = priorFor + ", " + clientIP
+		}
+		out.Header.Set("X-Forwarded-For", clientIP)
+	}
+	if priorHost != "" {
+		out.Header.Set("X-Forwarded-Host", priorHost)
+	} else if strings.TrimSpace(in.Host) != "" {
+		out.Header.Set("X-Forwarded-Host", in.Host)
+	}
+	if priorProto != "" {
+		out.Header.Set("X-Forwarded-Proto", priorProto)
+	} else if in.TLS != nil {
+		out.Header.Set("X-Forwarded-Proto", "https")
+	} else {
+		out.Header.Set("X-Forwarded-Proto", "http")
+	}
+}
+
+func removeForwardedIdentityHeaders(header http.Header) {
+	for _, name := range forwardedIdentityHeaders {
+		header.Del(name)
+	}
+}
+
+func removeHopByHopHeaders(header http.Header, keepUpgrade bool) {
+	removeConnectionHeaderTokens(header, keepUpgrade)
+	for _, name := range hopByHopHeaders {
+		if keepUpgrade && (strings.EqualFold(name, "Connection") || strings.EqualFold(name, "Upgrade")) {
+			continue
+		}
+		header.Del(name)
+	}
+	if keepUpgrade {
+		header.Set("Connection", "Upgrade")
+	}
+}
+
+func removeConnectionHeaderTokens(header http.Header, keepUpgrade bool) {
+	for _, value := range header.Values("Connection") {
+		for _, token := range strings.Split(value, ",") {
+			token = strings.TrimSpace(token)
+			if token == "" {
+				continue
+			}
+			if keepUpgrade && strings.EqualFold(token, "upgrade") {
+				continue
+			}
+			header.Del(token)
+		}
+	}
+}

--- a/pkg/proxy/options.go
+++ b/pkg/proxy/options.go
@@ -8,8 +8,9 @@ type RequestModifier func(*http.Request)
 type Option func(*options)
 
 type options struct {
-	requestModifiers []RequestModifier
-	httpClient       *http.Client
+	requestModifiers     []RequestModifier
+	httpClient           *http.Client
+	trustForwardedHeader bool
 }
 
 // WithRequestModifier registers a request modifier for proxy requests.
@@ -27,6 +28,15 @@ func WithRequestModifier(mod RequestModifier) Option {
 func WithHTTPClient(client *http.Client) Option {
 	return func(o *options) {
 		o.httpClient = client
+	}
+}
+
+// WithTrustedForwardedHeaders preserves inbound X-Forwarded-* identity headers
+// before appending the current proxy hop. Only use this on authenticated
+// internal proxy hops where the previous proxy is trusted.
+func WithTrustedForwardedHeaders() Option {
+	return func(o *options) {
+		o.trustForwardedHeader = true
 	}
 }
 

--- a/pkg/proxy/router.go
+++ b/pkg/proxy/router.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httputil"
@@ -21,6 +22,9 @@ type Router struct {
 	requestModifiers []RequestModifier
 	// httpClient is the HTTP client used for proxy requests
 	httpClient *http.Client
+	// trustForwardedHeader preserves forwarding headers from an authenticated
+	// upstream proxy before appending this proxy hop.
+	trustForwardedHeader bool
 }
 
 // NewRouter creates a new router
@@ -32,11 +36,12 @@ func NewRouter(targetUrl string, logger *zap.Logger, timeout time.Duration, opts
 
 	parsedOpts := collectOptions(opts...)
 	return &Router{
-		targetUrl:        tu,
-		logger:           logger,
-		timeout:          timeout,
-		requestModifiers: parsedOpts.requestModifiers,
-		httpClient:       parsedOpts.httpClient,
+		targetUrl:            tu,
+		logger:               logger,
+		timeout:              timeout,
+		requestModifiers:     parsedOpts.requestModifiers,
+		httpClient:           parsedOpts.httpClient,
+		trustForwardedHeader: parsedOpts.trustForwardedHeader,
 	}, nil
 }
 
@@ -49,6 +54,9 @@ func (r *Router) ProxyToTarget(c *gin.Context) {
 		opts := make([]Option, 0, len(r.requestModifiers))
 		for _, mod := range r.requestModifiers {
 			opts = append(opts, WithRequestModifier(mod))
+		}
+		if r.trustForwardedHeader {
+			opts = append(opts, WithTrustedForwardedHeaders())
 		}
 		NewWebSocketProxy(r.logger, opts...).Proxy(r.targetUrl)(c)
 		return
@@ -71,29 +79,6 @@ func (r *Router) ProxyToTarget(c *gin.Context) {
 
 // createReverseProxyDirector creates an httputil.ReverseProxy with proper configuration
 func (r *Router) createReverseProxyDirector(target *url.URL) *httputil.ReverseProxy {
-	director := func(req *http.Request) {
-		req.URL.Scheme = target.Scheme
-		req.URL.Host = target.Host
-		req.Host = target.Host
-
-		applyRequestModifiers(req, r.requestModifiers)
-
-		// Preserve the original path (don't rewrite it here)
-		// Path rewriting should be done by specific handlers if needed
-
-		// Forward auth context
-		if authCtx := req.Context().Value("auth_context"); authCtx != nil {
-			// The upstream service can validate this header
-			// In production, use mutual TLS or signed tokens
-			req.Header.Set("X-Team-ID", req.Header.Get("X-Team-ID"))
-		}
-
-		r.logger.Debug("Proxying request",
-			zap.String("method", req.Method),
-			zap.String("target", req.URL.String()),
-		)
-	}
-
 	// Use custom HTTP client's transport if provided, otherwise use default transport
 	var transport http.RoundTripper
 	if r.httpClient != nil && r.httpClient.Transport != nil {
@@ -107,12 +92,27 @@ func (r *Router) createReverseProxyDirector(target *url.URL) *httputil.ReversePr
 	}
 
 	proxy := &httputil.ReverseProxy{
-		Director:  director,
+		Rewrite: func(req *httputil.ProxyRequest) {
+			req.Out.URL.Scheme = target.Scheme
+			req.Out.URL.Host = target.Host
+			req.Out.Host = target.Host
+			setForwardedHeaders(req.Out, req.In, r.trustForwardedHeader)
+			applyRequestModifiers(req.Out, r.requestModifiers)
+
+			r.logger.Debug("Proxying request",
+				zap.String("method", req.Out.Method),
+				zap.String("target", req.Out.URL.String()),
+			)
+		},
 		Transport: transport,
 		ErrorHandler: func(w http.ResponseWriter, req *http.Request, err error) {
 			status := http.StatusBadGateway
 			body := `{"error": "upstream service unavailable"}`
-			if IsTimeoutError(err) {
+			var maxBytesErr *http.MaxBytesError
+			if errors.As(err, &maxBytesErr) {
+				status = http.StatusRequestEntityTooLarge
+				body = `{"error": "request body too large"}`
+			} else if IsTimeoutError(err) {
 				status = http.StatusGatewayTimeout
 				body = `{"error": "upstream request timed out"}`
 			}

--- a/pkg/proxy/router_test.go
+++ b/pkg/proxy/router_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -258,5 +259,151 @@ func TestRouterProxyToTargetStillTimesOutWhenStreamingDeadlinesDisabled(t *testi
 
 	if resp.StatusCode != http.StatusGatewayTimeout {
 		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusGatewayTimeout)
+	}
+}
+
+func TestRouterProxyToTargetRewritesUntrustedForwardedHeaders(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	gotHeaders := make(chan http.Header, 1)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeaders <- r.Header.Clone()
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+
+	router, err := NewRouter(upstream.URL, zap.NewNop(), time.Second)
+	if err != nil {
+		t.Fatalf("NewRouter() error = %v", err)
+	}
+
+	engine := gin.New()
+	engine.GET("/", router.ProxyToTarget)
+	server := httptest.NewServer(engine)
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/", nil)
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+	req.Host = "fn.example.test"
+	req.Header.Set("Forwarded", "for=203.0.113.10;proto=https")
+	req.Header.Set("X-Forwarded-For", "203.0.113.10")
+	req.Header.Set("X-Forwarded-Host", "evil.example")
+	req.Header.Set("X-Forwarded-Proto", "https")
+	req.Header.Set("X-Real-IP", "203.0.113.11")
+	req.Header.Set("Connection", "X-Smuggled")
+	req.Header.Set("X-Smuggled", "keep-me")
+
+	resp, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusNoContent)
+	}
+
+	headers := <-gotHeaders
+	if got := headers.Get("Forwarded"); got != "" {
+		t.Fatalf("Forwarded = %q, want empty", got)
+	}
+	if got := headers.Get("X-Real-IP"); got != "" {
+		t.Fatalf("X-Real-IP = %q, want empty", got)
+	}
+	if got := headers.Get("X-Smuggled"); got != "" {
+		t.Fatalf("X-Smuggled = %q, want empty", got)
+	}
+	if got := headers.Get("X-Forwarded-For"); strings.Contains(got, "203.0.113.10") || got == "" {
+		t.Fatalf("X-Forwarded-For = %q, want gateway remote address only", got)
+	}
+	if got := headers.Get("X-Forwarded-Host"); got != "fn.example.test" {
+		t.Fatalf("X-Forwarded-Host = %q, want fn.example.test", got)
+	}
+	if got := headers.Get("X-Forwarded-Proto"); got != "http" {
+		t.Fatalf("X-Forwarded-Proto = %q, want http", got)
+	}
+}
+
+func TestRouterProxyToTargetPreservesTrustedForwardedHeaders(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	gotHeaders := make(chan http.Header, 1)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeaders <- r.Header.Clone()
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+
+	router, err := NewRouter(upstream.URL, zap.NewNop(), time.Second, WithTrustedForwardedHeaders())
+	if err != nil {
+		t.Fatalf("NewRouter() error = %v", err)
+	}
+
+	engine := gin.New()
+	engine.GET("/", router.ProxyToTarget)
+	server := httptest.NewServer(engine)
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/", nil)
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+	req.Host = "cluster-gateway.internal"
+	req.Header.Set("X-Forwarded-For", "203.0.113.10")
+	req.Header.Set("X-Forwarded-Host", "fn.example.test")
+	req.Header.Set("X-Forwarded-Proto", "https")
+
+	resp, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusNoContent)
+	}
+
+	headers := <-gotHeaders
+	if got := headers.Get("X-Forwarded-For"); !strings.HasPrefix(got, "203.0.113.10, ") {
+		t.Fatalf("X-Forwarded-For = %q, want trusted value plus proxy hop", got)
+	}
+	if got := headers.Get("X-Forwarded-Host"); got != "fn.example.test" {
+		t.Fatalf("X-Forwarded-Host = %q, want fn.example.test", got)
+	}
+	if got := headers.Get("X-Forwarded-Proto"); got != "https" {
+		t.Fatalf("X-Forwarded-Proto = %q, want https", got)
+	}
+}
+
+func TestRouterProxyToTargetMapsMaxBytesErrorToRequestTooLarge(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+
+	router, err := NewRouter(upstream.URL, zap.NewNop(), time.Second)
+	if err != nil {
+		t.Fatalf("NewRouter() error = %v", err)
+	}
+
+	engine := gin.New()
+	engine.POST("/", func(c *gin.Context) {
+		c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, 4)
+		router.ProxyToTarget(c)
+	})
+	server := httptest.NewServer(engine)
+	defer server.Close()
+
+	resp, err := server.Client().Post(server.URL+"/", "text/plain", strings.NewReader("12345"))
+	if err != nil {
+		t.Fatalf("Post() error = %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want %d, body = %s", resp.StatusCode, http.StatusRequestEntityTooLarge, string(body))
 	}
 }

--- a/pkg/proxy/websocket.go
+++ b/pkg/proxy/websocket.go
@@ -19,14 +19,18 @@ type WebSocketProxy struct {
 	logger *zap.Logger
 	// requestModifiers are applied before proxying.
 	requestModifiers []RequestModifier
+	// trustForwardedHeader preserves forwarding headers from an authenticated
+	// upstream proxy before appending this proxy hop.
+	trustForwardedHeader bool
 }
 
 // NewWebSocketProxy creates a new WebSocket proxy
 func NewWebSocketProxy(logger *zap.Logger, opts ...Option) *WebSocketProxy {
 	parsedOpts := collectOptions(opts...)
 	return &WebSocketProxy{
-		logger:           logger,
-		requestModifiers: parsedOpts.requestModifiers,
+		logger:               logger,
+		requestModifiers:     parsedOpts.requestModifiers,
+		trustForwardedHeader: parsedOpts.trustForwardedHeader,
 	}
 }
 
@@ -58,6 +62,8 @@ func (p *WebSocketProxy) Proxy(targetURL *url.URL) gin.HandlerFunc {
 		outReq.URL.RawQuery = c.Request.URL.RawQuery
 		outReq.Host = targetURL.Host
 		outReq.RequestURI = ""
+		removeHopByHopHeaders(outReq.Header, true)
+		setForwardedHeaders(outReq, c.Request, p.trustForwardedHeader)
 
 		applyRequestModifiers(outReq, p.requestModifiers)
 

--- a/pkg/proxy/websocket_test.go
+++ b/pkg/proxy/websocket_test.go
@@ -1,0 +1,75 @@
+package proxy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+	"go.uber.org/zap"
+)
+
+func TestWebSocketProxyRewritesUntrustedForwardedHeaders(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	gotHeaders := make(chan http.Header, 1)
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeaders <- r.Header.Clone()
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade: %v", err)
+			return
+		}
+		_ = conn.Close()
+	}))
+	defer upstream.Close()
+
+	targetURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatalf("parse upstream URL: %v", err)
+	}
+	engine := gin.New()
+	engine.GET("/ws", NewWebSocketProxy(zap.NewNop()).Proxy(targetURL))
+	server := httptest.NewServer(engine)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/ws"
+	conn, resp, err := websocket.DefaultDialer.Dial(wsURL, http.Header{
+		"Forwarded":         []string{"for=203.0.113.10;proto=https"},
+		"X-Forwarded-For":   []string{"203.0.113.10"},
+		"X-Forwarded-Host":  []string{"evil.example"},
+		"X-Forwarded-Proto": []string{"https"},
+		"X-Real-IP":         []string{"203.0.113.11"},
+	})
+	if err != nil {
+		status := 0
+		if resp != nil {
+			status = resp.StatusCode
+		}
+		t.Fatalf("Dial() error = %v status=%d", err, status)
+	}
+	_ = conn.Close()
+
+	select {
+	case headers := <-gotHeaders:
+		if got := headers.Get("Forwarded"); got != "" {
+			t.Fatalf("Forwarded = %q, want empty", got)
+		}
+		if got := headers.Get("X-Real-IP"); got != "" {
+			t.Fatalf("X-Real-IP = %q, want empty", got)
+		}
+		if got := headers.Get("X-Forwarded-For"); got == "" || strings.Contains(got, "203.0.113.10") {
+			t.Fatalf("X-Forwarded-For = %q, want gateway remote address only", got)
+		}
+		if got := headers.Get("X-Forwarded-Proto"); got != "http" {
+			t.Fatalf("X-Forwarded-Proto = %q, want http", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for upstream headers")
+	}
+}


### PR DESCRIPTION
## What changed

- Hardened shared HTTP/WebSocket proxy forwarding semantics so public callers cannot spoof `Forwarded`, `X-Forwarded-*`, or common client-IP headers.
- Added an explicit trusted-forwarded-header option for authenticated internal proxy hops and used it for `function-gateway -> cluster-gateway -> runtime` serving.
- Added Function public ingress body-size enforcement and 413 mapping for streamed/chunked oversized bodies.
- Added function ingress failure metrics for auth, CORS, rate limit, route/method, and body-size rejects.
- Documented Function public ingress security boundaries and egress-policy interaction.

## Why

`function-gateway-gaps.md` called out that public Function ingress needed production hardening around header forwarding, trusted proxy semantics, abuse controls, failure metrics, and ingress/egress boundaries.

## Validation

- `GOTOOLCHAIN=go1.25.0+auto go test ./pkg/proxy ./function-gateway/pkg/http ./cluster-gateway/pkg/http ./regional-gateway/pkg/http ./global-gateway/pkg/http ./scheduler/pkg/http ./pkg/observability/metrics`
