### PR TITLE
Harden manager conflict retries

### DIFF
--- a/manager/pkg/controller/helpers.go
+++ b/manager/pkg/controller/helpers.go
@@ -63,7 +63,7 @@ func EnsureProcdConfigSecret(
 		},
 	}
 
-	existing, err := secretLister.Secrets(template.Namespace).Get(name)
+	_, err = secretLister.Secrets(template.Namespace).Get(name)
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
 			return fmt.Errorf("get procd config secret: %w", err)
@@ -72,29 +72,33 @@ func EnsureProcdConfigSecret(
 			if !apierrors.IsAlreadyExists(err) {
 				return fmt.Errorf("create procd config secret: %w", err)
 			}
-			existing, err = client.CoreV1().Secrets(template.Namespace).Get(ctx, name, metav1.GetOptions{})
-			if err != nil {
-				return fmt.Errorf("get procd config secret after already exists: %w", err)
-			}
 		} else {
 			return nil
 		}
 	}
 
-	updated := existing.DeepCopy()
-	updated.Labels = labels
-	updated.OwnerReferences = ownerRefs
-	updated.Data = desired.Data
-	updated.Type = desired.Type
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current, err := client.CoreV1().Secrets(template.Namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		updated := current.DeepCopy()
+		updated.Labels = labels
+		updated.OwnerReferences = ownerRefs
+		updated.Data = desired.Data
+		updated.Type = desired.Type
 
-	if reflect.DeepEqual(existing.Labels, updated.Labels) &&
-		reflect.DeepEqual(existing.OwnerReferences, updated.OwnerReferences) &&
-		reflect.DeepEqual(existing.Data, updated.Data) &&
-		reflect.DeepEqual(existing.Type, updated.Type) {
-		return nil
-	}
+		if reflect.DeepEqual(current.Labels, updated.Labels) &&
+			reflect.DeepEqual(current.OwnerReferences, updated.OwnerReferences) &&
+			reflect.DeepEqual(current.Data, updated.Data) &&
+			reflect.DeepEqual(current.Type, updated.Type) {
+			return nil
+		}
 
-	if _, err := client.CoreV1().Secrets(template.Namespace).Update(ctx, updated, metav1.UpdateOptions{}); err != nil {
+		_, err = client.CoreV1().Secrets(template.Namespace).Update(ctx, updated, metav1.UpdateOptions{})
+		return err
+	})
+	if err != nil {
 		return fmt.Errorf("update procd config secret: %w", err)
 	}
 	return nil
@@ -342,28 +346,39 @@ func EnsureNetdMITMCASecret(
 		},
 	}
 
-	existing, err := client.CoreV1().Secrets(templateNamespace).Get(ctx, cfg.NetdMITMCASecretName, metav1.GetOptions{})
+	_, err = client.CoreV1().Secrets(templateNamespace).Get(ctx, cfg.NetdMITMCASecretName, metav1.GetOptions{})
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
 			return fmt.Errorf("get target netd MITM CA secret: %w", err)
 		}
 		if _, err := client.CoreV1().Secrets(templateNamespace).Create(ctx, desired, metav1.CreateOptions{}); err != nil {
-			return fmt.Errorf("create target netd MITM CA secret: %w", err)
+			if !apierrors.IsAlreadyExists(err) {
+				return fmt.Errorf("create target netd MITM CA secret: %w", err)
+			}
+		} else {
+			return nil
 		}
-		return nil
 	}
 
-	updated := existing.DeepCopy()
-	updated.Type = desired.Type
-	updated.Data = desired.Data
-	updated.Labels = desired.Labels
-	if reflect.DeepEqual(existing.Type, updated.Type) &&
-		reflect.DeepEqual(existing.Data, updated.Data) &&
-		reflect.DeepEqual(existing.Labels, updated.Labels) {
-		return nil
-	}
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current, err := client.CoreV1().Secrets(templateNamespace).Get(ctx, cfg.NetdMITMCASecretName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		updated := current.DeepCopy()
+		updated.Type = desired.Type
+		updated.Data = desired.Data
+		updated.Labels = desired.Labels
+		if reflect.DeepEqual(current.Type, updated.Type) &&
+			reflect.DeepEqual(current.Data, updated.Data) &&
+			reflect.DeepEqual(current.Labels, updated.Labels) {
+			return nil
+		}
 
-	if _, err := client.CoreV1().Secrets(templateNamespace).Update(ctx, updated, metav1.UpdateOptions{}); err != nil {
+		_, err = client.CoreV1().Secrets(templateNamespace).Update(ctx, updated, metav1.UpdateOptions{})
+		return err
+	})
+	if err != nil {
 		return fmt.Errorf("update target netd MITM CA secret: %w", err)
 	}
 	return nil

--- a/manager/pkg/controller/pool_manager.go
+++ b/manager/pkg/controller/pool_manager.go
@@ -170,8 +170,7 @@ func (pm *PoolManager) ReconcilePool(ctx context.Context, template *v1alpha1.San
 			zap.Int32("desired", desiredReplicas),
 		)
 
