### PR TITLE
Fix RBAC and registry credential scope gaps

### DIFF
--- a/cluster-gateway/pkg/http/handlers_procd_authz_test.go
+++ b/cluster-gateway/pkg/http/handlers_procd_authz_test.go
@@ -1,0 +1,157 @@
+package http
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sandbox0-ai/sandbox0/cluster-gateway/pkg/middleware"
+	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
+	gatewayauthn "github.com/sandbox0-ai/sandbox0/pkg/gateway/authn"
+	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+	"go.uber.org/zap"
+)
+
+func TestSandboxProcdRoutesRequireReadWritePermissions(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	baseURL, incomingGen, cleanup := newSandboxProcdRoutePermissionTestServer(t)
+	defer cleanup()
+
+	tests := []struct {
+		name        string
+		method      string
+		path        string
+		permissions []string
+	}{
+		{
+			name:        "context create requires sandbox write",
+			method:      http.MethodPost,
+			path:        "/api/v1/sandboxes/sb-1/contexts",
+			permissions: []string{gatewayauthn.PermSandboxRead},
+		},
+		{
+			name:        "context delete requires sandbox write",
+			method:      http.MethodDelete,
+			path:        "/api/v1/sandboxes/sb-1/contexts/ctx-1",
+			permissions: []string{gatewayauthn.PermSandboxRead},
+		},
+		{
+			name:        "context exec requires sandbox write",
+			method:      http.MethodPost,
+			path:        "/api/v1/sandboxes/sb-1/contexts/ctx-1/exec",
+			permissions: []string{gatewayauthn.PermSandboxRead},
+		},
+		{
+			name:        "context websocket requires sandbox write",
+			method:      http.MethodGet,
+			path:        "/api/v1/sandboxes/sb-1/contexts/ctx-1/ws",
+			permissions: []string{gatewayauthn.PermSandboxRead},
+		},
+		{
+			name:        "context list requires sandbox read",
+			method:      http.MethodGet,
+			path:        "/api/v1/sandboxes/sb-1/contexts",
+			permissions: []string{gatewayauthn.PermSandboxWrite},
+		},
+		{
+			name:        "file write requires sandbox write",
+			method:      http.MethodPost,
+			path:        "/api/v1/sandboxes/sb-1/files?path=/tmp/a.txt",
+			permissions: []string{gatewayauthn.PermSandboxRead},
+		},
+		{
+			name:        "file delete requires sandbox write",
+			method:      http.MethodDelete,
+			path:        "/api/v1/sandboxes/sb-1/files?path=/tmp/a.txt",
+			permissions: []string{gatewayauthn.PermSandboxRead},
+		},
+		{
+			name:        "file move requires sandbox write",
+			method:      http.MethodPost,
+			path:        "/api/v1/sandboxes/sb-1/files/move",
+			permissions: []string{gatewayauthn.PermSandboxRead},
+		},
+		{
+			name:        "file list requires sandbox read",
+			method:      http.MethodGet,
+			path:        "/api/v1/sandboxes/sb-1/files/list?path=/tmp",
+			permissions: []string{gatewayauthn.PermSandboxWrite},
+		},
+	}
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest(tt.method, baseURL+tt.path, strings.NewReader(`{}`))
+			if err != nil {
+				t.Fatalf("new request: %v", err)
+			}
+			req.Header.Set(internalauth.DefaultTokenHeader, newSandboxProcdRouteInternalToken(t, incomingGen, tt.permissions...))
+
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatalf("do request: %v", err)
+			}
+			defer resp.Body.Close()
+			_, _ = io.Copy(io.Discard, resp.Body)
+
+			if resp.StatusCode != http.StatusForbidden {
+				t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+			}
+		})
+	}
+}
+
+func newSandboxProcdRoutePermissionTestServer(t *testing.T) (string, *internalauth.Generator, func()) {
+	t.Helper()
+
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate ed25519 keypair: %v", err)
+	}
+
+	logger := zap.NewNop()
+	validator := internalauth.NewValidator(internalauth.ValidatorConfig{
+		Target:             "cluster-gateway",
+		PublicKey:          publicKey,
+		AllowedCallers:     []string{"regional-gateway"},
+		ClockSkewTolerance: 5 * time.Second,
+	})
+	incomingGen := internalauth.NewGenerator(internalauth.GeneratorConfig{
+		Caller:     "regional-gateway",
+		PrivateKey: privateKey,
+		TTL:        time.Minute,
+	})
+	server := &Server{
+		cfg:            &config.ClusterGatewayConfig{AuthMode: authModeInternal},
+		authMiddleware: middleware.NewInternalAuthMiddleware(validator, logger),
+		logger:         logger,
+	}
+	server.router = gin.New()
+	v1 := server.router.Group("/api/v1")
+	v1.Use(server.authMiddleware.Authenticate())
+	sandboxes := v1.Group("/sandboxes")
+	server.registerSandboxProcdRoutes(sandboxes)
+
+	gateway := httptest.NewServer(server.router)
+	return gateway.URL, incomingGen, gateway.Close
+}
+
+func newSandboxProcdRouteInternalToken(t *testing.T, gen *internalauth.Generator, permissions ...string) string {
+	t.Helper()
+
+	token, err := gen.Generate("cluster-gateway", "team-1", "user-1", internalauth.GenerateOptions{
+		Permissions: permissions,
+	})
+	if err != nil {
+		t.Fatalf("generate internal token: %v", err)
+	}
+	return token
+}

