### PR TITLE
Support per-sandbox memory resize

### DIFF
--- a/docs/sandbox/page.mdx
+++ b/docs/sandbox/page.mdx
@@ -71,6 +71,7 @@ Claim a sandbox from a template. The sandbox is created from a pre-warmed pool f
 | `env_vars` | object | Sandbox-level default environment variables for new procd-managed processes |
 | `ttl` | integer | Time to live in seconds (soft limit, triggers auto-pause; default: `0`, disabled) |
 | `hard_ttl` | integer | Hard sandbox lifetime in seconds (deletes identity and durable state; default: `0`, disabled) |
+| `resources` | object | Optional per-sandbox resource override. Only `resources.memory` is accepted; CPU is derived from the platform memory-per-CPU ratio. |
 | `network` | object | `SandboxNetworkPolicy`. Controls traffic rules, protocol controls, credential bindings, and destination-scoped egress auth |
 | `webhook` | object | Webhook configuration |
 | `auto_resume` | boolean | Auto-resume when accessed (default: true) |
@@ -79,6 +80,14 @@ Claim a sandbox from a template. The sandbox is created from a pre-warmed pool f
 See [Network](/docs/sandbox/network) and [Protocol Controls](/docs/sandbox/protocol-controls) for outbound control, [Sandbox Services](/docs/sandbox/services) for public HTTP controls, [Sandbox Functions](/docs/sandbox/functions) for inline public handlers, and [Credential](/docs/sandbox/credential) for outbound auth and secret handling.
 
 Sandbox `env_vars` override template/container environment variables for new contexts, command services, and function executions. Per-context, per-command, service runtime, and function `env_vars` override sandbox `env_vars` for that narrower scope. Warm processes start before the sandbox is claimed, so they do not receive claim-time sandbox `env_vars`.
+
+### Sandbox Resources
+
+Set `config.resources.memory` when one sandbox needs a different memory limit from its template. The minimum is `128Mi`. The platform maximum defaults to `32Gi` and can be changed by the operator with `services.manager.config.sandboxMaxMemory`.
+
+Sandbox0 keeps CPU and memory in the platform-defined ratio. The request only accepts memory; manager derives CPU from `services.manager.config.teamTemplateMemoryPerCpu` and applies the result to the sandbox runtime container. Existing running sandboxes can update memory with the Update Sandbox API.
+
+SDK helpers expose this as `WithSandboxMemory` / `UpdateSandboxMemory` in Go, `memory` / `updateMemory` in TypeScript, `memory` / `update_memory` in Python, and `--memory` in the `s0` CLI.
 
 ### TTL vs Hard TTL
 
@@ -118,6 +127,7 @@ if err != nil {
 // Claim a sandbox from the "default" template
 sandbox, err := client.ClaimSandbox(ctx, "default",
     sandbox0.WithSandboxHardTTL(300),
+    sandbox0.WithSandboxMemory("512Mi"),
     sandbox0.WithSandboxEnvVars(map[string]string{
         "APP_ENV": "development",
     }),
@@ -147,6 +157,7 @@ sandbox = client.claim_sandbox(
         "hard_ttl": 300,
         "env_vars": {"APP_ENV": "development"},
     }),
+    memory="512Mi",
 )
 print(f"Sandbox ID: {sandbox.id}")
 
@@ -166,6 +177,7 @@ const client = new Client({
 // Claim a sandbox from the "default" template
 const sandbox = await client.sandboxes.claim('default', {
     hardTtl: 300,
+    memory: '512Mi',
     envVars: { APP_ENV: 'development' },
 });
 console.log('Sandbox ID:', sandbox.id);
@@ -177,7 +189,7 @@ await client.sandboxes.delete(sandbox.id);`
       label: "CLI",
       language: "bash",
       code: `# Claim a sandbox from the "default" template
-s0 sandbox create --template default --hard-ttl 300`
+s0 sandbox create --template default --hard-ttl 300 --memory 512Mi`
     }
   ]}
 />
@@ -419,6 +431,7 @@ Only the following fields can be updated at runtime:
 |-------|------|-------------|
 | `ttl` | integer | Time to live in seconds (soft limit) |
 | `hard_ttl` | integer | Hard sandbox lifetime in seconds |
+| `resources` | object | Runtime resource override. Only `resources.memory` is accepted. |
 | `network` | object | Network policy configuration |
 | `auto_resume` | boolean | Auto-resume when accessed |
 | `services` | array | Sandbox Services for public HTTP routes, including Sandbox Functions |
@@ -432,12 +445,7 @@ Only the following fields can be updated at runtime:
     {
       label: "Go",
       language: "go",
-      code: `_, err = client.UpdateSandbox(ctx, sandbox.ID, apispec.SandboxUpdateRequest{
-    Config: apispec.NewOptSandboxUpdateConfig(apispec.SandboxUpdateConfig{
-        TTL:        apispec.NewOptInt32(600),
-        AutoResume: apispec.NewOptBool(false),
-    }),
-})
+      code: `_, err = client.UpdateSandboxMemory(ctx, sandbox.ID, "2Gi")
 if err != nil {
     log.Fatal(err)
 }`
@@ -445,28 +453,17 @@ if err != nil {
     {
       label: "Python",
       language: "python",
-      code: `from sandbox0.apispec.models.sandbox_update_config import SandboxUpdateConfig
-from sandbox0.apispec.models.sandbox_update_request import SandboxUpdateRequest
-
-client.sandboxes.update(
-    sandbox.id,
-    SandboxUpdateRequest(config=SandboxUpdateConfig.from_dict({
-        "ttl": 600,
-        "auto_resume": False,
-    })),
-)`
+      code: `client.sandboxes.update_memory(sandbox.id, "2Gi")`
     },
     {
       label: "TypeScript",
       language: "typescript",
-      code: `await client.sandboxes.update(sandbox.id, {
-    config: { ttl: 600, autoResume: false },
-});`
+      code: `await client.sandboxes.updateMemory(sandbox.id, '2Gi');`
     },
     {
       label: "CLI",
       language: "bash",
-      code: `s0 sandbox update sb_abc123 --ttl 600 --auto-resume false`
+      code: `s0 sandbox update sb_abc123 --memory 2Gi`
     }
   ]}
 />

--- a/docs/self-hosted/configuration/page.mdx
+++ b/docs/self-hosted/configuration/page.mdx
@@ -184,6 +184,22 @@ This field only controls the `runtimeClassName` written onto sandbox Pods. The n
 
 `infra-operator` does not install node runtime handlers. It does not install `runsc`, write `/etc/containerd/config.toml`, restart containerd, or create a `gvisor-rootfs` handler. Do that through your node image, node bootstrap automation, or a dedicated privileged node setup process before scheduling sandbox workloads there.
 
+### Sandbox Memory Limits
+
+Sandbox claims and runtime updates can set `config.resources.memory`. The minimum accepted value is `128Mi`. The platform maximum defaults to `32Gi`.
+
+Use `services.manager.config.sandboxMaxMemory` to lower or raise the platform maximum:
+
+```yaml
+spec:
+    services:
+        manager:
+            config:
+                sandboxMaxMemory: 16Gi
+```
+
+Sandbox0 derives CPU from memory using `services.manager.config.teamTemplateMemoryPerCpu`, so callers do not set CPU directly on a sandbox claim or update.
+
 For `gVisor` rootfs checkpoint and restore support on self-managed clusters, use a dedicated containerd handler that points to `runsc` with shared file access and overlay disabled, then create a matching `RuntimeClass`:
 
 ```toml
@@ -450,6 +466,7 @@ Examples:
 
 - `services.clusterGateway.config.authMode` switches between `public`, `internal`, and `both`
 - `services.manager.config.autoscaler.*` tunes pool scale behavior
+- `services.manager.config.sandboxMaxMemory` caps per-sandbox memory overrides; the default is `32Gi`
 - `services.manager.config.allowColdStartWithoutReadyDataPlane` lets cold claims create Pending pods for external node autoscaler scale-from-zero deployments; keep it disabled unless the cluster autoscaler can provision matching sandbox nodes
 - `services.storageProxy.config.filesystem*` tunes filesystem behavior; `services.manager.config.procdConfig.volume*` tunes mounted volume cache sizing
 - `services.storageProxy.config.s0fsSegmentTargetSize` sets the target S0FS segment size for materialized volume data; the default is `4Mi`

--- a/docs/template/configuration/page.mdx
+++ b/docs/template/configuration/page.mdx
@@ -68,7 +68,7 @@ The main sandbox container configuration.
 | `env` | array | `[]` | Per-container environment variables. Each entry has `name` and `value`. |
 
 <Callout variant="info">
-`mainContainer.image`, `mainContainer.resources.cpu`, `mainContainer.resources.memory`, and `mainContainer.resources.ephemeralStorage` are strictly validated by the API when creating or updating templates.
+`mainContainer.image`, `mainContainer.resources.cpu`, `mainContainer.resources.memory`, and `mainContainer.resources.ephemeralStorage` are strictly validated by the API when creating or updating templates. Template resources are the default for new sandboxes; `config.resources.memory` can override the sandbox memory limit at claim time or runtime.
 </Callout>
 
 ---

--- a/docs/template/page.mdx
+++ b/docs/template/page.mdx
@@ -21,7 +21,7 @@ Builtin templates use curated public images and are ready to use immediately. Cu
 
 ## Custom Template Or Rootfs Snapshot
 
-You do not need a custom template for every initialized environment. If the base image, resources, network policy, and mount declarations already fit, you can claim a sandbox from a builtin template, install dependencies or clone repositories inside the writable root filesystem, pause it, create a rootfs snapshot, then claim future sandboxes with that `snapshot_id`.
+You do not need a custom template for every initialized environment. If the base image, default resources, network policy, and mount declarations already fit, you can claim a sandbox from a builtin template, install dependencies or clone repositories inside the writable root filesystem, pause it, create a rootfs snapshot, then claim future sandboxes with that `snapshot_id`.
 
 This is useful for dependency-heavy agent workspaces:
 
@@ -35,11 +35,11 @@ For platform-owned builtin templates, the operator manages the warm pool. That l
 
 | Need | Prefer |
 |------|--------|
-| Different base image, resource envelope, default environment, mount paths, network defaults, or privileged runtime fields | Custom template |
+| Different base image, default resource envelope, default environment, mount paths, network defaults, or privileged runtime fields | Custom template |
 | User-space dependencies, repository checkout, package cache, generated files, or per-project tool configuration on an existing base image | Builtin template plus rootfs snapshot and claim with `snapshot_id` |
 | Data that must outlive sandbox identity, be mounted by multiple sandboxes, or be accessed through direct storage APIs | Sandbox Volume |
 
-Rootfs snapshots do not create template IDs and do not appear in `s0 template list`. Claiming with `snapshot_id` creates a new running sandbox from the selected rootfs snapshot while the requested template still controls image, resources, mounts, services, and network defaults. Restore remains useful for rolling back an existing paused sandbox, and fork remains useful when you specifically need a paused child sandbox. See [Snapshot And Restore](/docs/sandbox/snapshot-restore) for the paused-state requirements and API workflow, or read [Initialize Once, Claim Many](/blog/2026-06/initialize-once-fork-many-custom-ai-agent-sandboxes) for the custom-rootfs pattern.
+Rootfs snapshots do not create template IDs and do not appear in `s0 template list`. Claiming with `snapshot_id` creates a new running sandbox from the selected rootfs snapshot while the requested template still controls image, default resources, mounts, services, and network defaults. A claim or runtime update can override only the sandbox memory limit; CPU is derived from the platform memory-per-CPU ratio. Restore remains useful for rolling back an existing paused sandbox, and fork remains useful when you specifically need a paused child sandbox. See [Snapshot And Restore](/docs/sandbox/snapshot-restore) for the paused-state requirements and API workflow, or read [Initialize Once, Claim Many](/blog/2026-06/initialize-once-fork-many-custom-ai-agent-sandboxes) for the custom-rootfs pattern.
 
 ---
 

--- a/infra-operator/api/config/manager.go
+++ b/infra-operator/api/config/manager.go
@@ -80,6 +80,10 @@ type ManagerConfig struct {
 	// +optional
 	// +kubebuilder:default="4Gi"
 	TeamTemplateMemoryPerCPU string `yaml:"team_template_memory_per_cpu" json:"teamTemplateMemoryPerCpu"`
+	// SandboxMaxMemory is the maximum memory limit accepted for a single sandbox.
+	// +optional
+	// +kubebuilder:default="32Gi"
+	SandboxMaxMemory string `yaml:"sandbox_max_memory" json:"sandboxMaxMemory"`
 	// +optional
 	SandboxRuntimeClassName string `yaml:"sandbox_runtime_class_name" json:"sandboxRuntimeClassName"`
 	// DefaultTeamQuotas configures region-wide fallback team quota limits.

--- a/infra-operator/api/config/manager_test.go
+++ b/infra-operator/api/config/manager_test.go
@@ -33,3 +33,21 @@ default_team_quotas:
 		t.Fatalf("second default quota = %+v, want cpu_millicpu=2000", cfg.DefaultTeamQuotas[1])
 	}
 }
