### PR TITLE
Support Ali worker autoscaler scale-from-zero

### DIFF
--- a/docs/self-hosted/configuration/page.mdx
+++ b/docs/self-hosted/configuration/page.mdx
@@ -358,6 +358,7 @@ Examples:
 
 - `services.clusterGateway.config.authMode` switches between `public`, `internal`, and `both`
 - `services.manager.config.autoscaler.*` tunes pool scale behavior
+- `services.manager.config.allowColdStartWithoutReadyDataPlane` lets cold claims create Pending pods for external node autoscaler scale-from-zero deployments; keep it disabled unless the cluster autoscaler can provision matching sandbox nodes
 - `services.storageProxy.config.filesystem*` tunes filesystem behavior; `services.manager.config.procdConfig.volume*` tunes mounted volume cache sizing
 - `services.storageProxy.config.s0fsSegmentTargetSize` sets the target S0FS segment size for materialized volume data; the default is `4Mi`
 - `services.storageProxy.config.s0fsCompaction*` tunes background S0FS compaction for RWO volume owners; `s0fsCompactionInterval` accepts `0`, `off`, or `disabled` to turn it off

--- a/infra-operator/api/config/manager.go
+++ b/infra-operator/api/config/manager.go
@@ -82,6 +82,11 @@ type ManagerConfig struct {
 	TeamTemplateMemoryPerCPU string `yaml:"team_template_memory_per_cpu" json:"teamTemplateMemoryPerCpu"`
 	// +optional
 	SandboxRuntimeClassName string `yaml:"sandbox_runtime_class_name" json:"sandboxRuntimeClassName"`
+	// AllowColdStartWithoutReadyDataPlane lets cold claims create Pending pods
+	// when no sandbox data-plane-ready nodes exist yet. This is required for
+	// node autoscaler scale-from-zero deployments.
+	// +optional
+	AllowColdStartWithoutReadyDataPlane bool `yaml:"allow_cold_start_without_ready_data_plane" json:"allowColdStartWithoutReadyDataPlane"`
 
 	// NetworkPolicyProvider selects the dataplane integration used to enforce sandbox network policy.
 	// +optional

--- a/infra-operator/api/v1alpha1/service_api_config_types.go
+++ b/infra-operator/api/v1alpha1/service_api_config_types.go
@@ -442,6 +442,11 @@ type ManagerConfig struct {
 	TeamTemplateMemoryPerCPU string `json:"teamTemplateMemoryPerCpu,omitempty"`
 	// +optional
 	SandboxRuntimeClassName string `json:"sandboxRuntimeClassName,omitempty"`
+	// AllowColdStartWithoutReadyDataPlane lets cold claims create Pending pods
+	// when no sandbox data-plane-ready nodes exist yet. This is required for
+	// node autoscaler scale-from-zero deployments.
+	// +optional
+	AllowColdStartWithoutReadyDataPlane bool `json:"allowColdStartWithoutReadyDataPlane,omitempty"`
 	// +optional
 	// +kubebuilder:default="30s"
 	NetdPolicyApplyTimeout metav1.Duration `json:"netdPolicyApplyTimeout,omitempty"`

--- a/infra-operator/chart/crds/infra.sandbox0.ai_sandbox0infras.yaml
+++ b/infra-operator/chart/crds/infra.sandbox0.ai_sandbox0infras.yaml
@@ -2764,6 +2764,12 @@ spec:
                         default: {}
                         description: Config contains manager specific configuration
                         properties:
+                          allowColdStartWithoutReadyDataPlane:
+                            description: |-
+                              AllowColdStartWithoutReadyDataPlane lets cold claims create Pending pods
+                              when no sandbox data-plane-ready nodes exist yet. This is required for
+                              node autoscaler scale-from-zero deployments.
+                            type: boolean
                           autoscaler:
                             default: {}
                             description: AutoscalerConfig defines manager autoscaler

--- a/infra-operator/internal/runtimeconfig/dataplane.go
+++ b/infra-operator/internal/runtimeconfig/dataplane.go
@@ -26,6 +26,7 @@ func ToManager(spec *infrav1alpha1.ManagerConfig) *apiconfig.ManagerConfig {
 	cfg.DefaultSandboxTTL = spec.DefaultSandboxTTL
 	cfg.TeamTemplateMemoryPerCPU = spec.TeamTemplateMemoryPerCPU
 	cfg.SandboxRuntimeClassName = spec.SandboxRuntimeClassName
+	cfg.AllowColdStartWithoutReadyDataPlane = spec.AllowColdStartWithoutReadyDataPlane
 	cfg.NetdPolicyApplyTimeout = spec.NetdPolicyApplyTimeout
 	cfg.NetdPolicyApplyPollInterval = spec.NetdPolicyApplyPollInterval
 	cfg.PauseMinMemoryRequest = spec.PauseMinMemoryRequest

--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -285,19 +285,20 @@ func main() {
 
 	// Create services
 	cfgForSandbox := service.SandboxServiceConfig{
-		DefaultTTL:             cfg.DefaultSandboxTTL.Duration,
-		PauseMinMemoryRequest:  cfg.PauseMinMemoryRequest,
-		PauseMinMemoryLimit:    cfg.PauseMinMemoryLimit,
-		PauseMemoryBufferRatio: pauseMemoryBufferRatio,
-		PauseMinCPU:            cfg.PauseMinCPU,
-		CtldEnabled:            cfg.CtldEnabled,
-		CtldPort:               cfg.CtldPort,
-		CtldClientTimeout:      cfg.CtldClientTimeout.Duration,
-		CtldHTTPClient:         obsProvider.HTTP.NewClient(httpobs.Config{Timeout: cfg.CtldClientTimeout.Duration}),
-		ProcdPort:              cfg.ProcdConfig.HTTPPort,
-		ProcdClientTimeout:     cfg.ProcdClientTimeout.Duration,
-		ProcdHTTPClient:        obsProvider.HTTP.NewClient(httpobs.Config{Timeout: cfg.ProcdClientTimeout.Duration}),
-		ProcdInitTimeout:       cfg.ProcdInitTimeout.Duration,
+		DefaultTTL:                          cfg.DefaultSandboxTTL.Duration,
+		PauseMinMemoryRequest:               cfg.PauseMinMemoryRequest,
+		PauseMinMemoryLimit:                 cfg.PauseMinMemoryLimit,
+		PauseMemoryBufferRatio:              pauseMemoryBufferRatio,
+		PauseMinCPU:                         cfg.PauseMinCPU,
+		CtldEnabled:                         cfg.CtldEnabled,
+		CtldPort:                            cfg.CtldPort,
+		CtldClientTimeout:                   cfg.CtldClientTimeout.Duration,
+		CtldHTTPClient:                      obsProvider.HTTP.NewClient(httpobs.Config{Timeout: cfg.CtldClientTimeout.Duration}),
+		ProcdPort:                           cfg.ProcdConfig.HTTPPort,
+		ProcdClientTimeout:                  cfg.ProcdClientTimeout.Duration,
+		ProcdHTTPClient:                     obsProvider.HTTP.NewClient(httpobs.Config{Timeout: cfg.ProcdClientTimeout.Duration}),
+		ProcdInitTimeout:                    cfg.ProcdInitTimeout.Duration,
+		AllowColdStartWithoutReadyDataPlane: cfg.AllowColdStartWithoutReadyDataPlane,
 	}
 
 	sandboxService := service.NewSandboxService(

--- a/manager/pkg/controller/pool_manager.go
+++ b/manager/pkg/controller/pool_manager.go
@@ -80,7 +80,7 @@ func TemplateLogicalID(template *v1alpha1.SandboxTemplate) string {
 }
 
 // ClaimedSandboxPodAnnotations returns manager-owned metadata for active sandbox
-// pods. Idle pool pods intentionally do not carry these annotations.
+// pods. Active sandboxes are marked unsafe for Cluster Autoscaler eviction.
 func ClaimedSandboxPodAnnotations(extra map[string]string) map[string]string {
 	annotations := make(map[string]string, len(extra)+1)
 	for key, value := range extra {
@@ -312,7 +312,8 @@ func (pm *PoolManager) reconcileReplicaSetMetadata(
 func (pm *PoolManager) buildPodTemplate(template *v1alpha1.SandboxTemplate, specHash string) (corev1.PodTemplateSpec, error) {
 	spec := v1alpha1.BuildPodSpec(template)
 	annotations := map[string]string{
-		AnnotationTemplateSpecHash: specHash,
+		AnnotationTemplateSpecHash:             specHash,
+		AnnotationClusterAutoscalerSafeToEvict: "true",
 	}
 	return corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{

--- a/manager/pkg/controller/pool_manager_test.go
+++ b/manager/pkg/controller/pool_manager_test.go
@@ -42,7 +42,7 @@ func TestBuildPodTemplateIncludesTemplateHash(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, got.Annotations)
 	assert.Equal(t, "hash-v1", got.Annotations[AnnotationTemplateSpecHash])
-	assert.NotContains(t, got.Annotations, AnnotationClusterAutoscalerSafeToEvict)
+	assert.Equal(t, "true", got.Annotations[AnnotationClusterAutoscalerSafeToEvict])
 	assert.Equal(t, PoolTypeIdle, got.Labels[LabelPoolType])
 	assert.Equal(t, "template-a", got.Labels[LabelTemplateID])
 	assert.Equal(t, "logical-a", got.Labels[LabelTemplateLogicalID])

--- a/manager/pkg/service/sandbox_service.go
+++ b/manager/pkg/service/sandbox_service.go
@@ -75,19 +75,20 @@ var claimIdlePodBackoff = wait.Backoff{
 
 // SandboxServiceConfig handles configuration for SandboxService
 type SandboxServiceConfig struct {
-	DefaultTTL             time.Duration
-	PauseMinMemoryRequest  string
-	PauseMinMemoryLimit    string
-	PauseMemoryBufferRatio float64
-	PauseMinCPU            string
-	CtldEnabled            bool
-	CtldPort               int
-	CtldClientTimeout      time.Duration
-	CtldHTTPClient         *http.Client
-	ProcdPort              int
-	ProcdClientTimeout     time.Duration
-	ProcdHTTPClient        *http.Client
-	ProcdInitTimeout       time.Duration
+	DefaultTTL                          time.Duration
+	PauseMinMemoryRequest               string
+	PauseMinMemoryLimit                 string
+	PauseMemoryBufferRatio              float64
+	PauseMinCPU                         string
+	CtldEnabled                         bool
+	CtldPort                            int
+	CtldClientTimeout                   time.Duration
+	CtldHTTPClient                      *http.Client
+	ProcdPort                           int
+	ProcdClientTimeout                  time.Duration
+	ProcdHTTPClient                     *http.Client
+	ProcdInitTimeout                    time.Duration
+	AllowColdStartWithoutReadyDataPlane bool
 }
 
 // SandboxService handles sandbox operations

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -1211,6 +1211,9 @@ func (s *SandboxService) ensureDataPlaneReadyCapacity(spec corev1.PodSpec) error
 		return nil
 	}
 	if s == nil || s.nodeLister == nil {
+		if s != nil && s.config.AllowColdStartWithoutReadyDataPlane {
+			return nil
+		}
 		return fmt.Errorf("%w: manager node cache is not configured", ErrDataPlaneNotReady)
 	}
 	selector := labels.SelectorFromSet(spec.NodeSelector)
@@ -1219,6 +1222,9 @@ func (s *SandboxService) ensureDataPlaneReadyCapacity(spec corev1.PodSpec) error
 		return fmt.Errorf("list data-plane-ready nodes: %w", err)
 	}
 	if len(nodes) == 0 {
+		if s.config.AllowColdStartWithoutReadyDataPlane {
+			return nil
+		}
 		return fmt.Errorf("%w: no nodes match selector %q", ErrDataPlaneNotReady, labels.Set(spec.NodeSelector).String())
 	}
 	return nil

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -312,6 +312,22 @@ func TestClaimIdlePodRequiresDataPlaneReadyNode(t *testing.T) {
 	}
 }
 
+func TestEnsureDataPlaneReadyCapacityAllowsColdStartWithoutReadyNode(t *testing.T) {
+	svc := &SandboxService{
+		nodeLister: newClaimTestNodeLister(t),
+		config: SandboxServiceConfig{
+			AllowColdStartWithoutReadyDataPlane: true,
+		},
+	}
+	spec := corev1.PodSpec{
+		NodeSelector: dataplane.DataPlaneReadyNodeSelector(),
+	}
+
+	if err := svc.ensureDataPlaneReadyCapacity(spec); err != nil {
+		t.Fatalf("ensureDataPlaneReadyCapacity() error = %v", err)
+	}
+}
+
 func TestClaimIdlePodRequestsDeleteAfterNetworkApplyFailure(t *testing.T) {
 	template := &v1alpha1.SandboxTemplate{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Summary
- add `allowColdStartWithoutReadyDataPlane` to infra-operator/manager config
- allow sandbox claims to proceed when no ready data-plane node exists and cold start is explicitly enabled
- mark idle pool pods safe to evict while keeping active sandbox pods protected
- document the new manager configuration option

## Tests
- `go test ./manager/pkg/controller ./manager/pkg/service ./infra-operator/internal/runtimeconfig/...`
