### PR TITLE
docs: prefer rootfs snapshot claim workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Sandbox0 is the runtime boundary for enterprise AI agent platforms.
 
 It gives platform teams isolated, persistent sandboxes for agent work that needs to run code, edit repositories, expose per-agent HTTP services, keep workspace state, and access external systems without placing broad production credentials inside the agent runtime.
 
-The sandbox writable root filesystem is checkpointed across pause/resume. Sandbox0 can release the runtime pod, keep the sandbox identity, and restore files written inside the sandbox when a new runtime generation starts. Named rootfs snapshots, restore, and fork let teams reuse an initialized filesystem state without building a new template when the base template already fits. Volumes are a separate storage primitive for data that must outlive one sandbox identity, be shared, snapshotted, forked, or accessed directly through APIs.
+The sandbox writable root filesystem is checkpointed across pause/resume. Sandbox0 can release the runtime pod, keep the sandbox identity, and restore files written inside the sandbox when a new runtime generation starts. Named rootfs snapshots plus claim-time `snapshot_id` let teams reuse an initialized filesystem state without building a new template when the base template already fits. Restore and fork remain available for rollback and paused child-sandbox workflows. Volumes are a separate storage primitive for data that must outlive one sandbox identity, be shared, snapshotted, forked, or accessed directly through APIs.
 
 Use Sandbox0 when you need to:
 
@@ -167,7 +167,7 @@ Use raw Sandbox0 sandboxes when you want direct control over processes, files, t
 
 **Coding agents**
 
-Start from a builtin template when its image, resources, mount points, and network defaults already fit. Install project dependencies or clone repositories inside the sandbox, pause it, then create a rootfs snapshot or fork the paused sandbox for per-task branches. Use a custom template when you need a different base image, resource envelope, mount declarations, default environment, or network policy. Use a stateful REPL for the active agent loop and one-shot commands for isolated build/test steps.
+Start from a builtin template when its image, resources, mount points, and network defaults already fit. Install project dependencies or clone repositories inside a seed sandbox, pause it, create a rootfs snapshot, then claim per-task sandboxes with the same template and `snapshot_id`. Use a custom template when you need a different base image, resource envelope, mount declarations, default environment, or network policy. Use a stateful REPL for the active agent loop and one-shot commands for isolated build/test steps.
 
 **Code interpreter, data, or browser agents**
 
@@ -179,7 +179,7 @@ Run gateways such as Hermes or OpenClaw as `cmd` Sandbox Services. Store framewo
 
 **Parallel workers**
 
-Create one sandbox per task, eval case, branch, or user request. Fork from a paused seed sandbox when each worker should inherit the same initialized rootfs. Share read-only data through volumes or object storage, then write outputs to separate volumes or task-specific paths. Keep orchestration outside the sandbox boundary.
+Create one sandbox per task, eval case, branch, or user request. Claim from a rootfs snapshot when each worker should inherit the same initialized rootfs. Share read-only data through volumes or object storage, then write outputs to separate volumes or task-specific paths. Keep orchestration outside the sandbox boundary.
 
 **Long-running sessions**
 
@@ -191,7 +191,7 @@ Treat the sandbox process as runtime state and the volume as durable state. Paus
 | -------------- | ---------- | ---------------------------- |
 | **Template** | A runtime blueprint: image, resources, warm pool, mount points, and default policy. | Keeps environments reproducible and claims fast. |
 | **Sandbox** | A durable identity and configuration for an isolated runtime instance. | Gives each task, user, or agent worker its own execution boundary. |
-| **Root filesystem** | The sandbox writable filesystem checkpointed during pause/resume and tied to the sandbox identity. | Lets files written inside the sandbox survive runtime pod cleanup without explicit mounts; named snapshots and forks can reuse initialized filesystem state. |
+| **Root filesystem** | The sandbox writable filesystem checkpointed during pause/resume and tied to the sandbox identity. | Lets files written inside the sandbox survive runtime pod cleanup without explicit mounts; named snapshots and claim-time `snapshot_id` can reuse initialized filesystem state. |
 | **Context** | A process/session inside a sandbox, either REPL-style or one-shot command. | Lets agents choose in-process continuity or clean execution per tool call. |
 | **Volume** | Persistent storage independent of a sandbox lifetime. | Keeps repositories, caches, agent memory, artifacts, checkpoints, snapshots, forks, and shared data. |
 | **Service** | A public HTTP entrypoint backed by a listener, command, or function. | Exposes per-sandbox APIs, previews, webhooks, and agent gateways with route policy. |
