### PR TITLE
Preserve hard TTL deadline on sandbox resume

### DIFF
--- a/manager/pkg/service/sandbox_runtime_identity_test.go
+++ b/manager/pkg/service/sandbox_runtime_identity_test.go
@@ -249,6 +249,40 @@ func TestResumePausedSandboxRuntimeDoesNotCreatePodWhileRuntimeDeleting(t *testi
 	}
 }
 
+func TestResumePausedSandboxRuntimeRejectsHardExpiredRecord(t *testing.T) {
+	now := time.Date(2026, time.March, 7, 12, 0, 0, 0, time.UTC)
+	hardExpiresAt := now.Add(-time.Second)
+	store := &memorySandboxStore{records: map[string]*SandboxRecord{
+		"sandbox-a": {
+			ID:                "sandbox-a",
+			TeamID:            "team-a",
+			UserID:            "user-a",
+			TemplateID:        "default",
+			TemplateName:      "default",
+			TemplateNamespace: "tpl-default",
+			Status:            SandboxStatusPaused,
+			HardExpiresAt:     hardExpiresAt,
+			TemplateSpec:      v1alpha1.SandboxTemplateSpec{},
+		},
+	}}
+	svc := &SandboxService{
+		sandboxStore: store,
+		clock:        fixedClock{now: now},
+		logger:       zap.NewNop(),
+	}
+
+	_, err := svc.ResumePausedSandboxRuntime(context.Background(), "sandbox-a")
+	if !k8serrors.IsNotFound(err) {
+		t.Fatalf("ResumePausedSandboxRuntime() error = %v, want not found", err)
+	}
+	if store.saves != 0 {
+		t.Fatalf("store saves = %d, want 0", store.saves)
+	}
+	if got := store.records["sandbox-a"].HardExpiresAt; !got.Equal(hardExpiresAt) {
+		t.Fatalf("hard expires at = %s, want %s", got, hardExpiresAt)
+	}
+}
+
 func TestTerminatePausedSandboxRecordRunsPersistentCleanup(t *testing.T) {
 	store := &memorySandboxStore{records: map[string]*SandboxRecord{
 		"sandbox-a": {

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -43,6 +43,8 @@ type ClaimRequest struct {
 	SandboxID string `json:"-"`
 	// RuntimeGeneration identifies the current runtime pod incarnation.
 	RuntimeGeneration int64 `json:"-"`
+	// HardExpiresAt preserves the absolute hard deadline when recreating a paused sandbox.
+	HardExpiresAt time.Time `json:"-"`
 }
 
 type ClaimMount struct {
@@ -166,6 +168,17 @@ func setHardExpirationAnnotation(annotations map[string]string, now time.Time, h
 	}
 	hardExpiresAt := now.Add(time.Duration(*hardTTL) * time.Second)
 	annotations[controller.AnnotationHardExpiresAt] = hardExpiresAt.Format(time.RFC3339)
+}
+
+func setClaimHardExpirationAnnotation(annotations map[string]string, now time.Time, hardTTL *int32, hardExpiresAt time.Time) {
+	if annotations == nil {
+		return
+	}
+	if !hardExpiresAt.IsZero() {
+		annotations[controller.AnnotationHardExpiresAt] = hardExpiresAt.UTC().Format(time.RFC3339)
+		return
+	}
+	setHardExpirationAnnotation(annotations, now, hardTTL)
 }
 
 func applyClaimMetadata(pod *corev1.Pod, metadata *ClaimMetadata) {
@@ -926,7 +939,7 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 		persistedConfig := s.claimConfigForPersistence(req.Config)
 		if persistedConfig != nil {
 			setExpirationAnnotation(pod.Annotations, s.clock.Now(), persistedConfig.TTL)
-			setHardExpirationAnnotation(pod.Annotations, s.clock.Now(), persistedConfig.HardTTL)
+			setClaimHardExpirationAnnotation(pod.Annotations, s.clock.Now(), persistedConfig.HardTTL, req.HardExpiresAt)
 		}
 		if err := setMountsAnnotation(pod.Annotations, req.Mounts); err != nil {
 			return err
@@ -1091,7 +1104,7 @@ func (s *SandboxService) createNewPod(ctx context.Context, template *v1alpha1.Sa
 	persistedConfig := s.claimConfigForPersistence(req.Config)
 	if persistedConfig != nil {
 		setExpirationAnnotation(pod.Annotations, s.clock.Now(), persistedConfig.TTL)
-		setHardExpirationAnnotation(pod.Annotations, s.clock.Now(), persistedConfig.HardTTL)
+		setClaimHardExpirationAnnotation(pod.Annotations, s.clock.Now(), persistedConfig.HardTTL, req.HardExpiresAt)
 	}
 	if err := setMountsAnnotation(pod.Annotations, req.Mounts); err != nil {
 		return nil, err

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -150,6 +150,50 @@ func TestClaimIdlePodAppliesRuntimeOwnerMetadata(t *testing.T) {
 	assertClaimOwnerMetadata(t, pod)
 }
 
+func TestClaimIdlePodUsesAbsoluteHardExpiresAtOverride(t *testing.T) {
+	now := time.Date(2026, time.March, 7, 12, 0, 0, 0, time.UTC)
+	hardExpiresAt := now.Add(30 * time.Minute)
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "template-a",
+			Namespace: "ns-a",
+		},
+	}
+	readyPod := newClaimTestPod("ns-a", "idle-ready", "template-a", true)
+
+	client := fake.NewSimpleClientset(readyPod.DeepCopy())
+	svc := &SandboxService{
+		k8sClient: client,
+		podLister: newClaimTestPodLister(t, readyPod),
+		clock:     fixedClock{now: now},
+		logger:    zap.NewNop(),
+	}
+
+	pod, err := svc.claimIdlePod(context.Background(), template, &ClaimRequest{
+		TeamID:        "team-a",
+		UserID:        "user-a",
+		Config:        &SandboxConfig{HardTTL: int32Ptr(3600)},
+		HardExpiresAt: hardExpiresAt,
+	})
+	if err != nil {
+		t.Fatalf("claimIdlePod() error = %v", err)
+	}
+	if pod == nil {
+		t.Fatal("claimIdlePod() = nil, want ready pod")
+	}
+	if got := pod.Annotations[controller.AnnotationHardExpiresAt]; got != hardExpiresAt.Format(time.RFC3339) {
+		t.Fatalf("hard-expires-at annotation = %q, want %q", got, hardExpiresAt.Format(time.RFC3339))
+	}
+
+	var cfg SandboxConfig
+	if err := json.Unmarshal([]byte(pod.Annotations[controller.AnnotationConfig]), &cfg); err != nil {
+		t.Fatalf("unmarshal config: %v", err)
+	}
+	if cfg.HardTTL == nil || *cfg.HardTTL != 3600 {
+		t.Fatalf("config hard_ttl = %v, want 3600", cfg.HardTTL)
+	}
+}
+
 func TestClaimIdlePodRequiresCurrentTemplateHash(t *testing.T) {
 	template := &v1alpha1.SandboxTemplate{
 		ObjectMeta: metav1.ObjectMeta{
@@ -461,6 +505,50 @@ func TestCreateNewPodAppliesRuntimeOwnerMetadata(t *testing.T) {
 		t.Fatalf("createNewPod() error = %v", err)
 	}
 	assertClaimOwnerMetadata(t, pod)
+}
+
+func TestCreateNewPodUsesAbsoluteHardExpiresAtOverride(t *testing.T) {
+	withClaimTestPublicKey(t)
+
+	now := time.Date(2026, time.March, 7, 12, 0, 0, 0, time.UTC)
+	hardExpiresAt := now.Add(30 * time.Minute)
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "template-a",
+			Namespace: "ns-a",
+		},
+		Spec: v1alpha1.SandboxTemplateSpec{
+			MainContainer: v1alpha1.ContainerSpec{Image: "busybox"},
+		},
+	}
+	client := fake.NewSimpleClientset()
+	svc := &SandboxService{
+		k8sClient:    client,
+		secretLister: newClaimTestSecretLister(t),
+		clock:        fixedClock{now: now},
+		logger:       zap.NewNop(),
+	}
+
+	pod, err := svc.createNewPod(context.Background(), template, &ClaimRequest{
+		TeamID:        "team-a",
+		UserID:        "user-a",
+		Config:        &SandboxConfig{HardTTL: int32Ptr(3600)},
+		HardExpiresAt: hardExpiresAt,
+	})
+	if err != nil {
+		t.Fatalf("createNewPod() error = %v", err)
+	}
+	if got := pod.Annotations[controller.AnnotationHardExpiresAt]; got != hardExpiresAt.Format(time.RFC3339) {
+		t.Fatalf("hard-expires-at annotation = %q, want %q", got, hardExpiresAt.Format(time.RFC3339))
+	}
+
+	var cfg SandboxConfig
+	if err := json.Unmarshal([]byte(pod.Annotations[controller.AnnotationConfig]), &cfg); err != nil {
+		t.Fatalf("unmarshal config: %v", err)
+	}
+	if cfg.HardTTL == nil || *cfg.HardTTL != 3600 {
+		t.Fatalf("config hard_ttl = %v, want 3600", cfg.HardTTL)
+	}
 }
 
 func TestCreateNewPodFailsBeforeCreateWhenDataPlaneNotReady(t *testing.T) {

--- a/manager/pkg/service/sandbox_service_lifecycle.go
+++ b/manager/pkg/service/sandbox_service_lifecycle.go
@@ -419,6 +419,17 @@ func expirationFromTTL(now time.Time, ttl *int32) time.Time {
 	return now.Add(time.Duration(*ttl) * time.Second)
 }
 
+func sandboxHardExpired(hardExpiresAt time.Time, now time.Time) bool {
+	return !hardExpiresAt.IsZero() && !hardExpiresAt.After(now)
+}
+
+func (s *SandboxService) now() time.Time {
+	if s != nil && s.clock != nil {
+		return s.clock.Now()
+	}
+	return time.Now()
+}
+
 func (s *SandboxService) persistUpdatedSandboxPod(ctx context.Context, pod *corev1.Pod) error {
 	if s == nil || s.sandboxStore == nil || pod == nil {
 		return nil

--- a/manager/pkg/service/sandbox_service_restore.go
+++ b/manager/pkg/service/sandbox_service_restore.go
@@ -29,6 +29,9 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 		if locked.Status == SandboxStatusDeleted || !locked.DeletedAt.IsZero() {
 			return k8serrors.NewNotFound(corev1.Resource("sandbox"), sandboxID)
 		}
+		if sandboxHardExpired(locked.HardExpiresAt, s.now()) {
+			return k8serrors.NewNotFound(corev1.Resource("sandbox"), sandboxID)
+		}
 		switch locked.Status {
 		case SandboxStatusStarting, SandboxStatusPausing, SandboxStatusResuming:
 			return k8serrors.NewConflict(corev1.Resource("sandbox"), sandboxID, fmt.Errorf("sandbox lifecycle operation %q is in progress", locked.Status))
@@ -69,6 +72,7 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 			Mounts:            locked.Mounts,
 			SandboxID:         locked.ID,
 			RuntimeGeneration: generation,
+			HardExpiresAt:     locked.HardExpiresAt,
 		}
 		pod, err = s.claimIdlePod(lockCtx, template, req)
 		if err != nil {


### PR DESCRIPTION
## Summary
- reject resume for paused sandbox records whose hard TTL deadline has already passed
- preserve the stored absolute hard_expires_at when recreating a paused sandbox runtime
- cover hot and cold claim paths plus hard-expired resume with unit tests

## Tests
- go test ./manager/pkg/service