### PR TITLE
Refactor sandbox metering to serverless windows

### DIFF
--- a/docs/self-hosted/configuration/page.mdx
+++ b/docs/self-hosted/configuration/page.mdx
@@ -36,6 +36,23 @@ In local-password mode it bootstraps the first admin credentials; in OIDC-only m
 | Multi-cluster control plane | `services.regionalGateway`, `services.scheduler` | You coordinate multiple data-plane clusters in one region |
 | Multi-cluster data plane | `controlPlane`, `cluster`, `services.clusterGateway`, `services.manager`, optional `storageProxy`/`netd` | You attach a cluster to an external control plane |
 
+## Metering Boundary
+
+Sandbox0 records usage truth in the region database and exports it from the region-scoped metering endpoints. Billing systems should rate these exported usage windows outside the open-source data plane.
+
+Sandbox compute uses a serverless-style contract:
+
+| Window type | Unit | Meaning |
+|---|---|---|
+| `sandbox.request_count` | `count` | One successful sandbox claim |
+| `sandbox.runtime_mib_milliseconds` | `mib_milliseconds` | Active sandbox runtime multiplied by allocated memory |
+| `sandbox.egress_bytes` | `bytes` | Egress traffic observed by `netd` |
+| `sandbox.ingress_bytes` | `bytes` | Ingress traffic observed by `netd` |
+| `sandbox.volume_byte_hours` | `byte_hours` | Persisted volume storage over time |
+| `sandbox.snapshot_byte_hours` | `byte_hours` | Persisted snapshot storage over time |
+
+Idle template pool pods are capacity, not billable sandbox runtime. Public template idle pools are platform cost, and team template idle pools should be controlled by plan or entitlement limits rather than usage metering.
+
 Official sample manifests:
 
 - <GitHubRawLink repo="sandbox0" path="infra-operator/chart/samples/single-cluster/minimal.yaml">single-cluster/minimal.yaml</GitHubRawLink>

