### PR TITLE
docs: clarify rootfs snapshot template workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Sandbox0 is the runtime boundary for enterprise AI agent platforms.
 
 It gives platform teams isolated, persistent sandboxes for agent work that needs to run code, edit repositories, expose per-agent HTTP services, keep workspace state, and access external systems without placing broad production credentials inside the agent runtime.
 
-The sandbox writable root filesystem is checkpointed across pause/resume. Sandbox0 can release the runtime pod, keep the sandbox identity, and restore files written inside the sandbox when a new runtime generation starts. Volumes are a separate storage primitive for data that must outlive one sandbox identity, be shared, snapshotted, forked, or accessed directly through APIs.
+The sandbox writable root filesystem is checkpointed across pause/resume. Sandbox0 can release the runtime pod, keep the sandbox identity, and restore files written inside the sandbox when a new runtime generation starts. Named rootfs snapshots, restore, and fork let teams reuse an initialized filesystem state without building a new template when the base template already fits. Volumes are a separate storage primitive for data that must outlive one sandbox identity, be shared, snapshotted, forked, or accessed directly through APIs.
 
 Use Sandbox0 when you need to:
 
@@ -26,7 +26,7 @@ Use Sandbox0 when you need to:
 | Expose per-agent HTTP endpoints | Sandbox Services with route auth, method filtering, CORS, rate limits, timeouts, path rewrite, and resume. |
 | Keep secrets outside the agent process | Credential sources, destination-scoped egress auth, SSH transparent proxying, LLMProxy, or an external AI gateway. |
 | Control network and MCP access | Ordered traffic rules, protocol-aware MCP tool controls, and egress audit in the data plane. |
-| Branch, evaluate, or recover agent state | Rootfs checkpoints for transparent sandbox resume, plus volumes, point-in-time snapshots, restore, and Copy-on-Write fork. |
+| Branch, evaluate, or recover agent state | Rootfs checkpoints for transparent sandbox resume, named rootfs snapshots, restore, Copy-on-Write sandbox fork, and volumes for shared durable data. |
 | Own the deployment boundary | Self-hosted Kubernetes data plane with external PostgreSQL, S3/OSS, Vault-compatible storage, Redis, and registry options. |
 
 Sandbox0 Cloud uses `https://api.sandbox0.ai` for sandboxes, templates, volumes, credentials, and team-scoped API keys. Managed Agents uses `https://agents.sandbox0.ai`.
@@ -167,7 +167,7 @@ Use raw Sandbox0 sandboxes when you want direct control over processes, files, t
 
 **Coding agents**
 
-Use a custom template with language runtimes, package managers, git, build tools, and an attached volume for the repository workspace. Use a stateful REPL for the active agent loop and one-shot commands for isolated build/test steps.
+Start from a builtin template when its image, resources, mount points, and network defaults already fit. Install project dependencies or clone repositories inside the sandbox, pause it, then create a rootfs snapshot or fork the paused sandbox for per-task branches. Use a custom template when you need a different base image, resource envelope, mount declarations, default environment, or network policy. Use a stateful REPL for the active agent loop and one-shot commands for isolated build/test steps.
 
 **Code interpreter, data, or browser agents**
 
@@ -179,7 +179,7 @@ Run gateways such as Hermes or OpenClaw as `cmd` Sandbox Services. Store framewo
 
 **Parallel workers**
 
-Create one sandbox per task, eval case, branch, or user request. Share read-only inputs through volumes, snapshots, or object storage, then write outputs to separate volumes or task-specific paths. Keep orchestration outside the sandbox boundary.
+Create one sandbox per task, eval case, branch, or user request. Fork from a paused seed sandbox when each worker should inherit the same initialized rootfs. Share read-only data through volumes or object storage, then write outputs to separate volumes or task-specific paths. Keep orchestration outside the sandbox boundary.
 
 **Long-running sessions**
 
