### PR TITLE
Add claimable rootfs objects

### DIFF
--- a/docs/get-started/concepts/page.mdx
+++ b/docs/get-started/concepts/page.mdx
@@ -27,7 +27,8 @@ A common confusion is mixing compute state and durable state.
 
 - Process state lives in the sandbox runtime and disappears when the runtime is paused or deleted.
 - Sandbox0 restores the writable root filesystem checkpoint for paused sandboxes, so files written outside mounted volumes survive pause/resume for the same sandbox identity.
-- The rootfs checkpoint is not a Volume. It is not shareable across sandboxes, does not expose volume snapshot/fork APIs, and is deleted with the sandbox identity.
+- A saved rootfs checkpoint has a `rootfs_id` that can be used as the base for a later sandbox claim when the template image matches the checkpoint base image.
+- The rootfs checkpoint is not a Volume. It does not expose mounted sharing, direct file APIs, or Volume snapshot/fork APIs, and it is deleted with the sandbox identity.
 - Durable state that must survive sandbox delete or `hard_ttl`, needs snapshots, or needs sharing outside the sandbox identity should be written to volumes or external systems.
 - If your agent must recover after failures or redeploys, treat sandbox runtime as ephemeral and volumes as the source of truth.
 

--- a/docs/sandbox/page.mdx
+++ b/docs/sandbox/page.mdx
@@ -44,9 +44,10 @@ Sandbox0 persists the sandbox writable root filesystem as part of checkpointed p
 - when `ttl` expires or pause is requested, Sandbox0 saves a rootfs checkpoint before releasing the runtime pod
 - when the sandbox resumes, Sandbox0 creates or reuses a runtime pod and restores the latest rootfs checkpoint before initializing sandbox processes
 - files written outside mounted volumes survive pause/resume for the same sandbox identity after a checkpoint succeeds
+- each saved checkpoint advances a `rootfs_id` that can be used as the root filesystem base for a later sandbox claim when the template image matches the checkpoint base image
 - rootfs checkpoints are deleted when the sandbox is deleted or `hard_ttl` expires
 
-Use the root filesystem for transparent same-sandbox continuity. Use [Volumes](/docs/volume) for data that must outlive one sandbox identity, be shared, snapshotted, forked, restored, or accessed directly through APIs.
+Use the root filesystem for transparent same-sandbox continuity and rootfs-based sandbox branching. Use [Volumes](/docs/volume) for data that must outlive one sandbox identity, be shared as a mounted filesystem, snapshotted, forked, restored, or accessed directly through APIs.
 
 ---
 

--- a/docs/sandbox/pause-resume/page.mdx
+++ b/docs/sandbox/pause-resume/page.mdx
@@ -26,7 +26,7 @@ Self-hosted deployments must run `ctld` on sandbox nodes for checkpointed pause/
 | Mounted Volumes | Remounted if configured | Preserved until the Volume is deleted |
 | Processes, memory, sockets, PID state, live REPL sessions | Not preserved | Deleted |
 
-The rootfs checkpoint covers files written inside the sandbox filesystem, including files outside mounted volumes. It is different from a Sandbox Volume: it is tied to one sandbox identity and does not provide volume sharing, direct file APIs, snapshots, forks, or restore operations.
+The rootfs checkpoint covers files written inside the sandbox filesystem, including files outside mounted volumes. Each successful checkpoint records a rootfs object id on the Sandbox. A later sandbox claim can pass that `rootfs_id` to start from the checkpointed root filesystem, but manager only accepts it when the requested template image matches the checkpoint base image. It is still different from a Sandbox Volume: it does not provide mounted shared storage, direct file APIs, or Volume snapshot/restore operations.
 
 On nodes using the containerd overlayfs snapshotter, `ctld` checkpoints only the active snapshot upperdir and stores it as a standard OCI layer diff. Other snapshotters, or nodes where the overlayfs upperdir is not readable by `ctld`, fall back to containerd's built-in diff path.
 
@@ -77,6 +77,8 @@ Resume a sandbox that was paused manually or by TTL expiry.
 
 Resume first restores the writable rootfs checkpoint onto a runtime pod created from the current template image. If that restore fails, Sandbox0 retries once with a runtime pod pinned to the checkpoint's recorded base image digest. Kubernetes pulls and garbage-collects that image through the normal kubelet image lifecycle.
 
+To create a new sandbox from a saved rootfs object, pass `rootfs_id` in `POST /api/v1/sandboxes`. The rootfs is applied before procd initialization, so files from the checkpoint are visible to the first process started in the new sandbox.
+
 <Endpoint method="POST">
 /api/v1/sandboxes/{'{id}'}/resume
 </Endpoint>
