### PR TITLE
Rename agent engine docs to agent harnesses

### DIFF
--- a/docs/managed-agents/agent-harnesses/page.mdx
+++ b/docs/managed-agents/agent-harnesses/page.mdx
@@ -1,8 +1,8 @@
-# Agent Engines
+# Agent Harnesses
 
-An agent engine is the Sandbox0 runtime adapter behind a Managed Agents session.
+An agent harness is the Sandbox0 runtime adapter behind a Managed Agents session.
 
-The public API still uses the Claude Managed Agents object model. The engine decides where the agent loop runs, which model API shape it expects, how credentials are projected, and how tool events are mapped back to the Managed Agents event stream.
+The public API still uses the Claude Managed Agents object model. The harness decides where the agent loop runs, which model API shape it expects, how credentials are projected, and how tool events are mapped back to the Managed Agents event stream.
 
 Official references:
 
@@ -13,18 +13,18 @@ Official references:
 
 Sandbox0 supports two execution models.
 
-| Model | How it works | Engines |
+| Model | How it works | Harnesses |
 |-------|--------------|---------|
-| Agent in sandbox | The agent runtime process runs inside the per-session Sandbox0 sandbox. The sandbox contains the agent process, workspace, tools, and engine state. | `claude`, `codex` |
+| Agent in sandbox | The agent runtime process runs inside the per-session Sandbox0 sandbox. The sandbox contains the agent process, workspace, tools, and harness state. | `claude`, `codex` |
 | Sandbox as tool | A resident runtime service runs the agent loop outside the sandbox. The sandbox is claimed lazily and exposed to the agent as tools such as `bash`. | `openai-agents` |
 
 Use agent in sandbox when you want the agent process itself to live with the workspace. This is the most direct fit for coding agents that expect local files, shell commands, home-directory state, and long-lived process state inside the sandbox.
 
 Use sandbox as tool when you want to embed an agent into a product workflow or control plane. The agent harness stays in a managed runtime service, while Sandbox0 provides isolated tool execution only when the agent needs to inspect files or run commands.
 
-## Supported Engines
+## Supported Harnesses
 
-| Engine | Execution model | Runtime adapter | Model API shape | Best fit |
+| Harness | Execution model | Runtime adapter | Model API shape | Best fit |
 |--------|-----------------|-----------------|-----------------|----------|
 | `claude` | Agent in sandbox | Claude Agent SDK wrapper | Anthropic-compatible | Claude Code style coding agents and Anthropic-compatible providers |
 | `codex` | Agent in sandbox | Codex app-server wrapper | OpenAI-compatible | Codex app-server sessions that should keep Codex state inside the workspace |
@@ -32,9 +32,9 @@ Use sandbox as tool when you want to embed an agent into a product workflow or c
 
 ## Retry Behavior
 
-All supported engines report observable automatic retry attempts through the same Managed Agents events: `session.error` with `error.retry_status.type = "retrying"`, `session.status_rescheduled`, then `session.status_running` if the run resumes.
+All supported harnesses report observable automatic retry attempts through the same Managed Agents events: `session.error` with `error.retry_status.type = "retrying"`, `session.status_rescheduled`, then `session.status_running` if the run resumes.
 
-| Engine | Retry signal used by Sandbox0 |
+| Harness | Retry signal used by Sandbox0 |
 |--------|-------------------------------|
 | `claude` | Claude Agent SDK `system` messages with `subtype = "api_retry"` |
 | `codex` | Codex app-server `error` notifications with `willRetry = true` |
@@ -42,9 +42,9 @@ All supported engines report observable automatic retry attempts through the sam
 
 Sandbox0 disables hidden OpenAI Python client retries for the `openai-agents` runtime and routes model retries through the OpenAI Agents SDK retry policy so retry state is visible in the session event stream.
 
-## Select An Engine
+## Select A Harness
 
-The session engine is selected by the attached LLM vault:
+The session harness is selected by the attached LLM vault. The metadata key remains `sandbox0.managed_agents.engine` for compatibility:
 
 ```typescript
 const claudeVault = await client.beta.vaults.create({
@@ -95,7 +95,7 @@ await client.beta.vaults.credentials.create(openAIAgentsVault.id, {
 });
 ```
 