--- a/cluster-gateway/pkg/http/server.go
+++ b/cluster-gateway/pkg/http/server.go
@@ -369,33 +369,7 @@ func (s *Server) setupRoutes() {
 			sandboxes.GET("/:id/services", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxRead), s.proxySandboxManagerSubresource("services"))
 			sandboxes.PUT("/:id/services", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxWrite), s.proxySandboxManagerSubresource("services"))
 
-			// === Process/Context Management (→ Procd) ===
-			contexts := sandboxes.Group("/:id/contexts")
-			{
-				contexts.POST("", s.createContext)
-				contexts.GET("", s.listContexts)
-				contexts.GET("/:ctx_id", s.getContext)
-				contexts.DELETE("/:ctx_id", s.deleteContext)
-				contexts.POST("/:ctx_id/restart", s.restartContext)
-				contexts.POST("/:ctx_id/input", s.contextInput)
-				contexts.POST("/:ctx_id/exec", s.contextExec)
-				contexts.POST("/:ctx_id/resize", s.contextResize)
-				contexts.POST("/:ctx_id/signal", s.contextSignal)
-				contexts.GET("/:ctx_id/stats", s.contextStats)
-				contexts.GET("/:ctx_id/ws", s.contextWebSocket)
-			}
-
-			// === File System (→ Procd) ===
-			files := sandboxes.Group("/:id/files")
-			{
-				files.GET("", s.handleFileOperation)
-				files.POST("", s.handleFileOperation)
-				files.DELETE("", s.handleFileOperation)
-				files.GET("/watch", s.handleFileWatch)
-				files.POST("/move", s.handleFileMove)
-				files.GET("/stat", s.handleFileStat)
-				files.GET("/list", s.handleFileList)
-			}
+			s.registerSandboxProcdRoutes(sandboxes)
 		}
 
 		// === Template Management (→ Manager) ===
