### PR TITLE
Add sandbox rootfs snapshot, restore, and fork APIs

### DIFF
--- a/cluster-gateway/pkg/http/server.go
+++ b/cluster-gateway/pkg/http/server.go
@@ -356,6 +356,10 @@ func (s *Server) setupRoutes() {
 			sandboxes.DELETE("/:id", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxDelete), s.deleteSandbox)
 			sandboxes.POST("/:id/pause", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxWrite), s.pauseSandbox)
 			sandboxes.POST("/:id/resume", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxWrite), s.resumeSandbox)
+			sandboxes.POST("/:id/snapshots", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxWrite), s.proxySandboxManagerSubresource("snapshots"))
+			sandboxes.GET("/:id/snapshots", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxRead), s.proxySandboxManagerSubresource("snapshots"))
+			sandboxes.POST("/:id/rootfs/restore", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxWrite), s.proxySandboxManagerSubresource("rootfs/restore"))
+			sandboxes.POST("/:id/fork", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxCreate), s.proxySandboxManagerSubresource("fork"))
 			sandboxes.POST("/:id/refresh", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxWrite), s.refreshSandbox)
 
 			// === Network Policy (→ Manager) ===
@@ -428,6 +432,13 @@ func (s *Server) setupRoutes() {
 			quotas.GET("/:dimension", s.authMiddleware.RequirePermission(gatewayauthn.PermQuotaRead), s.proxyToManager)
 			quotas.PUT("/:dimension", s.authMiddleware.RequirePermission(gatewayauthn.PermQuotaWrite), s.proxyToManager)
 			quotas.DELETE("/:dimension", s.authMiddleware.RequirePermission(gatewayauthn.PermQuotaWrite), s.proxyToManager)
+		}
+
+		rootFSSnapshots := v1.Group("/sandbox-rootfs-snapshots")
+		rootFSSnapshots.Use(s.managerUpstreamMiddleware())
+		{
+			rootFSSnapshots.GET("/:snapshot_id", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxRead), s.proxyManagerPathParam("/api/v1/sandbox-rootfs-snapshots/", "snapshot_id", "snapshot_id"))
+			rootFSSnapshots.DELETE("/:snapshot_id", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxWrite), s.proxyManagerPathParam("/api/v1/sandbox-rootfs-snapshots/", "snapshot_id", "snapshot_id"))
 		}
 
 		// === SandboxVolume Management (→ Storage Proxy) ===

--- a/manager/pkg/http/handlers_sandbox_rootfs.go
+++ b/manager/pkg/http/handlers_sandbox_rootfs.go
@@ -1,0 +1,155 @@
+package http
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/service"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
+	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+	"go.uber.org/zap"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+func (s *Server) createSandboxRootFSSnapshot(c *gin.Context) {
+	sandboxID := c.Param("id")
+	claims := internalauth.ClaimsFromContext(c.Request.Context())
+	if claims == nil {
+		spec.JSONError(c, http.StatusUnauthorized, spec.CodeUnauthorized, "missing authentication")
+		return
+	}
+	var req service.CreateSandboxRootFSSnapshotRequest
+	if err := bindOptionalJSON(c, &req); err != nil {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, fmt.Sprintf("invalid request: %v", err))
+		return
+	}
+	snapshot, err := s.sandboxService.CreateSandboxRootFSSnapshot(c.Request.Context(), sandboxID, claims.TeamID, &req)
+	if err != nil {
+		s.writeSandboxRootFSError(c, "create rootfs snapshot", sandboxID, err)
+		return
+	}
+	spec.JSONSuccess(c, http.StatusCreated, snapshot)
+}
+
+func (s *Server) listSandboxRootFSSnapshots(c *gin.Context) {
+	sandboxID := c.Param("id")
+	claims := internalauth.ClaimsFromContext(c.Request.Context())
+	if claims == nil {
+		spec.JSONError(c, http.StatusUnauthorized, spec.CodeUnauthorized, "missing authentication")
+		return
+	}
+	resp, err := s.sandboxService.ListSandboxRootFSSnapshots(c.Request.Context(), sandboxID, claims.TeamID)
+	if err != nil {
+		s.writeSandboxRootFSError(c, "list rootfs snapshots", sandboxID, err)
+		return
+	}
+	spec.JSONSuccess(c, http.StatusOK, resp)
+}
+
+func (s *Server) getSandboxRootFSSnapshot(c *gin.Context) {
+	snapshotID := c.Param("snapshot_id")
+	claims := internalauth.ClaimsFromContext(c.Request.Context())
+	if claims == nil {
+		spec.JSONError(c, http.StatusUnauthorized, spec.CodeUnauthorized, "missing authentication")
+		return
+	}
+	snapshot, err := s.sandboxService.GetSandboxRootFSSnapshot(c.Request.Context(), snapshotID, claims.TeamID)
+	if err != nil {
+		s.writeSandboxRootFSError(c, "get rootfs snapshot", "", err)
+		return
+	}
+	spec.JSONSuccess(c, http.StatusOK, snapshot)
+}
+
+func (s *Server) deleteSandboxRootFSSnapshot(c *gin.Context) {
+	snapshotID := c.Param("snapshot_id")
+	claims := internalauth.ClaimsFromContext(c.Request.Context())
+	if claims == nil {
+		spec.JSONError(c, http.StatusUnauthorized, spec.CodeUnauthorized, "missing authentication")
+		return
+	}
+	if err := s.sandboxService.DeleteSandboxRootFSSnapshot(c.Request.Context(), snapshotID, claims.TeamID); err != nil {
+		s.writeSandboxRootFSError(c, "delete rootfs snapshot", "", err)
+		return
+	}
+	spec.JSONSuccess(c, http.StatusOK, gin.H{"deleted": true})
+}
+
+func (s *Server) restoreSandboxRootFS(c *gin.Context) {
+	sandboxID := c.Param("id")
+	claims := internalauth.ClaimsFromContext(c.Request.Context())
+	if claims == nil {
+		spec.JSONError(c, http.StatusUnauthorized, spec.CodeUnauthorized, "missing authentication")
+		return
+	}
+	var req service.RestoreSandboxRootFSRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, fmt.Sprintf("invalid request: %v", err))
+		return
+	}
+	resp, err := s.sandboxService.RestoreSandboxRootFS(c.Request.Context(), sandboxID, claims.TeamID, &req)
+	if err != nil {
+		s.writeSandboxRootFSError(c, "restore rootfs", sandboxID, err)
+		return
+	}
+	spec.JSONSuccess(c, http.StatusOK, resp)
+}
+
+func (s *Server) forkSandbox(c *gin.Context) {
+	sandboxID := c.Param("id")
+	claims := internalauth.ClaimsFromContext(c.Request.Context())
+	if claims == nil {
+		spec.JSONError(c, http.StatusUnauthorized, spec.CodeUnauthorized, "missing authentication")
+		return
+	}
+	var req service.ForkSandboxRequest
+	if err := bindOptionalJSON(c, &req); err != nil {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, fmt.Sprintf("invalid request: %v", err))
+		return
+	}
+	resp, err := s.sandboxService.ForkSandbox(c.Request.Context(), sandboxID, claims.TeamID, claims.UserID, &req)
+	if err != nil {
+		s.writeSandboxRootFSError(c, "fork sandbox", sandboxID, err)
+		return
+	}
+	spec.JSONSuccess(c, http.StatusCreated, resp)
+}
+
+func bindOptionalJSON(c *gin.Context, target any) error {
+	if c.Request.Body == nil || c.Request.Body == http.NoBody {
+		return nil
+	}
+	if c.Request.ContentLength == 0 {
+		return nil
+	}
+	err := c.ShouldBindJSON(target)
+	if errors.Is(err, io.EOF) {
+		return nil
+	}
+	return err
+}
+
+func (s *Server) writeSandboxRootFSError(c *gin.Context, action, sandboxID string, err error) {
+	s.logger.Error("Failed sandbox rootfs operation",
+		zap.String("action", action),
+		zap.String("sandboxID", sandboxID),
+		zap.Error(err),
+	)
+	switch {
+	case apierrors.IsNotFound(err), errors.Is(err, service.ErrSandboxRecordNotFound), errors.Is(err, service.ErrRootFSSnapshotNotFound):
+		spec.JSONError(c, http.StatusNotFound, spec.CodeNotFound, "not found")
+	case apierrors.IsForbidden(err):
+		spec.JSONError(c, http.StatusForbidden, spec.CodeForbidden, "forbidden")
+	case errors.Is(err, service.ErrSandboxRootFSRequiresPausedSandbox):
+		spec.JSONError(c, http.StatusConflict, spec.CodeConflict, "sandbox rootfs operation requires a paused sandbox")
+	case errors.Is(err, service.ErrRootFSFilesystemConflict), errors.Is(err, service.ErrRootFSHeadConflict), errors.Is(err, service.ErrRootFSFilesystemNotFound):
+		spec.JSONError(c, http.StatusConflict, spec.CodeConflict, err.Error())
+	case errors.Is(err, service.ErrSandboxRootFSStoreUnavailable):
+		spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox rootfs store is unavailable")
+	default:
+		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, fmt.Sprintf("failed to %s: %v", action, err))
+	}
+}

--- a/manager/pkg/http/server.go
+++ b/manager/pkg/http/server.go
@@ -159,9 +159,16 @@ func (s *Server) setupRoutes() {
 			sandboxes.PUT("/:id/services", s.updateSandboxServices)
 			sandboxes.POST("/:id/pause", s.pauseSandbox)
 			sandboxes.POST("/:id/resume", s.resumeSandbox)
+			sandboxes.POST("/:id/snapshots", s.createSandboxRootFSSnapshot)
+			sandboxes.GET("/:id/snapshots", s.listSandboxRootFSSnapshots)
+			sandboxes.POST("/:id/rootfs/restore", s.restoreSandboxRootFS)
+			sandboxes.POST("/:id/fork", s.forkSandbox)
 			sandboxes.POST("/:id/refresh", s.refreshSandbox)
 			sandboxes.DELETE("/:id", s.terminateSandbox)
 		}
+
+		v1.GET("/sandbox-rootfs-snapshots/:snapshot_id", s.getSandboxRootFSSnapshot)
+		v1.DELETE("/sandbox-rootfs-snapshots/:snapshot_id", s.deleteSandboxRootFSSnapshot)
 
 		// Template management (public API)
 		templates := v1.Group("/templates")

--- a/manager/pkg/service/rootfs_persistent_filesystem.go
+++ b/manager/pkg/service/rootfs_persistent_filesystem.go
@@ -49,6 +49,11 @@ type CreateRootFSSnapshotRequest struct {
 	ExpiresAt   time.Time
 }
 
