### PR TITLE
Fix sandbox function service runtime behavior

### DIFF
--- a/cluster-gateway/pkg/http/handlers_exposure.go
+++ b/cluster-gateway/pkg/http/handlers_exposure.go
@@ -89,9 +89,6 @@ func (s *Server) handlePublicExposureNoRoute(c *gin.Context) {
 			return
 		}
 		if needsRuntimeRefetch {
-			if s.exposureSandboxCache != nil {
-				s.exposureSandboxCache.Delete(sandboxID)
-			}
 			sandbox, err = s.getSandboxForPublicExposure(c, sandboxID)
 			if err != nil {
 				spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox is waking up")
@@ -107,6 +104,16 @@ func (s *Server) handlePublicExposureNoRoute(c *gin.Context) {
 
 	if basePort, parseErr := portFromURL(sandbox.InternalAddr); parseErr == nil && basePort == port {
 		spec.JSONError(c, http.StatusForbidden, spec.CodeForbidden, "reserved port is not exposable")
+		return
+	}
+
+	if err := s.ensureSandboxServiceRuntime(c.Request.Context(), sandbox, match.service, route); err != nil {
+		s.logger.Warn("Sandbox service runtime is not ready",
+			zap.String("sandbox_id", sandboxID),
+			zap.String("service_id", match.service.ID),
+			zap.Error(err),
+		)
+		spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox service runtime unavailable")
 		return
 	}
 

--- a/cluster-gateway/pkg/http/handlers_sandbox_function.go
+++ b/cluster-gateway/pkg/http/handlers_sandbox_function.go
@@ -256,10 +256,9 @@ func buildSandboxFunctionExecuteRequest(r *http.Request, service *mgr.SandboxApp
 	fn := service.Runtime.Function
 	source := sandboxfunction.Source{
 		Type:     fn.Source.Type,
-		Filename: fn.Source.Filename,
+		Filename: sandboxfunction.DefaultFilename,
 		Code:     fn.Source.Code,
 	}
-	source.Digest = sandboxfunction.InlineDigest(source.Filename, source.Code)
 	execReq := sandboxfunction.ExecuteRequest{
 		ServiceID: service.ID,
 		Runtime:   fn.Runtime,

--- a/cluster-gateway/pkg/http/sandbox_service_policy.go
+++ b/cluster-gateway/pkg/http/sandbox_service_policy.go
@@ -24,19 +24,7 @@ type sandboxServiceMatch struct {
 }
 
 func (s *Server) getSandboxForPublicExposure(c *gin.Context, sandboxID string) (*mgr.Sandbox, error) {
-	if s.exposureSandboxCache != nil {
-		if sandbox, ok := s.exposureSandboxCache.Get(sandboxID); ok {
-			return sandbox, nil
-		}
-	}
-	sandbox, err := s.managerClient.GetSandboxInternal(c.Request.Context(), sandboxID)
-	if err != nil {
-		return nil, err
-	}
-	if s.exposureSandboxCache != nil {
-		s.exposureSandboxCache.Set(sandboxID, sandbox)
-	}
-	return sandbox, nil
+	return s.managerClient.GetSandboxInternal(c.Request.Context(), sandboxID)
 }
 
 func matchSandboxServiceRoute(services []mgr.SandboxAppService, port int, path string, method string) sandboxServiceMatch {

--- a/cluster-gateway/pkg/http/sandbox_service_policy_test.go
+++ b/cluster-gateway/pkg/http/sandbox_service_policy_test.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -216,9 +217,8 @@ func TestSandboxFunctionServiceExecutesThroughProcdPort(t *testing.T) {
 					Runtime: "python",
 					Handler: "handler",
 					Source: mgr.SandboxFunctionSource{
-						Type:     "inline",
-						Filename: "main.py",
-						Code:     "def handler(request):\n    return {'status': 201}\n",
+						Type: "inline",
+						Code: "def handler(request):\n    return {'status': 201}\n",
 					},
 				},
 			},
@@ -388,6 +388,186 @@ func TestSandboxFunctionServiceProxiesWebSocketThroughProcdPort(t *testing.T) {
 	}
 }
 
+func TestSandboxCMDServiceStartsContextBeforeProxy(t *testing.T) {
+	var created atomic.Bool
+	var createReq procdCreateContextRequest
+	procd := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/contexts":
+			_ = spec.WriteSuccess(w, http.StatusOK, procdContextListResponse{})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/contexts":
+			if err := json.NewDecoder(r.Body).Decode(&createReq); err != nil {
+				t.Fatalf("decode create context request: %v", err)
+			}
+			created.Store(true)
+			_ = spec.WriteSuccess(w, http.StatusCreated, procdContextResponse{
+				ID:      "ctx-service",
+				Type:    "cmd",
+				Command: createReq.Cmd.Command,
+				CWD:     createReq.CWD,
+				EnvVars: createReq.EnvVars,
+				Running: true,
+			})
+		default:
+			t.Fatalf("unexpected procd request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer procd.Close()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !created.Load() {
+			t.Fatalf("upstream hit before cmd context was created")
+		}
+		if r.URL.Path == "/healthz" {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		_, _ = w.Write([]byte("cmd ok"))
+	}))
+	defer upstream.Close()
+
+	port := serverPort(t, upstream.URL)
+	gateway := newSandboxServiceExposureTestServer(t, &mgr.Sandbox{
+		ID:           "sb-demo",
+		TeamID:       "team-1",
+		UserID:       "user-1",
+		InternalAddr: procd.URL,
+		AutoResume:   true,
+		Services: []mgr.SandboxAppService{{
+			ID:   "api",
+			Port: port,
+			Runtime: &mgr.SandboxAppServiceRuntime{
+				Type:    mgr.SandboxAppServiceRuntimeCMD,
+				Command: []string{"python3", "-m", "http.server", strconv.Itoa(port)},
+				CWD:     "/workspace",
+				EnvVars: map[string]string{"APP_ENV": "test"},
+			},
+			HealthCheck: &mgr.SandboxAppServiceHealth{Path: "/healthz"},
+			Ingress: mgr.SandboxAppServiceIngress{
+				Public: true,
+				Routes: []mgr.SandboxAppServiceRoute{{
+					ID:             "root",
+					PathPrefix:     "/",
+					TimeoutSeconds: 2,
+				}},
+			},
+		}},
+	})
+	gatewayServer := httptest.NewServer(gateway)
+	defer gatewayServer.Close()
+
+	req := newGatewayRequest(t, http.MethodGet, gatewayServer.URL, fmt.Sprintf("sb-demo--p%d.aws-us-east-1.sandbox0.app", port), "/hello")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("gateway request: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d body=%s", resp.StatusCode, string(body))
+	}
+	if string(body) != "cmd ok" {
+		t.Fatalf("body = %q, want cmd ok", string(body))
+	}
+	if createReq.Type != "cmd" || createReq.Cmd == nil || len(createReq.Cmd.Command) == 0 {
+		t.Fatalf("create context request = %+v, want cmd command", createReq)
+	}
+	if createReq.EnvVars[sandboxServiceRuntimeServiceIDEnv] != "api" || createReq.EnvVars[sandboxServiceRuntimePortEnv] != strconv.Itoa(port) {
+		t.Fatalf("service env vars = %#v, want service identity and port", createReq.EnvVars)
+	}
+	if createReq.EnvVars["APP_ENV"] != "test" {
+		t.Fatalf("APP_ENV = %q, want test", createReq.EnvVars["APP_ENV"])
+	}
+}
+
+func TestSandboxCMDServiceStartsAfterCleanedAutoResume(t *testing.T) {
+	var created atomic.Bool
+	procd := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/contexts":
+			_ = spec.WriteSuccess(w, http.StatusOK, procdContextListResponse{})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/contexts":
+			created.Store(true)
+			_ = spec.WriteSuccess(w, http.StatusCreated, procdContextResponse{ID: "ctx-service", Type: "cmd", Running: true})
+		default:
+			t.Fatalf("unexpected procd request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer procd.Close()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !created.Load() {
+			t.Fatalf("upstream hit before cmd context was created")
+		}
+		_, _ = w.Write([]byte("resumed cmd ok"))
+	}))
+	defer upstream.Close()
+
+	port := serverPort(t, upstream.URL)
+	activeSandbox := &mgr.Sandbox{
+		ID:           "sb-demo",
+		TeamID:       "team-1",
+		UserID:       "user-1",
+		InternalAddr: procd.URL,
+		AutoResume:   true,
+		Status:       mgr.SandboxStatusRunning,
+		Services:     []mgr.SandboxAppService{newCMDServiceForTest(port, true)},
+	}
+	cleanedSandbox := *activeSandbox
+	cleanedSandbox.InternalAddr = ""
+	cleanedSandbox.Status = mgr.SandboxStatusCleaned
+
+	var resumed atomic.Bool
+	manager := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/internal/v1/sandboxes/sb-demo":
+			if resumed.Load() {
+				_ = spec.WriteSuccess(w, http.StatusOK, activeSandbox)
+				return
+			}
+			_ = spec.WriteSuccess(w, http.StatusOK, &cleanedSandbox)
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/sandboxes/sb-demo/resume":
+			resumed.Store(true)
+			_ = spec.WriteSuccess(w, http.StatusOK, map[string]any{"sandbox_id": "sb-demo"})
+		default:
+			t.Fatalf("unexpected manager request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer manager.Close()
+
+	gateway := newSandboxServiceExposureTestServerWithManagerURL(t, manager.URL)
+	gatewayServer := httptest.NewServer(gateway)
+	defer gatewayServer.Close()
+
+	req := newGatewayRequest(t, http.MethodGet, gatewayServer.URL, fmt.Sprintf("sb-demo--p%d.aws-us-east-1.sandbox0.app", port), "/")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("gateway request: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d body=%s", resp.StatusCode, string(body))
+	}
+	if string(body) != "resumed cmd ok" {
+		t.Fatalf("body = %q, want resumed cmd ok", string(body))
+	}
+	if !resumed.Load() {
+		t.Fatal("manager resume was not called")
+	}
+	if !created.Load() {
+		t.Fatal("cmd context was not created after resume")
+	}
+}
+
 func newFunctionServiceSandbox(internalAddr string, port int) *mgr.Sandbox {
 	return &mgr.Sandbox{
 		ID:           "sb-demo",
@@ -404,9 +584,8 @@ func newFunctionServiceSandbox(internalAddr string, port int) *mgr.Sandbox {
 					Runtime: "python",
 					Handler: "handler",
 					Source: mgr.SandboxFunctionSource{
-						Type:     "inline",
-						Filename: "main.py",
-						Code:     "def handler(request):\n    return {'status': 201}\n",
+						Type: "inline",
+						Code: "def handler(request):\n    return {'status': 201}\n",
 					},
 				},
 			},
@@ -418,6 +597,26 @@ func newFunctionServiceSandbox(internalAddr string, port int) *mgr.Sandbox {
 				}},
 			},
 		}},
