### PR TITLE
Update managed agents harness docs

### DIFF
--- a/docs/managed-agents/agent-harnesses/page.mdx
+++ b/docs/managed-agents/agent-harnesses/page.mdx
@@ -16,13 +16,13 @@ Sandbox0 supports two execution models.
 | Model | How it works | Harnesses |
 |-------|--------------|---------|
 | Agent in sandbox | The agent runtime process runs inside the per-session Sandbox0 sandbox. The sandbox contains the agent process, workspace, tools, and harness state. | `claude`, `codex` |
-| Sandbox as tool | A resident runtime service runs the agent loop outside the sandbox. The sandbox is claimed lazily and exposed to the agent as tools such as `bash`. | `openai-agents` |
+| Sandbox as tool | A resident runtime service runs the agent loop outside the sandbox. The sandbox is claimed lazily and exposed to the agent as tools such as `bash`. | `sandpi` |
 
 Use agent in sandbox when you want the agent process itself to live with the workspace. This is the most direct fit for coding agents that expect local files, shell commands, home-directory state, and long-lived process state inside the sandbox.
 
 Use sandbox as tool when you want to embed an agent into a product workflow or control plane. The agent harness stays in a managed runtime service, while Sandbox0 provides isolated tool execution only when the agent needs to inspect files or run commands.
 
-Vault `environment_variable` credentials are applied to Sandbox0-backed sandbox processes. With `claude` and `codex`, the agent process runs in that sandbox and inherits those variables as placeholders. External sandbox-as-tool harnesses such as `openai-agents` reject `environment_variable` vault credentials today because the resident runtime service cannot receive them as SDK client or harness configuration secrets.
+Vault `environment_variable` credentials are applied to Sandbox0-backed sandbox processes. With `claude` and `codex`, the agent process runs in that sandbox and inherits those variables as placeholders. Resident sandbox-as-tool harnesses such as `sandpi` reject `environment_variable` vault credentials today because the resident runtime service cannot receive them as SDK client or harness configuration secrets.
 
 ## Supported Harnesses
 
@@ -30,7 +30,7 @@ Vault `environment_variable` credentials are applied to Sandbox0-backed sandbox 
 |--------|-----------------|-----------------|-----------------|----------|
 | `claude` | Agent in sandbox | Claude Agent SDK wrapper | Anthropic Messages-compatible | Claude Code style coding agents and Anthropic-compatible providers |
 | `codex` | Agent in sandbox | Codex app-server wrapper | OpenAI-compatible | Codex app-server sessions that should keep Codex state inside the workspace |
-| `openai-agents` | Sandbox as tool | Resident OpenAI Agents Python runtime | OpenAI Responses-compatible | Product copilots and agent workflows built on the OpenAI Agents SDK |
+| `sandpi` | Sandbox as tool | Resident SandPi runtime | OpenAI-compatible | Product copilots and agent workflows that should keep the agent loop outside the hands sandbox |
 
 ## Retry Behavior
 
@@ -40,9 +40,9 @@ Harnesses with observable automatic retry attempts report them through the same 
 |--------|-------------------------------|
 | `claude` | Claude Agent SDK `system` messages with `subtype = "api_retry"` |
 | `codex` | Codex app-server `error` notifications with `willRetry = true` |
-| `openai-agents` | OpenAI Agents SDK runner-managed `ModelRetrySettings` policy decisions |
+| `sandpi` | No automatic retry signal is exposed today |
 
-Sandbox0 disables hidden model client retries where they would obscure retry state. The `openai-agents` runtime disables hidden OpenAI Python client retries and routes model retries through the OpenAI Agents SDK retry policy.
+Sandbox0 disables hidden model client retries where they would obscure retry state.
 
 ## Select A Harness
 
@@ -72,14 +72,14 @@ const codexVault = await client.beta.vaults.create({
 });
 ```
 
-For `openai-agents`:
+For `sandpi`:
 
 ```typescript