@@ -191,19 +191,20 @@ Treat the sandbox process as runtime state and the volume as durable state. Paus
 | -------------- | ---------- | ---------------------------- |
 | **Template** | A runtime blueprint: image, resources, warm pool, mount points, and default policy. | Keeps environments reproducible and claims fast. |
 | **Sandbox** | A durable identity and configuration for an isolated runtime instance. | Gives each task, user, or agent worker its own execution boundary. |
-| **Root filesystem** | The sandbox writable filesystem checkpointed during pause/resume and tied to the sandbox identity. | Lets files written inside the sandbox survive runtime pod cleanup without explicit mounts. |
+| **Root filesystem** | The sandbox writable filesystem checkpointed during pause/resume and tied to the sandbox identity. | Lets files written inside the sandbox survive runtime pod cleanup without explicit mounts; named snapshots and forks can reuse initialized filesystem state. |
 | **Context** | A process/session inside a sandbox, either REPL-style or one-shot command. | Lets agents choose in-process continuity or clean execution per tool call. |
 | **Volume** | Persistent storage independent of a sandbox lifetime. | Keeps repositories, caches, agent memory, artifacts, checkpoints, snapshots, forks, and shared data. |
 | **Service** | A public HTTP entrypoint backed by a listener, command, or function. | Exposes per-sandbox APIs, previews, webhooks, and agent gateways with route policy. |
 | **Credential** | A secret source plus policy for how it may be projected or injected. | Lets agents call external services without storing raw production keys in the sandbox process. |
 
-The short version: use templates for repeatable environments, sandboxes for isolation, the root filesystem for same-sandbox file continuity across pause/resume, contexts for process behavior, volumes for durable or shared memory, services for controlled ingress, and credentials/network policy for controlled external access.
+The short version: use templates for runtime shape and warm pools, sandboxes for isolation, the root filesystem for same-sandbox file continuity and initialized-state snapshots, contexts for process behavior, volumes for durable or shared memory, services for controlled ingress, and credentials/network policy for controlled external access.
 
 ## Persistence And Lifecycle
 
 Sandbox0 separates runtime state from filesystem state.
 
 - The sandbox writable root filesystem is persisted as the latest rootfs checkpoint for the same sandbox identity. Files written outside mounted volumes survive pause/resume once the pause checkpoint succeeds.
+- Named rootfs snapshots, restore, and fork preserve or branch initialized sandbox filesystem state, but they still use the sandbox's template for image, resources, mounts, and network defaults.
 - `ttl` is a runtime soft timeout. When it expires, Sandbox0 checkpoints the writable root filesystem, pauses the sandbox, and releases runtime compute.
 - `hard_ttl` is a hard sandbox lifetime. When it expires, Sandbox0 deletes the sandbox identity and durable state tied to that identity, including rootfs checkpoints.
 - Pause/resume preserves sandbox identity and the latest writable root filesystem checkpoint, but not running processes, memory, sockets, PID state, or live REPL sessions.
@@ -233,9 +234,9 @@ Sandbox0 optimizes for this in these places:
 
 - **Warm pools** keep template instances ready so a claim can reuse an idle pod instead of starting the environment from scratch.
 - **Template images** move expensive package, toolchain, browser, and agent framework setup out of the request path.
-- **Rootfs checkpoints and volumes** keep resumed sandboxes useful after runtime cleanup. Use the rootfs checkpoint for transparent runtime restore and volumes for explicit durable workspaces, snapshots, forks, and shared data.
+- **Rootfs checkpoints, rootfs snapshots, and volumes** keep resumed or branched sandboxes useful after runtime cleanup. Use rootfs checkpoints for transparent runtime restore, rootfs snapshots/forks for initialized sandbox state, and volumes for explicit durable workspaces, snapshots, forks, and shared data.
 
-For best results, put expensive environment setup into the template image, keep active task state in a volume when it must outlive the sandbox identity, and keep sandboxes short-lived enough that idle compute does not become the source of truth.
+For best results, put broadly reused runtime setup into the template image, capture project-specific initialization with rootfs snapshots or forks when the base template already fits, keep active task state in a volume when it must outlive the sandbox identity, and keep sandboxes short-lived enough that idle compute does not become the source of truth.
 
 ## Self-Hosting
 