--- a/manager/pkg/metering/lifecycle_projector.go
+++ b/manager/pkg/metering/lifecycle_projector.go
@@ -147,7 +147,6 @@ func (p *LifecycleProjector) handleUpsert(obj any) {
 	pendingWindows := make([]*meteringpkg.Window, 0, 2)
 
 	if state == nil {
-		pendingEvents = append(pendingEvents, p.buildSandboxEvent(sandboxID, teamID, userID, templateID, claimedAt, meteringpkg.EventTypeSandboxClaimed, claimedEventID(sandboxID, claimedAt), claimEventData(pod)))
 		state = &meteringpkg.SandboxProjectionState{
 			SandboxID:         sandboxID,
 			Namespace:         pod.Namespace,
@@ -163,6 +162,8 @@ func (p *LifecycleProjector) handleUpsert(obj any) {
 			LastObservedAt:    observedAt,
 			LastResourceVer:   pod.ResourceVersion,
 		}
+		pendingEvents = append(pendingEvents, p.buildSandboxEvent(sandboxID, teamID, userID, templateID, claimedAt, meteringpkg.EventTypeSandboxClaimed, claimedEventID(sandboxID, claimedAt), claimEventData(pod)))
+		pendingWindows = append(pendingWindows, p.buildSandboxRequestWindow(state, teamID, userID, templateID, claimedAt, pod))
 	}
 
 	if paused {
@@ -172,7 +173,7 @@ func (p *LifecycleProjector) handleUpsert(obj any) {
 		}
 		if !state.Paused {
 			pendingEvents = append(pendingEvents, p.buildSandboxEvent(sandboxID, teamID, userID, templateID, eventTime, meteringpkg.EventTypeSandboxPaused, pauseEventID(sandboxID, eventTime), nil))
-			pendingWindows = append(pendingWindows, p.buildSandboxResourceWindows(state, teamID, userID, templateID, state.ActiveSince, eventTime)...)
+			pendingWindows = append(pendingWindows, p.buildSandboxRuntimeWindow(state, teamID, userID, templateID, state.ActiveSince, eventTime))
 		}
 		state.Paused = true
 		state.PausedAt = &eventTime
@@ -242,6 +243,7 @@ func (p *LifecycleProjector) handleDelete(obj any) {
 			pendingEvents = append(pendingEvents, p.buildSandboxEvent(sandboxID, teamID, userID, templateID, claimedAt, meteringpkg.EventTypeSandboxClaimed, claimedEventID(sandboxID, claimedAt), claimEventData(pod)))
 			state.ClaimedAt = &claimedAt
 			state.ActiveSince = &claimedAt
+			pendingWindows = append(pendingWindows, p.buildSandboxRequestWindow(state, teamID, userID, templateID, claimedAt, pod))
 		}
 		if pod.Annotations[controller.AnnotationPaused] == "true" {
 			pausedAt := observedAt
@@ -249,7 +251,7 @@ func (p *LifecycleProjector) handleDelete(obj any) {
 				pausedAt = parsedPausedAt
 			}
 			pendingEvents = append(pendingEvents, p.buildSandboxEvent(sandboxID, teamID, userID, templateID, pausedAt, meteringpkg.EventTypeSandboxPaused, pauseEventID(sandboxID, pausedAt), nil))
-			pendingWindows = append(pendingWindows, p.buildSandboxResourceWindows(state, teamID, userID, templateID, state.ActiveSince, pausedAt)...)
+			pendingWindows = append(pendingWindows, p.buildSandboxRuntimeWindow(state, teamID, userID, templateID, state.ActiveSince, pausedAt))
 			state.Paused = true
 			state.PausedAt = &pausedAt
 			state.ActiveSince = nil
@@ -257,7 +259,7 @@ func (p *LifecycleProjector) handleDelete(obj any) {
 	}
 	if state.TerminatedAt == nil {
 		if !state.Paused {
-			pendingWindows = append(pendingWindows, p.buildSandboxResourceWindows(state, teamID, userID, templateID, state.ActiveSince, observedAt)...)
+			pendingWindows = append(pendingWindows, p.buildSandboxRuntimeWindow(state, teamID, userID, templateID, state.ActiveSince, observedAt))
 		}
 		pendingEvents = append(pendingEvents, p.buildSandboxEvent(sandboxID, teamID, userID, templateID, observedAt, meteringpkg.EventTypeSandboxTerminated, terminateEventID(sandboxID, pod.ResourceVersion), nil))
 	}
@@ -374,56 +376,56 @@ func (p *LifecycleProjector) buildSandboxEvent(sandboxID, teamID, userID, templa
 	}
 }
 
-func (p *LifecycleProjector) buildSandboxResourceWindows(state *meteringpkg.SandboxProjectionState, teamID, userID, templateID string, start *time.Time, end time.Time) []*meteringpkg.Window {
+func (p *LifecycleProjector) buildSandboxRequestWindow(state *meteringpkg.SandboxProjectionState, teamID, userID, templateID string, occurredAt time.Time, pod *corev1.Pod) *meteringpkg.Window {
+	if state == nil || occurredAt.IsZero() {
+		return nil
+	}
+	return &meteringpkg.Window{
+		WindowID:    sandboxWindowID(state.SandboxID, meteringpkg.WindowTypeSandboxRequestCount, occurredAt, occurredAt),
+		Producer:    sandboxLifecycleProducer,
+		RegionID:    p.regionID,
+		WindowType:  meteringpkg.WindowTypeSandboxRequestCount,
+		SubjectType: meteringpkg.SubjectTypeSandbox,
+		SubjectID:   state.SandboxID,
+		TeamID:      teamID,
+		UserID:      userID,
+		SandboxID:   state.SandboxID,
+		TemplateID:  templateID,
+		ClusterID:   p.clusterID,
+		WindowStart: occurredAt,
+		WindowEnd:   occurredAt,
+		Value:       1,
+		Unit:        meteringpkg.WindowUnitCount,
+		Data:        requestWindowData(state, pod),
+	}
+}
+
+func (p *LifecycleProjector) buildSandboxRuntimeWindow(state *meteringpkg.SandboxProjectionState, teamID, userID, templateID string, start *time.Time, end time.Time) *meteringpkg.Window {
 	if state == nil || start == nil || start.IsZero() || end.IsZero() || !end.After(*start) {
 		return nil
 	}
-	windows := make([]*meteringpkg.Window, 0, 2)
 	durationMS := end.Sub(*start).Milliseconds()
-	if durationMS <= 0 {
-		return windows
+	if durationMS <= 0 || state.ResourceMemoryMiB <= 0 {
+		return nil
 	}
-	if state.ResourceMillicpu > 0 {
-		windows = append(windows, &meteringpkg.Window{
-			WindowID:    sandboxWindowID(state.SandboxID, meteringpkg.WindowTypeSandboxComputeMillicpuMilliseconds, *start, end),
-			Producer:    sandboxLifecycleProducer,
-			RegionID:    p.regionID,
-			WindowType:  meteringpkg.WindowTypeSandboxComputeMillicpuMilliseconds,
-			SubjectType: meteringpkg.SubjectTypeSandbox,
-			SubjectID:   state.SandboxID,
-			TeamID:      teamID,
-			UserID:      userID,
-			SandboxID:   state.SandboxID,
-			TemplateID:  templateID,
-			ClusterID:   p.clusterID,
-			WindowStart: *start,
-			WindowEnd:   end,
-			Value:       state.ResourceMillicpu * durationMS,
-			Unit:        meteringpkg.WindowUnitMillicpuMilliseconds,
-			Data:        resourceWindowData(state),
-		})
+	return &meteringpkg.Window{
+		WindowID:    sandboxWindowID(state.SandboxID, meteringpkg.WindowTypeSandboxRuntimeMiBMilliseconds, *start, end),
+		Producer:    sandboxLifecycleProducer,
+		RegionID:    p.regionID,
+		WindowType:  meteringpkg.WindowTypeSandboxRuntimeMiBMilliseconds,
+		SubjectType: meteringpkg.SubjectTypeSandbox,
+		SubjectID:   state.SandboxID,
+		TeamID:      teamID,
+		UserID:      userID,
+		SandboxID:   state.SandboxID,
+		TemplateID:  templateID,
+		ClusterID:   p.clusterID,
+		WindowStart: *start,
+		WindowEnd:   end,
+		Value:       state.ResourceMemoryMiB * durationMS,
+		Unit:        meteringpkg.WindowUnitMiBMilliseconds,
+		Data:        runtimeWindowData(state, durationMS),
 	}
-	if state.ResourceMemoryMiB > 0 {
-		windows = append(windows, &meteringpkg.Window{
-			WindowID:    sandboxWindowID(state.SandboxID, meteringpkg.WindowTypeSandboxMemoryMiBMilliseconds, *start, end),
-			Producer:    sandboxLifecycleProducer,
-			RegionID:    p.regionID,
-			WindowType:  meteringpkg.WindowTypeSandboxMemoryMiBMilliseconds,
-			SubjectType: meteringpkg.SubjectTypeSandbox,
-			SubjectID:   state.SandboxID,
-			TeamID:      teamID,
-			UserID:      userID,
-			SandboxID:   state.SandboxID,
-			TemplateID:  templateID,
-			ClusterID:   p.clusterID,
-			WindowStart: *start,
-			WindowEnd:   end,
-			Value:       state.ResourceMemoryMiB * durationMS,
-			Unit:        meteringpkg.WindowUnitMiBMilliseconds,
-			Data:        resourceWindowData(state),
-		})
-	}
-	return windows
 }
 
 func isClaimedActiveSandbox(pod *corev1.Pod) bool {
@@ -573,11 +575,24 @@ func bytesToMiBRoundUp(value int64) int64 {
 	return (value + mib - 1) / mib
 }
 
-func resourceWindowData(state *meteringpkg.SandboxProjectionState) json.RawMessage {
-	return mustJSON(map[string]any{
+func requestWindowData(state *meteringpkg.SandboxProjectionState, pod *corev1.Pod) json.RawMessage {
+	data := map[string]any{
 		"product":             meteringpkg.ProductSandbox,
 		"resource_millicpu":   state.ResourceMillicpu,
 		"resource_memory_mib": state.ResourceMemoryMiB,
+	}
+	if pod != nil {
+		data["claim_type"] = pod.Annotations[controller.AnnotationClaimType]
+	}
+	return mustJSON(data)
+}
+
+func runtimeWindowData(state *meteringpkg.SandboxProjectionState, durationMS int64) json.RawMessage {
+	return mustJSON(map[string]any{
+		"product":               meteringpkg.ProductSandbox,
+		"resource_millicpu":     state.ResourceMillicpu,
+		"resource_memory_mib":   state.ResourceMemoryMiB,
+		"duration_milliseconds": durationMS,
 	})
 }
 

--- a/manager/pkg/metering/lifecycle_projector_test.go
+++ b/manager/pkg/metering/lifecycle_projector_test.go
@@ -117,10 +117,13 @@ func TestLifecycleProjectorRecordsClaimPauseResumeTerminate(t *testing.T) {
 	projector.now = func() time.Time { return now }
 
 	claimedAt := now.Add(-10 * time.Minute)
-	pod := buildSandboxPod(claimedAt, false, "", "1")
+	pod := withSandboxResources(buildSandboxPod(claimedAt, false, "", "1"), "2", "1Gi")
 	projector.handleUpsert(pod)
 	if len(recorder.events) != 1 || recorder.events[0].EventType != meteringpkg.EventTypeSandboxClaimed {
 		t.Fatalf("expected claim event, got %#v", recorder.events)
+	}
+	if len(recorder.windows) != 1 || recorder.windows[0].WindowType != meteringpkg.WindowTypeSandboxRequestCount {
+		t.Fatalf("expected request count window, got %#v", recorder.windows)
 	}
 
 	pausedAt := now.Add(-2 * time.Minute)
@@ -129,18 +132,21 @@ func TestLifecycleProjectorRecordsClaimPauseResumeTerminate(t *testing.T) {
 	if len(recorder.events) != 2 || recorder.events[1].EventType != meteringpkg.EventTypeSandboxPaused {
 		t.Fatalf("expected pause event, got %#v", recorder.events)
 	}
-	if len(recorder.windows) != 0 {
-		t.Fatalf("expected no legacy lifecycle windows, got %#v", recorder.windows)
+	if len(recorder.windows) != 2 || recorder.windows[1].WindowType != meteringpkg.WindowTypeSandboxRuntimeMiBMilliseconds {
+		t.Fatalf("expected runtime window after pause, got %#v", recorder.windows)
+	}
+	if recorder.windows[1].Value != 491_520_000 {
+		t.Fatalf("paused runtime value = %d, want 491520000", recorder.windows[1].Value)
 	}
 
 	projector.now = func() time.Time { return now.Add(time.Minute) }
-	resumedPod := buildSandboxPod(claimedAt, false, "", "3")
+	resumedPod := withSandboxResources(buildSandboxPod(claimedAt, false, "", "3"), "2", "1Gi")
 	projector.handleUpsert(resumedPod)
 	if len(recorder.events) != 3 || recorder.events[2].EventType != meteringpkg.EventTypeSandboxResumed {
 		t.Fatalf("expected resume event, got %#v", recorder.events)
 	}
-	if len(recorder.windows) != 0 {
-		t.Fatalf("expected no paused seconds window, got %#v", recorder.windows)
+	if len(recorder.windows) != 2 {
+		t.Fatalf("window count after resume = %d, want 2", len(recorder.windows))
 	}
 
 	projector.now = func() time.Time { return now.Add(2 * time.Minute) }
@@ -148,8 +154,11 @@ func TestLifecycleProjectorRecordsClaimPauseResumeTerminate(t *testing.T) {
 	if len(recorder.events) != 4 || recorder.events[3].EventType != meteringpkg.EventTypeSandboxTerminated {
 		t.Fatalf("expected terminate event, got %#v", recorder.events)
 	}
-	if len(recorder.windows) != 0 {
-		t.Fatalf("expected no final active seconds window, got %#v", recorder.windows)
+	if len(recorder.windows) != 3 || recorder.windows[2].WindowType != meteringpkg.WindowTypeSandboxRuntimeMiBMilliseconds {
+		t.Fatalf("expected final runtime window, got %#v", recorder.windows)
+	}
+	if recorder.windows[2].Value != 61_440_000 {
+		t.Fatalf("final runtime value = %d, want 61440000", recorder.windows[2].Value)
 	}
 }
 
@@ -189,44 +198,34 @@ func TestLifecycleProjectorRecordsErrorsInMetrics(t *testing.T) {
 	}
 }
 
-func TestLifecycleProjectorRecordsSandboxComputeWindows(t *testing.T) {
+func TestLifecycleProjectorRecordsSandboxServerlessWindows(t *testing.T) {
 	recorder := &fakeRecorder{states: map[string]*meteringpkg.SandboxProjectionState{}}
 	projector := NewLifecycleProjector(recorder, "aws-us-east-1", "cluster-a")
 
 	now := time.Date(2026, 3, 12, 10, 0, 0, 0, time.UTC)
 	projector.now = func() time.Time { return now }
 	claimedAt := now.Add(-2 * time.Second)
-	pod := buildSandboxPod(claimedAt, false, "", "1")
-	pod.Spec.Containers = []corev1.Container{{
-		Name: "procd",
-		Resources: corev1.ResourceRequirements{
-			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("2"),
-				corev1.ResourceMemory: resource.MustParse("1Gi"),
-			},
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("100m"),
-				corev1.ResourceMemory: resource.MustParse("256Mi"),
-			},
-		},
-	}}
+	pod := withSandboxResources(buildSandboxPod(claimedAt, false, "", "1"), "2", "1Gi")
 
 	projector.handleDelete(pod)
 
 	if len(recorder.windows) != 2 {
 		t.Fatalf("window count = %d, want 2", len(recorder.windows))
 	}
-	if recorder.windows[0].WindowType != meteringpkg.WindowTypeSandboxComputeMillicpuMilliseconds {
-		t.Fatalf("first window type = %q, want %q", recorder.windows[0].WindowType, meteringpkg.WindowTypeSandboxComputeMillicpuMilliseconds)
+	if recorder.windows[0].WindowType != meteringpkg.WindowTypeSandboxRequestCount {
+		t.Fatalf("first window type = %q, want %q", recorder.windows[0].WindowType, meteringpkg.WindowTypeSandboxRequestCount)
 	}
-	if recorder.windows[0].Value != 4_000_000 {
-		t.Fatalf("compute value = %d, want 4000000", recorder.windows[0].Value)
+	if recorder.windows[0].Value != 1 || recorder.windows[0].Unit != meteringpkg.WindowUnitCount {
+		t.Fatalf("request window = %+v, want value=1 unit=count", recorder.windows[0])
 	}
-	if recorder.windows[1].WindowType != meteringpkg.WindowTypeSandboxMemoryMiBMilliseconds {
-		t.Fatalf("second window type = %q, want %q", recorder.windows[1].WindowType, meteringpkg.WindowTypeSandboxMemoryMiBMilliseconds)
+	if recorder.windows[1].WindowType != meteringpkg.WindowTypeSandboxRuntimeMiBMilliseconds {
+		t.Fatalf("second window type = %q, want %q", recorder.windows[1].WindowType, meteringpkg.WindowTypeSandboxRuntimeMiBMilliseconds)
 	}
 	if recorder.windows[1].Value != 2_048_000 {
-		t.Fatalf("memory value = %d, want 2048000", recorder.windows[1].Value)
+		t.Fatalf("runtime value = %d, want 2048000", recorder.windows[1].Value)
+	}
+	if recorder.windows[1].Unit != meteringpkg.WindowUnitMiBMilliseconds {
+		t.Fatalf("runtime unit = %q, want %q", recorder.windows[1].Unit, meteringpkg.WindowUnitMiBMilliseconds)
 	}
 }
 
@@ -238,7 +237,7 @@ func TestLifecycleProjectorTerminatesPausedSandboxWithPausedWindow(t *testing.T)
 	pausedAt := time.Date(2026, 3, 12, 10, 3, 0, 0, time.UTC)
 	projector.now = func() time.Time { return time.Date(2026, 3, 12, 10, 5, 0, 0, time.UTC) }
 
-	pod := buildSandboxPod(claimedAt, true, pausedAt.Format(time.RFC3339), "7")
+	pod := withSandboxResources(buildSandboxPod(claimedAt, true, pausedAt.Format(time.RFC3339), "7"), "1", "1Gi")
 	projector.handleDelete(pod)
 
 	if len(recorder.events) != 3 {
@@ -250,8 +249,17 @@ func TestLifecycleProjectorTerminatesPausedSandboxWithPausedWindow(t *testing.T)
 	if recorder.events[2].EventType != meteringpkg.EventTypeSandboxTerminated {
 		t.Fatalf("third event type = %q, want %q", recorder.events[2].EventType, meteringpkg.EventTypeSandboxTerminated)
 	}
-	if len(recorder.windows) != 0 {
-		t.Fatalf("expected no legacy lifecycle windows, got %+v", recorder.windows)
+	if len(recorder.windows) != 2 {
+		t.Fatalf("window count = %d, want 2", len(recorder.windows))
+	}
+	if recorder.windows[0].WindowType != meteringpkg.WindowTypeSandboxRequestCount {
+		t.Fatalf("first window type = %q, want request count", recorder.windows[0].WindowType)
+	}
+	if recorder.windows[1].WindowType != meteringpkg.WindowTypeSandboxRuntimeMiBMilliseconds {
+		t.Fatalf("second window type = %q, want runtime", recorder.windows[1].WindowType)
+	}
+	if recorder.windows[1].Value != 184_320_000 {
+		t.Fatalf("runtime value = %d, want 184320000", recorder.windows[1].Value)
 	}
 }
 
@@ -279,8 +287,8 @@ func TestLifecycleProjectorRetriesCommitWithoutDuplicatingWindows(t *testing.T) 
 	recorder.stateUpsertErr = errors.New("boom")
 	projector.now = func() time.Time { return now.Add(time.Minute) }
 	projector.handleUpsert(buildSandboxPod(claimedAt, false, "", "3"))
-	if len(recorder.windows) != 0 {
-		t.Fatalf("window count after failed resume = %d, want 0", len(recorder.windows))
+	if len(recorder.windows) != 1 {
+		t.Fatalf("window count after failed resume = %d, want 1", len(recorder.windows))
 	}
 
 	recorder.stateUpsertErr = nil
@@ -289,11 +297,29 @@ func TestLifecycleProjectorRetriesCommitWithoutDuplicatingWindows(t *testing.T) 
 	if len(recorder.events) != 3 {
 		t.Fatalf("event count = %d, want 3", len(recorder.events))
 	}
-	if len(recorder.windows) != 0 {
-		t.Fatalf("window count = %d, want 0", len(recorder.windows))
+	if len(recorder.windows) != 1 {
+		t.Fatalf("window count = %d, want 1", len(recorder.windows))
+	}
+	if recorder.windows[0].WindowType != meteringpkg.WindowTypeSandboxRequestCount {
+		t.Fatalf("window type = %q, want request count", recorder.windows[0].WindowType)
 	}
 	if recorder.transactionCalls != 5 {
 		t.Fatalf("transaction_calls = %d, want 5", recorder.transactionCalls)
+	}
+}
+
+func TestLifecycleProjectorIgnoresIdlePoolPods(t *testing.T) {
+	recorder := &fakeRecorder{states: map[string]*meteringpkg.SandboxProjectionState{}}
+	projector := NewLifecycleProjector(recorder, "aws-us-east-1", "cluster-a")
+
+	pod := buildSandboxPod(time.Date(2026, 3, 12, 10, 0, 0, 0, time.UTC), false, "", "1")
+	pod.Labels[controller.LabelPoolType] = controller.PoolTypeIdle
+	delete(pod.Labels, controller.LabelSandboxID)
+
+	projector.handleUpsert(pod)
+
+	if len(recorder.events) != 0 || len(recorder.windows) != 0 {
+		t.Fatalf("idle pool pod should not be metered, events=%#v windows=%#v", recorder.events, recorder.windows)
 	}
 }
 
@@ -323,4 +349,21 @@ func buildSandboxPod(claimedAt time.Time, paused bool, pausedAt string, resource
 			Annotations: annotations,
 		},
 	}
+}
+
+func withSandboxResources(pod *corev1.Pod, cpu, memory string) *corev1.Pod {
+	pod.Spec.Containers = []corev1.Container{{
+		Name: "procd",
+		Resources: corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse(cpu),
+				corev1.ResourceMemory: resource.MustParse(memory),
+			},
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+				corev1.ResourceMemory: resource.MustParse("256Mi"),
+			},
+		},
+	}}
+	return pod
 }

--- a/pkg/gateway/http/handlers/metering_test.go
+++ b/pkg/gateway/http/handlers/metering_test.go
@@ -264,10 +264,10 @@ func TestMeteringHandlerListWindows(t *testing.T) {
 			windows: []*metering.Window{
 				{
 					Sequence:    3,
-					WindowID:    "sandbox/sb-1/compute/2026-03-12T10:00:00Z/2026-03-12T10:05:00Z",
+					WindowID:    "sandbox/sb-1/runtime/2026-03-12T10:00:00Z/2026-03-12T10:05:00Z",
 					Producer:    "manager.lifecycle",
 					RegionID:    "aws-us-east-1",
-					WindowType:  metering.WindowTypeSandboxComputeMillicpuMilliseconds,
+					WindowType:  metering.WindowTypeSandboxRuntimeMiBMilliseconds,
 					SubjectType: metering.SubjectTypeSandbox,
 					SubjectID:   "sb-1",
 					TeamID:      "team-1",
@@ -275,7 +275,7 @@ func TestMeteringHandlerListWindows(t *testing.T) {
 					WindowStart: windowStart,
 					WindowEnd:   windowEnd,
 					Value:       300_000,
-					Unit:        metering.WindowUnitMillicpuMilliseconds,
+					Unit:        metering.WindowUnitMiBMilliseconds,
 					RecordedAt:  recordedAt,
 				},
 			},

--- a/pkg/metering/repository_test.go
+++ b/pkg/metering/repository_test.go
@@ -189,13 +189,13 @@ func TestAppendWindowUsesDefaultPayload(t *testing.T) {
 	err := repo.AppendWindow(context.Background(), &Window{
 		WindowID:    "win-1",
 		Producer:    "manager.sandbox_lifecycle",
-		WindowType:  WindowTypeSandboxComputeMillicpuMilliseconds,
+		WindowType:  WindowTypeSandboxRuntimeMiBMilliseconds,
 		SubjectType: SubjectTypeSandbox,
 		SubjectID:   "sb-1",
 		WindowStart: time.Date(2026, 3, 12, 12, 0, 0, 0, time.UTC),
 		WindowEnd:   time.Date(2026, 3, 12, 12, 5, 0, 0, time.UTC),
 		Value:       300_000,
-		Unit:        WindowUnitMillicpuMilliseconds,
+		Unit:        WindowUnitMiBMilliseconds,
 	})
 	if err != nil {
 		t.Fatalf("AppendWindow: %v", err)
@@ -308,7 +308,7 @@ func TestListWindowsAfterReturnsOrderedWindows(t *testing.T) {
 							"window-7",
 							"manager.sandbox_lifecycle",
 							"aws-us-east-1",
-							WindowTypeSandboxComputeMillicpuMilliseconds,
+							WindowTypeSandboxRuntimeMiBMilliseconds,
 							SubjectTypeSandbox,
 							"sb-1",
 							"team-1",
@@ -321,7 +321,7 @@ func TestListWindowsAfterReturnsOrderedWindows(t *testing.T) {
 							windowStart,
 							windowEnd,
 							int64(300_000),
-							WindowUnitMillicpuMilliseconds,
+							WindowUnitMiBMilliseconds,
 							recordedAt,
 							json.RawMessage(`{"source":"test"}`),
 						},

--- a/pkg/metering/types.go
+++ b/pkg/metering/types.go
@@ -29,19 +29,18 @@ const (
 	WindowTypeSandboxIngressBytes = "sandbox.ingress_bytes"
 	WindowTypeSandboxEgressBytes  = "sandbox.egress_bytes"
 
-	WindowTypeSandboxComputeMillicpuMilliseconds = "sandbox.compute_mcpu_milliseconds"
-	WindowTypeSandboxMemoryMiBMilliseconds       = "sandbox.memory_mib_milliseconds"
-	WindowTypeSandboxVolumeByteHours             = "sandbox.volume_byte_hours"
-	WindowTypeSandboxSnapshotByteHours           = "sandbox.snapshot_byte_hours"
+	WindowTypeSandboxRequestCount           = "sandbox.request_count"
+	WindowTypeSandboxRuntimeMiBMilliseconds = "sandbox.runtime_mib_milliseconds"
+	WindowTypeSandboxVolumeByteHours        = "sandbox.volume_byte_hours"
+	WindowTypeSandboxSnapshotByteHours      = "sandbox.snapshot_byte_hours"
 
 	WindowTypeManagedAgentSessionRunningMilliseconds = "managed_agent.session_running_milliseconds"
 
-	WindowUnitMilliseconds         = "milliseconds"
-	WindowUnitBytes                = "bytes"
-	WindowUnitByteHours            = "byte_hours"
-	WindowUnitCount                = "count"
-	WindowUnitMillicpuMilliseconds = "millicpu_milliseconds"
-	WindowUnitMiBMilliseconds      = "mib_milliseconds"
+	WindowUnitMilliseconds    = "milliseconds"
+	WindowUnitBytes           = "bytes"
+	WindowUnitByteHours       = "byte_hours"
+	WindowUnitCount           = "count"
+	WindowUnitMiBMilliseconds = "mib_milliseconds"
 
 	SubjectTypeSandbox             = "sandbox"
 	SubjectTypeVolume              = "volume"

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -447,11 +447,11 @@ func registerApiModeSuite(envProvider func() *framework.ScenarioEnv, opts apiMod
 						if err != nil {
 							return err
 						}
-						if !hasMeteringWindow(windows, metering.WindowTypeSandboxComputeMillicpuMilliseconds, pausedResp.SandboxId) {
-							return fmt.Errorf("missing sandbox.compute_mcpu_milliseconds window")
+						if !hasMeteringWindow(windows, metering.WindowTypeSandboxRequestCount, pausedResp.SandboxId) {
+							return fmt.Errorf("missing sandbox.request_count window")
 						}
-						if !hasMeteringWindow(windows, metering.WindowTypeSandboxMemoryMiBMilliseconds, pausedResp.SandboxId) {
-							return fmt.Errorf("missing sandbox.memory_mib_milliseconds window")
+						if !hasMeteringWindow(windows, metering.WindowTypeSandboxRuntimeMiBMilliseconds, pausedResp.SandboxId) {
+							return fmt.Errorf("missing sandbox.runtime_mib_milliseconds window")
 						}
 
 						return nil

--- a/tests/integration/internal/tests/cluster-gateway/metering_test.go
+++ b/tests/integration/internal/tests/cluster-gateway/metering_test.go
@@ -60,10 +60,10 @@ func TestClusterGatewayIntegration_MeteringExportContract(t *testing.T) {
 		t.Fatalf("append second event: %v", err)
 	}
 	if err := repo.AppendWindow(ctx, &metering.Window{
-		WindowID:    "sandbox/sb-1/compute/1",
+		WindowID:    "sandbox/sb-1/request/1",
 		Producer:    "manager.sandbox_lifecycle",
 		RegionID:    "aws-us-east-1",
-		WindowType:  metering.WindowTypeSandboxComputeMillicpuMilliseconds,
+		WindowType:  metering.WindowTypeSandboxRequestCount,
 		SubjectType: metering.SubjectTypeSandbox,
 		SubjectID:   "sb-1",
 		TeamID:      "team-1",
@@ -72,17 +72,17 @@ func TestClusterGatewayIntegration_MeteringExportContract(t *testing.T) {
 		TemplateID:  "tpl-1",
 		ClusterID:   "cluster-a",
 		WindowStart: baseTime,
-		WindowEnd:   baseTime.Add(5 * time.Minute),
-		Value:       300_000,
-		Unit:        metering.WindowUnitMillicpuMilliseconds,
+		WindowEnd:   baseTime,
+		Value:       1,
+		Unit:        metering.WindowUnitCount,
 	}); err != nil {
 		t.Fatalf("append first window: %v", err)
 	}
 	if err := repo.AppendWindow(ctx, &metering.Window{
-		WindowID:    "sandbox/sb-1/memory/2",
+		WindowID:    "sandbox/sb-1/runtime/2",
 		Producer:    "manager.sandbox_lifecycle",
 		RegionID:    "aws-us-east-1",
-		WindowType:  metering.WindowTypeSandboxMemoryMiBMilliseconds,
+		WindowType:  metering.WindowTypeSandboxRuntimeMiBMilliseconds,
 		SubjectType: metering.SubjectTypeSandbox,
 		SubjectID:   "sb-1",
 		TeamID:      "team-1",
@@ -187,7 +187,7 @@ func TestClusterGatewayIntegration_MeteringExportContract(t *testing.T) {
 	if len(windowsResp.Windows) != 1 {
 		t.Fatalf("window count = %d, want 1", len(windowsResp.Windows))
 	}
-	if windowsResp.Windows[0].Sequence != 2 || windowsResp.Windows[0].WindowType != metering.WindowTypeSandboxMemoryMiBMilliseconds {
+	if windowsResp.Windows[0].Sequence != 2 || windowsResp.Windows[0].WindowType != metering.WindowTypeSandboxRuntimeMiBMilliseconds {
 		t.Fatalf("unexpected window: %+v", windowsResp.Windows[0])
 	}
 }


### PR DESCRIPTION
## Summary
- replace sandbox CPU/memory lifecycle meters with Lambda-style request count and memory-duration runtime windows
- keep network and storage usage windows independent from compute billing
- document that idle template pool pods are capacity, not billable runtime

## Tests
- go test ./manager/pkg/metering ./pkg/metering ./pkg/gateway/http/handlers
- go test ./tests/integration/internal/tests/cluster-gateway -run TestClusterGatewayIntegration_MeteringExportContract -count=1
- go test ./tests/e2e/cases -run '^$'