@@ -117,6 +119,8 @@ console.log("Resume requested");`
 After requesting a pause or resume, fetch sandbox details to check the lifecycle status.
 
 During pause, `paused` remains `false` while `status` is `pausing`. It becomes `true` only after checkpoint upload has completed, the runtime pod has been released, and the sandbox is safe to resume from durable state.
+
+After a successful checkpoint, sandbox details include `rootfs_id`. Use that value in a future claim request only with a template image that matches the checkpoint base image.
 
 <Tabs
   tabs={[

--- a/docs/volume/page.mdx
+++ b/docs/volume/page.mdx
@@ -4,7 +4,7 @@ Volume provides persistent storage for Sandbox0. It is a storage unit independen
 
 ## Why Volumes?
 
-The default Sandbox writable filesystem is checkpointed across pause/resume for the same Sandbox identity. It is not independent long-term storage: when the Sandbox is deleted or `hard_ttl` expires, the identity and rootfs checkpoints are deleted too. Volumes solve the cases where data must outlive one Sandbox identity or be shared across Sandboxes:
+The default Sandbox writable filesystem is checkpointed across pause/resume for the same Sandbox identity. A saved checkpoint can also be used as a `rootfs_id` base for a later Sandbox claim when the template image matches. It is not independent long-term storage: when the Sandbox is deleted or `hard_ttl` expires, the identity and rootfs checkpoints are deleted too. Volumes solve the cases where data must outlive one Sandbox identity or be mounted/shared across Sandboxes:
 
 - **Data Persistence**: Store data that needs long-term retention, such as databases, model files, and user uploads
 - **Cross-Sandbox Sharing**: Mount the same Volume to multiple Sandboxes for data sharing
@@ -14,7 +14,7 @@ The default Sandbox writable filesystem is checkpointed across pause/resume for 
 
 | Storage surface | Survives pause/resume | Survives sandbox delete or `hard_ttl` | Shareable | Snapshots and forks | Direct file API |
 |-----------------|-----------------------|----------------------------------------|-----------|---------------------|-----------------|
-| Sandbox root filesystem | Yes, after checkpointed pause | No | No | No | Through the Sandbox file API while the Sandbox exists |
+| Sandbox root filesystem | Yes, after checkpointed pause | No | Claim by `rootfs_id` only | No | Through the Sandbox file API while the Sandbox exists |
 | Sandbox Volume | Yes | Yes, until the Volume is deleted | Yes | Yes | Yes |
 
 ## Volume and Sandbox Relationship

--- a/manager/pkg/controller/pool_manager.go
+++ b/manager/pkg/controller/pool_manager.go
@@ -57,6 +57,7 @@ const (
 	AnnotationNetworkPolicyHash            = "sandbox0.ai/network-policy-hash"
 	AnnotationNetworkPolicyAppliedHash     = "sandbox0.ai/network-policy-applied-hash"
 	AnnotationSandboxID                    = "sandbox0.ai/sandbox-id"
+	AnnotationRootFSID                     = "sandbox0.ai/rootfs-id"
 	AnnotationRuntimeGeneration            = "sandbox0.ai/runtime-generation"
 	AnnotationRuntimeDeletionReason        = "sandbox0.ai/runtime-deletion-reason"
 	AnnotationWebhookStateVolumeID         = "sandbox0.ai/webhook-state-volume-id"

--- a/manager/pkg/service/migrations/00004_add_sandbox_rootfs_id.sql
+++ b/manager/pkg/service/migrations/00004_add_sandbox_rootfs_id.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+
+ALTER TABLE sandboxes
+    ADD COLUMN IF NOT EXISTS rootfs_id TEXT NOT NULL DEFAULT '';
+
+CREATE INDEX IF NOT EXISTS idx_sandboxes_rootfs_id
+    ON sandboxes(rootfs_id)
+    WHERE rootfs_id <> '';
+
+-- +goose Down
+
+DROP INDEX IF EXISTS idx_sandboxes_rootfs_id;
+
+ALTER TABLE sandboxes
+    DROP COLUMN IF EXISTS rootfs_id;

--- a/manager/pkg/service/sandbox_runtime_identity_test.go
+++ b/manager/pkg/service/sandbox_runtime_identity_test.go
@@ -115,6 +115,11 @@ func (s *memorySandboxStore) SaveRootFSState(_ context.Context, state *SandboxRo
 		s.rootFSStates = make(map[string]*SandboxRootFSState)
 	}
 	s.rootFSStates[state.SandboxID] = cloneSandboxRootFSState(state)
+	if state.RootFSID != "" && s.records != nil {
+		if record := s.records[state.SandboxID]; record != nil {
+			record.RootFSID = state.RootFSID
+		}
+	}
 	return nil
 }
 
@@ -122,7 +127,35 @@ func (s *memorySandboxStore) GetLatestRootFSState(_ context.Context, sandboxID s
 	if s == nil || s.rootFSStates == nil {
 		return nil, nil
 	}
-	return cloneSandboxRootFSState(s.rootFSStates[sandboxID]), nil
+	if state := s.rootFSStates[sandboxID]; state != nil {
+		return cloneSandboxRootFSState(state), nil
+	}
+	if s.records != nil {
+		record := s.records[sandboxID]
+		if record != nil && record.RootFSID != "" {
+			for _, state := range s.rootFSStates {
+				if state != nil && state.RootFSID == record.RootFSID && state.TeamID == record.TeamID {
+					clone := cloneSandboxRootFSState(state)
+					clone.SandboxID = sandboxID
+					return clone, nil
+				}
+			}
+		}
+	}
+	return nil, nil
+}
+
+func (s *memorySandboxStore) GetRootFSState(_ context.Context, teamID, rootFSID string) (*SandboxRootFSState, error) {
+	if s == nil || s.rootFSStates == nil {
+		return nil, nil
+	}
+	for _, state := range s.rootFSStates {
+		if state == nil || state.RootFSID != rootFSID || state.TeamID != teamID {
+			continue
+		}
+		return cloneSandboxRootFSState(state), nil
+	}
+	return nil, nil
 }
 
 func (s *memorySandboxStore) WithSandboxLock(ctx context.Context, sandboxID string, fn func(context.Context, SandboxStoreTx, *SandboxRecord) error) error {

--- a/manager/pkg/service/sandbox_service.go
+++ b/manager/pkg/service/sandbox_service.go
@@ -32,6 +32,7 @@ type Sandbox struct {
 	Mounts            []ClaimMount        `json:"mounts,omitempty"`
 	PodName           string              `json:"pod_name"`
 	RuntimeGeneration int64               `json:"runtime_generation"`
+	RootFSID          string              `json:"rootfs_id,omitempty"`
 	ExpiresAt         time.Time           `json:"expires_at"`
 	HardExpiresAt     time.Time           `json:"hard_expires_at"`
 	ClaimedAt         time.Time           `json:"claimed_at"`

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -38,6 +38,7 @@ type ClaimRequest struct {
 	Template string         `json:"template"`
 	Config   *SandboxConfig `json:"config,omitempty"`
 	Mounts   []ClaimMount   `json:"mounts,omitempty"`
+	RootFSID string         `json:"rootfs_id,omitempty"`
 	Metadata *ClaimMetadata `json:"-"`
 	// SandboxID is an internal stable ID used when recreating an existing sandbox.
 	SandboxID string `json:"-"`
@@ -278,6 +279,7 @@ type ClaimResponse struct {
 	PodName         string                 `json:"pod_name"`
 	Template        string                 `json:"template"`
 	ClusterId       *string                `json:"cluster_id,omitempty"`
+	RootFSID        string                 `json:"rootfs_id,omitempty"`
 	BootstrapMounts []BootstrapMountStatus `json:"bootstrap_mounts,omitempty"`
 }
 
@@ -373,6 +375,15 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 	}
 	if req.RuntimeGeneration <= 0 {
 		req.RuntimeGeneration = 1
+	}
+	var rootFSState *SandboxRootFSState
+	if strings.TrimSpace(req.RootFSID) != "" {
+		phaseStarted = time.Now()
+		rootFSState, err = s.rootFSStateForClaim(ctx, req, template)
+		s.observeClaimPhase(req.Template, "unknown", "load_rootfs", phaseStarted, err)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	phaseStarted = time.Now()
@@ -474,6 +485,19 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 		s.refreshSandboxProbeConditionsAsync(pod)
 	}
 
+	if rootFSState != nil {
+		phaseStarted = time.Now()
+		pod, err = s.applySandboxRootFSCheckpointWithFallback(ctx, pod, nil, template, req, rootFSState)
+		s.observeClaimPhase(req.Template, claimType, "apply_rootfs", phaseStarted, err)
+		if err != nil {
+			s.requestSandboxDeletionAfterClaimFailure(pod, "rootfs apply failed")
+			if metrics != nil {
+				metrics.SandboxClaimsTotal.WithLabelValues(req.Template, "error").Inc()
+			}
+			return nil, fmt.Errorf("apply rootfs: %w", err)
+		}
+	}
+
 	phaseStarted = time.Now()
 	portalMounts, err := s.bindVolumePortals(ctx, pod, req, template)
 	s.observeClaimPhase(req.Template, claimType, "bind_volume_portals", phaseStarted, err)
@@ -539,6 +563,7 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 		PodName:         pod.Name,
 		Template:        req.Template,
 		ClusterId:       template.Spec.ClusterId,
+		RootFSID:        req.RootFSID,
 		BootstrapMounts: portalMounts,
 	}, nil
 }
@@ -556,6 +581,10 @@ func (s *SandboxService) persistClaimedSandbox(ctx context.Context, pod *corev1.
 	}
 	cfg := parseSandboxConfig(pod.Annotations[controller.AnnotationConfig])
 	mounts := parseClaimMounts(pod.Annotations[controller.AnnotationMounts])
+	rootFSID := strings.TrimSpace(pod.Annotations[controller.AnnotationRootFSID])
+	if rootFSID == "" {
+		rootFSID = strings.TrimSpace(req.RootFSID)
+	}
 	return s.sandboxStore.UpsertSandbox(ctx, &SandboxRecord{
 		ID:                  sandboxID,
 		TeamID:              req.TeamID,
@@ -571,6 +600,7 @@ func (s *SandboxService) persistClaimedSandbox(ctx context.Context, pod *corev1.
 		CurrentPodName:      pod.Name,
 		CurrentPodNamespace: pod.Namespace,
 		RuntimeGeneration:   runtimeGenerationFromPod(pod),
+		RootFSID:            rootFSID,
 		ClaimedAt:           parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationClaimedAt),
 		ExpiresAt:           parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationExpiresAt),
 		HardExpiresAt:       parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationHardExpiresAt),
@@ -925,6 +955,11 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 		pod.Annotations = controller.ClaimedSandboxPodAnnotations(pod.Annotations)
 		pod.Annotations[controller.AnnotationSandboxID] = sandboxID
 		pod.Annotations[controller.AnnotationRuntimeGeneration] = strconv.FormatInt(req.RuntimeGeneration, 10)
+		if rootFSID := strings.TrimSpace(req.RootFSID); rootFSID != "" {
+			pod.Annotations[controller.AnnotationRootFSID] = rootFSID
+		} else {
+			delete(pod.Annotations, controller.AnnotationRootFSID)
+		}
 		pod.Annotations[controller.AnnotationTeamID] = req.TeamID
 		pod.Annotations[controller.AnnotationUserID] = req.UserID
 		pod.Annotations[controller.AnnotationClaimedAt] = s.clock.Now().Format(time.RFC3339)
@@ -1079,6 +1114,9 @@ func (s *SandboxService) createNewPod(ctx context.Context, template *v1alpha1.Sa
 		controller.AnnotationClaimedAt:         s.clock.Now().Format(time.RFC3339),
 		controller.AnnotationClaimType:         "cold",
 	})
+	if rootFSID := strings.TrimSpace(req.RootFSID); rootFSID != "" {
+		annotations[controller.AnnotationRootFSID] = rootFSID
+	}
 	if stateVolume != nil {
 		annotations[controller.AnnotationWebhookStateVolumeID] = stateVolume.VolumeID
 	}

--- a/manager/pkg/service/sandbox_service_lifecycle.go
+++ b/manager/pkg/service/sandbox_service_lifecycle.go
@@ -429,7 +429,11 @@ func (s *SandboxService) GetSandbox(ctx context.Context, sandboxID string) (*San
 		return nil, fmt.Errorf("get pod: %w", err)
 	}
 
-	return s.podToSandbox(ctx, pod, sandboxID), nil
+	sandbox := s.podToSandbox(ctx, pod, sandboxID)
+	if sandbox != nil && sandbox.RootFSID == "" && record != nil {
+		sandbox.RootFSID = record.RootFSID
+	}
+	return sandbox, nil
 }
 
 // UpdateSandbox updates mutable sandbox configuration fields.
@@ -684,8 +688,18 @@ func (s *SandboxService) persistUpdatedSandboxPod(ctx context.Context, pod *core
 	if template == nil {
 		return nil
 	}
+	sandboxID := sandboxIDFromPod(pod)
+	if sandboxID == "" {
+		sandboxID = pod.Name
+	}
+	rootFSID := strings.TrimSpace(pod.Annotations[controller.AnnotationRootFSID])
+	if rootFSID == "" && sandboxID != "" {
+		if existing, err := s.sandboxStore.GetSandbox(ctx, sandboxID); err == nil && existing != nil {
+			rootFSID = existing.RootFSID
+		}
+	}
 	record := &SandboxRecord{
-		ID:                  sandboxIDFromPod(pod),
+		ID:                  sandboxID,
 		TeamID:              pod.Annotations[controller.AnnotationTeamID],
 		UserID:              pod.Annotations[controller.AnnotationUserID],
 		TemplateID:          sandboxTemplateIDFromLabels(pod.Labels),
@@ -699,13 +713,11 @@ func (s *SandboxService) persistUpdatedSandboxPod(ctx context.Context, pod *core
 		CurrentPodName:      pod.Name,
 		CurrentPodNamespace: pod.Namespace,
 		RuntimeGeneration:   runtimeGenerationFromPod(pod),
+		RootFSID:            rootFSID,
 		ClaimedAt:           parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationClaimedAt),
 		ExpiresAt:           parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationExpiresAt),
 		HardExpiresAt:       parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationHardExpiresAt),
 		CreatedAt:           pod.CreationTimestamp.Time,
-	}
-	if record.ID == "" {
-		record.ID = pod.Name
 	}
 	return s.sandboxStore.UpsertSandbox(ctx, record)
 }
@@ -805,6 +817,7 @@ func (s *SandboxService) podToSandbox(ctx context.Context, pod *corev1.Pod, sand
 		Mounts:            parseClaimMounts(pod.Annotations[controller.AnnotationMounts]),
 		PodName:           pod.Name,
 		RuntimeGeneration: runtimeGenerationFromPod(pod),
+		RootFSID:          strings.TrimSpace(pod.Annotations[controller.AnnotationRootFSID]),
 		ExpiresAt:         expiresAt,
 		HardExpiresAt:     hardExpiresAt,
 		ClaimedAt:         claimedAt,
@@ -833,6 +846,7 @@ func (s *SandboxService) recordToSandbox(record *SandboxRecord) *Sandbox {
 		Mounts:            record.Mounts,
 		PodName:           record.CurrentPodName,
 		RuntimeGeneration: record.RuntimeGeneration,
+		RootFSID:          record.RootFSID,
 		ExpiresAt:         record.ExpiresAt,
 		HardExpiresAt:     record.HardExpiresAt,
 		ClaimedAt:         record.ClaimedAt,

--- a/manager/pkg/service/sandbox_service_list.go
+++ b/manager/pkg/service/sandbox_service_list.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
@@ -35,6 +36,7 @@ type SandboxSummary struct {
 	Status            string    `json:"status"`
 	Paused            bool      `json:"paused"`
 	RuntimeGeneration int64     `json:"runtime_generation"`
+	RootFSID          string    `json:"rootfs_id,omitempty"`
 	CreatedAt         time.Time `json:"created_at"`
 	ExpiresAt         time.Time `json:"expires_at"`
 	HardExpiresAt     time.Time `json:"hard_expires_at"`
@@ -107,6 +109,7 @@ func (s *SandboxService) ListSandboxes(ctx context.Context, req *ListSandboxesRe
 			Status:            status,
 			Paused:            paused,
 			RuntimeGeneration: runtimeGenerationFromPod(pod),
+			RootFSID:          strings.TrimSpace(pod.Annotations[controller.AnnotationRootFSID]),
 			CreatedAt:         pod.CreationTimestamp.Time,
 			ExpiresAt:         expiresAt,
 			HardExpiresAt:     hardExpiresAt,
@@ -161,6 +164,9 @@ func (s *SandboxService) listSandboxesFromStore(ctx context.Context, req *ListSa
 		if record.CurrentPodName != "" && !recordLifecycleStatusOverridesPod(record.Status) {
 			if pod, err := s.getSandboxPod(ctx, record.ID); err == nil {
 				sandbox = s.podToSandbox(ctx, pod, record.ID)
+				if sandbox != nil && sandbox.RootFSID == "" {
+					sandbox.RootFSID = record.RootFSID
+				}
 			}
 		}
 		if req.Paused != nil && sandbox.Paused != *req.Paused {
@@ -172,6 +178,7 @@ func (s *SandboxService) listSandboxesFromStore(ctx context.Context, req *ListSa
 			Status:            sandbox.Status,
 			Paused:            sandbox.Paused,
 			RuntimeGeneration: sandbox.RuntimeGeneration,
+			RootFSID:          sandbox.RootFSID,
 			CreatedAt:         sandbox.CreatedAt,
 			ExpiresAt:         sandbox.ExpiresAt,
 			HardExpiresAt:     sandbox.HardExpiresAt,

--- a/manager/pkg/service/sandbox_service_restore.go
+++ b/manager/pkg/service/sandbox_service_restore.go
@@ -70,6 +70,7 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 			Template:          locked.TemplateID,
 			Config:            &locked.Config,
 			Mounts:            locked.Mounts,
+			RootFSID:          locked.RootFSID,
 			SandboxID:         locked.ID,
 			RuntimeGeneration: generation,
 			HardExpiresAt:     locked.HardExpiresAt,
@@ -131,6 +132,7 @@ func (s *SandboxService) finishRestoredSandboxRuntime(ctx context.Context, pod *
 		Template:          record.TemplateID,
 		Config:            &record.Config,
 		Mounts:            record.Mounts,
+		RootFSID:          record.RootFSID,
 		SandboxID:         record.ID,
 		RuntimeGeneration: record.RuntimeGeneration + 1,
 	}

--- a/manager/pkg/service/sandbox_service_rootfs.go
+++ b/manager/pkg/service/sandbox_service_rootfs.go
@@ -76,6 +76,8 @@ func (s *SandboxService) saveSandboxRootFSCheckpoint(ctx context.Context, pod *c
 	}
 	state.LayerID = uuid.NewString()
 	state.ParentLayerID = parentLayerID
+	state.RootFSID = uuid.NewString()
+	state.ExpiresAt = record.HardExpiresAt
 	if tx != nil {
 		return tx.SaveRootFSState(ctx, state)
 	}
@@ -127,6 +129,60 @@ func (s *SandboxService) applySandboxRootFSCheckpoint(ctx context.Context, pod *
 		return fmt.Errorf("apply sandbox rootfs checkpoint: ctld did not report applied")
 	}
 	return nil
+}
+
+func (s *SandboxService) rootFSStateForClaim(ctx context.Context, req *ClaimRequest, template *v1alpha1.SandboxTemplate) (*SandboxRootFSState, error) {
+	if req == nil {
+		return nil, nil
+	}
+	rootFSID := strings.TrimSpace(req.RootFSID)
+	if rootFSID == "" {
+		return nil, nil
+	}
+	if s == nil || s.sandboxStore == nil {
+		return nil, fmt.Errorf("%w: rootfs_id requires the sandbox store", ErrInvalidClaimRequest)
+	}
+	state, err := s.sandboxStore.GetRootFSState(ctx, req.TeamID, rootFSID)
+	if err != nil {
+		return nil, fmt.Errorf("load rootfs %s: %w", rootFSID, err)
+	}
+	if state == nil {
+		return nil, fmt.Errorf("%w: rootfs_id %q not found", ErrInvalidClaimRequest, rootFSID)
+	}
+	if err := validateRootFSBaseImageForTemplate(rootFSID, state, template); err != nil {
+		return nil, err
+	}
+	req.RootFSID = rootFSID
+	if sandboxID := strings.TrimSpace(req.SandboxID); sandboxID != "" {
+		state.SandboxID = sandboxID
+	}
+	return state, nil
+}
+
+func validateRootFSBaseImageForTemplate(rootFSID string, state *SandboxRootFSState, template *v1alpha1.SandboxTemplate) error {
+	if state == nil {
+		return fmt.Errorf("%w: rootfs_id %q not found", ErrInvalidClaimRequest, rootFSID)
+	}
+	if template == nil {
+		return fmt.Errorf("template is required")
+	}
+	templateImage := strings.TrimSpace(template.Spec.MainContainer.Image)
+	if templateImage == "" {
+		return fmt.Errorf("%w: template image is required for rootfs_id %q", ErrInvalidClaimRequest, rootFSID)
+	}
+	templateDigest := imageDigestFromRef(templateImage)
+	stateDigest := strings.TrimSpace(state.BaseImageDigest)
+	if templateDigest != "" {
+		if stateDigest == templateDigest {
+			return nil
+		}
+		return fmt.Errorf("%w: rootfs_id %q base image digest %q does not match template image digest %q", ErrInvalidClaimRequest, rootFSID, stateDigest, templateDigest)
+	}
+	stateRef := strings.TrimSpace(state.BaseImageRef)
+	if stateRef != "" && normalizeImageRefForRootFSCompare(stateRef) == normalizeImageRefForRootFSCompare(templateImage) {
+		return nil
+	}
+	return fmt.Errorf("%w: rootfs_id %q base image %q does not match template image %q", ErrInvalidClaimRequest, rootFSID, stateRef, templateImage)
 }
 
 func (s *SandboxService) applySandboxRootFSCheckpointWithFallback(ctx context.Context, pod *corev1.Pod, record *SandboxRecord, template *v1alpha1.SandboxTemplate, req *ClaimRequest, state *SandboxRootFSState) (*corev1.Pod, error) {
@@ -234,6 +290,39 @@ func imageRepositoryFromRef(ref string) string {
 		ref = ref[:lastColon]
 	}
 	return strings.TrimSpace(ref)
+}
+
+func imageDigestFromRef(ref string) string {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return ""
+	}
+	if idx := strings.LastIndex(ref, "@"); idx >= 0 {
+		return strings.TrimSpace(ref[idx+1:])
+	}
+	return ""
+}
+
+func normalizeImageRefForRootFSCompare(ref string) string {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return ""
+	}
+	first := ref
+	if idx := strings.Index(first, "/"); idx >= 0 {
+		first = first[:idx]
+	}
+	hasSlash := strings.Contains(ref, "/")
+	hasRegistry := hasSlash && (strings.Contains(first, ".") || strings.Contains(first, ":") || first == "localhost")
+	if !hasRegistry {
+		ref = "docker.io/" + ref
+	} else if strings.HasPrefix(ref, "index.docker.io/") {
+		ref = "docker.io/" + strings.TrimPrefix(ref, "index.docker.io/")
+	}
+	if rest := strings.TrimPrefix(ref, "docker.io/"); rest != ref && !strings.Contains(strings.SplitN(rest, "@", 2)[0], "/") {
+		ref = "docker.io/library/" + rest
+	}
+	return ref
 }
 
 func rootFSLayerDescriptors(state *SandboxRootFSState) []ctldapi.RootFSLayerDescriptor {

--- a/manager/pkg/service/sandbox_service_rootfs_test.go
+++ b/manager/pkg/service/sandbox_service_rootfs_test.go
@@ -435,6 +435,168 @@ func TestFinishRestoredSandboxRuntimeAppliesRootFSLayerChain(t *testing.T) {
 	assert.Equal(t, "rootfs/child.tar", applyReq.Layers[1].Descriptor.ObjectKey)
 }
 
+func TestClaimSandboxAppliesRootFSBeforeInitialize(t *testing.T) {
+	templateID := "template-a"
+	namespace, err := naming.TemplateNamespaceForBuiltin(templateID)
+	require.NoError(t, err)
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      templateID,
+			Namespace: namespace,
+		},
+		Spec: v1alpha1.SandboxTemplateSpec{
+			MainContainer: v1alpha1.ContainerSpec{Image: "docker.io/library/busybox:1.36"},
+		},
+	}
+	templateHash, err := controller.TemplateSpecHash(template)
+	require.NoError(t, err)
+
+	var applySeen atomic.Bool
+	var applyReq ctldapi.ApplyRootFSRequest
+	ctld := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/rootfs/apply", r.URL.Path)
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&applyReq))
+		applySeen.Store(true)
+		_ = json.NewEncoder(w).Encode(ctldapi.ApplyRootFSResponse{Applied: true})
+	}))
+	defer ctld.Close()
+	ctldURL, ctldPort := parsedTestServer(t, ctld.URL)
+
+	procd := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/initialize", r.URL.Path)
+		require.True(t, applySeen.Load(), "rootfs must be applied before procd initialization")
+		require.NoError(t, spec.WriteSuccess(w, http.StatusOK, InitializeResponse{SandboxID: "sandbox-claim", TeamID: "team-1"}))
+	}))
+	defer procd.Close()
+	procdURL, procdPort := parsedTestServer(t, procd.URL)
+
+	idlePod := newClaimTestPod(namespace, "idle-ready", templateID, true)
+	idlePod.Annotations[controller.AnnotationTemplateSpecHash] = templateHash
+	idlePod.Status.HostIP = ctldURL.Hostname()
+	idlePod.Status.PodIP = procdURL.Hostname()
+
+	store := &memorySandboxStore{
+		records: map[string]*SandboxRecord{},
+		rootFSStates: map[string]*SandboxRootFSState{
+			"source-sandbox": {
+				RootFSID:          "rootfs-1",
+				LayerID:           "layer-head",
+				SandboxID:         "source-sandbox",
+				TeamID:            "team-1",
+				Runtime:           "runc",
+				RuntimeHandler:    "io.containerd.runc.v2",
+				BaseImageRef:      "docker.io/library/busybox:1.36",
+				BaseImageDigest:   "sha256:base",
+				Snapshotter:       "overlayfs",
+				SnapshotParent:    "parent-1",
+				DiffDigest:        "sha256:diff",
+				DiffMediaType:     "application/vnd.oci.image.layer.v1.tar",
+				DiffSize:          123,
+				DiffObjectKey:     "rootfs/diff.tar",
+				RuntimeGeneration: 3,
+			},
+		},
+	}
+	client := fake.NewSimpleClientset(idlePod.DeepCopy())
+	svc := &SandboxService{
+		k8sClient:              client,
+		podLister:              newClaimTestPodLister(t, idlePod),
+		secretLister:           newClaimTestSecretLister(t),
+		templateLister:         staticTemplateLister{templates: []*v1alpha1.SandboxTemplate{template}},
+		sandboxStore:           store,
+		ctldClient:             NewCtldClient(CtldClientConfig{Timeout: time.Second}),
+		procdClient:            NewProcdClient(ProcdClientConfig{Timeout: time.Second}),
+		internalTokenGenerator: staticTokenGenerator{},
+		config: SandboxServiceConfig{
+			CtldEnabled: true,
+			CtldPort:    ctldPort,
+			ProcdPort:   procdPort,
+		},
+		clock:  systemTime{},
+		logger: zap.NewNop(),
+	}
+
+	resp, err := svc.ClaimSandbox(context.Background(), &ClaimRequest{
+		TeamID:    "team-1",
+		UserID:    "user-1",
+		Template:  templateID,
+		RootFSID:  "rootfs-1",
+		SandboxID: "sandbox-claim",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "rootfs-1", resp.RootFSID)
+	assert.Equal(t, "layer-head", applyReq.BaselineLayerID)
+	require.Len(t, applyReq.Layers, 1)
+	assert.Equal(t, "layer-head", applyReq.Layers[0].LayerID)
+	assert.Equal(t, "rootfs-1", store.records["sandbox-claim"].RootFSID)
+}
+
+func TestRootFSClaimRejectsTemplateImageMismatch(t *testing.T) {
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "template-a", Namespace: "ns-a"},
+		Spec: v1alpha1.SandboxTemplateSpec{
+			MainContainer: v1alpha1.ContainerSpec{Image: "docker.io/library/alpine:3.20"},
+		},
+	}
+	store := &memorySandboxStore{
+		rootFSStates: map[string]*SandboxRootFSState{
+			"source-sandbox": {
+				RootFSID:        "rootfs-1",
+				SandboxID:       "source-sandbox",
+				TeamID:          "team-1",
+				BaseImageRef:    "docker.io/library/busybox:1.36",
+				BaseImageDigest: "sha256:base",
+				DiffDigest:      "sha256:diff",
+				DiffObjectKey:   "rootfs/diff.tar",
+			},
+		},
+	}
+	svc := &SandboxService{sandboxStore: store}
+
+	_, err := svc.rootFSStateForClaim(context.Background(), &ClaimRequest{
+		TeamID:   "team-1",
+		RootFSID: "rootfs-1",
+	}, template)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidClaimRequest)
+}
+
+func TestRootFSClaimAcceptsDockerHubNormalizedImage(t *testing.T) {
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "template-a", Namespace: "ns-a"},
+		Spec: v1alpha1.SandboxTemplateSpec{
+			MainContainer: v1alpha1.ContainerSpec{Image: "busybox:1.36"},
+		},
+	}
+	store := &memorySandboxStore{
+		rootFSStates: map[string]*SandboxRootFSState{
+			"source-sandbox": {
+				RootFSID:        "rootfs-1",
+				SandboxID:       "source-sandbox",
+				TeamID:          "team-1",
+				BaseImageRef:    "docker.io/library/busybox:1.36",
+				BaseImageDigest: "sha256:base",
+				DiffDigest:      "sha256:diff",
+				DiffObjectKey:   "rootfs/diff.tar",
+			},
+		},
+	}
+	svc := &SandboxService{sandboxStore: store}
+	require.Equal(t,
+		normalizeImageRefForRootFSCompare("docker.io/library/busybox:1.36"),
+		normalizeImageRefForRootFSCompare("busybox:1.36"),
+	)
+
+	state, err := svc.rootFSStateForClaim(context.Background(), &ClaimRequest{
+		TeamID:   "team-1",
+		RootFSID: "rootfs-1",
+	}, template)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, "rootfs-1", state.RootFSID)
+}
+
 func TestFinishRestoredSandboxRuntimeRetriesWithCheckpointBaseImage(t *testing.T) {
 	withClaimTestPublicKey(t)
 

--- a/manager/pkg/service/sandbox_store.go
+++ b/manager/pkg/service/sandbox_store.go
@@ -40,6 +40,7 @@ type SandboxRecord struct {
 	CurrentPodName      string
 	CurrentPodNamespace string
 	RuntimeGeneration   int64
+	RootFSID            string
 	ClaimedAt           time.Time
 	ExpiresAt           time.Time
 	HardExpiresAt       time.Time
@@ -51,6 +52,7 @@ type SandboxRecord struct {
 // SandboxRootFSState is manager-internal metadata for one persisted sandbox
 // writable rootfs diff.
 type SandboxRootFSState struct {
+	RootFSID            string
 	LayerID             string
 	ParentLayerID       string
 	SandboxID           string
@@ -69,6 +71,7 @@ type SandboxRootFSState struct {
 	DiffObjectKey       string
 	CreatedAt           time.Time
 	UpdatedAt           time.Time
+	ExpiresAt           time.Time
 	LayerChain          []*SandboxRootFSLayer
 }
 
@@ -104,6 +107,7 @@ type SandboxStore interface {
 	MarkSandboxDeleted(ctx context.Context, sandboxID string, deletedAt time.Time) error
 	SaveRootFSState(ctx context.Context, state *SandboxRootFSState) error
 	GetLatestRootFSState(ctx context.Context, sandboxID string) (*SandboxRootFSState, error)
+	GetRootFSState(ctx context.Context, teamID, rootFSID string) (*SandboxRootFSState, error)
 	WithSandboxLock(ctx context.Context, sandboxID string, fn func(context.Context, SandboxStoreTx, *SandboxRecord) error) error
 }
 
@@ -157,9 +161,9 @@ func (s *PGSandboxStore) UpsertSandbox(ctx context.Context, record *SandboxRecor
 			sandbox_id, team_id, user_id, template_id, template_name, template_namespace,
 			cluster_id, status, config, mounts, template_spec,
 			current_pod_name, current_pod_namespace, runtime_generation,
-			claimed_at, expires_at, hard_expires_at, deleted_at, created_at, updated_at
+			rootfs_id, claimed_at, expires_at, hard_expires_at, deleted_at, created_at, updated_at
 		)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, COALESCE($19, NOW()), NOW())
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, COALESCE($20, NOW()), NOW())
 		ON CONFLICT (sandbox_id) DO UPDATE SET
 			team_id = EXCLUDED.team_id,
 			user_id = EXCLUDED.user_id,
@@ -174,6 +178,7 @@ func (s *PGSandboxStore) UpsertSandbox(ctx context.Context, record *SandboxRecor
 			current_pod_name = EXCLUDED.current_pod_name,
 			current_pod_namespace = EXCLUDED.current_pod_namespace,
 			runtime_generation = EXCLUDED.runtime_generation,
+			rootfs_id = EXCLUDED.rootfs_id,
 			claimed_at = EXCLUDED.claimed_at,
 			expires_at = EXCLUDED.expires_at,
 			hard_expires_at = EXCLUDED.hard_expires_at,
@@ -182,7 +187,7 @@ func (s *PGSandboxStore) UpsertSandbox(ctx context.Context, record *SandboxRecor
 	`, record.ID, record.TeamID, record.UserID, record.TemplateID, record.TemplateName, record.TemplateNamespace,
 		record.ClusterID, record.Status, configJSON, mountsJSON, specJSON,
 		record.CurrentPodName, record.CurrentPodNamespace, record.RuntimeGeneration,
