### PR TITLE
Support gVisor rootfs restore

### DIFF
--- a/.github/actions/prepare-infra/action.yml
+++ b/.github/actions/prepare-infra/action.yml
@@ -23,6 +23,14 @@ inputs:
     description: Run aggressive disk cleanup on GitHub-hosted Linux runners.
     required: false
     default: "true"
+  sandbox-runtime-class:
+    description: Optional RuntimeClass name used by sandbox pods in E2E.
+    required: false
+    default: ""
+  sandbox-runtime-handler:
+    description: Optional containerd runtime handler for the sandbox RuntimeClass.
+    required: false
+    default: ""
 runs:
   using: "composite"
   steps:
@@ -43,6 +51,16 @@ runs:
         version: v0.30.0
         config: ${{ inputs.kind-config }}
         cluster_name: ${{ inputs.kind-cluster-name }}
+
+    - name: Install gVisor runtime in Kind
+      if: ${{ inputs.sandbox-runtime-class != '' }}
+      shell: bash
+      run: |
+        handler="${{ inputs.sandbox-runtime-handler }}"
+        if [ -z "${handler}" ]; then
+          handler="${{ inputs.sandbox-runtime-class }}"
+        fi
+        bash tests/e2e/install-gvisor-kind.sh "${{ inputs.kind-cluster-name }}" "${{ inputs.sandbox-runtime-class }}" "${handler}"
 
     - name: Install Helm
       uses: azure/setup-helm@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -51,11 +51,15 @@ jobs:
           kind-config: tests/e2e/kind-config.yaml
           kind-cluster-name: sandbox0-e2e-${{ matrix.arch }}
           cache-key-suffix: ${{ matrix.arch }}
+          sandbox-runtime-class: gvisor
+          sandbox-runtime-handler: gvisor
 
       - name: Run E2E
         env:
           E2E_USE_EXISTING_CLUSTER: "true"
           E2E_CLUSTER_NAME: sandbox0-e2e-${{ matrix.arch }}
+          E2E_SANDBOX_RUNTIME_CLASS_NAME: gvisor
+          E2E_SANDBOX_RUNTIME_HANDLER: gvisor
         run: make test-e2e
 
       - name: Dump cluster state on failure

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -31,11 +31,15 @@ jobs:
           kind-config: tests/e2e/kind-config.yaml
           kind-cluster-name: ${{ env.KIND_CLUSTER_NAME }}
           cache-key-suffix: pr-amd64
+          sandbox-runtime-class: gvisor
+          sandbox-runtime-handler: gvisor
 
       - name: Run PR E2E
         env:
           E2E_USE_EXISTING_CLUSTER: "true"
           E2E_CLUSTER_NAME: ${{ env.KIND_CLUSTER_NAME }}
+          E2E_SANDBOX_RUNTIME_CLASS_NAME: gvisor
+          E2E_SANDBOX_RUNTIME_HANDLER: gvisor
         run: make test-e2e
 
       - name: Dump cluster state on failure

--- a/ctld/cmd/ctld/main.go
+++ b/ctld/cmd/ctld/main.go
@@ -111,6 +111,7 @@ func main() {
 		PodNamespace:  podNamespace,
 		RootFSBinder:  rootFSRuntime,
 	})
