### PR TITLE
document function revision specs

### DIFF
--- a/docs/function/page.mdx
+++ b/docs/function/page.mdx
@@ -1,18 +1,19 @@
 # Functions
 
-Sandbox0 Functions publish a Sandbox Service behind a stable function domain. A function keeps its identity, slug, and host across revisions, so callers can keep using the same URL while you publish new sandbox-backed code.
+Sandbox0 Functions serve immutable revisions behind a stable function domain. A function keeps its identity, slug, and host across revisions, so callers can keep using the same URL while you publish new sandbox-backed code.
 
 <Callout variant="info">
-Functions are created from Sandbox Services, not from uploaded ZIP files or container images. Publish starts from a `sandbox_id` and `service_id`; Sandbox0 snapshots the service configuration and restore mounts into an immutable revision.
+The canonical revision contract is `FunctionRevisionSpec`: the template used to claim runtime sandboxes, the runtime service to start, and the mounts or assets attached to that runtime. Publishing from a Sandbox Service is a shortcut; `sandbox_id` and `service_id` are compiled into the same immutable revision spec.
 </Callout>
 
 ## Model
 
 | Object | Description |
 |--------|-------------|
-| Sandbox Service | A named port, ingress routes, and restartable runtime inside a sandbox |
+| Sandbox Service | A named port, ingress routes, and restartable runtime inside a sandbox; it can be used as a publishing shortcut |
+| FunctionRevisionSpec | Immutable execution contract for a revision, including `template_id`, `runtime_service`, mounts, static assets, and environment references |
 | Function | Stable function identity, slug, and host under the configured function domain |
-| Revision | Immutable snapshot of the source service plus the SandboxVolume restore mounts needed to restore it |
+| Revision | Immutable stored spec plus source and provenance metadata |
 | Alias | Mutable pointer from a name such as `production` to a revision |
 | Runtime | Restored sandbox and process context currently serving a function revision |
 
@@ -22,7 +23,7 @@ The `production` alias is the serving pointer used by the function host. Creatin
 
 Function traffic is handled by `function-gateway`. The gateway resolves the host to a function, loads the `production` revision, enforces the revision's service route policy, then proxies through the owning `cluster-gateway` to the runtime sandbox service port. `function-gateway` is regional and does not rely on direct access to cluster-internal sandbox IPs.
 
-Function serving is revision-first. The gateway does not proxy production traffic to the mutable source sandbox. When no reusable runtime exists, the gateway claims a new runtime sandbox from the revision's template, mounts the revision-owned volumes, starts the service runtime command or binds to the referenced warm process, and reuses runtime instances for later requests. The runtime pool scales out up to the function's `max_active` setting when local in-flight requests reach the soft `target_concurrency` target. Changes made to the source sandbox after publishing require a new revision before they affect the function host.
+Function serving is revision-first. The gateway does not proxy production traffic to the mutable source sandbox. When no reusable runtime exists, the gateway claims a new runtime sandbox from the revision spec's template, attaches the revision mounts, starts the runtime service command or binds to the referenced warm process, and reuses runtime instances for later requests. The runtime pool scales out up to the function's `max_active` setting when local in-flight requests reach the soft `target_concurrency` target. Changes made to a source sandbox after publishing require a new revision before they affect the function host.
 
 ## Public Ingress Security
 
@@ -34,7 +35,7 @@ Inbound route policy controls how callers enter the Function. Outbound calls mad
 
 ## Publishable Services
 
-Only publishable Sandbox Services can become function revisions. A service is publishable when it is public and has a restartable runtime:
+When you publish through the Sandbox Service shortcut, only publishable services can become function revisions. A service is publishable when it is public and has a restartable runtime:
 
 | Blocker | Meaning |
 |---------|---------|
@@ -46,13 +47,13 @@ Only publishable Sandbox Services can become function revisions. A service is pu
 
 For Functions, a `warm_process` runtime must reference an existing `cmd` warm process alias or context ID. REPL warm processes are interactive execution contexts and cannot serve HTTP traffic.
 
