### PR TITLE
Return public URLs for sandbox services

### DIFF
--- a/docs/sandbox/pause-resume/page.mdx
+++ b/docs/sandbox/pause-resume/page.mdx
@@ -138,15 +138,17 @@ console.log("powerState=", sb.powerState);`
 | `ttl` | Soft timeout. When it expires, Sandbox0 pauses the sandbox. |
 | `hard_ttl` | Hard runtime timeout. When it expires, Sandbox0 cleans the runtime pod and keeps the sandbox identity for later resume. |
 
-`auto_resume` controls whether inbound access can wake a paused sandbox:
+`auto_resume` is the sandbox-level gate for whether inbound access can wake a paused or cleaned sandbox:
 
 - when `auto_resume` is `true`, supported access paths can resume the sandbox automatically
 - when `auto_resume` is `false`, you must call resume explicitly
 
 Common auto-resume entrypoints:
 
-- service routes configured with `resume: true`
+- service routes configured with `resume: true`; public service requests require both sandbox `auto_resume: true` and route `resume: true`
 - SSH access through Sandbox0 SSH Gateway
+
+For a cleaned sandbox, auto-resume creates a new runtime pod for the same sandbox identity. Public service URLs remain stable until the sandbox is explicitly deleted.
 
 See [Sandbox Services](/docs/sandbox/services) and [SSH](/docs/sandbox/ssh) for the user-facing flows.
 

--- a/docs/sandbox/services/page.mdx
+++ b/docs/sandbox/services/page.mdx
@@ -44,6 +44,15 @@ When `public` is true and `routes` is empty, Sandbox0 creates a default route us
 | `timeout_seconds` | integer | Optional upstream timeout in seconds |
 | `resume` | boolean | Whether this route may resume a paused sandbox when `auto_resume` is enabled |
 
+### Resume Gates
+
+Public service auto-resume uses two gates:
+
+- sandbox `auto_resume` is the sandbox-level gate. When it is `false`, inbound access must not auto-resume the sandbox.
+- route `resume` is the route-level gate. Only matching public routes with `resume: true` may wake the sandbox.
+
+Both gates must be enabled for a public URL request to resume a paused or cleaned sandbox. For a cleaned sandbox, Sandbox0 creates a new runtime pod for the same sandbox identity, so the `sandbox_id` and service `public_url` stay unchanged.
+
 <Callout>
 Route rate limits use the gateway rate limit backend. Self-hosted deployments default to process-local memory for simple onboarding. Configure `Sandbox0Infra.spec.redis` when multiple gateway replicas need shared Redis-backed limits.
 </Callout>
@@ -397,9 +406,9 @@ if err != nil {
 
 - Public HTTP traffic must match a route on a public service.
 - If `methods` is empty, every HTTP method is allowed for that route.
-- `resume` is evaluated with sandbox `auto_resume`. A route with `resume: false` will not resume a paused or cleaned sandbox.
+- Public URL auto-resume requires both sandbox `auto_resume: true` and route `resume: true`.
 - Public service responses include `public_url`, derived from the deployment exposure domain as `https://{sandbox_id}--p{port}.{exposure_domain}`.
-- Public URLs remain reserved for a `cleaned` sandbox and become unavailable only after explicit sandbox deletion.
+- Public URLs remain reserved for a `cleaned` sandbox. A later request can start a new runtime pod without changing the URL, and the URL becomes unavailable only after explicit sandbox deletion.
 
 ## Next Steps
 

--- a/docs/sandbox/services/page.mdx
+++ b/docs/sandbox/services/page.mdx
@@ -67,7 +67,7 @@ Route auth stores SHA-256 digests, not plaintext tokens. Hash secret values befo
 /api/v1/sandboxes/{'{id}'}/services
 </Endpoint>
 
