### PR TITLE
Run S0FS POSIX suite in PR e2e

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -38,6 +38,11 @@ jobs:
           E2E_CLUSTER_NAME: ${{ env.KIND_CLUSTER_NAME }}
         run: make test-e2e
 
+      - name: Run S0FS POSIX suite
+        env:
+          E2E_CLUSTER_NAME: ${{ env.KIND_CLUSTER_NAME }}
+        run: make test-e2e-s0fs-posix
+
       - name: Dump cluster state on failure
         if: failure()
         shell: bash

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build test test-all test-integration test-integration-verbose test-e2e test-e2e-kind test-e2e-destroy test-e2e-load-images test-e2e-prepare-kind test-e2e-specific test-e2e-netd-cni lint tidy vendor clean helm-update helm-configs release docker-build docker-build-local build-local-all docker-push proto manifests apispec oapi-codegen
+.PHONY: all build test test-all test-integration test-integration-verbose test-e2e test-e2e-kind test-e2e-destroy test-e2e-load-images test-e2e-prepare-kind test-e2e-specific test-e2e-s0fs-posix test-e2e-netd-cni lint tidy vendor clean helm-update helm-configs release docker-build docker-build-local build-local-all docker-push proto manifests apispec oapi-codegen
 
 # Tool Binaries
 LOCALBIN ?= $(shell pwd)/bin
@@ -19,6 +19,15 @@ E2E_SSH_FIXTURE_SOURCE_IMAGE := lscr.io/linuxserver/openssh-server@sha256:68b605
 E2E_SSH_FIXTURE_IMAGE := sandbox0ai/e2e-openssh-server:68b605929e83
 E2E_DEPENDENCY_IMAGES := postgres:16-alpine rustfs/rustfs:1.0.0-alpha.79 registry:2.8.3 sandbox0ai/otemplates:default-v0.2.0 $(E2E_SSH_FIXTURE_IMAGE)
 E2E_IMAGE_PLATFORM ?= linux/$(shell uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')
+E2E_CLUSTER_NAME ?= sandbox0-e2e
+S0FS_POSIX_CI_GIT_FILE_COUNT ?= 120
+S0FS_POSIX_CI_GIT_FILE_SIZE ?= 2048
+S0FS_POSIX_CI_BULK_FILE_COUNT ?= 1000
+S0FS_POSIX_CI_BULK_TOTAL_BYTES ?= 16777216
+S0FS_POSIX_CI_BULK_CONCURRENCY ?= 4
+S0FS_POSIX_CI_ARCHIVE_FILE_COUNT ?= 200
+S0FS_POSIX_CI_ARCHIVE_TOTAL_BYTES ?= 2097152
+S0FS_POSIX_CI_ARCHIVE_CONCURRENCY ?= 4
 
 # Default version
 VERSION ?= latest
@@ -204,6 +213,24 @@ test-e2e-specific:
 	fi
 	@printf "$(CYAN)Running E2E test: $(SPEC)...$(RESET)\n"
 	unset http_proxy && unset https_proxy && unset all_proxy && $(GO) test -v ./tests/e2e/... -focus="$(SPEC)" -timeout=30m
+
+test-e2e-s0fs-posix:
+	@printf "$(CYAN)Running S0FS POSIX E2E suite...$(RESET)\n"
+	unset http_proxy && unset https_proxy && unset all_proxy && python3 scripts/s0fs_posix_suite.py \
+		--kind-cluster "$(E2E_CLUSTER_NAME)" \
+		--kube-context "kind-$(E2E_CLUSTER_NAME)" \
+		--suite smoke \
+		--suite git-integrity \
+		--suite bulk-smallfile-integrity \
+		--suite archive-copy-rsync \
+		--git-file-count "$(S0FS_POSIX_CI_GIT_FILE_COUNT)" \
+		--git-file-size "$(S0FS_POSIX_CI_GIT_FILE_SIZE)" \
+		--bulk-file-count "$(S0FS_POSIX_CI_BULK_FILE_COUNT)" \
+		--bulk-total-bytes "$(S0FS_POSIX_CI_BULK_TOTAL_BYTES)" \
+		--bulk-concurrency "$(S0FS_POSIX_CI_BULK_CONCURRENCY)" \
+		--archive-file-count "$(S0FS_POSIX_CI_ARCHIVE_FILE_COUNT)" \
+		--archive-total-bytes "$(S0FS_POSIX_CI_ARCHIVE_TOTAL_BYTES)" \
+		--archive-concurrency "$(S0FS_POSIX_CI_ARCHIVE_CONCURRENCY)"
 
 test-e2e-netd-cni:
 	@printf "$(CYAN)Running netd CNI E2E tests...$(RESET)\n"


### PR DESCRIPTION
## Summary

Adds a CI-sized S0FS POSIX suite target and runs it from PR E2E after the existing Go E2E job has prepared the kind/fullmode environment.

The PR E2E profile intentionally avoids the high-cost or currently-known-failing suites. It covers the low-cost checks that passed reliably in the remote environment:

- `smoke`
- `git-integrity`
- `bulk-smallfile-integrity` with 1,000 files / 16 MiB / concurrency 4
- `archive-copy-rsync` with 200 files / 2 MiB / concurrency 4

The heavier/manual profiles remain available through `scripts/s0fs_posix_suite.py` and `tests/posix/README.md` for issue triage and nightly/manual runs.

## Remote validation

Ran the exact new Makefile entrypoint on the persistent remote kind fullmode environment:

```sh
make test-e2e-s0fs-posix E2E_CLUSTER_NAME=sandbox0-e2e
```

Result:

- `smoke`: passed
- `git-integrity`: passed
- `bulk-smallfile-integrity`: passed, overlay and S0FS both wrote and verified 1,000 files
- `archive-copy-rsync`: passed, overlay and S0FS digest parity matched

The remote ECS instance will be stopped after this PR is opened.

## Validation

- `make -n test-e2e-s0fs-posix`
- `python3 -m py_compile scripts/s0fs_posix_suite.py`
- YAML parse check for `.github/workflows/pr-e2e.yml`
- JSON parse check for `tests/posix/s0fs_suite_catalog.json`
- JSON parse check for `tests/posix/s0fs_known_failures.json`
- remote `make test-e2e-s0fs-posix E2E_CLUSTER_NAME=sandbox0-e2e`
