### PR TITLE
Fix cold claim netd apply race

### DIFF
--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -489,9 +489,35 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 
 	// Note: Network policies are stored in pod annotations.
 	// They are set in claimIdlePod() and createNewPod() methods. Hot claims have
-	// already selected a Kubernetes-ready idle pod; cold claims use the faster
-	// claim-ready path below and let Kubernetes PodReady catch up asynchronously.
+	// already selected a Kubernetes-ready idle pod. Cold claims must wait until
+	// the pod has the network identity netd watches before waiting for netd to
+	// patch the applied policy hash.
 	if claimType == "cold" {
+		if s.networkProvider != nil {
+			phaseStarted = time.Now()
+			networkPod, err := s.waitForPodNetworkIdentity(ctx, pod.Namespace, pod.Name)
+			s.observeClaimPhase(req.Template, claimType, "wait_for_pod_network_identity", phaseStarted, err)
+			if err != nil {
+				s.requestSandboxDeletionAfterClaimFailure(pod, "network identity readiness failed")
+				if metrics != nil {
+					metrics.SandboxClaimsTotal.WithLabelValues(req.Template, "error").Inc()
+				}
+				return nil, fmt.Errorf("wait for pod network identity: %w", err)
+			}
+			pod = networkPod
+
+			phaseStarted = time.Now()
+			err = s.applyNetworkProviderFromPod(ctx, pod, req.TeamID)
+			s.observeClaimPhase(req.Template, claimType, "apply_network_policy", phaseStarted, err)
+			if err != nil {
+				s.requestSandboxDeletionAfterClaimFailure(pod, "network policy apply failed")
+				if metrics != nil {
+					metrics.SandboxClaimsTotal.WithLabelValues(req.Template, "error").Inc()
+				}
+				return nil, fmt.Errorf("apply network policy: %w", err)
+			}
+		}
+
 		phaseStarted = time.Now()
 		readyPod, err := s.waitForPodClaimReady(ctx, pod.Namespace, pod.Name)
 		s.observeClaimPhase(req.Template, claimType, "wait_for_pod_claim_ready", phaseStarted, err)
@@ -1309,11 +1335,6 @@ func (s *SandboxService) createNewPod(ctx context.Context, template *v1alpha1.Sa
 			)
 		}
 		return nil, fmt.Errorf("create pod: %w", err)
-	}
-
-	if err := s.applyNetworkProvider(ctx, createdPod, req.TeamID, policySpecFromState(networkState)); err != nil {
-		s.requestSandboxDeletionAfterClaimFailure(createdPod, "network policy apply failed")
-		return nil, fmt.Errorf("apply network policy: %w", err)
 	}
 
 	s.logger.Info("Created new pod for cold start",

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -461,7 +461,39 @@ func TestWaitForPodClaimReadyUsesSandboxReadinessWithoutPodReady(t *testing.T) {
 	}
 }
 
