### PR TITLE
Add Python sandbox function runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 GOOS="${BUILD_GOOS}" GOARCH="${BUILD_GOARCH}" go build -o /out/cluster-gateway ./cluster-gateway/cmd/cluster-gateway && \
     CGO_ENABLED=0 GOOS="${BUILD_GOOS}" GOARCH="${BUILD_GOARCH}" go build -o /out/manager ./manager/cmd/manager && \
     CGO_ENABLED=0 GOOS="${BUILD_GOOS}" GOARCH="${BUILD_GOARCH}" go build -o /out/procd ./manager/cmd/procd && \
+    CGO_ENABLED=0 GOOS="${BUILD_GOOS}" GOARCH="${BUILD_GOARCH}" go build -o /out/python-runner ./manager/cmd/python-runner && \
     CGO_ENABLED=0 GOOS="${BUILD_GOOS}" GOARCH="${BUILD_GOARCH}" go build -o /out/scheduler ./scheduler/cmd/scheduler && \
     CGO_ENABLED=1 GOOS="${BUILD_GOOS}" GOARCH="${BUILD_GOARCH}" go build -o /out/storage-proxy ./storage-proxy/cmd/storage-proxy && \
     CGO_ENABLED=1 GOOS="${BUILD_GOOS}" GOARCH="${BUILD_GOARCH}" go build -o /out/infra-operator ./infra-operator/cmd/infra-operator && \

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ OAPI_CODEGEN_VERSION ?= v2.4.1
 PROTOC ?= protoc
 GO ?= env GOWORK=off go
 
-SERVICES := regional-gateway ssh-gateway global-gateway cluster-gateway manager scheduler storage-proxy ctld procd netd infra-operator
+SERVICES := regional-gateway ssh-gateway global-gateway cluster-gateway manager scheduler storage-proxy ctld procd python-runner netd infra-operator
 E2E_SSH_FIXTURE_SOURCE_IMAGE := lscr.io/linuxserver/openssh-server@sha256:68b605929e83b2efe000da09269688f6d82a44579e8a18e2d9e8c8d272917cf7
 E2E_SSH_FIXTURE_IMAGE := sandbox0ai/e2e-openssh-server:68b605929e83
 E2E_DEPENDENCY_IMAGES := postgres:16-alpine rustfs/rustfs:1.0.0-alpha.79 registry:2.8.3 sandbox0ai/otemplates:default-v0.1.0 $(E2E_SSH_FIXTURE_IMAGE)
@@ -44,8 +44,8 @@ build: manifests proto apispec
 			echo "Error: Unknown service '$$s'"; exit 1; \
 		fi; \
 		printf "$(GREEN)Building $$s...$(RESET)\n"; \
-		if [ "$$s" = "procd" ]; then \
-			dir="manager"; bin="procd"; src="./manager/cmd/procd"; \
+		if [ "$$s" = "procd" ] || [ "$$s" = "python-runner" ]; then \
+			dir="manager"; bin="$$s"; src="./manager/cmd/$$s"; \
 		elif [ "$$s" = "infra-operator" ]; then \
 			dir="infra-operator"; bin="infra-operator"; src="./infra-operator/cmd/infra-operator"; \
 		elif [ "$$s" = "ctld" ]; then \
@@ -109,7 +109,9 @@ test:
 		elif [ "$$service" = "manager" ]; then \
 			GOTOOLCHAIN=go1.25.0+auto $(GO) test -v -race -cover ./manager/...; \
 		elif [ "$$service" = "procd" ]; then \
-			GOTOOLCHAIN=go1.25.0+auto $(GO) test -v -race -cover ./manager/procd/...; \
+			GOTOOLCHAIN=go1.25.0+auto $(GO) test -v -race -cover ./manager/procd/... ./manager/cmd/python-runner/...; \
+		elif [ "$$service" = "python-runner" ]; then \
+			GOTOOLCHAIN=go1.25.0+auto $(GO) test -v -race -cover ./manager/cmd/python-runner/...; \
 		elif [ "$$service" = "netd" ]; then \
 			GOTOOLCHAIN=go1.25.0+auto $(GO) test -v -race -cover ./netd/...; \
 		elif [ "$$service" = "scheduler" ]; then \
@@ -202,7 +204,7 @@ test-e2e-specific:
 	unset http_proxy && unset https_proxy && unset all_proxy && $(GO) test -v ./tests/e2e/... -focus="$(SPEC)" -timeout=30m
 
 # Prevent make from treating service names as targets
-regional-gateway ssh-gateway global-gateway cluster-gateway manager scheduler storage-proxy ctld procd netd infra-operator:
+regional-gateway ssh-gateway global-gateway cluster-gateway manager scheduler storage-proxy ctld procd python-runner netd infra-operator:
 	@:
 
 lint:
@@ -217,8 +219,8 @@ vendor:
 clean:
 	@for service in $(SERVICES); do \
 		printf "$(YELLOW)Cleaning $$service...$(RESET)\n"; \
-		if [ "$$service" = "procd" ]; then \
-			rm -rf manager/bin/procd; \
+		if [ "$$service" = "procd" ] || [ "$$service" = "python-runner" ]; then \
+			rm -rf manager/bin/$$service; \
 		else \
 			rm -rf $$service/bin; \
 		fi; \

--- a/cluster-gateway/pkg/http/handlers_function.go
+++ b/cluster-gateway/pkg/http/handlers_function.go
@@ -1,0 +1,24 @@
+package http
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
+)
+
+// invokeFunction invokes a sandbox function through procd.
+// Route: /api/v1/sandboxes/:id/functions/:name/invoke
+func (s *Server) invokeFunction(c *gin.Context) {
+	sandboxID, ok := requireSandboxID(c)
+	if !ok {
+		return
+	}
+	name := c.Param("name")
+	if name == "" {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "function name is required")
+		return
+	}
+	s.proxyToSandboxProcdPath(c, sandboxID, "/api/v1/functions/"+url.PathEscape(name)+"/invoke")
+}

