### PR TITLE
Fix idle pod claim reservation under concurrency

### DIFF
--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -90,6 +90,11 @@ func main() {
 	if err != nil {
 		logger.Fatal("Failed to build Kubernetes config", zap.Error(err))
 	}
+	observeK8sClientRateLimit(managerMetrics, k8sConfig)
+	logger.Info("Kubernetes client rate limit configured",
+		zap.Float32("qps", effectiveK8sClientQPS(k8sConfig)),
+		zap.Int("burst", effectiveK8sClientBurst(k8sConfig)),
+	)
 
 	// Wrap K8s config with observability
 	obsProvider.K8s.WrapConfig(k8sConfig)
@@ -569,6 +574,28 @@ func buildKubeConfig(kubeconfig string) (*rest.Config, error) {
 		return clientcmd.BuildConfigFromFlags("", kubeconfig)
 	}
 	return rest.InClusterConfig()
+}
+
+func observeK8sClientRateLimit(metrics *obsmetrics.ManagerMetrics, config *rest.Config) {
+	if metrics == nil || metrics.K8sClientRateLimit == nil || config == nil {
+		return
+	}
+	metrics.K8sClientRateLimit.WithLabelValues("qps").Set(float64(effectiveK8sClientQPS(config)))
+	metrics.K8sClientRateLimit.WithLabelValues("burst").Set(float64(effectiveK8sClientBurst(config)))
+}
+
+func effectiveK8sClientQPS(config *rest.Config) float32 {
+	if config == nil || config.QPS <= 0 {
+		return rest.DefaultQPS
+	}
+	return config.QPS
+}
+
+func effectiveK8sClientBurst(config *rest.Config) int {
+	if config == nil || config.Burst <= 0 {
+		return rest.DefaultBurst
+	}
+	return config.Burst
 }
 
 // startMetricsServer starts the Prometheus metrics server

--- a/manager/pkg/service/idle_pod_reservation.go
+++ b/manager/pkg/service/idle_pod_reservation.go
@@ -1,0 +1,75 @@
+package service
+
+import (
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+const idlePodReservationTTL = 30 * time.Second
+
+type idlePodReservations struct {
+	mu     sync.Mutex
+	byName map[string]time.Time
+}
+
+func newIdlePodReservations() *idlePodReservations {
+	return &idlePodReservations{byName: map[string]time.Time{}}
+}
+
+func (r *idlePodReservations) tryReserve(pod *corev1.Pod, ttl time.Duration) bool {
+	if pod == nil {
+		return false
+	}
+	if ttl <= 0 {
+		ttl = idlePodReservationTTL
+	}
+	key := podReservationKey(pod)
+	now := time.Now()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.removeExpiredLocked(now)
+	if expiresAt, ok := r.byName[key]; ok && now.Before(expiresAt) {
+		return false
+	}
+	r.byName[key] = now.Add(ttl)
+	return true
+}
+
+func (r *idlePodReservations) release(pod *corev1.Pod) {
+	if pod == nil {
+		return
+	}
+	key := podReservationKey(pod)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.byName, key)
+}
+
+func (r *idlePodReservations) isReserved(pod *corev1.Pod) bool {
+	if pod == nil {
+		return false
+	}
+	key := podReservationKey(pod)
+	now := time.Now()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.removeExpiredLocked(now)
+	expiresAt, ok := r.byName[key]
+	return ok && now.Before(expiresAt)
+}
+
+func (r *idlePodReservations) removeExpiredLocked(now time.Time) {
+	for key, expiresAt := range r.byName {
+		if !now.Before(expiresAt) {
+			delete(r.byName, key)
+		}
+	}
+}
+
+func podReservationKey(pod *corev1.Pod) string {
+	return pod.Namespace + "/" + pod.Name
+}

