### PR TITLE
Introduce rootfs persistent filesystem metadata

### DIFF
--- a/manager/pkg/service/migrations/00004_add_rootfs_filesystems.sql
+++ b/manager/pkg/service/migrations/00004_add_rootfs_filesystems.sql
@@ -1,0 +1,199 @@
+-- +goose Up
+
+WITH latest_legacy AS (
+    SELECT DISTINCT ON (sandbox_id)
+        sandbox_id, team_id, runtime_generation, runtime, runtime_handler,
+        base_image_ref, base_image_digest, snapshotter, snapshot_parent,
+        snapshot_parent_chain, diff_digest, diff_media_type, diff_size,
+        diff_object_key, created_at
+    FROM manager.sandbox_rootfs_states
+    ORDER BY sandbox_id, runtime_generation DESC, updated_at DESC
+),
+legacy_without_head AS (
+    SELECT l.*
+    FROM latest_legacy l
+    LEFT JOIN manager.sandbox_rootfs_heads h ON h.sandbox_id = l.sandbox_id
+    WHERE h.sandbox_id IS NULL
+)
+INSERT INTO manager.rootfs_layers (
+    layer_id, parent_layer_id, source_sandbox_id, team_id, runtime_generation,
+    runtime, runtime_handler, base_image_ref, base_image_digest, snapshotter,
+    snapshot_parent, snapshot_parent_chain, diff_digest, diff_id, diff_media_type,
+    diff_size, diff_object_key, created_at
+)
+SELECT
+    'legacy:' || sandbox_id || ':' || runtime_generation,
+    NULL,
+    sandbox_id,
+    team_id,
+    runtime_generation,
+    runtime,
+    runtime_handler,
+    base_image_ref,
+    base_image_digest,
+    snapshotter,
+    snapshot_parent,
+    snapshot_parent_chain,
+    diff_digest,
+    '',
+    diff_media_type,
+    diff_size,
+    diff_object_key,
+    created_at
+FROM legacy_without_head
+ON CONFLICT (layer_id) DO NOTHING;
+
+WITH latest_legacy AS (
+    SELECT DISTINCT ON (sandbox_id)
+        sandbox_id, team_id, runtime_generation
+    FROM manager.sandbox_rootfs_states
+    ORDER BY sandbox_id, runtime_generation DESC, updated_at DESC
+)
+INSERT INTO manager.sandbox_rootfs_heads (
+    sandbox_id, team_id, head_layer_id, runtime_generation, updated_at
+)
+SELECT
+    l.sandbox_id,
+    l.team_id,
+    'legacy:' || l.sandbox_id || ':' || l.runtime_generation,
+    l.runtime_generation,
+    NOW()
+FROM latest_legacy l
+LEFT JOIN manager.sandbox_rootfs_heads h ON h.sandbox_id = l.sandbox_id
+WHERE h.sandbox_id IS NULL
+ON CONFLICT (sandbox_id) DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS manager.rootfs_filesystems (
+    filesystem_id TEXT PRIMARY KEY,
+    team_id TEXT NOT NULL,
+    source_filesystem_id TEXT REFERENCES manager.rootfs_filesystems(filesystem_id) ON DELETE RESTRICT,
+    head_layer_id TEXT REFERENCES manager.rootfs_layers(layer_id) ON DELETE RESTRICT,
+    base_image_ref TEXT NOT NULL DEFAULT '',
+    base_image_digest TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_rootfs_filesystems_team_updated
+    ON manager.rootfs_filesystems(team_id, updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_rootfs_filesystems_head
+    ON manager.rootfs_filesystems(head_layer_id)
+    WHERE head_layer_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_rootfs_filesystems_source
+    ON manager.rootfs_filesystems(source_filesystem_id)
+    WHERE source_filesystem_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS manager.sandbox_rootfs_bindings (
+    sandbox_id TEXT PRIMARY KEY REFERENCES manager.sandboxes(sandbox_id) ON DELETE CASCADE,
+    filesystem_id TEXT NOT NULL REFERENCES manager.rootfs_filesystems(filesystem_id) ON DELETE RESTRICT,
+    team_id TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_sandbox_rootfs_bindings_filesystem
+    ON manager.sandbox_rootfs_bindings(filesystem_id);
+
+CREATE INDEX IF NOT EXISTS idx_sandbox_rootfs_bindings_team_updated
+    ON manager.sandbox_rootfs_bindings(team_id, updated_at DESC);
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION manager.update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+DROP TRIGGER IF EXISTS update_rootfs_filesystems_updated_at ON manager.rootfs_filesystems;
+CREATE TRIGGER update_rootfs_filesystems_updated_at
+    BEFORE UPDATE ON manager.rootfs_filesystems
+    FOR EACH ROW
+    EXECUTE FUNCTION manager.update_updated_at_column();
+
+DROP TRIGGER IF EXISTS update_sandbox_rootfs_bindings_updated_at ON manager.sandbox_rootfs_bindings;
+CREATE TRIGGER update_sandbox_rootfs_bindings_updated_at
+    BEFORE UPDATE ON manager.sandbox_rootfs_bindings
+    FOR EACH ROW
+    EXECUTE FUNCTION manager.update_updated_at_column();
+
+INSERT INTO manager.rootfs_filesystems (
+    filesystem_id, team_id, head_layer_id, base_image_ref, base_image_digest,
+    created_at, updated_at
+)
+SELECT
+    h.sandbox_id,
+    h.team_id,
+    h.head_layer_id,
+    COALESCE(l.base_image_ref, ''),
+    COALESCE(l.base_image_digest, ''),
+    COALESCE(l.created_at, NOW()),
+    h.updated_at
+FROM manager.sandbox_rootfs_heads h
+LEFT JOIN manager.rootfs_layers l ON l.layer_id = h.head_layer_id
+ON CONFLICT (filesystem_id) DO NOTHING;
+
+INSERT INTO manager.sandbox_rootfs_bindings (
+    sandbox_id, filesystem_id, team_id, created_at, updated_at
+)
+SELECT
+    h.sandbox_id,
+    h.sandbox_id,
+    h.team_id,
+    h.updated_at,
+    h.updated_at
+FROM manager.sandbox_rootfs_heads h
+ON CONFLICT (sandbox_id) DO NOTHING;
+
+ALTER TABLE manager.rootfs_snapshots
+    ADD COLUMN IF NOT EXISTS filesystem_id TEXT REFERENCES manager.rootfs_filesystems(filesystem_id) ON DELETE RESTRICT;
+
+UPDATE manager.rootfs_snapshots s
+SET filesystem_id = b.filesystem_id
+FROM manager.sandbox_rootfs_bindings b
+WHERE s.filesystem_id IS NULL
+  AND s.source_sandbox_id = b.sandbox_id;
+
+CREATE INDEX IF NOT EXISTS idx_rootfs_snapshots_filesystem
+    ON manager.rootfs_snapshots(filesystem_id)
+    WHERE filesystem_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS manager.rootfs_object_deletions (
+    object_key TEXT PRIMARY KEY,
+    team_id TEXT NOT NULL DEFAULT '',
+    attempts INTEGER NOT NULL DEFAULT 0,
+    last_error TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_rootfs_object_deletions_updated
+    ON manager.rootfs_object_deletions(updated_at ASC);
+
+DROP TRIGGER IF EXISTS update_rootfs_object_deletions_updated_at ON manager.rootfs_object_deletions;
+CREATE TRIGGER update_rootfs_object_deletions_updated_at
+    BEFORE UPDATE ON manager.rootfs_object_deletions
+    FOR EACH ROW
+    EXECUTE FUNCTION manager.update_updated_at_column();
+
+-- +goose Down
+
+DROP TRIGGER IF EXISTS update_rootfs_object_deletions_updated_at ON manager.rootfs_object_deletions;
+DROP INDEX IF EXISTS manager.idx_rootfs_object_deletions_updated;
+DROP TABLE IF EXISTS manager.rootfs_object_deletions;
+DROP INDEX IF EXISTS manager.idx_rootfs_snapshots_filesystem;
+ALTER TABLE manager.rootfs_snapshots DROP COLUMN IF EXISTS filesystem_id;
+DROP TRIGGER IF EXISTS update_sandbox_rootfs_bindings_updated_at ON manager.sandbox_rootfs_bindings;
+DROP INDEX IF EXISTS manager.idx_sandbox_rootfs_bindings_team_updated;
+DROP INDEX IF EXISTS manager.idx_sandbox_rootfs_bindings_filesystem;
+DROP TABLE IF EXISTS manager.sandbox_rootfs_bindings;
+DROP TRIGGER IF EXISTS update_rootfs_filesystems_updated_at ON manager.rootfs_filesystems;
+DROP INDEX IF EXISTS manager.idx_rootfs_filesystems_source;
+DROP INDEX IF EXISTS manager.idx_rootfs_filesystems_head;
+DROP INDEX IF EXISTS manager.idx_rootfs_filesystems_team_updated;
+DROP TABLE IF EXISTS manager.rootfs_filesystems;
+DROP FUNCTION IF EXISTS manager.update_updated_at_column();

--- a/manager/pkg/service/rootfs_persistent_filesystem.go
+++ b/manager/pkg/service/rootfs_persistent_filesystem.go
@@ -1,0 +1,655 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+var ErrRootFSHeadConflict = errors.New("rootfs filesystem head conflict")
+var ErrRootFSFilesystemNotFound = errors.New("rootfs filesystem not found")
+var ErrRootFSFilesystemConflict = errors.New("rootfs filesystem conflict")
+var ErrRootFSSnapshotNotFound = errors.New("rootfs snapshot not found")
+
+// RootFSFilesystem is the canonical persistent filesystem object backing a
+// sandbox writable rootfs.
+type RootFSFilesystem struct {
+	ID                 string
+	TeamID             string
+	SourceFilesystemID string
+	HeadLayerID        string
+	BaseImageRef       string
+	BaseImageDigest    string
+	CreatedAt          time.Time
+	UpdatedAt          time.Time
+}
+
+// RootFSSnapshot is an immutable pointer to one rootfs filesystem head.
+type RootFSSnapshot struct {
+	ID              string
+	FilesystemID    string
+	TeamID          string
+	SourceSandboxID string
+	HeadLayerID     string
+	Name            string
+	Description     string
+	CreatedAt       time.Time
+	ExpiresAt       time.Time
+}
+
+type CreateRootFSSnapshotRequest struct {
+	SandboxID   string
+	SnapshotID  string
+	Name        string
+	Description string
+	ExpiresAt   time.Time
+}
+
+type ForkRootFSFilesystemRequest struct {
+	SourceSandboxID string
+	TargetSandboxID string
+	TargetTeamID    string
+}
+
+type RestoreRootFSFromSnapshotRequest struct {
+	SandboxID  string
+	SnapshotID string
+	TeamID     string
+}
+
+type SquashRootFSFilesystemRequest struct {
+	SandboxID           string
+	ExpectedHeadLayerID string
+	SquashedRootFSState *SandboxRootFSState
+}
+
+type RootFSGarbageCollectionResult struct {
+	Layers            []*SandboxRootFSLayer
+	DeletedObjectKeys []string
+}
+
+// RootFSObjectDeleter deletes rootfs diff objects from durable object storage.
+type RootFSObjectDeleter interface {
+	Delete(key string) error
+}
+
+func (s *PGSandboxStore) GetRootFSFilesystem(ctx context.Context, sandboxID string) (*RootFSFilesystem, error) {
+	if s == nil || s.pool == nil || strings.TrimSpace(sandboxID) == "" {
+		return nil, nil
+	}
+	filesystem, err := scanRootFSFilesystem(s.pool.QueryRow(ctx, `
+		SELECT f.filesystem_id, f.team_id, f.source_filesystem_id, f.head_layer_id,
+			f.base_image_ref, f.base_image_digest, f.created_at, f.updated_at
+		FROM manager.sandbox_rootfs_bindings b
+		JOIN manager.rootfs_filesystems f ON f.filesystem_id = b.filesystem_id
+		WHERE b.sandbox_id = $1
+	`, sandboxID))
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get rootfs filesystem: %w", err)
+	}
+	return filesystem, nil
+}
+
+func (s *PGSandboxStore) CreateRootFSSnapshot(ctx context.Context, req *CreateRootFSSnapshotRequest) (*RootFSSnapshot, error) {
+	if s == nil || s.pool == nil || req == nil {
+		return nil, nil
+	}
+	if strings.TrimSpace(req.SandboxID) == "" {
+		return nil, fmt.Errorf("sandbox_id is required")
+	}
+	if strings.TrimSpace(req.SnapshotID) == "" {
+		return nil, fmt.Errorf("snapshot_id is required")
+	}
+	snapshot, err := scanRootFSSnapshot(s.pool.QueryRow(ctx, `
+		WITH source AS (
+			SELECT b.filesystem_id, b.team_id, f.head_layer_id
+			FROM manager.sandbox_rootfs_bindings b
+			JOIN manager.rootfs_filesystems f ON f.filesystem_id = b.filesystem_id
+			WHERE b.sandbox_id = $1
+				AND f.head_layer_id IS NOT NULL
+		)
+		INSERT INTO manager.rootfs_snapshots (
+			snapshot_id, filesystem_id, team_id, source_sandbox_id, head_layer_id,
+			name, description, created_at, expires_at
+		)
+		SELECT $2, filesystem_id, team_id, $1, head_layer_id, $3, $4, NOW(), $5
+		FROM source
+		RETURNING snapshot_id, filesystem_id, team_id, source_sandbox_id,
+			head_layer_id, name, description, created_at, expires_at
+	`, req.SandboxID, req.SnapshotID, req.Name, req.Description, nullableTime(req.ExpiresAt)))
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, fmt.Errorf("%w: sandbox %s", ErrRootFSFilesystemNotFound, req.SandboxID)
+		}
+		return nil, fmt.Errorf("create rootfs snapshot: %w", err)
+	}
+	return snapshot, nil
+}
+
+func (s *PGSandboxStore) ForkRootFSFilesystem(ctx context.Context, req *ForkRootFSFilesystemRequest) (*RootFSFilesystem, error) {
+	if s == nil || s.pool == nil || req == nil {
+		return nil, nil
+	}
+	if strings.TrimSpace(req.SourceSandboxID) == "" {
+		return nil, fmt.Errorf("source_sandbox_id is required")
+	}
+	if strings.TrimSpace(req.TargetSandboxID) == "" {
+		return nil, fmt.Errorf("target_sandbox_id is required")
+	}
+	if strings.TrimSpace(req.SourceSandboxID) == strings.TrimSpace(req.TargetSandboxID) {
+		return nil, fmt.Errorf("%w: source and target sandbox are the same", ErrRootFSFilesystemConflict)
+	}
+	filesystem, err := scanRootFSFilesystem(s.pool.QueryRow(ctx, `
+		WITH source AS (
+			SELECT f.filesystem_id, f.team_id, f.head_layer_id, f.base_image_ref, f.base_image_digest
+			FROM manager.sandbox_rootfs_bindings b
+			JOIN manager.rootfs_filesystems f ON f.filesystem_id = b.filesystem_id
+			WHERE b.sandbox_id = $1
+				AND f.head_layer_id IS NOT NULL
+		),
+		target_sandbox AS (
+			SELECT sandbox_id, COALESCE(NULLIF($3, ''), team_id) AS team_id
+			FROM manager.sandboxes
+			WHERE sandbox_id = $2
+		),
+		created AS (
+			INSERT INTO manager.rootfs_filesystems (
+				filesystem_id, team_id, source_filesystem_id, head_layer_id,
+				base_image_ref, base_image_digest, created_at, updated_at
+			)
+			SELECT
+				$2,
+				target_sandbox.team_id,
+				source.filesystem_id,
+				source.head_layer_id,
+				source.base_image_ref,
+				source.base_image_digest,
+				NOW(),
+				NOW()
+			FROM source
+			CROSS JOIN target_sandbox
+			ON CONFLICT (filesystem_id) DO NOTHING
+			RETURNING filesystem_id, team_id, source_filesystem_id, head_layer_id,
+				base_image_ref, base_image_digest, created_at, updated_at
+		),
+		bound AS (
+			INSERT INTO manager.sandbox_rootfs_bindings (
+				sandbox_id, filesystem_id, team_id, created_at, updated_at
+			)
+			SELECT $2, filesystem_id, team_id, NOW(), NOW()
+			FROM created
+			ON CONFLICT (sandbox_id) DO NOTHING
+			RETURNING filesystem_id
+		)
+		SELECT created.filesystem_id, created.team_id, created.source_filesystem_id,
+			created.head_layer_id, created.base_image_ref, created.base_image_digest,
+			created.created_at, created.updated_at
+		FROM created
+		JOIN bound ON bound.filesystem_id = created.filesystem_id
+	`, req.SourceSandboxID, req.TargetSandboxID, strings.TrimSpace(req.TargetTeamID)))
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, s.rootFSForkNoRowsError(ctx, req)
+		}
+		return nil, fmt.Errorf("fork rootfs filesystem: %w", err)
+	}
+	return filesystem, nil
+}
+
+func (s *PGSandboxStore) RestoreRootFSFromSnapshot(ctx context.Context, req *RestoreRootFSFromSnapshotRequest) (*RootFSFilesystem, error) {
+	if s == nil || s.pool == nil || req == nil {
+		return nil, nil
+	}
+	if strings.TrimSpace(req.SandboxID) == "" {
+		return nil, fmt.Errorf("sandbox_id is required")
+	}
+	if strings.TrimSpace(req.SnapshotID) == "" {
+		return nil, fmt.Errorf("snapshot_id is required")
+	}
+	filesystem, err := scanRootFSFilesystem(s.pool.QueryRow(ctx, `
+		WITH snapshot AS (
+			SELECT s.snapshot_id, s.filesystem_id, s.team_id, s.head_layer_id,
+				l.base_image_ref, l.base_image_digest
+			FROM manager.rootfs_snapshots s
+			JOIN manager.rootfs_layers l ON l.layer_id = s.head_layer_id
+			WHERE s.snapshot_id = $2
+				AND ($3 = '' OR s.team_id = $3)
+		),
+		target_sandbox AS (
+			SELECT sandbox_id, COALESCE(NULLIF($3, ''), team_id) AS team_id
+			FROM manager.sandboxes
+			WHERE sandbox_id = $1
+		),
+		binding AS (
+			SELECT filesystem_id
+			FROM manager.sandbox_rootfs_bindings
+			WHERE sandbox_id = $1
+			UNION ALL
+			SELECT $1
+			WHERE NOT EXISTS (
+				SELECT 1
+				FROM manager.sandbox_rootfs_bindings
+				WHERE sandbox_id = $1
+			)
+			LIMIT 1
+		),
+		restored AS (
+			INSERT INTO manager.rootfs_filesystems (
+				filesystem_id, team_id, source_filesystem_id, head_layer_id,
+				base_image_ref, base_image_digest, created_at, updated_at
+			)
+			SELECT
+				binding.filesystem_id,
+				target_sandbox.team_id,
+				snapshot.filesystem_id,
+				snapshot.head_layer_id,
+				snapshot.base_image_ref,
+				snapshot.base_image_digest,
+				NOW(),
+				NOW()
+			FROM snapshot
+			CROSS JOIN target_sandbox
+			CROSS JOIN binding
+			ON CONFLICT (filesystem_id) DO UPDATE SET
+				team_id = EXCLUDED.team_id,
+				source_filesystem_id = COALESCE(
+					manager.rootfs_filesystems.source_filesystem_id,
+					EXCLUDED.source_filesystem_id
+				),
+				head_layer_id = EXCLUDED.head_layer_id,
+				base_image_ref = EXCLUDED.base_image_ref,
+				base_image_digest = EXCLUDED.base_image_digest,
+				updated_at = NOW()
+			RETURNING filesystem_id, team_id, source_filesystem_id, head_layer_id,
+				base_image_ref, base_image_digest, created_at, updated_at
+		),
+		bound AS (
+			INSERT INTO manager.sandbox_rootfs_bindings (
+				sandbox_id, filesystem_id, team_id, created_at, updated_at
+			)
+			SELECT $1, filesystem_id, team_id, NOW(), NOW()
+			FROM restored
+			ON CONFLICT (sandbox_id) DO UPDATE SET
+				team_id = EXCLUDED.team_id
+			RETURNING filesystem_id
+		)
+		SELECT restored.filesystem_id, restored.team_id, restored.source_filesystem_id,
+			restored.head_layer_id, restored.base_image_ref, restored.base_image_digest,
+			restored.created_at, restored.updated_at
+		FROM restored
+		JOIN bound ON bound.filesystem_id = restored.filesystem_id
+	`, req.SandboxID, req.SnapshotID, strings.TrimSpace(req.TeamID)))
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, s.rootFSRestoreNoRowsError(ctx, req)
+		}
+		return nil, fmt.Errorf("restore rootfs filesystem from snapshot: %w", err)
+	}
+	return filesystem, nil
+}
+
+// SquashRootFSFilesystem replaces a filesystem layer chain with a single
+// precomputed layer. The caller is responsible for creating the squashed diff
+// object before advancing the filesystem head.
+func (s *PGSandboxStore) SquashRootFSFilesystem(ctx context.Context, req *SquashRootFSFilesystemRequest) error {
+	if s == nil || s.pool == nil || req == nil || req.SquashedRootFSState == nil {
+		return nil
+	}
+	sandboxID := strings.TrimSpace(req.SandboxID)
+	if sandboxID == "" {
+		sandboxID = strings.TrimSpace(req.SquashedRootFSState.SandboxID)
+	}
+	if sandboxID == "" {
+		return fmt.Errorf("sandbox_id is required")
+	}
+	if strings.TrimSpace(req.ExpectedHeadLayerID) == "" {
+		return fmt.Errorf("expected_head_layer_id is required")
+	}
+	state := *req.SquashedRootFSState
+	state.SandboxID = sandboxID
+	if strings.TrimSpace(state.ParentLayerID) != "" {
+		return fmt.Errorf("squashed rootfs layer cannot have a parent layer")
+	}
+	if err := validateRootFSState(&state); err != nil {
+		return err
+	}
+
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("begin rootfs squash tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if err := saveRootFSLayer(ctx, tx, &state); err != nil {
+		return err
+	}
+	if err := advanceRootFSFilesystemHead(ctx, tx, &state, nullableText(req.ExpectedHeadLayerID)); err != nil {
+		return err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit rootfs squash tx: %w", err)
+	}
+	return nil
+}
+
+// GarbageCollectRootFSFilesystem removes unreferenced leaf layer metadata and
+// deletes the corresponding diff objects from durable object storage. Object
+// keys are durably queued before layer metadata is removed, so failed object
+// deletes can be retried without losing the key.
+func (s *PGSandboxStore) GarbageCollectRootFSFilesystem(ctx context.Context, deleter RootFSObjectDeleter, teamID string, limit int) (*RootFSGarbageCollectionResult, error) {
+	if deleter == nil {
+		return nil, fmt.Errorf("rootfs object deleter is required")
+	}
+	layers, err := s.collectUnreferencedRootFSLayers(ctx, teamID, limit)
+	if err != nil {
+		return nil, err
+	}
+	deletedObjectKeys, err := s.DeletePendingRootFSObjects(ctx, deleter, limit)
+	result := &RootFSGarbageCollectionResult{
+		Layers:            layers,
+		DeletedObjectKeys: deletedObjectKeys,
+	}
+	if err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+func (s *PGSandboxStore) collectUnreferencedRootFSLayers(ctx context.Context, teamID string, limit int) ([]*SandboxRootFSLayer, error) {
+	if s == nil || s.pool == nil {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	if limit > 1000 {
+		limit = 1000
+	}
+	rows, err := s.pool.Query(ctx, `
+		WITH RECURSIVE roots AS (
+			SELECT head_layer_id AS layer_id
+			FROM manager.rootfs_filesystems
+			WHERE head_layer_id IS NOT NULL
+			UNION
+			SELECT head_layer_id AS layer_id
+			FROM manager.rootfs_snapshots
+			WHERE head_layer_id IS NOT NULL
+		),
+		reachable AS (
+			SELECT l.layer_id, l.parent_layer_id
+			FROM manager.rootfs_layers l
+			JOIN roots r ON r.layer_id = l.layer_id
+			UNION
+			SELECT parent.layer_id, parent.parent_layer_id
+			FROM manager.rootfs_layers parent
+			JOIN reachable child ON child.parent_layer_id = parent.layer_id
+		),
+		candidates AS (
+			SELECT l.layer_id
+			FROM manager.rootfs_layers l
+			WHERE ($1 = '' OR l.team_id = $1)
+				AND NOT EXISTS (
+					SELECT 1
+					FROM reachable r
+					WHERE r.layer_id = l.layer_id
+				)
+				AND NOT EXISTS (
+					SELECT 1
+					FROM manager.rootfs_layers child
+					WHERE child.parent_layer_id = l.layer_id
+				)
+			ORDER BY l.created_at ASC
+			LIMIT $2
+			FOR UPDATE SKIP LOCKED
+		),
+		queued_objects AS (
+			INSERT INTO manager.rootfs_object_deletions (
+				object_key, team_id, created_at, updated_at
+			)
+			SELECT DISTINCT l.diff_object_key, l.team_id, NOW(), NOW()
+			FROM manager.rootfs_layers l
+			JOIN candidates c ON c.layer_id = l.layer_id
+			WHERE l.diff_object_key <> ''
+			ON CONFLICT (object_key) DO UPDATE SET
+				team_id = EXCLUDED.team_id,
+				updated_at = NOW()
+			RETURNING object_key
+		),
+		deleted AS (
+			DELETE FROM manager.rootfs_layers l
+			USING candidates c
+			WHERE l.layer_id = c.layer_id
+				AND (
+					l.diff_object_key = ''
+					OR EXISTS (
+						SELECT 1
+						FROM queued_objects q
+						WHERE q.object_key = l.diff_object_key
+					)
+				)
+			RETURNING l.layer_id, l.parent_layer_id, l.source_sandbox_id, l.team_id,
+				l.runtime_generation, l.runtime, l.runtime_handler, l.base_image_ref,
+				l.base_image_digest, l.snapshotter, l.snapshot_parent,
+				l.snapshot_parent_chain, l.diff_digest, l.diff_id, l.diff_media_type,
+				l.diff_size, l.diff_object_key, l.created_at
+		)
+		SELECT layer_id, parent_layer_id, source_sandbox_id, team_id, runtime_generation,
+			runtime, runtime_handler, base_image_ref, base_image_digest, snapshotter,
+			snapshot_parent, snapshot_parent_chain, diff_digest, diff_id, diff_media_type,
+			diff_size, diff_object_key, created_at
+		FROM deleted
+		ORDER BY created_at ASC
+	`, strings.TrimSpace(teamID), limit)
+	if err != nil {
+		return nil, fmt.Errorf("collect unreferenced rootfs layers: %w", err)
+	}
+	defer rows.Close()
+
+	var layers []*SandboxRootFSLayer
+	for rows.Next() {
+		layer, err := scanRootFSLayerRows(rows)
+		if err != nil {
+			return nil, err
+		}
+		layers = append(layers, layer)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate collected rootfs layers: %w", err)
+	}
+	return layers, nil
+}
+
+func (s *PGSandboxStore) DeletePendingRootFSObjects(ctx context.Context, deleter RootFSObjectDeleter, limit int) ([]string, error) {
+	if s == nil || s.pool == nil || deleter == nil {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	if limit > 1000 {
+		limit = 1000
+	}
+	rows, err := s.pool.Query(ctx, `
+		SELECT object_key
+		FROM manager.rootfs_object_deletions
+		ORDER BY updated_at ASC
+		LIMIT $1
+	`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list pending rootfs object deletions: %w", err)
+	}
+	defer rows.Close()
+
+	var keys []string
+	for rows.Next() {
+		var key string
+		if err := rows.Scan(&key); err != nil {
+			return nil, err
+		}
+		keys = append(keys, key)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate pending rootfs object deletions: %w", err)
+	}
+
+	deleted := make([]string, 0, len(keys))
+	for _, key := range keys {
+		if err := ctx.Err(); err != nil {
+			return deleted, err
+		}
+		if err := deleter.Delete(key); err != nil {
+			_, updateErr := s.pool.Exec(ctx, `
+				UPDATE manager.rootfs_object_deletions
+				SET attempts = attempts + 1,
+					last_error = $2,
+					updated_at = NOW()
+				WHERE object_key = $1
+			`, key, err.Error())
+			if updateErr != nil {
+				return deleted, fmt.Errorf("record rootfs object delete failure for %q: %w", key, updateErr)
+			}
+			return deleted, fmt.Errorf("delete rootfs object %q: %w", key, err)
+		}
+		if _, err := s.pool.Exec(ctx, `
+			DELETE FROM manager.rootfs_object_deletions
+			WHERE object_key = $1
+		`, key); err != nil {
+			return deleted, fmt.Errorf("clear rootfs object deletion %q: %w", key, err)
+		}
+		deleted = append(deleted, key)
+	}
+	return deleted, nil
+}
+
+func DeleteRootFSObjects(ctx context.Context, deleter RootFSObjectDeleter, layers []*SandboxRootFSLayer) ([]string, error) {
+	if deleter == nil || len(layers) == 0 {
+		return nil, nil
+	}
+	seen := make(map[string]struct{}, len(layers))
+	deleted := make([]string, 0, len(layers))
+	for _, layer := range layers {
+		if layer == nil {
+			continue
+		}
+		key := strings.TrimSpace(layer.DiffObjectKey)
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		if err := ctx.Err(); err != nil {
+			return deleted, err
+		}
+		if err := deleter.Delete(key); err != nil {
+			return deleted, fmt.Errorf("delete rootfs object %q: %w", key, err)
+		}
+		deleted = append(deleted, key)
+	}
+	return deleted, nil
+}
+
+func (s *PGSandboxStore) rootFSForkNoRowsError(ctx context.Context, req *ForkRootFSFilesystemRequest) error {
+	source, err := s.GetRootFSFilesystem(ctx, req.SourceSandboxID)
+	if err != nil {
+		return err
+	}
+	if source == nil || strings.TrimSpace(source.HeadLayerID) == "" {
+		return fmt.Errorf("%w: sandbox %s", ErrRootFSFilesystemNotFound, req.SourceSandboxID)
+	}
+	if ok, err := s.sandboxExists(ctx, req.TargetSandboxID); err != nil {
+		return err
+	} else if !ok {
+		return fmt.Errorf("%w: %s", ErrSandboxRecordNotFound, req.TargetSandboxID)
+	}
+	return fmt.Errorf("%w: target sandbox %s", ErrRootFSFilesystemConflict, req.TargetSandboxID)
+}
+
+func (s *PGSandboxStore) rootFSRestoreNoRowsError(ctx context.Context, req *RestoreRootFSFromSnapshotRequest) error {
+	if ok, err := s.rootFSSnapshotExists(ctx, req.SnapshotID, strings.TrimSpace(req.TeamID)); err != nil {
+		return err
+	} else if !ok {
+		return fmt.Errorf("%w: %s", ErrRootFSSnapshotNotFound, req.SnapshotID)
+	}
+	if ok, err := s.sandboxExists(ctx, req.SandboxID); err != nil {
+		return err
+	} else if !ok {
+		return fmt.Errorf("%w: %s", ErrSandboxRecordNotFound, req.SandboxID)
+	}
+	return fmt.Errorf("%w: restore target %s", ErrRootFSFilesystemConflict, req.SandboxID)
+}
+
+func (s *PGSandboxStore) sandboxExists(ctx context.Context, sandboxID string) (bool, error) {
+	var exists bool
+	if err := s.pool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM manager.sandboxes
+			WHERE sandbox_id = $1
+		)
+	`, sandboxID).Scan(&exists); err != nil {
+		return false, fmt.Errorf("check sandbox exists: %w", err)
+	}
+	return exists, nil
+}
+
+func (s *PGSandboxStore) rootFSSnapshotExists(ctx context.Context, snapshotID, teamID string) (bool, error) {
+	var exists bool
+	if err := s.pool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM manager.rootfs_snapshots
+			WHERE snapshot_id = $1
+				AND ($2 = '' OR team_id = $2)
+		)
+	`, snapshotID, teamID).Scan(&exists); err != nil {
+		return false, fmt.Errorf("check rootfs snapshot exists: %w", err)
+	}
+	return exists, nil
+}
+
+func scanRootFSFilesystem(row sandboxRecordScanner) (*RootFSFilesystem, error) {
+	var filesystem RootFSFilesystem
+	var sourceFilesystemID, headLayerID *string
+	if err := row.Scan(
+		&filesystem.ID, &filesystem.TeamID, &sourceFilesystemID, &headLayerID,
+		&filesystem.BaseImageRef, &filesystem.BaseImageDigest,
+		&filesystem.CreatedAt, &filesystem.UpdatedAt,
+	); err != nil {
+		return nil, err
+	}
+	if sourceFilesystemID != nil {
+		filesystem.SourceFilesystemID = *sourceFilesystemID
+	}
+	if headLayerID != nil {
+		filesystem.HeadLayerID = *headLayerID
+	}
+	return &filesystem, nil
+}
+
+func scanRootFSSnapshot(row sandboxRecordScanner) (*RootFSSnapshot, error) {
+	var snapshot RootFSSnapshot
+	var filesystemID *string
+	var expiresAt *time.Time
+	if err := row.Scan(
+		&snapshot.ID, &filesystemID, &snapshot.TeamID, &snapshot.SourceSandboxID,
+		&snapshot.HeadLayerID, &snapshot.Name, &snapshot.Description,
+		&snapshot.CreatedAt, &expiresAt,
+	); err != nil {
+		return nil, err
+	}
+	if filesystemID != nil {
+		snapshot.FilesystemID = *filesystemID
+	}
+	if expiresAt != nil {
+		snapshot.ExpiresAt = *expiresAt
+	}
+	return &snapshot, nil
+}

--- a/manager/pkg/service/rootfs_persistent_filesystem_integration_test.go
+++ b/manager/pkg/service/rootfs_persistent_filesystem_integration_test.go
@@ -1,0 +1,246 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRootFSFilesystemPersistenceIntegration(t *testing.T) {
+	ctx := context.Background()
+	pool := newSandboxStoreIntegrationPool(t)
+	store := NewPGSandboxStore(pool)
+
+	require.NoError(t, store.UpsertSandbox(ctx, rootFSTestSandboxRecord("sandbox-source", "team-1")))
+	require.NoError(t, store.SaveRootFSState(ctx, rootFSTestStoreState("sandbox-source", "team-1", "layer-root", "", 1, "root")))
+	require.NoError(t, store.SaveRootFSState(ctx, rootFSTestStoreState("sandbox-source", "team-1", "layer-child", "layer-root", 2, "child")))
+
+	latest, err := store.GetLatestRootFSState(ctx, "sandbox-source")
+	require.NoError(t, err)
+	require.NotNil(t, latest)
+	assert.Equal(t, "sandbox-source", latest.SandboxID)
+	assert.Equal(t, "layer-child", latest.LayerID)
+	require.Len(t, latest.LayerChain, 2)
+	assert.Equal(t, "layer-root", latest.LayerChain[0].ID)
+	assert.Equal(t, "layer-child", latest.LayerChain[1].ID)
+	assert.Equal(t, int64(0), rootFSTestCountRows(t, pool, "sandbox_rootfs_states"))
+	assert.Equal(t, int64(0), rootFSTestCountRows(t, pool, "sandbox_rootfs_heads"))
+
+	err = store.SaveRootFSState(ctx, rootFSTestStoreState("sandbox-source", "team-1", "layer-stale", "layer-root", 3, "stale"))
+	require.ErrorIs(t, err, ErrRootFSHeadConflict)
+
+	require.NoError(t, store.SquashRootFSFilesystem(ctx, &SquashRootFSFilesystemRequest{
+		SandboxID:           "sandbox-source",
+		ExpectedHeadLayerID: "layer-child",
+		SquashedRootFSState: rootFSTestStoreState("sandbox-source", "team-1", "layer-squash", "", 3, "squash"),
+	}))
+	latest, err = store.GetLatestRootFSState(ctx, "sandbox-source")
+	require.NoError(t, err)
+	require.NotNil(t, latest)
+	assert.Equal(t, "layer-squash", latest.LayerID)
+	require.Len(t, latest.LayerChain, 1)
+
+	deleter := &recordingRootFSObjectDeleter{}
+	gcResult, err := store.GarbageCollectRootFSFilesystem(ctx, deleter, "team-1", 10)
+	require.NoError(t, err)
+	require.Len(t, gcResult.Layers, 1)
+	assert.Equal(t, "layer-child", gcResult.Layers[0].ID)
+	assert.Equal(t, []string{"rootfs/child.tar"}, gcResult.DeletedObjectKeys)
+	gcResult, err = store.GarbageCollectRootFSFilesystem(ctx, deleter, "team-1", 10)
+	require.NoError(t, err)
+	require.Len(t, gcResult.Layers, 1)
+	assert.Equal(t, "layer-root", gcResult.Layers[0].ID)
+	assert.Equal(t, []string{"rootfs/root.tar"}, gcResult.DeletedObjectKeys)
+
+	snapshot, err := store.CreateRootFSSnapshot(ctx, &CreateRootFSSnapshotRequest{
+		SandboxID:   "sandbox-source",
+		SnapshotID:  "snapshot-squash",
+		Name:        "squash",
+		Description: "squashed head",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "sandbox-source", snapshot.FilesystemID)
+	assert.Equal(t, "layer-squash", snapshot.HeadLayerID)
+
+	require.NoError(t, store.UpsertSandbox(ctx, rootFSTestSandboxRecord("sandbox-fork", "team-1")))
+	forked, err := store.ForkRootFSFilesystem(ctx, &ForkRootFSFilesystemRequest{
+		SourceSandboxID: "sandbox-source",
+		TargetSandboxID: "sandbox-fork",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "sandbox-source", forked.SourceFilesystemID)
+	assert.Equal(t, "layer-squash", forked.HeadLayerID)
+
+	forkLatest, err := store.GetLatestRootFSState(ctx, "sandbox-fork")
+	require.NoError(t, err)
+	require.NotNil(t, forkLatest)
+	assert.Equal(t, "sandbox-fork", forkLatest.SandboxID)
+	assert.Equal(t, "layer-squash", forkLatest.LayerID)
+	require.Len(t, forkLatest.LayerChain, 1)
+
+	require.NoError(t, store.SaveRootFSState(ctx, rootFSTestStoreState("sandbox-fork", "team-1", "layer-fork", "layer-squash", 4, "fork")))
+	forkLatest, err = store.GetLatestRootFSState(ctx, "sandbox-fork")
+	require.NoError(t, err)
+	require.NotNil(t, forkLatest)
+	assert.Equal(t, "layer-fork", forkLatest.LayerID)
+
+	restored, err := store.RestoreRootFSFromSnapshot(ctx, &RestoreRootFSFromSnapshotRequest{
+		SandboxID:  "sandbox-fork",
+		SnapshotID: "snapshot-squash",
+		TeamID:     "team-1",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "sandbox-fork", restored.ID)
+	assert.Equal(t, "layer-squash", restored.HeadLayerID)
+
+	failDeleter := &recordingRootFSObjectDeleter{failKey: "rootfs/fork.tar", err: assert.AnError}
+	gcResult, err = store.GarbageCollectRootFSFilesystem(ctx, failDeleter, "team-1", 10)
+	require.ErrorIs(t, err, assert.AnError)
+	require.Len(t, gcResult.Layers, 1)
+	assert.Equal(t, "layer-fork", gcResult.Layers[0].ID)
+	assert.Equal(t, int64(1), rootFSTestCountRows(t, pool, "rootfs_object_deletions"))
+
+	deletedObjects, err := store.DeletePendingRootFSObjects(ctx, deleter, 10)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"rootfs/fork.tar"}, deletedObjects)
+	assert.Equal(t, int64(0), rootFSTestCountRows(t, pool, "rootfs_object_deletions"))
+
+	require.NoError(t, store.MarkSandboxDeleted(ctx, "sandbox-source", time.Now().UTC()))
+	sourceFilesystem, err := store.GetRootFSFilesystem(ctx, "sandbox-source")
+	require.NoError(t, err)
+	assert.Nil(t, sourceFilesystem)
+
+	var sourceFilesystemStillExists bool
+	require.NoError(t, pool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM manager.rootfs_filesystems
+			WHERE filesystem_id = 'sandbox-source'
+		)
+	`).Scan(&sourceFilesystemStillExists))
+	assert.True(t, sourceFilesystemStillExists, "source filesystem is retained by snapshot and fork references")
+}
+
+func TestRootFSRootLayerSaveCanCASAgainstExistingHead(t *testing.T) {
+	ctx := context.Background()
+	pool := newSandboxStoreIntegrationPool(t)
+	store := NewPGSandboxStore(pool)
+
+	require.NoError(t, store.UpsertSandbox(ctx, rootFSTestSandboxRecord("sandbox-source", "team-1")))
+	require.NoError(t, store.SaveRootFSState(ctx, rootFSTestStoreState("sandbox-source", "team-1", "layer-root", "", 1, "root")))
+
+	fullLayer := rootFSTestStoreState("sandbox-source", "team-1", "layer-full", "", 2, "full")
+	fullLayer.ExpectedHeadLayerID = "layer-root"
+	require.NoError(t, store.SaveRootFSState(ctx, fullLayer))
+
+	latest, err := store.GetLatestRootFSState(ctx, "sandbox-source")
+	require.NoError(t, err)
+	require.NotNil(t, latest)
+	assert.Equal(t, "layer-full", latest.LayerID)
+	assert.Empty(t, latest.ParentLayerID)
+	require.Len(t, latest.LayerChain, 1)
+
+	staleLayer := rootFSTestStoreState("sandbox-source", "team-1", "layer-stale", "", 3, "stale")
+	staleLayer.ExpectedHeadLayerID = "layer-root"
+	err = store.SaveRootFSState(ctx, staleLayer)
+	require.ErrorIs(t, err, ErrRootFSHeadConflict)
+
+	var staleExists bool
+	require.NoError(t, pool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM manager.rootfs_layers
+			WHERE layer_id = 'layer-stale'
+		)
+	`).Scan(&staleExists))
+	assert.False(t, staleExists, "failed CAS must roll back the candidate layer")
+}
+
+func newSandboxStoreIntegrationPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dbURL := os.Getenv("INTEGRATION_DATABASE_URL")
+	if dbURL == "" {
+		dbURL = os.Getenv("TEST_DATABASE_URL")
+	}
+	if dbURL == "" {
+		t.Skip("missing INTEGRATION_DATABASE_URL or TEST_DATABASE_URL")
+	}
+
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, dbURL)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+
+	_, _ = pool.Exec(ctx, "DROP SCHEMA IF EXISTS manager CASCADE")
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, "DROP SCHEMA IF EXISTS manager CASCADE")
+	})
+	require.NoError(t, RunSandboxStoreMigrations(ctx, pool, noopSandboxStoreMigrateLogger{}))
+	return pool
+}
+
+func rootFSTestSandboxRecord(sandboxID, teamID string) *SandboxRecord {
+	return &SandboxRecord{
+		ID:                sandboxID,
+		TeamID:            teamID,
+		UserID:            "user-1",
+		TemplateID:        "template-1",
+		TemplateName:      "template-1",
+		TemplateNamespace: "template-default",
+		Status:            SandboxStatusRunning,
+		CreatedAt:         time.Now().UTC(),
+	}
+}
+
+func rootFSTestStoreState(sandboxID, teamID, layerID, parentLayerID string, generation int64, suffix string) *SandboxRootFSState {
+	return &SandboxRootFSState{
+		LayerID:             layerID,
+		ParentLayerID:       parentLayerID,
+		SandboxID:           sandboxID,
+		TeamID:              teamID,
+		RuntimeGeneration:   generation,
+		Runtime:             "runc",
+		RuntimeHandler:      "io.containerd.runc.v2",
+		BaseImageRef:        "docker.io/library/busybox:1.36",
+		BaseImageDigest:     "sha256:base",
+		Snapshotter:         "overlayfs",
+		SnapshotParent:      "parent-1",
+		SnapshotParentChain: []string{"parent-1", "parent-0"},
+		DiffDigest:          "sha256:" + suffix,
+		DiffMediaType:       "application/vnd.oci.image.layer.v1.tar",
+		DiffSize:            int64(len(suffix)),
+		DiffObjectKey:       "rootfs/" + suffix + ".tar",
+		CreatedAt:           time.Now().UTC(),
+	}
+}
+
+func rootFSTestCountRows(t *testing.T, pool *pgxpool.Pool, table string) int64 {
+	t.Helper()
+	query := ""
+	switch table {
+	case "sandbox_rootfs_states":
+		query = "SELECT COUNT(*) FROM manager.sandbox_rootfs_states"
+	case "sandbox_rootfs_heads":
+		query = "SELECT COUNT(*) FROM manager.sandbox_rootfs_heads"
+	case "rootfs_object_deletions":
+		query = "SELECT COUNT(*) FROM manager.rootfs_object_deletions"
+	default:
+		t.Fatalf("unexpected table %q", table)
+	}
+	var count int64
+	require.NoError(t, pool.QueryRow(context.Background(), query).Scan(&count))
+	return count
+}
+
+type noopSandboxStoreMigrateLogger struct{}
+
+func (noopSandboxStoreMigrateLogger) Printf(string, ...any) {}
+func (noopSandboxStoreMigrateLogger) Fatalf(format string, args ...any) {
+	panic(fmt.Sprintf(format, args...))
+}

