### PR TITLE
Check team-owned resources before deleting teams

### DIFF
--- a/cluster-gateway/pkg/http/server.go
+++ b/cluster-gateway/pkg/http/server.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/public"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/ratelimit"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/teamresources"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"github.com/sandbox0-ai/sandbox0/pkg/licensing"
 	"github.com/sandbox0-ai/sandbox0/pkg/metering"
@@ -317,16 +318,21 @@ func (s *Server) setupRoutes() {
 	s.router.GET("/metrics", gin.WrapH(promhttp.Handler()))
 
 	if authModeEnabled(s.cfg.AuthMode, authModePublic) {
+		var teamDeletePreflight gatewayhandlers.TeamDeletePreflight
+		if s.publicIdentityRepo != nil {
+			teamDeletePreflight = teamresources.NewRepository(s.publicIdentityRepo.Pool())
+		}
 		public.RegisterRoutes(s.router, public.Deps{
-			IdentityRepo:    s.publicIdentityRepo,
-			APIKeyRepo:      s.publicAPIKeyRepo,
-			AuthMiddleware:  s.publicAuth,
-			BuiltinProvider: s.publicBuiltin,
-			OIDCManager:     s.publicOIDC,
-			Entitlements:    s.entitlements,
-			JWTIssuer:       s.publicJWT,
-			RegionID:        s.cfg.RegionID,
-			Logger:          s.logger,
+			IdentityRepo:        s.publicIdentityRepo,
+			APIKeyRepo:          s.publicAPIKeyRepo,
+			AuthMiddleware:      s.publicAuth,
+			TeamDeletePreflight: teamDeletePreflight,
+			BuiltinProvider:     s.publicBuiltin,
+			OIDCManager:         s.publicOIDC,
+			Entitlements:        s.entitlements,
+			JWTIssuer:           s.publicJWT,
+			RegionID:            s.cfg.RegionID,
+			Logger:              s.logger,
 		})
 	}
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -288,6 +288,10 @@
         {
           "slug": "configuration",
           "title": "Configuration"
+        },
+        {
+          "slug": "team-deletion",
+          "title": "Team Deletion"
         }
       ]
     }

--- a/docs/self-hosted/team-deletion/page.mdx
+++ b/docs/self-hosted/team-deletion/page.mdx
@@ -1,0 +1,9 @@
+# Team Deletion
+
+Team deletion is conservative. <code>DELETE /teams/{'{id}'}</code> first checks the current region for team-owned resources and returns `409 conflict` when resources still exist.
+
+The conflict response includes `error.details.blocking_resources`, with one entry per category and a count. Clear those resources before retrying team deletion.
+
+Blocking categories include active sandbox records, scheduler templates and allocations, credential sources, egress credential bindings, API keys, team-scoped SSH public keys, sandbox volumes and snapshots, rootfs records, volume handoff state, team quota limits, and discovered non-metering tables with a `team_id` column. Team membership is removed by the final team delete once the preflight passes.
+
+Historical metering records are retained for usage truth and audit. They appear in `error.details.retained_resources` when present, but they do not block team deletion.

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -904,6 +904,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorEnvelope"
+        "409":
+          description: Team has resources that must be removed before deletion
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TeamDeleteConflictResponse"
   /teams/{id}/owner:
     put:
       tags: [teams]
@@ -3651,6 +3657,52 @@ components:
           type: string
           format: date-time
       required: [id, name, slug, created_at, updated_at]
+    TeamDeleteResourceCount:
+      type: object
+      properties:
+        category:
+          type: string
+          description: Machine-readable resource category that still references the team.
+        count:
+          type: integer
+          format: int64
+          description: Number of resources in this category.
+      required: [category, count]
+    TeamDeleteConflictDetails:
+      type: object
+      properties:
+        team_id:
+          type: string
+        blocking_resources:
+          type: array
+          description: Resources that must be removed before the team can be deleted.
+          items:
+            $ref: "#/components/schemas/TeamDeleteResourceCount"
+        retained_resources:
+          type: array
+          description: Historical resources retained by policy. These do not block deletion.
+          items:
+            $ref: "#/components/schemas/TeamDeleteResourceCount"
+        retention_policy:
+          type: string
+          description: Summary of the historical metering retention policy for team deletion.
+      required: [team_id, blocking_resources]
+    TeamDeleteConflictResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        error:
+          type: object
+          properties:
+            code:
+              type: string
+            message:
+              type: string
+            details:
+              $ref: "#/components/schemas/TeamDeleteConflictDetails"
+          required: [code, message]
+      required: [success, error]
     Region:
       type: object
       properties:

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -2560,6 +2560,38 @@ type Team struct {
 	UpdatedAt    time.Time `json:"updated_at"`
 }
 
+// TeamDeleteConflictDetails defines model for TeamDeleteConflictDetails.
+type TeamDeleteConflictDetails struct {
+	// BlockingResources Resources that must be removed before the team can be deleted.
+	BlockingResources []TeamDeleteResourceCount `json:"blocking_resources"`
+
+	// RetainedResources Historical resources retained by policy. These do not block deletion.
+	RetainedResources *[]TeamDeleteResourceCount `json:"retained_resources,omitempty"`
+
+	// RetentionPolicy Summary of the historical metering retention policy for team deletion.
+	RetentionPolicy *string `json:"retention_policy,omitempty"`
+	TeamId          string  `json:"team_id"`
+}
+
+// TeamDeleteConflictResponse defines model for TeamDeleteConflictResponse.
+type TeamDeleteConflictResponse struct {
+	Error struct {
+		Code    string                     `json:"code"`
+		Details *TeamDeleteConflictDetails `json:"details,omitempty"`
+		Message string                     `json:"message"`
+	} `json:"error"`
+	Success bool `json:"success"`
+}
+
+// TeamDeleteResourceCount defines model for TeamDeleteResourceCount.
+type TeamDeleteResourceCount struct {
+	// Category Machine-readable resource category that still references the team.
+	Category string `json:"category"`
+
+	// Count Number of resources in this category.
+	Count int64 `json:"count"`
+}
+
 // TeamMember defines model for TeamMember.
 type TeamMember struct {
 	// AvatarUrl User avatar URL. Present in team member list responses.

--- a/pkg/gateway/http/handlers/team.go
+++ b/pkg/gateway/http/handlers/team.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/identity"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/middleware"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/teamresources"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/tenantdir"
 	"go.uber.org/zap"
 )
