### PR TITLE
Default data-plane identity for fullmode storage

### DIFF
--- a/infra-operator/internal/controller/pkg/common/common.go
+++ b/infra-operator/internal/controller/pkg/common/common.go
@@ -42,6 +42,7 @@ import (
 
 	infrav1alpha1 "github.com/sandbox0-ai/sandbox0/infra-operator/api/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 )
 
 type ResourceManager struct {
@@ -406,6 +407,28 @@ func ResolveServicePort(config *infrav1alpha1.ServiceNetworkConfig, fallback int
 		return config.Port
 	}
 	return fallback
+}
+
+// ResolveRegionID returns the canonical region ID used by data-plane services.
+func ResolveRegionID(infra *infrav1alpha1.Sandbox0Infra) string {
+	if infra == nil {
+		return ""
+	}
+	if regionID := strings.TrimSpace(infra.Spec.Region); regionID != "" {
+		return regionID
+	}
+	if infra.Spec.PublicExposure == nil {
+		return ""
+	}
+	return strings.TrimSpace(infra.Spec.PublicExposure.RegionID)
+}
+
+// ResolveClusterID returns the data-plane cluster ID, defaulting single-cluster installs.
+func ResolveClusterID(infra *infrav1alpha1.Sandbox0Infra) string {
+	if infra != nil && infra.Spec.Cluster != nil {
+		return naming.ClusterIDOrDefault(&infra.Spec.Cluster.ID)
+	}
+	return naming.DefaultClusterID
 }
 
 // ResolveSSHEndpoint returns the advertised SSH endpoint for a region when the

--- a/infra-operator/internal/controller/services/ctld/ctld.go
+++ b/infra-operator/internal/controller/services/ctld/ctld.go
@@ -330,6 +330,8 @@ func (r *Reconciler) buildStorageConfig(ctx context.Context, infra *infrav1alpha
 	if infra != nil && infra.Spec.Services != nil && infra.Spec.Services.StorageProxy != nil {
 		cfg = runtimeconfig.ToStorageProxy(infra.Spec.Services.StorageProxy.Config)
 	}
+	cfg.RegionID = common.ResolveRegionID(infra)
+	cfg.DefaultClusterId = common.ResolveClusterID(infra)
 	if infra != nil && infra.Spec.Database != nil && r != nil && r.Resources != nil && r.Resources.Client != nil {
 		if dsn, err := database.GetDatabaseDSN(ctx, r.Resources.Client, infra); err == nil {
 			cfg.DatabaseURL = dsn
@@ -349,12 +351,6 @@ func (r *Reconciler) buildStorageConfig(ctx context.Context, infra *infrav1alpha
 	cfg.S3AccessKey = storageConfig.AccessKey
 	cfg.S3SecretKey = storageConfig.SecretKey
 	cfg.S3SessionToken = storageConfig.SessionToken
-	if infra.Spec.Region != "" {
-		cfg.RegionID = infra.Spec.Region
-	}
-	if infra.Spec.Cluster != nil && infra.Spec.Cluster.ID != "" {
-		cfg.DefaultClusterId = infra.Spec.Cluster.ID
-	}
 	return cfg, nil
 }
 

--- a/infra-operator/internal/controller/services/ctld/ctld_test.go
+++ b/infra-operator/internal/controller/services/ctld/ctld_test.go
@@ -16,6 +16,7 @@ import (
 
 	infrav1alpha1 "github.com/sandbox0-ai/sandbox0/infra-operator/api/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/pkg/common"
+	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 )
 
 func TestReconcileUsesSharedSandboxNodePlacement(t *testing.T) {
@@ -188,6 +189,25 @@ func TestReconcileMountsObjectEncryptionKeyWhenEnabled(t *testing.T) {
 	ds := reconcileCtldDaemonSet(t, infra)
 	assertContainerVolumeMount(t, ds.Spec.Template.Spec.Containers[0].VolumeMounts, "object-encryption-key", common.ObjectEncryptionMountDir)
 	assertPodVolume(t, ds.Spec.Template.Spec.Volumes, "object-encryption-key")
+}
+
+func TestBuildStorageConfigDefaultsDataPlaneIdentity(t *testing.T) {
+	infra := newCtldTestInfra()
+	infra.Spec.PublicExposure = &infrav1alpha1.PublicExposureConfig{
+		RegionID: "aws-us-east-1",
+	}
+
+	reconciler := NewReconciler(common.NewResourceManager(nil, nil, nil, common.LocalDevConfig{}))
+	cfg, err := reconciler.buildStorageConfig(context.Background(), infra)
+	if err != nil {
+		t.Fatalf("buildStorageConfig returned error: %v", err)
+	}
+	if cfg.RegionID != "aws-us-east-1" {
+		t.Fatalf("region_id = %q, want aws-us-east-1", cfg.RegionID)
+	}
+	if cfg.DefaultClusterId != naming.DefaultClusterID {
+		t.Fatalf("default_cluster_id = %q, want %q", cfg.DefaultClusterId, naming.DefaultClusterID)
+	}
 }
 
 func assertContainsArg(t *testing.T, args []string, want string) {

--- a/infra-operator/internal/controller/services/storageproxy/storageproxy.go
+++ b/infra-operator/internal/controller/services/storageproxy/storageproxy.go
@@ -273,9 +273,7 @@ func (r *Reconciler) buildConfig(ctx context.Context, infra *infrav1alpha1.Sandb
 		return nil, err
 	}
 	cfg.MetaURL = metaURL
-	if infra.Spec.Region != "" {
-		cfg.RegionID = infra.Spec.Region
-	}
+	cfg.RegionID = common.ResolveRegionID(infra)
 
 	storageConfig, err := storage.GetStorageConfig(ctx, r.Resources.Client, infra)
 	if err != nil {
@@ -290,9 +288,7 @@ func (r *Reconciler) buildConfig(ctx context.Context, infra *infrav1alpha1.Sandb
 	cfg.S3SecretKey = storageConfig.SecretKey
 	cfg.S3SessionToken = storageConfig.SessionToken
 
-	if infra.Spec.Cluster != nil && infra.Spec.Cluster.ID != "" {
-		cfg.DefaultClusterId = infra.Spec.Cluster.ID
-	}
+	cfg.DefaultClusterId = common.ResolveClusterID(infra)
 
 	return cfg, nil
 }

--- a/infra-operator/internal/controller/services/storageproxy/storageproxy_test.go
+++ b/infra-operator/internal/controller/services/storageproxy/storageproxy_test.go
@@ -15,6 +15,7 @@ import (
 
 	infrav1alpha1 "github.com/sandbox0-ai/sandbox0/infra-operator/api/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/pkg/common"
+	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 )
 
 func TestReconcileUsesServicePortForHTTPServiceExposure(t *testing.T) {
@@ -339,6 +340,76 @@ func TestBuildConfigMapsBuiltinStorageToS3CompatibleType(t *testing.T) {
 	}
 	if cfg.S3Endpoint != "http://demo-rustfs.sandbox0-system.svc:9000" {
 		t.Fatalf("unexpected s3 endpoint: %q", cfg.S3Endpoint)
+	}
+}
+
+func TestBuildConfigDefaultsDataPlaneIdentity(t *testing.T) {
+	infra := &infrav1alpha1.Sandbox0Infra{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fullmode",
+			Namespace: "sandbox0-system",
+		},
+		Spec: infrav1alpha1.Sandbox0InfraSpec{
+			PublicExposure: &infrav1alpha1.PublicExposureConfig{
+				RegionID: "aws-us-east-1",
+			},
+			Database: &infrav1alpha1.DatabaseConfig{
+				Type: infrav1alpha1.DatabaseTypeBuiltin,
+				Builtin: &infrav1alpha1.BuiltinDatabaseConfig{
+					Enabled:  true,
+					Port:     5432,
+					Username: "sandbox0",
+					Database: "sandbox0",
+					SSLMode:  "disable",
+				},
+			},
+			Storage: &infrav1alpha1.StorageConfig{
+				Type: infrav1alpha1.StorageTypeBuiltin,
+				Builtin: &infrav1alpha1.BuiltinStorageConfig{
+					Enabled: true,
+					Bucket:  "sandbox0",
+					Region:  "us-east-1",
+				},
+			},
+		},
+	}
+
+	reconciler, _ := newStorageProxyTestReconciler(t,
+		infra.DeepCopy(),
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "fullmode-sandbox0-database-credentials",
+				Namespace: infra.Namespace,
+			},
+			Data: map[string][]byte{
+				"username": []byte("sandbox0"),
+				"password": []byte("db-password"),
+				"database": []byte("sandbox0"),
+				"port":     []byte("5432"),
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "fullmode-sandbox0-rustfs-credentials",
+				Namespace: infra.Namespace,
+			},
+			Data: map[string][]byte{
+				"endpoint":          []byte("http://fullmode-rustfs.sandbox0-system.svc:9000"),
+				"RUSTFS_ACCESS_KEY": []byte("access-key"),
+				"RUSTFS_SECRET_KEY": []byte("secret-key"),
+			},
+		},
+	)
+
+	cfg, err := reconciler.buildConfig(context.Background(), infra)
+	if err != nil {
+		t.Fatalf("buildConfig returned error: %v", err)
+	}
+	if cfg.RegionID != "aws-us-east-1" {
+		t.Fatalf("region_id = %q, want aws-us-east-1", cfg.RegionID)
+	}
+	if cfg.DefaultClusterId != naming.DefaultClusterID {
+		t.Fatalf("default_cluster_id = %q, want %q", cfg.DefaultClusterId, naming.DefaultClusterID)
 	}
 }
 

--- a/infra-operator/internal/plan/plan.go
+++ b/infra-operator/internal/plan/plan.go
@@ -379,10 +379,8 @@ func compileManagerPlan(infra *infrav1alpha1.Sandbox0Infra, compiled *InfraPlan)
 		managerPlan.NetworkPolicyProvider = "netd"
 	}
 	if infra != nil {
-		managerPlan.RegionID = infra.Spec.Region
-		if infra.Spec.Cluster != nil {
-			managerPlan.DefaultClusterID = infra.Spec.Cluster.ID
-		}
+		managerPlan.RegionID = common.ResolveRegionID(infra)
+		managerPlan.DefaultClusterID = common.ResolveClusterID(infra)
 		if infra.Spec.Services != nil && infra.Spec.Services.Manager != nil {
 			svc := infra.Spec.Services.Manager
 			managerPlan.Replicas = svc.Replicas
@@ -544,10 +542,8 @@ func compileNetdPlan(infra *infrav1alpha1.Sandbox0Infra, compiled *InfraPlan) Ne
 	}
 
 	if infra != nil {
-		netdPlan.RegionID = infra.Spec.Region
-		if infra.Spec.Cluster != nil {
-			netdPlan.ClusterID = infra.Spec.Cluster.ID
-		}
+		netdPlan.RegionID = common.ResolveRegionID(infra)
+		netdPlan.ClusterID = common.ResolveClusterID(infra)
 		if infra.Spec.Services != nil && infra.Spec.Services.Netd != nil {
 			if infra.Spec.Services.Netd.Config != nil {
 				netdPlan.Config = runtimeconfig.ToNetd(infra.Spec.Services.Netd.Config)

--- a/infra-operator/internal/plan/plan_test.go
+++ b/infra-operator/internal/plan/plan_test.go
@@ -9,6 +9,7 @@ import (
 
 	infrav1alpha1 "github.com/sandbox0-ai/sandbox0/infra-operator/api/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/pkg/dataplane"
+	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 	"github.com/sandbox0-ai/sandbox0/pkg/template"
 )
 
@@ -196,6 +197,51 @@ func TestBuiltinTemplatesDefaultsAndOverrides(t *testing.T) {
 	}).BuiltinTemplates()
 	if len(empty) != 0 {
 		t.Fatalf("explicit empty builtin templates = %#v, want none", empty)
+	}
+}
+
+func TestCompileDefaultsDataPlaneIdentityFromPublicExposure(t *testing.T) {
+	infra := &infrav1alpha1.Sandbox0Infra{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fullmode",
+			Namespace: "sandbox0-system",
+		},
+		Spec: infrav1alpha1.Sandbox0InfraSpec{
+			PublicExposure: &infrav1alpha1.PublicExposureConfig{
+				RegionID: "aws-us-east-1",
+			},
+			Services: &infrav1alpha1.ServicesConfig{
+				Manager: &infrav1alpha1.ManagerServiceConfig{
+					WorkloadServiceConfig: infrav1alpha1.WorkloadServiceConfig{
+						EnabledServiceConfig: infrav1alpha1.EnabledServiceConfig{Enabled: true},
+					},
+				},
+				Netd: &infrav1alpha1.NetdServiceConfig{
+					EnabledServiceConfig: infrav1alpha1.EnabledServiceConfig{Enabled: true},
+				},
+			},
+		},
+	}
+
+	compiled := Compile(infra)
+
+	if got := compiled.Manager.RegionID; got != "aws-us-east-1" {
+		t.Fatalf("manager region ID = %q, want aws-us-east-1", got)
+	}
+	if got := compiled.Manager.DefaultClusterID; got != naming.DefaultClusterID {
+		t.Fatalf("manager default cluster ID = %q, want %q", got, naming.DefaultClusterID)
+	}
+	if got := compiled.Manager.Config.RegionID; got != "aws-us-east-1" {
+		t.Fatalf("manager config region ID = %q, want aws-us-east-1", got)
+	}
+	if got := compiled.Manager.Config.DefaultClusterId; got != naming.DefaultClusterID {
+		t.Fatalf("manager config default cluster ID = %q, want %q", got, naming.DefaultClusterID)
+	}
+	if got := compiled.Netd.RegionID; got != "aws-us-east-1" {
+		t.Fatalf("netd region ID = %q, want aws-us-east-1", got)
+	}
+	if got := compiled.Netd.ClusterID; got != naming.DefaultClusterID {
+		t.Fatalf("netd cluster ID = %q, want %q", got, naming.DefaultClusterID)
 	}
 }
 


### PR DESCRIPTION
## Summary
- default data-plane region identity from `spec.region` or `publicExposure.regionId`
- default missing single-cluster IDs to `naming.DefaultClusterID` for manager, netd, storage-proxy, and ctld storage config
- cover fullmode-style defaults with targeted operator tests

Fixes #510

## Tests
- `go test ./infra-operator/internal/plan ./infra-operator/internal/controller/services/storageproxy ./infra-operator/internal/controller/services/ctld`