### PR TITLE
Harden atomic pause/resume lifecycle handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ For API changes, `pkg/apispec/openapi.yaml` is the source of truth. Generated SD
 ## Known Boundaries
 
 - Sandbox0 is a runtime boundary, not a complete agent framework. Bring your own harness or use Agent in Sandbox when you want a framework gateway to live inside the sandbox boundary.
-- Pause/resume does not preserve live processes, sockets, memory, or in-flight requests.
+- Pause/resume does not preserve live processes, sockets, or memory. Runtime requests are routed to a committed generation; during lifecycle transitions they may wait for the transaction to commit and continue after resume.
 - Self-hosted production installs require deliberate choices for Kubernetes runtime isolation, CNI, PostgreSQL, S3-compatible storage, registry, ingress, and credential policy.
 - Browser and computer-use workloads require templates and integrations that include the browser/runtime tools you need.
 - Do not hand-edit generated OpenAPI or SDK output. Update `sandbox0/pkg/apispec/openapi.yaml`, regenerate, and synchronize.

--- a/cluster-gateway/pkg/client/manager.go
+++ b/cluster-gateway/pkg/client/manager.go
@@ -197,7 +197,8 @@ func (c *ManagerClient) ResumeSandbox(ctx context.Context, sandboxID, userID, te
 	req.Header.Set(internalauth.DefaultTokenHeader, token)
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := c.httpClient.Do(req)
+	httpClient := c.resumeHTTPClient()
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("execute request: %w", err)
 	}
@@ -216,6 +217,18 @@ func (c *ManagerClient) ResumeSandbox(ctx context.Context, sandboxID, userID, te
 		return fmt.Errorf("%w: unexpected status code %d", ErrManagerUnavailable, resp.StatusCode)
 	}
 	return nil
+}
+
+func (c *ManagerClient) resumeHTTPClient() *http.Client {
+	if c == nil || c.httpClient == nil {
+		return http.DefaultClient
+	}
+	if c.httpClient.Timeout == 0 {
+		return c.httpClient
+	}
+	withoutClientTimeout := *c.httpClient
+	withoutClientTimeout.Timeout = 0
+	return &withoutClientTimeout
 }
 
 func managerUnavailableStatusError(statusCode int, body []byte) error {

--- a/cluster-gateway/pkg/client/manager_test.go
+++ b/cluster-gateway/pkg/client/manager_test.go
@@ -1,9 +1,18 @@
 package client
 
 import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+	"go.uber.org/zap"
 )
 
 func TestManagerUnavailableStatusErrorUsesSpecMessage(t *testing.T) {
@@ -25,5 +34,30 @@ func TestManagerUnavailableStatusErrorFallsBackToBody(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "unexpected status code 502: plain error") {
 		t.Fatalf("error = %q, want status and body", err.Error())
+	}
+}
+
+func TestResumeSandboxUsesRequestContextInsteadOfClientTimeout(t *testing.T) {
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate keypair: %v", err)
+	}
+	tokenGen := internalauth.NewGenerator(internalauth.GeneratorConfig{
+		Caller:     "cluster-gateway",
+		PrivateKey: privateKey,
+		TTL:        time.Minute,
+	})
+	manager := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(50 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer manager.Close()
+
+	client := NewManagerClient(manager.URL, tokenGen, zap.NewNop(), 5*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	if err := client.ResumeSandbox(ctx, "sandbox-1", "user-1", "team-1"); err != nil {
+		t.Fatalf("ResumeSandbox() error = %v, want nil", err)
 	}
 }

--- a/cluster-gateway/pkg/http/handlers_context.go
+++ b/cluster-gateway/pkg/http/handlers_context.go
@@ -2,7 +2,6 @@ package http
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -19,8 +18,6 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/proxy"
 	"go.uber.org/zap"
 )
-
-const defaultAutoResumeTimeout = 2 * time.Minute
 
 // === Process/Context Management Handlers (→ Procd) ===
 
