### PR TITLE
Use hashed ConfigMaps for service configs

### DIFF
--- a/infra-operator/internal/controller/pkg/common/common.go
+++ b/infra-operator/internal/controller/pkg/common/common.go
@@ -59,6 +59,12 @@ type LocalDevConfig struct {
 
 const PodTemplateConfigHashAnnotation = "infra.sandbox0.ai/config-hash"
 
+const (
+	ServiceConfigBaseNameAnnotation = "infra.sandbox0.ai/service-config-base-name"
+	ServiceConfigHashAnnotation     = "infra.sandbox0.ai/service-config-hash"
+	serviceConfigNameHashLength     = 16
+)
+
 func NewResourceManager(client client.Client, scheme *runtime.Scheme, imagePullPolicy *corev1.PullPolicy, localDev LocalDevConfig) *ResourceManager {
 	return &ResourceManager{
 		Client:          client,
@@ -86,6 +92,17 @@ type ServiceDefinition struct {
 	ReadinessProbe     *corev1.Probe
 	ServiceAccountName string
 	Resources          *corev1.ResourceRequirements
+}
+
+type ServiceConfigRef struct {
+	ConfigMapName string
+	Hash          string
+}
+
+// PodAnnotations returns the pod-template annotations that roll workloads when
+// the referenced service config changes.
+func (r ServiceConfigRef) PodAnnotations() map[string]string {
+	return ConfigHashAnnotationFromHash(r.Hash)
 }
 
 // ReconcileDeployment creates or updates a deployment.
@@ -685,6 +702,115 @@ func (r *ResourceManager) ReconcileServiceConfigMapWithScope(ctx context.Context
 	return r.Client.Update(ctx, existing)
 }
 
+func (r *ResourceManager) ReconcileHashedServiceConfigMap(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, name string, labels map[string]string, config any) (ServiceConfigRef, error) {
+	return r.ReconcileHashedServiceConfigMapWithScope(ctx, NewObjectScope(infra), name, labels, config)
+}
+
+// ReconcileHashedServiceConfigMapWithScope creates an immutable ConfigMap whose
+// name includes the config hash. Service pods mount config.yaml with subPath, so
+// the pod spec must reference the exact ConfigMap object for the desired config.
+func (r *ResourceManager) ReconcileHashedServiceConfigMapWithScope(ctx context.Context, scope ObjectScope, name string, labels map[string]string, config any) (ServiceConfigRef, error) {
+	if config == nil {
+		config = map[string]any{}
+	}
+
+	payload, err := yamlv3.Marshal(config)
+	if err != nil {
+		return ServiceConfigRef{}, fmt.Errorf("marshal config for %s: %w", name, err)
+	}
+	hash := ConfigHashFromPayload(payload)
+	configMapName := HashedServiceConfigMapName(name, hash)
+
+	desiredLabels := EnsureManagedLabels(labels, name)
+	desired := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMapName,
+			Namespace: scope.Namespace,
+			Labels:    desiredLabels,
+			Annotations: map[string]string{
+				ServiceConfigBaseNameAnnotation: name,
+				ServiceConfigHashAnnotation:     hash,
+			},
+		},
+		Immutable: BoolPtr(true),
+		Data: map[string]string{
+			"config.yaml": string(payload),
+		},
+	}
+
+	if err := scope.SetControllerReference(desired, r.Scheme); err != nil {
+		return ServiceConfigRef{}, err
+	}
+
+	existing := &corev1.ConfigMap{}
+	err = r.Client.Get(ctx, types.NamespacedName{Name: configMapName, Namespace: scope.Namespace}, existing)
+	if err != nil && !errors.IsNotFound(err) {
+		return ServiceConfigRef{}, err
+	}
+
+	if errors.IsNotFound(err) {
+		if err := r.Client.Create(ctx, desired); err != nil {
+			return ServiceConfigRef{}, err
+		}
+	} else {
+		if existing.Data["config.yaml"] != desired.Data["config.yaml"] {
+			return ServiceConfigRef{}, fmt.Errorf("service configmap %q already exists with mismatched config hash", configMapName)
+		}
+		existing.Labels = desired.Labels
+		existing.Annotations = desired.Annotations
+		existing.OwnerReferences = desired.OwnerReferences
+		if existing.Immutable == nil || !*existing.Immutable {
+			existing.Immutable = BoolPtr(true)
+		}
+		if err := r.Client.Update(ctx, existing); err != nil {
+			return ServiceConfigRef{}, err
+		}
+	}
+
+	ref := ServiceConfigRef{ConfigMapName: configMapName, Hash: hash}
+	if err := r.cleanupUnusedServiceConfigMaps(ctx, scope, name, ref.ConfigMapName); err != nil {
+		return ServiceConfigRef{}, err
+	}
+	return ref, nil
+}
+
+func (r *ResourceManager) cleanupUnusedServiceConfigMaps(ctx context.Context, scope ObjectScope, baseName, currentName string) error {
+	var pods corev1.PodList
+	if err := r.Client.List(ctx, &pods, client.InNamespace(scope.Namespace)); err != nil {
+		return err
+	}
+	inUse := make(map[string]struct{})
+	for _, pod := range pods.Items {
+		for _, volume := range pod.Spec.Volumes {
+			if volume.ConfigMap == nil {
+				continue
+			}
+			inUse[volume.ConfigMap.Name] = struct{}{}
+		}
+	}
+
+	var configMaps corev1.ConfigMapList
+	if err := r.Client.List(ctx, &configMaps, client.InNamespace(scope.Namespace)); err != nil {
+		return err
+	}
+	for _, configMap := range configMaps.Items {
+		if configMap.Name == currentName {
+			continue
+		}
+		if configMap.Annotations[ServiceConfigBaseNameAnnotation] != baseName {
+			continue
+		}
+		if _, ok := inUse[configMap.Name]; ok {
+			continue
+		}
+		cm := configMap.DeepCopy()
+		if err := r.Client.Delete(ctx, cm); err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+	}
+	return nil
+}
+
 // ReconcileNamespace creates a namespace if it does not exist.
 // It ignores errors if the operator does not have permission to create the namespace.
 func (r *ResourceManager) ReconcileNamespace(ctx context.Context, name string) error {
@@ -963,8 +1089,12 @@ func ConfigHash(config any) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	return ConfigHashFromPayload(payload), nil
+}
+
+func ConfigHashFromPayload(payload []byte) string {
 	sum := sha256.Sum256(payload)
-	return hex.EncodeToString(sum[:]), nil
+	return hex.EncodeToString(sum[:])
 }
 
 func ConfigHashAnnotation(config any) (map[string]string, error) {
@@ -972,9 +1102,28 @@ func ConfigHashAnnotation(config any) (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	return ConfigHashAnnotationFromHash(hash), nil
+}
+
+func ConfigHashAnnotationFromHash(hash string) map[string]string {
 	return map[string]string{
 		PodTemplateConfigHashAnnotation: hash,
-	}, nil
+	}
+}
+
+func HashedServiceConfigMapName(baseName, hash string) string {
+	if len(hash) > serviceConfigNameHashLength {
+		hash = hash[:serviceConfigNameHashLength]
+	}
+	suffix := "-config-" + hash
+	if len(baseName)+len(suffix) <= 253 {
+		return baseName + suffix
+	}
+	maxBaseLen := 253 - len(suffix)
+	if maxBaseLen < 1 {
+		maxBaseLen = 1
+	}
+	return strings.TrimRight(baseName[:maxBaseLen], "-.") + suffix
 }
 
 // EnsurePodTemplateAnnotations returns a cloned annotations map for pod templates.

--- a/infra-operator/internal/controller/pkg/common/common_test.go
+++ b/infra-operator/internal/controller/pkg/common/common_test.go
@@ -7,6 +7,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -229,6 +230,139 @@ func TestConfigHashAnnotationChangesWithConfig(t *testing.T) {
 	}
 	if sameA[PodTemplateConfigHashAnnotation] == changed[PodTemplateConfigHashAnnotation] {
 		t.Fatalf("expected changed config to produce a different hash, got %q", changed[PodTemplateConfigHashAnnotation])
+	}
+}
+
+func TestReconcileHashedServiceConfigMapCreatesImmutableContentAddressedConfigMap(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1 scheme: %v", err)
+	}
+	if err := infrav1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add infra scheme: %v", err)
+	}
+
+	infra := &infrav1alpha1.Sandbox0Infra{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "sandbox0-system",
+		},
+	}
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(infra.DeepCopy()).
+		Build()
+	manager := NewResourceManager(client, scheme, nil, LocalDevConfig{})
+
+	ref, err := manager.ReconcileHashedServiceConfigMap(context.Background(), infra, "demo-manager", GetServiceLabels("demo", "manager"), map[string]any{
+		"http_port": 8080,
+	})
+	if err != nil {
+		t.Fatalf("reconcile hashed service configmap: %v", err)
+	}
+	if ref.ConfigMapName != HashedServiceConfigMapName("demo-manager", ref.Hash) {
+		t.Fatalf("configmap name = %q, want hashed name for %q", ref.ConfigMapName, ref.Hash)
+	}
+	if ref.ConfigMapName == "demo-manager" {
+		t.Fatal("expected content-addressed configmap name, got legacy service name")
+	}
+	if got := ref.PodAnnotations()[PodTemplateConfigHashAnnotation]; got != ref.Hash {
+		t.Fatalf("pod config hash annotation = %q, want %q", got, ref.Hash)
+	}
+
+	cm := &corev1.ConfigMap{}
+	if err := client.Get(context.Background(), types.NamespacedName{Name: ref.ConfigMapName, Namespace: infra.Namespace}, cm); err != nil {
+		t.Fatalf("get configmap: %v", err)
+	}
+	if cm.Immutable == nil || !*cm.Immutable {
+		t.Fatalf("expected immutable configmap, got %#v", cm.Immutable)
+	}
+	if cm.Annotations[ServiceConfigBaseNameAnnotation] != "demo-manager" {
+		t.Fatalf("base name annotation = %q", cm.Annotations[ServiceConfigBaseNameAnnotation])
+	}
+	if cm.Annotations[ServiceConfigHashAnnotation] != ref.Hash {
+		t.Fatalf("hash annotation = %q, want %q", cm.Annotations[ServiceConfigHashAnnotation], ref.Hash)
+	}
+	if cm.Data["config.yaml"] == "" {
+		t.Fatal("expected config.yaml data")
+	}
+	if len(cm.OwnerReferences) != 1 || cm.OwnerReferences[0].Name != infra.Name {
+		t.Fatalf("expected owner reference to infra, got %#v", cm.OwnerReferences)
+	}
+}
+
+func TestReconcileHashedServiceConfigMapRetainsLivePodConfigAndCleansUnusedConfig(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1 scheme: %v", err)
+	}
+	if err := infrav1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add infra scheme: %v", err)
+	}
+
+	infra := &infrav1alpha1.Sandbox0Infra{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "sandbox0-system",
+		},
+	}
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(infra.DeepCopy()).
+		Build()
+	manager := NewResourceManager(client, scheme, nil, LocalDevConfig{})
+	labels := GetServiceLabels("demo", "manager")
+
+	first, err := manager.ReconcileHashedServiceConfigMap(context.Background(), infra, "demo-manager", labels, map[string]any{
+		"http_port": 8080,
+	})
+	if err != nil {
+		t.Fatalf("reconcile first configmap: %v", err)
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "manager-old",
+			Namespace: infra.Namespace,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "manager", Image: "manager:test"}},
+			Volumes: []corev1.Volume{{
+				Name: "config",
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{Name: first.ConfigMapName},
+					},
+				},
+			}},
+		},
+	}
+	if err := client.Create(context.Background(), pod); err != nil {
+		t.Fatalf("create pod: %v", err)
+	}
+
+	second, err := manager.ReconcileHashedServiceConfigMap(context.Background(), infra, "demo-manager", labels, map[string]any{
+		"http_port": 18080,
+	})
+	if err != nil {
+		t.Fatalf("reconcile second configmap: %v", err)
+	}
+	if second.ConfigMapName == first.ConfigMapName {
+		t.Fatalf("expected changed config to use a new configmap name, got %q", second.ConfigMapName)
+	}
+	if err := client.Get(context.Background(), types.NamespacedName{Name: first.ConfigMapName, Namespace: infra.Namespace}, &corev1.ConfigMap{}); err != nil {
+		t.Fatalf("expected live pod referenced configmap to be retained: %v", err)
+	}
+
+	if err := client.Delete(context.Background(), pod); err != nil {
+		t.Fatalf("delete pod: %v", err)
+	}
+	if _, err := manager.ReconcileHashedServiceConfigMap(context.Background(), infra, "demo-manager", labels, map[string]any{
+		"http_port": 18080,
+	}); err != nil {
+		t.Fatalf("reconcile second configmap after old pod deletion: %v", err)
+	}
+	if err := client.Get(context.Background(), types.NamespacedName{Name: first.ConfigMapName, Namespace: infra.Namespace}, &corev1.ConfigMap{}); !errors.IsNotFound(err) {
+		t.Fatalf("expected unused old configmap to be cleaned up, got err=%v", err)
 	}
 }
 

