### PR TITLE
Optimize S0FS active mount write path

### DIFF
--- a/ctld/cmd/ctld/main.go
+++ b/ctld/cmd/ctld/main.go
@@ -7,9 +7,11 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"syscall"
 	"time"
@@ -45,6 +47,9 @@ var (
 	csiSocket              = "/var/lib/kubelet/plugins/volume.sandbox0.ai/csi.sock"
 	podName                = os.Getenv("POD_NAME")
 	podNamespace           = os.Getenv("POD_NAMESPACE")
+	pprofAddr              = ""
+	pprofBlockProfileRate  = 0
+	pprofMutexFraction     = 0
 )
 
 func main() {
@@ -60,6 +65,9 @@ func main() {
 	flag.StringVar(&nodeName, "node-name", os.Getenv("NODE_NAME"), "current node name used to validate local sandbox ownership")
 	flag.StringVar(&portalRoot, "volume-portal-root", "/var/lib/sandbox0/ctld", "host-local root for ctld volume portal WAL and cache")
 	flag.StringVar(&csiSocket, "csi-socket", "/var/lib/kubelet/plugins/volume.sandbox0.ai/csi.sock", "CSI endpoint socket for sandbox volume portals")
+	flag.StringVar(&pprofAddr, "pprof-addr", "", "optional pprof listen address; disabled when empty")
+	flag.IntVar(&pprofBlockProfileRate, "pprof-block-profile-rate", 0, "runtime.SetBlockProfileRate value used when pprof is enabled")
+	flag.IntVar(&pprofMutexFraction, "pprof-mutex-profile-fraction", 0, "runtime.SetMutexProfileFraction value used when pprof is enabled")
 	flag.Parse()
 
 	log.Println("Starting ctld")
@@ -67,6 +75,14 @@ func main() {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	pprofServer := startPprofServer()
+	if pprofServer != nil {
+		defer func() {
+			shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			_ = pprofServer.Shutdown(shutdownCtx)
+			shutdownCancel()
+		}()
+	}
 
 	zapLogger, err := observability.NewLogger(observability.LoggerConfig{
 		ServiceName: "ctld",
@@ -141,6 +157,30 @@ func main() {
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	_ = httpServer.Shutdown(shutdownCtx)
 	shutdownCancel()
+}
+
+func startPprofServer() *http.Server {
+	if strings.TrimSpace(pprofAddr) == "" {
+		return nil
+	}
+	if pprofBlockProfileRate > 0 {
+		runtime.SetBlockProfileRate(pprofBlockProfileRate)
+	}
+	if pprofMutexFraction > 0 {
+		runtime.SetMutexProfileFraction(pprofMutexFraction)
+	}
+	server := &http.Server{
+		Addr:              pprofAddr,
+		Handler:           http.DefaultServeMux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	go func() {
+		log.Printf("Starting ctld pprof server on %s", pprofAddr)
+		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Fatalf("ctld pprof server failed: %v", err)
+		}
+	}()
+	return server
 }
 
 func newHTTPServer(addr string, controller ctldserver.Controller) *http.Server {

--- a/ctld/internal/ctld/portal/manager.go
+++ b/ctld/internal/ctld/portal/manager.go
@@ -998,7 +998,7 @@ func (m *Manager) garbageCollectBoundS0FSObjects(ctx context.Context, bound *bou
 		return nil, err
 	}
 	retainedStates := []*s0fs.SnapshotState{manifest.State}
-	if current := bound.volCtx.S0FS.SnapshotState(); current != nil {
+	if current := bound.volCtx.S0FS.SnapshotReferenceState(); current != nil {
 		retainedStates = append(retainedStates, current)
 	}
 	cfg := s0fs.Config{

--- a/storage-proxy/pkg/fsserver/server.go
+++ b/storage-proxy/pkg/fsserver/server.go
@@ -97,6 +97,10 @@ func (s *FileSystemServer) currentTime() time.Time {
 	return time.Now().UTC()
 }
 
+func (s *FileSystemServer) shouldPublishEvents() bool {
+	return s != nil && s.eventBroadcaster != nil
+}
+
 func (s *FileSystemServer) primaryRoute(volumeID string) router.Route {
 	if s == nil || s.volumeRouter == nil {
 		return router.Route{
@@ -280,12 +284,12 @@ func (s *FileSystemServer) AckInvalidate(ctx context.Context, req *pb.AckInvalid
 }
 
 func (s *FileSystemServer) publishEvent(ctx context.Context, event *pb.WatchEvent) {
-	claims := internalauth.ClaimsFromContext(ctx)
-	if claims != nil && event != nil && event.OriginSandboxId == "" {
-		event.OriginSandboxId = claims.SandboxID
-	}
-	if s.eventBroadcaster == nil || event == nil {
+	if event == nil || !s.shouldPublishEvents() {
 		return
+	}
+	claims := internalauth.ClaimsFromContext(ctx)
+	if claims != nil && event.OriginSandboxId == "" {
+		event.OriginSandboxId = claims.SandboxID
 	}
 	if event.TimestampUnix == 0 {
 		event.TimestampUnix = s.currentTime().Unix()
@@ -487,17 +491,19 @@ func (s *FileSystemServer) Write(ctx context.Context, req *pb.WriteRequest) (*pb
 				return nil, mapS0FSError(err)
 			}
 			s.markDirtyWrite(req.VolumeId, req.Inode, req.HandleId)
-			path := resolveInodePath(volCtx, req.Inode)
-			eventType := pb.WatchEventType_WATCH_EVENT_TYPE_WRITE
-			if path == "" {
-				eventType = pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE
+			if s.shouldPublishEvents() {
+				path := resolveInodePath(volCtx, req.Inode)
+				eventType := pb.WatchEventType_WATCH_EVENT_TYPE_WRITE
+				if path == "" {
+					eventType = pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE
+				}
+				s.publishEvent(runCtx, &pb.WatchEvent{
+					VolumeId:  req.VolumeId,
+					EventType: eventType,
+					Path:      path,
+					Inode:     req.Inode,
+				})
 			}
-			s.publishEvent(runCtx, &pb.WatchEvent{
-				VolumeId:  req.VolumeId,
-				EventType: eventType,
-				Path:      path,
-				Inode:     req.Inode,
-			})
 			return &pb.WriteResponse{BytesWritten: int64(len(req.Data))}, nil
 		}
 		return nil, unsupportedVolumeBackend(volCtx)
@@ -511,33 +517,32 @@ func (s *FileSystemServer) Create(ctx context.Context, req *pb.CreateRequest) (*
 			if err := ensureLazyRootPosixIdentity(volCtx, req.Actor, fsmeta.Ino(req.Parent)); err != nil {
 				return nil, fserror.New(fserror.Internal, err.Error())
 			}
-			path := resolveChildPath(volCtx, req.Parent, req.Name)
-			node, err := volCtx.S0FS.CreateFile(req.Parent, req.Name, req.Mode)
+			var node *s0fs.Node
+			var err error
+			if req.Actor != nil && len(req.Actor.Gids) > 0 {
+				node, err = volCtx.S0FS.CreateFileWithOwner(req.Parent, req.Name, req.Mode, req.Actor.Uid, req.Actor.Gids[0])
+			} else {
+				node, err = volCtx.S0FS.CreateFile(req.Parent, req.Name, req.Mode)
+			}
 			if err != nil {
 				return nil, mapS0FSError(err)
 			}
-			if req.Actor != nil && len(req.Actor.Gids) > 0 {
-				if err := volCtx.S0FS.SetOwner(node.Inode, req.Actor.Uid, req.Actor.Gids[0]); err != nil {
-					return nil, fserror.New(fserror.Internal, err.Error())
+			if s.shouldPublishEvents() {
+				path := resolveChildPath(volCtx, req.Parent, req.Name)
+				if path == "" {
+					path = resolveInodePath(volCtx, node.Inode)
 				}
-				node, err = volCtx.S0FS.GetAttr(node.Inode)
-				if err != nil {
-					return nil, mapS0FSError(err)
+				eventType := pb.WatchEventType_WATCH_EVENT_TYPE_CREATE
+				if path == "" {
+					eventType = pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE
 				}
+				s.publishEvent(runCtx, &pb.WatchEvent{
+					VolumeId:  req.VolumeId,
+					EventType: eventType,
+					Path:      path,
+					Inode:     node.Inode,
+				})
 			}
-			if path == "" {
-				path = resolveInodePath(volCtx, node.Inode)
-			}
-			eventType := pb.WatchEventType_WATCH_EVENT_TYPE_CREATE
-			if path == "" {
-				eventType = pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE
-			}
-			s.publishEvent(runCtx, &pb.WatchEvent{
-				VolumeId:  req.VolumeId,
-				EventType: eventType,
-				Path:      path,
-				Inode:     node.Inode,
-			})
 			return s0fsNodeResponse(node, volCtx.OpenFileHandle(node.Inode)), nil
 		}
 		return nil, unsupportedVolumeBackend(volCtx)
@@ -551,7 +556,6 @@ func (s *FileSystemServer) Mkdir(ctx context.Context, req *pb.MkdirRequest) (*pb
 			if err := ensureLazyRootPosixIdentity(volCtx, req.Actor, fsmeta.Ino(req.Parent)); err != nil {
 				return nil, fserror.New(fserror.Internal, err.Error())
 			}
-			path := resolveChildPath(volCtx, req.Parent, req.Name)
 			node, err := volCtx.S0FS.Mkdir(req.Parent, req.Name, req.Mode)
 			if err != nil {
 				return nil, mapS0FSError(err)
@@ -565,19 +569,22 @@ func (s *FileSystemServer) Mkdir(ctx context.Context, req *pb.MkdirRequest) (*pb
 					return nil, mapS0FSError(err)
 				}
 			}
-			if path == "" {
-				path = resolveInodePath(volCtx, node.Inode)
+			if s.shouldPublishEvents() {
+				path := resolveChildPath(volCtx, req.Parent, req.Name)
+				if path == "" {
+					path = resolveInodePath(volCtx, node.Inode)
+				}
+				eventType := pb.WatchEventType_WATCH_EVENT_TYPE_CREATE
+				if path == "" {
+					eventType = pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE
+				}
+				s.publishEvent(runCtx, &pb.WatchEvent{
+					VolumeId:  req.VolumeId,
+					EventType: eventType,
+					Path:      path,
+					Inode:     node.Inode,
+				})
 			}
-			eventType := pb.WatchEventType_WATCH_EVENT_TYPE_CREATE
-			if path == "" {
-				eventType = pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE
-			}
-			s.publishEvent(runCtx, &pb.WatchEvent{
-				VolumeId:  req.VolumeId,
-				EventType: eventType,
-				Path:      path,
-				Inode:     node.Inode,
-			})
 			return s0fsNodeResponse(node, 0), nil
 		}
 		return nil, unsupportedVolumeBackend(volCtx)
@@ -609,17 +616,19 @@ func (s *FileSystemServer) openS0FS(ctx context.Context, volCtx *volume.VolumeCo
 		if err := volCtx.S0FS.Truncate(req.Inode, 0); err != nil {
 			return nil, mapS0FSError(err)
 		}
-		path := resolveInodePath(volCtx, req.Inode)
-		eventType := pb.WatchEventType_WATCH_EVENT_TYPE_WRITE
-		if path == "" {
-			eventType = pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE
+		if s.shouldPublishEvents() {
+			path := resolveInodePath(volCtx, req.Inode)
+			eventType := pb.WatchEventType_WATCH_EVENT_TYPE_WRITE
+			if path == "" {
+				eventType = pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE
+			}
+			s.publishEvent(ctx, &pb.WatchEvent{
+				VolumeId:  req.VolumeId,
+				EventType: eventType,
+				Path:      path,
+				Inode:     req.Inode,
+			})
 		}
-		s.publishEvent(ctx, &pb.WatchEvent{
-			VolumeId:  req.VolumeId,
-			EventType: eventType,
-			Path:      path,
-			Inode:     req.Inode,
-		})
 	}
 	return &pb.OpenResponse{HandleId: volCtx.OpenFileHandle(node.Inode)}, nil
 }
@@ -628,7 +637,6 @@ func (s *FileSystemServer) openS0FS(ctx context.Context, volCtx *volume.VolumeCo
 func (s *FileSystemServer) Unlink(ctx context.Context, req *pb.UnlinkRequest) (*pb.Empty, error) {
 	return withAuthorizedVolumeMutation(s, ctx, req.VolumeId, func(runCtx context.Context, volCtx *volume.VolumeContext) (*pb.Empty, error) {
 		if isS0FSVolume(volCtx) {
-			path := resolveChildPath(volCtx, req.Parent, req.Name)
 			inode, err := volCtx.S0FS.UnlinkWithInode(req.Parent, req.Name)
 			if err != nil {
 				return nil, mapS0FSError(err)
@@ -636,16 +644,19 @@ func (s *FileSystemServer) Unlink(ctx context.Context, req *pb.UnlinkRequest) (*
 			if !volCtx.MarkUnlinkedFileIfOpen(inode) {
 				_ = volCtx.S0FS.Forget(inode)
 			}
-			eventType := pb.WatchEventType_WATCH_EVENT_TYPE_REMOVE
-			if path == "" {
-				eventType = pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE
+			if s.shouldPublishEvents() {
+				path := resolveChildPath(volCtx, req.Parent, req.Name)
+				eventType := pb.WatchEventType_WATCH_EVENT_TYPE_REMOVE
+				if path == "" {
+					eventType = pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE
+				}
+				s.publishEvent(runCtx, &pb.WatchEvent{
+					VolumeId:  req.VolumeId,
+					EventType: eventType,
+					Path:      path,
+					Inode:     inode,
+				})
 			}
-			s.publishEvent(runCtx, &pb.WatchEvent{
-				VolumeId:  req.VolumeId,
-				EventType: eventType,
-				Path:      path,
-				Inode:     inode,
-			})
 			return &pb.Empty{}, nil
 		}
 		return nil, unsupportedVolumeBackend(volCtx)
@@ -728,21 +739,23 @@ func (s *FileSystemServer) ReleaseDir(ctx context.Context, req *pb.ReleaseDirReq
 func (s *FileSystemServer) Rename(ctx context.Context, req *pb.RenameRequest) (*pb.Empty, error) {
 	return withAuthorizedVolumeMutation(s, ctx, req.VolumeId, func(runCtx context.Context, volCtx *volume.VolumeContext) (*pb.Empty, error) {
 		if isS0FSVolume(volCtx) {
-			oldPath := resolveChildPath(volCtx, req.OldParent, req.OldName)
-			newPath := resolveChildPath(volCtx, req.NewParent, req.NewName)
 			if err := volCtx.S0FS.Rename(req.OldParent, req.OldName, req.NewParent, req.NewName); err != nil {
 				return nil, mapS0FSError(err)
 			}
-			eventType := pb.WatchEventType_WATCH_EVENT_TYPE_RENAME
-			if oldPath == "" && newPath == "" {
-				eventType = pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE
+			if s.shouldPublishEvents() {
+				oldPath := resolveChildPath(volCtx, req.OldParent, req.OldName)
+				newPath := resolveChildPath(volCtx, req.NewParent, req.NewName)
+				eventType := pb.WatchEventType_WATCH_EVENT_TYPE_RENAME
+				if oldPath == "" && newPath == "" {
+					eventType = pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE
+				}
+				s.publishEvent(runCtx, &pb.WatchEvent{
+					VolumeId:  req.VolumeId,
+					EventType: eventType,
+					Path:      newPath,
+					OldPath:   oldPath,
+				})
 			}
-			s.publishEvent(runCtx, &pb.WatchEvent{
-				VolumeId:  req.VolumeId,
-				EventType: eventType,
-				Path:      newPath,
-				OldPath:   oldPath,
-			})
 			return &pb.Empty{}, nil
 		}
 		return nil, unsupportedVolumeBackend(volCtx)
@@ -757,7 +770,6 @@ func (s *FileSystemServer) SetAttr(ctx context.Context, req *pb.SetAttrRequest) 
 			if attr == nil {
 				attr = &pb.GetAttrResponse{}
 			}
-			path := resolveInodePath(volCtx, req.Inode)
 			if req.Valid&uint32(fsmeta.SetAttrMode) != 0 {
 				if err := volCtx.S0FS.SetMode(req.Inode, attr.Mode&0o7777); err != nil {
 					return nil, mapS0FSError(err)
@@ -789,21 +801,24 @@ func (s *FileSystemServer) SetAttr(ctx context.Context, req *pb.SetAttrRequest) 
 			if err != nil {
 				return nil, mapS0FSError(err)
 			}
-			eventType := pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE
-			if req.Valid&uint32(fsmeta.SetAttrMode) != 0 {
-				eventType = pb.WatchEventType_WATCH_EVENT_TYPE_CHMOD
-			} else if path != "" {
-				eventType = pb.WatchEventType_WATCH_EVENT_TYPE_WRITE
+			if s.shouldPublishEvents() {
+				path := resolveInodePath(volCtx, req.Inode)
+				eventType := pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE
+				if req.Valid&uint32(fsmeta.SetAttrMode) != 0 {
+					eventType = pb.WatchEventType_WATCH_EVENT_TYPE_CHMOD
+				} else if path != "" {
+					eventType = pb.WatchEventType_WATCH_EVENT_TYPE_WRITE
+				}
+				if path == "" {
+					eventType = pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE
+				}
+				s.publishEvent(runCtx, &pb.WatchEvent{
+					VolumeId:  req.VolumeId,
+					EventType: eventType,
+					Path:      path,
+					Inode:     req.Inode,
+				})
 			}
-			if path == "" {
-				eventType = pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE
-			}
-			s.publishEvent(runCtx, &pb.WatchEvent{
-				VolumeId:  req.VolumeId,
-				EventType: eventType,
-				Path:      path,
-				Inode:     req.Inode,
-			})
 			return &pb.SetAttrResponse{Attr: s0fsAttr(updated)}, nil
 		}
 		return nil, unsupportedVolumeBackend(volCtx)
@@ -883,19 +898,21 @@ func (s *FileSystemServer) Release(ctx context.Context, req *pb.ReleaseRequest) 
 func (s *FileSystemServer) Rmdir(ctx context.Context, req *pb.RmdirRequest) (*pb.Empty, error) {
 	return withAuthorizedVolumeMutation(s, ctx, req.VolumeId, func(runCtx context.Context, volCtx *volume.VolumeContext) (*pb.Empty, error) {
 		if isS0FSVolume(volCtx) {
-			path := resolveChildPath(volCtx, req.Parent, req.Name)
 			if err := volCtx.S0FS.RemoveDir(req.Parent, req.Name); err != nil {
 				return nil, mapS0FSError(err)
 			}
-			eventType := pb.WatchEventType_WATCH_EVENT_TYPE_REMOVE
-			if path == "" {
-				eventType = pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE
+			if s.shouldPublishEvents() {
+				path := resolveChildPath(volCtx, req.Parent, req.Name)
+				eventType := pb.WatchEventType_WATCH_EVENT_TYPE_REMOVE
+				if path == "" {
+					eventType = pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE
+				}
+				s.publishEvent(runCtx, &pb.WatchEvent{
+					VolumeId:  req.VolumeId,
+					EventType: eventType,
+					Path:      path,
+				})
 			}
-			s.publishEvent(runCtx, &pb.WatchEvent{
-				VolumeId:  req.VolumeId,
-				EventType: eventType,
-				Path:      path,
-			})
 			return &pb.Empty{}, nil
 		}
 		return nil, unsupportedVolumeBackend(volCtx)
@@ -931,7 +948,6 @@ func (s *FileSystemServer) Symlink(ctx context.Context, req *pb.SymlinkRequest) 
 			if err := ensureLazyRootPosixIdentity(volCtx, req.Actor, fsmeta.Ino(req.Parent)); err != nil {
 				return nil, fserror.New(fserror.Internal, err.Error())
 			}
-			path := resolveChildPath(volCtx, req.Parent, req.Name)
 			node, err := volCtx.S0FS.Symlink(req.Parent, req.Name, req.Target, 0o777)
 			if err != nil {
 				return nil, mapS0FSError(err)
@@ -945,19 +961,22 @@ func (s *FileSystemServer) Symlink(ctx context.Context, req *pb.SymlinkRequest) 
 					return nil, mapS0FSError(err)
 				}
 			}
-			if path == "" {
-				path = resolveInodePath(volCtx, node.Inode)
+			if s.shouldPublishEvents() {
+				path := resolveChildPath(volCtx, req.Parent, req.Name)
+				if path == "" {
+					path = resolveInodePath(volCtx, node.Inode)
+				}
+				eventType := pb.WatchEventType_WATCH_EVENT_TYPE_CREATE
+				if path == "" {
+					eventType = pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE
+				}
+				s.publishEvent(runCtx, &pb.WatchEvent{
+					VolumeId:  req.VolumeId,
+					EventType: eventType,
+					Path:      path,
+					Inode:     node.Inode,
+				})
 			}
-			eventType := pb.WatchEventType_WATCH_EVENT_TYPE_CREATE
-			if path == "" {
-				eventType = pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE
-			}
-			s.publishEvent(runCtx, &pb.WatchEvent{
-				VolumeId:  req.VolumeId,
-				EventType: eventType,
-				Path:      path,
-				Inode:     node.Inode,
-			})
 			return s0fsNodeResponse(node, 0), nil
 		}
 		return nil, unsupportedVolumeBackend(volCtx)
@@ -988,21 +1007,23 @@ func (s *FileSystemServer) Readlink(ctx context.Context, req *pb.ReadlinkRequest
 func (s *FileSystemServer) Link(ctx context.Context, req *pb.LinkRequest) (*pb.NodeResponse, error) {
 	return withAuthorizedVolumeMutation(s, ctx, req.VolumeId, func(runCtx context.Context, volCtx *volume.VolumeContext) (*pb.NodeResponse, error) {
 		if isS0FSVolume(volCtx) {
-			path := resolveChildPath(volCtx, req.NewParent, req.NewName)
 			node, err := volCtx.S0FS.Link(req.Inode, req.NewParent, req.NewName)
 			if err != nil {
 				return nil, mapS0FSError(err)
 			}
-			eventType := pb.WatchEventType_WATCH_EVENT_TYPE_CREATE
-			if path == "" {
-				eventType = pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE
+			if s.shouldPublishEvents() {
+				path := resolveChildPath(volCtx, req.NewParent, req.NewName)
+				eventType := pb.WatchEventType_WATCH_EVENT_TYPE_CREATE
+				if path == "" {
+					eventType = pb.WatchEventType_WATCH_EVENT_TYPE_INVALIDATE
+				}
+				s.publishEvent(runCtx, &pb.WatchEvent{
+					VolumeId:  req.VolumeId,
+					EventType: eventType,
+					Path:      path,
+					Inode:     node.Inode,
+				})
 			}
-			s.publishEvent(runCtx, &pb.WatchEvent{
-				VolumeId:  req.VolumeId,
-				EventType: eventType,
-				Path:      path,
-				Inode:     node.Inode,
-			})
 			return s0fsNodeResponse(node, 0), nil
 		}
 		return nil, unsupportedVolumeBackend(volCtx)

--- a/storage-proxy/pkg/fsserver/server_s0fs_test.go
+++ b/storage-proxy/pkg/fsserver/server_s0fs_test.go
@@ -107,6 +107,35 @@ func TestS0FSFileLifecycle(t *testing.T) {
 	}
 }
 
+func TestS0FSCreateAppliesActorOwner(t *testing.T) {
+	t.Parallel()
+
+	volCtx := newMountedS0FSVolumeContext(t, "vol-1", "team-a")
+	server := newTestFileSystemServer(&fakeVolumeManager{
+		volumes: map[string]*volume.VolumeContext{
+			"vol-1": volCtx,
+		},
+	}, nil, nil)
+	ctx := authContext("team-a", "")
+
+	createResp, err := server.Create(ctx, &pb.CreateRequest{
+		VolumeId: "vol-1",
+		Parent:   1,
+		Name:     "owned.txt",
+		Mode:     0o640,
+		Actor:    &pb.PosixActor{Uid: 1000, Gids: []uint32{2000}},
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if createResp.Attr == nil {
+		t.Fatal("Create() returned nil attr")
+	}
+	if createResp.Attr.Mode&0o7777 != 0o640 || createResp.Attr.Uid != 1000 || createResp.Attr.Gid != 2000 {
+		t.Fatalf("Create() attr = %+v, want mode 0640 owner 1000:2000", createResp.Attr)
+	}
+}
+
 func TestS0FSOpenTruncatesExistingFile(t *testing.T) {
 	t.Parallel()
 
@@ -230,6 +259,73 @@ func TestS0FSFlushSyncsDirtyWrites(t *testing.T) {
 		HandleId: createResp.HandleId,
 	}); err != nil {
 		t.Fatalf("second Flush() error = %v", err)
+	}
+	if got := syncs.Load(); got != 1 {
+		t.Fatalf("sync count after second Flush() = %d, want 1", got)
+	}
+}
+
+func TestS0FSFlushSkipsRedundantWALSyncAfterBatch(t *testing.T) {
+	t.Parallel()
+
+	volCtx, syncs := newMountedS0FSVolumeContextWithSyncCounter(t, "vol-1", "team-a")
+	server := newTestFileSystemServer(&fakeVolumeManager{
+		volumes: map[string]*volume.VolumeContext{
+			"vol-1": volCtx,
+		},
+	}, nil, nil)
+	ctx := authContext("team-a", "")
+
+	first, err := server.Create(ctx, &pb.CreateRequest{
+		VolumeId: "vol-1",
+		Parent:   1,
+		Name:     "first.txt",
+		Mode:     0o644,
+	})
+	if err != nil {
+		t.Fatalf("Create(first) error = %v", err)
+	}
+	second, err := server.Create(ctx, &pb.CreateRequest{
+		VolumeId: "vol-1",
+		Parent:   1,
+		Name:     "second.txt",
+		Mode:     0o644,
+	})
+	if err != nil {
+		t.Fatalf("Create(second) error = %v", err)
+	}
+	if _, err := server.Write(ctx, &pb.WriteRequest{
+		VolumeId: "vol-1",
+		Inode:    first.Inode,
+		Offset:   0,
+		Data:     []byte("first"),
+		HandleId: first.HandleId,
+	}); err != nil {
+		t.Fatalf("Write(first) error = %v", err)
+	}
+	if _, err := server.Write(ctx, &pb.WriteRequest{
+		VolumeId: "vol-1",
+		Inode:    second.Inode,
+		Offset:   0,
+		Data:     []byte("second"),
+		HandleId: second.HandleId,
+	}); err != nil {
+		t.Fatalf("Write(second) error = %v", err)
+	}
+	if _, err := server.Flush(ctx, &pb.FlushRequest{
+		VolumeId: "vol-1",
+		HandleId: first.HandleId,
+	}); err != nil {
+		t.Fatalf("Flush(first) error = %v", err)
+	}
+	if got := syncs.Load(); got != 1 {
+		t.Fatalf("sync count after first Flush() = %d, want 1", got)
+	}
+	if _, err := server.Flush(ctx, &pb.FlushRequest{
+		VolumeId: "vol-1",
+		HandleId: second.HandleId,
+	}); err != nil {
+		t.Fatalf("Flush(second) error = %v", err)
 	}
 	if got := syncs.Load(); got != 1 {
 		t.Fatalf("sync count after second Flush() = %d, want 1", got)

--- a/storage-proxy/pkg/s0fs/engine.go
+++ b/storage-proxy/pkg/s0fs/engine.go
@@ -182,7 +182,7 @@ func (e *Engine) GetAttr(inode uint64) (*Node, error) {
 }
 
 func (e *Engine) Mkdir(parent uint64, name string, mode uint32) (*Node, error) {
-	return e.create(parent, name, TypeDirectory, mode, "")
+	return e.create(parent, name, TypeDirectory, mode, "", CreateOptions{})
 }
 
 func (e *Engine) ReadDir(inode uint64) ([]DirEntry, error) {
@@ -239,14 +239,18 @@ func (e *Engine) ChildPath(parent uint64, name string) (string, bool) {
 }
 
 func (e *Engine) CreateFile(parent uint64, name string, mode uint32) (*Node, error) {
-	return e.create(parent, name, TypeFile, mode, "")
+	return e.create(parent, name, TypeFile, mode, "", CreateOptions{})
+}
+
+func (e *Engine) CreateFileWithOwner(parent uint64, name string, mode uint32, uid, gid uint32) (*Node, error) {
+	return e.create(parent, name, TypeFile, mode, "", CreateOptions{UID: uid, GID: gid})
 }
 
 func (e *Engine) Symlink(parent uint64, name, target string, mode uint32) (*Node, error) {
 	if target == "" {
 		return nil, fmt.Errorf("%w: symlink target is required", ErrInvalidInput)
 	}
-	return e.create(parent, name, TypeSymlink, mode, target)
+	return e.create(parent, name, TypeSymlink, mode, target, CreateOptions{})
 }
 
 func (e *Engine) Link(inode uint64, newParent uint64, newName string) (*Node, error) {
@@ -294,7 +298,7 @@ func (e *Engine) Write(inode uint64, offset uint64, payload []byte) (int, error)
 	record := e.newRecord("write")
 	record.Inode = inode
 	record.Offset = offset
-	record.Data = slices.Clone(payload)
+	record.Data = payload
 	projectedBytes := estimatedWALRecordBytes(record)
 	end := offset + uint64(len(payload))
 	if end > node.Size {
@@ -713,7 +717,7 @@ func (e *Engine) DeleteSnapshot(snapshotID string) error {
 	return nil
 }
 
-func (e *Engine) create(parent uint64, name string, typ FileType, mode uint32, target string) (*Node, error) {
+func (e *Engine) create(parent uint64, name string, typ FileType, mode uint32, target string, opts CreateOptions) (*Node, error) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	if err := e.checkOpen(); err != nil {
@@ -735,6 +739,8 @@ func (e *Engine) create(parent uint64, name string, typ FileType, mode uint32, t
 	record.Name = name
 	record.Type = typ
 	record.Mode = mode
+	record.UID = opts.UID
+	record.GID = opts.GID
 	record.Target = target
 	if err := e.appendAndApplyLocked(record, estimatedWALRecordBytes(record)); err != nil {
 		return nil, err
@@ -917,6 +923,8 @@ func (e *Engine) applyCreate(record walRecord) error {
 		Inode:  record.Inode,
 		Type:   record.Type,
 		Mode:   record.Mode,
+		UID:    record.UID,
+		GID:    record.GID,
 		Nlink:  1,
 		Target: record.Target,
 		Atime:  now,
@@ -1149,7 +1157,7 @@ func (e *Engine) exportStateLocked() (*SnapshotState, error) {
 }
 
 func (e *Engine) materializeStateLocked() (*SnapshotState, error) {
-	state := cloneState(e.currentStateLocked())
+	state := cloneStateForMaterialization(e.currentStateLocked())
 	if len(state.ColdFiles) == 0 {
 		pruneUnreferencedSegments(state)
 		return state, nil

--- a/storage-proxy/pkg/s0fs/engine.go
+++ b/storage-proxy/pkg/s0fs/engine.go
@@ -116,11 +116,20 @@ func Open(ctx context.Context, cfg Config) (*Engine, error) {
 		e.lastCommittedManifest = latestManifest.ManifestSeq
 	}
 
+	appliedRecords := 0
 	for _, record := range records {
+		if record.Seq < e.nextSeq {
+			continue
+		}
+		if record.Seq > e.nextSeq {
+			_ = walFile.close()
+			return nil, fmt.Errorf("replay wal seq %d: %w: missing wal seq %d", record.Seq, ErrInvalidInput, e.nextSeq)
+		}
 		if err := e.apply(record); err != nil {
 			_ = walFile.close()
 			return nil, fmt.Errorf("replay wal seq %d: %w", record.Seq, err)
 		}
+		appliedRecords++
 		if record.Seq >= e.nextSeq {
 			e.nextSeq = record.Seq + 1
 		}
@@ -129,7 +138,7 @@ func Open(ctx context.Context, cfg Config) (*Engine, error) {
 		}
 	}
 	e.collectUnlinkedLocked()
-	if len(records) > 0 {
+	if appliedRecords > 0 {
 		e.dirty = true
 		e.dirtyAt = time.Now().UTC()
 		e.mutationVersion = 1

--- a/storage-proxy/pkg/s0fs/engine.go
+++ b/storage-proxy/pkg/s0fs/engine.go
@@ -520,6 +520,15 @@ func (e *Engine) SnapshotState() *SnapshotState {
 	return cloneState(e.currentStateLocked())
 }
 
+// SnapshotReferenceState returns a metadata snapshot for retaining live object
+// references during GC. Inline payload bytes may be shared with the engine and
+// must be treated as read-only by callers.
+func (e *Engine) SnapshotReferenceState() *SnapshotState {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return cloneStateForMaterialization(e.currentStateLocked())
+}
+
 func (e *Engine) ExportState() (*SnapshotState, error) {
 	e.mu.RLock()
 	defer e.mu.RUnlock()

--- a/storage-proxy/pkg/s0fs/engine_test.go
+++ b/storage-proxy/pkg/s0fs/engine_test.go
@@ -48,6 +48,83 @@ func TestEngineSmallFileReadWriteReplay(t *testing.T) {
 	}
 }
 
+func TestEngineWriteCopiesCallerBufferBeforeReturn(t *testing.T) {
+	walPath := filepath.Join(t.TempDir(), "volume.wal")
+
+	engine, err := Open(context.Background(), Config{VolumeID: "vol-1", WALPath: walPath})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	node, err := engine.CreateFile(RootInode, "data.txt", 0o644)
+	if err != nil {
+		t.Fatalf("CreateFile() error = %v", err)
+	}
+	payload := []byte("stable")
+	if _, err := engine.Write(node.Inode, 0, payload); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	copy(payload, "mutate")
+	data, err := engine.Read(node.Inode, 0, 16)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if !bytes.Equal(data, []byte("stable")) {
+		t.Fatalf("read data = %q, want stable", data)
+	}
+	if err := engine.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	replayed, err := Open(context.Background(), Config{VolumeID: "vol-1", WALPath: walPath})
+	if err != nil {
+		t.Fatalf("Open(replay) error = %v", err)
+	}
+	defer replayed.Close()
+	replayedNode, err := replayed.Lookup(RootInode, "data.txt")
+	if err != nil {
+		t.Fatalf("Lookup() after replay error = %v", err)
+	}
+	replayedData, err := replayed.Read(replayedNode.Inode, 0, 16)
+	if err != nil {
+		t.Fatalf("Read() after replay error = %v", err)
+	}
+	if !bytes.Equal(replayedData, []byte("stable")) {
+		t.Fatalf("replayed data = %q, want stable", replayedData)
+	}
+}
+
+func TestEngineCreateFileWithOwnerReplay(t *testing.T) {
+	walPath := filepath.Join(t.TempDir(), "volume.wal")
+
+	engine, err := Open(context.Background(), Config{VolumeID: "vol-1", WALPath: walPath})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	node, err := engine.CreateFileWithOwner(RootInode, "owned.txt", 0o640, 1000, 2000)
+	if err != nil {
+		t.Fatalf("CreateFileWithOwner() error = %v", err)
+	}
+	if node.UID != 1000 || node.GID != 2000 {
+		t.Fatalf("created node owner = %d:%d, want 1000:2000", node.UID, node.GID)
+	}
+	if err := engine.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	replayed, err := Open(context.Background(), Config{VolumeID: "vol-1", WALPath: walPath})
+	if err != nil {
+		t.Fatalf("Open(replay) error = %v", err)
+	}
+	defer replayed.Close()
+	replayedNode, err := replayed.Lookup(RootInode, "owned.txt")
+	if err != nil {
+		t.Fatalf("Lookup() after replay error = %v", err)
+	}
+	if replayedNode.Mode != 0o640 || replayedNode.UID != 1000 || replayedNode.GID != 2000 {
+		t.Fatalf("replayed node = %+v, want mode 0640 owner 1000:2000", replayedNode)
+	}
+}
+
 func TestEngineLocalDiskGuardRejectsProjectedCacheGrowth(t *testing.T) {
 	dir := t.TempDir()
 	engine, err := Open(context.Background(), Config{

--- a/storage-proxy/pkg/s0fs/engine_test.go
+++ b/storage-proxy/pkg/s0fs/engine_test.go
@@ -48,6 +48,57 @@ func TestEngineSmallFileReadWriteReplay(t *testing.T) {
 	}
 }
 
+func TestEngineSnapshotReferenceStateSharesInlinePayload(t *testing.T) {
+	engine, err := Open(context.Background(), Config{
+		VolumeID:    "vol-1",
+		WALPath:     filepath.Join(t.TempDir(), "volume.wal"),
+		ObjectStore: newPrefixedRecordingStore(t, "vol-1"),
+		HeadStore:   newMemoryHeadStore(),
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer engine.Close()
+
+	node, err := engine.CreateFile(RootInode, "payload.txt", 0o644)
+	if err != nil {
+		t.Fatalf("CreateFile() error = %v", err)
+	}
+	if _, err := engine.Write(node.Inode, 0, []byte("payload")); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	var segmentID string
+	for id, segment := range engine.segments {
+		if len(segment.InlineData) > 0 {
+			segmentID = id
+			break
+		}
+	}
+	if segmentID == "" {
+		t.Fatal("engine did not retain an inline segment")
+	}
+	engineSegment := engine.segments[segmentID]
+
+	full := engine.SnapshotState()
+	fullSegment := full.Segments[segmentID]
+	if fullSegment == nil || len(fullSegment.InlineData) == 0 {
+		t.Fatalf("SnapshotState() missing inline segment %s", segmentID)
+	}
+	if &fullSegment.InlineData[0] == &engineSegment.InlineData[0] {
+		t.Fatal("SnapshotState() shared inline payload with engine")
+	}
+
+	references := engine.SnapshotReferenceState()
+	referenceSegment := references.Segments[segmentID]
+	if referenceSegment == nil || len(referenceSegment.InlineData) == 0 {
+		t.Fatalf("SnapshotReferenceState() missing inline segment %s", segmentID)
+	}
+	if &referenceSegment.InlineData[0] != &engineSegment.InlineData[0] {
+		t.Fatal("SnapshotReferenceState() copied inline payload")
+	}
+}
+
 func TestEngineWriteCopiesCallerBufferBeforeReturn(t *testing.T) {
 	walPath := filepath.Join(t.TempDir(), "volume.wal")
 

--- a/storage-proxy/pkg/s0fs/materializer.go
+++ b/storage-proxy/pkg/s0fs/materializer.go
@@ -652,7 +652,9 @@ func (c *segmentCache) put(key string, payload []byte) {
 	} else {
 		c.order = append(c.order, key)
 	}
-	c.entries[key] = append([]byte(nil), payload...)
+	// The cache takes ownership of payload. ReadSegmentRange returns cloned
+	// ranges to callers, so cached segment bytes remain immutable after put.
+	c.entries[key] = payload
 	c.size += int64(len(payload))
 
 	for c.size > c.maxBytes && len(c.order) > 0 {

--- a/storage-proxy/pkg/s0fs/materializer.go
+++ b/storage-proxy/pkg/s0fs/materializer.go
@@ -103,7 +103,7 @@ func (m *Materializer) Materialize(ctx context.Context, state *SnapshotState, ex
 		return nil, fmt.Errorf("%w: snapshot state is required", ErrInvalidInput)
 	}
 
-	inline := cloneState(state)
+	inline := cloneStateForMaterialization(state)
 	normalizeState(inline)
 	defaultSegmentVolumeIDs(inline, m.volumeID)
 	if inline.NextSeq <= 1 {
@@ -698,4 +698,25 @@ func cloneSegment(segment *Segment) *Segment {
 	}
 	copy.InlineData = append([]byte(nil), segment.InlineData...)
 	return &copy
+}
+
+func cloneSegmentForMaterialization(segment *Segment) *Segment {
+	if segment == nil {
+		return nil
+	}
+	clone := *segment
+	if segment.Encryption != nil {
+		enc := *segment.Encryption
+		enc.WrappedKey = append([]byte(nil), segment.Encryption.WrappedKey...)
+		enc.NoncePrefix = append([]byte(nil), segment.Encryption.NoncePrefix...)
+		clone.Encryption = &enc
+	}
+	if isInlineSegment(segment) {
+		// Inline segment payloads are immutable after creation; materialization
+		// snapshots can share the backing bytes while the engine lock is released.
+		clone.InlineData = segment.InlineData
+	} else {
+		clone.InlineData = append([]byte(nil), segment.InlineData...)
+	}
+	return &clone
 }

--- a/storage-proxy/pkg/s0fs/materializer.go
+++ b/storage-proxy/pkg/s0fs/materializer.go
@@ -460,6 +460,7 @@ func (b *segmentBuilder) ensureCurrent() *materializedSegment {
 		ID:       segmentID,
 		VolumeID: b.volumeID,
 		Key:      fmt.Sprintf("%s/%s.bin", segmentDir, segmentID),
+		Payload:  make([]byte, 0, int(b.targetSize)),
 	}
 	b.segments = append(b.segments, b.current)
 	return b.current

--- a/storage-proxy/pkg/s0fs/materializer_test.go
+++ b/storage-proxy/pkg/s0fs/materializer_test.go
@@ -224,6 +224,44 @@ func TestEngineMaterializeRecoversViaColdRangeRead(t *testing.T) {
 	}
 }
 
+func TestCloneStateForMaterializationSharesOnlyInlinePayload(t *testing.T) {
+	state := &SnapshotState{
+		NextSeq:   2,
+		NextInode: 3,
+		Nodes: map[uint64]*Node{
+			RootInode: {Inode: RootInode, Type: TypeDirectory, Mode: 0o755, Nlink: 1},
+		},
+		Children: map[uint64]map[string]uint64{
+			RootInode: {},
+		},
+		Segments: map[string]*Segment{
+			"inline": {
+				ID:         "inline",
+				Length:     3,
+				InlineData: []byte("abc"),
+			},
+		},
+	}
+
+	regular := cloneState(state)
+	if &regular.Segments["inline"].InlineData[0] == &state.Segments["inline"].InlineData[0] {
+		t.Fatal("cloneState shared inline payload, want deep copy")
+	}
+	regular.Segments["inline"].InlineData[0] = 'z'
+	if got := string(state.Segments["inline"].InlineData); got != "abc" {
+		t.Fatalf("mutating regular clone changed original payload to %q", got)
+	}
+
+	materialized := cloneStateForMaterialization(state)
+	if &materialized.Segments["inline"].InlineData[0] != &state.Segments["inline"].InlineData[0] {
+		t.Fatal("cloneStateForMaterialization deep-copied inline payload, want shared immutable payload")
+	}
+	materialized.Segments["inline"].ID = "changed"
+	if got := state.Segments["inline"].ID; got != "inline" {
+		t.Fatalf("mutating materialization segment metadata changed original ID to %q", got)
+	}
+}
+
 func TestEngineBulkSmallFilesWithFrequentMaterialize(t *testing.T) {
 	ctx := context.Background()
 	store := newPrefixedRecordingStore(t, "vol-bulk")

--- a/storage-proxy/pkg/s0fs/snapshot.go
+++ b/storage-proxy/pkg/s0fs/snapshot.go
@@ -140,6 +140,14 @@ func normalizeState(state *SnapshotState) {
 }
 
 func cloneState(state *SnapshotState) *SnapshotState {
+	return cloneStateWithSegmentCloner(state, cloneSegment)
+}
+
+func cloneStateForMaterialization(state *SnapshotState) *SnapshotState {
+	return cloneStateWithSegmentCloner(state, cloneSegmentForMaterialization)
+}
+
+func cloneStateWithSegmentCloner(state *SnapshotState, cloneSegmentFn func(*Segment) *Segment) *SnapshotState {
 	if state == nil {
 		return nil
 	}
@@ -169,8 +177,11 @@ func cloneState(state *SnapshotState) *SnapshotState {
 	for inode, extents := range state.ColdFiles {
 		clone.ColdFiles[inode] = slices.Clone(extents)
 	}
+	if cloneSegmentFn == nil {
+		cloneSegmentFn = cloneSegment
+	}
 	for segmentID, segment := range state.Segments {
-		clone.Segments[segmentID] = cloneSegment(segment)
+		clone.Segments[segmentID] = cloneSegmentFn(segment)
 	}
 	return clone
 }

--- a/storage-proxy/pkg/s0fs/types.go
+++ b/storage-proxy/pkg/s0fs/types.go
@@ -77,6 +77,11 @@ type DirEntry struct {
 	Type  FileType
 }
 
+type CreateOptions struct {
+	UID uint32
+	GID uint32
+}
+
 func cloneNode(node *Node) *Node {
 	if node == nil {
 		return nil
@@ -95,6 +100,8 @@ type walRecord struct {
 	NewName   string   `json:"new_name,omitempty"`
 	Type      FileType `json:"type,omitempty"`
 	Mode      uint32   `json:"mode,omitempty"`
+	UID       uint32   `json:"uid,omitempty"`
+	GID       uint32   `json:"gid,omitempty"`
 	Offset    uint64   `json:"offset,omitempty"`
 	Data      []byte   `json:"data,omitempty"`
 	Target    string   `json:"target,omitempty"`

--- a/storage-proxy/pkg/s0fs/wal.go
+++ b/storage-proxy/pkg/s0fs/wal.go
@@ -16,6 +16,8 @@ type wal struct {
 	volumeID   string
 	encryption *EncryptionConfig
 	onSync     func()
+	writeGen   uint64
+	syncedGen  uint64
 }
 
 func openWAL(path, volumeID string, encryption *EncryptionConfig, onSync func()) (*wal, []walRecord, error) {
@@ -91,6 +93,7 @@ func (w *wal) append(record walRecord) error {
 	if _, err := w.file.Write(payload); err != nil {
 		return fmt.Errorf("append wal record: %w", err)
 	}
+	w.writeGen++
 	return nil
 }
 
@@ -98,9 +101,13 @@ func (w *wal) sync() error {
 	if w == nil || w.file == nil {
 		return ErrClosed
 	}
+	if w.syncedGen == w.writeGen {
+		return nil
+	}
 	if err := w.file.Sync(); err != nil {
 		return fmt.Errorf("sync wal: %w", err)
 	}
+	w.syncedGen = w.writeGen
 	if w.onSync != nil {
 		w.onSync()
 	}
@@ -130,5 +137,7 @@ func (w *wal) reset() error {
 		return fmt.Errorf("reset wal: %w", err)
 	}
 	w.file = file
+	w.writeGen = 0
+	w.syncedGen = 0
 	return nil
 }

--- a/storage-proxy/pkg/s0fs/wal.go
+++ b/storage-proxy/pkg/s0fs/wal.go
@@ -55,6 +55,9 @@ func readWAL(path, volumeID string, encryption *EncryptionConfig) ([]walRecord, 
 	for {
 		line, err := reader.ReadBytes('\n')
 		if len(line) > 0 {
+			if errors.Is(err, io.EOF) && line[len(line)-1] != '\n' {
+				return records, nil
+			}
 			payload := line
 			if plaintext, encrypted, err := encryption.decryptBlobIfEncrypted(line, walRecordAAD(volumeID)); encrypted || err != nil {
 				if err != nil {

--- a/storage-proxy/pkg/s0fs/wal_replay_test.go
+++ b/storage-proxy/pkg/s0fs/wal_replay_test.go
@@ -1,0 +1,152 @@
+package s0fs
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestOpenSkipsWALRecordsOlderThanHead(t *testing.T) {
+	walPath, inode := createHeadWithFile(t, "base")
+	appendPlainWALRecords(t, walPath,
+		walRecord{Seq: 1, Op: "create", Inode: inode, Parent: RootInode, Name: "data.txt", Type: TypeFile, Mode: 0o644, TimeUnix: time.Now().UnixNano()},
+		walRecord{Seq: 2, Op: "write", Inode: inode, Offset: 0, Data: []byte("stale"), TimeUnix: time.Now().UnixNano()},
+	)
+
+	engine, err := Open(context.Background(), Config{VolumeID: "vol-1", WALPath: walPath})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer engine.Close()
+
+	node, err := engine.Lookup(RootInode, "data.txt")
+	if err != nil {
+		t.Fatalf("Lookup() error = %v", err)
+	}
+	data, err := engine.Read(node.Inode, 0, 16)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if !bytes.Equal(data, []byte("base")) {
+		t.Fatalf("data = %q, want base", data)
+	}
+	if engine.dirty {
+		t.Fatal("engine dirty after replaying only stale WAL records")
+	}
+}
+
+func TestOpenAppliesWALSuffixNewerThanHead(t *testing.T) {
+	walPath, inode := createHeadWithFile(t, "base")
+	appendPlainWALRecords(t, walPath,
+		walRecord{Seq: 1, Op: "create", Inode: inode, Parent: RootInode, Name: "data.txt", Type: TypeFile, Mode: 0o644, TimeUnix: time.Now().UnixNano()},
+		walRecord{Seq: 2, Op: "write", Inode: inode, Offset: 0, Data: []byte("stale"), TimeUnix: time.Now().UnixNano()},
+		walRecord{Seq: 3, Op: "write", Inode: inode, Offset: 4, Data: []byte("++"), TimeUnix: time.Now().UnixNano()},
+	)
+
+	engine, err := Open(context.Background(), Config{VolumeID: "vol-1", WALPath: walPath})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer engine.Close()
+
+	node, err := engine.Lookup(RootInode, "data.txt")
+	if err != nil {
+		t.Fatalf("Lookup() error = %v", err)
+	}
+	data, err := engine.Read(node.Inode, 0, 16)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if !bytes.Equal(data, []byte("base++")) {
+		t.Fatalf("data = %q, want base++", data)
+	}
+	if !engine.dirty {
+		t.Fatal("engine not dirty after applying WAL suffix")
+	}
+}
+
+func TestOpenRejectsWALGapAfterHead(t *testing.T) {
+	walPath, inode := createHeadWithFile(t, "base")
+	appendPlainWALRecords(t, walPath,
+		walRecord{Seq: 4, Op: "write", Inode: inode, Offset: 4, Data: []byte("gap"), TimeUnix: time.Now().UnixNano()},
+	)
+
+	if _, err := Open(context.Background(), Config{VolumeID: "vol-1", WALPath: walPath}); !errors.Is(err, ErrInvalidInput) {
+		t.Fatalf("Open() error = %v, want ErrInvalidInput", err)
+	}
+}
+
+func TestOpenIgnoresPartialWALTail(t *testing.T) {
+	walPath := filepath.Join(t.TempDir(), "volume.wal")
+	appendPlainWALRecords(t, walPath,
+		walRecord{Seq: 1, Op: "create", Inode: RootInode + 1, Parent: RootInode, Name: "data.txt", Type: TypeFile, Mode: 0o644, TimeUnix: time.Now().UnixNano()},
+	)
+	appendPlainWALTail(t, walPath, []byte(`{"seq":2,"op":"create"`))
+
+	engine, err := Open(context.Background(), Config{VolumeID: "vol-1", WALPath: walPath})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer engine.Close()
+
+	if _, err := engine.Lookup(RootInode, "data.txt"); err != nil {
+		t.Fatalf("Lookup() error = %v", err)
+	}
+	if _, err := engine.Lookup(RootInode, "partial.txt"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Lookup(partial) error = %v, want ErrNotFound", err)
+	}
+}
+
+func createHeadWithFile(t *testing.T, payload string) (string, uint64) {
+	t.Helper()
+
+	walPath := filepath.Join(t.TempDir(), "volume.wal")
+	engine, err := Open(context.Background(), Config{VolumeID: "vol-1", WALPath: walPath})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	node, err := engine.CreateFile(RootInode, "data.txt", 0o644)
+	if err != nil {
+		t.Fatalf("CreateFile() error = %v", err)
+	}
+	if _, err := engine.Write(node.Inode, 0, []byte(payload)); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	if err := engine.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	return walPath, node.Inode
+}
+
+func appendPlainWALRecords(t *testing.T, walPath string, records ...walRecord) {
+	t.Helper()
+
+	var payload []byte
+	for _, record := range records {
+		line, err := json.Marshal(record)
+		if err != nil {
+			t.Fatalf("marshal WAL record: %v", err)
+		}
+		payload = append(payload, line...)
+		payload = append(payload, '\n')
+	}
+	appendPlainWALTail(t, walPath, payload)
+}
+
+func appendPlainWALTail(t *testing.T, walPath string, payload []byte) {
+	t.Helper()
+
+	file, err := os.OpenFile(walPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatalf("open WAL: %v", err)
+	}
+	defer file.Close()
+	if _, err := file.Write(payload); err != nil {
+		t.Fatalf("append WAL payload: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- reduce active S0FS write-path allocations by avoiding duplicate WAL payload cloning and duplicate FUSE path construction
- harden WAL replay around committed heads, sequence gaps, and partial WAL tails
- avoid an extra full payload copy when inserting materialized segments into the segment cache
- add optional/default-off ctld pprof flags for remote performance profiling

Fixes part of #618.

## Validation

Local tests:

- `go test ./storage-proxy/pkg/s0fs`
- `go test ./storage-proxy/pkg/fsserver ./pkg/volumefuse/... ./ctld/internal/ctld/portal/... ./ctld/cmd/ctld`
- `git diff --check`

Remote benchmark environment:

- persistent Aliyun Singapore ECS kind environment
- workload: `scripts/volume_mount_bench.py --local-root /root --file-count 5000 --file-size 17476 --parallelism 32 --files-per-dir 128 --rounds 1`
- ctld pprof enabled with `-pprof-addr=:6060`, block profile rate `1`, mutex profile fraction `1`

Baseline Phase 3 artifact: `/tmp/s0fs-pprof-phase3-5k-20260627-183735`

- S0FS write: `461.11 ops/s`, `p95 170.56 ms`, `p99 318.70 ms`, total `10.84s`
- active ctld heap alloc: `3735 MiB`

Final cache optimization artifacts:

- `/tmp/s0fs-pprof-iter5-cache-r1-5k-20260627-193644`
- `/tmp/s0fs-pprof-iter5-cache-r2-5k-20260627-193746`

Final R2 result:

- S0FS write: `487.09 ops/s`, `p95 155.56 ms`, `p99 284.76 ms`, total `10.27s`
- single-run active ctld heap alloc in R1: `3285.23 MiB`; `segmentCache.put` no longer appears as a large allocation bucket

I also tested and discarded an attempted atomic/fsync checkpoint path because it regressed write throughput and allocation. Details are in #618.