### PR TITLE
Fix stale deleting idle pod cleanup

### DIFF
--- a/manager/pkg/controller/cleanup_controller.go
+++ b/manager/pkg/controller/cleanup_controller.go
@@ -138,8 +138,14 @@ func (cc *CleanupController) runCleanup(ctx context.Context) error {
 	return nil
 }
 
-// cleanupExpired cleans up expired active pods
+// cleanupExpired cleans up stale deleting idle pods and expired active pods.
 func (cc *CleanupController) cleanupExpired(ctx context.Context, template *v1alpha1.SandboxTemplate) error {
+	now := cc.clock.Now()
+
+	if err := cc.cleanupStaleDeletingIdlePods(ctx, template, now); err != nil {
+		return err
+	}
+
 	// Get all active pods for this template
 	pods, err := cc.podLister.Pods(template.Namespace).List(labels.SelectorFromSet(map[string]string{
 		LabelTemplateID: template.Name,
@@ -149,7 +155,6 @@ func (cc *CleanupController) cleanupExpired(ctx context.Context, template *v1alp
 		return err
 	}
 
-	now := cc.clock.Now()
 	expiredCount := 0
 
 	for _, pod := range pods {
@@ -271,6 +276,23 @@ func (cc *CleanupController) cleanupExpired(ctx context.Context, template *v1alp
 		)
 	}
 
+	return nil
+}
+
+func (cc *CleanupController) cleanupStaleDeletingIdlePods(ctx context.Context, template *v1alpha1.SandboxTemplate, now time.Time) error {
+	pods, err := cc.podLister.Pods(template.Namespace).List(labels.SelectorFromSet(map[string]string{
+		LabelTemplateID: template.Name,
+		LabelPoolType:   PoolTypeIdle,
+	}))
+	if err != nil {
+		return err
+	}
+
+	for _, pod := range pods {
+		if pod.DeletionTimestamp != nil {
+			cc.forceDeleteStaleDeletingPod(ctx, template, pod, now)
+		}
+	}
 	return nil
 }
 

--- a/manager/pkg/controller/cleanup_controller_test.go
+++ b/manager/pkg/controller/cleanup_controller_test.go
@@ -263,6 +263,58 @@ func TestCleanupExpiredForceDeletesStaleDeletingPod(t *testing.T) {
 	}
 }
 
+func TestCleanupExpiredForceDeletesStaleDeletingIdlePod(t *testing.T) {
+	now := time.Date(2026, time.April, 15, 19, 31, 0, 0, time.UTC)
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: "tpl-default",
+		},
+	}
+	deletedAt := metav1.NewTime(now.Add(-30 * time.Minute))
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "idle-1",
+			Namespace:         "tpl-default",
+			UID:               types.UID("pod-uid-1"),
+			DeletionTimestamp: &deletedAt,
+			Labels: map[string]string{
+				LabelTemplateID: "default",
+				LabelPoolType:   PoolTypeIdle,
+			},
+		},
+	}
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+	})
+	require.NoError(t, indexer.Add(pod))
+
+	client := fake.NewSimpleClientset(pod)
+	recorder := record.NewFakeRecorder(1)
+	controller := NewCleanupController(
+		client,
+		corelisters.NewPodLister(indexer),
+		nil,
+		recorder,
+		staticCleanupClock{now: now},
+		nil,
+		nil,
+		zap.NewNop(),
+		time.Minute,
+	)
+
+	require.NoError(t, controller.cleanupExpired(context.Background(), template))
+
+	_, err := client.CoreV1().Pods("tpl-default").Get(context.Background(), "idle-1", metav1.GetOptions{})
+	require.True(t, apierrors.IsNotFound(err), "expected stale deleting idle pod to be force deleted, got %v", err)
+	select {
+	case event := <-recorder.Events:
+		assert.Contains(t, event, "StaleDeletingPodForceDeleted")
+	default:
+		t.Fatal("expected stale force-delete event")
+	}
+}
+
 func TestCleanupExpiredDeletesCompletedSandboxPodViaTerminator(t *testing.T) {
 	now := time.Date(2026, time.April, 15, 19, 31, 0, 0, time.UTC)
 	template := &v1alpha1.SandboxTemplate{

--- a/manager/pkg/controller/pool_manager.go
+++ b/manager/pkg/controller/pool_manager.go
@@ -370,6 +370,9 @@ func (pm *PoolManager) drainStaleIdlePods(ctx context.Context, template *v1alpha
 
 	drained := 0
 	for _, pod := range pods {
+		if pod.DeletionTimestamp != nil {
+			continue
+		}
 		if pod.Annotations[AnnotationTemplateSpecHash] == desiredTemplateHash {
 			continue
 		}
@@ -500,8 +503,10 @@ func (pm *PoolManager) deleteStaleIdlePodWithRetry(ctx context.Context, namespac
 			return err
 		}
 
-		// If pod has been claimed or already updated to latest hash, skip delete.
-		if pod.Labels[LabelPoolType] != PoolTypeIdle || pod.Annotations[AnnotationTemplateSpecHash] == desiredTemplateHash {
+		// If pod is already deleting, claimed, or already updated to latest hash, skip delete.
+		if pod.DeletionTimestamp != nil ||
+			pod.Labels[LabelPoolType] != PoolTypeIdle ||
+			pod.Annotations[AnnotationTemplateSpecHash] == desiredTemplateHash {
 			return nil
 		}
 

--- a/manager/pkg/controller/pool_manager_test.go
+++ b/manager/pkg/controller/pool_manager_test.go
@@ -119,6 +119,103 @@ func TestDrainStaleIdlePodsUsesDeletePreconditions(t *testing.T) {
 	assert.Equal(t, 1, deleteActions)
 }
 
+func TestDrainStaleIdlePodsSkipsAlreadyDeletingPod(t *testing.T) {
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "template-a",
+			Namespace: "default",
+		},
+	}
+	deletedAt := metav1.NewTime(time.Now().Add(-30 * time.Minute))
+	stalePod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "idle-stale",
+			Namespace:         "default",
+			UID:               types.UID("uid-stale"),
+			ResourceVersion:   "11",
+			DeletionTimestamp: &deletedAt,
+			Labels: map[string]string{
+				LabelTemplateID: "template-a",
+				LabelPoolType:   PoolTypeIdle,
+			},
+			Annotations: map[string]string{
+				AnnotationTemplateSpecHash: "old-hash",
+			},
+		},
+	}
+
+	client := fake.NewSimpleClientset(stalePod)
+	podIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	require.NoError(t, podIndexer.Add(stalePod))
+	podLister := corelisters.NewPodLister(podIndexer)
+
+	deleteActions := 0
+	client.PrependReactor("delete", "pods", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		deleteActions++
+		return false, nil, nil
+	})
+
+	pm := &PoolManager{
+		k8sClient: client,
+		podLister: podLister,
+		recorder:  record.NewFakeRecorder(10),
+		logger:    zap.NewNop(),
+	}
+
+	err := pm.drainStaleIdlePods(context.Background(), template, "new-hash")
+	require.NoError(t, err)
+	assert.Equal(t, 0, deleteActions)
+}
+
+func TestDrainStaleIdlePodsSkipsPodDeletingAfterList(t *testing.T) {
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "template-a",
+			Namespace: "default",
+		},
+	}
+	stalePod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "idle-stale",
+			Namespace:       "default",
+			UID:             types.UID("uid-stale"),
+			ResourceVersion: "11",
+			Labels: map[string]string{
+				LabelTemplateID: "template-a",
+				LabelPoolType:   PoolTypeIdle,
+			},
+			Annotations: map[string]string{
+				AnnotationTemplateSpecHash: "old-hash",
+			},
+		},
+	}
+	deletingPod := stalePod.DeepCopy()
+	deletedAt := metav1.NewTime(time.Now().Add(-30 * time.Minute))
+	deletingPod.DeletionTimestamp = &deletedAt
+
+	client := fake.NewSimpleClientset(deletingPod)
+	podIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	require.NoError(t, podIndexer.Add(stalePod))
+	podLister := corelisters.NewPodLister(podIndexer)
+
+	deleteActions := 0
+	client.PrependReactor("delete", "pods", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		deleteActions++
+		return false, nil, nil
+	})
+
+	pm := &PoolManager{
+		k8sClient: client,
+		podLister: podLister,
+		recorder:  record.NewFakeRecorder(10),
+		logger:    zap.NewNop(),
+	}
+
+	err := pm.drainStaleIdlePods(context.Background(), template, "new-hash")
+	require.NoError(t, err)
+	assert.Equal(t, 0, deleteActions)
+}
+
 func TestDrainStaleIdlePodsSkipsClaimedActivePods(t *testing.T) {
 	template := &v1alpha1.SandboxTemplate{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Summary
- force-delete stale deleting idle sandbox pods from the cleanup controller, matching the existing active pod fallback
- stop stale idle pool draining from repeatedly deleting pods that already have a deletion timestamp
- add unit coverage for stale deleting idle pods and delete/list race cases

## Tests
- go test ./manager/pkg/controller
