### PR TITLE
Filter volume paths from persistent rootfs checkpoints

### DIFF
--- a/ctld/internal/ctld/rootfs/containerd_runtime.go
+++ b/ctld/internal/ctld/rootfs/containerd_runtime.go
@@ -153,7 +153,7 @@ func (r *ContainerdRuntime) Inspect(ctx context.Context, target ctldapi.RootFSCo
 	return info, nil
 }
 
-func (r *ContainerdRuntime) CreateDiff(ctx context.Context, info ctldapi.RootFSInfo) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error) {
+func (r *ContainerdRuntime) CreateDiff(ctx context.Context, info ctldapi.RootFSInfo, excludedPaths []string) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error) {
 	if strings.TrimSpace(info.SnapshotKey) == "" || strings.TrimSpace(info.Snapshotter) == "" {
 		return ctldapi.RootFSDiffDescriptor{}, nil, fmt.Errorf("%w: snapshot key and snapshotter are required", ErrBadRequest)
 	}
@@ -162,7 +162,7 @@ func (r *ContainerdRuntime) CreateDiff(ctx context.Context, info ctldapi.RootFSI
 		return ctldapi.RootFSDiffDescriptor{}, nil, err
 	}
 
-	if desc, reader, ok, fastErr := r.createOverlayUpperDiff(ctx, client, info); ok && fastErr == nil {
+	if desc, reader, ok, fastErr := r.createOverlayUpperDiff(ctx, client, info, excludedPaths); ok && fastErr == nil {
 		closeClient()
 		return desc, reader, nil
 	} else if ok && fastErr != nil {
@@ -171,12 +171,16 @@ func (r *ContainerdRuntime) CreateDiff(ctx context.Context, info ctldapi.RootFSI
 			closeClient()
 			return ctldapi.RootFSDiffDescriptor{}, nil, fmt.Errorf("overlayfs fast diff: %v; containerd diff: %w", fastErr, err)
 		}
-		blob, err := content.BlobReadSeeker(ctx, client.ContentStore(), desc)
+		rootDesc, reader, needsClient, err := rootFSDiffReaderFromContent(ctx, client, desc, excludedPaths)
 		if err != nil {
 			closeClient()
 			return ctldapi.RootFSDiffDescriptor{}, nil, err
 		}
-		return descriptorFromOCI(desc), closeReadSeekWithFunc{ReadSeekCloser: blob, closeFunc: closeClient}, nil
+		if !needsClient {
+			closeClient()
+			return rootDesc, reader, nil
+		}
+		return rootDesc, closeReadSeekWithFunc{ReadSeekCloser: reader, closeFunc: closeClient}, nil
 	}
 
 	desc, err := crootfs.CreateDiff(ctx, info.SnapshotKey, client.SnapshotService(info.Snapshotter), client.DiffService())
@@ -184,15 +188,19 @@ func (r *ContainerdRuntime) CreateDiff(ctx context.Context, info ctldapi.RootFSI
 		closeClient()
 		return ctldapi.RootFSDiffDescriptor{}, nil, err
 	}
-	reader, err := content.BlobReadSeeker(ctx, client.ContentStore(), desc)
+	rootDesc, reader, needsClient, err := rootFSDiffReaderFromContent(ctx, client, desc, excludedPaths)
 	if err != nil {
 		closeClient()
 		return ctldapi.RootFSDiffDescriptor{}, nil, err
 	}
-	return descriptorFromOCI(desc), closeReadSeekWithFunc{ReadSeekCloser: reader, closeFunc: closeClient}, nil
+	if !needsClient {
+		closeClient()
+		return rootDesc, reader, nil
+	}
+	return rootDesc, closeReadSeekWithFunc{ReadSeekCloser: reader, closeFunc: closeClient}, nil
 }
 
-func (r *ContainerdRuntime) CreateDiffFromBaseline(ctx context.Context, info ctldapi.RootFSInfo, baselineLayerID string) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error) {
+func (r *ContainerdRuntime) CreateDiffFromBaseline(ctx context.Context, info ctldapi.RootFSInfo, baselineLayerID string, excludedPaths []string) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error) {
 	if strings.TrimSpace(baselineLayerID) == "" {
 		return ctldapi.RootFSDiffDescriptor{}, nil, fmt.Errorf("%w: baseline layer id is required", ErrBadRequest)
 	}
@@ -215,10 +223,10 @@ func (r *ContainerdRuntime) CreateDiffFromBaseline(ctx context.Context, info ctl
 	} else if !st.IsDir() {
 		return ctldapi.RootFSDiffDescriptor{}, nil, fmt.Errorf("%w: rootfs baseline path is not a directory", ErrConflict)
 	}
-	return writeOverlayUpperDiffFromBaseline(ctx, baselineDir, upperdir)
+	return writeOverlayUpperDiffFromBaseline(ctx, baselineDir, upperdir, excludedPaths)
 }
 