--- a/manager/pkg/service/rootfs_persistent_filesystem_test.go
+++ b/manager/pkg/service/rootfs_persistent_filesystem_test.go
@@ -1,0 +1,160 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSaveRootFSStateWritesLayerAndFilesystemHeadOnly(t *testing.T) {
+	exec := &recordingRootFSStateExecutor{
+		tags: []pgconn.CommandTag{
+			pgconn.NewCommandTag("INSERT 0 1"),
+			pgconn.NewCommandTag("SELECT 1"),
+		},
+	}
+	state := rootFSTestState()
+	state.LayerID = "layer-1"
+
+	err := saveRootFSState(context.Background(), exec, state)
+
+	require.NoError(t, err)
+	require.Len(t, exec.sqls, 2)
+	assert.Contains(t, exec.sqls[0], "INSERT INTO manager.rootfs_layers")
+	assert.Contains(t, exec.sqls[1], "INSERT INTO manager.rootfs_filesystems")
+	for _, sql := range exec.sqls {
+		assert.NotContains(t, sql, "INSERT INTO manager.sandbox_rootfs_states")
+		assert.NotContains(t, sql, "INSERT INTO manager.sandbox_rootfs_heads")
+	}
+}
+
+func TestSaveRootFSStateRequiresLayerID(t *testing.T) {
+	exec := &recordingRootFSStateExecutor{}
+	state := rootFSTestState()
+
+	err := saveRootFSState(context.Background(), exec, state)
+
+	require.ErrorContains(t, err, "layer_id is required")
+	assert.Empty(t, exec.sqls)
+}
+
+func TestSaveRootFSStateMapsHeadCASMissToConflict(t *testing.T) {
+	exec := &recordingRootFSStateExecutor{
+		tags: []pgconn.CommandTag{
+			pgconn.NewCommandTag("INSERT 0 1"),
+			pgconn.NewCommandTag("SELECT 0"),
+		},
+	}
+	state := rootFSTestState()
+	state.LayerID = "layer-child"
+	state.ParentLayerID = "layer-stale"
+
+	err := saveRootFSState(context.Background(), exec, state)
+
+	require.ErrorIs(t, err, ErrRootFSHeadConflict)
+	require.Len(t, exec.sqls, 2)
+}
+
+func TestSaveRootFSStateUsesExpectedHeadLayerIDWhenParentDiffers(t *testing.T) {
+	exec := &recordingRootFSStateExecutor{
+		tags: []pgconn.CommandTag{
+			pgconn.NewCommandTag("INSERT 0 1"),
+			pgconn.NewCommandTag("SELECT 1"),
+		},
+	}
+	state := rootFSTestState()
+	state.LayerID = "layer-full"
+	state.ParentLayerID = ""
+	state.ExpectedHeadLayerID = "layer-parent"
+
+	err := saveRootFSState(context.Background(), exec, state)
+
+	require.NoError(t, err)
+	require.Len(t, exec.args, 2)
+	assert.Equal(t, "layer-parent", exec.args[1][3])
+}
+
+func TestDeleteRootFSObjectsDedupesAndSkipsEmptyKeys(t *testing.T) {
+	deleter := &recordingRootFSObjectDeleter{}
+
+	deleted, err := DeleteRootFSObjects(context.Background(), deleter, []*SandboxRootFSLayer{
+		{DiffObjectKey: " rootfs/a.tar "},
+		nil,
+		{DiffObjectKey: ""},
+		{DiffObjectKey: "rootfs/a.tar"},
+		{DiffObjectKey: "rootfs/b.tar"},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"rootfs/a.tar", "rootfs/b.tar"}, deleted)
+	assert.Equal(t, []string{"rootfs/a.tar", "rootfs/b.tar"}, deleter.keys)
+}
+
+func TestDeleteRootFSObjectsReturnsDeletedKeysBeforeFailure(t *testing.T) {
+	deleteErr := errors.New("delete failed")
+	deleter := &recordingRootFSObjectDeleter{failKey: "rootfs/b.tar", err: deleteErr}
+
+	deleted, err := DeleteRootFSObjects(context.Background(), deleter, []*SandboxRootFSLayer{
+		{DiffObjectKey: "rootfs/a.tar"},
+		{DiffObjectKey: "rootfs/b.tar"},
+		{DiffObjectKey: "rootfs/c.tar"},
+	})
+
+	require.ErrorIs(t, err, deleteErr)
+	assert.Equal(t, []string{"rootfs/a.tar"}, deleted)
+	assert.Equal(t, []string{"rootfs/a.tar", "rootfs/b.tar"}, deleter.keys)
+}
+
+func TestDeleteRootFSObjectsHonorsCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	deleter := &recordingRootFSObjectDeleter{}
+
+	deleted, err := DeleteRootFSObjects(ctx, deleter, []*SandboxRootFSLayer{
+		{DiffObjectKey: "rootfs/a.tar"},
+	})
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Empty(t, deleted)
+	assert.Empty(t, deleter.keys)
+}
+
+type recordingRootFSObjectDeleter struct {
+	keys    []string
+	failKey string
+	err     error
+}
+
+func (d *recordingRootFSObjectDeleter) Delete(key string) error {
+	d.keys = append(d.keys, key)
+	if key == d.failKey {
+		return d.err
+	}
+	return nil
+}
+
+type recordingRootFSStateExecutor struct {
+	sqls []string
+	args [][]any
+	tags []pgconn.CommandTag
+	err  error
+}
+
+func (e *recordingRootFSStateExecutor) Exec(_ context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+	e.sqls = append(e.sqls, strings.Join(strings.Fields(sql), " "))
+	e.args = append(e.args, args)
+	if e.err != nil {
+		return pgconn.CommandTag{}, e.err
+	}
+	if len(e.tags) == 0 {
+		return pgconn.NewCommandTag("INSERT 0 1"), nil
+	}
+	tag := e.tags[0]
+	e.tags = e.tags[1:]
+	return tag, nil
+}

