### PR TITLE
Use default template image v0.2.0

### DIFF
--- a/.github/actions/prepare-infra/action.yml
+++ b/.github/actions/prepare-infra/action.yml
@@ -23,10 +23,6 @@ inputs:
     description: Run aggressive disk cleanup on GitHub-hosted Linux runners.
     required: false
     default: "true"
-  build-local-template-image:
-    description: Add repo-local template image changes on top of the published default template image before loading it into Kind.
-    required: false
-    default: "false"
 runs:
   using: "composite"
   steps:
@@ -98,8 +94,8 @@ runs:
       id: infra-template-cache
       uses: actions/cache/restore@v4
       with:
-        path: ${{ runner.temp }}/infra-image-cache/infra-image-template-default-v0.1.0.tar
-        key: infra-image-${{ runner.os }}-${{ inputs.cache-key-suffix }}-template-default-v0.1.0
+        path: ${{ runner.temp }}/infra-image-cache/infra-image-template-default-v0.2.0.tar
+        key: infra-image-${{ runner.os }}-${{ inputs.cache-key-suffix }}-template-default-v0.2.0
 
     - name: Restore SSH fixture image cache
       id: infra-ssh-fixture-cache
@@ -135,24 +131,7 @@ runs:
         ensure_image "postgres:16-alpine" "${image_cache_dir}/infra-image-postgres-16-alpine.tar"
         ensure_image "rustfs/rustfs:1.0.0-alpha.79" "${image_cache_dir}/infra-image-rustfs-1.0.0-alpha.79.tar"
         ensure_image "registry:2.8.3" "${image_cache_dir}/infra-image-registry-2.8.3.tar"
