### PR TITLE
Fix Sandbox0Infra hot-loop from no-op child updates

### DIFF
--- a/infra-operator/internal/controller/pkg/common/common.go
+++ b/infra-operator/internal/controller/pkg/common/common.go
@@ -29,6 +29,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -72,6 +73,16 @@ func NewResourceManager(client client.Client, scheme *runtime.Scheme, imagePullP
 		ImagePullPolicy: imagePullPolicy,
 		LocalDev:        localDev,
 	}
+}
+
+// UpdateObjectIfChanged updates obj only when mutate changes the live object.
+func (r *ResourceManager) UpdateObjectIfChanged(ctx context.Context, obj client.Object, mutate func()) error {
+	before := obj.DeepCopyObject()
+	mutate()
+	if apiequality.Semantic.DeepEqual(before, obj) {
+		return nil
+	}
+	return r.Client.Update(ctx, obj)
 }
 
 // ServiceDefinition defines deployment/daemonset configuration for a service.
@@ -179,9 +190,13 @@ func (r *ResourceManager) ReconcileDeploymentWithScope(ctx context.Context, scop
 		return r.Client.Create(ctx, desiredDeploy)
 	}
 
-	deploy.Spec = desiredDeploy.Spec
-	deploy.Labels = desiredLabels
-	return r.Client.Update(ctx, deploy)
+	return r.UpdateObjectIfChanged(ctx, deploy, func() {
+		deploy.Labels = desiredLabels
+		deploy.OwnerReferences = desiredDeploy.OwnerReferences
+		deploy.Spec.Replicas = desiredDeploy.Spec.Replicas
+		deploy.Spec.Selector = desiredDeploy.Spec.Selector
+		deploy.Spec.Template = desiredDeploy.Spec.Template
+	})
 }
 
 // EnsureDeploymentReady validates deployment readiness before reporting success.
@@ -285,6 +300,42 @@ func (r *ResourceManager) ReconcileDaemonSetWithScope(ctx context.Context, scope
 	return r.ApplyDaemonSetWithScope(ctx, scope, desiredDs)
 }
 
+// ApplyStatefulSet creates or updates a statefulset using fresh reads on each retry.
+func (r *ResourceManager) ApplyStatefulSet(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, desired *appsv1.StatefulSet) error {
+	return r.ApplyStatefulSetWithScope(ctx, NewObjectScope(infra), desired)
+}
+
+func (r *ResourceManager) ApplyStatefulSetWithScope(ctx context.Context, scope ObjectScope, desired *appsv1.StatefulSet) error {
+	if err := scope.SetControllerReference(desired, r.Scheme); err != nil {
+		return err
+	}
+
+	key := types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current := &appsv1.StatefulSet{}
+		err := r.Client.Get(ctx, key, current)
+		if errors.IsNotFound(err) {
+			return r.Client.Create(ctx, desired.DeepCopy())
+		}
+		if err != nil {
+			return err
+		}
+
+		return r.UpdateObjectIfChanged(ctx, current, func() {
+			current.Labels = desired.Labels
+			current.Annotations = desired.Annotations
+			current.OwnerReferences = desired.OwnerReferences
+			current.Spec.ServiceName = desired.Spec.ServiceName
+			current.Spec.Replicas = desired.Spec.Replicas
+			current.Spec.Selector = desired.Spec.Selector
+			current.Spec.Template = desired.Spec.Template
+			current.Spec.VolumeClaimTemplates = desired.Spec.VolumeClaimTemplates
+			current.Spec.PersistentVolumeClaimRetentionPolicy = desired.Spec.PersistentVolumeClaimRetentionPolicy
+			current.Spec.Ordinals = desired.Spec.Ordinals
+		})
+	})
+}
+
 // ApplyDaemonSet creates or updates a daemonset using fresh reads on each retry
 // so controller-driven status/resourceVersion updates do not cause reconcile
 // loops to fail on optimistic concurrency conflicts.
@@ -308,11 +359,13 @@ func (r *ResourceManager) ApplyDaemonSetWithScope(ctx context.Context, scope Obj
 			return err
 		}
 
-		current.Labels = desired.Labels
-		current.Annotations = desired.Annotations
-		current.Spec = desired.Spec
-		current.OwnerReferences = desired.OwnerReferences
-		return r.Client.Update(ctx, current)
+		return r.UpdateObjectIfChanged(ctx, current, func() {
+			current.Labels = desired.Labels
+			current.Annotations = desired.Annotations
+			current.OwnerReferences = desired.OwnerReferences
+			current.Spec.Selector = desired.Spec.Selector
+			current.Spec.Template = desired.Spec.Template
+		})
 	})
 }
 
