### PR TITLE
Fix sandbox env vars for procd processes

### DIFF
--- a/docs/sandbox/contexts/page.mdx
+++ b/docs/sandbox/contexts/page.mdx
@@ -383,7 +383,7 @@ Create a new context in a sandbox.
 | `repl` | object | REPL configuration (optional for `type=repl`; defaults to Python when omitted) |
 | `cmd` | object | Command configuration (`cmd.command` required if `type=cmd`) |
 | `cwd` | string | Working directory |
-| `env_vars` | object | Environment variables |
+| `env_vars` | object | Context environment variables; override sandbox-level `env_vars` for this context |
 | `pty_size` | object | Terminal size `{rows, cols}` |
 | `ttl_sec` | integer | Context time-to-live in seconds |
 | `idle_timeout_sec` | integer | Idle timeout in seconds |

--- a/docs/sandbox/page.mdx
+++ b/docs/sandbox/page.mdx
@@ -55,7 +55,7 @@ Claim a sandbox from a template. The sandbox is created from a pre-warmed pool f
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `env_vars` | object | Environment variables |
+| `env_vars` | object | Sandbox-level default environment variables for new procd-managed processes |
 | `ttl` | integer | Time to live in seconds (soft limit, triggers auto-pause; default: `0`, disabled) |
 | `hard_ttl` | integer | Hard runtime lifetime in seconds (cleans compute while preserving sandbox identity and services; default: `0`, disabled) |
 | `network` | object | `SandboxNetworkPolicy`. Controls traffic rules, protocol controls, credential bindings, and destination-scoped egress auth |
@@ -64,6 +64,8 @@ Claim a sandbox from a template. The sandbox is created from a pre-warmed pool f
 | `services` | array | Sandbox Services for public HTTP routes |
 
 See [Network](/docs/sandbox/network) and [Protocol Controls](/docs/sandbox/protocol-controls) for outbound control, [Sandbox Services](/docs/sandbox/services) for public HTTP controls, and [Credential](/docs/credential) for outbound auth and secret handling.
+
+Sandbox `env_vars` override template/container environment variables for new contexts, command services, and function executions. Per-context, per-command, service runtime, and function `env_vars` override sandbox `env_vars` for that narrower scope. Warm processes start before the sandbox is claimed, so they do not receive claim-time sandbox `env_vars`.
 
 ### TTL vs Hard TTL
 
@@ -409,7 +411,7 @@ Only the following fields can be updated at runtime:
 | `services` | array | Sandbox Services for public HTTP routes |
 
 <Callout variant="warning">
-<code>env_vars</code> and <code>webhook</code> cannot be updated at runtime. These fields only take effect when the sandbox is created. To use different environment variables, create a new sandbox.
+<code>env_vars</code> and <code>webhook</code> cannot be updated at runtime. These fields only take effect when the sandbox is created. To use different sandbox-level environment variables, create a new sandbox.
 </Callout>
 
 <Tabs

