### PR TITLE
Make default template Docker-capable

### DIFF
--- a/docs/sandbox/docker-in-sandbox/page.mdx
+++ b/docs/sandbox/docker-in-sandbox/page.mdx
@@ -1,6 +1,6 @@
 # Docker in Sandbox
 
-Docker in Sandbox lets a sandbox run a Docker daemon inside the sandbox. Use the `dins` template when tests, build steps, or agent tools expect a local Docker socket.
+Docker in Sandbox lets a sandbox run a Docker daemon inside the sandbox. The built-in `default` template includes Docker support for tests, build steps, or agent tools that expect a local Docker socket.
 
 Typical uses:
 
@@ -11,18 +11,18 @@ Typical uses:
 `/var/lib/docker` is ephemeral. Images, containers, layers, and Docker volumes are discarded when the sandbox is deleted. Store source code and durable outputs in Sandbox volumes instead.
 
 <Callout variant="info">
-The examples assume your workspace has a `dins` template. If claiming `dins` returns not found, ask your Sandbox0 operator to enable Docker in Sandbox for your environment.
+The `default` template provides Docker binaries and writable Docker state, but it does not start `dockerd` before the sandbox is claimed. Start `/usr/local/bin/sandbox0-dockerd-entrypoint` from a sandbox command before using `docker`.
 </Callout>
 
-<Callout variant="info">
-The `dins` template provides Docker binaries and writable Docker state, but it does not start `dockerd` before the sandbox is claimed. Start `/usr/local/bin/sandbox0-dockerd-entrypoint` from a sandbox command before using `docker`.
+<Callout variant="warning">
+For multi-tenant production deployments, run sandbox pods with a sandboxed runtime class such as gVisor or Kata. Docker runs inside the sandbox boundary; do not mount host Docker sockets or host paths into sandbox templates.
 </Callout>
 
 ---
 
 ## Start Test Databases
 
-Claim a `dins` sandbox, start Redis and PostgreSQL with Docker, then run tests against `localhost` from inside the sandbox.
+Claim a `default` sandbox, start Redis and PostgreSQL with Docker, then run tests against `localhost` from inside the sandbox.
 
 <Tabs
   tabs={[
@@ -52,7 +52,7 @@ func main() {
         log.Fatal(err)
     }
 
-    sandbox, err := client.ClaimSandbox(ctx, "dins", sandbox0.WithSandboxHardTTL(1800))
+    sandbox, err := client.ClaimSandbox(ctx, "default", sandbox0.WithSandboxHardTTL(1800))
     if err != nil {
         log.Fatal(err)
     }
@@ -125,7 +125,7 @@ client = Client(
 )
 
 sandbox = client.claim_sandbox(
-    template="dins",
+    template="default",
     config=SandboxConfig.from_dict({"hard_ttl": 1800}),
 )
 
@@ -183,7 +183,7 @@ finally:
         baseUrl: process.env.SANDBOX0_BASE_URL || 'https://api.sandbox0.ai',
     });
 