-Use Sandbox Services route policy for path matching, allowed methods, bearer/header auth, CORS, rate limits, path rewrite, and upstream timeout. Functions reuse the same route model.
+Direct `revision_spec` publishing uses the same service schema in `runtime_service`, so the same route policy model controls path matching, allowed methods, bearer/header auth, CORS, rate limits, path rewrite, and upstream timeout.
 
 ## Next Steps
 
 <CardGroup>
   <Card title="Publish Functions" href="/docs/function/publish" cta="Continue">
-    Configure a publishable service and create a function from it.
+    Create a function from a publishable service shortcut or from a revision spec.
   </Card>
 
   <Card title="Revisions And Aliases" href="/docs/function/revisions" cta="Continue">

--- a/docs/function/publish/page.mdx
+++ b/docs/function/publish/page.mdx
@@ -1,6 +1,6 @@
 # Publish Functions
 
-Publish a Function by first configuring a Sandbox Service with public ingress and a restartable runtime, then creating a function from that service.
+Publish a Function from either a publishable Sandbox Service shortcut or an explicit `FunctionRevisionSpec`. Both paths create the stable function record, revision 1, and the `production` alias.
 
 ## Configure a Publishable Service
 
@@ -182,13 +182,13 @@ for (const service of services.services) {
   ]}
 />
 
-## Create a Function
+## Create From A Sandbox Service
 
 <Endpoint method="POST">
 /api/v1/functions
 </Endpoint>
 
