### PR TITLE
Remove manager-local procd pause/resume fallback

### DIFF
--- a/docs/sandbox/pause-resume/page.mdx
+++ b/docs/sandbox/pause-resume/page.mdx
@@ -13,6 +13,10 @@ Use this page when you need to:
 Pause state is separate from `status`. Use `paused` for the simple user-facing state, and `power_state` when you need to inspect desired versus observed transition progress.
 </Callout>
 
+<Callout variant="warning">
+Self-hosted deployments must run `ctld` on sandbox nodes for pause and resume. The manager records the desired power state, and `ctld` performs cgroup freeze/thaw plus the observed-state update.
+</Callout>
+
 ## Pause A Sandbox
 
 Pause a sandbox to release compute while keeping its state available for a later resume.

--- a/docs/self-hosted/install/page.mdx
+++ b/docs/self-hosted/install/page.mdx
@@ -10,7 +10,7 @@ This is the shortest production-like path from zero to a running self-hosted San
 - A default `StorageClass`
 
 <Callout variant="info">
-Kubernetes `1.35+` is required because Sandbox0 pause/resume depends on Kubernetes in-place pod resource updates. Sandbox pause needs to reduce sandbox pod resources without recreating the pod, otherwise process state cannot be preserved across pause/resume.
+Kubernetes `1.35+` is required because Sandbox0 pause/resume depends on `ctld` and Kubernetes in-place pod resource updates. Sandbox pause needs to freeze the sandbox cgroup and reduce sandbox pod resources without recreating the pod, otherwise process state cannot be preserved across pause/resume.
 </Callout>
 
 ## 0) Create a Local Kind Cluster

