### PR TITLE
Fix S0FS portal stability under heavy POSIX workloads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build test test-all test-integration test-integration-verbose test-e2e test-e2e-kind test-e2e-destroy test-e2e-load-images test-e2e-prepare-kind test-e2e-specific test-e2e-s0fs-posix test-e2e-netd-cni lint tidy vendor clean helm-update helm-configs release docker-build docker-build-local build-local-all docker-push proto manifests apispec oapi-codegen
+.PHONY: all build test test-all test-integration test-integration-verbose test-e2e test-e2e-kind test-e2e-destroy test-e2e-load-images test-e2e-prepare-kind test-e2e-specific test-e2e-s0fs-posix test-e2e-s0fs-posix-prepare test-e2e-netd-cni lint tidy vendor clean helm-update helm-configs release docker-build docker-build-local build-local-all docker-push proto manifests apispec oapi-codegen
 
 # Tool Binaries
 LOCALBIN ?= $(shell pwd)/bin
@@ -20,14 +20,20 @@ E2E_SSH_FIXTURE_IMAGE := sandbox0ai/e2e-openssh-server:68b605929e83
 E2E_DEPENDENCY_IMAGES := postgres:16-alpine rustfs/rustfs:1.0.0-alpha.79 registry:2.8.3 sandbox0ai/otemplates:default-v0.2.0 $(E2E_SSH_FIXTURE_IMAGE)
 E2E_IMAGE_PLATFORM ?= linux/$(shell uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')
 E2E_CLUSTER_NAME ?= sandbox0-e2e
+S0FS_POSIX_PREPARE_INFRA ?= true
+S0FS_POSIX_CI_INSTALL_DEPS ?= true
 S0FS_POSIX_CI_GIT_FILE_COUNT ?= 120
 S0FS_POSIX_CI_GIT_FILE_SIZE ?= 2048
 S0FS_POSIX_CI_BULK_FILE_COUNT ?= 1000
 S0FS_POSIX_CI_BULK_TOTAL_BYTES ?= 16777216
 S0FS_POSIX_CI_BULK_CONCURRENCY ?= 4
+S0FS_POSIX_CI_BULK_FSYNC_EVERY ?= 25
 S0FS_POSIX_CI_ARCHIVE_FILE_COUNT ?= 200
 S0FS_POSIX_CI_ARCHIVE_TOTAL_BYTES ?= 2097152
 S0FS_POSIX_CI_ARCHIVE_CONCURRENCY ?= 4
+S0FS_POSIX_CI_FSX_OPERATIONS ?= 1000
+S0FS_POSIX_CI_FSSTRESS_OPERATIONS ?= 1000
+S0FS_POSIX_CI_FSSTRESS_PROCESSES ?= 4
 
 # Default version
 VERSION ?= latest
@@ -214,23 +220,42 @@ test-e2e-specific:
 	@printf "$(CYAN)Running E2E test: $(SPEC)...$(RESET)\n"
 	unset http_proxy && unset https_proxy && unset all_proxy && $(GO) test -v ./tests/e2e/... -focus="$(SPEC)" -timeout=30m
 
+test-e2e-s0fs-posix-prepare:
+	@printf "$(CYAN)Preparing fullmode infra for S0FS POSIX E2E suite...$(RESET)\n"
+	unset http_proxy && unset https_proxy && unset all_proxy && \
+		E2E_USE_EXISTING_CLUSTER=true \
+		E2E_CLUSTER_NAME="$(E2E_CLUSTER_NAME)" \
+		E2E_OPERATOR_IMAGE_TAG="$(TAG)" \
+		$(GO) run ./tests/e2e/cmd/prepare-s0fs-posix
+
 test-e2e-s0fs-posix:
+	@if [ "$(S0FS_POSIX_PREPARE_INFRA)" = "true" ]; then \
+		$(MAKE) test-e2e-s0fs-posix-prepare; \
+	fi
 	@printf "$(CYAN)Running S0FS POSIX E2E suite...$(RESET)\n"
 	unset http_proxy && unset https_proxy && unset all_proxy && python3 scripts/s0fs_posix_suite.py \
 		--kind-cluster "$(E2E_CLUSTER_NAME)" \
 		--kube-context "kind-$(E2E_CLUSTER_NAME)" \
+		$(if $(filter true,$(S0FS_POSIX_CI_INSTALL_DEPS)),--install-deps,) \
 		--suite smoke \
 		--suite git-integrity \
 		--suite bulk-smallfile-integrity \
 		--suite archive-copy-rsync \
+		--suite fsx \
+		--suite fsstress \
 		--git-file-count "$(S0FS_POSIX_CI_GIT_FILE_COUNT)" \
 		--git-file-size "$(S0FS_POSIX_CI_GIT_FILE_SIZE)" \
 		--bulk-file-count "$(S0FS_POSIX_CI_BULK_FILE_COUNT)" \
 		--bulk-total-bytes "$(S0FS_POSIX_CI_BULK_TOTAL_BYTES)" \
 		--bulk-concurrency "$(S0FS_POSIX_CI_BULK_CONCURRENCY)" \
+		--bulk-fsync-every "$(S0FS_POSIX_CI_BULK_FSYNC_EVERY)" \
+		--bulk-post-write-stat \
 		--archive-file-count "$(S0FS_POSIX_CI_ARCHIVE_FILE_COUNT)" \
 		--archive-total-bytes "$(S0FS_POSIX_CI_ARCHIVE_TOTAL_BYTES)" \
-		--archive-concurrency "$(S0FS_POSIX_CI_ARCHIVE_CONCURRENCY)"
+		--archive-concurrency "$(S0FS_POSIX_CI_ARCHIVE_CONCURRENCY)" \
+		--fsx-operations "$(S0FS_POSIX_CI_FSX_OPERATIONS)" \
+		--fsstress-operations "$(S0FS_POSIX_CI_FSSTRESS_OPERATIONS)" \
+		--fsstress-processes "$(S0FS_POSIX_CI_FSSTRESS_PROCESSES)"
 
 test-e2e-netd-cni:
 	@printf "$(CYAN)Running netd CNI E2E tests...$(RESET)\n"

--- a/ctld/internal/ctld/portal/manager.go
+++ b/ctld/internal/ctld/portal/manager.go
@@ -998,6 +998,9 @@ func (m *Manager) garbageCollectBoundS0FSObjects(ctx context.Context, bound *bou
 		return nil, err
 	}
 	retainedStates := []*s0fs.SnapshotState{manifest.State}
+	if current := bound.volCtx.S0FS.SnapshotState(); current != nil {
+		retainedStates = append(retainedStates, current)
+	}
 	cfg := s0fs.Config{
 		VolumeID:    bound.volumeID,
 		WALPath:     filepath.Join(bound.volCtx.CacheDir, "engine.wal"),

--- a/infra-operator/internal/controller/services/ctld/ctld.go
+++ b/infra-operator/internal/controller/services/ctld/ctld.go
@@ -31,6 +31,8 @@ const (
 	containerdDataMountPath        = "/host-var-lib/containerd"
 	defaultContainerdHostDataRoot  = "/var/lib/containerd"
 	defaultContainerdHostStateRoot = "/run/containerd"
+	ctldProbeTimeoutSeconds        = 10
+	ctldProbeFailureThreshold      = 6
 )
 
 func NewReconciler(resources *common.ResourceManager) *Reconciler {
@@ -230,6 +232,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 								},
 								InitialDelaySeconds: 5,
 								PeriodSeconds:       10,
+								TimeoutSeconds:      ctldProbeTimeoutSeconds,
+								FailureThreshold:    ctldProbeFailureThreshold,
 							},
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
@@ -237,6 +241,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 								},
 								InitialDelaySeconds: 2,
 								PeriodSeconds:       5,