+	}
+}
+
+func newCMDServiceForTest(port int, resume bool) mgr.SandboxAppService {
+	return mgr.SandboxAppService{
+		ID:   "api",
+		Port: port,
+		Runtime: &mgr.SandboxAppServiceRuntime{
+			Type:    mgr.SandboxAppServiceRuntimeCMD,
+			Command: []string{"python3", "-m", "http.server", strconv.Itoa(port)},
+		},
+		Ingress: mgr.SandboxAppServiceIngress{
+			Public: true,
+			Routes: []mgr.SandboxAppServiceRoute{{
+				ID:             "root",
+				PathPrefix:     "/",
+				TimeoutSeconds: 2,
+				Resume:         resume,
+			}},
+		},
 	}
 }
 
@@ -433,6 +632,13 @@ func newSandboxServiceExposureTestServer(t *testing.T, sandbox *mgr.Sandbox) htt
 		_ = spec.WriteSuccess(w, http.StatusOK, sandbox)
 	}))
 	t.Cleanup(manager.Close)
+
+	return newSandboxServiceExposureTestServerWithManagerURL(t, manager.URL)
+}
+
+func newSandboxServiceExposureTestServerWithManagerURL(t *testing.T, managerURL string) http.Handler {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
 
 	_, privateKey, err := ed25519.GenerateKey(nil)
 	if err != nil {
@@ -454,7 +660,7 @@ func newSandboxServiceExposureTestServer(t *testing.T, sandbox *mgr.Sandbox) htt
 			ProxyTimeout: metav1.Duration{Duration: 10 * time.Second},
 		},
 		logger:                zap.NewNop(),
-		managerClient:         client.NewManagerClient(manager.URL, gen, zap.NewNop(), time.Second),
+		managerClient:         client.NewManagerClient(managerURL, gen, zap.NewNop(), time.Second),
 		internalAuthGen:       gen,
 		sandboxServiceLimiter: ratelimit.NewMemoryLimiter(ratelimit.MemoryConfig{}),
 	}

--- a/cluster-gateway/pkg/http/sandbox_service_runtime.go
+++ b/cluster-gateway/pkg/http/sandbox_service_runtime.go
@@ -1,0 +1,279 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	mgr "github.com/sandbox0-ai/sandbox0/manager/pkg/service"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
+	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+)
+
+const (
+	sandboxServiceRuntimeServiceIDEnv = "SANDBOX0_SERVICE_ID"
+	sandboxServiceRuntimePortEnv      = "SANDBOX0_SERVICE_PORT"
+	sandboxServiceRuntimeTypeEnv      = "SANDBOX0_SERVICE_RUNTIME"
+	sandboxServiceReadinessInterval   = 200 * time.Millisecond
+)
+
+var errSandboxServiceReadinessTimeout = errors.New("sandbox service did not become ready")
+
+type procdContextListResponse struct {
+	Contexts []procdContextResponse `json:"contexts"`
+}
+
+type procdContextResponse struct {
+	ID      string            `json:"id"`
+	Type    string            `json:"type"`
+	Command []string          `json:"command,omitempty"`
+	CWD     string            `json:"cwd"`
+	EnvVars map[string]string `json:"env_vars"`
+	Running bool              `json:"running"`
+	Paused  bool              `json:"paused"`
+}
+
+type procdCreateContextRequest struct {
+	Type    string                        `json:"type"`
+	Cmd     *procdCreateCMDContextRequest `json:"cmd,omitempty"`
+	CWD     string                        `json:"cwd,omitempty"`
+	EnvVars map[string]string             `json:"env_vars,omitempty"`
+}
+
+type procdCreateCMDContextRequest struct {
+	Command []string `json:"command"`
+}
+
+func (s *Server) ensureSandboxServiceRuntime(ctx context.Context, sandbox *mgr.Sandbox, service *mgr.SandboxAppService, route *mgr.SandboxAppServiceRoute) error {
+	if service == nil || service.Runtime == nil {
+		return nil
+	}
+	switch service.Runtime.Type {
+	case mgr.SandboxAppServiceRuntimeCMD:
+		if len(service.Runtime.Command) == 0 {
+			return errors.New("cmd runtime command is required")
+		}
+		running, err := s.sandboxServiceCMDContextRunning(ctx, sandbox, service)
+		if err != nil {
+			return err
+		}
+		if !running {
+			if err := s.createSandboxServiceCMDContext(ctx, sandbox, service); err != nil {
+				return err
+			}
+		}
+		return s.waitSandboxServiceReady(ctx, sandbox, service, route)
+	default:
+		return nil
+	}
+}
+
+func (s *Server) sandboxServiceCMDContextRunning(ctx context.Context, sandbox *mgr.Sandbox, service *mgr.SandboxAppService) (bool, error) {
+	var list procdContextListResponse
+	if err := s.doSandboxProcdJSON(ctx, sandbox, http.MethodGet, "/api/v1/contexts", nil, &list); err != nil {
+		return false, err
+	}
+	for _, candidate := range list.Contexts {
+		if sandboxServiceContextMatchesCMD(candidate, service) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func sandboxServiceContextMatchesCMD(ctx procdContextResponse, service *mgr.SandboxAppService) bool {
+	if service == nil || service.Runtime == nil {
+		return false
+	}
+	if ctx.Type != "cmd" || !ctx.Running || ctx.Paused {
+		return false
+	}
+	if ctx.EnvVars[sandboxServiceRuntimeServiceIDEnv] != service.ID {
+		return false
+	}
+	if !slices.Equal(ctx.Command, service.Runtime.Command) {
+		return false
+	}
+	return strings.TrimSpace(ctx.CWD) == strings.TrimSpace(service.Runtime.CWD)
+}
+
+func (s *Server) createSandboxServiceCMDContext(ctx context.Context, sandbox *mgr.Sandbox, service *mgr.SandboxAppService) error {
+	req := procdCreateContextRequest{
+		Type: "cmd",
+		Cmd: &procdCreateCMDContextRequest{
+			Command: service.Runtime.Command,
+		},
+		CWD:     service.Runtime.CWD,
+		EnvVars: sandboxServiceRuntimeEnvVars(service),
+	}
+	var created procdContextResponse
+	return s.doSandboxProcdJSON(ctx, sandbox, http.MethodPost, "/api/v1/contexts", req, &created)
+}
+
+func sandboxServiceRuntimeEnvVars(service *mgr.SandboxAppService) map[string]string {
+	env := make(map[string]string, len(service.Runtime.EnvVars)+3)
+	for key, value := range service.Runtime.EnvVars {
+		env[key] = value
+	}
+	env[sandboxServiceRuntimeServiceIDEnv] = service.ID
+	env[sandboxServiceRuntimePortEnv] = strconv.Itoa(service.Port)
+	env[sandboxServiceRuntimeTypeEnv] = mgr.SandboxAppServiceRuntimeCMD
+	return env
+}
+
+func (s *Server) doSandboxProcdJSON(ctx context.Context, sandbox *mgr.Sandbox, method, path string, payload any, out any) error {
+	if sandbox == nil {
+		return errors.New("sandbox is required")
+	}
+	procdURL, err := functionProcdURL(sandbox.InternalAddr, path)
+	if err != nil {
+		return err
+	}
+	var body io.Reader
+	if payload != nil {
+		data, err := json.Marshal(payload)
+		if err != nil {
+			return fmt.Errorf("encode procd request: %w", err)
+		}
+		body = bytes.NewReader(data)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, procdURL.String(), body)
+	if err != nil {
+		return err
+	}
+	token, err := s.functionProcdToken(sandbox)
+	if err != nil {
+		return err
+	}
+	req.Header.Set(internalauth.DefaultTokenHeader, token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.outboundHTTPClient().Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		data, _ := io.ReadAll(resp.Body)
+		if message, ok := spec.DecodeErrorMessage(data); ok {
+			return fmt.Errorf("procd returned %d: %s", resp.StatusCode, message)
+		}
+		return fmt.Errorf("procd returned %d", resp.StatusCode)
+	}
+	if out == nil {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil
+	}
+	value, apiErr, err := spec.DecodeResponse[json.RawMessage](resp.Body)
+	if err != nil {
+		return err
+	}
+	if apiErr != nil {
+		return errors.New(apiErr.Message)
+	}
+	if value == nil || len(*value) == 0 || string(*value) == "null" {
+		return nil
+	}
+	if err := json.Unmarshal(*value, out); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *Server) waitSandboxServiceReady(ctx context.Context, sandbox *mgr.Sandbox, service *mgr.SandboxAppService, route *mgr.SandboxAppServiceRoute) error {
+	timeout := s.sandboxServiceReadinessTimeout(route)
+	readyCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(sandboxServiceReadinessInterval)
+	defer ticker.Stop()
+
+	var lastErr error
+	for {
+		ready, err := s.checkSandboxServiceReady(readyCtx, sandbox, service)
+		if ready {
+			return nil
+		}
+		if err != nil {
+			lastErr = err
+		}
+		select {
+		case <-readyCtx.Done():
+			if lastErr != nil {
+				return fmt.Errorf("%w: %v", errSandboxServiceReadinessTimeout, lastErr)
+			}
+			return errSandboxServiceReadinessTimeout
+		case <-ticker.C:
+		}
+	}
+}
+
+func (s *Server) sandboxServiceReadinessTimeout(route *mgr.SandboxAppServiceRoute) time.Duration {
+	if route != nil && route.TimeoutSeconds > 0 {
+		return time.Duration(route.TimeoutSeconds) * time.Second
+	}
+	if s != nil && s.cfg != nil && s.cfg.ProxyTimeout.Duration > 0 {
+		return s.cfg.ProxyTimeout.Duration
+	}
+	return 10 * time.Second
+}
+
+func (s *Server) checkSandboxServiceReady(ctx context.Context, sandbox *mgr.Sandbox, service *mgr.SandboxAppService) (bool, error) {
+	targetURL, err := withPort(sandbox.InternalAddr, service.Port)
+	if err != nil {
+		return false, err
+	}
+	if service.HealthCheck != nil && strings.TrimSpace(service.HealthCheck.Path) != "" {
+		return s.checkSandboxServiceHTTPReady(ctx, targetURL, service.HealthCheck.Path)
+	}
+	return checkSandboxServiceTCPReady(ctx, targetURL)
+}
+
+func (s *Server) checkSandboxServiceHTTPReady(ctx context.Context, targetURL *url.URL, path string) (bool, error) {
+	healthURL := *targetURL
+	healthURL.Path = sandboxServiceHealthPath(path)
+	healthURL.RawQuery = ""
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, healthURL.String(), nil)
+	if err != nil {
+		return false, err
+	}
+	resp, err := s.outboundHTTPClient().Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return resp.StatusCode >= 200 && resp.StatusCode < 400, nil
+}
+
+func checkSandboxServiceTCPReady(ctx context.Context, targetURL *url.URL) (bool, error) {
+	host := targetURL.Hostname()
+	port := targetURL.Port()
+	if host == "" || port == "" {
+		return false, errors.New("service target address is missing host or port")
+	}
+	conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", net.JoinHostPort(host, port))
+	if err != nil {
+		return false, err
+	}
+	_ = conn.Close()
+	return true, nil
+}
+
+func sandboxServiceHealthPath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" || strings.HasPrefix(path, "/") {
+		return path
+	}
+	return "/" + path
+}