-        ensure_image "sandbox0ai/otemplates:default-v0.1.0" "${image_cache_dir}/infra-image-template-default-v0.1.0.tar"
-
-        if [ "${{ inputs.build-local-template-image }}" = "true" ]; then
-          echo "Building local default template image overlay..."
-          cat > "${RUNNER_TEMP}/sandbox0-template-overlay.Dockerfile" <<'EOF'
-        FROM sandbox0ai/otemplates:default-v0.1.0
-        ENV DEBIAN_FRONTEND=noninteractive
-        RUN if ! command -v dockerd >/dev/null 2>&1 || ! command -v fuse-overlayfs >/dev/null 2>&1; then \
-              apt-get update && \
-              apt-get install -y --no-install-recommends docker.io fuse-overlayfs iptables uidmap && \
-              rm -rf /var/lib/apt/lists/*; \
-            fi
-        COPY manager/procd/sandbox0-dockerd-entrypoint /usr/local/bin/sandbox0-dockerd-entrypoint
-        RUN chmod 0755 /usr/local/bin/sandbox0-dockerd-entrypoint
-        EOF
-          docker build -t sandbox0ai/otemplates:default-v0.1.0 -f "${RUNNER_TEMP}/sandbox0-template-overlay.Dockerfile" .
-          docker save -o "${image_cache_dir}/infra-image-template-default-v0.1.0.tar" sandbox0ai/otemplates:default-v0.1.0
-        fi
+        ensure_image "sandbox0ai/otemplates:default-v0.2.0" "${image_cache_dir}/infra-image-template-default-v0.2.0.tar"
 
         ssh_fixture_archive="${image_cache_dir}/infra-image-e2e-openssh-server-68b605929e83.tar"
         ssh_fixture_source="lscr.io/linuxserver/openssh-server@sha256:68b605929e83b2efe000da09269688f6d82a44579e8a18e2d9e8c8d272917cf7"
@@ -181,7 +160,7 @@ runs:
         kind load image-archive "${image_cache_dir}/infra-image-postgres-16-alpine.tar" --name ${{ inputs.kind-cluster-name }}
         kind load image-archive "${image_cache_dir}/infra-image-rustfs-1.0.0-alpha.79.tar" --name ${{ inputs.kind-cluster-name }}
         kind load image-archive "${image_cache_dir}/infra-image-registry-2.8.3.tar" --name ${{ inputs.kind-cluster-name }}
-        kind load image-archive "${image_cache_dir}/infra-image-template-default-v0.1.0.tar" --name ${{ inputs.kind-cluster-name }}
+        kind load image-archive "${image_cache_dir}/infra-image-template-default-v0.2.0.tar" --name ${{ inputs.kind-cluster-name }}
         kind load image-archive "${image_cache_dir}/infra-image-e2e-openssh-server-68b605929e83.tar" --name ${{ inputs.kind-cluster-name }}
 
     - name: Save shared infra build cache
@@ -213,11 +192,11 @@ runs:
         key: infra-image-${{ runner.os }}-${{ inputs.cache-key-suffix }}-registry-2.8.3
 
     - name: Save template image cache
-      if: ${{ steps.infra-template-cache.outputs.cache-hit != 'true' && inputs.build-local-template-image != 'true' }}
+      if: steps.infra-template-cache.outputs.cache-hit != 'true'
       uses: actions/cache/save@v4
       with:
-        path: ${{ runner.temp }}/infra-image-cache/infra-image-template-default-v0.1.0.tar
-        key: infra-image-${{ runner.os }}-${{ inputs.cache-key-suffix }}-template-default-v0.1.0
+        path: ${{ runner.temp }}/infra-image-cache/infra-image-template-default-v0.2.0.tar
+        key: infra-image-${{ runner.os }}-${{ inputs.cache-key-suffix }}-template-default-v0.2.0
 
     - name: Save SSH fixture image cache
       if: steps.infra-ssh-fixture-cache.outputs.cache-hit != 'true'
@@ -235,7 +214,7 @@ runs:
           postgres:16-alpine \
           rustfs/rustfs:1.0.0-alpha.79 \
           registry:2.8.3 \
-          sandbox0ai/otemplates:default-v0.1.0 \
+          sandbox0ai/otemplates:default-v0.2.0 \
           sandbox0ai/e2e-openssh-server:68b605929e83 \
           2>/dev/null || true
         docker builder prune -af || true

--- a/.github/workflows/build-template-image.yml
+++ b/.github/workflows/build-template-image.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Template image tag (e.g. default-v0.1.0)"
+        description: "Template image tag (e.g. default-v0.2.0)"
         required: true
-        default: "default-v0.1.0"
+        default: "default-v0.2.0"
       dockerfile:
         description: "Dockerfile path relative to repo root"
         required: true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -51,7 +51,6 @@ jobs:
           kind-config: tests/e2e/kind-config.yaml
           kind-cluster-name: sandbox0-e2e-${{ matrix.arch }}
           cache-key-suffix: ${{ matrix.arch }}
-          build-local-template-image: "true"
 
       - name: Run E2E
         env:

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -31,7 +31,6 @@ jobs:
           kind-config: tests/e2e/kind-config.yaml
           kind-cluster-name: ${{ env.KIND_CLUSTER_NAME }}
           cache-key-suffix: pr-amd64
-          build-local-template-image: "true"
 
       - name: Run PR E2E
         env:

--- a/.github/workflows/sdk-e2e.yml
+++ b/.github/workflows/sdk-e2e.yml
@@ -70,7 +70,6 @@ jobs:
           kind-config: tests/e2e/kind-config.yaml
           kind-cluster-name: ${{ env.KIND_CLUSTER_NAME }}
           cache-key-suffix: amd64
-          build-local-template-image: "true"
 
       - name: Install infra-operator
         run: |

--- a/infra-operator/chart/samples/multi-cluster/data-plane.yaml
+++ b/infra-operator/chart/samples/multi-cluster/data-plane.yaml
@@ -79,14 +79,14 @@ spec:
     name: Production US East 1
   builtinTemplates:
     - templateId: default
-      image: sandbox0ai/otemplates:default-v0.1.0
+      image: sandbox0ai/otemplates:default-v0.2.0
       displayName: Default
       description: Builtin template installed by infra-operator.
       pool:
         minIdle: 1
         maxIdle: 5
     - templateId: dins
-      image: sandbox0ai/otemplates:default-v0.1.0
+      image: sandbox0ai/otemplates:default-v0.2.0
       displayName: Docker in Sandbox
       description: Builtin Docker in Sandbox template installed by infra-operator.
       pool:

--- a/infra-operator/chart/samples/single-cluster/fullmode-gke-gvisor.yaml
+++ b/infra-operator/chart/samples/single-cluster/fullmode-gke-gvisor.yaml
@@ -36,7 +36,7 @@ spec:
       pushEndpoint: 127.0.0.1:30500
   builtinTemplates:
     - templateId: default
-      image: sandbox0ai/otemplates:default-v0.1.0
+      image: sandbox0ai/otemplates:default-v0.2.0
       displayName: Default
       description: Builtin template installed by infra-operator.
       pool:

--- a/infra-operator/chart/samples/single-cluster/fullmode.yaml
+++ b/infra-operator/chart/samples/single-cluster/fullmode.yaml
@@ -86,14 +86,14 @@ spec:
   #       secretKeyKey: secretAccessKey
   builtinTemplates:
     - templateId: default
-      image: sandbox0ai/otemplates:default-v0.1.0
+      image: sandbox0ai/otemplates:default-v0.2.0
       displayName: Default
       description: Builtin template installed by infra-operator.
       pool:
         minIdle: 1
         maxIdle: 5
     - templateId: dins
-      image: sandbox0ai/otemplates:default-v0.1.0
+      image: sandbox0ai/otemplates:default-v0.2.0
       displayName: Docker in Sandbox
       description: Builtin Docker in Sandbox template installed by infra-operator.
       pool:

--- a/infra-operator/chart/samples/single-cluster/minimal.yaml
+++ b/infra-operator/chart/samples/single-cluster/minimal.yaml
@@ -44,14 +44,14 @@ spec:
   #     pushEndpoint: 127.0.0.1:30500
   builtinTemplates:
     - templateId: default
-      image: sandbox0ai/otemplates:default-v0.1.0
+      image: sandbox0ai/otemplates:default-v0.2.0
       displayName: Default
       description: Builtin template installed by infra-operator.
       pool:
         minIdle: 1
         maxIdle: 5
     - templateId: dins
-      image: sandbox0ai/otemplates:default-v0.1.0
+      image: sandbox0ai/otemplates:default-v0.2.0
       displayName: Docker in Sandbox
       description: Builtin Docker in Sandbox template installed by infra-operator.
       pool:

--- a/infra-operator/chart/samples/single-cluster/network-policy.yaml
+++ b/infra-operator/chart/samples/single-cluster/network-policy.yaml
@@ -44,14 +44,14 @@ spec:
   #     pushEndpoint: 127.0.0.1:30500
   builtinTemplates:
     - templateId: default
-      image: sandbox0ai/otemplates:default-v0.1.0
+      image: sandbox0ai/otemplates:default-v0.2.0
       displayName: Default
       description: Builtin template installed by infra-operator.
       pool:
         minIdle: 1
         maxIdle: 5
     - templateId: dins
-      image: sandbox0ai/otemplates:default-v0.1.0
+      image: sandbox0ai/otemplates:default-v0.2.0
       displayName: Docker in Sandbox
       description: Builtin Docker in Sandbox template installed by infra-operator.
       pool:

--- a/infra-operator/chart/samples/single-cluster/volumes.yaml
+++ b/infra-operator/chart/samples/single-cluster/volumes.yaml
@@ -62,14 +62,14 @@ spec:
   #     pushEndpoint: 127.0.0.1:30500
   builtinTemplates:
     - templateId: default
-      image: sandbox0ai/otemplates:default-v0.1.0
+      image: sandbox0ai/otemplates:default-v0.2.0
       displayName: Default
       description: Builtin template installed by infra-operator.
       pool:
         minIdle: 1
         maxIdle: 5
     - templateId: dins
-      image: sandbox0ai/otemplates:default-v0.1.0
+      image: sandbox0ai/otemplates:default-v0.2.0
       displayName: Docker in Sandbox
       description: Builtin Docker in Sandbox template installed by infra-operator.
       pool:

--- a/pkg/template/defaults.go
+++ b/pkg/template/defaults.go
@@ -4,7 +4,7 @@ import "github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 
 const (
 	DefaultTemplateID               = "default"
-	DefaultTemplateImage            = "sandbox0ai/otemplates:default-v0.1.0"
+	DefaultTemplateImage            = "sandbox0ai/otemplates:default-v0.2.0"
 	DefaultTemplateCPU              = "500m"
 	DefaultTemplateMemory           = "2Gi"
 	DefaultTemplateEphemeralStorage = v1alpha1.DefaultSandboxEphemeralStorage

--- a/tests/e2e/cases/api_network_policy_netd.go
+++ b/tests/e2e/cases/api_network_policy_netd.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	netdHTTPFixtureImageEnvVar     = "E2E_NETD_HTTP_FIXTURE_IMAGE"
-	defaultNetdHTTPFixtureImageRef = "sandbox0ai/otemplates:default-v0.1.0"
+	defaultNetdHTTPFixtureImageRef = "sandbox0ai/otemplates:default-v0.2.0"
 	netdHTTPFixturePort            = 8080
 )
 


### PR DESCRIPTION
## Summary
- switch the builtin default template image to `sandbox0ai/otemplates:default-v0.2.0`
- update infra-operator samples and e2e fixture refs so `default` and `dins` use the published v0.2.0 image
- remove the temporary CI overlay that rebuilt the default template image during e2e setup

## Image publish
- Built `sandbox0ai/otemplates:default-v0.2.0` from `main` with `build-template-image.yml`
- Workflow run: https://github.com/sandbox0-ai/sandbox0/actions/runs/26777398149
- Published manifest includes `linux/amd64` and `linux/arm64`

## Testing
- `git diff --check`
- `go test ./pkg/template/... ./infra-operator/internal/controller/pkg/common/...`
- `docker manifest inspect sandbox0ai/otemplates:default-v0.2.0`

Related to #370
