### PR TITLE
Improve autoscaler cold claim backpressure

### DIFF
--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -330,6 +330,7 @@ func main() {
 	sandboxService.SetCredentialStore(credentialStore)
 	sandboxService.SetQuotaStore(quotaRepo)
 	sandboxService.SetSandboxStore(sandboxStore)
+	sandboxService.SetAutoScaler(operator.GetAutoScaler())
 	rootFSObjectStore, rootFSObjectStoreErr := buildRootFSObjectStore(cfg)
 	if rootFSObjectStoreErr != nil {
 		logger.Warn("Rootfs object cleanup disabled; object store is not configured", zap.Error(rootFSObjectStoreErr))

--- a/manager/pkg/controller/autoscaler.go
+++ b/manager/pkg/controller/autoscaler.go
@@ -107,6 +107,8 @@ type AutoScaler struct {
 
 	// Rate limiter to prevent over-scaling during concurrent cold claims
 	rateLimiter *scaleRateLimiter
+	// Admission limiter caps cold pods waiting for their first network identity.
+	coldClaims *coldClaimLimiter
 
 	// Configuration
 	config AutoScaleConfig
@@ -146,6 +148,11 @@ type AutoScaleConfig struct {
 	// ScaleDownPercent is the percentage to reduce replicas during scale down.
 	// Default: 10%
 	ScaleDownPercent float64
+
+	// MaxColdClaimInFlight caps per-template cold pod creations that have not
+	// reached network identity yet. Zero derives a conservative limit from
+	// MaxScaleStep and the template pool bounds.
+	MaxColdClaimInFlight int32
 }
 
 // DefaultAutoScaleConfig returns the default configuration.
@@ -185,6 +192,7 @@ func NewAutoScalerWithConfig(
 		replicaSetLister: replicaSetLister,
 		logger:           logger,
 		rateLimiter:      newScaleRateLimiter(config.MinScaleInterval),
+		coldClaims:       newColdClaimLimiter(),
 		config:           config,
 	}
 }
@@ -198,15 +206,98 @@ type ScaleDecision struct {
 	Reason      string // Human-readable reason for the decision
 }
 
+// ColdClaimAdmission is the autoscaler's synchronous decision before the
+// service creates a cold runtime pod.
+type ColdClaimAdmission struct {
+	Admitted       bool
+	Reason         string
+	RetryAfter     time.Duration
+	InFlight       int32
+	Limit          int32
+	NetworkBacklog int32
+	ScaleDecision  *ScaleDecision
+}
+
 // OnColdClaim is called when a cold claim occurs.
 // It makes an immediate scaling decision to replenish the idle pool.
 // This method is designed to be fast and can be called in a goroutine.
 func (s *AutoScaler) OnColdClaim(ctx context.Context, template *v1alpha1.SandboxTemplate) (decision *ScaleDecision, err error) {
+	return s.scaleForClaim(ctx, template, "cold claim")
+}
+
+// OnHotClaim is called after a hot claim removes one ready pod from the idle pool.
+func (s *AutoScaler) OnHotClaim(ctx context.Context, template *v1alpha1.SandboxTemplate) (*ScaleDecision, error) {
+	return s.scaleForClaim(ctx, template, "hot claim")
+}
+
+// AdmitColdClaim applies synchronous backpressure before the service creates a
+// new cold pod. The scaler still replenishes the idle pool first, but admission
+// is denied when either the observed Kubernetes backlog or this manager's
+// in-flight cold claims are already at the template limit.
+func (s *AutoScaler) AdmitColdClaim(ctx context.Context, template *v1alpha1.SandboxTemplate) (*ColdClaimAdmission, error) {
 	if template == nil {
 		return nil, fmt.Errorf("nil template")
 	}
 
-	templateKey := template.Namespace + "/" + template.Name
+	stats, err := s.getPoolStatsDetailed(template)
+	if err != nil {
+		return nil, fmt.Errorf("get pool stats: %w", err)
+	}
+	limit := s.maxColdClaimInFlight(template)
+	if stats.activeWithoutIP >= limit {
+		return &ColdClaimAdmission{
+			Admitted:       false,
+			Reason:         "pod network identity backlog",
+			RetryAfter:     time.Second,
+			Limit:          limit,
+			NetworkBacklog: stats.activeWithoutIP,
+		}, nil
+	}
+
+	templateKey := autoscalerTemplateKey(template)
+	inFlight, ok := s.coldClaims.TryAcquire(templateKey, limit)
+	if !ok {
+		return &ColdClaimAdmission{
+			Admitted:       false,
+			Reason:         "cold claim in-flight limit reached",
+			RetryAfter:     time.Second,
+			InFlight:       inFlight,
+			Limit:          limit,
+			NetworkBacklog: stats.activeWithoutIP,
+		}, nil
+	}
+
+	decision, scaleErr := s.OnColdClaim(ctx, template)
+	if scaleErr != nil {
+		s.coldClaims.Release(templateKey)
+		return nil, scaleErr
+	}
+
+	return &ColdClaimAdmission{
+		Admitted:       true,
+		Reason:         "admitted",
+		InFlight:       inFlight,
+		Limit:          limit,
+		NetworkBacklog: stats.activeWithoutIP,
+		ScaleDecision:  decision,
+	}, nil
+}
+
+// CompleteColdClaim releases a cold admission slot when the pod has either
+// reached network identity or failed before reaching it.
+func (s *AutoScaler) CompleteColdClaim(template *v1alpha1.SandboxTemplate) {
+	if template == nil || s == nil || s.coldClaims == nil {
+		return
+	}
+	s.coldClaims.Release(autoscalerTemplateKey(template))
+}
+
+func (s *AutoScaler) scaleForClaim(ctx context.Context, template *v1alpha1.SandboxTemplate, claimReason string) (decision *ScaleDecision, err error) {
+	if template == nil {
+		return nil, fmt.Errorf("nil template")
+	}
+
+	templateKey := autoscalerTemplateKey(template)
 
 	// Atomic check-and-record: if rate limited, return immediately
 	// This prevents race conditions when multiple goroutines call this method
@@ -225,7 +316,7 @@ func (s *AutoScaler) OnColdClaim(ctx context.Context, template *v1alpha1.Sandbox
 	defer s.rateLimiter.Complete(templateKey)
 
 	// Get current state
-	idleCount, activeCount, err := s.getPoolStats(template)
+	stats, err := s.getPoolStatsDetailed(template)
 	if err != nil {
 		return nil, fmt.Errorf("get pool stats: %w", err)
 	}
@@ -243,7 +334,7 @@ func (s *AutoScaler) OnColdClaim(ctx context.Context, template *v1alpha1.Sandbox
 	}
 
 	// Calculate desired replicas
-	desiredReplicas := s.calculateDesiredReplicas(template, currentReplicas, idleCount, activeCount)
+	desiredReplicas := s.calculateDesiredReplicas(template, currentReplicas, stats.readyIdle, stats.runningActive)
 
 	// Check if we need to scale
 	if desiredReplicas <= currentReplicas {
@@ -252,7 +343,7 @@ func (s *AutoScaler) OnColdClaim(ctx context.Context, template *v1alpha1.Sandbox
 			OldReplicas: currentReplicas,
 			NewReplicas: currentReplicas,
 			Reason: fmt.Sprintf("no scale needed: current=%d, desired=%d, idle=%d, active=%d",
-				currentReplicas, desiredReplicas, idleCount, activeCount),
+				currentReplicas, desiredReplicas, stats.readyIdle, stats.runningActive),
 		}, nil
 	}
 
@@ -266,8 +357,9 @@ func (s *AutoScaler) OnColdClaim(ctx context.Context, template *v1alpha1.Sandbox
 		zap.String("namespace", template.Namespace),
 		zap.Int32("oldReplicas", currentReplicas),
 		zap.Int32("newReplicas", desiredReplicas),
-		zap.Int32("idle", idleCount),
-		zap.Int32("active", activeCount),
+		zap.Int32("idle", stats.readyIdle),
+		zap.Int32("active", stats.runningActive),
+		zap.Int32("activeWithoutIP", stats.activeWithoutIP),
 	)
 
 	return &ScaleDecision{
@@ -275,7 +367,7 @@ func (s *AutoScaler) OnColdClaim(ctx context.Context, template *v1alpha1.Sandbox
 		OldReplicas: currentReplicas,
 		NewReplicas: desiredReplicas,
 		Delta:       desiredReplicas - currentReplicas,
-		Reason:      fmt.Sprintf("cold claim triggered scale: idle=%d, active=%d", idleCount, activeCount),
+		Reason:      fmt.Sprintf("%s triggered scale: idle=%d, active=%d", claimReason, stats.readyIdle, stats.runningActive),
 	}, nil
 }
 
@@ -342,20 +434,43 @@ func (s *AutoScaler) calculateDesiredReplicas(
 	return desired
 }
 
-// getPoolStats returns the current idle and active pod counts.
+type autoScalerPoolStats struct {
+	readyIdle       int32
+	pendingIdle     int32
+	runningActive   int32
+	pendingActive   int32
+	activeWithoutIP int32
+}
+
+// getPoolStats returns the current ready idle and running active pod counts.
 func (s *AutoScaler) getPoolStats(template *v1alpha1.SandboxTemplate) (idle, active int32, err error) {
+	stats, err := s.getPoolStatsDetailed(template)
+	if err != nil {
+		return 0, 0, err
+	}
+	return stats.readyIdle, stats.runningActive, nil
+}
+
+func (s *AutoScaler) getPoolStatsDetailed(template *v1alpha1.SandboxTemplate) (autoScalerPoolStats, error) {
+	var stats autoScalerPoolStats
+
 	// Count idle pods
 	idlePods, err := s.podLister.Pods(template.Namespace).List(labels.SelectorFromSet(map[string]string{
 		LabelTemplateID: template.Name,
 		LabelPoolType:   PoolTypeIdle,
 	}))
 	if err != nil {
-		return 0, 0, fmt.Errorf("list idle pods: %w", err)
+		return stats, fmt.Errorf("list idle pods: %w", err)
 	}
 
 	for _, pod := range idlePods {
+		if pod.DeletionTimestamp != nil || isTerminalPodPhase(pod.Status.Phase) {
+			continue
+		}
 		if IsPodReady(pod) {
-			idle++
+			stats.readyIdle++
+		} else {
+			stats.pendingIdle++
 		}
 	}
 
@@ -365,16 +480,28 @@ func (s *AutoScaler) getPoolStats(template *v1alpha1.SandboxTemplate) (idle, act
 		LabelPoolType:   PoolTypeActive,
 	}))
 	if err != nil {
-		return 0, 0, fmt.Errorf("list active pods: %w", err)
+		return stats, fmt.Errorf("list active pods: %w", err)
 	}
 
 	for _, pod := range activePods {
+		if pod.DeletionTimestamp != nil || isTerminalPodPhase(pod.Status.Phase) {
+			continue
+		}
+		if pod.Status.PodIP == "" {
+			stats.activeWithoutIP++
+		}
 		if pod.Status.Phase == corev1.PodRunning {
-			active++
+			stats.runningActive++
+		} else {
+			stats.pendingActive++
 		}
 	}
 
-	return idle, active, nil
+	return stats, nil
+}
+
+func isTerminalPodPhase(phase corev1.PodPhase) bool {
+	return phase == corev1.PodSucceeded || phase == corev1.PodFailed
 }
 
 // getCurrentReplicas returns the current replica count from the ReplicaSet.
@@ -515,4 +642,37 @@ func (s *AutoScaler) getLastClaimTime(template *v1alpha1.SandboxTemplate) time.T
 
 func ptrToInt32(v int32) *int32 {
 	return &v
+}
+
+func autoscalerTemplateKey(template *v1alpha1.SandboxTemplate) string {
+	if template == nil {
+		return ""
+	}
+	return template.Namespace + "/" + template.Name
+}
+
+func (s *AutoScaler) maxColdClaimInFlight(template *v1alpha1.SandboxTemplate) int32 {
+	if s.config.MaxColdClaimInFlight > 0 {
+		return s.config.MaxColdClaimInFlight
+	}
+
+	limit := s.config.MaxScaleStep * 5
+	if limit <= 0 {
+		limit = 50
+	}
+	minRecommended := template.Spec.Pool.MinIdle + s.config.MinIdleBuffer
+	if limit < minRecommended {
+		limit = minRecommended
+	}
+	maxIdle := template.Spec.Pool.MaxIdle
+	if maxIdle < template.Spec.Pool.MinIdle {
+		maxIdle = template.Spec.Pool.MinIdle
+	}
+	if maxIdle > 0 && limit > maxIdle {
+		limit = maxIdle
+	}
+	if limit <= 0 {
+		limit = 1
+	}
+	return limit
 }

--- a/manager/pkg/controller/autoscaler_test.go
+++ b/manager/pkg/controller/autoscaler_test.go
@@ -398,6 +398,106 @@ func TestAutoScaler_CalculateDesiredReplicas(t *testing.T) {
 	}
 }
 
