### PR TITLE
Restore rootfs apply fallback runtime

### DIFF
--- a/manager/pkg/service/sandbox_service_restore.go
+++ b/manager/pkg/service/sandbox_service_restore.go
@@ -100,7 +100,11 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 		return s.GetSandbox(ctx, sandboxID)
 	}
 
-	if err := s.finishRestoredSandboxRuntime(ctx, pod, record, claimType); err != nil {
+	restoredPod, err := s.finishRestoredSandboxRuntime(ctx, pod, record, claimType)
+	if err != nil {
+		if restoredPod != nil {
+			pod = restoredPod
+		}
 		s.requestSandboxDeletionAfterClaimFailure(pod, "restored runtime initialization failed")
 		_ = s.pauseSandboxRuntime(context.Background(), sandboxID, false)
 		return nil, err
@@ -108,15 +112,15 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 	return s.GetSandbox(ctx, sandboxID)
 }
 
-func (s *SandboxService) finishRestoredSandboxRuntime(ctx context.Context, pod *corev1.Pod, record *SandboxRecord, claimType string) error {
+func (s *SandboxService) finishRestoredSandboxRuntime(ctx context.Context, pod *corev1.Pod, record *SandboxRecord, claimType string) (*corev1.Pod, error) {
 	template, err := s.templateForSandboxRecord(record)
 	if err != nil {
-		return err
+		return pod, err
 	}
 	if claimType == "cold" {
 		readyPod, err := s.waitForPodClaimReady(ctx, pod.Namespace, pod.Name)
 		if err != nil {
-			return fmt.Errorf("wait for pod claim readiness: %w", err)
+			return pod, fmt.Errorf("wait for pod claim readiness: %w", err)
 		}
 		pod = readyPod
 		s.refreshSandboxProbeConditionsAsync(pod)
@@ -132,26 +136,27 @@ func (s *SandboxService) finishRestoredSandboxRuntime(ctx context.Context, pod *
 	}
 	rootFSState, err := s.latestRootFSState(ctx, record.ID)
 	if err != nil {
-		return fmt.Errorf("load rootfs checkpoint: %w", err)
+		return pod, fmt.Errorf("load rootfs checkpoint: %w", err)
 	}
-	if err := s.applySandboxRootFSCheckpoint(ctx, pod, rootFSState); err != nil {
-		return err
+	pod, err = s.applySandboxRootFSCheckpointWithFallback(ctx, pod, record, template, req, rootFSState)
+	if err != nil {
+		return pod, err
 	}
 	if _, err := s.bindVolumePortals(ctx, pod, req, template); err != nil {
-		return fmt.Errorf("bind volume portals: %w", err)
+		return pod, fmt.Errorf("bind volume portals: %w", err)
 	}
 	if err := s.bindWebhookStatePortal(ctx, pod, req); err != nil {
-		return fmt.Errorf("bind webhook state portal: %w", err)
+		return pod, fmt.Errorf("bind webhook state portal: %w", err)
 	}
 	procdAddress, err := s.prodAddress(ctx, pod)
 	if err != nil {
-		return fmt.Errorf("get procd address: %w", err)
+		return pod, fmt.Errorf("get procd address: %w", err)
 	}
 	if _, err := s.initializeProcd(ctx, pod, req, procdAddress); err != nil {
-		return fmt.Errorf("initialize procd: %w", err)
+		return pod, fmt.Errorf("initialize procd: %w", err)
 	}
 	if err := s.persistUpdatedSandboxPod(ctx, pod); err != nil {
-		return fmt.Errorf("persist restored sandbox: %w", err)
+		return pod, fmt.Errorf("persist restored sandbox: %w", err)
 	}
 	if s.logger != nil {
 		s.logger.Info("Resumed paused sandbox runtime",
@@ -160,7 +165,7 @@ func (s *SandboxService) finishRestoredSandboxRuntime(ctx context.Context, pod *
 			zap.String("claimType", claimType),
 		)
 	}
-	return nil
+	return pod, nil
 }
 
 func (s *SandboxService) templateForSandboxRecord(record *SandboxRecord) (*v1alpha1.SandboxTemplate, error) {

--- a/manager/pkg/service/sandbox_service_rootfs.go
+++ b/manager/pkg/service/sandbox_service_rootfs.go
@@ -9,8 +9,11 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	godigest "github.com/opencontainers/go-digest"
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
+	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -124,6 +127,113 @@ func (s *SandboxService) applySandboxRootFSCheckpoint(ctx context.Context, pod *
 		return fmt.Errorf("apply sandbox rootfs checkpoint: ctld did not report applied")
 	}
 	return nil
+}
+
+func (s *SandboxService) applySandboxRootFSCheckpointWithFallback(ctx context.Context, pod *corev1.Pod, record *SandboxRecord, template *v1alpha1.SandboxTemplate, req *ClaimRequest, state *SandboxRootFSState) (*corev1.Pod, error) {
+	if state == nil {
+		return pod, nil
+	}
+	err := s.applySandboxRootFSCheckpoint(ctx, pod, state)
+	if err == nil {
+		return pod, nil
+	}
+	fallbackTemplate, fallbackErr := templateWithCheckpointBaseImage(template, state)
+	if fallbackErr != nil {
+		return pod, fmt.Errorf("%w; checkpoint base image fallback unavailable: %v", err, fallbackErr)
+	}
+	if s != nil && s.logger != nil {
+		s.logger.Warn("Rootfs force-apply failed; retrying with checkpoint base image",
+			zap.String("sandboxID", state.SandboxID),
+			zap.String("baseImageRef", state.BaseImageRef),
+			zap.String("baseImageDigest", state.BaseImageDigest),
+			zap.Error(err),
+		)
+	}
+	s.requestSandboxDeletionAfterClaimFailure(pod, "rootfs force-apply failed")
+
+	fallbackPod, fallbackErr := s.createNewPod(ctx, fallbackTemplate, req)
+	if fallbackErr != nil {
+		return pod, fmt.Errorf("%w; create checkpoint base image runtime: %v", err, fallbackErr)
+	}
+	readyPod, fallbackErr := s.waitForPodClaimReady(ctx, fallbackPod.Namespace, fallbackPod.Name)
+	if fallbackErr != nil {
+		s.requestSandboxDeletionAfterClaimFailure(fallbackPod, "checkpoint base image runtime readiness failed")
+		return fallbackPod, fmt.Errorf("%w; wait for checkpoint base image runtime: %v", err, fallbackErr)
+	}
+	if fallbackErr := s.saveRestoredRuntimePod(ctx, readyPod, record, SandboxStatusResuming); fallbackErr != nil {
+		s.requestSandboxDeletionAfterClaimFailure(readyPod, "checkpoint base image runtime persistence failed")
+		return readyPod, fmt.Errorf("%w; save checkpoint base image runtime: %v", err, fallbackErr)
+	}
+	if fallbackErr := s.applySandboxRootFSCheckpoint(ctx, readyPod, state); fallbackErr != nil {
+		s.requestSandboxDeletionAfterClaimFailure(readyPod, "checkpoint base image rootfs apply failed")
+		return readyPod, fmt.Errorf("%w; checkpoint base image retry failed: %v", err, fallbackErr)
+	}
+	return readyPod, nil
+}
+
+func (s *SandboxService) saveRestoredRuntimePod(ctx context.Context, pod *corev1.Pod, record *SandboxRecord, status string) error {
+	if s == nil || s.sandboxStore == nil || pod == nil || record == nil {
+		return nil
+	}
+	sandboxID := strings.TrimSpace(record.ID)
+	if sandboxID == "" {
+		sandboxID = sandboxIDFromPod(pod)
+	}
+	if sandboxID == "" {
+		return fmt.Errorf("sandbox_id is required")
+	}
+	return s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, _ *SandboxRecord) error {
+		return tx.SaveRuntime(lockCtx, sandboxID, pod.Namespace, pod.Name, status, runtimeGenerationFromPod(pod), parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationExpiresAt), parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationHardExpiresAt))
+	})
+}
+
+func templateWithCheckpointBaseImage(template *v1alpha1.SandboxTemplate, state *SandboxRootFSState) (*v1alpha1.SandboxTemplate, error) {
+	if template == nil {
+		return nil, fmt.Errorf("template is required")
+	}
+	image, err := checkpointBaseImageRef(state)
+	if err != nil {
+		return nil, err
+	}
+	clone := template.DeepCopy()
+	clone.Spec.MainContainer.Image = image
+	clone.Spec.MainContainer.ImagePullPolicy = string(corev1.PullIfNotPresent)
+	return clone, nil
+}
+
+func checkpointBaseImageRef(state *SandboxRootFSState) (string, error) {
+	if state == nil {
+		return "", fmt.Errorf("rootfs state is required")
+	}
+	repo := imageRepositoryFromRef(state.BaseImageRef)
+	if repo == "" {
+		return "", fmt.Errorf("base image ref is required")
+	}
+	digestValue := strings.TrimSpace(state.BaseImageDigest)
+	if digestValue == "" {
+		return "", fmt.Errorf("base image digest is required")
+	}
+	parsed, err := godigest.Parse(digestValue)
+	if err != nil {
+		return "", fmt.Errorf("base image digest %q is invalid: %w", digestValue, err)
+	}
+	return repo + "@" + parsed.String(), nil
+}
+
+func imageRepositoryFromRef(ref string) string {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return ""
+	}
+	if idx := strings.LastIndex(ref, "@"); idx >= 0 {
+		ref = ref[:idx]
+	}
+	lastSlash := strings.LastIndex(ref, "/")
+	lastColon := strings.LastIndex(ref, ":")
+	if lastColon > lastSlash {
+		ref = ref[:lastColon]
+	}
+	return strings.TrimSpace(ref)
 }
 
 func rootFSLayerDescriptors(state *SandboxRootFSState) []ctldapi.RootFSLayerDescriptor {

--- a/manager/pkg/service/sandbox_service_rootfs_test.go
+++ b/manager/pkg/service/sandbox_service_rootfs_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -15,6 +16,8 @@ import (
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
+	"github.com/sandbox0-ai/sandbox0/pkg/naming"
+	"github.com/sandbox0-ai/sandbox0/pkg/sandboxprobe"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -23,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
+	corelisters "k8s.io/client-go/listers/core/v1"
 	ktesting "k8s.io/client-go/testing"
 )
 
@@ -358,7 +362,8 @@ func TestFinishRestoredSandboxRuntimeAppliesRootFSBeforeProcdInitialization(t *t
 		Status:            SandboxStatusPaused,
 	}
 
-	require.NoError(t, svc.finishRestoredSandboxRuntime(context.Background(), pod, record, "hot"))
+	_, err := svc.finishRestoredSandboxRuntime(context.Background(), pod, record, "hot")
+	require.NoError(t, err)
 	assert.Equal(t, []string{"apply", "procd"}, calls)
 }
 