--- a/infra-operator/internal/controller/sandbox0infra_cleanup_test.go
+++ b/infra-operator/internal/controller/sandbox0infra_cleanup_test.go
@@ -85,6 +85,13 @@ func TestCleanupDisabledServiceResourcesCleansBuiltinDependencies(t *testing.T) 
 		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "demo-manager", Namespace: "sandbox0-system"}},
 		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "demo-manager", Namespace: "sandbox0-system"}},
 		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "demo-manager", Namespace: "sandbox0-system"}},
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo-manager-config-abc123",
+			Namespace: "sandbox0-system",
+			Annotations: map[string]string{
+				common.ServiceConfigBaseNameAnnotation: "demo-manager",
+			},
+		}},
 		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "demo-manager", Namespace: "sandbox0-system"}},
 		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "demo-manager"}},
 		&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "demo-manager"}},
@@ -127,6 +134,7 @@ func TestCleanupDisabledServiceResourcesCleansBuiltinDependencies(t *testing.T) 
 	assertClientObjectMissing(t, client, types.NamespacedName{Namespace: "sandbox0-system", Name: "demo-manager"}, &appsv1.Deployment{})
 	assertClientObjectMissing(t, client, types.NamespacedName{Namespace: "sandbox0-system", Name: "demo-manager"}, &corev1.Service{})
 	assertClientObjectMissing(t, client, types.NamespacedName{Namespace: "sandbox0-system", Name: "demo-manager"}, &corev1.ConfigMap{})
