### PR TITLE
Link rootfs fork environment blog from docs

### DIFF
--- a/docs/sandbox/snapshot-restore/page.mdx
+++ b/docs/sandbox/snapshot-restore/page.mdx
@@ -76,6 +76,8 @@ s0 sandbox resume "$FORKED_SANDBOX_ID"
 
 Fork is usually the shorter path for branch-per-task workflows because it creates a new paused sandbox directly from the seed rootfs. Snapshot is better when you need a named checkpoint that can be listed, fetched, restored later, and cleaned up independently.
 
+For a longer walkthrough of this pattern, see [Initialize Once, Fork Many](/blog/2026-06/initialize-once-fork-many-custom-ai-agent-sandboxes).
+
 <Callout variant="warning">
 This pattern does not replace template-level configuration. Use a custom template when you need a different container image, resource limits, mount declarations, default network policy, environment defaults, or privileged runtime fields. Mounted Sandbox Volumes are separate from the sandbox rootfs and should be managed with Volume snapshot and fork APIs.
 </Callout>
@@ -453,5 +455,9 @@ For coding-agent and test-generation workflows, a common pattern is:
 
   <Card title="Volumes" href="/docs/volume" cta="Continue">
     Use durable shared storage when rootfs snapshots are not the right persistence boundary.
+  </Card>
+
+  <Card title="Initialize Once, Fork Many" href="/blog/2026-06/initialize-once-fork-many-custom-ai-agent-sandboxes" cta="Read">
+    Use rootfs snapshots and forks as lightweight custom environments.
   </Card>
 </CardGroup>

--- a/docs/template/page.mdx
+++ b/docs/template/page.mdx
@@ -39,7 +39,7 @@ For platform-owned builtin templates, the operator manages the warm pool. That l
 | User-space dependencies, repository checkout, package cache, generated files, or per-project tool configuration on an existing base image | Builtin template plus rootfs snapshot or fork |
 | Data that must outlive sandbox identity, be mounted by multiple sandboxes, or be accessed through direct storage APIs | Sandbox Volume |
 
-Rootfs snapshots do not create template IDs and do not appear in `s0 template list`. A fork keeps the source sandbox's template and sandbox configuration, while restore changes only the target sandbox rootfs. See [Snapshot And Restore](/docs/sandbox/snapshot-restore) for the paused-state requirements and API workflow.
+Rootfs snapshots do not create template IDs and do not appear in `s0 template list`. A fork keeps the source sandbox's template and sandbox configuration, while restore changes only the target sandbox rootfs. See [Snapshot And Restore](/docs/sandbox/snapshot-restore) for the paused-state requirements and API workflow, or read [Initialize Once, Fork Many](/blog/2026-06/initialize-once-fork-many-custom-ai-agent-sandboxes) for the custom-environment pattern.
 
 ---
 
@@ -379,5 +379,9 @@ console.log("Template deleted");`
 
   <Card title="Snapshot And Restore" href="/docs/sandbox/snapshot-restore" cta="Continue">
     Reuse initialized rootfs state without creating another template.
+  </Card>
+
+  <Card title="Initialize Once, Fork Many" href="/blog/2026-06/initialize-once-fork-many-custom-ai-agent-sandboxes" cta="Read">
+    Customize a builtin template with rootfs snapshots and forks.
   </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary
- link the new Initialize Once, Fork Many blog from the Template docs
- add a Snapshot And Restore docs link for the custom-environment workflow
- make the template docs clearer that custom templates are not the only way to customize initialized runtime state

## Tests
- git diff --check