-Use the vault id for the engine you want. LLM credentials must be unbound `static_bearer` credentials; do not set `mcp_server_url` for the model provider token.
+Use the vault id for the harness you want. LLM credentials must be unbound `static_bearer` credentials; do not set `mcp_server_url` for the model provider token.
 
 Attach exactly one LLM vault to the session:
 
@@ -107,29 +107,29 @@ const session = await client.beta.sessions.create({
 });
 ```
 
-If no LLM vault selects an engine, Sandbox0 defaults to `claude`.
+If no LLM vault selects a harness, Sandbox0 defaults to `claude`.
 
 ## AI Gateway Integration
 
-Managed Agents does not require Sandbox0 to own model-provider routing. You can put a third-party AI gateway between the selected agent engine and the model provider when you need protocol normalization, request logs, caching, retry policy, rate limits, budget controls, or bring-your-own-key storage.
+Managed Agents does not require Sandbox0 to own model-provider routing. You can put a third-party AI gateway between the selected agent harness and the model provider when you need protocol normalization, request logs, caching, retry policy, rate limits, budget controls, or bring-your-own-key storage.
 
-Choose the gateway endpoint that matches the selected engine:
+Choose the gateway endpoint that matches the selected harness:
 
-| Engine | Gateway endpoint must expose |
+| Harness | Gateway endpoint must expose |
 |--------|------------------------------|
 | `claude` | Anthropic Messages-compatible API |
 | `codex` | OpenAI-compatible API |
 | `openai-agents` | OpenAI Responses-compatible API |
 
-If you only need to bridge a Claude Code-compatible provider into an OpenAI-style engine, LLMProxy is the simplest option. The hosted tool does not require a Sandbox0 account, an LLMProxy login, or gateway-side setup. Use the LLMProxy URL as the LLM vault base URL, keep the upstream provider token in the vault credential, and let the selected runtime call it directly.
+If you only need to bridge a Claude Code-compatible provider into an OpenAI-style harness, LLMProxy is the simplest option. The hosted tool does not require a Sandbox0 account, an LLMProxy login, or gateway-side setup. Use the LLMProxy URL as the LLM vault base URL, keep the upstream provider token in the vault credential, and let the selected runtime call it directly.
 
 <CardGroup>
   <Card title="LLMProxy" href="/docs/managed-agents/llmproxy" cta="Open docs">
-    Use the free no-login protocol bridge for Claude-compatible providers and OpenAI-style engines.
+    Use the free no-login protocol bridge for Claude-compatible providers and OpenAI-style harnesses.
   </Card>
 </CardGroup>
 
-The gateway can route to whichever upstream providers it supports. For example, Cloudflare AI Gateway, LiteLLM Proxy, Portkey, Helicone, Kong AI Gateway, Envoy AI Gateway, TrueFoundry, and similar products can sit behind an LLM vault as long as the configured gateway endpoint speaks the API shape required by the engine.
+The gateway can route to whichever upstream providers it supports. For example, Cloudflare AI Gateway, LiteLLM Proxy, Portkey, Helicone, Kong AI Gateway, Envoy AI Gateway, TrueFoundry, and similar products can sit behind an LLM vault as long as the configured gateway endpoint speaks the API shape required by the harness.
 
 In this setup, the LLM vault stores the gateway base URL and the gateway API token. Provider keys should usually live in the AI gateway through BYOK, virtual keys, or gateway-managed billing. Sandbox0 still owns the Managed Agents API, session truth, sandbox lifecycle, workspace state, network policy, and runtime credential projection.
 
@@ -157,36 +157,36 @@ await client.beta.vaults.credentials.create(cloudflareGatewayVault.id, {
 Configure the agent model to the gateway's model identifier, such as `anthropic/claude-sonnet-4` on Cloudflare AI Gateway or the model alias configured in LiteLLM, Portkey, or another gateway.
 
 <Callout variant="warning">
-Do not point an engine at a gateway endpoint with the wrong API shape. For example, the `openai-agents` engine needs an OpenAI Responses-compatible endpoint even if the gateway routes the request to an Anthropic model upstream.
+Do not point a harness at a gateway endpoint with the wrong API shape. For example, the `openai-agents` harness needs an OpenAI Responses-compatible endpoint even if the gateway routes the request to an Anthropic model upstream.
 </Callout>
 
-## Claude Engine
+## Claude Harness
 
-The Claude engine runs the Claude Agent SDK wrapper inside the session sandbox. It expects an Anthropic-compatible API. Use it when the provider already exposes the Anthropic Messages API shape and you want Claude Code style behavior.
+The Claude harness runs the Claude Agent SDK wrapper inside the session sandbox. It expects an Anthropic-compatible API. Use it when the provider already exposes the Anthropic Messages API shape and you want Claude Code style behavior.
 
 Sandbox0 sets compatibility environment values such as `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, and `ANTHROPIC_BASE_URL`, then injects the real credential through egress auth for the configured LLM host.
 