--- a/cluster-gateway/pkg/http/server.go
+++ b/cluster-gateway/pkg/http/server.go
@@ -14,8 +14,6 @@ import (
 	"github.com/sandbox0-ai/sandbox0/cluster-gateway/pkg/client"
 	"github.com/sandbox0-ai/sandbox0/cluster-gateway/pkg/middleware"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
-	mgr "github.com/sandbox0-ai/sandbox0/manager/pkg/service"
-	"github.com/sandbox0-ai/sandbox0/pkg/cache"
 	gatewayapikey "github.com/sandbox0-ai/sandbox0/pkg/gateway/apikey"
 	gatewaybuiltin "github.com/sandbox0-ai/sandbox0/pkg/gateway/auth/builtin"
 	gatewayoidc "github.com/sandbox0-ai/sandbox0/pkg/gateway/auth/oidc"
@@ -60,7 +58,6 @@ type Server struct {
 	entitlements          licensing.Entitlements
 	obsProvider           *observability.Provider
 	httpClient            *http.Client
-	exposureSandboxCache  *cache.Cache[string, *mgr.Sandbox]
 	sandboxServiceLimiter ratelimit.Limiter
 }
 
@@ -250,33 +247,28 @@ func NewServer(
 	}
 
 	server := &Server{
-		router:             router,
-		cfg:                cfg,
-		proxy2Mgr:          proxy2Mgr,
-		proxy2sp:           proxy2sp,
-		managerClient:      managerClient,
-		authMiddleware:     authMiddleware,
-		publicAuth:         publicAuth,
-		compositeAuth:      compositeAuth,
-		publicIdentityRepo: publicIdentityRepo,
-		publicAPIKeyRepo:   publicAPIKeyRepo,
-		rateLimiter:        rateLimiter,
-		externalLimiter:    externalLimiter,
-		publicBuiltin:      publicBuiltin,
-		publicOIDC:         publicOIDC,
-		publicJWT:          publicJWT,
-		requestLogger:      requestLogger,
-		logger:             logger,
-		meteringHandler:    meteringHandler,
-		internalAuthGen:    internalAuthGen,
-		entitlements:       entitlements,
-		obsProvider:        obsProvider,
-		httpClient:         httpClient,
-		exposureSandboxCache: cache.New[string, *mgr.Sandbox](cache.Config{
-			MaxSize:         4096,
-			TTL:             5 * time.Second,
-			CleanupInterval: 5 * time.Second,
-		}),
+		router:                router,
+		cfg:                   cfg,
+		proxy2Mgr:             proxy2Mgr,
+		proxy2sp:              proxy2sp,
+		managerClient:         managerClient,
+		authMiddleware:        authMiddleware,
+		publicAuth:            publicAuth,
+		compositeAuth:         compositeAuth,
+		publicIdentityRepo:    publicIdentityRepo,
+		publicAPIKeyRepo:      publicAPIKeyRepo,
+		rateLimiter:           rateLimiter,
+		externalLimiter:       externalLimiter,
+		publicBuiltin:         publicBuiltin,
+		publicOIDC:            publicOIDC,
+		publicJWT:             publicJWT,
+		requestLogger:         requestLogger,
+		logger:                logger,
+		meteringHandler:       meteringHandler,
+		internalAuthGen:       internalAuthGen,
+		entitlements:          entitlements,
+		obsProvider:           obsProvider,
+		httpClient:            httpClient,
 		sandboxServiceLimiter: sandboxServiceLimiter,
 	}
 

--- a/docs/sandbox/services/page.mdx
+++ b/docs/sandbox/services/page.mdx
@@ -1,87 +1,121 @@
 # Sandbox Services
 
-Sandbox Services expose named ports inside a sandbox. Use them when a sandbox needs public HTTP routes with method filtering, auth, CORS, rate limits, upstream timeout, path rewrite, and route-level resume behavior.
+Sandbox Services expose public HTTP entrypoints for workloads inside a sandbox. A service can point to a long-running listener on a sandbox port, start a command on first public access, or execute inline function code through procd.
 
-## Service Model
+Use services for:
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `id` | string | Stable service ID. Must be unique in the sandbox |
-| `display_name` | string | Optional human-readable label |
-| `port` | integer | Public exposure routing port. Function services normally use the procd port, default `49983` |
-| `runtime` | object | Optional restartable service process configuration |
-| `ingress` | object | Public exposure and route policy |
-| `health_check` | object | Optional readiness path |
+- public HTTP routes into a sandbox
+- route-level method filtering, auth, CORS, rate limits, timeout, and path rewrite
+- public URL auto-resume for paused or cleaned sandboxes
+- function handlers that do not run a long-lived HTTP server
 
-### Runtime
+## Mental Model
 
-Service runtime supports `cmd`, `warm_process`, `manual`, and `function`. Use `cmd` when Sandbox0 should create a new command context for the service. Use `warm_process` when the template already starts a long-lived process and the service should bind to that existing context. Use `function` when cluster-gateway should receive public HTTP traffic and ask procd to execute gateway-provided function source inside the sandbox.
+A sandbox service has three layers:
 
-### Health Check
+| Layer | Purpose |
+|-------|---------|
+| Service | Names the public entrypoint and, for listener-backed services, the sandbox port |
+| Runtime | Describes who owns the backing process: user, warm process, command, or function |
+| Route | Matches public HTTP requests and applies route policy before proxying or executing |
 
-`health_check.path` is the service readiness path. Services without `health_check.path` use TCP listen readiness as a fallback.
+The service response includes a `public_url` when `ingress.public` is true and the deployment has an exposure domain. Treat `public_url` as the service base URL. Append a route path when calling it.
 
-### Ingress
+```bash
+curl "$PUBLIC_URL/api/health"
+```
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `public` | boolean | Exposes the service on the deployment exposure domain |
-| `routes` | array | Ordered public HTTP routes for this service |
+## Runtime Behavior
 
-When `public` is true and `routes` is empty, Sandbox0 creates a default route using the service ID and `/`.
+When `runtime` is omitted, Sandbox0 treats the service as `manual`.
 
-### Route
+| Runtime | `port` | Public access behavior |
+|---------|--------|------------------------|
+| `manual` | Required | Sandbox0 proxies traffic to `port`. The template, user, or agent must keep the listener running |
+| `warm_process` | Required | Sandbox0 proxies traffic to `port`. Public access does not create a new process; the template warm process must already provide the listener |
+| `cmd` | Required | On public access, Sandbox0 creates the configured procd `cmd` context when it is missing, waits for readiness, then proxies traffic to `port` |
+| `function` | Omit | Sandbox0 routes the request to procd and executes the configured inline function source. No user-managed listener is required |
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `id` | string | Stable route ID. Must be unique within the service |
-| `path_prefix` | string | Request path prefix to match. Defaults to `/` |
-| `methods` | string array | Allowed HTTP methods. Empty allows every method |
-| `rewrite_prefix` | string or null | Optional path prefix replacement before proxying |
-| `auth` | object | Optional request authentication |
-| `cors` | object | Optional CORS policy |
-| `rate_limit` | object | Optional per-route rate limit |
-| `timeout_seconds` | integer | Optional upstream timeout in seconds |
-| `resume` | boolean | Whether this route may resume a paused sandbox when `auto_resume` is enabled |
+For `cmd` services, `health_check.path` controls readiness. If it is omitted, Sandbox0 falls back to a TCP connect check on the service port.
 
-### Resume Gates
+## Public URL Shape
 
-Public service auto-resume uses two gates:
+For listener-backed services, the public URL is derived from the sandbox ID, service port, region ID, and root domain:
 
-- sandbox `auto_resume` is the sandbox-level gate. When it is `false`, inbound access must not auto-resume the sandbox.
-- route `resume` is the route-level gate. Only matching public routes with `resume: true` may wake the sandbox.
+```text
+https://<sandbox_id>--p<port>.<region_id>.<root_domain>
+```
 
-Both gates must be enabled for a public URL request to resume a paused or cleaned sandbox. For a cleaned sandbox, Sandbox0 creates a new runtime pod for the same sandbox identity, so the `sandbox_id` and service `public_url` stay unchanged.
+For function services, the API still returns a service-level `public_url`, but the service uses Sandbox0's reserved function routing label:
 
-<Callout>
-Route rate limits use the gateway rate limit backend. Self-hosted deployments default to process-local memory for simple onboarding. Configure `Sandbox0Infra.spec.redis` when multiple gateway replicas need shared Redis-backed limits.
-</Callout>
+```text
+https://<sandbox_id>--p49983.<region_id>.<root_domain>
+```
 
-### Auth
+`49983` is an internal routing port for function services. Do not set it in function service config and do not depend on hand-built URLs. Use the `public_url` returned by `GET` or `PUT /api/v1/sandboxes/{'{id}'}/services`.
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `mode` | string | `none`, `bearer`, or `header` |
-| `bearer_token_sha256` | string | SHA-256 hex digest for bearer token auth |
-| `header_name` | string | Header name for header auth |
-| `header_value_sha256` | string | SHA-256 hex digest for header value auth |
+The URL itself does not include a route path. If a route has `path_prefix: /webhook`, call:
 
-<Callout variant="warning">
-Route auth stores SHA-256 digests, not plaintext tokens. Hash secret values before sending service configuration.
-</Callout>
+```bash
+curl -X POST "$PUBLIC_URL/webhook/github"
+```
+
+## Routes And Paths
+
+Routes are evaluated before proxying or function execution.
+
+| Field | Behavior |
+|-------|----------|
+| `path_prefix` | Matches request paths. Defaults to `/` |
+| `methods` | Allows only listed HTTP methods. Empty allows all methods |
+| `rewrite_prefix` | Rewrites the matched path prefix before proxying or function execution |
+| `auth` | Applies bearer or header authentication before the request reaches the sandbox |
+| `cors` | Handles CORS preflight and response headers at the gateway |
+| `rate_limit` | Applies per-route rate limiting at the gateway |
+| `timeout_seconds` | Sets the upstream or function execution timeout |
+| `resume` | Allows this route to resume a paused or cleaned sandbox when sandbox `auto_resume` is also true |
+
+`path_prefix` is not stripped automatically. Without `rewrite_prefix`, the upstream service or function handler sees the original request path.
+
+```yaml
+routes:
+    - id: webhook
+      path_prefix: /webhook
+      resume: true
+```
+
+A request to `$PUBLIC_URL/webhook/github` reaches the backing service or function as `/webhook/github`.
+
+To strip `/webhook`, set `rewrite_prefix: /`:
+
+```yaml
+routes:
+    - id: webhook
+      path_prefix: /webhook
+      rewrite_prefix: /
+      resume: true
+```
+
+The same request reaches the backing service or function as `/github`.
 
 ## Function Services
 
-A function service is a sandbox service with `runtime.type: function`. cluster-gateway owns the public URL, route policy, auth, CORS, rate limit, timeout, rewrite, and resume behavior. Function source is stored in the service config and carried by cluster-gateway to procd for execution inside the sandbox.
+A function service has `runtime.type: function`. It stores inline source code in the service config. On each matching public request, cluster-gateway applies route policy, forwards an execution request to procd, and returns the function handler response.
 
-Function services should use the sandbox procd port as the service `port`. The default procd port is `49983`. cluster-gateway only allows that reserved port for function services and never exposes procd management APIs publicly.
+Function services are different from listener-backed services:
 
-Python is the first supported runtime. The sandbox image must include `python3` in `PATH`. HTTP request/response, SSE, and WebSocket requests all use the same service config and route policy.
+- omit `port` in the request
+- do not start or expose a user HTTP listener
+- use the returned `public_url` as the only public entrypoint
+- may return normal HTTP responses, SSE streams, or WebSocket messages
+
+Python is the first supported function runtime. The sandbox image must include `python3` in `PATH`.
+
+### Function Config
 
 ```yaml
 services:
     - id: webhook
-      port: 49983
       runtime:
           type: function
           function:
@@ -89,13 +123,14 @@ services:
               handler: handler
               source:
                   type: inline
-                  filename: main.py
                   code: |
                       def handler(request):
                           return {
                               "status": 200,
                               "headers": {"content-type": "application/json"},
                               "body": {
+                                  "service_id": request["service_id"],
+                                  "route_id": request["route_id"],
                                   "method": request["method"],
                                   "path": request["path"],
                               },
@@ -103,193 +138,122 @@ services:
       ingress:
           public: true
           routes:
-              - id: root
-                path_prefix: /
+              - id: webhook
+                path_prefix: /webhook
                 methods: [POST]
                 timeout_seconds: 30
                 resume: true
 ```
 
-Configure a function service through the SDKs or CLI by replacing the sandbox service list. In the TypeScript generated model, the JSON field `function` is exposed as `_function`.
+Apply it with the CLI:
 
-<Tabs
-  tabs={[
-    {
-      label: "Go",
-      language: "go",
-      code: `functionSource := \`def handler(request):
-    return {"status": 200, "body": "ok"}
-\`
+```bash
+s0 sandbox service update --services-file function-services.yaml -s sb_abc123
+```
 
-resp, err := sandbox.UpdateServices(ctx, []apispec.SandboxAppService{
-    {
-        ID:   "handler",
-        Port: 49983,
-        Runtime: apispec.NewOptSandboxAppServiceRuntime(apispec.SandboxAppServiceRuntime{
-            Type: apispec.SandboxAppServiceRuntimeTypeFunction,
-            Function: apispec.NewOptSandboxFunction(apispec.SandboxFunction{
-                Runtime: apispec.SandboxFunctionRuntimePython,
-                Handler: apispec.NewOptString("handler"),
-                Source: apispec.SandboxFunctionSource{
-                    Type:     apispec.SandboxFunctionSourceTypeInline,
-                    Filename: apispec.NewOptString("main.py"),
-                    Code:     functionSource,
-                },
-            }),
-        }),
-        Ingress: apispec.SandboxAppServiceIngress{
-            Public: true,
-            Routes: []apispec.SandboxAppServiceRoute{
-                {
-                    ID:             "handler",
-                    PathPrefix:     apispec.NewOptString("/"),
-                    Methods:        []string{"POST"},
-                    TimeoutSeconds: apispec.NewOptInt32(30),
-                    Resume:         true,
-                },
+Or with the API:
+
+```json
+{
+    "services": [
+        {
+            "id": "webhook",
+            "runtime": {
+                "type": "function",
+                "function": {
+                    "runtime": "python",
+                    "handler": "handler",
+                    "source": {
+                        "type": "inline",
+                        "code": "def handler(request):\n    return {\n        \"status\": 200,\n        \"headers\": {\"content-type\": \"application/json\"},\n        \"body\": {\n            \"service_id\": request[\"service_id\"],\n            \"route_id\": request[\"route_id\"],\n            \"method\": request[\"method\"],\n            \"path\": request[\"path\"],\n        },\n    }\n"
+                    }
+                }
             },
-        },
-    },
-})
-if err != nil {
-    log.Fatal(err)
+            "ingress": {
+                "public": true,
+                "routes": [
+                    {
+                        "id": "webhook",
+                        "path_prefix": "/webhook",
+                        "methods": ["POST"],
+                        "timeout_seconds": 30,
+                        "resume": true
+                    }
+                ]
+            }
+        }
+    ]
 }
-fmt.Printf("services: %d\\n", len(resp.Services))`
-    },
-    {
-      label: "Python",
-      language: "python",
-      code: `from sandbox0.apispec.models.sandbox_app_service import SandboxAppService
-from sandbox0.apispec.models.sandbox_app_service_ingress import SandboxAppServiceIngress
-from sandbox0.apispec.models.sandbox_app_service_route import SandboxAppServiceRoute
-from sandbox0.apispec.models.sandbox_app_service_runtime import SandboxAppServiceRuntime
-from sandbox0.apispec.models.sandbox_app_service_runtime_type import SandboxAppServiceRuntimeType
-from sandbox0.apispec.models.sandbox_function import SandboxFunction
-from sandbox0.apispec.models.sandbox_function_runtime import SandboxFunctionRuntime
-from sandbox0.apispec.models.sandbox_function_source import SandboxFunctionSource
-from sandbox0.apispec.models.sandbox_function_source_type import SandboxFunctionSourceType
+```
 
-function_source = """def handler(request):
-    return {"status": 200, "body": "ok"}
-"""
+```bash
+curl -X PUT "$SANDBOX0_API_URL/api/v1/sandboxes/$SANDBOX_ID/services" \
+    -H "authorization: Bearer $SANDBOX0_API_TOKEN" \
+    -H "x-team-id: $SANDBOX0_TEAM_ID" \
+    -H "content-type: application/json" \
+    --data-binary @function-services.json
+```
 
-resp = sandbox.update_services([
-    SandboxAppService(
-        id="handler",
-        port=49983,
-        runtime=SandboxAppServiceRuntime(
-            type_=SandboxAppServiceRuntimeType.FUNCTION,
-            function=SandboxFunction(
-                runtime=SandboxFunctionRuntime.PYTHON,
-                handler="handler",
-                source=SandboxFunctionSource(
-                    type_=SandboxFunctionSourceType.INLINE,
-                    filename="main.py",
-                    code=function_source,
-                ),
-            ),
-        ),
-        ingress=SandboxAppServiceIngress(
-            public=True,
-            routes=[
-                SandboxAppServiceRoute(
-                    id="handler",
-                    path_prefix="/",
-                    methods=["POST"],
-                    timeout_seconds=30,
-                    resume=True,
-                ),
-            ],
-        ),
-    ),
-])
-print(f"services: {len(resp.services)}")`
-    },
-    {
-      label: "TypeScript",
-      language: "typescript",
-      code: `const functionSource = \`def handler(request):
-    return {"status": 200, "body": "ok"}
-\`;
+The service response includes a `public_url`:
 
-const resp = await sandbox.updateServices([
-    {
-        id: 'handler',
-        port: 49983,
-        runtime: {
-            type: 'function',
-            _function: {
-                runtime: 'python',
-                handler: 'handler',
-                source: {
-                    type: 'inline',
-                    filename: 'main.py',
-                    code: functionSource,
-                },
-            },
-        },
-        ingress: {
-            public: true,
-            routes: [
-                {
-                    id: 'handler',
-                    pathPrefix: '/',
-                    methods: ['POST'],
-                    timeoutSeconds: 30,
-                    resume: true,
-                },
-            ],
-        },
-    },
-]);
-console.log('services:', resp.services?.length ?? 0);`
-    },
-    {
-      label: "CLI",
-      language: "bash",
-      code: `cat > function-services.yaml <<'EOF'
-services:
-  - id: handler
-    port: 49983
-    runtime:
-      type: function
-      function:
-        runtime: python
-        handler: handler
-        source:
-          type: inline
-          filename: main.py
-          code: |
-            def handler(request):
-                return {"status": 200, "body": "ok"}
-    ingress:
-      public: true
-      routes:
-        - id: handler
-          path_prefix: /
-          methods: [POST]
-          timeout_seconds: 30
-          resume: true
-EOF
-
-s0 sandbox service update --services-file function-services.yaml -s sb_abc123`
+```json
+{
+    "success": true,
+    "data": {
+        "sandbox_id": "rs-example",
+        "exposure_domain": "aws-us-east-1.sandbox0.app",
+        "services": [
+            {
+                "id": "webhook",
+                "port": 49983,
+                "public_url": "https://rs-example--p49983.aws-us-east-1.sandbox0.app"
+            }
+        ]
     }
-  ]}
-/>
+}
+```
 
-The handler receives a request object with:
+The response includes `port: 49983` because Sandbox0 normalizes the service for routing. Do not send `port` when configuring a function service.
+
+### Call A Function
+
+Use the returned `public_url` and append a path that matches the route.
+
+```bash
+curl -X POST "$PUBLIC_URL/webhook/github" \
+    -H "content-type: application/json" \
+    -d '{"event":"ping"}'
+```
+
+With the config above, the function handler receives:
+
+```json
+{
+    "service_id": "webhook",
+    "route_id": "webhook",
+    "method": "POST",
+    "path": "/webhook/github",
+    "body_base64": "eyJldmVudCI6InBpbmcifQ=="
+}
+```
+
+The function response is the HTTP response body and status. The function does not return a URL.
+
+### Function Request Object
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `service_id` | string | Matched service ID |
 | `route_id` | string | Matched route ID |
 | `method` | string | HTTP method |
-| `path` | string | Request path after route rewrite |
+| `path` | string | Request path after any `rewrite_prefix` |
 | `raw_query` | string | Raw query string |
-| `headers` | object | HTTP headers |
+| `headers` | object | Request headers |
 | `body_base64` | string | Base64-encoded request body |
 
-The handler returns either a value or a response object:
+### Function Return Value
+
+Handlers may return any JSON-serializable value, or a response object.
 
 ```python
 def handler(request):
@@ -300,7 +264,7 @@ def handler(request):
     }
 ```
 
-For SSE, clients send `Accept: text/event-stream`. The handler can return a response object whose `body` is a Python iterable or async iterable. Each yielded string or bytes value is streamed and flushed to the client.
+For SSE, clients send `Accept: text/event-stream`. Return an iterable or async iterable body.
 
 ```python
 def handler(request):
@@ -315,7 +279,7 @@ def handler(request):
     }
 ```
 
-For WebSocket requests, define an async handler that accepts `(request, ws)`. The `ws` object supports `receive()`, `send(value)`, `close(reason="")`, and async iteration. Text messages are strings; binary messages are bytes.
+For WebSocket requests, define an async handler that accepts `(request, ws)`.
 
 ```python
 async def handler(request, ws):
@@ -323,13 +287,111 @@ async def handler(request, ws):
         await ws.send("echo:" + message)
 ```
 
-## List Services
+## Cmd Services
+
+A `cmd` service starts a procd command on first matching public access when the service command is not already running. Sandbox0 injects these environment variables into the command:
+
+| Environment variable | Value |
+|----------------------|-------|
+| `SANDBOX0_SERVICE_ID` | Service ID |
+| `SANDBOX0_SERVICE_PORT` | Configured service port |
+| `SANDBOX0_SERVICE_RUNTIME` | `cmd` |
+
+```yaml
+services:
+    - id: api
+      port: 8080
+      runtime:
+          type: cmd
+          command:
+              - python3
+              - -c
+              - |
+                  import http.server
+                  import json
+                  import os
+                  import socketserver
+
+                  port = int(os.environ["SANDBOX0_SERVICE_PORT"])
+
+                  class Handler(http.server.BaseHTTPRequestHandler):
+                      def do_GET(self):
+                          if self.path == "/healthz":
+                              self.send_response(204)
+                              self.end_headers()
+                              return
+                          self.send_response(200)
+                          self.send_header("content-type", "application/json")
+                          self.end_headers()
+                          self.wfile.write(json.dumps({
+                              "service_id": os.environ["SANDBOX0_SERVICE_ID"],
+                              "path": self.path,
+                          }).encode())
+
+                  socketserver.TCPServer(("", port), Handler).serve_forever()
+      health_check:
+          path: /healthz
+      ingress:
+          public: true
+          routes:
+              - id: api
+                path_prefix: /api
+                rewrite_prefix: /
+                methods: [GET]
+                timeout_seconds: 30
+                resume: true
+```
+
+After applying this service, the first request starts the command, waits for `/healthz`, rewrites `/api/hello` to `/hello`, and proxies to the command.
+
+```bash
+curl "$PUBLIC_URL/api/hello"
+```
+
+## Manual And Warm Process Services
+
+Use `manual` when another actor starts and owns the listener.
+
+```yaml
+services:
+    - id: web
+      port: 3000
+      runtime:
+          type: manual
+      ingress:
+          public: true
+          routes:
+              - id: web
+                path_prefix: /
+                resume: true
+```
+
+Use `warm_process` when the template already starts the listener as a warm process. Public access does not create another process.
+
+```yaml
+services:
+    - id: web
+      port: 3000
+      runtime:
+          type: warm_process
+          warm_process_name: web
+      ingress:
+          public: true
+          routes:
+              - id: web
+                path_prefix: /
+                resume: true
+```
+
+## API Reference
+
+### List Services
 
 <Endpoint method="GET">
 /api/v1/sandboxes/{'{id}'}/services
 </Endpoint>
 
-The response includes `publishable`, `publish_blockers`, `public_url`, and `exposure_domain`.
+The response includes the normalized services, `publishable`, `publish_blockers`, `public_url`, and `exposure_domain`.
 
 <Tabs
   tabs={[
@@ -340,27 +402,24 @@ The response includes `publishable`, `publish_blockers`, `public_url`, and `expo
 if err != nil {
     log.Fatal(err)
 }
-fmt.Printf("services: %d\\n", len(resp.Services))
 for _, service := range resp.Services {
-    fmt.Printf("%s -> port %d url=%s\\n", service.ID, service.Port, service.PublicURL.Or(""))
+    fmt.Printf("%s url=%s port=%d\\n", service.ID, service.PublicURL.Or(""), service.Port.Or(0))
+}`
+    },
+    {
+      label: "TypeScript",
+      language: "typescript",
+      code: `const resp = await sandbox.getServices();
+for (const service of resp.services ?? []) {
+    console.log(\`\${service.id} url=\${service.publicUrl ?? ''} port=\${service.port ?? ''}\`);
 }`
     },
     {
       label: "Python",
       language: "python",
       code: `resp = sandbox.get_services()
-print(f"services: {len(resp.services)}")
 for service in resp.services:
-    print(f"{service.id} -> port {service.port}")`
-    },
-    {
-      label: "TypeScript",
-      language: "typescript",
-      code: `const resp = await sandbox.getServices();
-console.log('services:', resp.services?.length ?? 0);
-for (const service of resp.services ?? []) {
-    console.log(\`\${service.id} -> port \${service.port}\`);
-}`
+    print(f"{service.id} url={service.public_url} port={service.port}")`
     },
     {
       label: "CLI",
@@ -370,13 +429,13 @@ for (const service of resp.services ?? []) {
   ]}
 />
 
-## Replace Services
+### Replace Services
 
 <Endpoint method="PUT">
 /api/v1/sandboxes/{'{id}'}/services
 </Endpoint>
 
-The update replaces the full service list. Include every service that should remain active.
+`PUT` replaces the full service list. Include every service that should remain active.
 
 <Tabs
   tabs={[
@@ -388,7 +447,7 @@ The update replaces the full service list. Include every service that should rem
 resp, err := sandbox.UpdateServices(ctx, []apispec.SandboxAppService{
     {
         ID:   "api",
-        Port: 8080,
+        Port: apispec.NewOptInt32(8080),
         Ingress: apispec.SandboxAppServiceIngress{
             Public: true,
             Routes: []apispec.SandboxAppServiceRoute{
@@ -399,10 +458,6 @@ resp, err := sandbox.UpdateServices(ctx, []apispec.SandboxAppService{
                     Auth: apispec.NewOptSandboxAppServiceRouteAuth(apispec.SandboxAppServiceRouteAuth{
                         Mode:              apispec.SandboxAppServiceRouteAuthModeBearer,
                         BearerTokenSHA256: apispec.NewOptString(hex.EncodeToString(tokenHash[:])),
-                    }),
-                    RateLimit: apispec.NewOptSandboxAppServiceRouteRateLimit(apispec.SandboxAppServiceRouteRateLimit{
-                        Rps:   20,
-                        Burst: 40,
                     }),
                     TimeoutSeconds: apispec.NewOptInt32(30),
                     Resume:         true,
@@ -417,6 +472,39 @@ if err != nil {
 fmt.Printf("services: %d\\n", len(resp.Services))`
     },
     {
+      label: "TypeScript",
+      language: "typescript",
+      code: `import { createHash } from 'node:crypto';
+
+const tokenHash = createHash('sha256')
+    .update(process.env.PUBLIC_API_TOKEN!)
+    .digest('hex');
+
+const resp = await sandbox.updateServices([
+    {
+        id: 'api',
+        port: 8080,
+        ingress: {
+            _public: true,
+            routes: [
+                {
+                    id: 'api',
+                    pathPrefix: '/api',
+                    methods: ['GET', 'POST'],
+                    auth: {
+                        mode: 'bearer',
+                        bearerTokenSha256: tokenHash,
+                    },
+                    timeoutSeconds: 30,
+                    resume: true,
+                },
+            ],
+        },
+    },
+]);
+console.log('services:', resp.services?.length ?? 0);`
+    },
+    {
       label: "Python",
       language: "python",
       code: `import hashlib
@@ -427,7 +515,6 @@ from sandbox0.apispec.models.sandbox_app_service_ingress import SandboxAppServic
 from sandbox0.apispec.models.sandbox_app_service_route import SandboxAppServiceRoute
 from sandbox0.apispec.models.sandbox_app_service_route_auth import SandboxAppServiceRouteAuth
 from sandbox0.apispec.models.sandbox_app_service_route_auth_mode import SandboxAppServiceRouteAuthMode
-from sandbox0.apispec.models.sandbox_app_service_route_rate_limit import SandboxAppServiceRouteRateLimit
 
 token_hash = hashlib.sha256(os.environ["PUBLIC_API_TOKEN"].encode()).hexdigest()
 
@@ -446,7 +533,6 @@ resp = sandbox.update_services([
                         mode=SandboxAppServiceRouteAuthMode.BEARER,
                         bearer_token_sha256=token_hash,
                     ),
-                    rate_limit=SandboxAppServiceRouteRateLimit(rps=20, burst=40),
                     timeout_seconds=30,
                     resume=True,
                 ),
@@ -457,173 +543,14 @@ resp = sandbox.update_services([
 print(f"services: {len(resp.services)}")`
     },
     {
-      label: "TypeScript",
-      language: "typescript",
-      code: `import { createHash } from 'node:crypto';
-
-const tokenHash = createHash('sha256')
-    .update(process.env.PUBLIC_API_TOKEN!)
-    .digest('hex');
-
-const resp = await sandbox.updateServices([
-    {
-        id: 'api',
-        port: 8080,
-        ingress: {
-            public: true,
-            routes: [
-                {
-                    id: 'api',
-                    pathPrefix: '/api',
-                    methods: ['GET', 'POST'],
-                    auth: {
-                        mode: 'bearer',
-                        bearerTokenSha256: tokenHash,
-                    },
-                    rateLimit: {
-                        rps: 20,
-                        burst: 40,
-                    },
-                    timeoutSeconds: 30,
-                    resume: true,
-                },
-            ],
-        },
-    },
-]);
-console.log('services:', resp.services?.length ?? 0);`
-    },
-    {
       label: "CLI",
       language: "bash",
-      code: `TOKEN_HASH="$(printf %s "$PUBLIC_API_TOKEN" | sha256sum | awk '{print $1}')"
-
-cat > services.yaml <<EOF
-services:
-  - id: api
-    port: 8080
-    ingress:
-      public: true
-      routes:
-        - id: api
-          path_prefix: /api
-          methods: [GET, POST]
-          auth:
-            mode: bearer
-            bearer_token_sha256: "$TOKEN_HASH"
-          rate_limit:
-            rps: 20
-            burst: 40
-          timeout_seconds: 30
-          resume: true
-EOF
-
-s0 sandbox service update --services-file services.yaml -s sb_abc123`
+      code: `s0 sandbox service update --services-file services.yaml -s sb_abc123`
     }
   ]}
 />
 