-func TestCreateNewPodRequestsDeleteAfterNetworkApplyFailure(t *testing.T) {
+func TestWaitForPodNetworkIdentityWaitsForNodeNameAndPodIP(t *testing.T) {
+	pod := newClaimTestPod("ns-a", "cold-pod", "template-a", false)
+	indexer := newClaimTestPodIndexer(t, pod)
+	svc := &SandboxService{
+		podLister: corelisters.NewPodLister(indexer),
+		logger:    zap.NewNop(),
+	}
+
+	go func() {
+		time.Sleep(80 * time.Millisecond)
+		updated := pod.DeepCopy()
+		updated.Spec.NodeName = "node-a"
+		updated.Status.PodIP = "10.244.0.10"
+		if err := indexer.Update(updated); err != nil {
+			t.Errorf("update pod: %v", err)
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	readyPod, err := svc.waitForPodNetworkIdentity(ctx, pod.Namespace, pod.Name)
+	if err != nil {
+		t.Fatalf("waitForPodNetworkIdentity() error = %v", err)
+	}
+	if readyPod.Spec.NodeName != "node-a" {
+		t.Fatalf("node name = %q, want node-a", readyPod.Spec.NodeName)
+	}
+	if readyPod.Status.PodIP != "10.244.0.10" {
+		t.Fatalf("pod IP = %q, want 10.244.0.10", readyPod.Status.PodIP)
+	}
+}
+
+func TestCreateNewPodDefersNetworkApplyUntilPodHasNetworkIdentity(t *testing.T) {
 	withClaimTestPublicKey(t)
 
 	template := &v1alpha1.SandboxTemplate{
@@ -473,40 +505,87 @@ func TestCreateNewPodRequestsDeleteAfterNetworkApplyFailure(t *testing.T) {
 			MainContainer: v1alpha1.ContainerSpec{Image: "busybox"},
 		},
 	}
-	applyErr := errors.New("apply failed")
-	removed := make([]string, 0, 1)
+	applyCalls := 0
 	client := fake.NewSimpleClientset()
 	svc := &SandboxService{
 		k8sClient:            client,
 		secretLister:         newClaimTestSecretLister(t),
 		NetworkPolicyService: NewNetworkPolicyService(zap.NewNop()),
-		networkProvider: &assertingNetworkProvider{
-			applyErr: applyErr,
-			removeFunc: func(namespace, sandboxID string) {
-				removed = append(removed, namespace+"/"+sandboxID)
-			},
-		},
+		networkProvider: &assertingNetworkProvider{applyFunc: func(_ network.SandboxPolicyInput) {
+			applyCalls++
+		}},
 		clock:  systemTime{},
 		logger: zap.NewNop(),
 	}
 
-	_, err := svc.createNewPod(context.Background(), template, &ClaimRequest{TeamID: "team-a", UserID: "user-a"})
-	if err == nil {
-		t.Fatal("createNewPod() error = nil, want network apply failure")
+	pod, err := svc.createNewPod(context.Background(), template, &ClaimRequest{TeamID: "team-a", UserID: "user-a"})
+	if err != nil {
+		t.Fatalf("createNewPod() error = %v", err)
 	}
-	if !errors.Is(err, applyErr) {
-		t.Fatalf("createNewPod() error = %v, want wrapped apply failure", err)
+	if applyCalls != 0 {
+		t.Fatalf("network apply calls = %d, want 0 before pod has network identity", applyCalls)
+	}
+	if pod.Annotations[controller.AnnotationNetworkPolicy] == "" {
+		t.Fatal("network policy annotation is empty")
+	}
+	if pod.Annotations[controller.AnnotationNetworkPolicyHash] == "" {
+		t.Fatal("network policy hash annotation is empty")
 	}
 
 	pods, err := client.CoreV1().Pods("ns-a").List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		t.Fatalf("list pods: %v", err)
 	}
+	if len(pods.Items) != 1 {
+		t.Fatalf("pods after createNewPod() = %d, want 1", len(pods.Items))
+	}
+}
+
+func TestClaimSandboxDeletesColdPodAfterNetworkApplyFailure(t *testing.T) {
+	withClaimTestPublicKey(t)
+
+	templateNamespace, err := naming.TemplateNamespaceForBuiltin("managed-agent-claude")
+	if err != nil {
+		t.Fatalf("template namespace: %v", err)
+	}
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "managed-agent-claude",
+			Namespace: templateNamespace,
+		},
+		Spec: v1alpha1.SandboxTemplateSpec{
+			MainContainer: v1alpha1.ContainerSpec{Image: "busybox"},
+		},
+	}
+	applyErr := errors.New("apply failed")
+	indexer := newClaimTestPodIndexer(t)
+	client := fake.NewSimpleClientset()
+	scheduleCreatedClaimPodInIndexer(t, client, indexer, nil)
+	svc := &SandboxService{
+		k8sClient:            client,
+		podLister:            corelisters.NewPodLister(indexer),
+		secretLister:         newClaimTestSecretLister(t),
+		templateLister:       staticTemplateLister{templates: []*v1alpha1.SandboxTemplate{template}},
+		NetworkPolicyService: NewNetworkPolicyService(zap.NewNop()),
+		networkProvider:      &assertingNetworkProvider{applyErr: applyErr},
+		clock:                systemTime{},
+		logger:               zap.NewNop(),
+	}
+
+	_, err = svc.ClaimSandbox(context.Background(), &ClaimRequest{Template: "managed-agent-claude", TeamID: "team-a", UserID: "user-a"})
+	if err == nil {
+		t.Fatal("ClaimSandbox() error = nil, want network apply failure")
+	}
+	if !errors.Is(err, applyErr) {
+		t.Fatalf("ClaimSandbox() error = %v, want wrapped apply failure", err)
+	}
+
+	pods, err := client.CoreV1().Pods(templateNamespace).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list pods: %v", err)
+	}
 	if len(pods.Items) != 0 {
 		t.Fatalf("pods after failed cold claim = %d, want 0", len(pods.Items))
-	}
-	if len(removed) != 0 {
-		t.Fatalf("network policy removals = %d, want 0; lifecycle controller owns delete cleanup", len(removed))
 	}
 }
 
@@ -833,11 +912,15 @@ func TestClaimSandboxCleansColdPodWhenClaimReadinessFails(t *testing.T) {
 			MainContainer: v1alpha1.ContainerSpec{Image: "busybox"},
 		},
 	}
