### PR TITLE
Restore rootfs across base image changes

### DIFF
--- a/ctld/internal/ctld/rootfs/controller.go
+++ b/ctld/internal/ctld/rootfs/controller.go
@@ -258,28 +258,7 @@ func validateExpectedBase(info ctldapi.RootFSInfo, req ctldapi.ApplyRootFSReques
 	if expected := strings.TrimSpace(req.ExpectedSnapshotter); expected != "" && strings.TrimSpace(info.Snapshotter) != expected {
 		return fmt.Errorf("%w: snapshotter mismatch: expected %s, got %s", ErrConflict, expected, info.Snapshotter)
 	}
-	if expected := strings.TrimSpace(req.ExpectedBaseImageDigest); expected != "" && strings.TrimSpace(info.BaseImageDigest) != expected {
-		return fmt.Errorf("%w: base image digest mismatch: expected %s, got %s", ErrConflict, expected, info.BaseImageDigest)
-	}
-	if expected := strings.TrimSpace(req.ExpectedSnapshotParent); expected != "" && strings.TrimSpace(info.SnapshotParent) != expected {
-		return fmt.Errorf("%w: snapshot parent mismatch: expected %s, got %s", ErrConflict, expected, info.SnapshotParent)
-	}
-	if len(req.ExpectedSnapshotParentChain) > 0 && !sameStringSlice(req.ExpectedSnapshotParentChain, info.SnapshotParentChain) {
-		return fmt.Errorf("%w: snapshot parent chain mismatch", ErrConflict)
-	}
 	return nil
-}
-
-func sameStringSlice(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
 }
 
 func defaultObjectKey(teamID, sandboxID string, generation int64, digest string) (string, error) {

--- a/ctld/internal/ctld/rootfs/controller_test.go
+++ b/ctld/internal/ctld/rootfs/controller_test.go
@@ -124,15 +124,24 @@ func TestControllerApplyRootFSDownloadsAndAppliesDiff(t *testing.T) {
 	assert.Equal(t, "rootfs/diff.tar", runtime.applyInputDesc.ObjectKey)
 }
 
-func TestControllerApplyRootFSRejectsBaseMismatch(t *testing.T) {
+func TestControllerApplyRootFSForceAppliesBaseMismatch(t *testing.T) {
 	store := objectstore.NewMemoryStore(t.Name())
 	require.NoError(t, store.Put("rootfs/diff.tar", strings.NewReader("rootfs diff")))
-	runtime := &fakeRuntime{info: rootFSInfo("gvisor")}
+	runtime := &fakeRuntime{
+		info: rootFSInfo("gvisor"),
+		applyDesc: ctldapi.RootFSDiffDescriptor{
+			MediaType: "application/vnd.oci.image.layer.v1.tar",
+			Digest:    "sha256:feedface",
+			Size:      int64(len("rootfs diff")),
+		},
+	}
 	controller := NewController(Config{Runtime: runtime, Store: store})
 
 	resp, status := controller.ApplyRootFS(httptest.NewRequest(http.MethodPost, "/", nil), ctldapi.ApplyRootFSRequest{
-		Target:                  rootFSTarget(),
-		ExpectedBaseImageDigest: "sha256:other-base",
+		Target:                      rootFSTarget(),
+		ExpectedBaseImageDigest:     "sha256:other-base",
+		ExpectedSnapshotParent:      "other-parent",
+		ExpectedSnapshotParentChain: []string{"other-parent"},
 		Descriptor: ctldapi.RootFSDiffDescriptor{
 			MediaType: "application/vnd.oci.image.layer.v1.tar",
 			Digest:    "sha256:feedface",
@@ -141,9 +150,10 @@ func TestControllerApplyRootFSRejectsBaseMismatch(t *testing.T) {
 		},
 	})
 
-	require.Equal(t, http.StatusConflict, status)
-	assert.Contains(t, resp.Error, "base image digest mismatch")
-	assert.False(t, runtime.applyCalled)
+	require.Equal(t, http.StatusOK, status, resp.Error)
+	assert.True(t, resp.Applied)
+	assert.True(t, runtime.applyCalled)
+	assert.Equal(t, "rootfs diff", runtime.applyContent)
 }
 
 func TestControllerApplyRootFSRejectsRuntimeMismatch(t *testing.T) {

--- a/docs/sandbox/pause-resume/page.mdx
+++ b/docs/sandbox/pause-resume/page.mdx
@@ -60,6 +60,8 @@ console.log("Pause requested");`
 
 Resume a sandbox that was paused manually or by TTL expiry.
 
+Resume first restores the writable rootfs checkpoint onto a runtime pod created from the current template image. If that restore fails, Sandbox0 retries once with a runtime pod pinned to the checkpoint's recorded base image digest. Kubernetes pulls and garbage-collects that image through the normal kubelet image lifecycle.
+
 <Endpoint method="POST">
 /api/v1/sandboxes/{'{id}'}/resume
 </Endpoint>

--- a/manager/pkg/service/sandbox_service_restore.go
+++ b/manager/pkg/service/sandbox_service_restore.go
@@ -134,7 +134,8 @@ func (s *SandboxService) finishRestoredSandboxRuntime(ctx context.Context, pod *
 	if err != nil {
 		return fmt.Errorf("load rootfs checkpoint: %w", err)
 	}
-	if err := s.applySandboxRootFSCheckpoint(ctx, pod, rootFSState); err != nil {
+	pod, err = s.applySandboxRootFSCheckpointWithFallback(ctx, pod, record, template, req, rootFSState)
+	if err != nil {
 		return err
 	}
 	if _, err := s.bindVolumePortals(ctx, pod, req, template); err != nil {

--- a/manager/pkg/service/sandbox_service_rootfs.go
+++ b/manager/pkg/service/sandbox_service_rootfs.go
@@ -6,8 +6,11 @@ import (
 	"strings"
 	"time"
 
+	godigest "github.com/opencontainers/go-digest"
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
+	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -102,6 +105,113 @@ func (s *SandboxService) applySandboxRootFSCheckpoint(ctx context.Context, pod *
 		return fmt.Errorf("apply sandbox rootfs checkpoint: ctld did not report applied")
 	}
 	return nil
+}
+
+func (s *SandboxService) applySandboxRootFSCheckpointWithFallback(ctx context.Context, pod *corev1.Pod, record *SandboxRecord, template *v1alpha1.SandboxTemplate, req *ClaimRequest, state *SandboxRootFSState) (*corev1.Pod, error) {
+	if state == nil {
+		return pod, nil
+	}
+	err := s.applySandboxRootFSCheckpoint(ctx, pod, state)
+	if err == nil {
+		return pod, nil
+	}
+	fallbackTemplate, fallbackErr := templateWithCheckpointBaseImage(template, state)
+	if fallbackErr != nil {
+		return nil, fmt.Errorf("%w; checkpoint base image fallback unavailable: %v", err, fallbackErr)
+	}
+	if s != nil && s.logger != nil {
+		s.logger.Warn("Rootfs force-apply failed; retrying with checkpoint base image",
+			zap.String("sandboxID", state.SandboxID),
+			zap.String("baseImageRef", state.BaseImageRef),
+			zap.String("baseImageDigest", state.BaseImageDigest),
+			zap.Error(err),
+		)
+	}
+	s.requestSandboxDeletionAfterClaimFailure(pod, "rootfs force-apply failed")
+
+	fallbackPod, fallbackErr := s.createNewPod(ctx, fallbackTemplate, req)
+	if fallbackErr != nil {
+		return nil, fmt.Errorf("%w; create checkpoint base image runtime: %v", err, fallbackErr)
+	}
+	readyPod, fallbackErr := s.waitForPodClaimReady(ctx, fallbackPod.Namespace, fallbackPod.Name)
+	if fallbackErr != nil {
+		s.requestSandboxDeletionAfterClaimFailure(fallbackPod, "checkpoint base image runtime readiness failed")
+		return nil, fmt.Errorf("%w; wait for checkpoint base image runtime: %v", err, fallbackErr)
+	}
+	if fallbackErr := s.saveRestoredRuntimePod(ctx, readyPod, record, SandboxStatusResuming); fallbackErr != nil {
+		s.requestSandboxDeletionAfterClaimFailure(readyPod, "checkpoint base image runtime persistence failed")
+		return nil, fmt.Errorf("%w; save checkpoint base image runtime: %v", err, fallbackErr)
+	}
+	if fallbackErr := s.applySandboxRootFSCheckpoint(ctx, readyPod, state); fallbackErr != nil {
+		s.requestSandboxDeletionAfterClaimFailure(readyPod, "checkpoint base image rootfs apply failed")
+		return nil, fmt.Errorf("%w; checkpoint base image retry failed: %v", err, fallbackErr)
+	}
+	return readyPod, nil
+}
+
+func (s *SandboxService) saveRestoredRuntimePod(ctx context.Context, pod *corev1.Pod, record *SandboxRecord, status string) error {
+	if s == nil || s.sandboxStore == nil || pod == nil || record == nil {
+		return nil
+	}
+	sandboxID := strings.TrimSpace(record.ID)
+	if sandboxID == "" {
+		sandboxID = sandboxIDFromPod(pod)
+	}
+	if sandboxID == "" {
+		return fmt.Errorf("sandbox_id is required")
+	}
+	return s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, _ *SandboxRecord) error {
+		return tx.SaveRuntime(lockCtx, sandboxID, pod.Namespace, pod.Name, status, runtimeGenerationFromPod(pod), parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationExpiresAt), parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationHardExpiresAt))
+	})
+}
+
+func templateWithCheckpointBaseImage(template *v1alpha1.SandboxTemplate, state *SandboxRootFSState) (*v1alpha1.SandboxTemplate, error) {
+	if template == nil {
+		return nil, fmt.Errorf("template is required")
+	}
+	image, err := checkpointBaseImageRef(state)
+	if err != nil {
+		return nil, err
+	}
+	clone := template.DeepCopy()
+	clone.Spec.MainContainer.Image = image
+	clone.Spec.MainContainer.ImagePullPolicy = string(corev1.PullIfNotPresent)
+	return clone, nil
+}
+
+func checkpointBaseImageRef(state *SandboxRootFSState) (string, error) {
+	if state == nil {
+		return "", fmt.Errorf("rootfs state is required")
+	}
+	repo := imageRepositoryFromRef(state.BaseImageRef)
+	if repo == "" {
+		return "", fmt.Errorf("base image ref is required")
+	}
+	digestValue := strings.TrimSpace(state.BaseImageDigest)
+	if digestValue == "" {
+		return "", fmt.Errorf("base image digest is required")
+	}
+	parsed, err := godigest.Parse(digestValue)
+	if err != nil {
+		return "", fmt.Errorf("base image digest %q is invalid: %w", digestValue, err)
+	}
+	return repo + "@" + parsed.String(), nil
+}
+
+func imageRepositoryFromRef(ref string) string {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return ""
+	}
+	if idx := strings.LastIndex(ref, "@"); idx >= 0 {
+		ref = ref[:idx]
+	}
+	lastSlash := strings.LastIndex(ref, "/")
+	lastColon := strings.LastIndex(ref, ":")
+	if lastColon > lastSlash {
+		ref = ref[:lastColon]
+	}
+	return strings.TrimSpace(ref)
 }
 
 func (s *SandboxService) latestRootFSState(ctx context.Context, sandboxID string) (*SandboxRootFSState, error) {

--- a/manager/pkg/service/sandbox_service_rootfs_test.go
+++ b/manager/pkg/service/sandbox_service_rootfs_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -15,6 +16,8 @@ import (
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
+	"github.com/sandbox0-ai/sandbox0/pkg/naming"
+	"github.com/sandbox0-ai/sandbox0/pkg/sandboxprobe"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -23,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
+	corelisters "k8s.io/client-go/listers/core/v1"
 	ktesting "k8s.io/client-go/testing"
 )
 
@@ -171,6 +175,155 @@ func TestFinishRestoredSandboxRuntimeAppliesRootFSBeforeProcdInitialization(t *t
 
 	require.NoError(t, svc.finishRestoredSandboxRuntime(context.Background(), pod, record, "hot"))
 	assert.Equal(t, []string{"apply", "procd"}, calls)
+}
+
+func TestFinishRestoredSandboxRuntimeRetriesWithCheckpointBaseImage(t *testing.T) {
+	withClaimTestPublicKey(t)
+
+	const checkpointDigest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	templateNamespace, err := naming.TemplateNamespaceForTeam("team-1")
+	require.NoError(t, err)
+
+	var applyTargets []string
+	ctld := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v1/rootfs/apply":
+			var req ctldapi.ApplyRootFSRequest
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+			applyTargets = append(applyTargets, req.Target.PodName)
+			assert.Equal(t, checkpointDigest, req.ExpectedBaseImageDigest)
+			if req.Target.PodName == "pod-current" {
+				w.WriteHeader(http.StatusInternalServerError)
+				_ = json.NewEncoder(w).Encode(ctldapi.ApplyRootFSResponse{Error: "apply rootfs diff: simulated conflict"})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(ctldapi.ApplyRootFSResponse{Applied: true})
+		case strings.HasSuffix(r.URL.Path, "/probes/readiness"):
+			_ = json.NewEncoder(w).Encode(sandboxprobe.Passed(sandboxprobe.KindReadiness, "SandboxProbePassed", "sandbox probe passed", nil))
+		case r.URL.Path == "/api/v1/volume-portals/check":
+			_ = json.NewEncoder(w).Encode(ctldapi.CheckVolumePortalsResponse{Ready: true})
+		default:
+			t.Fatalf("unexpected ctld path: %s", r.URL.Path)
+		}
+	}))
+	defer ctld.Close()
+	ctldURL, ctldPort := parsedTestServer(t, ctld.URL)
+
+	procd := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/initialize", r.URL.Path)
+		require.Len(t, applyTargets, 2)
+		require.NoError(t, spec.WriteSuccess(w, http.StatusOK, InitializeResponse{SandboxID: "sandbox-1", TeamID: "team-1"}))
+	}))
+	defer procd.Close()
+	procdURL, procdPort := parsedTestServer(t, procd.URL)
+
+	currentPod := rootFSTestPod("pod-current", "sandbox-1", "team-1")
+	currentPod.Namespace = templateNamespace
+	currentPod.Status.HostIP = ctldURL.Hostname()
+	currentPod.Status.PodIP = procdURL.Hostname()
+	indexer := newClaimTestPodIndexer(t, currentPod)
+	k8sClient := fake.NewSimpleClientset(currentPod)
+	var fallbackImage string
+	k8sClient.PrependReactor("create", "pods", func(action ktesting.Action) (bool, runtime.Object, error) {
+		pod := action.(ktesting.CreateAction).GetObject().(*corev1.Pod).DeepCopy()
+		require.Len(t, pod.Spec.Containers, 1)
+		fallbackImage = pod.Spec.Containers[0].Image
+
+		readyPod := pod.DeepCopy()
+		readyPod.UID = types.UID("fallback-uid")
+		readyPod.Status.Phase = corev1.PodRunning
+		readyPod.Status.HostIP = ctldURL.Hostname()
+		readyPod.Status.PodIP = procdURL.Hostname()
+		readyPod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+			Name:  "procd",
+			State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+		}}
+		require.NoError(t, indexer.Add(readyPod))
+		return false, nil, nil
+	})
+
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "template-1",
+			Namespace: templateNamespace,
+		},
+		Spec: v1alpha1.SandboxTemplateSpec{
+			MainContainer: v1alpha1.ContainerSpec{Image: "docker.io/library/busybox:1.37"},
+		},
+	}
+	store := &memorySandboxStore{
+		records: map[string]*SandboxRecord{
+			"sandbox-1": {
+				ID:                  "sandbox-1",
+				TeamID:              "team-1",
+				UserID:              "user-1",
+				TemplateID:          "template-1",
+				TemplateName:        "template-1",
+				TemplateNamespace:   templateNamespace,
+				TemplateSpec:        template.Spec,
+				CurrentPodName:      "pod-current",
+				CurrentPodNamespace: templateNamespace,
+				RuntimeGeneration:   3,
+				Status:              SandboxStatusResuming,
+			},
+		},
+		rootFSStates: map[string]*SandboxRootFSState{
+			"sandbox-1": {
+				SandboxID:           "sandbox-1",
+				TeamID:              "team-1",
+				RuntimeGeneration:   3,
+				Runtime:             "runc",
+				RuntimeHandler:      "io.containerd.runc.v2",
+				BaseImageRef:        "docker.io/library/busybox:1.36",
+				BaseImageDigest:     checkpointDigest,
+				Snapshotter:         "overlayfs",
+				SnapshotParent:      "parent-1",
+				SnapshotParentChain: []string{"parent-1", "parent-0"},
+				DiffDigest:          "sha256:diff",
+				DiffMediaType:       "application/vnd.oci.image.layer.v1.tar",
+				DiffSize:            123,
+				DiffObjectKey:       "sandbox-rootfs/team-1/sandbox-1/3/sha256/diff.tar",
+			},
+		},
+	}
+	svc := &SandboxService{
+		k8sClient:              k8sClient,
+		podLister:              corelisters.NewPodLister(indexer),
+		secretLister:           newClaimTestSecretLister(t),
+		templateLister:         staticTemplateLister{templates: []*v1alpha1.SandboxTemplate{template}},
+		sandboxStore:           store,
+		ctldClient:             NewCtldClient(CtldClientConfig{Timeout: time.Second}),
+		procdClient:            NewProcdClient(ProcdClientConfig{Timeout: time.Second}),
+		internalTokenGenerator: staticTokenGenerator{},
+		config: SandboxServiceConfig{
+			CtldEnabled:      true,
+			CtldPort:         ctldPort,
+			ProcdPort:        procdPort,
+			ProcdInitTimeout: time.Second,
+		},
+		clock:  systemTime{},
+		logger: zap.NewNop(),
+	}
+	record := store.records["sandbox-1"]
+
+	require.NoError(t, svc.finishRestoredSandboxRuntime(context.Background(), currentPod, record, "hot"))
+
+	require.Len(t, applyTargets, 2)
+	assert.Equal(t, "pod-current", applyTargets[0])
+	assert.NotEqual(t, "pod-current", applyTargets[1])
+	assert.Equal(t, "docker.io/library/busybox@"+checkpointDigest, fallbackImage)
+	assert.Equal(t, applyTargets[1], store.records["sandbox-1"].CurrentPodName)
+	assert.Equal(t, SandboxStatusRunning, store.records["sandbox-1"].Status)
+}
+
+func TestCheckpointBaseImageRefPinsDigest(t *testing.T) {
+	ref, err := checkpointBaseImageRef(&SandboxRootFSState{
+		BaseImageRef:    "registry.example.com:5000/team/image:old-tag",
+		BaseImageDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "registry.example.com:5000/team/image@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", ref)
 }
 
 func TestRestoreFailureCleanupCanSkipRootFSSave(t *testing.T) {


### PR DESCRIPTION
Closes #423

## Summary
- remove ctld's strict 409 on base image digest and snapshot parent mismatches so rootfs restore force-applies onto the current template image
- retry restore once on a new runtime pod pinned to the checkpoint's recorded base image digest when force-apply fails
- document that fallback image pull and cleanup go through kubelet's normal image lifecycle

## Tests
- `go test ./ctld/internal/ctld/rootfs`
- `go test ./manager/pkg/service -run 'TestFinishRestoredSandboxRuntime|TestCheckpointBaseImageRef|TestRestoreFailureCleanupCanSkipRootFSSave|TestPauseSandboxRuntimeSavesRootFS'`
- `git diff --check`

## Manual validation
Pending: remote test machine was checked before use; validation will run only while it is `Stopped` to avoid conflicts.