-		rs.Spec.Replicas = &desiredReplicas
-		_, err = pm.k8sClient.AppsV1().ReplicaSets(template.Namespace).Update(ctx, rs, metav1.UpdateOptions{})
+		_, err = pm.updateReplicaSetReplicas(ctx, template.Namespace, rs.Name, desiredReplicas)
 		if err != nil {
 			pm.recorder.Eventf(template, corev1.EventTypeWarning, "ReplicaSetUpdateFailed",
 				"Failed to update ReplicaSet: %v", err)
@@ -183,6 +182,29 @@ func (pm *PoolManager) ReconcilePool(ctx context.Context, template *v1alpha1.San
 	}
 
 	return nil
+}
+
+func (pm *PoolManager) updateReplicaSetReplicas(ctx context.Context, namespace, name string, replicas int32) (*appsv1.ReplicaSet, error) {
+	var updatedRS *appsv1.ReplicaSet
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current, err := pm.k8sClient.AppsV1().ReplicaSets(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		currentReplicas := getInt32Value(current.Spec.Replicas)
+		if current.Spec.Replicas != nil && currentReplicas == replicas {
+			updatedRS = current
+			return nil
+		}
+		updated := current.DeepCopy()
+		updated.Spec.Replicas = &replicas
+		updatedRS, err = pm.k8sClient.AppsV1().ReplicaSets(namespace).Update(ctx, updated, metav1.UpdateOptions{})
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return updatedRS, nil
 }
 
 func desiredPoolReplicas(template *v1alpha1.SandboxTemplate, current int32) int32 {
@@ -403,9 +425,21 @@ func (pm *PoolManager) reconcileReplicaSetTemplate(
 		return nil, fmt.Errorf("build pod template: %w", err)
 	}
 
-	updated := rs.DeepCopy()
-	updated.Spec.Template = newTemplate
-	updatedRS, err := pm.k8sClient.AppsV1().ReplicaSets(template.Namespace).Update(ctx, updated, metav1.UpdateOptions{})
+	var updatedRS *appsv1.ReplicaSet
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current, err := pm.k8sClient.AppsV1().ReplicaSets(template.Namespace).Get(ctx, rs.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if current.Spec.Template.Annotations[AnnotationTemplateSpecHash] == desiredTemplateHash {
+			updatedRS = current
+			return nil
+		}
+		updated := current.DeepCopy()
+		updated.Spec.Template = newTemplate
+		updatedRS, err = pm.k8sClient.AppsV1().ReplicaSets(template.Namespace).Update(ctx, updated, metav1.UpdateOptions{})
+		return err
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/manager/pkg/controller/pool_manager_test.go
+++ b/manager/pkg/controller/pool_manager_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -16,8 +17,10 @@ import (
 	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 	appslisters "k8s.io/client-go/listers/apps/v1"
@@ -108,6 +111,32 @@ func TestDesiredPoolReplicasPreservesAutoscalerTargetWithinBounds(t *testing.T) 
 	assert.Equal(t, int32(15), desiredPoolReplicas(template, 3))
 	assert.Equal(t, int32(25), desiredPoolReplicas(template, 25))
 	assert.Equal(t, int32(50), desiredPoolReplicas(template, 80))
+}
+
+func TestUpdateReplicaSetReplicasRetriesConflict(t *testing.T) {
+	replicas := int32(3)
+	rs := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "rs-template-a", Namespace: "default"},
+		Spec: appsv1.ReplicaSetSpec{
+			Replicas: &replicas,
+		},
+	}
+	client := fake.NewSimpleClientset(rs)
+	updates := 0
+	client.PrependReactor("update", "replicasets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		updates++
+		if updates == 1 {
+			return true, nil, apierrors.NewConflict(schema.GroupResource{Resource: "replicasets"}, rs.Name, errors.New("stale replicaset"))
+		}
+		return false, nil, nil
+	})
+	pm := &PoolManager{k8sClient: client, logger: zap.NewNop()}
+
+	updated, err := pm.updateReplicaSetReplicas(context.Background(), rs.Namespace, rs.Name, 15)
+	require.NoError(t, err)
+	require.NotNil(t, updated)
+	assert.Equal(t, 2, updates)
+	assert.Equal(t, int32(15), getInt32Value(updated.Spec.Replicas))
 }
 
 func findCSIVolumeByPortal(volumes []corev1.Volume, portalName string) *corev1.Volume {

--- a/manager/pkg/namespacepolicy/reconciler.go
+++ b/manager/pkg/namespacepolicy/reconciler.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
 )
 
 const (
@@ -98,25 +99,36 @@ func (r *Reconciler) EnsureBaseline(ctx context.Context, namespace string) error
 }
 
 func (r *Reconciler) ensurePolicy(ctx context.Context, desired *networkingv1.NetworkPolicy) error {
-	existing, err := r.client.NetworkingV1().NetworkPolicies(desired.Namespace).Get(ctx, desired.Name, metav1.GetOptions{})
+	_, err := r.client.NetworkingV1().NetworkPolicies(desired.Namespace).Get(ctx, desired.Name, metav1.GetOptions{})
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
 			return fmt.Errorf("get networkpolicy %s/%s: %w", desired.Namespace, desired.Name, err)
 		}
 		if _, err := r.client.NetworkingV1().NetworkPolicies(desired.Namespace).Create(ctx, desired, metav1.CreateOptions{}); err != nil {
-			return fmt.Errorf("create networkpolicy %s/%s: %w", desired.Namespace, desired.Name, err)
+			if !apierrors.IsAlreadyExists(err) {
+				return fmt.Errorf("create networkpolicy %s/%s: %w", desired.Namespace, desired.Name, err)
+			}
+		} else {
+			return nil
 		}
-		return nil
 	}
 
-	updated := existing.DeepCopy()
-	updated.Labels = desired.Labels
-	updated.Spec = desired.Spec
-	if reflect.DeepEqual(existing.Labels, updated.Labels) && reflect.DeepEqual(existing.Spec, updated.Spec) {
-		return nil
-	}
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current, err := r.client.NetworkingV1().NetworkPolicies(desired.Namespace).Get(ctx, desired.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		updated := current.DeepCopy()
+		updated.Labels = desired.Labels
+		updated.Spec = desired.Spec
+		if reflect.DeepEqual(current.Labels, updated.Labels) && reflect.DeepEqual(current.Spec, updated.Spec) {
+			return nil
+		}
 
-	if _, err := r.client.NetworkingV1().NetworkPolicies(desired.Namespace).Update(ctx, updated, metav1.UpdateOptions{}); err != nil {
+		_, err = r.client.NetworkingV1().NetworkPolicies(desired.Namespace).Update(ctx, updated, metav1.UpdateOptions{})
+		return err
+	})
+	if err != nil {
 		return fmt.Errorf("update networkpolicy %s/%s: %w", desired.Namespace, desired.Name, err)
 	}
 	return nil

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -1181,6 +1181,7 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 		}
 
 		// Update pod labels and annotations
+		originalIdlePod := pod.DeepCopy()
 		pod = pod.DeepCopy()
 		var resizeQuota *v1alpha1.ResourceQuota
 		if req.Config != nil && req.Config.Resources != nil {
@@ -1281,8 +1282,22 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 						zap.Error(rollbackErr),
 					)
 				}
-				s.requestSandboxDeletionAfterClaimFailure(updatedPod, "sandbox resource resize failed")
-				s.observeIdleClaim(templateID, "resize_error")
+				if k8serrors.IsConflict(resizeErr) {
+					s.observeIdleClaim(templateID, "resize_conflict")
+					restoreCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+					if restoreErr := s.restoreIdlePodAfterHotClaimResizeConflict(restoreCtx, updatedPod, originalIdlePod); restoreErr != nil {
+						s.logger.Warn("Failed to restore idle pod after hot-claim resize conflict",
+							zap.String("sandboxID", sandboxID),
+							zap.String("pod", updatedPod.Name),
+							zap.Error(restoreErr),
+						)
+					}
+					cancel()
+					keepReservationUntilTTL()
+				} else {
+					s.observeIdleClaim(templateID, "resize_error")
+					s.requestSandboxDeletionAfterClaimFailure(updatedPod, "sandbox resource resize failed")
+				}
 				return fmt.Errorf("resize sandbox resources: %w", resizeErr)
 			}
 			updatedPod = mergeSandboxMetadataAfterResize(resizedPod, updatedPod)