-## Set Services At Claim Time
-
-You can attach services when claiming a sandbox. This is useful when the sandbox starts a known HTTP service during boot.
-
-<Tabs
-  tabs={[
-    {
-      label: "Go",
-      language: "go",
-      code: `sandbox, err := client.ClaimSandbox(ctx, "default",
-    sandbox0.WithSandboxAutoResume(true),
-    sandbox0.WithSandboxServices([]apispec.SandboxAppService{
-        {
-            ID:   "web",
-            Port: 3000,
-            Ingress: apispec.SandboxAppServiceIngress{
-                Public: true,
-                Routes: []apispec.SandboxAppServiceRoute{
-                    {
-                        ID:         "web",
-                        PathPrefix: apispec.NewOptString("/"),
-                        Resume:     true,
-                    },
-                },
-            },
-        },
-    }),
-)
-if err != nil {
-    log.Fatal(err)
-}`
-    },
-    {
-      label: "Python",
-      language: "python",
-      code: `from sandbox0.apispec.models.sandbox_config import SandboxConfig
-
-sandbox = client.sandboxes.claim(
-    "default",
-    config=SandboxConfig.from_dict({
-        "auto_resume": True,
-        "services": [
-            {
-                "id": "web",
-                "port": 3000,
-                "ingress": {
-                    "public": True,
-                    "routes": [
-                        {
-                            "id": "web",
-                            "path_prefix": "/",
-                            "resume": True,
-                        },
-                    ],
-                },
-            },
-        ],
-    }),
-)`
-    },
-    {
-      label: "TypeScript",
-      language: "typescript",
-      code: `const sandbox = await client.sandboxes.claim('default', {
-    autoResume: true,
-    services: [
-        {
-            id: 'web',
-            port: 3000,
-            ingress: {
-                public: true,
-                routes: [{ id: 'web', pathPrefix: '/', resume: true }],
-            },
-        },
-    ],
-});`
-    },
-    {
-      label: "CLI",
-      language: "bash",
-      code: `cat > sandbox.yaml <<EOF
-template: default
-config:
-  auto_resume: true
-  services:
-    - id: web
-      port: 3000
-      ingress:
-        public: true
-        routes:
-          - id: web
-            path_prefix: /
-            resume: true
-EOF
-
-s0 sandbox create -f sandbox.yaml`
-    }
-  ]}
-/>
-
-## Clear Services
+### Clear Services
 
 Clearing services removes public HTTP exposure from the sandbox.
 