@@ -204,7 +204,7 @@ The short version: use templates for runtime shape and warm pools, sandboxes for
 Sandbox0 separates runtime state from filesystem state.
 
 - The sandbox writable root filesystem is persisted as the latest rootfs checkpoint for the same sandbox identity. Files written outside mounted volumes survive pause/resume once the pause checkpoint succeeds.
-- Named rootfs snapshots, restore, and fork preserve or branch initialized sandbox filesystem state, but they still use the sandbox's template for image, resources, mounts, and network defaults.
+- Named rootfs snapshots and claim-time `snapshot_id` preserve initialized sandbox filesystem state for new sandboxes, but the requested template still controls image, resources, mounts, and network defaults. Restore and fork remain available for existing paused sandboxes and paused child-sandbox workflows.
 - `ttl` is a runtime soft timeout. When it expires, Sandbox0 checkpoints the writable root filesystem, pauses the sandbox, and releases runtime compute.
 - `hard_ttl` is a hard sandbox lifetime. When it expires, Sandbox0 deletes the sandbox identity and durable state tied to that identity, including rootfs checkpoints.
 - Pause/resume preserves sandbox identity and the latest writable root filesystem checkpoint, but not running processes, memory, sockets, PID state, or live REPL sessions.
@@ -234,9 +234,9 @@ Sandbox0 optimizes for this in these places:
 
 - **Warm pools** keep template instances ready so a claim can reuse an idle pod instead of starting the environment from scratch.
 - **Template images** move expensive package, toolchain, browser, and agent framework setup out of the request path.
-- **Rootfs checkpoints, rootfs snapshots, and volumes** keep resumed or branched sandboxes useful after runtime cleanup. Use rootfs checkpoints for transparent runtime restore, rootfs snapshots/forks for initialized sandbox state, and volumes for explicit durable workspaces, snapshots, forks, and shared data.
+- **Rootfs checkpoints, rootfs snapshots, and volumes** keep resumed or branched sandboxes useful after runtime cleanup. Use rootfs checkpoints for transparent runtime restore, rootfs snapshots plus claim-time `snapshot_id` for initialized sandbox state, and volumes for explicit durable workspaces, snapshots, forks, and shared data.
 
-For best results, put broadly reused runtime setup into the template image, capture project-specific initialization with rootfs snapshots or forks when the base template already fits, keep active task state in a volume when it must outlive the sandbox identity, and keep sandboxes short-lived enough that idle compute does not become the source of truth.
+For best results, put broadly reused runtime setup into the template image, capture project-specific initialization with rootfs snapshots and claim new sandboxes with `snapshot_id` when the base template already fits, keep active task state in a volume when it must outlive the sandbox identity, and keep sandboxes short-lived enough that idle compute does not become the source of truth.
 
 ## Self-Hosting
 

--- a/docs/sandbox/snapshot-restore/page.mdx
+++ b/docs/sandbox/snapshot-restore/page.mdx
@@ -1,16 +1,17 @@
 # Snapshot And Restore
 
-Sandbox rootfs snapshots are point-in-time copies of a paused sandbox writable root filesystem. Use them when you want to checkpoint an initialized workspace, roll a sandbox back to a known filesystem state, or fork a paused sandbox into an isolated child sandbox.
+Sandbox rootfs snapshots are point-in-time copies of a paused sandbox writable root filesystem. Use them when you want to checkpoint an initialized workspace, claim new sandboxes from that known filesystem state, roll an existing sandbox back, or fork a paused sandbox into an isolated child sandbox.
 
 Use this page when you need to:
 
 - create named rootfs snapshots from a paused sandbox
+- claim a new sandbox with a named rootfs snapshot
 - restore a paused sandbox rootfs from a snapshot
 - fork a paused sandbox into another paused sandbox
 - understand how rootfs snapshots differ from pause/resume and Volumes
 
 <Callout variant="warning">
-Sandbox rootfs snapshot, restore, and fork operations require a paused sandbox. If you call them while the sandbox is running, Sandbox0 returns `409 Conflict`. Pause first, then wait until sandbox `status` is `paused`.
+Creating snapshots, restoring, and forking require a paused sandbox. Claiming with `snapshot_id` creates a new running sandbox from an existing snapshot and does not require a paused target sandbox. If you call paused-only operations while the sandbox is running, Sandbox0 returns `409 Conflict`.
 </Callout>
 
 ## How It Differs From Pause And Resume
