### PR TITLE
Require restartable runtime for public resume routes

### DIFF
--- a/cluster-gateway/pkg/http/handlers_exposure.go
+++ b/cluster-gateway/pkg/http/handlers_exposure.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/sandbox0-ai/sandbox0/cluster-gateway/pkg/client"
+	mgr "github.com/sandbox0-ai/sandbox0/manager/pkg/service"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 	"github.com/sandbox0-ai/sandbox0/pkg/proxy"
@@ -69,6 +70,10 @@ func (s *Server) handlePublicExposureNoRoute(c *gin.Context) {
 		return
 	}
 	if !s.enforceSandboxServiceRoute(c, sandboxID, sandbox.TeamID, route) {
+		return
+	}
+	if route.Resume && !clientServiceHasRestartableRuntime(match.service) {
+		spec.JSONError(c, http.StatusConflict, spec.CodeConflict, "resume-enabled route requires a restartable service runtime")
 		return
 	}
 	needsRuntimeRefetch := sandboxRuntimeMissing(sandbox)
@@ -137,6 +142,10 @@ func (s *Server) handlePublicExposureNoRoute(c *gin.Context) {
 		return
 	}
 	router.ProxyToTarget(c)
+}
+
+func clientServiceHasRestartableRuntime(service *mgr.SandboxAppService) bool {
+	return service != nil && mgr.SandboxAppServiceHasRestartableRuntime(*service)
 }
 
 func (s *Server) resolveExposureFromRequest(c *gin.Context) (sandboxID string, port int, _ string, err error) {

--- a/cluster-gateway/pkg/http/sandbox_service_policy_test.go
+++ b/cluster-gateway/pkg/http/sandbox_service_policy_test.go
@@ -202,6 +202,65 @@ func TestSandboxServiceExposureReturnsNotFoundForMissingSandbox(t *testing.T) {
 	}
 }
 