--- a/infra-operator/api/config/manager.go
+++ b/infra-operator/api/config/manager.go
@@ -113,6 +113,7 @@ type ManagerConfig struct {
 	// +optional
 	// +kubebuilder:default="10m"
 	PauseMinCPU string `yaml:"pause_min_cpu" json:"pauseMinCPU"`
+	// CtldEnabled gates ctld-owned sandbox power transitions. When false, pause/resume is unsupported.
 	// +optional
 	// +kubebuilder:default=false
 	CtldEnabled bool `yaml:"ctld_enabled" json:"-"`

--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -255,7 +255,7 @@ func main() {
 	var storageProxyAdminTokenGenerator service.TokenGenerator
 	privateKey, err := internalauth.LoadEd25519PrivateKeyFromFile(internalauth.DefaultInternalJWTPrivateKeyPath)
 	if err != nil {
-		logger.Warn("Failed to load internal auth private key, pause/resume will not work",
+		logger.Warn("Failed to load internal auth private key, procd and storage-proxy calls will not work",
 			zap.String("path", internalauth.DefaultInternalJWTPrivateKeyPath),
 			zap.Error(err),
 		)
@@ -267,7 +267,7 @@ func main() {
 		})
 		internalTokenGenerator = service.NewInternalTokenGenerator(internalAuthGen)
 		storageProxyAdminTokenGenerator = service.NewStorageProxyAdminTokenGenerator(internalAuthGen)
-		logger.Info("Internal auth generators initialized for procd communication")
+		logger.Info("Internal auth generators initialized for procd and storage-proxy communication")
 	}
 
 	// Parse ratios
@@ -485,7 +485,6 @@ func main() {
 		}
 	}()
 
-	go sandboxService.StartPowerStateReconciler(ctx, cfg.ResyncPeriod.Duration)
 	go sandboxService.StartSystemVolumeReconciler(ctx, cfg.ResyncPeriod.Duration)
 
 	// Start HTTP server

--- a/manager/pkg/http/handlers_sandbox.go
+++ b/manager/pkg/http/handlers_sandbox.go
@@ -600,6 +600,8 @@ func (s *Server) writeSandboxPowerTransitionError(c *gin.Context, action, sandbo
 	switch {
 	case errors.Is(err, service.ErrSandboxPowerTransitionSuperseded):
 		spec.JSONError(c, http.StatusConflict, spec.CodeConflict, fmt.Sprintf("sandbox %s was superseded by a newer power transition", action))
+	case errors.Is(err, service.ErrSandboxPowerRequiresCtld):
+		spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox pause/resume requires ctld")
 	case errors.Is(err, context.DeadlineExceeded):
 		spec.JSONError(c, http.StatusGatewayTimeout, spec.CodeUnavailable, fmt.Sprintf("timed out waiting for sandbox to %s", action))
 	case errors.Is(err, context.Canceled):

--- a/manager/pkg/service/power_executor.go
+++ b/manager/pkg/service/power_executor.go
@@ -8,48 +8,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// SandboxPowerExecutor executes pause and resume transitions for a sandbox.
-// The manager-local implementation executes transitions directly; ctld mode records desired state for node-local reconciliation.
-type SandboxPowerExecutor interface {
-	Pause(ctx context.Context, sandboxID string) (*PauseSandboxResponse, error)
-	Resume(ctx context.Context, sandboxID string) (*ResumeSandboxResponse, error)
-}
-
-type localSandboxPowerExecutor struct {
-	service *SandboxService
-}
-
-type ctldSandboxPowerExecutor struct {
-	service *SandboxService
-}
-
-func newSandboxPowerExecutor(service *SandboxService) SandboxPowerExecutor {
-	if service != nil && service.config.CtldEnabled {
-		return &ctldSandboxPowerExecutor{service: service}
-	}
-	return newLocalSandboxPowerExecutor(service)
-}
-
-func newLocalSandboxPowerExecutor(service *SandboxService) SandboxPowerExecutor {
-	return &localSandboxPowerExecutor{service: service}
-}
-
-func (e *localSandboxPowerExecutor) Pause(ctx context.Context, sandboxID string) (*PauseSandboxResponse, error) {
-	return e.service.pauseSandboxLocal(ctx, sandboxID)
-}
-
-func (e *localSandboxPowerExecutor) Resume(ctx context.Context, sandboxID string) (*ResumeSandboxResponse, error) {
-	return e.service.resumeSandboxLocal(ctx, sandboxID)
-}
-
-func (e *ctldSandboxPowerExecutor) Pause(ctx context.Context, sandboxID string) (*PauseSandboxResponse, error) {
-	return e.service.RequestPauseSandbox(ctx, sandboxID)
-}
-
-func (e *ctldSandboxPowerExecutor) Resume(ctx context.Context, sandboxID string) (*ResumeSandboxResponse, error) {
-	return e.service.RequestResumeSandbox(ctx, sandboxID)
-}
-
 func (s *SandboxService) ctldAddressForPod(ctx context.Context, pod *corev1.Pod) (string, error) {
 	if pod == nil {
 		return "", fmt.Errorf("pod is nil")

--- a/manager/pkg/service/power_executor_ctld_test.go
+++ b/manager/pkg/service/power_executor_ctld_test.go
@@ -15,14 +15,21 @@ import (
 	ktesting "k8s.io/client-go/testing"
 )
 
-func TestNewSandboxServiceUsesCtldExecutorWhenEnabled(t *testing.T) {
+func TestNewSandboxServiceInitializesCtldClientDefaults(t *testing.T) {
 	svc := NewSandboxService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, SandboxServiceConfig{CtldEnabled: true}, zap.NewNop(), nil)
-	_, ok := svc.powerExecutor.(*ctldSandboxPowerExecutor)
-	assert.True(t, ok)
 	assert.Equal(t, 8095, svc.config.CtldPort)
 	assert.Equal(t, 15*time.Second, svc.config.CtldClientTimeout)
 	require.NotNil(t, svc.ctldClient)
 	assert.Equal(t, 15*time.Second, svc.ctldClient.httpClient.Timeout)
+}
+
+func TestSandboxPowerRequiresCtldEnabled(t *testing.T) {
+	svc := NewSandboxService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, SandboxServiceConfig{}, zap.NewNop(), nil)
+
+	_, err := svc.PauseSandbox(context.Background(), "sandbox-1")
+	require.ErrorIs(t, err, ErrSandboxPowerRequiresCtld)
+	_, err = svc.ResumeSandbox(context.Background(), "sandbox-1")
+	require.ErrorIs(t, err, ErrSandboxPowerRequiresCtld)
 }
 
 func TestCtldAddressForPodUsesHostIPWithoutK8sClient(t *testing.T) {
@@ -75,7 +82,6 @@ func TestCtldPowerExecutorRequestsPauseAsDesiredState(t *testing.T) {
 		logger:    zap.NewNop(),
 		clock:     systemTime{},
 	}
-	svc.SetPowerExecutor(&ctldSandboxPowerExecutor{service: svc})
 
 	resp, err := svc.PauseSandbox(context.Background(), "sandbox-1")
 	require.NoError(t, err)
@@ -122,7 +128,6 @@ func TestCtldPowerExecutorRequestsResumeAsDesiredState(t *testing.T) {
 		logger:    zap.NewNop(),
 		clock:     systemTime{},
 	}
-	svc.SetPowerExecutor(&ctldSandboxPowerExecutor{service: svc})
 
 	resp, err := svc.ResumeSandbox(context.Background(), "sandbox-1")
 	require.NoError(t, err)

--- a/manager/pkg/service/procd_client.go
+++ b/manager/pkg/service/procd_client.go
@@ -88,19 +88,6 @@ type SandboxResourceUsage struct {
 	Contexts []ContextResourceUsage `json:"contexts"`
 }
 
-// PauseResponse represents the response from procd pause API.
-type PauseResponse struct {
-	Paused        bool                  `json:"paused"`
-	Error         string                `json:"error,omitempty"`
-	ResourceUsage *SandboxResourceUsage `json:"resource_usage,omitempty"`
-}
-
-// ResumeResponse represents the response from procd resume API.
-type ResumeResponse struct {
-	Resumed bool   `json:"resumed"`
-	Error   string `json:"error,omitempty"`
-}
-
 // StatsResponse represents the response from procd stats API.
 type StatsResponse struct {
 	SandboxResourceUsage
@@ -125,18 +112,6 @@ type InitializeWebhook struct {
 type InitializeResponse struct {
 	SandboxID string `json:"sandbox_id"`
 	TeamID    string `json:"team_id,omitempty"`
-}
-
-// Pause calls the procd pause API and returns resource usage.
-func (c *ProcdClient) Pause(ctx context.Context, procdAddress, internalToken string) (*PauseResponse, error) {
-	url := procdAddress + "/api/v1/sandbox/pause"
-	return doProcdRequest[PauseResponse](ctx, c.httpClient, http.MethodPost, url, internalToken, "pause", nil)
-}
-
-// Resume calls the procd resume API.
-func (c *ProcdClient) Resume(ctx context.Context, procdAddress, internalToken string) (*ResumeResponse, error) {
-	url := procdAddress + "/api/v1/sandbox/resume"
-	return doProcdRequest[ResumeResponse](ctx, c.httpClient, http.MethodPost, url, internalToken, "resume", nil)
 }
 
 // Stats calls the procd stats API.

--- a/manager/pkg/service/sandbox_lifecycle_controller.go
+++ b/manager/pkg/service/sandbox_lifecycle_controller.go
@@ -359,7 +359,6 @@ func (s *SandboxService) CleanupDeletedSandbox(ctx context.Context, info Sandbox
 		errs = append(errs, fmt.Errorf("unbind sandbox volume portals: %w", err))
 	}
 	s.powerStateLocks.Delete(sandboxID)
-	s.powerStateReconcilers.Delete(sandboxID)
 	return errors.Join(errs...)
 }
 

--- a/manager/pkg/service/sandbox_service.go
+++ b/manager/pkg/service/sandbox_service.go
@@ -71,6 +71,9 @@ var ErrDataPlaneNotReady = errors.New("data plane not ready")
 var ErrQuotaExceeded = errors.New("quota exceeded")
 var errSandboxPowerStateStale = errors.New("sandbox power state changed during execution")
 
+// ErrSandboxPowerRequiresCtld is returned when pause/resume is requested without ctld ownership enabled.
+var ErrSandboxPowerRequiresCtld = errors.New("sandbox power transitions require ctld")
+
 // ErrSandboxPowerTransitionSuperseded is returned when a newer pause/resume request replaces the requested transition.
 var ErrSandboxPowerTransitionSuperseded = errors.New("sandbox power transition superseded")
 
@@ -126,14 +129,12 @@ type SandboxService struct {
 	metrics                *obsmetrics.ManagerMetrics
 	autoScaler             AutoScalerInterface
 	credentialStore        egressauth.BindingStore
-	powerExecutor          SandboxPowerExecutor
 	webhookStateVolumes    SandboxSystemVolumeClient
 	volumeMetadata         SandboxVolumeMetadataClient
 	deletionWebhookEmitter SandboxDeletionWebhookEmitter
 	quotaStore             TeamQuotaLimitStore
 	sandboxStore           SandboxStore
 	powerStateLocks        sync.Map
-	powerStateReconcilers  sync.Map
 }
 
 type TeamQuotaLimitStore interface {
@@ -225,7 +226,6 @@ func NewSandboxService(
 		logger:                 logger,
 		metrics:                metrics,
 	}
-	service.powerExecutor = newSandboxPowerExecutor(service)
 	return service
 }
 
@@ -260,14 +260,6 @@ func (s *SandboxService) SetCredentialStore(store egressauth.BindingStore) {
 	s.credentialStore = store
 }
 
-// SetPowerExecutor overrides sandbox power execution (used by tests and future node executors).
-func (s *SandboxService) SetPowerExecutor(executor SandboxPowerExecutor) {
-	if executor == nil {
-		return
-	}
-	s.powerExecutor = executor
-}
-
 // SetWebhookStateVolumeClient injects the system volume client used for durable webhook state.
 func (s *SandboxService) SetWebhookStateVolumeClient(client SandboxSystemVolumeClient) {
 	s.webhookStateVolumes = client
@@ -294,11 +286,4 @@ func (s *SandboxService) SetQuotaStore(store TeamQuotaLimitStore) {
 // SetSandboxStore injects durable sandbox identity storage.
 func (s *SandboxService) SetSandboxStore(store SandboxStore) {
 	s.sandboxStore = store
-}
-
-func (s *SandboxService) sandboxPowerExecutor() SandboxPowerExecutor {
-	if s.powerExecutor != nil {
-		return s.powerExecutor
-	}
-	return newSandboxPowerExecutor(s)
 }

--- a/manager/pkg/service/sandbox_service_pause.go
+++ b/manager/pkg/service/sandbox_service_pause.go
@@ -2,18 +2,10 @@ package service
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
-	"time"
 
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
-	"go.uber.org/zap"
-	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/util/retry"
 )
 
 // PauseSandboxResponse represents the response from pausing a sandbox.
@@ -34,101 +26,16 @@ type ResumeSandboxResponse struct {
 	RestoredMemory string            `json:"restored_memory,omitempty"`
 }
 
-// PausedState stores the sandbox state before pause for restoration on resume.
-type PausedState struct {
-	// Resources stores original pod resources before pause.
-	Resources map[string]ContainerResources `json:"resources"`
-	// OriginalTTL stores the original TTL (in seconds) set by user or default.
-	// On resume, this TTL is reused to reset the countdown.
-	OriginalTTL *int32 `json:"original_ttl,omitempty"`
-}
-
-// ContainerResources stores resource requests/limits for a container.
-type ContainerResources struct {
-	Requests corev1.ResourceList `json:"requests,omitempty"`
-	Limits   corev1.ResourceList `json:"limits,omitempty"`
-}
-
-type resumeSandboxPreparation struct {
-	Pod            *corev1.Pod
-	PowerState     SandboxPowerState
-	RestoredMemory string
-	HadPausedState bool
-}
-
-type expectedSandboxPowerState struct {
-	Desired    string
-	Generation int64
-}
-
-// PauseSandbox delegates sandbox pause execution to the configured power executor.
+// PauseSandbox records a desired paused state for ctld reconciliation.
 func (s *SandboxService) PauseSandbox(ctx context.Context, sandboxID string) (*PauseSandboxResponse, error) {
-	return s.sandboxPowerExecutor().Pause(ctx, sandboxID)
-}
-
-// pauseSandboxLocal pauses a sandbox and reduces pod resources based on actual usage.
-// This uses Kubernetes 1.35+ in-place pod update feature.
-func (s *SandboxService) pauseSandboxLocal(ctx context.Context, sandboxID string) (*PauseSandboxResponse, error) {
-	s.logger.Info("Pausing sandbox", zap.String("sandboxID", sandboxID))
-
-	// Find the pod by sandbox ID
-	pod, err := s.getSandboxPod(ctx, sandboxID)
-	if err != nil {
-		return nil, fmt.Errorf("get pod: %w", err)
-	}
-
-	// Check if already paused
-	if pod.Annotations[controller.AnnotationPaused] == "true" {
-		return &PauseSandboxResponse{
-			SandboxID:  sandboxID,
-			Paused:     true,
-			PowerState: sandboxPowerStateFromAnnotations(pod.Annotations),
-		}, nil
-	}
-	expected := currentSandboxPowerExpectation(pod.Annotations, SandboxPowerStatePaused)
-
-	// Generate internal token for procd authentication
-	if s.internalTokenGenerator == nil {
-		return nil, fmt.Errorf("token generators not configured, cannot authenticate with procd")
-	}
-	teamID := pod.Annotations[controller.AnnotationTeamID]
-	userID := pod.Annotations[controller.AnnotationUserID]
-
-	internalToken, err := s.internalTokenGenerator.GenerateToken(teamID, userID, sandboxID)
-	if err != nil {
-		return nil, fmt.Errorf("generate internal token: %w", err)
-	}
-
-	// Call procd pause API
-	procdAddress, err := s.prodAddress(ctx, pod)
-	if err != nil {
-		return nil, fmt.Errorf("get procd address: %w", err)
-	}
-	pauseResp, err := s.procdClient.Pause(ctx, procdAddress, internalToken)
-	if err != nil {
-		return nil, fmt.Errorf("call procd pause: %w", err)
-	}
-
-	if !pauseResp.Paused {
-		return nil, fmt.Errorf("procd pause failed: %s", pauseResp.Error)
-	}
-
-	completedResp, err := s.completePausedSandbox(ctx, pod, sandboxID, pauseResp.ResourceUsage, expected)
-	if err != nil && errors.Is(err, errSandboxPowerStateStale) && completedResp != nil && completedResp.PowerState.Desired == SandboxPowerStateActive {
-		resumeResp, resumeErr := s.procdClient.Resume(ctx, procdAddress, internalToken)
-		if resumeErr != nil {
-			return completedResp, fmt.Errorf("resume procd after stale pause: %w", resumeErr)
-		}
-		if !resumeResp.Resumed {
-			return completedResp, fmt.Errorf("procd resume after stale pause failed: %s", resumeResp.Error)
-		}
-		return &PauseSandboxResponse{SandboxID: sandboxID, Paused: false, PowerState: completedResp.PowerState, ResourceUsage: pauseResp.ResourceUsage}, nil
-	}
-	return completedResp, err
+	return s.RequestPauseSandbox(ctx, sandboxID)
 }
 
 // RequestPauseSandbox records a desired paused state and reconciles it asynchronously.
 func (s *SandboxService) RequestPauseSandbox(ctx context.Context, sandboxID string) (*PauseSandboxResponse, error) {
+	if err := s.requireCtldPowerTransitions(); err != nil {
+		return nil, err
+	}
 	state, err := s.requestSandboxPowerState(ctx, sandboxID, SandboxPowerStatePaused)
 	if err != nil {
 		return nil, err
@@ -160,365 +67,16 @@ func (s *SandboxService) PauseSandboxAndWait(ctx context.Context, sandboxID stri
 	return resp, nil
 }
 
-// ResumeSandbox delegates sandbox resume execution to the configured power executor.
+// ResumeSandbox records a desired active state for ctld reconciliation.
 func (s *SandboxService) ResumeSandbox(ctx context.Context, sandboxID string) (*ResumeSandboxResponse, error) {
-	return s.sandboxPowerExecutor().Resume(ctx, sandboxID)
-}
-
-// resumeSandboxLocal resumes a paused sandbox and restores original pod resources.
-func (s *SandboxService) resumeSandboxLocal(ctx context.Context, sandboxID string) (*ResumeSandboxResponse, error) {
-	s.logger.Info("Resuming sandbox", zap.String("sandboxID", sandboxID))
-
-	// Find the pod by sandbox ID
-	pod, err := s.getSandboxPod(ctx, sandboxID)
-	if err != nil {
-		return nil, fmt.Errorf("get pods: %w", err)
-	}
-	expected := currentSandboxPowerExpectation(pod.Annotations, SandboxPowerStateActive)
-
-	prep, resp, err := s.prepareSandboxResume(ctx, pod, sandboxID, expected)
-	if err != nil {
-		return nil, err
-	}
-	if resp != nil {
-		return resp, nil
-	}
-	pod = prep.Pod
-
-	// Generate internal token for procd authentication
-	if s.internalTokenGenerator == nil {
-		return nil, fmt.Errorf("token generators not configured, cannot authenticate with procd")
-	}
-	teamID := pod.Annotations[controller.AnnotationTeamID]
-	userID := pod.Annotations[controller.AnnotationUserID]
-
-	internalToken, err := s.internalTokenGenerator.GenerateToken(teamID, userID, sandboxID)
-	if err != nil {
-		return nil, fmt.Errorf("generate internal token: %w", err)
-	}
-
-	// Call procd resume API
-	procdAddress, err := s.prodAddress(ctx, pod)
-	if err != nil {
-		return nil, fmt.Errorf("get procd address: %w", err)
-	}
-	resumeResp, err := s.procdClient.Resume(ctx, procdAddress, internalToken)
-	if err != nil {
-		return nil, fmt.Errorf("call procd resume: %w", err)
-	}
-
-	if !resumeResp.Resumed {
-		return nil, fmt.Errorf("procd resume failed: %s", resumeResp.Error)
-	}
-
-	powerState, err := s.completeSandboxResume(ctx, sandboxID, expected)
-	if err != nil {
-		return nil, err
-	}
-
-	s.logger.Info("Sandbox resumed successfully",
-		zap.String("sandboxID", sandboxID),
-		zap.String("restoredMemory", prep.RestoredMemory),
-	)
-
-	return &ResumeSandboxResponse{
-		SandboxID:      sandboxID,
-		Resumed:        true,
-		PowerState:     powerState,
-		RestoredMemory: prep.RestoredMemory,
-	}, nil
-}
-
-func (s *SandboxService) completePausedSandbox(ctx context.Context, pod *corev1.Pod, sandboxID string, usage *SandboxResourceUsage, expected expectedSandboxPowerState) (*PauseSandboxResponse, error) {
-	if pod.Annotations[controller.AnnotationPaused] == "true" {
-		return &PauseSandboxResponse{
-			SandboxID:  sandboxID,
-			Paused:     true,
-			PowerState: sandboxPowerStateFromAnnotations(pod.Annotations),
-		}, nil
-	}
-
-	pausedState := PausedState{Resources: s.extractOriginalResources(pod)}
-	if configJSON := pod.Annotations[controller.AnnotationConfig]; configJSON != "" {
-		var config SandboxConfig
-		if err := json.Unmarshal([]byte(configJSON), &config); err == nil && config.TTL != nil {
-			pausedState.OriginalTTL = config.TTL
-		}
-	}
-	pausedStateJSON, err := json.Marshal(pausedState)
-	if err != nil {
-		return nil, fmt.Errorf("marshal paused state: %w", err)
-	}
-
-	var newRequestMemory resource.Quantity
-	var newLimitMemory resource.Quantity
-	if usage != nil && usage.ContainerMemoryWorkingSet > 0 {
-		workingSet := usage.ContainerMemoryWorkingSet
-		reqBytes := int64(workingSet)
-		minReq, err := resource.ParseQuantity(s.config.PauseMinMemoryRequest)
-		if err == nil && reqBytes < minReq.Value() {
-			reqBytes = minReq.Value()
-		}
-		newRequestMemory = *resource.NewQuantity(reqBytes, resource.BinarySI)
-
-		limitBytes := int64(float64(workingSet) * s.config.PauseMemoryBufferRatio)
-		minLimit, err := resource.ParseQuantity(s.config.PauseMinMemoryLimit)
-		if err == nil && limitBytes < minLimit.Value() {
-			limitBytes = minLimit.Value()
-		}
-		newLimitMemory = *resource.NewQuantity(limitBytes, resource.BinarySI)
-	}
-
-	minCPU := resource.MustParse(s.config.PauseMinCPU)
-	var powerState SandboxPowerState
-	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		currentPod, getErr := s.getSandboxPodForPowerState(ctx, sandboxID)
-		if getErr != nil {
-			return getErr
-		}
-		if currentPod.Annotations[controller.AnnotationPaused] == "true" {
-			powerState = sandboxPowerStateFromAnnotations(currentPod.Annotations)
-			pod = currentPod
-			return nil
-		}
-		currentState, matchErr := s.matchSandboxPowerExpectation(currentPod, expected)
-		if matchErr != nil {
-			powerState = currentState
-			return matchErr
-		}
-		annotatedPod := currentPod.DeepCopy()
-		if annotatedPod.Annotations == nil {
-			annotatedPod.Annotations = make(map[string]string)
-		}
-		annotatedPod.Annotations[controller.AnnotationPaused] = "true"
-		annotatedPod.Annotations[controller.AnnotationPausedAt] = s.clock.Now().Format(time.RFC3339)
-		annotatedPod.Annotations[controller.AnnotationPausedState] = string(pausedStateJSON)
-		powerState = completedSandboxPowerState(annotatedPod.Annotations, SandboxPowerStatePaused)
-		applySandboxPowerStateAnnotations(annotatedPod.Annotations, powerState)
-		delete(annotatedPod.Annotations, controller.AnnotationExpiresAt)
-
-		updatedPod, updateErr := s.k8sClient.CoreV1().Pods(currentPod.Namespace).Update(ctx, annotatedPod, metav1.UpdateOptions{})
-		if updateErr != nil {
-			return updateErr
-		}
-		pod = updatedPod
-		return nil
-	})
-	if err != nil {
-		if errors.Is(err, errSandboxPowerStateStale) {
-			return &PauseSandboxResponse{
-				SandboxID:     sandboxID,
-				Paused:        powerState.Desired == SandboxPowerStatePaused,
-				PowerState:    powerState,
-				ResourceUsage: usage,
-			}, err
-		}
-		return nil, fmt.Errorf("update pod annotations after pause: %w", err)
-	}
-
-	if !newLimitMemory.IsZero() || !minCPU.IsZero() {
-		resizePod := pod.DeepCopy()
-		found := s.applyPausedResourceTargets(resizePod, newRequestMemory, newLimitMemory, minCPU)
-		if !found {
-			s.logger.Warn("Main container 'procd' not found during pause resource update", zap.String("sandboxID", sandboxID))
-		} else if _, err = s.k8sClient.CoreV1().Pods(pod.Namespace).UpdateResize(ctx, pod.Name, resizePod, metav1.UpdateOptions{}); err != nil {
-			s.logger.Error("Failed to update pod resources after pause",
-				zap.String("sandboxID", sandboxID),
-				zap.Error(err),
-			)
-		}
-	}
-
-	workingSet := int64(0)
-	if usage != nil {
-		workingSet = usage.ContainerMemoryWorkingSet
-	}
-	s.logger.Info("Sandbox paused successfully",
-		zap.String("sandboxID", sandboxID),
-		zap.String("newRequest", newRequestMemory.String()),
-		zap.String("newLimit", newLimitMemory.String()),
-		zap.Int64("workingSet", workingSet),
-	)
-
-	return &PauseSandboxResponse{
-		SandboxID:     sandboxID,
-		Paused:        true,
-		PowerState:    powerState,
-		ResourceUsage: usage,
-		UpdatedMemory: newLimitMemory.String(),
-		UpdatedCPU:    minCPU.String(),
-	}, nil
-}
-
-func (s *SandboxService) applyPausedResourceTargets(resizePod *corev1.Pod, newRequestMemory, newLimitMemory, minCPU resource.Quantity) bool {
-	if resizePod == nil {
-		return false
-	}
-	for i := range resizePod.Spec.Containers {
-		container := &resizePod.Spec.Containers[i]
-		if container.Name != "procd" {
-			continue
-		}
-		if container.Resources.Requests == nil {
-			container.Resources.Requests = make(corev1.ResourceList)
-		}
-		if !newRequestMemory.IsZero() {
-			container.Resources.Requests[corev1.ResourceMemory] = newRequestMemory
-		}
-		container.Resources.Requests[corev1.ResourceCPU] = minCPU
-		if container.Resources.Limits == nil {
-			container.Resources.Limits = make(corev1.ResourceList)
-		}
-		if !newLimitMemory.IsZero() {
-			container.Resources.Limits[corev1.ResourceMemory] = newLimitMemory
-		}
-		container.Resources.Limits[corev1.ResourceCPU] = minCPU
-		return true
-	}
-	return false
-}
-
-func (s *SandboxService) prepareSandboxResume(ctx context.Context, pod *corev1.Pod, sandboxID string, expected expectedSandboxPowerState) (*resumeSandboxPreparation, *ResumeSandboxResponse, error) {
-	if pod.Annotations[controller.AnnotationPaused] != "true" && !sandboxPodMayHaveFrozenCgroup(pod) {
-		return nil, &ResumeSandboxResponse{
-			SandboxID:  sandboxID,
-			Resumed:    true,
-			PowerState: sandboxPowerStateFromAnnotations(pod.Annotations),
-		}, nil
-	}
-	if pod.Annotations[controller.AnnotationPaused] != "true" {
-		return &resumeSandboxPreparation{Pod: pod, PowerState: sandboxPowerStateFromAnnotations(pod.Annotations)}, nil, nil
-	}
-
-	var restoredMemory string
-	var powerState SandboxPowerState
-	var hadPausedState bool
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		currentPod, getErr := s.getSandboxPodForPowerState(ctx, sandboxID)
-		if getErr != nil {
-			return getErr
-		}
-		if currentPod.Annotations[controller.AnnotationPaused] != "true" {
-			powerState = sandboxPowerStateFromAnnotations(currentPod.Annotations)
-			pod = currentPod
-			return nil
-		}
-		currentState, matchErr := s.matchSandboxPowerExpectation(currentPod, expected)
-		if matchErr != nil {
-			powerState = currentState
-			return matchErr
-		}
-
-		powerState = requestedSandboxPowerState(currentPod.Annotations, SandboxPowerStateActive)
-		pod = currentPod
-
-		pausedStateJSON := currentPod.Annotations[controller.AnnotationPausedState]
-		if pausedStateJSON == "" {
-			hadPausedState = false
-			return nil
-		}
-		var pausedState PausedState
-		if err := json.Unmarshal([]byte(pausedStateJSON), &pausedState); err != nil {
-			hadPausedState = false
-			return nil
-		}
-		hadPausedState = true
-		resizePod := currentPod.DeepCopy()
-		for i := range resizePod.Spec.Containers {
-			container := &resizePod.Spec.Containers[i]
-			if orig, ok := pausedState.Resources[container.Name]; ok {
-				container.Resources.Requests = orig.Requests
-				container.Resources.Limits = orig.Limits
-				if memReq, ok := orig.Requests[corev1.ResourceMemory]; ok {
-					restoredMemory = memReq.String()
-				}
-			}
-		}
-		_, updateErr := s.k8sClient.CoreV1().Pods(currentPod.Namespace).UpdateResize(ctx, currentPod.Name, resizePod, metav1.UpdateOptions{})
-		return updateErr
-	})
-	if err != nil {
-		if errors.Is(err, errSandboxPowerStateStale) {
-			return nil, &ResumeSandboxResponse{
-				SandboxID:  sandboxID,
-				Resumed:    powerState.Desired == SandboxPowerStateActive,
-				PowerState: powerState,
-			}, err
-		}
-		return nil, nil, fmt.Errorf("restore pod resources before resume: %w", err)
-	}
-
-	if pod.Annotations[controller.AnnotationPaused] != "true" {
-		return nil, &ResumeSandboxResponse{
-			SandboxID:  sandboxID,
-			Resumed:    true,
-			PowerState: powerState,
-		}, nil
-	}
-
-	return &resumeSandboxPreparation{Pod: pod, PowerState: powerState, RestoredMemory: restoredMemory, HadPausedState: hadPausedState}, nil, nil
-}
-
-func (s *SandboxService) completeSandboxResume(ctx context.Context, sandboxID string, expected expectedSandboxPowerState) (SandboxPowerState, error) {
-	var powerState SandboxPowerState
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		currentPod, getErr := s.getSandboxPodForPowerState(ctx, sandboxID)
-		if getErr != nil {
-			return getErr
-		}
-		if currentPod.Annotations[controller.AnnotationPaused] != "true" {
-			currentState := sandboxPowerStateFromAnnotations(currentPod.Annotations)
-			if !sandboxPodMayHaveFrozenCgroup(currentPod) && currentState.Desired == SandboxPowerStateActive && currentState.Observed == SandboxPowerStateActive && currentState.Phase == SandboxPowerPhaseStable {
-				powerState = currentState
-				return nil
-			}
-			annotationPod := currentPod.DeepCopy()
-			if annotationPod.Annotations == nil {
-				annotationPod.Annotations = make(map[string]string)
-			}
-			powerState = completedSandboxPowerState(annotationPod.Annotations, SandboxPowerStateActive)
-			applySandboxPowerStateAnnotations(annotationPod.Annotations, powerState)
-			_, updateErr := s.k8sClient.CoreV1().Pods(currentPod.Namespace).Update(ctx, annotationPod, metav1.UpdateOptions{})
-			return updateErr
-		}
-		currentState, matchErr := s.matchSandboxPowerExpectation(currentPod, expected)
-		if matchErr != nil {
-			powerState = currentState
-			return matchErr
-		}
-
-		annotationPod := currentPod.DeepCopy()
-		if annotationPod.Annotations == nil {
-			annotationPod.Annotations = make(map[string]string)
-		}
-		var ttlToRestore *int32
-		pausedStateJSON := currentPod.Annotations[controller.AnnotationPausedState]
-		if pausedStateJSON != "" {
-			var pausedState PausedState
-			if err := json.Unmarshal([]byte(pausedStateJSON), &pausedState); err == nil {
-				ttlToRestore = pausedState.OriginalTTL
-			}
-		}
-		if ttlToRestore == nil && s.config.DefaultTTL > 0 {
-			ttlToRestore = int32Ptr(int32(s.config.DefaultTTL.Seconds()))
-		}
-		setExpirationAnnotation(annotationPod.Annotations, s.clock.Now(), ttlToRestore)
-		delete(annotationPod.Annotations, controller.AnnotationPaused)
-		delete(annotationPod.Annotations, controller.AnnotationPausedAt)
-		delete(annotationPod.Annotations, controller.AnnotationPausedState)
-		powerState = completedSandboxPowerState(annotationPod.Annotations, SandboxPowerStateActive)
-		applySandboxPowerStateAnnotations(annotationPod.Annotations, powerState)
-		_, updateErr := s.k8sClient.CoreV1().Pods(currentPod.Namespace).Update(ctx, annotationPod, metav1.UpdateOptions{})
-		return updateErr
-	})
-	if err != nil {
-		return powerState, err
-	}
-	return powerState, nil
+	return s.RequestResumeSandbox(ctx, sandboxID)
 }
 
 // RequestResumeSandbox records a desired active state and reconciles it asynchronously.
 func (s *SandboxService) RequestResumeSandbox(ctx context.Context, sandboxID string) (*ResumeSandboxResponse, error) {
+	if err := s.requireCtldPowerTransitions(); err != nil {
+		return nil, err
+	}
 	state, err := s.requestSandboxPowerState(ctx, sandboxID, SandboxPowerStateActive)
 	if err != nil {
 		return nil, err
@@ -576,6 +134,13 @@ func (s *SandboxService) PauseSandboxByID(ctx context.Context, sandboxID string)
 	return s.RequestPauseSandboxByID(ctx, sandboxID)
 }
 
+func (s *SandboxService) requireCtldPowerTransitions() error {
+	if s == nil || !s.config.CtldEnabled {
+		return ErrSandboxPowerRequiresCtld
+	}
+	return nil
+}
+
 // TerminateSandboxByID implements the SandboxTerminator interface from controller package.
 // It wraps TerminateSandbox and returns only the error.
 func (s *SandboxService) TerminateSandboxByID(ctx context.Context, sandboxID string) error {
@@ -613,18 +178,4 @@ func (s *SandboxService) GetSandboxResourceUsage(ctx context.Context, sandboxID 
 	}
 
 	return &statsResp.SandboxResourceUsage, nil
-}
-
-// extractOriginalResources extracts current resources from pod containers.
-func (s *SandboxService) extractOriginalResources(pod *corev1.Pod) map[string]ContainerResources {
-	resources := make(map[string]ContainerResources)
-
-	for _, container := range pod.Spec.Containers {
-		resources[container.Name] = ContainerResources{
-			Requests: container.Resources.Requests.DeepCopy(),
-			Limits:   container.Resources.Limits.DeepCopy(),
-		}
-	}
-
-	return resources
 }

--- a/manager/pkg/service/sandbox_service_power.go
+++ b/manager/pkg/service/sandbox_service_power.go
@@ -6,10 +6,8 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
-	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -77,14 +75,6 @@ func annotationValue(annotations map[string]string, key string) string {
 		return ""
 	}
 	return annotations[key]
-}
-
-func shouldReconcileSandboxPowerState(pod *corev1.Pod) bool {
-	if pod == nil || pod.DeletionTimestamp != nil {
-		return false
-	}
-	state := sandboxPowerStateFromAnnotations(pod.Annotations)
-	return state.Phase != SandboxPowerPhaseStable || state.Desired != state.Observed
 }
 
 func sandboxPodMayHaveFrozenCgroup(pod *corev1.Pod) bool {
@@ -161,24 +151,8 @@ func completedSandboxPowerState(annotations map[string]string, target string) Sa
 	}
 }
 
-func currentSandboxPowerExpectation(annotations map[string]string, target string) expectedSandboxPowerState {
-	state := sandboxPowerStateFromAnnotations(annotations)
-	return expectedSandboxPowerState{Desired: target, Generation: state.DesiredGeneration}
-}
-
 func staleSandboxPowerStateError(current SandboxPowerState) error {
 	return fmt.Errorf("%w: desired=%s generation=%d", errSandboxPowerStateStale, current.Desired, current.DesiredGeneration)
-}
-
-func (s *SandboxService) matchSandboxPowerExpectation(pod *corev1.Pod, expected expectedSandboxPowerState) (SandboxPowerState, error) {
-	if pod == nil {
-		return SandboxPowerState{}, fmt.Errorf("pod is nil")
-	}
-	current := sandboxPowerStateFromAnnotations(pod.Annotations)
-	if expected.Generation > 0 && (current.Desired != expected.Desired || current.DesiredGeneration != expected.Generation) {
-		return current, staleSandboxPowerStateError(current)
-	}
-	return current, nil
 }
 
 func applySandboxPowerStateAnnotations(annotations map[string]string, state SandboxPowerState) {
@@ -239,9 +213,7 @@ func (s *SandboxService) requestSandboxPowerState(ctx context.Context, sandboxID
 
 		current := sandboxPowerStateFromAnnotations(pod.Annotations)
 		state = requestedSandboxPowerState(pod.Annotations, target)
-		if s.config.CtldEnabled {
-			state = preserveCtldInFlightPowerTransition(current, state, target)
-		}
+		state = preserveCtldInFlightPowerTransition(current, state, target)
 		if hasExplicitSandboxPowerStateAnnotations(pod.Annotations) && sandboxPowerStateEqual(current, state) {
 			return nil
 		}
@@ -250,10 +222,6 @@ func (s *SandboxService) requestSandboxPowerState(ctx context.Context, sandboxID
 	})
 	if err != nil {
 		return SandboxPowerState{}, fmt.Errorf("update power state annotations: %w", err)
-	}
-
-	if state.Phase != SandboxPowerPhaseStable && s.managerExecutesPowerTransitions() {
-		s.triggerSandboxPowerStateReconcile(sandboxID)
 	}
 
 	return state, nil
@@ -299,147 +267,6 @@ func sandboxPowerTransitionContext(ctx context.Context) (context.Context, contex
 		return context.WithCancel(ctx)
 	}
 	return context.WithTimeout(ctx, defaultSandboxPowerTransitionTimeout)
-}
-
-func (s *SandboxService) triggerSandboxPowerStateReconcile(sandboxID string) {
-	if _, loaded := s.powerStateReconcilers.LoadOrStore(sandboxID, struct{}{}); loaded {
-		return
-	}
-	go func() {
-		defer s.finishSandboxPowerStateReconcile(sandboxID)
-		s.reconcileSandboxPowerState(sandboxID)
-	}()
-}
-
-func (s *SandboxService) managerExecutesPowerTransitions() bool {
-	return s != nil && !s.config.CtldEnabled
-}
-
-// StartPowerStateReconciler periodically reconciles power transitions left pending by another manager replica.
-func (s *SandboxService) StartPowerStateReconciler(ctx context.Context, interval time.Duration) {
-	if !s.managerExecutesPowerTransitions() {
-		return
-	}
-	if interval <= 0 {
-		interval = 30 * time.Second
-	}
-	s.reconcilePendingSandboxPowerStates(ctx)
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-			s.reconcilePendingSandboxPowerStates(ctx)
-		}
-	}
-}
-
-func (s *SandboxService) reconcilePendingSandboxPowerStates(ctx context.Context) {
-	if ctx.Err() != nil || s.podLister == nil {
-		return
-	}
-	pods, err := s.podLister.List(labels.Everything())
-	if err != nil {
-		s.logger.Warn("Failed to list sandboxes for power state reconcile", zap.Error(err))
-		return
-	}
-	for _, pod := range pods {
-		if !shouldReconcileSandboxPowerState(pod) {
-			continue
-		}
-		sandboxID := strings.TrimSpace(pod.Labels[controller.LabelSandboxID])
-		if sandboxID == "" {
-			continue
-		}
-		s.triggerSandboxPowerStateReconcile(sandboxID)
-	}
-}
-
-func (s *SandboxService) finishSandboxPowerStateReconcile(sandboxID string) {
-	s.powerStateReconcilers.Delete(sandboxID)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	pod, err := s.getSandboxPodForPowerState(ctx, sandboxID)
-	if err != nil {
-		return
-	}
-	if shouldReconcileSandboxPowerState(pod) {
-		s.triggerSandboxPowerStateReconcile(sandboxID)
-	}
-}
-
-func (s *SandboxService) reconcileSandboxPowerState(sandboxID string) {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	defer cancel()
-
-	for {
-		pod, err := s.getSandboxPodForPowerState(ctx, sandboxID)
-		if err != nil {
-			s.logger.Warn("Power state reconcile failed to load sandbox",
-				zap.String("sandboxID", sandboxID),
-				zap.Error(err),
-			)
-			return
-		}
-		if pod.DeletionTimestamp != nil {
-			return
-		}
-
-		state := sandboxPowerStateFromAnnotations(pod.Annotations)
-		if state.Phase == SandboxPowerPhaseStable && state.Desired == state.Observed {
-			return
-		}
-
-		s.logger.Info("Reconciling sandbox power state",
-			zap.String("sandboxID", sandboxID),
-			zap.String("desired", state.Desired),
-			zap.Int64("desiredGeneration", state.DesiredGeneration),
-			zap.String("observed", state.Observed),
-			zap.Int64("observedGeneration", state.ObservedGeneration),
-			zap.String("phase", state.Phase),
-		)
-
-		switch state.Desired {
-		case SandboxPowerStatePaused:
-			if _, err := s.PauseSandbox(ctx, sandboxID); err != nil {
-				s.logger.Error("Pause reconcile failed",
-					zap.String("sandboxID", sandboxID),
-					zap.Error(err),
-				)
-				return
-			}
-		case SandboxPowerStateActive:
-			if _, err := s.ResumeSandbox(ctx, sandboxID); err != nil {
-				s.logger.Error("Resume reconcile failed",
-					zap.String("sandboxID", sandboxID),
-					zap.Error(err),
-				)
-				return
-			}
-		default:
-			s.logger.Warn("Skipping power state reconcile with unsupported desired state",
-				zap.String("sandboxID", sandboxID),
-				zap.String("desired", state.Desired),
-			)
-			return
-		}
-
-		nextPod, err := s.getSandboxPodForPowerState(ctx, sandboxID)
-		if err != nil {
-			return
-		}
-		nextState := sandboxPowerStateFromAnnotations(nextPod.Annotations)
-		if nextState.Phase == SandboxPowerPhaseStable && nextState.Desired == nextState.Observed {
-			return
-		}
-		if nextState.Desired == state.Desired && nextState.DesiredGeneration == state.DesiredGeneration {
-			return
-		}
-	}
 }
 
 func (s *SandboxService) getSandboxPodForPowerState(ctx context.Context, sandboxID string) (*corev1.Pod, error) {

--- a/manager/pkg/service/sandbox_service_power_state_test.go
+++ b/manager/pkg/service/sandbox_service_power_state_test.go
@@ -2,16 +2,11 @@ package service
 
 import (
 	"context"
-	"net/http"
-	"net/http/httptest"
-	"net/url"
 	"strconv"
-	"sync"
 	"testing"
 	"time"
 
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
-	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -211,6 +206,7 @@ func TestRequestPauseSandboxRecordsDesiredPausedState(t *testing.T) {
 	svc := &SandboxService{
 		k8sClient: k8sClient,
 		podLister: newTestPodLister(t, pod),
+		config:    SandboxServiceConfig{CtldEnabled: true},
 		clock:     systemTime{},
 		logger:    zap.NewNop(),
 	}
@@ -253,6 +249,7 @@ func TestRequestPauseSandboxRetriesConflict(t *testing.T) {
 	svc := &SandboxService{
 		k8sClient: k8sClient,
 		podLister: newTestPodLister(t, pod),
+		config:    SandboxServiceConfig{CtldEnabled: true},
 		clock:     systemTime{},
 		logger:    zap.NewNop(),
 	}
@@ -281,19 +278,16 @@ func TestRequestPauseSandboxByIDRecordsDesiredState(t *testing.T) {
 		Status: corev1.PodStatus{Phase: corev1.PodRunning},
 	}
 	k8sClient := fake.NewSimpleClientset(pod)
-	executor := &recordingPowerExecutor{}
 	svc := &SandboxService{
 		k8sClient: k8sClient,
 		podLister: newTestPodLister(t, pod),
+		config:    SandboxServiceConfig{CtldEnabled: true},
 		clock:     systemTime{},
 		logger:    zap.NewNop(),
 	}
-	svc.SetPowerExecutor(executor)
-	svc.powerStateReconcilers.Store("sandbox-1", struct{}{})
 
 	require.NoError(t, svc.RequestPauseSandboxByID(context.Background(), "sandbox-1"))
 
-	assert.Empty(t, executor.pauseCalls)
 	updated, err := k8sClient.CoreV1().Pods("default").Get(context.Background(), "sandbox-1", metav1.GetOptions{})
 	require.NoError(t, err)
 	state := sandboxPowerStateFromAnnotations(updated.Annotations)
@@ -302,175 +296,33 @@ func TestRequestPauseSandboxByIDRecordsDesiredState(t *testing.T) {
 	assert.Equal(t, SandboxPowerPhasePausing, state.Phase)
 }
 
-func TestSandboxPowerExecutorOverrideIsUsed(t *testing.T) {
-	executor := &recordingPowerExecutor{}
-	svc := &SandboxService{logger: zap.NewNop()}
-	svc.SetPowerExecutor(executor)
-
-	pauseResp, err := svc.PauseSandbox(context.Background(), "sandbox-1")
-	require.NoError(t, err)
-	resumeResp, err := svc.ResumeSandbox(context.Background(), "sandbox-1")
-	require.NoError(t, err)
-
-	assert.Equal(t, []string{"sandbox-1"}, executor.pauseCalls)
-	assert.Equal(t, []string{"sandbox-1"}, executor.resumeCalls)
-	assert.Equal(t, SandboxPowerStatePaused, pauseResp.PowerState.Desired)
-	assert.Equal(t, SandboxPowerStateActive, resumeResp.PowerState.Desired)
-}
-
-func TestReconcileSandboxPowerStateUsesConfiguredExecutor(t *testing.T) {
-	t.Run("pause", func(t *testing.T) {
-		pod := newPowerStatePod(SandboxPowerStatePaused, SandboxPowerStateActive, SandboxPowerPhasePausing)
-		executor := &recordingPowerExecutor{}
-		svc := &SandboxService{
-			k8sClient: fake.NewSimpleClientset(pod),
-			podLister: newTestPodLister(t, pod),
-			logger:    zap.NewNop(),
-		}
-		svc.SetPowerExecutor(executor)
-
-		svc.reconcileSandboxPowerState("sandbox-1")
-
-		assert.Equal(t, []string{"sandbox-1"}, executor.pauseCalls)
-		assert.Empty(t, executor.resumeCalls)
-	})
-
-	t.Run("resume", func(t *testing.T) {
-		pod := newPowerStatePod(SandboxPowerStateActive, SandboxPowerStatePaused, SandboxPowerPhaseResuming)
-		executor := &recordingPowerExecutor{}
-		svc := &SandboxService{
-			k8sClient: fake.NewSimpleClientset(pod),
-			podLister: newTestPodLister(t, pod),
-			logger:    zap.NewNop(),
-		}
-		svc.SetPowerExecutor(executor)
-
-		svc.reconcileSandboxPowerState("sandbox-1")
-
-		assert.Empty(t, executor.pauseCalls)
-		assert.Equal(t, []string{"sandbox-1"}, executor.resumeCalls)
-	})
-}
-
-func TestShouldReconcileSandboxPowerStateSkipsDeletingPod(t *testing.T) {
-	pending := newPowerStatePod(SandboxPowerStatePaused, SandboxPowerStateActive, SandboxPowerPhasePausing)
-	assert.True(t, shouldReconcileSandboxPowerState(pending))
-
-	stable := newPowerStatePod(SandboxPowerStatePaused, SandboxPowerStatePaused, SandboxPowerPhaseStable)
-	assert.False(t, shouldReconcileSandboxPowerState(stable))
-
-	deleting := newPowerStatePod(SandboxPowerStatePaused, SandboxPowerStateActive, SandboxPowerPhasePausing)
-	deletedAt := metav1.NewTime(time.Now())
-	deleting.DeletionTimestamp = &deletedAt
-	assert.False(t, shouldReconcileSandboxPowerState(deleting))
-}
-
-func TestReconcileSandboxPowerStateSkipsDeletingPod(t *testing.T) {
-	pod := newPowerStatePod(SandboxPowerStatePaused, SandboxPowerStateActive, SandboxPowerPhasePausing)
-	deletedAt := metav1.NewTime(time.Now())
-	pod.DeletionTimestamp = &deletedAt
-	executor := &recordingPowerExecutor{}
+func TestRequestSandboxPowerRequiresCtld(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sandbox-1",
+			Namespace: "default",
+			Labels: map[string]string{
+				controller.LabelSandboxID: "sandbox-1",
+			},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	k8sClient := fake.NewSimpleClientset(pod)
 	svc := &SandboxService{
-		k8sClient: fake.NewSimpleClientset(pod),
-		podLister: newTestPodLister(t, pod),
-		logger:    zap.NewNop(),
-	}
-	svc.SetPowerExecutor(executor)
-
-	svc.reconcileSandboxPowerState("sandbox-1")
-
-	assert.Empty(t, executor.pauseCalls)
-	assert.Empty(t, executor.resumeCalls)
-}
-
-func TestStartPowerStateReconcilerTriggersPendingTransitions(t *testing.T) {
-	pod := newPowerStatePod(SandboxPowerStatePaused, SandboxPowerStateActive, SandboxPowerPhasePausing)
-	pauseCalled := make(chan struct{})
-	svc := &SandboxService{
-		k8sClient: fake.NewSimpleClientset(pod),
-		podLister: newTestPodLister(t, pod),
-		logger:    zap.NewNop(),
-	}
-	svc.SetPowerExecutor(&completingPowerExecutor{service: svc, pauseCalled: pauseCalled})
-
-	ctx, cancel := context.WithCancel(context.Background())
-	done := make(chan struct{})
-	go func() {
-		svc.StartPowerStateReconciler(ctx, time.Hour)
-		close(done)
-	}()
-
-	<-pauseCalled
-	cancel()
-	<-done
-}
-
-func TestStartPowerStateReconcilerSkipsWhenCtldEnabled(t *testing.T) {
-	pod := newPowerStatePod(SandboxPowerStatePaused, SandboxPowerStateActive, SandboxPowerPhasePausing)
-	pauseCalled := make(chan struct{})
-	svc := &SandboxService{
-		k8sClient: fake.NewSimpleClientset(pod),
-		podLister: newTestPodLister(t, pod),
-		config:    SandboxServiceConfig{CtldEnabled: true},
-		logger:    zap.NewNop(),
-	}
-	svc.SetPowerExecutor(&completingPowerExecutor{service: svc, pauseCalled: pauseCalled})
-
-	done := make(chan struct{})
-	go func() {
-		svc.StartPowerStateReconciler(context.Background(), time.Millisecond)
-		close(done)
-	}()
-
-	select {
-	case <-done:
-	case <-time.After(200 * time.Millisecond):
-		t.Fatal("StartPowerStateReconciler did not return when ctld is enabled")
-	}
-	select {
-	case <-pauseCalled:
-		t.Fatal("manager reconciler executed a ctld-owned power transition")
-	default:
-	}
-}
-
-func TestRequestResumeSandboxDoesNotBlockOnInFlightReconcile(t *testing.T) {
-	pod := newPowerStatePod(SandboxPowerStatePaused, SandboxPowerStateActive, SandboxPowerPhasePausing)
-	executor := newBlockingPowerExecutor()
-	svc := &SandboxService{
-		k8sClient: fake.NewSimpleClientset(pod),
+		k8sClient: k8sClient,
 		podLister: newTestPodLister(t, pod),
 		clock:     systemTime{},
 		logger:    zap.NewNop(),
 	}
-	svc.SetPowerExecutor(executor)
 
-	go svc.reconcileSandboxPowerState("sandbox-1")
-	<-executor.pauseStarted
+	_, err := svc.RequestPauseSandbox(context.Background(), "sandbox-1")
+	require.ErrorIs(t, err, ErrSandboxPowerRequiresCtld)
+	_, err = svc.RequestResumeSandbox(context.Background(), "sandbox-1")
+	require.ErrorIs(t, err, ErrSandboxPowerRequiresCtld)
 
-	done := make(chan *ResumeSandboxResponse, 1)
-	errCh := make(chan error, 1)
-	go func() {
-		resp, err := svc.RequestResumeSandbox(context.Background(), "sandbox-1")
-		if err != nil {
-			errCh <- err
-			return
-		}
-		done <- resp
-	}()
-
-	select {
-	case err := <-errCh:
-		t.Fatalf("RequestResumeSandbox returned error: %v", err)
-	case resp := <-done:
-		assert.Equal(t, SandboxPowerStateActive, resp.PowerState.Desired)
-		assert.Equal(t, SandboxPowerPhaseStable, resp.PowerState.Phase)
-	case <-time.After(200 * time.Millisecond):
-		t.Fatal("RequestResumeSandbox blocked on in-flight reconcile")
-	}
-
-	close(executor.pauseRelease)
-	<-executor.pauseFinished
+	updated, err := k8sClient.CoreV1().Pods("default").Get(context.Background(), "sandbox-1", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, updated.Annotations[controller.AnnotationPowerStateDesired])
 }
 
 func TestRequestResumeSandboxKeepsCtldInFlightPausePending(t *testing.T) {
@@ -530,13 +382,15 @@ func TestPauseSandboxAndWaitReturnsAfterObservedPaused(t *testing.T) {
 		},
 		Status: corev1.PodStatus{Phase: corev1.PodRunning},
 	}
+	k8sClient := fake.NewSimpleClientset(pod)
+	completePowerTransitionOnUpdate(t, k8sClient, SandboxPowerStatePaused)
 	svc := &SandboxService{
-		k8sClient: fake.NewSimpleClientset(pod),
+		k8sClient: k8sClient,
 		podLister: newTestPodLister(t, pod),
+		config:    SandboxServiceConfig{CtldEnabled: true},
 		clock:     systemTime{},
 		logger:    zap.NewNop(),
 	}
-	svc.SetPowerExecutor(&completingPowerExecutor{service: svc})
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
@@ -551,13 +405,15 @@ func TestPauseSandboxAndWaitReturnsAfterObservedPaused(t *testing.T) {
 func TestResumeSandboxAndWaitReturnsAfterObservedActive(t *testing.T) {
 	pod := newPowerStatePod(SandboxPowerStatePaused, SandboxPowerStatePaused, SandboxPowerPhaseStable)
 	pod.Annotations[controller.AnnotationPaused] = "true"
+	k8sClient := fake.NewSimpleClientset(pod)
+	completePowerTransitionOnUpdate(t, k8sClient, SandboxPowerStateActive)
 	svc := &SandboxService{
-		k8sClient: fake.NewSimpleClientset(pod),
+		k8sClient: k8sClient,
 		podLister: newTestPodLister(t, pod),
+		config:    SandboxServiceConfig{CtldEnabled: true},
 		clock:     systemTime{},
 		logger:    zap.NewNop(),
 	}
-	svc.SetPowerExecutor(&completingPowerExecutor{service: svc})
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
@@ -580,14 +436,15 @@ func TestPauseSandboxAndWaitReturnsSupersededWhenDesiredChanges(t *testing.T) {
 		},
 		Status: corev1.PodStatus{Phase: corev1.PodRunning},
 	}
-	executor := newBlockingPowerExecutor()
+	k8sClient := fake.NewSimpleClientset(pod)
+	pauseRequested := notifyPowerTransitionRequest(k8sClient, SandboxPowerStatePaused)
 	svc := &SandboxService{
-		k8sClient: fake.NewSimpleClientset(pod),
+		k8sClient: k8sClient,
 		podLister: newTestPodLister(t, pod),
+		config:    SandboxServiceConfig{CtldEnabled: true},
 		clock:     systemTime{},
 		logger:    zap.NewNop(),
 	}
-	svc.SetPowerExecutor(executor)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
@@ -600,11 +457,10 @@ func TestPauseSandboxAndWaitReturnsSupersededWhenDesiredChanges(t *testing.T) {
 		resp, err := svc.PauseSandboxAndWait(ctx, "sandbox-1")
 		resultCh <- result{resp: resp, err: err}
 	}()
-	<-executor.pauseStarted
+	<-pauseRequested
 
 	_, err := svc.RequestResumeSandbox(context.Background(), "sandbox-1")
 	require.NoError(t, err)
-	close(executor.pauseRelease)
 
 	res := <-resultCh
 	require.ErrorIs(t, res.err, ErrSandboxPowerTransitionSuperseded)
@@ -613,224 +469,64 @@ func TestPauseSandboxAndWaitReturnsSupersededWhenDesiredChanges(t *testing.T) {
 	assert.Equal(t, SandboxPowerStateActive, res.resp.PowerState.Desired)
 }
 
-func TestPauseSandboxLocalResumesProcdAfterStalePause(t *testing.T) {
-	pod := newPowerStatePod(SandboxPowerStatePaused, SandboxPowerStateActive, SandboxPowerPhasePausing)
-	pod.Annotations[controller.AnnotationTeamID] = "team-1"
-	pod.Annotations[controller.AnnotationUserID] = "user-1"
-	pod.Spec = corev1.PodSpec{Containers: []corev1.Container{{Name: "procd"}}}
-	pod.Status = corev1.PodStatus{Phase: corev1.PodRunning, PodIP: "127.0.0.1"}
-	k8sClient := fake.NewSimpleClientset(pod)
-
-	var calls []string
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		calls = append(calls, r.URL.Path)
-		switch r.URL.Path {
-		case "/api/v1/sandbox/pause":
-			current, err := k8sClient.CoreV1().Pods("default").Get(r.Context(), "sandbox-1", metav1.GetOptions{})
-			require.NoError(t, err)
-			updated := current.DeepCopy()
-			updated.Annotations[controller.AnnotationPowerStateDesired] = SandboxPowerStateActive
-			updated.Annotations[controller.AnnotationPowerStateDesiredGeneration] = "3"
-			updated.Annotations[controller.AnnotationPowerStateObserved] = SandboxPowerStateActive
-			updated.Annotations[controller.AnnotationPowerStateObservedGeneration] = "3"
-			updated.Annotations[controller.AnnotationPowerStatePhase] = SandboxPowerPhaseStable
-			_, err = k8sClient.CoreV1().Pods("default").Update(r.Context(), updated, metav1.UpdateOptions{})
-			require.NoError(t, err)
-			_ = spec.WriteSuccess(w, http.StatusOK, PauseResponse{Paused: true, ResourceUsage: &SandboxResourceUsage{ContainerMemoryWorkingSet: 128}})
-		case "/api/v1/sandbox/resume":
-			_ = spec.WriteSuccess(w, http.StatusOK, ResumeResponse{Resumed: true})
-		default:
-			w.WriteHeader(http.StatusNotFound)
-		}
-	}))
-	defer server.Close()
-	serverURL, err := url.Parse(server.URL)
-	require.NoError(t, err)
-	port, err := strconv.Atoi(serverURL.Port())
-	require.NoError(t, err)
-
-	svc := &SandboxService{
-		k8sClient:              k8sClient,
-		podLister:              newTestPodLister(t, pod),
-		procdClient:            NewProcdClient(ProcdClientConfig{Timeout: time.Second}),
-		internalTokenGenerator: staticTokenGenerator{},
-		config: SandboxServiceConfig{
-			ProcdPort:              port,
-			PauseMinCPU:            "10m",
-			PauseMemoryBufferRatio: 1.1,
-		},
-		clock:  systemTime{},
-		logger: zap.NewNop(),
-	}
-
-	resp, err := svc.pauseSandboxLocal(context.Background(), "sandbox-1")
-	require.NoError(t, err)
-	assert.False(t, resp.Paused)
-	assert.Equal(t, SandboxPowerStateActive, resp.PowerState.Desired)
-	assert.Equal(t, []string{"/api/v1/sandbox/pause", "/api/v1/sandbox/resume"}, calls)
-}
-
-func TestCompletePausedSandboxRejectsStaleGeneration(t *testing.T) {
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "sandbox-1",
-			Namespace: "default",
-			Labels: map[string]string{
-				controller.LabelSandboxID: "sandbox-1",
-			},
-			Annotations: map[string]string{
-				controller.AnnotationPowerStateDesired:           SandboxPowerStateActive,
-				controller.AnnotationPowerStateDesiredGeneration: "2",
-				controller.AnnotationPowerStateObserved:          SandboxPowerStateActive,
-			},
-		},
-		Spec:   corev1.PodSpec{Containers: []corev1.Container{{Name: "procd"}}},
-		Status: corev1.PodStatus{Phase: corev1.PodRunning},
-	}
-	svc := &SandboxService{
-		k8sClient: fake.NewSimpleClientset(pod),
-		podLister: newTestPodLister(t, pod),
-		config: SandboxServiceConfig{
-			PauseMinCPU:            "10m",
-			PauseMemoryBufferRatio: 1.1,
-		},
-		clock:  systemTime{},
-		logger: zap.NewNop(),
-	}
-
-	resp, err := svc.completePausedSandbox(context.Background(), pod, "sandbox-1", &SandboxResourceUsage{ContainerMemoryWorkingSet: 128}, expectedSandboxPowerState{Desired: SandboxPowerStatePaused, Generation: 1})
-	require.ErrorIs(t, err, errSandboxPowerStateStale)
-	assert.False(t, resp.Paused)
-	assert.Equal(t, SandboxPowerStateActive, resp.PowerState.Desired)
-
-	updated, getErr := svc.k8sClient.CoreV1().Pods("default").Get(context.Background(), "sandbox-1", metav1.GetOptions{})
-	require.NoError(t, getErr)
-	assert.Empty(t, updated.Annotations[controller.AnnotationPaused])
-}
-
-type recordingPowerExecutor struct {
-	pauseCalls  []string
-	resumeCalls []string
-}
-
-type blockingPowerExecutor struct {
-	mu                sync.Mutex
-	pauseCalls        []string
-	resumeCalls       []string
-	pauseStarted      chan struct{}
-	pauseRelease      chan struct{}
-	pauseFinished     chan struct{}
-	pauseStartedOnce  sync.Once
-	pauseFinishedOnce sync.Once
-}
-
-type completingPowerExecutor struct {
-	service      *SandboxService
-	pauseCalled  chan struct{}
-	resumeCalled chan struct{}
-}
-
 type staticTokenGenerator struct{}
-
-func newBlockingPowerExecutor() *blockingPowerExecutor {
-	return &blockingPowerExecutor{
-		pauseStarted:  make(chan struct{}),
-		pauseRelease:  make(chan struct{}),
-		pauseFinished: make(chan struct{}),
-	}
-}
-
-func (e *recordingPowerExecutor) Pause(_ context.Context, sandboxID string) (*PauseSandboxResponse, error) {
-	e.pauseCalls = append(e.pauseCalls, sandboxID)
-	return &PauseSandboxResponse{
-		SandboxID: sandboxID,
-		Paused:    true,
-		PowerState: SandboxPowerState{
-			Desired: SandboxPowerStatePaused,
-		},
-	}, nil
-}
-
-func (e *recordingPowerExecutor) Resume(_ context.Context, sandboxID string) (*ResumeSandboxResponse, error) {
-	e.resumeCalls = append(e.resumeCalls, sandboxID)
-	return &ResumeSandboxResponse{
-		SandboxID: sandboxID,
-		Resumed:   true,
-		PowerState: SandboxPowerState{
-			Desired: SandboxPowerStateActive,
-		},
-	}, nil
-}
-
-func (e *blockingPowerExecutor) Pause(_ context.Context, sandboxID string) (*PauseSandboxResponse, error) {
-	e.mu.Lock()
-	e.pauseCalls = append(e.pauseCalls, sandboxID)
-	e.mu.Unlock()
-	e.pauseStartedOnce.Do(func() { close(e.pauseStarted) })
-	<-e.pauseRelease
-	e.pauseFinishedOnce.Do(func() { close(e.pauseFinished) })
-	return &PauseSandboxResponse{
-		SandboxID: sandboxID,
-		Paused:    true,
-		PowerState: SandboxPowerState{
-			Desired: SandboxPowerStatePaused,
-		},
-	}, nil
-}
-
-func (e *blockingPowerExecutor) Resume(_ context.Context, sandboxID string) (*ResumeSandboxResponse, error) {
-	e.mu.Lock()
-	e.resumeCalls = append(e.resumeCalls, sandboxID)
-	e.mu.Unlock()
-	return &ResumeSandboxResponse{
-		SandboxID: sandboxID,
-		Resumed:   true,
-		PowerState: SandboxPowerState{
-			Desired: SandboxPowerStateActive,
-		},
-	}, nil
-}
-
-func (e *completingPowerExecutor) Pause(ctx context.Context, sandboxID string) (*PauseSandboxResponse, error) {
-	notifyOnce(e.pauseCalled)
-	pod, err := e.service.getSandboxPodForPowerState(ctx, sandboxID)
-	if err != nil {
-		return nil, err
-	}
-	updated := pod.DeepCopy()
-	if updated.Annotations == nil {
-		updated.Annotations = make(map[string]string)
-	}
-	updated.Annotations[controller.AnnotationPaused] = "true"
-	state := completedSandboxPowerState(updated.Annotations, SandboxPowerStatePaused)
-	applySandboxPowerStateAnnotations(updated.Annotations, state)
-	if _, err := e.service.k8sClient.CoreV1().Pods(updated.Namespace).Update(ctx, updated, metav1.UpdateOptions{}); err != nil {
-		return nil, err
-	}
-	return &PauseSandboxResponse{SandboxID: sandboxID, Paused: true, PowerState: state}, nil
-}
-
-func (e *completingPowerExecutor) Resume(ctx context.Context, sandboxID string) (*ResumeSandboxResponse, error) {
-	notifyOnce(e.resumeCalled)
-	pod, err := e.service.getSandboxPodForPowerState(ctx, sandboxID)
-	if err != nil {
-		return nil, err
-	}
-	updated := pod.DeepCopy()
-	if updated.Annotations == nil {
-		updated.Annotations = make(map[string]string)
-	}
-	delete(updated.Annotations, controller.AnnotationPaused)
-	state := completedSandboxPowerState(updated.Annotations, SandboxPowerStateActive)
-	applySandboxPowerStateAnnotations(updated.Annotations, state)
-	if _, err := e.service.k8sClient.CoreV1().Pods(updated.Namespace).Update(ctx, updated, metav1.UpdateOptions{}); err != nil {
-		return nil, err
-	}
-	return &ResumeSandboxResponse{SandboxID: sandboxID, Resumed: true, PowerState: state}, nil
-}
 
 func (staticTokenGenerator) GenerateToken(_, _, _ string) (string, error) {
 	return "token", nil
+}
+
+func completePowerTransitionOnUpdate(t *testing.T, k8sClient *fake.Clientset, target string) {
+	t.Helper()
+	k8sClient.PrependReactor("update", "pods", func(action ktesting.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() != "" {
+			return false, nil, nil
+		}
+		updateAction, ok := action.(ktesting.UpdateAction)
+		if !ok {
+			return false, nil, nil
+		}
+		pod, ok := updateAction.GetObject().(*corev1.Pod)
+		if !ok || pod.Annotations == nil {
+			return false, nil, nil
+		}
+		state := sandboxPowerStateFromAnnotations(pod.Annotations)
+		if state.Desired != target || state.Phase == SandboxPowerPhaseStable {
+			return false, nil, nil
+		}
+		completed := completedSandboxPowerState(pod.Annotations, target)
+		applySandboxPowerStateAnnotations(pod.Annotations, completed)
+		if target == SandboxPowerStatePaused {
+			pod.Annotations[controller.AnnotationPaused] = "true"
+		} else {
+			delete(pod.Annotations, controller.AnnotationPaused)
+			delete(pod.Annotations, controller.AnnotationPausedAt)
+			delete(pod.Annotations, controller.AnnotationPausedState)
+		}
+		return false, nil, nil
+	})
+}
+
+func notifyPowerTransitionRequest(k8sClient *fake.Clientset, target string) <-chan struct{} {
+	requested := make(chan struct{})
+	k8sClient.PrependReactor("update", "pods", func(action ktesting.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() != "" {
+			return false, nil, nil
+		}
+		updateAction, ok := action.(ktesting.UpdateAction)
+		if !ok {
+			return false, nil, nil
+		}
+		pod, ok := updateAction.GetObject().(*corev1.Pod)
+		if !ok {
+			return false, nil, nil
+		}
+		state := sandboxPowerStateFromAnnotations(pod.Annotations)
+		if state.Desired == target {
+			notifyOnce(requested)
+		}
+		return false, nil, nil
+	})
+	return requested
 }
 
 func notifyOnce(ch chan struct{}) {

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -1555,6 +1555,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorEnvelope"
+        "503":
+          description: Sandbox pause requires ctld
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
         "404":
           description: Not found
           content:
@@ -1586,6 +1592,12 @@ paths:
                 $ref: "#/components/schemas/ErrorEnvelope"
         "504":
           description: Timed out waiting for the sandbox to resume
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "503":
+          description: Sandbox resume requires ctld
           content:
             application/json:
               schema:

--- a/tests/integration/internal/tests/manager/api_test.go
+++ b/tests/integration/internal/tests/manager/api_test.go
@@ -595,16 +595,16 @@ func newProcdStubServer(t *testing.T) *httptest.Server {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/sandbox/pause", func(w http.ResponseWriter, r *http.Request) {
-		response := service.PauseResponse{
-			Paused: true,
-			ResourceUsage: &service.SandboxResourceUsage{
+		response := map[string]any{
+			"paused": true,
+			"resource_usage": &service.SandboxResourceUsage{
 				ContainerMemoryWorkingSet: 64 * 1024 * 1024,
 			},
 		}
 		_ = json.NewEncoder(w).Encode(response)
 	})
 	mux.HandleFunc("/api/v1/sandbox/resume", func(w http.ResponseWriter, r *http.Request) {
-		response := service.ResumeResponse{Resumed: true}
+		response := map[string]any{"resumed": true}
 		_ = json.NewEncoder(w).Encode(response)
 	})
 	mux.HandleFunc("/api/v1/sandbox/stats", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- Remove the manager-local sandbox power executor and procd pause/resume client calls.
- Require ctld ownership for manager pause/resume requests, with explicit 503 handling when ctld is disabled.
- Stop manager power reconciliation startup and keep manager behavior to desired-state annotation writes.
- Update tests, OpenAPI responses, and docs to reflect ctld-owned pause/resume.

Fixes #411

## Tests
- go test ./infra-operator/api/config ./manager/cmd/manager ./manager/pkg/service ./manager/pkg/http ./tests/integration/internal/tests/manager ./ctld/internal/ctld/power