### PR TITLE
Remove sandbox request count metering

### DIFF
--- a/docs/self-hosted/configuration/page.mdx
+++ b/docs/self-hosted/configuration/page.mdx
@@ -46,7 +46,6 @@ Sandbox compute uses a serverless-style contract:
 
 | Window type | Unit | Meaning |
 |---|---|---|
-| `sandbox.request_count` | `count` | One claimed active sandbox |
 | `sandbox.runtime_mib_milliseconds` | `mib_milliseconds` | Active sandbox runtime multiplied by allocated memory |
 | `sandbox.egress_bytes` | `bytes` | Egress traffic observed by `netd` |
 | `sandbox.ingress_bytes` | `bytes` | Ingress traffic observed by `netd` |

--- a/manager/pkg/metering/lifecycle_projector.go
+++ b/manager/pkg/metering/lifecycle_projector.go
@@ -163,7 +163,6 @@ func (p *LifecycleProjector) handleUpsert(obj any) {
 			LastResourceVer:   pod.ResourceVersion,
 		}
 		pendingEvents = append(pendingEvents, p.buildSandboxEvent(sandboxID, teamID, userID, templateID, claimedAt, meteringpkg.EventTypeSandboxClaimed, claimedEventID(sandboxID, claimedAt), claimEventData(pod)))