+	assertClientObjectMissing(t, client, types.NamespacedName{Namespace: "sandbox0-system", Name: "demo-manager-config-abc123"}, &corev1.ConfigMap{})
 	assertClientObjectMissing(t, client, types.NamespacedName{Namespace: "sandbox0-system", Name: "demo-manager"}, &corev1.ServiceAccount{})
 	assertClientObjectMissing(t, client, types.NamespacedName{Name: "demo-manager"}, &rbacv1.ClusterRole{})
 	assertClientObjectMissing(t, client, types.NamespacedName{Name: "demo-manager"}, &rbacv1.ClusterRoleBinding{})

--- a/infra-operator/internal/controller/sandbox0infra_controller.go
+++ b/infra-operator/internal/controller/sandbox0infra_controller.go
@@ -453,12 +453,18 @@ func (r *Sandbox0InfraReconciler) cleanupDisabledServiceResources(
 		}
 		if err := r.Get(ctx, key, obj); err != nil {
 			if apierrors.IsNotFound(err) {
+				if ref.Kind == "ConfigMap" && ref.Namespace != "" {
+					return r.deleteHashedServiceConfigMaps(ctx, ref.Namespace, ref.Name)
+				}
 				return nil
 			}
 			return err
 		}
 		if err := r.Delete(ctx, obj); err != nil && !apierrors.IsNotFound(err) {
 			return err
+		}
+		if ref.Kind == "ConfigMap" && ref.Namespace != "" {
+			return r.deleteHashedServiceConfigMaps(ctx, ref.Namespace, ref.Name)
 		}
 		return nil
 	}
