### PR TITLE
Invalidate netd egress auth cache on credential rotation

### DIFF
--- a/.github/actions/prepare-infra/action.yml
+++ b/.github/actions/prepare-infra/action.yml
@@ -69,40 +69,16 @@ runs:
         echo "Building infra image..."
         make docker-build-local
 
-    - name: Restore postgres image cache
-      id: infra-postgres-cache
-      uses: actions/cache/restore@v4
-      with:
-        path: ${{ runner.temp }}/infra-image-cache/infra-image-postgres-16-alpine.tar
-        key: infra-image-${{ runner.os }}-${{ inputs.cache-key-suffix }}-postgres-16-alpine
-
-    - name: Restore rustfs image cache
-      id: infra-rustfs-cache
-      uses: actions/cache/restore@v4
-      with:
-        path: ${{ runner.temp }}/infra-image-cache/infra-image-rustfs-1.0.0-alpha.79.tar
-        key: infra-image-${{ runner.os }}-${{ inputs.cache-key-suffix }}-rustfs-1.0.0-alpha.79
-
-    - name: Restore registry image cache
-      id: infra-registry-cache
-      uses: actions/cache/restore@v4
-      with:
-        path: ${{ runner.temp }}/infra-image-cache/infra-image-registry-2.8.3.tar
-        key: infra-image-${{ runner.os }}-${{ inputs.cache-key-suffix }}-registry-2.8.3
-
-    - name: Restore template image cache
-      id: infra-template-cache
-      uses: actions/cache/restore@v4
-      with:
-        path: ${{ runner.temp }}/infra-image-cache/infra-image-template-default-v0.2.0.tar
-        key: infra-image-${{ runner.os }}-${{ inputs.cache-key-suffix }}-template-default-v0.2.0
-
-    - name: Restore SSH fixture image cache
-      id: infra-ssh-fixture-cache
-      uses: actions/cache/restore@v4
-      with:
-        path: ${{ runner.temp }}/infra-image-cache/infra-image-e2e-openssh-server-68b605929e83.tar
-        key: infra-image-${{ runner.os }}-${{ inputs.cache-key-suffix }}-e2e-openssh-server-68b605929e83
+    - name: Load infra image to Kind
+      shell: bash
+      run: |
+        kind load docker-image sandbox0ai/infra:latest --name ${{ inputs.kind-cluster-name }}
+        docker image rm sandbox0ai/infra:latest 2>/dev/null || true
+        docker builder prune -af || true
+        echo "=== df -h after infra image load ==="
+        df -h
+        echo "=== docker system df after infra image load ==="
+        docker system df || true
 
     - name: Prepare image cache and temp directories
       shell: bash
@@ -110,65 +86,21 @@ runs:
         mkdir -p "${RUNNER_TEMP}/infra-image-cache" "${RUNNER_TEMP}/kind-tmp"
         echo "TMPDIR=${RUNNER_TEMP}/kind-tmp" >> "$GITHUB_ENV"
 
-    - name: Pull or load dependency images
-      shell: bash
-      run: |
-        image_cache_dir="${RUNNER_TEMP}/infra-image-cache"
-
-        ensure_image() {
-          local image="$1"
-          local archive="$2"
-          if [ -f "$archive" ]; then
-            echo "Loading cached image: $image"
-            docker load -i "$archive"
-          else
-            echo "Pulling image: $image"
-            docker pull "$image"
-            docker save -o "$archive" "$image"
-          fi
-        }
-
-        ensure_image "postgres:16-alpine" "${image_cache_dir}/infra-image-postgres-16-alpine.tar"
-        ensure_image "rustfs/rustfs:1.0.0-alpha.79" "${image_cache_dir}/infra-image-rustfs-1.0.0-alpha.79.tar"
-        ensure_image "registry:2.8.3" "${image_cache_dir}/infra-image-registry-2.8.3.tar"
-        ensure_image "sandbox0ai/otemplates:default-v0.2.0" "${image_cache_dir}/infra-image-template-default-v0.2.0.tar"
-
-        ssh_fixture_archive="${image_cache_dir}/infra-image-e2e-openssh-server-68b605929e83.tar"
-        ssh_fixture_source="lscr.io/linuxserver/openssh-server@sha256:68b605929e83b2efe000da09269688f6d82a44579e8a18e2d9e8c8d272917cf7"
-        ssh_fixture_image="sandbox0ai/e2e-openssh-server:68b605929e83"
-        if [ -f "${ssh_fixture_archive}" ]; then
-          echo "Loading cached image: ${ssh_fixture_image}"
-          docker load -i "${ssh_fixture_archive}"
-        else
-          echo "Pulling image: ${ssh_fixture_source}"
-          docker pull "${ssh_fixture_source}"
-          docker tag "${ssh_fixture_source}" "${ssh_fixture_image}"
-          docker save -o "${ssh_fixture_archive}" "${ssh_fixture_image}"
-        fi
-
-    - name: Load Image to Kind
-      shell: bash
-      run: |
-        archive="${RUNNER_TEMP}/infra-image-cache/infra-image-sandbox0ai-infra-latest.tar"
-        docker save -o "${archive}" sandbox0ai/infra:latest
-        kind load image-archive "${archive}" --name ${{ inputs.kind-cluster-name }}
-
-    - name: Load dependency images to Kind
-      shell: bash
-      run: |
-        image_cache_dir="${RUNNER_TEMP}/infra-image-cache"
-        kind load image-archive "${image_cache_dir}/infra-image-postgres-16-alpine.tar" --name ${{ inputs.kind-cluster-name }}
-        kind load image-archive "${image_cache_dir}/infra-image-rustfs-1.0.0-alpha.79.tar" --name ${{ inputs.kind-cluster-name }}
-        kind load image-archive "${image_cache_dir}/infra-image-registry-2.8.3.tar" --name ${{ inputs.kind-cluster-name }}
-        kind load image-archive "${image_cache_dir}/infra-image-template-default-v0.2.0.tar" --name ${{ inputs.kind-cluster-name }}
-        kind load image-archive "${image_cache_dir}/infra-image-e2e-openssh-server-68b605929e83.tar" --name ${{ inputs.kind-cluster-name }}
-
-    - name: Save shared infra build cache
-      uses: ./.github/actions/save-infra-build-cache
+    - name: Restore postgres image cache
+      id: infra-postgres-cache
+      uses: actions/cache/restore@v4
       with:
-        infra-dir: ${{ inputs.infra-dir }}
-        cache-key-suffix: ${{ inputs.cache-key-suffix }}
-        cache-hit: ${{ steps.infra-build-cache.outputs.cache-hit }}
+        path: ${{ runner.temp }}/infra-image-cache/infra-image-postgres-16-alpine.tar
+        key: infra-image-${{ runner.os }}-${{ inputs.cache-key-suffix }}-postgres-16-alpine
+
+    - name: Create postgres image archive
+      if: steps.infra-postgres-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        archive="${RUNNER_TEMP}/infra-image-cache/infra-image-postgres-16-alpine.tar"
+        docker pull postgres:16-alpine
+        docker save -o "${archive}" postgres:16-alpine
+        docker image rm postgres:16-alpine 2>/dev/null || true
 
     - name: Save postgres image cache
       if: steps.infra-postgres-cache.outputs.cache-hit != 'true'
