### PR TITLE
Harden persistent rootfs storage accounting

### DIFF
--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -518,6 +518,8 @@ func main() {
 				logger,
 				managerMetrics,
 			)
+			rootFSMaintenanceController.SetObjectInspector(rootFSObjectStoreInspector{store: rootFSObjectStore})
+			rootFSMaintenanceController.SetStorageMeteringRecorder(meteringRepo)
 			go func() {
 				if err := rootFSMaintenanceController.Run(ctx); err != nil && err != context.Canceled {
 					logger.Error("Rootfs maintenance controller failed", zap.Error(err))
@@ -638,6 +640,22 @@ func buildRootFSObjectStore(cfg *config.ManagerConfig) (objectstore.Store, error
 		return nil, err
 	}
 	return store, nil
+}
+
+type rootFSObjectStoreInspector struct {
+	store objectstore.Store
+}
+
+func (i rootFSObjectStoreInspector) StatRootFSObject(key string) (service.RootFSObjectInfo, error) {
+	info, err := i.store.Head(key)
+	if err != nil {
+		return service.RootFSObjectInfo{}, err
+	}
+	return service.RootFSObjectInfo{
+		Key:      info.Key,
+		Size:     info.Size,
+		Modified: info.Modified,
+	}, nil
 }
 
 func rootFSMaintenanceControllerConfig(cfg *config.ManagerConfig) service.RootFSMaintenanceControllerConfig {

--- a/manager/pkg/service/migrations/00006_add_rootfs_object_inventory.sql
+++ b/manager/pkg/service/migrations/00006_add_rootfs_object_inventory.sql
@@ -1,0 +1,60 @@
+-- +goose Up
+
+CREATE TABLE IF NOT EXISTS manager.rootfs_objects (
+    object_key TEXT PRIMARY KEY,
+    team_id TEXT NOT NULL DEFAULT '',
+    diff_digest TEXT NOT NULL DEFAULT '',
+    diff_media_type TEXT NOT NULL DEFAULT '',
+    diff_size BIGINT NOT NULL DEFAULT 0,
+    first_layer_id TEXT NOT NULL DEFAULT '',
+    last_referenced_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    missing_at TIMESTAMPTZ,
+    deleted_at TIMESTAMPTZ,
+    last_error TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_rootfs_objects_team_updated
+    ON manager.rootfs_objects(team_id, updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_rootfs_objects_deleted
+    ON manager.rootfs_objects(deleted_at)
+    WHERE deleted_at IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_rootfs_objects_missing
+    ON manager.rootfs_objects(missing_at)
+    WHERE missing_at IS NOT NULL;
+
+DROP TRIGGER IF EXISTS update_rootfs_objects_updated_at ON manager.rootfs_objects;
+CREATE TRIGGER update_rootfs_objects_updated_at
+    BEFORE UPDATE ON manager.rootfs_objects
+    FOR EACH ROW
+    EXECUTE FUNCTION manager.update_updated_at_column();
+
+INSERT INTO manager.rootfs_objects (
+    object_key, team_id, diff_digest, diff_media_type, diff_size,
+    first_layer_id, last_referenced_at, created_at, updated_at
+)
+SELECT DISTINCT ON (diff_object_key)
+    diff_object_key,
+    team_id,
+    diff_digest,
+    diff_media_type,
+    diff_size,
+    layer_id,
+    created_at,
+    created_at,
+    created_at
+FROM manager.rootfs_layers
+WHERE diff_object_key <> ''
+ORDER BY diff_object_key, created_at ASC
+ON CONFLICT (object_key) DO NOTHING;
+
+-- +goose Down
+
+DROP TRIGGER IF EXISTS update_rootfs_objects_updated_at ON manager.rootfs_objects;
+DROP INDEX IF EXISTS manager.idx_rootfs_objects_missing;
+DROP INDEX IF EXISTS manager.idx_rootfs_objects_deleted;
+DROP INDEX IF EXISTS manager.idx_rootfs_objects_team_updated;
+DROP TABLE IF EXISTS manager.rootfs_objects;

--- a/manager/pkg/service/rootfs_maintenance_controller.go
+++ b/manager/pkg/service/rootfs_maintenance_controller.go
@@ -28,11 +28,13 @@ type RootFSMaintenanceControllerConfig struct {
 // RootFSMaintenanceController runs internal rootfs metadata and object-store
 // maintenance. It is not user-facing API surface.
 type RootFSMaintenanceController struct {
-	store   *PGSandboxStore
-	deleter RootFSObjectDeleter
-	cfg     RootFSMaintenanceControllerConfig
-	logger  *zap.Logger
-	metrics *obsmetrics.ManagerMetrics
+	store            *PGSandboxStore
+	deleter          RootFSObjectDeleter
+	cfg              RootFSMaintenanceControllerConfig
+	logger           *zap.Logger
+	metrics          *obsmetrics.ManagerMetrics
+	objectInspector  RootFSObjectInspector
+	meteringRecorder RootFSStorageMeteringRecorder
 }
 
 func NewRootFSMaintenanceController(store *PGSandboxStore, deleter RootFSObjectDeleter, cfg RootFSMaintenanceControllerConfig, logger *zap.Logger, metrics *obsmetrics.ManagerMetrics) *RootFSMaintenanceController {
@@ -47,6 +49,20 @@ func NewRootFSMaintenanceController(store *PGSandboxStore, deleter RootFSObjectD
 		logger:  logger,
 		metrics: metrics,
 	}
+}
+
+func (c *RootFSMaintenanceController) SetStorageMeteringRecorder(recorder RootFSStorageMeteringRecorder) {
+	if c == nil {
+		return
+	}
+	c.meteringRecorder = recorder
+}
+
+func (c *RootFSMaintenanceController) SetObjectInspector(inspector RootFSObjectInspector) {
+	if c == nil {
+		return
+	}
+	c.objectInspector = inspector
 }
 
 func (c *RootFSMaintenanceController) Run(ctx context.Context) error {
@@ -114,8 +130,20 @@ func (c *RootFSMaintenanceController) RunOnce(ctx context.Context) error {
 			runErr = err
 			break
 		}
-		if result == nil || (len(result.Layers) == 0 && len(result.DeletedObjectKeys) == 0) {
+		if result == nil || (len(result.Layers) == 0 && len(result.DeletedObjectKeys) == 0 && result.ExpiredSnapshots == 0 && result.DeletedFilesystems == 0) {
 			break
+		}
+	}
+	if err := c.auditRootFSObjects(ctx); err != nil {
+		status = "error"
+		if runErr == nil {
+			runErr = err
+		}
+	}
+	if err := c.observeStorageUsage(ctx); err != nil {
+		status = "error"
+		if runErr == nil {
+			runErr = err
 		}
 	}
 	return runErr
@@ -157,6 +185,58 @@ func (c *RootFSMaintenanceController) observeQueueStats(ctx context.Context) {
 	c.metrics.RootFSObjectDeletionQueueDepth.WithLabelValues("due").Set(float64(stats.Due))
 	c.metrics.RootFSObjectDeletionQueueDepth.WithLabelValues("claimed").Set(float64(stats.Claimed))
 	c.metrics.RootFSObjectDeletionQueueDepth.WithLabelValues("dead_lettered").Set(float64(stats.DeadLettered))
+}
+
+func (c *RootFSMaintenanceController) auditRootFSObjects(ctx context.Context) error {
+	if c == nil || c.store == nil || c.objectInspector == nil {
+		return nil
+	}
+	result, err := c.store.AuditRootFSObjects(ctx, c.objectInspector, "", c.cfg.BatchSize)
+	if err != nil {
+		c.logger.Warn("Failed to audit rootfs object store consistency", zap.Error(err))
+		return err
+	}
+	if result != nil && (result.Missing > 0 || result.SizeMismatched > 0) {
+		c.logger.Warn("Rootfs object store audit found inconsistent objects",
+			zap.Int("checked", result.Checked),
+			zap.Int("missing", result.Missing),
+			zap.Int("sizeMismatched", result.SizeMismatched),
+		)
+	}
+	return nil
+}
+
+func (c *RootFSMaintenanceController) observeStorageUsage(ctx context.Context) error {
+	if c == nil || c.store == nil {
+		return nil
+	}
+	var usages []RootFSStorageUsage
+	var err error
+	if c.meteringRecorder != nil {
+		usages, err = c.store.RecordRootFSStorageObservations(ctx, c.meteringRecorder, "", time.Now().UTC())
+	} else {
+		usages, err = c.store.ListRootFSStorageUsage(ctx, "")
+	}
+	if err != nil {
+		c.logger.Warn("Failed to collect rootfs storage usage", zap.Error(err))
+		return err
+	}
+	if c.metrics == nil {
+		return nil
+	}
+	var totalBytes int64
+	var totalObjects int64
+	for _, usage := range usages {
+		totalBytes += usage.StorageBytes
+		totalObjects += usage.ObjectCount
+	}
+	if c.metrics.RootFSStorageBytes != nil {
+		c.metrics.RootFSStorageBytes.Set(float64(totalBytes))
+	}
+	if c.metrics.RootFSStorageObjects != nil {
+		c.metrics.RootFSStorageObjects.Set(float64(totalObjects))
+	}
+	return nil
 }
 
 func normalizeRootFSMaintenanceControllerConfig(cfg RootFSMaintenanceControllerConfig) RootFSMaintenanceControllerConfig {

--- a/manager/pkg/service/rootfs_persistent_filesystem.go
+++ b/manager/pkg/service/rootfs_persistent_filesystem.go
@@ -8,12 +8,15 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	meteringpkg "github.com/sandbox0-ai/sandbox0/pkg/metering"
 )
 
 var ErrRootFSHeadConflict = errors.New("rootfs filesystem head conflict")
 var ErrRootFSFilesystemNotFound = errors.New("rootfs filesystem not found")
 var ErrRootFSFilesystemConflict = errors.New("rootfs filesystem conflict")
 var ErrRootFSSnapshotNotFound = errors.New("rootfs snapshot not found")
+var ErrRootFSObjectConflict = errors.New("rootfs object metadata conflict")
 
 // RootFSFilesystem is the canonical persistent filesystem object backing a
 // sandbox writable rootfs.
@@ -73,8 +76,10 @@ type SquashRootFSFilesystemRequest struct {
 }
 
 type RootFSGarbageCollectionResult struct {
-	Layers            []*SandboxRootFSLayer
-	DeletedObjectKeys []string
+	Layers             []*SandboxRootFSLayer
+	DeletedObjectKeys  []string
+	ExpiredSnapshots   int
+	DeletedFilesystems int
 }
 
 type DeletePendingRootFSObjectsOptions struct {
@@ -95,9 +100,44 @@ type RootFSObjectDeletionQueueStats struct {
 	OldestQueued time.Time
 }
 
+// RootFSStorageUsage is the current COW physical storage usage for one team.
+// It counts distinct reachable rootfs diff objects, not sandbox layer-chain sums.
+type RootFSStorageUsage struct {
+	TeamID       string
+	ObjectCount  int64
+	StorageBytes int64
+	ObservedAt   time.Time
+}
+
+type RootFSObjectInfo struct {
+	Key      string
+	Size     int64
+	Modified time.Time
+}
+
+type RootFSObjectAuditResult struct {
+	Checked        int
+	Missing        int
+	SizeMismatched int
+}
+
 // RootFSObjectDeleter deletes rootfs diff objects from durable object storage.
 type RootFSObjectDeleter interface {
 	Delete(key string) error
+}
+
+type RootFSObjectInspector interface {
+	StatRootFSObject(key string) (RootFSObjectInfo, error)
+}
+
+type RootFSStorageMeteringRecorder interface {
+	RecordStorageObservation(context.Context, *meteringpkg.StorageObservation) error
+}
+
+type rootFSStoreDB interface {
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
 }
 
 const (
@@ -132,13 +172,24 @@ func (s *PGSandboxStore) CreateRootFSSnapshot(ctx context.Context, req *CreateRo
 	if s == nil || s.pool == nil || req == nil {
 		return nil, nil
 	}
+	return createRootFSSnapshot(ctx, s.pool, req)
+}
+
+func (t sandboxStoreTx) CreateRootFSSnapshot(ctx context.Context, req *CreateRootFSSnapshotRequest) (*RootFSSnapshot, error) {
+	return createRootFSSnapshot(ctx, t.tx, req)
+}
+
+func createRootFSSnapshot(ctx context.Context, db rootFSStoreDB, req *CreateRootFSSnapshotRequest) (*RootFSSnapshot, error) {
+	if db == nil || req == nil {
+		return nil, nil
+	}
 	if strings.TrimSpace(req.SandboxID) == "" {
 		return nil, fmt.Errorf("sandbox_id is required")
 	}
 	if strings.TrimSpace(req.SnapshotID) == "" {
 		return nil, fmt.Errorf("snapshot_id is required")
 	}
-	snapshot, err := scanRootFSSnapshot(s.pool.QueryRow(ctx, `
+	snapshot, err := scanRootFSSnapshot(db.QueryRow(ctx, `
 		WITH source AS (
 			SELECT b.filesystem_id, b.team_id, f.head_layer_id
 			FROM manager.sandbox_rootfs_bindings b
@@ -174,6 +225,7 @@ func (s *PGSandboxStore) ListRootFSSnapshots(ctx context.Context, req *ListRootF
 		FROM manager.rootfs_snapshots
 		WHERE source_sandbox_id = $1
 			AND ($2 = '' OR team_id = $2)
+			AND (expires_at IS NULL OR expires_at > NOW())
 		ORDER BY created_at DESC
 	`, strings.TrimSpace(req.SandboxID), strings.TrimSpace(req.TeamID))
 	if err != nil {
@@ -205,6 +257,7 @@ func (s *PGSandboxStore) GetRootFSSnapshot(ctx context.Context, snapshotID, team
 		FROM manager.rootfs_snapshots
 		WHERE snapshot_id = $1
 			AND ($2 = '' OR team_id = $2)
+			AND (expires_at IS NULL OR expires_at > NOW())
 	`, strings.TrimSpace(snapshotID), strings.TrimSpace(teamID)))
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -237,6 +290,28 @@ func (s *PGSandboxStore) ForkRootFSFilesystem(ctx context.Context, req *ForkRoot
 	if s == nil || s.pool == nil || req == nil {
 		return nil, nil
 	}
+	filesystem, err := forkRootFSFilesystem(ctx, s.pool, req)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, s.rootFSForkNoRowsError(ctx, req)
+		}
+		return nil, err
+	}
+	return filesystem, nil
+}
+
+func (t sandboxStoreTx) ForkRootFSFilesystem(ctx context.Context, req *ForkRootFSFilesystemRequest) (*RootFSFilesystem, error) {
+	filesystem, err := forkRootFSFilesystem(ctx, t.tx, req)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, fmt.Errorf("%w: source sandbox %s or target sandbox %s", ErrRootFSFilesystemNotFound, req.SourceSandboxID, req.TargetSandboxID)
+	}
+	return filesystem, err
+}
+
+func forkRootFSFilesystem(ctx context.Context, db rootFSStoreDB, req *ForkRootFSFilesystemRequest) (*RootFSFilesystem, error) {
+	if db == nil || req == nil {
+		return nil, nil
+	}
 	if strings.TrimSpace(req.SourceSandboxID) == "" {
 		return nil, fmt.Errorf("source_sandbox_id is required")
 	}
@@ -246,7 +321,7 @@ func (s *PGSandboxStore) ForkRootFSFilesystem(ctx context.Context, req *ForkRoot
 	if strings.TrimSpace(req.SourceSandboxID) == strings.TrimSpace(req.TargetSandboxID) {
 		return nil, fmt.Errorf("%w: source and target sandbox are the same", ErrRootFSFilesystemConflict)
 	}
-	filesystem, err := scanRootFSFilesystem(s.pool.QueryRow(ctx, `
+	filesystem, err := scanRootFSFilesystem(db.QueryRow(ctx, `
 		WITH source AS (
 			SELECT f.filesystem_id, f.team_id, f.head_layer_id, f.base_image_ref, f.base_image_digest
 			FROM manager.sandbox_rootfs_bindings b
@@ -295,9 +370,6 @@ func (s *PGSandboxStore) ForkRootFSFilesystem(ctx context.Context, req *ForkRoot
 		JOIN bound ON bound.filesystem_id = created.filesystem_id
 	`, req.SourceSandboxID, req.TargetSandboxID, strings.TrimSpace(req.TargetTeamID)))
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, s.rootFSForkNoRowsError(ctx, req)
-		}
 		return nil, fmt.Errorf("fork rootfs filesystem: %w", err)
 	}
 	return filesystem, nil
@@ -307,13 +379,35 @@ func (s *PGSandboxStore) RestoreRootFSFromSnapshot(ctx context.Context, req *Res
 	if s == nil || s.pool == nil || req == nil {
 		return nil, nil
 	}
+	filesystem, err := restoreRootFSFromSnapshot(ctx, s.pool, req)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, s.rootFSRestoreNoRowsError(ctx, req)
+		}
+		return nil, err
+	}
+	return filesystem, nil
+}
+
+func (t sandboxStoreTx) RestoreRootFSFromSnapshot(ctx context.Context, req *RestoreRootFSFromSnapshotRequest) (*RootFSFilesystem, error) {
+	filesystem, err := restoreRootFSFromSnapshot(ctx, t.tx, req)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, fmt.Errorf("%w: snapshot %s or sandbox %s", ErrRootFSFilesystemConflict, req.SnapshotID, req.SandboxID)
+	}
+	return filesystem, err
+}
+
+func restoreRootFSFromSnapshot(ctx context.Context, db rootFSStoreDB, req *RestoreRootFSFromSnapshotRequest) (*RootFSFilesystem, error) {
+	if db == nil || req == nil {
+		return nil, nil
+	}
 	if strings.TrimSpace(req.SandboxID) == "" {
 		return nil, fmt.Errorf("sandbox_id is required")
 	}
 	if strings.TrimSpace(req.SnapshotID) == "" {
 		return nil, fmt.Errorf("snapshot_id is required")
 	}
-	filesystem, err := scanRootFSFilesystem(s.pool.QueryRow(ctx, `
+	filesystem, err := scanRootFSFilesystem(db.QueryRow(ctx, `
 		WITH snapshot AS (
 			SELECT s.snapshot_id, s.filesystem_id, s.team_id, s.head_layer_id,
 				l.base_image_ref, l.base_image_digest
@@ -321,6 +415,7 @@ func (s *PGSandboxStore) RestoreRootFSFromSnapshot(ctx context.Context, req *Res
 			JOIN manager.rootfs_layers l ON l.layer_id = s.head_layer_id
 			WHERE s.snapshot_id = $2
 				AND ($3 = '' OR s.team_id = $3)
+				AND (s.expires_at IS NULL OR s.expires_at > NOW())
 		),
 		target_sandbox AS (
 			SELECT sandbox_id, COALESCE(NULLIF($3, ''), team_id) AS team_id
@@ -387,9 +482,6 @@ func (s *PGSandboxStore) RestoreRootFSFromSnapshot(ctx context.Context, req *Res
 		JOIN bound ON bound.filesystem_id = restored.filesystem_id
 	`, req.SandboxID, req.SnapshotID, strings.TrimSpace(req.TeamID)))
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, s.rootFSRestoreNoRowsError(ctx, req)
-		}
 		return nil, fmt.Errorf("restore rootfs filesystem from snapshot: %w", err)
 	}
 	return filesystem, nil
@@ -450,6 +542,14 @@ func (s *PGSandboxStore) GarbageCollectRootFSFilesystemWithOptions(ctx context.C
 	if deleter == nil {
 		return nil, fmt.Errorf("rootfs object deleter is required")
 	}
+	expiredSnapshots, err := s.DeleteExpiredRootFSSnapshots(ctx, teamID, limit)
+	if err != nil {
+		return nil, err
+	}
+	deletedFilesystems, err := s.DeleteUnreferencedRootFSFilesystems(ctx, teamID, limit)
+	if err != nil {
+		return nil, err
+	}
 	layers, err := s.collectUnreferencedRootFSLayers(ctx, teamID, limit)
 	if err != nil {
 		return nil, err
@@ -457,13 +557,320 @@ func (s *PGSandboxStore) GarbageCollectRootFSFilesystemWithOptions(ctx context.C
 	opts.Limit = limit
 	deletedObjectKeys, err := s.DeletePendingRootFSObjectsWithOptions(ctx, deleter, opts)
 	result := &RootFSGarbageCollectionResult{
-		Layers:            layers,
-		DeletedObjectKeys: deletedObjectKeys,
+		Layers:             layers,
+		DeletedObjectKeys:  deletedObjectKeys,
+		ExpiredSnapshots:   expiredSnapshots,
+		DeletedFilesystems: deletedFilesystems,
 	}
 	if err != nil {
 		return result, err
 	}
 	return result, nil
+}
+
+func (s *PGSandboxStore) DeleteExpiredRootFSSnapshots(ctx context.Context, teamID string, limit int) (int, error) {
+	if s == nil || s.pool == nil {
+		return 0, nil
+	}
+	if limit <= 0 {
+		limit = defaultRootFSObjectDeleteLimit
+	}
+	if limit > maxRootFSObjectDeleteLimit {
+		limit = maxRootFSObjectDeleteLimit
+	}
+	tag, err := s.pool.Exec(ctx, `
+		WITH expired AS (
+			SELECT snapshot_id
+			FROM manager.rootfs_snapshots
+			WHERE expires_at IS NOT NULL
+				AND expires_at <= NOW()
+				AND ($1 = '' OR team_id = $1)
+			ORDER BY expires_at ASC
+			LIMIT $2
+			FOR UPDATE SKIP LOCKED
+		)
+		DELETE FROM manager.rootfs_snapshots s
+		USING expired e
+		WHERE s.snapshot_id = e.snapshot_id
+	`, strings.TrimSpace(teamID), limit)
+	if err != nil {
+		return 0, fmt.Errorf("delete expired rootfs snapshots: %w", err)
+	}
+	return int(tag.RowsAffected()), nil
+}
+
+func (s *PGSandboxStore) DeleteUnreferencedRootFSFilesystems(ctx context.Context, teamID string, limit int) (int, error) {
+	if s == nil || s.pool == nil {
+		return 0, nil
+	}
+	if limit <= 0 {
+		limit = defaultRootFSObjectDeleteLimit
+	}
+	if limit > maxRootFSObjectDeleteLimit {
+		limit = maxRootFSObjectDeleteLimit
+	}
+	total := 0
+	for total < limit {
+		deleted, err := s.deleteUnreferencedRootFSFilesystemLeaves(ctx, teamID, limit-total)
+		if err != nil {
+			return total, err
+		}
+		total += deleted
+		if deleted == 0 {
+			break
+		}
+	}
+	return total, nil
+}
+
+func (s *PGSandboxStore) deleteUnreferencedRootFSFilesystemLeaves(ctx context.Context, teamID string, limit int) (int, error) {
+	tag, err := s.pool.Exec(ctx, `
+		WITH RECURSIVE protected AS (
+			SELECT f.filesystem_id, f.source_filesystem_id
+			FROM manager.rootfs_filesystems f
+			WHERE EXISTS (
+				SELECT 1
+				FROM manager.sandbox_rootfs_bindings b
+				WHERE b.filesystem_id = f.filesystem_id
+			)
+			OR EXISTS (
+				SELECT 1
+				FROM manager.rootfs_snapshots s
+				WHERE s.filesystem_id = f.filesystem_id
+					AND (s.expires_at IS NULL OR s.expires_at > NOW())
+			)
+		),
+		protected_tree AS (
+			SELECT filesystem_id, source_filesystem_id
+			FROM protected
+			UNION
+			SELECT parent.filesystem_id, parent.source_filesystem_id
+			FROM manager.rootfs_filesystems parent
+			JOIN protected_tree child ON child.source_filesystem_id = parent.filesystem_id
+		),
+		candidates AS (
+			SELECT f.filesystem_id
+			FROM manager.rootfs_filesystems f
+			WHERE ($1 = '' OR f.team_id = $1)
+				AND NOT EXISTS (
+					SELECT 1
+					FROM protected_tree p
+					WHERE p.filesystem_id = f.filesystem_id
+				)
+				AND NOT EXISTS (
+					SELECT 1
+					FROM manager.rootfs_filesystems child
+					WHERE child.source_filesystem_id = f.filesystem_id
+				)
+			ORDER BY f.updated_at ASC
+			LIMIT $2
+			FOR UPDATE SKIP LOCKED
+		)
+		DELETE FROM manager.rootfs_filesystems f
+		USING candidates c
+		WHERE f.filesystem_id = c.filesystem_id
+	`, strings.TrimSpace(teamID), limit)
+	if err != nil {
+		return 0, fmt.Errorf("delete unreferenced rootfs filesystems: %w", err)
+	}
+	return int(tag.RowsAffected()), nil
+}
+
+func (s *PGSandboxStore) ListRootFSStorageUsage(ctx context.Context, teamID string) ([]RootFSStorageUsage, error) {
+	if s == nil || s.pool == nil {
+		return nil, nil
+	}
+	observedAt := time.Now().UTC()
+	rows, err := s.pool.Query(ctx, `
+		WITH RECURSIVE roots AS (
+			SELECT f.head_layer_id AS layer_id
+			FROM manager.sandbox_rootfs_bindings b
+			JOIN manager.rootfs_filesystems f ON f.filesystem_id = b.filesystem_id
+			WHERE f.head_layer_id IS NOT NULL
+			UNION
+			SELECT head_layer_id AS layer_id
+			FROM manager.rootfs_snapshots
+			WHERE head_layer_id IS NOT NULL
+				AND (expires_at IS NULL OR expires_at > NOW())
+		),
+		reachable AS (
+			SELECT l.layer_id, l.parent_layer_id
+			FROM manager.rootfs_layers l
+			JOIN roots r ON r.layer_id = l.layer_id
+			UNION
+			SELECT parent.layer_id, parent.parent_layer_id
+			FROM manager.rootfs_layers parent
+			JOIN reachable child ON child.parent_layer_id = parent.layer_id
+		),
+		reachable_objects AS (
+			SELECT l.team_id, l.diff_object_key, MAX(l.diff_size) AS diff_size
+			FROM manager.rootfs_layers l
+			JOIN reachable r ON r.layer_id = l.layer_id
+			WHERE l.diff_object_key <> ''
+				AND ($1 = '' OR l.team_id = $1)
+			GROUP BY l.team_id, l.diff_object_key
+		),
+		known_teams AS (
+			SELECT DISTINCT team_id
+			FROM manager.rootfs_objects
+			WHERE team_id <> ''
+				AND ($1 = '' OR team_id = $1)
+			UNION
+			SELECT DISTINCT team_id
+			FROM reachable_objects
+			WHERE team_id <> ''
+			UNION
+			SELECT $1
+			WHERE $1 <> ''
+		)
+		SELECT
+			known_teams.team_id,
+			COUNT(reachable_objects.diff_object_key) AS object_count,
+			COALESCE(SUM(reachable_objects.diff_size), 0) AS storage_bytes
+		FROM known_teams
+		LEFT JOIN reachable_objects ON reachable_objects.team_id = known_teams.team_id
+		GROUP BY known_teams.team_id
+		ORDER BY known_teams.team_id ASC
+	`, strings.TrimSpace(teamID))
+	if err != nil {
+		return nil, fmt.Errorf("list rootfs storage usage: %w", err)
+	}
+	defer rows.Close()
+
+	var usages []RootFSStorageUsage
+	for rows.Next() {
+		var usage RootFSStorageUsage
+		if err := rows.Scan(&usage.TeamID, &usage.ObjectCount, &usage.StorageBytes); err != nil {
+			return nil, err
+		}
+		usage.ObservedAt = observedAt
+		usages = append(usages, usage)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate rootfs storage usage: %w", err)
+	}
+	return usages, nil
+}
+
+func (s *PGSandboxStore) RecordRootFSStorageObservations(ctx context.Context, recorder RootFSStorageMeteringRecorder, teamID string, observedAt time.Time) ([]RootFSStorageUsage, error) {
+	if recorder == nil {
+		return nil, nil
+	}
+	if observedAt.IsZero() {
+		observedAt = time.Now().UTC()
+	} else {
+		observedAt = observedAt.UTC()
+	}
+	usages, err := s.ListRootFSStorageUsage(ctx, teamID)
+	if err != nil {
+		return nil, err
+	}
+	for i := range usages {
+		usages[i].ObservedAt = observedAt
+		if err := recorder.RecordStorageObservation(ctx, &meteringpkg.StorageObservation{
+			SubjectType: meteringpkg.SubjectTypeRootFS,
+			SubjectID:   usages[i].TeamID,
+			Product:     meteringpkg.ProductSandbox,
+			TeamID:      usages[i].TeamID,
+			SizeBytes:   usages[i].StorageBytes,
+			ObservedAt:  observedAt,
+		}); err != nil {
+			return usages, fmt.Errorf("record rootfs storage observation for team %q: %w", usages[i].TeamID, err)
+		}
+	}
+	return usages, nil
+}
+
+func (s *PGSandboxStore) AuditRootFSObjects(ctx context.Context, inspector RootFSObjectInspector, teamID string, limit int) (*RootFSObjectAuditResult, error) {
+	if s == nil || s.pool == nil || inspector == nil {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = defaultRootFSObjectDeleteLimit
+	}
+	if limit > maxRootFSObjectDeleteLimit {
+		limit = maxRootFSObjectDeleteLimit
+	}
+	rows, err := s.pool.Query(ctx, `
+		SELECT object_key, diff_size
+		FROM manager.rootfs_objects
+		WHERE deleted_at IS NULL
+			AND ($1 = '' OR team_id = $1)
+		ORDER BY last_referenced_at ASC, object_key ASC
+		LIMIT $2
+	`, strings.TrimSpace(teamID), limit)
+	if err != nil {
+		return nil, fmt.Errorf("list rootfs objects for audit: %w", err)
+	}
+	defer rows.Close()
+
+	type auditCandidate struct {
+		objectKey string
+		diffSize  int64
+	}
+	var candidates []auditCandidate
+	for rows.Next() {
+		var candidate auditCandidate
+		if err := rows.Scan(&candidate.objectKey, &candidate.diffSize); err != nil {
+			return nil, err
+		}
+		candidates = append(candidates, candidate)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate rootfs object audit candidates: %w", err)
+	}
+
+	result := &RootFSObjectAuditResult{}
+	for _, candidate := range candidates {
+		result.Checked++
+		info, err := inspector.StatRootFSObject(candidate.objectKey)
+		if err != nil {
+			result.Missing++
+			if updateErr := s.recordRootFSObjectAuditError(ctx, candidate.objectKey, err); updateErr != nil {
+				return result, updateErr
+			}
+			continue
+		}
+		if candidate.diffSize > 0 && info.Size > 0 && info.Size != candidate.diffSize {
+			result.SizeMismatched++
+			if updateErr := s.recordRootFSObjectAuditError(ctx, candidate.objectKey, fmt.Errorf("object size %d does not match db size %d", info.Size, candidate.diffSize)); updateErr != nil {
+				return result, updateErr
+			}
+			continue
+		}
+		if err := s.clearRootFSObjectAuditError(ctx, candidate.objectKey); err != nil {
+			return result, err
+		}
+	}
+	return result, nil
+}
+
+func (s *PGSandboxStore) recordRootFSObjectAuditError(ctx context.Context, objectKey string, auditErr error) error {
+	_, err := s.pool.Exec(ctx, `
+		UPDATE manager.rootfs_objects
+		SET missing_at = COALESCE(missing_at, NOW()),
+			last_error = $2,
+			updated_at = NOW()
+		WHERE object_key = $1
+	`, objectKey, truncateRootFSError(auditErr.Error()))
+	if err != nil {
+		return fmt.Errorf("record rootfs object audit error for %q: %w", objectKey, err)
+	}
+	return nil
+}
+
+func (s *PGSandboxStore) clearRootFSObjectAuditError(ctx context.Context, objectKey string) error {
+	_, err := s.pool.Exec(ctx, `
+		UPDATE manager.rootfs_objects
+		SET missing_at = NULL,
+			last_error = '',
+			updated_at = NOW()
+		WHERE object_key = $1
+	`, objectKey)
+	if err != nil {
+		return fmt.Errorf("clear rootfs object audit error for %q: %w", objectKey, err)
+	}
+	return nil
 }
 
 func (s *PGSandboxStore) collectUnreferencedRootFSLayers(ctx context.Context, teamID string, limit int) ([]*SandboxRootFSLayer, error) {
@@ -478,13 +885,15 @@ func (s *PGSandboxStore) collectUnreferencedRootFSLayers(ctx context.Context, te
 	}
 	rows, err := s.pool.Query(ctx, `
 		WITH RECURSIVE roots AS (
-			SELECT head_layer_id AS layer_id
-			FROM manager.rootfs_filesystems
-			WHERE head_layer_id IS NOT NULL
+			SELECT f.head_layer_id AS layer_id
+			FROM manager.sandbox_rootfs_bindings b
+			JOIN manager.rootfs_filesystems f ON f.filesystem_id = b.filesystem_id
+			WHERE f.head_layer_id IS NOT NULL
 			UNION
 			SELECT head_layer_id AS layer_id
 			FROM manager.rootfs_snapshots
 			WHERE head_layer_id IS NOT NULL
+				AND (expires_at IS NULL OR expires_at > NOW())
 		),
 		reachable AS (
 			SELECT l.layer_id, l.parent_layer_id
@@ -521,6 +930,16 @@ func (s *PGSandboxStore) collectUnreferencedRootFSLayers(ctx context.Context, te
 			FROM manager.rootfs_layers l
 			JOIN candidates c ON c.layer_id = l.layer_id
 			WHERE l.diff_object_key <> ''
+				AND NOT EXISTS (
+					SELECT 1
+					FROM manager.rootfs_layers ref
+					WHERE ref.diff_object_key = l.diff_object_key
+						AND NOT EXISTS (
+							SELECT 1
+							FROM candidates candidate_ref
+							WHERE candidate_ref.layer_id = ref.layer_id
+						)
+				)
 			ON CONFLICT (object_key) DO UPDATE SET
 				team_id = EXCLUDED.team_id,
 				next_attempt_at = NOW(),
@@ -534,14 +953,6 @@ func (s *PGSandboxStore) collectUnreferencedRootFSLayers(ctx context.Context, te
 			DELETE FROM manager.rootfs_layers l
 			USING candidates c
 			WHERE l.layer_id = c.layer_id
-				AND (
-					l.diff_object_key = ''
-					OR EXISTS (
-						SELECT 1
-						FROM queued_objects q
-						WHERE q.object_key = l.diff_object_key
-					)
-				)
 			RETURNING l.layer_id, l.parent_layer_id, l.source_sandbox_id, l.team_id,
 				l.runtime_generation, l.runtime, l.runtime_handler, l.base_image_ref,
 				l.base_image_digest, l.snapshotter, l.snapshot_parent,
@@ -594,6 +1005,16 @@ func (s *PGSandboxStore) DeletePendingRootFSObjectsWithOptions(ctx context.Conte
 		if err := ctx.Err(); err != nil {
 			return deleted, err
 		}
+		referenced, err := s.rootFSObjectHasLayerReferences(ctx, item.ObjectKey)
+		if err != nil {
+			return deleted, err
+		}
+		if referenced {
+			if err := s.clearRootFSObjectDeletion(ctx, item.ObjectKey, opts.ClaimedBy); err != nil {
+				return deleted, err
+			}
+			continue
+		}
 		if err := deleter.Delete(item.ObjectKey); err != nil {
 			if updateErr := s.recordRootFSObjectDeleteFailure(ctx, item, opts, err); updateErr != nil {
 				return deleted, updateErr
@@ -604,16 +1025,59 @@ func (s *PGSandboxStore) DeletePendingRootFSObjectsWithOptions(ctx context.Conte
 			}
 			continue
 		}
-		if _, err := s.pool.Exec(ctx, `
-			DELETE FROM manager.rootfs_object_deletions
-			WHERE object_key = $1
-				AND claimed_by = $2
-		`, item.ObjectKey, opts.ClaimedBy); err != nil {
-			return deleted, fmt.Errorf("clear rootfs object deletion %q: %w", item.ObjectKey, err)
+		if err := s.markRootFSObjectDeleted(ctx, item.ObjectKey); err != nil {
+			return deleted, err
+		}
+		if err := s.clearRootFSObjectDeletion(ctx, item.ObjectKey, opts.ClaimedBy); err != nil {
+			return deleted, err
 		}
 		deleted = append(deleted, item.ObjectKey)
 	}
 	return deleted, errors.Join(errs...)
+}
+
+func (s *PGSandboxStore) rootFSObjectHasLayerReferences(ctx context.Context, objectKey string) (bool, error) {
+	var referenced bool
+	if err := s.pool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM manager.rootfs_layers
+			WHERE diff_object_key = $1
+		)
+	`, objectKey).Scan(&referenced); err != nil {
+		return false, fmt.Errorf("check rootfs object references for %q: %w", objectKey, err)
+	}
+	return referenced, nil
+}
+
+func (s *PGSandboxStore) markRootFSObjectDeleted(ctx context.Context, objectKey string) error {
+	if _, err := s.pool.Exec(ctx, `
+		UPDATE manager.rootfs_objects
+		SET deleted_at = NOW(),
+			missing_at = NULL,
+			last_error = '',
+			updated_at = NOW()
+		WHERE object_key = $1
+			AND NOT EXISTS (
+				SELECT 1
+				FROM manager.rootfs_layers
+				WHERE diff_object_key = $1
+			)
+	`, objectKey); err != nil {
+		return fmt.Errorf("mark rootfs object deleted %q: %w", objectKey, err)
+	}
+	return nil
+}
+
+func (s *PGSandboxStore) clearRootFSObjectDeletion(ctx context.Context, objectKey, claimedBy string) error {
+	if _, err := s.pool.Exec(ctx, `
+		DELETE FROM manager.rootfs_object_deletions
+		WHERE object_key = $1
+			AND claimed_by = $2
+	`, objectKey, claimedBy); err != nil {
+		return fmt.Errorf("clear rootfs object deletion %q: %w", objectKey, err)
+	}
+	return nil
 }
 
 func (s *PGSandboxStore) RootFSObjectDeletionQueueStats(ctx context.Context) (*RootFSObjectDeletionQueueStats, error) {
@@ -875,6 +1339,7 @@ func (s *PGSandboxStore) rootFSSnapshotExists(ctx context.Context, snapshotID, t
 			FROM manager.rootfs_snapshots
 			WHERE snapshot_id = $1
 				AND ($2 = '' OR team_id = $2)
+				AND (expires_at IS NULL OR expires_at > NOW())
 		)
 	`, snapshotID, teamID).Scan(&exists); err != nil {
 		return false, fmt.Errorf("check rootfs snapshot exists: %w", err)

--- a/manager/pkg/service/rootfs_persistent_filesystem_integration_test.go
+++ b/manager/pkg/service/rootfs_persistent_filesystem_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	meteringpkg "github.com/sandbox0-ai/sandbox0/pkg/metering"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -277,6 +278,166 @@ func TestRootFSRootLayerSaveCanCASAgainstExistingHead(t *testing.T) {
 	assert.False(t, staleExists, "failed CAS must roll back the candidate layer")
 }
 
+func TestRootFSGCSkipsObjectDeleteWhenAnotherLayerReferencesSameKey(t *testing.T) {
+	ctx := context.Background()
+	pool := newSandboxStoreIntegrationPool(t)
+	store := NewPGSandboxStore(pool)
+
+	live := rootFSTestStoreState("sandbox-live", "team-1", "layer-live", "", 1, "shared")
+	live.DiffObjectKey = "rootfs/shared.tar"
+	stale := rootFSTestStoreState("sandbox-stale", "team-1", "layer-stale", "", 1, "shared")
+	stale.DiffObjectKey = live.DiffObjectKey
+
+	require.NoError(t, store.UpsertSandbox(ctx, rootFSTestSandboxRecord("sandbox-live", "team-1")))
+	require.NoError(t, store.SaveRootFSState(ctx, live))
+	require.NoError(t, store.UpsertSandbox(ctx, rootFSTestSandboxRecord("sandbox-stale", "team-1")))
+	require.NoError(t, store.SaveRootFSState(ctx, stale))
+	require.NoError(t, store.MarkSandboxDeleted(ctx, "sandbox-stale", time.Now().UTC()))
+
+	deleter := &recordingRootFSObjectDeleter{}
+	result, err := store.GarbageCollectRootFSFilesystem(ctx, deleter, "team-1", 10)
+	require.NoError(t, err)
+	require.Len(t, result.Layers, 1)
+	assert.Equal(t, "layer-stale", result.Layers[0].ID)
+	assert.Empty(t, result.DeletedObjectKeys)
+	assert.Empty(t, deleter.keys)
+	assert.Equal(t, int64(0), rootFSTestCountRows(t, pool, "rootfs_object_deletions"))
+
+	var deletedAt *time.Time
+	require.NoError(t, pool.QueryRow(ctx, `
+		SELECT deleted_at
+		FROM manager.rootfs_objects
+		WHERE object_key = 'rootfs/shared.tar'
+	`).Scan(&deletedAt))
+	assert.Nil(t, deletedAt)
+}
+
+func TestRootFSGCDeletesUnboundAncestorFilesystemAfterChildDeletion(t *testing.T) {
+	ctx := context.Background()
+	pool := newSandboxStoreIntegrationPool(t)
+	store := NewPGSandboxStore(pool)
+
+	require.NoError(t, store.UpsertSandbox(ctx, rootFSTestSandboxRecord("sandbox-source", "team-1")))
+	require.NoError(t, store.SaveRootFSState(ctx, rootFSTestStoreState("sandbox-source", "team-1", "layer-root", "", 1, "root")))
+	require.NoError(t, store.UpsertSandbox(ctx, rootFSTestSandboxRecord("sandbox-child", "team-1")))
+	_, err := store.ForkRootFSFilesystem(ctx, &ForkRootFSFilesystemRequest{
+		SourceSandboxID: "sandbox-source",
+		TargetSandboxID: "sandbox-child",
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, store.MarkSandboxDeleted(ctx, "sandbox-source", time.Now().UTC()))
+	assert.True(t, rootFSTestFilesystemExists(t, pool, "sandbox-source"))
+	require.NoError(t, store.MarkSandboxDeleted(ctx, "sandbox-child", time.Now().UTC()))
+
+	deleted, err := store.DeleteUnreferencedRootFSFilesystems(ctx, "team-1", 10)
+	require.NoError(t, err)
+	assert.Equal(t, 2, deleted)
+	assert.False(t, rootFSTestFilesystemExists(t, pool, "sandbox-source"))
+}
+
+func TestRootFSGCExpiresSnapshotBeforeLayerCollection(t *testing.T) {
+	ctx := context.Background()
+	pool := newSandboxStoreIntegrationPool(t)
+	store := NewPGSandboxStore(pool)
+
+	require.NoError(t, store.UpsertSandbox(ctx, rootFSTestSandboxRecord("sandbox-source", "team-1")))
+	require.NoError(t, store.SaveRootFSState(ctx, rootFSTestStoreState("sandbox-source", "team-1", "layer-old", "", 1, "old")))
+	_, err := store.CreateRootFSSnapshot(ctx, &CreateRootFSSnapshotRequest{
+		SandboxID:  "sandbox-source",
+		SnapshotID: "snapshot-expired",
+		ExpiresAt:  time.Now().Add(-time.Hour),
+	})
+	require.NoError(t, err)
+	full := rootFSTestStoreState("sandbox-source", "team-1", "layer-full", "", 2, "full")
+	full.ExpectedHeadLayerID = "layer-old"
+	require.NoError(t, store.SaveRootFSState(ctx, full))
+
+	deleter := &recordingRootFSObjectDeleter{}
+	result, err := store.GarbageCollectRootFSFilesystem(ctx, deleter, "team-1", 10)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.ExpiredSnapshots)
+	require.Len(t, result.Layers, 1)
+	assert.Equal(t, "layer-old", result.Layers[0].ID)
+	assert.Equal(t, []string{"rootfs/old.tar"}, result.DeletedObjectKeys)
+	assert.Equal(t, int64(0), rootFSTestCountRows(t, pool, "rootfs_snapshots"))
+}
+
+func TestRootFSStorageUsageDedupesReachableObjectsAndRecordsMetering(t *testing.T) {
+	ctx := context.Background()
+	pool := newSandboxStoreIntegrationPool(t)
+	store := NewPGSandboxStore(pool)
+
+	first := rootFSTestStoreState("sandbox-a", "team-1", "layer-a", "", 1, "shared")
+	first.DiffObjectKey = "rootfs/shared.tar"
+	second := rootFSTestStoreState("sandbox-b", "team-1", "layer-b", "", 1, "shared")
+	second.DiffObjectKey = first.DiffObjectKey
+
+	require.NoError(t, store.UpsertSandbox(ctx, rootFSTestSandboxRecord("sandbox-a", "team-1")))
+	require.NoError(t, store.SaveRootFSState(ctx, first))
+	require.NoError(t, store.UpsertSandbox(ctx, rootFSTestSandboxRecord("sandbox-b", "team-1")))
+	require.NoError(t, store.SaveRootFSState(ctx, second))
+
+	usages, err := store.ListRootFSStorageUsage(ctx, "team-1")
+	require.NoError(t, err)
+	require.Len(t, usages, 1)
+	assert.Equal(t, "team-1", usages[0].TeamID)
+	assert.Equal(t, int64(1), usages[0].ObjectCount)
+	assert.Equal(t, int64(len("shared")), usages[0].StorageBytes)
+
+	recorder := &recordingRootFSStorageMeteringRecorder{}
+	observedAt := time.Now().UTC()
+	usages, err = store.RecordRootFSStorageObservations(ctx, recorder, "team-1", observedAt)
+	require.NoError(t, err)
+	require.Len(t, usages, 1)
+	require.Len(t, recorder.observations, 1)
+	assert.Equal(t, meteringpkg.SubjectTypeRootFS, recorder.observations[0].SubjectType)
+	assert.Equal(t, "team-1", recorder.observations[0].SubjectID)
+	assert.Equal(t, int64(len("shared")), recorder.observations[0].SizeBytes)
+}
+
+func TestRootFSObjectAuditRecordsAndClearsMissingState(t *testing.T) {
+	ctx := context.Background()
+	pool := newSandboxStoreIntegrationPool(t)
+	store := NewPGSandboxStore(pool)
+
+	require.NoError(t, store.UpsertSandbox(ctx, rootFSTestSandboxRecord("sandbox-a", "team-1")))
+	require.NoError(t, store.SaveRootFSState(ctx, rootFSTestStoreState("sandbox-a", "team-1", "layer-a", "", 1, "audit")))
+
+	inspector := &recordingRootFSObjectInspector{err: assert.AnError}
+	result, err := store.AuditRootFSObjects(ctx, inspector, "team-1", 10)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 1, result.Checked)
+	assert.Equal(t, 1, result.Missing)
+
+	var missingAt *time.Time
+	var lastError string
+	require.NoError(t, pool.QueryRow(ctx, `
+		SELECT missing_at, last_error
+		FROM manager.rootfs_objects
+		WHERE object_key = 'rootfs/audit.tar'
+	`).Scan(&missingAt, &lastError))
+	require.NotNil(t, missingAt)
+	assert.Contains(t, lastError, assert.AnError.Error())
+
+	inspector.err = nil
+	inspector.info = RootFSObjectInfo{Key: "rootfs/audit.tar", Size: int64(len("audit"))}
+	result, err = store.AuditRootFSObjects(ctx, inspector, "team-1", 10)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 1, result.Checked)
+	assert.Equal(t, 0, result.Missing)
+
+	require.NoError(t, pool.QueryRow(ctx, `
+		SELECT missing_at, last_error
+		FROM manager.rootfs_objects
+		WHERE object_key = 'rootfs/audit.tar'
+	`).Scan(&missingAt, &lastError))
+	assert.Nil(t, missingAt)
+	assert.Empty(t, lastError)
+}
+
 func newSandboxStoreIntegrationPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
 	dbURL := os.Getenv("INTEGRATION_DATABASE_URL")
@@ -345,12 +506,48 @@ func rootFSTestCountRows(t *testing.T, pool *pgxpool.Pool, table string) int64 {
 		query = "SELECT COUNT(*) FROM manager.sandbox_rootfs_heads"
 	case "rootfs_object_deletions":
 		query = "SELECT COUNT(*) FROM manager.rootfs_object_deletions"
+	case "rootfs_snapshots":
+		query = "SELECT COUNT(*) FROM manager.rootfs_snapshots"
 	default:
 		t.Fatalf("unexpected table %q", table)
 	}
 	var count int64
 	require.NoError(t, pool.QueryRow(context.Background(), query).Scan(&count))
 	return count
+}
+
+func rootFSTestFilesystemExists(t *testing.T, pool *pgxpool.Pool, filesystemID string) bool {
+	t.Helper()
+	var exists bool
+	require.NoError(t, pool.QueryRow(context.Background(), `
+		SELECT EXISTS (
+			SELECT 1
+			FROM manager.rootfs_filesystems
+			WHERE filesystem_id = $1
+		)
+	`, filesystemID).Scan(&exists))
+	return exists
+}
+
+type recordingRootFSStorageMeteringRecorder struct {
+	observations []*meteringpkg.StorageObservation
+}
+
+func (r *recordingRootFSStorageMeteringRecorder) RecordStorageObservation(_ context.Context, observation *meteringpkg.StorageObservation) error {
+	r.observations = append(r.observations, observation)
+	return nil
+}
+
+type recordingRootFSObjectInspector struct {
+	info RootFSObjectInfo
+	err  error
+}
+
+func (i *recordingRootFSObjectInspector) StatRootFSObject(string) (RootFSObjectInfo, error) {
+	if i.err != nil {
+		return RootFSObjectInfo{}, i.err
+	}
+	return i.info, nil
 }
 
 type noopSandboxStoreMigrateLogger struct{}

--- a/manager/pkg/service/rootfs_persistent_filesystem_test.go
+++ b/manager/pkg/service/rootfs_persistent_filesystem_test.go
@@ -15,6 +15,7 @@ func TestSaveRootFSStateWritesLayerAndFilesystemHeadOnly(t *testing.T) {
 	exec := &recordingRootFSStateExecutor{
 		tags: []pgconn.CommandTag{
 			pgconn.NewCommandTag("INSERT 0 1"),
+			pgconn.NewCommandTag("INSERT 0 1"),
 			pgconn.NewCommandTag("SELECT 1"),
 		},
 	}
@@ -24,9 +25,10 @@ func TestSaveRootFSStateWritesLayerAndFilesystemHeadOnly(t *testing.T) {
 	err := saveRootFSState(context.Background(), exec, state)
 
 	require.NoError(t, err)
-	require.Len(t, exec.sqls, 2)
-	assert.Contains(t, exec.sqls[0], "INSERT INTO manager.rootfs_layers")
-	assert.Contains(t, exec.sqls[1], "INSERT INTO manager.rootfs_filesystems")
+	require.Len(t, exec.sqls, 3)
+	assert.Contains(t, exec.sqls[0], "INSERT INTO manager.rootfs_objects")
+	assert.Contains(t, exec.sqls[1], "INSERT INTO manager.rootfs_layers")
+	assert.Contains(t, exec.sqls[2], "INSERT INTO manager.rootfs_filesystems")
 	for _, sql := range exec.sqls {
 		assert.NotContains(t, sql, "INSERT INTO manager.sandbox_rootfs_states")
 		assert.NotContains(t, sql, "INSERT INTO manager.sandbox_rootfs_heads")
@@ -47,6 +49,7 @@ func TestSaveRootFSStateMapsHeadCASMissToConflict(t *testing.T) {
 	exec := &recordingRootFSStateExecutor{
 		tags: []pgconn.CommandTag{
 			pgconn.NewCommandTag("INSERT 0 1"),
+			pgconn.NewCommandTag("INSERT 0 1"),
 			pgconn.NewCommandTag("SELECT 0"),
 		},
 	}
@@ -57,12 +60,13 @@ func TestSaveRootFSStateMapsHeadCASMissToConflict(t *testing.T) {
 	err := saveRootFSState(context.Background(), exec, state)
 
 	require.ErrorIs(t, err, ErrRootFSHeadConflict)
-	require.Len(t, exec.sqls, 2)
+	require.Len(t, exec.sqls, 3)
 }
 
 func TestSaveRootFSStateUsesExpectedHeadLayerIDWhenParentDiffers(t *testing.T) {
 	exec := &recordingRootFSStateExecutor{
 		tags: []pgconn.CommandTag{
+			pgconn.NewCommandTag("INSERT 0 1"),
 			pgconn.NewCommandTag("INSERT 0 1"),
 			pgconn.NewCommandTag("SELECT 1"),
 		},
@@ -75,8 +79,24 @@ func TestSaveRootFSStateUsesExpectedHeadLayerIDWhenParentDiffers(t *testing.T) {
 	err := saveRootFSState(context.Background(), exec, state)
 
 	require.NoError(t, err)
-	require.Len(t, exec.args, 2)
-	assert.Equal(t, "layer-parent", exec.args[1][3])
+	require.Len(t, exec.args, 3)
+	assert.Equal(t, "layer-parent", exec.args[2][3])
+}
+
+func TestSaveRootFSStateMapsObjectMetadataConflict(t *testing.T) {
+	exec := &recordingRootFSStateExecutor{
+		tags: []pgconn.CommandTag{
+			pgconn.NewCommandTag("INSERT 0 0"),
+		},
+	}
+	state := rootFSTestState()
+	state.LayerID = "layer-conflict"
+
+	err := saveRootFSState(context.Background(), exec, state)
+
+	require.ErrorIs(t, err, ErrRootFSObjectConflict)
+	require.Len(t, exec.sqls, 1)
+	assert.Contains(t, exec.sqls[0], "INSERT INTO manager.rootfs_objects")
 }
 
 func TestDeleteRootFSObjectsDedupesAndSkipsEmptyKeys(t *testing.T) {

--- a/manager/pkg/service/sandbox_service_rootfs_product.go
+++ b/manager/pkg/service/sandbox_service_rootfs_product.go
@@ -26,6 +26,22 @@ type SandboxRootFSProductStore interface {
 	RestoreRootFSFromSnapshot(ctx context.Context, req *RestoreRootFSFromSnapshotRequest) (*RootFSFilesystem, error)
 }
 
+type sandboxRootFSSnapshotCreator interface {
+	CreateRootFSSnapshot(ctx context.Context, req *CreateRootFSSnapshotRequest) (*RootFSSnapshot, error)
+}
+
+type sandboxRootFSRestorer interface {
+	RestoreRootFSFromSnapshot(ctx context.Context, req *RestoreRootFSFromSnapshotRequest) (*RootFSFilesystem, error)
+}
+
+type sandboxRootFSForker interface {
+	ForkRootFSFilesystem(ctx context.Context, req *ForkRootFSFilesystemRequest) (*RootFSFilesystem, error)
+}
+
+type sandboxRecordUpserter interface {
+	UpsertSandbox(ctx context.Context, record *SandboxRecord) error
+}
+
 type CreateSandboxRootFSSnapshotRequest struct {
 	Name        string    `json:"name,omitempty"`
 	Description string    `json:"description,omitempty"`
@@ -80,12 +96,16 @@ func (s *SandboxService) CreateSandboxRootFSSnapshot(ctx context.Context, sandbo
 		return nil, fmt.Errorf("team_id is required")
 	}
 	var snapshot *RootFSSnapshot
-	err = s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, _ SandboxStoreTx, record *SandboxRecord) error {
+	err = s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, record *SandboxRecord) error {
 		if err := validateRootFSSandboxRecord(record, sandboxID, teamID, true); err != nil {
 			return err
 		}
+		creator := sandboxRootFSSnapshotCreator(store)
+		if txCreator, ok := tx.(sandboxRootFSSnapshotCreator); ok {
+			creator = txCreator
+		}
 		var createErr error
-		snapshot, createErr = store.CreateRootFSSnapshot(lockCtx, &CreateRootFSSnapshotRequest{
+		snapshot, createErr = creator.CreateRootFSSnapshot(lockCtx, &CreateRootFSSnapshotRequest{
 			SandboxID:   sandboxID,
 			SnapshotID:  generateRootFSSnapshotID(),
 			Name:        strings.TrimSpace(req.Name),
@@ -176,11 +196,15 @@ func (s *SandboxService) RestoreSandboxRootFS(ctx context.Context, sandboxID, te
 	if _, err := store.GetRootFSSnapshot(ctx, snapshotID, teamID); err != nil {
 		return nil, err
 	}
-	err = s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, _ SandboxStoreTx, record *SandboxRecord) error {
+	err = s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, record *SandboxRecord) error {
 		if err := validateRootFSSandboxRecord(record, sandboxID, teamID, true); err != nil {
 			return err
 		}
-		_, restoreErr := store.RestoreRootFSFromSnapshot(lockCtx, &RestoreRootFSFromSnapshotRequest{
+		restorer := sandboxRootFSRestorer(store)
+		if txRestorer, ok := tx.(sandboxRootFSRestorer); ok {
+			restorer = txRestorer
+		}
+		_, restoreErr := restorer.RestoreRootFSFromSnapshot(lockCtx, &RestoreRootFSFromSnapshotRequest{
 			SandboxID:  sandboxID,
 			SnapshotID: snapshotID,
 			TeamID:     teamID,
@@ -246,18 +270,32 @@ func (s *SandboxService) ForkSandbox(ctx context.Context, sourceSandboxID, teamI
 		CreatedAt:         now,
 		UpdatedAt:         now,
 	}
-	err = s.sandboxStore.WithSandboxLock(ctx, sourceSandboxID, func(lockCtx context.Context, _ SandboxStoreTx, record *SandboxRecord) error {
+	err = s.sandboxStore.WithSandboxLock(ctx, sourceSandboxID, func(lockCtx context.Context, tx SandboxStoreTx, record *SandboxRecord) error {
 		if err := validateRootFSSandboxRecord(record, sourceSandboxID, teamID, true); err != nil {
 			return err
 		}
-		if err := s.sandboxStore.UpsertSandbox(lockCtx, target); err != nil {
+		upserter := sandboxRecordUpserter(s.sandboxStore)
+		txBacked := false
+		if txUpserter, ok := tx.(sandboxRecordUpserter); ok {
+			upserter = txUpserter
+			txBacked = true
+		}
+		if err := upserter.UpsertSandbox(lockCtx, target); err != nil {
 			return err
 		}
-		if _, err := store.ForkRootFSFilesystem(lockCtx, &ForkRootFSFilesystemRequest{
+		forker := sandboxRootFSForker(store)
+		if txForker, ok := tx.(sandboxRootFSForker); ok {
+			forker = txForker
+			txBacked = true
+		}
+		if _, err := forker.ForkRootFSFilesystem(lockCtx, &ForkRootFSFilesystemRequest{
 			SourceSandboxID: sourceSandboxID,
 			TargetSandboxID: targetID,
 			TargetTeamID:    teamID,
 		}); err != nil {
+			if txBacked {
+				return err
+			}
 			if cleanupErr := s.sandboxStore.MarkSandboxDeleted(lockCtx, targetID, s.clock.Now().UTC()); cleanupErr != nil && s.logger != nil {
 				s.logger.Warn("Failed to clean up sandbox record after rootfs fork failure",
 					zap.String("sandboxID", targetID),

--- a/manager/pkg/service/sandbox_store.go
+++ b/manager/pkg/service/sandbox_store.go
@@ -147,6 +147,13 @@ func (s *PGSandboxStore) UpsertSandbox(ctx context.Context, record *SandboxRecor
 	if s == nil || s.pool == nil || record == nil {
 		return nil
 	}
+	return upsertSandboxRecord(ctx, s.pool, record)
+}
+
+func upsertSandboxRecord(ctx context.Context, exec rootFSStateExecutor, record *SandboxRecord) error {
+	if exec == nil || record == nil {
+		return nil
+	}
 	if strings.TrimSpace(record.ID) == "" {
 		return fmt.Errorf("sandbox_id is required")
 	}
@@ -154,7 +161,7 @@ func (s *PGSandboxStore) UpsertSandbox(ctx context.Context, record *SandboxRecor
 	if err != nil {
 		return err
 	}
-	_, err = s.pool.Exec(ctx, `
+	_, err = exec.Exec(ctx, `
 		INSERT INTO manager.sandboxes (
 			sandbox_id, team_id, user_id, template_id, template_name, template_namespace,
 			cluster_id, status, config, mounts, template_spec,
@@ -472,6 +479,10 @@ func (t sandboxStoreTx) SaveRootFSState(ctx context.Context, state *SandboxRootF
 	return saveRootFSState(ctx, t.tx, state)
 }
 
+func (t sandboxStoreTx) UpsertSandbox(ctx context.Context, record *SandboxRecord) error {
+	return upsertSandboxRecord(ctx, t.tx, record)
+}
+
 func sandboxRecordSelectSQL() string {
 	return `
 		SELECT sandbox_id, team_id, user_id, template_id, template_name, template_namespace,
@@ -530,6 +541,9 @@ func saveRootFSLayer(ctx context.Context, exec rootFSStateExecutor, state *Sandb
 	if strings.TrimSpace(state.ParentLayerID) == strings.TrimSpace(state.LayerID) {
 		return fmt.Errorf("parent_layer_id cannot reference layer_id")
 	}
+	if err := saveRootFSObject(ctx, exec, state); err != nil {
+		return err
+	}
 	parentLayerID := nullableText(state.ParentLayerID)
 	parentChainJSON, err := json.Marshal(state.SnapshotParentChain)
 	if err != nil {
@@ -550,6 +564,41 @@ func saveRootFSLayer(ctx context.Context, exec rootFSStateExecutor, state *Sandb
 		state.DiffSize, state.DiffObjectKey, nullableTime(state.CreatedAt))
 	if err != nil {
 		return fmt.Errorf("save rootfs layer: %w", err)
+	}
+	return nil
+}
+
+func saveRootFSObject(ctx context.Context, exec rootFSStateExecutor, state *SandboxRootFSState) error {
+	if exec == nil || state == nil {
+		return nil
+	}
+	tag, err := exec.Exec(ctx, `
+		INSERT INTO manager.rootfs_objects (
+			object_key, team_id, diff_digest, diff_media_type, diff_size,
+			first_layer_id, last_referenced_at, missing_at, deleted_at,
+			last_error, created_at, updated_at
+		)
+		VALUES ($1, $2, $3, $4, $5, $6, COALESCE($7, NOW()), NULL, NULL, '', COALESCE($7, NOW()), NOW())
+		ON CONFLICT (object_key) DO UPDATE SET
+			team_id = EXCLUDED.team_id,
+			diff_digest = EXCLUDED.diff_digest,
+			diff_media_type = EXCLUDED.diff_media_type,
+			diff_size = EXCLUDED.diff_size,
+			last_referenced_at = NOW(),
+			missing_at = NULL,
+			deleted_at = NULL,
+			last_error = '',
+			updated_at = NOW()
+		WHERE manager.rootfs_objects.team_id = EXCLUDED.team_id
+			AND manager.rootfs_objects.diff_digest = EXCLUDED.diff_digest
+			AND manager.rootfs_objects.diff_size = EXCLUDED.diff_size
+	`, state.DiffObjectKey, state.TeamID, state.DiffDigest, state.DiffMediaType,
+		state.DiffSize, state.LayerID, nullableTime(state.CreatedAt))
+	if err != nil {
+		return fmt.Errorf("save rootfs object: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("%w: %s", ErrRootFSObjectConflict, state.DiffObjectKey)
 	}
 	return nil
 }

--- a/pkg/metering/repository.go
+++ b/pkg/metering/repository.go
@@ -605,7 +605,7 @@ func (r *Repository) normalizeStorageObservation(ctx context.Context, db DB, obs
 	if observation.SubjectType == "" || observation.SubjectID == "" {
 		return nil, fmt.Errorf("storage subject_type and subject_id are required")
 	}
-	if observation.SubjectType != SubjectTypeVolume && observation.SubjectType != SubjectTypeSnapshot {
+	if observation.SubjectType != SubjectTypeVolume && observation.SubjectType != SubjectTypeSnapshot && observation.SubjectType != SubjectTypeRootFS {
 		return nil, fmt.Errorf("unsupported storage subject_type %q", observation.SubjectType)
 	}
 	if observation.SizeBytes < 0 {
@@ -748,8 +748,11 @@ func storageWindowFromState(state *StorageProjectionState, end time.Time) *Windo
 		return nil
 	}
 	windowType := WindowTypeSandboxVolumeByteHours
-	if state.SubjectType == SubjectTypeSnapshot {
+	switch state.SubjectType {
+	case SubjectTypeSnapshot:
 		windowType = WindowTypeSandboxSnapshotByteHours
+	case SubjectTypeRootFS:
+		windowType = WindowTypeSandboxRootFSByteHours
 	}
 	return &Window{
 		WindowID:    fmt.Sprintf("storage/%s/%s/%d/%d", state.SubjectType, state.SubjectID, start.UnixNano(), end.UnixNano()),

--- a/pkg/metering/repository_test.go
+++ b/pkg/metering/repository_test.go
@@ -357,6 +357,27 @@ func TestStorageWindowFromStateSkipsSubByteHour(t *testing.T) {
 	}
 }
 
+func TestStorageWindowFromStateUsesRootFSWindowType(t *testing.T) {
+	start := time.Date(2026, 3, 12, 12, 0, 0, 0, time.UTC)
+	window := storageWindowFromState(&StorageProjectionState{
+		SubjectType: SubjectTypeRootFS,
+		SubjectID:   "team-1",
+		Product:     ProductSandbox,
+		TeamID:      "team-1",
+		SizeBytes:   1024,
+		ObservedAt:  start,
+	}, start.Add(time.Hour))
+	if window == nil {
+		t.Fatal("expected rootfs storage window")
+	}
+	if window.WindowType != WindowTypeSandboxRootFSByteHours {
+		t.Fatalf("window_type = %q, want %q", window.WindowType, WindowTypeSandboxRootFSByteHours)
+	}
+	if window.SubjectType != SubjectTypeRootFS || window.SubjectID != "team-1" {
+		t.Fatalf("unexpected subject: %s/%s", window.SubjectType, window.SubjectID)
+	}
+}
+
 func TestRecordStorageObservationClosesPreviousWindow(t *testing.T) {
 	start := time.Date(2026, 3, 12, 12, 0, 0, 0, time.UTC)
 	end := start.Add(2 * time.Hour)

--- a/pkg/metering/types.go
+++ b/pkg/metering/types.go
@@ -32,6 +32,7 @@ const (
 	WindowTypeSandboxRuntimeMiBMilliseconds = "sandbox.runtime_mib_milliseconds"
 	WindowTypeSandboxVolumeByteHours        = "sandbox.volume_byte_hours"
 	WindowTypeSandboxSnapshotByteHours      = "sandbox.snapshot_byte_hours"
+	WindowTypeSandboxRootFSByteHours        = "sandbox.rootfs_byte_hours"
 
 	WindowTypeManagedAgentSessionRunningMilliseconds = "managed_agent.session_running_milliseconds"
 
@@ -44,6 +45,7 @@ const (
 	SubjectTypeSandbox             = "sandbox"
 	SubjectTypeVolume              = "volume"
 	SubjectTypeSnapshot            = "snapshot"
+	SubjectTypeRootFS              = "rootfs"
 	SubjectTypeManagedAgentSession = "managed_agent_session"
 )
 

--- a/pkg/observability/metrics/manager.go
+++ b/pkg/observability/metrics/manager.go
@@ -24,6 +24,8 @@ type ManagerMetrics struct {
 	RootFSGCLayersTotal            prometheus.Counter
 	RootFSObjectDeletesTotal       *prometheus.CounterVec
 	RootFSObjectDeletionQueueDepth *prometheus.GaugeVec
+	RootFSStorageBytes             prometheus.Gauge
+	RootFSStorageObjects           prometheus.Gauge
 }
 
 // NewManager registers and returns manager metrics.
@@ -108,5 +110,13 @@ func NewManager(registry prometheus.Registerer) *ManagerMetrics {
 			Name: "manager_rootfs_object_deletion_queue_depth",
 			Help: "Rootfs object deletion queue depth by state",
 		}, []string{"state"}),
+		RootFSStorageBytes: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "manager_rootfs_storage_bytes",
+			Help: "Current reachable persistent rootfs COW object bytes",
+		}),
+		RootFSStorageObjects: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "manager_rootfs_storage_objects",
+			Help: "Current reachable persistent rootfs COW object count",
+		}),
 	}
 }


### PR DESCRIPTION
## Summary

- add a persistent rootfs object inventory and validate object metadata before layer insertion
- harden rootfs GC around expired snapshots, unbound filesystem ancestors, shared object keys, and stale deletion queue entries
- add DB-to-object-store head audits for live rootfs objects and record missing/size mismatch state in PostgreSQL
- add team-level persistent rootfs COW storage observations using `sandbox.rootfs_byte_hours` plus manager live storage gauges
- make snapshot/restore/fork rootfs metadata paths use tx-backed store methods when running under the sandbox lock

Refs #473
Refs #474
Refs #475
Refs #476

## Tests

- `go test ./manager/pkg/service ./pkg/metering ./pkg/observability/metrics`
- `TEST_DATABASE_URL=postgres://postgres:postgres@127.0.0.1:55432/sandbox0_test?sslmode=disable go test ./manager/pkg/service -run 'TestRootFS' -count=1` against a temporary `postgres:16-alpine` container\n- `go test ./...` was attempted locally. It is blocked by existing local environment requirements: missing generated `github.com/sandbox0-ai/sandbox0/storage-proxy/proto/fs` for storage-proxy-dependent packages, and single-cluster e2e requires local image `sandbox0ai/infra:latest`.\n\n## Notes\n\nThis PR adds DB->object-store live object auditing through `Head`. Full prefix listing for S3-only orphan discovery remains a separate reconciliation extension because it needs bounded prefix policy and object age safety rules.

Fixes #473
Fixes #474
Fixes #475
Fixes #476