@@ -507,6 +513,23 @@ func (r *Sandbox0InfraReconciler) cleanupDisabledServiceResources(
 		}
 	}
 
+	return nil
+}
+
+func (r *Sandbox0InfraReconciler) deleteHashedServiceConfigMaps(ctx context.Context, namespace, baseName string) error {
+	var configMaps corev1.ConfigMapList
+	if err := r.List(ctx, &configMaps, client.InNamespace(namespace)); err != nil {
+		return err
+	}
+	for _, configMap := range configMaps.Items {
+		if configMap.Annotations[common.ServiceConfigBaseNameAnnotation] != baseName {
+			continue
+		}
+		cm := configMap.DeepCopy()
+		if err := r.Delete(ctx, cm); err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/infra-operator/internal/controller/services/clustergateway/clustergateway.go
+++ b/infra-operator/internal/controller/services/clustergateway/clustergateway.go
@@ -78,13 +78,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, imageRepo, imageTag string, 
 	}
 	needEnterpriseLicense := compiledPlan.Enterprise.ClusterGateway
 	common.NormalizeEnterpriseLicenseFile(&config.LicenseFile, needEnterpriseLicense)
-	podAnnotations, err := common.ConfigHashAnnotation(config)
+	configRef, err := r.Resources.ReconcileHashedServiceConfigMapWithScope(ctx, scope, deploymentName, labels, config)
 	if err != nil {
 		return err
 	}
-	if err := r.Resources.ReconcileServiceConfigMapWithScope(ctx, scope, deploymentName, labels, config); err != nil {
-		return err
-	}
+	podAnnotations := configRef.PodAnnotations()
 
 	needsControlPlanePublicKey := internalAuthRequiresControlPlaneKey(config)
 	controlPlanePublicSecretName := ""
@@ -119,7 +117,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, imageRepo, imageTag string, 
 			Name: "config",
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
-					LocalObjectReference: corev1.LocalObjectReference{Name: deploymentName},
+					LocalObjectReference: corev1.LocalObjectReference{Name: configRef.ConfigMapName},
 				},
 			},
 		},

--- a/infra-operator/internal/controller/services/clustergateway/clustergateway_test.go
+++ b/infra-operator/internal/controller/services/clustergateway/clustergateway_test.go
@@ -304,7 +304,7 @@ func TestReconcileRegionalGatewayPublicModeUpgradesToBoth(t *testing.T) {
 	}
 
 	configMap := &corev1.ConfigMap{}
