### PR TITLE
Initialize claimed sandboxes from rootfs snapshots

### DIFF
--- a/docs/sandbox/page.mdx
+++ b/docs/sandbox/page.mdx
@@ -63,6 +63,7 @@ Claim a sandbox from a template. The sandbox is created from a pre-warmed pool f
 | Field | Type | Description |
 |-------|------|-------------|
 | `template` | string | Template ID to use |
+| `snapshot_id` | string | Optional rootfs snapshot ID used to initialize the writable root filesystem |
 | `config` | object | Optional sandbox configuration |
 
 ### Sandbox Configuration

--- a/docs/sandbox/snapshot-restore/page.mdx
+++ b/docs/sandbox/snapshot-restore/page.mdx
@@ -29,6 +29,7 @@ Use [Volumes](/docs/volume) when data must be mounted by multiple sandboxes, acc
 ## State Model
 
 - `Create snapshot` reads the paused sandbox's current rootfs head and creates a snapshot record.
+- `Claim with snapshot_id` creates a running sandbox and initializes its writable rootfs from the selected snapshot before process APIs are initialized.
 - `Restore` changes a paused target sandbox rootfs head to the selected snapshot and leaves the sandbox paused.
 - `Fork` creates a new paused sandbox with the source sandbox configuration and an isolated rootfs fork.
 - `Resume` is required before reading or writing files through sandbox process and file APIs after restore or fork.
