### PR TITLE
Add sandbox execution GB-second metering

### DIFF
--- a/docs/sandbox/page.mdx
+++ b/docs/sandbox/page.mdx
@@ -79,6 +79,12 @@ The relationship: <code>ttl {'<='} hard_ttl</code>. When <code>ttl</code> expire
 When <code>hard_ttl</code> expires, sandbox compute is cleaned and the sandbox can be restored by resume-capable access. Both can be extended via the refresh API.
 </Callout>
 
+### Metering
+
+Sandbox runtime metering follows a serverless-style execution model. Active sandbox windows emit `sandbox.execution_gb_seconds`, calculated from the sandbox memory allocation and active runtime duration. The raw metering window stores fixed-point `micro_gb_seconds` so short active windows do not truncate to zero before billing systems aggregate them.
+
+`sandbox.compute_mcpu_milliseconds` and `sandbox.memory_mib_milliseconds` remain available for quota, showback, and cost analysis. Network and storage stay separate: `sandbox.ingress_bytes`, `sandbox.egress_bytes`, `sandbox.volume_byte_hours`, and `sandbox.snapshot_byte_hours` are not averaged into execution usage.
+
 **Example timeline (sandbox created with `ttl=300` and `hard_ttl=3600`):**
 - `t=0`: Sandbox created
 - `t=300`: TTL expires → sandbox auto-pauses

