### PR TITLE
Update Managed Agents harness docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Managed Agents supports two execution models:
 
 | Model | How it works | Best fit |
 | ----- | ------------ | -------- |
-| **Agent in sandbox** | The agent runtime process lives inside the per-session sandbox with the workspace and harness state. | Claude Code style coding agents, Codex app-server sessions, Pi Agent Core workflows, and workflows that expect local files and shell state. |
+| **Agent in sandbox** | The agent runtime process lives inside the per-session sandbox with the workspace and harness state. | Claude Code style coding agents, Codex app-server sessions, and workflows that expect local files and shell state. |
 | **Sandbox as tool** | A resident runtime service owns the agent loop and claims a Sandbox0 sandbox only when isolated tool execution is needed. | Product copilots and agent workflows built around a separate application control plane. |
 
 Use raw Sandbox0 sandboxes when you want direct control over processes, files, templates, volumes, ports, and network policy. Use Managed Agents when you want Sandbox0 to provide the session/event API and runtime attachment behind that API.

--- a/docs/managed-agents/agent-harnesses/page.mdx
+++ b/docs/managed-agents/agent-harnesses/page.mdx
@@ -15,14 +15,14 @@ Sandbox0 supports two execution models.
 
 | Model | How it works | Harnesses |
 |-------|--------------|---------|
-| Agent in sandbox | The agent runtime process runs inside the per-session Sandbox0 sandbox. The sandbox contains the agent process, workspace, tools, and harness state. | `claude`, `codex`, `pi` |
+| Agent in sandbox | The agent runtime process runs inside the per-session Sandbox0 sandbox. The sandbox contains the agent process, workspace, tools, and harness state. | `claude`, `codex` |
 | Sandbox as tool | A resident runtime service runs the agent loop outside the sandbox. The sandbox is claimed lazily and exposed to the agent as tools such as `bash`. | `openai-agents` |
 
 Use agent in sandbox when you want the agent process itself to live with the workspace. This is the most direct fit for coding agents that expect local files, shell commands, home-directory state, and long-lived process state inside the sandbox.
 
 Use sandbox as tool when you want to embed an agent into a product workflow or control plane. The agent harness stays in a managed runtime service, while Sandbox0 provides isolated tool execution only when the agent needs to inspect files or run commands.
 
-Vault `environment_variable` credentials are applied to Sandbox0-backed sandbox processes. With `claude`, `codex`, and `pi`, the agent process runs in that sandbox and inherits those variables as placeholders. External sandbox-as-tool harnesses such as `openai-agents` reject `environment_variable` vault credentials today because the resident runtime service cannot receive them as SDK client or harness configuration secrets.
+Vault `environment_variable` credentials are applied to Sandbox0-backed sandbox processes. With `claude` and `codex`, the agent process runs in that sandbox and inherits those variables as placeholders. External sandbox-as-tool harnesses such as `openai-agents` reject `environment_variable` vault credentials today because the resident runtime service cannot receive them as SDK client or harness configuration secrets.
 
 ## Supported Harnesses
 
@@ -31,7 +31,6 @@ Vault `environment_variable` credentials are applied to Sandbox0-backed sandbox 
 | `claude` | Agent in sandbox | Claude Agent SDK wrapper | Anthropic Messages-compatible | Claude Code style coding agents and Anthropic-compatible providers |
 | `codex` | Agent in sandbox | Codex app-server wrapper | OpenAI-compatible | Codex app-server sessions that should keep Codex state inside the workspace |
 | `openai-agents` | Sandbox as tool | Resident OpenAI Agents Python runtime | OpenAI Responses-compatible | Product copilots and agent workflows built on the OpenAI Agents SDK |
-| `pi` | Agent in sandbox | Pi Agent Core wrapper | Anthropic Messages-compatible | Pi Agent Core workflows that should keep native Pi state, tools, and workspace inside the sandbox |
 
 ## Retry Behavior
 
@@ -43,7 +42,7 @@ Harnesses with observable automatic retry attempts report them through the same 
 | `codex` | Codex app-server `error` notifications with `willRetry = true` |
 | `openai-agents` | OpenAI Agents SDK runner-managed `ModelRetrySettings` policy decisions |
 
-Sandbox0 disables hidden model client retries where they would obscure retry state. The `openai-agents` runtime disables hidden OpenAI Python client retries and routes model retries through the OpenAI Agents SDK retry policy. The `pi` harness surfaces provider or runtime failures as session errors, but does not expose a managed automatic retry signal yet.
+Sandbox0 disables hidden model client retries where they would obscure retry state. The `openai-agents` runtime disables hidden OpenAI Python client retries and routes model retries through the OpenAI Agents SDK retry policy.
 
 ## Select A Harness
 
