### PR TITLE
Add team owner transfer and member search

### DIFF
--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -903,6 +903,46 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorEnvelope"
+  /teams/{id}/owner:
+    put:
+      tags: [teams]
+      summary: Transfer team ownership
+      description: Transfers ownership to an existing team member and promotes the new owner to admin if needed.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/TeamID"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TransferTeamOwnerRequest"
+      responses:
+        "200":
+          description: Team owner transferred
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessTeamResponse"
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "403":
+          description: Only the current owner can transfer ownership
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "404":
+          description: Team or member not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
   /teams/{id}/members:
     get:
       tags: [teams]
@@ -911,6 +951,12 @@ paths:
         - bearerAuth: []
       parameters:
         - $ref: "#/components/parameters/TeamID"
+        - name: query
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Search by member email, display name, or user ID.
       responses:
         "200":
           description: Team members
@@ -984,6 +1030,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SuccessMessageResponse"
+        "400":
+          description: Invalid member role change
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
         "403":
           description: Forbidden
           content:
@@ -1011,6 +1063,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SuccessMessageResponse"
+        "400":
+          description: Invalid member removal
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
         "403":
           description: Forbidden
           content:
@@ -3538,6 +3596,12 @@ components:
           type: string
         slug:
           type: string
+    TransferTeamOwnerRequest:
+      type: object
+      properties:
+        user_id:
+          type: string
+      required: [user_id]
     AddTeamMemberRequest:
       type: object
       properties:

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -2482,6 +2482,11 @@ type TrafficRuleAction string
 // TrafficRuleAppProtocol defines model for TrafficRuleAppProtocol.
 type TrafficRuleAppProtocol string
 
