### PR TITLE
Merge snapshot storage metering into volume byte-hours

### DIFF
--- a/docs/self-hosted/configuration/page.mdx
+++ b/docs/self-hosted/configuration/page.mdx
@@ -49,8 +49,8 @@ Sandbox compute uses a serverless-style contract:
 | `sandbox.runtime_mib_milliseconds` | `mib_milliseconds` | Active sandbox runtime multiplied by allocated memory |
 | `sandbox.egress_bytes` | `bytes` | Egress traffic observed by `netd` |
 | `sandbox.ingress_bytes` | `bytes` | Ingress traffic observed by `netd` |
-| `sandbox.volume_byte_hours` | `byte_hours` | Persisted volume storage over time |
-| `sandbox.snapshot_byte_hours` | `byte_hours` | Persisted snapshot storage over time |
+| `sandbox.volume_byte_hours` | `byte_hours` | Persisted volume and volume snapshot storage over time. Snapshot rows keep `subject_type=snapshot` |
+| `sandbox.rootfs_byte_hours` | `byte_hours` | Persisted sandbox rootfs COW object storage over time |
 
 Idle template pool pods are capacity, not billable sandbox runtime. Public template idle pools are platform cost, and team template idle pools should be controlled by plan or entitlement limits rather than usage metering.
 

--- a/docs/self-hosted/configuration/page.mdx
+++ b/docs/self-hosted/configuration/page.mdx
@@ -46,13 +46,13 @@ Sandbox compute uses a serverless-style contract:
 
 | Window type | Unit | Meaning |
 |---|---|---|
-| `sandbox.runtime_mib_milliseconds` | `mib_milliseconds` | Active sandbox runtime multiplied by allocated memory |
+| `sandbox.runtime_mib_milliseconds` | `mib_milliseconds` | Active sandbox runtime and team-owned warm pool runtime multiplied by allocated memory |
 | `sandbox.egress_bytes` | `bytes` | Egress traffic observed by `netd` |
 | `sandbox.ingress_bytes` | `bytes` | Ingress traffic observed by `netd` |
 | `sandbox.volume_byte_hours` | `byte_hours` | Persisted volume and volume snapshot storage over time. Snapshot rows keep `subject_type=snapshot` |
 | `sandbox.rootfs_byte_hours` | `byte_hours` | Persisted sandbox rootfs COW object storage over time |
 
-Idle template pool pods are capacity, not billable sandbox runtime. Public template idle pools are platform cost, and team template idle pools should be controlled by plan or entitlement limits rather than usage metering.
+Public template idle pools are platform cost. Team-owned template warm pools are attributed to the owning team with `subject_type=template`.
 
 ## Platform Observability
 

--- a/manager/pkg/controller/pool_manager.go
+++ b/manager/pkg/controller/pool_manager.go
@@ -28,6 +28,7 @@ const (
 	// Labels
 	LabelTemplateID        = "sandbox0.ai/template-id"
 	LabelTemplateLogicalID = "sandbox0.ai/template-logical-id"
+	LabelTemplateScope     = "sandbox0.ai/template-scope"
 	LabelPoolType          = "sandbox0.ai/pool-type"
 	LabelSandboxID         = "sandbox0.ai/sandbox-id"
 	LabelOwnerKind         = "sandbox0.ai/owner-kind"
@@ -60,8 +61,12 @@ const (
 	AnnotationRuntimeGeneration            = "sandbox0.ai/runtime-generation"
 	AnnotationWebhookStateVolumeID         = "sandbox0.ai/webhook-state-volume-id"
 	AnnotationTemplateSpecHash             = "sandbox0.ai/template-spec-hash"
+	AnnotationTemplateTeamID               = "sandbox0.ai/template-team-id"
+	AnnotationTemplateUserID               = "sandbox0.ai/template-user-id"
 	AnnotationClusterAutoscalerSafeToEvict = "cluster-autoscaler.kubernetes.io/safe-to-evict"
 	AnnotationOwnerKind                    = "sandbox0.ai/owner-kind"
+
+	OwnerKindTeamWarmPool = "team_warm_pool"
 
 	unhealthyIdlePodRepairGracePeriod = 2 * time.Minute
 )
@@ -314,17 +319,58 @@ func (pm *PoolManager) buildPodTemplate(template *v1alpha1.SandboxTemplate, spec
 		AnnotationTemplateSpecHash:             specHash,
 		AnnotationClusterAutoscalerSafeToEvict: "true",
 	}
+	labels := map[string]string{
+		LabelTemplateID:        template.Name,
+		LabelTemplateLogicalID: TemplateLogicalID(template),
+		LabelPoolType:          PoolTypeIdle,
+	}
+	if teamID := teamOwnedTemplateTeamID(template); teamID != "" {
+		annotations[AnnotationTeamID] = teamID
+		annotations[AnnotationOwnerKind] = OwnerKindTeamWarmPool
+		labels[LabelOwnerKind] = OwnerKindTeamWarmPool
+		if userID := teamOwnedTemplateUserID(template); userID != "" {
+			annotations[AnnotationUserID] = userID
+		}
+	}
 	return corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels: map[string]string{
-				LabelTemplateID:        template.Name,
-				LabelTemplateLogicalID: TemplateLogicalID(template),
-				LabelPoolType:          PoolTypeIdle,
-			},
+			Labels:      labels,
 			Annotations: annotations,
 		},
 		Spec: spec,
 	}, nil