-## Codex Engine
+## Codex Harness
 
-The Codex engine launches Codex app-server inside the session sandbox. It expects an OpenAI-compatible model endpoint. Sandbox0 stores Codex home and thread state under the session workspace so runtime state stays session-scoped.
+The Codex harness launches Codex app-server inside the session sandbox. It expects an OpenAI-compatible model endpoint. Sandbox0 stores Codex home and thread state under the session workspace so runtime state stays session-scoped.
 
 For Minimax-compatible endpoints, Sandbox0 detects the provider from the LLM base URL and configures Codex provider settings accordingly.
 
-## OpenAI Agents Engine
+## OpenAI Agents Harness
 
-The `openai-agents` engine uses a resident Python runtime service built on the official OpenAI Agents SDK. The runtime receives the session snapshot from the Managed Agents gateway, runs the agent loop in the runtime service, and claims a Sandbox0 sandbox only when the agent needs sandbox tools.
+The `openai-agents` harness uses a resident Python runtime service built on the official OpenAI Agents SDK. The runtime receives the session snapshot from the Managed Agents gateway, runs the agent loop in the runtime service, and claims a Sandbox0 sandbox only when the agent needs sandbox tools.
 
 This is the sandbox as tool model. The session still has durable Managed Agents event history, but the agent process is not the same process as the sandbox. The sandbox is an isolated tool target for commands and workspace work.
 
-The engine expects an OpenAI Responses-compatible endpoint. If the target provider does not expose that API shape directly, use an AI gateway that provides an OpenAI Responses-compatible surface and routes to the provider upstream.
+The harness expects an OpenAI Responses-compatible endpoint. If the target provider does not expose that API shape directly, use an AI gateway that provides an OpenAI Responses-compatible surface and routes to the provider upstream.
 
 <Callout variant="info">
 For self-hosted deployments, configure the OpenAI Agents runtime callback base URL to an internal gateway URL when possible. The runtime sends session events back to the Managed Agents gateway; routing that callback through a public edge can introduce avoidable policy and timeout failures.
 </Callout>
 
-## Engine Configuration
+## Harness Configuration
 
-Agent engine behavior can be configured by deployment defaults and internal engine config. Application-level engine selection should normally happen through the LLM vault, not by putting reserved Sandbox0 keys into session metadata.
+Agent harness behavior can be configured by deployment defaults and internal harness config. Application-level harness selection should normally happen through the LLM vault, not by putting reserved Sandbox0 keys into session metadata.
 
 <Callout variant="warning">
 Do not use `sandbox0.managed_agents.engine` as session metadata. Reserved `sandbox0.managed_agents.*` keys are only supported on vault metadata today.
