### PR TITLE
Redefine sandbox lifecycle around checkpointed pause

### DIFF
--- a/cluster-gateway/pkg/http/handlers_context.go
+++ b/cluster-gateway/pkg/http/handlers_context.go
@@ -261,6 +261,10 @@ func (s *Server) getProcdURL(c *gin.Context, sandboxID string) (*url.URL, error)
 				spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox is waking up")
 				return nil, err
 			}
+			if sandboxNeedsRuntime(sandbox) {
+				spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox is waking up")
+				return nil, errors.New("sandbox runtime is still unavailable after resume")
+			}
 		}
 	}
 
@@ -277,25 +281,15 @@ func (s *Server) getProcdURL(c *gin.Context, sandboxID string) (*url.URL, error)
 	return addr, nil
 }
 
-func sandboxWantsPaused(sandbox *mgr.Sandbox) bool {
-	if sandbox == nil {
-		return false
-	}
-	if sandbox.PowerState.Desired == mgr.SandboxPowerStatePaused {
-		return true
-	}
-	return sandbox.Paused
-}
-
 func sandboxNeedsRuntime(sandbox *mgr.Sandbox) bool {
-	return sandboxRuntimeMissing(sandbox) || sandboxWantsPaused(sandbox)
+	return sandboxRuntimeMissing(sandbox)
 }
 
 func sandboxRuntimeMissing(sandbox *mgr.Sandbox) bool {
 	if sandbox == nil {
 		return false
 	}
-	if sandbox.Status == mgr.SandboxStatusCleaned || strings.TrimSpace(sandbox.InternalAddr) == "" {
+	if sandbox.Status == mgr.SandboxStatusPaused || strings.TrimSpace(sandbox.InternalAddr) == "" {
 		return true
 	}
 	return false

--- a/cluster-gateway/pkg/http/handlers_context_test.go
+++ b/cluster-gateway/pkg/http/handlers_context_test.go
@@ -97,13 +97,13 @@ func TestGetProcdURLRechecksPausedStateAfterSuccessfulAccess(t *testing.T) {
 			}
 			if getCalls == 2 {
 				sandbox.Paused = true
-				sandbox.PowerState = mgr.SandboxPowerState{
-					Desired:            mgr.SandboxPowerStatePaused,
-					DesiredGeneration:  3,
-					Observed:           mgr.SandboxPowerStatePaused,
-					ObservedGeneration: 3,
-					Phase:              mgr.SandboxPowerPhaseStable,
-				}
+				sandbox.Status = mgr.SandboxStatusPaused
+				sandbox.InternalAddr = ""
+			}
+			if getCalls >= 3 {
+				sandbox.Paused = false
+				sandbox.Status = mgr.SandboxStatusRunning
+				sandbox.InternalAddr = "http://127.0.0.1:7777"
 			}
 			_ = spec.WriteSuccess(w, http.StatusOK, sandbox)
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/sandboxes/sb-1/resume":
@@ -111,13 +111,6 @@ func TestGetProcdURLRechecksPausedStateAfterSuccessfulAccess(t *testing.T) {
 			_ = spec.WriteSuccess(w, http.StatusOK, mgr.ResumeSandboxResponse{
 				SandboxID: "sb-1",
 				Resumed:   true,
-				PowerState: mgr.SandboxPowerState{
-					Desired:            mgr.SandboxPowerStateActive,
-					DesiredGeneration:  4,
-					Observed:           mgr.SandboxPowerStateActive,
-					ObservedGeneration: 4,
-					Phase:              mgr.SandboxPowerPhaseStable,
-				},
 			})
 		default:
 			w.WriteHeader(http.StatusNotFound)
@@ -140,8 +133,8 @@ func TestGetProcdURLRechecksPausedStateAfterSuccessfulAccess(t *testing.T) {
 	if addr == nil || addr.String() != "http://127.0.0.1:7777" {
 		t.Fatalf("second addr = %v, want http://127.0.0.1:7777", addr)
 	}
-	if getCalls != 2 {
-		t.Fatalf("getCalls = %d, want 2", getCalls)
+	if getCalls != 3 {
+		t.Fatalf("getCalls = %d, want 3", getCalls)
 	}
 	if resumeCalls != 1 {
 		t.Fatalf("resumeCalls = %d, want 1", resumeCalls)
@@ -178,30 +171,16 @@ func TestGetProcdURLPausedSandboxReturnsWakingUp(t *testing.T) {
 				ID:           "sb-1",
 				TeamID:       "team-a",
 				UserID:       "user-a",
-				InternalAddr: "http://127.0.0.1:7777",
-				Status:       mgr.SandboxStatusRunning,
-				Paused:       false,
+				InternalAddr: "",
+				Status:       mgr.SandboxStatusPaused,
+				Paused:       true,
 				AutoResume:   true,
-				PowerState: mgr.SandboxPowerState{
-					Desired:            mgr.SandboxPowerStatePaused,
-					DesiredGeneration:  3,
-					Observed:           mgr.SandboxPowerStatePaused,
-					ObservedGeneration: 3,
-					Phase:              mgr.SandboxPowerPhaseStable,
-				},
 			})
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/sandboxes/sb-1/resume":
 			resumeCalls++
 			_ = spec.WriteSuccess(w, http.StatusOK, mgr.ResumeSandboxResponse{
 				SandboxID: "sb-1",
 				Resumed:   true,
-				PowerState: mgr.SandboxPowerState{
-					Desired:            mgr.SandboxPowerStateActive,
-					DesiredGeneration:  4,
-					Observed:           mgr.SandboxPowerStateActive,
-					ObservedGeneration: 4,
-					Phase:              mgr.SandboxPowerPhaseStable,
-				},
 			})
 		default:
 			w.WriteHeader(http.StatusNotFound)
@@ -215,9 +194,12 @@ func TestGetProcdURLPausedSandboxReturnsWakingUp(t *testing.T) {
 		logger:        zap.NewNop(),
 	}
 
-	addr, _ := mustGetProcdURL(t, server, "team-a", "user-a", "sb-1")
-	if addr == nil || addr.String() != "http://127.0.0.1:7777" {
-		t.Fatalf("addr = %v, want http://127.0.0.1:7777", addr)
+	addr, rec := mustGetProcdURL(t, server, "team-a", "user-a", "sb-1")
+	if addr != nil {
+		t.Fatalf("addr = %v, want nil", addr)
+	}
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
 	}
 	if resumeCalls != 1 {
 		t.Fatalf("resumeCalls = %d, want 1", resumeCalls)

--- a/cluster-gateway/pkg/http/sandbox_service_policy_test.go
+++ b/cluster-gateway/pkg/http/sandbox_service_policy_test.go
@@ -484,7 +484,7 @@ func TestSandboxCMDServiceStartsContextBeforeProxy(t *testing.T) {
 	}
 }
 
-func TestSandboxCMDServiceStartsAfterCleanedAutoResume(t *testing.T) {
+func TestSandboxCMDServiceStartsAfterPausedAutoResume(t *testing.T) {
 	var created atomic.Bool
 	procd := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
@@ -517,9 +517,10 @@ func TestSandboxCMDServiceStartsAfterCleanedAutoResume(t *testing.T) {
 		Status:       mgr.SandboxStatusRunning,
 		Services:     []mgr.SandboxAppService{newCMDServiceForTest(port, true)},
 	}
-	cleanedSandbox := *activeSandbox
-	cleanedSandbox.InternalAddr = ""
-	cleanedSandbox.Status = mgr.SandboxStatusCleaned
+	pausedSandbox := *activeSandbox
+	pausedSandbox.InternalAddr = ""
+	pausedSandbox.Status = mgr.SandboxStatusPaused
+	pausedSandbox.Paused = true
 
 	var resumed atomic.Bool
 	manager := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -529,7 +530,7 @@ func TestSandboxCMDServiceStartsAfterCleanedAutoResume(t *testing.T) {
 				_ = spec.WriteSuccess(w, http.StatusOK, activeSandbox)
 				return
 			}
-			_ = spec.WriteSuccess(w, http.StatusOK, &cleanedSandbox)
+			_ = spec.WriteSuccess(w, http.StatusOK, &pausedSandbox)
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/sandboxes/sb-demo/resume":
 			resumed.Store(true)
 			_ = spec.WriteSuccess(w, http.StatusOK, map[string]any{"sandbox_id": "sb-demo"})

--- a/docs/get-started/concepts/page.mdx
+++ b/docs/get-started/concepts/page.mdx
@@ -9,7 +9,7 @@ Think in four building blocks:
 | Concept | What It Is | Why Agent Developers Care |
 |-------|-------------|---------------------------|
 | `Template` | The runtime blueprint (image, resources, defaults). | Defines your agent's execution environment and startup behavior. |
-| `Sandbox` | An isolated runtime instance created from a template. | The agent's working machine for running tools, commands, and sessions. |
+| `Sandbox` | Durable identity and configuration for an isolated environment. | The agent's working machine identity across runtime generations. |
 | `Context` | A process/session inside the sandbox (for example REPL-like or one-shot execution). | Controls whether state is preserved across turns or reset each run. |
 | `Volume` | Persistent storage decoupled from sandbox lifecycle. | Keeps knowledge, artifacts, and checkpoints across sandbox recreation. |
 
@@ -23,8 +23,8 @@ The key idea is separation of concerns:
 
 A common confusion is mixing compute state and durable state.
 
-- Process state lives in the sandbox runtime and can disappear when the runtime is cleaned or deleted.
-- Sandbox0 restores the writable root filesystem checkpoint for cleaned sandboxes, so files written outside mounted volumes can survive clean/restore for the same sandbox identity.
+- Process state lives in the sandbox runtime and disappears when the runtime is paused or deleted.
+- Sandbox0 restores the writable root filesystem checkpoint for paused sandboxes, so files written outside mounted volumes can survive pause/resume for the same sandbox identity.
 - Durable state that needs snapshots, sharing, or recovery outside the sandbox identity should be written to volumes or external systems.
 - If your agent must recover after failures or redeploys, treat sandbox runtime as ephemeral and volumes as the source of truth.
 
@@ -36,8 +36,8 @@ Design for restartability: assume any sandbox can be replaced, and your agent sh
 
 Sandbox0 uses lifecycle controls to balance responsiveness and cost:
 
-- `ttl`: soft timeout, typically leading to auto-pause.
-- `hard_ttl`: hard runtime deadline, leading to runtime cleanup while preserving the sandbox identity.
+- `ttl`: runtime soft timeout, leading to checkpointed pause.
+- `hard_ttl`: hard sandbox deadline, deleting identity and durable state even if paused.
 
 For agents, this means:
 - Keep short `ttl` for bursty workloads.
@@ -93,6 +93,6 @@ This keeps each agent worker simple while allowing safe parallel execution.
   </Card>
 
   <Card title="Pause And Resume" href="/docs/sandbox/pause-resume" cta="Continue">
-    Control sandbox power state and resume behavior before wiring long-lived workflows.
+    Control checkpointed pause and resume behavior before wiring long-lived workflows.
   </Card>
 </CardGroup>

--- a/docs/get-started/page.mdx
+++ b/docs/get-started/page.mdx
@@ -172,7 +172,7 @@ func main() {
     // Claim a sandbox from the "default" template
     sandbox, err := client.ClaimSandbox(ctx, "default",
         sandbox0.WithSandboxTTL(300),      // Auto-pause after 5 minutes (default: 5m)
-        sandbox0.WithSandboxHardTTL(3600), // Clean runtime after 1 hour (optional, 0 disables)
+        sandbox0.WithSandboxHardTTL(3600), // Delete sandbox state after 1 hour (optional, 0 disables)
     )
     if err != nil {
         log.Fatal(err)
@@ -199,7 +199,7 @@ client = Client(
 # Claim a sandbox from the "default" template
 with client.sandboxes.open("default", config=SandboxConfig(
     ttl=300,       # Auto-pause after 5 minutes (default: 5m)
-    hard_ttl=3600, # Clean runtime after 1 hour (optional, 0 disables)
+    hard_ttl=3600, # Delete sandbox state after 1 hour (optional, 0 disables)
 )) as sandbox:
     print(f"Sandbox ID: {sandbox.id}")
     print(f"Status: {sandbox.status}")`
@@ -219,7 +219,7 @@ const client = new Client({
 // Claim a sandbox from the "default" template
 const sandbox = await client.sandboxes.claim('default', {
     ttl: 300,       // Auto-pause after 5 minutes (default: 5m)
-    hardTtl: 3600,  // Clean runtime after 1 hour (optional, 0 disables)
+    hardTtl: 3600,  // Delete sandbox state after 1 hour (optional, 0 disables)
 });
 console.log('Sandbox ID:', sandbox.id);
 console.log('Status:', sandbox.status);

--- a/docs/sandbox/functions/page.mdx
+++ b/docs/sandbox/functions/page.mdx
@@ -6,7 +6,7 @@ Use functions for:
 
 - public webhook receivers
 - lightweight control endpoints
-- HTTP handlers that should resume a paused or cleaned sandbox on demand
+- HTTP handlers that should resume a paused sandbox on demand
 - handlers that return normal HTTP responses, SSE streams, or WebSocket messages
 
 ## Use Case: Warm Repository Webhooks
@@ -360,7 +360,7 @@ Public function auto-resume has two gates:
 - sandbox `auto_resume` must be true
 - matched route `resume` must be true
 
-Both gates are required for public URL requests to wake a paused sandbox or a cleaned sandbox. For a cleaned sandbox, Sandbox0 creates a new runtime pod for the same sandbox identity. The sandbox ID and function `public_url` stay unchanged, and each matching request executes the handler after the sandbox runtime is available.
+Both gates are required for public URL requests to wake a paused sandbox. Sandbox0 creates a new runtime pod for the same sandbox identity, restores the latest rootfs checkpoint, and then executes the handler. The sandbox ID and function `public_url` stay unchanged until the sandbox is deleted or `hard_ttl` expires.
 
 ## Notes
 

--- a/docs/sandbox/page.mdx
+++ b/docs/sandbox/page.mdx
@@ -27,11 +27,14 @@ Sandbox0 Cloud clients should use `https://api.sandbox0.ai`. Set `SANDBOX0_BASE_
 |--------|-------------|
 | `starting` | Sandbox is being initialized |
 | `running` | Sandbox is active and ready to use |
+| `pausing` | Sandbox is checkpointing rootfs and releasing its runtime |
+| `paused` | Sandbox has no runtime; identity and latest rootfs checkpoint are preserved |
+| `resuming` | Sandbox is creating a new runtime and restoring rootfs |
+| `terminating` | Sandbox identity and durable state are being deleted |
 | `failed` | Sandbox encountered an error |
-| `completed` | Sandbox has finished execution |
 
 <Callout variant="info">
-Pause state is modeled separately from `status`. Use the `paused` boolean when you need to distinguish a paused sandbox from a running one. For async pause/resume flows, use `power_state` to inspect desired vs observed state plus generation counters.
+Use the `paused` boolean as a convenience for `status == "paused"`. Pause does not preserve running processes, memory, sockets, PID state, or live REPL sessions.
 </Callout>
 
 ---
@@ -57,7 +60,7 @@ Claim a sandbox from a template. The sandbox is created from a pre-warmed pool f
 |-------|------|-------------|
 | `env_vars` | object | Sandbox-level default environment variables for new procd-managed processes |
 | `ttl` | integer | Time to live in seconds (soft limit, triggers auto-pause; default: `0`, disabled) |
-| `hard_ttl` | integer | Hard runtime lifetime in seconds (cleans compute while preserving sandbox identity and services; default: `0`, disabled) |
+| `hard_ttl` | integer | Hard sandbox lifetime in seconds (deletes identity and durable state; default: `0`, disabled) |
 | `network` | object | `SandboxNetworkPolicy`. Controls traffic rules, protocol controls, credential bindings, and destination-scoped egress auth |
 | `webhook` | object | Webhook configuration |
 | `auto_resume` | boolean | Auto-resume when accessed (default: true) |
@@ -73,12 +76,12 @@ Sandbox0 uses two-tier TTL to balance resource efficiency and flexibility:
 
 | Field | Behavior | Use Case |
 |-------|----------|----------|
-| `ttl` | **Soft pause**: When expired, sandbox is automatically paused. Processes stop but state is preserved. Can be extended via refresh API. | Keep sandboxes alive during active use while freeing compute resources during idle periods. |
-| `hard_ttl` | **Hard clean**: When expired, Sandbox0 checkpoints the writable root filesystem, deletes the runtime pod, and marks the sandbox `cleaned`. Identity, configuration, services, and public URLs remain available until explicit delete. | Enforce compute cost limits while keeping a durable sandbox service that can be restored on demand. |
+| `ttl` | **Runtime soft pause**: When expired, Sandbox0 checkpoints the writable root filesystem, deletes the runtime pod, and marks the sandbox `paused`. | Keep sandboxes alive during active use while freeing compute resources during idle periods. |
+| `hard_ttl` | **Sandbox hard delete**: When expired, Sandbox0 deletes the sandbox identity and durable state, including paused rootfs checkpoints. | Enforce a maximum lifetime for compute and storage resources. |
 
 <Callout variant="info">
 The relationship: <code>ttl {'<='} hard_ttl</code>. When <code>ttl</code> expires first, sandbox pauses but can be resumed.
-When <code>hard_ttl</code> expires, sandbox compute is cleaned and the sandbox can be restored by resume-capable access. Restore starts a new runtime pod and reapplies the root filesystem checkpoint; it does not preserve running process state. Both can be extended via the refresh API.
+When <code>hard_ttl</code> expires, the sandbox is deleted and later access returns not found. Resume starts a new runtime generation from the latest rootfs checkpoint only while the sandbox is paused and still within its hard TTL.
 </Callout>
 
 **Example timeline (sandbox created with `ttl=300` and `hard_ttl=3600`):**
@@ -86,7 +89,7 @@ When <code>hard_ttl</code> expires, sandbox compute is cleaned and the sandbox c
 - `t=300`: TTL expires → sandbox auto-pauses
 - `t=310`: User calls refresh → TTL reset to 300, Hard TTL reset to 3600 (new hard deadline at `t=3910`)
 - `t=610`: TTL expires again → sandbox auto-pauses
-- `t=3910`: Hard TTL expires → runtime pod cleaned, sandbox status becomes `cleaned`
+- `t=3910`: Hard TTL expires → sandbox identity and durable state are deleted
 
 <Tabs
   tabs={[
@@ -405,7 +408,7 @@ Only the following fields can be updated at runtime:
 | Field | Type | Description |
 |-------|------|-------------|
 | `ttl` | integer | Time to live in seconds (soft limit) |
-| `hard_ttl` | integer | Hard runtime lifetime in seconds |
+| `hard_ttl` | integer | Hard sandbox lifetime in seconds |
 | `network` | object | Network policy configuration |
 | `auto_resume` | boolean | Auto-resume when accessed |
 | `services` | array | Sandbox Services for public HTTP routes, including Sandbox Functions |
@@ -589,7 +592,7 @@ console.log('Sandbox deleted');`
 
 <CardGroup>
   <Card title="Pause And Resume" href="/docs/sandbox/pause-resume" cta="Continue">
-    Control sandbox power state and resume behavior before wiring long-lived workflows.
+    Control checkpointed pause and resume behavior before wiring long-lived workflows.
   </Card>
 
   <Card title="Contexts" href="/docs/sandbox/contexts" cta="Continue">

--- a/docs/sandbox/pause-resume/page.mdx
+++ b/docs/sandbox/pause-resume/page.mdx
@@ -1,25 +1,25 @@
 # Pause And Resume
 
-Sandbox0 can pause an idle sandbox without deleting it. Pause preserves sandbox state, while resume makes the sandbox runnable again.
+Sandbox0 can pause an idle sandbox without deleting it. Pause checkpoints the writable root filesystem, releases the runtime pod, and keeps the sandbox identity and durable state. Resume creates a new runtime generation and restores the latest rootfs checkpoint.
 
 Use this page when you need to:
 
 - pause a sandbox explicitly
 - resume a paused sandbox explicitly
 - understand how `ttl`, `auto_resume`, service routes, and SSH interact with pause state
-- inspect whether a pause or resume request has completed
+- inspect whether a sandbox is running or paused
 
 <Callout variant="info">
-Pause state is separate from `status`. Use `paused` for the simple user-facing state, and `power_state` when you need to inspect desired versus observed transition progress.
+Pause is a runtime lifecycle operation. It does not preserve running processes, memory, sockets, PID state, or live REPL sessions.
 </Callout>
 
 <Callout variant="warning">
-Self-hosted deployments must run `ctld` on sandbox nodes for pause and resume. The manager records the desired power state, and `ctld` performs cgroup freeze/thaw plus the observed-state update.
+Self-hosted deployments must run `ctld` on sandbox nodes for checkpointed pause/resume. `ctld` freezes the sandbox only as an internal consistency mechanism while saving or applying the writable rootfs checkpoint.
 </Callout>
 
 ## Pause A Sandbox
 
-Pause a sandbox to release compute while keeping its state available for a later resume.
+Pause a sandbox to release compute while keeping its identity, configuration, services, mounted durable storage, and latest writable rootfs checkpoint available for a later resume.
 
 <Endpoint method="POST">
 /api/v1/sandboxes/{'{id}'}/pause
@@ -97,7 +97,7 @@ console.log("Resume requested");`
 
 ## Inspect Pause State
 
-After requesting a pause or resume, fetch sandbox details to check whether the transition has completed.
+After requesting a pause or resume, fetch sandbox details to check the lifecycle status.
 
 <Tabs
   tabs={[
@@ -109,21 +109,24 @@ if err != nil {
     log.Fatal(err)
 }
 fmt.Printf("paused=%v\n", sb.Paused)
-fmt.Printf("power_state=%+v\n", sb.PowerState)`
+fmt.Printf("status=%s\n", sb.Status)
+fmt.Printf("runtime_generation=%d\n", sb.RuntimeGeneration)`
     },
     {
       label: "Python",
       language: "python",
       code: `sb = client.get_sandbox(sandbox.id)
 print("paused=", sb.paused)
-print("power_state=", sb.power_state)`
+print("status=", sb.status)
+print("runtime_generation=", sb.runtime_generation)`
     },
     {
       label: "TypeScript",
       language: "typescript",
       code: `const sb = await client.sandboxes.get(sandbox.id);
 console.log("paused=", sb.paused);
-console.log("powerState=", sb.powerState);`
+console.log("status=", sb.status);
+console.log("runtimeGeneration=", sb.runtimeGeneration);`
     },
     {
       label: "CLI",
@@ -139,10 +142,10 @@ console.log("powerState=", sb.powerState);`
 
 | Field | Behavior |
 |-------|----------|
-| `ttl` | Soft timeout. When it expires, Sandbox0 pauses the sandbox. |
-| `hard_ttl` | Hard runtime timeout. When it expires, Sandbox0 checkpoints the writable root filesystem, cleans the runtime pod, and keeps the sandbox identity for later restore. |
+| `ttl` | Runtime soft timeout. When it expires, Sandbox0 checkpoints the writable rootfs, pauses the sandbox, and releases runtime compute. |
+| `hard_ttl` | Sandbox hard timeout. When it expires, Sandbox0 deletes the sandbox identity and durable state, including rootfs checkpoints, even if the sandbox is already paused. |
 
-`auto_resume` is the sandbox-level gate for whether inbound access can wake a paused or cleaned sandbox:
+`auto_resume` is the sandbox-level gate for whether inbound access can wake a paused sandbox:
 
 - when `auto_resume` is `true`, supported access paths can resume the sandbox automatically
 - when `auto_resume` is `false`, you must call resume explicitly
@@ -152,7 +155,7 @@ Common auto-resume entrypoints:
 - service routes configured with `resume: true`; public service requests require both sandbox `auto_resume: true` and route `resume: true`
 - SSH access through Sandbox0 SSH Gateway
 
-For a cleaned sandbox, auto-resume creates a new runtime pod for the same sandbox identity and restores the saved root filesystem checkpoint before the sandbox is used. Public service URLs remain stable until the sandbox is explicitly deleted. Running processes are not preserved across clean/restore.
+For a paused sandbox, auto-resume creates a new runtime pod for the same sandbox identity and restores the saved rootfs checkpoint before the sandbox is used. Public service URLs remain stable until the sandbox is explicitly deleted or `hard_ttl` expires.
 
 See [Sandbox Services](/docs/sandbox/services), [Sandbox Functions](/docs/sandbox/functions), and [SSH](/docs/sandbox/ssh) for the user-facing flows.
 

--- a/docs/sandbox/services/page.mdx
+++ b/docs/sandbox/services/page.mdx
@@ -6,7 +6,7 @@ Use services for:
 
 - public HTTP routes into a sandbox
 - route-level method filtering, auth, CORS, rate limits, timeout, and path rewrite
-- public URL auto-resume for paused or cleaned sandboxes
+- public URL auto-resume for paused sandboxes
 - public entrypoints for listeners, command-backed services, and sandbox functions
 
 ## Mental Model
@@ -66,7 +66,7 @@ Routes are evaluated before proxying or function execution.
 | `cors` | Handles CORS preflight and response headers at the gateway |
 | `rate_limit` | Applies per-route rate limiting at the gateway |
 | `timeout_seconds` | Sets the upstream or function execution timeout |
-| `resume` | Allows this route to resume a paused or cleaned sandbox when sandbox `auto_resume` is also true |
+| `resume` | Allows this route to resume a paused sandbox when sandbox `auto_resume` is also true |
 
 `path_prefix` is not stripped automatically. Without `rewrite_prefix`, the upstream service or function handler sees the original request path.
 
@@ -510,9 +510,9 @@ Public service auto-resume has two gates:
 - sandbox `auto_resume` must be true
 - matched route `resume` must be true
 
-Both gates are required for public URL requests to wake a paused sandbox or a cleaned sandbox.
+Both gates are required for public URL requests to wake a paused sandbox.
 
-For a cleaned sandbox, Sandbox0 creates a new runtime pod for the same sandbox identity. The sandbox ID and service `public_url` stay unchanged. For `cmd` services, the command is started again in the new runtime pod. For `function` services, there is still no long-running listener; each request executes the handler after the sandbox runtime is available.
+For a paused sandbox, Sandbox0 creates a new runtime pod for the same sandbox identity and restores the latest rootfs checkpoint. The sandbox ID and service `public_url` stay unchanged until the sandbox is deleted or `hard_ttl` expires. For `cmd` services, the command is started again in the new runtime pod. For `function` services, there is still no long-running listener; each request executes the handler after the sandbox runtime is available.
 
 ## Notes
 

--- a/docs/self-hosted/configuration/page.mdx
+++ b/docs/self-hosted/configuration/page.mdx
@@ -121,7 +121,7 @@ This field only controls the `runtimeClassName` written onto sandbox Pods. The n
 
 `infra-operator` does not install node runtime handlers. It does not install `runsc`, write `/etc/containerd/config.toml`, restart containerd, or create a `gvisor-rootfs` handler. Do that through your node image, node bootstrap automation, or a dedicated privileged node setup process before scheduling sandbox workloads there.
 
-For `gVisor` rootfs clean/restore support on self-managed clusters, use a dedicated containerd handler that points to `runsc` with shared file access and overlay disabled, then create a matching `RuntimeClass`:
+For `gVisor` rootfs checkpoint and restore support on self-managed clusters, use a dedicated containerd handler that points to `runsc` with shared file access and overlay disabled, then create a matching `RuntimeClass`:
 
 ```toml
 # /etc/containerd/config.toml

--- a/docs/self-hosted/install/page.mdx
+++ b/docs/self-hosted/install/page.mdx
@@ -10,7 +10,7 @@ This is the shortest production-like path from zero to a running self-hosted San
 - A default `StorageClass`
 
 <Callout variant="info">
-Kubernetes `1.35+` is required because Sandbox0 pause/resume depends on `ctld` and Kubernetes in-place pod resource updates. Sandbox pause needs to freeze the sandbox cgroup and reduce sandbox pod resources without recreating the pod, otherwise process state cannot be preserved across pause/resume.
+Kubernetes `1.35+` is required for the supported Sandbox0 runtime stack. Checkpointed pause/resume depends on `ctld` on sandbox nodes so Sandbox0 can save and restore writable rootfs checkpoints when releasing and recreating runtime pods.
 </Callout>
 
 ## 0) Create a Local Kind Cluster
@@ -288,7 +288,7 @@ This sample uses the native GKE node label `sandbox.gke.io/runtime=gvisor` for s
 
 On GKE Sandbox, Google manages the standard `gVisor` runtime setup and the sample uses `sandboxRuntimeClassName: gvisor`. On self-managed clusters, install the runtime handler and `RuntimeClass` before pointing Sandbox0 at it.
 
-For `gVisor` rootfs clean/restore support, use a dedicated handler with shared rootfs access. `gvisor-rootfs` is just an example name; the Kubernetes `RuntimeClass.handler` must match the handler configured in containerd on every sandbox node.
+For `gVisor` rootfs checkpoint and restore support, use a dedicated handler with shared rootfs access. `gvisor-rootfs` is just an example name; the Kubernetes `RuntimeClass.handler` must match the handler configured in containerd on every sandbox node.
 
 ```toml
 # /etc/containerd/config.toml

--- a/manager/pkg/controller/cleanup_controller.go
+++ b/manager/pkg/controller/cleanup_controller.go
@@ -15,10 +15,11 @@ import (
 )
 
 const staleDeletingPodForceDeleteAfter = 10 * time.Minute
+const hardExpiredSandboxCleanupBatchSize = 500
 
-// SandboxPauseRequester defines the interface for declaring that a sandbox should be paused.
-type SandboxPauseRequester interface {
-	RequestPauseSandboxByID(ctx context.Context, sandboxID string) error
+// SandboxRuntimePauser defines the interface for checkpointing and releasing a sandbox runtime.
+type SandboxRuntimePauser interface {
+	PauseSandboxByID(ctx context.Context, sandboxID string) error
 }
 
 // SandboxTerminator defines the interface for terminating sandboxes.
@@ -26,9 +27,9 @@ type SandboxTerminator interface {
 	TerminateSandboxByID(ctx context.Context, sandboxID string) error
 }
 
-// SandboxRuntimeCleaner defines cleanup that frees compute while keeping durable sandbox state.
-type SandboxRuntimeCleaner interface {
-	CleanSandboxRuntimeByID(ctx context.Context, sandboxID string) error
+// HardExpiredSandboxLister lists durable sandboxes whose hard TTL has expired.
+type HardExpiredSandboxLister interface {
+	ListHardExpiredSandboxIDs(ctx context.Context, now time.Time, limit int) ([]string, error)
 }
 
 // CleanupController handles cleanup of excess idle pods and expired active pods
@@ -38,9 +39,9 @@ type CleanupController struct {
 	templateLister    TemplateLister
 	recorder          record.EventRecorder
 	clock             TimeProvider
-	pauseRequester    SandboxPauseRequester
-	runtimeCleaner    SandboxRuntimeCleaner
+	runtimePauser     SandboxRuntimePauser
 	sandboxTerminator SandboxTerminator
+	hardExpiredLister HardExpiredSandboxLister
 	logger            *zap.Logger
 	interval          time.Duration
 }
@@ -72,7 +73,7 @@ func NewCleanupController(
 	templateLister TemplateLister,
 	recorder record.EventRecorder,
 	clock TimeProvider,
-	pauseRequester SandboxPauseRequester,
+	runtimePauser SandboxRuntimePauser,
 	sandboxTerminator SandboxTerminator,
 	logger *zap.Logger,
 	interval time.Duration,
@@ -82,16 +83,19 @@ func NewCleanupController(
 		clock = systemTime{}
 	}
 
-	runtimeCleaner, _ := sandboxTerminator.(SandboxRuntimeCleaner)
+	hardExpiredLister, _ := sandboxTerminator.(HardExpiredSandboxLister)
+	if hardExpiredLister == nil {
+		hardExpiredLister, _ = runtimePauser.(HardExpiredSandboxLister)
+	}
 	return &CleanupController{
 		k8sClient:         k8sClient,
 		podLister:         podLister,
 		templateLister:    templateLister,
 		recorder:          recorder,
 		clock:             clock,
-		pauseRequester:    pauseRequester,
-		runtimeCleaner:    runtimeCleaner,
+		runtimePauser:     runtimePauser,
 		sandboxTerminator: sandboxTerminator,
+		hardExpiredLister: hardExpiredLister,
 		logger:            logger,
 		interval:          interval,
 	}
@@ -135,6 +139,37 @@ func (cc *CleanupController) runCleanup(ctx context.Context) error {
 		}
 	}
 
+	if err := cc.cleanupHardExpiredDurableSandboxes(ctx); err != nil {
+		cc.logger.Error("Failed to cleanup hard-expired durable sandboxes", zap.Error(err))
+	}
+
+	return nil
+}
+
+func (cc *CleanupController) cleanupHardExpiredDurableSandboxes(ctx context.Context) error {
+	if cc.hardExpiredLister == nil || cc.sandboxTerminator == nil {
+		return nil
+	}
+	now := cc.clock.Now()
+	sandboxIDs, err := cc.hardExpiredLister.ListHardExpiredSandboxIDs(ctx, now, hardExpiredSandboxCleanupBatchSize)
+	if err != nil {
+		return err
+	}
+	for _, sandboxID := range sandboxIDs {
+		if sandboxID == "" {
+			continue
+		}
+		if err := cc.sandboxTerminator.TerminateSandboxByID(ctx, sandboxID); err != nil {
+			cc.logger.Error("Failed to delete hard-expired durable sandbox",
+				zap.String("sandboxID", sandboxID),
+				zap.Error(err),
+			)
+			continue
+		}
+	}
+	if len(sandboxIDs) > 0 {
+		cc.logger.Info("Deleted hard-expired durable sandboxes", zap.Int("count", len(sandboxIDs)))
+	}
 	return nil
 }
 
@@ -169,7 +204,7 @@ func (cc *CleanupController) cleanupExpired(ctx context.Context, template *v1alp
 			continue
 		}
 
-		// Hard expiry: delete even if paused.
+		// Hard expiry deletes the durable sandbox identity and state.
 		if hardExpiresAtStr := pod.Annotations[AnnotationHardExpiresAt]; hardExpiresAtStr != "" {
 			hardExpiresAt, err := time.Parse(time.RFC3339, hardExpiresAtStr)
 			if err != nil {
@@ -178,23 +213,14 @@ func (cc *CleanupController) cleanupExpired(ctx context.Context, template *v1alp
 					zap.String("value", hardExpiresAtStr),
 				)
 			} else if now.After(hardExpiresAt) {
-				cc.logger.Info("Deleting hard-expired pod",
+				cc.logger.Info("Deleting hard-expired sandbox",
 					zap.String("pod", pod.Name),
 					zap.Time("hardExpiresAt", hardExpiresAt),
 				)
 				sandboxID := cleanupSandboxIDFromPod(pod)
-				if cc.runtimeCleaner != nil {
-					if err := cc.runtimeCleaner.CleanSandboxRuntimeByID(ctx, sandboxID); err != nil {
-						cc.logger.Error("Failed to delete hard-expired pod",
-							zap.String("pod", pod.Name),
-							zap.String("sandboxID", sandboxID),
-							zap.Error(err),
-						)
-						continue
-					}
-				} else if cc.sandboxTerminator != nil {
+				if cc.sandboxTerminator != nil {
 					if err := cc.sandboxTerminator.TerminateSandboxByID(ctx, sandboxID); err != nil {
-						cc.logger.Error("Failed to delete hard-expired pod",
+						cc.logger.Error("Failed to delete hard-expired sandbox",
 							zap.String("pod", pod.Name),
 							zap.String("sandboxID", sandboxID),
 							zap.Error(err),
@@ -214,16 +240,11 @@ func (cc *CleanupController) cleanupExpired(ctx context.Context, template *v1alp
 					}
 				}
 
-				cc.recorder.Eventf(template, corev1.EventTypeNormal, "HardExpiredPodDeleted",
-					"Deleted hard-expired pod %s", pod.Name)
+				cc.recorder.Eventf(template, corev1.EventTypeNormal, "HardExpiredSandboxDeleted",
+					"Deleted hard-expired sandbox %s", sandboxID)
 				expiredCount++
 				continue
 			}
-		}
-
-		// Skip paused pods for soft expiry.
-		if pod.Annotations[AnnotationPaused] == "true" {
-			continue
 		}
 
 		// Check if pod has expiration annotation
@@ -243,26 +264,26 @@ func (cc *CleanupController) cleanupExpired(ctx context.Context, template *v1alp
 
 		// Check if pod is expired
 		if now.After(expiresAt) {
-			cc.logger.Info("Requesting pause for expired pod",
+			cc.logger.Info("Pausing expired sandbox runtime",
 				zap.String("pod", pod.Name),
 				zap.Time("expiresAt", expiresAt),
 			)
 
-			if cc.pauseRequester != nil {
-				err := cc.pauseRequester.RequestPauseSandboxByID(ctx, cleanupSandboxIDFromPod(pod))
+			if cc.runtimePauser != nil {
+				err := cc.runtimePauser.PauseSandboxByID(ctx, cleanupSandboxIDFromPod(pod))
 				if err != nil {
-					cc.logger.Error("Failed to request pause for expired pod",
+					cc.logger.Error("Failed to pause expired sandbox runtime",
 						zap.String("pod", pod.Name),
 						zap.Error(err),
 					)
 					continue
 				}
 
-				cc.recorder.Eventf(template, corev1.EventTypeNormal, "ExpiredPodPauseRequested",
-					"Requested pause for expired pod %s", pod.Name)
+				cc.recorder.Eventf(template, corev1.EventTypeNormal, "ExpiredSandboxRuntimePaused",
+					"Paused expired sandbox runtime %s", pod.Name)
 				expiredCount++
 			} else {
-				cc.logger.Warn("Sandbox pause requester not configured, skipping pause request for expired pod",
+				cc.logger.Warn("Sandbox runtime pauser not configured, skipping pause for expired pod",
 					zap.String("pod", pod.Name),
 				)
 			}

--- a/manager/pkg/controller/cleanup_controller_test.go
+++ b/manager/pkg/controller/cleanup_controller_test.go
@@ -27,11 +27,11 @@ func (c staticCleanupClock) Now() time.Time                  { return c.now }
 func (c staticCleanupClock) Since(t time.Time) time.Duration { return c.now.Sub(t) }
 func (c staticCleanupClock) Until(t time.Time) time.Duration { return t.Sub(c.now) }
 
-type recordingPauseRequester struct {
+type recordingRuntimePauser struct {
 	calls []string
 }
 
-func (r *recordingPauseRequester) RequestPauseSandboxByID(_ context.Context, sandboxID string) error {
+func (r *recordingRuntimePauser) PauseSandboxByID(_ context.Context, sandboxID string) error {
 	r.calls = append(r.calls, sandboxID)
 	return nil
 }
@@ -45,17 +45,23 @@ func (r *recordingSandboxTerminator) TerminateSandboxByID(_ context.Context, san
 	return nil
 }
 
-type recordingRuntimeCleaner struct {
+type recordingHardExpiredLister struct {
+	calls []time.Time
+	ids   []string
+}
+
+func (r *recordingHardExpiredLister) ListHardExpiredSandboxIDs(_ context.Context, now time.Time, _ int) ([]string, error) {
+	r.calls = append(r.calls, now)
+	return append([]string(nil), r.ids...), nil
+}
+
+type recordingLifecycleService struct {
+	recordingRuntimePauser
 	recordingSandboxTerminator
-	cleanCalls []string
+	recordingHardExpiredLister
 }
 
-func (r *recordingRuntimeCleaner) CleanSandboxRuntimeByID(_ context.Context, sandboxID string) error {
-	r.cleanCalls = append(r.cleanCalls, sandboxID)
-	return nil
-}
-
-func TestCleanupExpiredRequestsPauseDesiredState(t *testing.T) {
+func TestCleanupExpiredPausesRuntime(t *testing.T) {
 	now := time.Date(2026, time.April, 15, 19, 31, 0, 0, time.UTC)
 	template := &v1alpha1.SandboxTemplate{
 		ObjectMeta: metav1.ObjectMeta{
@@ -81,7 +87,7 @@ func TestCleanupExpiredRequestsPauseDesiredState(t *testing.T) {
 	})
 	require.NoError(t, indexer.Add(pod))
 
-	pauseRequester := &recordingPauseRequester{}
+	runtimePauser := &recordingRuntimePauser{}
 	recorder := record.NewFakeRecorder(1)
 	controller := NewCleanupController(
 		nil,
@@ -89,7 +95,7 @@ func TestCleanupExpiredRequestsPauseDesiredState(t *testing.T) {
 		nil,
 		recorder,
 		staticCleanupClock{now: now},
-		pauseRequester,
+		runtimePauser,
 		nil,
 		zap.NewNop(),
 		time.Minute,
@@ -97,10 +103,10 @@ func TestCleanupExpiredRequestsPauseDesiredState(t *testing.T) {
 
 	require.NoError(t, controller.cleanupExpired(context.Background(), template))
 
-	assert.Equal(t, []string{"sandbox-1"}, pauseRequester.calls)
+	assert.Equal(t, []string{"sandbox-1"}, runtimePauser.calls)
 	select {
 	case event := <-recorder.Events:
-		assert.Contains(t, event, "ExpiredPodPauseRequested")
+		assert.Contains(t, event, "ExpiredSandboxRuntimePaused")
 	default:
 		t.Fatal("expected pause-requested event")
 	}
@@ -134,7 +140,7 @@ func TestCleanupExpiredSkipsDeletingPod(t *testing.T) {
 	})
 	require.NoError(t, indexer.Add(pod))
 
-	pauseRequester := &recordingPauseRequester{}
+	runtimePauser := &recordingRuntimePauser{}
 	recorder := record.NewFakeRecorder(1)
 	controller := NewCleanupController(
 		nil,
@@ -142,7 +148,7 @@ func TestCleanupExpiredSkipsDeletingPod(t *testing.T) {
 		nil,
 		recorder,
 		staticCleanupClock{now: now},
-		pauseRequester,
+		runtimePauser,
 		nil,
 		zap.NewNop(),
 		time.Minute,
@@ -150,7 +156,7 @@ func TestCleanupExpiredSkipsDeletingPod(t *testing.T) {
 
 	require.NoError(t, controller.cleanupExpired(context.Background(), template))
 
-	assert.Empty(t, pauseRequester.calls)
+	assert.Empty(t, runtimePauser.calls)
 	select {
 	case event := <-recorder.Events:
 		t.Fatalf("unexpected event: %s", event)
@@ -158,7 +164,7 @@ func TestCleanupExpiredSkipsDeletingPod(t *testing.T) {
 	}
 }
 
-func TestCleanupExpiredCleansHardExpiredRuntime(t *testing.T) {
+func TestCleanupExpiredDeletesHardExpiredSandbox(t *testing.T) {
 	now := time.Date(2026, time.April, 15, 19, 31, 0, 0, time.UTC)
 	template := &v1alpha1.SandboxTemplate{
 		ObjectMeta: metav1.ObjectMeta{
@@ -185,7 +191,7 @@ func TestCleanupExpiredCleansHardExpiredRuntime(t *testing.T) {
 	})
 	require.NoError(t, indexer.Add(pod))
 
-	cleaner := &recordingRuntimeCleaner{}
+	terminator := &recordingSandboxTerminator{}
 	recorder := record.NewFakeRecorder(1)
 	controller := NewCleanupController(
 		nil,
@@ -194,21 +200,43 @@ func TestCleanupExpiredCleansHardExpiredRuntime(t *testing.T) {
 		recorder,
 		staticCleanupClock{now: now},
 		nil,
-		cleaner,
+		terminator,
 		zap.NewNop(),
 		time.Minute,
 	)
 
 	require.NoError(t, controller.cleanupExpired(context.Background(), template))
 
-	assert.Equal(t, []string{"sandbox-1"}, cleaner.cleanCalls)
-	assert.Empty(t, cleaner.calls)
+	assert.Equal(t, []string{"sandbox-1"}, terminator.calls)
 	select {
 	case event := <-recorder.Events:
-		assert.Contains(t, event, "HardExpiredPodDeleted")
+		assert.Contains(t, event, "HardExpiredSandboxDeleted")
 	default:
 		t.Fatal("expected hard-expired event")
 	}
+}
+
+func TestCleanupHardExpiredDurableSandboxesDeletesListedRecords(t *testing.T) {
+	now := time.Date(2026, time.April, 15, 19, 31, 0, 0, time.UTC)
+	service := &recordingLifecycleService{
+		recordingHardExpiredLister: recordingHardExpiredLister{ids: []string{"sandbox-paused"}},
+	}
+	controller := NewCleanupController(
+		nil,
+		corelisters.NewPodLister(cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})),
+		nil,
+		record.NewFakeRecorder(1),
+		staticCleanupClock{now: now},
+		service,
+		service,
+		zap.NewNop(),
+		time.Minute,
+	)
+
+	require.NoError(t, controller.cleanupHardExpiredDurableSandboxes(context.Background()))
+
+	assert.Len(t, service.recordingHardExpiredLister.calls, 1)
+	assert.Equal(t, []string{"sandbox-paused"}, service.recordingSandboxTerminator.calls)
 }
 
 func TestCleanupExpiredForceDeletesStaleDeletingPod(t *testing.T) {

--- a/manager/pkg/http/handlers_sandbox.go
+++ b/manager/pkg/http/handlers_sandbox.go
@@ -548,7 +548,7 @@ func (s *Server) pauseSandbox(c *gin.Context) {
 
 	resp, err := s.sandboxService.PauseSandboxAndWait(c.Request.Context(), sandboxID)
 	if err != nil {
-		s.writeSandboxPowerTransitionError(c, "pause", sandboxID, err)
+		s.writeSandboxLifecycleTransitionError(c, "pause", sandboxID, err)
 		return
 	}
 
@@ -584,24 +584,28 @@ func (s *Server) resumeSandbox(c *gin.Context) {
 
 	resp, err := s.sandboxService.ResumeSandboxAndWait(c.Request.Context(), sandboxID)
 	if err != nil {
-		s.writeSandboxPowerTransitionError(c, "resume", sandboxID, err)
+		s.writeSandboxLifecycleTransitionError(c, "resume", sandboxID, err)
 		return
 	}
 
 	spec.JSONSuccess(c, http.StatusOK, resp)
 }
 
-func (s *Server) writeSandboxPowerTransitionError(c *gin.Context, action, sandboxID string, err error) {
-	s.logger.Error("Failed to change sandbox power state",
+func (s *Server) writeSandboxLifecycleTransitionError(c *gin.Context, action, sandboxID string, err error) {
+	s.logger.Error("Failed to change sandbox lifecycle state",
 		zap.String("action", action),
 		zap.String("sandboxID", sandboxID),
 		zap.Error(err),
 	)
 	switch {
-	case errors.Is(err, service.ErrSandboxPowerTransitionSuperseded):
-		spec.JSONError(c, http.StatusConflict, spec.CodeConflict, fmt.Sprintf("sandbox %s was superseded by a newer power transition", action))
-	case errors.Is(err, service.ErrSandboxPowerRequiresCtld):
-		spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox pause/resume requires ctld")
+	case apierrors.IsConflict(err):
+		spec.JSONError(c, http.StatusConflict, spec.CodeConflict, fmt.Sprintf("sandbox %s conflicts with another lifecycle operation", action))
+	case apierrors.IsNotFound(err):
+		spec.JSONError(c, http.StatusNotFound, spec.CodeNotFound, "sandbox not found")
+	case errors.Is(err, service.ErrQuotaExceeded):
+		spec.JSONError(c, http.StatusTooManyRequests, "quota_exceeded", err.Error())
+	case errors.Is(err, service.ErrSandboxCheckpointRequiresCtld):
+		spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox checkpoint pause requires ctld")
 	case errors.Is(err, context.DeadlineExceeded):
 		spec.JSONError(c, http.StatusGatewayTimeout, spec.CodeUnavailable, fmt.Sprintf("timed out waiting for sandbox to %s", action))
 	case errors.Is(err, context.Canceled):

--- a/manager/pkg/metering/lifecycle_projector.go
+++ b/manager/pkg/metering/lifecycle_projector.go
@@ -223,6 +223,7 @@ func (p *LifecycleProjector) handleDelete(obj any) {
 	templateID := pod.Labels[controller.LabelTemplateID]
 	podUsage := sandboxUsageFromPod(pod)
 	claimedAt, claimedAtSet := parseRFC3339(pod.Annotations[controller.AnnotationClaimedAt])
+	runtimePaused := pod.Annotations[controller.AnnotationRuntimeDeletionReason] == "paused"
 	pendingEvents := make([]*meteringpkg.Event, 0, 3)
 	pendingWindows := make([]*meteringpkg.Window, 0, 2)
 	if state == nil {
@@ -256,6 +257,22 @@ func (p *LifecycleProjector) handleDelete(obj any) {
 			state.PausedAt = &pausedAt
 			state.ActiveSince = nil
 		}
+	}
+	if runtimePaused {
+		if !state.Paused {
+			pendingWindows = append(pendingWindows, p.buildSandboxRuntimeWindow(state, teamID, userID, templateID, state.ActiveSince, observedAt))
+			pendingEvents = append(pendingEvents, p.buildSandboxEvent(sandboxID, teamID, userID, templateID, observedAt, meteringpkg.EventTypeSandboxPaused, pauseEventID(sandboxID, observedAt), nil))
+		}
+		state.Paused = true
+		state.PausedAt = &observedAt
+		state.ActiveSince = nil
+		state.TerminatedAt = nil
+		state.LastObservedAt = observedAt
+		state.LastResourceVer = pod.ResourceVersion
+		if err := p.commitProjection(ctx, sandboxID, state, pendingEvents, pendingWindows, observedAt); err != nil {
+			return
+		}
+		return
 	}
 	if state.TerminatedAt == nil {
 		if !state.Paused {

--- a/manager/pkg/service/power_executor_ctld_test.go
+++ b/manager/pkg/service/power_executor_ctld_test.go
@@ -23,13 +23,35 @@ func TestNewSandboxServiceInitializesCtldClientDefaults(t *testing.T) {
 	assert.Equal(t, 15*time.Second, svc.ctldClient.httpClient.Timeout)
 }
 
-func TestSandboxPowerRequiresCtldEnabled(t *testing.T) {
-	svc := NewSandboxService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, SandboxServiceConfig{}, zap.NewNop(), nil)
+func TestCheckpointPauseRequiresCtldEnabled(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sandbox-1",
+			Namespace: "default",
+			Labels: map[string]string{
+				controller.LabelSandboxID: "sandbox-1",
+			},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	store := &memorySandboxStore{records: map[string]*SandboxRecord{
+		"sandbox-1": {
+			ID:     "sandbox-1",
+			TeamID: "team-1",
+			Status: SandboxStatusRunning,
+		},
+	}}
+	svc := &SandboxService{
+		k8sClient:    fake.NewSimpleClientset(pod),
+		podLister:    newTestPodLister(t, pod),
+		sandboxStore: store,
+		config:       SandboxServiceConfig{},
+		logger:       zap.NewNop(),
+		clock:        systemTime{},
+	}
 
 	_, err := svc.PauseSandbox(context.Background(), "sandbox-1")
-	require.ErrorIs(t, err, ErrSandboxPowerRequiresCtld)
-	_, err = svc.ResumeSandbox(context.Background(), "sandbox-1")
-	require.ErrorIs(t, err, ErrSandboxPowerRequiresCtld)
+	require.ErrorIs(t, err, ErrSandboxCheckpointRequiresCtld)
 }
 
 func TestCtldAddressForPodUsesHostIPWithoutK8sClient(t *testing.T) {
@@ -62,88 +84,6 @@ func TestCtldAddressForPodUsesNodeCacheBeforeLiveGet(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "http://10.0.0.1:8095", address)
 	assert.Empty(t, k8sClient.Actions())
-}
-
-func TestCtldPowerExecutorRequestsPauseAsDesiredState(t *testing.T) {
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "sandbox-1",
-			Namespace: "default",
-			Labels: map[string]string{
-				controller.LabelSandboxID: "sandbox-1",
-			},
-		},
-		Status: corev1.PodStatus{Phase: corev1.PodRunning},
-	}
-	svc := &SandboxService{
-		k8sClient: fake.NewSimpleClientset(pod),
-		podLister: newTestPodLister(t, pod),
-		config:    SandboxServiceConfig{CtldEnabled: true, CtldPort: 8095},
-		logger:    zap.NewNop(),
-		clock:     systemTime{},
-	}
-
-	resp, err := svc.PauseSandbox(context.Background(), "sandbox-1")
-	require.NoError(t, err)
-	assert.True(t, resp.Paused)
-	assert.Equal(t, SandboxPowerStatePaused, resp.PowerState.Desired)
-	assert.Equal(t, SandboxPowerStateActive, resp.PowerState.Observed)
-	assert.Equal(t, SandboxPowerPhasePausing, resp.PowerState.Phase)
-
-	updated, err := svc.k8sClient.CoreV1().Pods("default").Get(context.Background(), "sandbox-1", metav1.GetOptions{})
-	require.NoError(t, err)
-	state := sandboxPowerStateFromAnnotations(updated.Annotations)
-	assert.Equal(t, SandboxPowerStatePaused, state.Desired)
-	assert.Equal(t, SandboxPowerStateActive, state.Observed)
-	assert.Equal(t, SandboxPowerPhasePausing, state.Phase)
-	assert.Empty(t, updated.Annotations[controller.AnnotationPaused])
-	assert.Empty(t, updated.Annotations[controller.AnnotationPausedState])
-}
-
-func TestCtldPowerExecutorRequestsResumeAsDesiredState(t *testing.T) {
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "sandbox-1",
-			Namespace: "default",
-			Labels: map[string]string{
-				controller.LabelSandboxID: "sandbox-1",
-			},
-			Annotations: map[string]string{
-				controller.AnnotationPaused:                       "true",
-				controller.AnnotationPausedAt:                     time.Now().UTC().Format(time.RFC3339),
-				controller.AnnotationPausedState:                  `{"resources":{"procd":{"requests":{"cpu":"100m","memory":"128Mi"},"limits":{"cpu":"200m","memory":"256Mi"}}}}`,
-				controller.AnnotationPowerStateDesired:            SandboxPowerStatePaused,
-				controller.AnnotationPowerStateDesiredGeneration:  "2",
-				controller.AnnotationPowerStateObserved:           SandboxPowerStatePaused,
-				controller.AnnotationPowerStateObservedGeneration: "2",
-				controller.AnnotationPowerStatePhase:              SandboxPowerPhaseStable,
-			},
-		},
-		Status: corev1.PodStatus{Phase: corev1.PodRunning},
-	}
-	svc := &SandboxService{
-		k8sClient: fake.NewSimpleClientset(pod),
-		podLister: newTestPodLister(t, pod),
-		config:    SandboxServiceConfig{CtldEnabled: true, CtldPort: 8095},
-		logger:    zap.NewNop(),
-		clock:     systemTime{},
-	}
-
-	resp, err := svc.ResumeSandbox(context.Background(), "sandbox-1")
-	require.NoError(t, err)
-	assert.True(t, resp.Resumed)
-	assert.Equal(t, SandboxPowerStateActive, resp.PowerState.Desired)
-	assert.Equal(t, SandboxPowerStatePaused, resp.PowerState.Observed)
-	assert.Equal(t, SandboxPowerPhaseResuming, resp.PowerState.Phase)
-
-	updated, err := svc.k8sClient.CoreV1().Pods("default").Get(context.Background(), "sandbox-1", metav1.GetOptions{})
-	require.NoError(t, err)
-	state := sandboxPowerStateFromAnnotations(updated.Annotations)
-	assert.Equal(t, SandboxPowerStateActive, state.Desired)
-	assert.Equal(t, SandboxPowerStatePaused, state.Observed)
-	assert.Equal(t, SandboxPowerPhaseResuming, state.Phase)
-	assert.Equal(t, "true", updated.Annotations[controller.AnnotationPaused])
-	assert.NotEmpty(t, updated.Annotations[controller.AnnotationPausedState])
 }
 
 func TestTerminateSandboxRequestsAsyncThawBeforeDelete(t *testing.T) {

--- a/manager/pkg/service/sandbox_lifecycle_controller.go
+++ b/manager/pkg/service/sandbox_lifecycle_controller.go
@@ -327,9 +327,9 @@ func (s *SandboxService) CleanupDeletedSandbox(ctx context.Context, info Sandbox
 		return nil
 	}
 
-	runtimeCleaned := strings.TrimSpace(info.RuntimeDeletionReason) == runtimeDeletionReasonCleaned
+	runtimePaused := strings.TrimSpace(info.RuntimeDeletionReason) == runtimeDeletionReasonPaused
 	var errs []error
-	if !runtimeCleaned && s.deletionWebhookEmitter != nil && strings.TrimSpace(info.WebhookURL) != "" {
+	if !runtimePaused && s.deletionWebhookEmitter != nil && strings.TrimSpace(info.WebhookURL) != "" {
 		if err := s.deletionWebhookEmitter.EmitSandboxDeleted(ctx, info); err != nil {
 			errs = append(errs, fmt.Errorf("emit sandbox.deleted webhook: %w", err))
 		}
@@ -339,7 +339,7 @@ func (s *SandboxService) CleanupDeletedSandbox(ctx context.Context, info Sandbox
 			errs = append(errs, fmt.Errorf("remove network policy: %w", err))
 		}
 	}
-	if !runtimeCleaned && s.credentialStore != nil {
+	if !runtimePaused && s.credentialStore != nil {
 		teamID := strings.TrimSpace(info.TeamID)
 		if teamID == "" {
 			logger.Warn("Skipping credential binding cleanup for sandbox without team ID",
@@ -350,7 +350,7 @@ func (s *SandboxService) CleanupDeletedSandbox(ctx context.Context, info Sandbox
 			errs = append(errs, fmt.Errorf("delete credential bindings: %w", err))
 		}
 	}
-	if !runtimeCleaned {
+	if !runtimePaused {
 		if err := s.deleteWebhookStateVolume(ctx, info); err != nil {
 			errs = append(errs, fmt.Errorf("delete webhook state volume: %w", err))
 		}

--- a/manager/pkg/service/sandbox_lifecycle_controller_test.go
+++ b/manager/pkg/service/sandbox_lifecycle_controller_test.go
@@ -265,7 +265,7 @@ func TestSandboxServiceCleanupDeletedSandboxEmitsWebhookAndMarksStateVolumeForCl
 	}
 }
 
-func TestSandboxServiceCleanupDeletedSandboxPreservesDurableStateForCleanedRuntime(t *testing.T) {
+func TestSandboxServiceCleanupDeletedSandboxPreservesDurableStateForPausedRuntime(t *testing.T) {
 	removed := make([]string, 0, 1)
 	store := &deleteRecordingBindingStore{}
 	volumeClient := &recordingSystemVolumeClient{}
@@ -288,7 +288,7 @@ func TestSandboxServiceCleanupDeletedSandboxPreservesDurableStateForCleanedRunti
 		UserID:                "user-a",
 		WebhookURL:            "https://example.test/webhook",
 		WebhookStateVolumeID:  "volume-a",
-		RuntimeDeletionReason: runtimeDeletionReasonCleaned,
+		RuntimeDeletionReason: runtimeDeletionReasonPaused,
 	})
 	if err != nil {
 		t.Fatalf("CleanupDeletedSandbox() error = %v", err)

--- a/manager/pkg/service/sandbox_runtime_identity_test.go
+++ b/manager/pkg/service/sandbox_runtime_identity_test.go
@@ -21,7 +21,7 @@ type memorySandboxStore struct {
 	rootFSStates map[string]*SandboxRootFSState
 	deletes      []string
 	saves        int
-	cleans       int
+	pauses       int
 }
 
 type memorySandboxStoreTx struct {
@@ -43,7 +43,32 @@ func (s *memorySandboxStore) GetSandbox(_ context.Context, sandboxID string) (*S
 	return cloneSandboxRecord(s.records[sandboxID]), nil
 }
 
-func (s *memorySandboxStore) ListSandboxes(context.Context, *ListSandboxesRequest) ([]*SandboxRecord, error) {
+func (s *memorySandboxStore) ListSandboxes(_ context.Context, req *ListSandboxesRequest) ([]*SandboxRecord, error) {
+	if s == nil || s.records == nil {
+		return nil, nil
+	}
+	var records []*SandboxRecord
+	for _, record := range s.records {
+		if record == nil {
+			continue
+		}
+		if req != nil {
+			if req.TeamID != "" && record.TeamID != req.TeamID {
+				continue
+			}
+			if req.Status != "" && record.Status != req.Status {
+				continue
+			}
+			if req.TemplateID != "" && record.TemplateID != req.TemplateID {
+				continue
+			}
+		}
+		records = append(records, cloneSandboxRecord(record))
+	}
+	return records, nil
+}
+
+func (s *memorySandboxStore) ListHardExpiredSandboxes(context.Context, time.Time, int) ([]*SandboxRecord, error) {
 	return nil, nil
 }
 
@@ -103,15 +128,15 @@ func (t memorySandboxStoreTx) SaveRuntime(_ context.Context, sandboxID, namespac
 	return nil
 }
 
-func (t memorySandboxStoreTx) MarkRuntimeCleaned(_ context.Context, sandboxID string, generation int64, _ time.Time) error {
+func (t memorySandboxStoreTx) MarkRuntimePaused(_ context.Context, sandboxID string, generation int64, _ time.Time) error {
 	record := t.store.records[sandboxID]
 	record.CurrentPodNamespace = ""
 	record.CurrentPodName = ""
-	record.Status = SandboxStatusCleaned
+	record.Status = SandboxStatusPaused
 	if record.RuntimeGeneration < generation {
 		record.RuntimeGeneration = generation
 	}
-	t.store.cleans++
+	t.store.pauses++
 	return nil
 }
 
@@ -186,7 +211,7 @@ func TestGetSandboxPodRejectsMultipleActiveRuntimePods(t *testing.T) {
 	}
 }
 
-func TestRestoreCleanedSandboxRuntimeDoesNotCreatePodWhileRuntimeDeleting(t *testing.T) {
+func TestResumePausedSandboxRuntimeDoesNotCreatePodWhileRuntimeDeleting(t *testing.T) {
 	deletionTime := metav1.NewTime(time.Now().UTC())
 	pod := runtimeIdentityPod("ns-a", "pod-a", "sandbox-a")
 	pod.DeletionTimestamp = &deletionTime
@@ -198,7 +223,7 @@ func TestRestoreCleanedSandboxRuntimeDoesNotCreatePodWhileRuntimeDeleting(t *tes
 			TemplateID:        "default",
 			TemplateName:      "default",
 			TemplateNamespace: "tpl-default",
-			Status:            SandboxStatusCleaned,
+			Status:            SandboxStatusPaused,
 			TemplateSpec:      v1alpha1.SandboxTemplateSpec{},
 		},
 	}}
@@ -210,9 +235,9 @@ func TestRestoreCleanedSandboxRuntimeDoesNotCreatePodWhileRuntimeDeleting(t *tes
 		logger:       zap.NewNop(),
 	}
 
-	_, err := svc.RestoreCleanedSandboxRuntime(context.Background(), "sandbox-a")
+	_, err := svc.ResumePausedSandboxRuntime(context.Background(), "sandbox-a")
 	if !k8serrors.IsConflict(err) {
-		t.Fatalf("RestoreCleanedSandboxRuntime() error = %v, want conflict", err)
+		t.Fatalf("ResumePausedSandboxRuntime() error = %v, want conflict", err)
 	}
 	for _, action := range client.Actions() {
 		if action.GetVerb() == "create" && action.GetResource().Resource == "pods" {
@@ -224,13 +249,13 @@ func TestRestoreCleanedSandboxRuntimeDoesNotCreatePodWhileRuntimeDeleting(t *tes
 	}
 }
 
-func TestTerminateCleanedSandboxRecordRunsPersistentCleanup(t *testing.T) {
+func TestTerminatePausedSandboxRecordRunsPersistentCleanup(t *testing.T) {
 	store := &memorySandboxStore{records: map[string]*SandboxRecord{
 		"sandbox-a": {
 			ID:     "sandbox-a",
 			TeamID: "team-a",
 			UserID: "user-a",
-			Status: SandboxStatusCleaned,
+			Status: SandboxStatusPaused,
 			Config: SandboxConfig{Webhook: &WebhookConfig{
 				URL:    "https://example.test/webhook",
 				Secret: "secret",

--- a/manager/pkg/service/sandbox_service.go
+++ b/manager/pkg/service/sandbox_service.go
@@ -21,31 +21,33 @@ import (
 
 // Sandbox represents a sandbox instance
 type Sandbox struct {
-	ID            string              `json:"id"`
-	TemplateID    string              `json:"template_id"`
-	TeamID        string              `json:"team_id"`
-	UserID        string              `json:"user_id"`
-	InternalAddr  string              `json:"internal_addr"`
-	Status        string              `json:"status"`
-	Paused        bool                `json:"paused"`
-	PowerState    SandboxPowerState   `json:"power_state"`
-	AutoResume    bool                `json:"auto_resume"`
-	Services      []SandboxAppService `json:"services,omitempty"`
-	Mounts        []ClaimMount        `json:"mounts,omitempty"`
-	PodName       string              `json:"pod_name"`
-	ExpiresAt     time.Time           `json:"expires_at"`
-	HardExpiresAt time.Time           `json:"hard_expires_at"`
-	ClaimedAt     time.Time           `json:"claimed_at"`
-	CreatedAt     time.Time           `json:"created_at"`
+	ID                string              `json:"id"`
+	TemplateID        string              `json:"template_id"`
+	TeamID            string              `json:"team_id"`
+	UserID            string              `json:"user_id"`
+	InternalAddr      string              `json:"internal_addr"`
+	Status            string              `json:"status"`
+	Paused            bool                `json:"paused"`
+	AutoResume        bool                `json:"auto_resume"`
+	Services          []SandboxAppService `json:"services,omitempty"`
+	Mounts            []ClaimMount        `json:"mounts,omitempty"`
+	PodName           string              `json:"pod_name"`
+	RuntimeGeneration int64               `json:"runtime_generation"`
+	ExpiresAt         time.Time           `json:"expires_at"`
+	HardExpiresAt     time.Time           `json:"hard_expires_at"`
+	ClaimedAt         time.Time           `json:"claimed_at"`
+	CreatedAt         time.Time           `json:"created_at"`
+	UpdatedAt         time.Time           `json:"updated_at"`
 }
 
 // SandboxStatus represents possible sandbox statuses
 const (
-	SandboxStatusPending      = "pending"
 	SandboxStatusStarting     = "starting"
 	SandboxStatusRunning      = "running"
+	SandboxStatusPausing      = "pausing"
+	SandboxStatusPaused       = "paused"
+	SandboxStatusResuming     = "resuming"
 	SandboxStatusFailed       = "failed"
-	SandboxStatusCompleted    = "completed"
 	SandboxStatusTerminating  = "terminating"
 	SandboxPowerStateActive   = "active"
 	SandboxPowerStatePaused   = "paused"
@@ -54,7 +56,7 @@ const (
 	SandboxPowerPhaseResuming = "resuming"
 )
 
-// SandboxPowerState tracks the latest desired and observed power state for async pause/resume.
+// SandboxPowerState tracks ctld cgroup state annotations used to thaw runtimes before deletion.
 type SandboxPowerState struct {
 	Desired            string `json:"desired"`
 	DesiredGeneration  int64  `json:"desired_generation"`
@@ -69,17 +71,10 @@ var ErrInvalidClaimRequest = errors.New("invalid claim request")
 var ErrClaimConflict = errors.New("claim conflict")
 var ErrDataPlaneNotReady = errors.New("data plane not ready")
 var ErrQuotaExceeded = errors.New("quota exceeded")
-var errSandboxPowerStateStale = errors.New("sandbox power state changed during execution")
-
-// ErrSandboxPowerRequiresCtld is returned when pause/resume is requested without ctld ownership enabled.
-var ErrSandboxPowerRequiresCtld = errors.New("sandbox power transitions require ctld")
-
-// ErrSandboxPowerTransitionSuperseded is returned when a newer pause/resume request replaces the requested transition.
-var ErrSandboxPowerTransitionSuperseded = errors.New("sandbox power transition superseded")
+var ErrSandboxCheckpointRequiresCtld = errors.New("sandbox checkpoint pause requires ctld")
 
 const defaultPodClaimReadyTimeout = 90 * time.Second
-const defaultSandboxPowerTransitionTimeout = 2 * time.Minute
-const defaultSandboxPowerPollInterval = 100 * time.Millisecond
+const defaultSandboxRestoreTimeout = 2 * time.Minute
 
 // claimIdlePodBackoff is the retry backoff for claiming idle pods.
 // Designed to balance between:

--- a/manager/pkg/service/sandbox_service_lifecycle.go
+++ b/manager/pkg/service/sandbox_service_lifecycle.go
@@ -78,19 +78,32 @@ func (s *SandboxService) TerminateSandbox(ctx context.Context, sandboxID string)
 	return nil
 }
 
-// CleanSandboxRuntime deletes the runtime pod while preserving durable sandbox state and public services.
-func (s *SandboxService) CleanSandboxRuntime(ctx context.Context, sandboxID string) error {
-	return s.cleanSandboxRuntime(ctx, sandboxID, true)
+// PauseSandboxRuntime checkpoints the writable rootfs, deletes the runtime pod,
+// and preserves the durable sandbox identity for a later resume.
+func (s *SandboxService) PauseSandboxRuntime(ctx context.Context, sandboxID string) error {
+	return s.pauseSandboxRuntime(ctx, sandboxID, true)
 }
 
-func (s *SandboxService) cleanSandboxRuntime(ctx context.Context, sandboxID string, saveRootFS bool) error {
-	s.logger.Info("Cleaning sandbox runtime", zap.String("sandboxID", sandboxID))
-	clean := func(ctx context.Context, tx SandboxStoreTx, record *SandboxRecord) error {
+func (s *SandboxService) pauseSandboxRuntime(ctx context.Context, sandboxID string, saveRootFS bool) error {
+	s.logger.Info("Pausing sandbox runtime", zap.String("sandboxID", sandboxID))
+	pause := func(ctx context.Context, tx SandboxStoreTx, record *SandboxRecord) error {
+		if record != nil {
+			switch record.Status {
+			case SandboxStatusDeleted:
+				return k8serrors.NewNotFound(schema.GroupResource{Resource: "sandbox"}, sandboxID)
+			case SandboxStatusPaused:
+				return nil
+			case SandboxStatusStarting, SandboxStatusPausing, SandboxStatusResuming:
+				if saveRootFS {
+					return k8serrors.NewConflict(schema.GroupResource{Resource: "sandbox"}, sandboxID, fmt.Errorf("sandbox lifecycle operation %q is in progress", record.Status))
+				}
+			}
+		}
 		pod, err := s.getSandboxPod(ctx, sandboxID)
 		if err != nil {
 			if k8serrors.IsNotFound(err) {
 				if tx != nil {
-					return tx.MarkRuntimeCleaned(ctx, sandboxID, 0, s.clock.Now())
+					return tx.MarkRuntimePaused(ctx, sandboxID, 0, s.clock.Now())
 				}
 				return nil
 			}
@@ -98,6 +111,9 @@ func (s *SandboxService) cleanSandboxRuntime(ctx context.Context, sandboxID stri
 		}
 		generation := runtimeGenerationFromPod(pod)
 		if saveRootFS {
+			if s == nil || !s.config.CtldEnabled || s.ctldClient == nil {
+				return ErrSandboxCheckpointRequiresCtld
+			}
 			if err := s.saveSandboxRootFSCheckpoint(ctx, pod, record, tx); err != nil {
 				return err
 			}
@@ -106,7 +122,7 @@ func (s *SandboxService) cleanSandboxRuntime(ctx context.Context, sandboxID stri
 		if err != nil {
 			return fmt.Errorf("ensure sandbox cleanup finalizer: %w", err)
 		}
-		pod, err = s.markRuntimeDeletionReason(ctx, pod, runtimeDeletionReasonCleaned)
+		pod, err = s.markRuntimeDeletionReason(ctx, pod, runtimeDeletionReasonPaused)
 		if err != nil {
 			return fmt.Errorf("mark runtime deletion reason: %w", err)
 		}
@@ -114,29 +130,47 @@ func (s *SandboxService) cleanSandboxRuntime(ctx context.Context, sandboxID stri
 			return fmt.Errorf("delete runtime pod: %w", err)
 		}
 		if tx != nil {
-			return tx.MarkRuntimeCleaned(ctx, sandboxID, generation, s.clock.Now())
+			return tx.MarkRuntimePaused(ctx, sandboxID, generation, s.clock.Now())
 		}
 		return nil
 	}
 	if s.sandboxStore != nil {
-		if err := s.sandboxStore.WithSandboxLock(ctx, sandboxID, clean); err != nil {
+		if err := s.sandboxStore.WithSandboxLock(ctx, sandboxID, pause); err != nil {
 			if errors.Is(err, ErrSandboxRecordNotFound) {
-				return clean(ctx, nil, nil)
+				return pause(ctx, nil, nil)
 			}
 			return err
 		}
 		return nil
 	}
-	return clean(ctx, nil, nil)
+	return pause(ctx, nil, nil)
 }
 
-// CleanSandboxRuntimeByID implements controller.SandboxRuntimeCleaner.
-func (s *SandboxService) CleanSandboxRuntimeByID(ctx context.Context, sandboxID string) error {
-	return s.CleanSandboxRuntime(ctx, sandboxID)
+// PauseSandboxByID implements controller.SandboxRuntimePauser.
+func (s *SandboxService) PauseSandboxByID(ctx context.Context, sandboxID string) error {
+	return s.PauseSandboxRuntime(ctx, sandboxID)
+}
+
+// ListHardExpiredSandboxIDs returns durable sandboxes whose hard TTL has expired.
+func (s *SandboxService) ListHardExpiredSandboxIDs(ctx context.Context, now time.Time, limit int) ([]string, error) {
+	if s == nil || s.sandboxStore == nil {
+		return nil, nil
+	}
+	records, err := s.sandboxStore.ListHardExpiredSandboxes(ctx, now, limit)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(records))
+	for _, record := range records {
+		if record != nil && strings.TrimSpace(record.ID) != "" {
+			ids = append(ids, record.ID)
+		}
+	}
+	return ids, nil
 }
 
 const (
-	runtimeDeletionReasonCleaned = "cleaned"
+	runtimeDeletionReasonPaused  = "paused"
 	runtimeDeletionReasonDeleted = "deleted"
 )
 
@@ -168,7 +202,7 @@ func (s *SandboxService) thawSandboxBeforeTermination(ctx context.Context, pod *
 	if s == nil || !s.config.CtldEnabled || !sandboxPodMayHaveFrozenCgroup(pod) {
 		return
 	}
-	if _, err := s.RequestResumeSandbox(ctx, sandboxID); err != nil {
+	if _, err := s.requestSandboxPowerState(ctx, sandboxID, SandboxPowerStateActive); err != nil {
 		s.logger.Warn("Failed to request sandbox thaw before termination",
 			zap.String("sandboxID", sandboxID),
 			zap.Error(err),
@@ -215,7 +249,7 @@ func (s *SandboxService) UpdateSandbox(ctx context.Context, sandboxID string, cf
 				return nil, fmt.Errorf("get sandbox record: %w", getErr)
 			}
 			if record != nil && record.Status != SandboxStatusDeleted {
-				return s.updateCleanedSandboxRecord(ctx, record, cfg)
+				return s.updatePausedSandboxRecord(ctx, record, cfg)
 			}
 		}
 		return nil, fmt.Errorf("get pod: %w", err)
@@ -340,7 +374,7 @@ func (s *SandboxService) UpdateSandbox(ctx context.Context, sandboxID string, cf
 	return s.podToSandbox(ctx, updatedPod, sandboxID), nil
 }
 
-func (s *SandboxService) updateCleanedSandboxRecord(ctx context.Context, record *SandboxRecord, cfg *SandboxUpdateConfig) (*Sandbox, error) {
+func (s *SandboxService) updatePausedSandboxRecord(ctx context.Context, record *SandboxRecord, cfg *SandboxUpdateConfig) (*Sandbox, error) {
 	if record == nil {
 		return nil, k8serrors.NewNotFound(schema.GroupResource{Resource: "sandbox"}, "")
 	}
@@ -501,25 +535,24 @@ func (s *SandboxService) podToSandbox(ctx context.Context, pod *corev1.Pod, sand
 	if cfg.AutoResume != nil {
 		autoResume = *cfg.AutoResume
 	}
-	powerState := sandboxPowerStateFromAnnotations(pod.Annotations)
-
 	return &Sandbox{
-		ID:            sandboxID,
-		TemplateID:    sandboxTemplateIDFromLabels(pod.Labels),
-		TeamID:        pod.Annotations[controller.AnnotationTeamID],
-		UserID:        pod.Annotations[controller.AnnotationUserID],
-		InternalAddr:  internalAddr,
-		Status:        status,
-		Paused:        powerState.Observed == SandboxPowerStatePaused,
-		PowerState:    powerState,
-		AutoResume:    autoResume,
-		Services:      cfg.Services,
-		Mounts:        parseClaimMounts(pod.Annotations[controller.AnnotationMounts]),
-		PodName:       pod.Name,
-		ExpiresAt:     expiresAt,
-		HardExpiresAt: hardExpiresAt,
-		ClaimedAt:     claimedAt,
-		CreatedAt:     createdAt,
+		ID:                sandboxID,
+		TemplateID:        sandboxTemplateIDFromLabels(pod.Labels),
+		TeamID:            pod.Annotations[controller.AnnotationTeamID],
+		UserID:            pod.Annotations[controller.AnnotationUserID],
+		InternalAddr:      internalAddr,
+		Status:            status,
+		Paused:            status == SandboxStatusPaused,
+		AutoResume:        autoResume,
+		Services:          cfg.Services,
+		Mounts:            parseClaimMounts(pod.Annotations[controller.AnnotationMounts]),
+		PodName:           pod.Name,
+		RuntimeGeneration: runtimeGenerationFromPod(pod),
+		ExpiresAt:         expiresAt,
+		HardExpiresAt:     hardExpiresAt,
+		ClaimedAt:         claimedAt,
+		CreatedAt:         createdAt,
+		UpdatedAt:         createdAt,
 	}
 }
 
@@ -531,29 +564,23 @@ func (s *SandboxService) recordToSandbox(record *SandboxRecord) *Sandbox {
 	if record.Config.AutoResume != nil {
 		autoResume = *record.Config.AutoResume
 	}
-	powerState := SandboxPowerState{
-		Desired:            SandboxPowerStateActive,
-		DesiredGeneration:  record.RuntimeGeneration,
-		Observed:           SandboxPowerStateActive,
-		ObservedGeneration: record.RuntimeGeneration,
-		Phase:              SandboxPowerPhaseStable,
-	}
 	return &Sandbox{
-		ID:            record.ID,
-		TemplateID:    record.TemplateID,
-		TeamID:        record.TeamID,
-		UserID:        record.UserID,
-		Status:        record.Status,
-		Paused:        false,
-		PowerState:    powerState,
-		AutoResume:    autoResume,
-		Services:      record.Config.Services,
-		Mounts:        record.Mounts,
-		PodName:       record.CurrentPodName,
-		ExpiresAt:     record.ExpiresAt,
-		HardExpiresAt: record.HardExpiresAt,
-		ClaimedAt:     record.ClaimedAt,
-		CreatedAt:     record.CreatedAt,
+		ID:                record.ID,
+		TemplateID:        record.TemplateID,
+		TeamID:            record.TeamID,
+		UserID:            record.UserID,
+		Status:            record.Status,
+		Paused:            record.Status == SandboxStatusPaused,
+		AutoResume:        autoResume,
+		Services:          record.Config.Services,
+		Mounts:            record.Mounts,
+		PodName:           record.CurrentPodName,
+		RuntimeGeneration: record.RuntimeGeneration,
+		ExpiresAt:         record.ExpiresAt,
+		HardExpiresAt:     record.HardExpiresAt,
+		ClaimedAt:         record.ClaimedAt,
+		CreatedAt:         record.CreatedAt,
+		UpdatedAt:         record.UpdatedAt,
 	}
 }
 

--- a/manager/pkg/service/sandbox_service_list.go
+++ b/manager/pkg/service/sandbox_service_list.go
@@ -30,14 +30,15 @@ type ListSandboxesResponse struct {
 
 // SandboxSummary represents a summary of a sandbox for listing
 type SandboxSummary struct {
-	ID            string            `json:"id"`
-	TemplateID    string            `json:"template_id"`
-	Status        string            `json:"status"`
-	Paused        bool              `json:"paused"`
-	PowerState    SandboxPowerState `json:"power_state"`
-	CreatedAt     time.Time         `json:"created_at"`
-	ExpiresAt     time.Time         `json:"expires_at"`
-	HardExpiresAt time.Time         `json:"hard_expires_at"`
+	ID                string    `json:"id"`
+	TemplateID        string    `json:"template_id"`
+	Status            string    `json:"status"`
+	Paused            bool      `json:"paused"`
+	RuntimeGeneration int64     `json:"runtime_generation"`
+	CreatedAt         time.Time `json:"created_at"`
+	ExpiresAt         time.Time `json:"expires_at"`
+	HardExpiresAt     time.Time `json:"hard_expires_at"`
+	UpdatedAt         time.Time `json:"updated_at"`
 }
 
 // ListSandboxes lists all sandboxes for a team with optional filters
@@ -90,9 +91,8 @@ func (s *SandboxService) ListSandboxes(ctx context.Context, req *ListSandboxesRe
 			continue
 		}
 
-		// Filter by paused state if specified
-		powerState := sandboxPowerStateFromAnnotations(pod.Annotations)
-		paused := powerState.Observed == SandboxPowerStatePaused
+		// Filter by paused state if specified.
+		paused := status == SandboxStatusPaused
 		if req.Paused != nil && paused != *req.Paused {
 			continue
 		}
@@ -102,14 +102,15 @@ func (s *SandboxService) ListSandboxes(ctx context.Context, req *ListSandboxesRe
 		hardExpiresAt := parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationHardExpiresAt)
 
 		summaries = append(summaries, &SandboxSummary{
-			ID:            sandboxIDFromPod(pod),
-			TemplateID:    templateID,
-			Status:        status,
-			Paused:        paused,
-			PowerState:    powerState,
-			CreatedAt:     pod.CreationTimestamp.Time,
-			ExpiresAt:     expiresAt,
-			HardExpiresAt: hardExpiresAt,
+			ID:                sandboxIDFromPod(pod),
+			TemplateID:        templateID,
+			Status:            status,
+			Paused:            paused,
+			RuntimeGeneration: runtimeGenerationFromPod(pod),
+			CreatedAt:         pod.CreationTimestamp.Time,
+			ExpiresAt:         expiresAt,
+			HardExpiresAt:     hardExpiresAt,
+			UpdatedAt:         pod.CreationTimestamp.Time,
 		})
 	}
 
@@ -166,14 +167,15 @@ func (s *SandboxService) listSandboxesFromStore(ctx context.Context, req *ListSa
 			continue
 		}
 		summaries = append(summaries, &SandboxSummary{
-			ID:            sandbox.ID,
-			TemplateID:    sandbox.TemplateID,
-			Status:        sandbox.Status,
-			Paused:        sandbox.Paused,
-			PowerState:    sandbox.PowerState,
-			CreatedAt:     sandbox.CreatedAt,
-			ExpiresAt:     sandbox.ExpiresAt,
-			HardExpiresAt: sandbox.HardExpiresAt,
+			ID:                sandbox.ID,
+			TemplateID:        sandbox.TemplateID,
+			Status:            sandbox.Status,
+			Paused:            sandbox.Paused,
+			RuntimeGeneration: sandbox.RuntimeGeneration,
+			CreatedAt:         sandbox.CreatedAt,
+			ExpiresAt:         sandbox.ExpiresAt,
+			HardExpiresAt:     sandbox.HardExpiresAt,
+			UpdatedAt:         sandbox.UpdatedAt,
 		})
 	}
 

--- a/manager/pkg/service/sandbox_service_list_test.go
+++ b/manager/pkg/service/sandbox_service_list_test.go
@@ -94,7 +94,7 @@ func TestListSandboxes(t *testing.T) {
 			expectedHasMore: false,
 		},
 		{
-			name: "filter by paused state",
+			name: "filter by paused state excludes running pods without durable store",
 			pods: []*corev1.Pod{
 				createTestPod("sandbox-1", "team-a", "template-1", controller.PoolTypeActive, now, now, false),
 				createTestPod("sandbox-2", "team-a", "template-1", controller.PoolTypeActive, now, now, true),
@@ -106,8 +106,8 @@ func TestListSandboxes(t *testing.T) {
 				Limit:  50,
 				Offset: 0,
 			},
-			expectedCount:   1,
-			expectedIDs:     []string{"sandbox-2"},
+			expectedCount:   0,
+			expectedIDs:     nil,
 			expectedHasMore: false,
 		},
 		{
@@ -262,15 +262,11 @@ func TestListSandboxes_HardExpiresAt(t *testing.T) {
 	assert.True(t, gotWithoutHard.HardExpiresAt.IsZero())
 }
 
-func TestListSandboxes_IncludesPowerState(t *testing.T) {
+func TestListSandboxes_IncludesRuntimeGeneration(t *testing.T) {
 	logger := zap.NewNop()
 	now := time.Now()
-	pod := createTestPod("sandbox-power-state", "team-a", "template-1", controller.PoolTypeActive, now, now, false)
-	pod.Annotations[controller.AnnotationPowerStateDesired] = SandboxPowerStatePaused
-	pod.Annotations[controller.AnnotationPowerStateDesiredGeneration] = "7"
-	pod.Annotations[controller.AnnotationPowerStateObserved] = SandboxPowerStateActive
-	pod.Annotations[controller.AnnotationPowerStateObservedGeneration] = "6"
-	pod.Annotations[controller.AnnotationPowerStatePhase] = SandboxPowerPhasePausing
+	pod := createTestPod("sandbox-runtime-generation", "team-a", "template-1", controller.PoolTypeActive, now, now, false)
+	pod.Annotations[controller.AnnotationRuntimeGeneration] = "7"
 
 	k8sClient := fake.NewSimpleClientset(pod)
 	svc := &SandboxService{
@@ -287,12 +283,46 @@ func TestListSandboxes_IncludesPowerState(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Len(t, resp.Sandboxes, 1)
-	assert.Equal(t, SandboxPowerStatePaused, resp.Sandboxes[0].PowerState.Desired)
-	assert.Equal(t, int64(7), resp.Sandboxes[0].PowerState.DesiredGeneration)
-	assert.Equal(t, SandboxPowerStateActive, resp.Sandboxes[0].PowerState.Observed)
-	assert.Equal(t, int64(6), resp.Sandboxes[0].PowerState.ObservedGeneration)
-	assert.Equal(t, SandboxPowerPhasePausing, resp.Sandboxes[0].PowerState.Phase)
+	assert.Equal(t, int64(7), resp.Sandboxes[0].RuntimeGeneration)
 	assert.False(t, resp.Sandboxes[0].Paused)
+}
+
+func TestListSandboxesFromStoreFiltersPausedState(t *testing.T) {
+	now := time.Now()
+	store := &memorySandboxStore{records: map[string]*SandboxRecord{
+		"sandbox-running": {
+			ID:         "sandbox-running",
+			TeamID:     "team-a",
+			TemplateID: "template-1",
+			Status:     SandboxStatusRunning,
+			CreatedAt:  now.Add(-time.Minute),
+		},
+		"sandbox-paused": {
+			ID:                "sandbox-paused",
+			TeamID:            "team-a",
+			TemplateID:        "template-1",
+			Status:            SandboxStatusPaused,
+			RuntimeGeneration: 3,
+			CreatedAt:         now,
+		},
+	}}
+	svc := &SandboxService{
+		sandboxStore: store,
+		podLister:    newTestPodLister(t),
+		clock:        systemTime{},
+		logger:       zap.NewNop(),
+	}
+
+	resp, err := svc.ListSandboxes(context.Background(), &ListSandboxesRequest{
+		TeamID: "team-a",
+		Paused: boolPtr(true),
+		Limit:  50,
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Sandboxes, 1)
+	assert.Equal(t, "sandbox-paused", resp.Sandboxes[0].ID)
+	assert.True(t, resp.Sandboxes[0].Paused)
+	assert.Equal(t, int64(3), resp.Sandboxes[0].RuntimeGeneration)
 }
 
 func TestListSandboxes_TerminatingPodStatus(t *testing.T) {

--- a/manager/pkg/service/sandbox_service_pause.go
+++ b/manager/pkg/service/sandbox_service_pause.go
@@ -5,14 +5,12 @@ import (
 	"fmt"
 
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 // PauseSandboxResponse represents the response from pausing a sandbox.
 type PauseSandboxResponse struct {
 	SandboxID     string                `json:"sandbox_id"`
 	Paused        bool                  `json:"paused"`
-	PowerState    SandboxPowerState     `json:"power_state"`
 	ResourceUsage *SandboxResourceUsage `json:"resource_usage,omitempty"`
 	UpdatedMemory string                `json:"updated_memory,omitempty"`
 	UpdatedCPU    string                `json:"updated_cpu,omitempty"`
@@ -20,125 +18,44 @@ type PauseSandboxResponse struct {
 
 // ResumeSandboxResponse represents the response from resuming a sandbox.
 type ResumeSandboxResponse struct {
-	SandboxID      string            `json:"sandbox_id"`
-	Resumed        bool              `json:"resumed"`
-	PowerState     SandboxPowerState `json:"power_state"`
-	RestoredMemory string            `json:"restored_memory,omitempty"`
+	SandboxID      string `json:"sandbox_id"`
+	Resumed        bool   `json:"resumed"`
+	RestoredMemory string `json:"restored_memory,omitempty"`
 }
 
-// PauseSandbox records a desired paused state for ctld reconciliation.
+// PauseSandbox checkpoints the writable rootfs and releases the runtime.
 func (s *SandboxService) PauseSandbox(ctx context.Context, sandboxID string) (*PauseSandboxResponse, error) {
-	return s.RequestPauseSandbox(ctx, sandboxID)
-}
-
-// RequestPauseSandbox records a desired paused state and reconciles it asynchronously.
-func (s *SandboxService) RequestPauseSandbox(ctx context.Context, sandboxID string) (*PauseSandboxResponse, error) {
-	if err := s.requireCtldPowerTransitions(); err != nil {
-		return nil, err
-	}
-	state, err := s.requestSandboxPowerState(ctx, sandboxID, SandboxPowerStatePaused)
-	if err != nil {
+	if err := s.PauseSandboxRuntime(ctx, sandboxID); err != nil {
 		return nil, err
 	}
 	return &PauseSandboxResponse{
-		SandboxID:  sandboxID,
-		Paused:     true,
-		PowerState: state,
+		SandboxID: sandboxID,
+		Paused:    true,
 	}, nil
 }
 
-// PauseSandboxAndWait records a desired paused state and waits until the sandbox observes it.
+// PauseSandboxAndWait checkpoints the writable rootfs and releases the runtime.
 func (s *SandboxService) PauseSandboxAndWait(ctx context.Context, sandboxID string) (*PauseSandboxResponse, error) {
-	resp, err := s.RequestPauseSandbox(ctx, sandboxID)
-	if err != nil {
-		return nil, err
-	}
-	if resp.PowerState.Desired == SandboxPowerStatePaused && resp.PowerState.Observed == SandboxPowerStatePaused && resp.PowerState.Phase == SandboxPowerPhaseStable {
-		return resp, nil
-	}
-	waitCtx, cancel := sandboxPowerTransitionContext(ctx)
-	defer cancel()
-	state, err := s.waitForSandboxPowerState(waitCtx, sandboxID, SandboxPowerStatePaused, resp.PowerState.DesiredGeneration)
-	if err != nil {
-		return &PauseSandboxResponse{SandboxID: sandboxID, Paused: state.Observed == SandboxPowerStatePaused, PowerState: state}, err
-	}
-	resp.PowerState = state
-	resp.Paused = true
-	return resp, nil
+	return s.PauseSandbox(ctx, sandboxID)
 }
 
-// ResumeSandbox records a desired active state for ctld reconciliation.
+// ResumeSandbox creates or reuses a runtime and restores the latest rootfs checkpoint.
 func (s *SandboxService) ResumeSandbox(ctx context.Context, sandboxID string) (*ResumeSandboxResponse, error) {
-	return s.RequestResumeSandbox(ctx, sandboxID)
-}
-
-// RequestResumeSandbox records a desired active state and reconciles it asynchronously.
-func (s *SandboxService) RequestResumeSandbox(ctx context.Context, sandboxID string) (*ResumeSandboxResponse, error) {
-	if err := s.requireCtldPowerTransitions(); err != nil {
-		return nil, err
-	}
-	state, err := s.requestSandboxPowerState(ctx, sandboxID, SandboxPowerStateActive)
+	_, err := s.ResumePausedSandboxRuntime(ctx, sandboxID)
 	if err != nil {
 		return nil, err
 	}
 	return &ResumeSandboxResponse{
-		SandboxID:  sandboxID,
-		Resumed:    true,
-		PowerState: state,
+		SandboxID: sandboxID,
+		Resumed:   true,
 	}, nil
 }
 
-// ResumeSandboxAndWait records a desired active state and waits until the sandbox observes it.
+// ResumeSandboxAndWait creates or reuses a runtime and restores the latest rootfs checkpoint.
 func (s *SandboxService) ResumeSandboxAndWait(ctx context.Context, sandboxID string) (*ResumeSandboxResponse, error) {
-	resp, err := s.RequestResumeSandbox(ctx, sandboxID)
-	if err != nil {
-		if k8serrors.IsNotFound(err) && s.sandboxStore != nil {
-			waitCtx, cancel := sandboxRestoreContext(ctx)
-			defer cancel()
-			sandbox, restoreErr := s.RestoreCleanedSandboxRuntime(waitCtx, sandboxID)
-			if restoreErr != nil {
-				return nil, restoreErr
-			}
-			generation := int64(0)
-			if sandbox != nil {
-				generation = sandbox.PowerState.DesiredGeneration
-			}
-			return cleanedSandboxRestoreResponse(sandboxID, generation), nil
-		}
-		return nil, err
-	}
-	if resp.PowerState.Desired == SandboxPowerStateActive && resp.PowerState.Observed == SandboxPowerStateActive && resp.PowerState.Phase == SandboxPowerPhaseStable {
-		return resp, nil
-	}
-	waitCtx, cancel := sandboxPowerTransitionContext(ctx)
+	waitCtx, cancel := sandboxRestoreContext(ctx)
 	defer cancel()
-	state, err := s.waitForSandboxPowerState(waitCtx, sandboxID, SandboxPowerStateActive, resp.PowerState.DesiredGeneration)
-	if err != nil {
-		return &ResumeSandboxResponse{SandboxID: sandboxID, Resumed: state.Observed == SandboxPowerStateActive, PowerState: state}, err
-	}
-	resp.PowerState = state
-	resp.Resumed = true
-	return resp, nil
-}
-
-// RequestPauseSandboxByID records the desired paused state for controller-driven reconciliation.
-func (s *SandboxService) RequestPauseSandboxByID(ctx context.Context, sandboxID string) error {
-	_, err := s.RequestPauseSandbox(ctx, sandboxID)
-	return err
-}
-
-// PauseSandboxByID records the desired paused state for compatibility with older controller callers.
-//
-// Deprecated: use RequestPauseSandboxByID for declarative pause requests.
-func (s *SandboxService) PauseSandboxByID(ctx context.Context, sandboxID string) error {
-	return s.RequestPauseSandboxByID(ctx, sandboxID)
-}
-
-func (s *SandboxService) requireCtldPowerTransitions() error {
-	if s == nil || !s.config.CtldEnabled {
-		return ErrSandboxPowerRequiresCtld
-	}
-	return nil
+	return s.ResumeSandbox(waitCtx, sandboxID)
 }
 
 // TerminateSandboxByID implements the SandboxTerminator interface from controller package.

--- a/manager/pkg/service/sandbox_service_pod.go
+++ b/manager/pkg/service/sandbox_service_pod.go
@@ -272,7 +272,7 @@ func (s *SandboxService) probeSandboxPodOrFailure(ctx context.Context, pod *core
 // podToSandboxStatus converts pod state to sandbox status.
 func (s *SandboxService) podToSandboxStatus(pod *corev1.Pod) string {
 	if pod == nil {
-		return SandboxStatusPending
+		return SandboxStatusStarting
 	}
 	if pod.DeletionTimestamp != nil {
 		return SandboxStatusTerminating
@@ -288,10 +288,10 @@ func (s *SandboxService) podPhaseToSandboxStatus(phase corev1.PodPhase) string {
 	case corev1.PodRunning:
 		return SandboxStatusRunning
 	case corev1.PodSucceeded:
-		return SandboxStatusCompleted
+		return SandboxStatusFailed
 	case corev1.PodFailed:
 		return SandboxStatusFailed
 	default:
-		return SandboxStatusPending
+		return SandboxStatusStarting
 	}
 }

--- a/manager/pkg/service/sandbox_service_power.go
+++ b/manager/pkg/service/sandbox_service_power.go
@@ -12,7 +12,6 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 )
 
@@ -136,25 +135,6 @@ func requestedSandboxPowerState(annotations map[string]string, target string) Sa
 	return state
 }
 
-func completedSandboxPowerState(annotations map[string]string, target string) SandboxPowerState {
-	current := sandboxPowerStateFromAnnotations(annotations)
-	generation := current.DesiredGeneration
-	if generation == 0 || current.Desired != target {
-		generation = nextSandboxPowerStateGeneration(current)
-	}
-	return SandboxPowerState{
-		Desired:            target,
-		DesiredGeneration:  generation,
-		Observed:           target,
-		ObservedGeneration: generation,
-		Phase:              SandboxPowerPhaseStable,
-	}
-}
-
-func staleSandboxPowerStateError(current SandboxPowerState) error {
-	return fmt.Errorf("%w: desired=%s generation=%d", errSandboxPowerStateStale, current.Desired, current.DesiredGeneration)
-}
-
 func applySandboxPowerStateAnnotations(annotations map[string]string, state SandboxPowerState) {
 	if annotations == nil {
 		return
@@ -227,28 +207,6 @@ func (s *SandboxService) requestSandboxPowerState(ctx context.Context, sandboxID
 	return state, nil
 }
 
-func (s *SandboxService) waitForSandboxPowerState(ctx context.Context, sandboxID, target string, generation int64) (SandboxPowerState, error) {
-	var state SandboxPowerState
-	err := wait.PollUntilContextCancel(ctx, defaultSandboxPowerPollInterval, true, func(ctx context.Context) (bool, error) {
-		pod, err := s.getSandboxPodForPowerState(ctx, sandboxID)
-		if err != nil {
-			return false, err
-		}
-		state = sandboxPowerStateFromAnnotations(pod.Annotations)
-		if generation > 0 && (state.Desired != target || state.DesiredGeneration != generation) {
-			return false, fmt.Errorf("%w: %w", ErrSandboxPowerTransitionSuperseded, staleSandboxPowerStateError(state))
-		}
-		return state.Desired == target && state.Observed == target && state.Phase == SandboxPowerPhaseStable, nil
-	})
-	if err != nil {
-		if ctx.Err() != nil {
-			return state, ctx.Err()
-		}
-		return state, err
-	}
-	return state, nil
-}
-
 func preserveCtldInFlightPowerTransition(current, requested SandboxPowerState, target string) SandboxPowerState {
 	if current.Phase == SandboxPowerPhaseStable || current.Observed != target {
 		return requested
@@ -260,13 +218,6 @@ func preserveCtldInFlightPowerTransition(current, requested SandboxPowerState, t
 		requested.Phase = SandboxPowerPhaseResuming
 	}
 	return requested
-}
-
-func sandboxPowerTransitionContext(ctx context.Context) (context.Context, context.CancelFunc) {
-	if _, ok := ctx.Deadline(); ok {
-		return context.WithCancel(ctx)
-	}
-	return context.WithTimeout(ctx, defaultSandboxPowerTransitionTimeout)
 }
 
 func (s *SandboxService) getSandboxPodForPowerState(ctx context.Context, sandboxID string) (*corev1.Pod, error) {

--- a/manager/pkg/service/sandbox_service_power_state_test.go
+++ b/manager/pkg/service/sandbox_service_power_state_test.go
@@ -8,15 +8,9 @@ import (
 
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/kubernetes/fake"
-	ktesting "k8s.io/client-go/testing"
 )
 
 func TestSandboxPowerStateFromAnnotationsFallsBackToLegacyPausedAnnotation(t *testing.T) {
@@ -29,16 +23,6 @@ func TestSandboxPowerStateFromAnnotationsFallsBackToLegacyPausedAnnotation(t *te
 	assert.Equal(t, SandboxPowerPhaseStable, state.Phase)
 	assert.Zero(t, state.DesiredGeneration)
 	assert.Zero(t, state.ObservedGeneration)
-}
-
-func TestCompletedSandboxPowerStateAssignsGeneration(t *testing.T) {
-	state := completedSandboxPowerState(map[string]string{}, SandboxPowerStatePaused)
-
-	assert.Equal(t, SandboxPowerStatePaused, state.Desired)
-	assert.Equal(t, SandboxPowerStatePaused, state.Observed)
-	assert.Equal(t, int64(1), state.DesiredGeneration)
-	assert.Equal(t, int64(1), state.ObservedGeneration)
-	assert.Equal(t, SandboxPowerPhaseStable, state.Phase)
 }
 
 func TestCtldPowerStateRequestsPreserveInFlightTransitions(t *testing.T) {
@@ -151,7 +135,7 @@ func TestCtldPowerStateRequestsPreserveInFlightTransitions(t *testing.T) {
 	}
 }
 
-func TestPodToSandboxIncludesPowerState(t *testing.T) {
+func TestPodToSandboxDoesNotExposeLegacyPowerState(t *testing.T) {
 	svc := &SandboxService{
 		config: SandboxServiceConfig{ProcdPort: 49983},
 		logger: zap.NewNop(),
@@ -171,6 +155,7 @@ func TestPodToSandboxIncludesPowerState(t *testing.T) {
 				controller.AnnotationPowerStateDesiredGeneration:  "4",
 				controller.AnnotationPowerStateObserved:           SandboxPowerStatePaused,
 				controller.AnnotationPowerStateObservedGeneration: "3",
+				controller.AnnotationRuntimeGeneration:            "9",
 			},
 			CreationTimestamp: metav1.NewTime(time.Unix(1700000000, 0).UTC()),
 		},
@@ -182,382 +167,15 @@ func TestPodToSandboxIncludesPowerState(t *testing.T) {
 
 	sandbox := svc.podToSandbox(context.Background(), pod, pod.Name)
 
-	assert.Equal(t, SandboxPowerStateActive, sandbox.PowerState.Desired)
-	assert.Equal(t, int64(4), sandbox.PowerState.DesiredGeneration)
-	assert.Equal(t, SandboxPowerStatePaused, sandbox.PowerState.Observed)
-	assert.Equal(t, int64(3), sandbox.PowerState.ObservedGeneration)
-	assert.Equal(t, SandboxPowerPhaseResuming, sandbox.PowerState.Phase)
-	assert.True(t, sandbox.Paused)
+	assert.False(t, sandbox.Paused)
 	assert.Equal(t, "template-1", sandbox.TemplateID)
-}
-
-func TestRequestPauseSandboxRecordsDesiredPausedState(t *testing.T) {
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "sandbox-1",
-			Namespace: "default",
-			Labels: map[string]string{
-				controller.LabelSandboxID: "sandbox-1",
-			},
-		},
-		Status: corev1.PodStatus{Phase: corev1.PodRunning},
-	}
-	k8sClient := fake.NewSimpleClientset(pod)
-	svc := &SandboxService{
-		k8sClient: k8sClient,
-		podLister: newTestPodLister(t, pod),
-		config:    SandboxServiceConfig{CtldEnabled: true},
-		clock:     systemTime{},
-		logger:    zap.NewNop(),
-	}
-
-	resp, err := svc.RequestPauseSandbox(context.Background(), "sandbox-1")
-	require.NoError(t, err)
-	assert.True(t, resp.Paused)
-	assert.Equal(t, SandboxPowerStatePaused, resp.PowerState.Desired)
-	assert.Equal(t, SandboxPowerPhasePausing, resp.PowerState.Phase)
-
-	updated, err := k8sClient.CoreV1().Pods("default").Get(context.Background(), "sandbox-1", metav1.GetOptions{})
-	require.NoError(t, err)
-	state := sandboxPowerStateFromAnnotations(updated.Annotations)
-	assert.Equal(t, SandboxPowerStatePaused, state.Desired)
-	assert.Equal(t, SandboxPowerPhasePausing, state.Phase)
-	assert.Equal(t, int64(1), state.DesiredGeneration)
-	assert.Equal(t, SandboxPowerStateActive, state.Observed)
-}
-
-func TestRequestPauseSandboxRetriesConflict(t *testing.T) {
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "sandbox-1",
-			Namespace: "default",
-			Labels: map[string]string{
-				controller.LabelSandboxID: "sandbox-1",
-			},
-		},
-		Status: corev1.PodStatus{Phase: corev1.PodRunning},
-	}
-	k8sClient := fake.NewSimpleClientset(pod)
-	updateCalls := 0
-	k8sClient.PrependReactor("update", "pods", func(action ktesting.Action) (bool, runtime.Object, error) {
-		updateCalls++
-		if updateCalls == 1 {
-			return true, nil, k8serrors.NewConflict(schema.GroupResource{Resource: "pods"}, "sandbox-1", nil)
-		}
-		return false, nil, nil
-	})
-	svc := &SandboxService{
-		k8sClient: k8sClient,
-		podLister: newTestPodLister(t, pod),
-		config:    SandboxServiceConfig{CtldEnabled: true},
-		clock:     systemTime{},
-		logger:    zap.NewNop(),
-	}
-
-	resp, err := svc.RequestPauseSandbox(context.Background(), "sandbox-1")
-	require.NoError(t, err)
-	assert.True(t, resp.Paused)
-	assert.GreaterOrEqual(t, updateCalls, 2)
-
-	updated, err := k8sClient.CoreV1().Pods("default").Get(context.Background(), "sandbox-1", metav1.GetOptions{})
-	require.NoError(t, err)
-	state := sandboxPowerStateFromAnnotations(updated.Annotations)
-	assert.Equal(t, SandboxPowerStatePaused, state.Desired)
-	assert.Equal(t, SandboxPowerPhasePausing, state.Phase)
-}
-
-func TestRequestPauseSandboxByIDRecordsDesiredState(t *testing.T) {
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "sandbox-1",
-			Namespace: "default",
-			Labels: map[string]string{
-				controller.LabelSandboxID: "sandbox-1",
-			},
-		},
-		Status: corev1.PodStatus{Phase: corev1.PodRunning},
-	}
-	k8sClient := fake.NewSimpleClientset(pod)
-	svc := &SandboxService{
-		k8sClient: k8sClient,
-		podLister: newTestPodLister(t, pod),
-		config:    SandboxServiceConfig{CtldEnabled: true},
-		clock:     systemTime{},
-		logger:    zap.NewNop(),
-	}
-
-	require.NoError(t, svc.RequestPauseSandboxByID(context.Background(), "sandbox-1"))
-
-	updated, err := k8sClient.CoreV1().Pods("default").Get(context.Background(), "sandbox-1", metav1.GetOptions{})
-	require.NoError(t, err)
-	state := sandboxPowerStateFromAnnotations(updated.Annotations)
-	assert.Equal(t, SandboxPowerStatePaused, state.Desired)
-	assert.Equal(t, SandboxPowerStateActive, state.Observed)
-	assert.Equal(t, SandboxPowerPhasePausing, state.Phase)
-}
-
-func TestRequestSandboxPowerRequiresCtld(t *testing.T) {
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "sandbox-1",
-			Namespace: "default",
-			Labels: map[string]string{
-				controller.LabelSandboxID: "sandbox-1",
-			},
-		},
-		Status: corev1.PodStatus{Phase: corev1.PodRunning},
-	}
-	k8sClient := fake.NewSimpleClientset(pod)
-	svc := &SandboxService{
-		k8sClient: k8sClient,
-		podLister: newTestPodLister(t, pod),
-		clock:     systemTime{},
-		logger:    zap.NewNop(),
-	}
-
-	_, err := svc.RequestPauseSandbox(context.Background(), "sandbox-1")
-	require.ErrorIs(t, err, ErrSandboxPowerRequiresCtld)
-	_, err = svc.RequestResumeSandbox(context.Background(), "sandbox-1")
-	require.ErrorIs(t, err, ErrSandboxPowerRequiresCtld)
-
-	updated, err := k8sClient.CoreV1().Pods("default").Get(context.Background(), "sandbox-1", metav1.GetOptions{})
-	require.NoError(t, err)
-	assert.Empty(t, updated.Annotations[controller.AnnotationPowerStateDesired])
-}
-
-func TestRequestResumeSandboxKeepsCtldInFlightPausePending(t *testing.T) {
-	pod := newPowerStatePod(SandboxPowerStatePaused, SandboxPowerStateActive, SandboxPowerPhasePausing)
-	svc := &SandboxService{
-		k8sClient: fake.NewSimpleClientset(pod),
-		podLister: newTestPodLister(t, pod),
-		config:    SandboxServiceConfig{CtldEnabled: true},
-		clock:     systemTime{},
-		logger:    zap.NewNop(),
-	}
-
-	resp, err := svc.RequestResumeSandbox(context.Background(), "sandbox-1")
-	require.NoError(t, err)
-	assert.Equal(t, SandboxPowerStateActive, resp.PowerState.Desired)
-	assert.Equal(t, SandboxPowerStateActive, resp.PowerState.Observed)
-	assert.Equal(t, SandboxPowerPhaseResuming, resp.PowerState.Phase)
-	assert.Equal(t, int64(1), resp.PowerState.ObservedGeneration)
-
-	updated, err := svc.k8sClient.CoreV1().Pods("default").Get(context.Background(), "sandbox-1", metav1.GetOptions{})
-	require.NoError(t, err)
-	state := sandboxPowerStateFromAnnotations(updated.Annotations)
-	assert.Equal(t, SandboxPowerPhaseResuming, state.Phase)
-}
-
-func TestRequestPauseSandboxKeepsCtldInFlightResumePending(t *testing.T) {
-	pod := newPowerStatePod(SandboxPowerStateActive, SandboxPowerStatePaused, SandboxPowerPhaseResuming)
-	svc := &SandboxService{
-		k8sClient: fake.NewSimpleClientset(pod),
-		podLister: newTestPodLister(t, pod),
-		config:    SandboxServiceConfig{CtldEnabled: true},
-		clock:     systemTime{},
-		logger:    zap.NewNop(),
-	}
-
-	resp, err := svc.RequestPauseSandbox(context.Background(), "sandbox-1")
-	require.NoError(t, err)
-	assert.Equal(t, SandboxPowerStatePaused, resp.PowerState.Desired)
-	assert.Equal(t, SandboxPowerStatePaused, resp.PowerState.Observed)
-	assert.Equal(t, SandboxPowerPhasePausing, resp.PowerState.Phase)
-	assert.Equal(t, int64(1), resp.PowerState.ObservedGeneration)
-
-	updated, err := svc.k8sClient.CoreV1().Pods("default").Get(context.Background(), "sandbox-1", metav1.GetOptions{})
-	require.NoError(t, err)
-	state := sandboxPowerStateFromAnnotations(updated.Annotations)
-	assert.Equal(t, SandboxPowerPhasePausing, state.Phase)
-}
-
-func TestPauseSandboxAndWaitReturnsAfterObservedPaused(t *testing.T) {
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "sandbox-1",
-			Namespace: "default",
-			Labels: map[string]string{
-				controller.LabelSandboxID: "sandbox-1",
-			},
-		},
-		Status: corev1.PodStatus{Phase: corev1.PodRunning},
-	}
-	k8sClient := fake.NewSimpleClientset(pod)
-	completePowerTransitionOnUpdate(t, k8sClient, SandboxPowerStatePaused)
-	svc := &SandboxService{
-		k8sClient: k8sClient,
-		podLister: newTestPodLister(t, pod),
-		config:    SandboxServiceConfig{CtldEnabled: true},
-		clock:     systemTime{},
-		logger:    zap.NewNop(),
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-	resp, err := svc.PauseSandboxAndWait(ctx, "sandbox-1")
-	require.NoError(t, err)
-	assert.True(t, resp.Paused)
-	assert.Equal(t, SandboxPowerStatePaused, resp.PowerState.Desired)
-	assert.Equal(t, SandboxPowerStatePaused, resp.PowerState.Observed)
-	assert.Equal(t, SandboxPowerPhaseStable, resp.PowerState.Phase)
-}
-
-func TestResumeSandboxAndWaitReturnsAfterObservedActive(t *testing.T) {
-	pod := newPowerStatePod(SandboxPowerStatePaused, SandboxPowerStatePaused, SandboxPowerPhaseStable)
-	pod.Annotations[controller.AnnotationPaused] = "true"
-	k8sClient := fake.NewSimpleClientset(pod)
-	completePowerTransitionOnUpdate(t, k8sClient, SandboxPowerStateActive)
-	svc := &SandboxService{
-		k8sClient: k8sClient,
-		podLister: newTestPodLister(t, pod),
-		config:    SandboxServiceConfig{CtldEnabled: true},
-		clock:     systemTime{},
-		logger:    zap.NewNop(),
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-	resp, err := svc.ResumeSandboxAndWait(ctx, "sandbox-1")
-	require.NoError(t, err)
-	assert.True(t, resp.Resumed)
-	assert.Equal(t, SandboxPowerStateActive, resp.PowerState.Desired)
-	assert.Equal(t, SandboxPowerStateActive, resp.PowerState.Observed)
-	assert.Equal(t, SandboxPowerPhaseStable, resp.PowerState.Phase)
-}
-
-func TestPauseSandboxAndWaitReturnsSupersededWhenDesiredChanges(t *testing.T) {
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "sandbox-1",
-			Namespace: "default",
-			Labels: map[string]string{
-				controller.LabelSandboxID: "sandbox-1",
-			},
-		},
-		Status: corev1.PodStatus{Phase: corev1.PodRunning},
-	}
-	k8sClient := fake.NewSimpleClientset(pod)
-	pauseRequested := notifyPowerTransitionRequest(k8sClient, SandboxPowerStatePaused)
-	svc := &SandboxService{
-		k8sClient: k8sClient,
-		podLister: newTestPodLister(t, pod),
-		config:    SandboxServiceConfig{CtldEnabled: true},
-		clock:     systemTime{},
-		logger:    zap.NewNop(),
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	type result struct {
-		resp *PauseSandboxResponse
-		err  error
-	}
-	resultCh := make(chan result, 1)
-	go func() {
-		resp, err := svc.PauseSandboxAndWait(ctx, "sandbox-1")
-		resultCh <- result{resp: resp, err: err}
-	}()
-	<-pauseRequested
-
-	_, err := svc.RequestResumeSandbox(context.Background(), "sandbox-1")
-	require.NoError(t, err)
-
-	res := <-resultCh
-	require.ErrorIs(t, res.err, ErrSandboxPowerTransitionSuperseded)
-	require.NotNil(t, res.resp)
-	assert.False(t, res.resp.Paused)
-	assert.Equal(t, SandboxPowerStateActive, res.resp.PowerState.Desired)
+	assert.Equal(t, int64(9), sandbox.RuntimeGeneration)
 }
 
 type staticTokenGenerator struct{}
 
 func (staticTokenGenerator) GenerateToken(_, _, _ string) (string, error) {
 	return "token", nil
-}
-
-func completePowerTransitionOnUpdate(t *testing.T, k8sClient *fake.Clientset, target string) {
-	t.Helper()
-	k8sClient.PrependReactor("update", "pods", func(action ktesting.Action) (bool, runtime.Object, error) {
-		if action.GetSubresource() != "" {
-			return false, nil, nil
-		}
-		updateAction, ok := action.(ktesting.UpdateAction)
-		if !ok {
-			return false, nil, nil
-		}
-		pod, ok := updateAction.GetObject().(*corev1.Pod)
-		if !ok || pod.Annotations == nil {
-			return false, nil, nil
-		}
-		state := sandboxPowerStateFromAnnotations(pod.Annotations)
-		if state.Desired != target || state.Phase == SandboxPowerPhaseStable {
-			return false, nil, nil
-		}
-		completed := completedSandboxPowerState(pod.Annotations, target)
-		applySandboxPowerStateAnnotations(pod.Annotations, completed)
-		if target == SandboxPowerStatePaused {
-			pod.Annotations[controller.AnnotationPaused] = "true"
-		} else {
-			delete(pod.Annotations, controller.AnnotationPaused)
-			delete(pod.Annotations, controller.AnnotationPausedAt)
-			delete(pod.Annotations, controller.AnnotationPausedState)
-		}
-		return false, nil, nil
-	})
-}
-
-func notifyPowerTransitionRequest(k8sClient *fake.Clientset, target string) <-chan struct{} {
-	requested := make(chan struct{})
-	k8sClient.PrependReactor("update", "pods", func(action ktesting.Action) (bool, runtime.Object, error) {
-		if action.GetSubresource() != "" {
-			return false, nil, nil
-		}
-		updateAction, ok := action.(ktesting.UpdateAction)
-		if !ok {
-			return false, nil, nil
-		}
-		pod, ok := updateAction.GetObject().(*corev1.Pod)
-		if !ok {
-			return false, nil, nil
-		}
-		state := sandboxPowerStateFromAnnotations(pod.Annotations)
-		if state.Desired == target {
-			notifyOnce(requested)
-		}
-		return false, nil, nil
-	})
-	return requested
-}
-
-func notifyOnce(ch chan struct{}) {
-	if ch == nil {
-		return
-	}
-	select {
-	case <-ch:
-	default:
-		close(ch)
-	}
-}
-
-func newPowerStatePod(desired, observed, phase string) *corev1.Pod {
-	return &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "sandbox-1",
-			Namespace: "default",
-			Labels: map[string]string{
-				controller.LabelSandboxID: "sandbox-1",
-			},
-			Annotations: map[string]string{
-				controller.AnnotationPowerStateDesired:            desired,
-				controller.AnnotationPowerStateDesiredGeneration:  "2",
-				controller.AnnotationPowerStateObserved:           observed,
-				controller.AnnotationPowerStateObservedGeneration: "1",
-				controller.AnnotationPowerStatePhase:              phase,
-			},
-		},
-		Status: corev1.PodStatus{Phase: corev1.PodRunning},
-	}
 }
 
 func powerStateAnnotations(state SandboxPowerState) map[string]string {

--- a/manager/pkg/service/sandbox_service_restore.go
+++ b/manager/pkg/service/sandbox_service_restore.go
@@ -15,8 +15,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// RestoreCleanedSandboxRuntime recreates the runtime pod for a durable cleaned sandbox.
-func (s *SandboxService) RestoreCleanedSandboxRuntime(ctx context.Context, sandboxID string) (*Sandbox, error) {
+// ResumePausedSandboxRuntime creates a new runtime for a paused durable sandbox
+// and restores the latest writable rootfs checkpoint.
+func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandboxID string) (*Sandbox, error) {
 	if s == nil || s.sandboxStore == nil {
 		return nil, k8serrors.NewNotFound(corev1.Resource("pod"), sandboxID)
 	}
@@ -27,6 +28,10 @@ func (s *SandboxService) RestoreCleanedSandboxRuntime(ctx context.Context, sandb
 	err := s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, locked *SandboxRecord) error {
 		if locked.Status == SandboxStatusDeleted || !locked.DeletedAt.IsZero() {
 			return k8serrors.NewNotFound(corev1.Resource("sandbox"), sandboxID)
+		}
+		switch locked.Status {
+		case SandboxStatusStarting, SandboxStatusPausing, SandboxStatusResuming:
+			return k8serrors.NewConflict(corev1.Resource("sandbox"), sandboxID, fmt.Errorf("sandbox lifecycle operation %q is in progress", locked.Status))
 		}
 		record = locked
 
@@ -44,6 +49,15 @@ func (s *SandboxService) RestoreCleanedSandboxRuntime(ctx context.Context, sandb
 
 		template, err := s.templateForSandboxRecord(locked)
 		if err != nil {
+			return err
+		}
+		if err := s.enforceActiveSandboxQuota(lockCtx, locked.TeamID); err != nil {
+			return err
+		}
+		if err := s.enforceSandboxCPUQuota(lockCtx, locked.TeamID, template); err != nil {
+			return err
+		}
+		if err := s.enforceSandboxMemoryQuota(lockCtx, locked.TeamID, template); err != nil {
 			return err
 		}
 		generation := locked.RuntimeGeneration + 1
@@ -67,7 +81,7 @@ func (s *SandboxService) RestoreCleanedSandboxRuntime(ctx context.Context, sandb
 				return fmt.Errorf("create runtime pod: %w", err)
 			}
 		}
-		return tx.SaveRuntime(lockCtx, sandboxID, pod.Namespace, pod.Name, SandboxStatusStarting, generation, parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationExpiresAt), parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationHardExpiresAt))
+		return tx.SaveRuntime(lockCtx, sandboxID, pod.Namespace, pod.Name, SandboxStatusResuming, generation, parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationExpiresAt), parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationHardExpiresAt))
 	})
 	if err != nil {
 		if errors.Is(err, ErrSandboxRecordNotFound) {
@@ -84,7 +98,7 @@ func (s *SandboxService) RestoreCleanedSandboxRuntime(ctx context.Context, sandb
 
 	if err := s.finishRestoredSandboxRuntime(ctx, pod, record, claimType); err != nil {
 		s.requestSandboxDeletionAfterClaimFailure(pod, "restored runtime initialization failed")
-		_ = s.cleanSandboxRuntime(context.Background(), sandboxID, false)
+		_ = s.pauseSandboxRuntime(context.Background(), sandboxID, false)
 		return nil, err
 	}
 	return s.GetSandbox(ctx, sandboxID)
@@ -136,7 +150,7 @@ func (s *SandboxService) finishRestoredSandboxRuntime(ctx context.Context, pod *
 		return fmt.Errorf("persist restored sandbox: %w", err)
 	}
 	if s.logger != nil {
-		s.logger.Info("Restored cleaned sandbox runtime",
+		s.logger.Info("Resumed paused sandbox runtime",
 			zap.String("sandboxID", record.ID),
 			zap.String("pod", pod.Name),
 			zap.String("claimType", claimType),
@@ -179,23 +193,9 @@ func (s *SandboxService) templateForSandboxRecord(record *SandboxRecord) (*v1alp
 	}, nil
 }
 
-func cleanedSandboxRestoreResponse(sandboxID string, generation int64) *ResumeSandboxResponse {
-	return &ResumeSandboxResponse{
-		SandboxID: sandboxID,
-		Resumed:   true,
-		PowerState: SandboxPowerState{
-			Desired:            SandboxPowerStateActive,
-			DesiredGeneration:  generation,
-			Observed:           SandboxPowerStateActive,
-			ObservedGeneration: generation,
-			Phase:              SandboxPowerPhaseStable,
-		},
-	}
-}
-
 func sandboxRestoreContext(ctx context.Context) (context.Context, context.CancelFunc) {
 	if _, ok := ctx.Deadline(); ok {
 		return context.WithCancel(ctx)
 	}
-	return context.WithTimeout(ctx, defaultSandboxPowerTransitionTimeout)
+	return context.WithTimeout(ctx, defaultSandboxRestoreTimeout)
 }

--- a/manager/pkg/service/sandbox_service_rootfs_test.go
+++ b/manager/pkg/service/sandbox_service_rootfs_test.go
@@ -26,7 +26,7 @@ import (
 	ktesting "k8s.io/client-go/testing"
 )
 
-func TestCleanSandboxRuntimeSavesRootFSBeforeDeletingPod(t *testing.T) {
+func TestPauseSandboxRuntimeSavesRootFSBeforeDeletingPod(t *testing.T) {
 	saveCalled := false
 	ctld := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "/api/v1/rootfs/save", r.URL.Path)
@@ -89,7 +89,7 @@ func TestCleanSandboxRuntimeSavesRootFSBeforeDeletingPod(t *testing.T) {
 		logger:       zap.NewNop(),
 	}
 
-	require.NoError(t, svc.CleanSandboxRuntime(context.Background(), "sandbox-1"))
+	require.NoError(t, svc.PauseSandboxRuntime(context.Background(), "sandbox-1"))
 
 	state := store.rootFSStates["sandbox-1"]
 	require.NotNil(t, state)
@@ -99,7 +99,7 @@ func TestCleanSandboxRuntimeSavesRootFSBeforeDeletingPod(t *testing.T) {
 	assert.Equal(t, []string{"parent-1", "parent-0"}, state.SnapshotParentChain)
 	assert.Equal(t, "sha256:diff", state.DiffDigest)
 	assert.Equal(t, "sandbox-rootfs/team-1/sandbox-1/3/sha256/diff.tar", state.DiffObjectKey)
-	assert.Equal(t, SandboxStatusCleaned, store.records["sandbox-1"].Status)
+	assert.Equal(t, SandboxStatusPaused, store.records["sandbox-1"].Status)
 }
 
 func TestFinishRestoredSandboxRuntimeAppliesRootFSBeforeProcdInitialization(t *testing.T) {
@@ -166,7 +166,7 @@ func TestFinishRestoredSandboxRuntimeAppliesRootFSBeforeProcdInitialization(t *t
 		TemplateNamespace: "template-default",
 		TemplateSpec:      v1alpha1.SandboxTemplateSpec{},
 		RuntimeGeneration: 3,
-		Status:            SandboxStatusCleaned,
+		Status:            SandboxStatusPaused,
 	}
 
 	require.NoError(t, svc.finishRestoredSandboxRuntime(context.Background(), pod, record, "hot"))
@@ -210,11 +210,11 @@ func TestRestoreFailureCleanupCanSkipRootFSSave(t *testing.T) {
 		logger:       zap.NewNop(),
 	}
 
-	require.NoError(t, svc.cleanSandboxRuntime(context.Background(), "sandbox-1", false))
+	require.NoError(t, svc.pauseSandboxRuntime(context.Background(), "sandbox-1", false))
 
 	assert.False(t, saveCalled.Load())
 	assert.Equal(t, originalState.DiffObjectKey, store.rootFSStates["sandbox-1"].DiffObjectKey)
-	assert.Equal(t, SandboxStatusCleaned, store.records["sandbox-1"].Status)
+	assert.Equal(t, SandboxStatusPaused, store.records["sandbox-1"].Status)
 }
 
 func rootFSTestPod(name, sandboxID, teamID string) *corev1.Pod {

--- a/manager/pkg/service/sandbox_store.go
+++ b/manager/pkg/service/sandbox_store.go
@@ -20,9 +20,7 @@ const sandboxStoreSchemaName = "manager"
 
 var ErrSandboxRecordNotFound = errors.New("sandbox record not found")
 
-// SandboxRuntimeStateCleaned means the durable sandbox exists but has no runtime pod.
 const (
-	SandboxStatusCleaned = "cleaned"
 	SandboxStatusDeleted = "deleted"
 )
 
@@ -76,6 +74,7 @@ type SandboxStore interface {
 	UpsertSandbox(ctx context.Context, record *SandboxRecord) error
 	GetSandbox(ctx context.Context, sandboxID string) (*SandboxRecord, error)
 	ListSandboxes(ctx context.Context, req *ListSandboxesRequest) ([]*SandboxRecord, error)
+	ListHardExpiredSandboxes(ctx context.Context, now time.Time, limit int) ([]*SandboxRecord, error)
 	MarkSandboxDeleted(ctx context.Context, sandboxID string, deletedAt time.Time) error
 	SaveRootFSState(ctx context.Context, state *SandboxRootFSState) error
 	GetLatestRootFSState(ctx context.Context, sandboxID string) (*SandboxRootFSState, error)
@@ -85,7 +84,7 @@ type SandboxStore interface {
 // SandboxStoreTx is a locked sandbox store transaction.
 type SandboxStoreTx interface {
 	SaveRuntime(ctx context.Context, sandboxID, namespace, podName, status string, generation int64, expiresAt, hardExpiresAt time.Time) error
-	MarkRuntimeCleaned(ctx context.Context, sandboxID string, generation int64, cleanedAt time.Time) error
+	MarkRuntimePaused(ctx context.Context, sandboxID string, generation int64, pausedAt time.Time) error
 	SaveRootFSState(ctx context.Context, state *SandboxRootFSState) error
 }
 
@@ -200,6 +199,41 @@ func (s *PGSandboxStore) ListSandboxes(ctx context.Context, req *ListSandboxesRe
 	return records, nil
 }
 
+func (s *PGSandboxStore) ListHardExpiredSandboxes(ctx context.Context, now time.Time, limit int) ([]*SandboxRecord, error) {
+	if s == nil || s.pool == nil {
+		return nil, nil
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	if limit <= 0 {
+		limit = 500
+	}
+	rows, err := s.pool.Query(ctx, sandboxRecordSelectSQL()+`
+		WHERE deleted_at IS NULL
+			AND hard_expires_at IS NOT NULL
+			AND hard_expires_at <= $1
+		ORDER BY hard_expires_at ASC
+		LIMIT $2
+	`, now, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list hard-expired sandboxes: %w", err)
+	}
+	defer rows.Close()
+	var records []*SandboxRecord
+	for rows.Next() {
+		record, err := scanSandboxRecordRows(rows)
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, record)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate hard-expired sandboxes: %w", err)
+	}
+	return records, nil
+}
+
 func (s *PGSandboxStore) MarkSandboxDeleted(ctx context.Context, sandboxID string, deletedAt time.Time) error {
 	if s == nil || s.pool == nil {
 		return nil
@@ -291,7 +325,7 @@ func (t sandboxStoreTx) SaveRuntime(ctx context.Context, sandboxID, namespace, p
 	return nil
 }
 
-func (t sandboxStoreTx) MarkRuntimeCleaned(ctx context.Context, sandboxID string, generation int64, cleanedAt time.Time) error {
+func (t sandboxStoreTx) MarkRuntimePaused(ctx context.Context, sandboxID string, generation int64, pausedAt time.Time) error {
 	_, err := t.tx.Exec(ctx, `
 		UPDATE manager.sandboxes
 		SET status = $2,
@@ -301,9 +335,9 @@ func (t sandboxStoreTx) MarkRuntimeCleaned(ctx context.Context, sandboxID string
 			expires_at = NULL,
 			updated_at = NOW()
 		WHERE sandbox_id = $1
-	`, sandboxID, SandboxStatusCleaned, generation)
+	`, sandboxID, SandboxStatusPaused, generation)
 	if err != nil {
-		return fmt.Errorf("mark sandbox runtime cleaned: %w", err)
+		return fmt.Errorf("mark sandbox runtime paused: %w", err)
 	}
 	return nil
 }

--- a/pkg/apispec/compat.go
+++ b/pkg/apispec/compat.go
@@ -1,9 +1,10 @@
 package apispec
 
 const (
-	Cleaned     = SandboxLifecycleStatusCleaned
-	Completed   = SandboxLifecycleStatusCompleted
 	Failed      = SandboxLifecycleStatusFailed
+	Paused      = SandboxLifecycleStatusPaused
+	Pausing     = SandboxLifecycleStatusPausing
+	Resuming    = SandboxLifecycleStatusResuming
 	Running     = SandboxLifecycleStatusRunning
 	Starting    = SandboxLifecycleStatusStarting
 	Terminating = SandboxLifecycleStatusTerminating

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -1544,7 +1544,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/SuccessPauseSandboxResponse"
         "409":
-          description: Pause was superseded by a newer power transition
+          description: Another sandbox lifecycle operation is in progress
           content:
             application/json:
               schema:
@@ -1585,7 +1585,13 @@ paths:
               schema:
                 $ref: "#/components/schemas/SuccessResumeSandboxResponse"
         "409":
-          description: Resume was superseded by a newer power transition
+          description: Another sandbox lifecycle operation is in progress
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "429":
+          description: Resume would exceed active runtime quota
           content:
             application/json:
               schema:
@@ -1597,7 +1603,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorEnvelope"
         "503":
-          description: Sandbox resume requires ctld
+          description: Sandbox resume is temporarily unavailable
           content:
             application/json:
               schema:
@@ -3753,10 +3759,11 @@ components:
         ttl:
           type: integer
           format: int32
+          description: Runtime soft time-to-live in seconds. When it expires, Sandbox0 checkpoints the writable rootfs, pauses the sandbox, and releases runtime compute while preserving durable sandbox state.
         hard_ttl:
           type: integer
           format: int32
-          description: Hard time-to-live in seconds. When it expires, Sandbox0 cleans the runtime pod and preserves the sandbox identity, services, and public URLs until the sandbox is explicitly deleted.
+          description: Sandbox hard time-to-live in seconds. When it expires, Sandbox0 deletes the sandbox identity and durable state, including paused rootfs checkpoints.
         network:
           $ref: "#/components/schemas/SandboxNetworkPolicy"
         webhook:
@@ -4010,43 +4017,17 @@ components:
           properties:
             data:
               $ref: "#/components/schemas/ClaimResponse"
-    SandboxPowerState:
-      type: object
-      properties:
-        desired:
-          type: string
-          enum: [active, paused]
-        desired_generation:
-          type: integer
-          format: int64
-        observed:
-          type: string
-          enum: [active, paused]
-          x-enum-varnames:
-            - SandboxPowerStateObservedActive
-            - SandboxPowerStateObservedPaused
-        observed_generation:
-          type: integer
-          format: int64
-        phase:
-          type: string
-          enum: [stable, pausing, resuming]
-      required:
-        - desired
-        - desired_generation
-        - observed
-        - observed_generation
-        - phase
     SandboxLifecycleStatus:
       type: string
-      enum: [starting, running, failed, completed, terminating, cleaned]
+      enum: [starting, running, pausing, paused, resuming, terminating, failed]
       x-enum-varnames:
         - SandboxLifecycleStatusStarting
         - SandboxLifecycleStatusRunning
-        - SandboxLifecycleStatusFailed
-        - SandboxLifecycleStatusCompleted
+        - SandboxLifecycleStatusPausing
+        - SandboxLifecycleStatusPaused
+        - SandboxLifecycleStatusResuming
         - SandboxLifecycleStatusTerminating
-        - SandboxLifecycleStatusCleaned
+        - SandboxLifecycleStatusFailed
     Sandbox:
       type: object
       properties:
@@ -4062,8 +4043,7 @@ components:
           $ref: "#/components/schemas/SandboxLifecycleStatus"
         paused:
           type: boolean
-        power_state:
-          $ref: "#/components/schemas/SandboxPowerState"
+          description: True when status is paused and no runtime is attached.
         auto_resume:
           type: boolean
         services:
@@ -4076,6 +4056,10 @@ components:
             $ref: "#/components/schemas/ClaimMountRequest"
         pod_name:
           type: string
+        runtime_generation:
+          type: integer
+          format: int64
+          description: Monotonically increasing runtime generation. Resume starts a new generation.
         ssh:
           $ref: "#/components/schemas/SandboxSSHConnection"
         expires_at:
@@ -4092,19 +4076,23 @@ components:
         created_at:
           type: string
           format: date-time
+        updated_at:
+          type: string
+          format: date-time
       required:
         - id
         - template_id
         - team_id
         - status
         - paused
-        - power_state
         - auto_resume
         - pod_name
+        - runtime_generation
         - expires_at
         - hard_expires_at
         - claimed_at
         - created_at
+        - updated_at
     SandboxSSHConnection:
       type: object
       properties:
@@ -4127,10 +4115,11 @@ components:
         ttl:
           type: integer
           format: int32
+          description: Runtime soft time-to-live in seconds. When it expires, Sandbox0 checkpoints the writable rootfs, pauses the sandbox, and releases runtime compute while preserving durable sandbox state.
         hard_ttl:
           type: integer
           format: int32
-          description: Hard time-to-live in seconds. When it expires, Sandbox0 cleans the runtime pod and preserves the sandbox identity, services, and public URLs until the sandbox is explicitly deleted.
+          description: Sandbox hard time-to-live in seconds. When it expires, Sandbox0 deletes the sandbox identity and durable state, including paused rootfs checkpoints.
         network:
           $ref: "#/components/schemas/SandboxNetworkPolicy"
         auto_resume:
@@ -4196,8 +4185,11 @@ components:
           $ref: "#/components/schemas/SandboxLifecycleStatus"
         paused:
           type: boolean
-        power_state:
-          $ref: "#/components/schemas/SandboxPowerState"
+          description: True when status is paused and no runtime is attached.
+        runtime_generation:
+          type: integer
+          format: int64
+          description: Monotonically increasing runtime generation. Resume starts a new generation.
         cluster_id:
           type: string
           description: Cluster where sandbox runs (multi-cluster only)
@@ -4212,15 +4204,19 @@ components:
           type: string
           format: date-time
           description: Hard expiration timestamp. Zero value means not set.
+        updated_at:
+          type: string
+          format: date-time
       required:
         - id
         - template_id
         - status
         - paused
-        - power_state
+        - runtime_generation
         - created_at
         - expires_at
         - hard_expires_at
+        - updated_at
     SuccessSandboxListResponse:
       allOf:
         - $ref: "#/components/schemas/SuccessEnvelope"
@@ -4338,15 +4334,13 @@ components:
           type: string
         paused:
           type: boolean
-        power_state:
-          $ref: "#/components/schemas/SandboxPowerState"
         resource_usage:
           $ref: "#/components/schemas/SandboxResourceUsage"
         updated_memory:
           type: string
         updated_cpu:
           type: string
-      required: [sandbox_id, paused, power_state]
+      required: [sandbox_id, paused]
     ResumeSandboxResponse:
       type: object
       properties:
@@ -4354,11 +4348,9 @@ components:
           type: string
         resumed:
           type: boolean
-        power_state:
-          $ref: "#/components/schemas/SandboxPowerState"
         restored_memory:
           type: string
-      required: [sandbox_id, resumed, power_state]
+      required: [sandbox_id, resumed]
     SuccessPauseSandboxResponse:
       allOf:
         - $ref: "#/components/schemas/SuccessEnvelope"

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -171,9 +171,10 @@ const (
 
 // Defines values for SandboxLifecycleStatus.
 const (
-	SandboxLifecycleStatusCleaned     SandboxLifecycleStatus = "cleaned"
-	SandboxLifecycleStatusCompleted   SandboxLifecycleStatus = "completed"
 	SandboxLifecycleStatusFailed      SandboxLifecycleStatus = "failed"
+	SandboxLifecycleStatusPaused      SandboxLifecycleStatus = "paused"
+	SandboxLifecycleStatusPausing     SandboxLifecycleStatus = "pausing"
+	SandboxLifecycleStatusResuming    SandboxLifecycleStatus = "resuming"
 	SandboxLifecycleStatusRunning     SandboxLifecycleStatus = "running"
 	SandboxLifecycleStatusStarting    SandboxLifecycleStatus = "starting"
 	SandboxLifecycleStatusTerminating SandboxLifecycleStatus = "terminating"
@@ -183,25 +184,6 @@ const (
 const (
 	AllowAll SandboxNetworkPolicyMode = "allow-all"
 	BlockAll SandboxNetworkPolicyMode = "block-all"
-)
-
-// Defines values for SandboxPowerStateDesired.
-const (
-	Active SandboxPowerStateDesired = "active"
-	Paused SandboxPowerStateDesired = "paused"
-)
-
-// Defines values for SandboxPowerStateObserved.
-const (
-	SandboxPowerStateObservedActive SandboxPowerStateObserved = "active"
-	SandboxPowerStateObservedPaused SandboxPowerStateObserved = "paused"
-)
-
-// Defines values for SandboxPowerStatePhase.
-const (
-	Pausing  SandboxPowerStatePhase = "pausing"
-	Resuming SandboxPowerStatePhase = "resuming"
-	Stable   SandboxPowerStatePhase = "stable"
 )
 
 // Defines values for SeccompProfileType.
@@ -1169,7 +1151,6 @@ type PTYSize struct {
 // PauseSandboxResponse defines model for PauseSandboxResponse.
 type PauseSandboxResponse struct {
 	Paused        bool                  `json:"paused"`
-	PowerState    SandboxPowerState     `json:"power_state"`
 	ResourceUsage *SandboxResourceUsage `json:"resource_usage,omitempty"`
 	SandboxId     string                `json:"sandbox_id"`
 	UpdatedCpu    *string               `json:"updated_cpu,omitempty"`
@@ -1396,10 +1377,9 @@ type ResourceUsage struct {
 
 // ResumeSandboxResponse defines model for ResumeSandboxResponse.
 type ResumeSandboxResponse struct {
-	PowerState     SandboxPowerState `json:"power_state"`
-	RestoredMemory *string           `json:"restored_memory,omitempty"`
-	Resumed        bool              `json:"resumed"`
-	SandboxId      string            `json:"sandbox_id"`
+	RestoredMemory *string `json:"restored_memory,omitempty"`
+	Resumed        bool    `json:"resumed"`
+	SandboxId      string  `json:"sandbox_id"`
 }
 
 // SSHProxyProjection Transparent SSH proxy projection used for SSH egress re-origination.
@@ -1436,18 +1416,23 @@ type Sandbox struct {
 	ExpiresAt time.Time `json:"expires_at"`
 
 	// HardExpiresAt Hard expiration timestamp. Zero value means not set.
-	HardExpiresAt time.Time              `json:"hard_expires_at"`
-	Id            string                 `json:"id"`
-	Mounts        *[]ClaimMountRequest   `json:"mounts,omitempty"`
-	Paused        bool                   `json:"paused"`
-	PodName       string                 `json:"pod_name"`
-	PowerState    SandboxPowerState      `json:"power_state"`
-	Services      *[]SandboxAppService   `json:"services,omitempty"`
-	Ssh           *SandboxSSHConnection  `json:"ssh,omitempty"`
-	Status        SandboxLifecycleStatus `json:"status"`
-	TeamId        string                 `json:"team_id"`
-	TemplateId    string                 `json:"template_id"`
-	UserId        *string                `json:"user_id,omitempty"`
+	HardExpiresAt time.Time            `json:"hard_expires_at"`
+	Id            string               `json:"id"`
+	Mounts        *[]ClaimMountRequest `json:"mounts,omitempty"`
+
+	// Paused True when status is paused and no runtime is attached.
+	Paused  bool   `json:"paused"`
+	PodName string `json:"pod_name"`
+
+	// RuntimeGeneration Monotonically increasing runtime generation. Resume starts a new generation.
+	RuntimeGeneration int64                  `json:"runtime_generation"`
+	Services          *[]SandboxAppService   `json:"services,omitempty"`
+	Ssh               *SandboxSSHConnection  `json:"ssh,omitempty"`
+	Status            SandboxLifecycleStatus `json:"status"`
+	TeamId            string                 `json:"team_id"`
+	TemplateId        string                 `json:"template_id"`
+	UpdatedAt         time.Time              `json:"updated_at"`
+	UserId            *string                `json:"user_id,omitempty"`
 }
 
 // SandboxAppService Canonical service model for sandbox exposure.
@@ -1563,11 +1548,13 @@ type SandboxConfig struct {
 	AutoResume *bool              `json:"auto_resume,omitempty"`
 	EnvVars    *map[string]string `json:"env_vars,omitempty"`
 
-	// HardTtl Hard time-to-live in seconds. When it expires, Sandbox0 cleans the runtime pod and preserves the sandbox identity, services, and public URLs until the sandbox is explicitly deleted.
+	// HardTtl Sandbox hard time-to-live in seconds. When it expires, Sandbox0 deletes the sandbox identity and durable state, including paused rootfs checkpoints.
 	HardTtl  *int32                `json:"hard_ttl,omitempty"`
 	Network  *SandboxNetworkPolicy `json:"network,omitempty"`
 	Services *[]SandboxAppService  `json:"services,omitempty"`
-	Ttl      *int32                `json:"ttl,omitempty"`
+
+	// Ttl Runtime soft time-to-live in seconds. When it expires, Sandbox0 checkpoints the writable rootfs, pauses the sandbox, and releases runtime compute while preserving durable sandbox state.
+	Ttl *int32 `json:"ttl,omitempty"`
 
 	// Webhook Per-sandbox webhook configuration. Sandbox0 delivers webhook events at least once and consumers should deduplicate by event_id. For sandbox lifecycle events, procd persists signed delivery records to a manager-owned SandboxVolume outside the workspace before dispatch; manager also emits sandbox.deleted during pod deletion cleanup.
 	Webhook *WebhookConfig `json:"webhook,omitempty"`
@@ -1618,24 +1605,6 @@ type SandboxNetworkPolicy struct {
 
 // SandboxNetworkPolicyMode defines model for SandboxNetworkPolicy.Mode.
 type SandboxNetworkPolicyMode string
-
-// SandboxPowerState defines model for SandboxPowerState.
-type SandboxPowerState struct {
-	Desired            SandboxPowerStateDesired  `json:"desired"`
-	DesiredGeneration  int64                     `json:"desired_generation"`
-	Observed           SandboxPowerStateObserved `json:"observed"`
-	ObservedGeneration int64                     `json:"observed_generation"`
-	Phase              SandboxPowerStatePhase    `json:"phase"`
-}
-
-// SandboxPowerStateDesired defines model for SandboxPowerState.Desired.
-type SandboxPowerStateDesired string
-
-// SandboxPowerStateObserved defines model for SandboxPowerState.Observed.
-type SandboxPowerStateObserved string
-
-// SandboxPowerStatePhase defines model for SandboxPowerState.Phase.
-type SandboxPowerStatePhase string
 
 // SandboxRefreshRequest defines model for SandboxRefreshRequest.
 type SandboxRefreshRequest struct {
@@ -1694,12 +1663,17 @@ type SandboxSummary struct {
 	ExpiresAt time.Time `json:"expires_at"`
 
 	// HardExpiresAt Hard expiration timestamp. Zero value means not set.
-	HardExpiresAt time.Time              `json:"hard_expires_at"`
-	Id            string                 `json:"id"`
-	Paused        bool                   `json:"paused"`
-	PowerState    SandboxPowerState      `json:"power_state"`
-	Status        SandboxLifecycleStatus `json:"status"`
-	TemplateId    string                 `json:"template_id"`
+	HardExpiresAt time.Time `json:"hard_expires_at"`
+	Id            string    `json:"id"`
+
+	// Paused True when status is paused and no runtime is attached.
+	Paused bool `json:"paused"`
+
+	// RuntimeGeneration Monotonically increasing runtime generation. Resume starts a new generation.
+	RuntimeGeneration int64                  `json:"runtime_generation"`
+	Status            SandboxLifecycleStatus `json:"status"`
+	TemplateId        string                 `json:"template_id"`
+	UpdatedAt         time.Time              `json:"updated_at"`
 }
 
 // SandboxTemplateCondition defines model for SandboxTemplateCondition.
@@ -1743,11 +1717,13 @@ type SandboxUpdateConfig struct {
 	// (API or public exposure) must not auto resume the sandbox.
 	AutoResume *bool `json:"auto_resume,omitempty"`
 
-	// HardTtl Hard time-to-live in seconds. When it expires, Sandbox0 cleans the runtime pod and preserves the sandbox identity, services, and public URLs until the sandbox is explicitly deleted.
+	// HardTtl Sandbox hard time-to-live in seconds. When it expires, Sandbox0 deletes the sandbox identity and durable state, including paused rootfs checkpoints.
 	HardTtl  *int32                `json:"hard_ttl,omitempty"`
 	Network  *SandboxNetworkPolicy `json:"network,omitempty"`
 	Services *[]SandboxAppService  `json:"services,omitempty"`
-	Ttl      *int32                `json:"ttl,omitempty"`
+
+	// Ttl Runtime soft time-to-live in seconds. When it expires, Sandbox0 checkpoints the writable rootfs, pauses the sandbox, and releases runtime compute while preserving durable sandbox state.
+	Ttl *int32 `json:"ttl,omitempty"`
 }
 
 // SandboxUpdateRequest defines model for SandboxUpdateRequest.

--- a/pkg/sshgateway/connection_test.go
+++ b/pkg/sshgateway/connection_test.go
@@ -32,7 +32,6 @@ func TestSandboxToAPIIncludesSSHInfo(t *testing.T) {
 		UserID:        "user-1",
 		Status:        "running",
 		PodName:       "pod-1",
-		PowerState:    mgr.SandboxPowerState{Desired: "active", Observed: "active", Phase: "stable"},
 		AutoResume:    true,
 		Paused:        false,
 		ClaimedAt:     now,

--- a/pkg/sshgateway/sandbox_response.go
+++ b/pkg/sshgateway/sandbox_response.go
@@ -13,24 +13,19 @@ func SandboxToAPI(sandbox *mgr.Sandbox, sshInfo *ConnectionInfo) *apispec.Sandbo
 	}
 
 	payload := &apispec.Sandbox{
-		AutoResume:    sandbox.AutoResume,
-		ClaimedAt:     sandbox.ClaimedAt,
-		CreatedAt:     sandbox.CreatedAt,
-		ExpiresAt:     sandbox.ExpiresAt,
-		HardExpiresAt: sandbox.HardExpiresAt,
-		Id:            sandbox.ID,
-		Paused:        sandbox.Paused,
-		PodName:       sandbox.PodName,
-		PowerState: apispec.SandboxPowerState{
-			Desired:            apispec.SandboxPowerStateDesired(sandbox.PowerState.Desired),
-			DesiredGeneration:  sandbox.PowerState.DesiredGeneration,
-			Observed:           apispec.SandboxPowerStateObserved(sandbox.PowerState.Observed),
-			ObservedGeneration: sandbox.PowerState.ObservedGeneration,
-			Phase:              apispec.SandboxPowerStatePhase(sandbox.PowerState.Phase),
-		},
-		Status:     apispec.SandboxLifecycleStatus(sandbox.Status),
-		TeamId:     sandbox.TeamID,
-		TemplateId: sandbox.TemplateID,
+		AutoResume:        sandbox.AutoResume,
+		ClaimedAt:         sandbox.ClaimedAt,
+		CreatedAt:         sandbox.CreatedAt,
+		ExpiresAt:         sandbox.ExpiresAt,
+		HardExpiresAt:     sandbox.HardExpiresAt,
+		Id:                sandbox.ID,
+		Paused:            sandbox.Paused,
+		PodName:           sandbox.PodName,
+		RuntimeGeneration: sandbox.RuntimeGeneration,
+		Status:            apispec.SandboxLifecycleStatus(sandbox.Status),
+		TeamId:            sandbox.TeamID,
+		TemplateId:        sandbox.TemplateID,
+		UpdatedAt:         sandbox.UpdatedAt,
 	}
 	if sandbox.UserID != "" {
 		payload.UserId = &sandbox.UserID

--- a/regional-gateway/pkg/http/internal_ssh.go
+++ b/regional-gateway/pkg/http/internal_ssh.go
@@ -79,23 +79,21 @@ func (s *Server) resolveInternalSSHTarget(c *gin.Context) {
 		return
 	}
 
-	if sandboxWantsPausedRegional(sandbox) {
+	if sandboxNeedsRuntimeRegional(sandbox) {
 		if !sandbox.AutoResume {
-			spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox is paused and auto_resume is disabled")
+			spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox is not running and auto_resume is disabled")
 			return
 		}
-		if sandbox.PowerState.Desired != mgr.SandboxPowerStateActive {
-			if err := s.resumeSandboxViaClusterGateway(c.Request.Context(), targetURL, sandboxID, sandbox.TeamID, sshUserID); err != nil {
-				s.logger.Warn("Failed to request SSH sandbox resume via cluster-gateway",
-					zap.String("sandbox_id", sandboxID),
-					zap.String("team_id", sandbox.TeamID),
-					zap.String("user_id", sshUserID),
-					zap.String("cluster_gateway_url", targetURL),
-					zap.Error(err),
-				)
-				spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox resume failed")
-				return
-			}
+		if err := s.resumeSandboxViaClusterGateway(c.Request.Context(), targetURL, sandboxID, sandbox.TeamID, sshUserID); err != nil {
+			s.logger.Warn("Failed to request SSH sandbox resume via cluster-gateway",
+				zap.String("sandbox_id", sandboxID),
+				zap.String("team_id", sandbox.TeamID),
+				zap.String("user_id", sshUserID),
+				zap.String("cluster_gateway_url", targetURL),
+				zap.Error(err),
+			)
+			spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox resume failed")
+			return
 		}
 		spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox is waking up")
 		return
@@ -163,14 +161,14 @@ func (s *Server) resolveClusterGatewayTarget(c *gin.Context, sandboxID string) (
 	return targetURL, nil
 }
 
-func sandboxWantsPausedRegional(sandbox *mgr.Sandbox) bool {
+func sandboxNeedsRuntimeRegional(sandbox *mgr.Sandbox) bool {
 	if sandbox == nil {
 		return false
 	}
-	if sandbox.PowerState.Desired == mgr.SandboxPowerStatePaused {
+	if sandbox.Status == mgr.SandboxStatusPaused {
 		return true
 	}
-	return sandbox.Paused
+	return strings.TrimSpace(sandbox.InternalAddr) == ""
 }
 
 func (s *Server) getSandboxFromClusterGateway(ctx context.Context, clusterGatewayURL, sandboxID string) (*mgr.Sandbox, int, error) {

--- a/scheduler/pkg/http/handlers_sandbox_test.go
+++ b/scheduler/pkg/http/handlers_sandbox_test.go
@@ -608,7 +608,7 @@ func TestListSandboxesRoutesTeamScopedToken(t *testing.T) {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"success":true,"data":{"sandboxes":[{"id":"rs-home-team-a-demo-abcde","template_id":"tmpl-a","status":"running","paused":false,"power_state":{"desired":"active","desired_generation":2,"observed":"active","observed_generation":2,"phase":"stable"},"created_at":"2026-04-07T00:00:00Z","expires_at":"2026-04-07T01:00:00Z","hard_expires_at":"2026-04-07T02:00:00Z"}],"count":1,"has_more":false}}`))
+		_, _ = w.Write([]byte(`{"success":true,"data":{"sandboxes":[{"id":"rs-home-team-a-demo-abcde","template_id":"tmpl-a","status":"running","paused":false,"runtime_generation":2,"created_at":"2026-04-07T00:00:00Z","expires_at":"2026-04-07T01:00:00Z","hard_expires_at":"2026-04-07T02:00:00Z"}],"count":1,"has_more":false}}`))
 	}))
 	defer cluster.Close()
 
@@ -671,16 +671,10 @@ func TestListSandboxesRoutesTeamScopedToken(t *testing.T) {
 		Success bool `json:"success"`
 		Data    struct {
 			Sandboxes []struct {
-				ID         string  `json:"id"`
-				ClusterID  *string `json:"cluster_id"`
-				PowerState struct {
-					Desired            string `json:"desired"`
-					DesiredGeneration  int64  `json:"desired_generation"`
-					Observed           string `json:"observed"`
-					ObservedGeneration int64  `json:"observed_generation"`
-					Phase              string `json:"phase"`
-				} `json:"power_state"`
-				HardExpiresAt string `json:"hard_expires_at"`
+				ID                string  `json:"id"`
+				ClusterID         *string `json:"cluster_id"`
+				RuntimeGeneration int64   `json:"runtime_generation"`
+				HardExpiresAt     string  `json:"hard_expires_at"`
 			} `json:"sandboxes"`
 			Count int `json:"count"`
 		} `json:"data"`
@@ -700,11 +694,8 @@ func TestListSandboxesRoutesTeamScopedToken(t *testing.T) {
 	if body.Data.Sandboxes[0].ClusterID == nil || *body.Data.Sandboxes[0].ClusterID != "home" {
 		t.Fatalf("cluster_id = %v, want home", body.Data.Sandboxes[0].ClusterID)
 	}
-	if body.Data.Sandboxes[0].PowerState.Desired != "active" || body.Data.Sandboxes[0].PowerState.Phase != "stable" {
-		t.Fatalf("power_state = %+v, want active/stable", body.Data.Sandboxes[0].PowerState)
-	}
-	if body.Data.Sandboxes[0].PowerState.DesiredGeneration != 2 || body.Data.Sandboxes[0].PowerState.ObservedGeneration != 2 {
-		t.Fatalf("power_state generations = %d/%d, want 2/2", body.Data.Sandboxes[0].PowerState.DesiredGeneration, body.Data.Sandboxes[0].PowerState.ObservedGeneration)
+	if body.Data.Sandboxes[0].RuntimeGeneration != 2 {
+		t.Fatalf("runtime_generation = %d, want 2", body.Data.Sandboxes[0].RuntimeGeneration)
 	}
 }
 

--- a/tests/e2e/cases/api_fullmode.go
+++ b/tests/e2e/cases/api_fullmode.go
@@ -14,7 +14,7 @@ func registerApiFullModeSuite(envProvider func() *framework.ScenarioEnv) {
 		includeVolumeLifecycle:    true,
 		includeObjectEncryption:   true,
 		includeWebhookLifecycle:   true,
-		includeRootFSCleanRestore: true,
+		includeRootFSPauseResume:  true,
 		includeMeteringAssertions: true,
 	})
 }

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -36,7 +36,7 @@ type apiModeSuiteOptions struct {
 	includeVolumeLifecycle    bool
 	includeObjectEncryption   bool
 	includeWebhookLifecycle   bool
-	includeRootFSCleanRestore bool
+	includeRootFSPauseResume  bool
 	includeMeteringAssertions bool
 	expectStorageUnavailable  bool
 	expectNetworkUnavailable  bool
@@ -219,9 +219,9 @@ func registerApiModeSuite(envProvider func() *framework.ScenarioEnv, opts apiMod
 				})
 			}
 
-			if opts.includeRootFSCleanRestore {
-				It("persists rootfs changes across clean and restore", func() {
-					assertSandboxRootFSPersistsAcrossCleanRestore(env, session)
+			if opts.includeRootFSPauseResume {
+				It("persists rootfs changes across pause and resume", func() {
+					assertSandboxRootFSPersistsAcrossPauseResume(env, session)
 				})
 			}
 		})
@@ -369,14 +369,14 @@ func registerApiModeSuite(envProvider func() *framework.ScenarioEnv, opts apiMod
 					Expect(status).To(Equal(http.StatusOK))
 					Expect(pausedResp).NotTo(BeNil())
 					Expect(pausedResp.Paused).To(BeTrue())
-					waitForSandboxPowerStateEventually(env, session, sandboxID, apispec.SandboxPowerStateObserved("paused"))
+					waitForSandboxLifecycleStatusEventually(env, session, sandboxID, apispec.SandboxLifecycleStatusPaused)
 
 					resumeResp, status, err := session.ResumeSandbox(env.TestCtx.Context, GinkgoT(), sandboxID)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(status).To(Equal(http.StatusOK))
 					Expect(resumeResp).NotTo(BeNil())
 					Expect(resumeResp.Resumed).To(BeTrue())
-					waitForSandboxPowerStateEventually(env, session, sandboxID, apispec.SandboxPowerStateObserved("active"))
+					waitForSandboxLifecycleStatusEventually(env, session, sandboxID, apispec.SandboxLifecycleStatusRunning)
 
 					defaultUID := int64(1000)
 					defaultGID := int64(1000)
@@ -1308,7 +1308,7 @@ func assertSandboxListContainsClaimedSandbox(env *framework.ScenarioEnv, session
 	Expect(found).To(BeTrue(), "created sandbox should be in the list")
 }
 
-func assertSandboxRootFSPersistsAcrossCleanRestore(env *framework.ScenarioEnv, session *e2eutils.Session) {
+func assertSandboxRootFSPersistsAcrossPauseResume(env *framework.ScenarioEnv, session *e2eutils.Session) {
 	claimResp := claimSandboxEventually(env, session, "default")
 	sandboxID := claimResp.SandboxId
 	Expect(sandboxID).NotTo(BeEmpty())
@@ -1320,7 +1320,7 @@ func assertSandboxRootFSPersistsAcrossCleanRestore(env *framework.ScenarioEnv, s
 	Expect(err).NotTo(HaveOccurred())
 	sandbox := waitForSandboxPodReadyEventually(env, session, sandboxID, templateNamespace)
 
-	marker := fmt.Sprintf("s0-rootfs-clean-restore-%d", time.Now().UnixNano())
+	marker := fmt.Sprintf("s0-rootfs-pause-resume-%d", time.Now().UnixNano())
 	rootDir := "/tmp/" + marker
 	filePath := rootDir + "/marker.txt"
 	nestedPath := rootDir + "/nested/value.txt"
@@ -1357,18 +1357,18 @@ test "$(stat -c %%a %s)" = 751
 	_, err = execInSandboxPod(env, templateNamespace, sandbox.PodName, writeScript)
 	Expect(err).NotTo(HaveOccurred())
 
-	hardTTL := int32(1)
+	ttl := int32(1)
 	_, status, err := session.UpdateSandbox(env.TestCtx.Context, GinkgoT(), sandboxID, apispec.SandboxUpdateConfig{
-		HardTtl: &hardTTL,
+		Ttl: &ttl,
 	})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(status).To(Equal(http.StatusOK))
 
-	waitForSandboxLifecycleStatusEventually(env, session, sandboxID, apispec.SandboxLifecycleStatusCleaned)
+	waitForSandboxLifecycleStatusEventually(env, session, sandboxID, apispec.SandboxLifecycleStatusPaused)
 
-	disabledHardTTL := int32(0)
+	disabledTTL := int32(0)
 	_, status, err = session.UpdateSandbox(env.TestCtx.Context, GinkgoT(), sandboxID, apispec.SandboxUpdateConfig{
-		HardTtl: &disabledHardTTL,
+		Ttl: &disabledTTL,
 	})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(status).To(Equal(http.StatusOK))
@@ -1902,28 +1902,6 @@ func waitForSandboxPodReadyEventually(env *framework.ScenarioEnv, session *e2eut
 		sandbox = current
 		return nil
 	}).WithTimeout(3 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
-	return sandbox
-}
-
-func waitForSandboxPowerStateEventually(env *framework.ScenarioEnv, session *e2eutils.Session, sandboxID string, observed apispec.SandboxPowerStateObserved) *apispec.Sandbox {
-	var sandbox *apispec.Sandbox
-	Eventually(func() error {
-		resp, status, err := session.GetSandbox(env.TestCtx.Context, GinkgoT(), sandboxID)
-		if err != nil {
-			return err
-		}
-		if status != http.StatusOK {
-			return fmt.Errorf("get sandbox status %d", status)
-		}
-		if resp == nil {
-			return fmt.Errorf("sandbox response missing")
-		}
-		if resp.PowerState.Observed != observed || resp.PowerState.Phase != apispec.SandboxPowerStatePhase("stable") {
-			return fmt.Errorf("sandbox power state not stable at %s yet: observed=%s phase=%s", observed, resp.PowerState.Observed, resp.PowerState.Phase)
-		}
-		sandbox = resp
-		return nil
-	}).WithTimeout(90 * time.Second).WithPolling(2 * time.Second).Should(Succeed())
 	return sandbox
 }
 

--- a/tests/integration/internal/tests/manager/api_test.go
+++ b/tests/integration/internal/tests/manager/api_test.go
@@ -362,7 +362,7 @@ func TestClaimSandboxBindsDeclaredVolumePortal(t *testing.T) {
 	}
 }
 
-func TestCleanedSandboxRuntimeRestoreAppliesRootFSCheckpointBeforeInitialize(t *testing.T) {
+func TestPausedSandboxRuntimeResumeAppliesRootFSCheckpointBeforeInitialize(t *testing.T) {
 	events := &orderedEvents{}
 	namespace, err := naming.TemplateNamespaceForBuiltin("default")
 	utils.RequireNoError(t, err, "resolve template namespace")
@@ -387,7 +387,7 @@ func TestCleanedSandboxRuntimeRestoreAppliesRootFSCheckpointBeforeInitialize(t *
 		TemplateName:      template.Name,
 		TemplateNamespace: template.Namespace,
 		ClusterID:         "default",
-		Status:            service.SandboxStatusCleaned,
+		Status:            service.SandboxStatusPaused,
 		TemplateSpec:      template.Spec,
 		RuntimeGeneration: 3,
 		ClaimedAt:         now,
@@ -442,17 +442,17 @@ func TestCleanedSandboxRuntimeRestoreAppliesRootFSCheckpointBeforeInitialize(t *
 
 	resp, body = doRequest(t, env.server.Client(), http.MethodPost, env.server.URL+"/api/v1/sandboxes/sandbox-1/resume", env.token, nil)
 	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("cleaned runtime restore status = %d, body = %s", resp.StatusCode, string(body))
+		t.Fatalf("paused runtime resume status = %d, body = %s", resp.StatusCode, string(body))
 	}
 	resumeResp, errInfo, err := spec.DecodeResponse[service.ResumeSandboxResponse](bytes.NewReader(body))
 	if err != nil {
-		t.Fatalf("decode cleaned runtime restore response: %v", err)
+		t.Fatalf("decode paused runtime resume response: %v", err)
 	}
 	if errInfo != nil {
-		t.Fatalf("unexpected cleaned runtime restore error: %+v", errInfo)
+		t.Fatalf("unexpected paused runtime resume error: %+v", errInfo)
 	}
 	if resumeResp == nil || !resumeResp.Resumed {
-		t.Fatalf("cleaned runtime restore response = %+v, want restored", resumeResp)
+		t.Fatalf("paused runtime resume response = %+v, want resumed", resumeResp)
 	}
 
 	if got := events.List(); len(got) != 2 || got[0] != "apply-rootfs" || got[1] != "initialize-procd" {
@@ -759,6 +759,25 @@ func (s *memorySandboxStoreForManagerIntegration) ListSandboxes(_ context.Contex
 	return records, nil
 }
 
+func (s *memorySandboxStoreForManagerIntegration) ListHardExpiredSandboxes(_ context.Context, now time.Time, limit int) ([]*service.SandboxRecord, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if limit <= 0 {
+		limit = len(s.records)
+	}
+	records := make([]*service.SandboxRecord, 0, len(s.records))
+	for _, record := range s.records {
+		if record == nil || record.DeletedAt.IsZero() == false || record.HardExpiresAt.IsZero() || record.HardExpiresAt.After(now) {
+			continue
+		}
+		records = append(records, cloneSandboxRecordForManagerIntegration(record))
+		if len(records) >= limit {
+			break
+		}
+	}
+	return records, nil
+}
+
 func (s *memorySandboxStoreForManagerIntegration) MarkSandboxDeleted(_ context.Context, sandboxID string, deletedAt time.Time) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -821,14 +840,14 @@ func (t memorySandboxStoreTxForManagerIntegration) SaveRuntime(_ context.Context
 	return nil
 }
 
-func (t memorySandboxStoreTxForManagerIntegration) MarkRuntimeCleaned(_ context.Context, sandboxID string, generation int64, _ time.Time) error {
+func (t memorySandboxStoreTxForManagerIntegration) MarkRuntimePaused(_ context.Context, sandboxID string, generation int64, _ time.Time) error {
 	record := t.store.records[sandboxID]
 	if record == nil {
 		return service.ErrSandboxRecordNotFound
 	}
 	record.CurrentPodNamespace = ""
 	record.CurrentPodName = ""
-	record.Status = service.SandboxStatusCleaned
+	record.Status = service.SandboxStatusPaused
 	if record.RuntimeGeneration < generation {
 		record.RuntimeGeneration = generation
 	}


### PR DESCRIPTION
Fixes #416

## Summary
- Redefine public sandbox lifecycle so `pause` checkpoints writable rootfs and releases runtime compute, and `resume` creates/restores a runtime generation.
- Remove public soft power-state API shape from sandbox responses and OpenAPI; expose lifecycle status plus `runtime_generation` and `updated_at`.
- Make `ttl` pause runtimes while `hard_ttl` deletes durable sandbox state, including paused rootfs checkpoints.
- Update cleanup, metering, gateway auto-resume, SSH resolution, docs, integration tests, and e2e cases for the new lifecycle.

## Testing
- `make apispec`
- `go test ./manager/pkg/service ./manager/pkg/metering ./manager/pkg/controller ./cluster-gateway/pkg/http ./regional-gateway/pkg/http ./scheduler/pkg/http ./pkg/sshgateway ./pkg/apispec ./manager/pkg/http ./tests/integration/internal/tests/manager ./tests/e2e/cases`