### PR TITLE
Allow sandbox fork lifecycle overrides

### DIFF
--- a/docs/sandbox/snapshot-restore/page.mdx
+++ b/docs/sandbox/snapshot-restore/page.mdx
@@ -33,7 +33,7 @@ Use [Volumes](/docs/sandbox/volume) when data must be mounted by multiple sandbo
 - `Create snapshot` reads the paused sandbox's current rootfs head and creates a snapshot record.
 - `Claim with snapshot_id` creates a running sandbox and initializes its writable rootfs from the selected snapshot before process APIs are initialized.
 - `Restore` changes a paused target sandbox rootfs head to the selected snapshot and leaves the sandbox paused.
-- `Fork` creates a new paused sandbox with the source sandbox configuration and an isolated rootfs fork.
+- `Fork` creates a new paused sandbox with the source sandbox configuration and an isolated rootfs fork. The fork request can override lifecycle `ttl` and `hard_ttl`.
 - `Resume` is required before reading or writing files through sandbox process and file APIs after restore or fork. A sandbox claimed with `snapshot_id` starts running.
 - Deleting a snapshot does not modify any sandbox already claimed or restored from it, and it does not affect forks created from the same rootfs state.
 
@@ -412,6 +412,15 @@ Fork creates a new paused sandbox from a paused source sandbox rootfs. The fork 
 <Endpoint method="POST">
 /api/v1/sandboxes/{'{id}'}/fork
 </Endpoint>