@@ -196,7 +196,7 @@ Do not use `sandbox0.managed_agents.engine` as session metadata. Reserved `sandb
 
 <CardGroup>
   <Card title="Vaults" href="/docs/managed-agents/vaults" cta="Continue">
-    Store the selected engine, model gateway URL, and credential material.
+    Store the selected harness, model gateway URL, and credential material.
   </Card>
 
   <Card title="Compatibility" href="/docs/managed-agents/compatibility" cta="Continue">

--- a/docs/managed-agents/agents/page.mdx
+++ b/docs/managed-agents/agents/page.mdx
@@ -47,7 +47,7 @@ const agent = await client.beta.agents.create({
 
 | Tool type | Status in Sandbox0 |
 |-----------|--------------------|
-| `agent_toolset_20260401` | Supported through the selected agent engine |
+| `agent_toolset_20260401` | Supported through the selected agent harness |
 | `mcp_toolset` | Supported for URL MCP servers |
 | `custom` | Supported through `agent.custom_tool_use` and `user.custom_tool_result` events |
 
@@ -76,7 +76,7 @@ If the MCP server needs credentials, attach a vault to the session. The agent de
 ## Sandbox0 Notes
 
 - Reserved `sandbox0.managed_agents.*` metadata keys are not accepted on agents.
-- The agent model defaults to the Claude engine unless a session attaches an LLM vault that selects another supported engine.
+- The agent model defaults to the Claude harness unless a session attaches an LLM vault that selects another supported harness.
 - The agent object is copied into the session snapshot. Later agent updates do not mutate existing sessions.
 
 ## Next Steps

--- a/docs/managed-agents/compatibility/page.mdx
+++ b/docs/managed-agents/compatibility/page.mdx
@@ -19,8 +19,8 @@ Official reference: [Claude Managed Agents quickstart](https://platform.claude.c
 | Custom skills | Supported through uploaded skill versions |
 | MCP servers | Supported for URL MCP servers and vault-backed credentials |
 | GitHub repository resources | Supported at session creation |
-| Agent engines | Supported for `claude`, `codex`, and `openai-agents` |
-| External AI gateways | Supported when the gateway exposes the API shape required by the selected agent engine |
+| Agent harnesses | Supported for `claude`, `codex`, and `openai-agents` |
+| External AI gateways | Supported when the gateway exposes the API shape required by the selected agent harness |
 
 ## Current Differences
 
@@ -29,12 +29,12 @@ Official reference: [Claude Managed Agents quickstart](https://platform.claude.c
 | SDK ownership | Sandbox0 does not ship a Managed Agents SDK. Use the official Anthropic SDK. |
 | API token | SDK `apiKey` is a Sandbox0 API key, not the Anthropic LLM token. |
 | LLM token | Stored in an LLM vault and projected by Sandbox0 credential policy. |
-| Agent engine | Selected by `sandbox0.managed_agents.engine` on the LLM vault. |
+| Agent harness | Selected by the compatibility key `sandbox0.managed_agents.engine` on the LLM vault. |
 | Sandbox claim | Runtime setup claims or resumes a Sandbox0 sandbox and mounts a persistent workspace volume. |
-| Claude engine | Requires an Anthropic-compatible endpoint. |
-| Codex engine | Requires an OpenAI-compatible endpoint. |
-| OpenAI Agents engine | Requires an OpenAI Responses-compatible endpoint and uses Sandbox0 as a tool target. |
-| Retry state | Automatic retries are exposed as `session.status_rescheduled` plus `retry_status.type = "retrying"` errors when the selected engine provides a retry signal. |
+| Claude harness | Requires an Anthropic-compatible endpoint. |
+| Codex harness | Requires an OpenAI-compatible endpoint. |
+| OpenAI Agents harness | Requires an OpenAI Responses-compatible endpoint and uses Sandbox0 as a tool target. |
+| Retry state | Automatic retries are exposed as `session.status_rescheduled` plus `retry_status.type = "retrying"` errors when the selected harness provides a retry signal. |
 | External AI gateway | Optional. Use one when provider API shape, provider credentials, logging, caching, or rate limits should be managed outside Sandbox0. |
 | Anthropic pre-built skills | Not supported. Use Sandbox0 custom skills. |
 | Multi-agent threads | Not implemented in the current backend surface. |
@@ -47,7 +47,7 @@ The Claude wrapper maps Managed Agents tool definitions to Claude Agent SDK opti
 
 | Tool type | Status | Notes |
 |-----------|--------|-------|
-| `agent_toolset_20260401` | Supported | Enables built-in tools such as bash, file operations, grep/glob, web fetch, and web search through the selected engine wrapper |
+| `agent_toolset_20260401` | Supported | Enables built-in tools such as bash, file operations, grep/glob, web fetch, and web search through the selected harness wrapper |
 | `mcp_toolset` | Supported | Requires matching `mcp_servers` entries and vault credentials when the server needs auth |
 | Custom tools | Supported | The wrapper emits `agent.custom_tool_use` and waits for `user.custom_tool_result` |
 

--- a/docs/managed-agents/events/page.mdx
+++ b/docs/managed-agents/events/page.mdx
@@ -53,7 +53,7 @@ for await (const event of stream) {
 | `user.tool_confirmation` | Allow or deny a tool that requires confirmation |
 | `user.custom_tool_result` | Result for a custom tool call |
 | `session.status_running` | A run is active |
-| `session.status_rescheduled` | The active run is waiting for an automatic engine retry after a retriable error |
+| `session.status_rescheduled` | The active run is waiting for an automatic harness retry after a retriable error |
 | `session.status_idle` | The turn ended or the agent requires action |
 | `session.error` | Session-level error |
 
@@ -65,7 +65,7 @@ Sandbox0 exposes automatic model retries through the normal event stream:
 
 | Sequence | Meaning |
 |----------|---------|
-| `session.error` with `error.retry_status.type = "retrying"` | The engine observed a retriable model or transport error and will retry the same run automatically |
+| `session.error` with `error.retry_status.type = "retrying"` | The harness observed a retriable model or transport error and will retry the same run automatically |
 | `session.status_rescheduled` | The session is in the transient `rescheduling` state while the retry is pending |
 | `session.status_running` | The same run resumed and is producing output or completion events again |
 | `session.status_idle` with `stop_reason.type = "retries_exhausted"` | The retry budget was exhausted and the turn ended without success |
@@ -106,7 +106,7 @@ await client.beta.sessions.events.send(session.id, {
     Store model and external service credentials outside agent code.
   </Card>
 
-  <Card title="Agent Engines" href="/docs/managed-agents/agent-engines" cta="Continue">
+  <Card title="Agent Harnesses" href="/docs/managed-agents/agent-harnesses" cta="Continue">
     Choose the runtime adapter that should execute each managed session.
   </Card>
 </CardGroup>

--- a/docs/managed-agents/llmproxy/page.mdx
+++ b/docs/managed-agents/llmproxy/page.mdx
@@ -1,6 +1,6 @@
 # LLMProxy
 
-LLMProxy is a free protocol bridge for model providers. It is useful when the agent engine expects an OpenAI-style API shape, but the model provider exposes a Claude Code-compatible or Anthropic Messages-compatible API shape.
+LLMProxy is a free protocol bridge for model providers. It is useful when the agent harness expects an OpenAI-style API shape, but the model provider exposes a Claude Code-compatible or Anthropic Messages-compatible API shape.
 
 The hosted Sandbox0 LLMProxy is intentionally simple: no Sandbox0 account, no LLMProxy login, and no gateway configuration step. The upstream provider key is still required, but it should travel through normal request auth or a Sandbox0 LLM vault credential, not through the URL.
 
@@ -8,12 +8,12 @@ The hosted Sandbox0 LLMProxy is intentionally simple: no Sandbox0 account, no LL
 
 Use LLMProxy when:
 
-- The selected engine is `openai-agents`, `codex`, or another OpenAI-compatible runtime.
+- The selected harness is `openai-agents`, `codex`, or another OpenAI-compatible runtime.
 - The model provider exposes a Claude Code-compatible or Anthropic Messages-compatible endpoint.
 - You only need protocol translation and do not need request logs, caching, budgets, rate limits, or managed BYOK controls from a full AI gateway.
 - You want the fastest path: construct the URL, store it as the LLM base URL, and run the agent.
 
-Do not add LLMProxy just because a provider is non-OpenAI. If the selected engine is `claude` and the provider already exposes an Anthropic-compatible endpoint, point the LLM vault directly at that provider. If you need policy, observability, caching, or provider-key management outside Sandbox0, use an AI gateway instead.
+Do not add LLMProxy just because a provider is non-OpenAI. If the selected harness is `claude` and the provider already exposes an Anthropic-compatible endpoint, point the LLM vault directly at that provider. If you need policy, observability, caching, or provider-key management outside Sandbox0, use an AI gateway instead.
 
 ## URL Shape
 
@@ -66,7 +66,7 @@ flowchart LR
     proxy --> runtime
 ```
 
