### PR TITLE
Fix netd domain conntrack cleanup

### DIFF
--- a/netd/pkg/conntrack/manager.go
+++ b/netd/pkg/conntrack/manager.go
@@ -25,6 +25,8 @@ type FlowKey struct {
 	DstIP   netip.Addr
 	SrcPort uint16
 	DstPort uint16
+	Host    string
+	App     string
 }
 
 func NewManager(logger *zap.Logger) (*Manager, error) {

--- a/netd/pkg/daemon/conntrack_cleanup_test.go
+++ b/netd/pkg/daemon/conntrack_cleanup_test.go
@@ -1,0 +1,90 @@
+package daemon
+
+import (
+	"context"
+	"net/netip"
+	"testing"
+
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
+	"github.com/sandbox0-ai/sandbox0/netd/pkg/conntrack"
+	"github.com/sandbox0-ai/sandbox0/netd/pkg/policy"
+	"github.com/sandbox0-ai/sandbox0/netd/pkg/watcher"
+)
+
+func TestCleanupDeniedTrackedFlowsKeepsDomainAllowedTLSFlow(t *testing.T) {
+	const podIP = "172.28.23.117"
+	tracker := conntrack.NewTracker()
+	tracker.Record(testFlowKey(t, podIP, "172.67.213.44", "app.storenoviq.com", "tls"))
+
+	store := testPolicyStore(t, podIP, &v1alpha1.NetworkPolicySpec{
+		SandboxID: "sbx-test",
+		TeamID:    "team-test",
+		Mode:      v1alpha1.NetworkModeBlockAll,
+		Egress: &v1alpha1.NetworkEgressPolicy{
+			AllowedDomains: []string{"app.storenoviq.com"},
+		},
+	})
+
+	if killed := cleanupDeniedTrackedFlows(context.Background(), tracker, nil, store, podIP); killed != 0 {
+		t.Fatalf("cleanupDeniedTrackedFlows killed %d flows, want 0", killed)
+	}
+}
+
+func TestCleanupDeniedTrackedFlowsKillsDomainDeniedTLSFlow(t *testing.T) {
+	const podIP = "172.28.23.117"
+	tracker := conntrack.NewTracker()
+	tracker.Record(testFlowKey(t, podIP, "172.67.213.44", "blocked.example.com", "tls"))
+
+	store := testPolicyStore(t, podIP, &v1alpha1.NetworkPolicySpec{
+		SandboxID: "sbx-test",
+		TeamID:    "team-test",
+		Mode:      v1alpha1.NetworkModeBlockAll,
+		Egress: &v1alpha1.NetworkEgressPolicy{
+			AllowedDomains: []string{"app.storenoviq.com"},
+		},
+	})
+
+	if killed := cleanupDeniedTrackedFlows(context.Background(), tracker, nil, store, podIP); killed != 1 {
+		t.Fatalf("cleanupDeniedTrackedFlows killed %d flows, want 1", killed)
+	}
+}
+
+func testFlowKey(t *testing.T, srcIP string, dstIP string, host string, app string) conntrack.FlowKey {
+	t.Helper()
+	src, err := netip.ParseAddr(srcIP)
+	if err != nil {
+		t.Fatalf("parse src ip: %v", err)
+	}
+	dst, err := netip.ParseAddr(dstIP)
+	if err != nil {
+		t.Fatalf("parse dst ip: %v", err)
+	}
+	return conntrack.FlowKey{
+		Proto:   6,
+		SrcIP:   src,
+		DstIP:   dst,
+		SrcPort: 42123,
+		DstPort: 443,
+		Host:    host,
+		App:     app,
+	}
+}
+
+func testPolicyStore(t *testing.T, podIP string, spec *v1alpha1.NetworkPolicySpec) *policy.Store {
+	t.Helper()
+	annotation, err := v1alpha1.NetworkPolicyToAnnotation(spec)
+	if err != nil {
+		t.Fatalf("serialize network policy: %v", err)
+	}
+	store := policy.NewStore(nil)
+	store.ReconcileSandboxes([]*watcher.SandboxInfo{{
+		Namespace:         "default",
+		Name:              "sandbox-test",
+		PodIP:             podIP,
+		SandboxID:         spec.SandboxID,
+		TeamID:            spec.TeamID,
+		NetworkPolicy:     annotation,
+		NetworkPolicyHash: "hash-test",
+	}})
+	return store
+}

--- a/netd/pkg/daemon/daemon.go
+++ b/netd/pkg/daemon/daemon.go
@@ -603,7 +603,11 @@ func cleanupDeniedTrackedFlows(
 		if flow.Proto == 17 {
 			proto = "udp"
 		}
-		if !policy.AllowEgressL4(p, net.IP(flow.DstIP.AsSlice()), int(flow.DstPort), proto) {
+		allowed := policy.AllowEgressL4(p, net.IP(flow.DstIP.AsSlice()), int(flow.DstPort), proto)
+		if flow.Host != "" || flow.App != "" {
+			allowed = policy.AllowEgressDestination(p, net.IP(flow.DstIP.AsSlice()), int(flow.DstPort), proto, flow.Host, flow.App)
+		}
+		if !allowed {
 			flowsToKill = append(flowsToKill, flow)
 		}
 	}

--- a/netd/pkg/proxy/adapter_base.go
+++ b/netd/pkg/proxy/adapter_base.go
@@ -70,7 +70,7 @@ func (a *httpAdapter) Handle(req *adapterRequest) error {
 	if req == nil || req.Server == nil || req.Conn == nil {
 		return fmt.Errorf("http adapter requires connection")
 	}
-	req.Server.recordFlow(req.SrcIP, req.DestIP, req.DestPort, "tcp", remotePort(req.Conn.RemoteAddr()))
+	req.Server.recordFlow(req.SrcIP, req.DestIP, req.DestPort, "tcp", remotePort(req.Conn.RemoteAddr()), req.Host, "http")
 	if req.EgressAuth != nil && req.EgressAuth.Rule != nil {
 		if !egressAuthNeedsHTTPMatch(req) {
 			if err := prepareHTTPHeaderDirectives(req.EgressAuth, "http", true); err != nil {
@@ -159,7 +159,7 @@ func (a *tlsAdapter) Handle(req *adapterRequest) error {
 	if req == nil || req.Server == nil || req.Conn == nil {
 		return fmt.Errorf("tls adapter requires connection")
 	}
-	req.Server.recordFlow(req.SrcIP, req.DestIP, req.DestPort, "tcp", remotePort(req.Conn.RemoteAddr()))
+	req.Server.recordFlow(req.SrcIP, req.DestIP, req.DestPort, "tcp", remotePort(req.Conn.RemoteAddr()), req.Host, "tls")
 	if req.EgressAuth != nil && req.EgressAuth.Rule != nil {
 		if req.EgressAuth.Rule.Protocol == v1alpha1.EgressAuthProtocolTLS {
 			if err := prepareTLSClientCertificateDirectives(req.EgressAuth, "tls", tlsTerminationRequired(req)); err != nil {
@@ -215,7 +215,7 @@ func (a *sshAdapter) Handle(req *adapterRequest) error {
 	if req == nil || req.Server == nil || req.Conn == nil {
 		return fmt.Errorf("ssh adapter requires connection")
 	}
-	req.Server.recordFlow(req.SrcIP, req.DestIP, req.DestPort, "tcp", remotePort(req.Conn.RemoteAddr()))
+	req.Server.recordFlow(req.SrcIP, req.DestIP, req.DestPort, "tcp", remotePort(req.Conn.RemoteAddr()), req.Host, "ssh")
 	if req.EgressAuth != nil && req.EgressAuth.Rule != nil {
 		if err := prepareSSHProxyDirectives(req.EgressAuth, "ssh", true); err != nil {
 			if req.EgressAuth.ShouldBypass() {
@@ -257,7 +257,7 @@ func (a *socks5Adapter) Handle(req *adapterRequest) error {
 	if req == nil || req.Server == nil || req.Conn == nil {
 		return fmt.Errorf("socks5 adapter requires connection")
 	}
-	req.Server.recordFlow(req.SrcIP, req.DestIP, req.DestPort, "tcp", remotePort(req.Conn.RemoteAddr()))
+	req.Server.recordFlow(req.SrcIP, req.DestIP, req.DestPort, "tcp", remotePort(req.Conn.RemoteAddr()), req.Host, "socks5")
 	if req.EgressAuth != nil && req.EgressAuth.Rule != nil {
 		if err := prepareUsernamePasswordDirectives(req.EgressAuth, "socks5", true); err != nil {
 			if req.EgressAuth.ShouldBypass() {
@@ -295,7 +295,7 @@ func (a *amqpAdapter) Handle(req *adapterRequest) error {
 	if req == nil || req.Server == nil || req.Conn == nil {
 		return fmt.Errorf("amqp adapter requires connection")
 	}
-	req.Server.recordFlow(req.SrcIP, req.DestIP, req.DestPort, "tcp", remotePort(req.Conn.RemoteAddr()))
+	req.Server.recordFlow(req.SrcIP, req.DestIP, req.DestPort, "tcp", remotePort(req.Conn.RemoteAddr()), req.Host, "amqp")
 	return req.Server.relayTCPRequest(req)
 }
 
@@ -328,7 +328,7 @@ func (a *mqttAdapter) Handle(req *adapterRequest) error {
 	if req == nil || req.Server == nil || req.Conn == nil {
 		return fmt.Errorf("mqtt adapter requires connection")
 	}
-	req.Server.recordFlow(req.SrcIP, req.DestIP, req.DestPort, "tcp", remotePort(req.Conn.RemoteAddr()))
+	req.Server.recordFlow(req.SrcIP, req.DestIP, req.DestPort, "tcp", remotePort(req.Conn.RemoteAddr()), req.Host, "mqtt")
 	if req.EgressAuth != nil && req.EgressAuth.Rule != nil {
 		if err := prepareUsernamePasswordDirectives(req.EgressAuth, "mqtt", true); err != nil {
 			if req.EgressAuth.ShouldBypass() {
@@ -366,7 +366,7 @@ func (a *mongodbAdapter) Handle(req *adapterRequest) error {
 	if req == nil || req.Server == nil || req.Conn == nil {
 		return fmt.Errorf("mongodb adapter requires connection")
 	}
-	req.Server.recordFlow(req.SrcIP, req.DestIP, req.DestPort, "tcp", remotePort(req.Conn.RemoteAddr()))
+	req.Server.recordFlow(req.SrcIP, req.DestIP, req.DestPort, "tcp", remotePort(req.Conn.RemoteAddr()), req.Host, "mongodb")
 	return req.Server.relayTCPRequest(req)
 }
 
@@ -383,7 +383,7 @@ func (a *redisAdapter) Handle(req *adapterRequest) error {
 	if req == nil || req.Server == nil || req.Conn == nil {
 		return fmt.Errorf("redis adapter requires connection")
 	}
-	req.Server.recordFlow(req.SrcIP, req.DestIP, req.DestPort, "tcp", remotePort(req.Conn.RemoteAddr()))
+	req.Server.recordFlow(req.SrcIP, req.DestIP, req.DestPort, "tcp", remotePort(req.Conn.RemoteAddr()), req.Host, "redis")
 	if req.EgressAuth != nil && req.EgressAuth.Rule != nil {
 		if err := prepareUsernamePasswordDirectives(req.EgressAuth, "redis", true); err != nil {
 			if req.EgressAuth.ShouldBypass() {
@@ -421,7 +421,7 @@ func (a *udpAdapter) Handle(req *adapterRequest) error {
 	if req == nil || req.Server == nil || req.UDPConn == nil || req.UDPSource == nil {
 		return fmt.Errorf("udp adapter requires source datagram")
 	}
-	req.Server.recordFlow(req.SrcIP, req.DestIP, req.DestPort, "udp", req.UDPSource.Port)
+	req.Server.recordFlow(req.SrcIP, req.DestIP, req.DestPort, "udp", req.UDPSource.Port, req.Host, "udp")
 	return req.Server.forwardUDPDatagram(req.UDPConn, req.UDPSource, req.UDPPayload, req.DestIP, req.DestPort, req.Compiled, req.Audit)
 }
 
@@ -438,7 +438,7 @@ func (a *tcpPassThroughAdapter) Handle(req *adapterRequest) error {
 	if req == nil || req.Server == nil || req.Conn == nil {
 		return fmt.Errorf("tcp fallback adapter requires connection")
 	}
-	req.Server.recordFlow(req.SrcIP, req.DestIP, req.DestPort, "tcp", remotePort(req.Conn.RemoteAddr()))
+	req.Server.recordFlow(req.SrcIP, req.DestIP, req.DestPort, "tcp", remotePort(req.Conn.RemoteAddr()), req.Host, "unknown")
 	return req.Server.relayTCPRequest(req)
 }
 
@@ -455,6 +455,6 @@ func (a *udpPassThroughAdapter) Handle(req *adapterRequest) error {
 	if req == nil || req.Server == nil || req.UDPConn == nil || req.UDPSource == nil {
 		return fmt.Errorf("udp fallback adapter requires source datagram")
 	}
-	req.Server.recordFlow(req.SrcIP, req.DestIP, req.DestPort, "udp", req.UDPSource.Port)
+	req.Server.recordFlow(req.SrcIP, req.DestIP, req.DestPort, "udp", req.UDPSource.Port, req.Host, "unknown")
 	return req.Server.forwardUDPDatagram(req.UDPConn, req.UDPSource, req.UDPPayload, req.DestIP, req.DestPort, req.Compiled, req.Audit)
 }

--- a/netd/pkg/proxy/dns_cache.go
+++ b/netd/pkg/proxy/dns_cache.go
@@ -574,7 +574,7 @@ func (s *Server) proxyDNSTCP(req *adapterRequest) error {
 	if req.DestIP == nil || req.DestPort <= 0 {
 		return fmt.Errorf("missing destination")
 	}
-	s.recordFlow(req.SrcIP, req.DestIP, req.DestPort, "tcp", remotePort(req.Conn.RemoteAddr()))
+	s.recordFlow(req.SrcIP, req.DestIP, req.DestPort, "tcp", remotePort(req.Conn.RemoteAddr()), req.Host, "dns")
 	upstream := req.UpstreamConn
 	var err error
 	if upstream == nil {

--- a/netd/pkg/proxy/server.go
+++ b/netd/pkg/proxy/server.go
@@ -1008,13 +1008,13 @@ func (s *Server) runPassThrough(adapter proxyAdapter, req *adapterRequest) error
 		if req.Conn == nil {
 			return fmt.Errorf("tcp pass-through requires connection")
 		}
-		s.recordFlow(req.SrcIP, req.DestIP, req.DestPort, "tcp", remotePort(req.Conn.RemoteAddr()))
+		s.recordFlow(req.SrcIP, req.DestIP, req.DestPort, "tcp", remotePort(req.Conn.RemoteAddr()), req.Host, "unknown")
 		return s.relayTCPRequestWithUpstream(req, req.Prefix, req.UpstreamConn, req.UpstreamPrefix)
 	case "udp":
 		if req.UDPConn == nil || req.UDPSource == nil {
 			return fmt.Errorf("udp pass-through requires source datagram")
 		}
-		s.recordFlow(req.SrcIP, req.DestIP, req.DestPort, "udp", req.UDPSource.Port)
+		s.recordFlow(req.SrcIP, req.DestIP, req.DestPort, "udp", req.UDPSource.Port, req.Host, "unknown")
 		return s.forwardUDPDatagram(req.UDPConn, req.UDPSource, req.UDPPayload, req.DestIP, req.DestPort, req.Compiled, req.Audit)
 	default:
 		return fmt.Errorf("unsupported pass-through transport %q", adapter.Transport())
@@ -1133,7 +1133,7 @@ func normalizeRelayError(err error) error {
 	return err
 }
 
-func (s *Server) recordFlow(srcIP string, dstIP net.IP, dstPort int, proto string, srcPort int) {
+func (s *Server) recordFlow(srcIP string, dstIP net.IP, dstPort int, proto string, srcPort int, host string, app string) {
 	if s.tracker == nil {
 		return
 	}
@@ -1163,6 +1163,8 @@ func (s *Server) recordFlow(srcIP string, dstIP net.IP, dstPort int, proto strin
 		DstIP:   dstAddr,
 		SrcPort: uint16(srcPort),
 		DstPort: uint16(dstPort),
+		Host:    normalizeHost(host),
+		App:     strings.ToLower(strings.TrimSpace(app)),
 	})
 }
 


### PR DESCRIPTION
## Summary

- Preserve classified host/app context in netd tracked flows.
- Re-evaluate tracked flows with host/app policy context during policy-change conntrack cleanup.
- Add regression coverage for block-all domain-allowed TLS flows so active SNI-allowed connections are not killed as L4-denied.

## Context

For block-all policies that allow egress by domain only, the cleanup path previously rechecked tracked flows with L4 context only. A valid TLS flow such as `app.storenoviq.com:443` could be misclassified as denied during a policy update and have its conntrack entry deleted, surfacing to clients as TLS handshake timeout / downstream EOF.

## Tests

- `go test ./netd/pkg/daemon -count=1 -timeout=120s`
- `go test ./netd/pkg/proxy -run '^$' -count=1 -timeout=120s`
- `go test ./netd/pkg/conntrack -count=1 -timeout=120s`