@@ -638,14 +565,14 @@ if err != nil {
 }`
     },
     {
-      label: "Python",
-      language: "python",
-      code: `sandbox.clear_services()`
-    },
-    {
       label: "TypeScript",
       language: "typescript",
       code: `await sandbox.clearServices();`
+    },
+    {
+      label: "Python",
+      language: "python",
+      code: `sandbox.clear_services()`
     },
     {
       label: "CLI",
@@ -655,13 +582,175 @@ if err != nil {
   ]}
 />
 
-## Behavior Notes
+## Set Services At Claim Time
 
-- Public HTTP traffic must match a route on a public service.
-- If `methods` is empty, every HTTP method is allowed for that route.
-- Public URL auto-resume requires both sandbox `auto_resume: true` and route `resume: true`.
-- Public service responses include `public_url`, derived from the deployment exposure domain as `https://{sandbox_id}--p{port}.{exposure_domain}`.
-- Public URLs remain reserved for a `cleaned` sandbox. A later request can start a new runtime pod without changing the URL, and the URL becomes unavailable only after explicit sandbox deletion.
+You can attach services when claiming a sandbox. Function services may omit `port` in claim config just as they do in `PUT /services`.
+
+```yaml
+template: default
+config:
+    auto_resume: true
+    services:
+        - id: webhook
+          runtime:
+              type: function
+              function:
+                  runtime: python
+                  handler: handler
+                  source:
+                      type: inline
+                      code: |
+                          def handler(request):
+                              return {"status": 200, "body": "ok"}
+          ingress:
+              public: true
+              routes:
+                  - id: webhook
+                    path_prefix: /webhook
+                    methods: [POST]
+                    resume: true
+```
+
+<Tabs
+  tabs={[
+    {
+      label: "Go",
+      language: "go",
+      code: `functionSource := "def handler(request):\\n    return {\\"status\\": 200, \\"body\\": \\"ok\\"}\\n"
+
+sandbox, err := client.ClaimSandbox(ctx, "default",
+    sandbox0.WithSandboxAutoResume(true),
+    sandbox0.WithSandboxServices([]apispec.SandboxAppService{
+        {
+            ID: "webhook",
+            Runtime: apispec.NewOptSandboxAppServiceRuntime(apispec.SandboxAppServiceRuntime{
+                Type: apispec.SandboxAppServiceRuntimeTypeFunction,
+                Function: apispec.NewOptSandboxFunction(apispec.SandboxFunction{
+                    Runtime: apispec.SandboxFunctionRuntimePython,
+                    Handler: apispec.NewOptString("handler"),
+                    Source: apispec.SandboxFunctionSource{
+                        Type: apispec.SandboxFunctionSourceTypeInline,
+                        Code: functionSource,
+                    },
+                }),
+            }),
+            Ingress: apispec.SandboxAppServiceIngress{
+                Public: true,
+                Routes: []apispec.SandboxAppServiceRoute{
+                    {
+                        ID:         "webhook",
+                        PathPrefix: apispec.NewOptString("/webhook"),
+                        Methods:    []string{"POST"},
+                        Resume:     true,
+                    },
+                },
+            },
+        },
+    }),
+)
+if err != nil {
+    log.Fatal(err)
+}`
+    },
+    {
+      label: "TypeScript",
+      language: "typescript",
+      code: `const sandbox = await client.sandboxes.claim('default', {
+    autoResume: true,
+    services: [
+        {
+            id: 'webhook',
+            runtime: {
+                type: 'function',
+                _function: {
+                    runtime: 'python',
+                    handler: 'handler',
+                    source: {
+                        type: 'inline',
+                        code: 'def handler(request):\\n    return {"status": 200, "body": "ok"}\\n',
+                    },
+                },
+            },
+            ingress: {
+                _public: true,
+                routes: [
+                    {
+                        id: 'webhook',
+                        pathPrefix: '/webhook',
+                        methods: ['POST'],
+                        resume: true,
+                    },
+                ],
+            },
+        },
+    ],
+});`
+    },
+    {
+      label: "Python",
+      language: "python",
+      code: `from sandbox0.apispec.models.sandbox_config import SandboxConfig
+
+sandbox = client.sandboxes.claim(
+    "default",
+    config=SandboxConfig.from_dict({
+        "auto_resume": True,
+        "services": [
+            {
+                "id": "webhook",
+                "runtime": {
+                    "type": "function",
+                    "function": {
+                        "runtime": "python",
+                        "handler": "handler",
+                        "source": {
+                            "type": "inline",
+                            "code": "def handler(request):\\n    return {'status': 200, 'body': 'ok'}\\n",
+                        },
+                    },
+                },
+                "ingress": {
+                    "public": True,
+                    "routes": [
+                        {
+                            "id": "webhook",
+                            "path_prefix": "/webhook",
+                            "methods": ["POST"],
+                            "resume": True,
+                        },
+                    ],
+                },
+            },
+        ],
+    }),
+)`
+    },
+    {
+      label: "CLI",
+      language: "bash",
+      code: `s0 sandbox create -f sandbox.yaml`
+    }
+  ]}
+/>
+
+## Auto-Resume
+
+Public service auto-resume has two gates:
+
+- sandbox `auto_resume` must be true
+- matched route `resume` must be true
+
+Both gates are required for public URL requests to wake a paused sandbox or a cleaned sandbox.
+
+For a cleaned sandbox, Sandbox0 creates a new runtime pod for the same sandbox identity. The sandbox ID and service `public_url` stay unchanged. For `cmd` services, the command is started again in the new runtime pod. For `function` services, there is still no long-running listener; each request executes the handler after the sandbox runtime is available.
+
+## Notes
+
+- `PUT /services` replaces the entire service list.
+- Public traffic must match a route on a public service.
+- If `methods` is empty, all methods are allowed.
+- Route auth stores SHA-256 digests, not plaintext tokens.
+- Route rate limits use the gateway rate limit backend. Self-hosted deployments default to process-local memory; configure `Sandbox0Infra.spec.redis` for shared Redis-backed limits across gateway replicas.
 
 ## Next Steps
 
