### PR TITLE
Document placeholder substitution examples

### DIFF
--- a/docs/credential/egress-auth/page.mdx
+++ b/docs/credential/egress-auth/page.mdx
@@ -36,10 +36,10 @@ credentialBindings:
           httpHeaders:
               headers:
                   - name: Authorization
-                    valueTemplate: "Bearer {{token}}"
+                    valueTemplate: "Bearer {{ .token }}"
 ```
 
-In this example, `{{token}}` refers to the `token` key inside a `static_headers` source's `values` map. If the referenced key is missing, header rendering fails.
+In this example, `{{ .token }}` refers to the `token` key inside a `static_headers` source's `values` map. If the referenced key is missing, header rendering fails.
 
 ## Placeholder Substitution
 
@@ -56,7 +56,7 @@ credentialBindings:
           placeholderSubstitution:
               replacements:
                   - placeholder: s0env_api_token_placeholder
-                    valueTemplate: "{{token}}"
+                    valueTemplate: "{{ .token }}"
                     locations:
                         - header
                         - query
@@ -64,6 +64,263 @@ credentialBindings:
 ```
 
 With that binding, a sandbox process can send the placeholder in a header, query parameter, or request body. Matching outbound HTTP requests receive the resolved `token` value before they are sent upstream.
+
+## Runnable Placeholder Example
+
+The snippets below configure a sandbox so the process can send `s0env_api_token` in a header, query value, or body, while the egress path replaces it with the `token` stored in `api-token-source`.
+
+Set these values before running the snippets:
+
+- `SANDBOX_ID`: sandbox to update
+- `API_CIDR`: destination CIDR such as `203.0.113.10/32`
+- `API_ORIGIN`: destination origin such as `http://203.0.113.10:8080`
+- `API_PORT`: destination port, defaults to `8080`
+- `API_TOKEN`: secret value to inject, defaults to `docs-secret-token`
+
+For raw HTTP, also set `SANDBOX0_API_URL`, `SANDBOX0_TOKEN`, and `TEAM_ID`.
+
+<Tabs
+  tabs={[
+    {
+      label: "HTTP",
+      language: "bash",
+      code: `# Requires jq.
+if [ -z "$API_PORT" ]; then API_PORT=8080; fi
+if [ -z "$API_TOKEN" ]; then API_TOKEN=docs-secret-token; fi
+if [ -z "$SOURCE_NAME" ]; then SOURCE_NAME=api-token-source; fi
+if [ -z "$PLACEHOLDER" ]; then PLACEHOLDER=s0env_api_token; fi
+
+curl -fsS -X POST "$SANDBOX0_API_URL/api/v1/credential-sources" \\
+    -H "Authorization: Bearer $SANDBOX0_TOKEN" \\
+    -H "X-Team-ID: $TEAM_ID" \\
+    -H "Content-Type: application/json" \\
+    --data "$(jq -n \\
+        --arg name "$SOURCE_NAME" \\
+        --arg token "$API_TOKEN" \\
+        '{
+            name: $name,
+            resolverKind: "static_headers",
+            spec: {
+                staticHeaders: {
+                    values: {
+                        token: $token
+                    }
+                }
+            }
+        }')"
+
+curl -fsS -X PUT "$SANDBOX0_API_URL/api/v1/sandboxes/$SANDBOX_ID/network" \\
+    -H "Authorization: Bearer $SANDBOX0_TOKEN" \\
+    -H "X-Team-ID: $TEAM_ID" \\
+    -H "Content-Type: application/json" \\
+    --data "$(jq -n \\
+        --arg apiCidr "$API_CIDR" \\
+        --argjson apiPort "$API_PORT" \\
+        --arg source "$SOURCE_NAME" \\
+        --arg placeholder "$PLACEHOLDER" \\
+        '{
+            mode: "block-all",
+            egress: {
+                trafficRules: [
+                    {
+                        name: "allow-example-api",
+                        action: "allow",
+                        cidrs: [$apiCidr],
+                        ports: [
+                            {
+                                port: $apiPort,
+                                protocol: "tcp"
+                            }
+                        ]
+                    }
+                ],
+                credentialRules: [
+                    {
+                        name: "api-token",
+                        credentialRef: "api-token",
+                        protocol: "http",
+                        ports: [
+                            {
+                                port: $apiPort,
+                                protocol: "tcp"
+                            }
+                        ],
+                        failurePolicy: "fail-closed"
+                    }
+                ]
+            },
+            credentialBindings: [
+                {
+                    ref: "api-token",
+                    sourceRef: $source,
+                    projection: {
+                        type: "placeholder_substitution",
+                        placeholderSubstitution: {
+                            replacements: [
+                                {
+                                    placeholder: $placeholder,
+                                    valueTemplate: "{{ .token }}",
+                                    locations: ["query", "header", "body"]
+                                }
+                            ]
+                        }
+                    }
+                }
+            ]
+        }')"`
+    },
+    {
+      label: "Go",
+      language: "go",
+      code: `apiCIDR := os.Getenv("API_CIDR")
+apiPort := 8080
+apiToken := os.Getenv("API_TOKEN")
+if apiToken == "" {
+    apiToken = "docs-secret-token"
+}
+sourceName := os.Getenv("SOURCE_NAME")
+if sourceName == "" {
+    sourceName = "api-token-source"
+}
+
+_, err := client.CreateCredentialSource(ctx, apispec.CredentialSourceWriteRequest{
+    Name: sourceName,
+    ResolverKind: apispec.CredentialSourceResolverKindStaticHeaders,
+    Spec: apispec.CredentialSourceWriteSpec{
+        StaticHeaders: apispec.NewOptStaticHeadersSourceSpec(apispec.StaticHeadersSourceSpec{
+            Values: apispec.NewOptStaticHeadersSourceSpecValues(apispec.StaticHeadersSourceSpecValues{
+                "token": apiToken,
+            }),
+        }),
+    },
+})
+if err != nil {
+    log.Fatal(err)
+}
+
+_, err = sandbox.UpdateNetworkPolicy(ctx, apispec.SandboxNetworkPolicy{
+    Mode: apispec.SandboxNetworkPolicyModeBlockAll,
+    Egress: apispec.NewOptNetworkEgressPolicy(apispec.NetworkEgressPolicy{
+        TrafficRules: []apispec.TrafficRule{
+            {
+                Name: apispec.NewOptString("allow-example-api"),
+                Action: apispec.TrafficRuleActionAllow,
+                Cidrs: []string{apiCIDR},
+                Ports: []apispec.PortSpec{
+                    {
+                        Port: apiPort,
+                        Protocol: apispec.NewOptString("tcp"),
+                    },
+                },
+            },
+        },
+        CredentialRules: []apispec.EgressCredentialRule{
+            {
+                Name: apispec.NewOptString("api-token"),
+                CredentialRef: "api-token",
+                Protocol: apispec.NewOptEgressAuthProtocol(apispec.EgressAuthProtocolHTTP),
+                Ports: []apispec.PortSpec{
+                    {
+                        Port: apiPort,
+                        Protocol: apispec.NewOptString("tcp"),
+                    },
+                },
+                FailurePolicy: apispec.NewOptEgressAuthFailurePolicy(apispec.EgressAuthFailurePolicyFailClosed),
+            },
+        },
+    }),
+    CredentialBindings: []apispec.CredentialBinding{
+        {
+            Ref: "api-token",
+            SourceRef: sourceName,
+            Projection: apispec.ProjectionSpec{
+                Type: apispec.CredentialProjectionTypePlaceholderSubstitution,
+                PlaceholderSubstitution: apispec.NewOptPlaceholderSubstitutionProjection(apispec.PlaceholderSubstitutionProjection{
+                    Replacements: []apispec.PlaceholderReplacement{
+                        {
+                            Placeholder: "s0env_api_token",
+                            ValueTemplate: "{{ .token }}",
+                            Locations: []apispec.PlaceholderSubstitutionLocation{
+                                apispec.PlaceholderSubstitutionLocationQuery,
+                                apispec.PlaceholderSubstitutionLocationHeader,
+                                apispec.PlaceholderSubstitutionLocationBody,
+                            },
+                        },
+                    },
+                }),
+            },
+        },
+    },
+})
+if err != nil {
+    log.Fatal(err)
+}`
+    },
+    {
+      label: "CLI",
+      language: "bash",
+      code: `if [ -z "$API_PORT" ]; then API_PORT=8080; fi
+if [ -z "$API_TOKEN" ]; then API_TOKEN=docs-secret-token; fi
+if [ -z "$SOURCE_NAME" ]; then SOURCE_NAME=api-token-source; fi
+
+cat <<EOF > api-token-source.yaml
+name: $SOURCE_NAME
+resolverKind: static_headers
+spec:
+    staticHeaders:
+        values:
+            token: $API_TOKEN
+EOF
+s0 credential create -f api-token-source.yaml
+
+cat <<EOF > placeholder-network.yaml
+mode: block-all
+egress:
+    trafficRules:
+        - name: allow-example-api
+          action: allow
+          cidrs:
+              - $API_CIDR
+          ports:
+              - port: $API_PORT
+                protocol: tcp
+    credentialRules:
+        - name: api-token
+          credentialRef: api-token
+          protocol: http
+          ports:
+              - port: $API_PORT
+                protocol: tcp
+          failurePolicy: fail-closed
+credentialBindings:
+    - ref: api-token
+      sourceRef: $SOURCE_NAME
+      projection:
+          type: placeholder_substitution
+          placeholderSubstitution:
+              replacements:
+                  - placeholder: s0env_api_token
+                    valueTemplate: "{{ .token }}"
+                    locations:
+                        - query
+                        - header
+                        - body
+EOF
+s0 sandbox network update --policy-file placeholder-network.yaml -s "$SANDBOX_ID"`
+    }
+  ]}
+/>
+
+After the policy is applied, the sandbox process can send the placeholder without reading the secret:
+
+```bash
+curl -fsS \
+    -H "Authorization: Bearer s0env_api_token" \
+    "$API_ORIGIN/echo?token=s0env_api_token" \
+    --data "token=s0env_api_token"
+```
+
+The upstream service receives the resolved `API_TOKEN` value in the header, query parameter, and request body.
 
 ## Rule Fields
 
