### PR TITLE
docs: clarify sandbox function Python runtime

### DIFF
--- a/docs/sandbox/functions/page.mdx
+++ b/docs/sandbox/functions/page.mdx
@@ -24,7 +24,11 @@ Function services are different from listener-backed services:
 - use the returned `public_url` as the only public entrypoint
 - execute the handler once per matching request
 
-Python is the first supported function runtime. The sandbox image must include `python3` in `PATH`.
+Python is the first supported function runtime. The sandbox image must include `python3` in `PATH` and use Python 3.9 or later for the supported function feature set.
+
+<Callout variant="info">
+Sandbox0 injects `python-runner` into each sandbox pod, but the runner executes `python3` from the sandbox template image. Custom templates and custom images therefore own the Python runtime used by Sandbox Functions. Older Python versions are not supported; async handlers, streaming responses, and WebSocket handlers depend on Python's modern `asyncio` runtime.
+</Callout>
 
 ## Function Config
 

--- a/docs/template/images/page.mdx
+++ b/docs/template/images/page.mdx
@@ -9,6 +9,10 @@ Every Template references a container image. Sandbox0 supports two types of imag
 
 For private images, Sandbox0 provides a built-in registry and a CLI workflow to build and push images securely. Authentication is handled automatically — your images are protected and only accessible to your team.
 
+<Callout variant="info">
+If a template will run [Sandbox Functions](/docs/sandbox/functions), its image must include `python3` in `PATH` and use Python 3.9 or later. Sandbox0 injects the function runner, but the runner executes the Python interpreter from the template image, not from the manager image.
+</Callout>
+
 ---
 
 ## Using a Public Image


### PR DESCRIPTION
## Summary
- Clarify that Sandbox Functions execute `python3` from the sandbox template image.
- Document the Python 3.9+ requirement for the supported function feature set.
- Add a custom image reminder for templates that run Sandbox Functions.

Refs #574.

## Testing
- `git diff --check`
- Not run: docs build, because this repo does not include a docs package/build script.