+func TestSandboxServiceRejectsResumeRouteWithoutRestartableRuntime(t *testing.T) {
+	var resumed atomic.Bool
+	manager := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/internal/v1/sandboxes/sb-demo":
+			_ = spec.WriteSuccess(w, http.StatusOK, &mgr.Sandbox{
+				ID:         "sb-demo",
+				TeamID:     "team-1",
+				AutoResume: true,
+				Status:     mgr.SandboxStatusPaused,
+				Paused:     true,
+				Services: []mgr.SandboxAppService{{
+					ID:   "api",
+					Port: 3000,
+					Ingress: mgr.SandboxAppServiceIngress{
+						Public: true,
+						Routes: []mgr.SandboxAppServiceRoute{{
+							ID:         "api",
+							PathPrefix: "/",
+							Resume:     true,
+						}},
+					},
+				}},
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/sandboxes/sb-demo/resume":
+			resumed.Store(true)
+			_ = spec.WriteSuccess(w, http.StatusOK, map[string]any{"sandbox_id": "sb-demo"})
+		default:
+			t.Fatalf("unexpected manager request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer manager.Close()
+
+	gateway := newSandboxServiceExposureTestServerWithManagerURL(t, manager.URL)
+	gatewayServer := httptest.NewServer(gateway)
+	defer gatewayServer.Close()
+
+	req := newGatewayRequest(t, http.MethodGet, gatewayServer.URL, "sb-demo--p3000.aws-us-east-1.sandbox0.app", "/")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("gateway request: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status = %d body=%s, want %d", resp.StatusCode, string(body), http.StatusConflict)
+	}
+	if !strings.Contains(string(body), "restartable service runtime") {
+		t.Fatalf("body = %q, want restartable runtime error", string(body))
+	}
+	if resumed.Load() {
+		t.Fatal("manager resume was called for an unrestartable route")
+	}
+}
+
 func TestSandboxFunctionServiceExecutesThroughProcdPort(t *testing.T) {
 	var execReq sandboxfunction.ExecuteRequest
 	procd := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/docs/sandbox/pause-resume/page.mdx
+++ b/docs/sandbox/pause-resume/page.mdx
@@ -171,7 +171,7 @@ console.log("runtimeGeneration=", sb.runtimeGeneration);`
 
 Common auto-resume entrypoints:
 
-- service routes configured with `resume: true`; public service requests require both sandbox `auto_resume: true` and route `resume: true`
+- service routes configured with `resume: true`; public service requests require sandbox `auto_resume: true`, route `resume: true`, and a restartable service runtime (`cmd` or `function`)
 - SSH access through Sandbox0 SSH Gateway
 
 For a paused sandbox, auto-resume creates a new runtime pod for the same sandbox identity and restores the saved rootfs checkpoint before the sandbox is used. Public service URLs remain stable until the sandbox is explicitly deleted or `hard_ttl` expires.

--- a/docs/sandbox/services/page.mdx
+++ b/docs/sandbox/services/page.mdx
@@ -66,7 +66,7 @@ Routes are evaluated before proxying or function execution.
 | `cors` | Handles CORS preflight and response headers at the gateway |
 | `rate_limit` | Applies per-route rate limiting at the gateway |
 | `timeout_seconds` | Sets the upstream or function execution timeout |
-| `resume` | Allows this route to resume a paused sandbox when sandbox `auto_resume` is also true |
+| `resume` | Allows this route to resume a paused sandbox when sandbox `auto_resume` is also true. Resume-enabled public routes require `runtime.type: cmd` or `runtime.type: function` |
 
 `path_prefix` is not stripped automatically. Without `rewrite_prefix`, the upstream service or function handler sees the original request path.
 
@@ -173,8 +173,10 @@ services:
           routes:
               - id: web
                 path_prefix: /
-                resume: true
+                resume: false
 ```
+
+Manual services can expose a listener while the sandbox is running, but they cannot be restarted by public auto-resume. Use a `cmd` service or a function service when a public route needs `resume: true`.
 
 ## API Reference
 
@@ -241,6 +243,11 @@ resp, err := sandbox.UpdateServices(ctx, []apispec.SandboxAppService{
     {
         ID:   "api",
         Port: apispec.NewOptInt32(8080),
+        Runtime: apispec.NewOptSandboxAppServiceRuntime(apispec.SandboxAppServiceRuntime{
+            Type:    apispec.SandboxAppServiceRuntimeTypeCmd,
+            Command: []string{"python3", "-m", "http.server", "8080"},
+            Cwd:     apispec.NewOptString("/workspace"),
+        }),
         Ingress: apispec.SandboxAppServiceIngress{
             Public: true,
             Routes: []apispec.SandboxAppServiceRoute{
@@ -277,6 +284,11 @@ const resp = await sandbox.updateServices([
     {
         id: 'api',
         port: 8080,
+        runtime: {
+            type: 'cmd',
+            command: ['python3', '-m', 'http.server', '8080'],
+            cwd: '/workspace',
+        },
         ingress: {
             _public: true,
             routes: [
@@ -308,6 +320,7 @@ from sandbox0.apispec.models.sandbox_app_service_ingress import SandboxAppServic
 from sandbox0.apispec.models.sandbox_app_service_route import SandboxAppServiceRoute
 from sandbox0.apispec.models.sandbox_app_service_route_auth import SandboxAppServiceRouteAuth
 from sandbox0.apispec.models.sandbox_app_service_route_auth_mode import SandboxAppServiceRouteAuthMode
+from sandbox0.apispec.models.sandbox_app_service_runtime import SandboxAppServiceRuntime
 
 token_hash = hashlib.sha256(os.environ["PUBLIC_API_TOKEN"].encode()).hexdigest()
 
@@ -315,6 +328,11 @@ resp = sandbox.update_services([
     SandboxAppService(
         id="api",
         port=8080,
+        runtime=SandboxAppServiceRuntime(
+            type="cmd",
+            command=["python3", "-m", "http.server", "8080"],
+            cwd="/workspace",
+        ),
         ingress=SandboxAppServiceIngress(
             public=True,
             routes=[
@@ -400,6 +418,14 @@ config:
     services:
         - id: api
           port: 8080
+          runtime:
+              type: cmd
+              command:
+                  - python3
+                  - -m
+                  - http.server
+                  - "8080"
+              cwd: /workspace
           ingress:
               public: true
               routes:
@@ -421,6 +447,11 @@ config:
         {
             ID:   "api",
             Port: apispec.NewOptInt32(8080),
+            Runtime: apispec.NewOptSandboxAppServiceRuntime(apispec.SandboxAppServiceRuntime{
+                Type:    apispec.SandboxAppServiceRuntimeTypeCmd,
+                Command: []string{"python3", "-m", "http.server", "8080"},
+                Cwd:     apispec.NewOptString("/workspace"),
+            }),
             Ingress: apispec.SandboxAppServiceIngress{
                 Public: true,
                 Routes: []apispec.SandboxAppServiceRoute{
@@ -449,6 +480,11 @@ if err != nil {
         {
             id: 'api',
             port: 8080,
+            runtime: {
+                type: 'cmd',
+                command: ['python3', '-m', 'http.server', '8080'],
+                cwd: '/workspace',
+            },
             ingress: {
                 _public: true,
                 routes: [
@@ -478,6 +514,11 @@ sandbox = client.sandboxes.claim(
             {
                 "id": "api",
                 "port": 8080,
+                "runtime": {
+                    "type": "cmd",
+                    "command": ["python3", "-m", "http.server", "8080"],
+                    "cwd": "/workspace",
+                },
                 "ingress": {
                     "public": True,
                     "routes": [
@@ -505,12 +546,13 @@ sandbox = client.sandboxes.claim(
 
 ## Auto-Resume
 
-Public service auto-resume has two gates:
+Public service auto-resume has three requirements:
 
 - sandbox `auto_resume` must be true
 - matched route `resume` must be true
+- the matched service must be restartable with `runtime.type: cmd` or `runtime.type: function`
 
-Both gates are required for public URL requests to wake a paused sandbox.
+All three requirements are needed for public URL requests to wake a paused sandbox and make the backing service available.
 
 For a paused sandbox, Sandbox0 creates a new runtime pod for the same sandbox identity and restores the latest rootfs checkpoint. The sandbox ID and service `public_url` stay unchanged until the sandbox is deleted or `hard_ttl` expires. For `cmd` services, the command is started again in the new runtime pod. For `function` services, there is still no long-running listener; each request executes the handler after the sandbox runtime is available.
 

--- a/manager/pkg/service/sandbox_app_service.go
+++ b/manager/pkg/service/sandbox_app_service.go
@@ -177,6 +177,22 @@ func SandboxAppServicesHaveResumeRoute(services []SandboxAppService) bool {
 	return false
 }
 
+// SandboxAppServiceHasRestartableRuntime reports whether cluster-gateway can
+// recreate the service process after a sandbox runtime is resumed.
+func SandboxAppServiceHasRestartableRuntime(service SandboxAppService) bool {
+	if service.Runtime == nil {
+		return false
+	}
+	switch service.Runtime.Type {
+	case SandboxAppServiceRuntimeCMD:
+		return len(service.Runtime.Command) > 0
+	case SandboxAppServiceRuntimeFunction:
+		return service.Runtime.Function != nil
+	default:
+		return false
+	}
+}
+
 // NormalizeSandboxAppServices validates and canonicalizes sandbox services.
 func NormalizeSandboxAppServices(services []SandboxAppService) ([]SandboxAppService, error) {
 	if len(services) == 0 {
@@ -275,6 +291,9 @@ func normalizeSandboxAppService(service SandboxAppService) (SandboxAppService, e
 		}
 		if _, ok := seenRoutes[route.ID]; ok {
 			return service, fmt.Errorf("ingress.routes[%d]: duplicate id %q", i, route.ID)
+		}
+		if service.Ingress.Public && route.Resume && !SandboxAppServiceHasRestartableRuntime(service) {
+			return service, fmt.Errorf("ingress.routes[%d]: resume requires runtime.type cmd or function", i)
 		}
 		seenRoutes[route.ID] = struct{}{}
 		service.Ingress.Routes[i] = route

--- a/manager/pkg/service/sandbox_app_service_test.go
+++ b/manager/pkg/service/sandbox_app_service_test.go
@@ -108,6 +108,87 @@ func TestSandboxAppServicePublishBlockersRequirePublicRestartableRuntime(t *test
 	}
 }
 
+func TestNormalizeSandboxAppServicesRejectsResumeRouteWithoutRestartableRuntime(t *testing.T) {
+	tests := []struct {
+		name    string
+		runtime *SandboxAppServiceRuntime
+	}{
+		{
+			name: "missing runtime",
+		},
+		{
+			name:    "manual runtime",
+			runtime: &SandboxAppServiceRuntime{Type: SandboxAppServiceRuntimeManual},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NormalizeSandboxAppServices([]SandboxAppService{{
+				ID:      "api",
+				Port:    8080,
+				Runtime: tt.runtime,
+				Ingress: SandboxAppServiceIngress{
+					Public: true,
+					Routes: []SandboxAppServiceRoute{{
+						ID:         "api",
+						PathPrefix: "/",
+						Resume:     true,
+					}},
+				},
+			}})
+			if err == nil {
+				t.Fatal("NormalizeSandboxAppServices succeeded, want resume runtime error")
+			}
+			if !strings.Contains(err.Error(), "resume requires runtime.type cmd or function") {
+				t.Fatalf("error = %q, want resume runtime message", err.Error())
+			}
+		})
+	}
+}
+
+func TestNormalizeSandboxAppServicesAllowsManualRouteWithoutResume(t *testing.T) {
+	services, err := NormalizeSandboxAppServices([]SandboxAppService{{
+		ID:   "api",
+		Port: 8080,
+		Ingress: SandboxAppServiceIngress{
+			Public: true,
+			Routes: []SandboxAppServiceRoute{{
+				ID:         "api",
+				PathPrefix: "/",
+			}},
+		},
+	}})
+	if err != nil {
+		t.Fatalf("NormalizeSandboxAppServices: %v", err)
+	}
+	if services[0].Runtime != nil {
+		t.Fatalf("runtime = %#v, want nil manual service", services[0].Runtime)
+	}
+}
+
+func TestNormalizeSandboxAppServicesAllowsResumeRouteWithCMDRuntime(t *testing.T) {
+	_, err := NormalizeSandboxAppServices([]SandboxAppService{{
+		ID:   "api",
+		Port: 8080,
+		Runtime: &SandboxAppServiceRuntime{
+			Type:    SandboxAppServiceRuntimeCMD,
+			Command: []string{"python3", "-m", "http.server", "8080"},
+		},
+		Ingress: SandboxAppServiceIngress{
+			Public: true,
+			Routes: []SandboxAppServiceRoute{{
+				ID:         "api",
+				PathPrefix: "/",
+				Resume:     true,
+			}},
+		},
+	}})
+	if err != nil {
+		t.Fatalf("NormalizeSandboxAppServices: %v", err)
+	}
+}
+
 func TestNormalizeSandboxAppServicesSupportsFunctionRuntime(t *testing.T) {
 	services, err := NormalizeSandboxAppServices([]SandboxAppService{{
 		ID: "webhook",

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -4200,6 +4200,9 @@ components:
           format: int32
         resume:
           type: boolean
+          description: |
+            Allows this public route to wake a paused sandbox when sandbox auto_resume is true.
+            Resume-enabled public routes require a restartable service runtime: cmd or function.
       required: [id, resume]
     SandboxAppServiceHealth:
       type: object

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -1596,15 +1596,18 @@ type SandboxAppServiceIngress struct {
 
 // SandboxAppServiceRoute defines model for SandboxAppServiceRoute.
 type SandboxAppServiceRoute struct {
-	Auth           *SandboxAppServiceRouteAuth      `json:"auth,omitempty"`
-	Cors           *SandboxAppServiceRouteCORS      `json:"cors,omitempty"`
-	Id             string                           `json:"id"`
-	Methods        *[]string                        `json:"methods,omitempty"`
-	PathPrefix     *string                          `json:"path_prefix,omitempty"`
-	RateLimit      *SandboxAppServiceRouteRateLimit `json:"rate_limit,omitempty"`
-	Resume         bool                             `json:"resume"`
-	RewritePrefix  *string                          `json:"rewrite_prefix"`
-	TimeoutSeconds *int32                           `json:"timeout_seconds,omitempty"`
+	Auth       *SandboxAppServiceRouteAuth      `json:"auth,omitempty"`
+	Cors       *SandboxAppServiceRouteCORS      `json:"cors,omitempty"`
+	Id         string                           `json:"id"`
+	Methods    *[]string                        `json:"methods,omitempty"`
+	PathPrefix *string                          `json:"path_prefix,omitempty"`
+	RateLimit  *SandboxAppServiceRouteRateLimit `json:"rate_limit,omitempty"`
+
+	// Resume Allows this public route to wake a paused sandbox when sandbox auto_resume is true.
+	// Resume-enabled public routes require a restartable service runtime: cmd or function.
+	Resume         bool    `json:"resume"`
+	RewritePrefix  *string `json:"rewrite_prefix"`
+	TimeoutSeconds *int32  `json:"timeout_seconds,omitempty"`
 }
 
 // SandboxAppServiceRouteAuth defines model for SandboxAppServiceRouteAuth.

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -1749,7 +1749,7 @@ func assertSandboxNetworkIsolation(env *framework.ScenarioEnv, session *e2eutils
 	routes := []apispec.SandboxAppServiceRoute{{
 		Id:         "web",
 		PathPrefix: ptr("/"),
-		Resume:     true,
+		Resume:     false,
 	}}
 	_, exposureDomain, status, err := session.UpdateSandboxServices(env.TestCtx.Context, GinkgoT(), sandboxBID, []apispec.SandboxAppService{{
 		Id:   "web",


### PR DESCRIPTION
## Summary

- reject public service routes with `resume: true` unless the service has a restartable `cmd` or `function` runtime
- return a clear conflict error for legacy resume-enabled manual services instead of attempting resume and falling through to a backend 502
- document the three public auto-resume requirements in OpenAPI and docs

Closes #583.

## Tests

- `go test ./manager/pkg/service ./cluster-gateway/pkg/http ./pkg/apispec`