-const openAIAgentsVault = await client.beta.vaults.create({
-    display_name: "OpenAI Agents LLM",
+const sandpiVault = await client.beta.vaults.create({
+    display_name: "SandPi LLM",
     metadata: {
         "sandbox0.managed_agents.role": "llm",
-        "sandbox0.managed_agents.engine": "openai-agents",
+        "sandbox0.managed_agents.engine": "sandpi",
         "sandbox0.managed_agents.llm_base_url": "https://api.openai.com/v1",
     },
 });
@@ -88,7 +88,7 @@ const openAIAgentsVault = await client.beta.vaults.create({
 Add the model provider token to the selected LLM vault:
 
 ```typescript
-await client.beta.vaults.credentials.create(openAIAgentsVault.id, {
+await client.beta.vaults.credentials.create(sandpiVault.id, {
     display_name: "Model provider API key",
     auth: {
         type: "static_bearer",
@@ -105,7 +105,7 @@ Attach exactly one LLM vault to the session:
 const session = await client.beta.sessions.create({
     agent: agent.id,
     environment_id: environment.id,
-    vault_ids: [openAIAgentsVault.id],
+    vault_ids: [sandpiVault.id],
 });
 ```
 
@@ -121,7 +121,7 @@ Choose the gateway endpoint that matches the selected harness:
 |--------|------------------------------|
 | `claude` | Anthropic Messages-compatible API |
 | `codex` | OpenAI-compatible API |
-| `openai-agents` | OpenAI Responses-compatible API |
+| `sandpi` | OpenAI-compatible API |
 
 If you only need to bridge a Claude Code-compatible provider into an OpenAI-style harness, LLMProxy is the simplest option. The hosted tool does not require a Sandbox0 account, an LLMProxy login, or gateway-side setup. Use the LLMProxy URL as the LLM vault base URL, keep the upstream provider token in the vault credential, and let the selected runtime call it directly.
 
@@ -139,10 +139,10 @@ In this setup, the LLM vault stores the gateway base URL and the gateway API tok
 const cloudflareAccountId = process.env.CLOUDFLARE_ACCOUNT_ID!;
 
 const cloudflareGatewayVault = await client.beta.vaults.create({
-    display_name: "OpenAI Agents through Cloudflare AI Gateway",
+    display_name: "SandPi through Cloudflare AI Gateway",
     metadata: {
         "sandbox0.managed_agents.role": "llm",
-        "sandbox0.managed_agents.engine": "openai-agents",
+        "sandbox0.managed_agents.engine": "sandpi",
         "sandbox0.managed_agents.llm_base_url": `https://api.cloudflare.com/client/v4/accounts/${cloudflareAccountId}/ai/v1`,
     },
 });
@@ -159,7 +159,7 @@ await client.beta.vaults.credentials.create(cloudflareGatewayVault.id, {
 Configure the agent model to the gateway's model identifier, such as `anthropic/claude-sonnet-4` on Cloudflare AI Gateway or the model alias configured in LiteLLM, Portkey, or another gateway.
 
 <Callout variant="warning">
-Do not point a harness at a gateway endpoint with the wrong API shape. For example, the `openai-agents` harness needs an OpenAI Responses-compatible endpoint even if the gateway routes the request to an Anthropic model upstream.
+Do not point a harness at a gateway endpoint with the wrong API shape. For example, the `codex` and `sandpi` harnesses need an OpenAI-compatible endpoint even if the gateway routes the request to an Anthropic model upstream.
 </Callout>
 
 ## Claude Harness
@@ -174,17 +174,13 @@ The Codex harness launches Codex app-server inside the session sandbox. It expec
 
 For Minimax-compatible endpoints, Sandbox0 detects the provider from the LLM base URL and configures Codex provider settings accordingly.
 
-## OpenAI Agents Harness
+## SandPi Harness
 
-The `openai-agents` harness uses a resident Python runtime service built on the official OpenAI Agents SDK. The runtime receives the session snapshot from the Managed Agents gateway, runs the agent loop in the runtime service, and claims a Sandbox0 sandbox only when the agent needs sandbox tools.
+The `sandpi` harness uses a Sandbox0-native resident runtime. The runtime receives the session snapshot from the Managed Agents gateway, runs the agent loop in the runtime service, and claims a Sandbox0 sandbox only when the agent needs hands tools.
 
 This is the sandbox as tool model. The session still has durable Managed Agents event history, but the agent process is not the same process as the sandbox. The sandbox is an isolated tool target for commands and workspace work.
 
-The harness expects an OpenAI Responses-compatible endpoint. If the target provider does not expose that API shape directly, use an AI gateway that provides an OpenAI Responses-compatible surface and routes to the provider upstream.
-
-<Callout variant="info">
-For self-hosted deployments, configure the OpenAI Agents runtime callback base URL to an internal gateway URL when possible. The runtime sends session events back to the Managed Agents gateway; routing that callback through a public edge can introduce avoidable policy and timeout failures.
-</Callout>
+The harness expects an OpenAI-compatible endpoint. If the target provider does not expose that API shape directly, use an AI gateway that provides an OpenAI-compatible surface and routes to the provider upstream.
 
 ## Harness Configuration
 

--- a/docs/managed-agents/compatibility/page.mdx
+++ b/docs/managed-agents/compatibility/page.mdx
@@ -21,7 +21,7 @@ Official reference: [Claude Managed Agents quickstart](https://platform.claude.c
 | Custom skills | Supported through uploaded skill versions |
 | MCP servers | Supported for URL MCP servers and vault-backed credentials |
 | GitHub repository resources | Supported at session creation |
-| Agent harnesses | Supported for `claude`, `codex`, and `openai-agents` |
+| Agent harnesses | Supported for `claude`, `codex`, and `sandpi` |
 | External AI gateways | Supported when the gateway exposes the API shape required by the selected agent harness |
 
 ## Current Differences
@@ -32,11 +32,11 @@ Official reference: [Claude Managed Agents quickstart](https://platform.claude.c
 | API token | SDK `apiKey` is a Sandbox0 API key, not the Anthropic LLM token. |
 | LLM token | Stored in an LLM vault and projected by Sandbox0 credential policy. |
 | Agent harness | Selected by the compatibility key `sandbox0.managed_agents.engine` on the LLM vault. |
-| Environment variable credentials | Stored as sandbox environment placeholders and resolved by Sandbox0 egress auth. They are available to sandbox-backed runtimes such as `claude` and `codex`, not as SDK client or resident harness configuration secrets. External sandbox-as-tool harnesses reject them today. |
+| Environment variable credentials | Stored as sandbox environment placeholders and resolved by Sandbox0 egress auth. They are available to sandbox-backed runtimes such as `claude` and `codex`, not as SDK client or resident harness configuration secrets. Resident sandbox-as-tool harnesses such as `sandpi` reject them today. |
 | Sandbox claim | Agent-in-sandbox harnesses claim or resume a Sandbox0 sandbox before the run. Sandbox-as-tool harnesses start in a resident runtime and claim the sandbox only when a sandbox tool needs one. |
 | Claude harness | Requires an Anthropic Messages-compatible endpoint. |
 | Codex harness | Requires an OpenAI-compatible endpoint. |
-| OpenAI Agents harness | Requires an OpenAI Responses-compatible endpoint and uses Sandbox0 as a tool target. |
+| SandPi harness | Requires an OpenAI-compatible endpoint and uses Sandbox0 as a tool target. |
 | Retry state | Automatic retries are exposed as `session.status_rescheduled` plus `retry_status.type = "retrying"` errors when the selected harness provides a retry signal. |
 | Scheduled deployments | Sandbox0 accepts five-field POSIX cron expressions with IANA timezones. It does not backfill missed runs after unpause or downtime. |
 | Deployment failure handling | Scheduled run creation failures are stored on deployment runs. Non-rate-limit failures pause the deployment. |
@@ -133,9 +133,9 @@ Sandbox0 stores the session and event log outside the sandbox. Sandbox attachmen
 | Delete | Rejects active running sessions. Delete after interrupting and reaching idle. |
 | Archive | Makes the session read-only for new input events. |
 
-`claude` and `codex` use agent in sandbox behavior. `openai-agents` uses sandbox as tool behavior, so the resident runtime can start a run before a Sandbox0 sandbox is claimed.
+`claude` and `codex` use agent in sandbox behavior. `sandpi` uses sandbox as tool behavior, so the resident runtime can start a run before a Sandbox0 sandbox is claimed.
 
-Sandbox0 session lifecycle includes `idle`, `running`, `rescheduling`, and `terminated`. The `rescheduling` state is transient and means the active run is waiting for an automatic retry. It is currently mapped from Claude Agent SDK `api_retry` events, Codex app-server `willRetry` errors, and OpenAI Agents SDK runner-managed retry policy decisions.
+Sandbox0 session lifecycle includes `idle`, `running`, `rescheduling`, and `terminated`. The `rescheduling` state is transient and means the active run is waiting for an automatic retry. It is currently mapped from Claude Agent SDK `api_retry` events and Codex app-server `willRetry` errors when the selected harness exposes a retry signal.
 
 ## Version Drift
 

--- a/docs/managed-agents/llmproxy/page.mdx
+++ b/docs/managed-agents/llmproxy/page.mdx
@@ -8,7 +8,7 @@ The hosted Sandbox0 LLMProxy is intentionally simple: no Sandbox0 account, no LL
 
 Use LLMProxy when:
 
-- The selected harness is `openai-agents`, `codex`, or another OpenAI-compatible runtime.
+- The selected harness is `codex`, `sandpi`, or another OpenAI-compatible runtime.
 - The model provider exposes a Claude Code-compatible or Anthropic Messages-compatible endpoint.
 - You only need protocol translation and do not need request logs, caching, budgets, rate limits, or managed BYOK controls from a full AI gateway.
 - You want the fastest path: construct the URL, store it as the LLM base URL, and run the agent.
@@ -33,14 +33,14 @@ https://llmproxy.sandbox0.ai/claude2codex/https://api.z.ai/api/anthropic
 
 Use that full URL as `sandbox0.managed_agents.llm_base_url` on the LLM vault.
 
-## OpenAI Agents Example
+## Codex Example
 
 ```typescript
 const llmVault = await client.beta.vaults.create({
-    display_name: "OpenAI Agents via LLMProxy",
+    display_name: "Codex via LLMProxy",
     metadata: {
         "sandbox0.managed_agents.role": "llm",
-        "sandbox0.managed_agents.engine": "openai-agents",
+        "sandbox0.managed_agents.engine": "codex",
         "sandbox0.managed_agents.llm_base_url": "https://llmproxy.sandbox0.ai/claude2codex/https://api.z.ai/api/anthropic",
     },
 });

--- a/docs/managed-agents/page.mdx
+++ b/docs/managed-agents/page.mdx
@@ -32,7 +32,7 @@ Managed Agents can execute in two ways:
 | Model | What users should expect | Harnesses |
 |-------|--------------------------|---------|
 | Agent in sandbox | The agent runtime process lives inside the per-session sandbox with the workspace and harness state. | `claude`, `codex` |
-| Sandbox as tool | A resident runtime service owns the agent loop and uses Sandbox0 as an isolated tool target. | `openai-agents` |
+| Sandbox as tool | A resident runtime service owns the agent loop and uses Sandbox0 as an isolated tool target. | `sandpi` |
 
 Both models use the same Managed Agents API and durable event stream. Choose the model by selecting an agent harness through the LLM vault.
 
@@ -77,7 +77,7 @@ The public object model follows Claude Managed Agents where practical. The backe
 - The SDK `apiKey` is a Sandbox0 API key.
 - The LLM token is stored in a vault and projected by Sandbox0 credential policy.
 - The agent harness is selected through LLM vault metadata.
-- `claude` and `codex` run agent in sandbox; `openai-agents` uses sandbox as tool.
+- `claude` and `codex` run agent in sandbox; `sandpi` uses sandbox as tool.
 - The sandbox workspace is persistent across turns through a Sandbox0 volume.
 - Network policy and credential injection are enforced by Sandbox0.
 

--- a/docs/managed-agents/sessions/page.mdx
+++ b/docs/managed-agents/sessions/page.mdx
@@ -88,7 +88,7 @@ Sandbox0 keeps session state and event history outside the sandbox. The sandbox 
 - Runtime sandbox lifetime is managed by the Managed Agents deployment.
 - The selected agent harness is resolved from the attached LLM vault; if no harness is selected, the default is `claude`.
 - `claude` and `codex` run the agent process inside the sandbox.
-- `openai-agents` runs the agent loop in a resident runtime and uses Sandbox0 as a sandbox tool.
+- `sandpi` runs the agent loop in a resident runtime and uses Sandbox0 as a sandbox tool.
 - Harnesses with observable automatic retry attempts map them to the same session state sequence: `running`, `rescheduling`, `running`, then either `idle` or `terminated`.
 
 ## Next Steps

--- a/docs/managed-agents/vaults/page.mdx
+++ b/docs/managed-agents/vaults/page.mdx
@@ -34,7 +34,7 @@ await client.beta.vaults.credentials.create(llmVault.id, {
 | Metadata key | Required | Meaning |
 |--------------|----------|---------|
 | `sandbox0.managed_agents.role` | Yes | Must be `llm` for an LLM vault |
-| `sandbox0.managed_agents.engine` | Yes | `claude`, `codex`, or `openai-agents` |
+| `sandbox0.managed_agents.engine` | Yes | `claude`, `codex`, or `sandpi` |
 | `sandbox0.managed_agents.llm_base_url` | No | Model provider base URL |
 
 The LLM credential must be an unbound `static_bearer` credential. Do not set `mcp_server_url` on LLM credentials.
@@ -134,15 +134,15 @@ Sandbox0 injects model provider credentials through egress auth and harness comp
 |--------|---------------------------|
 | `claude` | `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BASE_URL` |
 | `codex` | `CODEX_API_KEY`, `OPENAI_API_KEY`, and `openai_base_url` harness config |
-| `openai-agents` | `OPENAI_API_KEY`, `OPENAI_BASE_URL`, and `openai_base_url` harness config |
+| `sandpi` | `OPENAI_API_KEY`, `OPENAI_BASE_URL`, `SANDPI_LLM_API_KEY`, `SANDPI_LLM_BASE_URL`, and OpenAI-compatible harness config |
 
 For agent-in-sandbox harnesses such as `claude` and `codex`, compatibility environment variables may contain placeholders. The real token is projected by Sandbox0-managed credential policy when the sandbox contacts the configured model provider host.
 
-For sandbox-as-tool harnesses such as `openai-agents`, model-provider credentials are resolved as resident runtime configuration. Sandbox0 passes the selected LLM vault token to the runtime service for model calls. User-defined `environment_variable` credentials are not accepted by external sandbox-as-tool harnesses today.
+For resident sandbox-as-tool harnesses such as `sandpi`, model-provider credentials are resolved as resident runtime configuration. Sandbox0 passes the selected LLM vault token to the runtime service for model calls. User-defined `environment_variable` credentials are not accepted by resident sandbox-as-tool harnesses today.
 
 Vault `environment_variable` credentials are separate from these harness compatibility variables. They create user-defined sandbox process environment variables and resolve them through the same egress auth boundary.
 
-For `openai-agents`, the runtime expects an OpenAI Responses-compatible base URL. If the provider exposes a different API shape, use an external AI gateway that presents an OpenAI Responses-compatible endpoint and store the gateway base URL in `sandbox0.managed_agents.llm_base_url`.
+For `sandpi`, the runtime expects an OpenAI-compatible base URL. If the provider exposes a different API shape, use an external AI gateway that presents an OpenAI-compatible endpoint and store the gateway base URL in `sandbox0.managed_agents.llm_base_url`.
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary
- remove openai-agents from managed-agents docs as a supported harness
- document the supported harness set as claude, codex, and sandpi
- update sandbox-as-tool, vault, compatibility, session, and LLMProxy examples to use SandPi/Codex

## Verification
- git diff --check
- npm run build:website in sibling sandbox0-cloud, which regenerated and rendered docs from this sandbox0 checkout
