### PR TITLE
docs: clarify persistent sandbox filesystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,19 @@ Sandbox0 is the runtime boundary for enterprise AI agent platforms.
 
 It gives platform teams isolated, persistent sandboxes for agent work that needs to run code, edit repositories, expose per-agent HTTP services, keep workspace state, and access external systems without placing broad production credentials inside the agent runtime.
 
+The sandbox writable root filesystem is checkpointed across pause/resume. Sandbox0 can release the runtime pod, keep the sandbox identity, and restore files written inside the sandbox when a new runtime generation starts. Volumes are a separate storage primitive for data that must outlive one sandbox identity, be shared, snapshotted, forked, or accessed directly through APIs.
+
 Use Sandbox0 when you need to:
 
 | Need | Sandbox0 angle |
 | ---- | -------------- |
 | Run untrusted code and tools | Isolated sandboxes with process, file, SSH, and service APIs. |
-| Build coding agents | Stateful REPL contexts, one-shot commands, persistent repo volumes, and fast template claims. |
+| Build coding agents | Stateful REPL contexts, one-shot commands, persistent rootfs across pause/resume, repo volumes, and fast template claims. |
 | Run agent gateways such as Hermes or OpenClaw | Agent in Sandbox with builtin templates, mounted volumes, public service routes, and auto-resume. |
 | Expose per-agent HTTP endpoints | Sandbox Services with route auth, method filtering, CORS, rate limits, timeouts, path rewrite, and resume. |
 | Keep secrets outside the agent process | Credential sources, destination-scoped egress auth, SSH transparent proxying, LLMProxy, or an external AI gateway. |
 | Control network and MCP access | Ordered traffic rules, protocol-aware MCP tool controls, and egress audit in the data plane. |
-| Branch, evaluate, or recover agent state | Volumes, point-in-time snapshots, restore, and Copy-on-Write fork. |
+| Branch, evaluate, or recover agent state | Rootfs checkpoints for transparent sandbox resume, plus volumes, point-in-time snapshots, restore, and Copy-on-Write fork. |
 | Own the deployment boundary | Self-hosted Kubernetes data plane with external PostgreSQL, S3/OSS, Vault-compatible storage, Redis, and registry options. |
 
 Sandbox0 Cloud uses `https://api.sandbox0.ai` for sandboxes, templates, volumes, credentials, and team-scoped API keys. Managed Agents uses `https://agents.sandbox0.ai`.
@@ -189,17 +191,19 @@ Treat the sandbox process as runtime state and the volume as durable state. Paus
 | -------------- | ---------- | ---------------------------- |
 | **Template** | A runtime blueprint: image, resources, warm pool, mount points, and default policy. | Keeps environments reproducible and claims fast. |
 | **Sandbox** | A durable identity and configuration for an isolated runtime instance. | Gives each task, user, or agent worker its own execution boundary. |
+| **Root filesystem** | The sandbox writable filesystem checkpointed during pause/resume and tied to the sandbox identity. | Lets files written inside the sandbox survive runtime pod cleanup without explicit mounts. |
 | **Context** | A process/session inside a sandbox, either REPL-style or one-shot command. | Lets agents choose in-process continuity or clean execution per tool call. |
-| **Volume** | Persistent storage independent of a sandbox lifetime. | Keeps repositories, caches, agent memory, artifacts, checkpoints, snapshots, and forks. |
+| **Volume** | Persistent storage independent of a sandbox lifetime. | Keeps repositories, caches, agent memory, artifacts, checkpoints, snapshots, forks, and shared data. |
 | **Service** | A public HTTP entrypoint backed by a listener, command, or function. | Exposes per-sandbox APIs, previews, webhooks, and agent gateways with route policy. |
 | **Credential** | A secret source plus policy for how it may be projected or injected. | Lets agents call external services without storing raw production keys in the sandbox process. |
 
-The short version: use templates for repeatable environments, sandboxes for isolation, contexts for process behavior, volumes for durable memory, services for controlled ingress, and credentials/network policy for controlled external access.
+The short version: use templates for repeatable environments, sandboxes for isolation, the root filesystem for same-sandbox file continuity across pause/resume, contexts for process behavior, volumes for durable or shared memory, services for controlled ingress, and credentials/network policy for controlled external access.
 
 ## Persistence And Lifecycle
 
-Sandbox0 separates runtime state from durable state.
+Sandbox0 separates runtime state from filesystem state.
 
+- The sandbox writable root filesystem is persisted as the latest rootfs checkpoint for the same sandbox identity. Files written outside mounted volumes survive pause/resume once the pause checkpoint succeeds.
 - `ttl` is a runtime soft timeout. When it expires, Sandbox0 checkpoints the writable root filesystem, pauses the sandbox, and releases runtime compute.
 - `hard_ttl` is a hard sandbox lifetime. When it expires, Sandbox0 deletes the sandbox identity and durable state tied to that identity, including rootfs checkpoints.
 - Pause/resume preserves sandbox identity and the latest writable root filesystem checkpoint, but not running processes, memory, sockets, PID state, or live REPL sessions.