@@ -670,7 +759,7 @@ if err != nil {
     Receive signed sandbox lifecycle, service, and file-related events.
   </Card>
 
-  <Card title="Overview" href="/docs/sandbox" cta="Continue">
-    Review sandbox configuration, lifecycle, and runtime controls.
+  <Card title="Contexts" href="/docs/sandbox/contexts" cta="Continue">
+    Create and inspect the command processes that can back services.
   </Card>
 </CardGroup>

--- a/manager/pkg/service/sandbox_app_service.go
+++ b/manager/pkg/service/sandbox_app_service.go
@@ -26,7 +26,6 @@ const (
 var sandboxServiceRouteIDPattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`)
 var httpMethodPattern = regexp.MustCompile(`^[A-Z][A-Z0-9_-]*$`)
 var sandboxFunctionHandlerPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$`)
-var sandboxFunctionFilenamePattern = regexp.MustCompile(`^[A-Za-z0-9_.-]+$`)
 
 // SandboxAppServiceRouteAuth controls inbound authentication for one public route.
 type SandboxAppServiceRouteAuth struct {
@@ -88,9 +87,8 @@ type SandboxFunction struct {
 
 // SandboxFunctionSource carries user function code in sandbox service config.
 type SandboxFunctionSource struct {
-	Type     string `json:"type"`
-	Filename string `json:"filename,omitempty"`
-	Code     string `json:"code,omitempty"`
+	Type string `json:"type"`
+	Code string `json:"code,omitempty"`
 }
 
 // SandboxAppServiceIngress captures how traffic enters a sandbox service.
@@ -163,9 +161,7 @@ func normalizeSandboxAppService(service SandboxAppService) (SandboxAppService, e
 		return service, fmt.Errorf("id must be a DNS label")
 	}
 	service.DisplayName = strings.TrimSpace(service.DisplayName)
-	if service.Port <= 0 || service.Port > 65535 {
-		return service, fmt.Errorf("port must be between 1 and 65535")
-	}
+	runtimeType := SandboxAppServiceRuntimeManual
 	if service.Runtime != nil {
 		runtime := *service.Runtime
 		runtime.Type = strings.ToLower(strings.TrimSpace(runtime.Type))
@@ -179,6 +175,7 @@ func normalizeSandboxAppService(service SandboxAppService) (SandboxAppService, e
 		if runtime.Type == "" {
 			runtime.Type = SandboxAppServiceRuntimeManual
 		}
+		runtimeType = runtime.Type
 		if runtime.Type == SandboxAppServiceRuntimeCMD && len(runtime.Command) == 0 {
 			return service, fmt.Errorf("runtime.command is required for cmd services")
 		}
@@ -195,6 +192,21 @@ func normalizeSandboxAppService(service SandboxAppService) (SandboxAppService, e
 			runtime.Function = nil
 		}
 		service.Runtime = &runtime
+	}
+	if runtimeType == SandboxAppServiceRuntimeFunction {
+		if service.Port == 0 {
+			service.Port = sandboxfunction.DefaultServicePort
+		}
+		if service.Port != sandboxfunction.DefaultServicePort {
+			return service, fmt.Errorf("port must be omitted or %d for function services", sandboxfunction.DefaultServicePort)
+		}
+	} else {
+		if service.Port <= 0 || service.Port > 65535 {
+			return service, fmt.Errorf("port must be between 1 and 65535")
+		}
+		if service.Port == sandboxfunction.DefaultServicePort {
+			return service, fmt.Errorf("port %d is reserved for function services", sandboxfunction.DefaultServicePort)
+		}
 	}
 	if service.Ingress.Public && len(service.Ingress.Routes) == 0 {
 		service.Ingress.Routes = []SandboxAppServiceRoute{{
@@ -314,16 +326,6 @@ func normalizeSandboxFunction(function *SandboxFunction) (*SandboxFunction, erro
 	}
 	if source.Type != sandboxfunction.SourceTypeInline {
 		return nil, fmt.Errorf("source.type must be %q", sandboxfunction.SourceTypeInline)
-	}
-	source.Filename = strings.TrimSpace(source.Filename)
-	if source.Filename == "" {
-		source.Filename = sandboxfunction.DefaultFilename
-	}
-	if strings.Contains(source.Filename, "/") || strings.Contains(source.Filename, "\\") || strings.HasPrefix(source.Filename, ".") {
-		return nil, fmt.Errorf("source.filename must be a relative file name")
-	}
-	if !sandboxFunctionFilenamePattern.MatchString(source.Filename) {
-		return nil, fmt.Errorf("source.filename contains unsupported characters")
 	}
 	if strings.TrimSpace(source.Code) == "" {
 		return nil, fmt.Errorf("source.code is required")

--- a/manager/pkg/service/sandbox_app_service_test.go
+++ b/manager/pkg/service/sandbox_app_service_test.go
@@ -111,8 +111,7 @@ func TestSandboxAppServicePublishBlockersRequirePublicRestartableRuntime(t *test
 
 func TestNormalizeSandboxAppServicesSupportsFunctionRuntime(t *testing.T) {
 	services, err := NormalizeSandboxAppServices([]SandboxAppService{{
-		ID:   "webhook",
-		Port: 49983,
+		ID: "webhook",
 		Runtime: &SandboxAppServiceRuntime{
 			Type: SandboxAppServiceRuntimeFunction,
 			Function: &SandboxFunction{
@@ -142,8 +141,8 @@ func TestNormalizeSandboxAppServicesSupportsFunctionRuntime(t *testing.T) {
 	if service.Runtime.Function.Source.Type != "inline" {
 		t.Fatalf("function source type = %q, want inline", service.Runtime.Function.Source.Type)
 	}
-	if service.Runtime.Function.Source.Filename != "main.py" {
-		t.Fatalf("function filename = %q, want main.py", service.Runtime.Function.Source.Filename)
+	if service.Port != 49983 {
+		t.Fatalf("function service port = %d, want 49983", service.Port)
 	}
 	if len(service.Runtime.Command) != 0 || service.Runtime.CWD != "" || service.Runtime.WarmProcessName != "" {
 		t.Fatalf("function runtime kept process fields: %#v", service.Runtime)
@@ -164,8 +163,8 @@ func TestNormalizeSandboxAppServicesRejectsInvalidFunctionSource(t *testing.T) {
 			Type: SandboxAppServiceRuntimeFunction,
 			Function: &SandboxFunction{
 				Source: SandboxFunctionSource{
-					Filename: "../main.py",
-					Code:     "def handler(request):\n    return None\n",
+					Type: "git",
+					Code: "def handler(request):\n    return None\n",
 				},
 			},
 		},
@@ -173,5 +172,38 @@ func TestNormalizeSandboxAppServicesRejectsInvalidFunctionSource(t *testing.T) {
 	}})
 	if err == nil {
 		t.Fatal("NormalizeSandboxAppServices succeeded, want error")
+	}
+}
+
+func TestNormalizeSandboxAppServicesRejectsWrongFunctionPort(t *testing.T) {
+	_, err := NormalizeSandboxAppServices([]SandboxAppService{{
+		ID:   "webhook",
+		Port: 8080,
+		Runtime: &SandboxAppServiceRuntime{
+			Type: SandboxAppServiceRuntimeFunction,
+			Function: &SandboxFunction{
+				Source: SandboxFunctionSource{
+					Code: "def handler(request):\n    return None\n",
+				},
+			},
+		},
+		Ingress: SandboxAppServiceIngress{Public: true},
+	}})
+	if err == nil {
+		t.Fatal("NormalizeSandboxAppServices succeeded, want wrong function port error")
+	}
+}
+
+func TestNormalizeSandboxAppServicesRejectsMissingNonFunctionPort(t *testing.T) {
+	_, err := NormalizeSandboxAppServices([]SandboxAppService{{
+		ID: "api",
+		Runtime: &SandboxAppServiceRuntime{
+			Type:    SandboxAppServiceRuntimeCMD,
+			Command: []string{"python3", "-m", "http.server", "8080"},
+		},
+		Ingress: SandboxAppServiceIngress{Public: true},
+	}})
+	if err == nil {
+		t.Fatal("NormalizeSandboxAppServices succeeded, want missing port error")
 	}
 }

--- a/manager/procd/pkg/http/handlers/function.go
+++ b/manager/procd/pkg/http/handlers/function.go
@@ -38,9 +38,8 @@ const (
 )
 
 var (
-	functionHandlerPattern  = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$`)
-	functionFilenamePattern = regexp.MustCompile(`^[A-Za-z0-9_.-]+$`)
-	functionDigestPattern   = regexp.MustCompile(`^sha256:[a-f0-9]{64}$`)
+	functionHandlerPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$`)
+	functionDigestPattern  = regexp.MustCompile(`^sha256:[a-f0-9]{64}$`)
 )
 
 type functionHandlerConfig struct {
@@ -322,13 +321,13 @@ func (h *FunctionHandler) requestTimeout(timeoutMS int) (time.Duration, error) {
 func (h *FunctionHandler) materializeSource(source sandboxfunction.Source) (string, error) {
 	digest := source.Digest
 	if digest == "" {
-		digest = sandboxfunction.InlineDigest(source.Filename, source.Code)
+		digest = sandboxfunction.InlineDigest(source.Code)
 	}
 	if !functionDigestPattern.MatchString(digest) {
 		return "", errors.New("source.digest must be a sha256 digest")
 	}
-	expected := sandboxfunction.InlineDigest(source.Filename, source.Code)
-	if source.Code != "" && digest != expected {
+	expected := sandboxfunction.InlineDigest(source.Code)
+	if source.Code != "" && digest != expected && digest != sandboxfunction.LegacyInlineDigest(source.Filename, source.Code) {
 		return "", errors.New("source.digest does not match source code")
 	}
 	dirName := strings.TrimPrefix(digest, "sha256:")
@@ -336,11 +335,7 @@ func (h *FunctionHandler) materializeSource(source sandboxfunction.Source) (stri
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return "", fmt.Errorf("prepare function source cache: %w", err)
 	}
-	modulePath := filepath.Join(dir, source.Filename)
-	rel, err := filepath.Rel(dir, modulePath)
-	if err != nil || strings.HasPrefix(rel, "..") || filepath.IsAbs(rel) {
-		return "", errors.New("source.filename escapes source cache")
-	}
+	modulePath := filepath.Join(dir, sandboxfunction.DefaultFilename)
 	if source.Code != "" {
 		if err := os.WriteFile(modulePath, []byte(source.Code), 0o600); err != nil {
 			return "", fmt.Errorf("write function source: %w", err)
@@ -632,15 +627,6 @@ func validateFunctionExecuteRequest(req sandboxfunction.ExecuteRequest) error {
 	}
 	if req.Source.Type != sandboxfunction.SourceTypeInline {
 		return fmt.Errorf("source.type must be %q", sandboxfunction.SourceTypeInline)
-	}
-	if req.Source.Filename == "" {
-		return errors.New("source.filename is required")
-	}
-	if strings.Contains(req.Source.Filename, "/") || strings.Contains(req.Source.Filename, "\\") || strings.HasPrefix(req.Source.Filename, ".") {
-		return errors.New("source.filename must be a relative file name")
-	}
-	if !functionFilenamePattern.MatchString(req.Source.Filename) {
-		return errors.New("source.filename contains unsupported characters")
 	}
 	if strings.TrimSpace(req.Source.Code) == "" {
 		return errors.New("source.code is required")

--- a/manager/procd/pkg/http/handlers/function_test.go
+++ b/manager/procd/pkg/http/handlers/function_test.go
@@ -45,9 +45,8 @@ printf '{"status":202,"headers":{"x-runner":["ok"]},"body_base64":"aGVsbG8="}\n'
 		Runtime:   sandboxfunction.RuntimePython,
 		Handler:   sandboxfunction.DefaultHandler,
 		Source: sandboxfunction.Source{
-			Type:     sandboxfunction.SourceTypeInline,
-			Filename: "main.py",
-			Code:     "def handler(request):\n    return {'status': 204}\n",
+			Type: sandboxfunction.SourceTypeInline,
+			Code: "def handler(request):\n    return {'status': 204}\n",
 		},
 		Request: sandboxfunction.HTTPRequest{
 			Method: "POST",
@@ -93,10 +92,9 @@ func TestFunctionHandlerRejectsMismatchedDigest(t *testing.T) {
 		Runtime: sandboxfunction.RuntimePython,
 		Handler: sandboxfunction.DefaultHandler,
 		Source: sandboxfunction.Source{
-			Type:     sandboxfunction.SourceTypeInline,
-			Filename: "main.py",
-			Code:     "def handler(request):\n    return None\n",
-			Digest:   "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			Type:   sandboxfunction.SourceTypeInline,
+			Code:   "def handler(request):\n    return None\n",
+			Digest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 		},
 		Request: sandboxfunction.HTTPRequest{
 			Method: "POST",
@@ -147,9 +145,8 @@ printf '{"type":"chunk","body_base64":"ZGF0YTogdHdvCgo="}\n'
 		Runtime: sandboxfunction.RuntimePython,
 		Handler: sandboxfunction.DefaultHandler,
 		Source: sandboxfunction.Source{
-			Type:     sandboxfunction.SourceTypeInline,
-			Filename: "main.py",
-			Code:     "def handler(request):\n    return None\n",
+			Type: sandboxfunction.SourceTypeInline,
+			Code: "def handler(request):\n    return None\n",
 		},
 		Request: sandboxfunction.HTTPRequest{Method: "GET", Path: "/events"},
 	}
@@ -198,9 +195,8 @@ printf '{"type":"message","message_type":"text","data":"echo"}\n'
 		Runtime: sandboxfunction.RuntimePython,
 		Handler: sandboxfunction.DefaultHandler,
 		Source: sandboxfunction.Source{
-			Type:     sandboxfunction.SourceTypeInline,
-			Filename: "main.py",
-			Code:     "def handler(request):\n    return None\n",
+			Type: sandboxfunction.SourceTypeInline,
+			Code: "def handler(request):\n    return None\n",
 		},
 		Request: sandboxfunction.HTTPRequest{Method: "GET", Path: "/ws"},
 	}

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -3816,14 +3816,14 @@ components:
         port:
           type: integer
           format: int32
-          description: Public exposure routing port. Function services normally use the sandbox procd port.
+          description: Public exposure routing port. Required for manual, cmd, and warm_process services. Omit for function services; Sandbox0 assigns the internal function service port.
         runtime:
           $ref: "#/components/schemas/SandboxAppServiceRuntime"
         ingress:
           $ref: "#/components/schemas/SandboxAppServiceIngress"
         health_check:
           $ref: "#/components/schemas/SandboxAppServiceHealth"
-      required: [id, port, ingress]
+      required: [id, ingress]
     SandboxAppServiceRuntime:
       type: object
       properties:
@@ -3870,9 +3870,6 @@ components:
           type: string
           enum: [inline]
           description: Source transport. Only inline source is supported in this version.
-        filename:
-          type: string
-          description: Relative Python filename used when materializing the source. Defaults to main.py.
         code:
           type: string
           description: Inline source code. Limited to 256 KiB.

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -1456,8 +1456,8 @@ type SandboxAppService struct {
 	Id      string                   `json:"id"`
 	Ingress SandboxAppServiceIngress `json:"ingress"`
 
-	// Port Public exposure routing port. Function services normally use the sandbox procd port.
-	Port    int32                     `json:"port"`
+	// Port Public exposure routing port. Required for manual, cmd, and warm_process services. Omit for function services; Sandbox0 assigns the internal function service port.
+	Port    *int32                    `json:"port,omitempty"`
 	Runtime *SandboxAppServiceRuntime `json:"runtime,omitempty"`
 }
 
@@ -1546,8 +1546,8 @@ type SandboxAppServiceView struct {
 	Id      string                   `json:"id"`
 	Ingress SandboxAppServiceIngress `json:"ingress"`
 
-	// Port Public exposure routing port. Function services normally use the sandbox procd port.
-	Port int32 `json:"port"`
+	// Port Public exposure routing port. Required for manual, cmd, and warm_process services. Omit for function services; Sandbox0 assigns the internal function service port.
+	Port *int32 `json:"port,omitempty"`
 
 	// PublicUrl Public HTTPS URL for this service when public exposure is enabled.
 	PublicUrl       *string                   `json:"public_url,omitempty"`
@@ -1592,9 +1592,6 @@ type SandboxFunctionRuntime string
 type SandboxFunctionSource struct {
 	// Code Inline source code. Limited to 256 KiB.
 	Code string `json:"code"`
-
-	// Filename Relative Python filename used when materializing the source. Defaults to main.py.
-	Filename *string `json:"filename,omitempty"`
 
 	// Type Source transport. Only inline source is supported in this version.
 	Type SandboxFunctionSourceType `json:"type"`

--- a/pkg/sandboxfunction/types.go
+++ b/pkg/sandboxfunction/types.go
@@ -30,11 +30,18 @@ const (
 
 	MaxInlineSourceBytes = 256 << 10
 	MaxHTTPRequestBytes  = 8 << 20
+
+	// DefaultServicePort is the internal public-exposure routing port used for
+	// function services. The actual procd address is still resolved from the
+	// sandbox runtime.
+	DefaultServicePort = 49983
 )
 
 // Source describes function code carried by cluster-gateway to procd.
 type Source struct {
-	Type     string `json:"type"`
+	Type string `json:"type"`
+	// Filename is accepted only for gateway/procd rollout compatibility.
+	// Function source is always materialized as DefaultFilename.
 	Filename string `json:"filename,omitempty"`
 	Code     string `json:"code,omitempty"`
 	Digest   string `json:"digest,omitempty"`
@@ -86,7 +93,14 @@ type WebSocketFrame struct {
 	Reason      string `json:"reason,omitempty"`
 }
 
-func InlineDigest(filename, code string) string {
+func InlineDigest(code string) string {
+	sum := sha256.Sum256([]byte(code))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+// LegacyInlineDigest returns the digest used by function services before the
+// public filename field was removed. It is kept for rolling-upgrade compatibility.
+func LegacyInlineDigest(filename, code string) string {
 	sum := sha256.Sum256([]byte(filename + "\x00" + code))
 	return "sha256:" + hex.EncodeToString(sum[:])
 }

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -1456,7 +1456,7 @@ func assertSandboxNetworkIsolation(env *framework.ScenarioEnv, session *e2eutils
 	}}
 	_, exposureDomain, status, err := session.UpdateSandboxServices(env.TestCtx.Context, GinkgoT(), sandboxBID, []apispec.SandboxAppService{{
 		Id:   "web",
-		Port: exposedPort,
+		Port: ptr(exposedPort),
 		Ingress: apispec.SandboxAppServiceIngress{
 			Public: true,
 			Routes: &routes,


### PR DESCRIPTION
## Summary
- remove public function source filename and make function service port internally assigned
- start cmd service runtimes through procd on public access, including cleaned auto-resume
- document service runtime behavior and function public URL access

## Tests
- go test ./pkg/apispec ./manager/pkg/service ./manager/procd/pkg/http/handlers ./cluster-gateway/pkg/http ./pkg/sandboxfunction