### PR TITLE
Refactor rootfs pause/resume around COW layers

### DIFF
--- a/ctld/cmd/ctld/main.go
+++ b/ctld/cmd/ctld/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -197,6 +198,7 @@ func buildRootFSController(storageCfg *apiconfig.StorageProxyConfig) ctldserver.
 			ContainerdHostRoot:     containerdHostRoot,
 			ContainerdDataRoot:     containerdDataRoot,
 			ContainerdHostDataRoot: containerdHostDataRoot,
+			RootFSCacheDir:         filepath.Join(portalRoot, "rootfs"),
 			Namespace:              containerdNamespace,
 		}),
 		Store: store,

--- a/ctld/internal/ctld/rootfs/containerd_runtime.go
+++ b/ctld/internal/ctld/rootfs/containerd_runtime.go
@@ -2,6 +2,8 @@ package rootfs
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -16,6 +18,7 @@ import (
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/containerd/v2/core/snapshots"
 	crootfs "github.com/containerd/containerd/v2/pkg/rootfs"
+	"github.com/containerd/continuity/fs"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
@@ -31,6 +34,7 @@ const (
 	defaultContainerdHostRoot     = "/run/containerd"
 	defaultContainerdDataRoot     = "/host-var-lib/containerd"
 	defaultContainerdHostDataRoot = "/var/lib/containerd"
+	defaultRootFSCacheDir         = "/var/lib/sandbox0/ctld/rootfs"
 	defaultNamespace              = "k8s.io"
 	defaultDialTimeout            = 10 * time.Second
 )
@@ -46,6 +50,7 @@ type ContainerdRuntimeConfig struct {
 	ContainerdHostRoot     string
 	ContainerdDataRoot     string
 	ContainerdHostDataRoot string
+	RootFSCacheDir         string
 	Namespace              string
 	DialTimeout            time.Duration
 	CRIClient              criRuntimeService
@@ -60,6 +65,7 @@ type ContainerdRuntime struct {
 	containerdHostRoot     string
 	containerdDataRoot     string
 	containerdHostDataRoot string
+	rootFSCacheDir         string
 	namespace              string
 	dialTimeout            time.Duration
 	criClient              criRuntimeService
@@ -101,6 +107,10 @@ func NewContainerdRuntime(cfg ContainerdRuntimeConfig) *ContainerdRuntime {
 	if containerdHostDataRoot == "" {
 		containerdHostDataRoot = defaultContainerdHostDataRoot
 	}
+	rootFSCacheDir := strings.TrimSpace(cfg.RootFSCacheDir)
+	if rootFSCacheDir == "" {
+		rootFSCacheDir = defaultRootFSCacheDir
+	}
 	namespace := strings.TrimSpace(cfg.Namespace)
 	if namespace == "" {
 		namespace = defaultNamespace
@@ -116,6 +126,7 @@ func NewContainerdRuntime(cfg ContainerdRuntimeConfig) *ContainerdRuntime {
 		containerdHostRoot:     containerdHostRoot,
 		containerdDataRoot:     containerdDataRoot,
 		containerdHostDataRoot: containerdHostDataRoot,
+		rootFSCacheDir:         rootFSCacheDir,
 		namespace:              namespace,
 		dialTimeout:            timeout,
 		criClient:              cfg.CRIClient,
@@ -181,6 +192,32 @@ func (r *ContainerdRuntime) CreateDiff(ctx context.Context, info ctldapi.RootFSI
 	return descriptorFromOCI(desc), closeReadSeekWithFunc{ReadSeekCloser: reader, closeFunc: closeClient}, nil
 }
 
+func (r *ContainerdRuntime) CreateDiffFromBaseline(ctx context.Context, info ctldapi.RootFSInfo, baselineLayerID string) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error) {
+	if strings.TrimSpace(baselineLayerID) == "" {
+		return ctldapi.RootFSDiffDescriptor{}, nil, fmt.Errorf("%w: baseline layer id is required", ErrBadRequest)
+	}
+	client, closeClient, err := r.client(ctx)
+	if err != nil {
+		return ctldapi.RootFSDiffDescriptor{}, nil, err
+	}
+	defer closeClient()
+
+	upperdir, err := r.activeOverlayUpperdir(ctx, client, info)
+	if err != nil {
+		return ctldapi.RootFSDiffDescriptor{}, nil, err
+	}
+	baselineDir := r.rootFSBaselinePath(info, baselineLayerID)
+	if st, err := os.Stat(baselineDir); err != nil {
+		if os.IsNotExist(err) {
+			return ctldapi.RootFSDiffDescriptor{}, nil, fmt.Errorf("%w: rootfs baseline %s is not captured", ErrNotFound, baselineLayerID)
+		}
+		return ctldapi.RootFSDiffDescriptor{}, nil, fmt.Errorf("inspect rootfs baseline: %w", err)
+	} else if !st.IsDir() {
+		return ctldapi.RootFSDiffDescriptor{}, nil, fmt.Errorf("%w: rootfs baseline path is not a directory", ErrConflict)
+	}
+	return writeOverlayUpperDiffFromBaseline(ctx, baselineDir, upperdir)
+}
+
 func (r *ContainerdRuntime) ApplyDiff(ctx context.Context, info ctldapi.RootFSInfo, desc ctldapi.RootFSDiffDescriptor, reader io.Reader) (ctldapi.RootFSDiffDescriptor, error) {
 	if strings.TrimSpace(info.ContainerID) == "" {
 		return ctldapi.RootFSDiffDescriptor{}, fmt.Errorf("%w: container id is required", ErrBadRequest)
@@ -213,6 +250,64 @@ func (r *ContainerdRuntime) ApplyDiff(ctx context.Context, info ctldapi.RootFSIn
 		return ctldapi.RootFSDiffDescriptor{}, err
 	}
 	return descriptorFromOCI(applied), nil
+}
+
+func (r *ContainerdRuntime) CaptureBaseline(ctx context.Context, info ctldapi.RootFSInfo, baselineLayerID string) error {
+	if strings.TrimSpace(baselineLayerID) == "" {
+		return fmt.Errorf("%w: baseline layer id is required", ErrBadRequest)
+	}
+	client, closeClient, err := r.client(ctx)
+	if err != nil {
+		return err
+	}
+	defer closeClient()
+
+	upperdir, err := r.activeOverlayUpperdir(ctx, client, info)
+	if err != nil {
+		return err
+	}
+	target := r.rootFSBaselinePath(info, baselineLayerID)
+	parent := filepath.Dir(target)
+	if err := os.MkdirAll(parent, 0o700); err != nil {
+		return fmt.Errorf("create rootfs baseline parent: %w", err)
+	}
+	tmp, err := os.MkdirTemp(parent, ".baseline-*")
+	if err != nil {
+		return fmt.Errorf("create rootfs baseline temp dir: %w", err)
+	}
+	removeTmp := true
+	defer func() {
+		if removeTmp {
+			_ = os.RemoveAll(tmp)
+		}
+	}()
+	if err := fs.CopyDir(tmp, upperdir); err != nil {
+		return fmt.Errorf("copy rootfs baseline: %w", err)
+	}
+	if err := os.RemoveAll(target); err != nil {
+		return fmt.Errorf("replace rootfs baseline: %w", err)
+	}
+	if err := os.Rename(tmp, target); err != nil {
+		return fmt.Errorf("publish rootfs baseline: %w", err)
+	}
+	removeTmp = false
+	return nil
+}
+
+func (r *ContainerdRuntime) rootFSBaselinePath(info ctldapi.RootFSInfo, baselineLayerID string) string {
+	root := defaultRootFSCacheDir
+	if r != nil && strings.TrimSpace(r.rootFSCacheDir) != "" {
+		root = r.rootFSCacheDir
+	}
+	sum := sha256.Sum256([]byte(strings.Join([]string{
+		info.PodNamespace,
+		info.PodName,
+		info.PodUID,
+		info.ContainerName,
+		info.ContainerID,
+		strings.TrimSpace(baselineLayerID),
+	}, "\x00")))
+	return filepath.Join(root, "baselines", hex.EncodeToString(sum[:]))
 }
 
 func (r *ContainerdRuntime) resolveContainerID(ctx context.Context, target ctldapi.RootFSContainerRef) (string, string, error) {

--- a/ctld/internal/ctld/rootfs/controller.go
+++ b/ctld/internal/ctld/rootfs/controller.go
@@ -24,7 +24,9 @@ var (
 type Runtime interface {
 	Inspect(ctx context.Context, target ctldapi.RootFSContainerRef) (ctldapi.RootFSInfo, error)
 	CreateDiff(ctx context.Context, info ctldapi.RootFSInfo) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error)
+	CreateDiffFromBaseline(ctx context.Context, info ctldapi.RootFSInfo, baselineLayerID string) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error)
 	ApplyDiff(ctx context.Context, info ctldapi.RootFSInfo, desc ctldapi.RootFSDiffDescriptor, content io.Reader) (ctldapi.RootFSDiffDescriptor, error)
+	CaptureBaseline(ctx context.Context, info ctldapi.RootFSInfo, baselineLayerID string) error
 }
 
 type Config struct {
@@ -80,7 +82,7 @@ func (c *Controller) SaveRootFS(r *http.Request, req ctldapi.SaveRootFSRequest) 
 	if err := validateSupportedRuntime(info); err != nil {
 		return ctldapi.SaveRootFSResponse{Info: info, Error: err.Error()}, http.StatusBadRequest
 	}
-	desc, reader, err := c.runtime.CreateDiff(ctx, info)
+	desc, reader, err := c.createDiff(ctx, info, strings.TrimSpace(req.ParentLayerID))
 	if err != nil {
 		return ctldapi.SaveRootFSResponse{Info: info, Error: fmt.Sprintf("create rootfs diff: %v", err)}, statusForError(err)
 	}
@@ -104,7 +106,12 @@ func (c *Controller) ApplyRootFS(r *http.Request, req ctldapi.ApplyRootFSRequest
 	if err := validateTarget(req.Target); err != nil {
 		return ctldapi.ApplyRootFSResponse{Error: err.Error()}, http.StatusBadRequest
 	}
-	if err := validateDescriptor(req.Descriptor); err != nil {
+	layered := len(req.Layers) > 0
+	if layered {
+		if err := validateLayerDescriptors(req.Layers); err != nil {
+			return ctldapi.ApplyRootFSResponse{Error: err.Error()}, http.StatusBadRequest
+		}
+	} else if err := validateDescriptor(req.Descriptor); err != nil {
 		return ctldapi.ApplyRootFSResponse{Error: err.Error()}, http.StatusBadRequest
 	}
 	if c.store == nil {
@@ -124,19 +131,68 @@ func (c *Controller) ApplyRootFS(r *http.Request, req ctldapi.ApplyRootFSRequest
 	if err := validateExpectedBase(info, req); err != nil {
 		return ctldapi.ApplyRootFSResponse{Info: info, Error: err.Error()}, http.StatusConflict
 	}
+	if layered {
+		if err := validateStrictExpectedBase(info, req); err != nil {
+			return ctldapi.ApplyRootFSResponse{Info: info, Error: err.Error()}, http.StatusConflict
+		}
+		if err := validateBaselineLayerID(req); err != nil {
+			return ctldapi.ApplyRootFSResponse{Info: info, Error: err.Error()}, http.StatusBadRequest
+		}
+		applied, err := c.applyLayers(ctx, info, req.Layers)
+		if err != nil {
+			return ctldapi.ApplyRootFSResponse{Info: info, Error: err.Error()}, statusForError(err)
+		}
+		if req.BaselineLayerID != "" {
+			if err := c.runtime.CaptureBaseline(ctx, info, req.BaselineLayerID); err != nil {
+				return ctldapi.ApplyRootFSResponse{Info: info, Error: fmt.Sprintf("capture rootfs baseline: %v", err)}, statusForError(err)
+			}
+		}
+		return ctldapi.ApplyRootFSResponse{Info: info, Layers: applied, Applied: true}, http.StatusOK
+	}
 
-	reader, err := c.store.Get(req.Descriptor.ObjectKey, 0, -1)
+	applied, err := c.applyDescriptor(ctx, info, req.Descriptor)
 	if err != nil {
-		return ctldapi.ApplyRootFSResponse{Info: info, Error: fmt.Sprintf("download rootfs diff: %v", err)}, http.StatusInternalServerError
+		return ctldapi.ApplyRootFSResponse{Info: info, Error: err.Error()}, statusForError(err)
+	}
+	return ctldapi.ApplyRootFSResponse{Info: info, Descriptor: applied, Applied: true}, http.StatusOK
+}
+
+func (c *Controller) createDiff(ctx context.Context, info ctldapi.RootFSInfo, parentLayerID string) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error) {
+	if parentLayerID != "" {
+		return c.runtime.CreateDiffFromBaseline(ctx, info, parentLayerID)
+	}
+	return c.runtime.CreateDiff(ctx, info)
+}
+
+func (c *Controller) applyLayers(ctx context.Context, info ctldapi.RootFSInfo, layers []ctldapi.RootFSLayerDescriptor) ([]ctldapi.RootFSLayerDescriptor, error) {
+	applied := make([]ctldapi.RootFSLayerDescriptor, 0, len(layers))
+	for _, layer := range layers {
+		desc, err := c.applyDescriptor(ctx, info, layer.Descriptor)
+		if err != nil {
+			return nil, err
+		}
+		applied = append(applied, ctldapi.RootFSLayerDescriptor{
+			LayerID:       layer.LayerID,
+			ParentLayerID: layer.ParentLayerID,
+			Descriptor:    desc,
+		})
+	}
+	return applied, nil
+}
+
+func (c *Controller) applyDescriptor(ctx context.Context, info ctldapi.RootFSInfo, desc ctldapi.RootFSDiffDescriptor) (ctldapi.RootFSDiffDescriptor, error) {
+	reader, err := c.store.Get(desc.ObjectKey, 0, -1)
+	if err != nil {
+		return ctldapi.RootFSDiffDescriptor{}, fmt.Errorf("download rootfs diff: %w", err)
 	}
 	defer reader.Close()
 
-	applied, err := c.runtime.ApplyDiff(ctx, info, req.Descriptor, reader)
+	applied, err := c.runtime.ApplyDiff(ctx, info, desc, reader)
 	if err != nil {
-		return ctldapi.ApplyRootFSResponse{Info: info, Error: fmt.Sprintf("apply rootfs diff: %v", err)}, statusForError(err)
+		return ctldapi.RootFSDiffDescriptor{}, fmt.Errorf("apply rootfs diff: %w", err)
 	}
-	applied.ObjectKey = req.Descriptor.ObjectKey
-	return ctldapi.ApplyRootFSResponse{Info: info, Descriptor: applied, Applied: true}, http.StatusOK
+	applied.ObjectKey = desc.ObjectKey
+	return applied, nil
 }
 
 func (c *Controller) inspect(ctx context.Context, target ctldapi.RootFSContainerRef) (ctldapi.RootFSInfo, error) {
@@ -190,6 +246,33 @@ func validateDescriptor(desc ctldapi.RootFSDiffDescriptor) error {
 	return nil
 }
 
+func validateLayerDescriptors(layers []ctldapi.RootFSLayerDescriptor) error {
+	if len(layers) == 0 {
+		return fmt.Errorf("%w: layers are required", ErrBadRequest)
+	}
+	seen := make(map[string]struct{}, len(layers))
+	for i, layer := range layers {
+		layerID := strings.TrimSpace(layer.LayerID)
+		if layerID == "" {
+			return fmt.Errorf("%w: layers[%d].layer_id is required", ErrBadRequest, i)
+		}
+		if _, ok := seen[layerID]; ok {
+			return fmt.Errorf("%w: duplicate rootfs layer %q", ErrBadRequest, layerID)
+		}
+		seen[layerID] = struct{}{}
+		if strings.TrimSpace(layer.ParentLayerID) == layerID {
+			return fmt.Errorf("%w: layers[%d].parent_layer_id cannot reference itself", ErrBadRequest, i)
+		}
+		if i > 0 && strings.TrimSpace(layer.ParentLayerID) != strings.TrimSpace(layers[i-1].LayerID) {
+			return fmt.Errorf("%w: layers[%d].parent_layer_id must reference previous layer", ErrBadRequest, i)
+		}
+		if err := validateDescriptor(layer.Descriptor); err != nil {
+			return fmt.Errorf("%w: layers[%d]: %v", ErrBadRequest, i, err)
+		}
+	}
+	return nil
+}
+
 func validateSupportedRuntime(info ctldapi.RootFSInfo) error {
 	runtime := strings.ToLower(strings.TrimSpace(info.Runtime))
 	switch runtime {
@@ -213,6 +296,45 @@ func validateExpectedBase(info ctldapi.RootFSInfo, req ctldapi.ApplyRootFSReques
 		return fmt.Errorf("%w: snapshotter mismatch: expected %s, got %s", ErrConflict, expected, info.Snapshotter)
 	}
 	return nil
+}
+
+func validateStrictExpectedBase(info ctldapi.RootFSInfo, req ctldapi.ApplyRootFSRequest) error {
+	if expected := strings.TrimSpace(req.ExpectedBaseImageDigest); expected != "" && strings.TrimSpace(info.BaseImageDigest) != expected {
+		return fmt.Errorf("%w: base image digest mismatch: expected %s, got %s", ErrConflict, expected, info.BaseImageDigest)
+	}
+	if expected := strings.TrimSpace(req.ExpectedSnapshotParent); expected != "" && strings.TrimSpace(info.SnapshotParent) != expected {
+		return fmt.Errorf("%w: snapshot parent mismatch: expected %s, got %s", ErrConflict, expected, info.SnapshotParent)
+	}
+	if len(req.ExpectedSnapshotParentChain) > 0 && !equalStringSlices(req.ExpectedSnapshotParentChain, info.SnapshotParentChain) {
+		return fmt.Errorf("%w: snapshot parent chain mismatch", ErrConflict)
+	}
+	return nil
+}
+
+func validateBaselineLayerID(req ctldapi.ApplyRootFSRequest) error {
+	if strings.TrimSpace(req.BaselineLayerID) == "" {
+		return nil
+	}
+	if len(req.Layers) == 0 {
+		return fmt.Errorf("%w: baseline_layer_id requires layers", ErrBadRequest)
+	}
+	head := strings.TrimSpace(req.Layers[len(req.Layers)-1].LayerID)
+	if strings.TrimSpace(req.BaselineLayerID) != head {
+		return fmt.Errorf("%w: baseline_layer_id must match the head layer", ErrBadRequest)
+	}
+	return nil
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if strings.TrimSpace(a[i]) != strings.TrimSpace(b[i]) {
+			return false
+		}
+	}
+	return true
 }
 
 func defaultObjectKey(teamID, sandboxID string, generation int64, digest string) (string, error) {

--- a/ctld/internal/ctld/rootfs/controller_test.go
+++ b/ctld/internal/ctld/rootfs/controller_test.go
@@ -69,6 +69,39 @@ func TestControllerSaveRootFSUploadsDiffWithDefaultObjectKey(t *testing.T) {
 	assert.Equal(t, "rootfs diff", string(payload))
 }
 
+func TestControllerSaveRootFSUsesParentBaseline(t *testing.T) {
+	store := objectstore.NewMemoryStore(t.Name())
+	runtime := &fakeRuntime{
+		info: rootFSInfo("runc"),
+		createBaselineDesc: ctldapi.RootFSDiffDescriptor{
+			MediaType: "application/vnd.oci.image.layer.v1.tar",
+			Digest:    "sha256:child",
+			Size:      int64(len("child diff")),
+		},
+		createBaselineContent: "child diff",
+	}
+	controller := NewController(Config{Runtime: runtime, Store: store})
+
+	resp, status := controller.SaveRootFS(httptest.NewRequest(http.MethodPost, "/", nil), ctldapi.SaveRootFSRequest{
+		Target:        rootFSTarget(),
+		SandboxID:     "sandbox-1",
+		TeamID:        "team-1",
+		ParentLayerID: "layer-parent",
+	})
+
+	require.Equal(t, http.StatusOK, status, resp.Error)
+	assert.True(t, runtime.createBaselineCalled)
+	assert.False(t, runtime.createCalled)
+	assert.Equal(t, "layer-parent", runtime.createBaselineLayerID)
+	assert.Equal(t, "sandbox-rootfs/team-1/sandbox-1/0/sha256/child.tar", resp.Descriptor.ObjectKey)
+	reader, err := store.Get(resp.Descriptor.ObjectKey, 0, -1)
+	require.NoError(t, err)
+	defer reader.Close()
+	payload, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	assert.Equal(t, "child diff", string(payload))
+}
+
 func TestControllerSaveRootFSRejectsUnsupportedRuntime(t *testing.T) {
 	runtime := &fakeRuntime{
 		info:          rootFSInfo("kata"),
@@ -124,6 +157,66 @@ func TestControllerApplyRootFSDownloadsAndAppliesDiff(t *testing.T) {
 	assert.Equal(t, "rootfs/diff.tar", runtime.applyInputDesc.ObjectKey)
 }
 
+func TestControllerApplyRootFSAppliesLayerChainAndCapturesBaseline(t *testing.T) {
+	store := objectstore.NewMemoryStore(t.Name())
+	require.NoError(t, store.Put("rootfs/parent.tar", strings.NewReader("parent diff")))
+	require.NoError(t, store.Put("rootfs/child.tar", strings.NewReader("child diff")))
+	runtime := &fakeRuntime{
+		info: rootFSInfo("runc"),
+		applyDesc: ctldapi.RootFSDiffDescriptor{
+			MediaType: "application/vnd.oci.image.layer.v1.tar",
+			Digest:    "sha256:applied",
+			Size:      int64(len("applied")),
+		},
+	}
+	controller := NewController(Config{Runtime: runtime, Store: store})
+
+	resp, status := controller.ApplyRootFS(httptest.NewRequest(http.MethodPost, "/", nil), ctldapi.ApplyRootFSRequest{
+		Target:                      rootFSTarget(),
+		ExpectedRuntime:             "runc",
+		ExpectedRuntimeHandler:      "runc",
+		ExpectedSnapshotter:         "overlayfs",
+		ExpectedBaseImageDigest:     "sha256:base",
+		ExpectedSnapshotParent:      "parent-1",
+		ExpectedSnapshotParentChain: []string{"parent-1", "parent-0"},
+		BaselineLayerID:             "layer-child",
+		Layers: []ctldapi.RootFSLayerDescriptor{
+			{
+				LayerID: "layer-parent",
+				Descriptor: ctldapi.RootFSDiffDescriptor{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    "sha256:parent",
+					Size:      int64(len("parent diff")),
+					ObjectKey: "rootfs/parent.tar",
+				},
+			},
+			{
+				LayerID:       "layer-child",
+				ParentLayerID: "layer-parent",
+				Descriptor: ctldapi.RootFSDiffDescriptor{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    "sha256:child",
+					Size:      int64(len("child diff")),
+					ObjectKey: "rootfs/child.tar",
+				},
+			},
+		},
+	})
+
+	require.Equal(t, http.StatusOK, status, resp.Error)
+	assert.True(t, resp.Applied)
+	require.Len(t, resp.Layers, 2)
+	assert.Equal(t, "rootfs/parent.tar", resp.Layers[0].Descriptor.ObjectKey)
+	assert.Equal(t, "rootfs/child.tar", resp.Layers[1].Descriptor.ObjectKey)
+	assert.Equal(t, []string{"parent diff", "child diff"}, runtime.applyContents)
+	require.Len(t, runtime.applyInputDescs, 2)
+	assert.Equal(t, "rootfs/parent.tar", runtime.applyInputDescs[0].ObjectKey)
+	assert.Equal(t, "rootfs/child.tar", runtime.applyInputDescs[1].ObjectKey)
+	assert.True(t, runtime.captureBaselineCalled)
+	assert.Equal(t, "layer-child", runtime.captureBaselineLayerID)
+	assert.Equal(t, rootFSInfo("runc"), runtime.captureInfo)
+}
+
 func TestControllerApplyRootFSForceAppliesBaseMismatch(t *testing.T) {
 	store := objectstore.NewMemoryStore(t.Name())
 	require.NoError(t, store.Put("rootfs/diff.tar", strings.NewReader("rootfs diff")))
@@ -154,6 +247,31 @@ func TestControllerApplyRootFSForceAppliesBaseMismatch(t *testing.T) {
 	assert.True(t, resp.Applied)
 	assert.True(t, runtime.applyCalled)
 	assert.Equal(t, "rootfs diff", runtime.applyContent)
+}
+
+func TestControllerApplyRootFSLayerChainRejectsBaseMismatch(t *testing.T) {
+	store := objectstore.NewMemoryStore(t.Name())
+	require.NoError(t, store.Put("rootfs/diff.tar", strings.NewReader("rootfs diff")))
+	runtime := &fakeRuntime{info: rootFSInfo("runc")}
+	controller := NewController(Config{Runtime: runtime, Store: store})
+
+	resp, status := controller.ApplyRootFS(httptest.NewRequest(http.MethodPost, "/", nil), ctldapi.ApplyRootFSRequest{
+		Target:                  rootFSTarget(),
+		ExpectedBaseImageDigest: "sha256:other-base",
+		Layers: []ctldapi.RootFSLayerDescriptor{{
+			LayerID: "layer-1",
+			Descriptor: ctldapi.RootFSDiffDescriptor{
+				MediaType: "application/vnd.oci.image.layer.v1.tar",
+				Digest:    "sha256:feedface",
+				Size:      int64(len("rootfs diff")),
+				ObjectKey: "rootfs/diff.tar",
+			},
+		}},
+	})
+
+	require.Equal(t, http.StatusConflict, status)
+	assert.Contains(t, resp.Error, "base image digest mismatch")
+	assert.False(t, runtime.applyCalled)
 }
 
 func TestControllerApplyRootFSRejectsRuntimeMismatch(t *testing.T) {
@@ -227,21 +345,33 @@ func TestControllerApplyRootFSRejectsMissingDescriptorObjectKey(t *testing.T) {
 }
 
 type fakeRuntime struct {
-	info          ctldapi.RootFSInfo
-	inspectErr    error
-	createDesc    ctldapi.RootFSDiffDescriptor
-	createContent string
-	createErr     error
-	applyDesc     ctldapi.RootFSDiffDescriptor
-	applyErr      error
+	info                  ctldapi.RootFSInfo
+	inspectErr            error
+	createDesc            ctldapi.RootFSDiffDescriptor
+	createContent         string
+	createErr             error
+	createBaselineDesc    ctldapi.RootFSDiffDescriptor
+	createBaselineContent string
+	createBaselineErr     error
+	applyDesc             ctldapi.RootFSDiffDescriptor
+	applyErr              error
+	captureBaselineErr    error
 
-	inspectTargets []ctldapi.RootFSContainerRef
-	createCalled   bool
-	createInfo     ctldapi.RootFSInfo
-	applyCalled    bool
-	applyInfo      ctldapi.RootFSInfo
-	applyInputDesc ctldapi.RootFSDiffDescriptor
-	applyContent   string
+	inspectTargets         []ctldapi.RootFSContainerRef
+	createCalled           bool
+	createInfo             ctldapi.RootFSInfo
+	createBaselineCalled   bool
+	createBaselineInfo     ctldapi.RootFSInfo
+	createBaselineLayerID  string
+	applyCalled            bool
+	applyInfo              ctldapi.RootFSInfo
+	applyInputDesc         ctldapi.RootFSDiffDescriptor
+	applyContent           string
+	applyInputDescs        []ctldapi.RootFSDiffDescriptor
+	applyContents          []string
+	captureBaselineCalled  bool
+	captureInfo            ctldapi.RootFSInfo
+	captureBaselineLayerID string
 }
 
 func (r *fakeRuntime) Inspect(_ context.Context, target ctldapi.RootFSContainerRef) (ctldapi.RootFSInfo, error) {
@@ -258,19 +388,38 @@ func (r *fakeRuntime) CreateDiff(_ context.Context, info ctldapi.RootFSInfo) (ct
 	return r.createDesc, readSeekNopCloser{Reader: strings.NewReader(r.createContent)}, nil
 }
 
+func (r *fakeRuntime) CreateDiffFromBaseline(_ context.Context, info ctldapi.RootFSInfo, baselineLayerID string) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error) {
+	r.createBaselineCalled = true
+	r.createBaselineInfo = info
+	r.createBaselineLayerID = baselineLayerID
+	if r.createBaselineErr != nil {
+		return ctldapi.RootFSDiffDescriptor{}, nil, r.createBaselineErr
+	}
+	return r.createBaselineDesc, readSeekNopCloser{Reader: strings.NewReader(r.createBaselineContent)}, nil
+}
+
 func (r *fakeRuntime) ApplyDiff(_ context.Context, info ctldapi.RootFSInfo, desc ctldapi.RootFSDiffDescriptor, content io.Reader) (ctldapi.RootFSDiffDescriptor, error) {
 	r.applyCalled = true
 	r.applyInfo = info
 	r.applyInputDesc = desc
+	r.applyInputDescs = append(r.applyInputDescs, desc)
 	payload, err := io.ReadAll(content)
 	if err != nil {
 		return ctldapi.RootFSDiffDescriptor{}, err
 	}
 	r.applyContent = string(payload)
+	r.applyContents = append(r.applyContents, string(payload))
 	if r.applyErr != nil {
 		return ctldapi.RootFSDiffDescriptor{}, r.applyErr
 	}
 	return r.applyDesc, nil
+}
+
+func (r *fakeRuntime) CaptureBaseline(_ context.Context, info ctldapi.RootFSInfo, baselineLayerID string) error {
+	r.captureBaselineCalled = true
+	r.captureInfo = info
+	r.captureBaselineLayerID = baselineLayerID
+	return r.captureBaselineErr
 }
 
 func rootFSTarget() ctldapi.RootFSContainerRef {

--- a/ctld/internal/ctld/rootfs/overlay_diff.go
+++ b/ctld/internal/ctld/rootfs/overlay_diff.go
@@ -24,31 +24,42 @@ func (r *ContainerdRuntime) createOverlayUpperDiff(ctx context.Context, client c
 	if strings.TrimSpace(info.Snapshotter) != "overlayfs" {
 		return ctldapi.RootFSDiffDescriptor{}, nil, false, nil
 	}
-	snapshotter := client.SnapshotService(info.Snapshotter)
-	if snapshotter == nil {
-		return ctldapi.RootFSDiffDescriptor{}, nil, true, fmt.Errorf("overlayfs snapshotter is not configured")
-	}
-	snapshotInfo, err := snapshotter.Stat(ctx, info.SnapshotKey)
-	if err != nil {
-		return ctldapi.RootFSDiffDescriptor{}, nil, true, fmt.Errorf("inspect overlayfs snapshot: %w", err)
-	}
-	if snapshotInfo.Kind != snapshots.KindActive {
-		return ctldapi.RootFSDiffDescriptor{}, nil, false, nil
-	}
-	mounts, err := snapshotter.Mounts(ctx, info.SnapshotKey)
-	if err != nil {
-		return ctldapi.RootFSDiffDescriptor{}, nil, true, fmt.Errorf("inspect overlayfs mounts: %w", err)
-	}
-	upperdir, ok := overlayUpperdir(mounts)
-	if !ok {
-		return ctldapi.RootFSDiffDescriptor{}, nil, false, nil
-	}
-	mountedUpperdir, err := r.mountedContainerdDataPath(upperdir)
+	upperdir, err := r.activeOverlayUpperdir(ctx, client, info)
 	if err != nil {
 		return ctldapi.RootFSDiffDescriptor{}, nil, true, err
 	}
-	desc, reader, err := writeOverlayUpperDiff(ctx, mountedUpperdir)
+	desc, reader, err := writeOverlayUpperDiff(ctx, upperdir)
 	return desc, reader, true, err
+}
+
+func (r *ContainerdRuntime) activeOverlayUpperdir(ctx context.Context, client containerdClient, info ctldapi.RootFSInfo) (string, error) {
+	if strings.TrimSpace(info.Snapshotter) != "overlayfs" {
+		return "", fmt.Errorf("%w: rootfs baseline requires overlayfs snapshotter", ErrBadRequest)
+	}
+	snapshotter := client.SnapshotService(info.Snapshotter)
+	if snapshotter == nil {
+		return "", fmt.Errorf("overlayfs snapshotter is not configured")
+	}
+	snapshotInfo, err := snapshotter.Stat(ctx, info.SnapshotKey)
+	if err != nil {
+		return "", fmt.Errorf("inspect overlayfs snapshot: %w", err)
+	}
+	if snapshotInfo.Kind != snapshots.KindActive {
+		return "", fmt.Errorf("%w: rootfs snapshot %s is not active", ErrBadRequest, info.SnapshotKey)
+	}
+	mounts, err := snapshotter.Mounts(ctx, info.SnapshotKey)
+	if err != nil {
+		return "", fmt.Errorf("inspect overlayfs mounts: %w", err)
+	}
+	upperdir, ok := overlayUpperdir(mounts)
+	if !ok {
+		return "", fmt.Errorf("%w: overlayfs upperdir is not available", ErrBadRequest)
+	}
+	mountedUpperdir, err := r.mountedContainerdDataPath(upperdir)
+	if err != nil {
+		return "", err
+	}
+	return mountedUpperdir, nil
 }
 
 func overlayUpperdir(mounts []mount.Mount) (string, bool) {
@@ -117,6 +128,46 @@ func rebasePath(path, fromRoot, toRoot string) (string, bool) {
 }
 
 func writeOverlayUpperDiff(ctx context.Context, upperdir string) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error) {
+	return writeOverlayDiffTar(upperdir, func(changeFn fs.ChangeFunc) error {
+		return walkOverlayUpper(ctx, upperdir, changeFn)
+	})
+}
+
+func writeOverlayUpperDiffFromBaseline(ctx context.Context, baselineDir, upperdir string) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error) {
+	return writeOverlayDiffTar(upperdir, func(changeFn fs.ChangeFunc) error {
+		return fs.Changes(ctx, baselineDir, upperdir, func(kind fs.ChangeKind, path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
+			if kind == fs.ChangeKindDelete {
+				return changeFn(kind, path, nil, nil)
+			}
+			if isOverlayWhiteout(info) {
+				return changeFn(fs.ChangeKindDelete, path, nil, nil)
+			}
+			if info != nil && info.IsDir() {
+				sourcePath := filepath.Join(upperdir, strings.TrimPrefix(path, string(filepath.Separator)))
+				opaque, err := isOverlayOpaqueDir(sourcePath)
+				if err != nil {
+					return err
+				}
+				if opaque {
+					if err := changeFn(fs.ChangeKindDelete, filepath.Join(path, ".wh..opq"), nil, nil); err != nil {
+						return err
+					}
+				}
+			}
+			return changeFn(kind, path, info, nil)
+		})
+	})
+}
+
+func writeOverlayDiffTar(source string, walkChanges func(fs.ChangeFunc) error) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error) {
 	tmp, err := os.CreateTemp("", "sandbox0-rootfs-overlay-diff-*.tar")
 	if err != nil {
 		return ctldapi.RootFSDiffDescriptor{}, nil, err
@@ -131,8 +182,8 @@ func writeOverlayUpperDiff(ctx context.Context, upperdir string) (ctldapi.RootFS
 
 	digester := digest.Canonical.Digester()
 	writer := io.MultiWriter(tmp, digester.Hash())
-	cw := archive.NewChangeWriter(writer, upperdir)
-	if err := walkOverlayUpper(ctx, upperdir, cw.HandleChange); err != nil {
+	cw := archive.NewChangeWriter(writer, source)
+	if err := walkChanges(cw.HandleChange); err != nil {
 		_ = cw.Close()
 		return ctldapi.RootFSDiffDescriptor{}, nil, err
 	}

--- a/ctld/internal/ctld/rootfs/overlay_diff_test.go
+++ b/ctld/internal/ctld/rootfs/overlay_diff_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/containerd/containerd/v2/pkg/archive"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
@@ -80,6 +81,41 @@ func TestWriteOverlayUpperDiffConvertsOpaqueDirectories(t *testing.T) {
 	assert.Contains(t, entries, "var/")
 }
 
+func TestWriteOverlayUpperDiffFromBaselineAppliesAsChildDelta(t *testing.T) {
+	ctx := context.Background()
+	baseline := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(baseline, "etc"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(baseline, "etc", "config"), []byte("parent"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(baseline, "etc", "removed"), []byte("removed"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(baseline, "etc", "same"), []byte("same"), 0o644))
+
+	current := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(current, "etc"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(current, "etc", "config"), []byte("child"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(current, "etc", "added"), []byte("added"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(current, "etc", "same"), []byte("same"), 0o644))
+
+	desc, reader, err := writeOverlayUpperDiffFromBaseline(ctx, baseline, current)
+	require.NoError(t, err)
+	defer reader.Close()
+	require.NotEmpty(t, desc.Digest)
+	require.Positive(t, desc.Size)
+
+	applied := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(applied, "etc"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(applied, "etc", "config"), []byte("parent"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(applied, "etc", "removed"), []byte("removed"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(applied, "etc", "same"), []byte("same"), 0o644))
+
+	_, err = archive.Apply(ctx, applied, reader)
+	require.NoError(t, err)
+	assertFileContent(t, filepath.Join(applied, "etc", "config"), "child")
+	assertFileContent(t, filepath.Join(applied, "etc", "added"), "added")
+	assertFileContent(t, filepath.Join(applied, "etc", "same"), "same")
+	_, err = os.Stat(filepath.Join(applied, "etc", "removed"))
+	assert.True(t, os.IsNotExist(err))
+}
+
 func readTarEntries(t *testing.T, reader io.Reader) []string {
 	t.Helper()
 	tarReader := tar.NewReader(reader)
@@ -92,4 +128,11 @@ func readTarEntries(t *testing.T, reader io.Reader) []string {
 		require.NoError(t, err)
 		entries = append(entries, header.Name)
 	}
+}
+
+func assertFileContent(t *testing.T, path, want string) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, want, string(got))
 }

--- a/manager/pkg/service/migrations/00003_add_rootfs_layer_graph.sql
+++ b/manager/pkg/service/migrations/00003_add_rootfs_layer_graph.sql
@@ -1,0 +1,68 @@
+-- +goose Up
+
+CREATE TABLE IF NOT EXISTS rootfs_layers (
+    layer_id TEXT PRIMARY KEY,
+    parent_layer_id TEXT REFERENCES rootfs_layers(layer_id) ON DELETE RESTRICT,
+    source_sandbox_id TEXT NOT NULL DEFAULT '',
+    team_id TEXT NOT NULL,
+    runtime_generation BIGINT NOT NULL,
+    runtime TEXT NOT NULL DEFAULT '',
+    runtime_handler TEXT NOT NULL DEFAULT '',
+    base_image_ref TEXT NOT NULL DEFAULT '',
+    base_image_digest TEXT NOT NULL DEFAULT '',
+    snapshotter TEXT NOT NULL DEFAULT '',
+    snapshot_parent TEXT NOT NULL DEFAULT '',
+    snapshot_parent_chain JSONB NOT NULL DEFAULT '[]',
+    diff_digest TEXT NOT NULL,
+    diff_id TEXT NOT NULL DEFAULT '',
+    diff_media_type TEXT NOT NULL DEFAULT '',
+    diff_size BIGINT NOT NULL DEFAULT 0,
+    diff_object_key TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_rootfs_layers_team_created
+    ON rootfs_layers(team_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_rootfs_layers_parent
+    ON rootfs_layers(parent_layer_id)
+    WHERE parent_layer_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS sandbox_rootfs_heads (
+    sandbox_id TEXT PRIMARY KEY REFERENCES sandboxes(sandbox_id) ON DELETE CASCADE,
+    team_id TEXT NOT NULL,
+    head_layer_id TEXT NOT NULL REFERENCES rootfs_layers(layer_id) ON DELETE RESTRICT,
+    runtime_generation BIGINT NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_sandbox_rootfs_heads_team_updated
+    ON sandbox_rootfs_heads(team_id, updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS rootfs_snapshots (
+    snapshot_id TEXT PRIMARY KEY,
+    team_id TEXT NOT NULL,
+    source_sandbox_id TEXT NOT NULL DEFAULT '',
+    head_layer_id TEXT NOT NULL REFERENCES rootfs_layers(layer_id) ON DELETE RESTRICT,
+    name TEXT NOT NULL DEFAULT '',
+    description TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    expires_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_rootfs_snapshots_team_created
+    ON rootfs_snapshots(team_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_rootfs_snapshots_head
+    ON rootfs_snapshots(head_layer_id);
+
+-- +goose Down
+
+DROP INDEX IF EXISTS idx_rootfs_snapshots_head;
+DROP INDEX IF EXISTS idx_rootfs_snapshots_team_created;
+DROP TABLE IF EXISTS rootfs_snapshots;
+DROP INDEX IF EXISTS idx_sandbox_rootfs_heads_team_updated;
+DROP TABLE IF EXISTS sandbox_rootfs_heads;
+DROP INDEX IF EXISTS idx_rootfs_layers_parent;
+DROP INDEX IF EXISTS idx_rootfs_layers_team_created;
+DROP TABLE IF EXISTS rootfs_layers;

--- a/manager/pkg/service/sandbox_runtime_identity_test.go
+++ b/manager/pkg/service/sandbox_runtime_identity_test.go
@@ -186,7 +186,41 @@ func cloneSandboxRootFSState(state *SandboxRootFSState) *SandboxRootFSState {
 	if state.SnapshotParentChain != nil {
 		clone.SnapshotParentChain = append([]string(nil), state.SnapshotParentChain...)
 	}
+	clone.LayerChain = cloneSandboxRootFSLayers(state.LayerChain)
 	return &clone
+}
+
+func TestRootFSStateFromLayerChainKeepsCurrentSandboxID(t *testing.T) {
+	state := rootFSStateFromLayerChain("child-sandbox", []*SandboxRootFSLayer{
+		{
+			ID:              "layer-parent",
+			SourceSandboxID: "parent-sandbox",
+			TeamID:          "team-1",
+			DiffDigest:      "sha256:parent",
+			DiffObjectKey:   "rootfs/parent.tar",
+		},
+		{
+			ID:              "layer-child",
+			ParentLayerID:   "layer-parent",
+			SourceSandboxID: "parent-sandbox",
+			TeamID:          "team-1",
+			DiffDigest:      "sha256:child",
+			DiffObjectKey:   "rootfs/child.tar",
+		},
+	})
+
+	if state == nil {
+		t.Fatal("state is nil")
+	}
+	if state.SandboxID != "child-sandbox" {
+		t.Fatalf("SandboxID = %q, want child-sandbox", state.SandboxID)
+	}
+	if state.LayerID != "layer-child" || state.ParentLayerID != "layer-parent" {
+		t.Fatalf("head = %q parent = %q, want layer-child/layer-parent", state.LayerID, state.ParentLayerID)
+	}
+	if len(state.LayerChain) != 2 {
+		t.Fatalf("LayerChain len = %d, want 2", len(state.LayerChain))
+	}
 }
 
 func TestSandboxIndexTracksMultipleRuntimePodsForSameSandbox(t *testing.T) {

--- a/manager/pkg/service/sandbox_service_restore.go
+++ b/manager/pkg/service/sandbox_service_restore.go
@@ -134,8 +134,7 @@ func (s *SandboxService) finishRestoredSandboxRuntime(ctx context.Context, pod *
 	if err != nil {
 		return fmt.Errorf("load rootfs checkpoint: %w", err)
 	}
-	pod, err = s.applySandboxRootFSCheckpointWithFallback(ctx, pod, record, template, req, rootFSState)
-	if err != nil {
+	if err := s.applySandboxRootFSCheckpoint(ctx, pod, rootFSState); err != nil {
 		return err
 	}
 	if _, err := s.bindVolumePortals(ctx, pod, req, template); err != nil {

--- a/manager/pkg/service/sandbox_service_rootfs.go
+++ b/manager/pkg/service/sandbox_service_rootfs.go
@@ -2,15 +2,15 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
-	godigest "github.com/opencontainers/go-digest"
-	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
+	"github.com/google/uuid"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
-	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -45,12 +45,25 @@ func (s *SandboxService) saveSandboxRootFSCheckpoint(ctx context.Context, pod *c
 		return err
 	}
 	generation := runtimeGenerationFromPod(pod)
-	resp, err := s.ctldClient.SaveRootFSWithTimeout(ctx, ctldAddress, ctldapi.SaveRootFSRequest{
+	parentLayerID := ""
+	if parentState, err := s.latestRootFSState(ctx, sandboxID); err != nil {
+		return fmt.Errorf("load current rootfs head: %w", err)
+	} else if parentState != nil {
+		parentLayerID = strings.TrimSpace(parentState.LayerID)
+	}
+	saveReq := ctldapi.SaveRootFSRequest{
 		Target:                    rootFSTargetForPod(pod),
 		SandboxID:                 sandboxID,
 		TeamID:                    teamID,
 		ExpectedRuntimeGeneration: generation,
-	}, sandboxRootFSOperationTimeout)
+		ParentLayerID:             parentLayerID,
+	}
+	resp, err := s.ctldClient.SaveRootFSWithTimeout(ctx, ctldAddress, saveReq, sandboxRootFSOperationTimeout)
+	if err != nil && parentLayerID != "" && rootFSBaselineMissing(err, resp) {
+		parentLayerID = ""
+		saveReq.ParentLayerID = ""
+		resp, err = s.ctldClient.SaveRootFSWithTimeout(ctx, ctldAddress, saveReq, sandboxRootFSOperationTimeout)
+	}
 	if err != nil {
 		return fmt.Errorf("save sandbox rootfs checkpoint: %w", rootFSResponseError(err, saveRootFSError(resp)))
 	}
@@ -58,6 +71,8 @@ func (s *SandboxService) saveSandboxRootFSCheckpoint(ctx context.Context, pod *c
 	if err != nil {
 		return err
 	}
+	state.LayerID = uuid.NewString()
+	state.ParentLayerID = parentLayerID
 	if tx != nil {
 		return tx.SaveRootFSState(ctx, state)
 	}
@@ -81,7 +96,7 @@ func (s *SandboxService) applySandboxRootFSCheckpoint(ctx context.Context, pod *
 	if err != nil {
 		return err
 	}
-	resp, err := s.ctldClient.ApplyRootFSWithTimeout(ctx, ctldAddress, ctldapi.ApplyRootFSRequest{
+	req := ctldapi.ApplyRootFSRequest{
 		Target:                      rootFSTargetForPod(pod),
 		ExpectedRuntime:             state.Runtime,
 		ExpectedRuntimeHandler:      state.RuntimeHandler,
@@ -95,7 +110,13 @@ func (s *SandboxService) applySandboxRootFSCheckpoint(ctx context.Context, pod *
 			Size:      state.DiffSize,
 			ObjectKey: state.DiffObjectKey,
 		},
-	}, sandboxRootFSOperationTimeout)
+	}
+	if layers := rootFSLayerDescriptors(state); len(layers) > 0 {
+		req.Layers = layers
+		req.BaselineLayerID = state.LayerID
+		req.Descriptor = ctldapi.RootFSDiffDescriptor{}
+	}
+	resp, err := s.ctldClient.ApplyRootFSWithTimeout(ctx, ctldAddress, req, sandboxRootFSOperationTimeout)
 	if err != nil {
 		return fmt.Errorf("apply sandbox rootfs checkpoint: %w", rootFSResponseError(err, applyRootFSError(resp)))
 	}
@@ -105,111 +126,44 @@ func (s *SandboxService) applySandboxRootFSCheckpoint(ctx context.Context, pod *
 	return nil
 }
 
-func (s *SandboxService) applySandboxRootFSCheckpointWithFallback(ctx context.Context, pod *corev1.Pod, record *SandboxRecord, template *v1alpha1.SandboxTemplate, req *ClaimRequest, state *SandboxRootFSState) (*corev1.Pod, error) {
+func rootFSLayerDescriptors(state *SandboxRootFSState) []ctldapi.RootFSLayerDescriptor {
 	if state == nil {
-		return pod, nil
-	}
-	err := s.applySandboxRootFSCheckpoint(ctx, pod, state)
-	if err == nil {
-		return pod, nil
-	}
-	fallbackTemplate, fallbackErr := templateWithCheckpointBaseImage(template, state)
-	if fallbackErr != nil {
-		return nil, fmt.Errorf("%w; checkpoint base image fallback unavailable: %v", err, fallbackErr)
-	}
-	if s != nil && s.logger != nil {
-		s.logger.Warn("Rootfs force-apply failed; retrying with checkpoint base image",
-			zap.String("sandboxID", state.SandboxID),
-			zap.String("baseImageRef", state.BaseImageRef),
-			zap.String("baseImageDigest", state.BaseImageDigest),
-			zap.Error(err),
-		)
-	}
-	s.requestSandboxDeletionAfterClaimFailure(pod, "rootfs force-apply failed")
-
-	fallbackPod, fallbackErr := s.createNewPod(ctx, fallbackTemplate, req)
-	if fallbackErr != nil {
-		return nil, fmt.Errorf("%w; create checkpoint base image runtime: %v", err, fallbackErr)
-	}
-	readyPod, fallbackErr := s.waitForPodClaimReady(ctx, fallbackPod.Namespace, fallbackPod.Name)
-	if fallbackErr != nil {
-		s.requestSandboxDeletionAfterClaimFailure(fallbackPod, "checkpoint base image runtime readiness failed")
-		return nil, fmt.Errorf("%w; wait for checkpoint base image runtime: %v", err, fallbackErr)
-	}
-	if fallbackErr := s.saveRestoredRuntimePod(ctx, readyPod, record, SandboxStatusResuming); fallbackErr != nil {
-		s.requestSandboxDeletionAfterClaimFailure(readyPod, "checkpoint base image runtime persistence failed")
-		return nil, fmt.Errorf("%w; save checkpoint base image runtime: %v", err, fallbackErr)
-	}
-	if fallbackErr := s.applySandboxRootFSCheckpoint(ctx, readyPod, state); fallbackErr != nil {
-		s.requestSandboxDeletionAfterClaimFailure(readyPod, "checkpoint base image rootfs apply failed")
-		return nil, fmt.Errorf("%w; checkpoint base image retry failed: %v", err, fallbackErr)
-	}
-	return readyPod, nil
-}
-
-func (s *SandboxService) saveRestoredRuntimePod(ctx context.Context, pod *corev1.Pod, record *SandboxRecord, status string) error {
-	if s == nil || s.sandboxStore == nil || pod == nil || record == nil {
 		return nil
 	}
-	sandboxID := strings.TrimSpace(record.ID)
-	if sandboxID == "" {
-		sandboxID = sandboxIDFromPod(pod)
+	if len(state.LayerChain) > 0 {
+		out := make([]ctldapi.RootFSLayerDescriptor, 0, len(state.LayerChain))
+		for _, layer := range state.LayerChain {
+			if layer == nil || strings.TrimSpace(layer.ID) == "" {
+				continue
+			}
+			out = append(out, ctldapi.RootFSLayerDescriptor{
+				LayerID:       layer.ID,
+				ParentLayerID: layer.ParentLayerID,
+				Descriptor: ctldapi.RootFSDiffDescriptor{
+					MediaType: layer.DiffMediaType,
+					Digest:    layer.DiffDigest,
+					Size:      layer.DiffSize,
+					ObjectKey: layer.DiffObjectKey,
+				},
+			})
+		}
+		if len(out) > 0 {
+			return out
+		}
 	}
-	if sandboxID == "" {
-		return fmt.Errorf("sandbox_id is required")
+	if strings.TrimSpace(state.LayerID) == "" {
+		return nil
 	}
-	return s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, _ *SandboxRecord) error {
-		return tx.SaveRuntime(lockCtx, sandboxID, pod.Namespace, pod.Name, status, runtimeGenerationFromPod(pod), parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationExpiresAt), parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationHardExpiresAt))
-	})
-}
-
-func templateWithCheckpointBaseImage(template *v1alpha1.SandboxTemplate, state *SandboxRootFSState) (*v1alpha1.SandboxTemplate, error) {
-	if template == nil {
-		return nil, fmt.Errorf("template is required")
-	}
-	image, err := checkpointBaseImageRef(state)
-	if err != nil {
-		return nil, err
-	}
-	clone := template.DeepCopy()
-	clone.Spec.MainContainer.Image = image
-	clone.Spec.MainContainer.ImagePullPolicy = string(corev1.PullIfNotPresent)
-	return clone, nil
-}
-
-func checkpointBaseImageRef(state *SandboxRootFSState) (string, error) {
-	if state == nil {
-		return "", fmt.Errorf("rootfs state is required")
-	}
-	repo := imageRepositoryFromRef(state.BaseImageRef)
-	if repo == "" {
-		return "", fmt.Errorf("base image ref is required")
-	}
-	digestValue := strings.TrimSpace(state.BaseImageDigest)
-	if digestValue == "" {
-		return "", fmt.Errorf("base image digest is required")
-	}
-	parsed, err := godigest.Parse(digestValue)
-	if err != nil {
-		return "", fmt.Errorf("base image digest %q is invalid: %w", digestValue, err)
-	}
-	return repo + "@" + parsed.String(), nil
-}
-
-func imageRepositoryFromRef(ref string) string {
-	ref = strings.TrimSpace(ref)
-	if ref == "" {
-		return ""
-	}
-	if idx := strings.LastIndex(ref, "@"); idx >= 0 {
-		ref = ref[:idx]
-	}
-	lastSlash := strings.LastIndex(ref, "/")
-	lastColon := strings.LastIndex(ref, ":")
-	if lastColon > lastSlash {
-		ref = ref[:lastColon]
-	}
-	return strings.TrimSpace(ref)
+	return []ctldapi.RootFSLayerDescriptor{{
+		LayerID:       state.LayerID,
+		ParentLayerID: state.ParentLayerID,
+		Descriptor: ctldapi.RootFSDiffDescriptor{
+			MediaType: state.DiffMediaType,
+			Digest:    state.DiffDigest,
+			Size:      state.DiffSize,
+			ObjectKey: state.DiffObjectKey,
+		},
+	}}
 }
 
 func (s *SandboxService) latestRootFSState(ctx context.Context, sandboxID string) (*SandboxRootFSState, error) {
@@ -271,6 +225,15 @@ func applyRootFSError(resp *ctldapi.ApplyRootFSResponse) string {
 		return ""
 	}
 	return strings.TrimSpace(resp.Error)
+}
+
+func rootFSBaselineMissing(err error, resp *ctldapi.SaveRootFSResponse) bool {
+	var reqErr *ctldapi.RequestError
+	if !errors.As(err, &reqErr) || reqErr == nil || reqErr.StatusCode != http.StatusNotFound {
+		return false
+	}
+	message := strings.ToLower(saveRootFSError(resp))
+	return strings.Contains(message, "baseline") && strings.Contains(message, "not captured")
 }
 
 func rootFSResponseError(err error, message string) error {

--- a/manager/pkg/service/sandbox_service_rootfs_test.go
+++ b/manager/pkg/service/sandbox_service_rootfs_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strconv"
-	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -16,8 +15,6 @@ import (
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
-	"github.com/sandbox0-ai/sandbox0/pkg/naming"
-	"github.com/sandbox0-ai/sandbox0/pkg/sandboxprobe"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -26,7 +23,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
-	corelisters "k8s.io/client-go/listers/core/v1"
 	ktesting "k8s.io/client-go/testing"
 )
 
@@ -39,6 +35,7 @@ func TestPauseSandboxRuntimeQueuesRootFSSaveBeforeDeletingPod(t *testing.T) {
 		assert.Equal(t, "sandbox-1", req.SandboxID)
 		assert.Equal(t, "team-1", req.TeamID)
 		assert.Equal(t, int64(3), req.ExpectedRuntimeGeneration)
+		assert.Empty(t, req.ParentLayerID)
 		assert.Equal(t, ctldapi.RootFSContainerRef{
 			Namespace:     "default",
 			PodName:       "pod-1",
@@ -113,7 +110,153 @@ func TestPauseSandboxRuntimeQueuesRootFSSaveBeforeDeletingPod(t *testing.T) {
 	assert.Equal(t, []string{"parent-1", "parent-0"}, state.SnapshotParentChain)
 	assert.Equal(t, "sha256:diff", state.DiffDigest)
 	assert.Equal(t, "sandbox-rootfs/team-1/sandbox-1/3/sha256/diff.tar", state.DiffObjectKey)
+	assert.NotEmpty(t, state.LayerID)
 	assert.Equal(t, SandboxStatusPaused, store.records["sandbox-1"].Status)
+}
+
+func TestPauseSandboxRuntimeSavesChildLayerFromParentHead(t *testing.T) {
+	var savedReq ctldapi.SaveRootFSRequest
+	ctld := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/rootfs/save", r.URL.Path)
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&savedReq))
+		_ = json.NewEncoder(w).Encode(ctldapi.SaveRootFSResponse{
+			Info: ctldapi.RootFSInfo{
+				Runtime:             "runc",
+				RuntimeHandler:      "io.containerd.runc.v2",
+				BaseImageRef:        "docker.io/library/busybox:1.36",
+				BaseImageDigest:     "sha256:base",
+				Snapshotter:         "overlayfs",
+				SnapshotParent:      "parent-1",
+				SnapshotParentChain: []string{"parent-1", "parent-0"},
+			},
+			Descriptor: ctldapi.RootFSDiffDescriptor{
+				MediaType: "application/vnd.oci.image.layer.v1.tar",
+				Digest:    "sha256:child",
+				Size:      123,
+				ObjectKey: "sandbox-rootfs/team-1/sandbox-1/4/sha256/child.tar",
+			},
+		})
+	}))
+	defer ctld.Close()
+	ctldURL, ctldPort := parsedTestServer(t, ctld.URL)
+
+	pod := rootFSTestPod("pod-1", "sandbox-1", "team-1")
+	pod.Status.HostIP = ctldURL.Hostname()
+	store := &memorySandboxStore{
+		records: map[string]*SandboxRecord{
+			"sandbox-1": {
+				ID:                "sandbox-1",
+				TeamID:            "team-1",
+				RuntimeGeneration: 3,
+				Status:            SandboxStatusPausing,
+			},
+		},
+		rootFSStates: map[string]*SandboxRootFSState{
+			"sandbox-1": {
+				LayerID:           "layer-parent",
+				SandboxID:         "sandbox-1",
+				TeamID:            "team-1",
+				RuntimeGeneration: 3,
+				DiffDigest:        "sha256:parent",
+				DiffObjectKey:     "sandbox-rootfs/team-1/sandbox-1/3/sha256/parent.tar",
+			},
+		},
+	}
+	svc := &SandboxService{
+		k8sClient:    fake.NewSimpleClientset(pod),
+		podLister:    newTestPodLister(t, pod),
+		sandboxStore: store,
+		ctldClient:   NewCtldClient(CtldClientConfig{Timeout: time.Second}),
+		config:       SandboxServiceConfig{CtldEnabled: true, CtldPort: ctldPort},
+		clock:        systemTime{},
+		logger:       zap.NewNop(),
+	}
+
+	require.NoError(t, svc.CompletePausingSandboxRuntime(context.Background(), "sandbox-1"))
+
+	assert.Equal(t, "layer-parent", savedReq.ParentLayerID)
+	state := store.rootFSStates["sandbox-1"]
+	require.NotNil(t, state)
+	assert.NotEmpty(t, state.LayerID)
+	assert.Equal(t, "layer-parent", state.ParentLayerID)
+	assert.Equal(t, "sha256:child", state.DiffDigest)
+}
+
+func TestPauseSandboxRuntimeFallsBackToRootLayerWhenBaselineIsMissing(t *testing.T) {
+	var saveRequests []ctldapi.SaveRootFSRequest
+	ctld := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/rootfs/save", r.URL.Path)
+		var req ctldapi.SaveRootFSRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		saveRequests = append(saveRequests, req)
+		if req.ParentLayerID != "" {
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(ctldapi.SaveRootFSResponse{Error: "create rootfs diff: rootfs baseline layer-parent is not captured"})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(ctldapi.SaveRootFSResponse{
+			Info: ctldapi.RootFSInfo{
+				Runtime:             "runc",
+				RuntimeHandler:      "io.containerd.runc.v2",
+				BaseImageRef:        "docker.io/library/busybox:1.36",
+				BaseImageDigest:     "sha256:base",
+				Snapshotter:         "overlayfs",
+				SnapshotParent:      "parent-1",
+				SnapshotParentChain: []string{"parent-1", "parent-0"},
+			},
+			Descriptor: ctldapi.RootFSDiffDescriptor{
+				MediaType: "application/vnd.oci.image.layer.v1.tar",
+				Digest:    "sha256:full",
+				Size:      456,
+				ObjectKey: "sandbox-rootfs/team-1/sandbox-1/3/sha256/full.tar",
+			},
+		})
+	}))
+	defer ctld.Close()
+	ctldURL, ctldPort := parsedTestServer(t, ctld.URL)
+
+	pod := rootFSTestPod("pod-1", "sandbox-1", "team-1")
+	pod.Status.HostIP = ctldURL.Hostname()
+	store := &memorySandboxStore{
+		records: map[string]*SandboxRecord{
+			"sandbox-1": {
+				ID:                "sandbox-1",
+				TeamID:            "team-1",
+				RuntimeGeneration: 3,
+				Status:            SandboxStatusPausing,
+			},
+		},
+		rootFSStates: map[string]*SandboxRootFSState{
+			"sandbox-1": {
+				LayerID:           "layer-parent",
+				SandboxID:         "sandbox-1",
+				TeamID:            "team-1",
+				RuntimeGeneration: 2,
+				DiffDigest:        "sha256:parent",
+				DiffObjectKey:     "sandbox-rootfs/team-1/sandbox-1/2/sha256/parent.tar",
+			},
+		},
+	}
+	svc := &SandboxService{
+		k8sClient:    fake.NewSimpleClientset(pod),
+		podLister:    newTestPodLister(t, pod),
+		sandboxStore: store,
+		ctldClient:   NewCtldClient(CtldClientConfig{Timeout: time.Second}),
+		config:       SandboxServiceConfig{CtldEnabled: true, CtldPort: ctldPort},
+		clock:        systemTime{},
+		logger:       zap.NewNop(),
+	}
+
+	require.NoError(t, svc.CompletePausingSandboxRuntime(context.Background(), "sandbox-1"))
+
+	require.Len(t, saveRequests, 2)
+	assert.Equal(t, "layer-parent", saveRequests[0].ParentLayerID)
+	assert.Empty(t, saveRequests[1].ParentLayerID)
+	state := store.rootFSStates["sandbox-1"]
+	require.NotNil(t, state)
+	assert.NotEmpty(t, state.LayerID)
+	assert.Empty(t, state.ParentLayerID)
+	assert.Equal(t, "sha256:full", state.DiffDigest)
 }
 
 func TestGetSandboxReportsPausingRecordWhileRuntimePodStillRunning(t *testing.T) {
@@ -219,120 +362,35 @@ func TestFinishRestoredSandboxRuntimeAppliesRootFSBeforeProcdInitialization(t *t
 	assert.Equal(t, []string{"apply", "procd"}, calls)
 }
 
-func TestFinishRestoredSandboxRuntimeRetriesWithCheckpointBaseImage(t *testing.T) {
-	withClaimTestPublicKey(t)
-
-	const checkpointDigest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-	templateNamespace, err := naming.TemplateNamespaceForTeam("team-1")
-	require.NoError(t, err)
-
-	var applyTargets []string
+func TestFinishRestoredSandboxRuntimeAppliesRootFSLayerChain(t *testing.T) {
+	var applyReq ctldapi.ApplyRootFSRequest
 	ctld := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.URL.Path == "/api/v1/rootfs/apply":
-			var req ctldapi.ApplyRootFSRequest
-			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
-			applyTargets = append(applyTargets, req.Target.PodName)
-			assert.Equal(t, checkpointDigest, req.ExpectedBaseImageDigest)
-			if req.Target.PodName == "pod-current" {
-				w.WriteHeader(http.StatusInternalServerError)
-				_ = json.NewEncoder(w).Encode(ctldapi.ApplyRootFSResponse{Error: "apply rootfs diff: simulated conflict"})
-				return
-			}
-			_ = json.NewEncoder(w).Encode(ctldapi.ApplyRootFSResponse{Applied: true})
-		case strings.HasSuffix(r.URL.Path, "/probes/readiness"):
-			_ = json.NewEncoder(w).Encode(sandboxprobe.Passed(sandboxprobe.KindReadiness, "SandboxProbePassed", "sandbox probe passed", nil))
-		case r.URL.Path == "/api/v1/volume-portals/check":
-			_ = json.NewEncoder(w).Encode(ctldapi.CheckVolumePortalsResponse{Ready: true})
-		default:
-			t.Fatalf("unexpected ctld path: %s", r.URL.Path)
-		}
+		require.Equal(t, "/api/v1/rootfs/apply", r.URL.Path)
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&applyReq))
+		_ = json.NewEncoder(w).Encode(ctldapi.ApplyRootFSResponse{Applied: true})
 	}))
 	defer ctld.Close()
 	ctldURL, ctldPort := parsedTestServer(t, ctld.URL)
 
 	procd := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "/api/v1/initialize", r.URL.Path)
-		require.Len(t, applyTargets, 2)
 		require.NoError(t, spec.WriteSuccess(w, http.StatusOK, InitializeResponse{SandboxID: "sandbox-1", TeamID: "team-1"}))
 	}))
 	defer procd.Close()
 	procdURL, procdPort := parsedTestServer(t, procd.URL)
 
-	currentPod := rootFSTestPod("pod-current", "sandbox-1", "team-1")
-	currentPod.Namespace = templateNamespace
-	currentPod.Status.HostIP = ctldURL.Hostname()
-	currentPod.Status.PodIP = procdURL.Hostname()
-	indexer := newClaimTestPodIndexer(t, currentPod)
-	k8sClient := fake.NewSimpleClientset(currentPod)
-	var fallbackImage string
-	k8sClient.PrependReactor("create", "pods", func(action ktesting.Action) (bool, runtime.Object, error) {
-		pod := action.(ktesting.CreateAction).GetObject().(*corev1.Pod).DeepCopy()
-		require.Len(t, pod.Spec.Containers, 1)
-		fallbackImage = pod.Spec.Containers[0].Image
-
-		readyPod := pod.DeepCopy()
-		readyPod.UID = types.UID("fallback-uid")
-		readyPod.Status.Phase = corev1.PodRunning
-		readyPod.Status.HostIP = ctldURL.Hostname()
-		readyPod.Status.PodIP = procdURL.Hostname()
-		readyPod.Status.ContainerStatuses = []corev1.ContainerStatus{{
-			Name:  "procd",
-			State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
-		}}
-		require.NoError(t, indexer.Add(readyPod))
-		return false, nil, nil
-	})
-
-	template := &v1alpha1.SandboxTemplate{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "template-1",
-			Namespace: templateNamespace,
-		},
-		Spec: v1alpha1.SandboxTemplateSpec{
-			MainContainer: v1alpha1.ContainerSpec{Image: "docker.io/library/busybox:1.37"},
-		},
-	}
+	pod := rootFSTestPod("pod-1", "sandbox-1", "team-1")
+	pod.Status.HostIP = ctldURL.Hostname()
+	pod.Status.PodIP = procdURL.Hostname()
 	store := &memorySandboxStore{
-		records: map[string]*SandboxRecord{
-			"sandbox-1": {
-				ID:                  "sandbox-1",
-				TeamID:              "team-1",
-				UserID:              "user-1",
-				TemplateID:          "template-1",
-				TemplateName:        "template-1",
-				TemplateNamespace:   templateNamespace,
-				TemplateSpec:        template.Spec,
-				CurrentPodName:      "pod-current",
-				CurrentPodNamespace: templateNamespace,
-				RuntimeGeneration:   3,
-				Status:              SandboxStatusResuming,
-			},
-		},
+		records: map[string]*SandboxRecord{},
 		rootFSStates: map[string]*SandboxRootFSState{
-			"sandbox-1": {
-				SandboxID:           "sandbox-1",
-				TeamID:              "team-1",
-				RuntimeGeneration:   3,
-				Runtime:             "runc",
-				RuntimeHandler:      "io.containerd.runc.v2",
-				BaseImageRef:        "docker.io/library/busybox:1.36",
-				BaseImageDigest:     checkpointDigest,
-				Snapshotter:         "overlayfs",
-				SnapshotParent:      "parent-1",
-				SnapshotParentChain: []string{"parent-1", "parent-0"},
-				DiffDigest:          "sha256:diff",
-				DiffMediaType:       "application/vnd.oci.image.layer.v1.tar",
-				DiffSize:            123,
-				DiffObjectKey:       "sandbox-rootfs/team-1/sandbox-1/3/sha256/diff.tar",
-			},
+			"sandbox-1": rootFSTestLayerState(),
 		},
 	}
 	svc := &SandboxService{
-		k8sClient:              k8sClient,
-		podLister:              corelisters.NewPodLister(indexer),
-		secretLister:           newClaimTestSecretLister(t),
-		templateLister:         staticTemplateLister{templates: []*v1alpha1.SandboxTemplate{template}},
+		k8sClient:              fake.NewSimpleClientset(pod),
+		podLister:              newTestPodLister(t, pod),
 		sandboxStore:           store,
 		ctldClient:             NewCtldClient(CtldClientConfig{Timeout: time.Second}),
 		procdClient:            NewProcdClient(ProcdClientConfig{Timeout: time.Second}),
@@ -346,26 +404,94 @@ func TestFinishRestoredSandboxRuntimeRetriesWithCheckpointBaseImage(t *testing.T
 		clock:  systemTime{},
 		logger: zap.NewNop(),
 	}
-	record := store.records["sandbox-1"]
+	record := &SandboxRecord{
+		ID:                "sandbox-1",
+		TeamID:            "team-1",
+		UserID:            "user-1",
+		TemplateID:        "template-1",
+		TemplateName:      "template-1",
+		TemplateNamespace: "template-default",
+		TemplateSpec:      v1alpha1.SandboxTemplateSpec{},
+		RuntimeGeneration: 3,
+		Status:            SandboxStatusPaused,
+	}
 
-	require.NoError(t, svc.finishRestoredSandboxRuntime(context.Background(), currentPod, record, "hot"))
+	require.NoError(t, svc.finishRestoredSandboxRuntime(context.Background(), pod, record, "hot"))
 
-	require.Len(t, applyTargets, 2)
-	assert.Equal(t, "pod-current", applyTargets[0])
-	assert.NotEqual(t, "pod-current", applyTargets[1])
-	assert.Equal(t, "docker.io/library/busybox@"+checkpointDigest, fallbackImage)
-	assert.Equal(t, applyTargets[1], store.records["sandbox-1"].CurrentPodName)
-	assert.Equal(t, SandboxStatusRunning, store.records["sandbox-1"].Status)
+	assert.Empty(t, applyReq.Descriptor.Digest)
+	assert.Equal(t, "layer-child", applyReq.BaselineLayerID)
+	require.Len(t, applyReq.Layers, 2)
+	assert.Equal(t, "layer-parent", applyReq.Layers[0].LayerID)
+	assert.Empty(t, applyReq.Layers[0].ParentLayerID)
+	assert.Equal(t, "rootfs/parent.tar", applyReq.Layers[0].Descriptor.ObjectKey)
+	assert.Equal(t, "layer-child", applyReq.Layers[1].LayerID)
+	assert.Equal(t, "layer-parent", applyReq.Layers[1].ParentLayerID)
+	assert.Equal(t, "rootfs/child.tar", applyReq.Layers[1].Descriptor.ObjectKey)
 }
 
-func TestCheckpointBaseImageRefPinsDigest(t *testing.T) {
-	ref, err := checkpointBaseImageRef(&SandboxRootFSState{
-		BaseImageRef:    "registry.example.com:5000/team/image:old-tag",
-		BaseImageDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-	})
+func TestFinishRestoredSandboxRuntimeDoesNotCreateFallbackPodOnRootFSApplyFailure(t *testing.T) {
+	ctld := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/rootfs/apply", r.URL.Path)
+		w.WriteHeader(http.StatusInternalServerError)
+		_ = json.NewEncoder(w).Encode(ctldapi.ApplyRootFSResponse{Error: "apply rootfs diff: simulated failure"})
+	}))
+	defer ctld.Close()
+	ctldURL, ctldPort := parsedTestServer(t, ctld.URL)
 
-	require.NoError(t, err)
-	assert.Equal(t, "registry.example.com:5000/team/image@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", ref)
+	procd := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("procd must not be initialized after rootfs apply failure")
+	}))
+	defer procd.Close()
+	procdURL, procdPort := parsedTestServer(t, procd.URL)
+
+	pod := rootFSTestPod("pod-1", "sandbox-1", "team-1")
+	pod.Status.HostIP = ctldURL.Hostname()
+	pod.Status.PodIP = procdURL.Hostname()
+	k8sClient := fake.NewSimpleClientset(pod)
+	var createCalled atomic.Bool
+	k8sClient.PrependReactor("create", "pods", func(action ktesting.Action) (bool, runtime.Object, error) {
+		createCalled.Store(true)
+		return false, nil, nil
+	})
+	store := &memorySandboxStore{
+		records: map[string]*SandboxRecord{},
+		rootFSStates: map[string]*SandboxRootFSState{
+			"sandbox-1": rootFSTestState(),
+		},
+	}
+	svc := &SandboxService{
+		k8sClient:              k8sClient,
+		podLister:              newTestPodLister(t, pod),
+		sandboxStore:           store,
+		ctldClient:             NewCtldClient(CtldClientConfig{Timeout: time.Second}),
+		procdClient:            NewProcdClient(ProcdClientConfig{Timeout: time.Second}),
+		internalTokenGenerator: staticTokenGenerator{},
+		config: SandboxServiceConfig{
+			CtldEnabled:      true,
+			CtldPort:         ctldPort,
+			ProcdPort:        procdPort,
+			ProcdInitTimeout: time.Second,
+		},
+		clock:  systemTime{},
+		logger: zap.NewNop(),
+	}
+	record := &SandboxRecord{
+		ID:                "sandbox-1",
+		TeamID:            "team-1",
+		UserID:            "user-1",
+		TemplateID:        "template-1",
+		TemplateName:      "template-1",
+		TemplateNamespace: "template-default",
+		TemplateSpec:      v1alpha1.SandboxTemplateSpec{},
+		RuntimeGeneration: 3,
+		Status:            SandboxStatusPaused,
+	}
+
+	err := svc.finishRestoredSandboxRuntime(context.Background(), pod, record, "hot")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "apply rootfs diff: simulated failure")
+	assert.False(t, createCalled.Load())
 }
 
 func TestRestoreFailureCleanupCanSkipRootFSSave(t *testing.T) {
@@ -478,6 +604,52 @@ func rootFSTestState() *SandboxRootFSState {
 		DiffSize:            123,
 		DiffObjectKey:       "sandbox-rootfs/team-1/sandbox-1/3/sha256/diff.tar",
 	}
+}
+
+func rootFSTestLayerState() *SandboxRootFSState {
+	state := rootFSTestState()
+	state.LayerID = "layer-child"
+	state.ParentLayerID = "layer-parent"
+	state.DiffDigest = "sha256:child"
+	state.DiffObjectKey = "rootfs/child.tar"
+	state.LayerChain = []*SandboxRootFSLayer{
+		{
+			ID:                  "layer-parent",
+			SourceSandboxID:     "sandbox-1",
+			TeamID:              "team-1",
+			RuntimeGeneration:   2,
+			Runtime:             "runc",
+			RuntimeHandler:      "io.containerd.runc.v2",
+			BaseImageRef:        "docker.io/library/busybox:1.36",
+			BaseImageDigest:     "sha256:base",
+			Snapshotter:         "overlayfs",
+			SnapshotParent:      "parent-1",
+			SnapshotParentChain: []string{"parent-1", "parent-0"},
+			DiffDigest:          "sha256:parent",
+			DiffMediaType:       "application/vnd.oci.image.layer.v1.tar",
+			DiffSize:            100,
+			DiffObjectKey:       "rootfs/parent.tar",
+		},
+		{
+			ID:                  "layer-child",
+			ParentLayerID:       "layer-parent",
+			SourceSandboxID:     "sandbox-1",
+			TeamID:              "team-1",
+			RuntimeGeneration:   3,
+			Runtime:             "runc",
+			RuntimeHandler:      "io.containerd.runc.v2",
+			BaseImageRef:        "docker.io/library/busybox:1.36",
+			BaseImageDigest:     "sha256:base",
+			Snapshotter:         "overlayfs",
+			SnapshotParent:      "parent-1",
+			SnapshotParentChain: []string{"parent-1", "parent-0"},
+			DiffDigest:          "sha256:child",
+			DiffMediaType:       "application/vnd.oci.image.layer.v1.tar",
+			DiffSize:            123,
+			DiffObjectKey:       "rootfs/child.tar",
+		},
+	}
+	return state
 }
 
 func parsedTestServer(t *testing.T, rawURL string) (*url.URL, int) {

--- a/manager/pkg/service/sandbox_store.go
+++ b/manager/pkg/service/sandbox_store.go
@@ -51,6 +51,8 @@ type SandboxRecord struct {
 // SandboxRootFSState is manager-internal metadata for one persisted sandbox
 // writable rootfs diff.
 type SandboxRootFSState struct {
+	LayerID             string
+	ParentLayerID       string
 	SandboxID           string
 	TeamID              string
 	RuntimeGeneration   int64
@@ -67,6 +69,29 @@ type SandboxRootFSState struct {
 	DiffObjectKey       string
 	CreatedAt           time.Time
 	UpdatedAt           time.Time
+	LayerChain          []*SandboxRootFSLayer
+}
+
+// SandboxRootFSLayer is one immutable OCI diff layer in a sandbox rootfs chain.
+type SandboxRootFSLayer struct {
+	ID                  string
+	ParentLayerID       string
+	SourceSandboxID     string
+	TeamID              string
+	RuntimeGeneration   int64
+	Runtime             string
+	RuntimeHandler      string
+	BaseImageRef        string
+	BaseImageDigest     string
+	Snapshotter         string
+	SnapshotParent      string
+	SnapshotParentChain []string
+	DiffDigest          string
+	DiffID              string
+	DiffMediaType       string
+	DiffSize            int64
+	DiffObjectKey       string
+	CreatedAt           time.Time
 }
 
 // SandboxStore persists sandbox identities independently of runtime pods.
@@ -288,6 +313,9 @@ func (s *PGSandboxStore) MarkSandboxDeleted(ctx context.Context, sandboxID strin
 	if _, err := s.pool.Exec(ctx, `DELETE FROM manager.sandbox_rootfs_states WHERE sandbox_id = $1`, sandboxID); err != nil {
 		return fmt.Errorf("delete sandbox rootfs states: %w", err)
 	}
+	if _, err := s.pool.Exec(ctx, `DELETE FROM manager.sandbox_rootfs_heads WHERE sandbox_id = $1`, sandboxID); err != nil {
+		return fmt.Errorf("delete sandbox rootfs head: %w", err)
+	}
 	return nil
 }
 
@@ -302,11 +330,41 @@ func (s *PGSandboxStore) GetLatestRootFSState(ctx context.Context, sandboxID str
 	if s == nil || s.pool == nil {
 		return nil, nil
 	}
+	chain, err := s.GetRootFSLayerChain(ctx, sandboxID)
+	if err != nil {
+		return nil, err
+	}
+	if len(chain) > 0 {
+		return rootFSStateFromLayerChain(sandboxID, chain), nil
+	}
 	return scanRootFSState(s.pool.QueryRow(ctx, rootFSStateSelectSQL()+`
 		WHERE sandbox_id = $1
 		ORDER BY runtime_generation DESC, updated_at DESC
 		LIMIT 1
 	`, sandboxID))
+}
+
+func (s *PGSandboxStore) GetRootFSLayerChain(ctx context.Context, sandboxID string) ([]*SandboxRootFSLayer, error) {
+	if s == nil || s.pool == nil || strings.TrimSpace(sandboxID) == "" {
+		return nil, nil
+	}
+	rows, err := s.pool.Query(ctx, rootFSLayerChainSQL(), sandboxID)
+	if err != nil {
+		return nil, fmt.Errorf("get rootfs layer chain: %w", err)
+	}
+	defer rows.Close()
+	var layers []*SandboxRootFSLayer
+	for rows.Next() {
+		layer, err := scanRootFSLayerRows(rows)
+		if err != nil {
+			return nil, err
+		}
+		layers = append(layers, layer)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate rootfs layer chain: %w", err)
+	}
+	return layers, nil
 }
 
 func (s *PGSandboxStore) WithSandboxLock(ctx context.Context, sandboxID string, fn func(context.Context, SandboxStoreTx, *SandboxRecord) error) error {
@@ -411,6 +469,11 @@ func saveRootFSState(ctx context.Context, exec rootFSStateExecutor, state *Sandb
 	if err != nil {
 		return fmt.Errorf("marshal rootfs snapshot parent chain: %w", err)
 	}
+	if strings.TrimSpace(state.LayerID) != "" {
+		if err := saveRootFSLayerAndHead(ctx, exec, state); err != nil {
+			return err
+		}
+	}
 	_, err = exec.Exec(ctx, `
 		INSERT INTO manager.sandbox_rootfs_states (
 			sandbox_id, team_id, runtime_generation, runtime, runtime_handler,
@@ -443,6 +506,54 @@ func saveRootFSState(ctx context.Context, exec rootFSStateExecutor, state *Sandb
 	return nil
 }
 
+func saveRootFSLayerAndHead(ctx context.Context, exec rootFSStateExecutor, state *SandboxRootFSState) error {
+	if exec == nil || state == nil {
+		return nil
+	}
+	if strings.TrimSpace(state.LayerID) == "" {
+		return fmt.Errorf("layer_id is required")
+	}
+	if strings.TrimSpace(state.ParentLayerID) == strings.TrimSpace(state.LayerID) {
+		return fmt.Errorf("parent_layer_id cannot reference layer_id")
+	}
+	parentLayerID := nullableText(state.ParentLayerID)
+	parentChainJSON, err := json.Marshal(state.SnapshotParentChain)
+	if err != nil {
+		return fmt.Errorf("marshal rootfs layer snapshot parent chain: %w", err)
+	}
+	_, err = exec.Exec(ctx, `
+		INSERT INTO manager.rootfs_layers (
+			layer_id, parent_layer_id, source_sandbox_id, team_id, runtime_generation,
+			runtime, runtime_handler, base_image_ref, base_image_digest, snapshotter,
+			snapshot_parent, snapshot_parent_chain, diff_digest, diff_id, diff_media_type,
+			diff_size, diff_object_key, created_at
+		)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, COALESCE($18, NOW()))
+		ON CONFLICT (layer_id) DO NOTHING
+	`, state.LayerID, parentLayerID, state.SandboxID, state.TeamID, state.RuntimeGeneration,
+		state.Runtime, state.RuntimeHandler, state.BaseImageRef, state.BaseImageDigest, state.Snapshotter,
+		state.SnapshotParent, parentChainJSON, state.DiffDigest, "", state.DiffMediaType,
+		state.DiffSize, state.DiffObjectKey, nullableTime(state.CreatedAt))
+	if err != nil {
+		return fmt.Errorf("save rootfs layer: %w", err)
+	}
+	_, err = exec.Exec(ctx, `
+		INSERT INTO manager.sandbox_rootfs_heads (
+			sandbox_id, team_id, head_layer_id, runtime_generation, updated_at
+		)
+		VALUES ($1, $2, $3, $4, NOW())
+		ON CONFLICT (sandbox_id) DO UPDATE SET
+			team_id = EXCLUDED.team_id,
+			head_layer_id = EXCLUDED.head_layer_id,
+			runtime_generation = EXCLUDED.runtime_generation,
+			updated_at = NOW()
+	`, state.SandboxID, state.TeamID, state.LayerID, state.RuntimeGeneration)
+	if err != nil {
+		return fmt.Errorf("advance rootfs head: %w", err)
+	}
+	return nil
+}
+
 func rootFSStateSelectSQL() string {
 	return `
 		SELECT sandbox_id, team_id, runtime_generation, runtime, runtime_handler,
@@ -450,6 +561,86 @@ func rootFSStateSelectSQL() string {
 			snapshot_parent_chain, diff_digest, diff_media_type, diff_size,
 			diff_object_key, created_at, updated_at
 		FROM manager.sandbox_rootfs_states`
+}
+
+func rootFSLayerChainSQL() string {
+	return `
+		WITH RECURSIVE chain AS (
+			SELECT
+				l.layer_id, l.parent_layer_id, l.source_sandbox_id, l.team_id,
+				l.runtime_generation, l.runtime, l.runtime_handler, l.base_image_ref,
+				l.base_image_digest, l.snapshotter, l.snapshot_parent,
+				l.snapshot_parent_chain, l.diff_digest, l.diff_id, l.diff_media_type,
+				l.diff_size, l.diff_object_key, l.created_at, 0 AS depth
+			FROM manager.sandbox_rootfs_heads h
+			JOIN manager.rootfs_layers l ON l.layer_id = h.head_layer_id
+			WHERE h.sandbox_id = $1
+			UNION ALL
+			SELECT
+				p.layer_id, p.parent_layer_id, p.source_sandbox_id, p.team_id,
+				p.runtime_generation, p.runtime, p.runtime_handler, p.base_image_ref,
+				p.base_image_digest, p.snapshotter, p.snapshot_parent,
+				p.snapshot_parent_chain, p.diff_digest, p.diff_id, p.diff_media_type,
+				p.diff_size, p.diff_object_key, p.created_at, c.depth + 1 AS depth
+			FROM manager.rootfs_layers p
+			JOIN chain c ON p.layer_id = c.parent_layer_id
+		)
+		SELECT layer_id, parent_layer_id, source_sandbox_id, team_id, runtime_generation,
+			runtime, runtime_handler, base_image_ref, base_image_digest, snapshotter,
+			snapshot_parent, snapshot_parent_chain, diff_digest, diff_id, diff_media_type,
+			diff_size, diff_object_key, created_at
+		FROM chain
+		ORDER BY depth DESC`
+}
+
+func scanRootFSLayerRows(rows pgx.Rows) (*SandboxRootFSLayer, error) {
+	var layer SandboxRootFSLayer
+	var parentLayerID *string
+	var parentChainJSON []byte
+	if err := rows.Scan(
+		&layer.ID, &parentLayerID, &layer.SourceSandboxID, &layer.TeamID, &layer.RuntimeGeneration,
+		&layer.Runtime, &layer.RuntimeHandler, &layer.BaseImageRef, &layer.BaseImageDigest, &layer.Snapshotter,
+		&layer.SnapshotParent, &parentChainJSON, &layer.DiffDigest, &layer.DiffID, &layer.DiffMediaType,
+		&layer.DiffSize, &layer.DiffObjectKey, &layer.CreatedAt,
+	); err != nil {
+		return nil, err
+	}
+	if parentLayerID != nil {
+		layer.ParentLayerID = *parentLayerID
+	}
+	if len(parentChainJSON) > 0 {
+		if err := json.Unmarshal(parentChainJSON, &layer.SnapshotParentChain); err != nil {
+			return nil, fmt.Errorf("unmarshal rootfs layer snapshot parent chain: %w", err)
+		}
+	}
+	return &layer, nil
+}
+
+func rootFSStateFromLayerChain(sandboxID string, chain []*SandboxRootFSLayer) *SandboxRootFSState {
+	if len(chain) == 0 {
+		return nil
+	}
+	head := chain[len(chain)-1]
+	return &SandboxRootFSState{
+		LayerID:             head.ID,
+		ParentLayerID:       head.ParentLayerID,
+		SandboxID:           sandboxID,
+		TeamID:              head.TeamID,
+		RuntimeGeneration:   head.RuntimeGeneration,
+		Runtime:             head.Runtime,
+		RuntimeHandler:      head.RuntimeHandler,
+		BaseImageRef:        head.BaseImageRef,
+		BaseImageDigest:     head.BaseImageDigest,
+		Snapshotter:         head.Snapshotter,
+		SnapshotParent:      head.SnapshotParent,
+		SnapshotParentChain: append([]string(nil), head.SnapshotParentChain...),
+		DiffDigest:          head.DiffDigest,
+		DiffMediaType:       head.DiffMediaType,
+		DiffSize:            head.DiffSize,
+		DiffObjectKey:       head.DiffObjectKey,
+		CreatedAt:           head.CreatedAt,
+		LayerChain:          cloneSandboxRootFSLayers(chain),
+	}
 }
 
 func scanRootFSState(row sandboxRecordScanner) (*SandboxRootFSState, error) {
@@ -548,9 +739,34 @@ func nullableTime(t time.Time) any {
 	return t
 }
 
+func nullableText(value string) any {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	return value
+}
+
 func derefTime(t *time.Time) time.Time {
 	if t == nil {
 		return time.Time{}
 	}
 	return *t
+}
+
+func cloneSandboxRootFSLayers(layers []*SandboxRootFSLayer) []*SandboxRootFSLayer {
+	if len(layers) == 0 {
+		return nil
+	}
+	out := make([]*SandboxRootFSLayer, 0, len(layers))
+	for _, layer := range layers {
+		if layer == nil {
+			out = append(out, nil)
+			continue
+		}
+		clone := *layer
+		clone.SnapshotParentChain = append([]string(nil), layer.SnapshotParentChain...)
+		out = append(out, &clone)
+	}
+	return out
 }

--- a/pkg/ctldapi/types.go
+++ b/pkg/ctldapi/types.go
@@ -67,6 +67,14 @@ type RootFSDiffDescriptor struct {
 	ObjectKey string `json:"object_key,omitempty"`
 }
 
+// RootFSLayerDescriptor identifies one immutable rootfs diff layer in a
+// sandbox rootfs head chain.
+type RootFSLayerDescriptor struct {
+	LayerID       string               `json:"layer_id"`
+	ParentLayerID string               `json:"parent_layer_id,omitempty"`
+	Descriptor    RootFSDiffDescriptor `json:"descriptor"`
+}
+
 type InspectRootFSRequest struct {
 	Target RootFSContainerRef `json:"target"`
 }
@@ -81,6 +89,7 @@ type SaveRootFSRequest struct {
 	SandboxID                 string             `json:"sandbox_id"`
 	TeamID                    string             `json:"team_id"`
 	ExpectedRuntimeGeneration int64              `json:"expected_runtime_generation,omitempty"`
+	ParentLayerID             string             `json:"parent_layer_id,omitempty"`
 	ObjectKey                 string             `json:"object_key,omitempty"`
 }
 
@@ -91,21 +100,24 @@ type SaveRootFSResponse struct {
 }
 
 type ApplyRootFSRequest struct {
-	Target                      RootFSContainerRef   `json:"target"`
-	ExpectedRuntime             string               `json:"expected_runtime,omitempty"`
-	ExpectedRuntimeHandler      string               `json:"expected_runtime_handler,omitempty"`
-	ExpectedSnapshotter         string               `json:"expected_snapshotter,omitempty"`
-	ExpectedBaseImageDigest     string               `json:"expected_base_image_digest,omitempty"`
-	ExpectedSnapshotParent      string               `json:"expected_snapshot_parent,omitempty"`
-	ExpectedSnapshotParentChain []string             `json:"expected_snapshot_parent_chain,omitempty"`
-	Descriptor                  RootFSDiffDescriptor `json:"descriptor"`
+	Target                      RootFSContainerRef      `json:"target"`
+	ExpectedRuntime             string                  `json:"expected_runtime,omitempty"`
+	ExpectedRuntimeHandler      string                  `json:"expected_runtime_handler,omitempty"`
+	ExpectedSnapshotter         string                  `json:"expected_snapshotter,omitempty"`
+	ExpectedBaseImageDigest     string                  `json:"expected_base_image_digest,omitempty"`
+	ExpectedSnapshotParent      string                  `json:"expected_snapshot_parent,omitempty"`
+	ExpectedSnapshotParentChain []string                `json:"expected_snapshot_parent_chain,omitempty"`
+	BaselineLayerID             string                  `json:"baseline_layer_id,omitempty"`
+	Layers                      []RootFSLayerDescriptor `json:"layers,omitempty"`
+	Descriptor                  RootFSDiffDescriptor    `json:"descriptor"`
 }
 
 type ApplyRootFSResponse struct {
-	Info       RootFSInfo           `json:"info,omitempty"`
-	Descriptor RootFSDiffDescriptor `json:"descriptor,omitempty"`
-	Applied    bool                 `json:"applied"`
-	Error      string               `json:"error,omitempty"`
+	Info       RootFSInfo              `json:"info,omitempty"`
+	Descriptor RootFSDiffDescriptor    `json:"descriptor,omitempty"`
+	Layers     []RootFSLayerDescriptor `json:"layers,omitempty"`
+	Applied    bool                    `json:"applied"`
+	Error      string                  `json:"error,omitempty"`
 }
 
 // BindVolumePortalRequest binds one pre-published pod portal to a concrete

--- a/tests/integration/internal/tests/manager/api_test.go
+++ b/tests/integration/internal/tests/manager/api_test.go
@@ -898,7 +898,25 @@ func cloneRootFSStateForManagerIntegration(state *service.SandboxRootFSState) *s
 	}
 	clone := *state
 	clone.SnapshotParentChain = append([]string(nil), state.SnapshotParentChain...)
+	clone.LayerChain = cloneRootFSLayersForManagerIntegration(state.LayerChain)
 	return &clone
+}
+
+func cloneRootFSLayersForManagerIntegration(layers []*service.SandboxRootFSLayer) []*service.SandboxRootFSLayer {
+	if len(layers) == 0 {
+		return nil
+	}
+	out := make([]*service.SandboxRootFSLayer, 0, len(layers))
+	for _, layer := range layers {
+		if layer == nil {
+			out = append(out, nil)
+			continue
+		}
+		clone := *layer
+		clone.SnapshotParentChain = append([]string(nil), layer.SnapshotParentChain...)
+		out = append(out, &clone)
+	}
+	return out
 }
 
 func (r *initializeRequestRecorder) Get() service.InitializeRequest {


### PR DESCRIPTION
## Summary

Refs #461.

This PR introduces the first rootfs layer-graph checkpoint slice while preserving the warm-pool-first resume path:

- add manager durable metadata for immutable `rootfs_layers`, `sandbox_rootfs_heads`, and future `rootfs_snapshots`;
- save new checkpoints as layer/head state while retaining legacy `sandbox_rootfs_states` for migration compatibility;
- apply rootfs layer chains into claimed warm/cold pods before procd initialization and capture a ctld baseline for the running head;
- make pause create a child diff relative to the captured parent baseline, with a narrow legacy full-diff fallback only when the local baseline was lost;
- remove the checkpoint-base-image retry path that could bypass warm-pool reuse after rootfs apply failure;
- add ctld overlay baseline diff support and stricter base validation for layer-chain materialization while leaving legacy descriptor apply behavior available.

Fork APIs, snapshot APIs, layer GC, and long-term runtime/user-rootfs split remain follow-up work on #461.

## Tests

- `go test ./pkg/ctldapi ./ctld/internal/ctld/rootfs ./ctld/internal/ctld/server ./manager/pkg/service ./tests/integration/internal/tests/manager`

Note: `go test ./ctld/cmd/ctld` currently fails before compiling this PR because the working tree lacks the generated `storage-proxy/proto/fs` Go package imported by storage-proxy code.
