### PR TITLE
Add team quota enforcement

### DIFF
--- a/cluster-gateway/pkg/http/server.go
+++ b/cluster-gateway/pkg/http/server.go
@@ -465,6 +465,14 @@ func (s *Server) setupRoutes() {
 			credentialSources.DELETE("/:name", s.authMiddleware.RequirePermission(gatewayauthn.PermCredentialSourceDelete), s.proxyToManager)
 		}
 
+		quotas := v1.Group("/quotas")
+		quotas.Use(s.managerUpstreamMiddleware())
+		{
+			quotas.GET("/:dimension", s.authMiddleware.RequirePermission(gatewayauthn.PermQuotaRead), s.proxyToManager)
+			quotas.PUT("/:dimension", s.authMiddleware.RequirePermission(gatewayauthn.PermQuotaWrite), s.proxyToManager)
+			quotas.DELETE("/:dimension", s.authMiddleware.RequirePermission(gatewayauthn.PermQuotaWrite), s.proxyToManager)
+		}
+
 		// === SandboxVolume Management (→ Storage Proxy) ===
 		sandboxvolumes := v1.Group("/sandboxvolumes")
 		sandboxvolumes.Use(s.storageProxyUpstreamMiddleware())

--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/observability"
 	httpobs "github.com/sandbox0-ai/sandbox0/pkg/observability/http"
 	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
+	"github.com/sandbox0-ai/sandbox0/pkg/quota"
 	templmigrations "github.com/sandbox0-ai/sandbox0/pkg/template/migrations"
 	templreconciler "github.com/sandbox0-ai/sandbox0/pkg/template/reconciler"
 	templstorepg "github.com/sandbox0-ai/sandbox0/pkg/template/store/pg"
@@ -125,6 +126,9 @@ func main() {
 	}
 	if err := runMeteringMigrations(ctx, pool, logger); err != nil {
 		logger.Fatal("Failed to run metering migrations", zap.Error(err))
+	}
+	if err := runQuotaMigrations(ctx, pool, logger); err != nil {
+		logger.Fatal("Failed to run quota migrations", zap.Error(err))
 	}
 	if err := runEgressAuthMigrations(ctx, pool, logger); err != nil {
 		logger.Fatal("Failed to run egress auth migrations", zap.Error(err))
@@ -300,6 +304,7 @@ func main() {
 		managerMetrics,
 	)
 	sandboxService.SetCredentialStore(credentialStore)
+	sandboxService.SetQuotaStore(quota.NewRepository(pool))
 	if cfg.StorageProxyBaseURL != "" && cfg.StorageProxyHTTPPort > 0 && storageProxyAdminTokenGenerator != nil {
 		storageProxyBaseURL := fmt.Sprintf("http://%s:%d", strings.TrimSpace(cfg.StorageProxyBaseURL), cfg.StorageProxyHTTPPort)
 		sandboxService.SetWebhookStateVolumeClient(service.NewStorageProxyVolumeClient(service.StorageProxyVolumeClientConfig{
@@ -427,6 +432,7 @@ func main() {
 		cfg.PublicRootDomain,
 		cfg.PublicRegionID,
 	)
+	httpServer.SetQuotaRepository(quota.NewRepository(pool))
 
 	// Start metrics server
 	go startMetricsServer(cfg.MetricsPort, logger)
@@ -564,6 +570,18 @@ func runMeteringMigrations(ctx context.Context, pool *pgxpool.Pool, logger *zap.
 	}
 
 	logger.Info("Metering migrations completed successfully")
+	return nil
+}
+
+func runQuotaMigrations(ctx context.Context, pool *pgxpool.Pool, logger *zap.Logger) error {
+	logger.Info("Running quota migrations")
+
+	migrateLogger := &zapMigrateLogger{logger: logger}
+	if err := quota.RunMigrations(ctx, pool, migrateLogger); err != nil {
+		return fmt.Errorf("quota migrations: %w", err)
+	}
+
+	logger.Info("Quota migrations completed successfully")
 	return nil
 }
 

--- a/manager/pkg/http/handlers_quota.go
+++ b/manager/pkg/http/handlers_quota.go
@@ -1,0 +1,104 @@
+package http
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
+	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+	"github.com/sandbox0-ai/sandbox0/pkg/quota"
+	"go.uber.org/zap"
+)
+
+type putTeamQuotaRequest struct {
+	LimitValue int64 `json:"limit_value"`
+}
+
+func (s *Server) getTeamQuota(c *gin.Context) {
+	teamID, dimension, ok := s.quotaRequestScope(c)
+	if !ok {
+		return
+	}
+	if s.quotaRepo == nil {
+		spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "quota is unavailable")
+		return
+	}
+	limit, err := s.quotaRepo.GetLimit(c.Request.Context(), teamID, dimension)
+	if err != nil {
+		s.logger.Error("Failed to get quota limit", zap.Error(err))
+		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to get quota")
+		return
+	}
+	if limit == nil {
+		spec.JSONSuccess(c, http.StatusOK, gin.H{
+			"team_id":     teamID,
+			"dimension":   dimension,
+			"limit_value": nil,
+		})
+		return
+	}
+	spec.JSONSuccess(c, http.StatusOK, limit)
+}
+
+func (s *Server) putTeamQuota(c *gin.Context) {
+	teamID, dimension, ok := s.quotaRequestScope(c)
+	if !ok {
+		return
+	}
+	if s.quotaRepo == nil {
+		spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "quota is unavailable")
+		return
+	}
+	var req putTeamQuotaRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, fmt.Sprintf("invalid request: %v", err))
+		return
+	}
+	if req.LimitValue < 0 {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "limit_value must be non-negative")
+		return
+	}
+	limit := &quota.Limit{TeamID: teamID, Dimension: dimension, LimitValue: req.LimitValue}
+	if err := s.quotaRepo.PutLimit(c.Request.Context(), limit); err != nil {
+		s.logger.Error("Failed to put quota limit", zap.Error(err))
+		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to update quota")
+		return
+	}
+	spec.JSONSuccess(c, http.StatusOK, limit)
+}
+
+func (s *Server) deleteTeamQuota(c *gin.Context) {
+	teamID, dimension, ok := s.quotaRequestScope(c)
+	if !ok {
+		return
+	}
+	if s.quotaRepo == nil {
+		spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "quota is unavailable")
+		return
+	}
+	if err := s.quotaRepo.DeleteLimit(c.Request.Context(), teamID, dimension); err != nil {
+		s.logger.Error("Failed to delete quota limit", zap.Error(err))
+		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to delete quota")
+		return
+	}
+	spec.JSONSuccess(c, http.StatusOK, gin.H{"deleted": true})
+}
+
+func (s *Server) quotaRequestScope(c *gin.Context) (string, quota.Dimension, bool) {
+	claims := internalauth.ClaimsFromContext(c.Request.Context())
+	if claims == nil {
+		spec.JSONError(c, http.StatusUnauthorized, spec.CodeUnauthorized, "missing authentication")
+		return "", "", false
+	}
+	if claims.TeamID == "" {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "team_id is required")
+		return "", "", false
+	}
+	dimension := quota.Dimension(c.Param("dimension"))
+	if !quota.KnownDimension(dimension) {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "unknown quota dimension")
+		return "", "", false
+	}
+	return claims.TeamID, dimension, true
+}

--- a/manager/pkg/http/handlers_sandbox.go
+++ b/manager/pkg/http/handlers_sandbox.go
@@ -61,6 +61,10 @@ func (s *Server) claimSandbox(c *gin.Context) {
 			spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, err.Error())
 			return
 		}
+		if errors.Is(err, service.ErrQuotaExceeded) {
+			spec.JSONError(c, http.StatusTooManyRequests, "quota_exceeded", err.Error())
+			return
+		}
 		s.logger.Error("Failed to claim sandbox",
 			zap.String("template", req.Template),
 			zap.String("teamID", req.TeamID),

--- a/manager/pkg/http/server.go
+++ b/manager/pkg/http/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"github.com/sandbox0-ai/sandbox0/pkg/observability"
 	httpobs "github.com/sandbox0-ai/sandbox0/pkg/observability/http"
+	"github.com/sandbox0-ai/sandbox0/pkg/quota"
 	templatehttp "github.com/sandbox0-ai/sandbox0/pkg/template/http"
 	"github.com/sandbox0-ai/sandbox0/pkg/template/store"
 	"go.opentelemetry.io/otel/trace"
@@ -35,6 +36,7 @@ type Server struct {
 	templateStoreEnabled    bool
 	templateHandler         *templatehttp.Handler
 	clusterService          *service.ClusterService
+	quotaRepo               *quota.Repository
 	authValidator           *internalauth.Validator
 	logger                  *zap.Logger
 	port                    int
@@ -187,6 +189,13 @@ func (s *Server) setupRoutes() {
 			credentialSources.PUT("/:name", s.updateCredentialSource)
 			credentialSources.DELETE("/:name", s.deleteCredentialSource)
 		}
+
+		quotas := v1.Group("/quotas")
+		{
+			quotas.GET("/:dimension", s.getTeamQuota)
+			quotas.PUT("/:dimension", s.putTeamQuota)
+			quotas.DELETE("/:dimension", s.deleteTeamQuota)
+		}
 	}
 
 	// Internal API v1 (for scheduler)
@@ -220,6 +229,10 @@ func (s *Server) setupRoutes() {
 			internalEgressAuth.POST("/resolve", s.resolveEgressAuth)
 		}
 	}
+}
+
+func (s *Server) SetQuotaRepository(repo *quota.Repository) {
+	s.quotaRepo = repo
 }
 
 // Start starts the HTTP server

--- a/manager/pkg/service/sandbox_service.go
+++ b/manager/pkg/service/sandbox_service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/network"
 	egressauth "github.com/sandbox0-ai/sandbox0/pkg/egressauth"
 	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
+	"github.com/sandbox0-ai/sandbox0/pkg/quota"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -67,6 +68,7 @@ var errNoIdlePod = errors.New("no idle pod available")
 var ErrInvalidClaimRequest = errors.New("invalid claim request")
 var ErrClaimConflict = errors.New("claim conflict")
 var ErrDataPlaneNotReady = errors.New("data plane not ready")
+var ErrQuotaExceeded = errors.New("quota exceeded")
 var errSandboxPowerStateStale = errors.New("sandbox power state changed during execution")
 
 // ErrSandboxPowerTransitionSuperseded is returned when a newer pause/resume request replaces the requested transition.
@@ -128,8 +130,14 @@ type SandboxService struct {
 	webhookStateVolumes    SandboxSystemVolumeClient
 	volumeMetadata         SandboxVolumeMetadataClient
 	deletionWebhookEmitter SandboxDeletionWebhookEmitter
+	quotaStore             TeamQuotaLimitStore
 	powerStateLocks        sync.Map
 	powerStateReconcilers  sync.Map
+}
+
+type TeamQuotaLimitStore interface {
+	GetLimit(ctx context.Context, teamID string, dimension quota.Dimension) (*quota.Limit, error)
+	CurrentUsage(ctx context.Context, teamID string, dimension quota.Dimension) (int64, error)
 }
 
 // AutoScalerInterface defines the interface for auto scaling.
@@ -275,6 +283,11 @@ func (s *SandboxService) SetVolumeMetadataClient(client SandboxVolumeMetadataCli
 // SetDeletionWebhookEmitter injects the emitter for manager-owned sandbox deletion events.
 func (s *SandboxService) SetDeletionWebhookEmitter(emitter SandboxDeletionWebhookEmitter) {
 	s.deletionWebhookEmitter = emitter
+}
+
+// SetQuotaStore injects the team quota limit store. Nil disables quota checks.
+func (s *SandboxService) SetQuotaStore(store TeamQuotaLimitStore) {
+	s.quotaStore = store
 }
 
 func (s *SandboxService) sandboxPowerExecutor() SandboxPowerExecutor {

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -286,6 +286,12 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 		}
 	}
 	s.observeClaimPhase(req.Template, "unknown", "validate_claim_mounts", phaseStarted, nil)
+	phaseStarted = time.Now()
+	if err := s.enforceActiveSandboxQuota(ctx, req.TeamID); err != nil {
+		s.observeClaimPhase(req.Template, "unknown", "enforce_active_sandbox_quota", phaseStarted, err)
+		return nil, err
+	}
+	s.observeClaimPhase(req.Template, "unknown", "enforce_active_sandbox_quota", phaseStarted, nil)
 	s.logger.Info("Claiming sandbox",
 		zap.String("template", req.Template),
 		zap.String("teamID", req.TeamID),

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -348,6 +348,13 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 	s.observeClaimPhase(req.Template, "unknown", "resolve_template", phaseStarted, nil)
 
 	phaseStarted = time.Now()
+	if err := s.enforceSandboxCPUQuota(ctx, req.TeamID, template); err != nil {
+		s.observeClaimPhase(req.Template, "unknown", "enforce_cpu_quota", phaseStarted, err)
+		return nil, err
+	}
+	s.observeClaimPhase(req.Template, "unknown", "enforce_cpu_quota", phaseStarted, nil)
+
+	phaseStarted = time.Now()
 	if err := validateClaimMountsForTemplate(req, template); err != nil {
 		s.observeClaimPhase(req.Template, "unknown", "validate_template_mounts", phaseStarted, err)
 		return nil, err

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -353,6 +353,12 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 		return nil, err
 	}
 	s.observeClaimPhase(req.Template, "unknown", "enforce_cpu_quota", phaseStarted, nil)
+	phaseStarted = time.Now()
+	if err := s.enforceSandboxMemoryQuota(ctx, req.TeamID, template); err != nil {
+		s.observeClaimPhase(req.Template, "unknown", "enforce_memory_quota", phaseStarted, err)
+		return nil, err
+	}
+	s.observeClaimPhase(req.Template, "unknown", "enforce_memory_quota", phaseStarted, nil)
 
 	phaseStarted = time.Now()
 	if err := validateClaimMountsForTemplate(req, template); err != nil {

--- a/manager/pkg/service/sandbox_service_quota.go
+++ b/manager/pkg/service/sandbox_service_quota.go
@@ -1,0 +1,32 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/sandbox0-ai/sandbox0/pkg/quota"
+)
+
+func (s *SandboxService) enforceActiveSandboxQuota(ctx context.Context, teamID string) error {
+	teamID = strings.TrimSpace(teamID)
+	if s == nil || s.quotaStore == nil || teamID == "" {
+		return nil
+	}
+	limit, err := s.quotaStore.GetLimit(ctx, teamID, quota.DimensionActiveSandboxes)
+	if err != nil {
+		return fmt.Errorf("load active sandbox quota: %w", err)
+	}
+	if limit == nil {
+		return nil
+	}
+	current, err := s.quotaStore.CurrentUsage(ctx, teamID, quota.DimensionActiveSandboxes)
+	if err != nil {
+		return fmt.Errorf("load active sandbox usage: %w", err)
+	}
+	decision := quota.Check(teamID, quota.DimensionActiveSandboxes, current, 1, limit)
+	if decision.Allowed {
+		return nil
+	}
+	return fmt.Errorf("%w: %s", ErrQuotaExceeded, decision.Err())
+}

--- a/manager/pkg/service/sandbox_service_quota.go
+++ b/manager/pkg/service/sandbox_service_quota.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/pkg/quota"
 )
 
@@ -29,4 +30,39 @@ func (s *SandboxService) enforceActiveSandboxQuota(ctx context.Context, teamID s
 		return nil
 	}
 	return fmt.Errorf("%w: %s", ErrQuotaExceeded, decision.Err())