@@ -457,10 +510,15 @@ func (r *ResourceManager) reconcileServicePorts(ctx context.Context, scope Objec
 			return err
 		}
 
-		svc.Spec = desiredSvc.Spec
-		svc.Labels = desiredLabels
-		svc.Annotations = CloneStringMap(annotations)
-		return r.Client.Update(ctx, svc)
+		return r.UpdateObjectIfChanged(ctx, svc, func() {
+			svc.Labels = desiredLabels
+			svc.Annotations = CloneStringMap(annotations)
+			svc.OwnerReferences = desiredSvc.OwnerReferences
+			svc.Spec.Type = desiredSvc.Spec.Type
+			svc.Spec.Selector = desiredSvc.Spec.Selector
+			svc.Spec.Ports = desiredSvc.Spec.Ports
+			svc.Spec.ExternalTrafficPolicy = desiredSvc.Spec.ExternalTrafficPolicy
+		})
 	})
 }
 
@@ -578,10 +636,12 @@ func (r *ResourceManager) ReconcileIngressWithScope(ctx context.Context, scope O
 		return r.Client.Create(ctx, desiredIngress)
 	}
 
-	ingress.Spec = desiredIngress.Spec
-	ingress.Labels = desiredLabels
-	ingress.Annotations = desiredAnnotations
-	return r.Client.Update(ctx, ingress)
+	return r.UpdateObjectIfChanged(ctx, ingress, func() {
+		ingress.Labels = desiredLabels
+		ingress.Annotations = desiredAnnotations
+		ingress.OwnerReferences = desiredIngress.OwnerReferences
+		ingress.Spec = desiredIngress.Spec
+	})
 }
 
 func ingressHosts(config *infrav1alpha1.IngressConfig) []string {
@@ -697,9 +757,11 @@ func (r *ResourceManager) ReconcileServiceConfigMapWithScope(ctx context.Context
 		return r.Client.Create(ctx, desired)
 	}
 
-	existing.Data = desired.Data
-	existing.Labels = desired.Labels
-	return r.Client.Update(ctx, existing)
+	return r.UpdateObjectIfChanged(ctx, existing, func() {
+		existing.Data = desired.Data
+		existing.Labels = desired.Labels
+		existing.OwnerReferences = desired.OwnerReferences
+	})
 }
 
 func (r *ResourceManager) ReconcileHashedServiceConfigMap(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, name string, labels map[string]string, config any) (ServiceConfigRef, error) {
@@ -756,13 +818,14 @@ func (r *ResourceManager) ReconcileHashedServiceConfigMapWithScope(ctx context.C
 		if existing.Data["config.yaml"] != desired.Data["config.yaml"] {
 			return ServiceConfigRef{}, fmt.Errorf("service configmap %q already exists with mismatched config hash", configMapName)
 		}
-		existing.Labels = desired.Labels
-		existing.Annotations = desired.Annotations
-		existing.OwnerReferences = desired.OwnerReferences
-		if existing.Immutable == nil || !*existing.Immutable {
-			existing.Immutable = BoolPtr(true)
-		}
-		if err := r.Client.Update(ctx, existing); err != nil {
+		if err := r.UpdateObjectIfChanged(ctx, existing, func() {
+			existing.Labels = desired.Labels
+			existing.Annotations = desired.Annotations
+			existing.OwnerReferences = desired.OwnerReferences
+			if existing.Immutable == nil || !*existing.Immutable {
+				existing.Immutable = BoolPtr(true)
+			}
+		}); err != nil {
 			return ServiceConfigRef{}, err
 		}
 	}

--- a/infra-operator/internal/controller/pkg/common/common_test.go
+++ b/infra-operator/internal/controller/pkg/common/common_test.go
@@ -11,7 +11,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	infrav1alpha1 "github.com/sandbox0-ai/sandbox0/infra-operator/api/v1alpha1"
 )
@@ -366,6 +368,34 @@ func TestReconcileHashedServiceConfigMapRetainsLivePodConfigAndCleansUnusedConfi
 	}
 }
 
