### PR TITLE
Handle missing sandbox records without panic

### DIFF
--- a/cluster-gateway/pkg/http/handlers_context_test.go
+++ b/cluster-gateway/pkg/http/handlers_context_test.go
@@ -59,6 +59,41 @@ func TestGetProcdURLFetchesManagerForEachRequest(t *testing.T) {
 	}
 }
 
+func TestGetProcdURLReturnsNotFoundForMissingSandbox(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate keypair: %v", err)
+	}
+	tokenGen := internalauth.NewGenerator(internalauth.GeneratorConfig{
+		Caller:     "cluster-gateway",
+		PrivateKey: privateKey,
+		TTL:        time.Minute,
+	})
+	manager := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/v1/sandboxes/missing-sandbox" {
+			t.Fatalf("unexpected manager request %s %s", r.Method, r.URL.Path)
+		}
+		_ = spec.WriteError(w, http.StatusNotFound, spec.CodeNotFound, "sandbox not found")
+	}))
+	defer manager.Close()
+
+	server := &Server{
+		managerClient: client.NewManagerClient(manager.URL, tokenGen, zap.NewNop(), time.Second),
+		logger:        zap.NewNop(),
+	}
+
+	addr, rec := mustGetProcdURL(t, server, "team-a", "user-a", "missing-sandbox")
+
+	if addr != nil {
+		t.Fatalf("addr = %v, want nil", addr)
+	}
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
 func TestGetProcdURLRechecksPausedStateAfterSuccessfulAccess(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/cluster-gateway/pkg/http/sandbox_service_policy_test.go
+++ b/cluster-gateway/pkg/http/sandbox_service_policy_test.go
@@ -177,6 +177,31 @@ func TestSandboxServiceHandlesCORSPreflight(t *testing.T) {
 	}
 }
 
+func TestSandboxServiceExposureReturnsNotFoundForMissingSandbox(t *testing.T) {
+	manager := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/internal/v1/sandboxes/sb-missing" {
+			t.Fatalf("unexpected manager request %s %s", r.Method, r.URL.Path)
+		}
+		_ = spec.WriteError(w, http.StatusNotFound, spec.CodeNotFound, "sandbox not found")
+	}))
+	defer manager.Close()
+
+	gateway := newSandboxServiceExposureTestServerWithManagerURL(t, manager.URL)
+	gatewayServer := httptest.NewServer(gateway)
+	defer gatewayServer.Close()
+
+	req := newGatewayRequest(t, http.MethodGet, gatewayServer.URL, "sb-missing--p3000.aws-us-east-1.sandbox0.app", "/")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("gateway request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusNotFound)
+	}
+}
+
 func TestSandboxFunctionServiceExecutesThroughProcdPort(t *testing.T) {
 	var execReq sandboxfunction.ExecuteRequest
 	procd := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/manager/pkg/service/sandbox_service_lifecycle.go
+++ b/manager/pkg/service/sandbox_service_lifecycle.go
@@ -413,18 +413,23 @@ func (s *SandboxService) GetSandbox(ctx context.Context, sandboxID string) (*San
 		if storeErr != nil {
 			return nil, fmt.Errorf("get sandbox record: %w", storeErr)
 		}
-		if record != nil && record.Status == SandboxStatusDeleted {
-			return nil, k8serrors.NewNotFound(schema.GroupResource{Resource: "sandbox"}, sandboxID)
-		}
-		if recordLifecycleStatusOverridesPod(record.Status) {
-			return s.recordToSandbox(record), nil
+		if record != nil {
+			if record.Status == SandboxStatusDeleted {
+				return nil, k8serrors.NewNotFound(schema.GroupResource{Resource: "sandbox"}, sandboxID)
+			}
+			if recordLifecycleStatusOverridesPod(record.Status) {
+				return s.recordToSandbox(record), nil
+			}
 		}
 	}
 	// Find the pod by sandbox ID
 	pod, err := s.getSandboxPod(ctx, sandboxID)
 	if err != nil {
-		if k8serrors.IsNotFound(err) && record != nil {
-			return s.recordToSandbox(record), nil
+		if k8serrors.IsNotFound(err) {
+			if record != nil {
+				return s.recordToSandbox(record), nil
+			}
+			return nil, k8serrors.NewNotFound(schema.GroupResource{Resource: "sandbox"}, sandboxID)
 		}
 		return nil, fmt.Errorf("get pod: %w", err)
 	}

--- a/manager/pkg/service/sandbox_service_lifecycle_test.go
+++ b/manager/pkg/service/sandbox_service_lifecycle_test.go
@@ -1,0 +1,49 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestGetSandboxReturnsNotFoundWhenRecordAndPodAreMissing(t *testing.T) {
+	svc := &SandboxService{
+		k8sClient:    fake.NewSimpleClientset(),
+		podLister:    newTestPodLister(t),
+		sandboxStore: &memorySandboxStore{records: map[string]*SandboxRecord{}},
+		clock:        systemTime{},
+		logger:       zap.NewNop(),
+	}
+
+	sandbox, err := svc.GetSandbox(context.Background(), "missing-sandbox")
+
+	require.Nil(t, sandbox)
+	require.Error(t, err)
+	require.True(t, k8serrors.IsNotFound(err), "err = %v", err)
+}
+
+func TestGetSandboxFallsBackToPodWhenRecordIsMissing(t *testing.T) {
+	pod := rootFSTestPod("pod-1", "sandbox-1", "team-1")
+	pod.Status.PodIP = "10.0.0.10"
+	svc := &SandboxService{
+		k8sClient:    fake.NewSimpleClientset(pod),
+		podLister:    newTestPodLister(t, pod),
+		sandboxStore: &memorySandboxStore{records: map[string]*SandboxRecord{}},
+		config:       SandboxServiceConfig{ProcdPort: 49983},
+		clock:        systemTime{},
+		logger:       zap.NewNop(),
+	}
+
+	sandbox, err := svc.GetSandbox(context.Background(), "sandbox-1")
+
+	require.NoError(t, err)
+	require.NotNil(t, sandbox)
+	assert.Equal(t, "sandbox-1", sandbox.ID)
+	assert.Equal(t, "team-1", sandbox.TeamID)
+	assert.Equal(t, "pod-1", sandbox.PodName)
+}


### PR DESCRIPTION
## Summary
- guard manager sandbox lookup when the durable sandbox record is absent
- return a sandbox not-found error when both record and runtime pod are missing
- cover procd-routed and public exposure missing-sandbox paths as 404s

Fixes #534
Fixes #512

## Tests
- go test ./manager/pkg/service
- go test ./cluster-gateway/pkg/http