+}
+
+func (s *SandboxService) enforceSandboxCPUQuota(ctx context.Context, teamID string, template *v1alpha1.SandboxTemplate) error {
+	requested := templateCPUMillicpu(template)
+	return s.enforceQuota(ctx, teamID, quota.DimensionCPU, requested)
+}
+
+func (s *SandboxService) enforceQuota(ctx context.Context, teamID string, dimension quota.Dimension, requested int64) error {
+	teamID = strings.TrimSpace(teamID)
+	if s == nil || s.quotaStore == nil || teamID == "" {
+		return nil
+	}
+	limit, err := s.quotaStore.GetLimit(ctx, teamID, dimension)
+	if err != nil {
+		return fmt.Errorf("load %s quota: %w", dimension, err)
+	}
+	if limit == nil {
+		return nil
+	}
+	current, err := s.quotaStore.CurrentUsage(ctx, teamID, dimension)
+	if err != nil {
+		return fmt.Errorf("load %s usage: %w", dimension, err)
+	}
+	decision := quota.Check(teamID, dimension, current, requested, limit)
+	if decision.Allowed {
+		return nil
+	}
+	return fmt.Errorf("%w: %s", ErrQuotaExceeded, decision.Err())
+}
+
+func templateCPUMillicpu(template *v1alpha1.SandboxTemplate) int64 {
+	if template == nil {
+		return 0
+	}
+	return template.Spec.MainContainer.Resources.CPU.MilliValue()
 }

--- a/manager/pkg/service/sandbox_service_quota.go
+++ b/manager/pkg/service/sandbox_service_quota.go
@@ -37,6 +37,11 @@ func (s *SandboxService) enforceSandboxCPUQuota(ctx context.Context, teamID stri
 	return s.enforceQuota(ctx, teamID, quota.DimensionCPU, requested)
 }
 
+func (s *SandboxService) enforceSandboxMemoryQuota(ctx context.Context, teamID string, template *v1alpha1.SandboxTemplate) error {
+	requested := templateMemoryMiB(template)
+	return s.enforceQuota(ctx, teamID, quota.DimensionMemory, requested)
+}
+
 func (s *SandboxService) enforceQuota(ctx context.Context, teamID string, dimension quota.Dimension, requested int64) error {
 	teamID = strings.TrimSpace(teamID)
 	if s == nil || s.quotaStore == nil || teamID == "" {
@@ -65,4 +70,19 @@ func templateCPUMillicpu(template *v1alpha1.SandboxTemplate) int64 {
 		return 0
 	}
 	return template.Spec.MainContainer.Resources.CPU.MilliValue()
+}
+
+func templateMemoryMiB(template *v1alpha1.SandboxTemplate) int64 {
+	if template == nil {
+		return 0
+	}
+	return bytesToMiBRoundUp(template.Spec.MainContainer.Resources.Memory.Value())
+}
+
+func bytesToMiBRoundUp(value int64) int64 {
+	if value <= 0 {
+		return 0
+	}
+	const mib = int64(1024 * 1024)
+	return (value + mib - 1) / mib
 }

--- a/manager/pkg/service/sandbox_service_quota_test.go
+++ b/manager/pkg/service/sandbox_service_quota_test.go
@@ -5,7 +5,10 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/pkg/quota"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type fakeQuotaLimitStore struct {
@@ -53,5 +56,48 @@ func TestEnforceActiveSandboxQuotaAllowsBelowLimit(t *testing.T) {
 
 	if err := svc.enforceActiveSandboxQuota(context.Background(), "team-1"); err != nil {
 		t.Fatalf("enforceActiveSandboxQuota() error = %v, want nil", err)
+	}
+}
+
+func TestEnforceSandboxCPUQuotaRejectsWhenRequestedWouldExceedLimit(t *testing.T) {
+	svc := &SandboxService{
+		quotaStore: fakeQuotaLimitStore{
+			limit: &quota.Limit{TeamID: "team-1", Dimension: quota.DimensionCPU, LimitValue: 1000},
+			usage: 750,
+		},
+	}
+	template := newQuotaTestTemplate("default", "500m", "1Gi")
+
+	err := svc.enforceSandboxCPUQuota(context.Background(), "team-1", template)
+	if !errors.Is(err, ErrQuotaExceeded) {
+		t.Fatalf("enforceSandboxCPUQuota() error = %v, want ErrQuotaExceeded", err)
+	}
+}
+
+func TestEnforceSandboxCPUQuotaAllowsBelowLimit(t *testing.T) {
+	svc := &SandboxService{
+		quotaStore: fakeQuotaLimitStore{
+			limit: &quota.Limit{TeamID: "team-1", Dimension: quota.DimensionCPU, LimitValue: 1000},
+			usage: 250,
+		},
+	}
+	template := newQuotaTestTemplate("default", "500m", "1Gi")
+
+	if err := svc.enforceSandboxCPUQuota(context.Background(), "team-1", template); err != nil {
+		t.Fatalf("enforceSandboxCPUQuota() error = %v, want nil", err)
+	}
+}
+
+func newQuotaTestTemplate(name, cpu, memory string) *v1alpha1.SandboxTemplate {
+	return &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec: v1alpha1.SandboxTemplateSpec{
+			MainContainer: v1alpha1.ContainerSpec{
+				Resources: v1alpha1.ResourceQuota{
+					CPU:    resource.MustParse(cpu),
+					Memory: resource.MustParse(memory),
+				},
+			},
+		},
 	}
 }

--- a/manager/pkg/service/sandbox_service_quota_test.go
+++ b/manager/pkg/service/sandbox_service_quota_test.go
@@ -88,6 +88,35 @@ func TestEnforceSandboxCPUQuotaAllowsBelowLimit(t *testing.T) {
 	}
 }
 
+func TestEnforceSandboxMemoryQuotaRejectsWhenRequestedWouldExceedLimit(t *testing.T) {
+	svc := &SandboxService{
+		quotaStore: fakeQuotaLimitStore{
+			limit: &quota.Limit{TeamID: "team-1", Dimension: quota.DimensionMemory, LimitValue: 1024},
+			usage: 768,
+		},
+	}
+	template := newQuotaTestTemplate("default", "500m", "512Mi")
+
+	err := svc.enforceSandboxMemoryQuota(context.Background(), "team-1", template)
+	if !errors.Is(err, ErrQuotaExceeded) {
+		t.Fatalf("enforceSandboxMemoryQuota() error = %v, want ErrQuotaExceeded", err)
+	}
+}
+
+func TestEnforceSandboxMemoryQuotaAllowsBelowLimit(t *testing.T) {
+	svc := &SandboxService{
+		quotaStore: fakeQuotaLimitStore{
+			limit: &quota.Limit{TeamID: "team-1", Dimension: quota.DimensionMemory, LimitValue: 2048},
+			usage: 768,
+		},
+	}
+	template := newQuotaTestTemplate("default", "500m", "512Mi")
+
+	if err := svc.enforceSandboxMemoryQuota(context.Background(), "team-1", template); err != nil {
+		t.Fatalf("enforceSandboxMemoryQuota() error = %v, want nil", err)
+	}
+}
+
 func newQuotaTestTemplate(name, cpu, memory string) *v1alpha1.SandboxTemplate {
 	return &v1alpha1.SandboxTemplate{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},

--- a/manager/pkg/service/sandbox_service_quota_test.go
+++ b/manager/pkg/service/sandbox_service_quota_test.go
@@ -1,0 +1,57 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/sandbox0-ai/sandbox0/pkg/quota"
+)
+
+type fakeQuotaLimitStore struct {
+	limit *quota.Limit
+	usage int64
+	err   error
+}
+
+func (f fakeQuotaLimitStore) GetLimit(context.Context, string, quota.Dimension) (*quota.Limit, error) {
+	return f.limit, f.err
+}
+
+func (f fakeQuotaLimitStore) CurrentUsage(context.Context, string, quota.Dimension) (int64, error) {
+	return f.usage, f.err
+}
+
+func TestEnforceActiveSandboxQuotaAllowsWhenNoLimit(t *testing.T) {
+	svc := &SandboxService{quotaStore: fakeQuotaLimitStore{}}
+	if err := svc.enforceActiveSandboxQuota(context.Background(), "team-1"); err != nil {
+		t.Fatalf("enforceActiveSandboxQuota() error = %v, want nil", err)
+	}
+}
+
+func TestEnforceActiveSandboxQuotaRejectsAtLimit(t *testing.T) {
+	svc := &SandboxService{
+		quotaStore: fakeQuotaLimitStore{
+			limit: &quota.Limit{TeamID: "team-1", Dimension: quota.DimensionActiveSandboxes, LimitValue: 1},
+			usage: 1,
+		},
+	}
+
+	err := svc.enforceActiveSandboxQuota(context.Background(), "team-1")
+	if !errors.Is(err, ErrQuotaExceeded) {
+		t.Fatalf("enforceActiveSandboxQuota() error = %v, want ErrQuotaExceeded", err)
+	}
+}
+
+func TestEnforceActiveSandboxQuotaAllowsBelowLimit(t *testing.T) {
+	svc := &SandboxService{
+		quotaStore: fakeQuotaLimitStore{
+			limit: &quota.Limit{TeamID: "team-1", Dimension: quota.DimensionActiveSandboxes, LimitValue: 2},
+			usage: 1,
+		},
+	}
+
+	if err := svc.enforceActiveSandboxQuota(context.Background(), "team-1"); err != nil {
+		t.Fatalf("enforceActiveSandboxQuota() error = %v, want nil", err)
+	}
+}

