### PR TITLE
Support runtime sandbox environment updates

### DIFF
--- a/manager/pkg/service/procd_client.go
+++ b/manager/pkg/service/procd_client.go
@@ -114,6 +114,16 @@ type InitializeResponse struct {
 	TeamID    string `json:"team_id,omitempty"`
 }
 
+// UpdateSandboxEnvVarsRequest updates sandbox-level default environment variables.
+type UpdateSandboxEnvVarsRequest struct {
+	EnvVars map[string]string `json:"env_vars,omitempty"`
+}
+
+// UpdateSandboxEnvVarsResponse represents the response from procd env update API.
+type UpdateSandboxEnvVarsResponse struct {
+	EnvVars map[string]string `json:"env_vars"`
+}
+
 // Stats calls the procd stats API.
 func (c *ProcdClient) Stats(ctx context.Context, procdAddress, internalToken string) (*StatsResponse, error) {
 	url := procdAddress + "/api/v1/sandbox/stats"
@@ -124,6 +134,12 @@ func (c *ProcdClient) Stats(ctx context.Context, procdAddress, internalToken str
 func (c *ProcdClient) Initialize(ctx context.Context, procdAddress string, req InitializeRequest, internalToken string) (*InitializeResponse, error) {
 	url := procdAddress + "/api/v1/initialize"
 	return doProcdRequest[InitializeResponse](ctx, c.httpClient, http.MethodPost, url, internalToken, "initialize", req)
+}
+
+// UpdateSandboxEnvVars updates sandbox-level default environment variables for future processes.
+func (c *ProcdClient) UpdateSandboxEnvVars(ctx context.Context, procdAddress string, req UpdateSandboxEnvVarsRequest, internalToken string) (*UpdateSandboxEnvVarsResponse, error) {
+	url := procdAddress + "/api/v1/sandbox/env_vars"
+	return doProcdRequest[UpdateSandboxEnvVarsResponse](ctx, c.httpClient, http.MethodPut, url, internalToken, "update sandbox env vars", req)
 }
 
 func doProcdRequest[T any](ctx context.Context, httpClient *http.Client, method, url, internalToken, action string, request any) (*T, error) {

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -78,9 +78,10 @@ type SandboxConfig struct {
 }
 
 // SandboxUpdateConfig represents sandbox configuration fields that can be updated at runtime.
-// Unlike SandboxConfig, env_vars and webhook are excluded as they only affect new processes
-// or require restart to take effect.
+// EnvVars updates only the default environment for new procd-managed processes.
+// Webhook is excluded because it requires reinitializing the sandbox runtime.
 type SandboxUpdateConfig struct {
+	EnvVars    map[string]string              `json:"env_vars,omitempty"`
 	TTL        *int32                         `json:"ttl,omitempty"`
 	HardTTL    *int32                         `json:"hard_ttl,omitempty"`
 	Network    *v1alpha1.SandboxNetworkPolicy `json:"network,omitempty"`

--- a/manager/pkg/service/sandbox_service_lifecycle.go
+++ b/manager/pkg/service/sandbox_service_lifecycle.go
@@ -489,6 +489,9 @@ func (s *SandboxService) UpdateSandbox(ctx context.Context, sandboxID string, cf
 		if cfg.AutoResume != nil {
 			merged.AutoResume = cfg.AutoResume
 		}
+		if cfg.EnvVars != nil {
+			merged.EnvVars = cloneEnvVars(cfg.EnvVars)
+		}
 		if cfg.Services != nil {
 			services, err := NormalizeSandboxAppServices(cfg.Services)
 			if err != nil {
@@ -558,6 +561,11 @@ func (s *SandboxService) UpdateSandbox(ctx context.Context, sandboxID string, cf
 		return nil, fmt.Errorf("update pod: %w", err)
 	}
 
+	if cfg.EnvVars != nil {
+		if err := s.updateActiveSandboxEnvVars(ctx, updatedPod, sandboxID, sandboxEnvVarsFromPod(updatedPod)); err != nil {
+			return nil, fmt.Errorf("update sandbox env vars: %w", err)
+		}
+	}
 	if networkState != nil {
 		teamID := updatedPod.Annotations[controller.AnnotationTeamID]
 		if err := s.applyNetworkProvider(ctx, updatedPod, teamID, policySpecFromState(networkState)); err != nil {
@@ -588,6 +596,9 @@ func (s *SandboxService) updatePausedSandboxRecord(ctx context.Context, record *
 	if cfg.AutoResume != nil {
 		merged.AutoResume = cfg.AutoResume
 	}
+	if cfg.EnvVars != nil {
+		merged.EnvVars = cloneEnvVars(cfg.EnvVars)
+	}
 	if cfg.Services != nil {
 		services, err := NormalizeSandboxAppServices(cfg.Services)
 		if err != nil {
@@ -607,6 +618,44 @@ func (s *SandboxService) updatePausedSandboxRecord(ctx context.Context, record *
 		return nil, err
 	}
 	return s.recordToSandbox(record), nil
+}
+
+func (s *SandboxService) updateActiveSandboxEnvVars(ctx context.Context, pod *corev1.Pod, sandboxID string, envVars map[string]string) error {
+	if s.procdClient == nil {
+		return fmt.Errorf("procd client is not configured")
+	}
+	if s.internalTokenGenerator == nil {
+		return fmt.Errorf("token generators not configured, cannot authenticate with procd")
+	}
+	procdAddress, err := s.prodAddress(ctx, pod)
+	if err != nil {
+		return fmt.Errorf("procd address: %w", err)
+	}
+	currentSandboxID := sandboxIDFromPod(pod)
+	if currentSandboxID == "" {
+		currentSandboxID = sandboxID
+	}
+	teamID, userID := "", ""
+	if pod != nil && pod.Annotations != nil {
+		teamID = pod.Annotations[controller.AnnotationTeamID]
+		userID = pod.Annotations[controller.AnnotationUserID]
+	}
+	internalToken, err := s.internalTokenGenerator.GenerateToken(teamID, userID, currentSandboxID)
+	if err != nil {
+		return fmt.Errorf("generate internal token: %w", err)
+	}
+	_, err = s.procdClient.UpdateSandboxEnvVars(ctx, procdAddress, UpdateSandboxEnvVarsRequest{
+		EnvVars: cloneEnvVars(envVars),
+	}, internalToken)
+	return err
+}
+
+func sandboxEnvVarsFromPod(pod *corev1.Pod) map[string]string {
+	if pod == nil || pod.Annotations == nil {
+		return nil
+	}
+	cfg := parseSandboxConfig(pod.Annotations[controller.AnnotationConfig])
+	return cloneEnvVars(cfg.EnvVars)
 }
 
 func expirationFromTTL(now time.Time, ttl *int32) time.Time {

--- a/manager/pkg/service/sandbox_service_ttl_test.go
+++ b/manager/pkg/service/sandbox_service_ttl_test.go
@@ -3,6 +3,11 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
 	"testing"
 	"time"
 
@@ -124,6 +129,88 @@ func TestUpdateSandboxZeroTTLDisablesExpirations(t *testing.T) {
 	assert.Equal(t, int32(0), *cfg.HardTTL)
 }
 
+func TestUpdateSandboxEnvVarsUpdatesProcdAndConfig(t *testing.T) {
+	pod := testSandboxPod()
+	pod.Annotations[controller.AnnotationConfig] = `{"env_vars":{"OLD":"old"},"ttl":300}`
+
+	var procdReq UpdateSandboxEnvVarsRequest
+	procdServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/api/v1/sandbox/env_vars" {
+			t.Fatalf("unexpected procd request %s %s", r.Method, r.URL.Path)
+		}
+		if got := r.Header.Get("X-Internal-Token"); got != "token" {
+			t.Fatalf("X-Internal-Token = %q, want token", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&procdReq); err != nil {
+			t.Fatalf("decode procd request: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"success": true,
+			"data": map[string]any{
+				"env_vars": procdReq.EnvVars,
+			},
+		})
+	}))
+	t.Cleanup(procdServer.Close)
+	procdPort := configurePodForProcdServer(t, pod, procdServer.URL)
+
+	svc, client := newSandboxServiceForTTLTests(t, pod, 0)
+	svc.config.ProcdPort = procdPort
+	svc.procdClient = NewProcdClientWithHTTPClient(procdServer.Client())
+	svc.internalTokenGenerator = staticTokenGenerator{}
+
+	_, err := svc.UpdateSandbox(context.Background(), pod.Name, &SandboxUpdateConfig{
+		EnvVars: map[string]string{
+			"APP_ENV": "test",
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"APP_ENV": "test"}, procdReq.EnvVars)
+
+	stored, err := client.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	var cfg SandboxConfig
+	require.NoError(t, json.Unmarshal([]byte(stored.Annotations[controller.AnnotationConfig]), &cfg))
+	assert.Equal(t, map[string]string{"APP_ENV": "test"}, cfg.EnvVars)
+	require.NotNil(t, cfg.TTL)
+	assert.Equal(t, int32(300), *cfg.TTL)
+}
+
+func TestUpdateSandboxEnvVarsClearsConfig(t *testing.T) {
+	pod := testSandboxPod()
+	pod.Annotations[controller.AnnotationConfig] = `{"env_vars":{"OLD":"old"}}`
+
+	var procdReq UpdateSandboxEnvVarsRequest
+	procdServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&procdReq); err != nil {
+			t.Fatalf("decode procd request: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"success": true,
+			"data":    map[string]any{"env_vars": map[string]string{}},
+		})
+	}))
+	t.Cleanup(procdServer.Close)
+	procdPort := configurePodForProcdServer(t, pod, procdServer.URL)
+
+	svc, client := newSandboxServiceForTTLTests(t, pod, 0)
+	svc.config.ProcdPort = procdPort
+	svc.procdClient = NewProcdClientWithHTTPClient(procdServer.Client())
+	svc.internalTokenGenerator = staticTokenGenerator{}
+
+	_, err := svc.UpdateSandbox(context.Background(), pod.Name, &SandboxUpdateConfig{
+		EnvVars: map[string]string{},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, procdReq.EnvVars)
+
+	stored, err := client.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	var cfg SandboxConfig
+	require.NoError(t, json.Unmarshal([]byte(stored.Annotations[controller.AnnotationConfig]), &cfg))
+	assert.Empty(t, cfg.EnvVars)
+}
+
 func TestRefreshSandboxDisabledTTLRemainsDisabled(t *testing.T) {
 	pod := testSandboxPod()
 	pod.Annotations[controller.AnnotationConfig] = `{"ttl":0,"hard_ttl":0}`
@@ -139,4 +226,23 @@ func TestRefreshSandboxDisabledTTLRemainsDisabled(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, stored.Annotations[controller.AnnotationExpiresAt])
 	assert.Empty(t, stored.Annotations[controller.AnnotationHardExpiresAt])
+}
+
+func configurePodForProcdServer(t *testing.T, pod *corev1.Pod, rawURL string) int {
+	t.Helper()
+	parsed, err := url.Parse(rawURL)
+	require.NoError(t, err)
+	host, portText, err := net.SplitHostPort(parsed.Host)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portText)
+	require.NoError(t, err)
+	if pod.Annotations == nil {
+		pod.Annotations = map[string]string{}
+	}
+	if pod.Labels == nil {
+		pod.Labels = map[string]string{}
+	}
+	pod.Annotations[controller.AnnotationSandboxID] = pod.Name
+	pod.Status.PodIP = host
+	return port
 }

--- a/manager/procd/pkg/http/handlers/initialize.go
+++ b/manager/procd/pkg/http/handlers/initialize.go
@@ -58,6 +58,16 @@ type InitializeResponse struct {
 	TeamID    string `json:"team_id,omitempty"`
 }
 
+// UpdateSandboxEnvVarsRequest updates sandbox-level default environment variables.
+type UpdateSandboxEnvVarsRequest struct {
+	EnvVars map[string]string `json:"env_vars,omitempty"`
+}
+
+// UpdateSandboxEnvVarsResponse returns the normalized sandbox environment.
+type UpdateSandboxEnvVarsResponse struct {
+	EnvVars map[string]string `json:"env_vars"`
+}
+
 // Initialize sets sandbox identity and webhook settings.
 func (h *InitializeHandler) Initialize(w http.ResponseWriter, r *http.Request) {
 	if h.dispatcher == nil {
@@ -123,6 +133,23 @@ func (h *InitializeHandler) Initialize(w http.ResponseWriter, r *http.Request) {
 		SandboxID: req.SandboxID,
 		TeamID:    teamID,
 	})
+}
+
+// UpdateSandboxEnvVars updates default environment variables for future sandbox processes.
+func (h *InitializeHandler) UpdateSandboxEnvVars(w http.ResponseWriter, r *http.Request) {
+	var req UpdateSandboxEnvVarsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	envVars := map[string]string{}
+	if h.contextManager != nil {
+		h.contextManager.SetSandboxEnvVars(req.EnvVars)
+		if current := h.contextManager.SandboxEnvVars(); current != nil {
+			envVars = current
+		}
+	}
+	writeJSON(w, http.StatusOK, UpdateSandboxEnvVarsResponse{EnvVars: envVars})
 }
 
 func (h *InitializeHandler) configureWebhookWatch(webhookURL, watchDir string) {

--- a/manager/procd/pkg/http/handlers/initialize_test.go
+++ b/manager/procd/pkg/http/handlers/initialize_test.go
@@ -83,3 +83,52 @@ func TestInitializeClearsSandboxEnvVars(t *testing.T) {
 		t.Fatalf("sandbox env vars = %#v, want empty", envVars)
 	}
 }
+
+func TestUpdateSandboxEnvVars(t *testing.T) {
+	dispatcher := webhook.NewDispatcher(webhook.Options{}, zap.NewNop())
+	t.Cleanup(func() {
+		_ = dispatcher.Shutdown(context.Background())
+	})
+	contextManager := ctxpkg.NewManager()
+	handler := NewInitializeHandler(dispatcher, nil, contextManager, 8080, zap.NewNop())
+
+	body, err := json.Marshal(UpdateSandboxEnvVarsRequest{
+		EnvVars: map[string]string{
+			"APP_ENV": "updated",
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/sandbox/env_vars", bytes.NewReader(body))
+	recorder := httptest.NewRecorder()
+	handler.UpdateSandboxEnvVars(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("UpdateSandboxEnvVars() status = %d, want %d body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	if got := contextManager.SandboxEnvVars()["APP_ENV"]; got != "updated" {
+		t.Fatalf("sandbox env APP_ENV = %q, want updated", got)
+	}
+}
+
+func TestUpdateSandboxEnvVarsClearsEnv(t *testing.T) {
+	dispatcher := webhook.NewDispatcher(webhook.Options{}, zap.NewNop())
+	t.Cleanup(func() {
+		_ = dispatcher.Shutdown(context.Background())
+	})
+	contextManager := ctxpkg.NewManager()
+	contextManager.SetSandboxEnvVars(map[string]string{"APP_ENV": "test"})
+	handler := NewInitializeHandler(dispatcher, nil, contextManager, 8080, zap.NewNop())
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/sandbox/env_vars", bytes.NewReader([]byte(`{}`)))
+	recorder := httptest.NewRecorder()
+	handler.UpdateSandboxEnvVars(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("UpdateSandboxEnvVars() status = %d, want %d body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	if envVars := contextManager.SandboxEnvVars(); len(envVars) != 0 {
+		t.Fatalf("sandbox env vars = %#v, want empty", envVars)
+	}
+}

--- a/manager/procd/pkg/http/server.go
+++ b/manager/procd/pkg/http/server.go
@@ -130,6 +130,7 @@ func (s *Server) setupRoutes() {
 	// Initialize handler
 	initializeHandler := handlers.NewInitializeHandler(s.webhookDispatcher, s.fileManager, s.contextManager, s.cfg.HTTPPort, s.logger)
 	api.HandleFunc("/initialize", initializeHandler.Initialize).Methods("POST")
+	api.HandleFunc("/sandbox/env_vars", initializeHandler.UpdateSandboxEnvVars).Methods("PUT")
 
 	// File handlers
 	fileHandler := handlers.NewFileHandler(s.fileManager, s.logger)

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -4184,8 +4184,16 @@ components:
       type: object
       description: |
         Subset of SandboxConfig fields that can be updated at runtime without restarting the sandbox.
-        Note: env_vars and webhook are not included as they only affect new processes or require restart.
+        Note: env_vars only affect new processes. webhook is not included as it requires restart.
       properties:
+        env_vars:
+          type: object
+          additionalProperties:
+            type: string
+          description: |
+            Sandbox-level environment variables used as defaults for new procd-managed
+            processes. Omitting this field preserves the existing environment map; passing
+            an empty object clears it.
         ttl:
           type: integer
           format: int32

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -1780,11 +1780,16 @@ type SandboxTemplateStatus struct {
 }
 
 // SandboxUpdateConfig Subset of SandboxConfig fields that can be updated at runtime without restarting the sandbox.
-// Note: env_vars and webhook are not included as they only affect new processes or require restart.
+// Note: env_vars only affect new processes. webhook is not included as it requires restart.
 type SandboxUpdateConfig struct {
 	// AutoResume Sandbox-level resume gate for paused sandboxes. When false, any inbound request
 	// (API or public exposure) must not auto resume the sandbox.
 	AutoResume *bool `json:"auto_resume,omitempty"`
+
+	// EnvVars Sandbox-level environment variables used as defaults for new procd-managed
+	// processes. Omitting this field preserves the existing environment map; passing
+	// an empty object clears it.
+	EnvVars *map[string]string `json:"env_vars,omitempty"`
 
 	// HardTtl Sandbox hard time-to-live in seconds. When it expires, Sandbox0 deletes the sandbox identity and durable state, including paused rootfs checkpoints.
 	HardTtl  *int32                `json:"hard_ttl,omitempty"`
@@ -1798,7 +1803,7 @@ type SandboxUpdateConfig struct {
 // SandboxUpdateRequest defines model for SandboxUpdateRequest.
 type SandboxUpdateRequest struct {
 	// Config Subset of SandboxConfig fields that can be updated at runtime without restarting the sandbox.
-	// Note: env_vars and webhook are not included as they only affect new processes or require restart.
+	// Note: env_vars only affect new processes. webhook is not included as it requires restart.
 	Config *SandboxUpdateConfig `json:"config,omitempty"`
 }
 


### PR DESCRIPTION
## Summary
- add `config.env_vars` to the runtime sandbox update API with full-replacement semantics
- persist active/paused sandbox env var updates in sandbox config annotations/records
- add an internal procd endpoint so active sandboxes update default env vars for future processes without restart

## Tests
- `make apispec`
- `go test -count=1 ./manager/procd/pkg/http/handlers -run 'Test(Initialize|UpdateSandboxEnvVars)'`
- `go test -count=1 ./manager/pkg/service -run 'TestUpdateSandbox(ZeroTTL|EnvVars)|TestRefreshSandboxDisabledTTL'`

Closes #454