+func TestAutoScaler_AdmitColdClaimLimitsInFlight(t *testing.T) {
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "template-a",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.SandboxTemplateSpec{
+			Pool: v1alpha1.PoolStrategy{MinIdle: 1, MaxIdle: 10},
+		},
+	}
+	rsName, err := naming.ReplicasetName(naming.DefaultClusterID, template.Name)
+	require.NoError(t, err)
+	replicas := int32(1)
+	rs := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{Name: rsName, Namespace: template.Namespace},
+		Spec:       appsv1.ReplicaSetSpec{Replicas: &replicas},
+	}
+
+	client := fake.NewSimpleClientset(rs)
+	podIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	rsIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	require.NoError(t, rsIndexer.Add(rs))
+
+	cfg := DefaultAutoScaleConfig()
+	cfg.MaxColdClaimInFlight = 1
+	scaler := NewAutoScalerWithConfig(
+		client,
+		corelisters.NewPodLister(podIndexer),
+		appslisters.NewReplicaSetLister(rsIndexer),
+		zap.NewNop(),
+		cfg,
+	)
+
+	first, err := scaler.AdmitColdClaim(context.Background(), template)
+	require.NoError(t, err)
+	require.True(t, first.Admitted)
+
+	second, err := scaler.AdmitColdClaim(context.Background(), template)
+	require.NoError(t, err)
+	require.False(t, second.Admitted)
+	assert.Equal(t, "cold claim in-flight limit reached", second.Reason)
+
+	scaler.CompleteColdClaim(template)
+	third, err := scaler.AdmitColdClaim(context.Background(), template)
+	require.NoError(t, err)
+	require.True(t, third.Admitted)
+}
+
+func TestAutoScaler_AdmitColdClaimRejectsNetworkBacklog(t *testing.T) {
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "template-a",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.SandboxTemplateSpec{
+			Pool: v1alpha1.PoolStrategy{MinIdle: 1, MaxIdle: 10},
+		},
+	}
+	activeWithoutIP := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "active-no-ip",
+			Namespace: template.Namespace,
+			Labels: map[string]string{
+				LabelTemplateID: template.Name,
+				LabelPoolType:   PoolTypeActive,
+			},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodPending},
+	}
+	rsName, err := naming.ReplicasetName(naming.DefaultClusterID, template.Name)
+	require.NoError(t, err)
+	replicas := int32(1)
+	rs := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{Name: rsName, Namespace: template.Namespace},
+		Spec:       appsv1.ReplicaSetSpec{Replicas: &replicas},
+	}
+
+	client := fake.NewSimpleClientset(activeWithoutIP, rs)
+	podIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	require.NoError(t, podIndexer.Add(activeWithoutIP))
+	rsIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	require.NoError(t, rsIndexer.Add(rs))
+
+	cfg := DefaultAutoScaleConfig()
+	cfg.MaxColdClaimInFlight = 1
+	scaler := NewAutoScalerWithConfig(
+		client,
+		corelisters.NewPodLister(podIndexer),
+		appslisters.NewReplicaSetLister(rsIndexer),
+		zap.NewNop(),
+		cfg,
+	)
+
+	admission, err := scaler.AdmitColdClaim(context.Background(), template)
+	require.NoError(t, err)
+	require.False(t, admission.Admitted)
+	assert.Equal(t, "pod network identity backlog", admission.Reason)
+	assert.Equal(t, int32(1), admission.NetworkBacklog)
+}
+
 func TestScaleRateLimiter(t *testing.T) {
 	limiter := newScaleRateLimiter(100 * time.Millisecond)
 

--- a/manager/pkg/controller/pool_manager.go
+++ b/manager/pkg/controller/pool_manager.go
@@ -159,15 +159,18 @@ func (pm *PoolManager) ReconcilePool(ctx context.Context, template *v1alpha1.San
 		return fmt.Errorf("repair unhealthy idle pods: %w", err)
 	}
 
-	// 5. Check if replicas match minIdle
-	if rs.Spec.Replicas == nil || *rs.Spec.Replicas != template.Spec.Pool.MinIdle {
+	// 5. Keep replicas inside the template pool bounds without fighting the
+	// autoscaler's current target.
+	currentReplicas := getInt32Value(rs.Spec.Replicas)
+	desiredReplicas := desiredPoolReplicas(template, currentReplicas)
+	if rs.Spec.Replicas == nil || currentReplicas != desiredReplicas {
 		pm.logger.Info("Updating ReplicaSet replicas",
 			zap.String("template", template.Name),
-			zap.Int32("current", getInt32Value(rs.Spec.Replicas)),
-			zap.Int32("desired", template.Spec.Pool.MinIdle),
+			zap.Int32("current", currentReplicas),
+			zap.Int32("desired", desiredReplicas),
 		)
 
-		rs.Spec.Replicas = &template.Spec.Pool.MinIdle
+		rs.Spec.Replicas = &desiredReplicas
 		_, err = pm.k8sClient.AppsV1().ReplicaSets(template.Namespace).Update(ctx, rs, metav1.UpdateOptions{})
 		if err != nil {
 			pm.recorder.Eventf(template, corev1.EventTypeWarning, "ReplicaSetUpdateFailed",
@@ -176,10 +179,25 @@ func (pm *PoolManager) ReconcilePool(ctx context.Context, template *v1alpha1.San
 		}
 
 		pm.recorder.Eventf(template, corev1.EventTypeNormal, "ReplicaSetUpdated",
-			"Updated ReplicaSet replicas to %d", template.Spec.Pool.MinIdle)
+			"Updated ReplicaSet replicas to %d", desiredReplicas)
 	}
 
 	return nil
+}
+
+func desiredPoolReplicas(template *v1alpha1.SandboxTemplate, current int32) int32 {
+	minIdle := template.Spec.Pool.MinIdle
+	maxIdle := template.Spec.Pool.MaxIdle
+	if maxIdle < minIdle {
+		maxIdle = minIdle
+	}
+	if current < minIdle {
+		return minIdle
+	}
+	if current > maxIdle {
+		return maxIdle
+	}
+	return current
 }
 
 // getOrCreateReplicaSet gets or creates the ReplicaSet for a template

--- a/manager/pkg/controller/pool_manager_test.go
+++ b/manager/pkg/controller/pool_manager_test.go
@@ -73,6 +73,18 @@ func TestBuildPodTemplateAnnotatesTeamOwnedWarmPool(t *testing.T) {
 	assert.Equal(t, OwnerKindTeamWarmPool, got.Labels[LabelOwnerKind])
 }
 
+func TestDesiredPoolReplicasPreservesAutoscalerTargetWithinBounds(t *testing.T) {
+	template := &v1alpha1.SandboxTemplate{
+		Spec: v1alpha1.SandboxTemplateSpec{
+			Pool: v1alpha1.PoolStrategy{MinIdle: 15, MaxIdle: 50},
+		},
+	}
+
+	assert.Equal(t, int32(15), desiredPoolReplicas(template, 10))
+	assert.Equal(t, int32(30), desiredPoolReplicas(template, 30))
+	assert.Equal(t, int32(50), desiredPoolReplicas(template, 80))
+}
+
 func TestBuildPodTemplatePreMountsUserVolumePortalsForIdlePool(t *testing.T) {
 	pm := &PoolManager{}
 	template := &v1alpha1.SandboxTemplate{

--- a/manager/pkg/controller/ratelimit.go
+++ b/manager/pkg/controller/ratelimit.go
@@ -60,3 +60,44 @@ func (r *scaleRateLimiter) Complete(key string) {
 	delete(r.inProgress, key)
 	r.lastCompleteAt[key] = time.Now()
 }
+
+type coldClaimLimiter struct {
+	mu       sync.Mutex
+	inFlight map[string]int32
+}
+
+func newColdClaimLimiter() *coldClaimLimiter {
+	return &coldClaimLimiter{
+		inFlight: make(map[string]int32),
+	}
+}
+
+func (l *coldClaimLimiter) TryAcquire(key string, limit int32) (int32, bool) {
+	if limit <= 0 {
+		limit = 1
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	current := l.inFlight[key]
+	if current >= limit {
+		return current, false
+	}
+	current++
+	l.inFlight[key] = current
+	return current, true
+}
+
+func (l *coldClaimLimiter) Release(key string) int32 {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	current := l.inFlight[key]
+	if current <= 1 {
+		delete(l.inFlight, key)
+		return 0
+	}
+	current--
+	l.inFlight[key] = current
+	return current
+}

--- a/manager/pkg/http/handlers_sandbox.go
+++ b/manager/pkg/http/handlers_sandbox.go
@@ -56,7 +56,7 @@ func (s *Server) claimSandbox(c *gin.Context) {
 			spec.JSONError(c, http.StatusConflict, spec.CodeConflict, err.Error())
 			return
 		}
-		if errors.Is(err, service.ErrDataPlaneNotReady) {
+		if errors.Is(err, service.ErrDataPlaneNotReady) || errors.Is(err, service.ErrColdClaimCapacityUnavailable) {
 			c.Header("Retry-After", "1")
 			spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, err.Error())
 			return

--- a/manager/pkg/service/sandbox_service.go
+++ b/manager/pkg/service/sandbox_service.go
@@ -55,6 +55,7 @@ var errNoIdlePod = errors.New("no idle pod available")
 var ErrInvalidClaimRequest = errors.New("invalid claim request")
 var ErrClaimConflict = errors.New("claim conflict")
 var ErrDataPlaneNotReady = errors.New("data plane not ready")
+var ErrColdClaimCapacityUnavailable = errors.New("cold claim capacity unavailable")
 var ErrQuotaExceeded = errors.New("quota exceeded")
 var ErrInvalidNetworkPolicy = errors.New("invalid network policy")
 var ErrSandboxCheckpointRequiresCtld = errors.New("sandbox checkpoint pause requires ctld")
@@ -145,6 +146,17 @@ type AutoScalerInterface interface {
 // ScaleDecisionResult represents the result of a scaling decision.
 // This is a local copy to avoid tight coupling with controller package.
 type ScaleDecisionResult = controller.ScaleDecision
+
+type HotClaimAutoScalerInterface interface {
+	OnHotClaim(ctx context.Context, template *v1alpha1.SandboxTemplate) (*ScaleDecisionResult, error)
+}
+
+type ColdClaimAdmissionAutoScalerInterface interface {
+	AdmitColdClaim(ctx context.Context, template *v1alpha1.SandboxTemplate) (*ColdClaimAdmissionResult, error)
+	CompleteColdClaim(template *v1alpha1.SandboxTemplate)
+}
+
+type ColdClaimAdmissionResult = controller.ColdClaimAdmission
 
 // TimeProvider provides time functions, allowing for synchronized time across clusters
 type TimeProvider interface {

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -447,6 +447,9 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 		return nil, fmt.Errorf("claim idle pod: %w", err)
 	}
 	claimType := "hot"
+	if pod != nil {
+		s.triggerHotClaimScale(template, req.Template)
+	}
 
 	// If no idle pod available, create a new one (cold start)
 	if pod == nil {
@@ -455,49 +458,44 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 			zap.String("template", req.Template),
 		)
 
-		// Trigger async scale-up to replenish the idle pool
-		// This runs in a goroutine to not block the cold claim response
-		if s.autoScaler != nil {
-			go func() {
-				scaleCtx := context.Background()
-				scaleDecision, scaleErr := s.autoScaler.OnColdClaim(scaleCtx, template)
-				if scaleErr != nil {
-					s.logger.Warn("Auto scale failed during cold claim",
-						zap.String("template", req.Template),
-						zap.Error(scaleErr),
-					)
-				} else if scaleDecision != nil && scaleDecision.ShouldScale {
-					s.logger.Info("Auto scale triggered",
-						zap.String("template", req.Template),
-						zap.Int32("delta", scaleDecision.Delta),
-						zap.String("reason", scaleDecision.Reason),
-					)
-				}
-			}()
+		phaseStarted = time.Now()
+		coldClaimAdmitter, coldClaimAdmitted, err := s.admitColdClaim(ctx, template, req.Template)
+		s.observeClaimPhase(req.Template, claimType, "admit_cold_claim", phaseStarted, err)
+		if err != nil {
+			if metrics != nil {
+				metrics.SandboxClaimsTotal.WithLabelValues(req.Template, "error").Inc()
+			}
+			return nil, err
+		}
+		completeColdAdmission := func() {
+			if coldClaimAdmitted && coldClaimAdmitter != nil {
+				coldClaimAdmitter.CompleteColdClaim(template)
+				coldClaimAdmitted = false
+			}
 		}
 
 		phaseStarted = time.Now()
 		pod, err = s.createNewPod(ctx, template, req)
 		s.observeClaimPhase(req.Template, claimType, "create_new_pod", phaseStarted, err)
 		if err != nil {
+			completeColdAdmission()
 			if metrics != nil {
 				metrics.SandboxClaimsTotal.WithLabelValues(req.Template, "error").Inc()
 			}
 			return nil, fmt.Errorf("create new pod: %w", err)
 		}
-	}
 
-	// Note: Network policies are stored in pod annotations.
-	// They are set in claimIdlePod() and createNewPod() methods. Hot claims have
-	// already selected a Kubernetes-ready idle pod. Cold claims must wait until
-	// the pod has the network identity netd watches before waiting for netd to
-	// patch the applied policy hash.
-	if claimType == "cold" {
+		// Note: Network policies are stored in pod annotations.
+		// They are set in claimIdlePod() and createNewPod() methods. Hot claims have
+		// already selected a Kubernetes-ready idle pod. Cold claims must wait until
+		// the pod has the network identity netd watches before waiting for netd to
+		// patch the applied policy hash.
 		if s.networkProvider != nil {
 			phaseStarted = time.Now()
 			networkPod, err := s.waitForPodNetworkIdentity(ctx, pod.Namespace, pod.Name)
 			s.observeClaimPhase(req.Template, claimType, "wait_for_pod_network_identity", phaseStarted, err)
 			if err != nil {
+				completeColdAdmission()
 				s.requestSandboxDeletionAfterClaimFailure(pod, "network identity readiness failed")
 				if metrics != nil {
 					metrics.SandboxClaimsTotal.WithLabelValues(req.Template, "error").Inc()
@@ -505,6 +503,7 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 				return nil, fmt.Errorf("wait for pod network identity: %w", err)
 			}
 			pod = networkPod
+			completeColdAdmission()
 
 			phaseStarted = time.Now()
 			err = s.applyNetworkProviderFromPod(ctx, pod, req.TeamID)
@@ -522,12 +521,14 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 		readyPod, err := s.waitForPodClaimReady(ctx, pod.Namespace, pod.Name)
 		s.observeClaimPhase(req.Template, claimType, "wait_for_pod_claim_ready", phaseStarted, err)
 		if err != nil {
+			completeColdAdmission()
 			s.requestSandboxDeletionAfterClaimFailure(pod, "claim readiness failed")
 			if metrics != nil {
 				metrics.SandboxClaimsTotal.WithLabelValues(req.Template, "error").Inc()
 			}
 			return nil, fmt.Errorf("wait for pod claim readiness: %w", err)
 		}
+		completeColdAdmission()
 		pod = readyPod
 		s.refreshSandboxProbeConditionsAsync(pod)
 	}
@@ -741,7 +742,91 @@ func (s *SandboxService) generateStableSandboxID(template *v1alpha1.SandboxTempl
 		return "", fmt.Errorf("template is required")
 	}
 	clusterID := naming.ClusterIDOrDefault(template.Spec.ClusterId)
-	return naming.SandboxName(clusterID, template.Name, utilrand.String(5))
+	rsName, err := naming.ReplicasetName(clusterID, template.Name)
+	if err != nil {
+		return "", fmt.Errorf("generate sandbox id prefix: %w", err)
+	}
+	return fmt.Sprintf("%s-%s", rsName, utilrand.String(10)), nil
+}
+
+func (s *SandboxService) triggerHotClaimScale(template *v1alpha1.SandboxTemplate, templateID string) {
+	scaler, ok := s.autoScaler.(HotClaimAutoScalerInterface)
+	if !ok || scaler == nil {
+		return
+	}
+	go func() {
+		decision, err := scaler.OnHotClaim(context.Background(), template)
+		if err != nil {
+			s.logger.Warn("Auto scale failed during hot claim",
+				zap.String("template", templateID),
+				zap.Error(err),
+			)
+			return
+		}
+		if decision != nil && decision.ShouldScale {
+			s.logger.Info("Auto scale triggered",
+				zap.String("template", templateID),
+				zap.Int32("delta", decision.Delta),
+				zap.String("reason", decision.Reason),
+			)
+		}
+	}()
+}
+
+func (s *SandboxService) admitColdClaim(
+	ctx context.Context,
+	template *v1alpha1.SandboxTemplate,
+	templateID string,
+) (ColdClaimAdmissionAutoScalerInterface, bool, error) {
+	admitter, ok := s.autoScaler.(ColdClaimAdmissionAutoScalerInterface)
+	if !ok || admitter == nil {
+		s.triggerLegacyColdClaimScale(template, templateID)
+		return nil, false, nil
+	}
+
+	admission, err := admitter.AdmitColdClaim(ctx, template)
+	if err != nil {
+		return nil, false, fmt.Errorf("admit cold claim: %w", err)
+	}
+	if admission != nil && !admission.Admitted {
+		s.logger.Warn("Cold claim capacity unavailable",
+			zap.String("template", templateID),
+			zap.String("reason", admission.Reason),
+			zap.Int32("inFlight", admission.InFlight),
+			zap.Int32("limit", admission.Limit),
+			zap.Int32("networkBacklog", admission.NetworkBacklog),
+		)
+		return nil, false, fmt.Errorf("%w: %s", ErrColdClaimCapacityUnavailable, admission.Reason)
+	}
+	if admission != nil && admission.ScaleDecision != nil && admission.ScaleDecision.ShouldScale {
+		s.logger.Info("Auto scale triggered",
+			zap.String("template", templateID),
+			zap.Int32("delta", admission.ScaleDecision.Delta),
+			zap.String("reason", admission.ScaleDecision.Reason),
+		)
+	}
+	return admitter, true, nil
+}
+
+func (s *SandboxService) triggerLegacyColdClaimScale(template *v1alpha1.SandboxTemplate, templateID string) {
+	if s.autoScaler == nil {
+		return
+	}
+	go func() {
+		scaleDecision, scaleErr := s.autoScaler.OnColdClaim(context.Background(), template)
+		if scaleErr != nil {
+			s.logger.Warn("Auto scale failed during cold claim",
+				zap.String("template", templateID),
+				zap.Error(scaleErr),
+			)
+		} else if scaleDecision != nil && scaleDecision.ShouldScale {
+			s.logger.Info("Auto scale triggered",
+				zap.String("template", templateID),
+				zap.Int32("delta", scaleDecision.Delta),
+				zap.String("reason", scaleDecision.Reason),
+			)
+		}
+	}()
 }
 
 func (s *SandboxService) observeClaimPhase(template, claimType, phase string, started time.Time, err error) {

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -589,6 +589,62 @@ func TestClaimSandboxDeletesColdPodAfterNetworkApplyFailure(t *testing.T) {
 	}
 }
 
+func TestClaimSandboxStopsBeforeCreateWhenColdClaimCapacityUnavailable(t *testing.T) {
+	withClaimTestPublicKey(t)
+
+	templateNamespace, err := naming.TemplateNamespaceForBuiltin("managed-agent-claude")
+	if err != nil {
+		t.Fatalf("template namespace: %v", err)
+	}
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "managed-agent-claude",
+			Namespace: templateNamespace,
+		},
+		Spec: v1alpha1.SandboxTemplateSpec{
+			MainContainer: v1alpha1.ContainerSpec{Image: "busybox"},
+		},
+	}
+	client := fake.NewSimpleClientset()
+	svc := &SandboxService{
+		k8sClient:      client,
+		podLister:      corelisters.NewPodLister(newClaimTestPodIndexer(t)),
+		secretLister:   newClaimTestSecretLister(t),
+		templateLister: staticTemplateLister{templates: []*v1alpha1.SandboxTemplate{template}},
+		clock:          systemTime{},
+		logger:         zap.NewNop(),
+	}
+	svc.SetAutoScaler(&rejectingColdClaimScaler{})
+
+	_, err = svc.ClaimSandbox(context.Background(), &ClaimRequest{Template: "managed-agent-claude", TeamID: "team-a", UserID: "user-a"})
+	if !errors.Is(err, ErrColdClaimCapacityUnavailable) {
+		t.Fatalf("ClaimSandbox() error = %v, want ErrColdClaimCapacityUnavailable", err)
+	}
+
+	pods, err := client.CoreV1().Pods(templateNamespace).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list pods: %v", err)
+	}
+	if len(pods.Items) != 0 {
+		t.Fatalf("pods after rejected cold claim = %d, want 0", len(pods.Items))
+	}
+}
+
+type rejectingColdClaimScaler struct{}
+
+func (s *rejectingColdClaimScaler) OnColdClaim(context.Context, *v1alpha1.SandboxTemplate) (*ScaleDecisionResult, error) {
+	return &ScaleDecisionResult{ShouldScale: false}, nil
+}
+
+func (s *rejectingColdClaimScaler) AdmitColdClaim(context.Context, *v1alpha1.SandboxTemplate) (*ColdClaimAdmissionResult, error) {
+	return &ColdClaimAdmissionResult{
+		Admitted: false,
+		Reason:   "cold claim in-flight limit reached",
+	}, nil
+}
+
+func (s *rejectingColdClaimScaler) CompleteColdClaim(*v1alpha1.SandboxTemplate) {}
+
 func TestCreateNewPodMarksColdPodNonEvictable(t *testing.T) {
 	withClaimTestPublicKey(t)
 


### PR DESCRIPTION
## Summary

- wire the operator autoscaler into `SandboxService` and let `PoolManager` preserve autoscaler-owned ReplicaSet targets within `minIdle/maxIdle`
- add synchronous cold-claim admission before `createNewPod`, using per-template in-flight limits plus observed active pods without PodIP as backpressure
- trigger proactive scale checks on hot claims and increase generated stable sandbox ID entropy without changing pod name suffix semantics

## Why

The benchmark showed cold claims creating hundreds of active pods on one node while the idle ReplicaSet stayed at `minIdle`. Most failures then timed out waiting for pod network identity because PodIP assignment lagged behind the burst. The manager should replenish the idle pool quickly, but it should not keep creating cold pods when the network-identity backlog is already saturated.

## Testing

- `go test ./manager/pkg/controller ./manager/pkg/service ./manager/pkg/http`
- `go test ./manager/...`
- `go test ./...` was attempted, but this checkout cannot complete the full suite because `storage-proxy/proto/fs` generated package is missing for storage-proxy/ctld setup, and local e2e requires `kind`, which is not installed in this environment.
