### PR TITLE
Make sandbox pause checkpoint asynchronous

### DIFF
--- a/cluster-gateway/pkg/http/handlers_context.go
+++ b/cluster-gateway/pkg/http/handlers_context.go
@@ -289,10 +289,11 @@ func sandboxRuntimeMissing(sandbox *mgr.Sandbox) bool {
 	if sandbox == nil {
 		return false
 	}
-	if sandbox.Status == mgr.SandboxStatusPaused || strings.TrimSpace(sandbox.InternalAddr) == "" {
+	switch sandbox.Status {
+	case mgr.SandboxStatusPaused, mgr.SandboxStatusPausing, mgr.SandboxStatusResuming:
 		return true
 	}
-	return false
+	return strings.TrimSpace(sandbox.InternalAddr) == ""
 }
 
 func (s *Server) buildProcdRequestModifier(c *gin.Context) (proxy.RequestModifier, error) {

--- a/docs/sandbox/pause-resume/page.mdx
+++ b/docs/sandbox/pause-resume/page.mdx
@@ -34,6 +34,8 @@ On nodes using the containerd overlayfs snapshotter, `ctld` checkpoints only the
 
 Pause a sandbox to release compute while keeping its identity, configuration, services, mounted durable storage, and latest writable rootfs checkpoint available for a later resume.
 
+The pause endpoint accepts the lifecycle transition and returns once the sandbox is recorded as `pausing`. Rootfs checkpoint upload and runtime pod deletion continue in the background. Poll sandbox details until `status` is `paused` before treating the checkpoint as resume-ready.
+
 <Endpoint method="POST">
 /api/v1/sandboxes/{'{id}'}/pause
 </Endpoint>
@@ -113,6 +115,8 @@ console.log("Resume requested");`
 ## Inspect Pause State
 
 After requesting a pause or resume, fetch sandbox details to check the lifecycle status.
+
+During pause, `paused` remains `false` while `status` is `pausing`. It becomes `true` only after checkpoint upload has completed, the runtime pod has been released, and the sandbox is safe to resume from durable state.
 
 <Tabs
   tabs={[

--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -333,6 +333,8 @@ func main() {
 	sandboxService.SetDeletionWebhookEmitter(service.NewHTTPSandboxDeletionWebhookEmitter(obsProvider.HTTP.NewClient(httpobs.Config{Timeout: cfg.ProcdClientTimeout.Duration})))
 	sandboxLifecycleController := service.NewSandboxLifecycleController(k8sClient, podLister, sandboxService, logger)
 	podInformer.Informer().AddEventHandler(sandboxLifecycleController.ResourceEventHandler())
+	sandboxPauseController := service.NewSandboxPauseController(sandboxService, logger)
+	sandboxService.SetPauseEnqueuer(sandboxPauseController)
 	operator.SetSandboxProbeRunner(sandboxService)
 	staticAuth := make([]egressauthruntime.StaticAuthConfig, 0, len(cfg.EgressAuthStaticAuth))
 	for _, entry := range cfg.EgressAuthStaticAuth {
@@ -488,6 +490,12 @@ func main() {
 	go func() {
 		if err := sandboxLifecycleController.Run(ctx, 2); err != nil && err != context.Canceled {
 			logger.Error("Sandbox lifecycle controller failed", zap.Error(err))
+		}
+	}()
+
+	go func() {
+		if err := sandboxPauseController.Run(ctx, 2); err != nil && err != context.Canceled {
+			logger.Error("Sandbox pause controller failed", zap.Error(err))
 		}
 	}()
 

--- a/manager/pkg/service/sandbox_pause_controller.go
+++ b/manager/pkg/service/sandbox_pause_controller.go
@@ -1,0 +1,133 @@
+package service
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/workqueue"
+)
+
+const (
+	defaultSandboxPauseResyncPeriod = 30 * time.Second
+	defaultSandboxPauseScanLimit    = 500
+)
+
+// SandboxPauseController completes durable pausing transitions outside the API request path.
+type SandboxPauseController struct {
+	service        *SandboxService
+	logger         *zap.Logger
+	queue          workqueue.TypedRateLimitingInterface[string]
+	resyncInterval time.Duration
+	scanLimit      int
+}
+
+func NewSandboxPauseController(service *SandboxService, logger *zap.Logger) *SandboxPauseController {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	return &SandboxPauseController{
+		service:        service,
+		logger:         logger,
+		queue:          workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
+		resyncInterval: defaultSandboxPauseResyncPeriod,
+		scanLimit:      defaultSandboxPauseScanLimit,
+	}
+}
+
+func (c *SandboxPauseController) EnqueueSandboxPause(sandboxID string) {
+	if c == nil || c.queue == nil {
+		return
+	}
+	sandboxID = strings.TrimSpace(sandboxID)
+	if sandboxID == "" {
+		return
+	}
+	c.queue.Add(sandboxID)
+}
+
+func (c *SandboxPauseController) Run(ctx context.Context, workers int) error {
+	if c == nil {
+		return nil
+	}
+	if workers <= 0 {
+		workers = 1
+	}
+	if c.queue == nil {
+		c.queue = workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]())
+	}
+	if c.scanLimit <= 0 {
+		c.scanLimit = defaultSandboxPauseScanLimit
+	}
+	if c.resyncInterval <= 0 {
+		c.resyncInterval = defaultSandboxPauseResyncPeriod
+	}
+
+	defer runtime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	c.logger.Info("Starting sandbox pause controller", zap.Int("workers", workers))
+	c.enqueuePausingSandboxes(ctx)
+	for i := 0; i < workers; i++ {
+		go wait.UntilWithContext(ctx, c.runWorker, time.Second)
+	}
+
+	ticker := time.NewTicker(c.resyncInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			c.logger.Info("Sandbox pause controller stopped")
+			return ctx.Err()
+		case <-ticker.C:
+			c.enqueuePausingSandboxes(ctx)
+		}
+	}
+}
+
+func (c *SandboxPauseController) enqueuePausingSandboxes(ctx context.Context) {
+	if c == nil || c.service == nil || c.service.sandboxStore == nil {
+		return
+	}
+	records, err := c.service.sandboxStore.ListPausingSandboxes(ctx, c.scanLimit)
+	if err != nil {
+		c.logger.Warn("Failed to list pausing sandboxes", zap.Error(err))
+		return
+	}
+	for _, record := range records {
+		if record != nil {
+			c.EnqueueSandboxPause(record.ID)
+		}
+	}
+}
+
+func (c *SandboxPauseController) runWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
+	}
+}
+
+func (c *SandboxPauseController) processNextWorkItem(ctx context.Context) bool {
+	sandboxID, shutdown := c.queue.Get()
+	if shutdown {
+		return false
+	}
+	defer c.queue.Done(sandboxID)
+
+	if c.service == nil {
+		c.queue.Forget(sandboxID)
+		return true
+	}
+	if err := c.service.CompletePausingSandboxRuntime(ctx, sandboxID); err != nil {
+		c.logger.Warn("Sandbox pause completion failed, requeueing",
+			zap.String("sandboxID", sandboxID),
+			zap.Error(err),
+		)
+		c.queue.AddRateLimited(sandboxID)
+		return true
+	}
+	c.queue.Forget(sandboxID)
+	return true
+}

--- a/manager/pkg/service/sandbox_runtime_identity_test.go
+++ b/manager/pkg/service/sandbox_runtime_identity_test.go
@@ -72,6 +72,26 @@ func (s *memorySandboxStore) ListHardExpiredSandboxes(context.Context, time.Time
 	return nil, nil
 }
 
+func (s *memorySandboxStore) ListPausingSandboxes(_ context.Context, limit int) ([]*SandboxRecord, error) {
+	if s == nil || s.records == nil {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = len(s.records)
+	}
+	records := make([]*SandboxRecord, 0, len(s.records))
+	for _, record := range s.records {
+		if record == nil || record.Status != SandboxStatusPausing {
+			continue
+		}
+		records = append(records, cloneSandboxRecord(record))
+		if len(records) >= limit {
+			break
+		}
+	}
+	return records, nil
+}
+
 func (s *memorySandboxStore) MarkSandboxDeleted(_ context.Context, sandboxID string, deletedAt time.Time) error {
 	if s.records == nil {
 		s.records = make(map[string]*SandboxRecord)

--- a/manager/pkg/service/sandbox_service.go
+++ b/manager/pkg/service/sandbox_service.go
@@ -108,6 +108,7 @@ type SandboxService struct {
 	logger                 *zap.Logger
 	metrics                *obsmetrics.ManagerMetrics
 	autoScaler             AutoScalerInterface
+	pauseEnqueuer          SandboxPauseEnqueuer
 	credentialStore        egressauth.BindingStore
 	webhookStateVolumes    SandboxSystemVolumeClient
 	volumeMetadata         SandboxVolumeMetadataClient
@@ -119,6 +120,11 @@ type SandboxService struct {
 type TeamQuotaLimitStore interface {
 	GetLimit(ctx context.Context, teamID string, dimension quota.Dimension) (*quota.Limit, error)
 	CurrentUsage(ctx context.Context, teamID string, dimension quota.Dimension) (int64, error)
+}
+
+// SandboxPauseEnqueuer schedules durable pausing sandboxes for background completion.
+type SandboxPauseEnqueuer interface {
+	EnqueueSandboxPause(sandboxID string)
 }
 
 // AutoScalerInterface defines the interface for auto scaling.
@@ -232,6 +238,11 @@ func (s *SandboxService) SetCtldClient(client *CtldClient) {
 // SetAutoScaler injects the auto scaler for automatic pool scaling.
 func (s *SandboxService) SetAutoScaler(scaler AutoScalerInterface) {
 	s.autoScaler = scaler
+}
+
+// SetPauseEnqueuer injects the background worker used to complete accepted pause operations.
+func (s *SandboxService) SetPauseEnqueuer(enqueuer SandboxPauseEnqueuer) {
+	s.pauseEnqueuer = enqueuer
 }
 
 // SetCredentialStore injects the sandbox credential binding store.

--- a/manager/pkg/service/sandbox_service_lifecycle.go
+++ b/manager/pkg/service/sandbox_service_lifecycle.go
@@ -17,6 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 )
 
@@ -77,14 +78,92 @@ func (s *SandboxService) TerminateSandbox(ctx context.Context, sandboxID string)
 	return nil
 }
 
-// PauseSandboxRuntime checkpoints the writable rootfs, deletes the runtime pod,
-// and preserves the durable sandbox identity for a later resume.
+// PauseSandboxRuntime accepts a pause request and schedules checkpoint work.
 func (s *SandboxService) PauseSandboxRuntime(ctx context.Context, sandboxID string) error {
-	return s.pauseSandboxRuntime(ctx, sandboxID, true)
+	_, err := s.RequestPauseSandboxRuntime(ctx, sandboxID)
+	return err
+}
+
+// RequestPauseSandboxRuntime records a durable pausing state and returns without
+// waiting for rootfs checkpoint upload.
+func (s *SandboxService) RequestPauseSandboxRuntime(ctx context.Context, sandboxID string) (string, error) {
+	if s == nil {
+		return "", fmt.Errorf("sandbox service is nil")
+	}
+	if s.sandboxStore == nil {
+		if err := s.pauseSandboxRuntime(ctx, sandboxID, true); err != nil {
+			return "", err
+		}
+		return SandboxStatusPaused, nil
+	}
+
+	status := SandboxStatusPausing
+	err := s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, record *SandboxRecord) error {
+		switch record.Status {
+		case SandboxStatusDeleted:
+			return k8serrors.NewNotFound(schema.GroupResource{Resource: "sandbox"}, sandboxID)
+		case SandboxStatusPaused:
+			status = SandboxStatusPaused
+			return nil
+		case SandboxStatusPausing:
+			status = SandboxStatusPausing
+			return nil
+		case SandboxStatusStarting, SandboxStatusResuming:
+			return k8serrors.NewConflict(schema.GroupResource{Resource: "sandbox"}, sandboxID, fmt.Errorf("sandbox lifecycle operation %q is in progress", record.Status))
+		}
+
+		pod, err := s.getSandboxPod(lockCtx, sandboxID)
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				status = SandboxStatusPaused
+				return tx.MarkRuntimePaused(lockCtx, sandboxID, 0, s.clock.Now())
+			}
+			return fmt.Errorf("get pod: %w", err)
+		}
+		if !s.config.CtldEnabled || s.ctldClient == nil {
+			return ErrSandboxCheckpointRequiresCtld
+		}
+		generation := runtimeGenerationFromPod(pod)
+		status = SandboxStatusPausing
+		return tx.SaveRuntime(lockCtx, sandboxID, pod.Namespace, pod.Name, SandboxStatusPausing, generation, parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationExpiresAt), parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationHardExpiresAt))
+	})
+	if err != nil {
+		if errors.Is(err, ErrSandboxRecordNotFound) {
+			if fallbackErr := s.pauseSandboxRuntime(ctx, sandboxID, true); fallbackErr != nil {
+				return "", fallbackErr
+			}
+			return SandboxStatusPaused, nil
+		}
+		return "", err
+	}
+	if status == SandboxStatusPausing {
+		s.enqueueSandboxPause(sandboxID)
+	}
+	return status, nil
+}
+
+func (s *SandboxService) enqueueSandboxPause(sandboxID string) {
+	if s == nil || strings.TrimSpace(sandboxID) == "" {
+		return
+	}
+	if s.pauseEnqueuer != nil {
+		s.pauseEnqueuer.EnqueueSandboxPause(sandboxID)
+		return
+	}
+	go func() {
+		if err := s.CompletePausingSandboxRuntime(context.Background(), sandboxID); err != nil && s.logger != nil {
+			s.logger.Warn("Async sandbox pause completion failed",
+				zap.String("sandboxID", sandboxID),
+				zap.Error(err),
+			)
+		}
+	}()
 }
 
 func (s *SandboxService) pauseSandboxRuntime(ctx context.Context, sandboxID string, saveRootFS bool) error {
-	s.logger.Info("Pausing sandbox runtime", zap.String("sandboxID", sandboxID))
+	if s.logger != nil {
+		s.logger.Info("Pausing sandbox runtime", zap.String("sandboxID", sandboxID))
+	}
 	pause := func(ctx context.Context, tx SandboxStoreTx, record *SandboxRecord) error {
 		if record != nil {
 			switch record.Status {
@@ -143,6 +222,134 @@ func (s *SandboxService) pauseSandboxRuntime(ctx context.Context, sandboxID stri
 		return nil
 	}
 	return pause(ctx, nil, nil)
+}
+
+// CompletePausingSandboxRuntime finishes a previously accepted durable pause.
+func (s *SandboxService) CompletePausingSandboxRuntime(ctx context.Context, sandboxID string) error {
+	if s == nil {
+		return nil
+	}
+	if s.sandboxStore == nil {
+		return s.pauseSandboxRuntime(ctx, sandboxID, true)
+	}
+
+	var record *SandboxRecord
+	if err := s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(_ context.Context, _ SandboxStoreTx, locked *SandboxRecord) error {
+		if locked.Status != SandboxStatusPausing {
+			return nil
+		}
+		record = cloneSandboxRecordForLifecycle(locked)
+		return nil
+	}); err != nil {
+		if errors.Is(err, ErrSandboxRecordNotFound) {
+			return nil
+		}
+		return err
+	}
+	if record == nil {
+		return nil
+	}
+
+	pod, err := s.getSandboxPod(ctx, sandboxID)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return s.markPausingRuntimePaused(ctx, sandboxID, record.RuntimeGeneration)
+		}
+		return fmt.Errorf("get pod: %w", err)
+	}
+	generation := runtimeGenerationFromPod(pod)
+	if generation != record.RuntimeGeneration {
+		return fmt.Errorf("sandbox runtime generation changed during pause: record=%d pod=%d", record.RuntimeGeneration, generation)
+	}
+	if record.CurrentPodName != "" && pod.Name != record.CurrentPodName {
+		return k8serrors.NewConflict(schema.GroupResource{Resource: "pod"}, pod.Name, fmt.Errorf("pausing sandbox points at runtime pod %s", record.CurrentPodName))
+	}
+	if record.CurrentPodNamespace != "" && pod.Namespace != record.CurrentPodNamespace {
+		return k8serrors.NewConflict(schema.GroupResource{Resource: "pod"}, pod.Name, fmt.Errorf("pausing sandbox points at runtime namespace %s", record.CurrentPodNamespace))
+	}
+	if !s.config.CtldEnabled || s.ctldClient == nil {
+		return ErrSandboxCheckpointRequiresCtld
+	}
+	if err := s.saveSandboxRootFSCheckpoint(ctx, pod, record, nil); err != nil {
+		return err
+	}
+	stillPausing, err := s.sandboxStillPausing(ctx, sandboxID, generation)
+	if err != nil || !stillPausing {
+		return err
+	}
+	pod, err = s.ensureSandboxDeletionFinalizer(ctx, pod)
+	if err != nil {
+		return fmt.Errorf("ensure sandbox cleanup finalizer: %w", err)
+	}
+	pod, err = s.markRuntimeDeletionReason(ctx, pod, runtimeDeletionReasonPaused)
+	if err != nil {
+		return fmt.Errorf("mark runtime deletion reason: %w", err)
+	}
+	if err := s.k8sClient.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{}); err != nil && !k8serrors.IsNotFound(err) {
+		return fmt.Errorf("delete runtime pod: %w", err)
+	}
+	if err := s.waitForRuntimePodDeleted(ctx, pod.Namespace, pod.Name); err != nil {
+		return err
+	}
+	return s.markPausingRuntimePaused(ctx, sandboxID, generation)
+}
+
+func (s *SandboxService) sandboxStillPausing(ctx context.Context, sandboxID string, generation int64) (bool, error) {
+	if s == nil || s.sandboxStore == nil {
+		return true, nil
+	}
+	record, err := s.sandboxStore.GetSandbox(ctx, sandboxID)
+	if err != nil {
+		return false, err
+	}
+	return record != nil && record.Status == SandboxStatusPausing && record.RuntimeGeneration == generation, nil
+}
+
+func (s *SandboxService) markPausingRuntimePaused(ctx context.Context, sandboxID string, generation int64) error {
+	if s == nil || s.sandboxStore == nil {
+		return nil
+	}
+	return s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, record *SandboxRecord) error {
+		if record.Status != SandboxStatusPausing || record.RuntimeGeneration != generation {
+			return nil
+		}
+		return tx.MarkRuntimePaused(lockCtx, sandboxID, generation, s.clock.Now())
+	})
+}
+
+const (
+	defaultSandboxPausePodDeletionTimeout = 2 * time.Minute
+	defaultSandboxPausePodDeletionPoll    = 500 * time.Millisecond
+)
+
+func (s *SandboxService) waitForRuntimePodDeleted(ctx context.Context, namespace, name string) error {
+	if s == nil || s.k8sClient == nil || namespace == "" || name == "" {
+		return nil
+	}
+	return wait.PollUntilContextTimeout(ctx, defaultSandboxPausePodDeletionPoll, defaultSandboxPausePodDeletionTimeout, true, func(ctx context.Context) (bool, error) {
+		_, err := s.k8sClient.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+		if k8serrors.IsNotFound(err) {
+			return true, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		return false, nil
+	})
+}
+
+func cloneSandboxRecordForLifecycle(record *SandboxRecord) *SandboxRecord {
+	if record == nil {
+		return nil
+	}
+	clone := *record
+	if record.Mounts != nil {
+		clone.Mounts = append([]ClaimMount(nil), record.Mounts...)
+	}
+	if record.Config.Services != nil {
+		clone.Config.Services = append([]SandboxAppService(nil), record.Config.Services...)
+	}
+	return &clone
 }
 
 // PauseSandboxByID implements controller.SandboxRuntimePauser.
@@ -208,6 +415,9 @@ func (s *SandboxService) GetSandbox(ctx context.Context, sandboxID string) (*San
 		}
 		if record != nil && record.Status == SandboxStatusDeleted {
 			return nil, k8serrors.NewNotFound(schema.GroupResource{Resource: "sandbox"}, sandboxID)
+		}
+		if recordLifecycleStatusOverridesPod(record.Status) {
+			return s.recordToSandbox(record), nil
 		}
 	}
 	// Find the pod by sandbox ID
@@ -579,6 +789,15 @@ func (s *SandboxService) recordToSandbox(record *SandboxRecord) *Sandbox {
 		ClaimedAt:         record.ClaimedAt,
 		CreatedAt:         record.CreatedAt,
 		UpdatedAt:         record.UpdatedAt,
+	}
+}
+
+func recordLifecycleStatusOverridesPod(status string) bool {
+	switch status {
+	case SandboxStatusPausing, SandboxStatusResuming:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/manager/pkg/service/sandbox_service_list.go
+++ b/manager/pkg/service/sandbox_service_list.go
@@ -158,7 +158,7 @@ func (s *SandboxService) listSandboxesFromStore(ctx context.Context, req *ListSa
 	summaries := make([]*SandboxSummary, 0, len(records))
 	for _, record := range records {
 		sandbox := s.recordToSandbox(record)
-		if record.CurrentPodName != "" {
+		if record.CurrentPodName != "" && !recordLifecycleStatusOverridesPod(record.Status) {
 			if pod, err := s.getSandboxPod(ctx, record.ID); err == nil {
 				sandbox = s.podToSandbox(ctx, pod, record.ID)
 			}

--- a/manager/pkg/service/sandbox_service_pause.go
+++ b/manager/pkg/service/sandbox_service_pause.go
@@ -11,6 +11,7 @@ import (
 type PauseSandboxResponse struct {
 	SandboxID     string                `json:"sandbox_id"`
 	Paused        bool                  `json:"paused"`
+	Status        string                `json:"status,omitempty"`
 	ResourceUsage *SandboxResourceUsage `json:"resource_usage,omitempty"`
 	UpdatedMemory string                `json:"updated_memory,omitempty"`
 	UpdatedCPU    string                `json:"updated_cpu,omitempty"`
@@ -23,18 +24,20 @@ type ResumeSandboxResponse struct {
 	RestoredMemory string `json:"restored_memory,omitempty"`
 }
 
-// PauseSandbox checkpoints the writable rootfs and releases the runtime.
+// PauseSandbox accepts a checkpointed pause request and returns the lifecycle state.
 func (s *SandboxService) PauseSandbox(ctx context.Context, sandboxID string) (*PauseSandboxResponse, error) {
-	if err := s.PauseSandboxRuntime(ctx, sandboxID); err != nil {
+	status, err := s.RequestPauseSandboxRuntime(ctx, sandboxID)
+	if err != nil {
 		return nil, err
 	}
 	return &PauseSandboxResponse{
 		SandboxID: sandboxID,
-		Paused:    true,
+		Paused:    status == SandboxStatusPaused,
+		Status:    status,
 	}, nil
 }
 
-// PauseSandboxAndWait checkpoints the writable rootfs and releases the runtime.
+// PauseSandboxAndWait accepts a pause request. Checkpoint completion is asynchronous.
 func (s *SandboxService) PauseSandboxAndWait(ctx context.Context, sandboxID string) (*PauseSandboxResponse, error) {
 	return s.PauseSandbox(ctx, sandboxID)
 }

--- a/manager/pkg/service/sandbox_service_rootfs_test.go
+++ b/manager/pkg/service/sandbox_service_rootfs_test.go
@@ -30,7 +30,7 @@ import (
 	ktesting "k8s.io/client-go/testing"
 )
 
-func TestPauseSandboxRuntimeSavesRootFSBeforeDeletingPod(t *testing.T) {
+func TestPauseSandboxRuntimeQueuesRootFSSaveBeforeDeletingPod(t *testing.T) {
 	saveCalled := false
 	ctld := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "/api/v1/rootfs/save", r.URL.Path)
@@ -82,17 +82,28 @@ func TestPauseSandboxRuntimeSavesRootFSBeforeDeletingPod(t *testing.T) {
 			Status:            SandboxStatusRunning,
 		},
 	}}
+	enqueuer := &recordingPauseEnqueuer{}
 	svc := &SandboxService{
-		k8sClient:    k8sClient,
-		podLister:    newTestPodLister(t, pod),
-		sandboxStore: store,
-		ctldClient:   NewCtldClient(CtldClientConfig{Timeout: time.Second}),
-		config:       SandboxServiceConfig{CtldEnabled: true, CtldPort: ctldPort},
-		clock:        systemTime{},
-		logger:       zap.NewNop(),
+		k8sClient:     k8sClient,
+		podLister:     newTestPodLister(t, pod),
+		sandboxStore:  store,
+		ctldClient:    NewCtldClient(CtldClientConfig{Timeout: time.Second}),
+		config:        SandboxServiceConfig{CtldEnabled: true, CtldPort: ctldPort},
+		clock:         systemTime{},
+		logger:        zap.NewNop(),
+		pauseEnqueuer: enqueuer,
 	}
 
-	require.NoError(t, svc.PauseSandboxRuntime(context.Background(), "sandbox-1"))
+	resp, err := svc.PauseSandbox(context.Background(), "sandbox-1")
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.False(t, resp.Paused)
+	assert.Equal(t, SandboxStatusPausing, resp.Status)
+	assert.False(t, saveCalled, "pause request must not synchronously save rootfs")
+	assert.Equal(t, []string{"sandbox-1"}, enqueuer.calls)
+	assert.Equal(t, SandboxStatusPausing, store.records["sandbox-1"].Status)
+
+	require.NoError(t, svc.CompletePausingSandboxRuntime(context.Background(), "sandbox-1"))
 
 	state := store.rootFSStates["sandbox-1"]
 	require.NotNil(t, state)
@@ -103,6 +114,39 @@ func TestPauseSandboxRuntimeSavesRootFSBeforeDeletingPod(t *testing.T) {
 	assert.Equal(t, "sha256:diff", state.DiffDigest)
 	assert.Equal(t, "sandbox-rootfs/team-1/sandbox-1/3/sha256/diff.tar", state.DiffObjectKey)
 	assert.Equal(t, SandboxStatusPaused, store.records["sandbox-1"].Status)
+}
+
+func TestGetSandboxReportsPausingRecordWhileRuntimePodStillRunning(t *testing.T) {
+	pod := rootFSTestPod("pod-1", "sandbox-1", "team-1")
+	pod.Status.PodIP = "10.0.0.10"
+	store := &memorySandboxStore{records: map[string]*SandboxRecord{
+		"sandbox-1": {
+			ID:                  "sandbox-1",
+			TeamID:              "team-1",
+			UserID:              "user-1",
+			TemplateID:          "template-1",
+			CurrentPodName:      "pod-1",
+			CurrentPodNamespace: "default",
+			RuntimeGeneration:   3,
+			Status:              SandboxStatusPausing,
+		},
+	}}
+	svc := &SandboxService{
+		k8sClient:    fake.NewSimpleClientset(pod),
+		podLister:    newTestPodLister(t, pod),
+		sandboxStore: store,
+		config:       SandboxServiceConfig{ProcdPort: 49983},
+		clock:        systemTime{},
+		logger:       zap.NewNop(),
+	}
+
+	sandbox, err := svc.GetSandbox(context.Background(), "sandbox-1")
+	require.NoError(t, err)
+	require.NotNil(t, sandbox)
+	assert.Equal(t, SandboxStatusPausing, sandbox.Status)
+	assert.False(t, sandbox.Paused)
+	assert.Empty(t, sandbox.InternalAddr)
+	assert.Equal(t, "pod-1", sandbox.PodName)
 }
 
 func TestFinishRestoredSandboxRuntimeAppliesRootFSBeforeProcdInitialization(t *testing.T) {
@@ -385,6 +429,14 @@ func rootFSTestPod(name, sandboxID, teamID string) *corev1.Pod {
 			}},
 		},
 	}
+}
+
+type recordingPauseEnqueuer struct {
+	calls []string
+}
+
+func (r *recordingPauseEnqueuer) EnqueueSandboxPause(sandboxID string) {
+	r.calls = append(r.calls, sandboxID)
 }
 
 func metav1ObjectMeta(name, sandboxID, teamID string) metav1.ObjectMeta {

--- a/manager/pkg/service/sandbox_store.go
+++ b/manager/pkg/service/sandbox_store.go
@@ -74,6 +74,7 @@ type SandboxStore interface {
 	UpsertSandbox(ctx context.Context, record *SandboxRecord) error
 	GetSandbox(ctx context.Context, sandboxID string) (*SandboxRecord, error)
 	ListSandboxes(ctx context.Context, req *ListSandboxesRequest) ([]*SandboxRecord, error)
+	ListPausingSandboxes(ctx context.Context, limit int) ([]*SandboxRecord, error)
 	ListHardExpiredSandboxes(ctx context.Context, now time.Time, limit int) ([]*SandboxRecord, error)
 	MarkSandboxDeleted(ctx context.Context, sandboxID string, deletedAt time.Time) error
 	SaveRootFSState(ctx context.Context, state *SandboxRootFSState) error
@@ -195,6 +196,37 @@ func (s *PGSandboxStore) ListSandboxes(ctx context.Context, req *ListSandboxesRe
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterate sandboxes: %w", err)
+	}
+	return records, nil
+}
+
+func (s *PGSandboxStore) ListPausingSandboxes(ctx context.Context, limit int) ([]*SandboxRecord, error) {
+	if s == nil || s.pool == nil {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 500
+	}
+	rows, err := s.pool.Query(ctx, sandboxRecordSelectSQL()+`
+		WHERE deleted_at IS NULL
+			AND status = $1
+		ORDER BY updated_at ASC
+		LIMIT $2
+	`, SandboxStatusPausing, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list pausing sandboxes: %w", err)
+	}
+	defer rows.Close()
+	var records []*SandboxRecord
+	for rows.Next() {
+		record, err := scanSandboxRecordRows(rows)
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, record)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate pausing sandboxes: %w", err)
 	}
 	return records, nil
 }

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -4344,6 +4344,10 @@ components:
           type: string
         paused:
           type: boolean
+          description: True when checkpoint completion has finished and the sandbox is paused.
+        status:
+          $ref: "#/components/schemas/SandboxLifecycleStatus"
+          description: Current lifecycle status. Async pause requests usually return pausing.
         resource_usage:
           $ref: "#/components/schemas/SandboxResourceUsage"
         updated_memory:

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -1184,11 +1184,13 @@ type PTYSize struct {
 
 // PauseSandboxResponse defines model for PauseSandboxResponse.
 type PauseSandboxResponse struct {
-	Paused        bool                  `json:"paused"`
-	ResourceUsage *SandboxResourceUsage `json:"resource_usage,omitempty"`
-	SandboxId     string                `json:"sandbox_id"`
-	UpdatedCpu    *string               `json:"updated_cpu,omitempty"`
-	UpdatedMemory *string               `json:"updated_memory,omitempty"`
+	// Paused True when checkpoint completion has finished and the sandbox is paused.
+	Paused        bool                    `json:"paused"`
+	ResourceUsage *SandboxResourceUsage   `json:"resource_usage,omitempty"`
+	SandboxId     string                  `json:"sandbox_id"`
+	Status        *SandboxLifecycleStatus `json:"status,omitempty"`
+	UpdatedCpu    *string                 `json:"updated_cpu,omitempty"`
+	UpdatedMemory *string                 `json:"updated_memory,omitempty"`
 }
 
 // PodAffinity defines model for PodAffinity.

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -374,7 +374,9 @@ func registerApiModeSuite(envProvider func() *framework.ScenarioEnv, opts apiMod
 					Expect(err).NotTo(HaveOccurred())
 					Expect(status).To(Equal(http.StatusOK))
 					Expect(pausedResp).NotTo(BeNil())
-					Expect(pausedResp.Paused).To(BeTrue())
+					Expect(pausedResp.Paused).To(BeFalse())
+					Expect(pausedResp.Status).NotTo(BeNil())
+					Expect(*pausedResp.Status).To(Equal(apispec.SandboxLifecycleStatusPausing))
 					waitForSandboxLifecycleStatusEventually(env, session, sandboxID, apispec.SandboxLifecycleStatusPaused)
 
 					resumeResp, status, err := session.ResumeSandbox(env.TestCtx.Context, GinkgoT(), sandboxID)

--- a/tests/integration/internal/tests/manager/api_test.go
+++ b/tests/integration/internal/tests/manager/api_test.go
@@ -778,6 +778,25 @@ func (s *memorySandboxStoreForManagerIntegration) ListHardExpiredSandboxes(_ con
 	return records, nil
 }
 
+func (s *memorySandboxStoreForManagerIntegration) ListPausingSandboxes(_ context.Context, limit int) ([]*service.SandboxRecord, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if limit <= 0 {
+		limit = len(s.records)
+	}
+	records := make([]*service.SandboxRecord, 0, len(s.records))
+	for _, record := range s.records {
+		if record == nil || record.Status != service.SandboxStatusPausing {
+			continue
+		}
+		records = append(records, cloneSandboxRecordForManagerIntegration(record))
+		if len(records) >= limit {
+			break
+		}
+	}
+	return records, nil
+}
+
 func (s *memorySandboxStoreForManagerIntegration) MarkSandboxDeleted(_ context.Context, sandboxID string, deletedAt time.Time) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()


### PR DESCRIPTION
## Summary

- record sandbox pause requests as durable `pausing` state and return before rootfs checkpoint upload completes
- add a manager pause controller that scans/retries `pausing` sandboxes and completes checkpoint, pod deletion, and final `paused` state transition
- preserve resume safety by projecting `pausing/resuming` from durable state and treating those states as missing runtime in cluster-gateway
- update OpenAPI, generated API types, docs, and pause/resume tests for async pause semantics

Closes #444.

## Tests

- `go test ./manager/pkg/service`
- `go test ./manager/pkg/http ./cluster-gateway/pkg/http ./tests/integration/internal/tests/manager ./pkg/apispec`
- `go test ./manager/pkg/controller`
- `go test ./scheduler/pkg/http`

Local e2e was not run; PR CI owns e2e per sandbox0 remote test workflow.