-The Managed Agents gateway does not call the model provider directly. It stores the vault credential and passes resolved engine configuration to the runtime. The runtime calls the LLM base URL for the selected engine.
+The Managed Agents gateway does not call the model provider directly. It stores the vault credential and passes resolved harness configuration to the runtime. The runtime calls the LLM base URL for the selected harness.
 
 ## Operational Notes
 
@@ -80,7 +80,7 @@ The Managed Agents gateway does not call the model provider directly. It stores 
 ## Next Steps
 
 <CardGroup>
-  <Card title="Agent Engines" href="/docs/managed-agents/agent-engines" cta="Continue">
+  <Card title="Agent Harnesses" href="/docs/managed-agents/agent-harnesses" cta="Continue">
     Choose the runtime adapter and model endpoint shape for each managed session.
   </Card>
 

--- a/docs/managed-agents/page.mdx
+++ b/docs/managed-agents/page.mdx
@@ -20,19 +20,19 @@ Managed Agents sit above raw sandboxes. A sandbox gives an agent processes, file
 | Events | Append-only interaction log for user input, agent output, tools, status, and errors |
 | Vault | Credential container attached to a session |
 | Resource | File or repository materialized into the session workspace |
-| Agent engine | Runtime adapter that runs the session as agent in sandbox or sandbox as tool |
+| Agent harness | Runtime adapter that runs the session as agent in sandbox or sandbox as tool |
 | AI gateway | Optional external gateway that normalizes model provider APIs, logs usage, enforces policy, or stores provider credentials |
 