-		nullableTime(record.ClaimedAt), nullableTime(record.ExpiresAt), nullableTime(record.HardExpiresAt), nullableTime(record.DeletedAt), nullableTime(record.CreatedAt))
+		record.RootFSID, nullableTime(record.ClaimedAt), nullableTime(record.ExpiresAt), nullableTime(record.HardExpiresAt), nullableTime(record.DeletedAt), nullableTime(record.CreatedAt))
 	if err != nil {
 		return fmt.Errorf("upsert sandbox: %w", err)
 	}
@@ -313,6 +318,9 @@ func (s *PGSandboxStore) MarkSandboxDeleted(ctx context.Context, sandboxID strin
 	if _, err := s.pool.Exec(ctx, `DELETE FROM manager.sandbox_rootfs_states WHERE sandbox_id = $1`, sandboxID); err != nil {
 		return fmt.Errorf("delete sandbox rootfs states: %w", err)
 	}
+	if _, err := s.pool.Exec(ctx, `DELETE FROM manager.rootfs_snapshots WHERE source_sandbox_id = $1`, sandboxID); err != nil {
+		return fmt.Errorf("delete sandbox rootfs objects: %w", err)
+	}
 	if _, err := s.pool.Exec(ctx, `DELETE FROM manager.sandbox_rootfs_heads WHERE sandbox_id = $1`, sandboxID); err != nil {
 		return fmt.Errorf("delete sandbox rootfs head: %w", err)
 	}
@@ -337,11 +345,27 @@ func (s *PGSandboxStore) GetLatestRootFSState(ctx context.Context, sandboxID str
 	if len(chain) > 0 {
 		return rootFSStateFromLayerChain(sandboxID, chain), nil
 	}
-	return scanRootFSState(s.pool.QueryRow(ctx, rootFSStateSelectSQL()+`
+	state, err := scanRootFSState(s.pool.QueryRow(ctx, rootFSStateSelectSQL()+`
 		WHERE sandbox_id = $1
 		ORDER BY runtime_generation DESC, updated_at DESC
 		LIMIT 1
 	`, sandboxID))
+	if err != nil || state != nil {
+		return state, err
+	}
+	record, err := s.GetSandbox(ctx, sandboxID)
+	if err != nil {
+		return nil, err
+	}
+	if record == nil || strings.TrimSpace(record.RootFSID) == "" {
+		return nil, nil
+	}
+	state, err = s.GetRootFSState(ctx, record.TeamID, record.RootFSID)
+	if err != nil || state == nil {
+		return state, err
+	}
+	state.SandboxID = sandboxID
+	return state, nil
 }
 
 func (s *PGSandboxStore) GetRootFSLayerChain(ctx context.Context, sandboxID string) ([]*SandboxRootFSLayer, error) {
@@ -365,6 +389,42 @@ func (s *PGSandboxStore) GetRootFSLayerChain(ctx context.Context, sandboxID stri
 		return nil, fmt.Errorf("iterate rootfs layer chain: %w", err)
 	}
 	return layers, nil
+}
+
+func (s *PGSandboxStore) GetRootFSState(ctx context.Context, teamID, rootFSID string) (*SandboxRootFSState, error) {
+	if s == nil || s.pool == nil {
+		return nil, nil
+	}
+	teamID = strings.TrimSpace(teamID)
+	rootFSID = strings.TrimSpace(rootFSID)
+	if teamID == "" || rootFSID == "" {
+		return nil, nil
+	}
+	rows, err := s.pool.Query(ctx, rootFSObjectLayerChainSQL(), teamID, rootFSID)
+	if err != nil {
+		return nil, fmt.Errorf("get rootfs object layer chain: %w", err)
+	}
+	defer rows.Close()
+	var layers []*SandboxRootFSLayer
+	for rows.Next() {
+		layer, err := scanRootFSLayerRows(rows)
+		if err != nil {
+			return nil, err
+		}
+		layers = append(layers, layer)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate rootfs object layer chain: %w", err)
+	}
+	if len(layers) == 0 {
+		return nil, nil
+	}
+	head := layers[len(layers)-1]
+	state := rootFSStateFromLayerChain(head.SourceSandboxID, layers)
+	if state != nil {
+		state.RootFSID = rootFSID
+	}
+	return state, nil
 }
 
 func (s *PGSandboxStore) WithSandboxLock(ctx context.Context, sandboxID string, fn func(context.Context, SandboxStoreTx, *SandboxRecord) error) error {
@@ -441,7 +501,7 @@ func sandboxRecordSelectSQL() string {
 		SELECT sandbox_id, team_id, user_id, template_id, template_name, template_namespace,
 			cluster_id, status, config, mounts, template_spec,
 			current_pod_name, current_pod_namespace, runtime_generation,
-			claimed_at, expires_at, hard_expires_at, deleted_at, created_at, updated_at
+			rootfs_id, claimed_at, expires_at, hard_expires_at, deleted_at, created_at, updated_at
 		FROM manager.sandboxes`
 }
 
@@ -464,6 +524,9 @@ func saveRootFSState(ctx context.Context, exec rootFSStateExecutor, state *Sandb
 	}
 	if strings.TrimSpace(state.DiffObjectKey) == "" {
 		return fmt.Errorf("diff_object_key is required")
+	}
+	if strings.TrimSpace(state.RootFSID) != "" && strings.TrimSpace(state.LayerID) == "" {
+		return fmt.Errorf("layer_id is required for rootfs object")
 	}
 	parentChainJSON, err := json.Marshal(state.SnapshotParentChain)
 	if err != nil {
@@ -551,6 +614,27 @@ func saveRootFSLayerAndHead(ctx context.Context, exec rootFSStateExecutor, state
 	if err != nil {
 		return fmt.Errorf("advance rootfs head: %w", err)
 	}
+	if strings.TrimSpace(state.RootFSID) != "" {
+		_, err = exec.Exec(ctx, `
+			INSERT INTO manager.rootfs_snapshots (
+				snapshot_id, team_id, source_sandbox_id, head_layer_id, created_at, expires_at
+			)
+			VALUES ($1, $2, $3, $4, COALESCE($5, NOW()), $6)
+			ON CONFLICT (snapshot_id) DO NOTHING
+		`, state.RootFSID, state.TeamID, state.SandboxID, state.LayerID, nullableTime(state.CreatedAt), nullableTime(state.ExpiresAt))
+		if err != nil {
+			return fmt.Errorf("save rootfs object: %w", err)
+		}
+		_, err = exec.Exec(ctx, `
+			UPDATE manager.sandboxes
+			SET rootfs_id = $2,
+				updated_at = NOW()
+			WHERE sandbox_id = $1
+		`, state.SandboxID, state.RootFSID)
+		if err != nil {
+			return fmt.Errorf("advance sandbox rootfs object: %w", err)
+		}
+	}
 	return nil
 }
 
@@ -575,6 +659,38 @@ func rootFSLayerChainSQL() string {
 			FROM manager.sandbox_rootfs_heads h
 			JOIN manager.rootfs_layers l ON l.layer_id = h.head_layer_id
 			WHERE h.sandbox_id = $1
+			UNION ALL
+			SELECT
+				p.layer_id, p.parent_layer_id, p.source_sandbox_id, p.team_id,
+				p.runtime_generation, p.runtime, p.runtime_handler, p.base_image_ref,
+				p.base_image_digest, p.snapshotter, p.snapshot_parent,
+				p.snapshot_parent_chain, p.diff_digest, p.diff_id, p.diff_media_type,
+				p.diff_size, p.diff_object_key, p.created_at, c.depth + 1 AS depth
+			FROM manager.rootfs_layers p
+			JOIN chain c ON p.layer_id = c.parent_layer_id
+		)
+		SELECT layer_id, parent_layer_id, source_sandbox_id, team_id, runtime_generation,
+			runtime, runtime_handler, base_image_ref, base_image_digest, snapshotter,
+			snapshot_parent, snapshot_parent_chain, diff_digest, diff_id, diff_media_type,
+			diff_size, diff_object_key, created_at
+		FROM chain
+		ORDER BY depth DESC`
+}
+
+func rootFSObjectLayerChainSQL() string {
+	return `
+		WITH RECURSIVE chain AS (
+			SELECT
+				l.layer_id, l.parent_layer_id, l.source_sandbox_id, l.team_id,
+				l.runtime_generation, l.runtime, l.runtime_handler, l.base_image_ref,
+				l.base_image_digest, l.snapshotter, l.snapshot_parent,
+				l.snapshot_parent_chain, l.diff_digest, l.diff_id, l.diff_media_type,
+				l.diff_size, l.diff_object_key, l.created_at, 0 AS depth
+			FROM manager.rootfs_snapshots r
+			JOIN manager.rootfs_layers l ON l.layer_id = r.head_layer_id
+			WHERE r.team_id = $1
+				AND r.snapshot_id = $2
+				AND (r.expires_at IS NULL OR r.expires_at > NOW())
 			UNION ALL
 			SELECT
 				p.layer_id, p.parent_layer_id, p.source_sandbox_id, p.team_id,
@@ -696,7 +812,7 @@ func scanSandboxRecordInto(scanner sandboxRecordScanner) (*SandboxRecord, error)
 		&record.ID, &record.TeamID, &record.UserID, &record.TemplateID, &record.TemplateName, &record.TemplateNamespace,
 		&record.ClusterID, &record.Status, &configJSON, &mountsJSON, &specJSON,
 		&record.CurrentPodName, &record.CurrentPodNamespace, &record.RuntimeGeneration,
-		&claimedAt, &expiresAt, &hardExpiresAt, &deletedAt, &record.CreatedAt, &record.UpdatedAt,
+		&record.RootFSID, &claimedAt, &expiresAt, &hardExpiresAt, &deletedAt, &record.CreatedAt, &record.UpdatedAt,
 	); err != nil {
 		return nil, err
 	}

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -3814,6 +3814,9 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/ClaimMountRequest"
+        rootfs_id:
+          type: string
+          description: Optional rootfs object to restore before procd initialization. The rootfs base image must match the selected template image.
       required: []
     ClaimMountRequest:
       type: object
@@ -4079,6 +4082,9 @@ components:
         cluster_id:
           type: string
           nullable: true
+        rootfs_id:
+          type: string
+          description: Rootfs object restored for this claim, when provided.
         bootstrap_mounts:
           type: array
           items:
@@ -4102,6 +4108,26 @@ components:
         - SandboxLifecycleStatusResuming
         - SandboxLifecycleStatusTerminating
         - SandboxLifecycleStatusFailed
+    RootFS:
+      type: object
+      description: Immutable sandbox writable root filesystem head that can be used as the base for a future sandbox claim or fork.
+      properties:
+        id:
+          type: string
+        source_sandbox_id:
+          type: string
+        base_image_ref:
+          type: string
+        base_image_digest:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        expires_at:
+          type: string
+          format: date-time
+          nullable: true
+      required: [id, source_sandbox_id, base_image_ref, base_image_digest, created_at]
     Sandbox:
       type: object
       properties:
@@ -4134,6 +4160,9 @@ components:
           type: integer
           format: int64
           description: Monotonically increasing runtime generation. Resume starts a new generation.
+        rootfs_id:
+          type: string
+          description: Current rootfs object id. Present after a rootfs checkpoint is saved or when the sandbox was claimed from a rootfs object.
         ssh:
           $ref: "#/components/schemas/SandboxSSHConnection"
         expires_at:
@@ -4272,6 +4301,9 @@ components:
           type: integer
           format: int64
           description: Monotonically increasing runtime generation. Resume starts a new generation.
+        rootfs_id:
+          type: string
+          description: Current rootfs object id when one is associated with the sandbox.
         cluster_id:
           type: string
           description: Cluster where sandbox runs (multi-cluster only)

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -589,19 +589,25 @@ type ClaimMountRequest struct {
 
 // ClaimRequest defines model for ClaimRequest.
 type ClaimRequest struct {
-	Config   *SandboxConfig       `json:"config,omitempty"`
-	Mounts   *[]ClaimMountRequest `json:"mounts,omitempty"`
-	Template *string              `json:"template,omitempty"`
+	Config *SandboxConfig       `json:"config,omitempty"`
+	Mounts *[]ClaimMountRequest `json:"mounts,omitempty"`
+
+	// RootfsId Optional rootfs object to restore before procd initialization. The rootfs base image must match the selected template image.
+	RootfsId *string `json:"rootfs_id,omitempty"`
+	Template *string `json:"template,omitempty"`
 }
 
 // ClaimResponse defines model for ClaimResponse.
 type ClaimResponse struct {
-	BootstrapMounts *[]MountStatus         `json:"bootstrap_mounts,omitempty"`
-	ClusterId       *string                `json:"cluster_id"`
-	PodName         string                 `json:"pod_name"`
-	SandboxId       string                 `json:"sandbox_id"`
-	Status          SandboxLifecycleStatus `json:"status"`
-	Template        string                 `json:"template"`
+	BootstrapMounts *[]MountStatus `json:"bootstrap_mounts,omitempty"`
+	ClusterId       *string        `json:"cluster_id"`
+	PodName         string         `json:"pod_name"`
+
+	// RootfsId Rootfs object restored for this claim, when provided.
+	RootfsId  *string                `json:"rootfs_id,omitempty"`
+	SandboxId string                 `json:"sandbox_id"`
+	Status    SandboxLifecycleStatus `json:"status"`
+	Template  string                 `json:"template"`
 }
 
 // ContainerSpec defines model for ContainerSpec.
@@ -1493,6 +1499,9 @@ type Sandbox struct {
 	Paused  bool   `json:"paused"`
 	PodName string `json:"pod_name"`
 
+	// RootfsId Current rootfs object id. Present after a rootfs checkpoint is saved or when the sandbox was claimed from a rootfs object.
+	RootfsId *string `json:"rootfs_id,omitempty"`
+
 	// RuntimeGeneration Monotonically increasing runtime generation. Resume starts a new generation.
 	RuntimeGeneration int64                  `json:"runtime_generation"`
 	Services          *[]SandboxAppService   `json:"services,omitempty"`
@@ -1737,6 +1746,9 @@ type SandboxSummary struct {
 
 	// Paused True when status is paused and no runtime is attached.
 	Paused bool `json:"paused"`
+
+	// RootfsId Current rootfs object id when one is associated with the sandbox.
+	RootfsId *string `json:"rootfs_id,omitempty"`
 
 	// RuntimeGeneration Monotonically increasing runtime generation. Resume starts a new generation.
 	RuntimeGeneration int64                  `json:"runtime_generation"`

--- a/pkg/sshgateway/connection_test.go
+++ b/pkg/sshgateway/connection_test.go
@@ -32,6 +32,7 @@ func TestSandboxToAPIIncludesSSHInfo(t *testing.T) {
 		UserID:        "user-1",
 		Status:        "running",
 		PodName:       "pod-1",
+		RootFSID:      "rootfs-1",
 		AutoResume:    true,
 		Paused:        false,
 		ClaimedAt:     now,
@@ -55,5 +56,8 @@ func TestSandboxToAPIIncludesSSHInfo(t *testing.T) {
 	}
 	if payload.Ssh.Username != sandbox.ID {
 		t.Fatalf("ssh username = %q", payload.Ssh.Username)
+	}
+	if payload.RootfsId == nil || *payload.RootfsId != "rootfs-1" {
+		t.Fatalf("rootfs_id = %v", payload.RootfsId)
 	}
 }

--- a/pkg/sshgateway/sandbox_response.go
+++ b/pkg/sshgateway/sandbox_response.go
@@ -30,6 +30,9 @@ func SandboxToAPI(sandbox *mgr.Sandbox, sshInfo *ConnectionInfo) *apispec.Sandbo
 	if sandbox.UserID != "" {
 		payload.UserId = &sandbox.UserID
 	}
+	if sandbox.RootFSID != "" {
+		payload.RootfsId = &sandbox.RootFSID
+	}
 	if sshInfo != nil {
 		payload.Ssh = &apispec.SandboxSSHConnection{
 			Host:     sshInfo.Host,

--- a/tests/integration/internal/tests/manager/api_test.go
+++ b/tests/integration/internal/tests/manager/api_test.go
@@ -817,6 +817,11 @@ func (s *memorySandboxStoreForManagerIntegration) SaveRootFSState(_ context.Cont
 		return nil
 	}
 	s.rootFSState[state.SandboxID] = cloneRootFSStateForManagerIntegration(state)
+	if state.RootFSID != "" {
+		if record := s.records[state.SandboxID]; record != nil {
+			record.RootFSID = state.RootFSID
+		}
+	}
 	return nil
 }
 
@@ -824,10 +829,33 @@ func (s *memorySandboxStoreForManagerIntegration) GetLatestRootFSState(_ context
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	state := s.rootFSState[sandboxID]
-	if state == nil {
+	if state != nil {
+		return cloneRootFSStateForManagerIntegration(state), nil
+	}
+	record := s.records[sandboxID]
+	if record == nil || record.RootFSID == "" {
 		return nil, nil
 	}
-	return cloneRootFSStateForManagerIntegration(state), nil
+	for _, state := range s.rootFSState {
+		if state != nil && state.RootFSID == record.RootFSID && state.TeamID == record.TeamID {
+			clone := cloneRootFSStateForManagerIntegration(state)
+			clone.SandboxID = sandboxID
+			return clone, nil
+		}
+	}
+	return nil, nil
+}
+
+func (s *memorySandboxStoreForManagerIntegration) GetRootFSState(_ context.Context, teamID, rootFSID string) (*service.SandboxRootFSState, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, state := range s.rootFSState {
+		if state == nil || state.RootFSID != rootFSID || state.TeamID != teamID {
+			continue
+		}
+		return cloneRootFSStateForManagerIntegration(state), nil
+	}
+	return nil, nil
 }
 
 func (s *memorySandboxStoreForManagerIntegration) WithSandboxLock(ctx context.Context, sandboxID string, fn func(context.Context, service.SandboxStoreTx, *service.SandboxRecord) error) error {
@@ -879,6 +907,11 @@ func (t memorySandboxStoreTxForManagerIntegration) SaveRootFSState(_ context.Con
 		return nil
 	}
 	t.store.rootFSState[state.SandboxID] = cloneRootFSStateForManagerIntegration(state)
+	if state.RootFSID != "" {
+		if record := t.store.records[state.SandboxID]; record != nil {
+			record.RootFSID = state.RootFSID
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- create a claimable rootfs object id for each saved rootfs checkpoint and persist the current sandbox rootfs_id
- allow sandbox claim requests to pass rootfs_id, validate the checkpoint base image against the selected template image, and apply the rootfs before procd initialization
- return rootfs_id through sandbox detail APIs and update OpenAPI/docs/tests for rootfs_id claim behavior

## Tests
- `env GOWORK=off go test ./manager/...`
- `env GOWORK=off go test ./manager/pkg/http`
- `env GOWORK=off go test ./pkg/apispec`
- `env GOWORK=off go test ./pkg/sshgateway`
- `env GOWORK=off go test ./cluster-gateway/pkg/http`
- `env GOWORK=off go test ./regional-gateway/pkg/http`
- `env GOWORK=off go test ./tests/integration/internal/tests/manager -run TestPausedSandboxRuntimeResumeAppliesRootFSCheckpointBeforeInitialize`

## Remote validation
- Deployed the branch to the Aliyun Singapore kind environment.
- Claimed a default sandbox, wrote a marker file into rootfs, paused it, observed `rootfs_id=fddbcf3b-ad90-4852-8f02-f1e7fda535fb` through the public sandbox detail API, then claimed a new default sandbox with that `rootfs_id` and verified the marker file was present before use.