### PR TITLE
Increase default sandbox ephemeral storage to 8Gi

### DIFF
--- a/docs/template/configuration/page.mdx
+++ b/docs/template/configuration/page.mdx
@@ -17,7 +17,7 @@ spec:
         resources:
             cpu: "2"
             memory: 8Gi
-            ephemeralStorage: 512Mi
+            ephemeralStorage: 8Gi
         env:
             - name: PYTHONPATH
               value: /workspace
@@ -64,7 +64,7 @@ The main sandbox container configuration.
 | `image` | string | — | Container image reference. Use a public image (e.g., `python:3.12-slim`) or the `Template image reference` returned by `s0 template image push` for private images. |
 | `resources.cpu` | string | — | CPU limit for the sandbox (e.g., `"1"`, `"2"`, `"500m"`). |
 | `resources.memory` | string | — | Memory limit for the sandbox (e.g., `"2Gi"`, `"512Mi"`). |
-| `resources.ephemeralStorage` | string | `512Mi` | Writable-layer and container-log storage for the sandbox runtime. Checkpointed pause/resume saves and restores the writable root filesystem, but this quota still bounds writes to `/tmp` or image-local paths. Use rootfs snapshots and claim-time `snapshot_id` to version initialized sandbox files, and use Sandbox Volumes for sharing or long-lived durable data independent of sandbox identity. |
+| `resources.ephemeralStorage` | string | `8Gi` | Writable-layer and container-log storage for the sandbox runtime. Checkpointed pause/resume saves and restores the writable root filesystem, but this quota still bounds writes to `/tmp` or image-local paths. Use rootfs snapshots and claim-time `snapshot_id` to version initialized sandbox files, and use Sandbox Volumes for sharing or long-lived durable data independent of sandbox identity. |
 | `env` | array | `[]` | Per-container environment variables. Each entry has `name` and `value`. |
 
 <Callout variant="info">

--- a/docs/template/page.mdx
+++ b/docs/template/page.mdx
@@ -73,7 +73,7 @@ spec:
         resources:
             cpu: "1"
             memory: 4Gi
-            ephemeralStorage: 512Mi
+            ephemeralStorage: 8Gi
     pool:
         minIdle: 2
         maxIdle: 10