@@ -416,7 +421,8 @@ func TestFinishRestoredSandboxRuntimeAppliesRootFSLayerChain(t *testing.T) {
 		Status:            SandboxStatusPaused,
 	}
 
-	require.NoError(t, svc.finishRestoredSandboxRuntime(context.Background(), pod, record, "hot"))
+	_, err := svc.finishRestoredSandboxRuntime(context.Background(), pod, record, "hot")
+	require.NoError(t, err)
 
 	assert.Empty(t, applyReq.Descriptor.Digest)
 	assert.Equal(t, "layer-child", applyReq.BaselineLayerID)
@@ -429,39 +435,119 @@ func TestFinishRestoredSandboxRuntimeAppliesRootFSLayerChain(t *testing.T) {
 	assert.Equal(t, "rootfs/child.tar", applyReq.Layers[1].Descriptor.ObjectKey)
 }
 
-func TestFinishRestoredSandboxRuntimeDoesNotCreateFallbackPodOnRootFSApplyFailure(t *testing.T) {
+func TestFinishRestoredSandboxRuntimeRetriesWithCheckpointBaseImage(t *testing.T) {
+	withClaimTestPublicKey(t)
+
+	const checkpointDigest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	templateNamespace, err := naming.TemplateNamespaceForTeam("team-1")
+	require.NoError(t, err)
+
+	var applyTargets []string
 	ctld := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/api/v1/rootfs/apply", r.URL.Path)
-		w.WriteHeader(http.StatusInternalServerError)
-		_ = json.NewEncoder(w).Encode(ctldapi.ApplyRootFSResponse{Error: "apply rootfs diff: simulated failure"})
+		switch {
+		case r.URL.Path == "/api/v1/rootfs/apply":
+			var req ctldapi.ApplyRootFSRequest
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+			applyTargets = append(applyTargets, req.Target.PodName)
+			assert.Equal(t, checkpointDigest, req.ExpectedBaseImageDigest)
+			if req.Target.PodName == "pod-current" {
+				w.WriteHeader(http.StatusInternalServerError)
+				_ = json.NewEncoder(w).Encode(ctldapi.ApplyRootFSResponse{Error: "apply rootfs diff: simulated conflict"})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(ctldapi.ApplyRootFSResponse{Applied: true})
+		case strings.HasSuffix(r.URL.Path, "/probes/readiness"):
+			_ = json.NewEncoder(w).Encode(sandboxprobe.Passed(sandboxprobe.KindReadiness, "SandboxProbePassed", "sandbox probe passed", nil))
+		case r.URL.Path == "/api/v1/volume-portals/check":
+			_ = json.NewEncoder(w).Encode(ctldapi.CheckVolumePortalsResponse{Ready: true})
+		default:
+			t.Fatalf("unexpected ctld path: %s", r.URL.Path)
+		}
 	}))
 	defer ctld.Close()
 	ctldURL, ctldPort := parsedTestServer(t, ctld.URL)
 
 	procd := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatalf("procd must not be initialized after rootfs apply failure")