+func TestReconcileHashedServiceConfigMapSkipsNoopUpdate(t *testing.T) {
+	infra := newCommonTestInfra()
+	updateCount := 0
+	manager, _ := newCommonTestResourceManager(t, interceptor.Funcs{
+		Update: func(ctx context.Context, client ctrlclient.WithWatch, obj ctrlclient.Object, opts ...ctrlclient.UpdateOption) error {
+			updateCount++
+			return client.Update(ctx, obj, opts...)
+		},
+	}, infra.DeepCopy())
+
+	labels := GetServiceLabels(infra.Name, "manager")
+	if _, err := manager.ReconcileHashedServiceConfigMap(context.Background(), infra, "demo-manager", labels, map[string]any{
+		"http_port": 8080,
+	}); err != nil {
+		t.Fatalf("reconcile hashed service configmap: %v", err)
+	}
+	updateCount = 0
+
+	if _, err := manager.ReconcileHashedServiceConfigMap(context.Background(), infra, "demo-manager", labels, map[string]any{
+		"http_port": 8080,
+	}); err != nil {
+		t.Fatalf("reconcile unchanged hashed service configmap: %v", err)
+	}
+	if updateCount != 0 {
+		t.Fatalf("expected unchanged hashed configmap to skip update, got %d updates", updateCount)
+	}
+}
+
 func TestEnsurePodTemplateAnnotationsClonesInput(t *testing.T) {
 	annotations := map[string]string{
 		PodTemplateConfigHashAnnotation: "abc123",
@@ -380,6 +410,174 @@ func TestEnsurePodTemplateAnnotationsClonesInput(t *testing.T) {
 	annotations["custom"] = "changed"
 	if got["custom"] != "value" {
 		t.Fatalf("expected cloned annotations to be isolated from caller mutation, got %#v", got)
+	}
+}
+
+func TestReconcileDeploymentSkipsNoopUpdate(t *testing.T) {
+	infra := newCommonTestInfra()
+	updateCount := 0
+	manager, client := newCommonTestResourceManager(t, interceptor.Funcs{
+		Update: func(ctx context.Context, client ctrlclient.WithWatch, obj ctrlclient.Object, opts ...ctrlclient.UpdateOption) error {
+			updateCount++
+			return client.Update(ctx, obj, opts...)
+		},
+	}, infra.DeepCopy())
+	labels := GetServiceLabels(infra.Name, "manager")
+	def := ServiceDefinition{
+		Name:       "manager",
+		TargetPort: 8080,
+		Image:      "sandbox0ai/infra:test",
+	}
+
+	if err := manager.ReconcileDeployment(context.Background(), infra, "demo-manager", labels, 1, def); err != nil {
+		t.Fatalf("reconcile deployment: %v", err)
+	}
+	updateCount = 0
+	if err := manager.ReconcileDeployment(context.Background(), infra, "demo-manager", labels, 1, def); err != nil {
+		t.Fatalf("reconcile unchanged deployment: %v", err)
+	}
+	if updateCount != 0 {
+		t.Fatalf("expected unchanged deployment to skip update, got %d updates", updateCount)
+	}
+
+	deploy := &appsv1.Deployment{}
+	if err := client.Get(context.Background(), types.NamespacedName{Name: "demo-manager", Namespace: infra.Namespace}, deploy); err != nil {
+		t.Fatalf("get deployment: %v", err)
+	}
+	deploy.Spec.Template.Spec.Containers[0].Image = "old:test"
+	if err := client.Update(context.Background(), deploy); err != nil {
+		t.Fatalf("drift deployment: %v", err)
+	}
+	updateCount = 0
+	if err := manager.ReconcileDeployment(context.Background(), infra, "demo-manager", labels, 1, def); err != nil {
+		t.Fatalf("reconcile drifted deployment: %v", err)
+	}
+	if updateCount != 1 {
+		t.Fatalf("expected drifted deployment to update once, got %d updates", updateCount)
+	}
+}
+
+func TestReconcileServiceSkipsNoopUpdateAndPreservesAllocatedFields(t *testing.T) {
+	infra := newCommonTestInfra()
+	scheme := newCommonTestScheme(t)
+	labels := GetServiceLabels(infra.Name, "cluster-gateway")
+	ipFamilyPolicy := corev1.IPFamilyPolicySingleStack
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo-cluster-gateway",
+			Namespace: infra.Namespace,
+			Labels:    EnsureManagedLabels(labels, "demo-cluster-gateway"),
+		},
+		Spec: corev1.ServiceSpec{
+			Type:            corev1.ServiceTypeClusterIP,
+			ClusterIP:       "10.96.0.25",
+			ClusterIPs:      []string{"10.96.0.25"},
+			IPFamilies:      []corev1.IPFamily{corev1.IPv4Protocol},
+			IPFamilyPolicy:  &ipFamilyPolicy,
+			SessionAffinity: corev1.ServiceAffinityNone,
+			Selector:        labels,
+			Ports: []corev1.ServicePort{
+				BuildServicePort("http", 80, 8080, corev1.ServiceTypeClusterIP),
+			},
+		},
+	}
+	if err := NewObjectScope(infra).SetControllerReference(service, scheme); err != nil {
+		t.Fatalf("set service owner: %v", err)
+	}
+
+	updateCount := 0
+	manager, client := newCommonTestResourceManager(t, interceptor.Funcs{
+		Update: func(ctx context.Context, client ctrlclient.WithWatch, obj ctrlclient.Object, opts ...ctrlclient.UpdateOption) error {
+			updateCount++
+			return client.Update(ctx, obj, opts...)
+		},
+	}, infra.DeepCopy(), service)
+
+	if err := manager.ReconcileService(context.Background(), infra, service.Name, labels, corev1.ServiceTypeClusterIP, nil, 80, 8080); err != nil {
+		t.Fatalf("reconcile unchanged service: %v", err)
+	}
+	if updateCount != 0 {
+		t.Fatalf("expected unchanged service to skip update, got %d updates", updateCount)
+	}
+	got := &corev1.Service{}
+	if err := client.Get(context.Background(), types.NamespacedName{Name: service.Name, Namespace: service.Namespace}, got); err != nil {
+		t.Fatalf("get service: %v", err)
+	}
+	if got.Spec.ClusterIP != "10.96.0.25" {
+		t.Fatalf("expected allocated clusterIP to be preserved, got %q", got.Spec.ClusterIP)
+	}
+}
+
+func TestApplyStatefulSetSkipsNoopUpdate(t *testing.T) {
+	infra := newCommonTestInfra()
+	updateCount := 0
+	manager, client := newCommonTestResourceManager(t, interceptor.Funcs{
+		Update: func(ctx context.Context, client ctrlclient.WithWatch, obj ctrlclient.Object, opts ...ctrlclient.UpdateOption) error {
+			updateCount++
+			return client.Update(ctx, obj, opts...)
+		},
+	}, infra.DeepCopy())
+	desired := newCommonTestStatefulSet(infra, "demo-postgres", "postgres", "postgres:16")
+
+	if err := manager.ApplyStatefulSet(context.Background(), infra, desired); err != nil {
+		t.Fatalf("apply statefulset: %v", err)
+	}
+	updateCount = 0
+	if err := manager.ApplyStatefulSet(context.Background(), infra, desired); err != nil {
+		t.Fatalf("apply unchanged statefulset: %v", err)
+	}
+	if updateCount != 0 {
+		t.Fatalf("expected unchanged statefulset to skip update, got %d updates", updateCount)
+	}
+
+	sts := &appsv1.StatefulSet{}
+	if err := client.Get(context.Background(), types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, sts); err != nil {
+		t.Fatalf("get statefulset: %v", err)
+	}
+	sts.Spec.Template.Spec.Containers[0].Image = "postgres:old"
+	if err := client.Update(context.Background(), sts); err != nil {
+		t.Fatalf("drift statefulset: %v", err)
+	}
+	updateCount = 0
+	if err := manager.ApplyStatefulSet(context.Background(), infra, desired); err != nil {
+		t.Fatalf("apply drifted statefulset: %v", err)
+	}
+	if updateCount != 1 {
+		t.Fatalf("expected drifted statefulset to update once, got %d updates", updateCount)
+	}
+}
+
+func TestApplyDaemonSetSkipsNoopUpdate(t *testing.T) {
+	infra := newCommonTestInfra()
+	updateCount := 0
+	manager, _ := newCommonTestResourceManager(t, interceptor.Funcs{
+		Update: func(ctx context.Context, client ctrlclient.WithWatch, obj ctrlclient.Object, opts ...ctrlclient.UpdateOption) error {
+			updateCount++
+			return client.Update(ctx, obj, opts...)
+		},
+	}, infra.DeepCopy())
+	desired := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo-netd", Namespace: infra.Namespace},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "netd"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "netd"}},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "netd", Image: "sandbox0ai/infra:test"}},
+				},
+			},
+		},
+	}
+
+	if err := manager.ApplyDaemonSet(context.Background(), infra, desired); err != nil {
+		t.Fatalf("apply daemonset: %v", err)
+	}
+	updateCount = 0
+	if err := manager.ApplyDaemonSet(context.Background(), infra, desired); err != nil {
+		t.Fatalf("apply unchanged daemonset: %v", err)
+	}
+	if updateCount != 0 {
+		t.Fatalf("expected unchanged daemonset to skip update, got %d updates", updateCount)
 	}
 }
 