@@ -92,7 +92,7 @@ spec:
             Resources: apispec.ResourceQuota{
                 CPU:              apispec.NewOptString("1"),
                 Memory:           apispec.NewOptString("4Gi"),
-                EphemeralStorage: apispec.NewOptString("512Mi"),
+                EphemeralStorage: apispec.NewOptString("8Gi"),
             },
         }),
         Pool: apispec.NewOptPoolStrategy(apispec.PoolStrategy{
@@ -117,7 +117,7 @@ tpl = client.create_template(TemplateCreateRequest(
     spec=SandboxTemplateSpec.from_dict({
         "mainContainer": {
             "image": "python:3.12-slim",
-            "resources": {"cpu": "1", "memory": "4Gi", "ephemeralStorage": "512Mi"},
+            "resources": {"cpu": "1", "memory": "4Gi", "ephemeralStorage": "8Gi"},
         },
         "pool": {"minIdle": 2, "maxIdle": 10},
     }),
@@ -132,7 +132,7 @@ print(f"Template created: {tpl.template_id}")`
     spec: {
         mainContainer: {
             image: "python:3.12-slim",
-            resources: { cpu: "1", memory: "4Gi", ephemeralStorage: "512Mi" },
+            resources: { cpu: "1", memory: "4Gi", ephemeralStorage: "8Gi" },
         },
         pool: { minIdle: 2, maxIdle: 10 },
     },
@@ -262,7 +262,7 @@ Updating a template does not affect already-running Sandboxes. New Sandboxes cla
             Resources: apispec.ResourceQuota{
                 CPU:              apispec.NewOptString("2"),
                 Memory:           apispec.NewOptString("8Gi"),
-                EphemeralStorage: apispec.NewOptString("512Mi"),
+                EphemeralStorage: apispec.NewOptString("8Gi"),
             },
         }),
         Pool: apispec.NewOptPoolStrategy(apispec.PoolStrategy{
@@ -288,7 +288,7 @@ tpl = client.update_template(
         spec=SandboxTemplateSpec.from_dict({
             "mainContainer": {
                 "image": "python:3.12-slim",
-                "resources": {"cpu": "2", "memory": "8Gi", "ephemeralStorage": "512Mi"},
+                "resources": {"cpu": "2", "memory": "8Gi", "ephemeralStorage": "8Gi"},
             },
             "pool": {"minIdle": 3, "maxIdle": 10},
         }),
@@ -303,7 +303,7 @@ print(f"Template updated: {tpl.template_id}")`
     spec: {
         mainContainer: {
             image: "python:3.12-slim",
-            resources: { cpu: "2", memory: "8Gi", ephemeralStorage: "512Mi" },
+            resources: { cpu: "2", memory: "8Gi", ephemeralStorage: "8Gi" },
         },
         pool: { minIdle: 3, maxIdle: 10 },
     },

--- a/manager/pkg/apis/sandbox0/v1alpha1/helpers_test.go
+++ b/manager/pkg/apis/sandbox0/v1alpha1/helpers_test.go
@@ -341,8 +341,8 @@ manager_image: sandbox0/manager:test
 	assertResourceQuantity(t, resources.Limits[corev1.ResourceCPU], "1")
 	assertResourceQuantity(t, resources.Requests[corev1.ResourceMemory], "256Mi")
 	assertResourceQuantity(t, resources.Limits[corev1.ResourceMemory], "1Gi")
-	assertResourceQuantity(t, resources.Requests[corev1.ResourceEphemeralStorage], "512Mi")
-	assertResourceQuantity(t, resources.Limits[corev1.ResourceEphemeralStorage], "512Mi")
+	assertResourceQuantity(t, resources.Requests[corev1.ResourceEphemeralStorage], "8Gi")
+	assertResourceQuantity(t, resources.Limits[corev1.ResourceEphemeralStorage], "8Gi")
 }
 
 func TestBuildPodSpecClampsReducedRequestsToSmallQuota(t *testing.T) {

--- a/manager/pkg/apis/sandbox0/v1alpha1/sandboxtemplate_types.go
+++ b/manager/pkg/apis/sandbox0/v1alpha1/sandboxtemplate_types.go
@@ -227,7 +227,7 @@ type Toleration struct {
 	Effect   string `json:"effect,omitempty"`
 }
 
-const DefaultSandboxEphemeralStorage = "512Mi"
+const DefaultSandboxEphemeralStorage = "8Gi"
 
 // ResourceQuota defines resource quota (per template)
 type ResourceQuota struct {

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -5564,7 +5564,7 @@ components:
           type: string
         ephemeralStorage:
           type: string
-          description: Ephemeral storage limit for the sandbox writable layer and container logs. Defaults to 512Mi when omitted.
+          description: Ephemeral storage limit for the sandbox writable layer and container logs. Defaults to 8Gi when omitted.
     SecurityContext:
       type: object
       properties:

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -1465,7 +1465,7 @@ type ResizeContextRequest struct {
 type ResourceQuota struct {
 	Cpu *string `json:"cpu,omitempty"`
 
-	// EphemeralStorage Ephemeral storage limit for the sandbox writable layer and container logs. Defaults to 512Mi when omitted.
+	// EphemeralStorage Ephemeral storage limit for the sandbox writable layer and container logs. Defaults to 8Gi when omitted.
 	EphemeralStorage *string `json:"ephemeralStorage,omitempty"`
 	Memory           *string `json:"memory,omitempty"`
 }


### PR DESCRIPTION
## Summary
- raise the default SandboxTemplate ephemeral storage limit from 512Mi to 8Gi
- update OpenAPI/generated API comments and template docs to reflect the new default
- update default resource expectation tests

## Tests
- `make apispec`
- `git diff --check`
- `GOTOOLCHAIN=go1.25.0+auto env GOWORK=off go test ./manager/pkg/apis/sandbox0/v1alpha1 ./pkg/template/http ./pkg/apispec`
- `GOTOOLCHAIN=go1.25.0+auto env GOWORK=off go test ./manager/...`