@@ -486,6 +460,36 @@ func (s *Server) setupRoutes() {
 
 	// Host-based public exposure fallback (for non-/api paths)
 	s.router.NoRoute(s.handlePublicExposureNoRoute)
+}
+
+func (s *Server) registerSandboxProcdRoutes(sandboxes *gin.RouterGroup) {
+	// === Process/Context Management (→ Procd) ===
+	contexts := sandboxes.Group("/:id/contexts")
+	{
+		contexts.POST("", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxWrite), s.createContext)
+		contexts.GET("", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxRead), s.listContexts)
+		contexts.GET("/:ctx_id", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxRead), s.getContext)
+		contexts.DELETE("/:ctx_id", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxWrite), s.deleteContext)
+		contexts.POST("/:ctx_id/restart", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxWrite), s.restartContext)
+		contexts.POST("/:ctx_id/input", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxWrite), s.contextInput)
+		contexts.POST("/:ctx_id/exec", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxWrite), s.contextExec)
+		contexts.POST("/:ctx_id/resize", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxWrite), s.contextResize)
+		contexts.POST("/:ctx_id/signal", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxWrite), s.contextSignal)
+		contexts.GET("/:ctx_id/stats", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxRead), s.contextStats)
+		contexts.GET("/:ctx_id/ws", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxWrite), s.contextWebSocket)
+	}
+
+	// === File System (→ Procd) ===
+	files := sandboxes.Group("/:id/files")
+	{
+		files.GET("", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxRead), s.handleFileOperation)
+		files.POST("", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxWrite), s.handleFileOperation)
+		files.DELETE("", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxWrite), s.handleFileOperation)
+		files.GET("/watch", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxRead), s.handleFileWatch)
+		files.POST("/move", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxWrite), s.handleFileMove)
+		files.GET("/stat", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxRead), s.handleFileStat)
+		files.GET("/list", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxRead), s.handleFileList)
+	}
 }
 
 func (s *Server) setupInternalControlPlaneRoutes() {

--- a/manager/pkg/http/handlers_registry.go
+++ b/manager/pkg/http/handlers_registry.go
@@ -41,6 +41,10 @@ func (s *Server) getRegistryCredentials(c *gin.Context) {
 			spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "registry provider is not configured")
 			return
 		}
+		if errors.Is(err, registry.ErrInvalidTargetImage) {
+			spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
+			return
+		}
 		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to get registry credentials")
 		return
 	}

--- a/manager/pkg/http/handlers_registry_test.go
+++ b/manager/pkg/http/handlers_registry_test.go
@@ -1,0 +1,45 @@
+package http
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/registry"
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/service"
+	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+	"go.uber.org/zap"
+)
+
+func TestGetRegistryCredentialsReturnsBadRequestForInvalidTarget(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	server := &Server{
+		registryService: service.NewRegistryService(registryProviderFunc(func(context.Context, registry.PushCredentialsRequest) (*registry.Credential, error) {
+			return nil, registry.ErrInvalidTargetImage
+		}), zap.NewNop()),
+		logger: zap.NewNop(),
+	}
+	router := gin.New()
+	router.POST("/api/v1/registry/credentials", server.getRegistryCredentials)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/registry/credentials", strings.NewReader(`{"targetImage":"t-other/probe:v1"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(internalauth.WithClaims(req.Context(), &internalauth.Claims{TeamID: "team-1"}))
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+}
+
+type registryProviderFunc func(context.Context, registry.PushCredentialsRequest) (*registry.Credential, error)
+
+func (f registryProviderFunc) GetPushCredentials(ctx context.Context, req registry.PushCredentialsRequest) (*registry.Credential, error) {
+	return f(ctx, req)
+}

--- a/manager/pkg/registry/aws.go
+++ b/manager/pkg/registry/aws.go
@@ -358,18 +358,18 @@ func resolveAWSTargetRepository(teamID, targetImage string) (string, error) {
 
 	_, repository, err := naming.SplitImageReference(trimmedTarget)
 	if err != nil {
-		return "", fmt.Errorf("invalid aws target image: %w", err)
+		return "", fmt.Errorf("%w: invalid aws target image: %v", ErrInvalidTargetImage, err)
 	}
 	prefix := naming.TeamImageRepositoryPrefix(teamID)
 	if prefix == "" {
-		return "", fmt.Errorf("aws target image requires team id")
+		return "", fmt.Errorf("%w: aws target image requires team id", ErrInvalidTargetImage)
 	}
 	if repository == prefix || strings.HasPrefix(repository, prefix+"/") {
 		return repository, nil
 	}
 	firstSegment, _, _ := strings.Cut(repository, "/")
 	if strings.HasPrefix(firstSegment, "t-") {
-		return "", fmt.Errorf("target image %q is outside team registry prefix %q", targetImage, prefix)
+		return "", fmt.Errorf("%w: target image %q is outside team registry prefix %q", ErrInvalidTargetImage, targetImage, prefix)
 	}
 	return prefix + "/" + repository, nil
 }