-Creating a function creates the stable function record, revision 1, and the `production` alias. Autoscaling settings are optional; omitted values use the defaults documented in [Function Autoscaling](/docs/function/autoscaling).
+The Sandbox Service shortcut is the fastest path from a running sandbox to a function. Sandbox0 reads the source service, validates that it is publishable, captures the needed restore mounts, and stores the result as an immutable `FunctionRevisionSpec`. Autoscaling settings are optional; omitted values use the defaults documented in [Function Autoscaling](/docs/function/autoscaling).
 
 <Tabs
   tabs={[
@@ -255,6 +255,190 @@ console.log('function URL:', result.function.url);`
     }
   ]}
 />
+
+## Create From A Revision Spec
+
+Use `revision_spec` when a deployment system already has the template, runtime service, and mount contract it wants to publish. The same service validation applies to `runtime_service`: it must expose public ingress and use a restartable runtime.
+
+<Tabs
+  tabs={[
+    {
+      label: "API",
+      language: "json",
+      code: `{
+    "name": "my-api",
+    "source": {
+        "type": "revision_spec",
+        "revision_spec": {
+            "template_id": "default",
+            "runtime_service": {
+                "id": "api",
+                "port": 8080,
+                "runtime": {
+                    "type": "cmd",
+                    "command": ["python3", "-m", "http.server", "8080", "--bind", "0.0.0.0", "-d", "/workspace/public"],
+                    "cwd": "/workspace"
+                },
+                "ingress": {
+                    "public": true,
+                    "routes": [
+                        {
+                            "id": "api",
+                            "path_prefix": "/",
+                            "methods": ["GET"],
+                            "resume": true
+                        }
+                    ]
+                },
+                "health_check": {
+                    "path": "/"
+                }
+            }
+        }
+    }
+}`
+    },
+    {
+      label: "Go",
+      language: "go",
+      code: `spec := apispec.FunctionRevisionSpec{
+    TemplateID: "default",
+    RuntimeService: apispec.SandboxAppService{
+        ID:   "api",
+        Port: 8080,
+        Runtime: apispec.NewOptSandboxAppServiceRuntime(apispec.SandboxAppServiceRuntime{
+            Type:    apispec.SandboxAppServiceRuntimeTypeCmd,
+            Command: []string{"python3", "-m", "http.server", "8080", "--bind", "0.0.0.0", "-d", "/workspace/public"},
+            Cwd:     apispec.NewOptString("/workspace"),
+        }),
+        Ingress: apispec.SandboxAppServiceIngress{
+            Public: true,
+            Routes: []apispec.SandboxAppServiceRoute{
+                {
+                    ID:         "api",
+                    PathPrefix: apispec.NewOptString("/"),
+                    Methods:    []string{"GET"},
+                    Resume:     true,
+                },
+            },
+        },
+        HealthCheck: apispec.NewOptSandboxAppServiceHealth(apispec.SandboxAppServiceHealth{
+            Path: apispec.NewOptString("/"),
+        }),
+    },
+}
+
+result, err := client.CreateFunctionFromRevisionSpec(
+    ctx,
+    spec,
+    sandbox0.WithFunctionName("my-api"),
+)
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Printf("function URL: %s\\n", result.Function.URL)`
+    },
+    {
+      label: "Python",
+      language: "python",
+      code: `from sandbox0.apispec.models.function_revision_spec import FunctionRevisionSpec
+from sandbox0.apispec.models.sandbox_app_service import SandboxAppService
+from sandbox0.apispec.models.sandbox_app_service_health import SandboxAppServiceHealth
+from sandbox0.apispec.models.sandbox_app_service_ingress import SandboxAppServiceIngress
+from sandbox0.apispec.models.sandbox_app_service_route import SandboxAppServiceRoute
+from sandbox0.apispec.models.sandbox_app_service_runtime import SandboxAppServiceRuntime
+from sandbox0.apispec.models.sandbox_app_service_runtime_type import SandboxAppServiceRuntimeType
+
+spec = FunctionRevisionSpec(
+    template_id="default",
+    runtime_service=SandboxAppService(
+        id="api",
+        port=8080,
+        runtime=SandboxAppServiceRuntime(
+            type_=SandboxAppServiceRuntimeType.CMD,
+            command=["python3", "-m", "http.server", "8080", "--bind", "0.0.0.0", "-d", "/workspace/public"],
+            cwd="/workspace",
+        ),
+        ingress=SandboxAppServiceIngress(
+            public=True,
+            routes=[
+                SandboxAppServiceRoute(
+                    id="api",
+                    path_prefix="/",
+                    methods=["GET"],
+                    resume=True,
+                ),
+            ],
+        ),
+        health_check=SandboxAppServiceHealth(path="/"),
+    ),
+)
+
+result = client.functions.create_from_revision_spec(spec, name="my-api")
+print(f"function URL: {result.function.url}")`
+    },
+    {
+      label: "TypeScript",
+      language: "typescript",
+      code: `const spec = {
+    templateId: 'default',
+    runtimeService: {
+        id: 'api',
+        port: 8080,
+        runtime: {
+            type: 'cmd',
+            command: ['python3', '-m', 'http.server', '8080', '--bind', '0.0.0.0', '-d', '/workspace/public'],
+            cwd: '/workspace',
+        },
+        ingress: {
+            _public: true,
+            routes: [
+                {
+                    id: 'api',
+                    pathPrefix: '/',
+                    methods: ['GET'],
+                    resume: true,
+                },
+            ],
+        },
+        healthCheck: { path: '/' },
+    },
+};
+
+const result = await client.functions.createFromRevisionSpec(spec, {
+    name: 'my-api',
+});
+console.log('function URL:', result.function.url);`
+    },
+    {
+      label: "CLI",
+      language: "bash",
+      code: `cat > function-spec.yaml <<EOF
+template_id: default
+runtime_service:
+  id: api
+  port: 8080
+  runtime:
+    type: cmd
+    command: ["python3", "-m", "http.server", "8080", "--bind", "0.0.0.0", "-d", "/workspace/public"]
+    cwd: /workspace
+  ingress:
+    public: true
+    routes:
+      - id: api
+        path_prefix: /
+        methods: [GET]
+        resume: true
+  health_check:
+    path: /
+EOF
+
+s0 function create --spec-file function-spec.yaml --name my-api`
+    }
+  ]}
+/>
+
+The response revision includes `source_type: "revision_spec"` and the stored `revision_spec`. Functions created from `sandbox_id` and `service_id` include `source_type: "sandbox_service"` and compatibility mirrors such as `source_sandbox_id` and `source_service_id`.
 
 ## Invoke the Function
 

--- a/docs/function/revisions/page.mdx
+++ b/docs/function/revisions/page.mdx
@@ -1,6 +1,6 @@
 # Revisions And Aliases
 
-Function revisions are immutable snapshots of a Sandbox Service. Aliases are mutable pointers to revisions. The function host serves the revision pointed to by the `production` alias.
+Function revisions are immutable execution specs. A revision can come from a publishable Sandbox Service shortcut or from an explicit `FunctionRevisionSpec`. Aliases are mutable pointers to revisions, and the function host serves the revision pointed to by the `production` alias.
 
 ## Create a Revision
 
@@ -8,7 +8,7 @@ Function revisions are immutable snapshots of a Sandbox Service. Aliases are mut
 /api/v1/functions/{'{id}'}/revisions
 </Endpoint>
 
-Create a revision from the same service or from another publishable service. Set `promote` to `false` when you want to inspect the revision before moving production traffic.
+Create a revision from the same service, another publishable service, or a revision spec. Set `promote` to `false` when you want to inspect the revision before moving production traffic.
 
 <Tabs
   tabs={[
@@ -57,6 +57,56 @@ console.log('revision:', result.revision.revisionNumber, 'promoted=', result.pro
   ]}
 />
 
+## Create A Revision From A Spec
+
+Use the same `FunctionRevisionSpec` shape shown in [Publish Functions](/docs/function/publish#create-from-a-revision-spec). This path is useful when a deployment system already owns the template, runtime service, and mount contract.
+
+<Tabs
+  tabs={[
+    {
+      label: "Go",
+      language: "go",
+      code: `result, err := client.CreateFunctionRevisionFromSpec(
+    ctx,
+    functionID,
+    spec,
+    sandbox0.WithFunctionRevisionPromote(false),
+)
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Printf("revision: %d promoted=%t\\n", result.Revision.RevisionNumber, result.Promoted)`
+    },
+    {
+      label: "Python",
+      language: "python",
+      code: `result = client.functions.create_revision_from_spec(
+    function_id,
+    spec,
+    promote=False,
+)
+print(f"revision: {result.revision.revision_number} promoted={result.promoted}")`
+    },
+    {
+      label: "TypeScript",
+      language: "typescript",
+      code: `const result = await client.functions.createRevisionFromSpec(
+    functionId,
+    spec,
+    { promote: false },
+);
+console.log('revision:', result.revision.revisionNumber, 'promoted=', result.promoted);`
+    },
+    {
+      label: "CLI",
+      language: "bash",
+      code: `s0 function revision create fn_abc123 \\
+    --spec-file function-spec.yaml \\
+    --promote=false`
+    }
+  ]}
+/>
+
 ## List Revisions
 
 <Endpoint method="GET">
@@ -73,7 +123,13 @@ if err != nil {
     log.Fatal(err)
 }
 for _, revision := range revisions {
-    fmt.Printf("revision %d from %s/%s\\n", revision.RevisionNumber, revision.SourceSandboxID, revision.SourceServiceID)
+    fmt.Printf(
+        "revision %d source=%s template=%s service=%s\\n",
+        revision.RevisionNumber,
+        revision.SourceType,
+        revision.RevisionSpec.TemplateID,
+        revision.RevisionSpec.RuntimeService.ID,
+    )
 }`
     },
     {
@@ -81,14 +137,28 @@ for _, revision := range revisions {
       language: "python",
       code: `revisions = client.functions.list_revisions(function_id)
 for revision in revisions:
-    print(f"revision {revision.revision_number} from {revision.source_sandbox_id}/{revision.source_service_id}")`
+    print(
+        f"revision {revision.revision_number} "
+        f"source={revision.source_type} "
+        f"template={revision.revision_spec.template_id} "
+        f"service={revision.revision_spec.runtime_service.id}"
+    )`
     },
     {
       label: "TypeScript",
       language: "typescript",
       code: `const revisions = await client.functions.listRevisions(functionId);
 for (const revision of revisions) {
-    console.log(\`revision \${revision.revisionNumber} from \${revision.sourceSandboxId}/\${revision.sourceServiceId}\`);
+    console.log(
+        'revision',
+        revision.revisionNumber,
+        'source=',
+        revision.sourceType,
+        'template=',
+        revision.revisionSpec.templateId,
+        'service=',
+        revision.revisionSpec.runtimeService.id,
+    );
 }`
     },
     {

--- a/docs/function/runtime/page.mdx
+++ b/docs/function/runtime/page.mdx
@@ -1,6 +1,6 @@
 # Function Runtime
 
-Function runtime state describes the restored sandbox pool serving a function revision. Function Gateway serves production traffic from revision runtime sandboxes, not from the mutable source sandbox. When no reusable runtime exists, Function Gateway restores a runtime sandbox from the revision's template and revision-owned volumes.
+Function runtime state describes the restored sandbox pool serving a function revision. Function Gateway serves production traffic from revision runtime sandboxes, not from a mutable source sandbox. When no reusable runtime exists, Function Gateway restores a runtime sandbox from the revision spec's template and mounts.
 
 Runtime pool size and scale-out behavior are configured on the function's autoscaling policy. See [Function Autoscaling](/docs/function/autoscaling) for defaults, limits, and update examples.
 

--- a/docs/sandbox/services/page.mdx
+++ b/docs/sandbox/services/page.mdx
@@ -2,7 +2,7 @@
 
 Sandbox Services expose named ports inside a sandbox. Use them when a sandbox needs public HTTP routes with method filtering, auth, CORS, rate limits, upstream timeout, path rewrite, and route-level resume behavior.
 
-Services are also the source model for Sandbox0 Functions. A publishable service is public and has a restartable runtime.
+Services are also the shortcut source model for Sandbox0 Functions. A publishable service is public and has a restartable runtime; publishing it compiles the service into the `FunctionRevisionSpec` used at serve time.
 
 ## Service Model
 

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -1661,8 +1661,8 @@ paths:
                 $ref: "#/components/schemas/SuccessFunctionListResponse"
     post:
       tags: [functions]
-      summary: Create a function from a sandbox service
-      description: Creates a function, revision 1, and the production alias from an existing sandbox service.
+      summary: Create a function
+      description: Creates a function, revision 1, and the production alias from a sandbox-service shortcut or an explicit FunctionRevisionSpec.
       security:
         - bearerAuth: []
       requestBody:
@@ -1679,7 +1679,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/SuccessFunctionCreateResponse"
         "400":
-          description: Source service is invalid or not publishable
+          description: Function source is invalid or not publishable
           content:
             application/json:
               schema:
@@ -1791,7 +1791,8 @@ paths:
                 $ref: "#/components/schemas/SuccessFunctionRevisionListResponse"
     post:
       tags: [functions]
-      summary: Create function revision from a sandbox service
+      summary: Create function revision
+      description: Creates a function revision from a sandbox-service shortcut or an explicit FunctionRevisionSpec.
       security:
         - bearerAuth: []
       parameters:


### PR DESCRIPTION
## Summary
- Update Function docs to describe FunctionRevisionSpec as the canonical revision contract and Sandbox Service publishing as a shortcut
- Add revision_spec create examples for API, Go, Python, TypeScript, and s0 CLI --spec-file
- Update revision listing examples and OpenAPI operation descriptions so they no longer imply Sandbox Service is the only source

## Why
PR #353 added the function revision spec model, but the docs still described Function publishing as sandbox-service-only.

## Validation
- make apispec
- GOWORK=off go test ./pkg/apispec/...
- git diff --check