### PR TITLE
docs: document managed agent env var credentials

### DIFF
--- a/docs/managed-agents/agent-harnesses/page.mdx
+++ b/docs/managed-agents/agent-harnesses/page.mdx
@@ -22,6 +22,8 @@ Use agent in sandbox when you want the agent process itself to live with the wor
 
 Use sandbox as tool when you want to embed an agent into a product workflow or control plane. The agent harness stays in a managed runtime service, while Sandbox0 provides isolated tool execution only when the agent needs to inspect files or run commands.
 
+Vault `environment_variable` credentials are applied to the Sandbox0 sandbox process environment. With `claude` and `codex`, the agent process runs in that sandbox and inherits those variables as placeholders. With `openai-agents`, only sandbox tool processes see them; the resident OpenAI Agents runtime service does not receive those secrets as SDK client or harness configuration.
+
 ## Supported Harnesses
 
 | Harness | Execution model | Runtime adapter | Model API shape | Best fit |

--- a/docs/managed-agents/compatibility/page.mdx
+++ b/docs/managed-agents/compatibility/page.mdx
@@ -17,7 +17,7 @@ Official reference: [Claude Managed Agents quickstart](https://platform.claude.c
 | Deployment runs | Supported for manual and scheduled session creation audit records |
 | Events | Supported for list, send, and event streaming |
 | Files | Supported for upload, metadata, download, delete, and file-backed message content |
-| Vaults and credentials | Supported for LLM credentials, MCP credentials, and Sandbox0 HTTP header credential projection |
+| Vaults and credentials | Supported for LLM credentials, MCP credentials, Sandbox0 HTTP header credential projection, and sandbox environment variable credentials |
 | Custom skills | Supported through uploaded skill versions |
 | MCP servers | Supported for URL MCP servers and vault-backed credentials |
 | GitHub repository resources | Supported at session creation |
@@ -32,6 +32,7 @@ Official reference: [Claude Managed Agents quickstart](https://platform.claude.c
 | API token | SDK `apiKey` is a Sandbox0 API key, not the Anthropic LLM token. |
 | LLM token | Stored in an LLM vault and projected by Sandbox0 credential policy. |
 | Agent harness | Selected by the compatibility key `sandbox0.managed_agents.engine` on the LLM vault. |
+| Environment variable credentials | Stored as sandbox environment placeholders and resolved by Sandbox0 egress auth. They are available to sandbox processes, not as SDK client or harness configuration secrets. |
 | Sandbox claim | Runtime setup claims or resumes a Sandbox0 sandbox and mounts a persistent workspace volume. |
 | Claude harness | Requires an Anthropic-compatible endpoint. |
 | Codex harness | Requires an OpenAI-compatible endpoint. |
@@ -68,6 +69,8 @@ Networking options:
 | `unrestricted` | Sandbox network mode is `allow-all` |
 | `limited` | Sandbox network mode is `block-all` with allowed hosts derived from environment settings, package managers, MCP servers, and session credential bindings |
 
+For `environment_variable` credentials, `auth.networking.type = "unrestricted"` uses the session environment network policy as the egress boundary. `auth.networking.type = "limited"` requires `allowed_hosts`; each entry must be a bare hostname, IPv4 address, or `*.` wildcard hostname, with no scheme, port, or path.
+
 Package managers supported in environment config:
 
 - `apt`
@@ -97,6 +100,10 @@ Only vault metadata supports reserved `sandbox0.managed_agents.*` keys today.
 | `credential` | `role`, `kind=http_headers`, `target_domains`, `headers_json` |
 
 LLM vaults must contain exactly one active `static_bearer` credential and must not set `mcp_server_url`.
+
+Credential vaults may contain `static_bearer`, `mcp_oauth`, or `environment_variable` credentials. `static_bearer` and `mcp_oauth` follow the official Managed Agents MCP credential model when `mcp_server_url` is set. Sandbox0 also uses unbound `static_bearer` credentials for LLM vaults and HTTP header projection vaults as a compatibility extension.
+
+`environment_variable` credentials follow the official Managed Agents auth shape: create them with `auth.secret_name`, write-only `auth.secret_value`, and `auth.networking`. Read APIs return `secret_name` and networking metadata, never `secret_value`. `secret_name` is unique among active credentials in the same vault and immutable after creation.
 
 ## Session Lifecycle Notes
 

--- a/docs/managed-agents/sdk/page.mdx
+++ b/docs/managed-agents/sdk/page.mdx
@@ -129,7 +129,7 @@ Set both `apiKey` and `authToken` to the Sandbox0 API key. The Anthropic SDK can
 </Callout>
 
 <Callout variant="info">
-The `as any` cast on unbound `static_bearer` credentials is intentional for current Anthropic TypeScript SDK types. Sandbox0 LLM credentials must omit `mcp_server_url`.
+The `as any` cast on unbound `static_bearer` credentials is intentional for current Anthropic TypeScript SDK types. Sandbox0 LLM credentials must omit `mcp_server_url`. Do not use this cast for `environment_variable` credentials when using current official SDKs; they are part of the official Managed Agents auth shape.
 </Callout>
 
 ## Direct HTTP Calls

--- a/docs/managed-agents/vaults/page.mdx
+++ b/docs/managed-agents/vaults/page.mdx
@@ -71,7 +71,45 @@ await client.beta.vaults.credentials.create(apiVault.id, {
 });
 ```
 
-Credential vaults can use `static_bearer` or `mcp_oauth` credentials. Sandbox0 resolves secret values and projects headers only for the target domains.
+Credential vaults can use `static_bearer`, `mcp_oauth`, or `environment_variable` credentials. For Sandbox0 HTTP header projection, Sandbox0 resolves secret values and projects headers only for the target domains.
+
+<Callout variant="info">
+Sandbox0 credential vault metadata is still validated as `kind=http_headers`, so provide `target_domains` and `headers_json` when creating the vault. `environment_variable` credentials use the official Managed Agents credential auth shape, but their runtime scope comes from `auth.networking`.
+</Callout>
+
+## Environment Variable Credentials
+
+Use `environment_variable` credentials when a process running inside the sandbox expects a conventional environment variable, such as `OPENAI_API_KEY`, `GITHUB_TOKEN`, or a service-specific SDK token.
+
+```typescript
+await client.beta.vaults.credentials.create(apiVault.id, {
+    display_name: "OpenAI API key",
+    auth: {
+        type: "environment_variable",
+        secret_name: "OPENAI_API_KEY",
+        secret_value: process.env.OPENAI_API_KEY!,
+        networking: {
+            type: "limited",
+            allowed_hosts: ["api.openai.com"],
+        },
+    },
+});
+```
+
+Sandbox0 stores `secret_value` as write-only secret material. At runtime, Sandbox0 sets the sandbox-level environment variable named by `secret_name` to an opaque placeholder. New processes in the sandbox inherit that placeholder through normal process environment behavior. When sandbox HTTP traffic leaves through Sandbox0 egress auth, the placeholder is substituted with the real secret in headers, query parameters, and request bodies for the credential's networking scope.
+
+This credential is for the sandbox, not for the Managed Agents SDK client or harness configuration. Do not pass the real secret to Claude, Codex, or the OpenAI Agents harness. Store it in the vault and let Sandbox0 project it into sandbox processes.
+
+| Networking type | Behavior |
+|-----------------|----------|
+| `unrestricted` | The secret can be substituted on any outbound host allowed by the session environment network policy |
+| `limited` | The secret can be substituted only for `allowed_hosts`; entries must be bare hostnames, IPv4 addresses, or `*.` wildcard hostnames, with no scheme, port, or path |
+
+`secret_name` must be unique among active credentials in the same vault and cannot be changed after creation. Archive the credential and create a replacement if the environment variable name needs to change. A vault can contain at most 20 active credentials.
+
+<Callout variant="warning">
+`environment_variable` credentials require a Sandbox0-backed runtime path. External managed-agent runtimes reject them because they cannot use Sandbox0 sandbox environment injection and egress substitution.
+</Callout>
 
 ## MCP Credentials
 
@@ -90,7 +128,7 @@ await client.beta.vaults.credentials.create(vault.id, {
 
 ## Runtime Injection
 
-Sandbox0 injects credentials through egress auth and compatibility environment variables:
+Sandbox0 injects model provider credentials through egress auth and harness compatibility environment variables:
 
 | Harness | Compatibility environment |
 |--------|---------------------------|
@@ -98,7 +136,9 @@ Sandbox0 injects credentials through egress auth and compatibility environment v
 | `codex` | `CODEX_API_KEY`, `OPENAI_API_KEY`, and `openai_base_url` harness config |
 | `openai-agents` | `OPENAI_API_KEY`, `OPENAI_BASE_URL`, and `openai_base_url` harness config |
 
-The environment variables may contain placeholders. The real token is projected by Sandbox0-managed credential policy when the sandbox contacts the configured host.
+The harness compatibility environment variables may contain placeholders. The real token is projected by Sandbox0-managed credential policy when the sandbox contacts the configured model provider host.
+
+Vault `environment_variable` credentials are separate from these harness compatibility variables. They create user-defined sandbox process environment variables and resolve them through the same egress auth boundary.
 
 For `openai-agents`, the runtime expects an OpenAI Responses-compatible base URL. If the provider exposes a different API shape, use an external AI gateway that presents an OpenAI Responses-compatible endpoint and store the gateway base URL in `sandbox0.managed_agents.llm_base_url`.
 


### PR DESCRIPTION
## Summary
- document official Managed Agents `environment_variable` credential usage in Sandbox0 vault docs
- clarify that env var credentials are injected into sandbox processes, not SDK clients or harness config
- update compatibility and harness docs for claude/codex/openai-agents behavior

## Testing
- git diff --check -- docs/managed-agents

## Notes
- `environment_variable` follows the official Anthropic Managed Agents credential auth shape. The remaining `as any` callouts apply only to Sandbox0 unbound `static_bearer` compatibility extensions.