--- a/manager/pkg/registry/provider.go
+++ b/manager/pkg/registry/provider.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -28,6 +29,10 @@ type PushCredentialsRequest struct {
 	TeamID      string
 	TargetImage string
 }
+
+// ErrInvalidTargetImage indicates the requested image cannot be served by the
+// current team-scoped registry credential flow.
+var ErrInvalidTargetImage = errors.New("invalid target image")
 
 // Provider returns short-lived registry credentials.
 type Provider interface {
@@ -202,6 +207,9 @@ func (p *builtinProvider) GetPushCredentials(ctx context.Context, req PushCreden
 	if strings.TrimSpace(p.registry) == "" {
 		return nil, fmt.Errorf("builtin push registry is required")
 	}
+	if err := validateBuiltinTargetImage(req.TeamID, req.TargetImage, p.registry); err != nil {
+		return nil, err
+	}
 	username := strings.TrimSpace(p.cfg.Username)
 	password := strings.TrimSpace(p.cfg.Password)
 	if username == "" || password == "" {
@@ -221,4 +229,32 @@ func (p *builtinProvider) GetPushCredentials(ctx context.Context, req PushCreden
 		Username:     username,
 		Password:     password,
 	}, nil
+}
+
+func validateBuiltinTargetImage(teamID, targetImage, registryHost string) error {
+	trimmedTarget := strings.TrimSpace(targetImage)
+	if trimmedTarget == "" {
+		return fmt.Errorf("%w: targetImage is required for builtin registry credentials", ErrInvalidTargetImage)
+	}
+
+	prefix := naming.TeamImageRepositoryPrefix(teamID)
+	if prefix == "" {
+		return fmt.Errorf("%w: team id is required for builtin registry credentials", ErrInvalidTargetImage)
+	}
+
+	registryHostFromTarget, repository, err := naming.SplitImageReference(trimmedTarget)
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrInvalidTargetImage, err)
+	}
+	if registryHostFromTarget != "" && naming.NormalizeRegistryHost(registryHostFromTarget) != naming.NormalizeRegistryHost(registryHost) {
+		return fmt.Errorf("%w: target image %q is outside builtin registry %q", ErrInvalidTargetImage, targetImage, naming.NormalizeRegistryHost(registryHost))
+	}
+	if repository == prefix || strings.HasPrefix(repository, prefix+"/") {
+		return nil
+	}
+	firstSegment, _, _ := strings.Cut(repository, "/")
+	if strings.HasPrefix(firstSegment, "t-") {
+		return fmt.Errorf("%w: target image %q is outside team registry prefix %q", ErrInvalidTargetImage, targetImage, prefix)
+	}
+	return nil
 }

--- a/manager/pkg/registry/provider_direct_test.go
+++ b/manager/pkg/registry/provider_direct_test.go
@@ -28,7 +28,7 @@ func TestNewProvider_BuiltinWithDirectCredentials(t *testing.T) {
 		t.Fatal("NewProvider returned nil provider")
 	}
 
-	cred, err := p.GetPushCredentials(context.Background(), PushCredentialsRequest{TeamID: "team-1"})
+	cred, err := p.GetPushCredentials(context.Background(), PushCredentialsRequest{TeamID: "team-1", TargetImage: "my-app:v1"})
 	if err != nil {
 		t.Fatalf("GetPushCredentials returned error: %v", err)
 	}
