### PR TITLE
chore: unify platform logging setup

### DIFF
--- a/cluster-gateway/cmd/cluster-gateway/main.go
+++ b/cluster-gateway/cmd/cluster-gateway/main.go
@@ -17,7 +17,6 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/migrate"
 	"github.com/sandbox0-ai/sandbox0/pkg/observability"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
 
 func main() {
@@ -25,7 +24,10 @@ func main() {
 	cfg := config.LoadClusterGatewayConfig()
 
 	// Initialize logger
-	logger, err := initLogger(cfg.LogLevel)
+	logger, err := observability.NewLogger(observability.LoggerConfig{
+		ServiceName: "cluster-gateway",
+		Level:       cfg.LogLevel,
+	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to initialize logger: %v\n", err)
 		os.Exit(1)
@@ -66,7 +68,7 @@ func main() {
 		}
 	}
 	if pool != nil {
-		if err := metering.RunMigrations(ctx, pool, &zapLogger{logger: logger}); err != nil {
+		if err := metering.RunMigrations(ctx, pool, observability.NewMigrateLogger(logger)); err != nil {
 			logger.Fatal("Failed to run metering migrations", zap.Error(err))
 		}
 	}
@@ -101,47 +103,6 @@ func main() {
 	logger.Info("Internal gateway shutdown complete")
 }
 
-// initLogger initializes the zap logger
-func initLogger(level string) (*zap.Logger, error) {
-	var logLevel zapcore.Level
-	switch level {
-	case "debug":
-		logLevel = zapcore.DebugLevel
-	case "info":
-		logLevel = zapcore.InfoLevel
-	case "warn":
-		logLevel = zapcore.WarnLevel
-	case "error":
-		logLevel = zapcore.ErrorLevel
-	default:
-		logLevel = zapcore.InfoLevel
-	}
-
-	config := zap.Config{
-		Level:       zap.NewAtomicLevelAt(logLevel),
-		Development: false,
-		Encoding:    "json",
-		EncoderConfig: zapcore.EncoderConfig{
-			TimeKey:        "ts",
-			LevelKey:       "level",
-			NameKey:        "logger",
-			CallerKey:      "caller",
-			FunctionKey:    zapcore.OmitKey,
-			MessageKey:     "msg",
-			StacktraceKey:  "stacktrace",
-			LineEnding:     zapcore.DefaultLineEnding,
-			EncodeLevel:    zapcore.LowercaseLevelEncoder,
-			EncodeTime:     zapcore.ISO8601TimeEncoder,
-			EncodeDuration: zapcore.SecondsDurationEncoder,
-			EncodeCaller:   zapcore.ShortCallerEncoder,
-		},
-		OutputPaths:      []string{"stdout"},
-		ErrorOutputPaths: []string{"stderr"},
-	}
-
-	return config.Build()
-}
-
 func initDatabase(ctx context.Context, cfg *config.ClusterGatewayConfig, logger *zap.Logger, obsProvider *observability.Provider) *pgxpool.Pool {
 	pool, err := dbpool.New(ctx, dbpool.Options{
 		DatabaseURL:    cfg.DatabaseURL,
@@ -165,11 +126,9 @@ func initDatabase(ctx context.Context, cfg *config.ClusterGatewayConfig, logger 
 func runMigrations(ctx context.Context, pool *pgxpool.Pool, logger *zap.Logger) error {
 	logger.Info("Running database migrations")
 
-	migrateLogger := &zapLogger{logger: logger}
-
 	if err := migrate.Up(ctx, pool, ".",
 		migrate.WithBaseFS(gatewaymigrations.FS),
-		migrate.WithLogger(migrateLogger),
+		migrate.WithLogger(observability.NewMigrateLogger(logger)),
 		migrate.WithSchema("shared_gateway"),
 	); err != nil {
 		return fmt.Errorf("migrate up: %w", err)
@@ -177,16 +136,4 @@ func runMigrations(ctx context.Context, pool *pgxpool.Pool, logger *zap.Logger) 
 
 	logger.Info("Database migrations completed successfully")
 	return nil
-}
-
-type zapLogger struct {
-	logger *zap.Logger
-}
-
-func (z *zapLogger) Printf(format string, args ...any) {
-	z.logger.Info(fmt.Sprintf(format, args...))
-}
-
-func (z *zapLogger) Fatalf(format string, args ...any) {
-	z.logger.Fatal(fmt.Sprintf(format, args...))
 }

--- a/ctld/cmd/ctld/main.go
+++ b/ctld/cmd/ctld/main.go
@@ -27,7 +27,6 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/sandboxprobe"
 	storagedb "github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/objectstore"
-	"go.uber.org/zap"
 )
 
 var (
@@ -68,7 +67,10 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	zapLogger, err := zap.NewProduction()
+	zapLogger, err := observability.NewLogger(observability.LoggerConfig{
+		ServiceName: "ctld",
+		Level:       "info",
+	})
 	if err != nil {
 		log.Printf("ctld observability disabled: create zap logger: %v", err)
 	}

--- a/global-gateway/cmd/global-gateway/main.go
+++ b/global-gateway/cmd/global-gateway/main.go
@@ -15,13 +15,15 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/migrate"
 	"github.com/sandbox0-ai/sandbox0/pkg/observability"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
 
 func main() {
 	cfg := config.LoadGlobalGatewayConfig()
 
-	logger, err := initLogger(cfg.LogLevel)
+	logger, err := observability.NewLogger(observability.LoggerConfig{
+		ServiceName: "global-gateway",
+		Level:       cfg.LogLevel,
+	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to initialize logger: %v\n", err)
 		os.Exit(1)
@@ -82,45 +84,6 @@ func main() {
 	logger.Info("Global gateway shutdown complete")
 }
 
-func initLogger(level string) (*zap.Logger, error) {
-	var logLevel zapcore.Level
-	switch level {
-	case "debug":
-		logLevel = zapcore.DebugLevel
-	case "info":
-		logLevel = zapcore.InfoLevel
-	case "warn":
-		logLevel = zapcore.WarnLevel
-	case "error":
-		logLevel = zapcore.ErrorLevel
-	default:
-		logLevel = zapcore.InfoLevel
-	}
-
-	cfg := zap.Config{
-		Level:       zap.NewAtomicLevelAt(logLevel),
-		Development: false,
-		Encoding:    "json",
-		EncoderConfig: zapcore.EncoderConfig{
-			TimeKey:        "ts",
-			LevelKey:       "level",
-			NameKey:        "logger",
-			CallerKey:      "caller",
-			FunctionKey:    zapcore.OmitKey,
-			MessageKey:     "msg",
-			StacktraceKey:  "stacktrace",
-			LineEnding:     zapcore.DefaultLineEnding,
-			EncodeLevel:    zapcore.LowercaseLevelEncoder,
-			EncodeTime:     zapcore.ISO8601TimeEncoder,
-			EncodeDuration: zapcore.SecondsDurationEncoder,
-			EncodeCaller:   zapcore.ShortCallerEncoder,
-		},
-		OutputPaths:      []string{"stdout"},
-		ErrorOutputPaths: []string{"stderr"},
-	}
-	return cfg.Build()
-}
-
 func initDatabase(
 	ctx context.Context,
 	cfg *config.GlobalGatewayConfig,
@@ -158,25 +121,12 @@ func runMigrations(ctx context.Context, pool *pgxpool.Pool, cfg *config.GlobalGa
 	}
 
 	logger.Info("Running database migrations", zap.String("schema", schema))
-	migrateLogger := &zapLogger{logger: logger}
 	if err := migrate.Up(ctx, pool, ".",
 		migrate.WithBaseFS(gatewaymigrations.FS),
-		migrate.WithLogger(migrateLogger),
+		migrate.WithLogger(observability.NewMigrateLogger(logger)),
 		migrate.WithSchema(schema),
 	); err != nil {
 		return fmt.Errorf("migrate up: %w", err)
 	}
 	return nil
-}
-
-type zapLogger struct {
-	logger *zap.Logger
-}
-
-func (z *zapLogger) Printf(format string, args ...any) {
-	z.logger.Info(fmt.Sprintf(format, args...))
-}
-
-func (z *zapLogger) Fatalf(format string, args ...any) {
-	z.logger.Fatal(fmt.Sprintf(format, args...))
 }

--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -39,7 +39,6 @@ import (
 	templreconciler "github.com/sandbox0-ai/sandbox0/pkg/template/reconciler"
 	templstorepg "github.com/sandbox0-ai/sandbox0/pkg/template/store/pg"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
@@ -56,7 +55,14 @@ func main() {
 	cfg := config.LoadManagerConfig()
 
 	// Initialize logger
-	logger := initLogger(cfg.LogLevel)
+	logger, err := observability.NewLogger(observability.LoggerConfig{
+		ServiceName: "manager",
+		Level:       cfg.LogLevel,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to initialize logger: %v\n", err)
+		os.Exit(1)
+	}
 	defer logger.Sync()
 
 	logger.Info("Starting Manager",
@@ -506,31 +512,6 @@ func main() {
 	logger.Info("Manager stopped")
 }
 
-// initLogger initializes the logger
-func initLogger(logLevel string) *zap.Logger {
-	level := zapcore.InfoLevel
-	switch logLevel {
-	case "debug":
-		level = zapcore.DebugLevel
-	case "warn":
-		level = zapcore.WarnLevel
-	case "error":
-		level = zapcore.ErrorLevel
-	}
-
-	cfg := zap.NewProductionConfig()
-	cfg.Level = zap.NewAtomicLevelAt(level)
-	cfg.EncoderConfig.TimeKey = "timestamp"
-	cfg.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
-
-	logger, err := cfg.Build()
-	if err != nil {
-		panic(fmt.Sprintf("Failed to initialize logger: %v", err))
-	}
-
-	return logger
-}
-
 // buildKubeConfig builds Kubernetes config
 func buildKubeConfig(kubeconfig string) (*rest.Config, error) {
 	if kubeconfig != "" {
@@ -554,10 +535,9 @@ func startMetricsServer(port int, logger *zap.Logger) {
 func runTemplateMigrations(ctx context.Context, pool *pgxpool.Pool, logger *zap.Logger) error {
 	logger.Info("Running template migrations")
 
-	migrateLogger := &zapMigrateLogger{logger: logger}
 	if err := migrate.Up(ctx, pool, ".",
 		migrate.WithBaseFS(templmigrations.FS),
-		migrate.WithLogger(migrateLogger),
+		migrate.WithLogger(observability.NewMigrateLogger(logger)),
 		migrate.WithSchema("scheduler"),
 	); err != nil {
 		return fmt.Errorf("migrate up: %w", err)
@@ -570,8 +550,7 @@ func runTemplateMigrations(ctx context.Context, pool *pgxpool.Pool, logger *zap.
 func runMeteringMigrations(ctx context.Context, pool *pgxpool.Pool, logger *zap.Logger) error {
 	logger.Info("Running metering migrations")
 
-	migrateLogger := &zapMigrateLogger{logger: logger}
-	if err := metering.RunMigrations(ctx, pool, migrateLogger); err != nil {
+	if err := metering.RunMigrations(ctx, pool, observability.NewMigrateLogger(logger)); err != nil {
 		return fmt.Errorf("metering migrations: %w", err)
 	}
 
@@ -582,8 +561,7 @@ func runMeteringMigrations(ctx context.Context, pool *pgxpool.Pool, logger *zap.
 func runQuotaMigrations(ctx context.Context, pool *pgxpool.Pool, logger *zap.Logger) error {
 	logger.Info("Running quota migrations")
 
-	migrateLogger := &zapMigrateLogger{logger: logger}
-	if err := quota.RunMigrations(ctx, pool, migrateLogger); err != nil {
+	if err := quota.RunMigrations(ctx, pool, observability.NewMigrateLogger(logger)); err != nil {
 		return fmt.Errorf("quota migrations: %w", err)
 	}
 
@@ -594,8 +572,7 @@ func runQuotaMigrations(ctx context.Context, pool *pgxpool.Pool, logger *zap.Log
 func runEgressAuthMigrations(ctx context.Context, pool *pgxpool.Pool, logger *zap.Logger) error {
 	logger.Info("Running egress auth migrations")
 
-	migrateLogger := &zapMigrateLogger{logger: logger}
-	if err := egressauth.RunMigrations(ctx, pool, migrateLogger); err != nil {
+	if err := egressauth.RunMigrations(ctx, pool, observability.NewMigrateLogger(logger)); err != nil {
 		return fmt.Errorf("egress auth migrations: %w", err)
 	}
 
@@ -674,8 +651,7 @@ func loadCredentialEncryptionKey(cfg config.CredentialEncryptedPGConfig) ([]byte
 func runSandboxStoreMigrations(ctx context.Context, pool *pgxpool.Pool, logger *zap.Logger) error {
 	logger.Info("Running sandbox store migrations")
 
-	migrateLogger := &zapMigrateLogger{logger: logger}
-	if err := service.RunSandboxStoreMigrations(ctx, pool, migrateLogger); err != nil {
+	if err := service.RunSandboxStoreMigrations(ctx, pool, observability.NewMigrateLogger(logger)); err != nil {
 		return fmt.Errorf("sandbox store migrations: %w", err)
 	}
 
@@ -702,19 +678,6 @@ func initDatabase(ctx context.Context, databaseURL string, maxConns, minConns in
 	)
 
 	return pool, nil
-}
-
-// zapMigrateLogger adapts zap.Logger to migrate.Logger interface.
-type zapMigrateLogger struct {
-	logger *zap.Logger
-}
-
-func (z *zapMigrateLogger) Printf(format string, args ...any) {
-	z.logger.Info(fmt.Sprintf(format, args...))
-}
-
-func (z *zapMigrateLogger) Fatalf(format string, args ...any) {
-	z.logger.Fatal(fmt.Sprintf(format, args...))
 }
 
 // pgxPoolAdapter adapts pgxpool.Pool to clock.DB interface

--- a/manager/cmd/procd/main.go
+++ b/manager/cmd/procd/main.go
@@ -21,7 +21,6 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"github.com/sandbox0-ai/sandbox0/pkg/observability"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
 
 func main() {
@@ -37,7 +36,14 @@ func main() {
 	}
 
 	// Initialize logger
-	logger := initLogger(cfg.LogLevel)
+	logger, err := observability.NewLogger(observability.LoggerConfig{
+		ServiceName: "procd",
+		Level:       cfg.LogLevel,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to initialize logger: %v\n", err)
+		os.Exit(1)
+	}
 	defer logger.Sync()
 
 	logger.Info("Starting Procd",
@@ -222,46 +228,4 @@ func main() {
 
 	<-done
 	logger.Info("Procd shutdown complete")
-}
-
-func initLogger(logLevel string) *zap.Logger {
-	level := zapcore.InfoLevel
-
-	switch logLevel {
-	case "debug":
-		level = zapcore.DebugLevel
-	case "warn":
-		level = zapcore.WarnLevel
-	case "error":
-		level = zapcore.ErrorLevel
-	}
-
-	config := zap.Config{
-		Level:       zap.NewAtomicLevelAt(level),
-		Development: false,
-		Encoding:    "json",
-		EncoderConfig: zapcore.EncoderConfig{
-			TimeKey:        "timestamp",
-			LevelKey:       "level",
-			NameKey:        "logger",
-			CallerKey:      "caller",
-			FunctionKey:    zapcore.OmitKey,
-			MessageKey:     "message",
-			StacktraceKey:  "stacktrace",
-			LineEnding:     zapcore.DefaultLineEnding,
-			EncodeLevel:    zapcore.LowercaseLevelEncoder,
-			EncodeTime:     zapcore.ISO8601TimeEncoder,
-			EncodeDuration: zapcore.SecondsDurationEncoder,
-			EncodeCaller:   zapcore.ShortCallerEncoder,
-		},
-		OutputPaths:      []string{"stdout"},
-		ErrorOutputPaths: []string{"stderr"},
-	}
-
-	logger, err := config.Build()
-	if err != nil {
-		panic(err)
-	}
-
-	return logger
 }

--- a/netd/cmd/netd/main.go
+++ b/netd/cmd/netd/main.go
@@ -11,13 +11,15 @@ import (
 	"github.com/sandbox0-ai/sandbox0/netd/pkg/daemon"
 	"github.com/sandbox0-ai/sandbox0/pkg/observability"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
 
 func main() {
 	cfg := config.LoadNetdConfig()
 
-	logger, err := initLogger(cfg.LogLevel)
+	logger, err := observability.NewLogger(observability.LoggerConfig{
+		ServiceName: "netd",
+		Level:       cfg.LogLevel,
+	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to initialize logger: %v\n", err)
 		os.Exit(1)
@@ -52,44 +54,4 @@ func main() {
 	if err := daemon.Run(ctx); err != nil {
 		logger.Fatal("netd exited with error", zap.Error(err))
 	}
-}
-
-func initLogger(level string) (*zap.Logger, error) {
-	var logLevel zapcore.Level
-	switch level {
-	case "debug":
-		logLevel = zapcore.DebugLevel
-	case "info":
-		logLevel = zapcore.InfoLevel
-	case "warn":
-		logLevel = zapcore.WarnLevel
-	case "error":
-		logLevel = zapcore.ErrorLevel
-	default:
-		logLevel = zapcore.InfoLevel
-	}
-
-	cfg := zap.Config{
-		Level:       zap.NewAtomicLevelAt(logLevel),
-		Development: false,
-		Encoding:    "json",
-		EncoderConfig: zapcore.EncoderConfig{
-			TimeKey:        "ts",
-			LevelKey:       "level",
-			NameKey:        "logger",
-			CallerKey:      "caller",
-			FunctionKey:    zapcore.OmitKey,
-			MessageKey:     "msg",
-			StacktraceKey:  "stacktrace",
-			LineEnding:     zapcore.DefaultLineEnding,
-			EncodeLevel:    zapcore.LowercaseLevelEncoder,
-			EncodeTime:     zapcore.ISO8601TimeEncoder,
-			EncodeDuration: zapcore.SecondsDurationEncoder,
-			EncodeCaller:   zapcore.ShortCallerEncoder,
-		},
-		OutputPaths:      []string{"stdout"},
-		ErrorOutputPaths: []string{"stderr"},
-	}
-
-	return cfg.Build()
 }

--- a/netd/pkg/daemon/daemon.go
+++ b/netd/pkg/daemon/daemon.go
@@ -149,10 +149,10 @@ func (d *Daemon) runNetd(ctx context.Context, cancel context.CancelFunc, proxyEx
 			return fmt.Errorf("create netd database pool: %w", err)
 		}
 		meteringPool = pool
-		if err := meteringpkg.RunMigrations(ctx, meteringPool, &zapLoggerAdapter{logger: d.logger}); err != nil {
+		if err := meteringpkg.RunMigrations(ctx, meteringPool, observability.NewMigrateLogger(d.logger)); err != nil {
 			return fmt.Errorf("run metering migrations: %w", err)
 		}
-		if err := quota.RunMigrations(ctx, meteringPool, &zapLoggerAdapter{logger: d.logger}); err != nil {
+		if err := quota.RunMigrations(ctx, meteringPool, observability.NewMigrateLogger(d.logger)); err != nil {
 			return fmt.Errorf("run quota migrations: %w", err)
 		}
 		usageAggregator = netdmetering.NewAggregator(
@@ -403,24 +403,6 @@ func closeRuntimeResource(resource runtimeResource) {
 	if resource != nil {
 		resource.Close()
 	}
-}
-
-type zapLoggerAdapter struct {
-	logger *zap.Logger
-}
-
-func (l *zapLoggerAdapter) Printf(format string, args ...any) {
-	if l == nil || l.logger == nil {
-		return
-	}
-	l.logger.Sugar().Infof(format, args...)
-}
-
-func (l *zapLoggerAdapter) Fatalf(format string, args ...any) {
-	if l == nil || l.logger == nil {
-		return
-	}
-	l.logger.Sugar().Errorf(format, args...)
 }
 
 func (d *Daemon) syncRedirect(

--- a/pkg/observability/doc.go
+++ b/pkg/observability/doc.go
@@ -16,7 +16,16 @@
 //
 // # Quick Start
 //
-// Initialize observability provider once in your main.go:
+// Initialize the shared service logger and observability provider once in your
+// main.go:
+//
+//	logger, err := observability.NewLogger(observability.LoggerConfig{
+//	    ServiceName: "cluster-gateway",
+//	    Level:       cfg.LogLevel,
+//	})
+//	if err != nil {
+//	    return err
+//	}
 //
 //	provider, err := observability.New(observability.Config{
 //	    ServiceName: "cluster-gateway",
@@ -87,11 +96,12 @@
 //
 // # Best Practices
 //
-// 1. Create one Provider instance per service
+// 1. Create one Logger and Provider instance per service
 // 2. Pass the provider to all client constructors
 // 3. Always call provider.Shutdown() on graceful shutdown
-// 4. Use context for request-scoped metadata
-// 5. Set appropriate timeout values for all clients
+// 4. Use NewMigrateLogger when wiring migration output to zap
+// 5. Use context for request-scoped metadata
+// 6. Set appropriate timeout values for all clients
 //
 // # Performance
 //

--- a/pkg/observability/logger.go
+++ b/pkg/observability/logger.go
@@ -1,0 +1,106 @@
+package observability
+
+import (
+	"fmt"
+	"strings"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// LoggerConfig configures the shared zap logger used by sandbox0 services.
+type LoggerConfig struct {
+	ServiceName      string
+	Level            string
+	Development      bool
+	OutputPaths      []string
+	ErrorOutputPaths []string
+	Fields           []zap.Field
+}
+
+// NewLogger creates a production JSON zap logger with the shared sandbox0 log format.
+func NewLogger(cfg LoggerConfig) (*zap.Logger, error) {
+	zapCfg := zap.Config{
+		Level:       zap.NewAtomicLevelAt(parseLoggerLevel(cfg.Level)),
+		Development: cfg.Development,
+		Encoding:    "json",
+		EncoderConfig: zapcore.EncoderConfig{
+			TimeKey:        "ts",
+			LevelKey:       "level",
+			NameKey:        "logger",
+			CallerKey:      "caller",
+			FunctionKey:    zapcore.OmitKey,
+			MessageKey:     "msg",
+			StacktraceKey:  "stacktrace",
+			LineEnding:     zapcore.DefaultLineEnding,
+			EncodeLevel:    zapcore.LowercaseLevelEncoder,
+			EncodeTime:     zapcore.ISO8601TimeEncoder,
+			EncodeDuration: zapcore.SecondsDurationEncoder,
+			EncodeCaller:   zapcore.ShortCallerEncoder,
+		},
+		OutputPaths:      cfg.OutputPaths,
+		ErrorOutputPaths: cfg.ErrorOutputPaths,
+	}
+	if len(zapCfg.OutputPaths) == 0 {
+		zapCfg.OutputPaths = []string{"stdout"}
+	}
+	if len(zapCfg.ErrorOutputPaths) == 0 {
+		zapCfg.ErrorOutputPaths = []string{"stderr"}
+	}
+
+	logger, err := zapCfg.Build()
+	if err != nil {
+		return nil, err
+	}
+	fields := make([]zap.Field, 0, len(cfg.Fields)+1)
+	if cfg.ServiceName != "" {
+		fields = append(fields, zap.String("service", cfg.ServiceName))
+	}
+	fields = append(fields, cfg.Fields...)
+	if len(fields) > 0 {
+		logger = logger.With(fields...)
+	}
+	return logger, nil
+}
+
+func parseLoggerLevel(level string) zapcore.Level {
+	switch strings.ToLower(strings.TrimSpace(level)) {
+	case "debug":
+		return zapcore.DebugLevel
+	case "warn", "warning":
+		return zapcore.WarnLevel
+	case "error":
+		return zapcore.ErrorLevel
+	default:
+		return zapcore.InfoLevel
+	}
+}
+
+// MigrateLogger adapts zap logging to migration packages.
+type MigrateLogger interface {
+	Printf(format string, args ...any)
+	Fatalf(format string, args ...any)
+}
+
+// NewMigrateLogger returns a logger compatible with migration libraries.
+func NewMigrateLogger(logger *zap.Logger) MigrateLogger {
+	return migrateLogger{logger: logger}
+}
+
+type migrateLogger struct {
+	logger *zap.Logger
+}
+
+func (l migrateLogger) Printf(format string, args ...any) {
+	if l.logger == nil {
+		return
+	}
+	l.logger.Info(fmt.Sprintf(format, args...))
+}
+
+func (l migrateLogger) Fatalf(format string, args ...any) {
+	if l.logger == nil {
+		return
+	}
+	l.logger.Fatal(fmt.Sprintf(format, args...))
+}

--- a/pkg/observability/logger_test.go
+++ b/pkg/observability/logger_test.go
@@ -1,0 +1,136 @@
+package observability
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestNewLoggerUsesSharedJSONFormat(t *testing.T) {
+	output := filepath.Join(t.TempDir(), "service.log")
+	logger, err := NewLogger(LoggerConfig{
+		ServiceName: "test-service",
+		OutputPaths: []string{
+			output,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewLogger() error = %v", err)
+	}
+
+	logger.Info("hello")
+	_ = logger.Sync()
+
+	entry := readLogEntry(t, output)
+	if entry["service"] != "test-service" {
+		t.Fatalf("service = %v, want test-service", entry["service"])
+	}
+	if entry["level"] != "info" {
+		t.Fatalf("level = %v, want info", entry["level"])
+	}
+	if entry["msg"] != "hello" {
+		t.Fatalf("msg = %v, want hello", entry["msg"])
+	}
+	if _, ok := entry["ts"]; !ok {
+		t.Fatal("missing ts field")
+	}
+	if _, ok := entry["caller"]; !ok {
+		t.Fatal("missing caller field")
+	}
+	if _, ok := entry["message"]; ok {
+		t.Fatal("unexpected legacy message field")
+	}
+	if _, ok := entry["timestamp"]; ok {
+		t.Fatal("unexpected legacy timestamp field")
+	}
+}
+
+func TestNewLoggerDefaultsInvalidLevelToInfo(t *testing.T) {
+	output := filepath.Join(t.TempDir(), "service.log")
+	logger, err := NewLogger(LoggerConfig{
+		ServiceName: "test-service",
+		Level:       "invalid",
+		OutputPaths: []string{
+			output,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewLogger() error = %v", err)
+	}
+
+	logger.Debug("debug message")
+	logger.Info("info message")
+	_ = logger.Sync()
+
+	entry := readLogEntry(t, output)
+	if entry["msg"] != "info message" {
+		t.Fatalf("msg = %v, want info message", entry["msg"])
+	}
+}
+
+func TestNewMigrateLoggerFormatsMessages(t *testing.T) {
+	output := filepath.Join(t.TempDir(), "migration.log")
+	logger, err := NewLogger(LoggerConfig{
+		ServiceName: "test-service",
+		OutputPaths: []string{
+			output,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewLogger() error = %v", err)
+	}
+
+	migrateLogger := NewMigrateLogger(logger)
+	migrateLogger.Printf("applied %d migrations", 3)
+	_ = logger.Sync()
+
+	entry := readLogEntry(t, output)
+	if entry["msg"] != "applied 3 migrations" {
+		t.Fatalf("msg = %v, want applied 3 migrations", entry["msg"])
+	}
+}
+
+func TestNewMigrateLoggerAllowsNilLogger(t *testing.T) {
+	NewMigrateLogger(nil).Printf("ignored")
+}
+
+func readLogEntry(t *testing.T, path string) map[string]any {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read log file: %v", err)
+	}
+	var entry map[string]any
+	if err := json.Unmarshal(data, &entry); err != nil {
+		t.Fatalf("decode log entry: %v", err)
+	}
+	return entry
+}
+
+func TestNewLoggerIncludesExtraFields(t *testing.T) {
+	output := filepath.Join(t.TempDir(), "service.log")
+	logger, err := NewLogger(LoggerConfig{
+		ServiceName: "test-service",
+		OutputPaths: []string{
+			output,
+		},
+		Fields: []zap.Field{
+			zap.String("region", "us-east-1"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewLogger() error = %v", err)
+	}
+
+	logger.Info("hello")
+	_ = logger.Sync()
+
+	entry := readLogEntry(t, output)
+	if entry["region"] != "us-east-1" {
+		t.Fatalf("region = %v, want us-east-1", entry["region"])
+	}
+}

--- a/regional-gateway/cmd/regional-gateway/main.go
+++ b/regional-gateway/cmd/regional-gateway/main.go
@@ -15,7 +15,6 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/observability"
 	"github.com/sandbox0-ai/sandbox0/regional-gateway/pkg/http"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
 
 func main() {
@@ -23,7 +22,10 @@ func main() {
 	cfg := config.LoadRegionalGatewayConfig()
 
 	// Initialize logger
-	logger, err := initLogger(cfg.LogLevel)
+	logger, err := observability.NewLogger(observability.LoggerConfig{
+		ServiceName: "regional-gateway",
+		Level:       cfg.LogLevel,
+	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to initialize logger: %v\n", err)
 		os.Exit(1)
@@ -95,47 +97,6 @@ func main() {
 	logger.Info("Edge gateway shutdown complete")
 }
 
-// initLogger initializes the zap logger
-func initLogger(level string) (*zap.Logger, error) {
-	var logLevel zapcore.Level
-	switch level {
-	case "debug":
-		logLevel = zapcore.DebugLevel
-	case "info":
-		logLevel = zapcore.InfoLevel
-	case "warn":
-		logLevel = zapcore.WarnLevel
-	case "error":
-		logLevel = zapcore.ErrorLevel
-	default:
-		logLevel = zapcore.InfoLevel
-	}
-
-	config := zap.Config{
-		Level:       zap.NewAtomicLevelAt(logLevel),
-		Development: false,
-		Encoding:    "json",
-		EncoderConfig: zapcore.EncoderConfig{
-			TimeKey:        "ts",
-			LevelKey:       "level",
-			NameKey:        "logger",
-			CallerKey:      "caller",
-			FunctionKey:    zapcore.OmitKey,
-			MessageKey:     "msg",
-			StacktraceKey:  "stacktrace",
-			LineEnding:     zapcore.DefaultLineEnding,
-			EncodeLevel:    zapcore.LowercaseLevelEncoder,
-			EncodeTime:     zapcore.ISO8601TimeEncoder,
-			EncodeDuration: zapcore.SecondsDurationEncoder,
-			EncodeCaller:   zapcore.ShortCallerEncoder,
-		},
-		OutputPaths:      []string{"stdout"},
-		ErrorOutputPaths: []string{"stderr"},
-	}
-
-	return config.Build()
-}
-
 // initDatabase initializes the database connection pool
 func initDatabase(ctx context.Context, cfg *config.RegionalGatewayConfig, logger *zap.Logger, obsProvider *observability.Provider) (*pgxpool.Pool, error) {
 	pool, err := dbpool.New(ctx, dbpool.Options{
@@ -161,12 +122,9 @@ func initDatabase(ctx context.Context, cfg *config.RegionalGatewayConfig, logger
 func runMigrations(ctx context.Context, pool *pgxpool.Pool, logger *zap.Logger) error {
 	logger.Info("Running database migrations")
 
-	// Create a migration logger that writes to zap
-	migrateLogger := &zapLogger{logger: logger}
-
 	if err := migrate.Up(ctx, pool, ".",
 		migrate.WithBaseFS(gatewaymigrations.FS),
-		migrate.WithLogger(migrateLogger),
+		migrate.WithLogger(observability.NewMigrateLogger(logger)),
 		migrate.WithSchema("shared_gateway"),
 	); err != nil {
 		return fmt.Errorf("migrate up: %w", err)
@@ -174,17 +132,4 @@ func runMigrations(ctx context.Context, pool *pgxpool.Pool, logger *zap.Logger) 
 
 	logger.Info("Database migrations completed successfully")
 	return nil
-}
-
-// zapLogger adapts zap.Logger to migrate.Logger interface
-type zapLogger struct {
-	logger *zap.Logger
-}
-
-func (z *zapLogger) Printf(format string, args ...any) {
-	z.logger.Info(fmt.Sprintf(format, args...))
-}
-
-func (z *zapLogger) Fatalf(format string, args ...any) {
-	z.logger.Fatal(fmt.Sprintf(format, args...))
 }

--- a/scheduler/cmd/scheduler/main.go
+++ b/scheduler/cmd/scheduler/main.go
@@ -25,7 +25,6 @@ import (
 	schedpubsub "github.com/sandbox0-ai/sandbox0/scheduler/pkg/pubsub"
 	"github.com/sandbox0-ai/sandbox0/scheduler/pkg/reconciler"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
 
 func main() {
@@ -33,7 +32,14 @@ func main() {
 	cfg := config.LoadSchedulerConfig()
 
 	// Initialize logger
-	logger := initLogger(cfg.LogLevel)
+	logger, err := observability.NewLogger(observability.LoggerConfig{
+		ServiceName: "scheduler",
+		Level:       cfg.LogLevel,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to initialize logger: %v\n", err)
+		os.Exit(1)
+	}
 	defer logger.Sync()
 
 	logger.Info("Starting Scheduler",
@@ -166,10 +172,9 @@ func main() {
 func runMigrations(ctx context.Context, pool *pgxpool.Pool, logger *zap.Logger) error {
 	logger.Info("Running database migrations")
 
-	migrateLogger := &zapLogger{logger: logger}
 	if err := migrate.Up(ctx, pool, ".",
 		migrate.WithBaseFS(templmigrations.FS),
-		migrate.WithLogger(migrateLogger),
+		migrate.WithLogger(observability.NewMigrateLogger(logger)),
 		migrate.WithSchema("scheduler"),
 	); err != nil {
 		return fmt.Errorf("migrate up: %w", err)
@@ -177,63 +182,6 @@ func runMigrations(ctx context.Context, pool *pgxpool.Pool, logger *zap.Logger) 
 
 	logger.Info("Database migrations completed successfully")
 	return nil
-}
-
-func initLogger(level string) *zap.Logger {
-	var zapLevel zapcore.Level
-	switch level {
-	case "debug":
-		zapLevel = zapcore.DebugLevel
-	case "info":
-		zapLevel = zapcore.InfoLevel
-	case "warn":
-		zapLevel = zapcore.WarnLevel
-	case "error":
-		zapLevel = zapcore.ErrorLevel
-	default:
-		zapLevel = zapcore.InfoLevel
-	}
-
-	config := zap.Config{
-		Level:       zap.NewAtomicLevelAt(zapLevel),
-		Development: false,
-		Encoding:    "json",
-		EncoderConfig: zapcore.EncoderConfig{
-			TimeKey:        "ts",
-			LevelKey:       "level",
-			NameKey:        "logger",
-			CallerKey:      "caller",
-			MessageKey:     "msg",
-			StacktraceKey:  "stacktrace",
-			LineEnding:     zapcore.DefaultLineEnding,
-			EncodeLevel:    zapcore.LowercaseLevelEncoder,
-			EncodeTime:     zapcore.ISO8601TimeEncoder,
-			EncodeDuration: zapcore.SecondsDurationEncoder,
-			EncodeCaller:   zapcore.ShortCallerEncoder,
-		},
-		OutputPaths:      []string{"stdout"},
-		ErrorOutputPaths: []string{"stderr"},
-	}
-
-	logger, err := config.Build()
-	if err != nil {
-		panic(fmt.Sprintf("failed to create logger: %v", err))
-	}
-
-	return logger
-}
-
-// zapLogger adapts zap.Logger to migrate.Logger interface.
-type zapLogger struct {
-	logger *zap.Logger
-}
-
-func (z *zapLogger) Printf(format string, args ...any) {
-	z.logger.Info(fmt.Sprintf(format, args...))
-}
-
-func (z *zapLogger) Fatalf(format string, args ...any) {
-	z.logger.Fatal(fmt.Sprintf(format, args...))
 }
 
 func initDatabase(ctx context.Context, cfg *config.SchedulerConfig, logger *zap.Logger, obsProvider *observability.Provider) (*pgxpool.Pool, error) {

--- a/ssh-gateway/cmd/ssh-gateway/main.go
+++ b/ssh-gateway/cmd/ssh-gateway/main.go
@@ -19,13 +19,15 @@ import (
 	httpobs "github.com/sandbox0-ai/sandbox0/pkg/observability/http"
 	sshserver "github.com/sandbox0-ai/sandbox0/ssh-gateway/pkg/server"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
 
 func main() {
 	cfg := config.LoadSSHGatewayConfig()
 
-	logger, err := initLogger(cfg.LogLevel)
+	logger, err := observability.NewLogger(observability.LoggerConfig{
+		ServiceName: "ssh-gateway",
+		Level:       cfg.LogLevel,
+	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to initialize logger: %v\n", err)
 		os.Exit(1)
@@ -114,46 +116,6 @@ func main() {
 	}
 }
 
-func initLogger(level string) (*zap.Logger, error) {
-	var logLevel zapcore.Level
-	switch level {
-	case "debug":
-		logLevel = zapcore.DebugLevel
-	case "info":
-		logLevel = zapcore.InfoLevel
-	case "warn":
-		logLevel = zapcore.WarnLevel
-	case "error":
-		logLevel = zapcore.ErrorLevel
-	default:
-		logLevel = zapcore.InfoLevel
-	}
-
-	config := zap.Config{
-		Level:       zap.NewAtomicLevelAt(logLevel),
-		Development: false,
-		Encoding:    "json",
-		EncoderConfig: zapcore.EncoderConfig{
-			TimeKey:        "ts",
-			LevelKey:       "level",
-			NameKey:        "logger",
-			CallerKey:      "caller",
-			FunctionKey:    zapcore.OmitKey,
-			MessageKey:     "msg",
-			StacktraceKey:  "stacktrace",
-			LineEnding:     zapcore.DefaultLineEnding,
-			EncodeLevel:    zapcore.LowercaseLevelEncoder,
-			EncodeTime:     zapcore.ISO8601TimeEncoder,
-			EncodeDuration: zapcore.SecondsDurationEncoder,
-			EncodeCaller:   zapcore.ShortCallerEncoder,
-		},
-		OutputPaths:      []string{"stdout"},
-		ErrorOutputPaths: []string{"stderr"},
-	}
-
-	return config.Build()
-}
-
 func initDatabase(ctx context.Context, cfg *config.SSHGatewayConfig, logger *zap.Logger, obsProvider *observability.Provider) (*pgxpool.Pool, error) {
 	pool, err := dbpool.New(ctx, dbpool.Options{
 		DatabaseURL:    cfg.DatabaseURL,
@@ -174,26 +136,13 @@ func initDatabase(ctx context.Context, cfg *config.SSHGatewayConfig, logger *zap
 
 func runMigrations(ctx context.Context, pool *pgxpool.Pool, logger *zap.Logger) error {
 	logger.Info("Running database migrations")
-	migrateLogger := &zapLogger{logger: logger}
 	if err := migrate.Up(ctx, pool, ".",
 		migrate.WithBaseFS(gatewaymigrations.FS),
-		migrate.WithLogger(migrateLogger),
+		migrate.WithLogger(observability.NewMigrateLogger(logger)),
 		migrate.WithSchema("shared_gateway"),
 	); err != nil {
 		return fmt.Errorf("migrate up: %w", err)
 	}
 	logger.Info("Database migrations completed successfully")
 	return nil
-}
-
-type zapLogger struct {
-	logger *zap.Logger
-}
-
-func (z *zapLogger) Printf(format string, args ...any) {
-	z.logger.Info(fmt.Sprintf(format, args...))
-}
-
-func (z *zapLogger) Fatalf(format string, args ...any) {
-	z.logger.Fatal(fmt.Sprintf(format, args...))
 }

--- a/storage-proxy/cmd/storage-proxy/main.go
+++ b/storage-proxy/cmd/storage-proxy/main.go
@@ -33,7 +33,6 @@ import (
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volumelock"
 	"github.com/sirupsen/logrus"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
 
 func main() {
@@ -57,13 +56,11 @@ func main() {
 	}
 	logrusLogger.SetLevel(level)
 
-	// Setup zap logger for new components
-	zapConfig := zap.NewProductionConfig()
-	zapConfig.Level = zap.NewAtomicLevelAt(zapcore.InfoLevel)
-	if cfg.LogLevel == "debug" {
-		zapConfig.Level = zap.NewAtomicLevelAt(zapcore.DebugLevel)
-	}
-	zapLogger, err := zapConfig.Build()
+	// Setup zap logger for new components.
+	zapLogger, err := observability.NewLogger(observability.LoggerConfig{
+		ServiceName: "storage-proxy",
+		Level:       cfg.LogLevel,
+	})
 	if err != nil {
 		logrusLogger.WithError(err).Fatal("Failed to create zap logger")
 	}
@@ -116,10 +113,10 @@ func main() {
 		if err := runMigrations(context.Background(), pool, cfg.DatabaseSchema, zapLogger); err != nil {
 			zapLogger.Fatal("Failed to run database migrations", zap.Error(err))
 		}
-		if err := metering.RunMigrations(context.Background(), pool, &zapLoggerAdapter{logger: zapLogger}); err != nil {
+		if err := metering.RunMigrations(context.Background(), pool, observability.NewMigrateLogger(zapLogger)); err != nil {
 			zapLogger.Fatal("Failed to run metering migrations", zap.Error(err))
 		}
-		if err := quota.RunMigrations(context.Background(), pool, &zapLoggerAdapter{logger: zapLogger}); err != nil {
+		if err := quota.RunMigrations(context.Background(), pool, observability.NewMigrateLogger(zapLogger)); err != nil {
 			zapLogger.Fatal("Failed to run quota migrations", zap.Error(err))
 		}
 
@@ -355,18 +352,6 @@ func initDatabase(ctx context.Context, databaseURL string, cfg *config.StoragePr
 	return pool, nil
 }
 
-type zapLoggerAdapter struct {
-	logger *zap.Logger
-}
-
-func (z *zapLoggerAdapter) Printf(format string, args ...any) {
-	z.logger.Info(fmt.Sprintf(format, args...))
-}
-
-func (z *zapLoggerAdapter) Fatalf(format string, args ...any) {
-	z.logger.Fatal(fmt.Sprintf(format, args...))
-}
-
 // runMigrations runs database migrations on startup
 func runMigrations(ctx context.Context, pool *pgxpool.Pool, schema string, logger *zap.Logger) error {
 	logger.Info("Running database migrations")
@@ -375,12 +360,9 @@ func runMigrations(ctx context.Context, pool *pgxpool.Pool, schema string, logge
 		schema = "storage_proxy"
 	}
 
-	// Create a migration logger that writes to zap
-	migrateLogger := &zapLogger{logger: logger}
-
 	if err := migrate.Up(ctx, pool, ".",
 		migrate.WithBaseFS(spmigrations.FS),
-		migrate.WithLogger(migrateLogger),
+		migrate.WithLogger(observability.NewMigrateLogger(logger)),
 		migrate.WithSchema(schema),
 	); err != nil {
 		return fmt.Errorf("migrate up: %w", err)
@@ -419,19 +401,6 @@ func runStorageMeteringFlushLoop(ctx context.Context, repo *metering.Repository,
 			}
 		}
 	}
-}
-
-// zapLogger adapts zap.Logger to migrate.Logger interface
-type zapLogger struct {
-	logger *zap.Logger
-}
-
-func (z *zapLogger) Printf(format string, args ...any) {
-	z.logger.Info(fmt.Sprintf(format, args...))
-}
-
-func (z *zapLogger) Fatalf(format string, args ...any) {
-	z.logger.Fatal(fmt.Sprintf(format, args...))
 }
 
 type pgxPoolClockAdapter struct {


### PR DESCRIPTION
## Summary
- add shared observability.NewLogger for the platform zap JSON format and service field
- add observability.NewMigrateLogger and remove duplicated migration logger adapters
- refactor platform service entrypoints to use the shared logger setup

## Tests
- go test ./pkg/observability
- go test ./global-gateway/cmd/global-gateway ./regional-gateway/cmd/regional-gateway ./cluster-gateway/cmd/cluster-gateway ./scheduler/cmd/scheduler ./ssh-gateway/cmd/ssh-gateway ./netd/cmd/netd ./netd/pkg/daemon ./manager/cmd/manager ./manager/cmd/procd ./storage-proxy/cmd/storage-proxy ./ctld/cmd/ctld