### PR TITLE
Redesign manager autoscaler target controller

### DIFF
--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -330,6 +330,7 @@ func main() {
 	sandboxService.SetCredentialStore(credentialStore)
 	sandboxService.SetQuotaStore(quotaRepo)
 	sandboxService.SetSandboxStore(sandboxStore)
+	sandboxService.SetAutoScaler(operator.GetAutoScaler())
 	rootFSObjectStore, rootFSObjectStoreErr := buildRootFSObjectStore(cfg)
 	if rootFSObjectStoreErr != nil {
 		logger.Warn("Rootfs object cleanup disabled; object store is not configured", zap.Error(rootFSObjectStoreErr))

--- a/manager/pkg/controller/autoscaler.go
+++ b/manager/pkg/controller/autoscaler.go
@@ -387,15 +387,6 @@ func (s *AutoScaler) scaleUpStep(deficit int32) int32 {
 	return step
 }
 
-// getPoolStats returns the current ready idle and running active pod counts.
-func (s *AutoScaler) getPoolStats(template *v1alpha1.SandboxTemplate) (idle, active int32, err error) {
-	stats, err := s.getPoolStatsDetailed(template)
-	if err != nil {
-		return 0, 0, err
-	}
-	return stats.readyIdle, stats.runningActive, nil
-}
-
 func (s *AutoScaler) getPoolStatsDetailed(template *v1alpha1.SandboxTemplate) (autoScalerPoolStats, error) {
 	var stats autoScalerPoolStats
 

--- a/manager/pkg/controller/autoscaler.go
+++ b/manager/pkg/controller/autoscaler.go
@@ -1,89 +1,15 @@
 package controller
 
-// AutoScaler Algorithm
-//
-// This autoscaler is a fast, event-driven approach that responds in milliseconds.
-//
-// # Architecture Overview
-//
-//	Cold Claim Request
-//	        │
-//	        ▼
-//	┌───────────────────┐
-//	│ Start goroutine   │  ← Non-blocking, returns immediately
-//	└─────────┬─────────┘
-//	          │
-//	          ▼
-//	┌───────────────────┐     Rate Limited
-//	│ TryAcquire()      │─────────────────► return
-//	└─────────┬─────────┘
-//	          │ Acquired
-//	          ▼
-//	┌───────────────────┐
-//	│ Calculate desired │
-//	│ replicas          │
-//	└─────────┬─────────┘
-//	          │
-//	          ▼
-//	┌───────────────────┐
-//	│ Update ReplicaSet │
-//	└─────────┬─────────┘
-//	          │
-//	          ▼
-//	┌───────────────────┐
-//	│ Complete()        │  ← Release rate limiter
-//	└───────────────────┘
-//
-// # Rate Limiter Design
-//
-// The rate limiter ensures safe concurrent scaling with two conditions:
-//
-//  1. In-Progress Check: Only ONE scale operation can run at a time
-//     - Prevents thundering herd when multiple cold claims arrive simultaneously
-//     - Uses atomic check-and-set via TryAcquire()
-//
-//  2. Interval Check: After a scale COMPLETES, wait minInterval before next scale
-//     - Interval is measured from completion time, not start time
-//     - Default: 100ms
-//
-// Timeline:
-//
-//	T0: TryAcquire() → true (inProgress=true)
-//	T1: Scaling in progress...
-//	    TryAcquire() → false (in progress)
-//	T2: Complete() (inProgress=false, lastCompleteAt=T2)
-//	    TryAcquire() → false (interval not passed)
-//	T2+100ms: TryAcquire() → true
-//
-// # Scaling Strategy
-//
-// The desired replica count is calculated using multiple strategies:
-//
-//  1. MinIdle Guarantee: Ensure at least minIdle replicas
-//
-//  2. Active Ratio: Scale based on active pod count
-//     desiredIdle = activeCount × TargetIdleRatio (default 0.2)
-//
-//  3. Scale Factor: On cold claim, scale up by factor (default 1.5x)
-//     newReplicas = currentReplicas × ScaleUpFactor
-//     Capped by MaxScaleStep (default 10)
-//
-//  4. Bounds: Always clamp to [minIdle, maxIdle]
-//
-// # Scale Down
-//
-// Scale down is handled asynchronously by the background reconcile loop:
-// - Triggered after NoTrafficScaleDownAfter (default 10min) of no claims
-// - Reduces replicas by ScaleDownPercent (default 10%)
-// - Never goes below minIdle
-
 import (
 	"context"
 	"fmt"
+	"math"
+	"sync"
 	"time"
 
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
+	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -95,57 +21,72 @@ import (
 	"k8s.io/client-go/util/retry"
 )
 
-// AutoScaler provides synchronous scaling decisions during cold claims.
-// Unlike the previous async autoscaler with 30s cooldown, this scaler
-// responds in milliseconds by making scaling decisions directly in the
-// claim path.
+// AutoScaler owns the idle pool replica target for a SandboxTemplate.
+//
+// The external contract is still template pool minIdle/maxIdle plus the
+// OnColdClaim hook. Internally the scaler is deliberately small:
+//   - claim events update the recent-traffic timestamp,
+//   - hot/cold claims ask for a bounded idle-pool refill,
+//   - cold claims are admitted only while the pod-network backlog is healthy,
+//   - scale-down returns the pool target to minIdle after no traffic.
 type AutoScaler struct {
-	k8sClient        kubernetes.Interface
-	podLister        corelisters.PodLister
-	replicaSetLister appslisters.ReplicaSetLister
-	logger           *zap.Logger
+	k8sClient kubernetes.Interface
+	podLister corelisters.PodLister
+	logger    *zap.Logger
 
-	// Rate limiter to prevent over-scaling during concurrent cold claims
 	rateLimiter *scaleRateLimiter
+	coldClaims  *coldClaimLimiter
 
-	// Configuration
-	config AutoScaleConfig
+	stateMu sync.Mutex
+	state   map[string]*autoScalerTemplateState
+
+	metrics *obsmetrics.ManagerMetrics
+	config  AutoScaleConfig
 }
 
-// AutoScaleConfig holds configuration for the sync scaler.
+// AutoScaleConfig holds configuration for pool scaling behavior.
 type AutoScaleConfig struct {
-	// MinScaleInterval is the minimum time between scale operations for a template.
-	// This prevents thundering herd when multiple cold claims arrive simultaneously.
-	// Default: 100ms (much faster than the previous 30s async cooldown)
+	// MinScaleInterval is the minimum time between scale writes for a template.
 	MinScaleInterval time.Duration
 
-	// ScaleUpFactor determines how aggressively to scale up.
-	// When cold claim occurs, newReplicas = current * ScaleUpFactor.
-	// Default: 1.5 (50% increase per cold claim, capped by MaxScaleStep)
+	// ScaleUpFactor adds headroom to observed idle-pool deficits.
 	ScaleUpFactor float64
 
-	// MaxScaleStep caps the maximum pods to add in a single scale operation.
-	// Default: 10
+	// MaxScaleStep caps the maximum replicas added in one scale-up write.
 	MaxScaleStep int32
 
-	// MinIdleBuffer is the minimum number of idle pods to maintain above minIdle.
-	// When idle count drops to minIdle + MinIdleBuffer, proactive scaling kicks in.
-	// Default: 2
+	// MinIdleBuffer is the extra idle target used during urgent refills.
 	MinIdleBuffer int32
 
-	// TargetIdleRatio is the target ratio of idle pods to active pods.
-	// Formula: desiredIdle = active * TargetIdleRatio
-	// Default: 0.2 (1 idle for every 5 active)
+	// TargetIdleRatio keeps idle capacity proportional to active sandboxes.
 	TargetIdleRatio float64
 
-	// NoTrafficScaleDownAfter is the duration without any claims before scaling down.
-	// Scale down is still async and happens in the background reconcile loop.
-	// Default: 10 minutes
+	// NoTrafficScaleDownAfter is the idle period before returning to minIdle.
 	NoTrafficScaleDownAfter time.Duration
 
-	// ScaleDownPercent is the percentage to reduce replicas during scale down.
-	// Default: 10%
+	// ScaleDownPercent is kept for config compatibility. Scale-down now returns
+	// directly to minIdle after the idle window.
 	ScaleDownPercent float64
+
+	// MaxColdClaimInFlight caps per-template cold pods that have not reached
+	// network identity yet. Zero derives a cap from MaxScaleStep and pool bounds.
+	MaxColdClaimInFlight int32
+}
+
+type autoScalerTemplateState struct {
+	lastClaimAt time.Time
+}
+
+type autoScalerPoolStats struct {
+	readyIdle       int32
+	pendingIdle     int32
+	runningActive   int32
+	pendingActive   int32
+	activeWithoutIP int32
+}
+
+func (s autoScalerPoolStats) activeTotal() int32 {
+	return s.runningActive + s.pendingActive
 }
 
 // DefaultAutoScaleConfig returns the default configuration.
@@ -179,86 +120,169 @@ func NewAutoScalerWithConfig(
 	logger *zap.Logger,
 	config AutoScaleConfig,
 ) *AutoScaler {
-	return &AutoScaler{
-		k8sClient:        k8sClient,
-		podLister:        podLister,
-		replicaSetLister: replicaSetLister,
-		logger:           logger,
-		rateLimiter:      newScaleRateLimiter(config.MinScaleInterval),
-		config:           config,
+	config = normalizeAutoScaleConfig(config)
+	if logger == nil {
+		logger = zap.NewNop()
 	}
+	return &AutoScaler{
+		k8sClient:   k8sClient,
+		podLister:   podLister,
+		logger:      logger,
+		rateLimiter: newScaleRateLimiter(config.MinScaleInterval),
+		coldClaims:  newColdClaimLimiter(),
+		state:       make(map[string]*autoScalerTemplateState),
+		config:      config,
+	}
+}
+
+// SetMetrics attaches manager metrics. Nil disables autoscaler metrics.
+func (s *AutoScaler) SetMetrics(metrics *obsmetrics.ManagerMetrics) {
+	s.metrics = metrics
 }
 
 // ScaleDecision represents the result of a scaling decision.
 type ScaleDecision struct {
-	ShouldScale bool   // Whether scaling was performed
-	OldReplicas int32  // Previous replica count
-	NewReplicas int32  // New replica count (same as OldReplicas if ShouldScale is false)
-	Delta       int32  // Change in replicas (positive = scale up)
-	Reason      string // Human-readable reason for the decision
+	ShouldScale bool
+	OldReplicas int32
+	NewReplicas int32
+	Delta       int32
+	Reason      string
 }
 
-// OnColdClaim is called when a cold claim occurs.
-// It makes an immediate scaling decision to replenish the idle pool.
-// This method is designed to be fast and can be called in a goroutine.
-func (s *AutoScaler) OnColdClaim(ctx context.Context, template *v1alpha1.SandboxTemplate) (decision *ScaleDecision, err error) {
+// ColdClaimAdmission is the autoscaler's synchronous decision before the
+// service creates a cold runtime pod.
+type ColdClaimAdmission struct {
+	Admitted       bool
+	Reason         string
+	RetryAfter     time.Duration
+	InFlight       int32
+	Limit          int32
+	NetworkBacklog int32
+	ScaleDecision  *ScaleDecision
+}
+
+// OnColdClaim preserves the existing autoscaler hook for cold claims.
+func (s *AutoScaler) OnColdClaim(ctx context.Context, template *v1alpha1.SandboxTemplate) (*ScaleDecision, error) {
+	s.recordClaim(template)
+	return s.scaleForClaim(ctx, template, "cold")
+}
+
+// OnHotClaim is called after a hot claim removes one ready pod from the pool.
+func (s *AutoScaler) OnHotClaim(ctx context.Context, template *v1alpha1.SandboxTemplate) (*ScaleDecision, error) {
+	s.recordClaim(template)
+	return s.scaleForClaim(ctx, template, "hot")
+}
+
+// AdmitColdClaim applies backpressure before the service creates a cold pod.
+func (s *AutoScaler) AdmitColdClaim(ctx context.Context, template *v1alpha1.SandboxTemplate) (*ColdClaimAdmission, error) {
+	if template == nil {
+		return nil, fmt.Errorf("nil template")
+	}
+	s.recordClaim(template)
+
+	stats, err := s.getPoolStatsDetailed(template)
+	if err != nil {
+		return nil, fmt.Errorf("get pool stats: %w", err)
+	}
+	templateName := autoscalerMetricTemplate(template)
+	limit := s.maxColdClaimInFlight(template)
+	s.observePool(templateName, stats, 0, 0)
+
+	if stats.activeWithoutIP >= limit {
+		s.observeDecision(templateName, "admit_cold_claim", "pod_network_identity_backlog", "rejected")
+		return &ColdClaimAdmission{
+			Admitted:       false,
+			Reason:         "pod network identity backlog",
+			RetryAfter:     time.Second,
+			Limit:          limit,
+			NetworkBacklog: stats.activeWithoutIP,
+		}, nil
+	}
+
+	key := autoscalerTemplateKey(template)
+	inFlight, ok := s.coldClaims.TryAcquire(key, limit)
+	s.observeColdClaimsInFlight(templateName, inFlight)
+	if !ok {
+		s.observeDecision(templateName, "admit_cold_claim", "in_flight_limit", "rejected")
+		return &ColdClaimAdmission{
+			Admitted:       false,
+			Reason:         "cold claim in-flight limit reached",
+			RetryAfter:     time.Second,
+			InFlight:       inFlight,
+			Limit:          limit,
+			NetworkBacklog: stats.activeWithoutIP,
+		}, nil
+	}
+
+	decision, err := s.scaleForClaim(ctx, template, "cold")
+	if err != nil {
+		remaining := s.coldClaims.Release(key)
+		s.observeColdClaimsInFlight(templateName, remaining)
+		return nil, err
+	}
+
+	s.observeDecision(templateName, "admit_cold_claim", "admitted", "admitted")
+	return &ColdClaimAdmission{
+		Admitted:       true,
+		Reason:         "admitted",
+		InFlight:       inFlight,
+		Limit:          limit,
+		NetworkBacklog: stats.activeWithoutIP,
+		ScaleDecision:  decision,
+	}, nil
+}
+
+// CompleteColdClaim releases a cold admission slot.
+func (s *AutoScaler) CompleteColdClaim(template *v1alpha1.SandboxTemplate) {
+	if s == nil || template == nil || s.coldClaims == nil {
+		return
+	}
+	remaining := s.coldClaims.Release(autoscalerTemplateKey(template))
+	s.observeColdClaimsInFlight(autoscalerMetricTemplate(template), remaining)
+}
+
+func (s *AutoScaler) scaleForClaim(ctx context.Context, template *v1alpha1.SandboxTemplate, claimType string) (*ScaleDecision, error) {
 	if template == nil {
 		return nil, fmt.Errorf("nil template")
 	}
 
-	templateKey := template.Namespace + "/" + template.Name
-
-	// Atomic check-and-record: if rate limited, return immediately
-	// This prevents race conditions when multiple goroutines call this method
-	if !s.rateLimiter.TryAcquire(templateKey) {
-		s.logger.Debug("Scale rate limited",
-			zap.String("template", template.Name),
-		)
-		return &ScaleDecision{
-			ShouldScale: false,
-			Reason:      "rate limited",
-		}, nil
+	key := autoscalerTemplateKey(template)
+	templateName := autoscalerMetricTemplate(template)
+	if !s.rateLimiter.TryAcquire(key) {
+		s.observeDecision(templateName, "scale_up", "rate_limited", "skipped")
+		return &ScaleDecision{ShouldScale: false, Reason: "rate limited"}, nil
 	}
+	defer s.rateLimiter.Complete(key)
 
-	// Always mark complete when done (success, failure, or no scale needed)
-	// This ensures the rate limiter is released and interval starts from completion
-	defer s.rateLimiter.Complete(templateKey)
-
-	// Get current state
-	idleCount, activeCount, err := s.getPoolStats(template)
+	stats, err := s.getPoolStatsDetailed(template)
 	if err != nil {
 		return nil, fmt.Errorf("get pool stats: %w", err)
 	}
 
-	currentReplicas, err := s.getCurrentReplicas(template)
+	currentReplicas, err := s.getCurrentReplicas(ctx, template)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			// ReplicaSet doesn't exist yet, PoolManager will create it
-			return &ScaleDecision{
-				ShouldScale: false,
-				Reason:      "replicaset not found",
-			}, nil
+			s.observeDecision(templateName, "scale_up", "replicaset_not_found", "skipped")
+			return &ScaleDecision{ShouldScale: false, Reason: "replicaset not found"}, nil
 		}
 		return nil, fmt.Errorf("get current replicas: %w", err)
 	}
 
-	// Calculate desired replicas
-	desiredReplicas := s.calculateDesiredReplicas(template, currentReplicas, idleCount, activeCount)
-
-	// Check if we need to scale
+	desiredReplicas, reason := s.calculateScaleUpTarget(template, currentReplicas, stats, claimType)
+	s.observePool(templateName, stats, currentReplicas, desiredReplicas)
 	if desiredReplicas <= currentReplicas {
+		s.observeDecision(templateName, "scale_up", reason, "skipped")
 		return &ScaleDecision{
 			ShouldScale: false,
 			OldReplicas: currentReplicas,
 			NewReplicas: currentReplicas,
-			Reason: fmt.Sprintf("no scale needed: current=%d, desired=%d, idle=%d, active=%d",
-				currentReplicas, desiredReplicas, idleCount, activeCount),
+			Reason: fmt.Sprintf("no scale needed: current=%d desired=%d ready_idle=%d pending_idle=%d active=%d",
+				currentReplicas, desiredReplicas, stats.readyIdle, stats.pendingIdle, stats.activeTotal()),
 		}, nil
 	}
 
-	// Execute the scale operation
-	if err := s.executeScaleUp(ctx, template, currentReplicas, desiredReplicas); err != nil {
-		return nil, fmt.Errorf("execute scale up: %w", err)
+	if err := s.executeScale(ctx, template, desiredReplicas); err != nil {
+		return nil, fmt.Errorf("execute scale: %w", err)
 	}
 
 	s.logger.Info("Auto scale up completed",
@@ -266,142 +290,179 @@ func (s *AutoScaler) OnColdClaim(ctx context.Context, template *v1alpha1.Sandbox
 		zap.String("namespace", template.Namespace),
 		zap.Int32("oldReplicas", currentReplicas),
 		zap.Int32("newReplicas", desiredReplicas),
-		zap.Int32("idle", idleCount),
-		zap.Int32("active", activeCount),
+		zap.Int32("readyIdle", stats.readyIdle),
+		zap.Int32("pendingIdle", stats.pendingIdle),
+		zap.Int32("active", stats.activeTotal()),
+		zap.String("reason", reason),
 	)
+	s.observeDecision(templateName, "scale_up", reason, "scaled")
+	s.observeScaleDelta(templateName, desiredReplicas-currentReplicas)
 
 	return &ScaleDecision{
 		ShouldScale: true,
 		OldReplicas: currentReplicas,
 		NewReplicas: desiredReplicas,
 		Delta:       desiredReplicas - currentReplicas,
-		Reason:      fmt.Sprintf("cold claim triggered scale: idle=%d, active=%d", idleCount, activeCount),
+		Reason:      reason,
 	}, nil
 }
 
-// calculateDesiredReplicas determines the target replica count.
-func (s *AutoScaler) calculateDesiredReplicas(
+func (s *AutoScaler) calculateScaleUpTarget(
 	template *v1alpha1.SandboxTemplate,
-	currentReplicas, _ /* idleCount */, activeCount int32,
-) int32 {
-	// Note: idleCount is tracked but not used in current strategy.
-	// Future enhancements may use it for predictive scaling.
-	cfg := s.config
-	minIdle := template.Spec.Pool.MinIdle
-	maxIdle := template.Spec.Pool.MaxIdle
-
-	// Ensure maxIdle is at least minIdle
-	if maxIdle < minIdle {
-		maxIdle = minIdle
-	}
-
-	var desired int32
-
-	// Strategy 1: Ensure at least minIdle
-	if currentReplicas < minIdle {
+	currentReplicas int32,
+	stats autoScalerPoolStats,
+	claimType string,
+) (int32, string) {
+	minIdle, maxIdle := normalizedPoolBounds(template)
+	desired := currentReplicas
+	reason := "within_target"
+	if desired < minIdle {
 		desired = minIdle
-	} else {
-		desired = currentReplicas
+		reason = "min_idle"
 	}
 
-	// Strategy 2: Scale based on active count (target idle ratio)
-	// desiredIdle = activeCount * TargetIdleRatio
-	// But we need at least minIdle + MinIdleBuffer to handle burst
-	targetIdleFromActive := int32(float64(activeCount) * cfg.TargetIdleRatio)
-	minRecommended := minIdle + cfg.MinIdleBuffer
-
-	if targetIdleFromActive > minRecommended {
-		minRecommended = targetIdleFromActive
+	activeTarget := int32(math.Ceil(float64(stats.activeTotal()) * s.config.TargetIdleRatio))
+	if activeTarget < minIdle {
+		activeTarget = minIdle
+	}
+	if activeTarget > desired {
+		desired = activeTarget
+		reason = "active_ratio"
 	}
 
-	// Strategy 3: Apply scale factor on cold claim
-	// This ensures we over-provision slightly to handle burst traffic
-	scaledDesired := int32(float64(desired) * cfg.ScaleUpFactor)
-	if scaledDesired > desired {
-		// Cap by MaxScaleStep
-		delta := scaledDesired - desired
-		if delta > cfg.MaxScaleStep {
-			delta = cfg.MaxScaleStep
+	availableIdle := stats.readyIdle + stats.pendingIdle
+	urgentIdleTarget := minIdle + s.config.MinIdleBuffer
+	if urgentIdleTarget < minIdle {
+		urgentIdleTarget = minIdle
+	}
+	switch claimType {
+	case "cold":
+		if availableIdle < urgentIdleTarget {
+			deficit := urgentIdleTarget - availableIdle
+			target := currentReplicas + s.scaleUpStep(deficit)
+			if target > desired {
+				desired = target
+				reason = "cold_idle_deficit"
+			}
 		}
-		desired = desired + delta
+	case "hot":
+		lowWatermark := minIdle / 2
+		if lowWatermark < 1 && minIdle > 0 {
+			lowWatermark = 1
+		}
+		if stats.readyIdle <= lowWatermark && availableIdle < urgentIdleTarget {
+			deficit := urgentIdleTarget - availableIdle
+			target := currentReplicas + s.scaleUpStep(deficit)
+			if target > desired {
+				desired = target
+				reason = "hot_low_watermark"
+			}
+		}
 	}
 
-	// Ensure we have at least the minimum recommended
-	if desired < minRecommended {
-		desired = minRecommended
-	}
-
-	// Clamp to [minIdle, maxIdle]
 	if desired < minIdle {
 		desired = minIdle
 	}
 	if desired > maxIdle {
 		desired = maxIdle
 	}
-
-	return desired
+	return desired, reason
 }
 
-// getPoolStats returns the current idle and active pod counts.
+func (s *AutoScaler) scaleUpStep(deficit int32) int32 {
+	if deficit < 1 {
+		deficit = 1
+	}
+	factor := s.config.ScaleUpFactor
+	if factor < 1 {
+		factor = 1
+	}
+	step := int32(math.Ceil(float64(deficit) * factor))
+	if step < 1 {
+		step = 1
+	}
+	if s.config.MaxScaleStep > 0 && step > s.config.MaxScaleStep {
+		step = s.config.MaxScaleStep
+	}
+	return step
+}
+
+// getPoolStats returns the current ready idle and running active pod counts.
 func (s *AutoScaler) getPoolStats(template *v1alpha1.SandboxTemplate) (idle, active int32, err error) {
-	// Count idle pods
+	stats, err := s.getPoolStatsDetailed(template)
+	if err != nil {
+		return 0, 0, err
+	}
+	return stats.readyIdle, stats.runningActive, nil
+}
+
+func (s *AutoScaler) getPoolStatsDetailed(template *v1alpha1.SandboxTemplate) (autoScalerPoolStats, error) {
+	var stats autoScalerPoolStats
+
 	idlePods, err := s.podLister.Pods(template.Namespace).List(labels.SelectorFromSet(map[string]string{
 		LabelTemplateID: template.Name,
 		LabelPoolType:   PoolTypeIdle,
 	}))
 	if err != nil {
-		return 0, 0, fmt.Errorf("list idle pods: %w", err)
+		return stats, fmt.Errorf("list idle pods: %w", err)
 	}
-
 	for _, pod := range idlePods {
+		if pod.DeletionTimestamp != nil || isTerminalPodPhase(pod.Status.Phase) {
+			continue
+		}
 		if IsPodReady(pod) {
-			idle++
+			stats.readyIdle++
+		} else {
+			stats.pendingIdle++
 		}
 	}
 
-	// Count active pods
 	activePods, err := s.podLister.Pods(template.Namespace).List(labels.SelectorFromSet(map[string]string{
 		LabelTemplateID: template.Name,
 		LabelPoolType:   PoolTypeActive,
 	}))
 	if err != nil {
-		return 0, 0, fmt.Errorf("list active pods: %w", err)
+		return stats, fmt.Errorf("list active pods: %w", err)
 	}
-
 	for _, pod := range activePods {
+		if pod.DeletionTimestamp != nil || isTerminalPodPhase(pod.Status.Phase) {
+			continue
+		}
+		if pod.Status.PodIP == "" {
+			stats.activeWithoutIP++
+		}
 		if pod.Status.Phase == corev1.PodRunning {
-			active++
+			stats.runningActive++
+		} else {
+			stats.pendingActive++
 		}
 	}
 
-	return idle, active, nil
+	return stats, nil
 }
 
-// getCurrentReplicas returns the current replica count from the ReplicaSet.
-func (s *AutoScaler) getCurrentReplicas(template *v1alpha1.SandboxTemplate) (int32, error) {
+func isTerminalPodPhase(phase corev1.PodPhase) bool {
+	return phase == corev1.PodSucceeded || phase == corev1.PodFailed
+}
+
+func (s *AutoScaler) getCurrentReplicas(ctx context.Context, template *v1alpha1.SandboxTemplate) (int32, error) {
 	clusterID := naming.ClusterIDOrDefault(template.Spec.ClusterId)
 	rsName, err := naming.ReplicasetName(clusterID, template.Name)
 	if err != nil {
 		return 0, fmt.Errorf("generate replicaset name: %w", err)
 	}
 
-	rs, err := s.replicaSetLister.ReplicaSets(template.Namespace).Get(rsName)
+	rs, err := s.k8sClient.AppsV1().ReplicaSets(template.Namespace).Get(ctx, rsName, metav1.GetOptions{})
 	if err != nil {
 		return 0, err
 	}
-
 	if rs.Spec.Replicas == nil {
 		return 0, nil
 	}
 	return *rs.Spec.Replicas, nil
 }
 
-// executeScaleUp updates the ReplicaSet with the new replica count.
-func (s *AutoScaler) executeScaleUp(
-	ctx context.Context,
-	template *v1alpha1.SandboxTemplate,
-	_ /* oldReplicas */, newReplicas int32,
-) error {
+func (s *AutoScaler) executeScale(ctx context.Context, template *v1alpha1.SandboxTemplate, replicas int32) error {
 	clusterID := naming.ClusterIDOrDefault(template.Spec.ClusterId)
 	rsName, err := naming.ReplicasetName(clusterID, template.Name)
 	if err != nil {
@@ -409,41 +470,27 @@ func (s *AutoScaler) executeScaleUp(
 	}
 
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		rs, err := s.replicaSetLister.ReplicaSets(template.Namespace).Get(rsName)
+		rs, err := s.k8sClient.AppsV1().ReplicaSets(template.Namespace).Get(ctx, rsName, metav1.GetOptions{})
 		if err != nil {
 			if errors.IsNotFound(err) {
-				return nil // PoolManager will create it
+				return nil
 			}
 			return err
 		}
-
-		rs = rs.DeepCopy()
-		rs.Spec.Replicas = ptrToInt32(newReplicas)
-
-		_, err = s.k8sClient.AppsV1().ReplicaSets(rs.Namespace).Update(ctx, rs, metav1.UpdateOptions{})
+		updated := rs.DeepCopy()
+		updated.Spec.Replicas = ptrToInt32(replicas)
+		_, err = s.k8sClient.AppsV1().ReplicaSets(updated.Namespace).Update(ctx, updated, metav1.UpdateOptions{})
 		return err
 	})
 }
 
-// ReconcileScaleDown performs async scale-down for templates with no traffic.
-// This is called from the background reconcile loop, not from the claim path.
+// ReconcileScaleDown returns the idle pool target to minIdle after no traffic.
 func (s *AutoScaler) ReconcileScaleDown(ctx context.Context, template *v1alpha1.SandboxTemplate, now time.Time) error {
 	if template == nil {
 		return nil
 	}
 
-	// Check if we should scale down based on last claim time
-	lastClaimTime := s.getLastClaimTime(template)
-	if lastClaimTime.IsZero() {
-		return nil
-	}
-
-	timeSinceLastClaim := now.Sub(lastClaimTime)
-	if timeSinceLastClaim < s.config.NoTrafficScaleDownAfter {
-		return nil
-	}
-
-	currentReplicas, err := s.getCurrentReplicas(template)
+	currentReplicas, err := s.getCurrentReplicas(ctx, template)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil
@@ -451,36 +498,44 @@ func (s *AutoScaler) ReconcileScaleDown(ctx context.Context, template *v1alpha1.
 		return err
 	}
 
-	minIdle := template.Spec.Pool.MinIdle
+	minIdle, _ := normalizedPoolBounds(template)
 	if currentReplicas <= minIdle {
-		return nil // Already at minimum
+		return nil
 	}
 
-	// Calculate new replica count (reduce by ScaleDownPercent)
-	delta := int32(float64(currentReplicas) * s.config.ScaleDownPercent)
-	if delta < 1 {
-		delta = 1
+	stats, err := s.getPoolStatsDetailed(template)
+	if err != nil {
+		return fmt.Errorf("get pool stats: %w", err)
 	}
-	newReplicas := currentReplicas - delta
-	if newReplicas < minIdle {
-		newReplicas = minIdle
+	templateName := autoscalerMetricTemplate(template)
+	s.observePool(templateName, stats, currentReplicas, minIdle)
+	if stats.activeTotal() > 0 {
+		s.observeDecision(templateName, "scale_down", "active_pods", "skipped")
+		return nil
 	}
 
-	if newReplicas == currentReplicas {
+	lastClaimTime := s.lastClaimTime(template)
+	if observed := s.getLastClaimTime(template); observed.After(lastClaimTime) {
+		lastClaimTime = observed
+	}
+	if !lastClaimTime.IsZero() && now.Sub(lastClaimTime) < s.config.NoTrafficScaleDownAfter {
+		s.observeDecision(templateName, "scale_down", "recent_claim", "skipped")
 		return nil
 	}
 
 	s.logger.Info("Scale down due to no traffic",
 		zap.String("template", template.Name),
 		zap.Int32("oldReplicas", currentReplicas),
-		zap.Int32("newReplicas", newReplicas),
-		zap.Duration("idle", timeSinceLastClaim),
+		zap.Int32("newReplicas", minIdle),
 	)
-
-	return s.executeScaleUp(ctx, template, currentReplicas, newReplicas)
+	if err := s.executeScale(ctx, template, minIdle); err != nil {
+		return err
+	}
+	s.observeDecision(templateName, "scale_down", "no_recent_claims", "scaled")
+	s.observeScaleDelta(templateName, minIdle-currentReplicas)
+	return nil
 }
 
-// getLastClaimTime returns the most recent claim time from active pods.
 func (s *AutoScaler) getLastClaimTime(template *v1alpha1.SandboxTemplate) time.Time {
 	activePods, err := s.podLister.Pods(template.Namespace).List(labels.SelectorFromSet(map[string]string{
 		LabelTemplateID: template.Name,
@@ -507,11 +562,151 @@ func (s *AutoScaler) getLastClaimTime(template *v1alpha1.SandboxTemplate) time.T
 			lastClaim = claimedAt
 		}
 	}
-
 	return lastClaim
 }
 
-// Helper functions
+func normalizeAutoScaleConfig(cfg AutoScaleConfig) AutoScaleConfig {
+	defaultCfg := DefaultAutoScaleConfig()
+	if cfg.MinScaleInterval <= 0 {
+		cfg.MinScaleInterval = defaultCfg.MinScaleInterval
+	}
+	if cfg.ScaleUpFactor <= 0 {
+		cfg.ScaleUpFactor = defaultCfg.ScaleUpFactor
+	}
+	if cfg.MaxScaleStep <= 0 {
+		cfg.MaxScaleStep = defaultCfg.MaxScaleStep
+	}
+	if cfg.MinIdleBuffer <= 0 {
+		cfg.MinIdleBuffer = defaultCfg.MinIdleBuffer
+	}
+	if cfg.TargetIdleRatio <= 0 {
+		cfg.TargetIdleRatio = defaultCfg.TargetIdleRatio
+	}
+	if cfg.NoTrafficScaleDownAfter <= 0 {
+		cfg.NoTrafficScaleDownAfter = defaultCfg.NoTrafficScaleDownAfter
+	}
+	if cfg.ScaleDownPercent <= 0 {
+		cfg.ScaleDownPercent = defaultCfg.ScaleDownPercent
+	}
+	return cfg
+}
+
+func normalizedPoolBounds(template *v1alpha1.SandboxTemplate) (minIdle, maxIdle int32) {
+	if template == nil {
+		return 0, 0
+	}
+	minIdle = template.Spec.Pool.MinIdle
+	maxIdle = template.Spec.Pool.MaxIdle
+	if minIdle < 0 {
+		minIdle = 0
+	}
+	if maxIdle < minIdle {
+		maxIdle = minIdle
+	}
+	return minIdle, maxIdle
+}
+
+func (s *AutoScaler) maxColdClaimInFlight(template *v1alpha1.SandboxTemplate) int32 {
+	if s.config.MaxColdClaimInFlight > 0 {
+		return s.config.MaxColdClaimInFlight
+	}
+	minIdle, maxIdle := normalizedPoolBounds(template)
+	limit := s.config.MaxScaleStep * 3
+	if limit < minIdle+s.config.MinIdleBuffer {
+		limit = minIdle + s.config.MinIdleBuffer
+	}
+	if limit <= 0 {
+		limit = 1
+	}
+	if maxIdle > 0 && limit > maxIdle {
+		limit = maxIdle
+	}
+	return limit
+}
+
+func autoscalerTemplateKey(template *v1alpha1.SandboxTemplate) string {
+	if template == nil {
+		return ""
+	}
+	return template.Namespace + "/" + template.Name
+}
+
+func autoscalerMetricTemplate(template *v1alpha1.SandboxTemplate) string {
+	if template == nil {
+		return ""
+	}
+	return template.Name
+}
+
+func (s *AutoScaler) recordClaim(template *v1alpha1.SandboxTemplate) {
+	if s == nil || template == nil {
+		return
+	}
+	key := autoscalerTemplateKey(template)
+	s.stateMu.Lock()
+	defer s.stateMu.Unlock()
+	state := s.state[key]
+	if state == nil {
+		state = &autoScalerTemplateState{}
+		s.state[key] = state
+	}
+	state.lastClaimAt = time.Now()
+}
+
+func (s *AutoScaler) lastClaimTime(template *v1alpha1.SandboxTemplate) time.Time {
+	if s == nil || template == nil {
+		return time.Time{}
+	}
+	key := autoscalerTemplateKey(template)
+	s.stateMu.Lock()
+	defer s.stateMu.Unlock()
+	if state := s.state[key]; state != nil {
+		return state.lastClaimAt
+	}
+	return time.Time{}
+}
+
+func (s *AutoScaler) observeDecision(template, action, reason, result string) {
+	if s == nil || s.metrics == nil || s.metrics.AutoscalerDecisionsTotal == nil {
+		return
+	}
+	s.metrics.AutoscalerDecisionsTotal.WithLabelValues(template, action, reason, result).Inc()
+}
+
+func (s *AutoScaler) observePool(template string, stats autoScalerPoolStats, currentReplicas, desiredReplicas int32) {
+	if s == nil || s.metrics == nil {
+		return
+	}
+	if s.metrics.AutoscalerPoolReplicas != nil {
+		s.metrics.AutoscalerPoolReplicas.WithLabelValues(template, "current").Set(float64(currentReplicas))
+		s.metrics.AutoscalerPoolReplicas.WithLabelValues(template, "desired").Set(float64(desiredReplicas))
+	}
+	if s.metrics.AutoscalerPoolPods != nil {
+		s.metrics.AutoscalerPoolPods.WithLabelValues(template, "ready_idle").Set(float64(stats.readyIdle))
+		s.metrics.AutoscalerPoolPods.WithLabelValues(template, "pending_idle").Set(float64(stats.pendingIdle))
+		s.metrics.AutoscalerPoolPods.WithLabelValues(template, "active").Set(float64(stats.activeTotal()))
+		s.metrics.AutoscalerPoolPods.WithLabelValues(template, "active_without_ip").Set(float64(stats.activeWithoutIP))
+	}
+}
+
+func (s *AutoScaler) observeColdClaimsInFlight(template string, count int32) {
+	if s == nil || s.metrics == nil || s.metrics.AutoscalerColdClaimsInFlight == nil {
+		return
+	}
+	s.metrics.AutoscalerColdClaimsInFlight.WithLabelValues(template).Set(float64(count))
+}
+
+func (s *AutoScaler) observeScaleDelta(template string, delta int32) {
+	if s == nil || s.metrics == nil || s.metrics.AutoscalerScaleDelta == nil || delta == 0 {
+		return
+	}
+	direction := "up"
+	if delta < 0 {
+		direction = "down"
+		delta = -delta
+	}
+	s.metrics.AutoscalerScaleDelta.WithLabelValues(template, direction).Observe(float64(delta))
+}
 
 func ptrToInt32(v int32) *int32 {
 	return &v

--- a/manager/pkg/controller/autoscaler_test.go
+++ b/manager/pkg/controller/autoscaler_test.go
@@ -6,8 +6,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	apiconfig "github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
+	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -15,421 +19,195 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/fake"
 	appslisters "k8s.io/client-go/listers/apps/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 )
 
-func TestAutoScaler_OnColdClaim(t *testing.T) {
-	tests := []struct {
-		name             string
-		template         *v1alpha1.SandboxTemplate
-		existingPods     []*corev1.Pod
-		existingRS       *appsv1.ReplicaSet
-		expectedShould   bool
-		expectedDelta    int32
-		expectedReplicas int32
-		expectError      bool
-		skipIfNoRS       bool // If true, skip when ReplicaSet doesn't exist
-		testRateLimit    bool // If true, test rate limiting by making two calls
-	}{
-		{
-			name: "scale up on cold claim with no idle pods",
-			template: &v1alpha1.SandboxTemplate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-template",
-					Namespace: "default",
-				},
-				Spec: v1alpha1.SandboxTemplateSpec{
-					Pool: v1alpha1.PoolStrategy{
-						MinIdle: 2,
-						MaxIdle: 20,
-					},
-				},
-			},
-			existingPods: []*corev1.Pod{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "active-1",
-						Namespace: "default",
-						Labels: map[string]string{
-							LabelTemplateID: "test-template",
-							LabelPoolType:   PoolTypeActive,
-						},
-						Annotations: map[string]string{
-							AnnotationClaimedAt: time.Now().Add(-1 * time.Minute).Format(time.RFC3339),
-							AnnotationClaimType: "cold",
-						},
-					},
-					Status: corev1.PodStatus{Phase: corev1.PodRunning},
-				},
-			},
-			existingRS: func() *appsv1.ReplicaSet {
-				rsName, _ := naming.ReplicasetName(naming.DefaultClusterID, "test-template")
-				replicas := int32(2)
-				return &appsv1.ReplicaSet{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      rsName,
-						Namespace: "default",
-					},
-					Spec: appsv1.ReplicaSetSpec{
-						Replicas: &replicas,
-					},
-				}
-			}(),
-			expectedShould:   true,
-			expectedDelta:    1,
-			expectedReplicas: 3,
-		},
-		{
-			name: "no scale when rate limited",
-			template: &v1alpha1.SandboxTemplate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "rate-limited-template",
-					Namespace: "default",
-				},
-				Spec: v1alpha1.SandboxTemplateSpec{
-					Pool: v1alpha1.PoolStrategy{
-						MinIdle: 2,
-						MaxIdle: 20,
-					},
-				},
-			},
-			existingPods: []*corev1.Pod{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "active-1",
-						Namespace: "default",
-						Labels: map[string]string{
-							LabelTemplateID: "rate-limited-template",
-							LabelPoolType:   PoolTypeActive,
-						},
-						Annotations: map[string]string{
-							AnnotationClaimedAt: time.Now().Format(time.RFC3339),
-						},
-					},
-					Status: corev1.PodStatus{Phase: corev1.PodRunning},
-				},
-			},
-			existingRS: func() *appsv1.ReplicaSet {
-				rsName, _ := naming.ReplicasetName(naming.DefaultClusterID, "rate-limited-template")
-				replicas := int32(2)
-				return &appsv1.ReplicaSet{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      rsName,
-						Namespace: "default",
-					},
-					Spec: appsv1.ReplicaSetSpec{
-						Replicas: &replicas,
-					},
-				}
-			}(),
-			expectedShould: false,
-			// This test makes TWO calls to verify rate limiting works
-			// First call will succeed, second call will be rate limited
-			testRateLimit: true,
-		},
-		{
-			name: "respect maxIdle limit",
-			template: &v1alpha1.SandboxTemplate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "max-idle-template",
-					Namespace: "default",
-				},
-				Spec: v1alpha1.SandboxTemplateSpec{
-					Pool: v1alpha1.PoolStrategy{
-						MinIdle: 5,
-						MaxIdle: 5,
-					},
-				},
-			},
-			existingPods: []*corev1.Pod{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "active-1",
-						Namespace: "default",
-						Labels: map[string]string{
-							LabelTemplateID: "max-idle-template",
-							LabelPoolType:   PoolTypeActive,
-						},
-					},
-					Status: corev1.PodStatus{Phase: corev1.PodRunning},
-				},
-			},
-			existingRS: func() *appsv1.ReplicaSet {
-				rsName, _ := naming.ReplicasetName(naming.DefaultClusterID, "max-idle-template")
-				replicas := int32(5)
-				return &appsv1.ReplicaSet{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      rsName,
-						Namespace: "default",
-					},
-					Spec: appsv1.ReplicaSetSpec{
-						Replicas: &replicas,
-					},
-				}
-			}(),
-			expectedShould:   false,
-			expectedReplicas: 5,
-		},
-		{
-			name: "scale based on active count ratio",
-			template: &v1alpha1.SandboxTemplate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "ratio-template",
-					Namespace: "default",
-				},
-				Spec: v1alpha1.SandboxTemplateSpec{
-					Pool: v1alpha1.PoolStrategy{
-						MinIdle: 1,
-						MaxIdle: 50,
-					},
-				},
-			},
-			existingPods: func() []*corev1.Pod {
-				var pods []*corev1.Pod
-				for i := 0; i < 20; i++ {
-					pods = append(pods, &corev1.Pod{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "active-" + string(rune('0'+i)),
-							Namespace: "default",
-							Labels: map[string]string{
-								LabelTemplateID: "ratio-template",
-								LabelPoolType:   PoolTypeActive,
-							},
-							Annotations: map[string]string{
-								AnnotationClaimedAt: time.Now().Add(-1 * time.Minute).Format(time.RFC3339),
-							},
-						},
-						Status: corev1.PodStatus{Phase: corev1.PodRunning},
-					})
-				}
-				return pods
-			}(),
-			existingRS: func() *appsv1.ReplicaSet {
-				rsName, _ := naming.ReplicasetName(naming.DefaultClusterID, "ratio-template")
-				replicas := int32(2)
-				return &appsv1.ReplicaSet{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      rsName,
-						Namespace: "default",
-					},
-					Spec: appsv1.ReplicaSetSpec{
-						Replicas: &replicas,
-					},
-				}
-			}(),
-			expectedShould:   true,
-			expectedReplicas: 4,
-		},
-		{
-			name: "no replicaset exists",
-			template: &v1alpha1.SandboxTemplate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "no-rs-template",
-					Namespace: "default",
-				},
-				Spec: v1alpha1.SandboxTemplateSpec{
-					Pool: v1alpha1.PoolStrategy{
-						MinIdle: 2,
-						MaxIdle: 20,
-					},
-				},
-			},
-			existingPods:   nil,
-			existingRS:     nil, // No ReplicaSet
-			expectedShould: false,
-			skipIfNoRS:     true,
-		},
-	}
+func TestAutoScalerColdClaimRefillsIdleDeficitByStep(t *testing.T) {
+	template := autoscalerTestTemplate("template-a", 15, 50)
+	scaler, client := newAutoScalerTestHarness(t, template, 15, nil, AutoScaleConfig{
+		MinScaleInterval:        time.Millisecond,
+		ScaleUpFactor:           1.5,
+		MaxScaleStep:            10,
+		MinIdleBuffer:           2,
+		TargetIdleRatio:         0.2,
+		NoTrafficScaleDownAfter: time.Minute,
+		ScaleDownPercent:        0.1,
+	})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Setup fake client and informers
-			var objects []runtime.Object
-			for _, pod := range tt.existingPods {
-				objects = append(objects, pod)
-			}
-			if tt.existingRS != nil {
-				objects = append(objects, tt.existingRS)
-			}
-			k8sClient := fake.NewSimpleClientset(objects...)
+	decision, err := scaler.OnColdClaim(context.Background(), template)
+	require.NoError(t, err)
+	require.True(t, decision.ShouldScale)
+	assert.Equal(t, int32(15), decision.OldReplicas)
+	assert.Equal(t, int32(25), decision.NewReplicas)
+	assert.Equal(t, int32(10), decision.Delta)
 
-			// Create indexer and lister for pods
-			podIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
-			for _, pod := range tt.existingPods {
-				require.NoError(t, podIndexer.Add(pod))
-			}
-			podLister := corelisters.NewPodLister(podIndexer)
-
-			// Create indexer and lister for replicasets
-			rsIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
-			if tt.existingRS != nil {
-				require.NoError(t, rsIndexer.Add(tt.existingRS))
-			}
-			rsLister := appslisters.NewReplicaSetLister(rsIndexer)
-
-			// Create sync scaler with fast rate limit for testing
-			config := DefaultAutoScaleConfig()
-			config.MinScaleInterval = 10 * time.Millisecond
-			config.ScaleUpFactor = 1.5
-			config.MaxScaleStep = 10
-
-			scaler := NewAutoScalerWithConfig(
-				k8sClient,
-				podLister,
-				rsLister,
-				zap.NewNop(),
-				config,
-			)
-
-			ctx := context.Background()
-
-			if tt.testRateLimit {
-				// First call should succeed
-				decision1, err := scaler.OnColdClaim(ctx, tt.template)
-				require.NoError(t, err)
-				assert.True(t, decision1.ShouldScale, "First call should trigger scale")
-
-				// Second immediate call should be rate limited
-				decision2, err := scaler.OnColdClaim(ctx, tt.template)
-				require.NoError(t, err)
-				assert.False(t, decision2.ShouldScale, "Second call should be rate limited")
-				return
-			}
-
-			// First call
-			decision, err := scaler.OnColdClaim(ctx, tt.template)
-
-			if tt.expectError {
-				require.Error(t, err)
-				return
-			}
-
-			require.NoError(t, err)
-			assert.Equal(t, tt.expectedShould, decision.ShouldScale, "ShouldScale mismatch")
-
-			if tt.expectedShould {
-				assert.GreaterOrEqual(t, decision.Delta, tt.expectedDelta, "Delta should be at least expected")
-			}
-		})
-	}
+	rs := getAutoscalerTestReplicaSet(t, client, template)
+	assert.Equal(t, int32(25), *rs.Spec.Replicas)
 }
 