-		pendingWindows = append(pendingWindows, p.buildSandboxRequestWindow(state, teamID, userID, templateID, claimedAt, pod))
 	}
 
 	if paused {
@@ -244,7 +243,6 @@ func (p *LifecycleProjector) handleDelete(obj any) {
 			pendingEvents = append(pendingEvents, p.buildSandboxEvent(sandboxID, teamID, userID, templateID, claimedAt, meteringpkg.EventTypeSandboxClaimed, claimedEventID(sandboxID, claimedAt), claimEventData(pod)))
 			state.ClaimedAt = &claimedAt
 			state.ActiveSince = &claimedAt
-			pendingWindows = append(pendingWindows, p.buildSandboxRequestWindow(state, teamID, userID, templateID, claimedAt, pod))
 		}
 		if pod.Annotations[controller.AnnotationPaused] == "true" {
 			pausedAt := observedAt
@@ -390,30 +388,6 @@ func (p *LifecycleProjector) buildSandboxEvent(sandboxID, teamID, userID, templa
 		ClusterID:   p.clusterID,
 		OccurredAt:  occurredAt,
 		Data:        payload,
-	}
-}
-
-func (p *LifecycleProjector) buildSandboxRequestWindow(state *meteringpkg.SandboxProjectionState, teamID, userID, templateID string, occurredAt time.Time, pod *corev1.Pod) *meteringpkg.Window {
-	if state == nil || occurredAt.IsZero() {
-		return nil
-	}
-	return &meteringpkg.Window{
-		WindowID:    sandboxWindowID(state.SandboxID, meteringpkg.WindowTypeSandboxRequestCount, occurredAt, occurredAt),
-		Producer:    sandboxLifecycleProducer,
-		RegionID:    p.regionID,
-		WindowType:  meteringpkg.WindowTypeSandboxRequestCount,
-		SubjectType: meteringpkg.SubjectTypeSandbox,
-		SubjectID:   state.SandboxID,
-		TeamID:      teamID,
-		UserID:      userID,
-		SandboxID:   state.SandboxID,
-		TemplateID:  templateID,
-		ClusterID:   p.clusterID,
-		WindowStart: occurredAt,
-		WindowEnd:   occurredAt,
-		Value:       1,
-		Unit:        meteringpkg.WindowUnitCount,
-		Data:        requestWindowData(state, pod),
 	}
 }
 
@@ -590,18 +564,6 @@ func bytesToMiBRoundUp(value int64) int64 {
 	}
 	const mib = int64(1024 * 1024)
 	return (value + mib - 1) / mib
-}
-
-func requestWindowData(state *meteringpkg.SandboxProjectionState, pod *corev1.Pod) json.RawMessage {
-	data := map[string]any{
-		"product":             meteringpkg.ProductSandbox,
-		"resource_millicpu":   state.ResourceMillicpu,
-		"resource_memory_mib": state.ResourceMemoryMiB,
-	}
-	if pod != nil {
-		data["claim_type"] = pod.Annotations[controller.AnnotationClaimType]
-	}
-	return mustJSON(data)
 }
 
 func runtimeWindowData(state *meteringpkg.SandboxProjectionState, durationMS int64) json.RawMessage {

--- a/manager/pkg/metering/lifecycle_projector_test.go
+++ b/manager/pkg/metering/lifecycle_projector_test.go
@@ -122,8 +122,8 @@ func TestLifecycleProjectorRecordsClaimPauseResumeTerminate(t *testing.T) {
 	if len(recorder.events) != 1 || recorder.events[0].EventType != meteringpkg.EventTypeSandboxClaimed {
 		t.Fatalf("expected claim event, got %#v", recorder.events)
 	}
-	if len(recorder.windows) != 1 || recorder.windows[0].WindowType != meteringpkg.WindowTypeSandboxRequestCount {
-		t.Fatalf("expected request count window, got %#v", recorder.windows)
+	if len(recorder.windows) != 0 {
+		t.Fatalf("claim should not emit windows, got %#v", recorder.windows)
 	}
 
 	pausedAt := now.Add(-2 * time.Minute)
@@ -132,11 +132,11 @@ func TestLifecycleProjectorRecordsClaimPauseResumeTerminate(t *testing.T) {
 	if len(recorder.events) != 2 || recorder.events[1].EventType != meteringpkg.EventTypeSandboxPaused {
 		t.Fatalf("expected pause event, got %#v", recorder.events)
 	}
-	if len(recorder.windows) != 2 || recorder.windows[1].WindowType != meteringpkg.WindowTypeSandboxRuntimeMiBMilliseconds {
+	if len(recorder.windows) != 1 || recorder.windows[0].WindowType != meteringpkg.WindowTypeSandboxRuntimeMiBMilliseconds {
 		t.Fatalf("expected runtime window after pause, got %#v", recorder.windows)
 	}
-	if recorder.windows[1].Value != 491_520_000 {
-		t.Fatalf("paused runtime value = %d, want 491520000", recorder.windows[1].Value)
+	if recorder.windows[0].Value != 491_520_000 {
+		t.Fatalf("paused runtime value = %d, want 491520000", recorder.windows[0].Value)
 	}
 
 	projector.now = func() time.Time { return now.Add(time.Minute) }
@@ -145,8 +145,8 @@ func TestLifecycleProjectorRecordsClaimPauseResumeTerminate(t *testing.T) {
 	if len(recorder.events) != 3 || recorder.events[2].EventType != meteringpkg.EventTypeSandboxResumed {
 		t.Fatalf("expected resume event, got %#v", recorder.events)
 	}
-	if len(recorder.windows) != 2 {
-		t.Fatalf("window count after resume = %d, want 2", len(recorder.windows))
+	if len(recorder.windows) != 1 {
+		t.Fatalf("window count after resume = %d, want 1", len(recorder.windows))
 	}
 
 	projector.now = func() time.Time { return now.Add(2 * time.Minute) }
@@ -154,11 +154,11 @@ func TestLifecycleProjectorRecordsClaimPauseResumeTerminate(t *testing.T) {
 	if len(recorder.events) != 4 || recorder.events[3].EventType != meteringpkg.EventTypeSandboxTerminated {
 		t.Fatalf("expected terminate event, got %#v", recorder.events)
 	}
-	if len(recorder.windows) != 3 || recorder.windows[2].WindowType != meteringpkg.WindowTypeSandboxRuntimeMiBMilliseconds {
+	if len(recorder.windows) != 2 || recorder.windows[1].WindowType != meteringpkg.WindowTypeSandboxRuntimeMiBMilliseconds {
 		t.Fatalf("expected final runtime window, got %#v", recorder.windows)
 	}
-	if recorder.windows[2].Value != 61_440_000 {
-		t.Fatalf("final runtime value = %d, want 61440000", recorder.windows[2].Value)
+	if recorder.windows[1].Value != 61_440_000 {
+		t.Fatalf("final runtime value = %d, want 61440000", recorder.windows[1].Value)
 	}
 }
 
@@ -209,23 +209,17 @@ func TestLifecycleProjectorRecordsSandboxServerlessWindows(t *testing.T) {
 
 	projector.handleDelete(pod)
 
-	if len(recorder.windows) != 2 {
-		t.Fatalf("window count = %d, want 2", len(recorder.windows))
+	if len(recorder.windows) != 1 {
+		t.Fatalf("window count = %d, want 1", len(recorder.windows))
 	}
-	if recorder.windows[0].WindowType != meteringpkg.WindowTypeSandboxRequestCount {
-		t.Fatalf("first window type = %q, want %q", recorder.windows[0].WindowType, meteringpkg.WindowTypeSandboxRequestCount)
+	if recorder.windows[0].WindowType != meteringpkg.WindowTypeSandboxRuntimeMiBMilliseconds {
+		t.Fatalf("window type = %q, want %q", recorder.windows[0].WindowType, meteringpkg.WindowTypeSandboxRuntimeMiBMilliseconds)
 	}
-	if recorder.windows[0].Value != 1 || recorder.windows[0].Unit != meteringpkg.WindowUnitCount {
-		t.Fatalf("request window = %+v, want value=1 unit=count", recorder.windows[0])
+	if recorder.windows[0].Value != 2_048_000 {
+		t.Fatalf("runtime value = %d, want 2048000", recorder.windows[0].Value)
 	}
-	if recorder.windows[1].WindowType != meteringpkg.WindowTypeSandboxRuntimeMiBMilliseconds {
-		t.Fatalf("second window type = %q, want %q", recorder.windows[1].WindowType, meteringpkg.WindowTypeSandboxRuntimeMiBMilliseconds)
-	}
-	if recorder.windows[1].Value != 2_048_000 {
-		t.Fatalf("runtime value = %d, want 2048000", recorder.windows[1].Value)
-	}
-	if recorder.windows[1].Unit != meteringpkg.WindowUnitMiBMilliseconds {
-		t.Fatalf("runtime unit = %q, want %q", recorder.windows[1].Unit, meteringpkg.WindowUnitMiBMilliseconds)
+	if recorder.windows[0].Unit != meteringpkg.WindowUnitMiBMilliseconds {
+		t.Fatalf("runtime unit = %q, want %q", recorder.windows[0].Unit, meteringpkg.WindowUnitMiBMilliseconds)
 	}
 }
 
@@ -249,17 +243,14 @@ func TestLifecycleProjectorTerminatesPausedSandboxWithPausedWindow(t *testing.T)
 	if recorder.events[2].EventType != meteringpkg.EventTypeSandboxTerminated {
 		t.Fatalf("third event type = %q, want %q", recorder.events[2].EventType, meteringpkg.EventTypeSandboxTerminated)
 	}
-	if len(recorder.windows) != 2 {
-		t.Fatalf("window count = %d, want 2", len(recorder.windows))
+	if len(recorder.windows) != 1 {
+		t.Fatalf("window count = %d, want 1", len(recorder.windows))
 	}
-	if recorder.windows[0].WindowType != meteringpkg.WindowTypeSandboxRequestCount {
-		t.Fatalf("first window type = %q, want request count", recorder.windows[0].WindowType)
+	if recorder.windows[0].WindowType != meteringpkg.WindowTypeSandboxRuntimeMiBMilliseconds {
+		t.Fatalf("window type = %q, want runtime", recorder.windows[0].WindowType)
 	}
-	if recorder.windows[1].WindowType != meteringpkg.WindowTypeSandboxRuntimeMiBMilliseconds {
-		t.Fatalf("second window type = %q, want runtime", recorder.windows[1].WindowType)
-	}
-	if recorder.windows[1].Value != 184_320_000 {
-		t.Fatalf("runtime value = %d, want 184320000", recorder.windows[1].Value)
+	if recorder.windows[0].Value != 184_320_000 {
+		t.Fatalf("runtime value = %d, want 184320000", recorder.windows[0].Value)
 	}
 }
 
@@ -274,34 +265,37 @@ func TestLifecycleProjectorRetriesCommitWithoutDuplicatingWindows(t *testing.T) 
 	projector.now = func() time.Time { return now }
 	claimedAt := now.Add(-10 * time.Minute)
 	pausedAt := now.Add(-2 * time.Minute)
+	buildPod := func(paused bool, pausedAtValue string, resourceVersion string) *corev1.Pod {
+		return withSandboxResources(buildSandboxPod(claimedAt, paused, pausedAtValue, resourceVersion), "1", "1Gi")
+	}
 
-	projector.handleUpsert(buildSandboxPod(claimedAt, false, "", "1"))
+	projector.handleUpsert(buildPod(false, "", "1"))
 	if len(recorder.events) != 0 || len(recorder.windows) != 0 {
 		t.Fatalf("failed transaction should not persist facts")
 	}
 
 	recorder.stateUpsertErr = nil
-	projector.handleUpsert(buildSandboxPod(claimedAt, false, "", "1"))
-	projector.handleUpsert(buildSandboxPod(claimedAt, true, pausedAt.Format(time.RFC3339), "2"))
+	projector.handleUpsert(buildPod(false, "", "1"))
+	projector.handleUpsert(buildPod(true, pausedAt.Format(time.RFC3339), "2"))
 
 	recorder.stateUpsertErr = errors.New("boom")
 	projector.now = func() time.Time { return now.Add(time.Minute) }
-	projector.handleUpsert(buildSandboxPod(claimedAt, false, "", "3"))
+	projector.handleUpsert(buildPod(false, "", "3"))
 	if len(recorder.windows) != 1 {
 		t.Fatalf("window count after failed resume = %d, want 1", len(recorder.windows))
 	}
 
 	recorder.stateUpsertErr = nil
 	projector.now = func() time.Time { return now.Add(2 * time.Minute) }
-	projector.handleUpsert(buildSandboxPod(claimedAt, false, "", "3"))
+	projector.handleUpsert(buildPod(false, "", "3"))
 	if len(recorder.events) != 3 {
 		t.Fatalf("event count = %d, want 3", len(recorder.events))
 	}
 	if len(recorder.windows) != 1 {
 		t.Fatalf("window count = %d, want 1", len(recorder.windows))
 	}
-	if recorder.windows[0].WindowType != meteringpkg.WindowTypeSandboxRequestCount {
-		t.Fatalf("window type = %q, want request count", recorder.windows[0].WindowType)
+	if recorder.windows[0].WindowType != meteringpkg.WindowTypeSandboxRuntimeMiBMilliseconds {
+		t.Fatalf("window type = %q, want runtime", recorder.windows[0].WindowType)
 	}
 	if recorder.transactionCalls != 5 {
 		t.Fatalf("transaction_calls = %d, want 5", recorder.transactionCalls)

--- a/pkg/metering/types.go
+++ b/pkg/metering/types.go
@@ -29,7 +29,6 @@ const (
 	WindowTypeSandboxIngressBytes = "sandbox.ingress_bytes"
 	WindowTypeSandboxEgressBytes  = "sandbox.egress_bytes"
 
-	WindowTypeSandboxRequestCount           = "sandbox.request_count"
 	WindowTypeSandboxRuntimeMiBMilliseconds = "sandbox.runtime_mib_milliseconds"
 	WindowTypeSandboxVolumeByteHours        = "sandbox.volume_byte_hours"
 	WindowTypeSandboxSnapshotByteHours      = "sandbox.snapshot_byte_hours"

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -463,9 +463,6 @@ func registerApiModeSuite(envProvider func() *framework.ScenarioEnv, opts apiMod
 						if err != nil {
 							return err
 						}
-						if !hasMeteringWindow(windows, metering.WindowTypeSandboxRequestCount, pausedResp.SandboxId) {
-							return fmt.Errorf("missing sandbox.request_count window")
-						}
 						if !hasMeteringWindow(windows, metering.WindowTypeSandboxRuntimeMiBMilliseconds, pausedResp.SandboxId) {
 							return fmt.Errorf("missing sandbox.runtime_mib_milliseconds window")
 						}

--- a/tests/integration/internal/tests/cluster-gateway/metering_test.go
+++ b/tests/integration/internal/tests/cluster-gateway/metering_test.go
@@ -60,10 +60,10 @@ func TestClusterGatewayIntegration_MeteringExportContract(t *testing.T) {
 		t.Fatalf("append second event: %v", err)
 	}
 	if err := repo.AppendWindow(ctx, &metering.Window{
-		WindowID:    "sandbox/sb-1/request/1",
-		Producer:    "manager.sandbox_lifecycle",
+		WindowID:    "sandbox/sb-1/egress/1",
+		Producer:    "netd.byte_windows/node-a",
 		RegionID:    "aws-us-east-1",
-		WindowType:  metering.WindowTypeSandboxRequestCount,
+		WindowType:  metering.WindowTypeSandboxEgressBytes,
 		SubjectType: metering.SubjectTypeSandbox,
 		SubjectID:   "sb-1",
 		TeamID:      "team-1",
@@ -72,9 +72,9 @@ func TestClusterGatewayIntegration_MeteringExportContract(t *testing.T) {
 		TemplateID:  "tpl-1",
 		ClusterID:   "cluster-a",
 		WindowStart: baseTime,
-		WindowEnd:   baseTime,
-		Value:       1,
-		Unit:        metering.WindowUnitCount,
+		WindowEnd:   baseTime.Add(time.Minute),
+		Value:       512,
+		Unit:        metering.WindowUnitBytes,
 	}); err != nil {
 		t.Fatalf("append first window: %v", err)
 	}


### PR DESCRIPTION
## Summary
- stop emitting the `sandbox.request_count` usage window from manager lifecycle metering
- remove the request-count window constant and docs entry
- update metering unit, integration, and e2e assertions to expect runtime windows only

## Tests
- `go test ./manager/pkg/metering ./pkg/metering ./pkg/gateway/http/handlers`
- `go test ./tests/integration/internal/tests/cluster-gateway -run TestClusterGatewayIntegration_MeteringExportContract -count=1`