### PR TITLE
Speed up rootfs pause

### DIFF
--- a/ctld/cmd/ctld/main.go
+++ b/ctld/cmd/ctld/main.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
-	ctldcgroup "github.com/sandbox0-ai/sandbox0/ctld/internal/ctld/cgroup"
 	ctldportal "github.com/sandbox0-ai/sandbox0/ctld/internal/ctld/portal"
 	ctldpower "github.com/sandbox0-ai/sandbox0/ctld/internal/ctld/power"
 	ctldrootfs "github.com/sandbox0-ai/sandbox0/ctld/internal/ctld/rootfs"
@@ -33,25 +32,27 @@ import (
 )
 
 var (
-	httpAddr               = ":8095"
-	kubeconfig             = ""
-	cgroupRoot             = "/host-sys/fs/cgroup"
-	criEndpoint            = "/host-run/containerd/containerd.sock"
-	containerdEndpoint     = "/host-run/containerd/containerd.sock"
-	containerdRoot         = "/host-run/containerd"
-	containerdHostRoot     = "/run/containerd"
-	containerdNamespace    = "k8s.io"
-	procRoot               = "/proc"
-	nodeName               = os.Getenv("NODE_NAME")
-	pauseMinMemoryRequest  = "10Mi"
-	pauseMinMemoryLimit    = "32Mi"
-	pauseMemoryBufferRatio = "1.1"
-	pauseMinCPU            = "10m"
-	defaultSandboxTTL      time.Duration
-	portalRoot             = "/var/lib/sandbox0/ctld"
-	csiSocket              = "/var/lib/kubelet/plugins/volume.sandbox0.ai/csi.sock"
-	podName                = os.Getenv("POD_NAME")
-	podNamespace           = os.Getenv("POD_NAMESPACE")
+	httpAddr                = ":8095"
+	kubeconfig              = ""
+	cgroupRoot              = "/host-sys/fs/cgroup"
+	criEndpoint             = "/host-run/containerd/containerd.sock"
+	containerdEndpoint      = "/host-run/containerd/containerd.sock"
+	containerdRoot          = "/host-run/containerd"
+	containerdHostRoot      = "/run/containerd"
+	containerdStateRoot     = "/host-var-lib/containerd"
+	containerdStateHostRoot = "/var/lib/containerd"
+	containerdNamespace     = "k8s.io"
+	procRoot                = "/proc"
+	nodeName                = os.Getenv("NODE_NAME")
+	pauseMinMemoryRequest   = "10Mi"
+	pauseMinMemoryLimit     = "32Mi"
+	pauseMemoryBufferRatio  = "1.1"
+	pauseMinCPU             = "10m"
+	defaultSandboxTTL       time.Duration
+	portalRoot              = "/var/lib/sandbox0/ctld"
+	csiSocket               = "/var/lib/kubelet/plugins/volume.sandbox0.ai/csi.sock"
+	podName                 = os.Getenv("POD_NAME")
+	podNamespace            = os.Getenv("POD_NAMESPACE")
 )
 
 func main() {
@@ -62,6 +63,8 @@ func main() {
 	flag.StringVar(&containerdEndpoint, "containerd-endpoint", "/host-run/containerd/containerd.sock", "host containerd socket used for rootfs diff/apply")
 	flag.StringVar(&containerdRoot, "containerd-root", "/host-run/containerd", "host containerd runtime root mounted into ctld")
 	flag.StringVar(&containerdHostRoot, "containerd-host-root", "/run/containerd", "host containerd runtime root path used in containerd mount requests")
+	flag.StringVar(&containerdStateRoot, "containerd-state-root", "/host-var-lib/containerd", "host containerd state root mounted into ctld")
+	flag.StringVar(&containerdStateHostRoot, "containerd-state-host-root", "/var/lib/containerd", "host containerd state root path used in snapshot mounts")
 	flag.StringVar(&containerdNamespace, "containerd-namespace", "k8s.io", "containerd namespace used by Kubernetes")
 	flag.StringVar(&procRoot, "proc-root", "/proc", "host proc root used to inspect sandbox processes")
 	flag.StringVar(&nodeName, "node-name", os.Getenv("NODE_NAME"), "current node name used to validate local sandbox ownership")
@@ -134,11 +137,11 @@ func main() {
 	}()
 	defer csiServer.Stop()
 
-	powerController, podResolver := buildPowerController(ctx, obsProvider)
+	powerController := buildPowerController(ctx, obsProvider)
 	httpServer := newHTTPServer(httpAddr, combinedController{
 		Controller: powerController,
 		Portal:     portalManager,
-		RootFS:     buildRootFSController(storageCfg, podResolver),
+		RootFS:     buildRootFSController(storageCfg),
 	})
 	if obsProvider != nil {
 		httpServer.Handler = httpobs.ServerMiddleware(obsProvider.HTTPServerConfig(zapLogger))(httpServer.Handler)
@@ -163,14 +166,14 @@ func newHTTPServer(addr string, controller ctldserver.Controller) *http.Server {
 	return &http.Server{Addr: addr, Handler: ctldserver.NewMux(controller)}
 }
 
-func buildPowerController(ctx context.Context, obsProvider *observability.Provider) (ctldserver.Controller, *ctldpower.PodResolver) {
+func buildPowerController(ctx context.Context, obsProvider *observability.Provider) ctldserver.Controller {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	k8sClient, err := k8s.NewClientWithObservability(kubeconfig, obsProvider)
 	if err != nil {
 		log.Printf("ctld power control disabled: build kubernetes client: %v", err)
-		return ctldserver.NotImplementedController{}, nil
+		return ctldserver.NotImplementedController{}
 	}
 	resolver := ctldpower.NewPodResolver(k8sClient, nodeName, cgroupRoot)
 	resolver.ProcRoot = procRoot
@@ -210,25 +213,25 @@ func buildPowerController(ctx context.Context, obsProvider *observability.Provid
 			powerReconciler.Run(ctx, 1)
 		}()
 	}
-	return controller, resolver
+	return controller
 }
 
-func buildRootFSController(storageCfg *apiconfig.StorageProxyConfig, resolver *ctldpower.PodResolver) ctldserver.RootFSController {
+func buildRootFSController(storageCfg *apiconfig.StorageProxyConfig) ctldserver.RootFSController {
 	store, err := buildRootFSObjectStore(storageCfg)
 	if err != nil {
 		log.Printf("ctld rootfs object store disabled: %v", err)
 	}
 	return ctldrootfs.NewController(ctldrootfs.Config{
 		Runtime: ctldrootfs.NewContainerdRuntime(ctldrootfs.ContainerdRuntimeConfig{
-			CRIEndpoint:        criEndpoint,
-			ContainerdEndpoint: containerdEndpoint,
-			ContainerdRoot:     containerdRoot,
-			ContainerdHostRoot: containerdHostRoot,
-			Namespace:          containerdNamespace,
+			CRIEndpoint:             criEndpoint,
+			ContainerdEndpoint:      containerdEndpoint,
+			ContainerdRoot:          containerdRoot,
+			ContainerdHostRoot:      containerdHostRoot,
+			ContainerdStateRoot:     containerdStateRoot,
+			ContainerdStateHostRoot: containerdStateHostRoot,
+			Namespace:               containerdNamespace,
 		}),
-		Store:    store,
-		Resolver: resolver,
-		FS:       ctldcgroup.NewFS(),
+		Store: store,
 	})
 }
 

--- a/ctld/cmd/ctld/main.go
+++ b/ctld/cmd/ctld/main.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -283,6 +284,8 @@ type combinedController struct {
 	RootFS ctldserver.RootFSController
 }
 
+var _ ctldserver.RootFSController = combinedController{}
+
 func (c combinedController) BindVolumePortal(r *http.Request, req ctldapi.BindVolumePortalRequest) (ctldapi.BindVolumePortalResponse, int) {
 	if c.Portal == nil {
 		return ctldapi.BindVolumePortalResponse{Error: "ctld volume portals not implemented"}, http.StatusNotImplemented
@@ -455,6 +458,13 @@ func (c combinedController) ApplyRootFS(r *http.Request, req ctldapi.ApplyRootFS
 		return ctldapi.ApplyRootFSResponse{Error: "ctld rootfs apply not implemented"}, http.StatusNotImplemented
 	}
 	return c.RootFS.ApplyRootFS(r, req)
+}
+
+func (c combinedController) ReadRootFSDiff(r *http.Request, req ctldapi.ReadRootFSDiffRequest) (io.ReadCloser, ctldapi.RootFSDiffDescriptor, int, error) {
+	if c.RootFS == nil {
+		return nil, ctldapi.RootFSDiffDescriptor{}, http.StatusNotImplemented, fmt.Errorf("ctld rootfs diff read not implemented")
+	}
+	return c.RootFS.ReadRootFSDiff(r, req)
 }
 
 type volumePortalHandler interface {

--- a/ctld/internal/ctld/rootfs/containerd_runtime.go
+++ b/ctld/internal/ctld/rootfs/containerd_runtime.go
@@ -2,7 +2,10 @@ package rootfs
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -15,7 +18,9 @@ import (
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/containerd/v2/core/snapshots"
+	"github.com/containerd/containerd/v2/pkg/archive"
 	crootfs "github.com/containerd/containerd/v2/pkg/rootfs"
+	"github.com/containerd/continuity/fs"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
@@ -25,40 +30,48 @@ import (
 )
 
 const (
-	defaultCRIEndpoint        = "/host-run/containerd/containerd.sock"
-	defaultContainerdEndpoint = "/host-run/containerd/containerd.sock"
-	defaultContainerdRoot     = "/host-run/containerd"
-	defaultContainerdHostRoot = "/run/containerd"
-	defaultNamespace          = "k8s.io"
-	defaultDialTimeout        = 10 * time.Second
+	defaultCRIEndpoint             = "/host-run/containerd/containerd.sock"
+	defaultContainerdEndpoint      = "/host-run/containerd/containerd.sock"
+	defaultContainerdRoot          = "/host-run/containerd"
+	defaultContainerdHostRoot      = "/run/containerd"
+	defaultContainerdStateRoot     = "/host-var-lib/containerd"
+	defaultContainerdStateHostRoot = "/var/lib/containerd"
+	defaultNamespace               = "k8s.io"
+	defaultDialTimeout             = 10 * time.Second
 )
+
+var errOverlayUpperDiffUnavailable = errors.New("overlay upperdir diff unavailable")
 
 type criRuntimeService interface {
 	ListContainers(ctx context.Context, in *runtimeapi.ListContainersRequest, opts ...grpc.CallOption) (*runtimeapi.ListContainersResponse, error)
 }
 
 type ContainerdRuntimeConfig struct {
-	CRIEndpoint        string
-	ContainerdEndpoint string
-	ContainerdRoot     string
-	ContainerdHostRoot string
-	Namespace          string
-	DialTimeout        time.Duration
-	CRIClient          criRuntimeService
-	CRIDialContext     func(ctx context.Context, endpoint string) (*grpc.ClientConn, error)
-	ContainerdClient   containerdClient
+	CRIEndpoint             string
+	ContainerdEndpoint      string
+	ContainerdRoot          string
+	ContainerdHostRoot      string
+	ContainerdStateRoot     string
+	ContainerdStateHostRoot string
+	Namespace               string
+	DialTimeout             time.Duration
+	CRIClient               criRuntimeService
+	CRIDialContext          func(ctx context.Context, endpoint string) (*grpc.ClientConn, error)
+	ContainerdClient        containerdClient
 }
 
 type ContainerdRuntime struct {
-	criEndpoint        string
-	containerdEndpoint string
-	containerdRoot     string
-	containerdHostRoot string
-	namespace          string
-	dialTimeout        time.Duration
-	criClient          criRuntimeService
-	criDialContext     func(ctx context.Context, endpoint string) (*grpc.ClientConn, error)
-	containerdClient   containerdClient
+	criEndpoint             string
+	containerdEndpoint      string
+	containerdRoot          string
+	containerdHostRoot      string
+	containerdStateRoot     string
+	containerdStateHostRoot string
+	namespace               string
+	dialTimeout             time.Duration
+	criClient               criRuntimeService
+	criDialContext          func(ctx context.Context, endpoint string) (*grpc.ClientConn, error)
+	containerdClient        containerdClient
 }
 
 type containerdClient interface {
@@ -87,6 +100,14 @@ func NewContainerdRuntime(cfg ContainerdRuntimeConfig) *ContainerdRuntime {
 	if containerdHostRoot == "" {
 		containerdHostRoot = defaultContainerdHostRoot
 	}
+	containerdStateRoot := strings.TrimSpace(cfg.ContainerdStateRoot)
+	if containerdStateRoot == "" {
+		containerdStateRoot = defaultContainerdStateRoot
+	}
+	containerdStateHostRoot := strings.TrimSpace(cfg.ContainerdStateHostRoot)
+	if containerdStateHostRoot == "" {
+		containerdStateHostRoot = defaultContainerdStateHostRoot
+	}
 	namespace := strings.TrimSpace(cfg.Namespace)
 	if namespace == "" {
 		namespace = defaultNamespace
@@ -96,15 +117,17 @@ func NewContainerdRuntime(cfg ContainerdRuntimeConfig) *ContainerdRuntime {
 		timeout = defaultDialTimeout
 	}
 	return &ContainerdRuntime{
-		criEndpoint:        criEndpoint,
-		containerdEndpoint: containerdEndpoint,
-		containerdRoot:     containerdRoot,
-		containerdHostRoot: containerdHostRoot,
-		namespace:          namespace,
-		dialTimeout:        timeout,
-		criClient:          cfg.CRIClient,
-		criDialContext:     cfg.CRIDialContext,
-		containerdClient:   cfg.ContainerdClient,
+		criEndpoint:             criEndpoint,
+		containerdEndpoint:      containerdEndpoint,
+		containerdRoot:          containerdRoot,
+		containerdHostRoot:      containerdHostRoot,
+		containerdStateRoot:     containerdStateRoot,
+		containerdStateHostRoot: containerdStateHostRoot,
+		namespace:               namespace,
+		dialTimeout:             timeout,
+		criClient:               cfg.CRIClient,
+		criDialContext:          cfg.CRIDialContext,
+		containerdClient:        cfg.ContainerdClient,
 	}
 }
 
@@ -133,6 +156,14 @@ func (r *ContainerdRuntime) CreateDiff(ctx context.Context, info ctldapi.RootFSI
 	client, closeClient, err := r.client(ctx)
 	if err != nil {
 		return ctldapi.RootFSDiffDescriptor{}, nil, err
+	}
+
+	if desc, reader, err := r.createOverlayUpperDiff(ctx, client, info); err == nil {
+		closeClient()
+		return desc, reader, nil
+	} else if ctxErr := ctx.Err(); ctxErr != nil {
+		closeClient()
+		return ctldapi.RootFSDiffDescriptor{}, nil, ctxErr
 	}
 
 	desc, err := crootfs.CreateDiff(ctx, info.SnapshotKey, client.SnapshotService(info.Snapshotter), client.DiffService())
@@ -180,6 +211,88 @@ func (r *ContainerdRuntime) ApplyDiff(ctx context.Context, info ctldapi.RootFSIn
 		return ctldapi.RootFSDiffDescriptor{}, err
 	}
 	return descriptorFromOCI(applied), nil
+}
+
+func (r *ContainerdRuntime) createOverlayUpperDiff(ctx context.Context, client containerdClient, info ctldapi.RootFSInfo) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error) {
+	snapshotter := client.SnapshotService(info.Snapshotter)
+	if snapshotter == nil {
+		return ctldapi.RootFSDiffDescriptor{}, nil, errOverlayUpperDiffUnavailable
+	}
+	activeMounts, err := snapshotter.Mounts(ctx, info.SnapshotKey)
+	if err != nil {
+		return ctldapi.RootFSDiffDescriptor{}, nil, fmt.Errorf("inspect active snapshot mounts: %w", err)
+	}
+	activeMounts = mapMountsToLocalHostPaths(activeMounts, r.hostPathMappings())
+	upperdir, ok := overlayUpperDir(activeMounts)
+	if !ok {
+		return ctldapi.RootFSDiffDescriptor{}, nil, errOverlayUpperDiffUnavailable
+	}
+	if st, err := os.Stat(upperdir); err != nil {
+		return ctldapi.RootFSDiffDescriptor{}, nil, fmt.Errorf("inspect overlay upperdir %s: %w", upperdir, err)
+	} else if !st.IsDir() {
+		return ctldapi.RootFSDiffDescriptor{}, nil, fmt.Errorf("overlay upperdir %s is not a directory", upperdir)
+	}
+
+	snapInfo, err := snapshotter.Stat(ctx, info.SnapshotKey)
+	if err != nil {
+		return ctldapi.RootFSDiffDescriptor{}, nil, fmt.Errorf("inspect active snapshot: %w", err)
+	}
+	parent := strings.TrimSpace(snapInfo.Parent)
+	if parent == "" {
+		return ctldapi.RootFSDiffDescriptor{}, nil, errOverlayUpperDiffUnavailable
+	}
+	viewKey := newRootFSParentViewKey()
+	parentMounts, err := snapshotter.View(ctx, viewKey, parent)
+	if err != nil {
+		return ctldapi.RootFSDiffDescriptor{}, nil, fmt.Errorf("create parent snapshot view: %w", err)
+	}
+	defer func() { _ = snapshotter.Remove(ctx, viewKey) }()
+
+	parentMounts = mapMountsToLocalHostPaths(parentMounts, r.hostPathMappings())
+	var desc ctldapi.RootFSDiffDescriptor
+	var reader io.ReadSeekCloser
+	err = mount.WithReadonlyTempMount(ctx, parentMounts, func(lowerRoot string) error {
+		var diffErr error
+		desc, reader, diffErr = createOverlayUpperDiffTar(ctx, lowerRoot, upperdir)
+		return diffErr
+	})
+	if err != nil {
+		return ctldapi.RootFSDiffDescriptor{}, nil, err
+	}
+	return desc, reader, nil
+}
+
+func createOverlayUpperDiffTar(ctx context.Context, lowerRoot, upperdir string) (_ ctldapi.RootFSDiffDescriptor, _ io.ReadSeekCloser, retErr error) {
+	tmp, err := os.CreateTemp("", "sandbox0-rootfs-diff-*.tar")
+	if err != nil {
+		return ctldapi.RootFSDiffDescriptor{}, nil, err
+	}
+	defer func() {
+		if retErr != nil {
+			_ = tmp.Close()
+			_ = os.Remove(tmp.Name())
+		}
+	}()
+
+	digester := digest.Canonical.Digester()
+	counter := &countingWriter{w: io.MultiWriter(tmp, digester.Hash())}
+	cw := archive.NewChangeWriter(counter, upperdir)
+	diffErr := fs.DiffDirChanges(ctx, lowerRoot, upperdir, fs.DiffSourceOverlayFS, cw.HandleChange)
+	closeErr := cw.Close()
+	if diffErr != nil {
+		return ctldapi.RootFSDiffDescriptor{}, nil, fmt.Errorf("create overlay upperdir diff: %w", diffErr)
+	}
+	if closeErr != nil {
+		return ctldapi.RootFSDiffDescriptor{}, nil, fmt.Errorf("close overlay upperdir diff: %w", closeErr)
+	}
+	if _, err := tmp.Seek(0, io.SeekStart); err != nil {
+		return ctldapi.RootFSDiffDescriptor{}, nil, err
+	}
+	return ctldapi.RootFSDiffDescriptor{
+		MediaType: ocispec.MediaTypeImageLayer,
+		Digest:    digester.Digest().String(),
+		Size:      counter.n,
+	}, tempFileReadSeekCloser{File: tmp, path: tmp.Name()}, nil
 }
 
 func (r *ContainerdRuntime) resolveContainerID(ctx context.Context, target ctldapi.RootFSContainerRef) (string, string, error) {
@@ -452,6 +565,102 @@ func descriptorToOCI(desc ctldapi.RootFSDiffDescriptor) (ocispec.Descriptor, err
 	}, nil
 }
 
+func overlayUpperDir(mounts []mount.Mount) (string, bool) {
+	for _, m := range mounts {
+		if m.Type != "overlay" {
+			continue
+		}
+		for _, opt := range m.Options {
+			key, value, ok := strings.Cut(opt, "=")
+			if ok && key == "upperdir" && strings.TrimSpace(value) != "" {
+				return value, true
+			}
+		}
+	}
+	return "", false
+}
+
+type hostPathMapping struct {
+	hostRoot  string
+	localRoot string
+}
+
+func (r *ContainerdRuntime) hostPathMappings() []hostPathMapping {
+	return []hostPathMapping{
+		{hostRoot: r.containerdHostRoot, localRoot: r.containerdRoot},
+		{hostRoot: r.containerdStateHostRoot, localRoot: r.containerdStateRoot},
+	}
+}
+
+func mapMountsToLocalHostPaths(mounts []mount.Mount, mappings []hostPathMapping) []mount.Mount {
+	if len(mounts) == 0 {
+		return nil
+	}
+	mapped := make([]mount.Mount, 0, len(mounts))
+	for _, m := range mounts {
+		clone := m
+		clone.Source = mapHostPathToLocalRoot(clone.Source, mappings)
+		if len(m.Options) > 0 {
+			clone.Options = make([]string, 0, len(m.Options))
+			for _, opt := range m.Options {
+				clone.Options = append(clone.Options, mapMountOptionToLocalRoot(opt, mappings))
+			}
+		}
+		mapped = append(mapped, clone)
+	}
+	return mapped
+}
+
+func mapMountOptionToLocalRoot(opt string, mappings []hostPathMapping) string {
+	key, value, ok := strings.Cut(opt, "=")
+	if !ok {
+		return opt
+	}
+	switch key {
+	case "lowerdir":
+		parts := strings.Split(value, ":")
+		for i := range parts {
+			parts[i] = mapHostPathToLocalRoot(parts[i], mappings)
+		}
+		return key + "=" + strings.Join(parts, ":")
+	case "upperdir", "workdir":
+		return key + "=" + mapHostPathToLocalRoot(value, mappings)
+	default:
+		return opt
+	}
+}
+
+func mapHostPathToLocalRoot(pathValue string, mappings []hostPathMapping) string {
+	pathValue = strings.TrimSpace(pathValue)
+	if pathValue == "" {
+		return pathValue
+	}
+	cleanPath := filepath.Clean(pathValue)
+	for _, mapping := range mappings {
+		if strings.TrimSpace(mapping.hostRoot) == "" || strings.TrimSpace(mapping.localRoot) == "" {
+			continue
+		}
+		hostRoot := filepath.Clean(mapping.hostRoot)
+		localRoot := filepath.Clean(mapping.localRoot)
+		if cleanPath == hostRoot {
+			return localRoot
+		}
+		prefix := hostRoot + string(filepath.Separator)
+		if strings.HasPrefix(cleanPath, prefix) {
+			return filepath.Join(localRoot, strings.TrimPrefix(cleanPath, prefix))
+		}
+	}
+	return pathValue
+}
+
+func newRootFSParentViewKey() string {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err == nil {
+		return "sandbox0-rootfs-parent-view-" + hex.EncodeToString(b[:])
+	}
+	return fmt.Sprintf("sandbox0-rootfs-parent-view-%d", time.Now().UnixNano())
+}
+
 func runtimeFamily(handler string) string {
 	raw := strings.ToLower(strings.TrimSpace(handler))
 	switch {
@@ -511,6 +720,30 @@ func (r closeReadSeekWithFunc) Close() error {
 	err := r.ReadSeekCloser.Close()
 	if r.closeFunc != nil {
 		r.closeFunc()
+	}
+	return err
+}
+
+type countingWriter struct {
+	w io.Writer
+	n int64
+}
+
+func (w *countingWriter) Write(p []byte) (int, error) {
+	n, err := w.w.Write(p)
+	w.n += int64(n)
+	return n, err
+}
+
+type tempFileReadSeekCloser struct {
+	*os.File
+	path string
+}
+
+func (r tempFileReadSeekCloser) Close() error {
+	err := r.File.Close()
+	if removeErr := os.Remove(r.path); err == nil {
+		err = removeErr
 	}
 	return err
 }

--- a/ctld/internal/ctld/rootfs/containerd_runtime_test.go
+++ b/ctld/internal/ctld/rootfs/containerd_runtime_test.go
@@ -1,13 +1,18 @@
 package rootfs
 
 import (
+	"archive/tar"
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/containerd/containerd/v2/core/mount"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -170,6 +175,57 @@ func TestLiveRootFSPathMapsMountedRootToHostRoot(t *testing.T) {
 	assert.Equal(t, filepath.Join(containerdHostRoot, "io.containerd.runtime.v2.task", "k8s.io", containerID, "rootfs"), got)
 }
 
+func TestMapMountsToContainerdRootMapsOverlayPaths(t *testing.T) {
+	mounts := []mount.Mount{{
+		Type:   "overlay",
+		Source: "overlay",
+		Options: []string{
+			"lowerdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/2/fs:/run/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1/fs",
+			"upperdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/3/fs",
+			"workdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/3/work",
+			"index=off",
+		},
+	}}
+
+	mapped := mapMountsToLocalHostPaths(mounts, []hostPathMapping{
+		{hostRoot: "/run/containerd", localRoot: "/host-run/containerd"},
+		{hostRoot: "/var/lib/containerd", localRoot: "/host-var-lib/containerd"},
+	})
+	upperdir, ok := overlayUpperDir(mapped)
+
+	require.True(t, ok)
+	assert.Equal(t, "/host-var-lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/3/fs", upperdir)
+	assert.Equal(t, "lowerdir=/host-var-lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/2/fs:/host-run/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1/fs", mapped[0].Options[0])
+	assert.Equal(t, "workdir=/host-var-lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/3/work", mapped[0].Options[2])
+}
+
+func TestCreateOverlayUpperDiffTarWritesUpperdirLayer(t *testing.T) {
+	lowerRoot := t.TempDir()
+	upperdir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(lowerRoot, "common.txt"), []byte("old"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(upperdir, "common.txt"), []byte("new"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(upperdir, "nested"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(upperdir, "nested", "added.txt"), []byte("added"), 0o644))
+
+	desc, reader, err := createOverlayUpperDiffTar(context.Background(), lowerRoot, upperdir)
+	require.NoError(t, err)
+	tmpReader := reader.(tempFileReadSeekCloser)
+	tmpPath := tmpReader.path
+
+	assert.Equal(t, ocispec.MediaTypeImageLayer, desc.MediaType)
+	assert.Greater(t, desc.Size, int64(0))
+	_, err = digest.Parse(desc.Digest)
+	require.NoError(t, err)
+
+	entries := readTarRegularFiles(t, reader)
+	assert.Equal(t, "new", entries["common.txt"])
+	assert.Equal(t, "added", entries["nested/added.txt"])
+
+	require.NoError(t, reader.Close())
+	_, err = os.Stat(tmpPath)
+	assert.True(t, os.IsNotExist(err))
+}
+
 func TestDigestFromReference(t *testing.T) {
 	assert.Equal(t, "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", digestFromReference("busybox@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
 	assert.Empty(t, digestFromReference("busybox:1.36"))
@@ -201,4 +257,24 @@ func writeTaskConfig(t *testing.T, taskDir string, annotations map[string]string
 	}{Annotations: annotations})
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(filepath.Join(taskDir, "config.json"), raw, 0o644))
+}
+
+func readTarRegularFiles(t *testing.T, reader io.Reader) map[string]string {
+	t.Helper()
+	files := map[string]string{}
+	tr := tar.NewReader(reader)
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err)
+		if hdr.Typeflag != tar.TypeReg {
+			continue
+		}
+		raw, err := io.ReadAll(tr)
+		require.NoError(t, err)
+		files[hdr.Name] = string(raw)
+	}
+	return files
 }

--- a/ctld/internal/ctld/rootfs/controller.go
+++ b/ctld/internal/ctld/rootfs/controller.go
@@ -140,6 +140,30 @@ func (c *Controller) ApplyRootFS(r *http.Request, req ctldapi.ApplyRootFSRequest
 	return ctldapi.ApplyRootFSResponse{Info: info, Descriptor: applied, Applied: true}, http.StatusOK
 }
 
+func (c *Controller) ReadRootFSDiff(r *http.Request, req ctldapi.ReadRootFSDiffRequest) (io.ReadCloser, ctldapi.RootFSDiffDescriptor, int, error) {
+	if err := validateDescriptor(req.Descriptor); err != nil {
+		return nil, ctldapi.RootFSDiffDescriptor{}, http.StatusBadRequest, err
+	}
+	objectKey := strings.Trim(strings.TrimSpace(req.Descriptor.ObjectKey), "/")
+	if objectKey == "" {
+		return nil, ctldapi.RootFSDiffDescriptor{}, http.StatusBadRequest, fmt.Errorf("%w: descriptor object_key is required", ErrBadRequest)
+	}
+	if !strings.HasPrefix(objectKey, "sandbox-rootfs/") {
+		return nil, ctldapi.RootFSDiffDescriptor{}, http.StatusBadRequest, fmt.Errorf("%w: rootfs diff object key must be under sandbox-rootfs/", ErrBadRequest)
+	}
+	if c.store == nil {
+		return nil, ctldapi.RootFSDiffDescriptor{}, http.StatusNotImplemented, fmt.Errorf("rootfs object store is not configured")
+	}
+
+	reader, err := c.store.Get(objectKey, 0, -1)
+	if err != nil {
+		return nil, ctldapi.RootFSDiffDescriptor{}, http.StatusInternalServerError, fmt.Errorf("download rootfs diff: %w", err)
+	}
+	desc := req.Descriptor
+	desc.ObjectKey = objectKey
+	return reader, desc, http.StatusOK, nil
+}
+
 func (c *Controller) inspect(ctx context.Context, target ctldapi.RootFSContainerRef) (ctldapi.RootFSInfo, error) {
 	if c == nil || c.runtime == nil {
 		return ctldapi.RootFSInfo{}, fmt.Errorf("rootfs runtime is not configured")

--- a/ctld/internal/ctld/rootfs/controller.go
+++ b/ctld/internal/ctld/rootfs/controller.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sandbox0-ai/sandbox0/ctld/internal/ctld/cgroup"
 	ctldpower "github.com/sandbox0-ai/sandbox0/ctld/internal/ctld/power"
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/objectstore"
@@ -29,23 +28,15 @@ type Runtime interface {
 	ApplyDiff(ctx context.Context, info ctldapi.RootFSInfo, desc ctldapi.RootFSDiffDescriptor, content io.Reader) (ctldapi.RootFSDiffDescriptor, error)
 }
 
-type PodResolver interface {
-	ResolvePod(r *http.Request, namespace, name string) (ctldpower.Target, error)
-}
-
 type Config struct {
 	Runtime          Runtime
 	Store            objectstore.Store
-	Resolver         PodResolver
-	FS               *cgroup.FS
 	OperationTimeout time.Duration
 }
 
 type Controller struct {
 	runtime          Runtime
 	store            objectstore.Store
-	resolver         PodResolver
-	fs               *cgroup.FS
 	operationTimeout time.Duration
 }
 
@@ -57,8 +48,6 @@ func NewController(cfg Config) *Controller {
 	return &Controller{
 		runtime:          cfg.Runtime,
 		store:            cfg.Store,
-		resolver:         cfg.Resolver,
-		fs:               cfg.FS,
 		operationTimeout: timeout,
 	}
 }
@@ -84,11 +73,6 @@ func (c *Controller) SaveRootFS(r *http.Request, req ctldapi.SaveRootFSRequest) 
 
 	ctx, cancel := c.operationContext(requestContext(r))
 	defer cancel()
-	thaw, err := c.freezeIfRequested(r, req.Target, req.Freeze)
-	if err != nil {
-		return ctldapi.SaveRootFSResponse{Error: err.Error()}, statusForError(err)
-	}
-	defer thaw()
 
 	info, err := c.inspect(ctx, req.Target)
 	if err != nil {
@@ -130,11 +114,6 @@ func (c *Controller) ApplyRootFS(r *http.Request, req ctldapi.ApplyRootFSRequest
 
 	ctx, cancel := c.operationContext(requestContext(r))
 	defer cancel()
-	thaw, err := c.freezeIfRequested(r, req.Target, req.Freeze)
-	if err != nil {
-		return ctldapi.ApplyRootFSResponse{Error: err.Error()}, statusForError(err)
-	}
-	defer thaw()
 
 	info, err := c.inspect(ctx, req.Target)
 	if err != nil {
@@ -177,30 +156,6 @@ func (c *Controller) operationContext(parent context.Context) (context.Context, 
 		timeout = c.operationTimeout
 	}
 	return context.WithTimeout(parent, timeout)
-}
-
-func (c *Controller) freezeIfRequested(r *http.Request, target ctldapi.RootFSContainerRef, freeze bool) (func(), error) {
-	if !freeze {
-		return func() {}, nil
-	}
-	if c == nil || c.resolver == nil || c.fs == nil {
-		return nil, fmt.Errorf("rootfs freeze requested but pod resolver or cgroup fs is not configured")
-	}
-	powerTarget, err := c.resolver.ResolvePod(r, target.Namespace, target.PodName)
-	if err != nil {
-		return nil, err
-	}
-	if err := c.fs.Freeze(powerTarget.CgroupDir); err != nil {
-		return nil, fmt.Errorf("freeze sandbox cgroup: %w", err)
-	}
-	thawed := false
-	return func() {
-		if thawed {
-			return
-		}
-		thawed = true
-		_ = c.fs.Thaw(powerTarget.CgroupDir)
-	}, nil
 }
 
 func requestContext(r *http.Request) context.Context {

--- a/ctld/internal/ctld/rootfs/controller_test.go
+++ b/ctld/internal/ctld/rootfs/controller_test.go
@@ -226,6 +226,47 @@ func TestControllerApplyRootFSRejectsMissingDescriptorObjectKey(t *testing.T) {
 	assert.Contains(t, resp.Error, "descriptor object_key is required")
 }
 
+func TestControllerReadRootFSDiffStreamsStoredDiff(t *testing.T) {
+	store := objectstore.NewMemoryStore(t.Name())
+	require.NoError(t, store.Put("sandbox-rootfs/team-1/sandbox-1/3/sha256/feedface.tar", strings.NewReader("rootfs diff")))
+	controller := NewController(Config{Runtime: &fakeRuntime{}, Store: store})
+
+	reader, desc, status, err := controller.ReadRootFSDiff(httptest.NewRequest(http.MethodPost, "/", nil), ctldapi.ReadRootFSDiffRequest{
+		Descriptor: ctldapi.RootFSDiffDescriptor{
+			MediaType: "application/vnd.oci.image.layer.v1.tar",
+			Digest:    "sha256:feedface",
+			Size:      int64(len("rootfs diff")),
+			ObjectKey: "sandbox-rootfs/team-1/sandbox-1/3/sha256/feedface.tar",
+		},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, status)
+	require.NotNil(t, reader)
+	defer reader.Close()
+	payload, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	assert.Equal(t, "rootfs diff", string(payload))
+	assert.Equal(t, "sandbox-rootfs/team-1/sandbox-1/3/sha256/feedface.tar", desc.ObjectKey)
+}
+
+func TestControllerReadRootFSDiffRejectsNonRootFSPrefix(t *testing.T) {
+	controller := NewController(Config{Runtime: &fakeRuntime{}, Store: objectstore.NewMemoryStore(t.Name())})
+
+	reader, _, status, err := controller.ReadRootFSDiff(httptest.NewRequest(http.MethodPost, "/", nil), ctldapi.ReadRootFSDiffRequest{
+		Descriptor: ctldapi.RootFSDiffDescriptor{
+			MediaType: "application/vnd.oci.image.layer.v1.tar",
+			Digest:    "sha256:feedface",
+			ObjectKey: "other/team-1/diff.tar",
+		},
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, reader)
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Contains(t, err.Error(), "sandbox-rootfs")
+}
+
 type fakeRuntime struct {
 	info          ctldapi.RootFSInfo
 	inspectErr    error

--- a/ctld/internal/ctld/server/server.go
+++ b/ctld/internal/ctld/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"strings"
 
@@ -35,6 +36,7 @@ type RootFSController interface {
 	InspectRootFS(r *http.Request, req ctldapi.InspectRootFSRequest) (ctldapi.InspectRootFSResponse, int)
 	SaveRootFS(r *http.Request, req ctldapi.SaveRootFSRequest) (ctldapi.SaveRootFSResponse, int)
 	ApplyRootFS(r *http.Request, req ctldapi.ApplyRootFSRequest) (ctldapi.ApplyRootFSResponse, int)
+	ReadRootFSDiff(r *http.Request, req ctldapi.ReadRootFSDiffRequest) (io.ReadCloser, ctldapi.RootFSDiffDescriptor, int, error)
 }
 
 type MountedVolumeController interface {
@@ -69,6 +71,10 @@ func (NotImplementedController) SaveRootFS(_ *http.Request, _ ctldapi.SaveRootFS
 
 func (NotImplementedController) ApplyRootFS(_ *http.Request, _ ctldapi.ApplyRootFSRequest) (ctldapi.ApplyRootFSResponse, int) {
 	return ctldapi.ApplyRootFSResponse{Error: "ctld rootfs apply not implemented"}, http.StatusNotImplemented
+}
+
+func (NotImplementedController) ReadRootFSDiff(_ *http.Request, _ ctldapi.ReadRootFSDiffRequest) (io.ReadCloser, ctldapi.RootFSDiffDescriptor, int, error) {
+	return nil, ctldapi.RootFSDiffDescriptor{}, http.StatusNotImplemented, nil
 }
 
 func NewMux(controller Controller) http.Handler {
@@ -397,6 +403,45 @@ func NewMux(controller Controller) http.Handler {
 		resp, status := rootFSController.ApplyRootFS(r, req)
 		w.WriteHeader(status)
 		_ = json.NewEncoder(w).Encode(resp)
+	})
+	mux.HandleFunc("/api/v1/rootfs/diffs/read", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		rootFSController, ok := controller.(RootFSController)
+		if !ok {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotImplemented)
+			_ = json.NewEncoder(w).Encode(ctldapi.ReadRootFSDiffResponse{Error: "ctld rootfs diff read not implemented"})
+			return
+		}
+		var req ctldapi.ReadRootFSDiffRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(ctldapi.ReadRootFSDiffResponse{Error: err.Error()})
+			return
+		}
+		reader, desc, status, err := rootFSController.ReadRootFSDiff(r, req)
+		if err != nil || reader == nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(status)
+			msg := "read rootfs diff failed"
+			if err != nil {
+				msg = err.Error()
+			}
+			_ = json.NewEncoder(w).Encode(ctldapi.ReadRootFSDiffResponse{Error: msg})
+			return
+		}
+		defer reader.Close()
+		mediaType := strings.TrimSpace(desc.MediaType)
+		if mediaType == "" {
+			mediaType = "application/octet-stream"
+		}
+		w.Header().Set("Content-Type", mediaType)
+		w.WriteHeader(status)
+		_, _ = io.Copy(w, reader)
 	})
 	mux.HandleFunc("/api/v1/sandboxes/", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {

--- a/ctld/internal/ctld/server/server_test.go
+++ b/ctld/internal/ctld/server/server_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -61,6 +62,11 @@ func (c *recordingController) SaveRootFS(_ *http.Request, req ctldapi.SaveRootFS
 func (c *recordingController) ApplyRootFS(_ *http.Request, req ctldapi.ApplyRootFSRequest) (ctldapi.ApplyRootFSResponse, int) {
 	c.rootFSTarget = req.Target
 	return ctldapi.ApplyRootFSResponse{Applied: true}, http.StatusOK
+}
+
+func (c *recordingController) ReadRootFSDiff(_ *http.Request, req ctldapi.ReadRootFSDiffRequest) (io.ReadCloser, ctldapi.RootFSDiffDescriptor, int, error) {
+	desc := req.Descriptor
+	return io.NopCloser(bytes.NewReader([]byte("rootfs diff"))), desc, http.StatusOK, nil
 }
 
 func TestNewMuxRoutesPauseResume(t *testing.T) {
@@ -177,4 +183,26 @@ func TestNewMuxRoutesRootFS(t *testing.T) {
 			tt.want(t, rec.Body.Bytes())
 		})
 	}
+}
+
+func TestNewMuxRoutesRootFSDiffRead(t *testing.T) {
+	controller := &recordingController{}
+	handler := NewMux(controller)
+	body := ctldapi.ReadRootFSDiffRequest{
+		Descriptor: ctldapi.RootFSDiffDescriptor{
+			MediaType: "application/vnd.oci.image.layer.v1.tar",
+			Digest:    "sha256:abc",
+			ObjectKey: "sandbox-rootfs/team-1/sandbox-1/3/sha256/abc.tar",
+		},
+	}
+	payload, err := json.Marshal(body)
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/rootfs/diffs/read", bytes.NewReader(payload))
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "application/vnd.oci.image.layer.v1.tar", rec.Header().Get("Content-Type"))
+	assert.Equal(t, "rootfs diff", rec.Body.String())
 }

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.33.14
 	github.com/container-storage-interface/spec v1.12.0
 	github.com/containerd/containerd/v2 v2.2.0
+	github.com/containerd/continuity v0.4.5
 	github.com/coreos/go-iptables v0.8.0
 	github.com/coreos/go-oidc/v3 v3.17.0
 	github.com/creack/pty v1.1.21
@@ -97,7 +98,6 @@ require (
 	github.com/chenzhuoyu/iasm v0.9.0 // indirect
 	github.com/containerd/cgroups/v3 v3.1.0 // indirect
 	github.com/containerd/containerd/api v1.10.0 // indirect
-	github.com/containerd/continuity v0.4.5 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/containerd/fifo v1.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -209,7 +209,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/apiextensions-apiserver v0.35.0 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/go-jose/go-jose/v4 v4.1.3
 	github.com/go-logr/logr v1.4.3
 	github.com/golang-jwt/jwt/v5 v5.3.0
+	github.com/google/go-containerregistry v0.20.1
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
@@ -104,11 +105,16 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v1.0.0-rc.2 // indirect
 	github.com/containerd/plugin v1.0.0 // indirect
+	github.com/containerd/stargz-snapshotter/estargz v0.14.3 // indirect
 	github.com/containerd/ttrpc v1.2.7 // indirect
 	github.com/containerd/typeurl/v2 v2.2.3 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/distribution/reference v0.6.0 // indirect
+	github.com/docker/cli v24.0.0+incompatible // indirect
+	github.com/docker/distribution v2.8.2+incompatible // indirect
+	github.com/docker/docker v24.0.0+incompatible // indirect
+	github.com/docker/docker-credential-helpers v0.7.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
@@ -150,6 +156,7 @@ require (
 	github.com/mdlayher/netlink v1.7.2 // indirect
 	github.com/mdlayher/socket v0.5.1 // indirect
 	github.com/mfridman/interpolate v0.0.2 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/moby/locker v1.0.1 // indirect
 	github.com/moby/sys/mountinfo v0.7.2 // indirect
 	github.com/moby/sys/sequential v0.6.0 // indirect
@@ -176,6 +183,7 @@ require (
 	github.com/tidwall/match v1.2.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.11 // indirect
+	github.com/vbatts/tar-split v0.11.3 // indirect
 	github.com/vishvananda/netns v0.0.5 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/yuin/gopher-lua v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -640,6 +640,8 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools/v3 v3.0.3 h1:4AuOwCGf4lLR9u3YOe2awrHygurzhO/HeQ6laiA6Sx0=
+gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 k8s.io/api v0.35.0 h1:iBAU5LTyBI9vw3L5glmat1njFK34srdLmktWwLTprlY=

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,7 @@ github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1/go.mo
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 h1:XRzhVemXdgvJqCH0sFfrBUTnUJSBrBf7++ypk+twtRs=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0/go.mod h1:HKpQxkWaGLJ+D/5H8QRpyQXA1eKjxkFlOMwck5+33Jk=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
@@ -113,6 +114,8 @@ github.com/containerd/platforms v1.0.0-rc.2 h1:0SPgaNZPVWGEi4grZdV8VRYQn78y+nm6a
 github.com/containerd/platforms v1.0.0-rc.2/go.mod h1:J71L7B+aiM5SdIEqmd9wp6THLVRzJGXfNuWCZCllLA4=
 github.com/containerd/plugin v1.0.0 h1:c8Kf1TNl6+e2TtMHZt+39yAPDbouRH9WAToRjex483Y=
 github.com/containerd/plugin v1.0.0/go.mod h1:hQfJe5nmWfImiqT1q8Si3jLv3ynMUIBB47bQ+KexvO8=
+github.com/containerd/stargz-snapshotter/estargz v0.14.3 h1:OqlDCK3ZVUO6C3B/5FSkDwbkEETK84kQgEeFwDC+62k=
+github.com/containerd/stargz-snapshotter/estargz v0.14.3/go.mod h1:KY//uOCIkSuNAHhJogcZtrNHdKrA99/FCCRjE3HD36o=
 github.com/containerd/ttrpc v1.2.7 h1:qIrroQvuOL9HQ1X6KHe2ohc7p+HP/0VE6XPU7elJRqQ=
 github.com/containerd/ttrpc v1.2.7/go.mod h1:YCXHsb32f+Sq5/72xHubdiJRQY9inL4a4ZQrAbN1q9o=
 github.com/containerd/typeurl/v2 v2.2.3 h1:yNA/94zxWdvYACdYO8zofhrTVuQY73fFU1y++dYSw40=
@@ -121,6 +124,7 @@ github.com/coreos/go-iptables v0.8.0 h1:MPc2P89IhuVpLI7ETL/2tx3XZ61VeICZjYqDEgNs
 github.com/coreos/go-iptables v0.8.0/go.mod h1:Qe8Bv2Xik5FyTXwgIbLAnv2sWSBmvWdFETJConOQ//Q=
 github.com/coreos/go-oidc/v3 v3.17.0 h1:hWBGaQfbi0iVviX4ibC7bk8OKT5qNr4klBaCHVNvehc=
 github.com/coreos/go-oidc/v3 v3.17.0/go.mod h1:wqPbKFrVnE90vty060SB40FCJ8fTHTxSwyXJqZH+sI8=
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.21 h1:1/QdRyBaHHJP61QkWMXlOIBfsgdDeeKfK8SYVUWJKf0=
 github.com/creack/pty v1.1.21/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
@@ -134,6 +138,14 @@ github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/r
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
+github.com/docker/cli v24.0.0+incompatible h1:0+1VshNwBQzQAx9lOl+OYCTCEAD8fKs/qeXMx3O0wqM=
+github.com/docker/cli v24.0.0+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
+github.com/docker/distribution v2.8.2+incompatible h1:T3de5rq0dB1j30rp0sA2rER+m322EBzniBPB6ZIzuh8=
+github.com/docker/distribution v2.8.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+github.com/docker/docker v24.0.0+incompatible h1:z4bf8HvONXX9Tde5lGBMQ7yCJgNahmJumdrStZAbeY4=
+github.com/docker/docker v24.0.0+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker-credential-helpers v0.7.0 h1:xtCHsjxogADNZcdv1pKUHXryefjlVRqWqIhk/uXJp0A=
+github.com/docker/docker-credential-helpers v0.7.0/go.mod h1:rETQfLdHNT3foU5kuNkFR1R1V12OJRRO5lzt2D1b5X0=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/emicklei/go-restful/v3 v3.13.0 h1:C4Bl2xDndpU6nJ4bc1jXd+uTmYPVUwkD6bFY/oTyCes=
@@ -236,6 +248,8 @@ github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/go-containerregistry v0.20.1 h1:eTgx9QNYugV4DN5mz4U8hiAGTi1ybXn0TPi4Smd8du0=
+github.com/google/go-containerregistry v0.20.1/go.mod h1:YCMFNQeeXeLF+dnhhWkqDItx/JSkH01j1Kis4PsjzFI=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -312,6 +326,8 @@ github.com/mfridman/interpolate v0.0.2 h1:pnuTK7MQIxxFz1Gr+rjSIx9u7qVjf5VOoM/u6B
 github.com/mfridman/interpolate v0.0.2/go.mod h1:p+7uk6oE07mpE/Ik1b8EckO0O4ZXiGAfshKBWLUM9Xg=
 github.com/mfridman/tparse v0.18.0 h1:wh6dzOKaIwkUGyKgOntDW4liXSo37qg5AXbIhkMV3vE=
 github.com/mfridman/tparse v0.18.0/go.mod h1:gEvqZTuCgEhPbYk/2lS3Kcxg1GmTxxU7kTC8DvP0i/A=
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
+github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/moby/locker v1.0.1 h1:fOXqR41zeveg4fFODix+1Ch4mj/gT0NE1XJbp/epuBg=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
 github.com/moby/sys/mountinfo v0.7.2 h1:1shs6aH5s4o5H2zQLn796ADW1wMrIwHsyJ2v9KouLrg=
@@ -385,8 +401,10 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sethvargo/go-retry v0.3.0 h1:EEt31A35QhrcRZtrYFDTBg91cqZVnFL2navjDrah2SE=
 github.com/sethvargo/go-retry v0.3.0/go.mod h1:mNX17F0C/HguQMyMyJxcnU471gOZGxCLyYaFyAZraas=
+github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
@@ -423,6 +441,9 @@ github.com/uber/jaeger-lib v2.4.1+incompatible h1:td4jdvLcExb4cBISKIpHuGoVXh+dVK
 github.com/uber/jaeger-lib v2.4.1+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/ugorji/go/codec v1.2.11 h1:BMaWp1Bb6fHwEtbplGBGJ498wD+LKlNSl25MjdZY4dU=
 github.com/ugorji/go/codec v1.2.11/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
+github.com/urfave/cli v1.22.12/go.mod h1:sSBEIC79qR6OvcmsD4U3KABeOTxDqQtdDnaFuUN30b8=
+github.com/vbatts/tar-split v0.11.3 h1:hLFqsOLQ1SsppQNTMpkpPXClLDfC2A3Zgy9OUU+RVck=
+github.com/vbatts/tar-split v0.11.3/go.mod h1:9QlHN18E+fEH7RdG+QAJJcuya3rqT7eXSTY7wGrAokY=
 github.com/vishvananda/netlink v1.3.1 h1:3AEMt62VKqz90r0tmNhog0r/PpWKmrEShJU0wJW6bV0=
 github.com/vishvananda/netlink v1.3.1/go.mod h1:ARtKouGSTGchR8aMwmkzC0qiNPrrWO5JS/XMVl45+b4=
 github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zdEY=
@@ -530,6 +551,7 @@ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220906165534-d0df966e6959/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/infra-operator/internal/controller/services/ctld/ctld.go
+++ b/infra-operator/internal/controller/services/ctld/ctld.go
@@ -77,6 +77,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 		{Name: "ctld-data", MountPath: "/var/lib/sandbox0/ctld"},
 		{Name: "host-cgroup", MountPath: "/host-sys/fs/cgroup"},
 		{Name: "containerd-sock", MountPath: "/host-run/containerd"},
+		{Name: "containerd-state", MountPath: "/host-var-lib/containerd"},
 	}
 	volumes := []corev1.Volume{
 		{
@@ -130,6 +131,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 			Name: "containerd-sock",
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{Path: "/run/containerd"},
+			},
+		},
+		{
+			Name: "containerd-state",
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{Path: "/var/lib/containerd"},
 			},
 		},
 	}
@@ -281,6 +288,8 @@ func ctldArgs(infra *infrav1alpha1.Sandbox0Infra) []string {
 		"-http-addr=:8095",
 		"-cgroup-root=/host-sys/fs/cgroup",
 		"-cri-endpoint=/host-run/containerd/containerd.sock",
+		"-containerd-state-root=/host-var-lib/containerd",
+		"-containerd-state-host-root=/var/lib/containerd",
 		"-volume-portal-root=/var/lib/sandbox0/ctld",
 		"-csi-socket=/csi/csi.sock",
 		fmt.Sprintf("-pause-min-memory-request=%s", pauseMinMemoryRequest),

--- a/infra-operator/internal/controller/services/ctld/ctld_test.go
+++ b/infra-operator/internal/controller/services/ctld/ctld_test.go
@@ -115,6 +115,8 @@ func reconcileCtldDaemonSet(t *testing.T, infra *infrav1alpha1.Sandbox0Infra) *a
 	if len(ds.Spec.Template.Spec.Containers[0].Args) < 5 || ds.Spec.Template.Spec.Containers[0].Args[1] != "-cgroup-root=/host-sys/fs/cgroup" || ds.Spec.Template.Spec.Containers[0].Args[2] != "-cri-endpoint=/host-run/containerd/containerd.sock" {
 		t.Fatalf("expected cgroup root arg, got %#v", ds.Spec.Template.Spec.Containers[0].Args)
 	}
+	assertContainsArg(t, ds.Spec.Template.Spec.Containers[0].Args, "-containerd-state-root=/host-var-lib/containerd")
+	assertContainsArg(t, ds.Spec.Template.Spec.Containers[0].Args, "-containerd-state-host-root=/var/lib/containerd")
 	if ds.Spec.Template.Spec.Containers[0].SecurityContext == nil || ds.Spec.Template.Spec.Containers[0].SecurityContext.Privileged == nil || !*ds.Spec.Template.Spec.Containers[0].SecurityContext.Privileged {
 		t.Fatal("expected ctld container to run privileged")
 	}
@@ -124,6 +126,8 @@ func reconcileCtldDaemonSet(t *testing.T, infra *infrav1alpha1.Sandbox0Infra) *a
 	if len(ds.Spec.Template.Spec.Containers[0].VolumeMounts) < 6 {
 		t.Fatalf("expected ctld config, csi, kubelet, data, cgroup, and containerd mounts, got %#v", ds.Spec.Template.Spec.Containers[0].VolumeMounts)
 	}
+	assertContainerVolumeMount(t, ds.Spec.Template.Spec.Containers[0].VolumeMounts, "containerd-state", "/host-var-lib/containerd")
+	assertHostPathVolume(t, ds.Spec.Template.Spec.Volumes, "containerd-state", "/var/lib/containerd")
 	driver := &storagev1.CSIDriver{}
 	if err := client.Get(context.Background(), types.NamespacedName{Name: "volume.sandbox0.ai"}, driver); err != nil {
 		t.Fatalf("expected csi driver to be created: %v", err)
@@ -208,6 +212,22 @@ func assertPodVolume(t *testing.T, volumes []corev1.Volume, name string) {
 		}
 	}
 	t.Fatalf("expected volume %q, got %#v", name, volumes)
+}
+
+func assertHostPathVolume(t *testing.T, volumes []corev1.Volume, name, path string) {
+	t.Helper()
+	for _, volume := range volumes {
+		if volume.Name == name {
+			if volume.HostPath == nil {
+				t.Fatalf("volume %q is not a hostPath volume: %#v", name, volume)
+			}
+			if volume.HostPath.Path != path {
+				t.Fatalf("hostPath volume %q path = %q, want %q", name, volume.HostPath.Path, path)
+			}
+			return
+		}
+	}
+	t.Fatalf("expected hostPath volume %q, got %#v", name, volumes)
 }
 
 func newCtldTestInfra() *infrav1alpha1.Sandbox0Infra {

--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -312,6 +312,7 @@ func main() {
 	sandboxService.SetCredentialStore(credentialStore)
 	sandboxService.SetQuotaStore(quota.NewRepository(pool))
 	sandboxService.SetSandboxStore(service.NewPGSandboxStore(pool))
+	sandboxService.SetPauseMeteringRecorder(lifecycleProjector)
 	if cfg.StorageProxyBaseURL != "" && cfg.StorageProxyHTTPPort > 0 && storageProxyAdminTokenGenerator != nil {
 		storageProxyBaseURL := fmt.Sprintf("http://%s:%d", strings.TrimSpace(cfg.StorageProxyBaseURL), cfg.StorageProxyHTTPPort)
 		sandboxService.SetWebhookStateVolumeClient(service.NewStorageProxyVolumeClient(service.StorageProxyVolumeClientConfig{

--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -359,6 +359,7 @@ func main() {
 		logger.Warn("Registry provider disabled", zap.Error(err))
 	}
 	registryService := service.NewRegistryService(registryProvider, logger)
+	sandboxService.SetRegistryService(registryService)
 	var templateStore *templstorepg.Store
 	var templateReconciler *templreconciler.SingleClusterReconciler
 	if cfg.TemplateStoreEnabled {

--- a/manager/pkg/metering/lifecycle_projector.go
+++ b/manager/pkg/metering/lifecycle_projector.go
@@ -110,6 +110,23 @@ func (p *LifecycleProjector) ResourceEventHandler() cache.ResourceEventHandlerFu
 	}
 }
 
+// RecordSandboxPaused projects a durable pause without requiring the runtime pod to be patched first.
+func (p *LifecycleProjector) RecordSandboxPaused(_ context.Context, pod *corev1.Pod, pausedAt time.Time) {
+	if p == nil || pod == nil {
+		return
+	}
+	if pausedAt.IsZero() {
+		pausedAt = p.now()
+	}
+	pausedPod := pod.DeepCopy()
+	if pausedPod.Annotations == nil {
+		pausedPod.Annotations = map[string]string{}
+	}
+	pausedPod.Annotations[controller.AnnotationPaused] = "true"
+	pausedPod.Annotations[controller.AnnotationPausedAt] = pausedAt.UTC().Format(time.RFC3339)
+	p.handleUpsert(pausedPod)
+}
+
 func (p *LifecycleProjector) handleUpsert(obj any) {
 	pod := extractPod(obj)
 	if pod == nil {
@@ -223,7 +240,7 @@ func (p *LifecycleProjector) handleDelete(obj any) {
 	templateID := pod.Labels[controller.LabelTemplateID]
 	podUsage := sandboxUsageFromPod(pod)
 	claimedAt, claimedAtSet := parseRFC3339(pod.Annotations[controller.AnnotationClaimedAt])
-	runtimePaused := pod.Annotations[controller.AnnotationRuntimeDeletionReason] == "paused"
+	runtimePaused := pod.Annotations[controller.AnnotationRuntimeDeletionReason] == "paused" || (pod.Annotations[controller.AnnotationRuntimeDeletionReason] == "" && state != nil && state.Paused)
 	pendingEvents := make([]*meteringpkg.Event, 0, 3)
 	pendingWindows := make([]*meteringpkg.Window, 0, 2)
 	if state == nil {
@@ -262,9 +279,11 @@ func (p *LifecycleProjector) handleDelete(obj any) {
 		if !state.Paused {
 			pendingWindows = append(pendingWindows, p.buildSandboxRuntimeWindow(state, teamID, userID, templateID, state.ActiveSince, observedAt))
 			pendingEvents = append(pendingEvents, p.buildSandboxEvent(sandboxID, teamID, userID, templateID, observedAt, meteringpkg.EventTypeSandboxPaused, pauseEventID(sandboxID, observedAt), nil))
+			state.PausedAt = &observedAt
+		} else if state.PausedAt == nil {
+			state.PausedAt = &observedAt
 		}
 		state.Paused = true
-		state.PausedAt = &observedAt
 		state.ActiveSince = nil
 		state.TerminatedAt = nil
 		state.LastObservedAt = observedAt

--- a/manager/pkg/metering/lifecycle_projector_test.go
+++ b/manager/pkg/metering/lifecycle_projector_test.go
@@ -162,6 +162,44 @@ func TestLifecycleProjectorRecordsClaimPauseResumeTerminate(t *testing.T) {
 	}
 }
 
+func TestLifecycleProjectorRecordsDirectPauseWithoutTerminatingRuntimeDelete(t *testing.T) {
+	recorder := &fakeRecorder{states: map[string]*meteringpkg.SandboxProjectionState{}}
+	projector := NewLifecycleProjector(recorder, "aws-us-east-1", "cluster-a")
+
+	now := time.Date(2026, 3, 12, 10, 0, 0, 0, time.UTC)
+	projector.now = func() time.Time { return now }
+
+	claimedAt := now.Add(-10 * time.Minute)
+	pod := withSandboxResources(buildSandboxPod(claimedAt, false, "", "1"), "2", "1Gi")
+	projector.handleUpsert(pod)
+
+	pausedAt := now.Add(-2 * time.Minute)
+	projector.RecordSandboxPaused(context.Background(), pod, pausedAt)
+	if len(recorder.events) != 2 || recorder.events[1].EventType != meteringpkg.EventTypeSandboxPaused {
+		t.Fatalf("expected direct pause event, got %#v", recorder.events)
+	}
+	if len(recorder.windows) != 2 || recorder.windows[1].WindowType != meteringpkg.WindowTypeSandboxRuntimeMiBMilliseconds {
+		t.Fatalf("expected direct pause runtime window, got %#v", recorder.windows)
+	}
+
+	projector.now = func() time.Time { return pausedAt.Add(5 * time.Second) }
+	projector.handleDelete(pod)
+	if len(recorder.events) != 2 {
+		t.Fatalf("runtime delete after direct pause recorded extra events: %#v", recorder.events)
+	}
+	state := recorder.states["sb-1"]
+	if state == nil || !state.Paused || state.TerminatedAt != nil {
+		t.Fatalf("runtime delete state = %#v, want paused and not terminated", state)
+	}
+
+	projector.now = func() time.Time { return now.Add(time.Minute) }
+	resumedPod := withSandboxResources(buildSandboxPod(claimedAt, false, "", "3"), "2", "1Gi")
+	projector.handleUpsert(resumedPod)
+	if len(recorder.events) != 3 || recorder.events[2].EventType != meteringpkg.EventTypeSandboxResumed {
+		t.Fatalf("expected resume event after direct pause runtime delete, got %#v", recorder.events)
+	}
+}
+
 func TestLifecycleProjectorRecordsErrorsInMetrics(t *testing.T) {
 	recorder := &fakeRecorder{
 		states: map[string]*meteringpkg.SandboxProjectionState{},

--- a/manager/pkg/service/ctld_client.go
+++ b/manager/pkg/service/ctld_client.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"time"
 
@@ -78,6 +79,10 @@ func (c *CtldClient) ApplyRootFS(ctx context.Context, ctldAddress string, req ct
 
 func (c *CtldClient) ApplyRootFSWithTimeout(ctx context.Context, ctldAddress string, req ctldapi.ApplyRootFSRequest, timeout time.Duration) (*ctldapi.ApplyRootFSResponse, error) {
 	return c.apiWithTimeout(timeout).ApplyRootFS(ctx, ctldAddress, req)
+}
+
+func (c *CtldClient) OpenRootFSDiffWithTimeout(ctx context.Context, ctldAddress string, req ctldapi.ReadRootFSDiffRequest, timeout time.Duration) (io.ReadCloser, error) {
+	return c.apiWithTimeout(timeout).OpenRootFSDiff(ctx, ctldAddress, req)
 }
 
 func (c *CtldClient) PrepareVolumePortalHandoff(ctx context.Context, ctldAddress string, req ctldapi.PrepareVolumePortalHandoffRequest) (*ctldapi.PrepareVolumePortalHandoffResponse, error) {

--- a/manager/pkg/service/migrations/00002_add_sandbox_rootfs_states.sql
+++ b/manager/pkg/service/migrations/00002_add_sandbox_rootfs_states.sql
@@ -6,6 +6,7 @@ CREATE TABLE IF NOT EXISTS sandbox_rootfs_states (
     runtime_generation BIGINT NOT NULL,
     runtime TEXT NOT NULL DEFAULT '',
     runtime_handler TEXT NOT NULL DEFAULT '',
+    node_name TEXT NOT NULL DEFAULT '',
     base_image_ref TEXT NOT NULL DEFAULT '',
     base_image_digest TEXT NOT NULL DEFAULT '',
     snapshotter TEXT NOT NULL DEFAULT '',

--- a/manager/pkg/service/power_executor.go
+++ b/manager/pkg/service/power_executor.go
@@ -36,6 +36,26 @@ func (s *SandboxService) ctldAddressForPod(ctx context.Context, pod *corev1.Pod)
 	return ctldAddressForNode(node, s.config.CtldPort)
 }
 
+func (s *SandboxService) ctldAddressForNodeName(ctx context.Context, nodeName string) (string, error) {
+	if nodeName == "" {
+		return "", fmt.Errorf("node name is required")
+	}
+	if s.nodeLister != nil {
+		node, err := s.nodeLister.Get(nodeName)
+		if err == nil {
+			return ctldAddressForNode(node, s.config.CtldPort)
+		}
+	}
+	if s.k8sClient == nil {
+		return "", fmt.Errorf("kubernetes client is not configured")
+	}
+	node, err := s.k8sClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("get node %s: %w", nodeName, err)
+	}
+	return ctldAddressForNode(node, s.config.CtldPort)
+}
+
 func ctldAddressForNode(node *corev1.Node, port int) (string, error) {
 	if node == nil {
 		return "", fmt.Errorf("node is nil")

--- a/manager/pkg/service/sandbox_lifecycle_controller.go
+++ b/manager/pkg/service/sandbox_lifecycle_controller.go
@@ -327,7 +327,19 @@ func (s *SandboxService) CleanupDeletedSandbox(ctx context.Context, info Sandbox
 		return nil
 	}
 
-	runtimePaused := strings.TrimSpace(info.RuntimeDeletionReason) == runtimeDeletionReasonPaused
+	runtimeDeletionReason := strings.TrimSpace(info.RuntimeDeletionReason)
+	runtimePaused := runtimeDeletionReason == runtimeDeletionReasonPaused
+	if !runtimePaused && runtimeDeletionReason == "" && s.sandboxStore != nil && sandboxID != "" {
+		record, err := s.sandboxStore.GetSandbox(ctx, sandboxID)
+		if err == nil && record != nil && record.Status == SandboxStatusPaused {
+			runtimePaused = true
+		} else if err != nil && !errors.Is(err, ErrSandboxRecordNotFound) {
+			logger.Warn("Failed to load sandbox state during deletion cleanup",
+				zap.String("sandboxID", sandboxID),
+				zap.Error(err),
+			)
+		}
+	}
 	var errs []error
 	if !runtimePaused && s.deletionWebhookEmitter != nil && strings.TrimSpace(info.WebhookURL) != "" {
 		if err := s.deletionWebhookEmitter.EmitSandboxDeleted(ctx, info); err != nil {

--- a/manager/pkg/service/sandbox_rootfs_image.go
+++ b/manager/pkg/service/sandbox_rootfs_image.go
@@ -1,0 +1,266 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/tarball"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/registry"
+	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
+	"go.uber.org/zap"
+)
+
+type RootFSCheckpointImage struct {
+	PushRef string
+	PullRef string
+}
+
+type RootFSCheckpointImagePublishRequest struct {
+	TeamID      string
+	CtldAddress string
+	State       *SandboxRootFSState
+}
+
+type RootFSCheckpointImagePublisher interface {
+	Publish(ctx context.Context, req RootFSCheckpointImagePublishRequest) (*RootFSCheckpointImage, error)
+}
+
+type rootFSDiffOpener interface {
+	OpenRootFSDiffWithTimeout(ctx context.Context, ctldAddress string, req ctldapi.ReadRootFSDiffRequest, timeout time.Duration) (io.ReadCloser, error)
+}
+
+type RegistryRootFSCheckpointImagePublisher struct {
+	registry *RegistryService
+	ctld     rootFSDiffOpener
+	logger   *zap.Logger
+}
+
+func NewRegistryRootFSCheckpointImagePublisher(registryService *RegistryService, ctld rootFSDiffOpener, logger *zap.Logger) *RegistryRootFSCheckpointImagePublisher {
+	return &RegistryRootFSCheckpointImagePublisher{
+		registry: registryService,
+		ctld:     ctld,
+		logger:   logger,
+	}
+}
+
+func (p *RegistryRootFSCheckpointImagePublisher) Publish(ctx context.Context, req RootFSCheckpointImagePublishRequest) (*RootFSCheckpointImage, error) {
+	if p == nil || p.registry == nil {
+		return nil, fmt.Errorf("registry provider is required to publish rootfs checkpoint image")
+	}
+	if p.ctld == nil {
+		return nil, fmt.Errorf("ctld client is required to read rootfs checkpoint diff")
+	}
+	state := req.State
+	if state == nil {
+		return nil, fmt.Errorf("rootfs state is required")
+	}
+	ctldAddress := strings.TrimSpace(req.CtldAddress)
+	if ctldAddress == "" {
+		return nil, fmt.Errorf("ctld address is required")
+	}
+
+	targetImage, err := rootFSCheckpointTargetImage(state)
+	if err != nil {
+		return nil, err
+	}
+	teamID := strings.TrimSpace(req.TeamID)
+	if teamID == "" {
+		teamID = state.TeamID
+	}
+	creds, err := p.registry.GetPushCredentials(ctx, registry.PushCredentialsRequest{
+		TeamID:      teamID,
+		TargetImage: targetImage,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get checkpoint image registry credentials: %w", err)
+	}
+	if creds == nil || strings.TrimSpace(creds.PushRegistry) == "" {
+		return nil, fmt.Errorf("checkpoint image registry returned no push registry")
+	}
+	pushRef := joinImageReference(creds.PushRegistry, targetImage)
+	pullRegistry := strings.TrimSpace(creds.PullRegistry)
+	if pullRegistry == "" {
+		pullRegistry = creds.PushRegistry
+	}
+	pullRef := joinImageReference(pullRegistry, targetImage)
+
+	baseImageRef, err := checkpointBaseImageRef(state)
+	if err != nil {
+		return nil, err
+	}
+	baseRef, err := name.ParseReference(baseImageRef, name.WeakValidation)
+	if err != nil {
+		return nil, fmt.Errorf("parse checkpoint base image ref %q: %w", baseImageRef, err)
+	}
+	baseImage, err := remote.Image(baseRef, remoteOptionsForRegistryCredentials(ctx, creds, baseRef)...)
+	if err != nil {
+		return nil, fmt.Errorf("pull checkpoint base image %q: %w", baseImageRef, err)
+	}
+
+	diffReader, err := p.ctld.OpenRootFSDiffWithTimeout(ctx, ctldAddress, ctldapi.ReadRootFSDiffRequest{
+		Descriptor: rootFSDiffDescriptorFromState(state),
+	}, sandboxRootFSOperationTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("open rootfs checkpoint diff: %w", err)
+	}
+	defer diffReader.Close()
+
+	mediaType := strings.TrimSpace(state.DiffMediaType)
+	if mediaType == "" {
+		mediaType = "application/vnd.oci.image.layer.v1.tar"
+	}
+	layer, err := tarball.LayerFromReader(diffReader, tarball.WithMediaType(types.MediaType(mediaType)))
+	if err != nil {
+		return nil, fmt.Errorf("create checkpoint layer: %w", err)
+	}
+	image, err := mutate.AppendLayers(baseImage, layer)
+	if err != nil {
+		return nil, fmt.Errorf("append checkpoint layer: %w", err)
+	}
+
+	pushReference, err := name.ParseReference(pushRef, name.WeakValidation)
+	if err != nil {
+		return nil, fmt.Errorf("parse checkpoint image ref %q: %w", pushRef, err)
+	}
+	options := []remote.Option{remote.WithContext(ctx)}
+	if strings.TrimSpace(creds.Username) != "" || strings.TrimSpace(creds.Password) != "" {
+		options = append(options, remote.WithAuth(authn.FromConfig(authn.AuthConfig{
+			Username: creds.Username,
+			Password: creds.Password,
+		})))
+	}
+	if err := remote.Write(pushReference, image, options...); err != nil {
+		return nil, fmt.Errorf("push checkpoint image %q: %w", pushRef, err)
+	}
+	if p.logger != nil {
+		p.logger.Info("Published rootfs checkpoint image",
+			zap.String("sandboxID", state.SandboxID),
+			zap.String("runtime", state.Runtime),
+			zap.String("pushRef", pushRef),
+			zap.String("pullRef", pullRef),
+		)
+	}
+	return &RootFSCheckpointImage{PushRef: pushRef, PullRef: pullRef}, nil
+}
+
+func remoteOptionsForRegistryCredentials(ctx context.Context, creds *registry.Credential, ref name.Reference) []remote.Option {
+	options := []remote.Option{remote.WithContext(ctx)}
+	if registryCredentialsMatchReference(creds, ref) {
+		options = append(options, remote.WithAuth(authn.FromConfig(authn.AuthConfig{
+			Username: creds.Username,
+			Password: creds.Password,
+		})))
+	}
+	return options
+}
+
+func registryCredentialsMatchReference(creds *registry.Credential, ref name.Reference) bool {
+	if creds == nil || ref == nil {
+		return false
+	}
+	if strings.TrimSpace(creds.Username) == "" && strings.TrimSpace(creds.Password) == "" {
+		return false
+	}
+	refHost := strings.ToLower(strings.TrimSpace(ref.Context().RegistryStr()))
+	if refHost == "" {
+		return false
+	}
+	for _, registryRef := range []string{creds.PushRegistry, creds.PullRegistry} {
+		if registryCredentialHost(registryRef) == refHost {
+			return true
+		}
+	}
+	return false
+}
+
+func registryCredentialHost(raw string) string {
+	raw = strings.ToLower(strings.TrimSpace(raw))
+	raw = strings.TrimPrefix(raw, "https://")
+	raw = strings.TrimPrefix(raw, "http://")
+	if idx := strings.Index(raw, "/"); idx >= 0 {
+		raw = raw[:idx]
+	}
+	return raw
+}
+
+func rootFSDiffDescriptorFromState(state *SandboxRootFSState) ctldapi.RootFSDiffDescriptor {
+	if state == nil {
+		return ctldapi.RootFSDiffDescriptor{}
+	}
+	return ctldapi.RootFSDiffDescriptor{
+		MediaType: state.DiffMediaType,
+		Digest:    state.DiffDigest,
+		Size:      state.DiffSize,
+		ObjectKey: state.DiffObjectKey,
+	}
+}
+
+func rootFSCheckpointTargetImage(state *SandboxRootFSState) (string, error) {
+	if state == nil {
+		return "", fmt.Errorf("rootfs state is required")
+	}
+	sandboxID := sanitizeImagePathComponent(state.SandboxID)
+	if sandboxID == "" {
+		return "", fmt.Errorf("sandbox id is required")
+	}
+	shortDigest := shortImageDigest(state.DiffDigest)
+	if shortDigest == "" {
+		return "", fmt.Errorf("diff digest is required")
+	}
+	return fmt.Sprintf("sandbox-rootfs/%s:g%d-%s", sandboxID, state.RuntimeGeneration, shortDigest), nil
+}
+
+func joinImageReference(registryHost, image string) string {
+	return strings.TrimRight(strings.TrimSpace(registryHost), "/") + "/" + strings.TrimLeft(strings.TrimSpace(image), "/")
+}
+
+func sanitizeImagePathComponent(raw string) string {
+	raw = strings.ToLower(strings.TrimSpace(raw))
+	var b strings.Builder
+	lastDash := false
+	for _, r := range raw {
+		allowed := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '.' || r == '_' || r == '-'
+		if allowed {
+			b.WriteRune(r)
+			lastDash = false
+			continue
+		}
+		if !lastDash {
+			b.WriteByte('-')
+			lastDash = true
+		}
+	}
+	value := strings.Trim(b.String(), ".-_")
+	if value == "" {
+		return ""
+	}
+	if ch := value[0]; ch < 'a' || ch > 'z' {
+		if ch < '0' || ch > '9' {
+			value = "s" + value
+		}
+	}
+	return value
+}
+
+func shortImageDigest(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	if _, value, ok := strings.Cut(raw, ":"); ok {
+		raw = value
+	}
+	raw = strings.TrimSpace(raw)
+	if len(raw) > 16 {
+		return raw[:16]
+	}
+	return raw
+}

--- a/manager/pkg/service/sandbox_rootfs_image_test.go
+++ b/manager/pkg/service/sandbox_rootfs_image_test.go
@@ -1,0 +1,52 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/registry"
+)
+
+func TestRegistryCredentialsMatchReference(t *testing.T) {
+	ref, err := name.ParseReference("registry.example.com/team/base@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", name.WeakValidation)
+	if err != nil {
+		t.Fatalf("ParseReference() error = %v", err)
+	}
+
+	creds := &registry.Credential{
+		PushRegistry: "https://registry.example.com/team-1",
+		Username:     "user",
+		Password:     "pass",
+	}
+	if !registryCredentialsMatchReference(creds, ref) {
+		t.Fatalf("expected credentials to match base image registry host")
+	}
+}
+
+func TestRegistryCredentialsMatchReferenceRejectsOtherHost(t *testing.T) {
+	ref, err := name.ParseReference("docker.io/library/busybox:1.36", name.WeakValidation)
+	if err != nil {
+		t.Fatalf("ParseReference() error = %v", err)
+	}
+
+	creds := &registry.Credential{
+		PushRegistry: "registry.example.com/team-1",
+		Username:     "user",
+		Password:     "pass",
+	}
+	if registryCredentialsMatchReference(creds, ref) {
+		t.Fatalf("expected credentials not to match a different registry host")
+	}
+}
+
+func TestRegistryCredentialsMatchReferenceRejectsEmptyAuth(t *testing.T) {
+	ref, err := name.ParseReference("registry.example.com/team/base:latest", name.WeakValidation)
+	if err != nil {
+		t.Fatalf("ParseReference() error = %v", err)
+	}
+
+	creds := &registry.Credential{PushRegistry: "registry.example.com/team-1"}
+	if registryCredentialsMatchReference(creds, ref) {
+		t.Fatalf("expected empty credentials not to match")
+	}
+}

--- a/manager/pkg/service/sandbox_runtime_identity_test.go
+++ b/manager/pkg/service/sandbox_runtime_identity_test.go
@@ -249,6 +249,72 @@ func TestResumePausedSandboxRuntimeDoesNotCreatePodWhileRuntimeDeleting(t *testi
 	}
 }
 
+func TestWaitForPausedRuntimeDeletionReturnsAfterAPINotFound(t *testing.T) {
+	deletionTime := metav1.NewTime(time.Now().UTC())
+	pod := runtimeIdentityPod("ns-a", "pod-a", "sandbox-a")
+	pod.DeletionTimestamp = &deletionTime
+	pod.Annotations[controller.AnnotationRuntimeDeletionReason] = runtimeDeletionReasonPaused
+	svc := &SandboxService{
+		k8sClient: fake.NewSimpleClientset(),
+		logger:    zap.NewNop(),
+	}
+
+	if !pausedRuntimeDeletionPending(pod) {
+		t.Fatal("expected paused runtime deletion to be detected")
+	}
+	if err := svc.waitForPausedRuntimeDeletion(context.Background(), pod); err != nil {
+		t.Fatalf("waitForPausedRuntimeDeletion() error = %v", err)
+	}
+}
+
+func TestPausedRuntimeDeletionPendingRefreshesFromAPI(t *testing.T) {
+	deletionTime := metav1.NewTime(time.Now().UTC())
+	stalePod := runtimeIdentityPod("ns-a", "pod-a", "sandbox-a")
+	stalePod.DeletionTimestamp = &deletionTime
+	currentPod := stalePod.DeepCopy()
+	currentPod.Annotations[controller.AnnotationRuntimeDeletionReason] = runtimeDeletionReasonPaused
+	svc := &SandboxService{
+		k8sClient: fake.NewSimpleClientset(currentPod),
+		logger:    zap.NewNop(),
+	}
+
+	pending, err := svc.pausedRuntimeDeletionPending(context.Background(), stalePod)
+	if err != nil {
+		t.Fatalf("pausedRuntimeDeletionPending() error = %v", err)
+	}
+	if !pending {
+		t.Fatal("pausedRuntimeDeletionPending() = false, want true from API refresh")
+	}
+}
+
+func TestGetSandboxReturnsPausedRecordWhileOldRuntimeStillExists(t *testing.T) {
+	pod := runtimeIdentityPod("ns-a", "pod-a", "sandbox-a")
+	store := &memorySandboxStore{records: map[string]*SandboxRecord{
+		"sandbox-a": {
+			ID:           "sandbox-a",
+			TeamID:       "team-a",
+			UserID:       "user-a",
+			TemplateID:   "default",
+			Status:       SandboxStatusPaused,
+			TemplateSpec: v1alpha1.SandboxTemplateSpec{},
+		},
+	}}
+	svc := &SandboxService{
+		podLister:    runtimeIdentityPodLister(t, pod),
+		sandboxStore: store,
+		logger:       zap.NewNop(),
+	}
+
+	sandbox, err := svc.GetSandbox(context.Background(), "sandbox-a")
+
+	if err != nil {
+		t.Fatalf("GetSandbox() error = %v", err)
+	}
+	if sandbox.Status != SandboxStatusPaused || !sandbox.Paused {
+		t.Fatalf("sandbox status = %q paused=%v, want paused record", sandbox.Status, sandbox.Paused)
+	}
+}
+
 func TestResumePausedSandboxRuntimeRejectsHardExpiredRecord(t *testing.T) {
 	now := time.Date(2026, time.March, 7, 12, 0, 0, 0, time.UTC)
 	hardExpiresAt := now.Add(-time.Second)

--- a/manager/pkg/service/sandbox_runtime_identity_test.go
+++ b/manager/pkg/service/sandbox_runtime_identity_test.go
@@ -144,6 +144,10 @@ func (t memorySandboxStoreTx) SaveRootFSState(_ context.Context, state *SandboxR
 	return t.store.SaveRootFSState(context.Background(), state)
 }
 
+func (t memorySandboxStoreTx) GetLatestRootFSState(_ context.Context, sandboxID string) (*SandboxRootFSState, error) {
+	return cloneSandboxRootFSState(t.store.rootFSStates[sandboxID]), nil
+}
+
 func cloneSandboxRecord(record *SandboxRecord) *SandboxRecord {
 	if record == nil {
 		return nil

--- a/manager/pkg/service/sandbox_service.go
+++ b/manager/pkg/service/sandbox_service.go
@@ -130,6 +130,8 @@ type SandboxService struct {
 	deletionWebhookEmitter SandboxDeletionWebhookEmitter
 	quotaStore             TeamQuotaLimitStore
 	sandboxStore           SandboxStore
+	registryService        *RegistryService
+	rootFSImagePublisher   RootFSCheckpointImagePublisher
 	powerStateLocks        sync.Map
 }
 
@@ -277,6 +279,17 @@ func (s *SandboxService) SetDeletionWebhookEmitter(emitter SandboxDeletionWebhoo
 // SetQuotaStore injects the team quota limit store. Nil disables quota checks.
 func (s *SandboxService) SetQuotaStore(store TeamQuotaLimitStore) {
 	s.quotaStore = store
+}
+
+func (s *SandboxService) SetRegistryService(registryService *RegistryService) {
+	s.registryService = registryService
+	if registryService != nil && s.ctldClient != nil {
+		s.rootFSImagePublisher = NewRegistryRootFSCheckpointImagePublisher(registryService, s.ctldClient, s.logger)
+	}
+}
+
+func (s *SandboxService) SetRootFSImagePublisher(publisher RootFSCheckpointImagePublisher) {
+	s.rootFSImagePublisher = publisher
 }
 
 // SetSandboxStore injects durable sandbox identity storage.

--- a/manager/pkg/service/sandbox_service.go
+++ b/manager/pkg/service/sandbox_service.go
@@ -75,6 +75,7 @@ var ErrSandboxCheckpointRequiresCtld = errors.New("sandbox checkpoint pause requ
 
 const defaultPodClaimReadyTimeout = 90 * time.Second
 const defaultSandboxRestoreTimeout = 2 * time.Minute
+const defaultPausedRuntimeDeletionWaitTimeout = 10 * time.Second
 
 // claimIdlePodBackoff is the retry backoff for claiming idle pods.
 // Designed to balance between:

--- a/manager/pkg/service/sandbox_service.go
+++ b/manager/pkg/service/sandbox_service.go
@@ -14,6 +14,7 @@ import (
 	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
 	"github.com/sandbox0-ai/sandbox0/pkg/quota"
 	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
@@ -130,6 +131,7 @@ type SandboxService struct {
 	deletionWebhookEmitter SandboxDeletionWebhookEmitter
 	quotaStore             TeamQuotaLimitStore
 	sandboxStore           SandboxStore
+	pauseMeteringRecorder  SandboxPauseMeteringRecorder
 	registryService        *RegistryService
 	rootFSImagePublisher   RootFSCheckpointImagePublisher
 	powerStateLocks        sync.Map
@@ -155,6 +157,11 @@ type TimeProvider interface {
 	Now() time.Time
 	Since(t time.Time) time.Duration
 	Until(t time.Time) time.Duration
+}
+
+// SandboxPauseMeteringRecorder records pause facts without requiring a Kubernetes pod patch.
+type SandboxPauseMeteringRecorder interface {
+	RecordSandboxPaused(ctx context.Context, pod *corev1.Pod, pausedAt time.Time)
 }
 
 // systemTime is the default implementation using system time
@@ -238,6 +245,13 @@ func (s *SandboxService) SetProcdClient(client *ProcdClient) {
 		return
 	}
 	s.procdClient = client
+}
+
+func (s *SandboxService) SetPauseMeteringRecorder(recorder SandboxPauseMeteringRecorder) {
+	if s == nil {
+		return
+	}
+	s.pauseMeteringRecorder = recorder
 }
 
 // SetCtldClient overrides the ctld client (used by tests and future node runtimes).

--- a/manager/pkg/service/sandbox_service_lifecycle.go
+++ b/manager/pkg/service/sandbox_service_lifecycle.go
@@ -111,10 +111,12 @@ func (s *SandboxService) pauseSandboxRuntimeWithCheckpoint(ctx context.Context, 
 		s.restoreSandboxRuntimeAfterPauseFailure(ctx, sandboxID, plan.pod, plan.generation)
 		return err
 	}
-	if err := s.finishSandboxRuntimePause(ctx, sandboxID, plan.generation); err != nil {
+	pausedAt, err := s.finishSandboxRuntimePause(ctx, sandboxID, plan.generation)
+	if err != nil {
 		s.restoreSandboxRuntimeAfterPauseFailure(ctx, sandboxID, plan.pod, plan.generation)
 		return err
 	}
+	s.recordSandboxPaused(ctx, plan.pod, pausedAt)
 	s.deleteRuntimePodForPauseAsync(sandboxID, plan.pod)
 	return nil
 }
@@ -196,11 +198,15 @@ func (s *SandboxService) deleteRuntimePodForPauseAsync(sandboxID string, pod *co
 	}()
 }
 
-func (s *SandboxService) finishSandboxRuntimePause(ctx context.Context, sandboxID string, generation int64) error {
-	if s == nil || s.sandboxStore == nil {
-		return nil
+func (s *SandboxService) finishSandboxRuntimePause(ctx context.Context, sandboxID string, generation int64) (time.Time, error) {
+	pausedAt := time.Now()
+	if s != nil && s.clock != nil {
+		pausedAt = s.clock.Now()
 	}
-	return s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, record *SandboxRecord) error {
+	if s == nil || s.sandboxStore == nil {
+		return pausedAt, nil
+	}
+	err := s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, record *SandboxRecord) error {
 		if record != nil {
 			switch record.Status {
 			case SandboxStatusDeleted:
@@ -213,10 +219,18 @@ func (s *SandboxService) finishSandboxRuntimePause(ctx context.Context, sandboxI
 			}
 		}
 		if tx != nil {
-			return tx.MarkRuntimePaused(lockCtx, sandboxID, generation, s.clock.Now())
+			return tx.MarkRuntimePaused(lockCtx, sandboxID, generation, pausedAt)
 		}
 		return nil
 	})
+	return pausedAt, err
+}
+
+func (s *SandboxService) recordSandboxPaused(ctx context.Context, pod *corev1.Pod, pausedAt time.Time) {
+	if s == nil || s.pauseMeteringRecorder == nil || pod == nil {
+		return
+	}
+	s.pauseMeteringRecorder.RecordSandboxPaused(ctx, pod, pausedAt)
 }
 
 func (s *SandboxService) restoreSandboxRuntimeAfterPauseFailure(ctx context.Context, sandboxID string, pod *corev1.Pod, generation int64) {

--- a/manager/pkg/service/sandbox_service_lifecycle.go
+++ b/manager/pkg/service/sandbox_service_lifecycle.go
@@ -35,7 +35,9 @@ func (s *SandboxService) TerminateSandbox(ctx context.Context, sandboxID string)
 					return fmt.Errorf("get sandbox record: %w", getErr)
 				}
 				if record != nil && record.Status != SandboxStatusDeleted {
-					if err := s.CleanupDeletedSandbox(ctx, sandboxLifecycleInfoFromRecord(record)); err != nil {
+					info := sandboxLifecycleInfoFromRecord(record)
+					info.RuntimeDeletionReason = runtimeDeletionReasonDeleted
+					if err := s.CleanupDeletedSandbox(ctx, info); err != nil {
 						return fmt.Errorf("cleanup deleted sandbox record: %w", err)
 					}
 				}
@@ -109,12 +111,6 @@ func (s *SandboxService) pauseSandboxRuntimeWithCheckpoint(ctx context.Context, 
 		s.restoreSandboxRuntimeAfterPauseFailure(ctx, sandboxID, plan.pod, plan.generation)
 		return err
 	}
-	preparedPod, err := s.prepareRuntimePodForDeletion(ctx, plan.pod, runtimeDeletionReasonPaused)
-	if err != nil {
-		s.restoreSandboxRuntimeAfterPauseFailure(ctx, sandboxID, plan.pod, plan.generation)
-		return fmt.Errorf("prepare paused runtime deletion: %w", err)
-	}
-	plan.pod = preparedPod
 	if err := s.finishSandboxRuntimePause(ctx, sandboxID, plan.generation); err != nil {
 		s.restoreSandboxRuntimeAfterPauseFailure(ctx, sandboxID, plan.pod, plan.generation)
 		return err
@@ -169,10 +165,6 @@ func (s *SandboxService) prepareSandboxRuntimePause(ctx context.Context, sandbox
 }
 
 func (s *SandboxService) deleteRuntimePodForPause(ctx context.Context, pod *corev1.Pod) error {
-	pod, err := s.prepareRuntimePodForDeletion(ctx, pod, runtimeDeletionReasonPaused)
-	if err != nil {
-		return fmt.Errorf("prepare runtime deletion: %w", err)
-	}
 	return s.deletePreparedRuntimePodForPause(ctx, pod)
 }
 

--- a/manager/pkg/service/sandbox_service_lifecycle.go
+++ b/manager/pkg/service/sandbox_service_lifecycle.go
@@ -47,13 +47,9 @@ func (s *SandboxService) TerminateSandbox(ctx context.Context, sandboxID string)
 	}
 	s.thawSandboxBeforeTermination(ctx, pod, sandboxID)
 
-	pod, err = s.ensureSandboxDeletionFinalizer(ctx, pod)
+	pod, err = s.prepareRuntimePodForDeletion(ctx, pod, runtimeDeletionReasonDeleted)
 	if err != nil {
-		return fmt.Errorf("ensure sandbox cleanup finalizer: %w", err)
-	}
-	pod, err = s.markRuntimeDeletionReason(ctx, pod, runtimeDeletionReasonDeleted)
-	if err != nil {
-		return fmt.Errorf("mark sandbox deletion reason: %w", err)
+		return fmt.Errorf("prepare sandbox deletion: %w", err)
 	}
 
 	err = s.k8sClient.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{})
@@ -84,8 +80,172 @@ func (s *SandboxService) PauseSandboxRuntime(ctx context.Context, sandboxID stri
 	return s.pauseSandboxRuntime(ctx, sandboxID, true)
 }
 
+type sandboxRuntimePausePlan struct {
+	record     *SandboxRecord
+	pod        *corev1.Pod
+	generation int64
+}
+
 func (s *SandboxService) pauseSandboxRuntime(ctx context.Context, sandboxID string, saveRootFS bool) error {
 	s.logger.Info("Pausing sandbox runtime", zap.String("sandboxID", sandboxID))
+	if s.sandboxStore != nil && saveRootFS {
+		return s.pauseSandboxRuntimeWithCheckpoint(ctx, sandboxID)
+	}
+	return s.pauseSandboxRuntimeSynchronous(ctx, sandboxID, saveRootFS)
+}
+
+func (s *SandboxService) pauseSandboxRuntimeWithCheckpoint(ctx context.Context, sandboxID string) error {
+	plan, err := s.prepareSandboxRuntimePause(ctx, sandboxID)
+	if err != nil {
+		if errors.Is(err, ErrSandboxRecordNotFound) {
+			return s.pauseSandboxRuntimeSynchronous(ctx, sandboxID, true)
+		}
+		return err
+	}
+	if plan == nil {
+		return nil
+	}
+	if err := s.saveSandboxRootFSCheckpoint(ctx, plan.pod, plan.record, nil); err != nil {
+		s.restoreSandboxRuntimeAfterPauseFailure(ctx, sandboxID, plan.pod, plan.generation)
+		return err
+	}
+	preparedPod, err := s.prepareRuntimePodForDeletion(ctx, plan.pod, runtimeDeletionReasonPaused)
+	if err != nil {
+		s.restoreSandboxRuntimeAfterPauseFailure(ctx, sandboxID, plan.pod, plan.generation)
+		return fmt.Errorf("prepare paused runtime deletion: %w", err)
+	}
+	plan.pod = preparedPod
+	if err := s.finishSandboxRuntimePause(ctx, sandboxID, plan.generation); err != nil {
+		s.restoreSandboxRuntimeAfterPauseFailure(ctx, sandboxID, plan.pod, plan.generation)
+		return err
+	}
+	s.deleteRuntimePodForPauseAsync(sandboxID, plan.pod)
+	return nil
+}
+
+func (s *SandboxService) prepareSandboxRuntimePause(ctx context.Context, sandboxID string) (*sandboxRuntimePausePlan, error) {
+	if s == nil || !s.config.CtldEnabled || s.ctldClient == nil {
+		return nil, ErrSandboxCheckpointRequiresCtld
+	}
+	var plan *sandboxRuntimePausePlan
+	err := s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, record *SandboxRecord) error {
+		if record != nil {
+			switch record.Status {
+			case SandboxStatusDeleted:
+				return k8serrors.NewNotFound(schema.GroupResource{Resource: "sandbox"}, sandboxID)
+			case SandboxStatusPaused:
+				return nil
+			case SandboxStatusStarting, SandboxStatusPausing, SandboxStatusResuming:
+				return k8serrors.NewConflict(schema.GroupResource{Resource: "sandbox"}, sandboxID, fmt.Errorf("sandbox lifecycle operation %q is in progress", record.Status))
+			}
+		}
+		pod, err := s.getSandboxPod(lockCtx, sandboxID)
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				if tx != nil {
+					return tx.MarkRuntimePaused(lockCtx, sandboxID, 0, s.clock.Now())
+				}
+				return nil
+			}
+			return fmt.Errorf("get pod: %w", err)
+		}
+		generation := runtimeGenerationFromPod(pod)
+		if tx != nil {
+			if err := tx.SaveRuntime(lockCtx, sandboxID, pod.Namespace, pod.Name, SandboxStatusPausing, generation, parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationExpiresAt), parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationHardExpiresAt)); err != nil {
+				return err
+			}
+		}
+		plan = &sandboxRuntimePausePlan{
+			record:     record,
+			pod:        pod,
+			generation: generation,
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return plan, nil
+}
+
+func (s *SandboxService) deleteRuntimePodForPause(ctx context.Context, pod *corev1.Pod) error {
+	pod, err := s.prepareRuntimePodForDeletion(ctx, pod, runtimeDeletionReasonPaused)
+	if err != nil {
+		return fmt.Errorf("prepare runtime deletion: %w", err)
+	}
+	return s.deletePreparedRuntimePodForPause(ctx, pod)
+}
+
+func (s *SandboxService) deletePreparedRuntimePodForPause(ctx context.Context, pod *corev1.Pod) error {
+	if s == nil || s.k8sClient == nil || pod == nil {
+		return nil
+	}
+	if err := s.k8sClient.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{}); err != nil && !k8serrors.IsNotFound(err) {
+		return fmt.Errorf("delete runtime pod: %w", err)
+	}
+	return nil
+}
+
+func (s *SandboxService) deleteRuntimePodForPauseAsync(sandboxID string, pod *corev1.Pod) {
+	if s == nil || s.k8sClient == nil || pod == nil {
+		return
+	}
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := s.deleteRuntimePodForPause(ctx, pod); err != nil && s.logger != nil {
+			s.logger.Warn("Failed to delete paused sandbox runtime pod",
+				zap.String("sandboxID", sandboxID),
+				zap.String("namespace", pod.Namespace),
+				zap.String("pod", pod.Name),
+				zap.Error(err),
+			)
+		}
+	}()
+}
+
+func (s *SandboxService) finishSandboxRuntimePause(ctx context.Context, sandboxID string, generation int64) error {
+	if s == nil || s.sandboxStore == nil {
+		return nil
+	}
+	return s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, record *SandboxRecord) error {
+		if record != nil {
+			switch record.Status {
+			case SandboxStatusDeleted:
+				return k8serrors.NewNotFound(schema.GroupResource{Resource: "sandbox"}, sandboxID)
+			case SandboxStatusPaused:
+				return nil
+			case SandboxStatusPausing:
+			default:
+				return k8serrors.NewConflict(schema.GroupResource{Resource: "sandbox"}, sandboxID, fmt.Errorf("sandbox lifecycle status changed to %q", record.Status))
+			}
+		}
+		if tx != nil {
+			return tx.MarkRuntimePaused(lockCtx, sandboxID, generation, s.clock.Now())
+		}
+		return nil
+	})
+}
+
+func (s *SandboxService) restoreSandboxRuntimeAfterPauseFailure(ctx context.Context, sandboxID string, pod *corev1.Pod, generation int64) {
+	if s == nil || s.sandboxStore == nil || pod == nil {
+		return
+	}
+	err := s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, record *SandboxRecord) error {
+		if record == nil || record.Status != SandboxStatusPausing {
+			return nil
+		}
+		return tx.SaveRuntime(lockCtx, sandboxID, pod.Namespace, pod.Name, SandboxStatusRunning, generation, parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationExpiresAt), parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationHardExpiresAt))
+	})
+	if err != nil && !errors.Is(err, ErrSandboxRecordNotFound) {
+		s.logger.Warn("Failed to restore sandbox runtime status after pause failure",
+			zap.String("sandboxID", sandboxID),
+			zap.Error(err),
+		)
+	}
+}
+
+func (s *SandboxService) pauseSandboxRuntimeSynchronous(ctx context.Context, sandboxID string, saveRootFS bool) error {
 	pause := func(ctx context.Context, tx SandboxStoreTx, record *SandboxRecord) error {
 		if record != nil {
 			switch record.Status {
@@ -118,16 +278,8 @@ func (s *SandboxService) pauseSandboxRuntime(ctx context.Context, sandboxID stri
 				return err
 			}
 		}
-		pod, err = s.ensureSandboxDeletionFinalizer(ctx, pod)
-		if err != nil {
-			return fmt.Errorf("ensure sandbox cleanup finalizer: %w", err)
-		}
-		pod, err = s.markRuntimeDeletionReason(ctx, pod, runtimeDeletionReasonPaused)
-		if err != nil {
-			return fmt.Errorf("mark runtime deletion reason: %w", err)
-		}
-		if err := s.k8sClient.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{}); err != nil && !k8serrors.IsNotFound(err) {
-			return fmt.Errorf("delete runtime pod: %w", err)
+		if err := s.deleteRuntimePodForPause(ctx, pod); err != nil {
+			return err
 		}
 		if tx != nil {
 			return tx.MarkRuntimePaused(ctx, sandboxID, generation, s.clock.Now())
@@ -174,21 +326,37 @@ const (
 	runtimeDeletionReasonDeleted = "deleted"
 )
 
-func (s *SandboxService) markRuntimeDeletionReason(ctx context.Context, pod *corev1.Pod, reason string) (*corev1.Pod, error) {
-	if s == nil || pod == nil || s.k8sClient == nil || strings.TrimSpace(reason) == "" {
+func (s *SandboxService) prepareRuntimePodForDeletion(ctx context.Context, pod *corev1.Pod, reason string) (*corev1.Pod, error) {
+	if s == nil || pod == nil || s.k8sClient == nil || pod.DeletionTimestamp != nil {
 		return pod, nil
 	}
+	reason = strings.TrimSpace(reason)
 	var updated *corev1.Pod
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		current, err := s.k8sClient.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
-		updated = current.DeepCopy()
-		if updated.Annotations == nil {
-			updated.Annotations = make(map[string]string)
+		if current.DeletionTimestamp != nil {
+			updated = current
+			return nil
 		}
-		updated.Annotations[controller.AnnotationRuntimeDeletionReason] = reason
+		needsFinalizer := !hasSandboxCleanupFinalizer(current)
+		needsReason := reason != "" && strings.TrimSpace(current.Annotations[controller.AnnotationRuntimeDeletionReason]) != reason
+		if !needsFinalizer && !needsReason {
+			updated = current
+			return nil
+		}
+		updated = current.DeepCopy()
+		if needsFinalizer {
+			ensureSandboxCleanupFinalizer(updated)
+		}
+		if needsReason {
+			if updated.Annotations == nil {
+				updated.Annotations = make(map[string]string)
+			}
+			updated.Annotations[controller.AnnotationRuntimeDeletionReason] = reason
+		}
 		updated, err = s.k8sClient.CoreV1().Pods(updated.Namespace).Update(ctx, updated, metav1.UpdateOptions{})
 		return err
 	})
@@ -230,6 +398,9 @@ func (s *SandboxService) GetSandbox(ctx context.Context, sandboxID string) (*San
 			return s.recordToSandbox(record), nil
 		}
 		return nil, fmt.Errorf("get pod: %w", err)
+	}
+	if record != nil && record.Status == SandboxStatusPaused {
+		return s.recordToSandbox(record), nil
 	}
 
 	return s.podToSandbox(ctx, pod, sandboxID), nil

--- a/manager/pkg/service/sandbox_service_restore.go
+++ b/manager/pkg/service/sandbox_service_restore.go
@@ -52,21 +52,16 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 		if getErr == nil {
 			if locked.Status == SandboxStatusPaused {
 				if existing.DeletionTimestamp != nil {
-					pending, err := s.pausedRuntimeDeletionPending(lockCtx, existing)
-					if err != nil {
+					if err := s.waitForPausedRuntimeDeletion(lockCtx, existing); err != nil {
 						return err
 					}
-					if !pending {
-						return k8serrors.NewConflict(corev1.Resource("pod"), existing.Name, fmt.Errorf("sandbox runtime deletion is still in progress"))
-					}
-				}
-				if existing.DeletionTimestamp == nil {
+				} else {
 					if err := s.deleteRuntimePodForPause(lockCtx, existing); err != nil {
 						return err
 					}
-				}
-				if err := s.waitForPausedRuntimeDeletion(lockCtx, existing); err != nil {
-					return err
+					if err := s.waitForPausedRuntimeDeletion(lockCtx, existing); err != nil {
+						return err
+					}
 				}
 			} else {
 				if existing.DeletionTimestamp != nil {

--- a/manager/pkg/service/sandbox_service_restore.go
+++ b/manager/pkg/service/sandbox_service_restore.go
@@ -24,10 +24,18 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 		return nil, k8serrors.NewNotFound(corev1.Resource("pod"), sandboxID)
 	}
 
+	preparedCheckpointImage, err := s.prepublishRootFSCheckpointImage(ctx, sandboxID)
+	if err != nil && s.logger != nil {
+		s.logger.Warn("Failed to prepublish rootfs checkpoint image before resume",
+			zap.String("sandboxID", sandboxID),
+			zap.Error(err),
+		)
+	}
+
 	var pod *corev1.Pod
 	var record *SandboxRecord
 	claimType := "hot"
-	err := s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, locked *SandboxRecord) error {
+	err = s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, locked *SandboxRecord) error {
 		if locked.Status == SandboxStatusDeleted || !locked.DeletedAt.IsZero() {
 			return k8serrors.NewNotFound(corev1.Resource("sandbox"), sandboxID)
 		}
@@ -86,6 +94,10 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 			return err
 		}
 		generation := locked.RuntimeGeneration + 1
+		rootFSState, err := tx.GetLatestRootFSState(lockCtx, locked.ID)
+		if err != nil {
+			return fmt.Errorf("load rootfs checkpoint: %w", err)
+		}
 		req := &ClaimRequest{
 			TeamID:            locked.TeamID,
 			UserID:            locked.UserID,
@@ -96,15 +108,37 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 			RuntimeGeneration: generation,
 			HardExpiresAt:     locked.HardExpiresAt,
 		}
-		pod, err = s.claimIdlePod(lockCtx, template, req)
-		if err != nil {
-			return fmt.Errorf("claim idle pod: %w", err)
-		}
-		if pod == nil {
-			claimType = "cold"
-			pod, err = s.createNewPod(lockCtx, template, req)
+		if rootFSRequiresCheckpointImageRestore(rootFSState) {
+			var checkpointImage *RootFSCheckpointImage
+			if preparedCheckpointImage != nil && preparedCheckpointImage.matches(rootFSState) {
+				checkpointImage = preparedCheckpointImage.image
+			}
+			if checkpointImage == nil {
+				checkpointImage, err = s.publishRootFSCheckpointImage(lockCtx, rootFSState)
+				if err != nil {
+					return fmt.Errorf("publish rootfs checkpoint image: %w", err)
+				}
+			}
+			checkpointTemplate, err := templateWithRootFSCheckpointImage(template, checkpointImage)
 			if err != nil {
-				return fmt.Errorf("create runtime pod: %w", err)
+				return fmt.Errorf("prepare checkpoint image runtime: %w", err)
+			}
+			claimType = "checkpoint-image"
+			pod, err = s.createNewPod(lockCtx, checkpointTemplate, req)
+			if err != nil {
+				return fmt.Errorf("create checkpoint image runtime pod: %w", err)
+			}
+		} else {
+			pod, err = s.claimIdlePod(lockCtx, template, req)
+			if err != nil {
+				return fmt.Errorf("claim idle pod: %w", err)
+			}
+			if pod == nil {
+				claimType = "cold"
+				pod, err = s.createNewPod(lockCtx, template, req)
+				if err != nil {
+					return fmt.Errorf("create runtime pod: %w", err)
+				}
 			}
 		}
 		return tx.SaveRuntime(lockCtx, sandboxID, pod.Namespace, pod.Name, SandboxStatusResuming, generation, parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationExpiresAt), parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationHardExpiresAt))
@@ -182,7 +216,7 @@ func (s *SandboxService) finishRestoredSandboxRuntime(ctx context.Context, pod *
 	if err != nil {
 		return err
 	}
-	if claimType == "cold" {
+	if claimType == "cold" || claimType == "checkpoint-image" {
 		readyPod, err := s.waitForPodClaimReady(ctx, pod.Namespace, pod.Name)
 		if err != nil {
 			return fmt.Errorf("wait for pod claim readiness: %w", err)
@@ -203,7 +237,7 @@ func (s *SandboxService) finishRestoredSandboxRuntime(ctx context.Context, pod *
 	if err != nil {
 		return fmt.Errorf("load rootfs checkpoint: %w", err)
 	}
-	pod, err = s.applySandboxRootFSCheckpointWithFallback(ctx, pod, record, template, req, rootFSState)
+	pod, err = s.applySandboxRootFSCheckpointWithFallback(ctx, pod, record, template, req, rootFSState, claimType)
 	if err != nil {
 		return err
 	}

--- a/manager/pkg/service/sandbox_service_restore.go
+++ b/manager/pkg/service/sandbox_service_restore.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
@@ -13,6 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 // ResumePausedSandboxRuntime creates a new runtime for a paused durable sandbox
@@ -40,11 +42,31 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 
 		existing, getErr := s.getSandboxPod(lockCtx, sandboxID)
 		if getErr == nil {
-			if existing.DeletionTimestamp != nil {
-				return k8serrors.NewConflict(corev1.Resource("pod"), existing.Name, fmt.Errorf("sandbox runtime deletion is still in progress"))
+			if locked.Status == SandboxStatusPaused {
+				if existing.DeletionTimestamp != nil {
+					pending, err := s.pausedRuntimeDeletionPending(lockCtx, existing)
+					if err != nil {
+						return err
+					}
+					if !pending {
+						return k8serrors.NewConflict(corev1.Resource("pod"), existing.Name, fmt.Errorf("sandbox runtime deletion is still in progress"))
+					}
+				}
+				if existing.DeletionTimestamp == nil {
+					if err := s.deleteRuntimePodForPause(lockCtx, existing); err != nil {
+						return err
+					}
+				}
+				if err := s.waitForPausedRuntimeDeletion(lockCtx, existing); err != nil {
+					return err
+				}
+			} else {
+				if existing.DeletionTimestamp != nil {
+					return k8serrors.NewConflict(corev1.Resource("pod"), existing.Name, fmt.Errorf("sandbox runtime deletion is still in progress"))
+				}
+				pod = existing
+				return tx.SaveRuntime(lockCtx, sandboxID, existing.Namespace, existing.Name, s.podToSandboxStatus(existing), runtimeGenerationFromPod(existing), parseRFC3339AnnotationTime(existing.Annotations, controller.AnnotationExpiresAt), parseRFC3339AnnotationTime(existing.Annotations, controller.AnnotationHardExpiresAt))
 			}
-			pod = existing
-			return tx.SaveRuntime(lockCtx, sandboxID, existing.Namespace, existing.Name, s.podToSandboxStatus(existing), runtimeGenerationFromPod(existing), parseRFC3339AnnotationTime(existing.Annotations, controller.AnnotationExpiresAt), parseRFC3339AnnotationTime(existing.Annotations, controller.AnnotationHardExpiresAt))
 		}
 		if getErr != nil && !k8serrors.IsNotFound(getErr) {
 			return fmt.Errorf("get current runtime pod: %w", getErr)
@@ -106,6 +128,53 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 		return nil, err
 	}
 	return s.GetSandbox(ctx, sandboxID)
+}
+
+func pausedRuntimeDeletionPending(pod *corev1.Pod) bool {
+	return pod != nil &&
+		strings.TrimSpace(pod.Annotations[controller.AnnotationRuntimeDeletionReason]) == runtimeDeletionReasonPaused
+}
+
+func (s *SandboxService) pausedRuntimeDeletionPending(ctx context.Context, pod *corev1.Pod) (bool, error) {
+	if pausedRuntimeDeletionPending(pod) {
+		return true, nil
+	}
+	if s == nil || s.k8sClient == nil || pod == nil {
+		return false, nil
+	}
+	current, err := s.k8sClient.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+	if k8serrors.IsNotFound(err) {
+		return true, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("get deleting runtime pod: %w", err)
+	}
+	return pausedRuntimeDeletionPending(current), nil
+}
+
+func (s *SandboxService) waitForPausedRuntimeDeletion(ctx context.Context, pod *corev1.Pod) error {
+	if s == nil || s.k8sClient == nil || pod == nil {
+		return k8serrors.NewConflict(corev1.Resource("pod"), "", fmt.Errorf("sandbox runtime deletion is still in progress"))
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, defaultPausedRuntimeDeletionWaitTimeout)
+	defer cancel()
+	err := wait.PollUntilContextCancel(waitCtx, 100*time.Millisecond, true, func(pollCtx context.Context) (bool, error) {
+		_, getErr := s.k8sClient.CoreV1().Pods(pod.Namespace).Get(pollCtx, pod.Name, metav1.GetOptions{})
+		if k8serrors.IsNotFound(getErr) {
+			return true, nil
+		}
+		if getErr != nil {
+			return false, getErr
+		}
+		return false, nil
+	})
+	if err == nil {
+		return nil
+	}
+	if errors.Is(waitCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
+		return k8serrors.NewConflict(corev1.Resource("pod"), pod.Name, fmt.Errorf("sandbox runtime deletion is still in progress"))
+	}
+	return fmt.Errorf("wait for paused runtime deletion: %w", err)
 }
 
 func (s *SandboxService) finishRestoredSandboxRuntime(ctx context.Context, pod *corev1.Pod, record *SandboxRecord, claimType string) error {

--- a/manager/pkg/service/sandbox_service_rootfs.go
+++ b/manager/pkg/service/sandbox_service_rootfs.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -12,6 +13,8 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 const sandboxRootFSContainerName = "procd"
@@ -54,7 +57,7 @@ func (s *SandboxService) saveSandboxRootFSCheckpoint(ctx context.Context, pod *c
 	if err != nil {
 		return fmt.Errorf("save sandbox rootfs checkpoint: %w", rootFSResponseError(err, saveRootFSError(resp)))
 	}
-	state, err := rootFSStateFromSaveResponse(sandboxID, teamID, generation, resp)
+	state, err := rootFSStateFromSaveResponse(sandboxID, teamID, pod.Spec.NodeName, generation, resp)
 	if err != nil {
 		return err
 	}
@@ -105,9 +108,15 @@ func (s *SandboxService) applySandboxRootFSCheckpoint(ctx context.Context, pod *
 	return nil
 }
 
-func (s *SandboxService) applySandboxRootFSCheckpointWithFallback(ctx context.Context, pod *corev1.Pod, record *SandboxRecord, template *v1alpha1.SandboxTemplate, req *ClaimRequest, state *SandboxRootFSState) (*corev1.Pod, error) {
+func (s *SandboxService) applySandboxRootFSCheckpointWithFallback(ctx context.Context, pod *corev1.Pod, record *SandboxRecord, template *v1alpha1.SandboxTemplate, req *ClaimRequest, state *SandboxRootFSState, claimType string) (*corev1.Pod, error) {
 	if state == nil {
 		return pod, nil
+	}
+	if rootFSRequiresCheckpointImageRestore(state) {
+		if claimType == "checkpoint-image" {
+			return pod, nil
+		}
+		return nil, fmt.Errorf("runtime %q rootfs checkpoint restore requires a checkpoint image runtime", state.Runtime)
 	}
 	err := s.applySandboxRootFSCheckpoint(ctx, pod, state)
 	if err == nil {
@@ -145,6 +154,141 @@ func (s *SandboxService) applySandboxRootFSCheckpointWithFallback(ctx context.Co
 		return nil, fmt.Errorf("%w; checkpoint base image retry failed: %v", err, fallbackErr)
 	}
 	return readyPod, nil
+}
+
+type preparedRootFSCheckpointImage struct {
+	state *SandboxRootFSState
+	image *RootFSCheckpointImage
+}
+
+func (p *preparedRootFSCheckpointImage) matches(state *SandboxRootFSState) bool {
+	if p == nil || p.state == nil || p.image == nil || state == nil {
+		return false
+	}
+	return p.state.SandboxID == state.SandboxID &&
+		p.state.RuntimeGeneration == state.RuntimeGeneration &&
+		p.state.DiffDigest == state.DiffDigest &&
+		p.state.DiffObjectKey == state.DiffObjectKey &&
+		p.state.BaseImageDigest == state.BaseImageDigest
+}
+
+func (s *SandboxService) prepublishRootFSCheckpointImage(ctx context.Context, sandboxID string) (*preparedRootFSCheckpointImage, error) {
+	if s == nil || s.sandboxStore == nil {
+		return nil, nil
+	}
+	record, err := s.sandboxStore.GetSandbox(ctx, sandboxID)
+	if err != nil {
+		if errors.Is(err, ErrSandboxRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if record == nil || record.Status != SandboxStatusPaused {
+		return nil, nil
+	}
+	state, err := s.latestRootFSState(ctx, sandboxID)
+	if err != nil {
+		return nil, err
+	}
+	if !rootFSRequiresCheckpointImageRestore(state) {
+		return nil, nil
+	}
+	image, err := s.publishRootFSCheckpointImage(ctx, state)
+	if err != nil {
+		return nil, err
+	}
+	return &preparedRootFSCheckpointImage{state: state, image: image}, nil
+}
+
+func (s *SandboxService) publishRootFSCheckpointImage(ctx context.Context, state *SandboxRootFSState) (*RootFSCheckpointImage, error) {
+	if state == nil {
+		return nil, fmt.Errorf("rootfs state is required")
+	}
+	if s == nil || s.rootFSImagePublisher == nil {
+		return nil, fmt.Errorf("rootfs checkpoint image publisher is not configured")
+	}
+	ctldAddress, err := s.rootFSDiffCtldAddress(ctx, state)
+	if err != nil {
+		return nil, err
+	}
+	image, err := s.rootFSImagePublisher.Publish(ctx, RootFSCheckpointImagePublishRequest{
+		TeamID:      state.TeamID,
+		CtldAddress: ctldAddress,
+		State:       state,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if image == nil || strings.TrimSpace(image.PullRef) == "" {
+		return nil, fmt.Errorf("rootfs checkpoint image publisher returned no pull ref")
+	}
+	return image, nil
+}
+
+func templateWithRootFSCheckpointImage(template *v1alpha1.SandboxTemplate, image *RootFSCheckpointImage) (*v1alpha1.SandboxTemplate, error) {
+	if template == nil {
+		return nil, fmt.Errorf("template is required")
+	}
+	if image == nil || strings.TrimSpace(image.PullRef) == "" {
+		return nil, fmt.Errorf("rootfs checkpoint image pull ref is required")
+	}
+	clone := template.DeepCopy()
+	clone.Spec.MainContainer.Image = image.PullRef
+	clone.Spec.MainContainer.ImagePullPolicy = string(corev1.PullIfNotPresent)
+	return clone, nil
+}
+
+func (s *SandboxService) rootFSDiffCtldAddress(ctx context.Context, state *SandboxRootFSState) (string, error) {
+	if state != nil && strings.TrimSpace(state.NodeName) != "" {
+		addr, err := s.ctldAddressForNodeName(ctx, strings.TrimSpace(state.NodeName))
+		if err == nil {
+			return addr, nil
+		}
+		if s != nil && s.logger != nil {
+			s.logger.Warn("Failed to resolve rootfs checkpoint source node ctld; trying another node",
+				zap.String("sandboxID", state.SandboxID),
+				zap.String("node", state.NodeName),
+				zap.Error(err),
+			)
+		}
+	}
+	if s == nil {
+		return "", fmt.Errorf("sandbox service is nil")
+	}
+	if s.nodeLister != nil {
+		nodes, err := s.nodeLister.List(labels.Everything())
+		if err == nil {
+			for _, node := range nodes {
+				addr, addrErr := ctldAddressForNode(node, s.config.CtldPort)
+				if addrErr == nil {
+					return addr, nil
+				}
+			}
+		}
+	}
+	if s.k8sClient == nil {
+		return "", fmt.Errorf("kubernetes client is not configured")
+	}
+	nodes, err := s.k8sClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return "", fmt.Errorf("list nodes for rootfs checkpoint diff: %w", err)
+	}
+	for i := range nodes.Items {
+		addr, addrErr := ctldAddressForNode(&nodes.Items[i], s.config.CtldPort)
+		if addrErr == nil {
+			return addr, nil
+		}
+	}
+	return "", fmt.Errorf("no node with an internal ip is available for rootfs checkpoint diff")
+}
+
+func rootFSRequiresCheckpointImageRestore(state *SandboxRootFSState) bool {
+	if state == nil {
+		return false
+	}
+	runtime := strings.ToLower(strings.TrimSpace(state.Runtime))
+	handler := strings.ToLower(strings.TrimSpace(state.RuntimeHandler))
+	return runtime == "gvisor" || strings.Contains(handler, "gvisor") || strings.Contains(handler, "runsc")
 }
 
 func (s *SandboxService) saveRestoredRuntimePod(ctx context.Context, pod *corev1.Pod, record *SandboxRecord, status string) error {
@@ -231,7 +375,7 @@ func rootFSTargetForPod(pod *corev1.Pod) ctldapi.RootFSContainerRef {
 	}
 }
 
-func rootFSStateFromSaveResponse(sandboxID, teamID string, generation int64, resp *ctldapi.SaveRootFSResponse) (*SandboxRootFSState, error) {
+func rootFSStateFromSaveResponse(sandboxID, teamID, nodeName string, generation int64, resp *ctldapi.SaveRootFSResponse) (*SandboxRootFSState, error) {
 	if resp == nil {
 		return nil, fmt.Errorf("save sandbox rootfs checkpoint: empty ctld response")
 	}
@@ -247,6 +391,7 @@ func rootFSStateFromSaveResponse(sandboxID, teamID string, generation int64, res
 		RuntimeGeneration:   generation,
 		Runtime:             resp.Info.Runtime,
 		RuntimeHandler:      resp.Info.RuntimeHandler,
+		NodeName:            nodeName,
 		BaseImageRef:        resp.Info.BaseImageRef,
 		BaseImageDigest:     resp.Info.BaseImageDigest,
 		Snapshotter:         resp.Info.Snapshotter,

--- a/manager/pkg/service/sandbox_service_rootfs.go
+++ b/manager/pkg/service/sandbox_service_rootfs.go
@@ -50,7 +50,6 @@ func (s *SandboxService) saveSandboxRootFSCheckpoint(ctx context.Context, pod *c
 		SandboxID:                 sandboxID,
 		TeamID:                    teamID,
 		ExpectedRuntimeGeneration: generation,
-		Freeze:                    true,
 	}, sandboxRootFSOperationTimeout)
 	if err != nil {
 		return fmt.Errorf("save sandbox rootfs checkpoint: %w", rootFSResponseError(err, saveRootFSError(resp)))
@@ -96,7 +95,6 @@ func (s *SandboxService) applySandboxRootFSCheckpoint(ctx context.Context, pod *
 			Size:      state.DiffSize,
 			ObjectKey: state.DiffObjectKey,
 		},
-		Freeze: true,
 	}, sandboxRootFSOperationTimeout)
 	if err != nil {
 		return fmt.Errorf("apply sandbox rootfs checkpoint: %w", rootFSResponseError(err, applyRootFSError(resp)))

--- a/manager/pkg/service/sandbox_service_rootfs_test.go
+++ b/manager/pkg/service/sandbox_service_rootfs_test.go
@@ -39,7 +39,6 @@ func TestPauseSandboxRuntimeSavesRootFSBeforeDeletingPod(t *testing.T) {
 		assert.Equal(t, "sandbox-1", req.SandboxID)
 		assert.Equal(t, "team-1", req.TeamID)
 		assert.Equal(t, int64(3), req.ExpectedRuntimeGeneration)
-		assert.True(t, req.Freeze)
 		assert.Equal(t, ctldapi.RootFSContainerRef{
 			Namespace:     "default",
 			PodName:       "pod-1",
@@ -71,16 +70,36 @@ func TestPauseSandboxRuntimeSavesRootFSBeforeDeletingPod(t *testing.T) {
 	pod := rootFSTestPod("pod-1", "sandbox-1", "team-1")
 	pod.Status.HostIP = ctldURL.Hostname()
 	k8sClient := fake.NewSimpleClientset(pod)
+	var store *memorySandboxStore
+	deleteStarted := make(chan struct{}, 1)
+	allowDelete := make(chan struct{})
+	releaseDelete := func() {
+		select {
+		case <-allowDelete:
+		default:
+			close(allowDelete)
+		}
+	}
+	defer releaseDelete()
 	k8sClient.PrependReactor("delete", "pods", func(action ktesting.Action) (bool, runtime.Object, error) {
 		require.True(t, saveCalled, "pod delete must happen after rootfs checkpoint save")
+		require.NotNil(t, store)
+		assert.Equal(t, SandboxStatusPaused, store.records["sandbox-1"].Status)
+		select {
+		case deleteStarted <- struct{}{}:
+		default:
+		}
+		<-allowDelete
 		return false, nil, nil
 	})
-	store := &memorySandboxStore{records: map[string]*SandboxRecord{
+	store = &memorySandboxStore{records: map[string]*SandboxRecord{
 		"sandbox-1": {
-			ID:                "sandbox-1",
-			TeamID:            "team-1",
-			RuntimeGeneration: 3,
-			Status:            SandboxStatusRunning,
+			ID:                  "sandbox-1",
+			TeamID:              "team-1",
+			RuntimeGeneration:   3,
+			Status:              SandboxStatusRunning,
+			CurrentPodNamespace: "default",
+			CurrentPodName:      "pod-1",
 		},
 	}}
 	svc := &SandboxService{
@@ -93,7 +112,23 @@ func TestPauseSandboxRuntimeSavesRootFSBeforeDeletingPod(t *testing.T) {
 		logger:       zap.NewNop(),
 	}
 
-	require.NoError(t, svc.PauseSandboxRuntime(context.Background(), "sandbox-1"))
+	done := make(chan error, 1)
+	go func() {
+		done <- svc.PauseSandboxRuntime(context.Background(), "sandbox-1")
+	}()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		releaseDelete()
+		t.Fatal("PauseSandboxRuntime waited for pod delete to complete")
+	}
+	select {
+	case <-deleteStarted:
+	case <-time.After(time.Second):
+		t.Fatal("pod delete was not requested after pause")
+	}
+	releaseDelete()
 
 	state := store.rootFSStates["sandbox-1"]
 	require.NotNil(t, state)
@@ -104,6 +139,57 @@ func TestPauseSandboxRuntimeSavesRootFSBeforeDeletingPod(t *testing.T) {
 	assert.Equal(t, "sha256:diff", state.DiffDigest)
 	assert.Equal(t, "sandbox-rootfs/team-1/sandbox-1/3/sha256/diff.tar", state.DiffObjectKey)
 	assert.Equal(t, SandboxStatusPaused, store.records["sandbox-1"].Status)
+	assert.Equal(t, 1, store.saves)
+	assert.Equal(t, 1, store.pauses)
+}
+
+func TestPauseSandboxRuntimeRestoresRunningWhenRootFSSaveFails(t *testing.T) {
+	ctld := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/rootfs/save", r.URL.Path)
+		w.WriteHeader(http.StatusInternalServerError)
+		_ = json.NewEncoder(w).Encode(ctldapi.SaveRootFSResponse{Error: "simulated save failure"})
+	}))
+	defer ctld.Close()
+	ctldURL, ctldPort := parsedTestServer(t, ctld.URL)
+
+	pod := rootFSTestPod("pod-1", "sandbox-1", "team-1")
+	pod.Status.HostIP = ctldURL.Hostname()
+	k8sClient := fake.NewSimpleClientset(pod)
+	var deleted atomic.Bool
+	k8sClient.PrependReactor("delete", "pods", func(action ktesting.Action) (bool, runtime.Object, error) {
+		deleted.Store(true)
+		return false, nil, nil
+	})
+	store := &memorySandboxStore{records: map[string]*SandboxRecord{
+		"sandbox-1": {
+			ID:                  "sandbox-1",
+			TeamID:              "team-1",
+			RuntimeGeneration:   3,
+			Status:              SandboxStatusRunning,
+			CurrentPodNamespace: "default",
+			CurrentPodName:      "pod-1",
+		},
+	}}
+	svc := &SandboxService{
+		k8sClient:    k8sClient,
+		podLister:    newTestPodLister(t, pod),
+		sandboxStore: store,
+		ctldClient:   NewCtldClient(CtldClientConfig{Timeout: time.Second}),
+		config:       SandboxServiceConfig{CtldEnabled: true, CtldPort: ctldPort},
+		clock:        systemTime{},
+		logger:       zap.NewNop(),
+	}
+
+	err := svc.PauseSandboxRuntime(context.Background(), "sandbox-1")
+
+	require.Error(t, err)
+	assert.False(t, deleted.Load())
+	assert.Nil(t, store.rootFSStates["sandbox-1"])
+	require.NotNil(t, store.records["sandbox-1"])
+	assert.Equal(t, SandboxStatusRunning, store.records["sandbox-1"].Status)
+	assert.Equal(t, "default", store.records["sandbox-1"].CurrentPodNamespace)
+	assert.Equal(t, "pod-1", store.records["sandbox-1"].CurrentPodName)
+	assert.Equal(t, int64(3), store.records["sandbox-1"].RuntimeGeneration)
 }
 
 func TestFinishRestoredSandboxRuntimeAppliesRootFSBeforeProcdInitialization(t *testing.T) {
@@ -120,7 +206,6 @@ func TestFinishRestoredSandboxRuntimeAppliesRootFSBeforeProcdInitialization(t *t
 		assert.Equal(t, []string{"parent-1", "parent-0"}, req.ExpectedSnapshotParentChain)
 		assert.Equal(t, "sha256:diff", req.Descriptor.Digest)
 		assert.Equal(t, "sandbox-rootfs/team-1/sandbox-1/3/sha256/diff.tar", req.Descriptor.ObjectKey)
-		assert.True(t, req.Freeze)
 		calls = append(calls, "apply")
 		_ = json.NewEncoder(w).Encode(ctldapi.ApplyRootFSResponse{Applied: true})
 	}))

--- a/manager/pkg/service/sandbox_service_rootfs_test.go
+++ b/manager/pkg/service/sandbox_service_rootfs_test.go
@@ -136,6 +136,7 @@ func TestPauseSandboxRuntimeSavesRootFSBeforeDeletingPod(t *testing.T) {
 	assert.Equal(t, "runc", state.Runtime)
 	assert.Equal(t, "sha256:base", state.BaseImageDigest)
 	assert.Equal(t, []string{"parent-1", "parent-0"}, state.SnapshotParentChain)
+	assert.Equal(t, "node-1", state.NodeName)
 	assert.Equal(t, "sha256:diff", state.DiffDigest)
 	assert.Equal(t, "sandbox-rootfs/team-1/sandbox-1/3/sha256/diff.tar", state.DiffObjectKey)
 	assert.Equal(t, SandboxStatusPaused, store.records["sandbox-1"].Status)
@@ -283,7 +284,7 @@ func TestFinishRestoredSandboxRuntimeRetriesWithCheckpointBaseImage(t *testing.T
 				return
 			}
 			_ = json.NewEncoder(w).Encode(ctldapi.ApplyRootFSResponse{Applied: true})
-		case strings.HasSuffix(r.URL.Path, "/probes/readiness"):
+		case strings.Contains(r.URL.Path, "/probes/"):
 			_ = json.NewEncoder(w).Encode(sandboxprobe.Passed(sandboxprobe.KindReadiness, "SandboxProbePassed", "sandbox probe passed", nil))
 		case r.URL.Path == "/api/v1/volume-portals/check":
 			_ = json.NewEncoder(w).Encode(ctldapi.CheckVolumePortalsResponse{Ready: true})
@@ -411,6 +412,134 @@ func TestCheckpointBaseImageRefPinsDigest(t *testing.T) {
 	assert.Equal(t, "registry.example.com:5000/team/image@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", ref)
 }
 
+func TestResumePausedSandboxRuntimeUsesCheckpointImageForGVisor(t *testing.T) {
+	withClaimTestPublicKey(t)
+
+	templateNamespace, err := naming.TemplateNamespaceForTeam("team-1")
+	require.NoError(t, err)
+
+	var ctldApplyCalled atomic.Bool
+	ctld := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v1/rootfs/apply":
+			ctldApplyCalled.Store(true)
+			w.WriteHeader(http.StatusInternalServerError)
+			_ = json.NewEncoder(w).Encode(ctldapi.ApplyRootFSResponse{Error: "gvisor must not live-apply rootfs"})
+		case strings.Contains(r.URL.Path, "/probes/"):
+			_ = json.NewEncoder(w).Encode(sandboxprobe.Passed(sandboxprobe.KindReadiness, "SandboxProbePassed", "sandbox probe passed", nil))
+		case r.URL.Path == "/api/v1/volume-portals/check":
+			_ = json.NewEncoder(w).Encode(ctldapi.CheckVolumePortalsResponse{Ready: true})
+		default:
+			t.Fatalf("unexpected ctld path: %s", r.URL.Path)
+		}
+	}))
+	defer ctld.Close()
+	ctldURL, ctldPort := parsedTestServer(t, ctld.URL)
+
+	procd := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/initialize", r.URL.Path)
+		require.NoError(t, spec.WriteSuccess(w, http.StatusOK, InitializeResponse{SandboxID: "sandbox-1", TeamID: "team-1"}))
+	}))
+	defer procd.Close()
+	procdURL, procdPort := parsedTestServer(t, procd.URL)
+
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "template-1",
+			Namespace: templateNamespace,
+		},
+		Spec: v1alpha1.SandboxTemplateSpec{
+			MainContainer: v1alpha1.ContainerSpec{Image: "docker.io/sandbox0ai/otemplates:default-v0.2.0"},
+		},
+	}
+	state := rootFSTestState()
+	state.Runtime = "gvisor"
+	state.RuntimeHandler = "runsc"
+	state.NodeName = "node-1"
+	state.BaseImageDigest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	state.DiffDigest = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	state.DiffObjectKey = "sandbox-rootfs/team-1/sandbox-1/3/sha256/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.tar"
+	store := &memorySandboxStore{
+		records: map[string]*SandboxRecord{
+			"sandbox-1": {
+				ID:                "sandbox-1",
+				TeamID:            "team-1",
+				UserID:            "user-1",
+				TemplateID:        "template-1",
+				TemplateName:      "template-1",
+				TemplateNamespace: templateNamespace,
+				TemplateSpec:      template.Spec,
+				RuntimeGeneration: 3,
+				Status:            SandboxStatusPaused,
+			},
+		},
+		rootFSStates: map[string]*SandboxRootFSState{
+			"sandbox-1": state,
+		},
+	}
+
+	indexer := newClaimTestPodIndexer(t)
+	k8sClient := fake.NewSimpleClientset(newClaimTestNode("node-1", ctldURL.Hostname()))
+	var createdImage string
+	k8sClient.PrependReactor("create", "pods", func(action ktesting.Action) (bool, runtime.Object, error) {
+		pod := action.(ktesting.CreateAction).GetObject().(*corev1.Pod).DeepCopy()
+		require.Len(t, pod.Spec.Containers, 1)
+		createdImage = pod.Spec.Containers[0].Image
+		readyPod := pod.DeepCopy()
+		readyPod.UID = types.UID("checkpoint-pod-uid")
+		readyPod.Spec.NodeName = "node-1"
+		readyPod.Status.Phase = corev1.PodRunning
+		readyPod.Status.HostIP = ctldURL.Hostname()
+		readyPod.Status.PodIP = procdURL.Hostname()
+		readyPod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+			Name:  "procd",
+			State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+		}}
+		require.NoError(t, indexer.Add(readyPod))
+		return false, nil, nil
+	})
+
+	publisher := &recordingRootFSImagePublisher{
+		image: &RootFSCheckpointImage{
+			PushRef: "registry.example.com/t-team/sandbox-rootfs/sandbox-1:g3-bbbb",
+			PullRef: "registry.internal.svc:5000/t-team/sandbox-rootfs/sandbox-1:g3-bbbb",
+		},
+	}
+	svc := &SandboxService{
+		k8sClient:              k8sClient,
+		podLister:              corelisters.NewPodLister(indexer),
+		nodeLister:             newClaimTestNodeLister(t, newClaimTestNode("node-1", ctldURL.Hostname())),
+		secretLister:           newClaimTestSecretLister(t),
+		templateLister:         staticTemplateLister{templates: []*v1alpha1.SandboxTemplate{template}},
+		sandboxStore:           store,
+		ctldClient:             NewCtldClient(CtldClientConfig{Timeout: time.Second}),
+		procdClient:            NewProcdClient(ProcdClientConfig{Timeout: time.Second}),
+		internalTokenGenerator: staticTokenGenerator{},
+		rootFSImagePublisher:   publisher,
+		config: SandboxServiceConfig{
+			CtldEnabled:      true,
+			CtldPort:         ctldPort,
+			ProcdPort:        procdPort,
+			ProcdInitTimeout: time.Second,
+		},
+		clock:  systemTime{},
+		logger: zap.NewNop(),
+	}
+
+	_, err = svc.ResumePausedSandboxRuntime(context.Background(), "sandbox-1")
+
+	require.NoError(t, err)
+	require.Len(t, publisher.requests, 1)
+	assert.Equal(t, "team-1", publisher.requests[0].TeamID)
+	assert.Equal(t, ctld.URL, publisher.requests[0].CtldAddress)
+	assert.Equal(t, state.DiffObjectKey, publisher.requests[0].State.DiffObjectKey)
+	assert.Equal(t, publisher.image.PullRef, createdImage)
+	assert.False(t, ctldApplyCalled.Load())
+	require.NotNil(t, store.records["sandbox-1"])
+	assert.Equal(t, SandboxStatusRunning, store.records["sandbox-1"].Status)
+	assert.Equal(t, int64(4), store.records["sandbox-1"].RuntimeGeneration)
+}
+
 func TestRestoreFailureCleanupCanSkipRootFSSave(t *testing.T) {
 	var saveCalled atomic.Bool
 	ctld := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -503,6 +632,7 @@ func rootFSTestState() *SandboxRootFSState {
 		RuntimeGeneration:   3,
 		Runtime:             "runc",
 		RuntimeHandler:      "io.containerd.runc.v2",
+		NodeName:            "node-1",
 		BaseImageRef:        "docker.io/library/busybox:1.36",
 		BaseImageDigest:     "sha256:base",
 		Snapshotter:         "overlayfs",
@@ -513,6 +643,20 @@ func rootFSTestState() *SandboxRootFSState {
 		DiffSize:            123,
 		DiffObjectKey:       "sandbox-rootfs/team-1/sandbox-1/3/sha256/diff.tar",
 	}
+}
+
+type recordingRootFSImagePublisher struct {
+	image    *RootFSCheckpointImage
+	requests []RootFSCheckpointImagePublishRequest
+	err      error
+}
+
+func (p *recordingRootFSImagePublisher) Publish(_ context.Context, req RootFSCheckpointImagePublishRequest) (*RootFSCheckpointImage, error) {
+	p.requests = append(p.requests, req)
+	if p.err != nil {
+		return nil, p.err
+	}
+	return p.image, nil
 }
 
 func parsedTestServer(t *testing.T, rawURL string) (*url.URL, int) {

--- a/manager/pkg/service/sandbox_service_rootfs_test.go
+++ b/manager/pkg/service/sandbox_service_rootfs_test.go
@@ -30,6 +30,18 @@ import (
 	ktesting "k8s.io/client-go/testing"
 )
 
+type recordingPauseMeteringRecorder struct {
+	calls     atomic.Int32
+	sandboxID string
+	pausedAt  time.Time
+}
+
+func (r *recordingPauseMeteringRecorder) RecordSandboxPaused(_ context.Context, pod *corev1.Pod, pausedAt time.Time) {
+	r.calls.Add(1)
+	r.sandboxID = pod.Labels[controller.LabelSandboxID]
+	r.pausedAt = pausedAt
+}
+
 func TestPauseSandboxRuntimeSavesRootFSBeforeDeletingPod(t *testing.T) {
 	saveCalled := false
 	ctld := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -102,14 +114,16 @@ func TestPauseSandboxRuntimeSavesRootFSBeforeDeletingPod(t *testing.T) {
 			CurrentPodName:      "pod-1",
 		},
 	}}
+	pauseMeteringRecorder := &recordingPauseMeteringRecorder{}
 	svc := &SandboxService{
-		k8sClient:    k8sClient,
-		podLister:    newTestPodLister(t, pod),
-		sandboxStore: store,
-		ctldClient:   NewCtldClient(CtldClientConfig{Timeout: time.Second}),
-		config:       SandboxServiceConfig{CtldEnabled: true, CtldPort: ctldPort},
-		clock:        systemTime{},
-		logger:       zap.NewNop(),
+		k8sClient:             k8sClient,
+		podLister:             newTestPodLister(t, pod),
+		sandboxStore:          store,
+		pauseMeteringRecorder: pauseMeteringRecorder,
+		ctldClient:            NewCtldClient(CtldClientConfig{Timeout: time.Second}),
+		config:                SandboxServiceConfig{CtldEnabled: true, CtldPort: ctldPort},
+		clock:                 systemTime{},
+		logger:                zap.NewNop(),
 	}
 
 	done := make(chan error, 1)
@@ -140,6 +154,9 @@ func TestPauseSandboxRuntimeSavesRootFSBeforeDeletingPod(t *testing.T) {
 	assert.Equal(t, "sha256:diff", state.DiffDigest)
 	assert.Equal(t, "sandbox-rootfs/team-1/sandbox-1/3/sha256/diff.tar", state.DiffObjectKey)
 	assert.Equal(t, SandboxStatusPaused, store.records["sandbox-1"].Status)
+	assert.Equal(t, int32(1), pauseMeteringRecorder.calls.Load())
+	assert.Equal(t, "sandbox-1", pauseMeteringRecorder.sandboxID)
+	assert.False(t, pauseMeteringRecorder.pausedAt.IsZero())
 	assert.Equal(t, 1, store.saves)
 	assert.Equal(t, 1, store.pauses)
 }

--- a/manager/pkg/service/sandbox_store.go
+++ b/manager/pkg/service/sandbox_store.go
@@ -56,6 +56,7 @@ type SandboxRootFSState struct {
 	RuntimeGeneration   int64
 	Runtime             string
 	RuntimeHandler      string
+	NodeName            string
 	BaseImageRef        string
 	BaseImageDigest     string
 	Snapshotter         string
@@ -86,6 +87,7 @@ type SandboxStoreTx interface {
 	SaveRuntime(ctx context.Context, sandboxID, namespace, podName, status string, generation int64, expiresAt, hardExpiresAt time.Time) error
 	MarkRuntimePaused(ctx context.Context, sandboxID string, generation int64, pausedAt time.Time) error
 	SaveRootFSState(ctx context.Context, state *SandboxRootFSState) error
+	GetLatestRootFSState(ctx context.Context, sandboxID string) (*SandboxRootFSState, error)
 }
 
 type PGSandboxStore struct {
@@ -346,6 +348,13 @@ func (t sandboxStoreTx) SaveRootFSState(ctx context.Context, state *SandboxRootF
 	return saveRootFSState(ctx, t.tx, state)
 }
 
+func (t sandboxStoreTx) GetLatestRootFSState(ctx context.Context, sandboxID string) (*SandboxRootFSState, error) {
+	return scanRootFSState(t.tx.QueryRow(ctx, rootFSStateSelectSQL()+`
+			WHERE sandbox_id = $1
+			ORDER BY runtime_generation DESC, updated_at DESC
+			LIMIT 1`, sandboxID))
+}
+
 func sandboxRecordSelectSQL() string {
 	return `
 		SELECT sandbox_id, team_id, user_id, template_id, template_name, template_namespace,
@@ -382,15 +391,16 @@ func saveRootFSState(ctx context.Context, exec rootFSStateExecutor, state *Sandb
 	_, err = exec.Exec(ctx, `
 		INSERT INTO manager.sandbox_rootfs_states (
 			sandbox_id, team_id, runtime_generation, runtime, runtime_handler,
-			base_image_ref, base_image_digest, snapshotter, snapshot_parent,
+			node_name, base_image_ref, base_image_digest, snapshotter, snapshot_parent,
 			snapshot_parent_chain, diff_digest, diff_media_type, diff_size,
 			diff_object_key, created_at, updated_at
 		)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, COALESCE($15, NOW()), NOW())
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, COALESCE($16, NOW()), NOW())
 		ON CONFLICT (sandbox_id, runtime_generation) DO UPDATE SET
 			team_id = EXCLUDED.team_id,
 			runtime = EXCLUDED.runtime,
 			runtime_handler = EXCLUDED.runtime_handler,
+			node_name = EXCLUDED.node_name,
 			base_image_ref = EXCLUDED.base_image_ref,
 			base_image_digest = EXCLUDED.base_image_digest,
 			snapshotter = EXCLUDED.snapshotter,
@@ -402,7 +412,7 @@ func saveRootFSState(ctx context.Context, exec rootFSStateExecutor, state *Sandb
 			diff_object_key = EXCLUDED.diff_object_key,
 			updated_at = NOW()
 	`, state.SandboxID, state.TeamID, state.RuntimeGeneration, state.Runtime, state.RuntimeHandler,
-		state.BaseImageRef, state.BaseImageDigest, state.Snapshotter, state.SnapshotParent,
+		state.NodeName, state.BaseImageRef, state.BaseImageDigest, state.Snapshotter, state.SnapshotParent,
 		parentChainJSON, state.DiffDigest, state.DiffMediaType, state.DiffSize,
 		state.DiffObjectKey, nullableTime(state.CreatedAt))
 	if err != nil {
@@ -414,7 +424,7 @@ func saveRootFSState(ctx context.Context, exec rootFSStateExecutor, state *Sandb
 func rootFSStateSelectSQL() string {
 	return `
 		SELECT sandbox_id, team_id, runtime_generation, runtime, runtime_handler,
-			base_image_ref, base_image_digest, snapshotter, snapshot_parent,
+			node_name, base_image_ref, base_image_digest, snapshotter, snapshot_parent,
 			snapshot_parent_chain, diff_digest, diff_media_type, diff_size,
 			diff_object_key, created_at, updated_at
 		FROM manager.sandbox_rootfs_states`
@@ -425,7 +435,7 @@ func scanRootFSState(row sandboxRecordScanner) (*SandboxRootFSState, error) {
 	var parentChainJSON []byte
 	if err := row.Scan(
 		&state.SandboxID, &state.TeamID, &state.RuntimeGeneration, &state.Runtime, &state.RuntimeHandler,
-		&state.BaseImageRef, &state.BaseImageDigest, &state.Snapshotter, &state.SnapshotParent,
+		&state.NodeName, &state.BaseImageRef, &state.BaseImageDigest, &state.Snapshotter, &state.SnapshotParent,
 		&parentChainJSON, &state.DiffDigest, &state.DiffMediaType, &state.DiffSize,
 		&state.DiffObjectKey, &state.CreatedAt, &state.UpdatedAt,
 	); err != nil {

--- a/pkg/ctldapi/client.go
+++ b/pkg/ctldapi/client.go
@@ -33,6 +33,7 @@ const (
 	pathRootFSInspect               = "/api/v1/rootfs/inspect"
 	pathRootFSSave                  = "/api/v1/rootfs/save"
 	pathRootFSApply                 = "/api/v1/rootfs/apply"
+	pathRootFSDiffRead              = "/api/v1/rootfs/diffs/read"
 )
 
 var defaultHTTPClient = &http.Client{Timeout: DefaultRequestTimeout}
@@ -146,11 +147,55 @@ func (c *Client) ApplyRootFS(ctx context.Context, ctldAddress string, req ApplyR
 	return PostJSON[ApplyRootFSResponse](ctx, c.httpClientOrDefault(), ctldAddress, pathRootFSApply, req)
 }
 
+func (c *Client) OpenRootFSDiff(ctx context.Context, ctldAddress string, req ReadRootFSDiffRequest) (io.ReadCloser, error) {
+	return PostStream(ctx, c.httpClientOrDefault(), ctldAddress, pathRootFSDiffRead, req)
+}
+
 func (c *Client) httpClientOrDefault() *http.Client {
 	if c != nil && c.httpClient != nil {
 		return c.httpClient
 	}
 	return defaultHTTPClient
+}
+
+// PostStream sends a JSON POST request and returns the response body stream.
+func PostStream(ctx context.Context, httpClient *http.Client, baseURL, path string, request any) (io.ReadCloser, error) {
+	if httpClient == nil {
+		httpClient = defaultHTTPClient
+	}
+
+	var reader io.Reader
+	if request != nil {
+		payload, err := json.Marshal(request)
+		if err != nil {
+			return nil, fmt.Errorf("encode request: %w", err)
+		}
+		reader = bytes.NewReader(payload)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimRight(baseURL, "/")+path, reader)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("do request: %w", err)
+	}
+	if resp.StatusCode == http.StatusOK {
+		return resp.Body, nil
+	}
+	defer resp.Body.Close()
+	body, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		return nil, fmt.Errorf("read response: %w", readErr)
+	}
+	var out ReadRootFSDiffResponse
+	if len(body) > 0 {
+		_ = json.Unmarshal(body, &out)
+	}
+	return nil, &RequestError{StatusCode: resp.StatusCode, Message: strings.TrimSpace(out.Error)}
 }
 
 // PostJSON sends a JSON POST request to ctld and decodes the response.

--- a/pkg/ctldapi/types.go
+++ b/pkg/ctldapi/types.go
@@ -108,6 +108,14 @@ type ApplyRootFSResponse struct {
 	Error      string               `json:"error,omitempty"`
 }
 
+type ReadRootFSDiffRequest struct {
+	Descriptor RootFSDiffDescriptor `json:"descriptor"`
+}
+
+type ReadRootFSDiffResponse struct {
+	Error string `json:"error,omitempty"`
+}
+
 // BindVolumePortalRequest binds one pre-published pod portal to a concrete
 // sandbox volume at claim time.
 type BindVolumePortalRequest struct {

--- a/pkg/ctldapi/types.go
+++ b/pkg/ctldapi/types.go
@@ -82,7 +82,6 @@ type SaveRootFSRequest struct {
 	TeamID                    string             `json:"team_id"`
 	ExpectedRuntimeGeneration int64              `json:"expected_runtime_generation,omitempty"`
 	ObjectKey                 string             `json:"object_key,omitempty"`
-	Freeze                    bool               `json:"freeze,omitempty"`
 }
 
 type SaveRootFSResponse struct {
@@ -100,7 +99,6 @@ type ApplyRootFSRequest struct {
 	ExpectedSnapshotParent      string               `json:"expected_snapshot_parent,omitempty"`
 	ExpectedSnapshotParentChain []string             `json:"expected_snapshot_parent_chain,omitempty"`
 	Descriptor                  RootFSDiffDescriptor `json:"descriptor"`
-	Freeze                      bool                 `json:"freeze,omitempty"`
 }
 
 type ApplyRootFSResponse struct {

--- a/tests/integration/internal/tests/manager/api_test.go
+++ b/tests/integration/internal/tests/manager/api_test.go
@@ -863,6 +863,10 @@ func (t memorySandboxStoreTxForManagerIntegration) SaveRootFSState(_ context.Con
 	return nil
 }
 
+func (t memorySandboxStoreTxForManagerIntegration) GetLatestRootFSState(_ context.Context, sandboxID string) (*service.SandboxRootFSState, error) {
+	return cloneRootFSStateForManagerIntegration(t.store.rootFSState[sandboxID]), nil
+}
+
 func cloneSandboxRecordForManagerIntegration(record *service.SandboxRecord) *service.SandboxRecord {
 	if record == nil {
 		return nil

--- a/tests/integration/internal/tests/manager/api_test.go
+++ b/tests/integration/internal/tests/manager/api_test.go
@@ -683,7 +683,7 @@ func newRootFSApplyRecordingCtldServer(t *testing.T, events *orderedEvents, name
 		if req.ExpectedBaseImageDigest != "sha256:base" || len(req.ExpectedSnapshotParentChain) != 1 || req.ExpectedSnapshotParentChain[0] != "sha256:parent" {
 			t.Fatalf("unexpected rootfs base validation: %+v", req)
 		}
-		if req.Descriptor.Digest != "sha256:diff" || req.Descriptor.ObjectKey != "sandbox-rootfs/team-1/sandbox-1/3/sha256/diff.tar" || !req.Freeze {
+		if req.Descriptor.Digest != "sha256:diff" || req.Descriptor.ObjectKey != "sandbox-rootfs/team-1/sandbox-1/3/sha256/diff.tar" {
 			t.Fatalf("unexpected rootfs descriptor: %+v", req.Descriptor)
 		}
 		events.Add("apply-rootfs")


### PR DESCRIPTION
## Summary
- add an overlay upperdir fast path for ctld rootfs diff, with /var/lib/containerd mounted into ctld so overlay snapshot upperdirs are readable
- change durable pause to checkpoint first, mark pausing -> paused, and move runtime pod deletion out of the pause response path
- make resume handle the async-delete window by deleting/waiting for any old runtime pod before restoring

## Tests
- go test ./ctld/internal/ctld/rootfs ./infra-operator/internal/controller/services/ctld ./manager/pkg/service ./ctld/internal/ctld/server ./pkg/ctldapi ./tests/integration/internal/tests/manager

## Remote validation
- deployed to the Aliyun Singapore kind environment as sandbox0ai/infra:fast-pause-final4 (image sha256:86b1a06b630d67a28fdca3a577c5350e5b92cba8e7badf07275e48bedafb2043)
- verified ctld has /host-var-lib/containerd mounted from /var/lib/containerd and uses the new containerd-state flags
- 5 rounds, each writing 1MiB then immediate pause/resume: pause latencies were 0.149614s, 0.042060s, 0.059861s, 0.168165s, 0.088516s; every post-pause status read returned paused
- resume succeeded in all 5 rounds; resume latency remains several seconds and is not optimized in this PR
