### PR TITLE
Expose split stdout and stderr for command contexts

### DIFF
--- a/docs/sandbox/contexts/page.mdx
+++ b/docs/sandbox/contexts/page.mdx
@@ -189,7 +189,8 @@ result2, err := sandbox.Cmd(ctx, \`/bin/sh -c "echo hi"\`)
 if err != nil {
     log.Fatal(err)
 }
-fmt.Print(result2.OutputRaw)
+fmt.Print(result2.Stdout)
+fmt.Fprint(os.Stderr, result2.Stderr)
 
 // Variables NOT preserved between Cmd calls
 sandbox.Cmd(ctx, \`/bin/sh -c "x=3"\`)
@@ -197,31 +198,38 @@ result2, err = sandbox.Cmd(ctx, \`/bin/sh -c "echo $x"\`)
 if err != nil {
     log.Fatal(err)
 }
-fmt.Print(result2.OutputRaw)`
+fmt.Print(result2.Stdout)
+fmt.Fprint(os.Stderr, result2.Stderr)`
     },
     {
       label: "Python",
       language: "python",
-      code: `# One-shot command - stateless
+      code: `import sys
+
+# One-shot command - stateless
 result = sandbox.cmd('echo "hello from cmd"')
-print(result.output_raw, end="")
+print(result.stdout, end="")
+print(result.stderr, end="", file=sys.stderr)
 
 # Variables NOT preserved between cmd calls
 sandbox.cmd('/bin/sh -c "x=3"')
 result = sandbox.cmd('/bin/sh -c "echo $x"')
-print(result.output_raw, end="")`
+print(result.stdout, end="")
+print(result.stderr, end="", file=sys.stderr)`
     },
     {
       label: "TypeScript",
       language: "typescript",
       code: `// One-shot command - stateless
 let cmdResult = await sandbox.cmd('echo "hello from cmd"');
-process.stdout.write(cmdResult.outputRaw);
+process.stdout.write(cmdResult.stdout);
+process.stderr.write(cmdResult.stderr);
 
 // Variables NOT preserved between cmd calls
 await sandbox.cmd('/bin/sh -c "x=3"');
 cmdResult = await sandbox.cmd('/bin/sh -c "echo $x"');
-process.stdout.write(cmdResult.outputRaw);`
+process.stdout.write(cmdResult.stdout);
+process.stderr.write(cmdResult.stderr);`
     },
     {
       label: "CLI",
@@ -233,9 +241,15 @@ process.stdout.write(cmdResult.outputRaw);`
 />
 
 When a non-streaming Cmd waits for completion, the response includes `output_raw`,
-`stdout`, `stderr`, `exit_code`, and `state`. `output_raw` remains the merged
-raw output for existing clients. `s0 sandbox exec` exits locally with the remote
-command exit code when it is non-zero.
+`stdout`, `stderr`, `exit_code`, and `state`. SDK `Cmd` helpers expose the split
+streams directly. `output_raw` remains the merged raw output for compatibility
+and as a fallback for PTY-style output. `s0 sandbox exec` writes command stdout
+to local stdout and command stderr to local stderr when split streams are
+available, falls back to `output_raw` otherwise, and exits locally with the
+remote command exit code when it is non-zero.
+
+When supporting older Sandbox0 servers, fall back to `output_raw` / `outputRaw`
+if both split stream fields are empty.
 
 ### Cmd with Options
 
@@ -255,12 +269,15 @@ command exit code when it is non-zero.
 if err != nil {
     log.Fatal(err)
 }
-fmt.Print(result2.OutputRaw)`
+fmt.Print(result2.Stdout)
+fmt.Fprint(os.Stderr, result2.Stderr)`
     },
     {
       label: "Python",
       language: "python",
-      code: `from sandbox0 import CmdOptions
+      code: `import sys
+
+from sandbox0 import CmdOptions
 
 result = sandbox.cmd(
     "bash -c 'echo $GREETING && pwd'",
@@ -271,7 +288,8 @@ result = sandbox.cmd(
         idle_timeout_sec=60,
     ),
 )
-print(result.output_raw, end="")`
+print(result.stdout, end="")
+print(result.stderr, end="", file=sys.stderr)`
     },
     {
       label: "TypeScript",
@@ -282,7 +300,8 @@ print(result.output_raw, end="")`
     ttlSec: 120,
     idleTimeoutSec: 60,
 });
