### PR TITLE
Fix empty list response shapes

### DIFF
--- a/manager/pkg/service/credential_source_service.go
+++ b/manager/pkg/service/credential_source_service.go
@@ -29,7 +29,14 @@ func (s *CredentialSourceService) ListSources(ctx context.Context, teamID string
 	if s == nil || s.store == nil {
 		return nil, fmt.Errorf("credential source store is not configured")
 	}
-	return s.store.ListSourceMetadata(ctx, teamID)
+	records, err := s.store.ListSourceMetadata(ctx, teamID)
+	if err != nil {
+		return nil, err
+	}
+	if records == nil {
+		records = []egressauth.CredentialSourceMetadata{}
+	}
+	return records, nil
 }
 
 func (s *CredentialSourceService) GetSource(ctx context.Context, teamID, name string) (*egressauth.CredentialSourceMetadata, error) {

--- a/manager/pkg/service/credential_source_service_test.go
+++ b/manager/pkg/service/credential_source_service_test.go
@@ -19,6 +19,10 @@ type memorySourceStore struct {
 	records map[string]*egressauth.CredentialSourceMetadata
 }
 
+type nilListSourceStore struct {
+	*memorySourceStore
+}
+
 func newMemorySourceStore() *memorySourceStore {
 	return &memorySourceStore{records: make(map[string]*egressauth.CredentialSourceMetadata)}
 }
@@ -58,6 +62,25 @@ func (s *memorySourceStore) PutSource(_ context.Context, teamID string, record *
 func (s *memorySourceStore) DeleteSource(_ context.Context, teamID, name string) error {
 	delete(s.records, teamID+"/"+name)
 	return nil
+}
+
+func (s *nilListSourceStore) ListSourceMetadata(context.Context, string) ([]egressauth.CredentialSourceMetadata, error) {
+	return nil, nil
+}
+
+func TestCredentialSourceServiceListSourcesReturnsEmptySlice(t *testing.T) {
+	svc := NewCredentialSourceService(&nilListSourceStore{memorySourceStore: newMemorySourceStore()}, zap.NewNop())
+
+	records, err := svc.ListSources(context.Background(), "team-1")
+	if err != nil {
+		t.Fatalf("list sources: %v", err)
+	}
+	if records == nil {
+		t.Fatal("records slice is nil, want empty slice")
+	}
+	if len(records) != 0 {
+		t.Fatalf("records = %d, want 0", len(records))
+	}
 }
 
 func TestCredentialSourceServicePutSource(t *testing.T) {

--- a/manager/procd/pkg/file/manager.go
+++ b/manager/procd/pkg/file/manager.go
@@ -230,7 +230,7 @@ func (m *Manager) ListDir(path string) ([]*FileInfo, error) {
 		return nil, err
 	}
 
-	var result []*FileInfo
+	result := make([]*FileInfo, 0, len(entries))
 	for _, entry := range entries {
 		info, err := entry.Info()
 		if err != nil {

--- a/manager/procd/pkg/file/manager_test.go
+++ b/manager/procd/pkg/file/manager_test.go
@@ -492,6 +492,31 @@ func TestListDir(t *testing.T) {
 	}
 }
 
+func TestListDirEmptyReturnsEmptySlice(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "test-file-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	m, err := NewManager(tempDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+
+	entries, err := m.ListDir(".")
+	if err != nil {
+		t.Fatalf("ListDir() failed = %v", err)
+	}
+	if entries == nil {
+		t.Fatal("ListDir() returned nil, want empty slice")
+	}
+	if len(entries) != 0 {
+		t.Fatalf("ListDir() returned %d entries, want 0", len(entries))
+	}
+}
+
 // TestGetRootPath tests GetRootPath returns the configured root.
 func TestGetRootPath(t *testing.T) {
 	tempDir, err := os.MkdirTemp("", "test-file-")

--- a/manager/procd/pkg/http/handlers/context.go
+++ b/manager/procd/pkg/http/handlers/context.go
@@ -219,7 +219,7 @@ func processDoneMessage(exitEvent *process.ExitEvent, proc process.Process) (wsD
 func (h *ContextHandler) List(w http.ResponseWriter, r *http.Request) {
 	contexts := h.manager.ListContexts()
 
-	var response []ContextResponse
+	response := make([]ContextResponse, 0, len(contexts))
 	for _, ctx := range contexts {
 		response = append(response, newContextResponse(ctx, ""))
 	}

--- a/manager/procd/pkg/http/handlers/context_test.go
+++ b/manager/procd/pkg/http/handlers/context_test.go
@@ -127,6 +127,36 @@ func newHandlerWithContext(proc process.Process, processType process.ProcessType
 	return NewContextHandler(manager, zap.NewNop()), ctx
 }
 
+func TestListContextsReturnsEmptyArray(t *testing.T) {
+	handler := NewContextHandler(ctxpkg.NewManager(), zap.NewNop())
+	req := httptest.NewRequest(http.MethodGet, "/contexts", nil)
+	rec := httptest.NewRecorder()
+
+	handler.List(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var payload struct {
+		Success bool `json:"success"`
+		Data    struct {
+			Contexts []ContextResponse `json:"contexts"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !payload.Success {
+		t.Fatal("success = false, want true")
+	}
+	if payload.Data.Contexts == nil {
+		t.Fatal("contexts slice is nil, want empty array")
+	}
+	if len(payload.Data.Contexts) != 0 {
+		t.Fatalf("contexts = %d, want 0", len(payload.Data.Contexts))
+	}
+}
+
 func TestExecInputSync_PromptBeforeOutputReturnsEmpty(t *testing.T) {
 	outputCh := make(chan process.ProcessOutput, 2)
 	proc := &fakeProcess{

--- a/manager/procd/pkg/http/handlers/file_test.go
+++ b/manager/procd/pkg/http/handlers/file_test.go
@@ -1,0 +1,51 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	filepkg "github.com/sandbox0-ai/sandbox0/manager/procd/pkg/file"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
+	"go.uber.org/zap"
+)
+
+func TestListFilesReturnsEmptyArray(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "test-file-handler-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	manager, err := filepkg.NewManager(tempDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer manager.Close()
+
+	handler := NewFileHandler(manager, zap.NewNop())
+	req := httptest.NewRequest(http.MethodGet, "/files/list?path=.", nil)
+	rec := httptest.NewRecorder()
+
+	handler.List(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	resp, apiErr, err := spec.DecodeResponse[struct {
+		Entries []*filepkg.FileInfo `json:"entries"`
+	}](rec.Body)
+	if err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if apiErr != nil {
+		t.Fatalf("unexpected api error: %+v", apiErr)
+	}
+	if resp.Entries == nil {
+		t.Fatal("entries slice is nil, want empty array")
+	}
+	if len(resp.Entries) != 0 {
+		t.Fatalf("entries = %d, want 0", len(resp.Entries))
+	}
+}

--- a/pkg/egressauth/repository.go
+++ b/pkg/egressauth/repository.go
@@ -332,7 +332,7 @@ func (r *Repository) ListSourceMetadata(ctx context.Context, teamID string) ([]C
 	}
 	defer rows.Close()
 
-	var out []CredentialSourceMetadata
+	out := make([]CredentialSourceMetadata, 0)
 	for rows.Next() {
 		record, err := r.scanSourceMetadata(rows)
 		if err != nil {

--- a/pkg/gateway/apikey/repository.go
+++ b/pkg/gateway/apikey/repository.go
@@ -126,7 +126,7 @@ func (r *Repository) GetAPIKeysByTeamID(ctx context.Context, teamID string) ([]*
 	}
 	defer rows.Close()
 
-	var keys []*APIKey
+	keys := make([]*APIKey, 0)
 	for rows.Next() {
 		var key APIKey
 		var rolesJSON []byte
@@ -141,6 +141,9 @@ func (r *Repository) GetAPIKeysByTeamID(ctx context.Context, teamID string) ([]*
 			return nil, err
 		}
 		keys = append(keys, &key)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate api keys: %w", err)
 	}
 	return keys, nil
 }
@@ -159,7 +162,7 @@ func (r *Repository) GetAPIKeysByUserID(ctx context.Context, userID string) ([]*
 	}
 	defer rows.Close()
 
-	var keys []*APIKey
+	keys := make([]*APIKey, 0)
 	for rows.Next() {
 		var key APIKey
 		var rolesJSON []byte
@@ -174,6 +177,9 @@ func (r *Repository) GetAPIKeysByUserID(ctx context.Context, userID string) ([]*
 			return nil, err
 		}
 		keys = append(keys, &key)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate api keys: %w", err)
 	}
 	return keys, nil
 }

--- a/pkg/gateway/http/handlers/apikey.go
+++ b/pkg/gateway/http/handlers/apikey.go
@@ -67,6 +67,9 @@ func (h *APIKeyHandler) ListAPIKeys(c *gin.Context) {
 		return
 	}
 	keys = filterVisibleAPIKeys(authCtx, keys)
+	if keys == nil {
+		keys = []*apikey.APIKey{}
+	}
 
 	spec.JSONSuccess(c, http.StatusOK, gin.H{"api_keys": keys})
 }

--- a/pkg/gateway/http/handlers/apikey_test.go
+++ b/pkg/gateway/http/handlers/apikey_test.go
@@ -298,6 +298,38 @@ func TestDeleteAPIKeyRejectsPlatformKeyForTeamAdmin(t *testing.T) {
 	}
 }
 
+func TestListAPIKeysReturnsEmptyArray(t *testing.T) {
+	t.Setenv("GIN_MODE", "release")
+	gin.SetMode(gin.ReleaseMode)
+
+	authCtx := &authn.AuthContext{
+		AuthMethod: authn.AuthMethodJWT,
+		TeamID:     "team-1",
+		UserID:     "user-1",
+		TeamRole:   "admin",
+	}
+	rec := performListAPIKeysRequest(t, &fakeAPIKeyStore{}, authCtx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	resp, apiErr, err := spec.DecodeResponse[struct {
+		APIKeys []*apikey.APIKey `json:"api_keys"`
+	}](rec.Body)
+	if err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if apiErr != nil {
+		t.Fatalf("unexpected api error: %+v", apiErr)
+	}
+	if resp.APIKeys == nil {
+		t.Fatal("api_keys slice is nil, want empty array")
+	}
+	if len(resp.APIKeys) != 0 {
+		t.Fatalf("api_keys = %d, want 0", len(resp.APIKeys))
+	}
+}
+
 func TestCreateAPIKeyRejectsRoleEscalation(t *testing.T) {
 	t.Setenv("GIN_MODE", "release")
 	gin.SetMode(gin.ReleaseMode)
@@ -418,6 +450,26 @@ func performDeleteAPIKeyRequest(t *testing.T, store apiKeyStore, authCtx *authn.
 	return rec
 }
 
+func performListAPIKeysRequest(t *testing.T, store apiKeyStore, authCtx *authn.AuthContext) *httptest.ResponseRecorder {
+	t.Helper()
+
+	handler := &APIKeyHandler{
+		keys:   store,
+		logger: zap.NewNop(),
+	}
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("auth_context", authCtx)
+		c.Next()
+	})
+	router.GET("/api-keys", handler.ListAPIKeys)
+
+	req := httptest.NewRequest(http.MethodGet, "/api-keys", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	return rec
+}
+
 type fakeAPIKeyStore struct {
 	key              *apikey.APIKey
 	createdScope     string
@@ -445,10 +497,16 @@ func (s *fakeAPIKeyStore) CreateAPIKey(_ context.Context, teamID, _ string, user
 }
 
 func (s *fakeAPIKeyStore) GetAPIKeysByTeamID(context.Context, string) ([]*apikey.APIKey, error) {
+	if s.key == nil {
+		return nil, nil
+	}
 	return []*apikey.APIKey{s.key}, nil
 }
 
 func (s *fakeAPIKeyStore) GetAPIKeysByUserID(context.Context, string) ([]*apikey.APIKey, error) {
+	if s.key == nil {
+		return nil, nil
+	}
 	return []*apikey.APIKey{s.key}, nil
 }
 

--- a/pkg/gateway/http/handlers/team.go
+++ b/pkg/gateway/http/handlers/team.go
@@ -412,6 +412,9 @@ func (h *TeamHandler) ListTeamMembers(c *gin.Context) {
 		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to get members")
 		return
 	}
+	if members == nil {
+		members = []*identity.TeamMemberWithUser{}
+	}
 
 	spec.JSONSuccess(c, http.StatusOK, gin.H{"members": members})
 }

--- a/pkg/gateway/http/handlers/team_test.go
+++ b/pkg/gateway/http/handlers/team_test.go
@@ -422,6 +422,35 @@ func TestTeamHandlerListTeamMembersUsesSearchQuery(t *testing.T) {
 	}
 }
 
+func TestTeamHandlerListTeamMembersSearchReturnsEmptyArray(t *testing.T) {
+	ownerID := "user-owner"
+	repo := newTeamManagementRepo(ownerID)
+
+	rec := performTeamManagementRequest(t, repo, ownerID, http.MethodGet, "/teams/team-1/members?query=missing", nil)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	resp, apiErr, err := spec.DecodeResponse[struct {
+		Members []*identity.TeamMemberWithUser `json:"members"`
+	}](rec.Body)
+	if err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if apiErr != nil {
+		t.Fatalf("unexpected api error: %+v", apiErr)
+	}
+	if resp.Members == nil {
+		t.Fatal("members slice is nil, want empty array")
+	}
+	if len(resp.Members) != 0 {
+		t.Fatalf("members = %d, want 0", len(resp.Members))
+	}
+	if repo.searchTeamID != "team-1" || repo.searchQuery != "missing" {
+		t.Fatalf("search = (%q, %q), want (team-1, missing)", repo.searchTeamID, repo.searchQuery)
+	}
+}
+
 func TestTeamHandlerUpdateTeamMemberRejectsOwnerDemotion(t *testing.T) {
 	ownerID := "user-owner"
 	callerID := "user-admin"

--- a/pkg/gateway/identity/team_repository.go
+++ b/pkg/gateway/identity/team_repository.go
@@ -300,7 +300,7 @@ func (r *Repository) SearchTeamMembers(ctx context.Context, teamID, query string
 
 func scanTeamMembers(rows pgx.Rows) ([]*TeamMemberWithUser, error) {
 	defer rows.Close()
-	var members []*TeamMemberWithUser
+	members := make([]*TeamMemberWithUser, 0)
 	for rows.Next() {
 		var m TeamMemberWithUser
 		if err := rows.Scan(

--- a/storage-proxy/pkg/db/repository.go
+++ b/storage-proxy/pkg/db/repository.go
@@ -263,7 +263,7 @@ func (r *Repository) ListSandboxVolumesByTeam(ctx context.Context, teamID string
 	}
 	defer rows.Close()
 
-	var volumes []*SandboxVolume
+	volumes := make([]*SandboxVolume, 0)
 	for rows.Next() {
 		var v SandboxVolume
 		err := rows.Scan(
@@ -277,6 +277,9 @@ func (r *Repository) ListSandboxVolumesByTeam(ctx context.Context, teamID string
 			return nil, fmt.Errorf("scan sandbox volume: %w", err)
 		}
 		volumes = append(volumes, &v)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate sandbox volumes: %w", err)
 	}
 
 	return volumes, nil
@@ -639,7 +642,7 @@ func (r *Repository) ListSnapshotsByVolume(ctx context.Context, volumeID string)
 	}
 	defer rows.Close()
 
-	var snapshots []*Snapshot
+	snapshots := make([]*Snapshot, 0)
 	for rows.Next() {
 		var s Snapshot
 		err := rows.Scan(
@@ -652,6 +655,9 @@ func (r *Repository) ListSnapshotsByVolume(ctx context.Context, volumeID string)
 			return nil, fmt.Errorf("scan snapshot: %w", err)
 		}
 		snapshots = append(snapshots, &s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate snapshots: %w", err)
 	}
 
 	return snapshots, nil

--- a/storage-proxy/pkg/http/handlers_sandboxvolume.go
+++ b/storage-proxy/pkg/http/handlers_sandboxvolume.go
@@ -206,6 +206,9 @@ func (s *Server) listSandboxVolumes(w http.ResponseWriter, r *http.Request) {
 		_ = spec.WriteError(w, http.StatusInternalServerError, spec.CodeInternal, "internal server error")
 		return
 	}
+	if volumes == nil {
+		volumes = []*db.SandboxVolume{}
+	}
 
 	_ = spec.WriteSuccess(w, http.StatusOK, volumes)
 }

--- a/storage-proxy/pkg/http/handlers_sandboxvolume_test.go
+++ b/storage-proxy/pkg/http/handlers_sandboxvolume_test.go
@@ -107,6 +107,36 @@ func TestCreateSandboxVolumeDefaultsPosixIdentityToRoot(t *testing.T) {
 	}
 }
 
+func TestListSandboxVolumesReturnsEmptyArray(t *testing.T) {
+	server := &Server{
+		logger: logrus.New(),
+		repo:   newFakeHTTPRepo(),
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/sandboxvolumes", nil)
+	req = req.WithContext(internalauth.WithClaims(req.Context(), &internalauth.Claims{TeamID: "team-1", UserID: "user-1"}))
+	recorder := httptest.NewRecorder()
+
+	server.listSandboxVolumes(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	resp, apiErr, err := spec.DecodeResponse[[]db.SandboxVolume](recorder.Body)
+	if err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if apiErr != nil {
+		t.Fatalf("unexpected api error: %+v", apiErr)
+	}
+	if *resp == nil {
+		t.Fatal("volumes slice is nil, want empty array")
+	}
+	if len(*resp) != 0 {
+		t.Fatalf("volumes = %d, want 0", len(*resp))
+	}
+}
+
 func TestCreateSandboxVolumeFromSnapshot(t *testing.T) {
 	repo := newFakeHTTPRepo()
 	snapshotMgr := &fakeHTTPSnapshotManager{}
@@ -138,6 +168,37 @@ func TestCreateSandboxVolumeFromSnapshot(t *testing.T) {
 	}
 	if len(repo.volumes) != 0 {
 		t.Fatalf("expected handler to delegate snapshot-backed create, repo volumes = %d", len(repo.volumes))
+	}
+}
+
+func TestListSnapshotsReturnsEmptyArray(t *testing.T) {
+	server := &Server{
+		logger:      logrus.New(),
+		snapshotMgr: &fakeHTTPSnapshotManager{},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/sandboxvolumes/vol-1/snapshots", nil)
+	req.SetPathValue("volume_id", "vol-1")
+	req = req.WithContext(internalauth.WithClaims(req.Context(), &internalauth.Claims{TeamID: "team-1", UserID: "user-1"}))
+	recorder := httptest.NewRecorder()
+
+	server.listSnapshots(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	resp, apiErr, err := spec.DecodeResponse[[]snapshotResponse](recorder.Body)
+	if err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if apiErr != nil {
+		t.Fatalf("unexpected api error: %+v", apiErr)
+	}
+	if *resp == nil {
+		t.Fatal("snapshots slice is nil, want empty array")
+	}
+	if len(*resp) != 0 {
+		t.Fatalf("snapshots = %d, want 0", len(*resp))
 	}
 }
 

--- a/storage-proxy/pkg/http/handlers_snapshot.go
+++ b/storage-proxy/pkg/http/handlers_snapshot.go
@@ -125,7 +125,7 @@ func (s *Server) listSnapshots(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var responses []snapshotResponse
+	responses := make([]snapshotResponse, 0, len(snapshots))
 	for _, snap := range snapshots {
 		resp := snapshotResponse{
 			ID:          snap.ID,


### PR DESCRIPTION
## Summary

- return non-null empty arrays for empty sandbox volume, credential source, snapshot, API key, context, file, and team member lists
- initialize list slices at repository/service/handler boundaries where these responses are built
- add regression tests for the empty-array response shapes

Fixes #487
Fixes #488
Fixes #491
Fixes #492
Fixes #528
Fixes #531
Fixes #532

## Tests

```bash
make proto
go test ./storage-proxy/pkg/http ./storage-proxy/pkg/db ./manager/pkg/service ./manager/procd/pkg/file ./manager/procd/pkg/http/handlers ./pkg/egressauth ./pkg/gateway/apikey ./pkg/gateway/http/handlers ./pkg/gateway/identity
```
