### PR TITLE
Fix function resume readiness and command exit status

### DIFF
--- a/cluster-gateway/pkg/http/sandbox_service_policy_test.go
+++ b/cluster-gateway/pkg/http/sandbox_service_policy_test.go
@@ -413,6 +413,117 @@ func TestSandboxFunctionServiceProxiesWebSocketThroughProcdPort(t *testing.T) {
 	}
 }
 
+func TestSandboxFunctionServiceExecutesAfterPausedAutoResume(t *testing.T) {
+	var executeCalled atomic.Bool
+	procd := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/v1/functions/execute" {
+			t.Fatalf("unexpected procd request %s %s", r.Method, r.URL.Path)
+		}
+		executeCalled.Store(true)
+		_ = spec.WriteSuccess(w, http.StatusOK, sandboxfunction.ExecuteResponse{
+			Status:     http.StatusCreated,
+			BodyBase64: "cmVzdW1lZCBmdW5jdGlvbiBvaw==",
+		})
+	}))
+	defer procd.Close()
+
+	port := serverPort(t, procd.URL)
+	activeSandbox := newFunctionServiceSandbox(procd.URL, port)
+	activeSandbox.Status = mgr.SandboxStatusRunning
+	activeSandbox.Services[0].Ingress.Routes[0].Resume = true
+	managerURL, resumed := newPausedFunctionManager(t, activeSandbox)
+
+	gateway := newSandboxServiceExposureTestServerWithManagerURL(t, managerURL)
+	gatewayServer := httptest.NewServer(gateway)
+	defer gatewayServer.Close()
+
+	req, err := http.NewRequest(http.MethodPost, gatewayServer.URL+"/events/resume", strings.NewReader("payload"))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Host = fmt.Sprintf("sb-demo--p%d.aws-us-east-1.sandbox0.app", port)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("gateway request: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("status = %d body=%s", resp.StatusCode, string(body))
+	}
+	if string(body) != "resumed function ok" {
+		t.Fatalf("body = %q, want resumed function ok", string(body))
+	}
+	if !resumed.Load() {
+		t.Fatal("manager resume was not called")
+	}
+	if !executeCalled.Load() {
+		t.Fatal("function execute was not called")
+	}
+}
+
+func TestSandboxFunctionServiceProxiesWebSocketAfterPausedAutoResume(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	procd := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/v1/functions/ws" {
+			t.Fatalf("unexpected procd request %s %s", r.Method, r.URL.Path)
+		}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Fatalf("upgrade procd websocket: %v", err)
+		}
+		defer conn.Close()
+		var initReq sandboxfunction.ExecuteRequest
+		if err := conn.ReadJSON(&initReq); err != nil {
+			t.Fatalf("read init request: %v", err)
+		}
+		messageType, data, err := conn.ReadMessage()
+		if err != nil {
+			t.Fatalf("read proxied message: %v", err)
+		}
+		if err := conn.WriteMessage(messageType, []byte("echo:"+string(data))); err != nil {
+			t.Fatalf("write proxied message: %v", err)
+		}
+	}))
+	defer procd.Close()
+
+	port := serverPort(t, procd.URL)
+	activeSandbox := newFunctionServiceSandbox(procd.URL, port)
+	activeSandbox.Status = mgr.SandboxStatusRunning
+	activeSandbox.Services[0].Ingress.Routes[0].Resume = true
+	managerURL, resumed := newPausedFunctionManager(t, activeSandbox)
+
+	gateway := newSandboxServiceExposureTestServerWithManagerURL(t, managerURL)
+	gatewayServer := httptest.NewServer(gateway)
+	defer gatewayServer.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(gatewayServer.URL, "http") + "/events/ws"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, http.Header{
+		"Host": {fmt.Sprintf("sb-demo--p%d.aws-us-east-1.sandbox0.app", port)},
+	})
+	if err != nil {
+		t.Fatalf("dial gateway websocket: %v", err)
+	}
+	defer conn.Close()
+	if err := conn.WriteMessage(websocket.TextMessage, []byte("after-pause")); err != nil {
+		t.Fatalf("write gateway websocket: %v", err)
+	}
+	_, data, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("read gateway websocket: %v", err)
+	}
+	if string(data) != "echo:after-pause" {
+		t.Fatalf("websocket data = %q, want echo:after-pause", string(data))
+	}
+	if !resumed.Load() {
+		t.Fatal("manager resume was not called")
+	}
+}
+
 func TestSandboxCMDServiceStartsContextBeforeProxy(t *testing.T) {
 	var created atomic.Bool
 	var createReq procdCreateContextRequest
@@ -624,6 +735,33 @@ func newFunctionServiceSandbox(internalAddr string, port int) *mgr.Sandbox {
 			},
 		}},
 	}
