### PR TITLE
Add active RWO snapshot checkpoints

### DIFF
--- a/ctld/cmd/ctld/main.go
+++ b/ctld/cmd/ctld/main.go
@@ -316,6 +316,39 @@ func (c combinedController) AbortVolumePortalHandoff(r *http.Request, req ctldap
 	return resp, http.StatusOK
 }
 
+func (c combinedController) PrepareVolumeSnapshotCheckpoint(r *http.Request, req ctldapi.PrepareVolumeSnapshotCheckpointRequest) (ctldapi.PrepareVolumeSnapshotCheckpointResponse, int) {
+	if c.Portal == nil {
+		return ctldapi.PrepareVolumeSnapshotCheckpointResponse{Error: "ctld volume snapshot checkpoint not implemented"}, http.StatusNotImplemented
+	}
+	resp, err := c.Portal.PrepareSnapshotCheckpoint(r.Context(), req)
+	if err != nil {
+		return ctldapi.PrepareVolumeSnapshotCheckpointResponse{Error: err.Error()}, volumePortalErrorStatus(err)
+	}
+	return resp, http.StatusOK
+}
+
+func (c combinedController) CompleteVolumeSnapshotCheckpoint(r *http.Request, req ctldapi.CompleteVolumeSnapshotCheckpointRequest) (ctldapi.CompleteVolumeSnapshotCheckpointResponse, int) {
+	if c.Portal == nil {
+		return ctldapi.CompleteVolumeSnapshotCheckpointResponse{Error: "ctld volume snapshot checkpoint not implemented"}, http.StatusNotImplemented
+	}
+	resp, err := c.Portal.CompleteSnapshotCheckpoint(r.Context(), req)
+	if err != nil {
+		return ctldapi.CompleteVolumeSnapshotCheckpointResponse{Error: err.Error()}, volumePortalErrorStatus(err)
+	}
+	return resp, http.StatusOK
+}
+
+func (c combinedController) AbortVolumeSnapshotCheckpoint(r *http.Request, req ctldapi.AbortVolumeSnapshotCheckpointRequest) (ctldapi.AbortVolumeSnapshotCheckpointResponse, int) {
+	if c.Portal == nil {
+		return ctldapi.AbortVolumeSnapshotCheckpointResponse{Error: "ctld volume snapshot checkpoint not implemented"}, http.StatusNotImplemented
+	}
+	resp, err := c.Portal.AbortSnapshotCheckpoint(r.Context(), req)
+	if err != nil {
+		return ctldapi.AbortVolumeSnapshotCheckpointResponse{Error: err.Error()}, volumePortalErrorStatus(err)
+	}
+	return resp, http.StatusOK
+}
+
 func volumePortalErrorStatus(err error) int {
 	if err == nil {
 		return http.StatusOK
@@ -356,5 +389,8 @@ type volumePortalHandler interface {
 	PrepareHandoff(ctx context.Context, req ctldapi.PrepareVolumePortalHandoffRequest) (ctldapi.PrepareVolumePortalHandoffResponse, error)
 	CompleteHandoff(ctx context.Context, req ctldapi.CompleteVolumePortalHandoffRequest) (ctldapi.CompleteVolumePortalHandoffResponse, error)
 	AbortHandoff(ctx context.Context, req ctldapi.AbortVolumePortalHandoffRequest) (ctldapi.AbortVolumePortalHandoffResponse, error)
+	PrepareSnapshotCheckpoint(ctx context.Context, req ctldapi.PrepareVolumeSnapshotCheckpointRequest) (ctldapi.PrepareVolumeSnapshotCheckpointResponse, error)
+	CompleteSnapshotCheckpoint(ctx context.Context, req ctldapi.CompleteVolumeSnapshotCheckpointRequest) (ctldapi.CompleteVolumeSnapshotCheckpointResponse, error)
+	AbortSnapshotCheckpoint(ctx context.Context, req ctldapi.AbortVolumeSnapshotCheckpointRequest) (ctldapi.AbortVolumeSnapshotCheckpointResponse, error)
 	MountedVolumeHandler() http.Handler
 }

--- a/ctld/cmd/ctld/main_test.go
+++ b/ctld/cmd/ctld/main_test.go
@@ -196,6 +196,18 @@ func (f fakeVolumePortalHandler) AbortHandoff(_ context.Context, _ ctldapi.Abort
 	return ctldapi.AbortVolumePortalHandoffResponse{Aborted: true}, nil
 }
 
+func (f fakeVolumePortalHandler) PrepareSnapshotCheckpoint(_ context.Context, _ ctldapi.PrepareVolumeSnapshotCheckpointRequest) (ctldapi.PrepareVolumeSnapshotCheckpointResponse, error) {
+	return ctldapi.PrepareVolumeSnapshotCheckpointResponse{Prepared: true}, nil
+}
+
+func (f fakeVolumePortalHandler) CompleteSnapshotCheckpoint(_ context.Context, _ ctldapi.CompleteVolumeSnapshotCheckpointRequest) (ctldapi.CompleteVolumeSnapshotCheckpointResponse, error) {
+	return ctldapi.CompleteVolumeSnapshotCheckpointResponse{Completed: true}, nil
+}
+
+func (f fakeVolumePortalHandler) AbortSnapshotCheckpoint(_ context.Context, _ ctldapi.AbortVolumeSnapshotCheckpointRequest) (ctldapi.AbortVolumeSnapshotCheckpointResponse, error) {
+	return ctldapi.AbortVolumeSnapshotCheckpointResponse{Aborted: true}, nil
+}
+
 func (f fakeVolumePortalHandler) MountedVolumeHandler() http.Handler {
 	return f.mountedHandler
 }

--- a/ctld/internal/ctld/portal/manager.go
+++ b/ctld/internal/ctld/portal/manager.go
@@ -680,6 +680,45 @@ func (m *Manager) AbortHandoff(ctx context.Context, req ctldapi.AbortVolumePorta
 	return ctldapi.AbortVolumePortalHandoffResponse{Aborted: true}, nil
 }
 
+func (m *Manager) PrepareSnapshotCheckpoint(ctx context.Context, req ctldapi.PrepareVolumeSnapshotCheckpointRequest) (ctldapi.PrepareVolumeSnapshotCheckpointResponse, error) {
+	volumeID := strings.TrimSpace(req.SandboxVolumeID)
+	if volumeID == "" {
+		return ctldapi.PrepareVolumeSnapshotCheckpointResponse{}, fmt.Errorf("sandboxvolume_id is required")
+	}
+	m.mu.Lock()
+	bound := m.boundVolumes[volumeID]
+	m.mu.Unlock()
+	if bound == nil || bound.volCtx == nil || bound.volCtx.S0FS == nil {
+		return ctldapi.PrepareVolumeSnapshotCheckpointResponse{}, fmt.Errorf("volume %s is not owned by this ctld", volumeID)
+	}
+	if err := m.volumes.prepareSnapshotCheckpoint(ctx, volumeID); err != nil {
+		return ctldapi.PrepareVolumeSnapshotCheckpointResponse{}, err
+	}
+	if _, err := bound.volCtx.S0FS.SyncMaterialize(ctx); err != nil {
+		m.volumes.completeSnapshotCheckpoint(volumeID)
+		return ctldapi.PrepareVolumeSnapshotCheckpointResponse{}, err
+	}
+	return ctldapi.PrepareVolumeSnapshotCheckpointResponse{Prepared: true}, nil
+}
+
+func (m *Manager) CompleteSnapshotCheckpoint(_ context.Context, req ctldapi.CompleteVolumeSnapshotCheckpointRequest) (ctldapi.CompleteVolumeSnapshotCheckpointResponse, error) {
+	volumeID := strings.TrimSpace(req.SandboxVolumeID)
+	if volumeID == "" {
+		return ctldapi.CompleteVolumeSnapshotCheckpointResponse{}, fmt.Errorf("sandboxvolume_id is required")
+	}
+	m.volumes.completeSnapshotCheckpoint(volumeID)
+	return ctldapi.CompleteVolumeSnapshotCheckpointResponse{Completed: true}, nil
+}
+
+func (m *Manager) AbortSnapshotCheckpoint(_ context.Context, req ctldapi.AbortVolumeSnapshotCheckpointRequest) (ctldapi.AbortVolumeSnapshotCheckpointResponse, error) {
+	volumeID := strings.TrimSpace(req.SandboxVolumeID)
+	if volumeID == "" {
+		return ctldapi.AbortVolumeSnapshotCheckpointResponse{}, fmt.Errorf("sandboxvolume_id is required")
+	}
+	m.volumes.completeSnapshotCheckpoint(volumeID)
+	return ctldapi.AbortVolumeSnapshotCheckpointResponse{Aborted: true}, nil
+}
+
 func (m *Manager) cleanupIdleOwnerOnlyVolumes(ctx context.Context) {
 	if m == nil || m.ownerOnlyIdleTTL <= 0 {
 		return

--- a/ctld/internal/ctld/portal/session.go
+++ b/ctld/internal/ctld/portal/session.go
@@ -150,6 +150,14 @@ func (m *localVolumeManager) abortHandoff(volumeID string) {
 	}
 }
 
+func (m *localVolumeManager) prepareSnapshotCheckpoint(ctx context.Context, volumeID string) error {
+	return m.prepareHandoff(ctx, volumeID)
+}
+
+func (m *localVolumeManager) completeSnapshotCheckpoint(volumeID string) {
+	m.abortHandoff(volumeID)
+}
+
 func (m *localVolumeManager) touch(volumeID string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -323,6 +331,13 @@ func (s *localSession) fix(volumeID *string) {
 	}
 }
 
+func (s *localSession) acquireMutating(ctx context.Context, volumeID string) (func(), error) {
+	if s == nil || s.mgr == nil || volumeID == "" {
+		return func() {}, nil
+	}
+	return s.mgr.acquire(ctx, volumeID)
+}
+
 func (s *localSession) Lookup(ctx context.Context, req *pb.LookupRequest) (*pb.NodeResponse, error) {
 	s.fix(&req.VolumeId)
 	return s.fs.Lookup(s.ctx(ctx), req)
@@ -333,6 +348,11 @@ func (s *localSession) GetAttr(ctx context.Context, req *pb.GetAttrRequest) (*pb
 }
 func (s *localSession) SetAttr(ctx context.Context, req *pb.SetAttrRequest) (*pb.SetAttrResponse, error) {
 	s.fix(&req.VolumeId)
+	release, err := s.acquireMutating(ctx, req.VolumeId)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
 	resp, err := s.fs.SetAttr(s.ctx(ctx), req)
 	if err != nil {
 		return nil, err
@@ -351,30 +371,65 @@ func (s *localSession) SetAttr(ctx context.Context, req *pb.SetAttrRequest) (*pb
 }
 func (s *localSession) Mkdir(ctx context.Context, req *pb.MkdirRequest) (*pb.NodeResponse, error) {
 	s.fix(&req.VolumeId)
+	release, err := s.acquireMutating(ctx, req.VolumeId)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
 	return s.fs.Mkdir(s.ctx(ctx), req)
 }
 func (s *localSession) Create(ctx context.Context, req *pb.CreateRequest) (*pb.NodeResponse, error) {
 	s.fix(&req.VolumeId)
+	release, err := s.acquireMutating(ctx, req.VolumeId)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
 	return s.fs.Create(s.ctx(ctx), req)
 }
 func (s *localSession) Unlink(ctx context.Context, req *pb.UnlinkRequest) (*pb.Empty, error) {
 	s.fix(&req.VolumeId)
+	release, err := s.acquireMutating(ctx, req.VolumeId)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
 	return s.fs.Unlink(s.ctx(ctx), req)
 }
 func (s *localSession) Rmdir(ctx context.Context, req *pb.RmdirRequest) (*pb.Empty, error) {
 	s.fix(&req.VolumeId)
+	release, err := s.acquireMutating(ctx, req.VolumeId)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
 	return s.fs.Rmdir(s.ctx(ctx), req)
 }
 func (s *localSession) Rename(ctx context.Context, req *pb.RenameRequest) (*pb.Empty, error) {
 	s.fix(&req.VolumeId)
+	release, err := s.acquireMutating(ctx, req.VolumeId)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
 	return s.fs.Rename(s.ctx(ctx), req)
 }
 func (s *localSession) Link(ctx context.Context, req *pb.LinkRequest) (*pb.NodeResponse, error) {
 	s.fix(&req.VolumeId)
+	release, err := s.acquireMutating(ctx, req.VolumeId)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
 	return s.fs.Link(s.ctx(ctx), req)
 }
 func (s *localSession) Symlink(ctx context.Context, req *pb.SymlinkRequest) (*pb.NodeResponse, error) {
 	s.fix(&req.VolumeId)
+	release, err := s.acquireMutating(ctx, req.VolumeId)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
 	return s.fs.Symlink(s.ctx(ctx), req)
 }
 func (s *localSession) Readlink(ctx context.Context, req *pb.ReadlinkRequest) (*pb.ReadlinkResponse, error) {
@@ -390,6 +445,15 @@ func (s *localSession) Open(ctx context.Context, req *pb.OpenRequest) (*pb.OpenR
 		return nil, ctx.Err()
 	}
 	s.fix(&req.VolumeId)
+	var release func()
+	if req.Flags&syscall.O_ACCMODE != syscall.O_RDONLY {
+		var err error
+		release, err = s.acquireMutating(ctx, req.VolumeId)
+		if err != nil {
+			return nil, err
+		}
+		defer release()
+	}
 	resp, err := s.fs.Open(s.ctx(ctx), req)
 	if err != nil {
 		return nil, err
@@ -443,6 +507,11 @@ func (s *localSession) ReadInto(ctx context.Context, req *pb.ReadRequest, dest [
 }
 func (s *localSession) Write(ctx context.Context, req *pb.WriteRequest) (*pb.WriteResponse, error) {
 	s.fix(&req.VolumeId)
+	release, err := s.acquireMutating(ctx, req.VolumeId)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
 	resp, err := s.fs.Write(s.ctx(ctx), req)
 	if err != nil {
 		return nil, err
@@ -457,6 +526,11 @@ func (s *localSession) Write(ctx context.Context, req *pb.WriteRequest) (*pb.Wri
 }
 func (s *localSession) Release(ctx context.Context, req *pb.ReleaseRequest) (*pb.Empty, error) {
 	s.fix(&req.VolumeId)
+	release, err := s.acquireMutating(ctx, req.VolumeId)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
 	if s.takeReadOnlyHandle(req.VolumeId, req.HandleId) {
 		if volCtx, err := s.localS0FSVolume(req.VolumeId); err == nil && volCtx != nil {
 			if inode, remaining, unlinked, ok := volCtx.ReleaseFileHandle(req.HandleId); ok && remaining == 0 && unlinked {
@@ -470,14 +544,29 @@ func (s *localSession) Release(ctx context.Context, req *pb.ReleaseRequest) (*pb
 }
 func (s *localSession) Flush(ctx context.Context, req *pb.FlushRequest) (*pb.Empty, error) {
 	s.fix(&req.VolumeId)
+	release, err := s.acquireMutating(ctx, req.VolumeId)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
 	return s.fs.Flush(s.ctx(ctx), req)
 }
 func (s *localSession) Fsync(ctx context.Context, req *pb.FsyncRequest) (*pb.Empty, error) {
 	s.fix(&req.VolumeId)
+	release, err := s.acquireMutating(ctx, req.VolumeId)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
 	return s.fs.Fsync(s.ctx(ctx), req)
 }
 func (s *localSession) Fallocate(ctx context.Context, req *pb.FallocateRequest) (*pb.Empty, error) {
 	s.fix(&req.VolumeId)
+	release, err := s.acquireMutating(ctx, req.VolumeId)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
 	resp, err := s.fs.Fallocate(s.ctx(ctx), req)
 	if err == nil {
 		if volCtx, volErr := s.localS0FSVolume(req.VolumeId); volErr == nil && volCtx != nil {
@@ -488,6 +577,11 @@ func (s *localSession) Fallocate(ctx context.Context, req *pb.FallocateRequest) 
 }
 func (s *localSession) CopyFileRange(ctx context.Context, req *pb.CopyFileRangeRequest) (*pb.CopyFileRangeResponse, error) {
 	s.fix(&req.VolumeId)
+	release, err := s.acquireMutating(ctx, req.VolumeId)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
 	resp, err := s.fs.CopyFileRange(s.ctx(ctx), req)
 	if err == nil {
 		if volCtx, volErr := s.localS0FSVolume(req.VolumeId); volErr == nil && volCtx != nil {
@@ -518,6 +612,11 @@ func (s *localSession) GetXattr(ctx context.Context, req *pb.GetXattrRequest) (*
 }
 func (s *localSession) SetXattr(ctx context.Context, req *pb.SetXattrRequest) (*pb.Empty, error) {
 	s.fix(&req.VolumeId)
+	release, err := s.acquireMutating(ctx, req.VolumeId)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
 	return s.fs.SetXattr(s.ctx(ctx), req)
 }
 func (s *localSession) ListXattr(ctx context.Context, req *pb.ListXattrRequest) (*pb.ListXattrResponse, error) {
@@ -526,10 +625,20 @@ func (s *localSession) ListXattr(ctx context.Context, req *pb.ListXattrRequest) 
 }
 func (s *localSession) RemoveXattr(ctx context.Context, req *pb.RemoveXattrRequest) (*pb.Empty, error) {
 	s.fix(&req.VolumeId)
+	release, err := s.acquireMutating(ctx, req.VolumeId)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
 	return s.fs.RemoveXattr(s.ctx(ctx), req)
 }
 func (s *localSession) Mknod(ctx context.Context, req *pb.MknodRequest) (*pb.NodeResponse, error) {
 	s.fix(&req.VolumeId)
+	release, err := s.acquireMutating(ctx, req.VolumeId)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
 	return s.fs.Mknod(s.ctx(ctx), req)
 }
 func (s *localSession) GetLk(ctx context.Context, req *pb.GetLkRequest) (*pb.GetLkResponse, error) {
@@ -538,14 +647,29 @@ func (s *localSession) GetLk(ctx context.Context, req *pb.GetLkRequest) (*pb.Get
 }
 func (s *localSession) SetLk(ctx context.Context, req *pb.SetLkRequest) (*pb.Empty, error) {
 	s.fix(&req.VolumeId)
+	release, err := s.acquireMutating(ctx, req.VolumeId)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
 	return s.fs.SetLk(s.ctx(ctx), req)
 }
 func (s *localSession) SetLkw(ctx context.Context, req *pb.SetLkRequest) (*pb.Empty, error) {
 	s.fix(&req.VolumeId)
+	release, err := s.acquireMutating(ctx, req.VolumeId)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
 	return s.fs.SetLkw(s.ctx(ctx), req)
 }
 func (s *localSession) Flock(ctx context.Context, req *pb.FlockRequest) (*pb.Empty, error) {
 	s.fix(&req.VolumeId)
+	release, err := s.acquireMutating(ctx, req.VolumeId)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
 	return s.fs.Flock(s.ctx(ctx), req)
 }
 

--- a/ctld/internal/ctld/portal/session_test.go
+++ b/ctld/internal/ctld/portal/session_test.go
@@ -227,6 +227,62 @@ func TestLocalVolumeManagerPrepareHandoffDrainsInflightAndBlocksNewAcquires(t *t
 	}
 }
 
+func TestLocalSessionMutationsWaitForSnapshotCheckpoint(t *testing.T) {
+	engine, err := s0fs.Open(context.Background(), s0fs.Config{
+		VolumeID: "vol-1",
+		WALPath:  filepath.Join(t.TempDir(), "volume.wal"),
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer engine.Close()
+
+	mgr := newLocalVolumeManager()
+	mgr.add(&volume.VolumeContext{
+		VolumeID:  "vol-1",
+		TeamID:    "team-a",
+		Backend:   volume.BackendS0FS,
+		S0FS:      engine,
+		Access:    volume.AccessModeRWO,
+		MountedAt: time.Now().UTC(),
+		RootInode: 1,
+		RootPath:  "/",
+	})
+	session := newLocalSession("vol-1", mgr, nil)
+
+	if err := mgr.prepareSnapshotCheckpoint(context.Background(), "vol-1"); err != nil {
+		t.Fatalf("prepareSnapshotCheckpoint() error = %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := session.Create(context.Background(), &pb.CreateRequest{
+			VolumeId: "ignored-by-local-session",
+			Parent:   s0fs.RootInode,
+			Name:     "blocked.txt",
+			Mode:     0o644,
+		})
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		t.Fatalf("Create() returned during checkpoint: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	mgr.completeSnapshotCheckpoint("vol-1")
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Create() error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Create() did not resume after checkpoint completed")
+	}
+}
+
 func TestLocalSessionReadCacheTracksSmallWrites(t *testing.T) {
 	engine, err := s0fs.Open(context.Background(), s0fs.Config{
 		VolumeID: "vol-1",

--- a/ctld/internal/ctld/server/server.go
+++ b/ctld/internal/ctld/server/server.go
@@ -26,6 +26,9 @@ type VolumePortalController interface {
 	PrepareVolumePortalHandoff(r *http.Request, req ctldapi.PrepareVolumePortalHandoffRequest) (ctldapi.PrepareVolumePortalHandoffResponse, int)
 	CompleteVolumePortalHandoff(r *http.Request, req ctldapi.CompleteVolumePortalHandoffRequest) (ctldapi.CompleteVolumePortalHandoffResponse, int)
 	AbortVolumePortalHandoff(r *http.Request, req ctldapi.AbortVolumePortalHandoffRequest) (ctldapi.AbortVolumePortalHandoffResponse, int)
+	PrepareVolumeSnapshotCheckpoint(r *http.Request, req ctldapi.PrepareVolumeSnapshotCheckpointRequest) (ctldapi.PrepareVolumeSnapshotCheckpointResponse, int)
+	CompleteVolumeSnapshotCheckpoint(r *http.Request, req ctldapi.CompleteVolumeSnapshotCheckpointRequest) (ctldapi.CompleteVolumeSnapshotCheckpointResponse, int)
+	AbortVolumeSnapshotCheckpoint(r *http.Request, req ctldapi.AbortVolumeSnapshotCheckpointRequest) (ctldapi.AbortVolumeSnapshotCheckpointResponse, int)
 }
 
 type MountedVolumeController interface {
@@ -242,6 +245,72 @@ func NewMux(controller Controller) http.Handler {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		resp, status := volumeController.AbortVolumePortalHandoff(r, req)
+		w.WriteHeader(status)
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+	mux.HandleFunc("/api/v1/volume-portals/snapshot-checkpoints/prepare", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		volumeController, ok := controller.(VolumePortalController)
+		if !ok {
+			w.WriteHeader(http.StatusNotImplemented)
+			_ = json.NewEncoder(w).Encode(ctldapi.PrepareVolumeSnapshotCheckpointResponse{Error: "ctld volume snapshot checkpoint not implemented"})
+			return
+		}
+		var req ctldapi.PrepareVolumeSnapshotCheckpointRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(ctldapi.PrepareVolumeSnapshotCheckpointResponse{Error: err.Error()})
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		resp, status := volumeController.PrepareVolumeSnapshotCheckpoint(r, req)
+		w.WriteHeader(status)
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+	mux.HandleFunc("/api/v1/volume-portals/snapshot-checkpoints/complete", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		volumeController, ok := controller.(VolumePortalController)
+		if !ok {
+			w.WriteHeader(http.StatusNotImplemented)
+			_ = json.NewEncoder(w).Encode(ctldapi.CompleteVolumeSnapshotCheckpointResponse{Error: "ctld volume snapshot checkpoint not implemented"})
+			return
+		}
+		var req ctldapi.CompleteVolumeSnapshotCheckpointRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(ctldapi.CompleteVolumeSnapshotCheckpointResponse{Error: err.Error()})
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		resp, status := volumeController.CompleteVolumeSnapshotCheckpoint(r, req)
+		w.WriteHeader(status)
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+	mux.HandleFunc("/api/v1/volume-portals/snapshot-checkpoints/abort", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		volumeController, ok := controller.(VolumePortalController)
+		if !ok {
+			w.WriteHeader(http.StatusNotImplemented)
+			_ = json.NewEncoder(w).Encode(ctldapi.AbortVolumeSnapshotCheckpointResponse{Error: "ctld volume snapshot checkpoint not implemented"})
+			return
+		}
+		var req ctldapi.AbortVolumeSnapshotCheckpointRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(ctldapi.AbortVolumeSnapshotCheckpointResponse{Error: err.Error()})
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		resp, status := volumeController.AbortVolumeSnapshotCheckpoint(r, req)
 		w.WriteHeader(status)
 		_ = json.NewEncoder(w).Encode(resp)
 	})

--- a/docs/volume/snapshots/page.mdx
+++ b/docs/volume/snapshots/page.mdx
@@ -28,6 +28,10 @@ flowchart TB
 
 ## Create a Snapshot
 
+<Callout variant="info">
+For active mounted Volumes, snapshot creation is mode-aware. `RWO` mounts are checkpointed before the snapshot is published, `ROX` mounts do not need a writable flush, and active writable `RWX` mounts currently return `409 Conflict`. Unmount or quiesce active `RWX` writers before creating a snapshot.
+</Callout>
+
 <Tabs
   tabs={[
     {
@@ -101,6 +105,53 @@ s0 volume snapshot create vol_abc123xyz \
 
 # For automation scripts, prefer JSON output:
 s0 volume snapshot create vol_abc123xyz --name "v1.2-prod" -o json`
+    }
+  ]}
+/>
+
+## Create a Volume from a Snapshot
+
+Creating a new Volume with `snapshot_id` gives each workflow an isolated writable Volume initialized from immutable snapshot state.
+
+<Tabs
+  tabs={[
+    {
+      label: "Go",
+      language: "go",
+      code: `taskVolume, err := client.CreateVolume(ctx, apispec.CreateSandboxVolumeRequest{
+    SnapshotID: apispec.NewOptString(snapshot.ID),
+    AccessMode: apispec.NewOptVolumeAccessMode(apispec.VolumeAccessModeRWO),
+})
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Printf("Task Volume ID: %s\\n", taskVolume.ID)`
+    },
+    {
+      label: "Python",
+      language: "python",
+      code: `from sandbox0.apispec.models.create_sandbox_volume_request import CreateSandboxVolumeRequest
+from sandbox0.apispec.models.volume_access_mode import VolumeAccessMode
+
+task_volume = client.volumes.create(CreateSandboxVolumeRequest(
+    snapshot_id=snapshot.id,
+    access_mode=VolumeAccessMode.RWO,
+))
+print(f"Task Volume ID: {task_volume.id}")`
+    },
+    {
+      label: "TypeScript",
+      language: "typescript",
+      code: `const taskVolume = await client.volumes.create({
+    snapshotId: snapshot.id,
+    accessMode: models.VolumeAccessMode.Rwo,
+});
+console.log("Task Volume ID:", taskVolume.id);`
+    },
+    {
+      label: "CLI",
+      language: "bash",
+      code: `s0 volume create --snapshot-id snap_def456uvw --access-mode RWO`
     }
   ]}
 />

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -2726,6 +2726,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SuccessSnapshotResponse"
+        "409":
+          description: Volume is busy or active RWX snapshot is unsupported
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
     get:
       tags: [snapshots]
       summary: List snapshots

--- a/pkg/ctldapi/client.go
+++ b/pkg/ctldapi/client.go
@@ -27,6 +27,9 @@ const (
 	pathVolumePortalHandoffPrepare  = "/api/v1/volume-portals/handoffs/prepare"
 	pathVolumePortalHandoffComplete = "/api/v1/volume-portals/handoffs/complete"
 	pathVolumePortalHandoffAbort    = "/api/v1/volume-portals/handoffs/abort"
+	pathVolumeSnapshotPrepare       = "/api/v1/volume-portals/snapshot-checkpoints/prepare"
+	pathVolumeSnapshotComplete      = "/api/v1/volume-portals/snapshot-checkpoints/complete"
+	pathVolumeSnapshotAbort         = "/api/v1/volume-portals/snapshot-checkpoints/abort"
 )
 
 var defaultHTTPClient = &http.Client{Timeout: DefaultRequestTimeout}
@@ -116,6 +119,18 @@ func (c *Client) AbortVolumePortalHandoff(ctx context.Context, ctldAddress strin
 	return PostJSON[AbortVolumePortalHandoffResponse](ctx, c.httpClientOrDefault(), ctldAddress, pathVolumePortalHandoffAbort, req)
 }
 
+func (c *Client) PrepareVolumeSnapshotCheckpoint(ctx context.Context, ctldAddress string, req PrepareVolumeSnapshotCheckpointRequest) (*PrepareVolumeSnapshotCheckpointResponse, error) {
+	return PostJSON[PrepareVolumeSnapshotCheckpointResponse](ctx, c.httpClientOrDefault(), ctldAddress, pathVolumeSnapshotPrepare, req)
+}
+
+func (c *Client) CompleteVolumeSnapshotCheckpoint(ctx context.Context, ctldAddress string, req CompleteVolumeSnapshotCheckpointRequest) (*CompleteVolumeSnapshotCheckpointResponse, error) {
+	return PostJSON[CompleteVolumeSnapshotCheckpointResponse](ctx, c.httpClientOrDefault(), ctldAddress, pathVolumeSnapshotComplete, req)
+}
+
+func (c *Client) AbortVolumeSnapshotCheckpoint(ctx context.Context, ctldAddress string, req AbortVolumeSnapshotCheckpointRequest) (*AbortVolumeSnapshotCheckpointResponse, error) {
+	return PostJSON[AbortVolumeSnapshotCheckpointResponse](ctx, c.httpClientOrDefault(), ctldAddress, pathVolumeSnapshotAbort, req)
+}
+
 func (c *Client) httpClientOrDefault() *http.Client {
 	if c != nil && c.httpClient != nil {
 		return c.httpClient
@@ -184,6 +199,12 @@ func responseError(resp any) string {
 	case *CompleteVolumePortalHandoffResponse:
 		return strings.TrimSpace(typed.Error)
 	case *AbortVolumePortalHandoffResponse:
+		return strings.TrimSpace(typed.Error)
+	case *PrepareVolumeSnapshotCheckpointResponse:
+		return strings.TrimSpace(typed.Error)
+	case *CompleteVolumeSnapshotCheckpointResponse:
+		return strings.TrimSpace(typed.Error)
+	case *AbortVolumeSnapshotCheckpointResponse:
 		return strings.TrimSpace(typed.Error)
 	case *BindVolumePortalResponse:
 		return strings.TrimSpace(typed.Error)

--- a/pkg/ctldapi/types.go
+++ b/pkg/ctldapi/types.go
@@ -116,6 +116,33 @@ type AbortVolumePortalHandoffResponse struct {
 	Error   string `json:"error,omitempty"`
 }
 
+type PrepareVolumeSnapshotCheckpointRequest struct {
+	SandboxVolumeID string `json:"sandboxvolume_id"`
+}
+
+type PrepareVolumeSnapshotCheckpointResponse struct {
+	Prepared bool   `json:"prepared"`
+	Error    string `json:"error,omitempty"`
+}
+
+type CompleteVolumeSnapshotCheckpointRequest struct {
+	SandboxVolumeID string `json:"sandboxvolume_id"`
+}
+
+type CompleteVolumeSnapshotCheckpointResponse struct {
+	Completed bool   `json:"completed"`
+	Error     string `json:"error,omitempty"`
+}
+
+type AbortVolumeSnapshotCheckpointRequest struct {
+	SandboxVolumeID string `json:"sandboxvolume_id"`
+}
+
+type AbortVolumeSnapshotCheckpointResponse struct {
+	Aborted bool   `json:"aborted"`
+	Error   string `json:"error,omitempty"`
+}
+
 type AttachVolumeOwnerRequest struct {
 	TeamID          string `json:"team_id"`
 	SandboxVolumeID string `json:"sandboxvolume_id"`

--- a/storage-proxy/pkg/http/ctld_owner_test.go
+++ b/storage-proxy/pkg/http/ctld_owner_test.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net"
@@ -14,6 +15,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/snapshot"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volume"
 	"github.com/sirupsen/logrus"
 )
@@ -115,6 +117,110 @@ func TestForkVolumeReleasesCtldOwnerBeforeFork(t *testing.T) {
 	}
 	if snapshotMgr.lastFork == nil || snapshotMgr.lastFork.SourceVolumeID != "vol-1" {
 		t.Fatalf("ForkVolume request = %+v, want source vol-1", snapshotMgr.lastFork)
+	}
+}
+
+func TestCreateSnapshotPreparesCtldCheckpoint(t *testing.T) {
+	checkpointCalls := map[string]int{}
+	ctldServer, ownerPort := newSnapshotCheckpointTestServer(t, checkpointCalls)
+	defer ctldServer.Close()
+
+	repo := newFakeHTTPRepo()
+	repo.volumes["vol-1"] = &db.SandboxVolume{ID: "vol-1", TeamID: "team-1", UserID: "user-1"}
+	repo.activeMounts["vol-1"] = []*db.VolumeMount{ctldOwnerMount(t, "vol-1", "cluster-a", "sandbox0-system/ctld-a", ownerPort)}
+	snapshotMgr := &fakeHTTPSnapshotManager{}
+	server := &Server{
+		logger:        logrus.New(),
+		repo:          repo,
+		snapshotMgr:   snapshotMgr,
+		podResolver:   &fakeVolumeFilePodResolver{urls: map[string]string{"sandbox0-system/ctld-a": ctldServer.URL}},
+		selfClusterID: "cluster-a",
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/sandboxvolumes/vol-1/snapshots", bytes.NewReader([]byte(`{"name":"checkpoint"}`)))
+	req.SetPathValue("volume_id", "vol-1")
+	req = req.WithContext(internalauth.WithClaims(req.Context(), &internalauth.Claims{TeamID: "team-1", UserID: "user-1"}))
+	recorder := httptest.NewRecorder()
+
+	server.createSnapshot(recorder, req)
+
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusCreated, recorder.Body.String())
+	}
+	if checkpointCalls["prepare"] != 1 || checkpointCalls["complete"] != 1 || checkpointCalls["abort"] != 0 {
+		t.Fatalf("checkpoint calls = %v, want prepare=1 complete=1 abort=0", checkpointCalls)
+	}
+	if snapshotMgr.lastCreate == nil || !snapshotMgr.lastCreate.ActiveCheckpointPrepared {
+		t.Fatalf("CreateSnapshot request = %+v, want active checkpoint prepared", snapshotMgr.lastCreate)
+	}
+}
+
+func TestCreateSnapshotAbortsCtldCheckpointOnSnapshotError(t *testing.T) {
+	checkpointCalls := map[string]int{}
+	ctldServer, ownerPort := newSnapshotCheckpointTestServer(t, checkpointCalls)
+	defer ctldServer.Close()
+
+	repo := newFakeHTTPRepo()
+	repo.volumes["vol-1"] = &db.SandboxVolume{ID: "vol-1", TeamID: "team-1", UserID: "user-1"}
+	repo.activeMounts["vol-1"] = []*db.VolumeMount{ctldOwnerMount(t, "vol-1", "cluster-a", "sandbox0-system/ctld-a", ownerPort)}
+	server := &Server{
+		logger:        logrus.New(),
+		repo:          repo,
+		snapshotMgr:   &fakeHTTPSnapshotManager{createErr: snapshot.ErrCloneFailed},
+		podResolver:   &fakeVolumeFilePodResolver{urls: map[string]string{"sandbox0-system/ctld-a": ctldServer.URL}},
+		selfClusterID: "cluster-a",
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/sandboxvolumes/vol-1/snapshots", bytes.NewReader([]byte(`{"name":"checkpoint"}`)))
+	req.SetPathValue("volume_id", "vol-1")
+	req = req.WithContext(internalauth.WithClaims(req.Context(), &internalauth.Claims{TeamID: "team-1", UserID: "user-1"}))
+	recorder := httptest.NewRecorder()
+
+	server.createSnapshot(recorder, req)
+
+	if recorder.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusInternalServerError)
+	}
+	if checkpointCalls["prepare"] != 1 || checkpointCalls["complete"] != 0 || checkpointCalls["abort"] != 1 {
+		t.Fatalf("checkpoint calls = %v, want prepare=1 complete=0 abort=1", checkpointCalls)
+	}
+}
+
+func TestCreateSnapshotRejectsActiveRWXWritableMount(t *testing.T) {
+	repo := newFakeHTTPRepo()
+	repo.volumes["vol-1"] = &db.SandboxVolume{ID: "vol-1", TeamID: "team-1", UserID: "user-1", AccessMode: string(volume.AccessModeRWX)}
+	repo.activeMounts["vol-1"] = []*db.VolumeMount{{
+		VolumeID:     "vol-1",
+		ClusterID:    "cluster-a",
+		PodID:        "storage-proxy-a",
+		MountOptions: mustMountOptionsRaw(t, volume.MountOptions{AccessMode: volume.AccessModeRWX, OwnerKind: volume.OwnerKindStorageProxy}),
+	}}
+	snapshotMgr := &fakeHTTPSnapshotManager{}
+	server := &Server{
+		logger:      logrus.New(),
+		repo:        repo,
+		snapshotMgr: snapshotMgr,
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/sandboxvolumes/vol-1/snapshots", bytes.NewReader([]byte(`{"name":"rwx"}`)))
+	req.SetPathValue("volume_id", "vol-1")
+	req = req.WithContext(internalauth.WithClaims(req.Context(), &internalauth.Claims{TeamID: "team-1", UserID: "user-1"}))
+	recorder := httptest.NewRecorder()
+
+	server.createSnapshot(recorder, req)
+
+	if recorder.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusConflict)
+	}
+	if snapshotMgr.lastCreate != nil {
+		t.Fatalf("CreateSnapshot request = %+v, want nil for active RWX", snapshotMgr.lastCreate)
+	}
+	_, apiErr, err := spec.DecodeResponse[map[string]any](recorder.Body)
+	if err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if apiErr == nil || apiErr.Message != "active RWX volume snapshots are not supported" {
+		t.Fatalf("api error = %+v, want active RWX conflict", apiErr)
 	}
 }
 
@@ -221,6 +327,27 @@ func newReleaseOwnerTestServer(t *testing.T, status int, resp ctldapi.ReleaseVol
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(status)
 		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	return server, mustHTTPServerPort(t, server)
+}
+
+func newSnapshotCheckpointTestServer(t *testing.T, calls map[string]int) (*httptest.Server, int) {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/volume-portals/snapshot-checkpoints/prepare":
+			calls["prepare"]++
+			_ = json.NewEncoder(w).Encode(ctldapi.PrepareVolumeSnapshotCheckpointResponse{Prepared: true})
+		case "/api/v1/volume-portals/snapshot-checkpoints/complete":
+			calls["complete"]++
+			_ = json.NewEncoder(w).Encode(ctldapi.CompleteVolumeSnapshotCheckpointResponse{Completed: true})
+		case "/api/v1/volume-portals/snapshot-checkpoints/abort":
+			calls["abort"]++
+			_ = json.NewEncoder(w).Encode(ctldapi.AbortVolumeSnapshotCheckpointResponse{Aborted: true})
+		default:
+			t.Fatalf("ctld checkpoint path = %q", r.URL.Path)
+		}
 	}))
 	return server, mustHTTPServerPort(t, server)
 }

--- a/storage-proxy/pkg/http/handlers_metering_test.go
+++ b/storage-proxy/pkg/http/handlers_metering_test.go
@@ -245,6 +245,7 @@ func (f *fakeHTTPMeteringWriter) UpsertProducerWatermarkTx(ctx context.Context, 
 
 type fakeHTTPSnapshotManager struct {
 	exportBody           []byte
+	createErr            error
 	lastCreate           *snapshot.CreateSnapshotRequest
 	lastCreateVolume     *snapshot.CreateVolumeFromSnapshotRequest
 	lastRestore          *snapshot.RestoreSnapshotRequest
@@ -258,6 +259,9 @@ type fakeHTTPSnapshotManager struct {
 
 func (f *fakeHTTPSnapshotManager) CreateSnapshotSimple(ctx context.Context, req *snapshot.CreateSnapshotRequest) (*db.Snapshot, error) {
 	f.lastCreate = req
+	if f.createErr != nil {
+		return nil, f.createErr
+	}
 	return &db.Snapshot{
 		ID:          "snap-1",
 		VolumeID:    req.VolumeID,

--- a/storage-proxy/pkg/http/handlers_snapshot.go
+++ b/storage-proxy/pkg/http/handlers_snapshot.go
@@ -54,19 +54,40 @@ func (s *Server) createSnapshot(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	checkpoint, err := s.prepareVolumeSnapshotCheckpoint(r.Context(), volumeID, claims.TeamID)
+	if err != nil {
+		s.handleSnapshotError(w, err)
+		return
+	}
+	checkpointCompleted := false
+	defer func() {
+		if checkpoint != nil && !checkpointCompleted {
+			checkpoint.Abort(context.Background())
+		}
+	}()
+
 	snap, err := s.snapshotMgr.CreateSnapshotSimple(r.Context(), &snapshot.CreateSnapshotRequest{
-		VolumeID:        volumeID,
-		Name:            req.Name,
-		Description:     req.Description,
-		TeamID:          claims.TeamID,
-		UserID:          claims.UserID,
-		StorageMetadata: storageObservationMetadataFromHeaders(r.Header),
+		VolumeID:                 volumeID,
+		Name:                     req.Name,
+		Description:              req.Description,
+		TeamID:                   claims.TeamID,
+		UserID:                   claims.UserID,
+		ActiveCheckpointPrepared: checkpoint.Prepared(),
+		StorageMetadata:          storageObservationMetadataFromHeaders(r.Header),
 	})
 
 	if err != nil {
 		s.handleSnapshotError(w, err)
 		return
 	}
+	if err := checkpoint.Complete(r.Context()); err != nil {
+		if s.logger != nil {
+			s.logger.WithError(err).WithField("volume_id", volumeID).Error("Failed to complete volume snapshot checkpoint")
+		}
+		s.handleSnapshotError(w, err)
+		return
+	}
+	checkpointCompleted = true
 
 	resp := snapshotResponse{
 		ID:          snap.ID,
@@ -250,6 +271,10 @@ func (s *Server) handleSnapshotError(w http.ResponseWriter, err error) {
 		_ = spec.WriteError(w, http.StatusNotFound, spec.CodeNotFound, "snapshot not found") // Don't reveal existence
 	case errors.Is(err, snapshot.ErrVolumeLocked):
 		_ = spec.WriteError(w, http.StatusConflict, spec.CodeConflict, "volume is locked for another operation")
+	case errors.Is(err, snapshot.ErrVolumeBusy):
+		_ = spec.WriteError(w, http.StatusConflict, spec.CodeConflict, "volume is busy, try again later")
+	case errors.Is(err, snapshot.ErrActiveRWXSnapshotUnsupported):
+		_ = spec.WriteError(w, http.StatusConflict, spec.CodeConflict, "active RWX volume snapshots are not supported")
 	case errors.Is(err, snapshot.ErrFlushFailed):
 		_ = spec.WriteError(w, http.StatusInternalServerError, spec.CodeInternal, "failed to flush data")
 	case errors.Is(err, snapshot.ErrCloneFailed):

--- a/storage-proxy/pkg/http/volume_snapshot_checkpoint.go
+++ b/storage-proxy/pkg/http/volume_snapshot_checkpoint.go
@@ -1,0 +1,149 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/snapshot"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volume"
+)
+
+type volumeSnapshotCheckpoint struct {
+	server   *Server
+	volumeID string
+	ctlds    []string
+}
+
+func (c *volumeSnapshotCheckpoint) Prepared() bool {
+	return c != nil && len(c.ctlds) > 0
+}
+
+func (c *volumeSnapshotCheckpoint) Complete(ctx context.Context) error {
+	if c == nil {
+		return nil
+	}
+	var firstErr error
+	client := ctldapi.NewClient(c.server.ctldHTTPClientOrDefault())
+	for i := len(c.ctlds) - 1; i >= 0; i-- {
+		_, err := client.CompleteVolumeSnapshotCheckpoint(ctx, c.ctlds[i], ctldapi.CompleteVolumeSnapshotCheckpointRequest{
+			SandboxVolumeID: c.volumeID,
+		})
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+func (c *volumeSnapshotCheckpoint) Abort(ctx context.Context) {
+	if c == nil {
+		return
+	}
+	client := ctldapi.NewClient(c.server.ctldHTTPClientOrDefault())
+	for i := len(c.ctlds) - 1; i >= 0; i-- {
+		_, err := client.AbortVolumeSnapshotCheckpoint(ctx, c.ctlds[i], ctldapi.AbortVolumeSnapshotCheckpointRequest{
+			SandboxVolumeID: c.volumeID,
+		})
+		if err != nil && c.server != nil && c.server.logger != nil {
+			c.server.logger.WithError(err).WithField("volume_id", c.volumeID).Warn("Failed to abort volume snapshot checkpoint")
+		}
+	}
+}
+
+func (s *Server) prepareVolumeSnapshotCheckpoint(ctx context.Context, volumeID, teamID string) (*volumeSnapshotCheckpoint, error) {
+	checkpoint := &volumeSnapshotCheckpoint{server: s, volumeID: volumeID}
+	if s == nil || s.repo == nil {
+		return checkpoint, nil
+	}
+	volumeRecord, err := s.repo.GetSandboxVolume(ctx, volumeID)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return nil, snapshot.ErrVolumeNotFound
+		}
+		return nil, err
+	}
+	if volumeRecord.TeamID != teamID {
+		return nil, snapshot.ErrVolumeNotFound
+	}
+
+	mounts, err := s.getActiveVolumeMounts(ctx, volumeID)
+	if err != nil {
+		return nil, err
+	}
+	accessMode := volume.NormalizeAccessMode(volumeRecord.AccessMode)
+	switch accessMode {
+	case volume.AccessModeROX:
+		return checkpoint, nil
+	case volume.AccessModeRWX:
+		if hasWritableActiveMount(mounts) {
+			return nil, snapshot.ErrActiveRWXSnapshotUnsupported
+		}
+		return checkpoint, nil
+	}
+
+	client := ctldapi.NewClient(s.ctldHTTPClientOrDefault())
+	for _, mount := range mounts {
+		if mount == nil {
+			continue
+		}
+		opts := volume.DecodeMountOptions(mount.MountOptions)
+		if opts.OwnerKind != volume.OwnerKindCtld {
+			continue
+		}
+		ownerURL, err := s.resolveVolumeMountURL(ctx, mount)
+		if err != nil {
+			checkpoint.Abort(context.Background())
+			return nil, err
+		}
+		if ownerURL == nil {
+			continue
+		}
+		resp, err := client.PrepareVolumeSnapshotCheckpoint(ctx, ownerURL.String(), ctldapi.PrepareVolumeSnapshotCheckpointRequest{
+			SandboxVolumeID: volumeID,
+		})
+		if err != nil {
+			checkpoint.Abort(context.Background())
+			if ctldapi.IsConflictError(err) {
+				return nil, fmt.Errorf("%w: %v", snapshot.ErrVolumeBusy, err)
+			}
+			return nil, err
+		}
+		if resp == nil || !resp.Prepared {
+			checkpoint.Abort(context.Background())
+			if resp != nil && strings.TrimSpace(resp.Error) != "" {
+				return nil, fmt.Errorf("%w: %s", snapshot.ErrVolumeBusy, strings.TrimSpace(resp.Error))
+			}
+			return nil, snapshot.ErrVolumeBusy
+		}
+		checkpoint.ctlds = append(checkpoint.ctlds, ownerURL.String())
+	}
+	return checkpoint, nil
+}
+
+func (s *Server) getActiveVolumeMounts(ctx context.Context, volumeID string) ([]*db.VolumeMount, error) {
+	if s == nil || s.repo == nil || strings.TrimSpace(volumeID) == "" {
+		return nil, nil
+	}
+	heartbeatTimeout := 15
+	if s.cfg != nil && s.cfg.HeartbeatTimeout > 0 {
+		heartbeatTimeout = s.cfg.HeartbeatTimeout
+	}
+	return s.repo.GetActiveMounts(ctx, volumeID, heartbeatTimeout)
+}
+
+func hasWritableActiveMount(mounts []*db.VolumeMount) bool {
+	for _, mount := range mounts {
+		if mount == nil {
+			continue
+		}
+		opts := volume.DecodeMountOptions(mount.MountOptions)
+		if volume.NormalizeAccessMode(string(opts.AccessMode)) != volume.AccessModeROX {
+			return true
+		}
+	}
+	return false
+}

--- a/storage-proxy/pkg/snapshot/manager.go
+++ b/storage-proxy/pkg/snapshot/manager.go
@@ -68,16 +68,17 @@ type FlushCoordinator interface {
 
 // Errors
 var (
-	ErrVolumeNotFound            = errors.New("volume not found")
-	ErrSnapshotNotFound          = errors.New("snapshot not found")
-	ErrSnapshotNotBelongToVolume = errors.New("snapshot does not belong to volume")
-	ErrVolumeLocked              = errors.New("volume is locked for restore")
-	ErrFlushFailed               = errors.New("flush failed on one or more nodes")
-	ErrCloneFailed               = errors.New("clone operation failed")
-	ErrVolumeBusy                = errors.New("volume is busy, try again later")
-	ErrRemountTimeout            = errors.New("remount timeout")
-	ErrInvalidAccessMode         = errors.New("invalid access mode")
-	ErrMountedCtldOwner          = errors.New("snapshot operations require ctld-mounted volumes to be unmounted")
+	ErrVolumeNotFound               = errors.New("volume not found")
+	ErrSnapshotNotFound             = errors.New("snapshot not found")
+	ErrSnapshotNotBelongToVolume    = errors.New("snapshot does not belong to volume")
+	ErrVolumeLocked                 = errors.New("volume is locked for restore")
+	ErrFlushFailed                  = errors.New("flush failed on one or more nodes")
+	ErrCloneFailed                  = errors.New("clone operation failed")
+	ErrVolumeBusy                   = errors.New("volume is busy, try again later")
+	ErrRemountTimeout               = errors.New("remount timeout")
+	ErrInvalidAccessMode            = errors.New("invalid access mode")
+	ErrMountedCtldOwner             = errors.New("snapshot operations require ctld-mounted volumes to be unmounted")
+	ErrActiveRWXSnapshotUnsupported = errors.New("active RWX volume snapshots are not supported")
 )
 
 // Manager handles snapshot operations for SandboxVolumes
@@ -220,12 +221,13 @@ func (m *Manager) SetFlushCoordinator(coordinator FlushCoordinator) {
 
 // CreateSnapshotRequest contains parameters for creating a snapshot
 type CreateSnapshotRequest struct {
-	VolumeID        string
-	Name            string
-	Description     string
-	TeamID          string
-	UserID          string
-	StorageMetadata *meteringpkg.StorageObservation
+	VolumeID                 string
+	Name                     string
+	Description              string
+	TeamID                   string
+	UserID                   string
+	ActiveCheckpointPrepared bool
+	StorageMetadata          *meteringpkg.StorageObservation
 }
 
 // ForkVolumeRequest contains parameters for forking a volume.
@@ -258,6 +260,36 @@ func (m *Manager) CreateSnapshot(ctx context.Context, req *CreateSnapshotRequest
 		"volume_id": req.VolumeID,
 		"name":      req.Name,
 	}).Info("Creating snapshot")
+
+	vol, err := m.repo.GetSandboxVolume(ctx, req.VolumeID)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return nil, ErrVolumeNotFound
+		}
+		return nil, err
+	}
+	if vol.TeamID != req.TeamID {
+		return nil, ErrVolumeNotFound
+	}
+	accessMode := volume.NormalizeAccessMode(vol.AccessMode)
+	if accessMode == volume.AccessModeRWX {
+		activeWritableMount, err := m.hasActiveWritableMount(ctx, req.VolumeID)
+		if err != nil {
+			return nil, err
+		}
+		if activeWritableMount {
+			return nil, ErrActiveRWXSnapshotUnsupported
+		}
+	}
+	if accessMode != volume.AccessModeROX {
+		ctldMounted, err := m.hasMountedCtldOwner(ctx, req.VolumeID)
+		if err != nil {
+			return nil, err
+		}
+		if ctldMounted && !req.ActiveCheckpointPrepared {
+			return nil, ErrMountedCtldOwner
+		}
+	}
 
 	// 0. Distributed flush coordination (if coordinator is set)
 	// This ensures all storage-proxy instances that have this volume mounted

--- a/storage-proxy/pkg/snapshot/manager_test.go
+++ b/storage-proxy/pkg/snapshot/manager_test.go
@@ -661,7 +661,27 @@ func TestRestoreSnapshot_BeginInvalidateError(t *testing.T) {
 	}
 }
 
-func TestCreateSnapshot_AllowsMountedCtldOwner(t *testing.T) {
+func TestCreateSnapshot_RejectsMountedCtldOwnerWithoutCheckpoint(t *testing.T) {
+	repo := newFakeRepo()
+	repo.volumes["vol1"] = &db.SandboxVolume{ID: "vol1", TeamID: "team1"}
+	repo.activeMounts["vol1"] = []*db.VolumeMount{{
+		VolumeID:     "vol1",
+		MountOptions: rawMountOptions(t, volume.MountOptions{AccessMode: volume.AccessModeRWO, OwnerKind: volume.OwnerKindCtld}),
+	}}
+	mgr := newTestManager(repo, nil)
+
+	_, err := mgr.CreateSnapshot(context.Background(), &CreateSnapshotRequest{
+		VolumeID: "vol1",
+		Name:     "snap1",
+		TeamID:   "team1",
+		UserID:   "user1",
+	})
+	if !errors.Is(err, ErrMountedCtldOwner) {
+		t.Fatalf("CreateSnapshot() error = %v, want %v", err, ErrMountedCtldOwner)
+	}
+}
+
+func TestCreateSnapshot_AllowsMountedCtldOwnerWithCheckpoint(t *testing.T) {
 	repo := newFakeRepo()
 	repo.volumes["vol1"] = &db.SandboxVolume{ID: "vol1", TeamID: "team1"}
 	repo.activeMounts["vol1"] = []*db.VolumeMount{{
@@ -673,10 +693,11 @@ func TestCreateSnapshot_AllowsMountedCtldOwner(t *testing.T) {
 	mgr.SetFlushCoordinator(coordinator)
 
 	snapshot, err := mgr.CreateSnapshot(context.Background(), &CreateSnapshotRequest{
-		VolumeID: "vol1",
-		Name:     "snap1",
-		TeamID:   "team1",
-		UserID:   "user1",
+		VolumeID:                 "vol1",
+		Name:                     "snap1",
+		TeamID:                   "team1",
+		UserID:                   "user1",
+		ActiveCheckpointPrepared: true,
 	})
 	if err != nil {
 		t.Fatalf("CreateSnapshot() error = %v", err)
@@ -686,6 +707,26 @@ func TestCreateSnapshot_AllowsMountedCtldOwner(t *testing.T) {
 	}
 	if coordinator.called {
 		t.Fatal("CreateSnapshot called distributed flush coordinator for ctld-owned mount")
+	}
+}
+
+func TestCreateSnapshot_RejectsActiveRWXWritableMount(t *testing.T) {
+	repo := newFakeRepo()
+	repo.volumes["vol1"] = &db.SandboxVolume{ID: "vol1", TeamID: "team1", AccessMode: string(volume.AccessModeRWX)}
+	repo.activeMounts["vol1"] = []*db.VolumeMount{{
+		VolumeID:     "vol1",
+		MountOptions: rawMountOptions(t, volume.MountOptions{AccessMode: volume.AccessModeRWX, OwnerKind: volume.OwnerKindStorageProxy}),
+	}}
+	mgr := newTestManager(repo, nil)
+
+	_, err := mgr.CreateSnapshot(context.Background(), &CreateSnapshotRequest{
+		VolumeID: "vol1",
+		Name:     "snap1",
+		TeamID:   "team1",
+		UserID:   "user1",
+	})
+	if !errors.Is(err, ErrActiveRWXSnapshotUnsupported) {
+		t.Fatalf("CreateSnapshot() error = %v, want %v", err, ErrActiveRWXSnapshotUnsupported)
 	}
 }
 

--- a/storage-proxy/pkg/snapshot/s0fs.go
+++ b/storage-proxy/pkg/snapshot/s0fs.go
@@ -108,18 +108,30 @@ func (m *Manager) hasMountedStorageProxyOwner(ctx context.Context, volumeID stri
 	return m.hasMountedOwnerKind(ctx, volumeID, volume.OwnerKindStorageProxy)
 }
 
+func (m *Manager) hasActiveWritableMount(ctx context.Context, volumeID string) (bool, error) {
+	mounts, err := m.activeMounts(ctx, volumeID)
+	if err != nil {
+		return false, err
+	}
+	for _, mount := range mounts {
+		if mount == nil {
+			continue
+		}
+		opts := volume.DecodeMountOptions(mount.MountOptions)
+		if volume.NormalizeAccessMode(string(opts.AccessMode)) != volume.AccessModeROX {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func (m *Manager) hasMountedOwnerKind(ctx context.Context, volumeID, ownerKind string) (bool, error) {
-	repo, ok := any(m.repo).(activeMountRepository)
-	if !ok || repo == nil || volumeID == "" || ownerKind == "" {
+	if ownerKind == "" {
 		return false, nil
 	}
-	heartbeatTimeout := 15
-	if m.config != nil && m.config.HeartbeatTimeout > 0 {
-		heartbeatTimeout = m.config.HeartbeatTimeout
-	}
-	mounts, err := repo.GetActiveMounts(ctx, volumeID, heartbeatTimeout)
+	mounts, err := m.activeMounts(ctx, volumeID)
 	if err != nil {
-		return false, fmt.Errorf("get active mounts: %w", err)
+		return false, err
 	}
 	for _, mount := range mounts {
 		if volume.DecodeMountOptions(mount.MountOptions).OwnerKind == ownerKind {
@@ -127,6 +139,22 @@ func (m *Manager) hasMountedOwnerKind(ctx context.Context, volumeID, ownerKind s
 		}
 	}
 	return false, nil
+}
+
+func (m *Manager) activeMounts(ctx context.Context, volumeID string) ([]*db.VolumeMount, error) {
+	repo, ok := any(m.repo).(activeMountRepository)
+	if !ok || repo == nil || volumeID == "" {
+		return nil, nil
+	}
+	heartbeatTimeout := 15
+	if m.config != nil && m.config.HeartbeatTimeout > 0 {
+		heartbeatTimeout = m.config.HeartbeatTimeout
+	}
+	mounts, err := repo.GetActiveMounts(ctx, volumeID, heartbeatTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("get active mounts: %w", err)
+	}
+	return mounts, nil
 }
 
 func (m *Manager) s0fsObjectStore(teamID, volumeID string) (objectstore.Store, error) {


### PR DESCRIPTION
## Summary
- add ctld snapshot checkpoint endpoints that block mutating RWO operations, materialize active writer state, and release or abort the checkpoint around snapshot creation
- make storage-proxy snapshot creation prepare active RWO ctld mounts, leave ROX mounts untouched, and return 409 for active writable RWX mounts
- update snapshot docs and the OpenAPI 409 response contract

## Tests
- env GOWORK=off go test ./pkg/ctldapi ./ctld/internal/ctld/server ./ctld/cmd/ctld ./ctld/internal/ctld/portal ./storage-proxy/pkg/snapshot ./storage-proxy/pkg/http
- git diff --cached --check