-func TestAutoScaler_CalculateDesiredReplicas(t *testing.T) {
-	scaler := &AutoScaler{
-		config: AutoScaleConfig{
-			ScaleUpFactor:   1.5,
-			MaxScaleStep:    10,
-			MinIdleBuffer:   2,
-			TargetIdleRatio: 0.2,
-		},
+func TestAutoScalerColdClaimUsesLiveReplicaSetTarget(t *testing.T) {
+	template := autoscalerTestTemplate("template-a", 15, 50)
+	scaler, client := newAutoScalerTestHarness(t, template, 15, nil, AutoScaleConfig{
+		MinScaleInterval:        time.Millisecond,
+		ScaleUpFactor:           1.5,
+		MaxScaleStep:            10,
+		MinIdleBuffer:           2,
+		TargetIdleRatio:         0.2,
+		NoTrafficScaleDownAfter: time.Minute,
+		ScaleDownPercent:        0.1,
+	})
+	rs := getAutoscalerTestReplicaSet(t, client, template)
+	liveReplicas := int32(25)
+	rs.Spec.Replicas = &liveReplicas
+	_, err := client.AppsV1().ReplicaSets(template.Namespace).Update(context.Background(), rs, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	decision, err := scaler.OnColdClaim(context.Background(), template)
+	require.NoError(t, err)
+	require.True(t, decision.ShouldScale)
+	assert.Equal(t, int32(25), decision.OldReplicas)
+	assert.Equal(t, int32(35), decision.NewReplicas)
+
+	rs = getAutoscalerTestReplicaSet(t, client, template)
+	assert.Equal(t, int32(35), *rs.Spec.Replicas)
+}
+
+func TestAutoScalerHotClaimSkipsWhenPendingIdleCoversTarget(t *testing.T) {
+	template := autoscalerTestTemplate("template-a", 15, 50)
+	var pods []*corev1.Pod
+	for i := 0; i < 17; i++ {
+		pods = append(pods, autoscalerIdlePod(template, "idle-pending-"+string(rune('a'+i)), false))
 	}
+	scaler, _ := newAutoScalerTestHarness(t, template, 17, pods, AutoScaleConfig{
+		MinScaleInterval:        time.Millisecond,
+		ScaleUpFactor:           1.5,
+		MaxScaleStep:            10,
+		MinIdleBuffer:           2,
+		TargetIdleRatio:         0.2,
+		NoTrafficScaleDownAfter: time.Minute,
+		ScaleDownPercent:        0.1,
+	})
 
-	tests := []struct {
-		name            string
-		minIdle         int32
-		maxIdle         int32
-		currentReplicas int32
-		idleCount       int32
-		activeCount     int32
-		expectedMin     int32
-		expectedMax     int32
-	}{
-		{
-			name:            "scale up from zero",
-			minIdle:         2,
-			maxIdle:         20,
-			currentReplicas: 0,
-			idleCount:       0,
-			activeCount:     1,
-			expectedMin:     2,
-			expectedMax:     20,
-		},
-		{
-			name:            "scale based on active count",
-			minIdle:         1,
-			maxIdle:         50,
-			currentReplicas: 2,
-			idleCount:       0,
-			activeCount:     20,
-			expectedMin:     4,
-			expectedMax:     12,
-		},
-		{
-			name:            "respect maxIdle",
-			minIdle:         5,
-			maxIdle:         5,
-			currentReplicas: 5,
-			idleCount:       0,
-			activeCount:     100,
-			expectedMin:     5,
-			expectedMax:     5,
-		},
-		{
-			name:            "scale with buffer",
-			minIdle:         2,
-			maxIdle:         20,
-			currentReplicas: 2,
-			idleCount:       0,
-			activeCount:     0,
-			expectedMin:     4,
-			expectedMax:     20,
-		},
+	decision, err := scaler.OnHotClaim(context.Background(), template)
+	require.NoError(t, err)
+	require.False(t, decision.ShouldScale)
+	assert.Contains(t, decision.Reason, "no scale needed")
+}
+
+func TestAutoScalerAdmitColdClaimRejectsNetworkBacklogAndRecordsMetric(t *testing.T) {
+	template := autoscalerTestTemplate("template-a", 1, 10)
+	pods := []*corev1.Pod{
+		autoscalerActivePod(template, "active-no-ip", corev1.PodPending, ""),
 	}
+	scaler, _ := newAutoScalerTestHarness(t, template, 1, pods, AutoScaleConfig{
+		MinScaleInterval:        time.Millisecond,
+		ScaleUpFactor:           1.5,
+		MaxScaleStep:            10,
+		MinIdleBuffer:           2,
+		TargetIdleRatio:         0.2,
+		NoTrafficScaleDownAfter: time.Minute,
+		ScaleDownPercent:        0.1,
+		MaxColdClaimInFlight:    1,
+	})
+	registry := prometheus.NewRegistry()
+	metrics := obsmetrics.NewManager(registry)
+	scaler.SetMetrics(metrics)
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			template := &v1alpha1.SandboxTemplate{
-				Spec: v1alpha1.SandboxTemplateSpec{
-					Pool: v1alpha1.PoolStrategy{
-						MinIdle: tt.minIdle,
-						MaxIdle: tt.maxIdle,
-					},
-				},
-			}
+	admission, err := scaler.AdmitColdClaim(context.Background(), template)
+	require.NoError(t, err)
+	require.False(t, admission.Admitted)
+	assert.Equal(t, "pod network identity backlog", admission.Reason)
+	assert.Equal(t, int32(1), admission.NetworkBacklog)
+	assert.Equal(t, float64(1), testutil.ToFloat64(metrics.AutoscalerDecisionsTotal.WithLabelValues(
+		"template-a", "admit_cold_claim", "pod_network_identity_backlog", "rejected",
+	)))
+}
 
-			result := scaler.calculateDesiredReplicas(template, tt.currentReplicas, tt.idleCount, tt.activeCount)
+func TestAutoScalerReconcileScaleDownReturnsToMinIdle(t *testing.T) {
+	template := autoscalerTestTemplate("template-a", 15, 50)
+	scaler, client := newAutoScalerTestHarness(t, template, 30, nil, AutoScaleConfig{
+		MinScaleInterval:        time.Millisecond,
+		ScaleUpFactor:           1.5,
+		MaxScaleStep:            10,
+		MinIdleBuffer:           2,
+		TargetIdleRatio:         0.2,
+		NoTrafficScaleDownAfter: time.Minute,
+		ScaleDownPercent:        0.1,
+	})
 
-			assert.GreaterOrEqual(t, result, tt.expectedMin, "Result should be >= expectedMin")
-			assert.LessOrEqual(t, result, tt.expectedMax, "Result should be <= expectedMax")
-		})
+	err := scaler.ReconcileScaleDown(context.Background(), template, time.Now().Add(2*time.Minute))
+	require.NoError(t, err)
+
+	rs := getAutoscalerTestReplicaSet(t, client, template)
+	assert.Equal(t, int32(15), *rs.Spec.Replicas)
+}
+
+func TestAutoScalerPoolStatsCountsBacklog(t *testing.T) {
+	template := autoscalerTestTemplate("template-a", 1, 10)
+	pods := []*corev1.Pod{
+		autoscalerIdlePod(template, "idle-ready", true),
+		autoscalerIdlePod(template, "idle-pending", false),
+		autoscalerActivePod(template, "active-running", corev1.PodRunning, "10.0.0.10"),
+		autoscalerActivePod(template, "active-no-ip", corev1.PodPending, ""),
 	}
+	scaler, _ := newAutoScalerTestHarness(t, template, 1, pods, DefaultAutoScaleConfig())
+
+	stats, err := scaler.getPoolStatsDetailed(template)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), stats.readyIdle)
+	assert.Equal(t, int32(1), stats.pendingIdle)
+	assert.Equal(t, int32(1), stats.runningActive)
+	assert.Equal(t, int32(1), stats.pendingActive)
+	assert.Equal(t, int32(1), stats.activeWithoutIP)
+}
+
+func TestToAutoScaleConfigAppliesRuntimeDefaults(t *testing.T) {
+	cfg := toAutoScaleConfig(apiconfig.AutoscalerConfig{})
+	defaults := DefaultAutoScaleConfig()
+	assert.Equal(t, defaults.MinScaleInterval, cfg.MinScaleInterval)
+	assert.Equal(t, defaults.MaxScaleStep, cfg.MaxScaleStep)
+	assert.Equal(t, defaults.MinIdleBuffer, cfg.MinIdleBuffer)
+	assert.Equal(t, defaults.NoTrafficScaleDownAfter, cfg.NoTrafficScaleDownAfter)
+}
+
+func TestNewAutoScalerWithConfigAppliesZeroDefaults(t *testing.T) {
+	scaler := NewAutoScalerWithConfig(
+		fake.NewSimpleClientset(),
+		corelisters.NewPodLister(cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})),
+		appslisters.NewReplicaSetLister(cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})),
+		zap.NewNop(),
+		AutoScaleConfig{},
+	)
+
+	defaults := DefaultAutoScaleConfig()
+	assert.Equal(t, defaults.MinScaleInterval, scaler.config.MinScaleInterval)
+	assert.Equal(t, defaults.MaxScaleStep, scaler.config.MaxScaleStep)
+	assert.Equal(t, defaults.MinIdleBuffer, scaler.config.MinIdleBuffer)
+	assert.Equal(t, defaults.NoTrafficScaleDownAfter, scaler.config.NoTrafficScaleDownAfter)
 }
 
 func TestScaleRateLimiter(t *testing.T) {
 	limiter := newScaleRateLimiter(100 * time.Millisecond)
-
 	key := "test-template"
 
-	// First call should succeed (acquire the lock)
-	assert.True(t, limiter.TryAcquire(key), "First TryAcquire should succeed")
-
-	// Immediate second call should be blocked (in progress)
-	assert.False(t, limiter.TryAcquire(key), "Second TryAcquire while in progress should be blocked")
-
-	// Complete the first operation
+	assert.True(t, limiter.TryAcquire(key))
+	assert.False(t, limiter.TryAcquire(key))
 	limiter.Complete(key)
-
-	// Immediate third call should still be blocked (interval not passed)
-	assert.False(t, limiter.TryAcquire(key), "TryAcquire immediately after complete should be blocked by interval")
-
-	// Wait for interval
+	assert.False(t, limiter.TryAcquire(key))
 	time.Sleep(110 * time.Millisecond)
-
-	// After interval, should be allowed again
-	assert.True(t, limiter.TryAcquire(key), "TryAcquire after interval should succeed")
+	assert.True(t, limiter.TryAcquire(key))
 }
 