-The response includes `publishable`, `publish_blockers`, and `exposure_domain`.
+The response includes `publishable`, `publish_blockers`, `public_url`, and `exposure_domain`.
 
 <Tabs
   tabs={[
@@ -80,7 +80,7 @@ if err != nil {
 }
 fmt.Printf("services: %d\\n", len(resp.Services))
 for _, service := range resp.Services {
-    fmt.Printf("%s -> port %d\\n", service.ID, service.Port)
+    fmt.Printf("%s -> port %d url=%s\\n", service.ID, service.Port, service.PublicURL.Or(""))
 }`
     },
     {
@@ -398,7 +398,7 @@ if err != nil {
 - Public HTTP traffic must match a route on a public service.
 - If `methods` is empty, every HTTP method is allowed for that route.
 - `resume` is evaluated with sandbox `auto_resume`. A route with `resume: false` will not resume a paused or cleaned sandbox.
-- Public URLs are derived from the deployment exposure domain as `{sandbox_id}--p{port}.{exposure_domain}`.
+- Public service responses include `public_url`, derived from the deployment exposure domain as `https://{sandbox_id}--p{port}.{exposure_domain}`.
 - Public URLs remain reserved for a `cleaned` sandbox and become unavailable only after explicit sandbox deletion.
 
 ## Next Steps

--- a/manager/pkg/http/handlers_services.go
+++ b/manager/pkg/http/handlers_services.go
@@ -45,10 +45,11 @@ func (s *Server) listSandboxServices(c *gin.Context) {
 		return
 	}
 
+	exposureDomain := s.getExposureDomain()
 	spec.JSONSuccess(c, http.StatusOK, gin.H{
 		"sandbox_id":      sandboxID,
-		"services":        service.SandboxAppServiceViews(sandbox.Services),
-		"exposure_domain": s.getExposureDomain(),
+		"services":        service.SandboxAppServiceViewsForExposure(sandboxID, exposureDomain, sandbox.Services),
+		"exposure_domain": exposureDomain,
 	})
 }
 
@@ -99,9 +100,10 @@ func (s *Server) updateSandboxServices(c *gin.Context) {
 		return
 	}
 
+	exposureDomain := s.getExposureDomain()
 	spec.JSONSuccess(c, http.StatusOK, gin.H{
 		"sandbox_id":      sandboxID,
-		"services":        service.SandboxAppServiceViews(updated.Services),
-		"exposure_domain": s.getExposureDomain(),
+		"services":        service.SandboxAppServiceViewsForExposure(sandboxID, exposureDomain, updated.Services),
+		"exposure_domain": exposureDomain,
 	})
 }

--- a/manager/pkg/service/sandbox_app_service.go
+++ b/manager/pkg/service/sandbox_app_service.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
+
+	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 )
 
 const (
@@ -101,6 +103,7 @@ type SandboxAppServiceView struct {
 	SandboxAppService
 	Publishable     bool     `json:"publishable"`
 	PublishBlockers []string `json:"publish_blockers,omitempty"`
+	PublicURL       string   `json:"public_url,omitempty"`
 }
 
 func SandboxAppServicesHaveResumeRoute(services []SandboxAppService) bool {
@@ -192,6 +195,12 @@ func normalizeSandboxAppService(service SandboxAppService) (SandboxAppService, e
 }
 
 func SandboxAppServiceViews(services []SandboxAppService) []SandboxAppServiceView {
+	return SandboxAppServiceViewsForExposure("", "", services)
+}
+
+// SandboxAppServiceViewsForExposure adds derived fields that depend on the
+// deployment exposure domain.
+func SandboxAppServiceViewsForExposure(sandboxID, exposureDomain string, services []SandboxAppService) []SandboxAppServiceView {
 	if len(services) == 0 {
 		return []SandboxAppServiceView{}
 	}
@@ -202,9 +211,28 @@ func SandboxAppServiceViews(services []SandboxAppService) []SandboxAppServiceVie
 			SandboxAppService: service,
 			Publishable:       len(blockers) == 0,
 			PublishBlockers:   blockers,
+			PublicURL:         SandboxAppServicePublicURL(sandboxID, exposureDomain, service),
 		})
 	}
 	return views