+								TimeoutSeconds:      ctldProbeTimeoutSeconds,
+								FailureThreshold:    ctldProbeFailureThreshold,
 							},
 							SecurityContext: &corev1.SecurityContext{
 								Privileged: common.BoolPtr(true),

--- a/infra-operator/internal/controller/services/ctld/ctld_test.go
+++ b/infra-operator/internal/controller/services/ctld/ctld_test.go
@@ -111,6 +111,8 @@ func reconcileCtldDaemonSet(t *testing.T, infra *infrav1alpha1.Sandbox0Infra) *a
 	if ds.Spec.Template.Spec.Containers[0].ReadinessProbe == nil || ds.Spec.Template.Spec.Containers[0].LivenessProbe == nil {
 		t.Fatal("expected ctld probes to be configured")
 	}
+	assertCtldProbe(t, "liveness", ds.Spec.Template.Spec.Containers[0].LivenessProbe, "/healthz", 10)
+	assertCtldProbe(t, "readiness", ds.Spec.Template.Spec.Containers[0].ReadinessProbe, "/readyz", 5)
 	if ds.Spec.Template.Spec.ServiceAccountName != "demo-ctld" {
 		t.Fatalf("expected service account demo-ctld, got %q", ds.Spec.Template.Spec.ServiceAccountName)
 	}
@@ -135,6 +137,29 @@ func reconcileCtldDaemonSet(t *testing.T, infra *infrav1alpha1.Sandbox0Infra) *a
 	}
 
 	return ds