--- a/manager/pkg/service/sandbox_service.go
+++ b/manager/pkg/service/sandbox_service.go
@@ -125,6 +125,7 @@ type SandboxService struct {
 	sandboxStore           SandboxStore
 	rootFSObjectDeleter    RootFSObjectDeleter
 	resumeGroup            singleflight.Group
+	idlePodReservations    *idlePodReservations
 }
 
 type TeamQuotaLimitStore interface {
@@ -237,6 +238,7 @@ func NewSandboxService(
 		config:                 config,
 		logger:                 logger,
 		metrics:                metrics,
+		idlePodReservations:    newIdlePodReservations(),
 	}
 	return service
 }

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -32,6 +32,8 @@ const (
 	volumePortalBindRetryInterval = 100 * time.Millisecond
 )
 
+var errIdlePodReservationConflict = errors.New("idle pod reservation conflict")
+
 // ClaimRequest represents a sandbox claim request
 type ClaimRequest struct {
 	TeamID     string
@@ -839,6 +841,13 @@ func (s *SandboxService) observeClaimPhase(template, claimType, phase string, st
 	s.metrics.SandboxClaimPhaseDuration.WithLabelValues(template, claimType, phase, status).Observe(time.Since(started).Seconds())
 }
 
+func (s *SandboxService) observeIdleClaim(template, result string) {
+	if s == nil || s.metrics == nil || s.metrics.SandboxIdleClaimsTotal == nil {
+		return
+	}
+	s.metrics.SandboxIdleClaimsTotal.WithLabelValues(template, result).Inc()
+}
+
 func validateClaimMountsForTemplate(req *ClaimRequest, template *v1alpha1.SandboxTemplate) error {
 	allowed := declaredVolumeMountsByPath(template)
 	var mounts []ClaimMount
@@ -1097,7 +1106,10 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 	if err != nil {
 		return nil, fmt.Errorf("compute template hash: %w", err)
 	}
-	err = retry.OnError(claimIdlePodBackoff, k8serrors.IsConflict, func() error {
+	templateID := controller.TemplateLogicalID(template)
+	err = retry.OnError(claimIdlePodBackoff, func(err error) bool {
+		return k8serrors.IsConflict(err) || errors.Is(err, errIdlePodReservationConflict)
+	}, func() error {
 		// Get all idle pods for this template
 		pods, listErr := s.podLister.Pods(template.Namespace).List(labels.SelectorFromSet(map[string]string{
 			controller.LabelTemplateID: template.Name,
@@ -1110,18 +1122,35 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 		// Filter hot-claimable pods to Kubernetes-ready instances only.
 		var readyPods []*corev1.Pod
 		for _, pod := range pods {
-			if s.isHotClaimableIdlePod(pod, desiredTemplateHash) {
+			if s.isHotClaimableIdlePod(pod, desiredTemplateHash) && !s.isIdlePodReserved(pod) {
 				readyPods = append(readyPods, pod)
 			}
 		}
 
 		if len(readyPods) == 0 {
 			// No idle pod available, not an error - use a special error to stop retry
+			s.observeIdleClaim(templateID, "no_candidate")
 			return errNoIdlePod
 		}
 
 		// Claim an available pod
 		pod := readyPods[rand.Intn(len(readyPods))]
+		if !s.reserveIdlePod(pod) {
+			s.observeIdleClaim(templateID, "reservation_conflict")
+			return errIdlePodReservationConflict
+		}
+		reservationHeld := true
+		releaseReservation := func() {
+			if reservationHeld {
+				s.releaseIdlePodReservation(pod)
+				reservationHeld = false
+			}
+		}
+		keepReservationUntilTTL := func() {
+			reservationHeld = false
+		}
+		defer releaseReservation()
+		s.observeIdleClaim(templateID, "reserved")
 
 		sandboxID := strings.TrimSpace(req.SandboxID)
 		if sandboxID == "" {
@@ -1228,10 +1257,19 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 				)
 			}
 			if isIdlePodLostDuringClaim(updateErr) {
+				s.observeIdleClaim(templateID, "update_conflict")
+				keepReservationUntilTTL()
 				return errNoIdlePod
+			}
+			if k8serrors.IsConflict(updateErr) {
+				s.observeIdleClaim(templateID, "update_conflict")
+				keepReservationUntilTTL()
+			} else {
+				s.observeIdleClaim(templateID, "update_error")
 			}
 			return updateErr
 		}
+		keepReservationUntilTTL()
 
 		if resizeQuota != nil {
 			resizedPod, resizeErr := s.resizeSandboxPodResources(ctx, updatedPod, *resizeQuota)
@@ -1244,6 +1282,7 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 					)
 				}
 				s.requestSandboxDeletionAfterClaimFailure(updatedPod, "sandbox resource resize failed")
+				s.observeIdleClaim(templateID, "resize_error")
 				return fmt.Errorf("resize sandbox resources: %w", resizeErr)
 			}
 			updatedPod = mergeSandboxMetadataAfterResize(resizedPod, updatedPod)
@@ -1251,6 +1290,7 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 
 		if applyErr := s.applyNetworkProvider(ctx, updatedPod, req.TeamID, policySpecFromState(networkState)); applyErr != nil {
 			s.requestSandboxDeletionAfterClaimFailure(updatedPod, "network policy apply failed")
+			s.observeIdleClaim(templateID, "network_policy_error")
 			return fmt.Errorf("apply network policy: %w", applyErr)
 		}
 
@@ -1261,6 +1301,7 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 		)
 
 		claimedPod = updatedPod
+		s.observeIdleClaim(templateID, "success")
 		return nil
 	})
 	if err != nil {
@@ -1280,6 +1321,25 @@ func (s *SandboxService) isHotClaimableIdlePod(pod *corev1.Pod, desiredTemplateH
 		return false
 	}
 	return controller.IsPodReady(pod) && s.podDataPlaneReady(pod)
+}
+
+func (s *SandboxService) reserveIdlePod(pod *corev1.Pod) bool {
+	return s.idleReservations().tryReserve(pod, idlePodReservationTTL)
+}
+
+func (s *SandboxService) releaseIdlePodReservation(pod *corev1.Pod) {
+	s.idleReservations().release(pod)
+}
+
+func (s *SandboxService) isIdlePodReserved(pod *corev1.Pod) bool {
+	return s.idleReservations().isReserved(pod)
+}
+
+func (s *SandboxService) idleReservations() *idlePodReservations {
+	if s.idlePodReservations == nil {
+		s.idlePodReservations = newIdlePodReservations()
+	}
+	return s.idlePodReservations
 }
 
 func isIdlePodLostDuringClaim(err error) bool {

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -106,6 +106,86 @@ func TestClaimIdlePodClaimsReadyPod(t *testing.T) {
 	}
 }
 
+func TestClaimIdlePodReservationPreventsStaleCacheReuse(t *testing.T) {
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "template-a",
+			Namespace: "ns-a",
+		},
+	}
+	readyPod := newClaimTestPod("ns-a", "idle-ready", "template-a", true)
+	reservations := newIdlePodReservations()
+
+	client := fake.NewSimpleClientset(readyPod.DeepCopy())
+	svc := &SandboxService{
+		k8sClient:           client,
+		podLister:           newClaimTestPodLister(t, readyPod),
+		clock:               systemTime{},
+		logger:              zap.NewNop(),
+		idlePodReservations: reservations,
+	}
+
+	pod, err := svc.claimIdlePod(context.Background(), template, &ClaimRequest{
+		TeamID: "team-a",
+		UserID: "user-a",
+	})
+	if err != nil {
+		t.Fatalf("first claimIdlePod() error = %v", err)
+	}
+	if pod == nil {
+		t.Fatal("first claimIdlePod() = nil, want ready pod")
+	}
+
+	pod, err = svc.claimIdlePod(context.Background(), template, &ClaimRequest{
+		TeamID: "team-a",
+		UserID: "user-a",
+	})
+	if err != nil {
+		t.Fatalf("second claimIdlePod() error = %v", err)
+	}
+	if pod != nil {
+		t.Fatalf("second claimIdlePod() = %s, want nil while stale idle pod is reserved", pod.Name)
+	}
+}
+
+func TestClaimIdlePodSkipsReservedPod(t *testing.T) {
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "template-a",
+			Namespace: "ns-a",
+		},
+	}
+	podA := newClaimTestPod("ns-a", "idle-a", "template-a", true)
+	podB := newClaimTestPod("ns-a", "idle-b", "template-a", true)
+	reservations := newIdlePodReservations()
+
+	client := fake.NewSimpleClientset(podA.DeepCopy(), podB.DeepCopy())
+	svc := &SandboxService{
+		k8sClient:           client,
+		podLister:           newClaimTestPodLister(t, podA, podB),
+		clock:               systemTime{},
+		logger:              zap.NewNop(),
+		idlePodReservations: reservations,
+	}
+	if !svc.reserveIdlePod(podA) {
+		t.Fatal("reserveIdlePod(podA) = false, want true")
+	}
+
+	pod, err := svc.claimIdlePod(context.Background(), template, &ClaimRequest{
+		TeamID: "team-a",
+		UserID: "user-a",
+	})
+	if err != nil {
+		t.Fatalf("claimIdlePod() error = %v", err)
+	}
+	if pod == nil {
+		t.Fatal("claimIdlePod() = nil, want unreserved pod")
+	}
+	if pod.Name != "idle-b" {
+		t.Fatalf("claimIdlePod() selected %q, want idle-b", pod.Name)
+	}
+}
+
 func TestClaimIdlePodAllowsClaimMounts(t *testing.T) {
 	template := &v1alpha1.SandboxTemplate{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1013,6 +1093,28 @@ func TestObserveClaimPhaseRecordsMetric(t *testing.T) {
 	}
 	if got := metric.GetHistogram().GetSampleSum(); got <= 0 {
 		t.Fatalf("claim phase sample sum = %f, want > 0", got)
+	}
+}
+
+func TestObserveIdleClaimRecordsMetric(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	svc := &SandboxService{metrics: obsmetrics.NewManager(registry)}
+
+	svc.observeIdleClaim("managed-agents", "success")
+
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("gather metrics: %v", err)
+	}
+	metric := findMetric(families, "manager_sandbox_idle_claims_total", map[string]string{
+		"template": "managed-agents",
+		"result":   "success",
+	})
+	if metric == nil || metric.GetCounter() == nil {
+		t.Fatal("idle claim counter metric not found")
+	}
+	if got := metric.GetCounter().GetValue(); got != 1 {
+		t.Fatalf("idle claim counter = %f, want 1", got)
 	}
 }
 