--- a/cluster-gateway/pkg/http/server.go
+++ b/cluster-gateway/pkg/http/server.go
@@ -383,6 +383,12 @@ func (s *Server) setupRoutes() {
 				contexts.GET("/:ctx_id/ws", s.contextWebSocket)
 			}
 
+			// === Function Invocation (→ Procd) ===
+			functions := sandboxes.Group("/:id/functions")
+			{
+				functions.POST("/:name/invoke", s.invokeFunction)
+			}
+
 			// === File System (→ Procd) ===
 			files := sandboxes.Group("/:id/files")
 			{

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -36,6 +36,10 @@
           "title": "Files"
         },
         {
+          "slug": "function",
+          "title": "Functions"
+        },
+        {
           "slug": "ssh",
           "title": "SSH"
         },

--- a/docs/sandbox/function/page.mdx
+++ b/docs/sandbox/function/page.mdx
@@ -1,0 +1,171 @@
+# Sandbox Functions
+
+Sandbox functions are one-shot handlers stored in the sandbox filesystem. The first Python runtime maps a function name such as `main` to `/workspace/functions/main.py` and invokes the `handler` function by default.
+
+<Callout variant="info">
+Function invocation does not add another daemon. Procd stays as the sandbox entry process and starts the injected `/procd/runtimes/python-runner` binary for each invocation.
+</Callout>
+
+## Runtime Requirements
+
+The sandbox image must provide `python3` on `PATH`. The default Sandbox0 template includes Python. Custom images should install Python when they need this function runtime.
+
+The platform injects both binaries into the sandbox pod:
+
+| Path | Purpose |
+|------|---------|
+| `/procd/bin/procd` | Sandbox entry process |
+| `/procd/runtimes/python-runner` | Python function runner |
+
+## Handler Contract
+
+Create a function module under `/workspace/functions`. For `main`, write `/workspace/functions/main.py`:
+
+```python
+import base64
+import json
+
+
+def handler(request):
+    raw = base64.b64decode(request.get("body_base64") or "e30=")
+    payload = json.loads(raw.decode("utf-8"))
+    name = payload.get("name", "world")
+    return {
+        "status": 200,
+        "headers": {"content-type": "application/json"},
+        "body": {"message": f"hello {name}"},
+    }
+```
+
+The request object contains `method`, `path`, `query`, `headers`, and `body_base64`. The response object contains `status`, `headers`, and `body_base64`. Returning a Python `dict`, `str`, `bytes`, or `None` is supported; non-response dictionaries can be returned as `{"body": ...}`.
+
+## Invoke
+
+<Endpoint method="POST">
+/api/v1/sandboxes/{'{id}'}/functions/{'{name}'}/invoke
+</Endpoint>
+
+<Tabs
+  tabs={[
+    {
+      label: "Go",
+      language: "go",
+      code: `source := []byte(\`import base64
+import json
+
+def handler(request):
+    raw = base64.b64decode(request.get("body_base64") or "e30=")
+    payload = json.loads(raw.decode("utf-8"))
+    return {
+        "status": 200,
+        "headers": {"content-type": "application/json"},
+        "body": {"message": "hello " + payload.get("name", "world")},
+    }
+\`)
+
+_, err := sandbox.Mkdir(ctx, "/workspace/functions", true)
+if err != nil {
+    log.Fatal(err)
+}
+
+_, err = sandbox.WriteFile(ctx, "/workspace/functions/main.py", source)
+if err != nil {
+    log.Fatal(err)
+}
+
+body := base64.StdEncoding.EncodeToString([]byte(\`{"name":"Ada"}\`))
+resp, err := sandbox.InvokeFunction(ctx, "main", apispec.FunctionInvokeRequest{
+    Method:     apispec.NewOptString("POST"),
+    Path:       apispec.NewOptString("/hello"),
+    BodyBase64: apispec.NewOptString(body),
+})
+if err != nil {
+    log.Fatal(err)
+}
+
+decoded, err := base64.StdEncoding.DecodeString(resp.BodyBase64.Or(""))
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Println(string(decoded))`
+    },
+    {
+      label: "Python",
+      language: "python",
+      code: `import base64
+
+from sandbox0.apispec.models.function_invoke_request import FunctionInvokeRequest
+
+source = b"""import base64
+import json
+
+def handler(request):
+    raw = base64.b64decode(request.get("body_base64") or "e30=")
+    payload = json.loads(raw.decode("utf-8"))
+    return {
+        "status": 200,
+        "headers": {"content-type": "application/json"},
+        "body": {"message": "hello " + payload.get("name", "world")},
+    }
+"""
+
+sandbox.mkdir("/workspace/functions", recursive=True)
+sandbox.write_file("/workspace/functions/main.py", source)
+
+body = base64.b64encode(b'{"name":"Ada"}').decode("ascii")
+resp = sandbox.invoke_function(
+    "main",
+    FunctionInvokeRequest(method="POST", path="/hello", body_base64=body),
+)
+print(base64.b64decode(resp.body_base64).decode("utf-8"))`
+    },
+    {
+      label: "TypeScript",
+      language: "typescript",
+      code: `const source = \`import base64
+import json
+
+def handler(request):
+    raw = base64.b64decode(request.get("body_base64") or "e30=")
+    payload = json.loads(raw.decode("utf-8"))
+    return {
+        "status": 200,
+        "headers": {"content-type": "application/json"},
+        "body": {"message": "hello " + payload.get("name", "world")},
+    }
+\`;
+
+await sandbox.mkdir("/workspace/functions", true);
+await sandbox.writeFile("/workspace/functions/main.py", source);
+
+const resp = await sandbox.invokeFunction("main", {
+    method: "POST",
+    path: "/hello",
+    bodyBase64: Buffer.from('{"name":"Ada"}').toString("base64"),
+});
+console.log(Buffer.from(resp.bodyBase64 ?? "", "base64").toString("utf8"));`
+    },
+    {
+      label: "CLI",
+      language: "bash",
+      code: `s0 sandbox files mkdir -s sb_abc123 /workspace/functions --parents
+
+s0 sandbox files write -s sb_abc123 /workspace/functions/main.py --data 'import base64
+import json
+
+def handler(request):
+    raw = base64.b64decode(request.get("body_base64") or "e30=")
+    payload = json.loads(raw.decode("utf-8"))
+    return {
+        "status": 200,
+        "headers": {"content-type": "application/json"},
+        "body": {"message": "hello " + payload.get("name", "world")},
+    }
+'
+
+s0 sandbox function invoke -s sb_abc123 main --method POST --path /hello --body '{"name":"Ada"}'`
+    }
+  ]}
+/>
+
+By default, the CLI prints the decoded function body. Use `-o json` to inspect the full function response, including `status`, `headers`, and `body_base64`.