--- a/netd/pkg/daemon/daemon.go
+++ b/netd/pkg/daemon/daemon.go
@@ -25,6 +25,7 @@ import (
 	meteringpkg "github.com/sandbox0-ai/sandbox0/pkg/metering"
 	"github.com/sandbox0-ai/sandbox0/pkg/observability"
 	httpobs "github.com/sandbox0-ai/sandbox0/pkg/observability/http"
+	"github.com/sandbox0-ai/sandbox0/pkg/quota"
 	"go.uber.org/zap"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -150,6 +151,9 @@ func (d *Daemon) runNetd(ctx context.Context, cancel context.CancelFunc, proxyEx
 		if err := meteringpkg.RunMigrations(ctx, meteringPool, &zapLoggerAdapter{logger: d.logger}); err != nil {
 			return fmt.Errorf("run metering migrations: %w", err)
 		}
+		if err := quota.RunMigrations(ctx, meteringPool, &zapLoggerAdapter{logger: d.logger}); err != nil {
+			return fmt.Errorf("run quota migrations: %w", err)
+		}
 		usageAggregator = netdmetering.NewAggregator(
 			netdmetering.NewRecorder(meteringpkg.NewRepository(meteringPool)),
 			d.cfg.RegionID,
@@ -157,6 +161,7 @@ func (d *Daemon) runNetd(ctx context.Context, cancel context.CancelFunc, proxyEx
 			d.cfg.NodeName,
 			d.logger,
 		)
+		usageAggregator.SetQuotaStore(quota.NewRepository(meteringPool))
 	}
 	syncTrigger := make(chan struct{}, 1)
 	triggerSync := func() {

--- a/netd/pkg/metering/aggregator.go
+++ b/netd/pkg/metering/aggregator.go
@@ -11,6 +11,7 @@ import (
 	policypkg "github.com/sandbox0-ai/sandbox0/netd/pkg/policy"
 	"github.com/sandbox0-ai/sandbox0/pkg/functionruntime"
 	meteringpkg "github.com/sandbox0-ai/sandbox0/pkg/metering"
+	"github.com/sandbox0-ai/sandbox0/pkg/quota"
 	"go.uber.org/zap"
 )
 
@@ -23,6 +24,11 @@ type txRecorder interface {
 
 type Recorder interface {
 	RunInTx(ctx context.Context, fn func(tx txRecorder) error) error
+}
+
+type quotaStore interface {
+	GetLimit(ctx context.Context, teamID string, dimension quota.Dimension) (*quota.Limit, error)
+	CurrentUsage(ctx context.Context, teamID string, dimension quota.Dimension) (int64, error)
 }
 
 type repositoryAdapter struct {
@@ -72,6 +78,7 @@ type Aggregator struct {
 	clusterID   string
 	nodeName    string
 	producer    string
+	quotaStore  quotaStore
 	logger      *zap.Logger
 	now         func() time.Time
 	mu          sync.Mutex
@@ -97,6 +104,19 @@ func NewAggregator(recorder Recorder, regionID, clusterID, nodeName string, logg
 	}
 	agg.windowStart = agg.now()
 	return agg
+}
+
+func (a *Aggregator) SetQuotaStore(store quotaStore) {
+	if a == nil {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.quotaStore = store
+}
+
+func (a *Aggregator) AllowEgress(compiled *policypkg.CompiledPolicy) error {
+	return a.allowNetworkUsage(context.Background(), compiled, quota.DimensionEgress)
 }
 
 func (a *Aggregator) RecordEgress(compiled *policypkg.CompiledPolicy, bytes int64) {
@@ -143,6 +163,48 @@ func (a *Aggregator) record(compiled *policypkg.CompiledPolicy, bytes int64, egr
 	} else {
 		entry.ingress += bytes
 	}
+}
+
+func (a *Aggregator) allowNetworkUsage(ctx context.Context, compiled *policypkg.CompiledPolicy, dimension quota.Dimension) error {
+	if a == nil || compiled == nil || compiled.TeamID == "" {
+		return nil
+	}
+	a.mu.Lock()
+	store := a.quotaStore
+	a.mu.Unlock()
+	if store == nil {
+		return nil
+	}
+	limit, err := store.GetLimit(ctx, compiled.TeamID, dimension)
+	if err != nil {
+		return err
+	}
+	if limit == nil {
+		return nil
+	}
+	current, err := store.CurrentUsage(ctx, compiled.TeamID, dimension)
+	if err != nil {
+		return err
+	}
+	a.mu.Lock()
+	current += a.localNetworkUsageLocked(compiled.TeamID, dimension)
+	a.mu.Unlock()
+	decision := quota.Check(compiled.TeamID, dimension, current, 1, limit)
+	return decision.Err()
+}
+
+func (a *Aggregator) localNetworkUsageLocked(teamID string, dimension quota.Dimension) int64 {
+	var total int64
+	for _, usage := range a.usage {
+		if usage == nil || usage.teamID != teamID {
+			continue
+		}
+		switch dimension {
+		case quota.DimensionEgress:
+			total += usage.egress
+		}
+	}
+	return total
 }
 
 func (a *Aggregator) Flush(ctx context.Context) error {

--- a/netd/pkg/metering/aggregator.go
+++ b/netd/pkg/metering/aggregator.go
@@ -119,6 +119,10 @@ func (a *Aggregator) AllowEgress(compiled *policypkg.CompiledPolicy) error {
 	return a.allowNetworkUsage(context.Background(), compiled, quota.DimensionEgress)
 }
 
+func (a *Aggregator) AllowIngress(compiled *policypkg.CompiledPolicy) error {
+	return a.allowNetworkUsage(context.Background(), compiled, quota.DimensionIngress)
+}
+
 func (a *Aggregator) RecordEgress(compiled *policypkg.CompiledPolicy, bytes int64) {
 	a.record(compiled, bytes, true)
 }
@@ -202,6 +206,8 @@ func (a *Aggregator) localNetworkUsageLocked(teamID string, dimension quota.Dime
 		switch dimension {
 		case quota.DimensionEgress:
 			total += usage.egress
+		case quota.DimensionIngress:
+			total += usage.ingress
 		}
 	}
 	return total

--- a/netd/pkg/metering/aggregator_test.go
+++ b/netd/pkg/metering/aggregator_test.go
@@ -230,3 +230,20 @@ func TestAggregatorAllowEgressIncludesUnflushedUsage(t *testing.T) {
 		t.Fatalf("AllowEgress error = %v, want quota exceeded", err)
 	}
 }
+
+func TestAggregatorAllowIngressRejectsAtQuotaLimit(t *testing.T) {
+	agg := NewAggregator(&fakeRecorder{}, "aws-us-east-1", "cluster-a", "node-1", nil)
+	agg.SetQuotaStore(&fakeQuotaStore{
+		limit: &quota.Limit{
+			TeamID:     "team-1",
+			Dimension:  quota.DimensionIngress,
+			LimitValue: 10,
+		},
+		current: 10,
+	})
+
+	err := agg.AllowIngress(&policypkg.CompiledPolicy{SandboxID: "sb-1", TeamID: "team-1"})
+	if !quota.IsExceeded(err) {
+		t.Fatalf("AllowIngress error = %v, want quota exceeded", err)
+	}
+}

--- a/netd/pkg/metering/aggregator_test.go
+++ b/netd/pkg/metering/aggregator_test.go
@@ -10,6 +10,7 @@ import (
 	policypkg "github.com/sandbox0-ai/sandbox0/netd/pkg/policy"
 	"github.com/sandbox0-ai/sandbox0/pkg/functionruntime"
 	meteringpkg "github.com/sandbox0-ai/sandbox0/pkg/metering"
+	"github.com/sandbox0-ai/sandbox0/pkg/quota"
 )
 
 type fakeTxRecorder struct {
@@ -43,6 +44,19 @@ type fakeRecorder struct {
 	tx       *fakeTxRecorder
 	runCalls int
 	runErr   error
+}
+
+type fakeQuotaStore struct {
+	limit   *quota.Limit
+	current int64
+}
+
+func (f *fakeQuotaStore) GetLimit(context.Context, string, quota.Dimension) (*quota.Limit, error) {
+	return f.limit, nil
+}
+
+func (f *fakeQuotaStore) CurrentUsage(context.Context, string, quota.Dimension) (int64, error) {
+	return f.current, nil
 }
 
 func (f *fakeRecorder) RunInTx(ctx context.Context, fn func(tx txRecorder) error) error {
@@ -178,5 +192,41 @@ func TestAggregatorFlushFailureRetainsUsage(t *testing.T) {
 	}
 	if !agg.windowStart.Equal(start) {
 		t.Fatalf("window start advanced on failure: %v", agg.windowStart)
+	}
+}
+
+func TestAggregatorAllowEgressRejectsAtQuotaLimit(t *testing.T) {
+	agg := NewAggregator(&fakeRecorder{}, "aws-us-east-1", "cluster-a", "node-1", nil)
+	agg.SetQuotaStore(&fakeQuotaStore{
+		limit: &quota.Limit{
+			TeamID:     "team-1",
+			Dimension:  quota.DimensionEgress,
+			LimitValue: 10,
+		},
+		current: 10,
+	})
+
+	err := agg.AllowEgress(&policypkg.CompiledPolicy{SandboxID: "sb-1", TeamID: "team-1"})
+	if !quota.IsExceeded(err) {
+		t.Fatalf("AllowEgress error = %v, want quota exceeded", err)
+	}
+}
+
+func TestAggregatorAllowEgressIncludesUnflushedUsage(t *testing.T) {
+	agg := NewAggregator(&fakeRecorder{}, "aws-us-east-1", "cluster-a", "node-1", nil)
+	agg.SetQuotaStore(&fakeQuotaStore{
+		limit: &quota.Limit{
+			TeamID:     "team-1",
+			Dimension:  quota.DimensionEgress,
+			LimitValue: 10,
+		},
+		current: 8,
+	})
+	compiled := &policypkg.CompiledPolicy{SandboxID: "sb-1", TeamID: "team-1"}
+	agg.RecordEgress(compiled, 2)
+
+	err := agg.AllowEgress(compiled)
+	if !quota.IsExceeded(err) {
+		t.Fatalf("AllowEgress error = %v, want quota exceeded", err)
 	}
 }

--- a/netd/pkg/proxy/server.go
+++ b/netd/pkg/proxy/server.go
@@ -55,6 +55,10 @@ type UsageRecorder interface {
 	RecordIngress(compiled *policy.CompiledPolicy, bytes int64)
 }
 
+type UsageQuotaChecker interface {
+	AllowEgress(compiled *policy.CompiledPolicy) error
+}
+
 func NewServer(cfg *config.NetdConfig, store *policy.Store, tracker *conntrack.Tracker, usageRecorder UsageRecorder, logger *zap.Logger, opts ...ServerOption) (*Server, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("netd config is nil")
@@ -464,6 +468,12 @@ func (s *Server) handleTCPDecision(req *adapterRequest, decision trafficDecision
 			zap.String("auth_rule", decision.MatchedAuthRule.Name),
 		)
 	}
+	if err := s.checkEgressQuota(req.Compiled, decision); err != nil {
+		closeProbedUpstream(req)
+		decision.Action = decisionActionDeny
+		decision.Reason = "egress_quota_exceeded"
+		baseFields = append(baseFields, zap.Error(err))
+	}
 	baseFields = append(baseFields, fields...)
 	switch decision.Action {
 	case decisionActionDeny:
@@ -833,6 +843,11 @@ func (s *Server) handleUDPDecision(req *adapterRequest, decision trafficDecision
 			zap.String("auth_rule", decision.MatchedAuthRule.Name),
 		)
 	}
+	if err := s.checkEgressQuota(req.Compiled, decision); err != nil {
+		decision.Action = decisionActionDeny
+		decision.Reason = "egress_quota_exceeded"
+		fields = append(fields, zap.Error(err))
+	}
 	switch decision.Action {
 	case decisionActionDeny:
 		s.logger.Info("UDP decision denied", fields...)
@@ -1143,6 +1158,17 @@ func (s *Server) recordEgressBytes(compiled *policy.CompiledPolicy, bytes int64,
 		return
 	}
 	s.usageRecorder.RecordEgress(compiled, bytes)
+}
+
+func (s *Server) checkEgressQuota(compiled *policy.CompiledPolicy, decision trafficDecision) error {
+	if decision.Action == decisionActionDeny || s == nil || s.usageRecorder == nil {
+		return nil
+	}
+	checker, ok := s.usageRecorder.(UsageQuotaChecker)
+	if !ok {
+		return nil
+	}
+	return checker.AllowEgress(compiled)
 }
 
 func (s *Server) recordIngressBytes(compiled *policy.CompiledPolicy, bytes int64, audit *flowAudit) {

--- a/netd/pkg/proxy/server.go
+++ b/netd/pkg/proxy/server.go
@@ -57,6 +57,7 @@ type UsageRecorder interface {
 
 type UsageQuotaChecker interface {
 	AllowEgress(compiled *policy.CompiledPolicy) error
+	AllowIngress(compiled *policy.CompiledPolicy) error
 }
 
 func NewServer(cfg *config.NetdConfig, store *policy.Store, tracker *conntrack.Tracker, usageRecorder UsageRecorder, logger *zap.Logger, opts ...ServerOption) (*Server, error) {
@@ -474,6 +475,12 @@ func (s *Server) handleTCPDecision(req *adapterRequest, decision trafficDecision
 		decision.Reason = "egress_quota_exceeded"
 		baseFields = append(baseFields, zap.Error(err))
 	}
+	if err := s.checkIngressQuota(req.Compiled, decision); err != nil {
+		closeProbedUpstream(req)
+		decision.Action = decisionActionDeny
+		decision.Reason = "ingress_quota_exceeded"
+		baseFields = append(baseFields, zap.Error(err))
+	}
 	baseFields = append(baseFields, fields...)
 	switch decision.Action {
 	case decisionActionDeny:
@@ -848,6 +855,11 @@ func (s *Server) handleUDPDecision(req *adapterRequest, decision trafficDecision
 		decision.Reason = "egress_quota_exceeded"
 		fields = append(fields, zap.Error(err))
 	}
+	if err := s.checkIngressQuota(req.Compiled, decision); err != nil {
+		decision.Action = decisionActionDeny
+		decision.Reason = "ingress_quota_exceeded"
+		fields = append(fields, zap.Error(err))
+	}
 	switch decision.Action {
 	case decisionActionDeny:
 		s.logger.Info("UDP decision denied", fields...)
@@ -1169,6 +1181,17 @@ func (s *Server) checkEgressQuota(compiled *policy.CompiledPolicy, decision traf
 		return nil
 	}
 	return checker.AllowEgress(compiled)
+}
+
+func (s *Server) checkIngressQuota(compiled *policy.CompiledPolicy, decision trafficDecision) error {
+	if decision.Action == decisionActionDeny || s == nil || s.usageRecorder == nil {
+		return nil
+	}
+	checker, ok := s.usageRecorder.(UsageQuotaChecker)
+	if !ok {
+		return nil
+	}
+	return checker.AllowIngress(compiled)
 }
 
 func (s *Server) recordIngressBytes(compiled *policy.CompiledPolicy, bytes int64, audit *flowAudit) {

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -1227,6 +1227,85 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorEnvelope"
+        "429":
+          description: Team quota exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+  /api/v1/quotas/{dimension}:
+    get:
+      tags: [quotas]
+      summary: Get team quota
+      security:
+        - bearerAuth: []
+      x-upstream-service: manager
+      x-upstream-path: /api/v1/quotas/{dimension}
+      parameters:
+        - $ref: "#/components/parameters/QuotaDimension"
+      responses:
+        "200":
+          description: Team quota
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessTeamQuotaResponse"
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+    put:
+      tags: [quotas]
+      summary: Set team quota
+      security:
+        - bearerAuth: []
+      x-upstream-service: manager
+      x-upstream-path: /api/v1/quotas/{dimension}
+      parameters:
+        - $ref: "#/components/parameters/QuotaDimension"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PutTeamQuotaRequest"
+      responses:
+        "200":
+          description: Updated team quota
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessTeamQuotaResponse"
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+    delete:
+      tags: [quotas]
+      summary: Delete team quota
+      security:
+        - bearerAuth: []
+      x-upstream-service: manager
+      x-upstream-path: /api/v1/quotas/{dimension}
+      parameters:
+        - $ref: "#/components/parameters/QuotaDimension"
+      responses:
+        "200":
+          description: Deleted team quota
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessDeletedResponse"
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
   /api/v1/sandboxes/{id}:
     get:
       tags: [sandboxes]
@@ -3163,6 +3242,12 @@ components:
       required: false
       schema:
         type: boolean
+    QuotaDimension:
+      name: dimension
+      in: path
+      required: true
+      schema:
+        $ref: "#/components/schemas/QuotaDimension"
   schemas:
     Error:
       type: object
@@ -3229,6 +3314,43 @@ components:
               properties:
                 message:
                   type: string
+    SuccessTeamQuotaResponse:
+      allOf:
+        - $ref: "#/components/schemas/SuccessEnvelope"
+        - type: object
+          properties:
+            data:
+              $ref: "#/components/schemas/TeamQuota"
+    QuotaDimension:
+      type: string
+      enum:
+        - active_sandboxes
+        - cpu_millicpu
+        - memory_mib
+        - volume_storage_gb
+        - snapshot_storage_gb
+        - egress
+        - ingress
+    TeamQuota:
+      type: object
+      properties:
+        team_id:
+          type: string
+        dimension:
+          $ref: "#/components/schemas/QuotaDimension"
+        limit_value:
+          type: integer
+          format: int64
+          nullable: true
+      required: [team_id, dimension]
+    PutTeamQuotaRequest:
+      type: object
+      properties:
+        limit_value:
+          type: integer
+          format: int64
+          minimum: 0
+      required: [limit_value]
     SuccessRegistryCredentialsResponse:
       allOf:
         - $ref: "#/components/schemas/SuccessEnvelope"

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -181,6 +181,17 @@ const (
 	ProtocolRuleProtocolMcp ProtocolRuleProtocol = "mcp"
 )
 
+// Defines values for QuotaDimension.
+const (
+	ActiveSandboxes   QuotaDimension = "active_sandboxes"
+	CpuMillicpu       QuotaDimension = "cpu_millicpu"
+	Egress            QuotaDimension = "egress"
+	Ingress           QuotaDimension = "ingress"
+	MemoryMib         QuotaDimension = "memory_mib"
+	SnapshotStorageGb QuotaDimension = "snapshot_storage_gb"
+	VolumeStorageGb   QuotaDimension = "volume_storage_gb"
+)
+
 // Defines values for REPLReadyMode.
 const (
 	PromptToken  REPLReadyMode = "prompt_token"
@@ -515,6 +526,11 @@ const (
 	SuccessTeamMemberResponseSuccessTrue SuccessTeamMemberResponseSuccess = true
 )
 
+// Defines values for SuccessTeamQuotaResponseSuccess.
+const (
+	SuccessTeamQuotaResponseSuccessTrue SuccessTeamQuotaResponseSuccess = true
+)
+
 // Defines values for SuccessTeamResponseSuccess.
 const (
 	SuccessTeamResponseSuccessTrue SuccessTeamResponseSuccess = true
@@ -542,7 +558,7 @@ const (
 
 // Defines values for SuccessWrittenResponseSuccess.
 const (
-	SuccessWrittenResponseSuccessTrue SuccessWrittenResponseSuccess = true
+	True SuccessWrittenResponseSuccess = true
 )
 
 // Defines values for TrafficRuleAction.
@@ -1690,6 +1706,14 @@ type ProtocolRule struct {
 // ProtocolRuleProtocol defines model for ProtocolRuleProtocol.
 type ProtocolRuleProtocol string
 
+// PutTeamQuotaRequest defines model for PutTeamQuotaRequest.
+type PutTeamQuotaRequest struct {
+	LimitValue int64 `json:"limit_value"`
+}
+
+// QuotaDimension defines model for QuotaDimension.
+type QuotaDimension string
+
 // REPLConfig defines model for REPLConfig.
 type REPLConfig struct {
 	Candidates  []ExecCandidate   `json:"candidates"`
@@ -2777,6 +2801,15 @@ type SuccessTeamMemberResponse struct {
 // SuccessTeamMemberResponseSuccess defines model for SuccessTeamMemberResponse.Success.
 type SuccessTeamMemberResponseSuccess bool
 
+// SuccessTeamQuotaResponse defines model for SuccessTeamQuotaResponse.
+type SuccessTeamQuotaResponse struct {
+	Data    *TeamQuota                      `json:"data,omitempty"`
+	Success SuccessTeamQuotaResponseSuccess `json:"success"`
+}
+
+// SuccessTeamQuotaResponseSuccess defines model for SuccessTeamQuotaResponse.Success.
+type SuccessTeamQuotaResponseSuccess bool
+
 // SuccessTeamResponse defines model for SuccessTeamResponse.
 type SuccessTeamResponse struct {
 	Data    *Team                      `json:"data,omitempty"`
@@ -2863,6 +2896,13 @@ type TeamMember struct {
 	Role     string    `json:"role"`
 	TeamId   string    `json:"team_id"`
 	UserId   string    `json:"user_id"`
+}
+
+// TeamQuota defines model for TeamQuota.
+type TeamQuota struct {
+	Dimension  QuotaDimension `json:"dimension"`
+	LimitValue *int64         `json:"limit_value"`
+	TeamId     string         `json:"team_id"`
 }
 
 // Template defines model for Template.
@@ -3210,6 +3250,9 @@ type PutApiV1FunctionsIdAliasesAliasJSONRequestBody = FunctionAliasUpdateRequest
 
 // PostApiV1FunctionsIdRevisionsJSONRequestBody defines body for PostApiV1FunctionsIdRevisions for application/json ContentType.
 type PostApiV1FunctionsIdRevisionsJSONRequestBody = FunctionRevisionCreateRequest
+
+// PutApiV1QuotasDimensionJSONRequestBody defines body for PutApiV1QuotasDimension for application/json ContentType.
+type PutApiV1QuotasDimensionJSONRequestBody = PutTeamQuotaRequest
 
 // PostApiV1RegistryCredentialsJSONRequestBody defines body for PostApiV1RegistryCredentials for application/json ContentType.
 type PostApiV1RegistryCredentialsJSONRequestBody = RegistryCredentialsRequest

--- a/pkg/gateway/authn/context.go
+++ b/pkg/gateway/authn/context.go
@@ -88,6 +88,9 @@ const (
 
 	PermSandboxVolumeFileRead  = "sandboxvolumefile:read"
 	PermSandboxVolumeFileWrite = "sandboxvolumefile:write"
+
+	PermQuotaRead  = "quota:read"
+	PermQuotaWrite = "quota:write"
 )
 
 // RolePermissions maps team roles to their permissions.
@@ -115,6 +118,8 @@ var RolePermissions = map[string][]string{
 		PermSandboxVolumeDelete,
 		PermSandboxVolumeFileRead,
 		PermSandboxVolumeFileWrite,
+		PermQuotaRead,
+		PermQuotaWrite,
 	},
 	"developer": {
 		PermSandboxCreate,
@@ -136,6 +141,7 @@ var RolePermissions = map[string][]string{
 		PermSandboxVolumeDelete,
 		PermSandboxVolumeFileRead,
 		PermSandboxVolumeFileWrite,
+		PermQuotaRead,
 	},
 	"builder": {
 		PermTemplateRead,
@@ -149,6 +155,7 @@ var RolePermissions = map[string][]string{
 		PermCredentialSourceRead,
 		PermSandboxVolumeRead,
 		PermSandboxVolumeFileRead,
+		PermQuotaRead,
 	},
 }
 

--- a/pkg/quota/migrate.go
+++ b/pkg/quota/migrate.go
@@ -1,0 +1,28 @@
+package quota
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/sandbox0-ai/sandbox0/pkg/migrate"
+	"github.com/sandbox0-ai/sandbox0/pkg/quota/migrations"
+)
+
+const SchemaName = "quota"
+
+type Logger interface {
+	Printf(format string, args ...any)
+	Fatalf(format string, args ...any)
+}
+
+func RunMigrations(ctx context.Context, pool *pgxpool.Pool, logger Logger) error {
+	if err := migrate.Up(ctx, pool, ".",
+		migrate.WithBaseFS(migrations.FS),
+		migrate.WithLogger(logger),
+		migrate.WithSchema(SchemaName),
+	); err != nil {
+		return fmt.Errorf("run quota migrations: %w", err)
+	}
+	return nil
+}

--- a/pkg/quota/migrations/00001_init_schema.sql
+++ b/pkg/quota/migrations/00001_init_schema.sql
@@ -1,0 +1,36 @@
+-- +goose Up
+
+CREATE TABLE IF NOT EXISTS team_quota_limits (
+    team_id TEXT NOT NULL,
+    dimension TEXT NOT NULL,
+    limit_value BIGINT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (team_id, dimension),
+    CHECK (limit_value >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_team_quota_limits_dimension
+    ON team_quota_limits(dimension);
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+DROP TRIGGER IF EXISTS update_team_quota_limits_updated_at ON team_quota_limits;
+CREATE TRIGGER update_team_quota_limits_updated_at
+    BEFORE UPDATE ON team_quota_limits
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+-- +goose Down
+
+DROP TRIGGER IF EXISTS update_team_quota_limits_updated_at ON team_quota_limits;
+DROP INDEX IF EXISTS idx_team_quota_limits_dimension;
+DROP TABLE IF EXISTS team_quota_limits;

--- a/pkg/quota/migrations/embed.go
+++ b/pkg/quota/migrations/embed.go
@@ -1,0 +1,6 @@
+package migrations
+
+import "embed"
+
+//go:embed *.sql
+var FS embed.FS

--- a/pkg/quota/repository.go
+++ b/pkg/quota/repository.go
@@ -82,6 +82,18 @@ func (r *Repository) CurrentUsage(ctx context.Context, teamID string, dimension 
 			return 0, fmt.Errorf("query active sandbox usage: %w", err)
 		}
 		return current, nil
+	case DimensionCPU:
+		var current int64
+		if err := r.db.QueryRow(ctx, `
+			SELECT COALESCE(SUM(resource_millicpu), 0)
+			FROM metering.manager_sandbox_projection_state
+			WHERE team_id = $1
+				AND claimed_at IS NOT NULL
+				AND terminated_at IS NULL
+		`, teamID).Scan(&current); err != nil {
+			return 0, fmt.Errorf("query cpu quota usage: %w", err)
+		}
+		return current, nil
 	default:
 		return 0, fmt.Errorf("unsupported quota usage dimension %q", dimension)
 	}

--- a/pkg/quota/repository.go
+++ b/pkg/quota/repository.go
@@ -94,6 +94,18 @@ func (r *Repository) CurrentUsage(ctx context.Context, teamID string, dimension 
 			return 0, fmt.Errorf("query cpu quota usage: %w", err)
 		}
 		return current, nil
+	case DimensionMemory:
+		var current int64
+		if err := r.db.QueryRow(ctx, `
+			SELECT COALESCE(SUM(resource_memory_mib), 0)
+			FROM metering.manager_sandbox_projection_state
+			WHERE team_id = $1
+				AND claimed_at IS NOT NULL
+				AND terminated_at IS NULL
+		`, teamID).Scan(&current); err != nil {
+			return 0, fmt.Errorf("query memory quota usage: %w", err)
+		}
+		return current, nil
 	default:
 		return 0, fmt.Errorf("unsupported quota usage dimension %q", dimension)
 	}

--- a/pkg/quota/repository.go
+++ b/pkg/quota/repository.go
@@ -119,6 +119,8 @@ func (r *Repository) CurrentUsage(ctx context.Context, teamID string, dimension 
 			return 0, err
 		}
 		return BytesToGBRoundUp(current), nil
+	case DimensionEgress:
+		return r.currentNetworkUsage(ctx, teamID, metering.WindowTypeSandboxEgressBytes, metering.WindowTypeFunctionEgressBytes)
 	default:
 		return 0, fmt.Errorf("unsupported quota usage dimension %q", dimension)
 	}
@@ -185,6 +187,29 @@ func (r *Repository) currentStorageUsageBytes(ctx context.Context, teamID, subje
 			AND subject_type = $2
 	`, teamID, subjectType).Scan(&current); err != nil {
 		return 0, fmt.Errorf("query storage quota usage: %w", err)
+	}
+	return current, nil
+}
+
+func (r *Repository) currentNetworkUsage(ctx context.Context, teamID string, windowTypes ...string) (int64, error) {
+	if len(windowTypes) == 0 {
+		return 0, fmt.Errorf("window type is required")
+	}
+	args := make([]any, 0, len(windowTypes)+1)
+	args = append(args, teamID)
+	placeholders := make([]string, 0, len(windowTypes))
+	for i, windowType := range windowTypes {
+		args = append(args, windowType)
+		placeholders = append(placeholders, fmt.Sprintf("$%d", i+2))
+	}
+	var current int64
+	if err := r.db.QueryRow(ctx, fmt.Sprintf(`
+		SELECT COALESCE(SUM(value), 0)
+		FROM metering.usage_windows
+		WHERE team_id = $1
+			AND window_type IN (%s)
+	`, strings.Join(placeholders, ", ")), args...).Scan(&current); err != nil {
+		return 0, fmt.Errorf("query network quota usage: %w", err)
 	}
 	return current, nil
 }

--- a/pkg/quota/repository.go
+++ b/pkg/quota/repository.go
@@ -121,6 +121,8 @@ func (r *Repository) CurrentUsage(ctx context.Context, teamID string, dimension 
 		return BytesToGBRoundUp(current), nil
 	case DimensionEgress:
 		return r.currentNetworkUsage(ctx, teamID, metering.WindowTypeSandboxEgressBytes, metering.WindowTypeFunctionEgressBytes)
+	case DimensionIngress:
+		return r.currentNetworkUsage(ctx, teamID, metering.WindowTypeSandboxIngressBytes, metering.WindowTypeFunctionIngressBytes)
 	default:
 		return 0, fmt.Errorf("unsupported quota usage dimension %q", dimension)
 	}

--- a/pkg/quota/repository.go
+++ b/pkg/quota/repository.go
@@ -148,6 +148,29 @@ func (r *Repository) CheckProjectedStorageUsageGB(ctx context.Context, teamID st
 	return decision, decision.Err()
 }
 
+func (r *Repository) CheckAdditionalStorageUsageGB(ctx context.Context, teamID string, dimension Dimension, subjectType string, additionalBytes int64) (Decision, error) {
+	teamID = strings.TrimSpace(teamID)
+	if teamID == "" {
+		return Decision{}, fmt.Errorf("team_id is required")
+	}
+	if additionalBytes <= 0 {
+		return Check(teamID, dimension, 0, 0, nil), nil
+	}
+	limit, err := r.GetLimit(ctx, teamID, dimension)
+	if err != nil {
+		return Decision{}, err
+	}
+	if limit == nil {
+		return Check(teamID, dimension, 0, 0, nil), nil
+	}
+	projected, err := r.AdditionalStorageUsageGB(ctx, teamID, dimension, subjectType, additionalBytes)
+	if err != nil {
+		return Decision{}, err
+	}
+	decision := Check(teamID, dimension, projected, 0, limit)
+	return decision, decision.Err()
+}
+
 func (r *Repository) ProjectedStorageUsageGB(ctx context.Context, teamID string, dimension Dimension, subjectType, subjectID string, sizeBytes int64) (int64, error) {
 	if r == nil || r.db == nil {
 		return 0, nil
@@ -178,6 +201,27 @@ func (r *Repository) ProjectedStorageUsageGB(ctx context.Context, teamID string,
 		return 0, fmt.Errorf("query projected storage quota usage: %w", err)
 	}
 	return BytesToGBRoundUp(otherBytes + sizeBytes), nil
+}
+
+func (r *Repository) AdditionalStorageUsageGB(ctx context.Context, teamID string, dimension Dimension, subjectType string, additionalBytes int64) (int64, error) {
+	if r == nil || r.db == nil {
+		return 0, nil
+	}
+	teamID = strings.TrimSpace(teamID)
+	if teamID == "" {
+		return 0, fmt.Errorf("team_id is required")
+	}
+	if additionalBytes < 0 {
+		return 0, fmt.Errorf("additional_bytes must be non-negative")
+	}
+	if !storageDimensionMatchesSubjectType(dimension, subjectType) {
+		return 0, fmt.Errorf("quota dimension %q does not match storage subject_type %q", dimension, subjectType)
+	}
+	current, err := r.currentStorageUsageBytes(ctx, teamID, subjectType)
+	if err != nil {
+		return 0, err
+	}
+	return BytesToGBRoundUp(current + additionalBytes), nil
 }
 
 func (r *Repository) currentStorageUsageBytes(ctx context.Context, teamID, subjectType string) (int64, error) {

--- a/pkg/quota/repository.go
+++ b/pkg/quota/repository.go
@@ -1,0 +1,141 @@
+package quota
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type DB interface {
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+}
+
+type Repository struct {
+	db DB
+}
+
+func NewRepository(pool *pgxpool.Pool) *Repository {
+	if pool == nil {
+		return nil
+	}
+	return &Repository{db: pool}
+}
+
+func NewRepositoryWithDB(db DB) *Repository {
+	if db == nil {
+		return nil
+	}
+	return &Repository{db: db}
+}
+
+func (r *Repository) GetLimit(ctx context.Context, teamID string, dimension Dimension) (*Limit, error) {
+	if r == nil || r.db == nil {
+		return nil, nil
+	}
+	teamID = strings.TrimSpace(teamID)
+	if teamID == "" {
+		return nil, fmt.Errorf("team_id is required")
+	}
+	if dimension == "" {
+		return nil, fmt.Errorf("dimension is required")
+	}
+
+	var limit Limit
+	err := r.db.QueryRow(ctx, `
+		SELECT team_id, dimension, limit_value
+		FROM quota.team_quota_limits
+		WHERE team_id = $1 AND dimension = $2
+	`, teamID, string(dimension)).Scan(&limit.TeamID, &limit.Dimension, &limit.LimitValue)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("query team quota limit: %w", err)
+	}
+	return &limit, nil
+}
+
+func (r *Repository) CurrentUsage(ctx context.Context, teamID string, dimension Dimension) (int64, error) {
+	if r == nil || r.db == nil {
+		return 0, nil
+	}
+	teamID = strings.TrimSpace(teamID)
+	if teamID == "" {
+		return 0, fmt.Errorf("team_id is required")
+	}
+	switch dimension {
+	case DimensionActiveSandboxes:
+		var current int64
+		if err := r.db.QueryRow(ctx, `
+			SELECT COUNT(*)
+			FROM metering.manager_sandbox_projection_state
+			WHERE team_id = $1
+				AND claimed_at IS NOT NULL
+				AND terminated_at IS NULL
+		`, teamID).Scan(&current); err != nil {
+			return 0, fmt.Errorf("query active sandbox usage: %w", err)
+		}
+		return current, nil
+	default:
+		return 0, fmt.Errorf("unsupported quota usage dimension %q", dimension)
+	}
+}
+
+func (r *Repository) PutLimit(ctx context.Context, limit *Limit) error {
+	if r == nil || r.db == nil {
+		return fmt.Errorf("quota repository is not configured")
+	}
+	if limit == nil {
+		return fmt.Errorf("limit is nil")
+	}
+	limit.TeamID = strings.TrimSpace(limit.TeamID)
+	if limit.TeamID == "" {
+		return fmt.Errorf("team_id is required")
+	}
+	if limit.Dimension == "" {
+		return fmt.Errorf("dimension is required")
+	}
+	if limit.LimitValue < 0 {
+		return fmt.Errorf("limit_value must be non-negative")
+	}
+
+	_, err := r.db.Exec(ctx, `
+		INSERT INTO quota.team_quota_limits (team_id, dimension, limit_value)
+		VALUES ($1, $2, $3)
+		ON CONFLICT (team_id, dimension) DO UPDATE
+		SET limit_value = EXCLUDED.limit_value,
+			updated_at = NOW()
+	`, limit.TeamID, string(limit.Dimension), limit.LimitValue)
+	if err != nil {
+		return fmt.Errorf("upsert team quota limit: %w", err)
+	}
+	return nil
+}
+
+func (r *Repository) DeleteLimit(ctx context.Context, teamID string, dimension Dimension) error {
+	if r == nil || r.db == nil {
+		return fmt.Errorf("quota repository is not configured")
+	}
+	teamID = strings.TrimSpace(teamID)
+	if teamID == "" {
+		return fmt.Errorf("team_id is required")
+	}
+	if dimension == "" {
+		return fmt.Errorf("dimension is required")
+	}
+
+	_, err := r.db.Exec(ctx, `
+		DELETE FROM quota.team_quota_limits
+		WHERE team_id = $1 AND dimension = $2
+	`, teamID, string(dimension))
+	if err != nil {
+		return fmt.Errorf("delete team quota limit: %w", err)
+	}
+	return nil
+}

--- a/pkg/quota/repository.go
+++ b/pkg/quota/repository.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/sandbox0-ai/sandbox0/pkg/metering"
 )
 
 type DB interface {
@@ -106,8 +107,88 @@ func (r *Repository) CurrentUsage(ctx context.Context, teamID string, dimension 
 			return 0, fmt.Errorf("query memory quota usage: %w", err)
 		}
 		return current, nil
+	case DimensionVolumeStorageGB:
+		current, err := r.currentStorageUsageBytes(ctx, teamID, metering.SubjectTypeVolume)
+		if err != nil {
+			return 0, err
+		}
+		return BytesToGBRoundUp(current), nil
 	default:
 		return 0, fmt.Errorf("unsupported quota usage dimension %q", dimension)
+	}
+}
+
+func (r *Repository) CheckProjectedStorageUsageGB(ctx context.Context, teamID string, dimension Dimension, subjectType, subjectID string, sizeBytes int64) (Decision, error) {
+	teamID = strings.TrimSpace(teamID)
+	if teamID == "" {
+		return Decision{}, fmt.Errorf("team_id is required")
+	}
+	limit, err := r.GetLimit(ctx, teamID, dimension)
+	if err != nil {
+		return Decision{}, err
+	}
+	if limit == nil {
+		return Check(teamID, dimension, 0, 0, nil), nil
+	}
+	projected, err := r.ProjectedStorageUsageGB(ctx, teamID, dimension, subjectType, subjectID, sizeBytes)
+	if err != nil {
+		return Decision{}, err
+	}
+	decision := Check(teamID, dimension, projected, 0, limit)
+	return decision, decision.Err()
+}
+
+func (r *Repository) ProjectedStorageUsageGB(ctx context.Context, teamID string, dimension Dimension, subjectType, subjectID string, sizeBytes int64) (int64, error) {
+	if r == nil || r.db == nil {
+		return 0, nil
+	}
+	teamID = strings.TrimSpace(teamID)
+	subjectID = strings.TrimSpace(subjectID)
+	if teamID == "" {
+		return 0, fmt.Errorf("team_id is required")
+	}
+	if subjectID == "" {
+		return 0, fmt.Errorf("subject_id is required")
+	}
+	if sizeBytes < 0 {
+		return 0, fmt.Errorf("size_bytes must be non-negative")
+	}
+	if !storageDimensionMatchesSubjectType(dimension, subjectType) {
+		return 0, fmt.Errorf("quota dimension %q does not match storage subject_type %q", dimension, subjectType)
+	}
+
+	var otherBytes int64
+	if err := r.db.QueryRow(ctx, `
+		SELECT COALESCE(SUM(size_bytes), 0)
+		FROM metering.storage_projection_state
+		WHERE team_id = $1
+			AND subject_type = $2
+			AND subject_id <> $3
+	`, teamID, subjectType, subjectID).Scan(&otherBytes); err != nil {
+		return 0, fmt.Errorf("query projected storage quota usage: %w", err)
+	}
+	return BytesToGBRoundUp(otherBytes + sizeBytes), nil
+}
+
+func (r *Repository) currentStorageUsageBytes(ctx context.Context, teamID, subjectType string) (int64, error) {
+	var current int64
+	if err := r.db.QueryRow(ctx, `
+		SELECT COALESCE(SUM(size_bytes), 0)
+		FROM metering.storage_projection_state
+		WHERE team_id = $1
+			AND subject_type = $2
+	`, teamID, subjectType).Scan(&current); err != nil {
+		return 0, fmt.Errorf("query storage quota usage: %w", err)
+	}
+	return current, nil
+}
+
+func storageDimensionMatchesSubjectType(dimension Dimension, subjectType string) bool {
+	switch dimension {
+	case DimensionVolumeStorageGB:
+		return subjectType == metering.SubjectTypeVolume
+	default:
+		return false
 	}
 }
 

--- a/pkg/quota/repository.go
+++ b/pkg/quota/repository.go
@@ -113,6 +113,12 @@ func (r *Repository) CurrentUsage(ctx context.Context, teamID string, dimension 
 			return 0, err
 		}
 		return BytesToGBRoundUp(current), nil
+	case DimensionSnapshotGB:
+		current, err := r.currentStorageUsageBytes(ctx, teamID, metering.SubjectTypeSnapshot)
+		if err != nil {
+			return 0, err
+		}
+		return BytesToGBRoundUp(current), nil
 	default:
 		return 0, fmt.Errorf("unsupported quota usage dimension %q", dimension)
 	}
@@ -187,6 +193,8 @@ func storageDimensionMatchesSubjectType(dimension Dimension, subjectType string)
 	switch dimension {
 	case DimensionVolumeStorageGB:
 		return subjectType == metering.SubjectTypeVolume
+	case DimensionSnapshotGB:
+		return subjectType == metering.SubjectTypeSnapshot
 	default:
 		return false
 	}

--- a/pkg/quota/repository_test.go
+++ b/pkg/quota/repository_test.go
@@ -116,3 +116,27 @@ func TestProjectedStorageUsageGBExcludesCurrentSubject(t *testing.T) {
 		t.Fatalf("ProjectedStorageUsageGB = %d, want 2", got)
 	}
 }
+
+func TestCurrentUsageReturnsEgressBytes(t *testing.T) {
+	repo := NewRepositoryWithDB(&fakeDB{
+		queryRowFn: func(ctx context.Context, sql string, args ...any) pgx.Row {
+			if !strings.Contains(sql, "usage_windows") {
+				t.Fatalf("sql = %s, want usage windows query", sql)
+			}
+			if args[0] != "team-1" ||
+				args[1] != metering.WindowTypeSandboxEgressBytes ||
+				args[2] != metering.WindowTypeFunctionEgressBytes {
+				t.Fatalf("args = %#v, want team and egress window types", args)
+			}
+			return fakeRow{values: []any{int64(1024)}}
+		},
+	})
+
+	got, err := repo.CurrentUsage(context.Background(), "team-1", DimensionEgress)
+	if err != nil {
+		t.Fatalf("CurrentUsage: %v", err)
+	}
+	if got != 1024 {
+		t.Fatalf("CurrentUsage = %d, want 1024", got)
+	}
+}

--- a/pkg/quota/repository_test.go
+++ b/pkg/quota/repository_test.go
@@ -117,6 +117,25 @@ func TestProjectedStorageUsageGBExcludesCurrentSubject(t *testing.T) {
 	}
 }
 
+func TestAdditionalStorageUsageGBAddsToCurrentTeamStorage(t *testing.T) {
+	repo := NewRepositoryWithDB(&fakeDB{
+		queryRowFn: func(ctx context.Context, sql string, args ...any) pgx.Row {
+			if !strings.Contains(sql, "storage_projection_state") {
+				t.Fatalf("sql = %s, want storage projection query", sql)
+			}
+			return fakeRow{values: []any{BytesPerGB}}
+		},
+	})
+
+	got, err := repo.AdditionalStorageUsageGB(context.Background(), "team-1", DimensionVolumeStorageGB, metering.SubjectTypeVolume, 1)
+	if err != nil {
+		t.Fatalf("AdditionalStorageUsageGB: %v", err)
+	}
+	if got != 2 {
+		t.Fatalf("AdditionalStorageUsageGB = %d, want 2", got)
+	}
+}
+
 func TestCurrentUsageReturnsNetworkBytes(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/pkg/quota/repository_test.go
+++ b/pkg/quota/repository_test.go
@@ -61,25 +61,37 @@ func (r fakeRow) Scan(dest ...any) error {
 	return nil
 }
 
-func TestCurrentUsageReturnsVolumeStorageGB(t *testing.T) {
-	repo := NewRepositoryWithDB(&fakeDB{
-		queryRowFn: func(ctx context.Context, sql string, args ...any) pgx.Row {
-			if !strings.Contains(sql, "storage_projection_state") {
-				t.Fatalf("sql = %s, want storage projection query", sql)
-			}
-			if args[0] != "team-1" || args[1] != metering.SubjectTypeVolume {
-				t.Fatalf("args = %#v, want team and volume subject", args)
-			}
-			return fakeRow{values: []any{BytesPerGB + 1}}
-		},
-	})
-
-	got, err := repo.CurrentUsage(context.Background(), "team-1", DimensionVolumeStorageGB)
-	if err != nil {
-		t.Fatalf("CurrentUsage: %v", err)
+func TestCurrentUsageReturnsStorageGB(t *testing.T) {
+	tests := []struct {
+		name        string
+		dimension   Dimension
+		subjectType string
+	}{
+		{name: "volume", dimension: DimensionVolumeStorageGB, subjectType: metering.SubjectTypeVolume},
+		{name: "snapshot", dimension: DimensionSnapshotGB, subjectType: metering.SubjectTypeSnapshot},
 	}
-	if got != 2 {
-		t.Fatalf("CurrentUsage = %d, want 2", got)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := NewRepositoryWithDB(&fakeDB{
+				queryRowFn: func(ctx context.Context, sql string, args ...any) pgx.Row {
+					if !strings.Contains(sql, "storage_projection_state") {
+						t.Fatalf("sql = %s, want storage projection query", sql)
+					}
+					if args[0] != "team-1" || args[1] != tt.subjectType {
+						t.Fatalf("args = %#v, want team and storage subject", args)
+					}
+					return fakeRow{values: []any{BytesPerGB + 1}}
+				},
+			})
+
+			got, err := repo.CurrentUsage(context.Background(), "team-1", tt.dimension)
+			if err != nil {
+				t.Fatalf("CurrentUsage: %v", err)
+			}
+			if got != 2 {
+				t.Fatalf("CurrentUsage = %d, want 2", got)
+			}
+		})
 	}
 }
 

--- a/pkg/quota/repository_test.go
+++ b/pkg/quota/repository_test.go
@@ -1,0 +1,106 @@
+package quota
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/sandbox0-ai/sandbox0/pkg/metering"
+)
+
+type fakeDB struct {
+	execFn     func(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
+	queryRowFn func(ctx context.Context, sql string, args ...any) pgx.Row
+}
+
+func (f *fakeDB) Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+	if f.execFn != nil {
+		return f.execFn(ctx, sql, args...)
+	}
+	return pgconn.CommandTag{}, nil
+}
+
+func (f *fakeDB) QueryRow(ctx context.Context, sql string, args ...any) pgx.Row {
+	if f.queryRowFn != nil {
+		return f.queryRowFn(ctx, sql, args...)
+	}
+	return fakeRow{}
+}
+
+type fakeRow struct {
+	values []any
+	err    error
+}
+
+func (r fakeRow) Scan(dest ...any) error {
+	if r.err != nil {
+		return r.err
+	}
+	for i := range dest {
+		switch typed := dest[i].(type) {
+		case *int64:
+			*typed = r.values[i].(int64)
+		case *string:
+			*typed = r.values[i].(string)
+		case *Dimension:
+			switch value := r.values[i].(type) {
+			case Dimension:
+				*typed = value
+			case string:
+				*typed = Dimension(value)
+			default:
+				return errors.New("unsupported dimension value")
+			}
+		default:
+			return errors.New("unsupported scan target")
+		}
+	}
+	return nil
+}
+
+func TestCurrentUsageReturnsVolumeStorageGB(t *testing.T) {
+	repo := NewRepositoryWithDB(&fakeDB{
+		queryRowFn: func(ctx context.Context, sql string, args ...any) pgx.Row {
+			if !strings.Contains(sql, "storage_projection_state") {
+				t.Fatalf("sql = %s, want storage projection query", sql)
+			}
+			if args[0] != "team-1" || args[1] != metering.SubjectTypeVolume {
+				t.Fatalf("args = %#v, want team and volume subject", args)
+			}
+			return fakeRow{values: []any{BytesPerGB + 1}}
+		},
+	})
+
+	got, err := repo.CurrentUsage(context.Background(), "team-1", DimensionVolumeStorageGB)
+	if err != nil {
+		t.Fatalf("CurrentUsage: %v", err)
+	}
+	if got != 2 {
+		t.Fatalf("CurrentUsage = %d, want 2", got)
+	}
+}
+
+func TestProjectedStorageUsageGBExcludesCurrentSubject(t *testing.T) {
+	repo := NewRepositoryWithDB(&fakeDB{
+		queryRowFn: func(ctx context.Context, sql string, args ...any) pgx.Row {
+			if !strings.Contains(sql, "subject_id <> $3") {
+				t.Fatalf("sql = %s, want current subject exclusion", sql)
+			}
+			if args[2] != "vol-1" {
+				t.Fatalf("subject id arg = %v, want vol-1", args[2])
+			}
+			return fakeRow{values: []any{BytesPerGB}}
+		},
+	})
+
+	got, err := repo.ProjectedStorageUsageGB(context.Background(), "team-1", DimensionVolumeStorageGB, metering.SubjectTypeVolume, "vol-1", 1)
+	if err != nil {
+		t.Fatalf("ProjectedStorageUsageGB: %v", err)
+	}
+	if got != 2 {
+		t.Fatalf("ProjectedStorageUsageGB = %d, want 2", got)
+	}
+}

--- a/pkg/quota/repository_test.go
+++ b/pkg/quota/repository_test.go
@@ -117,26 +117,36 @@ func TestProjectedStorageUsageGBExcludesCurrentSubject(t *testing.T) {
 	}
 }
 
-func TestCurrentUsageReturnsEgressBytes(t *testing.T) {
-	repo := NewRepositoryWithDB(&fakeDB{
-		queryRowFn: func(ctx context.Context, sql string, args ...any) pgx.Row {
-			if !strings.Contains(sql, "usage_windows") {
-				t.Fatalf("sql = %s, want usage windows query", sql)
-			}
-			if args[0] != "team-1" ||
-				args[1] != metering.WindowTypeSandboxEgressBytes ||
-				args[2] != metering.WindowTypeFunctionEgressBytes {
-				t.Fatalf("args = %#v, want team and egress window types", args)
-			}
-			return fakeRow{values: []any{int64(1024)}}
-		},
-	})
-
-	got, err := repo.CurrentUsage(context.Background(), "team-1", DimensionEgress)
-	if err != nil {
-		t.Fatalf("CurrentUsage: %v", err)
+func TestCurrentUsageReturnsNetworkBytes(t *testing.T) {
+	tests := []struct {
+		name        string
+		dimension   Dimension
+		windowTypes []string
+	}{
+		{name: "egress", dimension: DimensionEgress, windowTypes: []string{metering.WindowTypeSandboxEgressBytes, metering.WindowTypeFunctionEgressBytes}},
+		{name: "ingress", dimension: DimensionIngress, windowTypes: []string{metering.WindowTypeSandboxIngressBytes, metering.WindowTypeFunctionIngressBytes}},
 	}
-	if got != 1024 {
-		t.Fatalf("CurrentUsage = %d, want 1024", got)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := NewRepositoryWithDB(&fakeDB{
+				queryRowFn: func(ctx context.Context, sql string, args ...any) pgx.Row {
+					if !strings.Contains(sql, "usage_windows") {
+						t.Fatalf("sql = %s, want usage windows query", sql)
+					}
+					if args[0] != "team-1" || args[1] != tt.windowTypes[0] || args[2] != tt.windowTypes[1] {
+						t.Fatalf("args = %#v, want team and network window types", args)
+					}
+					return fakeRow{values: []any{int64(1024)}}
+				},
+			})
+
+			got, err := repo.CurrentUsage(context.Background(), "team-1", tt.dimension)
+			if err != nil {
+				t.Fatalf("CurrentUsage: %v", err)
+			}
+			if got != 1024 {
+				t.Fatalf("CurrentUsage = %d, want 1024", got)
+			}
+		})
 	}
 }

--- a/pkg/quota/types.go
+++ b/pkg/quota/types.go
@@ -1,0 +1,84 @@
+package quota
+
+import "fmt"
+
+type Dimension string
+
+const (
+	DimensionActiveSandboxes Dimension = "active_sandboxes"
+	DimensionCPU             Dimension = "cpu_millicpu"
+	DimensionMemory          Dimension = "memory_mib"
+	DimensionVolumeStorageGB Dimension = "volume_storage_gb"
+	DimensionSnapshotGB      Dimension = "snapshot_storage_gb"
+	DimensionEgress          Dimension = "egress"
+	DimensionIngress         Dimension = "ingress"
+)
+
+func KnownDimension(d Dimension) bool {
+	switch d {
+	case DimensionActiveSandboxes,
+		DimensionCPU,
+		DimensionMemory,
+		DimensionVolumeStorageGB,
+		DimensionSnapshotGB,
+		DimensionEgress,
+		DimensionIngress:
+		return true
+	default:
+		return false
+	}
+}
+
+type Limit struct {
+	TeamID     string    `json:"team_id"`
+	Dimension  Dimension `json:"dimension"`
+	LimitValue int64     `json:"limit_value"`
+}
+
+type Decision struct {
+	Allowed    bool      `json:"allowed"`
+	TeamID     string    `json:"team_id"`
+	Dimension  Dimension `json:"dimension"`
+	LimitValue int64     `json:"limit_value"`
+	Current    int64     `json:"current"`
+	Requested  int64     `json:"requested"`
+}
+
+func (d Decision) Err() error {
+	if d.Allowed {
+		return nil
+	}
+	return &ExceededError{Decision: d}
+}
+
+type ExceededError struct {
+	Decision Decision
+}
+
+func (e *ExceededError) Error() string {
+	if e == nil {
+		return "quota exceeded"
+	}
+	d := e.Decision
+	return fmt.Sprintf("quota exceeded for %s: current %d + requested %d exceeds limit %d", d.Dimension, d.Current, d.Requested, d.LimitValue)
+}
+
+func Check(teamID string, dimension Dimension, current, requested int64, limit *Limit) Decision {
+	decision := Decision{
+		Allowed:   true,
+		TeamID:    teamID,
+		Dimension: dimension,
+		Current:   current,
+		Requested: requested,
+	}
+	if limit == nil {
+		return decision
+	}
+	decision.LimitValue = limit.LimitValue
+	if requested < 0 {
+		requested = 0
+		decision.Requested = 0
+	}
+	decision.Allowed = current+requested <= limit.LimitValue
+	return decision
+}

--- a/pkg/quota/types.go
+++ b/pkg/quota/types.go
@@ -1,6 +1,11 @@
 package quota
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
+
+const BytesPerGB int64 = 1_000_000_000
 
 type Dimension string
 
@@ -61,6 +66,18 @@ func (e *ExceededError) Error() string {
 	}
 	d := e.Decision
 	return fmt.Sprintf("quota exceeded for %s: current %d + requested %d exceeds limit %d", d.Dimension, d.Current, d.Requested, d.LimitValue)
+}
+
+func IsExceeded(err error) bool {
+	var exceeded *ExceededError
+	return errors.As(err, &exceeded)
+}
+
+func BytesToGBRoundUp(value int64) int64 {
+	if value <= 0 {
+		return 0
+	}
+	return (value + BytesPerGB - 1) / BytesPerGB
 }
 
 func Check(teamID string, dimension Dimension, current, requested int64, limit *Limit) Decision {

--- a/pkg/quota/types_test.go
+++ b/pkg/quota/types_test.go
@@ -1,6 +1,9 @@
 package quota
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
 func TestCheckAllowsUnlimitedWhenLimitIsNil(t *testing.T) {
 	decision := Check("team-1", DimensionActiveSandboxes, 100, 1, nil)
@@ -20,5 +23,35 @@ func TestCheckRejectsWhenRequestedWouldExceedLimit(t *testing.T) {
 	}
 	if decision.Err() == nil {
 		t.Fatal("Err() = nil, want quota error")
+	}
+}
+
+func TestIsExceeded(t *testing.T) {
+	err := (&Decision{Allowed: false}).Err()
+	if !IsExceeded(err) {
+		t.Fatal("IsExceeded = false, want true")
+	}
+	if IsExceeded(errors.New("other")) {
+		t.Fatal("IsExceeded = true for non-quota error")
+	}
+}
+
+func TestBytesToGBRoundUp(t *testing.T) {
+	tests := []struct {
+		name  string
+		value int64
+		want  int64
+	}{
+		{name: "zero", value: 0, want: 0},
+		{name: "one byte", value: 1, want: 1},
+		{name: "one gb", value: BytesPerGB, want: 1},
+		{name: "one gb plus one byte", value: BytesPerGB + 1, want: 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := BytesToGBRoundUp(tt.value); got != tt.want {
+				t.Fatalf("BytesToGBRoundUp(%d) = %d, want %d", tt.value, got, tt.want)
+			}
+		})
 	}
 }

--- a/pkg/quota/types_test.go
+++ b/pkg/quota/types_test.go
@@ -1,0 +1,24 @@
+package quota
+
+import "testing"
+
+func TestCheckAllowsUnlimitedWhenLimitIsNil(t *testing.T) {
+	decision := Check("team-1", DimensionActiveSandboxes, 100, 1, nil)
+	if !decision.Allowed {
+		t.Fatalf("Allowed = false, want true")
+	}
+}
+
+func TestCheckRejectsWhenRequestedWouldExceedLimit(t *testing.T) {
+	decision := Check("team-1", DimensionActiveSandboxes, 2, 1, &Limit{
+		TeamID:     "team-1",
+		Dimension:  DimensionActiveSandboxes,
+		LimitValue: 2,
+	})
+	if decision.Allowed {
+		t.Fatalf("Allowed = true, want false")
+	}
+	if decision.Err() == nil {
+		t.Fatal("Err() = nil, want quota error")
+	}
+}

--- a/storage-proxy/cmd/storage-proxy/main.go
+++ b/storage-proxy/cmd/storage-proxy/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/observability"
 	httpobs "github.com/sandbox0-ai/sandbox0/pkg/observability/http"
 	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
+	"github.com/sandbox0-ai/sandbox0/pkg/quota"
 	spmigrations "github.com/sandbox0-ai/sandbox0/storage-proxy/migrations"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/auth"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/coordinator"
@@ -93,6 +94,7 @@ func main() {
 	// Initialize database connection pool
 	var repo *db.Repository
 	var meteringRepo *metering.Repository
+	var quotaRepo *quota.Repository
 	var pool *pgxpool.Pool
 	var sharedClock *clock.Clock
 	if cfg.DatabaseURL != "" {
@@ -117,9 +119,13 @@ func main() {
 		if err := metering.RunMigrations(context.Background(), pool, &zapLoggerAdapter{logger: zapLogger}); err != nil {
 			zapLogger.Fatal("Failed to run metering migrations", zap.Error(err))
 		}
+		if err := quota.RunMigrations(context.Background(), pool, &zapLoggerAdapter{logger: zapLogger}); err != nil {
+			zapLogger.Fatal("Failed to run quota migrations", zap.Error(err))
+		}
 
 		repo = db.NewRepository(pool)
 		meteringRepo = metering.NewRepository(pool)
+		quotaRepo = quota.NewRepository(pool)
 	} else {
 		zapLogger.Warn("DATABASE_URL not set, running without database persistence")
 	}
@@ -232,6 +238,7 @@ func main() {
 		zapLogger.Fatal("Failed to initialize snapshot manager", zap.Error(err))
 	}
 	snapshotMgr.SetMeteringRepository(meteringRepo)
+	snapshotMgr.SetQuotaRepository(quotaRepo)
 	volMgr.SetStorageObserver(snapshotMgr)
 	if eventBroadcaster != nil {
 		snapshotMgr.SetEventPublisher(eventBroadcaster)
@@ -250,6 +257,7 @@ func main() {
 
 	// Create HTTP server
 	httpSrv := httpserver.NewServer(logrusLogger, cfg, k8sClient, repo, meteringRepo, cfg.RegionID, httpAuthenticator, snapshotMgr, volumeBarrier, volMgr, fsServer, eventHub)
+	httpSrv.SetQuotaRepository(quotaRepo)
 	httpAddr := fmt.Sprintf("%s:%d", cfg.HTTPAddr, cfg.HTTPPort)
 
 	readTimeout, _ := time.ParseDuration(cfg.HTTPReadTimeout)

--- a/storage-proxy/pkg/http/handlers_sandboxvolume.go
+++ b/storage-proxy/pkg/http/handlers_sandboxvolume.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	meteringpkg "github.com/sandbox0-ai/sandbox0/pkg/metering"
+	"github.com/sandbox0-ai/sandbox0/pkg/quota"
 	"github.com/sandbox0-ai/sandbox0/pkg/volumeportal"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/snapshot"
@@ -133,6 +134,8 @@ func (s *Server) createSandboxVolume(w http.ResponseWriter, r *http.Request) {
 		})
 		if err != nil {
 			switch {
+			case quota.IsExceeded(err):
+				_ = spec.WriteError(w, http.StatusTooManyRequests, "quota_exceeded", err.Error())
 			case errors.Is(err, snapshot.ErrSnapshotNotFound), errors.Is(err, snapshot.ErrVolumeNotFound):
 				_ = spec.WriteError(w, http.StatusNotFound, spec.CodeNotFound, "snapshot not found")
 			case errors.Is(err, snapshot.ErrInvalidAccessMode):
@@ -170,6 +173,10 @@ func (s *Server) createSandboxVolume(w http.ResponseWriter, r *http.Request) {
 		}
 		return nil
 	}); err != nil {
+		if quota.IsExceeded(err) {
+			_ = spec.WriteError(w, http.StatusTooManyRequests, "quota_exceeded", err.Error())
+			return
+		}
 		s.logger.WithError(err).Error("Failed to create sandbox volume")
 		_ = spec.WriteError(w, http.StatusInternalServerError, spec.CodeInternal, "internal server error")
 		return
@@ -846,6 +853,8 @@ func (s *Server) forkVolume(w http.ResponseWriter, r *http.Request) {
 	}
 	if err != nil {
 		switch {
+		case quota.IsExceeded(err):
+			_ = spec.WriteError(w, http.StatusTooManyRequests, "quota_exceeded", err.Error())
 		case errors.Is(err, snapshot.ErrVolumeNotFound):
 			_ = spec.WriteError(w, http.StatusNotFound, spec.CodeNotFound, "volume not found")
 		case errors.Is(err, snapshot.ErrInvalidAccessMode):

--- a/storage-proxy/pkg/http/handlers_snapshot.go
+++ b/storage-proxy/pkg/http/handlers_snapshot.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+	"github.com/sandbox0-ai/sandbox0/pkg/quota"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/snapshot"
 )
 
@@ -239,6 +240,8 @@ func (s *Server) deleteSnapshot(w http.ResponseWriter, r *http.Request) {
 // handleSnapshotError maps snapshot errors to HTTP responses
 func (s *Server) handleSnapshotError(w http.ResponseWriter, err error) {
 	switch {
+	case quota.IsExceeded(err):
+		_ = spec.WriteError(w, http.StatusTooManyRequests, "quota_exceeded", err.Error())
 	case errors.Is(err, snapshot.ErrVolumeNotFound):
 		_ = spec.WriteError(w, http.StatusNotFound, spec.CodeNotFound, "volume not found")
 	case errors.Is(err, snapshot.ErrSnapshotNotFound):

--- a/storage-proxy/pkg/http/handlers_volume_files.go
+++ b/storage-proxy/pkg/http/handlers_volume_files.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	httpproxy "github.com/sandbox0-ai/sandbox0/pkg/proxy"
+	"github.com/sandbox0-ai/sandbox0/pkg/quota"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/fserror"
 	pb "github.com/sandbox0-ai/sandbox0/storage-proxy/proto/fs"
@@ -1488,6 +1489,8 @@ func (s *Server) writeVolumeFileError(w http.ResponseWriter, err error) {
 		_ = spec.WriteError(w, http.StatusConflict, spec.CodeConflict, err.Error())
 	case errors.Is(err, errInvalidPath), errors.Is(err, errInvalidArchive):
 		_ = spec.WriteError(w, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
+	case quota.IsExceeded(err):
+		_ = spec.WriteError(w, http.StatusTooManyRequests, "quota_exceeded", err.Error())
 	default:
 		_ = spec.WriteError(w, http.StatusInternalServerError, spec.CodeInternal, err.Error())
 	}

--- a/storage-proxy/pkg/http/handlers_volume_files.go
+++ b/storage-proxy/pkg/http/handlers_volume_files.go
@@ -523,13 +523,13 @@ func (s *Server) readVolumeFile(w http.ResponseWriter, r *http.Request, volumeID
 
 func (s *Server) writeVolumeFile(w http.ResponseWriter, r *http.Request, volumeID, logicalPath string) {
 	s.withSharedVolumeFileRequest(w, r, volumeID, func(lockedReq *http.Request) {
-		ctx, volumeRecord, cleanup, handled := s.prepareOrProxyVolumeFileRequest(w, lockedReq, volumeID)
-		if handled {
-			return
-		}
-		defer cleanup()
-
 		if lockedReq.URL.Query().Get("mkdir") == "true" {
+			ctx, _, cleanup, handled := s.prepareOrProxyVolumeFileRequest(w, lockedReq, volumeID)
+			if handled {
+				return
+			}
+			defer cleanup()
+
 			changed, err := s.mkdirVolumePath(ctx, volumeID, logicalPath, lockedReq.URL.Query().Get("recursive") == "true")
 			if err != nil {
 				s.writeVolumeFileError(w, err)
@@ -554,10 +554,24 @@ func (s *Server) writeVolumeFile(w http.ResponseWriter, r *http.Request, volumeI
 			s.writeVolumeFileError(w, errFileTooLarge)
 			return
 		}
-		if err := s.enforceVolumeStorageAdditionalQuota(ctx, volumeRecord, int64(len(data))); err != nil {
+
+		volumeRecord, err := s.loadAuthorizedVolume(lockedReq.Context(), volumeID)
+		if err != nil {
 			s.writeVolumeFileError(w, err)
 			return
 		}
+		if err := s.enforceVolumeStorageAdditionalQuota(lockedReq.Context(), volumeRecord, int64(len(data))); err != nil {
+			s.writeVolumeFileError(w, err)
+			return
+		}
+		lockedReq.Body = io.NopCloser(bytes.NewReader(data))
+		lockedReq.ContentLength = int64(len(data))
+
+		ctx, _, cleanup, handled := s.prepareOrProxyVolumeFileRequest(w, lockedReq, volumeID)
+		if handled {
+			return
+		}
+		defer cleanup()
 
 		changed, err := s.writeVolumePath(ctx, volumeID, logicalPath, data)
 		if err != nil {

--- a/storage-proxy/pkg/http/handlers_volume_files.go
+++ b/storage-proxy/pkg/http/handlers_volume_files.go
@@ -523,7 +523,7 @@ func (s *Server) readVolumeFile(w http.ResponseWriter, r *http.Request, volumeID
 
 func (s *Server) writeVolumeFile(w http.ResponseWriter, r *http.Request, volumeID, logicalPath string) {
 	s.withSharedVolumeFileRequest(w, r, volumeID, func(lockedReq *http.Request) {
-		ctx, _, cleanup, handled := s.prepareOrProxyVolumeFileRequest(w, lockedReq, volumeID)
+		ctx, volumeRecord, cleanup, handled := s.prepareOrProxyVolumeFileRequest(w, lockedReq, volumeID)
 		if handled {
 			return
 		}
@@ -552,6 +552,10 @@ func (s *Server) writeVolumeFile(w http.ResponseWriter, r *http.Request, volumeI
 		}
 		if len(data) > maxVolumeFileSize {
 			s.writeVolumeFileError(w, errFileTooLarge)
+			return
+		}
+		if err := s.enforceVolumeStorageAdditionalQuota(ctx, volumeRecord, int64(len(data))); err != nil {
+			s.writeVolumeFileError(w, err)
 			return
 		}
 

--- a/storage-proxy/pkg/http/handlers_volume_files_test.go
+++ b/storage-proxy/pkg/http/handlers_volume_files_test.go
@@ -11,13 +11,17 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strconv"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+	"github.com/sandbox0-ai/sandbox0/pkg/quota"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/fserror"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volume"
@@ -49,6 +53,56 @@ type fakeHTTPSharedVolumeBarrier struct {
 	sharedCalls    int
 	exclusiveCalls int
 	lastVolumeID   string
+}
+
+type fakeQuotaDB struct {
+	limit        *quota.Limit
+	currentBytes int64
+}
+
+type fakeQuotaRow struct {
+	values []any
+	err    error
+}
+
+func (db *fakeQuotaDB) Exec(context.Context, string, ...any) (pgconn.CommandTag, error) {
+	return pgconn.CommandTag{}, nil
+}
+
+func (db *fakeQuotaDB) QueryRow(_ context.Context, sql string, _ ...any) pgx.Row {
+	switch {
+	case strings.Contains(sql, "quota.team_quota_limits"):
+		if db.limit == nil {
+			return fakeQuotaRow{err: pgx.ErrNoRows}
+		}
+		return fakeQuotaRow{values: []any{db.limit.TeamID, db.limit.Dimension, db.limit.LimitValue}}
+	case strings.Contains(sql, "metering.storage_projection_state"):
+		return fakeQuotaRow{values: []any{db.currentBytes}}
+	default:
+		return fakeQuotaRow{err: errors.New("unexpected quota query")}
+	}
+}
+
+func (r fakeQuotaRow) Scan(dest ...any) error {
+	if r.err != nil {
+		return r.err
+	}
+	if len(dest) != len(r.values) {
+		return errors.New("unexpected scan destination count")
+	}
+	for i, value := range r.values {
+		switch target := dest[i].(type) {
+		case *string:
+			*target = value.(string)
+		case *quota.Dimension:
+			*target = value.(quota.Dimension)
+		case *int64:
+			*target = value.(int64)
+		default:
+			return errors.New("unexpected scan destination type")
+		}
+	}
+	return nil
 }
 
 func mustMountOptionsRaw(t *testing.T, opts volume.MountOptions) *json.RawMessage {
@@ -647,6 +701,59 @@ func TestWriteVolumeFileSkipsSyncWhenContentUnchanged(t *testing.T) {
 	}
 	if volMgr.syncCalls != 0 {
 		t.Fatalf("SyncDirectVolumeFileMount() calls = %d, want 0", volMgr.syncCalls)
+	}
+}
+
+func TestWriteVolumeFileChecksQuotaBeforeProxyingToOwner(t *testing.T) {
+	remoteSeen := make(chan struct{}, 1)
+	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case remoteSeen <- struct{}{}:
+		default:
+		}
+		_ = spec.WriteSuccess(w, http.StatusOK, map[string]bool{"written": true})
+	}))
+	defer remote.Close()
+
+	fileRPC := &fakeHTTPVolumeFileRPC{}
+	server, volMgr := newVolumeFileTestServer(fileRPC)
+	server.quotaRepo = quota.NewRepositoryWithDB(&fakeQuotaDB{
+		limit: &quota.Limit{
+			TeamID:     "team-a",
+			Dimension:  quota.DimensionVolumeStorageGB,
+			LimitValue: 0,
+		},
+	})
+	repo := server.repo.(*fakeHTTPRepo)
+	repo.activeMounts["vol-1"] = []*db.VolumeMount{
+		{
+			VolumeID:  "vol-1",
+			ClusterID: "cluster-a",
+			PodID:     "remote-pod",
+			MountedAt: time.Unix(10, 0),
+		},
+	}
+	server.podResolver = &fakeVolumeFilePodResolver{
+		urls: map[string]string{"remote-pod": remote.URL},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/sandboxvolumes/vol-1/files?path=/quota.txt", bytes.NewReader([]byte("quota")))
+	req.SetPathValue("id", "vol-1")
+	req = req.WithContext(internalauth.WithClaims(req.Context(), &internalauth.Claims{TeamID: "team-a"}))
+	recorder := httptest.NewRecorder()
+
+	server.handleVolumeFileOperation(recorder, req)
+
+	if recorder.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusTooManyRequests)
+	}
+	if volMgr.acquireCalls != 0 {
+		t.Fatalf("AcquireDirectVolumeFileMount() calls = %d, want 0", volMgr.acquireCalls)
+	}
+	select {
+	case <-remoteSeen:
+		t.Fatal("quota exceeded write was proxied to owner")
+	default:
 	}
 }
 

--- a/storage-proxy/pkg/http/server.go
+++ b/storage-proxy/pkg/http/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	meteringpkg "github.com/sandbox0-ai/sandbox0/pkg/metering"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
+	"github.com/sandbox0-ai/sandbox0/pkg/quota"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/auth"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/notify"
@@ -115,6 +116,7 @@ type Server struct {
 	cfg            *config.StorageProxyConfig
 	repo           volumeRepository
 	meteringRepo   meteringWriter
+	quotaRepo      *quota.Repository
 	regionID       string
 	authenticator  *auth.HTTPAuthenticator
 	snapshotMgr    snapshotManager
@@ -127,6 +129,10 @@ type Server struct {
 	ctldHTTPClient *http.Client
 	selfPodID      string
 	selfClusterID  string
+}
+
+func (s *Server) SetQuotaRepository(repo *quota.Repository) {
+	s.quotaRepo = repo
 }
 
 // NewServer creates a new HTTP server
@@ -300,6 +306,9 @@ func (s *Server) appendMeteringEventTx(ctx context.Context, tx pgx.Tx, event *me
 func (s *Server) appendStorageObservationTx(ctx context.Context, tx pgx.Tx, observation *meteringpkg.StorageObservation) error {
 	if s.meteringRepo == nil || observation == nil {
 		return nil
+	}
+	if err := s.enforceStorageObservationQuota(ctx, observation); err != nil {
+		return err
 	}
 	if err := s.meteringRepo.RecordStorageObservationTx(ctx, tx, observation); err != nil {
 		return err

--- a/storage-proxy/pkg/http/storage_quota.go
+++ b/storage-proxy/pkg/http/storage_quota.go
@@ -23,6 +23,8 @@ func storageQuotaDimension(subjectType string) (quota.Dimension, bool) {
 	switch subjectType {
 	case meteringpkg.SubjectTypeVolume:
 		return quota.DimensionVolumeStorageGB, true
+	case meteringpkg.SubjectTypeSnapshot:
+		return quota.DimensionSnapshotGB, true
 	default:
 		return "", false
 	}

--- a/storage-proxy/pkg/http/storage_quota.go
+++ b/storage-proxy/pkg/http/storage_quota.go
@@ -1,0 +1,29 @@
+package http
+
+import (
+	"context"
+
+	meteringpkg "github.com/sandbox0-ai/sandbox0/pkg/metering"
+	"github.com/sandbox0-ai/sandbox0/pkg/quota"
+)
+
+func (s *Server) enforceStorageObservationQuota(ctx context.Context, observation *meteringpkg.StorageObservation) error {
+	if s == nil || s.quotaRepo == nil || observation == nil || observation.TeamID == "" {
+		return nil
+	}
+	dimension, ok := storageQuotaDimension(observation.SubjectType)
+	if !ok {
+		return nil
+	}
+	_, err := s.quotaRepo.CheckProjectedStorageUsageGB(ctx, observation.TeamID, dimension, observation.SubjectType, observation.SubjectID, observation.SizeBytes)
+	return err
+}
+
+func storageQuotaDimension(subjectType string) (quota.Dimension, bool) {
+	switch subjectType {
+	case meteringpkg.SubjectTypeVolume:
+		return quota.DimensionVolumeStorageGB, true
+	default:
+		return "", false
+	}
+}

--- a/storage-proxy/pkg/http/storage_quota.go
+++ b/storage-proxy/pkg/http/storage_quota.go
@@ -5,6 +5,7 @@ import (
 
 	meteringpkg "github.com/sandbox0-ai/sandbox0/pkg/metering"
 	"github.com/sandbox0-ai/sandbox0/pkg/quota"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
 )
 
 func (s *Server) enforceStorageObservationQuota(ctx context.Context, observation *meteringpkg.StorageObservation) error {
@@ -16,6 +17,14 @@ func (s *Server) enforceStorageObservationQuota(ctx context.Context, observation
 		return nil
 	}
 	_, err := s.quotaRepo.CheckProjectedStorageUsageGB(ctx, observation.TeamID, dimension, observation.SubjectType, observation.SubjectID, observation.SizeBytes)
+	return err
+}
+
+func (s *Server) enforceVolumeStorageAdditionalQuota(ctx context.Context, volume *db.SandboxVolume, additionalBytes int64) error {
+	if s == nil || s.quotaRepo == nil || volume == nil || volume.TeamID == "" || additionalBytes <= 0 {
+		return nil
+	}
+	_, err := s.quotaRepo.CheckAdditionalStorageUsageGB(ctx, volume.TeamID, quota.DimensionVolumeStorageGB, meteringpkg.SubjectTypeVolume, additionalBytes)
 	return err
 }
 

--- a/storage-proxy/pkg/snapshot/manager.go
+++ b/storage-proxy/pkg/snapshot/manager.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
 	meteringpkg "github.com/sandbox0-ai/sandbox0/pkg/metering"
 	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
+	"github.com/sandbox0-ai/sandbox0/pkg/quota"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/fsmeta"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volume"
@@ -93,6 +94,7 @@ type Manager struct {
 	podID             string
 	eventPublisher    eventPublisher
 	meteringRepo      meteringRecorder
+	quotaRepo         *quota.Repository
 	metrics           *obsmetrics.StorageProxyMetrics
 }
 
@@ -129,6 +131,12 @@ func (m *Manager) SetMeteringRepository(repo meteringRecorder) {
 	m.meteringRepo = repo
 }
 
+func (m *Manager) SetQuotaRepository(repo *quota.Repository) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.quotaRepo = repo
+}
+
 func (m *Manager) appendMeteringEvent(ctx context.Context, event *meteringpkg.Event) error {
 	if m.meteringRepo == nil || event == nil {
 		return nil
@@ -153,6 +161,9 @@ func (m *Manager) appendStorageObservation(ctx context.Context, observation *met
 	if m.meteringRepo == nil || observation == nil {
 		return nil
 	}
+	if err := m.enforceStorageObservationQuota(ctx, observation); err != nil {
+		return err
+	}
 	if err := m.meteringRepo.RecordStorageObservation(ctx, observation); err != nil {
 		return err
 	}
@@ -162,6 +173,9 @@ func (m *Manager) appendStorageObservation(ctx context.Context, observation *met
 func (m *Manager) appendStorageObservationTx(ctx context.Context, tx pgx.Tx, observation *meteringpkg.StorageObservation) error {
 	if m.meteringRepo == nil || observation == nil {
 		return nil
+	}
+	if err := m.enforceStorageObservationQuota(ctx, observation); err != nil {
+		return err
 	}
 	if err := m.meteringRepo.RecordStorageObservationTx(ctx, tx, observation); err != nil {
 		return err

--- a/storage-proxy/pkg/snapshot/s0fs.go
+++ b/storage-proxy/pkg/snapshot/s0fs.go
@@ -386,6 +386,13 @@ func (m *Manager) createS0FSSnapshot(ctx context.Context, req *CreateSnapshotReq
 		SizeBytes:   snapshotSizeBytes(state),
 		CreatedAt:   time.Now(),
 	}
+	if err := m.enforceStorageObservationQuota(ctx, applyStorageObservationMetadata(
+		m.snapshotStorageObservation(ctx, snapshot, snapshot.CreatedAt),
+		req.StorageMetadata,
+	)); err != nil {
+		_ = engine.DeleteSnapshot(snapshotID)
+		return nil, err
+	}
 	if err := m.repo.CreateSnapshot(ctx, snapshot); err != nil {
 		_ = engine.DeleteSnapshot(snapshotID)
 		return nil, err

--- a/storage-proxy/pkg/snapshot/storage_quota.go
+++ b/storage-proxy/pkg/snapshot/storage_quota.go
@@ -29,6 +29,8 @@ func storageQuotaDimension(subjectType string) (quota.Dimension, bool) {
 	switch subjectType {
 	case meteringpkg.SubjectTypeVolume:
 		return quota.DimensionVolumeStorageGB, true
+	case meteringpkg.SubjectTypeSnapshot:
+		return quota.DimensionSnapshotGB, true
 	default:
 		return "", false
 	}

--- a/storage-proxy/pkg/snapshot/storage_quota.go
+++ b/storage-proxy/pkg/snapshot/storage_quota.go
@@ -1,0 +1,35 @@
+package snapshot
+
+import (
+	"context"
+
+	meteringpkg "github.com/sandbox0-ai/sandbox0/pkg/metering"
+	"github.com/sandbox0-ai/sandbox0/pkg/quota"
+)
+
+func (m *Manager) enforceStorageObservationQuota(ctx context.Context, observation *meteringpkg.StorageObservation) error {
+	if m == nil || observation == nil || observation.TeamID == "" {
+		return nil
+	}
+	m.mu.RLock()
+	repo := m.quotaRepo
+	m.mu.RUnlock()
+	if repo == nil {
+		return nil
+	}
+	dimension, ok := storageQuotaDimension(observation.SubjectType)
+	if !ok {
+		return nil
+	}
+	_, err := repo.CheckProjectedStorageUsageGB(ctx, observation.TeamID, dimension, observation.SubjectType, observation.SubjectID, observation.SizeBytes)
+	return err
+}
+
+func storageQuotaDimension(subjectType string) (quota.Dimension, bool) {
+	switch subjectType {
+	case meteringpkg.SubjectTypeVolume:
+		return quota.DimensionVolumeStorageGB, true
+	default:
+		return "", false
+	}
+}

--- a/storage-proxy/pkg/volume/manager.go
+++ b/storage-proxy/pkg/volume/manager.go
@@ -555,17 +555,18 @@ func (m *Manager) SyncDirectVolumeFileMount(ctx context.Context, volumeID string
 	if err != nil {
 		return err
 	}
-	m.observeMaterializedManifest(ctx, volCtx, manifest)
-	return nil
+	return m.observeMaterializedManifest(ctx, volCtx, manifest)
 }
 
-func (m *Manager) observeMaterializedManifest(ctx context.Context, volCtx *VolumeContext, manifest *s0fs.Manifest) {
+func (m *Manager) observeMaterializedManifest(ctx context.Context, volCtx *VolumeContext, manifest *s0fs.Manifest) error {
 	if volCtx == nil || volCtx.Observer == nil || manifest == nil || manifest.State == nil {
-		return
+		return nil
 	}
 	if err := volCtx.Observer.ObserveVolumeState(ctx, volCtx.VolumeID, volCtx.TeamID, manifest.State, time.Now().UTC()); err != nil {
 		m.logger.WithError(err).WithField("volume_id", volCtx.VolumeID).Warn("Failed to record volume storage observation")
+		return err
 	}
+	return nil
 }
 
 func (m *Manager) releaseDirectVolumeFileMount(volumeID, sessionID string) func() {

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -161,6 +161,19 @@ func registerApiModeSuite(envProvider func() *framework.ScenarioEnv, opts apiMod
 				Expect(status).To(Equal(http.StatusTooManyRequests))
 			})
 
+			It("enforces CPU quota", func() {
+				_, status, err := session.PutTeamQuota(env.TestCtx.Context, quota.DimensionCPU, 0)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(status).To(Equal(http.StatusOK))
+				defer func() {
+					_, _ = session.DeleteTeamQuota(env.TestCtx.Context, quota.DimensionCPU)
+				}()
+
+				_, status, err = session.ClaimSandboxDetailed(env.TestCtx.Context, GinkgoT(), apispec.ClaimRequest{Template: ptr("default")})
+				Expect(err).To(HaveOccurred())
+				Expect(status).To(Equal(http.StatusTooManyRequests))
+			})
+
 			It("fetches status and refreshes sandboxes", func() {
 				Expect(sandboxID).NotTo(BeEmpty())
 

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -174,6 +174,19 @@ func registerApiModeSuite(envProvider func() *framework.ScenarioEnv, opts apiMod
 				Expect(status).To(Equal(http.StatusTooManyRequests))
 			})
 
+			It("enforces memory quota", func() {
+				_, status, err := session.PutTeamQuota(env.TestCtx.Context, quota.DimensionMemory, 0)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(status).To(Equal(http.StatusOK))
+				defer func() {
+					_, _ = session.DeleteTeamQuota(env.TestCtx.Context, quota.DimensionMemory)
+				}()
+
+				_, status, err = session.ClaimSandboxDetailed(env.TestCtx.Context, GinkgoT(), apispec.ClaimRequest{Template: ptr("default")})
+				Expect(err).To(HaveOccurred())
+				Expect(status).To(Equal(http.StatusTooManyRequests))
+			})
+
 			It("fetches status and refreshes sandboxes", func() {
 				Expect(sandboxID).NotTo(BeEmpty())
 

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/framework"
 	"github.com/sandbox0-ai/sandbox0/pkg/metering"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
+	"github.com/sandbox0-ai/sandbox0/pkg/quota"
 	e2eutils "github.com/sandbox0-ai/sandbox0/tests/e2e/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
@@ -147,6 +148,19 @@ func registerApiModeSuite(envProvider func() *framework.ScenarioEnv, opts apiMod
 		})
 
 		Context("sandbox lifecycle", func() {
+			It("enforces active sandbox quota", func() {
+				_, status, err := session.PutTeamQuota(env.TestCtx.Context, quota.DimensionActiveSandboxes, 1)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(status).To(Equal(http.StatusOK))
+				defer func() {
+					_, _ = session.DeleteTeamQuota(env.TestCtx.Context, quota.DimensionActiveSandboxes)
+				}()
+
+				_, status, err = session.ClaimSandboxDetailed(env.TestCtx.Context, GinkgoT(), apispec.ClaimRequest{Template: ptr("default")})
+				Expect(err).To(HaveOccurred())
+				Expect(status).To(Equal(http.StatusTooManyRequests))
+			})
+
 			It("fetches status and refreshes sandboxes", func() {
 				Expect(sandboxID).NotTo(BeEmpty())
 

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -1499,7 +1499,7 @@ func assertEgressQuota(env *framework.ScenarioEnv, session *e2eutils.Session, sa
 	Expect(err).NotTo(HaveOccurred())
 	Expect(status).To(Equal(http.StatusOK))
 	Expect(sandbox).NotTo(BeNil())
-	templateNamespace, err := naming.TemplateNamespaceForTeam(sandbox.TeamId)
+	templateNamespace, err := naming.TemplateNamespaceForBuiltin(sandbox.TemplateId)
 	Expect(err).NotTo(HaveOccurred())
 	waitForSandboxPodReadyEventually(env, session, sandboxID, templateNamespace)
 
@@ -1519,7 +1519,7 @@ func assertIngressQuota(env *framework.ScenarioEnv, session *e2eutils.Session, s
 	Expect(err).NotTo(HaveOccurred())
 	Expect(status).To(Equal(http.StatusOK))
 	Expect(sandbox).NotTo(BeNil())
-	templateNamespace, err := naming.TemplateNamespaceForTeam(sandbox.TeamId)
+	templateNamespace, err := naming.TemplateNamespaceForBuiltin(sandbox.TemplateId)
 	Expect(err).NotTo(HaveOccurred())
 	waitForSandboxPodReadyEventually(env, session, sandboxID, templateNamespace)
 

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -287,6 +287,10 @@ func registerApiModeSuite(envProvider func() *framework.ScenarioEnv, opts apiMod
 					assertVolumeStorageQuota(env, session)
 				})
 
+				It("enforces snapshot storage quota", func() {
+					assertSnapshotStorageQuota(env, session)
+				})
+
 				It("bootstraps an existing volume during claim", func() {
 					assertClaimBootstrapMountLifecycle(env, session)
 				})
@@ -2282,6 +2286,32 @@ func assertVolumeStorageQuota(env *framework.ScenarioEnv, session *e2eutils.Sess
 	})
 
 	status, err = session.WriteVolumeFile(env.TestCtx.Context, GinkgoT(), volumeID, "/quota.txt", []byte("quota"), "")
+	Expect(err).To(HaveOccurred())
+	Expect(status).To(Equal(http.StatusTooManyRequests))
+}
+
+func assertSnapshotStorageQuota(env *framework.ScenarioEnv, session *e2eutils.Session) {
+	volume, status, err := session.CreateSandboxVolume(env.TestCtx.Context, GinkgoT(), apispec.CreateSandboxVolumeRequest{})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusCreated))
+	Expect(volume).NotTo(BeNil())
+	volumeID := expectStringPtr(volume.Id, "snapshot quota volume id")
+	DeferCleanup(func() {
+		deleteSandboxVolumeForCleanup(env, session, volumeID)
+	})
+
+	status, err = session.WriteVolumeFile(env.TestCtx.Context, GinkgoT(), volumeID, "/snapshot-quota.txt", []byte("snapshot quota"), "")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+
+	_, status, err = session.PutTeamQuota(env.TestCtx.Context, quota.DimensionSnapshotGB, 0)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+	DeferCleanup(func() {
+		_, _ = session.DeleteTeamQuota(env.TestCtx.Context, quota.DimensionSnapshotGB)
+	})
+
+	_, status, err = session.CreateSnapshot(env.TestCtx.Context, GinkgoT(), volumeID, apispec.CreateSnapshotRequest{Name: "quota"})
 	Expect(err).To(HaveOccurred())
 	Expect(status).To(Equal(http.StatusTooManyRequests))
 }

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -283,6 +283,10 @@ func registerApiModeSuite(envProvider func() *framework.ScenarioEnv, opts apiMod
 					assertVolumeLifecycle(env, session)
 				})
 
+				It("enforces volume storage quota", func() {
+					assertVolumeStorageQuota(env, session)
+				})
+
 				It("bootstraps an existing volume during claim", func() {
 					assertClaimBootstrapMountLifecycle(env, session)
 				})
@@ -2258,6 +2262,28 @@ func assertVolumeLifecycle(env *framework.ScenarioEnv, session *e2eutils.Session
 	status, err = session.DeleteSnapshot(env.TestCtx.Context, GinkgoT(), snapshotVolumeID, snapshot.Id)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(status).To(Equal(http.StatusOK))
+}
+
+func assertVolumeStorageQuota(env *framework.ScenarioEnv, session *e2eutils.Session) {
+	volume, status, err := session.CreateSandboxVolume(env.TestCtx.Context, GinkgoT(), apispec.CreateSandboxVolumeRequest{})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusCreated))
+	Expect(volume).NotTo(BeNil())
+	volumeID := expectStringPtr(volume.Id, "quota volume id")
+	DeferCleanup(func() {
+		deleteSandboxVolumeForCleanup(env, session, volumeID)
+	})
+
+	_, status, err = session.PutTeamQuota(env.TestCtx.Context, quota.DimensionVolumeStorageGB, 0)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+	DeferCleanup(func() {
+		_, _ = session.DeleteTeamQuota(env.TestCtx.Context, quota.DimensionVolumeStorageGB)
+	})
+
+	status, err = session.WriteVolumeFile(env.TestCtx.Context, GinkgoT(), volumeID, "/quota.txt", []byte("quota"), "")
+	Expect(err).To(HaveOccurred())
+	Expect(status).To(Equal(http.StatusTooManyRequests))
 }
 
 func assertObjectEncryptionLifecycle(env *framework.ScenarioEnv, session *e2eutils.Session) {

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -263,6 +263,10 @@ func registerApiModeSuite(envProvider func() *framework.ScenarioEnv, opts apiMod
 					assertEgressQuota(env, session, sandboxID)
 				})
 
+				It("enforces ingress quota", func() {
+					assertIngressQuota(env, session, sandboxID)
+				})
+
 				It("proxies SSH egress auth without exposing upstream private keys to the sandbox", func() {
 					assertSSHTransparentEgressAuthProxy(env, session, sandboxID, sshFixtureState)
 				})
@@ -1504,6 +1508,26 @@ func assertEgressQuota(env *framework.ScenarioEnv, session *e2eutils.Session, sa
 	Expect(status).To(Equal(http.StatusOK))
 	DeferCleanup(func() {
 		_, _ = session.DeleteTeamQuota(env.TestCtx.Context, quota.DimensionEgress)
+	})
+
+	_, err = execInSandboxPod(env, templateNamespace, sandbox.PodName, "curl -fsS --max-time 5 http://example.com/")
+	Expect(err).To(HaveOccurred())
+}
+
+func assertIngressQuota(env *framework.ScenarioEnv, session *e2eutils.Session, sandboxID string) {
+	sandbox, status, err := session.GetSandbox(env.TestCtx.Context, GinkgoT(), sandboxID)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+	Expect(sandbox).NotTo(BeNil())
+	templateNamespace, err := naming.TemplateNamespaceForTeam(sandbox.TeamId)
+	Expect(err).NotTo(HaveOccurred())
+	waitForSandboxPodReadyEventually(env, session, sandboxID, templateNamespace)
+
+	_, status, err = session.PutTeamQuota(env.TestCtx.Context, quota.DimensionIngress, 0)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+	DeferCleanup(func() {
+		_, _ = session.DeleteTeamQuota(env.TestCtx.Context, quota.DimensionIngress)
 	})
 
 	_, err = execInSandboxPod(env, templateNamespace, sandbox.PodName, "curl -fsS --max-time 5 http://example.com/")

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -259,6 +259,10 @@ func registerApiModeSuite(envProvider func() *framework.ScenarioEnv, opts apiMod
 					assertSandboxEgressProxy(env, session, sandboxID)
 				})
 
+				It("enforces egress quota", func() {
+					assertEgressQuota(env, session, sandboxID)
+				})
+
 				It("proxies SSH egress auth without exposing upstream private keys to the sandbox", func() {
 					assertSSHTransparentEgressAuthProxy(env, session, sandboxID, sshFixtureState)
 				})
@@ -1484,6 +1488,26 @@ func assertSandboxNetworkIsolation(env *framework.ScenarioEnv, session *e2eutils
 		}
 		return nil
 	}).WithTimeout(45 * time.Second).WithPolling(3 * time.Second).Should(Succeed())
+}
+
+func assertEgressQuota(env *framework.ScenarioEnv, session *e2eutils.Session, sandboxID string) {
+	sandbox, status, err := session.GetSandbox(env.TestCtx.Context, GinkgoT(), sandboxID)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+	Expect(sandbox).NotTo(BeNil())
+	templateNamespace, err := naming.TemplateNamespaceForTeam(sandbox.TeamId)
+	Expect(err).NotTo(HaveOccurred())
+	waitForSandboxPodReadyEventually(env, session, sandboxID, templateNamespace)
+
+	_, status, err = session.PutTeamQuota(env.TestCtx.Context, quota.DimensionEgress, 0)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+	DeferCleanup(func() {
+		_, _ = session.DeleteTeamQuota(env.TestCtx.Context, quota.DimensionEgress)
+	})
+
+	_, err = execInSandboxPod(env, templateNamespace, sandbox.PodName, "curl -fsS --max-time 5 http://example.com/")
+	Expect(err).To(HaveOccurred())
 }
 
 func assertCredentialSourceBindingLifecycle(env *framework.ScenarioEnv, session *e2eutils.Session, sandboxID string) {

--- a/tests/e2e/utils/quota.go
+++ b/tests/e2e/utils/quota.go
@@ -1,0 +1,44 @@
+package utils
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+
+	gatewayspec "github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
+	"github.com/sandbox0-ai/sandbox0/pkg/quota"
+)
+
+type PutTeamQuotaRequest struct {
+	LimitValue int64 `json:"limit_value"`
+}
+
+func (s *Session) PutTeamQuota(ctx context.Context, dimension quota.Dimension, limitValue int64) (*quota.Limit, int, error) {
+	status, body, err := s.doJSONRequest(ctx, http.MethodPut, "/api/v1/quotas/"+string(dimension), PutTeamQuotaRequest{LimitValue: limitValue}, true)
+	if err != nil {
+		return nil, status, err
+	}
+	if status != http.StatusOK {
+		return nil, status, fmt.Errorf("put team quota failed with status %d: %s", status, formatAPIError(body))
+	}
+	resp, apiErr, err := gatewayspec.DecodeResponse[quota.Limit](bytes.NewReader(body))
+	if err != nil {
+		return nil, status, err
+	}
+	if apiErr != nil {
+		return nil, status, fmt.Errorf("put team quota failed: %s", apiErr.Message)
+	}
+	return resp, status, nil
+}
+
+func (s *Session) DeleteTeamQuota(ctx context.Context, dimension quota.Dimension) (int, error) {
+	status, body, err := s.doJSONRequest(ctx, http.MethodDelete, "/api/v1/quotas/"+string(dimension), nil, true)
+	if err != nil {
+		return status, err
+	}
+	if status != http.StatusOK {
+		return status, fmt.Errorf("delete team quota failed with status %d: %s", status, formatAPIError(body))
+	}
+	return status, nil
+}


### PR DESCRIPTION
## Summary
- add team quota limit storage and API for active sandboxes, CPU, memory, storage, and network dimensions
- enforce active sandbox, CPU, memory, volume storage, snapshot storage, egress, and ingress quotas in the relevant data-plane/control-plane paths
- add focused unit and e2e coverage for each quota dimension

## Tests
- go test ./pkg/quota ./manager/pkg/service ./netd/pkg/metering
- go test -run "^$" ./manager/pkg/http ./manager/cmd/manager ./cluster-gateway/pkg/http ./storage-proxy/pkg/http ./storage-proxy/pkg/snapshot ./storage-proxy/pkg/volume ./storage-proxy/cmd/storage-proxy ./netd/pkg/proxy ./netd/pkg/daemon ./tests/e2e/utils ./tests/e2e/cases ./pkg/apispec

Note: egress/ingress quotas are enforced as team transfer-byte gates for new proxied traffic; this is not Mbps shaping.