### PR TITLE
Expose team member profile fields in OpenAPI

### DIFF
--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -3509,6 +3509,16 @@ components:
         joined_at:
           type: string
           format: date-time
+        email:
+          type: string
+          format: email
+          description: User email address. Present in team member list responses.
+        name:
+          type: string
+          description: User display name. Present in team member list responses.
+        avatar_url:
+          type: string
+          description: User avatar URL. Present in team member list responses.
       required: [id, team_id, user_id, role, joined_at]
     CreateTeamRequest:
       type: object

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -2401,11 +2401,19 @@ type Team struct {
 
 // TeamMember defines model for TeamMember.
 type TeamMember struct {
-	Id       string    `json:"id"`
-	JoinedAt time.Time `json:"joined_at"`
-	Role     string    `json:"role"`
-	TeamId   string    `json:"team_id"`
-	UserId   string    `json:"user_id"`
+	// AvatarUrl User avatar URL. Present in team member list responses.
+	AvatarUrl *string `json:"avatar_url,omitempty"`
+
+	// Email User email address. Present in team member list responses.
+	Email    *openapi_types.Email `json:"email,omitempty"`
+	Id       string               `json:"id"`
+	JoinedAt time.Time            `json:"joined_at"`
+
+	// Name User display name. Present in team member list responses.
+	Name   *string `json:"name,omitempty"`
+	Role   string  `json:"role"`
+	TeamId string  `json:"team_id"`
+	UserId string  `json:"user_id"`
 }
 
 // TeamQuota defines model for TeamQuota.


### PR DESCRIPTION
## Summary
- Add optional `email`, `name`, and `avatar_url` fields to the public `TeamMember` schema.
- Regenerate sandbox0 apispec Go types.

## Testing
- `make apispec`
- `go test ./pkg/apispec/...`