### PR TITLE
Fix optional volume mounts in rootfs persistence

### DIFF
--- a/docs/sandbox/pause-resume/page.mdx
+++ b/docs/sandbox/pause-resume/page.mdx
@@ -26,7 +26,7 @@ Self-hosted deployments must run `ctld` on sandbox nodes for checkpointed pause/
 | Mounted Volumes | Remounted if configured | Preserved until the Volume is deleted |
 | Processes, memory, sockets, PID state, live REPL sessions | Not preserved | Deleted |
 
-The rootfs checkpoint covers files written inside the sandbox filesystem, including files outside mounted volumes. It is different from a Sandbox Volume: it is tied to sandbox rootfs lifecycle and does not provide volume sharing or direct Volume file APIs. For named rootfs snapshots, restore, and fork operations, see [Snapshot And Restore](/docs/sandbox/snapshot-restore).
+The rootfs checkpoint covers files written inside the sandbox filesystem, including template-declared Volume mount paths that were not bound by the claim. Bound Sandbox Volume paths are excluded because the Volume owns that data. Rootfs checkpoints are different from Sandbox Volumes: they are tied to sandbox rootfs lifecycle and do not provide volume sharing or direct Volume file APIs. For named rootfs snapshots, restore, and fork operations, see [Snapshot And Restore](/docs/sandbox/snapshot-restore).
 
 On nodes using the containerd overlayfs snapshotter, `ctld` checkpoints only the active snapshot upperdir and stores it as a standard OCI layer diff. Other snapshotters, or nodes where the overlayfs upperdir is not readable by `ctld`, fall back to containerd's built-in diff path.
 

--- a/docs/sandbox/snapshot-restore/page.mdx
+++ b/docs/sandbox/snapshot-restore/page.mdx
@@ -86,7 +86,7 @@ Claiming with `snapshot_id` is the preferred path for reusable custom rootfs sta
 For a longer walkthrough of this pattern, see [Initialize Once, Claim Many](/blog/2026-06/initialize-once-fork-many-custom-ai-agent-sandboxes).
 
 <Callout variant="warning">
-This pattern does not replace template-level configuration. Use a custom template when you need a different container image, resource limits, mount declarations, default network policy, environment defaults, or privileged runtime fields. Mounted Sandbox Volumes are separate from the sandbox rootfs and should be managed with Volume snapshot and fork APIs.
+This pattern does not replace template-level configuration. Use a custom template when you need a different container image, resource limits, mount declarations, default network policy, environment defaults, or privileged runtime fields. Template-declared Volume paths that are not bound by the claim remain ordinary rootfs directories and are included in rootfs snapshots. Mounted Sandbox Volumes are separate from the sandbox rootfs and should be managed with Volume snapshot and fork APIs.
 </Callout>
 
 ## Pause Before Rootfs Operations

--- a/docs/volume/mounts/page.mdx
+++ b/docs/volume/mounts/page.mdx
@@ -2,7 +2,7 @@
 
 Volumes are mounted through template-declared mount points and bound when a Sandbox is claimed.
 
-Dynamic mount and unmount APIs are no longer part of the Sandbox API. Define the allowed mount paths in the template, then provide the Volume IDs for those paths in the claim request.
+Dynamic mount and unmount APIs are no longer part of the Sandbox API. Define the allowed mount paths in the template, then provide the Volume IDs for those paths in the claim request. Declaring a mount point does not mount a Volume by itself.
 
 ## Mount Flow
 
@@ -22,7 +22,7 @@ flowchart LR
 
 ## Define Mount Points
 
-Template mount paths are fixed before the Sandbox starts.
+Template mount paths are fixed before the Sandbox starts. They are optional claim-time binding points: if a claim does not bind a Volume at one of these paths, that path remains part of the sandbox writable root filesystem.
 
 ```yaml
 apiVersion: sandbox0.ai/v1alpha1
@@ -59,7 +59,7 @@ The claim request binds existing Volumes to template-declared paths.
 }
 ```
 
-`mount_point` must match a path declared in `spec.volumeMounts`.
+`mount_point` must match a path declared in `spec.volumeMounts`. Only paths present in the claim request are mounted as Sandbox Volumes. Unbound declared paths behave like ordinary rootfs directories and are included in rootfs checkpoints, snapshots, restore, and fork state. Bound Volume paths are excluded from rootfs checkpoints because the Volume owns that data.
 
 ## Access Modes
 

