### PR TITLE
docs: fix README architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ export SANDBOX0_TOKEN="$(s0 apikey create --name sdk-quickstart --role developer
 
 For Sandbox0 Cloud, SDKs default to `https://api.sandbox0.ai`. Set `SANDBOX0_BASE_URL` only when connecting to a self-hosted or private deployment.
 
-Install an SDK.
+Install an SDK. The Python SDK requires Python 3.9 or later, the TypeScript SDK requires Node.js 18 or later, and the Go SDK requires Go 1.25 or later.
 
 ```bash
 # Python
@@ -163,19 +163,18 @@ Sandboxing reduces blast radius and gives policy a real enforcement point. It do
 ```mermaid
 flowchart TB
     client["Client, SDK, CLI, or agent platform"] --> cgw["cluster-gateway"]
-    client --> rgw["regional-gateway"]
-    rgw --> sched["scheduler"]
-    sched --> cgw
     cgw --> mgr["manager"]
     cgw --> pod["sandbox pod with procd"]
     mgr --> pod
+    mgr --> ctld["ctld (node-local)"]
     mgr <--> netd["netd (optional)"]
+    pod --> ctld
     pod --> sp["storage-proxy (optional)"]
     mgr --> pg[("PostgreSQL")]
     mgr --> s3[("S3-compatible storage")]
-    sp --> pg[("PostgreSQL")]
-    sp --> s3[("S3-compatible storage")]
-    rgw --> pg
+    ctld --> s3
+    sp --> pg
+    sp --> s3
 ```
 
 Sandbox0 separates region-scoped control-plane services from cluster-scoped data-plane services. In single-cluster mode, `cluster-gateway` can act as the entrypoint. In multi-cluster mode, `regional-gateway` and `scheduler` select and route to one of the data-plane clusters in the same region.
@@ -183,7 +182,7 @@ Sandbox0 separates region-scoped control-plane services from cluster-scoped data
 | Layer | Components | Responsibility |
 | --- | --- | --- |
 | Control plane | Optional `regional-gateway`, optional `scheduler` | Tenant/API key management, cluster selection, internal routing, template distribution |
-| Data plane | `cluster-gateway`, `manager`, optional `storage-proxy`, optional `netd` | Sandbox lifecycle, process/file APIs, volume storage, network enforcement |
+| Data plane | `cluster-gateway`, `manager`, `ctld`, optional `storage-proxy`, optional `netd` | Sandbox lifecycle, rootfs checkpoints, process/file APIs, volume storage, network enforcement |
 | In-pod runtime | `procd` | PID 1 inside each sandbox pod, process abstraction, file I/O, volume mount operations |
 | Storage | PostgreSQL plus S3-compatible object storage | Metadata, usage truth, events, rootfs/volume data |
 


### PR DESCRIPTION
## Summary
- remove `regional-gateway` and `scheduler` from the README self-hosted architecture diagram
- add node-local `ctld` to the diagram and data-plane component table
- document SDK runtime prerequisites after remote validation found the default remote Python was too old for the Python SDK

## Validation
- `git diff --check`
- README self-hosted architecture check: no `regional-gateway` / `scheduler` in the diagram, `ctld` present, no `managed-agents` mention
- Remote Aliyun Singapore kind environment: `Sandbox0Infra` reached `Ready 9/9`; `ctld`, `manager`, `cluster-gateway`, `storage-proxy`, and `netd` pods were Running
- Ran the README Python SDK snippet against `http://localhost:30080` with Python 3.11 and `sandbox0` from PyPI; it claimed a `default` sandbox, preserved REPL state, printed `42`, and executed `/bin/sh -c 'pwd && ls -la'`