+	rootFSRuntime.SetRootFSPortalAttacher(portalManager)
 	go portalManager.Run(ctx)
 	csiServer := ctldportal.NewCSIServer(nodeName, portalManager)
 	go func() {

--- a/ctld/internal/ctld/portal/manager.go
+++ b/ctld/internal/ctld/portal/manager.go
@@ -67,6 +67,7 @@ type portalMount struct {
 
 	rootfsBackingPath string
 	rootfsSession     volumefuse.Session
+	rootfsAttached    bool
 
 	volumeID  string
 	teamID    string
@@ -102,6 +103,16 @@ type Config struct {
 type RootFSVolumePortalBindRequest struct {
 	PodUID    string
 	MountPath string
+}
+
+type RootFSPortalSessionRequest struct {
+	PodUID  string
+	Session volumefuse.Session
+}
+
+type RootFSPortalSessionResponse struct {
+	MountPath  string
+	TargetPath string
 }
 
 type RootFSVolumePortalBinder interface {
@@ -314,7 +325,7 @@ func (m *Manager) RootFSPortalPaths(podUID string) []ctldapi.RootFSPortalPath {
 		if pm == nil || pm.podUID != podUID || pm.volumeID != "" {
 			continue
 		}
-		if pm.name == volumeportal.WebhookStatePortalName || pm.mountPath == volumeportal.WebhookStateMountPath {
+		if volumeportal.IsSystemPortal(pm.name, pm.mountPath) {
 			continue
 		}
 		if strings.TrimSpace(pm.mountPath) == "" || strings.TrimSpace(pm.rootfsBackingPath) == "" {
@@ -336,6 +347,9 @@ func (m *Manager) Bind(ctx context.Context, req ctldapi.BindVolumePortalRequest)
 	portalName := volumeportal.NormalizePortalName(req.PortalName, req.MountPath)
 	if portalName == "" {
 		return ctldapi.BindVolumePortalResponse{}, fmt.Errorf("portal name or mount path is required")
+	}
+	if volumeportal.IsSystemPortal(portalName, req.MountPath) {
+		return ctldapi.BindVolumePortalResponse{}, fmt.Errorf("volume portal %s is reserved by sandbox0", portalName)
 	}
 	if req.PodUID == "" || req.SandboxVolumeID == "" || req.TeamID == "" {
 		return ctldapi.BindVolumePortalResponse{}, fmt.Errorf("pod_uid, sandboxvolume_id and team_id are required")
@@ -553,6 +567,9 @@ func (m *Manager) Unbind(ctx context.Context, req ctldapi.UnbindVolumePortalRequ
 	if req.PodUID == "" || portalName == "" {
 		return ctldapi.UnbindVolumePortalResponse{}, fmt.Errorf("pod_uid and portal identity are required")
 	}
+	if volumeportal.IsSystemPortal(portalName, req.MountPath) {
+		return ctldapi.UnbindVolumePortalResponse{Unbound: true}, nil
+	}
 	m.mu.Lock()
 	pm := m.portals[portalKey(req.PodUID, portalName)]
 	if pm == nil {
@@ -594,6 +611,56 @@ func (m *Manager) CheckPublished(ctx context.Context, req ctldapi.CheckVolumePor
 		Ready:   len(missing) == 0,
 		Missing: missing,
 	}, nil
+}
+
+func (m *Manager) AttachRootFSPortalSession(ctx context.Context, req RootFSPortalSessionRequest) (RootFSPortalSessionResponse, error) {
+	if err := ctx.Err(); err != nil {
+		return RootFSPortalSessionResponse{}, err
+	}
+	if strings.TrimSpace(req.PodUID) == "" {
+		return RootFSPortalSessionResponse{}, fmt.Errorf("pod uid is required")
+	}
+	if req.Session == nil {
+		return RootFSPortalSessionResponse{}, fmt.Errorf("rootfs session is required")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	pm := m.portals[portalKey(req.PodUID, volumeportal.RootFSPortalName)]
+	if pm == nil {
+		return RootFSPortalSessionResponse{}, fmt.Errorf("rootfs portal for pod %s is not published", req.PodUID)
+	}
+	if pm.fs == nil {
+		return RootFSPortalSessionResponse{}, fmt.Errorf("rootfs portal for pod %s has no filesystem", req.PodUID)
+	}
+	pm.fs.SetSession(req.Session)
+	pm.rootfsAttached = true
+	return RootFSPortalSessionResponse{
+		MountPath:  pm.mountPath,
+		TargetPath: pm.targetPath,
+	}, nil
+}
+
+func (m *Manager) DetachRootFSPortalSession(ctx context.Context, podUID string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	podUID = strings.TrimSpace(podUID)
+	if podUID == "" {
+		return nil
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	pm := m.portals[portalKey(podUID, volumeportal.RootFSPortalName)]
+	if pm == nil || !pm.rootfsAttached {
+		return nil
+	}
+	if pm.fs != nil {
+		pm.fs.SetSession(pm.rootfsSession)
+	}
+	pm.rootfsAttached = false
+	return nil
 }
 
 func (m *Manager) AttachOwner(ctx context.Context, req ctldapi.AttachVolumeOwnerRequest) (ctldapi.AttachVolumeOwnerResponse, error) {
@@ -1130,6 +1197,7 @@ func (m *Manager) clearPortalLocked(pm *portalMount) {
 	if pm.fs != nil {
 		pm.fs.SetSession(pm.rootfsSession)
 	}
+	pm.rootfsAttached = false
 	pm.volumeID = ""
 	pm.teamID = ""
 	pm.mountedAt = time.Time{}

--- a/ctld/internal/ctld/portal/manager_shared_test.go
+++ b/ctld/internal/ctld/portal/manager_shared_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 	"github.com/sandbox0-ai/sandbox0/pkg/volumefuse"
+	"github.com/sandbox0-ai/sandbox0/pkg/volumeportal"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volume"
 )
 
@@ -185,6 +186,64 @@ func TestCheckPublishedReportsMissingPortals(t *testing.T) {
 	}
 	if len(resp.Missing) != 1 || resp.Missing[0] != "cache" {
 		t.Fatalf("CheckPublished() missing = %v, want [cache]", resp.Missing)
+	}
+}
+
+func TestRootFSPortalPathsSkipsSystemPortals(t *testing.T) {
+	mgr := &Manager{portals: make(map[string]*portalMount)}
+	mgr.portals[portalKey("pod-uid", "workspace")] = &portalMount{
+		podUID:            "pod-uid",
+		name:              "workspace",
+		mountPath:         "/workspace",
+		rootfsBackingPath: "/tmp/workspace",
+	}
+	mgr.portals[portalKey("pod-uid", volumeportal.RootFSPortalName)] = &portalMount{
+		podUID:            "pod-uid",
+		name:              volumeportal.RootFSPortalName,
+		mountPath:         volumeportal.RootFSMountPath,
+		rootfsBackingPath: "/tmp/rootfs",
+	}
+
+	got := mgr.RootFSPortalPaths("pod-uid")
+
+	if len(got) != 1 || got[0].PortalName != "workspace" {
+		t.Fatalf("RootFSPortalPaths() = %+v, want only workspace", got)
+	}
+}
+
+func TestAttachRootFSPortalSessionSwitchesPublishedPortal(t *testing.T) {
+	rootfsSession := unboundSession{}
+	pm := &portalMount{
+		podUID:        "pod-uid",
+		name:          volumeportal.RootFSPortalName,
+		mountPath:     volumeportal.RootFSMountPath,
+		targetPath:    "/var/lib/kubelet/pods/pod-uid/rootfs",
+		rootfsSession: rootfsSession,
+		fs:            volumefuse.New(volumeportal.RootFSPortalName, time.Second, rootfsSession),
+	}
+	mgr := &Manager{portals: map[string]*portalMount{
+		portalKey("pod-uid", volumeportal.RootFSPortalName): pm,
+	}}
+
+	resp, err := mgr.AttachRootFSPortalSession(context.Background(), RootFSPortalSessionRequest{
+		PodUID:  "pod-uid",
+		Session: unboundSession{},
+	})
+	if err != nil {
+		t.Fatalf("AttachRootFSPortalSession() error = %v", err)
+	}
+	if resp.MountPath != volumeportal.RootFSMountPath || resp.TargetPath != pm.targetPath {
+		t.Fatalf("AttachRootFSPortalSession() response = %+v", resp)
+	}
+	if !pm.rootfsAttached {
+		t.Fatal("rootfsAttached = false, want true")
+	}
+
+	if err := mgr.DetachRootFSPortalSession(context.Background(), "pod-uid"); err != nil {
+		t.Fatalf("DetachRootFSPortalSession() error = %v", err)
+	}
+	if pm.rootfsAttached {
+		t.Fatal("rootfsAttached = true after detach")
 	}
 }
 

--- a/ctld/internal/ctld/rootfs/containerd_runtime.go
+++ b/ctld/internal/ctld/rootfs/containerd_runtime.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/rootfsstore"
 	"github.com/sandbox0-ai/sandbox0/pkg/s0fs"
 	"github.com/sandbox0-ai/sandbox0/pkg/volumefuse"
+	"github.com/sandbox0-ai/sandbox0/pkg/volumeportal"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/objectstore"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -36,7 +37,7 @@ const (
 	defaultContainerdDataRoot     = "/host-var-lib/containerd"
 	defaultContainerdHostDataRoot = "/var/lib/containerd"
 	defaultRootFSCacheDir         = "/var/lib/sandbox0/ctld/rootfs"
-	defaultRootFSUserMountPath    = "/sandbox0/rootfs"
+	defaultRootFSUserMountPath    = volumeportal.RootFSMountPath
 	defaultNamespace              = "k8s.io"
 	defaultDialTimeout            = 10 * time.Second
 )
@@ -73,6 +74,7 @@ type ContainerdRuntime struct {
 	criClient              criRuntimeService
 	criDialContext         func(ctx context.Context, endpoint string) (*grpc.ClientConn, error)
 	containerdClient       containerdClient
+	rootFSPortal           RootFSPortalAttacher
 	s0fsMu                 sync.Mutex
 	s0fsMounts             map[string]*s0fsRootFSMount
 	s0fsMountsByPodUID     map[string]*s0fsRootFSMount
@@ -94,13 +96,21 @@ type s0fsRootFSMount struct {
 	mountPath          string
 	portalMounts       map[string]string
 	runtimeMounts      map[string]string
+	rootFSPortal       RootFSPortalAttacher
+	rootFSPortalAttach bool
 }
 
 type liveRootFSPaths struct {
 	mountedPath        string
 	hostPath           string
+	taskRootPath       string
 	mountNamespacePath string
 	mountInfoPath      string
+}
+
+type RootFSPortalAttacher interface {
+	AttachRootFSPortalSession(ctx context.Context, req portal.RootFSPortalSessionRequest) (portal.RootFSPortalSessionResponse, error)
+	DetachRootFSPortalSession(ctx context.Context, podUID string) error
 }
 
 type containerdClient interface {
@@ -163,6 +173,13 @@ func NewContainerdRuntime(cfg ContainerdRuntimeConfig) *ContainerdRuntime {
 		s0fsMounts:             make(map[string]*s0fsRootFSMount),
 		s0fsMountsByPodUID:     make(map[string]*s0fsRootFSMount),
 	}
+}
+
+func (r *ContainerdRuntime) SetRootFSPortalAttacher(attacher RootFSPortalAttacher) {
+	if r == nil {
+		return
+	}
+	r.rootFSPortal = attacher
 }
 
 func (r *ContainerdRuntime) Inspect(ctx context.Context, target ctldapi.RootFSContainerRef) (ctldapi.RootFSInfo, error) {
@@ -293,6 +310,10 @@ func (r *ContainerdRuntime) AttachS0FSRootFS(ctx context.Context, req S0FSAttach
 		_ = old.close()
 	}
 
+	if strings.EqualFold(strings.TrimSpace(req.Info.Runtime), "gvisor") {
+		return r.attachS0FSRootFSViaPortal(ctx, req, engine, head, targetFilesystemID, teamID, liveRootFS, mountKey)
+	}
+
 	containerMountPath := defaultRootFSUserMountPath
 	hostMountPath := filepath.Join(liveRootFS.mountedPath, strings.TrimPrefix(containerMountPath, "/"))
 	if err := os.MkdirAll(hostMountPath, 0o755); err != nil {
@@ -335,14 +356,64 @@ func (r *ContainerdRuntime) AttachS0FSRootFS(ctx context.Context, req S0FSAttach
 		portalMounts:       make(map[string]string),
 		runtimeMounts:      runtimeMounts,
 	}
-	r.s0fsMu.Lock()
-	r.s0fsMounts[mountKey] = active
-	if strings.TrimSpace(active.podUID) != "" {
-		r.s0fsMountsByPodUID[active.podUID] = active
-	}
-	r.s0fsMu.Unlock()
+	r.storeS0FSMount(active)
 
 	return head, containerMountPath, nil
+}
+
+func (r *ContainerdRuntime) attachS0FSRootFSViaPortal(ctx context.Context, req S0FSAttachRequest, engine *s0fs.Engine, head ctldapi.RootFSHeadDescriptor, volumeID, teamID string, liveRootFS liveRootFSPaths, mountKey string) (ctldapi.RootFSHeadDescriptor, string, error) {
+	if r == nil || r.rootFSPortal == nil {
+		_ = engine.Close()
+		return ctldapi.RootFSHeadDescriptor{}, "", fmt.Errorf("%w: gvisor rootfs attach requires a published rootfs portal", ErrNotFound)
+	}
+	podUID := strings.TrimSpace(req.Info.PodUID)
+	if podUID == "" {
+		_ = engine.Close()
+		return ctldapi.RootFSHeadDescriptor{}, "", fmt.Errorf("%w: pod uid is required for gvisor rootfs attach", ErrBadRequest)
+	}
+	baseRoot := rootFSUnionBaseRoot(liveRootFS)
+	if baseRoot == "" {
+		_ = engine.Close()
+		return ctldapi.RootFSHeadDescriptor{}, "", fmt.Errorf("%w: gvisor rootfs base path is not available", ErrNotFound)
+	}
+	if err := validateRootFSUnionBaseRoot(baseRoot); err != nil {
+		_ = engine.Close()
+		return ctldapi.RootFSHeadDescriptor{}, "", err
+	}
+
+	session := portal.NewS0FSRootFSSession(volumeID, teamID, engine, baseRoot, nil)
+	attached, err := r.rootFSPortal.AttachRootFSPortalSession(ctx, portal.RootFSPortalSessionRequest{
+		PodUID:  podUID,
+		Session: session,
+	})
+	if err != nil {
+		session.Close()
+		_ = engine.Close()
+		return ctldapi.RootFSHeadDescriptor{}, "", err
+	}
+	mountPath := strings.TrimSpace(attached.MountPath)
+	if mountPath == "" {
+		mountPath = defaultRootFSUserMountPath
+	}
+
+	active := &s0fsRootFSMount{
+		key:                mountKey,
+		podUID:             podUID,
+		volumeID:           volumeID,
+		teamID:             teamID,
+		hostMountPath:      attached.TargetPath,
+		containerMountPath: mountPath,
+		engine:             engine,
+		session:            session,
+		mountRootPath:      baseRoot,
+		mountPath:          mountPath,
+		portalMounts:       make(map[string]string),
+		runtimeMounts:      make(map[string]string),
+		rootFSPortal:       r.rootFSPortal,
+		rootFSPortalAttach: true,
+	}
+	r.storeS0FSMount(active)
+	return head, mountPath, nil
 }
 
 func (r *ContainerdRuntime) BindRootFSVolumePortal(ctx context.Context, req portal.RootFSVolumePortalBindRequest) error {
@@ -351,6 +422,9 @@ func (r *ContainerdRuntime) BindRootFSVolumePortal(ctx context.Context, req port
 	}
 	active := r.s0fsMountByPodUID(req.PodUID)
 	if active == nil {
+		return nil
+	}
+	if active.rootFSPortalAttach {
 		return nil
 	}
 	mountPath := cleanRootFSPath(req.MountPath)
@@ -386,6 +460,9 @@ func (r *ContainerdRuntime) UnbindRootFSVolumePortal(ctx context.Context, req po
 	}
 	active := r.s0fsMountByPodUID(req.PodUID)
 	if active == nil {
+		return nil
+	}
+	if active.rootFSPortalAttach {
 		return nil
 	}
 	mountPath := cleanRootFSPath(req.MountPath)
@@ -429,6 +506,9 @@ func (m *s0fsRootFSMount) close() error {
 	if m.server != nil {
 		_ = unmountS0FSRootFS(m.server, m.mountNamespacePath, m.mountRootPath, m.mountPath)
 	}
+	if m.rootFSPortalAttach && m.rootFSPortal != nil {
+		_ = m.rootFSPortal.DetachRootFSPortalSession(context.Background(), m.podUID)
+	}
 	m.mu.Unlock()
 	if m.session != nil {
 		m.session.Close()
@@ -437,6 +517,18 @@ func (m *s0fsRootFSMount) close() error {
 		return m.engine.Close()
 	}
 	return nil
+}
+
+func (r *ContainerdRuntime) storeS0FSMount(active *s0fsRootFSMount) {
+	if r == nil || active == nil {
+		return
+	}
+	r.s0fsMu.Lock()
+	defer r.s0fsMu.Unlock()
+	r.s0fsMounts[active.key] = active
+	if strings.TrimSpace(active.podUID) != "" {
+		r.s0fsMountsByPodUID[active.podUID] = active
+	}
 }
 
 func (r *ContainerdRuntime) takeS0FSMount(info ctldapi.RootFSInfo) *s0fsRootFSMount {
@@ -1009,6 +1101,7 @@ func liveRootFSPathsFromTaskDir(taskDir, hostTaskDir, mountedRootFS string) (liv
 		return liveRootFSPaths{
 			mountedPath:        pidRootFS,
 			hostPath:           hostPath,
+			taskRootPath:       liveRootFSIfExists(mountedRootFS, taskRootExists),
 			mountNamespacePath: nsPath,
 			mountInfoPath:      mountInfoPath,
 		}, true, nil
@@ -1017,10 +1110,43 @@ func liveRootFSPathsFromTaskDir(taskDir, hostTaskDir, mountedRootFS string) (liv
 		return liveRootFSPaths{
 			mountedPath:        mountedRootFS,
 			hostPath:           filepath.Join(hostTaskDir, "rootfs"),
+			taskRootPath:       mountedRootFS,
 			mountNamespacePath: "",
 		}, true, nil
 	}
 	return liveRootFSPaths{}, false, nil
+}
+
+func liveRootFSIfExists(path string, exists bool) string {
+	if !exists {
+		return ""
+	}
+	return path
+}
+
+func rootFSUnionBaseRoot(paths liveRootFSPaths) string {
+	if strings.TrimSpace(paths.taskRootPath) != "" {
+		return strings.TrimSpace(paths.taskRootPath)
+	}
+	return strings.TrimSpace(paths.mountedPath)
+}
+
+func validateRootFSUnionBaseRoot(baseRoot string) error {
+	info, err := os.Stat(baseRoot)
+	if err != nil {
+		return fmt.Errorf("stat gvisor rootfs base path %s: %w", baseRoot, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%w: gvisor rootfs base path %s is not a directory", ErrBadRequest, baseRoot)
+	}
+	entries, err := os.ReadDir(baseRoot)
+	if err != nil {
+		return fmt.Errorf("read gvisor rootfs base path %s: %w", baseRoot, err)
+	}
+	if len(entries) == 0 {
+		return fmt.Errorf("%w: gvisor rootfs base path %s is empty; check containerd state root mount propagation", ErrNotFound, baseRoot)
+	}
+	return nil
 }
 
 func taskProcessRootFSPath(taskDir string) (string, string, string) {

--- a/ctld/internal/ctld/rootfs/containerd_runtime_test.go
+++ b/ctld/internal/ctld/rootfs/containerd_runtime_test.go
@@ -10,9 +10,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sandbox0-ai/sandbox0/ctld/internal/ctld/portal"
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
 	"github.com/sandbox0-ai/sandbox0/pkg/s0fs"
+	"github.com/sandbox0-ai/sandbox0/pkg/volumeportal"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/objectstore"
+	pb "github.com/sandbox0-ai/sandbox0/storage-proxy/proto/fs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -206,6 +209,143 @@ func TestCommitS0FSRootFSUsesActiveMountEngine(t *testing.T) {
 	assert.Equal(t, "child-data", string(payload))
 }
 
+func TestAttachS0FSRootFSGVisorUsesRootFSPortal(t *testing.T) {
+	ctx := context.Background()
+	store := objectstore.NewMemoryStore("rootfs-gvisor-attach-" + t.Name())
+	teamID := "team-1"
+	sourceID := "source"
+	targetID := "target"
+	sourceHead := writeTestRootFSHead(t, ctx, store, teamID, sourceID)
+
+	containerdRoot := t.TempDir()
+	containerdHostRoot := filepath.Join(string(filepath.Separator), "run", "containerd")
+	containerID := "container-1"
+	taskRoot := filepath.Join(containerdRoot, "io.containerd.runtime.v2.task", "k8s.io", containerID)
+	require.NoError(t, os.MkdirAll(filepath.Join(taskRoot, "rootfs", "bin"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(taskRoot, "rootfs", "bin", "sh"), []byte("#!/bin/sh\n"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(taskRoot, "init.pid"), []byte("123456"), 0o644))
+
+	attacher := &recordingRootFSPortalAttacher{
+		response: portal.RootFSPortalSessionResponse{
+			MountPath:  volumeportal.RootFSMountPath,
+			TargetPath: filepath.Join(t.TempDir(), "rootfs-target"),
+		},
+	}
+	runtime := NewContainerdRuntime(ContainerdRuntimeConfig{
+		ContainerdRoot:     containerdRoot,
+		ContainerdHostRoot: containerdHostRoot,
+		RootFSCacheDir:     t.TempDir(),
+	})
+	runtime.SetRootFSPortalAttacher(attacher)
+
+	head, mountPath, err := runtime.AttachS0FSRootFS(ctx, S0FSAttachRequest{
+		Info: ctldapi.RootFSInfo{
+			Runtime:       "gvisor",
+			ContainerID:   containerID,
+			ContainerName: "procd",
+			PodNamespace:  "tpl-default",
+			PodName:       "pod-1",
+			PodUID:        "pod-uid",
+		},
+		Store:        store,
+		FilesystemID: targetID,
+		Head:         sourceHead,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, targetID, head.FilesystemID)
+	assert.Equal(t, volumeportal.RootFSMountPath, mountPath)
+	assert.Equal(t, "pod-uid", attacher.attach.PodUID)
+	assert.NotNil(t, attacher.attach.Session)
+	binNode, err := attacher.attach.Session.Lookup(ctx, &pb.LookupRequest{
+		VolumeId: targetID,
+		Parent:   s0fs.RootInode,
+		Name:     "bin",
+	})
+	require.NoError(t, err)
+	_, err = attacher.attach.Session.Lookup(ctx, &pb.LookupRequest{
+		VolumeId: targetID,
+		Parent:   binNode.Inode,
+		Name:     "sh",
+	})
+	require.NoError(t, err)
+
+	active := runtime.s0fsMountByPodUID("pod-uid")
+	require.NotNil(t, active)
+	assert.True(t, active.rootFSPortalAttach)
+	assert.Equal(t, filepath.Join(taskRoot, "rootfs"), active.mountRootPath)
+	assert.Equal(t, attacher.response.TargetPath, active.hostMountPath)
+}
+
+func TestAttachS0FSRootFSGVisorRejectsEmptyBaseRoot(t *testing.T) {
+	ctx := context.Background()
+	store := objectstore.NewMemoryStore("rootfs-gvisor-empty-base-" + t.Name())
+	teamID := "team-1"
+	sourceID := "source"
+	targetID := "target"
+	sourceHead := writeTestRootFSHead(t, ctx, store, teamID, sourceID)
+
+	containerdRoot := t.TempDir()
+	containerdHostRoot := filepath.Join(string(filepath.Separator), "run", "containerd")
+	containerID := "container-1"
+	taskRoot := filepath.Join(containerdRoot, "io.containerd.runtime.v2.task", "k8s.io", containerID)
+	require.NoError(t, os.MkdirAll(filepath.Join(taskRoot, "rootfs"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(taskRoot, "init.pid"), []byte("123456"), 0o644))
+
+	attacher := &recordingRootFSPortalAttacher{
+		response: portal.RootFSPortalSessionResponse{
+			MountPath:  volumeportal.RootFSMountPath,
+			TargetPath: filepath.Join(t.TempDir(), "rootfs-target"),
+		},
+	}
+	runtime := NewContainerdRuntime(ContainerdRuntimeConfig{
+		ContainerdRoot:     containerdRoot,
+		ContainerdHostRoot: containerdHostRoot,
+		RootFSCacheDir:     t.TempDir(),
+	})
+	runtime.SetRootFSPortalAttacher(attacher)
+
+	_, _, err := runtime.AttachS0FSRootFS(ctx, S0FSAttachRequest{
+		Info: ctldapi.RootFSInfo{
+			Runtime:       "gvisor",
+			ContainerID:   containerID,
+			ContainerName: "procd",
+			PodNamespace:  "tpl-default",
+			PodName:       "pod-1",
+			PodUID:        "pod-uid",
+		},
+		Store:        store,
+		FilesystemID: targetID,
+		Head:         sourceHead,
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrNotFound))
+	assert.Contains(t, err.Error(), "is empty")
+	assert.Nil(t, attacher.attach.Session)
+	assert.Nil(t, runtime.s0fsMountByPodUID("pod-uid"))
+}
+
+func writeTestRootFSHead(t *testing.T, ctx context.Context, store objectstore.Store, teamID, sourceID string) ctldapi.RootFSHeadDescriptor {
+	t.Helper()
+
+	source, err := s0fs.Open(ctx, s0fs.Config{
+		VolumeID:             sourceID,
+		WALPath:              filepath.Join(t.TempDir(), "source.wal"),
+		ObjectStore:          rootFSS0FSObjectStore(store, teamID, sourceID),
+		ObjectStoreForVolume: rootFSS0FSObjectStoreResolver(store, teamID),
+	})
+	require.NoError(t, err)
+	node, err := source.CreateFile(s0fs.RootInode, "restored.txt", 0o644)
+	require.NoError(t, err)
+	_, err = source.Write(node.Inode, 0, []byte("restored"))
+	require.NoError(t, err)
+	sourceManifest, err := source.EnsureMaterialized(ctx)
+	require.NoError(t, err)
+	require.NoError(t, source.Close())
+	sourceHead, err := rootFSS0FSHeadFromManifest(teamID, sourceID, sourceManifest)
+	require.NoError(t, err)
+	return sourceHead
+}
+
 func TestTakeS0FSMountFallsBackToPodUID(t *testing.T) {
 	runtime := NewContainerdRuntime(ContainerdRuntimeConfig{})
 	active := &s0fsRootFSMount{
@@ -223,6 +363,22 @@ func TestTakeS0FSMountFallsBackToPodUID(t *testing.T) {
 	require.Same(t, active, got)
 	assert.Empty(t, runtime.s0fsMounts)
 	assert.Empty(t, runtime.s0fsMountsByPodUID)
+}
+
+type recordingRootFSPortalAttacher struct {
+	response portal.RootFSPortalSessionResponse
+	attach   portal.RootFSPortalSessionRequest
+	detach   string
+}
+
+func (a *recordingRootFSPortalAttacher) AttachRootFSPortalSession(_ context.Context, req portal.RootFSPortalSessionRequest) (portal.RootFSPortalSessionResponse, error) {
+	a.attach = req
+	return a.response, nil
+}
+
+func (a *recordingRootFSPortalAttacher) DetachRootFSPortalSession(_ context.Context, podUID string) error {
+	a.detach = podUID
+	return nil
 }
 
 func TestS0FSRootFSVolumePortalPaths(t *testing.T) {
@@ -475,6 +631,7 @@ func TestRootFSImportExcludedPathsIncludesProcessMounts(t *testing.T) {
 	got := rootFSImportExcludedPaths([]string{"/workspace/data", "/proc"}, mountInfo)
 
 	assert.ElementsMatch(t, []string{
+		"/.wh..wh..opq",
 		"/procd",
 		"/workspace/data",
 		"/proc",

--- a/ctld/internal/ctld/rootfs/rootfs_paths.go
+++ b/ctld/internal/ctld/rootfs/rootfs_paths.go
@@ -15,6 +15,7 @@ import (
 )
 
 var defaultRootFSSnapshotExcludedPaths = []string{
+	"/.wh..wh..opq",
 	"/procd",
 }
 

--- a/infra-operator/internal/controller/services/ctld/ctld.go
+++ b/infra-operator/internal/controller/services/ctld/ctld.go
@@ -77,13 +77,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 	containerdHostDataRoot := ctldContainerdHostDataRoot(infra)
 	args := ctldArgs(containerdHostDataRoot)
 	bidirectional := corev1.MountPropagationBidirectional
+	hostToContainer := corev1.MountPropagationHostToContainer
 	hostPathDirectoryOrCreate := corev1.HostPathDirectoryOrCreate
 	volumeMounts := []corev1.VolumeMount{
 		{Name: "config", MountPath: "/config/config.yaml", SubPath: "config.yaml", ReadOnly: true},
 		{Name: "csi-plugin", MountPath: "/csi"},
 		{Name: "kubelet", MountPath: "/var/lib/kubelet", MountPropagation: &bidirectional},
 		{Name: "ctld-data", MountPath: "/var/lib/sandbox0/ctld"},
-		{Name: "containerd-sock", MountPath: "/host-run/containerd"},
+		{Name: "containerd-sock", MountPath: "/host-run/containerd", MountPropagation: &hostToContainer},
 		{Name: "containerd-data", MountPath: containerdDataMountPath, ReadOnly: true},
 	}
 	volumes := []corev1.Volume{

--- a/infra-operator/internal/controller/services/ctld/ctld_test.go
+++ b/infra-operator/internal/controller/services/ctld/ctld_test.go
@@ -125,6 +125,7 @@ func reconcileCtldDaemonSet(t *testing.T, infra *infrav1alpha1.Sandbox0Infra) *a
 	if len(ds.Spec.Template.Spec.Containers[0].VolumeMounts) < 6 {
 		t.Fatalf("expected ctld config, csi, kubelet, data, containerd socket, and containerd data mounts, got %#v", ds.Spec.Template.Spec.Containers[0].VolumeMounts)
 	}
+	assertContainerVolumeMountPropagation(t, ds.Spec.Template.Spec.Containers[0].VolumeMounts, "containerd-sock", "/host-run/containerd", corev1.MountPropagationHostToContainer)
 	assertContainerVolumeMount(t, ds.Spec.Template.Spec.Containers[0].VolumeMounts, "containerd-data", "/host-var-lib/containerd")
 	driver := &storagev1.CSIDriver{}
 	if err := client.Get(context.Background(), types.NamespacedName{Name: "volume.sandbox0.ai"}, driver); err != nil {
@@ -238,6 +239,26 @@ func assertContainerVolumeMount(t *testing.T, mounts []corev1.VolumeMount, name,
 			}
 			return
 		}
+	}
+	t.Fatalf("expected volume mount %q, got %#v", name, mounts)
+}
+
+func assertContainerVolumeMountPropagation(t *testing.T, mounts []corev1.VolumeMount, name, mountPath string, want corev1.MountPropagationMode) {
+	t.Helper()
+	for _, mount := range mounts {
+		if mount.Name != name {
+			continue
+		}
+		if mount.MountPath != mountPath {
+			t.Fatalf("volume mount %q path = %q, want %q", name, mount.MountPath, mountPath)
+		}
+		if mount.MountPropagation == nil {
+			t.Fatalf("volume mount %q propagation is nil, want %s", name, want)
+		}
+		if *mount.MountPropagation != want {
+			t.Fatalf("volume mount %q propagation = %s, want %s", name, *mount.MountPropagation, want)
+		}
+		return
 	}
 	t.Fatalf("expected volume mount %q, got %#v", name, mounts)
 }

--- a/manager/pkg/apis/sandbox0/v1alpha1/helpers.go
+++ b/manager/pkg/apis/sandbox0/v1alpha1/helpers.go
@@ -177,7 +177,11 @@ func applyVolumePortals(spec *corev1.PodSpec, volumeMounts []VolumeMountSpec) {
 	if spec == nil {
 		return
 	}
-	mounts := make([]VolumeMountSpec, 0, len(volumeMounts)+1)
+	mounts := make([]VolumeMountSpec, 0, len(volumeMounts)+2)
+	mounts = append(mounts, VolumeMountSpec{
+		Name:      volumeportal.RootFSPortalName,
+		MountPath: volumeportal.RootFSMountPath,
+	})
 	mounts = append(mounts, VolumeMountSpec{
 		Name:      volumeportal.WebhookStatePortalName,
 		MountPath: volumeportal.WebhookStateMountPath,

--- a/manager/pkg/apis/sandbox0/v1alpha1/helpers_test.go
+++ b/manager/pkg/apis/sandbox0/v1alpha1/helpers_test.go
@@ -229,6 +229,14 @@ manager_image: sandbox0/manager:test
 	if mount := findVolumeMount(spec.Containers[0].VolumeMounts, webhookVolume.Name); mount == nil || mount.MountPath != volumeportal.WebhookStateMountPath {
 		t.Fatalf("expected webhook state mount, got %#v", spec.Containers[0].VolumeMounts)
 	}
+
+	rootFSVolume := findCSIVolumeByPortal(spec.Volumes, volumeportal.RootFSPortalName)
+	if rootFSVolume == nil {
+		t.Fatalf("expected rootfs portal volume, got %#v", spec.Volumes)
+	}
+	if mount := findVolumeMount(spec.Containers[0].VolumeMounts, rootFSVolume.Name); mount == nil || mount.MountPath != volumeportal.RootFSMountPath {
+		t.Fatalf("expected rootfs mount, got %#v", spec.Containers[0].VolumeMounts)
+	}
 }
 
 func TestBuildIdlePodSpecPreMountsUserVolumePortals(t *testing.T) {
@@ -257,6 +265,14 @@ manager_image: sandbox0/manager:test
 	}
 	if mount := findVolumeMount(spec.Containers[0].VolumeMounts, webhookVolume.Name); mount == nil || mount.MountPath != volumeportal.WebhookStateMountPath {
 		t.Fatalf("expected webhook state mount, got %#v", spec.Containers[0].VolumeMounts)
+	}
+
+	rootFSVolume := findCSIVolumeByPortal(spec.Volumes, volumeportal.RootFSPortalName)
+	if rootFSVolume == nil {
+		t.Fatalf("expected rootfs portal volume, got %#v", spec.Volumes)
+	}
+	if mount := findVolumeMount(spec.Containers[0].VolumeMounts, rootFSVolume.Name); mount == nil || mount.MountPath != volumeportal.RootFSMountPath {
+		t.Fatalf("expected rootfs mount, got %#v", spec.Containers[0].VolumeMounts)
 	}
 }
 

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -271,6 +271,9 @@ func normalizeClaimMounts(mounts []ClaimMount) ([]ClaimMount, error) {
 		if cleanMountPoint == webhookStateMountPoint || strings.HasPrefix(cleanMountPoint, webhookStateMountPoint+string(filepath.Separator)) {
 			return nil, fmt.Errorf("%w: mounts[%d].mount_point uses a sandbox0 reserved path", ErrInvalidClaimRequest, i)
 		}
+		if mountPathConflicts(cleanMountPoint, volumeportal.RootFSMountPath) {
+			return nil, fmt.Errorf("%w: mounts[%d].mount_point uses a sandbox0 reserved path", ErrInvalidClaimRequest, i)
+		}
 		if _, exists := seenVolumes[mount.SandboxVolumeID]; exists {
 			return nil, fmt.Errorf("%w: duplicate sandboxvolume_id %q in claim mounts", ErrInvalidClaimRequest, mount.SandboxVolumeID)
 		}
@@ -757,9 +760,24 @@ func declaredVolumeMountsByPath(template *v1alpha1.SandboxTemplate) map[string]v
 		if mountPath == webhookStateMountPoint || strings.HasPrefix(mountPath, webhookStateMountPoint+string(filepath.Separator)) {
 			continue
 		}
+		if mountPathConflicts(mountPath, volumeportal.RootFSMountPath) {
+			continue
+		}
 		out[mountPath] = item
 	}
 	return out
+}
+
+func mountPathConflicts(path, reserved string) bool {
+	path = filepath.Clean(strings.TrimSpace(path))
+	reserved = filepath.Clean(strings.TrimSpace(reserved))
+	if path == "." || reserved == "." {
+		return false
+	}
+	sep := string(filepath.Separator)
+	return path == reserved ||
+		strings.HasPrefix(path, reserved+sep) ||
+		strings.HasPrefix(reserved, path+sep)
 }
 
 func declaredVolumeMountDirs(template *v1alpha1.SandboxTemplate) []string {

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -1096,6 +1096,20 @@ func TestValidateClaimMountsRejectsWebhookStatePath(t *testing.T) {
 	}
 }
 
+func TestValidateClaimMountsRejectsRootFSPath(t *testing.T) {
+	req := &ClaimRequest{
+		Mounts: []ClaimMount{{SandboxVolumeID: "vol-1", MountPoint: volumeportal.RootFSMountPath}},
+	}
+
+	err := validateClaimMounts(req)
+	if err == nil {
+		t.Fatal("expected reserved mount point validation error")
+	}
+	if !errors.Is(err, ErrInvalidClaimRequest) {
+		t.Fatalf("expected ErrInvalidClaimRequest, got %v", err)
+	}
+}
+
 func TestValidateClaimMountsForTemplateRequiresDeclaredMountPoint(t *testing.T) {
 	req := &ClaimRequest{
 		Mounts: []ClaimMount{{SandboxVolumeID: "vol-1", MountPoint: "/workspace/data"}},

--- a/manager/pkg/service/sandbox_service_rootfs.go
+++ b/manager/pkg/service/sandbox_service_rootfs.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
+	"github.com/sandbox0-ai/sandbox0/pkg/volumeportal"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -246,6 +247,7 @@ func rootFSExcludedPathsForPod(pod *corev1.Pod) []string {
 	for _, mount := range mounts {
 		add(strings.TrimSpace(mount.MountPoint))
 	}
+	add(volumeportal.RootFSMountPath)
 	if pod.Annotations != nil && strings.TrimSpace(pod.Annotations[controller.AnnotationWebhookStateVolumeID]) != "" {
 		add(webhookStateMountPoint)
 	}

--- a/manager/pkg/service/sandbox_service_rootfs_test.go
+++ b/manager/pkg/service/sandbox_service_rootfs_test.go
@@ -46,7 +46,7 @@ func TestPauseSandboxRuntimeQueuesRootFSSaveBeforeDeletingPod(t *testing.T) {
 			PodUID:        "pod-uid",
 			ContainerName: "procd",
 		}, req.Target)
-		assert.ElementsMatch(t, []string{"/workspace/data", volumeportal.WebhookStateMountPath}, req.ExcludedPaths)
+		assert.ElementsMatch(t, []string{"/workspace/data", volumeportal.RootFSMountPath, volumeportal.WebhookStateMountPath}, req.ExcludedPaths)
 		saveCalled = true
 		_ = json.NewEncoder(w).Encode(ctldapi.SaveRootFSResponse{
 			Info: ctldapi.RootFSInfo{
@@ -247,7 +247,7 @@ func TestFinishRestoredSandboxRuntimeAppliesRootFSBeforeProcdInitialization(t *t
 		assert.Equal(t, ctldapi.RootFSStorageEngineS0FS, req.Head.Engine)
 		assert.Equal(t, "fs-1", req.Head.VolumeID)
 		assert.Equal(t, "manifests/00000000000000000007.json", req.Head.ManifestKey)
-		assert.ElementsMatch(t, []string{"/workspace/data"}, req.ExcludedPaths)
+		assert.ElementsMatch(t, []string{"/workspace/data", volumeportal.RootFSMountPath}, req.ExcludedPaths)
 		calls = append(calls, "apply")
 		_ = json.NewEncoder(w).Encode(ctldapi.ApplyRootFSResponse{Applied: true})
 	}))
@@ -597,7 +597,7 @@ func TestRootFSExcludedPathsForPodUsesBoundClaimMountPaths(t *testing.T) {
 
 	got := rootFSExcludedPathsForPod(pod)
 
-	assert.ElementsMatch(t, []string{"/workspace/data", "/workspace/database", volumeportal.WebhookStateMountPath}, got)
+	assert.ElementsMatch(t, []string{"/workspace/data", "/workspace/database", volumeportal.RootFSMountPath, volumeportal.WebhookStateMountPath}, got)
 }
 
 func TestRootFSExcludedPathsForPodIgnoresUnboundVolumePortals(t *testing.T) {
@@ -606,7 +606,7 @@ func TestRootFSExcludedPathsForPodIgnoresUnboundVolumePortals(t *testing.T) {
 
 	got := rootFSExcludedPathsForPod(pod)
 
-	assert.Empty(t, got)
+	assert.Equal(t, []string{volumeportal.RootFSMountPath}, got)
 }
 
 func rootFSTestPod(name, sandboxID, teamID string) *corev1.Pod {

--- a/manager/procd/pkg/process/sysproc.go
+++ b/manager/procd/pkg/process/sysproc.go
@@ -19,6 +19,9 @@ func ApplySysProcAttr(cmd *exec.Cmd, config ProcessConfig, setpgid bool) {
 	attr.Setpgid = attr.Setpgid || setpgid
 	if rootFS := strings.TrimSpace(config.RootFS); rootFS != "" {
 		attr.Chroot = rootFS
+		if strings.TrimSpace(cmd.Dir) == "" {
+			cmd.Dir = "/"
+		}
 	}
 	cmd.SysProcAttr = attr
 }

--- a/manager/procd/pkg/process/sysproc_test.go
+++ b/manager/procd/pkg/process/sysproc_test.go
@@ -21,4 +21,18 @@ func TestApplySysProcAttrSetsProcessGroupAndRootFS(t *testing.T) {
 	if cmd.SysProcAttr.Chroot != "/sandbox0/rootfs" {
 		t.Fatalf("Chroot = %q, want /sandbox0/rootfs", cmd.SysProcAttr.Chroot)
 	}
+	if cmd.Dir != "/" {
+		t.Fatalf("Dir = %q, want /", cmd.Dir)
+	}
+}
+
+func TestApplySysProcAttrPreservesExplicitWorkingDirectory(t *testing.T) {
+	cmd := exec.Command("/bin/true")
+	cmd.Dir = "/workspace"
+
+	ApplySysProcAttr(cmd, ProcessConfig{RootFS: " /sandbox0/rootfs "}, false)
+
+	if cmd.Dir != "/workspace" {
+		t.Fatalf("Dir = %q, want /workspace", cmd.Dir)
+	}
 }

--- a/pkg/framework/config.go
+++ b/pkg/framework/config.go
@@ -27,6 +27,9 @@ type Config struct {
 	OperatorImagePullPolicy string
 
 	InfraNamespace string
+
+	SandboxRuntimeClassName string
+	SandboxRuntimeHandler   string
 }
 
 // LoadConfig reads E2E configuration from environment variables.
@@ -58,6 +61,12 @@ func LoadConfig() (Config, error) {
 		OperatorImagePullPolicy: envString("E2E_OPERATOR_IMAGE_PULL_POLICY", "IfNotPresent"),
 
 		InfraNamespace: envString("E2E_INFRA_NAMESPACE", "sandbox0-system"),
+
+		SandboxRuntimeClassName: envString("E2E_SANDBOX_RUNTIME_CLASS_NAME", ""),
+		SandboxRuntimeHandler:   envString("E2E_SANDBOX_RUNTIME_HANDLER", ""),
+	}
+	if cfg.SandboxRuntimeHandler == "" {
+		cfg.SandboxRuntimeHandler = cfg.SandboxRuntimeClassName
 	}
 
 	if cfg.UseExistingCluster {

--- a/pkg/framework/infra.go
+++ b/pkg/framework/infra.go
@@ -41,6 +41,20 @@ func EnsureNamespace(ctx context.Context, kubeconfig, namespace string) error {
 	return ApplyManifestContent(ctx, kubeconfig, "sandbox0-e2e-namespace-", manifest)
 }
 
+func EnsureRuntimeClass(ctx context.Context, kubeconfig, name, handler string) error {
+	name = strings.TrimSpace(name)
+	handler = strings.TrimSpace(handler)
+	if name == "" {
+		return nil
+	}
+	if handler == "" {
+		handler = name
+	}
+	fmt.Printf("Ensuring RuntimeClass %q with handler %q exists...\n", name, handler)
+	manifest := fmt.Sprintf("apiVersion: node.k8s.io/v1\nkind: RuntimeClass\nmetadata:\n  name: %s\nhandler: %s\n", name, handler)
+	return ApplyManifestContent(ctx, kubeconfig, "sandbox0-e2e-runtimeclass-", manifest)
+}
+
 func ApplySecret(ctx context.Context, kubeconfig string, spec SecretSpec) error {
 	if spec.Name == "" || spec.Namespace == "" {
 		return fmt.Errorf("secret name and namespace are required")

--- a/pkg/framework/manifest.go
+++ b/pkg/framework/manifest.go
@@ -56,6 +56,44 @@ func RewriteManifestNamespace(manifestPath, targetNamespace string) (string, fun
 	return path, func() { _ = os.Remove(path) }, nil
 }
 
+// RewriteManifestSandboxRuntimeClass creates a temporary manifest that sets the
+// manager sandbox runtime class for every Sandbox0Infra document.
+func RewriteManifestSandboxRuntimeClass(manifestPath, runtimeClassName string) (string, func(), error) {
+	runtimeClassName = strings.TrimSpace(runtimeClassName)
+	if manifestPath == "" {
+		return "", nil, fmt.Errorf("manifest path is required")
+	}
+	if runtimeClassName == "" {
+		return manifestPath, nil, nil
+	}
+
+	content, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return "", nil, fmt.Errorf("read manifest %q: %w", manifestPath, err)
+	}
+	rewritten, err := rewriteManifestSandboxRuntimeClass(content, runtimeClassName)
+	if err != nil {
+		return "", nil, fmt.Errorf("rewrite sandbox runtime class: %w", err)
+	}
+
+	file, err := os.CreateTemp("", "sandbox0-e2e-runtime-*.yaml")
+	if err != nil {
+		return "", nil, fmt.Errorf("create temporary manifest: %w", err)
+	}
+	path := file.Name()
+	if _, err := file.Write(rewritten); err != nil {
+		_ = file.Close()
+		_ = os.Remove(path)
+		return "", nil, fmt.Errorf("write temporary manifest %q: %w", path, err)
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(path)
+		return "", nil, fmt.Errorf("close temporary manifest %q: %w", path, err)
+	}
+
+	return path, func() { _ = os.Remove(path) }, nil
+}
+
 func manifestInfraNamespace(content []byte) (string, error) {
 	infra, err := extractSandbox0Infra(content)
 	if err != nil {
@@ -94,6 +132,48 @@ func rewriteManifestNamespace(content []byte, sourceNamespace, targetNamespace s
 	return output.Bytes(), nil
 }
 
+func rewriteManifestSandboxRuntimeClass(content []byte, runtimeClassName string) ([]byte, error) {
+	decoder := yamlv3.NewDecoder(bytes.NewReader(content))
+	var output bytes.Buffer
+	encoder := yamlv3.NewEncoder(&output)
+	encoder.SetIndent(2)
+	defer encoder.Close()
+
+	for {
+		var doc yamlv3.Node
+		if err := decoder.Decode(&doc); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, err
+		}
+		if isEmptyYAMLDocument(&doc) {
+			continue
+		}
+		setSandboxRuntimeClassNode(&doc, runtimeClassName)
+		if err := encoder.Encode(&doc); err != nil {
+			return nil, err
+		}
+	}
+	return output.Bytes(), nil
+}
+
+func setSandboxRuntimeClassNode(doc *yamlv3.Node, runtimeClassName string) {
+	root := documentRoot(doc)
+	if root == nil || root.Kind != yamlv3.MappingNode {
+		return
+	}
+	kind := mappingValue(root, "kind")
+	if kind == nil || kind.Kind != yamlv3.ScalarNode || kind.Value != "Sandbox0Infra" {
+		return
+	}
+	spec := ensureMappingValue(root, "spec")
+	services := ensureMappingValue(spec, "services")
+	manager := ensureMappingValue(services, "manager")
+	config := ensureMappingValue(manager, "config")
+	setScalarValue(config, "sandboxRuntimeClassName", runtimeClassName)
+}
+
 func rewriteNamespaceNode(node *yamlv3.Node, sourceNamespace, targetNamespace string) {
 	if node == nil {
 		return
@@ -117,6 +197,16 @@ func rewriteNamespaceNode(node *yamlv3.Node, sourceNamespace, targetNamespace st
 	}
 }
 
+func documentRoot(node *yamlv3.Node) *yamlv3.Node {
+	if node == nil {
+		return nil
+	}
+	if node.Kind == yamlv3.DocumentNode && len(node.Content) > 0 {
+		return node.Content[0]
+	}
+	return node
+}
+
 func rewriteNamespaceResourceName(node *yamlv3.Node, sourceNamespace, targetNamespace string) {
 	metadata := mappingValue(node, "metadata")
 	if metadata == nil || metadata.Kind != yamlv3.MappingNode {
@@ -138,6 +228,55 @@ func mappingValue(node *yamlv3.Node, key string) *yamlv3.Node {
 		}
 	}
 	return nil
+}
+
+func ensureMappingValue(node *yamlv3.Node, key string) *yamlv3.Node {
+	if node == nil {
+		return nil
+	}
+	if node.Kind != yamlv3.MappingNode {
+		node.Kind = yamlv3.MappingNode
+		node.Tag = "!!map"
+		node.Value = ""
+		node.Content = nil
+	}
+	if existing := mappingValue(node, key); existing != nil {
+		if existing.Kind != yamlv3.MappingNode {
+			existing.Kind = yamlv3.MappingNode
+			existing.Tag = "!!map"
+			existing.Value = ""
+			existing.Content = nil
+		}
+		return existing
+	}
+	child := &yamlv3.Node{Kind: yamlv3.MappingNode, Tag: "!!map"}
+	node.Content = append(node.Content,
+		&yamlv3.Node{Kind: yamlv3.ScalarNode, Tag: "!!str", Value: key},
+		child,
+	)
+	return child
+}
+
+func setScalarValue(node *yamlv3.Node, key, value string) {
+	if node == nil {
+		return
+	}
+	if node.Kind != yamlv3.MappingNode {
+		node.Kind = yamlv3.MappingNode
+		node.Tag = "!!map"
+		node.Value = ""
+		node.Content = nil
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == key {
+			node.Content[i+1] = &yamlv3.Node{Kind: yamlv3.ScalarNode, Tag: "!!str", Value: value}
+			return
+		}
+	}
+	node.Content = append(node.Content,
+		&yamlv3.Node{Kind: yamlv3.ScalarNode, Tag: "!!str", Value: key},
+		&yamlv3.Node{Kind: yamlv3.ScalarNode, Tag: "!!str", Value: value},
+	)
 }
 
 func isEmptyYAMLDocument(node *yamlv3.Node) bool {

--- a/pkg/framework/scenario_test.go
+++ b/pkg/framework/scenario_test.go
@@ -86,3 +86,38 @@ spec:
 		t.Fatalf("rewritten manifest still contains source namespace:\n%s", got)
 	}
 }
+
+func TestRewriteManifestSandboxRuntimeClass(t *testing.T) {
+	manifest := `apiVersion: infra.sandbox0.ai/v1alpha1
+kind: Sandbox0Infra
+metadata:
+  name: fullmode
+  namespace: sandbox0-system
+spec:
+  services:
+    manager:
+      enabled: true
+`
+	manifestPath := filepath.Join(t.TempDir(), "fullmode.yaml")
+	if err := os.WriteFile(manifestPath, []byte(manifest), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	rewrittenPath, cleanup, err := RewriteManifestSandboxRuntimeClass(manifestPath, "gvisor")
+	if err != nil {
+		t.Fatalf("RewriteManifestSandboxRuntimeClass returned error: %v", err)
+	}
+	defer cleanup()
+	if rewrittenPath == manifestPath {
+		t.Fatal("RewriteManifestSandboxRuntimeClass returned original path, want rewritten manifest")
+	}
+
+	content, err := os.ReadFile(rewrittenPath)
+	if err != nil {
+		t.Fatalf("read rewritten manifest: %v", err)
+	}
+	got := string(content)
+	if !strings.Contains(got, "sandboxRuntimeClassName: gvisor") {
+		t.Fatalf("rewritten manifest missing sandbox runtime class:\n%s", got)
+	}
+}

--- a/pkg/framework/setup.go
+++ b/pkg/framework/setup.go
@@ -128,6 +128,10 @@ func SetupScenario(cfg Config, scenario Scenario) (*ScenarioEnv, func(), error) 
 		cleanup()
 		return nil, nil, err
 	}
+	if err := EnsureRuntimeClass(testCtx.Context, workingCfg.Kubeconfig, workingCfg.SandboxRuntimeClassName, workingCfg.SandboxRuntimeHandler); err != nil {
+		cleanup()
+		return nil, nil, err
+	}
 
 	for _, spec := range scenario.Secrets {
 		if err := ApplySecret(testCtx.Context, workingCfg.Kubeconfig, spec); err != nil {
@@ -146,6 +150,17 @@ func SetupScenario(cfg Config, scenario Scenario) (*ScenarioEnv, func(), error) 
 		if namespacedManifest != scenario.ManifestPath {
 			manifestPath = namespacedManifest
 			appendCleanup(removeNamespacedManifest)
+		}
+	}
+	if workingCfg.SandboxRuntimeClassName != "" {
+		runtimeManifest, removeRuntimeManifest, err := RewriteManifestSandboxRuntimeClass(manifestPath, workingCfg.SandboxRuntimeClassName)
+		if err != nil {
+			cleanup()
+			return nil, nil, err
+		}
+		if runtimeManifest != manifestPath {
+			manifestPath = runtimeManifest
+			appendCleanup(removeRuntimeManifest)
 		}
 	}
 

--- a/pkg/template/http/handlers_test.go
+++ b/pkg/template/http/handlers_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 	"github.com/sandbox0-ai/sandbox0/pkg/template"
+	"github.com/sandbox0-ai/sandbox0/pkg/volumeportal"
 )
 
 type testTemplateStore struct {
@@ -960,6 +961,22 @@ func TestValidateTemplateSpec_StrictValidation(t *testing.T) {
 				}
 			},
 			wantErr: "spec.pod.emptyDirMounts[0].mountPath uses reserved path \"/config\"",
+		},
+		{
+			name: "reject rootfs emptyDir mount path",
+			mutate: func(s *v1alpha1.SandboxTemplateSpec) {
+				s.Pod = &v1alpha1.PodSpecOverride{
+					EmptyDirMounts: []v1alpha1.EmptyDirMountSpec{{MountPath: volumeportal.RootFSMountPath}},
+				}
+			},
+			wantErr: "spec.pod.emptyDirMounts[0].mountPath uses reserved path \"/sandbox0/rootfs\"",
+		},
+		{
+			name: "reject rootfs parent volume mount path",
+			mutate: func(s *v1alpha1.SandboxTemplateSpec) {
+				s.VolumeMounts = []v1alpha1.VolumeMountSpec{{Name: "system-shadow", MountPath: "/sandbox0"}}
+			},
+			wantErr: "spec.volumeMounts[0].mountPath uses a sandbox0 reserved path",
 		},
 		{
 			name: "reject emptyDir mount colliding with volume mount",

--- a/pkg/template/http/template_validation.go
+++ b/pkg/template/http/template_validation.go
@@ -210,6 +210,9 @@ func validateVolumeMounts(mounts []v1alpha1.VolumeMountSpec) error {
 		if cleanMountPath == volumeportal.WebhookStateMountPath || strings.HasPrefix(cleanMountPath, volumeportal.WebhookStateMountPath+string(filepath.Separator)) {
 			return fmt.Errorf("%s.mountPath uses a sandbox0 reserved path", field)
 		}
+		if mountPathConflicts(cleanMountPath, volumeportal.RootFSMountPath) {
+			return fmt.Errorf("%s.mountPath uses a sandbox0 reserved path", field)
+		}
 		if _, ok := seenPaths[cleanMountPath]; ok {
 			return fmt.Errorf("%s.mountPath %q is duplicated", field, cleanMountPath)
 		}
@@ -274,7 +277,22 @@ func validateReservedMountPath(path, field string) error {
 			return fmt.Errorf("%s uses reserved path %q", field, prefix)
 		}
 	}
+	if mountPathConflicts(path, volumeportal.RootFSMountPath) {
+		return fmt.Errorf("%s uses reserved path %q", field, volumeportal.RootFSMountPath)
+	}
 	return nil
+}
+
+func mountPathConflicts(path, reserved string) bool {
+	path = filepath.Clean(strings.TrimSpace(path))
+	reserved = filepath.Clean(strings.TrimSpace(reserved))
+	if path == "." || reserved == "." {
+		return false
+	}
+	sep := string(filepath.Separator)
+	return path == reserved ||
+		strings.HasPrefix(path, reserved+sep) ||
+		strings.HasPrefix(reserved, path+sep)
 }
 
 func validateTemplateResourceRatio(spec v1alpha1.SandboxTemplateSpec, subject string) error {

--- a/pkg/volumeportal/constants.go
+++ b/pkg/volumeportal/constants.go
@@ -11,6 +11,9 @@ const (
 	WebhookStatePortalName = "sandbox0-webhook-state"
 	WebhookStateMountPath  = "/var/lib/sandbox0/procd"
 
+	RootFSPortalName = "sandbox0-rootfs"
+	RootFSMountPath  = "/sandbox0/rootfs"
+
 	PodInfoName      = "csi.storage.k8s.io/pod.name"
 	PodInfoNamespace = "csi.storage.k8s.io/pod.namespace"
 	PodInfoUID       = "csi.storage.k8s.io/pod.uid"
@@ -28,4 +31,14 @@ func NormalizePortalName(name, mountPath string) string {
 		return ""
 	}
 	return strings.NewReplacer("/", "-", "_", "-", ".", "-").Replace(mountPath)
+}
+
+// IsSystemPortal reports whether a published portal is owned by sandbox0.
+func IsSystemPortal(name, mountPath string) bool {
+	name = strings.TrimSpace(name)
+	mountPath = strings.TrimRight(strings.TrimSpace(mountPath), "/")
+	return name == WebhookStatePortalName ||
+		name == RootFSPortalName ||
+		mountPath == WebhookStateMountPath ||
+		mountPath == RootFSMountPath
 }

--- a/tests/e2e/install-gvisor-kind.sh
+++ b/tests/e2e/install-gvisor-kind.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cluster="${1:-sandbox0-e2e}"
+runtime_class="${2:-gvisor}"
+runtime_handler="${3:-$runtime_class}"
+kubectl_context="${KUBECTL_CONTEXT:-kind-${cluster}}"
+
+if ! command -v kind >/dev/null 2>&1; then
+  echo "kind is required" >&2
+  exit 1
+fi
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker is required" >&2
+  exit 1
+fi
+
+nodes="$(kind get nodes --name "$cluster")"
+if [ -z "$nodes" ]; then
+  echo "kind cluster $cluster has no nodes" >&2
+  exit 1
+fi
+
+for node in $nodes; do
+  echo "Installing gVisor runtime in kind node $node"
+  docker exec -i "$node" bash -se -- "$runtime_handler" <<'NODE_SCRIPT'
+set -euo pipefail
+handler="$1"
+
+if ! command -v curl >/dev/null 2>&1 && ! command -v wget >/dev/null 2>&1; then
+  apt-get update
+  apt-get install -y ca-certificates curl wget
+fi
+
+if command -v runsc >/dev/null 2>&1 && command -v containerd-shim-runsc-v1 >/dev/null 2>&1; then
+  echo "gVisor binaries already installed"
+else
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' EXIT
+  cd "$tmp"
+  arch="$(uname -m)"
+  url="https://storage.googleapis.com/gvisor/releases/release/latest/${arch}"
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSLO "${url}/runsc"
+    curl -fsSLO "${url}/runsc.sha512"
+    curl -fsSLO "${url}/containerd-shim-runsc-v1"
+    curl -fsSLO "${url}/containerd-shim-runsc-v1.sha512"
+  else
+    wget "${url}/runsc" "${url}/runsc.sha512" "${url}/containerd-shim-runsc-v1" "${url}/containerd-shim-runsc-v1.sha512"
+  fi
+  sha512sum -c runsc.sha512
+  sha512sum -c containerd-shim-runsc-v1.sha512
+  chmod 0755 runsc containerd-shim-runsc-v1
+  install -m 0755 runsc containerd-shim-runsc-v1 /usr/local/bin/
+fi
+
+mkdir -p /etc/containerd/conf.d
+cat >/etc/containerd/runsc.toml <<'RUNSC_CONFIG'
+[runsc_config]
+  overlay2 = "none"
+  file-access = "shared"
+  directfs = "true"
+RUNSC_CONFIG
+
+config=/etc/containerd/config.toml
+if ! grep -q 'conf.d/\*.toml' "$config"; then
+  if grep -q '^imports[[:space:]]*=' "$config"; then
+    tmp_config="$(mktemp)"
+    awk '
+      /^imports[[:space:]]*=/ {
+        if ($0 ~ /\[[[:space:]]*\]/) {
+          sub(/\[[[:space:]]*\]/, "[\"/etc/containerd/conf.d/*.toml\"]")
+        } else {
+          sub(/\][[:space:]]*$/, ", \"/etc/containerd/conf.d/*.toml\"]")
+        }
+      }
+      { print }
+    ' "$config" >"$tmp_config"
+    cat "$tmp_config" >"$config"
+    rm -f "$tmp_config"
+  else
+    tmp_config="$(mktemp)"
+    awk '
+      !inserted && /^version[[:space:]]*=/ {
+        print
+        print "imports = [\"/etc/containerd/conf.d/*.toml\"]"
+        inserted = 1
+        next
+      }
+      { print }
+      END {
+        if (!inserted) {
+          print "imports = [\"/etc/containerd/conf.d/*.toml\"]"
+        }
+      }
+    ' "$config" >"$tmp_config"
+    cat "$tmp_config" >"$config"
+    rm -f "$tmp_config"
+  fi
+fi
+
+version="$(awk -F= '/^version[[:space:]]*=/{gsub(/[[:space:]]/, "", $2); print $2; exit}' "$config")"
+if [ "$version" = "3" ]; then
+  runtime_plugin='io.containerd.cri.v1.runtime'
+else
+  runtime_plugin='io.containerd.grpc.v1.cri'
+fi
+
+cat >/etc/containerd/conf.d/sandbox0-gvisor.toml <<EOF
+[plugins."${runtime_plugin}".containerd.runtimes."${handler}"]
+  runtime_type = "io.containerd.runsc.v1"
+[plugins."${runtime_plugin}".containerd.runtimes."${handler}".options]
+  TypeUrl = "io.containerd.runsc.v1.options"
+  ConfigPath = "/etc/containerd/runsc.toml"
+EOF
+
+systemctl restart containerd
+runsc --version
+NODE_SCRIPT
+done
+
+if command -v kubectl >/dev/null 2>&1; then
+  cat <<EOF | kubectl --context "$kubectl_context" apply -f -
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: ${runtime_class}
+handler: ${runtime_handler}
+EOF
+fi


### PR DESCRIPTION
## Summary
- add a built-in rootfs CSI portal and use it for gVisor rootfs restore instead of writing through /proc/<pid>/root
- keep the existing runc mount-namespace rootfs restore path unchanged
- make PR/full E2E install and target a gVisor RuntimeClass, with runtime-class manifest rewriting in the E2E framework
- reserve /sandbox0/rootfs from user-declared mounts and exclude it from rootfs snapshots

## Tests
- bash -n tests/e2e/install-gvisor-kind.sh
- git diff --check
- go test ./ctld/internal/ctld/rootfs ./ctld/internal/ctld/portal
- go test ./manager/pkg/apis/sandbox0/v1alpha1 ./manager/pkg/service
- go test ./pkg/template/http ./pkg/framework ./pkg/volumeportal
- go list -buildvcs=false ./... | grep -Ev '/tests/(e2e|integration)(/|$)' | xargs go test\n\n## Remote validation\n- Will validate gVisor rootfs behavior on the persistent remote kind environment while PR CI is running.