### PR TITLE
Add Managed Agents deployments docs

### DIFF
--- a/docs/managed-agents/compatibility/page.mdx
+++ b/docs/managed-agents/compatibility/page.mdx
@@ -13,6 +13,8 @@ Official reference: [Claude Managed Agents quickstart](https://platform.claude.c
 | Agents | Supported, including versioned agent definitions |
 | Environments | Supported for `type: cloud` with package and networking configuration |
 | Sessions | Supported with durable status, metadata, agent snapshot, resources, vault ids, usage, and stats |
+| Deployments | Supported for reusable manual runs and cron scheduled runs |
+| Deployment runs | Supported for manual and scheduled session creation audit records |
 | Events | Supported for list, send, and event streaming |
 | Files | Supported for upload, metadata, download, delete, and file-backed message content |
 | Vaults and credentials | Supported for LLM credentials, MCP credentials, and Sandbox0 HTTP header credential projection |
@@ -35,6 +37,8 @@ Official reference: [Claude Managed Agents quickstart](https://platform.claude.c
 | Codex harness | Requires an OpenAI-compatible endpoint. |
 | OpenAI Agents harness | Requires an OpenAI Responses-compatible endpoint and uses Sandbox0 as a tool target. |
 | Retry state | Automatic retries are exposed as `session.status_rescheduled` plus `retry_status.type = "retrying"` errors when the selected harness provides a retry signal. |
+| Scheduled deployments | Sandbox0 accepts five-field POSIX cron expressions with IANA timezones. It does not backfill missed runs after unpause or downtime. |
+| Deployment failure handling | Scheduled run creation failures are stored on deployment runs. Non-rate-limit failures pause the deployment. |
 | External AI gateway | Optional. Use one when provider API shape, provider credentials, logging, caching, or rate limits should be managed outside Sandbox0. |
 | Anthropic pre-built skills | Not supported. Use Sandbox0 custom skills. |
 | Multi-agent threads | Not implemented in the current backend surface. |

--- a/docs/managed-agents/deployments/page.mdx
+++ b/docs/managed-agents/deployments/page.mdx
@@ -1,0 +1,137 @@
+# Deployments
+
+A deployment is a reusable Managed Agents run definition. It stores the agent snapshot, environment, initial user input, resources, vault ids, and optional schedule used to create sessions later.
+
+Official reference: [Claude Managed Agents scheduled deployments](https://platform.claude.com/docs/en/managed-agents/scheduled-deployments).
+
+## Create A Scheduled Deployment
+
+Use a scheduled deployment for recurring work such as daily digests, nightly repository checks, weekly compliance scans, or periodic sync jobs.
+
+```typescript
+const deployment = await client.beta.deployments.create({
+    agent: agent.id,
+    environment_id: environment.id,
+    name: "daily-digest",
+    description: "Create the weekday engineering digest.",
+    initial_events: [{
+        type: "user.message",
+        content: [{
+            type: "text",
+            text: "Summarize yesterday's changes and open risks.",
+        }],
+    }],
+    resources: [{
+        type: "github_repository",
+        url: "https://github.com/acme/app",
+        checkout: { type: "branch", name: "main" },
+    }],
+    schedule: {
+        type: "cron",
+        expression: "0 9 * * 1-5",
+        timezone: "UTC",
+    },
+    vault_ids: [llmVault.id],
+    metadata: {
+        workflow: "daily-digest",
+    },
+});
+```
+
+When the cron fires, Sandbox0 creates a new session from the stored deployment definition and sends the configured initial events. The created session then follows the normal session lifecycle and event stream.
+
+`initial_events` is required. Use `user.message` for normal recurring tasks; Sandbox0 also accepts compatible initial event types such as `system.message` and `user.define_outcome` when your SDK version exposes them.
+
+## Schedule Support
+
+Sandbox0 supports cron schedules with minute-level precision.
+
+| Field | Meaning |
+|-------|---------|
+| `type` | Must be `cron` |
+| `expression` | Five-field POSIX cron expression |
+| `timezone` | IANA timezone such as `UTC` or `America/Los_Angeles` |
+| `upcoming_runs_at` | Next scheduled run times returned by read APIs |
+| `last_run_at` | Last time this deployment started a scheduled run |
+
+Cron seconds, year fields, shortcuts such as `@daily`, and extended Quartz syntax such as `?`, `L`, `W`, and `#` are not accepted.
+
+Pausing a deployment stops future scheduled runs but does not stop sessions already created by the deployment. Unpausing resumes future schedule evaluation; missed triggers are not backfilled.
+
+## Run Manually
+
+Manual runs use the same deployment definition but do not require a schedule.
+
+```typescript
+const run = await client.beta.deployments.run(deployment.id);
+
+if (run.session_id) {
+    console.log(`started session ${run.session_id}`);
+}
+```
+
+Use manual runs for ad-hoc retries, operator-triggered workflows, or deployments that should be callable by a product action instead of a cron trigger.
+
+## Deployment Runs
+
+Deployment runs are the audit records for session creation attempts.
+
+```typescript
+for await (const run of client.beta.deploymentRuns.list({
+    deployment_id: deployment.id,
+    trigger_type: "schedule",
+    limit: 20,
+})) {
+    console.log(run.id, run.session_id, run.error);
+}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `deployment_id` | Deployment that created the run |
+| `trigger_context.type` | `manual` or `schedule` |
+| `trigger_context.scheduled_at` | Scheduled fire time for cron-triggered runs |
+| `session_id` | Session id when session creation succeeded |
+| `error` | Error object when session creation failed |
+
+A deployment run records whether a session was started. It does not replace the session event stream. After a run has a `session_id`, use session APIs to read events, stream output, interrupt work, or delete the session.
+
+## Lifecycle
+
+| Action | SDK method | Behavior |
+|--------|------------|----------|
+| Create | `client.beta.deployments.create` | Stores the deployment and starts schedule evaluation if a schedule is present |
+| List | `client.beta.deployments.list` | Lists active or paused deployments, with optional archived inclusion |
+| Retrieve | `client.beta.deployments.retrieve` | Reads one deployment |
+| Update | `client.beta.deployments.update` | Replaces mutable fields such as name, description, metadata, schedule, resources, and vault ids |
+| Pause | `client.beta.deployments.pause` | Stops future scheduled runs |
+| Unpause | `client.beta.deployments.unpause` | Resumes future scheduled runs |
+| Archive | `client.beta.deployments.archive` | Makes the deployment unavailable for future runs |
+| Run | `client.beta.deployments.run` | Creates one manual deployment run |
+
+Scheduled session creation failures are recorded on the deployment run. Non-rate-limit failures pause the deployment so operators can inspect and fix the definition before it keeps firing.
+
+## Resources And Secrets
+
+Deployments can include the same resources used by sessions. File resources and GitHub repository resources are materialized into each created session workspace.
+
+Repository authorization tokens are accepted when creating or updating a deployment, but they are never returned by read APIs. Sandbox0 stores resource secret material encrypted at rest and resolves it only when creating a session from the deployment.
+
+## Sandbox0 Notes
+
+- A deployment snapshots the agent version used at creation time, just like a session.
+- Sessions created by deployments use the same Sandbox0 persistent workspace, network policy, credential projection, and harness selection as sessions created directly.
+- Attach exactly one LLM vault for normal deployments.
+- Prefer deployment runs for operational audit and session events for agent output.
+
+## Next Steps
+
+<CardGroup>
+  <Card title="Events" href="/docs/managed-agents/events" cta="Continue">
+    Read session output and status events from sessions created by deployments.
+  </Card>
+
+  <Card title="Vaults" href="/docs/managed-agents/vaults" cta="Continue">
+    Store model and service credentials used by recurring deployments.
+  </Card>
+</CardGroup>

--- a/docs/managed-agents/page.mdx
+++ b/docs/managed-agents/page.mdx
@@ -17,6 +17,8 @@ Managed Agents sit above raw sandboxes. A sandbox gives an agent processes, file
 | Agent | Versioned instructions, model, tools, MCP servers, and skills |
 | Environment | Runtime package and networking configuration |
 | Session | Durable unit of work that binds an agent snapshot, environment, resources, and vaults |
+| Deployment | Reusable session creation definition with optional cron schedule |
+| Deployment run | Audit record for one manual or scheduled session creation attempt |
 | Events | Append-only interaction log for user input, agent output, tools, status, and errors |
 | Vault | Credential container attached to a session |
 | Resource | File or repository materialized into the session workspace |
@@ -62,7 +64,7 @@ Session truth lives outside the sandbox. The sandbox is an execution attachment 
 2. Create an `environment` with package and network settings.
 3. Create an LLM vault with `sandbox0.managed_agents.role = llm` and the target agent harness.
 4. Create a session that references the agent, environment, and vault ids.
-5. Send `user.message` events.
+5. Send `user.message` events, or create a deployment that stores initial events for manual or scheduled runs.
 6. Sandbox0 starts the selected agent harness. Agent-in-sandbox harnesses claim or resume a sandbox immediately; sandbox-as-tool harnesses claim a sandbox when a tool needs one.
 7. The harness emits callbacks. The gateway appends events to the durable session log.
 8. The client lists or streams events until the session becomes idle, requires action, or terminates.
@@ -87,6 +89,7 @@ The official Claude Managed Agents documentation is still the canonical SDK refe
 - [Agent setup](https://platform.claude.com/docs/en/managed-agents/agent-setup)
 - [Environments](https://platform.claude.com/docs/en/managed-agents/environments)
 - [Sessions](https://platform.claude.com/docs/en/managed-agents/sessions)
+- [Scheduled deployments](https://platform.claude.com/docs/en/managed-agents/scheduled-deployments)
 - [Vaults](https://platform.claude.com/docs/en/managed-agents/vaults)
 
 ## Next Steps
@@ -98,5 +101,9 @@ The official Claude Managed Agents documentation is still the canonical SDK refe
 
   <Card title="Agents" href="/docs/managed-agents/agents" cta="Continue">
     Define versioned agents with prompts, tools, MCP servers, and skills.
+  </Card>
+
+  <Card title="Deployments" href="/docs/managed-agents/deployments" cta="Continue">
+    Run managed agents manually or on a cron schedule from a reusable definition.
   </Card>
 </CardGroup>

--- a/docs/managed-agents/sdk/page.mdx
+++ b/docs/managed-agents/sdk/page.mdx
@@ -80,6 +80,37 @@ for await (const event of client.beta.sessions.events.list(session.id, { limit: 
 }
 ```
 
+## Scheduled Deployment
+
+Use deployments when the same agent workflow should run manually or on a cron schedule.
+
+```typescript
+const deployment = await client.beta.deployments.create({
+    agent: agent.id,
+    environment_id: environment.id,
+    name: `Daily digest ${suffix}`,
+    initial_events: [{
+        type: "user.message",
+        content: [{ type: "text", text: "Create the daily digest." }],
+    }],
+    schedule: {
+        type: "cron",
+        expression: "0 9 * * 1-5",
+        timezone: "UTC",
+    },
+    vault_ids: [llmVault.id],
+});
+
+const run = await client.beta.deployments.run(deployment.id);
+
+for await (const deploymentRun of client.beta.deploymentRuns.list({
+    deployment_id: deployment.id,
+    limit: 20,
+})) {
+    console.log(deploymentRun.id, deploymentRun.session_id);
+}
+```
+
 ## Required Variables
 
 | Variable | Purpose |
@@ -127,5 +158,9 @@ curl -fsS "https://agents.sandbox0.ai/v1/sessions" \
 
   <Card title="Environments" href="/docs/managed-agents/environments" cta="Continue">
     Prepare reusable environments with packages and network policy.
+  </Card>
+
+  <Card title="Deployments" href="/docs/managed-agents/deployments" cta="Continue">
+    Create recurring or manually triggered managed agent workflows.
   </Card>
 </CardGroup>

--- a/docs/managed-agents/sessions/page.mdx
+++ b/docs/managed-agents/sessions/page.mdx
@@ -4,6 +4,8 @@ A session is the durable unit of agent work. It binds one agent snapshot, one en
 
 Official reference: [Claude Managed Agents sessions](https://platform.claude.com/docs/en/managed-agents/sessions).
 
+Sessions can be created directly by application code or indirectly by a deployment run. After a deployment starts a session, read and control that session with the same session and event APIs used for direct sessions.
+
 ## Create A Session
 
 ```typescript
@@ -89,6 +91,10 @@ Sandbox0 keeps session state and event history outside the sandbox. The sandbox 
 <CardGroup>
   <Card title="Events" href="/docs/managed-agents/events" cta="Continue">
     Append user input, stream agent output, and interpret retry lifecycle events.
+  </Card>
+
+  <Card title="Deployments" href="/docs/managed-agents/deployments" cta="Continue">
+    Reuse a session definition for manual or scheduled runs.
   </Card>
 
   <Card title="Vaults" href="/docs/managed-agents/vaults" cta="Continue">

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -94,6 +94,10 @@
           "title": "Sessions"
         },
         {
+          "slug": "deployments",
+          "title": "Deployments"
+        },
+        {
           "slug": "events",
           "title": "Events"
         },


### PR DESCRIPTION
## Summary
- add a Managed Agents Deployments docs page covering scheduled deployments, manual runs, deployment runs, lifecycle controls, resources, and Sandbox0 behavior
- add Deployments to the Managed Agents docs navigation
- cross-link deployments from the overview, SDK usage, sessions, and compatibility pages

## Notes
- docs follow-up for sandbox0-ai/managed-agents#143
- aligned with the official Claude Managed Agents scheduled deployments reference: https://platform.claude.com/docs/en/managed-agents/scheduled-deployments

## Checks
- git diff --check
- jq empty docs/manifest.json