### PR TITLE
Fix empty SandboxVolume fork

### DIFF
--- a/storage-proxy/pkg/s0fs/materializer.go
+++ b/storage-proxy/pkg/s0fs/materializer.go
@@ -106,6 +106,9 @@ func (m *Materializer) Materialize(ctx context.Context, state *SnapshotState, ex
 	inline := cloneState(state)
 	normalizeState(inline)
 	defaultSegmentVolumeIDs(inline, m.volumeID)
+	if inline.NextSeq <= 1 {
+		inline.NextSeq = 2
+	}
 
 	nextSeq := checkpointSequence(inline)
 	if nextSeq == 0 {

--- a/storage-proxy/pkg/snapshot/manager_s0fs_test.go
+++ b/storage-proxy/pkg/snapshot/manager_s0fs_test.go
@@ -167,6 +167,57 @@ func TestS0FSForkVolumeUsesCopyOnWriteState(t *testing.T) {
 	}
 }
 
+func TestS0FSForkFreshEmptyVolumeCreatesEmptyChild(t *testing.T) {
+	t.Parallel()
+
+	mgr, repo, _, _ := newS0FSSnapshotTestManager(t, "vol-empty")
+
+	forked, err := mgr.ForkVolume(context.Background(), &ForkVolumeRequest{
+		SourceVolumeID: "vol-empty",
+		TeamID:         "team-1",
+		UserID:         "user-2",
+	})
+	if err != nil {
+		t.Fatalf("ForkVolume() error = %v", err)
+	}
+	if forked == nil || forked.ID == "" {
+		t.Fatalf("forked volume = %+v", forked)
+	}
+	if forked.SourceVolumeID == nil || *forked.SourceVolumeID != "vol-empty" {
+		t.Fatalf("forked source volume = %v, want vol-empty", forked.SourceVolumeID)
+	}
+	if _, ok := repo.volumes[forked.ID]; !ok {
+		t.Fatalf("forked volume not persisted: %+v", repo.volumes)
+	}
+
+	forkCfg, err := mgr.s0fsConfig("team-1", forked.ID)
+	if err != nil {
+		t.Fatalf("s0fsConfig(forked) error = %v", err)
+	}
+	forkMaterializer := s0fs.NewMaterializer(forked.ID, forkCfg.ObjectStore, forkCfg.HeadStore, forkCfg.ObjectStoreForVolume)
+	forkMaterializer.SetEncryption(forkCfg.Encryption)
+	forkState, _, err := forkMaterializer.LoadLatestState(context.Background())
+	if err != nil {
+		t.Fatalf("LoadLatestState(forked) error = %v", err)
+	}
+	if len(forkState.Data) != 0 || len(forkState.ColdFiles) != 0 || len(forkState.Segments) != 0 {
+		t.Fatalf("forked state has file data: data=%v cold=%v segments=%v", forkState.Data, forkState.ColdFiles, forkState.Segments)
+	}
+	if got := len(forkState.Children[s0fs.RootInode]); got != 0 {
+		t.Fatalf("forked root entries = %d, want 0", got)
+	}
+
+	freshForked := openFreshS0FSEngine(t, mgr, "team-1", forked.ID)
+	defer freshForked.Close()
+	entries, err := freshForked.ReadDir(s0fs.RootInode)
+	if err != nil {
+		t.Fatalf("ReadDir(forked root) error = %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("forked root entries = %+v, want empty", entries)
+	}
+}
+
 func TestS0FSCreateVolumeFromSnapshotUsesCopyOnWriteState(t *testing.T) {
 	t.Parallel()
 

--- a/storage-proxy/pkg/snapshot/s0fs.go
+++ b/storage-proxy/pkg/snapshot/s0fs.go
@@ -344,7 +344,18 @@ func (m *Manager) resolveS0FSForkState(ctx context.Context, teamID, sourceVolume
 	}
 	state, _, err := materializer.LoadLatestState(ctx)
 	if err != nil {
-		return nil, err
+		if !errors.Is(err, s0fs.ErrMaterializedManifestNotFound) {
+			return nil, err
+		}
+		engine, closeFn, openErr := m.openS0FSEngine(ctx, teamID, sourceVolumeID)
+		if openErr != nil {
+			return nil, openErr
+		}
+		defer closeFn()
+		state, err = engine.ExportState()
+		if err != nil {
+			return nil, err
+		}
 	}
 	return s0fs.PrepareForkState(state, sourceVolumeID)
 }


### PR DESCRIPTION
## Summary
- fall back to exporting the source s0fs engine state when a volume has no materialized manifest yet
- allow empty initial s0fs states to materialize with a valid manifest sequence
- add a regression test for forking a fresh empty SandboxVolume

Fixes #509

## Tests
- go test ./storage-proxy/pkg/snapshot ./storage-proxy/pkg/s0fs