-    const sandbox = await client.sandboxes.claim('dins', { hardTtl: 1800 });
+    const sandbox = await client.sandboxes.claim('default', { hardTtl: 1800 });
 
     try {
         await sandbox.cmd('rm -f /tmp/sandbox0-test-databases.ready');
@@ -243,7 +243,7 @@ main().catch((err) => {
     {
       label: "CLI",
       language: "bash",
-      code: `SANDBOX_ID="$(s0 -o json sandbox create --template dins --hard-ttl 1800 | jq -r '.ID')"
+      code: `SANDBOX_ID="$(s0 -o json sandbox create --template default --hard-ttl 1800 | jq -r '.ID')"
 trap 's0 sandbox delete "$SANDBOX_ID" >/dev/null 2>&1 || true' EXIT
 
 s0 sandbox exec "$SANDBOX_ID" -- rm -f /tmp/sandbox0-test-databases.ready
@@ -331,8 +331,8 @@ Docker build cache also lives under `/var/lib/docker`, so this is best for tempo
     "COPY hello /hello",
     "ENTRYPOINT [\\"/hello\\"]",
     "EOF",
-    "docker build -t sandbox0-dins-test .",
-    "docker run --rm sandbox0-dins-test",
+    "docker build -t sandbox0-docker-test .",
+    "docker run --rm sandbox0-docker-test",
 }, "\\n")
 
 result, err := sandbox.Cmd(ctx, "sh",
@@ -364,8 +364,8 @@ FROM scratch
 COPY hello /hello
 ENTRYPOINT ["/hello"]
 EOF
-docker build -t sandbox0-dins-test .
-docker run --rm sandbox0-dins-test
+docker build -t sandbox0-docker-test .
+docker run --rm sandbox0-docker-test
 """
 
 result = sandbox.cmd(
@@ -394,8 +394,8 @@ print(result.output_raw, end="")`
     'COPY hello /hello',
     'ENTRYPOINT ["/hello"]',
     'EOF',
-    'docker build -t sandbox0-dins-test .',
-    'docker run --rm sandbox0-dins-test',
+    'docker build -t sandbox0-docker-test .',
+    'docker run --rm sandbox0-docker-test',
 ].join('\\n');
 
 const result = await sandbox.cmd('sh', {
@@ -424,8 +424,8 @@ FROM scratch
 COPY hello /hello
 ENTRYPOINT ["/hello"]
 EOF
-docker build -t sandbox0-dins-test .
-docker run --rm sandbox0-dins-test
+docker build -t sandbox0-docker-test .
+docker run --rm sandbox0-docker-test
 '`
     }
   ]}
@@ -438,6 +438,7 @@ docker run --rm sandbox0-dins-test
 - Containers launched by Docker are sandbox-local. Start test dependencies with `-p` and connect to `127.0.0.1` from commands inside the sandbox.
 - Use Sandbox Services when a containerized HTTP service needs to be reachable from outside the sandbox.
 - Docker state is not durable. Use Sandbox Volumes for source, generated files, or database dumps that must survive sandbox cleanup.
+- Docker state uses the default template's ephemeral storage limit. Hosted default sandboxes keep the standard `500m` CPU and `2Gi` memory baseline, so large builds should request larger sandbox resources.
 - Pulling images can take longer than a single synchronous command request. Start long Docker setup commands asynchronously, then poll readiness with short commands.
 - Nested Kubernetes tools such as kind can run in a Docker in Sandbox environment, but node images and cluster data consume the sandbox's ephemeral disk.
 - Long-running containers count against the sandbox resource limits. Stop containers when a test run finishes if the sandbox will stay alive.

--- a/docs/self-hosted/configuration/page.mdx
+++ b/docs/self-hosted/configuration/page.mdx
@@ -27,7 +27,7 @@ A `Sandbox0Infra` spec is easier to reason about when you split it into five lay
 `spec.initUser` is consumed by the gateway runtime, not created by the operator itself.
 In local-password mode it bootstraps the first admin credentials; in OIDC-only mode it pre-creates the admin user and initial team so the first OIDC login with the same email lands on the intended admin account.
 
-When `spec.builtinTemplates` is omitted, infra-operator seeds public builtin templates for `default`, `dins`, `openclaw`, and `hermes`. Set `spec.builtinTemplates` explicitly when you want to pin images, adjust pools, disable one of the builtins, or provide a full template `spec` for a runtime-specific setup. Set it to `[]` to remove all operator-managed builtin templates.
+When `spec.builtinTemplates` is omitted, infra-operator seeds public builtin templates for `default`, `openclaw`, and `hermes`. Set `spec.builtinTemplates` explicitly when you want to pin images, adjust pools, disable one of the builtins, or provide a full template `spec` for a runtime-specific setup. Set it to `[]` to remove all operator-managed builtin templates.
 
 ## Deployment Profiles
 

--- a/docs/template/page.mdx
+++ b/docs/template/page.mdx
@@ -25,7 +25,7 @@ You do not need a custom template for every initialized environment. If the base
 
 This is useful for dependency-heavy agent workspaces:
 
-1. claim a sandbox from a platform-owned builtin template such as `default` or `dins`
+1. claim a sandbox from a platform-owned builtin template such as `default`
 2. install packages, populate caches, clone repositories, or write tool configuration
 3. pause the sandbox and wait for `status` to become `paused`
 4. create a named rootfs snapshot for the initialized state

--- a/infra-operator/chart/samples/multi-cluster/data-plane.yaml
+++ b/infra-operator/chart/samples/multi-cluster/data-plane.yaml
@@ -85,13 +85,6 @@ spec:
       pool:
         minIdle: 1
         maxIdle: 5
-    - templateId: dins
-      image: sandbox0ai/otemplates:default-v0.2.0
-      displayName: Docker in Sandbox
-      description: Builtin Docker in Sandbox template installed by infra-operator.
-      pool:
-        minIdle: 1
-        maxIdle: 5
     - templateId: openclaw
       image: ghcr.io/openclaw/openclaw:latest
       displayName: OpenClaw

--- a/infra-operator/chart/samples/single-cluster/fullmode.yaml
+++ b/infra-operator/chart/samples/single-cluster/fullmode.yaml
@@ -92,13 +92,6 @@ spec:
       pool:
         minIdle: 1
         maxIdle: 5
-    - templateId: dins
-      image: sandbox0ai/otemplates:default-v0.2.0
-      displayName: Docker in Sandbox
-      description: Builtin Docker in Sandbox template installed by infra-operator.
-      pool:
-        minIdle: 1
-        maxIdle: 5
     - templateId: openclaw
       image: ghcr.io/openclaw/openclaw:latest
       displayName: OpenClaw

--- a/infra-operator/chart/samples/single-cluster/minimal.yaml
+++ b/infra-operator/chart/samples/single-cluster/minimal.yaml
@@ -50,13 +50,6 @@ spec:
       pool:
         minIdle: 1
         maxIdle: 5
-    - templateId: dins
-      image: sandbox0ai/otemplates:default-v0.2.0
-      displayName: Docker in Sandbox
-      description: Builtin Docker in Sandbox template installed by infra-operator.
-      pool:
-        minIdle: 1
-        maxIdle: 5
     - templateId: openclaw
       image: ghcr.io/openclaw/openclaw:latest
       displayName: OpenClaw

--- a/infra-operator/chart/samples/single-cluster/network-policy.yaml
+++ b/infra-operator/chart/samples/single-cluster/network-policy.yaml
@@ -54,13 +54,6 @@ spec:
       pool:
         minIdle: 1
         maxIdle: 5
-    - templateId: dins
-      image: sandbox0ai/otemplates:default-v0.2.0
-      displayName: Docker in Sandbox
-      description: Builtin Docker in Sandbox template installed by infra-operator.
-      pool:
-        minIdle: 1
-        maxIdle: 5
     - templateId: openclaw
       image: ghcr.io/openclaw/openclaw:latest
       displayName: OpenClaw

--- a/infra-operator/chart/samples/single-cluster/volumes.yaml
+++ b/infra-operator/chart/samples/single-cluster/volumes.yaml
@@ -68,13 +68,6 @@ spec:
       pool:
         minIdle: 1
         maxIdle: 5
-    - templateId: dins
-      image: sandbox0ai/otemplates:default-v0.2.0
-      displayName: Docker in Sandbox
-      description: Builtin Docker in Sandbox template installed by infra-operator.
-      pool:
-        minIdle: 1
-        maxIdle: 5
     - templateId: openclaw
       image: ghcr.io/openclaw/openclaw:latest
       displayName: OpenClaw

--- a/infra-operator/internal/controller/pkg/common/builtin_templates.go
+++ b/infra-operator/internal/controller/pkg/common/builtin_templates.go
@@ -170,8 +170,6 @@ func BuildBuiltinTemplateSpec(templateID string, builtin infrav1alpha1.BuiltinTe
 	var spec templatev1alpha1.SandboxTemplateSpec
 	if builtin.Spec != nil {
 		spec = *builtin.Spec.DeepCopy()
-	} else if templateID == template.DockerInSandboxTemplateID {
-		spec = dockerInSandboxTemplateSpec()
 	} else if templateID == template.OpenClawTemplateID {
 		spec = openClawTemplateSpec()
 	} else if templateID == template.HermesTemplateID {
@@ -210,38 +208,21 @@ func defaultBuiltinTemplateSpec(templateID string) templatev1alpha1.SandboxTempl
 			Name:      template.DefaultTemplateWorkspaceName,
 			MountPath: template.DefaultTemplateWorkspaceMount,
 		}}
+		spec.MainContainer.SecurityContext = &templatev1alpha1.SecurityContext{
+			Privileged:               BoolPtr(true),
+			AllowPrivilegeEscalation: BoolPtr(true),
+		}
+		sizeLimit := resource.MustParse(template.DefaultTemplateDockerRootSize)
+		spec.Pod = &templatev1alpha1.PodSpecOverride{
+			EmptyDirMounts: []templatev1alpha1.EmptyDirMountSpec{
+				{
+					MountPath: template.DefaultTemplateDockerRoot,
+					SizeLimit: &sizeLimit,
+				},
+			},
+		}
 	}
 	return spec
-}
-
-func dockerInSandboxTemplateSpec() templatev1alpha1.SandboxTemplateSpec {
-	sizeLimit := resource.MustParse(template.DockerInSandboxDockerRootSizeLimit)
-	return templatev1alpha1.SandboxTemplateSpec{
-		DisplayName: template.DockerInSandboxTemplateDisplayName,
-		Description: template.DockerInSandboxTemplateDescription,
-		MainContainer: templatev1alpha1.ContainerSpec{
-			Image: template.DefaultTemplateImage,
-			Resources: templatev1alpha1.ResourceQuota{
-				CPU:              resource.MustParse(template.DockerInSandboxCPU),
-				Memory:           resource.MustParse(template.DockerInSandboxMemory),
-				EphemeralStorage: resource.MustParse(template.DockerInSandboxEphemeralStorage),
-			},
-			SecurityContext: &templatev1alpha1.SecurityContext{
-				Privileged:               BoolPtr(true),
-				AllowPrivilegeEscalation: BoolPtr(true),
-			},
-		},
-		Pod: &templatev1alpha1.PodSpecOverride{
-			EmptyDirMounts: []templatev1alpha1.EmptyDirMountSpec{{
-				MountPath: template.DockerInSandboxDockerRoot,
-				SizeLimit: &sizeLimit,
-			}},
-		},
-		Pool: defaultBuiltinTemplatePool(),
-		Network: &templatev1alpha1.SandboxNetworkPolicy{
-			Mode: templatev1alpha1.NetworkModeAllowAll,
-		},
-	}
 }
 
 func openClawTemplateSpec() templatev1alpha1.SandboxTemplateSpec {

--- a/infra-operator/internal/controller/pkg/common/builtin_templates_test.go
+++ b/infra-operator/internal/controller/pkg/common/builtin_templates_test.go
@@ -22,6 +22,15 @@ func TestBuildBuiltinTemplateSpecUsesDefaultPreset(t *testing.T) {
 	if spec.MainContainer.Image != template.DefaultTemplateImage {
 		t.Fatalf("image = %q, want %q", spec.MainContainer.Image, template.DefaultTemplateImage)
 	}
+	if spec.MainContainer.Resources.CPU.Cmp(resource.MustParse(template.DefaultTemplateCPU)) != 0 {
+		t.Fatalf("cpu = %s, want %s", spec.MainContainer.Resources.CPU.String(), template.DefaultTemplateCPU)
+	}
+	if spec.MainContainer.Resources.Memory.Cmp(resource.MustParse(template.DefaultTemplateMemory)) != 0 {
+		t.Fatalf("memory = %s, want %s", spec.MainContainer.Resources.Memory.String(), template.DefaultTemplateMemory)
+	}
+	if spec.MainContainer.Resources.EphemeralStorage.Cmp(resource.MustParse(template.DefaultTemplateEphemeralStorage)) != 0 {
+		t.Fatalf("ephemeralStorage = %s, want %s", spec.MainContainer.Resources.EphemeralStorage.String(), template.DefaultTemplateEphemeralStorage)
+	}
 	if len(spec.VolumeMounts) != 1 {
 		t.Fatalf("volumeMounts = %#v, want one workspace mount", spec.VolumeMounts)
 	}
@@ -29,9 +38,25 @@ func TestBuildBuiltinTemplateSpecUsesDefaultPreset(t *testing.T) {
 	if mount.Name != template.DefaultTemplateWorkspaceName || mount.MountPath != template.DefaultTemplateWorkspaceMount || mount.ReadOnly {
 		t.Fatalf("volumeMounts[0] = %#v, want writable %s at %s", mount, template.DefaultTemplateWorkspaceName, template.DefaultTemplateWorkspaceMount)
 	}
+	if spec.MainContainer.SecurityContext == nil || spec.MainContainer.SecurityContext.Privileged == nil || !*spec.MainContainer.SecurityContext.Privileged {
+		t.Fatalf("expected privileged security context, got %#v", spec.MainContainer.SecurityContext)
+	}
+	if spec.MainContainer.SecurityContext.AllowPrivilegeEscalation == nil || !*spec.MainContainer.SecurityContext.AllowPrivilegeEscalation {
+		t.Fatalf("expected allowPrivilegeEscalation=true, got %#v", spec.MainContainer.SecurityContext)
+	}
+	if spec.Pod == nil || len(spec.Pod.EmptyDirMounts) != 1 {
+		t.Fatalf("expected one emptyDir mount, got %#v", spec.Pod)
+	}
+	dockerRoot := spec.Pod.EmptyDirMounts[0]
+	if dockerRoot.MountPath != template.DefaultTemplateDockerRoot {
+		t.Fatalf("emptyDir mount path = %q, want %q", dockerRoot.MountPath, template.DefaultTemplateDockerRoot)
+	}
+	if dockerRoot.SizeLimit == nil || dockerRoot.SizeLimit.Cmp(resource.MustParse(template.DefaultTemplateDockerRootSize)) != 0 {
+		t.Fatalf("emptyDir sizeLimit = %#v, want %s", dockerRoot.SizeLimit, template.DefaultTemplateDockerRootSize)
+	}
 }
 
-func TestBuildBuiltinTemplateSpecDoesNotAddDefaultWorkspaceToGenericPreset(t *testing.T) {
+func TestBuildBuiltinTemplateSpecDoesNotAddDefaultRuntimeShapeToGenericPreset(t *testing.T) {
 	t.Parallel()
 
 	spec := BuildBuiltinTemplateSpec("custom", infrav1alpha1.BuiltinTemplateConfig{})
@@ -39,33 +64,11 @@ func TestBuildBuiltinTemplateSpecDoesNotAddDefaultWorkspaceToGenericPreset(t *te
 	if len(spec.VolumeMounts) != 0 {
 		t.Fatalf("volumeMounts = %#v, want none for generic builtin preset", spec.VolumeMounts)
 	}
-}
-
-func TestBuildBuiltinTemplateSpecUsesDockerInSandboxPreset(t *testing.T) {
-	t.Parallel()
-
-	spec := BuildBuiltinTemplateSpec(template.DockerInSandboxTemplateID, infrav1alpha1.BuiltinTemplateConfig{})
-
-	if spec.DisplayName != template.DockerInSandboxTemplateDisplayName {
-		t.Fatalf("DisplayName = %q, want %q", spec.DisplayName, template.DockerInSandboxTemplateDisplayName)
+	if spec.MainContainer.SecurityContext != nil {
+		t.Fatalf("securityContext = %#v, want nil for generic builtin preset", spec.MainContainer.SecurityContext)
 	}
-	if spec.MainContainer.Image != template.DefaultTemplateImage {
-		t.Fatalf("image = %q, want %q", spec.MainContainer.Image, template.DefaultTemplateImage)
-	}
-	if spec.MainContainer.Resources.CPU.Cmp(resource.MustParse(template.DockerInSandboxCPU)) != 0 {
-		t.Fatalf("cpu = %s, want %s", spec.MainContainer.Resources.CPU.String(), template.DockerInSandboxCPU)
-	}
-	if spec.MainContainer.Resources.Memory.Cmp(resource.MustParse(template.DockerInSandboxMemory)) != 0 {
-		t.Fatalf("memory = %s, want %s", spec.MainContainer.Resources.Memory.String(), template.DockerInSandboxMemory)
-	}
-	if spec.MainContainer.SecurityContext == nil || spec.MainContainer.SecurityContext.Privileged == nil || !*spec.MainContainer.SecurityContext.Privileged {
-		t.Fatalf("expected privileged security context, got %#v", spec.MainContainer.SecurityContext)
-	}
-	if spec.Pod == nil || len(spec.Pod.EmptyDirMounts) != 1 {
-		t.Fatalf("expected one emptyDir mount, got %#v", spec.Pod)
-	}
-	if got := spec.Pod.EmptyDirMounts[0].MountPath; got != template.DockerInSandboxDockerRoot {
-		t.Fatalf("emptyDir mount path = %q, want %q", got, template.DockerInSandboxDockerRoot)
+	if spec.Pod != nil {
+		t.Fatalf("pod = %#v, want nil for generic builtin preset", spec.Pod)
 	}
 }
 
@@ -171,7 +174,6 @@ func TestBuiltinTemplatePresetsSatisfyResourceRatio(t *testing.T) {
 
 	for _, templateID := range []string{
 		template.DefaultTemplateID,
-		template.DockerInSandboxTemplateID,
 		template.OpenClawTemplateID,
 		template.HermesTemplateID,
 	} {

--- a/infra-operator/internal/plan/plan_test.go
+++ b/infra-operator/internal/plan/plan_test.go
@@ -160,12 +160,11 @@ func TestBuiltinTemplatesDefaultsAndOverrides(t *testing.T) {
 	t.Parallel()
 
 	defaults := Compile(&infrav1alpha1.Sandbox0Infra{}).BuiltinTemplates()
-	if len(defaults) != 4 {
-		t.Fatalf("default builtin template count = %d, want 4", len(defaults))
+	if len(defaults) != 3 {
+		t.Fatalf("default builtin template count = %d, want 3", len(defaults))
 	}
 	wantDefaults := []string{
 		template.DefaultTemplateID,
-		template.DockerInSandboxTemplateID,
 		template.OpenClawTemplateID,
 		template.HermesTemplateID,
 	}

--- a/infra-operator/internal/plan/runtime_access.go
+++ b/infra-operator/internal/plan/runtime_access.go
@@ -35,7 +35,6 @@ func (p *InfraPlan) BuiltinTemplates() []infrav1alpha1.BuiltinTemplateConfig {
 func defaultBuiltinTemplates() []infrav1alpha1.BuiltinTemplateConfig {
 	return []infrav1alpha1.BuiltinTemplateConfig{
 		{TemplateID: s0template.DefaultTemplateID},
-		{TemplateID: s0template.DockerInSandboxTemplateID},
 		{TemplateID: s0template.OpenClawTemplateID},
 		{TemplateID: s0template.HermesTemplateID},
 	}

--- a/manager/pkg/apis/sandbox0/v1alpha1/helpers.go
+++ b/manager/pkg/apis/sandbox0/v1alpha1/helpers.go
@@ -44,9 +44,11 @@ func BuildIdlePodSpec(template *SandboxTemplate) corev1.PodSpec {
 }
 
 func buildPodSpec(template *SandboxTemplate, volumeMounts []VolumeMountSpec) corev1.PodSpec {
+	automountServiceAccountToken := false
 	spec := corev1.PodSpec{
-		RestartPolicy: corev1.RestartPolicyAlways,
-		Containers:    buildContainers(template),
+		RestartPolicy:                corev1.RestartPolicyAlways,
+		AutomountServiceAccountToken: &automountServiceAccountToken,
+		Containers:                   buildContainers(template),
 		ReadinessGates: []corev1.PodReadinessGate{{
 			ConditionType: SandboxPodReadinessConditionType,
 		}},

--- a/manager/pkg/apis/sandbox0/v1alpha1/helpers_test.go
+++ b/manager/pkg/apis/sandbox0/v1alpha1/helpers_test.go
@@ -107,6 +107,18 @@ sandbox_runtime_class_name: kata-shared
 	}
 }
 
+func TestBuildPodSpecDisablesServiceAccountTokenAutomount(t *testing.T) {
+	configPath := writeManagerConfig(t, `
+manager_image: sandbox0/manager:test
+`)
+	t.Setenv("CONFIG_PATH", configPath)
+
+	spec := BuildPodSpec(newTestTemplate())
+	if spec.AutomountServiceAccountToken == nil || *spec.AutomountServiceAccountToken {
+		t.Fatalf("automountServiceAccountToken = %#v, want false", spec.AutomountServiceAccountToken)
+	}
+}
+
 func TestBuildPodSpecLeavesOrdinarySandboxNonPrivileged(t *testing.T) {
 	configPath := writeManagerConfig(t, `
 manager_image: sandbox0/manager:test

--- a/manager/procd/Dockerfile.default
+++ b/manager/procd/Dockerfile.default
@@ -167,8 +167,8 @@ RUN python3 -m pip install --no-cache-dir --break-system-packages --ignore-insta
     xarray==2025.4.0 \
     xlrd==2.0.1
 
-# Docker client/daemon support for Docker in Sandbox templates.
-# Docker-in-Sandbox users start dockerd after the sandbox is claimed.
+# Docker client/daemon support for the default sandbox template.
+# Users start dockerd after the sandbox is claimed.
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     docker.io \

--- a/pkg/template/defaults.go
+++ b/pkg/template/defaults.go
@@ -13,15 +13,8 @@ const (
 	DefaultTemplateMaxIdle          = int32(5)
 	DefaultTemplateWorkspaceName    = "workspace"
 	DefaultTemplateWorkspaceMount   = "/workspace"
-
-	DockerInSandboxTemplateID          = "dins"
-	DockerInSandboxTemplateDisplayName = "Docker in Sandbox"
-	DockerInSandboxTemplateDescription = "Builtin Docker in Sandbox template installed by infra-operator."
-	DockerInSandboxCPU                 = "1"
-	DockerInSandboxMemory              = "4Gi"
-	DockerInSandboxEphemeralStorage    = "20Gi"
-	DockerInSandboxDockerRoot          = "/var/lib/docker"
-	DockerInSandboxDockerRootSizeLimit = "20Gi"
+	DefaultTemplateDockerRoot       = "/var/lib/docker"
+	DefaultTemplateDockerRootSize   = v1alpha1.DefaultSandboxEphemeralStorage
 
 	OpenClawTemplateID          = "openclaw"
 	OpenClawTemplateImage       = "ghcr.io/openclaw/openclaw:latest"

--- a/pkg/template/http/handlers.go
+++ b/pkg/template/http/handlers.go
@@ -84,7 +84,7 @@ func (h *Handler) ListTemplates(c *gin.Context) {
 	h.enrichTemplatesStatus(c.Request.Context(), templates)
 
 	spec.JSONSuccess(c, http.StatusOK, gin.H{
-		"templates": templates,
+		"templates": templatesForResponse(templates, claims),
 		"count":     len(templates),
 	})
 }
@@ -132,7 +132,7 @@ func (h *Handler) GetTemplate(c *gin.Context) {
 	}
 	h.enrichTemplatesStatus(c.Request.Context(), []*template.Template{tpl})
 
-	spec.JSONSuccess(c, http.StatusOK, tpl)
+	spec.JSONSuccess(c, http.StatusOK, templateForResponse(tpl, claims))
 }
 
 func (h *Handler) enrichTemplatesStatus(ctx context.Context, templates []*template.Template) {
@@ -186,6 +186,32 @@ func templateNamespaceForScope(scope, teamID, templateID string) (string, error)
 
 func templateStatKey(namespace, templateID string) string {
 	return namespace + "\x00" + templateID
+}
+
+func templatesForResponse(templates []*template.Template, claims *internalauth.Claims) []*template.Template {
+	out := make([]*template.Template, 0, len(templates))
+	for _, tpl := range templates {
+		out = append(out, templateForResponse(tpl, claims))
+	}
+	return out
+}
+
+func templateForResponse(tpl *template.Template, claims *internalauth.Claims) *template.Template {
+	if tpl == nil {
+		return nil
+	}
+	out := *tpl
+	out.Spec = *tpl.Spec.DeepCopy()
+	if tpl.Status != nil {
+		out.Status = tpl.Status.DeepCopy()
+	}
+	if claims == nil || !claims.IsSystemToken() {
+		out.Spec.Pod = nil
+		out.Spec.MainContainer.SecurityContext = nil
+		out.Spec.MainContainer.ImagePullPolicy = ""
+		out.Spec.ClusterId = nil
+	}
+	return &out
 }
 
 func templateScopeForClaims(claims *internalauth.Claims) (string, string, error) {

--- a/pkg/template/http/handlers_test.go
+++ b/pkg/template/http/handlers_test.go
@@ -448,6 +448,138 @@ func TestGetTemplate_SystemWithoutTeamReadsPublicTemplate(t *testing.T) {
 	}
 }
 
+func TestListTemplates_SanitizesSystemOnlyFieldsForRegularTeam(t *testing.T) {
+	t.Parallel()
+
+	store := &testTemplateStore{
+		listVisibleFn: func(_ context.Context, teamID string) ([]*template.Template, error) {
+			if teamID != "team-1" {
+				t.Fatalf("ListVisibleTemplates teamID = %q, want team-1", teamID)
+			}
+			return []*template.Template{systemOnlyTemplate("default")}, nil
+		},
+	}
+	h := &Handler{Store: store, Logger: zap.NewNop()}
+
+	router := gin.New()
+	router.Use(withClaims(&internalauth.Claims{
+		TeamID: "team-1",
+		UserID: "user-1",
+	}))
+	router.GET("/api/v1/templates", h.ListTemplates)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/templates", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+
+	var resp struct {
+		Success bool `json:"success"`
+		Data    struct {
+			Templates []template.Template `json:"templates"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(resp.Data.Templates) != 1 {
+		t.Fatalf("templates len = %d, want 1", len(resp.Data.Templates))
+	}
+	assertSystemOnlyFieldsStripped(t, resp.Data.Templates[0].Spec)
+}
+
+func TestGetTemplate_SanitizesSystemOnlyFieldsForRegularTeam(t *testing.T) {
+	t.Parallel()
+
+	store := &testTemplateStore{
+		getTemplateForTeamFn: func(_ context.Context, teamID, templateID string) (*template.Template, error) {
+			if teamID != "team-1" || templateID != "default" {
+				t.Fatalf("GetTemplateForTeam team/id = %q/%q, want team-1/default", teamID, templateID)
+			}
+			return systemOnlyTemplate(templateID), nil
+		},
+	}
+	h := &Handler{Store: store, Logger: zap.NewNop()}
+
+	router := gin.New()
+	router.Use(withClaims(&internalauth.Claims{
+		TeamID: "team-1",
+		UserID: "user-1",
+	}))
+	router.GET("/api/v1/templates/:id", h.GetTemplate)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/templates/default", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+
+	var resp struct {
+		Success bool              `json:"success"`
+		Data    template.Template `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	assertSystemOnlyFieldsStripped(t, resp.Data.Spec)
+}
+
+func TestGetTemplate_PreservesSystemOnlyFieldsForSystemToken(t *testing.T) {
+	t.Parallel()
+
+	store := &testTemplateStore{
+		getTemplateFn: func(_ context.Context, scope, teamID, templateID string) (*template.Template, error) {
+			if scope != naming.ScopePublic || teamID != "" || templateID != "default" {
+				t.Fatalf("GetTemplate scope/team/id = %q/%q/%q, want public//default", scope, teamID, templateID)
+			}
+			return systemOnlyTemplate(templateID), nil
+		},
+	}
+	h := &Handler{Store: store, Logger: zap.NewNop()}
+
+	router := gin.New()
+	router.Use(withClaims(&internalauth.Claims{
+		UserID:   "system",
+		IsSystem: true,
+	}))
+	router.GET("/api/v1/templates/:id", h.GetTemplate)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/templates/default", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+
+	var resp struct {
+		Success bool              `json:"success"`
+		Data    template.Template `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Data.Spec.Pod == nil || len(resp.Data.Spec.Pod.EmptyDirMounts) != 1 {
+		t.Fatalf("expected pod emptyDir mounts to be preserved, got %#v", resp.Data.Spec.Pod)
+	}
+	if resp.Data.Spec.MainContainer.SecurityContext == nil ||
+		resp.Data.Spec.MainContainer.SecurityContext.Privileged == nil ||
+		!*resp.Data.Spec.MainContainer.SecurityContext.Privileged {
+		t.Fatalf("expected privileged security context to be preserved, got %#v", resp.Data.Spec.MainContainer.SecurityContext)
+	}
+	if resp.Data.Spec.MainContainer.ImagePullPolicy != "Always" {
+		t.Fatalf("imagePullPolicy = %q, want Always", resp.Data.Spec.MainContainer.ImagePullPolicy)
+	}
+	if resp.Data.Spec.ClusterId == nil || *resp.Data.Spec.ClusterId != "cluster-a" {
+		t.Fatalf("clusterId = %#v, want cluster-a", resp.Data.Spec.ClusterId)
+	}
+}
+
 func TestCreateTemplate_RejectsMissingMainContainerImage(t *testing.T) {
 	t.Parallel()
 
@@ -1231,6 +1363,44 @@ func validTemplateSpec() v1alpha1.SandboxTemplateSpec {
 			},
 		},
 		Pool: v1alpha1.PoolStrategy{MinIdle: 0, MaxIdle: 1},
+	}
+}
+
+func systemOnlyTemplate(templateID string) *template.Template {
+	sizeLimit := resource.MustParse("8Gi")
+	spec := validTemplateSpec()
+	spec.MainContainer.SecurityContext = &v1alpha1.SecurityContext{
+		Privileged:               ptrBool(true),
+		AllowPrivilegeEscalation: ptrBool(true),
+	}
+	spec.MainContainer.ImagePullPolicy = "Always"
+	spec.Pod = &v1alpha1.PodSpecOverride{
+		EmptyDirMounts: []v1alpha1.EmptyDirMountSpec{{
+			MountPath: "/var/lib/docker",
+			SizeLimit: &sizeLimit,
+		}},
+	}
+	spec.ClusterId = ptrString("cluster-a")
+	return &template.Template{
+		TemplateID: templateID,
+		Scope:      naming.ScopePublic,
+		Spec:       spec,
+	}
+}
+
+func assertSystemOnlyFieldsStripped(t *testing.T, spec v1alpha1.SandboxTemplateSpec) {
+	t.Helper()
+	if spec.Pod != nil {
+		t.Fatalf("pod = %#v, want nil", spec.Pod)
+	}
+	if spec.MainContainer.SecurityContext != nil {
+		t.Fatalf("securityContext = %#v, want nil", spec.MainContainer.SecurityContext)
+	}
+	if spec.MainContainer.ImagePullPolicy != "" {
+		t.Fatalf("imagePullPolicy = %q, want empty", spec.MainContainer.ImagePullPolicy)
+	}
+	if spec.ClusterId != nil {
+		t.Fatalf("clusterId = %#v, want nil", spec.ClusterId)
 	}
 }
 

--- a/pkg/template/resource_policy_test.go
+++ b/pkg/template/resource_policy_test.go
@@ -81,16 +81,16 @@ func TestValidateResourceRatio(t *testing.T) {
 		},
 	}
 
-	if err := ValidateResourceRatio(spec, resource.MustParse("4Gi"), "builtin template dins"); err != nil {
+	if err := ValidateResourceRatio(spec, resource.MustParse("4Gi"), "builtin template default"); err != nil {
 		t.Fatalf("expected ratio to pass, got %v", err)
 	}
 
 	spec.MainContainer.Resources.Memory = resource.MustParse("1Gi")
-	err := ValidateResourceRatio(spec, resource.MustParse("4Gi"), "builtin template dins")
+	err := ValidateResourceRatio(spec, resource.MustParse("4Gi"), "builtin template default")
 	if err == nil {
 		t.Fatal("expected ratio validation to fail")
 	}
-	if got := err.Error(); !strings.Contains(got, "builtin template dins total memory must equal total cpu * 4Gi") {
+	if got := err.Error(); !strings.Contains(got, "builtin template default total memory must equal total cpu * 4Gi") {
 		t.Fatalf("unexpected error %q", got)
 	}
 }


### PR DESCRIPTION
## Summary
- move Docker-in-Sandbox runtime shape into the default builtin template while keeping default 500m/2Gi resources
- stop seeding the separate `dins` builtin/template pool and remove `dins` from samples/docs
- disable service account token automount for sandbox pods

## Tests
- `go test ./infra-operator/internal/controller/pkg/common ./infra-operator/internal/plan ./manager/pkg/apis/sandbox0/v1alpha1 ./pkg/template`
- `go test ./manager/pkg/controller ./manager/pkg/service ./pkg/template/http ./pkg/template/reconciler ./infra-operator/internal/controller/services/manager ./infra-operator/internal/controller/services/scheduler`
- `git diff --check`
- `go test ./...` fails before completing due existing environment/generated-artifact blockers: missing `github.com/sandbox0-ai/sandbox0/storage-proxy/proto/fs` generated package and `kind` not installed for e2e tests