+
+Omit the request body to inherit the source sandbox lifecycle configuration. To set a new lifecycle window for the fork, pass `config.ttl` and/or `config.hard_ttl`. Positive values are counted from the fork creation time, and `0` disables that expiration path.
+
+    {
+        "config": {
+            "ttl": 300,
+            "hard_ttl": 3600
+        }
+    }
 
 <Tabs
   tabs={[

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -112,10 +112,19 @@ func cloneSandboxConfig(cfg *SandboxConfig) *SandboxConfig {
 	cloned := *cfg
 	cloned.EnvVars = cloneEnvVars(cfg.EnvVars)
 	cloned.Resources = cloneSandboxResourceConfig(cfg.Resources)
+	cloned.TTL = cloneInt32Ptr(cfg.TTL)
+	cloned.HardTTL = cloneInt32Ptr(cfg.HardTTL)
 	if cloned.Network != nil {
 		cloned.Network = sanitizedNetworkPolicyForPersistence(cloned.Network)
 	}
 	return &cloned
+}
+
+func cloneInt32Ptr(v *int32) *int32 {
+	if v == nil {
+		return nil
+	}
+	return int32Ptr(*v)
 }
 
 func cloneSandboxResourceConfig(resources *SandboxResourceConfig) *SandboxResourceConfig {

--- a/manager/pkg/service/sandbox_service_rootfs_product.go
+++ b/manager/pkg/service/sandbox_service_rootfs_product.go
@@ -73,7 +73,14 @@ type RestoreSandboxRootFSResponse struct {
 	Status     string `json:"status"`
 }
 
-type ForkSandboxRequest struct{}
+type ForkSandboxRequest struct {
+	Config *ForkSandboxConfig `json:"config,omitempty"`
+}
+
+type ForkSandboxConfig struct {
+	TTL     *int32 `json:"ttl,omitempty"`
+	HardTTL *int32 `json:"hard_ttl,omitempty"`
+}
 
 type ForkSandboxResponse struct {
 	SourceSandboxID string   `json:"source_sandbox_id"`
@@ -225,10 +232,13 @@ func (s *SandboxService) RestoreSandboxRootFS(ctx context.Context, sandboxID, te
 	}, nil
 }
 
-func (s *SandboxService) ForkSandbox(ctx context.Context, sourceSandboxID, teamID, userID string, _ *ForkSandboxRequest) (*ForkSandboxResponse, error) {
+func (s *SandboxService) ForkSandbox(ctx context.Context, sourceSandboxID, teamID, userID string, req *ForkSandboxRequest) (*ForkSandboxResponse, error) {
 	store, err := s.rootFSProductStore()
 	if err != nil {
 		return nil, err
+	}
+	if req == nil {
+		req = &ForkSandboxRequest{}
 	}
 	sourceSandboxID = strings.TrimSpace(sourceSandboxID)
 	teamID = strings.TrimSpace(teamID)
@@ -242,7 +252,7 @@ func (s *SandboxService) ForkSandbox(ctx context.Context, sourceSandboxID, teamI
 
 	var source *SandboxRecord
 	if err := s.sandboxStore.WithSandboxLock(ctx, sourceSandboxID, func(lockCtx context.Context, _ SandboxStoreTx, record *SandboxRecord) error {
-		if err := validateRootFSSandboxRecord(record, sourceSandboxID, teamID, true); err != nil {
+		if err := validateForkSourceSandboxRecord(record, sourceSandboxID, teamID, s.now()); err != nil {
 			return err
 		}
 		source = cloneSandboxRecordForRootFSProduct(record)
@@ -258,8 +268,19 @@ func (s *SandboxService) ForkSandbox(ctx context.Context, sourceSandboxID, teamI
 	if err != nil {
 		return nil, err
 	}
-	now := s.clock.Now().UTC()
+	now := s.now().UTC()
 	targetConfig := cloneSandboxConfigValue(source.Config)
+	if req.Config != nil {
+		if req.Config.TTL != nil {
+			targetConfig.TTL = cloneInt32Ptr(req.Config.TTL)
+		}
+		if req.Config.HardTTL != nil {
+			targetConfig.HardTTL = cloneInt32Ptr(req.Config.HardTTL)
+		}
+	}
+	if err := validateSandboxConfigLifecycle(targetConfig.TTL, targetConfig.HardTTL); err != nil {
+		return nil, err
+	}
 	expiresAt := expirationFromTTL(now, targetConfig.TTL)
 	if expiresAt.IsZero() && targetConfig.TTL == nil {
 		expiresAt = source.ExpiresAt
@@ -286,7 +307,7 @@ func (s *SandboxService) ForkSandbox(ctx context.Context, sourceSandboxID, teamI
 		UpdatedAt:         now,
 	}
 	err = s.sandboxStore.WithSandboxLock(ctx, sourceSandboxID, func(lockCtx context.Context, tx SandboxStoreTx, record *SandboxRecord) error {
-		if err := validateRootFSSandboxRecord(record, sourceSandboxID, teamID, true); err != nil {
+		if err := validateForkSourceSandboxRecord(record, sourceSandboxID, teamID, s.now()); err != nil {
 			return err
 		}
 		upserter := sandboxRecordUpserter(s.sandboxStore)
@@ -311,7 +332,7 @@ func (s *SandboxService) ForkSandbox(ctx context.Context, sourceSandboxID, teamI
 			if txBacked {
 				return err
 			}
-			if cleanupErr := s.sandboxStore.MarkSandboxDeleted(lockCtx, targetID, s.clock.Now().UTC()); cleanupErr != nil && s.logger != nil {
+			if cleanupErr := s.sandboxStore.MarkSandboxDeleted(lockCtx, targetID, s.now().UTC()); cleanupErr != nil && s.logger != nil {
 				s.logger.Warn("Failed to clean up sandbox record after rootfs fork failure",
 					zap.String("sandboxID", targetID),
 					zap.Error(cleanupErr),
@@ -384,6 +405,16 @@ func validateRootFSSandboxRecord(record *SandboxRecord, sandboxID, teamID string
 	}
 	if requirePaused && record.Status != SandboxStatusPaused {
 		return fmt.Errorf("%w: current status is %s", ErrSandboxRootFSRequiresPausedSandbox, record.Status)
+	}
+	return nil
+}
+
+func validateForkSourceSandboxRecord(record *SandboxRecord, sandboxID, teamID string, now time.Time) error {
+	if err := validateRootFSSandboxRecord(record, sandboxID, teamID, true); err != nil {
+		return err
+	}
+	if sandboxHardExpired(record.HardExpiresAt, now) {
+		return apierrors.NewNotFound(schema.GroupResource{Resource: "sandbox"}, sandboxID)
 	}
 	return nil
 }

--- a/manager/pkg/service/sandbox_service_rootfs_product_test.go
+++ b/manager/pkg/service/sandbox_service_rootfs_product_test.go
@@ -146,6 +146,144 @@ func TestSandboxRootFSProductForkSetsLifecycleExpirations(t *testing.T) {
 	assert.Equal(t, wantHardExpiresAt, stored.HardExpiresAt)
 }
 
+func TestSandboxRootFSProductForkOverridesLifecycleConfig(t *testing.T) {
+	claimedAt := time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC)
+	forkedAt := claimedAt.Add(5 * time.Minute)
+	source := rootFSProductTestRecord("sandbox-1", "team-1", SandboxStatusPaused, claimedAt)
+	source.Config.TTL = int32Ptr(900)
+	source.Config.HardTTL = int32Ptr(1800)
+	source.ExpiresAt = claimedAt.Add(15 * time.Minute)
+	source.HardExpiresAt = claimedAt.Add(30 * time.Minute)
+	store := &memorySandboxStore{
+		records: map[string]*SandboxRecord{
+			"sandbox-1": source,
+		},
+		rootFSStates: map[string]*SandboxRootFSState{
+			"sandbox-1": rootFSProductTestState("sandbox-1", "team-1", "layer-v1"),
+		},
+	}
+	svc := rootFSProductTestService(store)
+	svc.clock = fixedClock{now: forkedAt}
+	ttl := int32(60)
+	hardTTL := int32(120)
+
+	forkResp, err := svc.ForkSandbox(context.Background(), "sandbox-1", "team-1", "user-2", &ForkSandboxRequest{
+		Config: &ForkSandboxConfig{
+			TTL:     &ttl,
+			HardTTL: &hardTTL,
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, forkResp)
+	require.NotNil(t, forkResp.Sandbox)
+	wantExpiresAt := forkedAt.Add(time.Minute)
+	wantHardExpiresAt := forkedAt.Add(2 * time.Minute)
+	assert.Equal(t, wantExpiresAt, forkResp.Sandbox.ExpiresAt)
+	assert.Equal(t, wantHardExpiresAt, forkResp.Sandbox.HardExpiresAt)
+	stored := store.records[forkResp.Sandbox.ID]
+	require.NotNil(t, stored)
+	require.NotNil(t, stored.Config.TTL)
+	require.NotNil(t, stored.Config.HardTTL)
+	assert.Equal(t, ttl, *stored.Config.TTL)
+	assert.Equal(t, hardTTL, *stored.Config.HardTTL)
+	assert.Equal(t, wantExpiresAt, stored.ExpiresAt)
+	assert.Equal(t, wantHardExpiresAt, stored.HardExpiresAt)
+	assert.Equal(t, int32(900), *store.records["sandbox-1"].Config.TTL)
+	assert.Equal(t, int32(1800), *store.records["sandbox-1"].Config.HardTTL)
+}
+
+func TestSandboxRootFSProductForkCanDisableInheritedLifecycleConfig(t *testing.T) {
+	claimedAt := time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC)
+	forkedAt := claimedAt.Add(5 * time.Minute)
+	source := rootFSProductTestRecord("sandbox-1", "team-1", SandboxStatusPaused, claimedAt)
+	source.Config.TTL = int32Ptr(900)
+	source.Config.HardTTL = int32Ptr(1800)
+	source.ExpiresAt = claimedAt.Add(15 * time.Minute)
+	source.HardExpiresAt = claimedAt.Add(30 * time.Minute)
+	store := &memorySandboxStore{
+		records: map[string]*SandboxRecord{
+			"sandbox-1": source,
+		},
+		rootFSStates: map[string]*SandboxRootFSState{
+			"sandbox-1": rootFSProductTestState("sandbox-1", "team-1", "layer-v1"),
+		},
+	}
+	svc := rootFSProductTestService(store)
+	svc.clock = fixedClock{now: forkedAt}
+	zero := int32(0)
+
+	forkResp, err := svc.ForkSandbox(context.Background(), "sandbox-1", "team-1", "user-2", &ForkSandboxRequest{
+		Config: &ForkSandboxConfig{
+			TTL:     &zero,
+			HardTTL: &zero,
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, forkResp)
+	require.NotNil(t, forkResp.Sandbox)
+	assert.True(t, forkResp.Sandbox.ExpiresAt.IsZero())
+	assert.True(t, forkResp.Sandbox.HardExpiresAt.IsZero())
+	stored := store.records[forkResp.Sandbox.ID]
+	require.NotNil(t, stored)
+	require.NotNil(t, stored.Config.TTL)
+	require.NotNil(t, stored.Config.HardTTL)
+	assert.Equal(t, int32(0), *stored.Config.TTL)
+	assert.Equal(t, int32(0), *stored.Config.HardTTL)
+	assert.True(t, stored.ExpiresAt.IsZero())
+	assert.True(t, stored.HardExpiresAt.IsZero())
+}
+
+func TestSandboxRootFSProductForkRejectsInvalidLifecycleConfig(t *testing.T) {
+	now := time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC)
+	source := rootFSProductTestRecord("sandbox-1", "team-1", SandboxStatusPaused, now)
+	store := &memorySandboxStore{
+		records: map[string]*SandboxRecord{
+			"sandbox-1": source,
+		},
+		rootFSStates: map[string]*SandboxRootFSState{
+			"sandbox-1": rootFSProductTestState("sandbox-1", "team-1", "layer-v1"),
+		},
+	}
+	svc := rootFSProductTestService(store)
+	ttl := int32(120)
+	hardTTL := int32(60)
+
+	_, err := svc.ForkSandbox(context.Background(), "sandbox-1", "team-1", "user-2", &ForkSandboxRequest{
+		Config: &ForkSandboxConfig{
+			TTL:     &ttl,
+			HardTTL: &hardTTL,
+		},
+	})
+
+	require.ErrorIs(t, err, ErrInvalidClaimRequest)
+	assert.Len(t, store.records, 1)
+}
+
+func TestSandboxRootFSProductForkRejectsHardExpiredSource(t *testing.T) {
+	now := time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC)
+	source := rootFSProductTestRecord("sandbox-1", "team-1", SandboxStatusPaused, now.Add(-time.Hour))
+	source.HardExpiresAt = now.Add(-time.Second)
+	store := &memorySandboxStore{
+		records: map[string]*SandboxRecord{
+			"sandbox-1": source,
+		},
+		rootFSStates: map[string]*SandboxRootFSState{
+			"sandbox-1": rootFSProductTestState("sandbox-1", "team-1", "layer-v1"),
+		},
+	}
+	svc := rootFSProductTestService(store)
+	svc.clock = fixedClock{now: now}
+
+	_, err := svc.ForkSandbox(context.Background(), "sandbox-1", "team-1", "user-2", nil)
+
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("ForkSandbox() error = %v, want not found", err)
+	}
+	assert.Len(t, store.records, 1)
+}
+
 func TestSandboxRootFSProductRejectsExpiredSnapshotExpiration(t *testing.T) {
 	now := time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC)
 	store := &memorySandboxStore{

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -4543,6 +4543,23 @@ components:
     ForkSandboxRequest:
       type: object
       additionalProperties: false
+      properties:
+        config:
+          $ref: "#/components/schemas/ForkSandboxConfig"
+      description: |
+        Optional fork overrides. Omit config to inherit the source sandbox configuration.
+    ForkSandboxConfig:
+      type: object
+      additionalProperties: false
+      properties:
+        ttl:
+          type: integer
+          format: int32
+          description: Runtime soft time-to-live in seconds for the forked sandbox. Omit to inherit the source setting. Set 0 to disable soft expiration.
+        hard_ttl:
+          type: integer
+          format: int32
+          description: Sandbox hard time-to-live in seconds for the forked sandbox. Omit to inherit the source setting. Set 0 to disable hard expiration.
     ForkSandboxResponse:
       type: object
       properties:

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -1011,8 +1011,19 @@ type FileInfo struct {
 // FileInfoType defines model for FileInfo.Type.
 type FileInfoType string
 
-// ForkSandboxRequest defines model for ForkSandboxRequest.
-type ForkSandboxRequest = map[string]interface{}
+// ForkSandboxConfig defines model for ForkSandboxConfig.
+type ForkSandboxConfig struct {
+	// HardTtl Sandbox hard time-to-live in seconds for the forked sandbox. Omit to inherit the source setting. Set 0 to disable hard expiration.
+	HardTtl *int32 `json:"hard_ttl,omitempty"`
+
+	// Ttl Runtime soft time-to-live in seconds for the forked sandbox. Omit to inherit the source setting. Set 0 to disable soft expiration.
+	Ttl *int32 `json:"ttl,omitempty"`
+}
+
+// ForkSandboxRequest Optional fork overrides. Omit config to inherit the source sandbox configuration.
+type ForkSandboxRequest struct {
+	Config *ForkSandboxConfig `json:"config,omitempty"`
+}
 
 // ForkSandboxResponse defines model for ForkSandboxResponse.
 type ForkSandboxResponse struct {

--- a/tests/integration/internal/tests/manager/api_test.go
+++ b/tests/integration/internal/tests/manager/api_test.go
@@ -569,7 +569,12 @@ func TestSandboxRootFSProductAPI(t *testing.T) {
 		t.Fatalf("restored rootfs state = %+v, want layer-v1", restoredState)
 	}
 
-	resp, body = doRequest(t, env.server.Client(), http.MethodPost, env.server.URL+"/api/v1/sandboxes/sandbox-1/fork", env.token, nil)
+	resp, body = doRequest(t, env.server.Client(), http.MethodPost, env.server.URL+"/api/v1/sandboxes/sandbox-1/fork", env.token, map[string]any{
+		"config": map[string]any{
+			"ttl":      60,
+			"hard_ttl": 120,
+		},
+	})
 	if resp.StatusCode != http.StatusCreated {
 		t.Fatalf("fork sandbox status = %d, body = %s", resp.StatusCode, string(body))
 	}
@@ -585,6 +590,13 @@ func TestSandboxRootFSProductAPI(t *testing.T) {
 	}
 	if forkResp.Sandbox.ID == "sandbox-1" || forkResp.Sandbox.Status != service.SandboxStatusPaused {
 		t.Fatalf("unexpected fork sandbox: %+v", forkResp.Sandbox)
+	}
+	forkRecord, err := store.GetSandbox(context.Background(), forkResp.Sandbox.ID)
+	if err != nil {
+		t.Fatalf("get fork sandbox record: %v", err)
+	}
+	if forkRecord.Config.TTL == nil || *forkRecord.Config.TTL != 60 || forkRecord.Config.HardTTL == nil || *forkRecord.Config.HardTTL != 120 {
+		t.Fatalf("fork lifecycle config = %+v, want ttl=60 hard_ttl=120", forkRecord.Config)
 	}
 	forkState, err := store.GetLatestRootFSState(context.Background(), forkResp.Sandbox.ID)
 	if err != nil {


### PR DESCRIPTION
## Summary
- add optional fork request lifecycle config for ttl and hard_ttl
- preserve source lifecycle inheritance when fork config is omitted, and allow explicit zero to disable expiration
- reject hard-expired paused source sandboxes before forking
- update OpenAPI generated types and snapshot/fork docs

## Tests
- go test ./manager/pkg/service ./manager/pkg/http ./pkg/apispec ./tests/integration/internal/tests/manager
- git diff --check