### PR TITLE
Fix observability-only infra cleanup

### DIFF
--- a/infra-operator/internal/controller/sandbox0infra_cleanup_test.go
+++ b/infra-operator/internal/controller/sandbox0infra_cleanup_test.go
@@ -16,7 +16,10 @@ import (
 
 	infrav1alpha1 "github.com/sandbox0-ai/sandbox0/infra-operator/api/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/pkg/common"
+	credentialstoresvc "github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/credentialstore"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/database"
+	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/observability"
+	redissvc "github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/redis"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/registry"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/storage"
 	infraplan "github.com/sandbox0-ai/sandbox0/infra-operator/internal/plan"
@@ -139,6 +142,39 @@ func TestCleanupDisabledServiceResourcesCleansBuiltinDependencies(t *testing.T) 
 	assertClientObjectMissing(t, client, types.NamespacedName{Namespace: "sandbox0-system", Name: "demo-manager"}, &corev1.ServiceAccount{})
 	assertClientObjectMissing(t, client, types.NamespacedName{Name: "demo-manager"}, &rbacv1.ClusterRole{})
 	assertClientObjectMissing(t, client, types.NamespacedName{Name: "demo-manager"}, &rbacv1.ClusterRoleBinding{})
+}
+
+func TestCleanupDisabledServiceResourcesAllowsObservabilityOnlySpec(t *testing.T) {
+	infra := &infrav1alpha1.Sandbox0Infra{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "sandbox0-system"},
+		Spec: infrav1alpha1.Sandbox0InfraSpec{
+			Observability: &infrav1alpha1.ObservabilityConfig{
+				Backend: &infrav1alpha1.ObservabilityBackendConfig{
+					Type: infrav1alpha1.ObservabilityBackendTypeBuiltin,
+					Builtin: &infrav1alpha1.BuiltinObservabilityBackendConfig{
+						Provider: infrav1alpha1.ObservabilityBuiltinProviderClickHouse,
+					},
+				},
+			},
+		},
+	}
+
+	reconciler, _, scheme := newCleanupTestReconciler(t)
+	resources := common.NewResourceManager(reconciler.Client, scheme, nil, common.LocalDevConfig{})
+	err := reconciler.cleanupDisabledServiceResources(
+		context.Background(),
+		infra,
+		infraplan.Compile(infra).Cleanup,
+		database.NewReconciler(resources),
+		redissvc.NewReconciler(resources),
+		credentialstoresvc.NewReconciler(resources),
+		storage.NewReconciler(resources),
+		registry.NewReconciler(resources),
+		observability.NewReconciler(resources),
+	)
+	if err != nil {
+		t.Fatalf("cleanup disabled service resources: %v", err)
+	}
 }
 
 func newCleanupTestReconciler(t *testing.T, objects ...ctrlclient.Object) (*Sandbox0InfraReconciler, ctrlclient.Client, *runtime.Scheme) {

--- a/infra-operator/internal/controller/services/database/database.go
+++ b/infra-operator/internal/controller/services/database/database.go
@@ -675,7 +675,7 @@ func resolveBuiltinDatabaseConfig(infra *infrav1alpha1.Sandbox0Infra) infrav1alp
 		SSLMode:                "disable",
 		StatefulResourcePolicy: infrav1alpha1.BuiltinStatefulResourcePolicyRetain,
 	}
-	if infra.Spec.Database.Builtin == nil {
+	if infra == nil || infra.Spec.Database == nil || infra.Spec.Database.Builtin == nil {
 		return cfg
 	}
 


### PR DESCRIPTION
## Summary
- Make builtin database cleanup tolerate Sandbox0Infra specs that omit `spec.database`.
- Add a controller-level regression test for an observability-only builtin backend spec so cleanup of inactive builtin services does not panic before observability reconciliation.

## Tests
- `go test ./infra-operator/internal/controller ./infra-operator/internal/controller/services/database ./infra-operator/internal/controller/services/storage ./infra-operator/internal/controller/services/redis ./infra-operator/internal/controller/services/credentialstore ./infra-operator/internal/controller/services/registry ./infra-operator/internal/controller/services/observability ./infra-operator/internal/plan`
- `go test ./infra-operator/...`

## Remote validation
Validated on the shared Aliyun Singapore ECS kind environment using a minimal observability-only `Sandbox0Infra` with builtin ClickHouse and managed OpenTelemetry collector/agent.

Evidence captured:
- CRD accepted `spec.observability` after deploying the fixed operator.
- `Sandbox0Infra/obs-builtin` reached `Ready`, `progress: 1/1`, `Ready=True`, `ObservabilityReady=True`.
- ClickHouse StatefulSet was `1/1`, collector Deployment was `1/1`, and agent DaemonSet was `2/2`.
- ClickHouse PVC was `Bound`, collector service exposed OTLP gRPC/HTTP and health ports.
- Collector config included logs/metrics/traces pipelines exporting to ClickHouse; agent config included filelog to collector OTLP.
- Sent a unique OTLP HTTP log marker through the collector and queried the same marker from ClickHouse `otel.otel_logs`.
- Checked recent operator/collector/agent logs; no current panic/error/warning after startup settled.