@@ -30,6 +31,11 @@ type teamRepository interface {
 	RemoveTeamMember(ctx context.Context, teamID, userID string) error
 }
 
+// TeamDeletePreflight checks for resources that must be cleared before deleting a team.
+type TeamDeletePreflight interface {
+	GetTeamResourceInventory(ctx context.Context, teamID string) (*teamresources.Inventory, error)
+}
+
 // TeamRegionLookup resolves region directory entries for team validation.
 type TeamRegionLookup interface {
 	GetRegion(ctx context.Context, regionID string) (*tenantdir.Region, error)
@@ -41,6 +47,7 @@ type TeamHandler struct {
 	logger                    *zap.Logger
 	requireHomeRegionOnCreate bool
 	regionLookup              TeamRegionLookup
+	deletePreflight           TeamDeletePreflight
 }
 
 // TeamHandlerOption configures TeamHandler behavior.
@@ -51,6 +58,13 @@ func WithCreateHomeRegionRequired(regionLookup TeamRegionLookup) TeamHandlerOpti
 	return func(h *TeamHandler) {
 		h.requireHomeRegionOnCreate = true
 		h.regionLookup = regionLookup
+	}
+}
+
+// WithTeamDeletePreflight configures the resource inventory used by team deletion.
+func WithTeamDeletePreflight(preflight TeamDeletePreflight) TeamHandlerOption {
+	return func(h *TeamHandler) {
+		h.deletePreflight = preflight
 	}
 }
 