@@ -478,5 +676,59 @@ func TestApplyDaemonSetUpdatesExistingObject(t *testing.T) {
 	}
 	if len(got.OwnerReferences) != 1 || got.OwnerReferences[0].Name != infra.Name {
 		t.Fatalf("expected daemonset owner reference, got %#v", got.OwnerReferences)
+	}
+}
+
+func newCommonTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add appsv1 scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1 scheme: %v", err)
+	}
+	if err := infrav1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add infra scheme: %v", err)
+	}
+	return scheme
+}
+
+func newCommonTestInfra() *infrav1alpha1.Sandbox0Infra {
+	return &infrav1alpha1.Sandbox0Infra{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "sandbox0-system",
+		},
+	}
+}
+
+func newCommonTestResourceManager(t *testing.T, interceptors interceptor.Funcs, objects ...ctrlclient.Object) (*ResourceManager, ctrlclient.Client) {
+	t.Helper()
+	scheme := newCommonTestScheme(t)
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		WithInterceptorFuncs(interceptors).
+		Build()
+	return NewResourceManager(client, scheme, nil, LocalDevConfig{}), client
+}
+
+func newCommonTestStatefulSet(infra *infrav1alpha1.Sandbox0Infra, name, containerName, image string) *appsv1.StatefulSet {
+	labels := map[string]string{"app": name}
+	replicas := int32(1)
+	return &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: infra.Namespace},
+		Spec: appsv1.StatefulSetSpec{
+			ServiceName: name,
+			Replicas:    &replicas,
+			Selector:    &metav1.LabelSelector{MatchLabels: labels},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: labels},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: containerName, Image: image}},
+				},
+			},
+		},
 	}
 }

