### PR TITLE
add function revision spec model

### DIFF
--- a/.github/workflows/pr-quick-check.yml
+++ b/.github/workflows/pr-quick-check.yml
@@ -71,13 +71,13 @@ jobs:
         run: helm lint infra-operator/chart
 
       - name: Run golangci-lint
-        run: golangci-lint run ./...
+        run: GOFLAGS=-buildvcs=false golangci-lint run ./...
 
       - name: Run unit tests
         shell: bash
         run: |
-          packages="$(go list ./... | grep -Ev '/tests/(e2e|integration)(/|$)')"
-          GOTOOLCHAIN=go1.25.0+auto go test -race -count=1 $packages
+          packages="$(go list -buildvcs=false ./... | grep -Ev '/tests/(e2e|integration)(/|$)')"
+          GOTOOLCHAIN=go1.25.0+auto go test -buildvcs=false -race -count=1 $packages
 
       - name: Show git diff on failure
         if: failure()

--- a/function-gateway/pkg/http/runtime.go
+++ b/function-gateway/pkg/http/runtime.go
@@ -76,8 +76,8 @@ func (s *Server) serveFunctionRevision(c *gin.Context, fn *functions.Function, r
 		s.observeFunctionRequest(c, fn, servedRevision, routeID, runtimeInstance, requestStarted)
 	}()
 