--- a/manager/cmd/python-runner/main.go
+++ b/manager/cmd/python-runner/main.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	osexec "os/exec"
+	"syscall"
+)
+
+const pythonBootstrap = `
+import asyncio
+import base64
+import importlib.util
+import inspect
+import json
+import os
+import sys
+import traceback
+
+
+def _load_handler(module_path, handler_name):
+    module_path = os.path.abspath(module_path)
+    module_dir = os.path.dirname(module_path)
+    if module_dir not in sys.path:
+        sys.path.insert(0, module_dir)
+
+    spec = importlib.util.spec_from_file_location("sandbox0_function", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load function module: {module_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["sandbox0_function"] = module
+    spec.loader.exec_module(module)
+
+    target = module
+    for part in handler_name.split("."):
+        target = getattr(target, part)
+    if not callable(target):
+        raise TypeError(f"handler is not callable: {handler_name}")
+    return target
+
+
+def _normalize_headers(headers):
+    if headers is None:
+        return {}
+    if not isinstance(headers, dict):
+        raise TypeError("response headers must be an object")
+
+    out = {}
+    for key, value in headers.items():
+        if value is None:
+            continue
+        if isinstance(value, (list, tuple)):
+            out[str(key)] = [str(item) for item in value]
+        else:
+            out[str(key)] = [str(value)]
+    return out
+
+
+def _encode_body(value, headers):
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return base64.b64encode(value).decode("ascii")
+    if isinstance(value, bytearray):
+        return base64.b64encode(bytes(value)).decode("ascii")
+    if isinstance(value, str):
+        return base64.b64encode(value.encode("utf-8")).decode("ascii")
+
+    headers.setdefault("content-type", ["application/json"])
+    encoded = json.dumps(value, separators=(",", ":")).encode("utf-8")
+    return base64.b64encode(encoded).decode("ascii")
+
+
+def _normalize_response(value):
+    if value is None:
+        return {"status": 204, "headers": {}, "body_base64": ""}
+
+    if isinstance(value, dict):
+        headers = _normalize_headers(value.get("headers"))
+        status = int(value.get("status", 200))
+        if "body_base64" in value:
+            body_base64 = str(value.get("body_base64") or "")
+        else:
+            body_base64 = _encode_body(value.get("body"), headers)
+        return {"status": status, "headers": headers, "body_base64": body_base64}
+
+    headers = {}
+    body_base64 = _encode_body(value, headers)
+    return {"status": 200, "headers": headers, "body_base64": body_base64}
+
+
+def main():
+    if len(sys.argv) != 3:
+        print("usage: python-runner <module-path> <handler>", file=sys.stderr)
+        return 64
+
+    raw = sys.stdin.buffer.read()
+    request = json.loads(raw.decode("utf-8")) if raw.strip() else {}
+    handler = _load_handler(sys.argv[1], sys.argv[2])
+
+    original_stdout = sys.stdout
+    sys.stdout = sys.stderr
+    try:
+        result = handler(request)
+        if inspect.isawaitable(result):
+            result = asyncio.run(result)
+    finally:
+        sys.stdout = original_stdout
+
+    response = _normalize_response(result)
+    json.dump(response, original_stdout, separators=(",", ":"))
+    original_stdout.write("\n")
+    original_stdout.flush()
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception:
+        traceback.print_exc(file=sys.stderr)
+        raise SystemExit(1)
+`
+
+func main() {
+	if len(os.Args) != 3 {
+		fmt.Fprintln(os.Stderr, "usage: python-runner <module-path> <handler>")
+		os.Exit(64)
+	}
+
+	pythonPath, err := osexec.LookPath("python3")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "python3 not found in PATH")
+		os.Exit(127)
+	}
+
+	args := []string{pythonPath, "-c", pythonBootstrap, os.Args[1], os.Args[2]}
+	env := append(os.Environ(), "PYTHONUNBUFFERED=1")
+	if err := syscall.Exec(pythonPath, args, env); err != nil {
+		fmt.Fprintf(os.Stderr, "exec python3: %v\n", err)
+		os.Exit(127)
+	}
+}