--- a/infra-operator/internal/controller/pkg/rbac/rbac.go
+++ b/infra-operator/internal/controller/pkg/rbac/rbac.go
@@ -291,8 +291,10 @@ func (r *Reconciler) reconcileClusterRole(ctx context.Context, name string, labe
 		return err
 	}
 
-	found.Rules = rules
-	return r.Resources.Client.Update(ctx, found)
+	return r.Resources.UpdateObjectIfChanged(ctx, found, func() {
+		found.Labels = labels
+		found.Rules = rules
+	})
 }
 
 // reconcileClusterRoleBinding creates or updates a ClusterRoleBinding for a service.
@@ -324,7 +326,9 @@ func (r *Reconciler) reconcileClusterRoleBinding(ctx context.Context, infra *inf
 		return err
 	}
 
-	found.RoleRef = binding.RoleRef
-	found.Subjects = binding.Subjects
-	return r.Resources.Client.Update(ctx, found)
+	return r.Resources.UpdateObjectIfChanged(ctx, found, func() {
+		found.Labels = labels
+		found.RoleRef = binding.RoleRef
+		found.Subjects = binding.Subjects
+	})
 }

--- a/infra-operator/internal/controller/services/credentialstore/credentialstore.go
+++ b/infra-operator/internal/controller/services/credentialstore/credentialstore.go
@@ -186,9 +186,11 @@ func (r *Reconciler) reconcileConfigMap(ctx context.Context, infra *infrav1alpha
 	if err != nil {
 		return err
 	}
-	current.Labels = desired.Labels
-	current.Data = desired.Data
-	return r.Resources.Client.Update(ctx, current)
+	return r.Resources.UpdateObjectIfChanged(ctx, current, func() {
+		current.Labels = desired.Labels
+		current.Data = desired.Data
+		current.OwnerReferences = desired.OwnerReferences
+	})
 }
 
 func (r *Reconciler) reconcilePVC(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, cfg infrav1alpha1.BuiltinCredentialVaultConfig) error {
@@ -316,9 +318,7 @@ func (r *Reconciler) reconcileStatefulSet(ctx context.Context, infra *infrav1alp
 	if err != nil {
 		return err
 	}
-	current.Labels = desired.Labels
-	current.Spec = desired.Spec
-	return r.Resources.Client.Update(ctx, current)
+	return r.Resources.ApplyStatefulSet(ctx, infra, desired)
 }
 
 func (r *Reconciler) reconcileService(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, cfg infrav1alpha1.BuiltinCredentialVaultConfig) error {

--- a/infra-operator/internal/controller/services/ctld/ctld.go
+++ b/infra-operator/internal/controller/services/ctld/ctld.go
@@ -315,9 +315,10 @@ func (r *Reconciler) ensureCSIDriver(ctx context.Context, labels map[string]stri
 	if err != nil {
 		return err
 	}
-	current.Labels = desired.Labels
-	current.Spec = desired.Spec
-	return r.Resources.Client.Update(ctx, current)
+	return r.Resources.UpdateObjectIfChanged(ctx, current, func() {
+		current.Labels = desired.Labels
+		current.Spec = desired.Spec
+	})
 }
 
 func (r *Reconciler) buildStorageConfig(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra) (*apiconfig.StorageProxyConfig, error) {

--- a/infra-operator/internal/controller/services/database/database.go
+++ b/infra-operator/internal/controller/services/database/database.go
@@ -381,9 +381,7 @@ func (r *Reconciler) reconcileDatabaseStatefulSet(ctx context.Context, infra *in
 		return r.Resources.Client.Create(ctx, desiredSts)
 	}
 
-	// Update existing StatefulSet
-	sts.Spec = desiredSts.Spec
-	return r.Resources.Client.Update(ctx, sts)
+	return r.Resources.ApplyStatefulSet(ctx, infra, desiredSts)
 }
 
 // reconcileDatabaseService creates or updates the PostgreSQL Service.
@@ -430,9 +428,12 @@ func (r *Reconciler) reconcileDatabaseService(ctx context.Context, infra *infrav
 		return r.Resources.Client.Create(ctx, desiredSvc)
 	}
 
-	// Update existing Service
-	svc.Spec = desiredSvc.Spec
-	return r.Resources.Client.Update(ctx, svc)
+	return r.Resources.UpdateObjectIfChanged(ctx, svc, func() {
+		svc.OwnerReferences = desiredSvc.OwnerReferences
+		svc.Spec.Type = desiredSvc.Spec.Type
+		svc.Spec.Selector = desiredSvc.Spec.Selector
+		svc.Spec.Ports = desiredSvc.Spec.Ports
+	})
 }
 
 func (r *Reconciler) ensureDatabaseReady(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra) error {

--- a/infra-operator/internal/controller/services/redis/redis.go
+++ b/infra-operator/internal/controller/services/redis/redis.go
@@ -157,9 +157,13 @@ func (r *Reconciler) reconcileRedisDeployment(ctx context.Context, infra *infrav
 		return r.Resources.Client.Create(ctx, desired)
 	}
 
-	deploy.Labels = desired.Labels
-	deploy.Spec = desired.Spec
-	return r.Resources.Client.Update(ctx, deploy)
+	return r.Resources.UpdateObjectIfChanged(ctx, deploy, func() {
+		deploy.Labels = desired.Labels
+		deploy.OwnerReferences = desired.OwnerReferences
+		deploy.Spec.Replicas = desired.Spec.Replicas
+		deploy.Spec.Selector = desired.Spec.Selector
+		deploy.Spec.Template = desired.Spec.Template
+	})
 }
 
 func (r *Reconciler) reconcileRedisService(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra) error {

--- a/infra-operator/internal/controller/services/registry/registry.go
+++ b/infra-operator/internal/controller/services/registry/registry.go
@@ -434,18 +434,28 @@ func (r *Reconciler) reconcileRegistryAuthSecret(ctx context.Context, infra *inf
 		return username, password, nil
 	}
 
-	updated := secret.DeepCopy()
-	if updated.Data == nil {
-		updated.Data = map[string][]byte{}
+	desired := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: infra.Namespace,
+		},
 	}
-	updated.Data["username"] = []byte(username)
-	updated.Data["password"] = []byte(password)
-	updated.Data["htpasswd"] = []byte(htpasswd)
-
-	if err := r.Resources.Client.Update(ctx, updated); err != nil {
+	if err := ctrl.SetControllerReference(infra, desired, r.Resources.Scheme); err != nil {
 		return "", "", err
 	}
 
+	if err := r.Resources.UpdateObjectIfChanged(ctx, secret, func() {
+		if secret.Data == nil {
+			secret.Data = map[string][]byte{}
+		}
+		secret.Type = corev1.SecretTypeOpaque
+		secret.Data["username"] = []byte(username)
+		secret.Data["password"] = []byte(password)
+		secret.Data["htpasswd"] = []byte(htpasswd)
+		secret.OwnerReferences = desired.OwnerReferences
+	}); err != nil {
+		return "", "", err
+	}
 	return username, password, nil
 }
 
@@ -480,15 +490,23 @@ func (r *Reconciler) reconcileRegistryPullSecret(ctx context.Context, infra *inf
 		return r.Resources.Client.Create(ctx, secret)
 	}
 
-	if secret.Data == nil {
-		secret.Data = map[string][]byte{}
+	desired := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: infra.Namespace,
+		},
 	}