@@ -177,12 +109,58 @@ runs:
         path: ${{ runner.temp }}/infra-image-cache/infra-image-postgres-16-alpine.tar
         key: infra-image-${{ runner.os }}-${{ inputs.cache-key-suffix }}-postgres-16-alpine
 
+    - name: Load postgres image to Kind
+      shell: bash
+      run: |
+        archive="${RUNNER_TEMP}/infra-image-cache/infra-image-postgres-16-alpine.tar"
+        kind load image-archive "${archive}" --name ${{ inputs.kind-cluster-name }}
+        rm -f "${archive}"
+
+    - name: Restore rustfs image cache
+      id: infra-rustfs-cache
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ runner.temp }}/infra-image-cache/infra-image-rustfs-1.0.0-alpha.79.tar
+        key: infra-image-${{ runner.os }}-${{ inputs.cache-key-suffix }}-rustfs-1.0.0-alpha.79
+
+    - name: Create rustfs image archive
+      if: steps.infra-rustfs-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        archive="${RUNNER_TEMP}/infra-image-cache/infra-image-rustfs-1.0.0-alpha.79.tar"
+        docker pull rustfs/rustfs:1.0.0-alpha.79
+        docker save -o "${archive}" rustfs/rustfs:1.0.0-alpha.79
+        docker image rm rustfs/rustfs:1.0.0-alpha.79 2>/dev/null || true
+
     - name: Save rustfs image cache
       if: steps.infra-rustfs-cache.outputs.cache-hit != 'true'
       uses: actions/cache/save@v4
       with:
         path: ${{ runner.temp }}/infra-image-cache/infra-image-rustfs-1.0.0-alpha.79.tar
         key: infra-image-${{ runner.os }}-${{ inputs.cache-key-suffix }}-rustfs-1.0.0-alpha.79
+
+    - name: Load rustfs image to Kind
+      shell: bash
+      run: |
+        archive="${RUNNER_TEMP}/infra-image-cache/infra-image-rustfs-1.0.0-alpha.79.tar"
+        kind load image-archive "${archive}" --name ${{ inputs.kind-cluster-name }}
+        rm -f "${archive}"
+
+    - name: Restore registry image cache
+      id: infra-registry-cache
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ runner.temp }}/infra-image-cache/infra-image-registry-2.8.3.tar
+        key: infra-image-${{ runner.os }}-${{ inputs.cache-key-suffix }}-registry-2.8.3
+
+    - name: Create registry image archive
+      if: steps.infra-registry-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        archive="${RUNNER_TEMP}/infra-image-cache/infra-image-registry-2.8.3.tar"
+        docker pull registry:2.8.3
+        docker save -o "${archive}" registry:2.8.3
+        docker image rm registry:2.8.3 2>/dev/null || true
 
     - name: Save registry image cache
       if: steps.infra-registry-cache.outputs.cache-hit != 'true'
@@ -191,12 +169,61 @@ runs:
         path: ${{ runner.temp }}/infra-image-cache/infra-image-registry-2.8.3.tar
         key: infra-image-${{ runner.os }}-${{ inputs.cache-key-suffix }}-registry-2.8.3
 
+    - name: Load registry image to Kind
+      shell: bash
+      run: |
+        archive="${RUNNER_TEMP}/infra-image-cache/infra-image-registry-2.8.3.tar"
+        kind load image-archive "${archive}" --name ${{ inputs.kind-cluster-name }}
+        rm -f "${archive}"
+
+    - name: Restore template image cache
+      id: infra-template-cache
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ runner.temp }}/infra-image-cache/infra-image-template-default-v0.2.0.tar
+        key: infra-image-${{ runner.os }}-${{ inputs.cache-key-suffix }}-template-default-v0.2.0
+
+    - name: Create template image archive
+      if: steps.infra-template-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        archive="${RUNNER_TEMP}/infra-image-cache/infra-image-template-default-v0.2.0.tar"
+        docker pull sandbox0ai/otemplates:default-v0.2.0
+        docker save -o "${archive}" sandbox0ai/otemplates:default-v0.2.0
+        docker image rm sandbox0ai/otemplates:default-v0.2.0 2>/dev/null || true
+
     - name: Save template image cache
       if: steps.infra-template-cache.outputs.cache-hit != 'true'
       uses: actions/cache/save@v4
       with:
         path: ${{ runner.temp }}/infra-image-cache/infra-image-template-default-v0.2.0.tar
         key: infra-image-${{ runner.os }}-${{ inputs.cache-key-suffix }}-template-default-v0.2.0
+
+    - name: Load template image to Kind
+      shell: bash
+      run: |
+        archive="${RUNNER_TEMP}/infra-image-cache/infra-image-template-default-v0.2.0.tar"
+        kind load image-archive "${archive}" --name ${{ inputs.kind-cluster-name }}
+        rm -f "${archive}"
+
+    - name: Restore SSH fixture image cache
+      id: infra-ssh-fixture-cache
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ runner.temp }}/infra-image-cache/infra-image-e2e-openssh-server-68b605929e83.tar
+        key: infra-image-${{ runner.os }}-${{ inputs.cache-key-suffix }}-e2e-openssh-server-68b605929e83
+
+    - name: Create SSH fixture image archive
+      if: steps.infra-ssh-fixture-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        archive="${RUNNER_TEMP}/infra-image-cache/infra-image-e2e-openssh-server-68b605929e83.tar"
+        source="lscr.io/linuxserver/openssh-server@sha256:68b605929e83b2efe000da09269688f6d82a44579e8a18e2d9e8c8d272917cf7"
+        image="sandbox0ai/e2e-openssh-server:68b605929e83"
+        docker pull "${source}"
+        docker tag "${source}" "${image}"
+        docker save -o "${archive}" "${image}"
+        docker image rm "${image}" "${source}" 2>/dev/null || true
 
     - name: Save SSH fixture image cache
       if: steps.infra-ssh-fixture-cache.outputs.cache-hit != 'true'
@@ -205,10 +232,24 @@ runs:
         path: ${{ runner.temp }}/infra-image-cache/infra-image-e2e-openssh-server-68b605929e83.tar
         key: infra-image-${{ runner.os }}-${{ inputs.cache-key-suffix }}-e2e-openssh-server-68b605929e83
 
-    - name: Free image archives after Kind load
+    - name: Load SSH fixture image to Kind
       shell: bash
       run: |
-        rm -f "${RUNNER_TEMP}/infra-image-cache/"*.tar
+        archive="${RUNNER_TEMP}/infra-image-cache/infra-image-e2e-openssh-server-68b605929e83.tar"
+        kind load image-archive "${archive}" --name ${{ inputs.kind-cluster-name }}
+        rm -f "${archive}"
+
+    - name: Save shared infra build cache
+      uses: ./.github/actions/save-infra-build-cache
+      with:
+        infra-dir: ${{ inputs.infra-dir }}
+        cache-key-suffix: ${{ inputs.cache-key-suffix }}
+        cache-hit: ${{ steps.infra-build-cache.outputs.cache-hit }}
+
+    - name: Final disk diagnostics
+      shell: bash
+      run: |
+        rm -f "${RUNNER_TEMP}/infra-image-cache/"*.tar 2>/dev/null || true
         docker image rm \
           sandbox0ai/infra:latest \
           postgres:16-alpine \

