### PR TITLE
Optimize S0FS WAL sync locking

### DIFF
--- a/ctld/cmd/ctld/main.go
+++ b/ctld/cmd/ctld/main.go
@@ -7,11 +7,9 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"syscall"
 	"time"
@@ -52,9 +50,6 @@ var (
 	rootFSObjectCacheSweepInterval = time.Minute
 	podName                        = os.Getenv("POD_NAME")
 	podNamespace                   = os.Getenv("POD_NAMESPACE")
-	pprofAddr                      = ""
-	pprofBlockProfileRate          = 0
-	pprofMutexFraction             = 0
 )
 
 func main() {
@@ -74,9 +69,6 @@ func main() {
 	flag.StringVar(&rootFSObjectCacheMinFreeBytes, "rootfs-object-cache-min-free-bytes", "0", "minimum free bytes to preserve on the rootfs object cache filesystem")
 	flag.DurationVar(&rootFSObjectCacheMaxAge, "rootfs-object-cache-max-age", 0, "maximum age for node-local rootfs cache objects; 0 disables age-based eviction")
 	flag.DurationVar(&rootFSObjectCacheSweepInterval, "rootfs-object-cache-sweep-interval", time.Minute, "interval for node-local rootfs object cache garbage collection")
-	flag.StringVar(&pprofAddr, "pprof-addr", "", "optional pprof listen address; disabled when empty")
-	flag.IntVar(&pprofBlockProfileRate, "pprof-block-profile-rate", 0, "runtime.SetBlockProfileRate value used when pprof is enabled")
-	flag.IntVar(&pprofMutexFraction, "pprof-mutex-profile-fraction", 0, "runtime.SetMutexProfileFraction value used when pprof is enabled")
 	flag.Parse()
 
 	log.Println("Starting ctld")
@@ -84,14 +76,6 @@ func main() {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	pprofServer := startPprofServer()
-	if pprofServer != nil {
-		defer func() {
-			shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
-			_ = pprofServer.Shutdown(shutdownCtx)
-			shutdownCancel()
-		}()
-	}
 
 	zapLogger, err := observability.NewLogger(observability.LoggerConfig{
 		ServiceName: "ctld",
@@ -166,30 +150,6 @@ func main() {
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	_ = httpServer.Shutdown(shutdownCtx)
 	shutdownCancel()
-}
-
-func startPprofServer() *http.Server {
-	if strings.TrimSpace(pprofAddr) == "" {
-		return nil
-	}
-	if pprofBlockProfileRate > 0 {
-		runtime.SetBlockProfileRate(pprofBlockProfileRate)
-	}
-	if pprofMutexFraction > 0 {
-		runtime.SetMutexProfileFraction(pprofMutexFraction)
-	}
-	server := &http.Server{
-		Addr:              pprofAddr,
-		Handler:           http.DefaultServeMux,
-		ReadHeaderTimeout: 5 * time.Second,
-	}
-	go func() {
-		log.Printf("Starting ctld pprof server on %s", pprofAddr)
-		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			log.Fatalf("ctld pprof server failed: %v", err)
-		}
-	}()
-	return server
 }
 
 func newHTTPServer(addr string, controller ctldserver.Controller) *http.Server {

--- a/storage-proxy/pkg/s0fs/engine.go
+++ b/storage-proxy/pkg/s0fs/engine.go
@@ -13,6 +13,7 @@ import (
 
 type Engine struct {
 	mu            sync.RWMutex
+	mutationMu    sync.Mutex
 	materializeMu sync.Mutex
 	volumeID      string
 	wal           *wal
@@ -148,6 +149,9 @@ func Open(ctx context.Context, cfg Config) (*Engine, error) {
 }
 
 func (e *Engine) Close() error {
+	e.mutationMu.Lock()
+	defer e.mutationMu.Unlock()
+
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	if e.closed {
@@ -263,6 +267,9 @@ func (e *Engine) Symlink(parent uint64, name, target string, mode uint32) (*Node
 }
 
 func (e *Engine) Link(inode uint64, newParent uint64, newName string) (*Node, error) {
+	e.mutationMu.Lock()
+	defer e.mutationMu.Unlock()
+
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	if err := e.checkOpen(); err != nil {
@@ -295,13 +302,17 @@ func (e *Engine) Link(inode uint64, newParent uint64, newName string) (*Node, er
 }
 
 func (e *Engine) Write(inode uint64, offset uint64, payload []byte) (int, error) {
+	e.mutationMu.Lock()
+	defer e.mutationMu.Unlock()
+
 	e.mu.Lock()
-	defer e.mu.Unlock()
 	if err := e.checkOpen(); err != nil {
+		e.mu.Unlock()
 		return 0, err
 	}
 	node, err := e.fileNodeLocked(inode)
 	if err != nil {
+		e.mu.Unlock()
 		return 0, err
 	}
 	record := e.newRecord("write")
@@ -313,7 +324,23 @@ func (e *Engine) Write(inode uint64, offset uint64, payload []byte) (int, error)
 	if end > node.Size {
 		projectedBytes += int64(end - node.Size)
 	}
-	if err := e.appendAndApplyLocked(record, projectedBytes); err != nil {
+	if err := e.reserveLocalDiskLocked(projectedBytes); err != nil {
+		e.mu.Unlock()
+		return 0, err
+	}
+	e.mu.Unlock()
+
+	walPayload, err := e.wal.prepare(record)
+	if err != nil {
+		return 0, err
+	}
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if err := e.checkOpen(); err != nil {
+		return 0, err
+	}
+	if err := e.appendPreparedAndApplyLocked(record, walPayload); err != nil {
 		return 0, err
 	}
 	return len(payload), nil
@@ -346,6 +373,9 @@ func (e *Engine) ReadInto(inode uint64, offset uint64, dest []byte) (int, error)
 }
 
 func (e *Engine) Rename(oldParent uint64, oldName string, newParent uint64, newName string) error {
+	e.mutationMu.Lock()
+	defer e.mutationMu.Unlock()
+
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	if err := e.checkOpen(); err != nil {
@@ -378,6 +408,9 @@ func (e *Engine) Unlink(parent uint64, name string) error {
 
 // UnlinkWithInode removes a file entry and returns the inode that was unlinked.
 func (e *Engine) UnlinkWithInode(parent uint64, name string) (uint64, error) {
+	e.mutationMu.Lock()
+	defer e.mutationMu.Unlock()
+
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	if err := e.checkOpen(); err != nil {
@@ -401,6 +434,9 @@ func (e *Engine) UnlinkWithInode(parent uint64, name string) (uint64, error) {
 }
 
 func (e *Engine) Forget(inode uint64) error {
+	e.mutationMu.Lock()
+	defer e.mutationMu.Unlock()
+
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	if err := e.checkOpen(); err != nil {
@@ -417,6 +453,9 @@ func (e *Engine) Forget(inode uint64) error {
 }
 
 func (e *Engine) RemoveDir(parent uint64, name string) error {
+	e.mutationMu.Lock()
+	defer e.mutationMu.Unlock()
+
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	if err := e.checkOpen(); err != nil {
@@ -446,6 +485,9 @@ func (e *Engine) RemoveDir(parent uint64, name string) error {
 }
 
 func (e *Engine) SetMode(inode uint64, mode uint32) error {
+	e.mutationMu.Lock()
+	defer e.mutationMu.Unlock()
+
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	if err := e.checkOpen(); err != nil {
@@ -464,6 +506,9 @@ func (e *Engine) SetMode(inode uint64, mode uint32) error {
 }
 
 func (e *Engine) SetOwner(inode uint64, uid, gid uint32) error {
+	e.mutationMu.Lock()
+	defer e.mutationMu.Unlock()
+
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	if err := e.checkOpen(); err != nil {
@@ -483,6 +528,9 @@ func (e *Engine) SetOwner(inode uint64, uid, gid uint32) error {
 }
 
 func (e *Engine) Truncate(inode uint64, size uint64) error {
+	e.mutationMu.Lock()
+	defer e.mutationMu.Unlock()
+
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	if err := e.checkOpen(); err != nil {
@@ -507,11 +555,16 @@ func (e *Engine) Truncate(inode uint64, size uint64) error {
 
 func (e *Engine) Fsync(_ uint64) error {
 	e.mu.RLock()
-	defer e.mu.RUnlock()
 	if err := e.checkOpen(); err != nil {
+		e.mu.RUnlock()
 		return err
 	}
-	return e.wal.sync()
+	wait, err := e.wal.beginSyncCurrent()
+	e.mu.RUnlock()
+	if err != nil || wait == nil {
+		return err
+	}
+	return wait()
 }
 
 func (e *Engine) SnapshotState() *SnapshotState {
@@ -575,6 +628,9 @@ func (e *Engine) syncMaterialize(ctx context.Context, force bool) (*Manifest, er
 		return manifest, err
 	}
 
+	e.mutationMu.Lock()
+	defer e.mutationMu.Unlock()
+
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	if e.mutationVersion == version && e.lastCommittedManifest == expectedManifestSeq {
@@ -621,6 +677,9 @@ func (e *Engine) RefreshMaterialized(ctx context.Context) (bool, error) {
 		return false, nil
 	}
 
+	e.mutationMu.Lock()
+	defer e.mutationMu.Unlock()
+
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	if err := e.checkOpen(); err != nil {
@@ -664,6 +723,9 @@ func (e *Engine) CreateSnapshot(snapshotID string) (*SnapshotState, error) {
 }
 
 func (e *Engine) RestoreSnapshot(snapshotID string) error {
+	e.mutationMu.Lock()
+	defer e.mutationMu.Unlock()
+
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	if err := e.checkOpen(); err != nil {
@@ -696,6 +758,9 @@ func (e *Engine) RestoreSnapshot(snapshotID string) error {
 }
 
 func (e *Engine) ReplaceState(state *SnapshotState) error {
+	e.mutationMu.Lock()
+	defer e.mutationMu.Unlock()
+
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	if err := e.checkOpen(); err != nil {
@@ -736,18 +801,24 @@ func (e *Engine) DeleteSnapshot(snapshotID string) error {
 }
 
 func (e *Engine) create(parent uint64, name string, typ FileType, mode uint32, target string, opts CreateOptions) (*Node, error) {
+	e.mutationMu.Lock()
+	defer e.mutationMu.Unlock()
+
 	e.mu.Lock()
-	defer e.mu.Unlock()
 	if err := e.checkOpen(); err != nil {
+		e.mu.Unlock()
 		return nil, err
 	}
 	if name == "" {
+		e.mu.Unlock()
 		return nil, fmt.Errorf("%w: empty name", ErrInvalidInput)
 	}
 	if err := e.ensureDirLocked(parent); err != nil {
+		e.mu.Unlock()
 		return nil, err
 	}
 	if _, exists := e.children[parent][name]; exists {
+		e.mu.Unlock()
 		return nil, ErrExists
 	}
 
@@ -760,34 +831,63 @@ func (e *Engine) create(parent uint64, name string, typ FileType, mode uint32, t
 	record.UID = opts.UID
 	record.GID = opts.GID
 	record.Target = target
-	if err := e.appendAndApplyLocked(record, estimatedWALRecordBytes(record)); err != nil {
+	if err := e.reserveLocalDiskLocked(estimatedWALRecordBytes(record)); err != nil {
+		e.mu.Unlock()
+		return nil, err
+	}
+	e.mu.Unlock()
+
+	walPayload, err := e.wal.prepare(record)
+	if err != nil {
+		return nil, err
+	}
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if err := e.checkOpen(); err != nil {
+		return nil, err
+	}
+	if err := e.appendPreparedAndApplyLocked(record, walPayload); err != nil {
 		return nil, err
 	}
 	return cloneNode(e.nodes[record.Inode]), nil
 }
 
 func (e *Engine) newRecord(op string) walRecord {
-	record := walRecord{
+	return walRecord{
 		Seq:      e.nextSeq,
 		Op:       op,
 		TimeUnix: time.Now().UTC().UnixNano(),
 	}
-	e.nextSeq++
-	return record
 }
 
 func (e *Engine) appendAndApplyLocked(record walRecord, projectedBytes int64) error {
 	if err := e.reserveLocalDiskLocked(projectedBytes); err != nil {
 		return err
 	}
-	if err := e.wal.append(record); err != nil {
+	walPayload, err := e.wal.prepare(record)
+	if err != nil {
+		return err
+	}
+	return e.appendPreparedAndApplyLocked(record, walPayload)
+}
+
+func (e *Engine) appendPreparedAndApplyLocked(record walRecord, walPayload []byte) error {
+	if err := e.wal.appendPrepared(walPayload); err != nil {
 		return err
 	}
 	if err := e.apply(record); err != nil {
 		return err
 	}
+	e.advanceSeqLocked(record)
 	e.markDirtyLocked()
 	return nil
+}
+
+func (e *Engine) advanceSeqLocked(record walRecord) {
+	if record.Seq >= e.nextSeq {
+		e.nextSeq = record.Seq + 1
+	}
 }
 
 func (e *Engine) reserveLocalDiskLocked(projectedBytes int64) error {

--- a/storage-proxy/pkg/s0fs/engine_test.go
+++ b/storage-proxy/pkg/s0fs/engine_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
+	"sync"
+	"sync/atomic"
 	"testing"
 )
 
@@ -45,6 +47,54 @@ func TestEngineSmallFileReadWriteReplay(t *testing.T) {
 	}
 	if !bytes.Equal(data, []byte("hello")) {
 		t.Fatalf("replayed data = %q, want hello", data)
+	}
+}
+
+func TestEngineConcurrentFsyncCoalescesWALSync(t *testing.T) {
+	var syncs atomic.Int64
+	engine, err := Open(context.Background(), Config{
+		VolumeID: "vol-1",
+		WALPath:  filepath.Join(t.TempDir(), "volume.wal"),
+		WALSyncHook: func() {
+			syncs.Add(1)
+		},
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer engine.Close()
+
+	node, err := engine.CreateFile(RootInode, "data.txt", 0o644)
+	if err != nil {
+		t.Fatalf("CreateFile() error = %v", err)
+	}
+	if _, err := engine.Write(node.Inode, 0, []byte("payload")); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	const callers = 16
+	start := make(chan struct{})
+	errs := make(chan error, callers)
+	var wg sync.WaitGroup
+	wg.Add(callers)
+	for range callers {
+		go func() {
+			defer wg.Done()
+			<-start
+			errs <- engine.Fsync(node.Inode)
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("Fsync() error = %v", err)
+		}
+	}
+	if got := syncs.Load(); got != 1 {
+		t.Fatalf("WAL sync count = %d, want 1", got)
 	}
 }
 

--- a/storage-proxy/pkg/s0fs/wal.go
+++ b/storage-proxy/pkg/s0fs/wal.go
@@ -8,16 +8,23 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sync"
+	"time"
 )
+
+const walSyncCoalesceDelay = time.Millisecond
 
 type wal struct {
 	path       string
+	mu         sync.Mutex
+	syncCond   *sync.Cond
 	file       *os.File
 	volumeID   string
 	encryption *EncryptionConfig
 	onSync     func()
 	writeGen   uint64
 	syncedGen  uint64
+	syncing    bool
 }
 
 func openWAL(path, volumeID string, encryption *EncryptionConfig, onSync func()) (*wal, []walRecord, error) {
@@ -37,7 +44,9 @@ func openWAL(path, volumeID string, encryption *EncryptionConfig, onSync func())
 	if err != nil {
 		return nil, nil, fmt.Errorf("open wal: %w", err)
 	}
-	return &wal{path: path, file: file, volumeID: volumeID, encryption: encryption, onSync: onSync}, records, nil
+	w := &wal{path: path, file: file, volumeID: volumeID, encryption: encryption, onSync: onSync}
+	w.syncCond = sync.NewCond(&w.mu)
+	return w, records, nil
 }
 
 func readWAL(path, volumeID string, encryption *EncryptionConfig) ([]walRecord, error) {
@@ -80,19 +89,37 @@ func readWAL(path, volumeID string, encryption *EncryptionConfig) ([]walRecord, 
 	}
 }
 
-func (w *wal) append(record walRecord) error {
-	if w == nil || w.file == nil {
-		return ErrClosed
+func (w *wal) prepare(record walRecord) ([]byte, error) {
+	if w == nil {
+		return nil, ErrClosed
+	}
+	w.mu.Lock()
+	closed := w.file == nil
+	w.mu.Unlock()
+	if closed {
+		return nil, ErrClosed
 	}
 	payload, err := json.Marshal(record)
 	if err != nil {
-		return fmt.Errorf("marshal wal record: %w", err)
+		return nil, fmt.Errorf("marshal wal record: %w", err)
 	}
 	payload, err = w.encryption.encryptBlob(payload, walRecordAAD(w.volumeID))
 	if err != nil {
-		return fmt.Errorf("encrypt wal record: %w", err)
+		return nil, fmt.Errorf("encrypt wal record: %w", err)
 	}
 	payload = append(payload, '\n')
+	return payload, nil
+}
+
+func (w *wal) appendPrepared(payload []byte) error {
+	if w == nil {
+		return ErrClosed
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.file == nil {
+		return ErrClosed
+	}
 	if _, err := w.file.Write(payload); err != nil {
 		return fmt.Errorf("append wal record: %w", err)
 	}
@@ -100,25 +127,96 @@ func (w *wal) append(record walRecord) error {
 	return nil
 }
 
-func (w *wal) sync() error {
-	if w == nil || w.file == nil {
+func (w *wal) beginSyncCurrent() (func() error, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.file == nil {
+		return nil, ErrClosed
+	}
+	target := w.writeGen
+	if target <= w.syncedGen {
+		return nil, nil
+	}
+	if w.syncing {
+		return func() error {
+			return w.waitSync(target)
+		}, nil
+	}
+	w.syncing = true
+	return func() error {
+		return w.runSync(target)
+	}, nil
+}
+
+func (w *wal) waitSync(target uint64) error {
+	for {
+		w.mu.Lock()
+		if w.file == nil {
+			w.mu.Unlock()
+			return ErrClosed
+		}
+		if target <= w.syncedGen {
+			w.mu.Unlock()
+			return nil
+		}
+		if !w.syncing {
+			w.syncing = true
+			w.mu.Unlock()
+			return w.runSync(target)
+		}
+		w.syncCond.Wait()
+		w.mu.Unlock()
+	}
+}
+
+func (w *wal) runSync(target uint64) error {
+	if walSyncCoalesceDelay > 0 {
+		time.Sleep(walSyncCoalesceDelay)
+	}
+
+	w.mu.Lock()
+	if w.file == nil {
+		w.syncing = false
+		w.syncCond.Broadcast()
+		w.mu.Unlock()
 		return ErrClosed
 	}
-	if w.syncedGen == w.writeGen {
-		return nil
+	if w.writeGen > target {
+		target = w.writeGen
 	}
-	if err := w.file.Sync(); err != nil {
+	file := w.file
+	w.mu.Unlock()
+
+	err := file.Sync()
+
+	w.mu.Lock()
+	if err == nil && target > w.syncedGen {
+		w.syncedGen = target
+	}
+	w.syncing = false
+	w.syncCond.Broadcast()
+	onSync := w.onSync
+	w.mu.Unlock()
+
+	if err != nil {
 		return fmt.Errorf("sync wal: %w", err)
 	}
-	w.syncedGen = w.writeGen
-	if w.onSync != nil {
-		w.onSync()
+	if onSync != nil {
+		onSync()
 	}
 	return nil
 }
 
 func (w *wal) close() error {
-	if w == nil || w.file == nil {
+	if w == nil {
+		return nil
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for w.syncing {
+		w.syncCond.Wait()
+	}
+	if w.file == nil {
 		return nil
 	}
 	err := w.file.Close()
@@ -129,6 +227,11 @@ func (w *wal) close() error {
 func (w *wal) reset() error {
 	if w == nil {
 		return ErrClosed
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for w.syncing {
+		w.syncCond.Wait()
 	}
 	if w.file != nil {
 		if err := w.file.Close(); err != nil {


### PR DESCRIPTION
## Summary

- move S0FS write/create WAL preparation out of the main engine state lock while preserving per-volume mutation ordering
- coalesce concurrent WAL fsync callers so repeated Flush/Fsync waits share the same disk sync
- remove ctld pprof flags/server from the runtime path to avoid profiling hooks in the performance PR
- add a concurrent Fsync test that verifies WAL sync coalescing keeps durability semantics

## Tests

- `go test ./ctld/cmd/ctld ./storage-proxy/pkg/s0fs ./storage-proxy/pkg/fsserver`
- `go test -race ./storage-proxy/pkg/s0fs`

## Notes

A remote 5k-file benchmark was used during development to confirm the lock-contention direction. I will add the larger issue609 500MiB/30k-small-file correctness and performance result separately after running it on the remote kind environment.