-## Engine Models
+## Execution Models
 
 Managed Agents can execute in two ways:
 
-| Model | What users should expect | Engines |
+| Model | What users should expect | Harnesses |
 |-------|--------------------------|---------|
-| Agent in sandbox | The agent runtime process lives inside the per-session sandbox with the workspace and engine state. | `claude`, `codex` |
+| Agent in sandbox | The agent runtime process lives inside the per-session sandbox with the workspace and harness state. | `claude`, `codex` |
 | Sandbox as tool | A resident runtime service owns the agent loop and uses Sandbox0 as an isolated tool target. | `openai-agents` |
 
-Both models use the same Managed Agents API and durable event stream. Choose the model by selecting an agent engine through the LLM vault.
+Both models use the same Managed Agents API and durable event stream. Choose the model by selecting an agent harness through the LLM vault.
 
 ## Architecture
 
@@ -42,7 +42,7 @@ flowchart TD
     gateway --> pg[(PostgreSQL session and event truth)]
     gateway --> sandbox0[Sandbox0 API]
     sandbox0 --> runtime[Sandbox0 sandbox or tool sandbox]
-    gateway --> resident[resident runtime for sandbox-as-tool engines]
+    gateway --> resident[resident runtime for sandbox-as-tool harnesses]
     runtime --> wrapper[agent-in-sandbox wrapper]
     wrapper --> callbacks[Signed runtime callbacks]
     resident --> callbacks
@@ -60,11 +60,11 @@ Session truth lives outside the sandbox. The sandbox is an execution attachment 
 
 1. Create an `agent` with a model, system prompt, tools, and optional skills.
 2. Create an `environment` with package and network settings.
-3. Create an LLM vault with `sandbox0.managed_agents.role = llm` and the target agent engine.
+3. Create an LLM vault with `sandbox0.managed_agents.role = llm` and the target agent harness.
 4. Create a session that references the agent, environment, and vault ids.
 5. Send `user.message` events.
-6. Sandbox0 starts the selected agent engine. Agent-in-sandbox engines claim or resume a sandbox immediately; sandbox-as-tool engines claim a sandbox when a tool needs one.
-7. The engine emits callbacks. The gateway appends events to the durable session log.
+6. Sandbox0 starts the selected agent harness. Agent-in-sandbox harnesses claim or resume a sandbox immediately; sandbox-as-tool harnesses claim a sandbox when a tool needs one.
+7. The harness emits callbacks. The gateway appends events to the durable session log.
 8. The client lists or streams events until the session becomes idle, requires action, or terminates.
 
 ## Sandbox0-Specific Boundaries
@@ -74,7 +74,7 @@ The public object model follows Claude Managed Agents where practical. The backe
 - The API host is Sandbox0, not Anthropic.
 - The SDK `apiKey` is a Sandbox0 API key.
 - The LLM token is stored in a vault and projected by Sandbox0 credential policy.
-- The agent engine is selected through LLM vault metadata.
+- The agent harness is selected through LLM vault metadata.
 - `claude` and `codex` run agent in sandbox; `openai-agents` uses sandbox as tool.
 - The sandbox workspace is persistent across turns through a Sandbox0 volume.
 - Network policy and credential injection are enforced by Sandbox0.

--- a/docs/managed-agents/sessions/page.mdx
+++ b/docs/managed-agents/sessions/page.mdx
@@ -65,8 +65,8 @@ Repository authorization tokens are accepted on create or update, but are not re
 | State | Meaning |
 |-------|---------|
 | `idle` | Ready for new input or waiting for required action |
