### PR TITLE
Remove function runner preflight polling

### DIFF
--- a/manager/procd/pkg/http/handlers/function.go
+++ b/manager/procd/pkg/http/handlers/function.go
@@ -28,15 +28,14 @@ import (
 )
 
 const (
-	defaultFunctionRunnerPath  = "/procd/bin/python-runner"
-	defaultFunctionCacheRoot   = "/tmp/sandbox0-functions"
-	defaultFunctionTimeout     = 30 * time.Second
-	maxFunctionTimeout         = 120 * time.Second
-	maxFunctionExecuteBytes    = sandboxfunction.MaxHTTPRequestBytes + sandboxfunction.MaxInlineSourceBytes + (1 << 20)
-	maxFunctionStdoutBytes     = 4 << 20
-	maxFunctionStderrBytes     = 64 << 10
-	maxFunctionStreamFrame     = 4 << 20
-	functionRunnerWaitInterval = 50 * time.Millisecond
+	defaultFunctionRunnerPath = "/procd/bin/python-runner"
+	defaultFunctionCacheRoot  = "/tmp/sandbox0-functions"
+	defaultFunctionTimeout    = 30 * time.Second
+	maxFunctionTimeout        = 120 * time.Second
+	maxFunctionExecuteBytes   = sandboxfunction.MaxHTTPRequestBytes + sandboxfunction.MaxInlineSourceBytes + (1 << 20)
+	maxFunctionStdoutBytes    = 4 << 20
+	maxFunctionStderrBytes    = 64 << 10
+	maxFunctionStreamFrame    = 4 << 20
 )
 
 var (
@@ -137,10 +136,6 @@ func (h *FunctionHandler) Execute(w http.ResponseWriter, r *http.Request) {
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), timeout)
 	defer cancel()
-	if err := h.waitRunner(ctx); err != nil {
-		h.writeRunnerUnavailable(w, err)
-		return
-	}
 	modulePath, err := h.materializeSource(req.Source)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
@@ -161,6 +156,10 @@ func (h *FunctionHandler) Execute(w http.ResponseWriter, r *http.Request) {
 	}
 
 	stdout, stderr, truncated, err := h.run(ctx, modulePath, req.Handler, req.EnvVars, payload)
+	if isFunctionRunnerStartError(err) {
+		h.writeRunnerStartError(w, err)
+		return
+	}
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		writeError(w, http.StatusGatewayTimeout, spec.CodeUnavailable, "function execution timed out")
 		return
@@ -213,12 +212,6 @@ func (h *FunctionHandler) Stream(w http.ResponseWriter, r *http.Request) {
 		ctx, cancel = context.WithTimeout(ctx, time.Duration(req.TimeoutMS)*time.Millisecond)
 		defer cancel()
 	}
-	waitCtx, waitCancel := h.runnerWaitContext(ctx, req.TimeoutMS)
-	defer waitCancel()
-	if err := h.waitRunner(waitCtx); err != nil {
-		h.writeRunnerUnavailable(w, err)
-		return
-	}
 	modulePath, err := h.materializeSource(req.Source)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
@@ -242,6 +235,12 @@ func (h *FunctionHandler) Stream(w http.ResponseWriter, r *http.Request) {
 	}
 	tracker := &trackingResponseWriter{ResponseWriter: w}
 	if err := h.runStream(ctx, tracker, modulePath, req.Handler, req.EnvVars, payload); err != nil {
+		if isFunctionRunnerStartError(err) {
+			if !tracker.written {
+				h.writeRunnerStartError(w, err)
+			}
+			return
+		}
 		if !tracker.written {
 			writeError(w, http.StatusInternalServerError, "function_failed", "function stream failed")
 		}
@@ -281,12 +280,6 @@ func (h *FunctionHandler) WebSocket(w http.ResponseWriter, r *http.Request) {
 		_ = conn.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.ClosePolicyViolation, err.Error()), time.Now().Add(time.Second))
 		return
 	}
-	waitCtx, waitCancel := h.runnerWaitContext(r.Context(), req.TimeoutMS)
-	defer waitCancel()
-	if err := h.waitRunner(waitCtx); err != nil {
-		_ = conn.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseInternalServerErr, "function runtime unavailable"), time.Now().Add(time.Second))
-		return
-	}
 	modulePath, err := h.materializeSource(req.Source)
 	if err != nil {
 		_ = conn.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.ClosePolicyViolation, err.Error()), time.Now().Add(time.Second))