-func TestScaleRateLimiter_Concurrency(t *testing.T) {
-	limiter := newScaleRateLimiter(10 * time.Millisecond) // Short interval for testing
-
+func TestScaleRateLimiterConcurrency(t *testing.T) {
+	limiter := newScaleRateLimiter(10 * time.Millisecond)
 	key := "concurrent-template"
 	var successCount int32
 	var wg sync.WaitGroup
 
-	// Launch 100 concurrent goroutines trying to acquire the rate limiter
 	for i := 0; i < 100; i++ {
 		wg.Add(1)
 		go func() {
@@ -441,169 +219,135 @@ func TestScaleRateLimiter_Concurrency(t *testing.T) {
 	}
 
 	wg.Wait()
-
-	// Only ONE goroutine should have succeeded
-	assert.Equal(t, int32(1), successCount, "Only one goroutine should acquire the rate limiter")
-
-	// Complete the operation
-	limiter.Complete(key)
-
-	// Wait for interval to pass
-	time.Sleep(20 * time.Millisecond)
-
-	// Now another should succeed
-	assert.True(t, limiter.TryAcquire(key), "TryAcquire after complete+interval should succeed")
+	assert.Equal(t, int32(1), successCount)
 }
 
-func TestAutoScaler_GetPoolStats(t *testing.T) {
-	template := &v1alpha1.SandboxTemplate{
+func autoscalerTestTemplate(name string, minIdle, maxIdle int32) *v1alpha1.SandboxTemplate {
+	return &v1alpha1.SandboxTemplate{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "stats-template",
+			Name:      name,
 			Namespace: "default",
 		},
-	}
-
-	pods := []*corev1.Pod{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "idle-running",
-				Namespace: "default",
-				Labels: map[string]string{
-					LabelTemplateID: "stats-template",
-					LabelPoolType:   PoolTypeIdle,
-				},
+		Spec: v1alpha1.SandboxTemplateSpec{
+			Pool: v1alpha1.PoolStrategy{
+				MinIdle: minIdle,
+				MaxIdle: maxIdle,
 			},
-			Status: corev1.PodStatus{
-				Phase: corev1.PodRunning,
-				Conditions: []corev1.PodCondition{
-					{Type: corev1.PodReady, Status: corev1.ConditionTrue},
-				},
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "idle-not-ready",
-				Namespace: "default",
-				Labels: map[string]string{
-					LabelTemplateID: "stats-template",
-					LabelPoolType:   PoolTypeIdle,
-				},
-			},
-			Status: corev1.PodStatus{
-				Phase: corev1.PodRunning,
-				Conditions: []corev1.PodCondition{
-					{Type: corev1.PodReady, Status: corev1.ConditionFalse},
-				},
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "idle-failed",
-				Namespace: "default",
-				Labels: map[string]string{
-					LabelTemplateID: "stats-template",
-					LabelPoolType:   PoolTypeIdle,
-				},
-			},
-			Status: corev1.PodStatus{Phase: corev1.PodFailed},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "active-running",
-				Namespace: "default",
-				Labels: map[string]string{
-					LabelTemplateID: "stats-template",
-					LabelPoolType:   PoolTypeActive,
-				},
-			},
-			Status: corev1.PodStatus{Phase: corev1.PodRunning},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "active-pending",
-				Namespace: "default",
-				Labels: map[string]string{
-					LabelTemplateID: "stats-template",
-					LabelPoolType:   PoolTypeActive,
-				},
-			},
-			Status: corev1.PodStatus{Phase: corev1.PodPending},
 		},
 	}
+}
 
-	// Create indexer and lister
-	podIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
-	for _, pod := range pods {
-		require.NoError(t, podIndexer.Add(pod))
-	}
-	podLister := corelisters.NewPodLister(podIndexer)
+func newAutoScalerTestHarness(
+	t *testing.T,
+	template *v1alpha1.SandboxTemplate,
+	replicas int32,
+	pods []*corev1.Pod,
+	config AutoScaleConfig,
+) (*AutoScaler, *fake.Clientset) {
+	t.Helper()
 
-	scaler := &AutoScaler{
-		podLister: podLister,
-		logger:    zap.NewNop(),
-		config:    DefaultAutoScaleConfig(),
-	}
-
-	idle, active, err := scaler.getPoolStats(template)
-
+	rsName, err := replicasetNameForTest(template)
 	require.NoError(t, err)
-	assert.Equal(t, int32(1), idle, "Idle count mismatch")
-	assert.Equal(t, int32(1), active, "Active count mismatch")
-}
-
-func TestAutoScaler_GetLastClaimTime(t *testing.T) {
-	template := &v1alpha1.SandboxTemplate{
+	rs := &appsv1.ReplicaSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "claim-time-template",
-			Namespace: "default",
+			Name:      rsName,
+			Namespace: template.Namespace,
+		},
+		Spec: appsv1.ReplicaSetSpec{
+			Replicas: &replicas,
 		},
 	}
-
-	now := time.Now()
-	pods := []*corev1.Pod{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "active-1",
-				Namespace: "default",
-				Labels: map[string]string{
-					LabelTemplateID: "claim-time-template",
-					LabelPoolType:   PoolTypeActive,
-				},
-				Annotations: map[string]string{
-					AnnotationClaimedAt: now.Add(-5 * time.Minute).Format(time.RFC3339),
-				},
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "active-2",
-				Namespace: "default",
-				Labels: map[string]string{
-					LabelTemplateID: "claim-time-template",
-					LabelPoolType:   PoolTypeActive,
-				},
-				Annotations: map[string]string{
-					AnnotationClaimedAt: now.Add(-1 * time.Minute).Format(time.RFC3339),
-				},
-			},
-		},
+	objects := []runtime.Object{rs}
+	for _, pod := range pods {
+		objects = append(objects, pod)
 	}
+	client := fake.NewSimpleClientset(objects...)
 
 	podIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
 	for _, pod := range pods {
 		require.NoError(t, podIndexer.Add(pod))
 	}
-	podLister := corelisters.NewPodLister(podIndexer)
+	rsIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	require.NoError(t, rsIndexer.Add(rs))
 
-	scaler := &AutoScaler{
-		podLister: podLister,
-		logger:    zap.NewNop(),
-		config:    DefaultAutoScaleConfig(),
+	return NewAutoScalerWithConfig(
+		client,
+		corelisters.NewPodLister(podIndexer),
+		appslisters.NewReplicaSetLister(rsIndexer),
+		zap.NewNop(),
+		config,
+	), client
+}
+
+func autoscalerIdlePod(template *v1alpha1.SandboxTemplate, name string, ready bool) *corev1.Pod {
+	status := corev1.ConditionFalse
+	if ready {
+		status = corev1.ConditionTrue
 	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: template.Namespace,
+			Labels: map[string]string{
+				LabelTemplateID: template.Name,
+				LabelPoolType:   PoolTypeIdle,
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "main",
+				Image: "busybox",
+				Ports: []corev1.ContainerPort{{
+					Name:          "http",
+					ContainerPort: 8080,
+					Protocol:      corev1.ProtocolTCP,
+				}},
+				ReadinessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path: "/healthz",
+							Port: intstr.FromInt(8080),
+						},
+					},
+				},
+			}},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{{
+				Type:   corev1.PodReady,
+				Status: status,
+			}},
+		},
+	}
+}
 