@@ -371,6 +385,19 @@ func (h *TeamHandler) DeleteTeam(c *gin.Context) {
 	if team.OwnerID == nil || *team.OwnerID != authCtx.UserID {
 		spec.JSONError(c, http.StatusForbidden, spec.CodeForbidden, "only team owner can delete team")
 		return
+	}
+
+	if h.deletePreflight != nil {
+		inventory, err := h.deletePreflight.GetTeamResourceInventory(c.Request.Context(), teamID)
+		if err != nil {
+			h.logger.Error("Failed to check team resources before deletion", zap.Error(err), zap.String("team_id", teamID))
+			spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to check team resources")
+			return
+		}
+		if inventory.HasBlockingResources() {
+			spec.JSONError(c, http.StatusConflict, spec.CodeConflict, "team has resources that must be removed before deletion", inventory)
+			return
+		}
 	}
 
 	if err := h.repo.DeleteTeam(c.Request.Context(), teamID); err != nil {

--- a/pkg/gateway/http/handlers/team_test.go
+++ b/pkg/gateway/http/handlers/team_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/authn"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/identity"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/teamresources"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/tenantdir"
 	"go.uber.org/zap"
 )
@@ -36,6 +37,7 @@ type stubTeamRepository struct {
 	searchMembers   []*identity.TeamMemberWithUser
 	searchTeamID    string
 	searchQuery     string
+	deletedTeamID   string
 }
 
 func (s *stubTeamRepository) GetTeamsByUserID(context.Context, string) ([]*identity.Team, error) {
@@ -80,8 +82,26 @@ func (s *stubTeamRepository) UpdateTeam(_ context.Context, team *identity.Team) 
 	return nil
 }
 
-func (s *stubTeamRepository) DeleteTeam(context.Context, string) error {
+func (s *stubTeamRepository) DeleteTeam(_ context.Context, id string) error {
+	s.deletedTeamID = id
 	return nil
+}
+
+type stubTeamDeletePreflight struct {
+	teamID    string
+	inventory *teamresources.Inventory
+	err       error
+}
+
+func (s *stubTeamDeletePreflight) GetTeamResourceInventory(_ context.Context, teamID string) (*teamresources.Inventory, error) {
+	s.teamID = teamID
+	if s.err != nil {
+		return nil, s.err
+	}
+	if s.inventory != nil {
+		return s.inventory, nil
+	}
+	return &teamresources.Inventory{TeamID: teamID}, nil
 }
 
 func (s *stubTeamRepository) TransferTeamOwner(_ context.Context, teamID, userID string) (*identity.Team, error) {
@@ -549,6 +569,82 @@ func TestTeamHandlerRejectsMalformedTeamIDs(t *testing.T) {
 	}
 }
 
+func TestTeamHandlerDeleteTeamReturnsConflictWhenResourcesExist(t *testing.T) {
+	ownerID := testOwnerUserID
+	repo := newTeamManagementRepo(ownerID)
+	preflight := &stubTeamDeletePreflight{
+		inventory: &teamresources.Inventory{
+			TeamID: testTeamID,
+			BlockingResources: []teamresources.ResourceCount{
+				{Category: "sandboxes", Count: 2},
+				{Category: "api_keys", Count: 1},
+			},
+			RetainedResources: []teamresources.ResourceCount{
+				{Category: "usage_events", Count: 3},
+			},
+			RetentionPolicy: teamresources.MeteringRetentionPolicy,
+		},
+	}
+
+	rec := performTeamManagementRequestWithOptions(t, repo, ownerID, http.MethodDelete, "/teams/"+testTeamID, nil, WithTeamDeletePreflight(preflight))
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusConflict, rec.Body.String())
+	}
+	if preflight.teamID != testTeamID {
+		t.Fatalf("preflight team id = %q, want %q", preflight.teamID, testTeamID)
+	}
+	if repo.deletedTeamID != "" {
+		t.Fatalf("team was deleted despite blocking resources: %q", repo.deletedTeamID)
+	}
+
+	var payload spec.Response
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if payload.Error == nil || payload.Error.Code != spec.CodeConflict {
+		t.Fatalf("error = %#v, want conflict", payload.Error)
+	}
+	details, ok := payload.Error.Details.(map[string]any)
+	if !ok {
+		t.Fatalf("details = %#v, want object", payload.Error.Details)
+	}
+	resources, ok := details["blocking_resources"].([]any)
+	if !ok || len(resources) != 2 {
+		t.Fatalf("blocking_resources = %#v, want two entries", details["blocking_resources"])
+	}
+}
+
+func TestTeamHandlerDeleteTeamReturnsInternalErrorWhenPreflightFails(t *testing.T) {
+	ownerID := testOwnerUserID
+	repo := newTeamManagementRepo(ownerID)
+	preflight := &stubTeamDeletePreflight{err: errors.New("inventory failed")}
+
+	rec := performTeamManagementRequestWithOptions(t, repo, ownerID, http.MethodDelete, "/teams/"+testTeamID, nil, WithTeamDeletePreflight(preflight))
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusInternalServerError, rec.Body.String())
+	}
+	if repo.deletedTeamID != "" {
+		t.Fatalf("team was deleted after preflight error: %q", repo.deletedTeamID)
+	}
+}
+
+func TestTeamHandlerDeleteTeamRunsAfterEmptyPreflight(t *testing.T) {
+	ownerID := testOwnerUserID
+	repo := newTeamManagementRepo(ownerID)
+	preflight := &stubTeamDeletePreflight{}
+
+	rec := performTeamManagementRequestWithOptions(t, repo, ownerID, http.MethodDelete, "/teams/"+testTeamID, nil, WithTeamDeletePreflight(preflight))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if repo.deletedTeamID != testTeamID {
+		t.Fatalf("deleted team id = %q, want %q", repo.deletedTeamID, testTeamID)
+	}
+}
+
 func TestTeamHandlerRejectsMalformedUserIDs(t *testing.T) {
 	ownerID := testOwnerUserID
 
@@ -753,8 +849,13 @@ func newTeamManagementRepo(ownerID string) *stubTeamRepository {
 
 func performTeamManagementRequest(t *testing.T, repo *stubTeamRepository, authUserID, method, path string, body map[string]any) *httptest.ResponseRecorder {
 	t.Helper()
+	return performTeamManagementRequestWithOptions(t, repo, authUserID, method, path, body)
+}
 
-	handler := NewTeamHandler(repo, zap.NewNop())
+func performTeamManagementRequestWithOptions(t *testing.T, repo *stubTeamRepository, authUserID, method, path string, body map[string]any, opts ...TeamHandlerOption) *httptest.ResponseRecorder {
+	t.Helper()
+
+	handler := NewTeamHandler(repo, zap.NewNop(), opts...)
 	router := gin.New()
 	router.Use(func(c *gin.Context) {
 		c.Set("auth_context", &authn.AuthContext{

--- a/pkg/gateway/public/routes.go
+++ b/pkg/gateway/public/routes.go
@@ -19,6 +19,7 @@ type Deps struct {
 	IdentityRepo            *identity.Repository
 	APIKeyRepo              *apikey.Repository
 	AuthMiddleware          *middleware.AuthMiddleware
+	TeamDeletePreflight     handlers.TeamDeletePreflight
 	BuiltinProvider         *builtin.Provider
 	OIDCManager             *oidc.Manager
 	Entitlements            licensing.Entitlements
@@ -37,9 +38,12 @@ func RegisterRoutes(router gin.IRouter, deps Deps) {
 }
 
 func newTeamHandler(deps Deps) *handlers.TeamHandler {
-	teamOpts := make([]handlers.TeamHandlerOption, 0, 1)
+	teamOpts := make([]handlers.TeamHandlerOption, 0, 2)
 	if deps.RequireCreateHomeRegion {
 		teamOpts = append(teamOpts, handlers.WithCreateHomeRegionRequired(deps.RegionRepo))
+	}
+	if deps.TeamDeletePreflight != nil {
+		teamOpts = append(teamOpts, handlers.WithTeamDeletePreflight(deps.TeamDeletePreflight))
 	}
 	return handlers.NewTeamHandler(deps.IdentityRepo, deps.Logger, teamOpts...)
 }

--- a/pkg/gateway/teamresources/inventory.go
+++ b/pkg/gateway/teamresources/inventory.go
@@ -1,0 +1,38 @@
+package teamresources
+
+// ResourceCount reports how many team-owned resources exist in one category.
+type ResourceCount struct {
+	Category string `json:"category"`
+	Count    int64  `json:"count"`
+}
+
+// Inventory is the team deletion preflight result.
+type Inventory struct {
+	TeamID            string          `json:"team_id"`
+	BlockingResources []ResourceCount `json:"blocking_resources,omitempty"`
+	RetainedResources []ResourceCount `json:"retained_resources,omitempty"`
+	RetentionPolicy   string          `json:"retention_policy,omitempty"`
+}
+
+const MeteringRetentionPolicy = "historical metering records are retained for usage truth and audit and do not block team deletion"
+
+// HasBlockingResources returns true when team deletion should be rejected.
+func (i *Inventory) HasBlockingResources() bool {
+	return i != nil && len(i.BlockingResources) > 0
+}
+
+// AddBlocking adds a blocking resource category when count is non-zero.
+func (i *Inventory) AddBlocking(category string, count int64) {
+	if i == nil || count <= 0 {
+		return
+	}
+	i.BlockingResources = append(i.BlockingResources, ResourceCount{Category: category, Count: count})
+}
+
+// AddRetained adds a retained resource category when count is non-zero.
+func (i *Inventory) AddRetained(category string, count int64) {
+	if i == nil || count <= 0 {
+		return
+	}
+	i.RetainedResources = append(i.RetainedResources, ResourceCount{Category: category, Count: count})
+}

--- a/pkg/gateway/teamresources/inventory_test.go
+++ b/pkg/gateway/teamresources/inventory_test.go
@@ -1,0 +1,111 @@
+package teamresources
+
+import "testing"
+
+func TestInventoryTracksBlockingResources(t *testing.T) {
+	inventory := &Inventory{TeamID: "team-1"}
+	if inventory.HasBlockingResources() {
+		t.Fatal("empty inventory should not block deletion")
+	}
+
+	inventory.AddBlocking("sandboxes", 2)
+	inventory.AddBlocking("api_keys", 0)
+
+	if !inventory.HasBlockingResources() {
+		t.Fatal("inventory with blocking resources should block deletion")
+	}
+	if len(inventory.BlockingResources) != 1 {
+		t.Fatalf("blocking resources = %d, want 1", len(inventory.BlockingResources))
+	}
+	if inventory.BlockingResources[0].Category != "sandboxes" || inventory.BlockingResources[0].Count != 2 {
+		t.Fatalf("blocking resource = %#v, want sandboxes count 2", inventory.BlockingResources[0])
+	}
+}
+
+func TestRepositoryBlockingQueriesCoverTeamScopedStores(t *testing.T) {
+	repo := NewRepository(nil)
+	got := map[string]bool{}
+	for _, query := range repo.blockingQueries() {
+		got[query.category] = true
+	}
+
+	want := []string{
+		"api_keys",
+		"ssh_public_keys",
+		"scheduler_templates",
+		"scheduler_template_allocations",
+		"credential_sources",
+		"credential_source_versions",
+		"sandbox_egress_credential_bindings",
+		"sandboxes",
+		"sandbox_lifecycle_transactions",
+		"sandbox_rootfs_states",
+		"sandbox_rootfs_heads",
+		"sandbox_rootfs_bindings",
+		"rootfs_filesystems",
+		"rootfs_snapshots",
+		"rootfs_layers",
+		"rootfs_objects",
+		"rootfs_object_deletions",
+		"sandbox_volumes",
+		"sandbox_volume_snapshots",
+		"sandbox_volume_mounts",
+		"snapshot_coordinations",
+		"snapshot_flush_responses",
+		"sandbox_volume_owners",
+		"sandbox_volume_s0fs_heads",
+		"sandbox_volume_handoffs",
+		"sandbox_volume_sync_replicas",
+		"sandbox_volume_sync_journal",
+		"sandbox_volume_sync_conflicts",
+		"sandbox_volume_sync_requests",
+		"sandbox_volume_sync_retention",
+		"sandbox_volume_sync_namespace_policy",
+		"team_quota_limits",
+	}
+	for _, category := range want {
+		if !got[category] {
+			t.Fatalf("missing blocking query category %q", category)
+		}
+	}
+}
+
+func TestRepositoryRetainedQueriesDocumentMeteringPolicy(t *testing.T) {
+	repo := NewRepository(nil)
+	got := map[string]bool{}
+	for _, query := range repo.retainedQueries() {
+		got[query.category] = true
+	}
+
+	want := []string{
+		"usage_events",
+		"usage_windows",
+		"manager_sandbox_projection_state",
+		"storage_projection_state",
+	}
+	for _, category := range want {
+		if !got[category] {
+			t.Fatalf("missing retained query category %q", category)
+		}
+	}
+	if MeteringRetentionPolicy == "" {
+		t.Fatal("metering retention policy must be explicit")
+	}
+}
+
+func TestDiscoveryHelpers(t *testing.T) {
+	schemas := compactSchemas([]string{"shared_gateway", "", "manager", "shared_gateway", " "})
+	if len(schemas) != 2 || schemas[0] != "shared_gateway" || schemas[1] != "manager" {
+		t.Fatalf("schemas = %#v, want shared_gateway and manager", schemas)
+	}
+
+	if !isIgnoredDiscoveredTable("shared_gateway", "team_members") {
+		t.Fatal("team_members should be ignored because team deletion cascades membership")
+	}
+	if isIgnoredDiscoveredTable("manager", "sandboxes") {
+		t.Fatal("sandboxes should not be ignored")
+	}
+	if got := discoveredCategory("manager", "custom_team_table"); got != "manager.custom_team_table" {
+		t.Fatalf("category = %q, want manager.custom_team_table", got)
+	}
+}

--- a/pkg/gateway/teamresources/repository.go
+++ b/pkg/gateway/teamresources/repository.go
@@ -1,0 +1,567 @@
+package teamresources
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// SchemaConfig names the module schemas that may hold team-owned resources.
+type SchemaConfig struct {
+	Scheduler    string
+	Manager      string
+	StorageProxy string
+	Quota        string
+	Metering     string
+}
+
+// DefaultSchemaConfig returns the deployment defaults used by sandbox0 services.
+func DefaultSchemaConfig() SchemaConfig {
+	return SchemaConfig{
+		Scheduler:    "scheduler",
+		Manager:      "manager",
+		StorageProxy: "storage_proxy",
+		Quota:        "quota",
+		Metering:     "metering",
+	}
+}
+
+// Repository builds a conservative team-owned resource inventory from region PostgreSQL.
+type Repository struct {
+	pool    *pgxpool.Pool
+	schemas SchemaConfig
+}
+
+// Option configures a Repository.
+type Option func(*Repository)
+
+// WithSchemaConfig overrides module schema names.
+func WithSchemaConfig(schemas SchemaConfig) Option {
+	return func(r *Repository) {
+		r.schemas = schemas
+	}
+}
+
+// NewRepository creates a team resource inventory repository.
+func NewRepository(pool *pgxpool.Pool, opts ...Option) *Repository {
+	r := &Repository{
+		pool:    pool,
+		schemas: DefaultSchemaConfig(),
+	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
+}
+
+// GetTeamResourceInventory returns resource counts that should block or survive team deletion.
+func (r *Repository) GetTeamResourceInventory(ctx context.Context, teamID string) (*Inventory, error) {
+	inventory := &Inventory{
+		TeamID:          strings.TrimSpace(teamID),
+		RetentionPolicy: MeteringRetentionPolicy,
+	}
+	if r == nil || r.pool == nil || inventory.TeamID == "" {
+		return inventory, nil
+	}
+
+	blockingQueries := r.blockingQueries()
+	retainedQueries := r.retainedQueries()
+
+	for _, query := range blockingQueries {
+		count, err := r.countOptional(ctx, query.table, query.sql, inventory.TeamID)
+		if err != nil {
+			return nil, err
+		}
+		inventory.AddBlocking(query.category, count)
+	}
+
+	blockingDiscoverySchemas, err := r.blockingDiscoverySchemas(ctx)
+	if err != nil {
+		return nil, err
+	}
+	discoveredBlocking, err := r.discoverTeamIDQueries(ctx, blockingQueries, blockingDiscoverySchemas)
+	if err != nil {
+		return nil, err
+	}
+	for _, query := range discoveredBlocking {
+		count, err := r.countOptional(ctx, query.table, query.sql, inventory.TeamID)
+		if err != nil {
+			return nil, err
+		}
+		inventory.AddBlocking(query.category, count)
+	}
+
+	for _, query := range retainedQueries {
+		count, err := r.countOptional(ctx, query.table, query.sql, inventory.TeamID)
+		if err != nil {
+			return nil, err
+		}
+		inventory.AddRetained(query.category, count)
+	}
+
+	discoveredRetained, err := r.discoverTeamIDQueries(ctx, append(blockingQueries, retainedQueries...), r.retainedDiscoverySchemas())
+	if err != nil {
+		return nil, err
+	}
+	for _, query := range discoveredRetained {
+		count, err := r.countOptional(ctx, query.table, query.sql, inventory.TeamID)
+		if err != nil {
+			return nil, err
+		}
+		inventory.AddRetained(query.category, count)
+	}
+
+	return inventory, nil
+}
+
+type countQuery struct {
+	category string
+	table    string
+	sql      string
+}
+
+func (r *Repository) blockingQueries() []countQuery {
+	apiKeys := tableRef("", "api_keys")
+	sshKeys := tableRef("", "user_ssh_public_keys")
+
+	schedulerTemplates := tableRef(r.schemas.Scheduler, "scheduler_templates")
+	schedulerAllocations := tableRef(r.schemas.Scheduler, "scheduler_template_allocations")
+	credentialSources := tableRef(r.schemas.Scheduler, "credential_sources")
+	credentialSourceVersions := tableRef(r.schemas.Scheduler, "credential_source_versions")
+	credentialBindings := tableRef(r.schemas.Scheduler, "sandbox_egress_credential_bindings")
+
+	managerSandboxes := tableRef(r.schemas.Manager, "sandboxes")
+	managerLifecycleTxns := tableRef(r.schemas.Manager, "sandbox_lifecycle_txns")
+	managerRootFSStates := tableRef(r.schemas.Manager, "sandbox_rootfs_states")
+	managerRootFSHeads := tableRef(r.schemas.Manager, "sandbox_rootfs_heads")
+	managerRootFSBindings := tableRef(r.schemas.Manager, "sandbox_rootfs_bindings")
+	managerRootFSFilesystems := tableRef(r.schemas.Manager, "rootfs_filesystems")
+	managerRootFSSnapshots := tableRef(r.schemas.Manager, "rootfs_snapshots")
+	managerRootFSLayers := tableRef(r.schemas.Manager, "rootfs_layers")
+	managerRootFSObjects := tableRef(r.schemas.Manager, "rootfs_objects")
+	managerRootFSObjectDeletions := tableRef(r.schemas.Manager, "rootfs_object_deletions")
+
+	storageVolumes := tableRef(r.schemas.StorageProxy, "sandbox_volumes")
+	storageSnapshots := tableRef(r.schemas.StorageProxy, "sandbox_volume_snapshots")
+	storageMounts := tableRef(r.schemas.StorageProxy, "sandbox_volume_mounts")
+	storageCoordinations := tableRef(r.schemas.StorageProxy, "snapshot_coordinations")
+	storageFlushResponses := tableRef(r.schemas.StorageProxy, "snapshot_flush_responses")
+	storageOwners := tableRef(r.schemas.StorageProxy, "sandbox_volume_owners")
+	storageS0FSHeads := tableRef(r.schemas.StorageProxy, "sandbox_volume_s0fs_heads")
+	storageHandoffs := tableRef(r.schemas.StorageProxy, "sandbox_volume_handoffs")
+	storageSyncReplicas := tableRef(r.schemas.StorageProxy, "sandbox_volume_sync_replicas")
+	storageSyncJournal := tableRef(r.schemas.StorageProxy, "sandbox_volume_sync_journal")
+	storageSyncConflicts := tableRef(r.schemas.StorageProxy, "sandbox_volume_sync_conflicts")
+	storageSyncRequests := tableRef(r.schemas.StorageProxy, "sandbox_volume_sync_requests")
+	storageSyncRetention := tableRef(r.schemas.StorageProxy, "sandbox_volume_sync_retention")
+	storageSyncNamespacePolicy := tableRef(r.schemas.StorageProxy, "sandbox_volume_sync_namespace_policy")
+
+	quotaLimits := tableRef(r.schemas.Quota, "team_quota_limits")
+
+	return []countQuery{
+		{
+			category: "api_keys",
+			table:    apiKeys,
+			sql:      fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE team_id::text = $1`, apiKeys),
+		},
+		{
+			category: "ssh_public_keys",
+			table:    sshKeys,
+			sql:      fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE COALESCE(team_id, '') = $1`, sshKeys),
+		},
+		{
+			category: "scheduler_templates",
+			table:    schedulerTemplates,
+			sql:      fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE scope = 'team' AND team_id = $1`, schedulerTemplates),
+		},
+		{
+			category: "scheduler_template_allocations",
+			table:    schedulerAllocations,
+			sql:      fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE scope = 'team' AND team_id = $1`, schedulerAllocations),
+		},
+		{
+			category: "credential_sources",
+			table:    credentialSources,
+			sql:      fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE team_id = $1`, credentialSources),
+		},
+		{
+			category: "credential_source_versions",
+			table:    credentialSourceVersions,
+			sql: fmt.Sprintf(`
+				SELECT COUNT(*)
+				FROM %s v
+				JOIN %s s ON s.id = v.source_id
+				WHERE s.team_id = $1
+			`, credentialSourceVersions, credentialSources),
+		},
+		{
+			category: "sandbox_egress_credential_bindings",
+			table:    credentialBindings,
+			sql:      fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE team_id = $1`, credentialBindings),
+		},
+		{
+			category: "sandboxes",
+			table:    managerSandboxes,
+			sql:      fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE team_id = $1 AND deleted_at IS NULL`, managerSandboxes),
+		},
+		{
+			category: "sandbox_lifecycle_transactions",
+			table:    managerLifecycleTxns,
+			sql: fmt.Sprintf(`
+				SELECT COUNT(*)
+				FROM %s tx
+				JOIN %s s ON s.sandbox_id = tx.sandbox_id
+				WHERE s.team_id = $1
+				  AND tx.phase IN ('preparing', 'barriered', 'publishing', 'committing')
+			`, managerLifecycleTxns, managerSandboxes),
+		},
+		{
+			category: "sandbox_rootfs_states",
+			table:    managerRootFSStates,
+			sql:      fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE team_id = $1`, managerRootFSStates),
+		},
+		{
+			category: "sandbox_rootfs_heads",
+			table:    managerRootFSHeads,
+			sql:      fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE team_id = $1`, managerRootFSHeads),
+		},
+		{
+			category: "sandbox_rootfs_bindings",
+			table:    managerRootFSBindings,
+			sql:      fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE team_id = $1`, managerRootFSBindings),
+		},
+		{
+			category: "rootfs_filesystems",
+			table:    managerRootFSFilesystems,
+			sql:      fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE team_id = $1`, managerRootFSFilesystems),
+		},
+		{
+			category: "rootfs_snapshots",
+			table:    managerRootFSSnapshots,
+			sql:      fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE team_id = $1`, managerRootFSSnapshots),
+		},
+		{
+			category: "rootfs_layers",
+			table:    managerRootFSLayers,
+			sql:      fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE team_id = $1`, managerRootFSLayers),
+		},
+		{
+			category: "rootfs_objects",
+			table:    managerRootFSObjects,
+			sql:      fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE team_id = $1 AND deleted_at IS NULL`, managerRootFSObjects),
+		},
+		{
+			category: "rootfs_object_deletions",
+			table:    managerRootFSObjectDeletions,
+			sql:      fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE team_id = $1`, managerRootFSObjectDeletions),
+		},
+		{
+			category: "sandbox_volumes",
+			table:    storageVolumes,
+			sql:      fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE team_id = $1`, storageVolumes),
+		},
+		{
+			category: "sandbox_volume_snapshots",
+			table:    storageSnapshots,
+			sql:      fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE team_id = $1`, storageSnapshots),
+		},
+		{
+			category: "sandbox_volume_mounts",
+			table:    storageMounts,
+			sql: fmt.Sprintf(`
+				SELECT COUNT(*)
+				FROM %s m
+				JOIN %s v ON v.id = m.volume_id
+				WHERE v.team_id = $1
+			`, storageMounts, storageVolumes),
+		},
+		{
+			category: "snapshot_coordinations",
+			table:    storageCoordinations,
+			sql: fmt.Sprintf(`
+				SELECT COUNT(*)
+				FROM %s c
+				JOIN %s v ON v.id = c.volume_id
+				WHERE v.team_id = $1
+			`, storageCoordinations, storageVolumes),
+		},
+		{
+			category: "snapshot_flush_responses",
+			table:    storageFlushResponses,
+			sql: fmt.Sprintf(`
+				SELECT COUNT(*)
+				FROM %s r
+				JOIN %s c ON c.id = r.coord_id
+				JOIN %s v ON v.id = c.volume_id
+				WHERE v.team_id = $1
+			`, storageFlushResponses, storageCoordinations, storageVolumes),
+		},
+		{
+			category: "sandbox_volume_owners",
+			table:    storageOwners,
+			sql: fmt.Sprintf(`
+				SELECT COUNT(*)
+				FROM %s o
+				JOIN %s v ON v.id = o.volume_id
+				WHERE v.team_id = $1
+			`, storageOwners, storageVolumes),
+		},
+		{
+			category: "sandbox_volume_s0fs_heads",
+			table:    storageS0FSHeads,
+			sql: fmt.Sprintf(`
+				SELECT COUNT(*)
+				FROM %s h
+				JOIN %s v ON v.id = h.volume_id
+				WHERE v.team_id = $1
+			`, storageS0FSHeads, storageVolumes),
+		},
+		{
+			category: "sandbox_volume_handoffs",
+			table:    storageHandoffs,
+			sql: fmt.Sprintf(`
+				SELECT COUNT(*)
+				FROM %s h
+				JOIN %s v ON v.id = h.volume_id
+				WHERE v.team_id = $1
+			`, storageHandoffs, storageVolumes),
+		},
+		{
+			category: "sandbox_volume_sync_replicas",
+			table:    storageSyncReplicas,
+			sql:      fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE team_id = $1`, storageSyncReplicas),
+		},
+		{
+			category: "sandbox_volume_sync_journal",
+			table:    storageSyncJournal,
+			sql:      fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE team_id = $1`, storageSyncJournal),
+		},
+		{
+			category: "sandbox_volume_sync_conflicts",
+			table:    storageSyncConflicts,
+			sql:      fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE team_id = $1`, storageSyncConflicts),
+		},
+		{
+			category: "sandbox_volume_sync_requests",
+			table:    storageSyncRequests,
+			sql: fmt.Sprintf(`
+				SELECT COUNT(*)
+				FROM %s r
+				JOIN %s v ON v.id = r.volume_id
+				WHERE v.team_id = $1
+			`, storageSyncRequests, storageVolumes),
+		},
+		{
+			category: "sandbox_volume_sync_retention",
+			table:    storageSyncRetention,
+			sql:      fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE team_id = $1`, storageSyncRetention),
+		},
+		{
+			category: "sandbox_volume_sync_namespace_policy",
+			table:    storageSyncNamespacePolicy,
+			sql:      fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE team_id = $1`, storageSyncNamespacePolicy),
+		},
+		{
+			category: "team_quota_limits",
+			table:    quotaLimits,
+			sql:      fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE team_id = $1`, quotaLimits),
+		},
+	}
+}
+
+func (r *Repository) retainedQueries() []countQuery {
+	usageEvents := tableRef(r.schemas.Metering, "usage_events")
+	usageWindows := tableRef(r.schemas.Metering, "usage_windows")
+	managerProjection := tableRef(r.schemas.Metering, "manager_sandbox_projection_state")
+	storageProjection := tableRef(r.schemas.Metering, "storage_projection_state")
+
+	return []countQuery{
+		{
+			category: "usage_events",
+			table:    usageEvents,
+			sql:      fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE team_id = $1`, usageEvents),
+		},
+		{
+			category: "usage_windows",
+			table:    usageWindows,
+			sql:      fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE team_id = $1`, usageWindows),
+		},
+		{
+			category: "manager_sandbox_projection_state",
+			table:    managerProjection,
+			sql:      fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE team_id = $1`, managerProjection),
+		},
+		{
+			category: "storage_projection_state",
+			table:    storageProjection,
+			sql:      fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE team_id = $1`, storageProjection),
+		},
+	}
+}
+
+func (r *Repository) countOptional(ctx context.Context, table, query, teamID string) (int64, error) {
+	var tableName sql.NullString
+	if err := r.pool.QueryRow(ctx, `SELECT to_regclass($1)::text`, table).Scan(&tableName); err != nil {
+		return 0, fmt.Errorf("check resource table %s: %w", table, err)
+	}
+	if !tableName.Valid {
+		return 0, nil
+	}
+
+	var count int64
+	if err := r.pool.QueryRow(ctx, query, teamID).Scan(&count); err != nil {
+		if isUndefinedRelation(err) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("count team resources in %s: %w", table, err)
+	}
+	return count, nil
+}
+
+func (r *Repository) discoverTeamIDQueries(ctx context.Context, known []countQuery, schemas []string) ([]countQuery, error) {
+	schemas = compactSchemas(schemas)
+	if len(schemas) == 0 {
+		return nil, nil
+	}
+
+	knownTables, err := r.resolveKnownTables(ctx, known)
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := r.pool.Query(ctx, `
+		SELECT table_schema, table_name
+		FROM information_schema.columns
+		WHERE column_name = 'team_id'
+		  AND table_schema = ANY($1::text[])
+		GROUP BY table_schema, table_name
+		ORDER BY table_schema, table_name
+	`, schemas)
+	if err != nil {
+		return nil, fmt.Errorf("discover team-scoped resource tables: %w", err)
+	}
+	defer rows.Close()
+
+	var queries []countQuery
+	for rows.Next() {
+		var schema, tableName string
+		if err := rows.Scan(&schema, &tableName); err != nil {
+			return nil, fmt.Errorf("scan team-scoped resource table: %w", err)
+		}
+		if isIgnoredDiscoveredTable(schema, tableName) || knownTables[tableKey(schema, tableName)] {
+			continue
+		}
+		table := tableRef(schema, tableName)
+		queries = append(queries, countQuery{
+			category: discoveredCategory(schema, tableName),
+			table:    table,
+			sql:      fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE team_id::text = $1`, table),
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate team-scoped resource tables: %w", err)
+	}
+	return queries, nil
+}
+
+func (r *Repository) blockingDiscoverySchemas(ctx context.Context) ([]string, error) {
+	gatewaySchema, err := r.currentSchema(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return []string{
+		gatewaySchema,
+		r.schemas.Scheduler,
+		r.schemas.Manager,
+		r.schemas.StorageProxy,
+		r.schemas.Quota,
+	}, nil
+}
+
+func (r *Repository) retainedDiscoverySchemas() []string {
+	return []string{r.schemas.Metering}
+}
+
+func (r *Repository) currentSchema(ctx context.Context) (string, error) {
+	var schema string
+	if err := r.pool.QueryRow(ctx, `SELECT current_schema()`).Scan(&schema); err != nil {
+		return "", fmt.Errorf("get current schema: %w", err)
+	}
+	return schema, nil
+}
+
+func (r *Repository) resolveKnownTables(ctx context.Context, queries []countQuery) (map[string]bool, error) {
+	known := make(map[string]bool, len(queries))
+	for _, query := range queries {
+		var schema, table string
+		err := r.pool.QueryRow(ctx, `
+			SELECT n.nspname, c.relname
+			FROM pg_class c
+			JOIN pg_namespace n ON n.oid = c.relnamespace
+			WHERE c.oid = to_regclass($1)
+		`, query.table).Scan(&schema, &table)
+		if errors.Is(err, pgx.ErrNoRows) {
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("resolve resource table %s: %w", query.table, err)
+		}
+		known[tableKey(schema, table)] = true
+	}
+	return known, nil
+}
+
+func compactSchemas(schemas []string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(schemas))
+	for _, schema := range schemas {
+		schema = strings.TrimSpace(schema)
+		if schema == "" || seen[schema] {
+			continue
+		}
+		seen[schema] = true
+		out = append(out, schema)
+	}
+	return out
+}
+
+func isIgnoredDiscoveredTable(_ string, table string) bool {
+	switch table {
+	case "team_members":
+		return true
+	default:
+		return false
+	}
+}
+
+func discoveredCategory(schema, table string) string {
+	if strings.TrimSpace(schema) == "" {
+		return table
+	}
+	return schema + "." + table
+}
+
+func tableKey(schema, table string) string {
+	return schema + "." + table
+}
+
+func tableRef(schema, table string) string {
+	if strings.TrimSpace(schema) == "" {
+		return pgx.Identifier{table}.Sanitize()
+	}
+	return pgx.Identifier{schema, table}.Sanitize()
+}
+
+func isUndefinedRelation(err error) bool {
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) {
+		return false
+	}
+	return pgErr.Code == "42P01" || pgErr.Code == "3F000"
+}

