### PR TITLE
Fix self-hosted SSH key docs path

### DIFF
--- a/docs/self-hosted/configuration/page.mdx
+++ b/docs/self-hosted/configuration/page.mdx
@@ -302,7 +302,7 @@ spec:
             endpointPort: 22
 ```
 
-After exposing the service through DNS or a load balancer, users can upload SSH public keys with `POST /api/v1/users/me/ssh-keys` and connect with standard clients. See [SSH](/docs/sandbox/ssh) for the user-facing flow.
+After exposing the service through DNS or a load balancer, users can upload SSH public keys with `POST /users/me/ssh-keys` and connect with standard clients. See [SSH](/docs/sandbox/ssh) for the user-facing flow.
 
 ### AWS LoadBalancer TLS
 


### PR DESCRIPTION
## Summary

- correct the self-hosted SSH gateway docs to use `POST /users/me/ssh-keys`
- leave sandbox-level stats unchanged because #525 was closed as not a public API bug

Fixes #503

## Tests

- `make apispec`