--- a/docs/sandbox/snapshot-restore/page.mdx
+++ b/docs/sandbox/snapshot-restore/page.mdx
@@ -38,6 +38,48 @@ Use [Volumes](/docs/volume) when data must be mounted by multiple sandboxes, acc
 The rootfs snapshot API stores snapshot metadata including `name`, `description`, and optional `expires_at`. Delete snapshots explicitly when cleanup workflows no longer need them.
 </Callout>
 
+## Initialize Once, Fork Many
+
+Rootfs snapshots and forks can act like a lightweight custom environment when your changes are ordinary filesystem state. Instead of building a custom image and maintaining a team-owned warm pool, start from a builtin template, initialize the sandbox, then checkpoint that rootfs state.
+
+Use this pattern for:
+
+- package installs and dependency caches
+- cloned repositories and checked-out branches
+- generated build artifacts that future runs should inherit
+- local tool configuration written into the sandbox filesystem
+
+Typical workflow:
+
+1. claim a sandbox from a builtin template backed by the platform warm pool
+2. install dependencies or prepare the workspace inside the sandbox rootfs
+3. pause the sandbox and wait until `status` is `paused`
+4. create a named snapshot when you need a stable restore point, or fork the paused sandbox directly when you need isolated task sandboxes
+5. resume the restored or forked sandbox before running task-specific commands
+
+```bash
+SANDBOX_ID="$(s0 -o json sandbox create --template default --hard-ttl 86400 | jq -r '.ID')"
+
+# Initialize the rootfs with your normal sandbox commands, file writes, or SSH session.
+
+s0 sandbox pause "$SANDBOX_ID"
+# Wait until this shows status "paused".
+s0 sandbox get "$SANDBOX_ID"
+
+s0 sandbox snapshot create "$SANDBOX_ID" \
+    --name python-deps-v1 \
+    --description "Default template after Python dependency install"
+
+FORKED_SANDBOX_ID="$(s0 -o json sandbox fork "$SANDBOX_ID" | jq -r '.sandbox.id')"
+s0 sandbox resume "$FORKED_SANDBOX_ID"
+```
+
+Fork is usually the shorter path for branch-per-task workflows because it creates a new paused sandbox directly from the seed rootfs. Snapshot is better when you need a named checkpoint that can be listed, fetched, restored later, and cleaned up independently.
+
+<Callout variant="warning">
+This pattern does not replace template-level configuration. Use a custom template when you need a different container image, resource limits, mount declarations, default network policy, environment defaults, or privileged runtime fields. Mounted Sandbox Volumes are separate from the sandbox rootfs and should be managed with Volume snapshot and fork APIs.
+</Callout>
+
 ## Pause Before Rootfs Operations
 
 Pause the sandbox and wait until `status` is `paused` before creating a snapshot, restoring, or forking.

--- a/docs/template/configuration/page.mdx
+++ b/docs/template/configuration/page.mdx
@@ -64,7 +64,7 @@ The main sandbox container configuration.
 | `image` | string | — | Container image reference. Use a public image (e.g., `python:3.12-slim`) or the `Template image reference` returned by `s0 template image push` for private images. |
 | `resources.cpu` | string | — | CPU limit for the sandbox (e.g., `"1"`, `"2"`, `"500m"`). |
 | `resources.memory` | string | — | Memory limit for the sandbox (e.g., `"2Gi"`, `"512Mi"`). |