--- a/manager/pkg/service/sandbox_service_network.go
+++ b/manager/pkg/service/sandbox_service_network.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
@@ -24,6 +25,25 @@ type webhookInfo struct {
 	URL      string
 	Secret   string
 	WatchDir string
+}
+
+func (s *SandboxService) observeNetworkPolicyApply(provider string, started time.Time, err error) {
+	if s == nil || s.metrics == nil {
+		return
+	}
+	if provider == "" {
+		provider = "unknown"
+	}
+	result := "success"
+	if err != nil {
+		result = "error"
+	}
+	if s.metrics.NetworkPolicyApplyTotal != nil {
+		s.metrics.NetworkPolicyApplyTotal.WithLabelValues(provider, result).Inc()
+	}
+	if s.metrics.NetworkPolicyApplyDuration != nil {
+		s.metrics.NetworkPolicyApplyDuration.WithLabelValues(provider, result).Observe(time.Since(started).Seconds())
+	}
 }
 
 func (s *SandboxService) getWebhookInfo(req *ClaimRequest) *webhookInfo {
@@ -498,6 +518,8 @@ func (s *SandboxService) applyNetworkProvider(
 		return nil
 	}
 
+	providerName := s.networkProvider.Name()
+	started := time.Now()
 	sandboxID := sandboxIDFromPod(pod)
 	if sandboxID == "" {
 		sandboxID = pod.Name
@@ -511,11 +533,13 @@ func (s *SandboxService) applyNetworkProvider(
 		NetworkPolicy: networkSpec,
 	}
 	if err := s.networkProvider.ApplySandboxPolicy(ctx, input); err != nil {
+		s.observeNetworkPolicyApply(providerName, started, err)
 		if errors.Is(err, network.ErrPolicyApplyTimeout) {
 			return fmt.Errorf("%w: %v", ErrDataPlaneNotReady, err)
 		}
 		return err
 	}
+	s.observeNetworkPolicyApply(providerName, started, nil)
 	return nil
 }
 

--- a/manager/pkg/service/sandbox_service_network_test.go
+++ b/manager/pkg/service/sandbox_service_network_test.go
@@ -7,10 +7,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/network"
 	"github.com/sandbox0-ai/sandbox0/pkg/egressauth"
+	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -134,6 +136,44 @@ func TestApplyNetworkProviderMapsTimeoutToDataPlaneNotReady(t *testing.T) {
 	}
 	if !errors.Is(err, ErrDataPlaneNotReady) {
 		t.Fatalf("applyNetworkProvider() error = %v, want ErrDataPlaneNotReady", err)
+	}
+}
+
+func TestApplyNetworkProviderRecordsMetric(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	svc := &SandboxService{
+		networkProvider: &assertingNetworkProvider{},
+		metrics:         obsmetrics.NewManager(registry),
+	}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "sandbox-a", Namespace: "ns-a"}}
+
+	if err := svc.applyNetworkProvider(context.Background(), pod, "team-a", &v1alpha1.NetworkPolicySpec{}); err != nil {
+		t.Fatalf("applyNetworkProvider() error = %v", err)
+	}
+
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("gather metrics: %v", err)
+	}
+	counter := findMetric(families, "manager_network_policy_apply_total", map[string]string{
+		"provider": "test",
+		"result":   "success",
+	})
+	if counter == nil || counter.GetCounter() == nil {
+		t.Fatal("network policy apply counter metric not found")
+	}
+	if got := counter.GetCounter().GetValue(); got != 1 {
+		t.Fatalf("network policy apply counter = %f, want 1", got)
+	}
+	histogram := findMetric(families, "manager_network_policy_apply_duration_seconds", map[string]string{
+		"provider": "test",
+		"result":   "success",
+	})
+	if histogram == nil || histogram.GetHistogram() == nil {
+		t.Fatal("network policy apply duration metric not found")
+	}
+	if got := histogram.GetHistogram().GetSampleCount(); got != 1 {
+		t.Fatalf("network policy apply duration samples = %d, want 1", got)
 	}
 }
 