-func (r *ContainerdRuntime) ApplyDiff(ctx context.Context, info ctldapi.RootFSInfo, desc ctldapi.RootFSDiffDescriptor, reader io.Reader) (ctldapi.RootFSDiffDescriptor, error) {
+func (r *ContainerdRuntime) ApplyDiff(ctx context.Context, info ctldapi.RootFSInfo, desc ctldapi.RootFSDiffDescriptor, reader io.Reader, excludedPaths []string) (ctldapi.RootFSDiffDescriptor, error) {
 	if strings.TrimSpace(info.ContainerID) == "" {
 		return ctldapi.RootFSDiffDescriptor{}, fmt.Errorf("%w: container id is required", ErrBadRequest)
 	}
@@ -232,7 +240,7 @@ func (r *ContainerdRuntime) ApplyDiff(ctx context.Context, info ctldapi.RootFSIn
 	if err != nil {
 		return ctldapi.RootFSDiffDescriptor{}, err
 	}
-	filteredDesc, filteredReader, err := filterRootFSDiffTar(desc, reader)
+	filteredDesc, filteredReader, err := filterRootFSDiffTar(desc, reader, excludedPaths)
 	if err != nil {
 		return ctldapi.RootFSDiffDescriptor{}, fmt.Errorf("filter rootfs diff: %w", err)
 	}
@@ -259,7 +267,7 @@ func (r *ContainerdRuntime) ApplyDiff(ctx context.Context, info ctldapi.RootFSIn
 	return descriptorFromOCI(applied), nil
 }
 
-func (r *ContainerdRuntime) CaptureBaseline(ctx context.Context, info ctldapi.RootFSInfo, baselineLayerID string) error {
+func (r *ContainerdRuntime) CaptureBaseline(ctx context.Context, info ctldapi.RootFSInfo, baselineLayerID string, excludedPaths []string) error {
 	if strings.TrimSpace(baselineLayerID) == "" {
 		return fmt.Errorf("%w: baseline layer id is required", ErrBadRequest)
 	}
@@ -291,6 +299,9 @@ func (r *ContainerdRuntime) CaptureBaseline(ctx context.Context, info ctldapi.Ro
 	if err := fs.CopyDir(tmp, upperdir); err != nil {
 		return fmt.Errorf("copy rootfs baseline: %w", err)
 	}
+	if err := newRootFSPathFilter(excludedPaths).RemoveAll(tmp); err != nil {
+		return fmt.Errorf("filter rootfs baseline: %w", err)
+	}
 	if err := os.RemoveAll(target); err != nil {
 		return fmt.Errorf("replace rootfs baseline: %w", err)
 	}
@@ -299,6 +310,28 @@ func (r *ContainerdRuntime) CaptureBaseline(ctx context.Context, info ctldapi.Ro
 	}
 	removeTmp = false
 	return nil
+}
+
+func rootFSDiffReaderFromContent(ctx context.Context, client containerdClient, desc ocispec.Descriptor, excludedPaths []string) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, bool, error) {
+	rootDesc := descriptorFromOCI(desc)
+	reader, err := content.BlobReadSeeker(ctx, client.ContentStore(), desc)
+	if err != nil {
+		return ctldapi.RootFSDiffDescriptor{}, nil, false, err
+	}
+	if !shouldFilterRootFSDiffTar(rootDesc) {
+		return rootDesc, reader, true, nil
+	}
+
+	filteredDesc, filteredReader, err := filterRootFSDiffTar(rootDesc, reader, excludedPaths)
+	closeErr := reader.Close()
+	if err != nil {
+		return ctldapi.RootFSDiffDescriptor{}, nil, false, err
+	}
+	if closeErr != nil {
+		_ = filteredReader.Close()
+		return ctldapi.RootFSDiffDescriptor{}, nil, false, closeErr
+	}
+	return filteredDesc, filteredReader, false, nil
 }
 
 func (r *ContainerdRuntime) rootFSBaselinePath(info ctldapi.RootFSInfo, baselineLayerID string) string {

--- a/ctld/internal/ctld/rootfs/controller.go
+++ b/ctld/internal/ctld/rootfs/controller.go
@@ -23,10 +23,10 @@ var (
 
 type Runtime interface {
 	Inspect(ctx context.Context, target ctldapi.RootFSContainerRef) (ctldapi.RootFSInfo, error)
-	CreateDiff(ctx context.Context, info ctldapi.RootFSInfo) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error)
-	CreateDiffFromBaseline(ctx context.Context, info ctldapi.RootFSInfo, baselineLayerID string) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error)
-	ApplyDiff(ctx context.Context, info ctldapi.RootFSInfo, desc ctldapi.RootFSDiffDescriptor, content io.Reader) (ctldapi.RootFSDiffDescriptor, error)
-	CaptureBaseline(ctx context.Context, info ctldapi.RootFSInfo, baselineLayerID string) error
+	CreateDiff(ctx context.Context, info ctldapi.RootFSInfo, excludedPaths []string) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error)
+	CreateDiffFromBaseline(ctx context.Context, info ctldapi.RootFSInfo, baselineLayerID string, excludedPaths []string) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error)
+	ApplyDiff(ctx context.Context, info ctldapi.RootFSInfo, desc ctldapi.RootFSDiffDescriptor, content io.Reader, excludedPaths []string) (ctldapi.RootFSDiffDescriptor, error)
+	CaptureBaseline(ctx context.Context, info ctldapi.RootFSInfo, baselineLayerID string, excludedPaths []string) error
 }
 
 type Config struct {
@@ -82,7 +82,7 @@ func (c *Controller) SaveRootFS(r *http.Request, req ctldapi.SaveRootFSRequest) 
 	if err := validateSupportedRuntime(info); err != nil {
 		return ctldapi.SaveRootFSResponse{Info: info, Error: err.Error()}, http.StatusBadRequest
 	}
-	desc, reader, err := c.createDiff(ctx, info, strings.TrimSpace(req.ParentLayerID))
+	desc, reader, err := c.createDiff(ctx, info, strings.TrimSpace(req.ParentLayerID), req.ExcludedPaths)
 	if err != nil {
 		return ctldapi.SaveRootFSResponse{Info: info, Error: fmt.Sprintf("create rootfs diff: %v", err)}, statusForError(err)
 	}
@@ -138,36 +138,36 @@ func (c *Controller) ApplyRootFS(r *http.Request, req ctldapi.ApplyRootFSRequest
 		if err := validateBaselineLayerID(req); err != nil {
 			return ctldapi.ApplyRootFSResponse{Info: info, Error: err.Error()}, http.StatusBadRequest
 		}
-		applied, err := c.applyLayers(ctx, info, req.Layers)
+		applied, err := c.applyLayers(ctx, info, req.Layers, req.ExcludedPaths)
 		if err != nil {
 			return ctldapi.ApplyRootFSResponse{Info: info, Error: err.Error()}, statusForError(err)
 		}
 		if req.BaselineLayerID != "" {
-			if err := c.runtime.CaptureBaseline(ctx, info, req.BaselineLayerID); err != nil {
+			if err := c.runtime.CaptureBaseline(ctx, info, req.BaselineLayerID, req.ExcludedPaths); err != nil {
 				return ctldapi.ApplyRootFSResponse{Info: info, Error: fmt.Sprintf("capture rootfs baseline: %v", err)}, statusForError(err)
 			}
 		}
 		return ctldapi.ApplyRootFSResponse{Info: info, Layers: applied, Applied: true}, http.StatusOK
 	}
 
-	applied, err := c.applyDescriptor(ctx, info, req.Descriptor)
+	applied, err := c.applyDescriptor(ctx, info, req.Descriptor, req.ExcludedPaths)
 	if err != nil {
 		return ctldapi.ApplyRootFSResponse{Info: info, Error: err.Error()}, statusForError(err)
 	}
 	return ctldapi.ApplyRootFSResponse{Info: info, Descriptor: applied, Applied: true}, http.StatusOK
 }
 
-func (c *Controller) createDiff(ctx context.Context, info ctldapi.RootFSInfo, parentLayerID string) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error) {
+func (c *Controller) createDiff(ctx context.Context, info ctldapi.RootFSInfo, parentLayerID string, excludedPaths []string) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error) {
 	if parentLayerID != "" {
-		return c.runtime.CreateDiffFromBaseline(ctx, info, parentLayerID)
+		return c.runtime.CreateDiffFromBaseline(ctx, info, parentLayerID, excludedPaths)
 	}
-	return c.runtime.CreateDiff(ctx, info)
+	return c.runtime.CreateDiff(ctx, info, excludedPaths)
 }
 
-func (c *Controller) applyLayers(ctx context.Context, info ctldapi.RootFSInfo, layers []ctldapi.RootFSLayerDescriptor) ([]ctldapi.RootFSLayerDescriptor, error) {
+func (c *Controller) applyLayers(ctx context.Context, info ctldapi.RootFSInfo, layers []ctldapi.RootFSLayerDescriptor, excludedPaths []string) ([]ctldapi.RootFSLayerDescriptor, error) {
 	applied := make([]ctldapi.RootFSLayerDescriptor, 0, len(layers))
 	for _, layer := range layers {
-		desc, err := c.applyDescriptor(ctx, info, layer.Descriptor)
+		desc, err := c.applyDescriptor(ctx, info, layer.Descriptor, excludedPaths)
 		if err != nil {
 			return nil, err
 		}
@@ -180,14 +180,14 @@ func (c *Controller) applyLayers(ctx context.Context, info ctldapi.RootFSInfo, l
 	return applied, nil
 }
 
-func (c *Controller) applyDescriptor(ctx context.Context, info ctldapi.RootFSInfo, desc ctldapi.RootFSDiffDescriptor) (ctldapi.RootFSDiffDescriptor, error) {
+func (c *Controller) applyDescriptor(ctx context.Context, info ctldapi.RootFSInfo, desc ctldapi.RootFSDiffDescriptor, excludedPaths []string) (ctldapi.RootFSDiffDescriptor, error) {
 	reader, err := c.store.Get(desc.ObjectKey, 0, -1)
 	if err != nil {
 		return ctldapi.RootFSDiffDescriptor{}, fmt.Errorf("download rootfs diff: %w", err)
 	}
 	defer reader.Close()
 
-	applied, err := c.runtime.ApplyDiff(ctx, info, desc, reader)
+	applied, err := c.runtime.ApplyDiff(ctx, info, desc, reader, excludedPaths)
 	if err != nil {
 		return ctldapi.RootFSDiffDescriptor{}, fmt.Errorf("apply rootfs diff: %w", err)
 	}

--- a/ctld/internal/ctld/rootfs/controller_test.go
+++ b/ctld/internal/ctld/rootfs/controller_test.go
@@ -61,6 +61,7 @@ func TestControllerSaveRootFSUploadsDiffWithDefaultObjectKey(t *testing.T) {
 	require.Equal(t, http.StatusOK, status, resp.Error)
 	assert.Equal(t, "sandbox-rootfs/team-1/sandbox-1/7/sha256/feedface.tar", resp.Descriptor.ObjectKey)
 	assert.Equal(t, rootFSInfo("gvisor"), runtime.createInfo)
+	assert.Empty(t, runtime.createExcludedPaths)
 	reader, err := store.Get(resp.Descriptor.ObjectKey, 0, -1)
 	require.NoError(t, err)
 	defer reader.Close()
@@ -87,12 +88,14 @@ func TestControllerSaveRootFSUsesParentBaseline(t *testing.T) {
 		SandboxID:     "sandbox-1",
 		TeamID:        "team-1",
 		ParentLayerID: "layer-parent",
+		ExcludedPaths: []string{"/workspace/data"},
 	})
 
 	require.Equal(t, http.StatusOK, status, resp.Error)
 	assert.True(t, runtime.createBaselineCalled)
 	assert.False(t, runtime.createCalled)
 	assert.Equal(t, "layer-parent", runtime.createBaselineLayerID)
+	assert.Equal(t, []string{"/workspace/data"}, runtime.createBaselineExcludedPaths)
 	assert.Equal(t, "sandbox-rootfs/team-1/sandbox-1/0/sha256/child.tar", resp.Descriptor.ObjectKey)
 	reader, err := store.Get(resp.Descriptor.ObjectKey, 0, -1)
 	require.NoError(t, err)
@@ -141,6 +144,7 @@ func TestControllerApplyRootFSDownloadsAndAppliesDiff(t *testing.T) {
 		ExpectedBaseImageDigest:     "sha256:base",
 		ExpectedSnapshotParent:      "parent-1",
 		ExpectedSnapshotParentChain: []string{"parent-1", "parent-0"},
+		ExcludedPaths:               []string{"/workspace/data"},
 		Descriptor: ctldapi.RootFSDiffDescriptor{
 			MediaType: "application/vnd.oci.image.layer.v1.tar",
 			Digest:    "sha256:feedface",
@@ -155,6 +159,7 @@ func TestControllerApplyRootFSDownloadsAndAppliesDiff(t *testing.T) {
 	assert.Equal(t, "rootfs diff", runtime.applyContent)
 	assert.Equal(t, rootFSInfo("runc"), runtime.applyInfo)
 	assert.Equal(t, "rootfs/diff.tar", runtime.applyInputDesc.ObjectKey)
+	assert.Equal(t, []string{"/workspace/data"}, runtime.applyExcludedPaths)
 }
 
 func TestControllerApplyRootFSAppliesLayerChainAndCapturesBaseline(t *testing.T) {
@@ -180,6 +185,7 @@ func TestControllerApplyRootFSAppliesLayerChainAndCapturesBaseline(t *testing.T)
 		ExpectedSnapshotParent:      "parent-1",
 		ExpectedSnapshotParentChain: []string{"parent-1", "parent-0"},
 		BaselineLayerID:             "layer-child",
+		ExcludedPaths:               []string{"/workspace/data"},
 		Layers: []ctldapi.RootFSLayerDescriptor{
 			{
 				LayerID: "layer-parent",
@@ -212,8 +218,10 @@ func TestControllerApplyRootFSAppliesLayerChainAndCapturesBaseline(t *testing.T)
 	require.Len(t, runtime.applyInputDescs, 2)
 	assert.Equal(t, "rootfs/parent.tar", runtime.applyInputDescs[0].ObjectKey)
 	assert.Equal(t, "rootfs/child.tar", runtime.applyInputDescs[1].ObjectKey)
+	assert.Equal(t, [][]string{{"/workspace/data"}, {"/workspace/data"}}, runtime.applyExcludedPathCalls)
 	assert.True(t, runtime.captureBaselineCalled)
 	assert.Equal(t, "layer-child", runtime.captureBaselineLayerID)
+	assert.Equal(t, []string{"/workspace/data"}, runtime.captureBaselineExcludedPaths)
 	assert.Equal(t, rootFSInfo("runc"), runtime.captureInfo)
 }
 
@@ -357,21 +365,26 @@ type fakeRuntime struct {
 	applyErr              error
 	captureBaselineErr    error
 
-	inspectTargets         []ctldapi.RootFSContainerRef
-	createCalled           bool
-	createInfo             ctldapi.RootFSInfo
-	createBaselineCalled   bool
-	createBaselineInfo     ctldapi.RootFSInfo
-	createBaselineLayerID  string
-	applyCalled            bool
-	applyInfo              ctldapi.RootFSInfo
-	applyInputDesc         ctldapi.RootFSDiffDescriptor
-	applyContent           string
-	applyInputDescs        []ctldapi.RootFSDiffDescriptor
-	applyContents          []string
-	captureBaselineCalled  bool
-	captureInfo            ctldapi.RootFSInfo
-	captureBaselineLayerID string
+	inspectTargets               []ctldapi.RootFSContainerRef
+	createCalled                 bool
+	createInfo                   ctldapi.RootFSInfo
+	createBaselineCalled         bool
+	createBaselineInfo           ctldapi.RootFSInfo
+	createBaselineLayerID        string
+	createExcludedPaths          []string
+	createBaselineExcludedPaths  []string
+	applyCalled                  bool
+	applyInfo                    ctldapi.RootFSInfo
+	applyInputDesc               ctldapi.RootFSDiffDescriptor
+	applyContent                 string
+	applyInputDescs              []ctldapi.RootFSDiffDescriptor
+	applyContents                []string
+	applyExcludedPaths           []string
+	applyExcludedPathCalls       [][]string
+	captureBaselineCalled        bool
+	captureInfo                  ctldapi.RootFSInfo
+	captureBaselineLayerID       string
+	captureBaselineExcludedPaths []string
 }
 
 func (r *fakeRuntime) Inspect(_ context.Context, target ctldapi.RootFSContainerRef) (ctldapi.RootFSInfo, error) {
@@ -379,30 +392,34 @@ func (r *fakeRuntime) Inspect(_ context.Context, target ctldapi.RootFSContainerR
 	return r.info, r.inspectErr
 }
 
-func (r *fakeRuntime) CreateDiff(_ context.Context, info ctldapi.RootFSInfo) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error) {
+func (r *fakeRuntime) CreateDiff(_ context.Context, info ctldapi.RootFSInfo, excludedPaths []string) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error) {
 	r.createCalled = true
 	r.createInfo = info
+	r.createExcludedPaths = append([]string(nil), excludedPaths...)
 	if r.createErr != nil {
 		return ctldapi.RootFSDiffDescriptor{}, nil, r.createErr
 	}
 	return r.createDesc, readSeekNopCloser{Reader: strings.NewReader(r.createContent)}, nil
 }
 
-func (r *fakeRuntime) CreateDiffFromBaseline(_ context.Context, info ctldapi.RootFSInfo, baselineLayerID string) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error) {
+func (r *fakeRuntime) CreateDiffFromBaseline(_ context.Context, info ctldapi.RootFSInfo, baselineLayerID string, excludedPaths []string) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error) {
 	r.createBaselineCalled = true
 	r.createBaselineInfo = info
 	r.createBaselineLayerID = baselineLayerID
+	r.createBaselineExcludedPaths = append([]string(nil), excludedPaths...)
 	if r.createBaselineErr != nil {
 		return ctldapi.RootFSDiffDescriptor{}, nil, r.createBaselineErr
 	}
 	return r.createBaselineDesc, readSeekNopCloser{Reader: strings.NewReader(r.createBaselineContent)}, nil
 }
 
-func (r *fakeRuntime) ApplyDiff(_ context.Context, info ctldapi.RootFSInfo, desc ctldapi.RootFSDiffDescriptor, content io.Reader) (ctldapi.RootFSDiffDescriptor, error) {
+func (r *fakeRuntime) ApplyDiff(_ context.Context, info ctldapi.RootFSInfo, desc ctldapi.RootFSDiffDescriptor, content io.Reader, excludedPaths []string) (ctldapi.RootFSDiffDescriptor, error) {
 	r.applyCalled = true
 	r.applyInfo = info
 	r.applyInputDesc = desc
 	r.applyInputDescs = append(r.applyInputDescs, desc)
+	r.applyExcludedPaths = append([]string(nil), excludedPaths...)
+	r.applyExcludedPathCalls = append(r.applyExcludedPathCalls, append([]string(nil), excludedPaths...))
 	payload, err := io.ReadAll(content)
 	if err != nil {
 		return ctldapi.RootFSDiffDescriptor{}, err
@@ -415,10 +432,11 @@ func (r *fakeRuntime) ApplyDiff(_ context.Context, info ctldapi.RootFSInfo, desc
 	return r.applyDesc, nil
 }
 
-func (r *fakeRuntime) CaptureBaseline(_ context.Context, info ctldapi.RootFSInfo, baselineLayerID string) error {
+func (r *fakeRuntime) CaptureBaseline(_ context.Context, info ctldapi.RootFSInfo, baselineLayerID string, excludedPaths []string) error {
 	r.captureBaselineCalled = true
 	r.captureInfo = info
 	r.captureBaselineLayerID = baselineLayerID
+	r.captureBaselineExcludedPaths = append([]string(nil), excludedPaths...)
 	return r.captureBaselineErr
 }
 

--- a/ctld/internal/ctld/rootfs/overlay_diff.go
+++ b/ctld/internal/ctld/rootfs/overlay_diff.go
@@ -23,12 +23,12 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-var rootFSSnapshotExcludedPaths = []string{
+var defaultRootFSSnapshotExcludedPaths = []string{
 	"/procd",
 	volumeportal.WebhookStateMountPath,
 }
 
-func (r *ContainerdRuntime) createOverlayUpperDiff(ctx context.Context, client containerdClient, info ctldapi.RootFSInfo) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, bool, error) {
+func (r *ContainerdRuntime) createOverlayUpperDiff(ctx context.Context, client containerdClient, info ctldapi.RootFSInfo, excludedPaths []string) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, bool, error) {
 	if strings.TrimSpace(info.Snapshotter) != "overlayfs" {
 		return ctldapi.RootFSDiffDescriptor{}, nil, false, nil
 	}
@@ -36,7 +36,7 @@ func (r *ContainerdRuntime) createOverlayUpperDiff(ctx context.Context, client c
 	if err != nil {
 		return ctldapi.RootFSDiffDescriptor{}, nil, true, err
 	}
-	desc, reader, err := writeOverlayUpperDiff(ctx, upperdir)
+	desc, reader, err := writeOverlayUpperDiff(ctx, upperdir, excludedPaths)
 	return desc, reader, true, err
 }
 
@@ -135,14 +135,16 @@ func rebasePath(path, fromRoot, toRoot string) (string, bool) {
 	return filepath.Join(toRoot, rel), true
 }
 
-func writeOverlayUpperDiff(ctx context.Context, upperdir string) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error) {
-	return writeOverlayDiffTar(upperdir, func(changeFn fs.ChangeFunc) error {
-		return walkOverlayUpper(ctx, upperdir, changeFn)
+func writeOverlayUpperDiff(ctx context.Context, upperdir string, excludedPaths []string) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error) {
+	filter := newRootFSPathFilter(excludedPaths)
+	return writeOverlayDiffTar(upperdir, filter, func(changeFn fs.ChangeFunc) error {
+		return walkOverlayUpper(ctx, upperdir, filter, changeFn)
 	})
 }
 
-func writeOverlayUpperDiffFromBaseline(ctx context.Context, baselineDir, upperdir string) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error) {
-	return writeOverlayDiffTar(upperdir, func(changeFn fs.ChangeFunc) error {
+func writeOverlayUpperDiffFromBaseline(ctx context.Context, baselineDir, upperdir string, excludedPaths []string) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error) {
+	filter := newRootFSPathFilter(excludedPaths)
+	return writeOverlayDiffTar(upperdir, filter, func(changeFn fs.ChangeFunc) error {
 		return fs.Changes(ctx, baselineDir, upperdir, func(kind fs.ChangeKind, path string, info os.FileInfo, err error) error {
 			if err != nil {
 				return err
@@ -153,7 +155,13 @@ func writeOverlayUpperDiffFromBaseline(ctx context.Context, baselineDir, upperdi
 			default:
 			}
 			if kind == fs.ChangeKindDelete {
+				if filter.Excludes(path) {
+					return nil
+				}
 				return changeFn(kind, path, nil, nil)
+			}
+			if filter.Excludes(path) {
+				return nil
 			}
 			if isOverlayWhiteout(info) {
 				return changeFn(fs.ChangeKindDelete, path, nil, nil)
@@ -175,7 +183,7 @@ func writeOverlayUpperDiffFromBaseline(ctx context.Context, baselineDir, upperdi
 	})
 }
 
-func writeOverlayDiffTar(source string, walkChanges func(fs.ChangeFunc) error) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error) {
+func writeOverlayDiffTar(source string, filter rootFSPathFilter, walkChanges func(fs.ChangeFunc) error) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error) {
 	tmp, err := os.CreateTemp("", "sandbox0-rootfs-overlay-diff-*.tar")
 	if err != nil {
 		return ctldapi.RootFSDiffDescriptor{}, nil, err
@@ -191,7 +199,7 @@ func writeOverlayDiffTar(source string, walkChanges func(fs.ChangeFunc) error) (
 	digester := digest.Canonical.Digester()
 	writer := io.MultiWriter(tmp, digester.Hash())
 	cw := archive.NewChangeWriter(writer, source)
-	if err := walkChanges(filteredRootFSChangeFunc(cw.HandleChange)); err != nil {
+	if err := walkChanges(filter.ChangeFunc(cw.HandleChange)); err != nil {
 		_ = cw.Close()
 		return ctldapi.RootFSDiffDescriptor{}, nil, err
 	}
@@ -214,7 +222,7 @@ func writeOverlayDiffTar(source string, walkChanges func(fs.ChangeFunc) error) (
 	}, removeOnCloseFile{File: tmp}, nil
 }
 
-func walkOverlayUpper(ctx context.Context, upperdir string, changeFn fs.ChangeFunc) error {
+func walkOverlayUpper(ctx context.Context, upperdir string, filter rootFSPathFilter, changeFn fs.ChangeFunc) error {
 	return filepath.Walk(upperdir, func(path string, info os.FileInfo, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
@@ -233,7 +241,7 @@ func walkOverlayUpper(ctx context.Context, upperdir string, changeFn fs.ChangeFu
 			return nil
 		}
 		changePath := string(filepath.Separator) + rel
-		if isRootFSSnapshotExcludedPath(changePath) {
+		if filter.Excludes(changePath) {
 			if info != nil && info.IsDir() {
 				return filepath.SkipDir
 			}
@@ -283,22 +291,100 @@ func isOverlayOpaqueDir(path string) (bool, error) {
 	return false, nil
 }
 
-func filteredRootFSChangeFunc(next fs.ChangeFunc) fs.ChangeFunc {
+type rootFSPathFilter struct {
+	excluded       []string
+	opaquePreserve []string
+}
+
+func newRootFSPathFilter(extraPaths []string) rootFSPathFilter {
+	seen := make(map[string]struct{}, len(defaultRootFSSnapshotExcludedPaths)+len(extraPaths))
+	excluded := make([]string, 0, len(defaultRootFSSnapshotExcludedPaths)+len(extraPaths))
+	var opaquePreserve []string
+	add := func(value string, preserveOpaque bool) {
+		clean := cleanRootFSPath(value)
+		if clean == "/" {
+			return
+		}
+		if _, ok := seen[clean]; !ok {
+			seen[clean] = struct{}{}
+			excluded = append(excluded, clean)
+		}
+		if preserveOpaque {
+			opaquePreserve = append(opaquePreserve, clean)
+		}
+	}
+	for _, value := range defaultRootFSSnapshotExcludedPaths {
+		add(value, false)
+	}
+	for _, value := range extraPaths {
+		add(value, true)
+	}
+	return rootFSPathFilter{excluded: excluded, opaquePreserve: opaquePreserve}
+}
+
+func (f rootFSPathFilter) Excludes(changePath string) bool {
+	clean := cleanRootFSPath(changePath)
+	for _, excluded := range f.excluded {
+		if clean == excluded || strings.HasPrefix(clean, excluded+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+func (f rootFSPathFilter) ExcludesTarHeader(headerName string) bool {
+	if f.Excludes(headerName) {
+		return true
+	}
+	if target, opaque, ok := rootFSTarWhiteoutTargetPath(headerName); ok {
+		if opaque {
+			return f.AffectsOpaquePreservedPath(target)
+		}
+		return f.Excludes(target)
+	}
+	return false
+}
+
+func (f rootFSPathFilter) ChangeFunc(next fs.ChangeFunc) fs.ChangeFunc {
 	return func(kind fs.ChangeKind, changePath string, info os.FileInfo, err error) error {
 		if err != nil {
 			return next(kind, changePath, info, err)
 		}
-		if isRootFSSnapshotExcludedPath(changePath) {
+		if f.Excludes(changePath) {
 			return nil
+		}
+		if target, opaque, ok := rootFSChangeWhiteoutTargetPath(changePath); ok {
+			if opaque && f.AffectsOpaquePreservedPath(target) {
+				return nil
+			}
+			if !opaque && f.Excludes(target) {
+				return nil
+			}
 		}
 		return next(kind, changePath, info, err)
 	}
 }
 
-func filterRootFSDiffTar(desc ctldapi.RootFSDiffDescriptor, reader io.Reader) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error) {
-	if strings.TrimSpace(desc.MediaType) != "" && strings.TrimSpace(desc.MediaType) != ocispec.MediaTypeImageLayer {
+func (f rootFSPathFilter) AffectsOpaquePreservedPath(dir string) bool {
+	clean := cleanRootFSPath(dir)
+	for _, preserved := range f.opaquePreserve {
+		if clean == preserved || strings.HasPrefix(preserved, clean+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+func shouldFilterRootFSDiffTar(desc ctldapi.RootFSDiffDescriptor) bool {
+	mediaType := strings.TrimSpace(desc.MediaType)
+	return mediaType == "" || mediaType == ocispec.MediaTypeImageLayer
+}
+
+func filterRootFSDiffTar(desc ctldapi.RootFSDiffDescriptor, reader io.Reader, excludedPaths []string) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error) {
+	if !shouldFilterRootFSDiffTar(desc) {
 		return desc, noopReadSeekCloser{Reader: reader}, nil
 	}
+	filter := newRootFSPathFilter(excludedPaths)
 
 	tmp, err := os.CreateTemp("", "sandbox0-rootfs-filtered-diff-*.tar")
 	if err != nil {
@@ -325,7 +411,7 @@ func filterRootFSDiffTar(desc ctldapi.RootFSDiffDescriptor, reader io.Reader) (c
 			_ = tarWriter.Close()
 			return ctldapi.RootFSDiffDescriptor{}, nil, err
 		}
-		if isRootFSSnapshotExcludedPath(header.Name) {
+		if filter.ExcludesTarHeader(header.Name) {
 			continue
 		}
 
@@ -361,15 +447,47 @@ func filterRootFSDiffTar(desc ctldapi.RootFSDiffDescriptor, reader io.Reader) (c
 	return desc, removeOnCloseFile{File: tmp}, nil
 }
 
-func isRootFSSnapshotExcludedPath(changePath string) bool {
-	clean := cleanRootFSPath(changePath)
-	for _, excluded := range rootFSSnapshotExcludedPaths {
-		excluded = cleanRootFSPath(excluded)
-		if clean == excluded || strings.HasPrefix(clean, excluded+"/") {
-			return true
+func (f rootFSPathFilter) RemoveAll(root string) error {
+	for _, excluded := range f.excluded {
+		rel := strings.TrimPrefix(excluded, "/")
+		if rel == "" {
+			continue
+		}
+		if err := os.RemoveAll(filepath.Join(root, filepath.FromSlash(rel))); err != nil {
+			return fmt.Errorf("remove excluded rootfs path %s: %w", excluded, err)
 		}
 	}
-	return false
+	return nil
+}
+
+func rootFSTarWhiteoutTargetPath(headerName string) (string, bool, bool) {
+	clean := cleanRootFSPath(headerName)
+	base := path.Base(clean)
+	if base == ".wh..wh..opq" {
+		return path.Dir(clean), true, true
+	}
+	return rootFSFileWhiteoutTargetPath(clean)
+}
+
+func rootFSChangeWhiteoutTargetPath(changePath string) (string, bool, bool) {
+	clean := cleanRootFSPath(changePath)
+	base := path.Base(clean)
+	if base == ".wh..opq" {
+		return path.Dir(clean), true, true
+	}
+	return rootFSFileWhiteoutTargetPath(clean)
+}
+
+func rootFSFileWhiteoutTargetPath(clean string) (string, bool, bool) {
+	base := path.Base(clean)
+	if !strings.HasPrefix(base, ".wh.") {
+		return "", false, false
+	}
+	name := strings.TrimPrefix(base, ".wh.")
+	if name == "" {
+		return "", false, false
+	}
+	return path.Join(path.Dir(clean), name), false, true
 }
 
 func cleanRootFSPath(value string) string {

--- a/ctld/internal/ctld/rootfs/overlay_diff_test.go
+++ b/ctld/internal/ctld/rootfs/overlay_diff_test.go
@@ -33,7 +33,7 @@ func TestWriteOverlayUpperDiffIncludesUpperEntries(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(upperdir, "etc", "config"), []byte("value"), 0o644))
 	require.NoError(t, os.Symlink("config", filepath.Join(upperdir, "etc", "config-link")))
 
-	desc, reader, err := writeOverlayUpperDiff(context.Background(), upperdir)
+	desc, reader, err := writeOverlayUpperDiff(context.Background(), upperdir, nil)
 	require.NoError(t, err)
 	defer reader.Close()
 	require.NotEmpty(t, desc.Digest)
@@ -55,7 +55,7 @@ func TestWriteOverlayUpperDiffExcludesRuntimePaths(t *testing.T) {
 	require.NoError(t, os.MkdirAll(filepath.Join(upperdir, "workspace"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(upperdir, "workspace", "state"), []byte("value"), 0o644))
 
-	_, reader, err := writeOverlayUpperDiff(context.Background(), upperdir)
+	_, reader, err := writeOverlayUpperDiff(context.Background(), upperdir, nil)
 	require.NoError(t, err)
 	defer reader.Close()
 
@@ -71,6 +71,50 @@ func TestWriteOverlayUpperDiffExcludesRuntimePaths(t *testing.T) {
 	assert.Contains(t, entries, "workspace/state")
 }
 
+func TestWriteOverlayUpperDiffExcludesConfiguredVolumePaths(t *testing.T) {
+	upperdir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(upperdir, "workspace", "data", "nested"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(upperdir, "workspace", "data", "nested", "volume.txt"), []byte("volume"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(upperdir, "workspace", "database"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(upperdir, "workspace", "database", "rootfs.txt"), []byte("rootfs"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(upperdir, "workspace", "other"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(upperdir, "workspace", "other", "state"), []byte("value"), 0o644))
+
+	_, reader, err := writeOverlayUpperDiff(context.Background(), upperdir, []string{
+		" /workspace/data/ ",
+		"/workspace/data",
+		"/",
+		"",
+	})
+	require.NoError(t, err)
+	defer reader.Close()
+
+	entries := readTarEntries(t, reader)
+	assert.NotContains(t, entries, "workspace/data/")
+	assert.NotContains(t, entries, "workspace/data/nested/")
+	assert.NotContains(t, entries, "workspace/data/nested/volume.txt")
+	assert.Contains(t, entries, "workspace/database/")
+	assert.Contains(t, entries, "workspace/database/rootfs.txt")
+	assert.Contains(t, entries, "workspace/other/state")
+}
+
+func TestWriteOverlayUpperDiffExcludesOpaqueWhiteoutAffectingVolumePath(t *testing.T) {
+	upperdir := t.TempDir()
+	workspace := filepath.Join(upperdir, "workspace")
+	require.NoError(t, os.MkdirAll(filepath.Join(workspace, "database"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(workspace, "database", "rootfs.txt"), []byte("rootfs"), 0o644))
+	markOverlayOpaqueForTest(t, workspace)
+
+	_, reader, err := writeOverlayUpperDiff(context.Background(), upperdir, []string{"/workspace/data"})
+	require.NoError(t, err)
+	defer reader.Close()
+
+	entries := readTarEntries(t, reader)
+	assert.NotContains(t, entries, "workspace/.wh..wh..opq")
+	assert.Contains(t, entries, "workspace/")
+	assert.Contains(t, entries, "workspace/database/rootfs.txt")
+}
+
 func TestWriteOverlayUpperDiffConvertsWhiteouts(t *testing.T) {
 	upperdir := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(upperdir, "etc"), 0o755))
@@ -82,7 +126,7 @@ func TestWriteOverlayUpperDiffConvertsWhiteouts(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	_, reader, err := writeOverlayUpperDiff(context.Background(), upperdir)
+	_, reader, err := writeOverlayUpperDiff(context.Background(), upperdir, nil)
 	require.NoError(t, err)
 	defer reader.Close()
 
@@ -95,14 +139,9 @@ func TestWriteOverlayUpperDiffConvertsOpaqueDirectories(t *testing.T) {
 	upperdir := t.TempDir()
 	dir := filepath.Join(upperdir, "var")
 	require.NoError(t, os.MkdirAll(dir, 0o755))
-	if err := unix.Lsetxattr(dir, "user.overlay.opaque", []byte{'y'}, 0); err != nil {
-		if err == unix.EPERM || err == unix.EACCES || err == unix.ENOTSUP || err == unix.EOPNOTSUPP {
-			t.Skipf("setting overlay opaque xattr is not supported: %v", err)
-		}
-		require.NoError(t, err)
-	}
+	markOverlayOpaqueForTest(t, dir)
 
-	_, reader, err := writeOverlayUpperDiff(context.Background(), upperdir)
+	_, reader, err := writeOverlayUpperDiff(context.Background(), upperdir, nil)
 	require.NoError(t, err)
 	defer reader.Close()
 
@@ -125,7 +164,7 @@ func TestWriteOverlayUpperDiffFromBaselineAppliesAsChildDelta(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(current, "etc", "added"), []byte("added"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(current, "etc", "same"), []byte("same"), 0o644))
 
-	desc, reader, err := writeOverlayUpperDiffFromBaseline(ctx, baseline, current)
+	desc, reader, err := writeOverlayUpperDiffFromBaseline(ctx, baseline, current, nil)
 	require.NoError(t, err)
 	defer reader.Close()
 	require.NotEmpty(t, desc.Digest)
@@ -146,6 +185,31 @@ func TestWriteOverlayUpperDiffFromBaselineAppliesAsChildDelta(t *testing.T) {
 	assert.True(t, os.IsNotExist(err))
 }
 
+func TestWriteOverlayUpperDiffFromBaselineExcludesConfiguredVolumePaths(t *testing.T) {
+	ctx := context.Background()
+	baseline := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(baseline, "workspace", "data"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(baseline, "workspace", "data", "old-volume.txt"), []byte("old"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(baseline, "workspace", "database"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(baseline, "workspace", "database", "same"), []byte("same"), 0o644))
+
+	current := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(current, "workspace", "data"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(current, "workspace", "data", "new-volume.txt"), []byte("new"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(current, "workspace", "database"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(current, "workspace", "database", "same"), []byte("changed"), 0o644))
+
+	_, reader, err := writeOverlayUpperDiffFromBaseline(ctx, baseline, current, []string{"/workspace/data"})
+	require.NoError(t, err)
+	defer reader.Close()
+
+	entries := readTarEntries(t, reader)
+	assert.NotContains(t, entries, "workspace/data/")
+	assert.NotContains(t, entries, "workspace/data/old-volume.txt")
+	assert.NotContains(t, entries, "workspace/data/new-volume.txt")
+	assert.Contains(t, entries, "workspace/database/same")
+}
+
 func TestFilterRootFSDiffTarExcludesRuntimePaths(t *testing.T) {
 	var buf bytes.Buffer
 	tarWriter := tar.NewWriter(&buf)
@@ -156,7 +220,7 @@ func TestFilterRootFSDiffTarExcludesRuntimePaths(t *testing.T) {
 	writeTarEntry(t, tarWriter, "workspace/state", []byte("value"), 0o644)
 	require.NoError(t, tarWriter.Close())
 
-	desc, reader, err := filterRootFSDiffTar(rootFSDiffDescriptorForTest(), bytes.NewReader(buf.Bytes()))
+	desc, reader, err := filterRootFSDiffTar(rootFSDiffDescriptorForTest(), bytes.NewReader(buf.Bytes()), nil)
 	require.NoError(t, err)
 	defer reader.Close()
 	require.NotEmpty(t, desc.Digest)
@@ -168,6 +232,51 @@ func TestFilterRootFSDiffTarExcludesRuntimePaths(t *testing.T) {
 	assert.NotContains(t, entries, "var/lib/sandbox0/procd/webhook-outbox/evt.json")
 	assert.NotContains(t, entries, "var/lib/sandbox0/procd/.wh..wh..opq")
 	assert.Contains(t, entries, "workspace/state")
+}
+
+func TestFilterRootFSDiffTarExcludesConfiguredVolumePathsAndWhiteouts(t *testing.T) {
+	var buf bytes.Buffer
+	tarWriter := tar.NewWriter(&buf)
+	writeTarEntry(t, tarWriter, "workspace/data/file", []byte("volume"), 0o644)
+	writeTarEntry(t, tarWriter, "workspace/.wh.data", nil, 0o000)
+	writeTarEntry(t, tarWriter, "workspace/.wh..wh..opq", nil, 0o000)
+	writeTarEntry(t, tarWriter, "workspace/database/file", []byte("rootfs"), 0o644)
+	writeTarEntry(t, tarWriter, "workspace/other/file", []byte("rootfs"), 0o644)
+	require.NoError(t, tarWriter.Close())
+
+	desc, reader, err := filterRootFSDiffTar(rootFSDiffDescriptorForTest(), bytes.NewReader(buf.Bytes()), []string{
+		"/workspace/data",
+		"/",
+	})
+	require.NoError(t, err)
+	defer reader.Close()
+	require.NotEmpty(t, desc.Digest)
+	require.Positive(t, desc.Size)
+
+	entries := readTarEntries(t, reader)
+	assert.NotContains(t, entries, "workspace/data/file")
+	assert.NotContains(t, entries, "workspace/.wh.data")
+	assert.NotContains(t, entries, "workspace/.wh..wh..opq")
+	assert.Contains(t, entries, "workspace/database/file")
+	assert.Contains(t, entries, "workspace/other/file")
+}
+
+func TestRootFSPathFilterDoesNotExcludeSimilarPrefixes(t *testing.T) {
+	filter := newRootFSPathFilter([]string{"/workspace/data"})
+
+	assert.True(t, filter.Excludes("/workspace/data"))
+	assert.True(t, filter.Excludes("/workspace/data/file"))
+	assert.False(t, filter.Excludes("/workspace/database/file"))
+	assert.False(t, filter.Excludes("/workspace/data-old/file"))
+	assert.True(t, filter.ExcludesTarHeader("workspace/.wh.data"))
+	assert.False(t, filter.ExcludesTarHeader("workspace/.wh.database"))
+	assert.True(t, filter.ExcludesTarHeader("workspace/.wh..wh..opq"))
+	assert.False(t, filter.ExcludesTarHeader("workspace/database/.wh..wh..opq"))
+	target, opaque, ok := rootFSChangeWhiteoutTargetPath("/workspace/.wh..opq")
+	require.True(t, ok)
+	assert.True(t, opaque)
+	assert.Equal(t, "/workspace", target)
+	assert.True(t, filter.AffectsOpaquePreservedPath(target))
 }
 
 func rootFSDiffDescriptorForTest() ctldapi.RootFSDiffDescriptor {
@@ -199,6 +308,16 @@ func readTarEntries(t *testing.T, reader io.Reader) []string {
 		}
 		require.NoError(t, err)
 		entries = append(entries, header.Name)
+	}
+}
+
+func markOverlayOpaqueForTest(t *testing.T, dir string) {
+	t.Helper()
+	if err := unix.Lsetxattr(dir, "user.overlay.opaque", []byte{'y'}, 0); err != nil {
+		if err == unix.EPERM || err == unix.EACCES || err == unix.ENOTSUP || err == unix.EOPNOTSUPP {
+			t.Skipf("setting overlay opaque xattr is not supported: %v", err)
+		}
+		require.NoError(t, err)
 	}
 }
 

--- a/manager/pkg/service/sandbox_service_rootfs.go
+++ b/manager/pkg/service/sandbox_service_rootfs.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"path"
 	"strings"
 	"time"
 
@@ -72,6 +73,7 @@ func (s *SandboxService) saveSandboxRootFSCheckpoint(ctx context.Context, pod *c
 		TeamID:                    teamID,
 		ExpectedRuntimeGeneration: generation,
 		ParentLayerID:             parentLayerID,
+		ExcludedPaths:             rootFSExcludedPathsForPod(pod),
 	}
 	resp, err := s.ctldClient.SaveRootFSWithTimeout(ctx, ctldAddress, saveReq, sandboxRootFSOperationTimeout)
 	if err != nil && parentLayerID != "" && rootFSBaselineMissing(err, resp) {
@@ -154,6 +156,7 @@ func (s *SandboxService) applySandboxRootFSCheckpoint(ctx context.Context, pod *
 			Size:      state.DiffSize,
 			ObjectKey: state.DiffObjectKey,
 		},
+		ExcludedPaths: rootFSExcludedPathsForPod(pod),
 	}
 	if layers := rootFSLayerDescriptors(state); len(layers) > 0 {
 		req.Layers = layers
@@ -168,6 +171,34 @@ func (s *SandboxService) applySandboxRootFSCheckpoint(ctx context.Context, pod *
 		return fmt.Errorf("apply sandbox rootfs checkpoint: ctld did not report applied")
 	}
 	return nil
+}
+
+func rootFSExcludedPathsForPod(pod *corev1.Pod) []string {
+	if pod == nil {
+		return nil
+	}
+	portals := expectedVolumePortalsForPod(pod)
+	if len(portals) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(portals))
+	out := make([]string, 0, len(portals))
+	for _, portal := range portals {
+		raw := strings.TrimSpace(portal.MountPath)
+		if raw == "" || !strings.HasPrefix(raw, "/") {
+			continue
+		}
+		mountPath := path.Clean(raw)
+		if mountPath == "/" {
+			continue
+		}
+		if _, ok := seen[mountPath]; ok {
+			continue
+		}
+		seen[mountPath] = struct{}{}
+		out = append(out, mountPath)
+	}
+	return out
 }
 
 func (s *SandboxService) applySandboxRootFSCheckpointWithFallback(ctx context.Context, pod *corev1.Pod, record *SandboxRecord, template *v1alpha1.SandboxTemplate, req *ClaimRequest, state *SandboxRootFSState, fallbackStatus string) (*corev1.Pod, error) {

--- a/manager/pkg/service/sandbox_service_rootfs_test.go
+++ b/manager/pkg/service/sandbox_service_rootfs_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 	"github.com/sandbox0-ai/sandbox0/pkg/sandboxprobe"
+	"github.com/sandbox0-ai/sandbox0/pkg/volumeportal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -46,6 +47,7 @@ func TestPauseSandboxRuntimeQueuesRootFSSaveBeforeDeletingPod(t *testing.T) {
 			PodUID:        "pod-uid",
 			ContainerName: "procd",
 		}, req.Target)
+		assert.ElementsMatch(t, []string{"/workspace/data", volumeportal.WebhookStateMountPath}, req.ExcludedPaths)
 		saveCalled = true
 		_ = json.NewEncoder(w).Encode(ctldapi.SaveRootFSResponse{
 			Info: ctldapi.RootFSInfo{
@@ -69,6 +71,8 @@ func TestPauseSandboxRuntimeQueuesRootFSSaveBeforeDeletingPod(t *testing.T) {
 	ctldURL, ctldPort := parsedTestServer(t, ctld.URL)
 
 	pod := rootFSTestPod("pod-1", "sandbox-1", "team-1")
+	addRootFSTestVolumePortal(pod, "data", "/workspace/data")
+	addRootFSTestVolumePortal(pod, volumeportal.WebhookStatePortalName, volumeportal.WebhookStateMountPath)
 	pod.Status.HostIP = ctldURL.Hostname()
 	k8sClient := fake.NewSimpleClientset(pod)
 	k8sClient.PrependReactor("delete", "pods", func(action ktesting.Action) (bool, runtime.Object, error) {
@@ -398,6 +402,7 @@ func TestFinishRestoredSandboxRuntimeAppliesRootFSBeforeProcdInitialization(t *t
 		assert.Equal(t, []string{"parent-1", "parent-0"}, req.ExpectedSnapshotParentChain)
 		assert.Equal(t, "sha256:diff", req.Descriptor.Digest)
 		assert.Equal(t, "sandbox-rootfs/team-1/sandbox-1/3/sha256/diff.tar", req.Descriptor.ObjectKey)
+		assert.ElementsMatch(t, []string{"/workspace/data"}, req.ExcludedPaths)
 		calls = append(calls, "apply")
 		_ = json.NewEncoder(w).Encode(ctldapi.ApplyRootFSResponse{Applied: true})
 	}))
@@ -414,6 +419,7 @@ func TestFinishRestoredSandboxRuntimeAppliesRootFSBeforeProcdInitialization(t *t
 	procdURL, procdPort := parsedTestServer(t, procd.URL)
 
 	pod := rootFSTestPod("pod-1", "sandbox-1", "team-1")
+	addRootFSTestVolumePortal(pod, "data", "/workspace/data")
 	pod.Status.HostIP = ctldURL.Hostname()
 	pod.Status.PodIP = procdURL.Hostname()
 	store := &memorySandboxStore{
@@ -716,6 +722,30 @@ func TestRestoreFailureCleanupCanSkipRootFSSave(t *testing.T) {
 	assert.Equal(t, SandboxStatusPaused, store.records["sandbox-1"].Status)
 }
 
+func TestRootFSExcludedPathsForPodUsesVolumePortalMountPaths(t *testing.T) {
+	pod := rootFSTestPod("pod-1", "sandbox-1", "team-1")
+	addRootFSTestVolumePortal(pod, "data", "/workspace/data/")
+	addRootFSTestVolumePortal(pod, "data-duplicate", "/workspace/data")
+	addRootFSTestVolumePortal(pod, "database", "/workspace/database")
+	addRootFSTestVolumePortal(pod, "ignored-root", "/")
+	pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
+		Name: "ignored-relative",
+		VolumeSource: corev1.VolumeSource{
+			CSI: &corev1.CSIVolumeSource{
+				Driver: volumeportal.DriverName,
+				VolumeAttributes: map[string]string{
+					volumeportal.AttributePortalName: "ignored-relative",
+					volumeportal.AttributeMountPath:  "workspace/relative",
+				},
+			},
+		},
+	})
+
+	got := rootFSExcludedPathsForPod(pod)
+
+	assert.ElementsMatch(t, []string{"/workspace/data", "/workspace/database"}, got)
+}
+
 func rootFSTestPod(name, sandboxID, teamID string) *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1ObjectMeta(name, sandboxID, teamID),
@@ -732,6 +762,32 @@ func rootFSTestPod(name, sandboxID, teamID string) *corev1.Pod {
 				State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
 			}},
 		},
+	}
+}
+
+func addRootFSTestVolumePortal(pod *corev1.Pod, name, mountPath string) {
+	if pod == nil {
+		return
+	}
+	portalName := volumeportal.NormalizePortalName(name, mountPath)
+	volumeName := "volume-" + portalName
+	pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
+		Name: volumeName,
+		VolumeSource: corev1.VolumeSource{
+			CSI: &corev1.CSIVolumeSource{
+				Driver: volumeportal.DriverName,
+				VolumeAttributes: map[string]string{
+					volumeportal.AttributePortalName: portalName,
+					volumeportal.AttributeMountPath:  mountPath,
+				},
+			},
+		},
+	})
+	for i := range pod.Spec.Containers {
+		pod.Spec.Containers[i].VolumeMounts = append(pod.Spec.Containers[i].VolumeMounts, corev1.VolumeMount{
+			Name:      volumeName,
+			MountPath: mountPath,
+		})
 	}
 }
 

--- a/pkg/ctldapi/types.go
+++ b/pkg/ctldapi/types.go
@@ -91,6 +91,7 @@ type SaveRootFSRequest struct {
 	ExpectedRuntimeGeneration int64              `json:"expected_runtime_generation,omitempty"`
 	ParentLayerID             string             `json:"parent_layer_id,omitempty"`
 	ObjectKey                 string             `json:"object_key,omitempty"`
+	ExcludedPaths             []string           `json:"excluded_paths,omitempty"`
 }
 
 type SaveRootFSResponse struct {
@@ -110,6 +111,7 @@ type ApplyRootFSRequest struct {
 	BaselineLayerID             string                  `json:"baseline_layer_id,omitempty"`
 	Layers                      []RootFSLayerDescriptor `json:"layers,omitempty"`
 	Descriptor                  RootFSDiffDescriptor    `json:"descriptor"`
+	ExcludedPaths               []string                `json:"excluded_paths,omitempty"`
 }
 
 type ApplyRootFSResponse struct {


### PR DESCRIPTION
## Summary
- pass sandbox volume portal mount paths from manager to ctld rootfs save/apply requests
- filter dynamic excluded paths in overlay fast diffs, containerd diff fallback, apply tar filtering, and captured baselines
- handle boundary cases for path normalization, similar prefixes, and OCI whiteouts for excluded mountpoints

## Tests
- go test ./ctld/internal/ctld/rootfs ./manager/pkg/service -run 'TestWriteOverlayUpperDiff|TestFilterRootFSDiffTar|TestRootFSPathFilter|TestController.*RootFS|TestPauseSandboxRuntime|TestFinishRestoredSandboxRuntime|TestRootFSExcludedPathsForPod|TestRestoreFailureCleanupCanSkipRootFSSave'\n- make proto\n- go test ./pkg/ctldapi ./ctld/internal/ctld/... ./manager/pkg/service\n\nRemote kind validation will be added after deployment.