### PR TITLE
Fix netd CNI chain priority

### DIFF
--- a/.github/workflows/netd-cni-e2e.yml
+++ b/.github/workflows/netd-cni-e2e.yml
@@ -1,0 +1,98 @@
+name: Netd CNI E2E
+
+on:
+  pull_request:
+    paths:
+      - ".github/actions/**"
+      - ".github/workflows/netd-cni-e2e.yml"
+      - "Dockerfile"
+      - "Dockerfile.local"
+      - "Makefile"
+      - "manager/**"
+      - "netd/**"
+      - "pkg/**"
+      - "tests/e2e/**"
+      - "go.mod"
+      - "go.sum"
+  workflow_dispatch:
+
+concurrency:
+  group: netd-cni-e2e-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  netd-cni:
+    name: netd (${{ matrix.cni }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 50
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - cni: kindnet
+            short: kindnet
+            kind_config: tests/e2e/kind-config.yaml
+            install_cni: "false"
+          - cni: flannel
+            short: flannel
+            kind_config: tests/e2e/kind-config-no-cni.yaml
+            install_cni: "true"
+          - cni: canal
+            short: canal
+            kind_config: tests/e2e/kind-config-no-cni.yaml
+            install_cni: "true"
+          - cni: cilium-native-host-legacy
+            short: cilium
+            kind_config: tests/e2e/kind-config-no-cni.yaml
+            install_cni: "true"
+    env:
+      KIND_CLUSTER_NAME: sandbox0-netd-${{ matrix.short }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Prepare infra environment
+        uses: ./.github/actions/prepare-infra
+        with:
+          infra-dir: .
+          kind-config: ${{ matrix.kind_config }}
+          kind-cluster-name: ${{ env.KIND_CLUSTER_NAME }}
+          cache-key-suffix: netd-cni-${{ matrix.short }}
+
+      - name: Install CNI
+        if: matrix.install_cni == 'true'
+        shell: bash
+        run: bash tests/e2e/cni/install.sh "${{ matrix.cni }}"
+
+      - name: Run netd CNI E2E
+        env:
+          E2E_USE_EXISTING_CLUSTER: "true"
+          E2E_CLUSTER_NAME: ${{ env.KIND_CLUSTER_NAME }}
+        run: make test-e2e-netd-cni
+
+      - name: Dump cluster state on failure
+        if: failure()
+        shell: bash
+        run: |
+          echo "=== nodes ==="
+          kubectl get nodes -o wide || true
+          echo "=== pods ==="
+          kubectl get pods -A -o wide || true
+          echo "=== netd logs ==="
+          kubectl -n sandbox0-system logs -l app.kubernetes.io/name=netd --all-containers --tail=-1 || true
+          echo "=== sandbox0-system events ==="
+          kubectl -n sandbox0-system get events --sort-by=.lastTimestamp || true
+          kind export logs "${RUNNER_TEMP}/kind-logs-${{ matrix.short }}" --name "${KIND_CLUSTER_NAME}" || true
+
+      - name: Upload kind logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: netd-cni-e2e-kind-logs-${{ matrix.short }}
+          path: ${{ runner.temp }}/kind-logs-${{ matrix.short }}
+          if-no-files-found: ignore
+
+      - name: Cleanup Kind cluster
+        if: always()
+        run: kind delete cluster --name "${KIND_CLUSTER_NAME}" || true

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build test test-all test-integration test-integration-verbose test-e2e test-e2e-kind test-e2e-destroy test-e2e-load-images test-e2e-prepare-kind test-e2e-specific lint tidy vendor clean helm-update helm-configs release docker-build docker-build-local build-local-all docker-push proto manifests apispec oapi-codegen
+.PHONY: all build test test-all test-integration test-integration-verbose test-e2e test-e2e-kind test-e2e-destroy test-e2e-load-images test-e2e-prepare-kind test-e2e-specific test-e2e-netd-cni lint tidy vendor clean helm-update helm-configs release docker-build docker-build-local build-local-all docker-push proto manifests apispec oapi-codegen
 
 # Tool Binaries
 LOCALBIN ?= $(shell pwd)/bin
@@ -204,6 +204,10 @@ test-e2e-specific:
 	fi
 	@printf "$(CYAN)Running E2E test: $(SPEC)...$(RESET)\n"
 	unset http_proxy && unset https_proxy && unset all_proxy && $(GO) test -v ./tests/e2e/... -focus="$(SPEC)" -timeout=30m
+
+test-e2e-netd-cni:
+	@printf "$(CYAN)Running netd CNI E2E test...$(RESET)\n"
+	unset http_proxy && unset https_proxy && unset all_proxy && E2E_SINGLE_CLUSTER_SCENARIOS=network-policy $(GO) test -v -count=1 ./tests/e2e/scenarios/single-cluster -run TestSingleCluster -ginkgo.focus="API network policy mode.*enforces transparent TCP egress through netd" -timeout=30m
 
 # Prevent make from treating service names as targets
 regional-gateway ssh-gateway global-gateway cluster-gateway manager scheduler storage-proxy ctld procd netd infra-operator:

--- a/netd/pkg/redirect/manager.go
+++ b/netd/pkg/redirect/manager.go
@@ -24,7 +24,18 @@ const (
 type iptablesManager struct {
 	cfg    Config
 	logger *zap.Logger
-	ipt    *iptables.IPTables
+	ipt    iptablesClient
+}
+
+type iptablesClient interface {
+	ChainExists(table, chain string) (bool, error)
+	ClearChain(table, chain string) error
+	DeleteById(table, chain string, id int) error
+	DeleteChain(table, chain string) error
+	DeleteIfExists(table, chain string, rulespec ...string) error
+	Insert(table, chain string, pos int, rulespec ...string) error
+	List(table, chain string) ([]string, error)
+	NewChain(table, chain string) error
 }
 
 func NewManager(cfg Config, logger *zap.Logger) Manager {
@@ -35,10 +46,14 @@ func NewManager(cfg Config, logger *zap.Logger) Manager {
 	if err != nil {
 		logger.Error("Failed to initialize iptables", zap.Error(err))
 	}
+	var iptClient iptablesClient
+	if ipt != nil {
+		iptClient = ipt
+	}
 	return &iptablesManager{
 		cfg:    cfg,
 		logger: logger,
-		ipt:    ipt,
+		ipt:    iptClient,
 	}
 }
 
@@ -65,13 +80,10 @@ func (m *iptablesManager) Sync(ctx context.Context, sandboxIPs []string, bypassC
 	if err := m.ensureJump(ctx); err != nil {
 		return err
 	}
-	if err := m.ensureNATBypassChain(ctx); err != nil {
+	if err := m.ensureNATChain(ctx); err != nil {
 		return err
 	}
-	if err := m.ensureNATBypassJump(ctx); err != nil {
-		return err
-	}
-	if err := m.syncNATBypassChain(ctx); err != nil {
+	if err := m.ensureNATJump(ctx); err != nil {
 		return err
 	}
 	if err := m.syncIPSet(ctx, normalizeIPs(sandboxIPs)); err != nil {
@@ -85,6 +97,12 @@ func (m *iptablesManager) Sync(ctx context.Context, sandboxIPs []string, bypassC
 	cmd.Stdin = strings.NewReader(restoreInput)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("iptables-restore failed: %s: %w", string(out), err)
+	}
+	if err := m.ensureJump(ctx); err != nil {
+		return err
+	}
+	if err := m.ensureNATJump(ctx); err != nil {
+		return err
 	}
 
 	m.logger.Info("Iptables sync complete")
@@ -130,18 +148,10 @@ func (m *iptablesManager) ensureCustomChain(ctx context.Context) error {
 }
 
 func (m *iptablesManager) ensureJump(ctx context.Context) error {
-	_ = ctx
-	exists, err := m.ipt.Exists(mangleTable, "PREROUTING", "-j", chainName)
-	if err != nil {
-		return err
-	}
-	if exists {
-		return nil
-	}
-	return m.ipt.Append(mangleTable, "PREROUTING", "-j", chainName)
+	return m.ensureTopJump(ctx, mangleTable, "PREROUTING", chainName)
 }
 
-func (m *iptablesManager) ensureNATBypassChain(ctx context.Context) error {
+func (m *iptablesManager) ensureNATChain(ctx context.Context) error {
 	_ = ctx
 	exists, err := m.ipt.ChainExists(natTable, natChainName)
 	if err != nil {
@@ -153,18 +163,36 @@ func (m *iptablesManager) ensureNATBypassChain(ctx context.Context) error {
 	return m.ipt.NewChain(natTable, natChainName)
 }
 
-func (m *iptablesManager) ensureNATBypassJump(ctx context.Context) error {
-	_ = ctx
-	_ = m.ipt.DeleteIfExists(natTable, "PREROUTING", "-j", natChainName)
-	return m.ipt.Insert(natTable, "PREROUTING", 1, "-j", natChainName)
+func (m *iptablesManager) ensureNATJump(ctx context.Context) error {
+	return m.ensureTopJump(ctx, natTable, "PREROUTING", natChainName)
 }
 
-func (m *iptablesManager) syncNATBypassChain(ctx context.Context) error {
+func (m *iptablesManager) ensureTopJump(ctx context.Context, table, chain, target string) error {
 	_ = ctx
-	if err := m.ipt.ClearChain(natTable, natChainName); err != nil {
+	rules, err := m.ipt.List(table, chain)
+	if err != nil {
 		return err
 	}
-	return m.ipt.Append(natTable, natChainName, natBypassRuleSpec()...)
+	jumpLines := jumpRuleLineNumbers(rules, chain, target)
+	if len(jumpLines) == 0 || jumpLines[0] != 1 {
+		if err := m.ipt.Insert(table, chain, 1, "-j", target); err != nil {
+			return err
+		}
+		rules, err = m.ipt.List(table, chain)
+		if err != nil {
+			return err
+		}
+		jumpLines = jumpRuleLineNumbers(rules, chain, target)
+	}
+	if len(jumpLines) == 0 || jumpLines[0] != 1 {
+		return fmt.Errorf("ensure %s/%s jump to %s at line 1", table, chain, target)
+	}
+	for i := len(jumpLines) - 1; i >= 1; i-- {
+		if err := m.ipt.DeleteById(table, chain, jumpLines[i]); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (m *iptablesManager) flushCustomChain(ctx context.Context) error {
@@ -238,6 +266,32 @@ func localRouteExists(routes []netlink.Route) bool {
 			continue
 		}
 		if route.Dst.String() == "0.0.0.0/0" && route.Type == unix.RTN_LOCAL {
+			return true
+		}
+	}
+	return false
+}
+
+func jumpRuleLineNumbers(rules []string, chain, target string) []int {
+	lines := []int{}
+	ruleLine := 0
+	for _, rule := range rules {
+		fields := strings.Fields(rule)
+		if len(fields) < 4 || fields[0] != "-A" || fields[1] != chain {
+			continue
+		}
+		ruleLine++
+		if !ruleJumpsTo(fields, target) {
+			continue
+		}
+		lines = append(lines, ruleLine)
+	}
+	return lines
+}
+
+func ruleJumpsTo(fields []string, target string) bool {
+	for i := 2; i < len(fields)-1; i++ {
+		if fields[i] == "-j" && fields[i+1] == target {
 			return true
 		}
 	}

--- a/netd/pkg/redirect/manager_test.go
+++ b/netd/pkg/redirect/manager_test.go
@@ -3,6 +3,8 @@
 package redirect
 
 import (
+	"context"
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -19,26 +21,37 @@ func TestBuildIPTablesRestoreInputRoutesSpecificAndGenericTraffic(t *testing.T) 
 	mustContain(t, restore, "-A "+chainName+" -d 10.0.0.0/8 -j RETURN")
 	mustContain(t, restore, "-A "+chainName+" -d 192.168.0.0/16 -j RETURN")
 
-	mustContain(t, restore, "-p tcp --dport 443 -m conntrack --ctstate NEW -j TPROXY --on-port 18443")
-	mustContain(t, restore, "-p tcp --dport 443 -m connmark --mark 0x1/0x1 -j TPROXY --on-port 18443")
-	mustContain(t, restore, "-p tcp --dport 443 -m conntrack --ctstate NEW -j CONNMARK --set-mark 0x1/0x1")
-	mustContain(t, restore, "-p tcp --dport 853 -m socket --transparent -j TPROXY --on-port 18443")
+	mustContain(t, restore, "-i cali+ -m set --match-set "+ipsetName+" src -p tcp --dport 443 -m conntrack --ctstate NEW -j TPROXY --on-port 18443")
+	mustContain(t, restore, "-i cali+ -m set --match-set "+ipsetName+" src -p tcp --dport 443 -m connmark --mark 0x1/0x1 -j TPROXY --on-port 18443")
+	mustContain(t, restore, "-i cali+ -m set --match-set "+ipsetName+" src -p tcp --dport 853 -m socket --transparent -j TPROXY --on-port 18443")
+	mustContain(t, restore, "-i cali+ -m set --match-set "+ipsetName+" src -p tcp -m conntrack --ctstate NEW -j TPROXY --on-port 18080")
+	mustContain(t, restore, "-i cali+ -m set --match-set "+ipsetName+" src -p tcp -m connmark --mark 0x1/0x1 -j TPROXY --on-port 18080")
+	mustContain(t, restore, "-i cali+ -m set --match-set "+ipsetName+" src -p tcp -m socket --transparent -j TPROXY --on-port 18080")
+	mustContain(t, restore, "-i lxc+ -m set --match-set "+ipsetName+" src -p tcp --dport 443 -m conntrack --ctstate NEW -j TPROXY --on-port 18443")
+	mustContain(t, restore, "-i lxc+ -m set --match-set "+ipsetName+" src -p tcp --dport 853 -m socket --transparent -j TPROXY --on-port 18443")
+	mustContain(t, restore, "-i lxc+ -m set --match-set "+ipsetName+" src -p tcp -m conntrack --ctstate NEW -j TPROXY --on-port 18080")
+	mustContain(t, restore, "-i lxc+ -m set --match-set "+ipsetName+" src -p tcp -m socket --transparent -j TPROXY --on-port 18080")
 	mustContain(t, restore, "-p udp --dport 443 -m conntrack --ctstate NEW -j TPROXY --on-port 18443")
 	mustContain(t, restore, "-p udp --dport 443 -m connmark --mark 0x1/0x1 -j TPROXY --on-port 18443")
 	mustContain(t, restore, "-p udp --dport 443 -m conntrack --ctstate NEW -j CONNMARK --set-mark 0x1/0x1")
 	mustContain(t, restore, "-p udp --dport 853 -m socket --transparent -j TPROXY --on-port 18443")
 
-	mustContain(t, restore, "-p tcp -m conntrack --ctstate NEW -j TPROXY --on-port 18080")
-	mustContain(t, restore, "-p tcp -m connmark --mark 0x1/0x1 -j TPROXY --on-port 18080")
-	mustContain(t, restore, "-p tcp -m conntrack --ctstate NEW -j CONNMARK --set-mark 0x1/0x1")
-	mustContain(t, restore, "-p tcp -m socket --transparent -j TPROXY --on-port 18080")
 	mustContain(t, restore, "-p udp -m conntrack --ctstate NEW -j TPROXY --on-port 18080")
 	mustContain(t, restore, "-p udp -m connmark --mark 0x1/0x1 -j TPROXY --on-port 18080")
 	mustContain(t, restore, "-p udp -m conntrack --ctstate NEW -j CONNMARK --set-mark 0x1/0x1")
 	mustContain(t, restore, "-p udp -m socket --transparent -j TPROXY --on-port 18080")
 
-	if strings.Count(restore, "-d 10.0.0.0/8 -j RETURN") != 1 {
-		t.Fatalf("expected duplicate bypass CIDRs to be normalized once, got:\n%s", restore)
+	mustContain(t, restore, "-A "+natChainName+" -m mark --mark 0x1/0x1 -j ACCEPT")
+	mustContain(t, restore, "-A "+natChainName+" -d "+defaultLoopback+" -j RETURN")
+	mustContain(t, restore, "-A "+natChainName+" -d 10.0.0.0/8 -j RETURN")
+	mustContain(t, restore, "-p tcp --dport 443 -j REDIRECT --to-ports 18443")
+	mustContain(t, restore, "-p tcp --dport 853 -j REDIRECT --to-ports 18443")
+	mustContain(t, restore, "-p tcp -j REDIRECT --to-ports 18080")
+
+	mustNotContain(t, restore, "-A "+chainName+" -m set --match-set "+ipsetName+" src -p tcp")
+
+	if strings.Count(restore, "-d 10.0.0.0/8 -j RETURN") != 2 {
+		t.Fatalf("expected duplicate bypass CIDRs to be normalized once per chain, got:\n%s", restore)
 	}
 }
 
@@ -54,10 +67,61 @@ func TestBuildIPSetRestoreInput(t *testing.T) {
 	mustContain(t, restore, "destroy "+nextIPSetName)
 }
 
-func TestNatBypassRuleSpecSkipsDNATForMarkedPackets(t *testing.T) {
-	if got, want := natBypassRuleSpec(), []string{"-m", "mark", "--mark", tproxyMark, "-j", "ACCEPT"}; strings.Join(got, " ") != strings.Join(want, " ") {
-		t.Fatalf("unexpected nat bypass rule spec: %#v", got)
+func TestEnsureTopJumpInsertsMissingJumpAtFirstRule(t *testing.T) {
+	ipt := newFakeIPTables([]string{"-j CNI_PREROUTING"})
+	manager := &iptablesManager{ipt: ipt}
+
+	if err := manager.ensureTopJump(context.Background(), mangleTable, "PREROUTING", chainName); err != nil {
+		t.Fatal(err)
 	}
+
+	wantRules := []string{"-j " + chainName, "-j CNI_PREROUTING"}
+	assertStringSlicesEqual(t, ipt.rulesFor(mangleTable, "PREROUTING"), wantRules)
+	assertStringSlicesEqual(t, ipt.ops, []string{"insert mangle/PREROUTING 1 -j " + chainName})
+}
+
+func TestEnsureTopJumpInsertsBeforeDeletingExistingLowerJump(t *testing.T) {
+	ipt := newFakeIPTables([]string{"-j CNI_PREROUTING", "-j " + chainName})
+	manager := &iptablesManager{ipt: ipt}
+
+	if err := manager.ensureTopJump(context.Background(), mangleTable, "PREROUTING", chainName); err != nil {
+		t.Fatal(err)
+	}
+
+	wantRules := []string{"-j " + chainName, "-j CNI_PREROUTING"}
+	assertStringSlicesEqual(t, ipt.rulesFor(mangleTable, "PREROUTING"), wantRules)
+	assertStringSlicesEqual(t, ipt.ops, []string{
+		"insert mangle/PREROUTING 1 -j " + chainName,
+		"delete-by-id mangle/PREROUTING 3 -j " + chainName,
+	})
+}
+
+func TestEnsureTopJumpDeletesDuplicateLowerJumpWithoutReinserting(t *testing.T) {
+	ipt := newFakeIPTables([]string{"-j " + chainName, "-j CNI_PREROUTING", "-j " + chainName})
+	manager := &iptablesManager{ipt: ipt}
+
+	if err := manager.ensureTopJump(context.Background(), mangleTable, "PREROUTING", chainName); err != nil {
+		t.Fatal(err)
+	}
+
+	wantRules := []string{"-j " + chainName, "-j CNI_PREROUTING"}
+	assertStringSlicesEqual(t, ipt.rulesFor(mangleTable, "PREROUTING"), wantRules)
+	assertStringSlicesEqual(t, ipt.ops, []string{"delete-by-id mangle/PREROUTING 3 -j " + chainName})
+}
+
+func TestJumpRuleLineNumbersOnlyCountsRulesInTargetChain(t *testing.T) {
+	rules := []string{
+		"-P PREROUTING ACCEPT",
+		"-N " + chainName,
+		"-A PREROUTING -m comment --comment cni -j CNI_PREROUTING",
+		"-A PREROUTING -m comment --comment netd -j " + chainName,
+		"-A OUTPUT -j " + chainName,
+		"-A PREROUTING -g " + chainName,
+		"-A PREROUTING -j " + chainName,
+	}
+
+	got := jumpRuleLineNumbers(rules, "PREROUTING", chainName)
+	assertIntsEqual(t, got, []int{2, 4})
 }
 
 func TestNormalizeInputsDeduplicateAndTrim(t *testing.T) {
@@ -76,5 +140,128 @@ func mustContain(t *testing.T, got string, want string) {
 	t.Helper()
 	if !strings.Contains(got, want) {
 		t.Fatalf("expected output to contain %q, got:\n%s", want, got)
+	}
+}
+
+func mustNotContain(t *testing.T, got string, want string) {
+	t.Helper()
+	if strings.Contains(got, want) {
+		t.Fatalf("expected output not to contain %q, got:\n%s", want, got)
+	}
+}
+
+type fakeIPTables struct {
+	rules map[string][]string
+	ops   []string
+}
+
+func newFakeIPTables(preroutingRules []string) *fakeIPTables {
+	fake := &fakeIPTables{rules: map[string][]string{}}
+	fake.rules[fakeKey(mangleTable, "PREROUTING")] = append([]string(nil), preroutingRules...)
+	return fake
+}
+
+func (f *fakeIPTables) ChainExists(table, chain string) (bool, error) {
+	_, ok := f.rules[fakeKey(table, chain)]
+	return ok, nil
+}
+
+func (f *fakeIPTables) ClearChain(table, chain string) error {
+	f.rules[fakeKey(table, chain)] = nil
+	f.ops = append(f.ops, fmt.Sprintf("clear %s/%s", table, chain))
+	return nil
+}
+
+func (f *fakeIPTables) DeleteById(table, chain string, id int) error {
+	key := fakeKey(table, chain)
+	rules := f.rules[key]
+	if id < 1 || id > len(rules) {
+		return fmt.Errorf("rule id %d out of range", id)
+	}
+	rule := rules[id-1]
+	f.rules[key] = append(append([]string{}, rules[:id-1]...), rules[id:]...)
+	f.ops = append(f.ops, fmt.Sprintf("delete-by-id %s/%s %d %s", table, chain, id, rule))
+	return nil
+}
+
+func (f *fakeIPTables) DeleteChain(table, chain string) error {
+	delete(f.rules, fakeKey(table, chain))
+	f.ops = append(f.ops, fmt.Sprintf("delete-chain %s/%s", table, chain))
+	return nil
+}
+
+func (f *fakeIPTables) DeleteIfExists(table, chain string, rulespec ...string) error {
+	key := fakeKey(table, chain)
+	targetRule := strings.Join(rulespec, " ")
+	for i, rule := range f.rules[key] {
+		if rule != targetRule {
+			continue
+		}
+		f.rules[key] = append(append([]string{}, f.rules[key][:i]...), f.rules[key][i+1:]...)
+		f.ops = append(f.ops, fmt.Sprintf("delete-if-exists %s/%s %s", table, chain, targetRule))
+		return nil
+	}
+	return nil
+}
+
+func (f *fakeIPTables) Insert(table, chain string, pos int, rulespec ...string) error {
+	key := fakeKey(table, chain)
+	rules := f.rules[key]
+	if pos < 1 {
+		return fmt.Errorf("rule position %d out of range", pos)
+	}
+	if pos > len(rules)+1 {
+		pos = len(rules) + 1
+	}
+	rule := strings.Join(rulespec, " ")
+	idx := pos - 1
+	f.rules[key] = append(append(append([]string{}, rules[:idx]...), rule), rules[idx:]...)
+	f.ops = append(f.ops, fmt.Sprintf("insert %s/%s %d %s", table, chain, pos, rule))
+	return nil
+}
+
+func (f *fakeIPTables) List(table, chain string) ([]string, error) {
+	out := []string{"-P " + chain + " ACCEPT"}
+	for _, rule := range f.rules[fakeKey(table, chain)] {
+		out = append(out, "-A "+chain+" "+rule)
+	}
+	return out, nil
+}
+
+func (f *fakeIPTables) NewChain(table, chain string) error {
+	f.rules[fakeKey(table, chain)] = []string{}
+	f.ops = append(f.ops, fmt.Sprintf("new-chain %s/%s", table, chain))
+	return nil
+}
+
+func (f *fakeIPTables) rulesFor(table, chain string) []string {
+	return append([]string(nil), f.rules[fakeKey(table, chain)]...)
+}
+
+func fakeKey(table, chain string) string {
+	return table + "/" + chain
+}
+
+func assertStringSlicesEqual(t *testing.T, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("unexpected strings:\ngot:  %#v\nwant: %#v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("unexpected strings:\ngot:  %#v\nwant: %#v", got, want)
+		}
+	}
+}
+
+func assertIntsEqual(t *testing.T, got, want []int) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("unexpected ints:\ngot:  %#v\nwant: %#v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("unexpected ints:\ngot:  %#v\nwant: %#v", got, want)
+		}
 	}
 }

--- a/netd/pkg/redirect/rules.go
+++ b/netd/pkg/redirect/rules.go
@@ -16,34 +16,57 @@ const (
 	tproxyMark        = "0x1/0x1"
 	defaultLoopback   = "127.0.0.0/8"
 	natBypassJumpMark = tproxyMark
+	calicoWorkloadIF  = "cali+"
+	ciliumWorkloadIF  = "lxc+"
 )
 
 func buildIPTablesRestoreInput(cfg Config, bypassCIDRs []string) string {
 	var buf bytes.Buffer
+	bypass := normalizeCIDRs(append([]string{defaultLoopback}, bypassCIDRs...))
+
 	buf.WriteString("*mangle\n")
 	buf.WriteString(fmt.Sprintf("-F %s\n", chainName))
 
-	bypass := append([]string{defaultLoopback}, bypassCIDRs...)
-	for _, cidr := range normalizeCIDRs(bypass) {
+	for _, cidr := range bypass {
 		buf.WriteString(fmt.Sprintf("-A %s -d %s -j RETURN\n", chainName, cidr))
 	}
 
-	appendTPROXYRules(&buf, "tcp", 443, cfg.ProxyHTTPSPort)
-	appendTPROXYRules(&buf, "tcp", 853, cfg.ProxyHTTPSPort)
-	appendTPROXYRules(&buf, "udp", 443, cfg.ProxyHTTPSPort)
-	appendTPROXYRules(&buf, "udp", 853, cfg.ProxyHTTPSPort)
-	appendTPROXYRules(&buf, "tcp", 0, cfg.ProxyHTTPPort)
-	appendTPROXYRules(&buf, "udp", 0, cfg.ProxyHTTPPort)
+	// Calico/Canal and Cilium native mode need TCP TPROXY on their workload
+	// veth interfaces. Bridge CNIs use the NAT REDIRECT fallback below.
+	for _, inputInterface := range []string{calicoWorkloadIF, ciliumWorkloadIF} {
+		appendTPROXYRules(&buf, inputInterface, "tcp", 443, cfg.ProxyHTTPSPort)
+		appendTPROXYRules(&buf, inputInterface, "tcp", 853, cfg.ProxyHTTPSPort)
+		appendTPROXYRules(&buf, inputInterface, "tcp", 0, cfg.ProxyHTTPPort)
+	}
+	appendTPROXYRules(&buf, "", "udp", 443, cfg.ProxyHTTPSPort)
+	appendTPROXYRules(&buf, "", "udp", 853, cfg.ProxyHTTPSPort)
+	appendTPROXYRules(&buf, "", "udp", 0, cfg.ProxyHTTPPort)
 
 	buf.WriteString("COMMIT\n")
+
+	buf.WriteString("*nat\n")
+	buf.WriteString(fmt.Sprintf("-F %s\n", natChainName))
+	buf.WriteString(fmt.Sprintf("-A %s -m mark --mark %s -j ACCEPT\n", natChainName, natBypassJumpMark))
+	for _, cidr := range bypass {
+		buf.WriteString(fmt.Sprintf("-A %s -d %s -j RETURN\n", natChainName, cidr))
+	}
+	appendTCPRedirectRules(&buf, 443, cfg.ProxyHTTPSPort)
+	appendTCPRedirectRules(&buf, 853, cfg.ProxyHTTPSPort)
+	appendTCPRedirectRules(&buf, 0, cfg.ProxyHTTPPort)
+	buf.WriteString("COMMIT\n")
+
 	return buf.String()
 }
 
-func appendTPROXYRules(buf *bytes.Buffer, protocol string, destPort int, proxyPort int) {
+func appendTPROXYRules(buf *bytes.Buffer, inputInterface, protocol string, destPort int, proxyPort int) {
 	if buf == nil || protocol == "" || proxyPort <= 0 {
 		return
 	}
-	base := fmt.Sprintf("-A %s -m set --match-set %s src -p %s", chainName, ipsetName, protocol)
+	base := fmt.Sprintf("-A %s", chainName)
+	if inputInterface != "" {
+		base += fmt.Sprintf(" -i %s", inputInterface)
+	}
+	base += fmt.Sprintf(" -m set --match-set %s src -p %s", ipsetName, protocol)
 	if destPort > 0 {
 		base += fmt.Sprintf(" --dport %d", destPort)
 	}
@@ -57,8 +80,15 @@ func appendTPROXYRules(buf *bytes.Buffer, protocol string, destPort int, proxyPo
 		base, proxyPort, tproxyMark)
 }
 
-func natBypassRuleSpec() []string {
-	return []string{"-m", "mark", "--mark", natBypassJumpMark, "-j", "ACCEPT"}
+func appendTCPRedirectRules(buf *bytes.Buffer, destPort int, proxyPort int) {
+	if buf == nil || proxyPort <= 0 {
+		return
+	}
+	base := fmt.Sprintf("-A %s -m set --match-set %s src -p tcp", natChainName, ipsetName)
+	if destPort > 0 {
+		base += fmt.Sprintf(" --dport %d", destPort)
+	}
+	_, _ = fmt.Fprintf(buf, "%s -j REDIRECT --to-ports %d\n", base, proxyPort)
 }
 
 func buildIPSetRestoreInput(ips []string) string {

--- a/pkg/framework/setup.go
+++ b/pkg/framework/setup.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -88,6 +89,9 @@ func SetupScenario(cfg Config, scenario Scenario) (*ScenarioEnv, func(), error) 
 		})
 	}
 
+	if err := ScaleScenarioManagerToZero(testCtx.Context, workingCfg.Kubeconfig, env.Infra); err != nil {
+		fmt.Printf("Failed to scale scenario manager down before setup cleanup: %v\n", err)
+	}
 	if err := CleanupManagerOwnedNamespaces(testCtx.Context, workingCfg.Kubeconfig, managerOwnedNamespaceCleanupTimeout); err != nil {
 		cleanup()
 		return nil, nil, err
@@ -149,9 +153,30 @@ func SetupScenario(cfg Config, scenario Scenario) (*ScenarioEnv, func(), error) 
 		cleanup()
 		return nil, nil, err
 	}
+	for _, rollout := range scenario.Rollouts {
+		resourceID, err := rollout.ResourceID()
+		if err != nil {
+			cleanup()
+			return nil, nil, err
+		}
+		timeout := rollout.Timeout
+		if timeout == "" {
+			timeout = scenario.ReadyTimeout
+		}
+		if timeout == "" {
+			timeout = "5m"
+		}
+		if err := KubectlRolloutStatus(testCtx.Context, workingCfg.Kubeconfig, rollout.Namespace, resourceID, timeout); err != nil {
+			cleanup()
+			return nil, nil, err
+		}
+	}
 	appendCleanup(func() {
 		// Pods can mount sandbox0 CSI volumes. Delete sandbox namespaces before the
 		// infra manifest so storage-proxy is still available for kubelet unpublish.
+		if err := ScaleScenarioManagerToZero(testCtx.Context, workingCfg.Kubeconfig, env.Infra); err != nil {
+			fmt.Printf("Failed to scale scenario manager down before namespace cleanup: %v\n", err)
+		}
 		if err := CleanupManagerOwnedNamespaces(testCtx.Context, workingCfg.Kubeconfig, managerOwnedNamespaceCleanupTimeout); err != nil {
 			preserveInfraForNamespaceCleanup = true
 			fmt.Printf("Failed to clean up manager-owned namespaces: %v\n", err)
@@ -167,6 +192,47 @@ func SetupScenario(cfg Config, scenario Scenario) (*ScenarioEnv, func(), error) 
 	})
 
 	return env, cleanup, nil
+}
+
+// ScaleScenarioManagerToZero stops manager reconciliation while preserving CSI components.
+func ScaleScenarioManagerToZero(ctx context.Context, kubeconfig string, infra InfraConfig) error {
+	if ctx == nil {
+		return fmt.Errorf("context is required")
+	}
+	if infra.Name == "" || infra.Namespace == "" {
+		return fmt.Errorf("infra name and namespace are required")
+	}
+
+	name := infra.Name + "-manager"
+	err := Kubectl(
+		ctx,
+		kubeconfig,
+		"scale",
+		"deployment/"+name,
+		"--replicas=0",
+		"--namespace",
+		infra.Namespace,
+	)
+	if err == nil {
+		return nil
+	}
+
+	output, getErr := KubectlOutput(
+		ctx,
+		kubeconfig,
+		"get",
+		"deployment",
+		name,
+		"--namespace",
+		infra.Namespace,
+		"--ignore-not-found=true",
+		"-o",
+		"name",
+	)
+	if getErr == nil && strings.TrimSpace(output) == "" {
+		return nil
+	}
+	return err
 }
 
 // CleanupManagerOwnedNamespaces removes namespaces created by sandbox managers during e2e scenarios.

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -245,6 +245,10 @@ func registerApiModeSuite(envProvider func() *framework.ScenarioEnv, opts apiMod
 					assertSandboxEgressProxy(env, session, sandboxID)
 				})
 
+				It("enforces transparent TCP egress through netd", func() {
+					assertNetdTransparentEgressPolicy(env, session, sandboxID)
+				})
+
 				It("enforces egress quota", func() {
 					assertEgressQuota(env, session, sandboxID)
 				})

--- a/tests/e2e/cases/api_network_policy_netd.go
+++ b/tests/e2e/cases/api_network_policy_netd.go
@@ -1,0 +1,255 @@
+package cases
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
+	"github.com/sandbox0-ai/sandbox0/pkg/apispec"
+	"github.com/sandbox0-ai/sandbox0/pkg/framework"
+	"github.com/sandbox0-ai/sandbox0/pkg/naming"
+	e2eutils "github.com/sandbox0-ai/sandbox0/tests/e2e/utils"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	netdHTTPFixtureImageEnvVar     = "E2E_NETD_HTTP_FIXTURE_IMAGE"
+	defaultNetdHTTPFixtureImageRef = "sandbox0ai/otemplates:default-v0.1.0"
+	netdHTTPFixturePort            = 8080
+)
+
+type netdHTTPFixture struct {
+	Namespace string
+	AllowIP   string
+	DenyIP    string
+}
+
+func assertNetdTransparentEgressPolicy(env *framework.ScenarioEnv, session *e2eutils.Session, sandboxID string) {
+	Expect(sandboxID).NotTo(BeEmpty())
+
+	sandbox, status, err := session.GetSandbox(env.TestCtx.Context, GinkgoT(), sandboxID)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+	Expect(sandbox).NotTo(BeNil())
+
+	templateNamespace, err := naming.TemplateNamespaceForBuiltin(sandbox.TemplateId)
+	Expect(err).NotTo(HaveOccurred())
+	sandbox = waitForSandboxPodReadyEventually(env, session, sandboxID, templateNamespace)
+
+	fixture := setupNetdHTTPFixture(env, templateNamespace, sandbox.PodName)
+	clearPolicy := apispec.SandboxNetworkPolicy{Mode: apispec.AllowAll}
+	defer func() {
+		_, _, _, _ = session.UpdateNetworkPolicy(env.TestCtx.Context, GinkgoT(), sandboxID, clearPolicy)
+	}()
+
+	rules := []apispec.TrafficRule{
+		buildNetdHTTPRule("allow-http-fixture", apispec.Allow, fixture.AllowIP),
+	}
+	policy, status, apiErr, err := session.UpdateNetworkPolicy(env.TestCtx.Context, GinkgoT(), sandboxID, apispec.SandboxNetworkPolicy{
+		Mode: apispec.BlockAll,
+		Egress: &apispec.NetworkEgressPolicy{
+			TrafficRules: &rules,
+		},
+	})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(apiErr).To(BeNil())
+	Expect(status).To(Equal(http.StatusOK))
+	Expect(policy).NotTo(BeNil())
+	waitForSandboxNetworkPolicyApplied(env, templateNamespace, sandbox.PodName)
+
+	assertNetdHTTPFixtureEventuallySucceeds(env, templateNamespace, sandbox.PodName, fixture.AllowIP, "allow")
+	assertNetdHTTPFixtureEventuallyFails(env, templateNamespace, sandbox.PodName, fixture.DenyIP)
+}
+
+func setupNetdHTTPFixture(env *framework.ScenarioEnv, sandboxNamespace, sandboxPodName string) *netdHTTPFixture {
+	imageRef := strings.TrimSpace(os.Getenv(netdHTTPFixtureImageEnvVar))
+	if imageRef == "" {
+		imageRef = defaultNetdHTTPFixtureImageRef
+	}
+
+	namespace := fmt.Sprintf("sandbox0-e2e-netd-%d", time.Now().UnixNano())
+	nodeName := selectNetdHTTPFixtureNode(env, sandboxNamespace, sandboxPodName)
+
+	Expect(framework.ApplyManifestContent(
+		env.TestCtx.Context,
+		env.Config.Kubeconfig,
+		"sandbox0-e2e-netd-",
+		buildNetdHTTPFixtureManifest(namespace, imageRef, nodeName),
+	)).To(Succeed())
+	DeferCleanup(func() {
+		_ = framework.Kubectl(
+			env.TestCtx.Context,
+			env.Config.Kubeconfig,
+			"delete",
+			"namespace",
+			namespace,
+			"--ignore-not-found=true",
+			"--wait=false",
+		)
+	})
+
+	Expect(framework.KubectlWaitForCondition(env.TestCtx.Context, env.Config.Kubeconfig, namespace, "pod", "allow-http", "Ready", "2m")).To(Succeed())
+	Expect(framework.KubectlWaitForCondition(env.TestCtx.Context, env.Config.Kubeconfig, namespace, "pod", "deny-http", "Ready", "2m")).To(Succeed())
+
+	allowIP, err := framework.KubectlGetJSONPath(env.TestCtx.Context, env.Config.Kubeconfig, namespace, "pod", "allow-http", "{.status.podIP}")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(strings.TrimSpace(allowIP)).NotTo(BeEmpty())
+
+	denyIP, err := framework.KubectlGetJSONPath(env.TestCtx.Context, env.Config.Kubeconfig, namespace, "pod", "deny-http", "{.status.podIP}")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(strings.TrimSpace(denyIP)).NotTo(BeEmpty())
+
+	return &netdHTTPFixture{
+		Namespace: namespace,
+		AllowIP:   strings.TrimSpace(allowIP),
+		DenyIP:    strings.TrimSpace(denyIP),
+	}
+}
+
+func selectNetdHTTPFixtureNode(env *framework.ScenarioEnv, sandboxNamespace, sandboxPodName string) string {
+	sandboxNode, err := framework.KubectlGetJSONPath(env.TestCtx.Context, env.Config.Kubeconfig, sandboxNamespace, "pod", sandboxPodName, "{.spec.nodeName}")
+	Expect(err).NotTo(HaveOccurred())
+	sandboxNode = strings.TrimSpace(sandboxNode)
+
+	workerNodes, err := listWorkerNodes(env)
+	Expect(err).NotTo(HaveOccurred())
+	for _, node := range workerNodes {
+		if node != sandboxNode {
+			return node
+		}
+	}
+	if len(workerNodes) > 0 {
+		return workerNodes[0]
+	}
+	return ""
+}
+
+func buildNetdHTTPFixtureManifest(namespace, imageRef, nodeName string) string {
+	return fmt.Sprintf(`apiVersion: v1
+kind: Namespace
+metadata:
+  name: %s
+---
+%s
+---
+%s
+`, namespace, buildNetdHTTPFixturePodManifest(namespace, imageRef, "allow-http", "allow", nodeName), buildNetdHTTPFixturePodManifest(namespace, imageRef, "deny-http", "deny", nodeName))
+}
+
+func buildNetdHTTPFixturePodManifest(namespace, imageRef, name, body, nodeName string) string {
+	return fmt.Sprintf(`apiVersion: v1
+kind: Pod
+metadata:
+  name: %[3]s
+  namespace: %[1]s
+  labels:
+    app.kubernetes.io/name: sandbox0-e2e-netd-http
+spec:
+%[5]s  containers:
+    - name: http
+      image: %[2]q
+      imagePullPolicy: IfNotPresent
+      command:
+        - /bin/sh
+        - -lc
+        - |
+          set -eu
+          dir=/tmp/sandbox0-e2e-netd-http
+          rm -rf "$dir"
+          mkdir -p "$dir"
+          printf '%[4]s\n' > "$dir/index.html"
+          exec python3 -m http.server %[6]d --bind 0.0.0.0 -d "$dir"
+      ports:
+        - name: http
+          containerPort: %[6]d
+          protocol: TCP
+      readinessProbe:
+        httpGet:
+          path: /
+          port: http
+        initialDelaySeconds: 1
+        periodSeconds: 2
+`, namespace, imageRef, name, body, netdHTTPFixtureNodeNameYAML(nodeName), netdHTTPFixturePort)
+}
+
+func netdHTTPFixtureNodeNameYAML(nodeName string) string {
+	nodeName = strings.TrimSpace(nodeName)
+	if nodeName == "" {
+		return ""
+	}
+	return fmt.Sprintf("  nodeName: %q\n", nodeName)
+}
+
+func buildNetdHTTPRule(name string, action apispec.TrafficRuleAction, ip string) apispec.TrafficRule {
+	cidrs := []string{ip + "/32"}
+	ports := []apispec.PortSpec{{
+		Port:     netdHTTPFixturePort,
+		Protocol: ptrTo("tcp"),
+	}}
+	return apispec.TrafficRule{
+		Name:   ptrTo(name),
+		Action: action,
+		Cidrs:  &cidrs,
+		Ports:  &ports,
+	}
+}
+
+func waitForSandboxNetworkPolicyApplied(env *framework.ScenarioEnv, namespace, podName string) {
+	Eventually(func() error {
+		output, err := framework.KubectlOutput(
+			env.TestCtx.Context,
+			env.Config.Kubeconfig,
+			"get", "pod", podName,
+			"--namespace", namespace,
+			"-o", "json",
+		)
+		if err != nil {
+			return err
+		}
+		var pod e2ePod
+		if err := json.Unmarshal([]byte(output), &pod); err != nil {
+			return err
+		}
+		hash := strings.TrimSpace(pod.Metadata.Annotations[controller.AnnotationNetworkPolicyHash])
+		appliedHash := strings.TrimSpace(pod.Metadata.Annotations[controller.AnnotationNetworkPolicyAppliedHash])
+		if hash == "" {
+			return fmt.Errorf("pod %s network policy hash is not set", podName)
+		}
+		if appliedHash != hash {
+			return fmt.Errorf("pod %s network policy hash is not applied yet: hash=%s applied=%s", podName, hash, appliedHash)
+		}
+		return nil
+	}).WithTimeout(90 * time.Second).WithPolling(2 * time.Second).Should(Succeed())
+}
+
+func assertNetdHTTPFixtureEventuallySucceeds(env *framework.ScenarioEnv, namespace, podName, ip, wantBody string) {
+	Eventually(func() error {
+		body, err := execInSandboxPod(env, namespace, podName, netdHTTPFixtureCurlCommand(ip))
+		if err != nil {
+			return err
+		}
+		if strings.TrimSpace(body) != wantBody {
+			return fmt.Errorf("unexpected response body from %s: %q", ip, body)
+		}
+		return nil
+	}).WithTimeout(60 * time.Second).WithPolling(3 * time.Second).Should(Succeed())
+}
+
+func assertNetdHTTPFixtureEventuallyFails(env *framework.ScenarioEnv, namespace, podName, ip string) {
+	Eventually(func() error {
+		if body, err := execInSandboxPod(env, namespace, podName, netdHTTPFixtureCurlCommand(ip)); err == nil {
+			return fmt.Errorf("request to denied fixture %s succeeded with body %q", ip, body)
+		}
+		return nil
+	}).WithTimeout(30 * time.Second).WithPolling(3 * time.Second).Should(Succeed())
+}
+
+func netdHTTPFixtureCurlCommand(ip string) string {
+	return fmt.Sprintf("curl -4 -fsS --connect-timeout 2 --max-time 5 http://%s:%d/", ip, netdHTTPFixturePort)
+}

--- a/tests/e2e/cni/install.sh
+++ b/tests/e2e/cni/install.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cni="${1:-}"
+if [[ -z "${cni}" ]]; then
+  echo "usage: $0 <flannel|canal|cilium-native-host-legacy>" >&2
+  exit 2
+fi
+
+FLANNEL_VERSION="${FLANNEL_VERSION:-v0.28.1}"
+CALICO_VERSION="${CALICO_VERSION:-v3.32.0}"
+CILIUM_VERSION="${CILIUM_VERSION:-1.19.4}"
+CNI_PLUGINS_VERSION="${CNI_PLUGINS_VERSION:-v1.8.0}"
+POD_CIDR="${POD_CIDR:-10.244.0.0/16}"
+
+run_privileged() {
+  if [[ "$(id -u)" == "0" ]]; then
+    "$@"
+  elif command -v sudo >/dev/null 2>&1; then
+    sudo "$@"
+  else
+    "$@"
+  fi
+}
+
+ensure_bridge_netfilter() {
+  run_privileged modprobe br_netfilter || true
+  run_privileged sysctl -w net.bridge.bridge-nf-call-iptables=1 >/dev/null || true
+  run_privileged sysctl -w net.bridge.bridge-nf-call-ip6tables=1 >/dev/null || true
+}
+
+linux_arch() {
+  case "$(uname -m)" in
+    x86_64)
+      echo amd64
+      ;;
+    aarch64 | arm64)
+      echo arm64
+      ;;
+    *)
+      uname -m
+      ;;
+  esac
+}
+
+ensure_kind_bridge_plugin() {
+  if ! command -v docker >/dev/null 2>&1; then
+    return
+  fi
+
+  local nodes
+  nodes="$(kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')"
+  if [[ -z "${nodes}" ]]; then
+    return
+  fi
+
+  local missing=false
+  local node
+  for node in ${nodes}; do
+    if ! docker exec "${node}" test -x /opt/cni/bin/bridge >/dev/null 2>&1; then
+      missing=true
+      break
+    fi
+  done
+  if [[ "${missing}" != "true" ]]; then
+    return
+  fi
+
+  local tmp
+  tmp="$(mktemp -d)"
+
+  local archive="${tmp}/cni-plugins.tgz"
+  local arch
+  arch="$(linux_arch)"
+  curl -fsSL -o "${archive}" "https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGINS_VERSION}/cni-plugins-linux-${arch}-${CNI_PLUGINS_VERSION}.tgz"
+  tar -xzf "${archive}" -C "${tmp}" ./bridge
+
+  for node in ${nodes}; do
+    if docker exec "${node}" test -x /opt/cni/bin/bridge >/dev/null 2>&1; then
+      continue
+    fi
+    docker cp "${tmp}/bridge" "${node}:/opt/cni/bin/bridge"
+    docker exec "${node}" chmod +x /opt/cni/bin/bridge
+  done
+  rm -rf "${tmp}"
+}
+
+wait_for_cluster_network() {
+  kubectl wait node --all --for=condition=Ready --timeout=5m
+  kubectl -n kube-system rollout status deployment/coredns --timeout=5m
+}
+
+install_flannel() {
+  kubectl apply -f "https://raw.githubusercontent.com/flannel-io/flannel/${FLANNEL_VERSION}/Documentation/kube-flannel.yml"
+  kubectl -n kube-flannel rollout status daemonset/kube-flannel-ds --timeout=5m
+  wait_for_cluster_network
+}
+
+install_canal() {
+  kubectl apply -f "https://raw.githubusercontent.com/projectcalico/calico/${CALICO_VERSION}/manifests/canal.yaml"
+  kubectl -n kube-system rollout status daemonset/canal --timeout=5m
+  kubectl -n kube-system rollout status deployment/calico-kube-controllers --timeout=5m
+  wait_for_cluster_network
+}
+
+install_cilium_native_host_legacy() {
+  helm repo add cilium https://helm.cilium.io/ --force-update >/dev/null
+  helm repo update cilium >/dev/null
+  helm upgrade --install cilium cilium/cilium \
+    --version "${CILIUM_VERSION}" \
+    --namespace kube-system \
+    --set routingMode=native \
+    --set autoDirectNodeRoutes=true \
+    --set ipv4NativeRoutingCIDR="${POD_CIDR}" \
+    --set ipam.mode=kubernetes \
+    --set k8s.requireIPv4PodCIDR=true \
+    --set bpf.hostLegacyRouting=true \
+    --set enableIPv4Masquerade=false \
+    --set kubeProxyReplacement=false \
+    --set operator.replicas=1
+  kubectl -n kube-system rollout status daemonset/cilium --timeout=8m
+  kubectl -n kube-system rollout status deployment/cilium-operator --timeout=8m
+  wait_for_cluster_network
+}
+
+case "${cni}" in
+  flannel)
+    ensure_bridge_netfilter
+    ensure_kind_bridge_plugin
+    install_flannel
+    ;;
+  canal)
+    ensure_bridge_netfilter
+    ensure_kind_bridge_plugin
+    install_canal
+    ;;
+  cilium-native-host-legacy)
+    install_cilium_native_host_legacy
+    ;;
+  *)
+    echo "unsupported cni: ${cni}" >&2
+    exit 2
+    ;;
+esac

--- a/tests/e2e/kind-config-no-cni.yaml
+++ b/tests/e2e/kind-config-no-cni.yaml
@@ -1,0 +1,32 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: sandbox0-e2e
+networking:
+  disableDefaultCNI: true
+  podSubnet: 10.244.0.0/16
+nodes:
+- role: control-plane
+  image: kindest/node:v1.35.0
+  kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+    apiServer:
+      extraArgs:
+        enable-aggregator-routing: "true"
+  extraPortMappings:
+  # cluster-gateway HTTP port
+  - containerPort: 30080
+    hostPort: 30080
+  # reserved test HTTP port
+  - containerPort: 30081
+    hostPort: 30081
+  # ssh-gateway SSH port
+  - containerPort: 30222
+    hostPort: 30222
+  # registry port for template image push
+  - containerPort: 30500
+    hostPort: 30500
+- role: worker
+  image: kindest/node:v1.35.0
+- role: worker
+  image: kindest/node:v1.35.0


### PR DESCRIPTION
## Summary
- Keep `NETD_PREROUTING` and `NETD_NAT_PREROUTING` pinned at the top of host `PREROUTING` chains without a delete-before-insert gap.
- Add unit coverage for insert-before-cleanup behavior and iptables rule parsing.
- Add a shared netd transparent TCP egress e2e case and a CNI matrix workflow for kindnet, flannel, canal, and Cilium native + host legacy routing.

## CNI support boundary
- Supported: kindnet, flannel, canal, and Cilium `routingMode=native` with `bpf.hostLegacyRouting=true`.
- Not supported by this backend: Cilium default tunnel/VXLAN datapath, because sandbox pod traffic does not reliably traverse host iptables `mangle/PREROUTING` before Cilium's eBPF datapath forwards it.

Fixes #373

## Tests
- `go test ./netd/pkg/redirect`
- `go test ./tests/e2e/cases`
- `go test -run TestSelectScenarioManifestPaths ./tests/e2e/scenarios/single-cluster`
- `go test ./tests/e2e/scenarios/single-cluster -run TestSingleCluster -ginkgo.dry-run -ginkgo.focus="API network policy mode.*enforces transparent TCP egress through netd"`
- `bash -n tests/e2e/cni/install.sh`
- `git diff --check`