+		require.Equal(t, "/api/v1/initialize", r.URL.Path)
+		require.Len(t, applyTargets, 2)
+		require.NoError(t, spec.WriteSuccess(w, http.StatusOK, InitializeResponse{SandboxID: "sandbox-1", TeamID: "team-1"}))
 	}))
 	defer procd.Close()
 	procdURL, procdPort := parsedTestServer(t, procd.URL)
 
-	pod := rootFSTestPod("pod-1", "sandbox-1", "team-1")
-	pod.Status.HostIP = ctldURL.Hostname()
-	pod.Status.PodIP = procdURL.Hostname()
-	k8sClient := fake.NewSimpleClientset(pod)
-	var createCalled atomic.Bool
+	currentPod := rootFSTestPod("pod-current", "sandbox-1", "team-1")
+	currentPod.Namespace = templateNamespace
+	currentPod.Status.HostIP = ctldURL.Hostname()
+	currentPod.Status.PodIP = procdURL.Hostname()
+	indexer := newClaimTestPodIndexer(t, currentPod)
+	k8sClient := fake.NewSimpleClientset(currentPod)
+	var fallbackImage string
 	k8sClient.PrependReactor("create", "pods", func(action ktesting.Action) (bool, runtime.Object, error) {
-		createCalled.Store(true)
+		pod := action.(ktesting.CreateAction).GetObject().(*corev1.Pod).DeepCopy()
+		require.Len(t, pod.Spec.Containers, 1)
+		fallbackImage = pod.Spec.Containers[0].Image
+
+		readyPod := pod.DeepCopy()
+		readyPod.UID = types.UID("fallback-uid")
+		readyPod.Status.Phase = corev1.PodRunning
+		readyPod.Status.HostIP = ctldURL.Hostname()
+		readyPod.Status.PodIP = procdURL.Hostname()
+		readyPod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+			Name:  "procd",
+			State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+		}}
+		require.NoError(t, indexer.Add(readyPod))
 		return false, nil, nil
 	})
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "template-1",
+			Namespace: templateNamespace,
+		},
+		Spec: v1alpha1.SandboxTemplateSpec{
+			MainContainer: v1alpha1.ContainerSpec{Image: "docker.io/library/busybox:1.37"},
+		},
+	}
 	store := &memorySandboxStore{
-		records: map[string]*SandboxRecord{},
+		records: map[string]*SandboxRecord{
+			"sandbox-1": {
+				ID:                  "sandbox-1",
+				TeamID:              "team-1",
+				UserID:              "user-1",
+				TemplateID:          "template-1",
+				TemplateName:        "template-1",
+				TemplateNamespace:   templateNamespace,
+				TemplateSpec:        template.Spec,
+				CurrentPodName:      "pod-current",
+				CurrentPodNamespace: templateNamespace,
+				RuntimeGeneration:   3,
+				Status:              SandboxStatusResuming,
+			},
+		},
 		rootFSStates: map[string]*SandboxRootFSState{
-			"sandbox-1": rootFSTestState(),
+			"sandbox-1": {
+				SandboxID:           "sandbox-1",
+				TeamID:              "team-1",
+				RuntimeGeneration:   3,
+				Runtime:             "runc",
+				RuntimeHandler:      "io.containerd.runc.v2",
+				BaseImageRef:        "docker.io/library/busybox:1.36",
+				BaseImageDigest:     checkpointDigest,
+				Snapshotter:         "overlayfs",
+				SnapshotParent:      "parent-1",
+				SnapshotParentChain: []string{"parent-1", "parent-0"},
+				DiffDigest:          "sha256:diff",
+				DiffMediaType:       "application/vnd.oci.image.layer.v1.tar",
+				DiffSize:            123,
+				DiffObjectKey:       "sandbox-rootfs/team-1/sandbox-1/3/sha256/diff.tar",
+			},
 		},
 	}
 	svc := &SandboxService{
 		k8sClient:              k8sClient,
-		podLister:              newTestPodLister(t, pod),
+		podLister:              corelisters.NewPodLister(indexer),
+		secretLister:           newClaimTestSecretLister(t),
+		templateLister:         staticTemplateLister{templates: []*v1alpha1.SandboxTemplate{template}},
 		sandboxStore:           store,
 		ctldClient:             NewCtldClient(CtldClientConfig{Timeout: time.Second}),
 		procdClient:            NewProcdClient(ProcdClientConfig{Timeout: time.Second}),
@@ -475,23 +561,27 @@ func TestFinishRestoredSandboxRuntimeDoesNotCreateFallbackPodOnRootFSApplyFailur
 		clock:  systemTime{},
 		logger: zap.NewNop(),
 	}