+	indexer := newClaimTestPodIndexer(t)
 	client := fake.NewSimpleClientset()
+	scheduleCreatedClaimPodInIndexer(t, client, indexer, func(pod *corev1.Pod) {
+		pod.Status.ContainerStatuses = nil
+	})
 	ctx, cancel := context.WithCancel(context.Background())
 	svc := &SandboxService{
 		k8sClient:            client,
-		podLister:            newClaimTestPodLister(t),
+		podLister:            corelisters.NewPodLister(indexer),
 		secretLister:         newClaimTestSecretLister(t),
 		templateLister:       staticTemplateLister{templates: []*v1alpha1.SandboxTemplate{template}},
 		NetworkPolicyService: NewNetworkPolicyService(zap.NewNop()),
@@ -1487,6 +1570,32 @@ func newClaimTestPodIndexer(t *testing.T, pods ...*corev1.Pod) cache.Indexer {
 		}
 	}
 	return indexer
+}
+
+func scheduleCreatedClaimPodInIndexer(t *testing.T, client *fake.Clientset, indexer cache.Indexer, mutate func(*corev1.Pod)) {
+	t.Helper()
+	client.PrependReactor("create", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		createAction, ok := action.(k8stesting.CreateAction)
+		if !ok {
+			return false, nil, nil
+		}
+		pod, ok := createAction.GetObject().(*corev1.Pod)
+		if !ok || pod == nil {
+			return false, nil, nil
+		}
+		indexedPod := pod.DeepCopy()
+		indexedPod.ResourceVersion = "2"
+		indexedPod.Spec.NodeName = "node-a"
+		indexedPod.Status.Phase = corev1.PodRunning
+		indexedPod.Status.PodIP = "10.244.0.10"
+		if mutate != nil {
+			mutate(indexedPod)
+		}
+		if err := indexer.Add(indexedPod); err != nil {
+			return true, nil, err
+		}
+		return false, nil, nil
+	})
 }
 
 func newClaimTestPod(namespace, name, templateID string, ready bool) *corev1.Pod {

--- a/manager/pkg/service/sandbox_service_network.go
+++ b/manager/pkg/service/sandbox_service_network.go
@@ -519,6 +519,38 @@ func (s *SandboxService) applyNetworkProvider(
 	return nil
 }
 
+func (s *SandboxService) applyNetworkProviderFromPod(ctx context.Context, pod *corev1.Pod, teamID string) error {
+	if s.networkProvider == nil || pod == nil {
+		return nil
+	}
+	annotation := ""
+	if pod.Annotations != nil {
+		annotation = pod.Annotations[controller.AnnotationNetworkPolicy]
+	}
+	networkSpec, err := v1alpha1.ParseNetworkPolicyFromAnnotation(annotation)
+	if err != nil {
+		return fmt.Errorf("parse network policy annotation: %w", err)
+	}
+	return s.applyNetworkProvider(ctx, pod, teamID, networkSpec)
+}
+
+func (s *SandboxService) waitForColdPodNetworkPolicy(ctx context.Context, pod *corev1.Pod, teamID string) (*corev1.Pod, error) {
+	if pod == nil {
+		return nil, fmt.Errorf("pod is nil")
+	}
+	if s.networkProvider == nil {
+		return pod, nil
+	}
+	networkPod, err := s.waitForPodNetworkIdentity(ctx, pod.Namespace, pod.Name)
+	if err != nil {
+		return pod, fmt.Errorf("wait for pod network identity: %w", err)
+	}
+	if err := s.applyNetworkProviderFromPod(ctx, networkPod, teamID); err != nil {
+		return networkPod, fmt.Errorf("apply network policy: %w", err)
+	}
+	return networkPod, nil
+}
+
 // GetNetworkPolicy gets the effective sandbox network policy.
 func (s *SandboxService) GetNetworkPolicy(ctx context.Context, sandboxID string) (*v1alpha1.SandboxNetworkPolicy, error) {
 	pod, err := s.getSandboxPod(ctx, sandboxID)

--- a/manager/pkg/service/sandbox_service_pod.go
+++ b/manager/pkg/service/sandbox_service_pod.go
@@ -96,6 +96,72 @@ func (s *SandboxService) waitForPodClaimReady(ctx context.Context, namespace, na
 	}
 }
 
+func (s *SandboxService) waitForPodNetworkIdentity(ctx context.Context, namespace, name string) (*corev1.Pod, error) {
+	timeout := s.config.ProcdInitTimeout
+	if timeout < defaultPodClaimReadyTimeout {
+		timeout = defaultPodClaimReadyTimeout
+	}
+
+	readyCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+
+	lastReason := "pod network identity is not ready"
+	for {
+		if s.podLister == nil {
+			return nil, fmt.Errorf("pod lister is not configured")
+		}
+		pod, err := s.podLister.Pods(namespace).Get(name)
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				lastReason = fmt.Sprintf("pod %s/%s is not visible", namespace, name)
+				select {
+				case <-readyCtx.Done():
+					return nil, fmt.Errorf("pod %s/%s network identity not ready after %s: %s", namespace, name, timeout, lastReason)
+				case <-ticker.C:
+					continue
+				}
+			}
+			return nil, fmt.Errorf("get pod for network identity: %w", err)
+		}
+
+		ready, reason := isPodNetworkIdentityReady(pod)
+		if ready {
+			return pod, nil
+		}
+		if reason != "" {
+			lastReason = reason
+		}
+
+		select {
+		case <-readyCtx.Done():
+			return nil, fmt.Errorf("pod %s/%s network identity not ready after %s: %s", namespace, name, timeout, lastReason)
+		case <-ticker.C:
+		}
+	}
+}
+
+func isPodNetworkIdentityReady(pod *corev1.Pod) (bool, string) {
+	if pod == nil {
+		return false, "pod is nil"
+	}
+	if pod.DeletionTimestamp != nil {
+		return false, "pod is deleting"
+	}
+	if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
+		return false, fmt.Sprintf("pod phase is terminal: %s", pod.Status.Phase)
+	}
+	if strings.TrimSpace(pod.Spec.NodeName) == "" {
+		return false, "pod node is not assigned"
+	}
+	if strings.TrimSpace(pod.Status.PodIP) == "" {
+		return false, "pod IP is not assigned"
+	}
+	return true, ""
+}
+
 func (s *SandboxService) isPodClaimReady(ctx context.Context, pod *corev1.Pod) (bool, string) {
 	if pod == nil {
 		return false, "pod is nil"

--- a/manager/pkg/service/sandbox_service_restore.go
+++ b/manager/pkg/service/sandbox_service_restore.go
@@ -354,6 +354,11 @@ func (s *SandboxService) finishRestoredSandboxRuntime(ctx context.Context, pod *
 		return pod, err
 	}
 	if claimType == "cold" {
+		networkPod, err := s.waitForColdPodNetworkPolicy(ctx, pod, record.TeamID)
+		if err != nil {
+			return pod, err
+		}
+		pod = networkPod
 		readyPod, err := s.waitForPodClaimReady(ctx, pod.Namespace, pod.Name)
 		if err != nil {
 			return pod, fmt.Errorf("wait for pod claim readiness: %w", err)

--- a/manager/pkg/service/sandbox_service_rootfs.go
+++ b/manager/pkg/service/sandbox_service_rootfs.go
@@ -289,6 +289,12 @@ func (s *SandboxService) applySandboxRootFSCheckpointWithFallback(ctx context.Co
 	if fallbackErr != nil {
 		return pod, fmt.Errorf("%w; create checkpoint base image runtime: %v", err, fallbackErr)
 	}
+	networkPod, fallbackErr := s.waitForColdPodNetworkPolicy(ctx, fallbackPod, req.TeamID)
+	if fallbackErr != nil {
+		s.requestSandboxDeletionAfterClaimFailure(fallbackPod, "checkpoint base image network policy failed")
+		return fallbackPod, fmt.Errorf("%w; prepare checkpoint base image network policy: %v", err, fallbackErr)
+	}
+	fallbackPod = networkPod
 	readyPod, fallbackErr := s.waitForPodClaimReady(ctx, fallbackPod.Namespace, fallbackPod.Name)
 	if fallbackErr != nil {
 		s.requestSandboxDeletionAfterClaimFailure(fallbackPod, "checkpoint base image runtime readiness failed")


### PR DESCRIPTION
## Summary
- wait for cold-created pods to have the NodeName/PodIP identity that netd watches before waiting for netd policy application
- move cold create network provider application out of createNewPod, while preserving hot-claim behavior
- apply the same cold-pod network policy preparation for restore/rootfs fallback paths

## Tests
- go test ./manager/...
- go test ./netd/...

## Root cause
Cold claims created a pod and immediately waited for netd to patch sandbox0.ai/network-policy-applied-hash. netd intentionally ignores pods until they have NodeName and PodIP, so under scheduling/CNI delay the manager could time out and delete pods before netd ever tracked them.