### PR TITLE
Allow advertised SSH endpoint port override

### DIFF
--- a/docs/self-hosted/configuration/page.mdx
+++ b/docs/self-hosted/configuration/page.mdx
@@ -166,7 +166,9 @@ The routing model is intentionally simple:
 - SSH username is the target sandbox ID
 - User authentication uses SSH public keys uploaded to the gateway API
 
-In Kubernetes terms, `spec.services.sshGateway.service.port` is the externally exposed Service port and `spec.services.sshGateway.config.sshPort` is the container listen port. You usually keep the internal port at `2222` and expose `22` or a NodePort externally.
+In Kubernetes terms, `spec.services.sshGateway.service.port` is the Kubernetes Service port and `spec.services.sshGateway.config.sshPort` is the container listen port. You usually keep the internal port at `2222` and expose `22` or a NodePort externally.
+
+When an external load balancer listens on a different public port than the Kubernetes Service or NodePort, set `spec.services.sshGateway.endpointPort` to the public port that clients should use.
 
 The operator also manages a persistent Ed25519 host key Secret for the service. As long as that Secret is retained, clients continue to see the same SSH host identity across pod restarts.
 
@@ -194,6 +196,7 @@ spec:
             service:
                 type: NodePort
                 port: 30222
+            endpointPort: 22
 ```
 
 After exposing the service through DNS or a load balancer, users can upload SSH public keys with `POST /api/v1/users/me/ssh-keys` and connect with standard clients. See [SSH](/docs/sandbox/ssh) for the user-facing flow.

--- a/infra-operator/api/v1alpha1/sandbox0infra_types.go
+++ b/infra-operator/api/v1alpha1/sandbox0infra_types.go
@@ -968,6 +968,13 @@ type RegionalGatewayServiceConfig struct {
 type SSHGatewayServiceConfig struct {
 	WorkloadServiceConfig `json:",inline"`
 	ServiceExposureConfig `json:",inline"`
+	// EndpointPort optionally overrides the SSH port advertised by regional and
+	// cluster gateways. Use this when an external load balancer listens on a
+	// different port than the Kubernetes Service or NodePort.
+	// +optional
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=65535
+	EndpointPort int32 `json:"endpointPort,omitempty"`
 	// Config contains ssh-gateway specific configuration.
 	// +optional
 	// +kubebuilder:default={}

--- a/infra-operator/chart/crds/infra.sandbox0.ai_sandbox0infras.yaml
+++ b/infra-operator/chart/crds/infra.sandbox0.ai_sandbox0infras.yaml
@@ -2524,6 +2524,15 @@ spec:
                         default: false
                         description: Enabled enables or disables the service
                         type: boolean
+                      endpointPort:
+                        description: |-
+                          EndpointPort optionally overrides the SSH port advertised by regional and
+                          cluster gateways. Use this when an external load balancer listens on a
+                          different port than the Kubernetes Service or NodePort.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
                       replicas:
                         default: 1
                         description: Replicas specifies the number of replicas

--- a/infra-operator/internal/controller/pkg/common/common.go
+++ b/infra-operator/internal/controller/pkg/common/common.go
@@ -354,9 +354,13 @@ func ResolveSSHEndpoint(infra *infrav1alpha1.Sandbox0Infra, fallbackPort int32) 
 		return "", 0, false
 	}
 
-	port := ResolveServicePort(infra.Spec.Services.SSHGateway.Service, fallbackPort)
-	if port <= 0 {
+	servicePort := ResolveServicePort(infra.Spec.Services.SSHGateway.Service, fallbackPort)
+	if servicePort <= 0 {
 		return "", 0, false
+	}
+	port := servicePort
+	if infra.Spec.Services.SSHGateway.EndpointPort > 0 {
+		port = infra.Spec.Services.SSHGateway.EndpointPort
 	}
 
 	return fmt.Sprintf("%s.ssh.%s", regionLabel, rootDomain), port, true

--- a/infra-operator/internal/controller/pkg/common/common_test.go
+++ b/infra-operator/internal/controller/pkg/common/common_test.go
@@ -55,6 +55,74 @@ func TestResolveSandboxNodePlacementFallsBackToNetdPlacement(t *testing.T) {
 	}
 }
 
+func TestResolveSSHEndpointUsesEndpointPortOverride(t *testing.T) {
+	infra := &infrav1alpha1.Sandbox0Infra{
+		Spec: infrav1alpha1.Sandbox0InfraSpec{
+			PublicExposure: &infrav1alpha1.PublicExposureConfig{
+				RootDomain: "sandbox0.app",
+				RegionID:   "ali-ue1",
+			},
+			Services: &infrav1alpha1.ServicesConfig{
+				SSHGateway: &infrav1alpha1.SSHGatewayServiceConfig{
+					WorkloadServiceConfig: infrav1alpha1.WorkloadServiceConfig{
+						EnabledServiceConfig: infrav1alpha1.EnabledServiceConfig{Enabled: true},
+					},
+					ServiceExposureConfig: infrav1alpha1.ServiceExposureConfig{
+						Service: &infrav1alpha1.ServiceNetworkConfig{
+							Type: corev1.ServiceTypeNodePort,
+							Port: 30222,
+						},
+					},
+					EndpointPort: 22,
+				},
+			},
+		},
+	}
+
+	host, port, ok := ResolveSSHEndpoint(infra, 2222)
+	if !ok {
+		t.Fatal("expected SSH endpoint to resolve")
+	}
+	if host != "ali-ue1.ssh.sandbox0.app" {
+		t.Fatalf("host = %q, want ali-ue1.ssh.sandbox0.app", host)
+	}
+	if port != 22 {
+		t.Fatalf("port = %d, want 22", port)
+	}
+}
+
+func TestResolveSSHEndpointFallsBackToServicePort(t *testing.T) {
+	infra := &infrav1alpha1.Sandbox0Infra{
+		Spec: infrav1alpha1.Sandbox0InfraSpec{
+			PublicExposure: &infrav1alpha1.PublicExposureConfig{
+				RootDomain: "sandbox0.app",
+				RegionID:   "ali-ue1",
+			},
+			Services: &infrav1alpha1.ServicesConfig{
+				SSHGateway: &infrav1alpha1.SSHGatewayServiceConfig{
+					WorkloadServiceConfig: infrav1alpha1.WorkloadServiceConfig{
+						EnabledServiceConfig: infrav1alpha1.EnabledServiceConfig{Enabled: true},
+					},
+					ServiceExposureConfig: infrav1alpha1.ServiceExposureConfig{
+						Service: &infrav1alpha1.ServiceNetworkConfig{
+							Type: corev1.ServiceTypeNodePort,
+							Port: 30222,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, port, ok := ResolveSSHEndpoint(infra, 2222)
+	if !ok {
+		t.Fatal("expected SSH endpoint to resolve")
+	}
+	if port != 30222 {
+		t.Fatalf("port = %d, want 30222", port)
+	}
+}
+
 func TestResolveSandboxNodePlacementPrefersSharedPlacement(t *testing.T) {
 	infra := &infrav1alpha1.Sandbox0Infra{
 		Spec: infrav1alpha1.Sandbox0InfraSpec{

--- a/infra-operator/internal/controller/sandbox0infra_validation.go
+++ b/infra-operator/internal/controller/sandbox0infra_validation.go
@@ -75,6 +75,12 @@ func validateServiceSemantics(infra *infrav1alpha1.Sandbox0Infra) []error {
 	if services.ClusterGateway != nil {
 		errs = append(errs, validateServiceNetworkConfig("spec.services.clusterGateway.service", services.ClusterGateway.Service)...)
 	}
+	if services.SSHGateway != nil {
+		errs = append(errs, validateServiceNetworkConfig("spec.services.sshGateway.service", services.SSHGateway.Service)...)
+		if services.SSHGateway.EndpointPort < 0 || services.SSHGateway.EndpointPort > 65535 {
+			errs = append(errs, fmt.Errorf("spec.services.sshGateway.endpointPort must be within 1-65535 when set"))
+		}
+	}
 	if services.Manager != nil {
 		errs = append(errs, validateServiceNetworkConfig("spec.services.manager.service", services.Manager.Service)...)
 	}

--- a/infra-operator/internal/controller/sandbox0infra_validation_test.go
+++ b/infra-operator/internal/controller/sandbox0infra_validation_test.go
@@ -359,6 +359,50 @@ func TestValidateSpecSemanticsAcceptsValidNodePortServicePort(t *testing.T) {
 	}
 }
 
+func TestValidateSpecSemanticsAcceptsSSHEndpointPortBelowNodePortRange(t *testing.T) {
+	infra := &infrav1alpha1.Sandbox0Infra{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "sandbox0-system"},
+		Spec: infrav1alpha1.Sandbox0InfraSpec{
+			Services: &infrav1alpha1.ServicesConfig{
+				SSHGateway: &infrav1alpha1.SSHGatewayServiceConfig{
+					ServiceExposureConfig: infrav1alpha1.ServiceExposureConfig{
+						Service: &infrav1alpha1.ServiceNetworkConfig{
+							Type: corev1.ServiceTypeNodePort,
+							Port: 30222,
+						},
+					},
+					EndpointPort: 22,
+				},
+			},
+		},
+	}
+
+	if err := validateSpecSemantics(context.Background(), newValidationTestClient(t), infra); err != nil {
+		t.Fatalf("expected valid SSH endpoint port configuration, got: %v", err)
+	}
+}
+
+func TestValidateSpecSemanticsRejectsInvalidSSHEndpointPort(t *testing.T) {
+	infra := &infrav1alpha1.Sandbox0Infra{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "sandbox0-system"},
+		Spec: infrav1alpha1.Sandbox0InfraSpec{
+			Services: &infrav1alpha1.ServicesConfig{
+				SSHGateway: &infrav1alpha1.SSHGatewayServiceConfig{
+					EndpointPort: 70000,
+				},
+			},
+		},
+	}
+
+	err := validateSpecSemantics(context.Background(), newValidationTestClient(t), infra)
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if !strings.Contains(err.Error(), "spec.services.sshGateway.endpointPort must be within 1-65535 when set") {
+		t.Fatalf("unexpected validation error: %v", err)
+	}
+}
+
 func newValidationTestClient(t *testing.T, objects ...ctrlclient.Object) ctrlclient.Client {
 	t.Helper()
 

--- a/infra-operator/internal/controller/services/clustergateway/clustergateway_test.go
+++ b/infra-operator/internal/controller/services/clustergateway/clustergateway_test.go
@@ -465,6 +465,7 @@ func TestBuildConfigPublishesSSHEndpoint(t *testing.T) {
 							Port: 30222,
 						},
 					},
+					EndpointPort: 22,
 					Config: &infrav1alpha1.SSHGatewayConfig{
 						SSHPort: 2222,
 					},
@@ -500,8 +501,8 @@ func TestBuildConfigPublishesSSHEndpoint(t *testing.T) {
 	if cfg.SSHEndpointHost != "aws-us-east-1.ssh.sandbox0.app" {
 		t.Fatalf("ssh endpoint host = %q, want %q", cfg.SSHEndpointHost, "aws-us-east-1.ssh.sandbox0.app")
 	}
-	if cfg.SSHEndpointPort != 30222 {
-		t.Fatalf("ssh endpoint port = %d, want %d", cfg.SSHEndpointPort, 30222)
+	if cfg.SSHEndpointPort != 22 {
+		t.Fatalf("ssh endpoint port = %d, want %d", cfg.SSHEndpointPort, 22)
 	}
 }
 

--- a/infra-operator/internal/controller/services/regionalgateway/regionalgateway_registry_test.go
+++ b/infra-operator/internal/controller/services/regionalgateway/regionalgateway_registry_test.go
@@ -452,6 +452,7 @@ func TestBuildConfigPublishesSSHEndpoint(t *testing.T) {
 							Port: 30222,
 						},
 					},
+					EndpointPort: 22,
 					Config: &infrav1alpha1.SSHGatewayConfig{
 						SSHPort: 2222,
 					},
@@ -478,8 +479,8 @@ func TestBuildConfigPublishesSSHEndpoint(t *testing.T) {
 	if cfg.SSHEndpointHost != "aws-us-east-1.ssh.sandbox0.app" {
 		t.Fatalf("ssh endpoint host = %q, want %q", cfg.SSHEndpointHost, "aws-us-east-1.ssh.sandbox0.app")
 	}
-	if cfg.SSHEndpointPort != 30222 {
-		t.Fatalf("ssh endpoint port = %d, want %d", cfg.SSHEndpointPort, 30222)
+	if cfg.SSHEndpointPort != 22 {
+		t.Fatalf("ssh endpoint port = %d, want %d", cfg.SSHEndpointPort, 22)
 	}
 }
 

--- a/infra-operator/internal/ownership/registry.go
+++ b/infra-operator/internal/ownership/registry.go
@@ -80,6 +80,7 @@ func Registry() []Entry {
 
 		exact("spec.services.clusterGateway.config.authMode", "plan", []string{"cluster-gateway", "manager"}, []string{"InfraPlan.Manager.TemplateStoreEnabled", "InfraPlan.Enterprise.ClusterGateway"}, UpdateSemanticsDeclarative, "Auth mode affects manager template-store behavior and enterprise-license requirements."),
 		exact("spec.services.clusterGateway.config.oidcProviders", "plan", []string{"cluster-gateway"}, []string{"InfraPlan.Enterprise.ClusterGateway"}, UpdateSemanticsDeclarative, "Enabled OIDC providers drive cluster-gateway enterprise-license requirements."),
+		exact("spec.services.sshGateway.endpointPort", "plan", []string{"regional-gateway", "cluster-gateway"}, []string{"ssh endpoint advertisement"}, UpdateSemanticsDeclarative, "Optional public SSH endpoint port advertised by regional-gateway and cluster-gateway."),
 		exact("spec.services.clusterGateway.service.port", "plan", []string{"cluster-gateway", "regional-gateway"}, []string{"InfraPlan.Services.ClusterGateway.Port", "InfraPlan.RegionalGateway.DefaultClusterGatewayURL"}, UpdateSemanticsDeclarative, "Cluster-gateway service port is projected into regional-gateway routing."),
 		exact("spec.services.clusterGateway.service.type", "plan", []string{"cluster-gateway", "regional-gateway"}, []string{"InfraPlan.Services.ClusterGateway.Port", "validation"}, UpdateSemanticsDeclarative, "Service type determines how the cluster-gateway address is projected downstream."),
 


### PR DESCRIPTION
## Summary
- Add spec.services.sshGateway.endpointPort to advertise a public SSH port separately from the Kubernetes Service/NodePort
- Use endpointPort when regional-gateway and cluster-gateway publish ssh_endpoint_port
- Regenerate CRD schema and document the NodePort plus external LB port translation case

## Tests
- make manifests
- GOTOOLCHAIN=go1.25.0+auto env GOWORK=off go test ./infra-operator/internal/controller/pkg/common ./infra-operator/internal/controller/services/clustergateway ./infra-operator/internal/controller/services/regionalgateway ./infra-operator/internal/controller ./infra-operator/internal/plan ./infra-operator/internal/ownership
- GOTOOLCHAIN=go1.25.0+auto env GOWORK=off go test ./infra-operator/...