-	if err := client.Get(context.Background(), types.NamespacedName{Name: "demo-cluster-gateway", Namespace: infra.Namespace}, configMap); err != nil {
+	if err := client.Get(context.Background(), types.NamespacedName{Name: configMapNameForVolume(t, deployment.Spec.Template.Spec.Volumes, "config"), Namespace: infra.Namespace}, configMap); err != nil {
 		t.Fatalf("get cluster gateway configmap: %v", err)
 	}
 	if !strings.Contains(configMap.Data["config.yaml"], "auth_mode: both") {
@@ -332,6 +332,17 @@ func newClusterGatewayTestReconciler(t *testing.T, objects ...runtime.Object) (*
 		Build()
 
 	return NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{})), client
+}
+
+func configMapNameForVolume(t *testing.T, volumes []corev1.Volume, name string) string {
+	t.Helper()
+	for _, volume := range volumes {
+		if volume.Name == name && volume.ConfigMap != nil {
+			return volume.ConfigMap.Name
+		}
+	}
+	t.Fatalf("expected configmap volume %q, got %#v", name, volumes)
+	return ""
 }
 
 func hasVolume(volumes []corev1.Volume, name string) bool {

--- a/infra-operator/internal/controller/services/ctld/ctld.go
+++ b/infra-operator/internal/controller/services/ctld/ctld.go
@@ -51,13 +51,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 		}
 		storageConfig.ObjectEncryptionKeyPath = common.ObjectEncryptionKeyPath
 	}
-	podAnnotations, err := common.ConfigHashAnnotation(storageConfig)
+	configRef, err := r.Resources.ReconcileHashedServiceConfigMap(ctx, infra, name, labels, storageConfig)
 	if err != nil {
 		return err
 	}
-	if err := r.Resources.ReconcileServiceConfigMap(ctx, infra, name, labels, storageConfig); err != nil {
-		return err
-	}
+	podAnnotations := configRef.PodAnnotations()
 	if err := r.ensureCSIDriver(ctx, labels); err != nil {
 		return err
 	}
@@ -85,7 +83,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 			Name: "config",
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
-					LocalObjectReference: corev1.LocalObjectReference{Name: name},
+					LocalObjectReference: corev1.LocalObjectReference{Name: configRef.ConfigMapName},
 				},
 			},
 		},

--- a/infra-operator/internal/controller/services/globalgateway/globalgateway.go
+++ b/infra-operator/internal/controller/services/globalgateway/globalgateway.go
@@ -78,13 +78,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 	if err := ensureGlobalGatewayBootstrapState(ctx, infra, config); err != nil {
 		return err
 	}
-	podAnnotations, err := common.ConfigHashAnnotation(config)
+	configRef, err := r.Resources.ReconcileHashedServiceConfigMap(ctx, infra, deploymentName, labels, config)
 	if err != nil {
 		return err
 	}
-	if err := r.Resources.ReconcileServiceConfigMap(ctx, infra, deploymentName, labels, config); err != nil {
-		return err
-	}
+	podAnnotations := configRef.PodAnnotations()
 
 	var resources *corev1.ResourceRequirements
 	serviceConfig := (*infrav1alpha1.ServiceNetworkConfig)(nil)
@@ -108,7 +106,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 			Name: "config",
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
-					LocalObjectReference: corev1.LocalObjectReference{Name: deploymentName},
+					LocalObjectReference: corev1.LocalObjectReference{Name: configRef.ConfigMapName},
 				},
 			},
 		},

--- a/infra-operator/internal/controller/services/globalgateway/globalgateway_test.go
+++ b/infra-operator/internal/controller/services/globalgateway/globalgateway_test.go
@@ -563,9 +563,16 @@ func TestReconcileCreatesGlobalGatewayResources(t *testing.T) {
 		t.Fatalf("reconcile returned error: %v", err)
 	}
 
-	configMap := &corev1.ConfigMap{}
+	deployment := &appsv1.Deployment{}
 	if err := client.Get(context.Background(), types.NamespacedName{
 		Name:      "demo-global-gateway",
+		Namespace: infra.Namespace,
+	}, deployment); err != nil {
+		t.Fatalf("expected deployment to be updated: %v", err)
+	}
+	configMap := &corev1.ConfigMap{}
+	if err := client.Get(context.Background(), types.NamespacedName{
+		Name:      globalGatewayConfigMapName(t, deployment),
 		Namespace: infra.Namespace,
 	}, configMap); err != nil {
 		t.Fatalf("expected configmap to be created: %v", err)
@@ -585,13 +592,6 @@ func TestReconcileCreatesGlobalGatewayResources(t *testing.T) {
 		t.Fatalf("expected service port 8080, got %#v", service.Spec.Ports)
 	}
 
-	deployment := &appsv1.Deployment{}
-	if err := client.Get(context.Background(), types.NamespacedName{
-		Name:      "demo-global-gateway",
-		Namespace: infra.Namespace,
-	}, deployment); err != nil {
-		t.Fatalf("expected deployment to be updated: %v", err)
-	}
 	if len(deployment.Spec.Template.Spec.Containers) != 1 {
 		t.Fatalf("expected one container, got %d", len(deployment.Spec.Template.Spec.Containers))
 	}
@@ -605,5 +605,15 @@ func TestReconcileCreatesGlobalGatewayResources(t *testing.T) {
 	if len(container.Ports) != 1 || container.Ports[0].ContainerPort != 8080 {
 		t.Fatalf("expected container port 8080, got %#v", container.Ports)
 	}
+}
 
+func globalGatewayConfigMapName(t *testing.T, deployment *appsv1.Deployment) string {
+	t.Helper()
+	for _, volume := range deployment.Spec.Template.Spec.Volumes {
+		if volume.Name == "config" && volume.ConfigMap != nil {
+			return volume.ConfigMap.Name
+		}
+	}
+	t.Fatalf("expected config volume, got %#v", deployment.Spec.Template.Spec.Volumes)
+	return ""
 }

--- a/infra-operator/internal/controller/services/manager/manager.go
+++ b/infra-operator/internal/controller/services/manager/manager.go
@@ -66,14 +66,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, imageRepo, imageTag string, 
 	if err != nil {
 		return err
 	}
-	podAnnotations, err := common.ConfigHashAnnotation(config)
+	configRef, err := r.Resources.ReconcileHashedServiceConfigMapWithScope(ctx, scope, deploymentName, labels, config)
 	if err != nil {
 		return err
 	}
-
-	if err := r.Resources.ReconcileServiceConfigMapWithScope(ctx, scope, deploymentName, labels, config); err != nil {
-		return err
-	}
+	podAnnotations := configRef.PodAnnotations()
 
 	httpPort := int32(config.HTTPPort)
 	metricsPort := int32(config.MetricsPort)
@@ -108,7 +105,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, imageRepo, imageTag string, 
 			Name: "config",
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
-					LocalObjectReference: corev1.LocalObjectReference{Name: deploymentName},
+					LocalObjectReference: corev1.LocalObjectReference{Name: configRef.ConfigMapName},
 				},
 			},
 		},

