### PR TITLE
Fix S0FS write amplification with extent compaction

### DIFF
--- a/ctld/internal/ctld/portal/manager.go
+++ b/ctld/internal/ctld/portal/manager.go
@@ -2,6 +2,7 @@ package portal
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -362,10 +363,15 @@ func (m *Manager) Bind(ctx context.Context, req ctldapi.BindVolumePortalRequest)
 	if err != nil {
 		return ctldapi.BindVolumePortalResponse{}, err
 	}
+	segmentTargetSize, err := volume.S0FSSegmentTargetSize(m.storage)
+	if err != nil {
+		return ctldapi.BindVolumePortalResponse{}, err
+	}
 	engine, err := s0fs.Open(ctx, s0fs.Config{
-		VolumeID:    req.SandboxVolumeID,
-		WALPath:     filepath.Join(cacheDir, "engine.wal"),
-		ObjectStore: remoteStore,
+		VolumeID:          req.SandboxVolumeID,
+		WALPath:           filepath.Join(cacheDir, "engine.wal"),
+		ObjectStore:       remoteStore,
+		SegmentTargetSize: segmentTargetSize,
 		ObjectStoreForVolume: func(volumeID string) (objectstore.Store, error) {
 			return m.createObjectStore(req.TeamID, volumeID)
 		},
@@ -549,10 +555,15 @@ func (m *Manager) AttachOwner(ctx context.Context, req ctldapi.AttachVolumeOwner
 	if err != nil {
 		return ctldapi.AttachVolumeOwnerResponse{}, err
 	}
+	segmentTargetSize, err := volume.S0FSSegmentTargetSize(m.storage)
+	if err != nil {
+		return ctldapi.AttachVolumeOwnerResponse{}, err
+	}
 	engine, err := s0fs.Open(ctx, s0fs.Config{
-		VolumeID:    req.SandboxVolumeID,
-		WALPath:     filepath.Join(cacheDir, "engine.wal"),
-		ObjectStore: remoteStore,
+		VolumeID:          req.SandboxVolumeID,
+		WALPath:           filepath.Join(cacheDir, "engine.wal"),
+		ObjectStore:       remoteStore,
+		SegmentTargetSize: segmentTargetSize,
 		ObjectStoreForVolume: func(volumeID string) (objectstore.Store, error) {
 			return m.createObjectStore(req.TeamID, volumeID)
 		},
@@ -880,6 +891,23 @@ func (m *Manager) startMaterializer(bound *boundVolume) {
 	if bound == nil || bound.volCtx == nil || bound.volCtx.S0FS == nil {
 		return
 	}
+	compactionInterval, err := volume.S0FSCompactionInterval(m.storage)
+	if err != nil {
+		if m.logger != nil {
+			m.logger.Warn("ctld s0fs compaction disabled due to invalid configuration", zap.String("volume_id", bound.volumeID), zap.Error(err))
+		}
+		compactionInterval = 0
+	}
+	compactionOptions, err := volume.S0FSCompactionOptions(m.storage)
+	if err != nil {
+		if m.logger != nil {
+			m.logger.Warn("ctld s0fs compaction disabled due to invalid options", zap.String("volume_id", bound.volumeID), zap.Error(err))
+		}
+		compactionInterval = 0
+	}
+	if !volume.S0FSBackgroundCompactionEnabled(bound.access) {
+		compactionInterval = 0
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	bound.materializeCancel = cancel
@@ -888,17 +916,156 @@ func (m *Manager) startMaterializer(bound *boundVolume) {
 		defer close(done)
 		ticker := time.NewTicker(2 * time.Second)
 		defer ticker.Stop()
+		var compactionTicker *time.Ticker
+		var compactionC <-chan time.Time
+		if compactionInterval > 0 {
+			compactionTicker = time.NewTicker(compactionInterval)
+			compactionC = compactionTicker.C
+			defer compactionTicker.Stop()
+		}
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				if _, err := bound.volCtx.S0FS.SyncMaterialize(ctx); err != nil && m.logger != nil {
+				manifest, err := bound.volCtx.S0FS.SyncMaterialize(ctx)
+				if err != nil && m.logger != nil {
 					m.logger.Warn("ctld volume materialize failed", zap.String("volume_id", volumeID), zap.Error(err))
+					continue
 				}
+				m.garbageCollectBoundS0FS(ctx, bound, manifest)
+			case <-compactionC:
+				resultManifest, result, err := bound.volCtx.S0FS.Compact(ctx, compactionOptions)
+				if err != nil && m.logger != nil {
+					m.logger.Warn("ctld volume compaction failed", zap.String("volume_id", volumeID), zap.Error(err))
+					continue
+				}
+				if result != nil && len(result.CompactedSegments) > 0 && m.logger != nil {
+					m.logger.Info("ctld volume compacted",
+						zap.String("volume_id", volumeID),
+						zap.Int("segments", len(result.CompactedSegments)),
+						zap.Uint64("rewritten_bytes", result.RewrittenBytes),
+						zap.Uint64("reclaimable_bytes", result.ReclaimableBytes),
+					)
+				}
+				m.garbageCollectBoundS0FS(ctx, bound, resultManifest)
 			}
 		}
 	}(bound.volumeID)
+}
+
+func (m *Manager) garbageCollectBoundS0FS(ctx context.Context, bound *boundVolume, manifest *s0fs.Manifest) {
+	if m == nil || bound == nil || manifest == nil || manifest.State == nil {
+		return
+	}
+	if !volume.S0FSBackgroundCompactionEnabled(bound.access) {
+		return
+	}
+	result, err := m.garbageCollectBoundS0FSObjects(ctx, bound, manifest)
+	if err != nil {
+		if m.logger != nil {
+			m.logger.Warn("ctld volume garbage collection failed", zap.String("volume_id", bound.volumeID), zap.Error(err))
+		}
+		return
+	}
+	if result != nil && (len(result.DeletedSegments) > 0 || len(result.DeletedManifests) > 0) && m.logger != nil {
+		m.logger.Info("ctld volume garbage collected",
+			zap.String("volume_id", bound.volumeID),
+			zap.Int("segments", len(result.DeletedSegments)),
+			zap.Int("manifests", len(result.DeletedManifests)),
+		)
+	}
+}
+
+func (m *Manager) garbageCollectBoundS0FSObjects(ctx context.Context, bound *boundVolume, manifest *s0fs.Manifest) (*s0fs.GarbageCollectionResult, error) {
+	if m == nil || m.repo == nil || m.volumes == nil || bound == nil || bound.volCtx == nil || manifest == nil || manifest.State == nil {
+		return nil, nil
+	}
+	if !volume.S0FSBackgroundCompactionEnabled(bound.access) || !m.volumes.canGarbageCollectS0FS(bound.volumeID) {
+		return nil, nil
+	}
+	children, err := m.repo.ListSandboxVolumesBySource(ctx, bound.volumeID)
+	if err != nil {
+		return nil, err
+	}
+	if len(children) > 0 {
+		return nil, nil
+	}
+	snapshots, err := m.repo.ListSnapshotsByVolume(ctx, bound.volumeID)
+	if err != nil {
+		return nil, err
+	}
+	if len(snapshots) > 0 {
+		return nil, nil
+	}
+	store, err := m.createObjectStore(bound.teamID, bound.volumeID)
+	if err != nil {
+		return nil, err
+	}
+	encryption, err := volume.S0FSEncryptionConfig(m.storage)
+	if err != nil {
+		return nil, err
+	}
+	headStore := db.NewS0FSHeadStore(m.repo)
+	materializer := s0fs.NewMaterializer(bound.volumeID, store, headStore, func(sourceVolumeID string) (objectstore.Store, error) {
+		return m.createObjectStore(bound.teamID, sourceVolumeID)
+	})
+	if materializer == nil || !materializer.Enabled() {
+		return nil, nil
+	}
+	materializer.SetEncryption(encryption)
+
+	headBefore, err := headStore.LoadCommittedHead(ctx, bound.volumeID)
+	if err != nil && !errors.Is(err, s0fs.ErrCommittedHeadNotFound) {
+		return nil, err
+	}
+	retainedStates := []*s0fs.SnapshotState{manifest.State}
+	cfg := s0fs.Config{
+		VolumeID:    bound.volumeID,
+		WALPath:     filepath.Join(bound.volCtx.CacheDir, "engine.wal"),
+		ObjectStore: store,
+		HeadStore:   headStore,
+		Encryption:  encryption,
+	}
+	localSnapshots, err := s0fs.LoadLocalSnapshots(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	retainedStates = append(retainedStates, localSnapshots...)
+	retainedManifests := map[string]struct{}{
+		"manifests/latest.json": {},
+	}
+	if manifest.ManifestSeq > 0 {
+		retainedManifests[fmt.Sprintf("manifests/%020d.json", manifest.ManifestSeq)] = struct{}{}
+	}
+	if headBefore != nil && strings.TrimSpace(headBefore.ManifestKey) != "" {
+		retainedManifests[headBefore.ManifestKey] = struct{}{}
+	}
+	plan, err := materializer.PlanGarbageCollection(ctx, retainedStates, retainedManifests)
+	if err != nil {
+		return nil, err
+	}
+	if len(plan.Segments) == 0 && len(plan.Manifests) == 0 {
+		return &s0fs.GarbageCollectionResult{}, nil
+	}
+	if !m.volumes.canGarbageCollectS0FS(bound.volumeID) {
+		return nil, nil
+	}
+	headAfter, err := headStore.LoadCommittedHead(ctx, bound.volumeID)
+	if err != nil && !errors.Is(err, s0fs.ErrCommittedHeadNotFound) {
+		return nil, err
+	}
+	if !sameS0FSHeadKey(headBefore, headAfter) {
+		return nil, nil
+	}
+	return plan.Apply(ctx)
+}
+
+func sameS0FSHeadKey(a, b *s0fs.CommittedHead) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return strings.TrimSpace(a.ManifestKey) == strings.TrimSpace(b.ManifestKey)
 }
 
 func (m *Manager) attachPortalLocked(pm *portalMount, volumeID, teamID string, mountedAt time.Time) {

--- a/ctld/internal/ctld/portal/session.go
+++ b/ctld/internal/ctld/portal/session.go
@@ -158,6 +158,13 @@ func (m *localVolumeManager) completeSnapshotCheckpoint(volumeID string) {
 	m.abortHandoff(volumeID)
 }
 
+func (m *localVolumeManager) canGarbageCollectS0FS(volumeID string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	state := m.requests[volumeID]
+	return state != nil && !state.transferring
+}
+
 func (m *localVolumeManager) touch(volumeID string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/docs/self-hosted/configuration/page.mdx
+++ b/docs/self-hosted/configuration/page.mdx
@@ -302,6 +302,8 @@ Examples:
 - `services.clusterGateway.config.authMode` switches between `public`, `internal`, and `both`
 - `services.manager.config.autoscaler.*` tunes pool scale behavior
 - `services.storageProxy.config.filesystem*` tunes filesystem behavior; `services.manager.config.procdConfig.volume*` tunes mounted volume cache sizing
+- `services.storageProxy.config.s0fsSegmentTargetSize` sets the target S0FS segment size for materialized volume data; the default is `4Mi`
+- `services.storageProxy.config.s0fsCompaction*` tunes background S0FS compaction for RWO volume owners; `s0fsCompactionInterval` accepts `0`, `off`, or `disabled` to turn it off
 - `services.storageProxy.config.cacheSizeLimit`, `logSizeLimit`, `volumePortalCacheSizeLimit`, and `volumePortalRootMinFree` cap node-local storage used by storage-proxy cache, logs, and mounted volume portals
 - `services.storageProxy.config.objectEncryptionEnabled` controls application-layer encryption for S0FS object storage and node-local volume cache files; it is enabled by default
 - `services.netd.config.egressBandwidthBytesPerSecond`, `ingressBandwidthBytesPerSecond`, and `bandwidthBurstBytes` apply per-sandbox bandwidth throttling when set above zero
@@ -314,6 +316,10 @@ spec:
             config:
                 cacheSizeLimit: 20Gi
                 logSizeLimit: 1Gi
+                s0fsSegmentTargetSize: 4Mi
+                s0fsCompactionInterval: 1m
+                s0fsCompactionMinDeadRatio: "0.5"
+                s0fsCompactionMinReclaimSize: 1Mi
                 volumePortalCacheSizeLimit: 20Gi
                 volumePortalRootMinFree: 5Gi
         netd:

--- a/infra-operator/api/config/storage_proxy.go
+++ b/infra-operator/api/config/storage_proxy.go
@@ -59,6 +59,18 @@ type StorageProxyConfig struct {
 	// +kubebuilder:default=20
 	FilesystemMaxUpload int `yaml:"filesystem_max_upload" json:"filesystemMaxUpload"`
 	// +optional
+	// +kubebuilder:default="4Mi"
+	S0FSSegmentTargetSize string `yaml:"s0fs_segment_target_size" json:"s0fsSegmentTargetSize"`
+	// +optional
+	// +kubebuilder:default="1m"
+	S0FSCompactionInterval string `yaml:"s0fs_compaction_interval" json:"s0fsCompactionInterval"`
+	// +optional
+	// +kubebuilder:default="0.5"
+	S0FSCompactionMinDeadRatio string `yaml:"s0fs_compaction_min_dead_ratio" json:"s0fsCompactionMinDeadRatio"`
+	// +optional
+	// +kubebuilder:default="1Mi"
+	S0FSCompactionMinReclaimSize string `yaml:"s0fs_compaction_min_reclaim_size" json:"s0fsCompactionMinReclaimSize"`
+	// +optional
 	// +kubebuilder:default=true
 	ObjectEncryptionEnabled bool `yaml:"object_encryption_enabled" json:"objectEncryptionEnabled"`
 	// +optional

--- a/infra-operator/api/v1alpha1/service_api_config_types.go
+++ b/infra-operator/api/v1alpha1/service_api_config_types.go
@@ -513,6 +513,18 @@ type StorageProxyConfig struct {
 	// +kubebuilder:default=20
 	FilesystemMaxUpload int `json:"filesystemMaxUpload,omitempty"`
 	// +optional
+	// +kubebuilder:default="4Mi"
+	S0FSSegmentTargetSize string `json:"s0fsSegmentTargetSize,omitempty"`
+	// +optional
+	// +kubebuilder:default="1m"
+	S0FSCompactionInterval string `json:"s0fsCompactionInterval,omitempty"`
+	// +optional
+	// +kubebuilder:default="0.5"
+	S0FSCompactionMinDeadRatio string `json:"s0fsCompactionMinDeadRatio,omitempty"`
+	// +optional
+	// +kubebuilder:default="1Mi"
+	S0FSCompactionMinReclaimSize string `json:"s0fsCompactionMinReclaimSize,omitempty"`
+	// +optional
 	// +kubebuilder:default=true
 	ObjectEncryptionEnabled bool `json:"objectEncryptionEnabled,omitempty"`
 	// +optional

--- a/infra-operator/chart/crds/infra.sandbox0.ai_sandbox0infras.yaml
+++ b/infra-operator/chart/crds/infra.sandbox0.ai_sandbox0infras.yaml
@@ -2871,6 +2871,18 @@ spec:
                           restoreRemountTimeout:
                             default: 30s
                             type: string
+                          s0fsCompactionInterval:
+                            default: 1m
+                            type: string
+                          s0fsCompactionMinDeadRatio:
+                            default: "0.5"
+                            type: string
+                          s0fsCompactionMinReclaimSize:
+                            default: 1Mi
+                            type: string
+                          s0fsSegmentTargetSize:
+                            default: 4Mi
+                            type: string
                           volumePortalCacheSizeLimit:
                             default: 20Gi
                             type: string

--- a/infra-operator/internal/runtimeconfig/dataplane.go
+++ b/infra-operator/internal/runtimeconfig/dataplane.go
@@ -77,6 +77,10 @@ func ToStorageProxy(spec *infrav1alpha1.StorageProxyConfig) *apiconfig.StoragePr
 	cfg.FilesystemTrashDays = spec.FilesystemTrashDays
 	cfg.FilesystemMetaRetries = spec.FilesystemMetaRetries
 	cfg.FilesystemMaxUpload = spec.FilesystemMaxUpload
+	cfg.S0FSSegmentTargetSize = spec.S0FSSegmentTargetSize
+	cfg.S0FSCompactionInterval = spec.S0FSCompactionInterval
+	cfg.S0FSCompactionMinDeadRatio = spec.S0FSCompactionMinDeadRatio
+	cfg.S0FSCompactionMinReclaimSize = spec.S0FSCompactionMinReclaimSize
 	cfg.ObjectEncryptionEnabled = spec.ObjectEncryptionEnabled
 	cfg.ObjectEncryptionPassphrase = spec.ObjectEncryptionPassphrase
 	cfg.ObjectEncryptionAlgo = spec.ObjectEncryptionAlgo

--- a/infra-operator/internal/runtimeconfig/dataplane_test.go
+++ b/infra-operator/internal/runtimeconfig/dataplane_test.go
@@ -32,6 +32,21 @@ func TestToStorageProxyPreservesLocalStorageLimits(t *testing.T) {
 	}
 }
 
+func TestToStorageProxyPreservesS0FSLayoutConfig(t *testing.T) {
+	cfg := ToStorageProxy(&infrav1alpha1.StorageProxyConfig{
+		S0FSSegmentTargetSize:        "8Mi",
+		S0FSCompactionInterval:       "30s",
+		S0FSCompactionMinDeadRatio:   "0.25",
+		S0FSCompactionMinReclaimSize: "2Mi",
+	})
+	if cfg.S0FSSegmentTargetSize != "8Mi" ||
+		cfg.S0FSCompactionInterval != "30s" ||
+		cfg.S0FSCompactionMinDeadRatio != "0.25" ||
+		cfg.S0FSCompactionMinReclaimSize != "2Mi" {
+		t.Fatalf("s0fs layout config was not preserved: %#v", cfg)
+	}
+}
+
 func TestToNetdPreservesBandwidthLimits(t *testing.T) {
 	cfg := ToNetd(&infrav1alpha1.NetdConfig{
 		EgressBandwidthBytesPerSecond:  1024,

--- a/storage-proxy/pkg/s0fs/compaction.go
+++ b/storage-proxy/pkg/s0fs/compaction.go
@@ -1,0 +1,288 @@
+package s0fs
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+)
+
+type CompactionOptions struct {
+	SegmentTargetSize uint64
+	MinDeadRatio      float64
+	MinReclaimBytes   uint64
+	Force             bool
+}
+
+type CompactionResult struct {
+	CompactedSegments []string
+	RewrittenBytes    uint64
+	ReclaimableBytes  uint64
+}
+
+func (e *Engine) Compact(ctx context.Context, opts CompactionOptions) (*Manifest, *CompactionResult, error) {
+	if _, err := e.SyncMaterialize(ctx); err != nil {
+		return nil, nil, err
+	}
+
+	e.materializeMu.Lock()
+	defer e.materializeMu.Unlock()
+
+	e.mu.RLock()
+	if err := e.checkOpen(); err != nil {
+		e.mu.RUnlock()
+		return nil, nil, err
+	}
+	if e.materializer == nil || !e.materializer.Enabled() {
+		e.mu.RUnlock()
+		return nil, nil, nil
+	}
+	state := cloneState(e.currentStateLocked())
+	expectedManifestSeq := e.lastCommittedManifest
+	if state.NextSeq <= expectedManifestSeq+1 {
+		state.NextSeq = expectedManifestSeq + 2
+	}
+	e.mu.RUnlock()
+
+	manifest, result, err := e.materializer.Compact(ctx, state, expectedManifestSeq, opts)
+	if err != nil || manifest == nil {
+		return manifest, result, err
+	}
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.lastCommittedManifest == expectedManifestSeq {
+		e.replaceStateLocked(cloneState(manifest.State))
+		if err := e.persistCurrentStateLocked(); err != nil {
+			return nil, nil, err
+		}
+		if err := e.wal.reset(); err != nil {
+			return nil, nil, err
+		}
+		e.refreshLocalDiskGuardLocked()
+		e.lastCommittedManifest = manifest.ManifestSeq
+		e.lastMaterializedVersion = e.mutationVersion
+		e.dirty = false
+	} else if manifest.ManifestSeq > e.lastCommittedManifest {
+		e.lastCommittedManifest = manifest.ManifestSeq
+	}
+	return manifest, result, nil
+}
+
+func (m *Materializer) Compact(ctx context.Context, state *SnapshotState, expectedManifestSeq uint64, opts CompactionOptions) (*Manifest, *CompactionResult, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
+	}
+	if !m.Enabled() {
+		return nil, nil, nil
+	}
+	inline := cloneState(state)
+	normalizeState(inline)
+	defaultSegmentVolumeIDs(inline, m.volumeID)
+	if inline.NextSeq <= expectedManifestSeq+1 {
+		inline.NextSeq = expectedManifestSeq + 2
+	}
+	nextSeq := checkpointSequence(inline)
+	if nextSeq <= expectedManifestSeq {
+		return nil, nil, fmt.Errorf("%w: compact manifest seq %d must advance beyond %d", ErrCommittedHeadConflict, nextSeq, expectedManifestSeq)
+	}
+
+	selected, result := planCompactionSegments(inline, opts)
+	if len(selected) == 0 && !hasInlineSegments(inline) {
+		return nil, result, nil
+	}
+	manifestState, segments, err := buildCompactedState(ctx, m, nextSeq, m.volumeID, inline, selected, opts.SegmentTargetSize)
+	if err != nil {
+		return nil, nil, err
+	}
+	manifest := &Manifest{
+		Version:       1,
+		VolumeID:      m.volumeID,
+		ManifestSeq:   nextSeq,
+		CheckpointSeq: checkpointSequence(inline),
+		CreatedAt:     time.Now().UTC(),
+		State:         manifestState,
+	}
+	for _, segment := range segments {
+		storedSegmentPayload, segmentEncryption, err := m.encryption.encryptSegment(m.volumeID, segment)
+		if err != nil {
+			return nil, nil, err
+		}
+		segment.Encryption = segmentEncryption
+		if meta := manifest.State.Segments[segment.ID]; meta != nil {
+			meta.Encryption = segmentEncryption
+		}
+		if err := m.putBytes(ctx, segment.Key, storedSegmentPayload); err != nil {
+			return nil, nil, err
+		}
+		m.cache.put(segmentCacheKey(segment.VolumeID, segment.Key), segment.Payload)
+	}
+	if err := m.putJSON(ctx, manifestKey(nextSeq), manifest); err != nil {
+		return nil, nil, err
+	}
+	if m.headStore != nil {
+		head := &CommittedHead{
+			VolumeID:      m.volumeID,
+			ManifestSeq:   manifest.ManifestSeq,
+			CheckpointSeq: manifest.CheckpointSeq,
+			ManifestKey:   manifestKey(manifest.ManifestSeq),
+			UpdatedAt:     manifest.CreatedAt,
+		}
+		if err := m.headStore.CompareAndSwapCommittedHead(ctx, m.volumeID, expectedManifestSeq, head); err != nil {
+			return nil, nil, err
+		}
+	} else if err := m.putJSON(ctx, manifestLatestKey, manifest); err != nil {
+		return nil, nil, err
+	}
+	return manifest, result, nil
+}
+
+func planCompactionSegments(state *SnapshotState, opts CompactionOptions) (map[string]struct{}, *CompactionResult) {
+	live := make(map[string]uint64)
+	for _, extents := range state.ColdFiles {
+		for _, extent := range extents {
+			if extent.SegmentID != "" {
+				live[extent.SegmentID] += extent.Length
+			}
+		}
+	}
+	selected := make(map[string]struct{})
+	result := &CompactionResult{}
+	for segmentID, liveBytes := range live {
+		segment := state.Segments[segmentID]
+		if segment == nil || isInlineSegment(segment) || segment.Key == "" || segment.Length == 0 {
+			continue
+		}
+		if liveBytes >= segment.Length && !opts.Force {
+			continue
+		}
+		deadBytes := segment.Length - minUint64(liveBytes, segment.Length)
+		deadRatio := float64(deadBytes) / float64(segment.Length)
+		if !opts.Force {
+			if opts.MinReclaimBytes > 0 && deadBytes < opts.MinReclaimBytes {
+				continue
+			}
+			if opts.MinDeadRatio > 0 && deadRatio < opts.MinDeadRatio {
+				continue
+			}
+			if deadBytes == 0 {
+				continue
+			}
+		}
+		selected[segmentID] = struct{}{}
+		result.CompactedSegments = append(result.CompactedSegments, segmentID)
+		result.RewrittenBytes += liveBytes
+		result.ReclaimableBytes += deadBytes
+	}
+	sort.Strings(result.CompactedSegments)
+	return selected, result
+}
+
+func buildCompactedState(ctx context.Context, materializer *Materializer, manifestSeq uint64, volumeID string, state *SnapshotState, selected map[string]struct{}, targetSize uint64) (*SnapshotState, []*materializedSegment, error) {
+	manifestState := &SnapshotState{
+		NextSeq:   state.NextSeq,
+		NextInode: state.NextInode,
+		Nodes:     cloneNodeMap(state.Nodes),
+		Children:  cloneChildrenMap(state.Children),
+		Data:      make(map[uint64][]byte),
+		ColdFiles: make(map[uint64][]FileExtent),
+		Segments:  make(map[string]*Segment),
+	}
+	builder := newSegmentBuilder(manifestSeq, volumeID, targetSize)
+	inodes := make([]uint64, 0, len(state.ColdFiles)+len(state.Data))
+	seen := make(map[uint64]struct{}, len(state.ColdFiles)+len(state.Data))
+	for inode := range state.ColdFiles {
+		seen[inode] = struct{}{}
+		inodes = append(inodes, inode)
+	}
+	for inode := range state.Data {
+		if _, ok := seen[inode]; !ok {
+			seen[inode] = struct{}{}
+			inodes = append(inodes, inode)
+		}
+	}
+	sort.Slice(inodes, func(i, j int) bool { return inodes[i] < inodes[j] })
+
+	for _, inode := range inodes {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
+		}
+		node := state.Nodes[inode]
+		if node == nil || node.Type == TypeDirectory {
+			continue
+		}
+		var fileExtents []FileExtent
+		if payload := state.Data[inode]; len(payload) > 0 {
+			extents, err := builder.append(payload)
+			if err != nil {
+				return nil, nil, err
+			}
+			fileExtents = append(fileExtents, extents...)
+		}
+		for _, extent := range state.ColdFiles[inode] {
+			if extent.Length == 0 {
+				continue
+			}
+			if extent.SegmentID == "" {
+				fileExtents = append(fileExtents, extent)
+				continue
+			}
+			segment := state.Segments[extent.SegmentID]
+			if segment == nil {
+				return nil, nil, fmt.Errorf("%w: missing compact segment %s", ErrInvalidInput, extent.SegmentID)
+			}
+			if isInlineSegment(segment) {
+				payload, err := inlineSegmentRange(segment, extent.Offset, extent.Length)
+				if err != nil {
+					return nil, nil, err
+				}
+				extents, err := builder.append(payload)
+				if err != nil {
+					return nil, nil, err
+				}
+				fileExtents = append(fileExtents, extents...)
+				continue
+			}
+			if _, ok := selected[extent.SegmentID]; !ok {
+				fileExtents = append(fileExtents, extent)
+				manifestState.Segments[extent.SegmentID] = cloneSegment(segment)
+				continue
+			}
+			payload, err := materializer.ReadSegmentRange(segment, int64(extent.Offset), int64(extent.Length))
+			if err != nil {
+				return nil, nil, fmt.Errorf("read compact segment %s: %w", segment.Key, err)
+			}
+			extents, err := builder.append(payload)
+			if err != nil {
+				return nil, nil, err
+			}
+			fileExtents = append(fileExtents, extents...)
+		}
+		fileExtents = coalesceExtents(fileExtents)
+		if len(fileExtents) > 0 {
+			manifestState.ColdFiles[inode] = fileExtents
+		}
+	}
+	segments := builder.finish()
+	for _, segment := range segments {
+		manifestState.Segments[segment.ID] = &Segment{
+			ID:       segment.ID,
+			VolumeID: segment.VolumeID,
+			Key:      segment.Key,
+			Length:   uint64(len(segment.Payload)),
+			SHA256:   segment.SHA256,
+		}
+	}
+	return manifestState, segments, nil
+}
+
+func hasInlineSegments(state *SnapshotState) bool {
+	for _, extents := range state.ColdFiles {
+		for _, extent := range extents {
+			if isInlineSegment(state.Segments[extent.SegmentID]) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/storage-proxy/pkg/s0fs/crypto_test.go
+++ b/storage-proxy/pkg/s0fs/crypto_test.go
@@ -78,7 +78,12 @@ func TestEncryptedS0FSObjectsAndLocalStateHidePlaintext(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateSnapshot() error = %v", err)
 	}
-	if got := string(snapshotState.Data[node.Inode]); got != string(secretPayload) {
+	snapshotReader := NewSnapshotReader(snapshotState, engine.materializer)
+	snapshotPayload, err := snapshotReader.Read(node.Inode, 0, uint64(len(secretPayload)))
+	if err != nil {
+		t.Fatalf("snapshot Read() error = %v", err)
+	}
+	if got := string(snapshotPayload); got != string(secretPayload) {
 		t.Fatalf("snapshot data = %q, want %q", got, string(secretPayload))
 	}
 	assertFileDoesNotContain(t, filepath.Join(dir, "snapshots", "snap-1.json"), []byte(secretName))

--- a/storage-proxy/pkg/s0fs/engine.go
+++ b/storage-proxy/pkg/s0fs/engine.go
@@ -53,6 +53,7 @@ func Open(ctx context.Context, cfg Config) (*Engine, error) {
 	materializer := NewMaterializer(cfg.VolumeID, cfg.ObjectStore, cfg.HeadStore, cfg.ObjectStoreForVolume)
 	if materializer != nil {
 		materializer.SetEncryption(cfg.Encryption)
+		materializer.SetSegmentTargetSize(cfg.SegmentTargetSize)
 	}
 	var latestManifest *Manifest
 	if materializer != nil {
@@ -841,6 +842,7 @@ func (e *Engine) persistCurrentStateLocked() error {
 
 func (e *Engine) persistCurrentStateLockedWithReserve(reserve bool) error {
 	state := cloneState(e.currentStateLocked())
+	pruneUnreferencedSegments(state)
 	if reserve {
 		if err := e.reserveLocalDiskLocked(estimatedStateBytes(state)); err != nil {
 			return err
@@ -959,6 +961,9 @@ func (e *Engine) applyLink(record walRecord) error {
 }
 
 func (e *Engine) applyWrite(record walRecord) error {
+	if e.usesExtentLayoutLocked() {
+		return e.applyExtentWrite(record)
+	}
 	node, err := e.fileNodeLocked(record.Inode)
 	if err != nil {
 		return err
@@ -1041,6 +1046,9 @@ func (e *Engine) applySetOwner(record walRecord) error {
 }
 
 func (e *Engine) applyTruncate(record walRecord) error {
+	if e.usesExtentLayoutLocked() {
+		return e.applyExtentTruncate(record)
+	}
 	node, err := e.fileNodeLocked(record.Inode)
 	if err != nil {
 		return err
@@ -1097,6 +1105,13 @@ func (e *Engine) needsMaterializationLocked() bool {
 			return true
 		}
 	}
+	for _, extents := range e.coldFiles {
+		for _, extent := range extents {
+			if segment := e.segments[extent.SegmentID]; isInlineSegment(segment) {
+				return true
+			}
+		}
+	}
 	return false
 }
 
@@ -1136,6 +1151,7 @@ func (e *Engine) exportStateLocked() (*SnapshotState, error) {
 func (e *Engine) materializeStateLocked() (*SnapshotState, error) {
 	state := cloneState(e.currentStateLocked())
 	if len(state.ColdFiles) == 0 {
+		pruneUnreferencedSegments(state)
 		return state, nil
 	}
 	for inode := range state.ColdFiles {
@@ -1143,6 +1159,7 @@ func (e *Engine) materializeStateLocked() (*SnapshotState, error) {
 			delete(state.ColdFiles, inode)
 		}
 	}
+	pruneUnreferencedSegments(state)
 	return state, nil
 }
 

--- a/storage-proxy/pkg/s0fs/engine_extents.go
+++ b/storage-proxy/pkg/s0fs/engine_extents.go
@@ -1,0 +1,137 @@
+package s0fs
+
+import (
+	"fmt"
+	"slices"
+	"time"
+)
+
+func (e *Engine) usesExtentLayoutLocked() bool {
+	return e != nil && e.materializer != nil && e.materializer.Enabled()
+}
+
+func (e *Engine) applyExtentWrite(record walRecord) error {
+	node, err := e.fileNodeLocked(record.Inode)
+	if err != nil {
+		return err
+	}
+	oldSize := node.Size
+	extents, err := e.extentsForMutationLocked(record.Inode, record.Seq)
+	if err != nil {
+		return err
+	}
+
+	writeEnd := record.Offset + uint64(len(record.Data))
+	var next []FileExtent
+	next = append(next, sliceExtents(extents, 0, minUint64(record.Offset, oldSize))...)
+	if record.Offset > oldSize {
+		next = append(next, FileExtent{Length: record.Offset - oldSize})
+	}
+	if len(record.Data) > 0 {
+		next = append(next, e.appendInlineSegmentLocked(record.Seq, "write", record.Data))
+	}
+	if writeEnd < oldSize {
+		next = append(next, sliceExtents(extents, writeEnd, oldSize)...)
+	}
+
+	delete(e.data, record.Inode)
+	next = coalesceExtents(next)
+	if len(next) == 0 {
+		delete(e.coldFiles, record.Inode)
+	} else {
+		e.coldFiles[record.Inode] = next
+	}
+	node.Size = maxUint64(oldSize, writeEnd)
+	now := time.Unix(0, record.TimeUnix).UTC()
+	node.Mtime = now
+	node.Ctime = now
+	return nil
+}
+
+func (e *Engine) applyExtentTruncate(record walRecord) error {
+	node, err := e.fileNodeLocked(record.Inode)
+	if err != nil {
+		return err
+	}
+	oldSize := node.Size
+	target := record.Offset
+	if target == 0 {
+		delete(e.data, record.Inode)
+		delete(e.coldFiles, record.Inode)
+		node.Size = 0
+		now := time.Unix(0, record.TimeUnix).UTC()
+		node.Mtime = now
+		node.Ctime = now
+		return nil
+	}
+
+	extents, err := e.extentsForMutationLocked(record.Inode, record.Seq)
+	if err != nil {
+		return err
+	}
+	var next []FileExtent
+	switch {
+	case target < oldSize:
+		next = sliceExtents(extents, 0, target)
+	case target > oldSize:
+		next = append(cloneExtents(extents), FileExtent{Length: target - oldSize})
+	default:
+		next = cloneExtents(extents)
+	}
+	delete(e.data, record.Inode)
+	next = coalesceExtents(next)
+	if len(next) == 0 {
+		delete(e.coldFiles, record.Inode)
+	} else {
+		e.coldFiles[record.Inode] = next
+	}
+	node.Size = target
+	now := time.Unix(0, record.TimeUnix).UTC()
+	node.Mtime = now
+	node.Ctime = now
+	return nil
+}
+
+func (e *Engine) extentsForMutationLocked(inode uint64, seq uint64) ([]FileExtent, error) {
+	if payload, ok := e.data[inode]; ok {
+		delete(e.data, inode)
+		if len(payload) == 0 {
+			if node := e.nodes[inode]; node != nil && node.Size > 0 {
+				return []FileExtent{{Length: node.Size}}, nil
+			}
+			return nil, nil
+		}
+		return []FileExtent{e.appendInlineSegmentLocked(seq, "base", payload)}, nil
+	}
+	if extents := e.coldFiles[inode]; len(extents) > 0 {
+		return cloneExtents(extents), nil
+	}
+	if node := e.nodes[inode]; node != nil && node.Size > 0 {
+		return []FileExtent{{Length: node.Size}}, nil
+	}
+	return nil, nil
+}
+
+func (e *Engine) appendInlineSegmentLocked(seq uint64, suffix string, payload []byte) FileExtent {
+	segmentID := fmt.Sprintf("inline-%020d-%s", seq, suffix)
+	if existing := e.segments[segmentID]; existing != nil {
+		for i := 1; ; i++ {
+			candidate := fmt.Sprintf("inline-%020d-%s-%d", seq, suffix, i)
+			if e.segments[candidate] == nil {
+				segmentID = candidate
+				break
+			}
+		}
+	}
+	e.segments[segmentID] = &Segment{
+		ID:         segmentID,
+		VolumeID:   e.volumeID,
+		Length:     uint64(len(payload)),
+		InlineData: slices.Clone(payload),
+	}
+	return FileExtent{
+		SegmentID: segmentID,
+		Offset:    0,
+		Length:    uint64(len(payload)),
+	}
+}

--- a/storage-proxy/pkg/s0fs/extents.go
+++ b/storage-proxy/pkg/s0fs/extents.go
@@ -1,0 +1,94 @@
+package s0fs
+
+import "fmt"
+
+func cloneExtents(extents []FileExtent) []FileExtent {
+	if len(extents) == 0 {
+		return nil
+	}
+	return append([]FileExtent(nil), extents...)
+}
+
+func extentsLength(extents []FileExtent) uint64 {
+	var size uint64
+	for _, extent := range extents {
+		size += extent.Length
+	}
+	return size
+}
+
+func sliceExtents(extents []FileExtent, start, end uint64) []FileExtent {
+	if end <= start || len(extents) == 0 {
+		return nil
+	}
+	var out []FileExtent
+	fileOffset := uint64(0)
+	for _, extent := range extents {
+		extentStart := fileOffset
+		extentEnd := fileOffset + extent.Length
+		fileOffset = extentEnd
+		if end <= extentStart || start >= extentEnd {
+			continue
+		}
+		readStart := maxUint64(start, extentStart)
+		readEnd := minUint64(end, extentEnd)
+		cloned := extent
+		if cloned.SegmentID != "" {
+			cloned.Offset += readStart - extentStart
+		} else {
+			cloned.Offset = 0
+		}
+		cloned.Length = readEnd - readStart
+		out = append(out, cloned)
+	}
+	return coalesceExtents(out)
+}
+
+func coalesceExtents(extents []FileExtent) []FileExtent {
+	if len(extents) == 0 {
+		return nil
+	}
+	out := make([]FileExtent, 0, len(extents))
+	for _, extent := range extents {
+		if extent.Length == 0 {
+			continue
+		}
+		if len(out) == 0 {
+			out = append(out, extent)
+			continue
+		}
+		last := &out[len(out)-1]
+		if last.SegmentID == "" && extent.SegmentID == "" {
+			last.Length += extent.Length
+			continue
+		}
+		if last.SegmentID == extent.SegmentID && last.Offset+last.Length == extent.Offset {
+			last.Length += extent.Length
+			continue
+		}
+		out = append(out, extent)
+	}
+	return out
+}
+
+func isInlineSegment(segment *Segment) bool {
+	return segment != nil && segment.Key == "" && len(segment.InlineData) > 0
+}
+
+func inlineSegmentRange(segment *Segment, off, length uint64) ([]byte, error) {
+	if !isInlineSegment(segment) {
+		return nil, fmt.Errorf("%w: segment %s is not inline", ErrInvalidInput, segmentIDForError(segment))
+	}
+	end := off + length
+	if end > uint64(len(segment.InlineData)) {
+		return nil, fmt.Errorf("%w: inline segment %s range exceeds payload", ErrInvalidInput, segment.ID)
+	}
+	return segment.InlineData[int(off):int(end)], nil
+}
+
+func segmentIDForError(segment *Segment) string {
+	if segment == nil {
+		return "<nil>"
+	}
+	return segment.ID
+}

--- a/storage-proxy/pkg/s0fs/extents.go
+++ b/storage-proxy/pkg/s0fs/extents.go
@@ -9,14 +9,6 @@ func cloneExtents(extents []FileExtent) []FileExtent {
 	return append([]FileExtent(nil), extents...)
 }
 
-func extentsLength(extents []FileExtent) uint64 {
-	var size uint64
-	for _, extent := range extents {
-		size += extent.Length
-	}
-	return size
-}
-
 func sliceExtents(extents []FileExtent, start, end uint64) []FileExtent {
 	if end <= start || len(extents) == 0 {
 		return nil

--- a/storage-proxy/pkg/s0fs/materializer.go
+++ b/storage-proxy/pkg/s0fs/materializer.go
@@ -23,7 +23,10 @@ const (
 	segmentDir        = "segments"
 )
 
-const defaultSegmentCacheMaxBytes int64 = 64 << 20
+const (
+	DefaultSegmentTargetSizeBytes uint64 = 4 << 20
+	defaultSegmentCacheMaxBytes   int64  = 64 << 20
+)
 
 var segmentCacheMaxBytes int64 = defaultSegmentCacheMaxBytes
 
@@ -45,6 +48,7 @@ type Materializer struct {
 	headStore            HeadStore
 	encryption           *EncryptionConfig
 	cache                *segmentCache
+	segmentTargetSize    uint64
 }
 
 func NewMaterializer(volumeID string, store objectstore.Store, headStore HeadStore, resolvers ...ObjectStoreResolver) *Materializer {
@@ -61,6 +65,7 @@ func NewMaterializer(volumeID string, store objectstore.Store, headStore HeadSto
 		objectStoreForVolume: resolver,
 		headStore:            headStore,
 		cache:                newSegmentCache(segmentCacheMaxBytes),
+		segmentTargetSize:    DefaultSegmentTargetSizeBytes,
 	}
 }
 
@@ -68,6 +73,16 @@ func (m *Materializer) SetEncryption(encryption *EncryptionConfig) {
 	if m != nil {
 		m.encryption = encryption
 	}
+}
+
+func (m *Materializer) SetSegmentTargetSize(size uint64) {
+	if m == nil {
+		return
+	}
+	if size == 0 {
+		size = DefaultSegmentTargetSizeBytes
+	}
+	m.segmentTargetSize = size
 }
 
 func (m *Materializer) Enabled() bool {
@@ -100,20 +115,7 @@ func (m *Materializer) Materialize(ctx context.Context, state *SnapshotState, ex
 		return nil, fmt.Errorf("%w: manifest seq %d must advance beyond %d", ErrCommittedHeadConflict, nextSeq, expectedManifestSeq)
 	}
 
-	segment, fileExtents, err := buildSegment(nextSeq, m.volumeID, inline)
-	if err != nil {
-		return nil, err
-	}
-
-	storedSegmentPayload, segmentEncryption, err := m.encryption.encryptSegment(m.volumeID, segment)
-	if err != nil {
-		return nil, err
-	}
-	if segment != nil {
-		segment.Encryption = segmentEncryption
-	}
-
-	manifestState, err := buildManifestState(inline, segment, fileExtents)
+	manifestState, segments, err := buildMaterializedState(nextSeq, m.volumeID, inline, m.segmentTargetSize)
 	if err != nil {
 		return nil, err
 	}
@@ -126,7 +128,15 @@ func (m *Materializer) Materialize(ctx context.Context, state *SnapshotState, ex
 		State:         manifestState,
 	}
 
-	if len(segment.Payload) > 0 {
+	for _, segment := range segments {
+		storedSegmentPayload, segmentEncryption, err := m.encryption.encryptSegment(m.volumeID, segment)
+		if err != nil {
+			return nil, err
+		}
+		segment.Encryption = segmentEncryption
+		if meta := manifest.State.Segments[segment.ID]; meta != nil {
+			meta.Encryption = segmentEncryption
+		}
 		if err := m.putBytes(ctx, segment.Key, storedSegmentPayload); err != nil {
 			return nil, err
 		}
@@ -274,49 +284,7 @@ type materializedSegment struct {
 	Encryption *SegmentEncryption
 }
 
-func buildSegment(manifestSeq uint64, volumeID string, state *SnapshotState) (*materializedSegment, map[uint64][]FileExtent, error) {
-	segmentID := fmt.Sprintf("%020d-0", manifestSeq)
-	segmentKey := fmt.Sprintf("%s/%s.bin", segmentDir, segmentID)
-
-	inodes := make([]uint64, 0, len(state.Data))
-	for inode, payload := range state.Data {
-		if len(payload) == 0 {
-			continue
-		}
-		if node := state.Nodes[inode]; node == nil || node.Type == TypeDirectory {
-			continue
-		}
-		inodes = append(inodes, inode)
-	}
-	sort.Slice(inodes, func(i, j int) bool { return inodes[i] < inodes[j] })
-
-	var buf bytes.Buffer
-	files := make(map[uint64][]FileExtent, len(inodes))
-	for _, inode := range inodes {
-		payload := state.Data[inode]
-		offset := uint64(buf.Len())
-		if _, err := buf.Write(payload); err != nil {
-			return nil, nil, fmt.Errorf("write segment buffer: %w", err)
-		}
-		files[inode] = []FileExtent{{
-			SegmentID: segmentID,
-			Offset:    offset,
-			Length:    uint64(len(payload)),
-		}}
-	}
-
-	sum := sha256.Sum256(buf.Bytes())
-	segment := &materializedSegment{
-		ID:       segmentID,
-		VolumeID: volumeID,
-		Key:      segmentKey,
-		Payload:  buf.Bytes(),
-		SHA256:   hex.EncodeToString(sum[:]),
-	}
-	return segment, files, nil
-}
-
-func buildManifestState(state *SnapshotState, segment *materializedSegment, hotFiles map[uint64][]FileExtent) (*SnapshotState, error) {
+func buildMaterializedState(manifestSeq uint64, volumeID string, state *SnapshotState, targetSize uint64) (*SnapshotState, []*materializedSegment, error) {
 	manifestState := &SnapshotState{
 		NextSeq:   state.NextSeq,
 		NextInode: state.NextInode,
@@ -327,45 +295,179 @@ func buildManifestState(state *SnapshotState, segment *materializedSegment, hotF
 		Segments:  make(map[string]*Segment),
 	}
 
-	hotInodes := make(map[uint64]struct{}, len(state.Data))
+	builder := newSegmentBuilder(manifestSeq, volumeID, targetSize)
+	inodes := make([]uint64, 0, len(state.Data)+len(state.ColdFiles))
+	seen := make(map[uint64]struct{}, len(state.Data)+len(state.ColdFiles))
 	for inode := range state.Data {
-		hotInodes[inode] = struct{}{}
+		seen[inode] = struct{}{}
+		inodes = append(inodes, inode)
 	}
-
 	for inode, extents := range state.ColdFiles {
-		if _, hot := hotInodes[inode]; hot {
+		if len(extents) == 0 {
 			continue
 		}
-		if state.Nodes[inode] == nil {
+		if _, ok := seen[inode]; !ok {
+			seen[inode] = struct{}{}
+			inodes = append(inodes, inode)
+		}
+	}
+	sort.Slice(inodes, func(i, j int) bool { return inodes[i] < inodes[j] })
+
+	for _, inode := range inodes {
+		node := state.Nodes[inode]
+		if node == nil || node.Type == TypeDirectory {
 			continue
 		}
-		manifestState.ColdFiles[inode] = append([]FileExtent(nil), extents...)
-		for _, extent := range extents {
-			existing := state.Segments[extent.SegmentID]
-			if existing == nil {
-				return nil, fmt.Errorf("%w: missing retained segment %s", ErrInvalidInput, extent.SegmentID)
+		var fileExtents []FileExtent
+		if payload, ok := state.Data[inode]; ok && len(payload) > 0 {
+			extents, err := builder.append(payload)
+			if err != nil {
+				return nil, nil, err
 			}
-			manifestState.Segments[extent.SegmentID] = cloneSegment(existing)
+			fileExtents = append(fileExtents, extents...)
+		} else {
+			extents, err := materializeFileExtents(builder, state, manifestState, inode)
+			if err != nil {
+				return nil, nil, err
+			}
+			fileExtents = append(fileExtents, extents...)
+		}
+		fileExtents = coalesceExtents(fileExtents)
+		if len(fileExtents) > 0 {
+			manifestState.ColdFiles[inode] = fileExtents
 		}
 	}
 
-	for inode, extents := range hotFiles {
-		if state.Nodes[inode] == nil {
+	segments := builder.finish()
+	for _, segment := range segments {
+		manifestState.Segments[segment.ID] = &Segment{
+			ID:       segment.ID,
+			VolumeID: segment.VolumeID,
+			Key:      segment.Key,
+			Length:   uint64(len(segment.Payload)),
+			SHA256:   segment.SHA256,
+		}
+	}
+	return manifestState, segments, nil
+}
+
+func buildSegment(manifestSeq uint64, volumeID string, state *SnapshotState) (*materializedSegment, map[uint64][]FileExtent, error) {
+	manifestState, segments, err := buildMaterializedState(manifestSeq, volumeID, state, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+	segment := &materializedSegment{
+		ID:       fmt.Sprintf("%020d-0", manifestSeq),
+		VolumeID: volumeID,
+		Key:      fmt.Sprintf("%s/%020d-0.bin", segmentDir, manifestSeq),
+	}
+	if len(segments) > 0 {
+		segment = segments[0]
+	}
+	return segment, manifestState.ColdFiles, nil
+}
+
+func materializeFileExtents(builder *segmentBuilder, state, manifestState *SnapshotState, inode uint64) ([]FileExtent, error) {
+	var out []FileExtent
+	for _, extent := range state.ColdFiles[inode] {
+		if extent.Length == 0 {
 			continue
 		}
-		manifestState.ColdFiles[inode] = append([]FileExtent(nil), extents...)
-	}
-	if segment != nil && len(segment.Payload) > 0 {
-		manifestState.Segments[segment.ID] = &Segment{
-			ID:         segment.ID,
-			VolumeID:   segment.VolumeID,
-			Key:        segment.Key,
-			Length:     uint64(len(segment.Payload)),
-			SHA256:     segment.SHA256,
-			Encryption: segment.Encryption,
+		if extent.SegmentID == "" {
+			out = append(out, extent)
+			continue
 		}
+		existing := state.Segments[extent.SegmentID]
+		if existing == nil {
+			return nil, fmt.Errorf("%w: missing retained segment %s", ErrInvalidInput, extent.SegmentID)
+		}
+		if isInlineSegment(existing) {
+			payload, err := inlineSegmentRange(existing, extent.Offset, extent.Length)
+			if err != nil {
+				return nil, err
+			}
+			extents, err := builder.append(payload)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, extents...)
+			continue
+		}
+		out = append(out, extent)
+		manifestState.Segments[extent.SegmentID] = cloneSegment(existing)
 	}
-	return manifestState, nil
+	return out, nil
+}
+
+type segmentBuilder struct {
+	manifestSeq uint64
+	volumeID    string
+	targetSize  uint64
+	nextIndex   int
+	current     *materializedSegment
+	segments    []*materializedSegment
+}
+
+func newSegmentBuilder(manifestSeq uint64, volumeID string, targetSize uint64) *segmentBuilder {
+	if targetSize == 0 {
+		targetSize = DefaultSegmentTargetSizeBytes
+	}
+	return &segmentBuilder{
+		manifestSeq: manifestSeq,
+		volumeID:    volumeID,
+		targetSize:  targetSize,
+	}
+}
+
+func (b *segmentBuilder) append(payload []byte) ([]FileExtent, error) {
+	if len(payload) == 0 {
+		return nil, nil
+	}
+	var out []FileExtent
+	for len(payload) > 0 {
+		segment := b.ensureCurrent()
+		space := b.targetSize - uint64(len(segment.Payload))
+		if space == 0 {
+			b.current = nil
+			continue
+		}
+		n := len(payload)
+		if uint64(n) > space {
+			n = int(space)
+		}
+		offset := uint64(len(segment.Payload))
+		segment.Payload = append(segment.Payload, payload[:n]...)
+		out = append(out, FileExtent{
+			SegmentID: segment.ID,
+			Offset:    offset,
+			Length:    uint64(n),
+		})
+		payload = payload[n:]
+	}
+	return out, nil
+}
+
+func (b *segmentBuilder) ensureCurrent() *materializedSegment {
+	if b.current != nil && uint64(len(b.current.Payload)) < b.targetSize {
+		return b.current
+	}
+	segmentID := fmt.Sprintf("%020d-%d", b.manifestSeq, b.nextIndex)
+	b.nextIndex++
+	b.current = &materializedSegment{
+		ID:       segmentID,
+		VolumeID: b.volumeID,
+		Key:      fmt.Sprintf("%s/%s.bin", segmentDir, segmentID),
+	}
+	b.segments = append(b.segments, b.current)
+	return b.current
+}
+
+func (b *segmentBuilder) finish() []*materializedSegment {
+	for _, segment := range b.segments {
+		sum := sha256.Sum256(segment.Payload)
+		segment.SHA256 = hex.EncodeToString(sum[:])
+	}
+	return b.segments
 }
 
 func manifestKey(seq uint64) string {
@@ -591,5 +693,6 @@ func cloneSegment(segment *Segment) *Segment {
 		enc.NoncePrefix = append([]byte(nil), segment.Encryption.NoncePrefix...)
 		copy.Encryption = &enc
 	}
+	copy.InlineData = append([]byte(nil), segment.InlineData...)
 	return &copy
 }

--- a/storage-proxy/pkg/s0fs/materializer_test.go
+++ b/storage-proxy/pkg/s0fs/materializer_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1150,6 +1151,19 @@ func TestCreateSnapshotPreservesColdSegments(t *testing.T) {
 	if string(payload) != "snapshot-data" {
 		t.Fatalf("snapshot data = %q, want snapshot-data", payload)
 	}
+
+	localSnapshots, err := LoadLocalSnapshots(ctx, Config{
+		VolumeID:    "vol-snapshot",
+		WALPath:     walPath,
+		ObjectStore: store,
+		HeadStore:   heads,
+	})
+	if err != nil {
+		t.Fatalf("LoadLocalSnapshots() error = %v", err)
+	}
+	if len(localSnapshots) != 1 {
+		t.Fatalf("local snapshots = %d, want 1", len(localSnapshots))
+	}
 }
 
 func TestMaterializerGarbageCollectionPlanDeletesUnreferencedObjects(t *testing.T) {
@@ -1215,6 +1229,310 @@ func TestMaterializerGarbageCollectionPlanDeletesUnreferencedObjects(t *testing.
 	}
 	if _, err := store.Head("manifests/00000000000000000004.json"); err != nil {
 		t.Fatalf("current manifest missing after GC: %v", err)
+	}
+}
+
+func TestCompactionGarbageCollectionRetainsSnapshotSegments(t *testing.T) {
+	ctx := context.Background()
+	store := newPrefixedRecordingStore(t, "vol-compact-snapshot")
+	engine, err := Open(ctx, Config{
+		VolumeID:          "vol-compact-snapshot",
+		WALPath:           filepath.Join(t.TempDir(), "engine.wal"),
+		ObjectStore:       store,
+		HeadStore:         newMemoryHeadStore(),
+		SegmentTargetSize: 1024,
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer engine.Close()
+
+	node, err := engine.CreateFile(RootInode, "data.txt", 0o644)
+	if err != nil {
+		t.Fatalf("CreateFile() error = %v", err)
+	}
+	if _, err := engine.Write(node.Inode, 0, []byte("abcdef")); err != nil {
+		t.Fatalf("Write(initial) error = %v", err)
+	}
+	first, err := engine.SyncMaterialize(ctx)
+	if err != nil {
+		t.Fatalf("SyncMaterialize(initial) error = %v", err)
+	}
+	var oldSegmentKey string
+	for _, segment := range first.State.Segments {
+		oldSegmentKey = segment.Key
+	}
+	if oldSegmentKey == "" {
+		t.Fatal("initial materialization did not create a segment")
+	}
+
+	snapshotState, err := engine.CreateSnapshot("snap-before-overwrite")
+	if err != nil {
+		t.Fatalf("CreateSnapshot() error = %v", err)
+	}
+	if _, err := engine.Write(node.Inode, 1, []byte("Z")); err != nil {
+		t.Fatalf("Write(overwrite) error = %v", err)
+	}
+	if _, err := engine.SyncMaterialize(ctx); err != nil {
+		t.Fatalf("SyncMaterialize(overwrite) error = %v", err)
+	}
+	compacted, _, err := engine.Compact(ctx, CompactionOptions{Force: true})
+	if err != nil {
+		t.Fatalf("Compact() error = %v", err)
+	}
+
+	latest, err := engine.Read(node.Inode, 0, 6)
+	if err != nil {
+		t.Fatalf("Read(latest) error = %v", err)
+	}
+	if string(latest) != "aZcdef" {
+		t.Fatalf("latest payload = %q, want aZcdef", latest)
+	}
+	snapshotPayload, err := NewSnapshotReader(snapshotState, engine.materializer).Read(node.Inode, 0, 6)
+	if err != nil {
+		t.Fatalf("SnapshotReader.Read() error = %v", err)
+	}
+	if string(snapshotPayload) != "abcdef" {
+		t.Fatalf("snapshot payload = %q, want abcdef", snapshotPayload)
+	}
+
+	retainedManifests := map[string]struct{}{manifestKey(compacted.ManifestSeq): {}}
+	withSnapshot, err := engine.materializer.PlanGarbageCollection(ctx, []*SnapshotState{compacted.State, snapshotState}, retainedManifests)
+	if err != nil {
+		t.Fatalf("PlanGarbageCollection(with snapshot) error = %v", err)
+	}
+	for _, key := range withSnapshot.Segments {
+		if key == oldSegmentKey {
+			t.Fatalf("old snapshot segment %s was planned for deletion", oldSegmentKey)
+		}
+	}
+	withoutSnapshot, err := engine.materializer.PlanGarbageCollection(ctx, []*SnapshotState{compacted.State}, retainedManifests)
+	if err != nil {
+		t.Fatalf("PlanGarbageCollection(without snapshot) error = %v", err)
+	}
+	if !slices.Contains(withoutSnapshot.Segments, oldSegmentKey) {
+		t.Fatalf("old segment %s was not collectible without snapshot retention: %v", oldSegmentKey, withoutSnapshot.Segments)
+	}
+}
+
+func TestExtentWriteDoesNotRewriteUnmodifiedColdData(t *testing.T) {
+	ctx := context.Background()
+	store := newPrefixedRecordingStore(t, "vol-extent-overwrite")
+	heads := newMemoryHeadStore()
+	engine, err := Open(ctx, Config{
+		VolumeID:          "vol-extent-overwrite",
+		WALPath:           filepath.Join(t.TempDir(), "engine.wal"),
+		ObjectStore:       store,
+		HeadStore:         heads,
+		SegmentTargetSize: 1024,
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer engine.Close()
+
+	a, err := engine.CreateFile(RootInode, "a.txt", 0o644)
+	if err != nil {
+		t.Fatalf("CreateFile(a) error = %v", err)
+	}
+	b, err := engine.CreateFile(RootInode, "b.txt", 0o644)
+	if err != nil {
+		t.Fatalf("CreateFile(b) error = %v", err)
+	}
+	aPayload := bytes.Repeat([]byte("a"), 64)
+	bPayload := bytes.Repeat([]byte("b"), 64)
+	if _, err := engine.Write(a.Inode, 0, aPayload); err != nil {
+		t.Fatalf("Write(a) error = %v", err)
+	}
+	if _, err := engine.Write(b.Inode, 0, bPayload); err != nil {
+		t.Fatalf("Write(b) error = %v", err)
+	}
+	first, err := engine.SyncMaterialize(ctx)
+	if err != nil {
+		t.Fatalf("SyncMaterialize(first) error = %v", err)
+	}
+	if len(first.State.Segments) != 1 {
+		t.Fatalf("first segment count = %d, want 1", len(first.State.Segments))
+	}
+
+	store.resetCalls()
+	if _, err := engine.Write(a.Inode, 10, []byte("Z")); err != nil {
+		t.Fatalf("overwrite a byte: %v", err)
+	}
+	second, err := engine.SyncMaterialize(ctx)
+	if err != nil {
+		t.Fatalf("SyncMaterialize(second) error = %v", err)
+	}
+	if gets := store.calls(); len(gets) != 0 {
+		t.Fatalf("overwrite materialization read cold segments = %+v, want none", gets)
+	}
+	if len(second.State.Segments) != 2 {
+		t.Fatalf("second segment count = %d, want old segment plus 1-byte segment", len(second.State.Segments))
+	}
+	if got, want := StateStorageBytes(second.State), int64(len(aPayload)+len(bPayload)+1); got != want {
+		t.Fatalf("StateStorageBytes() = %d, want %d", got, want)
+	}
+	updated, err := engine.Read(a.Inode, 0, uint64(len(aPayload)))
+	if err != nil {
+		t.Fatalf("Read(a) error = %v", err)
+	}
+	wantPayload := bytes.Clone(aPayload)
+	wantPayload[10] = 'Z'
+	if !bytes.Equal(updated, wantPayload) {
+		t.Fatalf("updated payload mismatch")
+	}
+	bRead, err := engine.Read(b.Inode, 0, uint64(len(bPayload)))
+	if err != nil {
+		t.Fatalf("Read(b) error = %v", err)
+	}
+	if !bytes.Equal(bRead, bPayload) {
+		t.Fatalf("b payload changed")
+	}
+}
+
+func TestMaterializerSplitsDirtyDataAtSegmentTargetSize(t *testing.T) {
+	ctx := context.Background()
+	store := newPrefixedRecordingStore(t, "vol-target-size")
+	engine, err := Open(ctx, Config{
+		VolumeID:          "vol-target-size",
+		WALPath:           filepath.Join(t.TempDir(), "engine.wal"),
+		ObjectStore:       store,
+		HeadStore:         newMemoryHeadStore(),
+		SegmentTargetSize: 4,
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer engine.Close()
+
+	node, err := engine.CreateFile(RootInode, "large.txt", 0o644)
+	if err != nil {
+		t.Fatalf("CreateFile() error = %v", err)
+	}
+	if _, err := engine.Write(node.Inode, 0, []byte("0123456789")); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	manifest, err := engine.SyncMaterialize(ctx)
+	if err != nil {
+		t.Fatalf("SyncMaterialize() error = %v", err)
+	}
+	var lengths []uint64
+	for _, segment := range manifest.State.Segments {
+		lengths = append(lengths, segment.Length)
+	}
+	slices.Sort(lengths)
+	if got, want := lengths, []uint64{2, 4, 4}; !slices.Equal(got, want) {
+		t.Fatalf("segment lengths = %v, want %v", got, want)
+	}
+}
+
+func TestSparseExtentWriteReadsZerosWithoutStoringHoleBytes(t *testing.T) {
+	ctx := context.Background()
+	store := newPrefixedRecordingStore(t, "vol-sparse")
+	engine, err := Open(ctx, Config{
+		VolumeID:    "vol-sparse",
+		WALPath:     filepath.Join(t.TempDir(), "engine.wal"),
+		ObjectStore: store,
+		HeadStore:   newMemoryHeadStore(),
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer engine.Close()
+
+	node, err := engine.CreateFile(RootInode, "sparse.txt", 0o644)
+	if err != nil {
+		t.Fatalf("CreateFile() error = %v", err)
+	}
+	if _, err := engine.Write(node.Inode, 4, []byte("x")); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	payload, err := engine.Read(node.Inode, 0, 5)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if got, want := payload, []byte{0, 0, 0, 0, 'x'}; !bytes.Equal(got, want) {
+		t.Fatalf("payload = %v, want %v", got, want)
+	}
+	manifest, err := engine.SyncMaterialize(ctx)
+	if err != nil {
+		t.Fatalf("SyncMaterialize() error = %v", err)
+	}
+	if got, want := StateStorageBytes(manifest.State), int64(1); got != want {
+		t.Fatalf("StateStorageBytes() = %d, want %d", got, want)
+	}
+}
+
+func TestCompactionRewritesLiveRangesFromFragmentedSegments(t *testing.T) {
+	ctx := context.Background()
+	store := newPrefixedRecordingStore(t, "vol-compact-fragment")
+	engine, err := Open(ctx, Config{
+		VolumeID:          "vol-compact-fragment",
+		WALPath:           filepath.Join(t.TempDir(), "engine.wal"),
+		ObjectStore:       store,
+		HeadStore:         newMemoryHeadStore(),
+		SegmentTargetSize: 1024,
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer engine.Close()
+
+	a, err := engine.CreateFile(RootInode, "a.txt", 0o644)
+	if err != nil {
+		t.Fatalf("CreateFile(a) error = %v", err)
+	}
+	b, err := engine.CreateFile(RootInode, "b.txt", 0o644)
+	if err != nil {
+		t.Fatalf("CreateFile(b) error = %v", err)
+	}
+	aPayload := bytes.Repeat([]byte("a"), 64)
+	bPayload := bytes.Repeat([]byte("b"), 64)
+	if _, err := engine.Write(a.Inode, 0, aPayload); err != nil {
+		t.Fatalf("Write(a) error = %v", err)
+	}
+	if _, err := engine.Write(b.Inode, 0, bPayload); err != nil {
+		t.Fatalf("Write(b) error = %v", err)
+	}
+	first, err := engine.SyncMaterialize(ctx)
+	if err != nil {
+		t.Fatalf("SyncMaterialize(first) error = %v", err)
+	}
+	var oldSegmentID string
+	for id := range first.State.Segments {
+		oldSegmentID = id
+	}
+	if _, err := engine.Write(a.Inode, 10, []byte("Z")); err != nil {
+		t.Fatalf("overwrite a byte: %v", err)
+	}
+	if _, err := engine.SyncMaterialize(ctx); err != nil {
+		t.Fatalf("SyncMaterialize(fragmented) error = %v", err)
+	}
+
+	manifest, result, err := engine.Compact(ctx, CompactionOptions{
+		MinDeadRatio:    0.001,
+		MinReclaimBytes: 1,
+	})
+	if err != nil {
+		t.Fatalf("Compact() error = %v", err)
+	}
+	if result == nil || !slices.Equal(result.CompactedSegments, []string{oldSegmentID}) {
+		t.Fatalf("compacted segments = %+v, want %s", result, oldSegmentID)
+	}
+	if _, ok := manifest.State.Segments[oldSegmentID]; ok {
+		t.Fatalf("old segment %s is still referenced after compaction", oldSegmentID)
+	}
+	if got, want := StateStorageBytes(manifest.State), int64(len(aPayload)+len(bPayload)); got != want {
+		t.Fatalf("StateStorageBytes() = %d, want %d", got, want)
+	}
+	updated, err := engine.Read(a.Inode, 0, uint64(len(aPayload)))
+	if err != nil {
+		t.Fatalf("Read(a) error = %v", err)
+	}
+	wantPayload := bytes.Clone(aPayload)
+	wantPayload[10] = 'Z'
+	if !bytes.Equal(updated, wantPayload) {
+		t.Fatalf("compacted a payload mismatch")
 	}
 }
 

--- a/storage-proxy/pkg/s0fs/snapshot.go
+++ b/storage-proxy/pkg/s0fs/snapshot.go
@@ -3,6 +3,7 @@ package s0fs
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -17,6 +18,41 @@ func LoadSnapshot(_ context.Context, cfg Config, snapshotID string) (*SnapshotSt
 		return nil, fmt.Errorf("%w: wal path is required", ErrInvalidInput)
 	}
 	return loadSnapshotState(snapshotFilePath(cfg.WALPath, snapshotID), cfg.VolumeID, "snapshot:"+snapshotID, cfg.Encryption)
+}
+
+func LoadLocalSnapshots(ctx context.Context, cfg Config) ([]*SnapshotState, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if cfg.WALPath == "" {
+		return nil, fmt.Errorf("%w: wal path is required", ErrInvalidInput)
+	}
+	entries, err := os.ReadDir(filepath.Join(filepath.Dir(cfg.WALPath), "snapshots"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read local snapshots: %w", err)
+	}
+	states := make([]*SnapshotState, 0, len(entries))
+	for _, entry := range entries {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		snapshotID := strings.TrimSuffix(entry.Name(), ".json")
+		state, err := LoadSnapshot(ctx, cfg, snapshotID)
+		if err != nil {
+			if errors.Is(err, ErrSnapshotNotFound) {
+				continue
+			}
+			return nil, err
+		}
+		states = append(states, state)
+	}
+	return states, nil
 }
 
 func snapshotFilePath(walPath, snapshotID string) string {
@@ -157,6 +193,9 @@ func PrepareForkState(state *SnapshotState, sourceVolumeID string) (*SnapshotSta
 			continue
 		}
 		for _, extent := range extents {
+			if extent.SegmentID == "" {
+				continue
+			}
 			segment := clone.Segments[extent.SegmentID]
 			if segment == nil {
 				return nil, fmt.Errorf("%w: missing source segment %s", ErrInvalidInput, extent.SegmentID)
@@ -291,9 +330,6 @@ func (s *SnapshotState) Read(inode uint64, offset uint64, size uint64) ([]byte, 
 }
 
 func readColdRange(materializer *Materializer, extents []FileExtent, segments map[string]*Segment, offset uint64, size uint64) ([]byte, error) {
-	if materializer == nil || !materializer.Enabled() {
-		return nil, fmt.Errorf("%w: cold data resolver is not configured", ErrInvalidInput)
-	}
 	if len(extents) == 0 {
 		return nil, nil
 	}
@@ -313,12 +349,35 @@ func readColdRange(materializer *Materializer, extents []FileExtent, segments ma
 
 		readStart := maxUint64(rangeStart, extentStart)
 		readEnd := minUint64(rangeEnd, extentEnd)
+		if extent.SegmentID == "" {
+			out = append(out, make([]byte, readEnd-readStart)...)
+			remaining -= readEnd - readStart
+			if remaining == 0 {
+				break
+			}
+			fileOffset = extentEnd
+			continue
+		}
 		segment := segments[extent.SegmentID]
 		if segment == nil {
 			return nil, fmt.Errorf("%w: missing segment %s", ErrInvalidInput, extent.SegmentID)
 		}
 		segmentOffset := extent.Offset + (readStart - extentStart)
-		chunk, err := materializer.ReadSegmentRange(segment, int64(segmentOffset), int64(readEnd-readStart))
+		var (
+			chunk []byte
+			err   error
+		)
+		if isInlineSegment(segment) {
+			chunk, err = inlineSegmentRange(segment, segmentOffset, readEnd-readStart)
+			if err == nil {
+				chunk = slices.Clone(chunk)
+			}
+		} else {
+			if materializer == nil || !materializer.Enabled() {
+				return nil, fmt.Errorf("%w: cold data resolver is not configured", ErrInvalidInput)
+			}
+			chunk, err = materializer.ReadSegmentRange(segment, int64(segmentOffset), int64(readEnd-readStart))
+		}
 		if err != nil {
 			return nil, fmt.Errorf("read cold segment %s: %w", segment.Key, err)
 		}

--- a/storage-proxy/pkg/s0fs/storage_size.go
+++ b/storage-proxy/pkg/s0fs/storage_size.go
@@ -14,7 +14,6 @@ func StateStorageBytes(state *SnapshotState) int64 {
 	for _, extents := range state.ColdFiles {
 		for _, extent := range extents {
 			if extent.SegmentID == "" {
-				size += int64(extent.Length)
 				continue
 			}
 			if _, seen := seenSegments[extent.SegmentID]; seen {

--- a/storage-proxy/pkg/s0fs/types.go
+++ b/storage-proxy/pkg/s0fs/types.go
@@ -24,6 +24,7 @@ type Config struct {
 	HeadStore            HeadStore
 	Encryption           *EncryptionConfig
 	MaterializeInterval  time.Duration
+	SegmentTargetSize    uint64
 	WALSyncHook          func()
 	LocalDiskGuard       *LocalDiskGuard
 }
@@ -53,6 +54,7 @@ type Segment struct {
 	Length     uint64             `json:"length"`
 	SHA256     string             `json:"sha256,omitempty"`
 	Encryption *SegmentEncryption `json:"encryption,omitempty"`
+	InlineData []byte             `json:"inline_data,omitempty"`
 }
 
 type Node struct {

--- a/storage-proxy/pkg/snapshot/s0fs.go
+++ b/storage-proxy/pkg/snapshot/s0fs.go
@@ -86,6 +86,11 @@ func (m *Manager) s0fsConfig(teamID, volumeID string) (s0fs.Config, error) {
 		return s0fs.Config{}, err
 	}
 	cfg.Encryption = encryption
+	segmentTargetSize, err := volume.S0FSSegmentTargetSize(m.config)
+	if err != nil {
+		return s0fs.Config{}, err
+	}
+	cfg.SegmentTargetSize = segmentTargetSize
 	store, err := m.s0fsObjectStore(teamID, volumeID)
 	if err != nil {
 		return s0fs.Config{}, err
@@ -824,7 +829,7 @@ func (m *Manager) garbageCollectS0FSVolumeObjects(ctx context.Context, volumeID,
 		state, err := s0fs.LoadSnapshot(ctx, cfg, snapshot.ID)
 		if err != nil {
 			if errors.Is(err, s0fs.ErrSnapshotNotFound) {
-				continue
+				return nil, nil
 			}
 			return nil, err
 		}

--- a/storage-proxy/pkg/volume/access_mode.go
+++ b/storage-proxy/pkg/volume/access_mode.go
@@ -60,6 +60,10 @@ func ParseAccessMode(value string) (AccessMode, bool) {
 	}
 }
 
+func S0FSBackgroundCompactionEnabled(accessMode AccessMode) bool {
+	return NormalizeAccessMode(string(accessMode)) == AccessModeRWO
+}
+
 func NormalizeOwnerKind(value string) string {
 	switch strings.TrimSpace(value) {
 	case OwnerKindCtld:

--- a/storage-proxy/pkg/volume/backend_test.go
+++ b/storage-proxy/pkg/volume/backend_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/s0fs"
 	"github.com/sirupsen/logrus"
 )
 
@@ -102,6 +103,56 @@ func TestManagerMountUsesDefaultBackend(t *testing.T) {
 	}
 	if s0fsBackend.mountCalls != 1 {
 		t.Fatalf("s0fs backend mount calls = %d, want 1", s0fsBackend.mountCalls)
+	}
+}
+
+func TestS0FSSegmentTargetSizeDefaultsToFourMiB(t *testing.T) {
+	got, err := S0FSSegmentTargetSize(&config.StorageProxyConfig{})
+	if err != nil {
+		t.Fatalf("S0FSSegmentTargetSize() error = %v", err)
+	}
+	if got != s0fs.DefaultSegmentTargetSizeBytes {
+		t.Fatalf("segment target size = %d, want %d", got, s0fs.DefaultSegmentTargetSizeBytes)
+	}
+}
+
+func TestS0FSSegmentTargetSizeParsesConfig(t *testing.T) {
+	got, err := S0FSSegmentTargetSize(&config.StorageProxyConfig{S0FSSegmentTargetSize: "8Mi"})
+	if err != nil {
+		t.Fatalf("S0FSSegmentTargetSize() error = %v", err)
+	}
+	if want := uint64(8 << 20); got != want {
+		t.Fatalf("segment target size = %d, want %d", got, want)
+	}
+}
+
+func TestS0FSCompactionOptionsParseConfig(t *testing.T) {
+	opts, err := S0FSCompactionOptions(&config.StorageProxyConfig{
+		S0FSSegmentTargetSize:        "8Mi",
+		S0FSCompactionMinDeadRatio:   "0.25",
+		S0FSCompactionMinReclaimSize: "2Mi",
+	})
+	if err != nil {
+		t.Fatalf("S0FSCompactionOptions() error = %v", err)
+	}
+	if opts.SegmentTargetSize != 8<<20 || opts.MinDeadRatio != 0.25 || opts.MinReclaimBytes != 2<<20 {
+		t.Fatalf("unexpected compaction options: %+v", opts)
+	}
+}
+
+func TestS0FSBackgroundCompactionEnabledOnlyForRWO(t *testing.T) {
+	for _, tc := range []struct {
+		access AccessMode
+		want   bool
+	}{
+		{access: AccessModeRWO, want: true},
+		{access: AccessModeROX, want: false},
+		{access: AccessModeRWX, want: false},
+		{access: "", want: true},
+	} {
+		if got := S0FSBackgroundCompactionEnabled(tc.access); got != tc.want {
+			t.Fatalf("S0FSBackgroundCompactionEnabled(%q) = %v, want %v", tc.access, got, tc.want)
+		}
 	}
 }
 

--- a/storage-proxy/pkg/volume/s0fs_backend.go
+++ b/storage-proxy/pkg/volume/s0fs_backend.go
@@ -2,8 +2,10 @@ package volume
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -13,19 +15,25 @@ import (
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/objectstore"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/s0fs"
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 // S0FSBackend mounts the in-process active volume engine.
 type S0FSBackend struct {
 	logger    *logrus.Logger
 	config    *config.StorageProxyConfig
+	repo      *db.Repository
 	headStore s0fs.HeadStore
 }
 
 func NewS0FSBackend(logger *logrus.Logger, cfg *config.StorageProxyConfig, repo *db.Repository) *S0FSBackend {
+	if logger == nil {
+		logger = logrus.New()
+	}
 	return &S0FSBackend{
 		logger:    logger,
 		config:    cfg,
+		repo:      repo,
 		headStore: db.NewS0FSHeadStore(repo),
 	}
 }
@@ -46,10 +54,15 @@ func (b *S0FSBackend) MountVolume(ctx context.Context, req BackendMountRequest) 
 	if err != nil {
 		return nil, err
 	}
+	segmentTargetSize, err := S0FSSegmentTargetSize(b.config)
+	if err != nil {
+		return nil, err
+	}
 	engine, err := s0fs.Open(ctx, s0fs.Config{
-		VolumeID:    req.VolumeID,
-		WALPath:     filepath.Join(cacheDir, "engine.wal"),
-		ObjectStore: remoteStore,
+		VolumeID:          req.VolumeID,
+		WALPath:           filepath.Join(cacheDir, "engine.wal"),
+		ObjectStore:       remoteStore,
+		SegmentTargetSize: segmentTargetSize,
 		ObjectStoreForVolume: func(volumeID string) (objectstore.Store, error) {
 			return b.createObjectStorageForVolume(req, volumeID)
 		},
@@ -76,6 +89,83 @@ func (b *S0FSBackend) MountVolume(ctx context.Context, req BackendMountRequest) 
 	return volCtx, nil
 }
 
+func S0FSSegmentTargetSize(cfg *config.StorageProxyConfig) (uint64, error) {
+	value := ""
+	if cfg != nil {
+		value = strings.TrimSpace(cfg.S0FSSegmentTargetSize)
+	}
+	if value == "" {
+		return s0fs.DefaultSegmentTargetSizeBytes, nil
+	}
+	quantity, err := resource.ParseQuantity(value)
+	if err != nil {
+		return 0, fmt.Errorf("parse s0fs segment target size: %w", err)
+	}
+	bytes := quantity.Value()
+	if bytes <= 0 {
+		return 0, fmt.Errorf("s0fs segment target size must be > 0")
+	}
+	return uint64(bytes), nil
+}
+
+func S0FSCompactionInterval(cfg *config.StorageProxyConfig) (time.Duration, error) {
+	value := ""
+	if cfg != nil {
+		value = strings.TrimSpace(cfg.S0FSCompactionInterval)
+	}
+	if value == "" {
+		value = "1m"
+	}
+	switch strings.ToLower(value) {
+	case "0", "off", "disabled":
+		return 0, nil
+	}
+	interval, err := time.ParseDuration(value)
+	if err != nil {
+		return 0, fmt.Errorf("parse s0fs compaction interval: %w", err)
+	}
+	if interval < 0 {
+		return 0, fmt.Errorf("s0fs compaction interval must be >= 0")
+	}
+	return interval, nil
+}
+
+func S0FSCompactionOptions(cfg *config.StorageProxyConfig) (s0fs.CompactionOptions, error) {
+	targetSize, err := S0FSSegmentTargetSize(cfg)
+	if err != nil {
+		return s0fs.CompactionOptions{}, err
+	}
+	minDeadRatio := 0.5
+	minReclaimSize := "1Mi"
+	if cfg != nil {
+		if value := strings.TrimSpace(cfg.S0FSCompactionMinDeadRatio); value != "" {
+			parsed, err := strconv.ParseFloat(value, 64)
+			if err != nil {
+				return s0fs.CompactionOptions{}, fmt.Errorf("parse s0fs compaction min dead ratio: %w", err)
+			}
+			minDeadRatio = parsed
+		}
+		if strings.TrimSpace(cfg.S0FSCompactionMinReclaimSize) != "" {
+			minReclaimSize = strings.TrimSpace(cfg.S0FSCompactionMinReclaimSize)
+		}
+	}
+	if minDeadRatio < 0 || minDeadRatio > 1 {
+		return s0fs.CompactionOptions{}, fmt.Errorf("s0fs compaction min dead ratio must be between 0 and 1")
+	}
+	quantity, err := resource.ParseQuantity(minReclaimSize)
+	if err != nil {
+		return s0fs.CompactionOptions{}, fmt.Errorf("parse s0fs compaction min reclaim size: %w", err)
+	}
+	if quantity.Sign() < 0 {
+		return s0fs.CompactionOptions{}, fmt.Errorf("s0fs compaction min reclaim size must be >= 0")
+	}
+	return s0fs.CompactionOptions{
+		SegmentTargetSize: targetSize,
+		MinDeadRatio:      minDeadRatio,
+		MinReclaimBytes:   uint64(quantity.Value()),
+	}, nil
+}
+
 func (b *S0FSBackend) UnmountVolume(ctx context.Context, volCtx *VolumeContext) error {
 	if volCtx == nil || volCtx.S0FS == nil {
 		return nil
@@ -91,6 +181,7 @@ func (b *S0FSBackend) UnmountVolume(ctx context.Context, volCtx *VolumeContext) 
 		return fmt.Errorf("materialize s0fs volume: %w", err)
 	}
 	b.observeMaterializedManifest(ctx, volCtx, manifest)
+	b.garbageCollectRWO(ctx, volCtx, manifest)
 	return volCtx.S0FS.Close()
 }
 
@@ -133,6 +224,19 @@ func (b *S0FSBackend) startMaterializer(volCtx *VolumeContext) {
 	if volCtx == nil || volCtx.S0FS == nil {
 		return
 	}
+	compactionInterval, err := S0FSCompactionInterval(b.config)
+	if err != nil {
+		b.logger.WithError(err).WithField("volume_id", volCtx.VolumeID).Warn("Disabling s0fs compaction due to invalid configuration")
+		compactionInterval = 0
+	}
+	compactionOptions, err := S0FSCompactionOptions(b.config)
+	if err != nil {
+		b.logger.WithError(err).WithField("volume_id", volCtx.VolumeID).Warn("Disabling s0fs compaction due to invalid options")
+		compactionInterval = 0
+	}
+	if !S0FSBackgroundCompactionEnabled(volCtx.Access) {
+		compactionInterval = 0
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	volCtx.materializeCancel = cancel
@@ -142,6 +246,13 @@ func (b *S0FSBackend) startMaterializer(volCtx *VolumeContext) {
 		defer close(done)
 		ticker := time.NewTicker(2 * time.Second)
 		defer ticker.Stop()
+		var compactionTicker *time.Ticker
+		var compactionC <-chan time.Time
+		if compactionInterval > 0 {
+			compactionTicker = time.NewTicker(compactionInterval)
+			compactionC = compactionTicker.C
+			defer compactionTicker.Stop()
+		}
 		for {
 			select {
 			case <-ctx.Done():
@@ -153,6 +264,23 @@ func (b *S0FSBackend) startMaterializer(volCtx *VolumeContext) {
 					continue
 				}
 				b.observeMaterializedManifest(ctx, volCtx, manifest)
+				b.garbageCollectRWO(ctx, volCtx, manifest)
+			case <-compactionC:
+				manifest, result, err := volCtx.S0FS.Compact(ctx, compactionOptions)
+				if err != nil {
+					b.logger.WithError(err).WithField("volume_id", volCtx.VolumeID).Warn("Failed to compact s0fs volume")
+					continue
+				}
+				if result != nil && len(result.CompactedSegments) > 0 {
+					b.logger.WithFields(logrus.Fields{
+						"volume_id":         volCtx.VolumeID,
+						"segments":          len(result.CompactedSegments),
+						"rewritten_bytes":   result.RewrittenBytes,
+						"reclaimable_bytes": result.ReclaimableBytes,
+					}).Info("Compacted s0fs volume")
+				}
+				b.observeMaterializedManifest(ctx, volCtx, manifest)
+				b.garbageCollectRWO(ctx, volCtx, manifest)
 			}
 		}
 	}()
@@ -165,4 +293,139 @@ func (b *S0FSBackend) observeMaterializedManifest(ctx context.Context, volCtx *V
 	if err := volCtx.Observer.ObserveVolumeState(ctx, volCtx.VolumeID, volCtx.TeamID, manifest.State, time.Now().UTC()); err != nil {
 		b.logger.WithError(err).WithField("volume_id", volCtx.VolumeID).Warn("Failed to record volume storage observation")
 	}
+}
+
+func (b *S0FSBackend) garbageCollectRWO(ctx context.Context, volCtx *VolumeContext, manifest *s0fs.Manifest) {
+	if b == nil || b.repo == nil || volCtx == nil || manifest == nil || manifest.State == nil {
+		return
+	}
+	if volCtx.Access != AccessModeRWO {
+		return
+	}
+	result, err := b.garbageCollectVolumeObjects(ctx, volCtx, manifest)
+	if err != nil {
+		b.logger.WithError(err).WithField("volume_id", volCtx.VolumeID).Warn("Failed to garbage collect s0fs volume objects")
+		return
+	}
+	if result != nil && (len(result.DeletedSegments) > 0 || len(result.DeletedManifests) > 0) {
+		b.logger.WithFields(logrus.Fields{
+			"volume_id": volCtx.VolumeID,
+			"segments":  len(result.DeletedSegments),
+			"manifests": len(result.DeletedManifests),
+		}).Info("Garbage collected s0fs volume objects")
+	}
+}
+
+func (b *S0FSBackend) garbageCollectVolumeObjects(ctx context.Context, volCtx *VolumeContext, manifest *s0fs.Manifest) (*s0fs.GarbageCollectionResult, error) {
+	children, err := b.repo.ListSandboxVolumesBySource(ctx, volCtx.VolumeID)
+	if err != nil {
+		return nil, err
+	}
+	if len(children) > 0 {
+		return nil, nil
+	}
+	store, err := b.objectStoreForTeamVolume(volCtx.TeamID, volCtx.VolumeID)
+	if err != nil {
+		return nil, err
+	}
+	if store == nil {
+		return nil, nil
+	}
+	materializer := s0fs.NewMaterializer(volCtx.VolumeID, store, b.headStore, func(sourceVolumeID string) (objectstore.Store, error) {
+		return b.objectStoreForTeamVolume(volCtx.TeamID, sourceVolumeID)
+	})
+	if materializer == nil || !materializer.Enabled() {
+		return nil, nil
+	}
+	encryption, err := S0FSEncryptionConfig(b.config)
+	if err != nil {
+		return nil, err
+	}
+	materializer.SetEncryption(encryption)
+
+	headBefore, err := b.headStore.LoadCommittedHead(ctx, volCtx.VolumeID)
+	if err != nil && !errors.Is(err, s0fs.ErrCommittedHeadNotFound) {
+		return nil, err
+	}
+	retainedStates := []*s0fs.SnapshotState{manifest.State}
+	cfg := s0fs.Config{
+		VolumeID:    volCtx.VolumeID,
+		WALPath:     filepath.Join(volCtx.CacheDir, "engine.wal"),
+		ObjectStore: store,
+		HeadStore:   b.headStore,
+		Encryption:  encryption,
+	}
+	localSnapshots, err := s0fs.LoadLocalSnapshots(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	retainedStates = append(retainedStates, localSnapshots...)
+	snapshots, err := b.repo.ListSnapshotsByVolume(ctx, volCtx.VolumeID)
+	if err != nil {
+		return nil, err
+	}
+	for _, snapshot := range snapshots {
+		state, err := s0fs.LoadSnapshot(ctx, cfg, snapshot.ID)
+		if err != nil {
+			if errors.Is(err, s0fs.ErrSnapshotNotFound) {
+				return nil, nil
+			}
+			return nil, err
+		}
+		retainedStates = append(retainedStates, state)
+	}
+	retainedManifests := map[string]struct{}{
+		"manifests/latest.json": {},
+	}
+	if manifest.ManifestSeq > 0 {
+		retainedManifests[fmt.Sprintf("manifests/%020d.json", manifest.ManifestSeq)] = struct{}{}
+	}
+	if headBefore != nil && strings.TrimSpace(headBefore.ManifestKey) != "" {
+		retainedManifests[headBefore.ManifestKey] = struct{}{}
+	}
+	plan, err := materializer.PlanGarbageCollection(ctx, retainedStates, retainedManifests)
+	if err != nil {
+		return nil, err
+	}
+	if len(plan.Segments) == 0 && len(plan.Manifests) == 0 {
+		return &s0fs.GarbageCollectionResult{}, nil
+	}
+	headAfter, err := b.headStore.LoadCommittedHead(ctx, volCtx.VolumeID)
+	if err != nil && !errors.Is(err, s0fs.ErrCommittedHeadNotFound) {
+		return nil, err
+	}
+	if !sameHeadKey(headBefore, headAfter) {
+		return nil, nil
+	}
+	return plan.Apply(ctx)
+}
+
+func (b *S0FSBackend) objectStoreForTeamVolume(teamID, volumeID string) (objectstore.Store, error) {
+	if b == nil || b.config == nil || teamID == "" || volumeID == "" || strings.TrimSpace(b.config.S3Bucket) == "" {
+		return nil, nil
+	}
+	prefix, err := naming.S3VolumePrefix(teamID, volumeID)
+	if err != nil {
+		return nil, err
+	}
+	store, err := objectstore.Create(objectstore.Config{
+		Type:         b.config.ObjectStorageType,
+		Bucket:       b.config.S3Bucket,
+		Region:       b.config.S3Region,
+		Endpoint:     b.config.S3Endpoint,
+		AccessKey:    b.config.S3AccessKey,
+		SecretKey:    b.config.S3SecretKey,
+		SessionToken: b.config.S3SessionToken,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return objectstore.Prefix(store, prefix+"/s0fs/"), nil
+}
+
+func sameHeadKey(a, b *s0fs.CommittedHead) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return strings.TrimSpace(a.ManifestKey) == strings.TrimSpace(b.ManifestKey)
 }

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -1,6 +1,7 @@
 package cases
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -295,6 +296,10 @@ func registerApiModeSuite(envProvider func() *framework.ScenarioEnv, opts apiMod
 
 				It("keeps claim-mounted volumes writable", func() {
 					assertClaimMountedVolumeWritable(env, session)
+				})
+
+				It("persists large-file partial rewrites across remounts", func() {
+					assertS0FSLargeFilePartialRewriteAcrossRemount(env, session)
 				})
 
 				It("rejects mounting an active RWO volume into a second sandbox", func() {
@@ -2331,6 +2336,100 @@ func assertClaimMountedVolumeWritable(env *framework.ScenarioEnv, session *e2eut
 			return body, readErr
 		}).WithTimeout(90 * time.Second).WithPolling(2 * time.Second).Should(Equal(expected))
 	}
+}
+
+func assertS0FSLargeFilePartialRewriteAcrossRemount(env *framework.ScenarioEnv, session *e2eutils.Session) {
+	volume, status, err := session.CreateSandboxVolume(env.TestCtx.Context, GinkgoT(), apispec.CreateSandboxVolumeRequest{})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusCreated))
+	Expect(volume).NotTo(BeNil())
+	volumeID := expectStringPtr(volume.Id, "volume id")
+	DeferCleanup(func() {
+		deleteSandboxVolumeForCleanup(env, session, volumeID)
+	})
+
+	filePath := "/s0fs-large/large.bin"
+	original := bytes.Repeat([]byte("a"), 6*1024*1024)
+	patch := []byte("S0FS_PARTIAL_REWRITE_OK")
+	patchOffset := 4*1024*1024 + 257
+	expected := bytes.Clone(original)
+	copy(expected[patchOffset:], patch)
+
+	status, err = session.WriteVolumeFile(env.TestCtx.Context, GinkgoT(), volumeID, filePath, original, "")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+
+	mountPoint := "/workspace/s0fs-large"
+	templateID := createVolumePortalTemplate(env, session, mountPoint)
+	claimReq := apispec.ClaimRequest{
+		Template: &templateID,
+		Mounts: &[]apispec.ClaimMountRequest{{
+			SandboxvolumeId: volumeID,
+			MountPoint:      mountPoint,
+		}},
+	}
+	claimVolume := func() *apispec.ClaimResponse {
+		var resp *apispec.ClaimResponse
+		Eventually(func() error {
+			var claimErr error
+			resp, claimErr = session.ClaimSandboxWithRequest(env.TestCtx.Context, GinkgoT(), claimReq)
+			return claimErr
+		}).WithTimeout(2 * time.Minute).WithPolling(3 * time.Second).Should(Succeed())
+		Expect(resp).NotTo(BeNil())
+		return resp
+	}
+
+	firstClaim := claimVolume()
+	firstSandboxID := firstClaim.SandboxId
+	firstDeleted := false
+	DeferCleanup(func() {
+		if !firstDeleted {
+			_ = session.DeleteSandbox(env.TestCtx.Context, GinkgoT(), firstSandboxID)
+		}
+	})
+	processType := apispec.ProcessTypeCmd
+	ttlSec := int32(120)
+	envVars := map[string]string{
+		"PATCH_OFFSET": fmt.Sprintf("%d", patchOffset),
+		"PATCH_DATA":   string(patch),
+	}
+	ctxReq := apispec.CreateContextRequest{
+		Type: &processType,
+		Cmd: &apispec.CreateCMDContextRequest{
+			Command: []string{
+				"/bin/sh",
+				"-lc",
+				`set -eu; printf "%s" "$PATCH_DATA" | dd of=/workspace/s0fs-large/s0fs-large/large.bin bs=1 seek="$PATCH_OFFSET" conv=notrunc 2>/dev/null; sync`,
+			},
+		},
+		EnvVars: &envVars,
+		TtlSec:  &ttlSec,
+	}
+	ctxResp, status, err := session.CreateContext(env.TestCtx.Context, GinkgoT(), firstSandboxID, ctxReq)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusCreated))
+	Expect(ctxResp).NotTo(BeNil())
+	DeferCleanup(func() {
+		_, _ = session.DeleteContext(env.TestCtx.Context, GinkgoT(), firstSandboxID, ctxResp.Id)
+	})
+
+	Eventually(func() ([]byte, error) {
+		body, _, readErr := session.ReadVolumeFile(env.TestCtx.Context, GinkgoT(), volumeID, filePath)
+		return body, readErr
+	}).WithTimeout(90 * time.Second).WithPolling(3 * time.Second).Should(Equal(expected))
+
+	Expect(session.DeleteSandbox(env.TestCtx.Context, GinkgoT(), firstSandboxID)).To(Succeed())
+	firstDeleted = true
+
+	secondClaim := claimVolume()
+	secondSandboxID := secondClaim.SandboxId
+	DeferCleanup(func() {
+		_ = session.DeleteSandbox(env.TestCtx.Context, GinkgoT(), secondSandboxID)
+	})
+	Eventually(func() ([]byte, error) {
+		body, _, readErr := session.ReadFile(env.TestCtx.Context, GinkgoT(), secondSandboxID, mountPoint+filePath)
+		return body, readErr
+	}).WithTimeout(90 * time.Second).WithPolling(3 * time.Second).Should(Equal(expected))
 }
 
 func deleteSandboxVolumeForCleanup(env *framework.ScenarioEnv, session *e2eutils.Session, volumeID string) {

--- a/tests/integration/internal/tests/storage-proxy/s0fs_integration_test.go
+++ b/tests/integration/internal/tests/storage-proxy/s0fs_integration_test.go
@@ -1,0 +1,322 @@
+package storageproxy
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/objectstore"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/s0fs"
+)
+
+type integrationHeadStore struct {
+	mu    sync.Mutex
+	heads map[string]*s0fs.CommittedHead
+}
+
+func newIntegrationHeadStore() *integrationHeadStore {
+	return &integrationHeadStore{heads: make(map[string]*s0fs.CommittedHead)}
+}
+
+func (s *integrationHeadStore) LoadCommittedHead(_ context.Context, volumeID string) (*s0fs.CommittedHead, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	head := s.heads[volumeID]
+	if head == nil {
+		return nil, s0fs.ErrCommittedHeadNotFound
+	}
+	clone := *head
+	return &clone, nil
+}
+
+func (s *integrationHeadStore) CompareAndSwapCommittedHead(_ context.Context, volumeID string, expectedManifestSeq uint64, head *s0fs.CommittedHead) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	current := s.heads[volumeID]
+	if current == nil {
+		if expectedManifestSeq != 0 {
+			return s0fs.ErrCommittedHeadConflict
+		}
+		clone := *head
+		s.heads[volumeID] = &clone
+		return nil
+	}
+	if current.ManifestSeq != expectedManifestSeq || head.ManifestSeq <= current.ManifestSeq {
+		return s0fs.ErrCommittedHeadConflict
+	}
+	clone := *head
+	s.heads[volumeID] = &clone
+	return nil
+}
+
+func TestS0FSIntegrationPartialOverwritesCompactAndGarbageCollect(t *testing.T) {
+	ctx := context.Background()
+	volumeID := "vol-partial-overwrite"
+	store := newIntegrationObjectStore(t, volumeID)
+	heads := newIntegrationHeadStore()
+
+	engine := openIntegrationEngine(t, ctx, volumeID, store, heads, 1024)
+	node, err := engine.CreateFile(s0fs.RootInode, "pack.bin", 0o644)
+	if err != nil {
+		t.Fatalf("CreateFile() error = %v", err)
+	}
+	payload := deterministicPayload(4096)
+	if _, err := engine.Write(node.Inode, 0, payload); err != nil {
+		t.Fatalf("Write(initial) error = %v", err)
+	}
+	if _, err := engine.SyncMaterialize(ctx); err != nil {
+		t.Fatalf("SyncMaterialize(initial) error = %v", err)
+	}
+	initialSegments := listObjectKeys(t, store, "segments/")
+	if got, want := len(initialSegments), 4; got != want {
+		t.Fatalf("initial segment count = %d, want %d: %v", got, want, initialSegments)
+	}
+	if err := engine.Close(); err != nil {
+		t.Fatalf("Close(initial engine) error = %v", err)
+	}
+
+	engine = openIntegrationEngine(t, ctx, volumeID, store, heads, 1024)
+	replacement := bytes.Repeat([]byte("Z"), 128)
+	copy(payload[1536:], replacement)
+	if _, err := engine.Write(node.Inode, 1536, replacement); err != nil {
+		t.Fatalf("Write(overwrite) error = %v", err)
+	}
+	if _, err := engine.SyncMaterialize(ctx); err != nil {
+		t.Fatalf("SyncMaterialize(overwrite) error = %v", err)
+	}
+	fragmentedBytes := sumObjectSizes(t, store, "segments/")
+
+	compacted, result, err := engine.Compact(ctx, s0fs.CompactionOptions{
+		SegmentTargetSize: 1024,
+		MinDeadRatio:      0.01,
+		MinReclaimBytes:   1,
+	})
+	if err != nil {
+		t.Fatalf("Compact() error = %v", err)
+	}
+	if compacted == nil {
+		t.Fatal("Compact() returned nil manifest")
+	}
+	if result == nil || result.ReclaimableBytes < uint64(len(replacement)) || len(result.CompactedSegments) == 0 {
+		t.Fatalf("compaction result = %+v, want reclaimed overwrite bytes", result)
+	}
+	head := loadCommittedHead(t, ctx, heads, volumeID)
+	retainedManifests := map[string]struct{}{head.ManifestKey: {}}
+	materializer := s0fs.NewMaterializer(volumeID, store, heads)
+	plan, err := materializer.PlanGarbageCollection(ctx, []*s0fs.SnapshotState{compacted.State}, retainedManifests)
+	if err != nil {
+		t.Fatalf("PlanGarbageCollection() error = %v", err)
+	}
+	if len(plan.Segments) == 0 {
+		t.Fatalf("GC plan did not include obsolete segments after compaction")
+	}
+	gcResult, err := plan.Apply(ctx)
+	if err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	if len(gcResult.DeletedSegments) == 0 {
+		t.Fatalf("GC deleted no segments: %+v", gcResult)
+	}
+	if compactedBytes := sumObjectSizes(t, store, "segments/"); compactedBytes >= fragmentedBytes {
+		t.Fatalf("segment bytes after GC = %d, want less than fragmented bytes %d", compactedBytes, fragmentedBytes)
+	}
+	if err := engine.Close(); err != nil {
+		t.Fatalf("Close(compacted engine) error = %v", err)
+	}
+
+	engine = openIntegrationEngine(t, ctx, volumeID, store, heads, 1024)
+	readBack, err := engine.Read(node.Inode, 0, uint64(len(payload)))
+	if err != nil {
+		t.Fatalf("Read(after GC) error = %v", err)
+	}
+	if !bytes.Equal(readBack, payload) {
+		t.Fatalf("payload mismatch after compaction and GC")
+	}
+}
+
+func TestS0FSIntegrationSnapshotRetainsCompactedSegmentsUntilReleased(t *testing.T) {
+	ctx := context.Background()
+	volumeID := "vol-snapshot-retention"
+	store := newIntegrationObjectStore(t, volumeID)
+	heads := newIntegrationHeadStore()
+
+	engine := openIntegrationEngine(t, ctx, volumeID, store, heads, 1024)
+	node, err := engine.CreateFile(s0fs.RootInode, "data.txt", 0o644)
+	if err != nil {
+		t.Fatalf("CreateFile() error = %v", err)
+	}
+	if _, err := engine.Write(node.Inode, 0, []byte("abcdef")); err != nil {
+		t.Fatalf("Write(initial) error = %v", err)
+	}
+	first, err := engine.SyncMaterialize(ctx)
+	if err != nil {
+		t.Fatalf("SyncMaterialize(initial) error = %v", err)
+	}
+	oldSegmentKey := onlySegmentKey(t, first.State)
+	snapshotState, err := engine.CreateSnapshot("before-overwrite")
+	if err != nil {
+		t.Fatalf("CreateSnapshot() error = %v", err)
+	}
+
+	if _, err := engine.Write(node.Inode, 1, []byte("Z")); err != nil {
+		t.Fatalf("Write(overwrite) error = %v", err)
+	}
+	if _, err := engine.SyncMaterialize(ctx); err != nil {
+		t.Fatalf("SyncMaterialize(overwrite) error = %v", err)
+	}
+	compacted, _, err := engine.Compact(ctx, s0fs.CompactionOptions{
+		SegmentTargetSize: 1024,
+		Force:             true,
+	})
+	if err != nil {
+		t.Fatalf("Compact() error = %v", err)
+	}
+	if compacted == nil {
+		t.Fatal("Compact() returned nil manifest")
+	}
+
+	materializer := s0fs.NewMaterializer(volumeID, store, heads)
+	snapshotPayload, err := s0fs.NewSnapshotReader(snapshotState, materializer).Read(node.Inode, 0, 6)
+	if err != nil {
+		t.Fatalf("SnapshotReader.Read() error = %v", err)
+	}
+	if string(snapshotPayload) != "abcdef" {
+		t.Fatalf("snapshot payload = %q, want abcdef", snapshotPayload)
+	}
+
+	head := loadCommittedHead(t, ctx, heads, volumeID)
+	retainedManifests := map[string]struct{}{head.ManifestKey: {}}
+	withSnapshot, err := materializer.PlanGarbageCollection(ctx, []*s0fs.SnapshotState{compacted.State, snapshotState}, retainedManifests)
+	if err != nil {
+		t.Fatalf("PlanGarbageCollection(with snapshot) error = %v", err)
+	}
+	if slices.Contains(withSnapshot.Segments, oldSegmentKey) {
+		t.Fatalf("snapshot segment %s was planned for deletion while snapshot is retained", oldSegmentKey)
+	}
+	withoutSnapshot, err := materializer.PlanGarbageCollection(ctx, []*s0fs.SnapshotState{compacted.State}, retainedManifests)
+	if err != nil {
+		t.Fatalf("PlanGarbageCollection(without snapshot) error = %v", err)
+	}
+	if !slices.Contains(withoutSnapshot.Segments, oldSegmentKey) {
+		t.Fatalf("snapshot segment %s was not collectible after snapshot release: %v", oldSegmentKey, withoutSnapshot.Segments)
+	}
+}
+
+func newIntegrationObjectStore(t *testing.T, volumeID string) objectstore.Store {
+	t.Helper()
+	namespace := fmt.Sprintf("s0fs-integration-%s", strings.ReplaceAll(t.Name(), "/", "-"))
+	base := objectstore.NewMemoryStore(namespace)
+	return objectstore.Prefix(base, "sandboxvolumes/team-a/"+volumeID+"/s0fs")
+}
+
+func openIntegrationEngine(t *testing.T, ctx context.Context, volumeID string, store objectstore.Store, heads s0fs.HeadStore, segmentTargetSize uint64) *s0fs.Engine {
+	t.Helper()
+
+	engine, err := s0fs.Open(ctx, s0fs.Config{
+		VolumeID:          volumeID,
+		WALPath:           filepath.Join(t.TempDir(), "engine.wal"),
+		ObjectStore:       store,
+		HeadStore:         heads,
+		SegmentTargetSize: segmentTargetSize,
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = engine.Close()
+	})
+	return engine
+}
+
+func loadCommittedHead(t *testing.T, ctx context.Context, heads s0fs.HeadStore, volumeID string) *s0fs.CommittedHead {
+	t.Helper()
+
+	head, err := heads.LoadCommittedHead(ctx, volumeID)
+	if err != nil {
+		t.Fatalf("LoadCommittedHead() error = %v", err)
+	}
+	if head.ManifestKey == "" {
+		t.Fatal("committed head has empty manifest key")
+	}
+	return head
+}
+
+func onlySegmentKey(t *testing.T, state *s0fs.SnapshotState) string {
+	t.Helper()
+
+	var key string
+	for _, segment := range state.Segments {
+		if key != "" {
+			t.Fatalf("state has more than one segment: %v", state.Segments)
+		}
+		key = segment.Key
+	}
+	if key == "" {
+		t.Fatal("state has no segments")
+	}
+	return key
+}
+
+func listObjectKeys(t *testing.T, store objectstore.Store, prefix string) []string {
+	t.Helper()
+
+	infos := listObjectInfos(t, store, prefix)
+	keys := make([]string, 0, len(infos))
+	for _, info := range infos {
+		keys = append(keys, info.Key)
+	}
+	return keys
+}
+
+func sumObjectSizes(t *testing.T, store objectstore.Store, prefix string) int64 {
+	t.Helper()
+
+	var total int64
+	for _, info := range listObjectInfos(t, store, prefix) {
+		total += info.Size
+	}
+	return total
+}
+
+func listObjectInfos(t *testing.T, store objectstore.Store, prefix string) []objectstore.Info {
+	t.Helper()
+
+	var (
+		infos      []objectstore.Info
+		startAfter string
+		token      string
+	)
+	for {
+		page, hasMore, nextToken, err := store.List(prefix, startAfter, token, "", 1000)
+		if err != nil {
+			t.Fatalf("List(%q) error = %v", prefix, err)
+		}
+		infos = append(infos, page...)
+		if !hasMore {
+			break
+		}
+		if len(page) > 0 {
+			startAfter = page[len(page)-1].Key
+		}
+		token = nextToken
+	}
+	slices.SortFunc(infos, func(a, b objectstore.Info) int {
+		return strings.Compare(a.Key, b.Key)
+	})
+	return infos
+}
+
+func deterministicPayload(size int) []byte {
+	payload := make([]byte, size)
+	for i := range payload {
+		payload[i] = byte('a' + i%26)
+	}
+	return payload
+}


### PR DESCRIPTION
## Summary

Fixes #396.

- replace full-file cold rewrites with extent-based write/truncate metadata so small overwrites keep unmodified cold ranges instead of re-uploading whole files
- materialize dirty data into configurable target-sized segments, defaulting to `4Mi`
- add RWO background compaction and guarded GC in both storage-proxy and ctld owners; ROX/RWX do not run background compaction because reclamation needs stronger coordination
- add `storageProxy.config` knobs for S0FS segment target size, compaction interval, dead-ratio threshold, and reclaim threshold, plus CRD/docs updates
- add unit, integration-style, and e2e regression coverage for partial rewrites, compaction, snapshot retention, access-mode behavior, and remount persistence

## Tests

- `make proto`
- `make manifests`
- `go test ./storage-proxy/pkg/s0fs ./storage-proxy/pkg/volume ./storage-proxy/pkg/snapshot ./ctld/internal/ctld/portal ./infra-operator/internal/runtimeconfig`
- `go test ./tests/e2e/cases ./tests/e2e/utils`
- `go test ./storage-proxy/...`
- `go test ./ctld/...`
- `go test ./infra-operator/...`