-	var service mgr.SandboxAppService
-	if err := json.Unmarshal(rev.ServiceSnapshot, &service); err != nil {
+	service, err := functionRevisionRuntimeService(rev)
+	if err != nil {
 		s.logger.Warn("Failed to decode function service snapshot",
 			zap.String("function_id", fn.ID),
 			zap.String("revision_id", rev.ID),
@@ -548,6 +548,21 @@ func (s *Server) acquireFunctionRuntime(ctx context.Context, fn *functions.Funct
 	return autoscaler.acquire(ctx, fn, rev, service)
 }
 
+func functionRevisionRuntimeService(rev *functions.Revision) (mgr.SandboxAppService, error) {
+	if rev == nil {
+		return mgr.SandboxAppService{}, fmt.Errorf("function revision is nil")
+	}
+	serviceBytes := rev.Spec.RuntimeService
+	if len(serviceBytes) == 0 {
+		serviceBytes = rev.ServiceSnapshot
+	}
+	var service mgr.SandboxAppService
+	if err := json.Unmarshal(serviceBytes, &service); err != nil {
+		return mgr.SandboxAppService{}, err
+	}
+	return service, nil
+}
+
 func (s *Server) withRevisionRuntimeDistributedLock(ctx context.Context, revisionID string, fn func(context.Context) error) error {
 	if fn == nil {
 		return nil
@@ -587,8 +602,12 @@ func (s *Server) claimFunctionSandboxViaClusterGateway(ctx context.Context, fn *
 	if err != nil {
 		return nil, err
 	}
+	templateID := strings.TrimSpace(rev.Spec.TemplateID)
+	if templateID == "" {
+		templateID = strings.TrimSpace(rev.SourceTemplateID)
+	}
 	payload, err := json.Marshal(mgr.ClaimRequest{
-		Template: rev.SourceTemplateID,
+		Template: templateID,
 		Config: &mgr.SandboxConfig{
 			AutoResume: &autoResume,
 			Services:   []mgr.SandboxAppService{runtimeService},
@@ -646,13 +665,19 @@ func (s *Server) claimFunctionSandboxViaClusterGateway(ctx context.Context, fn *
 }
 
 func (s *Server) claimMountsFromRevision(rev *functions.Revision) ([]mgr.ClaimMount, error) {
-	mounts := rev.RestoreMounts
-	if len(mounts) == 0 {
+	if rev == nil {
 		return nil, nil
 	}
-	out := make([]mgr.ClaimMount, 0, len(mounts))
-	for _, mount := range mounts {
-		volumeID := strings.TrimSpace(mount.SandboxVolumeID)
+	specMounts := rev.Spec.Mounts
+	if len(specMounts) == 0 && len(rev.RestoreMounts) > 0 {
+		specMounts = functions.RevisionMountsFromRestoreMounts(rev.RestoreMounts)
+	}
+	if len(specMounts) == 0 {
+		return nil, nil
+	}
+	out := make([]mgr.ClaimMount, 0, len(specMounts))
+	for _, mount := range specMounts {
+		volumeID := strings.TrimSpace(mount.Source.SandboxVolumeID)
 		mountPoint := strings.TrimSpace(mount.MountPoint)
 		if volumeID == "" {
 			return nil, fmt.Errorf("function revision restore mount is missing sandbox volume id")

--- a/function-gateway/pkg/http/runtime_test.go
+++ b/function-gateway/pkg/http/runtime_test.go
@@ -24,6 +24,12 @@ import (
 	"go.uber.org/zap"
 )
 
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
 func TestMatchFunctionRouteChoosesLongestPrefix(t *testing.T) {
 	service := mgr.SandboxAppService{
 		Ingress: mgr.SandboxAppServiceIngress{
@@ -330,14 +336,30 @@ func TestClaimFunctionSandboxIncludesRuntimeOwnerMetadata(t *testing.T) {
 		ID:     "fn-1",
 		TeamID: "team-1",
 	}, &functions.Revision{
-		ID:               "rev-1",
-		FunctionID:       "fn-1",
-		TeamID:           "team-1",
-		SourceTemplateID: "tmpl-1",
+		ID:         "rev-1",
+		FunctionID: "fn-1",
+		TeamID:     "team-1",
+		Spec: functions.FunctionRevisionSpec{
+			TemplateID: "tmpl-spec",
+			Mounts: []functions.FunctionRevisionMount{{
+				MountPoint: "/workspace/app",
+				Source: functions.FunctionRevisionMountSource{
+					Type:            functions.FunctionRevisionMountSourceSandboxVolume,
+					SandboxVolumeID: "revision-volume",
+				},
+			}},
+		},
+		SourceTemplateID: "legacy-template",
 		CreatedBy:        "user-1",
 	}, mgr.SandboxAppService{}, "inst-1")
 	if err != nil {
 		t.Fatalf("claimFunctionSandboxViaClusterGateway() error = %v", err)
+	}
+	if got.Template != "tmpl-spec" {
+		t.Fatalf("claim template = %q, want spec template", got.Template)
+	}
+	if len(got.Mounts) != 1 || got.Mounts[0].SandboxVolumeID != "revision-volume" || got.Mounts[0].MountPoint != "/workspace/app" {
+		t.Fatalf("claim mounts = %+v, want spec mount", got.Mounts)
 	}
 	if got.Metadata != nil {
 		t.Fatal("claim request metadata should not be serialized in public JSON body")
@@ -603,24 +625,30 @@ func TestWaitForFunctionServiceReadinessFailure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("generate ed25519 keypair: %v", err)
 	}
-	clusterGateway := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "not ready", http.StatusServiceUnavailable)
-	}))
-	defer clusterGateway.Close()
 
 	server := &Server{
 		cfg: &config.FunctionGatewayConfig{
-			DefaultClusterGatewayURL: clusterGateway.URL,
+			DefaultClusterGatewayURL: "http://cluster-gateway.test",
 		},
 		internalAuthGen: internalauth.NewGenerator(internalauth.GeneratorConfig{
 			Caller:     internalauth.ServiceFunctionGateway,
 			PrivateKey: privateKey,
 			TTL:        time.Minute,
 		}),
-		httpClient: clusterGateway.Client(),
-		logger:     zap.NewNop(),
+		httpClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if got := req.URL.Path; got != "/internal/v1/functions/runtime/sandboxes/sb_test/services/api/readiness" {
+				t.Errorf("readiness path = %q, want runtime readiness path", got)
+			}
+			return &http.Response{
+				StatusCode: http.StatusServiceUnavailable,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader("not ready")),
+				Request:    req,
+			}, nil
+		})},
+		logger: zap.NewNop(),
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), functionServiceReadinessProbeInterval+50*time.Millisecond)
 	defer cancel()
 	err = server.waitForFunctionServiceReadiness(ctx, "sb_test", "team-1", "user-1", mgr.SandboxAppService{ID: "api"})
 	if err == nil {
@@ -719,12 +747,17 @@ func TestStartFunctionServiceRuntimeWarmProcessUsesExistingCMDContext(t *testing
 func TestClaimMountsFromRevisionUsesPreparedVolume(t *testing.T) {
 	server := &Server{}
 	mounts, err := server.claimMountsFromRevision(&functions.Revision{
-		RestoreMounts: []functions.RestoreMount{{
-			SandboxVolumeID:       "revision-volume",
-			SourceSandboxVolumeID: "source-volume",
-			SnapshotID:            "snapshot-1",
-			MountPoint:            "/workspace/data",
-		}},
+		Spec: functions.FunctionRevisionSpec{
+			Mounts: []functions.FunctionRevisionMount{{
+				MountPoint: "/workspace/data",
+				Source: functions.FunctionRevisionMountSource{
+					Type:                  functions.FunctionRevisionMountSourceSandboxVolume,
+					SandboxVolumeID:       "revision-volume",
+					SourceSandboxVolumeID: "source-volume",
+					SnapshotID:            "snapshot-1",
+				},
+			}},
+		},
 	})
 	if err != nil {
 		t.Fatalf("claimMountsFromRevision() error = %v", err)

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -4110,6 +4110,29 @@ components:
               required: [sandbox_id, services]
     FunctionSourceRequest:
       type: object
+      description: >
+        Source used to create a function revision. Omitting type with sandbox_id
+        and service_id keeps the sandbox-service shortcut shape; internally it
+        is compiled into an immutable FunctionRevisionSpec.
+      properties:
+        type:
+          $ref: "#/components/schemas/FunctionRevisionInputSourceType"
+        sandbox_id:
+          type: string
+          description: Compatibility shortcut for type=sandbox_service.
+        service_id:
+          type: string
+          description: Compatibility shortcut for type=sandbox_service.
+        sandbox_service:
+          $ref: "#/components/schemas/FunctionSandboxServiceSource"
+        revision_spec:
+          $ref: "#/components/schemas/FunctionRevisionSpec"
+        provenance:
+          type: object
+          additionalProperties: true
+          description: Optional non-execution metadata describing how the revision spec was produced.
+    FunctionSandboxServiceSource:
+      type: object
       properties:
         sandbox_id:
           type: string
@@ -4238,15 +4261,26 @@ components:
         revision_number:
           type: integer
           format: int32
+        source_type:
+          $ref: "#/components/schemas/FunctionRevisionSourceType"
+        revision_spec:
+          $ref: "#/components/schemas/FunctionRevisionSpec"
+        provenance:
+          type: object
+          additionalProperties: true
+          description: Non-execution metadata describing how the revision spec was produced.
         source_sandbox_id:
           type: string
+          description: Compatibility mirror for sandbox-service revisions.
         source_service_id:
           type: string
+          description: Compatibility mirror for sandbox-service revisions.
         source_template_id:
           type: string
+          description: Compatibility mirror of revision_spec.template_id.
         restore_mounts:
           type: array
-          description: SandboxVolume mounts captured from the source sandbox and reused when the function runtime sandbox is restored.
+          description: Compatibility mirror of revision_spec.mounts for prepared SandboxVolume mounts.
           items:
             $ref: "#/components/schemas/FunctionRestoreMount"
         service_snapshot:
@@ -4266,7 +4300,94 @@ components:
         created_at:
           type: string
           format: date-time
-      required: [id, function_id, team_id, revision_number, source_sandbox_id, source_service_id, source_template_id, service_snapshot, created_at]
+      required: [id, function_id, team_id, revision_number, source_type, revision_spec, created_at]
+    FunctionRevisionSourceType:
+      type: string
+      enum: [sandbox_service, revision_spec, artifact]
+    FunctionRevisionInputSourceType:
+      type: string
+      enum: [sandbox_service, revision_spec]
+    FunctionRevisionSpec:
+      type: object
+      description: Immutable execution contract used by Function Gateway to serve a revision.
+      properties:
+        template_id:
+          type: string
+          description: SandboxTemplate ID used to claim runtime sandboxes for this revision.
+        runtime_service:
+          $ref: "#/components/schemas/SandboxAppService"
+        mounts:
+          type: array
+          description: Volume or artifact mounts attached when runtime sandboxes are claimed.
+          items:
+            $ref: "#/components/schemas/FunctionRevisionMount"
+        static_assets:
+          type: array
+          description: Static asset artifacts associated with the revision for future direct serving paths.
+          items:
+            $ref: "#/components/schemas/FunctionStaticAsset"
+        env_refs:
+          type: array
+          description: Environment references resolved by future deployment flows.
+          items:
+            $ref: "#/components/schemas/FunctionEnvRef"
+      required: [template_id, runtime_service]
+    FunctionRevisionMount:
+      type: object
+      properties:
+        name:
+          type: string
+        mount_point:
+          type: string
+        mode:
+          type: string
+          enum: [read_only, read_write]
+        materialization:
+          type: string
+          description: Optional materialization policy such as fork_per_runtime for future artifact/volume flows.
+        source:
+          $ref: "#/components/schemas/FunctionRevisionMountSource"
+      required: [mount_point, source]
+    FunctionRevisionMountSource:
+      type: object
+      properties:
+        type:
+          type: string
+          enum: [sandbox_volume, artifact, volume_snapshot]
+        sandboxvolume_id:
+          type: string
+          description: Prepared SandboxVolume ID available to the runtime claim path.
+        source_sandboxvolume_id:
+          type: string
+          description: Source SandboxVolume captured by a sandbox-service publish.
+        snapshot_id:
+          type: string
+          description: Immutable snapshot used to materialize this mount.
+        artifact_id:
+          type: string
+          description: Future first-class Function artifact ID.
+        digest:
+          type: string
+          description: Content digest for artifact-backed sources.
+      required: [type]
+    FunctionStaticAsset:
+      type: object
+      properties:
+        artifact_id:
+          type: string
+        route_prefix:
+          type: string
+        digest:
+          type: string
+      required: [artifact_id, route_prefix]
+    FunctionEnvRef:
+      type: object
+      properties:
+        name:
+          type: string
+        source_ref:
+          type: string
+      required: [name, source_ref]
     FunctionRestoreMount:
       type: object
       properties:

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -96,6 +96,32 @@ const (
 	Symlink FileInfoType = "symlink"
 )
 
+// Defines values for FunctionRevisionInputSourceType.
+const (
+	FunctionRevisionInputSourceTypeRevisionSpec   FunctionRevisionInputSourceType = "revision_spec"
+	FunctionRevisionInputSourceTypeSandboxService FunctionRevisionInputSourceType = "sandbox_service"
+)
+
+// Defines values for FunctionRevisionMountMode.
+const (
+	ReadOnly  FunctionRevisionMountMode = "read_only"
+	ReadWrite FunctionRevisionMountMode = "read_write"
+)
+
+// Defines values for FunctionRevisionMountSourceType.
+const (
+	FunctionRevisionMountSourceTypeArtifact       FunctionRevisionMountSourceType = "artifact"
+	FunctionRevisionMountSourceTypeSandboxVolume  FunctionRevisionMountSourceType = "sandbox_volume"
+	FunctionRevisionMountSourceTypeVolumeSnapshot FunctionRevisionMountSourceType = "volume_snapshot"
+)
+
+// Defines values for FunctionRevisionSourceType.
+const (
+	FunctionRevisionSourceTypeArtifact       FunctionRevisionSourceType = "artifact"
+	FunctionRevisionSourceTypeRevisionSpec   FunctionRevisionSourceType = "revision_spec"
+	FunctionRevisionSourceTypeSandboxService FunctionRevisionSourceType = "sandbox_service"
+)
+
 // Defines values for FunctionRuntimeInstanceState.
 const (
 	FunctionRuntimeInstanceStateDraining FunctionRuntimeInstanceState = "draining"
@@ -1058,8 +1084,16 @@ type FunctionCreateRequest struct {
 	Autoscaling *FunctionAutoscaling `json:"autoscaling,omitempty"`
 
 	// Name Function display name. Defaults to the source service name or ID when omitted.
-	Name   *string               `json:"name,omitempty"`
+	Name *string `json:"name,omitempty"`
+
+	// Source Source used to create a function revision. Omitting type with sandbox_id and service_id keeps the sandbox-service shortcut shape; internally it is compiled into an immutable FunctionRevisionSpec.
 	Source FunctionSourceRequest `json:"source"`
+}
+
+// FunctionEnvRef defines model for FunctionEnvRef.
+type FunctionEnvRef struct {
+	Name      string `json:"name"`
+	SourceRef string `json:"source_ref"`
 }
 
 // FunctionRecord defines model for FunctionRecord.
@@ -1105,9 +1139,15 @@ type FunctionRevision struct {
 	FunctionId string    `json:"function_id"`
 	Id         string    `json:"id"`
 
-	// RestoreMounts SandboxVolume mounts captured from the source sandbox and reused when the function runtime sandbox is restored.
+	// Provenance Non-execution metadata describing how the revision spec was produced.
+	Provenance *map[string]interface{} `json:"provenance,omitempty"`
+
+	// RestoreMounts Compatibility mirror of revision_spec.mounts for prepared SandboxVolume mounts.
 	RestoreMounts  *[]FunctionRestoreMount `json:"restore_mounts,omitempty"`
 	RevisionNumber int32                   `json:"revision_number"`
+
+	// RevisionSpec Immutable execution contract used by Function Gateway to serve a revision.
+	RevisionSpec FunctionRevisionSpec `json:"revision_spec"`
 
 	// RuntimeContextId Current runtime process context inside the restored runtime sandbox.
 	RuntimeContextId *string `json:"runtime_context_id,omitempty"`
@@ -1119,18 +1159,86 @@ type FunctionRevision struct {
 	RuntimeUpdatedAt *time.Time `json:"runtime_updated_at,omitempty"`
 
 	// ServiceSnapshot Canonical service model for sandbox exposure and function publishing.
-	ServiceSnapshot  SandboxAppService `json:"service_snapshot"`
-	SourceSandboxId  string            `json:"source_sandbox_id"`
-	SourceServiceId  string            `json:"source_service_id"`
-	SourceTemplateId string            `json:"source_template_id"`
-	TeamId           string            `json:"team_id"`
+	ServiceSnapshot *SandboxAppService `json:"service_snapshot,omitempty"`
+
+	// SourceSandboxId Compatibility mirror for sandbox-service revisions.
+	SourceSandboxId *string `json:"source_sandbox_id,omitempty"`
+
+	// SourceServiceId Compatibility mirror for sandbox-service revisions.
+	SourceServiceId *string `json:"source_service_id,omitempty"`
+
+	// SourceTemplateId Compatibility mirror of revision_spec.template_id.
+	SourceTemplateId *string                    `json:"source_template_id,omitempty"`
+	SourceType       FunctionRevisionSourceType `json:"source_type"`
+	TeamId           string                     `json:"team_id"`
 }
 
 // FunctionRevisionCreateRequest defines model for FunctionRevisionCreateRequest.
 type FunctionRevisionCreateRequest struct {
 	// Promote Whether to move the production alias to the new revision.
-	Promote *bool                 `json:"promote,omitempty"`
-	Source  FunctionSourceRequest `json:"source"`
+	Promote *bool `json:"promote,omitempty"`
+
+	// Source Source used to create a function revision. Omitting type with sandbox_id and service_id keeps the sandbox-service shortcut shape; internally it is compiled into an immutable FunctionRevisionSpec.
+	Source FunctionSourceRequest `json:"source"`
+}
+
+// FunctionRevisionInputSourceType defines model for FunctionRevisionInputSourceType.
+type FunctionRevisionInputSourceType string
+
+// FunctionRevisionMount defines model for FunctionRevisionMount.
+type FunctionRevisionMount struct {
+	// Materialization Optional materialization policy such as fork_per_runtime for future artifact/volume flows.
+	Materialization *string                     `json:"materialization,omitempty"`
+	Mode            *FunctionRevisionMountMode  `json:"mode,omitempty"`
+	MountPoint      string                      `json:"mount_point"`
+	Name            *string                     `json:"name,omitempty"`
+	Source          FunctionRevisionMountSource `json:"source"`
+}
+
+// FunctionRevisionMountMode defines model for FunctionRevisionMount.Mode.
+type FunctionRevisionMountMode string
+
+// FunctionRevisionMountSource defines model for FunctionRevisionMountSource.
+type FunctionRevisionMountSource struct {
+	// ArtifactId Future first-class Function artifact ID.
+	ArtifactId *string `json:"artifact_id,omitempty"`
+
+	// Digest Content digest for artifact-backed sources.
+	Digest *string `json:"digest,omitempty"`
+
+	// SandboxvolumeId Prepared SandboxVolume ID available to the runtime claim path.
+	SandboxvolumeId *string `json:"sandboxvolume_id,omitempty"`
+
+	// SnapshotId Immutable snapshot used to materialize this mount.
+	SnapshotId *string `json:"snapshot_id,omitempty"`
+
+	// SourceSandboxvolumeId Source SandboxVolume captured by a sandbox-service publish.
+	SourceSandboxvolumeId *string                         `json:"source_sandboxvolume_id,omitempty"`
+	Type                  FunctionRevisionMountSourceType `json:"type"`
+}
+
+// FunctionRevisionMountSourceType defines model for FunctionRevisionMountSource.Type.
+type FunctionRevisionMountSourceType string
+
+// FunctionRevisionSourceType defines model for FunctionRevisionSourceType.
+type FunctionRevisionSourceType string
+
+// FunctionRevisionSpec Immutable execution contract used by Function Gateway to serve a revision.
+type FunctionRevisionSpec struct {
+	// EnvRefs Environment references resolved by future deployment flows.
+	EnvRefs *[]FunctionEnvRef `json:"env_refs,omitempty"`
+
+	// Mounts Volume or artifact mounts attached when runtime sandboxes are claimed.
+	Mounts *[]FunctionRevisionMount `json:"mounts,omitempty"`
+
+	// RuntimeService Canonical service model for sandbox exposure and function publishing.
+	RuntimeService SandboxAppService `json:"runtime_service"`
+
+	// StaticAssets Static asset artifacts associated with the revision for future direct serving paths.
+	StaticAssets *[]FunctionStaticAsset `json:"static_assets,omitempty"`
+
+	// TemplateId SandboxTemplate ID used to claim runtime sandboxes for this revision.
+	TemplateId string `json:"template_id"`
 }
 
 // FunctionRuntimeEvent defines model for FunctionRuntimeEvent.
@@ -1209,10 +1317,34 @@ type FunctionRuntimeStatus struct {
 	State             FunctionRuntimeState `json:"state"`
 }
 
-// FunctionSourceRequest defines model for FunctionSourceRequest.
-type FunctionSourceRequest struct {
+// FunctionSandboxServiceSource defines model for FunctionSandboxServiceSource.
+type FunctionSandboxServiceSource struct {
 	SandboxId string `json:"sandbox_id"`
 	ServiceId string `json:"service_id"`
+}
+
+// FunctionSourceRequest Source used to create a function revision. Omitting type with sandbox_id and service_id keeps the sandbox-service shortcut shape; internally it is compiled into an immutable FunctionRevisionSpec.
+type FunctionSourceRequest struct {
+	// Provenance Optional non-execution metadata describing how the revision spec was produced.
+	Provenance *map[string]interface{} `json:"provenance,omitempty"`
+
+	// RevisionSpec Immutable execution contract used by Function Gateway to serve a revision.
+	RevisionSpec *FunctionRevisionSpec `json:"revision_spec,omitempty"`
+
+	// SandboxId Compatibility shortcut for type=sandbox_service.
+	SandboxId      *string                       `json:"sandbox_id,omitempty"`
+	SandboxService *FunctionSandboxServiceSource `json:"sandbox_service,omitempty"`
+
+	// ServiceId Compatibility shortcut for type=sandbox_service.
+	ServiceId *string                          `json:"service_id,omitempty"`
+	Type      *FunctionRevisionInputSourceType `json:"type,omitempty"`
+}
+
+// FunctionStaticAsset defines model for FunctionStaticAsset.
+type FunctionStaticAsset struct {
+	ArtifactId  string  `json:"artifact_id"`
+	Digest      *string `json:"digest,omitempty"`
+	RoutePrefix string  `json:"route_prefix"`
 }
 
 // FunctionUpdateRequest defines model for FunctionUpdateRequest.

--- a/pkg/gateway/functionapi/handler.go
+++ b/pkg/gateway/functionapi/handler.go
@@ -2,6 +2,7 @@ package functionapi
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -175,6 +176,15 @@ func SandboxUnavailableError(message string) error {
 }
 
 type functionSourceRequest struct {
+	Type           functions.RevisionSourceType    `json:"type,omitempty"`
+	SandboxID      string                          `json:"sandbox_id,omitempty"`
+	ServiceID      string                          `json:"service_id,omitempty"`
+	SandboxService *sandboxServiceSourceRequest    `json:"sandbox_service,omitempty"`
+	RevisionSpec   *functions.FunctionRevisionSpec `json:"revision_spec,omitempty"`
+	Provenance     json.RawMessage                 `json:"provenance,omitempty"`
+}
+
+type sandboxServiceSourceRequest struct {
 	SandboxID string `json:"sandbox_id"`
 	ServiceID string `json:"service_id"`
 }
@@ -230,40 +240,29 @@ func (h *Handler) createFunction(c *gin.Context) {
 		return
 	}
 
-	sandbox, serviceSnapshot, err := h.loadPublishableService(c.Request.Context(), authCtx, req.Source)
+	rev, defaultName, cleanupRevision, err := h.prepareRevisionFromSource(c.Request.Context(), authCtx, req.Source)
 	if err != nil {
 		h.writePublishError(c, err)
 		return
 	}
+	cleanupRevisionAfterFailure := true
+	if cleanupRevision != nil {
+		defer func() {
+			if cleanupRevisionAfterFailure {
+				cleanupRevision()
+			}
+		}()
+	}
 
 	name := strings.TrimSpace(req.Name)
 	if name == "" {
-		name = strings.TrimSpace(serviceSnapshot.DisplayName)
-	}
-	if name == "" {
-		name = serviceSnapshot.ID
+		name = defaultName
 	}
 
 	userID := principalID(authCtx)
 	fn := functions.NewFunction(authCtx.TeamID, name, userID)
 	if req.Autoscaling != nil {
 		fn.Autoscaling = functions.NormalizeAutoscaling(*req.Autoscaling)
-	}
-	restoreMounts, err := h.prepareRestoreMounts(c.Request.Context(), authCtx, sandbox)
-	if err != nil {
-		h.writePublishError(c, err)
-		return
-	}
-	cleanupRestoreMounts := true
-	defer func() {
-		if cleanupRestoreMounts {
-			h.deletePreparedRestoreMounts(context.Background(), authCtx, sandbox, restoreMounts, "function create failed")
-		}
-	}()
-	rev, err := functions.NewRevision(authCtx.TeamID, sandbox.ID, serviceSnapshot.ID, sandbox.TemplateID, serviceSnapshot, restoreMounts, userID)
-	if err != nil {
-		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to create revision snapshot")
-		return
 	}
 
 	fn, rev, err = h.repo.CreateFunctionWithRevision(c.Request.Context(), fn, rev, userID)
@@ -276,7 +275,7 @@ func (h *Handler) createFunction(c *gin.Context) {
 		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to create function")
 		return
 	}
-	cleanupRestoreMounts = false
+	cleanupRevisionAfterFailure = false
 
 	spec.JSONSuccess(c, http.StatusCreated, gin.H{
 		"function": h.functionRecord(fn),
@@ -397,29 +396,21 @@ func (h *Handler) createFunctionRevision(c *gin.Context) {
 	}
 	defer unlockRevisionPublish()
 
-	sandbox, serviceSnapshot, err := h.loadPublishableService(c.Request.Context(), authCtx, req.Source)
+	rev, _, cleanupRevision, err := h.prepareRevisionFromSource(c.Request.Context(), authCtx, req.Source)
 	if err != nil {
 		h.writePublishError(c, err)
 		return
+	}
+	cleanupRevisionAfterFailure := true
+	if cleanupRevision != nil {
+		defer func() {
+			if cleanupRevisionAfterFailure {
+				cleanupRevision()
+			}
+		}()
 	}
 
 	userID := principalID(authCtx)
-	restoreMounts, err := h.prepareRestoreMounts(c.Request.Context(), authCtx, sandbox)
-	if err != nil {
-		h.writePublishError(c, err)
-		return
-	}
-	cleanupRestoreMounts := true
-	defer func() {
-		if cleanupRestoreMounts {
-			h.deletePreparedRestoreMounts(context.Background(), authCtx, sandbox, restoreMounts, "revision create failed")
-		}
-	}()
-	rev, err := functions.NewRevision(authCtx.TeamID, sandbox.ID, serviceSnapshot.ID, sandbox.TemplateID, serviceSnapshot, restoreMounts, userID)
-	if err != nil {
-		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to create revision snapshot")
-		return
-	}
 	promote := true
 	if req.Promote != nil {
 		promote = *req.Promote
@@ -434,7 +425,7 @@ func (h *Handler) createFunctionRevision(c *gin.Context) {
 		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to create revision")
 		return
 	}
-	cleanupRestoreMounts = false
+	cleanupRevisionAfterFailure = false
 	spec.JSONSuccess(c, http.StatusCreated, gin.H{"revision": rev, "promoted": promote})
 }
 
@@ -601,7 +592,110 @@ func (h *Handler) clearFunctionRuntime(c *gin.Context) {
 	spec.JSONSuccess(c, http.StatusOK, gin.H{"runtime": runtimeStatus(fn, rev, nil, nil)})
 }
 
-func (h *Handler) loadPublishableService(ctx context.Context, authCtx *authn.AuthContext, source functionSourceRequest) (*mgr.Sandbox, mgr.SandboxAppService, error) {
+func (h *Handler) prepareRevisionFromSource(ctx context.Context, authCtx *authn.AuthContext, source functionSourceRequest) (*functions.Revision, string, func(), error) {
+	sourceType := normalizeFunctionSourceType(source)
+	switch sourceType {
+	case functions.RevisionSourceTypeSandboxService:
+		sandboxSource := normalizeSandboxServiceSource(source)
+		sandbox, serviceSnapshot, err := h.loadPublishableService(ctx, authCtx, sandboxSource)
+		if err != nil {
+			return nil, "", nil, err
+		}
+		restoreMounts, err := h.prepareRestoreMounts(ctx, authCtx, sandbox)
+		if err != nil {
+			return nil, "", nil, err
+		}
+		cleanup := func() {
+			h.deletePreparedRestoreMounts(context.Background(), authCtx, sandbox, restoreMounts, "revision create failed")
+		}
+		rev, err := functions.NewRevision(authCtx.TeamID, sandbox.ID, serviceSnapshot.ID, sandbox.TemplateID, serviceSnapshot, restoreMounts, principalID(authCtx))
+		if err != nil {
+			cleanup()
+			return nil, "", nil, publishError{status: http.StatusBadRequest, code: spec.CodeBadRequest, message: err.Error()}
+		}
+		return rev, defaultFunctionName(serviceSnapshot), cleanup, nil
+	case functions.RevisionSourceTypeRevisionSpec:
+		if authCtx == nil || strings.TrimSpace(authCtx.TeamID) == "" {
+			return nil, "", nil, publishError{status: http.StatusForbidden, code: spec.CodeForbidden, message: "team context is required"}
+		}
+		if source.RevisionSpec == nil {
+			return nil, "", nil, publishError{status: http.StatusBadRequest, code: spec.CodeBadRequest, message: "source.revision_spec is required"}
+		}
+		serviceSnapshot, err := validatePublishableRevisionSpec(*source.RevisionSpec)
+		if err != nil {
+			return nil, "", nil, err
+		}
+		provenance := any(functions.RevisionProvenance{Type: functions.RevisionSourceTypeRevisionSpec})
+		if len(source.Provenance) > 0 {
+			provenance = source.Provenance
+		}
+		rev, err := functions.NewRevisionFromSpec(authCtx.TeamID, functions.RevisionSourceTypeRevisionSpec, *source.RevisionSpec, provenance, principalID(authCtx))
+		if err != nil {
+			return nil, "", nil, publishError{status: http.StatusBadRequest, code: spec.CodeBadRequest, message: err.Error()}
+		}
+		return rev, defaultFunctionName(serviceSnapshot), nil, nil
+	default:
+		return nil, "", nil, publishError{status: http.StatusBadRequest, code: spec.CodeBadRequest, message: "source.type is invalid"}
+	}
+}
+
+func normalizeFunctionSourceType(source functionSourceRequest) functions.RevisionSourceType {
+	if source.Type != "" {
+		return source.Type
+	}
+	if source.RevisionSpec != nil {
+		return functions.RevisionSourceTypeRevisionSpec
+	}
+	return functions.RevisionSourceTypeSandboxService
+}
+
+func normalizeSandboxServiceSource(source functionSourceRequest) sandboxServiceSourceRequest {
+	out := sandboxServiceSourceRequest{
+		SandboxID: source.SandboxID,
+		ServiceID: source.ServiceID,
+	}
+	if source.SandboxService != nil {
+		if strings.TrimSpace(source.SandboxService.SandboxID) != "" {
+			out.SandboxID = source.SandboxService.SandboxID
+		}
+		if strings.TrimSpace(source.SandboxService.ServiceID) != "" {
+			out.ServiceID = source.SandboxService.ServiceID
+		}
+	}
+	return out
+}
+
+func validatePublishableRevisionSpec(revisionSpec functions.FunctionRevisionSpec) (mgr.SandboxAppService, error) {
+	if err := revisionSpec.Validate(); err != nil {
+		return mgr.SandboxAppService{}, publishError{status: http.StatusBadRequest, code: spec.CodeBadRequest, message: err.Error()}
+	}
+	var serviceSnapshot mgr.SandboxAppService
+	if err := json.Unmarshal(revisionSpec.RuntimeService, &serviceSnapshot); err != nil {
+		return mgr.SandboxAppService{}, publishError{status: http.StatusBadRequest, code: spec.CodeBadRequest, message: "source.revision_spec.runtime_service is invalid"}
+	}
+	if blockers := mgr.SandboxAppServicePublishBlockers(serviceSnapshot); len(blockers) > 0 {
+		return mgr.SandboxAppService{}, publishError{
+			status:  http.StatusBadRequest,
+			code:    spec.CodeBadRequest,
+			message: "revision spec runtime service is not publishable",
+			details: gin.H{"blockers": blockers},
+		}
+	}
+	return serviceSnapshot, nil
+}
+
+func defaultFunctionName(service mgr.SandboxAppService) string {
+	name := strings.TrimSpace(service.DisplayName)
+	if name == "" {
+		name = strings.TrimSpace(service.ID)
+	}
+	if name == "" {
+		name = "function"
+	}
+	return name
+}
+
+func (h *Handler) loadPublishableService(ctx context.Context, authCtx *authn.AuthContext, source sandboxServiceSourceRequest) (*mgr.Sandbox, mgr.SandboxAppService, error) {
 	if authCtx == nil || strings.TrimSpace(authCtx.TeamID) == "" {
 		return nil, mgr.SandboxAppService{}, publishError{status: http.StatusForbidden, code: spec.CodeForbidden, message: "team context is required"}
 	}

--- a/pkg/gateway/functionapi/handler_test.go
+++ b/pkg/gateway/functionapi/handler_test.go
@@ -2,10 +2,12 @@ package functionapi
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
 
+	mgr "github.com/sandbox0-ai/sandbox0/manager/pkg/service"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/authn"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/functions"
 	"go.uber.org/zap"
@@ -36,6 +38,65 @@ func TestTryLockFunctionRevisionPublishSerializesFunction(t *testing.T) {
 		t.Fatal("publish lock was not reusable after release")
 	}
 	reacquired()
+}
+
+func TestPrepareRevisionFromSourceAcceptsRevisionSpec(t *testing.T) {
+	service := mgr.SandboxAppService{
+		ID:          "api",
+		DisplayName: "API",
+		Port:        3000,
+		Runtime: &mgr.SandboxAppServiceRuntime{
+			Type:    mgr.SandboxAppServiceRuntimeCMD,
+			Command: []string{"node", "server.js"},
+		},
+		Ingress: mgr.SandboxAppServiceIngress{
+			Public: true,
+			Routes: []mgr.SandboxAppServiceRoute{{
+				ID:     "root",
+				Resume: true,
+			}},
+		},
+	}
+	serviceBytes, err := json.Marshal(service)
+	if err != nil {
+		t.Fatalf("marshal service: %v", err)
+	}
+
+	rev, name, cleanup, err := (&Handler{}).prepareRevisionFromSource(context.Background(), &authn.AuthContext{
+		TeamID: "team-1",
+		UserID: "user-1",
+	}, functionSourceRequest{
+		Type: functions.RevisionSourceTypeRevisionSpec,
+		RevisionSpec: &functions.FunctionRevisionSpec{
+			TemplateID:     "node-template",
+			RuntimeService: serviceBytes,
+			Mounts: []functions.FunctionRevisionMount{{
+				MountPoint: "/workspace/app",
+				Source: functions.FunctionRevisionMountSource{
+					Type:            functions.FunctionRevisionMountSourceSandboxVolume,
+					SandboxVolumeID: "revision-volume",
+				},
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("prepareRevisionFromSource() error = %v", err)
+	}
+	if cleanup != nil {
+		t.Fatal("revision_spec source should not return sandbox restore cleanup")
+	}
+	if name != "API" {
+		t.Fatalf("name = %q, want API", name)
+	}
+	if rev.SourceType != functions.RevisionSourceTypeRevisionSpec {
+		t.Fatalf("source_type = %q, want revision_spec", rev.SourceType)
+	}
+	if rev.Spec.TemplateID != "node-template" || len(rev.Spec.Mounts) != 1 {
+		t.Fatalf("revision spec = %+v, want template and mount", rev.Spec)
+	}
+	if len(rev.ServiceSnapshot) == 0 {
+		t.Fatal("service snapshot compatibility mirror is empty")
+	}
 }
 
 func TestRuntimeStatusReportsFailedInstance(t *testing.T) {

--- a/pkg/gateway/functions/models.go
+++ b/pkg/gateway/functions/models.go
@@ -2,6 +2,8 @@ package functions
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
 	"time"
 )
 
@@ -38,15 +40,27 @@ type Function struct {
 }
 
 type Revision struct {
-	ID               string          `json:"id"`
-	FunctionID       string          `json:"function_id"`
-	TeamID           string          `json:"team_id"`
-	RevisionNumber   int             `json:"revision_number"`
-	SourceSandboxID  string          `json:"source_sandbox_id"`
-	SourceServiceID  string          `json:"source_service_id"`
-	SourceTemplateID string          `json:"source_template_id"`
+	ID             string             `json:"id"`
+	FunctionID     string             `json:"function_id"`
+	TeamID         string             `json:"team_id"`
+	RevisionNumber int                `json:"revision_number"`
+	SourceType     RevisionSourceType `json:"source_type"`
+
+	// Spec is the immutable execution contract for this revision. Publish flows
+	// such as sandbox service publishing compile into this model before storage.
+	Spec FunctionRevisionSpec `json:"revision_spec"`
+
+	// Provenance records how the spec was produced. It is not used for runtime
+	// execution and may differ between sandbox, CI, and future artifact flows.
+	Provenance json.RawMessage `json:"provenance,omitempty"`
+
+	// Legacy fields are retained as compatibility mirrors while the API moves
+	// to FunctionRevisionSpec as the runtime contract.
+	SourceSandboxID  string          `json:"source_sandbox_id,omitempty"`
+	SourceServiceID  string          `json:"source_service_id,omitempty"`
+	SourceTemplateID string          `json:"source_template_id,omitempty"`
 	RestoreMounts    []RestoreMount  `json:"restore_mounts,omitempty"`
-	ServiceSnapshot  json.RawMessage `json:"service_snapshot"`
+	ServiceSnapshot  json.RawMessage `json:"service_snapshot,omitempty"`
 	RuntimeSandboxID *string         `json:"runtime_sandbox_id,omitempty"`
 	RuntimeContextID *string         `json:"runtime_context_id,omitempty"`
 	RuntimeUpdatedAt *time.Time      `json:"runtime_updated_at,omitempty"`
@@ -59,6 +73,162 @@ type RestoreMount struct {
 	SourceSandboxVolumeID string `json:"source_sandboxvolume_id,omitempty"`
 	SnapshotID            string `json:"snapshot_id,omitempty"`
 	MountPoint            string `json:"mount_point"`
+}
+
+type RevisionSourceType string
+
+const (
+	RevisionSourceTypeSandboxService RevisionSourceType = "sandbox_service"
+	RevisionSourceTypeRevisionSpec   RevisionSourceType = "revision_spec"
+	RevisionSourceTypeArtifact       RevisionSourceType = "artifact"
+)
+
+type FunctionRevisionSpec struct {
+	TemplateID     string                  `json:"template_id"`
+	RuntimeService json.RawMessage         `json:"runtime_service"`
+	Mounts         []FunctionRevisionMount `json:"mounts,omitempty"`
+	StaticAssets   []FunctionStaticAsset   `json:"static_assets,omitempty"`
+	EnvRefs        []FunctionEnvRef        `json:"env_refs,omitempty"`
+}
+
+type FunctionRevisionMount struct {
+	Name            string                      `json:"name,omitempty"`
+	MountPoint      string                      `json:"mount_point"`
+	Mode            FunctionRevisionMountMode   `json:"mode,omitempty"`
+	Materialization string                      `json:"materialization,omitempty"`
+	Source          FunctionRevisionMountSource `json:"source"`
+}
+
+type FunctionRevisionMountMode string
+
+const (
+	FunctionRevisionMountModeReadOnly  FunctionRevisionMountMode = "read_only"
+	FunctionRevisionMountModeReadWrite FunctionRevisionMountMode = "read_write"
+)
+
+type FunctionRevisionMountSource struct {
+	Type                  FunctionRevisionMountSourceType `json:"type"`
+	SandboxVolumeID       string                          `json:"sandboxvolume_id,omitempty"`
+	SourceSandboxVolumeID string                          `json:"source_sandboxvolume_id,omitempty"`
+	SnapshotID            string                          `json:"snapshot_id,omitempty"`
+	ArtifactID            string                          `json:"artifact_id,omitempty"`
+	Digest                string                          `json:"digest,omitempty"`
+}
+
+type FunctionRevisionMountSourceType string
+
+const (
+	FunctionRevisionMountSourceSandboxVolume  FunctionRevisionMountSourceType = "sandbox_volume"
+	FunctionRevisionMountSourceArtifact       FunctionRevisionMountSourceType = "artifact"
+	FunctionRevisionMountSourceVolumeSnapshot FunctionRevisionMountSourceType = "volume_snapshot"
+)
+
+type FunctionStaticAsset struct {
+	ArtifactID  string `json:"artifact_id"`
+	RoutePrefix string `json:"route_prefix"`
+	Digest      string `json:"digest,omitempty"`
+}
+
+type FunctionEnvRef struct {
+	Name      string `json:"name"`
+	SourceRef string `json:"source_ref"`
+}
+
+type SandboxServiceProvenance struct {
+	SandboxID  string `json:"sandbox_id"`
+	ServiceID  string `json:"service_id"`
+	TemplateID string `json:"template_id"`
+}
+
+type RevisionProvenance struct {
+	Type           RevisionSourceType        `json:"type"`
+	SandboxService *SandboxServiceProvenance `json:"sandbox_service,omitempty"`
+}
+
+func NewSandboxServiceRevisionSpec(templateID string, service any, mounts []RestoreMount) (FunctionRevisionSpec, error) {
+	serviceBytes, err := json.Marshal(service)
+	if err != nil {
+		return FunctionRevisionSpec{}, err
+	}
+	spec := FunctionRevisionSpec{
+		TemplateID:     strings.TrimSpace(templateID),
+		RuntimeService: serviceBytes,
+		Mounts:         RevisionMountsFromRestoreMounts(mounts),
+	}
+	return spec, spec.Validate()
+}
+
+func RevisionMountsFromRestoreMounts(mounts []RestoreMount) []FunctionRevisionMount {
+	if len(mounts) == 0 {
+		return nil
+	}
+	out := make([]FunctionRevisionMount, 0, len(mounts))
+	for _, mount := range mounts {
+		out = append(out, FunctionRevisionMount{
+			MountPoint: strings.TrimSpace(mount.MountPoint),
+			Mode:       FunctionRevisionMountModeReadWrite,
+			Source: FunctionRevisionMountSource{
+				Type:                  FunctionRevisionMountSourceSandboxVolume,
+				SandboxVolumeID:       strings.TrimSpace(mount.SandboxVolumeID),
+				SourceSandboxVolumeID: strings.TrimSpace(mount.SourceSandboxVolumeID),
+				SnapshotID:            strings.TrimSpace(mount.SnapshotID),
+			},
+		})
+	}
+	return out
+}
+
+func RestoreMountsFromRevisionMounts(mounts []FunctionRevisionMount) []RestoreMount {
+	if len(mounts) == 0 {
+		return nil
+	}
+	out := make([]RestoreMount, 0, len(mounts))
+	for _, mount := range mounts {
+		if mount.Source.Type != FunctionRevisionMountSourceSandboxVolume || strings.TrimSpace(mount.Source.SandboxVolumeID) == "" {
+			continue
+		}
+		out = append(out, RestoreMount{
+			SandboxVolumeID:       strings.TrimSpace(mount.Source.SandboxVolumeID),
+			SourceSandboxVolumeID: strings.TrimSpace(mount.Source.SourceSandboxVolumeID),
+			SnapshotID:            strings.TrimSpace(mount.Source.SnapshotID),
+			MountPoint:            strings.TrimSpace(mount.MountPoint),
+		})
+	}
+	return out
+}
+
+func (s FunctionRevisionSpec) Validate() error {
+	if strings.TrimSpace(s.TemplateID) == "" {
+		return fmt.Errorf("revision_spec.template_id is required")
+	}
+	if len(s.RuntimeService) == 0 || string(s.RuntimeService) == "null" {
+		return fmt.Errorf("revision_spec.runtime_service is required")
+	}
+	for i, mount := range s.Mounts {
+		if strings.TrimSpace(mount.MountPoint) == "" {
+			return fmt.Errorf("revision_spec.mounts[%d].mount_point is required", i)
+		}
+		switch mount.Source.Type {
+		case FunctionRevisionMountSourceSandboxVolume:
+			if strings.TrimSpace(mount.Source.SandboxVolumeID) == "" {
+				return fmt.Errorf("revision_spec.mounts[%d].source.sandboxvolume_id is required", i)
+			}
+		case FunctionRevisionMountSourceArtifact:
+			if strings.TrimSpace(mount.Source.SandboxVolumeID) == "" {
+				return fmt.Errorf("revision_spec.mounts[%d].source.sandboxvolume_id is required for artifact mounts", i)
+			}
+		case FunctionRevisionMountSourceVolumeSnapshot:
+			if strings.TrimSpace(mount.Source.SnapshotID) == "" {
+				return fmt.Errorf("revision_spec.mounts[%d].source.snapshot_id is required", i)
+			}
+			if strings.TrimSpace(mount.Source.SandboxVolumeID) == "" {
+				return fmt.Errorf("revision_spec.mounts[%d].source.sandboxvolume_id is required for volume snapshot mounts", i)
+			}
+		default:
+			return fmt.Errorf("revision_spec.mounts[%d].source.type is invalid", i)
+		}
+	}
+	return nil
 }
 
 type Alias struct {

--- a/pkg/gateway/functions/repository.go
+++ b/pkg/gateway/functions/repository.go
@@ -22,6 +22,12 @@ type Repository struct {
 	pool *pgxpool.Pool
 }
 
+const revisionSelectColumns = `
+	id, function_id, team_id, revision_number, source_sandbox_id, source_service_id,
+	source_template_id, restore_mounts, service_snapshot, runtime_sandbox_id, runtime_context_id,
+	runtime_updated_at, created_by, created_at, source_type, revision_spec, provenance
+`
+
 func NewRepository(pool *pgxpool.Pool) *Repository {
 	return &Repository{pool: pool}
 }
@@ -205,9 +211,7 @@ func (r *Repository) GetActiveRevision(ctx context.Context, fn *Function) (*Revi
 		return nil, ErrNotFound
 	}
 	row := r.pool.QueryRow(ctx, `
-		SELECT id, function_id, team_id, revision_number, source_sandbox_id, source_service_id,
-			source_template_id, restore_mounts, service_snapshot, runtime_sandbox_id, runtime_context_id,
-			runtime_updated_at, created_by, created_at
+		SELECT `+revisionSelectColumns+`
 		FROM functions_revisions
 		WHERE function_id = $1 AND id = $2
 	`, fn.ID, *fn.ActiveRevisionID)
@@ -224,9 +228,7 @@ func (r *Repository) ListRevisions(ctx context.Context, teamID, functionRef stri
 		return nil, err
 	}
 	rows, err := r.pool.Query(ctx, `
-		SELECT id, function_id, team_id, revision_number, source_sandbox_id, source_service_id,
-			source_template_id, restore_mounts, service_snapshot, runtime_sandbox_id, runtime_context_id,
-			runtime_updated_at, created_by, created_at
+		SELECT `+revisionSelectColumns+`
 		FROM functions_revisions
 		WHERE function_id = $1
 		ORDER BY revision_number DESC
@@ -251,9 +253,7 @@ func (r *Repository) GetRevision(ctx context.Context, teamID, functionID, revisi
 		return nil, fmt.Errorf("function repository is not configured")
 	}
 	row := r.pool.QueryRow(ctx, `
-		SELECT id, function_id, team_id, revision_number, source_sandbox_id, source_service_id,
-			source_template_id, restore_mounts, service_snapshot, runtime_sandbox_id, runtime_context_id,
-			runtime_updated_at, created_by, created_at
+		SELECT `+revisionSelectColumns+`
 		FROM functions_revisions
 		WHERE team_id = $1 AND function_id = $2 AND id = $3
 	`, teamID, functionID, revisionID)
@@ -273,9 +273,7 @@ func (r *Repository) GetRevisionByNumber(ctx context.Context, teamID, functionRe
 		return nil, err
 	}
 	row := r.pool.QueryRow(ctx, `
-		SELECT id, function_id, team_id, revision_number, source_sandbox_id, source_service_id,
-			source_template_id, restore_mounts, service_snapshot, runtime_sandbox_id, runtime_context_id,
-			runtime_updated_at, created_by, created_at
+		SELECT `+revisionSelectColumns+`
 		FROM functions_revisions
 		WHERE function_id = $1 AND revision_number = $2
 	`, fn.ID, revisionNumber)
@@ -294,9 +292,7 @@ func (r *Repository) SetRevisionRuntime(ctx context.Context, teamID, functionID,
 		UPDATE functions_revisions
 		SET runtime_sandbox_id = $4, runtime_context_id = $5, runtime_updated_at = NOW()
 		WHERE team_id = $1 AND function_id = $2 AND id = $3
-		RETURNING id, function_id, team_id, revision_number, source_sandbox_id, source_service_id,
-			source_template_id, restore_mounts, service_snapshot, runtime_sandbox_id, runtime_context_id,
-			runtime_updated_at, created_by, created_at
+		RETURNING `+revisionSelectColumns+`
 	`, teamID, functionID, revisionID, sandboxID, contextID)
 	rev, err := scanRevision(row)
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -911,13 +907,59 @@ func NewRevision(teamID, sandboxID, serviceID, templateID string, snapshot any, 
 	if err != nil {
 		return nil, err
 	}
+	spec, err := NewSandboxServiceRevisionSpec(templateID, snapshot, mounts)
+	if err != nil {
+		return nil, err
+	}
+	provenance, err := json.Marshal(RevisionProvenance{
+		Type: RevisionSourceTypeSandboxService,
+		SandboxService: &SandboxServiceProvenance{
+			SandboxID:  strings.TrimSpace(sandboxID),
+			ServiceID:  strings.TrimSpace(serviceID),
+			TemplateID: strings.TrimSpace(templateID),
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
 	return &Revision{
+		SourceType:       RevisionSourceTypeSandboxService,
+		Spec:             spec,
+		Provenance:       provenance,
 		TeamID:           teamID,
 		SourceSandboxID:  sandboxID,
 		SourceServiceID:  serviceID,
 		SourceTemplateID: templateID,
 		RestoreMounts:    append([]RestoreMount(nil), mounts...),
 		ServiceSnapshot:  data,
+		CreatedBy:        userID,
+	}, nil
+}
+
+func NewRevisionFromSpec(teamID string, sourceType RevisionSourceType, spec FunctionRevisionSpec, provenance any, userID string) (*Revision, error) {
+	if sourceType == "" {
+		sourceType = RevisionSourceTypeRevisionSpec
+	}
+	if err := spec.Validate(); err != nil {
+		return nil, err
+	}
+	serviceSnapshot := append(json.RawMessage(nil), spec.RuntimeService...)
+	restoreMounts := RestoreMountsFromRevisionMounts(spec.Mounts)
+	provenanceBytes, err := json.Marshal(provenance)
+	if err != nil {
+		return nil, err
+	}
+	if string(provenanceBytes) == "null" {
+		provenanceBytes = nil
+	}
+	return &Revision{
+		TeamID:           teamID,
+		SourceType:       sourceType,
+		Spec:             spec,
+		Provenance:       provenanceBytes,
+		SourceTemplateID: spec.TemplateID,
+		RestoreMounts:    restoreMounts,
+		ServiceSnapshot:  serviceSnapshot,
 		CreatedBy:        userID,
 	}, nil
 }
@@ -937,20 +979,60 @@ func insertFunction(ctx context.Context, tx pgx.Tx, fn *Function) error {
 }
 
 func insertRevision(ctx context.Context, tx pgx.Tx, rev *Revision) error {
+	if err := normalizeRevisionForStorage(rev); err != nil {
+		return err
+	}
 	restoreMounts, err := json.Marshal(rev.RestoreMounts)
 	if err != nil {
 		return err
+	}
+	specBytes, err := json.Marshal(rev.Spec)
+	if err != nil {
+		return err
+	}
+	provenanceBytes := rev.Provenance
+	if len(provenanceBytes) == 0 {
+		provenanceBytes = []byte(`{}`)
 	}
 	_, err = tx.Exec(ctx, `
 		INSERT INTO functions_revisions (
 			id, function_id, team_id, revision_number, source_sandbox_id, source_service_id,
 			source_template_id, restore_mounts, service_snapshot, runtime_sandbox_id, runtime_context_id,
-			runtime_updated_at, created_by, created_at
-		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)
+			runtime_updated_at, created_by, created_at, source_type, revision_spec, provenance
+		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17)
 	`, rev.ID, rev.FunctionID, rev.TeamID, rev.RevisionNumber, rev.SourceSandboxID, rev.SourceServiceID,
 		rev.SourceTemplateID, restoreMounts, rev.ServiceSnapshot, rev.RuntimeSandboxID, rev.RuntimeContextID,
-		rev.RuntimeUpdatedAt, rev.CreatedBy, rev.CreatedAt)
+		rev.RuntimeUpdatedAt, rev.CreatedBy, rev.CreatedAt, rev.SourceType, specBytes, provenanceBytes)
 	return err
+}
+
+func normalizeRevisionForStorage(rev *Revision) error {
+	if rev == nil {
+		return fmt.Errorf("revision is nil")
+	}
+	if rev.SourceType == "" {
+		rev.SourceType = RevisionSourceTypeSandboxService
+	}
+	if rev.Spec.TemplateID == "" && len(rev.ServiceSnapshot) > 0 {
+		spec, err := NewSandboxServiceRevisionSpec(rev.SourceTemplateID, rev.ServiceSnapshot, rev.RestoreMounts)
+		if err != nil {
+			return err
+		}
+		rev.Spec = spec
+	}
+	if err := rev.Spec.Validate(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(rev.SourceTemplateID) == "" {
+		rev.SourceTemplateID = rev.Spec.TemplateID
+	}
+	if len(rev.ServiceSnapshot) == 0 {
+		rev.ServiceSnapshot = append(json.RawMessage(nil), rev.Spec.RuntimeService...)
+	}
+	if len(rev.RestoreMounts) == 0 {
+		rev.RestoreMounts = RestoreMountsFromRevisionMounts(rev.Spec.Mounts)
+	}
+	return nil
 }
 
 func upsertAlias(ctx context.Context, tx pgx.Tx, functionID, alias, revisionID, updatedBy string, updatedAt time.Time) error {
@@ -1029,13 +1111,22 @@ func normalizeRuntimeReadinessState(value RuntimeReadinessState, state RuntimeIn
 func scanRevision(row rowScanner) (*Revision, error) {
 	var rev Revision
 	var restoreMounts []byte
-	if err := row.Scan(&rev.ID, &rev.FunctionID, &rev.TeamID, &rev.RevisionNumber, &rev.SourceSandboxID, &rev.SourceServiceID, &rev.SourceTemplateID, &restoreMounts, &rev.ServiceSnapshot, &rev.RuntimeSandboxID, &rev.RuntimeContextID, &rev.RuntimeUpdatedAt, &rev.CreatedBy, &rev.CreatedAt); err != nil {
+	var specBytes []byte
+	if err := row.Scan(&rev.ID, &rev.FunctionID, &rev.TeamID, &rev.RevisionNumber, &rev.SourceSandboxID, &rev.SourceServiceID, &rev.SourceTemplateID, &restoreMounts, &rev.ServiceSnapshot, &rev.RuntimeSandboxID, &rev.RuntimeContextID, &rev.RuntimeUpdatedAt, &rev.CreatedBy, &rev.CreatedAt, &rev.SourceType, &specBytes, &rev.Provenance); err != nil {
 		return nil, err
 	}
 	if len(restoreMounts) > 0 {
 		if err := json.Unmarshal(restoreMounts, &rev.RestoreMounts); err != nil {
 			return nil, err
 		}
+	}
+	if len(specBytes) > 0 {
+		if err := json.Unmarshal(specBytes, &rev.Spec); err != nil {
+			return nil, err
+		}
+	}
+	if rev.SourceType == "" {
+		rev.SourceType = RevisionSourceTypeSandboxService
 	}
 	return &rev, nil
 }

--- a/pkg/gateway/functions/repository_test.go
+++ b/pkg/gateway/functions/repository_test.go
@@ -2,6 +2,7 @@ package functions
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -14,6 +15,41 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/migrations"
 	"github.com/sandbox0-ai/sandbox0/pkg/migrate"
 )
+
+func TestNewRevisionCompilesSandboxServiceIntoRevisionSpec(t *testing.T) {
+	rev, err := NewRevision("team-1", "source-sandbox", "api", "tmpl-1", map[string]any{
+		"id":   "api",
+		"port": 3000,
+	}, []RestoreMount{{
+		SandboxVolumeID:       "revision-volume",
+		SourceSandboxVolumeID: "source-volume",
+		SnapshotID:            "snapshot-1",
+		MountPoint:            "/workspace/data",
+	}}, "user-1")
+	if err != nil {
+		t.Fatalf("NewRevision() error = %v", err)
+	}
+	if rev.SourceType != RevisionSourceTypeSandboxService {
+		t.Fatalf("source_type = %q, want %q", rev.SourceType, RevisionSourceTypeSandboxService)
+	}
+	if rev.Spec.TemplateID != "tmpl-1" {
+		t.Fatalf("spec.template_id = %q, want tmpl-1", rev.Spec.TemplateID)
+	}
+	if len(rev.Spec.Mounts) != 1 {
+		t.Fatalf("spec mounts = %d, want 1", len(rev.Spec.Mounts))
+	}
+	mount := rev.Spec.Mounts[0]
+	if mount.MountPoint != "/workspace/data" || mount.Source.SandboxVolumeID != "revision-volume" {
+		t.Fatalf("spec mount = %+v, want prepared sandbox volume mount", mount)
+	}
+	var provenance RevisionProvenance
+	if err := json.Unmarshal(rev.Provenance, &provenance); err != nil {
+		t.Fatalf("unmarshal provenance: %v", err)
+	}
+	if provenance.Type != RevisionSourceTypeSandboxService || provenance.SandboxService == nil || provenance.SandboxService.SandboxID != "source-sandbox" {
+		t.Fatalf("provenance = %+v, want sandbox service provenance", provenance)
+	}
+}
 
 func TestListRuntimeCleanupCandidatesIncludesInactiveAndFailedRuntimes(t *testing.T) {
 	ctx := context.Background()

--- a/pkg/gateway/migrations/00013_add_function_revision_spec.sql
+++ b/pkg/gateway/migrations/00013_add_function_revision_spec.sql
@@ -1,0 +1,51 @@
+-- +goose Up
+ALTER TABLE functions_revisions
+    ADD COLUMN IF NOT EXISTS source_type TEXT NOT NULL DEFAULT 'sandbox_service',
+    ADD COLUMN IF NOT EXISTS revision_spec JSONB,
+    ADD COLUMN IF NOT EXISTS provenance JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+ALTER TABLE functions_revisions
+    DROP CONSTRAINT IF EXISTS functions_revisions_source_type_check;
+ALTER TABLE functions_revisions
+    ADD CONSTRAINT functions_revisions_source_type_check
+        CHECK (source_type IN ('sandbox_service', 'revision_spec', 'artifact'));
+
+UPDATE functions_revisions
+SET revision_spec = jsonb_build_object(
+        'template_id', source_template_id,
+        'runtime_service', service_snapshot,
+        'mounts', COALESCE((
+            SELECT jsonb_agg(jsonb_build_object(
+                'mount_point', mount->>'mount_point',
+                'mode', 'read_write',
+                'source', jsonb_strip_nulls(jsonb_build_object(
+                    'type', 'sandbox_volume',
+                    'sandboxvolume_id', mount->>'sandboxvolume_id',
+                    'source_sandboxvolume_id', NULLIF(mount->>'source_sandboxvolume_id', ''),
+                    'snapshot_id', NULLIF(mount->>'snapshot_id', '')
+                ))
+            ))
+            FROM jsonb_array_elements(restore_mounts) AS mount
+        ), '[]'::jsonb)
+    ),
+    provenance = jsonb_build_object(
+        'type', 'sandbox_service',
+        'sandbox_service', jsonb_build_object(
+            'sandbox_id', source_sandbox_id,
+            'service_id', source_service_id,
+            'template_id', source_template_id
+        )
+    )
+WHERE revision_spec IS NULL;
+
+ALTER TABLE functions_revisions
+    ALTER COLUMN revision_spec SET NOT NULL;
+
+-- +goose Down
+ALTER TABLE functions_revisions
+    DROP CONSTRAINT IF EXISTS functions_revisions_source_type_check;
+
+ALTER TABLE functions_revisions
+    DROP COLUMN IF EXISTS provenance,
+    DROP COLUMN IF EXISTS revision_spec,
+    DROP COLUMN IF EXISTS source_type;

--- a/tests/e2e/utils/function.go
+++ b/tests/e2e/utils/function.go
@@ -15,8 +15,8 @@ func (s *Session) CreateFunctionFromSandbox(ctx context.Context, t ContractT, sa
 	req := apispec.FunctionCreateRequest{
 		Name: &name,
 		Source: apispec.FunctionSourceRequest{
-			SandboxId: sandboxID,
-			ServiceId: serviceID,
+			SandboxId: &sandboxID,
+			ServiceId: &serviceID,
 		},
 	}
 	status, body, err := s.doJSONSpecRequest(t, ctx, http.MethodPost, specPath, requestPath, req, true)


### PR DESCRIPTION
## What changed

- Adds FunctionRevisionSpec as the immutable execution contract for function revisions.
- Compiles sandbox-service publish requests into revision specs while retaining compatibility mirrors for source sandbox/service fields.
- Lets Function Gateway claim runtime template and mounts from the revision spec, with legacy fallback for migrated rows.
- Extends OpenAPI and generated apispec types for revision_spec/source_type, plus a gateway migration and tests.
- Hardens quick-check against Go VCS stamping failures and updates e2e helpers for the generated optional source fields.

## Why

Sandbox service publish should be a shortcut, not the underlying Function model. This sets up the shared deployment contract needed for future artifact-backed revisions and revision-level traffic control.

## Follow-up PRs

- sdk-go: https://github.com/sandbox0-ai/sdk-go/pull/38
- sdk-js: https://github.com/sandbox0-ai/sdk-js/pull/32
- sdk-py: https://github.com/sandbox0-ai/sdk-py/pull/31
- s0 CLI: https://github.com/sandbox0-ai/s0/pull/51

## Validation

- go test ./pkg/gateway/functions ./pkg/gateway/functionapi ./function-gateway/pkg/http ./pkg/apispec
- go test ./pkg/gateway/...
- go test ./function-gateway/...
- make proto && go test ./pkg/...
- make proto manifests apispec
- go mod tidy && git diff --exit-code -- go.mod go.sum
- helm lint infra-operator/chart
- GOFLAGS=-buildvcs=false golangci-lint run ./...
- GOTOOLCHAIN=go1.25.0+auto go test -buildvcs=false -race -count=1 ./function-gateway/pkg/http
- git diff --check