+}
+
+// SandboxAppServicePublicURL returns the public entrypoint for a service when
+// the service is public and the deployment has an exposure domain.
+func SandboxAppServicePublicURL(sandboxID, exposureDomain string, service SandboxAppService) string {
+	if !service.Ingress.Public {
+		return ""
+	}
+	sandboxID = strings.TrimSpace(sandboxID)
+	exposureDomain = strings.Trim(strings.TrimSpace(exposureDomain), ".")
+	if sandboxID == "" || exposureDomain == "" {
+		return ""
+	}
+	label, err := naming.BuildExposureHostLabel(sandboxID, service.Port)
+	if err != nil {
+		return ""
+	}
+	return "https://" + label + "." + exposureDomain
 }
 
 // SandboxAppServicePublishBlockers returns reasons why a service cannot be

--- a/manager/pkg/service/sandbox_app_service_test.go
+++ b/manager/pkg/service/sandbox_app_service_test.go
@@ -45,6 +45,35 @@ func TestSandboxAppServiceViewsReturnsEmptySlice(t *testing.T) {
 	}
 }
 
+func TestSandboxAppServiceViewsForExposureAddsPublicURL(t *testing.T) {
+	views := SandboxAppServiceViewsForExposure("rs-default-api-abcde", "us.sandbox0.app", []SandboxAppService{
+		{
+			ID:   "api",
+			Port: 8080,
+			Ingress: SandboxAppServiceIngress{
+				Public: true,
+				Routes: []SandboxAppServiceRoute{{ID: "api", PathPrefix: "/", Resume: true}},
+			},
+		},
+		{
+			ID:   "worker",
+			Port: 9000,
+			Ingress: SandboxAppServiceIngress{
+				Public: false,
+			},
+		},
+	})
+	if len(views) != 2 {
+		t.Fatalf("views length = %d, want 2", len(views))
+	}
+	if got, want := views[0].PublicURL, "https://rs-default-api-abcde--p8080.us.sandbox0.app"; got != want {
+		t.Fatalf("PublicURL = %q, want %q", got, want)
+	}
+	if views[1].PublicURL != "" {
+		t.Fatalf("private service PublicURL = %q, want empty", views[1].PublicURL)
+	}
+}
+
 func TestSandboxAppServicePublishBlockersRequirePublicRestartableRuntime(t *testing.T) {
 	service := SandboxAppService{
 		ID:   "api",

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -3897,6 +3897,9 @@ components:
               type: array
               items:
                 type: string
+            public_url:
+              type: string
+              description: Public HTTPS URL for this service when public exposure is enabled.
           required: [publishable]
     SandboxServicesUpdateRequest:
       type: object

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -1527,9 +1527,12 @@ type SandboxAppServiceView struct {
 	HealthCheck *SandboxAppServiceHealth `json:"health_check,omitempty"`
 
 	// Id Stable service ID. Must be a DNS label.
-	Id              string                    `json:"id"`
-	Ingress         SandboxAppServiceIngress  `json:"ingress"`
-	Port            int32                     `json:"port"`
+	Id      string                   `json:"id"`
+	Ingress SandboxAppServiceIngress `json:"ingress"`
+	Port    int32                    `json:"port"`
+
+	// PublicUrl Public HTTPS URL for this service when public exposure is enabled.
+	PublicUrl       *string                   `json:"public_url,omitempty"`
 	PublishBlockers *[]string                 `json:"publish_blockers,omitempty"`
 	Publishable     bool                      `json:"publishable"`
 	Runtime         *SandboxAppServiceRuntime `json:"runtime,omitempty"`


### PR DESCRIPTION
## Summary
- add per-service public_url to sandbox service views
- derive URLs with naming.BuildExposureHostLabel and exposure_domain
- update OpenAPI generated types and service docs

## Tests
- make apispec
- GOTOOLCHAIN=go1.25.0+auto GOWORK=off go test ./manager/pkg/service -run SandboxAppService
- GOTOOLCHAIN=go1.25.0+auto GOWORK=off go test ./pkg/naming ./pkg/apispec
- GOTOOLCHAIN=go1.25.0+auto GOWORK=off go test ./manager/pkg/http -run Services