--- a/manager/cmd/python-runner/main_test.go
+++ b/manager/cmd/python-runner/main_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	osexec "os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPythonBootstrapInvokesHandler(t *testing.T) {
+	if _, err := osexec.LookPath("python3"); err != nil {
+		t.Skip("python3 not available")
+	}
+
+	modulePath := filepath.Join(t.TempDir(), "main.py")
+	if err := os.WriteFile(modulePath, []byte(`
+def handler(request):
+    print("log line")
+    return {
+        "status": 201,
+        "headers": {"x-value": "ok"},
+        "body": {"path": request["path"]},
+    }
+`), 0o644); err != nil {
+		t.Fatalf("write module: %v", err)
+	}
+
+	cmd := osexec.Command("python3", "-c", pythonBootstrap, modulePath, "handler")
+	cmd.Stdin = strings.NewReader(`{"path":"/hello"}`)
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("run bootstrap: %v", err)
+	}
+
+	var response struct {
+		Status     int                 `json:"status"`
+		Headers    map[string][]string `json:"headers"`
+		BodyBase64 string              `json:"body_base64"`
+	}
+	if err := json.Unmarshal(out, &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Status != 201 {
+		t.Fatalf("status = %d, want 201", response.Status)
+	}
+	if got := response.Headers["x-value"]; len(got) != 1 || got[0] != "ok" {
+		t.Fatalf("headers[x-value] = %#v, want [ok]", got)
+	}
+
+	body, err := base64.StdEncoding.DecodeString(response.BodyBase64)
+	if err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if string(body) != `{"path":"/hello"}` {
+		t.Fatalf("body = %q, want JSON path response", string(body))
+	}
+}
+
+func TestPythonBootstrapSupportsModuleDirectoryImports(t *testing.T) {
+	if _, err := osexec.LookPath("python3"); err != nil {
+		t.Skip("python3 not available")
+	}
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "helper.py"), []byte(`
+def message():
+    return "from helper"
+`), 0o644); err != nil {
+		t.Fatalf("write helper: %v", err)
+	}
+	modulePath := filepath.Join(dir, "main.py")
+	if err := os.WriteFile(modulePath, []byte(`
+import helper
+
+def handler(request):
+    return [helper.message()]
+`), 0o644); err != nil {
+		t.Fatalf("write module: %v", err)
+	}
+
+	cmd := osexec.Command("python3", "-c", pythonBootstrap, modulePath, "handler")
+	cmd.Stdin = strings.NewReader(`{}`)
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("run bootstrap: %v", err)
+	}
+
+	var response struct {
+		Headers    map[string][]string `json:"headers"`
+		BodyBase64 string              `json:"body_base64"`
+	}
+	if err := json.Unmarshal(out, &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got := response.Headers["content-type"]; len(got) != 1 || got[0] != "application/json" {
+		t.Fatalf("headers[content-type] = %#v, want [application/json]", got)
+	}
+	body, err := base64.StdEncoding.DecodeString(response.BodyBase64)
+	if err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if string(body) != `["from helper"]` {
+		t.Fatalf("body = %q, want helper response", string(body))
+	}
+}
+
+func TestPythonBootstrapFailureExitsNonZero(t *testing.T) {
+	if _, err := osexec.LookPath("python3"); err != nil {
+		t.Skip("python3 not available")
+	}
+
+	modulePath := filepath.Join(t.TempDir(), "main.py")
+	if err := os.WriteFile(modulePath, []byte(`
+def handler(request):
+    raise RuntimeError("boom")
+`), 0o644); err != nil {
+		t.Fatalf("write module: %v", err)
+	}
+
+	cmd := osexec.Command("python3", "-c", pythonBootstrap, modulePath, "handler")
+	cmd.Stdin = strings.NewReader(`{}`)
+	out, err := cmd.Output()
+	if err == nil {
+		t.Fatal("expected non-zero exit")
+	}
+	if len(out) != 0 {
+		t.Fatalf("stdout = %q, want empty stdout on failure", string(out))
+	}
+}

--- a/manager/pkg/apis/sandbox0/v1alpha1/helpers.go
+++ b/manager/pkg/apis/sandbox0/v1alpha1/helpers.go
@@ -290,7 +290,7 @@ func buildContainer(spec *ContainerSpec, template *SandboxTemplate) corev1.Conta
 	})
 	container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
 		Name:      procdBinVolumeName,
-		MountPath: "/procd/bin",
+		MountPath: "/procd",
 	})
 
 	// Security context
@@ -442,12 +442,12 @@ func applyProcdInit(spec *corev1.PodSpec) {
 		Command: []string{
 			"/bin/sh",
 			"-c",
-			"cp /usr/local/bin/procd /procd/bin/procd && chmod 0755 /procd/bin/procd",
+			"mkdir -p /procd/bin /procd/runtimes && cp /usr/local/bin/procd /procd/bin/procd && cp /usr/local/bin/python-runner /procd/runtimes/python-runner && chmod 0755 /procd/bin/procd /procd/runtimes/python-runner",
 		},
 		VolumeMounts: []corev1.VolumeMount{
 			{
 				Name:      procdBinVolumeName,
-				MountPath: "/procd/bin",
+				MountPath: "/procd",
 			},
 		},
 	})

--- a/manager/pkg/apis/sandbox0/v1alpha1/helpers_test.go
+++ b/manager/pkg/apis/sandbox0/v1alpha1/helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/sandbox0-ai/sandbox0/pkg/volumeportal"
@@ -128,6 +129,36 @@ manager_image: sandbox0/manager:test
 	}
 	if main.SecurityContext.Privileged != nil && *main.SecurityContext.Privileged {
 		t.Fatalf("expected ordinary sandbox to remain non-privileged, got %#v", main.SecurityContext)
+	}
+}
+
+func TestBuildPodSpecInjectsProcdRuntimeBinaries(t *testing.T) {
+	configPath := writeManagerConfig(t, `
+manager_image: sandbox0/manager:test
+`)
+	t.Setenv("CONFIG_PATH", configPath)
+
+	spec := BuildPodSpec(newTestTemplate())
+	if len(spec.InitContainers) == 0 {
+		t.Fatal("expected procd init container")
+	}
+	init := spec.InitContainers[0]
+	if init.Name != "procd-init" {
+		t.Fatalf("init container name = %q, want procd-init", init.Name)
+	}
+	if got := strings.Join(init.Command, " "); !strings.Contains(got, "/usr/local/bin/python-runner") || !strings.Contains(got, "/procd/runtimes/python-runner") {
+		t.Fatalf("init command = %q, want python-runner injection", got)
+	}
+	if mount := findVolumeMount(init.VolumeMounts, procdBinVolumeName); mount == nil || mount.MountPath != "/procd" {
+		t.Fatalf("init procd mount = %#v, want /procd", mount)
+	}
+
+	main := spec.Containers[0]
+	if mount := findVolumeMount(main.VolumeMounts, procdBinVolumeName); mount == nil || mount.MountPath != "/procd" {
+		t.Fatalf("main procd mount = %#v, want /procd", mount)
+	}
+	if len(main.Command) != 1 || main.Command[0] != "/procd/bin/procd" {
+		t.Fatalf("main command = %#v, want /procd/bin/procd", main.Command)
 	}
 }
 

