### PR TITLE
fix(netd): match egress auth candidates by HTTP request

### DIFF
--- a/docs/credential/egress-auth/page.mdx
+++ b/docs/credential/egress-auth/page.mdx
@@ -106,6 +106,8 @@ Use `httpMatch` when a credential should only be injected for specific API reque
 
 For `protocol: https` and `protocol: grpc`, request matching requires `tlsMode: terminate-reoriginate`.
 
+When multiple `credentialRules` match the same destination, Sandbox0 keeps the destination-matching rules as candidates and evaluates their `httpMatch` blocks in declaration order after the HTTP request is visible. The first rule with a matching `httpMatch` is selected. A rule without `httpMatch` matches any remaining request, so place narrower path, header, method, or query rules before catch-all rules.
+
 ```yaml
 mode: block-all
 egress:
@@ -148,6 +150,46 @@ credentialBindings:
               headers:
                   - name: Authorization
                     valueTemplate: "Bearer {{token}}"
+```
+
+You can use that ordering to inject different credentials for different paths on the same host:
+
+```yaml
+mode: block-all
+egress:
+    trafficRules:
+        - name: allow-github
+          action: allow
+          domains:
+              - github.com
+          ports:
+              - port: 443
+                protocol: tcp
+    credentialRules:
+        - name: github-emu-auth
+          credentialRef: github-emu
+          protocol: https
+          tlsMode: terminate-reoriginate
+          domains:
+              - github.com
+          ports:
+              - port: 443
+                protocol: tcp
+          httpMatch:
+              pathPrefixes:
+                  - /emu-org/
+        - name: github-cloud-auth
+          credentialRef: github-cloud
+          protocol: https
+          tlsMode: terminate-reoriginate
+          domains:
+              - github.com
+          ports:
+              - port: 443
+                protocol: tcp
+          httpMatch:
+              pathPrefixes:
+                  - /cloud-org/
 ```
 
 ## SSH Transparent Proxy

--- a/netd/pkg/policy/auth_test.go
+++ b/netd/pkg/policy/auth_test.go
@@ -35,6 +35,50 @@ func TestMatchEgressAuthRuleMatchesHTTPRule(t *testing.T) {
 	}
 }
 