-	lastClaim := scaler.getLastClaimTime(template)
+func autoscalerActivePod(template *v1alpha1.SandboxTemplate, name string, phase corev1.PodPhase, podIP string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: template.Namespace,
+			Labels: map[string]string{
+				LabelTemplateID: template.Name,
+				LabelPoolType:   PoolTypeActive,
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: phase,
+			PodIP: podIP,
+		},
+	}
+}
 
-	expectedTime := now.Add(-1 * time.Minute)
-	diff := lastClaim.Sub(expectedTime)
-	assert.Less(t, diff.Abs(), time.Second, "Last claim time should be within 1 second of expected")
+func getAutoscalerTestReplicaSet(t *testing.T, client *fake.Clientset, template *v1alpha1.SandboxTemplate) *appsv1.ReplicaSet {
+	t.Helper()
+	name, err := replicasetNameForTest(template)
+	require.NoError(t, err)
+	rs, err := client.AppsV1().ReplicaSets(template.Namespace).Get(context.Background(), name, metav1.GetOptions{})
+	require.NoError(t, err)
+	return rs
+}
+
+func replicasetNameForTest(template *v1alpha1.SandboxTemplate) (string, error) {
+	return naming.ReplicasetName(naming.DefaultClusterID, template.Name)
 }

--- a/manager/pkg/controller/operator.go
+++ b/manager/pkg/controller/operator.go
@@ -122,6 +122,7 @@ func NewOperator(
 	secretLister := corelisters.NewSecretLister(secretInformer.GetIndexer())
 	poolManager := NewPoolManager(k8sClient, podLister, replicaSetLister, secretLister, recorder, logger)
 	autoScaler := NewAutoScalerWithConfig(k8sClient, podLister, replicaSetLister, logger, toAutoScaleConfig(autoscalerConfig))
+	autoScaler.SetMetrics(metrics)
 
 	op := &Operator{
 		k8sClient:        k8sClient,
@@ -594,13 +595,29 @@ func (op *Operator) SetTemplateStatsPublisher(publisher TemplateStatsPublisher) 
 // toAutoScaleConfig converts config.AutoscalerConfig to AutoScaleConfig.
 func toAutoScaleConfig(cfg config.AutoscalerConfig) AutoScaleConfig {
 	defaultCfg := DefaultAutoScaleConfig()
+	minScaleInterval := cfg.MinScaleInterval.Duration
+	if minScaleInterval <= 0 {
+		minScaleInterval = defaultCfg.MinScaleInterval
+	}
+	maxScaleStep := cfg.MaxScaleStep
+	if maxScaleStep <= 0 {
+		maxScaleStep = defaultCfg.MaxScaleStep
+	}
+	minIdleBuffer := cfg.MinIdleBuffer
+	if minIdleBuffer <= 0 {
+		minIdleBuffer = defaultCfg.MinIdleBuffer
+	}
+	noTrafficScaleDownAfter := cfg.NoTrafficScaleDownAfter.Duration
+	if noTrafficScaleDownAfter <= 0 {
+		noTrafficScaleDownAfter = defaultCfg.NoTrafficScaleDownAfter
+	}
 	return AutoScaleConfig{
-		MinScaleInterval:        cfg.MinScaleInterval.Duration,
+		MinScaleInterval:        minScaleInterval,
 		ScaleUpFactor:           cfg.ParsedScaleUpFactor(defaultCfg.ScaleUpFactor),
-		MaxScaleStep:            cfg.MaxScaleStep,
-		MinIdleBuffer:           cfg.MinIdleBuffer,
+		MaxScaleStep:            maxScaleStep,
+		MinIdleBuffer:           minIdleBuffer,
 		TargetIdleRatio:         cfg.ParsedTargetIdleRatio(defaultCfg.TargetIdleRatio),
-		NoTrafficScaleDownAfter: cfg.NoTrafficScaleDownAfter.Duration,
+		NoTrafficScaleDownAfter: noTrafficScaleDownAfter,
 		ScaleDownPercent:        cfg.ParsedScaleDownPercent(defaultCfg.ScaleDownPercent),
 	}
 }

--- a/manager/pkg/controller/pool_manager.go
+++ b/manager/pkg/controller/pool_manager.go
@@ -159,15 +159,18 @@ func (pm *PoolManager) ReconcilePool(ctx context.Context, template *v1alpha1.San
 		return fmt.Errorf("repair unhealthy idle pods: %w", err)
 	}
 
-	// 5. Check if replicas match minIdle
-	if rs.Spec.Replicas == nil || *rs.Spec.Replicas != template.Spec.Pool.MinIdle {
+	// 5. Keep replicas inside the template pool bounds without fighting the
+	// autoscaler's current target.
+	currentReplicas := getInt32Value(rs.Spec.Replicas)
+	desiredReplicas := desiredPoolReplicas(template, currentReplicas)
+	if rs.Spec.Replicas == nil || currentReplicas != desiredReplicas {
 		pm.logger.Info("Updating ReplicaSet replicas",
 			zap.String("template", template.Name),
-			zap.Int32("current", getInt32Value(rs.Spec.Replicas)),
-			zap.Int32("desired", template.Spec.Pool.MinIdle),
+			zap.Int32("current", currentReplicas),
+			zap.Int32("desired", desiredReplicas),
 		)
 
-		rs.Spec.Replicas = &template.Spec.Pool.MinIdle
+		rs.Spec.Replicas = &desiredReplicas
 		_, err = pm.k8sClient.AppsV1().ReplicaSets(template.Namespace).Update(ctx, rs, metav1.UpdateOptions{})
 		if err != nil {
 			pm.recorder.Eventf(template, corev1.EventTypeWarning, "ReplicaSetUpdateFailed",
@@ -176,10 +179,21 @@ func (pm *PoolManager) ReconcilePool(ctx context.Context, template *v1alpha1.San
 		}
 
 		pm.recorder.Eventf(template, corev1.EventTypeNormal, "ReplicaSetUpdated",
-			"Updated ReplicaSet replicas to %d", template.Spec.Pool.MinIdle)
+			"Updated ReplicaSet replicas to %d", desiredReplicas)
 	}
 
 	return nil
+}
+
+func desiredPoolReplicas(template *v1alpha1.SandboxTemplate, current int32) int32 {
+	minIdle, maxIdle := normalizedPoolBounds(template)
+	if current < minIdle {
+		return minIdle
+	}
+	if current > maxIdle {
+		return maxIdle
+	}
+	return current
 }
 
 // getOrCreateReplicaSet gets or creates the ReplicaSet for a template

--- a/manager/pkg/controller/pool_manager_test.go
+++ b/manager/pkg/controller/pool_manager_test.go
@@ -95,6 +95,21 @@ func TestBuildPodTemplatePreMountsUserVolumePortalsForIdlePool(t *testing.T) {
 	assert.NotNil(t, findCSIVolumeByPortal(got.Spec.Volumes, volumeportal.WebhookStatePortalName))
 }
 
+func TestDesiredPoolReplicasPreservesAutoscalerTargetWithinBounds(t *testing.T) {
+	template := &v1alpha1.SandboxTemplate{
+		Spec: v1alpha1.SandboxTemplateSpec{
+			Pool: v1alpha1.PoolStrategy{
+				MinIdle: 15,
+				MaxIdle: 50,
+			},
+		},
+	}
+
+	assert.Equal(t, int32(15), desiredPoolReplicas(template, 3))
+	assert.Equal(t, int32(25), desiredPoolReplicas(template, 25))
+	assert.Equal(t, int32(50), desiredPoolReplicas(template, 80))
+}
+
 func findCSIVolumeByPortal(volumes []corev1.Volume, portalName string) *corev1.Volume {
 	for i := range volumes {
 		if volumes[i].CSI == nil {

--- a/manager/pkg/controller/ratelimit.go
+++ b/manager/pkg/controller/ratelimit.go
@@ -60,3 +60,44 @@ func (r *scaleRateLimiter) Complete(key string) {
 	delete(r.inProgress, key)
 	r.lastCompleteAt[key] = time.Now()
 }
+
+type coldClaimLimiter struct {
+	mu       sync.Mutex
+	inFlight map[string]int32
+}
+
+func newColdClaimLimiter() *coldClaimLimiter {
+	return &coldClaimLimiter{
+		inFlight: make(map[string]int32),
+	}
+}
+
+func (l *coldClaimLimiter) TryAcquire(key string, limit int32) (int32, bool) {
+	if limit <= 0 {
+		limit = 1
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	current := l.inFlight[key]
+	if current >= limit {
+		return current, false
+	}
+	current++
+	l.inFlight[key] = current
+	return current, true
+}
+
+func (l *coldClaimLimiter) Release(key string) int32 {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	current := l.inFlight[key]
+	if current <= 1 {
+		delete(l.inFlight, key)
+		return 0
+	}
+	current--
+	l.inFlight[key] = current
+	return current
+}

--- a/manager/pkg/http/handlers_sandbox.go
+++ b/manager/pkg/http/handlers_sandbox.go
@@ -56,7 +56,7 @@ func (s *Server) claimSandbox(c *gin.Context) {
 			spec.JSONError(c, http.StatusConflict, spec.CodeConflict, err.Error())
 			return
 		}
-		if errors.Is(err, service.ErrDataPlaneNotReady) {
+		if errors.Is(err, service.ErrDataPlaneNotReady) || errors.Is(err, service.ErrColdClaimCapacityUnavailable) {
 			c.Header("Retry-After", "1")
 			spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, err.Error())
 			return

--- a/manager/pkg/service/sandbox_service.go
+++ b/manager/pkg/service/sandbox_service.go
@@ -55,6 +55,7 @@ var errNoIdlePod = errors.New("no idle pod available")
 var ErrInvalidClaimRequest = errors.New("invalid claim request")
 var ErrClaimConflict = errors.New("claim conflict")
 var ErrDataPlaneNotReady = errors.New("data plane not ready")
+var ErrColdClaimCapacityUnavailable = errors.New("cold claim capacity unavailable")
 var ErrQuotaExceeded = errors.New("quota exceeded")
 var ErrInvalidNetworkPolicy = errors.New("invalid network policy")
 var ErrSandboxCheckpointRequiresCtld = errors.New("sandbox checkpoint pause requires ctld")
@@ -145,6 +146,17 @@ type AutoScalerInterface interface {
 // ScaleDecisionResult represents the result of a scaling decision.
 // This is a local copy to avoid tight coupling with controller package.
 type ScaleDecisionResult = controller.ScaleDecision
+
+type HotClaimAutoScalerInterface interface {
+	OnHotClaim(ctx context.Context, template *v1alpha1.SandboxTemplate) (*ScaleDecisionResult, error)
+}
+
+type ColdClaimAdmissionAutoScalerInterface interface {
+	AdmitColdClaim(ctx context.Context, template *v1alpha1.SandboxTemplate) (*ColdClaimAdmissionResult, error)
+	CompleteColdClaim(template *v1alpha1.SandboxTemplate)
+}
+
+type ColdClaimAdmissionResult = controller.ColdClaimAdmission
 
 // TimeProvider provides time functions, allowing for synchronized time across clusters
 type TimeProvider interface {

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -447,6 +447,9 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 		return nil, fmt.Errorf("claim idle pod: %w", err)
 	}
 	claimType := "hot"
+	if pod != nil {
+		s.triggerHotClaimScale(template, req.Template)
+	}
 
 	// If no idle pod available, create a new one (cold start)
 	if pod == nil {
@@ -455,49 +458,44 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 			zap.String("template", req.Template),
 		)
 
-		// Trigger async scale-up to replenish the idle pool
-		// This runs in a goroutine to not block the cold claim response
-		if s.autoScaler != nil {
-			go func() {
-				scaleCtx := context.Background()
-				scaleDecision, scaleErr := s.autoScaler.OnColdClaim(scaleCtx, template)
-				if scaleErr != nil {
-					s.logger.Warn("Auto scale failed during cold claim",
-						zap.String("template", req.Template),
-						zap.Error(scaleErr),
-					)
-				} else if scaleDecision != nil && scaleDecision.ShouldScale {
-					s.logger.Info("Auto scale triggered",
-						zap.String("template", req.Template),
-						zap.Int32("delta", scaleDecision.Delta),
-						zap.String("reason", scaleDecision.Reason),
-					)
-				}
-			}()
+		phaseStarted = time.Now()
+		coldClaimAdmitter, coldClaimAdmitted, err := s.admitColdClaim(ctx, template, req.Template)
+		s.observeClaimPhase(req.Template, claimType, "admit_cold_claim", phaseStarted, err)
+		if err != nil {
+			if metrics != nil {
+				metrics.SandboxClaimsTotal.WithLabelValues(req.Template, "error").Inc()
+			}
+			return nil, err
+		}
+		completeColdAdmission := func() {
+			if coldClaimAdmitted && coldClaimAdmitter != nil {
+				coldClaimAdmitter.CompleteColdClaim(template)
+				coldClaimAdmitted = false
+			}
 		}
 
 		phaseStarted = time.Now()
 		pod, err = s.createNewPod(ctx, template, req)
 		s.observeClaimPhase(req.Template, claimType, "create_new_pod", phaseStarted, err)
 		if err != nil {
+			completeColdAdmission()
 			if metrics != nil {
 				metrics.SandboxClaimsTotal.WithLabelValues(req.Template, "error").Inc()
 			}
 			return nil, fmt.Errorf("create new pod: %w", err)
 		}
-	}
 
-	// Note: Network policies are stored in pod annotations.
-	// They are set in claimIdlePod() and createNewPod() methods. Hot claims have
-	// already selected a Kubernetes-ready idle pod. Cold claims must wait until
-	// the pod has the network identity netd watches before waiting for netd to
-	// patch the applied policy hash.
-	if claimType == "cold" {
+		// Note: Network policies are stored in pod annotations.
+		// They are set in claimIdlePod() and createNewPod() methods. Hot claims have
+		// already selected a Kubernetes-ready idle pod. Cold claims must wait until
+		// the pod has the network identity netd watches before waiting for netd to
+		// patch the applied policy hash.
 		if s.networkProvider != nil {
 			phaseStarted = time.Now()
 			networkPod, err := s.waitForPodNetworkIdentity(ctx, pod.Namespace, pod.Name)
 			s.observeClaimPhase(req.Template, claimType, "wait_for_pod_network_identity", phaseStarted, err)
 			if err != nil {
+				completeColdAdmission()
 				s.requestSandboxDeletionAfterClaimFailure(pod, "network identity readiness failed")
 				if metrics != nil {
 					metrics.SandboxClaimsTotal.WithLabelValues(req.Template, "error").Inc()
@@ -505,6 +503,7 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 				return nil, fmt.Errorf("wait for pod network identity: %w", err)
 			}
 			pod = networkPod
+			completeColdAdmission()
 
 			phaseStarted = time.Now()
 			err = s.applyNetworkProviderFromPod(ctx, pod, req.TeamID)
@@ -522,12 +521,14 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 		readyPod, err := s.waitForPodClaimReady(ctx, pod.Namespace, pod.Name)
 		s.observeClaimPhase(req.Template, claimType, "wait_for_pod_claim_ready", phaseStarted, err)
 		if err != nil {
+			completeColdAdmission()
 			s.requestSandboxDeletionAfterClaimFailure(pod, "claim readiness failed")
 			if metrics != nil {
 				metrics.SandboxClaimsTotal.WithLabelValues(req.Template, "error").Inc()
 			}
 			return nil, fmt.Errorf("wait for pod claim readiness: %w", err)
 		}
+		completeColdAdmission()
 		pod = readyPod
 		s.refreshSandboxProbeConditionsAsync(pod)
 	}
@@ -742,6 +743,86 @@ func (s *SandboxService) generateStableSandboxID(template *v1alpha1.SandboxTempl
 	}
 	clusterID := naming.ClusterIDOrDefault(template.Spec.ClusterId)
 	return naming.SandboxName(clusterID, template.Name, utilrand.String(5))
+}
+
+func (s *SandboxService) triggerHotClaimScale(template *v1alpha1.SandboxTemplate, templateID string) {
+	scaler, ok := s.autoScaler.(HotClaimAutoScalerInterface)
+	if !ok || scaler == nil {
+		return
+	}
+	go func() {
+		decision, err := scaler.OnHotClaim(context.Background(), template)
+		if err != nil {
+			s.logger.Warn("Auto scale failed during hot claim",
+				zap.String("template", templateID),
+				zap.Error(err),
+			)
+			return
+		}
+		if decision != nil && decision.ShouldScale {
+			s.logger.Info("Auto scale triggered",
+				zap.String("template", templateID),
+				zap.Int32("delta", decision.Delta),
+				zap.String("reason", decision.Reason),
+			)
+		}
+	}()
+}
+
+func (s *SandboxService) admitColdClaim(
+	ctx context.Context,
+	template *v1alpha1.SandboxTemplate,
+	templateID string,
+) (ColdClaimAdmissionAutoScalerInterface, bool, error) {
+	admitter, ok := s.autoScaler.(ColdClaimAdmissionAutoScalerInterface)
+	if !ok || admitter == nil {
+		s.triggerLegacyColdClaimScale(template, templateID)
+		return nil, false, nil
+	}
+
+	admission, err := admitter.AdmitColdClaim(ctx, template)
+	if err != nil {
+		return nil, false, fmt.Errorf("admit cold claim: %w", err)
+	}
+	if admission != nil && !admission.Admitted {
+		s.logger.Warn("Cold claim capacity unavailable",
+			zap.String("template", templateID),
+			zap.String("reason", admission.Reason),
+			zap.Int32("inFlight", admission.InFlight),
+			zap.Int32("limit", admission.Limit),
+			zap.Int32("networkBacklog", admission.NetworkBacklog),
+		)
+		return nil, false, fmt.Errorf("%w: %s", ErrColdClaimCapacityUnavailable, admission.Reason)
+	}
+	if admission != nil && admission.ScaleDecision != nil && admission.ScaleDecision.ShouldScale {
+		s.logger.Info("Auto scale triggered",
+			zap.String("template", templateID),
+			zap.Int32("delta", admission.ScaleDecision.Delta),
+			zap.String("reason", admission.ScaleDecision.Reason),
+		)
+	}
+	return admitter, true, nil
+}
+
+func (s *SandboxService) triggerLegacyColdClaimScale(template *v1alpha1.SandboxTemplate, templateID string) {
+	if s.autoScaler == nil {
+		return
+	}
+	go func() {
+		scaleDecision, scaleErr := s.autoScaler.OnColdClaim(context.Background(), template)
+		if scaleErr != nil {
+			s.logger.Warn("Auto scale failed during cold claim",
+				zap.String("template", templateID),
+				zap.Error(scaleErr),
+			)
+		} else if scaleDecision != nil && scaleDecision.ShouldScale {
+			s.logger.Info("Auto scale triggered",
+				zap.String("template", templateID),
+				zap.Int32("delta", scaleDecision.Delta),
+				zap.String("reason", scaleDecision.Reason),
+			)
+		}
+	}()
 }
 
 func (s *SandboxService) observeClaimPhase(template, claimType, phase string, started time.Time, err error) {

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -589,6 +589,50 @@ func TestClaimSandboxDeletesColdPodAfterNetworkApplyFailure(t *testing.T) {
 	}
 }
 
+func TestClaimSandboxDoesNotCreateColdPodWhenAdmissionRejects(t *testing.T) {
+	withClaimTestPublicKey(t)
+
+	templateNamespace, err := naming.TemplateNamespaceForBuiltin("managed-agent-claude")
+	if err != nil {
+		t.Fatalf("template namespace: %v", err)
+	}
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "managed-agent-claude",
+			Namespace: templateNamespace,
+		},
+		Spec: v1alpha1.SandboxTemplateSpec{
+			MainContainer: v1alpha1.ContainerSpec{Image: "busybox"},
+		},
+	}
+	client := fake.NewSimpleClientset()
+	svc := &SandboxService{
+		k8sClient:      client,
+		podLister:      corelisters.NewPodLister(newClaimTestPodIndexer(t)),
+		secretLister:   newClaimTestSecretLister(t),
+		templateLister: staticTemplateLister{templates: []*v1alpha1.SandboxTemplate{template}},
+		clock:          systemTime{},
+		logger:         zap.NewNop(),
+	}
+	svc.SetAutoScaler(&rejectingColdClaimScaler{})
+
+	_, err = svc.ClaimSandbox(context.Background(), &ClaimRequest{Template: "managed-agent-claude", TeamID: "team-a", UserID: "user-a"})
+	if err == nil {
+		t.Fatal("ClaimSandbox() error = nil, want cold claim capacity error")
+	}
+	if !errors.Is(err, ErrColdClaimCapacityUnavailable) {
+		t.Fatalf("ClaimSandbox() error = %v, want ErrColdClaimCapacityUnavailable", err)
+	}
+
+	pods, err := client.CoreV1().Pods(templateNamespace).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list pods: %v", err)
+	}
+	if len(pods.Items) != 0 {
+		t.Fatalf("pods after rejected cold admission = %d, want 0", len(pods.Items))
+	}
+}
+
 func TestCreateNewPodMarksColdPodNonEvictable(t *testing.T) {
 	withClaimTestPublicKey(t)
 
@@ -1597,6 +1641,21 @@ func scheduleCreatedClaimPodInIndexer(t *testing.T, client *fake.Clientset, inde
 		return false, nil, nil
 	})
 }
+
+type rejectingColdClaimScaler struct{}
+
+func (rejectingColdClaimScaler) OnColdClaim(context.Context, *v1alpha1.SandboxTemplate) (*ScaleDecisionResult, error) {
+	return &ScaleDecisionResult{ShouldScale: false}, nil
+}
+
+func (rejectingColdClaimScaler) AdmitColdClaim(context.Context, *v1alpha1.SandboxTemplate) (*ColdClaimAdmissionResult, error) {
+	return &ColdClaimAdmissionResult{
+		Admitted: false,
+		Reason:   "cold claim in-flight limit reached",
+	}, nil
+}
+
+func (rejectingColdClaimScaler) CompleteColdClaim(*v1alpha1.SandboxTemplate) {}
 
 func newClaimTestPod(namespace, name, templateID string, ready bool) *corev1.Pod {
 	status := corev1.ConditionFalse

--- a/pkg/observability/metrics/manager.go
+++ b/pkg/observability/metrics/manager.go
@@ -13,6 +13,11 @@ type ManagerMetrics struct {
 	SandboxClaimsTotal             *prometheus.CounterVec
 	SandboxClaimDuration           *prometheus.HistogramVec
 	SandboxClaimPhaseDuration      *prometheus.HistogramVec
+	AutoscalerDecisionsTotal       *prometheus.CounterVec
+	AutoscalerPoolReplicas         *prometheus.GaugeVec
+	AutoscalerPoolPods             *prometheus.GaugeVec
+	AutoscalerColdClaimsInFlight   *prometheus.GaugeVec
+	AutoscalerScaleDelta           *prometheus.HistogramVec
 	PodsCleanedTotal               *prometheus.CounterVec
 	ReconcileTotal                 *prometheus.CounterVec
 	ReconcileDuration              *prometheus.HistogramVec
@@ -64,6 +69,27 @@ func NewManager(registry prometheus.Registerer) *ManagerMetrics {
 			Help:    "Duration of sandbox claim phases",
 			Buckets: []float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 30, 60, 120},
 		}, []string{"template", "type", "phase", "status"}), // type: "hot", "cold", or "unknown"
+		AutoscalerDecisionsTotal: factory.NewCounterVec(prometheus.CounterOpts{
+			Name: "manager_autoscaler_decisions_total",
+			Help: "Total number of autoscaler decisions by action, reason, and result",
+		}, []string{"template", "action", "reason", "result"}),
+		AutoscalerPoolReplicas: factory.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "manager_autoscaler_pool_replicas",
+			Help: "Autoscaler observed and desired idle pool ReplicaSet replicas",
+		}, []string{"template", "state"}), // state: current or desired
+		AutoscalerPoolPods: factory.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "manager_autoscaler_pool_pods",
+			Help: "Autoscaler observed pod counts by template and state",
+		}, []string{"template", "state"}), // state: ready_idle, pending_idle, active, active_without_ip
+		AutoscalerColdClaimsInFlight: factory.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "manager_autoscaler_cold_claims_in_flight",
+			Help: "Current admitted cold claims waiting for pod network identity",
+		}, []string{"template"}),
+		AutoscalerScaleDelta: factory.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "manager_autoscaler_scale_delta",
+			Help:    "Absolute ReplicaSet replica delta applied by the autoscaler",
+			Buckets: []float64{1, 2, 5, 10, 20, 50, 100},
+		}, []string{"template", "direction"}),
 		PodsCleanedTotal: factory.NewCounterVec(prometheus.CounterOpts{
 			Name: "manager_pods_cleaned_total",
 			Help: "Total number of pods cleaned up",


### PR DESCRIPTION
## Summary

- Replaces the manager autoscaler internals with a smaller target controller: claim events refill bounded idle-pool deficits, scale-down returns to `minIdle`, and PoolManager only clamps the current ReplicaSet target within `minIdle/maxIdle`.
- Adds cold-claim admission backpressure before creating runtime pods, using per-template in-flight limits plus active pods without Pod IP as the pod-network backlog signal.
- Wires the operator autoscaler into SandboxService, maps rejected cold admission to `503` with `Retry-After`, and adds autoscaler metrics for decisions, pool replicas, pool pods, cold claims in flight, and scale deltas.
- Uses live ReplicaSet reads for autoscaler decisions so consecutive cold claims do not wait on informer target staleness.

## Tests

- `go test ./manager/pkg/controller ./manager/pkg/service ./manager/pkg/http ./pkg/observability/...`
- `go test ./manager/...`
- `go test ./...` currently fails outside this change because `storage-proxy/proto/fs` is not generated locally and `kind` is not installed for the single-cluster e2e suite.