--- a/manager/procd/pkg/http/handlers/function.go
+++ b/manager/procd/pkg/http/handlers/function.go
@@ -1,0 +1,366 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	osexec "os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
+	"go.uber.org/zap"
+)
+
+const (
+	defaultFunctionRoot       = "/workspace/functions"
+	defaultFunctionRunnerPath = "/procd/runtimes/python-runner"
+	defaultFunctionTimeout    = 30 * time.Second
+	maxFunctionTimeout        = 120 * time.Second
+	maxFunctionRequestBytes   = 8 << 20
+	maxFunctionStdoutBytes    = 4 << 20
+	maxFunctionStderrBytes    = 64 << 10
+)
+
+var (
+	functionNamePattern    = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+	functionHandlerPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$`)
+)
+
+type functionHandlerConfig struct {
+	runnerPath     string
+	functionRoot   string
+	defaultTimeout time.Duration
+	maxTimeout     time.Duration
+}
+
+// FunctionHandler invokes sandbox functions through platform-provided runtimes.
+type FunctionHandler struct {
+	logger         *zap.Logger
+	runnerPath     string
+	functionRoot   string
+	defaultTimeout time.Duration
+	maxTimeout     time.Duration
+}
+
+// FunctionInvokeRequest is passed to the sandbox function handler.
+type FunctionInvokeRequest struct {
+	Method     string              `json:"method,omitempty"`
+	Path       string              `json:"path,omitempty"`
+	Query      map[string][]string `json:"query,omitempty"`
+	Headers    map[string][]string `json:"headers,omitempty"`
+	BodyBase64 string              `json:"body_base64,omitempty"`
+	Handler    string              `json:"handler,omitempty"`
+	TimeoutMS  int                 `json:"timeout_ms,omitempty"`
+}
+
+// FunctionInvokeResponse is returned by the sandbox function handler.
+type FunctionInvokeResponse struct {
+	Status     int                 `json:"status"`
+	Headers    map[string][]string `json:"headers,omitempty"`
+	BodyBase64 string              `json:"body_base64,omitempty"`
+}
+
+// NewFunctionHandler creates a function invocation handler.
+func NewFunctionHandler(logger *zap.Logger) *FunctionHandler {
+	return newFunctionHandler(functionHandlerConfig{}, logger)
+}
+
+func newFunctionHandler(config functionHandlerConfig, logger *zap.Logger) *FunctionHandler {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	if config.runnerPath == "" {
+		config.runnerPath = defaultFunctionRunnerPath
+	}
+	if config.functionRoot == "" {
+		config.functionRoot = defaultFunctionRoot
+	}
+	if config.defaultTimeout <= 0 {
+		config.defaultTimeout = defaultFunctionTimeout
+	}
+	if config.maxTimeout <= 0 {
+		config.maxTimeout = maxFunctionTimeout
+	}
+	return &FunctionHandler{
+		logger:         logger,
+		runnerPath:     config.runnerPath,
+		functionRoot:   filepath.Clean(config.functionRoot),
+		defaultTimeout: config.defaultTimeout,
+		maxTimeout:     config.maxTimeout,
+	}
+}
+
+// Invoke executes /workspace/functions/{name}.py with the requested handler.
+func (h *FunctionHandler) Invoke(w http.ResponseWriter, r *http.Request) {
+	functionName := mux.Vars(r)["name"]
+	modulePath, err := h.modulePath(functionName)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
+		return
+	}
+	if _, err := os.Stat(modulePath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			writeError(w, http.StatusNotFound, spec.CodeNotFound, "function not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, spec.CodeInternal, "function module unavailable")
+		return
+	}
+	if _, err := os.Stat(h.runnerPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			writeError(w, http.StatusServiceUnavailable, spec.CodeUnavailable, "function runtime unavailable")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, spec.CodeInternal, "function runtime unavailable")
+		return
+	}
+
+	req, err := decodeFunctionInvokeRequest(r.Body)
+	if err != nil {
+		if errors.Is(err, errFunctionRequestTooLarge) {
+			writeError(w, http.StatusRequestEntityTooLarge, "request_too_large", "function request is too large")
+			return
+		}
+		writeError(w, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
+		return
+	}
+	h.applyRequestDefaults(&req)
+	if err := validateFunctionRequest(req); err != nil {
+		writeError(w, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
+		return
+	}
+
+	timeout, err := h.requestTimeout(req.TimeoutMS)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
+		return
+	}
+
+	payload, err := json.Marshal(req)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, spec.CodeInternal, "failed to encode function request")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), timeout)
+	defer cancel()
+
+	stdout, stderr, truncated, err := h.run(ctx, modulePath, req.Handler, payload)
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		writeError(w, http.StatusGatewayTimeout, spec.CodeUnavailable, "function invocation timed out")
+		return
+	}
+	if truncated.stdout {
+		writeError(w, http.StatusBadGateway, spec.CodeUnavailable, "function response is too large")
+		return
+	}
+	if err != nil {
+		message := strings.TrimSpace(stderr)
+		if message == "" {
+			message = err.Error()
+		}
+		if truncated.stderr {
+			message += "\n[stderr truncated]"
+		}
+		h.logger.Warn("Function invocation failed",
+			zap.String("function", functionName),
+			zap.String("handler", req.Handler),
+			zap.Error(err),
+		)
+		writeError(w, http.StatusInternalServerError, "function_failed", message)
+		return
+	}
+
+	response, err := decodeFunctionInvokeResponse(stdout)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, spec.CodeUnavailable, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, response)
+}
+
+func (h *FunctionHandler) modulePath(name string) (string, error) {
+	if !functionNamePattern.MatchString(name) {
+		return "", fmt.Errorf("function name must match %s", functionNamePattern.String())
+	}
+	root := filepath.Clean(h.functionRoot)
+	modulePath := filepath.Join(root, name+".py")
+	rel, err := filepath.Rel(root, modulePath)
+	if err != nil || strings.HasPrefix(rel, "..") || filepath.IsAbs(rel) {
+		return "", errors.New("function path escapes function root")
+	}
+	return modulePath, nil
+}
+
+func (h *FunctionHandler) applyRequestDefaults(req *FunctionInvokeRequest) {
+	req.Method = strings.ToUpper(strings.TrimSpace(req.Method))
+	if req.Method == "" {
+		req.Method = http.MethodPost
+	}
+	req.Path = strings.TrimSpace(req.Path)
+	if req.Path == "" {
+		req.Path = "/"
+	}
+	req.Handler = strings.TrimSpace(req.Handler)
+	if req.Handler == "" {
+		req.Handler = "handler"
+	}
+}
+
+func (h *FunctionHandler) requestTimeout(timeoutMS int) (time.Duration, error) {
+	if timeoutMS == 0 {
+		return h.defaultTimeout, nil
+	}
+	if timeoutMS < 0 {
+		return 0, errors.New("timeout_ms must be >= 0")
+	}
+	timeout := time.Duration(timeoutMS) * time.Millisecond
+	if timeout > h.maxTimeout {
+		return 0, fmt.Errorf("timeout_ms must be <= %d", int(h.maxTimeout/time.Millisecond))
+	}
+	return timeout, nil
+}
+
+type functionRunTruncation struct {
+	stdout bool
+	stderr bool
+}
+
+func (h *FunctionHandler) run(ctx context.Context, modulePath, handler string, payload []byte) ([]byte, string, functionRunTruncation, error) {
+	cmd := osexec.CommandContext(ctx, h.runnerPath, modulePath, handler)
+	cmd.Dir = filepath.Dir(h.functionRoot)
+	cmd.Stdin = bytes.NewReader(payload)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
+			return cmd.Process.Kill()
+		}
+		return nil
+	}
+	cmd.WaitDelay = 5 * time.Second
+
+	stdout := newLimitedBuffer(maxFunctionStdoutBytes)
+	stderr := newLimitedBuffer(maxFunctionStderrBytes)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+
+	err := cmd.Run()
+	return stdout.Bytes(), stderr.String(), functionRunTruncation{
+		stdout: stdout.Truncated(),
+		stderr: stderr.Truncated(),
+	}, err
+}
+
+var errFunctionRequestTooLarge = errors.New("function request too large")
+
+func decodeFunctionInvokeRequest(body io.Reader) (FunctionInvokeRequest, error) {
+	limited := io.LimitReader(body, maxFunctionRequestBytes+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return FunctionInvokeRequest{}, err
+	}
+	if len(data) > maxFunctionRequestBytes {
+		return FunctionInvokeRequest{}, errFunctionRequestTooLarge
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return FunctionInvokeRequest{}, nil
+	}
+
+	var req FunctionInvokeRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		return FunctionInvokeRequest{}, fmt.Errorf("invalid request body: %w", err)
+	}
+	return req, nil
+}
+
+func validateFunctionRequest(req FunctionInvokeRequest) error {
+	if req.BodyBase64 != "" {
+		if _, err := base64.StdEncoding.DecodeString(req.BodyBase64); err != nil {
+			return errors.New("body_base64 must be valid base64")
+		}
+	}
+	if !strings.HasPrefix(req.Path, "/") {
+		return errors.New("path must start with /")
+	}
+	if !functionHandlerPattern.MatchString(req.Handler) {
+		return fmt.Errorf("handler must match %s", functionHandlerPattern.String())
+	}
+	return nil
+}
+
+func decodeFunctionInvokeResponse(data []byte) (FunctionInvokeResponse, error) {
+	if len(bytes.TrimSpace(data)) == 0 {
+		return FunctionInvokeResponse{}, errors.New("function returned an empty response")
+	}
+
+	var response FunctionInvokeResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return FunctionInvokeResponse{}, fmt.Errorf("function returned invalid JSON: %w", err)
+	}
+	if response.Status == 0 {
+		response.Status = http.StatusOK
+	}
+	if response.Status < 100 || response.Status > 599 {
+		return FunctionInvokeResponse{}, errors.New("function response status must be between 100 and 599")
+	}
+	if response.BodyBase64 != "" {
+		if _, err := base64.StdEncoding.DecodeString(response.BodyBase64); err != nil {
+			return FunctionInvokeResponse{}, errors.New("function response body_base64 must be valid base64")
+		}
+	}
+	if response.Headers == nil {
+		response.Headers = map[string][]string{}
+	}
+	return response, nil
+}
+
+type limitedBuffer struct {
+	buf       bytes.Buffer
+	limit     int
+	truncated bool
+}
+
+func newLimitedBuffer(limit int) *limitedBuffer {
+	return &limitedBuffer{limit: limit}
+}
+
+func (b *limitedBuffer) Write(p []byte) (int, error) {
+	remaining := b.limit - b.buf.Len()
+	if remaining > 0 {
+		if len(p) <= remaining {
+			_, _ = b.buf.Write(p)
+		} else {
+			_, _ = b.buf.Write(p[:remaining])
+			b.truncated = true
+		}
+	} else if len(p) > 0 {
+		b.truncated = true
+	}
+	return len(p), nil
+}
+
+func (b *limitedBuffer) Bytes() []byte {
+	return b.buf.Bytes()
+}
+
+func (b *limitedBuffer) String() string {
+	return b.buf.String()
+}
+
+func (b *limitedBuffer) Truncated() bool {
+	return b.truncated
+}

--- a/manager/procd/pkg/http/handlers/function_test.go
+++ b/manager/procd/pkg/http/handlers/function_test.go
@@ -1,0 +1,130 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
+	"go.uber.org/zap"
+)
+
+func TestFunctionInvokeRunsConfiguredRunner(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "functions")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("create root: %v", err)
+	}
+	modulePath := filepath.Join(root, "main.py")
+	if err := os.WriteFile(modulePath, []byte("def handler(request):\n    return None\n"), 0o644); err != nil {
+		t.Fatalf("write module: %v", err)
+	}
+
+	runnerPath := filepath.Join(t.TempDir(), "python-runner")
+	if err := os.WriteFile(runnerPath, []byte(`#!/bin/sh
+if [ "$1" != "$FUNCTION_MODULE" ]; then
+  echo "unexpected module: $1" >&2
+  exit 7
+fi
+if [ "$2" != "custom_handler" ]; then
+  echo "unexpected handler: $2" >&2
+  exit 8
+fi
+cat >/dev/null
+printf '{"status":202,"headers":{"x-runner":["ok"]},"body_base64":"b2s="}\n'
+`), 0o755); err != nil {
+		t.Fatalf("write runner: %v", err)
+	}
+	t.Setenv("FUNCTION_MODULE", modulePath)
+
+	handler := newTestFunctionHandler(root, runnerPath)
+	rec := invokeFunction(t, handler, "main", `{"path":"/hello","handler":"custom_handler"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+
+	response, apiErr, err := spec.DecodeResponse[FunctionInvokeResponse](rec.Body)
+	if err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if apiErr != nil {
+		t.Fatalf("api error: %v", apiErr)
+	}
+	if response.Status != 202 {
+		t.Fatalf("function status = %d, want 202", response.Status)
+	}
+	if got := response.Headers["x-runner"]; len(got) != 1 || got[0] != "ok" {
+		t.Fatalf("x-runner = %#v, want [ok]", got)
+	}
+	if response.BodyBase64 != "b2s=" {
+		t.Fatalf("body_base64 = %q, want b2s=", response.BodyBase64)
+	}
+}
+
+func TestFunctionInvokeRejectsInvalidFunctionName(t *testing.T) {
+	handler := newTestFunctionHandler(t.TempDir(), filepath.Join(t.TempDir(), "python-runner"))
+	rec := invokeFunction(t, handler, "main.py", `{}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestFunctionInvokeReturnsRunnerFailure(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "functions")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("create root: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "main.py"), []byte("def handler(request):\n    return None\n"), 0o644); err != nil {
+		t.Fatalf("write module: %v", err)
+	}
+
+	runnerPath := filepath.Join(t.TempDir(), "python-runner")
+	if err := os.WriteFile(runnerPath, []byte(`#!/bin/sh
+echo "boom" >&2
+exit 42
+`), 0o755); err != nil {
+		t.Fatalf("write runner: %v", err)
+	}
+
+	handler := newTestFunctionHandler(root, runnerPath)
+	rec := invokeFunction(t, handler, "main", `{}`)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "boom") {
+		t.Fatalf("body = %s, want runner stderr", rec.Body.String())
+	}
+}
+
+func TestDecodeFunctionInvokeResponseDefaultsStatus(t *testing.T) {
+	response, err := decodeFunctionInvokeResponse([]byte(`{"body_base64":"b2s="}`))
+	if err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Status != http.StatusOK {
+		t.Fatalf("status = %d, want 200", response.Status)
+	}
+}
+
+func newTestFunctionHandler(root, runner string) *FunctionHandler {
+	return newFunctionHandler(functionHandlerConfig{
+		functionRoot:   root,
+		runnerPath:     runner,
+		defaultTimeout: time.Second,
+		maxTimeout:     time.Second,
+	}, zap.NewNop())
+}
+
+func invokeFunction(t *testing.T, handler *FunctionHandler, name string, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/functions/"+name+"/invoke", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	router := mux.NewRouter()
+	router.HandleFunc("/api/v1/functions/{name}/invoke", handler.Invoke).Methods(http.MethodPost)
+	router.ServeHTTP(rec, req)
+	return rec
+}

--- a/manager/procd/pkg/http/server.go
+++ b/manager/procd/pkg/http/server.go
@@ -119,6 +119,10 @@ func (s *Server) setupRoutes() {
 	api.HandleFunc("/contexts/{id}/stats", contextHandler.Stats).Methods("GET")
 	api.HandleFunc("/contexts/{id}/ws", contextHandler.WebSocket).Methods("GET")
 
+	// Function handlers
+	functionHandler := handlers.NewFunctionHandler(s.logger)
+	api.HandleFunc("/functions/{name}/invoke", functionHandler.Invoke).Methods("POST")
+
 	// Initialize handler
 	initializeHandler := handlers.NewInitializeHandler(s.webhookDispatcher, s.fileManager, s.cfg.HTTPPort, s.logger)
 	api.HandleFunc("/initialize", initializeHandler.Initialize).Methods("POST")

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -16,6 +16,7 @@ tags:
   - name: api-keys
   - name: sandboxes
   - name: contexts
+  - name: functions
   - name: files
   - name: templates
   - name: registry
@@ -1961,6 +1962,49 @@ paths:
       responses:
         "101":
           description: Switching Protocols
+  /api/v1/sandboxes/{id}/functions/{name}/invoke:
+    post:
+      tags: [functions]
+      summary: Invoke a sandbox function
+      description: Invokes /workspace/functions/{name}.py through the Python function runtime. The default handler is `handler`.
+      security:
+        - bearerAuth: []
+      x-upstream-service: procd
+      x-upstream-path: /api/v1/functions/{name}/invoke
+      parameters:
+        - $ref: "#/components/parameters/SandboxID"
+        - $ref: "#/components/parameters/FunctionName"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/FunctionInvokeRequest"
+      responses:
+        "200":
+          description: Function invocation completed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessFunctionInvokeResponse"
+        "400":
+          description: Invalid invocation request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "404":
+          description: Function not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "500":
+          description: Function invocation failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
   /api/v1/sandboxes/{id}/files/move:
     post:
       tags: [files]
@@ -2820,6 +2864,13 @@ components:
       required: true
       schema:
         type: string
+    FunctionName:
+      name: name
+      in: path
+      required: true
+      schema:
+        type: string
+        pattern: "^[A-Za-z0-9_-]+$"
     TemplateID:
       name: id
       in: path
@@ -4529,6 +4580,54 @@ components:
           type: string
           description: Raw PTY output, may contain terminal control characters (e.g. \r)
       required: [output_raw]
+    FunctionInvokeRequest:
+      type: object
+      properties:
+        method:
+          type: string
+          description: Logical request method passed to the function. Defaults to POST.
+        path:
+          type: string
+          description: Logical request path passed to the function. Defaults to /.
+        query:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: string
+        headers:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: string
+        body_base64:
+          type: string
+          description: Base64-encoded request body passed to the function.
+        handler:
+          type: string
+          description: Python handler name inside the function module. Defaults to handler.
+        timeout_ms:
+          type: integer
+          format: int32
+          description: Per-invocation timeout in milliseconds. Defaults to 30000 and must not exceed 120000.
+    FunctionInvokeResponse:
+      type: object
+      properties:
+        status:
+          type: integer
+          format: int32
+          description: Function-level HTTP-style status code.
+        headers:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: string
+        body_base64:
+          type: string
+          description: Base64-encoded function response body.
+      required: [status]
     ResizeContextRequest:
       type: object
       properties:
@@ -4578,6 +4677,14 @@ components:
           properties:
             data:
               $ref: "#/components/schemas/ContextExecResponse"
+    SuccessFunctionInvokeResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        data:
+          $ref: "#/components/schemas/FunctionInvokeResponse"
+      required: [success]
     FileInfo:
       type: object
       properties:

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -936,6 +936,36 @@ type ForkVolumeRequest struct {
 	DefaultPosixUid *int64 `json:"default_posix_uid,omitempty"`
 }
 
+// FunctionInvokeRequest defines model for FunctionInvokeRequest.
+type FunctionInvokeRequest struct {
+	// BodyBase64 Base64-encoded request body passed to the function.
+	BodyBase64 *string `json:"body_base64,omitempty"`
+
+	// Handler Python handler name inside the function module. Defaults to handler.
+	Handler *string              `json:"handler,omitempty"`
+	Headers *map[string][]string `json:"headers,omitempty"`
+
+	// Method Logical request method passed to the function. Defaults to POST.
+	Method *string `json:"method,omitempty"`
+
+	// Path Logical request path passed to the function. Defaults to /.
+	Path  *string              `json:"path,omitempty"`
+	Query *map[string][]string `json:"query,omitempty"`
+
+	// TimeoutMs Per-invocation timeout in milliseconds. Defaults to 30000 and must not exceed 120000.
+	TimeoutMs *int32 `json:"timeout_ms,omitempty"`
+}
+
+// FunctionInvokeResponse defines model for FunctionInvokeResponse.
+type FunctionInvokeResponse struct {
+	// BodyBase64 Base64-encoded function response body.
+	BodyBase64 *string              `json:"body_base64,omitempty"`
+	Headers    *map[string][]string `json:"headers,omitempty"`
+
+	// Status Function-level HTTP-style status code.
+	Status int32 `json:"status"`
+}
+
 // GatewayMetadata defines model for GatewayMetadata.
 type GatewayMetadata struct {
 	GatewayMode GatewayMetadataGatewayMode `json:"gateway_mode"`
@@ -1967,6 +1997,12 @@ type SuccessFileStatResponse struct {
 // SuccessFileStatResponseSuccess defines model for SuccessFileStatResponse.Success.
 type SuccessFileStatResponseSuccess bool
 
+// SuccessFunctionInvokeResponse defines model for SuccessFunctionInvokeResponse.
+type SuccessFunctionInvokeResponse struct {
+	Data    *FunctionInvokeResponse `json:"data,omitempty"`
+	Success bool                    `json:"success"`
+}
+
 // SuccessGatewayMetadataResponse defines model for SuccessGatewayMetadataResponse.
 type SuccessGatewayMetadataResponse struct {
 	Data    *GatewayMetadata                      `json:"data,omitempty"`
@@ -2534,6 +2570,9 @@ type ContextID = string
 // FilePath defines model for FilePath.
 type FilePath = string
 
+// FunctionName defines model for FunctionName.
+type FunctionName = string
+
 // IdentityID defines model for IdentityID.
 type IdentityID = string
 
@@ -2726,6 +2765,9 @@ type PostApiV1SandboxesIdContextsCtxIdSignalJSONRequestBody = SignalContextReque
 
 // PostApiV1SandboxesIdFilesMoveJSONRequestBody defines body for PostApiV1SandboxesIdFilesMove for application/json ContentType.
 type PostApiV1SandboxesIdFilesMoveJSONRequestBody = MoveFileRequest
+
+// PostApiV1SandboxesIdFunctionsNameInvokeJSONRequestBody defines body for PostApiV1SandboxesIdFunctionsNameInvoke for application/json ContentType.
+type PostApiV1SandboxesIdFunctionsNameInvokeJSONRequestBody = FunctionInvokeRequest
 
 // PutApiV1SandboxesIdNetworkJSONRequestBody defines body for PutApiV1SandboxesIdNetwork for application/json ContentType.
 type PutApiV1SandboxesIdNetworkJSONRequestBody = SandboxNetworkPolicy


### PR DESCRIPTION
## Summary
- add an injected `/procd/runtimes/python-runner` binary and procd function invoke handler
- expose `POST /api/v1/sandboxes/{id}/functions/{name}/invoke` through cluster-gateway
- update OpenAPI, generated API types, pod injection, Docker/Make builds, and docs

## Tests
- `GOWORK=off go test ./manager/cmd/python-runner ./manager/procd/pkg/http/handlers ./manager/pkg/apis/sandbox0/v1alpha1 ./cluster-gateway/pkg/http`
- remote kind deploy with `sandbox0ai/infra:latest` from this branch
- remote API smoke: claim sandbox, write `/workspace/functions/main.py`, invoke function, got `{"message":"hello Ada","method":"POST","path":"/hello"}`
- remote pod check: `/procd/bin/procd` and `/procd/runtimes/python-runner` executable, `python3` on PATH