### PR TITLE
Declare /workspace mount on default template

### DIFF
--- a/docs/volume/mounts/page.mdx
+++ b/docs/volume/mounts/page.mdx
@@ -11,7 +11,7 @@ flowchart LR
     tmpl["SandboxTemplate<br/>volumeMounts"]
     claim["Claim request<br/>mounts"]
     ctld["ctld node portal"]
-    sb["Sandbox<br/>/workspace/data"]
+    sb["Sandbox<br/>/workspace"]
     vol["Volume"]
 
     tmpl --> claim
@@ -31,10 +31,12 @@ metadata:
     name: default
 spec:
     volumeMounts:
-        - name: workspace-data
-          mountPath: /workspace/data
+        - name: workspace
+          mountPath: /workspace
           readOnly: false
 ```
+
+The operator-managed `default` builtin template already declares the writable `/workspace` mount point. Custom templates must declare each mount point explicitly.
 
 Mount path requirements:
 
@@ -53,7 +55,7 @@ The claim request binds existing Volumes to template-declared paths.
     "mounts": [
         {
             "sandboxvolume_id": "vol_123",
-            "mount_point": "/workspace/data"
+            "mount_point": "/workspace"
         }
     ]
 }
@@ -86,8 +88,8 @@ This is what keeps file changes visible both from inside the sandbox and through
 After claim completes, use the mounted path like a normal filesystem:
 
 ```bash
-echo "hello" >/workspace/data/hello.txt
-cat /workspace/data/hello.txt
+echo "hello" >/workspace/hello.txt
+cat /workspace/hello.txt
 ```
 
 For control-plane file operations without a Sandbox, use `/api/v1/sandboxvolumes/{'{id}'}/files`.

--- a/infra-operator/internal/controller/pkg/common/builtin_templates.go
+++ b/infra-operator/internal/controller/pkg/common/builtin_templates.go
@@ -189,7 +189,7 @@ func defaultBuiltinTemplateSpec(templateID string) templatev1alpha1.SandboxTempl
 	if templateID == template.DefaultTemplateID {
 		displayName = template.DefaultTemplateDisplayName
 	}
-	return templatev1alpha1.SandboxTemplateSpec{
+	spec := templatev1alpha1.SandboxTemplateSpec{
 		DisplayName: displayName,
 		Description: fmt.Sprintf("Builtin template %s installed by infra-operator.", templateID),
 		MainContainer: templatev1alpha1.ContainerSpec{
@@ -205,6 +205,13 @@ func defaultBuiltinTemplateSpec(templateID string) templatev1alpha1.SandboxTempl
 			Mode: templatev1alpha1.NetworkModeAllowAll,
 		},
 	}
+	if templateID == template.DefaultTemplateID {
+		spec.VolumeMounts = []templatev1alpha1.VolumeMountSpec{{
+			Name:      template.DefaultTemplateWorkspaceName,
+			MountPath: template.DefaultTemplateWorkspaceMount,
+		}}
+	}
+	return spec
 }
 
 func dockerInSandboxTemplateSpec() templatev1alpha1.SandboxTemplateSpec {

--- a/infra-operator/internal/controller/pkg/common/builtin_templates_test.go
+++ b/infra-operator/internal/controller/pkg/common/builtin_templates_test.go
@@ -11,6 +11,36 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/template"
 )
 
+func TestBuildBuiltinTemplateSpecUsesDefaultPreset(t *testing.T) {
+	t.Parallel()
+
+	spec := BuildBuiltinTemplateSpec(template.DefaultTemplateID, infrav1alpha1.BuiltinTemplateConfig{})
+
+	if spec.DisplayName != template.DefaultTemplateDisplayName {
+		t.Fatalf("DisplayName = %q, want %q", spec.DisplayName, template.DefaultTemplateDisplayName)
+	}
+	if spec.MainContainer.Image != template.DefaultTemplateImage {
+		t.Fatalf("image = %q, want %q", spec.MainContainer.Image, template.DefaultTemplateImage)
+	}
+	if len(spec.VolumeMounts) != 1 {
+		t.Fatalf("volumeMounts = %#v, want one workspace mount", spec.VolumeMounts)
+	}
+	mount := spec.VolumeMounts[0]
+	if mount.Name != template.DefaultTemplateWorkspaceName || mount.MountPath != template.DefaultTemplateWorkspaceMount || mount.ReadOnly {
+		t.Fatalf("volumeMounts[0] = %#v, want writable %s at %s", mount, template.DefaultTemplateWorkspaceName, template.DefaultTemplateWorkspaceMount)
+	}
+}
+
+func TestBuildBuiltinTemplateSpecDoesNotAddDefaultWorkspaceToGenericPreset(t *testing.T) {
+	t.Parallel()
+
+	spec := BuildBuiltinTemplateSpec("custom", infrav1alpha1.BuiltinTemplateConfig{})
+
+	if len(spec.VolumeMounts) != 0 {
+		t.Fatalf("volumeMounts = %#v, want none for generic builtin preset", spec.VolumeMounts)
+	}
+}
+
 func TestBuildBuiltinTemplateSpecUsesDockerInSandboxPreset(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/template/defaults.go
+++ b/pkg/template/defaults.go
@@ -11,6 +11,8 @@ const (
 	DefaultTemplateDisplayName      = "Default"
 	DefaultTemplateMinIdle          = int32(1)
 	DefaultTemplateMaxIdle          = int32(5)
+	DefaultTemplateWorkspaceName    = "workspace"
+	DefaultTemplateWorkspaceMount   = "/workspace"
 
 	DockerInSandboxTemplateID          = "dins"
 	DockerInSandboxTemplateDisplayName = "Docker in Sandbox"
@@ -29,7 +31,7 @@ const (
 	OpenClawMemory              = "4Gi"
 	OpenClawEphemeralStorage    = "4Gi"
 	OpenClawDataMount           = "/home/node/.openclaw"
-	AgentWorkspaceMount         = "/workspace"
+	AgentWorkspaceMount         = DefaultTemplateWorkspaceMount
 	AgentWorkspaceSizeLimit     = "4Gi"
 
 	HermesTemplateID          = "hermes"


### PR DESCRIPTION
## Summary
- declare the operator-managed default builtin template workspace mount at /workspace
- add shared default workspace constants and keep agent workspace path aliased to the same value
- update volume mount docs so default template examples use /workspace consistently

## Tests
- go test ./infra-operator/internal/controller/pkg/common ./pkg/template/...