--- a/manager/pkg/metering/lifecycle_projector.go
+++ b/manager/pkg/metering/lifecycle_projector.go
@@ -144,7 +144,7 @@ func (p *LifecycleProjector) handleUpsert(obj any) {
 	paused := pod.Annotations[controller.AnnotationPaused] == "true"
 	pausedAt, pausedAtSet := parseRFC3339(pod.Annotations[controller.AnnotationPausedAt])
 	pendingEvents := make([]*meteringpkg.Event, 0, 2)
-	pendingWindows := make([]*meteringpkg.Window, 0, 2)
+	pendingWindows := make([]*meteringpkg.Window, 0, 3)
 
 	if state == nil {
 		pendingEvents = append(pendingEvents, p.buildSandboxEvent(sandboxID, teamID, userID, templateID, claimedAt, meteringpkg.EventTypeSandboxClaimed, claimedEventID(sandboxID, claimedAt), claimEventData(pod)))
@@ -223,7 +223,7 @@ func (p *LifecycleProjector) handleDelete(obj any) {
 	podUsage := sandboxUsageFromPod(pod)
 	claimedAt, claimedAtSet := parseRFC3339(pod.Annotations[controller.AnnotationClaimedAt])
 	pendingEvents := make([]*meteringpkg.Event, 0, 3)
-	pendingWindows := make([]*meteringpkg.Window, 0, 2)
+	pendingWindows := make([]*meteringpkg.Window, 0, 3)
 	if state == nil {
 		state = &meteringpkg.SandboxProjectionState{
 			SandboxID:         sandboxID,
@@ -378,7 +378,7 @@ func (p *LifecycleProjector) buildSandboxResourceWindows(state *meteringpkg.Sand
 	if state == nil || start == nil || start.IsZero() || end.IsZero() || !end.After(*start) {
 		return nil
 	}
-	windows := make([]*meteringpkg.Window, 0, 2)
+	windows := make([]*meteringpkg.Window, 0, 3)
 	durationMS := end.Sub(*start).Milliseconds()
 	if durationMS <= 0 {
 		return windows
@@ -422,8 +422,42 @@ func (p *LifecycleProjector) buildSandboxResourceWindows(state *meteringpkg.Sand
 			Unit:        meteringpkg.WindowUnitMiBMilliseconds,
 			Data:        resourceWindowData(state),
 		})
+		executionMicroGBSeconds := sandboxExecutionMicroGBSeconds(state.ResourceMemoryMiB, durationMS)
+		if executionMicroGBSeconds > 0 {
+			windows = append(windows, &meteringpkg.Window{
+				WindowID:    sandboxWindowID(state.SandboxID, meteringpkg.WindowTypeSandboxExecutionGBSeconds, *start, end),
+				Producer:    sandboxLifecycleProducer,
+				RegionID:    p.regionID,
+				WindowType:  meteringpkg.WindowTypeSandboxExecutionGBSeconds,
+				SubjectType: meteringpkg.SubjectTypeSandbox,
+				SubjectID:   state.SandboxID,
+				TeamID:      teamID,
+				UserID:      userID,
+				SandboxID:   state.SandboxID,
+				TemplateID:  templateID,
+				ClusterID:   p.clusterID,
+				WindowStart: *start,
+				WindowEnd:   end,
+				Value:       executionMicroGBSeconds,
+				Unit:        meteringpkg.WindowUnitMicroGBSeconds,
+				Data:        resourceWindowData(state),
+			})
+		}
 	}
 	return windows
+}
+
+func sandboxExecutionMicroGBSeconds(memoryMiB int64, durationMS int64) int64 {
+	if memoryMiB <= 0 || durationMS <= 0 {
+		return 0
+	}
+	// Store fixed-point GB-seconds so sub-second Lambda-style usage does not truncate to zero.
+	const (
+		microGBSecondsPerMiBMillisecondNumerator   = int64(125)
+		microGBSecondsPerMiBMillisecondDenominator = int64(128)
+	)
+	value := memoryMiB * durationMS * microGBSecondsPerMiBMillisecondNumerator
+	return (value + microGBSecondsPerMiBMillisecondDenominator - 1) / microGBSecondsPerMiBMillisecondDenominator
 }
 
 func isClaimedActiveSandbox(pod *corev1.Pod) bool {

--- a/manager/pkg/metering/lifecycle_projector_test.go
+++ b/manager/pkg/metering/lifecycle_projector_test.go
@@ -213,8 +213,8 @@ func TestLifecycleProjectorRecordsSandboxComputeWindows(t *testing.T) {
 
 	projector.handleDelete(pod)
 
-	if len(recorder.windows) != 2 {
-		t.Fatalf("window count = %d, want 2", len(recorder.windows))
+	if len(recorder.windows) != 3 {
+		t.Fatalf("window count = %d, want 3", len(recorder.windows))
 	}
 	if recorder.windows[0].WindowType != meteringpkg.WindowTypeSandboxComputeMillicpuMilliseconds {
 		t.Fatalf("first window type = %q, want %q", recorder.windows[0].WindowType, meteringpkg.WindowTypeSandboxComputeMillicpuMilliseconds)
@@ -227,6 +227,63 @@ func TestLifecycleProjectorRecordsSandboxComputeWindows(t *testing.T) {
 	}
 	if recorder.windows[1].Value != 2_048_000 {
 		t.Fatalf("memory value = %d, want 2048000", recorder.windows[1].Value)
+	}
+	if recorder.windows[2].WindowType != meteringpkg.WindowTypeSandboxExecutionGBSeconds {
+		t.Fatalf("third window type = %q, want %q", recorder.windows[2].WindowType, meteringpkg.WindowTypeSandboxExecutionGBSeconds)
+	}
+	if recorder.windows[2].Unit != meteringpkg.WindowUnitMicroGBSeconds {
+		t.Fatalf("execution unit = %q, want %q", recorder.windows[2].Unit, meteringpkg.WindowUnitMicroGBSeconds)
+	}
+	if recorder.windows[2].Value != 2_000_000 {
+		t.Fatalf("execution value = %d, want 2000000", recorder.windows[2].Value)
+	}
+}
+
+func TestSandboxExecutionMicroGBSeconds(t *testing.T) {
+	tests := []struct {
+		name        string
+		memoryMiB   int64
+		durationMS  int64
+		wantMicroGB int64
+	}{
+		{
+			name:        "one gib one second",
+			memoryMiB:   1024,
+			durationMS:  1000,
+			wantMicroGB: 1_000_000,
+		},
+		{
+			name:        "half gib one second",
+			memoryMiB:   512,
+			durationMS:  1000,
+			wantMicroGB: 500_000,
+		},
+		{
+			name:        "rounds tiny windows up",
+			memoryMiB:   1,
+			durationMS:  1,
+			wantMicroGB: 1,
+		},
+		{
+			name:        "skips zero memory",
+			memoryMiB:   0,
+			durationMS:  1000,
+			wantMicroGB: 0,
+		},
+		{
+			name:        "skips zero duration",
+			memoryMiB:   1024,
+			durationMS:  0,
+			wantMicroGB: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sandboxExecutionMicroGBSeconds(tt.memoryMiB, tt.durationMS)
+			if got != tt.wantMicroGB {
+				t.Fatalf("sandboxExecutionMicroGBSeconds(%d, %d) = %d, want %d", tt.memoryMiB, tt.durationMS, got, tt.wantMicroGB)
+			}
+		})
 	}
 }
 

--- a/pkg/metering/types.go
+++ b/pkg/metering/types.go
@@ -31,6 +31,7 @@ const (
 
 	WindowTypeSandboxComputeMillicpuMilliseconds = "sandbox.compute_mcpu_milliseconds"
 	WindowTypeSandboxMemoryMiBMilliseconds       = "sandbox.memory_mib_milliseconds"
+	WindowTypeSandboxExecutionGBSeconds          = "sandbox.execution_gb_seconds"
 	WindowTypeSandboxVolumeByteHours             = "sandbox.volume_byte_hours"
 	WindowTypeSandboxSnapshotByteHours           = "sandbox.snapshot_byte_hours"
 
@@ -40,6 +41,7 @@ const (
 	WindowUnitBytes                = "bytes"
 	WindowUnitByteHours            = "byte_hours"
 	WindowUnitCount                = "count"
+	WindowUnitMicroGBSeconds       = "micro_gb_seconds"
 	WindowUnitMillicpuMilliseconds = "millicpu_milliseconds"
 	WindowUnitMiBMilliseconds      = "mib_milliseconds"
 

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -453,6 +453,9 @@ func registerApiModeSuite(envProvider func() *framework.ScenarioEnv, opts apiMod
 						if !hasMeteringWindow(windows, metering.WindowTypeSandboxMemoryMiBMilliseconds, pausedResp.SandboxId) {
 							return fmt.Errorf("missing sandbox.memory_mib_milliseconds window")
 						}
+						if !hasMeteringWindow(windows, metering.WindowTypeSandboxExecutionGBSeconds, pausedResp.SandboxId) {
+							return fmt.Errorf("missing sandbox.execution_gb_seconds window")
+						}
 
 						return nil
 					}).WithTimeout(90 * time.Second).WithPolling(3 * time.Second).Should(Succeed())


### PR DESCRIPTION
## Summary
- add `sandbox.execution_gb_seconds` metering windows for active sandbox runtime
- store raw execution usage as `micro_gb_seconds` to avoid truncating short active windows
- keep CPU, memory, ingress/egress, volume, and snapshot windows intact
- update docs and e2e metering assertions

## Tests
- `go test ./manager/pkg/metering ./pkg/metering`
- `git diff --check`

## Notes
- Billing ingestion normalization is implemented in the companion sandbox0-cloud PR.