+func TestMatchEgressAuthRulesReturnsAllDestinationMatchesInOrder(t *testing.T) {
+	p := &CompiledPolicy{
+		Egress: CompiledRuleSet{
+			AuthRules: []CompiledEgressAuthRule{
+				{
+					Name:     "github-emu-auth",
+					AuthRef:  "github_emu",
+					Protocol: v1alpha1.EgressAuthProtocolHTTPS,
+					Domains: []DomainRule{
+						{Pattern: "github.com", Type: DomainMatchExact},
+					},
+				},
+				{
+					Name:     "github-cloud-auth",
+					AuthRef:  "github_cloud",
+					Protocol: v1alpha1.EgressAuthProtocolHTTPS,
+					Domains: []DomainRule{
+						{Pattern: "github.com", Type: DomainMatchExact},
+					},
+				},
+				{
+					Name:     "other-host-auth",
+					AuthRef:  "other",
+					Protocol: v1alpha1.EgressAuthProtocolHTTPS,
+					Domains: []DomainRule{
+						{Pattern: "gitlab.com", Type: DomainMatchExact},
+					},
+				},
+			},
+		},
+	}
+
+	rules := MatchEgressAuthRules(p, "tcp", "tls", 443, "github.com")
+	if len(rules) != 2 {
+		t.Fatalf("matched rules = %d, want 2", len(rules))
+	}
+	if rules[0].AuthRef != "github_emu" || rules[1].AuthRef != "github_cloud" {
+		t.Fatalf("unexpected rule order: %+v", rules)
+	}
+	if first := MatchEgressAuthRule(p, "tcp", "tls", 443, "github.com"); first == nil || first.AuthRef != "github_emu" {
+		t.Fatalf("unexpected first rule: %+v", first)
+	}
+}
+
 func TestMatchEgressAuthRuleSkipsTLSRuleForHTTPClassifier(t *testing.T) {
 	p := &CompiledPolicy{
 		Egress: CompiledRuleSet{

--- a/netd/pkg/policy/eval.go
+++ b/netd/pkg/policy/eval.go
@@ -188,12 +188,21 @@ func HasTrafficRuleAppProtocol(policy *CompiledPolicy, protocol string) bool {
 }
 
 func MatchEgressAuthRule(policy *CompiledPolicy, transport, protocol string, destPort int, host string) *CompiledEgressAuthRule {
+	rules := MatchEgressAuthRules(policy, transport, protocol, destPort, host)
+	if len(rules) == 0 {
+		return nil
+	}
+	return rules[0]
+}
+
+func MatchEgressAuthRules(policy *CompiledPolicy, transport, protocol string, destPort int, host string) []*CompiledEgressAuthRule {
 	if policy == nil || len(policy.Egress.AuthRules) == 0 {
 		return nil
 	}
 	transport = strings.ToLower(strings.TrimSpace(transport))
 	protocol = strings.ToLower(strings.TrimSpace(protocol))
 	host = strings.ToLower(strings.TrimSpace(host))
+	matches := make([]*CompiledEgressAuthRule, 0, len(policy.Egress.AuthRules))
 	for idx := range policy.Egress.AuthRules {
 		rule := &policy.Egress.AuthRules[idx]
 		if rule.Rollout == v1alpha1.EgressAuthRolloutDisabled {
@@ -210,9 +219,9 @@ func MatchEgressAuthRule(policy *CompiledPolicy, transport, protocol string, des
 				continue
 			}
 		}
-		return rule
+		matches = append(matches, rule)
 	}
-	return nil
+	return matches
 }
 
 func matchEgressAuthProtocol(ruleProtocol v1alpha1.EgressAuthProtocol, transport, classifiedProtocol string) bool {

--- a/netd/pkg/proxy/decision.go
+++ b/netd/pkg/proxy/decision.go
@@ -26,14 +26,15 @@ type trafficClassification struct {
 }
 
 type trafficDecision struct {
-	Action           decisionAction
-	Transport        string
-	Protocol         string
-	Reason           string
-	ClassifierResult string
-	NeedsAdapter     bool
-	NeedsEgressAuth  bool
-	MatchedAuthRule  *policy.CompiledEgressAuthRule
+	Action             decisionAction
+	Transport          string
+	Protocol           string
+	Reason             string
+	ClassifierResult   string
+	NeedsAdapter       bool
+	NeedsEgressAuth    bool
+	MatchedAuthRule    *policy.CompiledEgressAuthRule
+	AuthRuleCandidates []*policy.CompiledEgressAuthRule
 }
 
 func classifyKnownTraffic(transport, protocol string, destIP net.IP, destPort int, host string) trafficClassification {
@@ -112,7 +113,10 @@ func decideTraffic(compiled *policy.CompiledPolicy, classification trafficClassi
 	decision.Action = decisionActionUseAdapter
 	decision.Reason = "allowed"
 	decision.NeedsAdapter = true
-	decision.MatchedAuthRule = policy.MatchEgressAuthRule(compiled, classification.Transport, classification.Protocol, classification.DestPort, classification.Host)
-	decision.NeedsEgressAuth = decision.MatchedAuthRule != nil
+	decision.AuthRuleCandidates = policy.MatchEgressAuthRules(compiled, classification.Transport, classification.Protocol, classification.DestPort, classification.Host)
+	if len(decision.AuthRuleCandidates) > 0 {
+		decision.MatchedAuthRule = decision.AuthRuleCandidates[0]
+		decision.NeedsEgressAuth = true
+	}
 	return decision
 }

--- a/netd/pkg/proxy/egress_auth.go
+++ b/netd/pkg/proxy/egress_auth.go
@@ -17,6 +17,8 @@ import (
 
 type egressAuthContext struct {
 	Rule                         *policy.CompiledEgressAuthRule
+	CandidateRules               []*policy.CompiledEgressAuthRule
+	RequestMatch                 bool
 	Resolved                     *egressauth.ResolveResponse
 	ResolvedHeaders              map[string]string
 	ResolvedTLSClientCertificate *resolvedTLSClientCertificate
@@ -437,12 +439,16 @@ func applyEgressAuthDirectiveError(ctx *egressAuthContext, protocol string, err 
 }
 
 func (s *Server) attachEgressAuth(req *adapterRequest, decision trafficDecision) {
-	if req == nil || decision.MatchedAuthRule == nil {
+	candidates := egressAuthRuleCandidates(decision)
+	if req == nil || len(candidates) == 0 {
 		return
 	}
+	rule := candidates[0]
 	ctx := &egressAuthContext{
-		Rule:          decision.MatchedAuthRule,
-		FailurePolicy: egressAuthFailurePolicy(s.cfg, decision.MatchedAuthRule),
+		Rule:           rule,
+		CandidateRules: append([]*policy.CompiledEgressAuthRule(nil), candidates...),
+		RequestMatch:   rule.HTTPMatch != nil,
+		FailurePolicy:  egressAuthFailurePolicy(s.cfg, rule),
 	}
 	req.EgressAuth = ctx
 	if !egressAuthEnabled(s.cfg) {
@@ -450,10 +456,21 @@ func (s *Server) attachEgressAuth(req *adapterRequest, decision trafficDecision)
 		proxyMetrics.RecordEgressAuthDecision(decision.Protocol, "bypassed", ctx.BypassReason)
 		return
 	}
-	if decision.MatchedAuthRule.HTTPMatch != nil {
+	if ctx.RequestMatch {
 		return
 	}
+	decision.MatchedAuthRule = rule
 	s.resolveEgressAuth(req, decision)
+}
+
+func egressAuthRuleCandidates(decision trafficDecision) []*policy.CompiledEgressAuthRule {
+	if len(decision.AuthRuleCandidates) > 0 {
+		return decision.AuthRuleCandidates
+	}
+	if decision.MatchedAuthRule != nil {
+		return []*policy.CompiledEgressAuthRule{decision.MatchedAuthRule}
+	}
+	return nil
 }
 
 func (s *Server) resolveEgressAuth(req *adapterRequest, decision trafficDecision) {

--- a/netd/pkg/proxy/egress_auth_test.go
+++ b/netd/pkg/proxy/egress_auth_test.go
@@ -14,15 +14,24 @@ import (
 )
 
 type stubEgressAuthResolver struct {
-	calls int
-	resp  *egressauth.ResolveResponse
-	err   error
+	calls     int
+	resp      *egressauth.ResolveResponse
+	responses map[string]*egressauth.ResolveResponse
+	requests  []*egressauth.ResolveRequest
+	err       error
 }
 
-func (s *stubEgressAuthResolver) Resolve(_ context.Context, _ *egressauth.ResolveRequest) (*egressauth.ResolveResponse, error) {
+func (s *stubEgressAuthResolver) Resolve(_ context.Context, req *egressauth.ResolveRequest) (*egressauth.ResolveResponse, error) {
 	s.calls++
+	if req != nil {
+		copied := *req
+		s.requests = append(s.requests, &copied)
+	}
 	if s.err != nil {
 		return nil, s.err
+	}
+	if s.responses != nil && req != nil {
+		return cloneResolveResponse(s.responses[req.AuthRef]), nil
 	}
 	return cloneResolveResponse(s.resp), nil
 }

--- a/netd/pkg/proxy/http_injection_test.go
+++ b/netd/pkg/proxy/http_injection_test.go
@@ -420,6 +420,117 @@ func TestHTTPAdapterSkipsResolverWhenRequestMatcherDoesNotMatch(t *testing.T) {
 	}
 }
 
+func TestHTTPAdapterFallsThroughCredentialCandidatesByRequestMatcher(t *testing.T) {
+	requestHeaders := make(chan http.Header, 1)
+	upstream := httptestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		requestHeaders <- r.Header.Clone()
+		_, _ = w.Write([]byte("ok"))
+	})
+	defer upstream.Close()
+
+	addr := upstream.Listener.Addr().(*net.TCPAddr)
+	proxyListener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen proxy: %v", err)
+	}
+	defer proxyListener.Close()
+
+	emuRule := &policy.CompiledEgressAuthRule{
+		Name:    "github-emu-auth",
+		AuthRef: "github_emu",
+		HTTPMatch: &policy.CompiledHTTPMatch{
+			PathPrefixes: []string{"/emu-org/"},
+		},
+	}
+	cloudRule := &policy.CompiledEgressAuthRule{
+		Name:    "github-cloud-auth",
+		AuthRef: "github_cloud",
+		HTTPMatch: &policy.CompiledHTTPMatch{
+			PathPrefixes: []string{"/cloud-org/"},
+		},
+	}
+	resolver := &stubEgressAuthResolver{
+		responses: map[string]*egressauth.ResolveResponse{
+			"github_emu": egressauth.NewHTTPHeadersResolveResponse("github_emu", map[string]string{
+				"Authorization": "Bearer emu-token",
+			}, nil),
+			"github_cloud": egressauth.NewHTTPHeadersResolveResponse("github_cloud", map[string]string{
+				"Authorization": "Bearer cloud-token",
+			}, nil),
+		},
+	}
+	server := &Server{
+		cfg: &config.NetdConfig{
+			ProxyUpstreamTimeout: metav1.Duration{Duration: 2 * time.Second},
+			EgressAuthEnabled:    true,
+		},
+		authResolver: resolver,
+		authCache:    newMemoryEgressAuthCache(),
+		logger:       zap.NewNop(),
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		conn, acceptErr := proxyListener.Accept()
+		if acceptErr != nil {
+			done <- acceptErr
+			return
+		}
+		defer conn.Close()
+		rawReq := "GET /cloud-org/repo.git/info/refs HTTP/1.1\r\nHost: github.com\r\n\r\n"
+		req := &adapterRequest{
+			Server:   server,
+			Compiled: &policy.CompiledPolicy{SandboxID: "sbx_123", TeamID: "team_123"},
+			SrcIP:    "10.0.0.2",
+			DestIP:   addr.IP,
+			DestPort: addr.Port,
+			Host:     "github.com",
+			Conn:     conn,
+			Prefix:   bytes.NewReader([]byte(rawReq)),
+		}
+		server.attachEgressAuth(req, trafficDecision{
+			Transport:          "tcp",
+			Protocol:           "http",
+			MatchedAuthRule:    emuRule,
+			AuthRuleCandidates: []*policy.CompiledEgressAuthRule{emuRule, cloudRule},
+			NeedsEgressAuth:    true,
+		})
+		done <- (&httpAdapter{}).Handle(req)
+	}()
+
+	clientConn, err := net.Dial("tcp4", proxyListener.Addr().String())
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	defer clientConn.Close()
+	resp, err := http.ReadResponse(bufio.NewReader(clientConn), nil)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	_, _ = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err := <-done; err != nil {
+		t.Fatalf("adapter handle: %v", err)
+	}
+
+	headers := <-requestHeaders
+	if got := headers.Get("Authorization"); got != "Bearer cloud-token" {
+		t.Fatalf("authorization header = %q, want cloud token", got)
+	}
+	if resolver.calls != 1 {
+		t.Fatalf("resolver calls = %d, want 1", resolver.calls)
+	}
+	if len(resolver.requests) != 1 {
+		t.Fatalf("resolver requests = %d, want 1", len(resolver.requests))
+	}
+	if got := resolver.requests[0].AuthRef; got != "github_cloud" {
+		t.Fatalf("resolver auth ref = %q, want github_cloud", got)
+	}
+	if got := resolver.requests[0].RuleName; got != "github-cloud-auth" {
+		t.Fatalf("resolver rule name = %q, want github-cloud-auth", got)
+	}
+}
+
 func TestHTTPAdapterReturns503WhenDirectiveUnsupported(t *testing.T) {
 	server := &Server{
 		cfg: &config.NetdConfig{

--- a/netd/pkg/proxy/http_request_match.go
+++ b/netd/pkg/proxy/http_request_match.go
@@ -7,28 +7,75 @@ import (
 )
 
 func (s *Server) prepareEgressAuthForHTTPRequest(req *adapterRequest, httpReq *http.Request, classifiedProtocol string) {
-	if req == nil || req.EgressAuth == nil || req.EgressAuth.Rule == nil {
+	if req == nil || req.EgressAuth == nil || req.EgressAuth.ShouldBypass() {
 		return
 	}
-	if req.EgressAuth.Rule.HTTPMatch == nil {
+	ctx := req.EgressAuth
+	candidates := ctx.CandidateRules
+	if len(candidates) == 0 && ctx.Rule != nil {
+		candidates = []*policy.CompiledEgressAuthRule{ctx.Rule}
+	}
+	if len(candidates) == 0 {
 		return
 	}
-	if !policy.MatchHTTPRequest(req.EgressAuth.Rule.HTTPMatch, httpReq) {
+	if !ctx.RequestMatch && ctx.Rule != nil && ctx.Rule.HTTPMatch == nil {
+		return
+	}
+	rule := matchEgressAuthRuleForHTTPRequest(candidates, httpReq)
+	if rule == nil {
 		req.EgressAuth = nil
 		return
 	}
+	selectEgressAuthRuleForHTTPRequest(ctx, rule, s)
 	decision := trafficDecision{
 		Transport:       "tcp",
 		Protocol:        classifiedProtocol,
-		MatchedAuthRule: req.EgressAuth.Rule,
+		MatchedAuthRule: rule,
 		NeedsEgressAuth: true,
 	}
 	s.resolveEgressAuth(req, decision)
 }
 
+func matchEgressAuthRuleForHTTPRequest(candidates []*policy.CompiledEgressAuthRule, httpReq *http.Request) *policy.CompiledEgressAuthRule {
+	for _, rule := range candidates {
+		if rule == nil {
+			continue
+		}
+		if rule.HTTPMatch != nil && !policy.MatchHTTPRequest(rule.HTTPMatch, httpReq) {
+			continue
+		}
+		return rule
+	}
+	return nil
+}
+
+func selectEgressAuthRuleForHTTPRequest(ctx *egressAuthContext, rule *policy.CompiledEgressAuthRule, server *Server) {
+	if ctx == nil || rule == nil || ctx.Rule == rule {
+		if ctx != nil {
+			ctx.RequestMatch = true
+		}
+		return
+	}
+	ctx.Rule = rule
+	ctx.RequestMatch = true
+	ctx.Resolved = nil
+	ctx.ResolvedHeaders = nil
+	ctx.ResolvedTLSClientCertificate = nil
+	ctx.ResolvedUsernamePassword = nil
+	ctx.ResolvedSSHProxy = nil
+	ctx.CacheHit = false
+	ctx.ResolveAttempt = false
+	ctx.ResolveError = nil
+	ctx.BypassReason = ""
+	ctx.EnforcementReason = ""
+	if server != nil {
+		ctx.FailurePolicy = egressAuthFailurePolicy(server.cfg, rule)
+	}
+}
+
 func egressAuthNeedsHTTPMatch(req *adapterRequest) bool {
 	return req != nil &&
 		req.EgressAuth != nil &&
-		req.EgressAuth.Rule != nil &&
-		req.EgressAuth.Rule.HTTPMatch != nil
+		(req.EgressAuth.RequestMatch ||
+			(req.EgressAuth.Rule != nil && req.EgressAuth.Rule.HTTPMatch != nil))
 }

--- a/netd/pkg/proxy/tls_proxy.go
+++ b/netd/pkg/proxy/tls_proxy.go
@@ -69,7 +69,7 @@ func (s *Server) proxyHTTPSRequest(req *adapterRequest) error {
 			return fmt.Errorf("egress auth material missing for %q", req.EgressAuth.Rule.AuthRef)
 		}
 	}
-	if req.EgressAuth != nil && req.EgressAuth.Rule != nil && req.EgressAuth.Rule.Protocol == v1alpha1.EgressAuthProtocolGRPC && downstreamTLS.ConnectionState().NegotiatedProtocol != "h2" {
+	if egressAuthRequiresGRPCH2(req.EgressAuth) && downstreamTLS.ConnectionState().NegotiatedProtocol != "h2" {
 		_ = writeHTTPProxyError(downstreamTLS, http.StatusBadRequest, "grpc interception requires h2 alpn")
 		return fmt.Errorf("grpc interception requires h2 alpn for host %q", req.Host)
 	}
@@ -144,7 +144,10 @@ func downstreamTLSNextProtos(req *adapterRequest) []string {
 	if req != nil && req.EgressAuth != nil && req.EgressAuth.Rule != nil && req.EgressAuth.Rule.Protocol == v1alpha1.EgressAuthProtocolTLS {
 		return nil
 	}
-	if req != nil && req.EgressAuth != nil && req.EgressAuth.Rule != nil && req.EgressAuth.Rule.Protocol == v1alpha1.EgressAuthProtocolGRPC {
+	if req != nil && req.EgressAuth != nil && egressAuthMayUseGRPC(req.EgressAuth) {
+		if egressAuthMayUseHTTP1(req.EgressAuth) {
+			return []string{"h2", "http/1.1"}
+		}
 		return []string{"h2"}
 	}
 	if req != nil && policy.RequiresProtocolTLSTermination(req.Compiled, req.Host, req.DestPort, "mcp") {
@@ -163,7 +166,7 @@ func shouldProxyHTTP2(req *adapterRequest, state tls.ConnectionState) bool {
 		}
 		return policy.RequiresProtocolTLSTermination(req.Compiled, req.Host, req.DestPort, "mcp")
 	}
-	return req.EgressAuth != nil && req.EgressAuth.Rule != nil && req.EgressAuth.Rule.Protocol == v1alpha1.EgressAuthProtocolGRPC
+	return false
 }
 
 func (s *Server) dialUpstreamTLS(req *adapterRequest) (net.Conn, error) {
@@ -259,8 +262,73 @@ func tlsTerminationRequired(req *adapterRequest) bool {
 	if req == nil {
 		return false
 	}
-	if req.EgressAuth != nil && req.EgressAuth.Rule != nil && req.EgressAuth.Rule.TLSMode == "terminate-reoriginate" {
+	if egressAuthRequiresTLSTermination(req.EgressAuth) {
 		return true
 	}
 	return policy.RequiresProtocolTLSTermination(req.Compiled, req.Host, req.DestPort, "mcp")
+}
+
+func egressAuthRequiresTLSTermination(ctx *egressAuthContext) bool {
+	if ctx == nil {
+		return false
+	}
+	if !ctx.RequestMatch {
+		return ctx.Rule != nil && ctx.Rule.TLSMode == v1alpha1.EgressTLSModeTerminateReoriginate
+	}
+	for _, rule := range ctx.CandidateRules {
+		if rule != nil && rule.TLSMode == v1alpha1.EgressTLSModeTerminateReoriginate {
+			return true
+		}
+	}
+	return ctx.Rule != nil && ctx.Rule.TLSMode == v1alpha1.EgressTLSModeTerminateReoriginate
+}
+
+func egressAuthMayUseGRPC(ctx *egressAuthContext) bool {
+	if ctx == nil {
+		return false
+	}
+	if !ctx.RequestMatch {
+		return ctx.Rule != nil && ctx.Rule.Protocol == v1alpha1.EgressAuthProtocolGRPC
+	}
+	for _, rule := range ctx.CandidateRules {
+		if rule != nil && rule.Protocol == v1alpha1.EgressAuthProtocolGRPC {
+			return true
+		}
+	}
+	return ctx.Rule != nil && ctx.Rule.Protocol == v1alpha1.EgressAuthProtocolGRPC
+}
+
+func egressAuthMayUseHTTP1(ctx *egressAuthContext) bool {
+	if ctx == nil {
+		return false
+	}
+	if !ctx.RequestMatch {
+		return ctx.Rule != nil && ctx.Rule.Protocol != v1alpha1.EgressAuthProtocolGRPC && ctx.Rule.Protocol != v1alpha1.EgressAuthProtocolTLS
+	}
+	for _, rule := range ctx.CandidateRules {
+		if rule != nil && rule.Protocol != v1alpha1.EgressAuthProtocolGRPC && rule.Protocol != v1alpha1.EgressAuthProtocolTLS {
+			return true
+		}
+	}
+	return ctx.Rule != nil && ctx.Rule.Protocol != v1alpha1.EgressAuthProtocolGRPC && ctx.Rule.Protocol != v1alpha1.EgressAuthProtocolTLS
+}
+
+func egressAuthRequiresGRPCH2(ctx *egressAuthContext) bool {
+	if ctx == nil {
+		return false
+	}
+	if !ctx.RequestMatch {
+		return ctx.Rule != nil && ctx.Rule.Protocol == v1alpha1.EgressAuthProtocolGRPC
+	}
+	hasGRPC := false
+	for _, rule := range ctx.CandidateRules {
+		if rule == nil {
+			continue
+		}
+		if rule.Protocol != v1alpha1.EgressAuthProtocolGRPC {
+			return false
+		}
+		hasGRPC = true
+	}
+	return hasGRPC || (ctx.Rule != nil && ctx.Rule.Protocol == v1alpha1.EgressAuthProtocolGRPC)
 }


### PR DESCRIPTION
## Summary
- keep all destination-matching egress auth rules as candidates instead of discarding same-host rules after the first match
- select the first candidate whose `httpMatch` matches the parsed HTTP request, then resolve/inject that rule
- document same-destination rule ordering and add regression coverage for same-host path-based credentials

Fixes #381

## Tests
- `go test ./netd/pkg/policy ./netd/pkg/proxy`
- Remote manual test on Aliyun Singapore kind fullmode using PR image `sandbox0ai/infra:latest` from commit `30d198f`:
  - claimed a real `default` sandbox through `http://127.0.0.1:30080`
  - created two `static_headers` credential sources: `emu-token` and `cloud-token`
  - attached two same-destination HTTP credential rules for the echo fixture IP:8080, ordered `/emu-org/` then `/cloud-org/`
  - executed `curl` from the sandbox `procd` container against `/emu-org/repo`, `/cloud-org/repo`, and `/other/repo`
  - observed `Bearer emu-token`, `Bearer cloud-token`, and `NO_AUTH` respectively