### PR TITLE
Update README for agent platform positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,39 +10,39 @@
 
 # Sandbox0
 
-Sandbox0 is infrastructure for running AI agent work in isolated, resumable sandboxes.
+Sandbox0 is the runtime boundary for enterprise AI agent platforms.
 
-It gives agent developers a place to run code, shell commands, browser tooling, build steps, repository operations, and long-running sessions without giving that work direct access to the host machine or production credentials.
+It gives platform teams isolated, persistent sandboxes for agent work that needs to run code, edit repositories, expose per-agent HTTP services, keep workspace state, and access external systems without placing broad production credentials inside the agent runtime.
 
-Use Sandbox0 when your agent needs:
+Use Sandbox0 when you need to:
 
-- **Isolated execution** for untrusted code, user files, generated scripts, and tool calls.
-- **Stateful sessions** for REPL-style workflows such as `python`, `bash`, language servers, agent runtimes, and long-running helpers.
-- **Persistent workspaces** through volumes, snapshots, restore, fork, and sync workflows.
-- **Fast startup** through template-backed warm pools.
-- **Network control** with allow/deny policy and destination-scoped credential injection.
-- **Custom runtimes** from your own container images, packages, tools, and resource limits.
-- **Self-hosting** when you need to own the data plane, storage, network boundary, and deployment policy.
+| Need | Sandbox0 angle |
+| ---- | -------------- |
+| Run untrusted code and tools | Isolated sandboxes with process, file, SSH, and service APIs. |
+| Build coding agents | Stateful REPL contexts, one-shot commands, persistent repo volumes, and fast template claims. |
+| Run agent gateways such as Hermes or OpenClaw | Agent in Sandbox with builtin templates, mounted volumes, public service routes, and auto-resume. |
+| Expose per-agent HTTP endpoints | Sandbox Services with route auth, method filtering, CORS, rate limits, timeouts, path rewrite, and resume. |
+| Keep secrets outside the agent process | Credential sources, destination-scoped egress auth, SSH transparent proxying, LLMProxy, or an external AI gateway. |
+| Control network and MCP access | Ordered traffic rules, protocol-aware MCP tool controls, and egress audit in the data plane. |
+| Branch, evaluate, or recover agent state | Volumes, point-in-time snapshots, restore, and Copy-on-Write fork. |
+| Own the deployment boundary | Self-hosted Kubernetes data plane with external PostgreSQL, S3/OSS, Vault-compatible storage, Redis, and registry options. |
 
-Sandbox0 Cloud uses `https://api.sandbox0.ai` for sandboxes, templates, volumes, credentials, and team-scoped API keys.
+Sandbox0 Cloud uses `https://api.sandbox0.ai` for sandboxes, templates, volumes, credentials, and team-scoped API keys. Managed Agents uses `https://agents.sandbox0.ai`.
 
 > Sandbox0 is under active development. Prefer the SDKs and `s0` CLI over hardcoded HTTP paths, and check the docs before depending on beta surfaces.
 
-## What You Build With
+## Choose Your Path
 