@@ -121,10 +378,10 @@ credentialBindings:
           httpHeaders:
               headers:
                   - name: Authorization
-                    valueTemplate: "Bearer {{token}}"
+                    valueTemplate: "Bearer {{ .token }}"
 ```
 
-Here, `{{token}}` is rendered from the `token` entry stored in the bound `static_headers` source. Keep the projection template keys aligned with the source contents.
+Here, `{{ .token }}` is rendered from the `token` entry stored in the bound `static_headers` source. Keep the projection template keys aligned with the source contents.
 
 ## HTTP Request Matching
 
@@ -175,7 +432,7 @@ credentialBindings:
           httpHeaders:
               headers:
                   - name: Authorization
-                    valueTemplate: "Bearer {{token}}"
+                    valueTemplate: "Bearer {{ .token }}"
 ```
 
 You can use that ordering to inject different credentials for different paths on the same host:
@@ -316,7 +573,7 @@ SSH does not carry a hostname in the protocol. When `credentialRules[*].domains`
                     Headers: []apispec.ProjectedHeader{
                         {
                             Name: "Authorization",
-                            ValueTemplate: "Bearer {{token}}",
+                            ValueTemplate: "Bearer {{ .token }}",
                         },
                     },
                 }),
@@ -366,7 +623,7 @@ sandbox.update_network_policy(
                         "headers": [
                             {
                                 "name": "Authorization",
-                                "valueTemplate": "Bearer {{token}}",
+                                "valueTemplate": "Bearer {{ .token }}",
                             },
                         ],
                     },