+type ListRootFSSnapshotsRequest struct {
+	SandboxID string
+	TeamID    string
+}
+
 type ForkRootFSFilesystemRequest struct {
 	SourceSandboxID string
 	TargetSandboxID string
@@ -157,6 +162,75 @@ func (s *PGSandboxStore) CreateRootFSSnapshot(ctx context.Context, req *CreateRo
 		return nil, fmt.Errorf("create rootfs snapshot: %w", err)
 	}
 	return snapshot, nil
+}
+
+func (s *PGSandboxStore) ListRootFSSnapshots(ctx context.Context, req *ListRootFSSnapshotsRequest) ([]*RootFSSnapshot, error) {
+	if s == nil || s.pool == nil || req == nil {
+		return nil, nil
+	}
+	rows, err := s.pool.Query(ctx, `
+		SELECT snapshot_id, filesystem_id, team_id, source_sandbox_id,
+			head_layer_id, name, description, created_at, expires_at
+		FROM manager.rootfs_snapshots
+		WHERE source_sandbox_id = $1
+			AND ($2 = '' OR team_id = $2)
+		ORDER BY created_at DESC
+	`, strings.TrimSpace(req.SandboxID), strings.TrimSpace(req.TeamID))
+	if err != nil {
+		return nil, fmt.Errorf("list rootfs snapshots: %w", err)
+	}
+	defer rows.Close()
+
+	var snapshots []*RootFSSnapshot
+	for rows.Next() {
+		snapshot, err := scanRootFSSnapshot(rows)
+		if err != nil {
+			return nil, err
+		}
+		snapshots = append(snapshots, snapshot)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate rootfs snapshots: %w", err)
+	}
+	return snapshots, nil
+}
+
+func (s *PGSandboxStore) GetRootFSSnapshot(ctx context.Context, snapshotID, teamID string) (*RootFSSnapshot, error) {
+	if s == nil || s.pool == nil || strings.TrimSpace(snapshotID) == "" {
+		return nil, nil
+	}
+	snapshot, err := scanRootFSSnapshot(s.pool.QueryRow(ctx, `
+		SELECT snapshot_id, filesystem_id, team_id, source_sandbox_id,
+			head_layer_id, name, description, created_at, expires_at
+		FROM manager.rootfs_snapshots
+		WHERE snapshot_id = $1
+			AND ($2 = '' OR team_id = $2)
+	`, strings.TrimSpace(snapshotID), strings.TrimSpace(teamID)))
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, fmt.Errorf("%w: %s", ErrRootFSSnapshotNotFound, snapshotID)
+		}
+		return nil, fmt.Errorf("get rootfs snapshot: %w", err)
+	}
+	return snapshot, nil
+}
+
+func (s *PGSandboxStore) DeleteRootFSSnapshot(ctx context.Context, snapshotID, teamID string) error {
+	if s == nil || s.pool == nil {
+		return nil
+	}
+	tag, err := s.pool.Exec(ctx, `
+		DELETE FROM manager.rootfs_snapshots
+		WHERE snapshot_id = $1
+			AND ($2 = '' OR team_id = $2)
+	`, strings.TrimSpace(snapshotID), strings.TrimSpace(teamID))
+	if err != nil {
+		return fmt.Errorf("delete rootfs snapshot: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("%w: %s", ErrRootFSSnapshotNotFound, snapshotID)
+	}
+	return nil
 }
 
 func (s *PGSandboxStore) ForkRootFSFilesystem(ctx context.Context, req *ForkRootFSFilesystemRequest) (*RootFSFilesystem, error) {

--- a/manager/pkg/service/rootfs_persistent_filesystem_integration_test.go
+++ b/manager/pkg/service/rootfs_persistent_filesystem_integration_test.go
@@ -68,6 +68,29 @@ func TestRootFSFilesystemPersistenceIntegration(t *testing.T) {
 	assert.Equal(t, "sandbox-source", snapshot.FilesystemID)
 	assert.Equal(t, "layer-squash", snapshot.HeadLayerID)
 
+	snapshots, err := store.ListRootFSSnapshots(ctx, &ListRootFSSnapshotsRequest{
+		SandboxID: "sandbox-source",
+		TeamID:    "team-1",
+	})
+	require.NoError(t, err)
+	require.Len(t, snapshots, 1)
+	assert.Equal(t, snapshot.ID, snapshots[0].ID)
+
+	loadedSnapshot, err := store.GetRootFSSnapshot(ctx, "snapshot-squash", "team-1")
+	require.NoError(t, err)
+	assert.Equal(t, snapshot.HeadLayerID, loadedSnapshot.HeadLayerID)
+	_, err = store.GetRootFSSnapshot(ctx, "snapshot-squash", "team-2")
+	require.ErrorIs(t, err, ErrRootFSSnapshotNotFound)
+
+	_, err = store.CreateRootFSSnapshot(ctx, &CreateRootFSSnapshotRequest{
+		SandboxID:  "sandbox-source",
+		SnapshotID: "snapshot-delete",
+	})
+	require.NoError(t, err)
+	require.NoError(t, store.DeleteRootFSSnapshot(ctx, "snapshot-delete", "team-1"))
+	_, err = store.GetRootFSSnapshot(ctx, "snapshot-delete", "team-1")
+	require.ErrorIs(t, err, ErrRootFSSnapshotNotFound)
+
 	require.NoError(t, store.UpsertSandbox(ctx, rootFSTestSandboxRecord("sandbox-fork", "team-1")))
 	forked, err := store.ForkRootFSFilesystem(ctx, &ForkRootFSFilesystemRequest{
 		SourceSandboxID: "sandbox-source",

--- a/manager/pkg/service/sandbox_runtime_identity_test.go
+++ b/manager/pkg/service/sandbox_runtime_identity_test.go
@@ -17,11 +17,13 @@ import (
 )
 
 type memorySandboxStore struct {
-	records      map[string]*SandboxRecord
-	rootFSStates map[string]*SandboxRootFSState
-	deletes      []string
-	saves        int
-	pauses       int
+	records           map[string]*SandboxRecord
+	rootFSStates      map[string]*SandboxRootFSState
+	rootFSFilesystems map[string]*RootFSFilesystem
+	rootFSSnapshots   map[string]*RootFSSnapshot
+	deletes           []string
+	saves             int
+	pauses            int
 }
 
 type memorySandboxStoreTx struct {

--- a/manager/pkg/service/sandbox_service_rootfs_product.go
+++ b/manager/pkg/service/sandbox_service_rootfs_product.go
@@ -1,0 +1,373 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
+	"go.uber.org/zap"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
+)
+
+var ErrSandboxRootFSStoreUnavailable = errors.New("sandbox rootfs store is unavailable")
+var ErrSandboxRootFSRequiresPausedSandbox = errors.New("sandbox rootfs operation requires a paused sandbox")
+
+type SandboxRootFSProductStore interface {
+	CreateRootFSSnapshot(ctx context.Context, req *CreateRootFSSnapshotRequest) (*RootFSSnapshot, error)
+	ListRootFSSnapshots(ctx context.Context, req *ListRootFSSnapshotsRequest) ([]*RootFSSnapshot, error)
+	GetRootFSSnapshot(ctx context.Context, snapshotID, teamID string) (*RootFSSnapshot, error)
+	DeleteRootFSSnapshot(ctx context.Context, snapshotID, teamID string) error
+	ForkRootFSFilesystem(ctx context.Context, req *ForkRootFSFilesystemRequest) (*RootFSFilesystem, error)
+	RestoreRootFSFromSnapshot(ctx context.Context, req *RestoreRootFSFromSnapshotRequest) (*RootFSFilesystem, error)
+}
+
+type CreateSandboxRootFSSnapshotRequest struct {
+	Name        string    `json:"name,omitempty"`
+	Description string    `json:"description,omitempty"`
+	ExpiresAt   time.Time `json:"expires_at,omitempty"`
+}
+
+type SandboxRootFSSnapshot struct {
+	ID          string    `json:"id"`
+	SandboxID   string    `json:"sandbox_id"`
+	Name        string    `json:"name,omitempty"`
+	Description string    `json:"description,omitempty"`
+	CreatedAt   time.Time `json:"created_at"`
+	ExpiresAt   time.Time `json:"expires_at,omitempty"`
+}
+
+type ListSandboxRootFSSnapshotsResponse struct {
+	Snapshots []*SandboxRootFSSnapshot `json:"snapshots"`
+	Count     int                      `json:"count"`
+}
+
+type RestoreSandboxRootFSRequest struct {
+	SnapshotID string `json:"snapshot_id"`
+}
+
+type RestoreSandboxRootFSResponse struct {
+	SandboxID  string `json:"sandbox_id"`
+	SnapshotID string `json:"snapshot_id"`
+	Status     string `json:"status"`
+}
+
+type ForkSandboxRequest struct{}
+
+type ForkSandboxResponse struct {
+	SourceSandboxID string   `json:"source_sandbox_id"`
+	Sandbox         *Sandbox `json:"sandbox"`
+}
+
+func (s *SandboxService) CreateSandboxRootFSSnapshot(ctx context.Context, sandboxID, teamID string, req *CreateSandboxRootFSSnapshotRequest) (*SandboxRootFSSnapshot, error) {
+	store, err := s.rootFSProductStore()
+	if err != nil {
+		return nil, err
+	}
+	if req == nil {
+		req = &CreateSandboxRootFSSnapshotRequest{}
+	}
+	sandboxID = strings.TrimSpace(sandboxID)
+	teamID = strings.TrimSpace(teamID)
+	if sandboxID == "" {
+		return nil, fmt.Errorf("sandbox_id is required")
+	}
+	if teamID == "" {
+		return nil, fmt.Errorf("team_id is required")
+	}
+	var snapshot *RootFSSnapshot
+	err = s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, _ SandboxStoreTx, record *SandboxRecord) error {
+		if err := validateRootFSSandboxRecord(record, sandboxID, teamID, true); err != nil {
+			return err
+		}
+		var createErr error
+		snapshot, createErr = store.CreateRootFSSnapshot(lockCtx, &CreateRootFSSnapshotRequest{
+			SandboxID:   sandboxID,
+			SnapshotID:  generateRootFSSnapshotID(),
+			Name:        strings.TrimSpace(req.Name),
+			Description: strings.TrimSpace(req.Description),
+			ExpiresAt:   req.ExpiresAt,
+		})
+		return createErr
+	})
+	if err != nil {
+		return nil, err
+	}
+	return sandboxRootFSSnapshotFromStore(snapshot), nil
+}
+
+func (s *SandboxService) ListSandboxRootFSSnapshots(ctx context.Context, sandboxID, teamID string) (*ListSandboxRootFSSnapshotsResponse, error) {
+	store, err := s.rootFSProductStore()
+	if err != nil {
+		return nil, err
+	}
+	sandboxID = strings.TrimSpace(sandboxID)
+	teamID = strings.TrimSpace(teamID)
+	if sandboxID == "" {
+		return nil, fmt.Errorf("sandbox_id is required")
+	}
+	if teamID == "" {
+		return nil, fmt.Errorf("team_id is required")
+	}
+	if err := s.requireRootFSSandboxOwnership(ctx, sandboxID, teamID); err != nil {
+		return nil, err
+	}
+	snapshots, err := store.ListRootFSSnapshots(ctx, &ListRootFSSnapshotsRequest{
+		SandboxID: sandboxID,
+		TeamID:    teamID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*SandboxRootFSSnapshot, 0, len(snapshots))
+	for _, snapshot := range snapshots {
+		out = append(out, sandboxRootFSSnapshotFromStore(snapshot))
+	}
+	return &ListSandboxRootFSSnapshotsResponse{
+		Snapshots: out,
+		Count:     len(out),
+	}, nil
+}
+
+func (s *SandboxService) GetSandboxRootFSSnapshot(ctx context.Context, snapshotID, teamID string) (*SandboxRootFSSnapshot, error) {
+	store, err := s.rootFSProductStore()
+	if err != nil {
+		return nil, err
+	}
+	snapshot, err := store.GetRootFSSnapshot(ctx, strings.TrimSpace(snapshotID), strings.TrimSpace(teamID))
+	if err != nil {
+		return nil, err
+	}
+	return sandboxRootFSSnapshotFromStore(snapshot), nil
+}
+
+func (s *SandboxService) DeleteSandboxRootFSSnapshot(ctx context.Context, snapshotID, teamID string) error {
+	store, err := s.rootFSProductStore()
+	if err != nil {
+		return err
+	}
+	return store.DeleteRootFSSnapshot(ctx, strings.TrimSpace(snapshotID), strings.TrimSpace(teamID))
+}
+
+func (s *SandboxService) RestoreSandboxRootFS(ctx context.Context, sandboxID, teamID string, req *RestoreSandboxRootFSRequest) (*RestoreSandboxRootFSResponse, error) {
+	store, err := s.rootFSProductStore()
+	if err != nil {
+		return nil, err
+	}
+	if req == nil {
+		return nil, fmt.Errorf("snapshot_id is required")
+	}
+	sandboxID = strings.TrimSpace(sandboxID)
+	teamID = strings.TrimSpace(teamID)
+	snapshotID := strings.TrimSpace(req.SnapshotID)
+	if sandboxID == "" {
+		return nil, fmt.Errorf("sandbox_id is required")
+	}
+	if teamID == "" {
+		return nil, fmt.Errorf("team_id is required")
+	}
+	if snapshotID == "" {
+		return nil, fmt.Errorf("snapshot_id is required")
+	}
+	if _, err := store.GetRootFSSnapshot(ctx, snapshotID, teamID); err != nil {
+		return nil, err
+	}
+	err = s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, _ SandboxStoreTx, record *SandboxRecord) error {
+		if err := validateRootFSSandboxRecord(record, sandboxID, teamID, true); err != nil {
+			return err
+		}
+		_, restoreErr := store.RestoreRootFSFromSnapshot(lockCtx, &RestoreRootFSFromSnapshotRequest{
+			SandboxID:  sandboxID,
+			SnapshotID: snapshotID,
+			TeamID:     teamID,
+		})
+		return restoreErr
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &RestoreSandboxRootFSResponse{
+		SandboxID:  sandboxID,
+		SnapshotID: snapshotID,
+		Status:     SandboxStatusPaused,
+	}, nil
+}
+
+func (s *SandboxService) ForkSandbox(ctx context.Context, sourceSandboxID, teamID, userID string, _ *ForkSandboxRequest) (*ForkSandboxResponse, error) {
+	store, err := s.rootFSProductStore()
+	if err != nil {
+		return nil, err
+	}
+	sourceSandboxID = strings.TrimSpace(sourceSandboxID)
+	teamID = strings.TrimSpace(teamID)
+	userID = strings.TrimSpace(userID)
+	if sourceSandboxID == "" {
+		return nil, fmt.Errorf("sandbox_id is required")
+	}
+	if teamID == "" {
+		return nil, fmt.Errorf("team_id is required")
+	}
+
+	var source *SandboxRecord
+	if err := s.sandboxStore.WithSandboxLock(ctx, sourceSandboxID, func(lockCtx context.Context, _ SandboxStoreTx, record *SandboxRecord) error {
+		if err := validateRootFSSandboxRecord(record, sourceSandboxID, teamID, true); err != nil {
+			return err
+		}
+		source = cloneSandboxRecordForRootFSProduct(record)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	template, err := s.templateForSandboxRecord(source)
+	if err != nil {
+		return nil, err
+	}
+	targetID, err := s.generateAvailableForkSandboxID(ctx, template)
+	if err != nil {
+		return nil, err
+	}
+	now := s.clock.Now().UTC()
+	target := &SandboxRecord{
+		ID:                targetID,
+		TeamID:            teamID,
+		UserID:            userID,
+		TemplateID:        source.TemplateID,
+		TemplateName:      source.TemplateName,
+		TemplateNamespace: source.TemplateNamespace,
+		ClusterID:         source.ClusterID,
+		Status:            SandboxStatusPaused,
+		Config:            cloneSandboxConfigValue(source.Config),
+		TemplateSpec:      *source.TemplateSpec.DeepCopy(),
+		ClaimedAt:         now,
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	}
+	err = s.sandboxStore.WithSandboxLock(ctx, sourceSandboxID, func(lockCtx context.Context, _ SandboxStoreTx, record *SandboxRecord) error {
+		if err := validateRootFSSandboxRecord(record, sourceSandboxID, teamID, true); err != nil {
+			return err
+		}
+		if err := s.sandboxStore.UpsertSandbox(lockCtx, target); err != nil {
+			return err
+		}
+		if _, err := store.ForkRootFSFilesystem(lockCtx, &ForkRootFSFilesystemRequest{
+			SourceSandboxID: sourceSandboxID,
+			TargetSandboxID: targetID,
+			TargetTeamID:    teamID,
+		}); err != nil {
+			if cleanupErr := s.sandboxStore.MarkSandboxDeleted(lockCtx, targetID, s.clock.Now().UTC()); cleanupErr != nil && s.logger != nil {
+				s.logger.Warn("Failed to clean up sandbox record after rootfs fork failure",
+					zap.String("sandboxID", targetID),
+					zap.Error(cleanupErr),
+				)
+			}
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &ForkSandboxResponse{
+		SourceSandboxID: sourceSandboxID,
+		Sandbox:         s.recordToSandbox(target),
+	}, nil
+}
+
+func (s *SandboxService) rootFSProductStore() (SandboxRootFSProductStore, error) {
+	if s == nil || s.sandboxStore == nil {
+		return nil, ErrSandboxRootFSStoreUnavailable
+	}
+	store, ok := s.sandboxStore.(SandboxRootFSProductStore)
+	if !ok {
+		return nil, ErrSandboxRootFSStoreUnavailable
+	}
+	return store, nil
+}
+
+func (s *SandboxService) generateAvailableForkSandboxID(ctx context.Context, template *v1alpha1.SandboxTemplate) (string, error) {
+	if s == nil || s.sandboxStore == nil {
+		return "", ErrSandboxRootFSStoreUnavailable
+	}
+	for i := 0; i < 8; i++ {
+		sandboxID, err := s.generateStableSandboxID(template)
+		if err != nil {
+			return "", err
+		}
+		existing, err := s.sandboxStore.GetSandbox(ctx, sandboxID)
+		if err != nil {
+			if errors.Is(err, ErrSandboxRecordNotFound) {
+				return sandboxID, nil
+			}
+			return "", err
+		}
+		if existing == nil {
+			return sandboxID, nil
+		}
+	}
+	return "", fmt.Errorf("failed to allocate fork sandbox id")
+}
+
+func (s *SandboxService) requireRootFSSandboxOwnership(ctx context.Context, sandboxID, teamID string) error {
+	if s == nil || s.sandboxStore == nil {
+		return ErrSandboxRootFSStoreUnavailable
+	}
+	record, err := s.sandboxStore.GetSandbox(ctx, sandboxID)
+	if err != nil {
+		return err
+	}
+	return validateRootFSSandboxRecord(record, sandboxID, teamID, false)
+}
+
+func validateRootFSSandboxRecord(record *SandboxRecord, sandboxID, teamID string, requirePaused bool) error {
+	if record == nil || record.Status == SandboxStatusDeleted {
+		return apierrors.NewNotFound(schema.GroupResource{Resource: "sandbox"}, sandboxID)
+	}
+	if record.TeamID != teamID {
+		return apierrors.NewForbidden(schema.GroupResource{Resource: "sandbox"}, sandboxID, fmt.Errorf("sandbox belongs to a different team"))
+	}
+	if requirePaused && record.Status != SandboxStatusPaused {
+		return fmt.Errorf("%w: current status is %s", ErrSandboxRootFSRequiresPausedSandbox, record.Status)
+	}
+	return nil
+}
+
+func sandboxRootFSSnapshotFromStore(snapshot *RootFSSnapshot) *SandboxRootFSSnapshot {
+	if snapshot == nil {
+		return nil
+	}
+	return &SandboxRootFSSnapshot{
+		ID:          snapshot.ID,
+		SandboxID:   snapshot.SourceSandboxID,
+		Name:        snapshot.Name,
+		Description: snapshot.Description,
+		CreatedAt:   snapshot.CreatedAt,
+		ExpiresAt:   snapshot.ExpiresAt,
+	}
+}
+
+func generateRootFSSnapshotID() string {
+	return "rootfs-snapshot-" + utilrand.String(10)
+}
+
+func cloneSandboxRecordForRootFSProduct(record *SandboxRecord) *SandboxRecord {
+	if record == nil {
+		return nil
+	}
+	clone := *record
+	clone.Config = cloneSandboxConfigValue(record.Config)
+	clone.Mounts = append([]ClaimMount(nil), record.Mounts...)
+	clone.TemplateSpec = *record.TemplateSpec.DeepCopy()
+	return &clone
+}
+
+func cloneSandboxConfigValue(cfg SandboxConfig) SandboxConfig {
+	cloned := cloneSandboxConfig(&cfg)
+	if cloned == nil {
+		return SandboxConfig{}
+	}
+	return *cloned
+}

--- a/manager/pkg/service/sandbox_service_rootfs_product_test.go
+++ b/manager/pkg/service/sandbox_service_rootfs_product_test.go
@@ -1,0 +1,305 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+func TestSandboxRootFSProductRequiresPausedSandbox(t *testing.T) {
+	now := time.Now().UTC()
+	store := &memorySandboxStore{
+		records: map[string]*SandboxRecord{
+			"sandbox-1": rootFSProductTestRecord("sandbox-1", "team-1", SandboxStatusRunning, now),
+		},
+		rootFSStates: map[string]*SandboxRootFSState{
+			"sandbox-1": rootFSProductTestState("sandbox-1", "team-1", "layer-1"),
+		},
+		rootFSSnapshots: map[string]*RootFSSnapshot{
+			"snapshot-1": {
+				ID:              "snapshot-1",
+				FilesystemID:    "sandbox-1",
+				TeamID:          "team-1",
+				SourceSandboxID: "sandbox-1",
+				HeadLayerID:     "layer-1",
+				CreatedAt:       now,
+			},
+		},
+	}
+	svc := rootFSProductTestService(store)
+
+	_, err := svc.CreateSandboxRootFSSnapshot(context.Background(), "sandbox-1", "team-1", nil)
+	require.ErrorIs(t, err, ErrSandboxRootFSRequiresPausedSandbox)
+
+	_, err = svc.RestoreSandboxRootFS(context.Background(), "sandbox-1", "team-1", &RestoreSandboxRootFSRequest{SnapshotID: "snapshot-1"})
+	require.ErrorIs(t, err, ErrSandboxRootFSRequiresPausedSandbox)
+
+	_, err = svc.ForkSandbox(context.Background(), "sandbox-1", "team-1", "user-1", nil)
+	require.ErrorIs(t, err, ErrSandboxRootFSRequiresPausedSandbox)
+}
+
+func TestSandboxRootFSProductSnapshotsRestoresAndForksPausedSandbox(t *testing.T) {
+	now := time.Now().UTC()
+	autoResume := true
+	store := &memorySandboxStore{
+		records: map[string]*SandboxRecord{
+			"sandbox-1": rootFSProductTestRecord("sandbox-1", "team-1", SandboxStatusPaused, now),
+		},
+		rootFSStates: map[string]*SandboxRootFSState{
+			"sandbox-1": rootFSProductTestState("sandbox-1", "team-1", "layer-v1"),
+		},
+	}
+	store.records["sandbox-1"].Config = SandboxConfig{
+		AutoResume: &autoResume,
+		Services: []SandboxAppService{{
+			ID:      "web",
+			Port:    8080,
+			Ingress: SandboxAppServiceIngress{Public: true},
+		}},
+	}
+	store.records["sandbox-1"].Mounts = []ClaimMount{{
+		SandboxVolumeID: "volume-1",
+		MountPoint:      "/workspace/data",
+	}}
+	svc := rootFSProductTestService(store)
+
+	snapshot, err := svc.CreateSandboxRootFSSnapshot(context.Background(), "sandbox-1", "team-1", &CreateSandboxRootFSSnapshotRequest{
+		Name:        "before-edit",
+		Description: "state before edit",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, snapshot)
+	assert.Equal(t, "sandbox-1", snapshot.SandboxID)
+	assert.Equal(t, "before-edit", snapshot.Name)
+
+	list, err := svc.ListSandboxRootFSSnapshots(context.Background(), "sandbox-1", "team-1")
+	require.NoError(t, err)
+	require.NotNil(t, list)
+	require.Len(t, list.Snapshots, 1)
+	assert.Equal(t, snapshot.ID, list.Snapshots[0].ID)
+
+	loaded, err := svc.GetSandboxRootFSSnapshot(context.Background(), snapshot.ID, "team-1")
+	require.NoError(t, err)
+	assert.Equal(t, snapshot.ID, loaded.ID)
+
+	store.rootFSStates["sandbox-1"] = rootFSProductTestState("sandbox-1", "team-1", "layer-v2")
+	restoreResp, err := svc.RestoreSandboxRootFS(context.Background(), "sandbox-1", "team-1", &RestoreSandboxRootFSRequest{SnapshotID: snapshot.ID})
+	require.NoError(t, err)
+	assert.Equal(t, SandboxStatusPaused, restoreResp.Status)
+	assert.Equal(t, "layer-v1", store.rootFSStates["sandbox-1"].LayerID)
+
+	forkResp, err := svc.ForkSandbox(context.Background(), "sandbox-1", "team-1", "user-2", nil)
+	require.NoError(t, err)
+	require.NotNil(t, forkResp)
+	require.NotNil(t, forkResp.Sandbox)
+	assert.Equal(t, "sandbox-1", forkResp.SourceSandboxID)
+	assert.NotEqual(t, "sandbox-1", forkResp.Sandbox.ID)
+	assert.Equal(t, "team-1", forkResp.Sandbox.TeamID)
+	assert.Equal(t, "user-2", forkResp.Sandbox.UserID)
+	assert.Equal(t, SandboxStatusPaused, forkResp.Sandbox.Status)
+	assert.Empty(t, forkResp.Sandbox.Mounts)
+	assert.Len(t, forkResp.Sandbox.Services, 1)
+	assert.Equal(t, "layer-v1", store.rootFSStates[forkResp.Sandbox.ID].LayerID)
+
+	require.NoError(t, svc.DeleteSandboxRootFSSnapshot(context.Background(), snapshot.ID, "team-1"))
+	_, err = svc.GetSandboxRootFSSnapshot(context.Background(), snapshot.ID, "team-1")
+	require.ErrorIs(t, err, ErrRootFSSnapshotNotFound)
+}
+
+func TestSandboxRootFSProductEnforcesTeamOwnership(t *testing.T) {
+	now := time.Now().UTC()
+	store := &memorySandboxStore{
+		records: map[string]*SandboxRecord{
+			"sandbox-1": rootFSProductTestRecord("sandbox-1", "team-1", SandboxStatusPaused, now),
+		},
+		rootFSStates: map[string]*SandboxRootFSState{
+			"sandbox-1": rootFSProductTestState("sandbox-1", "team-1", "layer-1"),
+		},
+	}
+	svc := rootFSProductTestService(store)
+
+	_, err := svc.CreateSandboxRootFSSnapshot(context.Background(), "sandbox-1", "team-2", nil)
+	require.True(t, apierrors.IsForbidden(err), "error = %v", err)
+}
+
+func (s *memorySandboxStore) CreateRootFSSnapshot(_ context.Context, req *CreateRootFSSnapshotRequest) (*RootFSSnapshot, error) {
+	if s.rootFSSnapshots == nil {
+		s.rootFSSnapshots = make(map[string]*RootFSSnapshot)
+	}
+	state := s.rootFSStates[req.SandboxID]
+	if state == nil || state.LayerID == "" {
+		return nil, ErrRootFSFilesystemNotFound
+	}
+	record := s.records[req.SandboxID]
+	if record == nil {
+		return nil, ErrSandboxRecordNotFound
+	}
+	snapshot := &RootFSSnapshot{
+		ID:              req.SnapshotID,
+		FilesystemID:    req.SandboxID,
+		TeamID:          record.TeamID,
+		SourceSandboxID: req.SandboxID,
+		HeadLayerID:     state.LayerID,
+		Name:            req.Name,
+		Description:     req.Description,
+		CreatedAt:       time.Now().UTC(),
+		ExpiresAt:       req.ExpiresAt,
+	}
+	s.rootFSSnapshots[snapshot.ID] = cloneRootFSSnapshotForTest(snapshot)
+	return cloneRootFSSnapshotForTest(snapshot), nil
+}
+
+func (s *memorySandboxStore) ListRootFSSnapshots(_ context.Context, req *ListRootFSSnapshotsRequest) ([]*RootFSSnapshot, error) {
+	var snapshots []*RootFSSnapshot
+	for _, snapshot := range s.rootFSSnapshots {
+		if snapshot == nil || snapshot.SourceSandboxID != req.SandboxID {
+			continue
+		}
+		if req.TeamID != "" && snapshot.TeamID != req.TeamID {
+			continue
+		}
+		snapshots = append(snapshots, cloneRootFSSnapshotForTest(snapshot))
+	}
+	return snapshots, nil
+}
+
+func (s *memorySandboxStore) GetRootFSSnapshot(_ context.Context, snapshotID, teamID string) (*RootFSSnapshot, error) {
+	snapshot := s.rootFSSnapshots[snapshotID]
+	if snapshot == nil || (teamID != "" && snapshot.TeamID != teamID) {
+		return nil, ErrRootFSSnapshotNotFound
+	}
+	return cloneRootFSSnapshotForTest(snapshot), nil
+}
+
+func (s *memorySandboxStore) DeleteRootFSSnapshot(_ context.Context, snapshotID, teamID string) error {
+	snapshot := s.rootFSSnapshots[snapshotID]
+	if snapshot == nil || (teamID != "" && snapshot.TeamID != teamID) {
+		return ErrRootFSSnapshotNotFound
+	}
+	delete(s.rootFSSnapshots, snapshotID)
+	return nil
+}
+
+func (s *memorySandboxStore) ForkRootFSFilesystem(_ context.Context, req *ForkRootFSFilesystemRequest) (*RootFSFilesystem, error) {
+	sourceState := s.rootFSStates[req.SourceSandboxID]
+	if sourceState == nil || sourceState.LayerID == "" {
+		return nil, ErrRootFSFilesystemNotFound
+	}
+	target := s.records[req.TargetSandboxID]
+	if target == nil {
+		return nil, ErrSandboxRecordNotFound
+	}
+	targetTeamID := req.TargetTeamID
+	if targetTeamID == "" {
+		targetTeamID = target.TeamID
+	}
+	state := cloneSandboxRootFSState(sourceState)
+	state.SandboxID = req.TargetSandboxID
+	state.TeamID = targetTeamID
+	if s.rootFSStates == nil {
+		s.rootFSStates = make(map[string]*SandboxRootFSState)
+	}
+	s.rootFSStates[req.TargetSandboxID] = state
+	if s.rootFSFilesystems == nil {
+		s.rootFSFilesystems = make(map[string]*RootFSFilesystem)
+	}
+	filesystem := &RootFSFilesystem{
+		ID:                 req.TargetSandboxID,
+		TeamID:             targetTeamID,
+		SourceFilesystemID: req.SourceSandboxID,
+		HeadLayerID:        sourceState.LayerID,
+		CreatedAt:          time.Now().UTC(),
+		UpdatedAt:          time.Now().UTC(),
+	}
+	s.rootFSFilesystems[filesystem.ID] = cloneRootFSFilesystemForTest(filesystem)
+	return cloneRootFSFilesystemForTest(filesystem), nil
+}
+
+func (s *memorySandboxStore) RestoreRootFSFromSnapshot(_ context.Context, req *RestoreRootFSFromSnapshotRequest) (*RootFSFilesystem, error) {
+	snapshot, err := s.GetRootFSSnapshot(context.Background(), req.SnapshotID, req.TeamID)
+	if err != nil {
+		return nil, err
+	}
+	target := s.records[req.SandboxID]
+	if target == nil {
+		return nil, ErrSandboxRecordNotFound
+	}
+	if s.rootFSStates == nil {
+		s.rootFSStates = make(map[string]*SandboxRootFSState)
+	}
+	s.rootFSStates[req.SandboxID] = rootFSProductTestState(req.SandboxID, target.TeamID, snapshot.HeadLayerID)
+	filesystem := &RootFSFilesystem{
+		ID:                 req.SandboxID,
+		TeamID:             target.TeamID,
+		SourceFilesystemID: snapshot.FilesystemID,
+		HeadLayerID:        snapshot.HeadLayerID,
+		CreatedAt:          time.Now().UTC(),
+		UpdatedAt:          time.Now().UTC(),
+	}
+	return filesystem, nil
+}
+
+func rootFSProductTestService(store *memorySandboxStore) *SandboxService {
+	return &SandboxService{
+		sandboxStore: store,
+		clock:        systemTime{},
+		logger:       zap.NewNop(),
+	}
+}
+
+func rootFSProductTestRecord(id, teamID, status string, now time.Time) *SandboxRecord {
+	return &SandboxRecord{
+		ID:                id,
+		TeamID:            teamID,
+		UserID:            "user-1",
+		TemplateID:        "template-1",
+		TemplateName:      "template-1",
+		TemplateNamespace: "template-default",
+		ClusterID:         "default",
+		Status:            status,
+		TemplateSpec:      v1alpha1.SandboxTemplateSpec{},
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	}
+}
+
+func rootFSProductTestState(sandboxID, teamID, layerID string) *SandboxRootFSState {
+	return &SandboxRootFSState{
+		LayerID:           layerID,
+		SandboxID:         sandboxID,
+		TeamID:            teamID,
+		RuntimeGeneration: 1,
+		Runtime:           "runc",
+		BaseImageRef:      "docker.io/library/busybox:1.36",
+		BaseImageDigest:   "sha256:base",
+		Snapshotter:       "overlayfs",
+		DiffDigest:        "sha256:" + layerID,
+		DiffObjectKey:     "rootfs/" + layerID + ".tar",
+		CreatedAt:         time.Now().UTC(),
+		UpdatedAt:         time.Now().UTC(),
+	}
+}
+
+func cloneRootFSSnapshotForTest(snapshot *RootFSSnapshot) *RootFSSnapshot {
+	if snapshot == nil {
+		return nil
+	}
+	clone := *snapshot
+	return &clone
+}
+
+func cloneRootFSFilesystemForTest(filesystem *RootFSFilesystem) *RootFSFilesystem {
+	if filesystem == nil {
+		return nil
+	}
+	clone := *filesystem
+	return &clone
+}
+
+var _ SandboxRootFSProductStore = (*memorySandboxStore)(nil)

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -21,6 +21,7 @@ tags:
   - name: registry
   - name: sandbox-volumes
   - name: snapshots
+  - name: sandbox-rootfs
 paths:
   /healthz:
     get:
@@ -1672,6 +1673,178 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorEnvelope"
+  /api/v1/sandboxes/{id}/snapshots:
+    post:
+      tags: [sandbox-rootfs]
+      summary: Create sandbox rootfs snapshot
+      security:
+        - bearerAuth: []
+      x-upstream-service: manager
+      x-upstream-path: /api/v1/sandboxes/{id}/snapshots
+      parameters:
+        - $ref: "#/components/parameters/SandboxID"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateSandboxRootFSSnapshotRequest"
+      responses:
+        "201":
+          description: Sandbox rootfs snapshot created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessSandboxRootFSSnapshotResponse"
+        "409":
+          description: Sandbox is not paused or rootfs state is unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+    get:
+      tags: [sandbox-rootfs]
+      summary: List sandbox rootfs snapshots
+      security:
+        - bearerAuth: []
+      x-upstream-service: manager
+      x-upstream-path: /api/v1/sandboxes/{id}/snapshots
+      parameters:
+        - $ref: "#/components/parameters/SandboxID"
+      responses:
+        "200":
+          description: Sandbox rootfs snapshot list
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessSandboxRootFSSnapshotListResponse"
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+  /api/v1/sandboxes/{id}/rootfs/restore:
+    post:
+      tags: [sandbox-rootfs]
+      summary: Restore sandbox rootfs from snapshot
+      security:
+        - bearerAuth: []
+      x-upstream-service: manager
+      x-upstream-path: /api/v1/sandboxes/{id}/rootfs/restore
+      parameters:
+        - $ref: "#/components/parameters/SandboxID"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RestoreSandboxRootFSRequest"
+      responses:
+        "200":
+          description: Sandbox rootfs restored
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessRestoreSandboxRootFSResponse"
+        "409":
+          description: Sandbox is not paused
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+  /api/v1/sandboxes/{id}/fork:
+    post:
+      tags: [sandbox-rootfs]
+      summary: Fork sandbox from paused rootfs
+      security:
+        - bearerAuth: []
+      x-upstream-service: manager
+      x-upstream-path: /api/v1/sandboxes/{id}/fork
+      parameters:
+        - $ref: "#/components/parameters/SandboxID"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ForkSandboxRequest"
+      responses:
+        "201":
+          description: Sandbox forked
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessForkSandboxResponse"
+        "409":
+          description: Source sandbox is not paused or rootfs state is unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+  /api/v1/sandbox-rootfs-snapshots/{snapshot_id}:
+    get:
+      tags: [sandbox-rootfs]
+      summary: Get sandbox rootfs snapshot
+      security:
+        - bearerAuth: []
+      x-upstream-service: manager
+      x-upstream-path: /api/v1/sandbox-rootfs-snapshots/{snapshot_id}
+      parameters:
+        - $ref: "#/components/parameters/RootFSSnapshotID"
+      responses:
+        "200":
+          description: Sandbox rootfs snapshot
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessSandboxRootFSSnapshotResponse"
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+    delete:
+      tags: [sandbox-rootfs]
+      summary: Delete sandbox rootfs snapshot
+      security:
+        - bearerAuth: []
+      x-upstream-service: manager
+      x-upstream-path: /api/v1/sandbox-rootfs-snapshots/{snapshot_id}
+      parameters:
+        - $ref: "#/components/parameters/RootFSSnapshotID"
+      responses:
+        "200":
+          description: Deleted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessDeletedResponse"
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
   /api/v1/sandboxes/{id}/refresh:
     post:
       tags: [sandboxes]
@@ -2892,6 +3065,12 @@ components:
   parameters:
     SandboxID:
       name: id
+      in: path
+      required: true
+      schema:
+        type: string
+    RootFSSnapshotID:
+      name: snapshot_id
       in: path
       required: true
       schema:
@@ -4249,6 +4428,101 @@ components:
           properties:
             data:
               $ref: "#/components/schemas/Sandbox"
+    CreateSandboxRootFSSnapshotRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        expires_at:
+          type: string
+          format: date-time
+          description: Optional snapshot expiration timestamp. Zero value means not set.
+    SandboxRootFSSnapshot:
+      type: object
+      properties:
+        id:
+          type: string
+        sandbox_id:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        expires_at:
+          type: string
+          format: date-time
+          description: Optional snapshot expiration timestamp. Zero value means not set.
+      required: [id, sandbox_id, created_at]
+    SandboxRootFSSnapshotList:
+      type: object
+      properties:
+        snapshots:
+          type: array
+          items:
+            $ref: "#/components/schemas/SandboxRootFSSnapshot"
+        count:
+          type: integer
+      required: [snapshots, count]
+    RestoreSandboxRootFSRequest:
+      type: object
+      properties:
+        snapshot_id:
+          type: string
+      required: [snapshot_id]
+    RestoreSandboxRootFSResponse:
+      type: object
+      properties:
+        sandbox_id:
+          type: string
+        snapshot_id:
+          type: string
+        status:
+          $ref: "#/components/schemas/SandboxLifecycleStatus"
+      required: [sandbox_id, snapshot_id, status]
+    ForkSandboxRequest:
+      type: object
+      additionalProperties: false
+    ForkSandboxResponse:
+      type: object
+      properties:
+        source_sandbox_id:
+          type: string
+        sandbox:
+          $ref: "#/components/schemas/Sandbox"
+      required: [source_sandbox_id, sandbox]
+    SuccessSandboxRootFSSnapshotResponse:
+      allOf:
+        - $ref: "#/components/schemas/SuccessEnvelope"
+        - type: object
+          properties:
+            data:
+              $ref: "#/components/schemas/SandboxRootFSSnapshot"
+    SuccessSandboxRootFSSnapshotListResponse:
+      allOf:
+        - $ref: "#/components/schemas/SuccessEnvelope"
+        - type: object
+          properties:
+            data:
+              $ref: "#/components/schemas/SandboxRootFSSnapshotList"
+    SuccessRestoreSandboxRootFSResponse:
+      allOf:
+        - $ref: "#/components/schemas/SuccessEnvelope"
+        - type: object
+          properties:
+            data:
+              $ref: "#/components/schemas/RestoreSandboxRootFSResponse"
+    SuccessForkSandboxResponse:
+      allOf:
+        - $ref: "#/components/schemas/SuccessEnvelope"
+        - type: object
+          properties:
+            data:
+              $ref: "#/components/schemas/ForkSandboxResponse"
     SuccessSandboxStatusResponse:
       allOf:
         - $ref: "#/components/schemas/SuccessEnvelope"

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -292,6 +292,11 @@ const (
 	SuccessFileStatResponseSuccessTrue SuccessFileStatResponseSuccess = true
 )
 
+// Defines values for SuccessForkSandboxResponseSuccess.
+const (
+	SuccessForkSandboxResponseSuccessTrue SuccessForkSandboxResponseSuccess = true
+)
+
 // Defines values for SuccessGatewayMetadataResponseSuccess.
 const (
 	SuccessGatewayMetadataResponseSuccessTrue SuccessGatewayMetadataResponseSuccess = true
@@ -357,6 +362,11 @@ const (
 	SuccessRestoreResponseSuccessTrue SuccessRestoreResponseSuccess = true
 )
 
+// Defines values for SuccessRestoreSandboxRootFSResponseSuccess.
+const (
+	SuccessRestoreSandboxRootFSResponseSuccessTrue SuccessRestoreSandboxRootFSResponseSuccess = true
+)
+
 // Defines values for SuccessResumeSandboxResponseSuccess.
 const (
 	SuccessResumeSandboxResponseSuccessTrue SuccessResumeSandboxResponseSuccess = true
@@ -385,6 +395,16 @@ const (
 // Defines values for SuccessSandboxResponseSuccess.
 const (
 	SuccessSandboxResponseSuccessTrue SuccessSandboxResponseSuccess = true
+)
+
+// Defines values for SuccessSandboxRootFSSnapshotListResponseSuccess.
+const (
+	SuccessSandboxRootFSSnapshotListResponseSuccessTrue SuccessSandboxRootFSSnapshotListResponseSuccess = true
+)
+
+// Defines values for SuccessSandboxRootFSSnapshotResponseSuccess.
+const (
+	SuccessSandboxRootFSSnapshotResponseSuccessTrue SuccessSandboxRootFSSnapshotResponseSuccess = true
 )
 
 // Defines values for SuccessSandboxServicesResponseSuccess.
@@ -729,6 +749,15 @@ type CreateSSHPublicKeyRequest struct {
 	PublicKey string `json:"public_key"`
 }
 
+// CreateSandboxRootFSSnapshotRequest defines model for CreateSandboxRootFSSnapshotRequest.
+type CreateSandboxRootFSSnapshotRequest struct {
+	Description *string `json:"description,omitempty"`
+
+	// ExpiresAt Optional snapshot expiration timestamp. Zero value means not set.
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
+	Name      *string    `json:"name,omitempty"`
+}
+
 // CreateSandboxVolumeRequest defines model for CreateSandboxVolumeRequest.
 type CreateSandboxVolumeRequest struct {
 	// AccessMode Access mode for sandbox volumes. Enforcement is scoped to storage-proxy instances. RWO allows read-write mounts on a single instance; ROX allows read-only mounts across instances; RWX allows read-write mounts across instances.
@@ -945,6 +974,15 @@ type FileInfo struct {
 
 // FileInfoType defines model for FileInfo.Type.
 type FileInfoType string
+
+// ForkSandboxRequest defines model for ForkSandboxRequest.
+type ForkSandboxRequest = map[string]interface{}
+
+// ForkSandboxResponse defines model for ForkSandboxResponse.
+type ForkSandboxResponse struct {
+	Sandbox         Sandbox `json:"sandbox"`
+	SourceSandboxId string  `json:"source_sandbox_id"`
+}
 
 // ForkVolumeRequest defines model for ForkVolumeRequest.
 type ForkVolumeRequest struct {
@@ -1444,6 +1482,18 @@ type ResourceUsage struct {
 	ThreadCount               *int     `json:"thread_count,omitempty"`
 }
 
+// RestoreSandboxRootFSRequest defines model for RestoreSandboxRootFSRequest.
+type RestoreSandboxRootFSRequest struct {
+	SnapshotId string `json:"snapshot_id"`
+}
+
+// RestoreSandboxRootFSResponse defines model for RestoreSandboxRootFSResponse.
+type RestoreSandboxRootFSResponse struct {
+	SandboxId  string                 `json:"sandbox_id"`
+	SnapshotId string                 `json:"snapshot_id"`
+	Status     SandboxLifecycleStatus `json:"status"`
+}
+
 // ResumeSandboxResponse defines model for ResumeSandboxResponse.
 type ResumeSandboxResponse struct {
 	RestoredMemory *string `json:"restored_memory,omitempty"`
@@ -1696,6 +1746,24 @@ type SandboxResourceUsage struct {
 	TotalMemoryVms            *int64                  `json:"total_memory_vms,omitempty"`
 	TotalOpenFiles            *int                    `json:"total_open_files,omitempty"`
 	TotalThreadCount          *int                    `json:"total_thread_count,omitempty"`
+}
+
+// SandboxRootFSSnapshot defines model for SandboxRootFSSnapshot.
+type SandboxRootFSSnapshot struct {
+	CreatedAt   time.Time `json:"created_at"`
+	Description *string   `json:"description,omitempty"`
+
+	// ExpiresAt Optional snapshot expiration timestamp. Zero value means not set.
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
+	Id        string     `json:"id"`
+	Name      *string    `json:"name,omitempty"`
+	SandboxId string     `json:"sandbox_id"`
+}
+
+// SandboxRootFSSnapshotList defines model for SandboxRootFSSnapshotList.
+type SandboxRootFSSnapshotList struct {
+	Count     int                     `json:"count"`
+	Snapshots []SandboxRootFSSnapshot `json:"snapshots"`
 }
 
 // SandboxSSHConnection defines model for SandboxSSHConnection.
@@ -2059,6 +2127,15 @@ type SuccessFileStatResponse struct {
 // SuccessFileStatResponseSuccess defines model for SuccessFileStatResponse.Success.
 type SuccessFileStatResponseSuccess bool
 
+// SuccessForkSandboxResponse defines model for SuccessForkSandboxResponse.
+type SuccessForkSandboxResponse struct {
+	Data    *ForkSandboxResponse              `json:"data,omitempty"`
+	Success SuccessForkSandboxResponseSuccess `json:"success"`
+}
+
+// SuccessForkSandboxResponseSuccess defines model for SuccessForkSandboxResponse.Success.
+type SuccessForkSandboxResponseSuccess bool
+
 // SuccessGatewayMetadataResponse defines model for SuccessGatewayMetadataResponse.
 type SuccessGatewayMetadataResponse struct {
 	Data    *GatewayMetadata                      `json:"data,omitempty"`
@@ -2191,6 +2268,15 @@ type SuccessRestoreResponse struct {
 // SuccessRestoreResponseSuccess defines model for SuccessRestoreResponse.Success.
 type SuccessRestoreResponseSuccess bool
 
+// SuccessRestoreSandboxRootFSResponse defines model for SuccessRestoreSandboxRootFSResponse.
+type SuccessRestoreSandboxRootFSResponse struct {
+	Data    *RestoreSandboxRootFSResponse              `json:"data,omitempty"`
+	Success SuccessRestoreSandboxRootFSResponseSuccess `json:"success"`
+}
+
+// SuccessRestoreSandboxRootFSResponseSuccess defines model for SuccessRestoreSandboxRootFSResponse.Success.
+type SuccessRestoreSandboxRootFSResponseSuccess bool
+
 // SuccessResumeSandboxResponse defines model for SuccessResumeSandboxResponse.
 type SuccessResumeSandboxResponse struct {
 	Data    *ResumeSandboxResponse              `json:"data,omitempty"`
@@ -2253,6 +2339,24 @@ type SuccessSandboxResponse struct {
 
 // SuccessSandboxResponseSuccess defines model for SuccessSandboxResponse.Success.
 type SuccessSandboxResponseSuccess bool
+
+// SuccessSandboxRootFSSnapshotListResponse defines model for SuccessSandboxRootFSSnapshotListResponse.
+type SuccessSandboxRootFSSnapshotListResponse struct {
+	Data    *SandboxRootFSSnapshotList                      `json:"data,omitempty"`
+	Success SuccessSandboxRootFSSnapshotListResponseSuccess `json:"success"`
+}
+
+// SuccessSandboxRootFSSnapshotListResponseSuccess defines model for SuccessSandboxRootFSSnapshotListResponse.Success.
+type SuccessSandboxRootFSSnapshotListResponseSuccess bool
+
+// SuccessSandboxRootFSSnapshotResponse defines model for SuccessSandboxRootFSSnapshotResponse.
+type SuccessSandboxRootFSSnapshotResponse struct {
+	Data    *SandboxRootFSSnapshot                      `json:"data,omitempty"`
+	Success SuccessSandboxRootFSSnapshotResponseSuccess `json:"success"`
+}
+
+// SuccessSandboxRootFSSnapshotResponseSuccess defines model for SuccessSandboxRootFSSnapshotResponse.Success.
+type SuccessSandboxRootFSSnapshotResponseSuccess bool
 
 // SuccessSandboxServicesResponse defines model for SuccessSandboxServicesResponse.
 type SuccessSandboxServicesResponse struct {
@@ -2634,6 +2738,9 @@ type QueryRecursive = bool
 // RegionId defines model for RegionId.
 type RegionId = string
 
+// RootFSSnapshotID defines model for RootFSSnapshotID.
+type RootFSSnapshotID = string
+
 // SandboxID defines model for SandboxID.
 type SandboxID = string
 
@@ -2818,14 +2925,23 @@ type PostApiV1SandboxesIdContextsCtxIdSignalJSONRequestBody = SignalContextReque
 // PostApiV1SandboxesIdFilesMoveJSONRequestBody defines body for PostApiV1SandboxesIdFilesMove for application/json ContentType.
 type PostApiV1SandboxesIdFilesMoveJSONRequestBody = MoveFileRequest
 
+// PostApiV1SandboxesIdForkJSONRequestBody defines body for PostApiV1SandboxesIdFork for application/json ContentType.
+type PostApiV1SandboxesIdForkJSONRequestBody = ForkSandboxRequest
+
 // PutApiV1SandboxesIdNetworkJSONRequestBody defines body for PutApiV1SandboxesIdNetwork for application/json ContentType.
 type PutApiV1SandboxesIdNetworkJSONRequestBody = SandboxNetworkPolicy
 
 // PostApiV1SandboxesIdRefreshJSONRequestBody defines body for PostApiV1SandboxesIdRefresh for application/json ContentType.
 type PostApiV1SandboxesIdRefreshJSONRequestBody = SandboxRefreshRequest
 
+// PostApiV1SandboxesIdRootfsRestoreJSONRequestBody defines body for PostApiV1SandboxesIdRootfsRestore for application/json ContentType.
+type PostApiV1SandboxesIdRootfsRestoreJSONRequestBody = RestoreSandboxRootFSRequest
+
 // PutApiV1SandboxesIdServicesJSONRequestBody defines body for PutApiV1SandboxesIdServices for application/json ContentType.
 type PutApiV1SandboxesIdServicesJSONRequestBody = SandboxServicesUpdateRequest
+
+// PostApiV1SandboxesIdSnapshotsJSONRequestBody defines body for PostApiV1SandboxesIdSnapshots for application/json ContentType.
+type PostApiV1SandboxesIdSnapshotsJSONRequestBody = CreateSandboxRootFSSnapshotRequest
 
 // PostApiV1SandboxvolumesJSONRequestBody defines body for PostApiV1Sandboxvolumes for application/json ContentType.
 type PostApiV1SandboxvolumesJSONRequestBody = CreateSandboxVolumeRequest

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -225,6 +225,10 @@ func registerApiModeSuite(envProvider func() *framework.ScenarioEnv, opts apiMod
 				It("persists rootfs changes across pause and resume", func() {
 					assertSandboxRootFSPersistsAcrossPauseResume(env, session)
 				})
+
+				It("snapshots restores and forks paused sandbox rootfs", func() {
+					assertSandboxRootFSSnapshotRestoreFork(env, session)
+				})
 			}
 		})
 
@@ -1399,6 +1403,161 @@ test "$(stat -c %%a %s)" = 751
 		shellQuote(rootDir),
 	)
 	_, err = execInSandboxPod(env, templateNamespace, restored.PodName, verifyScript)
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func assertSandboxRootFSSnapshotRestoreFork(env *framework.ScenarioEnv, session *e2eutils.Session) {
+	claimResp := claimSandboxEventually(env, session, "default")
+	sourceSandboxID := claimResp.SandboxId
+	Expect(sourceSandboxID).NotTo(BeEmpty())
+	forkSandboxID := ""
+	snapshotID := ""
+	DeferCleanup(func() {
+		if snapshotID != "" {
+			_, _ = session.DeleteSandboxRootFSSnapshot(env.TestCtx.Context, GinkgoT(), snapshotID)
+		}
+		if forkSandboxID != "" {
+			_ = session.DeleteSandbox(env.TestCtx.Context, GinkgoT(), forkSandboxID)
+		}
+		_ = session.DeleteSandbox(env.TestCtx.Context, GinkgoT(), sourceSandboxID)
+	})
+
+	templateNamespace, err := naming.TemplateNamespaceForBuiltin("default")
+	Expect(err).NotTo(HaveOccurred())
+	source := waitForSandboxPodReadyEventually(env, session, sourceSandboxID, templateNamespace)
+
+	marker := fmt.Sprintf("s0-rootfs-snapshot-%d", time.Now().UnixNano())
+	rootDir := "/tmp/" + marker
+	filePath := rootDir + "/marker.txt"
+	nestedPath := rootDir + "/nested/value.txt"
+	v1Content := "snapshot v1 " + marker
+	v2Content := "snapshot v2 " + marker
+
+	writeV1Script := fmt.Sprintf(`set -eu
+rm -rf %s
+mkdir -p %s
+printf %%s %s > %s
+printf %%s nested-v1 > %s
+test "$(cat %s)" = %s
+test "$(cat %s)" = nested-v1
+`,
+		shellQuote(rootDir),
+		shellQuote(filepathDir(nestedPath)),
+		shellQuote(v1Content),
+		shellQuote(filePath),
+		shellQuote(nestedPath),
+		shellQuote(filePath),
+		shellQuote(v1Content),
+		shellQuote(nestedPath),
+	)
+	_, err = execInSandboxPod(env, templateNamespace, source.PodName, writeV1Script)
+	Expect(err).NotTo(HaveOccurred())
+
+	pausedResp, status, err := session.PauseSandbox(env.TestCtx.Context, GinkgoT(), sourceSandboxID)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+	Expect(pausedResp).NotTo(BeNil())
+	waitForSandboxLifecycleStatusEventually(env, session, sourceSandboxID, apispec.SandboxLifecycleStatusPaused)
+
+	name := "e2e-rootfs-" + marker
+	snapshot, status, err := session.CreateSandboxRootFSSnapshot(env.TestCtx.Context, GinkgoT(), sourceSandboxID, apispec.CreateSandboxRootFSSnapshotRequest{
+		Name: ptr(name),
+	})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusCreated))
+	Expect(snapshot).NotTo(BeNil())
+	Expect(snapshot.Id).NotTo(BeEmpty())
+	snapshotID = snapshot.Id
+
+	listResp, status, err := session.ListSandboxRootFSSnapshots(env.TestCtx.Context, GinkgoT(), sourceSandboxID)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+	Expect(listResp).NotTo(BeNil())
+	Expect(listResp.Count).To(BeNumerically(">=", 1))
+
+	loaded, status, err := session.GetSandboxRootFSSnapshot(env.TestCtx.Context, GinkgoT(), snapshotID)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+	Expect(loaded).NotTo(BeNil())
+	Expect(loaded.Id).To(Equal(snapshotID))
+
+	resumeResp, status, err := session.ResumeSandbox(env.TestCtx.Context, GinkgoT(), sourceSandboxID)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+	Expect(resumeResp).NotTo(BeNil())
+	Expect(resumeResp.Resumed).To(BeTrue())
+	source = waitForSandboxPodReadyEventually(env, session, sourceSandboxID, templateNamespace)
+
+	writeV2Script := fmt.Sprintf(`set -eu
+printf %%s %s > %s
+printf %%s nested-v2 > %s
+test "$(cat %s)" = %s
+test "$(cat %s)" = nested-v2
+`,
+		shellQuote(v2Content),
+		shellQuote(filePath),
+		shellQuote(nestedPath),
+		shellQuote(filePath),
+		shellQuote(v2Content),
+		shellQuote(nestedPath),
+	)
+	_, err = execInSandboxPod(env, templateNamespace, source.PodName, writeV2Script)
+	Expect(err).NotTo(HaveOccurred())
+
+	pausedResp, status, err = session.PauseSandbox(env.TestCtx.Context, GinkgoT(), sourceSandboxID)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+	Expect(pausedResp).NotTo(BeNil())
+	waitForSandboxLifecycleStatusEventually(env, session, sourceSandboxID, apispec.SandboxLifecycleStatusPaused)
+
+	restoreResp, status, err := session.RestoreSandboxRootFS(env.TestCtx.Context, GinkgoT(), sourceSandboxID, apispec.RestoreSandboxRootFSRequest{
+		SnapshotId: snapshotID,
+	})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+	Expect(restoreResp).NotTo(BeNil())
+	Expect(restoreResp.Status).To(Equal(apispec.SandboxLifecycleStatusPaused))
+
+	forkResp, status, err := session.ForkSandbox(env.TestCtx.Context, GinkgoT(), sourceSandboxID)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusCreated))
+	Expect(forkResp).NotTo(BeNil())
+	Expect(forkResp.SourceSandboxId).To(Equal(sourceSandboxID))
+	Expect(forkResp.Sandbox.Id).NotTo(BeEmpty())
+	Expect(forkResp.Sandbox.Id).NotTo(Equal(sourceSandboxID))
+	Expect(forkResp.Sandbox.Status).To(Equal(apispec.SandboxLifecycleStatusPaused))
+	forkSandboxID = forkResp.Sandbox.Id
+
+	status, err = session.DeleteSandboxRootFSSnapshot(env.TestCtx.Context, GinkgoT(), snapshotID)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+	snapshotID = ""
+
+	resumeResp, status, err = session.ResumeSandbox(env.TestCtx.Context, GinkgoT(), sourceSandboxID)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+	Expect(resumeResp).NotTo(BeNil())
+	Expect(resumeResp.Resumed).To(BeTrue())
+	source = waitForSandboxPodReadyEventually(env, session, sourceSandboxID, templateNamespace)
+
+	verifyV1Script := fmt.Sprintf(`set -eu
+test "$(cat %s)" = %s
+test "$(cat %s)" = nested-v1
+`,
+		shellQuote(filePath),
+		shellQuote(v1Content),
+		shellQuote(nestedPath),
+	)
+	_, err = execInSandboxPod(env, templateNamespace, source.PodName, verifyV1Script)
+	Expect(err).NotTo(HaveOccurred())
+
+	resumeResp, status, err = session.ResumeSandbox(env.TestCtx.Context, GinkgoT(), forkSandboxID)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+	Expect(resumeResp).NotTo(BeNil())
+	Expect(resumeResp.Resumed).To(BeTrue())
+	forked := waitForSandboxPodReadyEventually(env, session, forkSandboxID, templateNamespace)
+	_, err = execInSandboxPod(env, templateNamespace, forked.PodName, verifyV1Script)
 	Expect(err).NotTo(HaveOccurred())
 }
 

--- a/tests/e2e/utils/sandbox.go
+++ b/tests/e2e/utils/sandbox.go
@@ -246,3 +246,116 @@ func (s *Session) ResumeSandbox(ctx context.Context, t ContractT, sandboxID stri
 	}
 	return resp.Data, status, nil
 }
+
+func (s *Session) CreateSandboxRootFSSnapshot(ctx context.Context, t ContractT, sandboxID string, req apispec.CreateSandboxRootFSSnapshotRequest) (*apispec.SandboxRootFSSnapshot, int, error) {
+	specPath := "/api/v1/sandboxes/{id}/snapshots"
+	requestPath := "/api/v1/sandboxes/" + sandboxID + "/snapshots"
+	status, body, err := s.doJSONSpecRequest(t, ctx, http.MethodPost, specPath, requestPath, req, true)
+	if err != nil {
+		return nil, status, err
+	}
+	if status != http.StatusCreated {
+		return nil, status, fmt.Errorf("create sandbox rootfs snapshot failed with status %d: %s", status, formatAPIError(body))
+	}
+	var resp apispec.SuccessSandboxRootFSSnapshotResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, status, err
+	}
+	if !resp.Success || resp.Data == nil {
+		return nil, status, fmt.Errorf("create sandbox rootfs snapshot response missing data")
+	}
+	return resp.Data, status, nil
+}
+
+func (s *Session) ListSandboxRootFSSnapshots(ctx context.Context, t ContractT, sandboxID string) (*apispec.SandboxRootFSSnapshotList, int, error) {
+	specPath := "/api/v1/sandboxes/{id}/snapshots"
+	requestPath := "/api/v1/sandboxes/" + sandboxID + "/snapshots"
+	status, body, err := s.doJSONSpecRequest(t, ctx, http.MethodGet, specPath, requestPath, nil, true)
+	if err != nil {
+		return nil, status, err
+	}
+	if status != http.StatusOK {
+		return nil, status, fmt.Errorf("list sandbox rootfs snapshots failed with status %d: %s", status, formatAPIError(body))
+	}
+	var resp apispec.SuccessSandboxRootFSSnapshotListResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, status, err
+	}
+	if !resp.Success || resp.Data == nil {
+		return nil, status, fmt.Errorf("list sandbox rootfs snapshots response missing data")
+	}
+	return resp.Data, status, nil
+}
+
+func (s *Session) GetSandboxRootFSSnapshot(ctx context.Context, t ContractT, snapshotID string) (*apispec.SandboxRootFSSnapshot, int, error) {
+	specPath := "/api/v1/sandbox-rootfs-snapshots/{snapshot_id}"
+	requestPath := "/api/v1/sandbox-rootfs-snapshots/" + snapshotID
+	status, body, err := s.doJSONSpecRequest(t, ctx, http.MethodGet, specPath, requestPath, nil, true)
+	if err != nil {
+		return nil, status, err
+	}
+	if status != http.StatusOK {
+		return nil, status, fmt.Errorf("get sandbox rootfs snapshot failed with status %d: %s", status, formatAPIError(body))
+	}
+	var resp apispec.SuccessSandboxRootFSSnapshotResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, status, err
+	}
+	if !resp.Success || resp.Data == nil {
+		return nil, status, fmt.Errorf("get sandbox rootfs snapshot response missing data")
+	}
+	return resp.Data, status, nil
+}
+
+func (s *Session) DeleteSandboxRootFSSnapshot(ctx context.Context, t ContractT, snapshotID string) (int, error) {
+	specPath := "/api/v1/sandbox-rootfs-snapshots/{snapshot_id}"
+	requestPath := "/api/v1/sandbox-rootfs-snapshots/" + snapshotID
+	status, body, err := s.doJSONSpecRequest(t, ctx, http.MethodDelete, specPath, requestPath, nil, true)
+	if err != nil {
+		return status, err
+	}
+	if status != http.StatusOK {
+		return status, fmt.Errorf("delete sandbox rootfs snapshot failed with status %d: %s", status, formatAPIError(body))
+	}
+	return status, nil
+}
+
+func (s *Session) RestoreSandboxRootFS(ctx context.Context, t ContractT, sandboxID string, req apispec.RestoreSandboxRootFSRequest) (*apispec.RestoreSandboxRootFSResponse, int, error) {
+	specPath := "/api/v1/sandboxes/{id}/rootfs/restore"
+	requestPath := "/api/v1/sandboxes/" + sandboxID + "/rootfs/restore"
+	status, body, err := s.doJSONSpecRequest(t, ctx, http.MethodPost, specPath, requestPath, req, true)
+	if err != nil {
+		return nil, status, err
+	}
+	if status != http.StatusOK {
+		return nil, status, fmt.Errorf("restore sandbox rootfs failed with status %d: %s", status, formatAPIError(body))
+	}
+	var resp apispec.SuccessRestoreSandboxRootFSResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, status, err
+	}
+	if !resp.Success || resp.Data == nil {
+		return nil, status, fmt.Errorf("restore sandbox rootfs response missing data")
+	}
+	return resp.Data, status, nil
+}
+
+func (s *Session) ForkSandbox(ctx context.Context, t ContractT, sandboxID string) (*apispec.ForkSandboxResponse, int, error) {
+	specPath := "/api/v1/sandboxes/{id}/fork"
+	requestPath := "/api/v1/sandboxes/" + sandboxID + "/fork"
+	status, body, err := s.doJSONSpecRequest(t, ctx, http.MethodPost, specPath, requestPath, apispec.ForkSandboxRequest{}, true)
+	if err != nil {
+		return nil, status, err
+	}
+	if status != http.StatusCreated {
+		return nil, status, fmt.Errorf("fork sandbox failed with status %d: %s", status, formatAPIError(body))
+	}
+	var resp apispec.SuccessForkSandboxResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, status, err
+	}
+	if !resp.Success || resp.Data == nil {
+		return nil, status, fmt.Errorf("fork sandbox response missing data")
+	}
+	return resp.Data, status, nil
+}

--- a/tests/integration/internal/tests/cluster-gateway/auth_test.go
+++ b/tests/integration/internal/tests/cluster-gateway/auth_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -91,6 +92,68 @@ func TestClusterGatewayIntegration_VolumeEndpointsRequirePermissions(t *testing.
 	resp, _ = doGatewayRequest(t, env.server.Client(), http.MethodGet, env.server.URL+"/api/v1/sandboxvolumes", writeToken, nil)
 	if resp.StatusCode != http.StatusForbidden {
 		t.Fatalf("expected forbidden for list, got %d", resp.StatusCode)
+	}
+}
+
+func TestClusterGatewayIntegration_RootFSEndpointsProxyToManager(t *testing.T) {
+	keys := gatewayKeyPair{}
+	keys.privateKey, keys.publicKey = writeClusterGatewayKeys(t)
+
+	var mu sync.Mutex
+	var seen []string
+	managerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		seen = append(seen, r.Method+" "+r.URL.Path)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"success":true,"data":{}}`))
+	}))
+	t.Cleanup(managerServer.Close)
+
+	storageServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("unexpected storage-proxy request: %s", r.URL.Path)
+	}))
+	t.Cleanup(storageServer.Close)
+
+	env := newGatewayTestEnv(t, managerServer.URL, storageServer.URL, nil, keys)
+	readToken := newInternalToken(t, env.edgeGen, []string{authn.PermSandboxRead})
+	writeToken := newInternalToken(t, env.edgeGen, []string{authn.PermSandboxWrite})
+	createToken := newInternalToken(t, env.edgeGen, []string{authn.PermSandboxCreate})
+
+	tests := []struct {
+		method string
+		path   string
+		token  string
+		want   string
+	}{
+		{method: http.MethodPost, path: "/api/v1/sandboxes/sandbox-1/snapshots", token: writeToken, want: "POST /api/v1/sandboxes/sandbox-1/snapshots"},
+		{method: http.MethodGet, path: "/api/v1/sandboxes/sandbox-1/snapshots", token: readToken, want: "GET /api/v1/sandboxes/sandbox-1/snapshots"},
+		{method: http.MethodPost, path: "/api/v1/sandboxes/sandbox-1/rootfs/restore", token: writeToken, want: "POST /api/v1/sandboxes/sandbox-1/rootfs/restore"},
+		{method: http.MethodPost, path: "/api/v1/sandboxes/sandbox-1/fork", token: createToken, want: "POST /api/v1/sandboxes/sandbox-1/fork"},
+		{method: http.MethodGet, path: "/api/v1/sandbox-rootfs-snapshots/snapshot-1", token: readToken, want: "GET /api/v1/sandbox-rootfs-snapshots/snapshot-1"},
+		{method: http.MethodDelete, path: "/api/v1/sandbox-rootfs-snapshots/snapshot-1", token: writeToken, want: "DELETE /api/v1/sandbox-rootfs-snapshots/snapshot-1"},
+	}
+	for _, tt := range tests {
+		resp, _ := doGatewayRequest(t, env.server.Client(), tt.method, env.server.URL+tt.path, tt.token, nil)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("%s %s status = %d, want 200", tt.method, tt.path, resp.StatusCode)
+		}
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(seen) != len(tests) {
+		t.Fatalf("manager requests = %v, want %d requests", seen, len(tests))
+	}
+	for i, tt := range tests {
+		if seen[i] != tt.want {
+			t.Fatalf("manager request[%d] = %q, want %q; all requests: %v", i, seen[i], tt.want, seen)
+		}
+	}
+
+	resp, _ := doGatewayRequest(t, env.server.Client(), http.MethodPost, env.server.URL+"/api/v1/sandboxes/sandbox-1/fork", readToken, nil)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("fork with read permission status = %d, want forbidden", resp.StatusCode)
 	}
 }
 

--- a/tests/integration/internal/tests/manager/api_test.go
+++ b/tests/integration/internal/tests/manager/api_test.go
@@ -467,6 +467,151 @@ func TestPausedSandboxRuntimeResumeAppliesRootFSCheckpointBeforeInitialize(t *te
 	}
 }
 
+func TestSandboxRootFSProductAPI(t *testing.T) {
+	now := time.Now().UTC()
+	store := newMemorySandboxStoreForManagerIntegration(&service.SandboxRecord{
+		ID:                "sandbox-1",
+		TeamID:            "team-1",
+		UserID:            "user-1",
+		TemplateID:        "template-1",
+		TemplateName:      "template-1",
+		TemplateNamespace: "template-default",
+		ClusterID:         "default",
+		Status:            service.SandboxStatusPaused,
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	}, &service.SandboxRootFSState{
+		SandboxID:         "sandbox-1",
+		TeamID:            "team-1",
+		LayerID:           "layer-v1",
+		RuntimeGeneration: 1,
+		Runtime:           "runc",
+		BaseImageDigest:   "sha256:base",
+		Snapshotter:       "overlayfs",
+		DiffDigest:        "sha256:layer-v1",
+		DiffObjectKey:     "rootfs/layer-v1.tar",
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	})
+	env := newManagerTestEnvWithOptions(t, managerTestEnvOptions{sandboxStore: store})
+
+	resp, body := doRequest(t, env.server.Client(), http.MethodPost, env.server.URL+"/api/v1/sandboxes/sandbox-1/snapshots", env.token, map[string]any{
+		"name":        "before-edit",
+		"description": "state before edit",
+	})
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create rootfs snapshot status = %d, body = %s", resp.StatusCode, string(body))
+	}
+	snapshot, errInfo, err := spec.DecodeResponse[service.SandboxRootFSSnapshot](bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("decode create rootfs snapshot response: %v", err)
+	}
+	if errInfo != nil {
+		t.Fatalf("unexpected create rootfs snapshot error: %+v", errInfo)
+	}
+	if snapshot == nil || snapshot.SandboxID != "sandbox-1" || snapshot.ID == "" {
+		t.Fatalf("unexpected snapshot response: %+v", snapshot)
+	}
+
+	resp, body = doRequest(t, env.server.Client(), http.MethodGet, env.server.URL+"/api/v1/sandboxes/sandbox-1/snapshots", env.token, nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("list rootfs snapshots status = %d, body = %s", resp.StatusCode, string(body))
+	}
+	list, errInfo, err := spec.DecodeResponse[service.ListSandboxRootFSSnapshotsResponse](bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("decode list rootfs snapshots response: %v", err)
+	}
+	if errInfo != nil {
+		t.Fatalf("unexpected list rootfs snapshots error: %+v", errInfo)
+	}
+	if list == nil || list.Count != 1 || len(list.Snapshots) != 1 || list.Snapshots[0].ID != snapshot.ID {
+		t.Fatalf("unexpected snapshot list: %+v", list)
+	}
+
+	store.mu.Lock()
+	store.rootFSState["sandbox-1"] = &service.SandboxRootFSState{
+		SandboxID:         "sandbox-1",
+		TeamID:            "team-1",
+		LayerID:           "layer-v2",
+		RuntimeGeneration: 2,
+		Runtime:           "runc",
+		BaseImageDigest:   "sha256:base",
+		Snapshotter:       "overlayfs",
+		DiffDigest:        "sha256:layer-v2",
+		DiffObjectKey:     "rootfs/layer-v2.tar",
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	}
+	store.mu.Unlock()
+
+	resp, body = doRequest(t, env.server.Client(), http.MethodPost, env.server.URL+"/api/v1/sandboxes/sandbox-1/rootfs/restore", env.token, map[string]any{
+		"snapshot_id": snapshot.ID,
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("restore rootfs status = %d, body = %s", resp.StatusCode, string(body))
+	}
+	restoreResp, errInfo, err := spec.DecodeResponse[service.RestoreSandboxRootFSResponse](bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("decode restore rootfs response: %v", err)
+	}
+	if errInfo != nil {
+		t.Fatalf("unexpected restore rootfs error: %+v", errInfo)
+	}
+	if restoreResp == nil || restoreResp.Status != service.SandboxStatusPaused {
+		t.Fatalf("unexpected restore response: %+v", restoreResp)
+	}
+	restoredState, err := store.GetLatestRootFSState(context.Background(), "sandbox-1")
+	if err != nil {
+		t.Fatalf("get restored rootfs state: %v", err)
+	}
+	if restoredState == nil || restoredState.LayerID != "layer-v1" {
+		t.Fatalf("restored rootfs state = %+v, want layer-v1", restoredState)
+	}
+
+	resp, body = doRequest(t, env.server.Client(), http.MethodPost, env.server.URL+"/api/v1/sandboxes/sandbox-1/fork", env.token, nil)
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("fork sandbox status = %d, body = %s", resp.StatusCode, string(body))
+	}
+	forkResp, errInfo, err := spec.DecodeResponse[service.ForkSandboxResponse](bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("decode fork response: %v", err)
+	}
+	if errInfo != nil {
+		t.Fatalf("unexpected fork error: %+v", errInfo)
+	}
+	if forkResp == nil || forkResp.SourceSandboxID != "sandbox-1" || forkResp.Sandbox == nil {
+		t.Fatalf("unexpected fork response: %+v", forkResp)
+	}
+	if forkResp.Sandbox.ID == "sandbox-1" || forkResp.Sandbox.Status != service.SandboxStatusPaused {
+		t.Fatalf("unexpected fork sandbox: %+v", forkResp.Sandbox)
+	}
+	forkState, err := store.GetLatestRootFSState(context.Background(), forkResp.Sandbox.ID)
+	if err != nil {
+		t.Fatalf("get fork rootfs state: %v", err)
+	}
+	if forkState == nil || forkState.LayerID != "layer-v1" {
+		t.Fatalf("fork rootfs state = %+v, want layer-v1", forkState)
+	}
+
+	resp, body = doRequest(t, env.server.Client(), http.MethodGet, env.server.URL+"/api/v1/sandbox-rootfs-snapshots/"+snapshot.ID, env.token, nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("get rootfs snapshot status = %d, body = %s", resp.StatusCode, string(body))
+	}
+
+	resp, body = doRequest(t, env.server.Client(), http.MethodDelete, env.server.URL+"/api/v1/sandbox-rootfs-snapshots/"+snapshot.ID, env.token, nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("delete rootfs snapshot status = %d, body = %s", resp.StatusCode, string(body))
+	}
+
+	store.mu.Lock()
+	store.records["sandbox-1"].Status = service.SandboxStatusRunning
+	store.mu.Unlock()
+	resp, body = doRequest(t, env.server.Client(), http.MethodPost, env.server.URL+"/api/v1/sandboxes/sandbox-1/snapshots", env.token, nil)
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("running rootfs snapshot status = %d, body = %s", resp.StatusCode, string(body))
+	}
+}
+
 type testTemplateLister struct {
 	client clientset.Interface
 }
@@ -710,15 +855,19 @@ func newInitializeEventServer(t *testing.T, events *orderedEvents) *httptest.Ser
 }
 
 type memorySandboxStoreForManagerIntegration struct {
-	mu          sync.Mutex
-	records     map[string]*service.SandboxRecord
-	rootFSState map[string]*service.SandboxRootFSState
+	mu                sync.Mutex
+	records           map[string]*service.SandboxRecord
+	rootFSState       map[string]*service.SandboxRootFSState
+	rootFSFilesystems map[string]*service.RootFSFilesystem
+	rootFSSnapshots   map[string]*service.RootFSSnapshot
 }
 
 func newMemorySandboxStoreForManagerIntegration(record *service.SandboxRecord, rootFSState *service.SandboxRootFSState) *memorySandboxStoreForManagerIntegration {
 	store := &memorySandboxStoreForManagerIntegration{
-		records:     map[string]*service.SandboxRecord{},
-		rootFSState: map[string]*service.SandboxRootFSState{},
+		records:           map[string]*service.SandboxRecord{},
+		rootFSState:       map[string]*service.SandboxRootFSState{},
+		rootFSFilesystems: map[string]*service.RootFSFilesystem{},
+		rootFSSnapshots:   map[string]*service.RootFSSnapshot{},
 	}
 	if record != nil {
 		store.records[record.ID] = cloneSandboxRecordForManagerIntegration(record)
@@ -830,15 +979,148 @@ func (s *memorySandboxStoreForManagerIntegration) GetLatestRootFSState(_ context
 	return cloneRootFSStateForManagerIntegration(state), nil
 }
 
-func (s *memorySandboxStoreForManagerIntegration) WithSandboxLock(ctx context.Context, sandboxID string, fn func(context.Context, service.SandboxStoreTx, *service.SandboxRecord) error) error {
+func (s *memorySandboxStoreForManagerIntegration) CreateRootFSSnapshot(_ context.Context, req *service.CreateRootFSSnapshotRequest) (*service.RootFSSnapshot, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	state := s.rootFSState[req.SandboxID]
+	if state == nil || state.LayerID == "" {
+		return nil, service.ErrRootFSFilesystemNotFound
+	}
+	record := s.records[req.SandboxID]
+	if record == nil {
+		return nil, service.ErrSandboxRecordNotFound
+	}
+	snapshot := &service.RootFSSnapshot{
+		ID:              req.SnapshotID,
+		FilesystemID:    req.SandboxID,
+		TeamID:          record.TeamID,
+		SourceSandboxID: req.SandboxID,
+		HeadLayerID:     state.LayerID,
+		Name:            req.Name,
+		Description:     req.Description,
+		CreatedAt:       time.Now().UTC(),
+		ExpiresAt:       req.ExpiresAt,
+	}
+	s.rootFSSnapshots[snapshot.ID] = cloneRootFSSnapshotForManagerIntegration(snapshot)
+	return cloneRootFSSnapshotForManagerIntegration(snapshot), nil
+}
+
+func (s *memorySandboxStoreForManagerIntegration) ListRootFSSnapshots(_ context.Context, req *service.ListRootFSSnapshotsRequest) ([]*service.RootFSSnapshot, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	snapshots := make([]*service.RootFSSnapshot, 0, len(s.rootFSSnapshots))
+	for _, snapshot := range s.rootFSSnapshots {
+		if snapshot == nil || snapshot.SourceSandboxID != req.SandboxID {
+			continue
+		}
+		if req.TeamID != "" && snapshot.TeamID != req.TeamID {
+			continue
+		}
+		snapshots = append(snapshots, cloneRootFSSnapshotForManagerIntegration(snapshot))
+	}
+	return snapshots, nil
+}
+
+func (s *memorySandboxStoreForManagerIntegration) GetRootFSSnapshot(_ context.Context, snapshotID, teamID string) (*service.RootFSSnapshot, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	snapshot := s.rootFSSnapshots[snapshotID]
+	if snapshot == nil || (teamID != "" && snapshot.TeamID != teamID) {
+		return nil, service.ErrRootFSSnapshotNotFound
+	}
+	return cloneRootFSSnapshotForManagerIntegration(snapshot), nil
+}
+
+func (s *memorySandboxStoreForManagerIntegration) DeleteRootFSSnapshot(_ context.Context, snapshotID, teamID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	snapshot := s.rootFSSnapshots[snapshotID]
+	if snapshot == nil || (teamID != "" && snapshot.TeamID != teamID) {
+		return service.ErrRootFSSnapshotNotFound
+	}
+	delete(s.rootFSSnapshots, snapshotID)
+	return nil
+}
+
+func (s *memorySandboxStoreForManagerIntegration) ForkRootFSFilesystem(_ context.Context, req *service.ForkRootFSFilesystemRequest) (*service.RootFSFilesystem, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	sourceState := s.rootFSState[req.SourceSandboxID]
+	if sourceState == nil || sourceState.LayerID == "" {
+		return nil, service.ErrRootFSFilesystemNotFound
+	}
+	target := s.records[req.TargetSandboxID]
+	if target == nil {
+		return nil, service.ErrSandboxRecordNotFound
+	}
+	targetTeamID := req.TargetTeamID
+	if targetTeamID == "" {
+		targetTeamID = target.TeamID
+	}
+	state := cloneRootFSStateForManagerIntegration(sourceState)
+	state.SandboxID = req.TargetSandboxID
+	state.TeamID = targetTeamID
+	s.rootFSState[req.TargetSandboxID] = state
+	filesystem := &service.RootFSFilesystem{
+		ID:                 req.TargetSandboxID,
+		TeamID:             targetTeamID,
+		SourceFilesystemID: req.SourceSandboxID,
+		HeadLayerID:        sourceState.LayerID,
+		CreatedAt:          time.Now().UTC(),
+		UpdatedAt:          time.Now().UTC(),
+	}
+	s.rootFSFilesystems[filesystem.ID] = cloneRootFSFilesystemForManagerIntegration(filesystem)
+	return cloneRootFSFilesystemForManagerIntegration(filesystem), nil
+}
+
+func (s *memorySandboxStoreForManagerIntegration) RestoreRootFSFromSnapshot(_ context.Context, req *service.RestoreRootFSFromSnapshotRequest) (*service.RootFSFilesystem, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	snapshot := s.rootFSSnapshots[req.SnapshotID]
+	if snapshot == nil || (req.TeamID != "" && snapshot.TeamID != req.TeamID) {
+		return nil, service.ErrRootFSSnapshotNotFound
+	}
+	target := s.records[req.SandboxID]
+	if target == nil {
+		return nil, service.ErrSandboxRecordNotFound
+	}
+	now := time.Now().UTC()
+	s.rootFSState[req.SandboxID] = &service.SandboxRootFSState{
+		SandboxID:         req.SandboxID,
+		TeamID:            target.TeamID,
+		LayerID:           snapshot.HeadLayerID,
+		RuntimeGeneration: target.RuntimeGeneration,
+		Runtime:           "runc",
+		BaseImageDigest:   "sha256:base",
+		Snapshotter:       "overlayfs",
+		DiffDigest:        "sha256:" + snapshot.HeadLayerID,
+		DiffObjectKey:     "rootfs/" + snapshot.HeadLayerID + ".tar",
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	}
+	filesystem := &service.RootFSFilesystem{
+		ID:                 req.SandboxID,
+		TeamID:             target.TeamID,
+		SourceFilesystemID: snapshot.FilesystemID,
+		HeadLayerID:        snapshot.HeadLayerID,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+	s.rootFSFilesystems[filesystem.ID] = cloneRootFSFilesystemForManagerIntegration(filesystem)
+	return cloneRootFSFilesystemForManagerIntegration(filesystem), nil
+}
+
+func (s *memorySandboxStoreForManagerIntegration) WithSandboxLock(ctx context.Context, sandboxID string, fn func(context.Context, service.SandboxStoreTx, *service.SandboxRecord) error) error {
+	s.mu.Lock()
 	record := s.records[sandboxID]
 	if record == nil {
+		s.mu.Unlock()
 		return service.ErrSandboxRecordNotFound
 	}
+	cloned := cloneSandboxRecordForManagerIntegration(record)
+	s.mu.Unlock()
 	tx := memorySandboxStoreTxForManagerIntegration{store: s}
-	return fn(ctx, tx, cloneSandboxRecordForManagerIntegration(record))
+	return fn(ctx, tx, cloned)
 }
 
 type memorySandboxStoreTxForManagerIntegration struct {
@@ -917,6 +1199,22 @@ func cloneRootFSLayersForManagerIntegration(layers []*service.SandboxRootFSLayer
 		out = append(out, &clone)
 	}
 	return out
+}
+
+func cloneRootFSSnapshotForManagerIntegration(snapshot *service.RootFSSnapshot) *service.RootFSSnapshot {
+	if snapshot == nil {
+		return nil
+	}
+	clone := *snapshot
+	return &clone
+}
+
+func cloneRootFSFilesystemForManagerIntegration(filesystem *service.RootFSFilesystem) *service.RootFSFilesystem {
+	if filesystem == nil {
+		return nil
+	}
+	clone := *filesystem
+	return &clone
 }
 
 func (r *initializeRequestRecorder) Get() service.InitializeRequest {


### PR DESCRIPTION
## Summary
- expose paused-sandbox rootfs snapshot, restore, and fork APIs through manager and cluster-gateway
- add rootfs snapshot list/get/delete store operations and product-level service guards
- add unit, integration, and e2e coverage for snapshot/restore/fork flows

## Notes
- Rootfs snapshot, restore, and fork require the sandbox to be paused.
- Fork creates a new paused sandbox from the source rootfs head and does not copy mounted SandboxVolumes.
- Docs are intentionally out of scope for this PR and will be handled separately.

## Tests
- go test ./manager/pkg/service -run 'TestSandboxRootFSProduct|TestRootFSFilesystemPersistenceIntegration'\n- go test ./manager/pkg/http\n- go test ./cluster-gateway/pkg/http\n- go test ./tests/integration/internal/tests/manager -run TestSandboxRootFSProductAPI\n- go test ./tests/integration/internal/tests/cluster-gateway -run TestClusterGatewayIntegration_RootFSEndpointsProxyToManager\n- go test ./tests/e2e/... -run TestDoesNotExist\n- go test ./pkg/apispec\n\nCloses #469