--- a/infra-operator/internal/controller/services/netd/netd.go
+++ b/infra-operator/internal/controller/services/netd/netd.go
@@ -95,21 +95,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, imageRepo, imageTag string, 
 			config.MITMCAKeyPath = "/tls/ca.key"
 		}
 	}
-	podAnnotations, err := common.ConfigHashAnnotation(config)
+	configRef, err := r.Resources.ReconcileHashedServiceConfigMapWithScope(ctx, scope, name, labels, config)
 	if err != nil {
 		return err
 	}
-
-	if err := r.Resources.ReconcileServiceConfigMapWithScope(ctx, scope, name, labels, config); err != nil {
-		return err
-	}
+	podAnnotations := configRef.PodAnnotations()
 
 	volumes := []corev1.Volume{
 		{
 			Name: "config",
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
-					LocalObjectReference: corev1.LocalObjectReference{Name: name},
+					LocalObjectReference: corev1.LocalObjectReference{Name: configRef.ConfigMapName},
 				},
 			},
 		},

--- a/infra-operator/internal/controller/services/netd/netd_test.go
+++ b/infra-operator/internal/controller/services/netd/netd_test.go
@@ -243,10 +243,18 @@ func TestReconcileUsesCompiledPlanForEgressAuthResolverURL(t *testing.T) {
 	if err := reconciler.Reconcile(context.Background(), "ghcr.io/sandbox0-ai/sandbox0", "latest", compiled); err != nil {
 		t.Fatalf("reconcile returned error: %v", err)
 	}
+	ds := &appsv1.DaemonSet{}
+	if err := client.Get(context.Background(), types.NamespacedName{
+		Name:      infra.Name + "-netd",
+		Namespace: infra.Namespace,
+	}, ds); err != nil {
+		t.Fatalf("expected daemonset: %v", err)
+	}
+	configMapName := netdConfigMapName(t, ds)
 
 	configMap := &corev1.ConfigMap{}
 	if err := client.Get(context.Background(), types.NamespacedName{
-		Name:      infra.Name + "-netd",
+		Name:      configMapName,
 		Namespace: infra.Namespace,
 	}, configMap); err != nil {
 		t.Fatalf("expected configmap to be created: %v", err)
@@ -317,10 +325,11 @@ func assertNetdMITMSecretMounted(t *testing.T, client ctrlclient.Client, infra *
 	if !foundVolume || !foundMount {
 		t.Fatalf("expected mitm-ca volume and mount, got volumes=%#v mounts=%#v", ds.Spec.Template.Spec.Volumes, ds.Spec.Template.Spec.Containers[0].VolumeMounts)
 	}
+	configMapName := netdConfigMapName(t, ds)
 
 	cm := &corev1.ConfigMap{}
 	if err := client.Get(context.Background(), types.NamespacedName{
-		Name:      infra.Name + "-netd",
+		Name:      configMapName,
 		Namespace: infra.Namespace,
 	}, cm); err != nil {
 		t.Fatalf("expected configmap: %v", err)
@@ -328,6 +337,17 @@ func assertNetdMITMSecretMounted(t *testing.T, client ctrlclient.Client, infra *
 	if got := cm.Data["config.yaml"]; !containsMITMPaths(got) {
 		t.Fatalf("expected mitm ca paths in config, got %q", got)
 	}
+}
+
+func netdConfigMapName(t *testing.T, ds *appsv1.DaemonSet) string {
+	t.Helper()
+	for _, volume := range ds.Spec.Template.Spec.Volumes {
+		if volume.Name == "config" && volume.ConfigMap != nil {
+			return volume.ConfigMap.Name
+		}
+	}
+	t.Fatalf("expected config volume, got %#v", ds.Spec.Template.Spec.Volumes)
+	return ""
 }
 
 func assertValidManagedMITMCASecret(t *testing.T, secret *corev1.Secret) {

--- a/infra-operator/internal/controller/services/regionalgateway/regionalgateway.go
+++ b/infra-operator/internal/controller/services/regionalgateway/regionalgateway.go
@@ -71,13 +71,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, imageRepo, imageTag string, 
 	}
 	needEnterpriseLicense := compiledPlan.Enterprise.RegionalGateway
 	common.NormalizeEnterpriseLicenseFile(&config.LicenseFile, needEnterpriseLicense)
-	podAnnotations, err := common.ConfigHashAnnotation(config)
+	configRef, err := r.Resources.ReconcileHashedServiceConfigMapWithScope(ctx, scope, deploymentName, labels, config)
 	if err != nil {
 		return err
 	}
-	if err := r.Resources.ReconcileServiceConfigMapWithScope(ctx, scope, deploymentName, labels, config); err != nil {
-		return err
-	}
+	podAnnotations := configRef.PodAnnotations()
 
 	resources := compiledPlan.RegionalGateway.Resources
 	serviceConfig := compiledPlan.RegionalGateway.ServiceConfig
@@ -107,7 +105,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, imageRepo, imageTag string, 
 			Name: "config",
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
-					LocalObjectReference: corev1.LocalObjectReference{Name: deploymentName},
+					LocalObjectReference: corev1.LocalObjectReference{Name: configRef.ConfigMapName},
 				},
 			},
 		},

--- a/infra-operator/internal/controller/services/scheduler/scheduler.go
+++ b/infra-operator/internal/controller/services/scheduler/scheduler.go
@@ -79,13 +79,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, imageRepo, imageTag string, 
 	if err := r.ensureHomeCluster(ctx, compiledPlan, config); err != nil {
 		return err
 	}
-	podAnnotations, err := common.ConfigHashAnnotation(config)
+	configRef, err := r.Resources.ReconcileHashedServiceConfigMapWithScope(ctx, scope, deploymentName, labels, config)
 	if err != nil {
 		return err
 	}
-	if err := r.Resources.ReconcileServiceConfigMapWithScope(ctx, scope, deploymentName, labels, config); err != nil {
-		return err
-	}
+	podAnnotations := configRef.PodAnnotations()
 
 	resources := compiledPlan.Scheduler.Resources
 	serviceConfig := compiledPlan.Scheduler.ServiceConfig
@@ -115,7 +113,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, imageRepo, imageTag string, 
 			Name: "config",
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
-					LocalObjectReference: corev1.LocalObjectReference{Name: deploymentName},
+					LocalObjectReference: corev1.LocalObjectReference{Name: configRef.ConfigMapName},
 				},
 			},
 		},