+}
+
+type warmPoolTemplateMetadata struct {
+	TeamID    string `json:"team_id"`
+	UserID    string `json:"user_id,omitempty"`
+	OwnerKind string `json:"owner_kind"`
+}
+
+func teamWarmPoolTemplateMetadata(template *v1alpha1.SandboxTemplate) *warmPoolTemplateMetadata {
+	teamID := teamOwnedTemplateTeamID(template)
+	if teamID == "" {
+		return nil
+	}
+	return &warmPoolTemplateMetadata{
+		TeamID:    teamID,
+		UserID:    teamOwnedTemplateUserID(template),
+		OwnerKind: OwnerKindTeamWarmPool,
+	}
+}
+
+func teamOwnedTemplateTeamID(template *v1alpha1.SandboxTemplate) string {
+	if template == nil || template.Labels[LabelTemplateScope] != naming.ScopeTeam {
+		return ""
+	}
+	return template.Annotations[AnnotationTemplateTeamID]
+}
+
+func teamOwnedTemplateUserID(template *v1alpha1.SandboxTemplate) string {
+	if template == nil || template.Labels[LabelTemplateScope] != naming.ScopeTeam {
+		return ""
+	}
+	return template.Annotations[AnnotationTemplateUserID]
 }
 
 func (pm *PoolManager) reconcileReplicaSetTemplate(
@@ -534,9 +580,11 @@ func (pm *PoolManager) deleteStaleIdlePodWithRetry(ctx context.Context, namespac
 func TemplateSpecHash(template *v1alpha1.SandboxTemplate) (string, error) {
 	podSpec := v1alpha1.BuildIdlePodSpec(template)
 	payload := struct {
-		PodSpec corev1.PodSpec `json:"podSpec"`
+		PodSpec  corev1.PodSpec            `json:"podSpec"`
+		WarmPool *warmPoolTemplateMetadata `json:"warmPool,omitempty"`
 	}{
-		PodSpec: podSpec,
+		PodSpec:  podSpec,
+		WarmPool: teamWarmPoolTemplateMetadata(template),
 	}
 	b, err := json.Marshal(payload)
 	if err != nil {

--- a/manager/pkg/controller/pool_manager_test.go
+++ b/manager/pkg/controller/pool_manager_test.go
@@ -49,6 +49,30 @@ func TestBuildPodTemplateIncludesTemplateHash(t *testing.T) {
 	assert.Equal(t, "logical-a", got.Labels[LabelTemplateLogicalID])
 }
 
+func TestBuildPodTemplateAnnotatesTeamOwnedWarmPool(t *testing.T) {
+	pm := &PoolManager{}
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "team-template",
+			Namespace: "tpl-team",
+			Labels: map[string]string{
+				LabelTemplateScope: naming.ScopeTeam,
+			},
+			Annotations: map[string]string{
+				AnnotationTemplateTeamID: "team-1",
+				AnnotationTemplateUserID: "user-1",
+			},
+		},
+	}
+
+	got, err := pm.buildPodTemplate(template, "hash-v1")
+	require.NoError(t, err)
+	assert.Equal(t, "team-1", got.Annotations[AnnotationTeamID])
+	assert.Equal(t, "user-1", got.Annotations[AnnotationUserID])
+	assert.Equal(t, OwnerKindTeamWarmPool, got.Annotations[AnnotationOwnerKind])
+	assert.Equal(t, OwnerKindTeamWarmPool, got.Labels[LabelOwnerKind])
+}
+
 func TestBuildPodTemplatePreMountsUserVolumePortalsForIdlePool(t *testing.T) {
 	pm := &PoolManager{}
 	template := &v1alpha1.SandboxTemplate{

--- a/manager/pkg/metering/lifecycle_projector.go
+++ b/manager/pkg/metering/lifecycle_projector.go
@@ -144,6 +144,10 @@ func (p *LifecycleProjector) handleUpsert(obj any) {
 		return
 	}
 	if isTeamOwnedIdlePoolPod(pod) {
+		if pod.DeletionTimestamp != nil {
+			p.handleWarmPoolDelete(pod)
+			return
+		}
 		p.handleWarmPoolUpsert(pod)
 		return
 	}
@@ -355,6 +359,9 @@ func (p *LifecycleProjector) handleWarmPoolUpsert(pod *corev1.Pod) {
 		p.recordError("load_warm_pool_state", stateID, err)
 		return
 	}
+	if state != nil && state.TerminatedAt != nil {
+		return
+	}
 
 	teamID := pod.Annotations[controller.AnnotationTeamID]
 	userID := pod.Annotations[controller.AnnotationUserID]
@@ -413,6 +420,9 @@ func (p *LifecycleProjector) handleWarmPoolDelete(pod *corev1.Pod) {
 	state, err := p.store.GetSandboxProjectionState(ctx, stateID)
 	if err != nil {
 		p.recordError("load_warm_pool_state", stateID, err)
+		return
+	}
+	if state != nil && state.TerminatedAt != nil {
 		return
 	}
 

--- a/manager/pkg/metering/lifecycle_projector.go
+++ b/manager/pkg/metering/lifecycle_projector.go
@@ -124,14 +124,27 @@ func (p *LifecycleProjector) SetRuntimePauseLookup(lookup RuntimePauseLookup) {
 func (p *LifecycleProjector) ResourceEventHandler() cache.ResourceEventHandlerFuncs {
 	return cache.ResourceEventHandlerFuncs{
 		AddFunc:    p.handleUpsert,
-		UpdateFunc: func(_, newObj any) { p.handleUpsert(newObj) },
+		UpdateFunc: p.handleUpdate,
 		DeleteFunc: p.handleDelete,
 	}
+}
+
+func (p *LifecycleProjector) handleUpdate(oldObj, newObj any) {
+	oldPod := extractPod(oldObj)
+	newPod := extractPod(newObj)
+	if isTeamOwnedIdlePoolPod(oldPod) && !isTeamOwnedIdlePoolPod(newPod) {
+		p.handleWarmPoolDelete(oldPod)
+	}
+	p.handleUpsert(newObj)
 }
 
 func (p *LifecycleProjector) handleUpsert(obj any) {
 	pod := extractPod(obj)
 	if pod == nil {
+		return
+	}
+	if isTeamOwnedIdlePoolPod(pod) {
+		p.handleWarmPoolUpsert(pod)
 		return
 	}
 	if !isClaimedActiveSandbox(pod) {
@@ -223,7 +236,14 @@ func (p *LifecycleProjector) handleUpsert(obj any) {
 
 func (p *LifecycleProjector) handleDelete(obj any) {
 	pod := extractPod(obj)
-	if pod == nil || !isClaimedActiveSandbox(pod) {
+	if pod == nil {
+		return
+	}
+	if isTeamOwnedIdlePoolPod(pod) {
+		p.handleWarmPoolDelete(pod)
+		return
+	}
+	if !isClaimedActiveSandbox(pod) {
 		return
 	}
 	sandboxID := meteringSandboxIDFromPod(pod)
@@ -321,6 +341,124 @@ func (p *LifecycleProjector) runtimeDeletionIsPause(ctx context.Context, info Ru
 		return false, nil
 	}
 	return p.runtimePauseLookup(ctx, info)
+}
+
+func (p *LifecycleProjector) handleWarmPoolUpsert(pod *corev1.Pod) {
+	stateID := warmPoolMeteringIDFromPod(pod)
+	if stateID == "" {
+		return
+	}
+
+	ctx := context.Background()
+	state, err := p.store.GetSandboxProjectionState(ctx, stateID)
+	if err != nil {
+		p.recordError("load_warm_pool_state", stateID, err)
+		return
+	}
+
+	teamID := pod.Annotations[controller.AnnotationTeamID]
+	userID := pod.Annotations[controller.AnnotationUserID]
+	templateID := pod.Labels[controller.LabelTemplateID]
+	podUsage := sandboxUsageFromPod(pod)
+	observedAt := p.now()
+	activeSince := warmPoolActiveSince(pod, observedAt)
+	pendingWindows := make([]*meteringpkg.Window, 0, 1)
+
+	if state == nil {
+		state = &meteringpkg.SandboxProjectionState{
+			SandboxID:         stateID,
+			Namespace:         pod.Namespace,
+			TeamID:            teamID,
+			UserID:            userID,
+			TemplateID:        templateID,
+			ClusterID:         p.clusterID,
+			OwnerKind:         controller.OwnerKindTeamWarmPool,
+			ResourceMillicpu:  podUsage.ResourceMillicpu,
+			ResourceMemoryMiB: podUsage.ResourceMemoryMiB,
+			ActiveSince:       &activeSince,
+			LastObservedAt:    observedAt,
+			LastResourceVer:   pod.ResourceVersion,
+		}
+	}
+
+	pendingWindows = append(pendingWindows, p.buildWarmPoolRuntimeWindow(state, teamID, userID, templateID, state.ActiveSince, observedAt, pod))
+	state.Namespace = pod.Namespace
+	state.TeamID = teamID
+	state.UserID = userID
+	state.TemplateID = templateID
+	state.ClusterID = p.clusterID
+	state.OwnerKind = controller.OwnerKindTeamWarmPool
+	state.ResourceMillicpu = podUsage.ResourceMillicpu
+	state.ResourceMemoryMiB = podUsage.ResourceMemoryMiB
+	state.ClaimedAt = nil
+	state.ActiveSince = ptrTime(observedAt)
+	state.Paused = false
+	state.PausedAt = nil
+	state.TerminatedAt = nil
+	state.LastObservedAt = observedAt
+	state.LastResourceVer = pod.ResourceVersion
+
+	if err := p.commitProjection(ctx, stateID, state, nil, pendingWindows, observedAt); err != nil {
+		return
+	}
+}
+
+func (p *LifecycleProjector) handleWarmPoolDelete(pod *corev1.Pod) {
+	stateID := warmPoolMeteringIDFromPod(pod)
+	if stateID == "" {
+		return
+	}
+
+	ctx := context.Background()
+	state, err := p.store.GetSandboxProjectionState(ctx, stateID)
+	if err != nil {
+		p.recordError("load_warm_pool_state", stateID, err)
+		return
+	}
+
+	observedAt := p.now()
+	teamID := pod.Annotations[controller.AnnotationTeamID]
+	userID := pod.Annotations[controller.AnnotationUserID]
+	templateID := pod.Labels[controller.LabelTemplateID]
+	podUsage := sandboxUsageFromPod(pod)
+	if state == nil {
+		activeSince := warmPoolActiveSince(pod, observedAt)
+		state = &meteringpkg.SandboxProjectionState{
+			SandboxID:         stateID,
+			Namespace:         pod.Namespace,
+			TeamID:            teamID,
+			UserID:            userID,
+			TemplateID:        templateID,
+			ClusterID:         p.clusterID,
+			OwnerKind:         controller.OwnerKindTeamWarmPool,
+			ResourceMillicpu:  podUsage.ResourceMillicpu,
+			ResourceMemoryMiB: podUsage.ResourceMemoryMiB,
+			ActiveSince:       &activeSince,
+			LastObservedAt:    observedAt,
+			LastResourceVer:   pod.ResourceVersion,
+		}
+	}
+
+	pendingWindows := []*meteringpkg.Window{
+		p.buildWarmPoolRuntimeWindow(state, teamID, userID, templateID, state.ActiveSince, observedAt, pod),
+	}
+	state.Namespace = pod.Namespace
+	state.TeamID = teamID
+	state.UserID = userID
+	state.TemplateID = templateID
+	state.ClusterID = p.clusterID
+	state.OwnerKind = controller.OwnerKindTeamWarmPool
+	state.ResourceMillicpu = podUsage.ResourceMillicpu
+	state.ResourceMemoryMiB = podUsage.ResourceMemoryMiB
+	state.ActiveSince = nil
+	state.Paused = false
+	state.TerminatedAt = &observedAt
+	state.LastObservedAt = observedAt
+	state.LastResourceVer = pod.ResourceVersion
+
+	if err := p.commitProjection(ctx, stateID, state, nil, pendingWindows, observedAt); err != nil {
+		return
+	}
 }
 
 func runtimeGenerationFromPod(pod *corev1.Pod) int64 {
@@ -469,6 +607,33 @@ func (p *LifecycleProjector) buildSandboxRuntimeWindow(state *meteringpkg.Sandbo
 	}
 }
 
+func (p *LifecycleProjector) buildWarmPoolRuntimeWindow(state *meteringpkg.SandboxProjectionState, teamID, userID, templateID string, start *time.Time, end time.Time, pod *corev1.Pod) *meteringpkg.Window {
+	if state == nil || start == nil || start.IsZero() || end.IsZero() || !end.After(*start) {
+		return nil
+	}
+	durationMS := end.Sub(*start).Milliseconds()
+	if durationMS <= 0 || state.ResourceMemoryMiB <= 0 || teamID == "" || templateID == "" {
+		return nil
+	}
+	return &meteringpkg.Window{
+		WindowID:    warmPoolWindowID(state.SandboxID, meteringpkg.WindowTypeSandboxRuntimeMiBMilliseconds, *start, end),
+		Producer:    sandboxLifecycleProducer,
+		RegionID:    p.regionID,
+		WindowType:  meteringpkg.WindowTypeSandboxRuntimeMiBMilliseconds,
+		SubjectType: meteringpkg.SubjectTypeTemplate,
+		SubjectID:   templateID,
+		TeamID:      teamID,
+		UserID:      userID,
+		TemplateID:  templateID,
+		ClusterID:   p.clusterID,
+		WindowStart: *start,
+		WindowEnd:   end,
+		Value:       state.ResourceMemoryMiB * durationMS,
+		Unit:        meteringpkg.WindowUnitMiBMilliseconds,
+		Data:        warmPoolRuntimeWindowData(state, durationMS, pod),
+	}
+}
+
 func isClaimedActiveSandbox(pod *corev1.Pod) bool {
 	if pod == nil {
 		return false
@@ -480,6 +645,40 @@ func isClaimedActiveSandbox(pod *corev1.Pod) bool {
 		return false
 	}
 	return pod.Annotations[controller.AnnotationClaimedAt] != ""
+}
+
+func isTeamOwnedIdlePoolPod(pod *corev1.Pod) bool {
+	if pod == nil || pod.Labels[controller.LabelPoolType] != controller.PoolTypeIdle {
+		return false
+	}
+	if pod.Labels[controller.LabelTemplateID] == "" {
+		return false
+	}
+	return pod.Annotations[controller.AnnotationTeamID] != ""
+}
+
+func warmPoolMeteringIDFromPod(pod *corev1.Pod) string {
+	if pod == nil {
+		return ""
+	}
+	if pod.UID != "" {
+		return fmt.Sprintf("warm-pool/%s", pod.UID)
+	}
+	if pod.Namespace == "" || pod.Name == "" {
+		return ""
+	}
+	return fmt.Sprintf("warm-pool/%s/%s", pod.Namespace, pod.Name)
+}
+
+func warmPoolActiveSince(pod *corev1.Pod, observedAt time.Time) time.Time {
+	if pod == nil || pod.CreationTimestamp.IsZero() {
+		return observedAt
+	}
+	createdAt := pod.CreationTimestamp.UTC()
+	if createdAt.IsZero() || createdAt.After(observedAt) {
+		return observedAt
+	}
+	return createdAt
 }
 
 func meteringSandboxIDFromPod(pod *corev1.Pod) string {
@@ -625,6 +824,22 @@ func runtimeWindowData(state *meteringpkg.SandboxProjectionState, durationMS int
 	})
 }
 
+func warmPoolRuntimeWindowData(state *meteringpkg.SandboxProjectionState, durationMS int64, pod *corev1.Pod) json.RawMessage {
+	data := map[string]any{
+		"product":               meteringpkg.ProductSandbox,
+		"owner_kind":            controller.OwnerKindTeamWarmPool,
+		"pool_type":             controller.PoolTypeIdle,
+		"resource_millicpu":     state.ResourceMillicpu,
+		"resource_memory_mib":   state.ResourceMemoryMiB,
+		"duration_milliseconds": durationMS,
+	}
+	if pod != nil {
+		data["pod_name"] = pod.Name
+		data["namespace"] = pod.Namespace
+	}
+	return mustJSON(data)
+}
+
 func claimedEventID(sandboxID string, claimedAt time.Time) string {
 	return fmt.Sprintf("sandbox/%s/claimed/%d", sandboxID, claimedAt.UTC().UnixNano())
 }
@@ -643,6 +858,10 @@ func terminateEventID(sandboxID, resourceVersion string) string {
 
 func sandboxWindowID(sandboxID, windowType string, start, end time.Time) string {
 	return fmt.Sprintf("sandbox/%s/windows/%s/%d/%d", sandboxID, windowType, start.UTC().UnixNano(), end.UTC().UnixNano())
+}
+
+func warmPoolWindowID(stateID, windowType string, start, end time.Time) string {
+	return fmt.Sprintf("%s/windows/%s/%d/%d", stateID, windowType, start.UTC().UnixNano(), end.UTC().UnixNano())
 }
 
 func ptrTime(value time.Time) *time.Time {

--- a/manager/pkg/metering/lifecycle_projector_test.go
+++ b/manager/pkg/metering/lifecycle_projector_test.go
@@ -475,6 +475,37 @@ func TestLifecycleProjectorClosesTeamWarmPoolWhenClaimed(t *testing.T) {
 	}
 }
 
+func TestLifecycleProjectorDoesNotReactivateDeletedTeamWarmPool(t *testing.T) {
+	recorder := &fakeRecorder{states: map[string]*meteringpkg.SandboxProjectionState{}}
+	projector := NewLifecycleProjector(recorder, "aws-us-east-1", "cluster-a")
+
+	createdAt := time.Date(2026, 3, 12, 10, 0, 0, 0, time.UTC)
+	firstObservedAt := createdAt.Add(time.Minute)
+	projector.now = func() time.Time { return firstObservedAt }
+
+	pod := withSandboxResources(buildTeamWarmPoolPod(createdAt, "1"), "2", "1Gi")
+	projector.handleUpsert(pod)
+
+	deletedAt := firstObservedAt.Add(time.Minute)
+	projector.now = func() time.Time { return deletedAt }
+	projector.handleDelete(pod)
+	windowCountAfterDelete := len(recorder.windows)
+
+	lateUpdateAt := deletedAt.Add(time.Minute)
+	projector.now = func() time.Time { return lateUpdateAt }
+	pod.ResourceVersion = "3"
+	pod.DeletionTimestamp = ptrMetaTime(deletedAt)
+	projector.handleUpsert(pod)
+
+	if len(recorder.windows) != windowCountAfterDelete {
+		t.Fatalf("late deleted warm pool update added windows: got %d, want %d", len(recorder.windows), windowCountAfterDelete)
+	}
+	state := recorder.states["warm-pool/pod-uid-1"]
+	if state == nil || state.ActiveSince != nil || state.TerminatedAt == nil || !state.TerminatedAt.Equal(deletedAt) {
+		t.Fatalf("warm pool state after late update = %#v, want closed at %v", state, deletedAt)
+	}
+}
+
 func buildSandboxPod(claimedAt time.Time, paused bool, pausedAt string, resourceVersion string) *corev1.Pod {
 	annotations := map[string]string{
 		controller.AnnotationClaimedAt: claimedAt.Format(time.RFC3339),
@@ -540,4 +571,9 @@ func withSandboxResources(pod *corev1.Pod, cpu, memory string) *corev1.Pod {
 		},
 	}}
 	return pod
+}
+
+func ptrMetaTime(value time.Time) *metav1.Time {
+	metaTime := metav1.NewTime(value)
+	return &metaTime
 }

--- a/manager/pkg/metering/lifecycle_projector_test.go
+++ b/manager/pkg/metering/lifecycle_projector_test.go
@@ -13,6 +13,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 type fakeRecorder struct {
@@ -370,7 +371,7 @@ func TestLifecycleProjectorRetriesCommitWithoutDuplicatingWindows(t *testing.T) 
 	}
 }
 
-func TestLifecycleProjectorIgnoresIdlePoolPods(t *testing.T) {
+func TestLifecycleProjectorIgnoresPublicIdlePoolPods(t *testing.T) {
 	recorder := &fakeRecorder{states: map[string]*meteringpkg.SandboxProjectionState{}}
 	projector := NewLifecycleProjector(recorder, "aws-us-east-1", "cluster-a")
 
@@ -382,6 +383,95 @@ func TestLifecycleProjectorIgnoresIdlePoolPods(t *testing.T) {
 
 	if len(recorder.events) != 0 || len(recorder.windows) != 0 {
 		t.Fatalf("idle pool pod should not be metered, events=%#v windows=%#v", recorder.events, recorder.windows)
+	}
+}
+
+func TestLifecycleProjectorMetersTeamOwnedWarmPoolMemory(t *testing.T) {
+	recorder := &fakeRecorder{states: map[string]*meteringpkg.SandboxProjectionState{}}
+	projector := NewLifecycleProjector(recorder, "aws-us-east-1", "cluster-a")
+
+	createdAt := time.Date(2026, 3, 12, 10, 0, 0, 0, time.UTC)
+	now := createdAt.Add(2 * time.Minute)
+	projector.now = func() time.Time { return now }
+
+	pod := withSandboxResources(buildTeamWarmPoolPod(createdAt, "1"), "2", "1Gi")
+	projector.handleUpsert(pod)
+
+	if len(recorder.events) != 0 {
+		t.Fatalf("warm pool should not emit lifecycle events, got %#v", recorder.events)
+	}
+	if len(recorder.windows) != 1 {
+		t.Fatalf("warm pool window count = %d, want 1", len(recorder.windows))
+	}
+	window := recorder.windows[0]
+	if window.WindowType != meteringpkg.WindowTypeSandboxRuntimeMiBMilliseconds {
+		t.Fatalf("window type = %q, want runtime memory", window.WindowType)
+	}
+	if window.SubjectType != meteringpkg.SubjectTypeTemplate || window.SubjectID != "tpl-1" {
+		t.Fatalf("subject = %s/%s, want template/tpl-1", window.SubjectType, window.SubjectID)
+	}
+	if window.TeamID != "team-1" || window.UserID != "user-1" || window.TemplateID != "tpl-1" {
+		t.Fatalf("unexpected ownership fields: team=%s user=%s template=%s", window.TeamID, window.UserID, window.TemplateID)
+	}
+	if window.SandboxID != "" {
+		t.Fatalf("warm pool window sandbox_id = %q, want empty", window.SandboxID)
+	}
+	if window.Value != 122_880_000 {
+		t.Fatalf("warm pool value = %d, want 122880000", window.Value)
+	}
+	state := recorder.states["warm-pool/pod-uid-1"]
+	if state == nil || state.ActiveSince == nil || !state.ActiveSince.Equal(now) {
+		t.Fatalf("warm pool state = %#v, want active_since advanced to %v", state, now)
+	}
+
+	projector.now = func() time.Time { return now.Add(time.Minute) }
+	pod.ResourceVersion = "2"
+	projector.handleUpsert(pod)
+	if len(recorder.windows) != 2 {
+		t.Fatalf("warm pool window count after resync = %d, want 2", len(recorder.windows))
+	}
+	if recorder.windows[1].Value != 61_440_000 {
+		t.Fatalf("resync warm pool value = %d, want 61440000", recorder.windows[1].Value)
+	}
+}
+
+func TestLifecycleProjectorClosesTeamWarmPoolWhenClaimed(t *testing.T) {
+	recorder := &fakeRecorder{states: map[string]*meteringpkg.SandboxProjectionState{}}
+	projector := NewLifecycleProjector(recorder, "aws-us-east-1", "cluster-a")
+
+	createdAt := time.Date(2026, 3, 12, 10, 0, 0, 0, time.UTC)
+	firstObservedAt := createdAt.Add(2 * time.Minute)
+	projector.now = func() time.Time { return firstObservedAt }
+
+	idlePod := withSandboxResources(buildTeamWarmPoolPod(createdAt, "1"), "2", "1Gi")
+	projector.handleUpsert(idlePod)
+
+	claimedAt := createdAt.Add(5 * time.Minute)
+	projector.now = func() time.Time { return claimedAt }
+	activePod := withSandboxResources(buildSandboxPod(claimedAt, false, "", "2"), "2", "1Gi")
+	activePod.Name = idlePod.Name
+	activePod.Namespace = idlePod.Namespace
+	activePod.UID = idlePod.UID
+
+	projector.handleUpdate(idlePod, activePod)
+
+	if len(recorder.windows) != 2 {
+		t.Fatalf("window count after claim = %d, want 2", len(recorder.windows))
+	}
+	finalWarmPoolWindow := recorder.windows[1]
+	if finalWarmPoolWindow.SubjectType != meteringpkg.SubjectTypeTemplate || finalWarmPoolWindow.SubjectID != "tpl-1" {
+		t.Fatalf("final warm pool subject = %s/%s, want template/tpl-1", finalWarmPoolWindow.SubjectType, finalWarmPoolWindow.SubjectID)
+	}
+	if finalWarmPoolWindow.Value != 184_320_000 {
+		t.Fatalf("final warm pool value = %d, want 184320000", finalWarmPoolWindow.Value)
+	}
+
+	warmPoolState := recorder.states["warm-pool/pod-uid-1"]
+	if warmPoolState == nil || warmPoolState.ActiveSince != nil || warmPoolState.TerminatedAt == nil || !warmPoolState.TerminatedAt.Equal(claimedAt) {
+		t.Fatalf("warm pool state after claim = %#v, want closed at %v", warmPoolState, claimedAt)
+	}
+	if recorder.states["sb-1"] == nil {
+		t.Fatalf("active sandbox projection state was not created")
 	}
 }
 
@@ -409,6 +499,28 @@ func buildSandboxPod(claimedAt time.Time, paused bool, pausedAt string, resource
 				controller.LabelTemplateID: "tpl-1",
 			},
 			Annotations: annotations,
+		},
+	}
+}
+
+func buildTeamWarmPoolPod(createdAt time.Time, resourceVersion string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "idle-1",
+			Namespace:         "tpl-team-1",
+			UID:               types.UID("pod-uid-1"),
+			ResourceVersion:   resourceVersion,
+			CreationTimestamp: metav1.NewTime(createdAt),
+			Labels: map[string]string{
+				controller.LabelPoolType:   controller.PoolTypeIdle,
+				controller.LabelTemplateID: "tpl-1",
+				controller.LabelOwnerKind:  controller.OwnerKindTeamWarmPool,
+			},
+			Annotations: map[string]string{
+				controller.AnnotationTeamID:    "team-1",
+				controller.AnnotationUserID:    "user-1",
+				controller.AnnotationOwnerKind: controller.OwnerKindTeamWarmPool,
+			},
 		},
 	}
 }

--- a/pkg/metering/migrations/00004_merge_snapshot_byte_hours.sql
+++ b/pkg/metering/migrations/00004_merge_snapshot_byte_hours.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+
+UPDATE usage_windows
+SET window_type = 'sandbox.volume_byte_hours'
+WHERE window_type = 'sandbox.snapshot_byte_hours';
+
+-- +goose Down
+
+UPDATE usage_windows
+SET window_type = 'sandbox.snapshot_byte_hours'
+WHERE window_type = 'sandbox.volume_byte_hours'
+  AND subject_type = 'snapshot';

--- a/pkg/metering/migrations/00005_add_storage_projection_remainder.sql
+++ b/pkg/metering/migrations/00005_add_storage_projection_remainder.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+
+ALTER TABLE storage_projection_state
+ADD COLUMN IF NOT EXISTS unbilled_byte_nanoseconds BIGINT NOT NULL DEFAULT 0;
+
+-- +goose Down
+
+ALTER TABLE storage_projection_state
+DROP COLUMN IF EXISTS unbilled_byte_nanoseconds;

--- a/pkg/metering/repository.go
+++ b/pkg/metering/repository.go
@@ -749,8 +749,6 @@ func storageWindowFromState(state *StorageProjectionState, end time.Time) *Windo
 	}
 	windowType := WindowTypeSandboxVolumeByteHours
 	switch state.SubjectType {
-	case SubjectTypeSnapshot:
-		windowType = WindowTypeSandboxSnapshotByteHours
 	case SubjectTypeRootFS:
 		windowType = WindowTypeSandboxRootFSByteHours
 	}

--- a/pkg/metering/repository.go
+++ b/pkg/metering/repository.go
@@ -257,11 +257,13 @@ func (r *Repository) recordStorageObservation(ctx context.Context, db DB, observ
 		if state.ObservedAt.Before(previous.ObservedAt) {
 			return nil
 		}
-		if window := storageWindowFromState(previous, state.ObservedAt); window != nil {
+		window, remainder := storageWindowFromStateWithRemainder(previous, state.ObservedAt)
+		if window != nil {
 			if err := r.appendWindow(ctx, db, window); err != nil {
 				return err
 			}
 		}
+		state.UnbilledByteNanoseconds = remainder
 	}
 
 	return r.upsertStorageProjectionState(ctx, db, state)
@@ -295,7 +297,7 @@ func (r *Repository) closeStorageObservation(ctx context.Context, db DB, observa
 		}
 		end := state.ObservedAt
 		state.ObservedAt = observation.ResourceCreatedAt.UTC()
-		if window := storageWindowFromState(state, end); window != nil {
+		if window, _ := storageWindowFromStateWithRemainder(state, end); window != nil {
 			return r.appendWindow(ctx, db, window)
 		}
 		return nil
@@ -303,7 +305,7 @@ func (r *Repository) closeStorageObservation(ctx context.Context, db DB, observa
 	if state.ObservedAt.Before(previous.ObservedAt) {
 		return r.deleteStorageProjectionState(ctx, db, previous.SubjectType, previous.SubjectID)
 	}
-	if window := storageWindowFromState(previous, state.ObservedAt); window != nil {
+	if window, _ := storageWindowFromStateWithRemainder(previous, state.ObservedAt); window != nil {
 		if err := r.appendWindow(ctx, db, window); err != nil {
 			return err
 		}
@@ -331,7 +333,7 @@ func (r *Repository) FlushStorageProjectionWindows(ctx context.Context, before t
 				subject_type, subject_id, product, owner_kind,
 				team_id, user_id, COALESCE(sandbox_id, ''), COALESCE(volume_id, ''),
 				COALESCE(snapshot_id, ''), COALESCE(cluster_id, ''), region_id,
-				size_bytes, observed_at
+				size_bytes, observed_at, unbilled_byte_nanoseconds
 			FROM metering.storage_projection_state
 			WHERE observed_at < $1
 			ORDER BY observed_at ASC
@@ -350,7 +352,7 @@ func (r *Repository) FlushStorageProjectionWindows(ctx context.Context, before t
 				&state.SubjectType, &state.SubjectID, &state.Product, &state.OwnerKind,
 				&state.TeamID, &state.UserID, &state.SandboxID, &state.VolumeID,
 				&state.SnapshotID, &state.ClusterID, &state.RegionID,
-				&state.SizeBytes, &state.ObservedAt,
+				&state.SizeBytes, &state.ObservedAt, &state.UnbilledByteNanoseconds,
 			); err != nil {
 				return fmt.Errorf("scan storage projection state: %w", err)
 			}
@@ -361,7 +363,8 @@ func (r *Repository) FlushStorageProjectionWindows(ctx context.Context, before t
 		}
 
 		for _, state := range states {
-			if window := storageWindowFromState(state, before); window != nil {
+			window, remainder := storageWindowFromStateWithRemainder(state, before)
+			if window != nil {
 				if err := r.appendWindow(ctx, tx, window); err != nil {
 					return err
 				}
@@ -369,9 +372,10 @@ func (r *Repository) FlushStorageProjectionWindows(ctx context.Context, before t
 			if _, err := tx.Exec(ctx, `
 				UPDATE metering.storage_projection_state
 				SET observed_at = $3,
+					unbilled_byte_nanoseconds = $4,
 					updated_at = NOW()
 				WHERE subject_type = $1 AND subject_id = $2
-			`, state.SubjectType, state.SubjectID, before); err != nil {
+			`, state.SubjectType, state.SubjectID, before, remainder); err != nil {
 				return fmt.Errorf("advance storage projection state: %w", err)
 			}
 		}
@@ -670,7 +674,7 @@ func (r *Repository) getStorageProjectionStateForUpdate(ctx context.Context, db 
 			subject_type, subject_id, product, owner_kind,
 			team_id, user_id, COALESCE(sandbox_id, ''), COALESCE(volume_id, ''),
 			COALESCE(snapshot_id, ''), COALESCE(cluster_id, ''), region_id,
-			size_bytes, observed_at
+			size_bytes, observed_at, unbilled_byte_nanoseconds
 		FROM metering.storage_projection_state
 		WHERE subject_type = $1 AND subject_id = $2
 		FOR UPDATE
@@ -678,7 +682,7 @@ func (r *Repository) getStorageProjectionStateForUpdate(ctx context.Context, db 
 		&state.SubjectType, &state.SubjectID, &state.Product, &state.OwnerKind,
 		&state.TeamID, &state.UserID, &state.SandboxID, &state.VolumeID,
 		&state.SnapshotID, &state.ClusterID, &state.RegionID,
-		&state.SizeBytes, &state.ObservedAt,
+		&state.SizeBytes, &state.ObservedAt, &state.UnbilledByteNanoseconds,
 	)
 	if err != nil {
 		if err == pgx.ErrNoRows {
@@ -694,11 +698,11 @@ func (r *Repository) upsertStorageProjectionState(ctx context.Context, db DB, st
 		INSERT INTO metering.storage_projection_state (
 			subject_type, subject_id, product, owner_kind,
 			team_id, user_id, sandbox_id, volume_id, snapshot_id,
-			cluster_id, region_id, size_bytes, observed_at
+			cluster_id, region_id, size_bytes, observed_at, unbilled_byte_nanoseconds
 		) VALUES (
 			$1, $2, $3, $4,
 			$5, $6, $7, $8, $9,
-			$10, $11, $12, $13
+			$10, $11, $12, $13, $14
 		)
 		ON CONFLICT (subject_type, subject_id) DO UPDATE
 		SET product = EXCLUDED.product,
@@ -712,10 +716,11 @@ func (r *Repository) upsertStorageProjectionState(ctx context.Context, db DB, st
 			region_id = EXCLUDED.region_id,
 			size_bytes = EXCLUDED.size_bytes,
 			observed_at = EXCLUDED.observed_at,
+			unbilled_byte_nanoseconds = EXCLUDED.unbilled_byte_nanoseconds,
 			updated_at = NOW()
 	`, state.SubjectType, state.SubjectID, state.Product, state.OwnerKind,
 		state.TeamID, state.UserID, nullableString(state.SandboxID), nullableString(state.VolumeID), nullableString(state.SnapshotID),
-		nullableString(state.ClusterID), state.RegionID, state.SizeBytes, state.ObservedAt,
+		nullableString(state.ClusterID), state.RegionID, state.SizeBytes, state.ObservedAt, state.UnbilledByteNanoseconds,
 	)
 	if err != nil {
 		return fmt.Errorf("upsert storage projection state: %w", err)
@@ -735,17 +740,23 @@ func (r *Repository) deleteStorageProjectionState(ctx context.Context, db DB, su
 }
 
 func storageWindowFromState(state *StorageProjectionState, end time.Time) *Window {
-	if state == nil || state.SizeBytes <= 0 {
-		return nil
+	window, _ := storageWindowFromStateWithRemainder(state, end)
+	return window
+}
+
+func storageWindowFromStateWithRemainder(state *StorageProjectionState, end time.Time) (*Window, int64) {
+	if state == nil {
+		return nil, 0
 	}
+	remainder := normalizeStorageRemainder(state.UnbilledByteNanoseconds)
 	end = end.UTC()
 	start := state.ObservedAt.UTC()
 	if !end.After(start) {
-		return nil
+		return nil, remainder
 	}
-	value := storageByteHours(state.SizeBytes, end.Sub(start))
+	value, remainder := storageByteHoursWithRemainder(state.SizeBytes, end.Sub(start), remainder)
 	if value <= 0 {
-		return nil
+		return nil, remainder
 	}
 	windowType := WindowTypeSandboxVolumeByteHours
 	switch state.SubjectType {
@@ -770,20 +781,40 @@ func storageWindowFromState(state *StorageProjectionState, end time.Time) *Windo
 		Value:       value,
 		Unit:        WindowUnitByteHours,
 		Data:        storageWindowData(state, end.Sub(start)),
-	}
+	}, remainder
 }
 
 func storageByteHours(sizeBytes int64, duration time.Duration) int64 {
+	value, _ := storageByteHoursWithRemainder(sizeBytes, duration, 0)
+	return value
+}
+
+func storageByteHoursWithRemainder(sizeBytes int64, duration time.Duration, previousRemainder int64) (int64, int64) {
+	remainder := normalizeStorageRemainder(previousRemainder)
 	if sizeBytes <= 0 || duration <= 0 {
+		return 0, remainder
+	}
+	accumulator := big.NewInt(remainder)
+	var usage big.Int
+	usage.Mul(big.NewInt(sizeBytes), big.NewInt(duration.Nanoseconds()))
+	accumulator.Add(accumulator, &usage)
+
+	hourNanos := big.NewInt(int64(time.Hour))
+	var quotient big.Int
+	var modulo big.Int
+	quotient.QuoRem(accumulator, hourNanos, &modulo)
+	if !quotient.IsInt64() {
+		return math.MaxInt64, 0
+	}
+	return quotient.Int64(), modulo.Int64()
+}
+
+func normalizeStorageRemainder(value int64) int64 {
+	if value <= 0 {
 		return 0
 	}
-	var product big.Int
-	product.Mul(big.NewInt(sizeBytes), big.NewInt(duration.Nanoseconds()))
-	product.Div(&product, big.NewInt(int64(time.Hour)))
-	if !product.IsInt64() {
-		return math.MaxInt64
-	}
-	return product.Int64()
+	hourNanos := int64(time.Hour)
+	return value % hourNanos
 }
 
 func storageWindowData(state *StorageProjectionState, duration time.Duration) json.RawMessage {

--- a/pkg/metering/repository.go
+++ b/pkg/metering/repository.go
@@ -784,11 +784,6 @@ func storageWindowFromStateWithRemainder(state *StorageProjectionState, end time
 	}, remainder
 }
 
-func storageByteHours(sizeBytes int64, duration time.Duration) int64 {
-	value, _ := storageByteHoursWithRemainder(sizeBytes, duration, 0)
-	return value
-}
-
 func storageByteHoursWithRemainder(sizeBytes int64, duration time.Duration, previousRemainder int64) (int64, int64) {
 	remainder := normalizeStorageRemainder(previousRemainder)
 	if sizeBytes <= 0 || duration <= 0 {

--- a/pkg/metering/repository_test.go
+++ b/pkg/metering/repository_test.go
@@ -345,7 +345,7 @@ func TestListWindowsAfterReturnsOrderedWindows(t *testing.T) {
 
 func TestStorageWindowFromStateSkipsSubByteHour(t *testing.T) {
 	start := time.Date(2026, 3, 12, 12, 0, 0, 0, time.UTC)
-	window := storageWindowFromState(&StorageProjectionState{
+	window, remainder := storageWindowFromStateWithRemainder(&StorageProjectionState{
 		SubjectType: SubjectTypeVolume,
 		SubjectID:   "vol-1",
 		Product:     ProductSandbox,
@@ -354,6 +354,30 @@ func TestStorageWindowFromStateSkipsSubByteHour(t *testing.T) {
 	}, start.Add(time.Millisecond))
 	if window != nil {
 		t.Fatalf("expected nil window for sub-byte-hour usage, got %+v", window)
+	}
+	if remainder != int64(time.Millisecond) {
+		t.Fatalf("remainder = %d, want %d", remainder, int64(time.Millisecond))
+	}
+}
+
+func TestStorageWindowFromStateCarriesSubByteHourRemainder(t *testing.T) {
+	start := time.Date(2026, 3, 12, 12, 0, 0, 0, time.UTC)
+	window, remainder := storageWindowFromStateWithRemainder(&StorageProjectionState{
+		SubjectType:             SubjectTypeVolume,
+		SubjectID:               "vol-1",
+		Product:                 ProductSandbox,
+		SizeBytes:               1,
+		ObservedAt:              start,
+		UnbilledByteNanoseconds: int64(30 * time.Minute),
+	}, start.Add(30*time.Minute))
+	if window == nil {
+		t.Fatal("expected carried remainder to produce a byte-hour window")
+	}
+	if window.Value != 1 {
+		t.Fatalf("window value = %d, want 1", window.Value)
+	}
+	if remainder != 0 {
+		t.Fatalf("remainder = %d, want 0", remainder)
 	}
 }
 
@@ -429,6 +453,7 @@ func TestRecordStorageObservationClosesPreviousWindow(t *testing.T) {
 					"aws-us-east-1",
 					int64(1024),
 					start,
+					int64(0),
 				}}
 			},
 			execFn: func(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
@@ -445,6 +470,9 @@ func TestRecordStorageObservationClosesPreviousWindow(t *testing.T) {
 					upsertedState = true
 					if args[11] != int64(2048) {
 						t.Fatalf("state size arg = %v, want 2048", args[11])
+					}
+					if args[13] != int64(0) {
+						t.Fatalf("state remainder arg = %v, want 0", args[13])
 					}
 				default:
 					t.Fatalf("unexpected exec: %s", sql)

--- a/pkg/metering/repository_test.go
+++ b/pkg/metering/repository_test.go
@@ -378,6 +378,32 @@ func TestStorageWindowFromStateUsesRootFSWindowType(t *testing.T) {
 	}
 }
 
+func TestStorageWindowFromStateUsesVolumeWindowTypeForSnapshot(t *testing.T) {
+	start := time.Date(2026, 3, 12, 12, 0, 0, 0, time.UTC)
+	window := storageWindowFromState(&StorageProjectionState{
+		SubjectType: SubjectTypeSnapshot,
+		SubjectID:   "snap-1",
+		Product:     ProductSandbox,
+		TeamID:      "team-1",
+		VolumeID:    "vol-1",
+		SnapshotID:  "snap-1",
+		SizeBytes:   1024,
+		ObservedAt:  start,
+	}, start.Add(time.Hour))
+	if window == nil {
+		t.Fatal("expected snapshot storage window")
+	}
+	if window.WindowType != WindowTypeSandboxVolumeByteHours {
+		t.Fatalf("window_type = %q, want %q", window.WindowType, WindowTypeSandboxVolumeByteHours)
+	}
+	if window.SubjectType != SubjectTypeSnapshot || window.SubjectID != "snap-1" {
+		t.Fatalf("unexpected subject: %s/%s", window.SubjectType, window.SubjectID)
+	}
+	if window.VolumeID != "vol-1" || window.SnapshotID != "snap-1" {
+		t.Fatalf("unexpected volume/snapshot ids: %s/%s", window.VolumeID, window.SnapshotID)
+	}
+}
+
 func TestRecordStorageObservationClosesPreviousWindow(t *testing.T) {
 	start := time.Date(2026, 3, 12, 12, 0, 0, 0, time.UTC)
 	end := start.Add(2 * time.Hour)

--- a/pkg/metering/types.go
+++ b/pkg/metering/types.go
@@ -127,19 +127,20 @@ type SandboxProjectionState struct {
 }
 
 type StorageProjectionState struct {
-	SubjectType string    `json:"subject_type"`
-	SubjectID   string    `json:"subject_id"`
-	Product     string    `json:"product,omitempty"`
-	OwnerKind   string    `json:"owner_kind,omitempty"`
-	TeamID      string    `json:"team_id,omitempty"`
-	UserID      string    `json:"user_id,omitempty"`
-	SandboxID   string    `json:"sandbox_id,omitempty"`
-	VolumeID    string    `json:"volume_id,omitempty"`
-	SnapshotID  string    `json:"snapshot_id,omitempty"`
-	ClusterID   string    `json:"cluster_id,omitempty"`
-	RegionID    string    `json:"region_id,omitempty"`
-	SizeBytes   int64     `json:"size_bytes"`
-	ObservedAt  time.Time `json:"observed_at"`
+	SubjectType             string    `json:"subject_type"`
+	SubjectID               string    `json:"subject_id"`
+	Product                 string    `json:"product,omitempty"`
+	OwnerKind               string    `json:"owner_kind,omitempty"`
+	TeamID                  string    `json:"team_id,omitempty"`
+	UserID                  string    `json:"user_id,omitempty"`
+	SandboxID               string    `json:"sandbox_id,omitempty"`
+	VolumeID                string    `json:"volume_id,omitempty"`
+	SnapshotID              string    `json:"snapshot_id,omitempty"`
+	ClusterID               string    `json:"cluster_id,omitempty"`
+	RegionID                string    `json:"region_id,omitempty"`
+	SizeBytes               int64     `json:"size_bytes"`
+	ObservedAt              time.Time `json:"observed_at"`
+	UnbilledByteNanoseconds int64     `json:"unbilled_byte_nanoseconds,omitempty"`
 }
 
 type StorageObservation struct {

--- a/pkg/metering/types.go
+++ b/pkg/metering/types.go
@@ -31,7 +31,6 @@ const (
 
 	WindowTypeSandboxRuntimeMiBMilliseconds = "sandbox.runtime_mib_milliseconds"
 	WindowTypeSandboxVolumeByteHours        = "sandbox.volume_byte_hours"
-	WindowTypeSandboxSnapshotByteHours      = "sandbox.snapshot_byte_hours"
 	WindowTypeSandboxRootFSByteHours        = "sandbox.rootfs_byte_hours"
 
 	WindowTypeManagedAgentSessionRunningMilliseconds = "managed_agent.session_running_milliseconds"

--- a/pkg/metering/types.go
+++ b/pkg/metering/types.go
@@ -45,6 +45,7 @@ const (
 	SubjectTypeVolume              = "volume"
 	SubjectTypeSnapshot            = "snapshot"
 	SubjectTypeRootFS              = "rootfs"
+	SubjectTypeTemplate            = "template"
 	SubjectTypeManagedAgentSession = "managed_agent_session"
 )
 


### PR DESCRIPTION
## Summary

- remove the standalone `sandbox.snapshot_byte_hours` window type constant
- emit volume snapshots as `sandbox.volume_byte_hours` while preserving `subject_type=snapshot` and snapshot identifiers
- add a metering migration that rewrites historical `sandbox.snapshot_byte_hours` windows to `sandbox.volume_byte_hours`
- meter team-owned warm pool idle pod time as `sandbox.runtime_mib_milliseconds` with `subject_type=template`
- annotate team-owned warm pool pods with team/user ownership and close warm-pool windows when an idle pod is claimed as active
- fix storage byte-hour projection so sub-byte-hour usage carries forward between flushes instead of being rounded away
- make team-owned warm-pool metering idempotent for delete and late deleting update events
- update the self-hosted metering table to document the merged volume/snapshot metric, rootfs byte-hours, and team-owned warm pool runtime

## Tests

- `GOFLAGS=-buildvcs=false go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0 run ./...`
- `go test ./pkg/metering ./pkg/migrate ./pkg/quota ./manager/pkg/metering ./manager/pkg/controller ./netd/pkg/metering ./storage-proxy/pkg/snapshot ./storage-proxy/pkg/http`
- `go test -count=1 ./pkg/metering ./manager/pkg/metering ./netd/pkg/metering`
- Remote Aliyun Singapore kind fullmode using `LOCAL_SANDBOX0_DIR=/root/sandbox0ai/sandbox0-metering-volume-byte-hours make -C /root/sandbox0ai remote-test-again`
- Remote readiness: `Sandbox0Infra` reached `Ready` 9/9 with default template idle pod ready
- Remote metering verification: generated runtime, team-owned warm pool, volume storage, volume snapshot storage, rootfs storage, egress, and ingress windows; DB summary included `sandbox.volume_byte_hours` for both `volume` and `snapshot`, `sandbox.rootfs_byte_hours`, `sandbox.runtime_mib_milliseconds` for both `sandbox` and `template`, `sandbox.egress_bytes`, and `sandbox.ingress_bytes`; `sandbox.snapshot_byte_hours` row count stayed `0`