--- a/manager/pkg/apis/sandbox0/v1alpha1/helpers.go
+++ b/manager/pkg/apis/sandbox0/v1alpha1/helpers.go
@@ -31,8 +31,15 @@ const (
 	minSandboxEphemeralStorageRequestBytes = int64(64 * 1024 * 1024)
 )
 
-// buildPodSpec builds a pod spec from a template
+// BuildPodSpec builds a pod spec from a template without optional user volume
+// portals. Claim-time mounts should use BuildPodSpecWithVolumeMounts.
 func BuildPodSpec(template *SandboxTemplate) corev1.PodSpec {
+	return BuildPodSpecWithVolumeMounts(template, nil)
+}
+
+// BuildPodSpecWithVolumeMounts builds a pod spec from a template and injects
+// only the user volume portals that are actually bound for this runtime.
+func BuildPodSpecWithVolumeMounts(template *SandboxTemplate, volumeMounts []VolumeMountSpec) corev1.PodSpec {
 	spec := corev1.PodSpec{
 		RestartPolicy: corev1.RestartPolicyAlways,
 		Containers:    buildContainers(template),
@@ -43,7 +50,7 @@ func BuildPodSpec(template *SandboxTemplate) corev1.PodSpec {
 
 	applyProcdSecretVolume(&spec, template)
 	applyNetdMITMCATrustMaterial(&spec)
-	applyVolumePortals(&spec, template)
+	applyVolumePortals(&spec, volumeMounts)
 	applyEmptyDirMounts(&spec, template)
 	applyProcdInit(&spec)
 	applyDefaultSandboxPlacement(&spec)
@@ -163,16 +170,16 @@ func tolerationKey(tol corev1.Toleration) string {
 	return string(tol.Operator) + "\x00" + tol.Key + "\x00" + tol.Value + "\x00" + string(tol.Effect)
 }
 
-func applyVolumePortals(spec *corev1.PodSpec, template *SandboxTemplate) {
-	if spec == nil || template == nil {
+func applyVolumePortals(spec *corev1.PodSpec, volumeMounts []VolumeMountSpec) {
+	if spec == nil {
 		return
 	}
-	mounts := make([]VolumeMountSpec, 0, len(template.Spec.VolumeMounts)+1)
+	mounts := make([]VolumeMountSpec, 0, len(volumeMounts)+1)
 	mounts = append(mounts, VolumeMountSpec{
 		Name:      volumeportal.WebhookStatePortalName,
 		MountPath: volumeportal.WebhookStateMountPath,
 	})
-	mounts = append(mounts, template.Spec.VolumeMounts...)
+	mounts = append(mounts, volumeMounts...)
 
 	seenMountPaths := make(map[string]struct{}, len(mounts))
 	for i, mount := range mounts {

--- a/manager/pkg/apis/sandbox0/v1alpha1/helpers_test.go
+++ b/manager/pkg/apis/sandbox0/v1alpha1/helpers_test.go
@@ -196,7 +196,7 @@ manager_image: sandbox0/manager:test
 	}
 }
 
-func TestBuildPodSpecInjectsVolumePortalMounts(t *testing.T) {
+func TestBuildPodSpecDoesNotInjectOptionalUserVolumePortals(t *testing.T) {
 	configPath := writeManagerConfig(t, `
 manager_image: sandbox0/manager:test
 `)
@@ -208,6 +208,38 @@ manager_image: sandbox0/manager:test
 	}
 
 	spec := BuildPodSpec(template)
+	userVolume := findCSIVolumeByPortal(spec.Volumes, "workspace")
+	if userVolume != nil {
+		t.Fatalf("workspace csi volume = %#v, want nil for optional unbound mount", userVolume)
+	}
+	if mount := findVolumeMountByPath(spec.Containers[0].VolumeMounts, "/workspace/bench-volume"); mount != nil {
+		t.Fatalf("workspace volume mount = %#v, want nil for optional unbound mount", mount)
+	}
+
+	webhookVolume := findCSIVolumeByPortal(spec.Volumes, volumeportal.WebhookStatePortalName)
+	if webhookVolume == nil {
+		t.Fatalf("expected webhook state portal volume, got %#v", spec.Volumes)
+	}
+	if mount := findVolumeMount(spec.Containers[0].VolumeMounts, webhookVolume.Name); mount == nil || mount.MountPath != volumeportal.WebhookStateMountPath {
+		t.Fatalf("expected webhook state mount, got %#v", spec.Containers[0].VolumeMounts)
+	}
+}
+
+func TestBuildPodSpecWithVolumeMountsInjectsBoundUserVolumePortals(t *testing.T) {
+	configPath := writeManagerConfig(t, `
+manager_image: sandbox0/manager:test
+`)
+	t.Setenv("CONFIG_PATH", configPath)
+
+	template := newTestTemplate()
+	template.Spec.VolumeMounts = []VolumeMountSpec{
+		{Name: "workspace", MountPath: "/workspace/bench-volume"},
+		{Name: "cache", MountPath: "/workspace/cache"},
+	}
+
+	spec := BuildPodSpecWithVolumeMounts(template, []VolumeMountSpec{
+		{Name: "workspace", MountPath: "/workspace/bench-volume"},
+	})
 	userVolume := findCSIVolumeByPortal(spec.Volumes, "workspace")
 	if userVolume == nil {
 		t.Fatalf("expected workspace csi volume, got %#v", spec.Volumes)
@@ -221,13 +253,8 @@ manager_image: sandbox0/manager:test
 	if mount := findVolumeMount(spec.Containers[0].VolumeMounts, userVolume.Name); mount == nil || mount.MountPath != "/workspace/bench-volume" {
 		t.Fatalf("expected container mount for workspace volume, got %#v", spec.Containers[0].VolumeMounts)
 	}
-
-	webhookVolume := findCSIVolumeByPortal(spec.Volumes, volumeportal.WebhookStatePortalName)
-	if webhookVolume == nil {
-		t.Fatalf("expected webhook state portal volume, got %#v", spec.Volumes)
-	}
-	if mount := findVolumeMount(spec.Containers[0].VolumeMounts, webhookVolume.Name); mount == nil || mount.MountPath != volumeportal.WebhookStateMountPath {
-		t.Fatalf("expected webhook state mount, got %#v", spec.Containers[0].VolumeMounts)
+	if cacheVolume := findCSIVolumeByPortal(spec.Volumes, "cache"); cacheVolume != nil {
+		t.Fatalf("cache csi volume = %#v, want nil for unbound optional mount", cacheVolume)
 	}
 }
 

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -418,24 +418,28 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 
 	_ = resolvedName // reserved for audit/debugging (name used is template.ObjectMeta.Name)
 
-	// Try to claim an idle pod first
-	phaseStarted = time.Now()
-	pod, err := s.claimIdlePod(ctx, template, req)
-	claimIdleType := "hot"
-	if pod == nil {
-		claimIdleType = "cold"
-	}
-	if err != nil {
-		claimIdleType = "unknown"
-	}
-	s.observeClaimPhase(req.Template, claimIdleType, "claim_idle_pod", phaseStarted, err)
-	if err != nil {
-		if metrics != nil {
-			metrics.SandboxClaimsTotal.WithLabelValues(req.Template, "error").Inc()
-		}
-		return nil, fmt.Errorf("claim idle pod: %w", err)
-	}
+	// Try to claim an idle pod first. Claims with bound volumes need a
+	// claim-specific pod spec because Kubernetes volume mounts are immutable.
 	claimType := "hot"
+	var pod *corev1.Pod
+	if len(req.Mounts) == 0 {
+		phaseStarted = time.Now()
+		pod, err = s.claimIdlePod(ctx, template, req)
+		claimIdleType := "hot"
+		if pod == nil {
+			claimIdleType = "cold"
+		}
+		if err != nil {
+			claimIdleType = "unknown"
+		}
+		s.observeClaimPhase(req.Template, claimIdleType, "claim_idle_pod", phaseStarted, err)
+		if err != nil {
+			if metrics != nil {
+				metrics.SandboxClaimsTotal.WithLabelValues(req.Template, "error").Inc()
+			}
+			return nil, fmt.Errorf("claim idle pod: %w", err)
+		}
+	}
 
 	// If no idle pod available, create a new one (cold start)
 	if pod == nil {
@@ -753,6 +757,28 @@ func declaredVolumeMountsByPath(template *v1alpha1.SandboxTemplate) map[string]v
 	return out
 }
 
+func declaredVolumeMountsForClaim(template *v1alpha1.SandboxTemplate, mounts []ClaimMount) []v1alpha1.VolumeMountSpec {
+	if len(mounts) == 0 {
+		return nil
+	}
+	declared := declaredVolumeMountsByPath(template)
+	out := make([]v1alpha1.VolumeMountSpec, 0, len(mounts))
+	seen := make(map[string]struct{}, len(mounts))
+	for _, mount := range mounts {
+		mountPoint := filepath.Clean(strings.TrimSpace(mount.MountPoint))
+		if _, ok := seen[mountPoint]; ok {
+			continue
+		}
+		decl, ok := declared[mountPoint]
+		if !ok {
+			continue
+		}
+		seen[mountPoint] = struct{}{}
+		out = append(out, decl)
+	}
+	return out
+}
+
 func (s *SandboxService) bindVolumePortals(ctx context.Context, pod *corev1.Pod, req *ClaimRequest, template *v1alpha1.SandboxTemplate) ([]BootstrapMountStatus, error) {
 	if req == nil || len(req.Mounts) == 0 {
 		return nil, nil
@@ -954,6 +980,9 @@ func isVolumePortalPendingPublicationError(resp *ctldapi.BindVolumePortalRespons
 
 // claimIdlePod claims an idle pod from the pool
 func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.SandboxTemplate, req *ClaimRequest) (*corev1.Pod, error) {
+	if req != nil && len(req.Mounts) > 0 {
+		return nil, nil
+	}
 	var claimedPod *corev1.Pod
 	desiredTemplateHash, err := controller.TemplateSpecHash(template)
 	if err != nil {
@@ -1143,7 +1172,8 @@ func (s *SandboxService) createNewPod(ctx context.Context, template *v1alpha1.Sa
 
 	// Build pod spec before side-effecting resources so claims fail fast when the
 	// sandbox data plane has no ready nodes to receive the pod.
-	spec := v1alpha1.BuildPodSpec(template)
+	volumeMounts := declaredVolumeMountsForClaim(template, req.Mounts)
+	spec := v1alpha1.BuildPodSpecWithVolumeMounts(template, volumeMounts)
 	if err := s.ensureDataPlaneReadyCapacity(spec); err != nil {
 		return nil, err
 	}

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -106,6 +106,39 @@ func TestClaimIdlePodClaimsReadyPod(t *testing.T) {
 	}
 }
 
+func TestClaimIdlePodSkipsClaimsWithBoundVolumes(t *testing.T) {
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "template-a",
+			Namespace: "ns-a",
+		},
+	}
+	readyPod := newClaimTestPod("ns-a", "idle-ready", "template-a", true)
+
+	client := fake.NewSimpleClientset(readyPod.DeepCopy())
+	svc := &SandboxService{
+		k8sClient: client,
+		podLister: newClaimTestPodLister(t, readyPod),
+		clock:     systemTime{},
+		logger:    zap.NewNop(),
+	}
+
+	pod, err := svc.claimIdlePod(context.Background(), template, &ClaimRequest{
+		TeamID: "team-a",
+		UserID: "user-a",
+		Mounts: []ClaimMount{{
+			SandboxVolumeID: "volume-1",
+			MountPoint:      "/workspace/data",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("claimIdlePod() error = %v", err)
+	}
+	if pod != nil {
+		t.Fatalf("claimIdlePod() = %s, want nil for claim-specific volume mounts", pod.Name)
+	}
+}
+
 func TestClaimRequestDoesNotAcceptRuntimeMetadataFromJSON(t *testing.T) {
 	var req ClaimRequest
 	if err := json.Unmarshal([]byte(`{
@@ -501,6 +534,55 @@ func TestCreateNewPodMarksColdPodNonEvictable(t *testing.T) {
 	}
 	if got := pod.Annotations[controller.AnnotationClusterAutoscalerSafeToEvict]; got != "false" {
 		t.Fatalf("safe-to-evict annotation = %q, want false", got)
+	}
+}
+
+func TestCreateNewPodInjectsOnlyBoundVolumePortals(t *testing.T) {
+	withClaimTestPublicKey(t)
+
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "template-a",
+			Namespace: "ns-a",
+		},
+		Spec: v1alpha1.SandboxTemplateSpec{
+			MainContainer: v1alpha1.ContainerSpec{Image: "busybox"},
+			VolumeMounts: []v1alpha1.VolumeMountSpec{
+				{Name: "data", MountPath: "/workspace/data"},
+				{Name: "cache", MountPath: "/workspace/cache"},
+			},
+		},
+	}
+	client := fake.NewSimpleClientset()
+	svc := &SandboxService{
+		k8sClient:    client,
+		secretLister: newClaimTestSecretLister(t),
+		clock:        systemTime{},
+		logger:       zap.NewNop(),
+	}
+
+	pod, err := svc.createNewPod(context.Background(), template, &ClaimRequest{
+		TeamID: "team-a",
+		UserID: "user-a",
+		Mounts: []ClaimMount{{
+			SandboxVolumeID: "volume-1",
+			MountPoint:      "/workspace/data",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("createNewPod() error = %v", err)
+	}
+	if findClaimTestCSIVolumeByPortal(pod.Spec.Volumes, "data") == nil {
+		t.Fatalf("expected bound data portal, got volumes %#v", pod.Spec.Volumes)
+	}
+	if findClaimTestCSIVolumeByPortal(pod.Spec.Volumes, "cache") != nil {
+		t.Fatalf("unexpected unbound cache portal in volumes %#v", pod.Spec.Volumes)
+	}
+	if mount := findClaimTestVolumeMountByPath(pod.Spec.Containers[0].VolumeMounts, "/workspace/data"); mount == nil {
+		t.Fatalf("expected bound data volume mount, got %#v", pod.Spec.Containers[0].VolumeMounts)
+	}
+	if mount := findClaimTestVolumeMountByPath(pod.Spec.Containers[0].VolumeMounts, "/workspace/cache"); mount != nil {
+		t.Fatalf("unexpected unbound cache volume mount %#v", mount)
 	}
 }
 
@@ -1428,6 +1510,27 @@ func newClaimTestNode(name, internalIP string) *corev1.Node {
 			Address: internalIP,
 		}}},
 	}
+}
+
+func findClaimTestCSIVolumeByPortal(volumes []corev1.Volume, portalName string) *corev1.Volume {
+	for i := range volumes {
+		if volumes[i].CSI == nil || volumes[i].CSI.Driver != volumeportal.DriverName {
+			continue
+		}
+		if volumes[i].CSI.VolumeAttributes[volumeportal.AttributePortalName] == portalName {
+			return &volumes[i]
+		}
+	}
+	return nil
+}
+
+func findClaimTestVolumeMountByPath(mounts []corev1.VolumeMount, mountPath string) *corev1.VolumeMount {
+	for i := range mounts {
+		if mounts[i].MountPath == mountPath {
+			return &mounts[i]
+		}
+	}
+	return nil
 }
 
 func splitTestServerAddress(t *testing.T, server *httptest.Server) (string, int) {

--- a/manager/pkg/service/sandbox_service_restore.go
+++ b/manager/pkg/service/sandbox_service_restore.go
@@ -74,9 +74,11 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 			RuntimeGeneration: generation,
 			HardExpiresAt:     locked.HardExpiresAt,
 		}
-		pod, err = s.claimIdlePod(lockCtx, template, req)
-		if err != nil {
-			return fmt.Errorf("claim idle pod: %w", err)
+		if len(req.Mounts) == 0 {
+			pod, err = s.claimIdlePod(lockCtx, template, req)
+			if err != nil {
+				return fmt.Errorf("claim idle pod: %w", err)
+			}
 		}
 		if pod == nil {
 			claimType = "cold"

--- a/manager/pkg/service/sandbox_service_rootfs.go
+++ b/manager/pkg/service/sandbox_service_rootfs.go
@@ -73,7 +73,7 @@ func (s *SandboxService) saveSandboxRootFSCheckpoint(ctx context.Context, pod *c
 		TeamID:                    teamID,
 		ExpectedRuntimeGeneration: generation,
 		ParentLayerID:             parentLayerID,
-		ExcludedPaths:             rootFSExcludedPathsForPod(pod),
+		ExcludedPaths:             rootFSExcludedPathsForBoundMounts(pod, rootFSBoundMountsForCheckpoint(pod, record)),
 	}
 	resp, err := s.ctldClient.SaveRootFSWithTimeout(ctx, ctldAddress, saveReq, sandboxRootFSOperationTimeout)
 	if err != nil && parentLayerID != "" && rootFSBaselineMissing(err, resp) {
@@ -128,7 +128,7 @@ func (s *SandboxService) shouldSquashSandboxRootFSCheckpoint(state *SandboxRootF
 	return false, ""
 }
 
-func (s *SandboxService) applySandboxRootFSCheckpoint(ctx context.Context, pod *corev1.Pod, state *SandboxRootFSState) error {
+func (s *SandboxService) applySandboxRootFSCheckpoint(ctx context.Context, pod *corev1.Pod, state *SandboxRootFSState, mounts []ClaimMount) error {
 	if state == nil {
 		return nil
 	}
@@ -156,7 +156,7 @@ func (s *SandboxService) applySandboxRootFSCheckpoint(ctx context.Context, pod *
 			Size:      state.DiffSize,
 			ObjectKey: state.DiffObjectKey,
 		},
-		ExcludedPaths: rootFSExcludedPathsForPod(pod),
+		ExcludedPaths: rootFSExcludedPathsForBoundMounts(pod, mounts),
 	}
 	if layers := rootFSLayerDescriptors(state); len(layers) > 0 {
 		req.Layers = layers
@@ -173,32 +173,46 @@ func (s *SandboxService) applySandboxRootFSCheckpoint(ctx context.Context, pod *
 	return nil
 }
 
-func rootFSExcludedPathsForPod(pod *corev1.Pod) []string {
-	if pod == nil {
+func rootFSBoundMountsForCheckpoint(pod *corev1.Pod, record *SandboxRecord) []ClaimMount {
+	if record != nil && len(record.Mounts) > 0 {
+		return record.Mounts
+	}
+	return parseClaimMountsFromPod(pod)
+}
+
+func parseClaimMountsFromPod(pod *corev1.Pod) []ClaimMount {
+	if pod == nil || pod.Annotations == nil {
 		return nil
 	}
-	portals := expectedVolumePortalsForPod(pod)
-	if len(portals) == 0 {
-		return nil
+	return parseClaimMounts(pod.Annotations[controller.AnnotationMounts])
+}
+
+func rootFSExcludedPathsForBoundMounts(pod *corev1.Pod, mounts []ClaimMount) []string {
+	seen := make(map[string]struct{}, len(mounts)+1)
+	out := make([]string, 0, len(mounts)+1)
+	for _, mount := range mounts {
+		out = appendRootFSExcludedPath(out, seen, mount.MountPoint)
 	}
-	seen := make(map[string]struct{}, len(portals))
-	out := make([]string, 0, len(portals))
-	for _, portal := range portals {
-		raw := strings.TrimSpace(portal.MountPath)
-		if raw == "" || !strings.HasPrefix(raw, "/") {
-			continue
-		}
-		mountPath := path.Clean(raw)
-		if mountPath == "/" {
-			continue
-		}
-		if _, ok := seen[mountPath]; ok {
-			continue
-		}
-		seen[mountPath] = struct{}{}
-		out = append(out, mountPath)
+	if pod != nil && pod.Annotations != nil && strings.TrimSpace(pod.Annotations[controller.AnnotationWebhookStateVolumeID]) != "" {
+		out = appendRootFSExcludedPath(out, seen, webhookStateMountPoint)
 	}
 	return out
+}
+
+func appendRootFSExcludedPath(out []string, seen map[string]struct{}, raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || !strings.HasPrefix(raw, "/") {
+		return out
+	}
+	mountPath := path.Clean(raw)
+	if mountPath == "/" {
+		return out
+	}
+	if _, ok := seen[mountPath]; ok {
+		return out
+	}
+	seen[mountPath] = struct{}{}
+	return append(out, mountPath)
 }
 
 func (s *SandboxService) applySandboxRootFSCheckpointWithFallback(ctx context.Context, pod *corev1.Pod, record *SandboxRecord, template *v1alpha1.SandboxTemplate, req *ClaimRequest, state *SandboxRootFSState, fallbackStatus string) (*corev1.Pod, error) {
@@ -208,7 +222,8 @@ func (s *SandboxService) applySandboxRootFSCheckpointWithFallback(ctx context.Co
 	if strings.TrimSpace(fallbackStatus) == "" {
 		fallbackStatus = SandboxStatusResuming
 	}
-	err := s.applySandboxRootFSCheckpoint(ctx, pod, state)
+	mounts := claimMountsFromRequest(req)
+	err := s.applySandboxRootFSCheckpoint(ctx, pod, state, mounts)
 	if err == nil {
 		return pod, nil
 	}
@@ -239,11 +254,18 @@ func (s *SandboxService) applySandboxRootFSCheckpointWithFallback(ctx context.Co
 		s.requestSandboxDeletionAfterClaimFailure(readyPod, "checkpoint base image runtime persistence failed")
 		return readyPod, fmt.Errorf("%w; save checkpoint base image runtime: %v", err, fallbackErr)
 	}
-	if fallbackErr := s.applySandboxRootFSCheckpoint(ctx, readyPod, state); fallbackErr != nil {
+	if fallbackErr := s.applySandboxRootFSCheckpoint(ctx, readyPod, state, mounts); fallbackErr != nil {
 		s.requestSandboxDeletionAfterClaimFailure(readyPod, "checkpoint base image rootfs apply failed")
 		return readyPod, fmt.Errorf("%w; checkpoint base image retry failed: %v", err, fallbackErr)
 	}
 	return readyPod, nil
+}
+
+func claimMountsFromRequest(req *ClaimRequest) []ClaimMount {
+	if req == nil {
+		return nil
+	}
+	return req.Mounts
 }
 
 func (s *SandboxService) saveRestoredRuntimePod(ctx context.Context, pod *corev1.Pod, record *SandboxRecord, status string) error {

--- a/manager/pkg/service/sandbox_service_rootfs_test.go
+++ b/manager/pkg/service/sandbox_service_rootfs_test.go
@@ -73,6 +73,7 @@ func TestPauseSandboxRuntimeQueuesRootFSSaveBeforeDeletingPod(t *testing.T) {
 	pod := rootFSTestPod("pod-1", "sandbox-1", "team-1")
 	addRootFSTestVolumePortal(pod, "data", "/workspace/data")
 	addRootFSTestVolumePortal(pod, volumeportal.WebhookStatePortalName, volumeportal.WebhookStateMountPath)
+	pod.Annotations[controller.AnnotationWebhookStateVolumeID] = "webhook-volume-1"
 	pod.Status.HostIP = ctldURL.Hostname()
 	k8sClient := fake.NewSimpleClientset(pod)
 	k8sClient.PrependReactor("delete", "pods", func(action ktesting.Action) (bool, runtime.Object, error) {
@@ -85,6 +86,7 @@ func TestPauseSandboxRuntimeQueuesRootFSSaveBeforeDeletingPod(t *testing.T) {
 			TeamID:            "team-1",
 			RuntimeGeneration: 3,
 			Status:            SandboxStatusRunning,
+			Mounts:            []ClaimMount{{SandboxVolumeID: "volume-1", MountPoint: "/workspace/data"}},
 		},
 	}}
 	enqueuer := &recordingPauseEnqueuer{}
@@ -391,20 +393,33 @@ func TestGetSandboxReportsPausingRecordWhileRuntimePodStillRunning(t *testing.T)
 func TestFinishRestoredSandboxRuntimeAppliesRootFSBeforeProcdInitialization(t *testing.T) {
 	var calls []string
 	ctld := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/api/v1/rootfs/apply", r.URL.Path)
-		var req ctldapi.ApplyRootFSRequest
-		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
-		assert.Equal(t, "runc", req.ExpectedRuntime)
-		assert.Equal(t, "io.containerd.runc.v2", req.ExpectedRuntimeHandler)
-		assert.Equal(t, "overlayfs", req.ExpectedSnapshotter)
-		assert.Equal(t, "sha256:base", req.ExpectedBaseImageDigest)
-		assert.Equal(t, "parent-1", req.ExpectedSnapshotParent)
-		assert.Equal(t, []string{"parent-1", "parent-0"}, req.ExpectedSnapshotParentChain)
-		assert.Equal(t, "sha256:diff", req.Descriptor.Digest)
-		assert.Equal(t, "sandbox-rootfs/team-1/sandbox-1/3/sha256/diff.tar", req.Descriptor.ObjectKey)
-		assert.ElementsMatch(t, []string{"/workspace/data"}, req.ExcludedPaths)
-		calls = append(calls, "apply")
-		_ = json.NewEncoder(w).Encode(ctldapi.ApplyRootFSResponse{Applied: true})
+		switch r.URL.Path {
+		case "/api/v1/rootfs/apply":
+			var req ctldapi.ApplyRootFSRequest
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+			assert.Equal(t, "runc", req.ExpectedRuntime)
+			assert.Equal(t, "io.containerd.runc.v2", req.ExpectedRuntimeHandler)
+			assert.Equal(t, "overlayfs", req.ExpectedSnapshotter)
+			assert.Equal(t, "sha256:base", req.ExpectedBaseImageDigest)
+			assert.Equal(t, "parent-1", req.ExpectedSnapshotParent)
+			assert.Equal(t, []string{"parent-1", "parent-0"}, req.ExpectedSnapshotParentChain)
+			assert.Equal(t, "sha256:diff", req.Descriptor.Digest)
+			assert.Equal(t, "sandbox-rootfs/team-1/sandbox-1/3/sha256/diff.tar", req.Descriptor.ObjectKey)
+			assert.ElementsMatch(t, []string{"/workspace/data"}, req.ExcludedPaths)
+			calls = append(calls, "apply")
+			_ = json.NewEncoder(w).Encode(ctldapi.ApplyRootFSResponse{Applied: true})
+		case "/api/v1/volume-portals/bind":
+			var req ctldapi.BindVolumePortalRequest
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+			assert.Equal(t, "volume-1", req.SandboxVolumeID)
+			assert.Equal(t, "/workspace/data", req.MountPath)
+			_ = json.NewEncoder(w).Encode(ctldapi.BindVolumePortalResponse{
+				SandboxVolumeID: req.SandboxVolumeID,
+				MountPoint:      req.MountPath,
+			})
+		default:
+			t.Fatalf("unexpected ctld path %s", r.URL.Path)
+		}
 	}))
 	defer ctld.Close()
 	ctldURL, ctldPort := parsedTestServer(t, ctld.URL)
@@ -435,6 +450,7 @@ func TestFinishRestoredSandboxRuntimeAppliesRootFSBeforeProcdInitialization(t *t
 		ctldClient:             NewCtldClient(CtldClientConfig{Timeout: time.Second}),
 		procdClient:            NewProcdClient(ProcdClientConfig{Timeout: time.Second}),
 		internalTokenGenerator: staticTokenGenerator{},
+		volumeMetadata:         fakeVolumeMetadataClient{},
 		config: SandboxServiceConfig{
 			CtldEnabled:      true,
 			CtldPort:         ctldPort,
@@ -452,6 +468,7 @@ func TestFinishRestoredSandboxRuntimeAppliesRootFSBeforeProcdInitialization(t *t
 		TemplateName:      "template-1",
 		TemplateNamespace: "template-default",
 		TemplateSpec:      v1alpha1.SandboxTemplateSpec{},
+		Mounts:            []ClaimMount{{SandboxVolumeID: "volume-1", MountPoint: "/workspace/data"}},
 		RuntimeGeneration: 3,
 		Status:            SandboxStatusPaused,
 	}
@@ -722,7 +739,7 @@ func TestRestoreFailureCleanupCanSkipRootFSSave(t *testing.T) {
 	assert.Equal(t, SandboxStatusPaused, store.records["sandbox-1"].Status)
 }
 
-func TestRootFSExcludedPathsForPodUsesVolumePortalMountPaths(t *testing.T) {
+func TestRootFSExcludedPathsUseBoundMounts(t *testing.T) {
 	pod := rootFSTestPod("pod-1", "sandbox-1", "team-1")
 	addRootFSTestVolumePortal(pod, "data", "/workspace/data/")
 	addRootFSTestVolumePortal(pod, "data-duplicate", "/workspace/data")
@@ -741,9 +758,23 @@ func TestRootFSExcludedPathsForPodUsesVolumePortalMountPaths(t *testing.T) {
 		},
 	})
 
-	got := rootFSExcludedPathsForPod(pod)
+	got := rootFSExcludedPathsForBoundMounts(pod, []ClaimMount{
+		{SandboxVolumeID: "volume-1", MountPoint: "/workspace/data/"},
+		{SandboxVolumeID: "volume-2", MountPoint: "/workspace/database"},
+		{SandboxVolumeID: "volume-3", MountPoint: "/"},
+		{SandboxVolumeID: "volume-4", MountPoint: "workspace/relative"},
+	})
 
 	assert.ElementsMatch(t, []string{"/workspace/data", "/workspace/database"}, got)
+}
+
+func TestRootFSExcludedPathsIgnoreUnboundDeclaredVolumePortals(t *testing.T) {
+	pod := rootFSTestPod("pod-1", "sandbox-1", "team-1")
+	addRootFSTestVolumePortal(pod, "data", "/workspace/data")
+
+	got := rootFSExcludedPathsForBoundMounts(pod, nil)
+
+	assert.Empty(t, got)
 }
 
 func rootFSTestPod(name, sandboxID, teamID string) *corev1.Pod {


### PR DESCRIPTION
## Summary
- keep template-declared but unbound volume mount paths as ordinary sandbox rootfs directories
- inject user volume portals only for claim-time bound mounts and send volume-bound claims through cold runtime creation
- filter rootfs checkpoint/apply paths from actual bound mounts instead of all template-declared portals
- document optional mount/rootfs behavior

## Tests
- go test ./manager/pkg/apis/sandbox0/v1alpha1 ./manager/pkg/service ./manager/pkg/controller
- go test ./ctld/internal/ctld/rootfs

## Note
- go test ./ctld/internal/ctld/portal currently fails before tests with missing generated package github.com/sandbox0-ai/sandbox0/storage-proxy/proto/fs in this checkout.