@@ -1517,6 +1532,44 @@ func (s *SandboxService) requestSandboxDeletionAfterClaimFailure(pod *corev1.Pod
 			zap.Error(err),
 		)
 	}
+}
+
+func (s *SandboxService) restoreIdlePodAfterHotClaimResizeConflict(ctx context.Context, claimedPod, originalIdlePod *corev1.Pod) error {
+	if s == nil || s.k8sClient == nil || claimedPod == nil || originalIdlePod == nil {
+		return nil
+	}
+	if claimedPod.Namespace == "" || claimedPod.Name == "" {
+		return nil
+	}
+	namespace, name := claimedPod.Namespace, claimedPod.Name
+	claimedSandboxID := sandboxIDFromPod(claimedPod)
+
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current, err := s.k8sClient.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+		if current.DeletionTimestamp != nil {
+			return nil
+		}
+		if originalIdlePod.UID != "" && current.UID != "" && originalIdlePod.UID != current.UID {
+			return nil
+		}
+		if claimedSandboxID != "" && sandboxIDFromPod(current) != "" && sandboxIDFromPod(current) != claimedSandboxID {
+			return nil
+		}
+
+		restored := current.DeepCopy()
+		restored.Labels = cloneMetadataMap(originalIdlePod.Labels)
+		restored.Annotations = cloneMetadataMap(originalIdlePod.Annotations)
+		restored.Finalizers = append([]string(nil), originalIdlePod.Finalizers...)
+		restored.OwnerReferences = append([]metav1.OwnerReference(nil), originalIdlePod.OwnerReferences...)
+		_, err = s.k8sClient.CoreV1().Pods(namespace).Update(ctx, restored, metav1.UpdateOptions{})
+		return err
+	})
 }
 
 func (s *SandboxService) podDataPlaneReady(pod *corev1.Pod) bool {

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -573,6 +573,32 @@ func TestWaitForPodNetworkIdentityWaitsForNodeNameAndPodIP(t *testing.T) {
 	}
 }
 