-| `running` | The agent engine is processing events |
-| `rescheduling` | The active run hit a retriable model or transport error and Sandbox0 is waiting for the selected engine to retry automatically |
+| `running` | The agent harness is processing events |
+| `rescheduling` | The active run hit a retriable model or transport error and Sandbox0 is waiting for the selected harness to retry automatically |
 | `terminated` | The session is no longer active |
 
 Sandbox0 keeps session state and event history outside the sandbox. The sandbox and workspace volume are runtime attachments for the session.
@@ -79,10 +79,10 @@ Sandbox0 keeps session state and event history outside the sandbox. The sandbox 
 - The workspace is backed by a Sandbox0 volume mounted at `/workspace`.
 - The runtime sandbox uses auto-resume.
 - Runtime sandbox lifetime is managed by the Managed Agents deployment.
-- The selected agent engine is resolved from the attached LLM vault; if no engine is selected, the default is `claude`.
+- The selected agent harness is resolved from the attached LLM vault; if no harness is selected, the default is `claude`.
 - `claude` and `codex` run the agent process inside the sandbox.
 - `openai-agents` runs the agent loop in a resident runtime and uses Sandbox0 as a sandbox tool.
-- All supported engines map observable automatic retry attempts to the same session state sequence: `running`, `rescheduling`, `running`, then either `idle` or `terminated`.
+- All supported harnesses map observable automatic retry attempts to the same session state sequence: `running`, `rescheduling`, `running`, then either `idle` or `terminated`.
 
 ## Next Steps
 

--- a/docs/managed-agents/vaults/page.mdx
+++ b/docs/managed-agents/vaults/page.mdx
@@ -10,7 +10,7 @@ Managed Agents stores vault credential secret payloads as encrypted opaque secre
 
 ## LLM Vaults
 
-Every running session should attach exactly one LLM vault. The LLM vault selects the agent engine and model provider endpoint.
+Every running session should attach exactly one LLM vault. The LLM vault selects the agent harness and model provider endpoint.
 
 ```typescript
 const llmVault = await client.beta.vaults.create({
@@ -92,11 +92,11 @@ await client.beta.vaults.credentials.create(vault.id, {
 
 Sandbox0 injects credentials through egress auth and compatibility environment variables:
 
-| Engine | Compatibility environment |
+| Harness | Compatibility environment |
 |--------|---------------------------|
 | `claude` | `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BASE_URL` |
-| `codex` | `CODEX_API_KEY`, `OPENAI_API_KEY`, and `openai_base_url` engine config |
-| `openai-agents` | `OPENAI_API_KEY`, `OPENAI_BASE_URL`, and `openai_base_url` engine config |
+| `codex` | `CODEX_API_KEY`, `OPENAI_API_KEY`, and `openai_base_url` harness config |
+| `openai-agents` | `OPENAI_API_KEY`, `OPENAI_BASE_URL`, and `openai_base_url` harness config |
 
 The environment variables may contain placeholders. The real token is projected by Sandbox0-managed credential policy when the sandbox contacts the configured host.
 
@@ -105,7 +105,7 @@ For `openai-agents`, the runtime expects an OpenAI Responses-compatible base URL
 ## Next Steps
 
 <CardGroup>
-  <Card title="Agent Engines" href="/docs/managed-agents/agent-engines" cta="Continue">
+  <Card title="Agent Harnesses" href="/docs/managed-agents/agent-harnesses" cta="Continue">
     Choose the runtime adapter that should execute each managed session.
   </Card>
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -120,8 +120,9 @@
           "title": "Vaults"
         },
         {
-          "slug": "agent-engines",
-          "title": "Agent Engines"
+          "slug": "agent-harnesses",
+          "title": "Agent Harnesses",
+          "aliases": ["agent-engines"]
         },
         {
           "slug": "llmproxy",


### PR DESCRIPTION

## Summary
- Rename the Managed Agents docs page and navigation from Agent Engines to Agent Harnesses.
- Update Managed Agents docs copy to use agent harness terminology while keeping the compatibility metadata key `sandbox0.managed_agents.engine`.
- Add an `agent-engines` alias in the docs manifest so website builds can redirect the old URL.

Companion website PR: https://github.com/sandbox0-ai/sandbox0-cloud/pull/106

## Testing
- `python3 -m json.tool docs/manifest.json >/dev/null`
- Website CI should run the full docs/website build through the companion sandbox0-cloud PR.