--- a/docs/credential/egress-auth/page.mdx
+++ b/docs/credential/egress-auth/page.mdx
@@ -45,7 +45,9 @@ In this example, `{{ .token }}` refers to the `token` key inside a `static_heade
 
 Runtime egress auth resolution is cached by netd, not by manager. Manager resolves the current sandbox binding from PostgreSQL and returns an `expiresAt` timestamp. netd reuses that resolved material until `expiresAt`, then asks manager again.
 
-The default resolved-material lifetime is 5 minutes. Set `cachePolicy.ttl` on a binding when that binding needs a shorter or longer cache window. This TTL is also the normal propagation bound for credential source rotation: after `PUT /api/v1/credential-sources/{'{name}'}`, already-claimed sandboxes use the new source version once their netd cache entry expires.
+Credential source rotation actively invalidates cached resolved material on netd instances. After `PUT /api/v1/credential-sources/{'{name}'}`, already-claimed sandboxes should use the new source version on the next matching egress resolve. If realtime invalidation delivery is interrupted by netd, manager, or database restarts, cache expiry remains the fallback consistency bound.
+
+The default resolved-material lifetime is 5 minutes. Set `cachePolicy.ttl` on a binding when that binding needs a shorter or longer fallback cache window.
 
 ## Placeholder Substitution
 

--- a/docs/credential/sources/page.mdx
+++ b/docs/credential/sources/page.mdx
@@ -211,7 +211,7 @@ console.log(source.name, source.currentVersion, source.status);`
 
 Use `PUT /api/v1/credential-sources/{name}` to replace the source contents while keeping the same source name and resolver kind. Existing bindings continue to point at that source name.
 
-Sources are reusable. Rotate the source once, then keep bindings and credential rules stable by continuing to reference the same `sourceRef`. Already-claimed sandboxes pick up the new source version after their local resolved-material cache expires. By default that propagation bound is 5 minutes, or the binding's `cachePolicy.ttl` when set.
+Sources are reusable. Rotate the source once, then keep bindings and credential rules stable by continuing to reference the same `sourceRef`. Already-claimed sandboxes pick up the new source version through realtime netd cache invalidation. If invalidation delivery is interrupted by a restart or database notification outage, the binding's resolved-material cache TTL remains the fallback consistency bound. The default TTL is 5 minutes, or the binding's `cachePolicy.ttl` when set.
 
 <Endpoint method="PUT">
 /api/v1/credential-sources/{'{name}'}

--- a/docs/self-hosted/configuration/page.mdx
+++ b/docs/self-hosted/configuration/page.mdx
@@ -312,7 +312,7 @@ When `spec.credentialVault` is enabled, manager stores newly written credential 
 
 ### Egress Auth Resolve TTL
 
-netd caches resolved egress auth material until the `expiresAt` timestamp returned by manager. Manager does not keep an additional resolved-material cache. The default lifetime is 5 minutes and is also the normal credential rotation propagation bound for already-claimed sandboxes.
+netd caches resolved egress auth material until the `expiresAt` timestamp returned by manager. Manager does not keep an additional resolved-material cache. Credential source rotation actively invalidates affected netd cache entries, so already-claimed sandboxes normally use the rotated source on their next matching egress resolve. The default lifetime is 5 minutes, and the TTL remains the fallback consistency bound if realtime invalidation delivery is interrupted.
 
 Set `spec.services.manager.config.egressAuthDefaultResolveTtl` when you want a different platform default. Individual bindings can override it with `network.credentialBindings[*].cachePolicy.ttl`.
 

--- a/netd/pkg/daemon/daemon.go
+++ b/netd/pkg/daemon/daemon.go
@@ -228,6 +228,9 @@ func (d *Daemon) runNetd(ctx context.Context, cancel context.CancelFunc, proxyEx
 		return err
 	}
 	d.proxyServer = proxyServer
+	if d.cfg.EgressAuthResolverURL != "" && meteringPool != nil {
+		startCredentialSourceRotationListener(ctx, meteringPool, d.logger, proxyServer)
+	}
 	proxyServer.Start(ctx)
 	if proxyExitCh != nil {
 		go func() {

--- a/netd/pkg/daemon/egress_auth_invalidation_listener.go
+++ b/netd/pkg/daemon/egress_auth_invalidation_listener.go
@@ -1,0 +1,110 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/sandbox0-ai/sandbox0/netd/pkg/proxy"
+	"github.com/sandbox0-ai/sandbox0/pkg/pubsub"
+	"go.uber.org/zap"
+)
+
+func startCredentialSourceRotationListener(ctx context.Context, pool *pgxpool.Pool, logger *zap.Logger, proxyServer *proxy.Server) {
+	if pool == nil || proxyServer == nil {
+		return
+	}
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
+	go func() {
+		backoff := time.Second
+		for {
+			if ctx.Err() != nil {
+				return
+			}
+
+			if err := listenCredentialSourceRotationsOnce(ctx, pool, logger, proxyServer); err != nil {
+				if ctx.Err() != nil {
+					return
+				}
+				logger.Warn("Credential source rotation listener stopped, retrying",
+					zap.Error(err),
+					zap.Duration("backoff", backoff),
+				)
+				timer := time.NewTimer(backoff)
+				select {
+				case <-ctx.Done():
+					timer.Stop()
+					return
+				case <-timer.C:
+				}
+				if backoff < 10*time.Second {
+					backoff *= 2
+				}
+				continue
+			}
+			backoff = time.Second
+		}
+	}()
+}
+
+func listenCredentialSourceRotationsOnce(ctx context.Context, pool *pgxpool.Pool, logger *zap.Logger, proxyServer *proxy.Server) error {
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		return fmt.Errorf("acquire listen connection: %w", err)
+	}
+	defer conn.Release()
+
+	if _, err := conn.Exec(ctx, "LISTEN "+pubsub.CredentialSourceRotationChannel); err != nil {
+		return fmt.Errorf("listen: %w", err)
+	}
+
+	logger.Info("Credential source rotation listener started")
+	for {
+		notification, err := conn.Conn().WaitForNotification(ctx)
+		if err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			return fmt.Errorf("wait for notification: %w", err)
+		}
+		if notification.Channel != pubsub.CredentialSourceRotationChannel {
+			continue
+		}
+
+		var event pubsub.CredentialSourceRotatedEvent
+		if err := json.Unmarshal([]byte(notification.Payload), &event); err != nil {
+			logger.Warn("Failed to decode credential source rotation event", zap.Error(err))
+			continue
+		}
+		if !validCredentialSourceRotationEvent(event) {
+			logger.Warn("Invalid credential source rotation event payload",
+				zap.String("team_id", event.TeamID),
+				zap.Int64("source_id", event.SourceID),
+				zap.String("source_ref", event.SourceRef),
+				zap.Int64("source_version", event.SourceVersion),
+			)
+			continue
+		}
+
+		removed := proxyServer.InvalidateEgressAuthSource(event.TeamID, event.SourceID, event.SourceRef, event.SourceVersion)
+		logger.Info("Invalidated egress auth cache for credential source rotation",
+			zap.String("team_id", event.TeamID),
+			zap.Int64("source_id", event.SourceID),
+			zap.String("source_ref", event.SourceRef),
+			zap.Int64("source_version", event.SourceVersion),
+			zap.Int("removed_entries", removed),
+		)
+	}
+}
+
+func validCredentialSourceRotationEvent(event pubsub.CredentialSourceRotatedEvent) bool {
+	return strings.TrimSpace(event.TeamID) != "" &&
+		(event.SourceID > 0 || strings.TrimSpace(event.SourceRef) != "") &&
+		event.SourceVersion > 0
+}