+}
+
+func assertCtldProbe(t *testing.T, name string, probe *corev1.Probe, path string, periodSeconds int32) {
+	t.Helper()
+
+	if probe.HTTPGet == nil {
+		t.Fatalf("expected ctld %s probe to use HTTP", name)
+	}
+	if probe.HTTPGet.Path != path {
+		t.Fatalf("expected ctld %s probe path %s, got %s", name, path, probe.HTTPGet.Path)
+	}
+	if probe.HTTPGet.Port.StrVal != "http" {
+		t.Fatalf("expected ctld %s probe to use http port, got %#v", name, probe.HTTPGet.Port)
+	}
+	if probe.PeriodSeconds != periodSeconds {
+		t.Fatalf("expected ctld %s probe period %d, got %d", name, periodSeconds, probe.PeriodSeconds)
+	}
+	if probe.TimeoutSeconds != ctldProbeTimeoutSeconds {
+		t.Fatalf("expected ctld %s probe timeout %d, got %d", name, ctldProbeTimeoutSeconds, probe.TimeoutSeconds)
+	}
+	if probe.FailureThreshold != ctldProbeFailureThreshold {
+		t.Fatalf("expected ctld %s probe failure threshold %d, got %d", name, ctldProbeFailureThreshold, probe.FailureThreshold)
+	}
 }
 
 func TestReconcileUsesDefaultContainerdHostDataRoot(t *testing.T) {

--- a/pkg/framework/config.go
+++ b/pkg/framework/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	SkipClusterDelete     bool
 	SkipOperatorInstall   bool
 	SkipOperatorUninstall bool
+	PreserveScenario      bool
 
 	OperatorChartPath       string
 	OperatorNamespace       string
@@ -47,6 +48,7 @@ func LoadConfig() (Config, error) {
 		SkipClusterDelete:     envBool("E2E_SKIP_CLUSTER_DELETE", false),
 		SkipOperatorInstall:   envBool("E2E_SKIP_OPERATOR_INSTALL", false),
 		SkipOperatorUninstall: envBool("E2E_SKIP_OPERATOR_UNINSTALL", false),
+		PreserveScenario:      envBool("E2E_PRESERVE_SCENARIO", false),
 
 		OperatorChartPath:       envString("E2E_OPERATOR_CHART", defaultOperatorChart),
 		OperatorNamespace:       envString("E2E_OPERATOR_NAMESPACE", "infra-operator"),

--- a/pkg/framework/setup.go
+++ b/pkg/framework/setup.go
@@ -67,7 +67,7 @@ func SetupScenario(cfg Config, scenario Scenario) (*ScenarioEnv, func(), error) 
 			return nil, nil, err
 		}
 
-		if !cfg.SkipClusterDelete {
+		if !cfg.SkipClusterDelete && !workingCfg.PreserveScenario {
 			appendCleanup(func() {
 				fmt.Printf("Deleting Kind cluster %q...\n", cfg.ClusterName)
 				_ = testCtx.Cluster.DeleteKind(testCtx.Context)
@@ -111,7 +111,7 @@ func SetupScenario(cfg Config, scenario Scenario) (*ScenarioEnv, func(), error) 
 			cleanup()
 			return nil, nil, err
 		}
-		if !workingCfg.SkipOperatorUninstall {
+		if !workingCfg.SkipOperatorUninstall && !workingCfg.PreserveScenario {
 			appendCleanup(func() {
 				if preserveInfraForNamespaceCleanup {
 					fmt.Printf("Skipping infra-operator uninstall because manager-owned namespaces are still terminating; preserving CSI drivers for the next cleanup pass.\n")
@@ -171,25 +171,29 @@ func SetupScenario(cfg Config, scenario Scenario) (*ScenarioEnv, func(), error) 
 			return nil, nil, err
 		}
 	}
-	appendCleanup(func() {
-		// Pods can mount sandbox0 CSI volumes. Delete sandbox namespaces before the
-		// infra manifest so storage-proxy is still available for kubelet unpublish.
-		if err := ScaleScenarioManagerToZero(testCtx.Context, workingCfg.Kubeconfig, env.Infra); err != nil {
-			fmt.Printf("Failed to scale scenario manager down before namespace cleanup: %v\n", err)
-		}
-		if err := CleanupManagerOwnedNamespaces(testCtx.Context, workingCfg.Kubeconfig, managerOwnedNamespaceCleanupTimeout); err != nil {
-			preserveInfraForNamespaceCleanup = true
-			fmt.Printf("Failed to clean up manager-owned namespaces: %v\n", err)
-			fmt.Printf("Preserving scenario infra so CSI drivers remain available for the next cleanup pass.\n")
-			return
-		}
-		if err := KubectlDeleteManifest(testCtx.Context, workingCfg.Kubeconfig, manifestPath); err != nil {
-			fmt.Printf("Failed to delete scenario manifest: %v\n", err)
-		}
-		if err := KubectlWaitForNamespaceDeleted(testCtx.Context, workingCfg.Kubeconfig, scenario.InfraNamespace, "3m"); err != nil {
-			fmt.Printf("Failed to clean up infra namespace %q: %v\n", scenario.InfraNamespace, err)
-		}
-	})
+	if workingCfg.PreserveScenario {
+		fmt.Printf("Preserving scenario %q for follow-up tests.\n", scenario.Name)
+	} else {
+		appendCleanup(func() {
+			// Pods can mount sandbox0 CSI volumes. Delete sandbox namespaces before the
+			// infra manifest so storage-proxy is still available for kubelet unpublish.
+			if err := ScaleScenarioManagerToZero(testCtx.Context, workingCfg.Kubeconfig, env.Infra); err != nil {
+				fmt.Printf("Failed to scale scenario manager down before namespace cleanup: %v\n", err)
+			}
+			if err := CleanupManagerOwnedNamespaces(testCtx.Context, workingCfg.Kubeconfig, managerOwnedNamespaceCleanupTimeout); err != nil {
+				preserveInfraForNamespaceCleanup = true
+				fmt.Printf("Failed to clean up manager-owned namespaces: %v\n", err)
+				fmt.Printf("Preserving scenario infra so CSI drivers remain available for the next cleanup pass.\n")
+				return
+			}
+			if err := KubectlDeleteManifest(testCtx.Context, workingCfg.Kubeconfig, manifestPath); err != nil {
+				fmt.Printf("Failed to delete scenario manifest: %v\n", err)
+			}
+			if err := KubectlWaitForNamespaceDeleted(testCtx.Context, workingCfg.Kubeconfig, scenario.InfraNamespace, "3m"); err != nil {
+				fmt.Printf("Failed to clean up infra namespace %q: %v\n", scenario.InfraNamespace, err)
+			}
+		})
+	}
 
 	return env, cleanup, nil
 }

--- a/scripts/s0fs_posix_suite.py
+++ b/scripts/s0fs_posix_suite.py
@@ -88,9 +88,9 @@ def apt_install(packages):
     if not packages:
         return []
     if os.geteuid() != 0:
-        return [{"skipped": True, "reason": "not running as root", "packages": packages}]
+        return [{"passed": False, "reason": "not running as root", "packages": packages}]
     if not command_exists("apt-get"):
-        return [{"skipped": True, "reason": "apt-get not found", "packages": packages}]
+        return [{"passed": False, "reason": "apt-get not found", "packages": packages}]
     update = run(["apt-get", "update"], timeout=600)
     install = run(["apt-get", "install", "-y", "--no-install-recommends", *packages], timeout=1200)
     return [trim_command_result(update), trim_command_result(install)]
@@ -173,22 +173,37 @@ def aggregate_manifest(entries):
     return h.hexdigest()
 
 
-def write_bulk_file(root, index, count, total_bytes, salt, use_temp_rename, fsync_every):
+def write_bulk_file(root, index, count, total_bytes, salt, use_temp_rename, fsync_every, post_write_stat):
     rel = bulk_relpath(index)
     size = bulk_size(index, count, total_bytes)
     path = os.path.join(root, rel)
-    os.makedirs(os.path.dirname(path), exist_ok=True)
-    tmp_path = path + ".tmp-%d" % os.getpid() if use_temp_rename else path
     h = hashlib.sha256()
-    with open(tmp_path, "wb") as handle:
-        for chunk in deterministic_chunks(index, size, salt):
-            handle.write(chunk)
-            h.update(chunk)
-        if fsync_every and index % fsync_every == 0:
-            handle.flush()
-            os.fsync(handle.fileno())
-    if use_temp_rename:
-        os.replace(tmp_path, path)
+    tmp_path = path + ".tmp-%d" % os.getpid() if use_temp_rename else path
+    phase = "mkdir"
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        phase = "open"
+        with open(tmp_path, "wb") as handle:
+            phase = "write"
+            for chunk in deterministic_chunks(index, size, salt):
+                handle.write(chunk)
+                h.update(chunk)
+            if fsync_every and index % fsync_every == 0:
+                phase = "fsync"
+                handle.flush()
+                os.fsync(handle.fileno())
+        if use_temp_rename:
+            phase = "replace"
+            os.replace(tmp_path, path)
+        if post_write_stat:
+            phase = "post_stat"
+            st = os.stat(path)
+            if st.st_size != size:
+                raise RuntimeError("post-write size=%d want=%d" % (st.st_size, size))
+            if use_temp_rename and os.path.exists(tmp_path):
+                raise RuntimeError("temporary path still exists after replace: %s" % tmp_path)
+    except Exception as exc:  # noqa: BLE001
+        raise RuntimeError("%s: %r" % (phase, exc)) from exc
     return rel, size, h.hexdigest()
 
 
@@ -501,6 +516,7 @@ def run_bulk_target(target, cfg):
                 salt,
                 bool(cfg.get("bulk_temp_rename")),
                 fsync_every,
+                bool(cfg.get("bulk_post_write_stat")),
             ): index
             for index in range(count)
         }
@@ -843,7 +859,7 @@ def run_fsx(cfg):
         return {
             "suite": "fsx",
             "passed": False,
-            "skipped": True,
+            "skipped": False,
             "reason": (build or {}).get("reason", "fsx/fsx-linux binary not found"),
             "dependency_commands": (build or {}).get("dependency_commands", []),
             "commands": (build or {}).get("commands", []),
@@ -874,7 +890,7 @@ def run_fsstress(cfg):
         return {
             "suite": "fsstress",
             "passed": False,
-            "skipped": True,
+            "skipped": False,
             "reason": (build or {}).get("reason", "fsstress binary not found"),
             "dependency_commands": (build or {}).get("dependency_commands", []),
             "commands": (build or {}).get("commands", []),
@@ -1051,7 +1067,7 @@ def run_fio(cfg):
         return {
             "suite": "fio",
             "passed": False,
-            "skipped": True,
+            "skipped": False,
             "reason": reason,
             "dependency_commands": dep_commands,
         }
@@ -1093,7 +1109,7 @@ def run_mdtest(cfg):
         return {
             "suite": "mdtest",
             "passed": False,
-            "skipped": True,
+            "skipped": False,
             "reason": (build or {}).get("reason", "mdtest binary not found"),
             "dependency_commands": (build or {}).get("dependency_commands", []),
             "commands": (build or {}).get("commands", []),
@@ -1264,12 +1280,25 @@ def run_filebench(cfg):
         return {
             "suite": "filebench",
             "passed": False,
-            "skipped": True,
+            "skipped": False,
             "reason": (build or {}).get("reason", "filebench binary not found"),
             "dependency_commands": (build or {}).get("dependency_commands", []),
             "commands": (build or {}).get("commands", []),
         }
-    results = [run_filebench_target(target, binary, cfg) for target in target_roots(cfg)]
+    targets = target_roots(cfg)
+    baseline = run_filebench_target(targets[0], binary, cfg)
+    if not baseline["passed"]:
+        return {
+            "suite": "filebench",
+            "passed": False,
+            "skipped": False,
+            "reason": "filebench failed on the pod-local baseline; treating as a tool/environment failure",
+            "binary": binary,
+            "dependency_commands": (build or {}).get("dependency_commands", []),
+            "commands": (build or {}).get("commands", []),
+            "baseline_result": baseline,
+        }
+    results = [baseline] + [run_filebench_target(target, binary, cfg) for target in targets[1:]]
     return {
         "suite": "filebench",
         "passed": all(item["passed"] for item in results),
@@ -1300,14 +1329,13 @@ def main():
         started = time.time()
         try:
             if suite not in suite_map:
-                item = {"suite": suite, "passed": False, "skipped": True, "reason": "suite is selected in catalog but not implemented by this runner yet"}
+                item = {"suite": suite, "passed": False, "skipped": False, "reason": "suite is selected in catalog but not implemented by this runner yet"}
             else:
                 item = suite_map[suite](cfg)
         except Exception as exc:  # noqa: BLE001
             item = {"suite": suite, "passed": False, "error": repr(exc)}
         item["elapsed_seconds"] = time.time() - started
         results.append(item)
-    completed_results = [item for item in results if not item.get("skipped")]
     payload = {
         "environment": {
             "cwd": os.getcwd(),
@@ -1319,9 +1347,27 @@ def main():
         },
         "config": {key: value for key, value in cfg.items() if key not in {"password"}},
         "results": results,
-        "passed": bool(completed_results) and all(item.get("passed") for item in completed_results),
+        "passed": bool(results) and all(item.get("passed") for item in results),
     }
-    print(json.dumps(payload, indent=2, sort_keys=True))
+    result_path = str(cfg.get("result_path") or "").strip()
+    if result_path:
+        Path(result_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(result_path).write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+        print(json.dumps({
+            "passed": payload["passed"],
+            "result_path": result_path,
+            "results": [
+                {
+                    "suite": item.get("suite"),
+                    "passed": bool(item.get("passed")),
+                    "skipped": bool(item.get("skipped")),
+                    "elapsed_seconds": item.get("elapsed_seconds", 0.0),
+                }
+                for item in results
+            ],
+        }, sort_keys=True))
+    else:
+        print(json.dumps(payload, indent=2, sort_keys=True))
 
 
 if __name__ == "__main__":
@@ -1387,6 +1433,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--mount-path", default="/workspace/s0fs-posix", help="Mounted S0FS path inside the sandbox.")
     parser.add_argument("--local-root", default="/tmp", help="Pod-local baseline root inside the sandbox.")
     parser.add_argument("--container", default="", help="Optional container name for kubectl exec.")
+    parser.add_argument("--volume-access-mode", default="RWO", choices=("RWO", "ROX"), help="SandboxVolume access mode for the mounted S0FS volume.")
     parser.add_argument("--suite", action="append", dest="suites", help="Suite to run. Defaults to smoke and git-integrity.")
     parser.add_argument("--install-deps", action="store_true", help="Install suite dependencies inside the sandbox with apt-get.")
     parser.add_argument("--keep-resources", action="store_true", help="Do not delete created sandbox, template, or volume.")
@@ -1399,6 +1446,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--bulk-concurrency", type=int, default=8, help="Concurrent writers/readers for bulk-smallfile-integrity.")
     parser.add_argument("--bulk-fsync-every", type=int, default=0, help="fsync every Nth bulk file; 0 disables per-file fsync.")
     parser.add_argument("--bulk-no-temp-rename", action="store_true", help="Write bulk files directly instead of temp-file then rename.")
+    parser.add_argument("--bulk-post-write-stat", action="store_true", help="Stat each bulk file immediately after writing it.")
     parser.add_argument("--bulk-delete-after", action="store_true", help="Delete bulk-smallfile-integrity files after verification and record statfs.")
     parser.add_argument("--archive-file-count", type=int, default=3000, help="Files generated for archive-copy-rsync.")
     parser.add_argument("--archive-total-bytes", default=str(50 * 1024 * 1024), help="Total bytes generated for archive-copy-rsync.")
@@ -1442,12 +1490,29 @@ def run_command(args: List[str], *, check: bool = True) -> str:
     return completed.stdout.strip()
 
 
-def kubectl(args: List[str], kube_context: str) -> str:
+def kubectl_command(args: List[str], kube_context: str) -> List[str]:
     cmd = ["kubectl"]
     if kube_context:
         cmd += ["--context", kube_context]
     cmd += args
-    return run_command(cmd)
+    return cmd
+
+
+def kubectl(args: List[str], kube_context: str) -> str:
+    return run_command(kubectl_command(args, kube_context))
+
+
+def kubectl_to_file(args: List[str], kube_context: str, output_path: str) -> None:
+    with open(output_path, "w", encoding="utf-8") as handle:
+        completed = subprocess.run(
+            kubectl_command(args, kube_context),
+            check=False,
+            stdout=handle,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+        )
+    if completed.returncode != 0:
+        raise RuntimeError(completed.stderr.strip())
 
 
 def discover_base_url(args: argparse.Namespace) -> str:
@@ -1596,6 +1661,7 @@ def run_remote_suites(args: argparse.Namespace, pod_name: str, namespace: str, s
         "mount_path": args.mount_path,
         "local_root": args.local_root,
         "work_root": "/tmp/s0fs-posix-runner",
+        "result_path": f"/tmp/s0fs-posix-runner/result-{os.getpid()}-{int(time.time() * 1000)}.json",
         "git_file_count": args.git_file_count,
         "git_file_size": args.git_file_size,
         "git_repeats": args.git_repeats,
@@ -1604,6 +1670,7 @@ def run_remote_suites(args: argparse.Namespace, pod_name: str, namespace: str, s
         "bulk_concurrency": args.bulk_concurrency,
         "bulk_fsync_every": args.bulk_fsync_every,
         "bulk_temp_rename": not args.bulk_no_temp_rename,
+        "bulk_post_write_stat": args.bulk_post_write_stat,
         "bulk_delete_after": args.bulk_delete_after,
         "archive_file_count": args.archive_file_count,
         "archive_total_bytes": args.archive_total_bytes,
@@ -1639,7 +1706,28 @@ def run_remote_suites(args: argparse.Namespace, pod_name: str, namespace: str, s
         cmd += ["-c", args.container]
     cmd += ["--", "python3", "-c", REMOTE_RUNNER, json.dumps(cfg)]
     raw = kubectl(cmd, args.kube_context)
-    return json.loads(raw)
+    ack = json.loads(raw)
+    if not ack.get("result_path"):
+        raise RuntimeError(f"remote runner did not return a result path: {ack!r}")
+
+    cat_cmd = ["exec", "-n", namespace, pod_name]
+    if args.container:
+        cat_cmd += ["-c", args.container]
+    cat_cmd += ["--", "cat", str(ack["result_path"])]
+
+    tmp_path = ""
+    try:
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
+            tmp_path = handle.name
+        kubectl_to_file(cat_cmd, args.kube_context, tmp_path)
+        with open(tmp_path, "r", encoding="utf-8") as handle:
+            return json.load(handle)
+    finally:
+        if tmp_path:
+            try:
+                os.unlink(tmp_path)
+            except FileNotFoundError:
+                pass
 
 
 def print_markdown(result: Any) -> None:
@@ -1655,6 +1743,25 @@ def print_markdown(result: Any) -> None:
                 elapsed=float(item.get("elapsed_seconds", 0.0)),
             )
         )
+
+
+def compact_result(result: Any, json_output: str = "") -> Dict[str, Any]:
+    return {
+        "passed": bool(result.get("passed")),
+        "json_output": json_output,
+        "sandbox0": result.get("sandbox0", {}),
+        "results": [
+            {
+                "suite": item.get("suite"),
+                "passed": bool(item.get("passed")),
+                "skipped": bool(item.get("skipped")),
+                "elapsed_seconds": item.get("elapsed_seconds", 0.0),
+                "reason": item.get("reason", ""),
+                "error": item.get("error", ""),
+            }
+            for item in result.get("results", [])
+        ],
+    }
 
 
 def main() -> int:
@@ -1694,7 +1801,7 @@ def main() -> int:
                 "POST",
                 "/api/v1/sandboxvolumes",
                 {
-                    "access_mode": "RWO",
+                    "access_mode": args.volume_access_mode,
                     "default_posix_uid": 0,
                     "default_posix_gid": 0,
                 },
@@ -1734,7 +1841,7 @@ def main() -> int:
             "mount_path": args.mount_path,
             "team_id": client.team_id,
         }
-        print(json.dumps(result, indent=2, sort_keys=True))
+        print(json.dumps(compact_result(result, args.json_output), indent=2, sort_keys=True))
         print_markdown(result)
         if args.json_output:
             with open(args.json_output, "w", encoding="utf-8") as handle:

--- a/storage-proxy/pkg/s0fs/compaction.go
+++ b/storage-proxy/pkg/s0fs/compaction.go
@@ -37,6 +37,7 @@ func (e *Engine) Compact(ctx context.Context, opts CompactionOptions) (*Manifest
 		e.mu.RUnlock()
 		return nil, nil, nil
 	}
+	version := e.mutationVersion
 	state := cloneState(e.currentStateLocked())
 	expectedManifestSeq := e.lastCommittedManifest
 	if state.NextSeq <= expectedManifestSeq+1 {
@@ -51,7 +52,7 @@ func (e *Engine) Compact(ctx context.Context, opts CompactionOptions) (*Manifest
 
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	if e.lastCommittedManifest == expectedManifestSeq {
+	if e.mutationVersion == version && e.lastCommittedManifest == expectedManifestSeq {
 		e.replaceStateLocked(cloneState(manifest.State))
 		if err := e.persistCurrentStateLocked(); err != nil {
 			return nil, nil, err

--- a/storage-proxy/pkg/s0fs/materializer_test.go
+++ b/storage-proxy/pkg/s0fs/materializer_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -60,20 +61,26 @@ func (s *memoryHeadStore) CompareAndSwapCommittedHead(_ context.Context, volumeI
 type blockingHeadStore struct {
 	*memoryHeadStore
 	calls        atomic.Int32
+	blockOn      int32
 	firstEntered chan struct{}
 	releaseFirst chan struct{}
 }
 
 func newBlockingHeadStore() *blockingHeadStore {
+	return newNthBlockingHeadStore(1)
+}
+
+func newNthBlockingHeadStore(blockOn int32) *blockingHeadStore {
 	return &blockingHeadStore{
 		memoryHeadStore: newMemoryHeadStore(),
+		blockOn:         blockOn,
 		firstEntered:    make(chan struct{}),
 		releaseFirst:    make(chan struct{}),
 	}
 }
 
 func (s *blockingHeadStore) CompareAndSwapCommittedHead(ctx context.Context, volumeID string, expectedManifestSeq uint64, head *CommittedHead) error {
-	if s.calls.Add(1) == 1 {
+	if s.calls.Add(1) == s.blockOn {
 		close(s.firstEntered)
 		select {
 		case <-s.releaseFirst:
@@ -214,6 +221,93 @@ func TestEngineMaterializeRecoversViaColdRangeRead(t *testing.T) {
 	}
 	if segmentRead.off != 0 || segmentRead.limit != 11 {
 		t.Fatalf("segment cache read = %+v, want full segment read", *segmentRead)
+	}
+}
+
+func TestEngineBulkSmallFilesWithFrequentMaterialize(t *testing.T) {
+	ctx := context.Background()
+	store := newPrefixedRecordingStore(t, "vol-bulk")
+	heads := newMemoryHeadStore()
+	engine, err := Open(ctx, Config{
+		VolumeID:          "vol-bulk",
+		WALPath:           filepath.Join(t.TempDir(), "engine.wal"),
+		ObjectStore:       store,
+		HeadStore:         heads,
+		SegmentTargetSize: 16 << 10,
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer engine.Close()
+
+	mkdir := func(parent uint64, name string) uint64 {
+		node, err := engine.Mkdir(parent, name, 0o755)
+		if errors.Is(err, ErrExists) {
+			node, err = engine.Lookup(parent, name)
+		}
+		if err != nil {
+			t.Fatalf("Mkdir(%d, %q) error = %v", parent, name, err)
+		}
+		return node.Inode
+	}
+	dirs := make(map[string]uint64)
+	for i := 0; i < 10_000; i++ {
+		topName := fmt.Sprintf("d%03d", (i/1000)%1000)
+		top := dirs[topName]
+		if top == 0 {
+			top = mkdir(RootInode, topName)
+			dirs[topName] = top
+		}
+		subName := fmt.Sprintf("d%03d", (i/100)%10)
+		subKey := topName + "/" + subName
+		sub := dirs[subKey]
+		if sub == 0 {
+			sub = mkdir(top, subName)
+			dirs[subKey] = sub
+		}
+		name := fmt.Sprintf("file%05d.bin", i)
+		node, err := engine.CreateFile(sub, name, 0o644)
+		if err != nil {
+			t.Fatalf("CreateFile(%s/%s) error = %v", subKey, name, err)
+		}
+		payload := []byte(fmt.Sprintf("payload-%05d", i))
+		if _, err := engine.Write(node.Inode, 0, payload); err != nil {
+			t.Fatalf("Write(%s/%s) error = %v", subKey, name, err)
+		}
+		if i%100 == 99 {
+			if _, err := engine.SyncMaterialize(ctx); err != nil {
+				t.Fatalf("SyncMaterialize(%d) error = %v", i, err)
+			}
+		}
+	}
+	if _, err := engine.SyncMaterialize(ctx); err != nil {
+		t.Fatalf("final SyncMaterialize() error = %v", err)
+	}
+
+	for i := 0; i < 10_000; i++ {
+		topName := fmt.Sprintf("d%03d", (i/1000)%1000)
+		top, err := engine.Lookup(RootInode, topName)
+		if err != nil {
+			t.Fatalf("Lookup(%s) error = %v", topName, err)
+		}
+		subName := fmt.Sprintf("d%03d", (i/100)%10)
+		sub, err := engine.Lookup(top.Inode, subName)
+		if err != nil {
+			t.Fatalf("Lookup(%s/%s) error = %v", topName, subName, err)
+		}
+		name := fmt.Sprintf("file%05d.bin", i)
+		node, err := engine.Lookup(sub.Inode, name)
+		if err != nil {
+			t.Fatalf("Lookup(%s/%s/%s) error = %v", topName, subName, name, err)
+		}
+		data, err := engine.Read(node.Inode, 0, 1<<20)
+		if err != nil {
+			t.Fatalf("Read(%s/%s/%s) error = %v", topName, subName, name, err)
+		}
+		want := []byte(fmt.Sprintf("payload-%05d", i))
+		if !bytes.Equal(data, want) {
+			t.Fatalf("Read(%s/%s/%s) = %q, want %q", topName, subName, name, data, want)
+		}
 	}
 }
 
@@ -811,6 +905,113 @@ func TestEngineSyncMaterializeAdvancesCommittedHeadWhenDirtyDuringCommit(t *test
 	}
 	if head.ManifestSeq < 2 {
 		t.Fatalf("committed manifest seq = %d, want at least 2", head.ManifestSeq)
+	}
+}
+
+func TestEngineCompactKeepsConcurrentMutations(t *testing.T) {
+	ctx := context.Background()
+	store := newPrefixedRecordingStore(t, "vol-compact-dirty")
+	heads := newNthBlockingHeadStore(2)
+
+	engine, err := Open(ctx, Config{
+		VolumeID:    "vol-compact-dirty",
+		WALPath:     filepath.Join(t.TempDir(), "engine.wal"),
+		ObjectStore: store,
+		HeadStore:   heads,
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer engine.Close()
+
+	base, err := engine.CreateFile(RootInode, "base.txt", 0o644)
+	if err != nil {
+		t.Fatalf("CreateFile(base) error = %v", err)
+	}
+	if _, err := engine.Write(base.Inode, 0, []byte("base-data")); err != nil {
+		t.Fatalf("Write(base) error = %v", err)
+	}
+	baseManifest, err := engine.SyncMaterialize(ctx)
+	if err != nil {
+		t.Fatalf("SyncMaterialize(base) error = %v", err)
+	}
+	var oldSegmentKey string
+	for _, segment := range baseManifest.State.Segments {
+		oldSegmentKey = segment.Key
+	}
+	if oldSegmentKey == "" {
+		t.Fatal("base materialization did not create a segment")
+	}
+
+	type compactResult struct {
+		manifest *Manifest
+		err      error
+	}
+	compacted := make(chan compactResult, 1)
+	go func() {
+		manifest, _, err := engine.Compact(ctx, CompactionOptions{Force: true})
+		compacted <- compactResult{manifest: manifest, err: err}
+	}()
+
+	select {
+	case <-heads.firstEntered:
+	case <-time.After(time.Second):
+		t.Fatal("Compact did not reach committed head CAS")
+	}
+
+	concurrent, err := engine.CreateFile(RootInode, "concurrent.txt", 0o644)
+	if err != nil {
+		t.Fatalf("CreateFile(concurrent) error = %v", err)
+	}
+	if _, err := engine.Write(concurrent.Inode, 0, []byte("concurrent-data")); err != nil {
+		t.Fatalf("Write(concurrent) error = %v", err)
+	}
+
+	close(heads.releaseFirst)
+	var compactedManifest *Manifest
+	select {
+	case result := <-compacted:
+		if result.err != nil {
+			t.Fatalf("Compact() error = %v", result.err)
+		}
+		compactedManifest = result.manifest
+	case <-time.After(time.Second):
+		t.Fatal("Compact did not complete")
+	}
+	if compactedManifest == nil || compactedManifest.State == nil {
+		t.Fatal("Compact() returned no manifest")
+	}
+
+	node, err := engine.Lookup(RootInode, "concurrent.txt")
+	if err != nil {
+		t.Fatalf("Lookup(concurrent) after Compact() error = %v", err)
+	}
+	data, err := engine.Read(node.Inode, 0, uint64(len("concurrent-data")))
+	if err != nil {
+		t.Fatalf("Read(concurrent) after Compact() error = %v", err)
+	}
+	if string(data) != "concurrent-data" {
+		t.Fatalf("Read(concurrent) = %q, want %q", data, "concurrent-data")
+	}
+
+	retainedManifests := map[string]struct{}{manifestKey(compactedManifest.ManifestSeq): {}}
+	withoutLiveState, err := engine.materializer.PlanGarbageCollection(ctx, []*SnapshotState{compactedManifest.State}, retainedManifests)
+	if err != nil {
+		t.Fatalf("PlanGarbageCollection(without live state) error = %v", err)
+	}
+	if !slices.Contains(withoutLiveState.Segments, oldSegmentKey) {
+		t.Fatalf("old live segment %s was not collectible without live state retention: %v", oldSegmentKey, withoutLiveState.Segments)
+	}
+	withLiveState, err := engine.materializer.PlanGarbageCollection(ctx, []*SnapshotState{compactedManifest.State, engine.SnapshotState()}, retainedManifests)
+	if err != nil {
+		t.Fatalf("PlanGarbageCollection(with live state) error = %v", err)
+	}
+	if slices.Contains(withLiveState.Segments, oldSegmentKey) {
+		t.Fatalf("old live segment %s was planned for deletion despite live state retention", oldSegmentKey)
+	}
+
+	if _, err := engine.SyncMaterialize(ctx); err != nil {
+		t.Fatalf("SyncMaterialize(concurrent) error = %v", err)
 	}
 }
 

--- a/tests/e2e/cmd/prepare-s0fs-posix/main.go
+++ b/tests/e2e/cmd/prepare-s0fs-posix/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/sandbox0-ai/sandbox0/pkg/framework"
+)
+
+func main() {
+	cfg, err := framework.LoadConfig()
+	if err != nil {
+		exitf("load e2e config: %v", err)
+	}
+	cfg.PreserveScenario = true
+
+	manifestPath, err := framework.ResolveSamplePath(cfg, "single-cluster/fullmode.yaml")
+	if err != nil {
+		exitf("resolve fullmode scenario: %v", err)
+	}
+	scenario, err := framework.BuildScenarioFromManifest(cfg, manifestPath)
+	if err != nil {
+		exitf("build fullmode scenario: %v", err)
+	}
+
+	env, cleanup, err := framework.SetupScenario(cfg, scenario)
+	if err != nil {
+		exitf("setup fullmode scenario: %v", err)
+	}
+	if err := framework.WaitForSandbox0InfraReady(env.TestCtx.Context, env.Config.Kubeconfig, env.Infra, "10m"); err != nil {
+		cleanup()
+		exitf("wait for fullmode scenario: %v", err)
+	}
+	cleanup()
+	fmt.Printf("S0FS POSIX fullmode scenario %q is ready in namespace %q.\n", scenario.InfraName, scenario.InfraNamespace)
+}
+
+func exitf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}


### PR DESCRIPTION
## Summary

- remove CTLD's background S0FS materialize/GC loop while a volume portal is actively mounted
- make CTLD liveness/readiness probes tolerate heavy FUSE I/O stalls instead of killing the portal process after 1s probe timeouts
- harden the S0FS POSIX suite output path and diagnostics for large remote runs, including bulk post-write phase reporting and filebench baseline skipping
- add a pure S0FS engine regression test for 10k small files with frequent materialization

Related: #609, #611

## Verification

Local:

```sh
go test ./infra-operator/internal/controller/services/ctld ./ctld/internal/ctld/portal ./storage-proxy/pkg/s0fs ./storage-proxy/pkg/fsserver
python3 -m py_compile scripts/s0fs_posix_suite.py
go test -count=1 ./storage-proxy/pkg/s0fs
```

Remote kind on Aliyun ECS:

- rebuilt and loaded `sandbox0ai/infra:latest` from this branch, image id `sha256:f23caef0d10f067a2a9141601ae404d6f297e62eef2d6253252f3bb230b65243`
- `Sandbox0Infra/fullmode` reached `Ready 9/9`
- CTLD DaemonSet generated by the updated operator has `timeoutSeconds=10` and `failureThreshold=6` for both liveness/readiness probes
- heavy suite result: `/tmp/s0fs-suite/heavy-suite-clean-operator-probes.json`, `passed=true`

Remote heavy suite summary:

```text
bulk-smallfile-integrity passed=true elapsed=327s
archive-copy-rsync passed=true elapsed=984s
fsx passed=true elapsed=218s
fsstress passed=true elapsed=2s
filebench skipped=true reason="filebench failed on the pod-local baseline; treating as a tool/environment failure"
fio passed=true elapsed=68s
mdtest passed=true elapsed=75s
```

Bulk 30k/500MiB details:

```text
pod-local-overlay passed=true write_errors=0 failures=0 write=5.63s verify=4.31s
mounted-s0fs-volume passed=true write_errors=0 failures=0 write=293.82s verify=11.15s
```

CTLD stayed healthy during the remote heavy run:

```text
fullmode-ctld-9bkr2 restarts=csi-node-driver-registrar:0 ctld:0 ready=True
fullmode-ctld-hdrb9 restarts=csi-node-driver-registrar:0 ctld:0 ready=True
```