-	if existing := secret.Data[corev1.DockerConfigJsonKey]; string(existing) == string(dockerConfig) {
-		return nil
+	if err := ctrl.SetControllerReference(infra, desired, r.Resources.Scheme); err != nil {
+		return err
 	}
-	secret.Data[corev1.DockerConfigJsonKey] = dockerConfig
-	secret.Type = corev1.SecretTypeDockerConfigJson
-	return r.Resources.Client.Update(ctx, secret)
+	return r.Resources.UpdateObjectIfChanged(ctx, secret, func() {
+		if secret.Data == nil {
+			secret.Data = map[string][]byte{}
+		}
+		secret.Data[corev1.DockerConfigJsonKey] = dockerConfig
+		secret.Type = corev1.SecretTypeDockerConfigJson
+		secret.OwnerReferences = desired.OwnerReferences
+	})
 }
 
 func (r *Reconciler) reconcileRegistryDeployment(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, builtin infrav1alpha1.BuiltinRegistryConfig) error {

--- a/infra-operator/internal/controller/services/registry/registry.go
+++ b/infra-operator/internal/controller/services/registry/registry.go
@@ -405,7 +405,7 @@ func (r *Reconciler) reconcileRegistryAuthSecret(ctx context.Context, infra *inf
 		return "", "", err
 	}
 
-	htpasswd, err := buildHtpasswd(username, password)
+	htpasswd, err := registryHtpasswdForSecret(secret, username, password)
 	if err != nil {
 		return "", "", err
 	}
@@ -417,10 +417,10 @@ func (r *Reconciler) reconcileRegistryAuthSecret(ctx context.Context, infra *inf
 				Namespace: infra.Namespace,
 			},
 			Type: corev1.SecretTypeOpaque,
-			StringData: map[string]string{
-				"username": username,
-				"password": password,
-				"htpasswd": htpasswd,
+			Data: map[string][]byte{
+				"username": []byte(username),
+				"password": []byte(password),
+				"htpasswd": []byte(htpasswd),
 			},
 		}
 
@@ -820,6 +820,26 @@ func buildHtpasswd(username, password string) (string, error) {
 		return "", fmt.Errorf("hash registry password: %w", err)
 	}
 	return fmt.Sprintf("%s:%s", username, string(hash)), nil
+}
+
+func registryHtpasswdForSecret(secret *corev1.Secret, username, password string) (string, error) {
+	if secret != nil && secret.Data != nil {
+		currentUsername := string(secret.Data["username"])
+		currentPassword := string(secret.Data["password"])
+		currentHtpasswd := strings.TrimSpace(string(secret.Data["htpasswd"]))
+		if currentUsername == username && currentPassword == password && registryHtpasswdMatches(currentHtpasswd, username, password) {
+			return currentHtpasswd, nil
+		}
+	}
+	return buildHtpasswd(username, password)
+}
+
+func registryHtpasswdMatches(line, username, password string) bool {
+	parts := strings.SplitN(line, ":", 2)
+	if len(parts) != 2 || parts[0] != username || parts[1] == "" {
+		return false
+	}
+	return bcrypt.CompareHashAndPassword([]byte(parts[1]), []byte(password)) == nil
 }
 
 func buildDockerConfigJSON(registry, username, password string) ([]byte, error) {

--- a/infra-operator/internal/controller/services/registry/registry_test.go
+++ b/infra-operator/internal/controller/services/registry/registry_test.go
@@ -1,11 +1,19 @@
 package registry
 
 import (
+	"context"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	infrav1alpha1 "github.com/sandbox0-ai/sandbox0/infra-operator/api/v1alpha1"
+	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/pkg/common"
 )
 
 func TestBuiltinPushRegistryUsesServiceEndpointByDefault(t *testing.T) {
@@ -78,5 +86,71 @@ func TestResolveBuiltinRegistryConfigPreservesIngress(t *testing.T) {
 	cfg := resolveBuiltinRegistryConfig(infra)
 	if cfg.Ingress == nil || !cfg.Ingress.Enabled || cfg.Ingress.Host != "registry.example.com" {
 		t.Fatalf("expected ingress configuration to be preserved, got %#v", cfg.Ingress)
+	}
+}
+
+func TestReconcileRegistryAuthSecretSkipsNoopUpdate(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := infrav1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add infra scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+
+	infra := &infrav1alpha1.Sandbox0Infra{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "sandbox0-system",
+		},
+	}
+	credentials := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo-registry-credentials",
+			Namespace: infra.Namespace,
+		},
+		Data: map[string][]byte{
+			"username": []byte("sandbox0"),
+			"password": []byte("stable-password"),
+		},
+	}
+
+	updateCount := 0
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(infra, credentials).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, client ctrlclient.WithWatch, obj ctrlclient.Object, opts ...ctrlclient.UpdateOption) error {
+				updateCount++
+				return client.Update(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
+
+	if _, _, err := reconciler.reconcileRegistryAuthSecret(context.Background(), infra, infrav1alpha1.BuiltinRegistryConfig{}); err != nil {
+		t.Fatalf("reconcile auth secret: %v", err)
+	}
+	auth := &corev1.Secret{}
+	if err := client.Get(context.Background(), types.NamespacedName{Name: "demo-registry-auth", Namespace: infra.Namespace}, auth); err != nil {
+		t.Fatalf("get auth secret: %v", err)
+	}
+	firstHtpasswd := string(auth.Data["htpasswd"])
+	if !registryHtpasswdMatches(firstHtpasswd, "sandbox0", "stable-password") {
+		t.Fatalf("expected htpasswd to match generated credentials")
+	}
+
+	updateCount = 0
+	if _, _, err := reconciler.reconcileRegistryAuthSecret(context.Background(), infra, infrav1alpha1.BuiltinRegistryConfig{}); err != nil {
+		t.Fatalf("reconcile unchanged auth secret: %v", err)
+	}
+	if updateCount != 0 {
+		t.Fatalf("expected unchanged auth secret to skip update, got %d updates", updateCount)
+	}
+	if err := client.Get(context.Background(), types.NamespacedName{Name: "demo-registry-auth", Namespace: infra.Namespace}, auth); err != nil {
+		t.Fatalf("get auth secret after reconcile: %v", err)
+	}
+	if got := string(auth.Data["htpasswd"]); got != firstHtpasswd {
+		t.Fatalf("expected htpasswd to be reused, got %q want %q", got, firstHtpasswd)
 	}
 }

--- a/infra-operator/internal/controller/services/storage/storage.go
+++ b/infra-operator/internal/controller/services/storage/storage.go
@@ -441,9 +441,7 @@ func (r *Reconciler) reconcileStorageStatefulSet(ctx context.Context, infra *inf
 		return r.Resources.Client.Create(ctx, desiredSts)
 	}
 
-	// Update existing StatefulSet
-	sts.Spec = desiredSts.Spec
-	return r.Resources.Client.Update(ctx, sts)
+	return r.Resources.ApplyStatefulSet(ctx, infra, desiredSts)
 }
 
 // reconcileStorageService creates or updates the RustFS/MinIO Service.