+// TransferTeamOwnerRequest defines model for TransferTeamOwnerRequest.
+type TransferTeamOwnerRequest struct {
+	UserId string `json:"user_id"`
+}
+
 // UpdateRegionRequest defines model for UpdateRegionRequest.
 type UpdateRegionRequest struct {
 	DisplayName        *string `json:"display_name,omitempty"`
@@ -2733,6 +2738,12 @@ type GetAuthOidcProviderLoginParams struct {
 	WebLogin *bool `form:"web_login,omitempty" json:"web_login,omitempty"`
 }
 
+// GetTeamsIdMembersParams defines parameters for GetTeamsIdMembers.
+type GetTeamsIdMembersParams struct {
+	// Query Search by member email, display name, or user ID.
+	Query *string `form:"query,omitempty" json:"query,omitempty"`
+}
+
 // PostApiKeysJSONRequestBody defines body for PostApiKeys for application/json ContentType.
 type PostApiKeysJSONRequestBody = CreateAPIKeyRequest
 
@@ -2834,6 +2845,9 @@ type PostTeamsIdMembersJSONRequestBody = AddTeamMemberRequest
 
 // PutTeamsIdMembersUserIdJSONRequestBody defines body for PutTeamsIdMembersUserId for application/json ContentType.
 type PutTeamsIdMembersUserIdJSONRequestBody = UpdateTeamMemberRequest
+
+// PutTeamsIdOwnerJSONRequestBody defines body for PutTeamsIdOwner for application/json ContentType.
+type PutTeamsIdOwnerJSONRequestBody = TransferTeamOwnerRequest
 
 // PutUsersMeJSONRequestBody defines body for PutUsersMe for application/json ContentType.
 type PutUsersMeJSONRequestBody = UpdateUserRequest

--- a/pkg/gateway/http/handlers/team.go
+++ b/pkg/gateway/http/handlers/team.go
@@ -21,7 +21,9 @@ type teamRepository interface {
 	GetTeamByID(ctx context.Context, id string) (*identity.Team, error)
 	UpdateTeam(ctx context.Context, team *identity.Team) error
 	DeleteTeam(ctx context.Context, id string) error
+	TransferTeamOwner(ctx context.Context, teamID, userID string) (*identity.Team, error)
 	GetTeamMembers(ctx context.Context, teamID string) ([]*identity.TeamMemberWithUser, error)
+	SearchTeamMembers(ctx context.Context, teamID, query string) ([]*identity.TeamMemberWithUser, error)
 	GetUserByEmail(ctx context.Context, email string) (*identity.User, error)
 	AddTeamMember(ctx context.Context, member *identity.TeamMember) error
 	UpdateTeamMemberRole(ctx context.Context, teamID, userID, role string) error
@@ -317,6 +319,65 @@ func (h *TeamHandler) DeleteTeam(c *gin.Context) {
 	spec.JSONSuccess(c, http.StatusOK, gin.H{"message": "team deleted"})
 }
 
+// TransferTeamOwnerRequest is the request body for transferring team ownership.
+type TransferTeamOwnerRequest struct {
+	UserID string `json:"user_id" binding:"required"`
+}
+
+// TransferTeamOwner transfers team ownership to an existing team member.
+func (h *TeamHandler) TransferTeamOwner(c *gin.Context) {
+	authCtx := middleware.GetAuthContext(c)
+	if authCtx == nil || authCtx.UserID == "" {
+		spec.JSONError(c, http.StatusUnauthorized, spec.CodeUnauthorized, "not authenticated")
+		return
+	}
+
+	teamID := c.Param("id")
+
+	var req TransferTeamOwnerRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "invalid request body")
+		return
+	}
+	req.UserID = strings.TrimSpace(req.UserID)
+	if req.UserID == "" {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "user_id is required")
+		return
+	}
+
+	team, err := h.repo.GetTeamByID(c.Request.Context(), teamID)
+	if err != nil {
+		if errors.Is(err, identity.ErrTeamNotFound) {
+			spec.JSONError(c, http.StatusNotFound, spec.CodeNotFound, "team not found")
+			return
+		}
+		h.logger.Error("Failed to get team", zap.Error(err))
+		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to get team")
+		return
+	}
+	if !isTeamOwner(team, authCtx.UserID) {
+		spec.JSONError(c, http.StatusForbidden, spec.CodeForbidden, "only team owner can transfer ownership")
+		return
+	}
+
+	team, err = h.repo.TransferTeamOwner(c.Request.Context(), teamID, req.UserID)
+	if err != nil {
+		if errors.Is(err, identity.ErrMemberNotFound) {
+			spec.JSONError(c, http.StatusNotFound, spec.CodeNotFound, "member not found")
+			return
+		}
+		if errors.Is(err, identity.ErrTeamNotFound) {
+			spec.JSONError(c, http.StatusNotFound, spec.CodeNotFound, "team not found")
+			return
+		}
+		h.logger.Error("Failed to transfer team owner", zap.Error(err))
+		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to transfer team owner")
+		return
+	}
+
+	spec.JSONSuccess(c, http.StatusOK, team)
+}
+
 // ListTeamMembers returns all members of a team
 func (h *TeamHandler) ListTeamMembers(c *gin.Context) {
 	authCtx := middleware.GetAuthContext(c)
@@ -339,7 +400,13 @@ func (h *TeamHandler) ListTeamMembers(c *gin.Context) {
 		return
 	}
 
-	members, err := h.repo.GetTeamMembers(c.Request.Context(), teamID)
+	query := strings.TrimSpace(c.Query("query"))
+	var members []*identity.TeamMemberWithUser
+	if query == "" {
+		members, err = h.repo.GetTeamMembers(c.Request.Context(), teamID)
+	} else {
+		members, err = h.repo.SearchTeamMembers(c.Request.Context(), teamID, query)
+	}
 	if err != nil {
 		h.logger.Error("Failed to get members", zap.Error(err))
 		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to get members")
@@ -459,6 +526,43 @@ func (h *TeamHandler) UpdateTeamMember(c *gin.Context) {
 		return
 	}
 
+	team, err := h.repo.GetTeamByID(c.Request.Context(), teamID)
+	if err != nil {
+		if errors.Is(err, identity.ErrTeamNotFound) {
+			spec.JSONError(c, http.StatusNotFound, spec.CodeNotFound, "team not found")
+			return
+		}
+		h.logger.Error("Failed to get team", zap.Error(err))
+		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to get team")
+		return
+	}
+	targetMember, err := h.repo.GetTeamMember(c.Request.Context(), teamID, userID)
+	if err != nil {
+		if errors.Is(err, identity.ErrMemberNotFound) {
+			spec.JSONError(c, http.StatusNotFound, spec.CodeNotFound, "member not found")
+			return
+		}
+		h.logger.Error("Failed to get target member", zap.Error(err))
+		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to get member")
+		return
+	}
+	if isTeamOwner(team, userID) && req.Role != "admin" {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "team owner must remain an admin")
+		return
+	}
+	if targetMember.Role == "admin" && req.Role != "admin" {
+		members, err := h.repo.GetTeamMembers(c.Request.Context(), teamID)
+		if err != nil {
+			h.logger.Error("Failed to get members", zap.Error(err))
+			spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to check team admins")
+			return
+		}
+		if countTeamAdmins(members) <= 1 {
+			spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "cannot remove the last admin")
+			return
+		}
+	}
+
 	if err := h.repo.UpdateTeamMemberRole(c.Request.Context(), teamID, userID, req.Role); err != nil {
 		if errors.Is(err, identity.ErrMemberNotFound) {
 			spec.JSONError(c, http.StatusNotFound, spec.CodeNotFound, "member not found")
@@ -575,23 +679,40 @@ func (h *TeamHandler) RemoveTeamMember(c *gin.Context) {
 		return
 	}
 
-	// Check if this is the last admin
-	if userID == authCtx.UserID && member.Role == "admin" {
+	team, err := h.repo.GetTeamByID(c.Request.Context(), teamID)
+	if err != nil {
+		if errors.Is(err, identity.ErrTeamNotFound) {
+			spec.JSONError(c, http.StatusNotFound, spec.CodeNotFound, "team not found")
+			return
+		}
+		h.logger.Error("Failed to get team", zap.Error(err))
+		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to get team")
+		return
+	}
+	if isTeamOwner(team, userID) {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "cannot remove team owner")
+		return
+	}
+
+	targetMember, err := h.repo.GetTeamMember(c.Request.Context(), teamID, userID)
+	if err != nil {
+		if errors.Is(err, identity.ErrMemberNotFound) {
+			spec.JSONError(c, http.StatusNotFound, spec.CodeNotFound, "member not found")
+			return
+		}
+		h.logger.Error("Failed to get target member", zap.Error(err))
+		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to get member")
+		return
+	}
+
+	if targetMember.Role == "admin" {
 		members, err := h.repo.GetTeamMembers(c.Request.Context(), teamID)
 		if err != nil {
 			h.logger.Error("Failed to get members", zap.Error(err))
 			spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to check team admins")
 			return
 		}
-
-		adminCount := 0
-		for _, m := range members {
-			if m.Role == "admin" {
-				adminCount++
-			}
-		}
-
-		if adminCount <= 1 {
+		if countTeamAdmins(members) <= 1 {
 			spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "cannot remove the last admin")
 			return
 		}
@@ -608,4 +729,18 @@ func (h *TeamHandler) RemoveTeamMember(c *gin.Context) {
 	}
 
 	spec.JSONSuccess(c, http.StatusOK, gin.H{"message": "member removed"})
+}
+
+func isTeamOwner(team *identity.Team, userID string) bool {
+	return team != nil && team.OwnerID != nil && *team.OwnerID == strings.TrimSpace(userID)
+}
+
+func countTeamAdmins(members []*identity.TeamMemberWithUser) int {
+	count := 0
+	for _, member := range members {
+		if member != nil && member.Role == "admin" {
+			count++
+		}
+	}
+	return count
 }

--- a/pkg/gateway/http/handlers/team_test.go
+++ b/pkg/gateway/http/handlers/team_test.go
@@ -20,6 +20,12 @@ import (
 type stubTeamRepository struct {
 	createdTeam     *identity.Team
 	addedTeamMember *identity.TeamMember
+	teams           map[string]*identity.Team
+	members         map[string]*identity.TeamMember
+	memberLists     map[string][]*identity.TeamMemberWithUser
+	searchMembers   []*identity.TeamMemberWithUser
+	searchTeamID    string
+	searchQuery     string
 }
 
 func (s *stubTeamRepository) GetTeamsByUserID(context.Context, string) ([]*identity.Team, error) {
@@ -34,11 +40,23 @@ func (s *stubTeamRepository) CreateTeam(_ context.Context, team *identity.Team) 
 	return nil
 }
 
-func (s *stubTeamRepository) GetTeamMember(context.Context, string, string) (*identity.TeamMember, error) {
+func (s *stubTeamRepository) GetTeamMember(_ context.Context, teamID, userID string) (*identity.TeamMember, error) {
+	if s.members != nil {
+		if member, ok := s.members[teamMemberKey(teamID, userID)]; ok {
+			copyMember := *member
+			return &copyMember, nil
+		}
+	}
 	return nil, identity.ErrMemberNotFound
 }
 
-func (s *stubTeamRepository) GetTeamByID(context.Context, string) (*identity.Team, error) {
+func (s *stubTeamRepository) GetTeamByID(_ context.Context, id string) (*identity.Team, error) {
+	if s.teams != nil {
+		if team, ok := s.teams[id]; ok {
+			copyTeam := *team
+			return &copyTeam, nil
+		}
+	}
 	return nil, identity.ErrTeamNotFound
 }
 
@@ -50,8 +68,46 @@ func (s *stubTeamRepository) DeleteTeam(context.Context, string) error {
 	return nil
 }
 
-func (s *stubTeamRepository) GetTeamMembers(context.Context, string) ([]*identity.TeamMemberWithUser, error) {
-	return nil, nil
+func (s *stubTeamRepository) TransferTeamOwner(_ context.Context, teamID, userID string) (*identity.Team, error) {
+	team, ok := s.teams[teamID]
+	if !ok {
+		return nil, identity.ErrTeamNotFound
+	}
+	member, ok := s.members[teamMemberKey(teamID, userID)]
+	if !ok {
+		return nil, identity.ErrMemberNotFound
+	}
+	member.Role = "admin"
+	team.OwnerID = &member.UserID
+	copyTeam := *team
+	return &copyTeam, nil
+}
+
+func (s *stubTeamRepository) GetTeamMembers(_ context.Context, teamID string) ([]*identity.TeamMemberWithUser, error) {
+	if s.memberLists != nil {
+		if members, ok := s.memberLists[teamID]; ok {
+			return members, nil
+		}
+	}
+	members := make([]*identity.TeamMemberWithUser, 0)
+	for _, member := range s.members {
+		if member.TeamID == teamID {
+			members = append(members, &identity.TeamMemberWithUser{
+				ID:       member.ID,
+				TeamID:   member.TeamID,
+				UserID:   member.UserID,
+				Role:     member.Role,
+				JoinedAt: member.JoinedAt,
+			})
+		}
+	}
+	return members, nil
+}
+
+func (s *stubTeamRepository) SearchTeamMembers(_ context.Context, teamID, query string) ([]*identity.TeamMemberWithUser, error) {
+	s.searchTeamID = teamID
+	s.searchQuery = query
+	return s.searchMembers, nil
 }
 
 func (s *stubTeamRepository) GetUserByEmail(context.Context, string) (*identity.User, error) {
@@ -64,11 +120,21 @@ func (s *stubTeamRepository) AddTeamMember(_ context.Context, member *identity.T
 	return nil
 }
 
-func (s *stubTeamRepository) UpdateTeamMemberRole(context.Context, string, string, string) error {
+func (s *stubTeamRepository) UpdateTeamMemberRole(_ context.Context, teamID, userID, role string) error {
+	member, ok := s.members[teamMemberKey(teamID, userID)]
+	if !ok {
+		return identity.ErrMemberNotFound
+	}
+	member.Role = role
 	return nil
 }
 
-func (s *stubTeamRepository) RemoveTeamMember(context.Context, string, string) error {
+func (s *stubTeamRepository) RemoveTeamMember(_ context.Context, teamID, userID string) error {
+	key := teamMemberKey(teamID, userID)
+	if _, ok := s.members[key]; !ok {
+		return identity.ErrMemberNotFound
+	}
+	delete(s.members, key)
 	return nil
 }
 
@@ -288,4 +354,223 @@ func TestTeamHandlerCreateTeamReturnsInternalErrorWhenRegionLookupFails(t *testi
 	if rec.Code != http.StatusInternalServerError {
 		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusInternalServerError, rec.Body.String())
 	}
+}
+
+func TestTeamHandlerTransferTeamOwnerPromotesExistingMember(t *testing.T) {
+	ownerID := "user-owner"
+	nextOwnerID := "user-next"
+	repo := newTeamManagementRepo(ownerID)
+	repo.members[teamMemberKey("team-1", nextOwnerID)] = &identity.TeamMember{
+		ID:     "member-next",
+		TeamID: "team-1",
+		UserID: nextOwnerID,
+		Role:   "viewer",
+	}
+
+	rec := performTeamManagementRequest(t, repo, ownerID, http.MethodPut, "/teams/team-1/owner", map[string]any{
+		"user_id": nextOwnerID,
+	})
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if got := *repo.teams["team-1"].OwnerID; got != nextOwnerID {
+		t.Fatalf("owner = %q, want %q", got, nextOwnerID)
+	}
+	if got := repo.members[teamMemberKey("team-1", nextOwnerID)].Role; got != "admin" {
+		t.Fatalf("new owner role = %q, want admin", got)
+	}
+}
+
+func TestTeamHandlerTransferTeamOwnerRequiresCurrentOwner(t *testing.T) {
+	ownerID := "user-owner"
+	callerID := "user-admin"
+	repo := newTeamManagementRepo(ownerID)
+	repo.members[teamMemberKey("team-1", callerID)] = &identity.TeamMember{
+		ID:     "member-admin",
+		TeamID: "team-1",
+		UserID: callerID,
+		Role:   "admin",
+	}
+
+	rec := performTeamManagementRequest(t, repo, callerID, http.MethodPut, "/teams/team-1/owner", map[string]any{
+		"user_id": callerID,
+	})
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusForbidden, rec.Body.String())
+	}
+	if got := *repo.teams["team-1"].OwnerID; got != ownerID {
+		t.Fatalf("owner changed to %q", got)
+	}
+}
+
+func TestTeamHandlerListTeamMembersUsesSearchQuery(t *testing.T) {
+	ownerID := "user-owner"
+	repo := newTeamManagementRepo(ownerID)
+	repo.searchMembers = []*identity.TeamMemberWithUser{
+		{ID: "member-owner", TeamID: "team-1", UserID: ownerID, Role: "admin", Email: "owner@example.com"},
+	}
+
+	rec := performTeamManagementRequest(t, repo, ownerID, http.MethodGet, "/teams/team-1/members?query=owner", nil)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if repo.searchTeamID != "team-1" || repo.searchQuery != "owner" {
+		t.Fatalf("search = (%q, %q), want (team-1, owner)", repo.searchTeamID, repo.searchQuery)
+	}
+}
+
+func TestTeamHandlerUpdateTeamMemberRejectsOwnerDemotion(t *testing.T) {
+	ownerID := "user-owner"
+	callerID := "user-admin"
+	repo := newTeamManagementRepo(ownerID)
+	repo.members[teamMemberKey("team-1", callerID)] = &identity.TeamMember{
+		ID:     "member-admin",
+		TeamID: "team-1",
+		UserID: callerID,
+		Role:   "admin",
+	}
+
+	rec := performTeamManagementRequest(t, repo, callerID, http.MethodPut, "/teams/team-1/members/"+ownerID, map[string]any{
+		"role": "viewer",
+	})
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	if got := repo.members[teamMemberKey("team-1", ownerID)].Role; got != "admin" {
+		t.Fatalf("owner role = %q, want admin", got)
+	}
+}
+
+func TestTeamHandlerRemoveTeamMemberRejectsOwnerRemoval(t *testing.T) {
+	ownerID := "user-owner"
+	callerID := "user-admin"
+	repo := newTeamManagementRepo(ownerID)
+	repo.members[teamMemberKey("team-1", callerID)] = &identity.TeamMember{
+		ID:     "member-admin",
+		TeamID: "team-1",
+		UserID: callerID,
+		Role:   "admin",
+	}
+
+	rec := performTeamManagementRequest(t, repo, callerID, http.MethodDelete, "/teams/team-1/members/"+ownerID, nil)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	if _, ok := repo.members[teamMemberKey("team-1", ownerID)]; !ok {
+		t.Fatal("owner member was removed")
+	}
+}
+
+func TestTeamHandlerUpdateTeamMemberRejectsLastAdminDemotion(t *testing.T) {
+	adminID := "user-admin"
+	repo := newTeamManagementRepo("")
+	repo.members[teamMemberKey("team-1", adminID)] = &identity.TeamMember{
+		ID:     "member-admin",
+		TeamID: "team-1",
+		UserID: adminID,
+		Role:   "admin",
+	}
+
+	rec := performTeamManagementRequest(t, repo, adminID, http.MethodPut, "/teams/team-1/members/"+adminID, map[string]any{
+		"role": "viewer",
+	})
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	if got := repo.members[teamMemberKey("team-1", adminID)].Role; got != "admin" {
+		t.Fatalf("admin role = %q, want admin", got)
+	}
+}
+
+func TestTeamHandlerRemoveTeamMemberRejectsLastAdminRemoval(t *testing.T) {
+	adminID := "user-admin"
+	repo := newTeamManagementRepo("")
+	repo.members[teamMemberKey("team-1", adminID)] = &identity.TeamMember{
+		ID:     "member-admin",
+		TeamID: "team-1",
+		UserID: adminID,
+		Role:   "admin",
+	}
+
+	rec := performTeamManagementRequest(t, repo, adminID, http.MethodDelete, "/teams/team-1/members/"+adminID, nil)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	if _, ok := repo.members[teamMemberKey("team-1", adminID)]; !ok {
+		t.Fatal("last admin was removed")
+	}
+}
+
+func newTeamManagementRepo(ownerID string) *stubTeamRepository {
+	var ownerPtr *string
+	if ownerID != "" {
+		ownerPtr = &ownerID
+	}
+	repo := &stubTeamRepository{
+		teams: map[string]*identity.Team{
+			"team-1": {
+				ID:      "team-1",
+				Name:    "Team One",
+				Slug:    "team-one",
+				OwnerID: ownerPtr,
+			},
+		},
+		members: make(map[string]*identity.TeamMember),
+	}
+	if ownerID != "" {
+		repo.members[teamMemberKey("team-1", ownerID)] = &identity.TeamMember{
+			ID:     "member-owner",
+			TeamID: "team-1",
+			UserID: ownerID,
+			Role:   "admin",
+		}
+	}
+	return repo
+}
+
+func performTeamManagementRequest(t *testing.T, repo *stubTeamRepository, authUserID, method, path string, body map[string]any) *httptest.ResponseRecorder {
+	t.Helper()
+
+	handler := NewTeamHandler(repo, zap.NewNop())
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("auth_context", &authn.AuthContext{
+			AuthMethod: authn.AuthMethodJWT,
+			UserID:     authUserID,
+			TeamID:     "team-1",
+			TeamRole:   "admin",
+		})
+		c.Next()
+	})
+	router.GET("/teams/:id/members", handler.ListTeamMembers)
+	router.PUT("/teams/:id/owner", handler.TransferTeamOwner)
+	router.PUT("/teams/:id/members/:userId", handler.UpdateTeamMember)
+	router.DELETE("/teams/:id/members/:userId", handler.RemoveTeamMember)
+
+	var reader *bytes.Reader
+	if body == nil {
+		reader = bytes.NewReader(nil)
+	} else {
+		rawBody, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal request: %v", err)
+		}
+		reader = bytes.NewReader(rawBody)
+	}
+	req := httptest.NewRequest(method, path, reader)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	return rec
+}
+
+func teamMemberKey(teamID, userID string) string {
+	return teamID + ":" + userID
 }

--- a/pkg/gateway/identity/team_repository.go
+++ b/pkg/gateway/identity/team_repository.go
@@ -96,6 +96,64 @@ func (r *Repository) DeleteTeam(ctx context.Context, id string) error {
 	return nil
 }
 
+// TransferTeamOwner sets a team member as the team owner and ensures they have admin role.
+func (r *Repository) TransferTeamOwner(ctx context.Context, teamID, userID string) (*Team, error) {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("begin transfer team owner: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	var memberID string
+	if err := tx.QueryRow(ctx, `
+		SELECT id
+		FROM team_members
+		WHERE team_id = $1 AND user_id = $2
+	`, teamID, userID).Scan(&memberID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrMemberNotFound
+		}
+		return nil, fmt.Errorf("query owner member: %w", err)
+	}
+
+	if _, err := tx.Exec(ctx, `
+		UPDATE team_members
+		SET role = 'admin'
+		WHERE team_id = $1 AND user_id = $2
+	`, teamID, userID); err != nil {
+		return nil, fmt.Errorf("promote owner member: %w", err)
+	}
+
+	var team Team
+	err = tx.QueryRow(ctx, `
+		UPDATE teams
+		SET owner_id = $2
+		WHERE id = $1
+		RETURNING id, name, slug, owner_id, home_region_id, created_at, updated_at
+	`, teamID, userID).Scan(
+		&team.ID,
+		&team.Name,
+		&team.Slug,
+		&team.OwnerID,
+		&team.HomeRegionID,
+		&team.CreatedAt,
+		&team.UpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrTeamNotFound
+		}
+		return nil, fmt.Errorf("update team owner: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit transfer team owner: %w", err)
+	}
+	return &team, nil
+}
+
 // GetTeamsByUserID retrieves all teams a user belongs to.
 func (r *Repository) GetTeamsByUserID(ctx context.Context, userID string) ([]*Team, error) {
 	rows, err := r.pool.Query(ctx, `
@@ -211,8 +269,37 @@ func (r *Repository) GetTeamMembers(ctx context.Context, teamID string) ([]*Team
 	if err != nil {
 		return nil, fmt.Errorf("query team members: %w", err)
 	}
-	defer rows.Close()
+	return scanTeamMembers(rows)
+}
 
+// SearchTeamMembers retrieves members whose profile fields match query.
+func (r *Repository) SearchTeamMembers(ctx context.Context, teamID, query string) ([]*TeamMemberWithUser, error) {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return r.GetTeamMembers(ctx, teamID)
+	}
+
+	rows, err := r.pool.Query(ctx, `
+		SELECT tm.id, tm.team_id, tm.user_id, tm.role, tm.joined_at,
+		       u.id, u.email, u.name, u.avatar_url, u.email_verified, u.is_admin, u.created_at, u.updated_at
+		FROM team_members tm
+		INNER JOIN users u ON u.id = tm.user_id
+		WHERE tm.team_id = $1
+		  AND (
+		    u.email ILIKE $2 ESCAPE '\'
+		    OR u.name ILIKE $2 ESCAPE '\'
+		    OR tm.user_id::text ILIKE $2 ESCAPE '\'
+		  )
+		ORDER BY tm.joined_at
+	`, teamID, likeContainsPattern(query))
+	if err != nil {
+		return nil, fmt.Errorf("search team members: %w", err)
+	}
+	return scanTeamMembers(rows)
+}
+
+func scanTeamMembers(rows pgx.Rows) ([]*TeamMemberWithUser, error) {
+	defer rows.Close()
 	var members []*TeamMemberWithUser
 	for rows.Next() {
 		var m TeamMemberWithUser
@@ -224,7 +311,15 @@ func (r *Repository) GetTeamMembers(ctx context.Context, teamID string) ([]*Team
 		}
 		members = append(members, &m)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate team members: %w", err)
+	}
 	return members, nil
+}
+
+func likeContainsPattern(value string) string {
+	replacer := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
+	return "%" + replacer.Replace(value) + "%"
 }
 
 // GetTeamMember retrieves a specific team member.

--- a/pkg/gateway/identity/team_repository_test.go
+++ b/pkg/gateway/identity/team_repository_test.go
@@ -40,3 +40,96 @@ func TestTeamRepositoryScopesSlugUniquenessToOwner(t *testing.T) {
 		t.Fatalf("duplicate owner slug error = %v, want %v", err, ErrTeamAlreadyExists)
 	}
 }
+
+func TestTeamRepositorySearchTeamMembers(t *testing.T) {
+	pool, _ := newGatewayIdentityTestPool(t)
+	if pool == nil {
+		return
+	}
+
+	ctx := context.Background()
+	repo := NewRepository(pool)
+	owner := &User{Email: "owner@example.com", Name: "Owner User"}
+	developer := &User{Email: "developer@example.com", Name: "Build Runner"}
+	viewer := &User{Email: "viewer@example.com", Name: "Viewer User"}
+	for _, user := range []*User{owner, developer, viewer} {
+		if err := repo.CreateUser(ctx, user); err != nil {
+			t.Fatalf("create user %s: %v", user.Email, err)
+		}
+	}
+	ownerID := owner.ID
+	team := &Team{Name: "Team Search", Slug: "team-search", OwnerID: &ownerID}
+	if err := repo.CreateTeam(ctx, team); err != nil {
+		t.Fatalf("create team: %v", err)
+	}
+	for _, member := range []*TeamMember{
+		{TeamID: team.ID, UserID: owner.ID, Role: "admin"},
+		{TeamID: team.ID, UserID: developer.ID, Role: "builder"},
+		{TeamID: team.ID, UserID: viewer.ID, Role: "viewer"},
+	} {
+		if err := repo.AddTeamMember(ctx, member); err != nil {
+			t.Fatalf("add member %s: %v", member.UserID, err)
+		}
+	}
+
+	members, err := repo.SearchTeamMembers(ctx, team.ID, "build")
+	if err != nil {
+		t.Fatalf("search members: %v", err)
+	}
+	if len(members) != 1 || members[0].UserID != developer.ID {
+		t.Fatalf("search by name returned %#v, want developer", members)
+	}
+
+	members, err = repo.SearchTeamMembers(ctx, team.ID, "VIEWER@EXAMPLE.COM")
+	if err != nil {
+		t.Fatalf("search members by email: %v", err)
+	}
+	if len(members) != 1 || members[0].UserID != viewer.ID {
+		t.Fatalf("search by email returned %#v, want viewer", members)
+	}
+}
+
+func TestTeamRepositoryTransferTeamOwnerPromotesMember(t *testing.T) {
+	pool, _ := newGatewayIdentityTestPool(t)
+	if pool == nil {
+		return
+	}
+
+	ctx := context.Background()
+	repo := NewRepository(pool)
+	owner := &User{Email: "transfer-owner@example.com", Name: "Owner User"}
+	nextOwner := &User{Email: "transfer-next@example.com", Name: "Next Owner"}
+	for _, user := range []*User{owner, nextOwner} {
+		if err := repo.CreateUser(ctx, user); err != nil {
+			t.Fatalf("create user %s: %v", user.Email, err)
+		}
+	}
+	ownerID := owner.ID
+	team := &Team{Name: "Transfer Team", Slug: "transfer-team", OwnerID: &ownerID}
+	if err := repo.CreateTeam(ctx, team); err != nil {
+		t.Fatalf("create team: %v", err)
+	}
+	for _, member := range []*TeamMember{
+		{TeamID: team.ID, UserID: owner.ID, Role: "admin"},
+		{TeamID: team.ID, UserID: nextOwner.ID, Role: "viewer"},
+	} {
+		if err := repo.AddTeamMember(ctx, member); err != nil {
+			t.Fatalf("add member %s: %v", member.UserID, err)
+		}
+	}
+
+	updated, err := repo.TransferTeamOwner(ctx, team.ID, nextOwner.ID)
+	if err != nil {
+		t.Fatalf("transfer owner: %v", err)
+	}
+	if updated.OwnerID == nil || *updated.OwnerID != nextOwner.ID {
+		t.Fatalf("owner id = %#v, want %s", updated.OwnerID, nextOwner.ID)
+	}
+	member, err := repo.GetTeamMember(ctx, team.ID, nextOwner.ID)
+	if err != nil {
+		t.Fatalf("get next owner member: %v", err)
+	}
+	if member.Role != "admin" {
+		t.Fatalf("next owner role = %q, want admin", member.Role)
+	}
+}

--- a/pkg/gateway/public/routes.go
+++ b/pkg/gateway/public/routes.go
@@ -131,6 +131,7 @@ func RegisterIdentityRoutes(router gin.IRouter, deps Deps) {
 		teams.GET("/:id", teamHandler.GetTeam)
 		teams.PUT("/:id", teamHandler.UpdateTeam)
 		teams.DELETE("/:id", teamHandler.DeleteTeam)
+		teams.PUT("/:id/owner", teamHandler.TransferTeamOwner)
 
 		// Team members
 		teams.GET("/:id/members", teamHandler.ListTeamMembers)

--- a/pkg/gateway/public/routes_test.go
+++ b/pkg/gateway/public/routes_test.go
@@ -26,6 +26,9 @@ func TestRegisterRoutesMountsSelfHostedPublicSurface(t *testing.T) {
 	if !hasRoute(router, "GET", "/teams") {
 		t.Fatal("expected full public routes to include /teams")
 	}
+	if !hasRoute(router, "PUT", "/teams/:id/owner") {
+		t.Fatal("expected full public routes to include team owner transfer")
+	}
 	if !hasRoute(router, "GET", "/users/me/ssh-keys") {
 		t.Fatal("expected full public routes to include SSH key list")
 	}
@@ -63,6 +66,9 @@ func TestRegisterIdentityRoutesOmitsRegionalStateRoutes(t *testing.T) {
 	}
 	if !hasRoute(router, "GET", "/teams") {
 		t.Fatal("expected identity routes to include /teams")
+	}
+	if !hasRoute(router, "PUT", "/teams/:id/owner") {
+		t.Fatal("expected identity routes to include team owner transfer")
 	}
 }
 


### PR DESCRIPTION
## Summary
- add PUT /teams/{id}/owner for owner-only team ownership transfer
- protect team owner and last admin from role/removal changes
- add team member search by email, display name, or user ID
- update OpenAPI contract and generated API types

## Tests
- GOTOOLCHAIN=go1.25.0+auto env GOWORK=off go test ./pkg/gateway/http/handlers ./pkg/gateway/identity ./pkg/gateway/public ./pkg/apispec

Closes #448
Closes #449

Invite-new-user flow is intentionally not implemented here; it is tracked in sandbox0-cloud#138. UI is also intentionally out of scope.