--- a/netd/pkg/daemon/daemon.go
+++ b/netd/pkg/daemon/daemon.go
@@ -418,12 +418,21 @@ func (d *Daemon) syncRedirect(
 	tracker *conntrack.Tracker,
 	conntrackManager *conntrack.Manager,
 	proxyServer *proxy.Server,
-) error {
+) (err error) {
+	started := time.Now()
+	defer func() {
+		result := "success"
+		if err != nil {
+			result = "error"
+		}
+		daemonMetrics.RecordRedirectSync(result, time.Since(started))
+	}()
 	if netdWatcher == nil || redirectManager == nil || patcher == nil {
 		return fmt.Errorf("missing watcher or redirect manager or patcher or policy store")
 	}
 	// Redirect rules only need local source pods, while platform peer deny must
 	// know every active sandbox so cross-node private traffic is still blocked.
+	stageStarted := time.Now()
 	localSandboxes := netdWatcher.ListSandboxesByNode(d.cfg.NodeName)
 	allSandboxes := localSandboxes
 	if d.cfg.NodeName != "" {
@@ -438,8 +447,20 @@ func (d *Daemon) syncRedirect(
 		}
 		sandboxIPs = append(sandboxIPs, sandbox.PodIP)
 	}
+	daemonMetrics.RecordRedirectSyncStage("list_inputs", "success", time.Since(stageStarted))
+	daemonMetrics.SetRedirectSyncObjectCount("local_sandboxes", len(localSandboxes))
+	daemonMetrics.SetRedirectSyncObjectCount("total_sandboxes", len(allSandboxes))
+	daemonMetrics.SetRedirectSyncObjectCount("services", len(services))
+	daemonMetrics.SetRedirectSyncObjectCount("endpoints", len(endpoints))
+	daemonMetrics.SetRedirectSyncObjectCount("sandbox_ips", len(sandboxIPs))
+
+	policyChanged := 0
+	policyRemovedIPs := 0
 	if policyStore != nil {
+		stageStarted = time.Now()
 		result := policyStore.ReconcileSandboxes(localSandboxes)
+		policyChanged = len(result.Changed)
+		policyRemovedIPs = len(result.RemovedIPs)
 		for _, podIP := range result.RemovedIPs {
 			if proxyServer != nil {
 				proxyServer.ForgetSandboxDNS(podIP)
@@ -452,9 +473,15 @@ func (d *Daemon) syncRedirect(
 			}
 			cleanupDeniedTrackedFlows(ctx, tracker, conntrackManager, policyStore, change.PodIP)
 		}
+		daemonMetrics.RecordRedirectSyncStage("policy_reconcile", "success", time.Since(stageStarted))
 	}
+	daemonMetrics.SetRedirectSyncObjectCount("policy_changed", policyChanged)
+	daemonMetrics.SetRedirectSyncObjectCount("policy_removed_ips", policyRemovedIPs)
+
 	if platformState != nil {
+		stageStarted = time.Now()
 		platformState.Reconcile(allSandboxes, services, endpoints)
+		daemonMetrics.RecordRedirectSyncStage("platform_reconcile", "success", time.Since(stageStarted))
 	}
 
 	dnsCIDRs := clusterDNSCIDRs(d.cfg.ClusterDNSCIDR, services, endpoints)
@@ -467,6 +494,7 @@ func (d *Daemon) syncRedirect(
 		platformBypassCIDRs = append(platformBypassCIDRs, policyStore.AllowedPlatformCIDRs()...)
 	}
 	bypassCIDRs := redirectBypassCIDRs(dnsCIDRs, configuredBypassCIDRs, platformBypassCIDRs)
+	daemonMetrics.SetRedirectSyncObjectCount("bypass_cidrs", len(bypassCIDRs))
 
 	d.logger.Info(
 		"Syncing redirect rules",
@@ -476,19 +504,27 @@ func (d *Daemon) syncRedirect(
 		zap.Strings("sandbox_ips", sandboxIPs),
 		zap.Strings("bypass_cidrs", bypassCIDRs),
 	)
+	stageStarted = time.Now()
 	if err := redirectManager.Sync(ctx, sandboxIPs, bypassCIDRs); err != nil {
+		daemonMetrics.RecordRedirectSyncStage("redirect_sync", "error", time.Since(stageStarted))
 		return err
 	}
+	daemonMetrics.RecordRedirectSyncStage("redirect_sync", "success", time.Since(stageStarted))
+
 	patchedCount := 0
+	stageStarted = time.Now()
 	if err := patcher.SyncAppliedHashes(ctx, localSandboxes); err != nil {
+		daemonMetrics.RecordRedirectSyncStage("patch_applied_hashes", "error", time.Since(stageStarted))
 		d.logger.Warn("Failed to sync applied hashes", zap.Error(err))
 	} else {
+		daemonMetrics.RecordRedirectSyncStage("patch_applied_hashes", "success", time.Since(stageStarted))
 		for _, sandbox := range localSandboxes {
 			if sandbox.NetworkPolicyHash != "" && sandbox.NetworkPolicyHash == sandbox.NetworkAppliedHash {
 				patchedCount++
 			}
 		}
 	}
+	daemonMetrics.SetRedirectSyncObjectCount("patched_hashes", patchedCount)
 	d.logger.Info("Redirect rules synced",
 		zap.Int("sandboxes_patched", patchedCount),
 		zap.Int("sandboxes_local", len(localSandboxes)),

--- a/netd/pkg/daemon/metrics.go
+++ b/netd/pkg/daemon/metrics.go
@@ -1,0 +1,71 @@
+package daemon
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type daemonMetricsRegistry struct {
+	redirectSyncTotal         *prometheus.CounterVec
+	redirectSyncDuration      *prometheus.HistogramVec
+	redirectSyncStageDuration *prometheus.HistogramVec
+	redirectSyncObjects       *prometheus.GaugeVec
+}
+
+var daemonMetrics = newDaemonMetricsRegistry()
+
+func newDaemonMetricsRegistry() *daemonMetricsRegistry {
+	return &daemonMetricsRegistry{
+		redirectSyncTotal: promauto.NewCounterVec(prometheus.CounterOpts{
+			Name: "netd_redirect_sync_total",
+			Help: "Total number of netd redirect sync attempts by result",
+		}, []string{"result"}),
+		redirectSyncDuration: promauto.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "netd_redirect_sync_duration_seconds",
+			Help:    "Duration of netd redirect sync attempts by result",
+			Buckets: []float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 30},
+		}, []string{"result"}),
+		redirectSyncStageDuration: promauto.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "netd_redirect_sync_stage_duration_seconds",
+			Help:    "Duration of netd redirect sync stages by stage and result",
+			Buckets: []float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 30},
+		}, []string{"stage", "result"}),
+		redirectSyncObjects: promauto.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "netd_redirect_sync_objects",
+			Help: "Object counts from the most recent netd redirect sync by kind",
+		}, []string{"kind"}),
+	}
+}
+
+func (m *daemonMetricsRegistry) RecordRedirectSync(result string, duration time.Duration) {
+	if m == nil {
+		return
+	}
+	if result == "" {
+		result = "unknown"
+	}
+	m.redirectSyncTotal.WithLabelValues(result).Inc()
+	m.redirectSyncDuration.WithLabelValues(result).Observe(duration.Seconds())
+}
+
+func (m *daemonMetricsRegistry) RecordRedirectSyncStage(stage, result string, duration time.Duration) {
+	if m == nil {
+		return
+	}
+	if stage == "" {
+		stage = "unknown"
+	}
+	if result == "" {
+		result = "unknown"
+	}
+	m.redirectSyncStageDuration.WithLabelValues(stage, result).Observe(duration.Seconds())
+}
+
+func (m *daemonMetricsRegistry) SetRedirectSyncObjectCount(kind string, count int) {
+	if m == nil || kind == "" {
+		return
+	}
+	m.redirectSyncObjects.WithLabelValues(kind).Set(float64(count))
+}

