### PR TITLE
remove test-only dead code

### DIFF
--- a/function-gateway/pkg/http/runtime.go
+++ b/function-gateway/pkg/http/runtime.go
@@ -540,18 +540,6 @@ func functionSandboxWantsPaused(sandbox *mgr.Sandbox) bool {
 	return sandbox.Paused
 }
 
-func (s *Server) resolveFunctionSandbox(ctx context.Context, fn *functions.Function, rev *functions.Revision, service mgr.SandboxAppService) (*mgr.Sandbox, *functions.Revision, error) {
-	lease, updated, err := s.acquireFunctionRuntime(ctx, fn, rev, service)
-	if err != nil {
-		return nil, updated, err
-	}
-	if lease == nil {
-		return nil, updated, fmt.Errorf("function runtime lease is empty")
-	}
-	defer lease.Done()
-	return lease.Sandbox, updated, nil
-}
-
 func (s *Server) acquireFunctionRuntime(ctx context.Context, fn *functions.Function, rev *functions.Revision, service mgr.SandboxAppService) (*functionRuntimeLease, *functions.Revision, error) {
 	autoscaler := s.autoscaler
 	if autoscaler == nil {

--- a/function-gateway/pkg/http/runtime_test.go
+++ b/function-gateway/pkg/http/runtime_test.go
@@ -235,7 +235,7 @@ func TestFunctionRuntimeProxyUsesClusterGatewayForServing(t *testing.T) {
 	}
 }
 
-func TestResolveFunctionSandboxDoesNotServeSourceSandbox(t *testing.T) {
+func TestAcquireFunctionRuntimeDoesNotServeSourceSandbox(t *testing.T) {
 	_, privateKey, err := ed25519.GenerateKey(nil)
 	if err != nil {
 		t.Fatalf("generate ed25519 keypair: %v", err)
@@ -268,7 +268,7 @@ func TestResolveFunctionSandboxDoesNotServeSourceSandbox(t *testing.T) {
 		logger:     zap.NewNop(),
 	}
 
-	_, _, err = server.resolveFunctionSandbox(context.Background(), &functions.Function{
+	_, _, err = server.acquireFunctionRuntime(context.Background(), &functions.Function{
 		ID:     "fn-1",
 		TeamID: "team-1",
 	}, &functions.Revision{
@@ -280,7 +280,7 @@ func TestResolveFunctionSandboxDoesNotServeSourceSandbox(t *testing.T) {
 		CreatedBy:        "user-1",
 	}, mgr.SandboxAppService{})
 	if err == nil || !strings.Contains(err.Error(), "function repository is not configured") {
-		t.Fatalf("resolveFunctionSandbox() error = %v, want revision runtime path", err)
+		t.Fatalf("acquireFunctionRuntime() error = %v, want revision runtime path", err)
 	}
 	if got := sourceLookups.Load(); got != 0 {
 		t.Fatalf("source sandbox lookups = %d, want 0", got)

--- a/netd/pkg/proxy/egress_proxy.go
+++ b/netd/pkg/proxy/egress_proxy.go
@@ -145,23 +145,6 @@ func egressProxyDestination(req *adapterRequest) string {
 	return ""
 }
 
-func validateSOCKS5ProxyEndpoint(ctx context.Context, compiled *policy.CompiledPolicy, host string) error {
-	host = strings.TrimSpace(host)
-	if host == "" {
-		return fmt.Errorf("egress proxy host is required")
-	}
-	ips, err := resolveProxyEndpointIPs(ctx, host)
-	if err != nil {
-		return fmt.Errorf("resolve egress proxy host %q: %w", host, err)
-	}
-	for _, ip := range ips {
-		if isProtectedProxyEndpointIP(compiled, ip) {
-			return fmt.Errorf("%w: %s resolves to %s", errEgressProxyEndpointProtected, host, ip)
-		}
-	}
-	return nil
-}
-
 func resolveSOCKS5ProxyDialAddress(ctx context.Context, compiled *policy.CompiledPolicy, cfg *policy.CompiledEgressProxy) (string, error) {
 	if cfg == nil {
 		return "", fmt.Errorf("egress proxy config is nil")

--- a/netd/pkg/proxy/egress_proxy_test.go
+++ b/netd/pkg/proxy/egress_proxy_test.go
@@ -120,8 +120,11 @@ func TestDialTCPUpstreamForRequestUsesSOCKS5Credentials(t *testing.T) {
 	}
 }
 
-func TestValidateSOCKS5ProxyEndpointRejectsLoopback(t *testing.T) {
-	err := validateSOCKS5ProxyEndpoint(context.Background(), nil, "127.0.0.1")
+func TestResolveSOCKS5ProxyDialAddressRejectsLoopback(t *testing.T) {
+	_, err := resolveSOCKS5ProxyDialAddress(context.Background(), nil, &policy.CompiledEgressProxy{
+		Host: "127.0.0.1",
+		Port: 1080,
+	})
 	if err == nil {
 		t.Fatal("expected loopback endpoint rejection")
 	}

--- a/netd/pkg/proxy/ssh_proxy.go
+++ b/netd/pkg/proxy/ssh_proxy.go
@@ -347,15 +347,3 @@ func (e knownHostEntry) matches(host string, port int) bool {
 	}
 	return false
 }
-
-func knownHostLine(host string, port int, key ssh.PublicKey) string {
-	var buf bytes.Buffer
-	if port > 0 && port != 22 {
-		buf.WriteString(fmt.Sprintf("[%s]:%d", host, port))
-	} else {
-		buf.WriteString(host)
-	}
-	buf.WriteByte(' ')
-	buf.WriteString(strings.TrimSpace(string(ssh.MarshalAuthorizedKey(key))))
-	return buf.String()
-}

--- a/netd/pkg/proxy/ssh_proxy_test.go
+++ b/netd/pkg/proxy/ssh_proxy_test.go
@@ -55,7 +55,7 @@ func TestProxySSHSessionReoriginatesWithPlatformCredential(t *testing.T) {
 					UpstreamUsername:  "git",
 					PrivateKeyPEM:     upstreamPrivateKeyPEM,
 					KnownHosts: []string{
-						knownHostLine(upstreamHost, upstreamPort, upstreamHostSigner.PublicKey()),
+						testKnownHostLine(upstreamHost, upstreamPort, upstreamHostSigner.PublicKey()),
 					},
 				}, nil),
 			},
@@ -100,7 +100,7 @@ func TestKnownHostsCallbackRejectsUntrustedKey(t *testing.T) {
 	hostSigner, _, _ := mustTestSSHSigner(t)
 	otherSigner, _, _ := mustTestSSHSigner(t)
 	callback, err := newKnownHostsCallback("127.0.0.1", 2222, []string{
-		knownHostLine("127.0.0.1", 2222, hostSigner.PublicKey()),
+		testKnownHostLine("127.0.0.1", 2222, hostSigner.PublicKey()),
 	})
 	if err != nil {
 		t.Fatalf("known hosts callback: %v", err)
@@ -108,6 +108,14 @@ func TestKnownHostsCallbackRejectsUntrustedKey(t *testing.T) {
 	if err := callback("", nil, otherSigner.PublicKey()); err == nil {
 		t.Fatal("expected untrusted key rejection")
 	}
+}
+
+func testKnownHostLine(host string, port int, key ssh.PublicKey) string {
+	pattern := host
+	if port > 0 && port != 22 {
+		pattern = fmt.Sprintf("[%s]:%d", host, port)
+	}
+	return pattern + " " + strings.TrimSpace(string(ssh.MarshalAuthorizedKey(key)))
 }
 
 func startTestSSHUpstream(t *testing.T, hostSigner ssh.Signer, authorizedKey ssh.PublicKey) (string, func()) {

--- a/storage-proxy/pkg/fsserver/server.go
+++ b/storage-proxy/pkg/fsserver/server.go
@@ -594,23 +594,6 @@ func (s *FileSystemServer) Mknod(ctx context.Context, req *pb.MknodRequest) (*pb
 	})
 }
 
-func mapErrnoToCode(errno syscall.Errno) fserror.Code {
-	switch errno {
-	case syscall.EEXIST:
-		return fserror.AlreadyExists
-	case syscall.ENOENT:
-		return fserror.NotFound
-	case syscall.EACCES, syscall.EPERM:
-		return fserror.PermissionDenied
-	case syscall.ENOSPC:
-		return fserror.ResourceExhausted
-	case syscall.EINVAL, syscall.ENOTDIR:
-		return fserror.InvalidArgument
-	default:
-		return fserror.Internal
-	}
-}
-
 func (s *FileSystemServer) openS0FS(ctx context.Context, volCtx *volume.VolumeContext, req *pb.OpenRequest) (*pb.OpenResponse, error) {
 	node, err := volCtx.S0FS.GetAttr(req.Inode)
 	if err != nil {

--- a/storage-proxy/pkg/fsserver/server_test.go
+++ b/storage-proxy/pkg/fsserver/server_test.go
@@ -1,70 +1,12 @@
 package fsserver
 
 import (
-	"syscall"
 	"testing"
 
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/fserror"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volume"
 	pb "github.com/sandbox0-ai/sandbox0/storage-proxy/proto/fs"
 )
-
-func TestMapErrnoToCode(t *testing.T) {
-	tests := []struct {
-		name  string
-		errno syscall.Errno
-		want  fserror.Code
-	}{
-		{
-			name:  "already exists",
-			errno: syscall.EEXIST,
-			want:  fserror.AlreadyExists,
-		},
-		{
-			name:  "not found",
-			errno: syscall.ENOENT,
-			want:  fserror.NotFound,
-		},
-		{
-			name:  "permission denied",
-			errno: syscall.EACCES,
-			want:  fserror.PermissionDenied,
-		},
-		{
-			name:  "operation not permitted",
-			errno: syscall.EPERM,
-			want:  fserror.PermissionDenied,
-		},
-		{
-			name:  "no space",
-			errno: syscall.ENOSPC,
-			want:  fserror.ResourceExhausted,
-		},
-		{
-			name:  "invalid argument",
-			errno: syscall.EINVAL,
-			want:  fserror.InvalidArgument,
-		},
-		{
-			name:  "not a directory",
-			errno: syscall.ENOTDIR,
-			want:  fserror.InvalidArgument,
-		},
-		{
-			name:  "unknown errno",
-			errno: syscall.EIO,
-			want:  fserror.Internal,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := mapErrnoToCode(tt.errno); got != tt.want {
-				t.Errorf("mapErrnoToCode(%v) = %v, want %v", tt.errno, got, tt.want)
-			}
-		})
-	}
-}
 
 func TestLinkRejectsUnsupportedBackendWithoutLegacyFallback(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary
- Remove four production helpers that became unused when tests were temporarily removed.
- Keep behavior coverage by moving known-host formatting into test code and retargeting SOCKS5/runtime tests to the live production entry points.
- Drop the obsolete errno mapper unit test after removing the unused mapper.

## Validation
- Temporarily deleted all tracked `_test.go` files, ran `golangci-lint run ./...`, removed the reported unused production code, and reran lint with tests still deleted: `0 issues`.
- Restored `_test.go` files with `git checkout`, adjusted tests for the removed private helpers, and reran `golangci-lint run ./...`: `0 issues`.
- `go test ./function-gateway/pkg/http ./netd/pkg/proxy ./storage-proxy/pkg/fsserver`
- `git diff --check`