### PR TITLE
Optimize persistent rootfs pause completion

### DIFF
--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -208,9 +208,17 @@ func main() {
 	sandboxIndex := service.NewSandboxIndex()
 	podInformer.Informer().AddEventHandler(sandboxIndex.ResourceEventHandler())
 	meteringRepo := metering.NewRepository(pool)
+	sandboxStore := service.NewPGSandboxStore(pool)
 	lifecycleProjector := managermetering.NewLifecycleProjector(managermetering.NewStore(meteringRepo), cfg.RegionID, cfg.DefaultClusterId)
 	lifecycleProjector.SetLogger(logger)
 	lifecycleProjector.SetMetrics(managerMetrics)
+	lifecycleProjector.SetRuntimePauseLookup(func(ctx context.Context, info managermetering.RuntimeDeletionInfo) (bool, error) {
+		record, err := sandboxStore.GetSandbox(ctx, info.SandboxID)
+		if err != nil || record == nil {
+			return false, err
+		}
+		return service.SandboxRecordDeletionIsRuntimeOnly(record, info.Namespace, info.PodName, info.RuntimeGeneration), nil
+	})
 	podInformer.Informer().AddEventHandler(lifecycleProjector.ResourceEventHandler())
 
 	// Create network policy service for building policy annotations
@@ -315,7 +323,6 @@ func main() {
 	)
 	sandboxService.SetCredentialStore(credentialStore)
 	sandboxService.SetQuotaStore(quota.NewRepository(pool))
-	sandboxStore := service.NewPGSandboxStore(pool)
 	sandboxService.SetSandboxStore(sandboxStore)
 	if cfg.StorageProxyBaseURL != "" && cfg.StorageProxyHTTPPort > 0 && storageProxyAdminTokenGenerator != nil {
 		storageProxyBaseURL := fmt.Sprintf("http://%s:%d", strings.TrimSpace(cfg.StorageProxyBaseURL), cfg.StorageProxyHTTPPort)

--- a/manager/pkg/controller/pool_manager.go
+++ b/manager/pkg/controller/pool_manager.go
@@ -58,7 +58,6 @@ const (
 	AnnotationNetworkPolicyAppliedHash     = "sandbox0.ai/network-policy-applied-hash"
 	AnnotationSandboxID                    = "sandbox0.ai/sandbox-id"
 	AnnotationRuntimeGeneration            = "sandbox0.ai/runtime-generation"
-	AnnotationRuntimeDeletionReason        = "sandbox0.ai/runtime-deletion-reason"
 	AnnotationWebhookStateVolumeID         = "sandbox0.ai/webhook-state-volume-id"
 	AnnotationTemplateSpecHash             = "sandbox0.ai/template-spec-hash"
 	AnnotationClusterAutoscalerSafeToEvict = "cluster-autoscaler.kubernetes.io/safe-to-evict"

--- a/manager/pkg/metering/lifecycle_projector.go
+++ b/manager/pkg/metering/lifecycle_projector.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -28,6 +30,18 @@ type Store interface {
 	GetSandboxProjectionState(ctx context.Context, sandboxID string) (*meteringpkg.SandboxProjectionState, error)
 	RunInTx(ctx context.Context, fn func(tx txStore) error) error
 }
+
+// RuntimeDeletionInfo identifies the runtime pod behind a Pod delete event.
+type RuntimeDeletionInfo struct {
+	SandboxID         string
+	Namespace         string
+	PodName           string
+	RuntimeGeneration int64
+}
+
+// RuntimePauseLookup determines whether a runtime pod deletion is a pause/stale
+// runtime cleanup rather than a sandbox termination.
+type RuntimePauseLookup func(ctx context.Context, info RuntimeDeletionInfo) (bool, error)
 
 type repositoryStore struct {
 	repo *meteringpkg.Repository
@@ -72,12 +86,13 @@ func (s *repositoryTxStore) UpsertSandboxProjectionState(ctx context.Context, st
 }
 
 type LifecycleProjector struct {
-	store     Store
-	regionID  string
-	clusterID string
-	logger    *zap.Logger
-	metrics   *obsmetrics.ManagerMetrics
-	now       func() time.Time
+	store              Store
+	runtimePauseLookup RuntimePauseLookup
+	regionID           string
+	clusterID          string
+	logger             *zap.Logger
+	metrics            *obsmetrics.ManagerMetrics
+	now                func() time.Time
 }
 
 func NewLifecycleProjector(store Store, regionID string, clusterID string) *LifecycleProjector {
@@ -100,6 +115,10 @@ func (p *LifecycleProjector) SetLogger(logger *zap.Logger) {
 
 func (p *LifecycleProjector) SetMetrics(metrics *obsmetrics.ManagerMetrics) {
 	p.metrics = metrics
+}
+
+func (p *LifecycleProjector) SetRuntimePauseLookup(lookup RuntimePauseLookup) {
+	p.runtimePauseLookup = lookup
 }
 
 func (p *LifecycleProjector) ResourceEventHandler() cache.ResourceEventHandlerFuncs {
@@ -222,7 +241,16 @@ func (p *LifecycleProjector) handleDelete(obj any) {
 	templateID := pod.Labels[controller.LabelTemplateID]
 	podUsage := sandboxUsageFromPod(pod)
 	claimedAt, claimedAtSet := parseRFC3339(pod.Annotations[controller.AnnotationClaimedAt])
-	runtimePaused := pod.Annotations[controller.AnnotationRuntimeDeletionReason] == "paused"
+	runtimePaused, lookupErr := p.runtimeDeletionIsPause(ctx, RuntimeDeletionInfo{
+		SandboxID:         sandboxID,
+		Namespace:         pod.Namespace,
+		PodName:           pod.Name,
+		RuntimeGeneration: runtimeGenerationFromPod(pod),
+	})
+	if lookupErr != nil {
+		p.recordError("load_runtime_pause_state", sandboxID, lookupErr)
+		return
+	}
 	pendingEvents := make([]*meteringpkg.Event, 0, 3)
 	pendingWindows := make([]*meteringpkg.Window, 0, 2)
 	if state == nil {
@@ -286,6 +314,28 @@ func (p *LifecycleProjector) handleDelete(obj any) {
 	if err := p.commitProjection(ctx, sandboxID, state, pendingEvents, pendingWindows, observedAt); err != nil {
 		return
 	}
+}
+
+func (p *LifecycleProjector) runtimeDeletionIsPause(ctx context.Context, info RuntimeDeletionInfo) (bool, error) {
+	if p == nil || p.runtimePauseLookup == nil {
+		return false, nil
+	}
+	return p.runtimePauseLookup(ctx, info)
+}
+
+func runtimeGenerationFromPod(pod *corev1.Pod) int64 {
+	if pod == nil || pod.Annotations == nil {
+		return 0
+	}
+	raw := strings.TrimSpace(pod.Annotations[controller.AnnotationRuntimeGeneration])
+	if raw == "" {
+		return 0
+	}
+	generation, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || generation < 0 {
+		return 0
+	}
+	return generation
 }
 
 func (p *LifecycleProjector) commitProjection(ctx context.Context, sandboxID string, state *meteringpkg.SandboxProjectionState, events []*meteringpkg.Event, windows []*meteringpkg.Window, observedAt time.Time) error {

--- a/manager/pkg/metering/lifecycle_projector_test.go
+++ b/manager/pkg/metering/lifecycle_projector_test.go
@@ -223,6 +223,74 @@ func TestLifecycleProjectorRecordsSandboxServerlessWindows(t *testing.T) {
 	}
 }
 
+func TestLifecycleProjectorRecordsPauseFromDurableStatusOnPodDelete(t *testing.T) {
+	recorder := &fakeRecorder{states: map[string]*meteringpkg.SandboxProjectionState{}}
+	projector := NewLifecycleProjector(recorder, "aws-us-east-1", "cluster-a")
+	projector.SetRuntimePauseLookup(func(_ context.Context, info RuntimeDeletionInfo) (bool, error) {
+		if info.SandboxID != "sb-1" || info.Namespace != "sandbox0" || info.PodName != "sb-1" {
+			t.Fatalf("runtime deletion info = %#v", info)
+		}
+		return true, nil
+	})
+
+	now := time.Date(2026, 3, 12, 10, 0, 0, 0, time.UTC)
+	projector.now = func() time.Time { return now }
+	claimedAt := now
+	pod := withSandboxResources(buildSandboxPod(claimedAt, false, "", "1"), "1", "1Gi")
+	projector.handleUpsert(pod)
+
+	projector.now = func() time.Time { return now.Add(2 * time.Minute) }
+	projector.handleDelete(pod)
+
+	if len(recorder.events) != 2 {
+		t.Fatalf("event count = %d, want 2", len(recorder.events))
+	}
+	if recorder.events[1].EventType != meteringpkg.EventTypeSandboxPaused {
+		t.Fatalf("second event type = %q, want %q", recorder.events[1].EventType, meteringpkg.EventTypeSandboxPaused)
+	}
+	if len(recorder.windows) != 1 || recorder.windows[0].WindowType != meteringpkg.WindowTypeSandboxRuntimeMiBMilliseconds {
+		t.Fatalf("expected runtime window after durable pause delete, got %#v", recorder.windows)
+	}
+	if recorder.windows[0].Value != 122_880_000 {
+		t.Fatalf("runtime value = %d, want 122880000", recorder.windows[0].Value)
+	}
+	state := recorder.states["sb-1"]
+	if state == nil || !state.Paused || state.TerminatedAt != nil {
+		t.Fatalf("state after durable pause delete = %#v, want paused without termination", state)
+	}
+}
+
+func TestLifecycleProjectorTreatsStaleRuntimeDeleteAsPause(t *testing.T) {
+	recorder := &fakeRecorder{states: map[string]*meteringpkg.SandboxProjectionState{}}
+	projector := NewLifecycleProjector(recorder, "aws-us-east-1", "cluster-a")
+	projector.SetRuntimePauseLookup(func(_ context.Context, info RuntimeDeletionInfo) (bool, error) {
+		if info.RuntimeGeneration != 1 {
+			t.Fatalf("runtime generation = %d, want 1", info.RuntimeGeneration)
+		}
+		return true, nil
+	})
+
+	now := time.Date(2026, 3, 12, 10, 0, 0, 0, time.UTC)
+	projector.now = func() time.Time { return now }
+	pod := buildSandboxPod(now, false, "", "1")
+	pod.Annotations[controller.AnnotationRuntimeGeneration] = "1"
+	projector.handleUpsert(pod)
+
+	projector.now = func() time.Time { return now.Add(time.Minute) }
+	projector.handleDelete(pod)
+
+	if len(recorder.events) != 2 {
+		t.Fatalf("event count = %d, want claim and pause", len(recorder.events))
+	}
+	if recorder.events[1].EventType != meteringpkg.EventTypeSandboxPaused {
+		t.Fatalf("second event type = %q, want pause", recorder.events[1].EventType)
+	}
+	state := recorder.states["sb-1"]
+	if state == nil || !state.Paused || state.TerminatedAt != nil {
+		t.Fatalf("state after stale runtime delete = %#v, want paused", state)
+	}
+}
+
 func TestLifecycleProjectorTerminatesPausedSandboxWithPausedWindow(t *testing.T) {
 	recorder := &fakeRecorder{states: map[string]*meteringpkg.SandboxProjectionState{}}
 	projector := NewLifecycleProjector(recorder, "aws-us-east-1", "cluster-a")

--- a/manager/pkg/service/sandbox_lifecycle_controller.go
+++ b/manager/pkg/service/sandbox_lifecycle_controller.go
@@ -33,19 +33,19 @@ const (
 
 // SandboxLifecycleInfo carries the durable identity needed to clean sandbox-scoped state.
 type SandboxLifecycleInfo struct {
-	Namespace             string
-	PodName               string
-	SandboxID             string
-	TeamID                string
-	UserID                string
-	WebhookURL            string
-	WebhookSecret         string
-	WebhookStateVolumeID  string
-	PodUID                string
-	NodeName              string
-	HostIP                string
-	RuntimeDeletionReason string
-	VolumePortals         []SandboxLifecycleVolumePortal
+	Namespace            string
+	PodName              string
+	SandboxID            string
+	TeamID               string
+	UserID               string
+	WebhookURL           string
+	WebhookSecret        string
+	WebhookStateVolumeID string
+	PodUID               string
+	NodeName             string
+	HostIP               string
+	RuntimeGeneration    int64
+	VolumePortals        []SandboxLifecycleVolumePortal
 }
 
 // SandboxLifecycleVolumePortal carries the ctld identity for a bound sandbox volume portal.
@@ -61,20 +61,20 @@ type SandboxDeletionCleaner interface {
 }
 
 type sandboxLifecycleQueueItem struct {
-	Namespace             string
-	PodName               string
-	SandboxID             string
-	TeamID                string
-	UserID                string
-	WebhookURL            string
-	WebhookSecret         string
-	WebhookStateVolumeID  string
-	PodUID                string
-	NodeName              string
-	HostIP                string
-	RuntimeDeletionReason string
-	VolumePortalsJSON     string
-	Deleted               bool
+	Namespace            string
+	PodName              string
+	SandboxID            string
+	TeamID               string
+	UserID               string
+	WebhookURL           string
+	WebhookSecret        string
+	WebhookStateVolumeID string
+	PodUID               string
+	NodeName             string
+	HostIP               string
+	RuntimeGeneration    int64
+	VolumePortalsJSON    string
+	Deleted              bool
 }
 
 // SandboxLifecycleController reconciles sandbox deletion side effects from Pod lifecycle state.
@@ -271,19 +271,19 @@ func (c *SandboxLifecycleController) ensurePodCleanupFinalizer(ctx context.Conte
 
 func (c *SandboxLifecycleController) cleanupDeletedSandbox(ctx context.Context, item sandboxLifecycleQueueItem) error {
 	info := SandboxLifecycleInfo{
-		Namespace:             item.Namespace,
-		PodName:               item.PodName,
-		SandboxID:             item.SandboxID,
-		TeamID:                item.TeamID,
-		UserID:                item.UserID,
-		WebhookURL:            item.WebhookURL,
-		WebhookSecret:         item.WebhookSecret,
-		WebhookStateVolumeID:  item.WebhookStateVolumeID,
-		PodUID:                item.PodUID,
-		NodeName:              item.NodeName,
-		HostIP:                item.HostIP,
-		RuntimeDeletionReason: item.RuntimeDeletionReason,
-		VolumePortals:         decodeSandboxLifecycleVolumePortals(item.VolumePortalsJSON),
+		Namespace:            item.Namespace,
+		PodName:              item.PodName,
+		SandboxID:            item.SandboxID,
+		TeamID:               item.TeamID,
+		UserID:               item.UserID,
+		WebhookURL:           item.WebhookURL,
+		WebhookSecret:        item.WebhookSecret,
+		WebhookStateVolumeID: item.WebhookStateVolumeID,
+		PodUID:               item.PodUID,
+		NodeName:             item.NodeName,
+		HostIP:               item.HostIP,
+		RuntimeGeneration:    item.RuntimeGeneration,
+		VolumePortals:        decodeSandboxLifecycleVolumePortals(item.VolumePortalsJSON),
 	}
 	if info.SandboxID == "" {
 		info.SandboxID = info.PodName
@@ -315,6 +315,22 @@ func (s *SandboxService) CleanupDeletedSandbox(ctx context.Context, info Sandbox
 	if s == nil {
 		return nil
 	}
+	sandboxID := strings.TrimSpace(info.SandboxID)
+	if sandboxID == "" {
+		sandboxID = strings.TrimSpace(info.PodName)
+	}
+	if sandboxID == "" {
+		return nil
+	}
+
+	runtimePaused, err := s.runtimeDeletionIsPause(ctx, info)
+	if err != nil {
+		return err
+	}
+	return s.cleanupDeletedSandbox(ctx, info, runtimePaused)
+}
+
+func (s *SandboxService) cleanupDeletedSandbox(ctx context.Context, info SandboxLifecycleInfo, runtimePaused bool) error {
 	logger := s.logger
 	if logger == nil {
 		logger = zap.NewNop()
@@ -327,7 +343,6 @@ func (s *SandboxService) CleanupDeletedSandbox(ctx context.Context, info Sandbox
 		return nil
 	}
 
-	runtimePaused := strings.TrimSpace(info.RuntimeDeletionReason) == runtimeDeletionReasonPaused
 	var errs []error
 	if !runtimePaused && s.deletionWebhookEmitter != nil && strings.TrimSpace(info.WebhookURL) != "" {
 		if err := s.deletionWebhookEmitter.EmitSandboxDeleted(ctx, info); err != nil {
@@ -363,6 +378,50 @@ func (s *SandboxService) CleanupDeletedSandbox(ctx context.Context, info Sandbox
 		errs = append(errs, fmt.Errorf("unbind sandbox volume portals: %w", err))
 	}
 	return errors.Join(errs...)
+}
+
+func (s *SandboxService) runtimeDeletionIsPause(ctx context.Context, info SandboxLifecycleInfo) (bool, error) {
+	if s == nil || s.sandboxStore == nil {
+		return false, nil
+	}
+	sandboxID := strings.TrimSpace(info.SandboxID)
+	if sandboxID == "" {
+		sandboxID = strings.TrimSpace(info.PodName)
+	}
+	if sandboxID == "" {
+		return false, nil
+	}
+	record, err := s.sandboxStore.GetSandbox(ctx, sandboxID)
+	if err != nil {
+		return false, fmt.Errorf("get sandbox record for runtime deletion cleanup: %w", err)
+	}
+	return SandboxRecordDeletionIsRuntimeOnly(record, info.Namespace, info.PodName, info.RuntimeGeneration), nil
+}
+
+// SandboxRecordDeletionIsRuntimeOnly reports whether a runtime pod deletion should
+// be treated as pause/stale runtime cleanup instead of sandbox deletion.
+func SandboxRecordDeletionIsRuntimeOnly(record *SandboxRecord, namespace, podName string, runtimeGeneration int64) bool {
+	if record == nil {
+		return false
+	}
+	switch record.Status {
+	case SandboxStatusPausing, SandboxStatusPaused:
+		return true
+	case SandboxStatusDeleted:
+		return false
+	}
+	if runtimeGeneration > 0 && record.RuntimeGeneration > runtimeGeneration {
+		return true
+	}
+	podName = strings.TrimSpace(podName)
+	namespace = strings.TrimSpace(namespace)
+	if podName != "" && strings.TrimSpace(record.CurrentPodName) != "" && record.CurrentPodName != podName {
+		return true
+	}
+	if namespace != "" && strings.TrimSpace(record.CurrentPodNamespace) != "" && record.CurrentPodNamespace != namespace {
+		return true
+	}
+	return false
 }
 
 func (s *SandboxService) unbindDeletedSandboxVolumePortals(ctx context.Context, info SandboxLifecycleInfo) error {
@@ -459,20 +518,20 @@ func (s *SandboxService) ensureSandboxDeletionFinalizer(ctx context.Context, pod
 
 func sandboxLifecycleItemFromInfo(info SandboxLifecycleInfo, deleted bool) sandboxLifecycleQueueItem {
 	return sandboxLifecycleQueueItem{
-		Namespace:             info.Namespace,
-		PodName:               info.PodName,
-		SandboxID:             info.SandboxID,
-		TeamID:                info.TeamID,
-		UserID:                info.UserID,
-		WebhookURL:            info.WebhookURL,
-		WebhookSecret:         info.WebhookSecret,
-		WebhookStateVolumeID:  info.WebhookStateVolumeID,
-		PodUID:                info.PodUID,
-		NodeName:              info.NodeName,
-		HostIP:                info.HostIP,
-		RuntimeDeletionReason: info.RuntimeDeletionReason,
-		VolumePortalsJSON:     encodeSandboxLifecycleVolumePortals(info.VolumePortals),
-		Deleted:               deleted,
+		Namespace:            info.Namespace,
+		PodName:              info.PodName,
+		SandboxID:            info.SandboxID,
+		TeamID:               info.TeamID,
+		UserID:               info.UserID,
+		WebhookURL:           info.WebhookURL,
+		WebhookSecret:        info.WebhookSecret,
+		WebhookStateVolumeID: info.WebhookStateVolumeID,
+		PodUID:               info.PodUID,
+		NodeName:             info.NodeName,
+		HostIP:               info.HostIP,
+		RuntimeGeneration:    info.RuntimeGeneration,
+		VolumePortalsJSON:    encodeSandboxLifecycleVolumePortals(info.VolumePortals),
+		Deleted:              deleted,
 	}
 }
 
@@ -514,12 +573,10 @@ func sandboxLifecycleInfoFromPod(pod *corev1.Pod) (SandboxLifecycleInfo, bool) {
 	webhookURL := ""
 	webhookSecret := ""
 	webhookStateVolumeID := ""
-	runtimeDeletionReason := ""
 	if pod.Annotations != nil {
 		teamID = strings.TrimSpace(pod.Annotations[controller.AnnotationTeamID])
 		userID = strings.TrimSpace(pod.Annotations[controller.AnnotationUserID])
 		webhookStateVolumeID = strings.TrimSpace(pod.Annotations[controller.AnnotationWebhookStateVolumeID])
-		runtimeDeletionReason = strings.TrimSpace(pod.Annotations[controller.AnnotationRuntimeDeletionReason])
 		if configJSON := strings.TrimSpace(pod.Annotations[controller.AnnotationConfig]); configJSON != "" {
 			var cfg SandboxConfig
 			if err := json.Unmarshal([]byte(configJSON), &cfg); err == nil && cfg.Webhook != nil {
@@ -529,19 +586,19 @@ func sandboxLifecycleInfoFromPod(pod *corev1.Pod) (SandboxLifecycleInfo, bool) {
 		}
 	}
 	return SandboxLifecycleInfo{
-		Namespace:             pod.Namespace,
-		PodName:               pod.Name,
-		SandboxID:             sandboxID,
-		TeamID:                teamID,
-		UserID:                userID,
-		WebhookURL:            webhookURL,
-		WebhookSecret:         webhookSecret,
-		WebhookStateVolumeID:  webhookStateVolumeID,
-		PodUID:                string(pod.UID),
-		NodeName:              pod.Spec.NodeName,
-		HostIP:                pod.Status.HostIP,
-		RuntimeDeletionReason: runtimeDeletionReason,
-		VolumePortals:         sandboxLifecycleVolumePortalsFromPod(pod, webhookStateVolumeID),
+		Namespace:            pod.Namespace,
+		PodName:              pod.Name,
+		SandboxID:            sandboxID,
+		TeamID:               teamID,
+		UserID:               userID,
+		WebhookURL:           webhookURL,
+		WebhookSecret:        webhookSecret,
+		WebhookStateVolumeID: webhookStateVolumeID,
+		PodUID:               string(pod.UID),
+		NodeName:             pod.Spec.NodeName,
+		HostIP:               pod.Status.HostIP,
+		RuntimeGeneration:    runtimeGenerationFromPod(pod),
+		VolumePortals:        sandboxLifecycleVolumePortalsFromPod(pod, webhookStateVolumeID),
 	}, true
 }
 

--- a/manager/pkg/service/sandbox_lifecycle_controller_test.go
+++ b/manager/pkg/service/sandbox_lifecycle_controller_test.go
@@ -295,7 +295,7 @@ func TestSandboxServiceCleanupDeletedSandboxDoesNotBlockOnDeletionWebhookFailure
 	}
 }
 
-func TestSandboxServiceCleanupDeletedSandboxPreservesDurableStateForPausedRuntime(t *testing.T) {
+func TestSandboxServiceCleanupDeletedSandboxPreservesDurableStateForPausingRuntime(t *testing.T) {
 	removed := make([]string, 0, 1)
 	store := &deleteRecordingBindingStore{}
 	volumeClient := &recordingSystemVolumeClient{}
@@ -307,18 +307,76 @@ func TestSandboxServiceCleanupDeletedSandboxPreservesDurableStateForPausedRuntim
 		credentialStore:        store,
 		webhookStateVolumes:    volumeClient,
 		deletionWebhookEmitter: emitter,
-		logger:                 zap.NewNop(),
+		sandboxStore: &memorySandboxStore{records: map[string]*SandboxRecord{
+			"sandbox-a": {
+				ID:     "sandbox-a",
+				TeamID: "team-a",
+				Status: SandboxStatusPausing,
+			},
+		}},
+		logger: zap.NewNop(),
 	}
 
 	err := svc.CleanupDeletedSandbox(context.Background(), SandboxLifecycleInfo{
-		Namespace:             "ns-a",
-		PodName:               "pod-a",
-		SandboxID:             "sandbox-a",
-		TeamID:                "team-a",
-		UserID:                "user-a",
-		WebhookURL:            "https://example.test/webhook",
-		WebhookStateVolumeID:  "volume-a",
-		RuntimeDeletionReason: runtimeDeletionReasonPaused,
+		Namespace:            "ns-a",
+		PodName:              "pod-a",
+		SandboxID:            "sandbox-a",
+		TeamID:               "team-a",
+		UserID:               "user-a",
+		WebhookURL:           "https://example.test/webhook",
+		WebhookStateVolumeID: "volume-a",
+	})
+	if err != nil {
+		t.Fatalf("CleanupDeletedSandbox() error = %v", err)
+	}
+	if len(removed) != 1 || removed[0] != "ns-a/sandbox-a" {
+		t.Fatalf("network removals = %#v, want ns-a/sandbox-a", removed)
+	}
+	if store.deleteCalls != 0 {
+		t.Fatalf("DeleteBindings calls = %d, want 0", store.deleteCalls)
+	}
+	if len(emitter.calls) != 0 {
+		t.Fatalf("webhook calls = %d, want 0", len(emitter.calls))
+	}
+	if len(volumeClient.marked) != 0 {
+		t.Fatalf("marked volumes = %#v, want none", volumeClient.marked)
+	}
+}
+
+func TestSandboxServiceCleanupDeletedSandboxPreservesDurableStateForStaleRuntime(t *testing.T) {
+	removed := make([]string, 0, 1)
+	store := &deleteRecordingBindingStore{}
+	volumeClient := &recordingSystemVolumeClient{}
+	emitter := &recordingDeletionWebhookEmitter{}
+	svc := &SandboxService{
+		networkProvider: &assertingNetworkProvider{removeFunc: func(namespace, sandboxID string) {
+			removed = append(removed, namespace+"/"+sandboxID)
+		}},
+		credentialStore:        store,
+		webhookStateVolumes:    volumeClient,
+		deletionWebhookEmitter: emitter,
+		sandboxStore: &memorySandboxStore{records: map[string]*SandboxRecord{
+			"sandbox-a": {
+				ID:                  "sandbox-a",
+				TeamID:              "team-a",
+				Status:              SandboxStatusRunning,
+				CurrentPodNamespace: "ns-a",
+				CurrentPodName:      "pod-new",
+				RuntimeGeneration:   2,
+			},
+		}},
+		logger: zap.NewNop(),
+	}
+
+	err := svc.CleanupDeletedSandbox(context.Background(), SandboxLifecycleInfo{
+		Namespace:            "ns-a",
+		PodName:              "pod-old",
+		SandboxID:            "sandbox-a",
+		TeamID:               "team-a",
+		UserID:               "user-a",
+		WebhookURL:           "https://example.test/webhook",
+		WebhookStateVolumeID: "volume-a",
+		RuntimeGeneration:    1,
 	})
 	if err != nil {
 		t.Fatalf("CleanupDeletedSandbox() error = %v", err)
@@ -396,6 +454,7 @@ func TestSandboxLifecycleInfoFromPodIncludesWebhookMetadata(t *testing.T) {
 	pod := newLifecycleTestPod()
 	pod.Annotations[controller.AnnotationUserID] = "user-a"
 	pod.Annotations[controller.AnnotationWebhookStateVolumeID] = "volume-a"
+	pod.Annotations[controller.AnnotationRuntimeGeneration] = "7"
 	pod.Annotations[controller.AnnotationConfig] = `{"webhook":{"url":"https://example.test/webhook","secret":"secret"}}`
 
 	info, ok := sandboxLifecycleInfoFromPod(pod)
@@ -407,6 +466,9 @@ func TestSandboxLifecycleInfoFromPodIncludesWebhookMetadata(t *testing.T) {
 	}
 	if info.WebhookURL != "https://example.test/webhook" || info.WebhookSecret != "secret" {
 		t.Fatalf("unexpected webhook metadata: %#v", info)
+	}
+	if info.RuntimeGeneration != 7 {
+		t.Fatalf("runtime generation = %d, want 7", info.RuntimeGeneration)
 	}
 }
 

--- a/manager/pkg/service/sandbox_service_lifecycle.go
+++ b/manager/pkg/service/sandbox_service_lifecycle.go
@@ -17,7 +17,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 )
 
@@ -36,7 +35,7 @@ func (s *SandboxService) TerminateSandbox(ctx context.Context, sandboxID string)
 					return fmt.Errorf("get sandbox record: %w", getErr)
 				}
 				if record != nil && record.Status != SandboxStatusDeleted {
-					if err := s.CleanupDeletedSandbox(ctx, sandboxLifecycleInfoFromRecord(record)); err != nil {
+					if err := s.cleanupDeletedSandbox(ctx, sandboxLifecycleInfoFromRecord(record), false); err != nil {
 						return fmt.Errorf("cleanup deleted sandbox record: %w", err)
 					}
 				}
@@ -50,10 +49,6 @@ func (s *SandboxService) TerminateSandbox(ctx context.Context, sandboxID string)
 	pod, err = s.ensureSandboxDeletionFinalizer(ctx, pod)
 	if err != nil {
 		return fmt.Errorf("ensure sandbox cleanup finalizer: %w", err)
-	}
-	pod, err = s.markRuntimeDeletionReason(ctx, pod, runtimeDeletionReasonDeleted)
-	if err != nil {
-		return fmt.Errorf("mark sandbox deletion reason: %w", err)
 	}
 
 	err = s.k8sClient.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{})
@@ -200,10 +195,6 @@ func (s *SandboxService) pauseSandboxRuntime(ctx context.Context, sandboxID stri
 		if err != nil {
 			return fmt.Errorf("ensure sandbox cleanup finalizer: %w", err)
 		}
-		pod, err = s.markRuntimeDeletionReason(ctx, pod, runtimeDeletionReasonPaused)
-		if err != nil {
-			return fmt.Errorf("mark runtime deletion reason: %w", err)
-		}
 		if err := s.k8sClient.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{}); err != nil && !k8serrors.IsNotFound(err) {
 			return fmt.Errorf("delete runtime pod: %w", err)
 		}
@@ -281,15 +272,8 @@ func (s *SandboxService) CompletePausingSandboxRuntime(ctx context.Context, sand
 	if err != nil {
 		return fmt.Errorf("ensure sandbox cleanup finalizer: %w", err)
 	}
-	pod, err = s.markRuntimeDeletionReason(ctx, pod, runtimeDeletionReasonPaused)
-	if err != nil {
-		return fmt.Errorf("mark runtime deletion reason: %w", err)
-	}
 	if err := s.k8sClient.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{}); err != nil && !k8serrors.IsNotFound(err) {
 		return fmt.Errorf("delete runtime pod: %w", err)
-	}
-	if err := s.waitForRuntimePodDeleted(ctx, pod.Namespace, pod.Name); err != nil {
-		return err
 	}
 	return s.markPausingRuntimePaused(ctx, sandboxID, generation)
 }
@@ -314,27 +298,6 @@ func (s *SandboxService) markPausingRuntimePaused(ctx context.Context, sandboxID
 			return nil
 		}
 		return tx.MarkRuntimePaused(lockCtx, sandboxID, generation, s.clock.Now())
-	})
-}
-
-const (
-	defaultSandboxPausePodDeletionTimeout = 2 * time.Minute
-	defaultSandboxPausePodDeletionPoll    = 500 * time.Millisecond
-)
-
-func (s *SandboxService) waitForRuntimePodDeleted(ctx context.Context, namespace, name string) error {
-	if s == nil || s.k8sClient == nil || namespace == "" || name == "" {
-		return nil
-	}
-	return wait.PollUntilContextTimeout(ctx, defaultSandboxPausePodDeletionPoll, defaultSandboxPausePodDeletionTimeout, true, func(ctx context.Context) (bool, error) {
-		_, err := s.k8sClient.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
-		if k8serrors.IsNotFound(err) {
-			return true, nil
-		}
-		if err != nil {
-			return false, err
-		}
-		return false, nil
 	})
 }
 
@@ -373,35 +336,6 @@ func (s *SandboxService) ListHardExpiredSandboxIDs(ctx context.Context, now time
 		}
 	}
 	return ids, nil
-}
-
-const (
-	runtimeDeletionReasonPaused  = "paused"
-	runtimeDeletionReasonDeleted = "deleted"
-)
-
-func (s *SandboxService) markRuntimeDeletionReason(ctx context.Context, pod *corev1.Pod, reason string) (*corev1.Pod, error) {
-	if s == nil || pod == nil || s.k8sClient == nil || strings.TrimSpace(reason) == "" {
-		return pod, nil
-	}
-	var updated *corev1.Pod
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		current, err := s.k8sClient.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
-		if err != nil {
-			return err
-		}
-		updated = current.DeepCopy()
-		if updated.Annotations == nil {
-			updated.Annotations = make(map[string]string)
-		}
-		updated.Annotations[controller.AnnotationRuntimeDeletionReason] = reason
-		updated, err = s.k8sClient.CoreV1().Pods(updated.Namespace).Update(ctx, updated, metav1.UpdateOptions{})
-		return err
-	})
-	if err != nil {
-		return nil, err
-	}
-	return updated, nil
 }
 
 // GetSandbox gets a sandbox by ID
@@ -870,11 +804,12 @@ func sandboxLifecycleInfoFromRecord(record *SandboxRecord) SandboxLifecycleInfo 
 		return SandboxLifecycleInfo{}
 	}
 	info := SandboxLifecycleInfo{
-		Namespace: record.CurrentPodNamespace,
-		PodName:   record.CurrentPodName,
-		SandboxID: record.ID,
-		TeamID:    record.TeamID,
-		UserID:    record.UserID,
+		Namespace:         record.CurrentPodNamespace,
+		PodName:           record.CurrentPodName,
+		SandboxID:         record.ID,
+		TeamID:            record.TeamID,
+		UserID:            record.UserID,
+		RuntimeGeneration: record.RuntimeGeneration,
 	}
 	if record.Config.Webhook != nil {
 		info.WebhookURL = strings.TrimSpace(record.Config.Webhook.URL)

--- a/manager/pkg/service/sandbox_service_rootfs_test.go
+++ b/manager/pkg/service/sandbox_service_rootfs_test.go
@@ -77,8 +77,15 @@ func TestPauseSandboxRuntimeQueuesRootFSSaveBeforeDeletingPod(t *testing.T) {
 	pod.Annotations[controller.AnnotationWebhookStateVolumeID] = "webhook-state-vol-1"
 	pod.Status.HostIP = ctldURL.Hostname()
 	k8sClient := fake.NewSimpleClientset(pod)
+	deleteCalled := false
 	k8sClient.PrependReactor("delete", "pods", func(action ktesting.Action) (bool, runtime.Object, error) {
 		require.True(t, saveCalled, "pod delete must happen after rootfs checkpoint save")
+		deleteCalled = true
+		return true, nil, nil
+	})
+	k8sClient.PrependReactor("update", "pods", func(action ktesting.Action) (bool, runtime.Object, error) {
+		updated := action.(ktesting.UpdateAction).GetObject().(*corev1.Pod)
+		assert.NotContains(t, updated.Annotations, "sandbox0.ai/runtime-deletion-reason")
 		return false, nil, nil
 	})
 	store := &memorySandboxStore{records: map[string]*SandboxRecord{
@@ -112,6 +119,9 @@ func TestPauseSandboxRuntimeQueuesRootFSSaveBeforeDeletingPod(t *testing.T) {
 
 	require.NoError(t, svc.CompletePausingSandboxRuntime(context.Background(), "sandbox-1"))
 
+	assert.True(t, deleteCalled)
+	_, err = k8sClient.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+	require.NoError(t, err, "pause completion should not wait for the pod to disappear after delete is accepted")
 	state := store.rootFSStates["sandbox-1"]
 	require.NotNil(t, state)
 	assert.Equal(t, int64(3), state.RuntimeGeneration)

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -4322,7 +4322,7 @@ components:
           $ref: "#/components/schemas/SandboxLifecycleStatus"
         paused:
           type: boolean
-          description: True when status is paused and no runtime is attached.
+          description: True when status is paused.
         auto_resume:
           type: boolean
         services:
@@ -4567,7 +4567,7 @@ components:
           $ref: "#/components/schemas/SandboxLifecycleStatus"
         paused:
           type: boolean
-          description: True when status is paused and no runtime is attached.
+          description: True when status is paused.
         runtime_generation:
           type: integer
           format: int64
@@ -4716,7 +4716,7 @@ components:
           type: string
         paused:
           type: boolean
-          description: True when checkpoint completion has finished and the sandbox is paused.
+          description: True when checkpoint persistence has finished, runtime deletion has been accepted, and the sandbox is paused.
         status:
           $ref: "#/components/schemas/SandboxLifecycleStatus"
           description: Current lifecycle status. Async pause requests usually return pausing.

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -1251,7 +1251,7 @@ type PTYSize struct {
 
 // PauseSandboxResponse defines model for PauseSandboxResponse.
 type PauseSandboxResponse struct {
-	// Paused True when checkpoint completion has finished and the sandbox is paused.
+	// Paused True when checkpoint persistence has finished, runtime deletion has been accepted, and the sandbox is paused.
 	Paused        bool                    `json:"paused"`
 	ResourceUsage *SandboxResourceUsage   `json:"resource_usage,omitempty"`
 	SandboxId     string                  `json:"sandbox_id"`
@@ -1554,7 +1554,7 @@ type Sandbox struct {
 	Id            string               `json:"id"`
 	Mounts        *[]ClaimMountRequest `json:"mounts,omitempty"`
 
-	// Paused True when status is paused and no runtime is attached.
+	// Paused True when status is paused.
 	Paused  bool   `json:"paused"`
 	PodName string `json:"pod_name"`
 
@@ -1821,7 +1821,7 @@ type SandboxSummary struct {
 	HardExpiresAt time.Time `json:"hard_expires_at"`
 	Id            string    `json:"id"`
 
-	// Paused True when status is paused and no runtime is attached.
+	// Paused True when status is paused.
 	Paused bool `json:"paused"`
 
 	// RuntimeGeneration Monotonically increasing runtime generation. Resume starts a new generation.


### PR DESCRIPTION
## Summary
- Mark pause complete once rootfs checkpoint persistence finishes and runtime Pod deletion is accepted, without waiting for the Pod to disappear.
- Remove the `sandbox0.ai/runtime-deletion-reason` Pod annotation path; cleanup and metering classify runtime-only deletes from durable sandbox state plus runtime identity.
- Protect the immediate pause -> resume race by treating deletes for stale/older runtime Pods as runtime-only cleanup.
- Update pause API descriptions and focused lifecycle/metering tests.

## Tests
- `make apispec`
- `go test ./manager/pkg/service ./manager/pkg/metering ./manager/cmd/manager ./manager/pkg/controller ./manager/pkg/http ./pkg/apispec`
- Remote Aliyun Singapore kind deployment with final diff: `Sandbox0Infra fullmode Ready 9/9`
- Remote benchmark path: `/data/workspace/pause-fast-bench-final-20260625205622/results.jsonl`

## Remote Benchmark Summary
| rootfs write | iters | avg pause API | avg pause->paused | avg pod deleted | avg resume API | annotation writes |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| 0 MiB | 3 | 15 ms | 2608 ms | 2626 ms | 3923 ms | 0 |
| 1 MiB | 3 | 18 ms | 2631 ms | 2587 ms | 1047 ms | 0 |
| 16 MiB | 3 | 27 ms | 2423 ms | 2453 ms | 922 ms | 0 |
| 64 MiB | 3 | 22 ms | 2941 ms | 2978 ms | 1879 ms | 0 |
| 128 MiB | 3 | 35 ms | 4680 ms | 4689 ms | 4065 ms | 0 |

All benchmark iterations verified restored file size after immediate resume and ended with `remaining sandboxes listed: 0`.