--- a/pkg/observability/metrics/manager.go
+++ b/pkg/observability/metrics/manager.go
@@ -14,6 +14,9 @@ type ManagerMetrics struct {
 	SandboxClaimDuration           *prometheus.HistogramVec
 	SandboxClaimPhaseDuration      *prometheus.HistogramVec
 	SandboxIdleClaimsTotal         *prometheus.CounterVec
+	NetworkPolicyApplyTotal        *prometheus.CounterVec
+	NetworkPolicyApplyDuration     *prometheus.HistogramVec
+	K8sClientRateLimit             *prometheus.GaugeVec
 	AutoscalerDecisionsTotal       *prometheus.CounterVec
 	AutoscalerPoolReplicas         *prometheus.GaugeVec
 	AutoscalerPoolPods             *prometheus.GaugeVec
@@ -74,6 +77,19 @@ func NewManager(registry prometheus.Registerer) *ManagerMetrics {
 			Name: "manager_sandbox_idle_claims_total",
 			Help: "Total number of idle-pool claim attempts by result",
 		}, []string{"template", "result"}),
+		NetworkPolicyApplyTotal: factory.NewCounterVec(prometheus.CounterOpts{
+			Name: "manager_network_policy_apply_total",
+			Help: "Total number of network policy apply attempts by provider and result",
+		}, []string{"provider", "result"}),
+		NetworkPolicyApplyDuration: factory.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "manager_network_policy_apply_duration_seconds",
+			Help:    "Duration of network policy apply attempts by provider and result",
+			Buckets: []float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 30},
+		}, []string{"provider", "result"}),
+		K8sClientRateLimit: factory.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "manager_k8s_client_rate_limit",
+			Help: "Effective Kubernetes client rate limit configuration values",
+		}, []string{"setting"}),
 		AutoscalerDecisionsTotal: factory.NewCounterVec(prometheus.CounterOpts{
 			Name: "manager_autoscaler_decisions_total",
 			Help: "Total number of autoscaler decisions by action, reason, and result",

--- a/pkg/observability/metrics/manager.go
+++ b/pkg/observability/metrics/manager.go
@@ -13,6 +13,7 @@ type ManagerMetrics struct {
 	SandboxClaimsTotal             *prometheus.CounterVec
 	SandboxClaimDuration           *prometheus.HistogramVec
 	SandboxClaimPhaseDuration      *prometheus.HistogramVec
+	SandboxIdleClaimsTotal         *prometheus.CounterVec
 	AutoscalerDecisionsTotal       *prometheus.CounterVec
 	AutoscalerPoolReplicas         *prometheus.GaugeVec
 	AutoscalerPoolPods             *prometheus.GaugeVec
@@ -69,6 +70,10 @@ func NewManager(registry prometheus.Registerer) *ManagerMetrics {
 			Help:    "Duration of sandbox claim phases",
 			Buckets: []float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 30, 60, 120},
 		}, []string{"template", "type", "phase", "status"}), // type: "hot", "cold", or "unknown"
+		SandboxIdleClaimsTotal: factory.NewCounterVec(prometheus.CounterOpts{
+			Name: "manager_sandbox_idle_claims_total",
+			Help: "Total number of idle-pool claim attempts by result",
+		}, []string{"template", "result"}),
 		AutoscalerDecisionsTotal: factory.NewCounterVec(prometheus.CounterOpts{
 			Name: "manager_autoscaler_decisions_total",
 			Help: "Total number of autoscaler decisions by action, reason, and result",


### PR DESCRIPTION
## Summary

- add a manager-local idle pod reservation table so concurrent hot claims do not select the same stale informer pod
- keep reservations through update conflicts and successful pod updates to cover informer lag, while releasing them for pre-update failures
- add idle-pool claim outcome metrics with `manager_sandbox_idle_claims_total`
- add manager network policy apply metrics with `manager_network_policy_apply_total` and `manager_network_policy_apply_duration_seconds`
- expose effective manager Kubernetes client QPS/Burst via `manager_k8s_client_rate_limit` and startup logs
- add netd redirect sync metrics for sync count, total duration, stage duration, and last-sync object counts via `netd_redirect_sync_*`
- add regression coverage for stale idle-pod cache reuse, reserved-pod skipping, idle-claim metrics, and network-policy apply metrics

Refs #630

## Tests

- `go test ./manager/pkg/service ./pkg/observability/metrics ./netd/pkg/daemon`
- `go test ./manager/...`
- `go test ./netd/...`
- `go test ./pkg/observability/...`