### PR TITLE
Add sandbox function max concurrency

### DIFF
--- a/cluster-gateway/pkg/http/handlers_sandbox_function.go
+++ b/cluster-gateway/pkg/http/handlers_sandbox_function.go
@@ -260,11 +260,12 @@ func buildSandboxFunctionExecuteRequest(r *http.Request, service *mgr.SandboxApp
 		Code:     fn.Source.Code,
 	}
 	execReq := sandboxfunction.ExecuteRequest{
-		ServiceID: service.ID,
-		Runtime:   fn.Runtime,
-		Handler:   fn.Handler,
-		Source:    source,
-		EnvVars:   service.Runtime.EnvVars,
+		ServiceID:      service.ID,
+		Runtime:        fn.Runtime,
+		Handler:        fn.Handler,
+		MaxConcurrency: fn.MaxConcurrency,
+		Source:         source,
+		EnvVars:        service.Runtime.EnvVars,
 		Request: sandboxfunction.HTTPRequest{
 			Method:     r.Method,
 			Path:       r.URL.Path,

--- a/cluster-gateway/pkg/http/sandbox_service_policy_test.go
+++ b/cluster-gateway/pkg/http/sandbox_service_policy_test.go
@@ -298,8 +298,9 @@ func TestSandboxFunctionServiceExecutesThroughProcdPort(t *testing.T) {
 			Runtime: &mgr.SandboxAppServiceRuntime{
 				Type: mgr.SandboxAppServiceRuntimeFunction,
 				Function: &mgr.SandboxFunction{
-					Runtime: "python",
-					Handler: "handler",
+					Runtime:        "python",
+					Handler:        "handler",
+					MaxConcurrency: 2,
 					Source: mgr.SandboxFunctionSource{
 						Type: "inline",
 						Code: "def handler(request):\n    return {'status': 201}\n",
@@ -345,6 +346,9 @@ func TestSandboxFunctionServiceExecutesThroughProcdPort(t *testing.T) {
 	}
 	if execReq.ServiceID != "webhook" || execReq.RouteID != "root" {
 		t.Fatalf("execute service/route = %q/%q, want webhook/root", execReq.ServiceID, execReq.RouteID)
+	}
+	if execReq.MaxConcurrency != 2 {
+		t.Fatalf("execute max_concurrency = %d, want 2", execReq.MaxConcurrency)
 	}
 	if execReq.Request.Path != "/events/stripe" || execReq.Request.RawQuery != "source=test" {
 		t.Fatalf("execute path/query = %q/%q", execReq.Request.Path, execReq.Request.RawQuery)

--- a/docs/sandbox/functions/page.mdx
+++ b/docs/sandbox/functions/page.mdx
@@ -40,6 +40,7 @@ services:
           function:
               runtime: python
               handler: handler
+              max_concurrency: 1
               source:
                   type: inline
                   code: |
@@ -82,6 +83,7 @@ Or with the API:
                 "function": {
                     "runtime": "python",
                     "handler": "handler",
+                    "max_concurrency": 1,
                     "source": {
                         "type": "inline",
                         "code": "def handler(request):\n    return {\n        \"status\": 200,\n        \"headers\": {\"content-type\": \"application/json\"},\n        \"body\": {\n            \"service_id\": request[\"service_id\"],\n            \"route_id\": request[\"route_id\"],\n            \"method\": request[\"method\"],\n            \"path\": request[\"path\"],\n        },\n    }\n"
@@ -104,6 +106,8 @@ Or with the API:
     ]
 }
 ```
+
+Set `max_concurrency` when a function must serialize access to shared sandbox state, such as refreshing a repository volume or publishing snapshots. The limit is enforced inside procd for one function service in one sandbox runtime. Omit it or set it to `0` for unlimited execution. When the limit is reached, Sandbox0 rejects new HTTP and SSE invocations with `429 Too Many Requests`; WebSocket invocations are closed by the function runtime.
 
 ```bash
 curl -X PUT "$SANDBOX0_API_URL/api/v1/sandboxes/$SANDBOX_ID/services" \
@@ -221,6 +225,7 @@ config:
               function:
                   runtime: python
                   handler: handler
+                  max_concurrency: 1
                   source:
                       type: inline
                       code: |
@@ -252,6 +257,7 @@ sandbox, err := client.ClaimSandbox(ctx, "default",
                 Function: apispec.NewOptSandboxFunction(apispec.SandboxFunction{
                     Runtime: apispec.SandboxFunctionRuntimePython,
                     Handler: apispec.NewOptString("handler"),
+                    MaxConcurrency: apispec.NewOptInt32(1),
                     Source: apispec.SandboxFunctionSource{
                         Type: apispec.SandboxFunctionSourceTypeInline,
                         Code: functionSource,
@@ -289,6 +295,7 @@ if err != nil {
                 _function: {
                     runtime: 'python',
                     handler: 'handler',
+                    maxConcurrency: 1,
                     source: {
                         type: 'inline',
                         code: 'def handler(request):\\n    return {"status": 200, "body": "ok"}\\n',
@@ -327,6 +334,7 @@ sandbox = client.sandboxes.claim(
                     "function": {
                         "runtime": "python",
                         "handler": "handler",
+                        "max_concurrency": 1,
                         "source": {
                             "type": "inline",
                             "code": "def handler(request):\\n    return {'status': 200, 'body': 'ok'}\\n",
@@ -372,6 +380,7 @@ Both gates are required for public URL requests to wake a paused sandbox. Sandbo
 - Public traffic must match a route on a public function service.
 - If `methods` is empty, all methods are allowed.
 - Route auth, CORS, rate limits, timeouts, path rewrite, and resume behavior are applied before the handler runs.
+- Function `max_concurrency` limits simultaneous handler executions for one function service inside one sandbox runtime. It does not coordinate across different sandboxes or different function services.
 
 ## Next Steps
 

--- a/docs/sandbox/services/page.mdx
+++ b/docs/sandbox/services/page.mdx
@@ -95,7 +95,7 @@ The same request reaches the backing service or function as `/github`.
 
 Use [Sandbox Functions](/docs/sandbox/functions) when you want a public HTTP handler without running a long-lived listener inside the sandbox. A function is still configured as a service with `runtime.type: function`, so it uses the same public URL, route policy, auth, CORS, rate limit, timeout, rewrite, and auto-resume model.
 
-Function services omit `port`, execute inline source through procd, and can return normal HTTP responses, SSE streams, or WebSocket messages.
+Function services omit `port`, execute inline source through procd, and can return normal HTTP responses, SSE streams, or WebSocket messages. Set `runtime.function.max_concurrency` when one function service must limit simultaneous handler executions inside a sandbox runtime.
 
 ## Cmd Services
 

--- a/manager/pkg/service/sandbox_app_service.go
+++ b/manager/pkg/service/sandbox_app_service.go
@@ -24,6 +24,7 @@ const (
 	maxSandboxServiceRoutes        = 32
 	maxSandboxServiceMethods       = 16
 	maxSandboxServiceAllowedValues = 32
+	maxSandboxFunctionConcurrency  = 1024
 )
 
 var sandboxServiceRouteIDPattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`)
@@ -85,9 +86,10 @@ type SandboxAppServiceRuntime struct {
 
 // SandboxFunction configures code that cluster-gateway sends to procd for execution.
 type SandboxFunction struct {
-	Runtime string                `json:"runtime"`
-	Handler string                `json:"handler,omitempty"`
-	Source  SandboxFunctionSource `json:"source"`
+	Runtime        string                `json:"runtime"`
+	Handler        string                `json:"handler,omitempty"`
+	MaxConcurrency int                   `json:"max_concurrency,omitempty"`
+	Source         SandboxFunctionSource `json:"source"`
 }
 
 // SandboxFunctionSource carries user function code in sandbox service config.
@@ -384,6 +386,12 @@ func normalizeSandboxFunction(function *SandboxFunction) (*SandboxFunction, erro
 	}
 	if !sandboxFunctionHandlerPattern.MatchString(out.Handler) {
 		return nil, fmt.Errorf("handler must match %s", sandboxFunctionHandlerPattern.String())
+	}
+	if out.MaxConcurrency < 0 {
+		return nil, fmt.Errorf("max_concurrency must be greater than or equal to 0")
+	}
+	if out.MaxConcurrency > maxSandboxFunctionConcurrency {
+		return nil, fmt.Errorf("max_concurrency must be less than or equal to %d", maxSandboxFunctionConcurrency)
 	}
 
 	source := out.Source

--- a/manager/pkg/service/sandbox_app_service_test.go
+++ b/manager/pkg/service/sandbox_app_service_test.go
@@ -195,6 +195,7 @@ func TestNormalizeSandboxAppServicesSupportsFunctionRuntime(t *testing.T) {
 		Runtime: &SandboxAppServiceRuntime{
 			Type: SandboxAppServiceRuntimeFunction,
 			Function: &SandboxFunction{
+				MaxConcurrency: 2,
 				Source: SandboxFunctionSource{
 					Code: "def handler(request):\n    return {'status': 204}\n",
 				},
@@ -216,6 +217,9 @@ func TestNormalizeSandboxAppServicesSupportsFunctionRuntime(t *testing.T) {
 	}
 	if service.Runtime.Function.Handler != "handler" {
 		t.Fatalf("function handler = %q, want handler", service.Runtime.Function.Handler)
+	}
+	if service.Runtime.Function.MaxConcurrency != 2 {
+		t.Fatalf("function max concurrency = %d, want 2", service.Runtime.Function.MaxConcurrency)
 	}
 	if service.Runtime.Function.Source.Type != "inline" {
 		t.Fatalf("function source type = %q, want inline", service.Runtime.Function.Source.Type)
@@ -251,6 +255,28 @@ func TestNormalizeSandboxAppServicesRejectsInvalidFunctionSource(t *testing.T) {
 	}})
 	if err == nil {
 		t.Fatal("NormalizeSandboxAppServices succeeded, want error")
+	}
+}
+
+func TestNormalizeSandboxAppServicesRejectsInvalidFunctionMaxConcurrency(t *testing.T) {
+	for _, maxConcurrency := range []int{-1, maxSandboxFunctionConcurrency + 1} {
+		_, err := NormalizeSandboxAppServices([]SandboxAppService{{
+			ID:   "webhook",
+			Port: 49983,
+			Runtime: &SandboxAppServiceRuntime{
+				Type: SandboxAppServiceRuntimeFunction,
+				Function: &SandboxFunction{
+					MaxConcurrency: maxConcurrency,
+					Source: SandboxFunctionSource{
+						Code: "def handler(request):\n    return None\n",
+					},
+				},
+			},
+			Ingress: SandboxAppServiceIngress{Public: true},
+		}})
+		if err == nil {
+			t.Fatalf("NormalizeSandboxAppServices max_concurrency=%d succeeded, want error", maxConcurrency)
+		}
 	}
 }
 

--- a/manager/procd/pkg/http/handlers/function.go
+++ b/manager/procd/pkg/http/handlers/function.go
@@ -36,6 +36,9 @@ const (
 	maxFunctionStdoutBytes    = 4 << 20
 	maxFunctionStderrBytes    = 64 << 10
 	maxFunctionStreamFrame    = 4 << 20
+
+	functionConcurrencyExceededCode    = "function_concurrency_exceeded"
+	functionConcurrencyExceededMessage = "function concurrency limit exceeded"
 )
 
 var (
@@ -59,6 +62,7 @@ type FunctionHandler struct {
 	maxTimeout         time.Duration
 	upgrader           websocket.Upgrader
 	sandboxEnvProvider func() map[string]string
+	concurrency        *functionConcurrencyLimiter
 }
 
 type functionHandlerRequest struct {
@@ -100,6 +104,7 @@ func newFunctionHandler(config functionHandlerConfig, logger *zap.Logger) *Funct
 		upgrader: websocket.Upgrader{
 			CheckOrigin: func(*http.Request) bool { return true },
 		},
+		concurrency: newFunctionConcurrencyLimiter(),
 	}
 }
 
@@ -136,6 +141,12 @@ func (h *FunctionHandler) Execute(w http.ResponseWriter, r *http.Request) {
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), timeout)
 	defer cancel()
+	release, ok := h.acquireFunctionSlot(req)
+	if !ok {
+		writeError(w, http.StatusTooManyRequests, functionConcurrencyExceededCode, functionConcurrencyExceededMessage)
+		return
+	}
+	defer release()
 	modulePath, err := h.materializeSource(req.Source)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
@@ -212,6 +223,12 @@ func (h *FunctionHandler) Stream(w http.ResponseWriter, r *http.Request) {
 		ctx, cancel = context.WithTimeout(ctx, time.Duration(req.TimeoutMS)*time.Millisecond)
 		defer cancel()
 	}
+	release, ok := h.acquireFunctionSlot(req)
+	if !ok {
+		writeError(w, http.StatusTooManyRequests, functionConcurrencyExceededCode, functionConcurrencyExceededMessage)
+		return
+	}
+	defer release()
 	modulePath, err := h.materializeSource(req.Source)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
@@ -280,6 +297,12 @@ func (h *FunctionHandler) WebSocket(w http.ResponseWriter, r *http.Request) {
 		_ = conn.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.ClosePolicyViolation, err.Error()), time.Now().Add(time.Second))
 		return
 	}
+	release, ok := h.acquireFunctionSlot(req)
+	if !ok {
+		_ = conn.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseTryAgainLater, functionConcurrencyExceededMessage), time.Now().Add(time.Second))
+		return
+	}
+	defer release()
 	modulePath, err := h.materializeSource(req.Source)
 	if err != nil {
 		_ = conn.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.ClosePolicyViolation, err.Error()), time.Now().Add(time.Second))
@@ -655,6 +678,9 @@ func validateFunctionExecuteRequest(req sandboxfunction.ExecuteRequest) error {
 	if req.TimeoutMS < 0 {
 		return errors.New("timeout_ms must be >= 0")
 	}
+	if req.MaxConcurrency < 0 {
+		return errors.New("max_concurrency must be >= 0")
+	}
 	return nil
 }
 
@@ -749,6 +775,57 @@ type functionRunTruncation struct {
 type functionWebSocketResult struct {
 	err           error
 	processExited bool
+}
+
+type functionConcurrencyLimiter struct {
+	mu       sync.Mutex
+	inFlight map[string]int
+}
+
+func newFunctionConcurrencyLimiter() *functionConcurrencyLimiter {
+	return &functionConcurrencyLimiter{inFlight: map[string]int{}}
+}
+
+func (h *FunctionHandler) acquireFunctionSlot(req sandboxfunction.ExecuteRequest) (func(), bool) {
+	if h.concurrency == nil {
+		return func() {}, true
+	}
+	return h.concurrency.acquire(functionConcurrencyKey(req), req.MaxConcurrency)
+}
+
+func (l *functionConcurrencyLimiter) acquire(key string, limit int) (func(), bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if limit > 0 && l.inFlight[key] >= limit {
+		return nil, false
+	}
+	l.inFlight[key]++
+	return sync.OnceFunc(func() {
+		l.release(key)
+	}), true
+}
+
+func (l *functionConcurrencyLimiter) release(key string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	current := l.inFlight[key]
+	if current <= 1 {
+		delete(l.inFlight, key)
+		return
+	}
+	l.inFlight[key] = current - 1
+}
+
+func functionConcurrencyKey(req sandboxfunction.ExecuteRequest) string {
+	serviceID := strings.TrimSpace(req.ServiceID)
+	if serviceID != "" {
+		return "service:" + serviceID
+	}
+	digest := req.Source.Digest
+	if digest == "" && req.Source.Code != "" {
+		digest = sandboxfunction.InlineDigest(req.Source.Code)
+	}
+	return "source:" + req.Runtime + ":" + req.Handler + ":" + digest
 }
 
 type trackingResponseWriter struct {

--- a/manager/procd/pkg/http/handlers/function_test.go
+++ b/manager/procd/pkg/http/handlers/function_test.go
@@ -12,6 +12,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gorilla/websocket"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
@@ -190,6 +191,107 @@ printf '{"status":200,"body_base64":"b2s="}\n'
 	}
 }
 
+func TestFunctionHandlerEnforcesFunctionMaxConcurrency(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell runner fixture requires POSIX")
+	}
+	dir := t.TempDir()
+	startedPath := filepath.Join(dir, "started")
+	releasePath := filepath.Join(dir, "release")
+	runnerPath := filepath.Join(dir, "runner.sh")
+	if err := os.WriteFile(runnerPath, []byte(`#!/bin/sh
+cat >/dev/null
+touch "$RUNNER_STARTED"
+while [ ! -f "$RUNNER_RELEASE" ]; do
+  sleep 0.05
+done
+printf '{"status":200,"body_base64":"b2s="}\n'
+`), 0o755); err != nil {
+		t.Fatalf("write runner: %v", err)
+	}
+
+	handler := newFunctionHandler(functionHandlerConfig{
+		runnerPath: runnerPath,
+		cacheRoot:  filepath.Join(dir, "cache"),
+	}, zap.NewNop())
+	functionReq := sandboxfunction.ExecuteRequest{
+		ServiceID:      "webhook",
+		Runtime:        sandboxfunction.RuntimePython,
+		Handler:        sandboxfunction.DefaultHandler,
+		MaxConcurrency: 1,
+		EnvVars: map[string]string{
+			"RUNNER_STARTED": startedPath,
+			"RUNNER_RELEASE": releasePath,
+		},
+		Source: sandboxfunction.Source{
+			Type: sandboxfunction.SourceTypeInline,
+			Code: "def handler(request):\n    return None\n",
+		},
+		Request: sandboxfunction.HTTPRequest{
+			Method: "POST",
+			Path:   "/events",
+		},
+	}
+	body, err := json.Marshal(functionReq)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	firstDone := make(chan int, 1)
+	go func() {
+		rec := httptest.NewRecorder()
+		handler.Execute(rec, httptest.NewRequest(http.MethodPost, "/api/v1/functions/execute", bytes.NewReader(body)))
+		firstDone <- rec.Code
+	}()
+	waitForFile(t, startedPath)
+
+	rec := httptest.NewRecorder()
+	handler.Execute(rec, httptest.NewRequest(http.MethodPost, "/api/v1/functions/execute", bytes.NewReader(body)))
+	assertFunctionConcurrencyExceeded(t, rec.Code, rec.Body.Bytes())
+
+	rec = httptest.NewRecorder()
+	handler.Stream(rec, httptest.NewRequest(http.MethodPost, "/api/v1/functions/stream", bytes.NewReader(body)))
+	assertFunctionConcurrencyExceeded(t, rec.Code, rec.Body.Bytes())
+
+	server := httptest.NewServer(http.HandlerFunc(handler.WebSocket))
+	defer server.Close()
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	if err := conn.WriteJSON(functionReq); err != nil {
+		t.Fatalf("write websocket init: %v", err)
+	}
+	_, _, err = conn.ReadMessage()
+	_ = conn.Close()
+	var closeErr *websocket.CloseError
+	if !errors.As(err, &closeErr) {
+		t.Fatalf("websocket read error = %v, want close error", err)
+	}
+	if closeErr.Code != websocket.CloseTryAgainLater || closeErr.Text != functionConcurrencyExceededMessage {
+		t.Fatalf("websocket close error = %#v, want concurrency exceeded", closeErr)
+	}
+
+	if err := os.WriteFile(releasePath, []byte("release"), 0o600); err != nil {
+		t.Fatalf("write release file: %v", err)
+	}
+	select {
+	case code := <-firstDone:
+		if code != http.StatusOK {
+			t.Fatalf("first status = %d, want 200", code)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for first function execution")
+	}
+
+	rec = httptest.NewRecorder()
+	handler.Execute(rec, httptest.NewRequest(http.MethodPost, "/api/v1/functions/execute", bytes.NewReader(body)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status after release = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+}
+
 func TestFunctionHandlerRejectsMismatchedDigest(t *testing.T) {
 	handler := newFunctionHandler(functionHandlerConfig{
 		runnerPath: "/bin/false",
@@ -227,6 +329,32 @@ func TestFunctionHandlerRejectsMismatchedDigest(t *testing.T) {
 	if envelope.Error == nil || envelope.Error.Code != spec.CodeBadRequest {
 		t.Fatalf("error = %#v, want bad_request", envelope.Error)
 	}
+}
+
+func assertFunctionConcurrencyExceeded(t *testing.T, status int, body []byte) {
+	t.Helper()
+	if status != http.StatusTooManyRequests {
+		t.Fatalf("status = %d body=%s, want 429", status, string(body))
+	}
+	var envelope spec.Response
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if envelope.Error == nil || envelope.Error.Code != functionConcurrencyExceededCode || envelope.Error.Message != functionConcurrencyExceededMessage {
+		t.Fatalf("error = %#v, want concurrency exceeded", envelope.Error)
+	}
+}
+
+func waitForFile(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for file %s", path)
 }
 
 func TestFunctionHandlerStreamRunsRunner(t *testing.T) {

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -4157,6 +4157,12 @@ components:
         handler:
           type: string
           description: Python callable name. Defaults to handler.
+        max_concurrency:
+          type: integer
+          format: int32
+          minimum: 0
+          maximum: 1024
+          description: Maximum in-flight executions for this function service inside one sandbox runtime. Omit or set to 0 for unlimited.
         source:
           $ref: "#/components/schemas/SandboxFunctionSource"
       required: [runtime, source]

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -1702,6 +1702,9 @@ type SandboxFunction struct {
 	// Handler Python callable name. Defaults to handler.
 	Handler *string `json:"handler,omitempty"`
 
+	// MaxConcurrency Maximum in-flight executions for this function service inside one sandbox runtime. Omit or set to 0 for unlimited.
+	MaxConcurrency *int32 `json:"max_concurrency,omitempty"`
+
 	// Runtime Function runtime. Only python is supported in this version.
 	Runtime SandboxFunctionRuntime `json:"runtime"`
 

--- a/pkg/sandboxfunction/types.go
+++ b/pkg/sandboxfunction/types.go
@@ -58,14 +58,15 @@ type HTTPRequest struct {
 
 // ExecuteRequest asks procd to execute function code inside the sandbox.
 type ExecuteRequest struct {
-	ServiceID string            `json:"service_id,omitempty"`
-	RouteID   string            `json:"route_id,omitempty"`
-	Runtime   string            `json:"runtime"`
-	Handler   string            `json:"handler"`
-	Source    Source            `json:"source"`
-	EnvVars   map[string]string `json:"env_vars,omitempty"`
-	Request   HTTPRequest       `json:"request"`
-	TimeoutMS int               `json:"timeout_ms,omitempty"`
+	ServiceID      string            `json:"service_id,omitempty"`
+	RouteID        string            `json:"route_id,omitempty"`
+	Runtime        string            `json:"runtime"`
+	Handler        string            `json:"handler"`
+	MaxConcurrency int               `json:"max_concurrency,omitempty"`
+	Source         Source            `json:"source"`
+	EnvVars        map[string]string `json:"env_vars,omitempty"`
+	Request        HTTPRequest       `json:"request"`
+	TimeoutMS      int               `json:"timeout_ms,omitempty"`
 }
 
 // ExecuteResponse is the HTTP response returned by a function handler.


### PR DESCRIPTION
## Summary
- add `runtime.function.max_concurrency` to the sandbox service contract
- forward the limit from cluster-gateway to procd for function execution
- enforce per-function-service in-flight limits in procd across HTTP, SSE, and WebSocket handlers
- document the new field and update generated API spec types

## Testing
- `env GOWORK=off GOTOOLCHAIN=go1.25.0+auto go test ./manager/pkg/service ./cluster-gateway/pkg/http ./manager/procd/pkg/http/handlers ./pkg/sandboxfunction ./pkg/apispec`
- `make test procd`
- `make test cluster-gateway`
- `env GOWORK=off GOTOOLCHAIN=go1.25.0+auto go test -race ./manager/pkg/service`

## Remote validation
Pending. The shared remote test environment is in use; I will wait until `make remote-status` reports `Stopped` before starting remote validation.