@@ -19,10 +20,11 @@ Sandbox rootfs snapshot, restore, and fork operations require a paused sandbox. 
 |------------|---------|-------------------------------|-------------------------|-------------------------|
 | Pause/resume | Release compute and later continue the same sandbox identity from its latest checkpoint | No | No | Pause starts from a running sandbox; resume starts from a paused sandbox |
 | Snapshot | Publish an immutable point-in-time rootfs record | Yes | No | Yes |
+| Claim with `snapshot_id` | Create a running sandbox initialized from a named snapshot | Uses an existing snapshot | Yes | No target sandbox required |
 | Restore | Move a paused sandbox rootfs back to a snapshot | Uses an existing snapshot | No | Yes |
 | Fork | Create an isolated paused sandbox from a paused source sandbox rootfs | No | Yes | Yes |
 
-Pause/resume keeps the latest checkpoint for one sandbox identity. Rootfs snapshots are explicit records that you can list, fetch, restore, and delete. Fork creates a new sandbox with Copy-on-Write rootfs isolation from the source rootfs state.
+Pause/resume keeps the latest checkpoint for one sandbox identity. Rootfs snapshots are explicit records that you can list, fetch, claim from, restore, and delete. Fork creates a new sandbox with Copy-on-Write rootfs isolation from the source rootfs state.
 
 Use [Volumes](/docs/volume) when data must be mounted by multiple sandboxes, accessed directly through the Volume file API, or managed independently from sandbox rootfs lifecycle. Use sandbox rootfs snapshots when the default writable filesystem is the state you want to version.
 
@@ -32,16 +34,16 @@ Use [Volumes](/docs/volume) when data must be mounted by multiple sandboxes, acc
 - `Claim with snapshot_id` creates a running sandbox and initializes its writable rootfs from the selected snapshot before process APIs are initialized.
 - `Restore` changes a paused target sandbox rootfs head to the selected snapshot and leaves the sandbox paused.
 - `Fork` creates a new paused sandbox with the source sandbox configuration and an isolated rootfs fork.
-- `Resume` is required before reading or writing files through sandbox process and file APIs after restore or fork.
-- Deleting a snapshot does not modify any sandbox that already restored from it, and it does not affect forks created from the same rootfs state.
+- `Resume` is required before reading or writing files through sandbox process and file APIs after restore or fork. A sandbox claimed with `snapshot_id` starts running.
+- Deleting a snapshot does not modify any sandbox already claimed or restored from it, and it does not affect forks created from the same rootfs state.
 
 <Callout variant="info">
 The rootfs snapshot API stores snapshot metadata including `name`, `description`, and optional `expires_at`. Delete snapshots explicitly when cleanup workflows no longer need them.
 </Callout>
 
-## Initialize Once, Fork Many
+## Initialize Once, Claim Many
 
-Rootfs snapshots and forks can act like a lightweight custom environment when your changes are ordinary filesystem state. Instead of building a custom image and maintaining a team-owned warm pool, start from a builtin template, initialize the sandbox, then checkpoint that rootfs state.
+Rootfs snapshots plus claim-time `snapshot_id` can act like a lightweight custom rootfs when your changes are ordinary filesystem state. Instead of building a custom image and maintaining a team-owned warm pool, start from a builtin template, initialize the sandbox, publish a rootfs snapshot, then claim new sandboxes from that snapshot.
 
 Use this pattern for:
 
@@ -55,29 +57,33 @@ Typical workflow:
 1. claim a sandbox from a builtin template backed by the platform warm pool
 2. install dependencies or prepare the workspace inside the sandbox rootfs
 3. pause the sandbox and wait until `status` is `paused`
-4. create a named snapshot when you need a stable restore point, or fork the paused sandbox directly when you need isolated task sandboxes
-5. resume the restored or forked sandbox before running task-specific commands
+4. create a named rootfs snapshot for the initialized state
+5. claim each task sandbox with the same template and `snapshot_id`
 
 ```bash
-SANDBOX_ID="$(s0 -o json sandbox create --template default --hard-ttl 86400 | jq -r '.ID')"
+SEED_SANDBOX_ID="$(s0 -o json sandbox create --template default --hard-ttl 86400 | jq -r '.id')"
 
 # Initialize the rootfs with your normal sandbox commands, file writes, or SSH session.
 
-s0 sandbox pause "$SANDBOX_ID"
+s0 sandbox pause "$SEED_SANDBOX_ID"
 # Wait until this shows status "paused".
-s0 sandbox get "$SANDBOX_ID"
+s0 sandbox get "$SEED_SANDBOX_ID"
 
-s0 sandbox snapshot create "$SANDBOX_ID" \
+SNAPSHOT_ID="$(s0 -o json sandbox snapshot create "$SEED_SANDBOX_ID" \
     --name python-deps-v1 \
-    --description "Default template after Python dependency install"
+    --description "Default template after Python dependency install" \
+    | jq -r '.id')"
 
-FORKED_SANDBOX_ID="$(s0 -o json sandbox fork "$SANDBOX_ID" | jq -r '.sandbox.id')"
-s0 sandbox resume "$FORKED_SANDBOX_ID"
+TASK_SANDBOX_ID="$(s0 -o json sandbox create \
+    --template default \
+    --snapshot-id "$SNAPSHOT_ID" \
+    --hard-ttl 3600 \
+    | jq -r '.id')"
 ```
 