--- a/docs/get-started/concepts/page.mdx
+++ b/docs/get-started/concepts/page.mdx
@@ -4,20 +4,22 @@ This page explains Sandbox0 from an AI agent developer perspective: how to think
 
 ## The Mental Model
 
-Think in four building blocks:
+Think in five building blocks:
 
 | Concept | What It Is | Why Agent Developers Care |
 |-------|-------------|---------------------------|
 | `Template` | The runtime blueprint (image, resources, defaults). | Defines your agent's execution environment and startup behavior. |
 | `Sandbox` | Durable identity and configuration for an isolated environment. | The agent's working machine identity across runtime generations. |
+| Root filesystem | The sandbox writable filesystem checkpointed during pause/resume. | Keeps files written inside the sandbox available when compute is released and later restored. |
 | `Context` | A process/session inside the sandbox (for example REPL-like or one-shot execution). | Controls whether state is preserved across turns or reset each run. |
 | `Volume` | Persistent storage decoupled from sandbox lifecycle. | Keeps knowledge, artifacts, and checkpoints across sandbox recreation. |
 
 The key idea is separation of concerns:
 - Use `Template` for environment consistency.
 - Use `Sandbox` for isolated execution.
+- Use the root filesystem for same-sandbox file continuity across pause/resume.
 - Use `Context` for process-level interaction patterns.
-- Use `Volume` for durable memory.
+- Use `Volume` for durable, shareable, or snapshot-ready memory.
 
 ## Agent Runtime vs Agent Memory
 
@@ -25,6 +27,7 @@ A common confusion is mixing compute state and durable state.
 
 - Process state lives in the sandbox runtime and disappears when the runtime is paused or deleted.
 - Sandbox0 restores the writable root filesystem checkpoint for paused sandboxes, so files written outside mounted volumes survive pause/resume for the same sandbox identity.
+- The rootfs checkpoint is not a Volume. It is not shareable across sandboxes, does not expose volume snapshot/fork APIs, and is deleted with the sandbox identity.
 - Durable state that must survive sandbox delete or `hard_ttl`, needs snapshots, or needs sharing outside the sandbox identity should be written to volumes or external systems.
 - If your agent must recover after failures or redeploys, treat sandbox runtime as ephemeral and volumes as the source of truth.
 

--- a/docs/get-started/page.mdx
+++ b/docs/get-started/page.mdx
@@ -1,13 +1,14 @@
 # Get Started
 
-Sandbox0 provides isolated execution environments for AI agents with persistent storage, session state maintenance, and fast warm claims. Sandbox0 Cloud uses `https://api.sandbox0.ai` for sandboxes, templates, volumes, and credentials. Managed Agents uses `https://agents.sandbox0.ai`.
+Sandbox0 provides isolated execution environments for AI agents with a persistent sandbox root filesystem across pause/resume, volume storage for durable and shared data, session state maintenance, and fast warm claims. Sandbox0 Cloud uses `https://api.sandbox0.ai` for sandboxes, templates, volumes, and credentials. Managed Agents uses `https://agents.sandbox0.ai`.
 
 ## What is Sandbox0?
 
 Sandbox0 is an enterprise-grade AI Agent Sandbox platform that enables you to:
 
 - **Run code securely** in isolated environments with full process control
-- **Persist data** across sandbox lifecycles with volume storage and snapshots
+- **Persist sandbox files** across pause/resume with rootfs checkpoints tied to the sandbox identity
+- **Persist durable data** beyond one sandbox identity with volume storage, snapshots, and forks
 - **Control network access** with fine-grained policies
 - **Scale efficiently** with template-based sandbox pools and fast cold starts
 

--- a/docs/sandbox/files/page.mdx
+++ b/docs/sandbox/files/page.mdx
@@ -2,7 +2,7 @@
 
 Manage files and directories within a sandbox. The Files API provides full POSIX file operations including read, write, delete, move, and real-time file watching.
 
-Files written to the sandbox writable filesystem are restored across checkpointed pause/resume for the same sandbox identity. They are deleted when the sandbox is deleted or `hard_ttl` expires. Use [Volumes](/docs/volume) for data that must outlive a sandbox identity, needs snapshots, or must be shared across sandboxes.
+Files written to the sandbox writable filesystem are restored across checkpointed pause/resume for the same sandbox identity, including paths that are not backed by mounted Volumes. They are deleted when the sandbox is deleted or `hard_ttl` expires. Use [Volumes](/docs/volume) for data that must outlive a sandbox identity, needs snapshots, needs forks, must be shared across sandboxes, or must be accessed directly without a running sandbox.
 
 ## File Model
 

--- a/docs/sandbox/page.mdx
+++ b/docs/sandbox/page.mdx
@@ -1,6 +1,6 @@
 # Sandbox
 