-| `resources.ephemeralStorage` | string | `512Mi` | Writable-layer and container-log storage for the sandbox runtime. Checkpointed pause/resume saves and restores the writable root filesystem, but this quota still bounds writes to `/tmp` or image-local paths; use Sandbox Volumes for snapshots, sharing, and long-lived durable data. |
+| `resources.ephemeralStorage` | string | `512Mi` | Writable-layer and container-log storage for the sandbox runtime. Checkpointed pause/resume saves and restores the writable root filesystem, but this quota still bounds writes to `/tmp` or image-local paths. Use rootfs snapshots and forks to version initialized sandbox files, and use Sandbox Volumes for sharing or long-lived durable data independent of sandbox identity. |
 | `env` | array | `[]` | Per-container environment variables. Each entry has `name` and `value`. |
 
 <Callout variant="info">

--- a/docs/template/page.mdx
+++ b/docs/template/page.mdx
@@ -19,6 +19,30 @@ Builtin templates use curated public images and are ready to use immediately. Cu
 
 ---
 
+## Custom Template Or Rootfs Snapshot
+
+You do not need a custom template for every initialized environment. If the base image, resources, network policy, and mount declarations already fit, you can claim a sandbox from a builtin template, install dependencies or clone repositories inside the writable root filesystem, pause it, then create a rootfs snapshot or fork it.
+
+This is useful for dependency-heavy agent workspaces:
+
+1. claim a sandbox from a platform-owned builtin template such as `default` or `dins`
+2. install packages, populate caches, clone repositories, or write tool configuration
+3. pause the sandbox and wait for `status` to become `paused`
+4. create a named rootfs snapshot, or keep the paused sandbox as a seed and fork it for each task
+5. resume the restored or forked sandbox before running task-specific work
+
+For platform-owned builtin templates, the operator manages the warm pool. That lets teams reuse warm builtin capacity and store only the initialized rootfs state for their own dependency set instead of maintaining a separate custom template pool for each variation.
+
+| Need | Prefer |
+|------|--------|
+| Different base image, resource envelope, default environment, mount paths, network defaults, or privileged runtime fields | Custom template |
+| User-space dependencies, repository checkout, package cache, generated files, or per-project tool configuration on an existing base image | Builtin template plus rootfs snapshot or fork |
+| Data that must outlive sandbox identity, be mounted by multiple sandboxes, or be accessed through direct storage APIs | Sandbox Volume |
+
+Rootfs snapshots do not create template IDs and do not appear in `s0 template list`. A fork keeps the source sandbox's template and sandbox configuration, while restore changes only the target sandbox rootfs. See [Snapshot And Restore](/docs/sandbox/snapshot-restore) for the paused-state requirements and API workflow.
+
+---
+
 ## Create Template
 
 Create a custom template for your team. The template spec is defined in a YAML file.
@@ -351,5 +375,9 @@ console.log("Template deleted");`
 
   <Card title="Warm Pool" href="/docs/template/pool" cta="Continue">
     Use warm pools to reduce startup latency for common templates.
+  </Card>
+
+  <Card title="Snapshot And Restore" href="/docs/sandbox/snapshot-restore" cta="Continue">
+    Reuse initialized rootfs state without creating another template.
   </Card>
 </CardGroup>

--- a/docs/volume/page.mdx
+++ b/docs/volume/page.mdx
@@ -271,21 +271,6 @@ console.log("Volume deleted");`
   ]}
 />
 
----
-
-## Persist Runtime Environment with Nix
-
-You can use **Nix + Volume** to persist and reuse your **runtime environment artifacts** across Sandboxes.
-
-- **Can persist**: dependency closures, build caches, package stores, lock files, and workspace-level toolchains
-- **Cannot persist**: live process runtime state (in-memory variables, process stacks, open sockets, PID state)
-
-This means:
-- A new Sandbox can quickly reproduce the same environment from mounted Volume data
-- But it still starts as a new process runtime, not a paused/resumed OS process image
-
----
-
 ## Next Steps
 
 <CardGroup>


### PR DESCRIPTION
## Summary
- document using builtin templates plus rootfs snapshots/forks as a lightweight initialized environment workflow
- clarify the boundary between templates, sandbox rootfs state, and volumes in README and docs
- remove the Volume docs section that recommended persisting runtime environments with Nix

## Testing
- git diff --check