+
+func TestLoadManagerConfigPreservesSandboxMaxMemory(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "manager.yaml")
+	if err := os.WriteFile(path, []byte(`
+sandbox_max_memory: 16Gi
+`), 0o600); err != nil {
+		t.Fatalf("write manager config: %v", err)
+	}
+
+	cfg, err := loadManagerConfig(path)
+	if err != nil {
+		t.Fatalf("loadManagerConfig: %v", err)
+	}
+	if cfg.SandboxMaxMemory != "16Gi" {
+		t.Fatalf("sandbox max memory = %q, want 16Gi", cfg.SandboxMaxMemory)
+	}
+}

--- a/infra-operator/api/v1alpha1/service_api_config_types.go
+++ b/infra-operator/api/v1alpha1/service_api_config_types.go
@@ -442,6 +442,10 @@ type ManagerConfig struct {
 	// +optional
 	// +kubebuilder:default="4Gi"
 	TeamTemplateMemoryPerCPU string `json:"teamTemplateMemoryPerCpu,omitempty"`
+	// SandboxMaxMemory is the maximum memory limit accepted for a single sandbox.
+	// +optional
+	// +kubebuilder:default="32Gi"
+	SandboxMaxMemory string `json:"sandboxMaxMemory,omitempty"`
 	// +optional
 	SandboxRuntimeClassName string `json:"sandboxRuntimeClassName,omitempty"`
 	// DefaultTeamQuotas configures region-wide fallback team quota limits.

--- a/infra-operator/chart/crds/infra.sandbox0.ai_sandbox0infras.yaml
+++ b/infra-operator/chart/crds/infra.sandbox0.ai_sandbox0infras.yaml
@@ -3192,6 +3192,11 @@ spec:
                           resyncPeriod:
                             default: 30s
                             type: string
+                          sandboxMaxMemory:
+                            default: 32Gi
+                            description: SandboxMaxMemory is the maximum memory limit
+                              accepted for a single sandbox.
+                            type: string
                           sandboxRuntimeClassName:
                             type: string
                           shutdownTimeout:

--- a/infra-operator/internal/runtimeconfig/dataplane.go
+++ b/infra-operator/internal/runtimeconfig/dataplane.go
@@ -29,6 +29,7 @@ func ToManager(spec *infrav1alpha1.ManagerConfig) *apiconfig.ManagerConfig {
 	cfg.WebhookKeyPath = spec.WebhookKeyPath
 	cfg.DefaultSandboxTTL = spec.DefaultSandboxTTL
 	cfg.TeamTemplateMemoryPerCPU = spec.TeamTemplateMemoryPerCPU
+	cfg.SandboxMaxMemory = spec.SandboxMaxMemory
 	cfg.SandboxRuntimeClassName = spec.SandboxRuntimeClassName
 	cfg.DefaultTeamQuotas = cloneTeamQuotaLimitConfigs(spec.DefaultTeamQuotas)
 	cfg.AllowColdStartWithoutReadyDataPlane = spec.AllowColdStartWithoutReadyDataPlane

--- a/infra-operator/internal/runtimeconfig/dataplane_test.go
+++ b/infra-operator/internal/runtimeconfig/dataplane_test.go
@@ -66,6 +66,15 @@ func TestToManagerPreservesDefaultTeamQuotas(t *testing.T) {
 	}
 }
 
+func TestToManagerPreservesSandboxMaxMemory(t *testing.T) {
+	cfg := ToManager(&infrav1alpha1.ManagerConfig{
+		SandboxMaxMemory: "16Gi",
+	})
+	if cfg.SandboxMaxMemory != "16Gi" {
+		t.Fatalf("sandbox max memory = %q, want 16Gi", cfg.SandboxMaxMemory)
+	}
+}
+
 func TestToStorageProxyDefaultsObjectEncryptionEnabled(t *testing.T) {
 	cfg := ToStorageProxy(nil)
 	if !cfg.ObjectEncryptionEnabled {

--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -288,6 +288,8 @@ func main() {
 	// Create services
 	cfgForSandbox := service.SandboxServiceConfig{
 		DefaultTTL:                          cfg.DefaultSandboxTTL.Duration,
+		SandboxMemoryPerCPU:                 cfg.TeamTemplateMemoryPerCPU,
+		SandboxMaxMemory:                    cfg.SandboxMaxMemory,
 		PauseMinMemoryRequest:               cfg.PauseMinMemoryRequest,
 		PauseMinMemoryLimit:                 cfg.PauseMinMemoryLimit,
 		PauseMemoryBufferRatio:              pauseMemoryBufferRatio,

--- a/manager/pkg/apis/sandbox0/v1alpha1/helpers.go
+++ b/manager/pkg/apis/sandbox0/v1alpha1/helpers.go
@@ -326,7 +326,11 @@ func buildContainer(spec *ContainerSpec, template *SandboxTemplate) corev1.Conta
 		Name:            name,
 		Image:           spec.Image,
 		ImagePullPolicy: corev1.PullIfNotPresent,
-		Resources:       buildResourceRequirements(spec.Resources),
+		Resources:       BuildResourceRequirements(spec.Resources),
+		ResizePolicy: []corev1.ContainerResizePolicy{
+			{ResourceName: corev1.ResourceCPU, RestartPolicy: corev1.NotRequired},
+			{ResourceName: corev1.ResourceMemory, RestartPolicy: corev1.NotRequired},
+		},
 	}
 
 	if spec.ImagePullPolicy != "" {
@@ -373,7 +377,9 @@ func buildContainer(spec *ContainerSpec, template *SandboxTemplate) corev1.Conta
 	return container
 }
 
-func buildResourceRequirements(quota ResourceQuota) corev1.ResourceRequirements {
+// BuildResourceRequirements converts a sandbox resource quota into Kubernetes
+// container requests and limits.
+func BuildResourceRequirements(quota ResourceQuota) corev1.ResourceRequirements {
 	requests := corev1.ResourceList{}
 	limits := corev1.ResourceList{}
 	if quota.CPU.Sign() > 0 {

--- a/manager/pkg/apis/sandbox0/v1alpha1/helpers_test.go
+++ b/manager/pkg/apis/sandbox0/v1alpha1/helpers_test.go
@@ -345,6 +345,19 @@ manager_image: sandbox0/manager:test
 	assertResourceQuantity(t, resources.Limits[corev1.ResourceEphemeralStorage], "8Gi")
 }
 
+func TestBuildPodSpecUsesRestartFreeResourceResizePolicy(t *testing.T) {
+	configPath := writeManagerConfig(t, `
+manager_image: sandbox0/manager:test
+`)
+	t.Setenv("CONFIG_PATH", configPath)
+
+	spec := BuildPodSpec(newTestTemplate())
+	policies := spec.Containers[0].ResizePolicy
+
+	assertResizePolicy(t, policies, corev1.ResourceCPU, corev1.NotRequired)
+	assertResizePolicy(t, policies, corev1.ResourceMemory, corev1.NotRequired)
+}
+
 func TestBuildPodSpecClampsReducedRequestsToSmallQuota(t *testing.T) {
 	configPath := writeManagerConfig(t, `
 manager_image: sandbox0/manager:test
@@ -367,6 +380,19 @@ manager_image: sandbox0/manager:test
 	assertResourceQuantity(t, resources.Limits[corev1.ResourceMemory], "32Mi")
 	assertResourceQuantity(t, resources.Requests[corev1.ResourceEphemeralStorage], "32Mi")
 	assertResourceQuantity(t, resources.Limits[corev1.ResourceEphemeralStorage], "32Mi")
+}
+
+func assertResizePolicy(t *testing.T, policies []corev1.ContainerResizePolicy, resourceName corev1.ResourceName, want corev1.ResourceResizeRestartPolicy) {
+	t.Helper()
+	for _, policy := range policies {
+		if policy.ResourceName == resourceName {
+			if policy.RestartPolicy != want {
+				t.Fatalf("resize policy %s = %s, want %s", resourceName, policy.RestartPolicy, want)
+			}
+			return
+		}
+	}
+	t.Fatalf("missing resize policy for %s", resourceName)
 }
 
 func TestBuildPodSpecAddsSandboxReadinessGate(t *testing.T) {

--- a/manager/pkg/http/handlers_sandbox.go
+++ b/manager/pkg/http/handlers_sandbox.go
@@ -271,6 +271,10 @@ func (s *Server) updateSandbox(c *gin.Context) {
 			spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
 			return
 		}
+		if errors.Is(err, service.ErrQuotaExceeded) {
+			spec.JSONError(c, http.StatusTooManyRequests, "quota_exceeded", err.Error())
+			return
+		}
 		s.logger.Error("Failed to update sandbox",
 			zap.String("sandboxID", sandboxID),
 			zap.Error(err),

--- a/manager/pkg/service/sandbox_runtime_identity_test.go
+++ b/manager/pkg/service/sandbox_runtime_identity_test.go
@@ -411,6 +411,7 @@ func cloneSandboxRecord(record *SandboxRecord) *SandboxRecord {
 	if record.Config.Services != nil {
 		clone.Config.Services = append([]SandboxAppService(nil), record.Config.Services...)
 	}
+	clone.Config.Resources = cloneSandboxResourceConfig(record.Config.Resources)
 	return &clone
 }
 

--- a/manager/pkg/service/sandbox_service.go
+++ b/manager/pkg/service/sandbox_service.go
@@ -21,23 +21,24 @@ import (
 
 // Sandbox represents a sandbox instance
 type Sandbox struct {
-	ID                string              `json:"id"`
-	TemplateID        string              `json:"template_id"`
-	TeamID            string              `json:"team_id"`
-	UserID            string              `json:"user_id"`
-	InternalAddr      string              `json:"internal_addr"`
-	Status            string              `json:"status"`
-	Paused            bool                `json:"paused"`
-	AutoResume        bool                `json:"auto_resume"`
-	Services          []SandboxAppService `json:"services,omitempty"`
-	Mounts            []ClaimMount        `json:"mounts,omitempty"`
-	PodName           string              `json:"pod_name"`
-	RuntimeGeneration int64               `json:"runtime_generation"`
-	ExpiresAt         time.Time           `json:"expires_at"`
-	HardExpiresAt     time.Time           `json:"hard_expires_at"`
-	ClaimedAt         time.Time           `json:"claimed_at"`
-	CreatedAt         time.Time           `json:"created_at"`
-	UpdatedAt         time.Time           `json:"updated_at"`
+	ID                string                 `json:"id"`
+	TemplateID        string                 `json:"template_id"`
+	TeamID            string                 `json:"team_id"`
+	UserID            string                 `json:"user_id"`
+	InternalAddr      string                 `json:"internal_addr"`
+	Status            string                 `json:"status"`
+	Paused            bool                   `json:"paused"`
+	AutoResume        bool                   `json:"auto_resume"`
+	Resources         *SandboxResourceConfig `json:"resources,omitempty"`
+	Services          []SandboxAppService    `json:"services,omitempty"`
+	Mounts            []ClaimMount           `json:"mounts,omitempty"`
+	PodName           string                 `json:"pod_name"`
+	RuntimeGeneration int64                  `json:"runtime_generation"`
+	ExpiresAt         time.Time              `json:"expires_at"`
+	HardExpiresAt     time.Time              `json:"hard_expires_at"`
+	ClaimedAt         time.Time              `json:"claimed_at"`
+	CreatedAt         time.Time              `json:"created_at"`
+	UpdatedAt         time.Time              `json:"updated_at"`
 }
 
 // SandboxStatus represents possible sandbox statuses
@@ -76,6 +77,8 @@ var claimIdlePodBackoff = wait.Backoff{
 // SandboxServiceConfig handles configuration for SandboxService
 type SandboxServiceConfig struct {
 	DefaultTTL                          time.Duration
+	SandboxMemoryPerCPU                 string
+	SandboxMaxMemory                    string
 	PauseMinMemoryRequest               string
 	PauseMinMemoryLimit                 string
 	PauseMemoryBufferRatio              float64

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -71,6 +71,7 @@ type BootstrapMountStatus struct {
 // SandboxConfig represents sandbox configuration
 type SandboxConfig struct {
 	EnvVars    map[string]string              `json:"env_vars,omitempty"`
+	Resources  *SandboxResourceConfig         `json:"resources,omitempty"`
 	TTL        *int32                         `json:"ttl,omitempty"`      // Time-to-live in seconds (0 disables)
 	HardTTL    *int32                         `json:"hard_ttl,omitempty"` // Hard time-to-live in seconds (0 disables)
 	Network    *v1alpha1.SandboxNetworkPolicy `json:"network,omitempty"`
@@ -84,11 +85,18 @@ type SandboxConfig struct {
 // Webhook is excluded because it requires reinitializing the sandbox runtime.
 type SandboxUpdateConfig struct {
 	EnvVars    map[string]string              `json:"env_vars,omitempty"`
+	Resources  *SandboxResourceConfig         `json:"resources,omitempty"`
 	TTL        *int32                         `json:"ttl,omitempty"`
 	HardTTL    *int32                         `json:"hard_ttl,omitempty"`
 	Network    *v1alpha1.SandboxNetworkPolicy `json:"network,omitempty"`
 	AutoResume *bool                          `json:"auto_resume,omitempty"`
 	Services   []SandboxAppService            `json:"services,omitempty"`
+}
+
+// SandboxResourceConfig is an instance-level resource override. Only memory is
+// accepted; CPU is derived from the platform memory-per-CPU ratio.
+type SandboxResourceConfig struct {
+	Memory string `json:"memory,omitempty"`
 }
 
 func int32Ptr(v int32) *int32 {
@@ -101,10 +109,18 @@ func cloneSandboxConfig(cfg *SandboxConfig) *SandboxConfig {
 	}
 	cloned := *cfg
 	cloned.EnvVars = cloneEnvVars(cfg.EnvVars)
+	cloned.Resources = cloneSandboxResourceConfig(cfg.Resources)
 	if cloned.Network != nil {
 		cloned.Network = sanitizedNetworkPolicyForPersistence(cloned.Network)
 	}
 	return &cloned
+}
+
+func cloneSandboxResourceConfig(resources *SandboxResourceConfig) *SandboxResourceConfig {
+	if resources == nil {
+		return nil
+	}
+	return &SandboxResourceConfig{Memory: strings.TrimSpace(resources.Memory)}
 }
 
 func cloneEnvVars(envVars map[string]string) map[string]string {
@@ -398,17 +414,11 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 	}
 
 	phaseStarted = time.Now()
-	if err := s.enforceSandboxCPUQuota(ctx, req.TeamID, template); err != nil {
-		s.observeClaimPhase(req.Template, "unknown", "enforce_cpu_quota", phaseStarted, err)
+	if err := s.enforceSandboxResourceQuota(ctx, req.TeamID, template, req.Config); err != nil {
+		s.observeClaimPhase(req.Template, "unknown", "enforce_resource_quota", phaseStarted, err)
 		return nil, err
 	}
-	s.observeClaimPhase(req.Template, "unknown", "enforce_cpu_quota", phaseStarted, nil)
-	phaseStarted = time.Now()
-	if err := s.enforceSandboxMemoryQuota(ctx, req.TeamID, template); err != nil {
-		s.observeClaimPhase(req.Template, "unknown", "enforce_memory_quota", phaseStarted, err)
-		return nil, err
-	}
-	s.observeClaimPhase(req.Template, "unknown", "enforce_memory_quota", phaseStarted, nil)
+	s.observeClaimPhase(req.Template, "unknown", "enforce_resource_quota", phaseStarted, nil)
 
 	phaseStarted = time.Now()
 	if err := validateClaimMountsForTemplate(req, template); err != nil {
@@ -1036,6 +1046,14 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 
 		// Update pod labels and annotations
 		pod = pod.DeepCopy()
+		var resizeQuota *v1alpha1.ResourceQuota
+		if req.Config != nil && req.Config.Resources != nil {
+			resourceQuota, err := s.effectiveSandboxResourceQuota(template, req.Config)
+			if err != nil {
+				return err
+			}
+			resizeQuota = &resourceQuota
+		}
 
 		// Change pool type from idle to active
 		pod.Labels[controller.LabelPoolType] = controller.PoolTypeActive
@@ -1108,6 +1126,22 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 			return updateErr
 		}
 
+		if resizeQuota != nil {
+			resizedPod, resizeErr := s.resizeSandboxPodResources(ctx, updatedPod, *resizeQuota)
+			if resizeErr != nil {
+				rollbackStateVolume()
+				if rollbackErr := rollbackBindings(ctx); rollbackErr != nil {
+					s.logger.Warn("Failed to roll back credential bindings after hot-claim resize failure",
+						zap.String("sandboxID", sandboxID),
+						zap.Error(rollbackErr),
+					)
+				}
+				s.requestSandboxDeletionAfterClaimFailure(updatedPod, "sandbox resource resize failed")
+				return fmt.Errorf("resize sandbox resources: %w", resizeErr)
+			}
+			updatedPod = mergeSandboxMetadataAfterResize(resizedPod, updatedPod)
+		}
+
 		if applyErr := s.applyNetworkProvider(ctx, updatedPod, req.TeamID, policySpecFromState(networkState)); applyErr != nil {
 			s.requestSandboxDeletionAfterClaimFailure(updatedPod, "network policy apply failed")
 			return fmt.Errorf("apply network policy: %w", applyErr)
@@ -1165,6 +1199,13 @@ func (s *SandboxService) createNewPod(ctx context.Context, template *v1alpha1.Sa
 	// Build pod spec before side-effecting resources so claims fail fast when the
 	// sandbox data plane has no ready nodes to receive the pod.
 	spec := v1alpha1.BuildPodSpec(template)
+	resourceQuota, err := s.effectiveSandboxResourceQuota(template, req.Config)
+	if err != nil {
+		return nil, err
+	}
+	if err := applySandboxResourceQuotaToPodSpec(&spec, resourceQuota); err != nil {
+		return nil, err
+	}
 	if err := s.ensureDataPlaneReadyCapacity(spec); err != nil {
 		return nil, err
 	}

--- a/manager/pkg/service/sandbox_service_lifecycle.go
+++ b/manager/pkg/service/sandbox_service_lifecycle.go
@@ -609,6 +609,7 @@ func cloneSandboxRecordForLifecycle(record *SandboxRecord) *SandboxRecord {
 	if record.Config.Services != nil {
 		clone.Config.Services = append([]SandboxAppService(nil), record.Config.Services...)
 	}
+	clone.Config.Resources = cloneSandboxResourceConfig(record.Config.Resources)
 	return &clone
 }
 
@@ -720,10 +721,12 @@ func (s *SandboxService) UpdateSandbox(ctx context.Context, sandboxID string, cf
 			return err
 		}
 
+		var resizeQuota *v1alpha1.ResourceQuota
 		updatedPod = current.DeepCopy()
 		if updatedPod.Annotations == nil {
 			updatedPod.Annotations = make(map[string]string)
 		}
+		teamID := updatedPod.Annotations[controller.AnnotationTeamID]
 
 		merged := SandboxConfig{}
 		if configJSON := updatedPod.Annotations[controller.AnnotationConfig]; configJSON != "" {
@@ -759,13 +762,28 @@ func (s *SandboxService) UpdateSandbox(ctx context.Context, sandboxID string, cf
 			}
 			merged.Services = services
 		}
+		if cfg.Resources != nil {
+			merged.Resources = cloneSandboxResourceConfig(cfg.Resources)
+			template := s.templateForPod(updatedPod)
+			if template == nil {
+				return fmt.Errorf("template for sandbox pod not found")
+			}
+			resourceQuota, err := s.effectiveSandboxResourceQuota(template, &merged)
+			if err != nil {
+				return err
+			}
+			if err := s.enforceSandboxResourceQuotaIncrease(ctx, teamID, current, resourceQuota); err != nil {
+				return err
+			}
+			resizeQuota = &resourceQuota
+			merged.Resources = &SandboxResourceConfig{Memory: resourceQuota.Memory.String()}
+		}
 
 		if cfg.Network != nil {
 			if s.NetworkPolicyService == nil {
 				return fmt.Errorf("network policy service not configured")
 			}
 
-			teamID := updatedPod.Annotations[controller.AnnotationTeamID]
 			templateSpec, templateBindings := s.templateNetworkDefaults(updatedPod)
 			requestSpec := merged.Network
 			if cfg.Network != nil {
@@ -805,6 +823,22 @@ func (s *SandboxService) UpdateSandbox(ctx context.Context, sandboxID string, cf
 			return fmt.Errorf("marshal sandbox config: %w", err)
 		}
 		updatedPod.Annotations[controller.AnnotationConfig] = string(updatedConfigJSON)
+
+		if resizeQuota != nil {
+			resizedPod, err := s.resizeSandboxPodResources(ctx, current, *resizeQuota)
+			if err != nil {
+				if rollbackBindings != nil {
+					if rollbackErr := rollbackBindings(ctx); rollbackErr != nil {
+						s.logger.Warn("Failed to roll back credential bindings after sandbox resize failure",
+							zap.String("sandboxID", sandboxID),
+							zap.Error(rollbackErr),
+						)
+					}
+				}
+				return err
+			}
+			updatedPod = mergeSandboxMetadataAfterResize(resizedPod, updatedPod)
+		}
 
 		updatedPod, err = s.k8sClient.CoreV1().Pods(pod.Namespace).Update(ctx, updatedPod, metav1.UpdateOptions{})
 		if err != nil && rollbackBindings != nil {
@@ -872,6 +906,13 @@ func (s *SandboxService) updatePausedSandboxRecord(ctx context.Context, record *
 			return nil, err
 		}
 		merged.Services = services
+	}
+	if cfg.Resources != nil {
+		memory, err := s.validateSandboxMemory(cfg.Resources.Memory)
+		if err != nil {
+			return nil, err
+		}
+		merged.Resources = &SandboxResourceConfig{Memory: memory.String()}
 	}
 	if cfg.Network != nil {
 		merged.Network = sanitizedNetworkPolicyForPersistence(cfg.Network)
@@ -1085,6 +1126,7 @@ func (s *SandboxService) podToSandbox(ctx context.Context, pod *corev1.Pod, sand
 		Status:            status,
 		Paused:            status == SandboxStatusPaused,
 		AutoResume:        autoResume,
+		Resources:         cloneSandboxResourceConfig(cfg.Resources),
 		Services:          cfg.Services,
 		Mounts:            parseClaimMounts(pod.Annotations[controller.AnnotationMounts]),
 		PodName:           pod.Name,
@@ -1113,6 +1155,7 @@ func (s *SandboxService) recordToSandbox(record *SandboxRecord) *Sandbox {
 		Status:            record.Status,
 		Paused:            record.Status == SandboxStatusPaused,
 		AutoResume:        autoResume,
+		Resources:         cloneSandboxResourceConfig(record.Config.Resources),
 		Services:          record.Config.Services,
 		Mounts:            record.Mounts,
 		PodName:           record.CurrentPodName,

--- a/manager/pkg/service/sandbox_service_quota.go
+++ b/manager/pkg/service/sandbox_service_quota.go
@@ -32,13 +32,13 @@ func (s *SandboxService) enforceActiveSandboxQuota(ctx context.Context, teamID s
 	return fmt.Errorf("%w: %s", ErrQuotaExceeded, decision.Err())
 }
 
-func (s *SandboxService) enforceSandboxCPUQuota(ctx context.Context, teamID string, template *v1alpha1.SandboxTemplate) error {
-	requested := templateCPUMillicpu(template)
+func (s *SandboxService) enforceSandboxCPUQuota(ctx context.Context, teamID string, resourceQuota v1alpha1.ResourceQuota) error {
+	requested := resourceQuota.CPU.MilliValue()
 	return s.enforceQuota(ctx, teamID, quota.DimensionCPU, requested)
 }
 
-func (s *SandboxService) enforceSandboxMemoryQuota(ctx context.Context, teamID string, template *v1alpha1.SandboxTemplate) error {
-	requested := templateMemoryMiB(template)
+func (s *SandboxService) enforceSandboxMemoryQuota(ctx context.Context, teamID string, resourceQuota v1alpha1.ResourceQuota) error {
+	requested := bytesToMiBRoundUp(resourceQuota.Memory.Value())
 	return s.enforceQuota(ctx, teamID, quota.DimensionMemory, requested)
 }
 
@@ -63,20 +63,6 @@ func (s *SandboxService) enforceQuota(ctx context.Context, teamID string, dimens
 		return nil
 	}
 	return fmt.Errorf("%w: %s", ErrQuotaExceeded, decision.Err())
-}
-
-func templateCPUMillicpu(template *v1alpha1.SandboxTemplate) int64 {
-	if template == nil {
-		return 0
-	}
-	return template.Spec.MainContainer.Resources.CPU.MilliValue()
-}
-
-func templateMemoryMiB(template *v1alpha1.SandboxTemplate) int64 {
-	if template == nil {
-		return 0
-	}
-	return bytesToMiBRoundUp(template.Spec.MainContainer.Resources.Memory.Value())
 }
 
 func bytesToMiBRoundUp(value int64) int64 {

--- a/manager/pkg/service/sandbox_service_quota_test.go
+++ b/manager/pkg/service/sandbox_service_quota_test.go
@@ -68,7 +68,7 @@ func TestEnforceSandboxCPUQuotaRejectsWhenRequestedWouldExceedLimit(t *testing.T
 	}
 	template := newQuotaTestTemplate("default", "500m", "1Gi")
 
-	err := svc.enforceSandboxCPUQuota(context.Background(), "team-1", template)
+	err := svc.enforceSandboxCPUQuota(context.Background(), "team-1", template.Spec.MainContainer.Resources)
 	if !errors.Is(err, ErrQuotaExceeded) {
 		t.Fatalf("enforceSandboxCPUQuota() error = %v, want ErrQuotaExceeded", err)
 	}
@@ -83,7 +83,7 @@ func TestEnforceSandboxCPUQuotaAllowsBelowLimit(t *testing.T) {
 	}
 	template := newQuotaTestTemplate("default", "500m", "1Gi")
 
-	if err := svc.enforceSandboxCPUQuota(context.Background(), "team-1", template); err != nil {
+	if err := svc.enforceSandboxCPUQuota(context.Background(), "team-1", template.Spec.MainContainer.Resources); err != nil {
 		t.Fatalf("enforceSandboxCPUQuota() error = %v, want nil", err)
 	}
 }
@@ -97,7 +97,7 @@ func TestEnforceSandboxMemoryQuotaRejectsWhenRequestedWouldExceedLimit(t *testin
 	}
 	template := newQuotaTestTemplate("default", "500m", "512Mi")
 
-	err := svc.enforceSandboxMemoryQuota(context.Background(), "team-1", template)
+	err := svc.enforceSandboxMemoryQuota(context.Background(), "team-1", template.Spec.MainContainer.Resources)
 	if !errors.Is(err, ErrQuotaExceeded) {
 		t.Fatalf("enforceSandboxMemoryQuota() error = %v, want ErrQuotaExceeded", err)
 	}
@@ -112,7 +112,7 @@ func TestEnforceSandboxMemoryQuotaAllowsBelowLimit(t *testing.T) {
 	}
 	template := newQuotaTestTemplate("default", "500m", "512Mi")
 
-	if err := svc.enforceSandboxMemoryQuota(context.Background(), "team-1", template); err != nil {
+	if err := svc.enforceSandboxMemoryQuota(context.Background(), "team-1", template.Spec.MainContainer.Resources); err != nil {
 		t.Fatalf("enforceSandboxMemoryQuota() error = %v, want nil", err)
 	}
 }

--- a/manager/pkg/service/sandbox_service_resources.go
+++ b/manager/pkg/service/sandbox_service_resources.go
@@ -1,0 +1,246 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
+	"github.com/sandbox0-ai/sandbox0/pkg/quota"
+	s0template "github.com/sandbox0-ai/sandbox0/pkg/template"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	defaultSandboxMinMemory = "128Mi"
+	defaultSandboxMaxMemory = "32Gi"
+)
+
+func (s *SandboxService) effectiveSandboxResourceQuota(template *v1alpha1.SandboxTemplate, cfg *SandboxConfig) (v1alpha1.ResourceQuota, error) {
+	if template == nil {
+		return v1alpha1.ResourceQuota{}, fmt.Errorf("%w: template is required", ErrInvalidClaimRequest)
+	}
+	quota := *template.Spec.MainContainer.Resources.DeepCopy()
+	if cfg == nil || cfg.Resources == nil {
+		return quota, nil
+	}
+	memory, err := s.validateSandboxMemory(cfg.Resources.Memory)
+	if err != nil {
+		return v1alpha1.ResourceQuota{}, err
+	}
+	quota.Memory = memory
+	quota.CPU = s0template.CPUForMemory(memory, s.sandboxMemoryPerCPU())
+	return quota, nil
+}
+
+func (s *SandboxService) applySandboxResourceQuota(pod *corev1.Pod, quota v1alpha1.ResourceQuota) error {
+	if pod == nil {
+		return fmt.Errorf("%w: pod is required", ErrInvalidClaimRequest)
+	}
+	return applySandboxResourceQuotaToPodSpec(&pod.Spec, quota)
+}
+
+func (s *SandboxService) resizeSandboxPodResources(ctx context.Context, pod *corev1.Pod, quota v1alpha1.ResourceQuota) (*corev1.Pod, error) {
+	if s == nil || s.k8sClient == nil {
+		return nil, fmt.Errorf("%w: kubernetes client is not configured", ErrInvalidClaimRequest)
+	}
+	resized := pod.DeepCopy()
+	if err := s.applySandboxResourceQuota(resized, quota); err != nil {
+		return nil, err
+	}
+	updated, err := s.k8sClient.CoreV1().Pods(resized.Namespace).UpdateResize(ctx, resized.Name, resized, metav1.UpdateOptions{})
+	if err != nil {
+		return nil, err
+	}
+	if updated == nil || updated.Name == "" {
+		return resized, nil
+	}
+	return updated, nil
+}
+
+func mergeSandboxMetadataAfterResize(resizedPod, metadataPod *corev1.Pod) *corev1.Pod {
+	if resizedPod == nil {
+		return metadataPod
+	}
+	if metadataPod == nil {
+		return resizedPod
+	}
+	merged := resizedPod.DeepCopy()
+	merged.Labels = cloneMetadataMap(metadataPod.Labels)
+	merged.Annotations = cloneMetadataMap(metadataPod.Annotations)
+	merged.Finalizers = append([]string(nil), metadataPod.Finalizers...)
+	merged.OwnerReferences = append([]metav1.OwnerReference(nil), metadataPod.OwnerReferences...)
+	return merged
+}
+
+func cloneMetadataMap(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}
+
+func applySandboxResourceQuotaToPodSpec(spec *corev1.PodSpec, quota v1alpha1.ResourceQuota) error {
+	if spec == nil {
+		return fmt.Errorf("%w: pod spec is required", ErrInvalidClaimRequest)
+	}
+	for i := range spec.Containers {
+		if spec.Containers[i].Name != "procd" {
+			continue
+		}
+		spec.Containers[i].Resources = v1alpha1.BuildResourceRequirements(quota)
+		ensureSandboxResizePolicy(&spec.Containers[i])
+		return nil
+	}
+	return fmt.Errorf("%w: sandbox runtime container not found", ErrInvalidClaimRequest)
+}
+
+func ensureSandboxResizePolicy(container *corev1.Container) {
+	if container == nil {
+		return
+	}
+	upsert := func(name corev1.ResourceName) {
+		for i := range container.ResizePolicy {
+			if container.ResizePolicy[i].ResourceName == name {
+				container.ResizePolicy[i].RestartPolicy = corev1.NotRequired
+				return
+			}
+		}
+		container.ResizePolicy = append(container.ResizePolicy, corev1.ContainerResizePolicy{
+			ResourceName:  name,
+			RestartPolicy: corev1.NotRequired,
+		})
+	}
+	upsert(corev1.ResourceCPU)
+	upsert(corev1.ResourceMemory)
+}
+
+func (s *SandboxService) validateSandboxMemory(value string) (resource.Quantity, error) {
+	raw := strings.TrimSpace(value)
+	if raw == "" {
+		return resource.Quantity{}, fmt.Errorf("%w: config.resources.memory is required", ErrInvalidClaimRequest)
+	}
+	memory, err := resource.ParseQuantity(raw)
+	if err != nil {
+		return resource.Quantity{}, fmt.Errorf("%w: config.resources.memory is invalid: %v", ErrInvalidClaimRequest, err)
+	}
+	if memory.Sign() <= 0 {
+		return resource.Quantity{}, fmt.Errorf("%w: config.resources.memory must be > 0", ErrInvalidClaimRequest)
+	}
+	minMemory := sandboxMemoryQuantityOrDefault(defaultSandboxMinMemory, defaultSandboxMinMemory)
+	if memory.Cmp(minMemory) < 0 {
+		return resource.Quantity{}, fmt.Errorf("%w: config.resources.memory must be >= %s", ErrInvalidClaimRequest, minMemory.String())
+	}
+	maxMemory := s.sandboxMaxMemory()
+	if memory.Cmp(maxMemory) > 0 {
+		return resource.Quantity{}, fmt.Errorf("%w: config.resources.memory must be <= %s", ErrInvalidClaimRequest, maxMemory.String())
+	}
+	return memory, nil
+}
+
+func (s *SandboxService) sandboxMemoryPerCPU() resource.Quantity {
+	if s == nil {
+		return s0template.MemoryPerCPUOrDefault("")
+	}
+	return s0template.MemoryPerCPUOrDefault(s.config.SandboxMemoryPerCPU)
+}
+
+func (s *SandboxService) sandboxMaxMemory() resource.Quantity {
+	if s == nil {
+		return sandboxMemoryQuantityOrDefault("", defaultSandboxMaxMemory)
+	}
+	return sandboxMemoryQuantityOrDefault(s.config.SandboxMaxMemory, defaultSandboxMaxMemory)
+}
+
+func sandboxMemoryQuantityOrDefault(value, fallback string) resource.Quantity {
+	parsed, err := resource.ParseQuantity(strings.TrimSpace(value))
+	if err == nil && parsed.Sign() > 0 {
+		return parsed
+	}
+	return resource.MustParse(fallback)
+}
+
+func (s *SandboxService) enforceSandboxResourceQuota(ctx context.Context, teamID string, template *v1alpha1.SandboxTemplate, cfg *SandboxConfig) error {
+	quota, err := s.effectiveSandboxResourceQuota(template, cfg)
+	if err != nil {
+		return err
+	}
+	if err := s.enforceSandboxCPUQuota(ctx, teamID, quota); err != nil {
+		return err
+	}
+	return s.enforceSandboxMemoryQuota(ctx, teamID, quota)
+}
+
+func (s *SandboxService) enforceSandboxResourceQuotaIncrease(ctx context.Context, teamID string, current *corev1.Pod, next v1alpha1.ResourceQuota) error {
+	currentCPU, currentMemoryBytes := podContainerResourceAllocation(current)
+	oldCPU, oldMemoryBytes, ok := podRuntimeContainerResourceAllocation(current)
+	if !ok {
+		return fmt.Errorf("%w: sandbox runtime container not found", ErrInvalidClaimRequest)
+	}
+	nextCPU := currentCPU - oldCPU + next.CPU.MilliValue()
+	nextMemoryMiB := bytesToMiBRoundUp(currentMemoryBytes - oldMemoryBytes + next.Memory.Value())
+	currentMemoryMiB := bytesToMiBRoundUp(currentMemoryBytes)
+	if delta := nextCPU - currentCPU; delta > 0 {
+		if err := s.enforceQuota(ctx, teamID, quota.DimensionCPU, delta); err != nil {
+			return err
+		}
+	}
+	if delta := nextMemoryMiB - currentMemoryMiB; delta > 0 {
+		if err := s.enforceQuota(ctx, teamID, quota.DimensionMemory, delta); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func podContainerResourceAllocation(pod *corev1.Pod) (int64, int64) {
+	if pod == nil {
+		return 0, 0
+	}
+	var cpuMillis int64
+	var memoryBytes int64
+	for _, container := range pod.Spec.Containers {
+		cpuMillis += resourceListCPU(container.Resources)
+		memoryBytes += resourceListMemory(container.Resources)
+	}
+	return cpuMillis, memoryBytes
+}
+
+func podRuntimeContainerResourceAllocation(pod *corev1.Pod) (int64, int64, bool) {
+	if pod == nil {
+		return 0, 0, false
+	}
+	for _, container := range pod.Spec.Containers {
+		if container.Name != "procd" {
+			continue
+		}
+		return resourceListCPU(container.Resources), resourceListMemory(container.Resources), true
+	}
+	return 0, 0, false
+}
+
+func resourceListCPU(requirements corev1.ResourceRequirements) int64 {
+	if quantity, ok := requirements.Limits[corev1.ResourceCPU]; ok && !quantity.IsZero() {
+		return quantity.MilliValue()
+	}
+	if quantity, ok := requirements.Requests[corev1.ResourceCPU]; ok && !quantity.IsZero() {
+		return quantity.MilliValue()
+	}
+	return 0
+}
+
+func resourceListMemory(requirements corev1.ResourceRequirements) int64 {
+	if quantity, ok := requirements.Limits[corev1.ResourceMemory]; ok && !quantity.IsZero() {
+		return quantity.Value()
+	}
+	if quantity, ok := requirements.Requests[corev1.ResourceMemory]; ok && !quantity.IsZero() {
+		return quantity.Value()
+	}
+	return 0
+}

--- a/manager/pkg/service/sandbox_service_resources_test.go
+++ b/manager/pkg/service/sandbox_service_resources_test.go
@@ -1,0 +1,337 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
+	"github.com/sandbox0-ai/sandbox0/pkg/dataplane"
+	"github.com/sandbox0-ai/sandbox0/pkg/naming"
+	"github.com/sandbox0-ai/sandbox0/pkg/quota"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestEffectiveSandboxResourceQuotaDerivesCPUFromMemory(t *testing.T) {
+	svc := &SandboxService{config: SandboxServiceConfig{SandboxMemoryPerCPU: "4Gi"}}
+	template := newSandboxResourceTestTemplate(t)
+
+	quota, err := svc.effectiveSandboxResourceQuota(template, &SandboxConfig{
+		Resources: &SandboxResourceConfig{Memory: "128Mi"},
+	})
+	if err != nil {
+		t.Fatalf("effectiveSandboxResourceQuota() error = %v", err)
+	}
+	assertQuantity(t, quota.Memory, "128Mi")
+	assertQuantity(t, quota.CPU, "32m")
+}
+
+func TestValidateSandboxMemoryBounds(t *testing.T) {
+	tests := []struct {
+		name      string
+		maxMemory string
+		memory    string
+		wantErr   string
+	}{
+		{name: "minimum accepted", memory: "128Mi"},
+		{name: "below minimum rejected", memory: "127Mi", wantErr: "must be >= 128Mi"},
+		{name: "default max accepted", memory: "32Gi"},
+		{name: "above default max rejected", memory: "33Gi", wantErr: "must be <= 32Gi"},
+		{name: "custom max accepted", maxMemory: "64Gi", memory: "64Gi"},
+		{name: "above custom max rejected", maxMemory: "64Gi", memory: "65Gi", wantErr: "must be <= 64Gi"},
+		{name: "invalid rejected", memory: "large", wantErr: "is invalid"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := &SandboxService{config: SandboxServiceConfig{SandboxMaxMemory: tt.maxMemory}}
+			_, err := svc.validateSandboxMemory(tt.memory)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validateSandboxMemory() error = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || !errors.Is(err, ErrInvalidClaimRequest) {
+				t.Fatalf("validateSandboxMemory() error = %v, want ErrInvalidClaimRequest", err)
+			}
+			if got := err.Error(); !contains(got, tt.wantErr) {
+				t.Fatalf("validateSandboxMemory() error = %q, want substring %q", got, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCreateNewPodAppliesClaimMemoryResources(t *testing.T) {
+	withClaimTestPublicKey(t)
+	template := newSandboxResourceTestTemplate(t)
+	client := fake.NewSimpleClientset()
+	svc := &SandboxService{
+		k8sClient:    client,
+		secretLister: newClaimTestSecretLister(t),
+		clock:        systemTime{},
+		config:       SandboxServiceConfig{SandboxMemoryPerCPU: "4Gi"},
+		logger:       zap.NewNop(),
+	}
+
+	pod, err := svc.createNewPod(context.Background(), template, &ClaimRequest{
+		TeamID: "team-a",
+		UserID: "user-a",
+		Config: &SandboxConfig{
+			Resources: &SandboxResourceConfig{Memory: "2Gi"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("createNewPod() error = %v", err)
+	}
+	container := sandboxRuntimeContainer(t, pod)
+	assertQuantity(t, container.Resources.Limits[corev1.ResourceMemory], "2Gi")
+	assertQuantity(t, container.Resources.Limits[corev1.ResourceCPU], "500m")
+	assertResizePolicy(t, container.ResizePolicy, corev1.ResourceCPU, corev1.NotRequired)
+	assertResizePolicy(t, container.ResizePolicy, corev1.ResourceMemory, corev1.NotRequired)
+}
+
+func TestClaimIdlePodAppliesMemoryOverride(t *testing.T) {
+	template := newSandboxResourceTestTemplate(t)
+	idlePod := newSandboxResourceTestIdlePod(t, template, "idle-ready")
+	node := newClaimTestNode("node-a", "10.0.0.1")
+	node.Labels = map[string]string{dataplane.NodeDataPlaneReadyLabel: dataplane.ReadyLabelValue}
+	idlePod.Spec.NodeName = node.Name
+	client := fake.NewSimpleClientset(idlePod.DeepCopy(), node.DeepCopy())
+	svc := &SandboxService{
+		k8sClient:  client,
+		podLister:  newClaimTestPodLister(t, idlePod),
+		nodeLister: newClaimTestNodeLister(t, node),
+		clock:      systemTime{},
+		config:     SandboxServiceConfig{SandboxMemoryPerCPU: "4Gi"},
+		logger:     zap.NewNop(),
+	}
+
+	pod, err := svc.claimIdlePod(context.Background(), template, &ClaimRequest{
+		TeamID: "team-a",
+		UserID: "user-a",
+		Config: &SandboxConfig{Resources: &SandboxResourceConfig{Memory: "2Gi"}},
+	})
+	if err != nil {
+		t.Fatalf("claimIdlePod() error = %v", err)
+	}
+	container := sandboxRuntimeContainer(t, pod)
+	assertQuantity(t, container.Resources.Limits[corev1.ResourceMemory], "2Gi")
+	assertQuantity(t, container.Resources.Limits[corev1.ResourceCPU], "500m")
+	assertResizeSubresourceUpdate(t, client.Actions())
+}
+
+func TestUpdateSandboxAppliesMemoryResourcesAndPersistsConfig(t *testing.T) {
+	template := newSandboxResourceTestTemplate(t)
+	pod := newSandboxResourceTestActivePod(t, template, "sandbox-1")
+	client := fake.NewSimpleClientset(pod.DeepCopy())
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	if err := indexer.Add(pod.DeepCopy()); err != nil {
+		t.Fatalf("add pod: %v", err)
+	}
+	svc := &SandboxService{
+		k8sClient:      client,
+		podLister:      corelisters.NewPodLister(indexer),
+		templateLister: staticTemplateLister{templates: []*v1alpha1.SandboxTemplate{template}},
+		clock:          systemTime{},
+		config:         SandboxServiceConfig{SandboxMemoryPerCPU: "4Gi"},
+		logger:         zap.NewNop(),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	updated, err := svc.UpdateSandbox(ctx, "sandbox-1", &SandboxUpdateConfig{
+		Resources: &SandboxResourceConfig{Memory: "2Gi"},
+	})
+	if err != nil {
+		t.Fatalf("UpdateSandbox() error = %v", err)
+	}
+	if updated.Resources == nil || updated.Resources.Memory != "2Gi" {
+		t.Fatalf("updated resources = %#v, want memory 2Gi", updated.Resources)
+	}
+	stored, err := client.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get pod: %v", err)
+	}
+	container := sandboxRuntimeContainer(t, stored)
+	assertQuantity(t, container.Resources.Limits[corev1.ResourceMemory], "2Gi")
+	assertQuantity(t, container.Resources.Limits[corev1.ResourceCPU], "500m")
+	if got := stored.Annotations[controller.AnnotationConfig]; !contains(got, `"resources":{"memory":"2Gi"}`) {
+		t.Fatalf("config annotation = %s, want resources memory", got)
+	}
+	assertResizeSubresourceUpdate(t, client.Actions())
+}
+
+func TestUpdatePausedSandboxValidatesAndPersistsMemory(t *testing.T) {
+	now := timeNow()
+	record := &SandboxRecord{
+		ID:           "sandbox-1",
+		TeamID:       "team-a",
+		TemplateID:   "default",
+		Status:       SandboxStatusPaused,
+		Config:       SandboxConfig{},
+		ClaimedAt:    now,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+		TemplateSpec: newSandboxResourceTestTemplate(t).Spec,
+	}
+	store := &memorySandboxStore{records: map[string]*SandboxRecord{"sandbox-1": record}}
+	svc := &SandboxService{sandboxStore: store, clock: fixedClock{now: now}, logger: zap.NewNop()}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	updated, err := svc.UpdateSandbox(ctx, "sandbox-1", &SandboxUpdateConfig{
+		Resources: &SandboxResourceConfig{Memory: "2Gi"},
+	})
+	if err != nil {
+		t.Fatalf("UpdateSandbox() error = %v", err)
+	}
+	if updated.Resources == nil || updated.Resources.Memory != "2Gi" {
+		t.Fatalf("updated resources = %#v, want memory 2Gi", updated.Resources)
+	}
+	stored := store.records["sandbox-1"]
+	if stored.Config.Resources == nil || stored.Config.Resources.Memory != "2Gi" {
+		t.Fatalf("stored resources = %#v, want memory 2Gi", stored.Config.Resources)
+	}
+}
+
+func TestUpdateSandboxMemoryQuotaUsesIncreaseOnly(t *testing.T) {
+	template := newSandboxResourceTestTemplate(t)
+	pod := newSandboxResourceTestActivePod(t, template, "sandbox-1")
+	client := fake.NewSimpleClientset(pod.DeepCopy())
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	if err := indexer.Add(pod.DeepCopy()); err != nil {
+		t.Fatalf("add pod: %v", err)
+	}
+	svc := &SandboxService{
+		k8sClient:      client,
+		podLister:      corelisters.NewPodLister(indexer),
+		templateLister: staticTemplateLister{templates: []*v1alpha1.SandboxTemplate{template}},
+		quotaStore: fakeQuotaLimitStore{
+			limit: &quota.Limit{TeamID: "team-a", Dimension: quota.DimensionMemory, LimitValue: 2048},
+			usage: 1024,
+		},
+		clock:  systemTime{},
+		config: SandboxServiceConfig{SandboxMemoryPerCPU: "4Gi"},
+		logger: zap.NewNop(),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if _, err := svc.UpdateSandbox(ctx, "sandbox-1", &SandboxUpdateConfig{
+		Resources: &SandboxResourceConfig{Memory: "2Gi"},
+	}); err != nil {
+		t.Fatalf("UpdateSandbox() error = %v, want nil because only 1Gi increase is charged", err)
+	}
+}
+
+func newSandboxResourceTestTemplate(t *testing.T) *v1alpha1.SandboxTemplate {
+	t.Helper()
+	namespace, err := naming.TemplateNamespaceForTeam("team-a")
+	if err != nil {
+		t.Fatalf("template namespace: %v", err)
+	}
+	return &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: namespace},
+		Spec: v1alpha1.SandboxTemplateSpec{
+			MainContainer: v1alpha1.ContainerSpec{
+				Image: "busybox",
+				Resources: v1alpha1.ResourceQuota{
+					CPU:    resource.MustParse("250m"),
+					Memory: resource.MustParse("1Gi"),
+				},
+			},
+		},
+	}
+}
+
+func newSandboxResourceTestIdlePod(t *testing.T, template *v1alpha1.SandboxTemplate, name string) *corev1.Pod {
+	t.Helper()
+	pod := newClaimTestPod(template.Namespace, name, template.Name, true)
+	pod.Spec = v1alpha1.BuildPodSpec(template)
+	pod.Status.Conditions = append(pod.Status.Conditions, corev1.PodCondition{
+		Type:   v1alpha1.SandboxPodReadinessConditionType,
+		Status: corev1.ConditionTrue,
+	})
+	hash, err := controller.TemplateSpecHash(template)
+	if err != nil {
+		t.Fatalf("template hash: %v", err)
+	}
+	pod.Annotations[controller.AnnotationTemplateSpecHash] = hash
+	return pod
+}
+
+func newSandboxResourceTestActivePod(t *testing.T, template *v1alpha1.SandboxTemplate, name string) *corev1.Pod {
+	t.Helper()
+	pod := newSandboxResourceTestIdlePod(t, template, name)
+	pod.Labels[controller.LabelPoolType] = controller.PoolTypeActive
+	pod.Labels[controller.LabelSandboxID] = name
+	pod.Annotations[controller.AnnotationSandboxID] = name
+	pod.Annotations[controller.AnnotationTeamID] = "team-a"
+	pod.Annotations[controller.AnnotationUserID] = "user-a"
+	pod.Status.PodIP = "10.244.0.10"
+	return pod
+}
+
+func sandboxRuntimeContainer(t *testing.T, pod *corev1.Pod) corev1.Container {
+	t.Helper()
+	if pod == nil {
+		t.Fatal("pod is nil")
+	}
+	for _, container := range pod.Spec.Containers {
+		if container.Name == "procd" {
+			return container
+		}
+	}
+	t.Fatal("missing procd container")
+	return corev1.Container{}
+}
+
+func assertQuantity(t *testing.T, got resource.Quantity, want string) {
+	t.Helper()
+	wantQuantity := resource.MustParse(want)
+	if got.Cmp(wantQuantity) != 0 {
+		t.Fatalf("quantity = %s, want %s", got.String(), wantQuantity.String())
+	}
+}
+
+func assertResizePolicy(t *testing.T, policies []corev1.ContainerResizePolicy, resourceName corev1.ResourceName, want corev1.ResourceResizeRestartPolicy) {
+	t.Helper()
+	for _, policy := range policies {
+		if policy.ResourceName == resourceName {
+			if policy.RestartPolicy != want {
+				t.Fatalf("resize policy %s = %s, want %s", resourceName, policy.RestartPolicy, want)
+			}
+			return
+		}
+	}
+	t.Fatalf("missing resize policy for %s", resourceName)
+}
+
+func assertResizeSubresourceUpdate(t *testing.T, actions []k8stesting.Action) {
+	t.Helper()
+	for _, action := range actions {
+		if action.Matches("update", "pods") && action.GetSubresource() == "resize" {
+			return
+		}
+	}
+	t.Fatalf("missing update pods/resize action; actions = %#v", actions)
+}
+
+func contains(s, substr string) bool {
+	return strings.Contains(s, substr)
+}
+
+func timeNow() time.Time {
+	return time.Date(2026, time.June, 28, 12, 0, 0, 0, time.UTC)
+}

--- a/manager/pkg/service/sandbox_service_restore.go
+++ b/manager/pkg/service/sandbox_service_restore.go
@@ -111,10 +111,7 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 			if err := s.enforceActiveSandboxQuota(lockCtx, locked.TeamID); err != nil {
 				return err
 			}
-			if err := s.enforceSandboxCPUQuota(lockCtx, locked.TeamID, template); err != nil {
-				return err
-			}
-			if err := s.enforceSandboxMemoryQuota(lockCtx, locked.TeamID, template); err != nil {
+			if err := s.enforceSandboxResourceQuota(lockCtx, locked.TeamID, template, &locked.Config); err != nil {
 				return err
 			}
 			generation := locked.RuntimeGeneration + 1

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -4045,6 +4045,8 @@ components:
           type: object
           additionalProperties:
             type: string
+        resources:
+          $ref: "#/components/schemas/SandboxResourceConfig"
         ttl:
           type: integer
           format: int32
@@ -4067,6 +4069,13 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/SandboxAppService"
+    SandboxResourceConfig:
+      type: object
+      description: Instance-level sandbox resource override. Sandbox0 exposes memory only and derives CPU from the platform memory-per-CPU ratio.
+      properties:
+        memory:
+          type: string
+          description: Sandbox memory limit. Must be at least 128Mi and no more than the platform sandbox maximum, which defaults to 32Gi.
     SandboxAppServiceRouteAuth:
       type: object
       properties:
@@ -4346,6 +4355,8 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/SandboxAppService"
+        resources:
+          $ref: "#/components/schemas/SandboxResourceConfig"
         mounts:
           type: array
           items:
@@ -4416,6 +4427,8 @@ components:
             Sandbox-level environment variables used as defaults for new procd-managed
             processes. Omitting this field preserves the existing environment map; passing
             an empty object clears it.
+        resources:
+          $ref: "#/components/schemas/SandboxResourceConfig"
         ttl:
           type: integer
           format: int32

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -1560,6 +1560,9 @@ type Sandbox struct {
 	Paused  bool   `json:"paused"`
 	PodName string `json:"pod_name"`
 
+	// Resources Instance-level sandbox resource override. Sandbox0 exposes memory only and derives CPU from the platform memory-per-CPU ratio.
+	Resources *SandboxResourceConfig `json:"resources,omitempty"`
+
 	// RuntimeGeneration Monotonically increasing runtime generation. Resume starts a new generation.
 	RuntimeGeneration int64                  `json:"runtime_generation"`
 	Services          *[]SandboxAppService   `json:"services,omitempty"`
@@ -1688,9 +1691,12 @@ type SandboxConfig struct {
 	EnvVars    *map[string]string `json:"env_vars,omitempty"`
 
 	// HardTtl Sandbox hard time-to-live in seconds. When it expires, Sandbox0 deletes the sandbox identity and durable state, including paused rootfs checkpoints.
-	HardTtl  *int32                `json:"hard_ttl,omitempty"`
-	Network  *SandboxNetworkPolicy `json:"network,omitempty"`
-	Services *[]SandboxAppService  `json:"services,omitempty"`
+	HardTtl *int32                `json:"hard_ttl,omitempty"`
+	Network *SandboxNetworkPolicy `json:"network,omitempty"`
+
+	// Resources Instance-level sandbox resource override. Sandbox0 exposes memory only and derives CPU from the platform memory-per-CPU ratio.
+	Resources *SandboxResourceConfig `json:"resources,omitempty"`
+	Services  *[]SandboxAppService   `json:"services,omitempty"`
 
 	// Ttl Runtime soft time-to-live in seconds. When it expires, Sandbox0 checkpoints the writable rootfs, pauses the sandbox, and releases runtime compute while preserving durable sandbox state.
 	Ttl *int32 `json:"ttl,omitempty"`
@@ -1752,6 +1758,12 @@ type SandboxNetworkPolicyMode string
 type SandboxRefreshRequest struct {
 	// Duration Duration to extend TTL in seconds (optional, defaults to original TTL)
 	Duration *int32 `json:"duration,omitempty"`
+}
+
+// SandboxResourceConfig Instance-level sandbox resource override. Sandbox0 exposes memory only and derives CPU from the platform memory-per-CPU ratio.
+type SandboxResourceConfig struct {
+	// Memory Sandbox memory limit. Must be at least 128Mi and no more than the platform sandbox maximum, which defaults to 32Gi.
+	Memory *string `json:"memory,omitempty"`
 }
 
 // SandboxResourceUsage defines model for SandboxResourceUsage.
@@ -1880,9 +1892,12 @@ type SandboxUpdateConfig struct {
 	EnvVars *map[string]string `json:"env_vars,omitempty"`
 
 	// HardTtl Sandbox hard time-to-live in seconds. When it expires, Sandbox0 deletes the sandbox identity and durable state, including paused rootfs checkpoints.
-	HardTtl  *int32                `json:"hard_ttl,omitempty"`
-	Network  *SandboxNetworkPolicy `json:"network,omitempty"`
-	Services *[]SandboxAppService  `json:"services,omitempty"`
+	HardTtl *int32                `json:"hard_ttl,omitempty"`
+	Network *SandboxNetworkPolicy `json:"network,omitempty"`
+
+	// Resources Instance-level sandbox resource override. Sandbox0 exposes memory only and derives CPU from the platform memory-per-CPU ratio.
+	Resources *SandboxResourceConfig `json:"resources,omitempty"`
+	Services  *[]SandboxAppService   `json:"services,omitempty"`
 
 	// Ttl Runtime soft time-to-live in seconds. When it expires, Sandbox0 checkpoints the writable rootfs, pauses the sandbox, and releases runtime compute while preserving durable sandbox state.
 	Ttl *int32 `json:"ttl,omitempty"`

--- a/pkg/sshgateway/connection_test.go
+++ b/pkg/sshgateway/connection_test.go
@@ -34,6 +34,7 @@ func TestSandboxToAPIIncludesSSHInfo(t *testing.T) {
 		PodName:       "pod-1",
 		AutoResume:    true,
 		Paused:        false,
+		Resources:     &mgr.SandboxResourceConfig{Memory: "512Mi"},
 		ClaimedAt:     now,
 		CreatedAt:     now,
 		ExpiresAt:     now,
@@ -55,5 +56,8 @@ func TestSandboxToAPIIncludesSSHInfo(t *testing.T) {
 	}
 	if payload.Ssh.Username != sandbox.ID {
 		t.Fatalf("ssh username = %q", payload.Ssh.Username)
+	}
+	if payload.Resources == nil || payload.Resources.Memory == nil || *payload.Resources.Memory != "512Mi" {
+		t.Fatalf("resources = %#v, want memory 512Mi", payload.Resources)
 	}
 }

--- a/pkg/sshgateway/sandbox_response.go
+++ b/pkg/sshgateway/sandbox_response.go
@@ -30,6 +30,10 @@ func SandboxToAPI(sandbox *mgr.Sandbox, sshInfo *ConnectionInfo) *apispec.Sandbo
 	if sandbox.UserID != "" {
 		payload.UserId = &sandbox.UserID
 	}
+	if sandbox.Resources != nil && sandbox.Resources.Memory != "" {
+		memory := sandbox.Resources.Memory
+		payload.Resources = &apispec.SandboxResourceConfig{Memory: &memory}
+	}
 	if sshInfo != nil {
 		payload.Ssh = &apispec.SandboxSSHConnection{
 			Host:     sshInfo.Host,

--- a/pkg/template/resource_policy.go
+++ b/pkg/template/resource_policy.go
@@ -2,6 +2,7 @@ package template
 
 import (
 	"fmt"
+	"math/big"
 	"strings"
 
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
@@ -26,6 +27,25 @@ func MemoryForCPU(cpu, memoryPerCPU resource.Quantity) resource.Quantity {
 	}
 	requiredBytes := cpu.MilliValue() * memoryPerCPU.Value() / 1000
 	return *resource.NewQuantity(requiredBytes, resource.BinarySI)
+}
+
+// CPUForMemory returns the CPU limit required for a memory limit at the given
+// memory-per-CPU ratio, rounded up to Kubernetes millicpu precision.
+func CPUForMemory(memory, memoryPerCPU resource.Quantity) resource.Quantity {
+	if memory.Sign() <= 0 || memoryPerCPU.Sign() <= 0 {
+		return resource.Quantity{}
+	}
+	numerator := big.NewInt(memory.Value())
+	numerator.Mul(numerator, big.NewInt(1000))
+	denominator := big.NewInt(memoryPerCPU.Value())
+	quotient, remainder := new(big.Int).QuoRem(numerator, denominator, new(big.Int))
+	if remainder.Sign() > 0 {
+		quotient.Add(quotient, big.NewInt(1))
+	}
+	if !quotient.IsInt64() {
+		return *resource.NewMilliQuantity(1<<63-1, resource.DecimalSI)
+	}
+	return *resource.NewMilliQuantity(quotient.Int64(), resource.DecimalSI)
 }
 
 // ValidateResourceRatio enforces the platform CPU-to-memory resource shape for template specs.

--- a/pkg/template/resource_policy_test.go
+++ b/pkg/template/resource_policy_test.go
@@ -44,6 +44,31 @@ func TestMemoryForCPU(t *testing.T) {
 	}
 }
 
+func TestCPUForMemory(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		memory string
+		want   string
+	}{
+		{name: "whole cpu", memory: "4Gi", want: "1"},
+		{name: "fractional minimum sandbox memory rounds up to millicpu", memory: "128Mi", want: "32m"},
+		{name: "half cpu", memory: "2Gi", want: "500m"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := CPUForMemory(resource.MustParse(tt.memory), resource.MustParse("4Gi"))
+			want := resource.MustParse(tt.want)
+			if got.Cmp(want) != 0 {
+				t.Fatalf("CPUForMemory(%s) = %s, want %s", tt.memory, got.String(), want.String())
+			}
+		})
+	}
+}
+
 func TestValidateResourceRatio(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- add `config.resources.memory` to sandbox claim/update APIs and responses
- derive sandbox CPU from the existing memory-per-CPU ratio and enforce 128Mi min / configurable max memory, default 32Gi
- use Kubernetes `pods/resize` for hot-claim and active runtime memory changes, with restart-free CPU/memory resize policy
- wire `sandboxMaxMemory` through infra operator config, OpenAPI generation, CRDs, and docs

## Tests
- `go test ./pkg/template ./manager/pkg/apis/sandbox0/v1alpha1 ./manager/pkg/service ./manager/pkg/http ./infra-operator/api/config ./infra-operator/api/v1alpha1 ./infra-operator/internal/runtimeconfig ./infra-operator/internal/controller/pkg/rbac`