+func TestWaitForPodNetworkIdentityUsesLivePodWhenInformerStale(t *testing.T) {
+	cachedPod := newClaimTestPod("ns-a", "cold-pod", "template-a", false)
+	livePod := cachedPod.DeepCopy()
+	livePod.Spec.NodeName = "node-a"
+	livePod.Status.PodIP = "10.244.0.10"
+	indexer := newClaimTestPodIndexer(t, cachedPod)
+	svc := &SandboxService{
+		k8sClient: fake.NewSimpleClientset(livePod),
+		podLister: corelisters.NewPodLister(indexer),
+		logger:    zap.NewNop(),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	readyPod, err := svc.waitForPodNetworkIdentity(ctx, cachedPod.Namespace, cachedPod.Name)
+	if err != nil {
+		t.Fatalf("waitForPodNetworkIdentity() error = %v", err)
+	}
+	if readyPod.Spec.NodeName != "node-a" {
+		t.Fatalf("node name = %q, want node-a", readyPod.Spec.NodeName)
+	}
+	if readyPod.Status.PodIP != "10.244.0.10" {
+		t.Fatalf("pod IP = %q, want 10.244.0.10", readyPod.Status.PodIP)
+	}
+}
+
 func TestCreateNewPodDefersNetworkApplyUntilPodHasNetworkIdentity(t *testing.T) {
 	withClaimTestPublicKey(t)
 

--- a/manager/pkg/service/sandbox_service_lifecycle.go
+++ b/manager/pkg/service/sandbox_service_lifecycle.go
@@ -827,7 +827,7 @@ func (s *SandboxService) UpdateSandbox(ctx context.Context, sandboxID string, cf
 		if resizeQuota != nil {
 			resizedPod, err := s.resizeSandboxPodResources(ctx, current, *resizeQuota)
 			if err != nil {
-				if rollbackBindings != nil {
+				if rollbackBindings != nil && !k8serrors.IsConflict(err) {
 					if rollbackErr := rollbackBindings(ctx); rollbackErr != nil {
 						s.logger.Warn("Failed to roll back credential bindings after sandbox resize failure",
 							zap.String("sandboxID", sandboxID),
@@ -841,7 +841,7 @@ func (s *SandboxService) UpdateSandbox(ctx context.Context, sandboxID string, cf
 		}
 
 		updatedPod, err = s.k8sClient.CoreV1().Pods(pod.Namespace).Update(ctx, updatedPod, metav1.UpdateOptions{})
-		if err != nil && rollbackBindings != nil {
+		if err != nil && rollbackBindings != nil && !k8serrors.IsConflict(err) {
 			if rollbackErr := rollbackBindings(ctx); rollbackErr != nil {
 				s.logger.Warn("Failed to roll back credential bindings after sandbox update failure",
 					zap.String("sandboxID", sandboxID),
@@ -1316,63 +1316,77 @@ func (s *SandboxService) RefreshSandbox(ctx context.Context, sandboxID string, r
 		return nil, fmt.Errorf("list pods: %w", err)
 	}
 
-	// Parse original config to get TTL and HardTTL values
-	var originalConfig SandboxConfig
-	if configJSON := pod.Annotations[controller.AnnotationConfig]; configJSON != "" {
-		if err := json.Unmarshal([]byte(configJSON), &originalConfig); err != nil {
-			s.logger.Warn("Failed to parse original config, using defaults", zap.Error(err))
-		}
-	}
-
-	// Update pod annotation
-	podCopy := pod.DeepCopy()
-	if podCopy.Annotations == nil {
-		podCopy.Annotations = make(map[string]string)
-	}
-	now := s.clock.Now()
 	var ttlDuration time.Duration
-
-	// Determine the TTL to apply. Explicit duration enables TTL for that duration; otherwise use original config/default.
-	var ttlToApply *int32
-	if req != nil {
-		if req.Duration < 0 {
-			return nil, fmt.Errorf("%w: duration must be >= 0", ErrInvalidClaimRequest)
-		}
-		if req.Duration > 0 {
-			ttlToApply = int32Ptr(req.Duration)
-		}
-	}
-	if ttlToApply == nil && originalConfig.TTL != nil {
-		ttlToApply = originalConfig.TTL
-	} else if ttlToApply == nil && s.config.DefaultTTL > 0 {
-		ttlToApply = int32Ptr(int32(s.config.DefaultTTL.Seconds()))
-	}
-	if ttlToApply != nil && *ttlToApply > 0 {
-		ttlDuration = time.Duration(*ttlToApply) * time.Second
-	}
-	if err := validateSandboxConfigLifecycle(ttlToApply, originalConfig.HardTTL); err != nil {
-		return nil, err
-	}
-	setExpirationAnnotation(podCopy.Annotations, now, ttlToApply)
-
-	newExpiresAt := parseRFC3339AnnotationTime(podCopy.Annotations, controller.AnnotationExpiresAt)
-
-	// Also refresh HardTTL if configured.
+	var newExpiresAt time.Time
 	var newHardExpiresAt time.Time
-	if originalConfig.HardTTL != nil && *originalConfig.HardTTL > 0 {
-		setHardExpirationAnnotation(podCopy.Annotations, now, originalConfig.HardTTL)
-		newHardExpiresAt = parseRFC3339AnnotationTime(podCopy.Annotations, controller.AnnotationHardExpiresAt)
-		s.logger.Info("Refreshing hard TTL",
-			zap.String("sandboxID", sandboxID),
-			zap.Time("newHardExpiresAt", newHardExpiresAt),
-			zap.Duration("hardTTLDuration", time.Duration(*originalConfig.HardTTL)*time.Second),
-		)
-	} else {
-		delete(podCopy.Annotations, controller.AnnotationHardExpiresAt)
-	}
 
-	// Apply the update
-	_, err = s.k8sClient.CoreV1().Pods(pod.Namespace).Update(ctx, podCopy, metav1.UpdateOptions{})
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current, err := s.k8sClient.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if sandboxIDFromPod(current) != sandboxID {
+			return k8serrors.NewNotFound(schema.GroupResource{Resource: "pod"}, sandboxID)
+		}
+
+		// Parse original config to get TTL and HardTTL values
+		var originalConfig SandboxConfig
+		if configJSON := current.Annotations[controller.AnnotationConfig]; configJSON != "" {
+			if err := json.Unmarshal([]byte(configJSON), &originalConfig); err != nil {
+				s.logger.Warn("Failed to parse original config, using defaults", zap.Error(err))
+			}
+		}
+
+		// Update pod annotation
+		podCopy := current.DeepCopy()
+		if podCopy.Annotations == nil {
+			podCopy.Annotations = make(map[string]string)
+		}
+		now := s.clock.Now()
+
+		// Determine the TTL to apply. Explicit duration enables TTL for that duration; otherwise use original config/default.
+		var ttlToApply *int32
+		if req != nil {
+			if req.Duration < 0 {
+				return fmt.Errorf("%w: duration must be >= 0", ErrInvalidClaimRequest)
+			}
+			if req.Duration > 0 {
+				ttlToApply = int32Ptr(req.Duration)
+			}
+		}
+		if ttlToApply == nil && originalConfig.TTL != nil {
+			ttlToApply = originalConfig.TTL
+		} else if ttlToApply == nil && s.config.DefaultTTL > 0 {
+			ttlToApply = int32Ptr(int32(s.config.DefaultTTL.Seconds()))
+		}
+		if ttlToApply != nil && *ttlToApply > 0 {
+			ttlDuration = time.Duration(*ttlToApply) * time.Second
+		}
+		if err := validateSandboxConfigLifecycle(ttlToApply, originalConfig.HardTTL); err != nil {
+			return err
+		}
+		setExpirationAnnotation(podCopy.Annotations, now, ttlToApply)
+
+		newExpiresAt = parseRFC3339AnnotationTime(podCopy.Annotations, controller.AnnotationExpiresAt)
+
+		// Also refresh HardTTL if configured.
+		newHardExpiresAt = time.Time{}
+		if originalConfig.HardTTL != nil && *originalConfig.HardTTL > 0 {
+			setHardExpirationAnnotation(podCopy.Annotations, now, originalConfig.HardTTL)
+			newHardExpiresAt = parseRFC3339AnnotationTime(podCopy.Annotations, controller.AnnotationHardExpiresAt)
+			s.logger.Info("Refreshing hard TTL",
+				zap.String("sandboxID", sandboxID),
+				zap.Time("newHardExpiresAt", newHardExpiresAt),
+				zap.Duration("hardTTLDuration", time.Duration(*originalConfig.HardTTL)*time.Second),
+			)
+		} else {
+			delete(podCopy.Annotations, controller.AnnotationHardExpiresAt)
+		}
+
+		// Apply the update
+		_, err = s.k8sClient.CoreV1().Pods(pod.Namespace).Update(ctx, podCopy, metav1.UpdateOptions{})
+		return err
+	})
 	if err != nil {
 		return nil, fmt.Errorf("update pod: %w", err)
 	}

--- a/manager/pkg/service/sandbox_service_network.go
+++ b/manager/pkg/service/sandbox_service_network.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 )
@@ -702,7 +703,7 @@ func (s *SandboxService) UpdateNetworkPolicy(
 		}
 
 		updatedPod, err = s.k8sClient.CoreV1().Pods(pod.Namespace).Update(ctx, updatedPod, metav1.UpdateOptions{})
-		if err != nil && rollbackBindings != nil {
+		if err != nil && rollbackBindings != nil && !k8serrors.IsConflict(err) {
 			if rollbackErr := rollbackBindings(ctx); rollbackErr != nil {
 				s.logger.Warn("Failed to roll back credential bindings after network policy update failure",
 					zap.String("sandboxID", sandboxID),

--- a/manager/pkg/service/sandbox_service_network_test.go
+++ b/manager/pkg/service/sandbox_service_network_test.go
@@ -17,8 +17,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/fake"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	k8stesting "k8s.io/client-go/testing"
@@ -29,6 +31,8 @@ type memoryBindingStore struct {
 	records        map[string]*egressauth.BindingRecord
 	sourcesByRef   map[string]*egressauth.CredentialSource
 	sourceVersions map[string]*egressauth.CredentialSourceVersion
+	upsertCalls    int
+	deleteCalls    int
 }
 
 func newMemoryBindingStore() *memoryBindingStore {
@@ -47,11 +51,13 @@ func (s *memoryBindingStore) UpsertBindings(_ context.Context, record *egressaut
 	if record == nil {
 		return nil
 	}
+	s.upsertCalls++
 	s.records[s.bindingKey(record.TeamID, record.SandboxID)] = cloneBindingRecord(record)
 	return nil
 }
 
 func (s *memoryBindingStore) DeleteBindings(_ context.Context, teamID, sandboxID string) error {
+	s.deleteCalls++
 	delete(s.records, s.bindingKey(teamID, sandboxID))
 	return nil
 }
@@ -216,6 +222,9 @@ func testSandboxNetworkPod() *corev1.Pod {
 				controller.AnnotationConfig: "{}",
 			},
 		},
+		Status: corev1.PodStatus{
+			PodIP: "10.0.0.2",
+		},
 	}
 }
 
@@ -295,6 +304,47 @@ func TestUpdateNetworkPolicyRollsBackBindingsWhenPodUpdateFails(t *testing.T) {
 	require.NotNil(t, record)
 	require.Len(t, record.Bindings, 1)
 	assert.Equal(t, "existing-ref", record.Bindings[0].Ref)
+}
+
+func TestUpdateNetworkPolicyDoesNotRollbackBindingsOnTransientConflict(t *testing.T) {
+	ctx := context.Background()
+	pod := testSandboxNetworkPod()
+	store := newMemoryBindingStore()
+	store.addStaticHeadersSource("team-1", "new-ref", 2, 1, map[string]string{"token": "new"})
+	require.NoError(t, store.UpsertBindings(ctx, &egressauth.BindingRecord{
+		SandboxID: pod.Name,
+		TeamID:    "team-1",
+		Bindings: []egressauth.CredentialBinding{{
+			Ref:           "existing-ref",
+			SourceRef:     "existing-ref",
+			SourceID:      1,
+			SourceVersion: 1,
+			Projection:    egressauth.ProjectionSpec{Type: egressauth.CredentialProjectionTypeHTTPHeaders},
+		}},
+	}))
+	initialUpserts := store.upsertCalls
+
+	svc, client, _ := newSandboxServiceForNetworkTests(t, pod, store, network.NewNoopProvider())
+	updates := 0
+	client.PrependReactor("update", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		updates++
+		if updates == 1 {
+			return true, nil, apierrors.NewConflict(schema.GroupResource{Resource: "pods"}, pod.Name, errors.New("stale pod"))
+		}
+		return false, nil, nil
+	})
+
+	_, err := svc.UpdateNetworkPolicy(ctx, pod.Name, testNetworkPolicy("new-ref", "Bearer new"))
+	require.NoError(t, err)
+	assert.Equal(t, 2, updates)
+	assert.Equal(t, initialUpserts+2, store.upsertCalls)
+	assert.Equal(t, 0, store.deleteCalls)
+
+	record, err := store.GetBindings(ctx, "team-1", pod.Name)
+	require.NoError(t, err)
+	require.NotNil(t, record)
+	require.Len(t, record.Bindings, 1)
+	assert.Equal(t, "new-ref", record.Bindings[0].Ref)
 }
 
 func TestUpdateNetworkPolicyRejectsInvalidEgressPolicy(t *testing.T) {
@@ -426,6 +476,49 @@ func TestUpdateSandboxRollsBackBindingsWhenPodUpdateFails(t *testing.T) {
 	require.NotNil(t, record)
 	require.Len(t, record.Bindings, 1)
 	assert.Equal(t, "existing-ref", record.Bindings[0].Ref)
+}
+
+func TestUpdateSandboxDoesNotRollbackBindingsOnTransientConflict(t *testing.T) {
+	ctx := context.Background()
+	pod := testSandboxNetworkPod()
+	store := newMemoryBindingStore()
+	store.addStaticHeadersSource("team-1", "new-ref", 2, 1, map[string]string{"token": "new"})
+	require.NoError(t, store.UpsertBindings(ctx, &egressauth.BindingRecord{
+		SandboxID: pod.Name,
+		TeamID:    "team-1",
+		Bindings: []egressauth.CredentialBinding{{
+			Ref:           "existing-ref",
+			SourceRef:     "existing-ref",
+			SourceID:      1,
+			SourceVersion: 1,
+			Projection:    egressauth.ProjectionSpec{Type: egressauth.CredentialProjectionTypeHTTPHeaders},
+		}},
+	}))
+	initialUpserts := store.upsertCalls
+
+	svc, client, _ := newSandboxServiceForNetworkTests(t, pod, store, network.NewNoopProvider())
+	updates := 0
+	client.PrependReactor("update", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		updates++
+		if updates == 1 {
+			return true, nil, apierrors.NewConflict(schema.GroupResource{Resource: "pods"}, pod.Name, errors.New("stale pod"))
+		}
+		return false, nil, nil
+	})
+
+	_, err := svc.UpdateSandbox(ctx, pod.Name, &SandboxUpdateConfig{
+		Network: testNetworkPolicy("new-ref", "Bearer new"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, updates)
+	assert.Equal(t, initialUpserts+2, store.upsertCalls)
+	assert.Equal(t, 0, store.deleteCalls)
+
+	record, err := store.GetBindings(ctx, "team-1", pod.Name)
+	require.NoError(t, err)
+	require.NotNil(t, record)
+	require.Len(t, record.Bindings, 1)
+	assert.Equal(t, "new-ref", record.Bindings[0].Ref)
 }
 
 func TestRequestCredentialBindingsUsesNetworkBindings(t *testing.T) {

--- a/manager/pkg/service/sandbox_service_pod.go
+++ b/manager/pkg/service/sandbox_service_pod.go
@@ -13,7 +13,10 @@ import (
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+const podNetworkIdentityLiveProbeInterval = time.Second
 
 func (s *SandboxService) prodAddress(ctx context.Context, pod *corev1.Pod) (string, error) {
 	if pod == nil {
@@ -109,6 +112,34 @@ func (s *SandboxService) waitForPodNetworkIdentity(ctx context.Context, namespac
 	defer ticker.Stop()
 
 	lastReason := "pod network identity is not ready"
+	var lastLiveProbe time.Time
+	probeLive := func() (*corev1.Pod, bool, string) {
+		if s.k8sClient == nil {
+			return nil, false, ""
+		}
+		now := time.Now()
+		if !lastLiveProbe.IsZero() && now.Sub(lastLiveProbe) < podNetworkIdentityLiveProbeInterval {
+			return nil, false, ""
+		}
+		lastLiveProbe = now
+		pod, err := s.k8sClient.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				reason := fmt.Sprintf("pod %s/%s is not visible", namespace, name)
+				s.observePodNetworkIdentityCheck("live", "waiting", reason)
+				return nil, false, reason
+			}
+			s.observePodNetworkIdentityCheck("live", "error", "get pod for network identity")
+			return nil, false, ""
+		}
+		ready, reason := isPodNetworkIdentityReady(pod)
+		if ready {
+			s.observePodNetworkIdentityCheck("live", "ready", "ready")
+			return pod, true, "ready"
+		}
+		s.observePodNetworkIdentityCheck("live", "waiting", reason)
+		return nil, false, reason
+	}
 	for {
 		if s.podLister == nil {
 			return nil, fmt.Errorf("pod lister is not configured")
@@ -117,29 +148,78 @@ func (s *SandboxService) waitForPodNetworkIdentity(ctx context.Context, namespac
 		if err != nil {
 			if k8serrors.IsNotFound(err) {
 				lastReason = fmt.Sprintf("pod %s/%s is not visible", namespace, name)
+				if livePod, ok, liveReason := probeLive(); ok {
+					return livePod, nil
+				} else if liveReason != "" {
+					lastReason = liveReason
+				}
 				select {
 				case <-readyCtx.Done():
+					s.observePodNetworkIdentityCheck("cache", "timeout", lastReason)
 					return nil, fmt.Errorf("pod %s/%s network identity not ready after %s: %s", namespace, name, timeout, lastReason)
 				case <-ticker.C:
 					continue
 				}
 			}
+			s.observePodNetworkIdentityCheck("cache", "error", "get pod for network identity")
 			return nil, fmt.Errorf("get pod for network identity: %w", err)
 		}
 
 		ready, reason := isPodNetworkIdentityReady(pod)
 		if ready {
+			s.observePodNetworkIdentityCheck("cache", "ready", "ready")
 			return pod, nil
 		}
 		if reason != "" {
 			lastReason = reason
 		}
+		if livePod, ok, liveReason := probeLive(); ok {
+			return livePod, nil
+		} else if liveReason != "" {
+			lastReason = liveReason
+		}
 
 		select {
 		case <-readyCtx.Done():
+			s.observePodNetworkIdentityCheck("cache", "timeout", lastReason)
 			return nil, fmt.Errorf("pod %s/%s network identity not ready after %s: %s", namespace, name, timeout, lastReason)
 		case <-ticker.C:
 		}
+	}
+}
+
+func (s *SandboxService) observePodNetworkIdentityCheck(source, result, reason string) {
+	if s == nil || s.metrics == nil || s.metrics.PodNetworkIdentityChecksTotal == nil {
+		return
+	}
+	if source == "" {
+		source = "unknown"
+	}
+	if result == "" {
+		result = "unknown"
+	}
+	s.metrics.PodNetworkIdentityChecksTotal.WithLabelValues(source, result, podNetworkIdentityReasonLabel(reason)).Inc()
+}
+
+func podNetworkIdentityReasonLabel(reason string) string {
+	reason = strings.ToLower(strings.TrimSpace(reason))
+	switch {
+	case reason == "" || reason == "ready":
+		return "ready"
+	case strings.Contains(reason, "not visible") || strings.Contains(reason, "not found"):
+		return "not_found"
+	case strings.Contains(reason, "node is not assigned"):
+		return "node_unassigned"
+	case strings.Contains(reason, "ip is not assigned"):
+		return "ip_unassigned"
+	case strings.Contains(reason, "phase is terminal"):
+		return "terminal"
+	case strings.Contains(reason, "deleting"):
+		return "deleting"
+	case strings.Contains(reason, "get pod"):
+		return "get_error"
+	default:
+		return "not_ready"
 	}
 }
 

--- a/manager/pkg/service/sandbox_service_resources.go
+++ b/manager/pkg/service/sandbox_service_resources.go
@@ -11,6 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
 )
 
 const (
@@ -46,16 +47,34 @@ func (s *SandboxService) resizeSandboxPodResources(ctx context.Context, pod *cor
 	if s == nil || s.k8sClient == nil {
 		return nil, fmt.Errorf("%w: kubernetes client is not configured", ErrInvalidClaimRequest)
 	}
-	resized := pod.DeepCopy()
-	if err := s.applySandboxResourceQuota(resized, quota); err != nil {
-		return nil, err
+	if pod == nil || pod.Namespace == "" || pod.Name == "" {
+		return nil, fmt.Errorf("%w: pod is required", ErrInvalidClaimRequest)
 	}
-	updated, err := s.k8sClient.CoreV1().Pods(resized.Namespace).UpdateResize(ctx, resized.Name, resized, metav1.UpdateOptions{})
+
+	namespace, name := pod.Namespace, pod.Name
+	var updated *corev1.Pod
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current, err := s.k8sClient.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		resized := current.DeepCopy()
+		if err := s.applySandboxResourceQuota(resized, quota); err != nil {
+			return err
+		}
+		result, err := s.k8sClient.CoreV1().Pods(namespace).UpdateResize(ctx, name, resized, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+		if result == nil || result.Name == "" {
+			updated = resized
+		} else {
+			updated = result
+		}
+		return nil
+	})
 	if err != nil {
 		return nil, err
-	}
-	if updated == nil || updated.Name == "" {
-		return resized, nil
 	}
 	return updated, nil
 }

--- a/manager/pkg/service/sandbox_service_resources_test.go
+++ b/manager/pkg/service/sandbox_service_resources_test.go
@@ -14,8 +14,11 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/quota"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/fake"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	k8stesting "k8s.io/client-go/testing"
@@ -129,6 +132,106 @@ func TestClaimIdlePodAppliesMemoryOverride(t *testing.T) {
 	assertQuantity(t, container.Resources.Limits[corev1.ResourceMemory], "2Gi")
 	assertQuantity(t, container.Resources.Limits[corev1.ResourceCPU], "500m")
 	assertResizeSubresourceUpdate(t, client.Actions())
+}
+
+func TestResizeSandboxPodResourcesRetriesConflictWithFreshPod(t *testing.T) {
+	template := newSandboxResourceTestTemplate(t)
+	pod := newSandboxResourceTestActivePod(t, template, "sandbox-1")
+	client := fake.NewSimpleClientset(pod.DeepCopy())
+	resizeUpdates := 0
+	client.PrependReactor("update", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() != "resize" {
+			return false, nil, nil
+		}
+		resizeUpdates++
+		if resizeUpdates == 1 {
+			return true, nil, apierrors.NewConflict(schema.GroupResource{Resource: "pods"}, pod.Name, errors.New("stale pod"))
+		}
+		return false, nil, nil
+	})
+	svc := &SandboxService{
+		k8sClient: client,
+		config:    SandboxServiceConfig{SandboxMemoryPerCPU: "4Gi"},
+		logger:    zap.NewNop(),
+	}
+	quota, err := svc.effectiveSandboxResourceQuota(template, &SandboxConfig{
+		Resources: &SandboxResourceConfig{Memory: "2Gi"},
+	})
+	if err != nil {
+		t.Fatalf("effectiveSandboxResourceQuota() error = %v", err)
+	}
+
+	resized, err := svc.resizeSandboxPodResources(context.Background(), pod, quota)
+	if err != nil {
+		t.Fatalf("resizeSandboxPodResources() error = %v", err)
+	}
+	if resizeUpdates != 2 {
+		t.Fatalf("resize update calls = %d, want 2", resizeUpdates)
+	}
+	container := sandboxRuntimeContainer(t, resized)
+	assertQuantity(t, container.Resources.Limits[corev1.ResourceMemory], "2Gi")
+	assertQuantity(t, container.Resources.Limits[corev1.ResourceCPU], "500m")
+}
+
+func TestClaimIdlePodRestoresIdlePodAfterResizeConflict(t *testing.T) {
+	template := newSandboxResourceTestTemplate(t)
+	idlePod := newSandboxResourceTestIdlePod(t, template, "idle-ready")
+	node := newClaimTestNode("node-a", "10.0.0.1")
+	node.Labels = map[string]string{dataplane.NodeDataPlaneReadyLabel: dataplane.ReadyLabelValue}
+	idlePod.Spec.NodeName = node.Name
+	client := fake.NewSimpleClientset(idlePod.DeepCopy(), node.DeepCopy())
+	resizeUpdates := 0
+	deletes := 0
+	client.PrependReactor("update", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() != "resize" {
+			return false, nil, nil
+		}
+		resizeUpdates++
+		return true, nil, apierrors.NewConflict(schema.GroupResource{Resource: "pods"}, idlePod.Name, errors.New("stale pod"))
+	})
+	client.PrependReactor("delete", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		deletes++
+		return false, nil, nil
+	})
+	svc := &SandboxService{
+		k8sClient:  client,
+		podLister:  newClaimTestPodLister(t, idlePod),
+		nodeLister: newClaimTestNodeLister(t, node),
+		clock:      systemTime{},
+		config:     SandboxServiceConfig{SandboxMemoryPerCPU: "4Gi"},
+		logger:     zap.NewNop(),
+	}
+
+	pod, err := svc.claimIdlePod(context.Background(), template, &ClaimRequest{
+		TeamID: "team-a",
+		UserID: "user-a",
+		Config: &SandboxConfig{Resources: &SandboxResourceConfig{Memory: "2Gi"}},
+	})
+	if err != nil {
+		t.Fatalf("claimIdlePod() error = %v", err)
+	}
+	if pod != nil {
+		t.Fatalf("claimIdlePod() = %s, want nil after resize conflict", pod.Name)
+	}
+	if resizeUpdates == 0 {
+		t.Fatal("resize updates = 0, want at least one resize attempt")
+	}
+	if deletes != 0 {
+		t.Fatalf("delete calls = %d, want 0", deletes)
+	}
+	stored, err := client.CoreV1().Pods(idlePod.Namespace).Get(context.Background(), idlePod.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get stored pod: %v", err)
+	}
+	if got := stored.Labels[controller.LabelPoolType]; got != controller.PoolTypeIdle {
+		t.Fatalf("pool-type = %q, want %q", got, controller.PoolTypeIdle)
+	}
+	if got := stored.Labels[controller.LabelSandboxID]; got != "" {
+		t.Fatalf("sandbox label = %q, want empty", got)
+	}
+	if got := stored.Annotations[controller.AnnotationSandboxID]; got != "" {
+		t.Fatalf("sandbox annotation = %q, want empty", got)
+	}
 }
 
 func TestUpdateSandboxAppliesMemoryResourcesAndPersistsConfig(t *testing.T) {

--- a/manager/pkg/service/sandbox_service_ttl_test.go
+++ b/manager/pkg/service/sandbox_service_ttl_test.go
@@ -17,9 +17,13 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/fake"
 	corelisters "k8s.io/client-go/listers/core/v1"
+	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -366,6 +370,37 @@ func TestRefreshSandboxRejectsInvalidTTLState(t *testing.T) {
 			assert.Equal(t, "2026-03-07T12:10:00Z", stored.Annotations[controller.AnnotationHardExpiresAt])
 		})
 	}
+}
+
+func TestRefreshSandboxRetriesPodUpdateConflict(t *testing.T) {
+	pod := testSandboxPod()
+	pod.Annotations[controller.AnnotationConfig] = `{"ttl":300,"hard_ttl":600}`
+
+	svc, client := newSandboxServiceForTTLTests(t, pod, 0)
+	updates := 0
+	client.PrependReactor("update", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() != "" {
+			return false, nil, nil
+		}
+		updates++
+		if updates == 1 {
+			return true, nil, apierrors.NewConflict(schema.GroupResource{Resource: "pods"}, pod.Name, errors.New("stale pod"))
+		}
+		return false, nil, nil
+	})
+
+	resp, err := svc.RefreshSandbox(context.Background(), pod.Name, &RefreshRequest{Duration: 120})
+	require.NoError(t, err)
+	if updates != 2 {
+		t.Fatalf("pod update calls = %d, want 2", updates)
+	}
+	assert.Equal(t, time.Date(2026, time.March, 7, 12, 2, 0, 0, time.UTC), resp.ExpiresAt)
+	assert.Equal(t, time.Date(2026, time.March, 7, 12, 10, 0, 0, time.UTC), resp.HardExpiresAt)
+
+	stored, err := client.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "2026-03-07T12:02:00Z", stored.Annotations[controller.AnnotationExpiresAt])
+	assert.Equal(t, "2026-03-07T12:10:00Z", stored.Annotations[controller.AnnotationHardExpiresAt])
 }
 
 func configurePodForProcdServer(t *testing.T, pod *corev1.Pod, rawURL string) int {

--- a/manager/pkg/service/template_service.go
+++ b/manager/pkg/service/template_service.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/util/retry"
 )
 
 const (
@@ -159,14 +160,22 @@ func (s *TemplateService) UpdateTemplate(ctx context.Context, template *v1alpha1
 		return nil, fmt.Errorf("get current template: %w", err)
 	}
 	namespace := current.Namespace
-	template.Namespace = namespace
+	desired := template.DeepCopy()
+	desired.Namespace = namespace
 
-	template.ResourceVersion = current.ResourceVersion
-
-	// Preserve status
-	template.Status = current.Status
-
-	result, err := s.crdClient.Sandbox0V1alpha1().SandboxTemplates(namespace).Update(ctx, template, metav1.UpdateOptions{})
+	var result *v1alpha1.SandboxTemplate
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current, err := s.crdClient.Sandbox0V1alpha1().SandboxTemplates(namespace).Get(ctx, desired.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		updated := desired.DeepCopy()
+		updated.ResourceVersion = current.ResourceVersion
+		// Preserve status
+		updated.Status = current.Status
+		result, err = s.crdClient.Sandbox0V1alpha1().SandboxTemplates(namespace).Update(ctx, updated, metav1.UpdateOptions{})
+		return err
+	})
 	if err != nil {
 		return nil, fmt.Errorf("update template: %w", err)
 	}
@@ -395,24 +404,36 @@ func (s *TemplateService) ensureRegistryPullSecret(ctx context.Context, namespac
 		},
 	}
 
-	existing, err := s.k8sClient.CoreV1().Secrets(namespace).Get(ctx, s.registry.PullSecretName, metav1.GetOptions{})
+	_, err = s.k8sClient.CoreV1().Secrets(namespace).Get(ctx, s.registry.PullSecretName, metav1.GetOptions{})
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			return fmt.Errorf("get registry pull secret: %w", err)
 		}
 		if _, err := s.k8sClient.CoreV1().Secrets(namespace).Create(ctx, secret, metav1.CreateOptions{}); err != nil {
-			return fmt.Errorf("create registry pull secret: %w", err)
+			if !errors.IsAlreadyExists(err) {
+				return fmt.Errorf("create registry pull secret: %w", err)
+			}
+		} else {
+			return s.ensureDefaultServiceAccountPullSecret(ctx, namespace, s.registry.PullSecretName)
 		}
-	} else {
-		updated := existing.DeepCopy()
+	}
+
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current, err := s.k8sClient.CoreV1().Secrets(namespace).Get(ctx, s.registry.PullSecretName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		updated := current.DeepCopy()
 		updated.Type = corev1.SecretTypeDockerConfigJson
 		if updated.Data == nil {
 			updated.Data = map[string][]byte{}
 		}
 		updated.Data[corev1.DockerConfigJsonKey] = creds
-		if _, err := s.k8sClient.CoreV1().Secrets(namespace).Update(ctx, updated, metav1.UpdateOptions{}); err != nil {
-			return fmt.Errorf("update registry pull secret: %w", err)
-		}
+		_, err = s.k8sClient.CoreV1().Secrets(namespace).Update(ctx, updated, metav1.UpdateOptions{})
+		return err
+	})
+	if err != nil {
+		return fmt.Errorf("update registry pull secret: %w", err)
 	}
 
 	return s.ensureDefaultServiceAccountPullSecret(ctx, namespace, s.registry.PullSecretName)
@@ -448,12 +469,30 @@ func (s *TemplateService) ensureDefaultServiceAccountPullSecret(ctx context.Cont
 
 	sa.ImagePullSecrets = append(sa.ImagePullSecrets, corev1.LocalObjectReference{Name: secretName})
 	if sa.ResourceVersion == "" {
-		if _, err := s.k8sClient.CoreV1().ServiceAccounts(namespace).Create(ctx, sa, metav1.CreateOptions{}); err != nil && !errors.IsAlreadyExists(err) {
-			return fmt.Errorf("create default serviceaccount: %w", err)
+		if _, err := s.k8sClient.CoreV1().ServiceAccounts(namespace).Create(ctx, sa, metav1.CreateOptions{}); err != nil {
+			if !errors.IsAlreadyExists(err) {
+				return fmt.Errorf("create default serviceaccount: %w", err)
+			}
+		} else {
+			return nil
 		}
-		return nil
 	}
-	if _, err := s.k8sClient.CoreV1().ServiceAccounts(namespace).Update(ctx, sa, metav1.UpdateOptions{}); err != nil {
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current, err := s.k8sClient.CoreV1().ServiceAccounts(namespace).Get(ctx, "default", metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		updated := current.DeepCopy()
+		for _, ref := range updated.ImagePullSecrets {
+			if ref.Name == secretName {
+				return nil
+			}
+		}
+		updated.ImagePullSecrets = append(updated.ImagePullSecrets, corev1.LocalObjectReference{Name: secretName})
+		_, err = s.k8sClient.CoreV1().ServiceAccounts(namespace).Update(ctx, updated, metav1.UpdateOptions{})
+		return err
+	})
+	if err != nil {
 		return fmt.Errorf("update default serviceaccount: %w", err)
 	}
 	return nil

--- a/pkg/observability/metrics/manager.go
+++ b/pkg/observability/metrics/manager.go
@@ -14,6 +14,7 @@ type ManagerMetrics struct {
 	SandboxClaimDuration           *prometheus.HistogramVec
 	SandboxClaimPhaseDuration      *prometheus.HistogramVec
 	SandboxIdleClaimsTotal         *prometheus.CounterVec
+	PodNetworkIdentityChecksTotal  *prometheus.CounterVec
 	NetworkPolicyApplyTotal        *prometheus.CounterVec
 	NetworkPolicyApplyDuration     *prometheus.HistogramVec
 	K8sClientRateLimit             *prometheus.GaugeVec
@@ -77,6 +78,10 @@ func NewManager(registry prometheus.Registerer) *ManagerMetrics {
 			Name: "manager_sandbox_idle_claims_total",
 			Help: "Total number of idle-pool claim attempts by result",
 		}, []string{"template", "result"}),
+		PodNetworkIdentityChecksTotal: factory.NewCounterVec(prometheus.CounterOpts{
+			Name: "manager_pod_network_identity_checks_total",
+			Help: "Total number of pod network identity readiness checks by source, result, and reason",
+		}, []string{"source", "result", "reason"}),
 		NetworkPolicyApplyTotal: factory.NewCounterVec(prometheus.CounterOpts{
 			Name: "manager_network_policy_apply_total",
 			Help: "Total number of network policy apply attempts by provider and result",


### PR DESCRIPTION
## Summary
- retry UpdateResize and selected pod/ReplicaSet/template/bootstrap updates from fresh Kubernetes objects
- preserve hot idle pods on resize conflicts instead of deleting them, and restore idle metadata for later reuse
- avoid credential binding rollback on transient pod update conflicts and add pod network-identity live GET fallback plus metrics

## Tests
- go test ./manager/... -count=1 -timeout 300s
- go test ./manager/pkg/service -run 'Test(ResizeSandboxPodResourcesRetriesConflictWithFreshPod|ClaimIdlePodRestoresIdlePodAfterResizeConflict|RefreshSandboxRetriesPodUpdateConflict|UpdateNetworkPolicyDoesNotRollbackBindingsOnTransientConflict|UpdateSandboxDoesNotRollbackBindingsOnTransientConflict|WaitForPodNetworkIdentityUsesLivePodWhenInformerStale)$' -count=1 -v -timeout 120s\n- go test ./... -count=1 -timeout 600s (fails locally before/aside from this change: missing generated package github.com/sandbox0-ai/sandbox0/storage-proxy/proto/fs; e2e requires kind, which is not installed in this environment)\n