@@ -86,19 +85,6 @@ const openAIAgentsVault = await client.beta.vaults.create({
 });
 ```
 
-For `pi`:
-
-```typescript
-const piVault = await client.beta.vaults.create({
-    display_name: "Pi LLM",
-    metadata: {
-        "sandbox0.managed_agents.role": "llm",
-        "sandbox0.managed_agents.engine": "pi",
-        "sandbox0.managed_agents.llm_base_url": "https://api.anthropic.com",
-    },
-});
-```
-
 Add the model provider token to the selected LLM vault:
 
 ```typescript
@@ -136,7 +122,6 @@ Choose the gateway endpoint that matches the selected harness:
 | `claude` | Anthropic Messages-compatible API |
 | `codex` | OpenAI-compatible API |
 | `openai-agents` | OpenAI Responses-compatible API |
-| `pi` | Anthropic Messages-compatible API |
 
 If you only need to bridge a Claude Code-compatible provider into an OpenAI-style harness, LLMProxy is the simplest option. The hosted tool does not require a Sandbox0 account, an LLMProxy login, or gateway-side setup. Use the LLMProxy URL as the LLM vault base URL, keep the upstream provider token in the vault credential, and let the selected runtime call it directly.
 
@@ -174,7 +159,7 @@ await client.beta.vaults.credentials.create(cloudflareGatewayVault.id, {
 Configure the agent model to the gateway's model identifier, such as `anthropic/claude-sonnet-4` on Cloudflare AI Gateway or the model alias configured in LiteLLM, Portkey, or another gateway.
 
 <Callout variant="warning">
-Do not point a harness at a gateway endpoint with the wrong API shape. For example, the `openai-agents` harness needs an OpenAI Responses-compatible endpoint even if the gateway routes the request to an Anthropic model upstream. The `pi` harness should point at an Anthropic Messages-compatible endpoint directly.
+Do not point a harness at a gateway endpoint with the wrong API shape. For example, the `openai-agents` harness needs an OpenAI Responses-compatible endpoint even if the gateway routes the request to an Anthropic model upstream.
 </Callout>
 
 ## Claude Harness
@@ -200,18 +185,6 @@ The harness expects an OpenAI Responses-compatible endpoint. If the target provi
 <Callout variant="info">
 For self-hosted deployments, configure the OpenAI Agents runtime callback base URL to an internal gateway URL when possible. The runtime sends session events back to the Managed Agents gateway; routing that callback through a public edge can introduce avoidable policy and timeout failures.
 </Callout>
-
-## Pi Harness
-
-The `pi` harness runs Pi Agent Core inside the per-session sandbox through the Managed Agents agent wrapper. It uses Pi's native `AgentHarness` and Node execution environment, so the agent loop, shell tools, workspace, and Pi session artifacts all live with the sandbox attachment.
-
-This is the agent in sandbox model. Starting a run claims or resumes the Sandbox0 sandbox before Pi starts processing the turn. Shell execution happens through Pi's sandbox-local execution environment instead of a separate Sandbox0 SDK tool bridge.
-
-The harness expects an Anthropic Messages-compatible endpoint. Use this harness when the model provider or AI gateway already exposes the Claude/Anthropic message format. Do not use Codex or OpenAI Responses protocol endpoints for `pi`.
-
-Pi's local JSONL session repository is stored under the persistent workspace for native Pi state. Durable Managed Agents session truth remains in the Managed Agents gateway and PostgreSQL, and Pi events are translated back into the public Managed Agents event stream.
-
-Custom skills are materialized into the sandbox workspace and loaded through Pi-native skill discovery before each run.
 
 ## Harness Configuration
 

--- a/docs/managed-agents/compatibility/page.mdx
+++ b/docs/managed-agents/compatibility/page.mdx
@@ -21,7 +21,7 @@ Official reference: [Claude Managed Agents quickstart](https://platform.claude.c
 | Custom skills | Supported through uploaded skill versions |
 | MCP servers | Supported for URL MCP servers and vault-backed credentials |
 | GitHub repository resources | Supported at session creation |
-| Agent harnesses | Supported for `claude`, `codex`, `openai-agents`, and `pi` |
+| Agent harnesses | Supported for `claude`, `codex`, and `openai-agents` |
 | External AI gateways | Supported when the gateway exposes the API shape required by the selected agent harness |
 
 ## Current Differences
@@ -32,12 +32,11 @@ Official reference: [Claude Managed Agents quickstart](https://platform.claude.c
 | API token | SDK `apiKey` is a Sandbox0 API key, not the Anthropic LLM token. |
 | LLM token | Stored in an LLM vault and projected by Sandbox0 credential policy. |
 | Agent harness | Selected by the compatibility key `sandbox0.managed_agents.engine` on the LLM vault. |
-| Environment variable credentials | Stored as sandbox environment placeholders and resolved by Sandbox0 egress auth. They are available to sandbox-backed runtimes such as `claude`, `codex`, and `pi`, not as SDK client or resident harness configuration secrets. External sandbox-as-tool harnesses reject them today. |
+| Environment variable credentials | Stored as sandbox environment placeholders and resolved by Sandbox0 egress auth. They are available to sandbox-backed runtimes such as `claude` and `codex`, not as SDK client or resident harness configuration secrets. External sandbox-as-tool harnesses reject them today. |
 | Sandbox claim | Agent-in-sandbox harnesses claim or resume a Sandbox0 sandbox before the run. Sandbox-as-tool harnesses start in a resident runtime and claim the sandbox only when a sandbox tool needs one. |
 | Claude harness | Requires an Anthropic Messages-compatible endpoint. |
 | Codex harness | Requires an OpenAI-compatible endpoint. |
 | OpenAI Agents harness | Requires an OpenAI Responses-compatible endpoint and uses Sandbox0 as a tool target. |
-| Pi harness | Requires an Anthropic Messages-compatible endpoint and runs Pi Agent Core inside the sandbox. |
 | Retry state | Automatic retries are exposed as `session.status_rescheduled` plus `retry_status.type = "retrying"` errors when the selected harness provides a retry signal. |
 | Scheduled deployments | Sandbox0 accepts five-field POSIX cron expressions with IANA timezones. It does not backfill missed runs after unpause or downtime. |
 | Deployment failure handling | Scheduled run creation failures are stored on deployment runs. Non-rate-limit failures pause the deployment. |
@@ -134,9 +133,9 @@ Sandbox0 stores the session and event log outside the sandbox. Sandbox attachmen
 | Delete | Rejects active running sessions. Delete after interrupting and reaching idle. |
 | Archive | Makes the session read-only for new input events. |
 
-`claude`, `codex`, and `pi` use agent in sandbox behavior. `openai-agents` uses sandbox as tool behavior, so the resident runtime can start a run before a Sandbox0 sandbox is claimed.
+`claude` and `codex` use agent in sandbox behavior. `openai-agents` uses sandbox as tool behavior, so the resident runtime can start a run before a Sandbox0 sandbox is claimed.
 
-Sandbox0 session lifecycle includes `idle`, `running`, `rescheduling`, and `terminated`. The `rescheduling` state is transient and means the active run is waiting for an automatic retry. It is currently mapped from Claude Agent SDK `api_retry` events, Codex app-server `willRetry` errors, and OpenAI Agents SDK runner-managed retry policy decisions. The `pi` harness surfaces provider or runtime failures as session errors but does not expose a runtime-managed automatic retry signal yet.
+Sandbox0 session lifecycle includes `idle`, `running`, `rescheduling`, and `terminated`. The `rescheduling` state is transient and means the active run is waiting for an automatic retry. It is currently mapped from Claude Agent SDK `api_retry` events, Codex app-server `willRetry` errors, and OpenAI Agents SDK runner-managed retry policy decisions.
 
 ## Version Drift
 

--- a/docs/managed-agents/llmproxy/page.mdx
+++ b/docs/managed-agents/llmproxy/page.mdx
@@ -13,7 +13,7 @@ Use LLMProxy when:
 - You only need protocol translation and do not need request logs, caching, budgets, rate limits, or managed BYOK controls from a full AI gateway.
 - You want the fastest path: construct the URL, store it as the LLM base URL, and run the agent.
 
-Do not add LLMProxy just because a provider is non-OpenAI. If the selected harness is `claude` or `pi` and the provider already exposes an Anthropic Messages-compatible endpoint, point the LLM vault directly at that provider. If you need policy, observability, caching, or provider-key management outside Sandbox0, use an AI gateway instead.
+Do not add LLMProxy just because a provider is non-OpenAI. If the selected harness is `claude` and the provider already exposes an Anthropic Messages-compatible endpoint, point the LLM vault directly at that provider. If you need policy, observability, caching, or provider-key management outside Sandbox0, use an AI gateway instead.
 
 ## URL Shape
 

--- a/docs/managed-agents/page.mdx
+++ b/docs/managed-agents/page.mdx
@@ -31,7 +31,7 @@ Managed Agents can execute in two ways:
 
 | Model | What users should expect | Harnesses |
 |-------|--------------------------|---------|
-| Agent in sandbox | The agent runtime process lives inside the per-session sandbox with the workspace and harness state. | `claude`, `codex`, `pi` |
+| Agent in sandbox | The agent runtime process lives inside the per-session sandbox with the workspace and harness state. | `claude`, `codex` |
 | Sandbox as tool | A resident runtime service owns the agent loop and uses Sandbox0 as an isolated tool target. | `openai-agents` |
 
 Both models use the same Managed Agents API and durable event stream. Choose the model by selecting an agent harness through the LLM vault.
@@ -77,7 +77,7 @@ The public object model follows Claude Managed Agents where practical. The backe
 - The SDK `apiKey` is a Sandbox0 API key.
 - The LLM token is stored in a vault and projected by Sandbox0 credential policy.
 - The agent harness is selected through LLM vault metadata.
-- `claude`, `codex`, and `pi` run agent in sandbox; `openai-agents` uses sandbox as tool.
+- `claude` and `codex` run agent in sandbox; `openai-agents` uses sandbox as tool.
 - The sandbox workspace is persistent across turns through a Sandbox0 volume.
 - Network policy and credential injection are enforced by Sandbox0.
 

--- a/docs/managed-agents/sessions/page.mdx
+++ b/docs/managed-agents/sessions/page.mdx
@@ -87,7 +87,7 @@ Sandbox0 keeps session state and event history outside the sandbox. The sandbox 
 - The runtime sandbox uses auto-resume.
 - Runtime sandbox lifetime is managed by the Managed Agents deployment.
 - The selected agent harness is resolved from the attached LLM vault; if no harness is selected, the default is `claude`.
-- `claude`, `codex`, and `pi` run the agent process inside the sandbox.
+- `claude` and `codex` run the agent process inside the sandbox.
 - `openai-agents` runs the agent loop in a resident runtime and uses Sandbox0 as a sandbox tool.
 - Harnesses with observable automatic retry attempts map them to the same session state sequence: `running`, `rescheduling`, `running`, then either `idle` or `terminated`.
 

--- a/docs/managed-agents/vaults/page.mdx
+++ b/docs/managed-agents/vaults/page.mdx
@@ -34,7 +34,7 @@ await client.beta.vaults.credentials.create(llmVault.id, {
 | Metadata key | Required | Meaning |
 |--------------|----------|---------|
 | `sandbox0.managed_agents.role` | Yes | Must be `llm` for an LLM vault |
-| `sandbox0.managed_agents.engine` | Yes | `claude`, `codex`, `openai-agents`, or `pi` |
+| `sandbox0.managed_agents.engine` | Yes | `claude`, `codex`, or `openai-agents` |
 | `sandbox0.managed_agents.llm_base_url` | No | Model provider base URL |
 
 The LLM credential must be an unbound `static_bearer` credential. Do not set `mcp_server_url` on LLM credentials.
@@ -135,17 +135,14 @@ Sandbox0 injects model provider credentials through egress auth and harness comp
 | `claude` | `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BASE_URL` |
 | `codex` | `CODEX_API_KEY`, `OPENAI_API_KEY`, and `openai_base_url` harness config |
 | `openai-agents` | `OPENAI_API_KEY`, `OPENAI_BASE_URL`, and `openai_base_url` harness config |
-| `pi` | `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BASE_URL`, and `anthropic_base_url` harness config |
 
-For agent-in-sandbox harnesses such as `claude`, `codex`, and `pi`, compatibility environment variables may contain placeholders. The real token is projected by Sandbox0-managed credential policy when the sandbox contacts the configured model provider host.
+For agent-in-sandbox harnesses such as `claude` and `codex`, compatibility environment variables may contain placeholders. The real token is projected by Sandbox0-managed credential policy when the sandbox contacts the configured model provider host.
 
 For sandbox-as-tool harnesses such as `openai-agents`, model-provider credentials are resolved as resident runtime configuration. Sandbox0 passes the selected LLM vault token to the runtime service for model calls. User-defined `environment_variable` credentials are not accepted by external sandbox-as-tool harnesses today.
 
 Vault `environment_variable` credentials are separate from these harness compatibility variables. They create user-defined sandbox process environment variables and resolve them through the same egress auth boundary.
 
 For `openai-agents`, the runtime expects an OpenAI Responses-compatible base URL. If the provider exposes a different API shape, use an external AI gateway that presents an OpenAI Responses-compatible endpoint and store the gateway base URL in `sandbox0.managed_agents.llm_base_url`.
-
-For `pi`, the sandbox-local wrapper expects an Anthropic Messages-compatible base URL and uses Claude-format messages. If the provider exposes only an OpenAI or Codex-style API, use a gateway that presents an Anthropic Messages-compatible endpoint before selecting the `pi` harness.
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary
- remove Pi from the Managed Agents supported harness docs
- update execution model, vault metadata, LLMProxy, runtime injection, and compatibility pages to list only `claude`, `codex`, and `openai-agents`

## Tests
- rg check for stale Pi harness documentation
- no local docs build package is present in this repo