### PR TITLE
Test sandbox isolation across CNI variants

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,8 +206,8 @@ test-e2e-specific:
 	unset http_proxy && unset https_proxy && unset all_proxy && $(GO) test -v ./tests/e2e/... -focus="$(SPEC)" -timeout=30m
 
 test-e2e-netd-cni:
-	@printf "$(CYAN)Running netd CNI E2E test...$(RESET)\n"
-	unset http_proxy && unset https_proxy && unset all_proxy && E2E_SINGLE_CLUSTER_SCENARIOS=network-policy $(GO) test -v -count=1 ./tests/e2e/scenarios/single-cluster -run TestSingleCluster -ginkgo.focus="API network policy mode.*enforces transparent TCP egress through netd" -timeout=30m
+	@printf "$(CYAN)Running netd CNI E2E tests...$(RESET)\n"
+	unset http_proxy && unset https_proxy && unset all_proxy && E2E_SINGLE_CLUSTER_SCENARIOS=network-policy $(GO) test -v -count=1 ./tests/e2e/scenarios/single-cluster -run TestSingleCluster -ginkgo.focus="API network policy mode.*(enforces transparent TCP egress through netd|blocks private sandbox traffic while preserving public exposure and cluster service access)" -timeout=30m
 
 # Prevent make from treating service names as targets
 regional-gateway ssh-gateway global-gateway cluster-gateway manager scheduler storage-proxy ctld procd netd infra-operator:

--- a/netd/pkg/daemon/daemon.go
+++ b/netd/pkg/daemon/daemon.go
@@ -419,18 +419,24 @@ func (d *Daemon) syncRedirect(
 	if netdWatcher == nil || redirectManager == nil || patcher == nil {
 		return fmt.Errorf("missing watcher or redirect manager or patcher or policy store")
 	}
-	sandboxes := netdWatcher.ListSandboxesByNode(d.cfg.NodeName)
+	// Redirect rules only need local source pods, while platform peer deny must
+	// know every active sandbox so cross-node private traffic is still blocked.
+	localSandboxes := netdWatcher.ListSandboxesByNode(d.cfg.NodeName)
+	allSandboxes := localSandboxes
+	if d.cfg.NodeName != "" {
+		allSandboxes = netdWatcher.ListSandboxesByNode("")
+	}
 	services := netdWatcher.ListServices()
 	endpoints := netdWatcher.ListEndpoints()
-	sandboxIPs := make([]string, 0, len(sandboxes))
-	for _, sandbox := range sandboxes {
+	sandboxIPs := make([]string, 0, len(localSandboxes))
+	for _, sandbox := range localSandboxes {
 		if sandbox.PodIP == "" {
 			continue
 		}
 		sandboxIPs = append(sandboxIPs, sandbox.PodIP)
 	}
 	if policyStore != nil {
-		result := policyStore.ReconcileSandboxes(sandboxes)
+		result := policyStore.ReconcileSandboxes(localSandboxes)
 		for _, podIP := range result.RemovedIPs {
 			if proxyServer != nil {
 				proxyServer.ForgetSandboxDNS(podIP)
@@ -445,7 +451,7 @@ func (d *Daemon) syncRedirect(
 		}
 	}
 	if platformState != nil {
-		platformState.Reconcile(sandboxes, services, endpoints)
+		platformState.Reconcile(allSandboxes, services, endpoints)
 	}
 
 	dnsCIDRs := clusterDNSCIDRs(d.cfg.ClusterDNSCIDR, services, endpoints)
@@ -459,7 +465,8 @@ func (d *Daemon) syncRedirect(
 
 	d.logger.Info(
 		"Syncing redirect rules",
-		zap.Int("sandboxes_total", len(sandboxes)),
+		zap.Int("sandboxes_local", len(localSandboxes)),
+		zap.Int("sandboxes_total", len(allSandboxes)),
 		zap.Int("sandbox_ips", len(sandboxIPs)),
 		zap.Strings("sandbox_ips", sandboxIPs),
 		zap.Strings("bypass_cidrs", bypassCIDRs),
@@ -468,10 +475,10 @@ func (d *Daemon) syncRedirect(
 		return err
 	}
 	patchedCount := 0
-	if err := patcher.SyncAppliedHashes(ctx, sandboxes); err != nil {
+	if err := patcher.SyncAppliedHashes(ctx, localSandboxes); err != nil {
 		d.logger.Warn("Failed to sync applied hashes", zap.Error(err))
 	} else {
-		for _, sandbox := range sandboxes {
+		for _, sandbox := range localSandboxes {
 			if sandbox.NetworkPolicyHash != "" && sandbox.NetworkPolicyHash == sandbox.NetworkAppliedHash {
 				patchedCount++
 			}
@@ -479,7 +486,8 @@ func (d *Daemon) syncRedirect(
 	}
 	d.logger.Info("Redirect rules synced",
 		zap.Int("sandboxes_patched", patchedCount),
-		zap.Int("sandboxes_total", len(sandboxes)),
+		zap.Int("sandboxes_local", len(localSandboxes)),
+		zap.Int("sandboxes_total", len(allSandboxes)),
 	)
 	return nil
 }

--- a/netd/pkg/watcher/watcher_test.go
+++ b/netd/pkg/watcher/watcher_test.go
@@ -66,6 +66,18 @@ func TestListSandboxesByNodeUsesInformerCacheAsAuthoritativeSource(t *testing.T)
 	if got[0].Name != active.Name || got[0].PodIP != active.Status.PodIP {
 		t.Fatalf("unexpected sandbox: %#v", got[0])
 	}
+
+	all := w.ListSandboxesByNode("")
+	if len(all) != 2 {
+		t.Fatalf("all-node sandboxes = %#v, want active sandboxes from both nodes", all)
+	}
+	byName := map[string]*SandboxInfo{}
+	for _, info := range all {
+		byName[info.Name] = info
+	}
+	if byName[active.Name] == nil || byName[otherNode.Name] == nil {
+		t.Fatalf("all-node sandboxes = %#v, want %s and %s", all, active.Name, otherNode.Name)
+	}
 }
 
 func testSandboxPod(name, uid, resourceVersion, podIP, nodeName string) *corev1.Pod {

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -5,8 +5,10 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1726,7 +1728,12 @@ func assertSandboxNetworkIsolation(env *framework.ScenarioEnv, session *e2eutils
 
 	clusterGatewayPort, err := framework.GetServicePort(env.TestCtx.Context, env.Config.Kubeconfig, env.Infra.Namespace, env.Infra.Name+"-cluster-gateway")
 	Expect(err).NotTo(HaveOccurred())
-	clusterGatewayBaseURL := fmt.Sprintf("http://%s-cluster-gateway.%s.svc.cluster.local:%d", env.Infra.Name, env.Infra.Namespace, clusterGatewayPort)
+	clusterGatewayIP, err := framework.KubectlGetJSONPath(env.TestCtx.Context, env.Config.Kubeconfig, env.Infra.Namespace, "service", env.Infra.Name+"-cluster-gateway", "{.spec.clusterIP}")
+	Expect(err).NotTo(HaveOccurred())
+	clusterGatewayIP = strings.TrimSpace(clusterGatewayIP)
+	Expect(clusterGatewayIP).NotTo(BeEmpty())
+	Expect(strings.EqualFold(clusterGatewayIP, "None")).To(BeFalse())
+	clusterGatewayBaseURL := "http://" + net.JoinHostPort(clusterGatewayIP, strconv.Itoa(clusterGatewayPort))
 
 	Eventually(func() error {
 		body, execErr := execInSandboxPod(env, templateANamespace, sandboxA.PodName, fmt.Sprintf("curl -fsS --max-time 5 %s/healthz", clusterGatewayBaseURL))


### PR DESCRIPTION
## Summary
- include the sandbox private-traffic isolation e2e in the netd CNI matrix
- make netd platform peer-deny evaluate against all active sandbox pod IPs, while keeping redirect/ipset state local to the node
- cover all-node sandbox listing behavior in watcher tests

## Tests
- go test ./netd/pkg/watcher ./netd/pkg/policy ./netd/pkg/daemon ./manager/pkg/namespacepolicy
- go test ./tests/e2e/scenarios/single-cluster -run TestSelectScenarioManifestPaths -count=1
- make -n test-e2e-netd-cni