@@ -411,7 +668,7 @@ sandbox.update_network_policy(
                     headers: [
                         {
                             name: 'Authorization',
-                            valueTemplate: 'Bearer {{token}}',
+                            valueTemplate: 'Bearer {{ .token }}',
                         },
                     ],
                 },
@@ -426,7 +683,7 @@ sandbox.update_network_policy(
       code: `# Structured flags: good for scripts and one-off updates
 s0 sandbox network update --mode block-all \\
   --traffic-rule '{"name":"allow-github-api","action":"allow","domains":["api.github.com"],"ports":[{"port":443,"protocol":"tcp"}]}' \\
-  --credential-binding '{"ref":"gh-token","sourceRef":"github-source","projection":{"type":"http_headers","httpHeaders":{"headers":[{"name":"Authorization","valueTemplate":"Bearer {{token}}"}]}}}' \\
+  --credential-binding '{"ref":"gh-token","sourceRef":"github-source","projection":{"type":"http_headers","httpHeaders":{"headers":[{"name":"Authorization","valueTemplate":"Bearer {{ .token }}"}]}}}' \\
   --credential-rule '{"name":"github-auth","credentialRef":"gh-token","protocol":"https","domains":["api.github.com"],"ports":[{"port":443,"protocol":"tcp"}],"failurePolicy":"fail-closed"}' \\
   -s sb_abc123
 
@@ -460,7 +717,7 @@ credentialBindings:
           httpHeaders:
               headers:
                   - name: Authorization
-                    valueTemplate: "Bearer {{token}}"
+                    valueTemplate: "Bearer {{ .token }}"
 EOF
 
 s0 sandbox network update --policy-file network.yaml -s sb_abc123`

--- a/docs/credential/egress-auth/page.mdx
+++ b/docs/credential/egress-auth/page.mdx
@@ -173,7 +173,7 @@ curl -fsS -X PUT "$SANDBOX0_API_URL/api/v1/sandboxes/$SANDBOX_ID/network" \\
       label: "Go",
       language: "go",
       code: `apiCIDR := os.Getenv("API_CIDR")
-apiPort := 8080
+apiPort := int32(8080)
 apiToken := os.Getenv("API_TOKEN")
 if apiToken == "" {
     apiToken = "docs-secret-token"

--- a/docs/credential/egress-auth/page.mdx
+++ b/docs/credential/egress-auth/page.mdx
@@ -77,103 +77,20 @@ Set these values before running the snippets:
 - `API_PORT`: destination port, defaults to `8080`
 - `API_TOKEN`: secret value to inject, defaults to `docs-secret-token`
 
-For raw HTTP, also set `SANDBOX0_API_URL`, `SANDBOX0_TOKEN`, and `TEAM_ID`.
-
 <Tabs
   tabs={[
-    {
-      label: "HTTP",
-      language: "bash",
-      code: `# Requires jq.
-if [ -z "$API_PORT" ]; then API_PORT=8080; fi
-if [ -z "$API_TOKEN" ]; then API_TOKEN=docs-secret-token; fi
-if [ -z "$SOURCE_NAME" ]; then SOURCE_NAME=api-token-source; fi
-if [ -z "$PLACEHOLDER" ]; then PLACEHOLDER=s0env_api_token; fi
-
-curl -fsS -X POST "$SANDBOX0_API_URL/api/v1/credential-sources" \\
-    -H "Authorization: Bearer $SANDBOX0_TOKEN" \\
-    -H "X-Team-ID: $TEAM_ID" \\
-    -H "Content-Type: application/json" \\
-    --data "$(jq -n \\
-        --arg name "$SOURCE_NAME" \\
-        --arg token "$API_TOKEN" \\
-        '{
-            name: $name,
-            resolverKind: "static_headers",
-            spec: {
-                staticHeaders: {
-                    values: {
-                        token: $token
-                    }
-                }
-            }
-        }')"
-
-curl -fsS -X PUT "$SANDBOX0_API_URL/api/v1/sandboxes/$SANDBOX_ID/network" \\
-    -H "Authorization: Bearer $SANDBOX0_TOKEN" \\
-    -H "X-Team-ID: $TEAM_ID" \\
-    -H "Content-Type: application/json" \\
-    --data "$(jq -n \\
-        --arg apiCidr "$API_CIDR" \\
-        --argjson apiPort "$API_PORT" \\
-        --arg source "$SOURCE_NAME" \\
-        --arg placeholder "$PLACEHOLDER" \\
-        '{
-            mode: "block-all",
-            egress: {
-                trafficRules: [
-                    {
-                        name: "allow-example-api",
-                        action: "allow",
-                        cidrs: [$apiCidr],
-                        ports: [
-                            {
-                                port: $apiPort,
-                                protocol: "tcp"
-                            }
-                        ]
-                    }
-                ],
-                credentialRules: [
-                    {
-                        name: "api-token",
-                        credentialRef: "api-token",
-                        protocol: "http",
-                        ports: [
-                            {
-                                port: $apiPort,
-                                protocol: "tcp"
-                            }
-                        ],
-                        failurePolicy: "fail-closed"
-                    }
-                ]
-            },
-            credentialBindings: [
-                {
-                    ref: "api-token",
-                    sourceRef: $source,
-                    projection: {
-                        type: "placeholder_substitution",
-                        placeholderSubstitution: {
-                            replacements: [
-                                {
-                                    placeholder: $placeholder,
-                                    valueTemplate: "{{ .token }}",
-                                    locations: ["query", "header", "body"]
-                                }
-                            ]
-                        }
-                    }
-                }
-            ]
-        }')"`
-    },
     {
       label: "Go",
       language: "go",
       code: `apiCIDR := os.Getenv("API_CIDR")
 apiPort := int32(8080)
+if value := os.Getenv("API_PORT"); value != "" {
+    parsed, err := strconv.ParseInt(value, 10, 32)
+    if err != nil {
+        log.Fatal(err)
+    }
+    apiPort = int32(parsed)
+}
 apiToken := os.Getenv("API_TOKEN")
 if apiToken == "" {
     apiToken = "docs-secret-token"
@@ -257,6 +174,137 @@ if err != nil {
 }`
     },
     {
+      label: "Python",
+      language: "python",
+      code: `import os
+
+from sandbox0.apispec.models.credential_source_write_request import CredentialSourceWriteRequest
+from sandbox0.apispec.models.sandbox_network_policy import SandboxNetworkPolicy
+
+api_cidr = os.environ["API_CIDR"]
+api_port = int(os.environ.get("API_PORT", "8080"))
+api_token = os.environ.get("API_TOKEN", "docs-secret-token")
+source_name = os.environ.get("SOURCE_NAME", "api-token-source")
+
+client.create_credential_source(
+    CredentialSourceWriteRequest.from_dict({
+        "name": source_name,
+        "resolverKind": "static_headers",
+        "spec": {
+            "staticHeaders": {
+                "values": {
+                    "token": api_token,
+                },
+            },
+        },
+    })
+)
+
+sandbox.update_network_policy(
+    SandboxNetworkPolicy.from_dict({
+        "mode": "block-all",
+        "egress": {
+            "trafficRules": [
+                {
+                    "name": "allow-example-api",
+                    "action": "allow",
+                    "cidrs": [api_cidr],
+                    "ports": [{"port": api_port, "protocol": "tcp"}],
+                },
+            ],
+            "credentialRules": [
+                {
+                    "name": "api-token",
+                    "credentialRef": "api-token",
+                    "protocol": "http",
+                    "ports": [{"port": api_port, "protocol": "tcp"}],
+                    "failurePolicy": "fail-closed",
+                },
+            ],
+        },
+        "credentialBindings": [
+            {
+                "ref": "api-token",
+                "sourceRef": source_name,
+                "projection": {
+                    "type": "placeholder_substitution",
+                    "placeholderSubstitution": {
+                        "replacements": [
+                            {
+                                "placeholder": "s0env_api_token",
+                                "valueTemplate": "{{ .token }}",
+                                "locations": ["query", "header", "body"],
+                            },
+                        ],
+                    },
+                },
+            },
+        ],
+    })
+)`
+    },
+    {
+      label: "TypeScript",
+      language: "typescript",
+      code: `const apiCidr = process.env.API_CIDR ?? '';
+const apiPort = Number(process.env.API_PORT ?? '8080');
+const apiToken = process.env.API_TOKEN ?? 'docs-secret-token';
+const sourceName = process.env.SOURCE_NAME ?? 'api-token-source';
+
+await client.credentialSources.create({
+    name: sourceName,
+    resolverKind: 'static_headers',
+    spec: {
+        staticHeaders: {
+            values: {
+                token: apiToken,
+            },
+        },
+    },
+});
+
+await sandbox.updateNetworkPolicy({
+    mode: 'block-all',
+    egress: {
+        trafficRules: [
+            {
+                name: 'allow-example-api',
+                action: 'allow',
+                cidrs: [apiCidr],
+                ports: [{ port: apiPort, protocol: 'tcp' }],
+            },
+        ],
+        credentialRules: [
+            {
+                name: 'api-token',
+                credentialRef: 'api-token',
+                protocol: 'http',
+                ports: [{ port: apiPort, protocol: 'tcp' }],
+                failurePolicy: 'fail-closed',
+            },
+        ],
+    },
+    credentialBindings: [
+        {
+            ref: 'api-token',
+            sourceRef: sourceName,
+            projection: {
+                type: 'placeholder_substitution',
+                placeholderSubstitution: {
+                    replacements: [
+                        {
+                            placeholder: 's0env_api_token',
+                            valueTemplate: '{{ .token }}',
+                            locations: ['query', 'header', 'body'],
+                        },
+                    ],
+                },
+            },
+        },
+    ],
+});`
+    },
+    {
       label: "CLI",
       language: "bash",
       code: `if [ -z "$API_PORT" ]; then API_PORT=8080; fi
@@ -310,6 +358,95 @@ s0 sandbox network update --policy-file placeholder-network.yaml -s "$SANDBOX_ID
     }
   ]}
 />
+
+For raw HTTP, also set `SANDBOX0_API_URL`, `SANDBOX0_TOKEN`, and `TEAM_ID`.
+
+```bash
+# Requires jq.
+if [ -z "$API_PORT" ]; then API_PORT=8080; fi
+if [ -z "$API_TOKEN" ]; then API_TOKEN=docs-secret-token; fi
+if [ -z "$SOURCE_NAME" ]; then SOURCE_NAME=api-token-source; fi
+if [ -z "$PLACEHOLDER" ]; then PLACEHOLDER=s0env_api_token; fi
+
+curl -fsS -X POST "$SANDBOX0_API_URL/api/v1/credential-sources" \
+    -H "Authorization: Bearer $SANDBOX0_TOKEN" \
+    -H "X-Team-ID: $TEAM_ID" \
+    -H "Content-Type: application/json" \
+    --data "$(jq -n \
+        --arg name "$SOURCE_NAME" \
+        --arg token "$API_TOKEN" \
+        '{
+            name: $name,
+            resolverKind: "static_headers",
+            spec: {
+                staticHeaders: {
+                    values: {
+                        token: $token
+                    }
+                }
+            }
+        }')"
+
+curl -fsS -X PUT "$SANDBOX0_API_URL/api/v1/sandboxes/$SANDBOX_ID/network" \
+    -H "Authorization: Bearer $SANDBOX0_TOKEN" \
+    -H "X-Team-ID: $TEAM_ID" \
+    -H "Content-Type: application/json" \
+    --data "$(jq -n \
+        --arg apiCidr "$API_CIDR" \
+        --argjson apiPort "$API_PORT" \
+        --arg source "$SOURCE_NAME" \
+        --arg placeholder "$PLACEHOLDER" \
+        '{
+            mode: "block-all",
+            egress: {
+                trafficRules: [
+                    {
+                        name: "allow-example-api",
+                        action: "allow",
+                        cidrs: [$apiCidr],
+                        ports: [
+                            {
+                                port: $apiPort,
+                                protocol: "tcp"
+                            }
+                        ]
+                    }
+                ],
+                credentialRules: [
+                    {
+                        name: "api-token",
+                        credentialRef: "api-token",
+                        protocol: "http",
+                        ports: [
+                            {
+                                port: $apiPort,
+                                protocol: "tcp"
+                            }
+                        ],
+                        failurePolicy: "fail-closed"
+                    }
+                ]
+            },
+            credentialBindings: [
+                {
+                    ref: "api-token",
+                    sourceRef: $source,
+                    projection: {
+                        type: "placeholder_substitution",
+                        placeholderSubstitution: {
+                            replacements: [
+                                {
+                                    placeholder: $placeholder,
+                                    valueTemplate: "{{ .token }}",
+                                    locations: ["query", "header", "body"]
+                                }
+                            ]
+                        }
+                    }
+                }
+            ]
+        }')"
+```
 
 After the policy is applied, the sandbox process can send the placeholder without reading the secret:
 

--- a/docs/template/configuration/page.mdx
+++ b/docs/template/configuration/page.mdx
@@ -50,7 +50,7 @@ spec:
                   httpHeaders:
                       headers:
                           - name: Authorization
-                            valueTemplate: "Bearer {{token}}"
+                            valueTemplate: "Bearer {{ .token }}"
 ```
 
 ---


### PR DESCRIPTION
## Summary
- document placeholder_substitution credential projection in egress auth docs
- align runnable examples with the standard Go / Python / TypeScript / CLI tab order
- keep raw HTTP as a separate curl example and validate it with the same query/header/body coverage

## Tests
- remote Aliyun kind fullmode validation: HTTP, Go, Python, TypeScript, and CLI snippets all replaced query/header/body placeholders
- local docs repo has no standalone docs build package