+}
+
+func newPausedFunctionManager(t *testing.T, activeSandbox *mgr.Sandbox) (string, *atomic.Bool) {
+	t.Helper()
+	pausedSandbox := *activeSandbox
+	pausedSandbox.InternalAddr = ""
+	pausedSandbox.Status = mgr.SandboxStatusPaused
+	pausedSandbox.Paused = true
+
+	var resumed atomic.Bool
+	manager := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/internal/v1/sandboxes/sb-demo":
+			if resumed.Load() {
+				_ = spec.WriteSuccess(w, http.StatusOK, activeSandbox)
+				return
+			}
+			_ = spec.WriteSuccess(w, http.StatusOK, &pausedSandbox)
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/sandboxes/sb-demo/resume":
+			resumed.Store(true)
+			_ = spec.WriteSuccess(w, http.StatusOK, map[string]any{"sandbox_id": "sb-demo"})
+		default:
+			t.Fatalf("unexpected manager request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	t.Cleanup(manager.Close)
+	return manager.URL, &resumed
 }
 
 func newCMDServiceForTest(port int, resume bool) mgr.SandboxAppService {

--- a/ctld/internal/ctld/rootfs/containerd_runtime.go
+++ b/ctld/internal/ctld/rootfs/containerd_runtime.go
@@ -232,6 +232,13 @@ func (r *ContainerdRuntime) ApplyDiff(ctx context.Context, info ctldapi.RootFSIn
 	if err != nil {
 		return ctldapi.RootFSDiffDescriptor{}, err
 	}
+	filteredDesc, filteredReader, err := filterRootFSDiffTar(desc, reader)
+	if err != nil {
+		return ctldapi.RootFSDiffDescriptor{}, fmt.Errorf("filter rootfs diff: %w", err)
+	}
+	defer filteredReader.Close()
+	desc = filteredDesc
+	reader = filteredReader
 
 	ociDesc, err := descriptorToOCI(desc)
 	if err != nil {

--- a/ctld/internal/ctld/rootfs/overlay_diff.go
+++ b/ctld/internal/ctld/rootfs/overlay_diff.go
@@ -1,10 +1,12 @@
 package rootfs
 
 import (
+	"archive/tar"
 	"context"
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"syscall"
@@ -19,6 +21,10 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
 	"golang.org/x/sys/unix"
 )
+
+var rootFSSnapshotExcludedPaths = []string{
+	"/procd",
+}
 
 func (r *ContainerdRuntime) createOverlayUpperDiff(ctx context.Context, client containerdClient, info ctldapi.RootFSInfo) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, bool, error) {
 	if strings.TrimSpace(info.Snapshotter) != "overlayfs" {
@@ -183,7 +189,7 @@ func writeOverlayDiffTar(source string, walkChanges func(fs.ChangeFunc) error) (
 	digester := digest.Canonical.Digester()
 	writer := io.MultiWriter(tmp, digester.Hash())
 	cw := archive.NewChangeWriter(writer, source)
-	if err := walkChanges(cw.HandleChange); err != nil {
+	if err := walkChanges(filteredRootFSChangeFunc(cw.HandleChange)); err != nil {
 		_ = cw.Close()
 		return ctldapi.RootFSDiffDescriptor{}, nil, err
 	}
@@ -225,6 +231,12 @@ func walkOverlayUpper(ctx context.Context, upperdir string, changeFn fs.ChangeFu
 			return nil
 		}
 		changePath := string(filepath.Separator) + rel
+		if isRootFSSnapshotExcludedPath(changePath) {
+			if info != nil && info.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
 		if isOverlayWhiteout(info) {
 			return changeFn(fs.ChangeKindDelete, changePath, nil, nil)
 		}
@@ -269,6 +281,103 @@ func isOverlayOpaqueDir(path string) (bool, error) {
 	return false, nil
 }
 
+func filteredRootFSChangeFunc(next fs.ChangeFunc) fs.ChangeFunc {
+	return func(kind fs.ChangeKind, changePath string, info os.FileInfo, err error) error {
+		if err != nil {
+			return next(kind, changePath, info, err)
+		}
+		if isRootFSSnapshotExcludedPath(changePath) {
+			return nil
+		}
+		return next(kind, changePath, info, err)
+	}
+}
+
+func filterRootFSDiffTar(desc ctldapi.RootFSDiffDescriptor, reader io.Reader) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error) {
+	if strings.TrimSpace(desc.MediaType) != "" && strings.TrimSpace(desc.MediaType) != ocispec.MediaTypeImageLayer {
+		return desc, noopReadSeekCloser{Reader: reader}, nil
+	}
+
+	tmp, err := os.CreateTemp("", "sandbox0-rootfs-filtered-diff-*.tar")
+	if err != nil {
+		return ctldapi.RootFSDiffDescriptor{}, nil, err
+	}
+	removeOnError := true
+	defer func() {
+		if removeOnError {
+			_ = tmp.Close()
+			_ = os.Remove(tmp.Name())
+		}
+	}()
+
+	digester := digest.Canonical.Digester()
+	writer := io.MultiWriter(tmp, digester.Hash())
+	tarWriter := tar.NewWriter(writer)
+	tarReader := tar.NewReader(reader)
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			_ = tarWriter.Close()
+			return ctldapi.RootFSDiffDescriptor{}, nil, err
+		}
+		if isRootFSSnapshotExcludedPath(header.Name) {
+			continue
+		}
+
+		headerCopy := *header
+		if err := tarWriter.WriteHeader(&headerCopy); err != nil {
+			_ = tarWriter.Close()
+			return ctldapi.RootFSDiffDescriptor{}, nil, err
+		}
+		if header.Size > 0 {
+			if _, err := io.Copy(tarWriter, tarReader); err != nil {
+				_ = tarWriter.Close()
+				return ctldapi.RootFSDiffDescriptor{}, nil, err
+			}
+		}
+	}
+	if err := tarWriter.Close(); err != nil {
+		return ctldapi.RootFSDiffDescriptor{}, nil, err
+	}
+	stat, err := tmp.Stat()
+	if err != nil {
+		return ctldapi.RootFSDiffDescriptor{}, nil, err
+	}
+	if _, err := tmp.Seek(0, io.SeekStart); err != nil {
+		return ctldapi.RootFSDiffDescriptor{}, nil, err
+	}
+
+	desc.Digest = digester.Digest().String()
+	desc.Size = stat.Size()
+	if strings.TrimSpace(desc.MediaType) == "" {
+		desc.MediaType = ocispec.MediaTypeImageLayer
+	}
+	removeOnError = false
+	return desc, removeOnCloseFile{File: tmp}, nil
+}
+
+func isRootFSSnapshotExcludedPath(changePath string) bool {
+	clean := cleanRootFSPath(changePath)
+	for _, excluded := range rootFSSnapshotExcludedPaths {
+		excluded = cleanRootFSPath(excluded)
+		if clean == excluded || strings.HasPrefix(clean, excluded+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+func cleanRootFSPath(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "/"
+	}
+	return path.Clean("/" + strings.TrimPrefix(value, "/"))
+}
+
 type removeOnCloseFile struct {
 	*os.File
 }
@@ -283,5 +392,17 @@ func (f removeOnCloseFile) Close() error {
 	if removeErr != nil && !os.IsNotExist(removeErr) {
 		return removeErr
 	}
+	return nil
+}
+
+type noopReadSeekCloser struct {
+	io.Reader
+}
+
+func (noopReadSeekCloser) Seek(int64, int) (int64, error) {
+	return 0, fmt.Errorf("seek is not supported")
+}
+
+func (noopReadSeekCloser) Close() error {
 	return nil
 }

--- a/ctld/internal/ctld/rootfs/overlay_diff.go
+++ b/ctld/internal/ctld/rootfs/overlay_diff.go
@@ -19,11 +19,13 @@ import (
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
+	"github.com/sandbox0-ai/sandbox0/pkg/volumeportal"
 	"golang.org/x/sys/unix"
 )
 
 var rootFSSnapshotExcludedPaths = []string{
 	"/procd",
+	volumeportal.WebhookStateMountPath,
 }
 
 func (r *ContainerdRuntime) createOverlayUpperDiff(ctx context.Context, client containerdClient, info ctldapi.RootFSInfo) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, bool, error) {

--- a/ctld/internal/ctld/rootfs/overlay_diff_test.go
+++ b/ctld/internal/ctld/rootfs/overlay_diff_test.go
@@ -2,6 +2,7 @@ package rootfs
 
 import (
 	"archive/tar"
+	"bytes"
 	"context"
 	"io"
 	"os"
@@ -9,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/containerd/containerd/v2/pkg/archive"
+	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
@@ -39,6 +41,27 @@ func TestWriteOverlayUpperDiffIncludesUpperEntries(t *testing.T) {
 	assert.Contains(t, entries, "etc/")
 	assert.Contains(t, entries, "etc/config")
 	assert.Contains(t, entries, "etc/config-link")
+}
+
+func TestWriteOverlayUpperDiffExcludesRuntimePaths(t *testing.T) {
+	upperdir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(upperdir, "procd", "bin"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(upperdir, "procd", "bin", "procd"), []byte("runtime"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(upperdir, "procd", "bin", "python-runner"), []byte("runtime"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(upperdir, "workspace"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(upperdir, "workspace", "state"), []byte("value"), 0o644))
+
+	_, reader, err := writeOverlayUpperDiff(context.Background(), upperdir)
+	require.NoError(t, err)
+	defer reader.Close()
+
+	entries := readTarEntries(t, reader)
+	assert.NotContains(t, entries, "procd/")
+	assert.NotContains(t, entries, "procd/bin/")
+	assert.NotContains(t, entries, "procd/bin/procd")
+	assert.NotContains(t, entries, "procd/bin/python-runner")
+	assert.Contains(t, entries, "workspace/")
+	assert.Contains(t, entries, "workspace/state")
 }
 
 func TestWriteOverlayUpperDiffConvertsWhiteouts(t *testing.T) {
@@ -114,6 +137,44 @@ func TestWriteOverlayUpperDiffFromBaselineAppliesAsChildDelta(t *testing.T) {
 	assertFileContent(t, filepath.Join(applied, "etc", "same"), "same")
 	_, err = os.Stat(filepath.Join(applied, "etc", "removed"))
 	assert.True(t, os.IsNotExist(err))
+}
+
+func TestFilterRootFSDiffTarExcludesRuntimePaths(t *testing.T) {
+	var buf bytes.Buffer
+	tarWriter := tar.NewWriter(&buf)
+	writeTarEntry(t, tarWriter, "procd/bin/python-runner", []byte("runtime"), 0o755)
+	writeTarEntry(t, tarWriter, "procd/.wh..wh..opq", nil, 0o000)
+	writeTarEntry(t, tarWriter, "workspace/state", []byte("value"), 0o644)
+	require.NoError(t, tarWriter.Close())
+
+	desc, reader, err := filterRootFSDiffTar(rootFSDiffDescriptorForTest(), bytes.NewReader(buf.Bytes()))
+	require.NoError(t, err)
+	defer reader.Close()
+	require.NotEmpty(t, desc.Digest)
+	require.Positive(t, desc.Size)
+
+	entries := readTarEntries(t, reader)
+	assert.NotContains(t, entries, "procd/bin/python-runner")
+	assert.NotContains(t, entries, "procd/.wh..wh..opq")
+	assert.Contains(t, entries, "workspace/state")
+}
+
+func rootFSDiffDescriptorForTest() ctldapi.RootFSDiffDescriptor {
+	return ctldapi.RootFSDiffDescriptor{MediaType: "application/vnd.oci.image.layer.v1.tar"}
+}
+
+func writeTarEntry(t *testing.T, writer *tar.Writer, name string, data []byte, mode int64) {
+	t.Helper()
+	header := &tar.Header{
+		Name: name,
+		Mode: mode,
+		Size: int64(len(data)),
+	}
+	require.NoError(t, writer.WriteHeader(header))
+	if len(data) > 0 {
+		_, err := writer.Write(data)
+		require.NoError(t, err)
+	}
 }
 
 func readTarEntries(t *testing.T, reader io.Reader) []string {

--- a/ctld/internal/ctld/rootfs/overlay_diff_test.go
+++ b/ctld/internal/ctld/rootfs/overlay_diff_test.go
@@ -7,10 +7,12 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/containerd/containerd/v2/pkg/archive"
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
+	"github.com/sandbox0-ai/sandbox0/pkg/volumeportal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
@@ -48,6 +50,8 @@ func TestWriteOverlayUpperDiffExcludesRuntimePaths(t *testing.T) {
 	require.NoError(t, os.MkdirAll(filepath.Join(upperdir, "procd", "bin"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(upperdir, "procd", "bin", "procd"), []byte("runtime"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(upperdir, "procd", "bin", "python-runner"), []byte("runtime"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(upperdir, strings.TrimPrefix(volumeportal.WebhookStateMountPath, "/"), "webhook-outbox"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(upperdir, strings.TrimPrefix(volumeportal.WebhookStateMountPath, "/"), "webhook-outbox", "evt.json"), []byte("runtime"), 0o644))
 	require.NoError(t, os.MkdirAll(filepath.Join(upperdir, "workspace"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(upperdir, "workspace", "state"), []byte("value"), 0o644))
 
@@ -60,6 +64,9 @@ func TestWriteOverlayUpperDiffExcludesRuntimePaths(t *testing.T) {
 	assert.NotContains(t, entries, "procd/bin/")
 	assert.NotContains(t, entries, "procd/bin/procd")
 	assert.NotContains(t, entries, "procd/bin/python-runner")
+	assert.NotContains(t, entries, "var/lib/sandbox0/procd/")
+	assert.NotContains(t, entries, "var/lib/sandbox0/procd/webhook-outbox/")
+	assert.NotContains(t, entries, "var/lib/sandbox0/procd/webhook-outbox/evt.json")
 	assert.Contains(t, entries, "workspace/")
 	assert.Contains(t, entries, "workspace/state")
 }
@@ -144,6 +151,8 @@ func TestFilterRootFSDiffTarExcludesRuntimePaths(t *testing.T) {
 	tarWriter := tar.NewWriter(&buf)
 	writeTarEntry(t, tarWriter, "procd/bin/python-runner", []byte("runtime"), 0o755)
 	writeTarEntry(t, tarWriter, "procd/.wh..wh..opq", nil, 0o000)
+	writeTarEntry(t, tarWriter, "var/lib/sandbox0/procd/webhook-outbox/evt.json", []byte("runtime"), 0o644)
+	writeTarEntry(t, tarWriter, "var/lib/sandbox0/procd/.wh..wh..opq", nil, 0o000)
 	writeTarEntry(t, tarWriter, "workspace/state", []byte("value"), 0o644)
 	require.NoError(t, tarWriter.Close())
 
@@ -156,6 +165,8 @@ func TestFilterRootFSDiffTarExcludesRuntimePaths(t *testing.T) {
 	entries := readTarEntries(t, reader)
 	assert.NotContains(t, entries, "procd/bin/python-runner")
 	assert.NotContains(t, entries, "procd/.wh..wh..opq")
+	assert.NotContains(t, entries, "var/lib/sandbox0/procd/webhook-outbox/evt.json")
+	assert.NotContains(t, entries, "var/lib/sandbox0/procd/.wh..wh..opq")
 	assert.Contains(t, entries, "workspace/state")
 }
 

--- a/docs/sandbox/contexts/page.mdx
+++ b/docs/sandbox/contexts/page.mdx
@@ -232,6 +232,10 @@ process.stdout.write(cmdResult.outputRaw);`
   ]}
 />
 
+When a non-streaming Cmd waits for completion, the response includes `output_raw`,
+`exit_code`, and `state`. `s0 sandbox exec` exits locally with the remote command
+exit code when it is non-zero.
+
 ### Cmd with Options
 
 <Tabs
@@ -388,6 +392,9 @@ Create a new context in a sandbox.
 | `ttl_sec` | integer | Context time-to-live in seconds |
 | `idle_timeout_sec` | integer | Idle timeout in seconds |
 | `wait_until_done` | boolean | Wait for completion (default: false) |
+
+For Cmd contexts created with `wait_until_done: true`, the response includes
+`output_raw`, `exit_code`, and `state` after the process exits.
 
 ### REPL Configuration
 
@@ -980,6 +987,9 @@ Execute input and wait for completion. For REPL contexts, the server appends a t
 <Endpoint method="POST">
 /api/v1/sandboxes/{'{id}'}/contexts/{'{ctx_id}'}/exec
 </Endpoint>
+
+The response always includes `output_raw`. It also includes `exit_code` and
+`state` when the underlying process has exited.
 
 <Tabs
   tabs={[

--- a/manager/pkg/service/sandbox_lifecycle_controller.go
+++ b/manager/pkg/service/sandbox_lifecycle_controller.go
@@ -331,7 +331,11 @@ func (s *SandboxService) CleanupDeletedSandbox(ctx context.Context, info Sandbox
 	var errs []error
 	if !runtimePaused && s.deletionWebhookEmitter != nil && strings.TrimSpace(info.WebhookURL) != "" {
 		if err := s.deletionWebhookEmitter.EmitSandboxDeleted(ctx, info); err != nil {
-			errs = append(errs, fmt.Errorf("emit sandbox.deleted webhook: %w", err))
+			logger.Warn("Failed to emit sandbox.deleted webhook",
+				zap.String("sandboxID", sandboxID),
+				zap.String("namespace", info.Namespace),
+				zap.Error(err),
+			)
 		}
 	}
 	if s.networkProvider != nil && info.Namespace != "" {

--- a/manager/pkg/service/sandbox_lifecycle_controller_test.go
+++ b/manager/pkg/service/sandbox_lifecycle_controller_test.go
@@ -265,6 +265,36 @@ func TestSandboxServiceCleanupDeletedSandboxEmitsWebhookAndMarksStateVolumeForCl
 	}
 }
 
+func TestSandboxServiceCleanupDeletedSandboxDoesNotBlockOnDeletionWebhookFailure(t *testing.T) {
+	volumeClient := &recordingSystemVolumeClient{}
+	emitter := &recordingDeletionWebhookEmitter{err: errors.New("webhook unavailable")}
+	svc := &SandboxService{
+		webhookStateVolumes:    volumeClient,
+		deletionWebhookEmitter: emitter,
+		logger:                 zap.NewNop(),
+	}
+
+	err := svc.CleanupDeletedSandbox(context.Background(), SandboxLifecycleInfo{
+		Namespace:            "ns-a",
+		PodName:              "sandbox-a",
+		SandboxID:            "sandbox-a",
+		TeamID:               "team-a",
+		UserID:               "user-a",
+		WebhookURL:           "https://example.test/webhook",
+		WebhookSecret:        "secret",
+		WebhookStateVolumeID: "volume-a",
+	})
+	if err != nil {
+		t.Fatalf("CleanupDeletedSandbox() error = %v", err)
+	}
+	if len(emitter.calls) != 1 {
+		t.Fatalf("webhook calls = %d, want 1", len(emitter.calls))
+	}
+	if len(volumeClient.marked) != 1 || volumeClient.marked[0] != "sandbox-a:sandbox_deleted" {
+		t.Fatalf("marked volumes = %#v, want sandbox-a:sandbox_deleted", volumeClient.marked)
+	}
+}
+
 func TestSandboxServiceCleanupDeletedSandboxPreservesDurableStateForPausedRuntime(t *testing.T) {
 	removed := make([]string, 0, 1)
 	store := &deleteRecordingBindingStore{}

--- a/manager/procd/pkg/http/handlers/context.go
+++ b/manager/procd/pkg/http/handlers/context.go
@@ -84,6 +84,8 @@ type ContextResponse struct {
 	Paused    bool                `json:"paused"`
 	CreatedAt string              `json:"created_at"`
 	OutputRaw string              `json:"output_raw,omitempty"`
+	ExitCode  *int                `json:"exit_code,omitempty"`
+	State     string              `json:"state,omitempty"`
 }
 
 func normalizeStringMap(value map[string]string) map[string]string {
@@ -93,8 +95,13 @@ func normalizeStringMap(value map[string]string) map[string]string {
 	return value
 }
 
+type contextTerminalStatus struct {
+	ExitCode int
+	State    string
+}
+
 func newContextResponse(ctx *ctxpkg.Context, outputRaw string) ContextResponse {
-	return ContextResponse{
+	response := ContextResponse{
 		ID:        ctx.ID,
 		Type:      ctx.Type,
 		Alias:     ctx.Alias,
@@ -105,6 +112,31 @@ func newContextResponse(ctx *ctxpkg.Context, outputRaw string) ContextResponse {
 		Paused:    ctx.IsPaused(),
 		CreatedAt: ctx.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
 		OutputRaw: outputRaw,
+	}
+	applyTerminalStatusToContextResponse(&response, terminalStatusForContext(ctx))
+	return response
+}
+
+func applyTerminalStatusToContextResponse(response *ContextResponse, status *contextTerminalStatus) {
+	if response == nil || status == nil {
+		return
+	}
+	exitCode := status.ExitCode
+	response.ExitCode = &exitCode
+	response.State = status.State
+}
+
+func terminalStatusForContext(ctx *ctxpkg.Context) *contextTerminalStatus {
+	if ctx == nil || ctx.MainProcess == nil || !ctx.MainProcess.IsFinished() {
+		return nil
+	}
+	exitCode, err := ctx.MainProcess.ExitCode()
+	if err != nil {
+		return nil
+	}
+	return &contextTerminalStatus{
+		ExitCode: exitCode,
+		State:    string(ctx.MainProcess.State()),
 	}
 }
 
@@ -126,6 +158,8 @@ type ContextInputRequest struct {
 // ContextExecResponse is the response body for synchronous execution.
 type ContextExecResponse struct {
 	OutputRaw string `json:"output_raw"`
+	ExitCode  *int   `json:"exit_code,omitempty"`
+	State     string `json:"state,omitempty"`
 }
 
 // ResizeContextRequest is the request body for resizing a PTY.
@@ -464,7 +498,9 @@ func (h *ContextHandler) Exec(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, http.StatusOK, ContextExecResponse{OutputRaw: output})
+	response := ContextExecResponse{OutputRaw: output}
+	applyTerminalStatusToExecResponse(&response, terminalStatusForContext(ctx))
+	writeJSON(w, http.StatusOK, response)
 }
 
 // Stats returns resource usage statistics for a context.
@@ -514,6 +550,15 @@ func normalizeExecOutput(processType process.ProcessType, raw string) string {
 		normalized = repl.DefaultReadyToken + normalized
 	}
 	return normalized
+}
+
+func applyTerminalStatusToExecResponse(response *ContextExecResponse, status *contextTerminalStatus) {
+	if response == nil || status == nil {
+		return
+	}
+	exitCode := status.ExitCode
+	response.ExitCode = &exitCode
+	response.State = status.State
 }
 
 func (h *ContextHandler) execInputSync(ctx *ctxpkg.Context, input string, requestCtx context.Context) (string, *execError, bool) {

--- a/manager/procd/pkg/http/handlers/context_test.go
+++ b/manager/procd/pkg/http/handlers/context_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"reflect"
+	"runtime"
 	"strings"
 	"sync"
 	"syscall"
@@ -194,6 +195,87 @@ func TestCreateContextReturnsBadRequestForInvalidProcessConfig(t *testing.T) {
 				t.Fatalf("response = %+v, want invalid_request error", resp)
 			}
 		})
+	}
+}
+
+func TestCreateContextWaitUntilDoneIncludesCMDTerminalStatus(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell command fixture requires POSIX")
+	}
+	handler := NewContextHandler(ctxpkg.NewManager(), zap.NewNop())
+	req := httptest.NewRequest(http.MethodPost, "/contexts", strings.NewReader(`{
+		"type": "cmd",
+		"cmd": {"command": ["/bin/sh", "-c", "printf done; sleep 0.05; exit 7"]},
+		"wait_until_done": true
+	}`))
+	rec := httptest.NewRecorder()
+
+	handler.Create(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	var resp struct {
+		Success bool            `json:"success"`
+		Data    ContextResponse `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if !resp.Success {
+		t.Fatalf("success = false, body = %s", rec.Body.String())
+	}
+	if resp.Data.OutputRaw != "done" {
+		t.Fatalf("output_raw = %q, want done", resp.Data.OutputRaw)
+	}
+	if resp.Data.ExitCode == nil || *resp.Data.ExitCode != 7 {
+		t.Fatalf("exit_code = %#v, want 7", resp.Data.ExitCode)
+	}
+	if resp.Data.State != string(process.ProcessStateCrashed) {
+		t.Fatalf("state = %q, want %q", resp.Data.State, process.ProcessStateCrashed)
+	}
+}
+
+func TestExecReturnsCMDTerminalStatus(t *testing.T) {
+	outputCh := make(chan process.ProcessOutput, 1)
+	var proc *fakeProcess
+	proc = &fakeProcess{
+		outputCh:    outputCh,
+		processType: process.ProcessTypeCMD,
+		onWrite: func([]byte) {
+			outputCh <- process.ProcessOutput{Source: process.OutputSourceStdout, Data: []byte("failed\n")}
+			proc.triggerExit(process.ExitEvent{ExitCode: 9, State: process.ProcessStateCrashed})
+			close(outputCh)
+		},
+	}
+	handler, ctx := newHandlerWithContext(proc, process.ProcessTypeCMD)
+	req := httptest.NewRequest(http.MethodPost, "/contexts/"+ctx.ID+"/exec", strings.NewReader(`{"data":"run"}`))
+	req = mux.SetURLVars(req, map[string]string{"id": ctx.ID})
+	rec := httptest.NewRecorder()
+
+	handler.Exec(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var resp struct {
+		Success bool                `json:"success"`
+		Data    ContextExecResponse `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if !resp.Success {
+		t.Fatalf("success = false, body = %s", rec.Body.String())
+	}
+	if resp.Data.OutputRaw != "failed\n" {
+		t.Fatalf("output_raw = %q, want failed newline", resp.Data.OutputRaw)
+	}
+	if resp.Data.ExitCode == nil || *resp.Data.ExitCode != 9 {
+		t.Fatalf("exit_code = %#v, want 9", resp.Data.ExitCode)
+	}
+	if resp.Data.State != string(process.ProcessStateCrashed) {
+		t.Fatalf("state = %q, want %q", resp.Data.State, process.ProcessStateCrashed)
 	}
 }
 

--- a/manager/procd/pkg/http/handlers/function.go
+++ b/manager/procd/pkg/http/handlers/function.go
@@ -28,14 +28,15 @@ import (
 )
 
 const (
-	defaultFunctionRunnerPath = "/procd/bin/python-runner"
-	defaultFunctionCacheRoot  = "/tmp/sandbox0-functions"
-	defaultFunctionTimeout    = 30 * time.Second
-	maxFunctionTimeout        = 120 * time.Second
-	maxFunctionExecuteBytes   = sandboxfunction.MaxHTTPRequestBytes + sandboxfunction.MaxInlineSourceBytes + (1 << 20)
-	maxFunctionStdoutBytes    = 4 << 20
-	maxFunctionStderrBytes    = 64 << 10
-	maxFunctionStreamFrame    = 4 << 20
+	defaultFunctionRunnerPath  = "/procd/bin/python-runner"
+	defaultFunctionCacheRoot   = "/tmp/sandbox0-functions"
+	defaultFunctionTimeout     = 30 * time.Second
+	maxFunctionTimeout         = 120 * time.Second
+	maxFunctionExecuteBytes    = sandboxfunction.MaxHTTPRequestBytes + sandboxfunction.MaxInlineSourceBytes + (1 << 20)
+	maxFunctionStdoutBytes     = 4 << 20
+	maxFunctionStderrBytes     = 64 << 10
+	maxFunctionStreamFrame     = 4 << 20
+	functionRunnerWaitInterval = 50 * time.Millisecond
 )
 
 var (
@@ -129,17 +130,15 @@ func (h *FunctionHandler) Execute(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
 		return
 	}
-	if _, err := os.Stat(h.runnerPath); err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			writeError(w, http.StatusServiceUnavailable, spec.CodeUnavailable, "function runtime unavailable")
-			return
-		}
-		writeError(w, http.StatusInternalServerError, spec.CodeInternal, "function runtime unavailable")
-		return
-	}
 	timeout, err := h.requestTimeout(req.TimeoutMS)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), timeout)
+	defer cancel()
+	if err := h.waitRunner(ctx); err != nil {
+		h.writeRunnerUnavailable(w, err)
 		return
 	}
 	modulePath, err := h.materializeSource(req.Source)
@@ -160,9 +159,6 @@ func (h *FunctionHandler) Execute(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, spec.CodeInternal, "failed to encode function request")
 		return
 	}
-
-	ctx, cancel := context.WithTimeout(r.Context(), timeout)
-	defer cancel()
 
 	stdout, stderr, truncated, err := h.run(ctx, modulePath, req.Handler, req.EnvVars, payload)
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
@@ -207,12 +203,20 @@ func (h *FunctionHandler) Stream(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
 		return
 	}
-	if _, err := os.Stat(h.runnerPath); err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			writeError(w, http.StatusServiceUnavailable, spec.CodeUnavailable, "function runtime unavailable")
-			return
-		}
-		writeError(w, http.StatusInternalServerError, spec.CodeInternal, "function runtime unavailable")
+	ctx := r.Context()
+	if req.TimeoutMS < 0 {
+		writeError(w, http.StatusBadRequest, spec.CodeBadRequest, "timeout_ms must be >= 0")
+		return
+	}
+	if req.TimeoutMS > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(req.TimeoutMS)*time.Millisecond)
+		defer cancel()
+	}
+	waitCtx, waitCancel := h.runnerWaitContext(ctx, req.TimeoutMS)
+	defer waitCancel()
+	if err := h.waitRunner(waitCtx); err != nil {
+		h.writeRunnerUnavailable(w, err)
 		return
 	}
 	modulePath, err := h.materializeSource(req.Source)
@@ -235,16 +239,6 @@ func (h *FunctionHandler) Stream(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := proxy.DisableResponseWriteDeadline(w); err != nil {
 		h.logger.Debug("Failed to disable function stream response deadline", zap.Error(err))
-	}
-	ctx := r.Context()
-	if req.TimeoutMS < 0 {
-		writeError(w, http.StatusBadRequest, spec.CodeBadRequest, "timeout_ms must be >= 0")
-		return
-	}
-	if req.TimeoutMS > 0 {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, time.Duration(req.TimeoutMS)*time.Millisecond)
-		defer cancel()
 	}
 	tracker := &trackingResponseWriter{ResponseWriter: w}
 	if err := h.runStream(ctx, tracker, modulePath, req.Handler, req.EnvVars, payload); err != nil {
@@ -287,7 +281,9 @@ func (h *FunctionHandler) WebSocket(w http.ResponseWriter, r *http.Request) {
 		_ = conn.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.ClosePolicyViolation, err.Error()), time.Now().Add(time.Second))
 		return
 	}
-	if _, err := os.Stat(h.runnerPath); err != nil {
+	waitCtx, waitCancel := h.runnerWaitContext(r.Context(), req.TimeoutMS)
+	defer waitCancel()
+	if err := h.waitRunner(waitCtx); err != nil {
 		_ = conn.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseInternalServerErr, "function runtime unavailable"), time.Now().Add(time.Second))
 		return
 	}
@@ -659,6 +655,9 @@ func validateFunctionExecuteRequest(req sandboxfunction.ExecuteRequest) error {
 			return errors.New("request.body_base64 must be valid base64")
 		}
 	}
+	if req.TimeoutMS < 0 {
+		return errors.New("timeout_ms must be >= 0")
+	}
 	return nil
 }
 
@@ -686,6 +685,62 @@ func decodeFunctionExecuteResponse(data []byte) (sandboxfunction.ExecuteResponse
 		response.Headers = map[string][]string{}
 	}
 	return response, nil
+}
+
+func (h *FunctionHandler) checkRunner() error {
+	info, err := os.Stat(h.runnerPath)
+	if err != nil {
+		return err
+	}
+	if info.IsDir() {
+		return fmt.Errorf("%s is a directory", h.runnerPath)
+	}
+	return nil
+}
+
+func (h *FunctionHandler) waitRunner(ctx context.Context) error {
+	var lastErr error
+	for {
+		err := h.checkRunner()
+		if err == nil {
+			return nil
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		lastErr = err
+
+		timer := time.NewTimer(functionRunnerWaitInterval)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			if lastErr != nil {
+				return lastErr
+			}
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func (h *FunctionHandler) runnerWaitContext(parent context.Context, timeoutMS int) (context.Context, context.CancelFunc) {
+	if timeoutMS > 0 {
+		return context.WithTimeout(parent, time.Duration(timeoutMS)*time.Millisecond)
+	}
+	return context.WithTimeout(parent, h.defaultTimeout)
+}
+
+func (h *FunctionHandler) writeRunnerUnavailable(w http.ResponseWriter, err error) {
+	if errors.Is(err, os.ErrNotExist) {
+		writeError(w, http.StatusServiceUnavailable, spec.CodeUnavailable, "function runtime unavailable")
+		return
+	}
+	writeError(w, http.StatusInternalServerError, spec.CodeInternal, "function runtime unavailable")
 }
 
 func encodeWebSocketClientMessage(messageType int, data []byte) sandboxfunction.WebSocketFrame {

--- a/manager/procd/pkg/http/handlers/function_test.go
+++ b/manager/procd/pkg/http/handlers/function_test.go
@@ -11,12 +11,58 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gorilla/websocket"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/sandbox0-ai/sandbox0/pkg/sandboxfunction"
 	"go.uber.org/zap"
 )
+
+func TestFunctionHandlerExecuteWaitsForRunner(t *testing.T) {
+	dir := t.TempDir()
+	runnerPath := filepath.Join(dir, "runner")
+	handler := newFunctionHandler(functionHandlerConfig{runnerPath: runnerPath}, zap.NewNop())
+
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		_ = os.WriteFile(runnerPath, []byte(`#!/bin/sh
+cat >/dev/null
+printf '{"status":201,"body_base64":"b2s="}\n'
+`), 0o755)
+	}()
+
+	req := sandboxfunction.ExecuteRequest{
+		Runtime:   sandboxfunction.RuntimePython,
+		Handler:   sandboxfunction.DefaultHandler,
+		TimeoutMS: 1000,
+		Source: sandboxfunction.Source{
+			Type: sandboxfunction.SourceTypeInline,
+			Code: "def handler(request):\n    return {'status': 201}\n",
+		},
+		Request: sandboxfunction.HTTPRequest{Method: "POST", Path: "/events"},
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	handler.Execute(rec, httptest.NewRequest(http.MethodPost, "/api/v1/functions/execute", bytes.NewReader(body)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var envelope struct {
+		Success bool                            `json:"success"`
+		Data    sandboxfunction.ExecuteResponse `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !envelope.Success || envelope.Data.Status != http.StatusCreated {
+		t.Fatalf("response = %+v, want created function response", envelope)
+	}
+}
 
 func TestFunctionHandlerExecuteRunsRunnerWithInlineSource(t *testing.T) {
 	if runtime.GOOS == "windows" {
@@ -291,5 +337,58 @@ printf '{"type":"message","message_type":"text","data":"echo"}\n'
 	}
 	if string(data) != "echo" {
 		t.Fatalf("data = %q, want echo", string(data))
+	}
+}
+
+func TestFunctionHandlerWebSocketWaitsForRunner(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell runner fixture requires POSIX")
+	}
+	dir := t.TempDir()
+	runnerPath := filepath.Join(dir, "runner.sh")
+	handler := newFunctionHandler(functionHandlerConfig{
+		runnerPath: runnerPath,
+		cacheRoot:  filepath.Join(dir, "cache"),
+	}, zap.NewNop())
+	server := httptest.NewServer(http.HandlerFunc(handler.WebSocket))
+	defer server.Close()
+
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		_ = os.WriteFile(runnerPath, []byte(`#!/bin/sh
+read init
+read message
+printf '{"type":"message","message_type":"text","data":"echo-after-wait"}\n'
+`), 0o755)
+	}()
+
+	req := sandboxfunction.ExecuteRequest{
+		Runtime:   sandboxfunction.RuntimePython,
+		Handler:   sandboxfunction.DefaultHandler,
+		TimeoutMS: 1000,
+		Source: sandboxfunction.Source{
+			Type: sandboxfunction.SourceTypeInline,
+			Code: "def handler(request):\n    return None\n",
+		},
+		Request: sandboxfunction.HTTPRequest{Method: "GET", Path: "/ws"},
+	}
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer conn.Close()
+	if err := conn.WriteJSON(req); err != nil {
+		t.Fatalf("write init: %v", err)
+	}
+	if err := conn.WriteMessage(websocket.TextMessage, []byte("ping")); err != nil {
+		t.Fatalf("write message: %v", err)
+	}
+	_, data, err := conn.ReadMessage()
+	if err != nil && err != io.EOF {
+		t.Fatalf("read message: %v", err)
+	}
+	if string(data) != "echo-after-wait" {
+		t.Fatalf("data = %q, want echo-after-wait", string(data))
 	}
 }

--- a/manager/procd/pkg/http/handlers/initialize.go
+++ b/manager/procd/pkg/http/handlers/initialize.go
@@ -20,7 +20,8 @@ type InitializeHandler struct {
 	contextManager *ctxpkg.Manager
 	httpPort       int
 	logger         *zap.Logger
-	readyOnce      sync.Once
+	readyMu        sync.Mutex
+	readySentKey   string
 	watchMu        sync.Mutex
 	watchPath      string
 	unsubscribe    func() error
@@ -116,23 +117,40 @@ func (h *InitializeHandler) Initialize(w http.ResponseWriter, r *http.Request) {
 	h.configureWebhookWatch(strings.TrimSpace(webhookURL), strings.TrimSpace(webhookWatchDir))
 
 	if webhookURL != "" {
-		h.readyOnce.Do(func() {
-			if _, err := h.dispatcher.Enqueue(webhook.Event{
-				EventType: webhook.EventTypeSandboxReady,
-				Payload: map[string]any{
-					"http_port":  h.httpPort,
-					"sandbox_id": req.SandboxID,
-				},
-			}); err != nil && h.logger != nil {
+		if err := h.enqueueSandboxReady(req.SandboxID, webhookURL); err != nil {
+			if h.logger != nil {
 				h.logger.Warn("Failed to enqueue sandbox ready webhook", zap.Error(err))
 			}
-		})
+			writeError(w, http.StatusServiceUnavailable, "webhook_enqueue_failed", err.Error())
+			return
+		}
 	}
 
 	writeJSON(w, http.StatusOK, InitializeResponse{
 		SandboxID: req.SandboxID,
 		TeamID:    teamID,
 	})
+}
+
+func (h *InitializeHandler) enqueueSandboxReady(sandboxID, webhookURL string) error {
+	h.readyMu.Lock()
+	defer h.readyMu.Unlock()
+
+	readyKey := strings.TrimSpace(sandboxID) + "\x00" + strings.TrimSpace(webhookURL)
+	if h.readySentKey == readyKey {
+		return nil
+	}
+	if _, err := h.dispatcher.Enqueue(webhook.Event{
+		EventType: webhook.EventTypeSandboxReady,
+		Payload: map[string]any{
+			"http_port":  h.httpPort,
+			"sandbox_id": sandboxID,
+		},
+	}); err != nil {
+		return err
+	}
+	h.readySentKey = readyKey
+	return nil
 }
 
 // UpdateSandboxEnvVars updates default environment variables for future sandbox processes.

--- a/manager/procd/pkg/http/handlers/initialize_test.go
+++ b/manager/procd/pkg/http/handlers/initialize_test.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	ctxpkg "github.com/sandbox0-ai/sandbox0/manager/procd/pkg/context"
@@ -81,6 +83,36 @@ func TestInitializeClearsSandboxEnvVars(t *testing.T) {
 	}
 	if envVars := contextManager.SandboxEnvVars(); len(envVars) != 0 {
 		t.Fatalf("sandbox env vars = %#v, want empty", envVars)
+	}
+}
+
+func TestInitializeFailsWhenReadyWebhookCannotBeQueued(t *testing.T) {
+	outboxPath := filepath.Join(t.TempDir(), "outbox")
+	if err := os.WriteFile(outboxPath, []byte("not a directory"), 0o644); err != nil {
+		t.Fatalf("write outbox file: %v", err)
+	}
+	dispatcher := webhook.NewDispatcher(webhook.Options{OutboxDir: outboxPath}, zap.NewNop())
+	t.Cleanup(func() {
+		_ = dispatcher.Shutdown(context.Background())
+	})
+	handler := NewInitializeHandler(dispatcher, nil, ctxpkg.NewManager(), 8080, zap.NewNop())
+
+	body, err := json.Marshal(InitializeRequest{
+		SandboxID: "sandbox-1",
+		Webhook: &InitializeWebhook{
+			URL: "http://127.0.0.1:1/events",
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/initialize", bytes.NewReader(body))
+	recorder := httptest.NewRecorder()
+	handler.Initialize(recorder, req)
+
+	if recorder.Code != http.StatusServiceUnavailable {
+		t.Fatalf("Initialize() status = %d, want %d body=%s", recorder.Code, http.StatusServiceUnavailable, recorder.Body.String())
 	}
 }
 

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -4906,6 +4906,13 @@ components:
         output_raw:
           type: string
           description: Raw PTY output for CMD contexts with wait=true, may contain terminal control characters
+        exit_code:
+          type: integer
+          format: int32
+          description: Present when the underlying process has exited.
+        state:
+          type: string
+          description: Final process state when the underlying process has exited.
       required: [id, type, running, paused, created_at]
     ContextStatsResponse:
       type: object
@@ -4936,6 +4943,13 @@ components:
         output_raw:
           type: string
           description: Raw PTY output, may contain terminal control characters (e.g. \r)
+        exit_code:
+          type: integer
+          format: int32
+          description: Present when the underlying process has exited.
+        state:
+          type: string
+          description: Final process state when the underlying process has exited.
       required: [output_raw]
     ResizeContextRequest:
       type: object

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -635,8 +635,14 @@ type ContainerSpec struct {
 
 // ContextExecResponse defines model for ContextExecResponse.
 type ContextExecResponse struct {
+	// ExitCode Present when the underlying process has exited.
+	ExitCode *int32 `json:"exit_code,omitempty"`
+
 	// OutputRaw Raw PTY output, may contain terminal control characters (e.g. \r)
 	OutputRaw string `json:"output_raw"`
+
+	// State Final process state when the underlying process has exited.
+	State *string `json:"state,omitempty"`
 }
 
 // ContextInputRequest defines model for ContextInputRequest.
@@ -663,13 +669,19 @@ type ContextResponse struct {
 	CreatedAt string             `json:"created_at"`
 	Cwd       *string            `json:"cwd,omitempty"`
 	EnvVars   *map[string]string `json:"env_vars,omitempty"`
-	Id        string             `json:"id"`
+
+	// ExitCode Present when the underlying process has exited.
+	ExitCode *int32 `json:"exit_code,omitempty"`
+	Id       string `json:"id"`
 
 	// OutputRaw Raw PTY output for CMD contexts with wait=true, may contain terminal control characters
-	OutputRaw *string     `json:"output_raw,omitempty"`
-	Paused    bool        `json:"paused"`
-	Running   bool        `json:"running"`
-	Type      ProcessType `json:"type"`
+	OutputRaw *string `json:"output_raw,omitempty"`
+	Paused    bool    `json:"paused"`
+	Running   bool    `json:"running"`
+
+	// State Final process state when the underlying process has exited.
+	State *string     `json:"state,omitempty"`
+	Type  ProcessType `json:"type"`
 }
 
 // ContextStatsResponse defines model for ContextStatsResponse.


### PR DESCRIPTION
## Summary
- make procd wait briefly for the function runner before execute/stream/websocket handlers run, covering resumed function sandboxes without adding a gateway readiness API
- exclude `/procd` runtime paths when saving/applying rootfs checkpoints so pause/resume cannot clear `procd-bin` and remove `python-runner`
- include terminal `exit_code` and `state` on REST context create/exec responses when the process has exited
- add focused procd, cluster-gateway, and ctld rootfs regression tests; regenerate OpenAPI types; update context docs

Fixes #489.
Fixes #73.

## Tests
- `make apispec`
- `go test ./manager/procd/pkg/http/handlers ./cluster-gateway/pkg/http ./ctld/internal/ctld/rootfs -count=1`

## Follow-up PRs
- sandbox0-ai/sdk-go#57 exposes the new fields in `CmdResult`
- sandbox0-ai/s0#70 exits with the remote command status for `s0 sandbox exec`