### PR TITLE
Make sandbox pause/resume lifecycle atomic

### DIFF
--- a/docs/sandbox/pause-resume/page.mdx
+++ b/docs/sandbox/pause-resume/page.mdx
@@ -36,6 +36,8 @@ Pause a sandbox to release compute while keeping its identity, configuration, se
 
 The pause endpoint accepts the lifecycle transition and returns once the sandbox is recorded as `pausing`. Rootfs checkpoint upload and runtime pod deletion continue in the background. Poll sandbox details until `status` is `paused` before treating the checkpoint as resume-ready.
 
+Runtime access paths do not require callers to special-case `pausing` or `resuming`. File, context, public service, and SSH requests either use the currently committed runtime generation or wait for the lifecycle transition to commit before continuing on the next generation.
+
 <Endpoint method="POST">
 /api/v1/sandboxes/{'{id}'}/pause
 </Endpoint>
@@ -171,6 +173,7 @@ console.log("runtimeGeneration=", sb.runtimeGeneration);`
 
 Common auto-resume entrypoints:
 
+- sandbox runtime APIs such as files and contexts
 - service routes configured with `resume: true`; public service requests require sandbox `auto_resume: true`, route `resume: true`, and a restartable service runtime (`cmd` or `function`)
 - SSH access through Sandbox0 SSH Gateway
 

--- a/manager/pkg/service/sandbox_runtime_identity_test.go
+++ b/manager/pkg/service/sandbox_runtime_identity_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -267,7 +268,7 @@ func TestGetSandboxPodRejectsMultipleActiveRuntimePods(t *testing.T) {
 	}
 }
 
-func TestResumePausedSandboxRuntimeDoesNotCreatePodWhileRuntimeDeleting(t *testing.T) {
+func TestResumePausedSandboxRuntimeWaitsWhileRuntimeDeleting(t *testing.T) {
 	deletionTime := metav1.NewTime(time.Now().UTC())
 	pod := runtimeIdentityPod("ns-a", "pod-a", "sandbox-a")
 	pod.DeletionTimestamp = &deletionTime
@@ -291,9 +292,14 @@ func TestResumePausedSandboxRuntimeDoesNotCreatePodWhileRuntimeDeleting(t *testi
 		logger:       zap.NewNop(),
 	}
 
-	_, err := svc.ResumePausedSandboxRuntime(context.Background(), "sandbox-a")
-	if !k8serrors.IsConflict(err) {
-		t.Fatalf("ResumePausedSandboxRuntime() error = %v, want conflict", err)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*sandboxLifecycleWaitInterval)
+	defer cancel()
+	_, err := svc.ResumePausedSandboxRuntime(ctx, "sandbox-a")
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("ResumePausedSandboxRuntime() error = %v, want context deadline", err)
+	}
+	if k8serrors.IsConflict(err) {
+		t.Fatalf("ResumePausedSandboxRuntime() returned conflict while old runtime is deleting")
 	}
 	for _, action := range client.Actions() {
 		if action.GetVerb() == "create" && action.GetResource().Resource == "pods" {
@@ -302,6 +308,128 @@ func TestResumePausedSandboxRuntimeDoesNotCreatePodWhileRuntimeDeleting(t *testi
 	}
 	if store.saves != 0 {
 		t.Fatalf("store saves = %d, want 0", store.saves)
+	}
+}
+
+func TestResumePausedSandboxRuntimeJoinsResumingRuntime(t *testing.T) {
+	pod := runtimeIdentityPod("ns-a", "pod-a", "sandbox-a")
+	pod.Annotations[controller.AnnotationRuntimeGeneration] = "4"
+	pod.Status.Phase = corev1.PodRunning
+	pod.Status.PodIP = "10.0.0.4"
+	store := &memorySandboxStore{records: map[string]*SandboxRecord{
+		"sandbox-a": {
+			ID:                  "sandbox-a",
+			TeamID:              "team-a",
+			UserID:              "user-a",
+			TemplateID:          "default",
+			TemplateName:        "default",
+			TemplateNamespace:   "tpl-default",
+			Status:              SandboxStatusResuming,
+			CurrentPodName:      "pod-a",
+			CurrentPodNamespace: "ns-a",
+			RuntimeGeneration:   4,
+			TemplateSpec:        v1alpha1.SandboxTemplateSpec{},
+		},
+	}}
+	client := fake.NewSimpleClientset(pod.DeepCopy())
+	svc := &SandboxService{
+		k8sClient:    client,
+		podLister:    runtimeIdentityPodLister(t, pod),
+		sandboxStore: store,
+		config:       SandboxServiceConfig{ProcdPort: 49983},
+		logger:       zap.NewNop(),
+	}
+
+	go func() {
+		time.Sleep(2 * sandboxLifecycleWaitInterval)
+		store.records["sandbox-a"].Status = SandboxStatusRunning
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	sandbox, err := svc.ResumePausedSandboxRuntime(ctx, "sandbox-a")
+	if err != nil {
+		t.Fatalf("ResumePausedSandboxRuntime() error = %v, want nil", err)
+	}
+	if sandbox.Status != SandboxStatusRunning {
+		t.Fatalf("status = %q, want running", sandbox.Status)
+	}
+	if sandbox.RuntimeGeneration != 4 {
+		t.Fatalf("runtime generation = %d, want 4", sandbox.RuntimeGeneration)
+	}
+	for _, action := range client.Actions() {
+		if action.GetVerb() == "create" && action.GetResource().Resource == "pods" {
+			t.Fatalf("unexpected pod create while joining active resume: %#v", action)
+		}
+	}
+}
+
+func TestResumePausedSandboxRuntimeCompletesPausingInsteadOfConflict(t *testing.T) {
+	pod := runtimeIdentityPod("ns-a", "pod-a", "sandbox-a")
+	pod.Annotations[controller.AnnotationRuntimeGeneration] = "4"
+	pod.Status.Phase = corev1.PodRunning
+	pod.Status.PodIP = "10.0.0.4"
+	store := &memorySandboxStore{records: map[string]*SandboxRecord{
+		"sandbox-a": {
+			ID:                  "sandbox-a",
+			TeamID:              "team-a",
+			UserID:              "user-a",
+			TemplateID:          "default",
+			TemplateName:        "default",
+			TemplateNamespace:   "tpl-default",
+			Status:              SandboxStatusPausing,
+			CurrentPodName:      "pod-a",
+			CurrentPodNamespace: "ns-a",
+			RuntimeGeneration:   4,
+			TemplateSpec:        v1alpha1.SandboxTemplateSpec{},
+		},
+	}}
+	svc := &SandboxService{
+		k8sClient:    fake.NewSimpleClientset(pod.DeepCopy()),
+		podLister:    runtimeIdentityPodLister(t, pod),
+		sandboxStore: store,
+		logger:       zap.NewNop(),
+	}
+
+	_, err := svc.ResumePausedSandboxRuntime(context.Background(), "sandbox-a")
+	if !errors.Is(err, ErrSandboxCheckpointRequiresCtld) {
+		t.Fatalf("ResumePausedSandboxRuntime() error = %v, want checkpoint requirement", err)
+	}
+	if k8serrors.IsConflict(err) {
+		t.Fatalf("ResumePausedSandboxRuntime() returned conflict for pausing sandbox")
+	}
+}
+
+func TestResumePausedSandboxRuntimeDoesNotCreateRuntimeForRunningRecordWithoutPod(t *testing.T) {
+	store := &memorySandboxStore{records: map[string]*SandboxRecord{
+		"sandbox-a": {
+			ID:                "sandbox-a",
+			TeamID:            "team-a",
+			UserID:            "user-a",
+			TemplateID:        "default",
+			TemplateName:      "default",
+			TemplateNamespace: "tpl-default",
+			Status:            SandboxStatusRunning,
+			RuntimeGeneration: 4,
+			TemplateSpec:      v1alpha1.SandboxTemplateSpec{},
+		},
+	}}
+	client := fake.NewSimpleClientset()
+	svc := &SandboxService{
+		k8sClient:    client,
+		podLister:    runtimeIdentityPodLister(t),
+		sandboxStore: store,
+		logger:       zap.NewNop(),
+	}
+
+	_, err := svc.ResumePausedSandboxRuntime(context.Background(), "sandbox-a")
+	if !k8serrors.IsConflict(err) {
+		t.Fatalf("ResumePausedSandboxRuntime() error = %v, want conflict", err)
+	}
+	for _, action := range client.Actions() {
+		if action.GetVerb() == "create" && action.GetResource().Resource == "pods" {
+			t.Fatalf("unexpected pod create for running record without runtime: %#v", action)
+		}
 	}
 }
 

--- a/manager/pkg/service/sandbox_runtime_identity_test.go
+++ b/manager/pkg/service/sandbox_runtime_identity_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 )
 
 type memorySandboxStore struct {
+	mu                sync.Mutex
 	records           map[string]*SandboxRecord
 	rootFSStates      map[string]*SandboxRootFSState
 	rootFSFilesystems map[string]*RootFSFilesystem
@@ -32,6 +34,8 @@ type memorySandboxStoreTx struct {
 }
 
 func (s *memorySandboxStore) UpsertSandbox(_ context.Context, record *SandboxRecord) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.records == nil {
 		s.records = make(map[string]*SandboxRecord)
 	}
@@ -40,14 +44,24 @@ func (s *memorySandboxStore) UpsertSandbox(_ context.Context, record *SandboxRec
 }
 
 func (s *memorySandboxStore) GetSandbox(_ context.Context, sandboxID string) (*SandboxRecord, error) {
-	if s == nil || s.records == nil {
+	if s == nil {
+		return nil, nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.records == nil {
 		return nil, nil
 	}
 	return cloneSandboxRecord(s.records[sandboxID]), nil
 }
 
 func (s *memorySandboxStore) ListSandboxes(_ context.Context, req *ListSandboxesRequest) ([]*SandboxRecord, error) {
-	if s == nil || s.records == nil {
+	if s == nil {
+		return nil, nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.records == nil {
 		return nil, nil
 	}
 	var records []*SandboxRecord
@@ -76,7 +90,12 @@ func (s *memorySandboxStore) ListHardExpiredSandboxes(context.Context, time.Time
 }
 
 func (s *memorySandboxStore) ListPausingSandboxes(_ context.Context, limit int) ([]*SandboxRecord, error) {
-	if s == nil || s.records == nil {
+	if s == nil {
+		return nil, nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.records == nil {
 		return nil, nil
 	}
 	if limit <= 0 {
@@ -96,6 +115,8 @@ func (s *memorySandboxStore) ListPausingSandboxes(_ context.Context, limit int) 
 }
 
 func (s *memorySandboxStore) MarkSandboxDeleted(_ context.Context, sandboxID string, deletedAt time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.records == nil {
 		s.records = make(map[string]*SandboxRecord)
 	}
@@ -114,6 +135,8 @@ func (s *memorySandboxStore) MarkSandboxDeleted(_ context.Context, sandboxID str
 }
 
 func (s *memorySandboxStore) SaveRootFSState(_ context.Context, state *SandboxRootFSState) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.rootFSStates == nil {
 		s.rootFSStates = make(map[string]*SandboxRootFSState)
 	}
@@ -122,24 +145,41 @@ func (s *memorySandboxStore) SaveRootFSState(_ context.Context, state *SandboxRo
 }
 
 func (s *memorySandboxStore) GetLatestRootFSState(_ context.Context, sandboxID string) (*SandboxRootFSState, error) {
-	if s == nil || s.rootFSStates == nil {
+	if s == nil {
+		return nil, nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.rootFSStates == nil {
 		return nil, nil
 	}
 	return cloneSandboxRootFSState(s.rootFSStates[sandboxID]), nil
 }
 
 func (s *memorySandboxStore) WithSandboxLock(ctx context.Context, sandboxID string, fn func(context.Context, SandboxStoreTx, *SandboxRecord) error) error {
-	record, err := s.GetSandbox(ctx, sandboxID)
-	if err != nil {
-		return err
+	if s == nil {
+		return ErrSandboxRecordNotFound
 	}
+	s.mu.Lock()
+	record := cloneSandboxRecord(s.records[sandboxID])
+	s.mu.Unlock()
 	if record == nil {
 		return ErrSandboxRecordNotFound
 	}
 	return fn(ctx, memorySandboxStoreTx{store: s}, record)
 }
 
+func (s *memorySandboxStore) setSandboxStatus(sandboxID, status string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if record := s.records[sandboxID]; record != nil {
+		record.Status = status
+	}
+}
+
 func (t memorySandboxStoreTx) SaveRuntime(_ context.Context, sandboxID, namespace, podName, status string, generation int64, expiresAt, hardExpiresAt time.Time) error {
+	t.store.mu.Lock()
+	defer t.store.mu.Unlock()
 	record := t.store.records[sandboxID]
 	record.CurrentPodNamespace = namespace
 	record.CurrentPodName = podName
@@ -152,6 +192,8 @@ func (t memorySandboxStoreTx) SaveRuntime(_ context.Context, sandboxID, namespac
 }
 
 func (t memorySandboxStoreTx) MarkRuntimePaused(_ context.Context, sandboxID string, generation int64, _ time.Time) error {
+	t.store.mu.Lock()
+	defer t.store.mu.Unlock()
 	record := t.store.records[sandboxID]
 	record.CurrentPodNamespace = ""
 	record.CurrentPodName = ""
@@ -164,7 +206,13 @@ func (t memorySandboxStoreTx) MarkRuntimePaused(_ context.Context, sandboxID str
 }
 
 func (t memorySandboxStoreTx) SaveRootFSState(_ context.Context, state *SandboxRootFSState) error {
-	return t.store.SaveRootFSState(context.Background(), state)
+	t.store.mu.Lock()
+	defer t.store.mu.Unlock()
+	if t.store.rootFSStates == nil {
+		t.store.rootFSStates = make(map[string]*SandboxRootFSState)
+	}
+	t.store.rootFSStates[state.SandboxID] = cloneSandboxRootFSState(state)
+	return nil
 }
 
 func cloneSandboxRecord(record *SandboxRecord) *SandboxRecord {
@@ -342,7 +390,7 @@ func TestResumePausedSandboxRuntimeJoinsResumingRuntime(t *testing.T) {
 
 	go func() {
 		time.Sleep(2 * sandboxLifecycleWaitInterval)
-		store.records["sandbox-a"].Status = SandboxStatusRunning
+		store.setSandboxStatus("sandbox-a", SandboxStatusRunning)
 	}()
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)

--- a/manager/pkg/service/sandbox_service_lifecycle.go
+++ b/manager/pkg/service/sandbox_service_lifecycle.go
@@ -244,7 +244,7 @@ func (s *SandboxService) CompletePausingSandboxRuntime(ctx context.Context, sand
 	pod, err := s.getSandboxPod(ctx, sandboxID)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			return s.markPausingRuntimePaused(ctx, sandboxID, record.RuntimeGeneration)
+			return s.markPausingRuntimePaused(ctx, sandboxID, record.RuntimeGeneration, nil)
 		}
 		return fmt.Errorf("get pod: %w", err)
 	}
@@ -261,7 +261,8 @@ func (s *SandboxService) CompletePausingSandboxRuntime(ctx context.Context, sand
 	if !s.config.CtldEnabled || s.ctldClient == nil {
 		return ErrSandboxCheckpointRequiresCtld
 	}
-	if err := s.saveSandboxRootFSCheckpoint(ctx, pod, record, nil); err != nil {
+	rootFSState, err := s.prepareSandboxRootFSCheckpoint(ctx, pod, record)
+	if err != nil {
 		return err
 	}
 	stillPausing, err := s.sandboxStillPausing(ctx, sandboxID, generation)
@@ -275,7 +276,7 @@ func (s *SandboxService) CompletePausingSandboxRuntime(ctx context.Context, sand
 	if err := s.k8sClient.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{}); err != nil && !k8serrors.IsNotFound(err) {
 		return fmt.Errorf("delete runtime pod: %w", err)
 	}
-	return s.markPausingRuntimePaused(ctx, sandboxID, generation)
+	return s.markPausingRuntimePaused(ctx, sandboxID, generation, rootFSState)
 }
 
 func (s *SandboxService) sandboxStillPausing(ctx context.Context, sandboxID string, generation int64) (bool, error) {
@@ -289,13 +290,18 @@ func (s *SandboxService) sandboxStillPausing(ctx context.Context, sandboxID stri
 	return record != nil && record.Status == SandboxStatusPausing && record.RuntimeGeneration == generation, nil
 }
 
-func (s *SandboxService) markPausingRuntimePaused(ctx context.Context, sandboxID string, generation int64) error {
+func (s *SandboxService) markPausingRuntimePaused(ctx context.Context, sandboxID string, generation int64, rootFSState *SandboxRootFSState) error {
 	if s == nil || s.sandboxStore == nil {
 		return nil
 	}
 	return s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, record *SandboxRecord) error {
 		if record.Status != SandboxStatusPausing || record.RuntimeGeneration != generation {
 			return nil
+		}
+		if rootFSState != nil {
+			if err := tx.SaveRootFSState(lockCtx, rootFSState); err != nil {
+				return err
+			}
 		}
 		return tx.MarkRuntimePaused(lockCtx, sandboxID, generation, s.clock.Now())
 	})

--- a/manager/pkg/service/sandbox_service_restore.go
+++ b/manager/pkg/service/sandbox_service_restore.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
@@ -15,6 +16,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const sandboxLifecycleWaitInterval = 100 * time.Millisecond
+
 // ResumePausedSandboxRuntime creates a new runtime for a paused durable sandbox
 // and restores the latest writable rootfs checkpoint.
 func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandboxID string) (*Sandbox, error) {
@@ -24,79 +27,120 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 
 	var pod *corev1.Pod
 	var record *SandboxRecord
+	var deletingPodRef *sandboxRuntimePodRef
 	claimType := "hot"
-	err := s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, locked *SandboxRecord) error {
-		if locked.Status == SandboxStatusDeleted || !locked.DeletedAt.IsZero() {
-			return k8serrors.NewNotFound(corev1.Resource("sandbox"), sandboxID)
-		}
-		if sandboxHardExpired(locked.HardExpiresAt, s.now()) {
-			return k8serrors.NewNotFound(corev1.Resource("sandbox"), sandboxID)
-		}
-		switch locked.Status {
-		case SandboxStatusStarting, SandboxStatusPausing, SandboxStatusResuming:
-			return k8serrors.NewConflict(corev1.Resource("sandbox"), sandboxID, fmt.Errorf("sandbox lifecycle operation %q is in progress", locked.Status))
-		}
-		record = locked
-
-		existing, getErr := s.getSandboxPod(lockCtx, sandboxID)
-		if getErr == nil {
-			if existing.DeletionTimestamp != nil {
-				return k8serrors.NewConflict(corev1.Resource("pod"), existing.Name, fmt.Errorf("sandbox runtime deletion is still in progress"))
+	restoreNeeded := false
+	for {
+		pod = nil
+		record = nil
+		deletingPodRef = nil
+		restoreNeeded = false
+		err := s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, locked *SandboxRecord) error {
+			if locked.Status == SandboxStatusDeleted || !locked.DeletedAt.IsZero() {
+				return k8serrors.NewNotFound(corev1.Resource("sandbox"), sandboxID)
 			}
-			pod = existing
-			return tx.SaveRuntime(lockCtx, sandboxID, existing.Namespace, existing.Name, s.podToSandboxStatus(existing), runtimeGenerationFromPod(existing), parseRFC3339AnnotationTime(existing.Annotations, controller.AnnotationExpiresAt), parseRFC3339AnnotationTime(existing.Annotations, controller.AnnotationHardExpiresAt))
-		}
-		if getErr != nil && !k8serrors.IsNotFound(getErr) {
-			return fmt.Errorf("get current runtime pod: %w", getErr)
-		}
+			if sandboxHardExpired(locked.HardExpiresAt, s.now()) {
+				return k8serrors.NewNotFound(corev1.Resource("sandbox"), sandboxID)
+			}
+			switch locked.Status {
+			case SandboxStatusPausing:
+				return errSandboxLifecyclePausing
+			case SandboxStatusStarting, SandboxStatusResuming:
+				return errSandboxLifecycleResuming
+			}
+			record = locked
 
-		template, err := s.templateForSandboxRecord(locked)
-		if err != nil {
-			return err
-		}
-		if err := s.enforceActiveSandboxQuota(lockCtx, locked.TeamID); err != nil {
-			return err
-		}
-		if err := s.enforceSandboxCPUQuota(lockCtx, locked.TeamID, template); err != nil {
-			return err
-		}
-		if err := s.enforceSandboxMemoryQuota(lockCtx, locked.TeamID, template); err != nil {
-			return err
-		}
-		generation := locked.RuntimeGeneration + 1
-		req := &ClaimRequest{
-			TeamID:            locked.TeamID,
-			UserID:            locked.UserID,
-			Template:          locked.TemplateID,
-			Config:            &locked.Config,
-			Mounts:            locked.Mounts,
-			SandboxID:         locked.ID,
-			RuntimeGeneration: generation,
-			HardExpiresAt:     locked.HardExpiresAt,
-		}
-		pod, err = s.claimIdlePod(lockCtx, template, req)
-		if err != nil {
-			return fmt.Errorf("claim idle pod: %w", err)
-		}
-		if pod == nil {
-			claimType = "cold"
-			pod, err = s.createNewPod(lockCtx, template, req)
+			existing, getErr := s.getSandboxPod(lockCtx, sandboxID)
+			if getErr == nil {
+				if existing.DeletionTimestamp != nil {
+					deletingPodRef = &sandboxRuntimePodRef{
+						namespace: existing.Namespace,
+						name:      existing.Name,
+					}
+					return errSandboxRuntimeDeleting
+				}
+				pod = existing
+				record = nil
+				return tx.SaveRuntime(lockCtx, sandboxID, existing.Namespace, existing.Name, s.podToSandboxStatus(existing), runtimeGenerationFromPod(existing), parseRFC3339AnnotationTime(existing.Annotations, controller.AnnotationExpiresAt), parseRFC3339AnnotationTime(existing.Annotations, controller.AnnotationHardExpiresAt))
+			}
+			if getErr != nil && !k8serrors.IsNotFound(getErr) {
+				return fmt.Errorf("get current runtime pod: %w", getErr)
+			}
+			if locked.Status != SandboxStatusPaused {
+				return k8serrors.NewConflict(corev1.Resource("sandbox"), sandboxID, fmt.Errorf("sandbox runtime for status %q is not available", locked.Status))
+			}
+
+			template, err := s.templateForSandboxRecord(locked)
 			if err != nil {
-				return fmt.Errorf("create runtime pod: %w", err)
+				return err
 			}
+			if err := s.enforceActiveSandboxQuota(lockCtx, locked.TeamID); err != nil {
+				return err
+			}
+			if err := s.enforceSandboxCPUQuota(lockCtx, locked.TeamID, template); err != nil {
+				return err
+			}
+			if err := s.enforceSandboxMemoryQuota(lockCtx, locked.TeamID, template); err != nil {
+				return err
+			}
+			generation := locked.RuntimeGeneration + 1
+			req := &ClaimRequest{
+				TeamID:            locked.TeamID,
+				UserID:            locked.UserID,
+				Template:          locked.TemplateID,
+				Config:            &locked.Config,
+				Mounts:            locked.Mounts,
+				SandboxID:         locked.ID,
+				RuntimeGeneration: generation,
+				HardExpiresAt:     locked.HardExpiresAt,
+			}
+			pod, err = s.claimIdlePod(lockCtx, template, req)
+			if err != nil {
+				return fmt.Errorf("claim idle pod: %w", err)
+			}
+			if pod == nil {
+				claimType = "cold"
+				pod, err = s.createNewPod(lockCtx, template, req)
+				if err != nil {
+					return fmt.Errorf("create runtime pod: %w", err)
+				}
+			}
+			restoreNeeded = true
+			return tx.SaveRuntime(lockCtx, sandboxID, pod.Namespace, pod.Name, SandboxStatusResuming, generation, parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationExpiresAt), parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationHardExpiresAt))
+		})
+		if err == nil {
+			break
 		}
-		return tx.SaveRuntime(lockCtx, sandboxID, pod.Namespace, pod.Name, SandboxStatusResuming, generation, parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationExpiresAt), parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationHardExpiresAt))
-	})
-	if err != nil {
 		if errors.Is(err, ErrSandboxRecordNotFound) {
 			return nil, k8serrors.NewNotFound(corev1.Resource("sandbox"), sandboxID)
 		}
-		return nil, err
+		switch {
+		case errors.Is(err, errSandboxLifecyclePausing):
+			if err := s.CompletePausingSandboxRuntime(ctx, sandboxID); err != nil {
+				return nil, err
+			}
+			continue
+		case errors.Is(err, errSandboxLifecycleResuming):
+			if err := s.waitForSandboxLifecycleStatusExit(ctx, sandboxID, SandboxStatusStarting, SandboxStatusResuming); err != nil {
+				return nil, err
+			}
+			continue
+		case errors.Is(err, errSandboxRuntimeDeleting):
+			if deletingPodRef == nil {
+				return nil, err
+			}
+			if err := s.waitForSandboxRuntimePodDeletion(ctx, deletingPodRef.namespace, deletingPodRef.name); err != nil {
+				return nil, err
+			}
+			continue
+		default:
+			return nil, err
+		}
 	}
 	if pod == nil {
 		return nil, fmt.Errorf("restore sandbox runtime did not create or find a pod")
 	}
-	if record == nil {
+	if record == nil || !restoreNeeded {
 		return s.GetSandbox(ctx, sandboxID)
 	}
 
@@ -110,6 +154,92 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 		return nil, err
 	}
 	return s.GetSandbox(ctx, sandboxID)
+}
+
+var (
+	errSandboxLifecyclePausing  = errors.New("sandbox lifecycle pause is in progress")
+	errSandboxLifecycleResuming = errors.New("sandbox lifecycle resume is in progress")
+	errSandboxRuntimeDeleting   = errors.New("sandbox runtime pod deletion is in progress")
+)
+
+type sandboxRuntimePodRef struct {
+	namespace string
+	name      string
+}
+
+func (s *SandboxService) waitForSandboxLifecycleStatusExit(ctx context.Context, sandboxID string, statuses ...string) error {
+	if s == nil || s.sandboxStore == nil {
+		return nil
+	}
+	waiting := make(map[string]struct{}, len(statuses))
+	for _, status := range statuses {
+		waiting[status] = struct{}{}
+	}
+	ticker := time.NewTicker(sandboxLifecycleWaitInterval)
+	defer ticker.Stop()
+	for {
+		record, err := s.sandboxStore.GetSandbox(ctx, sandboxID)
+		if err != nil {
+			if errors.Is(err, ErrSandboxRecordNotFound) {
+				return k8serrors.NewNotFound(corev1.Resource("sandbox"), sandboxID)
+			}
+			return err
+		}
+		if record == nil || record.Status == SandboxStatusDeleted || !record.DeletedAt.IsZero() {
+			return k8serrors.NewNotFound(corev1.Resource("sandbox"), sandboxID)
+		}
+		if _, ok := waiting[record.Status]; !ok {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func (s *SandboxService) waitForSandboxRuntimePodDeletion(ctx context.Context, namespace, name string) error {
+	if strings.TrimSpace(namespace) == "" || strings.TrimSpace(name) == "" {
+		return nil
+	}
+	ticker := time.NewTicker(sandboxLifecycleWaitInterval)
+	defer ticker.Stop()
+	for {
+		apiDeleting := false
+		if s != nil && s.k8sClient != nil {
+			pod, err := s.k8sClient.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+			switch {
+			case k8serrors.IsNotFound(err):
+			case err != nil:
+				return err
+			case pod != nil && pod.DeletionTimestamp != nil:
+				apiDeleting = true
+			default:
+				return nil
+			}
+		}
+		if s != nil && s.podLister != nil {
+			pod, err := s.podLister.Pods(namespace).Get(name)
+			if k8serrors.IsNotFound(err) {
+				return nil
+			}
+			if err != nil {
+				return err
+			}
+			if pod != nil && pod.DeletionTimestamp == nil && !apiDeleting {
+				return nil
+			}
+		} else if !apiDeleting {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
 }
 
 func (s *SandboxService) finishRestoredSandboxRuntime(ctx context.Context, pod *corev1.Pod, record *SandboxRecord, claimType string) (*corev1.Pod, error) {

--- a/manager/pkg/service/sandbox_service_rootfs.go
+++ b/manager/pkg/service/sandbox_service_rootfs.go
@@ -23,11 +23,28 @@ const sandboxRootFSContainerName = "procd"
 const sandboxRootFSOperationTimeout = 5 * time.Minute
 
 func (s *SandboxService) saveSandboxRootFSCheckpoint(ctx context.Context, pod *corev1.Pod, record *SandboxRecord, tx SandboxStoreTx) error {
-	if s == nil || !s.config.CtldEnabled || s.ctldClient == nil || pod == nil {
+	state, err := s.prepareSandboxRootFSCheckpoint(ctx, pod, record)
+	if err != nil {
+		return err
+	}
+	if state == nil {
 		return nil
 	}
+	if tx != nil {
+		return tx.SaveRootFSState(ctx, state)
+	}
+	if s.sandboxStore != nil {
+		return s.sandboxStore.SaveRootFSState(ctx, state)
+	}
+	return nil
+}
+
+func (s *SandboxService) prepareSandboxRootFSCheckpoint(ctx context.Context, pod *corev1.Pod, record *SandboxRecord) (*SandboxRootFSState, error) {
+	if s == nil || !s.config.CtldEnabled || s.ctldClient == nil || pod == nil {
+		return nil, nil
+	}
 	if record == nil {
-		return nil
+		return nil, nil
 	}
 	sandboxID := sandboxIDFromPod(pod)
 	if sandboxID == "" {
@@ -41,18 +58,18 @@ func (s *SandboxService) saveSandboxRootFSCheckpoint(ctx context.Context, pod *c
 		teamID = pod.Annotations[controller.AnnotationTeamID]
 	}
 	if strings.TrimSpace(teamID) == "" {
-		return fmt.Errorf("team_id is required to save sandbox rootfs checkpoint")
+		return nil, fmt.Errorf("team_id is required to save sandbox rootfs checkpoint")
 	}
 
 	ctldAddress, err := s.ctldAddressForPod(ctx, pod)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	generation := runtimeGenerationFromPod(pod)
 	parentLayerID := ""
 	expectedHeadLayerID := ""
 	if parentState, err := s.latestRootFSState(ctx, sandboxID); err != nil {
-		return fmt.Errorf("load current rootfs head: %w", err)
+		return nil, fmt.Errorf("load current rootfs head: %w", err)
 	} else if parentState != nil {
 		expectedHeadLayerID = strings.TrimSpace(parentState.LayerID)
 		if squash, reason := s.shouldSquashSandboxRootFSCheckpoint(parentState); squash {
@@ -82,22 +99,16 @@ func (s *SandboxService) saveSandboxRootFSCheckpoint(ctx context.Context, pod *c
 		resp, err = s.ctldClient.SaveRootFSWithTimeout(ctx, ctldAddress, saveReq, sandboxRootFSOperationTimeout)
 	}
 	if err != nil {
-		return fmt.Errorf("save sandbox rootfs checkpoint: %w", rootFSResponseError(err, saveRootFSError(resp)))
+		return nil, fmt.Errorf("save sandbox rootfs checkpoint: %w", rootFSResponseError(err, saveRootFSError(resp)))
 	}
 	state, err := rootFSStateFromSaveResponse(sandboxID, teamID, generation, resp)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	state.LayerID = uuid.NewString()
 	state.ParentLayerID = parentLayerID
 	state.ExpectedHeadLayerID = expectedHeadLayerID
-	if tx != nil {
-		return tx.SaveRootFSState(ctx, state)
-	}
-	if s.sandboxStore != nil {
-		return s.sandboxStore.SaveRootFSState(ctx, state)
-	}
-	return nil
+	return state, nil
 }
 
 func (s *SandboxService) shouldSquashSandboxRootFSCheckpoint(state *SandboxRootFSState) (bool, string) {

--- a/manager/pkg/service/sandbox_service_rootfs_product_test.go
+++ b/manager/pkg/service/sandbox_service_rootfs_product_test.go
@@ -185,6 +185,8 @@ func TestSandboxRootFSProductEnforcesTeamOwnership(t *testing.T) {
 }
 
 func (s *memorySandboxStore) CreateRootFSSnapshot(_ context.Context, req *CreateRootFSSnapshotRequest) (*RootFSSnapshot, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.rootFSSnapshots == nil {
 		s.rootFSSnapshots = make(map[string]*RootFSSnapshot)
 	}
@@ -212,6 +214,8 @@ func (s *memorySandboxStore) CreateRootFSSnapshot(_ context.Context, req *Create
 }
 
 func (s *memorySandboxStore) ListRootFSSnapshots(_ context.Context, req *ListRootFSSnapshotsRequest) ([]*RootFSSnapshot, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	var snapshots []*RootFSSnapshot
 	for _, snapshot := range s.rootFSSnapshots {
 		if snapshot == nil || snapshot.SourceSandboxID != req.SandboxID {
@@ -226,6 +230,8 @@ func (s *memorySandboxStore) ListRootFSSnapshots(_ context.Context, req *ListRoo
 }
 
 func (s *memorySandboxStore) GetRootFSSnapshot(_ context.Context, snapshotID, teamID string) (*RootFSSnapshot, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	snapshot := s.rootFSSnapshots[snapshotID]
 	if snapshot == nil || (teamID != "" && snapshot.TeamID != teamID) {
 		return nil, ErrRootFSSnapshotNotFound
@@ -234,6 +240,8 @@ func (s *memorySandboxStore) GetRootFSSnapshot(_ context.Context, snapshotID, te
 }
 
 func (s *memorySandboxStore) DeleteRootFSSnapshot(_ context.Context, snapshotID, teamID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	snapshot := s.rootFSSnapshots[snapshotID]
 	if snapshot == nil || (teamID != "" && snapshot.TeamID != teamID) {
 		return ErrRootFSSnapshotNotFound
@@ -243,6 +251,8 @@ func (s *memorySandboxStore) DeleteRootFSSnapshot(_ context.Context, snapshotID,
 }
 
 func (s *memorySandboxStore) ForkRootFSFilesystem(_ context.Context, req *ForkRootFSFilesystemRequest) (*RootFSFilesystem, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	sourceState := s.rootFSStates[req.SourceSandboxID]
 	if sourceState == nil || sourceState.LayerID == "" {
 		return nil, ErrRootFSFilesystemNotFound
@@ -278,9 +288,11 @@ func (s *memorySandboxStore) ForkRootFSFilesystem(_ context.Context, req *ForkRo
 }
 
 func (s *memorySandboxStore) RestoreRootFSFromSnapshot(_ context.Context, req *RestoreRootFSFromSnapshotRequest) (*RootFSFilesystem, error) {
-	snapshot, err := s.GetRootFSSnapshot(context.Background(), req.SnapshotID, req.TeamID)
-	if err != nil {
-		return nil, err
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	snapshot := s.rootFSSnapshots[req.SnapshotID]
+	if snapshot == nil || (req.TeamID != "" && snapshot.TeamID != req.TeamID) {
+		return nil, ErrRootFSSnapshotNotFound
 	}
 	target := s.records[req.SandboxID]
 	if target == nil {

--- a/manager/pkg/service/sandbox_service_rootfs_test.go
+++ b/manager/pkg/service/sandbox_service_rootfs_test.go
@@ -202,6 +202,65 @@ func TestPauseSandboxRuntimeSavesChildLayerFromParentHead(t *testing.T) {
 	assert.Equal(t, "sha256:child", state.DiffDigest)
 }
 
+func TestCompletePausingSandboxRuntimeDoesNotCommitStaleCheckpoint(t *testing.T) {
+	store := &memorySandboxStore{
+		records: map[string]*SandboxRecord{
+			"sandbox-1": {
+				ID:                "sandbox-1",
+				TeamID:            "team-1",
+				RuntimeGeneration: 3,
+				Status:            SandboxStatusPausing,
+			},
+		},
+	}
+	ctld := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/rootfs/save", r.URL.Path)
+		store.records["sandbox-1"].Status = SandboxStatusRunning
+		_ = json.NewEncoder(w).Encode(ctldapi.SaveRootFSResponse{
+			Info: ctldapi.RootFSInfo{
+				Runtime:             "runc",
+				RuntimeHandler:      "io.containerd.runc.v2",
+				BaseImageRef:        "docker.io/library/busybox:1.36",
+				BaseImageDigest:     "sha256:base",
+				Snapshotter:         "overlayfs",
+				SnapshotParent:      "parent-1",
+				SnapshotParentChain: []string{"parent-1", "parent-0"},
+			},
+			Descriptor: ctldapi.RootFSDiffDescriptor{
+				MediaType: "application/vnd.oci.image.layer.v1.tar",
+				Digest:    "sha256:stale",
+				Size:      123,
+				ObjectKey: "sandbox-rootfs/team-1/sandbox-1/3/sha256/stale.tar",
+			},
+		})
+	}))
+	defer ctld.Close()
+	ctldURL, ctldPort := parsedTestServer(t, ctld.URL)
+
+	pod := rootFSTestPod("pod-1", "sandbox-1", "team-1")
+	pod.Status.HostIP = ctldURL.Hostname()
+	k8sClient := fake.NewSimpleClientset(pod)
+	deleteCalled := false
+	k8sClient.PrependReactor("delete", "pods", func(action ktesting.Action) (bool, runtime.Object, error) {
+		deleteCalled = true
+		return true, nil, nil
+	})
+	svc := &SandboxService{
+		k8sClient:    k8sClient,
+		podLister:    newTestPodLister(t, pod),
+		sandboxStore: store,
+		ctldClient:   NewCtldClient(CtldClientConfig{Timeout: time.Second}),
+		config:       SandboxServiceConfig{CtldEnabled: true, CtldPort: ctldPort},
+		clock:        systemTime{},
+		logger:       zap.NewNop(),
+	}
+
+	require.NoError(t, svc.CompletePausingSandboxRuntime(context.Background(), "sandbox-1"))
+	assert.False(t, deleteCalled)
+	assert.Nil(t, store.rootFSStates["sandbox-1"])
+	assert.Equal(t, SandboxStatusRunning, store.records["sandbox-1"].Status)
+}
+
 func TestPauseSandboxRuntimeSquashesRootFSWhenChainIsTooDeep(t *testing.T) {
 	var savedReq ctldapi.SaveRootFSRequest
 	ctld := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/manager/pkg/service/sandbox_service_rootfs_test.go
+++ b/manager/pkg/service/sandbox_service_rootfs_test.go
@@ -215,7 +215,7 @@ func TestCompletePausingSandboxRuntimeDoesNotCommitStaleCheckpoint(t *testing.T)
 	}
 	ctld := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "/api/v1/rootfs/save", r.URL.Path)
-		store.records["sandbox-1"].Status = SandboxStatusRunning
+		store.setSandboxStatus("sandbox-1", SandboxStatusRunning)
 		_ = json.NewEncoder(w).Encode(ctldapi.SaveRootFSResponse{
 			Info: ctldapi.RootFSInfo{
 				Runtime:             "runc",


### PR DESCRIPTION
## Summary
- make runtime resume join in-progress pausing/resuming states instead of surfacing lifecycle conflicts to callers
- wait for old runtime pod deletion before creating the next generation, avoiding transient 409/503 during auto-resume paths
- fence rootfs checkpoint commits with the pause generation inside the sandbox lock
- document that file/context/public/SSH runtime access paths do not need to special-case pausing/resuming

Fixes #598

## Tests
- `go test ./manager/pkg/service -run 'TestResumePausedSandboxRuntime|TestPauseSandboxRuntime|TestCompletePausingSandboxRuntimeDoesNotCommitStaleCheckpoint'`
- `go test ./manager/pkg/service ./manager/pkg/http ./cluster-gateway/pkg/http ./pkg/ctldapi`
- Remote kind: deployed final image `sha256:7aa0d1488ff77a83a55fffd603fd8dc029a2ee9ab389bc3867a2ae2512b9392c`, confirmed `Sandbox0Infra/fullmode` Ready
- Remote HTTP validation: claim sandbox, write file, start pause, immediate file read returned `200`, context command returned `final-before-pause:http-ok`
- Remote SDK validation: `sdk-go` claim/write/read, start pause, immediate `ReadFile` returned content, `Cmd` returned `sdk-final-before-pause:sdk-ok`, explicit resume succeeded