@@ -305,6 +298,10 @@ func (h *FunctionHandler) WebSocket(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := h.runWebSocket(r.Context(), conn, modulePath, req.Handler, req.EnvVars, payload); err != nil {
+		if isFunctionRunnerStartError(err) {
+			_ = conn.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseInternalServerErr, "function runtime unavailable"), time.Now().Add(time.Second))
+			return
+		}
 		h.logger.Warn("Function websocket failed",
 			zap.String("service_id", req.ServiceID),
 			zap.String("route_id", req.RouteID),
@@ -687,56 +684,19 @@ func decodeFunctionExecuteResponse(data []byte) (sandboxfunction.ExecuteResponse
 	return response, nil
 }
 
-func (h *FunctionHandler) checkRunner() error {
-	info, err := os.Stat(h.runnerPath)
-	if err != nil {
-		return err
-	}
-	if info.IsDir() {
-		return fmt.Errorf("%s is a directory", h.runnerPath)
-	}
-	return nil
+func isFunctionRunnerStartError(err error) bool {
+	return errors.Is(err, os.ErrNotExist) ||
+		errors.Is(err, osexec.ErrNotFound) ||
+		errors.Is(err, os.ErrPermission) ||
+		errors.Is(err, syscall.ENOTDIR) ||
+		errors.Is(err, syscall.EISDIR) ||
+		errors.Is(err, syscall.ENOEXEC)
 }
 
-func (h *FunctionHandler) waitRunner(ctx context.Context) error {
-	var lastErr error
-	for {
-		err := h.checkRunner()
-		if err == nil {
-			return nil
-		}
-		if !errors.Is(err, os.ErrNotExist) {
-			return err
-		}
-		lastErr = err
-
-		timer := time.NewTimer(functionRunnerWaitInterval)
-		select {
-		case <-ctx.Done():
-			if !timer.Stop() {
-				select {
-				case <-timer.C:
-				default:
-				}
-			}
-			if lastErr != nil {
-				return lastErr
-			}
-			return ctx.Err()
-		case <-timer.C:
-		}
-	}
-}
-
-func (h *FunctionHandler) runnerWaitContext(parent context.Context, timeoutMS int) (context.Context, context.CancelFunc) {
-	if timeoutMS > 0 {
-		return context.WithTimeout(parent, time.Duration(timeoutMS)*time.Millisecond)
-	}
-	return context.WithTimeout(parent, h.defaultTimeout)
-}
-
-func (h *FunctionHandler) writeRunnerUnavailable(w http.ResponseWriter, err error) {
-	if errors.Is(err, os.ErrNotExist) {
+func (h *FunctionHandler) writeRunnerStartError(w http.ResponseWriter, err error) {
+	if errors.Is(err, os.ErrNotExist) ||
+		errors.Is(err, osexec.ErrNotFound) ||
+		errors.Is(err, syscall.ENOTDIR) {
 		writeError(w, http.StatusServiceUnavailable, spec.CodeUnavailable, "function runtime unavailable")
 		return
 	}

--- a/manager/procd/pkg/http/handlers/function_test.go
+++ b/manager/procd/pkg/http/handlers/function_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -11,7 +12,6 @@ import (
 	"runtime"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/gorilla/websocket"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
@@ -19,23 +19,14 @@ import (
 	"go.uber.org/zap"
 )
 
-func TestFunctionHandlerExecuteWaitsForRunner(t *testing.T) {
+func TestFunctionHandlerExecuteMissingRunnerReturnsRuntimeUnavailable(t *testing.T) {
 	dir := t.TempDir()
 	runnerPath := filepath.Join(dir, "runner")
 	handler := newFunctionHandler(functionHandlerConfig{runnerPath: runnerPath}, zap.NewNop())
 
-	go func() {
-		time.Sleep(100 * time.Millisecond)
-		_ = os.WriteFile(runnerPath, []byte(`#!/bin/sh
-cat >/dev/null
-printf '{"status":201,"body_base64":"b2s="}\n'
-`), 0o755)
-	}()
-
 	req := sandboxfunction.ExecuteRequest{
-		Runtime:   sandboxfunction.RuntimePython,
-		Handler:   sandboxfunction.DefaultHandler,
-		TimeoutMS: 1000,
+		Runtime: sandboxfunction.RuntimePython,
+		Handler: sandboxfunction.DefaultHandler,
 		Source: sandboxfunction.Source{
 			Type: sandboxfunction.SourceTypeInline,
 			Code: "def handler(request):\n    return {'status': 201}\n",
@@ -49,18 +40,15 @@ printf '{"status":201,"body_base64":"b2s="}\n'
 
 	rec := httptest.NewRecorder()
 	handler.Execute(rec, httptest.NewRequest(http.MethodPost, "/api/v1/functions/execute", bytes.NewReader(body)))
-	if rec.Code != http.StatusOK {
+	if rec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
 	}
-	var envelope struct {
-		Success bool                            `json:"success"`
-		Data    sandboxfunction.ExecuteResponse `json:"data"`
-	}
+	var envelope spec.Response
 	if err := json.Unmarshal(rec.Body.Bytes(), &envelope); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if !envelope.Success || envelope.Data.Status != http.StatusCreated {
-		t.Fatalf("response = %+v, want created function response", envelope)
+	if envelope.Error == nil || envelope.Error.Code != spec.CodeUnavailable || envelope.Error.Message != "function runtime unavailable" {
+		t.Fatalf("error = %#v, want runtime unavailable", envelope.Error)
 	}
 }
 
@@ -289,6 +277,43 @@ printf '{"type":"chunk","body_base64":"ZGF0YTogdHdvCgo="}\n'
 	}
 }
 
+func TestFunctionHandlerStreamMissingRunnerReturnsRuntimeUnavailable(t *testing.T) {
+	dir := t.TempDir()
+	runnerPath := filepath.Join(dir, "runner")
+	handler := newFunctionHandler(functionHandlerConfig{
+		runnerPath: runnerPath,
+		cacheRoot:  filepath.Join(dir, "cache"),
+	}, zap.NewNop())
+	req := sandboxfunction.ExecuteRequest{
+		Runtime: sandboxfunction.RuntimePython,
+		Handler: sandboxfunction.DefaultHandler,
+		Source: sandboxfunction.Source{
+			Type: sandboxfunction.SourceTypeInline,
+			Code: "def handler(request):\n    return None\n",
+		},
+		Request: sandboxfunction.HTTPRequest{Method: "GET", Path: "/events"},
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/api/v1/functions/stream", bytes.NewReader(body))
+	handler.Stream(rec, httpReq)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var envelope spec.Response
+	if err := json.Unmarshal(rec.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if envelope.Error == nil || envelope.Error.Code != spec.CodeUnavailable || envelope.Error.Message != "function runtime unavailable" {
+		t.Fatalf("error = %#v, want runtime unavailable", envelope.Error)
+	}
+}
+
 func TestFunctionHandlerWebSocketRunsRunner(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell runner fixture requires POSIX")
@@ -340,12 +365,9 @@ printf '{"type":"message","message_type":"text","data":"echo"}\n'
 	}
 }
 
-func TestFunctionHandlerWebSocketWaitsForRunner(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("shell runner fixture requires POSIX")
-	}
+func TestFunctionHandlerWebSocketMissingRunnerClosesRuntimeUnavailable(t *testing.T) {
 	dir := t.TempDir()
-	runnerPath := filepath.Join(dir, "runner.sh")
+	runnerPath := filepath.Join(dir, "runner")
 	handler := newFunctionHandler(functionHandlerConfig{
 		runnerPath: runnerPath,
 		cacheRoot:  filepath.Join(dir, "cache"),
@@ -353,19 +375,9 @@ func TestFunctionHandlerWebSocketWaitsForRunner(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(handler.WebSocket))
 	defer server.Close()
 
-	go func() {
-		time.Sleep(100 * time.Millisecond)
-		_ = os.WriteFile(runnerPath, []byte(`#!/bin/sh
-read init
-read message
-printf '{"type":"message","message_type":"text","data":"echo-after-wait"}\n'
-`), 0o755)
-	}()
-
 	req := sandboxfunction.ExecuteRequest{
-		Runtime:   sandboxfunction.RuntimePython,
-		Handler:   sandboxfunction.DefaultHandler,
-		TimeoutMS: 1000,
+		Runtime: sandboxfunction.RuntimePython,
+		Handler: sandboxfunction.DefaultHandler,
 		Source: sandboxfunction.Source{
 			Type: sandboxfunction.SourceTypeInline,
 			Code: "def handler(request):\n    return None\n",
@@ -381,14 +393,12 @@ printf '{"type":"message","message_type":"text","data":"echo-after-wait"}\n'
 	if err := conn.WriteJSON(req); err != nil {
 		t.Fatalf("write init: %v", err)
 	}
-	if err := conn.WriteMessage(websocket.TextMessage, []byte("ping")); err != nil {
-		t.Fatalf("write message: %v", err)
+	_, _, err = conn.ReadMessage()
+	var closeErr *websocket.CloseError
+	if !errors.As(err, &closeErr) {
+		t.Fatalf("read error = %v, want close error", err)
 	}
-	_, data, err := conn.ReadMessage()
-	if err != nil && err != io.EOF {
-		t.Fatalf("read message: %v", err)
-	}
-	if string(data) != "echo-after-wait" {
-		t.Fatalf("data = %q, want echo-after-wait", string(data))
+	if closeErr.Code != websocket.CloseInternalServerErr || closeErr.Text != "function runtime unavailable" {
+		t.Fatalf("close error = %#v, want runtime unavailable", closeErr)
 	}
 }


### PR DESCRIPTION
## Summary
- remove procd function runner stat preflight and polling before execute/stream/websocket handlers run
- map runner process start failures back to function runtime unavailable/internal errors at the exec boundary
- replace delayed-runner tests with missing-runner coverage for execute, stream, and websocket paths

This keeps the rootfs checkpoint runtime-path exclusion from #543 as the actual fix for #489 and avoids treating /procd/bin/python-runner as an asynchronously ready service.

## Tests
- go test ./manager/procd/pkg/http/handlers -count=1
- go test ./manager/procd/pkg/http/handlers ./cluster-gateway/pkg/http ./ctld/internal/ctld/rootfs -count=1