### PR TITLE
Preserve sandbox identity across runtime cleanup

### DIFF
--- a/cluster-gateway/pkg/http/handlers_context.go
+++ b/cluster-gateway/pkg/http/handlers_context.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -238,11 +239,12 @@ func (s *Server) getProcdURL(c *gin.Context, sandboxID string) (*url.URL, error)
 		spec.JSONError(c, http.StatusForbidden, spec.CodeForbidden, "sandbox belongs to a different team")
 		return nil, errors.New("sandbox belongs to a different team")
 	}
-	if sandboxWantsPaused(sandbox) && !sandbox.AutoResume {
-		spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox is paused and auto_resume is disabled")
+	needsRuntimeRefetch := sandboxRuntimeMissing(sandbox)
+	if sandboxNeedsRuntime(sandbox) && !sandbox.AutoResume {
+		spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox is not running and auto_resume is disabled")
 		return nil, errors.New("sandbox auto_resume is disabled")
 	}
-	if sandboxWantsPaused(sandbox) {
+	if sandboxNeedsRuntime(sandbox) {
 		resumeCtx, cancel := context.WithTimeout(c.Request.Context(), defaultAutoResumeTimeout)
 		defer cancel()
 		if err := s.managerClient.ResumeSandbox(resumeCtx, sandboxID, authCtx.UserID, authCtx.TeamID); err != nil {
@@ -252,6 +254,13 @@ func (s *Server) getProcdURL(c *gin.Context, sandboxID string) (*url.URL, error)
 			)
 			spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox is waking up")
 			return nil, err
+		}
+		if needsRuntimeRefetch {
+			sandbox, err = s.managerClient.GetSandbox(c.Request.Context(), sandboxID, authCtx.UserID, authCtx.TeamID)
+			if err != nil {
+				spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox is waking up")
+				return nil, err
+			}
 		}
 	}
 
@@ -276,6 +285,20 @@ func sandboxWantsPaused(sandbox *mgr.Sandbox) bool {
 		return true
 	}
 	return sandbox.Paused
+}
+
+func sandboxNeedsRuntime(sandbox *mgr.Sandbox) bool {
+	return sandboxRuntimeMissing(sandbox) || sandboxWantsPaused(sandbox)
+}
+
+func sandboxRuntimeMissing(sandbox *mgr.Sandbox) bool {
+	if sandbox == nil {
+		return false
+	}
+	if sandbox.Status == mgr.SandboxStatusCleaned || strings.TrimSpace(sandbox.InternalAddr) == "" {
+		return true
+	}
+	return false
 }
 
 func (s *Server) buildProcdRequestModifier(c *gin.Context) (proxy.RequestModifier, error) {

--- a/cluster-gateway/pkg/http/handlers_exposure.go
+++ b/cluster-gateway/pkg/http/handlers_exposure.go
@@ -71,13 +71,14 @@ func (s *Server) handlePublicExposureNoRoute(c *gin.Context) {
 	if !s.enforceSandboxServiceRoute(c, sandboxID, sandbox.TeamID, route) {
 		return
 	}
-	if sandboxWantsPaused(sandbox) {
+	needsRuntimeRefetch := sandboxRuntimeMissing(sandbox)
+	if sandboxNeedsRuntime(sandbox) {
 		if !sandbox.AutoResume {
-			spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox is paused and auto_resume is disabled")
+			spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox is not running and auto_resume is disabled")
 			return
 		}
 		if !route.Resume {
-			spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox is paused and resume is disabled")
+			spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox is not running and resume is disabled")
 			return
 		}
 		resumeCtx, cancel := context.WithTimeout(c.Request.Context(), defaultAutoResumeTimeout)
@@ -86,6 +87,16 @@ func (s *Server) handlePublicExposureNoRoute(c *gin.Context) {
 			s.logger.Warn("Auto resume failed", zap.String("sandbox_id", sandboxID), zap.Error(err))
 			spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox is waking up")
 			return
+		}
+		if needsRuntimeRefetch {
+			if s.exposureSandboxCache != nil {
+				s.exposureSandboxCache.Delete(sandboxID)
+			}
+			sandbox, err = s.getSandboxForPublicExposure(c, sandboxID)
+			if err != nil {
+				spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox is waking up")
+				return
+			}
 		}
 	}
 

--- a/docs/get-started/concepts/page.mdx
+++ b/docs/get-started/concepts/page.mdx
@@ -36,7 +36,7 @@ Design for restartability: assume any sandbox can be replaced, and your agent sh
 Sandbox0 uses lifecycle controls to balance responsiveness and cost:
 
 - `ttl`: soft timeout, typically leading to auto-pause.
-- `hard_ttl`: hard deadline, leading to deletion.
+- `hard_ttl`: hard runtime deadline, leading to runtime cleanup while preserving the sandbox identity.
 
 For agents, this means:
 - Keep short `ttl` for bursty workloads.

--- a/docs/get-started/page.mdx
+++ b/docs/get-started/page.mdx
@@ -172,7 +172,7 @@ func main() {
     // Claim a sandbox from the "default" template
     sandbox, err := client.ClaimSandbox(ctx, "default",
         sandbox0.WithSandboxTTL(300),      // Auto-pause after 5 minutes (default: 5m)
-        sandbox0.WithSandboxHardTTL(3600), // Auto-delete after 1 hour (optional, 0 disables)
+        sandbox0.WithSandboxHardTTL(3600), // Clean runtime after 1 hour (optional, 0 disables)
     )
     if err != nil {
         log.Fatal(err)
@@ -199,7 +199,7 @@ client = Client(
 # Claim a sandbox from the "default" template
 with client.sandboxes.open("default", config=SandboxConfig(
     ttl=300,       # Auto-pause after 5 minutes (default: 5m)
-    hard_ttl=3600, # Auto-delete after 1 hour (optional, 0 disables)
+    hard_ttl=3600, # Clean runtime after 1 hour (optional, 0 disables)
 )) as sandbox:
     print(f"Sandbox ID: {sandbox.id}")
     print(f"Status: {sandbox.status}")`
@@ -219,7 +219,7 @@ const client = new Client({
 // Claim a sandbox from the "default" template
 const sandbox = await client.sandboxes.claim('default', {
     ttl: 300,       // Auto-pause after 5 minutes (default: 5m)
-    hardTtl: 3600,  // Auto-delete after 1 hour (optional, 0 disables)
+    hardTtl: 3600,  // Clean runtime after 1 hour (optional, 0 disables)
 });
 console.log('Sandbox ID:', sandbox.id);
 console.log('Status:', sandbox.status);

--- a/docs/sandbox/page.mdx
+++ b/docs/sandbox/page.mdx
@@ -57,7 +57,7 @@ Claim a sandbox from a template. The sandbox is created from a pre-warmed pool f
 |-------|------|-------------|
 | `env_vars` | object | Environment variables |
 | `ttl` | integer | Time to live in seconds (soft limit, triggers auto-pause; default: `0`, disabled) |
-| `hard_ttl` | integer | Maximum lifetime in seconds (hard limit, triggers deletion; default: `0`, disabled) |
+| `hard_ttl` | integer | Hard runtime lifetime in seconds (cleans compute while preserving sandbox identity and services; default: `0`, disabled) |
 | `network` | object | `SandboxNetworkPolicy`. Controls traffic rules, protocol controls, credential bindings, and destination-scoped egress auth |
 | `webhook` | object | Webhook configuration |
 | `auto_resume` | boolean | Auto-resume when accessed (default: true) |
@@ -72,11 +72,11 @@ Sandbox0 uses two-tier TTL to balance resource efficiency and flexibility:
 | Field | Behavior | Use Case |
 |-------|----------|----------|
 | `ttl` | **Soft pause**: When expired, sandbox is automatically paused. Processes stop but state is preserved. Can be extended via refresh API. | Keep sandboxes alive during active use while freeing compute resources during idle periods. |
-| `hard_ttl` | **Hard delete**: When expired, sandbox is permanently deleted regardless of pause state. Can also be extended via refresh API. | Enforce maximum lifetime for security or cost control. The difference from `ttl` is the expiration behavior (delete vs pause). |
+| `hard_ttl` | **Hard clean**: When expired, Sandbox0 deletes the runtime pod and marks the sandbox `cleaned`. Identity, configuration, services, and public URLs remain available until explicit delete. | Enforce compute cost limits while keeping a durable sandbox service that can be restored on demand. |
 
 <Callout variant="info">
 The relationship: <code>ttl {'<='} hard_ttl</code>. When <code>ttl</code> expires first, sandbox pauses but can be resumed.
-When <code>hard_ttl</code> expires, sandbox is deleted immediately. Both can be extended via the refresh API.
+When <code>hard_ttl</code> expires, sandbox compute is cleaned and the sandbox can be restored by resume-capable access. Both can be extended via the refresh API.
 </Callout>
 
 **Example timeline (sandbox created with `ttl=300` and `hard_ttl=3600`):**
@@ -84,7 +84,7 @@ When <code>hard_ttl</code> expires, sandbox is deleted immediately. Both can be 
 - `t=300`: TTL expires → sandbox auto-pauses
 - `t=310`: User calls refresh → TTL reset to 300, Hard TTL reset to 3600 (new hard deadline at `t=3910`)
 - `t=610`: TTL expires again → sandbox auto-pauses
-- `t=3910`: Hard TTL expires → sandbox deleted
+- `t=3910`: Hard TTL expires → runtime pod cleaned, sandbox status becomes `cleaned`
 
 <Tabs
   tabs={[
@@ -403,7 +403,7 @@ Only the following fields can be updated at runtime:
 | Field | Type | Description |
 |-------|------|-------------|
 | `ttl` | integer | Time to live in seconds (soft limit) |
-| `hard_ttl` | integer | Maximum lifetime in seconds (hard limit) |
+| `hard_ttl` | integer | Hard runtime lifetime in seconds |
 | `network` | object | Network policy configuration |
 | `auto_resume` | boolean | Auto-resume when accessed |
 | `services` | array | Sandbox Services for public HTTP routes |
@@ -468,7 +468,7 @@ See [Pause And Resume](/docs/sandbox/pause-resume) for explicit pause, state ins
 
 ## Refresh Sandbox TTL
 
-Extend the sandbox time-to-live. This resets both `ttl` and `hard_ttl` (if configured) from the current time.
+Extend the sandbox time-to-live. This resets both `ttl` and `hard_ttl` (if configured) from the current time while the sandbox has a runtime.
 
 <Endpoint method="POST">
 /api/v1/sandboxes/{'{id}'}/refresh

--- a/docs/sandbox/pause-resume/page.mdx
+++ b/docs/sandbox/pause-resume/page.mdx
@@ -136,7 +136,7 @@ console.log("powerState=", sb.powerState);`
 | Field | Behavior |
 |-------|----------|
 | `ttl` | Soft timeout. When it expires, Sandbox0 pauses the sandbox. |
-| `hard_ttl` | Hard timeout. When it expires, Sandbox0 deletes the sandbox. |
+| `hard_ttl` | Hard runtime timeout. When it expires, Sandbox0 cleans the runtime pod and keeps the sandbox identity for later resume. |
 
 `auto_resume` controls whether inbound access can wake a paused sandbox:
 

--- a/docs/sandbox/services/page.mdx
+++ b/docs/sandbox/services/page.mdx
@@ -397,8 +397,9 @@ if err != nil {
 
 - Public HTTP traffic must match a route on a public service.
 - If `methods` is empty, every HTTP method is allowed for that route.
-- `resume` is evaluated with sandbox `auto_resume`. A route with `resume: false` will not resume a paused sandbox.
+- `resume` is evaluated with sandbox `auto_resume`. A route with `resume: false` will not resume a paused or cleaned sandbox.
 - Public URLs are derived from the deployment exposure domain as `{sandbox_id}--p{port}.{exposure_domain}`.
+- Public URLs remain reserved for a `cleaned` sandbox and become unavailable only after explicit sandbox deletion.
 
 ## Next Steps
 

--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -133,6 +133,9 @@ func main() {
 	if err := runEgressAuthMigrations(ctx, pool, logger); err != nil {
 		logger.Fatal("Failed to run egress auth migrations", zap.Error(err))
 	}
+	if err := runSandboxStoreMigrations(ctx, pool, logger); err != nil {
+		logger.Fatal("Failed to run sandbox store migrations", zap.Error(err))
+	}
 	credentialStore := egressauth.NewRepository(pool)
 
 	// Initialize clock for cross-cluster time synchronization
@@ -305,6 +308,7 @@ func main() {
 	)
 	sandboxService.SetCredentialStore(credentialStore)
 	sandboxService.SetQuotaStore(quota.NewRepository(pool))
+	sandboxService.SetSandboxStore(service.NewPGSandboxStore(pool))
 	if cfg.StorageProxyBaseURL != "" && cfg.StorageProxyHTTPPort > 0 && storageProxyAdminTokenGenerator != nil {
 		storageProxyBaseURL := fmt.Sprintf("http://%s:%d", strings.TrimSpace(cfg.StorageProxyBaseURL), cfg.StorageProxyHTTPPort)
 		sandboxService.SetWebhookStateVolumeClient(service.NewStorageProxyVolumeClient(service.StorageProxyVolumeClientConfig{
@@ -594,6 +598,18 @@ func runEgressAuthMigrations(ctx context.Context, pool *pgxpool.Pool, logger *za
 	}
 
 	logger.Info("Egress auth migrations completed successfully")
+	return nil
+}
+
+func runSandboxStoreMigrations(ctx context.Context, pool *pgxpool.Pool, logger *zap.Logger) error {
+	logger.Info("Running sandbox store migrations")
+
+	migrateLogger := &zapMigrateLogger{logger: logger}
+	if err := service.RunSandboxStoreMigrations(ctx, pool, migrateLogger); err != nil {
+		return fmt.Errorf("sandbox store migrations: %w", err)
+	}
+
+	logger.Info("Sandbox store migrations completed successfully")
 	return nil
 }
 

--- a/manager/pkg/controller/cleanup_controller.go
+++ b/manager/pkg/controller/cleanup_controller.go
@@ -26,6 +26,11 @@ type SandboxTerminator interface {
 	TerminateSandboxByID(ctx context.Context, sandboxID string) error
 }
 
+// SandboxRuntimeCleaner defines cleanup that frees compute while keeping durable sandbox state.
+type SandboxRuntimeCleaner interface {
+	CleanSandboxRuntimeByID(ctx context.Context, sandboxID string) error
+}
+
 // CleanupController handles cleanup of excess idle pods and expired active pods
 type CleanupController struct {
 	k8sClient         kubernetes.Interface
@@ -34,6 +39,7 @@ type CleanupController struct {
 	recorder          record.EventRecorder
 	clock             TimeProvider
 	pauseRequester    SandboxPauseRequester
+	runtimeCleaner    SandboxRuntimeCleaner
 	sandboxTerminator SandboxTerminator
 	logger            *zap.Logger
 	interval          time.Duration
@@ -76,6 +82,7 @@ func NewCleanupController(
 		clock = systemTime{}
 	}
 
+	runtimeCleaner, _ := sandboxTerminator.(SandboxRuntimeCleaner)
 	return &CleanupController{
 		k8sClient:         k8sClient,
 		podLister:         podLister,
@@ -83,6 +90,7 @@ func NewCleanupController(
 		recorder:          recorder,
 		clock:             clock,
 		pauseRequester:    pauseRequester,
+		runtimeCleaner:    runtimeCleaner,
 		sandboxTerminator: sandboxTerminator,
 		logger:            logger,
 		interval:          interval,
@@ -169,10 +177,21 @@ func (cc *CleanupController) cleanupExpired(ctx context.Context, template *v1alp
 					zap.String("pod", pod.Name),
 					zap.Time("hardExpiresAt", hardExpiresAt),
 				)
-				if cc.sandboxTerminator != nil {
-					if err := cc.sandboxTerminator.TerminateSandboxByID(ctx, pod.Name); err != nil {
+				sandboxID := cleanupSandboxIDFromPod(pod)
+				if cc.runtimeCleaner != nil {
+					if err := cc.runtimeCleaner.CleanSandboxRuntimeByID(ctx, sandboxID); err != nil {
 						cc.logger.Error("Failed to delete hard-expired pod",
 							zap.String("pod", pod.Name),
+							zap.String("sandboxID", sandboxID),
+							zap.Error(err),
+						)
+						continue
+					}
+				} else if cc.sandboxTerminator != nil {
+					if err := cc.sandboxTerminator.TerminateSandboxByID(ctx, sandboxID); err != nil {
+						cc.logger.Error("Failed to delete hard-expired pod",
+							zap.String("pod", pod.Name),
+							zap.String("sandboxID", sandboxID),
 							zap.Error(err),
 						)
 						continue
@@ -225,7 +244,7 @@ func (cc *CleanupController) cleanupExpired(ctx context.Context, template *v1alp
 			)
 
 			if cc.pauseRequester != nil {
-				err := cc.pauseRequester.RequestPauseSandboxByID(ctx, pod.Name)
+				err := cc.pauseRequester.RequestPauseSandboxByID(ctx, cleanupSandboxIDFromPod(pod))
 				if err != nil {
 					cc.logger.Error("Failed to request pause for expired pod",
 						zap.String("pod", pod.Name),
@@ -266,7 +285,7 @@ func (cc *CleanupController) deleteCompletedPod(ctx context.Context, template *v
 	)
 
 	if cc.sandboxTerminator != nil {
-		if err := cc.sandboxTerminator.TerminateSandboxByID(ctx, pod.Name); err != nil {
+		if err := cc.sandboxTerminator.TerminateSandboxByID(ctx, cleanupSandboxIDFromPod(pod)); err != nil {
 			cc.logger.Error("Failed to delete completed sandbox pod",
 				zap.String("pod", pod.Name),
 				zap.Error(err),
@@ -292,6 +311,23 @@ func (cc *CleanupController) deleteCompletedPod(ctx context.Context, template *v
 	cc.recorder.Eventf(template, corev1.EventTypeNormal, "CompletedPodDeleted",
 		"Deleted completed sandbox pod %s", pod.Name)
 	return true
+}
+
+func cleanupSandboxIDFromPod(pod *corev1.Pod) string {
+	if pod == nil {
+		return ""
+	}
+	if pod.Labels != nil {
+		if sandboxID := pod.Labels[LabelSandboxID]; sandboxID != "" {
+			return sandboxID
+		}
+	}
+	if pod.Annotations != nil {
+		if sandboxID := pod.Annotations[AnnotationSandboxID]; sandboxID != "" {
+			return sandboxID
+		}
+	}
+	return pod.Name
 }
 
 func (cc *CleanupController) forceDeleteStaleDeletingPod(ctx context.Context, template *v1alpha1.SandboxTemplate, pod *corev1.Pod, now time.Time) {

--- a/manager/pkg/controller/cleanup_controller_test.go
+++ b/manager/pkg/controller/cleanup_controller_test.go
@@ -45,6 +45,16 @@ func (r *recordingSandboxTerminator) TerminateSandboxByID(_ context.Context, san
 	return nil
 }
 
+type recordingRuntimeCleaner struct {
+	recordingSandboxTerminator
+	cleanCalls []string
+}
+
+func (r *recordingRuntimeCleaner) CleanSandboxRuntimeByID(_ context.Context, sandboxID string) error {
+	r.cleanCalls = append(r.cleanCalls, sandboxID)
+	return nil
+}
+
 func TestCleanupExpiredRequestsPauseDesiredState(t *testing.T) {
 	now := time.Date(2026, time.April, 15, 19, 31, 0, 0, time.UTC)
 	template := &v1alpha1.SandboxTemplate{
@@ -145,6 +155,59 @@ func TestCleanupExpiredSkipsDeletingPod(t *testing.T) {
 	case event := <-recorder.Events:
 		t.Fatalf("unexpected event: %s", event)
 	default:
+	}
+}
+
+func TestCleanupExpiredCleansHardExpiredRuntime(t *testing.T) {
+	now := time.Date(2026, time.April, 15, 19, 31, 0, 0, time.UTC)
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: "tpl-default",
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "runtime-pod-1",
+			Namespace: "tpl-default",
+			Labels: map[string]string{
+				LabelTemplateID: "default",
+				LabelPoolType:   PoolTypeActive,
+				LabelSandboxID:  "sandbox-1",
+			},
+			Annotations: map[string]string{
+				AnnotationHardExpiresAt: now.Add(-time.Minute).Format(time.RFC3339),
+			},
+		},
+	}
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+	})
+	require.NoError(t, indexer.Add(pod))
+
+	cleaner := &recordingRuntimeCleaner{}
+	recorder := record.NewFakeRecorder(1)
+	controller := NewCleanupController(
+		nil,
+		corelisters.NewPodLister(indexer),
+		nil,
+		recorder,
+		staticCleanupClock{now: now},
+		nil,
+		cleaner,
+		zap.NewNop(),
+		time.Minute,
+	)
+
+	require.NoError(t, controller.cleanupExpired(context.Background(), template))
+
+	assert.Equal(t, []string{"sandbox-1"}, cleaner.cleanCalls)
+	assert.Empty(t, cleaner.calls)
+	select {
+	case event := <-recorder.Events:
+		assert.Contains(t, event, "HardExpiredPodDeleted")
+	default:
+		t.Fatal("expected hard-expired event")
 	}
 }
 

--- a/manager/pkg/controller/pool_manager.go
+++ b/manager/pkg/controller/pool_manager.go
@@ -57,6 +57,8 @@ const (
 	AnnotationNetworkPolicyHash            = "sandbox0.ai/network-policy-hash"
 	AnnotationNetworkPolicyAppliedHash     = "sandbox0.ai/network-policy-applied-hash"
 	AnnotationSandboxID                    = "sandbox0.ai/sandbox-id"
+	AnnotationRuntimeGeneration            = "sandbox0.ai/runtime-generation"
+	AnnotationRuntimeDeletionReason        = "sandbox0.ai/runtime-deletion-reason"
 	AnnotationWebhookStateVolumeID         = "sandbox0.ai/webhook-state-volume-id"
 	AnnotationTemplateSpecHash             = "sandbox0.ai/template-spec-hash"
 	AnnotationClusterAutoscalerSafeToEvict = "cluster-autoscaler.kubernetes.io/safe-to-evict"

--- a/manager/pkg/metering/lifecycle_projector.go
+++ b/manager/pkg/metering/lifecycle_projector.go
@@ -118,18 +118,19 @@ func (p *LifecycleProjector) handleUpsert(obj any) {
 	if !isClaimedActiveSandbox(pod) {
 		return
 	}
+	sandboxID := meteringSandboxIDFromPod(pod)
 
 	ctx := context.Background()
-	state, err := p.store.GetSandboxProjectionState(ctx, pod.Name)
+	state, err := p.store.GetSandboxProjectionState(ctx, sandboxID)
 	if err != nil {
-		p.recordError("load_state", pod.Name, err)
+		p.recordError("load_state", sandboxID, err)
 		return
 	}
 
 	claimedAt, ok := parseRFC3339(pod.Annotations[controller.AnnotationClaimedAt])
 	if !ok {
 		p.logger.Warn("Skipping metering projection for sandbox without valid claimed_at annotation",
-			zap.String("sandboxID", pod.Name),
+			zap.String("sandboxID", sandboxID),
 			zap.String("namespace", pod.Namespace),
 		)
 		p.incrementErrorCounter("invalid_claimed_at")
@@ -146,9 +147,9 @@ func (p *LifecycleProjector) handleUpsert(obj any) {
 	pendingWindows := make([]*meteringpkg.Window, 0, 2)
 
 	if state == nil {
-		pendingEvents = append(pendingEvents, p.buildSandboxEvent(pod.Name, teamID, userID, templateID, claimedAt, meteringpkg.EventTypeSandboxClaimed, claimedEventID(pod.Name, claimedAt), claimEventData(pod)))
+		pendingEvents = append(pendingEvents, p.buildSandboxEvent(sandboxID, teamID, userID, templateID, claimedAt, meteringpkg.EventTypeSandboxClaimed, claimedEventID(sandboxID, claimedAt), claimEventData(pod)))
 		state = &meteringpkg.SandboxProjectionState{
-			SandboxID:         pod.Name,
+			SandboxID:         sandboxID,
 			Namespace:         pod.Namespace,
 			TeamID:            teamID,
 			UserID:            userID,
@@ -170,14 +171,14 @@ func (p *LifecycleProjector) handleUpsert(obj any) {
 			eventTime = pausedAt
 		}
 		if !state.Paused {
-			pendingEvents = append(pendingEvents, p.buildSandboxEvent(pod.Name, teamID, userID, templateID, eventTime, meteringpkg.EventTypeSandboxPaused, pauseEventID(pod.Name, eventTime), nil))
+			pendingEvents = append(pendingEvents, p.buildSandboxEvent(sandboxID, teamID, userID, templateID, eventTime, meteringpkg.EventTypeSandboxPaused, pauseEventID(sandboxID, eventTime), nil))
 			pendingWindows = append(pendingWindows, p.buildSandboxResourceWindows(state, teamID, userID, templateID, state.ActiveSince, eventTime)...)
 		}
 		state.Paused = true
 		state.PausedAt = &eventTime
 		state.ActiveSince = nil
 	} else if state.Paused {
-		pendingEvents = append(pendingEvents, p.buildSandboxEvent(pod.Name, teamID, userID, templateID, observedAt, meteringpkg.EventTypeSandboxResumed, resumeEventID(pod.Name, pod.ResourceVersion), nil))
+		pendingEvents = append(pendingEvents, p.buildSandboxEvent(sandboxID, teamID, userID, templateID, observedAt, meteringpkg.EventTypeSandboxResumed, resumeEventID(sandboxID, pod.ResourceVersion), nil))
 		state.Paused = false
 		state.PausedAt = nil
 		state.ActiveSince = ptrTime(observedAt)
@@ -196,7 +197,7 @@ func (p *LifecycleProjector) handleUpsert(obj any) {
 	state.TerminatedAt = nil
 	state.LastObservedAt = observedAt
 	state.LastResourceVer = pod.ResourceVersion
-	if err := p.commitProjection(ctx, pod.Name, state, pendingEvents, pendingWindows, observedAt); err != nil {
+	if err := p.commitProjection(ctx, sandboxID, state, pendingEvents, pendingWindows, observedAt); err != nil {
 		return
 	}
 }
@@ -206,11 +207,12 @@ func (p *LifecycleProjector) handleDelete(obj any) {
 	if pod == nil || !isClaimedActiveSandbox(pod) {
 		return
 	}
+	sandboxID := meteringSandboxIDFromPod(pod)
 
 	ctx := context.Background()
-	state, err := p.store.GetSandboxProjectionState(ctx, pod.Name)
+	state, err := p.store.GetSandboxProjectionState(ctx, sandboxID)
 	if err != nil {
-		p.recordError("load_state", pod.Name, err)
+		p.recordError("load_state", sandboxID, err)
 		return
 	}
 
@@ -224,7 +226,7 @@ func (p *LifecycleProjector) handleDelete(obj any) {
 	pendingWindows := make([]*meteringpkg.Window, 0, 2)
 	if state == nil {
 		state = &meteringpkg.SandboxProjectionState{
-			SandboxID:         pod.Name,
+			SandboxID:         sandboxID,
 			Namespace:         pod.Namespace,
 			TeamID:            teamID,
 			UserID:            userID,
@@ -237,7 +239,7 @@ func (p *LifecycleProjector) handleDelete(obj any) {
 			LastResourceVer:   pod.ResourceVersion,
 		}
 		if claimedAtSet {
-			pendingEvents = append(pendingEvents, p.buildSandboxEvent(pod.Name, teamID, userID, templateID, claimedAt, meteringpkg.EventTypeSandboxClaimed, claimedEventID(pod.Name, claimedAt), claimEventData(pod)))
+			pendingEvents = append(pendingEvents, p.buildSandboxEvent(sandboxID, teamID, userID, templateID, claimedAt, meteringpkg.EventTypeSandboxClaimed, claimedEventID(sandboxID, claimedAt), claimEventData(pod)))
 			state.ClaimedAt = &claimedAt
 			state.ActiveSince = &claimedAt
 		}
@@ -246,7 +248,7 @@ func (p *LifecycleProjector) handleDelete(obj any) {
 			if parsedPausedAt, ok := parseRFC3339(pod.Annotations[controller.AnnotationPausedAt]); ok {
 				pausedAt = parsedPausedAt
 			}
-			pendingEvents = append(pendingEvents, p.buildSandboxEvent(pod.Name, teamID, userID, templateID, pausedAt, meteringpkg.EventTypeSandboxPaused, pauseEventID(pod.Name, pausedAt), nil))
+			pendingEvents = append(pendingEvents, p.buildSandboxEvent(sandboxID, teamID, userID, templateID, pausedAt, meteringpkg.EventTypeSandboxPaused, pauseEventID(sandboxID, pausedAt), nil))
 			pendingWindows = append(pendingWindows, p.buildSandboxResourceWindows(state, teamID, userID, templateID, state.ActiveSince, pausedAt)...)
 			state.Paused = true
 			state.PausedAt = &pausedAt
@@ -257,14 +259,14 @@ func (p *LifecycleProjector) handleDelete(obj any) {
 		if !state.Paused {
 			pendingWindows = append(pendingWindows, p.buildSandboxResourceWindows(state, teamID, userID, templateID, state.ActiveSince, observedAt)...)
 		}
-		pendingEvents = append(pendingEvents, p.buildSandboxEvent(pod.Name, teamID, userID, templateID, observedAt, meteringpkg.EventTypeSandboxTerminated, terminateEventID(pod.Name, pod.ResourceVersion), nil))
+		pendingEvents = append(pendingEvents, p.buildSandboxEvent(sandboxID, teamID, userID, templateID, observedAt, meteringpkg.EventTypeSandboxTerminated, terminateEventID(sandboxID, pod.ResourceVersion), nil))
 	}
 	state.Paused = pod.Annotations[controller.AnnotationPaused] == "true"
 	state.ActiveSince = nil
 	state.LastObservedAt = observedAt
 	state.LastResourceVer = pod.ResourceVersion
 	state.TerminatedAt = &observedAt
-	if err := p.commitProjection(ctx, pod.Name, state, pendingEvents, pendingWindows, observedAt); err != nil {
+	if err := p.commitProjection(ctx, sandboxID, state, pendingEvents, pendingWindows, observedAt); err != nil {
 		return
 	}
 }
@@ -435,6 +437,23 @@ func isClaimedActiveSandbox(pod *corev1.Pod) bool {
 		return false
 	}
 	return pod.Annotations[controller.AnnotationClaimedAt] != ""
+}
+
+func meteringSandboxIDFromPod(pod *corev1.Pod) string {
+	if pod == nil {
+		return ""
+	}
+	if pod.Labels != nil {
+		if sandboxID := pod.Labels[controller.LabelSandboxID]; sandboxID != "" {
+			return sandboxID
+		}
+	}
+	if pod.Annotations != nil {
+		if sandboxID := pod.Annotations[controller.AnnotationSandboxID]; sandboxID != "" {
+			return sandboxID
+		}
+	}
+	return pod.Name
 }
 
 func extractPod(obj any) *corev1.Pod {

--- a/manager/pkg/service/migrations/00001_init_sandbox_store.sql
+++ b/manager/pkg/service/migrations/00001_init_sandbox_store.sql
@@ -1,0 +1,41 @@
+-- +goose Up
+
+CREATE TABLE IF NOT EXISTS sandboxes (
+    sandbox_id TEXT PRIMARY KEY,
+    team_id TEXT NOT NULL,
+    user_id TEXT NOT NULL DEFAULT '',
+    template_id TEXT NOT NULL,
+    template_name TEXT NOT NULL,
+    template_namespace TEXT NOT NULL,
+    cluster_id TEXT NOT NULL DEFAULT '',
+    status TEXT NOT NULL,
+    config JSONB NOT NULL DEFAULT '{}',
+    mounts JSONB NOT NULL DEFAULT '[]',
+    template_spec JSONB NOT NULL DEFAULT '{}',
+    current_pod_name TEXT NOT NULL DEFAULT '',
+    current_pod_namespace TEXT NOT NULL DEFAULT '',
+    runtime_generation BIGINT NOT NULL DEFAULT 0,
+    claimed_at TIMESTAMPTZ,
+    expires_at TIMESTAMPTZ,
+    hard_expires_at TIMESTAMPTZ,
+    deleted_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_sandboxes_team_updated
+    ON sandboxes(team_id, updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_sandboxes_team_status
+    ON sandboxes(team_id, status);
+
+CREATE INDEX IF NOT EXISTS idx_sandboxes_current_pod
+    ON sandboxes(current_pod_namespace, current_pod_name)
+    WHERE current_pod_name <> '';
+
+-- +goose Down
+
+DROP INDEX IF EXISTS idx_sandboxes_current_pod;
+DROP INDEX IF EXISTS idx_sandboxes_team_status;
+DROP INDEX IF EXISTS idx_sandboxes_team_updated;
+DROP TABLE IF EXISTS sandboxes;

--- a/manager/pkg/service/migrations/embed.go
+++ b/manager/pkg/service/migrations/embed.go
@@ -1,0 +1,8 @@
+package migrations
+
+import "embed"
+
+// FS contains manager service database migrations.
+//
+//go:embed *.sql
+var FS embed.FS

--- a/manager/pkg/service/sandbox_index.go
+++ b/manager/pkg/service/sandbox_index.go
@@ -2,25 +2,32 @@ package service
 
 import (
 	"sort"
+	"strings"
 	"sync"
 
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
 )
+
+type SandboxPodRef struct {
+	Namespace string
+	Name      string
+}
 
 // SandboxIndex keeps an in-memory index of sandbox IDs by namespace.
 // All methods are safe for concurrent use.
 type SandboxIndex struct {
 	mu          sync.RWMutex
 	byNamespace map[string]map[string]struct{}
-	bySandboxID map[string]string
+	bySandboxID map[string]map[SandboxPodRef]struct{}
 }
 
 // NewSandboxIndex creates a new SandboxIndex instance.
 func NewSandboxIndex() *SandboxIndex {
 	return &SandboxIndex{
 		byNamespace: make(map[string]map[string]struct{}),
-		bySandboxID: make(map[string]string),
+		bySandboxID: make(map[string]map[SandboxPodRef]struct{}),
 	}
 }
 
@@ -35,10 +42,38 @@ func (s *SandboxIndex) ResourceEventHandler() cache.ResourceEventHandlerFuncs {
 
 // GetNamespace returns the namespace of a sandbox ID if present.
 func (s *SandboxIndex) GetNamespace(sandboxID string) (string, bool) {
+	ref, ok := s.GetPodRef(sandboxID)
+	return ref.Namespace, ok
+}
+
+// GetPodRef returns the current runtime pod reference for a sandbox ID if present.
+func (s *SandboxIndex) GetPodRef(sandboxID string) (SandboxPodRef, bool) {
+	refs := s.GetPodRefs(sandboxID)
+	if len(refs) == 0 {
+		return SandboxPodRef{}, false
+	}
+	return refs[0], true
+}
+
+// GetPodRefs returns all known runtime pod references for a sandbox ID.
+func (s *SandboxIndex) GetPodRefs(sandboxID string) []SandboxPodRef {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	namespace, ok := s.bySandboxID[sandboxID]
-	return namespace, ok
+	set := s.bySandboxID[sandboxID]
+	if len(set) == 0 {
+		return nil
+	}
+	refs := make([]SandboxPodRef, 0, len(set))
+	for ref := range set {
+		refs = append(refs, ref)
+	}
+	sort.Slice(refs, func(i, j int) bool {
+		if refs[i].Namespace == refs[j].Namespace {
+			return refs[i].Name < refs[j].Name
+		}
+		return refs[i].Namespace < refs[j].Namespace
+	})
+	return refs
 }
 
 // ListSandboxIDs returns sandbox IDs in the given namespace.
@@ -86,7 +121,7 @@ func (s *SandboxIndex) refreshPodIndex(oldPod, newPod *corev1.Pod) {
 				newNamespace = newPod.Namespace
 			}
 			if newID != oldID || oldPod.Namespace != newNamespace {
-				s.removeBySandboxID(oldID)
+				s.removePodRef(oldID, SandboxPodRef{Namespace: oldPod.Namespace, Name: oldPod.Name})
 			}
 		}
 	}
@@ -104,17 +139,18 @@ func (s *SandboxIndex) upsertPod(pod *corev1.Pod) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if oldNamespace, ok := s.bySandboxID[sandboxID]; ok && oldNamespace != pod.Namespace {
-		s.removeBySandboxIDLocked(sandboxID, oldNamespace)
-	}
-
 	set, ok := s.byNamespace[pod.Namespace]
 	if !ok {
 		set = make(map[string]struct{})
 		s.byNamespace[pod.Namespace] = set
 	}
 	set[sandboxID] = struct{}{}
-	s.bySandboxID[sandboxID] = pod.Namespace
+	refSet, ok := s.bySandboxID[sandboxID]
+	if !ok {
+		refSet = make(map[SandboxPodRef]struct{})
+		s.bySandboxID[sandboxID] = refSet
+	}
+	refSet[SandboxPodRef{Namespace: pod.Namespace, Name: pod.Name}] = struct{}{}
 }
 
 func (s *SandboxIndex) deletePod(pod *corev1.Pod) {
@@ -122,25 +158,36 @@ func (s *SandboxIndex) deletePod(pod *corev1.Pod) {
 	if sandboxID == "" {
 		return
 	}
-	s.removeBySandboxID(sandboxID)
+	s.removePodRef(sandboxID, SandboxPodRef{Namespace: pod.Namespace, Name: pod.Name})
 }
 
-func (s *SandboxIndex) removeBySandboxID(sandboxID string) {
+func (s *SandboxIndex) removePodRef(sandboxID string, ref SandboxPodRef) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	namespace, ok := s.bySandboxID[sandboxID]
-	if !ok {
-		return
-	}
-	s.removeBySandboxIDLocked(sandboxID, namespace)
+	s.removeBySandboxIDLocked(sandboxID, ref)
 }
 
-func (s *SandboxIndex) removeBySandboxIDLocked(sandboxID, namespace string) {
-	delete(s.bySandboxID, sandboxID)
-	if set, ok := s.byNamespace[namespace]; ok {
+func (s *SandboxIndex) removeBySandboxIDLocked(sandboxID string, ref SandboxPodRef) {
+	refStillInNamespace := false
+	if refSet, ok := s.bySandboxID[sandboxID]; ok {
+		delete(refSet, ref)
+		for remaining := range refSet {
+			if remaining.Namespace == ref.Namespace {
+				refStillInNamespace = true
+				break
+			}
+		}
+		if len(refSet) == 0 {
+			delete(s.bySandboxID, sandboxID)
+		}
+	}
+	if refStillInNamespace {
+		return
+	}
+	if set, ok := s.byNamespace[ref.Namespace]; ok {
 		delete(set, sandboxID)
 		if len(set) == 0 {
-			delete(s.byNamespace, namespace)
+			delete(s.byNamespace, ref.Namespace)
 		}
 	}
 }
@@ -148,6 +195,16 @@ func (s *SandboxIndex) removeBySandboxIDLocked(sandboxID, namespace string) {
 func sandboxIDFromPod(pod *corev1.Pod) string {
 	if pod == nil {
 		return ""
+	}
+	if pod.Labels != nil {
+		if sandboxID := strings.TrimSpace(pod.Labels[controller.LabelSandboxID]); sandboxID != "" {
+			return sandboxID
+		}
+	}
+	if pod.Annotations != nil {
+		if sandboxID := strings.TrimSpace(pod.Annotations[controller.AnnotationSandboxID]); sandboxID != "" {
+			return sandboxID
+		}
 	}
 	return pod.Name
 }

--- a/manager/pkg/service/sandbox_lifecycle_controller.go
+++ b/manager/pkg/service/sandbox_lifecycle_controller.go
@@ -33,18 +33,19 @@ const (
 
 // SandboxLifecycleInfo carries the durable identity needed to clean sandbox-scoped state.
 type SandboxLifecycleInfo struct {
-	Namespace            string
-	PodName              string
-	SandboxID            string
-	TeamID               string
-	UserID               string
-	WebhookURL           string
-	WebhookSecret        string
-	WebhookStateVolumeID string
-	PodUID               string
-	NodeName             string
-	HostIP               string
-	VolumePortals        []SandboxLifecycleVolumePortal
+	Namespace             string
+	PodName               string
+	SandboxID             string
+	TeamID                string
+	UserID                string
+	WebhookURL            string
+	WebhookSecret         string
+	WebhookStateVolumeID  string
+	PodUID                string
+	NodeName              string
+	HostIP                string
+	RuntimeDeletionReason string
+	VolumePortals         []SandboxLifecycleVolumePortal
 }
 
 // SandboxLifecycleVolumePortal carries the ctld identity for a bound sandbox volume portal.
@@ -60,19 +61,20 @@ type SandboxDeletionCleaner interface {
 }
 
 type sandboxLifecycleQueueItem struct {
-	Namespace            string
-	PodName              string
-	SandboxID            string
-	TeamID               string
-	UserID               string
-	WebhookURL           string
-	WebhookSecret        string
-	WebhookStateVolumeID string
-	PodUID               string
-	NodeName             string
-	HostIP               string
-	VolumePortalsJSON    string
-	Deleted              bool
+	Namespace             string
+	PodName               string
+	SandboxID             string
+	TeamID                string
+	UserID                string
+	WebhookURL            string
+	WebhookSecret         string
+	WebhookStateVolumeID  string
+	PodUID                string
+	NodeName              string
+	HostIP                string
+	RuntimeDeletionReason string
+	VolumePortalsJSON     string
+	Deleted               bool
 }
 
 // SandboxLifecycleController reconciles sandbox deletion side effects from Pod lifecycle state.
@@ -269,18 +271,19 @@ func (c *SandboxLifecycleController) ensurePodCleanupFinalizer(ctx context.Conte
 
 func (c *SandboxLifecycleController) cleanupDeletedSandbox(ctx context.Context, item sandboxLifecycleQueueItem) error {
 	info := SandboxLifecycleInfo{
-		Namespace:            item.Namespace,
-		PodName:              item.PodName,
-		SandboxID:            item.SandboxID,
-		TeamID:               item.TeamID,
-		UserID:               item.UserID,
-		WebhookURL:           item.WebhookURL,
-		WebhookSecret:        item.WebhookSecret,
-		WebhookStateVolumeID: item.WebhookStateVolumeID,
-		PodUID:               item.PodUID,
-		NodeName:             item.NodeName,
-		HostIP:               item.HostIP,
-		VolumePortals:        decodeSandboxLifecycleVolumePortals(item.VolumePortalsJSON),
+		Namespace:             item.Namespace,
+		PodName:               item.PodName,
+		SandboxID:             item.SandboxID,
+		TeamID:                item.TeamID,
+		UserID:                item.UserID,
+		WebhookURL:            item.WebhookURL,
+		WebhookSecret:         item.WebhookSecret,
+		WebhookStateVolumeID:  item.WebhookStateVolumeID,
+		PodUID:                item.PodUID,
+		NodeName:              item.NodeName,
+		HostIP:                item.HostIP,
+		RuntimeDeletionReason: item.RuntimeDeletionReason,
+		VolumePortals:         decodeSandboxLifecycleVolumePortals(item.VolumePortalsJSON),
 	}
 	if info.SandboxID == "" {
 		info.SandboxID = info.PodName
@@ -324,8 +327,9 @@ func (s *SandboxService) CleanupDeletedSandbox(ctx context.Context, info Sandbox
 		return nil
 	}
 
+	runtimeCleaned := strings.TrimSpace(info.RuntimeDeletionReason) == runtimeDeletionReasonCleaned
 	var errs []error
-	if s.deletionWebhookEmitter != nil && strings.TrimSpace(info.WebhookURL) != "" {
+	if !runtimeCleaned && s.deletionWebhookEmitter != nil && strings.TrimSpace(info.WebhookURL) != "" {
 		if err := s.deletionWebhookEmitter.EmitSandboxDeleted(ctx, info); err != nil {
 			errs = append(errs, fmt.Errorf("emit sandbox.deleted webhook: %w", err))
 		}
@@ -335,7 +339,7 @@ func (s *SandboxService) CleanupDeletedSandbox(ctx context.Context, info Sandbox
 			errs = append(errs, fmt.Errorf("remove network policy: %w", err))
 		}
 	}
-	if s.credentialStore != nil {
+	if !runtimeCleaned && s.credentialStore != nil {
 		teamID := strings.TrimSpace(info.TeamID)
 		if teamID == "" {
 			logger.Warn("Skipping credential binding cleanup for sandbox without team ID",
@@ -346,8 +350,10 @@ func (s *SandboxService) CleanupDeletedSandbox(ctx context.Context, info Sandbox
 			errs = append(errs, fmt.Errorf("delete credential bindings: %w", err))
 		}
 	}
-	if err := s.deleteWebhookStateVolume(ctx, info); err != nil {
-		errs = append(errs, fmt.Errorf("delete webhook state volume: %w", err))
+	if !runtimeCleaned {
+		if err := s.deleteWebhookStateVolume(ctx, info); err != nil {
+			errs = append(errs, fmt.Errorf("delete webhook state volume: %w", err))
+		}
 	}
 	if err := s.unbindDeletedSandboxVolumePortals(ctx, info); err != nil {
 		errs = append(errs, fmt.Errorf("unbind sandbox volume portals: %w", err))
@@ -451,19 +457,20 @@ func (s *SandboxService) ensureSandboxDeletionFinalizer(ctx context.Context, pod
 
 func sandboxLifecycleItemFromInfo(info SandboxLifecycleInfo, deleted bool) sandboxLifecycleQueueItem {
 	return sandboxLifecycleQueueItem{
-		Namespace:            info.Namespace,
-		PodName:              info.PodName,
-		SandboxID:            info.SandboxID,
-		TeamID:               info.TeamID,
-		UserID:               info.UserID,
-		WebhookURL:           info.WebhookURL,
-		WebhookSecret:        info.WebhookSecret,
-		WebhookStateVolumeID: info.WebhookStateVolumeID,
-		PodUID:               info.PodUID,
-		NodeName:             info.NodeName,
-		HostIP:               info.HostIP,
-		VolumePortalsJSON:    encodeSandboxLifecycleVolumePortals(info.VolumePortals),
-		Deleted:              deleted,
+		Namespace:             info.Namespace,
+		PodName:               info.PodName,
+		SandboxID:             info.SandboxID,
+		TeamID:                info.TeamID,
+		UserID:                info.UserID,
+		WebhookURL:            info.WebhookURL,
+		WebhookSecret:         info.WebhookSecret,
+		WebhookStateVolumeID:  info.WebhookStateVolumeID,
+		PodUID:                info.PodUID,
+		NodeName:              info.NodeName,
+		HostIP:                info.HostIP,
+		RuntimeDeletionReason: info.RuntimeDeletionReason,
+		VolumePortalsJSON:     encodeSandboxLifecycleVolumePortals(info.VolumePortals),
+		Deleted:               deleted,
 	}
 }
 
@@ -505,10 +512,12 @@ func sandboxLifecycleInfoFromPod(pod *corev1.Pod) (SandboxLifecycleInfo, bool) {
 	webhookURL := ""
 	webhookSecret := ""
 	webhookStateVolumeID := ""
+	runtimeDeletionReason := ""
 	if pod.Annotations != nil {
 		teamID = strings.TrimSpace(pod.Annotations[controller.AnnotationTeamID])
 		userID = strings.TrimSpace(pod.Annotations[controller.AnnotationUserID])
 		webhookStateVolumeID = strings.TrimSpace(pod.Annotations[controller.AnnotationWebhookStateVolumeID])
+		runtimeDeletionReason = strings.TrimSpace(pod.Annotations[controller.AnnotationRuntimeDeletionReason])
 		if configJSON := strings.TrimSpace(pod.Annotations[controller.AnnotationConfig]); configJSON != "" {
 			var cfg SandboxConfig
 			if err := json.Unmarshal([]byte(configJSON), &cfg); err == nil && cfg.Webhook != nil {
@@ -518,18 +527,19 @@ func sandboxLifecycleInfoFromPod(pod *corev1.Pod) (SandboxLifecycleInfo, bool) {
 		}
 	}
 	return SandboxLifecycleInfo{
-		Namespace:            pod.Namespace,
-		PodName:              pod.Name,
-		SandboxID:            sandboxID,
-		TeamID:               teamID,
-		UserID:               userID,
-		WebhookURL:           webhookURL,
-		WebhookSecret:        webhookSecret,
-		WebhookStateVolumeID: webhookStateVolumeID,
-		PodUID:               string(pod.UID),
-		NodeName:             pod.Spec.NodeName,
-		HostIP:               pod.Status.HostIP,
-		VolumePortals:        sandboxLifecycleVolumePortalsFromPod(pod, webhookStateVolumeID),
+		Namespace:             pod.Namespace,
+		PodName:               pod.Name,
+		SandboxID:             sandboxID,
+		TeamID:                teamID,
+		UserID:                userID,
+		WebhookURL:            webhookURL,
+		WebhookSecret:         webhookSecret,
+		WebhookStateVolumeID:  webhookStateVolumeID,
+		PodUID:                string(pod.UID),
+		NodeName:              pod.Spec.NodeName,
+		HostIP:                pod.Status.HostIP,
+		RuntimeDeletionReason: runtimeDeletionReason,
+		VolumePortals:         sandboxLifecycleVolumePortalsFromPod(pod, webhookStateVolumeID),
 	}, true
 }
 

--- a/manager/pkg/service/sandbox_lifecycle_controller_test.go
+++ b/manager/pkg/service/sandbox_lifecycle_controller_test.go
@@ -265,6 +265,48 @@ func TestSandboxServiceCleanupDeletedSandboxEmitsWebhookAndMarksStateVolumeForCl
 	}
 }
 
+func TestSandboxServiceCleanupDeletedSandboxPreservesDurableStateForCleanedRuntime(t *testing.T) {
+	removed := make([]string, 0, 1)
+	store := &deleteRecordingBindingStore{}
+	volumeClient := &recordingSystemVolumeClient{}
+	emitter := &recordingDeletionWebhookEmitter{}
+	svc := &SandboxService{
+		networkProvider: &assertingNetworkProvider{removeFunc: func(namespace, sandboxID string) {
+			removed = append(removed, namespace+"/"+sandboxID)
+		}},
+		credentialStore:        store,
+		webhookStateVolumes:    volumeClient,
+		deletionWebhookEmitter: emitter,
+		logger:                 zap.NewNop(),
+	}
+
+	err := svc.CleanupDeletedSandbox(context.Background(), SandboxLifecycleInfo{
+		Namespace:             "ns-a",
+		PodName:               "pod-a",
+		SandboxID:             "sandbox-a",
+		TeamID:                "team-a",
+		UserID:                "user-a",
+		WebhookURL:            "https://example.test/webhook",
+		WebhookStateVolumeID:  "volume-a",
+		RuntimeDeletionReason: runtimeDeletionReasonCleaned,
+	})
+	if err != nil {
+		t.Fatalf("CleanupDeletedSandbox() error = %v", err)
+	}
+	if len(removed) != 1 || removed[0] != "ns-a/sandbox-a" {
+		t.Fatalf("network removals = %#v, want ns-a/sandbox-a", removed)
+	}
+	if store.deleteCalls != 0 {
+		t.Fatalf("DeleteBindings calls = %d, want 0", store.deleteCalls)
+	}
+	if len(emitter.calls) != 0 {
+		t.Fatalf("webhook calls = %d, want 0", len(emitter.calls))
+	}
+	if len(volumeClient.marked) != 0 {
+		t.Fatalf("marked volumes = %#v, want none", volumeClient.marked)
+	}
+}
+
 func TestSandboxServiceCleanupDeletedSandboxUnbindsVolumePortals(t *testing.T) {
 	var got ctldapi.UnbindVolumePortalRequest
 	ctld := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/manager/pkg/service/sandbox_runtime_identity_test.go
+++ b/manager/pkg/service/sandbox_runtime_identity_test.go
@@ -1,0 +1,264 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+type memorySandboxStore struct {
+	records map[string]*SandboxRecord
+	deletes []string
+	saves   int
+	cleans  int
+}
+
+type memorySandboxStoreTx struct {
+	store *memorySandboxStore
+}
+
+func (s *memorySandboxStore) UpsertSandbox(_ context.Context, record *SandboxRecord) error {
+	if s.records == nil {
+		s.records = make(map[string]*SandboxRecord)
+	}
+	s.records[record.ID] = cloneSandboxRecord(record)
+	return nil
+}
+
+func (s *memorySandboxStore) GetSandbox(_ context.Context, sandboxID string) (*SandboxRecord, error) {
+	if s == nil || s.records == nil {
+		return nil, nil
+	}
+	return cloneSandboxRecord(s.records[sandboxID]), nil
+}
+
+func (s *memorySandboxStore) ListSandboxes(context.Context, *ListSandboxesRequest) ([]*SandboxRecord, error) {
+	return nil, nil
+}
+
+func (s *memorySandboxStore) MarkSandboxDeleted(_ context.Context, sandboxID string, deletedAt time.Time) error {
+	if s.records == nil {
+		s.records = make(map[string]*SandboxRecord)
+	}
+	record := s.records[sandboxID]
+	if record == nil {
+		record = &SandboxRecord{ID: sandboxID}
+		s.records[sandboxID] = record
+	}
+	record.Status = SandboxStatusDeleted
+	record.DeletedAt = deletedAt
+	record.CurrentPodName = ""
+	record.CurrentPodNamespace = ""
+	s.deletes = append(s.deletes, sandboxID)
+	return nil
+}
+
+func (s *memorySandboxStore) WithSandboxLock(ctx context.Context, sandboxID string, fn func(context.Context, SandboxStoreTx, *SandboxRecord) error) error {
+	record, err := s.GetSandbox(ctx, sandboxID)
+	if err != nil {
+		return err
+	}
+	if record == nil {
+		return ErrSandboxRecordNotFound
+	}
+	return fn(ctx, memorySandboxStoreTx{store: s}, record)
+}
+
+func (t memorySandboxStoreTx) SaveRuntime(_ context.Context, sandboxID, namespace, podName, status string, generation int64, expiresAt, hardExpiresAt time.Time) error {
+	record := t.store.records[sandboxID]
+	record.CurrentPodNamespace = namespace
+	record.CurrentPodName = podName
+	record.Status = status
+	record.RuntimeGeneration = generation
+	record.ExpiresAt = expiresAt
+	record.HardExpiresAt = hardExpiresAt
+	t.store.saves++
+	return nil
+}
+
+func (t memorySandboxStoreTx) MarkRuntimeCleaned(_ context.Context, sandboxID string, generation int64, _ time.Time) error {
+	record := t.store.records[sandboxID]
+	record.CurrentPodNamespace = ""
+	record.CurrentPodName = ""
+	record.Status = SandboxStatusCleaned
+	if record.RuntimeGeneration < generation {
+		record.RuntimeGeneration = generation
+	}
+	t.store.cleans++
+	return nil
+}
+
+func cloneSandboxRecord(record *SandboxRecord) *SandboxRecord {
+	if record == nil {
+		return nil
+	}
+	clone := *record
+	if record.Mounts != nil {
+		clone.Mounts = append([]ClaimMount(nil), record.Mounts...)
+	}
+	if record.Config.Services != nil {
+		clone.Config.Services = append([]SandboxAppService(nil), record.Config.Services...)
+	}
+	return &clone
+}
+
+func TestSandboxIndexTracksMultipleRuntimePodsForSameSandbox(t *testing.T) {
+	index := NewSandboxIndex()
+	first := runtimeIdentityPod("ns-a", "pod-a", "sandbox-a")
+	second := runtimeIdentityPod("ns-a", "pod-b", "sandbox-a")
+
+	index.handleAdd(first)
+	index.handleAdd(second)
+
+	refs := index.GetPodRefs("sandbox-a")
+	if len(refs) != 2 {
+		t.Fatalf("refs = %#v, want two runtime pod refs", refs)
+	}
+	ids := index.ListSandboxIDs("ns-a")
+	if len(ids) != 1 || ids[0] != "sandbox-a" {
+		t.Fatalf("sandbox ids = %#v, want sandbox-a", ids)
+	}
+
+	index.handleDelete(first)
+	refs = index.GetPodRefs("sandbox-a")
+	if len(refs) != 1 || refs[0].Name != "pod-b" {
+		t.Fatalf("refs after first delete = %#v, want pod-b", refs)
+	}
+	ids = index.ListSandboxIDs("ns-a")
+	if len(ids) != 1 || ids[0] != "sandbox-a" {
+		t.Fatalf("sandbox ids after first delete = %#v, want sandbox-a", ids)
+	}
+}
+
+func TestGetSandboxPodRejectsMultipleActiveRuntimePods(t *testing.T) {
+	first := runtimeIdentityPod("ns-a", "pod-a", "sandbox-a")
+	second := runtimeIdentityPod("ns-a", "pod-b", "sandbox-a")
+	svc := &SandboxService{
+		podLister: runtimeIdentityPodLister(t, first, second),
+		logger:    zap.NewNop(),
+	}
+
+	_, err := svc.getSandboxPod(context.Background(), "sandbox-a")
+	if !k8serrors.IsConflict(err) {
+		t.Fatalf("getSandboxPod() error = %v, want conflict", err)
+	}
+}
+
+func TestRestoreCleanedSandboxRuntimeDoesNotCreatePodWhileRuntimeDeleting(t *testing.T) {
+	deletionTime := metav1.NewTime(time.Now().UTC())
+	pod := runtimeIdentityPod("ns-a", "pod-a", "sandbox-a")
+	pod.DeletionTimestamp = &deletionTime
+	store := &memorySandboxStore{records: map[string]*SandboxRecord{
+		"sandbox-a": {
+			ID:                "sandbox-a",
+			TeamID:            "team-a",
+			UserID:            "user-a",
+			TemplateID:        "default",
+			TemplateName:      "default",
+			TemplateNamespace: "tpl-default",
+			Status:            SandboxStatusCleaned,
+			TemplateSpec:      v1alpha1.SandboxTemplateSpec{},
+		},
+	}}
+	client := fake.NewSimpleClientset(pod.DeepCopy())
+	svc := &SandboxService{
+		k8sClient:    client,
+		podLister:    runtimeIdentityPodLister(t, pod),
+		sandboxStore: store,
+		logger:       zap.NewNop(),
+	}
+
+	_, err := svc.RestoreCleanedSandboxRuntime(context.Background(), "sandbox-a")
+	if !k8serrors.IsConflict(err) {
+		t.Fatalf("RestoreCleanedSandboxRuntime() error = %v, want conflict", err)
+	}
+	for _, action := range client.Actions() {
+		if action.GetVerb() == "create" && action.GetResource().Resource == "pods" {
+			t.Fatalf("unexpected pod create while old runtime is deleting: %#v", action)
+		}
+	}
+	if store.saves != 0 {
+		t.Fatalf("store saves = %d, want 0", store.saves)
+	}
+}
+
+func TestTerminateCleanedSandboxRecordRunsPersistentCleanup(t *testing.T) {
+	store := &memorySandboxStore{records: map[string]*SandboxRecord{
+		"sandbox-a": {
+			ID:     "sandbox-a",
+			TeamID: "team-a",
+			UserID: "user-a",
+			Status: SandboxStatusCleaned,
+			Config: SandboxConfig{Webhook: &WebhookConfig{
+				URL:    "https://example.test/webhook",
+				Secret: "secret",
+			}},
+		},
+	}}
+	bindings := &deleteRecordingBindingStore{}
+	volumes := &recordingSystemVolumeClient{}
+	emitter := &recordingDeletionWebhookEmitter{}
+	svc := &SandboxService{
+		podLister:              runtimeIdentityPodLister(t),
+		credentialStore:        bindings,
+		webhookStateVolumes:    volumes,
+		deletionWebhookEmitter: emitter,
+		sandboxStore:           store,
+		clock:                  systemTime{},
+		logger:                 zap.NewNop(),
+	}
+
+	if err := svc.TerminateSandbox(context.Background(), "sandbox-a"); err != nil {
+		t.Fatalf("TerminateSandbox() error = %v", err)
+	}
+	if store.records["sandbox-a"].Status != SandboxStatusDeleted {
+		t.Fatalf("status = %q, want deleted", store.records["sandbox-a"].Status)
+	}
+	if bindings.deleteCalls != 1 {
+		t.Fatalf("DeleteBindings calls = %d, want 1", bindings.deleteCalls)
+	}
+	if len(emitter.calls) != 1 {
+		t.Fatalf("webhook calls = %d, want 1", len(emitter.calls))
+	}
+	if len(volumes.marked) != 1 || volumes.marked[0] != "sandbox-a:sandbox_deleted" {
+		t.Fatalf("marked volumes = %#v, want sandbox-a:sandbox_deleted", volumes.marked)
+	}
+}
+
+func runtimeIdentityPod(namespace, name, sandboxID string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				controller.LabelPoolType:  controller.PoolTypeActive,
+				controller.LabelSandboxID: sandboxID,
+			},
+			Annotations: map[string]string{
+				controller.AnnotationTeamID:    "team-a",
+				controller.AnnotationSandboxID: sandboxID,
+			},
+		},
+	}
+}
+
+func runtimeIdentityPodLister(t *testing.T, pods ...*corev1.Pod) corelisters.PodLister {
+	t.Helper()
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	for _, pod := range pods {
+		if err := indexer.Add(pod); err != nil {
+			t.Fatalf("add pod to indexer: %v", err)
+		}
+	}
+	return corelisters.NewPodLister(indexer)
+}

--- a/manager/pkg/service/sandbox_service.go
+++ b/manager/pkg/service/sandbox_service.go
@@ -131,6 +131,7 @@ type SandboxService struct {
 	volumeMetadata         SandboxVolumeMetadataClient
 	deletionWebhookEmitter SandboxDeletionWebhookEmitter
 	quotaStore             TeamQuotaLimitStore
+	sandboxStore           SandboxStore
 	powerStateLocks        sync.Map
 	powerStateReconcilers  sync.Map
 }
@@ -288,6 +289,11 @@ func (s *SandboxService) SetDeletionWebhookEmitter(emitter SandboxDeletionWebhoo
 // SetQuotaStore injects the team quota limit store. Nil disables quota checks.
 func (s *SandboxService) SetQuotaStore(store TeamQuotaLimitStore) {
 	s.quotaStore = store
+}
+
+// SetSandboxStore injects durable sandbox identity storage.
+func (s *SandboxService) SetSandboxStore(store SandboxStore) {
+	s.sandboxStore = store
 }
 
 func (s *SandboxService) sandboxPowerExecutor() SandboxPowerExecutor {

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math/rand"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -38,6 +39,10 @@ type ClaimRequest struct {
 	Config   *SandboxConfig `json:"config,omitempty"`
 	Mounts   []ClaimMount   `json:"mounts,omitempty"`
 	Metadata *ClaimMetadata `json:"-"`
+	// SandboxID is an internal stable ID used when recreating an existing sandbox.
+	SandboxID string `json:"-"`
+	// RuntimeGeneration identifies the current runtime pod incarnation.
+	RuntimeGeneration int64 `json:"-"`
 }
 
 type ClaimMount struct {
@@ -333,6 +338,16 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 		}
 	}
 	s.observeClaimPhase(req.Template, "unknown", "resolve_template", phaseStarted, nil)
+	if strings.TrimSpace(req.SandboxID) == "" {
+		req.SandboxID, err = s.generateStableSandboxID(template)
+		if err != nil {
+			s.observeClaimPhase(req.Template, "unknown", "generate_sandbox_id", phaseStarted, err)
+			return nil, err
+		}
+	}
+	if req.RuntimeGeneration <= 0 {
+		req.RuntimeGeneration = 1
+	}
 
 	phaseStarted = time.Now()
 	if err := s.enforceSandboxCPUQuota(ctx, req.TeamID, template); err != nil {
@@ -475,13 +490,24 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 	}
 	s.observeClaimPhase(req.Template, claimType, "initialize_procd", phaseStarted, nil)
 
+	phaseStarted = time.Now()
+	if err := s.persistClaimedSandbox(ctx, pod, template, req); err != nil {
+		s.observeClaimPhase(req.Template, claimType, "persist_sandbox", phaseStarted, err)
+		s.requestSandboxDeletionAfterClaimFailure(pod, "sandbox persistence failed")
+		if metrics != nil {
+			metrics.SandboxClaimsTotal.WithLabelValues(req.Template, "error").Inc()
+		}
+		return nil, fmt.Errorf("persist sandbox: %w", err)
+	}
+	s.observeClaimPhase(req.Template, claimType, "persist_sandbox", phaseStarted, nil)
+
 	if metrics != nil {
 		metrics.SandboxClaimsTotal.WithLabelValues(req.Template, "success").Inc()
 		metrics.SandboxClaimDuration.WithLabelValues(req.Template, claimType).Observe(time.Since(start).Seconds())
 	}
 
 	return &ClaimResponse{
-		SandboxID:       pod.Name,
+		SandboxID:       req.SandboxID,
 		Status:          "starting",
 		ProcdAddress:    procdAddress,
 		PodName:         pod.Name,
@@ -489,6 +515,64 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 		ClusterId:       template.Spec.ClusterId,
 		BootstrapMounts: portalMounts,
 	}, nil
+}
+
+func (s *SandboxService) persistClaimedSandbox(ctx context.Context, pod *corev1.Pod, template *v1alpha1.SandboxTemplate, req *ClaimRequest) error {
+	if s == nil || s.sandboxStore == nil || pod == nil || template == nil || req == nil {
+		return nil
+	}
+	sandboxID := sandboxIDFromPod(pod)
+	if sandboxID == "" {
+		sandboxID = req.SandboxID
+	}
+	if sandboxID == "" {
+		return fmt.Errorf("sandbox_id is required")
+	}
+	cfg := parseSandboxConfig(pod.Annotations[controller.AnnotationConfig])
+	mounts := parseClaimMounts(pod.Annotations[controller.AnnotationMounts])
+	return s.sandboxStore.UpsertSandbox(ctx, &SandboxRecord{
+		ID:                  sandboxID,
+		TeamID:              req.TeamID,
+		UserID:              req.UserID,
+		TemplateID:          controller.TemplateLogicalID(template),
+		TemplateName:        template.Name,
+		TemplateNamespace:   template.Namespace,
+		ClusterID:           naming.ClusterIDOrDefault(template.Spec.ClusterId),
+		Status:              s.podToSandboxStatus(pod),
+		Config:              cfg,
+		Mounts:              mounts,
+		TemplateSpec:        template.Spec,
+		CurrentPodName:      pod.Name,
+		CurrentPodNamespace: pod.Namespace,
+		RuntimeGeneration:   runtimeGenerationFromPod(pod),
+		ClaimedAt:           parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationClaimedAt),
+		ExpiresAt:           parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationExpiresAt),
+		HardExpiresAt:       parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationHardExpiresAt),
+		CreatedAt:           s.clock.Now(),
+	})
+}
+
+func runtimeGenerationFromPod(pod *corev1.Pod) int64 {
+	if pod == nil || pod.Annotations == nil {
+		return 0
+	}
+	raw := strings.TrimSpace(pod.Annotations[controller.AnnotationRuntimeGeneration])
+	if raw == "" {
+		return 0
+	}
+	generation, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || generation < 0 {
+		return 0
+	}
+	return generation
+}
+
+func (s *SandboxService) generateStableSandboxID(template *v1alpha1.SandboxTemplate) (string, error) {
+	if template == nil {
+		return "", fmt.Errorf("template is required")
+	}
+	clusterID := naming.ClusterIDOrDefault(template.Spec.ClusterId)
+	return naming.SandboxName(clusterID, template.Name, utilrand.String(5))
 }
 
 func (s *SandboxService) observeClaimPhase(template, claimType, phase string, started time.Time, err error) {
@@ -621,6 +705,10 @@ func (s *SandboxService) bindVolumePortal(ctx context.Context, pod *corev1.Pod, 
 	if pod == nil {
 		return nil, fmt.Errorf("pod is nil")
 	}
+	sandboxID := sandboxIDFromPod(pod)
+	if sandboxID == "" {
+		sandboxID = pod.Name
+	}
 	ctldAddress, err := s.ctldAddressForPod(ctx, pod)
 	if err != nil {
 		return nil, err
@@ -635,7 +723,7 @@ func (s *SandboxService) bindVolumePortal(ctx context.Context, pod *corev1.Pod, 
 		PodUID:         string(pod.UID),
 		PortalName:     volumeportal.NormalizePortalName(portalName, mountPoint),
 		MountPath:      mountPoint,
-		SandboxID:      pod.Name,
+		SandboxID:      sandboxID,
 		OwnerTeamID:    ownerTeamID,
 	}); err != nil {
 		if errors.Is(err, ErrVolumePortalBindConflict) {
@@ -649,7 +737,7 @@ func (s *SandboxService) bindVolumePortal(ctx context.Context, pod *corev1.Pod, 
 		PodUID:          string(pod.UID),
 		PortalName:      volumeportal.NormalizePortalName(portalName, mountPoint),
 		MountPath:       mountPoint,
-		SandboxID:       pod.Name,
+		SandboxID:       sandboxID,
 		TeamID:          ownerTeamID,
 		SandboxVolumeID: volumeID,
 	})
@@ -658,7 +746,7 @@ func (s *SandboxService) bindVolumePortal(ctx context.Context, pod *corev1.Pod, 
 	}
 	if s.logger != nil {
 		s.logger.Info("Bound sandbox volume portal",
-			zap.String("sandboxID", pod.Name),
+			zap.String("sandboxID", sandboxID),
 			zap.String("teamID", teamID),
 			zap.String("userID", userID),
 			zap.String("volumeID", volumeID),
@@ -765,12 +853,16 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 		// Claim an available pod
 		pod := readyPods[rand.Intn(len(readyPods))]
 
+		sandboxID := strings.TrimSpace(req.SandboxID)
+		if sandboxID == "" {
+			sandboxID = pod.Name
+		}
 		s.logger.Info("Claiming idle pod",
 			zap.String("pod", pod.Name),
-			zap.String("sandboxID", pod.Name),
+			zap.String("sandboxID", sandboxID),
 		)
 
-		stateVolume, err := s.prepareWebhookStateVolume(ctx, req, pod.Name)
+		stateVolume, err := s.prepareWebhookStateVolume(ctx, req, sandboxID)
 		if err != nil {
 			return fmt.Errorf("prepare webhook state volume: %w", err)
 		}
@@ -780,9 +872,9 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 			}
 			cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-			if err := s.webhookStateVolumes.Delete(cleanupCtx, req.TeamID, req.UserID, pod.Name, stateVolume.VolumeID); err != nil && s.logger != nil {
+			if err := s.webhookStateVolumes.Delete(cleanupCtx, req.TeamID, req.UserID, sandboxID, stateVolume.VolumeID); err != nil && s.logger != nil {
 				s.logger.Warn("Failed to roll back webhook state volume",
-					zap.String("sandboxID", pod.Name),
+					zap.String("sandboxID", sandboxID),
 					zap.String("volumeID", stateVolume.VolumeID),
 					zap.Error(err),
 				)
@@ -794,7 +886,7 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 
 		// Change pool type from idle to active
 		pod.Labels[controller.LabelPoolType] = controller.PoolTypeActive
-		pod.Labels[controller.LabelSandboxID] = pod.Name
+		pod.Labels[controller.LabelSandboxID] = sandboxID
 		ensureSandboxCleanupFinalizer(pod)
 
 		// Remove owner reference (so it's no longer managed by ReplicaSet)
@@ -805,7 +897,8 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 			pod.Annotations = make(map[string]string)
 		}
 		pod.Annotations = controller.ClaimedSandboxPodAnnotations(pod.Annotations)
-		pod.Annotations[controller.AnnotationSandboxID] = pod.Name
+		pod.Annotations[controller.AnnotationSandboxID] = sandboxID
+		pod.Annotations[controller.AnnotationRuntimeGeneration] = strconv.FormatInt(req.RuntimeGeneration, 10)
 		pod.Annotations[controller.AnnotationTeamID] = req.TeamID
 		pod.Annotations[controller.AnnotationUserID] = req.UserID
 		pod.Annotations[controller.AnnotationClaimedAt] = s.clock.Now().Format(time.RFC3339)
@@ -852,7 +945,7 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 			rollbackStateVolume()
 			if rollbackErr := rollbackBindings(ctx); rollbackErr != nil {
 				s.logger.Warn("Failed to roll back credential bindings after hot-claim update failure",
-					zap.String("sandboxID", pod.Name),
+					zap.String("sandboxID", sandboxID),
 					zap.Error(rollbackErr),
 				)
 			}
@@ -869,7 +962,7 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 
 		s.logger.Info("Successfully claimed idle pod",
 			zap.String("pod", updatedPod.Name),
-			zap.String("sandboxID", updatedPod.Name),
+			zap.String("sandboxID", sandboxID),
 			zap.String("expiresAt", updatedPod.Annotations[controller.AnnotationExpiresAt]),
 		)
 
@@ -922,7 +1015,11 @@ func (s *SandboxService) createNewPod(ctx context.Context, template *v1alpha1.Sa
 	if err := s.ensureDataPlaneReadyCapacity(spec); err != nil {
 		return nil, err
 	}
-	stateVolume, err := s.prepareWebhookStateVolume(ctx, req, podName)
+	sandboxID := strings.TrimSpace(req.SandboxID)
+	if sandboxID == "" {
+		sandboxID = podName
+	}
+	stateVolume, err := s.prepareWebhookStateVolume(ctx, req, sandboxID)
 	if err != nil {
 		return nil, fmt.Errorf("prepare webhook state volume: %w", err)
 	}
@@ -932,9 +1029,9 @@ func (s *SandboxService) createNewPod(ctx context.Context, template *v1alpha1.Sa
 		}
 		cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
-		if err := s.webhookStateVolumes.Delete(cleanupCtx, req.TeamID, req.UserID, podName, stateVolume.VolumeID); err != nil && s.logger != nil {
+		if err := s.webhookStateVolumes.Delete(cleanupCtx, req.TeamID, req.UserID, sandboxID, stateVolume.VolumeID); err != nil && s.logger != nil {
 			s.logger.Warn("Failed to roll back webhook state volume",
-				zap.String("sandboxID", podName),
+				zap.String("sandboxID", sandboxID),
 				zap.String("volumeID", stateVolume.VolumeID),
 				zap.Error(err),
 			)
@@ -949,11 +1046,12 @@ func (s *SandboxService) createNewPod(ctx context.Context, template *v1alpha1.Sa
 	}
 
 	annotations := controller.ClaimedSandboxPodAnnotations(map[string]string{
-		controller.AnnotationSandboxID: podName,
-		controller.AnnotationTeamID:    req.TeamID,
-		controller.AnnotationUserID:    req.UserID,
-		controller.AnnotationClaimedAt: s.clock.Now().Format(time.RFC3339),
-		controller.AnnotationClaimType: "cold",
+		controller.AnnotationSandboxID:         sandboxID,
+		controller.AnnotationRuntimeGeneration: strconv.FormatInt(req.RuntimeGeneration, 10),
+		controller.AnnotationTeamID:            req.TeamID,
+		controller.AnnotationUserID:            req.UserID,
+		controller.AnnotationClaimedAt:         s.clock.Now().Format(time.RFC3339),
+		controller.AnnotationClaimType:         "cold",
 	})
 	if stateVolume != nil {
 		annotations[controller.AnnotationWebhookStateVolumeID] = stateVolume.VolumeID
@@ -969,7 +1067,7 @@ func (s *SandboxService) createNewPod(ctx context.Context, template *v1alpha1.Sa
 				controller.LabelTemplateID:        template.Name,
 				controller.LabelTemplateLogicalID: controller.TemplateLogicalID(template),
 				controller.LabelPoolType:          controller.PoolTypeActive,
-				controller.LabelSandboxID:         podName,
+				controller.LabelSandboxID:         sandboxID,
 			},
 			Annotations: annotations,
 		},
@@ -1012,7 +1110,7 @@ func (s *SandboxService) createNewPod(ctx context.Context, template *v1alpha1.Sa
 		rollbackStateVolume()
 		if rollbackErr := rollbackBindings(ctx); rollbackErr != nil {
 			s.logger.Warn("Failed to clean up staged credential bindings after create failure",
-				zap.String("sandboxID", pod.Name),
+				zap.String("sandboxID", sandboxID),
 				zap.Error(rollbackErr),
 			)
 		}
@@ -1026,7 +1124,7 @@ func (s *SandboxService) createNewPod(ctx context.Context, template *v1alpha1.Sa
 
 	s.logger.Info("Created new pod for cold start",
 		zap.String("pod", createdPod.Name),
-		zap.String("sandboxID", createdPod.Name),
+		zap.String("sandboxID", sandboxID),
 		zap.String("expiresAt", createdPod.Annotations[controller.AnnotationExpiresAt]),
 	)
 
@@ -1047,7 +1145,7 @@ func (s *SandboxService) requestSandboxDeletionAfterClaimFailure(pod *corev1.Pod
 	if !hasSandboxCleanupFinalizer(pod) {
 		if _, err := s.ensureSandboxDeletionFinalizer(cleanupCtx, pod); err != nil {
 			logger.Warn("Failed to ensure sandbox cleanup finalizer after claim failure",
-				zap.String("sandboxID", pod.Name),
+				zap.String("sandboxID", sandboxIDFromPod(pod)),
 				zap.String("namespace", pod.Namespace),
 				zap.String("reason", reason),
 				zap.Error(err),
@@ -1057,7 +1155,7 @@ func (s *SandboxService) requestSandboxDeletionAfterClaimFailure(pod *corev1.Pod
 
 	if err := s.k8sClient.CoreV1().Pods(pod.Namespace).Delete(cleanupCtx, pod.Name, metav1.DeleteOptions{}); err != nil && !k8serrors.IsNotFound(err) {
 		logger.Warn("Delete pod failed after claim failure",
-			zap.String("sandboxID", pod.Name),
+			zap.String("sandboxID", sandboxIDFromPod(pod)),
 			zap.String("namespace", pod.Namespace),
 			zap.String("reason", reason),
 			zap.Error(err),
@@ -1115,7 +1213,13 @@ func (s *SandboxService) initializeProcd(
 
 	teamID := req.TeamID
 	userID := req.UserID
-	sandboxID := pod.Name
+	sandboxID := sandboxIDFromPod(pod)
+	if sandboxID == "" {
+		sandboxID = req.SandboxID
+	}
+	if sandboxID == "" {
+		sandboxID = pod.Name
+	}
 
 	internalToken, err := s.internalTokenGenerator.GenerateToken(teamID, userID, sandboxID)
 	if err != nil {

--- a/manager/pkg/service/sandbox_service_lifecycle.go
+++ b/manager/pkg/service/sandbox_service_lifecycle.go
@@ -3,12 +3,14 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
+	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -27,6 +29,18 @@ func (s *SandboxService) TerminateSandbox(ctx context.Context, sandboxID string)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			s.logger.Info("Sandbox already terminated", zap.String("sandboxID", sandboxID))
+			if s.sandboxStore != nil {
+				record, getErr := s.sandboxStore.GetSandbox(ctx, sandboxID)
+				if getErr != nil {
+					return fmt.Errorf("get sandbox record: %w", getErr)
+				}
+				if record != nil && record.Status != SandboxStatusDeleted {
+					if err := s.CleanupDeletedSandbox(ctx, sandboxLifecycleInfoFromRecord(record)); err != nil {
+						return fmt.Errorf("cleanup deleted sandbox record: %w", err)
+					}
+				}
+				return s.sandboxStore.MarkSandboxDeleted(ctx, sandboxID, s.clock.Now())
+			}
 			return nil
 		}
 		return fmt.Errorf("get pod: %w", err)
@@ -37,10 +51,17 @@ func (s *SandboxService) TerminateSandbox(ctx context.Context, sandboxID string)
 	if err != nil {
 		return fmt.Errorf("ensure sandbox cleanup finalizer: %w", err)
 	}
+	pod, err = s.markRuntimeDeletionReason(ctx, pod, runtimeDeletionReasonDeleted)
+	if err != nil {
+		return fmt.Errorf("mark sandbox deletion reason: %w", err)
+	}
 
 	err = s.k8sClient.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{})
 	if k8serrors.IsNotFound(err) {
 		s.logger.Info("Sandbox already terminated", zap.String("sandboxID", sandboxID))
+		if s.sandboxStore != nil {
+			return s.sandboxStore.MarkSandboxDeleted(ctx, sandboxID, s.clock.Now())
+		}
 		return nil
 	}
 	if err != nil {
@@ -48,8 +69,90 @@ func (s *SandboxService) TerminateSandbox(ctx context.Context, sandboxID string)
 	}
 
 	s.logger.Info("Sandbox termination requested", zap.String("sandboxID", sandboxID), zap.String("pod", pod.Name))
+	if s.sandboxStore != nil {
+		if err := s.sandboxStore.MarkSandboxDeleted(ctx, sandboxID, s.clock.Now()); err != nil {
+			return err
+		}
+	}
 
 	return nil
+}
+
+// CleanSandboxRuntime deletes the runtime pod while preserving durable sandbox state and public services.
+func (s *SandboxService) CleanSandboxRuntime(ctx context.Context, sandboxID string) error {
+	s.logger.Info("Cleaning sandbox runtime", zap.String("sandboxID", sandboxID))
+	clean := func(ctx context.Context, tx SandboxStoreTx, record *SandboxRecord) error {
+		pod, err := s.getSandboxPod(ctx, sandboxID)
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				if tx != nil {
+					return tx.MarkRuntimeCleaned(ctx, sandboxID, 0, s.clock.Now())
+				}
+				return nil
+			}
+			return fmt.Errorf("get pod: %w", err)
+		}
+		generation := runtimeGenerationFromPod(pod)
+		pod, err = s.ensureSandboxDeletionFinalizer(ctx, pod)
+		if err != nil {
+			return fmt.Errorf("ensure sandbox cleanup finalizer: %w", err)
+		}
+		pod, err = s.markRuntimeDeletionReason(ctx, pod, runtimeDeletionReasonCleaned)
+		if err != nil {
+			return fmt.Errorf("mark runtime deletion reason: %w", err)
+		}
+		if err := s.k8sClient.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{}); err != nil && !k8serrors.IsNotFound(err) {
+			return fmt.Errorf("delete runtime pod: %w", err)
+		}
+		if tx != nil {
+			return tx.MarkRuntimeCleaned(ctx, sandboxID, generation, s.clock.Now())
+		}
+		return nil
+	}
+	if s.sandboxStore != nil {
+		if err := s.sandboxStore.WithSandboxLock(ctx, sandboxID, clean); err != nil {
+			if errors.Is(err, ErrSandboxRecordNotFound) {
+				return clean(ctx, nil, nil)
+			}
+			return err
+		}
+		return nil
+	}
+	return clean(ctx, nil, nil)
+}
+
+// CleanSandboxRuntimeByID implements controller.SandboxRuntimeCleaner.
+func (s *SandboxService) CleanSandboxRuntimeByID(ctx context.Context, sandboxID string) error {
+	return s.CleanSandboxRuntime(ctx, sandboxID)
+}
+
+const (
+	runtimeDeletionReasonCleaned = "cleaned"
+	runtimeDeletionReasonDeleted = "deleted"
+)
+
+func (s *SandboxService) markRuntimeDeletionReason(ctx context.Context, pod *corev1.Pod, reason string) (*corev1.Pod, error) {
+	if s == nil || pod == nil || s.k8sClient == nil || strings.TrimSpace(reason) == "" {
+		return pod, nil
+	}
+	var updated *corev1.Pod
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current, err := s.k8sClient.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		updated = current.DeepCopy()
+		if updated.Annotations == nil {
+			updated.Annotations = make(map[string]string)
+		}
+		updated.Annotations[controller.AnnotationRuntimeDeletionReason] = reason
+		updated, err = s.k8sClient.CoreV1().Pods(updated.Namespace).Update(ctx, updated, metav1.UpdateOptions{})
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return updated, nil
 }
 
 func (s *SandboxService) thawSandboxBeforeTermination(ctx context.Context, pod *corev1.Pod, sandboxID string) {
@@ -66,9 +169,23 @@ func (s *SandboxService) thawSandboxBeforeTermination(ctx context.Context, pod *
 
 // GetSandbox gets a sandbox by ID
 func (s *SandboxService) GetSandbox(ctx context.Context, sandboxID string) (*Sandbox, error) {
+	var record *SandboxRecord
+	if s.sandboxStore != nil {
+		var storeErr error
+		record, storeErr = s.sandboxStore.GetSandbox(ctx, sandboxID)
+		if storeErr != nil {
+			return nil, fmt.Errorf("get sandbox record: %w", storeErr)
+		}
+		if record != nil && record.Status == SandboxStatusDeleted {
+			return nil, k8serrors.NewNotFound(schema.GroupResource{Resource: "sandbox"}, sandboxID)
+		}
+	}
 	// Find the pod by sandbox ID
 	pod, err := s.getSandboxPod(ctx, sandboxID)
 	if err != nil {
+		if k8serrors.IsNotFound(err) && record != nil {
+			return s.recordToSandbox(record), nil
+		}
 		return nil, fmt.Errorf("get pod: %w", err)
 	}
 
@@ -83,6 +200,15 @@ func (s *SandboxService) UpdateSandbox(ctx context.Context, sandboxID string, cf
 
 	pod, err := s.getSandboxPod(ctx, sandboxID)
 	if err != nil {
+		if k8serrors.IsNotFound(err) && s.sandboxStore != nil {
+			record, getErr := s.sandboxStore.GetSandbox(ctx, sandboxID)
+			if getErr != nil {
+				return nil, fmt.Errorf("get sandbox record: %w", getErr)
+			}
+			if record != nil && record.Status != SandboxStatusDeleted {
+				return s.updateCleanedSandboxRecord(ctx, record, cfg)
+			}
+		}
 		return nil, fmt.Errorf("get pod: %w", err)
 	}
 
@@ -151,7 +277,7 @@ func (s *SandboxService) UpdateSandbox(ctx context.Context, sandboxID string, cf
 				}
 			}
 			networkState = s.NetworkPolicyService.BuildNetworkPolicyState(&BuildNetworkPolicyRequest{
-				SandboxID:        updatedPod.Name,
+				SandboxID:        sandboxIDFromPod(updatedPod),
 				TeamID:           teamID,
 				TemplateSpec:     templateSpec,
 				RequestSpec:      requestSpec,
@@ -198,14 +324,111 @@ func (s *SandboxService) UpdateSandbox(ctx context.Context, sandboxID string, cf
 			return nil, fmt.Errorf("apply network policy: %w", err)
 		}
 	}
+	if err := s.persistUpdatedSandboxPod(ctx, updatedPod); err != nil {
+		return nil, err
+	}
 
 	return s.podToSandbox(ctx, updatedPod, sandboxID), nil
 }
 
+func (s *SandboxService) updateCleanedSandboxRecord(ctx context.Context, record *SandboxRecord, cfg *SandboxUpdateConfig) (*Sandbox, error) {
+	if record == nil {
+		return nil, k8serrors.NewNotFound(schema.GroupResource{Resource: "sandbox"}, "")
+	}
+	merged := record.Config
+	now := s.clock.Now()
+	if cfg.TTL != nil {
+		merged.TTL = cfg.TTL
+		record.ExpiresAt = expirationFromTTL(now, cfg.TTL)
+	}
+	if cfg.HardTTL != nil {
+		merged.HardTTL = cfg.HardTTL
+		record.HardExpiresAt = expirationFromTTL(now, cfg.HardTTL)
+	}
+	if cfg.AutoResume != nil {
+		merged.AutoResume = cfg.AutoResume
+	}
+	if cfg.Services != nil {
+		services, err := NormalizeSandboxAppServices(cfg.Services)
+		if err != nil {
+			return nil, err
+		}
+		merged.Services = services
+	}
+	if cfg.Network != nil {
+		merged.Network = sanitizedNetworkPolicyForPersistence(cfg.Network)
+	}
+	if merged.AutoResume != nil && !*merged.AutoResume && SandboxAppServicesHaveResumeRoute(merged.Services) {
+		return nil, fmt.Errorf("cannot set resume=true on public routes when sandbox auto_resume is disabled")
+	}
+	record.Config = merged
+	record.UpdatedAt = now
+	if err := s.sandboxStore.UpsertSandbox(ctx, record); err != nil {
+		return nil, err
+	}
+	return s.recordToSandbox(record), nil
+}
+
+func expirationFromTTL(now time.Time, ttl *int32) time.Time {
+	if ttl == nil || *ttl <= 0 {
+		return time.Time{}
+	}
+	return now.Add(time.Duration(*ttl) * time.Second)
+}
+
+func (s *SandboxService) persistUpdatedSandboxPod(ctx context.Context, pod *corev1.Pod) error {
+	if s == nil || s.sandboxStore == nil || pod == nil {
+		return nil
+	}
+	template := s.templateForPod(pod)
+	if template == nil {
+		return nil
+	}
+	record := &SandboxRecord{
+		ID:                  sandboxIDFromPod(pod),
+		TeamID:              pod.Annotations[controller.AnnotationTeamID],
+		UserID:              pod.Annotations[controller.AnnotationUserID],
+		TemplateID:          sandboxTemplateIDFromLabels(pod.Labels),
+		TemplateName:        template.Name,
+		TemplateNamespace:   template.Namespace,
+		ClusterID:           naming.ClusterIDOrDefault(template.Spec.ClusterId),
+		Status:              s.podToSandboxStatus(pod),
+		Config:              parseSandboxConfig(pod.Annotations[controller.AnnotationConfig]),
+		Mounts:              parseClaimMounts(pod.Annotations[controller.AnnotationMounts]),
+		TemplateSpec:        template.Spec,
+		CurrentPodName:      pod.Name,
+		CurrentPodNamespace: pod.Namespace,
+		RuntimeGeneration:   runtimeGenerationFromPod(pod),
+		ClaimedAt:           parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationClaimedAt),
+		ExpiresAt:           parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationExpiresAt),
+		HardExpiresAt:       parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationHardExpiresAt),
+		CreatedAt:           pod.CreationTimestamp.Time,
+	}
+	if record.ID == "" {
+		record.ID = pod.Name
+	}
+	return s.sandboxStore.UpsertSandbox(ctx, record)
+}
+
 func (s *SandboxService) getSandboxPod(ctx context.Context, sandboxID string) (*corev1.Pod, error) {
-	if s.sandboxIndex != nil {
-		if namespace, ok := s.sandboxIndex.GetNamespace(sandboxID); ok {
-			return s.podLister.Pods(namespace).Get(sandboxID)
+	if s.sandboxIndex != nil && s.podLister != nil {
+		refs := s.sandboxIndex.GetPodRefs(sandboxID)
+		if len(refs) > 0 {
+			pods := make([]*corev1.Pod, 0, len(refs))
+			for _, ref := range refs {
+				pod, err := s.podLister.Pods(ref.Namespace).Get(ref.Name)
+				if err != nil {
+					if k8serrors.IsNotFound(err) {
+						continue
+					}
+					return nil, err
+				}
+				pods = append(pods, pod)
+			}
+			pod, err := selectSandboxRuntimePod(sandboxID, pods)
+			if err == nil || !k8serrors.IsNotFound(err) {
+				return pod, err
+			}
 		}
 	}
 
@@ -215,14 +438,42 @@ func (s *SandboxService) getSandboxPod(ctx context.Context, sandboxID string) (*
 	if err != nil {
 		return nil, err
 	}
-	if len(pods) == 0 {
-		return nil, k8serrors.NewNotFound(schema.GroupResource{Resource: "pod"}, sandboxID)
+	return selectSandboxRuntimePod(sandboxID, pods)
+}
+
+func selectSandboxRuntimePod(sandboxID string, pods []*corev1.Pod) (*corev1.Pod, error) {
+	var active []*corev1.Pod
+	var deleting []*corev1.Pod
+	for _, pod := range pods {
+		if pod == nil || sandboxIDFromPod(pod) != sandboxID {
+			continue
+		}
+		if pod.DeletionTimestamp != nil {
+			deleting = append(deleting, pod)
+			continue
+		}
+		active = append(active, pod)
 	}
-	return pods[0], nil
+	if len(active) == 1 {
+		return active[0], nil
+	}
+	if len(active) > 1 {
+		return nil, k8serrors.NewConflict(schema.GroupResource{Resource: "pod"}, sandboxID, fmt.Errorf("multiple active runtime pods found for sandbox"))
+	}
+	if len(deleting) == 1 {
+		return deleting[0], nil
+	}
+	if len(deleting) > 1 {
+		return nil, k8serrors.NewConflict(schema.GroupResource{Resource: "pod"}, sandboxID, fmt.Errorf("multiple deleting runtime pods found for sandbox"))
+	}
+	return nil, k8serrors.NewNotFound(schema.GroupResource{Resource: "pod"}, sandboxID)
 }
 
 // podToSandbox converts a pod to a sandbox object
 func (s *SandboxService) podToSandbox(ctx context.Context, pod *corev1.Pod, sandboxID string) *Sandbox {
+	if sandboxID == "" {
+		sandboxID = sandboxIDFromPod(pod)
+	}
 	status := s.podToSandboxStatus(pod)
 
 	// Parse timestamps
@@ -261,6 +512,58 @@ func (s *SandboxService) podToSandbox(ctx context.Context, pod *corev1.Pod, sand
 		ClaimedAt:     claimedAt,
 		CreatedAt:     createdAt,
 	}
+}
+
+func (s *SandboxService) recordToSandbox(record *SandboxRecord) *Sandbox {
+	if record == nil {
+		return nil
+	}
+	autoResume := true
+	if record.Config.AutoResume != nil {
+		autoResume = *record.Config.AutoResume
+	}
+	powerState := SandboxPowerState{
+		Desired:            SandboxPowerStateActive,
+		DesiredGeneration:  record.RuntimeGeneration,
+		Observed:           SandboxPowerStateActive,
+		ObservedGeneration: record.RuntimeGeneration,
+		Phase:              SandboxPowerPhaseStable,
+	}
+	return &Sandbox{
+		ID:            record.ID,
+		TemplateID:    record.TemplateID,
+		TeamID:        record.TeamID,
+		UserID:        record.UserID,
+		Status:        record.Status,
+		Paused:        false,
+		PowerState:    powerState,
+		AutoResume:    autoResume,
+		Services:      record.Config.Services,
+		Mounts:        record.Mounts,
+		PodName:       record.CurrentPodName,
+		ExpiresAt:     record.ExpiresAt,
+		HardExpiresAt: record.HardExpiresAt,
+		ClaimedAt:     record.ClaimedAt,
+		CreatedAt:     record.CreatedAt,
+	}
+}
+
+func sandboxLifecycleInfoFromRecord(record *SandboxRecord) SandboxLifecycleInfo {
+	if record == nil {
+		return SandboxLifecycleInfo{}
+	}
+	info := SandboxLifecycleInfo{
+		Namespace: record.CurrentPodNamespace,
+		PodName:   record.CurrentPodName,
+		SandboxID: record.ID,
+		TeamID:    record.TeamID,
+		UserID:    record.UserID,
+	}
+	if record.Config.Webhook != nil {
+		info.WebhookURL = strings.TrimSpace(record.Config.Webhook.URL)
+		info.WebhookSecret = strings.TrimSpace(record.Config.Webhook.Secret)
+	}
+	return info
 }
 
 func sandboxTemplateIDFromLabels(labels map[string]string) string {

--- a/manager/pkg/service/sandbox_service_list.go
+++ b/manager/pkg/service/sandbox_service_list.go
@@ -56,6 +56,10 @@ func (s *SandboxService) ListSandboxes(ctx context.Context, req *ListSandboxesRe
 		req.Limit = 200
 	}
 
+	if s.sandboxStore != nil {
+		return s.listSandboxesFromStore(ctx, req)
+	}
+
 	// List all active pods (exclude idle pool)
 	pods, err := s.podLister.List(labels.SelectorFromSet(map[string]string{
 		controller.LabelPoolType: controller.PoolTypeActive,
@@ -98,7 +102,7 @@ func (s *SandboxService) ListSandboxes(ctx context.Context, req *ListSandboxesRe
 		hardExpiresAt := parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationHardExpiresAt)
 
 		summaries = append(summaries, &SandboxSummary{
-			ID:            pod.Name,
+			ID:            sandboxIDFromPod(pod),
 			TemplateID:    templateID,
 			Status:        status,
 			Paused:        paused,
@@ -143,4 +147,51 @@ func (s *SandboxService) ListSandboxes(ctx context.Context, req *ListSandboxesRe
 		Count:     totalCount,
 		HasMore:   hasMore,
 	}, nil
+}
+
+func (s *SandboxService) listSandboxesFromStore(ctx context.Context, req *ListSandboxesRequest) (*ListSandboxesResponse, error) {
+	records, err := s.sandboxStore.ListSandboxes(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	summaries := make([]*SandboxSummary, 0, len(records))
+	for _, record := range records {
+		sandbox := s.recordToSandbox(record)
+		if record.CurrentPodName != "" {
+			if pod, err := s.getSandboxPod(ctx, record.ID); err == nil {
+				sandbox = s.podToSandbox(ctx, pod, record.ID)
+			}
+		}
+		if req.Paused != nil && sandbox.Paused != *req.Paused {
+			continue
+		}
+		summaries = append(summaries, &SandboxSummary{
+			ID:            sandbox.ID,
+			TemplateID:    sandbox.TemplateID,
+			Status:        sandbox.Status,
+			Paused:        sandbox.Paused,
+			PowerState:    sandbox.PowerState,
+			CreatedAt:     sandbox.CreatedAt,
+			ExpiresAt:     sandbox.ExpiresAt,
+			HardExpiresAt: sandbox.HardExpiresAt,
+		})
+	}
+
+	sort.Slice(summaries, func(i, j int) bool {
+		return summaries[i].CreatedAt.After(summaries[j].CreatedAt)
+	})
+	totalCount := len(summaries)
+	hasMore := false
+	if req.Offset >= totalCount {
+		summaries = []*SandboxSummary{}
+	} else {
+		end := req.Offset + req.Limit
+		if end >= totalCount {
+			end = totalCount
+		} else {
+			hasMore = true
+		}
+		summaries = summaries[req.Offset:end]
+	}
+	return &ListSandboxesResponse{Sandboxes: summaries, Count: totalCount, HasMore: hasMore}, nil
 }

--- a/manager/pkg/service/sandbox_service_network.go
+++ b/manager/pkg/service/sandbox_service_network.go
@@ -103,8 +103,12 @@ func (s *SandboxService) applyPoliciesForPod(
 		requestNetwork = s.appendWebhookNetworkPolicy(requestNetwork, webhookInfo.URL)
 	}
 
+	sandboxID := sandboxIDFromPod(pod)
+	if sandboxID == "" {
+		sandboxID = pod.Name
+	}
 	networkState := s.NetworkPolicyService.BuildNetworkPolicyState(&BuildNetworkPolicyRequest{
-		SandboxID:        pod.Name,
+		SandboxID:        sandboxID,
 		TeamID:           req.TeamID,
 		TemplateSpec:     template.Spec.Network,
 		RequestSpec:      requestNetwork,
@@ -177,7 +181,11 @@ func (s *SandboxService) syncCredentialBindings(
 		return noopCredentialBindingRollback, nil
 	}
 
-	previous, err := s.credentialStore.GetBindings(ctx, teamID, pod.Name)
+	sandboxID := sandboxIDFromPod(pod)
+	if sandboxID == "" {
+		sandboxID = pod.Name
+	}
+	previous, err := s.credentialStore.GetBindings(ctx, teamID, sandboxID)
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +193,7 @@ func (s *SandboxService) syncCredentialBindings(
 
 	rollback := func(rollbackCtx context.Context) error {
 		if previous == nil || len(previous.Bindings) == 0 {
-			return s.credentialStore.DeleteBindings(rollbackCtx, teamID, pod.Name)
+			return s.credentialStore.DeleteBindings(rollbackCtx, teamID, sandboxID)
 		}
 		return s.credentialStore.UpsertBindings(rollbackCtx, previous)
 	}
@@ -194,7 +202,7 @@ func (s *SandboxService) syncCredentialBindings(
 		if previous == nil || len(previous.Bindings) == 0 {
 			return rollback, nil
 		}
-		if err := s.credentialStore.DeleteBindings(ctx, teamID, pod.Name); err != nil {
+		if err := s.credentialStore.DeleteBindings(ctx, teamID, sandboxID); err != nil {
 			return nil, err
 		}
 		return rollback, nil
@@ -206,7 +214,7 @@ func (s *SandboxService) syncCredentialBindings(
 	}
 
 	if err := s.credentialStore.UpsertBindings(ctx, &egressauth.BindingRecord{
-		SandboxID: pod.Name,
+		SandboxID: sandboxID,
 		TeamID:    teamID,
 		Bindings:  storeBindings,
 	}); err != nil {
@@ -228,7 +236,11 @@ func (s *SandboxService) loadCredentialBindings(ctx context.Context, pod *corev1
 	if s.credentialStore == nil || pod == nil {
 		return nil, nil
 	}
-	record, err := s.credentialStore.GetBindings(ctx, sandboxTeamID(pod), pod.Name)
+	sandboxID := sandboxIDFromPod(pod)
+	if sandboxID == "" {
+		sandboxID = pod.Name
+	}
+	record, err := s.credentialStore.GetBindings(ctx, sandboxTeamID(pod), sandboxID)
 	if err != nil {
 		return nil, err
 	}
@@ -442,8 +454,12 @@ func (s *SandboxService) applyNetworkProvider(
 		return nil
 	}
 
+	sandboxID := sandboxIDFromPod(pod)
+	if sandboxID == "" {
+		sandboxID = pod.Name
+	}
 	input := network.SandboxPolicyInput{
-		SandboxID:     pod.Name,
+		SandboxID:     sandboxID,
 		Namespace:     pod.Namespace,
 		PodName:       pod.Name,
 		TeamID:        teamID,
@@ -532,8 +548,12 @@ func (s *SandboxService) UpdateNetworkPolicy(
 			}
 		}
 
+		currentSandboxID := sandboxIDFromPod(current)
+		if currentSandboxID == "" {
+			currentSandboxID = current.Name
+		}
 		networkState = s.NetworkPolicyService.BuildNetworkPolicyState(&BuildNetworkPolicyRequest{
-			SandboxID:        current.Name,
+			SandboxID:        currentSandboxID,
 			TeamID:           teamID,
 			TemplateSpec:     templateSpec,
 			RequestSpec:      policy,

--- a/manager/pkg/service/sandbox_service_pause.go
+++ b/manager/pkg/service/sandbox_service_pause.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
@@ -533,6 +534,19 @@ func (s *SandboxService) RequestResumeSandbox(ctx context.Context, sandboxID str
 func (s *SandboxService) ResumeSandboxAndWait(ctx context.Context, sandboxID string) (*ResumeSandboxResponse, error) {
 	resp, err := s.RequestResumeSandbox(ctx, sandboxID)
 	if err != nil {
+		if k8serrors.IsNotFound(err) && s.sandboxStore != nil {
+			waitCtx, cancel := sandboxRestoreContext(ctx)
+			defer cancel()
+			sandbox, restoreErr := s.RestoreCleanedSandboxRuntime(waitCtx, sandboxID)
+			if restoreErr != nil {
+				return nil, restoreErr
+			}
+			generation := int64(0)
+			if sandbox != nil {
+				generation = sandbox.PowerState.DesiredGeneration
+			}
+			return cleanedSandboxResumeResponse(sandboxID, generation), nil
+		}
 		return nil, err
 	}
 	if resp.PowerState.Desired == SandboxPowerStateActive && resp.PowerState.Observed == SandboxPowerStateActive && resp.PowerState.Phase == SandboxPowerPhaseStable {

--- a/manager/pkg/service/sandbox_service_power.go
+++ b/manager/pkg/service/sandbox_service_power.go
@@ -14,7 +14,6 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 )
@@ -448,8 +447,23 @@ func (s *SandboxService) getSandboxPodForPowerState(ctx context.Context, sandbox
 		return s.getSandboxPod(ctx, sandboxID)
 	}
 	if s.sandboxIndex != nil {
-		if namespace, ok := s.sandboxIndex.GetNamespace(sandboxID); ok {
-			return s.k8sClient.CoreV1().Pods(namespace).Get(ctx, sandboxID, metav1.GetOptions{})
+		refs := s.sandboxIndex.GetPodRefs(sandboxID)
+		if len(refs) > 0 {
+			pods := make([]*corev1.Pod, 0, len(refs))
+			for _, ref := range refs {
+				pod, err := s.k8sClient.CoreV1().Pods(ref.Namespace).Get(ctx, ref.Name, metav1.GetOptions{})
+				if err != nil {
+					if k8serrors.IsNotFound(err) {
+						continue
+					}
+					return nil, err
+				}
+				pods = append(pods, pod)
+			}
+			pod, err := selectSandboxRuntimePod(sandboxID, pods)
+			if err == nil || !k8serrors.IsNotFound(err) {
+				return pod, err
+			}
 		}
 	}
 	selector := labels.SelectorFromSet(map[string]string{controller.LabelSandboxID: sandboxID}).String()
@@ -457,8 +471,9 @@ func (s *SandboxService) getSandboxPodForPowerState(ctx context.Context, sandbox
 	if err != nil {
 		return nil, err
 	}
-	if len(pods.Items) == 0 {
-		return nil, k8serrors.NewNotFound(schema.GroupResource{Resource: "pod"}, sandboxID)
+	podPtrs := make([]*corev1.Pod, 0, len(pods.Items))
+	for i := range pods.Items {
+		podPtrs = append(podPtrs, pods.Items[i].DeepCopy())
 	}
-	return pods.Items[0].DeepCopy(), nil
+	return selectSandboxRuntimePod(sandboxID, podPtrs)
 }

--- a/manager/pkg/service/sandbox_service_restore.go
+++ b/manager/pkg/service/sandbox_service_restore.go
@@ -1,0 +1,194 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
+	"github.com/sandbox0-ai/sandbox0/pkg/naming"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// RestoreCleanedSandboxRuntime recreates the runtime pod for a durable cleaned sandbox.
+func (s *SandboxService) RestoreCleanedSandboxRuntime(ctx context.Context, sandboxID string) (*Sandbox, error) {
+	if s == nil || s.sandboxStore == nil {
+		return nil, k8serrors.NewNotFound(corev1.Resource("pod"), sandboxID)
+	}
+
+	var pod *corev1.Pod
+	var record *SandboxRecord
+	claimType := "hot"
+	err := s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, locked *SandboxRecord) error {
+		if locked.Status == SandboxStatusDeleted || !locked.DeletedAt.IsZero() {
+			return k8serrors.NewNotFound(corev1.Resource("sandbox"), sandboxID)
+		}
+		record = locked
+
+		existing, getErr := s.getSandboxPod(lockCtx, sandboxID)
+		if getErr == nil {
+			if existing.DeletionTimestamp != nil {
+				return k8serrors.NewConflict(corev1.Resource("pod"), existing.Name, fmt.Errorf("sandbox runtime deletion is still in progress"))
+			}
+			pod = existing
+			return tx.SaveRuntime(lockCtx, sandboxID, existing.Namespace, existing.Name, s.podToSandboxStatus(existing), runtimeGenerationFromPod(existing), parseRFC3339AnnotationTime(existing.Annotations, controller.AnnotationExpiresAt), parseRFC3339AnnotationTime(existing.Annotations, controller.AnnotationHardExpiresAt))
+		}
+		if getErr != nil && !k8serrors.IsNotFound(getErr) {
+			return fmt.Errorf("get current runtime pod: %w", getErr)
+		}
+
+		template, err := s.templateForSandboxRecord(locked)
+		if err != nil {
+			return err
+		}
+		generation := locked.RuntimeGeneration + 1
+		req := &ClaimRequest{
+			TeamID:            locked.TeamID,
+			UserID:            locked.UserID,
+			Template:          locked.TemplateID,
+			Config:            &locked.Config,
+			Mounts:            locked.Mounts,
+			SandboxID:         locked.ID,
+			RuntimeGeneration: generation,
+		}
+		pod, err = s.claimIdlePod(lockCtx, template, req)
+		if err != nil {
+			return fmt.Errorf("claim idle pod: %w", err)
+		}
+		if pod == nil {
+			claimType = "cold"
+			pod, err = s.createNewPod(lockCtx, template, req)
+			if err != nil {
+				return fmt.Errorf("create runtime pod: %w", err)
+			}
+		}
+		return tx.SaveRuntime(lockCtx, sandboxID, pod.Namespace, pod.Name, SandboxStatusStarting, generation, parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationExpiresAt), parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationHardExpiresAt))
+	})
+	if err != nil {
+		if errors.Is(err, ErrSandboxRecordNotFound) {
+			return nil, k8serrors.NewNotFound(corev1.Resource("sandbox"), sandboxID)
+		}
+		return nil, err
+	}
+	if pod == nil {
+		return nil, fmt.Errorf("restore sandbox runtime did not create or find a pod")
+	}
+	if record == nil {
+		return s.GetSandbox(ctx, sandboxID)
+	}
+
+	if err := s.finishRestoredSandboxRuntime(ctx, pod, record, claimType); err != nil {
+		s.requestSandboxDeletionAfterClaimFailure(pod, "restored runtime initialization failed")
+		_ = s.CleanSandboxRuntime(context.Background(), sandboxID)
+		return nil, err
+	}
+	return s.GetSandbox(ctx, sandboxID)
+}
+
+func (s *SandboxService) finishRestoredSandboxRuntime(ctx context.Context, pod *corev1.Pod, record *SandboxRecord, claimType string) error {
+	template, err := s.templateForSandboxRecord(record)
+	if err != nil {
+		return err
+	}
+	if claimType == "cold" {
+		readyPod, err := s.waitForPodClaimReady(ctx, pod.Namespace, pod.Name)
+		if err != nil {
+			return fmt.Errorf("wait for pod claim readiness: %w", err)
+		}
+		pod = readyPod
+		s.refreshSandboxProbeConditionsAsync(pod)
+	}
+	req := &ClaimRequest{
+		TeamID:            record.TeamID,
+		UserID:            record.UserID,
+		Template:          record.TemplateID,
+		Config:            &record.Config,
+		Mounts:            record.Mounts,
+		SandboxID:         record.ID,
+		RuntimeGeneration: record.RuntimeGeneration + 1,
+	}
+	if _, err := s.bindVolumePortals(ctx, pod, req, template); err != nil {
+		return fmt.Errorf("bind volume portals: %w", err)
+	}
+	if err := s.bindWebhookStatePortal(ctx, pod, req); err != nil {
+		return fmt.Errorf("bind webhook state portal: %w", err)
+	}
+	procdAddress, err := s.prodAddress(ctx, pod)
+	if err != nil {
+		return fmt.Errorf("get procd address: %w", err)
+	}
+	if _, err := s.initializeProcd(ctx, pod, req, procdAddress); err != nil {
+		return fmt.Errorf("initialize procd: %w", err)
+	}
+	if err := s.persistUpdatedSandboxPod(ctx, pod); err != nil {
+		return fmt.Errorf("persist restored sandbox: %w", err)
+	}
+	if s.logger != nil {
+		s.logger.Info("Restored cleaned sandbox runtime",
+			zap.String("sandboxID", record.ID),
+			zap.String("pod", pod.Name),
+			zap.String("claimType", claimType),
+		)
+	}
+	return nil
+}
+
+func (s *SandboxService) templateForSandboxRecord(record *SandboxRecord) (*v1alpha1.SandboxTemplate, error) {
+	if record == nil {
+		return nil, fmt.Errorf("sandbox record is required")
+	}
+	if s.templateLister != nil && record.TemplateNamespace != "" && record.TemplateName != "" {
+		if template, err := s.templateLister.Get(record.TemplateNamespace, record.TemplateName); err == nil {
+			return template, nil
+		}
+	}
+	templateName := strings.TrimSpace(record.TemplateName)
+	if templateName == "" {
+		templateName = record.TemplateID
+	}
+	namespace := strings.TrimSpace(record.TemplateNamespace)
+	if namespace == "" {
+		var err error
+		namespace, err = naming.TemplateNamespaceForBuiltin(record.TemplateID)
+		if err != nil {
+			return nil, err
+		}
+	}
+	spec := record.TemplateSpec
+	return &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      templateName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				controller.LabelTemplateLogicalID: record.TemplateID,
+			},
+		},
+		Spec: spec,
+	}, nil
+}
+
+func cleanedSandboxResumeResponse(sandboxID string, generation int64) *ResumeSandboxResponse {
+	return &ResumeSandboxResponse{
+		SandboxID: sandboxID,
+		Resumed:   true,
+		PowerState: SandboxPowerState{
+			Desired:            SandboxPowerStateActive,
+			DesiredGeneration:  generation,
+			Observed:           SandboxPowerStateActive,
+			ObservedGeneration: generation,
+			Phase:              SandboxPowerPhaseStable,
+		},
+	}
+}
+
+func sandboxRestoreContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if _, ok := ctx.Deadline(); ok {
+		return context.WithCancel(ctx)
+	}
+	return context.WithTimeout(ctx, defaultSandboxPowerTransitionTimeout)
+}

--- a/manager/pkg/service/sandbox_store.go
+++ b/manager/pkg/service/sandbox_store.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 	servicemigrations "github.com/sandbox0-ai/sandbox0/manager/pkg/service/migrations"
@@ -63,12 +62,6 @@ type SandboxStore interface {
 type SandboxStoreTx interface {
 	SaveRuntime(ctx context.Context, sandboxID, namespace, podName, status string, generation int64, expiresAt, hardExpiresAt time.Time) error
 	MarkRuntimeCleaned(ctx context.Context, sandboxID string, generation int64, cleanedAt time.Time) error
-}
-
-type sandboxStoreDB interface {
-	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
-	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
-	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
 }
 
 type PGSandboxStore struct {

--- a/manager/pkg/service/sandbox_store.go
+++ b/manager/pkg/service/sandbox_store.go
@@ -1,0 +1,360 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
+	servicemigrations "github.com/sandbox0-ai/sandbox0/manager/pkg/service/migrations"
+	"github.com/sandbox0-ai/sandbox0/pkg/migrate"
+)
+
+const sandboxStoreSchemaName = "manager"
+
+var ErrSandboxRecordNotFound = errors.New("sandbox record not found")
+
+// SandboxRuntimeStateCleaned means the durable sandbox exists but has no runtime pod.
+const (
+	SandboxStatusCleaned = "cleaned"
+	SandboxStatusDeleted = "deleted"
+)
+
+// SandboxRecord is the durable sandbox identity and configuration.
+type SandboxRecord struct {
+	ID                  string
+	TeamID              string
+	UserID              string
+	TemplateID          string
+	TemplateName        string
+	TemplateNamespace   string
+	ClusterID           string
+	Status              string
+	Config              SandboxConfig
+	Mounts              []ClaimMount
+	TemplateSpec        v1alpha1.SandboxTemplateSpec
+	CurrentPodName      string
+	CurrentPodNamespace string
+	RuntimeGeneration   int64
+	ClaimedAt           time.Time
+	ExpiresAt           time.Time
+	HardExpiresAt       time.Time
+	DeletedAt           time.Time
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
+}
+
+// SandboxStore persists sandbox identities independently of runtime pods.
+type SandboxStore interface {
+	UpsertSandbox(ctx context.Context, record *SandboxRecord) error
+	GetSandbox(ctx context.Context, sandboxID string) (*SandboxRecord, error)
+	ListSandboxes(ctx context.Context, req *ListSandboxesRequest) ([]*SandboxRecord, error)
+	MarkSandboxDeleted(ctx context.Context, sandboxID string, deletedAt time.Time) error
+	WithSandboxLock(ctx context.Context, sandboxID string, fn func(context.Context, SandboxStoreTx, *SandboxRecord) error) error
+}
+
+// SandboxStoreTx is a locked sandbox store transaction.
+type SandboxStoreTx interface {
+	SaveRuntime(ctx context.Context, sandboxID, namespace, podName, status string, generation int64, expiresAt, hardExpiresAt time.Time) error
+	MarkRuntimeCleaned(ctx context.Context, sandboxID string, generation int64, cleanedAt time.Time) error
+}
+
+type sandboxStoreDB interface {
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+}
+
+type PGSandboxStore struct {
+	pool *pgxpool.Pool
+}
+
+func NewPGSandboxStore(pool *pgxpool.Pool) *PGSandboxStore {
+	if pool == nil {
+		return nil
+	}
+	return &PGSandboxStore{pool: pool}
+}
+
+type sandboxStoreLogger interface {
+	Printf(format string, args ...any)
+	Fatalf(format string, args ...any)
+}
+
+func RunSandboxStoreMigrations(ctx context.Context, pool *pgxpool.Pool, logger sandboxStoreLogger) error {
+	if err := migrate.Up(ctx, pool, ".",
+		migrate.WithBaseFS(servicemigrations.FS),
+		migrate.WithLogger(logger),
+		migrate.WithSchema(sandboxStoreSchemaName),
+	); err != nil {
+		return fmt.Errorf("run sandbox store migrations: %w", err)
+	}
+	return nil
+}
+
+func (s *PGSandboxStore) UpsertSandbox(ctx context.Context, record *SandboxRecord) error {
+	if s == nil || s.pool == nil || record == nil {
+		return nil
+	}
+	if strings.TrimSpace(record.ID) == "" {
+		return fmt.Errorf("sandbox_id is required")
+	}
+	configJSON, mountsJSON, specJSON, err := marshalSandboxRecordJSON(record)
+	if err != nil {
+		return err
+	}
+	_, err = s.pool.Exec(ctx, `
+		INSERT INTO manager.sandboxes (
+			sandbox_id, team_id, user_id, template_id, template_name, template_namespace,
+			cluster_id, status, config, mounts, template_spec,
+			current_pod_name, current_pod_namespace, runtime_generation,
+			claimed_at, expires_at, hard_expires_at, deleted_at, created_at, updated_at
+		)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, COALESCE($19, NOW()), NOW())
+		ON CONFLICT (sandbox_id) DO UPDATE SET
+			team_id = EXCLUDED.team_id,
+			user_id = EXCLUDED.user_id,
+			template_id = EXCLUDED.template_id,
+			template_name = EXCLUDED.template_name,
+			template_namespace = EXCLUDED.template_namespace,
+			cluster_id = EXCLUDED.cluster_id,
+			status = EXCLUDED.status,
+			config = EXCLUDED.config,
+			mounts = EXCLUDED.mounts,
+			template_spec = EXCLUDED.template_spec,
+			current_pod_name = EXCLUDED.current_pod_name,
+			current_pod_namespace = EXCLUDED.current_pod_namespace,
+			runtime_generation = EXCLUDED.runtime_generation,
+			claimed_at = EXCLUDED.claimed_at,
+			expires_at = EXCLUDED.expires_at,
+			hard_expires_at = EXCLUDED.hard_expires_at,
+			deleted_at = EXCLUDED.deleted_at,
+			updated_at = NOW()
+	`, record.ID, record.TeamID, record.UserID, record.TemplateID, record.TemplateName, record.TemplateNamespace,
+		record.ClusterID, record.Status, configJSON, mountsJSON, specJSON,
+		record.CurrentPodName, record.CurrentPodNamespace, record.RuntimeGeneration,
+		nullableTime(record.ClaimedAt), nullableTime(record.ExpiresAt), nullableTime(record.HardExpiresAt), nullableTime(record.DeletedAt), nullableTime(record.CreatedAt))
+	if err != nil {
+		return fmt.Errorf("upsert sandbox: %w", err)
+	}
+	return nil
+}
+
+func (s *PGSandboxStore) GetSandbox(ctx context.Context, sandboxID string) (*SandboxRecord, error) {
+	if s == nil || s.pool == nil {
+		return nil, nil
+	}
+	return scanSandboxRecord(s.pool.QueryRow(ctx, sandboxRecordSelectSQL()+` WHERE sandbox_id = $1`, sandboxID))
+}
+
+func (s *PGSandboxStore) ListSandboxes(ctx context.Context, req *ListSandboxesRequest) ([]*SandboxRecord, error) {
+	if s == nil || s.pool == nil || req == nil {
+		return nil, nil
+	}
+	rows, err := s.pool.Query(ctx, sandboxRecordSelectSQL()+`
+		WHERE team_id = $1
+			AND deleted_at IS NULL
+			AND ($2 = '' OR status = $2)
+			AND ($3 = '' OR template_id = $3)
+		ORDER BY created_at DESC
+	`, req.TeamID, req.Status, req.TemplateID)
+	if err != nil {
+		return nil, fmt.Errorf("list sandboxes: %w", err)
+	}
+	defer rows.Close()
+	var records []*SandboxRecord
+	for rows.Next() {
+		record, err := scanSandboxRecordRows(rows)
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, record)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate sandboxes: %w", err)
+	}
+	return records, nil
+}
+
+func (s *PGSandboxStore) MarkSandboxDeleted(ctx context.Context, sandboxID string, deletedAt time.Time) error {
+	if s == nil || s.pool == nil {
+		return nil
+	}
+	if deletedAt.IsZero() {
+		deletedAt = time.Now().UTC()
+	}
+	_, err := s.pool.Exec(ctx, `
+		UPDATE manager.sandboxes
+		SET status = $2,
+			current_pod_name = '',
+			current_pod_namespace = '',
+			deleted_at = $3,
+			updated_at = NOW()
+		WHERE sandbox_id = $1
+	`, sandboxID, SandboxStatusDeleted, deletedAt)
+	if err != nil {
+		return fmt.Errorf("mark sandbox deleted: %w", err)
+	}
+	return nil
+}
+
+func (s *PGSandboxStore) WithSandboxLock(ctx context.Context, sandboxID string, fn func(context.Context, SandboxStoreTx, *SandboxRecord) error) error {
+	if s == nil || s.pool == nil || fn == nil {
+		return nil
+	}
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("begin sandbox lock tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	record, err := scanSandboxRecord(tx.QueryRow(ctx, sandboxRecordSelectSQL()+` WHERE sandbox_id = $1 FOR UPDATE`, sandboxID))
+	if err != nil {
+		return err
+	}
+	if record == nil {
+		return fmt.Errorf("%w: %s", ErrSandboxRecordNotFound, sandboxID)
+	}
+	if err := fn(ctx, sandboxStoreTx{tx: tx}, record); err != nil {
+		return err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit sandbox lock tx: %w", err)
+	}
+	return nil
+}
+
+type sandboxStoreTx struct {
+	tx pgx.Tx
+}
+
+func (t sandboxStoreTx) SaveRuntime(ctx context.Context, sandboxID, namespace, podName, status string, generation int64, expiresAt, hardExpiresAt time.Time) error {
+	_, err := t.tx.Exec(ctx, `
+		UPDATE manager.sandboxes
+		SET status = $2,
+			current_pod_namespace = $3,
+			current_pod_name = $4,
+			runtime_generation = $5,
+			expires_at = $6,
+			hard_expires_at = $7,
+			deleted_at = NULL,
+			updated_at = NOW()
+		WHERE sandbox_id = $1
+	`, sandboxID, status, namespace, podName, generation, nullableTime(expiresAt), nullableTime(hardExpiresAt))
+	if err != nil {
+		return fmt.Errorf("save sandbox runtime: %w", err)
+	}
+	return nil
+}
+
+func (t sandboxStoreTx) MarkRuntimeCleaned(ctx context.Context, sandboxID string, generation int64, cleanedAt time.Time) error {
+	_, err := t.tx.Exec(ctx, `
+		UPDATE manager.sandboxes
+		SET status = $2,
+			current_pod_namespace = '',
+			current_pod_name = '',
+			runtime_generation = GREATEST(runtime_generation, $3),
+			expires_at = NULL,
+			updated_at = NOW()
+		WHERE sandbox_id = $1
+	`, sandboxID, SandboxStatusCleaned, generation)
+	if err != nil {
+		return fmt.Errorf("mark sandbox runtime cleaned: %w", err)
+	}
+	return nil
+}
+
+func sandboxRecordSelectSQL() string {
+	return `
+		SELECT sandbox_id, team_id, user_id, template_id, template_name, template_namespace,
+			cluster_id, status, config, mounts, template_spec,
+			current_pod_name, current_pod_namespace, runtime_generation,
+			claimed_at, expires_at, hard_expires_at, deleted_at, created_at, updated_at
+		FROM manager.sandboxes`
+}
+
+type sandboxRecordScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanSandboxRecord(row sandboxRecordScanner) (*SandboxRecord, error) {
+	record, err := scanSandboxRecordInto(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return record, nil
+}
+
+func scanSandboxRecordRows(rows pgx.Rows) (*SandboxRecord, error) {
+	record, err := scanSandboxRecordInto(rows)
+	if err != nil {
+		return nil, err
+	}
+	return record, nil
+}
+
+func scanSandboxRecordInto(scanner sandboxRecordScanner) (*SandboxRecord, error) {
+	var record SandboxRecord
+	var configJSON, mountsJSON, specJSON []byte
+	var claimedAt, expiresAt, hardExpiresAt, deletedAt *time.Time
+	if err := scanner.Scan(
+		&record.ID, &record.TeamID, &record.UserID, &record.TemplateID, &record.TemplateName, &record.TemplateNamespace,
+		&record.ClusterID, &record.Status, &configJSON, &mountsJSON, &specJSON,
+		&record.CurrentPodName, &record.CurrentPodNamespace, &record.RuntimeGeneration,
+		&claimedAt, &expiresAt, &hardExpiresAt, &deletedAt, &record.CreatedAt, &record.UpdatedAt,
+	); err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(configJSON, &record.Config); err != nil {
+		return nil, fmt.Errorf("unmarshal sandbox config: %w", err)
+	}
+	if err := json.Unmarshal(mountsJSON, &record.Mounts); err != nil {
+		return nil, fmt.Errorf("unmarshal sandbox mounts: %w", err)
+	}
+	if err := json.Unmarshal(specJSON, &record.TemplateSpec); err != nil {
+		return nil, fmt.Errorf("unmarshal sandbox template spec: %w", err)
+	}
+	record.ClaimedAt = derefTime(claimedAt)
+	record.ExpiresAt = derefTime(expiresAt)
+	record.HardExpiresAt = derefTime(hardExpiresAt)
+	record.DeletedAt = derefTime(deletedAt)
+	return &record, nil
+}
+
+func marshalSandboxRecordJSON(record *SandboxRecord) ([]byte, []byte, []byte, error) {
+	configJSON, err := json.Marshal(record.Config)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("marshal sandbox config: %w", err)
+	}
+	mountsJSON, err := json.Marshal(record.Mounts)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("marshal sandbox mounts: %w", err)
+	}
+	specJSON, err := json.Marshal(record.TemplateSpec)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("marshal sandbox template spec: %w", err)
+	}
+	return configJSON, mountsJSON, specJSON, nil
+}
+
+func nullableTime(t time.Time) any {
+	if t.IsZero() {
+		return nil
+	}
+	return t
+}
+
+func derefTime(t *time.Time) time.Time {
+	if t == nil {
+		return time.Time{}
+	}
+	return *t
+}

--- a/pkg/apispec/compat.go
+++ b/pkg/apispec/compat.go
@@ -1,9 +1,10 @@
 package apispec
 
 const (
-	Completed   = GetApiV1SandboxesParamsStatusCompleted
-	Failed      = GetApiV1SandboxesParamsStatusFailed
-	Running     = GetApiV1SandboxesParamsStatusRunning
-	Starting    = GetApiV1SandboxesParamsStatusStarting
-	Terminating = GetApiV1SandboxesParamsStatusTerminating
+	Cleaned     = SandboxLifecycleStatusCleaned
+	Completed   = SandboxLifecycleStatusCompleted
+	Failed      = SandboxLifecycleStatusFailed
+	Running     = SandboxLifecycleStatusRunning
+	Starting    = SandboxLifecycleStatusStarting
+	Terminating = SandboxLifecycleStatusTerminating
 )

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -1160,8 +1160,7 @@ paths:
           in: query
           description: Filter by sandbox status
           schema:
-            type: string
-            enum: [starting, running, failed, completed, terminating]
+            $ref: "#/components/schemas/SandboxLifecycleStatus"
         - name: template_id
           in: query
           description: Filter by template ID
@@ -3739,6 +3738,7 @@ components:
         hard_ttl:
           type: integer
           format: int32
+          description: Hard time-to-live in seconds. When it expires, Sandbox0 cleans the runtime pod and preserves the sandbox identity, services, and public URLs until the sandbox is explicitly deleted.
         network:
           $ref: "#/components/schemas/SandboxNetworkPolicy"
         webhook:
@@ -3943,7 +3943,7 @@ components:
         sandbox_id:
           type: string
         status:
-          type: string
+          $ref: "#/components/schemas/SandboxLifecycleStatus"
         pod_name:
           type: string
         template:
@@ -3990,6 +3990,16 @@ components:
         - observed
         - observed_generation
         - phase
+    SandboxLifecycleStatus:
+      type: string
+      enum: [starting, running, failed, completed, terminating, cleaned]
+      x-enum-varnames:
+        - SandboxLifecycleStatusStarting
+        - SandboxLifecycleStatusRunning
+        - SandboxLifecycleStatusFailed
+        - SandboxLifecycleStatusCompleted
+        - SandboxLifecycleStatusTerminating
+        - SandboxLifecycleStatusCleaned
     Sandbox:
       type: object
       properties:
@@ -4002,7 +4012,7 @@ components:
         user_id:
           type: string
         status:
-          type: string
+          $ref: "#/components/schemas/SandboxLifecycleStatus"
         paused:
           type: boolean
         power_state:
@@ -4073,6 +4083,7 @@ components:
         hard_ttl:
           type: integer
           format: int32
+          description: Hard time-to-live in seconds. When it expires, Sandbox0 cleans the runtime pod and preserves the sandbox identity, services, and public URLs until the sandbox is explicitly deleted.
         network:
           $ref: "#/components/schemas/SandboxNetworkPolicy"
         auto_resume:
@@ -4104,7 +4115,7 @@ components:
         pod_name:
           type: string
         status:
-          type: string
+          $ref: "#/components/schemas/SandboxLifecycleStatus"
         claimed_at:
           type: string
         expires_at:
@@ -4135,8 +4146,7 @@ components:
         template_id:
           type: string
         status:
-          type: string
-          enum: [starting, running, failed, completed, terminating]
+          $ref: "#/components/schemas/SandboxLifecycleStatus"
         paused:
           type: boolean
         power_state:

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -152,6 +152,16 @@ const (
 	SandboxAppServiceRuntimeTypeWarmProcess SandboxAppServiceRuntimeType = "warm_process"
 )
 
+// Defines values for SandboxLifecycleStatus.
+const (
+	SandboxLifecycleStatusCleaned     SandboxLifecycleStatus = "cleaned"
+	SandboxLifecycleStatusCompleted   SandboxLifecycleStatus = "completed"
+	SandboxLifecycleStatusFailed      SandboxLifecycleStatus = "failed"
+	SandboxLifecycleStatusRunning     SandboxLifecycleStatus = "running"
+	SandboxLifecycleStatusStarting    SandboxLifecycleStatus = "starting"
+	SandboxLifecycleStatusTerminating SandboxLifecycleStatus = "terminating"
+)
+
 // Defines values for SandboxNetworkPolicyMode.
 const (
 	AllowAll SandboxNetworkPolicyMode = "allow-all"
@@ -175,15 +185,6 @@ const (
 	Pausing  SandboxPowerStatePhase = "pausing"
 	Resuming SandboxPowerStatePhase = "resuming"
 	Stable   SandboxPowerStatePhase = "stable"
-)
-
-// Defines values for SandboxSummaryStatus.
-const (
-	SandboxSummaryStatusCompleted   SandboxSummaryStatus = "completed"
-	SandboxSummaryStatusFailed      SandboxSummaryStatus = "failed"
-	SandboxSummaryStatusRunning     SandboxSummaryStatus = "running"
-	SandboxSummaryStatusStarting    SandboxSummaryStatus = "starting"
-	SandboxSummaryStatusTerminating SandboxSummaryStatus = "terminating"
 )
 
 // Defines values for SuccessAPIKeyListResponseSuccess.
@@ -497,15 +498,6 @@ const (
 	WarmProcessSpecTypeRepl WarmProcessSpecType = "repl"
 )
 
-// Defines values for GetApiV1SandboxesParamsStatus.
-const (
-	GetApiV1SandboxesParamsStatusCompleted   GetApiV1SandboxesParamsStatus = "completed"
-	GetApiV1SandboxesParamsStatusFailed      GetApiV1SandboxesParamsStatus = "failed"
-	GetApiV1SandboxesParamsStatusRunning     GetApiV1SandboxesParamsStatus = "running"
-	GetApiV1SandboxesParamsStatusStarting    GetApiV1SandboxesParamsStatus = "starting"
-	GetApiV1SandboxesParamsStatusTerminating GetApiV1SandboxesParamsStatus = "terminating"
-)
-
 // APIKey defines model for APIKey.
 type APIKey struct {
 	CreatedAt  time.Time  `json:"created_at"`
@@ -585,12 +577,12 @@ type ClaimRequest struct {
 
 // ClaimResponse defines model for ClaimResponse.
 type ClaimResponse struct {
-	BootstrapMounts *[]MountStatus `json:"bootstrap_mounts,omitempty"`
-	ClusterId       *string        `json:"cluster_id"`
-	PodName         string         `json:"pod_name"`
-	SandboxId       string         `json:"sandbox_id"`
-	Status          string         `json:"status"`
-	Template        string         `json:"template"`
+	BootstrapMounts *[]MountStatus         `json:"bootstrap_mounts,omitempty"`
+	ClusterId       *string                `json:"cluster_id"`
+	PodName         string                 `json:"pod_name"`
+	SandboxId       string                 `json:"sandbox_id"`
+	Status          SandboxLifecycleStatus `json:"status"`
+	Template        string                 `json:"template"`
 }
 
 // ContainerSpec defines model for ContainerSpec.
@@ -1430,18 +1422,18 @@ type Sandbox struct {
 	ExpiresAt time.Time `json:"expires_at"`
 
 	// HardExpiresAt Hard expiration timestamp. Zero value means not set.
-	HardExpiresAt time.Time             `json:"hard_expires_at"`
-	Id            string                `json:"id"`
-	Mounts        *[]ClaimMountRequest  `json:"mounts,omitempty"`
-	Paused        bool                  `json:"paused"`
-	PodName       string                `json:"pod_name"`
-	PowerState    SandboxPowerState     `json:"power_state"`
-	Services      *[]SandboxAppService  `json:"services,omitempty"`
-	Ssh           *SandboxSSHConnection `json:"ssh,omitempty"`
-	Status        string                `json:"status"`
-	TeamId        string                `json:"team_id"`
-	TemplateId    string                `json:"template_id"`
-	UserId        *string               `json:"user_id,omitempty"`
+	HardExpiresAt time.Time              `json:"hard_expires_at"`
+	Id            string                 `json:"id"`
+	Mounts        *[]ClaimMountRequest   `json:"mounts,omitempty"`
+	Paused        bool                   `json:"paused"`
+	PodName       string                 `json:"pod_name"`
+	PowerState    SandboxPowerState      `json:"power_state"`
+	Services      *[]SandboxAppService   `json:"services,omitempty"`
+	Ssh           *SandboxSSHConnection  `json:"ssh,omitempty"`
+	Status        SandboxLifecycleStatus `json:"status"`
+	TeamId        string                 `json:"team_id"`
+	TemplateId    string                 `json:"template_id"`
+	UserId        *string                `json:"user_id,omitempty"`
 }
 
 // SandboxAppService Canonical service model for sandbox exposure.
@@ -1547,16 +1539,21 @@ type SandboxAppServiceView struct {
 type SandboxConfig struct {
 	// AutoResume Sandbox-level resume gate for paused sandboxes. When false, any inbound request
 	// (API or public exposure) must not auto resume the sandbox.
-	AutoResume *bool                 `json:"auto_resume,omitempty"`
-	EnvVars    *map[string]string    `json:"env_vars,omitempty"`
-	HardTtl    *int32                `json:"hard_ttl,omitempty"`
-	Network    *SandboxNetworkPolicy `json:"network,omitempty"`
-	Services   *[]SandboxAppService  `json:"services,omitempty"`
-	Ttl        *int32                `json:"ttl,omitempty"`
+	AutoResume *bool              `json:"auto_resume,omitempty"`
+	EnvVars    *map[string]string `json:"env_vars,omitempty"`
+
+	// HardTtl Hard time-to-live in seconds. When it expires, Sandbox0 cleans the runtime pod and preserves the sandbox identity, services, and public URLs until the sandbox is explicitly deleted.
+	HardTtl  *int32                `json:"hard_ttl,omitempty"`
+	Network  *SandboxNetworkPolicy `json:"network,omitempty"`
+	Services *[]SandboxAppService  `json:"services,omitempty"`
+	Ttl      *int32                `json:"ttl,omitempty"`
 
 	// Webhook Per-sandbox webhook configuration. Sandbox0 delivers webhook events at least once and consumers should deduplicate by event_id. For sandbox lifecycle events, procd persists signed delivery records to a manager-owned SandboxVolume outside the workspace before dispatch; manager also emits sandbox.deleted during pod deletion cleanup.
 	Webhook *WebhookConfig `json:"webhook,omitempty"`
 }
+
+// SandboxLifecycleStatus defines model for SandboxLifecycleStatus.
+type SandboxLifecycleStatus string
 
 // SandboxNetworkPolicy defines model for SandboxNetworkPolicy.
 type SandboxNetworkPolicy struct {
@@ -1646,16 +1643,16 @@ type SandboxServicesUpdateRequest struct {
 
 // SandboxStatus defines model for SandboxStatus.
 type SandboxStatus struct {
-	ClaimedAt     *string `json:"claimed_at,omitempty"`
-	CreatedAt     *string `json:"created_at,omitempty"`
-	ExpiresAt     *string `json:"expires_at,omitempty"`
-	HardExpiresAt *string `json:"hard_expires_at,omitempty"`
-	PodName       *string `json:"pod_name,omitempty"`
-	SandboxId     *string `json:"sandbox_id,omitempty"`
-	Status        *string `json:"status,omitempty"`
-	TeamId        *string `json:"team_id,omitempty"`
-	TemplateId    *string `json:"template_id,omitempty"`
-	UserId        *string `json:"user_id,omitempty"`
+	ClaimedAt     *string                 `json:"claimed_at,omitempty"`
+	CreatedAt     *string                 `json:"created_at,omitempty"`
+	ExpiresAt     *string                 `json:"expires_at,omitempty"`
+	HardExpiresAt *string                 `json:"hard_expires_at,omitempty"`
+	PodName       *string                 `json:"pod_name,omitempty"`
+	SandboxId     *string                 `json:"sandbox_id,omitempty"`
+	Status        *SandboxLifecycleStatus `json:"status,omitempty"`
+	TeamId        *string                 `json:"team_id,omitempty"`
+	TemplateId    *string                 `json:"template_id,omitempty"`
+	UserId        *string                 `json:"user_id,omitempty"`
 }
 
 // SandboxSummary defines model for SandboxSummary.
@@ -1666,16 +1663,13 @@ type SandboxSummary struct {
 	ExpiresAt time.Time `json:"expires_at"`
 
 	// HardExpiresAt Hard expiration timestamp. Zero value means not set.
-	HardExpiresAt time.Time            `json:"hard_expires_at"`
-	Id            string               `json:"id"`
-	Paused        bool                 `json:"paused"`
-	PowerState    SandboxPowerState    `json:"power_state"`
-	Status        SandboxSummaryStatus `json:"status"`
-	TemplateId    string               `json:"template_id"`
+	HardExpiresAt time.Time              `json:"hard_expires_at"`
+	Id            string                 `json:"id"`
+	Paused        bool                   `json:"paused"`
+	PowerState    SandboxPowerState      `json:"power_state"`
+	Status        SandboxLifecycleStatus `json:"status"`
+	TemplateId    string                 `json:"template_id"`
 }
-
-// SandboxSummaryStatus defines model for SandboxSummary.Status.
-type SandboxSummaryStatus string
 
 // SandboxTemplateCondition defines model for SandboxTemplateCondition.
 type SandboxTemplateCondition struct {
@@ -1717,11 +1711,13 @@ type SandboxTemplateStatus struct {
 type SandboxUpdateConfig struct {
 	// AutoResume Sandbox-level resume gate for paused sandboxes. When false, any inbound request
 	// (API or public exposure) must not auto resume the sandbox.
-	AutoResume *bool                 `json:"auto_resume,omitempty"`
-	HardTtl    *int32                `json:"hard_ttl,omitempty"`
-	Network    *SandboxNetworkPolicy `json:"network,omitempty"`
-	Services   *[]SandboxAppService  `json:"services,omitempty"`
-	Ttl        *int32                `json:"ttl,omitempty"`
+	AutoResume *bool `json:"auto_resume,omitempty"`
+
+	// HardTtl Hard time-to-live in seconds. When it expires, Sandbox0 cleans the runtime pod and preserves the sandbox identity, services, and public URLs until the sandbox is explicitly deleted.
+	HardTtl  *int32                `json:"hard_ttl,omitempty"`
+	Network  *SandboxNetworkPolicy `json:"network,omitempty"`
+	Services *[]SandboxAppService  `json:"services,omitempty"`
+	Ttl      *int32                `json:"ttl,omitempty"`
 }
 
 // SandboxUpdateRequest defines model for SandboxUpdateRequest.
@@ -2571,7 +2567,7 @@ type UserID = string
 // GetApiV1SandboxesParams defines parameters for GetApiV1Sandboxes.
 type GetApiV1SandboxesParams struct {
 	// Status Filter by sandbox status
-	Status *GetApiV1SandboxesParamsStatus `form:"status,omitempty" json:"status,omitempty"`
+	Status *SandboxLifecycleStatus `form:"status,omitempty" json:"status,omitempty"`
 
 	// TemplateId Filter by template ID
 	TemplateId *string `form:"template_id,omitempty" json:"template_id,omitempty"`
@@ -2585,9 +2581,6 @@ type GetApiV1SandboxesParams struct {
 	// Offset Pagination offset
 	Offset *int `form:"offset,omitempty" json:"offset,omitempty"`
 }
-
-// GetApiV1SandboxesParamsStatus defines parameters for GetApiV1Sandboxes.
-type GetApiV1SandboxesParamsStatus string
 
 // DeleteApiV1SandboxesIdFilesParams defines parameters for DeleteApiV1SandboxesIdFiles.
 type DeleteApiV1SandboxesIdFilesParams struct {

--- a/pkg/sshgateway/sandbox_response.go
+++ b/pkg/sshgateway/sandbox_response.go
@@ -28,7 +28,7 @@ func SandboxToAPI(sandbox *mgr.Sandbox, sshInfo *ConnectionInfo) *apispec.Sandbo
 			ObservedGeneration: sandbox.PowerState.ObservedGeneration,
 			Phase:              apispec.SandboxPowerStatePhase(sandbox.PowerState.Phase),
 		},
-		Status:     sandbox.Status,
+		Status:     apispec.SandboxLifecycleStatus(sandbox.Status),
 		TeamId:     sandbox.TeamID,
 		TemplateId: sandbox.TemplateID,
 	}


### PR DESCRIPTION
## Summary
- persist sandbox identity/configuration independently from runtime pods
- make hard_ttl clean runtime compute into a cleaned state instead of terminal deletion
- restore cleaned sandboxes on resume-capable API/public exposure access while preserving sandbox service URLs
- add duplicate-runtime detection and restore locking to avoid multiple active pods for one sandbox
- update OpenAPI/docs and generated apispec types

## Tests
- go test ./manager/pkg/service ./manager/pkg/controller ./manager/pkg/metering ./manager/cmd/manager ./cluster-gateway/pkg/http ./pkg/sshgateway ./pkg/apispec
- make apispec

SDK sync PRs will follow for sdk-go, sdk-js, and sdk-py.