--- a/netd/pkg/proxy/egress_auth.go
+++ b/netd/pkg/proxy/egress_auth.go
@@ -65,6 +65,8 @@ type egressAuthResolver interface {
 type egressAuthCache interface {
 	Get(egressAuthCacheKey) (*egressauth.ResolveResponse, bool)
 	Put(egressAuthCacheKey, *egressauth.ResolveResponse)
+	IsStale(*egressauth.ResolveResponse) bool
+	InvalidateSource(teamID string, sourceID int64, sourceRef string, sourceVersion int64) int
 }
 
 type egressAuthCacheKey struct {
@@ -76,10 +78,17 @@ type egressAuthCacheKey struct {
 	Protocol        string
 }
 
+type egressAuthSourceKey struct {
+	TeamID    string
+	SourceID  int64
+	SourceRef string
+}
+
 type memoryEgressAuthCache struct {
-	mu      sync.RWMutex
-	entries map[egressAuthCacheKey]*egressauth.ResolveResponse
-	now     func() time.Time
+	mu               sync.RWMutex
+	entries          map[egressAuthCacheKey]*egressauth.ResolveResponse
+	sourceWatermarks map[egressAuthSourceKey]int64
+	now              func() time.Time
 }
 
 type noopEgressAuthResolver struct{}
@@ -90,6 +99,7 @@ var errEgressAuthResolverUnconfigured = errors.New("egress auth resolver is not 
 var errEgressAuthDirectiveUnsupported = errors.New("egress auth directives unsupported by adapter")
 var errEgressAuthMaterialUnavailable = errors.New("egress auth material unavailable")
 var errEgressAuthDirectiveInvalid = errors.New("egress auth directive invalid")
+var errEgressAuthStaleResolvedMaterial = errors.New("egress auth resolved material is older than known credential source version")
 
 func WithEgressAuthResolver(resolver egressAuthResolver) ServerOption {
 	return func(s *Server) {
@@ -125,7 +135,8 @@ func WithUpstreamTLSConfig(cfg *tls.Config) ServerOption {
 
 func newMemoryEgressAuthCache() *memoryEgressAuthCache {
 	return &memoryEgressAuthCache{
-		entries: make(map[egressAuthCacheKey]*egressauth.ResolveResponse),
+		entries:          make(map[egressAuthCacheKey]*egressauth.ResolveResponse),
+		sourceWatermarks: make(map[egressAuthSourceKey]int64),
 		now: func() time.Time {
 			return time.Now().UTC()
 		},
@@ -136,20 +147,21 @@ func (c *memoryEgressAuthCache) Get(key egressAuthCacheKey) (*egressauth.Resolve
 	if c == nil {
 		return nil, false
 	}
-	c.mu.RLock()
+	c.mu.Lock()
 	entry := c.entries[key]
-	c.mu.RUnlock()
 	if entry == nil {
+		c.mu.Unlock()
 		return nil, false
 	}
-	if entry.ExpiresAt != nil && !entry.ExpiresAt.After(c.now()) {
-		c.mu.Lock()
+	if egressAuthCacheEntryExpired(entry, c.now()) || c.responseStaleLocked(entry) {
 		delete(c.entries, key)
 		proxyMetrics.SetEgressAuthCacheEntries(len(c.entries))
 		c.mu.Unlock()
 		return nil, false
 	}
-	return cloneResolveResponse(entry), true
+	cloned := cloneResolveResponse(entry)
+	c.mu.Unlock()
+	return cloned, true
 }
 
 func (c *memoryEgressAuthCache) Put(key egressAuthCacheKey, value *egressauth.ResolveResponse) {
@@ -157,9 +169,129 @@ func (c *memoryEgressAuthCache) Put(key egressAuthCacheKey, value *egressauth.Re
 		return
 	}
 	c.mu.Lock()
+	if c.responseStaleLocked(value) {
+		c.mu.Unlock()
+		return
+	}
 	c.entries[key] = cloneResolveResponse(value)
 	proxyMetrics.SetEgressAuthCacheEntries(len(c.entries))
 	c.mu.Unlock()
+}
+
+func (c *memoryEgressAuthCache) IsStale(value *egressauth.ResolveResponse) bool {
+	if c == nil || value == nil {
+		return false
+	}
+	c.mu.RLock()
+	stale := c.responseStaleLocked(value)
+	c.mu.RUnlock()
+	return stale
+}
+
+func (c *memoryEgressAuthCache) InvalidateSource(teamID string, sourceID int64, sourceRef string, sourceVersion int64) int {
+	if c == nil {
+		return 0
+	}
+	sourceKey, ok := egressAuthSourceKeyFromValues(teamID, sourceID, sourceRef)
+	if !ok {
+		return 0
+	}
+
+	c.mu.Lock()
+	if sourceVersion > c.sourceWatermarks[sourceKey] {
+		c.sourceWatermarks[sourceKey] = sourceVersion
+	}
+	removed := 0
+	for key, entry := range c.entries {
+		if !egressAuthSourceMatches(entry.Source, sourceKey) {
+			continue
+		}
+		if egressAuthSourceVersionBefore(entry.Source, sourceVersion) {
+			delete(c.entries, key)
+			removed++
+		}
+	}
+	if removed > 0 {
+		proxyMetrics.SetEgressAuthCacheEntries(len(c.entries))
+	}
+	c.mu.Unlock()
+	return removed
+}
+
+func egressAuthCacheEntryExpired(entry *egressauth.ResolveResponse, now time.Time) bool {
+	return entry != nil && entry.ExpiresAt != nil && !entry.ExpiresAt.After(now)
+}
+
+func (c *memoryEgressAuthCache) responseStaleLocked(value *egressauth.ResolveResponse) bool {
+	sourceKey, ok := egressAuthSourceKeyFromResolveSource(valueSource(value))
+	if !ok {
+		return false
+	}
+	watermark := c.sourceWatermarks[sourceKey]
+	return watermark > 0 && egressAuthSourceVersionBefore(value.Source, watermark)
+}
+
+func valueSource(value *egressauth.ResolveResponse) *egressauth.ResolveSource {
+	if value == nil {
+		return nil
+	}
+	return value.Source
+}
+
+func egressAuthSourceKeyFromResolveSource(source *egressauth.ResolveSource) (egressAuthSourceKey, bool) {
+	if source == nil {
+		return egressAuthSourceKey{}, false
+	}
+	return egressAuthSourceKeyFromValues(source.TeamID, source.SourceID, source.SourceRef)
+}
+
+func egressAuthSourceKeyFromValues(teamID string, sourceID int64, sourceRef string) (egressAuthSourceKey, bool) {
+	teamID = strings.TrimSpace(teamID)
+	sourceRef = strings.TrimSpace(sourceRef)
+	if sourceID <= 0 && sourceRef == "" {
+		return egressAuthSourceKey{}, false
+	}
+	if sourceID > 0 {
+		return egressAuthSourceKey{
+			TeamID:   teamID,
+			SourceID: sourceID,
+		}, true
+	}
+	return egressAuthSourceKey{
+		TeamID:    teamID,
+		SourceRef: sourceRef,
+	}, true
+}
+
+func egressAuthSourceMatches(source *egressauth.ResolveSource, target egressAuthSourceKey) bool {
+	sourceKey, ok := egressAuthSourceKeyFromResolveSource(source)
+	if !ok {
+		return false
+	}
+	if target.TeamID != "" && sourceKey.TeamID != "" && target.TeamID != sourceKey.TeamID {
+		return false
+	}
+	if target.SourceID > 0 && sourceKey.SourceID > 0 {
+		return target.SourceID == sourceKey.SourceID
+	}
+	return target.SourceRef != "" && sourceKey.SourceRef != "" && target.SourceRef == sourceKey.SourceRef
+}
+
+func egressAuthSourceVersionBefore(source *egressauth.ResolveSource, sourceVersion int64) bool {
+	if sourceVersion <= 0 {
+		return true
+	}
+	if source == nil || source.SourceVersion <= 0 {
+		return true
+	}
+	return source.SourceVersion < sourceVersion
+}
+
+func (s *Server) InvalidateEgressAuthSource(teamID string, sourceID int64, sourceRef string, sourceVersion int64) int {
+	if s == nil || s.authCache == nil {
+		return 0
+	}
+	return s.authCache.InvalidateSource(teamID, sourceID, sourceRef, sourceVersion)
 }
 
 func (noopEgressAuthResolver) Resolve(_ context.Context, _ *egressauth.ResolveRequest) (*egressauth.ResolveResponse, error) {
@@ -560,7 +692,7 @@ func (s *Server) resolveEgressAuth(req *adapterRequest, decision trafficDecision
 	}
 	ctx.ResolveAttempt = true
 	start := time.Now()
-	resolved, err := s.authResolver.Resolve(context.Background(), resolveReq)
+	resolved, err := s.resolveFreshEgressAuth(context.Background(), resolveReq)
 	duration := time.Since(start)
 	if err != nil {
 		ctx.ResolveError = err
@@ -580,6 +712,24 @@ func (s *Server) resolveEgressAuth(req *adapterRequest, decision trafficDecision
 	}
 	proxyMetrics.RecordEgressAuthResolve(decision.Protocol, "resolved", duration)
 	proxyMetrics.RecordEgressAuthDecision(decision.Protocol, "enforced", ctx.EnforcementReason)
+}
+
+func (s *Server) resolveFreshEgressAuth(ctx context.Context, req *egressauth.ResolveRequest) (*egressauth.ResolveResponse, error) {
+	if s == nil || s.authResolver == nil {
+		return nil, errEgressAuthResolverUnconfigured
+	}
+	resolved, err := s.authResolver.Resolve(ctx, req)
+	if err != nil || resolved == nil || s.authCache == nil || !s.authCache.IsStale(resolved) {
+		return resolved, err
+	}
+	resolved, err = s.authResolver.Resolve(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if resolved != nil && s.authCache.IsStale(resolved) {
+		return nil, errEgressAuthStaleResolvedMaterial
+	}
+	return resolved, nil
 }
 
 func (c *egressAuthContext) ShouldBypass() bool {

--- a/netd/pkg/proxy/egress_auth_test.go
+++ b/netd/pkg/proxy/egress_auth_test.go
@@ -14,11 +14,12 @@ import (
 )
 
 type stubEgressAuthResolver struct {
-	calls     int
-	resp      *egressauth.ResolveResponse
-	responses map[string]*egressauth.ResolveResponse
-	requests  []*egressauth.ResolveRequest
-	err       error
+	calls         int
+	resp          *egressauth.ResolveResponse
+	responseQueue []*egressauth.ResolveResponse
+	responses     map[string]*egressauth.ResolveResponse
+	requests      []*egressauth.ResolveRequest
+	err           error
 }
 
 func (s *stubEgressAuthResolver) Resolve(_ context.Context, req *egressauth.ResolveRequest) (*egressauth.ResolveResponse, error) {
@@ -30,10 +31,103 @@ func (s *stubEgressAuthResolver) Resolve(_ context.Context, req *egressauth.Reso
 	if s.err != nil {
 		return nil, s.err
 	}
+	if len(s.responseQueue) > 0 {
+		resp := s.responseQueue[0]
+		s.responseQueue = s.responseQueue[1:]
+		return cloneResolveResponse(resp), nil
+	}
 	if s.responses != nil && req != nil {
 		return cloneResolveResponse(s.responses[req.AuthRef]), nil
 	}
 	return cloneResolveResponse(s.resp), nil
+}
+
+func resolvedHeaderResponse(authRef, token, teamID, sourceRef string, sourceID, sourceVersion int64, expiresAt time.Time) *egressauth.ResolveResponse {
+	resp := egressauth.NewHTTPHeadersResolveResponse(authRef, map[string]string{"Authorization": "Bearer " + token}, &expiresAt)
+	resp.Source = &egressauth.ResolveSource{
+		TeamID:        teamID,
+		SourceRef:     sourceRef,
+		SourceID:      sourceID,
+		SourceVersion: sourceVersion,
+	}
+	return resp
+}
+
+func TestMemoryEgressAuthCacheInvalidatesRotatedSource(t *testing.T) {
+	expiresAt := time.Now().Add(time.Minute).UTC()
+	cache := newMemoryEgressAuthCache()
+	rotatedKey := egressAuthCacheKey{
+		SandboxID:       "sbx_123",
+		AuthRef:         "example-api",
+		Destination:     "api.example.com",
+		DestinationPort: 80,
+		Transport:       "tcp",
+		Protocol:        "http",
+	}
+	otherKey := egressAuthCacheKey{
+		SandboxID:       "sbx_123",
+		AuthRef:         "other-api",
+		Destination:     "other.example.com",
+		DestinationPort: 443,
+		Transport:       "tcp",
+		Protocol:        "tls",
+	}
+	staticKey := egressAuthCacheKey{
+		SandboxID:       "sbx_123",
+		AuthRef:         "static-api",
+		Destination:     "static.example.com",
+		DestinationPort: 80,
+		Transport:       "tcp",
+		Protocol:        "http",
+	}
+
+	cache.Put(rotatedKey, resolvedHeaderResponse("example-api", "old", "team-1", "example-source", 1, 1, expiresAt))
+	cache.Put(otherKey, resolvedHeaderResponse("other-api", "old", "team-1", "other-source", 2, 1, expiresAt))
+	cache.Put(staticKey, egressauth.NewHTTPHeadersResolveResponse("static-api", map[string]string{"Authorization": "Bearer static"}, &expiresAt))
+
+	removed := cache.InvalidateSource("team-1", 1, "example-source", 2)
+	if removed != 1 {
+		t.Fatalf("removed = %d, want 1", removed)
+	}
+	if _, ok := cache.Get(rotatedKey); ok {
+		t.Fatal("rotated source entry should be invalidated")
+	}
+	if _, ok := cache.Get(otherKey); !ok {
+		t.Fatal("unrelated source entry should remain cached")
+	}
+	if _, ok := cache.Get(staticKey); !ok {
+		t.Fatal("static auth entry should remain cached")
+	}
+}
+
+func TestMemoryEgressAuthCacheRejectsStaleResolvedMaterialAfterInvalidation(t *testing.T) {
+	expiresAt := time.Now().Add(time.Minute).UTC()
+	cache := newMemoryEgressAuthCache()
+	key := egressAuthCacheKey{
+		SandboxID:       "sbx_123",
+		AuthRef:         "example-api",
+		Destination:     "api.example.com",
+		DestinationPort: 80,
+		Transport:       "tcp",
+		Protocol:        "http",
+	}
+
+	cache.InvalidateSource("team-1", 1, "example-source", 2)
+	cache.Put(key, resolvedHeaderResponse("example-api", "old", "team-1", "example-source", 1, 1, expiresAt))
+	if _, ok := cache.Get(key); ok {
+		t.Fatal("stale resolved material should not be cached")
+	}
+
+	cache.Put(key, resolvedHeaderResponse("example-api", "new", "team-1", "example-source", 1, 2, expiresAt))
+	if _, ok := cache.Get(key); !ok {
+		t.Fatal("current source version should be cached")
+	}
+	if removed := cache.InvalidateSource("team-1", 1, "example-source", 1); removed != 0 {
+		t.Fatalf("older invalidation removed %d entries, want 0", removed)
+	}
+	if _, ok := cache.Get(key); !ok {
+		t.Fatal("current source version should survive older duplicate invalidation")
+	}
 }
 
 func TestAttachEgressAuthUsesCacheBeforeResolver(t *testing.T) {
@@ -142,6 +236,64 @@ func TestAttachEgressAuthResolvesAndCaches(t *testing.T) {
 	server.attachEgressAuth(nextReq, decision)
 	if nextReq.EgressAuth == nil || !nextReq.EgressAuth.CacheHit {
 		t.Fatal("expected cached auth material on second request")
+	}
+}
+
+func TestAttachEgressAuthRetriesStaleResolveAfterInvalidation(t *testing.T) {
+	expiresAt := time.Now().Add(time.Minute).UTC()
+	cache := newMemoryEgressAuthCache()
+	cache.InvalidateSource("team_123", 1, "example-source", 2)
+	resolver := &stubEgressAuthResolver{
+		responseQueue: []*egressauth.ResolveResponse{
+			resolvedHeaderResponse("example-api", "old", "team_123", "example-source", 1, 1, expiresAt),
+			resolvedHeaderResponse("example-api", "fresh", "team_123", "example-source", 1, 2, expiresAt),
+		},
+	}
+	server := &Server{
+		cfg:          &config.NetdConfig{EgressAuthEnabled: true},
+		authResolver: resolver,
+		authCache:    cache,
+	}
+	req := &adapterRequest{
+		Compiled: &policy.CompiledPolicy{
+			SandboxID: "sbx_123",
+			TeamID:    "team_123",
+		},
+		DestIP:   net.ParseIP("8.8.8.8"),
+		DestPort: 80,
+		Host:     "api.example.com",
+	}
+	decision := trafficDecision{
+		Action:          decisionActionUseAdapter,
+		Transport:       "tcp",
+		Protocol:        "http",
+		MatchedAuthRule: &policy.CompiledEgressAuthRule{Name: "example-http", AuthRef: "example-api"},
+	}
+
+	server.attachEgressAuth(req, decision)
+
+	if resolver.calls != 2 {
+		t.Fatalf("resolver calls = %d, want 2", resolver.calls)
+	}
+	if req.EgressAuth == nil || req.EgressAuth.ResolveError != nil {
+		t.Fatalf("unexpected egress auth context: %+v", req.EgressAuth)
+	}
+	if got := req.EgressAuth.Resolved.Headers["Authorization"]; got != "Bearer fresh" {
+		t.Fatalf("authorization header = %q, want Bearer fresh", got)
+	}
+
+	nextReq := &adapterRequest{
+		Compiled: req.Compiled,
+		DestIP:   req.DestIP,
+		DestPort: req.DestPort,
+		Host:     req.Host,
+	}
+	server.attachEgressAuth(nextReq, decision)
+	if nextReq.EgressAuth == nil || !nextReq.EgressAuth.CacheHit {
+		t.Fatal("expected retried fresh material to be cached")
+	}
+	if resolver.calls != 2 {
+		t.Fatalf("resolver calls after cache hit = %d, want 2", resolver.calls)
 	}
 }
 

--- a/netd/pkg/proxy/egress_proxy.go
+++ b/netd/pkg/proxy/egress_proxy.go
@@ -107,7 +107,7 @@ func (s *Server) resolveSOCKS5ProxyAuth(ctx context.Context, req *adapterRequest
 			return &xproxy.Auth{User: material.Username, Password: material.Password}, nil
 		}
 	}
-	resp, err := s.authResolver.Resolve(ctx, &egressauth.ResolveRequest{
+	resp, err := s.resolveFreshEgressAuth(ctx, &egressauth.ResolveRequest{
 		SandboxID:       req.Compiled.SandboxID,
 		TeamID:          req.Compiled.TeamID,
 		AuthRef:         cfg.CredentialRef,

--- a/pkg/egressauth/repository.go
+++ b/pkg/egressauth/repository.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/sandbox0-ai/sandbox0/pkg/pubsub"
 )
 
 type DB interface {
@@ -475,12 +476,33 @@ func (r *Repository) PutSource(ctx context.Context, teamID string, record *Crede
 		`, sourceID, currentVersion); err != nil {
 			return nil, fmt.Errorf("advance source bindings: %w", err)
 		}
+		event := pubsub.CredentialSourceRotatedEvent{
+			EventBase:     pubsub.NewEventBase(nil),
+			TeamID:        teamID,
+			SourceID:      sourceID,
+			SourceRef:     record.Name,
+			SourceVersion: currentVersion,
+		}
+		if err := notifyCredentialSourceRotated(ctx, tx, event); err != nil {
+			return nil, err
+		}
 	}
 
 	if err := tx.Commit(ctx); err != nil {
 		return nil, fmt.Errorf("commit source upsert: %w", err)
 	}
 	return r.GetSourceMetadata(ctx, teamID, record.Name)
+}
+
+func notifyCredentialSourceRotated(ctx context.Context, tx pgx.Tx, event pubsub.CredentialSourceRotatedEvent) error {
+	payload, err := json.Marshal(event)
+	if err != nil {
+		return fmt.Errorf("marshal credential source rotation event: %w", err)
+	}
+	if _, err := tx.Exec(ctx, "SELECT pg_notify($1, $2)", pubsub.CredentialSourceRotationChannel, string(payload)); err != nil {
+		return fmt.Errorf("notify credential source rotation: %w", err)
+	}
+	return nil
 }
 
 func (r *Repository) DeleteSource(ctx context.Context, teamID, name string) error {

--- a/pkg/egressauth/repository_test.go
+++ b/pkg/egressauth/repository_test.go
@@ -2,17 +2,20 @@ package egressauth
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/sandbox0-ai/sandbox0/pkg/dbpool"
 	"github.com/sandbox0-ai/sandbox0/pkg/egressauth/migrations"
 	"github.com/sandbox0-ai/sandbox0/pkg/migrate"
+	"github.com/sandbox0-ai/sandbox0/pkg/pubsub"
 )
 
 type testMigrateLogger struct{}
@@ -86,6 +89,63 @@ func TestRepositoryPutSourceAdvancesExistingBindings(t *testing.T) {
 	}
 	if got := version.Spec.StaticHeaders.Values["token"]; got != "new-token" {
 		t.Fatalf("resolved token = %q, want new-token", got)
+	}
+}
+
+func TestRepositoryPutSourcePublishesRotationEvent(t *testing.T) {
+	ctx := context.Background()
+	repo, pool := newRepositoryTestStore(t)
+
+	listenConn, err := pool.Acquire(ctx)
+	if err != nil {
+		t.Fatalf("acquire listen connection: %v", err)
+	}
+	defer listenConn.Release()
+	if _, err := listenConn.Exec(ctx, "LISTEN "+pubsub.CredentialSourceRotationChannel); err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	first, err := repo.PutSource(ctx, "team-1", staticHeadersSourceWriteRequest("github-source", "old-token"))
+	if err != nil {
+		t.Fatalf("put first source: %v", err)
+	}
+	source, err := repo.GetSourceByRef(ctx, "team-1", "github-source")
+	if err != nil {
+		t.Fatalf("get source by ref: %v", err)
+	}
+	if source == nil {
+		t.Fatal("source is nil")
+	}
+	if first.CurrentVersion != 1 {
+		t.Fatalf("first version = %d, want 1", first.CurrentVersion)
+	}
+
+	rotated, err := repo.PutSource(ctx, "team-1", staticHeadersSourceWriteRequest("github-source", "new-token"))
+	if err != nil {
+		t.Fatalf("rotate source: %v", err)
+	}
+	if rotated.CurrentVersion != 2 {
+		t.Fatalf("rotated version = %d, want 2", rotated.CurrentVersion)
+	}
+
+	waitCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	notification, err := listenConn.Conn().WaitForNotification(waitCtx)
+	if err != nil {
+		t.Fatalf("wait for notification: %v", err)
+	}
+	if notification.Channel != pubsub.CredentialSourceRotationChannel {
+		t.Fatalf("notification channel = %q, want %q", notification.Channel, pubsub.CredentialSourceRotationChannel)
+	}
+	var event pubsub.CredentialSourceRotatedEvent
+	if err := json.Unmarshal([]byte(notification.Payload), &event); err != nil {
+		t.Fatalf("unmarshal event: %v", err)
+	}
+	if event.TeamID != "team-1" || event.SourceID != source.ID || event.SourceRef != "github-source" || event.SourceVersion != 2 {
+		t.Fatalf("rotation event = %#v", event)
+	}
+	if event.Timestamp.IsZero() {
+		t.Fatal("rotation event timestamp is zero")
 	}
 }
 

--- a/pkg/egressauth/runtime/service.go
+++ b/pkg/egressauth/runtime/service.go
@@ -103,7 +103,18 @@ func (s *Service) resolveBinding(ctx context.Context, req *egressauth.ResolveReq
 		return nil, fmt.Errorf("provider %q returned empty response", providerName)
 	}
 
-	return cloneResolveResponse(result.Response), nil
+	teamID := sourceVersion.TeamID
+	if strings.TrimSpace(teamID) == "" {
+		teamID = req.TeamID
+	}
+	response := cloneResolveResponse(result.Response)
+	response.Source = &egressauth.ResolveSource{
+		TeamID:        teamID,
+		SourceRef:     binding.SourceRef,
+		SourceID:      sourceVersion.SourceID,
+		SourceVersion: sourceVersion.Version,
+	}
+	return response, nil
 }
 
 func (s *Service) resolveStatic(req *egressauth.ResolveRequest) (*egressauth.ResolveResponse, error) {

--- a/pkg/egressauth/runtime/service_test.go
+++ b/pkg/egressauth/runtime/service_test.go
@@ -302,6 +302,45 @@ func TestResolveUsesUpdatedBindingSourceVersion(t *testing.T) {
 	}
 }
 
+func TestResolveIncludesSourceMetadata(t *testing.T) {
+	store := &fakeBindingStore{
+		recordFn: func() *egressauth.BindingRecord {
+			record := testBindingRecord(time.Unix(10, 0).UTC())
+			record.Bindings[0].SourceVersion = 3
+			record.Bindings[0].Projection.HTTPHeaders = &egressauth.HTTPHeadersProjection{
+				Headers: []egressauth.ProjectedHeader{{
+					Name:          "Authorization",
+					ValueTemplate: "Bearer {{ .token }}",
+				}},
+			}
+			return record
+		},
+		sourceVersionFn: func(sourceID, version int64) *egressauth.CredentialSourceVersion {
+			source := testStaticSourceVersion("token")
+			source.SourceID = sourceID
+			source.TeamID = "team-1"
+			source.Version = version
+			return source
+		},
+	}
+
+	service := NewService(Config{DefaultResolveTTL: time.Minute}, store, zap.NewNop())
+	resp, err := service.Resolve(context.Background(), &egressauth.ResolveRequest{
+		TeamID:    "team-1",
+		SandboxID: "sbx-1",
+		AuthRef:   "example-api",
+	})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if resp.Source == nil {
+		t.Fatal("source metadata is nil")
+	}
+	if resp.Source.TeamID != "team-1" || resp.Source.SourceRef != "example-source" || resp.Source.SourceID != 1 || resp.Source.SourceVersion != 3 {
+		t.Fatalf("source metadata = %#v", resp.Source)
+	}
+}
+
 func TestResolveReturnsPlaceholderSubstitutionDirective(t *testing.T) {
 	store := &fakeBindingStore{
 		recordFn: func() *egressauth.BindingRecord {

--- a/pkg/egressauth/types.go
+++ b/pkg/egressauth/types.go
@@ -22,11 +22,21 @@ type ResolveResponse struct {
 	AuthRef    string             `json:"authRef"`
 	Directives []ResolveDirective `json:"directives,omitempty"`
 	ExpiresAt  *time.Time         `json:"expiresAt,omitempty"`
+	Source     *ResolveSource     `json:"source,omitempty"`
 
 	// Headers is an in-memory compatibility view derived from `directives`.
 	// It is intentionally excluded from the wire format so the broker protocol
 	// can move to typed directives before netd adapters are rewritten.
 	Headers map[string]string `json:"-"`
+}
+
+// ResolveSource identifies the source version used to resolve runtime auth
+// material. It intentionally contains no secret material.
+type ResolveSource struct {
+	TeamID        string `json:"teamId,omitempty"`
+	SourceRef     string `json:"sourceRef,omitempty"`
+	SourceID      int64  `json:"sourceId,omitempty"`
+	SourceVersion int64  `json:"sourceVersion,omitempty"`
 }
 
 type ResolveDirectiveKind string
@@ -96,6 +106,7 @@ type resolveResponseWire struct {
 	Directives []ResolveDirective `json:"directives,omitempty"`
 	Headers    map[string]string  `json:"headers,omitempty"`
 	ExpiresAt  *time.Time         `json:"expiresAt,omitempty"`
+	Source     *ResolveSource     `json:"source,omitempty"`
 }
 
 // NewHTTPHeadersResolveResponse constructs the first typed directive response
@@ -234,6 +245,7 @@ func (r ResolveResponse) MarshalJSON() ([]byte, error) {
 		AuthRef:    clone.AuthRef,
 		Directives: clone.Directives,
 		ExpiresAt:  clone.ExpiresAt,
+		Source:     cloneResolveSource(clone.Source),
 	}
 	return json.Marshal(wire)
 }
@@ -255,6 +267,7 @@ func (r *ResolveResponse) UnmarshalJSON(data []byte) error {
 	} else {
 		r.ExpiresAt = nil
 	}
+	r.Source = cloneResolveSource(wire.Source)
 	r.EnsureCompatibilityFields()
 	return nil
 }
@@ -268,6 +281,7 @@ func CloneResolveResponse(in *ResolveResponse) *ResolveResponse {
 		AuthRef:    in.AuthRef,
 		Directives: cloneDirectives(in.Directives),
 		Headers:    cloneStringMap(in.Headers),
+		Source:     cloneResolveSource(in.Source),
 	}
 	if in.ExpiresAt != nil {
 		expiresCopy := *in.ExpiresAt
@@ -275,6 +289,18 @@ func CloneResolveResponse(in *ResolveResponse) *ResolveResponse {
 	}
 	out.EnsureCompatibilityFields()
 	return out
+}
+
+func cloneResolveSource(in *ResolveSource) *ResolveSource {
+	if in == nil {
+		return nil
+	}
+	return &ResolveSource{
+		TeamID:        in.TeamID,
+		SourceRef:     in.SourceRef,
+		SourceID:      in.SourceID,
+		SourceVersion: in.SourceVersion,
+	}
 }
 
 func extractHTTPHeaders(directives []ResolveDirective) map[string]string {

--- a/pkg/egressauth/types_test.go
+++ b/pkg/egressauth/types_test.go
@@ -46,6 +46,37 @@ func TestResolveResponseUnmarshalHydratesCompatibilityHeaders(t *testing.T) {
 	}
 }
 
+func TestResolveResponsePreservesSourceMetadata(t *testing.T) {
+	resp := NewHTTPHeadersResolveResponse("example-api", map[string]string{"Authorization": "Bearer token"}, nil)
+	resp.Source = &ResolveSource{
+		TeamID:        "team-1",
+		SourceRef:     "github-token",
+		SourceID:      42,
+		SourceVersion: 7,
+	}
+
+	payload, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded ResolveResponse
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.Source == nil {
+		t.Fatal("source metadata was not decoded")
+	}
+	if decoded.Source.TeamID != "team-1" || decoded.Source.SourceRef != "github-token" || decoded.Source.SourceID != 42 || decoded.Source.SourceVersion != 7 {
+		t.Fatalf("decoded source = %#v", decoded.Source)
+	}
+
+	cloned := CloneResolveResponse(&decoded)
+	decoded.Source.SourceVersion = 8
+	if cloned.Source.SourceVersion != 7 {
+		t.Fatalf("clone source version = %d, want 7", cloned.Source.SourceVersion)
+	}
+}
+
 func TestResolveResponseMarshalPreservesTLSClientCertificateDirective(t *testing.T) {
 	payload, err := json.Marshal(NewTLSClientCertificateResolveResponse("example-cert", &TLSClientCertificateDirective{
 		CertificatePEM: "cert",

--- a/pkg/pubsub/credential_source_event.go
+++ b/pkg/pubsub/credential_source_event.go
@@ -1,0 +1,15 @@
+package pubsub
+
+// CredentialSourceRotationChannel is the PostgreSQL NOTIFY channel for
+// credential source version rotation events.
+const CredentialSourceRotationChannel = "credential_source_rotation_events"
+
+// CredentialSourceRotatedEvent identifies a new active credential source
+// version. It carries only invalidation metadata, never secret material.
+type CredentialSourceRotatedEvent struct {
+	EventBase
+	TeamID        string `json:"team_id"`
+	SourceID      int64  `json:"source_id"`
+	SourceRef     string `json:"source_ref"`
+	SourceVersion int64  `json:"source_version"`
+}


### PR DESCRIPTION
## Summary

Fixes #584.

- publish a PostgreSQL notification when an existing credential source version is rotated
- attach non-secret source metadata to manager egress-auth resolve responses
- have netd listen for credential-source rotation events and invalidate affected local resolved-material cache entries
- keep a per-source version watermark so stale concurrent resolve responses cannot be re-cached
- document realtime invalidation with TTL as the fallback consistency bound
- reduce CI peak disk usage in the shared `prepare-infra` action by loading images into Kind one at a time and deleting tar archives immediately after use

## Tests

- `GOTOOLCHAIN=go1.25.0+auto GOWORK=off go test ./pkg/egressauth/... ./netd/pkg/proxy ./netd/pkg/daemon ./manager/pkg/http ./manager/pkg/service`
- `GOTOOLCHAIN=go1.25.0+auto GOWORK=off go test ./netd/...`
- `GOTOOLCHAIN=go1.25.0+auto GOWORK=off go test ./pkg/pubsub ./pkg/egressauth/...`
- YAML parser check for `.github/actions/prepare-infra/action.yml` and `.github/workflows/netd-cni-e2e.yml`

## Remote Validation

- Restarted the persistent Aliyun Singapore ECS test environment from `Stopped` state, redeployed this PR branch with `make remote-test-again`, and verified `Sandbox0Infra fullmode Ready 9/9` with both `fullmode-netd` pods `1/1 Running`.
- Verified both netd pods started the credential source rotation listener.
- Created a cluster-local Python HTTP fixture that echoes the inbound `Authorization` header, claimed a `default` sandbox, and applied a `block-all` network policy allowing only the fixture pod `/32` on `8080/tcp`.
- Bound an HTTP egress credential rule to a `static_headers` credential source using `cachePolicy.ttl: 1h`; the first sandbox curl returned `Bearer issue584-old-token`, proving resolved material was injected and cacheable.
- Rotated the source with `PUT /api/v1/credential-sources/{name}`; source metadata reported `currentVersion: 2`.
- Netd logs showed `Invalidated egress auth cache for credential source rotation` on both pods; the sandbox node removed `1` cached entry and the other node removed `0`.
- Re-ran the same sandbox curl immediately, without waiting for the 1h TTL, and received `Bearer issue584-new-token`.
- Cleaned up the test sandbox, credential source, and temporary fixture namespace.