--- a/manager/pkg/service/sandbox_service_rootfs.go
+++ b/manager/pkg/service/sandbox_service_rootfs.go
@@ -54,6 +54,7 @@ func (s *SandboxService) saveSandboxRootFSCheckpoint(ctx context.Context, pod *c
 	} else if parentState != nil {
 		parentLayerID = strings.TrimSpace(parentState.LayerID)
 	}
+	expectedHeadLayerID := parentLayerID
 	saveReq := ctldapi.SaveRootFSRequest{
 		Target:                    rootFSTargetForPod(pod),
 		SandboxID:                 sandboxID,
@@ -76,6 +77,7 @@ func (s *SandboxService) saveSandboxRootFSCheckpoint(ctx context.Context, pod *c
 	}
 	state.LayerID = uuid.NewString()
 	state.ParentLayerID = parentLayerID
+	state.ExpectedHeadLayerID = expectedHeadLayerID
 	if tx != nil {
 		return tx.SaveRootFSState(ctx, state)
 	}

--- a/manager/pkg/service/sandbox_service_rootfs_test.go
+++ b/manager/pkg/service/sandbox_service_rootfs_test.go
@@ -260,6 +260,7 @@ func TestPauseSandboxRuntimeFallsBackToRootLayerWhenBaselineIsMissing(t *testing
 	require.NotNil(t, state)
 	assert.NotEmpty(t, state.LayerID)
 	assert.Empty(t, state.ParentLayerID)
+	assert.Equal(t, "layer-parent", state.ExpectedHeadLayerID)
 	assert.Equal(t, "sha256:full", state.DiffDigest)
 }
 

--- a/manager/pkg/service/sandbox_store.go
+++ b/manager/pkg/service/sandbox_store.go
@@ -51,8 +51,10 @@ type SandboxRecord struct {
 // SandboxRootFSState is manager-internal metadata for one persisted sandbox
 // writable rootfs diff.
 type SandboxRootFSState struct {
-	LayerID             string
-	ParentLayerID       string
+	LayerID       string
+	ParentLayerID string
+	// ExpectedHeadLayerID overrides ParentLayerID as the head CAS precondition.
+	ExpectedHeadLayerID string
 	SandboxID           string
 	TeamID              string
 	RuntimeGeneration   int64
@@ -310,6 +312,33 @@ func (s *PGSandboxStore) MarkSandboxDeleted(ctx context.Context, sandboxID strin
 	if err != nil {
 		return fmt.Errorf("mark sandbox deleted: %w", err)
 	}
+	if _, err := s.pool.Exec(ctx, `
+		WITH removed AS (
+			DELETE FROM manager.sandbox_rootfs_bindings
+			WHERE sandbox_id = $1
+			RETURNING filesystem_id
+		)
+		DELETE FROM manager.rootfs_filesystems f
+		USING removed r
+		WHERE f.filesystem_id = r.filesystem_id
+			AND NOT EXISTS (
+				SELECT 1
+				FROM manager.sandbox_rootfs_bindings b
+				WHERE b.filesystem_id = f.filesystem_id
+			)
+			AND NOT EXISTS (
+				SELECT 1
+				FROM manager.rootfs_snapshots s
+				WHERE s.filesystem_id = f.filesystem_id
+			)
+			AND NOT EXISTS (
+				SELECT 1
+				FROM manager.rootfs_filesystems child
+				WHERE child.source_filesystem_id = f.filesystem_id
+			)
+	`, sandboxID); err != nil {
+		return fmt.Errorf("delete sandbox rootfs binding: %w", err)
+	}
 	if _, err := s.pool.Exec(ctx, `DELETE FROM manager.sandbox_rootfs_states WHERE sandbox_id = $1`, sandboxID); err != nil {
 		return fmt.Errorf("delete sandbox rootfs states: %w", err)
 	}
@@ -323,7 +352,18 @@ func (s *PGSandboxStore) SaveRootFSState(ctx context.Context, state *SandboxRoot
 	if s == nil || s.pool == nil || state == nil {
 		return nil
 	}
-	return saveRootFSState(ctx, s.pool, state)
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("begin rootfs state tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if err := saveRootFSState(ctx, tx, state); err != nil {
+		return err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit rootfs state tx: %w", err)
+	}
+	return nil
 }
 
 func (s *PGSandboxStore) GetLatestRootFSState(ctx context.Context, sandboxID string) (*SandboxRootFSState, error) {
@@ -337,11 +377,7 @@ func (s *PGSandboxStore) GetLatestRootFSState(ctx context.Context, sandboxID str
 	if len(chain) > 0 {
 		return rootFSStateFromLayerChain(sandboxID, chain), nil
 	}
-	return scanRootFSState(s.pool.QueryRow(ctx, rootFSStateSelectSQL()+`
-		WHERE sandbox_id = $1
-		ORDER BY runtime_generation DESC, updated_at DESC
-		LIMIT 1
-	`, sandboxID))
+	return nil, nil
 }
 
 func (s *PGSandboxStore) GetRootFSLayerChain(ctx context.Context, sandboxID string) ([]*SandboxRootFSLayer, error) {
@@ -453,6 +489,19 @@ func saveRootFSState(ctx context.Context, exec rootFSStateExecutor, state *Sandb
 	if exec == nil || state == nil {
 		return nil
 	}
+	if err := validateRootFSState(state); err != nil {
+		return err
+	}
+	if err := saveRootFSLayer(ctx, exec, state); err != nil {
+		return err
+	}
+	return advanceSandboxRootFSFilesystemHead(ctx, exec, state)
+}
+
+func validateRootFSState(state *SandboxRootFSState) error {
+	if state == nil {
+		return nil
+	}
 	if strings.TrimSpace(state.SandboxID) == "" {
 		return fmt.Errorf("sandbox_id is required")
 	}
@@ -465,48 +514,13 @@ func saveRootFSState(ctx context.Context, exec rootFSStateExecutor, state *Sandb
 	if strings.TrimSpace(state.DiffObjectKey) == "" {
 		return fmt.Errorf("diff_object_key is required")
 	}
-	parentChainJSON, err := json.Marshal(state.SnapshotParentChain)
-	if err != nil {
-		return fmt.Errorf("marshal rootfs snapshot parent chain: %w", err)
-	}
-	if strings.TrimSpace(state.LayerID) != "" {
-		if err := saveRootFSLayerAndHead(ctx, exec, state); err != nil {
-			return err
-		}
-	}
-	_, err = exec.Exec(ctx, `
-		INSERT INTO manager.sandbox_rootfs_states (
-			sandbox_id, team_id, runtime_generation, runtime, runtime_handler,
-			base_image_ref, base_image_digest, snapshotter, snapshot_parent,
-			snapshot_parent_chain, diff_digest, diff_media_type, diff_size,
-			diff_object_key, created_at, updated_at
-		)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, COALESCE($15, NOW()), NOW())
-		ON CONFLICT (sandbox_id, runtime_generation) DO UPDATE SET
-			team_id = EXCLUDED.team_id,
-			runtime = EXCLUDED.runtime,
-			runtime_handler = EXCLUDED.runtime_handler,
-			base_image_ref = EXCLUDED.base_image_ref,
-			base_image_digest = EXCLUDED.base_image_digest,
-			snapshotter = EXCLUDED.snapshotter,
-			snapshot_parent = EXCLUDED.snapshot_parent,
-			snapshot_parent_chain = EXCLUDED.snapshot_parent_chain,
-			diff_digest = EXCLUDED.diff_digest,
-			diff_media_type = EXCLUDED.diff_media_type,
-			diff_size = EXCLUDED.diff_size,
-			diff_object_key = EXCLUDED.diff_object_key,
-			updated_at = NOW()
-	`, state.SandboxID, state.TeamID, state.RuntimeGeneration, state.Runtime, state.RuntimeHandler,
-		state.BaseImageRef, state.BaseImageDigest, state.Snapshotter, state.SnapshotParent,
-		parentChainJSON, state.DiffDigest, state.DiffMediaType, state.DiffSize,
-		state.DiffObjectKey, nullableTime(state.CreatedAt))
-	if err != nil {
-		return fmt.Errorf("save sandbox rootfs state: %w", err)
+	if strings.TrimSpace(state.LayerID) == "" {
+		return fmt.Errorf("layer_id is required")
 	}
 	return nil
 }
 
-func saveRootFSLayerAndHead(ctx context.Context, exec rootFSStateExecutor, state *SandboxRootFSState) error {
+func saveRootFSLayer(ctx context.Context, exec rootFSStateExecutor, state *SandboxRootFSState) error {
 	if exec == nil || state == nil {
 		return nil
 	}
@@ -537,44 +551,113 @@ func saveRootFSLayerAndHead(ctx context.Context, exec rootFSStateExecutor, state
 	if err != nil {
 		return fmt.Errorf("save rootfs layer: %w", err)
 	}
-	_, err = exec.Exec(ctx, `
-		INSERT INTO manager.sandbox_rootfs_heads (
-			sandbox_id, team_id, head_layer_id, runtime_generation, updated_at
+	return nil
+}
+
+func advanceSandboxRootFSFilesystemHead(ctx context.Context, exec rootFSStateExecutor, state *SandboxRootFSState) error {
+	expectedHeadLayerID := state.ParentLayerID
+	if strings.TrimSpace(state.ExpectedHeadLayerID) != "" {
+		expectedHeadLayerID = state.ExpectedHeadLayerID
+	}
+	return advanceRootFSFilesystemHead(ctx, exec, state, nullableText(expectedHeadLayerID))
+}
+
+func advanceRootFSFilesystemHead(ctx context.Context, exec rootFSStateExecutor, state *SandboxRootFSState, expectedHeadLayerID any) error {
+	if exec == nil || state == nil {
+		return nil
+	}
+	tag, err := exec.Exec(ctx, `
+		WITH binding AS (
+			SELECT filesystem_id
+			FROM manager.sandbox_rootfs_bindings
+			WHERE sandbox_id = $1
+			UNION ALL
+			SELECT $1
+			WHERE NOT EXISTS (
+				SELECT 1
+				FROM manager.sandbox_rootfs_bindings
+				WHERE sandbox_id = $1
+			)
+			LIMIT 1
+		),
+		advanced AS (
+			INSERT INTO manager.rootfs_filesystems (
+				filesystem_id, team_id, head_layer_id, base_image_ref,
+				base_image_digest, created_at, updated_at
+			)
+			SELECT
+				binding.filesystem_id,
+				$2,
+				$3,
+				$5,
+				$6,
+				COALESCE($7, NOW()),
+				NOW()
+			FROM binding
+			WHERE $4::text IS NULL OR EXISTS (
+				SELECT 1
+				FROM manager.rootfs_filesystems current
+				WHERE current.filesystem_id = binding.filesystem_id
+					AND current.head_layer_id IS NOT DISTINCT FROM $4
+			)
+			ON CONFLICT (filesystem_id) DO UPDATE SET
+				team_id = EXCLUDED.team_id,
+				head_layer_id = EXCLUDED.head_layer_id,
+				base_image_ref = EXCLUDED.base_image_ref,
+				base_image_digest = EXCLUDED.base_image_digest,
+				updated_at = NOW()
+			WHERE manager.rootfs_filesystems.head_layer_id IS NOT DISTINCT FROM $4
+			RETURNING filesystem_id
+		),
+		ensured_binding AS (
+			INSERT INTO manager.sandbox_rootfs_bindings (
+				sandbox_id, filesystem_id, team_id, created_at, updated_at
+			)
+			SELECT $1, filesystem_id, $2, NOW(), NOW()
+			FROM advanced
+			ON CONFLICT (sandbox_id) DO UPDATE SET
+				team_id = EXCLUDED.team_id
+			RETURNING filesystem_id
 		)
-		VALUES ($1, $2, $3, $4, NOW())
-		ON CONFLICT (sandbox_id) DO UPDATE SET
-			team_id = EXCLUDED.team_id,
-			head_layer_id = EXCLUDED.head_layer_id,
-			runtime_generation = EXCLUDED.runtime_generation,
-			updated_at = NOW()
-	`, state.SandboxID, state.TeamID, state.LayerID, state.RuntimeGeneration)
+		SELECT filesystem_id FROM ensured_binding
+	`, state.SandboxID, state.TeamID, state.LayerID, expectedHeadLayerID,
+		state.BaseImageRef, state.BaseImageDigest, nullableTime(state.CreatedAt))
 	if err != nil {
-		return fmt.Errorf("advance rootfs head: %w", err)
+		return fmt.Errorf("advance rootfs filesystem head: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("%w: sandbox %s", ErrRootFSHeadConflict, state.SandboxID)
 	}
 	return nil
 }
 
-func rootFSStateSelectSQL() string {
-	return `
-		SELECT sandbox_id, team_id, runtime_generation, runtime, runtime_handler,
-			base_image_ref, base_image_digest, snapshotter, snapshot_parent,
-			snapshot_parent_chain, diff_digest, diff_media_type, diff_size,
-			diff_object_key, created_at, updated_at
-		FROM manager.sandbox_rootfs_states`
-}
-
 func rootFSLayerChainSQL() string {
 	return `
-		WITH RECURSIVE chain AS (
+		WITH RECURSIVE head AS (
+			SELECT f.head_layer_id
+			FROM manager.sandbox_rootfs_bindings b
+			JOIN manager.rootfs_filesystems f ON f.filesystem_id = b.filesystem_id
+			WHERE b.sandbox_id = $1
+				AND f.head_layer_id IS NOT NULL
+			UNION ALL
+			SELECT h.head_layer_id
+			FROM manager.sandbox_rootfs_heads h
+			WHERE h.sandbox_id = $1
+				AND NOT EXISTS (
+					SELECT 1
+					FROM manager.sandbox_rootfs_bindings b
+					WHERE b.sandbox_id = $1
+				)
+		),
+		chain AS (
 			SELECT
 				l.layer_id, l.parent_layer_id, l.source_sandbox_id, l.team_id,
 				l.runtime_generation, l.runtime, l.runtime_handler, l.base_image_ref,
 				l.base_image_digest, l.snapshotter, l.snapshot_parent,
 				l.snapshot_parent_chain, l.diff_digest, l.diff_id, l.diff_media_type,
 				l.diff_size, l.diff_object_key, l.created_at, 0 AS depth
-			FROM manager.sandbox_rootfs_heads h
+			FROM head h
 			JOIN manager.rootfs_layers l ON l.layer_id = h.head_layer_id
-			WHERE h.sandbox_id = $1
 			UNION ALL
 			SELECT
 				p.layer_id, p.parent_layer_id, p.source_sandbox_id, p.team_id,
@@ -641,28 +724,6 @@ func rootFSStateFromLayerChain(sandboxID string, chain []*SandboxRootFSLayer) *S
 		CreatedAt:           head.CreatedAt,
 		LayerChain:          cloneSandboxRootFSLayers(chain),
 	}
-}
-
-func scanRootFSState(row sandboxRecordScanner) (*SandboxRootFSState, error) {
-	var state SandboxRootFSState
-	var parentChainJSON []byte
-	if err := row.Scan(
-		&state.SandboxID, &state.TeamID, &state.RuntimeGeneration, &state.Runtime, &state.RuntimeHandler,
-		&state.BaseImageRef, &state.BaseImageDigest, &state.Snapshotter, &state.SnapshotParent,
-		&parentChainJSON, &state.DiffDigest, &state.DiffMediaType, &state.DiffSize,
-		&state.DiffObjectKey, &state.CreatedAt, &state.UpdatedAt,
-	); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, nil
-		}
-		return nil, err
-	}
-	if len(parentChainJSON) > 0 {
-		if err := json.Unmarshal(parentChainJSON, &state.SnapshotParentChain); err != nil {
-			return nil, fmt.Errorf("unmarshal rootfs snapshot parent chain: %w", err)
-		}
-	}
-	return &state, nil
 }
 
 type sandboxRecordScanner interface {


### PR DESCRIPTION
## Summary
- add rootfs persistent filesystem and sandbox binding metadata, backfilled from legacy rootfs heads/states
- make rootfs checkpoint saves advance filesystem heads only, with CAS and transaction rollback on conflicts
- add snapshot, restore, COW fork, squashed-head replacement, and rootfs GC helpers
- make rootfs GC object-safe by queuing diff object keys before deleting layer metadata, then deleting pending objects through a retryable deleter path
- keep legacy sandbox_rootfs_heads as read fallback only when no filesystem binding exists

Refs #466

## Tests
- go test ./manager/pkg/service -count=1
- TEST_DATABASE_URL=postgres://test:test@127.0.0.1:<port>/test?sslmode=disable go test ./manager/pkg/service -run TestRootFSFilesystemPersistenceIntegration -count=1 -v
- go test ./manager/... -count=1

Note: local full/focused -race runs did not finish promptly in this environment; PR quick-check should run full race coverage.