--- a/regional-gateway/pkg/http/server.go
+++ b/regional-gateway/pkg/http/server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/middleware"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/public"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/teamresources"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"github.com/sandbox0-ai/sandbox0/pkg/licensing"
 	"github.com/sandbox0-ai/sandbox0/pkg/metering"
@@ -382,16 +383,22 @@ func (s *Server) setupMeteringRoutes() {
 }
 
 func (s *Server) setupPublicRoutes() {
+	var teamDeletePreflight gatewayhandlers.TeamDeletePreflight
+	if s.pool != nil {
+		teamDeletePreflight = teamresources.NewRepository(s.pool)
+	}
+
 	deps := public.Deps{
-		IdentityRepo:    s.identityRepo,
-		APIKeyRepo:      s.apiKeyRepo,
-		AuthMiddleware:  s.authMiddleware,
-		BuiltinProvider: s.builtinProvider,
-		OIDCManager:     s.oidcManager,
-		Entitlements:    s.entitlements,
-		JWTIssuer:       s.jwtIssuer,
-		RegionID:        s.cfg.RegionID,
-		Logger:          s.logger,
+		IdentityRepo:        s.identityRepo,
+		APIKeyRepo:          s.apiKeyRepo,
+		AuthMiddleware:      s.authMiddleware,
+		TeamDeletePreflight: teamDeletePreflight,
+		BuiltinProvider:     s.builtinProvider,
+		OIDCManager:         s.oidcManager,
+		Entitlements:        s.entitlements,
+		JWTIssuer:           s.jwtIssuer,
+		RegionID:            s.cfg.RegionID,
+		Logger:              s.logger,
 	}
 
 	if edgeAuthModeUsesSelfHostedIdentity(s.cfg.AuthMode) {


### PR DESCRIPTION
## Summary
- add a shared team deletion preflight inventory for blocking and retained team-owned resources
- wire the preflight into regional-gateway and cluster-gateway team deletion so DELETE /teams/{id} returns 409 with resource counts before deleting
- document the deletion behavior and update OpenAPI/generated types

Closes #593

## Tests
- make apispec
- go test ./pkg/gateway/teamresources ./pkg/gateway/http/handlers ./pkg/gateway/public ./regional-gateway/pkg/http ./cluster-gateway/pkg/http ./pkg/apispec
- go test ./pkg/gateway/... ./regional-gateway/pkg/http ./cluster-gateway/pkg/http
- go test ./... failed on existing prerequisites: missing generated github.com/sandbox0-ai/sandbox0/storage-proxy/proto/fs package and kind not found for single-cluster e2e