@@ -495,9 +493,12 @@ func (r *Reconciler) reconcileStorageService(ctx context.Context, infra *infrav1
 		return r.Resources.Client.Create(ctx, desiredSvc)
 	}
 
-	// Update existing Service
-	svc.Spec = desiredSvc.Spec
-	return r.Resources.Client.Update(ctx, svc)
+	return r.Resources.UpdateObjectIfChanged(ctx, svc, func() {
+		svc.OwnerReferences = desiredSvc.OwnerReferences
+		svc.Spec.Type = desiredSvc.Spec.Type
+		svc.Spec.Selector = desiredSvc.Spec.Selector
+		svc.Spec.Ports = desiredSvc.Spec.Ports
+	})
 }
 
 func (r *Reconciler) ensureStorageBucket(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra) error {


### PR DESCRIPTION
## Summary

Fixes #425.

This removes steady-state no-op Kubernetes writes from the infra-operator reconcile path. The common resource helpers now update only when managed fields actually change, direct StatefulSet/Service/Secret/RBAC paths use the same no-op guard where applicable, and builtin registry htpasswd generation now reuses the existing valid bcrypt hash instead of churning the auth Secret every reconcile.

## Validation

Baseline reproduced on the remote Aliyun Singapore kind environment before the fix:

- Source: `origin/main` at `ee733449`
- Deployment: single-cluster `fullmode`
- Status: `Sandbox0Infra/fullmode` `Ready`, `Progress: 9/9`, `All services are healthy`
- `Sandbox0Infra` resourceVersion stayed unchanged: `113188 -> 113188`
- Reconcile count over a steady 60s window: `299` (`~5.0/s`)

Local targeted tests:

- `go test ./infra-operator/internal/controller/pkg/common ./infra-operator/internal/controller/services/database ./infra-operator/internal/controller/services/storage ./infra-operator/internal/controller/services/registry ./infra-operator/internal/controller/services/credentialstore ./infra-operator/internal/controller/services/redis ./infra-operator/internal/controller/services/ctld ./infra-operator/internal/controller/pkg/rbac`
- `go test ./infra-operator/internal/controller/...`
- After stabilizing registry htpasswd reuse: `go test ./infra-operator/internal/controller/services/registry`
- After stabilizing registry htpasswd reuse: `go test ./infra-operator/internal/controller/...`

Remote post-fix validation on the same Aliyun Singapore kind environment while PR CI was running:

- Source: PR branch `fix/infra-reconcile-hot-loop` at `f786b743`
- Deployment: `make -C /root/sandbox0ai LOCAL_SANDBOX0_DIR=/root/sandbox0ai/.worktrees/sandbox0-425 remote-test-again`
- Status: `Sandbox0Infra/fullmode` `Ready`, `Progress: 9/9`, `All services are healthy`
- `Sandbox0Infra` resourceVersion stayed unchanged: `126168 -> 126168`
- `fullmode-registry-auth` Secret resourceVersion stayed unchanged: `125765 -> 125765`
- Reconcile count over a steady 60s window: `2` (matches the 30s periodic requeue)

Final PR CI status:

- `quick-check`: success
- `release-package / metadata`: success
- `release-package / infra`: success
- `release-package / publish images`: skipped
- `e2e`: success (`31m20s`)