@@ -245,9 +242,7 @@ func (s *Server) getProcdURL(c *gin.Context, sandboxID string) (*url.URL, error)
 		return nil, errors.New("sandbox auto_resume is disabled")
 	}
 	if sandboxNeedsRuntime(sandbox) {
-		resumeCtx, cancel := context.WithTimeout(c.Request.Context(), defaultAutoResumeTimeout)
-		defer cancel()
-		if err := s.managerClient.ResumeSandbox(resumeCtx, sandboxID, authCtx.UserID, authCtx.TeamID); err != nil {
+		if err := s.managerClient.ResumeSandbox(c.Request.Context(), sandboxID, authCtx.UserID, authCtx.TeamID); err != nil {
 			s.logger.Warn("Resume sandbox failed",
 				zap.String("sandbox_id", sandboxID),
 				zap.Error(err),
@@ -290,7 +285,7 @@ func sandboxRuntimeMissing(sandbox *mgr.Sandbox) bool {
 		return false
 	}
 	switch sandbox.Status {
-	case mgr.SandboxStatusPaused, mgr.SandboxStatusPausing, mgr.SandboxStatusResuming:
+	case mgr.SandboxStatusPaused:
 		return true
 	}
 	return strings.TrimSpace(sandbox.InternalAddr) == ""

--- a/cluster-gateway/pkg/http/handlers_exposure.go
+++ b/cluster-gateway/pkg/http/handlers_exposure.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -76,6 +75,10 @@ func (s *Server) handlePublicExposureNoRoute(c *gin.Context) {
 		spec.JSONError(c, http.StatusConflict, spec.CodeConflict, "resume-enabled route requires a restartable service runtime")
 		return
 	}
+	if !sandboxServiceHasTimeout(route) {
+		c.Request = proxy.WithUpstreamTimeoutDisabledRequest(c.Request)
+		_ = proxy.DisableResponseWriteDeadline(c.Writer)
+	}
 	needsRuntimeRefetch := sandboxRuntimeMissing(sandbox)
 	if sandboxNeedsRuntime(sandbox) {
 		if !sandbox.AutoResume {
@@ -86,9 +89,7 @@ func (s *Server) handlePublicExposureNoRoute(c *gin.Context) {
 			spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox is not running and resume is disabled")
 			return
 		}
-		resumeCtx, cancel := context.WithTimeout(c.Request.Context(), defaultAutoResumeTimeout)
-		defer cancel()
-		if err := s.managerClient.ResumeSandbox(resumeCtx, sandboxID, "", sandbox.TeamID); err != nil {
+		if err := s.managerClient.ResumeSandbox(c.Request.Context(), sandboxID, "", sandbox.TeamID); err != nil {
 			s.logger.Warn("Auto resume failed", zap.String("sandbox_id", sandboxID), zap.Error(err))
 			spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox is waking up")
 			return

--- a/cluster-gateway/pkg/http/sandbox_internal_cache.go
+++ b/cluster-gateway/pkg/http/sandbox_internal_cache.go
@@ -44,7 +44,10 @@ func (s *Server) getSandboxInternalCached(ctx context.Context, sandboxID string)
 	if s.sandboxInternalCache != nil {
 		sandbox, ok, err := s.sandboxInternalCache.Get(ctx, sandboxID)
 		if err == nil && ok && sandbox != nil {
-			return sandbox, nil
+			if sandboxInternalCacheable(sandbox) {
+				return sandbox, nil
+			}
+			s.invalidateSandboxInternalCache(ctx, sandboxID)
 		}
 		if err != nil && s.logger != nil {
 			s.logger.Debug("Sandbox internal cache lookup failed",
@@ -58,15 +61,21 @@ func (s *Server) getSandboxInternalCached(ctx context.Context, sandboxID string)
 	if err != nil {
 		return nil, err
 	}
-	if s.sandboxInternalCache != nil && sandbox != nil {
+	if s.sandboxInternalCache != nil && sandboxInternalCacheable(sandbox) {
 		if err := s.sandboxInternalCache.Set(ctx, sandboxID, sandbox); err != nil && s.logger != nil {
 			s.logger.Debug("Sandbox internal cache store failed",
 				zap.String("sandbox_id", sandboxID),
 				zap.Error(err),
 			)
 		}
+	} else if s.sandboxInternalCache != nil {
+		s.invalidateSandboxInternalCache(ctx, sandboxID)
 	}
 	return sandbox, nil
+}
+
+func sandboxInternalCacheable(sandbox *mgr.Sandbox) bool {
+	return sandbox != nil && strings.TrimSpace(sandbox.InternalAddr) == ""
 }
 
 func (s *Server) invalidateSandboxInternalCache(ctx context.Context, sandboxID string) {

--- a/cluster-gateway/pkg/http/sandbox_internal_cache_test.go
+++ b/cluster-gateway/pkg/http/sandbox_internal_cache_test.go
@@ -45,9 +45,47 @@ func TestGetSandboxInternalCachedPopulatesCache(t *testing.T) {
 		}
 		managerGets.Add(1)
 		_ = spec.WriteSuccess(w, http.StatusOK, &mgr.Sandbox{
+			ID:     "sb-1",
+			TeamID: "team-1",
+			Status: mgr.SandboxStatusPaused,
+			Paused: true,
+		})
+	}))
+	defer manager.Close()
+
+	cache := newTestSandboxInternalCache()
+	server := &Server{
+		managerClient:        newTestManagerClient(t, manager.URL),
+		sandboxInternalCache: cache,
+		logger:               zap.NewNop(),
+	}
+
+	for i := 0; i < 2; i++ {
+		sandbox, err := server.getSandboxInternalCached(context.Background(), "sb-1")
+		if err != nil {
+			t.Fatalf("get sandbox: %v", err)
+		}
+		if sandbox.Status != mgr.SandboxStatusPaused {
+			t.Fatalf("Status = %q, want paused", sandbox.Status)
+		}
+	}
+	if got := managerGets.Load(); got != 1 {
+		t.Fatalf("manager gets = %d, want 1", got)
+	}
+	if cache.sets != 1 {
+		t.Fatalf("cache sets = %d, want 1", cache.sets)
+	}
+}
+
+func TestGetSandboxInternalCachedDoesNotCacheRuntimeAddress(t *testing.T) {
+	var managerGets atomic.Int32
+	manager := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		managerGets.Add(1)
+		_ = spec.WriteSuccess(w, http.StatusOK, &mgr.Sandbox{
 			ID:           "sb-1",
 			TeamID:       "team-1",
 			InternalAddr: "http://127.0.0.1:7777",
+			Status:       mgr.SandboxStatusRunning,
 		})
 	}))
 	defer manager.Close()
@@ -65,14 +103,55 @@ func TestGetSandboxInternalCachedPopulatesCache(t *testing.T) {
 			t.Fatalf("get sandbox: %v", err)
 		}
 		if sandbox.InternalAddr != "http://127.0.0.1:7777" {
-			t.Fatalf("InternalAddr = %q", sandbox.InternalAddr)
+			t.Fatalf("InternalAddr = %q, want runtime address", sandbox.InternalAddr)
 		}
+	}
+	if got := managerGets.Load(); got != 2 {
+		t.Fatalf("manager gets = %d, want 2", got)
+	}
+	if cache.sets != 0 {
+		t.Fatalf("cache sets = %d, want 0", cache.sets)
+	}
+}
+
+func TestGetSandboxInternalCachedInvalidatesCachedRuntimeAddress(t *testing.T) {
+	var managerGets atomic.Int32
+	manager := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		managerGets.Add(1)
+		_ = spec.WriteSuccess(w, http.StatusOK, &mgr.Sandbox{
+			ID:     "sb-1",
+			TeamID: "team-1",
+			Status: mgr.SandboxStatusPaused,
+			Paused: true,
+		})
+	}))
+	defer manager.Close()
+
+	cache := newTestSandboxInternalCache()
+	cache.values["sb-1"] = &mgr.Sandbox{
+		ID:           "sb-1",
+		TeamID:       "team-1",
+		InternalAddr: "http://127.0.0.1:7777",
+		Status:       mgr.SandboxStatusRunning,
+	}
+	server := &Server{
+		managerClient:        newTestManagerClient(t, manager.URL),
+		sandboxInternalCache: cache,
+		logger:               zap.NewNop(),
+	}
+
+	sandbox, err := server.getSandboxInternalCached(context.Background(), "sb-1")
+	if err != nil {
+		t.Fatalf("get sandbox: %v", err)
+	}
+	if sandbox.InternalAddr != "" || sandbox.Status != mgr.SandboxStatusPaused {
+		t.Fatalf("sandbox = %+v, want paused sandbox without runtime address", sandbox)
 	}
 	if got := managerGets.Load(); got != 1 {
 		t.Fatalf("manager gets = %d, want 1", got)
 	}
-	if cache.sets != 1 {
-		t.Fatalf("cache sets = %d, want 1", cache.sets)
+	if cache.deletes != 1 {
+		t.Fatalf("cache deletes = %d, want 1", cache.deletes)
 	}
 }
 

--- a/ctld/cmd/ctld/main.go
+++ b/ctld/cmd/ctld/main.go
@@ -215,6 +215,21 @@ func buildRootFSObjectStore(cfg *apiconfig.StorageProxyConfig) (objectstore.Stor
 	if err != nil {
 		return nil, err
 	}
+	if cfg.ObjectEncryptionEnabled {
+		keyPEM, err := objectstore.LoadEncryptionKey(cfg.ObjectEncryptionKeyPath)
+		if err != nil {
+			return nil, err
+		}
+		keyEncryptor, err := objectstore.NewKeyEncryptor(keyPEM, cfg.ObjectEncryptionPassphrase)
+		if err != nil {
+			return nil, err
+		}
+		store = objectstore.Encrypting(store, objectstore.EncryptionConfig{
+			Enabled:      true,
+			Algorithm:    cfg.ObjectEncryptionAlgo,
+			KeyEncryptor: keyEncryptor,
+		})
+	}
 	return store, nil
 }
 

--- a/ctld/cmd/ctld/main.go
+++ b/ctld/cmd/ctld/main.go
@@ -178,7 +178,7 @@ func buildProbeController(ctx context.Context, obsProvider *observability.Provid
 	return controller
 }
 
-func buildRootFSController(storageCfg *apiconfig.StorageProxyConfig, portalResolver ctldrootfs.PortalResolver) ctldserver.RootFSController {
+func buildRootFSController(storageCfg *apiconfig.StorageProxyConfig, portalResolver ctldrootfs.PortalResolver) rootFSHandler {
 	store, err := buildRootFSObjectStore(storageCfg)
 	if err != nil {
 		log.Printf("ctld rootfs object store disabled: %v", err)
@@ -244,7 +244,7 @@ func initPortalDatabase(ctx context.Context, cfg *apiconfig.StorageProxyConfig, 
 type combinedController struct {
 	ctldserver.Controller
 	Portal volumePortalHandler
-	RootFS ctldserver.RootFSController
+	RootFS rootFSHandler
 }
 
 func (c combinedController) BindVolumePortal(r *http.Request, req ctldapi.BindVolumePortalRequest) (ctldapi.BindVolumePortalResponse, int) {
@@ -381,11 +381,37 @@ func (c combinedController) SaveRootFS(r *http.Request, req ctldapi.SaveRootFSRe
 	return c.RootFS.SaveRootFS(r, req)
 }
 
+func (c combinedController) PrepareRootFSSnapshot(r *http.Request, req ctldapi.PrepareRootFSSnapshotRequest) (ctldapi.PrepareRootFSSnapshotResponse, int) {
+	if c.RootFS == nil {
+		return ctldapi.PrepareRootFSSnapshotResponse{Error: "ctld rootfs snapshot prepare not implemented"}, http.StatusNotImplemented
+	}
+	return c.RootFS.PrepareRootFSSnapshot(r, req)
+}
+
+func (c combinedController) PublishRootFSSnapshot(r *http.Request, req ctldapi.PublishRootFSSnapshotRequest) (ctldapi.PublishRootFSSnapshotResponse, int) {
+	if c.RootFS == nil {
+		return ctldapi.PublishRootFSSnapshotResponse{Error: "ctld rootfs snapshot publish not implemented"}, http.StatusNotImplemented
+	}
+	return c.RootFS.PublishRootFSSnapshot(r, req)
+}
+
+func (c combinedController) AbortRootFSSnapshot(r *http.Request, req ctldapi.AbortRootFSSnapshotRequest) (ctldapi.AbortRootFSSnapshotResponse, int) {
+	if c.RootFS == nil {
+		return ctldapi.AbortRootFSSnapshotResponse{Error: "ctld rootfs snapshot abort not implemented"}, http.StatusNotImplemented
+	}
+	return c.RootFS.AbortRootFSSnapshot(r, req)
+}
+
 func (c combinedController) ApplyRootFS(r *http.Request, req ctldapi.ApplyRootFSRequest) (ctldapi.ApplyRootFSResponse, int) {
 	if c.RootFS == nil {
 		return ctldapi.ApplyRootFSResponse{Error: "ctld rootfs apply not implemented"}, http.StatusNotImplemented
 	}
 	return c.RootFS.ApplyRootFS(r, req)
+}
+
+type rootFSHandler interface {
+	ctldserver.RootFSController
+	ctldserver.RootFSSnapshotController
 }
 
 type volumePortalHandler interface {

--- a/ctld/cmd/ctld/main_test.go
+++ b/ctld/cmd/ctld/main_test.go
@@ -129,6 +129,76 @@ func TestReleaseVolumeOwnerReturnsConflictForBusyOwner(t *testing.T) {
 	assert.Equal(t, http.StatusConflict, rec.Code)
 }
 
+func TestCombinedControllerRoutesRootFSSnapshotAPI(t *testing.T) {
+	server := newHTTPServer(":0", combinedController{
+		Controller: ctldserver.NotImplementedController{},
+		RootFS:     fakeRootFSHandler{},
+	})
+
+	t.Run("prepare", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/rootfs/snapshots/prepare", strings.NewReader(`{"target":{"namespace":"ns","pod_name":"pod","container_name":"sandbox"}}`))
+		rec := httptest.NewRecorder()
+		server.Handler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		var resp ctldapi.PrepareRootFSSnapshotResponse
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		assert.Equal(t, "snapshot-handle", resp.Handle)
+	})
+
+	t.Run("publish", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/rootfs/snapshots/publish", strings.NewReader(`{"handle":"snapshot-handle","sandbox_id":"sandbox-1","team_id":"team-1"}`))
+		rec := httptest.NewRecorder()
+		server.Handler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		var resp ctldapi.PublishRootFSSnapshotResponse
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		assert.True(t, resp.Published)
+		assert.Equal(t, "sha256:test", resp.Descriptor.Digest)
+	})
+
+	t.Run("abort", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/rootfs/snapshots/abort", strings.NewReader(`{"handle":"snapshot-handle"}`))
+		rec := httptest.NewRecorder()
+		server.Handler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		var resp ctldapi.AbortRootFSSnapshotResponse
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		assert.True(t, resp.Aborted)
+	})
+}
+
+type fakeRootFSHandler struct{}
+
+func (fakeRootFSHandler) InspectRootFS(_ *http.Request, _ ctldapi.InspectRootFSRequest) (ctldapi.InspectRootFSResponse, int) {
+	return ctldapi.InspectRootFSResponse{}, http.StatusOK
+}
+
+func (fakeRootFSHandler) SaveRootFS(_ *http.Request, _ ctldapi.SaveRootFSRequest) (ctldapi.SaveRootFSResponse, int) {
+	return ctldapi.SaveRootFSResponse{}, http.StatusOK
+}
+
+func (fakeRootFSHandler) PrepareRootFSSnapshot(_ *http.Request, _ ctldapi.PrepareRootFSSnapshotRequest) (ctldapi.PrepareRootFSSnapshotResponse, int) {
+	return ctldapi.PrepareRootFSSnapshotResponse{Handle: "snapshot-handle"}, http.StatusOK
+}
+
+func (fakeRootFSHandler) PublishRootFSSnapshot(_ *http.Request, _ ctldapi.PublishRootFSSnapshotRequest) (ctldapi.PublishRootFSSnapshotResponse, int) {
+	return ctldapi.PublishRootFSSnapshotResponse{
+		Published:  true,
+		Descriptor: ctldapi.RootFSDiffDescriptor{Digest: "sha256:test"},
+	}, http.StatusOK
+}
+
+func (fakeRootFSHandler) AbortRootFSSnapshot(_ *http.Request, _ ctldapi.AbortRootFSSnapshotRequest) (ctldapi.AbortRootFSSnapshotResponse, int) {
+	return ctldapi.AbortRootFSSnapshotResponse{Aborted: true}, http.StatusOK
+}
+
+func (fakeRootFSHandler) ApplyRootFS(_ *http.Request, _ ctldapi.ApplyRootFSRequest) (ctldapi.ApplyRootFSResponse, int) {
+	return ctldapi.ApplyRootFSResponse{}, http.StatusOK
+}
+
 type fakeVolumePortalHandler struct {
 	mountedHandler http.Handler
 	bindErr        error

--- a/ctld/internal/ctld/rootfs/controller.go
+++ b/ctld/internal/ctld/rootfs/controller.go
@@ -2,15 +2,18 @@ package rootfs
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/objectstore"
 )
@@ -38,6 +41,7 @@ type Config struct {
 	Store            objectstore.Store
 	OperationTimeout time.Duration
 	PortalResolver   PortalResolver
+	SnapshotDir      string
 }
 
 type Controller struct {
@@ -45,6 +49,7 @@ type Controller struct {
 	store            objectstore.Store
 	operationTimeout time.Duration
 	portalResolver   PortalResolver
+	snapshotDir      string
 }
 
 func NewController(cfg Config) *Controller {
@@ -57,6 +62,7 @@ func NewController(cfg Config) *Controller {
 		store:            cfg.Store,
 		operationTimeout: timeout,
 		portalResolver:   cfg.PortalResolver,
+		snapshotDir:      cfg.SnapshotDir,
 	}
 }
 
@@ -72,42 +78,95 @@ func (c *Controller) InspectRootFS(r *http.Request, req ctldapi.InspectRootFSReq
 }
 
 func (c *Controller) SaveRootFS(r *http.Request, req ctldapi.SaveRootFSRequest) (ctldapi.SaveRootFSResponse, int) {
-	if err := validateTarget(req.Target); err != nil {
-		return ctldapi.SaveRootFSResponse{Error: err.Error()}, http.StatusBadRequest
-	}
 	if c.store == nil {
 		return ctldapi.SaveRootFSResponse{Error: "rootfs object store is not configured"}, http.StatusNotImplemented
 	}
 
+	prepared, status := c.PrepareRootFSSnapshot(r, ctldapi.PrepareRootFSSnapshotRequest{
+		Target:        req.Target,
+		ParentLayerID: req.ParentLayerID,
+		ExcludedPaths: req.ExcludedPaths,
+		PortalPaths:   req.PortalPaths,
+	})
+	if status != http.StatusOK {
+		return ctldapi.SaveRootFSResponse{Info: prepared.Info, Error: prepared.Error}, status
+	}
+	published, status := c.PublishRootFSSnapshot(r, ctldapi.PublishRootFSSnapshotRequest{
+		Handle:                    prepared.Handle,
+		SandboxID:                 req.SandboxID,
+		TeamID:                    req.TeamID,
+		ExpectedRuntimeGeneration: req.ExpectedRuntimeGeneration,
+		ObjectKey:                 req.ObjectKey,
+	})
+	if status != http.StatusOK {
+		_, _ = c.AbortRootFSSnapshot(r, ctldapi.AbortRootFSSnapshotRequest{Handle: prepared.Handle})
+		return ctldapi.SaveRootFSResponse{Info: published.Info, Error: published.Error}, status
+	}
+	return ctldapi.SaveRootFSResponse{Info: published.Info, Descriptor: published.Descriptor}, http.StatusOK
+}
+
+func (c *Controller) PrepareRootFSSnapshot(r *http.Request, req ctldapi.PrepareRootFSSnapshotRequest) (ctldapi.PrepareRootFSSnapshotResponse, int) {
+	if err := validateTarget(req.Target); err != nil {
+		return ctldapi.PrepareRootFSSnapshotResponse{Error: err.Error()}, http.StatusBadRequest
+	}
 	ctx, cancel := c.operationContext(requestContext(r))
 	defer cancel()
 
 	info, err := c.inspect(ctx, req.Target)
 	if err != nil {
-		return ctldapi.SaveRootFSResponse{Error: err.Error()}, statusForError(err)
+		return ctldapi.PrepareRootFSSnapshotResponse{Error: err.Error()}, statusForError(err)
 	}
 	if err := validateSupportedRuntime(info); err != nil {
-		return ctldapi.SaveRootFSResponse{Info: info, Error: err.Error()}, http.StatusBadRequest
+		return ctldapi.PrepareRootFSSnapshotResponse{Info: info, Error: err.Error()}, http.StatusBadRequest
 	}
 	portalPaths := c.portalPathsForRequest(info, req.Target, req.ExcludedPaths, req.PortalPaths)
 	desc, reader, err := c.createDiff(ctx, info, strings.TrimSpace(req.ParentLayerID), req.ExcludedPaths, portalPaths)
 	if err != nil {
-		return ctldapi.SaveRootFSResponse{Info: info, Error: fmt.Sprintf("create rootfs diff: %v", err)}, statusForError(err)
+		return ctldapi.PrepareRootFSSnapshotResponse{Info: info, Error: fmt.Sprintf("create rootfs diff: %v", err)}, statusForError(err)
 	}
 	defer reader.Close()
 
+	handle := uuid.NewString()
+	if err := c.writePreparedSnapshot(handle, info, desc, reader); err != nil {
+		return ctldapi.PrepareRootFSSnapshotResponse{Info: info, Error: fmt.Sprintf("prepare rootfs snapshot: %v", err)}, http.StatusInternalServerError
+	}
+	return ctldapi.PrepareRootFSSnapshotResponse{Handle: handle, Info: info, Descriptor: desc}, http.StatusOK
+}
+
+func (c *Controller) PublishRootFSSnapshot(r *http.Request, req ctldapi.PublishRootFSSnapshotRequest) (ctldapi.PublishRootFSSnapshotResponse, int) {
+	if c.store == nil {
+		return ctldapi.PublishRootFSSnapshotResponse{Error: "rootfs object store is not configured"}, http.StatusNotImplemented
+	}
+	prepared, err := c.readPreparedSnapshot(req.Handle)
+	if err != nil {
+		return ctldapi.PublishRootFSSnapshotResponse{Error: err.Error()}, statusForError(err)
+	}
 	objectKey := strings.Trim(strings.TrimSpace(req.ObjectKey), "/")
 	if objectKey == "" {
-		objectKey, err = defaultObjectKey(req.TeamID, req.SandboxID, req.ExpectedRuntimeGeneration, desc.Digest)
+		objectKey, err = defaultObjectKey(req.TeamID, req.SandboxID, req.ExpectedRuntimeGeneration, prepared.Descriptor.Digest)
 		if err != nil {
-			return ctldapi.SaveRootFSResponse{Info: info, Error: err.Error()}, http.StatusBadRequest
+			return ctldapi.PublishRootFSSnapshotResponse{Info: prepared.Info, Error: err.Error()}, http.StatusBadRequest
 		}
 	}
-	if err := c.store.Put(objectKey, reader); err != nil {
-		return ctldapi.SaveRootFSResponse{Info: info, Error: fmt.Sprintf("upload rootfs diff: %v", err)}, http.StatusInternalServerError
+	content, err := os.Open(c.preparedSnapshotContentPath(req.Handle))
+	if err != nil {
+		return ctldapi.PublishRootFSSnapshotResponse{Info: prepared.Info, Error: fmt.Sprintf("open prepared rootfs snapshot: %v", err)}, statusForError(err)
 	}
+	defer content.Close()
+	if err := c.store.Put(objectKey, content); err != nil {
+		return ctldapi.PublishRootFSSnapshotResponse{Info: prepared.Info, Error: fmt.Sprintf("upload rootfs diff: %v", err)}, http.StatusInternalServerError
+	}
+	desc := prepared.Descriptor
 	desc.ObjectKey = objectKey
-	return ctldapi.SaveRootFSResponse{Info: info, Descriptor: desc}, http.StatusOK
+	_ = c.removePreparedSnapshot(req.Handle)
+	return ctldapi.PublishRootFSSnapshotResponse{Info: prepared.Info, Descriptor: desc, Published: true}, http.StatusOK
+}
+
+func (c *Controller) AbortRootFSSnapshot(_ *http.Request, req ctldapi.AbortRootFSSnapshotRequest) (ctldapi.AbortRootFSSnapshotResponse, int) {
+	if err := c.removePreparedSnapshot(req.Handle); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return ctldapi.AbortRootFSSnapshotResponse{Error: err.Error()}, statusForError(err)
+	}
+	return ctldapi.AbortRootFSSnapshotResponse{Aborted: true}, http.StatusOK
 }
 
 func (c *Controller) ApplyRootFS(r *http.Request, req ctldapi.ApplyRootFSRequest) (ctldapi.ApplyRootFSResponse, int) {
@@ -203,6 +262,120 @@ func (c *Controller) applyDescriptor(ctx context.Context, info ctldapi.RootFSInf
 	}
 	applied.ObjectKey = desc.ObjectKey
 	return applied, nil
+}
+
+type preparedRootFSSnapshot struct {
+	Handle     string                       `json:"handle"`
+	Info       ctldapi.RootFSInfo           `json:"info"`
+	Descriptor ctldapi.RootFSDiffDescriptor `json:"descriptor"`
+	CreatedAt  time.Time                    `json:"created_at"`
+}
+
+func (c *Controller) writePreparedSnapshot(handle string, info ctldapi.RootFSInfo, desc ctldapi.RootFSDiffDescriptor, reader io.Reader) error {
+	if strings.TrimSpace(handle) == "" {
+		return fmt.Errorf("%w: snapshot handle is required", ErrBadRequest)
+	}
+	if err := os.MkdirAll(c.preparedSnapshotDir(), 0o755); err != nil {
+		return err
+	}
+	contentTmp := c.preparedSnapshotContentPath(handle) + ".tmp"
+	content, err := os.Create(contentTmp)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(content, reader); err != nil {
+		_ = content.Close()
+		_ = os.Remove(contentTmp)
+		return err
+	}
+	if err := content.Close(); err != nil {
+		_ = os.Remove(contentTmp)
+		return err
+	}
+	if err := os.Rename(contentTmp, c.preparedSnapshotContentPath(handle)); err != nil {
+		_ = os.Remove(contentTmp)
+		return err
+	}
+
+	meta := preparedRootFSSnapshot{
+		Handle:     handle,
+		Info:       info,
+		Descriptor: desc,
+		CreatedAt:  time.Now().UTC(),
+	}
+	metaTmp := c.preparedSnapshotMetaPath(handle) + ".tmp"
+	metaFile, err := os.Create(metaTmp)
+	if err != nil {
+		return err
+	}
+	if err := json.NewEncoder(metaFile).Encode(meta); err != nil {
+		_ = metaFile.Close()
+		_ = os.Remove(metaTmp)
+		return err
+	}
+	if err := metaFile.Close(); err != nil {
+		_ = os.Remove(metaTmp)
+		return err
+	}
+	if err := os.Rename(metaTmp, c.preparedSnapshotMetaPath(handle)); err != nil {
+		_ = os.Remove(metaTmp)
+		return err
+	}
+	return nil
+}
+
+func (c *Controller) readPreparedSnapshot(handle string) (preparedRootFSSnapshot, error) {
+	handle = strings.TrimSpace(handle)
+	if handle == "" {
+		return preparedRootFSSnapshot{}, fmt.Errorf("%w: snapshot handle is required", ErrBadRequest)
+	}
+	metaFile, err := os.Open(c.preparedSnapshotMetaPath(handle))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return preparedRootFSSnapshot{}, fmt.Errorf("%w: rootfs snapshot handle %s", ErrNotFound, handle)
+		}
+		return preparedRootFSSnapshot{}, err
+	}
+	defer metaFile.Close()
+	var prepared preparedRootFSSnapshot
+	if err := json.NewDecoder(metaFile).Decode(&prepared); err != nil {
+		return preparedRootFSSnapshot{}, err
+	}
+	return prepared, nil
+}
+
+func (c *Controller) removePreparedSnapshot(handle string) error {
+	handle = strings.TrimSpace(handle)
+	if handle == "" {
+		return nil
+	}
+	contentErr := os.Remove(c.preparedSnapshotContentPath(handle))
+	metaErr := os.Remove(c.preparedSnapshotMetaPath(handle))
+	if contentErr != nil && !errors.Is(contentErr, os.ErrNotExist) {
+		return contentErr
+	}
+	if metaErr != nil && !errors.Is(metaErr, os.ErrNotExist) {
+		return metaErr
+	}
+	if errors.Is(contentErr, os.ErrNotExist) && errors.Is(metaErr, os.ErrNotExist) {
+		return os.ErrNotExist
+	}
+	return nil
+}
+
+func (c *Controller) preparedSnapshotContentPath(handle string) string {
+	return filepath.Join(c.preparedSnapshotDir(), filepath.Base(handle)+".tar")
+}
+
+func (c *Controller) preparedSnapshotMetaPath(handle string) string {
+	return filepath.Join(c.preparedSnapshotDir(), filepath.Base(handle)+".json")
+}
+
+func (c *Controller) preparedSnapshotDir() string {
+	if c != nil && strings.TrimSpace(c.snapshotDir) != "" {
+		return c.snapshotDir
+	}
+	return filepath.Join(os.TempDir(), "sandbox0-rootfs-snapshots")
 }
 
 func (c *Controller) portalPathsForRequest(info ctldapi.RootFSInfo, target ctldapi.RootFSContainerRef, excludedPaths []string, requested []ctldapi.RootFSPortalPath) []ctldapi.RootFSPortalPath {

--- a/ctld/internal/ctld/server/server.go
+++ b/ctld/internal/ctld/server/server.go
@@ -34,6 +34,12 @@ type RootFSController interface {
 	ApplyRootFS(r *http.Request, req ctldapi.ApplyRootFSRequest) (ctldapi.ApplyRootFSResponse, int)
 }
 
+type RootFSSnapshotController interface {
+	PrepareRootFSSnapshot(r *http.Request, req ctldapi.PrepareRootFSSnapshotRequest) (ctldapi.PrepareRootFSSnapshotResponse, int)
+	PublishRootFSSnapshot(r *http.Request, req ctldapi.PublishRootFSSnapshotRequest) (ctldapi.PublishRootFSSnapshotResponse, int)
+	AbortRootFSSnapshot(r *http.Request, req ctldapi.AbortRootFSSnapshotRequest) (ctldapi.AbortRootFSSnapshotResponse, int)
+}
+
 type MountedVolumeController interface {
 	MountedVolumeHandler() http.Handler
 }
@@ -62,6 +68,18 @@ func (NotImplementedController) InspectRootFS(_ *http.Request, _ ctldapi.Inspect
 
 func (NotImplementedController) SaveRootFS(_ *http.Request, _ ctldapi.SaveRootFSRequest) (ctldapi.SaveRootFSResponse, int) {
 	return ctldapi.SaveRootFSResponse{Error: "ctld rootfs save not implemented"}, http.StatusNotImplemented
+}
+
+func (NotImplementedController) PrepareRootFSSnapshot(_ *http.Request, _ ctldapi.PrepareRootFSSnapshotRequest) (ctldapi.PrepareRootFSSnapshotResponse, int) {
+	return ctldapi.PrepareRootFSSnapshotResponse{Error: "ctld rootfs snapshot prepare not implemented"}, http.StatusNotImplemented
+}
+
+func (NotImplementedController) PublishRootFSSnapshot(_ *http.Request, _ ctldapi.PublishRootFSSnapshotRequest) (ctldapi.PublishRootFSSnapshotResponse, int) {
+	return ctldapi.PublishRootFSSnapshotResponse{Error: "ctld rootfs snapshot publish not implemented"}, http.StatusNotImplemented
+}
+
+func (NotImplementedController) AbortRootFSSnapshot(_ *http.Request, _ ctldapi.AbortRootFSSnapshotRequest) (ctldapi.AbortRootFSSnapshotResponse, int) {
+	return ctldapi.AbortRootFSSnapshotResponse{Error: "ctld rootfs snapshot abort not implemented"}, http.StatusNotImplemented
 }
 
 func (NotImplementedController) ApplyRootFS(_ *http.Request, _ ctldapi.ApplyRootFSRequest) (ctldapi.ApplyRootFSResponse, int) {
@@ -304,6 +322,72 @@ func NewMux(controller Controller) http.Handler {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		resp, status := rootFSController.SaveRootFS(r, req)
+		w.WriteHeader(status)
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+	mux.HandleFunc("/api/v1/rootfs/snapshots/prepare", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		rootFSController, ok := controller.(RootFSSnapshotController)
+		if !ok {
+			w.WriteHeader(http.StatusNotImplemented)
+			_ = json.NewEncoder(w).Encode(ctldapi.PrepareRootFSSnapshotResponse{Error: "ctld rootfs snapshot prepare not implemented"})
+			return
+		}
+		var req ctldapi.PrepareRootFSSnapshotRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(ctldapi.PrepareRootFSSnapshotResponse{Error: err.Error()})
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		resp, status := rootFSController.PrepareRootFSSnapshot(r, req)
+		w.WriteHeader(status)
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+	mux.HandleFunc("/api/v1/rootfs/snapshots/publish", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		rootFSController, ok := controller.(RootFSSnapshotController)
+		if !ok {
+			w.WriteHeader(http.StatusNotImplemented)
+			_ = json.NewEncoder(w).Encode(ctldapi.PublishRootFSSnapshotResponse{Error: "ctld rootfs snapshot publish not implemented"})
+			return
+		}
+		var req ctldapi.PublishRootFSSnapshotRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(ctldapi.PublishRootFSSnapshotResponse{Error: err.Error()})
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		resp, status := rootFSController.PublishRootFSSnapshot(r, req)
+		w.WriteHeader(status)
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+	mux.HandleFunc("/api/v1/rootfs/snapshots/abort", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		rootFSController, ok := controller.(RootFSSnapshotController)
+		if !ok {
+			w.WriteHeader(http.StatusNotImplemented)
+			_ = json.NewEncoder(w).Encode(ctldapi.AbortRootFSSnapshotResponse{Error: "ctld rootfs snapshot abort not implemented"})
+			return
+		}
+		var req ctldapi.AbortRootFSSnapshotRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(ctldapi.AbortRootFSSnapshotResponse{Error: err.Error()})
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		resp, status := rootFSController.AbortRootFSSnapshot(r, req)
 		w.WriteHeader(status)
 		_ = json.NewEncoder(w).Encode(resp)
 	})

--- a/docs/agent-in-sandbox/hermes/page.mdx
+++ b/docs/agent-in-sandbox/hermes/page.mdx
@@ -384,7 +384,7 @@ curl -fsS "$HERMES_PUBLIC_URL/health" \\
   ]}
 />
 
-Hermes state under `/opt/data` remains on the mounted volume. Running processes, sockets, memory, and in-flight requests are not preserved across pause/resume.
+Hermes state under `/opt/data` remains on the mounted volume. Running processes, sockets, and memory are not preserved across pause/resume. Runtime requests are routed to a committed generation and may wait while lifecycle transactions commit.
 
 <Callout variant="warning">
 Paused sandboxes cannot receive outbound long-polling, WebSocket, or cron events. Put message webhooks and schedulers in an always-on control plane that calls the Sandbox0 service URL, or keep the sandbox running for workflows that must listen continuously.

--- a/docs/agent-in-sandbox/openclaw/page.mdx
+++ b/docs/agent-in-sandbox/openclaw/page.mdx
@@ -338,7 +338,7 @@ curl -fsS "$OPENCLAW_PUBLIC_URL/health" \\
   ]}
 />
 
-OpenClaw state under `/home/node/.openclaw` remains on the mounted volume. Running processes, sockets, memory, and in-flight requests are not preserved across pause/resume.
+OpenClaw state under `/home/node/.openclaw` remains on the mounted volume. Running processes, sockets, and memory are not preserved across pause/resume. Runtime requests are routed to a committed generation and may wait while lifecycle transactions commit.
 
 <Callout variant="warning">
 Outbound channel connections do not wake a paused sandbox by themselves. If OpenClaw listens to Telegram, Discord, or another external channel through long polling or WebSockets, put the webhook receiver in an always-on control plane that calls the Sandbox0 service URL, or keep that sandbox running.

--- a/docs/sandbox/page.mdx
+++ b/docs/sandbox/page.mdx
@@ -27,14 +27,12 @@ Sandbox0 Cloud clients should use `https://api.sandbox0.ai`. Set `SANDBOX0_BASE_
 |--------|-------------|
 | `starting` | Sandbox is being initialized |
 | `running` | Sandbox is active and ready to use |
-| `pausing` | Sandbox is checkpointing rootfs and releasing its runtime |
 | `paused` | Sandbox has no runtime; identity and latest rootfs checkpoint are preserved |
-| `resuming` | Sandbox is creating a new runtime and restoring rootfs |
 | `terminating` | Sandbox identity and durable state are being deleted |
 | `failed` | Sandbox encountered an error |
 
 <Callout variant="info">
-Use the `paused` boolean as a convenience for `status == "paused"`. Pause does not preserve running processes, memory, sockets, PID state, or live REPL sessions.
+Pause and resume use internal lifecycle transactions, but `pausing` and `resuming` are not caller-visible statuses. Use the `paused` boolean as a convenience for `status == "paused"`. Pause does not preserve running processes, memory, sockets, PID state, or live REPL sessions.
 </Callout>
 
 ### Persistent Root Filesystem

--- a/docs/sandbox/pause-resume/page.mdx
+++ b/docs/sandbox/pause-resume/page.mdx
@@ -34,9 +34,11 @@ On nodes using the containerd overlayfs snapshotter, `ctld` checkpoints only the
 
 Pause a sandbox to release compute while keeping its identity, configuration, services, mounted durable storage, and latest writable rootfs checkpoint available for a later resume.
 
-The pause endpoint accepts the lifecycle transition and returns once the sandbox is recorded as `pausing`. Rootfs checkpoint upload and runtime pod deletion continue in the background. Poll sandbox details until `status` is `paused` before treating the checkpoint as resume-ready.
+The pause endpoint accepts the lifecycle transition and returns the current committed state. Rootfs checkpoint upload and runtime pod deletion continue in the background. Until the pause transaction commits, sandbox details continue to report the previous committed runtime state, usually `running`. Poll sandbox details until `status` is `paused` and `paused` is `true` before treating the checkpoint as resume-ready.
 
-Runtime access paths do not require callers to special-case `pausing` or `resuming`. File, context, public service, and SSH requests either use the currently committed runtime generation or wait for the lifecycle transition to commit before continuing on the next generation.
+Runtime access paths do not expose `pausing` or `resuming` states. File, context, public service, and SSH requests are linearized to a committed runtime generation: they either use the currently committed runtime or wait for the lifecycle transaction to commit before continuing after resume. Lifecycle work in progress should not be handled as a caller-visible `409 Conflict`; conflicts are reserved for real policy or state conflicts such as disabled auto-resume, non-restartable service routes, quota limits, deletion, or paused-only operations.
+
+Automatic pause from `ttl` is opportunistic. If supported runtime access arrives before an automatic pause reaches its commit point, Sandbox0 cancels that automatic pause, releases the runtime barrier, and continues on the existing runtime generation. Explicit pause requests are not canceled by runtime access; those requests wait for the committed pause and then resume if auto-resume is allowed.
 
 <Endpoint method="POST">
 /api/v1/sandboxes/{'{id}'}/pause
@@ -118,7 +120,9 @@ console.log("Resume requested");`
 
 After requesting a pause or resume, fetch sandbox details to check the lifecycle status.
 
-During pause, `paused` remains `false` while `status` is `pausing`. It becomes `true` only after checkpoint upload has completed, the runtime pod has been released, and the sandbox is safe to resume from durable state.
+During asynchronous pause, `paused` remains `false` and `status` continues to reflect the last committed runtime state, usually `running`. It becomes `true` only after checkpoint upload has completed, the runtime pod has been released, and the sandbox is safe to resume from durable state.
+
+During resume, callers may wait while Sandbox0 creates and initializes a new runtime generation. After the resume transaction commits, `status` is `running`, `paused` is `false`, and `runtime_generation` has advanced. If an automatic pause is canceled before commit, `status` remains `running`, `paused` remains `false`, and `runtime_generation` does not change.
 
 <Tabs
   tabs={[

--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	golang.org/x/crypto v0.47.0
 	golang.org/x/net v0.48.0
 	golang.org/x/oauth2 v0.34.0
+	golang.org/x/sync v0.19.0
 	golang.org/x/sys v0.40.0
 	golang.org/x/text v0.33.0
 	golang.org/x/time v0.14.0
@@ -192,7 +193,6 @@ require (
 	golang.org/x/arch v0.11.0 // indirect
 	golang.org/x/exp v0.0.0-20251113190631-e25ba8c21ef6 // indirect
 	golang.org/x/mod v0.31.0 // indirect
-	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/term v0.39.0 // indirect
 	golang.org/x/tools v0.40.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect

--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -324,6 +324,12 @@ func main() {
 	sandboxService.SetCredentialStore(credentialStore)
 	sandboxService.SetQuotaStore(quota.NewRepository(pool))
 	sandboxService.SetSandboxStore(sandboxStore)
+	rootFSObjectStore, rootFSObjectStoreErr := buildRootFSObjectStore(cfg)
+	if rootFSObjectStoreErr != nil {
+		logger.Warn("Rootfs object cleanup disabled; object store is not configured", zap.Error(rootFSObjectStoreErr))
+	} else if rootFSObjectStore != nil {
+		sandboxService.SetRootFSObjectDeleter(rootFSObjectStore)
+	}
 	if cfg.StorageProxyBaseURL != "" && cfg.StorageProxyHTTPPort > 0 && storageProxyAdminTokenGenerator != nil {
 		storageProxyBaseURL := fmt.Sprintf("http://%s:%d", strings.TrimSpace(cfg.StorageProxyBaseURL), cfg.StorageProxyHTTPPort)
 		sandboxService.SetWebhookStateVolumeClient(service.NewStorageProxyVolumeClient(service.StorageProxyVolumeClientConfig{
@@ -505,9 +511,8 @@ func main() {
 		}
 	}()
 	if !cfg.RootFSMaintenance.Disabled {
-		rootFSObjectStore, err := buildRootFSObjectStore(cfg)
-		if err != nil {
-			logger.Warn("Rootfs maintenance disabled; object store is not configured", zap.Error(err))
+		if rootFSObjectStoreErr != nil {
+			logger.Warn("Rootfs maintenance disabled; object store is not configured", zap.Error(rootFSObjectStoreErr))
 		} else if rootFSObjectStore == nil {
 			logger.Warn("Rootfs maintenance disabled; object store is not configured")
 		} else {

--- a/manager/pkg/http/handlers_sandbox.go
+++ b/manager/pkg/http/handlers_sandbox.go
@@ -151,9 +151,7 @@ func isValidSandboxListStatus(status string) bool {
 	switch status {
 	case service.SandboxStatusStarting,
 		service.SandboxStatusRunning,
-		service.SandboxStatusPausing,
 		service.SandboxStatusPaused,
-		service.SandboxStatusResuming,
 		service.SandboxStatusTerminating,
 		service.SandboxStatusFailed:
 		return true

--- a/manager/pkg/service/ctld_client.go
+++ b/manager/pkg/service/ctld_client.go
@@ -72,6 +72,18 @@ func (c *CtldClient) SaveRootFSWithTimeout(ctx context.Context, ctldAddress stri
 	return c.apiWithTimeout(timeout).SaveRootFS(ctx, ctldAddress, req)
 }
 
+func (c *CtldClient) PrepareRootFSSnapshotWithTimeout(ctx context.Context, ctldAddress string, req ctldapi.PrepareRootFSSnapshotRequest, timeout time.Duration) (*ctldapi.PrepareRootFSSnapshotResponse, error) {
+	return c.apiWithTimeout(timeout).PrepareRootFSSnapshot(ctx, ctldAddress, req)
+}
+
+func (c *CtldClient) PublishRootFSSnapshotWithTimeout(ctx context.Context, ctldAddress string, req ctldapi.PublishRootFSSnapshotRequest, timeout time.Duration) (*ctldapi.PublishRootFSSnapshotResponse, error) {
+	return c.apiWithTimeout(timeout).PublishRootFSSnapshot(ctx, ctldAddress, req)
+}
+
+func (c *CtldClient) AbortRootFSSnapshotWithTimeout(ctx context.Context, ctldAddress string, req ctldapi.AbortRootFSSnapshotRequest, timeout time.Duration) (*ctldapi.AbortRootFSSnapshotResponse, error) {
+	return c.apiWithTimeout(timeout).AbortRootFSSnapshot(ctx, ctldAddress, req)
+}
+
 func (c *CtldClient) ApplyRootFS(ctx context.Context, ctldAddress string, req ctldapi.ApplyRootFSRequest) (*ctldapi.ApplyRootFSResponse, error) {
 	return c.apiOrDefault().ApplyRootFS(ctx, ctldAddress, req)
 }

--- a/manager/pkg/service/migrations/00007_add_sandbox_lifecycle_txns.sql
+++ b/manager/pkg/service/migrations/00007_add_sandbox_lifecycle_txns.sql
@@ -1,0 +1,52 @@
+-- +goose Up
+
+ALTER TABLE manager.sandboxes
+    ADD COLUMN IF NOT EXISTS lifecycle_epoch BIGINT NOT NULL DEFAULT 0;
+
+CREATE TABLE IF NOT EXISTS manager.sandbox_lifecycle_txns (
+    txn_id TEXT PRIMARY KEY,
+    sandbox_id TEXT NOT NULL REFERENCES manager.sandboxes(sandbox_id) ON DELETE CASCADE,
+    kind TEXT NOT NULL,
+    phase TEXT NOT NULL,
+    source TEXT NOT NULL DEFAULT 'manual',
+    cancelable BOOLEAN NOT NULL DEFAULT FALSE,
+    epoch BIGINT NOT NULL,
+    from_generation BIGINT NOT NULL DEFAULT 0,
+    to_generation BIGINT NOT NULL DEFAULT 0,
+    from_pod_namespace TEXT NOT NULL DEFAULT '',
+    from_pod_name TEXT NOT NULL DEFAULT '',
+    to_pod_namespace TEXT NOT NULL DEFAULT '',
+    to_pod_name TEXT NOT NULL DEFAULT '',
+    expected_head_layer_id TEXT NOT NULL DEFAULT '',
+    prepared_head_layer_id TEXT NOT NULL DEFAULT '',
+    error TEXT NOT NULL DEFAULT '',
+    cancel_reason TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    cancel_requested_at TIMESTAMPTZ,
+    committed_at TIMESTAMPTZ,
+    aborted_at TIMESTAMPTZ
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_sandbox_lifecycle_txns_active
+    ON manager.sandbox_lifecycle_txns(sandbox_id)
+    WHERE phase IN ('preparing', 'barriered', 'publishing', 'committing');
+
+CREATE INDEX IF NOT EXISTS idx_sandbox_lifecycle_txns_kind_phase_updated
+    ON manager.sandbox_lifecycle_txns(kind, phase, updated_at ASC);
+
+DROP TRIGGER IF EXISTS update_sandbox_lifecycle_txns_updated_at ON manager.sandbox_lifecycle_txns;
+CREATE TRIGGER update_sandbox_lifecycle_txns_updated_at
+    BEFORE UPDATE ON manager.sandbox_lifecycle_txns
+    FOR EACH ROW
+    EXECUTE FUNCTION manager.update_updated_at_column();
+
+-- +goose Down
+
+DROP TRIGGER IF EXISTS update_sandbox_lifecycle_txns_updated_at ON manager.sandbox_lifecycle_txns;
+DROP INDEX IF EXISTS manager.idx_sandbox_lifecycle_txns_kind_phase_updated;
+DROP INDEX IF EXISTS manager.idx_sandbox_lifecycle_txns_active;
+DROP TABLE IF EXISTS manager.sandbox_lifecycle_txns;
+
+ALTER TABLE manager.sandboxes
+    DROP COLUMN IF EXISTS lifecycle_epoch;

--- a/manager/pkg/service/migrations/00008_add_lifecycle_txn_cancellation.sql
+++ b/manager/pkg/service/migrations/00008_add_lifecycle_txn_cancellation.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+
+ALTER TABLE manager.sandbox_lifecycle_txns
+    ADD COLUMN IF NOT EXISTS source TEXT NOT NULL DEFAULT 'manual',
+    ADD COLUMN IF NOT EXISTS cancelable BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS cancel_reason TEXT NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS cancel_requested_at TIMESTAMPTZ;
+
+-- +goose Down
+
+ALTER TABLE manager.sandbox_lifecycle_txns
+    DROP COLUMN IF EXISTS cancel_requested_at,
+    DROP COLUMN IF EXISTS cancel_reason,
+    DROP COLUMN IF EXISTS cancelable,
+    DROP COLUMN IF EXISTS source;

--- a/manager/pkg/service/procd_client.go
+++ b/manager/pkg/service/procd_client.go
@@ -93,6 +93,33 @@ type StatsResponse struct {
 	SandboxResourceUsage
 }
 
+// ProcdLifecycleBarrierRequest controls the runtime operation barrier in procd.
+type ProcdLifecycleBarrierRequest struct {
+	Active            bool  `json:"active"`
+	Epoch             int64 `json:"epoch,omitempty"`
+	RuntimeGeneration int64 `json:"runtime_generation,omitempty"`
+	WaitTimeoutMS     int64 `json:"wait_timeout_ms,omitempty"`
+}
+
+// ProcdLifecycleBarrierResponse is returned after procd applies the barrier.
+type ProcdLifecycleBarrierResponse struct {
+	Active            bool  `json:"active"`
+	Epoch             int64 `json:"epoch,omitempty"`
+	RuntimeGeneration int64 `json:"runtime_generation,omitempty"`
+	InFlight          int   `json:"in_flight"`
+}
+
+// ProcdPauseResponse is returned after pausing all procd-managed processes.
+type ProcdPauseResponse struct {
+	Paused        bool                  `json:"paused"`
+	ResourceUsage *SandboxResourceUsage `json:"resource_usage,omitempty"`
+}
+
+// ProcdResumeResponse is returned after resuming all procd-managed processes.
+type ProcdResumeResponse struct {
+	Resumed bool `json:"resumed"`
+}
+
 // InitializeRequest represents the procd initialize request.
 type InitializeRequest struct {
 	SandboxID string             `json:"sandbox_id"`
@@ -129,6 +156,24 @@ type UpdateSandboxEnvVarsResponse struct {
 func (c *ProcdClient) Stats(ctx context.Context, procdAddress, internalToken string) (*StatsResponse, error) {
 	url := procdAddress + "/api/v1/sandbox/stats"
 	return doProcdRequest[StatsResponse](ctx, c.httpClient, http.MethodGet, url, internalToken, "stats", nil)
+}
+
+// SetLifecycleBarrier activates or releases the procd runtime operation barrier.
+func (c *ProcdClient) SetLifecycleBarrier(ctx context.Context, procdAddress string, req ProcdLifecycleBarrierRequest, internalToken string) (*ProcdLifecycleBarrierResponse, error) {
+	url := procdAddress + "/api/v1/lifecycle/barrier"
+	return doProcdRequest[ProcdLifecycleBarrierResponse](ctx, c.httpClient, http.MethodPut, url, internalToken, "set lifecycle barrier", req)
+}
+
+// PauseSandbox pauses all procd-managed processes inside the sandbox.
+func (c *ProcdClient) PauseSandbox(ctx context.Context, procdAddress, internalToken string) (*ProcdPauseResponse, error) {
+	url := procdAddress + "/api/v1/sandbox/pause"
+	return doProcdRequest[ProcdPauseResponse](ctx, c.httpClient, http.MethodPost, url, internalToken, "pause procd sandbox", nil)
+}
+
+// ResumeSandbox resumes all procd-managed processes inside the sandbox.
+func (c *ProcdClient) ResumeSandbox(ctx context.Context, procdAddress, internalToken string) (*ProcdResumeResponse, error) {
+	url := procdAddress + "/api/v1/sandbox/resume"
+	return doProcdRequest[ProcdResumeResponse](ctx, c.httpClient, http.MethodPost, url, internalToken, "resume procd sandbox", nil)
 }
 
 // Initialize calls the procd initialize API.

--- a/manager/pkg/service/rootfs_persistent_filesystem.go
+++ b/manager/pkg/service/rootfs_persistent_filesystem.go
@@ -110,9 +110,10 @@ type RootFSStorageUsage struct {
 }
 
 type RootFSObjectInfo struct {
-	Key      string
-	Size     int64
-	Modified time.Time
+	Key           string
+	Size          int64
+	SizeIsLogical bool
+	Modified      time.Time
 }
 
 type RootFSObjectAuditResult struct {
@@ -146,6 +147,7 @@ const (
 	defaultRootFSObjectDeleteClaimTTL    = 2 * time.Minute
 	defaultRootFSObjectDeleteBackoffBase = 5 * time.Second
 	defaultRootFSObjectDeleteBackoffMax  = 10 * time.Minute
+	rootFSObjectActiveLifecycleRetry     = time.Minute
 )
 
 func (s *PGSandboxStore) GetRootFSFilesystem(ctx context.Context, sandboxID string) (*RootFSFilesystem, error) {
@@ -831,9 +833,9 @@ func (s *PGSandboxStore) AuditRootFSObjects(ctx context.Context, inspector RootF
 			}
 			continue
 		}
-		if candidate.diffSize > 0 && info.Size > 0 && info.Size != candidate.diffSize {
+		if rootFSObjectAuditSizeMismatch(info, candidate.diffSize) {
 			result.SizeMismatched++
-			if updateErr := s.recordRootFSObjectAuditError(ctx, candidate.objectKey, fmt.Errorf("object size %d does not match db size %d", info.Size, candidate.diffSize)); updateErr != nil {
+			if updateErr := s.recordRootFSObjectAuditError(ctx, candidate.objectKey, rootFSObjectAuditSizeMismatchError(info, candidate.diffSize)); updateErr != nil {
 				return result, updateErr
 			}
 			continue
@@ -843,6 +845,23 @@ func (s *PGSandboxStore) AuditRootFSObjects(ctx context.Context, inspector RootF
 		}
 	}
 	return result, nil
+}
+
+func rootFSObjectAuditSizeMismatch(info RootFSObjectInfo, diffSize int64) bool {
+	if diffSize <= 0 || info.Size <= 0 {
+		return false
+	}
+	if info.SizeIsLogical {
+		return info.Size != diffSize
+	}
+	return info.Size < diffSize
+}
+
+func rootFSObjectAuditSizeMismatchError(info RootFSObjectInfo, diffSize int64) error {
+	if info.SizeIsLogical {
+		return fmt.Errorf("object logical size %d does not match db diff size %d", info.Size, diffSize)
+	}
+	return fmt.Errorf("object physical size %d is smaller than db diff size %d", info.Size, diffSize)
 }
 
 func (s *PGSandboxStore) recordRootFSObjectAuditError(ctx context.Context, objectKey string, auditErr error) error {
@@ -994,6 +1013,109 @@ func (s *PGSandboxStore) DeletePendingRootFSObjects(ctx context.Context, deleter
 	return s.DeletePendingRootFSObjectsWithOptions(ctx, deleter, DeletePendingRootFSObjectsOptions{Limit: limit})
 }
 
+func (s *PGSandboxStore) QueueUncommittedRootFSObjectDeletion(ctx context.Context, state *SandboxRootFSState, notBefore time.Time) error {
+	if s == nil || s.pool == nil || state == nil || strings.TrimSpace(state.DiffObjectKey) == "" {
+		return nil
+	}
+	if notBefore.IsZero() {
+		notBefore = time.Now().UTC()
+	}
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("begin uncommitted rootfs object deletion tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	tag, err := tx.Exec(ctx, `
+		INSERT INTO manager.rootfs_objects (
+			object_key, team_id, diff_digest, diff_media_type, diff_size,
+			first_layer_id, last_referenced_at, missing_at, deleted_at,
+			last_error, created_at, updated_at
+		)
+		VALUES ($1, $2, $3, $4, $5, $6, NOW(), NULL, NULL, '', NOW(), NOW())
+		ON CONFLICT (object_key) DO UPDATE SET
+			team_id = EXCLUDED.team_id,
+			diff_digest = EXCLUDED.diff_digest,
+			diff_media_type = EXCLUDED.diff_media_type,
+			diff_size = EXCLUDED.diff_size,
+			last_error = '',
+			updated_at = NOW()
+		WHERE manager.rootfs_objects.team_id = EXCLUDED.team_id
+			AND manager.rootfs_objects.diff_digest = EXCLUDED.diff_digest
+			AND manager.rootfs_objects.diff_size = EXCLUDED.diff_size
+	`, state.DiffObjectKey, state.TeamID, state.DiffDigest, state.DiffMediaType,
+		state.DiffSize, state.LayerID)
+	if err != nil {
+		return fmt.Errorf("track uncommitted rootfs object: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("%w: %s", ErrRootFSObjectConflict, state.DiffObjectKey)
+	}
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO manager.rootfs_object_deletions (
+			object_key, team_id, attempts, last_error,
+			next_attempt_at, claimed_by, claimed_until, dead_lettered_at,
+			created_at, updated_at
+		)
+		VALUES ($1, $2, 0, '', $3, '', NULL, NULL, NOW(), NOW())
+		ON CONFLICT (object_key) DO UPDATE SET
+			team_id = EXCLUDED.team_id,
+			next_attempt_at = EXCLUDED.next_attempt_at,
+			claimed_by = '',
+			claimed_until = NULL,
+			dead_lettered_at = NULL,
+			last_error = '',
+			updated_at = NOW()
+	`, state.DiffObjectKey, state.TeamID, notBefore.UTC()); err != nil {
+		return fmt.Errorf("queue uncommitted rootfs object deletion: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit uncommitted rootfs object deletion tx: %w", err)
+	}
+	return nil
+}
+
+func (s *PGSandboxStore) CompleteRootFSObjectDeletion(ctx context.Context, objectKey string) error {
+	if s == nil || s.pool == nil || strings.TrimSpace(objectKey) == "" {
+		return nil
+	}
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("begin rootfs object deletion completion tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if _, err := tx.Exec(ctx, `
+		UPDATE manager.rootfs_objects
+		SET deleted_at = NOW(),
+			missing_at = NULL,
+			last_error = '',
+			updated_at = NOW()
+		WHERE object_key = $1
+			AND NOT EXISTS (
+				SELECT 1
+				FROM manager.rootfs_layers
+				WHERE diff_object_key = $1
+			)
+	`, strings.TrimSpace(objectKey)); err != nil {
+		return fmt.Errorf("mark rootfs object deleted %q: %w", objectKey, err)
+	}
+	if _, err := tx.Exec(ctx, `
+		DELETE FROM manager.rootfs_object_deletions
+		WHERE object_key = $1
+			AND NOT EXISTS (
+				SELECT 1
+				FROM manager.rootfs_layers
+				WHERE diff_object_key = $1
+			)
+	`, strings.TrimSpace(objectKey)); err != nil {
+		return fmt.Errorf("clear rootfs object deletion %q: %w", objectKey, err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit rootfs object deletion completion tx: %w", err)
+	}
+	return nil
+}
+
 func (s *PGSandboxStore) DeletePendingRootFSObjectsWithOptions(ctx context.Context, deleter RootFSObjectDeleter, opts DeletePendingRootFSObjectsOptions) ([]string, error) {
 	if s == nil || s.pool == nil || deleter == nil {
 		return nil, nil
@@ -1010,12 +1132,18 @@ func (s *PGSandboxStore) DeletePendingRootFSObjectsWithOptions(ctx context.Conte
 		if err := ctx.Err(); err != nil {
 			return deleted, err
 		}
-		referenced, err := s.rootFSObjectHasLayerReferences(ctx, item.ObjectKey)
+		refs, err := s.rootFSObjectReferences(ctx, item.ObjectKey)
 		if err != nil {
 			return deleted, err
 		}
-		if referenced {
+		if refs.HasLayerReferences {
 			if err := s.clearRootFSObjectDeletion(ctx, item.ObjectKey, opts.ClaimedBy); err != nil {
+				return deleted, err
+			}
+			continue
+		}
+		if refs.HasActiveLifecycleReferences {
+			if err := s.deferRootFSObjectDeletion(ctx, item.ObjectKey, opts.ClaimedBy, rootFSObjectActiveLifecycleRetry); err != nil {
 				return deleted, err
 			}
 			continue
@@ -1041,18 +1169,33 @@ func (s *PGSandboxStore) DeletePendingRootFSObjectsWithOptions(ctx context.Conte
 	return deleted, errors.Join(errs...)
 }
 
-func (s *PGSandboxStore) rootFSObjectHasLayerReferences(ctx context.Context, objectKey string) (bool, error) {
-	var referenced bool
+type rootFSObjectReferenceState struct {
+	HasLayerReferences           bool
+	HasActiveLifecycleReferences bool
+}
+
+func (s *PGSandboxStore) rootFSObjectReferences(ctx context.Context, objectKey string) (rootFSObjectReferenceState, error) {
+	var refs rootFSObjectReferenceState
 	if err := s.pool.QueryRow(ctx, `
-		SELECT EXISTS (
-			SELECT 1
-			FROM manager.rootfs_layers
-			WHERE diff_object_key = $1
-		)
-	`, objectKey).Scan(&referenced); err != nil {
-		return false, fmt.Errorf("check rootfs object references for %q: %w", objectKey, err)
+		SELECT
+			EXISTS (
+				SELECT 1
+				FROM manager.rootfs_layers
+				WHERE diff_object_key = $1
+			) AS has_layer_references,
+			EXISTS (
+				SELECT 1
+				FROM manager.rootfs_objects o
+				JOIN manager.sandbox_lifecycle_txns t
+					ON t.prepared_head_layer_id = o.first_layer_id
+				WHERE o.object_key = $1
+					AND t.kind = 'pause'
+					AND t.phase IN ('preparing', 'barriered', 'publishing', 'committing')
+			) AS has_active_lifecycle_references
+	`, objectKey).Scan(&refs.HasLayerReferences, &refs.HasActiveLifecycleReferences); err != nil {
+		return refs, fmt.Errorf("check rootfs object references for %q: %w", objectKey, err)
 	}
-	return referenced, nil
+	return refs, nil
 }
 
 func (s *PGSandboxStore) markRootFSObjectDeleted(ctx context.Context, objectKey string) error {
@@ -1081,6 +1224,24 @@ func (s *PGSandboxStore) clearRootFSObjectDeletion(ctx context.Context, objectKe
 			AND claimed_by = $2
 	`, objectKey, claimedBy); err != nil {
 		return fmt.Errorf("clear rootfs object deletion %q: %w", objectKey, err)
+	}
+	return nil
+}
+
+func (s *PGSandboxStore) deferRootFSObjectDeletion(ctx context.Context, objectKey, claimedBy string, delay time.Duration) error {
+	if delay <= 0 {
+		delay = rootFSObjectActiveLifecycleRetry
+	}
+	if _, err := s.pool.Exec(ctx, `
+		UPDATE manager.rootfs_object_deletions
+		SET claimed_by = '',
+			claimed_until = NULL,
+			next_attempt_at = NOW() + ($3::int * INTERVAL '1 second'),
+			updated_at = NOW()
+		WHERE object_key = $1
+			AND claimed_by = $2
+	`, objectKey, claimedBy, durationSeconds(delay)); err != nil {
+		return fmt.Errorf("defer rootfs object deletion %q: %w", objectKey, err)
 	}
 	return nil
 }

--- a/manager/pkg/service/rootfs_persistent_filesystem_integration_test.go
+++ b/manager/pkg/service/rootfs_persistent_filesystem_integration_test.go
@@ -243,6 +243,91 @@ func TestRootFSObjectDeletionQueueClaimsBacksOffAndDeadLetters(t *testing.T) {
 	assert.Equal(t, int64(1), stats.DeadLettered)
 }
 
+func TestRootFSObjectDeletionSkipsActiveLifecyclePreparedHead(t *testing.T) {
+	ctx := context.Background()
+	pool := newSandboxStoreIntegrationPool(t)
+	store := NewPGSandboxStore(pool)
+
+	require.NoError(t, store.UpsertSandbox(ctx, rootFSTestSandboxRecord("sandbox-pending", "team-1")))
+	state := rootFSTestStoreState("sandbox-pending", "team-1", "layer-pending", "", 1, "pending")
+	require.NoError(t, store.QueueUncommittedRootFSObjectDeletion(ctx, state, time.Now().Add(-time.Minute)))
+	require.NoError(t, store.WithSandboxLock(ctx, "sandbox-pending", func(lockCtx context.Context, tx SandboxStoreTx, _ *SandboxRecord) error {
+		return tx.BeginLifecycleTxn(lockCtx, &SandboxLifecycleTxn{
+			ID:                  "txn-pending",
+			SandboxID:           "sandbox-pending",
+			Kind:                SandboxLifecycleKindPause,
+			Phase:               SandboxLifecyclePhasePublishing,
+			Source:              SandboxLifecycleSourceAuto,
+			Cancelable:          true,
+			FromGeneration:      1,
+			PreparedHeadLayerID: "layer-pending",
+		})
+	}))
+
+	deleter := &recordingRootFSObjectDeleter{}
+	deleted, err := store.DeletePendingRootFSObjectsWithOptions(ctx, deleter, DeletePendingRootFSObjectsOptions{
+		Limit:     1,
+		ClaimedBy: "worker-active-txn",
+		ClaimTTL:  time.Minute,
+	})
+
+	require.NoError(t, err)
+	assert.Empty(t, deleted)
+	assert.Empty(t, deleter.keys)
+	assert.Equal(t, int64(1), rootFSTestCountRows(t, pool, "rootfs_object_deletions"))
+
+	var claimedBy string
+	var nextAttemptAt time.Time
+	require.NoError(t, pool.QueryRow(ctx, `
+		SELECT claimed_by, next_attempt_at
+		FROM manager.rootfs_object_deletions
+		WHERE object_key = $1
+	`, state.DiffObjectKey).Scan(&claimedBy, &nextAttemptAt))
+	assert.Empty(t, claimedBy)
+	assert.True(t, nextAttemptAt.After(time.Now().Add(30*time.Second)))
+
+	require.NoError(t, store.WithSandboxLock(ctx, "sandbox-pending", func(lockCtx context.Context, tx SandboxStoreTx, _ *SandboxRecord) error {
+		return tx.AbortLifecycleTxn(lockCtx, "txn-pending", "test cleanup")
+	}))
+	_, err = pool.Exec(ctx, `
+		UPDATE manager.rootfs_object_deletions
+		SET next_attempt_at = NOW()
+		WHERE object_key = $1
+	`, state.DiffObjectKey)
+	require.NoError(t, err)
+
+	deleted, err = store.DeletePendingRootFSObjectsWithOptions(ctx, deleter, DeletePendingRootFSObjectsOptions{
+		Limit:     1,
+		ClaimedBy: "worker-aborted-txn",
+		ClaimTTL:  time.Minute,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{state.DiffObjectKey}, deleted)
+	assert.Equal(t, []string{state.DiffObjectKey}, deleter.keys)
+	assert.Equal(t, int64(0), rootFSTestCountRows(t, pool, "rootfs_object_deletions"))
+}
+
+func TestRootFSObjectDeletionQueueClearedWhenObjectCommits(t *testing.T) {
+	ctx := context.Background()
+	pool := newSandboxStoreIntegrationPool(t)
+	store := NewPGSandboxStore(pool)
+
+	require.NoError(t, store.UpsertSandbox(ctx, rootFSTestSandboxRecord("sandbox-committed", "team-1")))
+	state := rootFSTestStoreState("sandbox-committed", "team-1", "layer-committed", "", 1, "committed")
+	require.NoError(t, store.QueueUncommittedRootFSObjectDeletion(ctx, state, time.Now().Add(-time.Minute)))
+	assert.Equal(t, int64(1), rootFSTestCountRows(t, pool, "rootfs_object_deletions"))
+
+	require.NoError(t, store.SaveRootFSState(ctx, state))
+	assert.Equal(t, int64(0), rootFSTestCountRows(t, pool, "rootfs_object_deletions"))
+
+	deleter := &recordingRootFSObjectDeleter{}
+	deleted, err := store.DeletePendingRootFSObjects(ctx, deleter, 10)
+	require.NoError(t, err)
+	assert.Empty(t, deleted)
+	assert.Empty(t, deleter.keys)
+}
+
 func TestRootFSRootLayerSaveCanCASAgainstExistingHead(t *testing.T) {
 	ctx := context.Background()
 	pool := newSandboxStoreIntegrationPool(t)
@@ -475,6 +560,96 @@ func TestRootFSObjectAuditRecordsAndClearsMissingState(t *testing.T) {
 	`).Scan(&missingAt, &lastError))
 	assert.Nil(t, missingAt)
 	assert.Empty(t, lastError)
+}
+
+func TestRootFSObjectAuditAcceptsEncryptedPhysicalSizeOverhead(t *testing.T) {
+	ctx := context.Background()
+	pool := newSandboxStoreIntegrationPool(t)
+	store := NewPGSandboxStore(pool)
+
+	require.NoError(t, store.UpsertSandbox(ctx, rootFSTestSandboxRecord("sandbox-a", "team-1")))
+	require.NoError(t, store.SaveRootFSState(ctx, rootFSTestStoreState("sandbox-a", "team-1", "layer-a", "", 1, "audit")))
+
+	_, err := pool.Exec(ctx, `
+		UPDATE manager.rootfs_objects
+		SET missing_at = NOW(),
+			last_error = 'previous transient audit error'
+		WHERE object_key = 'rootfs/audit.tar'
+	`)
+	require.NoError(t, err)
+
+	inspector := &recordingRootFSObjectInspector{
+		info: RootFSObjectInfo{Key: "rootfs/audit.tar", Size: int64(len("audit")) + 512},
+	}
+	result, err := store.AuditRootFSObjects(ctx, inspector, "team-1", 10)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 1, result.Checked)
+	assert.Equal(t, 0, result.SizeMismatched)
+
+	var missingAt *time.Time
+	var lastError string
+	require.NoError(t, pool.QueryRow(ctx, `
+		SELECT missing_at, last_error
+		FROM manager.rootfs_objects
+		WHERE object_key = 'rootfs/audit.tar'
+	`).Scan(&missingAt, &lastError))
+	assert.Nil(t, missingAt)
+	assert.Empty(t, lastError)
+}
+
+func TestRootFSObjectAuditRejectsTruncatedPhysicalSize(t *testing.T) {
+	ctx := context.Background()
+	pool := newSandboxStoreIntegrationPool(t)
+	store := NewPGSandboxStore(pool)
+
+	require.NoError(t, store.UpsertSandbox(ctx, rootFSTestSandboxRecord("sandbox-a", "team-1")))
+	require.NoError(t, store.SaveRootFSState(ctx, rootFSTestStoreState("sandbox-a", "team-1", "layer-a", "", 1, "audit")))
+
+	inspector := &recordingRootFSObjectInspector{
+		info: RootFSObjectInfo{Key: "rootfs/audit.tar", Size: int64(len("audit")) - 1},
+	}
+	result, err := store.AuditRootFSObjects(ctx, inspector, "team-1", 10)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 1, result.Checked)
+	assert.Equal(t, 1, result.SizeMismatched)
+
+	var missingAt *time.Time
+	var lastError string
+	require.NoError(t, pool.QueryRow(ctx, `
+		SELECT missing_at, last_error
+		FROM manager.rootfs_objects
+		WHERE object_key = 'rootfs/audit.tar'
+	`).Scan(&missingAt, &lastError))
+	require.NotNil(t, missingAt)
+	assert.Contains(t, lastError, "smaller than db diff size")
+}
+
+func TestRootFSObjectAuditRejectsLogicalSizeMismatch(t *testing.T) {
+	ctx := context.Background()
+	pool := newSandboxStoreIntegrationPool(t)
+	store := NewPGSandboxStore(pool)
+
+	require.NoError(t, store.UpsertSandbox(ctx, rootFSTestSandboxRecord("sandbox-a", "team-1")))
+	require.NoError(t, store.SaveRootFSState(ctx, rootFSTestStoreState("sandbox-a", "team-1", "layer-a", "", 1, "audit")))
+
+	inspector := &recordingRootFSObjectInspector{
+		info: RootFSObjectInfo{Key: "rootfs/audit.tar", Size: int64(len("audit")) + 1, SizeIsLogical: true},
+	}
+	result, err := store.AuditRootFSObjects(ctx, inspector, "team-1", 10)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 1, result.Checked)
+	assert.Equal(t, 1, result.SizeMismatched)
+
+	var lastError string
+	require.NoError(t, pool.QueryRow(ctx, `
+		SELECT last_error
+		FROM manager.rootfs_objects
+		WHERE object_key = 'rootfs/audit.tar'
+	`).Scan(&lastError))
+	assert.Contains(t, lastError, "logical size")
 }
 
 func newSandboxStoreIntegrationPool(t *testing.T) *pgxpool.Pool {

--- a/manager/pkg/service/rootfs_persistent_filesystem_test.go
+++ b/manager/pkg/service/rootfs_persistent_filesystem_test.go
@@ -15,6 +15,7 @@ func TestSaveRootFSStateWritesLayerAndFilesystemHeadOnly(t *testing.T) {
 	exec := &recordingRootFSStateExecutor{
 		tags: []pgconn.CommandTag{
 			pgconn.NewCommandTag("INSERT 0 1"),
+			pgconn.NewCommandTag("DELETE 0"),
 			pgconn.NewCommandTag("INSERT 0 1"),
 			pgconn.NewCommandTag("SELECT 1"),
 		},
@@ -25,10 +26,11 @@ func TestSaveRootFSStateWritesLayerAndFilesystemHeadOnly(t *testing.T) {
 	err := saveRootFSState(context.Background(), exec, state)
 
 	require.NoError(t, err)
-	require.Len(t, exec.sqls, 3)
+	require.Len(t, exec.sqls, 4)
 	assert.Contains(t, exec.sqls[0], "INSERT INTO manager.rootfs_objects")
-	assert.Contains(t, exec.sqls[1], "INSERT INTO manager.rootfs_layers")
-	assert.Contains(t, exec.sqls[2], "INSERT INTO manager.rootfs_filesystems")
+	assert.Contains(t, exec.sqls[1], "DELETE FROM manager.rootfs_object_deletions")
+	assert.Contains(t, exec.sqls[2], "INSERT INTO manager.rootfs_layers")
+	assert.Contains(t, exec.sqls[3], "INSERT INTO manager.rootfs_filesystems")
 	for _, sql := range exec.sqls {
 		assert.NotContains(t, sql, "INSERT INTO manager.sandbox_rootfs_states")
 		assert.NotContains(t, sql, "INSERT INTO manager.sandbox_rootfs_heads")
@@ -49,6 +51,7 @@ func TestSaveRootFSStateMapsHeadCASMissToConflict(t *testing.T) {
 	exec := &recordingRootFSStateExecutor{
 		tags: []pgconn.CommandTag{
 			pgconn.NewCommandTag("INSERT 0 1"),
+			pgconn.NewCommandTag("DELETE 0"),
 			pgconn.NewCommandTag("INSERT 0 1"),
 			pgconn.NewCommandTag("SELECT 0"),
 		},
@@ -60,13 +63,14 @@ func TestSaveRootFSStateMapsHeadCASMissToConflict(t *testing.T) {
 	err := saveRootFSState(context.Background(), exec, state)
 
 	require.ErrorIs(t, err, ErrRootFSHeadConflict)
-	require.Len(t, exec.sqls, 3)
+	require.Len(t, exec.sqls, 4)
 }
 
 func TestSaveRootFSStateUsesExpectedHeadLayerIDWhenParentDiffers(t *testing.T) {
 	exec := &recordingRootFSStateExecutor{
 		tags: []pgconn.CommandTag{
 			pgconn.NewCommandTag("INSERT 0 1"),
+			pgconn.NewCommandTag("DELETE 0"),
 			pgconn.NewCommandTag("INSERT 0 1"),
 			pgconn.NewCommandTag("SELECT 1"),
 		},
@@ -79,8 +83,8 @@ func TestSaveRootFSStateUsesExpectedHeadLayerIDWhenParentDiffers(t *testing.T) {
 	err := saveRootFSState(context.Background(), exec, state)
 
 	require.NoError(t, err)
-	require.Len(t, exec.args, 3)
-	assert.Equal(t, "layer-parent", exec.args[2][3])
+	require.Len(t, exec.args, 4)
+	assert.Equal(t, "layer-parent", exec.args[3][3])
 }
 
 func TestSaveRootFSStateMapsObjectMetadataConflict(t *testing.T) {

--- a/manager/pkg/service/sandbox_lifecycle_controller.go
+++ b/manager/pkg/service/sandbox_lifecycle_controller.go
@@ -405,7 +405,7 @@ func SandboxRecordDeletionIsRuntimeOnly(record *SandboxRecord, namespace, podNam
 		return false
 	}
 	switch record.Status {
-	case SandboxStatusPausing, SandboxStatusPaused:
+	case SandboxStatusPaused:
 		return true
 	case SandboxStatusDeleted:
 		return false

--- a/manager/pkg/service/sandbox_lifecycle_controller_test.go
+++ b/manager/pkg/service/sandbox_lifecycle_controller_test.go
@@ -311,7 +311,7 @@ func TestSandboxServiceCleanupDeletedSandboxPreservesDurableStateForPausingRunti
 			"sandbox-a": {
 				ID:     "sandbox-a",
 				TeamID: "team-a",
-				Status: SandboxStatusPausing,
+				Status: SandboxStatusPaused,
 			},
 		}},
 		logger: zap.NewNop(),

--- a/manager/pkg/service/sandbox_pause_controller.go
+++ b/manager/pkg/service/sandbox_pause_controller.go
@@ -16,7 +16,7 @@ const (
 	defaultSandboxPauseScanLimit    = 500
 )
 
-// SandboxPauseController completes durable pausing transitions outside the API request path.
+// SandboxPauseController completes durable pause transactions outside the API request path.
 type SandboxPauseController struct {
 	service        *SandboxService
 	logger         *zap.Logger
@@ -92,14 +92,14 @@ func (c *SandboxPauseController) enqueuePausingSandboxes(ctx context.Context) {
 	if c == nil || c.service == nil || c.service.sandboxStore == nil {
 		return
 	}
-	records, err := c.service.sandboxStore.ListPausingSandboxes(ctx, c.scanLimit)
+	txns, err := c.service.sandboxStore.ListActiveLifecycleTxns(ctx, SandboxLifecycleKindPause, c.scanLimit)
 	if err != nil {
-		c.logger.Warn("Failed to list pausing sandboxes", zap.Error(err))
+		c.logger.Warn("Failed to list active pause lifecycle transactions", zap.Error(err))
 		return
 	}
-	for _, record := range records {
-		if record != nil {
-			c.EnqueueSandboxPause(record.ID)
+	for _, txn := range txns {
+		if txn != nil {
+			c.EnqueueSandboxPause(txn.SandboxID)
 		}
 	}
 }

--- a/manager/pkg/service/sandbox_runtime_identity_test.go
+++ b/manager/pkg/service/sandbox_runtime_identity_test.go
@@ -3,6 +3,8 @@ package service
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -13,20 +15,26 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	corelisters "k8s.io/client-go/listers/core/v1"
+	ktesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 )
 
 type memorySandboxStore struct {
 	mu                sync.Mutex
 	records           map[string]*SandboxRecord
+	lifecycleTxns     map[string]*SandboxLifecycleTxn
 	rootFSStates      map[string]*SandboxRootFSState
 	rootFSFilesystems map[string]*RootFSFilesystem
 	rootFSSnapshots   map[string]*RootFSSnapshot
 	deletes           []string
 	saves             int
 	pauses            int
+	lockCalls         int
+	lockStarted       chan struct{}
+	blockLock         chan struct{}
 }
 
 type memorySandboxStoreTx struct {
@@ -89,29 +97,43 @@ func (s *memorySandboxStore) ListHardExpiredSandboxes(context.Context, time.Time
 	return nil, nil
 }
 
-func (s *memorySandboxStore) ListPausingSandboxes(_ context.Context, limit int) ([]*SandboxRecord, error) {
+func (s *memorySandboxStore) ListActiveLifecycleTxns(_ context.Context, kind string, limit int) ([]*SandboxLifecycleTxn, error) {
 	if s == nil {
 		return nil, nil
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.records == nil {
+	if s.lifecycleTxns == nil {
 		return nil, nil
 	}
 	if limit <= 0 {
-		limit = len(s.records)
+		limit = len(s.lifecycleTxns)
 	}
-	records := make([]*SandboxRecord, 0, len(s.records))
-	for _, record := range s.records {
-		if record == nil || record.Status != SandboxStatusPausing {
+	txns := make([]*SandboxLifecycleTxn, 0, len(s.lifecycleTxns))
+	for _, txn := range s.lifecycleTxns {
+		if txn == nil || txn.Kind != kind || !sandboxLifecyclePhaseActive(txn.Phase) {
 			continue
 		}
-		records = append(records, cloneSandboxRecord(record))
-		if len(records) >= limit {
+		txns = append(txns, cloneSandboxLifecycleTxn(txn))
+		if len(txns) >= limit {
 			break
 		}
 	}
-	return records, nil
+	return txns, nil
+}
+
+func (s *memorySandboxStore) GetActiveLifecycleTxn(_ context.Context, sandboxID string) (*SandboxLifecycleTxn, error) {
+	if s == nil {
+		return nil, nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, txn := range s.lifecycleTxns {
+		if txn != nil && txn.SandboxID == sandboxID && sandboxLifecyclePhaseActive(txn.Phase) {
+			return cloneSandboxLifecycleTxn(txn), nil
+		}
+	}
+	return nil, nil
 }
 
 func (s *memorySandboxStore) MarkSandboxDeleted(_ context.Context, sandboxID string, deletedAt time.Time) error {
@@ -129,6 +151,13 @@ func (s *memorySandboxStore) MarkSandboxDeleted(_ context.Context, sandboxID str
 	record.DeletedAt = deletedAt
 	record.CurrentPodName = ""
 	record.CurrentPodNamespace = ""
+	for _, txn := range s.lifecycleTxns {
+		if txn != nil && txn.SandboxID == sandboxID && sandboxLifecyclePhaseActive(txn.Phase) {
+			txn.Phase = SandboxLifecyclePhaseAborted
+			txn.Error = "sandbox deleted"
+			txn.AbortedAt = deletedAt
+		}
+	}
 	delete(s.rootFSStates, sandboxID)
 	s.deletes = append(s.deletes, sandboxID)
 	return nil
@@ -161,8 +190,23 @@ func (s *memorySandboxStore) WithSandboxLock(ctx context.Context, sandboxID stri
 		return ErrSandboxRecordNotFound
 	}
 	s.mu.Lock()
+	s.lockCalls++
+	if s.lockStarted != nil {
+		select {
+		case s.lockStarted <- struct{}{}:
+		default:
+		}
+	}
+	blockLock := s.blockLock
 	record := cloneSandboxRecord(s.records[sandboxID])
 	s.mu.Unlock()
+	if blockLock != nil {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-blockLock:
+		}
+	}
 	if record == nil {
 		return ErrSandboxRecordNotFound
 	}
@@ -181,6 +225,9 @@ func (t memorySandboxStoreTx) SaveRuntime(_ context.Context, sandboxID, namespac
 	t.store.mu.Lock()
 	defer t.store.mu.Unlock()
 	record := t.store.records[sandboxID]
+	if record == nil || !record.DeletedAt.IsZero() {
+		return ErrSandboxRecordNotFound
+	}
 	record.CurrentPodNamespace = namespace
 	record.CurrentPodName = podName
 	record.Status = status
@@ -195,6 +242,9 @@ func (t memorySandboxStoreTx) MarkRuntimePaused(_ context.Context, sandboxID str
 	t.store.mu.Lock()
 	defer t.store.mu.Unlock()
 	record := t.store.records[sandboxID]
+	if record == nil || !record.DeletedAt.IsZero() {
+		return ErrSandboxRecordNotFound
+	}
 	record.CurrentPodNamespace = ""
 	record.CurrentPodName = ""
 	record.Status = SandboxStatusPaused
@@ -212,6 +262,97 @@ func (t memorySandboxStoreTx) SaveRootFSState(_ context.Context, state *SandboxR
 		t.store.rootFSStates = make(map[string]*SandboxRootFSState)
 	}
 	t.store.rootFSStates[state.SandboxID] = cloneSandboxRootFSState(state)
+	return nil
+}
+
+func (t memorySandboxStoreTx) GetActiveLifecycleTxn(_ context.Context, sandboxID string) (*SandboxLifecycleTxn, error) {
+	t.store.mu.Lock()
+	defer t.store.mu.Unlock()
+	for _, txn := range t.store.lifecycleTxns {
+		if txn != nil && txn.SandboxID == sandboxID && sandboxLifecyclePhaseActive(txn.Phase) {
+			return cloneSandboxLifecycleTxn(txn), nil
+		}
+	}
+	return nil, nil
+}
+
+func (t memorySandboxStoreTx) BeginLifecycleTxn(_ context.Context, txn *SandboxLifecycleTxn) error {
+	t.store.mu.Lock()
+	defer t.store.mu.Unlock()
+	if t.store.lifecycleTxns == nil {
+		t.store.lifecycleTxns = make(map[string]*SandboxLifecycleTxn)
+	}
+	record := t.store.records[txn.SandboxID]
+	record.LifecycleEpoch++
+	txn.Epoch = record.LifecycleEpoch
+	if txn.Phase == "" {
+		txn.Phase = SandboxLifecyclePhasePreparing
+	}
+	if txn.Source == "" {
+		txn.Source = SandboxLifecycleSourceManual
+	}
+	t.store.lifecycleTxns[txn.ID] = cloneSandboxLifecycleTxn(txn)
+	return nil
+}
+
+func (t memorySandboxStoreTx) SetLifecycleTxnRuntime(_ context.Context, txnID, namespace, podName string) error {
+	t.store.mu.Lock()
+	defer t.store.mu.Unlock()
+	if txn := t.store.lifecycleTxns[txnID]; txn != nil && sandboxLifecyclePhaseActive(txn.Phase) {
+		txn.ToPodNamespace = namespace
+		txn.ToPodName = podName
+	}
+	return nil
+}
+
+func (t memorySandboxStoreTx) UpdateLifecycleTxnPhase(_ context.Context, txnID, phase string) error {
+	t.store.mu.Lock()
+	defer t.store.mu.Unlock()
+	if txn := t.store.lifecycleTxns[txnID]; txn != nil && sandboxLifecyclePhaseActive(txn.Phase) {
+		if sandboxLifecycleTxnCancelRequested(txn) {
+			return fmt.Errorf("active lifecycle txn %s not found", txnID)
+		}
+		txn.Phase = phase
+	}
+	return nil
+}
+
+func (t memorySandboxStoreTx) RequestLifecycleTxnCancel(_ context.Context, txnID, reason string) (bool, error) {
+	t.store.mu.Lock()
+	defer t.store.mu.Unlock()
+	txn := t.store.lifecycleTxns[txnID]
+	if !sandboxLifecycleTxnCancelableAutoPause(txn) {
+		return false, nil
+	}
+	if txn.CancelRequestedAt.IsZero() {
+		txn.CancelRequestedAt = time.Now()
+	}
+	if txn.CancelReason == "" {
+		txn.CancelReason = reason
+	}
+	return true, nil
+}
+
+func (t memorySandboxStoreTx) CommitLifecycleTxn(_ context.Context, txnID, preparedHeadLayerID string) error {
+	t.store.mu.Lock()
+	defer t.store.mu.Unlock()
+	if txn := t.store.lifecycleTxns[txnID]; txn != nil && sandboxLifecyclePhaseActive(txn.Phase) {
+		if sandboxLifecycleTxnCancelRequested(txn) {
+			return fmt.Errorf("active lifecycle txn %s not found", txnID)
+		}
+		txn.Phase = SandboxLifecyclePhaseCommitted
+		txn.PreparedHeadLayerID = preparedHeadLayerID
+	}
+	return nil
+}
+
+func (t memorySandboxStoreTx) AbortLifecycleTxn(_ context.Context, txnID, reason string) error {
+	t.store.mu.Lock()
+	defer t.store.mu.Unlock()
+	if txn := t.store.lifecycleTxns[txnID]; txn != nil && sandboxLifecyclePhaseActive(txn.Phase) {
+		txn.Phase = SandboxLifecyclePhaseAborted
+		txn.Error = reason
+	}
 	return nil
 }
 
@@ -364,21 +505,33 @@ func TestResumePausedSandboxRuntimeJoinsResumingRuntime(t *testing.T) {
 	pod.Annotations[controller.AnnotationRuntimeGeneration] = "4"
 	pod.Status.Phase = corev1.PodRunning
 	pod.Status.PodIP = "10.0.0.4"
-	store := &memorySandboxStore{records: map[string]*SandboxRecord{
-		"sandbox-a": {
-			ID:                  "sandbox-a",
-			TeamID:              "team-a",
-			UserID:              "user-a",
-			TemplateID:          "default",
-			TemplateName:        "default",
-			TemplateNamespace:   "tpl-default",
-			Status:              SandboxStatusResuming,
-			CurrentPodName:      "pod-a",
-			CurrentPodNamespace: "ns-a",
-			RuntimeGeneration:   4,
-			TemplateSpec:        v1alpha1.SandboxTemplateSpec{},
+	store := &memorySandboxStore{
+		records: map[string]*SandboxRecord{
+			"sandbox-a": {
+				ID:                "sandbox-a",
+				TeamID:            "team-a",
+				UserID:            "user-a",
+				TemplateID:        "default",
+				TemplateName:      "default",
+				TemplateNamespace: "tpl-default",
+				Status:            SandboxStatusPaused,
+				RuntimeGeneration: 3,
+				TemplateSpec:      v1alpha1.SandboxTemplateSpec{},
+			},
 		},
-	}}
+		lifecycleTxns: map[string]*SandboxLifecycleTxn{
+			"txn-a": {
+				ID:             "txn-a",
+				SandboxID:      "sandbox-a",
+				Kind:           SandboxLifecycleKindResume,
+				Phase:          SandboxLifecyclePhasePreparing,
+				FromGeneration: 3,
+				ToGeneration:   4,
+				ToPodNamespace: "ns-a",
+				ToPodName:      "pod-a",
+			},
+		},
+	}
 	client := fake.NewSimpleClientset(pod.DeepCopy())
 	svc := &SandboxService{
 		k8sClient:    client,
@@ -390,6 +543,12 @@ func TestResumePausedSandboxRuntimeJoinsResumingRuntime(t *testing.T) {
 
 	go func() {
 		time.Sleep(2 * sandboxLifecycleWaitInterval)
+		store.mu.Lock()
+		store.lifecycleTxns["txn-a"].Phase = SandboxLifecyclePhaseCommitted
+		store.records["sandbox-a"].CurrentPodName = "pod-a"
+		store.records["sandbox-a"].CurrentPodNamespace = "ns-a"
+		store.records["sandbox-a"].RuntimeGeneration = 4
+		store.mu.Unlock()
 		store.setSandboxStatus("sandbox-a", SandboxStatusRunning)
 	}()
 
@@ -412,26 +571,182 @@ func TestResumePausedSandboxRuntimeJoinsResumingRuntime(t *testing.T) {
 	}
 }
 
-func TestResumePausedSandboxRuntimeCompletesPausingInsteadOfConflict(t *testing.T) {
+func TestResumeSandboxSingleflightPreventsConcurrentSandboxLocks(t *testing.T) {
 	pod := runtimeIdentityPod("ns-a", "pod-a", "sandbox-a")
 	pod.Annotations[controller.AnnotationRuntimeGeneration] = "4"
 	pod.Status.Phase = corev1.PodRunning
 	pod.Status.PodIP = "10.0.0.4"
+	lockStarted := make(chan struct{}, 1)
+	blockLock := make(chan struct{})
+	store := &memorySandboxStore{
+		records: map[string]*SandboxRecord{
+			"sandbox-a": {
+				ID:                  "sandbox-a",
+				TeamID:              "team-a",
+				UserID:              "user-a",
+				TemplateID:          "default",
+				TemplateName:        "default",
+				TemplateNamespace:   "tpl-default",
+				Status:              SandboxStatusRunning,
+				CurrentPodName:      "pod-a",
+				CurrentPodNamespace: "ns-a",
+				RuntimeGeneration:   4,
+				TemplateSpec:        v1alpha1.SandboxTemplateSpec{},
+			},
+		},
+		lockStarted: lockStarted,
+		blockLock:   blockLock,
+	}
+	svc := &SandboxService{
+		k8sClient:    fake.NewSimpleClientset(pod.DeepCopy()),
+		podLister:    runtimeIdentityPodLister(t, pod),
+		sandboxStore: store,
+		config:       SandboxServiceConfig{ProcdPort: 49983},
+		logger:       zap.NewNop(),
+	}
+
+	const callers = 16
+	errs := make(chan error, callers)
+	for i := 0; i < callers; i++ {
+		go func() {
+			_, err := svc.ResumeSandbox(context.Background(), "sandbox-a")
+			errs <- err
+		}()
+	}
+
+	select {
+	case <-lockStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for first resume executor")
+	}
+	time.Sleep(2 * sandboxLifecycleWaitInterval)
+	store.mu.Lock()
+	lockCalls := store.lockCalls
+	store.mu.Unlock()
+	if lockCalls != 1 {
+		t.Fatalf("sandbox lock calls while first resume is in flight = %d, want 1", lockCalls)
+	}
+
+	close(blockLock)
+	for i := 0; i < callers; i++ {
+		if err := <-errs; err != nil {
+			t.Fatalf("ResumeSandbox() error = %v", err)
+		}
+	}
+	store.mu.Lock()
+	lockCalls = store.lockCalls
+	store.mu.Unlock()
+	if lockCalls != 1 {
+		t.Fatalf("sandbox lock calls after joined resumes = %d, want 1", lockCalls)
+	}
+}
+
+func TestResumePausedSandboxRuntimeBeginsTransactionBeforeClaimingPod(t *testing.T) {
+	idlePod := newClaimTestPod("tpl-default", "idle-a", "default", true)
 	store := &memorySandboxStore{records: map[string]*SandboxRecord{
 		"sandbox-a": {
-			ID:                  "sandbox-a",
-			TeamID:              "team-a",
-			UserID:              "user-a",
-			TemplateID:          "default",
-			TemplateName:        "default",
-			TemplateNamespace:   "tpl-default",
-			Status:              SandboxStatusPausing,
-			CurrentPodName:      "pod-a",
-			CurrentPodNamespace: "ns-a",
-			RuntimeGeneration:   4,
-			TemplateSpec:        v1alpha1.SandboxTemplateSpec{},
+			ID:                "sandbox-a",
+			TeamID:            "team-a",
+			UserID:            "user-a",
+			TemplateID:        "default",
+			TemplateName:      "default",
+			TemplateNamespace: "tpl-default",
+			Status:            SandboxStatusPaused,
+			RuntimeGeneration: 3,
+			TemplateSpec:      v1alpha1.SandboxTemplateSpec{},
 		},
 	}}
+	client := fake.NewSimpleClientset(idlePod.DeepCopy())
+	observedTxn := make(chan *SandboxLifecycleTxn, 1)
+	client.Fake.PrependReactor("update", "pods", func(_ ktesting.Action) (bool, runtime.Object, error) {
+		txn, err := store.GetActiveLifecycleTxn(context.Background(), "sandbox-a")
+		if err != nil {
+			t.Errorf("GetActiveLifecycleTxn() error = %v", err)
+		}
+		observedTxn <- txn
+		return true, nil, errors.New("stop hot claim")
+	})
+	svc := &SandboxService{
+		k8sClient:    client,
+		podLister:    runtimeIdentityPodLister(t, idlePod),
+		sandboxStore: store,
+		config:       SandboxServiceConfig{ProcdPort: 49983},
+		clock:        fixedClock{now: time.Date(2026, time.March, 7, 12, 0, 0, 0, time.UTC)},
+		logger:       zap.NewNop(),
+	}
+
+	_, err := svc.ResumePausedSandboxRuntime(context.Background(), "sandbox-a")
+	if err == nil || !strings.Contains(err.Error(), "stop hot claim") {
+		t.Fatalf("ResumePausedSandboxRuntime() error = %v, want hot claim failure", err)
+	}
+	var txn *SandboxLifecycleTxn
+	select {
+	case txn = <-observedTxn:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for pod update")
+	}
+	if txn == nil {
+		t.Fatal("active resume txn was not visible before pod claim")
+	}
+	if txn.Kind != SandboxLifecycleKindResume || txn.Phase != SandboxLifecyclePhasePreparing {
+		t.Fatalf("observed txn = %+v, want active resume preparing txn", txn)
+	}
+	if txn.FromGeneration != 3 || txn.ToGeneration != 4 {
+		t.Fatalf("txn generations = %d -> %d, want 3 -> 4", txn.FromGeneration, txn.ToGeneration)
+	}
+
+	active, err := store.GetActiveLifecycleTxn(context.Background(), "sandbox-a")
+	if err != nil {
+		t.Fatalf("GetActiveLifecycleTxn() error = %v", err)
+	}
+	if active != nil {
+		t.Fatalf("active txn after failed claim = %+v, want nil", active)
+	}
+	var aborted *SandboxLifecycleTxn
+	for _, candidate := range store.lifecycleTxns {
+		if candidate != nil && candidate.Kind == SandboxLifecycleKindResume {
+			aborted = candidate
+			break
+		}
+	}
+	if aborted == nil || aborted.Phase != SandboxLifecyclePhaseAborted {
+		t.Fatalf("stored resume txn = %+v, want aborted", aborted)
+	}
+}
+
+func TestResumePausedSandboxRuntimeWaitsForActivePauseTransaction(t *testing.T) {
+	pod := runtimeIdentityPod("ns-a", "pod-a", "sandbox-a")
+	pod.Annotations[controller.AnnotationRuntimeGeneration] = "4"
+	pod.Status.Phase = corev1.PodRunning
+	pod.Status.PodIP = "10.0.0.4"
+	store := &memorySandboxStore{
+		records: map[string]*SandboxRecord{
+			"sandbox-a": {
+				ID:                  "sandbox-a",
+				TeamID:              "team-a",
+				UserID:              "user-a",
+				TemplateID:          "default",
+				TemplateName:        "default",
+				TemplateNamespace:   "tpl-default",
+				Status:              SandboxStatusRunning,
+				CurrentPodName:      "pod-a",
+				CurrentPodNamespace: "ns-a",
+				RuntimeGeneration:   4,
+				TemplateSpec:        v1alpha1.SandboxTemplateSpec{},
+			},
+		},
+		lifecycleTxns: map[string]*SandboxLifecycleTxn{
+			"txn-a": {
+				ID:               "txn-a",
+				SandboxID:        "sandbox-a",
+				Kind:             SandboxLifecycleKindPause,
+				Phase:            SandboxLifecyclePhasePreparing,
+				FromGeneration:   4,
+				FromPodNamespace: "ns-a",
+				FromPodName:      "pod-a",
+			},
+		},
+	}
 	svc := &SandboxService{
 		k8sClient:    fake.NewSimpleClientset(pod.DeepCopy()),
 		podLister:    runtimeIdentityPodLister(t, pod),
@@ -439,12 +754,178 @@ func TestResumePausedSandboxRuntimeCompletesPausingInsteadOfConflict(t *testing.
 		logger:       zap.NewNop(),
 	}
 
-	_, err := svc.ResumePausedSandboxRuntime(context.Background(), "sandbox-a")
-	if !errors.Is(err, ErrSandboxCheckpointRequiresCtld) {
-		t.Fatalf("ResumePausedSandboxRuntime() error = %v, want checkpoint requirement", err)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*sandboxLifecycleWaitInterval)
+	defer cancel()
+	_, err := svc.ResumePausedSandboxRuntime(ctx, "sandbox-a")
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("ResumePausedSandboxRuntime() error = %v, want context deadline", err)
 	}
 	if k8serrors.IsConflict(err) {
-		t.Fatalf("ResumePausedSandboxRuntime() returned conflict for pausing sandbox")
+		t.Fatalf("ResumePausedSandboxRuntime() returned conflict for active pause transaction")
+	}
+	if txn := store.lifecycleTxns["txn-a"]; txn == nil || txn.Phase != SandboxLifecyclePhasePreparing {
+		t.Fatalf("pause txn = %+v, want request path to leave it for the pause controller", txn)
+	}
+}
+
+func TestResumePausedSandboxRuntimeCancelsAutoPauseTransaction(t *testing.T) {
+	pod := runtimeIdentityPod("ns-a", "pod-a", "sandbox-a")
+	pod.Annotations[controller.AnnotationRuntimeGeneration] = "4"
+	pod.Status.Phase = corev1.PodRunning
+	pod.Status.PodIP = "10.0.0.4"
+	store := &memorySandboxStore{
+		records: map[string]*SandboxRecord{
+			"sandbox-a": {
+				ID:                  "sandbox-a",
+				TeamID:              "team-a",
+				UserID:              "user-a",
+				TemplateID:          "default",
+				TemplateName:        "default",
+				TemplateNamespace:   "tpl-default",
+				Status:              SandboxStatusRunning,
+				CurrentPodName:      "pod-a",
+				CurrentPodNamespace: "ns-a",
+				RuntimeGeneration:   4,
+				TemplateSpec:        v1alpha1.SandboxTemplateSpec{},
+			},
+		},
+		lifecycleTxns: map[string]*SandboxLifecycleTxn{
+			"txn-a": {
+				ID:               "txn-a",
+				SandboxID:        "sandbox-a",
+				Kind:             SandboxLifecycleKindPause,
+				Phase:            SandboxLifecyclePhasePreparing,
+				Source:           SandboxLifecycleSourceAuto,
+				Cancelable:       true,
+				FromGeneration:   4,
+				FromPodNamespace: "ns-a",
+				FromPodName:      "pod-a",
+			},
+		},
+	}
+	client := fake.NewSimpleClientset(pod.DeepCopy())
+	svc := &SandboxService{
+		k8sClient:    client,
+		podLister:    runtimeIdentityPodLister(t, pod),
+		sandboxStore: store,
+		config:       SandboxServiceConfig{ProcdPort: 49983},
+		logger:       zap.NewNop(),
+	}
+
+	cancelObserved := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(10 * time.Millisecond)
+		defer ticker.Stop()
+		deadline := time.After(time.Second)
+		for {
+			select {
+			case <-deadline:
+				return
+			case <-ticker.C:
+			}
+			store.mu.Lock()
+			txn := store.lifecycleTxns["txn-a"]
+			if txn != nil && !txn.CancelRequestedAt.IsZero() {
+				txn.Phase = SandboxLifecyclePhaseAborted
+				txn.Error = txn.CancelReason
+				store.mu.Unlock()
+				close(cancelObserved)
+				return
+			}
+			store.mu.Unlock()
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	sandbox, err := svc.ResumePausedSandboxRuntime(ctx, "sandbox-a")
+	if err != nil {
+		t.Fatalf("ResumePausedSandboxRuntime() error = %v, want nil", err)
+	}
+	select {
+	case <-cancelObserved:
+	default:
+		t.Fatal("resume path did not request auto pause cancellation")
+	}
+	if sandbox.Status != SandboxStatusRunning {
+		t.Fatalf("status = %q, want running", sandbox.Status)
+	}
+	if sandbox.InternalAddr == "" {
+		t.Fatal("runtime address is empty, want existing runtime")
+	}
+	for _, action := range client.Actions() {
+		switch action.GetVerb() {
+		case "create", "delete":
+			if action.GetResource().Resource == "pods" {
+				t.Fatalf("unexpected pod %s while canceling auto pause: %#v", action.GetVerb(), action)
+			}
+		}
+	}
+	txn := store.lifecycleTxns["txn-a"]
+	if txn == nil || txn.Phase != SandboxLifecyclePhaseAborted || txn.CancelReason == "" {
+		t.Fatalf("pause txn = %+v, want aborted with cancel reason", txn)
+	}
+}
+
+func TestCompletePausingSandboxRuntimeAbortsCanceledAutoPause(t *testing.T) {
+	pod := runtimeIdentityPod("ns-a", "pod-a", "sandbox-a")
+	pod.Annotations[controller.AnnotationRuntimeGeneration] = "4"
+	pod.Status.Phase = corev1.PodRunning
+	pod.Status.PodIP = "10.0.0.4"
+	store := &memorySandboxStore{
+		records: map[string]*SandboxRecord{
+			"sandbox-a": {
+				ID:                  "sandbox-a",
+				TeamID:              "team-a",
+				UserID:              "user-a",
+				TemplateID:          "default",
+				TemplateName:        "default",
+				TemplateNamespace:   "tpl-default",
+				Status:              SandboxStatusRunning,
+				CurrentPodName:      "pod-a",
+				CurrentPodNamespace: "ns-a",
+				RuntimeGeneration:   4,
+				TemplateSpec:        v1alpha1.SandboxTemplateSpec{},
+			},
+		},
+		lifecycleTxns: map[string]*SandboxLifecycleTxn{
+			"txn-a": {
+				ID:                "txn-a",
+				SandboxID:         "sandbox-a",
+				Kind:              SandboxLifecycleKindPause,
+				Phase:             SandboxLifecyclePhasePreparing,
+				Source:            SandboxLifecycleSourceAuto,
+				Cancelable:        true,
+				FromGeneration:    4,
+				FromPodNamespace:  "ns-a",
+				FromPodName:       "pod-a",
+				CancelRequestedAt: time.Now(),
+				CancelReason:      "runtime access arrived during auto pause",
+			},
+		},
+	}
+	client := fake.NewSimpleClientset(pod.DeepCopy())
+	svc := &SandboxService{
+		k8sClient:    client,
+		podLister:    runtimeIdentityPodLister(t, pod),
+		sandboxStore: store,
+		logger:       zap.NewNop(),
+	}
+
+	if err := svc.CompletePausingSandboxRuntime(context.Background(), "sandbox-a"); err != nil {
+		t.Fatalf("CompletePausingSandboxRuntime() error = %v, want nil", err)
+	}
+	txn := store.lifecycleTxns["txn-a"]
+	if txn == nil || txn.Phase != SandboxLifecyclePhaseAborted {
+		t.Fatalf("pause txn = %+v, want aborted", txn)
+	}
+	if store.records["sandbox-a"].Status != SandboxStatusRunning {
+		t.Fatalf("record status = %q, want running", store.records["sandbox-a"].Status)
+	}
+	for _, action := range client.Actions() {
+		if action.GetVerb() == "delete" && action.GetResource().Resource == "pods" {
+			t.Fatalf("unexpected pod delete after canceled auto pause: %#v", action)
+		}
 	}
 }
 
@@ -555,6 +1036,57 @@ func TestTerminatePausedSandboxRecordRunsPersistentCleanup(t *testing.T) {
 	}
 	if len(volumes.marked) != 1 || volumes.marked[0] != "sandbox-a:sandbox_deleted" {
 		t.Fatalf("marked volumes = %#v, want sandbox-a:sandbox_deleted", volumes.marked)
+	}
+}
+
+func TestTerminateSandboxAbortsActivePauseTransaction(t *testing.T) {
+	now := time.Date(2026, time.March, 7, 12, 0, 0, 0, time.UTC)
+	store := &memorySandboxStore{
+		records: map[string]*SandboxRecord{
+			"sandbox-a": {
+				ID:                "sandbox-a",
+				TeamID:            "team-a",
+				UserID:            "user-a",
+				TemplateID:        "default",
+				TemplateName:      "default",
+				TemplateNamespace: "tpl-default",
+				Status:            SandboxStatusRunning,
+				RuntimeGeneration: 3,
+			},
+		},
+		lifecycleTxns: map[string]*SandboxLifecycleTxn{
+			"txn-a": {
+				ID:             "txn-a",
+				SandboxID:      "sandbox-a",
+				Kind:           SandboxLifecycleKindPause,
+				Phase:          SandboxLifecyclePhaseBarriered,
+				Epoch:          1,
+				FromGeneration: 3,
+			},
+		},
+	}
+	svc := &SandboxService{
+		k8sClient:    fake.NewSimpleClientset(),
+		podLister:    runtimeIdentityPodLister(t),
+		sandboxStore: store,
+		clock:        fixedClock{now: now},
+		logger:       zap.NewNop(),
+	}
+
+	if err := svc.TerminateSandbox(context.Background(), "sandbox-a"); err != nil {
+		t.Fatalf("TerminateSandbox() error = %v", err)
+	}
+	if err := svc.CompletePausingSandboxRuntime(context.Background(), "sandbox-a"); err != nil {
+		t.Fatalf("CompletePausingSandboxRuntime() error = %v", err)
+	}
+	if got := store.records["sandbox-a"].Status; got != SandboxStatusDeleted {
+		t.Fatalf("status = %q, want deleted", got)
+	}
+	if txn, err := store.GetActiveLifecycleTxn(context.Background(), "sandbox-a"); err != nil || txn != nil {
+		t.Fatalf("active txn = %+v, err = %v, want nil", txn, err)
+	}
+	if store.pauses != 0 {
+		t.Fatalf("store pauses = %d, want 0", store.pauses)
 	}
 }
 

--- a/manager/pkg/service/sandbox_runtime_identity_test.go
+++ b/manager/pkg/service/sandbox_runtime_identity_test.go
@@ -210,7 +210,39 @@ func (s *memorySandboxStore) WithSandboxLock(ctx context.Context, sandboxID stri
 	if record == nil {
 		return ErrSandboxRecordNotFound
 	}
-	return fn(ctx, memorySandboxStoreTx{store: s}, record)
+	snapshot := s.snapshot()
+	if err := fn(ctx, memorySandboxStoreTx{store: s}, record); err != nil {
+		s.restore(snapshot)
+		return err
+	}
+	return nil
+}
+
+type memorySandboxStoreSnapshot struct {
+	records           map[string]*SandboxRecord
+	lifecycleTxns     map[string]*SandboxLifecycleTxn
+	rootFSStates      map[string]*SandboxRootFSState
+	rootFSFilesystems map[string]*RootFSFilesystem
+}
+
+func (s *memorySandboxStore) snapshot() memorySandboxStoreSnapshot {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return memorySandboxStoreSnapshot{
+		records:           cloneSandboxRecordMap(s.records),
+		lifecycleTxns:     cloneSandboxLifecycleTxnMap(s.lifecycleTxns),
+		rootFSStates:      cloneSandboxRootFSStateMap(s.rootFSStates),
+		rootFSFilesystems: cloneRootFSFilesystemMap(s.rootFSFilesystems),
+	}
+}
+
+func (s *memorySandboxStore) restore(snapshot memorySandboxStoreSnapshot) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.records = snapshot.records
+	s.lifecycleTxns = snapshot.lifecycleTxns
+	s.rootFSStates = snapshot.rootFSStates
+	s.rootFSFilesystems = snapshot.rootFSFilesystems
 }
 
 func (s *memorySandboxStore) setSandboxStatus(sandboxID, status string) {
@@ -317,6 +349,18 @@ func (t memorySandboxStoreTx) UpdateLifecycleTxnPhase(_ context.Context, txnID, 
 	return nil
 }
 
+func (t memorySandboxStoreTx) SetLifecycleTxnPreparedHead(_ context.Context, txnID, preparedHeadLayerID string) error {
+	t.store.mu.Lock()
+	defer t.store.mu.Unlock()
+	if txn := t.store.lifecycleTxns[txnID]; txn != nil && sandboxLifecyclePhaseActive(txn.Phase) {
+		if sandboxLifecycleTxnCancelRequested(txn) {
+			return fmt.Errorf("active lifecycle txn %s not found", txnID)
+		}
+		txn.PreparedHeadLayerID = preparedHeadLayerID
+	}
+	return nil
+}
+
 func (t memorySandboxStoreTx) RequestLifecycleTxnCancel(_ context.Context, txnID, reason string) (bool, error) {
 	t.store.mu.Lock()
 	defer t.store.mu.Unlock()
@@ -370,6 +414,28 @@ func cloneSandboxRecord(record *SandboxRecord) *SandboxRecord {
 	return &clone
 }
 
+func cloneSandboxRecordMap(records map[string]*SandboxRecord) map[string]*SandboxRecord {
+	if records == nil {
+		return nil
+	}
+	cloned := make(map[string]*SandboxRecord, len(records))
+	for key, record := range records {
+		cloned[key] = cloneSandboxRecord(record)
+	}
+	return cloned
+}
+
+func cloneSandboxLifecycleTxnMap(txns map[string]*SandboxLifecycleTxn) map[string]*SandboxLifecycleTxn {
+	if txns == nil {
+		return nil
+	}
+	cloned := make(map[string]*SandboxLifecycleTxn, len(txns))
+	for key, txn := range txns {
+		cloned[key] = cloneSandboxLifecycleTxn(txn)
+	}
+	return cloned
+}
+
 func cloneSandboxRootFSState(state *SandboxRootFSState) *SandboxRootFSState {
 	if state == nil {
 		return nil
@@ -380,6 +446,28 @@ func cloneSandboxRootFSState(state *SandboxRootFSState) *SandboxRootFSState {
 	}
 	clone.LayerChain = cloneSandboxRootFSLayers(state.LayerChain)
 	return &clone
+}
+
+func cloneSandboxRootFSStateMap(states map[string]*SandboxRootFSState) map[string]*SandboxRootFSState {
+	if states == nil {
+		return nil
+	}
+	cloned := make(map[string]*SandboxRootFSState, len(states))
+	for key, state := range states {
+		cloned[key] = cloneSandboxRootFSState(state)
+	}
+	return cloned
+}
+
+func cloneRootFSFilesystemMap(filesystems map[string]*RootFSFilesystem) map[string]*RootFSFilesystem {
+	if filesystems == nil {
+		return nil
+	}
+	cloned := make(map[string]*RootFSFilesystem, len(filesystems))
+	for key, filesystem := range filesystems {
+		cloned[key] = cloneRootFSFilesystemForTest(filesystem)
+	}
+	return cloned
 }
 
 func TestRootFSStateFromLayerChainKeepsCurrentSandboxID(t *testing.T) {

--- a/manager/pkg/service/sandbox_runtime_identity_test.go
+++ b/manager/pkg/service/sandbox_runtime_identity_test.go
@@ -746,7 +746,7 @@ func TestResumePausedSandboxRuntimeBeginsTransactionBeforeClaimingPod(t *testing
 	}}
 	client := fake.NewSimpleClientset(idlePod.DeepCopy())
 	observedTxn := make(chan *SandboxLifecycleTxn, 1)
-	client.Fake.PrependReactor("update", "pods", func(_ ktesting.Action) (bool, runtime.Object, error) {
+	client.PrependReactor("update", "pods", func(_ ktesting.Action) (bool, runtime.Object, error) {
 		txn, err := store.GetActiveLifecycleTxn(context.Background(), "sandbox-a")
 		if err != nil {
 			t.Errorf("GetActiveLifecycleTxn() error = %v", err)

--- a/manager/pkg/service/sandbox_service.go
+++ b/manager/pkg/service/sandbox_service.go
@@ -119,6 +119,7 @@ type SandboxService struct {
 	deletionWebhookEmitter SandboxDeletionWebhookEmitter
 	quotaStore             TeamQuotaLimitStore
 	sandboxStore           SandboxStore
+	rootFSObjectDeleter    RootFSObjectDeleter
 	resumeGroup            singleflight.Group
 }
 
@@ -287,4 +288,10 @@ func (s *SandboxService) SetQuotaStore(store TeamQuotaLimitStore) {
 // SetSandboxStore injects durable sandbox identity storage.
 func (s *SandboxService) SetSandboxStore(store SandboxStore) {
 	s.sandboxStore = store
+}
+
+// SetRootFSObjectDeleter injects the object-store deleter used to clean up
+// rootfs diffs that were uploaded but never committed into the DB rootfs head.
+func (s *SandboxService) SetRootFSObjectDeleter(deleter RootFSObjectDeleter) {
+	s.rootFSObjectDeleter = deleter
 }

--- a/manager/pkg/service/sandbox_service.go
+++ b/manager/pkg/service/sandbox_service.go
@@ -13,6 +13,7 @@ import (
 	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
 	"github.com/sandbox0-ai/sandbox0/pkg/quota"
 	"go.uber.org/zap"
+	"golang.org/x/sync/singleflight"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
@@ -43,9 +44,7 @@ type Sandbox struct {
 const (
 	SandboxStatusStarting    = "starting"
 	SandboxStatusRunning     = "running"
-	SandboxStatusPausing     = "pausing"
 	SandboxStatusPaused      = "paused"
-	SandboxStatusResuming    = "resuming"
 	SandboxStatusFailed      = "failed"
 	SandboxStatusTerminating = "terminating"
 )
@@ -60,7 +59,7 @@ var ErrInvalidNetworkPolicy = errors.New("invalid network policy")
 var ErrSandboxCheckpointRequiresCtld = errors.New("sandbox checkpoint pause requires ctld")
 
 const defaultPodClaimReadyTimeout = 90 * time.Second
-const defaultSandboxRestoreTimeout = 2 * time.Minute
+const defaultSandboxRestoreTimeout = 5 * time.Minute
 
 // claimIdlePodBackoff is the retry backoff for claiming idle pods.
 // Designed to balance between:
@@ -120,6 +119,7 @@ type SandboxService struct {
 	deletionWebhookEmitter SandboxDeletionWebhookEmitter
 	quotaStore             TeamQuotaLimitStore
 	sandboxStore           SandboxStore
+	resumeGroup            singleflight.Group
 }
 
 type TeamQuotaLimitStore interface {
@@ -127,7 +127,7 @@ type TeamQuotaLimitStore interface {
 	CurrentUsage(ctx context.Context, teamID string, dimension quota.Dimension) (int64, error)
 }
 
-// SandboxPauseEnqueuer schedules durable pausing sandboxes for background completion.
+// SandboxPauseEnqueuer schedules durable pause transactions for background completion.
 type SandboxPauseEnqueuer interface {
 	EnqueueSandboxPause(sandboxID string)
 }

--- a/manager/pkg/service/sandbox_service_lifecycle.go
+++ b/manager/pkg/service/sandbox_service_lifecycle.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
@@ -79,9 +80,25 @@ func (s *SandboxService) PauseSandboxRuntime(ctx context.Context, sandboxID stri
 	return err
 }
 
-// RequestPauseSandboxRuntime records a durable pausing state and returns without
-// waiting for rootfs checkpoint upload.
+type pauseSandboxRuntimeOptions struct {
+	source     string
+	cancelable bool
+}
+
+// RequestPauseSandboxRuntime records a durable pause transaction and returns
+// without waiting for rootfs checkpoint upload.
 func (s *SandboxService) RequestPauseSandboxRuntime(ctx context.Context, sandboxID string) (string, error) {
+	return s.requestPauseSandboxRuntime(ctx, sandboxID, pauseSandboxRuntimeOptions{source: SandboxLifecycleSourceManual})
+}
+
+func (s *SandboxService) requestAutoPauseSandboxRuntime(ctx context.Context, sandboxID string) (string, error) {
+	return s.requestPauseSandboxRuntime(ctx, sandboxID, pauseSandboxRuntimeOptions{
+		source:     SandboxLifecycleSourceAuto,
+		cancelable: true,
+	})
+}
+
+func (s *SandboxService) requestPauseSandboxRuntime(ctx context.Context, sandboxID string, opts pauseSandboxRuntimeOptions) (string, error) {
 	if s == nil {
 		return "", fmt.Errorf("sandbox service is nil")
 	}
@@ -92,18 +109,26 @@ func (s *SandboxService) RequestPauseSandboxRuntime(ctx context.Context, sandbox
 		return SandboxStatusPaused, nil
 	}
 
-	status := SandboxStatusPausing
+	status := SandboxStatusRunning
 	err := s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, record *SandboxRecord) error {
+		activeTxn, err := tx.GetActiveLifecycleTxn(lockCtx, sandboxID)
+		if err != nil {
+			return err
+		}
+		if activeTxn != nil {
+			if activeTxn.Kind != SandboxLifecycleKindPause {
+				return errSandboxLifecycleResuming
+			}
+			status = record.Status
+			return nil
+		}
 		switch record.Status {
 		case SandboxStatusDeleted:
 			return k8serrors.NewNotFound(schema.GroupResource{Resource: "sandbox"}, sandboxID)
 		case SandboxStatusPaused:
 			status = SandboxStatusPaused
 			return nil
-		case SandboxStatusPausing:
-			status = SandboxStatusPausing
-			return nil
-		case SandboxStatusStarting, SandboxStatusResuming:
+		case SandboxStatusStarting:
 			return k8serrors.NewConflict(schema.GroupResource{Resource: "sandbox"}, sandboxID, fmt.Errorf("sandbox lifecycle operation %q is in progress", record.Status))
 		}
 
@@ -119,10 +144,30 @@ func (s *SandboxService) RequestPauseSandboxRuntime(ctx context.Context, sandbox
 			return ErrSandboxCheckpointRequiresCtld
 		}
 		generation := runtimeGenerationFromPod(pod)
-		status = SandboxStatusPausing
-		return tx.SaveRuntime(lockCtx, sandboxID, pod.Namespace, pod.Name, SandboxStatusPausing, generation, parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationExpiresAt), parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationHardExpiresAt))
+		status = record.Status
+		source := strings.TrimSpace(opts.source)
+		if source == "" {
+			source = SandboxLifecycleSourceManual
+		}
+		return tx.BeginLifecycleTxn(lockCtx, &SandboxLifecycleTxn{
+			ID:               uuid.NewString(),
+			SandboxID:        sandboxID,
+			Kind:             SandboxLifecycleKindPause,
+			Phase:            SandboxLifecyclePhasePreparing,
+			Source:           source,
+			Cancelable:       opts.cancelable,
+			FromGeneration:   generation,
+			FromPodNamespace: pod.Namespace,
+			FromPodName:      pod.Name,
+		})
 	})
 	if err != nil {
+		if errors.Is(err, errSandboxLifecycleResuming) {
+			if waitErr := s.waitForSandboxLifecycleTxnExit(ctx, sandboxID); waitErr != nil {
+				return "", waitErr
+			}
+			return s.requestPauseSandboxRuntime(ctx, sandboxID, opts)
+		}
 		if errors.Is(err, ErrSandboxRecordNotFound) {
 			if fallbackErr := s.pauseSandboxRuntime(ctx, sandboxID, true); fallbackErr != nil {
 				return "", fallbackErr
@@ -131,11 +176,15 @@ func (s *SandboxService) RequestPauseSandboxRuntime(ctx context.Context, sandbox
 		}
 		return "", err
 	}
-	if status == SandboxStatusPausing {
+	if status != SandboxStatusPaused {
 		s.enqueueSandboxPause(sandboxID)
 	}
 	return status, nil
 }
+
+const sandboxLifecycleBarrierWaitTimeout = 30 * time.Second
+
+var errSandboxLifecycleCanceled = errors.New("sandbox lifecycle transaction canceled")
 
 func (s *SandboxService) enqueueSandboxPause(sandboxID string) {
 	if s == nil || strings.TrimSpace(sandboxID) == "" {
@@ -155,6 +204,32 @@ func (s *SandboxService) enqueueSandboxPause(sandboxID string) {
 	}()
 }
 
+func (s *SandboxService) abortPauseIfCancelRequested(ctx context.Context, sandboxID, txnID string) (bool, error) {
+	if s == nil || s.sandboxStore == nil || strings.TrimSpace(txnID) == "" {
+		return false, nil
+	}
+	canceled := false
+	err := s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, _ *SandboxRecord) error {
+		activeTxn, err := tx.GetActiveLifecycleTxn(lockCtx, sandboxID)
+		if err != nil {
+			return err
+		}
+		if activeTxn == nil || activeTxn.ID != txnID || activeTxn.Kind != SandboxLifecycleKindPause {
+			return nil
+		}
+		if !sandboxLifecycleTxnCancelRequested(activeTxn) {
+			return nil
+		}
+		reason := strings.TrimSpace(activeTxn.CancelReason)
+		if reason == "" {
+			reason = "auto pause canceled by runtime access"
+		}
+		canceled = true
+		return tx.AbortLifecycleTxn(lockCtx, txnID, reason)
+	})
+	return canceled, err
+}
+
 func (s *SandboxService) pauseSandboxRuntime(ctx context.Context, sandboxID string, saveRootFS bool) error {
 	if s.logger != nil {
 		s.logger.Info("Pausing sandbox runtime", zap.String("sandboxID", sandboxID))
@@ -166,7 +241,7 @@ func (s *SandboxService) pauseSandboxRuntime(ctx context.Context, sandboxID stri
 				return k8serrors.NewNotFound(schema.GroupResource{Resource: "sandbox"}, sandboxID)
 			case SandboxStatusPaused:
 				return nil
-			case SandboxStatusStarting, SandboxStatusPausing, SandboxStatusResuming:
+			case SandboxStatusStarting:
 				if saveRootFS {
 					return k8serrors.NewConflict(schema.GroupResource{Resource: "sandbox"}, sandboxID, fmt.Errorf("sandbox lifecycle operation %q is in progress", record.Status))
 				}
@@ -225,11 +300,17 @@ func (s *SandboxService) CompletePausingSandboxRuntime(ctx context.Context, sand
 	}
 
 	var record *SandboxRecord
-	if err := s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(_ context.Context, _ SandboxStoreTx, locked *SandboxRecord) error {
-		if locked.Status != SandboxStatusPausing {
+	var txn *SandboxLifecycleTxn
+	if err := s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, locked *SandboxRecord) error {
+		activeTxn, err := tx.GetActiveLifecycleTxn(lockCtx, sandboxID)
+		if err != nil {
+			return err
+		}
+		if activeTxn == nil || activeTxn.Kind != SandboxLifecycleKindPause {
 			return nil
 		}
 		record = cloneSandboxRecordForLifecycle(locked)
+		txn = cloneSandboxLifecycleTxn(activeTxn)
 		return nil
 	}); err != nil {
 		if errors.Is(err, ErrSandboxRecordNotFound) {
@@ -240,62 +321,122 @@ func (s *SandboxService) CompletePausingSandboxRuntime(ctx context.Context, sand
 	if record == nil {
 		return nil
 	}
+	if canceled, err := s.abortPauseIfCancelRequested(ctx, sandboxID, txn.ID); err != nil || canceled {
+		return err
+	}
 
 	pod, err := s.getSandboxPod(ctx, sandboxID)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			return s.markPausingRuntimePaused(ctx, sandboxID, record.RuntimeGeneration, nil)
+			return s.commitPausingRuntimePaused(ctx, sandboxID, txn, record.RuntimeGeneration, nil)
 		}
 		return fmt.Errorf("get pod: %w", err)
 	}
 	generation := runtimeGenerationFromPod(pod)
-	if generation != record.RuntimeGeneration {
-		return fmt.Errorf("sandbox runtime generation changed during pause: record=%d pod=%d", record.RuntimeGeneration, generation)
+	if generation != txn.FromGeneration {
+		return fmt.Errorf("sandbox runtime generation changed during pause: txn=%d pod=%d", txn.FromGeneration, generation)
 	}
-	if record.CurrentPodName != "" && pod.Name != record.CurrentPodName {
-		return k8serrors.NewConflict(schema.GroupResource{Resource: "pod"}, pod.Name, fmt.Errorf("pausing sandbox points at runtime pod %s", record.CurrentPodName))
+	if txn.FromPodName != "" && pod.Name != txn.FromPodName {
+		return k8serrors.NewConflict(schema.GroupResource{Resource: "pod"}, pod.Name, fmt.Errorf("pause transaction points at runtime pod %s", txn.FromPodName))
 	}
-	if record.CurrentPodNamespace != "" && pod.Namespace != record.CurrentPodNamespace {
-		return k8serrors.NewConflict(schema.GroupResource{Resource: "pod"}, pod.Name, fmt.Errorf("pausing sandbox points at runtime namespace %s", record.CurrentPodNamespace))
+	if txn.FromPodNamespace != "" && pod.Namespace != txn.FromPodNamespace {
+		return k8serrors.NewConflict(schema.GroupResource{Resource: "pod"}, pod.Name, fmt.Errorf("pause transaction points at runtime namespace %s", txn.FromPodNamespace))
 	}
 	if !s.config.CtldEnabled || s.ctldClient == nil {
 		return ErrSandboxCheckpointRequiresCtld
 	}
-	rootFSState, err := s.prepareSandboxRootFSCheckpoint(ctx, pod, record)
-	if err != nil {
+	if canceled, err := s.abortPauseIfCancelRequested(ctx, sandboxID, txn.ID); err != nil || canceled {
 		return err
 	}
-	stillPausing, err := s.sandboxStillPausing(ctx, sandboxID, generation)
+	if err := s.markLifecycleTxnPhase(ctx, sandboxID, txn.ID, SandboxLifecyclePhaseBarriered); err != nil {
+		if errors.Is(err, errSandboxLifecycleCanceled) {
+			return nil
+		}
+		return err
+	}
+	procdAddress, internalToken, err := s.activatePauseRuntimeBarrier(ctx, pod, record, txn)
+	if err != nil {
+		_ = s.abortLifecycleTxn(ctx, sandboxID, txn.ID, err.Error())
+		return err
+	}
+	barrierActive := true
+	defer func() {
+		if barrierActive {
+			s.releasePauseRuntimeBarrier(context.Background(), procdAddress, internalToken)
+		}
+	}()
+	if canceled, err := s.abortPauseIfCancelRequested(ctx, sandboxID, txn.ID); err != nil || canceled {
+		return err
+	}
+	if err := s.markLifecycleTxnPhase(ctx, sandboxID, txn.ID, SandboxLifecyclePhasePublishing); err != nil {
+		if errors.Is(err, errSandboxLifecycleCanceled) {
+			return nil
+		}
+		_ = s.abortLifecycleTxn(ctx, sandboxID, txn.ID, err.Error())
+		return err
+	}
+	rootFSState, err := s.prepareSandboxRootFSCheckpoint(ctx, pod, record)
+	if err != nil {
+		_ = s.abortLifecycleTxn(ctx, sandboxID, txn.ID, err.Error())
+		return err
+	}
+	stillPausing, err := s.sandboxStillPausing(ctx, sandboxID, txn.ID)
 	if err != nil || !stillPausing {
+		return err
+	}
+	if canceled, err := s.abortPauseIfCancelRequested(ctx, sandboxID, txn.ID); err != nil || canceled {
 		return err
 	}
 	pod, err = s.ensureSandboxDeletionFinalizer(ctx, pod)
 	if err != nil {
+		_ = s.abortLifecycleTxn(ctx, sandboxID, txn.ID, err.Error())
 		return fmt.Errorf("ensure sandbox cleanup finalizer: %w", err)
 	}
-	if err := s.k8sClient.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{}); err != nil && !k8serrors.IsNotFound(err) {
-		return fmt.Errorf("delete runtime pod: %w", err)
+	if err := s.markLifecycleTxnPhase(ctx, sandboxID, txn.ID, SandboxLifecyclePhaseCommitting); err != nil {
+		if errors.Is(err, errSandboxLifecycleCanceled) {
+			return nil
+		}
+		_ = s.abortLifecycleTxn(ctx, sandboxID, txn.ID, err.Error())
+		return err
 	}
-	return s.markPausingRuntimePaused(ctx, sandboxID, generation, rootFSState)
+	if err := s.commitPausingRuntimePaused(ctx, sandboxID, txn, generation, rootFSState); err != nil {
+		_ = s.abortLifecycleTxn(ctx, sandboxID, txn.ID, err.Error())
+		return err
+	}
+	barrierActive = false
+	if err := s.k8sClient.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{}); err != nil && !k8serrors.IsNotFound(err) {
+		if s.logger != nil {
+			s.logger.Warn("Committed sandbox pause but failed to delete old runtime pod",
+				zap.String("sandboxID", sandboxID),
+				zap.String("pod", pod.Name),
+				zap.Error(err),
+			)
+		}
+	}
+	return nil
 }
 
-func (s *SandboxService) sandboxStillPausing(ctx context.Context, sandboxID string, generation int64) (bool, error) {
+func (s *SandboxService) sandboxStillPausing(ctx context.Context, sandboxID, txnID string) (bool, error) {
 	if s == nil || s.sandboxStore == nil {
 		return true, nil
 	}
-	record, err := s.sandboxStore.GetSandbox(ctx, sandboxID)
+	txn, err := s.sandboxStore.GetActiveLifecycleTxn(ctx, sandboxID)
 	if err != nil {
 		return false, err
 	}
-	return record != nil && record.Status == SandboxStatusPausing && record.RuntimeGeneration == generation, nil
+	return txn != nil && txn.ID == txnID && txn.Kind == SandboxLifecycleKindPause, nil
 }
 
-func (s *SandboxService) markPausingRuntimePaused(ctx context.Context, sandboxID string, generation int64, rootFSState *SandboxRootFSState) error {
+func (s *SandboxService) commitPausingRuntimePaused(ctx context.Context, sandboxID string, txn *SandboxLifecycleTxn, generation int64, rootFSState *SandboxRootFSState) error {
 	if s == nil || s.sandboxStore == nil {
 		return nil
 	}
 	return s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, record *SandboxRecord) error {
-		if record.Status != SandboxStatusPausing || record.RuntimeGeneration != generation {
+		activeTxn, err := tx.GetActiveLifecycleTxn(lockCtx, sandboxID)
+		if err != nil {
+			return err
+		}
+		if activeTxn == nil || activeTxn.Kind != SandboxLifecycleKindPause || txn == nil || activeTxn.ID != txn.ID {
 			return nil
 		}
 		if rootFSState != nil {
@@ -303,8 +444,119 @@ func (s *SandboxService) markPausingRuntimePaused(ctx context.Context, sandboxID
 				return err
 			}
 		}
-		return tx.MarkRuntimePaused(lockCtx, sandboxID, generation, s.clock.Now())
+		if err := tx.MarkRuntimePaused(lockCtx, sandboxID, generation, s.clock.Now()); err != nil {
+			return err
+		}
+		preparedHead := ""
+		if rootFSState != nil {
+			preparedHead = rootFSState.LayerID
+		}
+		return tx.CommitLifecycleTxn(lockCtx, txn.ID, preparedHead)
 	})
+}
+
+func (s *SandboxService) markLifecycleTxnPhase(ctx context.Context, sandboxID, txnID, phase string) error {
+	if s == nil || s.sandboxStore == nil || strings.TrimSpace(txnID) == "" {
+		return nil
+	}
+	err := s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, _ *SandboxRecord) error {
+		activeTxn, err := tx.GetActiveLifecycleTxn(lockCtx, sandboxID)
+		if err != nil {
+			return err
+		}
+		if activeTxn == nil || activeTxn.ID != txnID {
+			return nil
+		}
+		return tx.UpdateLifecycleTxnPhase(lockCtx, txnID, phase)
+	})
+	if err == nil {
+		return nil
+	}
+	if canceled, cancelErr := s.abortPauseIfCancelRequested(ctx, sandboxID, txnID); cancelErr != nil {
+		return cancelErr
+	} else if canceled {
+		return errSandboxLifecycleCanceled
+	}
+	return err
+}
+
+func (s *SandboxService) abortLifecycleTxn(ctx context.Context, sandboxID, txnID, reason string) error {
+	if s == nil || s.sandboxStore == nil || strings.TrimSpace(txnID) == "" {
+		return nil
+	}
+	return s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, _ *SandboxRecord) error {
+		activeTxn, err := tx.GetActiveLifecycleTxn(lockCtx, sandboxID)
+		if err != nil {
+			return err
+		}
+		if activeTxn == nil || activeTxn.ID != txnID {
+			return nil
+		}
+		return tx.AbortLifecycleTxn(lockCtx, txnID, reason)
+	})
+}
+
+func (s *SandboxService) activatePauseRuntimeBarrier(ctx context.Context, pod *corev1.Pod, record *SandboxRecord, txn *SandboxLifecycleTxn) (string, string, error) {
+	procdAddress, internalToken, err := s.procdLifecycleClientContext(ctx, pod, record)
+	if err != nil {
+		return "", "", err
+	}
+	if _, err := s.procdClient.SetLifecycleBarrier(ctx, procdAddress, ProcdLifecycleBarrierRequest{
+		Active:            true,
+		Epoch:             txn.Epoch,
+		RuntimeGeneration: txn.FromGeneration,
+		WaitTimeoutMS:     int64(sandboxLifecycleBarrierWaitTimeout / time.Millisecond),
+	}, internalToken); err != nil {
+		return procdAddress, internalToken, fmt.Errorf("activate procd lifecycle barrier: %w", err)
+	}
+	if _, err := s.procdClient.PauseSandbox(ctx, procdAddress, internalToken); err != nil {
+		_, _ = s.procdClient.SetLifecycleBarrier(context.Background(), procdAddress, ProcdLifecycleBarrierRequest{Active: false}, internalToken)
+		return procdAddress, internalToken, fmt.Errorf("freeze procd sandbox: %w", err)
+	}
+	return procdAddress, internalToken, nil
+}
+
+func (s *SandboxService) releasePauseRuntimeBarrier(ctx context.Context, procdAddress, internalToken string) {
+	if s == nil || s.procdClient == nil || strings.TrimSpace(procdAddress) == "" || strings.TrimSpace(internalToken) == "" {
+		return
+	}
+	_, _ = s.procdClient.ResumeSandbox(ctx, procdAddress, internalToken)
+	_, _ = s.procdClient.SetLifecycleBarrier(ctx, procdAddress, ProcdLifecycleBarrierRequest{Active: false}, internalToken)
+}
+
+func (s *SandboxService) procdLifecycleClientContext(ctx context.Context, pod *corev1.Pod, record *SandboxRecord) (string, string, error) {
+	if s == nil || s.procdClient == nil {
+		return "", "", fmt.Errorf("procd client is not configured")
+	}
+	if s.internalTokenGenerator == nil {
+		return "", "", fmt.Errorf("token generators not configured, cannot authenticate with procd")
+	}
+	procdAddress, err := s.prodAddress(ctx, pod)
+	if err != nil {
+		return "", "", fmt.Errorf("procd address: %w", err)
+	}
+	teamID, userID, sandboxID := "", "", ""
+	if record != nil {
+		teamID = record.TeamID
+		userID = record.UserID
+		sandboxID = record.ID
+	}
+	if pod != nil && pod.Annotations != nil {
+		if teamID == "" {
+			teamID = pod.Annotations[controller.AnnotationTeamID]
+		}
+		if userID == "" {
+			userID = pod.Annotations[controller.AnnotationUserID]
+		}
+	}
+	if sandboxID == "" {
+		sandboxID = sandboxIDFromPod(pod)
+	}
+	internalToken, err := s.internalTokenGenerator.GenerateToken(teamID, userID, sandboxID)
+	if err != nil {
+		return "", "", fmt.Errorf("generate internal token: %w", err)
+	}
+	return procdAddress, internalToken, nil
 }
 
 func cloneSandboxRecordForLifecycle(record *SandboxRecord) *SandboxRecord {
@@ -323,7 +575,8 @@ func cloneSandboxRecordForLifecycle(record *SandboxRecord) *SandboxRecord {
 
 // PauseSandboxByID implements controller.SandboxRuntimePauser.
 func (s *SandboxService) PauseSandboxByID(ctx context.Context, sandboxID string) error {
-	return s.PauseSandboxRuntime(ctx, sandboxID)
+	_, err := s.requestAutoPauseSandboxRuntime(ctx, sandboxID)
+	return err
 }
 
 // ListHardExpiredSandboxIDs returns durable sandboxes whose hard TTL has expired.
@@ -357,7 +610,14 @@ func (s *SandboxService) GetSandbox(ctx context.Context, sandboxID string) (*San
 			if record.Status == SandboxStatusDeleted {
 				return nil, k8serrors.NewNotFound(schema.GroupResource{Resource: "sandbox"}, sandboxID)
 			}
-			if recordLifecycleStatusOverridesPod(record.Status) {
+			if record.Status == SandboxStatusPaused {
+				return s.recordToSandbox(record), nil
+			}
+			activeTxn, txnErr := s.sandboxStore.GetActiveLifecycleTxn(ctx, sandboxID)
+			if txnErr != nil {
+				return nil, fmt.Errorf("get active sandbox lifecycle txn: %w", txnErr)
+			}
+			if sandboxLifecycleTxnHidesCommittedRuntime(activeTxn) {
 				return s.recordToSandbox(record), nil
 			}
 		}
@@ -796,9 +1056,33 @@ func (s *SandboxService) recordToSandbox(record *SandboxRecord) *Sandbox {
 	}
 }
 
-func recordLifecycleStatusOverridesPod(status string) bool {
-	switch status {
-	case SandboxStatusPausing, SandboxStatusResuming:
+func sandboxLifecycleTxnHidesCommittedRuntime(txn *SandboxLifecycleTxn) bool {
+	if txn == nil {
+		return false
+	}
+	switch txn.Kind {
+	case SandboxLifecycleKindResume:
+		return true
+	case SandboxLifecycleKindPause:
+		return true
+	default:
+		return false
+	}
+}
+
+func sandboxLifecycleTxnCancelRequested(txn *SandboxLifecycleTxn) bool {
+	return txn != nil && !txn.CancelRequestedAt.IsZero()
+}
+
+func sandboxLifecycleTxnCancelableAutoPause(txn *SandboxLifecycleTxn) bool {
+	if txn == nil {
+		return false
+	}
+	if txn.Kind != SandboxLifecycleKindPause || txn.Source != SandboxLifecycleSourceAuto || !txn.Cancelable {
+		return false
+	}
+	switch txn.Phase {
+	case SandboxLifecyclePhasePreparing, SandboxLifecyclePhaseBarriered, SandboxLifecyclePhasePublishing:
 		return true
 	default:
 		return false

--- a/manager/pkg/service/sandbox_service_lifecycle.go
+++ b/manager/pkg/service/sandbox_service_lifecycle.go
@@ -380,6 +380,19 @@ func (s *SandboxService) CompletePausingSandboxRuntime(ctx context.Context, sand
 		_ = s.abortLifecycleTxn(ctx, sandboxID, txn.ID, err.Error())
 		return err
 	}
+	rootFSCommitted := false
+	defer func() {
+		if !rootFSCommitted {
+			s.deleteUncommittedRootFSObject(rootFSState, "pause transaction did not commit")
+		}
+	}()
+	if err := s.markLifecycleTxnPreparedHead(ctx, sandboxID, txn.ID, rootFSState.LayerID); err != nil {
+		if errors.Is(err, errSandboxLifecycleCanceled) {
+			return nil
+		}
+		_ = s.abortLifecycleTxn(ctx, sandboxID, txn.ID, err.Error())
+		return err
+	}
 	stillPausing, err := s.sandboxStillPausing(ctx, sandboxID, txn.ID)
 	if err != nil || !stillPausing {
 		return err
@@ -403,6 +416,7 @@ func (s *SandboxService) CompletePausingSandboxRuntime(ctx context.Context, sand
 		_ = s.abortLifecycleTxn(ctx, sandboxID, txn.ID, err.Error())
 		return err
 	}
+	rootFSCommitted = true
 	barrierActive = false
 	if err := s.k8sClient.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{}); err != nil && !k8serrors.IsNotFound(err) {
 		if s.logger != nil {
@@ -425,6 +439,31 @@ func (s *SandboxService) sandboxStillPausing(ctx context.Context, sandboxID, txn
 		return false, err
 	}
 	return txn != nil && txn.ID == txnID && txn.Kind == SandboxLifecycleKindPause, nil
+}
+
+func (s *SandboxService) markLifecycleTxnPreparedHead(ctx context.Context, sandboxID, txnID, preparedHeadLayerID string) error {
+	if s == nil || s.sandboxStore == nil || strings.TrimSpace(txnID) == "" || strings.TrimSpace(preparedHeadLayerID) == "" {
+		return nil
+	}
+	err := s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, _ *SandboxRecord) error {
+		activeTxn, err := tx.GetActiveLifecycleTxn(lockCtx, sandboxID)
+		if err != nil {
+			return err
+		}
+		if activeTxn == nil || activeTxn.ID != txnID {
+			return nil
+		}
+		return tx.SetLifecycleTxnPreparedHead(lockCtx, txnID, preparedHeadLayerID)
+	})
+	if err == nil {
+		return nil
+	}
+	if canceled, cancelErr := s.abortPauseIfCancelRequested(ctx, sandboxID, txnID); cancelErr != nil {
+		return cancelErr
+	} else if canceled {
+		return errSandboxLifecycleCanceled
+	}
+	return err
 }
 
 func (s *SandboxService) commitPausingRuntimePaused(ctx context.Context, sandboxID string, txn *SandboxLifecycleTxn, generation int64, rootFSState *SandboxRootFSState) error {

--- a/manager/pkg/service/sandbox_service_lifecycle.go
+++ b/manager/pkg/service/sandbox_service_lifecycle.go
@@ -682,13 +682,26 @@ func (s *SandboxService) UpdateSandbox(ctx context.Context, sandboxID string, cf
 		return nil, fmt.Errorf("sandbox config is required")
 	}
 
+	var record *SandboxRecord
+	if s.sandboxStore != nil {
+		var getErr error
+		record, getErr = s.sandboxStore.GetSandbox(ctx, sandboxID)
+		if getErr != nil && !errors.Is(getErr, ErrSandboxRecordNotFound) {
+			return nil, fmt.Errorf("get sandbox record: %w", getErr)
+		}
+		if record != nil {
+			if record.Status == SandboxStatusDeleted {
+				return nil, k8serrors.NewNotFound(schema.GroupResource{Resource: "sandbox"}, sandboxID)
+			}
+			if record.Status == SandboxStatusPaused {
+				return s.updatePausedSandboxRecord(ctx, record, cfg)
+			}
+		}
+	}
+
 	pod, err := s.getSandboxPod(ctx, sandboxID)
 	if err != nil {
 		if k8serrors.IsNotFound(err) && s.sandboxStore != nil {
-			record, getErr := s.sandboxStore.GetSandbox(ctx, sandboxID)
-			if getErr != nil {
-				return nil, fmt.Errorf("get sandbox record: %w", getErr)
-			}
 			if record != nil && record.Status != SandboxStatusDeleted {
 				return s.updatePausedSandboxRecord(ctx, record, cfg)
 			}
@@ -934,12 +947,32 @@ func (s *SandboxService) persistUpdatedSandboxPod(ctx context.Context, pod *core
 	if s == nil || s.sandboxStore == nil || pod == nil {
 		return nil
 	}
+	sandboxID := sandboxIDFromPod(pod)
+	if sandboxID == "" {
+		sandboxID = pod.Name
+	}
+	existing, err := s.sandboxStore.GetSandbox(ctx, sandboxID)
+	if err != nil && !errors.Is(err, ErrSandboxRecordNotFound) {
+		return fmt.Errorf("get sandbox record before pod persistence: %w", err)
+	}
+	if existing != nil {
+		if existing.Status == SandboxStatusPaused || existing.Status == SandboxStatusDeleted {
+			return nil
+		}
+		activeTxn, txnErr := s.sandboxStore.GetActiveLifecycleTxn(ctx, sandboxID)
+		if txnErr != nil {
+			return fmt.Errorf("get active sandbox lifecycle txn before pod persistence: %w", txnErr)
+		}
+		if sandboxLifecycleTxnHidesCommittedRuntime(activeTxn) {
+			return nil
+		}
+	}
 	template := s.templateForPod(pod)
 	if template == nil {
 		return nil
 	}
 	record := &SandboxRecord{
-		ID:                  sandboxIDFromPod(pod),
+		ID:                  sandboxID,
 		TeamID:              pod.Annotations[controller.AnnotationTeamID],
 		UserID:              pod.Annotations[controller.AnnotationUserID],
 		TemplateID:          sandboxTemplateIDFromLabels(pod.Labels),
@@ -957,9 +990,6 @@ func (s *SandboxService) persistUpdatedSandboxPod(ctx context.Context, pod *core
 		ExpiresAt:           parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationExpiresAt),
 		HardExpiresAt:       parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationHardExpiresAt),
 		CreatedAt:           pod.CreationTimestamp.Time,
-	}
-	if record.ID == "" {
-		record.ID = pod.Name
 	}
 	return s.sandboxStore.UpsertSandbox(ctx, record)
 }

--- a/manager/pkg/service/sandbox_service_list.go
+++ b/manager/pkg/service/sandbox_service_list.go
@@ -158,7 +158,14 @@ func (s *SandboxService) listSandboxesFromStore(ctx context.Context, req *ListSa
 	summaries := make([]*SandboxSummary, 0, len(records))
 	for _, record := range records {
 		sandbox := s.recordToSandbox(record)
-		if record.CurrentPodName != "" && !recordLifecycleStatusOverridesPod(record.Status) {
+		var activeTxn *SandboxLifecycleTxn
+		if record != nil && record.Status != SandboxStatusPaused {
+			activeTxn, err = s.sandboxStore.GetActiveLifecycleTxn(ctx, record.ID)
+			if err != nil {
+				return nil, err
+			}
+		}
+		if record.CurrentPodName != "" && record.Status != SandboxStatusPaused && !sandboxLifecycleTxnHidesCommittedRuntime(activeTxn) {
 			if pod, err := s.getSandboxPod(ctx, record.ID); err == nil {
 				sandbox = s.podToSandbox(ctx, pod, record.ID)
 			}

--- a/manager/pkg/service/sandbox_service_pause.go
+++ b/manager/pkg/service/sandbox_service_pause.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
 )
@@ -44,21 +45,43 @@ func (s *SandboxService) PauseSandboxAndWait(ctx context.Context, sandboxID stri
 
 // ResumeSandbox creates or reuses a runtime and restores the latest rootfs checkpoint.
 func (s *SandboxService) ResumeSandbox(ctx context.Context, sandboxID string) (*ResumeSandboxResponse, error) {
-	_, err := s.ResumePausedSandboxRuntime(ctx, sandboxID)
-	if err != nil {
-		return nil, err
+	if ctx == nil {
+		ctx = context.Background()
 	}
-	return &ResumeSandboxResponse{
-		SandboxID: sandboxID,
-		Resumed:   true,
-	}, nil
+	key := strings.TrimSpace(sandboxID)
+	if key == "" {
+		return nil, fmt.Errorf("sandbox_id is required")
+	}
+	resultCh := s.resumeGroup.DoChan(key, func() (any, error) {
+		restoreCtx, cancel := sandboxRestoreContext(context.Background())
+		defer cancel()
+		_, err := s.ResumePausedSandboxRuntime(restoreCtx, key)
+		if err != nil {
+			return nil, err
+		}
+		return &ResumeSandboxResponse{
+			SandboxID: key,
+			Resumed:   true,
+		}, nil
+	})
+	select {
+	case result := <-resultCh:
+		if result.Err != nil {
+			return nil, result.Err
+		}
+		resp, ok := result.Val.(*ResumeSandboxResponse)
+		if !ok || resp == nil {
+			return nil, fmt.Errorf("resume sandbox returned invalid result")
+		}
+		return resp, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 }
 
 // ResumeSandboxAndWait creates or reuses a runtime and restores the latest rootfs checkpoint.
 func (s *SandboxService) ResumeSandboxAndWait(ctx context.Context, sandboxID string) (*ResumeSandboxResponse, error) {
-	waitCtx, cancel := sandboxRestoreContext(ctx)
-	defer cancel()
-	return s.ResumeSandbox(waitCtx, sandboxID)
+	return s.ResumeSandbox(ctx, sandboxID)
 }
 
 // TerminateSandboxByID implements the SandboxTerminator interface from controller package.

--- a/manager/pkg/service/sandbox_service_restore.go
+++ b/manager/pkg/service/sandbox_service_restore.go
@@ -42,6 +42,7 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 		req = nil
 		deletingPodRef = nil
 		restoreNeeded = false
+		var waitErr error
 		err := s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, locked *SandboxRecord) error {
 			if locked.Status == SandboxStatusDeleted || !locked.DeletedAt.IsZero() {
 				return k8serrors.NewNotFound(corev1.Resource("sandbox"), sandboxID)
@@ -61,14 +62,17 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 							return err
 						}
 					}
-					return errSandboxLifecyclePausing
+					waitErr = errSandboxLifecyclePausing
+					return nil
 				default:
-					return errSandboxLifecycleResuming
+					waitErr = errSandboxLifecycleResuming
+					return nil
 				}
 			}
 			switch locked.Status {
 			case SandboxStatusStarting:
-				return errSandboxLifecycleResuming
+				waitErr = errSandboxLifecycleResuming
+				return nil
 			}
 
 			existing, getErr := s.getSandboxPod(lockCtx, sandboxID)
@@ -136,6 +140,9 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 			}
 			return tx.BeginLifecycleTxn(lockCtx, txn)
 		})
+		if err == nil && waitErr != nil {
+			err = waitErr
+		}
 		if err == nil {
 			break
 		}

--- a/manager/pkg/service/sandbox_service_restore.go
+++ b/manager/pkg/service/sandbox_service_restore.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
@@ -27,12 +28,18 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 
 	var pod *corev1.Pod
 	var record *SandboxRecord
+	var template *v1alpha1.SandboxTemplate
+	var txn *SandboxLifecycleTxn
+	var req *ClaimRequest
 	var deletingPodRef *sandboxRuntimePodRef
 	claimType := "hot"
 	restoreNeeded := false
 	for {
 		pod = nil
 		record = nil
+		template = nil
+		txn = nil
+		req = nil
 		deletingPodRef = nil
 		restoreNeeded = false
 		err := s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, locked *SandboxRecord) error {
@@ -42,13 +49,27 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 			if sandboxHardExpired(locked.HardExpiresAt, s.now()) {
 				return k8serrors.NewNotFound(corev1.Resource("sandbox"), sandboxID)
 			}
+			activeTxn, err := tx.GetActiveLifecycleTxn(lockCtx, sandboxID)
+			if err != nil {
+				return err
+			}
+			if activeTxn != nil {
+				switch activeTxn.Kind {
+				case SandboxLifecycleKindPause:
+					if sandboxLifecycleTxnCancelableAutoPause(activeTxn) {
+						if _, err := tx.RequestLifecycleTxnCancel(lockCtx, activeTxn.ID, "runtime access arrived during auto pause"); err != nil {
+							return err
+						}
+					}
+					return errSandboxLifecyclePausing
+				default:
+					return errSandboxLifecycleResuming
+				}
+			}
 			switch locked.Status {
-			case SandboxStatusPausing:
-				return errSandboxLifecyclePausing
-			case SandboxStatusStarting, SandboxStatusResuming:
+			case SandboxStatusStarting:
 				return errSandboxLifecycleResuming
 			}
-			record = locked
 
 			existing, getErr := s.getSandboxPod(lockCtx, sandboxID)
 			if getErr == nil {
@@ -57,6 +78,14 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 						namespace: existing.Namespace,
 						name:      existing.Name,
 					}
+					return errSandboxRuntimeDeleting
+				}
+				if locked.Status == SandboxStatusPaused {
+					deletingPodRef = &sandboxRuntimePodRef{
+						namespace: existing.Namespace,
+						name:      existing.Name,
+					}
+					_ = s.k8sClient.CoreV1().Pods(existing.Namespace).Delete(lockCtx, existing.Name, metav1.DeleteOptions{})
 					return errSandboxRuntimeDeleting
 				}
 				pod = existing
@@ -70,10 +99,11 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 				return k8serrors.NewConflict(corev1.Resource("sandbox"), sandboxID, fmt.Errorf("sandbox runtime for status %q is not available", locked.Status))
 			}
 
-			template, err := s.templateForSandboxRecord(locked)
+			resumeTemplate, err := s.templateForSandboxRecord(locked)
 			if err != nil {
 				return err
 			}
+			template = resumeTemplate
 			if err := s.enforceActiveSandboxQuota(lockCtx, locked.TeamID); err != nil {
 				return err
 			}
@@ -84,7 +114,8 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 				return err
 			}
 			generation := locked.RuntimeGeneration + 1
-			req := &ClaimRequest{
+			record = cloneSandboxRecordForLifecycle(locked)
+			req = &ClaimRequest{
 				TeamID:            locked.TeamID,
 				UserID:            locked.UserID,
 				Template:          locked.TemplateID,
@@ -94,19 +125,16 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 				RuntimeGeneration: generation,
 				HardExpiresAt:     locked.HardExpiresAt,
 			}
-			pod, err = s.claimIdlePod(lockCtx, template, req)
-			if err != nil {
-				return fmt.Errorf("claim idle pod: %w", err)
-			}
-			if pod == nil {
-				claimType = "cold"
-				pod, err = s.createNewPod(lockCtx, template, req)
-				if err != nil {
-					return fmt.Errorf("create runtime pod: %w", err)
-				}
-			}
 			restoreNeeded = true
-			return tx.SaveRuntime(lockCtx, sandboxID, pod.Namespace, pod.Name, SandboxStatusResuming, generation, parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationExpiresAt), parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationHardExpiresAt))
+			txn = &SandboxLifecycleTxn{
+				ID:             uuid.NewString(),
+				SandboxID:      sandboxID,
+				Kind:           SandboxLifecycleKindResume,
+				Phase:          SandboxLifecyclePhasePreparing,
+				FromGeneration: locked.RuntimeGeneration,
+				ToGeneration:   generation,
+			}
+			return tx.BeginLifecycleTxn(lockCtx, txn)
 		})
 		if err == nil {
 			break
@@ -116,12 +144,12 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 		}
 		switch {
 		case errors.Is(err, errSandboxLifecyclePausing):
-			if err := s.CompletePausingSandboxRuntime(ctx, sandboxID); err != nil {
+			if err := s.waitForSandboxLifecycleTxnExit(ctx, sandboxID); err != nil {
 				return nil, err
 			}
 			continue
 		case errors.Is(err, errSandboxLifecycleResuming):
-			if err := s.waitForSandboxLifecycleStatusExit(ctx, sandboxID, SandboxStatusStarting, SandboxStatusResuming); err != nil {
+			if err := s.waitForSandboxLifecycleTxnExit(ctx, sandboxID); err != nil {
 				return nil, err
 			}
 			continue
@@ -138,7 +166,30 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 		}
 	}
 	if pod == nil {
-		return nil, fmt.Errorf("restore sandbox runtime did not create or find a pod")
+		if record == nil || !restoreNeeded {
+			return s.GetSandbox(ctx, sandboxID)
+		}
+		var err error
+		pod, err = s.claimIdlePod(ctx, template, req)
+		if err != nil {
+			_ = s.abortLifecycleTxn(context.Background(), sandboxID, txn.ID, err.Error())
+			return nil, fmt.Errorf("claim idle pod: %w", err)
+		}
+		if pod == nil {
+			claimType = "cold"
+			pod, err = s.createNewPod(ctx, template, req)
+			if err != nil {
+				_ = s.abortLifecycleTxn(context.Background(), sandboxID, txn.ID, err.Error())
+				return nil, fmt.Errorf("create runtime pod: %w", err)
+			}
+		}
+		txn.ToPodNamespace = pod.Namespace
+		txn.ToPodName = pod.Name
+		if err := s.recordResumeLifecycleRuntime(ctx, record.ID, txn, pod); err != nil {
+			s.requestSandboxDeletionAfterClaimFailure(pod, "restored runtime transaction update failed")
+			_ = s.abortLifecycleTxn(context.Background(), sandboxID, txn.ID, err.Error())
+			return nil, err
+		}
 	}
 	if record == nil || !restoreNeeded {
 		return s.GetSandbox(ctx, sandboxID)
@@ -150,10 +201,68 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 			pod = restoredPod
 		}
 		s.requestSandboxDeletionAfterClaimFailure(pod, "restored runtime initialization failed")
-		_ = s.pauseSandboxRuntime(context.Background(), sandboxID, false)
+		if txn != nil {
+			_ = s.abortLifecycleTxn(context.Background(), sandboxID, txn.ID, err.Error())
+		}
 		return nil, err
 	}
+	if txn != nil {
+		if err := s.commitResumedSandboxRuntime(ctx, restoredPod, record, txn); err != nil {
+			s.requestSandboxDeletionAfterClaimFailure(restoredPod, "restored runtime commit failed")
+			_ = s.abortLifecycleTxn(context.Background(), sandboxID, txn.ID, err.Error())
+			return nil, err
+		}
+	}
 	return s.GetSandbox(ctx, sandboxID)
+}
+
+func (s *SandboxService) recordResumeLifecycleRuntime(ctx context.Context, sandboxID string, txn *SandboxLifecycleTxn, pod *corev1.Pod) error {
+	if s == nil || s.sandboxStore == nil || txn == nil || pod == nil {
+		return nil
+	}
+	return s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, locked *SandboxRecord) error {
+		activeTxn, err := tx.GetActiveLifecycleTxn(lockCtx, sandboxID)
+		if err != nil {
+			return err
+		}
+		if activeTxn == nil || activeTxn.ID != txn.ID || activeTxn.Kind != SandboxLifecycleKindResume {
+			return fmt.Errorf("resume lifecycle transaction is no longer active")
+		}
+		if locked.Status != SandboxStatusPaused {
+			return fmt.Errorf("resume lifecycle runtime update expected paused sandbox, got %s", locked.Status)
+		}
+		podGeneration := runtimeGenerationFromPod(pod)
+		if podGeneration != txn.ToGeneration {
+			return fmt.Errorf("resume lifecycle generation changed: txn=%d pod=%d", txn.ToGeneration, podGeneration)
+		}
+		return tx.SetLifecycleTxnRuntime(lockCtx, txn.ID, pod.Namespace, pod.Name)
+	})
+}
+
+func (s *SandboxService) commitResumedSandboxRuntime(ctx context.Context, pod *corev1.Pod, record *SandboxRecord, txn *SandboxLifecycleTxn) error {
+	if s == nil || s.sandboxStore == nil || pod == nil || record == nil || txn == nil {
+		return nil
+	}
+	return s.sandboxStore.WithSandboxLock(ctx, record.ID, func(lockCtx context.Context, tx SandboxStoreTx, locked *SandboxRecord) error {
+		activeTxn, err := tx.GetActiveLifecycleTxn(lockCtx, record.ID)
+		if err != nil {
+			return err
+		}
+		if activeTxn == nil || activeTxn.ID != txn.ID || activeTxn.Kind != SandboxLifecycleKindResume {
+			return fmt.Errorf("resume lifecycle transaction is no longer active")
+		}
+		if locked.Status != SandboxStatusPaused {
+			return fmt.Errorf("resume lifecycle commit expected paused sandbox, got %s", locked.Status)
+		}
+		podGeneration := runtimeGenerationFromPod(pod)
+		if podGeneration != txn.ToGeneration {
+			return fmt.Errorf("resume lifecycle generation changed: txn=%d pod=%d", txn.ToGeneration, podGeneration)
+		}
+		if err := tx.SaveRuntime(lockCtx, record.ID, pod.Namespace, pod.Name, s.podToSandboxStatus(pod), txn.ToGeneration, parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationExpiresAt), parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationHardExpiresAt)); err != nil {
+			return err
+		}
+		return tx.CommitLifecycleTxn(lockCtx, txn.ID, "")
+	})
 }
 
 var (
@@ -167,28 +276,21 @@ type sandboxRuntimePodRef struct {
 	name      string
 }
 
-func (s *SandboxService) waitForSandboxLifecycleStatusExit(ctx context.Context, sandboxID string, statuses ...string) error {
+func (s *SandboxService) waitForSandboxLifecycleTxnExit(ctx context.Context, sandboxID string) error {
 	if s == nil || s.sandboxStore == nil {
 		return nil
-	}
-	waiting := make(map[string]struct{}, len(statuses))
-	for _, status := range statuses {
-		waiting[status] = struct{}{}
 	}
 	ticker := time.NewTicker(sandboxLifecycleWaitInterval)
 	defer ticker.Stop()
 	for {
-		record, err := s.sandboxStore.GetSandbox(ctx, sandboxID)
+		txn, err := s.sandboxStore.GetActiveLifecycleTxn(ctx, sandboxID)
 		if err != nil {
 			if errors.Is(err, ErrSandboxRecordNotFound) {
 				return k8serrors.NewNotFound(corev1.Resource("sandbox"), sandboxID)
 			}
 			return err
 		}
-		if record == nil || record.Status == SandboxStatusDeleted || !record.DeletedAt.IsZero() {
-			return k8serrors.NewNotFound(corev1.Resource("sandbox"), sandboxID)
-		}
-		if _, ok := waiting[record.Status]; !ok {
+		if txn == nil {
 			return nil
 		}
 		select {
@@ -268,7 +370,7 @@ func (s *SandboxService) finishRestoredSandboxRuntime(ctx context.Context, pod *
 	if err != nil {
 		return pod, fmt.Errorf("load rootfs checkpoint: %w", err)
 	}
-	pod, err = s.applySandboxRootFSCheckpointWithFallback(ctx, pod, record, template, req, rootFSState, SandboxStatusResuming)
+	pod, err = s.applySandboxRootFSCheckpointWithFallback(ctx, pod, record, template, req, rootFSState, "")
 	if err != nil {
 		return pod, err
 	}
@@ -284,9 +386,6 @@ func (s *SandboxService) finishRestoredSandboxRuntime(ctx context.Context, pod *
 	}
 	if _, err := s.initializeProcd(ctx, pod, template, req, procdAddress); err != nil {
 		return pod, fmt.Errorf("initialize procd: %w", err)
-	}
-	if err := s.persistUpdatedSandboxPod(ctx, pod); err != nil {
-		return pod, fmt.Errorf("persist restored sandbox: %w", err)
 	}
 	if s.logger != nil {
 		s.logger.Info("Resumed paused sandbox runtime",

--- a/manager/pkg/service/sandbox_service_rootfs.go
+++ b/manager/pkg/service/sandbox_service_rootfs.go
@@ -84,19 +84,16 @@ func (s *SandboxService) prepareSandboxRootFSCheckpoint(ctx context.Context, pod
 			parentLayerID = expectedHeadLayerID
 		}
 	}
-	saveReq := ctldapi.SaveRootFSRequest{
-		Target:                    rootFSTargetForPod(pod),
-		SandboxID:                 sandboxID,
-		TeamID:                    teamID,
-		ExpectedRuntimeGeneration: generation,
-		ParentLayerID:             parentLayerID,
-		ExcludedPaths:             rootFSExcludedPathsForPod(pod),
+	prepareReq := ctldapi.PrepareRootFSSnapshotRequest{
+		Target:        rootFSTargetForPod(pod),
+		ParentLayerID: parentLayerID,
+		ExcludedPaths: rootFSExcludedPathsForPod(pod),
 	}
-	resp, err := s.ctldClient.SaveRootFSWithTimeout(ctx, ctldAddress, saveReq, sandboxRootFSOperationTimeout)
+	resp, err := s.prepareAndPublishSandboxRootFSSnapshot(ctx, ctldAddress, prepareReq, sandboxID, teamID, generation)
 	if err != nil && parentLayerID != "" && rootFSBaselineMissing(err, resp) {
 		parentLayerID = ""
-		saveReq.ParentLayerID = ""
-		resp, err = s.ctldClient.SaveRootFSWithTimeout(ctx, ctldAddress, saveReq, sandboxRootFSOperationTimeout)
+		prepareReq.ParentLayerID = ""
+		resp, err = s.prepareAndPublishSandboxRootFSSnapshot(ctx, ctldAddress, prepareReq, sandboxID, teamID, generation)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("save sandbox rootfs checkpoint: %w", rootFSResponseError(err, saveRootFSError(resp)))
@@ -109,6 +106,40 @@ func (s *SandboxService) prepareSandboxRootFSCheckpoint(ctx context.Context, pod
 	state.ParentLayerID = parentLayerID
 	state.ExpectedHeadLayerID = expectedHeadLayerID
 	return state, nil
+}
+
+func (s *SandboxService) prepareAndPublishSandboxRootFSSnapshot(ctx context.Context, ctldAddress string, prepareReq ctldapi.PrepareRootFSSnapshotRequest, sandboxID, teamID string, generation int64) (*ctldapi.SaveRootFSResponse, error) {
+	prepared, err := s.ctldClient.PrepareRootFSSnapshotWithTimeout(ctx, ctldAddress, prepareReq, sandboxRootFSOperationTimeout)
+	if err != nil {
+		resp := &ctldapi.SaveRootFSResponse{}
+		if prepared != nil {
+			resp.Info = prepared.Info
+			resp.Descriptor = prepared.Descriptor
+			resp.Error = prepared.Error
+		}
+		return resp, err
+	}
+	published, err := s.ctldClient.PublishRootFSSnapshotWithTimeout(ctx, ctldAddress, ctldapi.PublishRootFSSnapshotRequest{
+		Handle:                    prepared.Handle,
+		SandboxID:                 sandboxID,
+		TeamID:                    teamID,
+		ExpectedRuntimeGeneration: generation,
+	}, sandboxRootFSOperationTimeout)
+	if err != nil {
+		_, _ = s.ctldClient.AbortRootFSSnapshotWithTimeout(context.Background(), ctldAddress, ctldapi.AbortRootFSSnapshotRequest{Handle: prepared.Handle}, sandboxRootFSOperationTimeout)
+		resp := &ctldapi.SaveRootFSResponse{Info: prepared.Info, Descriptor: prepared.Descriptor}
+		if published != nil {
+			resp.Info = published.Info
+			resp.Descriptor = published.Descriptor
+			resp.Error = published.Error
+		}
+		return resp, err
+	}
+	return &ctldapi.SaveRootFSResponse{
+		Info:       published.Info,
+		Descriptor: published.Descriptor,
+		Error:      published.Error,
+	}, nil
 }
 
 func (s *SandboxService) shouldSquashSandboxRootFSCheckpoint(state *SandboxRootFSState) (bool, string) {
@@ -221,9 +252,6 @@ func (s *SandboxService) applySandboxRootFSCheckpointWithFallback(ctx context.Co
 	if state == nil {
 		return pod, nil
 	}
-	if strings.TrimSpace(fallbackStatus) == "" {
-		fallbackStatus = SandboxStatusResuming
-	}
 	err := s.applySandboxRootFSCheckpoint(ctx, pod, state)
 	if err == nil {
 		return pod, nil
@@ -251,13 +279,15 @@ func (s *SandboxService) applySandboxRootFSCheckpointWithFallback(ctx context.Co
 		s.requestSandboxDeletionAfterClaimFailure(fallbackPod, "checkpoint base image runtime readiness failed")
 		return fallbackPod, fmt.Errorf("%w; wait for checkpoint base image runtime: %v", err, fallbackErr)
 	}
-	if fallbackErr := s.saveRestoredRuntimePod(ctx, readyPod, record, fallbackStatus); fallbackErr != nil {
-		s.requestSandboxDeletionAfterClaimFailure(readyPod, "checkpoint base image runtime persistence failed")
-		return readyPod, fmt.Errorf("%w; save checkpoint base image runtime: %v", err, fallbackErr)
-	}
 	if fallbackErr := s.applySandboxRootFSCheckpoint(ctx, readyPod, state); fallbackErr != nil {
 		s.requestSandboxDeletionAfterClaimFailure(readyPod, "checkpoint base image rootfs apply failed")
 		return readyPod, fmt.Errorf("%w; checkpoint base image retry failed: %v", err, fallbackErr)
+	}
+	if strings.TrimSpace(fallbackStatus) != "" {
+		if fallbackErr := s.saveRestoredRuntimePod(ctx, readyPod, record, fallbackStatus); fallbackErr != nil {
+			s.requestSandboxDeletionAfterClaimFailure(readyPod, "checkpoint base image runtime persistence failed")
+			return readyPod, fallbackErr
+		}
 	}
 	return readyPod, nil
 }

--- a/manager/pkg/service/sandbox_service_rootfs.go
+++ b/manager/pkg/service/sandbox_service_rootfs.go
@@ -21,6 +21,8 @@ import (
 const sandboxRootFSContainerName = "procd"
 
 const sandboxRootFSOperationTimeout = 5 * time.Minute
+const sandboxRootFSUncommittedObjectDeleteDelay = 15 * time.Minute
+const sandboxRootFSUncommittedObjectDeleteTimeout = 30 * time.Second
 
 func (s *SandboxService) saveSandboxRootFSCheckpoint(ctx context.Context, pod *corev1.Pod, record *SandboxRecord, tx SandboxStoreTx) error {
 	state, err := s.prepareSandboxRootFSCheckpoint(ctx, pod, record)
@@ -89,11 +91,12 @@ func (s *SandboxService) prepareSandboxRootFSCheckpoint(ctx context.Context, pod
 		ParentLayerID: parentLayerID,
 		ExcludedPaths: rootFSExcludedPathsForPod(pod),
 	}
-	resp, err := s.prepareAndPublishSandboxRootFSSnapshot(ctx, ctldAddress, prepareReq, sandboxID, teamID, generation)
+	layerID := uuid.NewString()
+	resp, err := s.prepareAndPublishSandboxRootFSSnapshot(ctx, ctldAddress, prepareReq, sandboxID, teamID, generation, layerID)
 	if err != nil && parentLayerID != "" && rootFSBaselineMissing(err, resp) {
 		parentLayerID = ""
 		prepareReq.ParentLayerID = ""
-		resp, err = s.prepareAndPublishSandboxRootFSSnapshot(ctx, ctldAddress, prepareReq, sandboxID, teamID, generation)
+		resp, err = s.prepareAndPublishSandboxRootFSSnapshot(ctx, ctldAddress, prepareReq, sandboxID, teamID, generation, layerID)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("save sandbox rootfs checkpoint: %w", rootFSResponseError(err, saveRootFSError(resp)))
@@ -102,13 +105,13 @@ func (s *SandboxService) prepareSandboxRootFSCheckpoint(ctx context.Context, pod
 	if err != nil {
 		return nil, err
 	}
-	state.LayerID = uuid.NewString()
+	state.LayerID = layerID
 	state.ParentLayerID = parentLayerID
 	state.ExpectedHeadLayerID = expectedHeadLayerID
 	return state, nil
 }
 
-func (s *SandboxService) prepareAndPublishSandboxRootFSSnapshot(ctx context.Context, ctldAddress string, prepareReq ctldapi.PrepareRootFSSnapshotRequest, sandboxID, teamID string, generation int64) (*ctldapi.SaveRootFSResponse, error) {
+func (s *SandboxService) prepareAndPublishSandboxRootFSSnapshot(ctx context.Context, ctldAddress string, prepareReq ctldapi.PrepareRootFSSnapshotRequest, sandboxID, teamID string, generation int64, layerID string) (*ctldapi.SaveRootFSResponse, error) {
 	prepared, err := s.ctldClient.PrepareRootFSSnapshotWithTimeout(ctx, ctldAddress, prepareReq, sandboxRootFSOperationTimeout)
 	if err != nil {
 		resp := &ctldapi.SaveRootFSResponse{}
@@ -119,14 +122,26 @@ func (s *SandboxService) prepareAndPublishSandboxRootFSSnapshot(ctx context.Cont
 		}
 		return resp, err
 	}
+	objectKey, err := defaultSandboxRootFSObjectKey(teamID, sandboxID, generation, prepared.Descriptor.Digest)
+	if err != nil {
+		_, _ = s.ctldClient.AbortRootFSSnapshotWithTimeout(context.Background(), ctldAddress, ctldapi.AbortRootFSSnapshotRequest{Handle: prepared.Handle}, sandboxRootFSOperationTimeout)
+		return &ctldapi.SaveRootFSResponse{Info: prepared.Info, Descriptor: prepared.Descriptor}, err
+	}
+	pendingState := rootFSStateFromPreparedSnapshot(sandboxID, teamID, generation, layerID, objectKey, prepared)
+	if err := s.queueUncommittedRootFSObjectDeletion(ctx, pendingState, s.now().Add(sandboxRootFSUncommittedObjectDeleteDelay)); err != nil {
+		_, _ = s.ctldClient.AbortRootFSSnapshotWithTimeout(context.Background(), ctldAddress, ctldapi.AbortRootFSSnapshotRequest{Handle: prepared.Handle}, sandboxRootFSOperationTimeout)
+		return &ctldapi.SaveRootFSResponse{Info: prepared.Info, Descriptor: prepared.Descriptor}, err
+	}
 	published, err := s.ctldClient.PublishRootFSSnapshotWithTimeout(ctx, ctldAddress, ctldapi.PublishRootFSSnapshotRequest{
 		Handle:                    prepared.Handle,
 		SandboxID:                 sandboxID,
 		TeamID:                    teamID,
 		ExpectedRuntimeGeneration: generation,
+		ObjectKey:                 objectKey,
 	}, sandboxRootFSOperationTimeout)
 	if err != nil {
 		_, _ = s.ctldClient.AbortRootFSSnapshotWithTimeout(context.Background(), ctldAddress, ctldapi.AbortRootFSSnapshotRequest{Handle: prepared.Handle}, sandboxRootFSOperationTimeout)
+		s.deleteUncommittedRootFSObject(pendingState, "rootfs snapshot publish failed")
 		resp := &ctldapi.SaveRootFSResponse{Info: prepared.Info, Descriptor: prepared.Descriptor}
 		if published != nil {
 			resp.Info = published.Info
@@ -442,6 +457,110 @@ func rootFSStateFromSaveResponse(sandboxID, teamID string, generation int64, res
 		DiffSize:            resp.Descriptor.Size,
 		DiffObjectKey:       resp.Descriptor.ObjectKey,
 	}, nil
+}
+
+func rootFSStateFromPreparedSnapshot(sandboxID, teamID string, generation int64, layerID, objectKey string, prepared *ctldapi.PrepareRootFSSnapshotResponse) *SandboxRootFSState {
+	if prepared == nil {
+		return nil
+	}
+	return &SandboxRootFSState{
+		LayerID:             layerID,
+		SandboxID:           sandboxID,
+		TeamID:              teamID,
+		RuntimeGeneration:   generation,
+		Runtime:             prepared.Info.Runtime,
+		RuntimeHandler:      prepared.Info.RuntimeHandler,
+		BaseImageRef:        prepared.Info.BaseImageRef,
+		BaseImageDigest:     prepared.Info.BaseImageDigest,
+		Snapshotter:         prepared.Info.Snapshotter,
+		SnapshotParent:      prepared.Info.SnapshotParent,
+		SnapshotParentChain: append([]string(nil), prepared.Info.SnapshotParentChain...),
+		DiffDigest:          prepared.Descriptor.Digest,
+		DiffMediaType:       prepared.Descriptor.MediaType,
+		DiffSize:            prepared.Descriptor.Size,
+		DiffObjectKey:       objectKey,
+	}
+}
+
+func defaultSandboxRootFSObjectKey(teamID, sandboxID string, generation int64, digest string) (string, error) {
+	teamID = strings.TrimSpace(teamID)
+	sandboxID = strings.TrimSpace(sandboxID)
+	if teamID == "" {
+		return "", fmt.Errorf("team_id is required when rootfs object key is omitted")
+	}
+	if sandboxID == "" {
+		return "", fmt.Errorf("sandbox_id is required when rootfs object key is omitted")
+	}
+	if strings.Contains(teamID, "/") || strings.Contains(sandboxID, "/") {
+		return "", fmt.Errorf("team_id and sandbox_id cannot contain '/'")
+	}
+	parts := strings.SplitN(strings.TrimSpace(digest), ":", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", fmt.Errorf("invalid rootfs diff digest %q", digest)
+	}
+	return path.Join("sandbox-rootfs", teamID, sandboxID, fmt.Sprintf("%d", generation), parts[0], parts[1]+".tar"), nil
+}
+
+func (s *SandboxService) queueUncommittedRootFSObjectDeletion(ctx context.Context, state *SandboxRootFSState, notBefore time.Time) error {
+	if state == nil || strings.TrimSpace(state.DiffObjectKey) == "" {
+		return nil
+	}
+	store, ok := s.sandboxStore.(interface {
+		QueueUncommittedRootFSObjectDeletion(context.Context, *SandboxRootFSState, time.Time) error
+	})
+	if !ok || store == nil {
+		return nil
+	}
+	return store.QueueUncommittedRootFSObjectDeletion(ctx, state, notBefore)
+}
+
+func (s *SandboxService) deleteUncommittedRootFSObject(state *SandboxRootFSState, reason string) {
+	if state == nil || strings.TrimSpace(state.DiffObjectKey) == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), sandboxRootFSUncommittedObjectDeleteTimeout)
+	defer cancel()
+	if err := s.queueUncommittedRootFSObjectDeletion(ctx, state, time.Now()); err != nil && s.logger != nil {
+		s.logger.Warn("Failed to queue uncommitted rootfs object deletion",
+			zap.String("sandboxID", state.SandboxID),
+			zap.String("objectKey", state.DiffObjectKey),
+			zap.String("reason", reason),
+			zap.Error(err),
+		)
+	}
+	if s.rootFSObjectDeleter == nil {
+		if s.logger != nil {
+			s.logger.Warn("Uncommitted rootfs object deletion deferred; object deleter is not configured",
+				zap.String("sandboxID", state.SandboxID),
+				zap.String("objectKey", state.DiffObjectKey),
+				zap.String("reason", reason),
+			)
+		}
+		return
+	}
+	if err := s.rootFSObjectDeleter.Delete(state.DiffObjectKey); err != nil {
+		if s.logger != nil {
+			s.logger.Warn("Failed to delete uncommitted rootfs object",
+				zap.String("sandboxID", state.SandboxID),
+				zap.String("objectKey", state.DiffObjectKey),
+				zap.String("reason", reason),
+				zap.Error(err),
+			)
+		}
+		return
+	}
+	store, ok := s.sandboxStore.(interface {
+		CompleteRootFSObjectDeletion(context.Context, string) error
+	})
+	if ok && store != nil {
+		if err := store.CompleteRootFSObjectDeletion(ctx, state.DiffObjectKey); err != nil && s.logger != nil {
+			s.logger.Warn("Failed to mark uncommitted rootfs object deleted",
+				zap.String("sandboxID", state.SandboxID),
+				zap.String("objectKey", state.DiffObjectKey),
+				zap.Error(err),
+			)
+		}
+	}
 }
 
 func saveRootFSError(resp *ctldapi.SaveRootFSResponse) string {

--- a/manager/pkg/service/sandbox_service_rootfs_test.go
+++ b/manager/pkg/service/sandbox_service_rootfs_test.go
@@ -320,13 +320,14 @@ func TestCompletePausingSandboxRuntimeDoesNotCommitStaleCheckpoint(t *testing.T)
 		return true, nil, nil
 	})
 	svc := &SandboxService{
-		k8sClient:    k8sClient,
-		podLister:    newTestPodLister(t, pod),
-		sandboxStore: store,
-		ctldClient:   NewCtldClient(CtldClientConfig{Timeout: time.Second}),
-		config:       SandboxServiceConfig{CtldEnabled: true, CtldPort: ctldPort},
-		clock:        systemTime{},
-		logger:       zap.NewNop(),
+		k8sClient:           k8sClient,
+		podLister:           newTestPodLister(t, pod),
+		sandboxStore:        store,
+		ctldClient:          NewCtldClient(CtldClientConfig{Timeout: time.Second}),
+		config:              SandboxServiceConfig{CtldEnabled: true, CtldPort: ctldPort},
+		clock:               systemTime{},
+		logger:              zap.NewNop(),
+		rootFSObjectDeleter: &recordingRootFSObjectDeleter{},
 	}
 	defer attachRootFSTestProcd(t, pod, svc, nil)()
 	txnID = addRootFSTestPauseTxn(store, pod, SandboxLifecyclePhasePreparing)
@@ -335,6 +336,8 @@ func TestCompletePausingSandboxRuntimeDoesNotCommitStaleCheckpoint(t *testing.T)
 	assert.False(t, deleteCalled)
 	assert.Nil(t, store.rootFSStates["sandbox-1"])
 	assert.Equal(t, SandboxStatusRunning, store.records["sandbox-1"].Status)
+	deleter := svc.rootFSObjectDeleter.(*recordingRootFSObjectDeleter)
+	assert.Equal(t, []string{"sandbox-rootfs/team-1/sandbox-1/3/sha256/stale.tar"}, deleter.keys)
 }
 
 func TestPauseSandboxRuntimeSquashesRootFSWhenChainIsTooDeep(t *testing.T) {

--- a/manager/pkg/service/sandbox_service_rootfs_test.go
+++ b/manager/pkg/service/sandbox_service_rootfs_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -34,38 +35,64 @@ import (
 func TestPauseSandboxRuntimeQueuesRootFSSaveBeforeDeletingPod(t *testing.T) {
 	saveCalled := false
 	ctld := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/api/v1/rootfs/save", r.URL.Path)
-		var req ctldapi.SaveRootFSRequest
-		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
-		assert.Equal(t, "sandbox-1", req.SandboxID)
-		assert.Equal(t, "team-1", req.TeamID)
-		assert.Equal(t, int64(3), req.ExpectedRuntimeGeneration)
-		assert.Empty(t, req.ParentLayerID)
-		assert.Equal(t, ctldapi.RootFSContainerRef{
-			Namespace:     "default",
-			PodName:       "pod-1",
-			PodUID:        "pod-uid",
-			ContainerName: "procd",
-		}, req.Target)
-		assert.ElementsMatch(t, []string{"/workspace/data", volumeportal.WebhookStateMountPath}, req.ExcludedPaths)
-		saveCalled = true
-		_ = json.NewEncoder(w).Encode(ctldapi.SaveRootFSResponse{
-			Info: ctldapi.RootFSInfo{
-				Runtime:             "runc",
-				RuntimeHandler:      "io.containerd.runc.v2",
-				BaseImageRef:        "docker.io/library/busybox:1.36",
-				BaseImageDigest:     "sha256:base",
-				Snapshotter:         "overlayfs",
-				SnapshotParent:      "parent-1",
-				SnapshotParentChain: []string{"parent-1", "parent-0"},
-			},
-			Descriptor: ctldapi.RootFSDiffDescriptor{
-				MediaType: "application/vnd.oci.image.layer.v1.tar",
-				Digest:    "sha256:diff",
-				Size:      123,
-				ObjectKey: "sandbox-rootfs/team-1/sandbox-1/3/sha256/diff.tar",
-			},
-		})
+		switch r.URL.Path {
+		case "/api/v1/rootfs/snapshots/prepare":
+			var req ctldapi.PrepareRootFSSnapshotRequest
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+			assert.Empty(t, req.ParentLayerID)
+			assert.Equal(t, ctldapi.RootFSContainerRef{
+				Namespace:     "default",
+				PodName:       "pod-1",
+				PodUID:        "pod-uid",
+				ContainerName: "procd",
+			}, req.Target)
+			assert.ElementsMatch(t, []string{"/workspace/data", volumeportal.WebhookStateMountPath}, req.ExcludedPaths)
+			_ = json.NewEncoder(w).Encode(ctldapi.PrepareRootFSSnapshotResponse{
+				Handle: "handle-1",
+				Info: ctldapi.RootFSInfo{
+					Runtime:             "runc",
+					RuntimeHandler:      "io.containerd.runc.v2",
+					BaseImageRef:        "docker.io/library/busybox:1.36",
+					BaseImageDigest:     "sha256:base",
+					Snapshotter:         "overlayfs",
+					SnapshotParent:      "parent-1",
+					SnapshotParentChain: []string{"parent-1", "parent-0"},
+				},
+				Descriptor: ctldapi.RootFSDiffDescriptor{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    "sha256:diff",
+					Size:      123,
+				},
+			})
+		case "/api/v1/rootfs/snapshots/publish":
+			var req ctldapi.PublishRootFSSnapshotRequest
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+			assert.Equal(t, "handle-1", req.Handle)
+			assert.Equal(t, "sandbox-1", req.SandboxID)
+			assert.Equal(t, "team-1", req.TeamID)
+			assert.Equal(t, int64(3), req.ExpectedRuntimeGeneration)
+			saveCalled = true
+			_ = json.NewEncoder(w).Encode(ctldapi.PublishRootFSSnapshotResponse{
+				Published: true,
+				Info: ctldapi.RootFSInfo{
+					Runtime:             "runc",
+					RuntimeHandler:      "io.containerd.runc.v2",
+					BaseImageRef:        "docker.io/library/busybox:1.36",
+					BaseImageDigest:     "sha256:base",
+					Snapshotter:         "overlayfs",
+					SnapshotParent:      "parent-1",
+					SnapshotParentChain: []string{"parent-1", "parent-0"},
+				},
+				Descriptor: ctldapi.RootFSDiffDescriptor{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    "sha256:diff",
+					Size:      123,
+					ObjectKey: "sandbox-rootfs/team-1/sandbox-1/3/sha256/diff.tar",
+				},
+			})
+		default:
+			t.Fatalf("unexpected ctld path %s", r.URL.Path)
+		}
 	}))
 	defer ctld.Close()
 	ctldURL, ctldPort := parsedTestServer(t, ctld.URL)
@@ -107,19 +134,24 @@ func TestPauseSandboxRuntimeQueuesRootFSSaveBeforeDeletingPod(t *testing.T) {
 		logger:        zap.NewNop(),
 		pauseEnqueuer: enqueuer,
 	}
+	var procdCalls []string
+	defer attachRootFSTestProcd(t, pod, svc, &procdCalls)()
 
 	resp, err := svc.PauseSandbox(context.Background(), "sandbox-1")
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.False(t, resp.Paused)
-	assert.Equal(t, SandboxStatusPausing, resp.Status)
+	assert.Equal(t, SandboxStatusRunning, resp.Status)
 	assert.False(t, saveCalled, "pause request must not synchronously save rootfs")
 	assert.Equal(t, []string{"sandbox-1"}, enqueuer.calls)
-	assert.Equal(t, SandboxStatusPausing, store.records["sandbox-1"].Status)
+	assert.Equal(t, SandboxStatusRunning, store.records["sandbox-1"].Status)
+	require.Len(t, store.lifecycleTxns, 1)
 
 	require.NoError(t, svc.CompletePausingSandboxRuntime(context.Background(), "sandbox-1"))
 
 	assert.True(t, deleteCalled)
+	assert.Contains(t, procdCalls, "barrier:true")
+	assert.Contains(t, procdCalls, "pause")
 	_, err = k8sClient.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
 	require.NoError(t, err, "pause completion should not wait for the pod to disappear after delete is accepted")
 	state := store.rootFSStates["sandbox-1"]
@@ -135,27 +167,50 @@ func TestPauseSandboxRuntimeQueuesRootFSSaveBeforeDeletingPod(t *testing.T) {
 }
 
 func TestPauseSandboxRuntimeSavesChildLayerFromParentHead(t *testing.T) {
-	var savedReq ctldapi.SaveRootFSRequest
+	var savedReq ctldapi.PrepareRootFSSnapshotRequest
 	ctld := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/api/v1/rootfs/save", r.URL.Path)
-		require.NoError(t, json.NewDecoder(r.Body).Decode(&savedReq))
-		_ = json.NewEncoder(w).Encode(ctldapi.SaveRootFSResponse{
-			Info: ctldapi.RootFSInfo{
-				Runtime:             "runc",
-				RuntimeHandler:      "io.containerd.runc.v2",
-				BaseImageRef:        "docker.io/library/busybox:1.36",
-				BaseImageDigest:     "sha256:base",
-				Snapshotter:         "overlayfs",
-				SnapshotParent:      "parent-1",
-				SnapshotParentChain: []string{"parent-1", "parent-0"},
-			},
-			Descriptor: ctldapi.RootFSDiffDescriptor{
-				MediaType: "application/vnd.oci.image.layer.v1.tar",
-				Digest:    "sha256:child",
-				Size:      123,
-				ObjectKey: "sandbox-rootfs/team-1/sandbox-1/4/sha256/child.tar",
-			},
-		})
+		switch r.URL.Path {
+		case "/api/v1/rootfs/snapshots/prepare":
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&savedReq))
+			_ = json.NewEncoder(w).Encode(ctldapi.PrepareRootFSSnapshotResponse{
+				Handle: "handle-1",
+				Info: ctldapi.RootFSInfo{
+					Runtime:             "runc",
+					RuntimeHandler:      "io.containerd.runc.v2",
+					BaseImageRef:        "docker.io/library/busybox:1.36",
+					BaseImageDigest:     "sha256:base",
+					Snapshotter:         "overlayfs",
+					SnapshotParent:      "parent-1",
+					SnapshotParentChain: []string{"parent-1", "parent-0"},
+				},
+				Descriptor: ctldapi.RootFSDiffDescriptor{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    "sha256:child",
+					Size:      123,
+				},
+			})
+		case "/api/v1/rootfs/snapshots/publish":
+			_ = json.NewEncoder(w).Encode(ctldapi.PublishRootFSSnapshotResponse{
+				Published: true,
+				Info: ctldapi.RootFSInfo{
+					Runtime:             "runc",
+					RuntimeHandler:      "io.containerd.runc.v2",
+					BaseImageRef:        "docker.io/library/busybox:1.36",
+					BaseImageDigest:     "sha256:base",
+					Snapshotter:         "overlayfs",
+					SnapshotParent:      "parent-1",
+					SnapshotParentChain: []string{"parent-1", "parent-0"},
+				},
+				Descriptor: ctldapi.RootFSDiffDescriptor{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    "sha256:child",
+					Size:      123,
+					ObjectKey: "sandbox-rootfs/team-1/sandbox-1/4/sha256/child.tar",
+				},
+			})
+		default:
+			t.Fatalf("unexpected ctld path %s", r.URL.Path)
+		}
 	}))
 	defer ctld.Close()
 	ctldURL, ctldPort := parsedTestServer(t, ctld.URL)
@@ -168,7 +223,7 @@ func TestPauseSandboxRuntimeSavesChildLayerFromParentHead(t *testing.T) {
 				ID:                "sandbox-1",
 				TeamID:            "team-1",
 				RuntimeGeneration: 3,
-				Status:            SandboxStatusPausing,
+				Status:            SandboxStatusRunning,
 			},
 		},
 		rootFSStates: map[string]*SandboxRootFSState{
@@ -191,6 +246,8 @@ func TestPauseSandboxRuntimeSavesChildLayerFromParentHead(t *testing.T) {
 		clock:        systemTime{},
 		logger:       zap.NewNop(),
 	}
+	defer attachRootFSTestProcd(t, pod, svc, nil)()
+	addRootFSTestPauseTxn(store, pod, SandboxLifecyclePhasePreparing)
 
 	require.NoError(t, svc.CompletePausingSandboxRuntime(context.Background(), "sandbox-1"))
 
@@ -209,30 +266,47 @@ func TestCompletePausingSandboxRuntimeDoesNotCommitStaleCheckpoint(t *testing.T)
 				ID:                "sandbox-1",
 				TeamID:            "team-1",
 				RuntimeGeneration: 3,
-				Status:            SandboxStatusPausing,
+				Status:            SandboxStatusRunning,
 			},
 		},
 	}
+	txnID := ""
 	ctld := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/api/v1/rootfs/save", r.URL.Path)
-		store.setSandboxStatus("sandbox-1", SandboxStatusRunning)
-		_ = json.NewEncoder(w).Encode(ctldapi.SaveRootFSResponse{
-			Info: ctldapi.RootFSInfo{
-				Runtime:             "runc",
-				RuntimeHandler:      "io.containerd.runc.v2",
-				BaseImageRef:        "docker.io/library/busybox:1.36",
-				BaseImageDigest:     "sha256:base",
-				Snapshotter:         "overlayfs",
-				SnapshotParent:      "parent-1",
-				SnapshotParentChain: []string{"parent-1", "parent-0"},
-			},
-			Descriptor: ctldapi.RootFSDiffDescriptor{
-				MediaType: "application/vnd.oci.image.layer.v1.tar",
-				Digest:    "sha256:stale",
-				Size:      123,
-				ObjectKey: "sandbox-rootfs/team-1/sandbox-1/3/sha256/stale.tar",
-			},
-		})
+		switch r.URL.Path {
+		case "/api/v1/rootfs/snapshots/prepare":
+			store.mu.Lock()
+			store.lifecycleTxns[txnID].Phase = SandboxLifecyclePhaseAborted
+			store.mu.Unlock()
+			_ = json.NewEncoder(w).Encode(ctldapi.PrepareRootFSSnapshotResponse{
+				Handle: "handle-1",
+				Info: ctldapi.RootFSInfo{
+					Runtime:             "runc",
+					RuntimeHandler:      "io.containerd.runc.v2",
+					BaseImageRef:        "docker.io/library/busybox:1.36",
+					BaseImageDigest:     "sha256:base",
+					Snapshotter:         "overlayfs",
+					SnapshotParent:      "parent-1",
+					SnapshotParentChain: []string{"parent-1", "parent-0"},
+				},
+				Descriptor: ctldapi.RootFSDiffDescriptor{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    "sha256:stale",
+					Size:      123,
+				},
+			})
+		case "/api/v1/rootfs/snapshots/publish":
+			_ = json.NewEncoder(w).Encode(ctldapi.PublishRootFSSnapshotResponse{
+				Published: true,
+				Descriptor: ctldapi.RootFSDiffDescriptor{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    "sha256:stale",
+					Size:      123,
+					ObjectKey: "sandbox-rootfs/team-1/sandbox-1/3/sha256/stale.tar",
+				},
+			})
+		default:
+			t.Fatalf("unexpected ctld path %s", r.URL.Path)
+		}
 	}))
 	defer ctld.Close()
 	ctldURL, ctldPort := parsedTestServer(t, ctld.URL)
@@ -254,6 +328,8 @@ func TestCompletePausingSandboxRuntimeDoesNotCommitStaleCheckpoint(t *testing.T)
 		clock:        systemTime{},
 		logger:       zap.NewNop(),
 	}
+	defer attachRootFSTestProcd(t, pod, svc, nil)()
+	txnID = addRootFSTestPauseTxn(store, pod, SandboxLifecyclePhasePreparing)
 
 	require.NoError(t, svc.CompletePausingSandboxRuntime(context.Background(), "sandbox-1"))
 	assert.False(t, deleteCalled)
@@ -262,27 +338,50 @@ func TestCompletePausingSandboxRuntimeDoesNotCommitStaleCheckpoint(t *testing.T)
 }
 
 func TestPauseSandboxRuntimeSquashesRootFSWhenChainIsTooDeep(t *testing.T) {
-	var savedReq ctldapi.SaveRootFSRequest
+	var savedReq ctldapi.PrepareRootFSSnapshotRequest
 	ctld := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/api/v1/rootfs/save", r.URL.Path)
-		require.NoError(t, json.NewDecoder(r.Body).Decode(&savedReq))
-		_ = json.NewEncoder(w).Encode(ctldapi.SaveRootFSResponse{
-			Info: ctldapi.RootFSInfo{
-				Runtime:             "runc",
-				RuntimeHandler:      "io.containerd.runc.v2",
-				BaseImageRef:        "docker.io/library/busybox:1.36",
-				BaseImageDigest:     "sha256:base",
-				Snapshotter:         "overlayfs",
-				SnapshotParent:      "parent-1",
-				SnapshotParentChain: []string{"parent-1", "parent-0"},
-			},
-			Descriptor: ctldapi.RootFSDiffDescriptor{
-				MediaType: "application/vnd.oci.image.layer.v1.tar",
-				Digest:    "sha256:squashed",
-				Size:      456,
-				ObjectKey: "sandbox-rootfs/team-1/sandbox-1/4/sha256/squashed.tar",
-			},
-		})
+		switch r.URL.Path {
+		case "/api/v1/rootfs/snapshots/prepare":
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&savedReq))
+			_ = json.NewEncoder(w).Encode(ctldapi.PrepareRootFSSnapshotResponse{
+				Handle: "handle-1",
+				Info: ctldapi.RootFSInfo{
+					Runtime:             "runc",
+					RuntimeHandler:      "io.containerd.runc.v2",
+					BaseImageRef:        "docker.io/library/busybox:1.36",
+					BaseImageDigest:     "sha256:base",
+					Snapshotter:         "overlayfs",
+					SnapshotParent:      "parent-1",
+					SnapshotParentChain: []string{"parent-1", "parent-0"},
+				},
+				Descriptor: ctldapi.RootFSDiffDescriptor{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    "sha256:squashed",
+					Size:      456,
+				},
+			})
+		case "/api/v1/rootfs/snapshots/publish":
+			_ = json.NewEncoder(w).Encode(ctldapi.PublishRootFSSnapshotResponse{
+				Published: true,
+				Info: ctldapi.RootFSInfo{
+					Runtime:             "runc",
+					RuntimeHandler:      "io.containerd.runc.v2",
+					BaseImageRef:        "docker.io/library/busybox:1.36",
+					BaseImageDigest:     "sha256:base",
+					Snapshotter:         "overlayfs",
+					SnapshotParent:      "parent-1",
+					SnapshotParentChain: []string{"parent-1", "parent-0"},
+				},
+				Descriptor: ctldapi.RootFSDiffDescriptor{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    "sha256:squashed",
+					Size:      456,
+					ObjectKey: "sandbox-rootfs/team-1/sandbox-1/4/sha256/squashed.tar",
+				},
+			})
+		default:
+			t.Fatalf("unexpected ctld path %s", r.URL.Path)
+		}
 	}))
 	defer ctld.Close()
 	ctldURL, ctldPort := parsedTestServer(t, ctld.URL)
@@ -316,7 +415,7 @@ func TestPauseSandboxRuntimeSquashesRootFSWhenChainIsTooDeep(t *testing.T) {
 				ID:                "sandbox-1",
 				TeamID:            "team-1",
 				RuntimeGeneration: 3,
-				Status:            SandboxStatusPausing,
+				Status:            SandboxStatusRunning,
 			},
 		},
 		rootFSStates: map[string]*SandboxRootFSState{
@@ -336,6 +435,8 @@ func TestPauseSandboxRuntimeSquashesRootFSWhenChainIsTooDeep(t *testing.T) {
 		clock:  systemTime{},
 		logger: zap.NewNop(),
 	}
+	defer attachRootFSTestProcd(t, pod, svc, nil)()
+	addRootFSTestPauseTxn(store, pod, SandboxLifecyclePhasePreparing)
 
 	require.NoError(t, svc.CompletePausingSandboxRuntime(context.Background(), "sandbox-1"))
 
@@ -349,34 +450,57 @@ func TestPauseSandboxRuntimeSquashesRootFSWhenChainIsTooDeep(t *testing.T) {
 }
 
 func TestPauseSandboxRuntimeFallsBackToRootLayerWhenBaselineIsMissing(t *testing.T) {
-	var saveRequests []ctldapi.SaveRootFSRequest
+	var saveRequests []ctldapi.PrepareRootFSSnapshotRequest
 	ctld := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/api/v1/rootfs/save", r.URL.Path)
-		var req ctldapi.SaveRootFSRequest
-		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
-		saveRequests = append(saveRequests, req)
-		if req.ParentLayerID != "" {
-			w.WriteHeader(http.StatusNotFound)
-			_ = json.NewEncoder(w).Encode(ctldapi.SaveRootFSResponse{Error: "create rootfs diff: rootfs baseline layer-parent is not captured"})
-			return
+		switch r.URL.Path {
+		case "/api/v1/rootfs/snapshots/prepare":
+			var req ctldapi.PrepareRootFSSnapshotRequest
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+			saveRequests = append(saveRequests, req)
+			if req.ParentLayerID != "" {
+				w.WriteHeader(http.StatusNotFound)
+				_ = json.NewEncoder(w).Encode(ctldapi.PrepareRootFSSnapshotResponse{Error: "create rootfs diff: rootfs baseline layer-parent is not captured"})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(ctldapi.PrepareRootFSSnapshotResponse{
+				Handle: "handle-2",
+				Info: ctldapi.RootFSInfo{
+					Runtime:             "runc",
+					RuntimeHandler:      "io.containerd.runc.v2",
+					BaseImageRef:        "docker.io/library/busybox:1.36",
+					BaseImageDigest:     "sha256:base",
+					Snapshotter:         "overlayfs",
+					SnapshotParent:      "parent-1",
+					SnapshotParentChain: []string{"parent-1", "parent-0"},
+				},
+				Descriptor: ctldapi.RootFSDiffDescriptor{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    "sha256:full",
+					Size:      456,
+				},
+			})
+		case "/api/v1/rootfs/snapshots/publish":
+			_ = json.NewEncoder(w).Encode(ctldapi.PublishRootFSSnapshotResponse{
+				Published: true,
+				Info: ctldapi.RootFSInfo{
+					Runtime:             "runc",
+					RuntimeHandler:      "io.containerd.runc.v2",
+					BaseImageRef:        "docker.io/library/busybox:1.36",
+					BaseImageDigest:     "sha256:base",
+					Snapshotter:         "overlayfs",
+					SnapshotParent:      "parent-1",
+					SnapshotParentChain: []string{"parent-1", "parent-0"},
+				},
+				Descriptor: ctldapi.RootFSDiffDescriptor{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    "sha256:full",
+					Size:      456,
+					ObjectKey: "sandbox-rootfs/team-1/sandbox-1/3/sha256/full.tar",
+				},
+			})
+		default:
+			t.Fatalf("unexpected ctld path %s", r.URL.Path)
 		}
-		_ = json.NewEncoder(w).Encode(ctldapi.SaveRootFSResponse{
-			Info: ctldapi.RootFSInfo{
-				Runtime:             "runc",
-				RuntimeHandler:      "io.containerd.runc.v2",
-				BaseImageRef:        "docker.io/library/busybox:1.36",
-				BaseImageDigest:     "sha256:base",
-				Snapshotter:         "overlayfs",
-				SnapshotParent:      "parent-1",
-				SnapshotParentChain: []string{"parent-1", "parent-0"},
-			},
-			Descriptor: ctldapi.RootFSDiffDescriptor{
-				MediaType: "application/vnd.oci.image.layer.v1.tar",
-				Digest:    "sha256:full",
-				Size:      456,
-				ObjectKey: "sandbox-rootfs/team-1/sandbox-1/3/sha256/full.tar",
-			},
-		})
 	}))
 	defer ctld.Close()
 	ctldURL, ctldPort := parsedTestServer(t, ctld.URL)
@@ -389,7 +513,7 @@ func TestPauseSandboxRuntimeFallsBackToRootLayerWhenBaselineIsMissing(t *testing
 				ID:                "sandbox-1",
 				TeamID:            "team-1",
 				RuntimeGeneration: 3,
-				Status:            SandboxStatusPausing,
+				Status:            SandboxStatusRunning,
 			},
 		},
 		rootFSStates: map[string]*SandboxRootFSState{
@@ -412,6 +536,8 @@ func TestPauseSandboxRuntimeFallsBackToRootLayerWhenBaselineIsMissing(t *testing
 		clock:        systemTime{},
 		logger:       zap.NewNop(),
 	}
+	defer attachRootFSTestProcd(t, pod, svc, nil)()
+	addRootFSTestPauseTxn(store, pod, SandboxLifecyclePhasePreparing)
 
 	require.NoError(t, svc.CompletePausingSandboxRuntime(context.Background(), "sandbox-1"))
 
@@ -426,21 +552,24 @@ func TestPauseSandboxRuntimeFallsBackToRootLayerWhenBaselineIsMissing(t *testing
 	assert.Equal(t, "sha256:full", state.DiffDigest)
 }
 
-func TestGetSandboxReportsPausingRecordWhileRuntimePodStillRunning(t *testing.T) {
+func TestGetSandboxHidesRuntimeAfterPauseBarrier(t *testing.T) {
 	pod := rootFSTestPod("pod-1", "sandbox-1", "team-1")
 	pod.Status.PodIP = "10.0.0.10"
-	store := &memorySandboxStore{records: map[string]*SandboxRecord{
-		"sandbox-1": {
-			ID:                  "sandbox-1",
-			TeamID:              "team-1",
-			UserID:              "user-1",
-			TemplateID:          "template-1",
-			CurrentPodName:      "pod-1",
-			CurrentPodNamespace: "default",
-			RuntimeGeneration:   3,
-			Status:              SandboxStatusPausing,
+	store := &memorySandboxStore{
+		records: map[string]*SandboxRecord{
+			"sandbox-1": {
+				ID:                  "sandbox-1",
+				TeamID:              "team-1",
+				UserID:              "user-1",
+				TemplateID:          "template-1",
+				CurrentPodName:      "pod-1",
+				CurrentPodNamespace: "default",
+				RuntimeGeneration:   3,
+				Status:              SandboxStatusRunning,
+			},
 		},
-	}}
+	}
+	addRootFSTestPauseTxn(store, pod, SandboxLifecyclePhaseBarriered)
 	svc := &SandboxService{
 		k8sClient:    fake.NewSimpleClientset(pod),
 		podLister:    newTestPodLister(t, pod),
@@ -453,7 +582,7 @@ func TestGetSandboxReportsPausingRecordWhileRuntimePodStillRunning(t *testing.T)
 	sandbox, err := svc.GetSandbox(context.Background(), "sandbox-1")
 	require.NoError(t, err)
 	require.NotNil(t, sandbox)
-	assert.Equal(t, SandboxStatusPausing, sandbox.Status)
+	assert.Equal(t, SandboxStatusRunning, sandbox.Status)
 	assert.False(t, sandbox.Paused)
 	assert.Empty(t, sandbox.InternalAddr)
 	assert.Equal(t, "pod-1", sandbox.PodName)
@@ -677,17 +806,15 @@ func TestFinishRestoredSandboxRuntimeRetriesWithCheckpointBaseImage(t *testing.T
 	store := &memorySandboxStore{
 		records: map[string]*SandboxRecord{
 			"sandbox-1": {
-				ID:                  "sandbox-1",
-				TeamID:              "team-1",
-				UserID:              "user-1",
-				TemplateID:          "template-1",
-				TemplateName:        "template-1",
-				TemplateNamespace:   templateNamespace,
-				TemplateSpec:        template.Spec,
-				CurrentPodName:      "pod-current",
-				CurrentPodNamespace: templateNamespace,
-				RuntimeGeneration:   3,
-				Status:              SandboxStatusResuming,
+				ID:                "sandbox-1",
+				TeamID:            "team-1",
+				UserID:            "user-1",
+				TemplateID:        "template-1",
+				TemplateName:      "template-1",
+				TemplateNamespace: templateNamespace,
+				TemplateSpec:      template.Spec,
+				RuntimeGeneration: 3,
+				Status:            SandboxStatusPaused,
 			},
 		},
 		rootFSStates: map[string]*SandboxRootFSState{
@@ -729,9 +856,21 @@ func TestFinishRestoredSandboxRuntimeRetriesWithCheckpointBaseImage(t *testing.T
 	}
 	record := store.records["sandbox-1"]
 
-	_, err = svc.finishRestoredSandboxRuntime(context.Background(), currentPod, record, "hot")
+	restoredPod, err := svc.finishRestoredSandboxRuntime(context.Background(), currentPod, record, "hot")
 
 	require.NoError(t, err)
+	txn := &SandboxLifecycleTxn{
+		ID:             "resume-txn-sandbox-1",
+		SandboxID:      "sandbox-1",
+		Kind:           SandboxLifecycleKindResume,
+		Phase:          SandboxLifecyclePhasePreparing,
+		FromGeneration: 3,
+		ToGeneration:   runtimeGenerationFromPod(restoredPod),
+		ToPodNamespace: restoredPod.Namespace,
+		ToPodName:      restoredPod.Name,
+	}
+	store.lifecycleTxns = map[string]*SandboxLifecycleTxn{txn.ID: txn}
+	require.NoError(t, svc.commitResumedSandboxRuntime(context.Background(), restoredPod, record, txn))
 	require.Len(t, applyTargets, 2)
 	assert.Equal(t, "pod-current", applyTargets[0])
 	assert.NotEqual(t, "pod-current", applyTargets[1])
@@ -883,6 +1022,75 @@ func setRootFSTestClaimMounts(t *testing.T, pod *corev1.Pod, mounts []ClaimMount
 		pod.Annotations = make(map[string]string)
 	}
 	require.NoError(t, setMountsAnnotation(pod.Annotations, mounts))
+}
+
+func attachRootFSTestProcd(t *testing.T, pod *corev1.Pod, svc *SandboxService, calls *[]string) func() {
+	t.Helper()
+	procd := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/lifecycle/barrier":
+			require.Equal(t, http.MethodPut, r.Method)
+			var req ProcdLifecycleBarrierRequest
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+			if calls != nil {
+				*calls = append(*calls, fmt.Sprintf("barrier:%t", req.Active))
+			}
+			require.NoError(t, spec.WriteSuccess(w, http.StatusOK, ProcdLifecycleBarrierResponse{
+				Active:            req.Active,
+				Epoch:             req.Epoch,
+				RuntimeGeneration: req.RuntimeGeneration,
+			}))
+		case "/api/v1/sandbox/pause":
+			require.Equal(t, http.MethodPost, r.Method)
+			if calls != nil {
+				*calls = append(*calls, "pause")
+			}
+			require.NoError(t, spec.WriteSuccess(w, http.StatusOK, ProcdPauseResponse{Paused: true}))
+		case "/api/v1/sandbox/resume":
+			require.Equal(t, http.MethodPost, r.Method)
+			if calls != nil {
+				*calls = append(*calls, "resume")
+			}
+			require.NoError(t, spec.WriteSuccess(w, http.StatusOK, ProcdResumeResponse{Resumed: true}))
+		default:
+			t.Fatalf("unexpected procd path %s", r.URL.Path)
+		}
+	}))
+	procdURL, procdPort := parsedTestServer(t, procd.URL)
+	pod.Status.PodIP = procdURL.Hostname()
+	svc.procdClient = NewProcdClientWithHTTPClient(procd.Client())
+	svc.internalTokenGenerator = staticTokenGenerator{}
+	svc.config.ProcdPort = procdPort
+	return procd.Close
+}
+
+func addRootFSTestPauseTxn(store *memorySandboxStore, pod *corev1.Pod, phase string) string {
+	if phase == "" {
+		phase = SandboxLifecyclePhasePreparing
+	}
+	sandboxID := sandboxIDFromPod(pod)
+	txnID := "pause-txn-" + sandboxID
+	if store.lifecycleTxns == nil {
+		store.lifecycleTxns = make(map[string]*SandboxLifecycleTxn)
+	}
+	store.lifecycleTxns[txnID] = &SandboxLifecycleTxn{
+		ID:               txnID,
+		SandboxID:        sandboxID,
+		Kind:             SandboxLifecycleKindPause,
+		Phase:            phase,
+		Epoch:            1,
+		FromGeneration:   runtimeGenerationFromPod(pod),
+		FromPodNamespace: pod.Namespace,
+		FromPodName:      pod.Name,
+	}
+	if record := store.records[sandboxID]; record != nil {
+		record.Status = SandboxStatusRunning
+		record.CurrentPodNamespace = pod.Namespace
+		record.CurrentPodName = pod.Name
+		record.RuntimeGeneration = runtimeGenerationFromPod(pod)
+		record.LifecycleEpoch = 1
+	}
+	return txnID
 }
 
 type recordingPauseEnqueuer struct {

--- a/manager/pkg/service/sandbox_service_ttl_test.go
+++ b/manager/pkg/service/sandbox_service_ttl_test.go
@@ -130,6 +130,81 @@ func TestUpdateSandboxZeroTTLDisablesExpirations(t *testing.T) {
 	assert.Equal(t, int32(0), *cfg.HardTTL)
 }
 
+func TestUpdateSandboxPausedRecordIgnoresStaleRuntimePod(t *testing.T) {
+	pod := testSandboxPod()
+	pod.Annotations[controller.AnnotationExpiresAt] = "2026-03-07T12:05:00Z"
+	pod.Annotations[controller.AnnotationConfig] = `{"ttl":300}`
+
+	svc, client := newSandboxServiceForTTLTests(t, pod, 0)
+	svc.sandboxStore = &memorySandboxStore{records: map[string]*SandboxRecord{
+		"sandbox-1": {
+			ID:                  "sandbox-1",
+			TeamID:              "team-1",
+			UserID:              "user-1",
+			TemplateID:          "default",
+			TemplateName:        "default",
+			TemplateNamespace:   "tpl-default",
+			Status:              SandboxStatusPaused,
+			Config:              SandboxConfig{TTL: int32Ptr(300)},
+			CurrentPodName:      pod.Name,
+			CurrentPodNamespace: pod.Namespace,
+			RuntimeGeneration:   3,
+			ExpiresAt:           time.Date(2026, time.March, 7, 12, 5, 0, 0, time.UTC),
+		},
+	}}
+
+	updated, err := svc.UpdateSandbox(context.Background(), "sandbox-1", &SandboxUpdateConfig{
+		TTL: int32Ptr(0),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, SandboxStatusPaused, updated.Status)
+	assert.True(t, updated.ExpiresAt.IsZero())
+
+	record, err := svc.sandboxStore.GetSandbox(context.Background(), "sandbox-1")
+	require.NoError(t, err)
+	require.NotNil(t, record.Config.TTL)
+	assert.Equal(t, SandboxStatusPaused, record.Status)
+	assert.Equal(t, int32(0), *record.Config.TTL)
+	assert.True(t, record.ExpiresAt.IsZero())
+
+	for _, action := range client.Actions() {
+		if action.GetVerb() == "update" && action.GetResource().Resource == "pods" {
+			t.Fatalf("unexpected stale runtime pod update: %#v", action)
+		}
+	}
+	stored, err := client.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "2026-03-07T12:05:00Z", stored.Annotations[controller.AnnotationExpiresAt])
+}
+
+func TestPersistUpdatedSandboxPodDoesNotOverwritePausedRecord(t *testing.T) {
+	pod := testSandboxPod()
+	pod.Annotations[controller.AnnotationConfig] = `{"ttl":0}`
+
+	svc, _ := newSandboxServiceForTTLTests(t, pod, 0)
+	store := &memorySandboxStore{records: map[string]*SandboxRecord{
+		"sandbox-1": {
+			ID:                "sandbox-1",
+			TeamID:            "team-1",
+			UserID:            "user-1",
+			TemplateID:        "default",
+			TemplateName:      "default",
+			TemplateNamespace: "tpl-default",
+			Status:            SandboxStatusPaused,
+			Config:            SandboxConfig{TTL: int32Ptr(300)},
+			RuntimeGeneration: 3,
+		},
+	}}
+	svc.sandboxStore = store
+
+	require.NoError(t, svc.persistUpdatedSandboxPod(context.Background(), pod))
+	record, err := store.GetSandbox(context.Background(), "sandbox-1")
+	require.NoError(t, err)
+	require.NotNil(t, record.Config.TTL)
+	assert.Equal(t, SandboxStatusPaused, record.Status)
+	assert.Equal(t, int32(300), *record.Config.TTL)
+}
+
 func TestUpdateSandboxEnvVarsUpdatesProcdAndConfig(t *testing.T) {
 	pod := testSandboxPod()
 	pod.Annotations[controller.AnnotationConfig] = `{"env_vars":{"OLD":"old"},"ttl":300}`

--- a/manager/pkg/service/sandbox_store.go
+++ b/manager/pkg/service/sandbox_store.go
@@ -40,6 +40,7 @@ type SandboxRecord struct {
 	CurrentPodName      string
 	CurrentPodNamespace string
 	RuntimeGeneration   int64
+	LifecycleEpoch      int64
 	ClaimedAt           time.Time
 	ExpiresAt           time.Time
 	HardExpiresAt       time.Time
@@ -96,12 +97,55 @@ type SandboxRootFSLayer struct {
 	CreatedAt           time.Time
 }
 
+const (
+	SandboxLifecycleKindPause  = "pause"
+	SandboxLifecycleKindResume = "resume"
+
+	SandboxLifecycleSourceManual = "manual"
+	SandboxLifecycleSourceAuto   = "auto"
+
+	SandboxLifecyclePhasePreparing  = "preparing"
+	SandboxLifecyclePhaseBarriered  = "barriered"
+	SandboxLifecyclePhasePublishing = "publishing"
+	SandboxLifecyclePhaseCommitting = "committing"
+	SandboxLifecyclePhaseCommitted  = "committed"
+	SandboxLifecyclePhaseAborted    = "aborted"
+)
+
+// SandboxLifecycleTxn is the durable prepare/commit record for a sandbox
+// runtime generation transition.
+type SandboxLifecycleTxn struct {
+	ID                  string
+	SandboxID           string
+	Kind                string
+	Phase               string
+	Source              string
+	Cancelable          bool
+	Epoch               int64
+	FromGeneration      int64
+	ToGeneration        int64
+	FromPodNamespace    string
+	FromPodName         string
+	ToPodNamespace      string
+	ToPodName           string
+	ExpectedHeadLayerID string
+	PreparedHeadLayerID string
+	Error               string
+	CancelReason        string
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
+	CancelRequestedAt   time.Time
+	CommittedAt         time.Time
+	AbortedAt           time.Time
+}
+
 // SandboxStore persists sandbox identities independently of runtime pods.
 type SandboxStore interface {
 	UpsertSandbox(ctx context.Context, record *SandboxRecord) error
 	GetSandbox(ctx context.Context, sandboxID string) (*SandboxRecord, error)
 	ListSandboxes(ctx context.Context, req *ListSandboxesRequest) ([]*SandboxRecord, error)
-	ListPausingSandboxes(ctx context.Context, limit int) ([]*SandboxRecord, error)
+	ListActiveLifecycleTxns(ctx context.Context, kind string, limit int) ([]*SandboxLifecycleTxn, error)
+	GetActiveLifecycleTxn(ctx context.Context, sandboxID string) (*SandboxLifecycleTxn, error)
 	ListHardExpiredSandboxes(ctx context.Context, now time.Time, limit int) ([]*SandboxRecord, error)
 	MarkSandboxDeleted(ctx context.Context, sandboxID string, deletedAt time.Time) error
 	SaveRootFSState(ctx context.Context, state *SandboxRootFSState) error
@@ -114,6 +158,13 @@ type SandboxStoreTx interface {
 	SaveRuntime(ctx context.Context, sandboxID, namespace, podName, status string, generation int64, expiresAt, hardExpiresAt time.Time) error
 	MarkRuntimePaused(ctx context.Context, sandboxID string, generation int64, pausedAt time.Time) error
 	SaveRootFSState(ctx context.Context, state *SandboxRootFSState) error
+	GetActiveLifecycleTxn(ctx context.Context, sandboxID string) (*SandboxLifecycleTxn, error)
+	BeginLifecycleTxn(ctx context.Context, txn *SandboxLifecycleTxn) error
+	SetLifecycleTxnRuntime(ctx context.Context, txnID, namespace, podName string) error
+	UpdateLifecycleTxnPhase(ctx context.Context, txnID, phase string) error
+	RequestLifecycleTxnCancel(ctx context.Context, txnID, reason string) (bool, error)
+	CommitLifecycleTxn(ctx context.Context, txnID, preparedHeadLayerID string) error
+	AbortLifecycleTxn(ctx context.Context, txnID, reason string) error
 }
 
 type PGSandboxStore struct {
@@ -165,10 +216,10 @@ func upsertSandboxRecord(ctx context.Context, exec rootFSStateExecutor, record *
 		INSERT INTO manager.sandboxes (
 			sandbox_id, team_id, user_id, template_id, template_name, template_namespace,
 			cluster_id, status, config, mounts, template_spec,
-			current_pod_name, current_pod_namespace, runtime_generation,
+			current_pod_name, current_pod_namespace, runtime_generation, lifecycle_epoch,
 			claimed_at, expires_at, hard_expires_at, deleted_at, created_at, updated_at
 		)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, COALESCE($19, NOW()), NOW())
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, COALESCE($20, NOW()), NOW())
 		ON CONFLICT (sandbox_id) DO UPDATE SET
 			team_id = EXCLUDED.team_id,
 			user_id = EXCLUDED.user_id,
@@ -183,6 +234,7 @@ func upsertSandboxRecord(ctx context.Context, exec rootFSStateExecutor, record *
 			current_pod_name = EXCLUDED.current_pod_name,
 			current_pod_namespace = EXCLUDED.current_pod_namespace,
 			runtime_generation = EXCLUDED.runtime_generation,
+			lifecycle_epoch = GREATEST(manager.sandboxes.lifecycle_epoch, EXCLUDED.lifecycle_epoch),
 			claimed_at = EXCLUDED.claimed_at,
 			expires_at = EXCLUDED.expires_at,
 			hard_expires_at = EXCLUDED.hard_expires_at,
@@ -190,7 +242,7 @@ func upsertSandboxRecord(ctx context.Context, exec rootFSStateExecutor, record *
 			updated_at = NOW()
 	`, record.ID, record.TeamID, record.UserID, record.TemplateID, record.TemplateName, record.TemplateNamespace,
 		record.ClusterID, record.Status, configJSON, mountsJSON, specJSON,
-		record.CurrentPodName, record.CurrentPodNamespace, record.RuntimeGeneration,
+		record.CurrentPodName, record.CurrentPodNamespace, record.RuntimeGeneration, record.LifecycleEpoch,
 		nullableTime(record.ClaimedAt), nullableTime(record.ExpiresAt), nullableTime(record.HardExpiresAt), nullableTime(record.DeletedAt), nullableTime(record.CreatedAt))
 	if err != nil {
 		return fmt.Errorf("upsert sandbox: %w", err)
@@ -234,35 +286,42 @@ func (s *PGSandboxStore) ListSandboxes(ctx context.Context, req *ListSandboxesRe
 	return records, nil
 }
 
-func (s *PGSandboxStore) ListPausingSandboxes(ctx context.Context, limit int) ([]*SandboxRecord, error) {
+func (s *PGSandboxStore) ListActiveLifecycleTxns(ctx context.Context, kind string, limit int) ([]*SandboxLifecycleTxn, error) {
 	if s == nil || s.pool == nil {
 		return nil, nil
 	}
 	if limit <= 0 {
 		limit = 500
 	}
-	rows, err := s.pool.Query(ctx, sandboxRecordSelectSQL()+`
-		WHERE deleted_at IS NULL
-			AND status = $1
+	rows, err := s.pool.Query(ctx, lifecycleTxnSelectSQL()+`
+		WHERE kind = $1
+			AND phase IN ('preparing', 'barriered', 'publishing', 'committing')
 		ORDER BY updated_at ASC
 		LIMIT $2
-	`, SandboxStatusPausing, limit)
+	`, strings.TrimSpace(kind), limit)
 	if err != nil {
-		return nil, fmt.Errorf("list pausing sandboxes: %w", err)
+		return nil, fmt.Errorf("list active lifecycle txns: %w", err)
 	}
 	defer rows.Close()
-	var records []*SandboxRecord
+	var txns []*SandboxLifecycleTxn
 	for rows.Next() {
-		record, err := scanSandboxRecordRows(rows)
+		txn, err := scanLifecycleTxnRows(rows)
 		if err != nil {
 			return nil, err
 		}
-		records = append(records, record)
+		txns = append(txns, txn)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate pausing sandboxes: %w", err)
+		return nil, fmt.Errorf("iterate active lifecycle txns: %w", err)
 	}
-	return records, nil
+	return txns, nil
+}
+
+func (s *PGSandboxStore) GetActiveLifecycleTxn(ctx context.Context, sandboxID string) (*SandboxLifecycleTxn, error) {
+	if s == nil || s.pool == nil {
+		return nil, nil
+	}
+	return getActiveLifecycleTxn(ctx, s.pool, sandboxID)
 }
 
 func (s *PGSandboxStore) ListHardExpiredSandboxes(ctx context.Context, now time.Time, limit int) ([]*SandboxRecord, error) {
@@ -307,7 +366,12 @@ func (s *PGSandboxStore) MarkSandboxDeleted(ctx context.Context, sandboxID strin
 	if deletedAt.IsZero() {
 		deletedAt = time.Now().UTC()
 	}
-	_, err := s.pool.Exec(ctx, `
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("begin mark sandbox deleted tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if _, err := tx.Exec(ctx, `
 		UPDATE manager.sandboxes
 		SET status = $2,
 			current_pod_name = '',
@@ -315,11 +379,21 @@ func (s *PGSandboxStore) MarkSandboxDeleted(ctx context.Context, sandboxID strin
 			deleted_at = $3,
 			updated_at = NOW()
 		WHERE sandbox_id = $1
-	`, sandboxID, SandboxStatusDeleted, deletedAt)
-	if err != nil {
+	`, sandboxID, SandboxStatusDeleted, deletedAt); err != nil {
 		return fmt.Errorf("mark sandbox deleted: %w", err)
 	}
-	if _, err := s.pool.Exec(ctx, `
+	if _, err := tx.Exec(ctx, `
+		UPDATE manager.sandbox_lifecycle_txns
+		SET phase = $2,
+			error = $3,
+			aborted_at = NOW(),
+			updated_at = NOW()
+		WHERE sandbox_id = $1
+			AND phase IN ('preparing', 'barriered', 'publishing', 'committing')
+	`, sandboxID, SandboxLifecyclePhaseAborted, "sandbox deleted"); err != nil {
+		return fmt.Errorf("abort sandbox lifecycle txns for deleted sandbox: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `
 		WITH removed AS (
 			DELETE FROM manager.sandbox_rootfs_bindings
 			WHERE sandbox_id = $1
@@ -346,11 +420,14 @@ func (s *PGSandboxStore) MarkSandboxDeleted(ctx context.Context, sandboxID strin
 	`, sandboxID); err != nil {
 		return fmt.Errorf("delete sandbox rootfs binding: %w", err)
 	}
-	if _, err := s.pool.Exec(ctx, `DELETE FROM manager.sandbox_rootfs_states WHERE sandbox_id = $1`, sandboxID); err != nil {
+	if _, err := tx.Exec(ctx, `DELETE FROM manager.sandbox_rootfs_states WHERE sandbox_id = $1`, sandboxID); err != nil {
 		return fmt.Errorf("delete sandbox rootfs states: %w", err)
 	}
-	if _, err := s.pool.Exec(ctx, `DELETE FROM manager.sandbox_rootfs_heads WHERE sandbox_id = $1`, sandboxID); err != nil {
+	if _, err := tx.Exec(ctx, `DELETE FROM manager.sandbox_rootfs_heads WHERE sandbox_id = $1`, sandboxID); err != nil {
 		return fmt.Errorf("delete sandbox rootfs head: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit mark sandbox deleted tx: %w", err)
 	}
 	return nil
 }
@@ -440,7 +517,7 @@ type sandboxStoreTx struct {
 }
 
 func (t sandboxStoreTx) SaveRuntime(ctx context.Context, sandboxID, namespace, podName, status string, generation int64, expiresAt, hardExpiresAt time.Time) error {
-	_, err := t.tx.Exec(ctx, `
+	tag, err := t.tx.Exec(ctx, `
 		UPDATE manager.sandboxes
 		SET status = $2,
 			current_pod_namespace = $3,
@@ -451,15 +528,19 @@ func (t sandboxStoreTx) SaveRuntime(ctx context.Context, sandboxID, namespace, p
 			deleted_at = NULL,
 			updated_at = NOW()
 		WHERE sandbox_id = $1
+			AND deleted_at IS NULL
 	`, sandboxID, status, namespace, podName, generation, nullableTime(expiresAt), nullableTime(hardExpiresAt))
 	if err != nil {
 		return fmt.Errorf("save sandbox runtime: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("%w: %s", ErrSandboxRecordNotFound, sandboxID)
 	}
 	return nil
 }
 
 func (t sandboxStoreTx) MarkRuntimePaused(ctx context.Context, sandboxID string, generation int64, pausedAt time.Time) error {
-	_, err := t.tx.Exec(ctx, `
+	tag, err := t.tx.Exec(ctx, `
 		UPDATE manager.sandboxes
 		SET status = $2,
 			current_pod_namespace = '',
@@ -468,15 +549,201 @@ func (t sandboxStoreTx) MarkRuntimePaused(ctx context.Context, sandboxID string,
 			expires_at = NULL,
 			updated_at = NOW()
 		WHERE sandbox_id = $1
+			AND deleted_at IS NULL
 	`, sandboxID, SandboxStatusPaused, generation)
 	if err != nil {
 		return fmt.Errorf("mark sandbox runtime paused: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("%w: %s", ErrSandboxRecordNotFound, sandboxID)
 	}
 	return nil
 }
 
 func (t sandboxStoreTx) SaveRootFSState(ctx context.Context, state *SandboxRootFSState) error {
 	return saveRootFSState(ctx, t.tx, state)
+}
+
+func (t sandboxStoreTx) GetActiveLifecycleTxn(ctx context.Context, sandboxID string) (*SandboxLifecycleTxn, error) {
+	return getActiveLifecycleTxn(ctx, t.tx, sandboxID)
+}
+
+func (t sandboxStoreTx) BeginLifecycleTxn(ctx context.Context, txn *SandboxLifecycleTxn) error {
+	if txn == nil {
+		return nil
+	}
+	if strings.TrimSpace(txn.ID) == "" {
+		return fmt.Errorf("txn_id is required")
+	}
+	if strings.TrimSpace(txn.SandboxID) == "" {
+		return fmt.Errorf("sandbox_id is required")
+	}
+	if strings.TrimSpace(txn.Kind) == "" {
+		return fmt.Errorf("lifecycle kind is required")
+	}
+	tag, err := t.tx.Exec(ctx, `
+		UPDATE manager.sandboxes
+		SET lifecycle_epoch = lifecycle_epoch + 1,
+			updated_at = NOW()
+		WHERE sandbox_id = $1
+	`, txn.SandboxID)
+	if err != nil {
+		return fmt.Errorf("advance lifecycle epoch: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("%w: %s", ErrSandboxRecordNotFound, txn.SandboxID)
+	}
+	var epoch int64
+	if err := t.tx.QueryRow(ctx, `SELECT lifecycle_epoch FROM manager.sandboxes WHERE sandbox_id = $1`, txn.SandboxID).Scan(&epoch); err != nil {
+		return fmt.Errorf("load lifecycle epoch: %w", err)
+	}
+	txn.Epoch = epoch
+	phase := strings.TrimSpace(txn.Phase)
+	if phase == "" {
+		phase = SandboxLifecyclePhasePreparing
+	}
+	source := strings.TrimSpace(txn.Source)
+	if source == "" {
+		source = SandboxLifecycleSourceManual
+	}
+	_, err = t.tx.Exec(ctx, `
+		INSERT INTO manager.sandbox_lifecycle_txns (
+			txn_id, sandbox_id, kind, phase, source, cancelable, epoch,
+			from_generation, to_generation,
+			from_pod_namespace, from_pod_name,
+			to_pod_namespace, to_pod_name,
+			expected_head_layer_id, prepared_head_layer_id,
+			created_at, updated_at
+		)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, NOW(), NOW())
+	`, txn.ID, txn.SandboxID, txn.Kind, phase, source, txn.Cancelable, txn.Epoch,
+		txn.FromGeneration, txn.ToGeneration,
+		txn.FromPodNamespace, txn.FromPodName,
+		txn.ToPodNamespace, txn.ToPodName,
+		txn.ExpectedHeadLayerID, txn.PreparedHeadLayerID)
+	if err != nil {
+		return fmt.Errorf("begin lifecycle txn: %w", err)
+	}
+	txn.Phase = phase
+	txn.Source = source
+	return nil
+}
+
+func (t sandboxStoreTx) SetLifecycleTxnRuntime(ctx context.Context, txnID, namespace, podName string) error {
+	txnID = strings.TrimSpace(txnID)
+	if txnID == "" {
+		return nil
+	}
+	tag, err := t.tx.Exec(ctx, `
+		UPDATE manager.sandbox_lifecycle_txns
+		SET to_pod_namespace = $2,
+			to_pod_name = $3,
+			updated_at = NOW()
+		WHERE txn_id = $1
+			AND phase IN ('preparing', 'barriered', 'publishing', 'committing')
+	`, txnID, strings.TrimSpace(namespace), strings.TrimSpace(podName))
+	if err != nil {
+		return fmt.Errorf("set lifecycle txn runtime: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("active lifecycle txn %s not found", txnID)
+	}
+	return nil
+}
+
+func (t sandboxStoreTx) UpdateLifecycleTxnPhase(ctx context.Context, txnID, phase string) error {
+	txnID = strings.TrimSpace(txnID)
+	phase = strings.TrimSpace(phase)
+	if txnID == "" || phase == "" {
+		return nil
+	}
+	tag, err := t.tx.Exec(ctx, `
+		UPDATE manager.sandbox_lifecycle_txns
+		SET phase = $2,
+			updated_at = NOW()
+		WHERE txn_id = $1
+			AND phase IN ('preparing', 'barriered', 'publishing', 'committing')
+			AND cancel_requested_at IS NULL
+	`, txnID, phase)
+	if err != nil {
+		return fmt.Errorf("update lifecycle txn phase: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("active lifecycle txn %s not found", txnID)
+	}
+	return nil
+}
+
+func (t sandboxStoreTx) RequestLifecycleTxnCancel(ctx context.Context, txnID, reason string) (bool, error) {
+	txnID = strings.TrimSpace(txnID)
+	if txnID == "" {
+		return false, nil
+	}
+	tag, err := t.tx.Exec(ctx, `
+		UPDATE manager.sandbox_lifecycle_txns
+		SET cancel_requested_at = COALESCE(cancel_requested_at, NOW()),
+			cancel_reason = CASE
+				WHEN cancel_reason = '' THEN $2
+				ELSE cancel_reason
+			END,
+			updated_at = NOW()
+		WHERE txn_id = $1
+			AND kind = 'pause'
+			AND source = 'auto'
+			AND cancelable = TRUE
+			AND phase IN ('preparing', 'barriered', 'publishing')
+	`, txnID, strings.TrimSpace(reason))
+	if err != nil {
+		return false, fmt.Errorf("request lifecycle txn cancel: %w", err)
+	}
+	return tag.RowsAffected() > 0, nil
+}
+
+func (t sandboxStoreTx) CommitLifecycleTxn(ctx context.Context, txnID, preparedHeadLayerID string) error {
+	txnID = strings.TrimSpace(txnID)
+	if txnID == "" {
+		return nil
+	}
+	tag, err := t.tx.Exec(ctx, `
+		UPDATE manager.sandbox_lifecycle_txns
+		SET phase = $2,
+			prepared_head_layer_id = $3,
+			committed_at = NOW(),
+			updated_at = NOW()
+		WHERE txn_id = $1
+			AND phase IN ('preparing', 'barriered', 'publishing', 'committing')
+			AND cancel_requested_at IS NULL
+	`, txnID, SandboxLifecyclePhaseCommitted, strings.TrimSpace(preparedHeadLayerID))
+	if err != nil {
+		return fmt.Errorf("commit lifecycle txn: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("active lifecycle txn %s not found", txnID)
+	}
+	return nil
+}
+
+func (t sandboxStoreTx) AbortLifecycleTxn(ctx context.Context, txnID, reason string) error {
+	txnID = strings.TrimSpace(txnID)
+	if txnID == "" {
+		return nil
+	}
+	tag, err := t.tx.Exec(ctx, `
+		UPDATE manager.sandbox_lifecycle_txns
+		SET phase = $2,
+			error = $3,
+			aborted_at = NOW(),
+			updated_at = NOW()
+		WHERE txn_id = $1
+			AND phase IN ('preparing', 'barriered', 'publishing', 'committing')
+	`, txnID, SandboxLifecyclePhaseAborted, strings.TrimSpace(reason))
+	if err != nil {
+		return fmt.Errorf("abort lifecycle txn: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("active lifecycle txn %s not found", txnID)
+	}
+	return nil
 }
 
 func (t sandboxStoreTx) UpsertSandbox(ctx context.Context, record *SandboxRecord) error {
@@ -487,9 +754,32 @@ func sandboxRecordSelectSQL() string {
 	return `
 		SELECT sandbox_id, team_id, user_id, template_id, template_name, template_namespace,
 			cluster_id, status, config, mounts, template_spec,
-			current_pod_name, current_pod_namespace, runtime_generation,
+			current_pod_name, current_pod_namespace, runtime_generation, lifecycle_epoch,
 			claimed_at, expires_at, hard_expires_at, deleted_at, created_at, updated_at
 		FROM manager.sandboxes`
+}
+
+func lifecycleTxnSelectSQL() string {
+	return `
+		SELECT txn_id, sandbox_id, kind, phase, source, cancelable, epoch,
+			from_generation, to_generation,
+			from_pod_namespace, from_pod_name,
+			to_pod_namespace, to_pod_name,
+			expected_head_layer_id, prepared_head_layer_id,
+			error, cancel_reason, created_at, updated_at,
+			cancel_requested_at, committed_at, aborted_at
+		FROM manager.sandbox_lifecycle_txns`
+}
+
+func getActiveLifecycleTxn(ctx context.Context, exec interface {
+	QueryRow(context.Context, string, ...any) pgx.Row
+}, sandboxID string) (*SandboxLifecycleTxn, error) {
+	return scanLifecycleTxn(exec.QueryRow(ctx, lifecycleTxnSelectSQL()+`
+		WHERE sandbox_id = $1
+			AND phase IN ('preparing', 'barriered', 'publishing', 'committing')
+		ORDER BY updated_at DESC
+		LIMIT 1
+	`, sandboxID))
 }
 
 type rootFSStateExecutor interface {
@@ -805,7 +1095,7 @@ func scanSandboxRecordInto(scanner sandboxRecordScanner) (*SandboxRecord, error)
 	if err := scanner.Scan(
 		&record.ID, &record.TeamID, &record.UserID, &record.TemplateID, &record.TemplateName, &record.TemplateNamespace,
 		&record.ClusterID, &record.Status, &configJSON, &mountsJSON, &specJSON,
-		&record.CurrentPodName, &record.CurrentPodNamespace, &record.RuntimeGeneration,
+		&record.CurrentPodName, &record.CurrentPodNamespace, &record.RuntimeGeneration, &record.LifecycleEpoch,
 		&claimedAt, &expiresAt, &hardExpiresAt, &deletedAt, &record.CreatedAt, &record.UpdatedAt,
 	); err != nil {
 		return nil, err
@@ -824,6 +1114,58 @@ func scanSandboxRecordInto(scanner sandboxRecordScanner) (*SandboxRecord, error)
 	record.HardExpiresAt = derefTime(hardExpiresAt)
 	record.DeletedAt = derefTime(deletedAt)
 	return &record, nil
+}
+
+func scanLifecycleTxn(row sandboxRecordScanner) (*SandboxLifecycleTxn, error) {
+	txn, err := scanLifecycleTxnInto(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return txn, nil
+}
+
+func scanLifecycleTxnRows(rows pgx.Rows) (*SandboxLifecycleTxn, error) {
+	return scanLifecycleTxnInto(rows)
+}
+
+func scanLifecycleTxnInto(scanner sandboxRecordScanner) (*SandboxLifecycleTxn, error) {
+	var txn SandboxLifecycleTxn
+	var cancelRequestedAt, committedAt, abortedAt *time.Time
+	if err := scanner.Scan(
+		&txn.ID, &txn.SandboxID, &txn.Kind, &txn.Phase, &txn.Source, &txn.Cancelable, &txn.Epoch,
+		&txn.FromGeneration, &txn.ToGeneration,
+		&txn.FromPodNamespace, &txn.FromPodName,
+		&txn.ToPodNamespace, &txn.ToPodName,
+		&txn.ExpectedHeadLayerID, &txn.PreparedHeadLayerID,
+		&txn.Error, &txn.CancelReason, &txn.CreatedAt, &txn.UpdatedAt,
+		&cancelRequestedAt, &committedAt, &abortedAt,
+	); err != nil {
+		return nil, err
+	}
+	txn.CancelRequestedAt = derefTime(cancelRequestedAt)
+	txn.CommittedAt = derefTime(committedAt)
+	txn.AbortedAt = derefTime(abortedAt)
+	return &txn, nil
+}
+
+func cloneSandboxLifecycleTxn(txn *SandboxLifecycleTxn) *SandboxLifecycleTxn {
+	if txn == nil {
+		return nil
+	}
+	clone := *txn
+	return &clone
+}
+
+func sandboxLifecyclePhaseActive(phase string) bool {
+	switch phase {
+	case SandboxLifecyclePhasePreparing, SandboxLifecyclePhaseBarriered, SandboxLifecyclePhasePublishing, SandboxLifecyclePhaseCommitting:
+		return true
+	default:
+		return false
+	}
 }
 
 func marshalSandboxRecordJSON(record *SandboxRecord) ([]byte, []byte, []byte, error) {

--- a/manager/pkg/service/sandbox_store.go
+++ b/manager/pkg/service/sandbox_store.go
@@ -162,6 +162,7 @@ type SandboxStoreTx interface {
 	BeginLifecycleTxn(ctx context.Context, txn *SandboxLifecycleTxn) error
 	SetLifecycleTxnRuntime(ctx context.Context, txnID, namespace, podName string) error
 	UpdateLifecycleTxnPhase(ctx context.Context, txnID, phase string) error
+	SetLifecycleTxnPreparedHead(ctx context.Context, txnID, preparedHeadLayerID string) error
 	RequestLifecycleTxnCancel(ctx context.Context, txnID, reason string) (bool, error)
 	CommitLifecycleTxn(ctx context.Context, txnID, preparedHeadLayerID string) error
 	AbortLifecycleTxn(ctx context.Context, txnID, reason string) error
@@ -674,6 +675,29 @@ func (t sandboxStoreTx) UpdateLifecycleTxnPhase(ctx context.Context, txnID, phas
 	return nil
 }
 
+func (t sandboxStoreTx) SetLifecycleTxnPreparedHead(ctx context.Context, txnID, preparedHeadLayerID string) error {
+	txnID = strings.TrimSpace(txnID)
+	preparedHeadLayerID = strings.TrimSpace(preparedHeadLayerID)
+	if txnID == "" || preparedHeadLayerID == "" {
+		return nil
+	}
+	tag, err := t.tx.Exec(ctx, `
+		UPDATE manager.sandbox_lifecycle_txns
+		SET prepared_head_layer_id = $2,
+			updated_at = NOW()
+		WHERE txn_id = $1
+			AND phase IN ('preparing', 'barriered', 'publishing', 'committing')
+			AND cancel_requested_at IS NULL
+	`, txnID, preparedHeadLayerID)
+	if err != nil {
+		return fmt.Errorf("set lifecycle txn prepared head: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("active lifecycle txn %s not found", txnID)
+	}
+	return nil
+}
+
 func (t sandboxStoreTx) RequestLifecycleTxnCancel(ctx context.Context, txnID, reason string) (bool, error) {
 	txnID = strings.TrimSpace(txnID)
 	if txnID == "" {
@@ -889,6 +913,12 @@ func saveRootFSObject(ctx context.Context, exec rootFSStateExecutor, state *Sand
 	}
 	if tag.RowsAffected() == 0 {
 		return fmt.Errorf("%w: %s", ErrRootFSObjectConflict, state.DiffObjectKey)
+	}
+	if _, err := exec.Exec(ctx, `
+		DELETE FROM manager.rootfs_object_deletions
+		WHERE object_key = $1
+	`, state.DiffObjectKey); err != nil {
+		return fmt.Errorf("clear pending rootfs object deletion: %w", err)
 	}
 	return nil
 }

--- a/manager/procd/pkg/http/lifecycle_barrier.go
+++ b/manager/procd/pkg/http/lifecycle_barrier.go
@@ -1,0 +1,188 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
+)
+
+const defaultLifecycleBarrierWaitTimeout = 30 * time.Second
+
+type lifecycleBarrier struct {
+	mu                sync.Mutex
+	cond              *sync.Cond
+	active            bool
+	epoch             int64
+	runtimeGeneration int64
+	inFlight          int
+}
+
+type lifecycleBarrierRequest struct {
+	Active            bool  `json:"active"`
+	Epoch             int64 `json:"epoch,omitempty"`
+	RuntimeGeneration int64 `json:"runtime_generation,omitempty"`
+	WaitTimeoutMS     int64 `json:"wait_timeout_ms,omitempty"`
+}
+
+type lifecycleBarrierResponse struct {
+	Active            bool  `json:"active"`
+	Epoch             int64 `json:"epoch,omitempty"`
+	RuntimeGeneration int64 `json:"runtime_generation,omitempty"`
+	InFlight          int   `json:"in_flight"`
+}
+
+func newLifecycleBarrier() *lifecycleBarrier {
+	b := &lifecycleBarrier{}
+	b.cond = sync.NewCond(&b.mu)
+	return b
+}
+
+func (b *lifecycleBarrier) middleware(next http.Handler) http.Handler {
+	if b == nil {
+		return next
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !procdRequestMutatesRuntime(r) {
+			next.ServeHTTP(w, r)
+			return
+		}
+		release, ok := b.enter()
+		if !ok {
+			_ = spec.WriteError(w, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox lifecycle barrier is active")
+			return
+		}
+		defer release()
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (b *lifecycleBarrier) enter() (func(), bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.active {
+		return nil, false
+	}
+	b.inFlight++
+	return func() {
+		b.mu.Lock()
+		defer b.mu.Unlock()
+		if b.inFlight > 0 {
+			b.inFlight--
+		}
+		if b.inFlight == 0 {
+			b.cond.Broadcast()
+		}
+	}, true
+}
+
+func (b *lifecycleBarrier) setActive(r *http.Request, req lifecycleBarrierRequest) (lifecycleBarrierResponse, error) {
+	timeout := time.Duration(req.WaitTimeoutMS) * time.Millisecond
+	if timeout <= 0 {
+		timeout = defaultLifecycleBarrierWaitTimeout
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if !req.Active {
+		b.active = false
+		b.epoch = 0
+		b.runtimeGeneration = 0
+		b.cond.Broadcast()
+		return b.snapshotLocked(), nil
+	}
+
+	b.active = true
+	b.epoch = req.Epoch
+	b.runtimeGeneration = req.RuntimeGeneration
+
+	deadline := time.Now().Add(timeout)
+	var timer *time.Timer
+	if timeout > 0 {
+		timer = time.AfterFunc(timeout, func() {
+			b.mu.Lock()
+			defer b.mu.Unlock()
+			b.cond.Broadcast()
+		})
+		defer timer.Stop()
+	}
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-r.Context().Done():
+			b.mu.Lock()
+			b.cond.Broadcast()
+			b.mu.Unlock()
+		case <-done:
+		}
+	}()
+	defer close(done)
+
+	for b.inFlight > 0 {
+		if err := r.Context().Err(); err != nil {
+			b.active = false
+			b.epoch = 0
+			b.runtimeGeneration = 0
+			b.cond.Broadcast()
+			return b.snapshotLocked(), err
+		}
+		if !deadline.IsZero() && time.Now().After(deadline) {
+			b.active = false
+			b.epoch = 0
+			b.runtimeGeneration = 0
+			b.cond.Broadcast()
+			return b.snapshotLocked(), http.ErrHandlerTimeout
+		}
+		b.cond.Wait()
+	}
+	return b.snapshotLocked(), nil
+}
+
+func (b *lifecycleBarrier) snapshotLocked() lifecycleBarrierResponse {
+	return lifecycleBarrierResponse{
+		Active:            b.active,
+		Epoch:             b.epoch,
+		RuntimeGeneration: b.runtimeGeneration,
+		InFlight:          b.inFlight,
+	}
+}
+
+func (s *Server) lifecycleBarrierHandler(w http.ResponseWriter, r *http.Request) {
+	var req lifecycleBarrierRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		_ = spec.WriteError(w, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
+		return
+	}
+	resp, err := s.barrier.setActive(r, req)
+	if err != nil {
+		_ = spec.WriteError(w, http.StatusServiceUnavailable, spec.CodeUnavailable, err.Error())
+		return
+	}
+	_ = spec.WriteSuccess(w, http.StatusOK, resp)
+}
+
+func procdRequestMutatesRuntime(r *http.Request) bool {
+	if r == nil || r.URL == nil {
+		return false
+	}
+	path := strings.TrimRight(r.URL.Path, "/")
+	switch path {
+	case "/api/v1/lifecycle/barrier", "/api/v1/sandbox/pause", "/api/v1/sandbox/resume":
+		return false
+	}
+	if !strings.HasPrefix(path, "/api/v1/") {
+		return false
+	}
+	switch r.Method {
+	case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
+		return true
+	case http.MethodGet:
+		return strings.HasSuffix(path, "/ws") || path == "/api/v1/functions/ws"
+	default:
+		return true
+	}
+}

--- a/manager/procd/pkg/http/lifecycle_barrier_test.go
+++ b/manager/procd/pkg/http/lifecycle_barrier_test.go
@@ -1,0 +1,27 @@
+package http
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestProcdRequestMutatesRuntimeSkipsLifecycleControlEndpoints(t *testing.T) {
+	for _, path := range []string{
+		"/api/v1/lifecycle/barrier",
+		"/api/v1/sandbox/pause",
+		"/api/v1/sandbox/resume",
+	} {
+		req := httptest.NewRequest(http.MethodPost, path, nil)
+		if procdRequestMutatesRuntime(req) {
+			t.Fatalf("procdRequestMutatesRuntime(%s) = true, want false", path)
+		}
+	}
+}
+
+func TestProcdRequestMutatesRuntimeBlocksMutatingAPIRequests(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/files/write", nil)
+	if !procdRequestMutatesRuntime(req) {
+		t.Fatal("procdRequestMutatesRuntime(write) = false, want true")
+	}
+}

--- a/manager/procd/pkg/http/server.go
+++ b/manager/procd/pkg/http/server.go
@@ -40,6 +40,7 @@ type Server struct {
 
 	// Internal auth validator
 	authValidator *internalauth.Validator
+	barrier       *lifecycleBarrier
 
 	// Webhook dispatcher
 	webhookDispatcher *webhook.Dispatcher
@@ -64,6 +65,7 @@ func NewServer(
 		contextManager:    contextManager,
 		fileManager:       fileManager,
 		authValidator:     authValidator,
+		barrier:           newLifecycleBarrier(),
 		webhookDispatcher: webhookDispatcher,
 		logger:            logger,
 		obsProvider:       obsProvider,
@@ -98,9 +100,11 @@ func (s *Server) setupRoutes() {
 	// Apply auth middleware to all API routes
 	api.Use(s.authMiddleware)
 	api.Use(s.internalTokenMiddleware)
+	api.Use(s.barrier.middleware)
 
 	// Sandbox-level handlers (pause/resume all processes)
 	sandboxHandler := handlers.NewSandboxHandler(s.contextManager, s.webhookDispatcher, s.logger)
+	api.HandleFunc("/lifecycle/barrier", s.lifecycleBarrierHandler).Methods("PUT")
 	api.HandleFunc("/sandbox/pause", sandboxHandler.Pause).Methods("POST")
 	api.HandleFunc("/sandbox/resume", sandboxHandler.Resume).Methods("POST")
 	api.HandleFunc("/sandbox/stats", sandboxHandler.Stats).Methods("GET")

--- a/pkg/apispec/compat.go
+++ b/pkg/apispec/compat.go
@@ -3,8 +3,6 @@ package apispec
 const (
 	Failed      = SandboxLifecycleStatusFailed
 	Paused      = SandboxLifecycleStatusPaused
-	Pausing     = SandboxLifecycleStatusPausing
-	Resuming    = SandboxLifecycleStatusResuming
 	Running     = SandboxLifecycleStatusRunning
 	Starting    = SandboxLifecycleStatusStarting
 	Terminating = SandboxLifecycleStatusTerminating

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -1603,7 +1603,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/SuccessPauseSandboxResponse"
         "409":
-          description: Another sandbox lifecycle operation is in progress
+          description: Sandbox lifecycle state conflicts with this operation
           content:
             application/json:
               schema:
@@ -1644,7 +1644,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/SuccessResumeSandboxResponse"
         "409":
-          description: Another sandbox lifecycle operation is in progress
+          description: Sandbox lifecycle state conflicts with this operation
           content:
             application/json:
               schema:
@@ -4298,13 +4298,11 @@ components:
               $ref: "#/components/schemas/ClaimResponse"
     SandboxLifecycleStatus:
       type: string
-      enum: [starting, running, pausing, paused, resuming, terminating, failed]
+      enum: [starting, running, paused, terminating, failed]
       x-enum-varnames:
         - SandboxLifecycleStatusStarting
         - SandboxLifecycleStatusRunning
-        - SandboxLifecycleStatusPausing
         - SandboxLifecycleStatusPaused
-        - SandboxLifecycleStatusResuming
         - SandboxLifecycleStatusTerminating
         - SandboxLifecycleStatusFailed
     Sandbox:
@@ -4719,7 +4717,7 @@ components:
           description: True when checkpoint persistence has finished, runtime deletion has been accepted, and the sandbox is paused.
         status:
           $ref: "#/components/schemas/SandboxLifecycleStatus"
-          description: Current lifecycle status. Async pause requests usually return pausing.
+          description: Current committed lifecycle status.
         resource_usage:
           $ref: "#/components/schemas/SandboxResourceUsage"
         updated_memory:

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -182,8 +182,6 @@ const (
 const (
 	SandboxLifecycleStatusFailed      SandboxLifecycleStatus = "failed"
 	SandboxLifecycleStatusPaused      SandboxLifecycleStatus = "paused"
-	SandboxLifecycleStatusPausing     SandboxLifecycleStatus = "pausing"
-	SandboxLifecycleStatusResuming    SandboxLifecycleStatus = "resuming"
 	SandboxLifecycleStatusRunning     SandboxLifecycleStatus = "running"
 	SandboxLifecycleStatusStarting    SandboxLifecycleStatus = "starting"
 	SandboxLifecycleStatusTerminating SandboxLifecycleStatus = "terminating"

--- a/pkg/ctldapi/client.go
+++ b/pkg/ctldapi/client.go
@@ -29,6 +29,9 @@ const (
 	pathVolumeSnapshotAbort      = "/api/v1/volume-portals/snapshot-checkpoints/abort"
 	pathRootFSInspect            = "/api/v1/rootfs/inspect"
 	pathRootFSSave               = "/api/v1/rootfs/save"
+	pathRootFSSnapshotPrepare    = "/api/v1/rootfs/snapshots/prepare"
+	pathRootFSSnapshotPublish    = "/api/v1/rootfs/snapshots/publish"
+	pathRootFSSnapshotAbort      = "/api/v1/rootfs/snapshots/abort"
 	pathRootFSApply              = "/api/v1/rootfs/apply"
 )
 
@@ -127,6 +130,18 @@ func (c *Client) SaveRootFS(ctx context.Context, ctldAddress string, req SaveRoo
 	return PostJSON[SaveRootFSResponse](ctx, c.httpClientOrDefault(), ctldAddress, pathRootFSSave, req)
 }
 
+func (c *Client) PrepareRootFSSnapshot(ctx context.Context, ctldAddress string, req PrepareRootFSSnapshotRequest) (*PrepareRootFSSnapshotResponse, error) {
+	return PostJSON[PrepareRootFSSnapshotResponse](ctx, c.httpClientOrDefault(), ctldAddress, pathRootFSSnapshotPrepare, req)
+}
+
+func (c *Client) PublishRootFSSnapshot(ctx context.Context, ctldAddress string, req PublishRootFSSnapshotRequest) (*PublishRootFSSnapshotResponse, error) {
+	return PostJSON[PublishRootFSSnapshotResponse](ctx, c.httpClientOrDefault(), ctldAddress, pathRootFSSnapshotPublish, req)
+}
+
+func (c *Client) AbortRootFSSnapshot(ctx context.Context, ctldAddress string, req AbortRootFSSnapshotRequest) (*AbortRootFSSnapshotResponse, error) {
+	return PostJSON[AbortRootFSSnapshotResponse](ctx, c.httpClientOrDefault(), ctldAddress, pathRootFSSnapshotAbort, req)
+}
+
 func (c *Client) ApplyRootFS(ctx context.Context, ctldAddress string, req ApplyRootFSRequest) (*ApplyRootFSResponse, error) {
 	return PostJSON[ApplyRootFSResponse](ctx, c.httpClientOrDefault(), ctldAddress, pathRootFSApply, req)
 }
@@ -207,6 +222,12 @@ func responseError(resp any) string {
 	case *InspectRootFSResponse:
 		return strings.TrimSpace(typed.Error)
 	case *SaveRootFSResponse:
+		return strings.TrimSpace(typed.Error)
+	case *PrepareRootFSSnapshotResponse:
+		return strings.TrimSpace(typed.Error)
+	case *PublishRootFSSnapshotResponse:
+		return strings.TrimSpace(typed.Error)
+	case *AbortRootFSSnapshotResponse:
 		return strings.TrimSpace(typed.Error)
 	case *ApplyRootFSResponse:
 		return strings.TrimSpace(typed.Error)

--- a/pkg/ctldapi/types.go
+++ b/pkg/ctldapi/types.go
@@ -109,6 +109,44 @@ type SaveRootFSResponse struct {
 	Error      string               `json:"error,omitempty"`
 }
 
+type PrepareRootFSSnapshotRequest struct {
+	Target        RootFSContainerRef `json:"target"`
+	ParentLayerID string             `json:"parent_layer_id,omitempty"`
+	ExcludedPaths []string           `json:"excluded_paths,omitempty"`
+	PortalPaths   []RootFSPortalPath `json:"portal_paths,omitempty"`
+}
+
+type PrepareRootFSSnapshotResponse struct {
+	Handle     string               `json:"handle,omitempty"`
+	Info       RootFSInfo           `json:"info,omitempty"`
+	Descriptor RootFSDiffDescriptor `json:"descriptor,omitempty"`
+	Error      string               `json:"error,omitempty"`
+}
+
+type PublishRootFSSnapshotRequest struct {
+	Handle                    string `json:"handle"`
+	SandboxID                 string `json:"sandbox_id"`
+	TeamID                    string `json:"team_id"`
+	ExpectedRuntimeGeneration int64  `json:"expected_runtime_generation,omitempty"`
+	ObjectKey                 string `json:"object_key,omitempty"`
+}
+
+type PublishRootFSSnapshotResponse struct {
+	Info       RootFSInfo           `json:"info,omitempty"`
+	Descriptor RootFSDiffDescriptor `json:"descriptor,omitempty"`
+	Published  bool                 `json:"published"`
+	Error      string               `json:"error,omitempty"`
+}
+
+type AbortRootFSSnapshotRequest struct {
+	Handle string `json:"handle"`
+}
+
+type AbortRootFSSnapshotResponse struct {
+	Aborted bool   `json:"aborted"`
+	Error   string `json:"error,omitempty"`
+}
+
 type ApplyRootFSRequest struct {
 	Target                      RootFSContainerRef      `json:"target"`
 	ExpectedRuntime             string                  `json:"expected_runtime,omitempty"`

--- a/pkg/gateway/middleware/upstream_timeout.go
+++ b/pkg/gateway/middleware/upstream_timeout.go
@@ -18,6 +18,7 @@ func UpstreamTimeoutWhitelist() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if RequestPathAllowedWithoutUpstreamTimeout(c.Request.URL.Path) {
 			c.Request = proxy.WithUpstreamTimeoutDisabledRequest(c.Request)
+			_ = proxy.DisableResponseWriteDeadline(c.Writer)
 		}
 		c.Next()
 	}

--- a/storage-proxy/pkg/objectstore/encrypted_store.go
+++ b/storage-proxy/pkg/objectstore/encrypted_store.go
@@ -1,0 +1,379 @@
+package objectstore
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"golang.org/x/crypto/chacha20poly1305"
+)
+
+const (
+	defaultEncryptedObjectChunkSize = 1 << 20
+	encryptedObjectMagic            = "s0.object.encrypted.v1\n"
+	encryptedObjectVersion          = 1
+	maxUint32                       = int64(^uint32(0))
+	maxInt64                        = int64(^uint64(0) >> 1)
+	maxInt                          = int64(^uint(0) >> 1)
+)
+
+// EncryptionConfig configures object-level envelope encryption for Store.
+type EncryptionConfig struct {
+	Enabled      bool
+	Algorithm    string
+	KeyEncryptor Encryptor
+	ChunkSize    int64
+}
+
+type encryptedStore struct {
+	store Store
+	cfg   EncryptionConfig
+}
+
+type encryptedObjectHeader struct {
+	Version     int    `json:"version"`
+	Algorithm   string `json:"algorithm"`
+	WrappedKey  []byte `json:"wrapped_key"`
+	NoncePrefix []byte `json:"nonce_prefix"`
+	ChunkSize   int64  `json:"chunk_size"`
+}
+
+// Encrypting wraps a Store with streaming object encryption when enabled.
+func Encrypting(store Store, cfg EncryptionConfig) Store {
+	if store == nil || !cfg.enabled() {
+		return store
+	}
+	return &encryptedStore{store: store, cfg: cfg}
+}
+
+func (c EncryptionConfig) enabled() bool {
+	return c.Enabled && c.KeyEncryptor != nil
+}
+
+func (c EncryptionConfig) normalizedAlgorithm() string {
+	if strings.TrimSpace(c.Algorithm) == "" {
+		return EncryptionAlgoAES256GCMRSA
+	}
+	return strings.TrimSpace(c.Algorithm)
+}
+
+func (c EncryptionConfig) chunkSize() int64 {
+	if c.ChunkSize <= 0 {
+		return defaultEncryptedObjectChunkSize
+	}
+	return c.ChunkSize
+}
+
+func (s *encryptedStore) String() string {
+	if s == nil || s.store == nil {
+		return "encrypted(<nil>)"
+	}
+	return "encrypted(" + s.store.String() + ")"
+}
+
+func (s *encryptedStore) Create() error {
+	return s.store.Create()
+}
+
+func (s *encryptedStore) Put(key string, in io.Reader) error {
+	if in == nil {
+		in = bytes.NewReader(nil)
+	}
+	tmp, err := os.CreateTemp("", "s0-object-encrypted-*")
+	if err != nil {
+		return fmt.Errorf("create encrypted object temp file: %w", err)
+	}
+	defer func() {
+		_ = tmp.Close()
+		_ = os.Remove(tmp.Name())
+	}()
+	if err := s.encryptTo(tmp, key, in); err != nil {
+		return err
+	}
+	if _, err := tmp.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("seek encrypted object temp file: %w", err)
+	}
+	return s.store.Put(key, tmp)
+}
+
+func (s *encryptedStore) Get(key string, off, limit int64) (io.ReadCloser, error) {
+	if limit == 0 {
+		return io.NopCloser(bytes.NewReader(nil)), nil
+	}
+	reader, err := s.store.Get(key, 0, -1)
+	if err != nil {
+		return nil, err
+	}
+	pr, pw := io.Pipe()
+	go func() {
+		defer reader.Close()
+		err := s.decryptTo(pw, key, reader, off, limit)
+		_ = pw.CloseWithError(err)
+	}()
+	return pr, nil
+}
+
+func (s *encryptedStore) Delete(key string) error {
+	return s.store.Delete(key)
+}
+
+func (s *encryptedStore) Head(key string) (Info, error) {
+	return s.store.Head(key)
+}
+
+func (s *encryptedStore) List(prefix, startAfter, token, delimiter string, limit int64) ([]Info, bool, string, error) {
+	return s.store.List(prefix, startAfter, token, delimiter, limit)
+}
+
+func (s *encryptedStore) encryptTo(out io.Writer, key string, in io.Reader) error {
+	dataKey := make([]byte, 32)
+	if _, err := io.ReadFull(rand.Reader, dataKey); err != nil {
+		return fmt.Errorf("generate object data key: %w", err)
+	}
+	wrappedKey, err := s.cfg.KeyEncryptor.Encrypt(dataKey)
+	if err != nil {
+		return fmt.Errorf("wrap object data key: %w", err)
+	}
+	aead, err := newObjectAEAD(s.cfg.normalizedAlgorithm(), dataKey)
+	if err != nil {
+		return err
+	}
+	noncePrefix := make([]byte, aead.NonceSize()-8)
+	if _, err := io.ReadFull(rand.Reader, noncePrefix); err != nil {
+		return fmt.Errorf("generate object nonce prefix: %w", err)
+	}
+	header := encryptedObjectHeader{
+		Version:     encryptedObjectVersion,
+		Algorithm:   s.cfg.normalizedAlgorithm(),
+		WrappedKey:  wrappedKey,
+		NoncePrefix: noncePrefix,
+		ChunkSize:   s.cfg.chunkSize(),
+	}
+	if header.ChunkSize > maxInt {
+		return fmt.Errorf("encrypted object chunk size is too large: %d", header.ChunkSize)
+	}
+	if err := writeEncryptedObjectHeader(out, header); err != nil {
+		return err
+	}
+	buf := make([]byte, int(header.ChunkSize))
+	for chunkIndex := uint64(0); ; chunkIndex++ {
+		n, readErr := io.ReadFull(in, buf)
+		if readErr == io.EOF {
+			return nil
+		}
+		if readErr == io.ErrUnexpectedEOF {
+			readErr = nil
+		}
+		if readErr != nil {
+			return readErr
+		}
+		nonce := encryptedObjectNonce(aead.NonceSize(), noncePrefix, chunkIndex)
+		ciphertext := aead.Seal(nil, nonce, buf[:n], encryptedObjectChunkAAD(key, chunkIndex, header.Algorithm))
+		if int64(len(ciphertext)) > maxUint32 {
+			return fmt.Errorf("encrypted object chunk is too large: %d", len(ciphertext))
+		}
+		var lenBuf [4]byte
+		binary.BigEndian.PutUint32(lenBuf[:], uint32(len(ciphertext)))
+		if _, err := out.Write(lenBuf[:]); err != nil {
+			return err
+		}
+		if _, err := out.Write(ciphertext); err != nil {
+			return err
+		}
+		if n < len(buf) {
+			return nil
+		}
+	}
+}
+
+func (s *encryptedStore) decryptTo(out io.Writer, key string, in io.Reader, off, limit int64) error {
+	if off < 0 {
+		return fmt.Errorf("negative object read offset: %d", off)
+	}
+	buffered := bufio.NewReader(in)
+	magic, err := buffered.Peek(len(encryptedObjectMagic))
+	if err != nil || string(magic) != encryptedObjectMagic {
+		return copyPlainRange(out, buffered, off, limit)
+	}
+	if _, err := buffered.Discard(len(encryptedObjectMagic)); err != nil {
+		return err
+	}
+	header, err := readEncryptedObjectHeader(buffered)
+	if err != nil {
+		return err
+	}
+	if header.Version != encryptedObjectVersion {
+		return fmt.Errorf("unsupported encrypted object version %d", header.Version)
+	}
+	if header.ChunkSize <= 0 {
+		return fmt.Errorf("encrypted object chunk size is required")
+	}
+	dataKey, err := s.cfg.KeyEncryptor.Decrypt(header.WrappedKey)
+	if err != nil {
+		return fmt.Errorf("unwrap object data key: %w", err)
+	}
+	aead, err := newObjectAEAD(header.Algorithm, dataKey)
+	if err != nil {
+		return err
+	}
+	if len(header.NoncePrefix) != aead.NonceSize()-8 {
+		return fmt.Errorf("invalid encrypted object nonce prefix size %d", len(header.NoncePrefix))
+	}
+	rangeEnd := int64(-1)
+	if limit >= 0 {
+		rangeEnd = off + limit
+		if rangeEnd < off {
+			rangeEnd = maxInt64
+		}
+	}
+	var plainOffset int64
+	for chunkIndex := uint64(0); ; chunkIndex++ {
+		var lenBuf [4]byte
+		if _, err := io.ReadFull(buffered, lenBuf[:]); err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return err
+		}
+		cipherLen := binary.BigEndian.Uint32(lenBuf[:])
+		if cipherLen == 0 || int64(cipherLen) > header.ChunkSize+int64(aead.Overhead()) {
+			return fmt.Errorf("invalid encrypted object chunk size %d", cipherLen)
+		}
+		ciphertext := make([]byte, cipherLen)
+		if _, err := io.ReadFull(buffered, ciphertext); err != nil {
+			return err
+		}
+		nonce := encryptedObjectNonce(aead.NonceSize(), header.NoncePrefix, chunkIndex)
+		plaintext, err := aead.Open(nil, nonce, ciphertext, encryptedObjectChunkAAD(key, chunkIndex, header.Algorithm))
+		if err != nil {
+			return fmt.Errorf("decrypt object chunk %d: %w", chunkIndex, err)
+		}
+		if err := writeRangeChunk(out, plaintext, plainOffset, off, rangeEnd); err != nil {
+			return err
+		}
+		plainOffset += int64(len(plaintext))
+		if rangeEnd >= 0 && plainOffset >= rangeEnd {
+			return nil
+		}
+	}
+}
+
+func writeEncryptedObjectHeader(out io.Writer, header encryptedObjectHeader) error {
+	headerBytes, err := json.Marshal(header)
+	if err != nil {
+		return fmt.Errorf("marshal encrypted object header: %w", err)
+	}
+	if int64(len(headerBytes)) > maxUint32 {
+		return fmt.Errorf("encrypted object header is too large: %d", len(headerBytes))
+	}
+	if _, err := out.Write([]byte(encryptedObjectMagic)); err != nil {
+		return err
+	}
+	var lenBuf [4]byte
+	binary.BigEndian.PutUint32(lenBuf[:], uint32(len(headerBytes)))
+	if _, err := out.Write(lenBuf[:]); err != nil {
+		return err
+	}
+	_, err = out.Write(headerBytes)
+	return err
+}
+
+func readEncryptedObjectHeader(in io.Reader) (encryptedObjectHeader, error) {
+	var lenBuf [4]byte
+	if _, err := io.ReadFull(in, lenBuf[:]); err != nil {
+		return encryptedObjectHeader{}, err
+	}
+	headerLen := binary.BigEndian.Uint32(lenBuf[:])
+	if headerLen == 0 || headerLen > 1<<20 {
+		return encryptedObjectHeader{}, fmt.Errorf("invalid encrypted object header size %d", headerLen)
+	}
+	headerBytes := make([]byte, headerLen)
+	if _, err := io.ReadFull(in, headerBytes); err != nil {
+		return encryptedObjectHeader{}, err
+	}
+	var header encryptedObjectHeader
+	if err := json.Unmarshal(headerBytes, &header); err != nil {
+		return encryptedObjectHeader{}, fmt.Errorf("unmarshal encrypted object header: %w", err)
+	}
+	return header, nil
+}
+
+func newObjectAEAD(algorithm string, key []byte) (cipher.AEAD, error) {
+	algorithm = strings.TrimSpace(algorithm)
+	if algorithm == "" {
+		algorithm = EncryptionAlgoAES256GCMRSA
+	}
+	switch algorithm {
+	case EncryptionAlgoAES256GCMRSA:
+		block, err := aes.NewCipher(key)
+		if err != nil {
+			return nil, err
+		}
+		return cipher.NewGCM(block)
+	case EncryptionAlgoCHACHA20RSA:
+		return chacha20poly1305.New(key)
+	default:
+		return nil, fmt.Errorf("unsupported object encryption algorithm: %s", algorithm)
+	}
+}
+
+func encryptedObjectNonce(nonceSize int, prefix []byte, chunkIndex uint64) []byte {
+	nonce := make([]byte, nonceSize)
+	copy(nonce, prefix)
+	binary.BigEndian.PutUint64(nonce[nonceSize-8:], chunkIndex)
+	return nonce
+}
+
+func encryptedObjectChunkAAD(key string, chunkIndex uint64, algorithm string) []byte {
+	return []byte(fmt.Sprintf("s0.object.encrypted.v1|%s|%d|%s", key, chunkIndex, algorithm))
+}
+
+func copyPlainRange(out io.Writer, in io.Reader, off, limit int64) error {
+	if limit == 0 {
+		return nil
+	}
+	if off > 0 {
+		if _, err := io.CopyN(io.Discard, in, off); err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return err
+		}
+	}
+	if limit < 0 {
+		_, err := io.Copy(out, in)
+		return err
+	}
+	if _, err := io.CopyN(out, in, limit); err != nil && err != io.EOF {
+		return err
+	}
+	return nil
+}
+
+func writeRangeChunk(out io.Writer, chunk []byte, chunkStart, rangeStart, rangeEnd int64) error {
+	chunkEnd := chunkStart + int64(len(chunk))
+	if chunkEnd <= rangeStart {
+		return nil
+	}
+	start := int64(0)
+	if rangeStart > chunkStart {
+		start = rangeStart - chunkStart
+	}
+	end := int64(len(chunk))
+	if rangeEnd >= 0 && chunkEnd > rangeEnd {
+		end = rangeEnd - chunkStart
+	}
+	if start >= end {
+		return nil
+	}
+	_, err := out.Write(chunk[int(start):int(end)])
+	return err
+}

--- a/storage-proxy/pkg/objectstore/encrypted_store_test.go
+++ b/storage-proxy/pkg/objectstore/encrypted_store_test.go
@@ -1,0 +1,110 @@
+package objectstore
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestEncryptedStoreRoundTripHidesPlaintext(t *testing.T) {
+	base := NewMemoryStore(t.Name())
+	store := Encrypting(base, EncryptionConfig{
+		Enabled:      true,
+		KeyEncryptor: reversibleTestEncryptor{},
+		ChunkSize:    8,
+	})
+	plaintext := []byte("rootfs secret marker across chunks")
+
+	if err := store.Put("rootfs/layer.tar", bytes.NewReader(plaintext)); err != nil {
+		t.Fatalf("Put() error = %v", err)
+	}
+	rawReader, err := base.Get("rootfs/layer.tar", 0, -1)
+	if err != nil {
+		t.Fatalf("raw Get() error = %v", err)
+	}
+	raw, err := io.ReadAll(rawReader)
+	_ = rawReader.Close()
+	if err != nil {
+		t.Fatalf("read raw object: %v", err)
+	}
+	if bytes.Contains(raw, plaintext) || bytes.Contains(raw, []byte("secret marker")) {
+		t.Fatalf("encrypted object contains plaintext: %q", raw)
+	}
+
+	reader, err := store.Get("rootfs/layer.tar", 0, -1)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	got, err := io.ReadAll(reader)
+	_ = reader.Close()
+	if err != nil {
+		t.Fatalf("read decrypted object: %v", err)
+	}
+	if !bytes.Equal(got, plaintext) {
+		t.Fatalf("decrypted object = %q, want %q", got, plaintext)
+	}
+}
+
+func TestEncryptedStorePlaintextRange(t *testing.T) {
+	base := NewMemoryStore(t.Name())
+	store := Encrypting(base, EncryptionConfig{
+		Enabled:      true,
+		KeyEncryptor: reversibleTestEncryptor{},
+		ChunkSize:    5,
+	})
+	if err := store.Put("rootfs/layer.tar", strings.NewReader("0123456789abcdef")); err != nil {
+		t.Fatalf("Put() error = %v", err)
+	}
+
+	reader, err := store.Get("rootfs/layer.tar", 4, 7)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	got, err := io.ReadAll(reader)
+	_ = reader.Close()
+	if err != nil {
+		t.Fatalf("read range: %v", err)
+	}
+	if string(got) != "456789a" {
+		t.Fatalf("range = %q, want 456789a", got)
+	}
+}
+
+func TestEncryptedStoreReadsExistingPlaintextObject(t *testing.T) {
+	base := NewMemoryStore(t.Name())
+	if err := base.Put("rootfs/plain.tar", strings.NewReader("plaintext")); err != nil {
+		t.Fatalf("raw Put() error = %v", err)
+	}
+	store := Encrypting(base, EncryptionConfig{
+		Enabled:      true,
+		KeyEncryptor: reversibleTestEncryptor{},
+	})
+
+	reader, err := store.Get("rootfs/plain.tar", 5, -1)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	got, err := io.ReadAll(reader)
+	_ = reader.Close()
+	if err != nil {
+		t.Fatalf("read plaintext object: %v", err)
+	}
+	if string(got) != "text" {
+		t.Fatalf("plaintext range = %q, want text", got)
+	}
+}
+
+type reversibleTestEncryptor struct{}
+
+func (reversibleTestEncryptor) Encrypt(in []byte) ([]byte, error) {
+	out := append([]byte(nil), in...)
+	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
+		out[i], out[j] = out[j], out[i]
+	}
+	return out, nil
+}
+
+func (reversibleTestEncryptor) Decrypt(in []byte) ([]byte, error) {
+	return reversibleTestEncryptor{}.Encrypt(in)
+}

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -386,7 +386,7 @@ func registerApiModeSuite(envProvider func() *framework.ScenarioEnv, opts apiMod
 					Expect(pausedResp).NotTo(BeNil())
 					Expect(pausedResp.Paused).To(BeFalse())
 					Expect(pausedResp.Status).NotTo(BeNil())
-					Expect(*pausedResp.Status).To(Equal(apispec.SandboxLifecycleStatusPausing))
+					Expect(*pausedResp.Status).To(Equal(apispec.SandboxLifecycleStatusRunning))
 					waitForSandboxLifecycleStatusEventually(env, session, sandboxID, apispec.SandboxLifecycleStatusPaused)
 
 					resumeResp, status, err := session.ResumeSandbox(env.TestCtx.Context, GinkgoT(), sandboxID)

--- a/tests/integration/internal/tests/manager/api_test.go
+++ b/tests/integration/internal/tests/manager/api_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -857,6 +858,7 @@ func newInitializeEventServer(t *testing.T, events *orderedEvents) *httptest.Ser
 type memorySandboxStoreForManagerIntegration struct {
 	mu                sync.Mutex
 	records           map[string]*service.SandboxRecord
+	lifecycleTxns     map[string]*service.SandboxLifecycleTxn
 	rootFSState       map[string]*service.SandboxRootFSState
 	rootFSFilesystems map[string]*service.RootFSFilesystem
 	rootFSSnapshots   map[string]*service.RootFSSnapshot
@@ -865,6 +867,7 @@ type memorySandboxStoreForManagerIntegration struct {
 func newMemorySandboxStoreForManagerIntegration(record *service.SandboxRecord, rootFSState *service.SandboxRootFSState) *memorySandboxStoreForManagerIntegration {
 	store := &memorySandboxStoreForManagerIntegration{
 		records:           map[string]*service.SandboxRecord{},
+		lifecycleTxns:     map[string]*service.SandboxLifecycleTxn{},
 		rootFSState:       map[string]*service.SandboxRootFSState{},
 		rootFSFilesystems: map[string]*service.RootFSFilesystem{},
 		rootFSSnapshots:   map[string]*service.RootFSSnapshot{},
@@ -927,23 +930,34 @@ func (s *memorySandboxStoreForManagerIntegration) ListHardExpiredSandboxes(_ con
 	return records, nil
 }
 
-func (s *memorySandboxStoreForManagerIntegration) ListPausingSandboxes(_ context.Context, limit int) ([]*service.SandboxRecord, error) {
+func (s *memorySandboxStoreForManagerIntegration) ListActiveLifecycleTxns(_ context.Context, kind string, limit int) ([]*service.SandboxLifecycleTxn, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if limit <= 0 {
-		limit = len(s.records)
+		limit = len(s.lifecycleTxns)
 	}
-	records := make([]*service.SandboxRecord, 0, len(s.records))
-	for _, record := range s.records {
-		if record == nil || record.Status != service.SandboxStatusPausing {
+	txns := make([]*service.SandboxLifecycleTxn, 0, len(s.lifecycleTxns))
+	for _, txn := range s.lifecycleTxns {
+		if txn == nil || txn.Kind != kind || !managerIntegrationLifecyclePhaseActive(txn.Phase) {
 			continue
 		}
-		records = append(records, cloneSandboxRecordForManagerIntegration(record))
-		if len(records) >= limit {
+		txns = append(txns, cloneSandboxLifecycleTxnForManagerIntegration(txn))
+		if len(txns) >= limit {
 			break
 		}
 	}
-	return records, nil
+	return txns, nil
+}
+
+func (s *memorySandboxStoreForManagerIntegration) GetActiveLifecycleTxn(_ context.Context, sandboxID string) (*service.SandboxLifecycleTxn, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, txn := range s.lifecycleTxns {
+		if txn != nil && txn.SandboxID == sandboxID && managerIntegrationLifecyclePhaseActive(txn.Phase) {
+			return cloneSandboxLifecycleTxnForManagerIntegration(txn), nil
+		}
+	}
+	return nil, nil
 }
 
 func (s *memorySandboxStoreForManagerIntegration) MarkSandboxDeleted(_ context.Context, sandboxID string, deletedAt time.Time) error {
@@ -955,6 +969,13 @@ func (s *memorySandboxStoreForManagerIntegration) MarkSandboxDeleted(_ context.C
 	}
 	record.Status = service.SandboxStatusDeleted
 	record.DeletedAt = deletedAt
+	for _, txn := range s.lifecycleTxns {
+		if txn != nil && txn.SandboxID == sandboxID && managerIntegrationLifecyclePhaseActive(txn.Phase) {
+			txn.Phase = service.SandboxLifecyclePhaseAborted
+			txn.Error = "sandbox deleted"
+			txn.AbortedAt = deletedAt
+		}
+	}
 	delete(s.rootFSState, sandboxID)
 	return nil
 }
@@ -1129,7 +1150,7 @@ type memorySandboxStoreTxForManagerIntegration struct {
 
 func (t memorySandboxStoreTxForManagerIntegration) SaveRuntime(_ context.Context, sandboxID, namespace, podName, status string, generation int64, expiresAt, hardExpiresAt time.Time) error {
 	record := t.store.records[sandboxID]
-	if record == nil {
+	if record == nil || !record.DeletedAt.IsZero() {
 		return service.ErrSandboxRecordNotFound
 	}
 	record.CurrentPodNamespace = namespace
@@ -1143,7 +1164,7 @@ func (t memorySandboxStoreTxForManagerIntegration) SaveRuntime(_ context.Context
 
 func (t memorySandboxStoreTxForManagerIntegration) MarkRuntimePaused(_ context.Context, sandboxID string, generation int64, _ time.Time) error {
 	record := t.store.records[sandboxID]
-	if record == nil {
+	if record == nil || !record.DeletedAt.IsZero() {
 		return service.ErrSandboxRecordNotFound
 	}
 	record.CurrentPodNamespace = ""
@@ -1164,6 +1185,90 @@ func (t memorySandboxStoreTxForManagerIntegration) SaveRootFSState(_ context.Con
 	return nil
 }
 
+func (t memorySandboxStoreTxForManagerIntegration) GetActiveLifecycleTxn(_ context.Context, sandboxID string) (*service.SandboxLifecycleTxn, error) {
+	for _, txn := range t.store.lifecycleTxns {
+		if txn != nil && txn.SandboxID == sandboxID && managerIntegrationLifecyclePhaseActive(txn.Phase) {
+			return cloneSandboxLifecycleTxnForManagerIntegration(txn), nil
+		}
+	}
+	return nil, nil
+}
+
+func (t memorySandboxStoreTxForManagerIntegration) BeginLifecycleTxn(_ context.Context, txn *service.SandboxLifecycleTxn) error {
+	if txn == nil || txn.ID == "" {
+		return nil
+	}
+	record := t.store.records[txn.SandboxID]
+	if record == nil {
+		return service.ErrSandboxRecordNotFound
+	}
+	record.LifecycleEpoch++
+	txn.Epoch = record.LifecycleEpoch
+	if txn.Phase == "" {
+		txn.Phase = service.SandboxLifecyclePhasePreparing
+	}
+	if txn.Source == "" {
+		txn.Source = service.SandboxLifecycleSourceManual
+	}
+	t.store.lifecycleTxns[txn.ID] = cloneSandboxLifecycleTxnForManagerIntegration(txn)
+	return nil
+}
+
+func (t memorySandboxStoreTxForManagerIntegration) SetLifecycleTxnRuntime(_ context.Context, txnID, namespace, podName string) error {
+	if txn := t.store.lifecycleTxns[txnID]; txn != nil && managerIntegrationLifecyclePhaseActive(txn.Phase) {
+		txn.ToPodNamespace = namespace
+		txn.ToPodName = podName
+	}
+	return nil
+}
+
+func (t memorySandboxStoreTxForManagerIntegration) UpdateLifecycleTxnPhase(_ context.Context, txnID, phase string) error {
+	if txn := t.store.lifecycleTxns[txnID]; txn != nil && managerIntegrationLifecyclePhaseActive(txn.Phase) {
+		if !txn.CancelRequestedAt.IsZero() {
+			return stderrors.New("active lifecycle txn not found")
+		}
+		txn.Phase = phase
+	}
+	return nil
+}
+
+func (t memorySandboxStoreTxForManagerIntegration) RequestLifecycleTxnCancel(_ context.Context, txnID, reason string) (bool, error) {
+	txn := t.store.lifecycleTxns[txnID]
+	if txn == nil ||
+		txn.Kind != service.SandboxLifecycleKindPause ||
+		txn.Source != service.SandboxLifecycleSourceAuto ||
+		!txn.Cancelable ||
+		!managerIntegrationLifecyclePhaseCancelable(txn.Phase) {
+		return false, nil
+	}
+	if txn.CancelRequestedAt.IsZero() {
+		txn.CancelRequestedAt = time.Now()
+	}
+	if txn.CancelReason == "" {
+		txn.CancelReason = reason
+	}
+	return true, nil
+}
+
+func (t memorySandboxStoreTxForManagerIntegration) CommitLifecycleTxn(_ context.Context, txnID, preparedHeadLayerID string) error {
+	if txn := t.store.lifecycleTxns[txnID]; txn != nil && managerIntegrationLifecyclePhaseActive(txn.Phase) {
+		if !txn.CancelRequestedAt.IsZero() {
+			return stderrors.New("active lifecycle txn not found")
+		}
+		txn.Phase = service.SandboxLifecyclePhaseCommitted
+		txn.PreparedHeadLayerID = preparedHeadLayerID
+	}
+	return nil
+}
+
+func (t memorySandboxStoreTxForManagerIntegration) AbortLifecycleTxn(_ context.Context, txnID, reason string) error {
+	if txn := t.store.lifecycleTxns[txnID]; txn != nil && managerIntegrationLifecyclePhaseActive(txn.Phase) {
+		txn.Phase = service.SandboxLifecyclePhaseAborted
+		txn.Error = reason
+	}
+	return nil
+}
+
 func cloneSandboxRecordForManagerIntegration(record *service.SandboxRecord) *service.SandboxRecord {
 	if record == nil {
 		return nil
@@ -1172,6 +1277,37 @@ func cloneSandboxRecordForManagerIntegration(record *service.SandboxRecord) *ser
 	clone.Mounts = append([]service.ClaimMount(nil), record.Mounts...)
 	clone.TemplateSpec = *record.TemplateSpec.DeepCopy()
 	return &clone
+}
+
+func cloneSandboxLifecycleTxnForManagerIntegration(txn *service.SandboxLifecycleTxn) *service.SandboxLifecycleTxn {
+	if txn == nil {
+		return nil
+	}
+	clone := *txn
+	return &clone
+}
+
+func managerIntegrationLifecyclePhaseActive(phase string) bool {
+	switch phase {
+	case service.SandboxLifecyclePhasePreparing,
+		service.SandboxLifecyclePhaseBarriered,
+		service.SandboxLifecyclePhasePublishing,
+		service.SandboxLifecyclePhaseCommitting:
+		return true
+	default:
+		return false
+	}
+}
+
+func managerIntegrationLifecyclePhaseCancelable(phase string) bool {
+	switch phase {
+	case service.SandboxLifecyclePhasePreparing,
+		service.SandboxLifecyclePhaseBarriered,
+		service.SandboxLifecyclePhasePublishing:
+		return true
+	default:
+		return false
+	}
 }
 
 func cloneRootFSStateForManagerIntegration(state *service.SandboxRootFSState) *service.SandboxRootFSState {

--- a/tests/integration/internal/tests/manager/api_test.go
+++ b/tests/integration/internal/tests/manager/api_test.go
@@ -1232,6 +1232,16 @@ func (t memorySandboxStoreTxForManagerIntegration) UpdateLifecycleTxnPhase(_ con
 	return nil
 }
 
+func (t memorySandboxStoreTxForManagerIntegration) SetLifecycleTxnPreparedHead(_ context.Context, txnID, preparedHeadLayerID string) error {
+	if txn := t.store.lifecycleTxns[txnID]; txn != nil && managerIntegrationLifecyclePhaseActive(txn.Phase) {
+		if !txn.CancelRequestedAt.IsZero() {
+			return stderrors.New("active lifecycle txn not found")
+		}
+		txn.PreparedHeadLayerID = preparedHeadLayerID
+	}
+	return nil
+}
+
 func (t memorySandboxStoreTxForManagerIntegration) RequestLifecycleTxnCancel(_ context.Context, txnID, reason string) (bool, error) {
 	txn := t.store.lifecycleTxns[txnID]
 	if txn == nil ||


### PR DESCRIPTION
## Summary
- Add durable sandbox lifecycle transactions for atomic pause/resume commit boundaries.
- Add procd lifecycle barriers and ctld prepare/publish rootfs snapshot APIs so requests do not observe half-completed transitions.
- Collapse concurrent resume calls and move slow pod claim/create work outside the DB row lock to avoid high-concurrency DB lock amplification.
- Update gateway auto-resume paths and timeout handling so SDK/service requests wait for committed runtime generation instead of returning lifecycle conflicts.
- Make TTL-triggered automatic pause cancelable before commit when runtime access arrives, while keeping explicit pause non-cancelable.
- Track uncommitted rootfs objects with deterministic keys, protect prepared lifecycle heads, clean abandoned objects, and encrypt rootfs checkpoint objects at rest.
- Fence paused records from stale runtime pod persistence so post-pause config updates cannot flip a sandbox back to running before resume.
- Document committed-state and cancelable-auto-pause semantics and update OpenAPI lifecycle conflict descriptions.

Fixes #598

## Validation
- `git diff --check`
- `go test ./manager/pkg/service ./manager/cmd/manager ./storage-proxy/pkg/objectstore ./ctld/cmd/ctld ./ctld/internal/ctld/rootfs ./ctld/internal/ctld/server`
- `go test ./manager/pkg/service ./manager/cmd/manager ./cluster-gateway/pkg/http ./pkg/gateway/middleware ./cluster-gateway/pkg/client ./manager/procd/pkg/http ./ctld/cmd/ctld ./ctld/internal/ctld/rootfs ./ctld/internal/ctld/server ./pkg/ctldapi ./storage-proxy/pkg/objectstore ./tests/integration/internal/tests/manager`
- `GOFLAGS=-buildvcs=false go list ./... | rg -v '/tests/e2e/scenarios' | xargs go test -buildvcs=false`
- GitHub PR checks on `524c48f2`: quick-check, e2e, netd canal/cilium/flannel/kindnet, release-package metadata/infra passed; publish images skipped for PR.
- Remote Aliyun kind validation on image digest `sha256:b6c45d7662c15c5a39d8cc814900647c6476062b28381486447f72ffc14c7fcb`:
  - real pause/resume with encrypted rootfs checkpoint, DB/S3 audit after maintenance, no plaintext marker in RustFS object, read-after-pause auto-resumed to generation 2
  - auto-pause cancellation kept the same pod and generation and aborted the pause txn
  - explicit/manual pause remained non-cancelable; runtime access waited instead of requesting cancellation
