### PR TITLE
docs: add managed agents files guide

### DIFF
--- a/docs/managed-agents/compatibility/page.mdx
+++ b/docs/managed-agents/compatibility/page.mdx
@@ -16,7 +16,7 @@ Official reference: [Claude Managed Agents quickstart](https://platform.claude.c
 | Deployments | Supported for reusable manual runs and cron scheduled runs |
 | Deployment runs | Supported for manual and scheduled session creation audit records |
 | Events | Supported for list, send, and event streaming |
-| Files | Supported for upload, metadata, download, delete, and file-backed message content |
+| Files | Supported for upload, metadata, download, delete, session-scoped resources, scoped listing, captured output files, and file-backed message content |
 | Vaults and credentials | Supported for LLM credentials, MCP credentials, Sandbox0 HTTP header credential projection, and sandbox environment variable credentials |
 | Custom skills | Supported through uploaded skill versions |
 | MCP servers | Supported for URL MCP servers and vault-backed credentials |
@@ -47,6 +47,19 @@ Official reference: [Claude Managed Agents quickstart](https://platform.claude.c
 | Outcomes and memory research preview | Not implemented in the current backend surface. |
 | Event catalog | Sandbox0 recognizes the current official event catalog for implemented capabilities. Outcome events are excluded, and multi-agent thread events are recognized for SDK compatibility but not emitted by the current backend. |
 | Rate limits | Deployment-specific. Do not assume Anthropic-hosted organization limits apply. |
+
+## Files Compatibility
+
+Sandbox0 implements the Managed Agents Files API as team-scoped storage plus session-scoped file records.
+
+| Capability | Sandbox0 behavior |
+|------------|-------------------|
+| Upload | Stores file bytes in the team asset store and metadata in PostgreSQL |
+| File resources | Creates a new session-scoped file id when an uploaded file is attached to a session |
+| Scoped listing | `files.list` with `scope_id: session.id` returns session-scoped file resources and captured output files |
+| Output files | Captures files under `/mnt/session/outputs` after terminal runs |
+| Download | Supported for uploaded and scoped files |
+| Limits | 500 MB per file, 500 GB per team, 100 Files API requests per minute per team, and 100 session-scoped file resources per session |
 
 ## Tool Support
 

--- a/docs/managed-agents/events/page.mdx
+++ b/docs/managed-agents/events/page.mdx
@@ -147,7 +147,7 @@ Do not send duplicate user input when a session is `rescheduling`. Wait for eith
 
 ## File-Backed Input
 
-Uploaded files can be referenced from message content:
+Uploaded files can be referenced from message content. See [Files](/docs/managed-agents/files) for upload, session-scoped copies, and output files.
 
 ```typescript
 await client.beta.sessions.events.send(session.id, {
@@ -159,6 +159,7 @@ await client.beta.sessions.events.send(session.id, {
                 type: "document",
                 source: { type: "file", file_id: uploaded.id },
                 title: "input",
+                citations: { enabled: true },
             },
         ],
     }],

--- a/docs/managed-agents/files/page.mdx
+++ b/docs/managed-agents/files/page.mdx
@@ -1,0 +1,142 @@
+# Files
+
+Managed Agents files are reusable inputs and session-scoped artifacts for agent runs. Use the official Anthropic SDK against the Sandbox0 Managed Agents endpoint.
+
+Official reference: [Claude Managed Agents files](https://platform.claude.com/docs/en/build-with-claude/files).
+
+Sandbox0 stores file bytes outside PostgreSQL in the team asset store. PostgreSQL remains the metadata and scope source of truth.
+
+## Upload A File
+
+```typescript
+import { toFile } from "@anthropic-ai/sdk";
+
+const uploaded = await client.beta.files.upload({
+    file: await toFile(
+        Buffer.from("hello from managed agents\n"),
+        "input.txt",
+        { type: "text/plain" },
+    ),
+});
+```
+
+The returned object includes the file id, filename, MIME type, size, download flag, optional scope, and creation time.
+
+```typescript
+const metadata = await client.beta.files.retrieveMetadata(uploaded.id);
+
+const files = await client.beta.files.list({
+    limit: 20,
+});
+```
+
+Sandbox0 currently supports downloading file content:
+
+```typescript
+const response = await client.beta.files.download(uploaded.id);
+const text = await response.text();
+```
+
+Delete files that are no longer needed:
+
+```typescript
+await client.beta.files.delete(uploaded.id);
+```
+
+## Attach Files To Sessions
+
+Uploaded files can be attached as session resources:
+
+```typescript
+const resource = await client.beta.sessions.resources.add(session.id, {
+    type: "file",
+    file_id: uploaded.id,
+    mount_path: "/workspace/input.txt",
+});
+```
+
+When a file is attached to a session, Sandbox0 creates a session-scoped copy and returns that scoped file id on the resource. The resource file id is intentionally different from the uploaded file id.
+
+```typescript
+console.log(resource.file_id === uploaded.id); // false
+```
+
+If `mount_path` is omitted, Sandbox0 mounts the scoped file under `/mnt/session/uploads/` using the scoped file id.
+
+## List Session-Scoped Files
+
+Use `scope_id` to list files associated with a session:
+
+```typescript
+const scopedFiles = await client.beta.files.list({
+    scope_id: session.id,
+    limit: 20,
+});
+```
+
+Session-scoped files include:
+
+| Source | Meaning |
+|--------|---------|
+| File resources | Copies created when an uploaded file is attached to a session |
+| Output files | Files captured from `/mnt/session/outputs` after a run reaches a terminal state |
+
+Deleting a file resource removes the session-scoped copy for that resource. Deleting a session removes its scoped files.
+
+## Output Files
+
+Agent runs can write files under `/mnt/session/outputs`. After the run reaches `session.status_idle` with a terminal stop reason, or reaches `session.status_terminated`, Sandbox0 captures those output files into the Files API with `scope.id = session.id`.
+
+```typescript
+const outputs = await client.beta.files.list({
+    scope_id: session.id,
+});
+```
+
+The output file name is derived from the path under `/mnt/session/outputs`. Nested output paths are flattened into safe filenames.
+
+## File-Backed Message Content
+
+Uploaded files can also be referenced directly from user messages:
+
+```typescript
+await client.beta.sessions.events.send(session.id, {
+    events: [{
+        type: "user.message",
+        content: [
+            { type: "text", text: "Summarize this document." },
+            {
+                type: "document",
+                source: { type: "file", file_id: uploaded.id },
+                title: "input",
+                citations: { enabled: true },
+            },
+        ],
+    }],
+});
+```
+
+For file-backed input, use a file id returned by the Files API. Sandbox0 reads the file content and forwards it to the selected harness as model input.
+
+## Limits
+
+| Limit | Value |
+|-------|-------|
+| Single file size | 500 MB |
+| Team file storage | 500 GB |
+| Files API rate limit | 100 requests per minute per team |
+| Session-scoped file resources | 100 per session |
+
+Filenames must be valid UTF-8, must not be empty, must not contain path separators or control characters, and must be at most 500 characters.
+
+## Next Steps
+
+<CardGroup>
+  <Card title="Sessions" href="/docs/managed-agents/sessions" cta="Continue">
+    Create sessions and attach file resources.
+  </Card>
+
+  <Card title="Events" href="/docs/managed-agents/events" cta="Continue">
+    Send file-backed image and document input.
+  </Card>
+</CardGroup>

--- a/docs/managed-agents/page.mdx
+++ b/docs/managed-agents/page.mdx
@@ -89,6 +89,7 @@ The official Claude Managed Agents documentation is still the canonical SDK refe
 - [Agent setup](https://platform.claude.com/docs/en/managed-agents/agent-setup)
 - [Environments](https://platform.claude.com/docs/en/managed-agents/environments)
 - [Sessions](https://platform.claude.com/docs/en/managed-agents/sessions)
+- [Files](https://platform.claude.com/docs/en/build-with-claude/files)
 - [Scheduled deployments](https://platform.claude.com/docs/en/managed-agents/scheduled-deployments)
 - [Vaults](https://platform.claude.com/docs/en/managed-agents/vaults)
 
@@ -103,7 +104,7 @@ The official Claude Managed Agents documentation is still the canonical SDK refe
     Define versioned agents with prompts, tools, MCP servers, and skills.
   </Card>
 
-  <Card title="Deployments" href="/docs/managed-agents/deployments" cta="Continue">
-    Run managed agents manually or on a cron schedule from a reusable definition.
+  <Card title="Files" href="/docs/managed-agents/files" cta="Continue">
+    Upload files, attach them to sessions, and read scoped outputs.
   </Card>
 </CardGroup>

--- a/docs/managed-agents/sessions/page.mdx
+++ b/docs/managed-agents/sessions/page.mdx
@@ -60,6 +60,10 @@ Resources are materialized into the session workspace.
 | `file` | Mount an uploaded file into the workspace |
 | `github_repository` | Clone a repository into the workspace |
 
+File resources are created from Files API uploads. When an uploaded file is attached to a session, Sandbox0 creates a new session-scoped file id for the resource. Use `files.list` with `scope_id: session.id` to list those scoped files and any output files captured for the session.
+
+See [Files](/docs/managed-agents/files) for upload, scoped copy, output file, and limit details.
+
 Repository authorization tokens are accepted on create or update, but are not returned in responses.
 
 ## Lifecycle
@@ -94,11 +98,11 @@ Sandbox0 keeps session state and event history outside the sandbox. The sandbox 
     Append user input, stream agent output, and interpret retry lifecycle events.
   </Card>
 
-  <Card title="Deployments" href="/docs/managed-agents/deployments" cta="Continue">
-    Reuse a session definition for manual or scheduled runs.
+  <Card title="Files" href="/docs/managed-agents/files" cta="Continue">
+    Upload files, attach them to sessions, and read scoped outputs.
   </Card>
 
-  <Card title="Vaults" href="/docs/managed-agents/vaults" cta="Continue">
-    Store model and external service credentials outside agent code.
+  <Card title="Deployments" href="/docs/managed-agents/deployments" cta="Continue">
+    Reuse a session definition for manual or scheduled runs.
   </Card>
 </CardGroup>

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -94,6 +94,10 @@
           "title": "Sessions"
         },
         {
+          "slug": "files",
+          "title": "Files"
+        },
+        {
           "slug": "deployments",
           "title": "Deployments"
         },


### PR DESCRIPTION
## Summary
- add Managed Agents Files documentation covering upload, metadata/list/download/delete, session-scoped file resources, scoped listing, output files, file-backed message input, limits, and filename constraints
- link the Files page from the Managed Agents overview, Sessions, Events, Compatibility, and docs manifest navigation
- document Sandbox0-specific compatibility, including supported downloads and session-scoped file ids that differ from uploaded file ids

## Validation
- jq empty docs/manifest.json
- git diff --check