### PR TITLE
docs: clarify pause/resume filesystem semantics

### DIFF
--- a/docs/get-started/concepts/page.mdx
+++ b/docs/get-started/concepts/page.mdx
@@ -24,8 +24,8 @@ The key idea is separation of concerns:
 A common confusion is mixing compute state and durable state.
 
 - Process state lives in the sandbox runtime and disappears when the runtime is paused or deleted.
-- Sandbox0 restores the writable root filesystem checkpoint for paused sandboxes, so files written outside mounted volumes can survive pause/resume for the same sandbox identity.
-- Durable state that needs snapshots, sharing, or recovery outside the sandbox identity should be written to volumes or external systems.
+- Sandbox0 restores the writable root filesystem checkpoint for paused sandboxes, so files written outside mounted volumes survive pause/resume for the same sandbox identity.
+- Durable state that must survive sandbox delete or `hard_ttl`, needs snapshots, or needs sharing outside the sandbox identity should be written to volumes or external systems.
 - If your agent must recover after failures or redeploys, treat sandbox runtime as ephemeral and volumes as the source of truth.
 
 <Callout variant="info">
@@ -80,7 +80,7 @@ This keeps each agent worker simple while allowing safe parallel execution.
 
 ## Common Pitfalls
 
-- Treating sandbox filesystem as permanent storage.
+- Treating the sandbox root filesystem as permanent storage after sandbox delete or `hard_ttl`.
 - Using a single long-lived sandbox for unrelated tasks.
 - Skipping checkpoint persistence until task end.
 - Over-permissive auth/network settings in early prototypes that leak into production.

--- a/docs/sandbox/files/page.mdx
+++ b/docs/sandbox/files/page.mdx
@@ -2,6 +2,8 @@
 
 Manage files and directories within a sandbox. The Files API provides full POSIX file operations including read, write, delete, move, and real-time file watching.
 
+Files written to the sandbox writable filesystem are restored across checkpointed pause/resume for the same sandbox identity. They are deleted when the sandbox is deleted or `hard_ttl` expires. Use [Volumes](/docs/volume) for data that must outlive a sandbox identity, needs snapshots, or must be shared across sandboxes.
+
 ## File Model
 
 ### FileInfo

--- a/docs/template/configuration/page.mdx
+++ b/docs/template/configuration/page.mdx
@@ -64,7 +64,7 @@ The main sandbox container configuration.
 | `image` | string | — | Container image reference. Use a public image (e.g., `python:3.12-slim`) or the `Template image reference` returned by `s0 template image push` for private images. |
 | `resources.cpu` | string | — | CPU limit for the sandbox (e.g., `"1"`, `"2"`, `"500m"`). |
 | `resources.memory` | string | — | Memory limit for the sandbox (e.g., `"2Gi"`, `"512Mi"`). |
-| `resources.ephemeralStorage` | string | `512Mi` | Writable-layer and container-log storage for the sandbox runtime. Clean/restore checkpoints the writable root filesystem, but this quota still bounds writes to `/tmp` or image-local paths; use Sandbox Volumes for snapshots, sharing, and long-lived durable data. |
+| `resources.ephemeralStorage` | string | `512Mi` | Writable-layer and container-log storage for the sandbox runtime. Checkpointed pause/resume saves and restores the writable root filesystem, but this quota still bounds writes to `/tmp` or image-local paths; use Sandbox Volumes for snapshots, sharing, and long-lived durable data. |
 | `env` | array | `[]` | Per-container environment variables. Each entry has `name` and `value`. |
 
 <Callout variant="info">

--- a/docs/volume/page.mdx
+++ b/docs/volume/page.mdx
@@ -4,7 +4,7 @@ Volume provides persistent storage for Sandbox0. It is a storage unit independen
 
 ## Why Volumes?
 
-The default Sandbox filesystem is ephemeral—when a Sandbox is deleted, all its data is lost. Volumes solve this problem:
+The default Sandbox writable filesystem is checkpointed across pause/resume for the same Sandbox identity. It is not independent long-term storage: when the Sandbox is deleted or `hard_ttl` expires, the identity and rootfs checkpoints are deleted too. Volumes solve the cases where data must outlive one Sandbox identity or be shared across Sandboxes:
 
 - **Data Persistence**: Store data that needs long-term retention, such as databases, model files, and user uploads
 - **Cross-Sandbox Sharing**: Mount the same Volume to multiple Sandboxes for data sharing


### PR DESCRIPTION
## Summary
- replace remaining clean/restore wording with checkpointed pause/resume semantics
- clarify that the sandbox writable root filesystem is restored across pause/resume for the same sandbox identity
- document that delete or hard_ttl removes the sandbox identity and rootfs checkpoints, while volumes are for longer-lived/shared data

## Tests
- git diff --check