-	record := &SandboxRecord{
-		ID:                "sandbox-1",
-		TeamID:            "team-1",
-		UserID:            "user-1",
-		TemplateID:        "template-1",
-		TemplateName:      "template-1",
-		TemplateNamespace: "template-default",
-		TemplateSpec:      v1alpha1.SandboxTemplateSpec{},
-		RuntimeGeneration: 3,
-		Status:            SandboxStatusPaused,
-	}
+	record := store.records["sandbox-1"]
 
-	err := svc.finishRestoredSandboxRuntime(context.Background(), pod, record, "hot")
+	_, err = svc.finishRestoredSandboxRuntime(context.Background(), currentPod, record, "hot")
 
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "apply rootfs diff: simulated failure")
-	assert.False(t, createCalled.Load())
+	require.NoError(t, err)
+	require.Len(t, applyTargets, 2)
+	assert.Equal(t, "pod-current", applyTargets[0])
+	assert.NotEqual(t, "pod-current", applyTargets[1])
+	assert.Equal(t, "docker.io/library/busybox@"+checkpointDigest, fallbackImage)
+	assert.Equal(t, applyTargets[1], store.records["sandbox-1"].CurrentPodName)
+	assert.Equal(t, SandboxStatusRunning, store.records["sandbox-1"].Status)
+}
+
+func TestCheckpointBaseImageRefPinsDigest(t *testing.T) {
+	ref, err := checkpointBaseImageRef(&SandboxRootFSState{
+		BaseImageRef:    "registry.example.com:5000/team/image:old-tag",
+		BaseImageDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "registry.example.com:5000/team/image@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", ref)
 }
 
 func TestRestoreFailureCleanupCanSkipRootFSSave(t *testing.T) {


### PR DESCRIPTION
## Summary
- retry rootfs restore on a checkpoint-base-image runtime when apply fails on the claimed pod
- keep resume warm-pool-first; the fallback pod is only created after rootfs apply failure
- return the final restored pod to cleanup paths so fallback runtimes are deleted on later initialization failures
- replace the no-fallback regression test with checkpoint-base-image fallback coverage

## Tests
- go test ./manager/pkg/service