@@ -269,6 +270,63 @@ console.log("Created at:", fetched.createdAt);`
       language: "bash",
       code: `s0 sandbox snapshot list sb_abc123
 s0 sandbox snapshot get rootfs-snapshot-abc123`
+    }
+  ]}
+/>
+
+## Claim From A Snapshot
+
+Use `snapshot_id` on sandbox claim when you want a new running sandbox initialized from a named rootfs snapshot. The requested template still controls image, resources, mount declarations, services, network defaults, and other runtime shape. Sandbox0 applies the snapshot rootfs before file APIs, contexts, services, and SSH are initialized.
+
+<Endpoint method="POST">
+/api/v1/sandboxes
+</Endpoint>
+
+### Request Body
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `template` | string | Template ID to use |
+| `snapshot_id` | string | Rootfs snapshot ID used to initialize the new sandbox writable rootfs |
+| `config` | object | Optional sandbox configuration |
+| `mounts` | array | Optional claim-time Sandbox Volume mounts |
+
+<Tabs
+  tabs={[
+    {
+      label: "Go",
+      language: "go",
+      code: `sandbox, err := client.ClaimSandbox(ctx, "default",
+    sandbox0.WithSandboxSnapshotID(snapshot.ID),
+    sandbox0.WithSandboxHardTTL(3600),
+)
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Printf("Sandbox ID: %s\\n", sandbox.ID)`
+    },
+    {
+      label: "Python",
+      language: "python",
+      code: `sandbox = client.sandboxes.claim(
+    "default",
+    snapshot_id=snapshot.id,
+)
+print(f"Sandbox ID: {sandbox.id}")`
+    },
+    {
+      label: "TypeScript",
+      language: "typescript",
+      code: `const sandbox = await client.sandboxes.claim("default", {
+    snapshotId: snapshot.id,
+    config: { hardTtl: 3600 },
+});
+console.log("Sandbox ID:", sandbox.id);`
+    },
+    {
+      label: "CLI",
+      language: "bash",
+      code: `s0 sandbox create --template default --snapshot-id rootfs-snapshot-abc123`
     }
   ]}
 />

--- a/manager/pkg/http/handlers_sandbox.go
+++ b/manager/pkg/http/handlers_sandbox.go
@@ -48,7 +48,7 @@ func (s *Server) claimSandbox(c *gin.Context) {
 			spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
 			return
 		}
-		if apierrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) || errors.Is(err, service.ErrRootFSSnapshotNotFound) {
 			spec.JSONError(c, http.StatusNotFound, spec.CodeNotFound, err.Error())
 			return
 		}

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -33,12 +33,13 @@ const (
 
 // ClaimRequest represents a sandbox claim request
 type ClaimRequest struct {
-	TeamID   string
-	UserID   string
-	Template string         `json:"template"`
-	Config   *SandboxConfig `json:"config,omitempty"`
-	Mounts   []ClaimMount   `json:"mounts,omitempty"`
-	Metadata *ClaimMetadata `json:"-"`
+	TeamID     string
+	UserID     string
+	Template   string         `json:"template"`
+	SnapshotID string         `json:"snapshot_id,omitempty"`
+	Config     *SandboxConfig `json:"config,omitempty"`
+	Mounts     []ClaimMount   `json:"mounts,omitempty"`
+	Metadata   *ClaimMetadata `json:"-"`
 	// SandboxID is an internal stable ID used when recreating an existing sandbox.
 	SandboxID string `json:"-"`
 	// RuntimeGeneration identifies the current runtime pod incarnation.
@@ -311,6 +312,7 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 		return nil, err
 	}
 	req.Template = canonicalTemplateID
+	req.SnapshotID = strings.TrimSpace(req.SnapshotID)
 	phaseStarted = time.Now()
 	if err := validateClaimMounts(req); err != nil {
 		s.observeClaimPhase(req.Template, "unknown", "validate_claim_mounts", phaseStarted, err)
@@ -493,11 +495,36 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 		s.refreshSandboxProbeConditionsAsync(pod)
 	}
 
+	claimRecordPersisted := false
+	cleanupClaimFailure := func(pod *corev1.Pod, reason string) {
+		s.requestSandboxDeletionAfterClaimFailure(pod, reason)
+		if claimRecordPersisted {
+			s.markSandboxDeletedAfterClaimFailure(req.SandboxID, reason)
+		}
+	}
+
+	if req.SnapshotID != "" {
+		phaseStarted = time.Now()
+		var recordPersisted bool
+		pod, recordPersisted, err = s.initializeClaimRootFSFromSnapshot(ctx, pod, template, req)
+		if recordPersisted {
+			claimRecordPersisted = true
+		}
+		s.observeClaimPhase(req.Template, claimType, "initialize_rootfs_snapshot", phaseStarted, err)
+		if err != nil {
+			cleanupClaimFailure(pod, "rootfs snapshot initialization failed")
+			if metrics != nil {
+				metrics.SandboxClaimsTotal.WithLabelValues(req.Template, "error").Inc()
+			}
+			return nil, fmt.Errorf("initialize rootfs from snapshot: %w", err)
+		}
+	}
+
 	phaseStarted = time.Now()
 	portalMounts, err := s.bindVolumePortals(ctx, pod, req, template)
 	s.observeClaimPhase(req.Template, claimType, "bind_volume_portals", phaseStarted, err)
 	if err != nil {
-		s.requestSandboxDeletionAfterClaimFailure(pod, "volume portal bind failed")
+		cleanupClaimFailure(pod, "volume portal bind failed")
 		if metrics != nil {
 			metrics.SandboxClaimsTotal.WithLabelValues(req.Template, "error").Inc()
 		}
@@ -506,7 +533,7 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 	phaseStarted = time.Now()
 	if err := s.bindWebhookStatePortal(ctx, pod, req); err != nil {
 		s.observeClaimPhase(req.Template, claimType, "bind_webhook_state_portal", phaseStarted, err)
-		s.requestSandboxDeletionAfterClaimFailure(pod, "webhook state portal bind failed")
+		cleanupClaimFailure(pod, "webhook state portal bind failed")
 		if metrics != nil {
 			metrics.SandboxClaimsTotal.WithLabelValues(req.Template, "error").Inc()
 		}
@@ -518,7 +545,7 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 	procdAddress, err := s.prodAddress(ctx, pod)
 	s.observeClaimPhase(req.Template, claimType, "resolve_procd_address", phaseStarted, err)
 	if err != nil {
-		s.requestSandboxDeletionAfterClaimFailure(pod, "procd address resolution failed")
+		cleanupClaimFailure(pod, "procd address resolution failed")
 		if metrics != nil {
 			metrics.SandboxClaimsTotal.WithLabelValues(req.Template, "error").Inc()
 		}
@@ -527,7 +554,7 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 	phaseStarted = time.Now()
 	if _, err := s.initializeProcd(ctx, pod, req, procdAddress); err != nil {
 		s.observeClaimPhase(req.Template, claimType, "initialize_procd", phaseStarted, err)
-		s.requestSandboxDeletionAfterClaimFailure(pod, "procd initialization failed")
+		cleanupClaimFailure(pod, "procd initialization failed")
 		if metrics != nil {
 			metrics.SandboxClaimsTotal.WithLabelValues(req.Template, "error").Inc()
 		}
@@ -538,7 +565,7 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 	phaseStarted = time.Now()
 	if err := s.persistClaimedSandbox(ctx, pod, template, req); err != nil {
 		s.observeClaimPhase(req.Template, claimType, "persist_sandbox", phaseStarted, err)
-		s.requestSandboxDeletionAfterClaimFailure(pod, "sandbox persistence failed")
+		cleanupClaimFailure(pod, "sandbox persistence failed")
 		if metrics != nil {
 			metrics.SandboxClaimsTotal.WithLabelValues(req.Template, "error").Inc()
 		}
@@ -566,16 +593,20 @@ func (s *SandboxService) persistClaimedSandbox(ctx context.Context, pod *corev1.
 	if s == nil || s.sandboxStore == nil || pod == nil || template == nil || req == nil {
 		return nil
 	}
+	return s.sandboxStore.UpsertSandbox(ctx, sandboxRecordForClaimedPod(s, pod, template, req))
+}
+
+func sandboxRecordForClaimedPod(s *SandboxService, pod *corev1.Pod, template *v1alpha1.SandboxTemplate, req *ClaimRequest) *SandboxRecord {
 	sandboxID := sandboxIDFromPod(pod)
 	if sandboxID == "" {
 		sandboxID = req.SandboxID
 	}
 	if sandboxID == "" {
-		return fmt.Errorf("sandbox_id is required")
+		sandboxID = pod.Name
 	}
 	cfg := parseSandboxConfig(pod.Annotations[controller.AnnotationConfig])
 	mounts := parseClaimMounts(pod.Annotations[controller.AnnotationMounts])
-	return s.sandboxStore.UpsertSandbox(ctx, &SandboxRecord{
+	return &SandboxRecord{
 		ID:                  sandboxID,
 		TeamID:              req.TeamID,
 		UserID:              req.UserID,
@@ -594,7 +625,63 @@ func (s *SandboxService) persistClaimedSandbox(ctx context.Context, pod *corev1.
 		ExpiresAt:           parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationExpiresAt),
 		HardExpiresAt:       parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationHardExpiresAt),
 		CreatedAt:           s.clock.Now(),
-	})
+	}
+}
+
+func (s *SandboxService) initializeClaimRootFSFromSnapshot(ctx context.Context, pod *corev1.Pod, template *v1alpha1.SandboxTemplate, req *ClaimRequest) (*corev1.Pod, bool, error) {
+	if req == nil || strings.TrimSpace(req.SnapshotID) == "" {
+		return pod, false, nil
+	}
+	store, err := s.rootFSProductStore()
+	if err != nil {
+		return pod, false, err
+	}
+	snapshotID := strings.TrimSpace(req.SnapshotID)
+	if _, err := store.GetRootFSSnapshot(ctx, snapshotID, req.TeamID); err != nil {
+		return pod, false, err
+	}
+	record := sandboxRecordForClaimedPod(s, pod, template, req)
+	if strings.TrimSpace(record.ID) == "" {
+		return pod, false, fmt.Errorf("sandbox_id is required")
+	}
+	if err := s.sandboxStore.UpsertSandbox(ctx, record); err != nil {
+		return pod, false, err
+	}
+	restorer := sandboxRootFSRestorer(store)
+	if _, err := restorer.RestoreRootFSFromSnapshot(ctx, &RestoreRootFSFromSnapshotRequest{
+		SandboxID:  record.ID,
+		SnapshotID: snapshotID,
+		TeamID:     req.TeamID,
+	}); err != nil {
+		return pod, true, err
+	}
+	state, err := s.latestRootFSState(ctx, record.ID)
+	if err != nil {
+		return pod, true, fmt.Errorf("load rootfs snapshot state: %w", err)
+	}
+	if state == nil {
+		return pod, true, fmt.Errorf("%w: snapshot %s", ErrRootFSFilesystemNotFound, snapshotID)
+	}
+	pod, err = s.applySandboxRootFSCheckpointWithFallback(ctx, pod, record, template, req, state, SandboxStatusStarting)
+	if err != nil {
+		return pod, true, err
+	}
+	return pod, true, nil
+}
+
+func (s *SandboxService) markSandboxDeletedAfterClaimFailure(sandboxID, reason string) {
+	if s == nil || s.sandboxStore == nil || strings.TrimSpace(sandboxID) == "" {
+		return
+	}
+	cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := s.sandboxStore.MarkSandboxDeleted(cleanupCtx, sandboxID, s.now().UTC()); err != nil && s.logger != nil {
+		s.logger.Warn("Failed to mark sandbox deleted after claim failure",
+			zap.String("sandboxID", sandboxID),
+			zap.String("reason", reason),
+			zap.Error(err),
+		)
+	}
 }
 
 func runtimeGenerationFromPod(pod *corev1.Pod) int64 {

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/network"
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
 	"github.com/sandbox0-ai/sandbox0/pkg/dataplane"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
@@ -117,6 +118,19 @@ func TestClaimRequestDoesNotAcceptRuntimeMetadataFromJSON(t *testing.T) {
 	}
 	if req.Metadata != nil {
 		t.Fatalf("metadata = %#v, want nil for public JSON input", req.Metadata)
+	}
+}
+
+func TestClaimRequestAcceptsSnapshotIDFromJSON(t *testing.T) {
+	var req ClaimRequest
+	if err := json.Unmarshal([]byte(`{
+		"template":"template-a",
+		"snapshot_id":"rootfs-snapshot-1"
+	}`), &req); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if req.SnapshotID != "rootfs-snapshot-1" {
+		t.Fatalf("SnapshotID = %q, want rootfs-snapshot-1", req.SnapshotID)
 	}
 }
 
@@ -602,6 +616,124 @@ func TestCreateNewPodFailsBeforeCreateWhenDataPlaneNotReady(t *testing.T) {
 	}
 	if len(pods.Items) != 0 {
 		t.Fatalf("pods after data-plane-not-ready cold claim = %d, want 0", len(pods.Items))
+	}
+}
+
+func TestClaimSandboxInitializesRootFSFromSnapshotBeforeProcd(t *testing.T) {
+	withClaimTestPublicKey(t)
+
+	templateID := "template-a"
+	templateNamespace, err := naming.TemplateNamespaceForBuiltin(templateID)
+	if err != nil {
+		t.Fatalf("template namespace: %v", err)
+	}
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      templateID,
+			Namespace: templateNamespace,
+		},
+	}
+
+	var calls []string
+	var applyReq ctldapi.ApplyRootFSRequest
+	ctld := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/rootfs/apply" {
+			http.NotFound(w, r)
+			return
+		}
+		if err := json.NewDecoder(r.Body).Decode(&applyReq); err != nil {
+			t.Fatalf("decode apply request: %v", err)
+		}
+		calls = append(calls, "apply")
+		_ = json.NewEncoder(w).Encode(ctldapi.ApplyRootFSResponse{Applied: true})
+	}))
+	defer ctld.Close()
+	ctldURL, ctldPort := parsedTestServer(t, ctld.URL)
+
+	procd := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/initialize" {
+			http.NotFound(w, r)
+			return
+		}
+		if len(calls) != 1 || calls[0] != "apply" {
+			t.Fatalf("calls before procd = %v, want [apply]", calls)
+		}
+		calls = append(calls, "procd")
+		if err := spec.WriteSuccess(w, http.StatusOK, InitializeResponse{SandboxID: "sandbox-a", TeamID: "team-a"}); err != nil {
+			t.Fatalf("write procd response: %v", err)
+		}
+	}))
+	defer procd.Close()
+	procdURL, procdPort := parsedTestServer(t, procd.URL)
+
+	idlePod := newClaimTestPod(templateNamespace, "idle-ready", templateID, true)
+	idlePod.Spec.NodeName = "node-a"
+	idlePod.Status.HostIP = ctldURL.Hostname()
+	idlePod.Status.PodIP = procdURL.Hostname()
+	store := &memorySandboxStore{
+		records: map[string]*SandboxRecord{},
+		rootFSSnapshots: map[string]*RootFSSnapshot{
+			"rootfs-snapshot-1": {
+				ID:              "rootfs-snapshot-1",
+				FilesystemID:    "source-fs",
+				TeamID:          "team-a",
+				SourceSandboxID: "source-sandbox",
+				HeadLayerID:     "layer-v1",
+				CreatedAt:       time.Now().UTC(),
+			},
+		},
+	}
+	client := fake.NewSimpleClientset(idlePod.DeepCopy())
+	svc := &SandboxService{
+		k8sClient:              client,
+		podLister:              newClaimTestPodLister(t, idlePod),
+		secretLister:           newClaimTestSecretLister(t),
+		templateLister:         staticTemplateLister{templates: []*v1alpha1.SandboxTemplate{template}},
+		sandboxStore:           store,
+		ctldClient:             NewCtldClient(CtldClientConfig{Timeout: time.Second}),
+		procdClient:            NewProcdClient(ProcdClientConfig{Timeout: time.Second}),
+		internalTokenGenerator: staticTokenGenerator{},
+		config: SandboxServiceConfig{
+			CtldEnabled:      true,
+			CtldPort:         ctldPort,
+			ProcdPort:        procdPort,
+			ProcdInitTimeout: time.Second,
+		},
+		clock:  systemTime{},
+		logger: zap.NewNop(),
+	}
+
+	resp, err := svc.ClaimSandbox(context.Background(), &ClaimRequest{
+		Template:   templateID,
+		SnapshotID: "rootfs-snapshot-1",
+		TeamID:     "team-a",
+		UserID:     "user-a",
+	})
+	if err != nil {
+		t.Fatalf("ClaimSandbox() error = %v", err)
+	}
+	if resp == nil || resp.SandboxID == "" {
+		t.Fatalf("ClaimSandbox() response = %+v, want sandbox id", resp)
+	}
+	if len(calls) != 2 || calls[0] != "apply" || calls[1] != "procd" {
+		t.Fatalf("calls = %v, want [apply procd]", calls)
+	}
+	if applyReq.Target.PodName != "idle-ready" {
+		t.Fatalf("apply target pod = %q, want idle-ready", applyReq.Target.PodName)
+	}
+	if applyReq.BaselineLayerID != "layer-v1" {
+		t.Fatalf("BaselineLayerID = %q, want layer-v1", applyReq.BaselineLayerID)
+	}
+	if len(applyReq.Layers) != 1 || applyReq.Layers[0].LayerID != "layer-v1" {
+		t.Fatalf("apply layers = %+v, want layer-v1", applyReq.Layers)
+	}
+	state := store.rootFSStates[resp.SandboxID]
+	if state == nil || state.LayerID != "layer-v1" {
+		t.Fatalf("rootfs state = %+v, want layer-v1 for claimed sandbox", state)
+	}
+	record := store.records[resp.SandboxID]
+	if record == nil || record.Status != SandboxStatusRunning {
+		t.Fatalf("record = %+v, want running claimed sandbox", record)
 	}
 }
 

--- a/manager/pkg/service/sandbox_service_restore.go
+++ b/manager/pkg/service/sandbox_service_restore.go
@@ -138,7 +138,7 @@ func (s *SandboxService) finishRestoredSandboxRuntime(ctx context.Context, pod *
 	if err != nil {
 		return pod, fmt.Errorf("load rootfs checkpoint: %w", err)
 	}
-	pod, err = s.applySandboxRootFSCheckpointWithFallback(ctx, pod, record, template, req, rootFSState)
+	pod, err = s.applySandboxRootFSCheckpointWithFallback(ctx, pod, record, template, req, rootFSState, SandboxStatusResuming)
 	if err != nil {
 		return pod, err
 	}

--- a/manager/pkg/service/sandbox_service_rootfs.go
+++ b/manager/pkg/service/sandbox_service_rootfs.go
@@ -170,9 +170,12 @@ func (s *SandboxService) applySandboxRootFSCheckpoint(ctx context.Context, pod *
 	return nil
 }
 
-func (s *SandboxService) applySandboxRootFSCheckpointWithFallback(ctx context.Context, pod *corev1.Pod, record *SandboxRecord, template *v1alpha1.SandboxTemplate, req *ClaimRequest, state *SandboxRootFSState) (*corev1.Pod, error) {
+func (s *SandboxService) applySandboxRootFSCheckpointWithFallback(ctx context.Context, pod *corev1.Pod, record *SandboxRecord, template *v1alpha1.SandboxTemplate, req *ClaimRequest, state *SandboxRootFSState, fallbackStatus string) (*corev1.Pod, error) {
 	if state == nil {
 		return pod, nil
+	}
+	if strings.TrimSpace(fallbackStatus) == "" {
+		fallbackStatus = SandboxStatusResuming
 	}
 	err := s.applySandboxRootFSCheckpoint(ctx, pod, state)
 	if err == nil {
@@ -201,7 +204,7 @@ func (s *SandboxService) applySandboxRootFSCheckpointWithFallback(ctx context.Co
 		s.requestSandboxDeletionAfterClaimFailure(fallbackPod, "checkpoint base image runtime readiness failed")
 		return fallbackPod, fmt.Errorf("%w; wait for checkpoint base image runtime: %v", err, fallbackErr)
 	}
-	if fallbackErr := s.saveRestoredRuntimePod(ctx, readyPod, record, SandboxStatusResuming); fallbackErr != nil {
+	if fallbackErr := s.saveRestoredRuntimePod(ctx, readyPod, record, fallbackStatus); fallbackErr != nil {
 		s.requestSandboxDeletionAfterClaimFailure(readyPod, "checkpoint base image runtime persistence failed")
 		return readyPod, fmt.Errorf("%w; save checkpoint base image runtime: %v", err, fallbackErr)
 	}

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -3999,6 +3999,9 @@ components:
       properties:
         template:
           type: string
+        snapshot_id:
+          type: string
+          description: Optional sandbox rootfs snapshot ID used to initialize the claimed sandbox writable root filesystem.
         config:
           $ref: "#/components/schemas/SandboxConfig"
         mounts:

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -609,9 +609,12 @@ type ClaimMountRequest struct {
 
 // ClaimRequest defines model for ClaimRequest.
 type ClaimRequest struct {
-	Config   *SandboxConfig       `json:"config,omitempty"`
-	Mounts   *[]ClaimMountRequest `json:"mounts,omitempty"`
-	Template *string              `json:"template,omitempty"`
+	Config *SandboxConfig       `json:"config,omitempty"`
+	Mounts *[]ClaimMountRequest `json:"mounts,omitempty"`
+
+	// SnapshotId Optional sandbox rootfs snapshot ID used to initialize the claimed sandbox writable root filesystem.
+	SnapshotId *string `json:"snapshot_id,omitempty"`
+	Template   *string `json:"template,omitempty"`
 }
 
 // ClaimResponse defines model for ClaimResponse.


### PR DESCRIPTION
## Summary
- add optional claim request snapshot_id for rootfs snapshot initialization
- restore and apply the snapshot rootfs before volume portals and procd initialization
- document claim-from-snapshot flows and update OpenAPI

## Tests
- go test ./manager/pkg/service ./manager/pkg/http ./pkg/apispec

## Remote validation
- pending: will deploy this PR to the remote kind environment after confirming the ECS is Stopped