--- a/docs/template/configuration/page.mdx
+++ b/docs/template/configuration/page.mdx
@@ -82,7 +82,15 @@ envVars:
     APP_ENV: production
 ```
 
-`envVars` are set at the template level and apply to every sandbox created from this template. Users can override or extend them at sandbox creation time via the `env_vars` field in the sandbox config.
+`envVars` are set at the template level and become part of the sandbox container's base environment, alongside `mainContainer.env`. Users can override or extend them at sandbox creation time via the `env_vars` field in the sandbox config.
+
+Environment variable precedence for procd-managed child processes is:
+
+1. Container image, template `envVars`, and `mainContainer.env`
+2. Sandbox creation `config.env_vars`
+3. Context, command, service runtime, or function `env_vars`
+
+Claim-time sandbox `env_vars` are applied to new procd-managed processes after the sandbox is claimed. Template warm processes are started before claim from the warm pool and only receive the template/warm-process environment.
 
 ---
 

--- a/manager/pkg/service/procd_client.go
+++ b/manager/pkg/service/procd_client.go
@@ -110,6 +110,7 @@ type StatsResponse struct {
 type InitializeRequest struct {
 	SandboxID string             `json:"sandbox_id"`
 	TeamID    string             `json:"team_id,omitempty"`
+	EnvVars   map[string]string  `json:"env_vars,omitempty"`
 	Webhook   *InitializeWebhook `json:"webhook,omitempty"`
 }
 

--- a/manager/pkg/service/sandbox_env_test.go
+++ b/manager/pkg/service/sandbox_env_test.go
@@ -1,0 +1,39 @@
+package service
+
+import "testing"
+
+func TestSandboxEnvVarsForInitializeClonesConfigEnvVars(t *testing.T) {
+	cfg := &SandboxConfig{
+		EnvVars: map[string]string{
+			"APP_ENV": "test",
+		},
+	}
+
+	got := sandboxEnvVarsForInitialize(cfg)
+	if got["APP_ENV"] != "test" {
+		t.Fatalf("APP_ENV = %q, want test", got["APP_ENV"])
+	}
+
+	got["APP_ENV"] = "mutated"
+	if cfg.EnvVars["APP_ENV"] != "test" {
+		t.Fatalf("config env mutated to %q, want test", cfg.EnvVars["APP_ENV"])
+	}
+}
+
+func TestCloneSandboxConfigClonesEnvVars(t *testing.T) {
+	cfg := &SandboxConfig{
+		EnvVars: map[string]string{
+			"APP_ENV": "test",
+		},
+	}
+
+	got := cloneSandboxConfig(cfg)
+	if got.EnvVars["APP_ENV"] != "test" {
+		t.Fatalf("APP_ENV = %q, want test", got.EnvVars["APP_ENV"])
+	}
+
+	got.EnvVars["APP_ENV"] = "mutated"
+	if cfg.EnvVars["APP_ENV"] != "test" {
+		t.Fatalf("config env mutated to %q, want test", cfg.EnvVars["APP_ENV"])
+	}
+}

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -95,10 +95,22 @@ func cloneSandboxConfig(cfg *SandboxConfig) *SandboxConfig {
 		return nil
 	}
 	cloned := *cfg
+	cloned.EnvVars = cloneEnvVars(cfg.EnvVars)
 	if cloned.Network != nil {
 		cloned.Network = sanitizedNetworkPolicyForPersistence(cloned.Network)
 	}
 	return &cloned
+}
+
+func cloneEnvVars(envVars map[string]string) map[string]string {
+	if len(envVars) == 0 {
+		return nil
+	}
+	cloned := make(map[string]string, len(envVars))
+	for key, value := range envVars {
+		cloned[key] = value
+	}
+	return cloned
 }
 
 func (s *SandboxService) claimConfigForPersistence(cfg *SandboxConfig) *SandboxConfig {
@@ -1239,6 +1251,7 @@ func (s *SandboxService) initializeProcd(
 	initReq := InitializeRequest{
 		SandboxID: sandboxID,
 		TeamID:    teamID,
+		EnvVars:   sandboxEnvVarsForInitialize(req.Config),
 		Webhook:   webhookConfig,
 	}
 
@@ -1268,4 +1281,11 @@ func (s *SandboxService) initializeProcd(
 			continue
 		}
 	}
+}
+
+func sandboxEnvVarsForInitialize(cfg *SandboxConfig) map[string]string {
+	if cfg == nil {
+		return nil
+	}
+	return cloneEnvVars(cfg.EnvVars)
 }

--- a/manager/procd/pkg/context/manager.go
+++ b/manager/procd/pkg/context/manager.go
@@ -50,6 +50,7 @@ type SandboxResourceUsage struct {
 type Manager struct {
 	mu                   sync.RWMutex
 	contexts             map[string]*Context
+	sandboxEnvVars       map[string]string
 	onExit               process.ExitHandler
 	onStart              process.StartHandler
 	defaultCleanupPolicy CleanupPolicy
@@ -84,6 +85,20 @@ func (m *Manager) SetDefaultCleanupPolicy(policy CleanupPolicy) {
 	m.defaultCleanupPolicy = policy
 }
 
+// SetSandboxEnvVars sets sandbox-level default environment variables for new contexts.
+func (m *Manager) SetSandboxEnvVars(envVars map[string]string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.sandboxEnvVars = process.CloneEnvVars(envVars)
+}
+
+// SandboxEnvVars returns a copy of the sandbox-level default environment variables.
+func (m *Manager) SandboxEnvVars() map[string]string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return process.CloneEnvVars(m.sandboxEnvVars)
+}
+
 // StartCleanup starts a background cleanup loop.
 func (m *Manager) StartCleanup(ctx context.Context, interval time.Duration) {
 	if interval <= 0 {
@@ -115,6 +130,7 @@ func (m *Manager) CreateContextWithPolicyAndREPLConfig(config process.ProcessCon
 	m.mu.Lock()
 	startHandler := m.onStart
 	defaultPolicy := m.defaultCleanupPolicy
+	config.EnvVars = process.MergeEnvVars(m.sandboxEnvVars, config.EnvVars)
 	// Define exit handler for the new context
 	exitHandler := func(event process.ExitEvent) {
 		if m.onExit != nil {

--- a/manager/procd/pkg/context/manager_test.go
+++ b/manager/procd/pkg/context/manager_test.go
@@ -66,6 +66,55 @@ func TestManager_CreateContext(t *testing.T) {
 	m.Cleanup()
 }
 
+func TestManager_CreateContextMergesSandboxEnvVars(t *testing.T) {
+	m := NewManager()
+	m.SetSandboxEnvVars(map[string]string{
+		"SANDBOX_ENV": "sandbox",
+		"OVERRIDE":    "sandbox",
+	})
+
+	ctx, err := m.CreateContext(process.ProcessConfig{
+		Type:    process.ProcessTypeCMD,
+		Command: []string{"/bin/sh", "-c", "true"},
+		EnvVars: map[string]string{
+			"OVERRIDE":    "context",
+			"CONTEXT_ENV": "context",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateContext() failed = %v", err)
+	}
+	t.Cleanup(func() {
+		m.Cleanup()
+	})
+
+	if got := ctx.EnvVars["SANDBOX_ENV"]; got != "sandbox" {
+		t.Fatalf("SANDBOX_ENV = %q, want sandbox", got)
+	}
+	if got := ctx.EnvVars["OVERRIDE"]; got != "context" {
+		t.Fatalf("OVERRIDE = %q, want context", got)
+	}
+	if got := ctx.EnvVars["CONTEXT_ENV"]; got != "context" {
+		t.Fatalf("CONTEXT_ENV = %q, want context", got)
+	}
+}
+
+func TestManagerSandboxEnvVarsReturnsCopy(t *testing.T) {
+	m := NewManager()
+	input := map[string]string{"APP_ENV": "test"}
+	m.SetSandboxEnvVars(input)
+	input["APP_ENV"] = "mutated"
+
+	got := m.SandboxEnvVars()
+	if got["APP_ENV"] != "test" {
+		t.Fatalf("APP_ENV = %q, want test", got["APP_ENV"])
+	}
+	got["APP_ENV"] = "mutated"
+	if again := m.SandboxEnvVars()["APP_ENV"]; again != "test" {
+		t.Fatalf("APP_ENV after returned map mutation = %q, want test", again)
+	}
+}
+
 // TestManager_CreateContextErrors tests error cases for context creation.
 func TestManager_CreateContextErrors(t *testing.T) {
 	m := NewManager()

--- a/manager/procd/pkg/http/handlers/function.go
+++ b/manager/procd/pkg/http/handlers/function.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/process"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/sandbox0-ai/sandbox0/pkg/proxy"
 	"github.com/sandbox0-ai/sandbox0/pkg/sandboxfunction"
@@ -51,12 +52,13 @@ type functionHandlerConfig struct {
 
 // FunctionHandler executes gateway-provided function source inside the sandbox.
 type FunctionHandler struct {
-	logger         *zap.Logger
-	runnerPath     string
-	cacheRoot      string
-	defaultTimeout time.Duration
-	maxTimeout     time.Duration
-	upgrader       websocket.Upgrader
+	logger             *zap.Logger
+	runnerPath         string
+	cacheRoot          string
+	defaultTimeout     time.Duration
+	maxTimeout         time.Duration
+	upgrader           websocket.Upgrader
+	sandboxEnvProvider func() map[string]string
 }
 
 type functionHandlerRequest struct {
@@ -99,6 +101,18 @@ func newFunctionHandler(config functionHandlerConfig, logger *zap.Logger) *Funct
 			CheckOrigin: func(*http.Request) bool { return true },
 		},
 	}
+}
+
+// SetSandboxEnvVarsProvider sets the provider for sandbox-level default environment variables.
+func (h *FunctionHandler) SetSandboxEnvVarsProvider(provider func() map[string]string) {
+	h.sandboxEnvProvider = provider
+}
+
+func (h *FunctionHandler) sandboxEnvVars() map[string]string {
+	if h.sandboxEnvProvider == nil {
+		return nil
+	}
+	return h.sandboxEnvProvider()
 }
 
 func (h *FunctionHandler) Execute(w http.ResponseWriter, r *http.Request) {
@@ -348,7 +362,7 @@ func (h *FunctionHandler) run(ctx context.Context, modulePath, handler string, e
 	cmd := osexec.CommandContext(ctx, h.runnerPath, modulePath, handler)
 	cmd.Dir = filepath.Dir(modulePath)
 	cmd.Stdin = bytes.NewReader(payload)
-	cmd.Env = mergeFunctionEnv(os.Environ(), envVars)
+	cmd.Env = process.MergeEnvironment(os.Environ(), h.sandboxEnvVars(), envVars)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.Cancel = killFunctionProcessGroup(cmd)
 	cmd.WaitDelay = 5 * time.Second
@@ -380,7 +394,7 @@ func killFunctionProcessGroup(cmd *osexec.Cmd) func() error {
 func (h *FunctionHandler) runStream(ctx context.Context, w http.ResponseWriter, modulePath, handler string, envVars map[string]string, payload []byte) error {
 	cmd := osexec.CommandContext(ctx, h.runnerPath, "--stream", modulePath, handler)
 	cmd.Dir = filepath.Dir(modulePath)
-	cmd.Env = mergeFunctionEnv(os.Environ(), envVars)
+	cmd.Env = process.MergeEnvironment(os.Environ(), h.sandboxEnvVars(), envVars)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.Cancel = killFunctionProcessGroup(cmd)
 	cmd.WaitDelay = 5 * time.Second
@@ -494,7 +508,7 @@ func (h *FunctionHandler) runWebSocket(ctx context.Context, conn *websocket.Conn
 
 	cmd := osexec.CommandContext(ctx, h.runnerPath, "--websocket", modulePath, handler)
 	cmd.Dir = filepath.Dir(modulePath)
-	cmd.Env = mergeFunctionEnv(os.Environ(), envVars)
+	cmd.Env = process.MergeEnvironment(os.Environ(), h.sandboxEnvVars(), envVars)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.Cancel = killFunctionProcessGroup(cmd)
 	cmd.WaitDelay = 5 * time.Second
@@ -702,37 +716,6 @@ func decodeWebSocketRunnerMessage(frame sandboxfunction.WebSocketFrame) (int, []
 	default:
 		return 0, nil, fmt.Errorf("unsupported websocket message_type %q", frame.MessageType)
 	}
-}
-
-func mergeFunctionEnv(base []string, envVars map[string]string) []string {
-	if len(envVars) == 0 {
-		return base
-	}
-	out := make([]string, 0, len(base)+len(envVars))
-	overrides := make(map[string]string, len(envVars))
-	for key, value := range envVars {
-		key = strings.TrimSpace(key)
-		if key == "" || strings.Contains(key, "=") {
-			continue
-		}
-		overrides[key] = value
-	}
-	for _, item := range base {
-		key, _, ok := strings.Cut(item, "=")
-		if !ok {
-			continue
-		}
-		if value, exists := overrides[key]; exists {
-			out = append(out, key+"="+value)
-			delete(overrides, key)
-			continue
-		}
-		out = append(out, item)
-	}
-	for key, value := range overrides {
-		out = append(out, key+"="+value)
-	}
-	return out
 }
 
 func trimLoggedStderr(stderr string, truncated bool) string {

--- a/manager/procd/pkg/http/handlers/function_test.go
+++ b/manager/procd/pkg/http/handlers/function_test.go
@@ -83,6 +83,79 @@ printf '{"status":202,"headers":{"x-runner":["ok"]},"body_base64":"aGVsbG8="}\n'
 	}
 }
 
+func TestFunctionHandlerExecuteMergesSandboxEnvVars(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell runner fixture requires POSIX")
+	}
+	dir := t.TempDir()
+	runnerPath := filepath.Join(dir, "runner.sh")
+	if err := os.WriteFile(runnerPath, []byte(`#!/bin/sh
+cat >/dev/null
+if [ "$SANDBOX_ENV" != "sandbox" ]; then
+  echo "missing sandbox env" >&2
+  exit 3
+fi
+if [ "$OVERRIDE_ENV" != "request" ]; then
+  echo "env precedence failed" >&2
+  exit 4
+fi
+printf '{"status":200,"body_base64":"b2s="}\n'
+`), 0o755); err != nil {
+		t.Fatalf("write runner: %v", err)
+	}
+
+	handler := newFunctionHandler(functionHandlerConfig{
+		runnerPath: runnerPath,
+		cacheRoot:  filepath.Join(dir, "cache"),
+	}, zap.NewNop())
+	handler.SetSandboxEnvVarsProvider(func() map[string]string {
+		return map[string]string{
+			"SANDBOX_ENV":  "sandbox",
+			"OVERRIDE_ENV": "sandbox",
+		}
+	})
+	req := sandboxfunction.ExecuteRequest{
+		Runtime: sandboxfunction.RuntimePython,
+		Handler: sandboxfunction.DefaultHandler,
+		EnvVars: map[string]string{
+			"OVERRIDE_ENV": "request",
+		},
+		Source: sandboxfunction.Source{
+			Type: sandboxfunction.SourceTypeInline,
+			Code: "def handler(request):\n    return {'status': 204}\n",
+		},
+		Request: sandboxfunction.HTTPRequest{
+			Method: "POST",
+			Path:   "/events",
+		},
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/api/v1/functions/execute", bytes.NewReader(body))
+	handler.Execute(rec, httpReq)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var envelope struct {
+		Success bool                            `json:"success"`
+		Data    sandboxfunction.ExecuteResponse `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !envelope.Success {
+		t.Fatalf("response success = false: %s", rec.Body.String())
+	}
+	if envelope.Data.BodyBase64 != "b2s=" {
+		t.Fatalf("body_base64 = %q, want b2s=", envelope.Data.BodyBase64)
+	}
+}
+
 func TestFunctionHandlerRejectsMismatchedDigest(t *testing.T) {
 	handler := newFunctionHandler(functionHandlerConfig{
 		runnerPath: "/bin/false",

--- a/manager/procd/pkg/http/handlers/initialize.go
+++ b/manager/procd/pkg/http/handlers/initialize.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 
+	ctxpkg "github.com/sandbox0-ai/sandbox0/manager/procd/pkg/context"
 	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/file"
 	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/webhook"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
@@ -14,23 +15,25 @@ import (
 
 // InitializeHandler handles sandbox initialization requests.
 type InitializeHandler struct {
-	dispatcher  *webhook.Dispatcher
-	fileManager *file.Manager
-	httpPort    int
-	logger      *zap.Logger
-	readyOnce   sync.Once
-	watchMu     sync.Mutex
-	watchPath   string
-	unsubscribe func() error
+	dispatcher     *webhook.Dispatcher
+	fileManager    *file.Manager
+	contextManager *ctxpkg.Manager
+	httpPort       int
+	logger         *zap.Logger
+	readyOnce      sync.Once
+	watchMu        sync.Mutex
+	watchPath      string
+	unsubscribe    func() error
 }
 
 // NewInitializeHandler creates a new initialize handler.
-func NewInitializeHandler(dispatcher *webhook.Dispatcher, fileManager *file.Manager, httpPort int, logger *zap.Logger) *InitializeHandler {
+func NewInitializeHandler(dispatcher *webhook.Dispatcher, fileManager *file.Manager, contextManager *ctxpkg.Manager, httpPort int, logger *zap.Logger) *InitializeHandler {
 	return &InitializeHandler{
-		dispatcher:  dispatcher,
-		fileManager: fileManager,
-		httpPort:    httpPort,
-		logger:      logger,
+		dispatcher:     dispatcher,
+		fileManager:    fileManager,
+		contextManager: contextManager,
+		httpPort:       httpPort,
+		logger:         logger,
 	}
 }
 
@@ -38,6 +41,7 @@ func NewInitializeHandler(dispatcher *webhook.Dispatcher, fileManager *file.Mana
 type InitializeRequest struct {
 	SandboxID string             `json:"sandbox_id"`
 	TeamID    string             `json:"team_id,omitempty"`
+	EnvVars   map[string]string  `json:"env_vars,omitempty"`
 	Webhook   *InitializeWebhook `json:"webhook,omitempty"`
 }
 
@@ -90,6 +94,10 @@ func (h *InitializeHandler) Initialize(w http.ResponseWriter, r *http.Request) {
 		webhookURL = req.Webhook.URL
 		webhookSecret = req.Webhook.Secret
 		webhookWatchDir = req.Webhook.WatchDir
+	}
+
+	if h.contextManager != nil {
+		h.contextManager.SetSandboxEnvVars(req.EnvVars)
 	}
 
 	h.dispatcher.SetConfig(webhookURL, webhookSecret)

--- a/manager/procd/pkg/http/handlers/initialize_test.go
+++ b/manager/procd/pkg/http/handlers/initialize_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	ctxpkg "github.com/sandbox0-ai/sandbox0/manager/procd/pkg/context"
 	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/webhook"
 	"go.uber.org/zap"
 )
@@ -17,11 +18,15 @@ func TestInitializeConfiguresSandboxIdentity(t *testing.T) {
 	t.Cleanup(func() {
 		_ = dispatcher.Shutdown(context.Background())
 	})
-	handler := NewInitializeHandler(dispatcher, nil, 8080, zap.NewNop())
+	contextManager := ctxpkg.NewManager()
+	handler := NewInitializeHandler(dispatcher, nil, contextManager, 8080, zap.NewNop())
 
 	body, err := json.Marshal(InitializeRequest{
 		SandboxID: "sandbox-1",
 		TeamID:    "team-1",
+		EnvVars: map[string]string{
+			"APP_ENV": "test",
+		},
 	})
 	if err != nil {
 		t.Fatalf("marshal request: %v", err)
@@ -47,5 +52,34 @@ func TestInitializeConfiguresSandboxIdentity(t *testing.T) {
 	}
 	if resp.Data.SandboxID != "sandbox-1" || resp.Data.TeamID != "team-1" {
 		t.Fatalf("response data = %+v", resp.Data)
+	}
+	if got := contextManager.SandboxEnvVars()["APP_ENV"]; got != "test" {
+		t.Fatalf("sandbox env APP_ENV = %q, want test", got)
+	}
+}
+
+func TestInitializeClearsSandboxEnvVars(t *testing.T) {
+	dispatcher := webhook.NewDispatcher(webhook.Options{}, zap.NewNop())
+	t.Cleanup(func() {
+		_ = dispatcher.Shutdown(context.Background())
+	})
+	contextManager := ctxpkg.NewManager()
+	contextManager.SetSandboxEnvVars(map[string]string{"APP_ENV": "test"})
+	handler := NewInitializeHandler(dispatcher, nil, contextManager, 8080, zap.NewNop())
+
+	body, err := json.Marshal(InitializeRequest{SandboxID: "sandbox-1"})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/initialize", bytes.NewReader(body))
+	recorder := httptest.NewRecorder()
+	handler.Initialize(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("Initialize() status = %d, want %d body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	if envVars := contextManager.SandboxEnvVars(); len(envVars) != 0 {
+		t.Fatalf("sandbox env vars = %#v, want empty", envVars)
 	}
 }

--- a/manager/procd/pkg/http/server.go
+++ b/manager/procd/pkg/http/server.go
@@ -120,12 +120,15 @@ func (s *Server) setupRoutes() {
 	api.HandleFunc("/contexts/{id}/ws", contextHandler.WebSocket).Methods("GET")
 
 	functionHandler := handlers.NewFunctionHandler(s.logger)
+	if s.contextManager != nil {
+		functionHandler.SetSandboxEnvVarsProvider(s.contextManager.SandboxEnvVars)
+	}
 	api.HandleFunc("/functions/execute", functionHandler.Execute).Methods("POST")
 	api.HandleFunc("/functions/stream", functionHandler.Stream).Methods("POST")
 	api.HandleFunc("/functions/ws", functionHandler.WebSocket).Methods("GET")
 
 	// Initialize handler
-	initializeHandler := handlers.NewInitializeHandler(s.webhookDispatcher, s.fileManager, s.cfg.HTTPPort, s.logger)
+	initializeHandler := handlers.NewInitializeHandler(s.webhookDispatcher, s.fileManager, s.contextManager, s.cfg.HTTPPort, s.logger)
 	api.HandleFunc("/initialize", initializeHandler.Initialize).Methods("POST")
 
 	// File handlers

--- a/manager/procd/pkg/process/cmd/cmd.go
+++ b/manager/procd/pkg/process/cmd/cmd.go
@@ -99,14 +99,11 @@ func (c *CMD) prepareExecCmd(ctx context.Context) *exec.Cmd {
 	}
 
 	// Set environment variables
-	env := os.Environ()
-	for k, v := range config.EnvVars {
-		env = append(env, fmt.Sprintf("%s=%s", k, v))
-	}
+	envLayers := []map[string]string{config.EnvVars}
 	if config.PTYSize != nil {
-		env = append(env, fmt.Sprintf("TERM=%s", resolveTerm(config)))
+		envLayers = append(envLayers, map[string]string{"TERM": resolveTerm(config)})
 	}
-	cmd.Env = env
+	cmd.Env = process.MergeEnvironment(os.Environ(), envLayers...)
 
 	return cmd
 }

--- a/manager/procd/pkg/process/env.go
+++ b/manager/procd/pkg/process/env.go
@@ -1,0 +1,98 @@
+package process
+
+import (
+	"sort"
+	"strings"
+)
+
+// CloneEnvVars returns a shallow copy of environment variables.
+func CloneEnvVars(src map[string]string) map[string]string {
+	if len(src) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(src))
+	for key, value := range src {
+		if normalized, ok := normalizeEnvKey(key); ok {
+			out[normalized] = value
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// MergeEnvVars merges environment maps with later maps overriding earlier maps.
+func MergeEnvVars(layers ...map[string]string) map[string]string {
+	out := map[string]string{}
+	for _, layer := range layers {
+		for key, value := range layer {
+			if normalized, ok := normalizeEnvKey(key); ok {
+				out[normalized] = value
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// MergeEnvironment overlays environment maps onto a base environment slice.
+// Precedence is left to right: base < layers[0] < layers[1]...
+func MergeEnvironment(base []string, layers ...map[string]string) []string {
+	values := make(map[string]string, len(base))
+	order := make([]string, 0, len(base))
+	seen := make(map[string]struct{}, len(base))
+	for _, item := range base {
+		key, value, ok := strings.Cut(item, "=")
+		if !ok {
+			continue
+		}
+		if normalized, ok := normalizeEnvKey(key); ok {
+			key = normalized
+		} else {
+			continue
+		}
+		if _, exists := seen[key]; !exists {
+			order = append(order, key)
+			seen[key] = struct{}{}
+		}
+		values[key] = value
+	}
+
+	for _, layer := range layers {
+		normalizedValues := make(map[string]string, len(layer))
+		keys := make([]string, 0, len(layer))
+		for key, value := range layer {
+			if normalized, ok := normalizeEnvKey(key); ok {
+				if _, exists := normalizedValues[normalized]; !exists {
+					keys = append(keys, normalized)
+				}
+				normalizedValues[normalized] = value
+			}
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			if _, exists := seen[key]; !exists {
+				order = append(order, key)
+				seen[key] = struct{}{}
+			}
+			values[key] = normalizedValues[key]
+		}
+	}
+
+	out := make([]string, 0, len(order))
+	for _, key := range order {
+		out = append(out, key+"="+values[key])
+	}
+	return out
+}
+
+func normalizeEnvKey(key string) (string, bool) {
+	key = strings.TrimSpace(key)
+	if key == "" || strings.Contains(key, "=") {
+		return "", false
+	}
+	return key, true
+}

--- a/manager/procd/pkg/process/env_test.go
+++ b/manager/procd/pkg/process/env_test.go
@@ -1,0 +1,59 @@
+package process
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMergeEnvVarsAppliesLaterLayers(t *testing.T) {
+	got := MergeEnvVars(
+		map[string]string{
+			"BASE":     "base",
+			"OVERRIDE": "sandbox",
+			"BAD=KEY":  "ignored",
+			" EMPTY ":  "trimmed",
+			"":         "ignored",
+		},
+		map[string]string{
+			"OVERRIDE": "context",
+			"PROCESS":  "process",
+		},
+	)
+
+	want := map[string]string{
+		"BASE":     "base",
+		"OVERRIDE": "context",
+		"EMPTY":    "trimmed",
+		"PROCESS":  "process",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("MergeEnvVars() = %#v, want %#v", got, want)
+	}
+}
+
+func TestMergeEnvironmentOverlaysBaseInOrder(t *testing.T) {
+	got := MergeEnvironment(
+		[]string{"BASE=base", "OVERRIDE=base", "MALFORMED"},
+		map[string]string{
+			"OVERRIDE": "sandbox",
+			"SANDBOX":  "sandbox",
+		},
+		map[string]string{
+			"OVERRIDE": "context",
+			"PROCESS":  "process",
+			" BAD ":    "trimmed",
+			"BAD=KEY":  "ignored",
+		},
+	)
+
+	want := []string{
+		"BASE=base",
+		"OVERRIDE=context",
+		"SANDBOX=sandbox",
+		"BAD=trimmed",
+		"PROCESS=process",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("MergeEnvironment() = %#v, want %#v", got, want)
+	}
+}

--- a/manager/procd/pkg/process/repl/repl.go
+++ b/manager/procd/pkg/process/repl/repl.go
@@ -96,8 +96,8 @@ func (r *REPL) Start() error {
 }
 
 // buildEnvVars builds the environment variables for the REPL.
-func (r *REPL) buildEnvVars(processConfig process.ProcessConfig) []string {
-	var envVars []string
+func (r *REPL) buildEnvVars(processConfig process.ProcessConfig) map[string]string {
+	envVars := map[string]string{}
 
 	// Get TERM value
 	term := processConfig.Term
@@ -119,10 +119,13 @@ func (r *REPL) buildEnvVars(processConfig process.ProcessConfig) []string {
 			value = env.Value
 		}
 		if value != "" {
-			envVars = append(envVars, fmt.Sprintf("%s=%s", env.Name, value))
+			envVars[env.Name] = value
 		}
 	}
 
+	if len(envVars) == 0 {
+		return nil
+	}
 	return envVars
 }
 

--- a/manager/procd/pkg/process/repl/repl_helpers.go
+++ b/manager/procd/pkg/process/repl/repl_helpers.go
@@ -16,7 +16,7 @@ type execCandidate struct {
 }
 
 // startWithCandidates tries to start a process with the given candidates in order.
-func startWithCandidates(base *process.BaseProcess, runner *process.PTYRunner, config process.ProcessConfig, candidates []execCandidate, extraEnv []string) error {
+func startWithCandidates(base *process.BaseProcess, runner *process.PTYRunner, config process.ProcessConfig, candidates []execCandidate, extraEnv map[string]string) error {
 	if len(candidates) == 0 {
 		if base != nil {
 			base.SetState(process.ProcessStateCrashed)
@@ -49,12 +49,7 @@ func startWithCandidates(base *process.BaseProcess, runner *process.PTYRunner, c
 		// PTY automatically creates a new session and handles terminal control.
 		// Setting Setpgid would conflict with PTY's session management.
 
-		env := os.Environ()
-		for k, v := range config.EnvVars {
-			env = append(env, fmt.Sprintf("%s=%s", k, v))
-		}
-		env = append(env, extraEnv...)
-		cmd.Env = env
+		cmd.Env = process.MergeEnvironment(os.Environ(), config.EnvVars, extraEnv)
 
 		err = runner.Start(cmd, config.PTYSize)
 		if err == nil {


### PR DESCRIPTION
## Summary
- pass claim-time sandbox env_vars through manager procd initialization
- centralize env merging with precedence: container/template < sandbox < context/process/service/function
- document env precedence and add focused tests for context, function, initialize, and manager service helpers

## Tests
- go test ./manager/procd/pkg/process ./manager/procd/pkg/context ./manager/procd/pkg/http/handlers ./manager/pkg/service