-Fork is usually the shorter path for branch-per-task workflows because it creates a new paused sandbox directly from the seed rootfs. Snapshot is better when you need a named checkpoint that can be listed, fetched, restored later, and cleaned up independently.
+Claiming with `snapshot_id` is the preferred path for reusable custom rootfs state because the result is a fresh running sandbox that still uses the builtin template's image, resources, mounts, services, and network defaults. Use restore when you need to roll an existing paused sandbox back to a snapshot. Use fork when you specifically need a paused child sandbox cloned from a paused seed.
 
-For a longer walkthrough of this pattern, see [Initialize Once, Fork Many](/blog/2026-06/initialize-once-fork-many-custom-ai-agent-sandboxes).
+For a longer walkthrough of this pattern, see [Initialize Once, Claim Many](/blog/2026-06/initialize-once-fork-many-custom-ai-agent-sandboxes).
 
 <Callout variant="warning">
 This pattern does not replace template-level configuration. Use a custom template when you need a different container image, resource limits, mount declarations, default network policy, environment defaults, or privileged runtime fields. Mounted Sandbox Volumes are separate from the sandbox rootfs and should be managed with Volume snapshot and fork APIs.
@@ -496,9 +502,9 @@ For coding-agent and test-generation workflows, a common pattern is:
 1. claim a sandbox and initialize the repository or dependency cache
 2. write a marker, lockfile, or workspace state that future tasks should inherit
 3. pause the sandbox and wait for `status` to become `paused`
-4. create a rootfs snapshot, or fork directly from the paused sandbox
-5. restore or fork for each task branch
-6. resume the restored or forked sandbox and run task-specific work
+4. create a rootfs snapshot for that initialized state
+5. claim each task sandbox with the same template and `snapshot_id`
+6. run task-specific work in the newly claimed sandbox
 
 ## Next Steps
 
@@ -515,7 +521,7 @@ For coding-agent and test-generation workflows, a common pattern is:
     Use durable shared storage when rootfs snapshots are not the right persistence boundary.
   </Card>
 
-  <Card title="Initialize Once, Fork Many" href="/blog/2026-06/initialize-once-fork-many-custom-ai-agent-sandboxes" cta="Read">
-    Use rootfs snapshots and forks as lightweight custom environments.
+  <Card title="Initialize Once, Claim Many" href="/blog/2026-06/initialize-once-fork-many-custom-ai-agent-sandboxes" cta="Read">
+    Use rootfs snapshots and claim-time snapshot IDs as lightweight custom rootfs state.
   </Card>
 </CardGroup>

--- a/docs/template/configuration/page.mdx
+++ b/docs/template/configuration/page.mdx
@@ -64,7 +64,7 @@ The main sandbox container configuration.
 | `image` | string | — | Container image reference. Use a public image (e.g., `python:3.12-slim`) or the `Template image reference` returned by `s0 template image push` for private images. |
 | `resources.cpu` | string | — | CPU limit for the sandbox (e.g., `"1"`, `"2"`, `"500m"`). |
 | `resources.memory` | string | — | Memory limit for the sandbox (e.g., `"2Gi"`, `"512Mi"`). |
-| `resources.ephemeralStorage` | string | `512Mi` | Writable-layer and container-log storage for the sandbox runtime. Checkpointed pause/resume saves and restores the writable root filesystem, but this quota still bounds writes to `/tmp` or image-local paths. Use rootfs snapshots and forks to version initialized sandbox files, and use Sandbox Volumes for sharing or long-lived durable data independent of sandbox identity. |
+| `resources.ephemeralStorage` | string | `512Mi` | Writable-layer and container-log storage for the sandbox runtime. Checkpointed pause/resume saves and restores the writable root filesystem, but this quota still bounds writes to `/tmp` or image-local paths. Use rootfs snapshots and claim-time `snapshot_id` to version initialized sandbox files, and use Sandbox Volumes for sharing or long-lived durable data independent of sandbox identity. |
 | `env` | array | `[]` | Per-container environment variables. Each entry has `name` and `value`. |
 
 <Callout variant="info">