-| Building block | What it is                                                                                                 | Why agent developers care                                                                             |
-| -------------- | ---------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| **Template**   | A runtime blueprint: image, resources, warm pool, volume mount points, and default policy.                 | Keeps environments reproducible and makes startup fast.                                               |
-| **Sandbox**    | An isolated runtime instance created from a template.                                                      | Gives each task, user, or agent worker its own execution boundary.                                    |
-| **Context**    | A process/session inside a sandbox.                                                                        | Choose stateful REPL behavior or one-shot command execution per tool call.                            |
-| **Volume**     | Persistent storage independent of a sandbox lifetime.                                                      | Keeps repositories, caches, checkpoints, artifacts, and session workspaces across sandbox recreation. |
-| **Credential** | A secret source plus policy for how it may be used.                                                        | Lets agents call external services without storing raw API keys in the sandbox process.               |
-
-The short version: use templates for repeatable environments, sandboxes for isolation, contexts for process behavior, volumes for durable memory, and credentials/network policy for controlled external access.
+| Path | Use it when | Start here |
+| ---- | ----------- | ---------- |
+| **Raw Sandboxes** | You want direct control over processes, files, volumes, ports, templates, and network policy. | [Get started](https://sandbox0.ai/docs/get-started) |
+| **Agent in Sandbox** | You want an agent framework gateway to run inside the sandbox, with its state on a volume and its API exposed through Sandbox0 routes. | [Agent in Sandbox](https://sandbox0.ai/docs/agent-in-sandbox) |
+| **Managed Agents** | You want a Claude Managed Agents-compatible session and event API backed by Sandbox0 runtime primitives. | [Managed Agents](https://sandbox0.ai/docs/managed-agents) |
+| **Self-hosted** | You need private deployment, data-plane ownership, regional storage boundaries, or custom runtime isolation. | [Self-hosted](https://sandbox0.ai/docs/self-hosted) |
 
 ## Quickstart
 
-Install the `s0` CLI:
+Install the `s0` CLI.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/sandbox0-ai/s0/main/scripts/install.sh | bash
@@ -54,7 +54,7 @@ Windows PowerShell:
 irm https://raw.githubusercontent.com/sandbox0-ai/s0/main/scripts/install.ps1 | iex
 ```
 
-Sign in, then create an API key for SDK or automation usage:
+Sign in, then create a team-scoped API key for SDK or automation usage.
 
 ```bash
 s0 auth login
@@ -65,10 +65,11 @@ s0 auth login
 # s0 team use <team-id>
 
 export SANDBOX0_TOKEN="$(s0 apikey create --name sdk-quickstart --role developer --expires-in 30d --raw)"
-export SANDBOX0_BASE_URL="https://api.sandbox0.ai"
 ```
 
-Install an SDK:
+For Sandbox0 Cloud, SDKs default to `https://api.sandbox0.ai`. Set `SANDBOX0_BASE_URL` only when connecting to a self-hosted or private deployment.
+
+Install an SDK.
 
 ```bash
 # Python
@@ -81,7 +82,7 @@ npm install sandbox0
 go get github.com/sandbox0-ai/sdk-go
 ```
 
-Claim a sandbox, run stateful code, and run a one-shot command:
+Claim a sandbox, keep state in a REPL context, and run an isolated command.
 
 ```python
 import os
@@ -111,47 +112,111 @@ More examples:
 - [Sandbox lifecycle and execution](https://sandbox0.ai/docs/sandbox)
 - [Templates and warm pools](https://sandbox0.ai/docs/template)
 - [Volumes, snapshots, fork, and sync](https://sandbox0.ai/docs/volume)
+- [Agent in Sandbox](https://sandbox0.ai/docs/agent-in-sandbox)
 - [Network policy](https://sandbox0.ai/docs/sandbox/network)
 - [Credentials and egress auth](https://sandbox0.ai/docs/credential)
 
-## Common Agent Patterns
+## Agent In Sandbox
 
-**Coding agents**
+Agent in Sandbox runs an agent framework gateway inside a Sandbox0 sandbox instead of on a cloud VM, VPS, or developer workstation.
 
-Use a custom template with language runtimes, package managers, git, build tools, and an attached volume for the repository workspace. Use a REPL for the active agent loop, and one-shot commands for isolated build/test steps.
+Use this path when the agent needs a long-lived workspace, controlled network access, and a service endpoint, but you do not want the sandbox filesystem to become the place where broad production credentials live.
 
-**Data or browser agents**
+Sandbox0 owns the runtime boundary around the framework:
 
-Use a template with the required browser or data tooling, expose only the ports needed for previews, and persist downloads or generated artifacts into a volume. Apply network policy early so agent browsing and API calls stay inside the intended boundary.
+| Layer | Sandbox0 primitive |
+| ----- | ------------------ |
+| Runtime image | Builtin or custom Template |
+| Durable agent state | SandboxVolume |
+| Process restart | `cmd` Sandbox Service |
+| Public HTTP entrypoint | Sandbox Service route |
+| Wake-up path | Sandbox `auto_resume` plus route `resume` |
+| Secret boundary | Credential sources, egress auth, LLMProxy, or an external model proxy |
+| Network boundary | Sandbox network policy and protocol controls |
 
-**Parallel workers**
+Self-hosted deployments seed builtin templates for `openclaw` and `hermes` when `Sandbox0Infra.spec.builtinTemplates` is omitted. Operators can pin images, tune pools, or remove either template explicitly.
 
-Create one sandbox per task or user request. Share read-only inputs through volumes or object storage, and write outputs to separate volumes or task-specific paths. Keep orchestration outside the sandbox.
+| Template | Typical persistent path | What it gives you |
+| -------- | ----------------------- | ----------------- |
+| [`hermes`](https://sandbox0.ai/docs/agent-in-sandbox/hermes) | `/opt/data` | Hermes gateway sessions, memory, skills, and state behind Sandbox0 runtime controls. |
+| [`openclaw`](https://sandbox0.ai/docs/agent-in-sandbox/openclaw) | `/home/node/.openclaw` | OpenClaw gateway, workspace, logs, and session state behind Sandbox0 route and lifecycle controls. |
 
-**Long-running sessions**
-
-Treat the sandbox process as runtime state and the volume as durable state. Cleaned sandboxes restore the writable root filesystem checkpoint, but running processes are recreated. Checkpoint progress frequently, use TTLs to pause idle compute, and keep important workspace state in volumes or external storage.
+Public route auth is enforced before traffic reaches the agent gateway. Paused sandboxes can be resumed by public service requests when both sandbox `auto_resume` and route `resume` are enabled. Running processes, sockets, memory, and in-flight requests are not preserved across pause/resume, so durable state should live on the mounted volume.
 
 ## Managed Agents
 
-Sandbox0 also provides a Managed Agents path for developers who want a higher-level, Claude Managed Agents-compatible API shape.
+Sandbox0 Managed Agents is a higher-level path for developers who want a Claude Managed Agents-compatible API shape.
 
-Managed Agents sit above raw sandboxes. Application code uses the official Anthropic SDK pointed at Sandbox0's Managed Agents endpoint, while Sandbox0 provides durable sessions, event history, sandbox orchestration, persistent workspaces, network policy, and credential injection underneath.
+Application code uses the official Anthropic SDK pointed at Sandbox0's Managed Agents endpoint, while Sandbox0 provides durable sessions, event history, sandbox orchestration, persistent workspaces, network policy, and credential injection underneath.
 
 - Managed Agents API: `https://agents.sandbox0.ai`
 - Documentation: <https://sandbox0.ai/docs/managed-agents>
 
-Use raw Sandbox0 sandboxes when you want direct control over processes, files, templates, volumes, ports, and network policy. Use Managed Agents when you want a session/event API for agent applications and want Sandbox0 to manage the runtime attachment behind that API.
+Managed Agents supports two execution models:
 
-## Safety And Isolation Model
+| Model | How it works | Best fit |
+| ----- | ------------ | -------- |
+| **Agent in sandbox** | The agent runtime process lives inside the per-session sandbox with the workspace and harness state. | Claude Code style coding agents, Codex app-server sessions, and workflows that expect local files and shell state. |
+| **Sandbox as tool** | A resident runtime service owns the agent loop and claims a Sandbox0 sandbox only when isolated tool execution is needed. | Product copilots and agent workflows built around a separate application control plane. |
+
+Use raw Sandbox0 sandboxes when you want direct control over processes, files, templates, volumes, ports, and network policy. Use Managed Agents when you want Sandbox0 to provide the session/event API and runtime attachment behind that API.
+
+## Platform Patterns
+
+**Coding agents**
+
+Use a custom template with language runtimes, package managers, git, build tools, and an attached volume for the repository workspace. Use a stateful REPL for the active agent loop and one-shot commands for isolated build/test steps.
+
+**Code interpreter, data, or browser agents**
+
+Use a template with the required browser or data tooling, expose only the ports needed for previews, and persist downloads or generated artifacts into a volume. Apply network policy early so agent browsing and API calls stay inside the intended boundary.
+
+**Agent gateways**
+
+Run gateways such as Hermes or OpenClaw as `cmd` Sandbox Services. Store framework state on a mounted volume, protect public routes with Sandbox0 route auth, and keep model/provider credentials behind egress auth, LLMProxy, or an external AI gateway.
+
+**Parallel workers**
+
+Create one sandbox per task, eval case, branch, or user request. Share read-only inputs through volumes, snapshots, or object storage, then write outputs to separate volumes or task-specific paths. Keep orchestration outside the sandbox boundary.
+
+**Long-running sessions**
+
+Treat the sandbox process as runtime state and the volume as durable state. Paused sandboxes restore the writable root filesystem checkpoint, but running processes are recreated. Checkpoint progress frequently, use TTLs to pause idle compute, and keep important workspace state in volumes or external storage.
+
+## Core Concepts
+
+| Building block | What it is | Why platform developers care |
+| -------------- | ---------- | ---------------------------- |
+| **Template** | A runtime blueprint: image, resources, warm pool, mount points, and default policy. | Keeps environments reproducible and claims fast. |
+| **Sandbox** | A durable identity and configuration for an isolated runtime instance. | Gives each task, user, or agent worker its own execution boundary. |
+| **Context** | A process/session inside a sandbox, either REPL-style or one-shot command. | Lets agents choose in-process continuity or clean execution per tool call. |
+| **Volume** | Persistent storage independent of a sandbox lifetime. | Keeps repositories, caches, agent memory, artifacts, checkpoints, snapshots, and forks. |
+| **Service** | A public HTTP entrypoint backed by a listener, command, or function. | Exposes per-sandbox APIs, previews, webhooks, and agent gateways with route policy. |
+| **Credential** | A secret source plus policy for how it may be projected or injected. | Lets agents call external services without storing raw production keys in the sandbox process. |
+
+The short version: use templates for repeatable environments, sandboxes for isolation, contexts for process behavior, volumes for durable memory, services for controlled ingress, and credentials/network policy for controlled external access.
+
+## Persistence And Lifecycle
+
+Sandbox0 separates runtime state from durable state.
+
+- `ttl` is a runtime soft timeout. When it expires, Sandbox0 checkpoints the writable root filesystem, pauses the sandbox, and releases runtime compute.
+- `hard_ttl` is a hard sandbox lifetime. When it expires, Sandbox0 deletes the sandbox identity and durable state tied to that identity, including rootfs checkpoints.
+- Pause/resume preserves sandbox identity and the latest writable root filesystem checkpoint, but not running processes, memory, sockets, PID state, or live REPL sessions.
+- Volumes are the durable workspace surface for data that must outlive one sandbox identity, be shared, snapshotted, forked, restored, or accessed directly through APIs.
+
+Design long-running agents so the runtime can be replaced and the volume or external store remains the source of truth.
+
+## Safety, Networking, And Credentials
 
 Sandbox0 is designed for workloads that execute code the host should not trust.
 
 - Each sandbox is a separate runtime instance created from a template.
-- Sandbox lifetime is controlled with `ttl` and `hard_ttl`; idle work can pause while durable state remains in volumes.
-- Network policy can block or restrict outbound traffic by default.
+- Network policy can default to `block-all` and allow only explicit destinations.
+- Protocol controls can restrict remote MCP tool calls after destination traffic is allowed.
 - Egress auth resolves and injects credentials outside the sandbox process, so raw secrets do not need to be placed in environment variables or files inside untrusted code.
-- Sandbox0 checkpoints the sandbox writable root filesystem across clean/restore, while volumes remain the explicit durable storage surface for snapshots, sharing, and long-lived workspace data.
+- SSH egress auth can proxy Git-over-SSH without writing the upstream private key into the sandbox.
+- Sandbox Services enforce route auth, CORS, rate limits, timeouts, and path policy before public traffic reaches the sandbox.
 - Self-hosted deployments let platform teams choose the Kubernetes runtime, storage, network, and regional boundary that match their security requirements.
 
 Isolation strength depends on your deployment choices. For production self-hosting, review the self-hosted docs and choose runtime, CNI, storage, and credential policies deliberately.
@@ -160,10 +225,11 @@ Isolation strength depends on your deployment choices. For production self-hosti
 
 Agent workloads are latency-sensitive because every tool call can sit on the critical path of a user interaction.
 
-Sandbox0 optimizes for this in three places:
+Sandbox0 optimizes for this in these places:
 
-- **Warm pools** keep template instances ready so a claim does not need to build the environment from scratch.
-- **Rootfs checkpoints and volumes** keep restored sandboxes useful after cleanup. Use the rootfs checkpoint for transparent runtime restore and volumes for explicit durable workspaces, snapshots, and shared data.
+- **Warm pools** keep template instances ready so a claim can reuse an idle pod instead of starting the environment from scratch.
+- **Template images** move expensive package, toolchain, browser, and agent framework setup out of the request path.
+- **Rootfs checkpoints and volumes** keep resumed sandboxes useful after runtime cleanup. Use the rootfs checkpoint for transparent runtime restore and volumes for explicit durable workspaces, snapshots, forks, and shared data.
 
 For best results, put expensive environment setup into the template image, keep active task state in a volume when it must outlive the sandbox identity, and keep sandboxes short-lived enough that idle compute does not become the source of truth.
 
@@ -176,6 +242,15 @@ Self-hosting is operator-first:
 1. Install `infra-operator`.
 2. Apply a `Sandbox0Infra` resource.
 3. Let the operator reconcile gateways, manager, storage, networking, and supporting services.
+
+Common deployment shapes:
+
+| Profile | Use when |
+| ------- | -------- |
+| Minimal single-cluster | You want a fast first install for local eval or API validation. |
+| Full single-cluster | You need persistent volumes, snapshots, public sandbox services, or network controls. |
+| Multi-cluster control plane | You coordinate multiple data-plane clusters in one region. |
+| Multi-cluster data plane | You attach a runtime cluster to an external regional control plane. |
 
 Start here: <https://sandbox0.ai/docs/self-hosted>
 


### PR DESCRIPTION
## Summary
- Repositions the README around enterprise AI agent platform needs instead of starting with internal primitives.
- Adds first-class paths for Raw Sandboxes, Agent in Sandbox, Managed Agents, and Self-hosted deployments.
- Adds Hermes/OpenClaw Agent in Sandbox coverage, plus clearer persistence, network, credential, service, and self-hosting guidance.

## Validation
- `git diff --check`

No build or test suite was run because this is a README-only change.
