### PR TITLE
Update E2E default template image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ GO ?= env GOWORK=off go
 SERVICES := regional-gateway ssh-gateway global-gateway cluster-gateway manager scheduler storage-proxy ctld procd netd infra-operator
 E2E_SSH_FIXTURE_SOURCE_IMAGE := lscr.io/linuxserver/openssh-server@sha256:68b605929e83b2efe000da09269688f6d82a44579e8a18e2d9e8c8d272917cf7
 E2E_SSH_FIXTURE_IMAGE := sandbox0ai/e2e-openssh-server:68b605929e83
-E2E_DEPENDENCY_IMAGES := postgres:16-alpine rustfs/rustfs:1.0.0-alpha.79 registry:2.8.3 sandbox0ai/otemplates:default-v0.1.0 $(E2E_SSH_FIXTURE_IMAGE)
+E2E_DEPENDENCY_IMAGES := postgres:16-alpine rustfs/rustfs:1.0.0-alpha.79 registry:2.8.3 sandbox0ai/otemplates:default-v0.2.0 $(E2E_SSH_FIXTURE_IMAGE)
 E2E_IMAGE_PLATFORM ?= linux/$(shell uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')
 
 # Default version


### PR DESCRIPTION
## Summary
- update the E2E dependency image preload from `sandbox0ai/otemplates:default-v0.1.0` to `sandbox0ai/otemplates:default-v0.2.0`
- keep Kind E2E image loading aligned with `pkg/template.DefaultTemplateImage`

## Testing
- `rg -n "default-v0\\.1\\.0" sandbox0 --glob '!vendor/**'`
