### PR TITLE
fix(netd): support h2 for HTTPS credential interception

### DIFF
--- a/docs/credential/egress-auth/page.mdx
+++ b/docs/credential/egress-auth/page.mdx
@@ -63,6 +63,8 @@ When a credential rule uses TLS interception such as `protocol: https`, `protoco
 
 At procd startup, Sandbox0 writes a combined CA bundle containing the image's system roots plus the netd MITM CA, then exports it through common TLS environment variables such as `SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`, and `AWS_CA_BUNDLE`. Applications normally do not need to handle the MITM CA themselves.
 
+For HTTPS credential injection, netd supports both HTTP/1.1 and HTTP/2 on `terminate-reoriginate` connections. Clients that offer HTTP/2 negotiate HTTP/2; HTTP/1.1-only clients continue to use HTTP/1.1. netd preserves the negotiated downstream ALPN protocol when re-originating upstream traffic and does not silently downgrade an HTTP/2 downstream request to HTTP/1.1 upstream.
+
 ## Example Policy
 
 This policy allows access to the GitHub API, binds a token source, and injects an `Authorization` header for matching HTTPS requests:

--- a/netd/pkg/proxy/tls_proxy.go
+++ b/netd/pkg/proxy/tls_proxy.go
@@ -150,6 +150,9 @@ func downstreamTLSNextProtos(req *adapterRequest) []string {
 		}
 		return []string{"h2"}
 	}
+	if req != nil && req.EgressAuth != nil && egressAuthMayUseHTTPSH2(req.EgressAuth) {
+		return []string{"h2", "http/1.1"}
+	}
 	if req != nil && policy.RequiresProtocolTLSTermination(req.Compiled, req.Host, req.DestPort, "mcp") {
 		return []string{"h2", "http/1.1"}
 	}
@@ -308,6 +311,33 @@ func egressAuthMayUseHTTP1(ctx *egressAuthContext) bool {
 		}
 	}
 	return ctx.Rule != nil && ctx.Rule.Protocol != v1alpha1.EgressAuthProtocolGRPC && ctx.Rule.Protocol != v1alpha1.EgressAuthProtocolTLS
+}
+
+func egressAuthMayUseHTTPSH2(ctx *egressAuthContext) bool {
+	if ctx == nil {
+		return false
+	}
+	if !ctx.RequestMatch {
+		return egressAuthRuleMayUseHTTPSH2(ctx.Rule)
+	}
+	for _, rule := range ctx.CandidateRules {
+		if egressAuthRuleMayUseHTTPSH2(rule) {
+			return true
+		}
+	}
+	return egressAuthRuleMayUseHTTPSH2(ctx.Rule)
+}
+
+func egressAuthRuleMayUseHTTPSH2(rule *policy.CompiledEgressAuthRule) bool {
+	if rule == nil || rule.TLSMode != v1alpha1.EgressTLSModeTerminateReoriginate {
+		return false
+	}
+	switch rule.Protocol {
+	case "", v1alpha1.EgressAuthProtocolHTTPS:
+		return true
+	default:
+		return false
+	}
 }
 
 func egressAuthRequiresGRPCH2(ctx *egressAuthContext) bool {

--- a/netd/pkg/proxy/tls_proxy_test.go
+++ b/netd/pkg/proxy/tls_proxy_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/netd/pkg/policy"
 	"github.com/sandbox0-ai/sandbox0/pkg/egressauth"
 	"go.uber.org/zap"
+	"golang.org/x/net/http2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/health"
@@ -192,6 +193,12 @@ func TestTLSAdapterInterceptsHTTPSAndInjectsHeaders(t *testing.T) {
 		MinVersion: tls.VersionTLS12,
 	})
 	defer clientTLS.Close()
+	if err := clientTLS.Handshake(); err != nil {
+		t.Fatalf("handshake client tls: %v", err)
+	}
+	if got := clientTLS.ConnectionState().NegotiatedProtocol; got != "http/1.1" {
+		t.Fatalf("negotiated protocol = %q, want http/1.1", got)
+	}
 
 	if _, err := io.WriteString(clientTLS, "POST /v1/test HTTP/1.1\r\nHost: api.example.com\r\nContent-Length: 7\r\n\r\npayload"); err != nil {
 		t.Fatalf("write tls request: %v", err)
@@ -218,6 +225,191 @@ func TestTLSAdapterInterceptsHTTPSAndInjectsHeaders(t *testing.T) {
 	}
 	if got := <-requestBody; got != "payload" {
 		t.Fatalf("request body = %q", got)
+	}
+}
+
+func TestTLSAdapterInterceptsHTTPSOverHTTP2AndInjectsHeaders(t *testing.T) {
+	mitmCertPEM, mitmKeyPEM, err := newSelfSignedCertificateAuthority("sandbox0-mitm", time.Hour)
+	if err != nil {
+		t.Fatalf("new mitm ca: %v", err)
+	}
+	mitmAuthority, err := newCertificateAuthority(mitmCertPEM, mitmKeyPEM, time.Hour)
+	if err != nil {
+		t.Fatalf("new mitm authority: %v", err)
+	}
+
+	upstreamCAPEM, upstreamCAKeyPEM, err := newSelfSignedCertificateAuthority("sandbox0-upstream", time.Hour)
+	if err != nil {
+		t.Fatalf("new upstream ca: %v", err)
+	}
+	upstreamAuthority, err := newCertificateAuthority(upstreamCAPEM, upstreamCAKeyPEM, time.Hour)
+	if err != nil {
+		t.Fatalf("new upstream authority: %v", err)
+	}
+	upstreamLeaf, err := upstreamAuthority.CertificateForHost("api.example.com")
+	if err != nil {
+		t.Fatalf("upstream leaf: %v", err)
+	}
+	upstreamRootPool := x509.NewCertPool()
+	if !upstreamRootPool.AppendCertsFromPEM(upstreamCAPEM) {
+		t.Fatal("append upstream ca")
+	}
+
+	requestHeaders := make(chan http.Header, 1)
+	requestBody := make(chan string, 1)
+	requestProtocol := make(chan string, 1)
+	upstreamListener, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{
+		Certificates: []tls.Certificate{*upstreamLeaf},
+		NextProtos:   []string{"h2"},
+		MinVersion:   tls.VersionTLS12,
+	})
+	if err != nil {
+		t.Fatalf("tls listen upstream: %v", err)
+	}
+	defer upstreamListener.Close()
+	upstreamServer := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, readErr := io.ReadAll(r.Body)
+			if readErr != nil {
+				t.Errorf("read upstream body: %v", readErr)
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			requestHeaders <- r.Header.Clone()
+			requestBody <- string(body)
+			requestProtocol <- r.Proto
+			_, _ = w.Write([]byte("h2-secure-ok"))
+		}),
+	}
+	if err := http2.ConfigureServer(upstreamServer, &http2.Server{}); err != nil {
+		t.Fatalf("configure upstream http2 server: %v", err)
+	}
+	defer upstreamServer.Close()
+	go func() {
+		_ = upstreamServer.Serve(upstreamListener)
+	}()
+
+	proxyListener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen proxy: %v", err)
+	}
+	defer proxyListener.Close()
+
+	server := &Server{
+		cfg: &config.NetdConfig{
+			ProxyUpstreamTimeout: metav1.Duration{Duration: 2 * time.Second},
+		},
+		logger:            zap.NewNop(),
+		tlsAuthority:      mitmAuthority,
+		upstreamTLSConfig: &tls.Config{RootCAs: upstreamRootPool},
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		conn, acceptErr := proxyListener.Accept()
+		if acceptErr != nil {
+			done <- acceptErr
+			return
+		}
+		defer conn.Close()
+		req := &adapterRequest{
+			Server:   server,
+			Compiled: &policy.CompiledPolicy{SandboxID: "sbx_123", TeamID: "team_123", Mode: v1alpha1.NetworkModeAllowAll},
+			SrcIP:    "10.0.0.2",
+			DestIP:   upstreamListener.Addr().(*net.TCPAddr).IP,
+			DestPort: upstreamListener.Addr().(*net.TCPAddr).Port,
+			Host:     "api.example.com",
+			Conn:     conn,
+			EgressAuth: &egressAuthContext{
+				Rule: &policy.CompiledEgressAuthRule{
+					Name:     "example-https",
+					AuthRef:  "example-api",
+					Protocol: v1alpha1.EgressAuthProtocolHTTPS,
+					TLSMode:  v1alpha1.EgressTLSModeTerminateReoriginate,
+				},
+				Resolved: egressauth.NewHTTPHeadersResolveResponse("example-api", map[string]string{
+					"Authorization": "Bearer h2-token",
+				}, nil),
+			},
+		}
+		done <- (&tlsAdapter{}).Handle(req)
+	}()
+
+	clientRootPool := x509.NewCertPool()
+	if !clientRootPool.AppendCertsFromPEM(mitmCertPEM) {
+		t.Fatal("append mitm ca")
+	}
+	clientTLSConfig := &tls.Config{
+		ServerName: "api.example.com",
+		RootCAs:    clientRootPool,
+		NextProtos: []string{"h2"},
+		MinVersion: tls.VersionTLS12,
+	}
+	negotiatedProtocol := make(chan string, 1)
+	clientTransport := &http2.Transport{
+		TLSClientConfig: clientTLSConfig,
+		DialTLSContext: func(ctx context.Context, network, addr string, cfg *tls.Config) (net.Conn, error) {
+			_ = network
+			_ = addr
+			tlsCfg := clientTLSConfig
+			if cfg != nil {
+				tlsCfg = cfg.Clone()
+			}
+			rawConn, dialErr := net.Dial("tcp4", proxyListener.Addr().String())
+			if dialErr != nil {
+				return nil, dialErr
+			}
+			tlsConn := tls.Client(rawConn, tlsCfg)
+			if handshakeErr := tlsConn.HandshakeContext(ctx); handshakeErr != nil {
+				_ = rawConn.Close()
+				return nil, handshakeErr
+			}
+			negotiatedProtocol <- tlsConn.ConnectionState().NegotiatedProtocol
+			return tlsConn, nil
+		},
+	}
+	defer clientTransport.CloseIdleConnections()
+	client := &http.Client{
+		Transport: clientTransport,
+		Timeout:   5 * time.Second,
+	}
+	httpReq, err := http.NewRequest(http.MethodPost, "https://api.example.com/v1/test", strings.NewReader("payload"))
+	if err != nil {
+		t.Fatalf("new http2 request: %v", err)
+	}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		t.Fatalf("http2 client request: %v", err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read http2 response body: %v", err)
+	}
+	_ = resp.Body.Close()
+	if got := string(body); got != "h2-secure-ok" {
+		t.Fatalf("response body = %q", got)
+	}
+	if got := <-negotiatedProtocol; got != "h2" {
+		t.Fatalf("negotiated protocol = %q, want h2", got)
+	}
+	if got := <-requestProtocol; got != "HTTP/2.0" {
+		t.Fatalf("upstream protocol = %q, want HTTP/2.0", got)
+	}
+	headers := <-requestHeaders
+	if got := headers.Get("Authorization"); got != "Bearer h2-token" {
+		t.Fatalf("authorization header = %q", got)
+	}
+	if got := <-requestBody; got != "payload" {
+		t.Fatalf("request body = %q", got)
+	}
+	clientTransport.CloseIdleConnections()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("tls adapter handle: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for tls adapter")
 	}
 }
 


### PR DESCRIPTION
## Summary
- advertise h2 for HTTPS terminate-reoriginate credential rules while keeping HTTP/1.1 preferred for dual-stack clients
- route negotiated h2 HTTPS requests through the existing HTTP/2 proxy path so injected headers are preserved upstream
- document that netd preserves the negotiated downstream ALPN and does not silently downgrade h2 to HTTP/1.1 upstream

Fixes #433

## Tests
- go test ./netd/pkg/proxy -count=1 -timeout=3m
- go test ./netd/pkg/policy ./netd/pkg/proxy -count=1 -timeout=3m