### PR TITLE
Fix SSH egress auth domain matching

### DIFF
--- a/docs/credential/egress-auth/page.mdx
+++ b/docs/credential/egress-auth/page.mdx
@@ -193,6 +193,8 @@ credentialBindings:
 
 For Git-over-SSH, use the normal Git SSH URL and configure Git or OpenSSH in the sandbox to use the fake private key. Netd terminates the sandbox SSH session, verifies the fake key, verifies the upstream host key against `knownHosts`, and re-originates the session with the stored upstream private key.
 
+SSH does not carry a hostname in the protocol. When `credentialRules[*].domains` or hostname-based `knownHosts` entries are used for SSH, netd associates the SSH connection with the sandbox's recent DNS response for that destination IP. The association is per sandbox and expires with the DNS TTL. Direct IP connections, stale DNS entries, or DNS traffic that bypasses netd are treated as hostless SSH traffic.
+
 ## Update Runtime Policy
 
 <Endpoint method="PUT">

--- a/netd/pkg/daemon/daemon.go
+++ b/netd/pkg/daemon/daemon.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -175,36 +176,31 @@ func (d *Daemon) runNetd(ctx context.Context, cancel context.CancelFunc, proxyEx
 		if info == nil {
 			return
 		}
-		platformState.OnSandboxUpsert(info)
-		changed, prevHash := policyStore.UpsertFromSandbox(info)
-		if changed && info.PodIP != "" {
-			cleanupDeniedTrackedFlows(ctx, tracker, conntrackManager, policyStore, info.PodIP)
-		}
-		d.logger.Info("Sandbox policy handler triggered",
+		d.logger.Info("Sandbox policy change observed",
 			zap.String("sandbox", info.Namespace+"/"+info.Name),
 			zap.String("pod_ip", info.PodIP),
-			zap.Bool("policy_changed", changed),
 			zap.String("policy_hash", info.NetworkPolicyHash),
-			zap.String("prev_hash", prevHash),
 		)
 		triggerSync()
 	}, func(info *watcher.SandboxInfo) {
 		if info != nil {
-			platformState.OnSandboxDelete(info)
-			policyStore.DeleteByKey(info.Namespace, info.Name)
-			flows := tracker.PopBySrc(info.PodIP)
-			if conntrackManager != nil {
-				conntrackManager.CleanupFlows(ctx, flows)
-			}
-			d.logger.Info("Sandbox delete handler triggered",
+			d.logger.Info("Sandbox policy delete observed",
 				zap.String("sandbox", info.Namespace+"/"+info.Name),
 				zap.String("pod_ip", info.PodIP),
 			)
 		}
 		triggerSync()
 	})
-	netdWatcher.SetServiceHandlers(platformState.OnServiceUpsert, platformState.OnServiceDelete)
-	netdWatcher.SetEndpointsHandlers(platformState.OnEndpointsUpsert, platformState.OnEndpointsDelete)
+	netdWatcher.SetServiceHandlers(func(*watcher.ServiceInfo) {
+		triggerSync()
+	}, func(*watcher.ServiceInfo) {
+		triggerSync()
+	})
+	netdWatcher.SetEndpointsHandlers(func(*watcher.EndpointsInfo) {
+		triggerSync()
+	}, func(*watcher.EndpointsInfo) {
+		triggerSync()
+	})
 	if err := netdWatcher.Start(ctx); err != nil {
 		return err
 	}
@@ -265,7 +261,7 @@ func (d *Daemon) runNetd(ctx context.Context, cancel context.CancelFunc, proxyEx
 			case <-ticker.C:
 			case <-syncTrigger:
 			}
-			if err := d.syncRedirect(ctx, netdWatcher, policyStore, platformState, redirectManager, patcher, tracker, conntrackManager); err != nil {
+			if err := d.syncRedirect(ctx, netdWatcher, policyStore, platformState, redirectManager, patcher, tracker, conntrackManager, proxyServer); err != nil {
 				d.logger.Error("Failed to sync redirect rules", zap.Error(err))
 				if d.cfg.FailClosed {
 					d.ready.Store(false)
@@ -436,6 +432,7 @@ func (d *Daemon) syncRedirect(
 	patcher *apply.Patcher,
 	tracker *conntrack.Tracker,
 	conntrackManager *conntrack.Manager,
+	proxyServer *proxy.Server,
 ) error {
 	if netdWatcher == nil || redirectManager == nil || patcher == nil {
 		return fmt.Errorf("missing watcher or redirect manager or patcher or policy store")
@@ -453,6 +450,9 @@ func (d *Daemon) syncRedirect(
 	if policyStore != nil {
 		result := policyStore.ReconcileSandboxes(sandboxes)
 		for _, podIP := range result.RemovedIPs {
+			if proxyServer != nil {
+				proxyServer.ForgetSandboxDNS(podIP)
+			}
 			cleanupTrackedFlows(ctx, tracker, conntrackManager, podIP)
 		}
 		for _, change := range result.Changed {
@@ -466,15 +466,13 @@ func (d *Daemon) syncRedirect(
 		platformState.Reconcile(sandboxes, services, endpoints)
 	}
 
+	dnsCIDRs := clusterDNSCIDRs(d.cfg.ClusterDNSCIDR, services, endpoints)
 	bypassCIDRs := []string{}
-	if d.cfg.ClusterDNSCIDR != "" {
-		bypassCIDRs = append(bypassCIDRs, d.cfg.ClusterDNSCIDR)
-	}
 	if len(d.cfg.PlatformAllowedCIDRs) > 0 {
-		bypassCIDRs = append(bypassCIDRs, d.cfg.PlatformAllowedCIDRs...)
+		bypassCIDRs = append(bypassCIDRs, excludeCIDRs(d.cfg.PlatformAllowedCIDRs, dnsCIDRs)...)
 	}
 	if policyStore != nil {
-		bypassCIDRs = append(bypassCIDRs, policyStore.AllowedPlatformCIDRs()...)
+		bypassCIDRs = append(bypassCIDRs, excludeCIDRs(policyStore.AllowedPlatformCIDRs(), dnsCIDRs)...)
 	}
 
 	d.logger.Info(
@@ -502,6 +500,69 @@ func (d *Daemon) syncRedirect(
 		zap.Int("sandboxes_total", len(sandboxes)),
 	)
 	return nil
+}
+
+func clusterDNSCIDRs(configured string, services []*watcher.ServiceInfo, endpoints []*watcher.EndpointsInfo) []string {
+	out := []string{}
+	if strings.TrimSpace(configured) != "" {
+		out = append(out, configured)
+	}
+	endpointsByService := make(map[string]*watcher.EndpointsInfo, len(endpoints))
+	for _, endpoint := range endpoints {
+		if endpoint == nil {
+			continue
+		}
+		endpointsByService[endpoint.Namespace+"/"+endpoint.Name] = endpoint
+	}
+	for _, service := range services {
+		if !isClusterDNSService(service) {
+			continue
+		}
+		if service.ClusterIP != "" && strings.ToLower(service.ClusterIP) != "none" {
+			out = append(out, service.ClusterIP)
+		}
+		if endpoint := endpointsByService[service.Namespace+"/"+service.Name]; endpoint != nil {
+			out = append(out, endpoint.Addresses...)
+		}
+	}
+	return out
+}
+
+func excludeCIDRs(values []string, excluded []string) []string {
+	if len(values) == 0 || len(excluded) == 0 {
+		return append([]string(nil), values...)
+	}
+	exclusionSet := make(map[string]struct{}, len(excluded))
+	for _, value := range excluded {
+		if key := cidrKey(value); key != "" {
+			exclusionSet[key] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if _, ok := exclusionSet[cidrKey(value)]; ok {
+			continue
+		}
+		out = append(out, value)
+	}
+	return out
+}
+
+func cidrKey(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	if _, network, err := net.ParseCIDR(value); err == nil && network != nil {
+		return network.String()
+	}
+	if ip := net.ParseIP(value); ip != nil {
+		if ip.To4() != nil {
+			return ip.String() + "/32"
+		}
+		return ip.String() + "/128"
+	}
+	return value
 }
 
 func cleanupTrackedFlows(

--- a/netd/pkg/daemon/daemon_lifecycle_test.go
+++ b/netd/pkg/daemon/daemon_lifecycle_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	apiconfig "github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
+	"github.com/sandbox0-ai/sandbox0/netd/pkg/watcher"
 	"go.uber.org/zap"
 )
 
@@ -53,6 +54,55 @@ func TestShutdownClosesRuntimeResourcesAfterMeteringLoopStops(t *testing.T) {
 			}
 		default:
 			t.Fatalf("missing event %q", expected)
+		}
+	}
+}
+
+func TestExcludeCIDRsRemovesClusterDNSCIDR(t *testing.T) {
+	got := excludeCIDRs(
+		[]string{"10.96.0.10/32", "10.96.0.20/32", "192.168.1.1"},
+		[]string{"10.96.0.10"},
+	)
+	want := []string{"10.96.0.20/32", "192.168.1.1"}
+	if len(got) != len(want) {
+		t.Fatalf("cidrs = %#v, want %#v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("cidrs = %#v, want %#v", got, want)
+		}
+	}
+}
+
+func TestClusterDNSCIDRsIncludesServiceAndEndpointIPs(t *testing.T) {
+	got := clusterDNSCIDRs(
+		"10.96.0.10",
+		[]*watcher.ServiceInfo{{
+			Namespace: "kube-system",
+			Name:      "kube-dns",
+			ClusterIP: "10.96.0.10",
+		}, {
+			Namespace: "sandbox0-system",
+			Name:      "fullmode-manager",
+			ClusterIP: "10.96.0.20",
+		}},
+		[]*watcher.EndpointsInfo{{
+			Namespace: "kube-system",
+			Name:      "kube-dns",
+			Addresses: []string{"10.244.0.53", "10.244.1.53"},
+		}, {
+			Namespace: "sandbox0-system",
+			Name:      "fullmode-manager",
+			Addresses: []string{"10.244.0.20"},
+		}},
+	)
+	want := []string{"10.96.0.10", "10.96.0.10", "10.244.0.53", "10.244.1.53"}
+	if len(got) != len(want) {
+		t.Fatalf("cidrs = %#v, want %#v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("cidrs = %#v, want %#v", got, want)
 		}
 	}
 }

--- a/netd/pkg/proxy/adapter_base.go
+++ b/netd/pkg/proxy/adapter_base.go
@@ -305,15 +305,14 @@ func (a *dnsAdapter) Name() string      { return "dns" }
 func (a *dnsAdapter) Transport() string { return "tcp" }
 func (a *dnsAdapter) Protocol() string  { return "dns" }
 func (a *dnsAdapter) Capability() adapterCapability {
-	return adapterCapabilityPassThrough
+	return adapterCapabilityInspect
 }
 
 func (a *dnsAdapter) Handle(req *adapterRequest) error {
 	if req == nil || req.Server == nil || req.Conn == nil {
 		return fmt.Errorf("dns adapter requires connection")
 	}
-	req.Server.recordFlow(req.SrcIP, req.DestIP, req.DestPort, "tcp", remotePort(req.Conn.RemoteAddr()))
-	return req.Server.relayTCPRequest(req)
+	return req.Server.proxyDNSTCP(req)
 }
 
 type mqttAdapter struct{}

--- a/netd/pkg/proxy/adapter_base_test.go
+++ b/netd/pkg/proxy/adapter_base_test.go
@@ -9,7 +9,7 @@ func TestAdapterCapabilities(t *testing.T) {
 		capability adapterCapability
 	}{
 		{name: "amqp passthrough", adapter: &amqpAdapter{}, capability: adapterCapabilityPassThrough},
-		{name: "dns passthrough", adapter: &dnsAdapter{}, capability: adapterCapabilityPassThrough},
+		{name: "dns inspect", adapter: &dnsAdapter{}, capability: adapterCapabilityInspect},
 		{name: "http inspect", adapter: &httpAdapter{}, capability: adapterCapabilityInspect},
 		{name: "mongodb passthrough", adapter: &mongodbAdapter{}, capability: adapterCapabilityPassThrough},
 		{name: "mqtt inspect", adapter: &mqttAdapter{}, capability: adapterCapabilityInspect},

--- a/netd/pkg/proxy/decision.go
+++ b/netd/pkg/proxy/decision.go
@@ -21,6 +21,7 @@ type trafficClassification struct {
 	DestIP        net.IP
 	DestPort      int
 	Host          string
+	HostSource    string
 	UnknownReason string
 	Verification  string
 }

--- a/netd/pkg/proxy/dns_cache.go
+++ b/netd/pkg/proxy/dns_cache.go
@@ -1,0 +1,598 @@
+package proxy
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"net"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
+	"github.com/sandbox0-ai/sandbox0/netd/pkg/policy"
+	"golang.org/x/net/dns/dnsmessage"
+)
+
+const (
+	defaultDNSHostCacheMinTTL = 5 * time.Second
+	defaultDNSHostCacheMaxTTL = 5 * time.Minute
+	maxDNSHostCacheEntries    = 4096
+
+	classificationHostSourceDNSCache = "dns-cache"
+)
+
+type dnsHostCache struct {
+	mu     sync.Mutex
+	now    func() time.Time
+	minTTL time.Duration
+	maxTTL time.Duration
+
+	bySandbox map[string]map[string]map[string]dnsHostCacheEntry
+}
+
+type dnsHostCacheEntry struct {
+	host       string
+	ip         string
+	expiresAt  time.Time
+	observedAt time.Time
+}
+
+type dnsHostCandidate struct {
+	Host       string
+	ObservedAt time.Time
+}
+
+type dnsHostRecord struct {
+	host string
+	ip   net.IP
+	ttl  uint32
+}
+
+type dnsAddressRecord struct {
+	ip  net.IP
+	ttl uint32
+}
+
+type dnsCNAMERecord struct {
+	target string
+	ttl    uint32
+}
+
+func newDNSHostCache() *dnsHostCache {
+	return &dnsHostCache{
+		now:       time.Now,
+		minTTL:    defaultDNSHostCacheMinTTL,
+		maxTTL:    defaultDNSHostCacheMaxTTL,
+		bySandbox: make(map[string]map[string]map[string]dnsHostCacheEntry),
+	}
+}
+
+func (c *dnsHostCache) ObserveResponse(sandboxIP string, payload []byte) {
+	sandboxIP = strings.TrimSpace(sandboxIP)
+	if c == nil || sandboxIP == "" || len(payload) == 0 {
+		return
+	}
+	records, err := parseDNSHostRecords(payload)
+	if err != nil || len(records) == 0 {
+		return
+	}
+	now := c.currentTime()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	sandboxEntries := c.bySandbox[sandboxIP]
+	if sandboxEntries == nil {
+		sandboxEntries = make(map[string]map[string]dnsHostCacheEntry)
+		c.bySandbox[sandboxIP] = sandboxEntries
+	}
+	for _, record := range records {
+		host := normalizeDNSHostname(record.host)
+		if host == "" || record.ip == nil {
+			continue
+		}
+		ip := record.ip.String()
+		if ip == "" {
+			continue
+		}
+		hostEntries := sandboxEntries[ip]
+		if hostEntries == nil {
+			hostEntries = make(map[string]dnsHostCacheEntry)
+			sandboxEntries[ip] = hostEntries
+		}
+		hostEntries[host] = dnsHostCacheEntry{
+			host:       host,
+			ip:         ip,
+			expiresAt:  now.Add(c.clampTTL(record.ttl)),
+			observedAt: now,
+		}
+	}
+	c.pruneLocked(sandboxIP, now)
+}
+
+func (c *dnsHostCache) Lookup(sandboxIP string, destIP net.IP) []dnsHostCandidate {
+	sandboxIP = strings.TrimSpace(sandboxIP)
+	if c == nil || sandboxIP == "" || destIP == nil {
+		return nil
+	}
+	ip := destIP.String()
+	if ip == "" {
+		return nil
+	}
+	now := c.currentTime()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	sandboxEntries := c.bySandbox[sandboxIP]
+	if len(sandboxEntries) == 0 {
+		return nil
+	}
+	hostEntries := sandboxEntries[ip]
+	if len(hostEntries) == 0 {
+		return nil
+	}
+	candidates := make([]dnsHostCandidate, 0, len(hostEntries))
+	for host, entry := range hostEntries {
+		if !entry.expiresAt.After(now) {
+			delete(hostEntries, host)
+			continue
+		}
+		candidates = append(candidates, dnsHostCandidate{
+			Host:       entry.host,
+			ObservedAt: entry.observedAt,
+		})
+	}
+	if len(hostEntries) == 0 {
+		delete(sandboxEntries, ip)
+	}
+	if len(sandboxEntries) == 0 {
+		delete(c.bySandbox, sandboxIP)
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		if !candidates[i].ObservedAt.Equal(candidates[j].ObservedAt) {
+			return candidates[i].ObservedAt.After(candidates[j].ObservedAt)
+		}
+		return candidates[i].Host < candidates[j].Host
+	})
+	return candidates
+}
+
+func (c *dnsHostCache) ForgetSandbox(sandboxIP string) {
+	if c == nil {
+		return
+	}
+	sandboxIP = strings.TrimSpace(sandboxIP)
+	if sandboxIP == "" {
+		return
+	}
+	c.mu.Lock()
+	delete(c.bySandbox, sandboxIP)
+	c.mu.Unlock()
+}
+
+func (c *dnsHostCache) currentTime() time.Time {
+	if c == nil || c.now == nil {
+		return time.Now()
+	}
+	return c.now()
+}
+
+func (c *dnsHostCache) clampTTL(ttl uint32) time.Duration {
+	if c == nil {
+		return defaultDNSHostCacheMinTTL
+	}
+	value := time.Duration(ttl) * time.Second
+	minTTL := c.minTTL
+	if minTTL <= 0 {
+		minTTL = defaultDNSHostCacheMinTTL
+	}
+	maxTTL := c.maxTTL
+	if maxTTL <= 0 {
+		maxTTL = defaultDNSHostCacheMaxTTL
+	}
+	if value < minTTL {
+		return minTTL
+	}
+	if value > maxTTL {
+		return maxTTL
+	}
+	return value
+}
+
+func (c *dnsHostCache) pruneLocked(sandboxIP string, now time.Time) {
+	sandboxEntries := c.bySandbox[sandboxIP]
+	if len(sandboxEntries) == 0 {
+		return
+	}
+	entries := make([]dnsHostCacheEntry, 0)
+	for ip, hostEntries := range sandboxEntries {
+		for host, entry := range hostEntries {
+			if !entry.expiresAt.After(now) {
+				delete(hostEntries, host)
+				continue
+			}
+			entries = append(entries, entry)
+		}
+		if len(hostEntries) == 0 {
+			delete(sandboxEntries, ip)
+		}
+	}
+	if len(sandboxEntries) == 0 {
+		delete(c.bySandbox, sandboxIP)
+		return
+	}
+	if len(entries) <= maxDNSHostCacheEntries {
+		return
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if !entries[i].observedAt.Equal(entries[j].observedAt) {
+			return entries[i].observedAt.Before(entries[j].observedAt)
+		}
+		if entries[i].ip != entries[j].ip {
+			return entries[i].ip < entries[j].ip
+		}
+		return entries[i].host < entries[j].host
+	})
+	for _, entry := range entries[:len(entries)-maxDNSHostCacheEntries] {
+		if hostEntries := sandboxEntries[entry.ip]; hostEntries != nil {
+			delete(hostEntries, entry.host)
+			if len(hostEntries) == 0 {
+				delete(sandboxEntries, entry.ip)
+			}
+		}
+	}
+	if len(sandboxEntries) == 0 {
+		delete(c.bySandbox, sandboxIP)
+	}
+}
+
+func parseDNSHostRecords(payload []byte) ([]dnsHostRecord, error) {
+	var parser dnsmessage.Parser
+	header, err := parser.Start(payload)
+	if err != nil {
+		return nil, err
+	}
+	if !header.Response || header.RCode != dnsmessage.RCodeSuccess {
+		return nil, nil
+	}
+	questions, err := parser.AllQuestions()
+	if err != nil {
+		return nil, err
+	}
+	if len(questions) == 0 {
+		return nil, nil
+	}
+	queryHosts := make([]string, 0, len(questions))
+	seenQueries := make(map[string]struct{}, len(questions))
+	for _, question := range questions {
+		host := normalizeDNSName(question.Name)
+		if host == "" {
+			continue
+		}
+		if _, ok := seenQueries[host]; ok {
+			continue
+		}
+		seenQueries[host] = struct{}{}
+		queryHosts = append(queryHosts, host)
+	}
+	if len(queryHosts) == 0 {
+		return nil, nil
+	}
+
+	addresses := map[string][]dnsAddressRecord{}
+	cnames := map[string][]dnsCNAMERecord{}
+	for {
+		header, err := parser.AnswerHeader()
+		if err == dnsmessage.ErrSectionDone {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		owner := normalizeDNSName(header.Name)
+		switch header.Type {
+		case dnsmessage.TypeA:
+			resource, err := parser.AResource()
+			if err != nil {
+				return nil, err
+			}
+			if owner != "" {
+				addresses[owner] = append(addresses[owner], dnsAddressRecord{
+					ip:  net.IPv4(resource.A[0], resource.A[1], resource.A[2], resource.A[3]),
+					ttl: header.TTL,
+				})
+			}
+		case dnsmessage.TypeAAAA:
+			resource, err := parser.AAAAResource()
+			if err != nil {
+				return nil, err
+			}
+			if owner != "" {
+				ip := make(net.IP, net.IPv6len)
+				copy(ip, resource.AAAA[:])
+				addresses[owner] = append(addresses[owner], dnsAddressRecord{
+					ip:  ip,
+					ttl: header.TTL,
+				})
+			}
+		case dnsmessage.TypeCNAME:
+			resource, err := parser.CNAMEResource()
+			if err != nil {
+				return nil, err
+			}
+			target := normalizeDNSName(resource.CNAME)
+			if owner != "" && target != "" {
+				cnames[owner] = append(cnames[owner], dnsCNAMERecord{
+					target: target,
+					ttl:    header.TTL,
+				})
+			}
+		default:
+			if err := parser.SkipAnswer(); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	records := make([]dnsHostRecord, 0)
+	for _, queryHost := range queryHosts {
+		records = append(records, resolveDNSHostRecords(queryHost, addresses, cnames)...)
+	}
+	return records, nil
+}
+
+func resolveDNSHostRecords(queryHost string, addresses map[string][]dnsAddressRecord, cnames map[string][]dnsCNAMERecord) []dnsHostRecord {
+	type pendingName struct {
+		name string
+		ttl  uint32
+	}
+	out := make([]dnsHostRecord, 0)
+	queue := []pendingName{{name: queryHost, ttl: math.MaxUint32}}
+	visited := map[string]struct{}{}
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		if current.name == "" {
+			continue
+		}
+		if _, ok := visited[current.name]; ok {
+			continue
+		}
+		visited[current.name] = struct{}{}
+		for _, address := range addresses[current.name] {
+			ttl := minDNSRecordTTL(current.ttl, address.ttl)
+			out = append(out, dnsHostRecord{
+				host: queryHost,
+				ip:   address.ip,
+				ttl:  ttl,
+			})
+		}
+		for _, cname := range cnames[current.name] {
+			queue = append(queue, pendingName{
+				name: cname.target,
+				ttl:  minDNSRecordTTL(current.ttl, cname.ttl),
+			})
+		}
+	}
+	return out
+}
+
+func minDNSRecordTTL(a, b uint32) uint32 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func normalizeDNSName(name dnsmessage.Name) string {
+	return normalizeDNSHostname(name.String())
+}
+
+func normalizeDNSHostname(host string) string {
+	host = strings.TrimSuffix(strings.TrimSpace(host), ".")
+	return normalizeHost(host)
+}
+
+func (s *Server) observeDNSResponse(sandboxIP string, payload []byte) {
+	if s == nil || s.dnsCache == nil {
+		return
+	}
+	s.dnsCache.ObserveResponse(sandboxIP, payload)
+}
+
+func (s *Server) forgetDNSHostCache(sandboxIP string) {
+	if s == nil || s.dnsCache == nil {
+		return
+	}
+	s.dnsCache.ForgetSandbox(sandboxIP)
+}
+
+// ForgetSandboxDNS removes DNS host associations for a sandbox pod IP.
+func (s *Server) ForgetSandboxDNS(sandboxIP string) {
+	s.forgetDNSHostCache(sandboxIP)
+}
+
+func (s *Server) applyCachedDNSHost(req *adapterRequest, classification trafficClassification) trafficClassification {
+	if s == nil || s.dnsCache == nil || req == nil {
+		return classification
+	}
+	if classification.Transport != "tcp" || classification.Protocol != "ssh" || classification.Host != "" || classification.UnknownReason != "" {
+		return classification
+	}
+	candidates := s.dnsCache.Lookup(req.SrcIP, classification.DestIP)
+	if len(candidates) == 0 {
+		return classification
+	}
+	host := chooseCachedSSHHost(req, classification, candidates)
+	if host == "" {
+		return classification
+	}
+	classification.Host = host
+	classification.HostSource = classificationHostSourceDNSCache
+	req.Host = host
+	return classification
+}
+
+func chooseCachedSSHHost(req *adapterRequest, classification trafficClassification, candidates []dnsHostCandidate) string {
+	if len(candidates) == 0 {
+		return ""
+	}
+	latest := strings.TrimSpace(candidates[0].Host)
+	if latest == "" {
+		return ""
+	}
+	if len(candidates) == 1 {
+		return latest
+	}
+	if policyAllowsCachedSSHHost(req, classification, latest) {
+		return latest
+	}
+	return ""
+}
+
+func policyAllowsCachedSSHHost(req *adapterRequest, classification trafficClassification, host string) bool {
+	if req == nil {
+		return false
+	}
+	if policy.MatchEgressAuthRule(req.Compiled, classification.Transport, classification.Protocol, classification.DestPort, host) != nil {
+		return true
+	}
+	if hasDomainScopedSSHAuthRule(req.Compiled) {
+		return false
+	}
+	if !policy.AllowEgressDestination(req.Compiled, classification.DestIP, classification.DestPort, classification.Transport, host, classification.Protocol) {
+		return false
+	}
+	if policy.HasDomainRules(req.Compiled) && !policy.AllowEgressDomain(req.Compiled, host) {
+		return false
+	}
+	return true
+}
+
+func hasDomainScopedSSHAuthRule(compiled *policy.CompiledPolicy) bool {
+	if compiled == nil {
+		return false
+	}
+	for _, rule := range compiled.Egress.AuthRules {
+		if rule.Rollout == v1alpha1.EgressAuthRolloutDisabled || len(rule.Domains) == 0 {
+			continue
+		}
+		if rule.Protocol == "" || rule.Protocol == v1alpha1.EgressAuthProtocolSSH {
+			return true
+		}
+	}
+	return false
+}
+
+type dnsTCPResponseObserver struct {
+	writer    io.Writer
+	server    *Server
+	sandboxIP string
+	buffer    []byte
+}
+
+func (w *dnsTCPResponseObserver) Write(p []byte) (int, error) {
+	n, err := w.writer.Write(p)
+	if n > 0 {
+		w.observe(p[:n])
+	}
+	return n, err
+}
+
+func (w *dnsTCPResponseObserver) observe(data []byte) {
+	if w == nil || w.server == nil || len(data) == 0 {
+		return
+	}
+	w.buffer = append(w.buffer, data...)
+	for {
+		if len(w.buffer) < 2 {
+			return
+		}
+		messageLength := int(binary.BigEndian.Uint16(w.buffer[:2]))
+		if messageLength <= 0 {
+			w.buffer = w.buffer[2:]
+			continue
+		}
+		if messageLength > math.MaxUint16 {
+			w.buffer = nil
+			return
+		}
+		if len(w.buffer) < 2+messageLength {
+			if len(w.buffer) > 2+math.MaxUint16 {
+				w.buffer = nil
+			}
+			return
+		}
+		message := append([]byte(nil), w.buffer[2:2+messageLength]...)
+		w.server.observeDNSResponse(w.sandboxIP, message)
+		w.buffer = w.buffer[2+messageLength:]
+	}
+}
+
+func (s *Server) pipeDNSOverTCP(client net.Conn, upstream net.Conn, upstreamWriter io.Reader, downstreamWriter io.Reader, compiled *policy.CompiledPolicy, audit *flowAudit, sandboxIP string) error {
+	upstreamCounter := &countingWriter{writer: upstream}
+	clientCounter := &countingWriter{writer: client}
+	dnsObserver := &dnsTCPResponseObserver{
+		writer:    clientCounter,
+		server:    s,
+		sandboxIP: sandboxIP,
+	}
+	errCh := make(chan error, 2)
+	go func() {
+		n, err := io.Copy(upstreamCounter, upstreamWriter)
+		s.recordEgressBytes(compiled, n, audit)
+		closeConnWrite(upstream)
+		errCh <- err
+	}()
+	go func() {
+		n, err := io.Copy(dnsObserver, downstreamWriter)
+		s.recordIngressBytes(compiled, n, audit)
+		closeConnWrite(client)
+		errCh <- err
+	}()
+	errs := make([]error, 0, 2)
+	for i := 0; i < 2; i++ {
+		if err := normalizeRelayError(<-errCh); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errorsJoin(errs...)
+}
+
+func errorsJoin(errs ...error) error {
+	if len(errs) == 1 {
+		return errs[0]
+	}
+	return errors.Join(errs...)
+}
+
+func (s *Server) proxyDNSTCP(req *adapterRequest) error {
+	if s == nil || req == nil || req.Conn == nil {
+		return fmt.Errorf("dns tcp proxy requires connection")
+	}
+	if req.DestIP == nil || req.DestPort <= 0 {
+		return fmt.Errorf("missing destination")
+	}
+	s.recordFlow(req.SrcIP, req.DestIP, req.DestPort, "tcp", remotePort(req.Conn.RemoteAddr()))
+	upstream := req.UpstreamConn
+	var err error
+	if upstream == nil {
+		upstream, err = s.dialTCPUpstreamForRequest(req)
+		if err != nil {
+			return err
+		}
+	}
+	upstream = &countingConn{Conn: upstream}
+	defer upstream.Close()
+
+	reader := io.Reader(req.Conn)
+	if req.Prefix != nil {
+		reader = io.MultiReader(req.Prefix, req.Conn)
+	}
+	upstreamReader := io.Reader(upstream)
+	if req.UpstreamPrefix != nil {
+		upstreamReader = io.MultiReader(req.UpstreamPrefix, upstream)
+	}
+	return s.pipeDNSOverTCP(req.Conn, upstream, reader, upstreamReader, req.Compiled, req.Audit, req.SrcIP)
+}

--- a/netd/pkg/proxy/dns_cache_test.go
+++ b/netd/pkg/proxy/dns_cache_test.go
@@ -1,0 +1,210 @@
+package proxy
+
+import (
+	"encoding/binary"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
+	"github.com/sandbox0-ai/sandbox0/netd/pkg/policy"
+	"golang.org/x/net/dns/dnsmessage"
+)
+
+func TestDNSHostCacheStoresResponsePerSandboxAndTTL(t *testing.T) {
+	now := time.Unix(100, 0)
+	cache := newDNSHostCache()
+	cache.now = func() time.Time { return now }
+
+	cache.ObserveResponse("10.0.0.2", buildDNSAResponse(t, "GitHub.COM.", "140.82.112.4", 60))
+	candidates := cache.Lookup("10.0.0.2", net.ParseIP("140.82.112.4"))
+	if len(candidates) != 1 || candidates[0].Host != "github.com" {
+		t.Fatalf("candidates = %#v, want github.com", candidates)
+	}
+	if got := cache.Lookup("10.0.0.3", net.ParseIP("140.82.112.4")); len(got) != 0 {
+		t.Fatalf("other sandbox candidates = %#v, want none", got)
+	}
+
+	now = now.Add(61 * time.Second)
+	if got := cache.Lookup("10.0.0.2", net.ParseIP("140.82.112.4")); len(got) != 0 {
+		t.Fatalf("expired candidates = %#v, want none", got)
+	}
+}
+
+func TestDNSHostCacheUsesQuestionNameThroughCNAME(t *testing.T) {
+	cache := newDNSHostCache()
+	cache.ObserveResponse("10.0.0.2", buildDNSCNAMEResponse(t, "github.com.", "github.map.fastly.net.", "140.82.112.4", 60))
+
+	candidates := cache.Lookup("10.0.0.2", net.ParseIP("140.82.112.4"))
+	if len(candidates) != 1 || candidates[0].Host != "github.com" {
+		t.Fatalf("candidates = %#v, want original question host", candidates)
+	}
+}
+
+func TestDNSHostCacheForgetSandbox(t *testing.T) {
+	cache := newDNSHostCache()
+	cache.ObserveResponse("10.0.0.2", buildDNSAResponse(t, "github.com.", "140.82.112.4", 60))
+	cache.ForgetSandbox("10.0.0.2")
+
+	if got := cache.Lookup("10.0.0.2", net.ParseIP("140.82.112.4")); len(got) != 0 {
+		t.Fatalf("candidates = %#v, want none", got)
+	}
+}
+
+func TestDNSTCPResponseObserverCachesCompleteFramesAcrossWrites(t *testing.T) {
+	cache := newDNSHostCache()
+	server := &Server{dnsCache: cache}
+	observer := &dnsTCPResponseObserver{
+		writer:    io.Discard,
+		server:    server,
+		sandboxIP: "10.0.0.2",
+	}
+	response := buildDNSAResponse(t, "github.com.", "140.82.112.4", 60)
+	frame := make([]byte, 2+len(response))
+	binary.BigEndian.PutUint16(frame[:2], uint16(len(response)))
+	copy(frame[2:], response)
+
+	if n, err := observer.Write(frame[:3]); err != nil || n != 3 {
+		t.Fatalf("first write = (%d, %v), want 3 nil", n, err)
+	}
+	if got := cache.Lookup("10.0.0.2", net.ParseIP("140.82.112.4")); len(got) != 0 {
+		t.Fatalf("partial frame candidates = %#v, want none", got)
+	}
+	if n, err := observer.Write(frame[3:]); err != nil || n != len(frame)-3 {
+		t.Fatalf("second write = (%d, %v), want %d nil", n, err, len(frame)-3)
+	}
+	candidates := cache.Lookup("10.0.0.2", net.ParseIP("140.82.112.4"))
+	if len(candidates) != 1 || candidates[0].Host != "github.com" {
+		t.Fatalf("candidates = %#v, want github.com", candidates)
+	}
+}
+
+func TestApplyCachedDNSHostMatchesSSHCredentialRule(t *testing.T) {
+	cache := newDNSHostCache()
+	cache.ObserveResponse("10.0.0.2", buildDNSAResponse(t, "github.com.", "140.82.112.4", 60))
+	server := &Server{dnsCache: cache}
+	compiled := &policy.CompiledPolicy{
+		Mode: v1alpha1.NetworkModeAllowAll,
+		Egress: policy.CompiledRuleSet{
+			AuthRules: []policy.CompiledEgressAuthRule{{
+				Name:     "git-ssh",
+				AuthRef:  "git-cred",
+				Protocol: v1alpha1.EgressAuthProtocolSSH,
+				Domains:  []policy.DomainRule{{Pattern: "github.com", Type: policy.DomainMatchExact}},
+			}},
+		},
+	}
+	req := &adapterRequest{
+		Compiled: compiled,
+		SrcIP:    "10.0.0.2",
+		DestIP:   net.ParseIP("140.82.112.4"),
+		DestPort: 22,
+	}
+	classification := server.applyCachedDNSHost(req, classifyKnownTraffic("tcp", "ssh", req.DestIP, req.DestPort, ""))
+	if classification.Host != "github.com" {
+		t.Fatalf("host = %q, want github.com", classification.Host)
+	}
+	if classification.HostSource != classificationHostSourceDNSCache {
+		t.Fatalf("host source = %q, want dns-cache", classification.HostSource)
+	}
+	if req.Host != "github.com" {
+		t.Fatalf("request host = %q, want github.com", req.Host)
+	}
+	decision := decideTraffic(compiled, classification)
+	if decision.MatchedAuthRule == nil || decision.MatchedAuthRule.AuthRef != "git-cred" {
+		t.Fatalf("matched auth rule = %+v, want git-cred", decision.MatchedAuthRule)
+	}
+}
+
+func TestApplyCachedDNSHostDoesNotUseOlderMatchingHostWhenLatestDoesNotMatch(t *testing.T) {
+	now := time.Unix(100, 0)
+	cache := newDNSHostCache()
+	cache.now = func() time.Time { return now }
+	cache.ObserveResponse("10.0.0.2", buildDNSAResponse(t, "github.com.", "140.82.112.4", 60))
+	now = now.Add(time.Second)
+	cache.ObserveResponse("10.0.0.2", buildDNSAResponse(t, "example.com.", "140.82.112.4", 60))
+	server := &Server{dnsCache: cache}
+	compiled := &policy.CompiledPolicy{
+		Mode: v1alpha1.NetworkModeAllowAll,
+		Egress: policy.CompiledRuleSet{
+			AuthRules: []policy.CompiledEgressAuthRule{{
+				Name:     "git-ssh",
+				AuthRef:  "git-cred",
+				Protocol: v1alpha1.EgressAuthProtocolSSH,
+				Domains:  []policy.DomainRule{{Pattern: "github.com", Type: policy.DomainMatchExact}},
+			}},
+		},
+	}
+	req := &adapterRequest{
+		Compiled: compiled,
+		SrcIP:    "10.0.0.2",
+		DestIP:   net.ParseIP("140.82.112.4"),
+		DestPort: 22,
+	}
+
+	classification := server.applyCachedDNSHost(req, classifyKnownTraffic("tcp", "ssh", req.DestIP, req.DestPort, ""))
+	if classification.Host != "" {
+		t.Fatalf("host = %q, want empty because latest DNS host does not match policy", classification.Host)
+	}
+}
+
+func buildDNSAResponse(t *testing.T, host string, ip string, ttl uint32) []byte {
+	t.Helper()
+	name := dnsmessage.MustNewName(host)
+	parsed := net.ParseIP(ip).To4()
+	if parsed == nil {
+		t.Fatalf("invalid IPv4 address %q", ip)
+	}
+	builder := dnsmessage.NewBuilder(nil, dnsmessage.Header{Response: true, RCode: dnsmessage.RCodeSuccess})
+	builder.EnableCompression()
+	if err := builder.StartQuestions(); err != nil {
+		t.Fatalf("start questions: %v", err)
+	}
+	if err := builder.Question(dnsmessage.Question{Name: name, Type: dnsmessage.TypeA, Class: dnsmessage.ClassINET}); err != nil {
+		t.Fatalf("add question: %v", err)
+	}
+	if err := builder.StartAnswers(); err != nil {
+		t.Fatalf("start answers: %v", err)
+	}
+	if err := builder.AResource(dnsmessage.ResourceHeader{Name: name, Type: dnsmessage.TypeA, Class: dnsmessage.ClassINET, TTL: ttl}, dnsmessage.AResource{A: [4]byte{parsed[0], parsed[1], parsed[2], parsed[3]}}); err != nil {
+		t.Fatalf("add A record: %v", err)
+	}
+	out, err := builder.Finish()
+	if err != nil {
+		t.Fatalf("finish dns response: %v", err)
+	}
+	return out
+}
+
+func buildDNSCNAMEResponse(t *testing.T, host string, cname string, ip string, ttl uint32) []byte {
+	t.Helper()
+	name := dnsmessage.MustNewName(host)
+	cnameName := dnsmessage.MustNewName(cname)
+	parsed := net.ParseIP(ip).To4()
+	if parsed == nil {
+		t.Fatalf("invalid IPv4 address %q", ip)
+	}
+	builder := dnsmessage.NewBuilder(nil, dnsmessage.Header{Response: true, RCode: dnsmessage.RCodeSuccess})
+	builder.EnableCompression()
+	if err := builder.StartQuestions(); err != nil {
+		t.Fatalf("start questions: %v", err)
+	}
+	if err := builder.Question(dnsmessage.Question{Name: name, Type: dnsmessage.TypeA, Class: dnsmessage.ClassINET}); err != nil {
+		t.Fatalf("add question: %v", err)
+	}
+	if err := builder.StartAnswers(); err != nil {
+		t.Fatalf("start answers: %v", err)
+	}
+	if err := builder.CNAMEResource(dnsmessage.ResourceHeader{Name: name, Type: dnsmessage.TypeCNAME, Class: dnsmessage.ClassINET, TTL: ttl}, dnsmessage.CNAMEResource{CNAME: cnameName}); err != nil {
+		t.Fatalf("add CNAME record: %v", err)
+	}
+	if err := builder.AResource(dnsmessage.ResourceHeader{Name: cnameName, Type: dnsmessage.TypeA, Class: dnsmessage.ClassINET, TTL: ttl}, dnsmessage.AResource{A: [4]byte{parsed[0], parsed[1], parsed[2], parsed[3]}}); err != nil {
+		t.Fatalf("add A record: %v", err)
+	}
+	out, err := builder.Finish()
+	if err != nil {
+		t.Fatalf("finish dns response: %v", err)
+	}
+	return out
+}

--- a/netd/pkg/proxy/host_verifier.go
+++ b/netd/pkg/proxy/host_verifier.go
@@ -148,6 +148,9 @@ func verifyClassifiedHost(verifier hostVerifier, compiled *policy.CompiledPolicy
 	if verifier == nil || compiled == nil || !policy.HasDomainRules(compiled) {
 		return classification
 	}
+	if classification.HostSource == classificationHostSourceDNSCache {
+		return classification
+	}
 	if classification.UnknownReason != "" || classification.Host == "" || classification.DestIP == nil {
 		return classification
 	}

--- a/netd/pkg/proxy/quic_reassembly.go
+++ b/netd/pkg/proxy/quic_reassembly.go
@@ -102,7 +102,19 @@ func buildStreamKey(srcIP, dstIP string, dcid []byte) string {
 	return srcIP + "|" + dstIP + "|" + hex.EncodeToString(dcid)
 }
 
-func unprotectInitial(packet []byte, pnOffset int64, hdr *quicsni.Header) ([]byte, error) {
+func unprotectInitial(packet []byte, pnOffset int64, hdr *quicsni.Header) (out []byte, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			out = nil
+			err = fmt.Errorf("unprotect quic initial: %v", recovered)
+		}
+	}()
+	if len(packet) == 0 || packet[0]&0x80 == 0 {
+		return nil, fmt.Errorf("quic initial packet is not a long-header packet")
+	}
+	if pnOffset < 0 || pnOffset+4+16 > int64(len(packet)) {
+		return nil, fmt.Errorf("quic initial packet is too short")
+	}
 	initialSecret := hkdf.Extract(crypto.SHA256.New, hdr.DestConnectionID, getSalt(hdr.Version))
 	clientSecret := hkdfExpandLabel(crypto.SHA256.New, initialSecret, "client in", []byte{}, crypto.SHA256.Size())
 	key, err := quicsni.NewInitialProtectionKey(clientSecret, hdr.Version)

--- a/netd/pkg/proxy/quic_sni_test.go
+++ b/netd/pkg/proxy/quic_sni_test.go
@@ -57,6 +57,14 @@ func TestParseUDPSNIFromQUIC(t *testing.T) {
 	}
 }
 
+func TestParseUDPSNIIgnoresMalformedInitial(t *testing.T) {
+	reassembler := newQuicReassembler()
+	malformed := []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+	if sni := reassembler.ParseSNI(malformed, "10.0.0.2", "10.0.0.53"); sni != "" {
+		t.Fatalf("expected malformed packet to have no SNI, got %q", sni)
+	}
+}
+
 func mustHexDecodeString(s string) []byte {
 	normalized := strings.Map(func(c rune) rune {
 		if unicode.IsSpace(c) {

--- a/netd/pkg/proxy/server.go
+++ b/netd/pkg/proxy/server.go
@@ -40,6 +40,8 @@ type Server struct {
 	adapters          *adapterRegistry
 	authResolver      egressAuthResolver
 	authCache         egressAuthCache
+	dnsCache          *dnsHostCache
+	udpReplyDialer    udpReplyDialer
 	tlsAuthority      tlsInterceptAuthority
 	upstreamTLSConfig *tls.Config
 	auditor           *auditLogger
@@ -162,6 +164,8 @@ func NewServer(cfg *config.NetdConfig, store *policy.Store, tracker *conntrack.T
 		adapters:       adapters,
 		authResolver:   noopEgressAuthResolver{},
 		authCache:      newMemoryEgressAuthCache(),
+		dnsCache:       newDNSHostCache(),
+		udpReplyDialer: dialUDPTransparent,
 		auditor:        auditor,
 		exitCh:         make(chan error, 1),
 	}
@@ -336,14 +340,15 @@ func (s *Server) handleTCPConn(conn net.Conn) {
 	if result.Apply != nil {
 		result.Apply(req)
 	}
-	result.Classification = verifyClassifiedHost(s.hostVerifier, p, result.Classification)
 	result.Classification = s.probeServerFirstSSH(req, result.Classification, ctx)
+	result.Classification = s.applyCachedDNSHost(req, result.Classification)
+	result.Classification = verifyClassifiedHost(s.hostVerifier, p, result.Classification)
 	decision := decideTraffic(p, result.Classification)
 	fields := []zap.Field{}
 	if result.Error != nil {
 		fields = append(fields, zap.Error(result.Error))
 	}
-	s.handleTCPDecision(req, decision, result.Host, fields...)
+	s.handleTCPDecision(req, decision, result.Classification.Host, fields...)
 }
 
 func (s *Server) handleUDP(ctx context.Context, conn *net.UDPConn) {

--- a/netd/pkg/proxy/server_integration_test.go
+++ b/netd/pkg/proxy/server_integration_test.go
@@ -154,10 +154,11 @@ func TestHandleUDPDecisionPassThroughRelaysAndAudits(t *testing.T) {
 		cfg: &config.NetdConfig{
 			ProxyUpstreamTimeout: metav1.Duration{Duration: 2 * time.Second},
 		},
-		logger:      zap.NewNop(),
-		udpHTTPConn: proxyConn,
-		adapters:    registry,
-		auditor:     newAuditLoggerFromWriter(nopWriteCloser{Writer: &auditBuf}),
+		logger:         zap.NewNop(),
+		udpHTTPConn:    proxyConn,
+		adapters:       registry,
+		auditor:        newAuditLoggerFromWriter(nopWriteCloser{Writer: &auditBuf}),
+		udpReplyDialer: dialUDPEphemeralForTest,
 	}
 
 	payload := []byte("udp-payload")
@@ -247,10 +248,11 @@ func TestHandleUDPDecisionPassThroughReusesUDPSession(t *testing.T) {
 		cfg: &config.NetdConfig{
 			ProxyUpstreamTimeout: metav1.Duration{Duration: 2 * time.Second},
 		},
-		logger:      zap.NewNop(),
-		udpHTTPConn: proxyConn,
-		adapters:    registry,
-		auditor:     newAuditLoggerFromWriter(nopWriteCloser{Writer: &auditBuf}),
+		logger:         zap.NewNop(),
+		udpHTTPConn:    proxyConn,
+		adapters:       registry,
+		auditor:        newAuditLoggerFromWriter(nopWriteCloser{Writer: &auditBuf}),
+		udpReplyDialer: dialUDPEphemeralForTest,
 	}
 	defer server.closeUDPSessions()
 
@@ -305,6 +307,74 @@ func TestHandleUDPDecisionPassThroughReusesUDPSession(t *testing.T) {
 	if events[0].EgressBytes != wantBytes || events[0].IngressBytes != wantBytes {
 		t.Fatalf("unexpected aggregated udp bytes: %+v", events[0])
 	}
+}
+
+func TestUDPSessionReplyUsesOriginalDestination(t *testing.T) {
+	var gotLocal *net.UDPAddr
+	var gotRemote *net.UDPAddr
+	reply := &recordingUDPReplyConn{}
+	server := &Server{
+		logger: zap.NewNop(),
+		udpReplyDialer: func(local *net.UDPAddr, remote *net.UDPAddr) (udpReplyConn, error) {
+			gotLocal = cloneUDPAddr(local)
+			gotRemote = cloneUDPAddr(remote)
+			return reply, nil
+		},
+	}
+	req := &adapterRequest{
+		Server:    server,
+		Compiled:  &policy.CompiledPolicy{Mode: v1alpha1.NetworkModeAllowAll},
+		SrcIP:     "10.244.2.10",
+		DestIP:    net.ParseIP("10.244.1.53"),
+		DestPort:  53,
+		UDPSource: &net.UDPAddr{IP: net.ParseIP("10.244.2.10"), Port: 40000},
+	}
+	session := newUDPSession(server, udpSessionKey{
+		SrcIP:    "10.244.2.10",
+		SrcPort:  40000,
+		DestIP:   "10.244.1.53",
+		DestPort: 53,
+	}, req)
+
+	written, err := session.replyToClient([]byte("dns-response"))
+	if err != nil {
+		t.Fatalf("reply to client: %v", err)
+	}
+	if written != len("dns-response") {
+		t.Fatalf("written = %d", written)
+	}
+	if gotLocal == nil || gotLocal.String() != "10.244.1.53:53" {
+		t.Fatalf("reply local addr = %v", gotLocal)
+	}
+	if gotRemote == nil || gotRemote.String() != "10.244.2.10:40000" {
+		t.Fatalf("reply remote addr = %v", gotRemote)
+	}
+	if !bytes.Equal(reply.payload, []byte("dns-response")) {
+		t.Fatalf("reply payload = %q", reply.payload)
+	}
+	session.close()
+	if !reply.closed {
+		t.Fatal("expected reply connection to close with session")
+	}
+}
+
+func dialUDPEphemeralForTest(_ *net.UDPAddr, remote *net.UDPAddr) (udpReplyConn, error) {
+	return net.DialUDP("udp4", nil, remote)
+}
+
+type recordingUDPReplyConn struct {
+	payload []byte
+	closed  bool
+}
+
+func (c *recordingUDPReplyConn) Write(payload []byte) (int, error) {
+	c.payload = append(c.payload[:0], payload...)
+	return len(payload), nil
+}
+
+func (c *recordingUDPReplyConn) Close() error {
+	c.closed = true
+	return nil
 }
 
 func startTCPEchoServer(t *testing.T, expectedBytes int) (*net.TCPAddr, <-chan []byte) {

--- a/netd/pkg/proxy/transparent_linux.go
+++ b/netd/pkg/proxy/transparent_linux.go
@@ -17,11 +17,7 @@ func transparentListenConfig() net.ListenConfig {
 		Control: func(network, address string, c syscall.RawConn) error {
 			var controlErr error
 			err := c.Control(func(fd uintptr) {
-				if err := unix.SetsockoptInt(int(fd), unix.SOL_IP, unix.IP_TRANSPARENT, 1); err != nil {
-					controlErr = err
-					return
-				}
-				if err := unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEADDR, 1); err != nil {
+				if err := setTransparentSocketOptions(fd); err != nil {
 					controlErr = err
 					return
 				}
@@ -44,6 +40,16 @@ func transparentListenConfig() net.ListenConfig {
 	}
 }
 
+func setTransparentSocketOptions(fd uintptr) error {
+	if err := unix.SetsockoptInt(int(fd), unix.SOL_IP, unix.IP_TRANSPARENT, 1); err != nil {
+		return err
+	}
+	if err := unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEADDR, 1); err != nil {
+		return err
+	}
+	return nil
+}
+
 func listenTCPTransparent(addr string) (net.Listener, error) {
 	cfg := transparentListenConfig()
 	return cfg.Listen(context.Background(), "tcp4", addr)
@@ -59,6 +65,32 @@ func listenUDPTransparent(addr string) (*net.UDPConn, error) {
 	if !ok {
 		_ = pc.Close()
 		return nil, fmt.Errorf("listen packet is not udp")
+	}
+	return udpConn, nil
+}
+
+func dialUDPTransparent(local *net.UDPAddr, remote *net.UDPAddr) (udpReplyConn, error) {
+	dialer := net.Dialer{
+		LocalAddr: local,
+		Control: func(network, address string, c syscall.RawConn) error {
+			var controlErr error
+			err := c.Control(func(fd uintptr) {
+				controlErr = setTransparentSocketOptions(fd)
+			})
+			if err != nil {
+				return err
+			}
+			return controlErr
+		},
+	}
+	conn, err := dialer.Dial("udp4", remote.String())
+	if err != nil {
+		return nil, err
+	}
+	udpConn, ok := conn.(*net.UDPConn)
+	if !ok {
+		_ = conn.Close()
+		return nil, fmt.Errorf("transparent udp dial returned %T", conn)
 	}
 	return udpConn, nil
 }

--- a/netd/pkg/proxy/transparent_other.go
+++ b/netd/pkg/proxy/transparent_other.go
@@ -19,3 +19,7 @@ func listenUDPTransparent(addr string) (*net.UDPConn, error) {
 	}
 	return net.ListenUDP("udp", udpAddr)
 }
+
+func dialUDPTransparent(local *net.UDPAddr, remote *net.UDPAddr) (udpReplyConn, error) {
+	return net.DialUDP("udp", local, remote)
+}

--- a/netd/pkg/proxy/udp_session.go
+++ b/netd/pkg/proxy/udp_session.go
@@ -31,6 +31,7 @@ type udpSession struct {
 	destIP      net.IP
 	destPort    int
 	upstream    *net.UDPConn
+	downstream  udpReplyConn
 	closed      bool
 	auditReq    *adapterRequest
 	decision    trafficDecision
@@ -40,6 +41,13 @@ type udpSession struct {
 	lastSeenUnixNano int64
 	closeOnce        sync.Once
 }
+
+type udpReplyConn interface {
+	Write([]byte) (int, error)
+	Close() error
+}
+
+type udpReplyDialer func(local *net.UDPAddr, remote *net.UDPAddr) (udpReplyConn, error)
 
 func newUDPSessionKey(req *adapterRequest) (udpSessionKey, error) {
 	if req == nil || req.UDPSource == nil || req.DestIP == nil || req.DestPort <= 0 {
@@ -238,27 +246,81 @@ func (session *udpSession) readLoop(conn *net.UDPConn) {
 		}
 		payload := append([]byte(nil), buf[:n]...)
 		session.touch()
-		clientConn, clientAddr, compiled, audit := session.snapshot()
-		if clientConn == nil || clientAddr == nil {
-			continue
+		if session.destinationPort() == 53 {
+			session.server.observeDNSResponse(session.key.SrcIP, payload)
 		}
-		if session.server != nil {
-			session.server.recordIngressBytes(compiled, int64(n), audit)
-		}
-		if _, writeErr := clientConn.WriteToUDP(payload, clientAddr); writeErr != nil {
+		compiled, audit := session.auditSnapshot()
+		written, writeErr := session.replyToClient(payload)
+		if writeErr != nil {
 			if !errors.Is(writeErr, net.ErrClosed) {
 				session.server.logger.Warn("UDP session reply write failed", zap.Error(writeErr))
 			}
 			session.closeWithError(writeErr)
 			return
 		}
+		if session.server != nil && written > 0 {
+			session.server.recordIngressBytes(compiled, int64(written), audit)
+		}
 	}
 }
 
-func (session *udpSession) snapshot() (*net.UDPConn, *net.UDPAddr, *policy.CompiledPolicy, *flowAudit) {
+func (session *udpSession) replyToClient(payload []byte) (int, error) {
+	if session == nil {
+		return 0, fmt.Errorf("udp session is nil")
+	}
+	if len(payload) == 0 {
+		return 0, nil
+	}
+	downstream, err := session.ensureDownstream()
+	if err != nil {
+		return 0, err
+	}
+	return downstream.Write(payload)
+}
+
+func (session *udpSession) ensureDownstream() (udpReplyConn, error) {
+	if session == nil || session.server == nil {
+		return nil, fmt.Errorf("udp session is not configured")
+	}
 	session.mu.Lock()
 	defer session.mu.Unlock()
-	return session.clientConn, cloneUDPAddr(session.clientAddr), session.compiled, session.audit
+	if session.closed {
+		return nil, fmt.Errorf("udp session is closed")
+	}
+	if session.downstream != nil {
+		return session.downstream, nil
+	}
+	if session.destIP == nil || session.destPort <= 0 || session.clientAddr == nil {
+		return nil, fmt.Errorf("udp session reply route is missing")
+	}
+	dialer := session.server.udpReplyDialer
+	if dialer == nil {
+		dialer = dialUDPTransparent
+	}
+	downstream, err := dialer(
+		&net.UDPAddr{IP: cloneIP(session.destIP), Port: session.destPort},
+		cloneUDPAddr(session.clientAddr),
+	)
+	if err != nil {
+		return nil, err
+	}
+	session.downstream = downstream
+	return downstream, nil
+}
+
+func (session *udpSession) auditSnapshot() (*policy.CompiledPolicy, *flowAudit) {
+	session.mu.Lock()
+	defer session.mu.Unlock()
+	return session.compiled, session.audit
+}
+
+func (session *udpSession) destinationPort() int {
+	if session == nil {
+		return 0
+	}
+	session.mu.Lock()
+	defer session.mu.Unlock()
+	return session.destPort
 }
 
 func (session *udpSession) touch() {
@@ -300,6 +362,7 @@ func (session *udpSession) closeWithError(err error) {
 		session.mu.Lock()
 		session.closed = true
 		upstream := session.upstream
+		downstream := session.downstream
 		if err != nil && session.terminalErr == nil {
 			session.terminalErr = err
 		}
@@ -309,9 +372,13 @@ func (session *udpSession) closeWithError(err error) {
 		audit := session.audit
 		terminalErr := session.terminalErr
 		session.upstream = nil
+		session.downstream = nil
 		session.mu.Unlock()
 		if upstream != nil {
 			_ = upstream.Close()
+		}
+		if downstream != nil {
+			_ = downstream.Close()
 		}
 		if session.server != nil {
 			session.server.removeUDPSession(session)


### PR DESCRIPTION
## Summary
- add a per-sandbox DNS response cache in netd and use it to recover hostnames for SSH flows before policy/auth matching
- observe UDP and TCP DNS responses, honor DNS TTL bounds, and clear cache entries when sandbox pod IPs are removed
- route cluster DNS through netd, including kube-dns service and endpoint IPs, so sandbox DNS responses can be observed under CNI DNAT
- fix transparent UDP replies to preserve the original destination IP/port back to the sandbox, and harden QUIC SNI parsing for non-QUIC UDP packets
- document SSH hostname matching behavior

Fixes #382

## Tests
- go test ./netd/...

## Remote validation
- Deployed the PR netd image to the Aliyun Singapore kind environment.
- Validated a cross-node headless SSH fixture: sandbox resolved `ssh-server.sandbox0-e2e-ssh-fixture.svc.cluster.local`, fake SSH key failed before credential policy, then succeeded after a domain-scoped SSH credential rule with `ssh_proxy` binding.