@@ -45,6 +45,67 @@ func TestNewProvider_BuiltinWithDirectCredentials(t *testing.T) {
 	}
 	if cred.Username != "u" || cred.Password != "p" {
 		t.Fatalf("unexpected credentials: %s/%s", cred.Username, cred.Password)
+	}
+}
+
+func TestNewProvider_BuiltinAllowsTeamScopedTargetImages(t *testing.T) {
+	p, err := NewProvider(config.RegistryConfig{
+		Provider:     "builtin",
+		PushRegistry: "registry.example.com",
+		Builtin: &config.RegistryBuiltinConfig{
+			Username: "u",
+			Password: "p",
+		},
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("NewProvider returned error: %v", err)
+	}
+
+	prefix := naming.TeamImageRepositoryPrefix("team-1")
+	tests := []string{
+		"my-app:v1",
+		prefix + "/my-app:v1",
+		"registry.example.com/" + prefix + "/my-app:v1",
+	}
+	for _, targetImage := range tests {
+		t.Run(targetImage, func(t *testing.T) {
+			cred, err := p.GetPushCredentials(context.Background(), PushCredentialsRequest{TeamID: "team-1", TargetImage: targetImage})
+			if err != nil {
+				t.Fatalf("GetPushCredentials returned error: %v", err)
+			}
+			if cred.Provider != "builtin" {
+				t.Fatalf("unexpected provider: %s", cred.Provider)
+			}
+		})
+	}
+}
+
+func TestNewProvider_BuiltinRejectsOutOfScopeTargets(t *testing.T) {
+	p, err := NewProvider(config.RegistryConfig{
+		Provider:     "builtin",
+		PushRegistry: "registry.example.com",
+		Builtin: &config.RegistryBuiltinConfig{
+			Username: "u",
+			Password: "p",
+		},
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("NewProvider returned error: %v", err)
+	}
+
+	tests := []string{
+		"",
+		"t-other/probe:v1",
+		"registry.example.com/t-other/probe:v1",
+		"other-registry.example.com/my-app:v1",
+	}
+	for _, targetImage := range tests {
+		t.Run(targetImage, func(t *testing.T) {
+			_, err := p.GetPushCredentials(context.Background(), PushCredentialsRequest{TeamID: "team-1", TargetImage: targetImage})
+			if !errors.Is(err, ErrInvalidTargetImage) {
+				t.Fatalf("error = %v, want ErrInvalidTargetImage", err)
+			}
+		})
 	}
 }
 

--- a/pkg/gateway/authn/context.go
+++ b/pkg/gateway/authn/context.go
@@ -72,6 +72,8 @@ const (
 
 	PermRegistryWrite = "registry:write"
 
+	PermAPIKeyManage = "apikey:manage"
+
 	PermCredentialSourceRead   = "credentialsource:read"
 	PermCredentialSourceWrite  = "credentialsource:write"
 	PermCredentialSourceDelete = "credentialsource:delete"
@@ -100,6 +102,7 @@ var RolePermissions = map[string][]string{
 		PermTemplateWrite,
 		PermTemplateDelete,
 		PermRegistryWrite,
+		PermAPIKeyManage,
 		PermCredentialSourceRead,
 		PermCredentialSourceWrite,
 		PermCredentialSourceDelete,

--- a/pkg/gateway/authn/context_test.go
+++ b/pkg/gateway/authn/context_test.go
@@ -51,6 +51,28 @@ func TestRolePermissionsIncludeRegistryWrite(t *testing.T) {
 	}
 }
 
+func TestRolePermissionsIncludeAPIKeyManageForAdminsOnly(t *testing.T) {
+	tests := []struct {
+		role string
+		want bool
+	}{
+		{role: "admin", want: true},
+		{role: "developer", want: false},
+		{role: "builder", want: false},
+		{role: "viewer", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.role, func(t *testing.T) {
+			permissions := ExpandRolePermissions(tt.role)
+			got := containsPermission(permissions, PermAPIKeyManage)
+			if got != tt.want {
+				t.Fatalf("api key manage permission = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func containsPermission(permissions []string, target string) bool {
 	for _, permission := range permissions {
 		if permission == target {

--- a/pkg/gateway/http/handlers/apikey.go
+++ b/pkg/gateway/http/handlers/apikey.go
@@ -50,6 +50,10 @@ func (h *APIKeyHandler) ListAPIKeys(c *gin.Context) {
 		spec.JSONError(c, http.StatusUnauthorized, spec.CodeUnauthorized, "not authenticated")
 		return
 	}
+	if !canManageTeamAPIKeys(authCtx) {
+		spec.JSONError(c, http.StatusForbidden, spec.CodeForbidden, "API key management requires team admin access")
+		return
+	}
 
 	// Get keys for the current team or user
 	var keys []*apikey.APIKey
@@ -141,6 +145,10 @@ func (h *APIKeyHandler) CreateAPIKey(c *gin.Context) {
 	authCtx := middleware.GetAuthContext(c)
 	if authCtx == nil || authCtx.UserID == "" {
 		spec.JSONError(c, http.StatusUnauthorized, spec.CodeUnauthorized, "not authenticated")
+		return
+	}
+	if !canManageTeamAPIKeys(authCtx) {
+		spec.JSONError(c, http.StatusForbidden, spec.CodeForbidden, "API key management requires team admin access")
 		return
 	}
 
@@ -254,6 +262,10 @@ func (h *APIKeyHandler) DeleteAPIKey(c *gin.Context) {
 		spec.JSONError(c, http.StatusUnauthorized, spec.CodeUnauthorized, "not authenticated")
 		return
 	}
+	if !canManageTeamAPIKeys(authCtx) {
+		spec.JSONError(c, http.StatusForbidden, spec.CodeForbidden, "API key management requires team admin access")
+		return
+	}
 
 	keyID := c.Param("id")
 
@@ -298,6 +310,10 @@ func (h *APIKeyHandler) DeactivateAPIKey(c *gin.Context) {
 	authCtx := middleware.GetAuthContext(c)
 	if authCtx == nil || authCtx.UserID == "" {
 		spec.JSONError(c, http.StatusUnauthorized, spec.CodeUnauthorized, "not authenticated")
+		return
+	}
+	if !canManageTeamAPIKeys(authCtx) {
+		spec.JSONError(c, http.StatusForbidden, spec.CodeForbidden, "API key management requires team admin access")
 		return
 	}
 
@@ -397,6 +413,10 @@ func canGrantAPIKeyRoles(authCtx *authn.AuthContext, roles []string) bool {
 
 func canManagePlatformAPIKeys(authCtx *authn.AuthContext) bool {
 	return authCtx != nil && authCtx.AuthMethod == authn.AuthMethodJWT && authCtx.IsSystemAdmin
+}
+
+func canManageTeamAPIKeys(authCtx *authn.AuthContext) bool {
+	return authCtx != nil && authCtx.AuthMethod == authn.AuthMethodJWT && authCtx.HasPermission(authn.PermAPIKeyManage)
 }
 
 func filterVisibleAPIKeys(authCtx *authn.AuthContext, keys []*apikey.APIKey) []*apikey.APIKey {

--- a/pkg/gateway/public/routes.go
+++ b/pkg/gateway/public/routes.go
@@ -173,6 +173,7 @@ func RegisterAPIKeyRoutes(router gin.IRouter, deps Deps) {
 		apiKeys := router.Group("/api-keys")
 		apiKeys.Use(deps.AuthMiddleware.Authenticate())
 		apiKeys.Use(deps.AuthMiddleware.RequireJWTAuth())
+		apiKeys.Use(deps.AuthMiddleware.RequirePermission(authn.PermAPIKeyManage))
 		{
 			apiKeys.GET("", apiKeyHandler.ListAPIKeys)
 			apiKeys.POST("", apiKeyHandler.CreateAPIKey)

--- a/pkg/gateway/public/routes_test.go
+++ b/pkg/gateway/public/routes_test.go
@@ -1,6 +1,9 @@
 package public
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -8,6 +11,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/apikey"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/authn"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/middleware"
+	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"go.uber.org/zap"
 )
 
@@ -89,6 +93,50 @@ func TestRegisterAPIKeyRoutesOnlyMountsRegionalAPIKeySurface(t *testing.T) {
 	}
 	if hasRoute(router, "POST", "/auth/login") {
 		t.Fatal("expected regional API key routes to omit /auth/login")
+	}
+}
+
+func TestRegisterAPIKeyRoutesRejectViewerJWTForManagement(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	deps := testDeps()
+	router := gin.New()
+	RegisterAPIKeyRoutes(router, deps)
+
+	tokens, err := deps.JWTIssuer.IssueTokenPair("user-1", "viewer@example.com", "Viewer", false, []authn.TeamGrant{
+		{TeamID: "team-1", TeamRole: "viewer", HomeRegionID: "aws-us-east-1"},
+	})
+	if err != nil {
+		t.Fatalf("issue token pair: %v", err)
+	}
+
+	tests := []struct {
+		method string
+		path   string
+		body   string
+	}{
+		{method: http.MethodGet, path: "/api-keys"},
+		{method: http.MethodPost, path: "/api-keys", body: `{"name":"viewer-key","roles":["viewer"]}`},
+		{method: http.MethodDelete, path: "/api-keys/key-1"},
+		{method: http.MethodPost, path: "/api-keys/key-1/deactivate"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.method+" "+tt.path, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, tt.path, strings.NewReader(tt.body))
+			if tt.body != "" {
+				req.Header.Set("Content-Type", "application/json")
+			}
+			req.Header.Set("Authorization", "Bearer "+tokens.AccessToken)
+			req.Header.Set(internalauth.TeamIDHeader, "team-1")
+
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusForbidden, rec.Body.String())
+			}
+		})
 	}
 }
 

--- a/regional-gateway/pkg/http/handlers_registry.go
+++ b/regional-gateway/pkg/http/handlers_registry.go
@@ -39,6 +39,10 @@ func (s *Server) getRegistryCredentials(c *gin.Context) {
 	})
 	if err != nil {
 		s.logger.Error("Failed to get registry credentials", zap.Error(err))
+		if errors.Is(err, registryprovider.ErrInvalidTargetImage) {
+			spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
+			return
+		}
 		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to get registry credentials")
 		return
 	}

--- a/regional-gateway/pkg/http/handlers_registry_test.go
+++ b/regional-gateway/pkg/http/handlers_registry_test.go
@@ -97,6 +97,27 @@ func TestRegistryCredentialsRequireRegistryWritePermission(t *testing.T) {
 		}
 	})
 
+	t.Run("invalid target image returns bad request", func(t *testing.T) {
+		registrySpy.reset()
+		registrySpy.setError(registryprovider.ErrInvalidTargetImage)
+		tokens, err := server.jwtIssuer.IssueTokenPair("user-1", "user@example.com", "User", false, []authn.TeamGrant{{TeamID: "team-1", TeamRole: "developer"}})
+		if err != nil {
+			t.Fatalf("issue token pair: %v", err)
+		}
+
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/registry/credentials", strings.NewReader(`{"targetImage":"t-other/my-app:v1"}`))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+tokens.AccessToken)
+		req.Header.Set(internalauth.TeamIDHeader, "team-1")
+
+		rec := httptest.NewRecorder()
+		server.router.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+		}
+	})
+
 	t.Run("invalid json is rejected", func(t *testing.T) {
 		registrySpy.reset()
 		tokens, err := server.jwtIssuer.IssueTokenPair("user-1", "user@example.com", "User", false, []authn.TeamGrant{{TeamID: "team-1", TeamRole: "builder"}})
@@ -121,12 +142,16 @@ func TestRegistryCredentialsRequireRegistryWritePermission(t *testing.T) {
 type registryProviderSpy struct {
 	mu       sync.Mutex
 	requests []registryprovider.PushCredentialsRequest
+	err      error
 }
 
 func (s *registryProviderSpy) GetPushCredentials(_ context.Context, req registryprovider.PushCredentialsRequest) (*registryprovider.Credential, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.requests = append(s.requests, req)
+	if s.err != nil {
+		return nil, s.err
+	}
 	return &registryprovider.Credential{
 		Provider:     "builtin",
 		PushRegistry: "registry.example.com",
@@ -145,6 +170,13 @@ func (s *registryProviderSpy) reset() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.requests = nil
+	s.err = nil
+}
+
+func (s *registryProviderSpy) setError(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.err = err
 }
 
 func (s *registryProviderSpy) teamID() string {


### PR DESCRIPTION
## Summary
- add an explicit `apikey:manage` permission and require team-admin JWT access for API key management routes
- protect procd-backed sandbox context/file routes with `sandbox:read` and `sandbox:write` permissions
- reject builtin registry credential requests with missing or out-of-scope `targetImage` values and map invalid targets to 400

Fixes #533
Fixes #530
Fixes #520

## Tests
- `go test ./pkg/gateway/authn ./pkg/gateway/public ./pkg/gateway/http/handlers ./cluster-gateway/pkg/http ./manager/pkg/registry ./manager/pkg/http ./regional-gateway/pkg/http`

Remote kind validation will be added after deployment.