-process.stdout.write(cmdResult.outputRaw);`
+process.stdout.write(cmdResult.stdout);
+process.stderr.write(cmdResult.stderr);`
     },
     {
       label: "CLI",

--- a/docs/sandbox/contexts/page.mdx
+++ b/docs/sandbox/contexts/page.mdx
@@ -233,8 +233,9 @@ process.stdout.write(cmdResult.outputRaw);`
 />
 
 When a non-streaming Cmd waits for completion, the response includes `output_raw`,
-`exit_code`, and `state`. `s0 sandbox exec` exits locally with the remote command
-exit code when it is non-zero.
+`stdout`, `stderr`, `exit_code`, and `state`. `output_raw` remains the merged
+raw output for existing clients. `s0 sandbox exec` exits locally with the remote
+command exit code when it is non-zero.
 
 ### Cmd with Options
 
@@ -394,7 +395,9 @@ Create a new context in a sandbox.
 | `wait_until_done` | boolean | Wait for completion (default: false) |
 
 For Cmd contexts created with `wait_until_done: true`, the response includes
-`output_raw`, `exit_code`, and `state` after the process exits.
+`output_raw`, `stdout`, `stderr`, `exit_code`, and `state` after the process
+exits. `stdout` and `stderr` are populated for non-PTY Cmd contexts when
+available; PTY and REPL contexts may only expose `output_raw`.
 
 ### REPL Configuration
 
@@ -988,7 +991,8 @@ Execute input and wait for completion. For REPL contexts, the server appends a t
 /api/v1/sandboxes/{'{id}'}/contexts/{'{ctx_id}'}/exec
 </Endpoint>
 
-The response always includes `output_raw`. It also includes `exit_code` and
+The response always includes `output_raw`. For non-PTY Cmd contexts it also
+includes `stdout` and `stderr` when available. It includes `exit_code` and
 `state` when the underlying process has exited.
 
 <Tabs

--- a/manager/procd/pkg/http/handlers/context.go
+++ b/manager/procd/pkg/http/handlers/context.go
@@ -84,6 +84,8 @@ type ContextResponse struct {
 	Paused    bool                `json:"paused"`
 	CreatedAt string              `json:"created_at"`
 	OutputRaw string              `json:"output_raw,omitempty"`
+	Stdout    *string             `json:"stdout,omitempty"`
+	Stderr    *string             `json:"stderr,omitempty"`
 	ExitCode  *int                `json:"exit_code,omitempty"`
 	State     string              `json:"state,omitempty"`
 }
@@ -113,8 +115,36 @@ func newContextResponse(ctx *ctxpkg.Context, outputRaw string) ContextResponse {
 		CreatedAt: ctx.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
 		OutputRaw: outputRaw,
 	}
+	applySplitOutputToContextResponse(&response, ctx)
 	applyTerminalStatusToContextResponse(&response, terminalStatusForContext(ctx))
 	return response
+}
+
+func splitOutputForContext(ctx *ctxpkg.Context) (string, string, bool) {
+	if ctx == nil || ctx.Type != process.ProcessTypeCMD || ctx.MainProcess == nil {
+		return "", "", false
+	}
+	outputProvider, ok := ctx.MainProcess.(process.OutputProvider)
+	if !ok {
+		return "", "", false
+	}
+	stdout, stderr := outputProvider.GetOutput()
+	if stdout == "" && stderr == "" {
+		return "", "", false
+	}
+	return stdout, stderr, true
+}
+
+func applySplitOutputToContextResponse(response *ContextResponse, ctx *ctxpkg.Context) {
+	if response == nil {
+		return
+	}
+	stdout, stderr, ok := splitOutputForContext(ctx)
+	if !ok {
+		return
+	}
+	response.Stdout = &stdout
+	response.Stderr = &stderr
 }
 
 func applyTerminalStatusToContextResponse(response *ContextResponse, status *contextTerminalStatus) {
@@ -157,9 +187,11 @@ type ContextInputRequest struct {
 
 // ContextExecResponse is the response body for synchronous execution.
 type ContextExecResponse struct {
-	OutputRaw string `json:"output_raw"`
-	ExitCode  *int   `json:"exit_code,omitempty"`
-	State     string `json:"state,omitempty"`
+	OutputRaw string  `json:"output_raw"`
+	Stdout    *string `json:"stdout,omitempty"`
+	Stderr    *string `json:"stderr,omitempty"`
+	ExitCode  *int    `json:"exit_code,omitempty"`
+	State     string  `json:"state,omitempty"`
 }
 
 // ResizeContextRequest is the request body for resizing a PTY.
@@ -499,6 +531,7 @@ func (h *ContextHandler) Exec(w http.ResponseWriter, r *http.Request) {
 	}
 
 	response := ContextExecResponse{OutputRaw: output}
+	applySplitOutputToExecResponse(&response, ctx)
 	applyTerminalStatusToExecResponse(&response, terminalStatusForContext(ctx))
 	writeJSON(w, http.StatusOK, response)
 }
@@ -559,6 +592,18 @@ func applyTerminalStatusToExecResponse(response *ContextExecResponse, status *co
 	exitCode := status.ExitCode
 	response.ExitCode = &exitCode
 	response.State = status.State
+}
+
+func applySplitOutputToExecResponse(response *ContextExecResponse, ctx *ctxpkg.Context) {
+	if response == nil {
+		return
+	}
+	stdout, stderr, ok := splitOutputForContext(ctx)
+	if !ok {
+		return
+	}
+	response.Stdout = &stdout
+	response.Stderr = &stderr
 }
 
 func (h *ContextHandler) execInputSync(ctx *ctxpkg.Context, input string, requestCtx context.Context) (string, *execError, bool) {

--- a/manager/procd/pkg/http/handlers/context_test.go
+++ b/manager/procd/pkg/http/handlers/context_test.go
@@ -30,6 +30,8 @@ type fakeProcess struct {
 	exitCode     int
 	state        process.ProcessState
 	processType  process.ProcessType
+	stdout       string
+	stderr       string
 	exitHandlers []process.ExitHandler
 	handlerAdded chan struct{}
 	writeErr     error
@@ -87,8 +89,13 @@ func (f *fakeProcess) WriteInput(data []byte) error {
 	return nil
 }
 func (f *fakeProcess) ReadOutput() <-chan process.ProcessOutput { return f.outputCh }
-func (f *fakeProcess) ResizePTY(process.PTYSize) error          { return nil }
-func (f *fakeProcess) SendSignal(syscall.Signal) error          { return nil }
+func (f *fakeProcess) GetOutput() (stdout, stderr string) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.stdout, f.stderr
+}
+func (f *fakeProcess) ResizePTY(process.PTYSize) error { return nil }
+func (f *fakeProcess) SendSignal(syscall.Signal) error { return nil }
 func (f *fakeProcess) ExitCode() (int, error) {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
@@ -236,6 +243,50 @@ func TestCreateContextWaitUntilDoneIncludesCMDTerminalStatus(t *testing.T) {
 	}
 }
 
+func TestCreateContextWaitUntilDoneIncludesCMDSplitOutput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell command fixture requires POSIX")
+	}
+	handler := NewContextHandler(ctxpkg.NewManager(), zap.NewNop())
+	req := httptest.NewRequest(http.MethodPost, "/contexts", strings.NewReader(`{
+		"type": "cmd",
+		"cmd": {"command": ["/bin/sh", "-c", "printf out; printf err >&2; exit 7"]},
+		"wait_until_done": true
+	}`))
+	rec := httptest.NewRecorder()
+
+	handler.Create(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	var resp struct {
+		Success bool            `json:"success"`
+		Data    ContextResponse `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if !resp.Success {
+		t.Fatalf("success = false, body = %s", rec.Body.String())
+	}
+	if resp.Data.Stdout == nil || *resp.Data.Stdout != "out" {
+		t.Fatalf("stdout = %#v, want out", resp.Data.Stdout)
+	}
+	if resp.Data.Stderr == nil || *resp.Data.Stderr != "err" {
+		t.Fatalf("stderr = %#v, want err", resp.Data.Stderr)
+	}
+	if !strings.Contains(resp.Data.OutputRaw, "out") || !strings.Contains(resp.Data.OutputRaw, "err") {
+		t.Fatalf("output_raw = %q, want merged output containing stdout and stderr", resp.Data.OutputRaw)
+	}
+	if resp.Data.ExitCode == nil || *resp.Data.ExitCode != 7 {
+		t.Fatalf("exit_code = %#v, want 7", resp.Data.ExitCode)
+	}
+	if resp.Data.State != string(process.ProcessStateCrashed) {
+		t.Fatalf("state = %q, want %q", resp.Data.State, process.ProcessStateCrashed)
+	}
+}
+
 func TestExecReturnsCMDTerminalStatus(t *testing.T) {
 	outputCh := make(chan process.ProcessOutput, 1)
 	var proc *fakeProcess
@@ -276,6 +327,55 @@ func TestExecReturnsCMDTerminalStatus(t *testing.T) {
 	}
 	if resp.Data.State != string(process.ProcessStateCrashed) {
 		t.Fatalf("state = %q, want %q", resp.Data.State, process.ProcessStateCrashed)
+	}
+}
+
+func TestExecReturnsCMDSplitOutput(t *testing.T) {
+	outputCh := make(chan process.ProcessOutput, 2)
+	var proc *fakeProcess
+	proc = &fakeProcess{
+		outputCh:    outputCh,
+		processType: process.ProcessTypeCMD,
+		stdout:      "out",
+		stderr:      "err",
+		onWrite: func([]byte) {
+			outputCh <- process.ProcessOutput{Source: process.OutputSourceStdout, Data: []byte("out")}
+			outputCh <- process.ProcessOutput{Source: process.OutputSourceStderr, Data: []byte("err")}
+			proc.triggerExit(process.ExitEvent{ExitCode: 7, State: process.ProcessStateCrashed})
+			close(outputCh)
+		},
+	}
+	handler, ctx := newHandlerWithContext(proc, process.ProcessTypeCMD)
+	req := httptest.NewRequest(http.MethodPost, "/contexts/"+ctx.ID+"/exec", strings.NewReader(`{"data":"run"}`))
+	req = mux.SetURLVars(req, map[string]string{"id": ctx.ID})
+	rec := httptest.NewRecorder()
+
+	handler.Exec(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var resp struct {
+		Success bool                `json:"success"`
+		Data    ContextExecResponse `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if !resp.Success {
+		t.Fatalf("success = false, body = %s", rec.Body.String())
+	}
+	if resp.Data.Stdout == nil || *resp.Data.Stdout != "out" {
+		t.Fatalf("stdout = %#v, want out", resp.Data.Stdout)
+	}
+	if resp.Data.Stderr == nil || *resp.Data.Stderr != "err" {
+		t.Fatalf("stderr = %#v, want err", resp.Data.Stderr)
+	}
+	if resp.Data.OutputRaw != "outerr" {
+		t.Fatalf("output_raw = %q, want outerr", resp.Data.OutputRaw)
+	}
+	if resp.Data.ExitCode == nil || *resp.Data.ExitCode != 7 {
+		t.Fatalf("exit_code = %#v, want 7", resp.Data.ExitCode)
 	}
 }
 

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -4910,6 +4910,12 @@ components:
         output_raw:
           type: string
           description: Raw PTY output for CMD contexts with wait=true, may contain terminal control characters
+        stdout:
+          type: string
+          description: Captured stdout for non-PTY CMD contexts when available.
+        stderr:
+          type: string
+          description: Captured stderr for non-PTY CMD contexts when available.
         exit_code:
           type: integer
           format: int32
@@ -4947,6 +4953,12 @@ components:
         output_raw:
           type: string
           description: Raw PTY output, may contain terminal control characters (e.g. \r)
+        stdout:
+          type: string
+          description: Captured stdout for non-PTY CMD contexts when available.
+        stderr:
+          type: string
+          description: Captured stderr for non-PTY CMD contexts when available.
         exit_code:
           type: integer
           format: int32

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -648,6 +648,12 @@ type ContextExecResponse struct {
 
 	// State Final process state when the underlying process has exited.
 	State *string `json:"state,omitempty"`
+
+	// Stderr Captured stderr for non-PTY CMD contexts when available.
+	Stderr *string `json:"stderr,omitempty"`
+
+	// Stdout Captured stdout for non-PTY CMD contexts when available.
+	Stdout *string `json:"stdout,omitempty"`
 }
 
 // ContextInputRequest defines model for ContextInputRequest.
@@ -685,8 +691,14 @@ type ContextResponse struct {
 	Running   bool    `json:"running"`
 
 	// State Final process state when the underlying process has exited.
-	State *string     `json:"state,omitempty"`
-	Type  ProcessType `json:"type"`
+	State *string `json:"state,omitempty"`
+
+	// Stderr Captured stderr for non-PTY CMD contexts when available.
+	Stderr *string `json:"stderr,omitempty"`
+
+	// Stdout Captured stdout for non-PTY CMD contexts when available.
+	Stdout *string     `json:"stdout,omitempty"`
+	Type   ProcessType `json:"type"`
 }
 
 // ContextStatsResponse defines model for ContextStatsResponse.


### PR DESCRIPTION
## Summary

- add optional `stdout` and `stderr` fields to synchronous context responses in the OpenAPI contract
- populate split output for non-PTY CMD contexts from the existing procd `OutputProvider`
- keep `output_raw` backward compatible and update contexts docs with SDK/CLI split-output usage
- add procd tests for split stdout/stderr on `wait_until_done` and sync exec paths

Refs #570.

Companion PRs:

- sdk-go: sandbox0-ai/sdk-go#60
- sdk-py: sandbox0-ai/sdk-py#48
- sdk-js: sandbox0-ai/sdk-js#52
- s0 CLI: sandbox0-ai/s0#73

## Tests

- `make apispec`
- `env GOWORK=off go test ./manager/procd/pkg/http/handlers ./pkg/apispec`
- `env GOWORK=off go test ./manager/procd/pkg/... ./cluster-gateway/pkg/http`
- remote kind validation: `stdout=out`, `stderr=err`, `output_raw=outerr`, `exit_code=7`
- docs proofreading: `git diff --check` and MDX endpoint brace check