--- a/docs/template/page.mdx
+++ b/docs/template/page.mdx
@@ -21,25 +21,25 @@ Builtin templates use curated public images and are ready to use immediately. Cu
 
 ## Custom Template Or Rootfs Snapshot
 
-You do not need a custom template for every initialized environment. If the base image, resources, network policy, and mount declarations already fit, you can claim a sandbox from a builtin template, install dependencies or clone repositories inside the writable root filesystem, pause it, then create a rootfs snapshot or fork it.
+You do not need a custom template for every initialized environment. If the base image, resources, network policy, and mount declarations already fit, you can claim a sandbox from a builtin template, install dependencies or clone repositories inside the writable root filesystem, pause it, create a rootfs snapshot, then claim future sandboxes with that `snapshot_id`.
 
 This is useful for dependency-heavy agent workspaces:
 
 1. claim a sandbox from a platform-owned builtin template such as `default` or `dins`
 2. install packages, populate caches, clone repositories, or write tool configuration
 3. pause the sandbox and wait for `status` to become `paused`
-4. create a named rootfs snapshot, or keep the paused sandbox as a seed and fork it for each task
-5. resume the restored or forked sandbox before running task-specific work
+4. create a named rootfs snapshot for the initialized state
+5. claim each task sandbox with the same template and `snapshot_id`
 
 For platform-owned builtin templates, the operator manages the warm pool. That lets teams reuse warm builtin capacity and store only the initialized rootfs state for their own dependency set instead of maintaining a separate custom template pool for each variation.
 
 | Need | Prefer |
 |------|--------|
 | Different base image, resource envelope, default environment, mount paths, network defaults, or privileged runtime fields | Custom template |
-| User-space dependencies, repository checkout, package cache, generated files, or per-project tool configuration on an existing base image | Builtin template plus rootfs snapshot or fork |
+| User-space dependencies, repository checkout, package cache, generated files, or per-project tool configuration on an existing base image | Builtin template plus rootfs snapshot and claim with `snapshot_id` |
 | Data that must outlive sandbox identity, be mounted by multiple sandboxes, or be accessed through direct storage APIs | Sandbox Volume |
 
-Rootfs snapshots do not create template IDs and do not appear in `s0 template list`. A fork keeps the source sandbox's template and sandbox configuration, while restore changes only the target sandbox rootfs. See [Snapshot And Restore](/docs/sandbox/snapshot-restore) for the paused-state requirements and API workflow, or read [Initialize Once, Fork Many](/blog/2026-06/initialize-once-fork-many-custom-ai-agent-sandboxes) for the custom-environment pattern.
+Rootfs snapshots do not create template IDs and do not appear in `s0 template list`. Claiming with `snapshot_id` creates a new running sandbox from the selected rootfs snapshot while the requested template still controls image, resources, mounts, services, and network defaults. Restore remains useful for rolling back an existing paused sandbox, and fork remains useful when you specifically need a paused child sandbox. See [Snapshot And Restore](/docs/sandbox/snapshot-restore) for the paused-state requirements and API workflow, or read [Initialize Once, Claim Many](/blog/2026-06/initialize-once-fork-many-custom-ai-agent-sandboxes) for the custom-rootfs pattern.
 
 ---
 
@@ -381,7 +381,7 @@ console.log("Template deleted");`
     Reuse initialized rootfs state without creating another template.
   </Card>
 
-  <Card title="Initialize Once, Fork Many" href="/blog/2026-06/initialize-once-fork-many-custom-ai-agent-sandboxes" cta="Read">
-    Customize a builtin template with rootfs snapshots and forks.
+  <Card title="Initialize Once, Claim Many" href="/blog/2026-06/initialize-once-fork-many-custom-ai-agent-sandboxes" cta="Read">
+    Customize a builtin template with rootfs snapshots and claim-time snapshot IDs.
   </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary
- recommend rootfs snapshot + claim with snapshot_id for builtin-template custom rootfs workflows
- keep restore and fork documented as rollback / paused child-sandbox paths
- update README, template docs, and snapshot/restore docs consistently

## Verification
- npm run build (sandbox0-cloud/apps/website)
- git diff --check (sandbox0)
- git diff --check (sandbox0-cloud)