-A Sandbox is an isolated execution environment where you can run code, manage files, and control network access. Each sandbox is created from a [Template](/docs/template) and provides a secure, ephemeral workspace.
+A Sandbox is an isolated execution environment where you can run code, manage files, and control network access. Each sandbox is created from a [Template](/docs/template) and has a writable root filesystem that is checkpointed across pause/resume for the same sandbox identity.
 
 For shell access and file copy over standard SSH clients, see [SSH](/docs/sandbox/ssh).
 
@@ -36,6 +36,17 @@ Sandbox0 Cloud clients should use `https://api.sandbox0.ai`. Set `SANDBOX0_BASE_
 <Callout variant="info">
 Use the `paused` boolean as a convenience for `status == "paused"`. Pause does not preserve running processes, memory, sockets, PID state, or live REPL sessions.
 </Callout>
+
+### Persistent Root Filesystem
+
+Sandbox0 persists the sandbox writable root filesystem as part of checkpointed pause/resume:
+
+- when `ttl` expires or pause is requested, Sandbox0 saves a rootfs checkpoint before releasing the runtime pod
+- when the sandbox resumes, Sandbox0 creates or reuses a runtime pod and restores the latest rootfs checkpoint before initializing sandbox processes
+- files written outside mounted volumes survive pause/resume for the same sandbox identity after a checkpoint succeeds
+- rootfs checkpoints are deleted when the sandbox is deleted or `hard_ttl` expires
+
+Use the root filesystem for transparent same-sandbox continuity. Use [Volumes](/docs/volume) for data that must outlive one sandbox identity, be shared, snapshotted, forked, restored, or accessed directly through APIs.
 
 ---
 

--- a/docs/sandbox/pause-resume/page.mdx
+++ b/docs/sandbox/pause-resume/page.mdx
@@ -14,8 +14,19 @@ Pause is a runtime lifecycle operation. It does not preserve running processes, 
 </Callout>
 
 <Callout variant="warning">
-Self-hosted deployments must run `ctld` on sandbox nodes for checkpointed pause/resume. `ctld` freezes the sandbox only as an internal consistency mechanism while saving or applying the writable rootfs checkpoint.
+Self-hosted deployments must run `ctld` on sandbox nodes for checkpointed pause/resume. Pause saves the writable rootfs checkpoint and releases the runtime pod; it does not preserve process state.
 </Callout>
+
+## What Persists
+
+| State | Across pause/resume | After sandbox delete or `hard_ttl` |
+|-------|---------------------|-------------------------------------|
+| Sandbox identity and configuration | Preserved | Deleted |
+| Writable root filesystem | Latest checkpoint is restored | Deleted with the sandbox identity |
+| Mounted Volumes | Remounted if configured | Preserved until the Volume is deleted |
+| Processes, memory, sockets, PID state, live REPL sessions | Not preserved | Deleted |
+
+The rootfs checkpoint covers files written inside the sandbox filesystem, including files outside mounted volumes. It is different from a Sandbox Volume: it is tied to one sandbox identity and does not provide volume sharing, direct file APIs, snapshots, forks, or restore operations.
 
 ## Pause A Sandbox
 

--- a/docs/volume/page.mdx
+++ b/docs/volume/page.mdx
@@ -12,6 +12,11 @@ The default Sandbox writable filesystem is checkpointed across pause/resume for 
 - **Fast Forking**: Create independent child Volumes with Copy-on-Write isolation
 - **Quick Recovery**: Restore from snapshots quickly, ideal for rollbacks and environment cloning
 
+| Storage surface | Survives pause/resume | Survives sandbox delete or `hard_ttl` | Shareable | Snapshots and forks | Direct file API |
+|-----------------|-----------------------|----------------------------------------|-----------|---------------------|-----------------|
+| Sandbox root filesystem | Yes, after checkpointed pause | No | No | No | Through the Sandbox file API while the Sandbox exists |
+| Sandbox Volume | Yes | Yes, until the Volume is deleted | Yes | Yes | Yes |
+
 ## Volume and Sandbox Relationship
 
 ```mermaid


### PR DESCRIPTION
Summary:
- Document the sandbox writable root filesystem as a persistent checkpoint across pause/resume.
- Clarify the lifecycle boundary between rootfs checkpoints and Sandbox Volumes in README, get-started, sandbox, files, pause/resume, and volume docs.
- Add a pause/resume persistence table and volume comparison so users can see what survives runtime cleanup versus sandbox deletion.

Verification:
- git diff --check
- GOWORK=off go test ./manager/pkg/service -run 'TestPauseSandboxRuntimeSavesRootFSBeforeDeletingPod|TestFinishRestoredSandboxRuntimeAppliesRootFSBeforeProcdInitialization|TestFinishRestoredSandboxRuntimeRetriesWithCheckpointBaseImage' -count=1