--- a/infra-operator/internal/controller/services/sshgateway/sshgateway.go
+++ b/infra-operator/internal/controller/services/sshgateway/sshgateway.go
@@ -62,13 +62,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 	if _, _, err := common.EnsureEd25519KeyPair(ctx, r.Resources.Client, r.Resources.Scheme, infra, hostKeySecretName, sshHostPrivateKeyKey, sshHostPublicKeyKey); err != nil {
 		return err
 	}
-	podAnnotations, err := common.ConfigHashAnnotation(config)
+	configRef, err := r.Resources.ReconcileHashedServiceConfigMap(ctx, infra, deploymentName, labels, config)
 	if err != nil {
 		return err
 	}
-	if err := r.Resources.ReconcileServiceConfigMap(ctx, infra, deploymentName, labels, config); err != nil {
-		return err
-	}
+	podAnnotations := configRef.PodAnnotations()
 
 	var resources *corev1.ResourceRequirements
 	serviceConfig := (*infrav1alpha1.ServiceNetworkConfig)(nil)
@@ -107,7 +105,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 		{
 			Name: "config",
 			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: deploymentName}},
+				ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: configRef.ConfigMapName}},
 			},
 		},
 		{

--- a/infra-operator/internal/controller/services/sshgateway/sshgateway_test.go
+++ b/infra-operator/internal/controller/services/sshgateway/sshgateway_test.go
@@ -88,7 +88,7 @@ func TestReconcileCreatesSSHGatewayResources(t *testing.T) {
 	}
 
 	configMap := &corev1.ConfigMap{}
-	if err := client.Get(context.Background(), types.NamespacedName{Name: "demo-ssh-gateway", Namespace: infra.Namespace}, configMap); err != nil {
+	if err := client.Get(context.Background(), types.NamespacedName{Name: sshGatewayConfigMapName(t, deployment), Namespace: infra.Namespace}, configMap); err != nil {
 		t.Fatalf("get configmap: %v", err)
 	}
 	configYAML := configMap.Data["config.yaml"]
@@ -106,6 +106,17 @@ func TestReconcileCreatesSSHGatewayResources(t *testing.T) {
 	if len(hostKeySecret.Data[sshHostPrivateKeyKey]) == 0 && len(hostKeySecret.StringData[sshHostPrivateKeyKey]) == 0 {
 		t.Fatal("expected ssh host private key to be generated")
 	}
+}
+
+func sshGatewayConfigMapName(t *testing.T, deployment *appsv1.Deployment) string {
+	t.Helper()
+	for _, volume := range deployment.Spec.Template.Spec.Volumes {
+		if volume.Name == "config" && volume.ConfigMap != nil {
+			return volume.ConfigMap.Name
+		}
+	}
+	t.Fatalf("expected config volume, got %#v", deployment.Spec.Template.Spec.Volumes)
+	return ""
 }
 
 func newTestScheme(t *testing.T) *runtime.Scheme {

--- a/infra-operator/internal/controller/services/storageproxy/storageproxy.go
+++ b/infra-operator/internal/controller/services/storageproxy/storageproxy.go
@@ -88,13 +88,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 	if err != nil {
 		return err
 	}
-	podAnnotations, err := common.ConfigHashAnnotation(config)
+	configRef, err := r.Resources.ReconcileHashedServiceConfigMap(ctx, infra, deploymentName, labels, config)
 	if err != nil {
 		return err
 	}
-	if err := r.Resources.ReconcileServiceConfigMap(ctx, infra, deploymentName, labels, config); err != nil {
-		return err
-	}
+	podAnnotations := configRef.PodAnnotations()
 
 	httpPort := int32(config.HTTPPort)
 	metricsPort := int32(config.MetricsPort)
@@ -133,7 +131,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 			Name: "config",
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
-					LocalObjectReference: corev1.LocalObjectReference{Name: deploymentName},
+					LocalObjectReference: corev1.LocalObjectReference{Name: configRef.ConfigMapName},
 				},
 			},
 		},

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -2057,8 +2057,8 @@ func assertObjectEncryptionLifecycle(env *framework.ScenarioEnv, session *e2euti
 	privateKey := getSecretValueWithEscapedKey(env, secretName, "private\\.key")
 	Expect(privateKey).To(ContainSubstring("BEGIN"))
 
-	assertConfigMapContains(env, env.Infra.Name+"-storage-proxy", "object_encryption_enabled: true")
-	assertConfigMapContains(env, env.Infra.Name+"-ctld", "object_encryption_enabled: true")
+	assertWorkloadConfigMapContains(env, "deployment", env.Infra.Name+"-storage-proxy", "object_encryption_enabled: true")
+	assertWorkloadConfigMapContains(env, "daemonset", env.Infra.Name+"-ctld", "object_encryption_enabled: true")
 
 	volume, status, err := session.CreateSandboxVolume(env.TestCtx.Context, GinkgoT(), apispec.CreateSandboxVolumeRequest{})
 	Expect(err).NotTo(HaveOccurred())
@@ -2174,6 +2174,29 @@ func assertConfigMapContains(env *framework.ScenarioEnv, configMapName, expected
 	)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(output).To(ContainSubstring(expected))
+}
+
+func assertWorkloadConfigMapContains(env *framework.ScenarioEnv, workloadKind, workloadName, expected string) {
+	configMapName := workloadConfigMapName(env, workloadKind, workloadName)
+	assertConfigMapContains(env, configMapName, expected)
+}
+
+func workloadConfigMapName(env *framework.ScenarioEnv, workloadKind, workloadName string) string {
+	output, err := framework.KubectlOutput(
+		env.TestCtx.Context,
+		env.Config.Kubeconfig,
+		"get",
+		workloadKind,
+		workloadName,
+		"-o",
+		`jsonpath={.spec.template.spec.volumes[?(@.name=="config")].configMap.name}`,
+		"--namespace",
+		env.Infra.Namespace,
+	)
+	Expect(err).NotTo(HaveOccurred())
+	name := strings.TrimSpace(output)
+	Expect(name).NotTo(BeEmpty())
+	return name
 }
 
 func assertNoPlaintextInStorage(env *framework.ScenarioEnv, target, root, sentinel string) {


### PR DESCRIPTION
## Summary
- create immutable, content-addressed ConfigMaps for infra-operator managed service configs
- update manager, gateways, scheduler, netd, storage-proxy, ssh-gateway, and ctld to mount the hashed ConfigMap name
- keep the config-hash pod annotation tied to the same rendered config payload and clean unused old hashed ConfigMaps after live pods stop referencing them

Fixes #402.

## Testing
- go test ./infra-operator/internal/controller/...
