### PR TITLE
Reduce manager Kubernetes API reads with cache

### DIFF
--- a/docs/self-hosted/configuration/page.mdx
+++ b/docs/self-hosted/configuration/page.mdx
@@ -466,6 +466,7 @@ Examples:
 
 - `services.clusterGateway.config.authMode` switches between `public`, `internal`, and `both`
 - `services.manager.config.autoscaler.*` tunes pool scale behavior
+- `services.manager.config.k8sClientQps` and `k8sClientBurst` tune the manager Kubernetes client token bucket rate limit
 - `services.manager.config.sandboxMaxMemory` caps per-sandbox memory overrides; the default is `32Gi`
 - `services.manager.config.allowColdStartWithoutReadyDataPlane` lets cold claims create Pending pods for external node autoscaler scale-from-zero deployments; keep it disabled unless the cluster autoscaler can provision matching sandbox nodes
 - `services.storageProxy.config.filesystem*` tunes filesystem behavior; `services.manager.config.procdConfig.volume*` tunes mounted volume cache sizing

--- a/infra-operator/api/config/manager.go
+++ b/infra-operator/api/config/manager.go
@@ -31,6 +31,14 @@ type ManagerConfig struct {
 	// Kubernetes
 	// +optional
 	KubeConfig string `yaml:"kube_config" json:"kubeConfig"`
+	// K8sClientQPS configures the manager-wide Kubernetes client token bucket rate.
+	// When unset, manager uses the client-go default.
+	// +optional
+	K8sClientQPS int `yaml:"k8s_client_qps" json:"k8sClientQps"`
+	// K8sClientBurst configures the manager-wide Kubernetes client burst.
+	// When unset, manager uses the client-go default.
+	// +optional
+	K8sClientBurst int `yaml:"k8s_client_burst" json:"k8sClientBurst"`
 	// +optional
 	// +kubebuilder:default=true
 	LeaderElection bool `yaml:"leader_election" json:"leaderElection"`

--- a/infra-operator/api/v1alpha1/service_api_config_types.go
+++ b/infra-operator/api/v1alpha1/service_api_config_types.go
@@ -407,6 +407,12 @@ type ManagerConfig struct {
 	// +optional
 	KubeConfig string `json:"kubeConfig,omitempty"`
 	// +optional
+	// +kubebuilder:default=5
+	K8sClientQPS int `json:"k8sClientQps,omitempty"`
+	// +optional
+	// +kubebuilder:default=10
+	K8sClientBurst int `json:"k8sClientBurst,omitempty"`
+	// +optional
 	// +kubebuilder:default=true
 	LeaderElection bool `json:"leaderElection,omitempty"`
 	// +optional

--- a/infra-operator/chart/crds/infra.sandbox0.ai_sandbox0infras.yaml
+++ b/infra-operator/chart/crds/infra.sandbox0.ai_sandbox0infras.yaml
@@ -3113,6 +3113,12 @@ spec:
                           httpPort:
                             default: 8080
                             type: integer
+                          k8sClientBurst:
+                            default: 10
+                            type: integer
+                          k8sClientQps:
+                            default: 5
+                            type: integer
                           kubeConfig:
                             type: string
                           leaderElection:

--- a/infra-operator/internal/runtimeconfig/dataplane.go
+++ b/infra-operator/internal/runtimeconfig/dataplane.go
@@ -17,6 +17,8 @@ func ToManager(spec *infrav1alpha1.ManagerConfig) *apiconfig.ManagerConfig {
 
 	cfg.HTTPPort = spec.HTTPPort
 	cfg.KubeConfig = spec.KubeConfig
+	cfg.K8sClientQPS = spec.K8sClientQPS
+	cfg.K8sClientBurst = spec.K8sClientBurst
 	cfg.LeaderElection = spec.LeaderElection
 	cfg.ResyncPeriod = spec.ResyncPeriod
 	cfg.DatabaseMaxConns = spec.DatabaseMaxConns

--- a/infra-operator/internal/runtimeconfig/dataplane_test.go
+++ b/infra-operator/internal/runtimeconfig/dataplane_test.go
@@ -75,6 +75,19 @@ func TestToManagerPreservesSandboxMaxMemory(t *testing.T) {
 	}
 }
 
+func TestToManagerPreservesK8sClientRateLimit(t *testing.T) {
+	cfg := ToManager(&infrav1alpha1.ManagerConfig{
+		K8sClientQPS:   25,
+		K8sClientBurst: 50,
+	})
+	if cfg.K8sClientQPS != 25 {
+		t.Fatalf("k8s client qps = %v, want 25", cfg.K8sClientQPS)
+	}
+	if cfg.K8sClientBurst != 50 {
+		t.Fatalf("k8s client burst = %d, want 50", cfg.K8sClientBurst)
+	}
+}
+
 func TestToStorageProxyDefaultsObjectEncryptionEnabled(t *testing.T) {
 	cfg := ToStorageProxy(nil)
 	if !cfg.ObjectEncryptionEnabled {

--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -49,6 +49,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/flowcontrol"
 )
 
 func main() {
@@ -90,6 +91,7 @@ func main() {
 	if err != nil {
 		logger.Fatal("Failed to build Kubernetes config", zap.Error(err))
 	}
+	configureK8sClientRateLimiter(k8sConfig, cfg.K8sClientQPS, cfg.K8sClientBurst)
 	observeK8sClientRateLimit(managerMetrics, k8sConfig)
 	logger.Info("Kubernetes client rate limit configured",
 		zap.Float32("qps", effectiveK8sClientQPS(k8sConfig)),
@@ -167,8 +169,10 @@ func main() {
 	podInformer := informerFactory.Core().V1().Pods()
 	nodeInformer := informerFactory.Core().V1().Nodes().Informer()
 	secretInformer := informerFactory.Core().V1().Secrets().Informer()
-	_ = informerFactory.Core().V1().Namespaces().Informer()
+	namespaceInformer := informerFactory.Core().V1().Namespaces().Informer()
+	serviceAccountInformer := informerFactory.Core().V1().ServiceAccounts().Informer()
 	replicaSetInformer := informerFactory.Apps().V1().ReplicaSets().Informer()
+	networkPolicyInformer := informerFactory.Networking().V1().NetworkPolicies().Informer()
 
 	// Create CRD informer factory using generated clientset
 	crdInformerFactory := externalversions.NewSharedInformerFactory(
@@ -187,6 +191,14 @@ func main() {
 	eventSource := corev1.EventSource{Component: "manager"}
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, eventSource)
 
+	// Create listers
+	podLister := informerFactory.Core().V1().Pods().Lister()
+	nodeLister := informerFactory.Core().V1().Nodes().Lister()
+	secretLister := informerFactory.Core().V1().Secrets().Lister()
+	namespaceLister := informerFactory.Core().V1().Namespaces().Lister()
+	serviceAccountLister := informerFactory.Core().V1().ServiceAccounts().Lister()
+	networkPolicyLister := informerFactory.Networking().V1().NetworkPolicies().Lister()
+
 	// Create operator
 	operator := controller.NewOperator(
 		k8sClient,
@@ -203,12 +215,6 @@ func main() {
 	if pool != nil {
 		operator.SetTemplateStatsPublisher(controller.NewPGTemplateStatsPublisher(pool, cfg.DefaultClusterId, clk, logger))
 	}
-
-	// Create listers
-	podLister := informerFactory.Core().V1().Pods().Lister()
-	nodeLister := informerFactory.Core().V1().Nodes().Lister()
-	secretLister := informerFactory.Core().V1().Secrets().Lister()
-	namespaceLister := informerFactory.Core().V1().Namespaces().Lister()
 
 	sandboxIndex := service.NewSandboxIndex()
 	podInformer.Informer().AddEventHandler(sandboxIndex.ResourceEventHandler())
@@ -229,7 +235,7 @@ func main() {
 	// Create network policy service for building policy annotations
 	networkPolicyService := service.NewNetworkPolicyService(logger)
 	var templateNamespacePolicy namespacepolicy.TemplateNamespaceReconciler
-	baselineReconciler, err := namespacepolicy.NewReconciler(k8sClient, namespacepolicy.Config{
+	baselineReconciler, err := namespacepolicy.NewReconciler(k8sClient, networkPolicyLister, namespacepolicy.Config{
 		SystemNamespace: cfg.NetdMITMCASecretNamespace,
 		ProcdPort:       cfg.ProcdConfig.HTTPPort,
 	}, logger)
@@ -379,6 +385,9 @@ func main() {
 		crdClient,
 		operator.GetTemplateLister(),
 		namespaceLister,
+		podLister,
+		secretLister,
+		serviceAccountLister,
 		networkProvider,
 		cfg.Registry,
 		logger,
@@ -483,7 +492,7 @@ func main() {
 
 	// Wait for cache sync
 	logger.Info("Waiting for informer caches to sync")
-	if !cache.WaitForCacheSync(ctx.Done(), podInformer.Informer().HasSynced, nodeInformer.HasSynced, secretInformer.HasSynced, replicaSetInformer.HasSynced, templateInformer.HasSynced) {
+	if !cache.WaitForCacheSync(ctx.Done(), podInformer.Informer().HasSynced, nodeInformer.HasSynced, secretInformer.HasSynced, namespaceInformer.HasSynced, serviceAccountInformer.HasSynced, replicaSetInformer.HasSynced, networkPolicyInformer.HasSynced, templateInformer.HasSynced) {
 		logger.Fatal("Failed to sync informer caches")
 	}
 
@@ -574,6 +583,22 @@ func buildKubeConfig(kubeconfig string) (*rest.Config, error) {
 		return clientcmd.BuildConfigFromFlags("", kubeconfig)
 	}
 	return rest.InClusterConfig()
+}
+
+func configureK8sClientRateLimiter(config *rest.Config, qps int, burst int) {
+	if config == nil {
+		return
+	}
+	rate := float32(qps)
+	if rate <= 0 {
+		rate = rest.DefaultQPS
+	}
+	if burst <= 0 {
+		burst = rest.DefaultBurst
+	}
+	config.QPS = rate
+	config.Burst = burst
+	config.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(rate, burst)
 }
 
 func observeK8sClientRateLimit(metrics *obsmetrics.ManagerMetrics, config *rest.Config) {

--- a/manager/cmd/manager/main_test.go
+++ b/manager/cmd/manager/main_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"testing"
+
+	"k8s.io/client-go/rest"
+)
+
+func TestConfigureK8sClientRateLimiterUsesConfiguredValues(t *testing.T) {
+	cfg := &rest.Config{}
+
+	configureK8sClientRateLimiter(cfg, 25, 50)
+
+	if cfg.QPS != 25 {
+		t.Fatalf("qps = %v, want 25", cfg.QPS)
+	}
+	if cfg.Burst != 50 {
+		t.Fatalf("burst = %d, want 50", cfg.Burst)
+	}
+	if cfg.RateLimiter == nil {
+		t.Fatal("expected shared rate limiter")
+	}
+}
+
+func TestConfigureK8sClientRateLimiterDefaultsWhenUnset(t *testing.T) {
+	cfg := &rest.Config{}
+
+	configureK8sClientRateLimiter(cfg, 0, 0)
+
+	if cfg.QPS != rest.DefaultQPS {
+		t.Fatalf("qps = %v, want %v", cfg.QPS, rest.DefaultQPS)
+	}
+	if cfg.Burst != rest.DefaultBurst {
+		t.Fatalf("burst = %d, want %d", cfg.Burst, rest.DefaultBurst)
+	}
+	if cfg.RateLimiter == nil {
+		t.Fatal("expected shared rate limiter")
+	}
+}

--- a/manager/pkg/controller/autoscaler.go
+++ b/manager/pkg/controller/autoscaler.go
@@ -30,9 +30,10 @@ import (
 //   - cold claims are admitted only while the pod-network backlog is healthy,
 //   - scale-down returns the pool target to minIdle after no traffic.
 type AutoScaler struct {
-	k8sClient kubernetes.Interface
-	podLister corelisters.PodLister
-	logger    *zap.Logger
+	k8sClient        kubernetes.Interface
+	podLister        corelisters.PodLister
+	replicaSetLister appslisters.ReplicaSetLister
+	logger           *zap.Logger
 
 	rateLimiter *scaleRateLimiter
 	coldClaims  *coldClaimLimiter
@@ -125,13 +126,14 @@ func NewAutoScalerWithConfig(
 		logger = zap.NewNop()
 	}
 	return &AutoScaler{
-		k8sClient:   k8sClient,
-		podLister:   podLister,
-		logger:      logger,
-		rateLimiter: newScaleRateLimiter(config.MinScaleInterval),
-		coldClaims:  newColdClaimLimiter(),
-		state:       make(map[string]*autoScalerTemplateState),
-		config:      config,
+		k8sClient:        k8sClient,
+		podLister:        podLister,
+		replicaSetLister: replicaSetLister,
+		logger:           logger,
+		rateLimiter:      newScaleRateLimiter(config.MinScaleInterval),
+		coldClaims:       newColdClaimLimiter(),
+		state:            make(map[string]*autoScalerTemplateState),
+		config:           config,
 	}
 }
 
@@ -441,6 +443,16 @@ func (s *AutoScaler) getCurrentReplicas(ctx context.Context, template *v1alpha1.
 	rsName, err := naming.ReplicasetName(clusterID, template.Name)
 	if err != nil {
 		return 0, fmt.Errorf("generate replicaset name: %w", err)
+	}
+
+	if s.replicaSetLister != nil {
+		rs, err := s.replicaSetLister.ReplicaSets(template.Namespace).Get(rsName)
+		if err == nil {
+			return getInt32Value(rs.Spec.Replicas), nil
+		}
+		if !errors.IsNotFound(err) {
+			return 0, err
+		}
 	}
 
 	rs, err := s.k8sClient.AppsV1().ReplicaSets(template.Namespace).Get(ctx, rsName, metav1.GetOptions{})

--- a/manager/pkg/controller/autoscaler_test.go
+++ b/manager/pkg/controller/autoscaler_test.go
@@ -49,7 +49,7 @@ func TestAutoScalerColdClaimRefillsIdleDeficitByStep(t *testing.T) {
 	assert.Equal(t, int32(25), *rs.Spec.Replicas)
 }
 
-func TestAutoScalerColdClaimUsesLiveReplicaSetTarget(t *testing.T) {
+func TestAutoScalerColdClaimUsesCachedReplicaSetTarget(t *testing.T) {
 	template := autoscalerTestTemplate("template-a", 15, 50)
 	scaler, client := newAutoScalerTestHarness(t, template, 15, nil, AutoScaleConfig{
 		MinScaleInterval:        time.Millisecond,
@@ -69,11 +69,11 @@ func TestAutoScalerColdClaimUsesLiveReplicaSetTarget(t *testing.T) {
 	decision, err := scaler.OnColdClaim(context.Background(), template)
 	require.NoError(t, err)
 	require.True(t, decision.ShouldScale)
-	assert.Equal(t, int32(25), decision.OldReplicas)
-	assert.Equal(t, int32(35), decision.NewReplicas)
+	assert.Equal(t, int32(15), decision.OldReplicas)
+	assert.Equal(t, int32(25), decision.NewReplicas)
 
 	rs = getAutoscalerTestReplicaSet(t, client, template)
-	assert.Equal(t, int32(35), *rs.Spec.Replicas)
+	assert.Equal(t, int32(25), *rs.Spec.Replicas)
 }
 
 func TestAutoScalerHotClaimSkipsWhenPendingIdleCoversTarget(t *testing.T) {

--- a/manager/pkg/controller/helpers.go
+++ b/manager/pkg/controller/helpers.go
@@ -63,7 +63,10 @@ func EnsureProcdConfigSecret(
 		},
 	}
 
-	_, err = secretLister.Secrets(template.Namespace).Get(name)
+	current, err := secretLister.Secrets(template.Namespace).Get(name)
+	if err == nil && secretMatches(current, desired) {
+		return nil
+	}
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
 			return fmt.Errorf("get procd config secret: %w", err)
@@ -307,6 +310,7 @@ func setPodCondition(conditions *[]corev1.PodCondition, condition corev1.PodCond
 func EnsureNetdMITMCASecret(
 	ctx context.Context,
 	client kubernetes.Interface,
+	secretLister corelisters.SecretLister,
 	templateNamespace string,
 ) error {
 	cfg := config.LoadManagerConfig()
@@ -322,7 +326,7 @@ func EnsureNetdMITMCASecret(
 		return err
 	}
 
-	source, err := client.CoreV1().Secrets(sourceNamespace).Get(ctx, cfg.NetdMITMCASecretName, metav1.GetOptions{})
+	source, err := getSecret(ctx, client, secretLister, sourceNamespace, cfg.NetdMITMCASecretName)
 	if err != nil {
 		return fmt.Errorf("get netd MITM CA secret %s/%s: %w", sourceNamespace, cfg.NetdMITMCASecretName, err)
 	}
@@ -346,7 +350,10 @@ func EnsureNetdMITMCASecret(
 		},
 	}
 
-	_, err = client.CoreV1().Secrets(templateNamespace).Get(ctx, cfg.NetdMITMCASecretName, metav1.GetOptions{})
+	current, err := getSecret(ctx, client, secretLister, templateNamespace, cfg.NetdMITMCASecretName)
+	if err == nil && secretMatches(current, desired) {
+		return nil
+	}
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
 			return fmt.Errorf("get target netd MITM CA secret: %w", err)
@@ -382,6 +389,23 @@ func EnsureNetdMITMCASecret(
 		return fmt.Errorf("update target netd MITM CA secret: %w", err)
 	}
 	return nil
+}
+
+func getSecret(ctx context.Context, client kubernetes.Interface, secretLister corelisters.SecretLister, namespace, name string) (*corev1.Secret, error) {
+	if secretLister != nil {
+		return secretLister.Secrets(namespace).Get(name)
+	}
+	return client.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
+}
+
+func secretMatches(current, desired *corev1.Secret) bool {
+	if current == nil || desired == nil {
+		return false
+	}
+	return reflect.DeepEqual(current.Labels, desired.Labels) &&
+		reflect.DeepEqual(current.OwnerReferences, desired.OwnerReferences) &&
+		reflect.DeepEqual(current.Data, desired.Data) &&
+		reflect.DeepEqual(current.Type, desired.Type)
 }
 
 func resolveNetdMITMCASecretNamespace(cfg *config.ManagerConfig) (string, error) {

--- a/manager/pkg/controller/helpers_test.go
+++ b/manager/pkg/controller/helpers_test.go
@@ -256,7 +256,7 @@ netd_mitm_ca_secret_namespace: sandbox0-system
 `)
 	t.Setenv("CONFIG_PATH", configPath)
 
-	client := fake.NewSimpleClientset(&corev1.Secret{
+	source := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "fullmode-netd-mitm-ca",
 			Namespace: "sandbox0-system",
@@ -266,9 +266,10 @@ netd_mitm_ca_secret_namespace: sandbox0-system
 			"ca.crt": []byte("test-ca"),
 			"ca.key": []byte("should-not-copy"),
 		},
-	})
+	}
+	client := fake.NewSimpleClientset(source)
 
-	err := EnsureNetdMITMCASecret(context.Background(), client, "tpl-default")
+	err := EnsureNetdMITMCASecret(context.Background(), client, newHelpersSecretLister(t, source), "tpl-default")
 	require.NoError(t, err)
 
 	copied, err := client.CoreV1().Secrets("tpl-default").Get(context.Background(), "fullmode-netd-mitm-ca", metav1.GetOptions{})
@@ -285,12 +286,49 @@ func TestEnsureNetdMITMCASecretNoopsWithoutConfiguredSecret(t *testing.T) {
 	t.Setenv("CONFIG_PATH", configPath)
 
 	client := fake.NewSimpleClientset()
-	err := EnsureNetdMITMCASecret(context.Background(), client, "tpl-default")
+	err := EnsureNetdMITMCASecret(context.Background(), client, newHelpersSecretLister(t), "tpl-default")
 	require.NoError(t, err)
 
 	secrets, err := client.CoreV1().Secrets("tpl-default").List(context.Background(), metav1.ListOptions{})
 	require.NoError(t, err)
 	require.Empty(t, secrets.Items)
+}
+
+func TestEnsureNetdMITMCASecretNoopsWhenCacheMatches(t *testing.T) {
+	configPath := writeHelpersManagerConfig(t, `
+netd_mitm_ca_secret_name: fullmode-netd-mitm-ca
+netd_mitm_ca_secret_namespace: sandbox0-system
+`)
+	t.Setenv("CONFIG_PATH", configPath)
+
+	source := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fullmode-netd-mitm-ca",
+			Namespace: "sandbox0-system",
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"ca.crt": []byte("test-ca"),
+		},
+	}
+	target := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fullmode-netd-mitm-ca",
+			Namespace: "tpl-default",
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "sandbox0-manager",
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"ca.crt": []byte("test-ca"),
+		},
+	}
+	client := fake.NewSimpleClientset()
+
+	err := EnsureNetdMITMCASecret(context.Background(), client, newHelpersSecretLister(t, source, target), "tpl-default")
+	require.NoError(t, err)
+	require.Empty(t, client.Actions())
 }
 
 func TestEnsureProcdConfigSecretHandlesAlreadyExistsWhenListerIsStale(t *testing.T) {
@@ -335,6 +373,17 @@ func TestEnsureProcdConfigSecretHandlesAlreadyExistsWhenListerIsStale(t *testing
 	require.Len(t, updated.OwnerReferences, 1)
 	require.Equal(t, "SandboxTemplate", updated.OwnerReferences[0].Kind)
 	require.Equal(t, "template-a", updated.OwnerReferences[0].Name)
+}
+
+func newHelpersSecretLister(t *testing.T, secrets ...*corev1.Secret) corelisters.SecretLister {
+	t.Helper()
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+	})
+	for _, secret := range secrets {
+		require.NoError(t, indexer.Add(secret))
+	}
+	return corelisters.NewSecretLister(indexer)
 }
 
 func writeHelpersManagerConfig(t *testing.T, contents string) string {

--- a/manager/pkg/controller/pool_manager.go
+++ b/manager/pkg/controller/pool_manager.go
@@ -228,7 +228,7 @@ func (pm *PoolManager) getOrCreateReplicaSet(ctx context.Context, template *v1al
 	if err := EnsureProcdConfigSecret(ctx, pm.k8sClient, pm.secretLister, template); err != nil {
 		return nil, fmt.Errorf("ensure procd config secret: %w", err)
 	}
-	if err := EnsureNetdMITMCASecret(ctx, pm.k8sClient, template.Namespace); err != nil {
+	if err := EnsureNetdMITMCASecret(ctx, pm.k8sClient, pm.secretLister, template.Namespace); err != nil {
 		return nil, fmt.Errorf("ensure netd MITM CA secret: %w", err)
 	}
 	// Try to get existing ReplicaSet

--- a/manager/pkg/namespacepolicy/reconciler.go
+++ b/manager/pkg/namespacepolicy/reconciler.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
+	networkinglisters "k8s.io/client-go/listers/networking/v1"
 	"k8s.io/client-go/util/retry"
 )
 
@@ -45,10 +46,11 @@ type Config struct {
 
 // Reconciler manages template namespace ingress baseline policies.
 type Reconciler struct {
-	client          kubernetes.Interface
-	logger          *zap.Logger
-	systemNamespace string
-	procdPort       int
+	client              kubernetes.Interface
+	networkPolicyLister networkinglisters.NetworkPolicyLister
+	logger              *zap.Logger
+	systemNamespace     string
+	procdPort           int
 }
 
 type systemIngressRule struct {
@@ -57,7 +59,7 @@ type systemIngressRule struct {
 }
 
 // NewReconciler creates a manager-owned template namespace baseline reconciler.
-func NewReconciler(client kubernetes.Interface, cfg Config, logger *zap.Logger) (*Reconciler, error) {
+func NewReconciler(client kubernetes.Interface, networkPolicyLister networkinglisters.NetworkPolicyLister, cfg Config, logger *zap.Logger) (*Reconciler, error) {
 	if client == nil {
 		return nil, fmt.Errorf("k8s client is required")
 	}
@@ -76,10 +78,11 @@ func NewReconciler(client kubernetes.Interface, cfg Config, logger *zap.Logger) 
 	}
 
 	return &Reconciler{
-		client:          client,
-		logger:          logger,
-		systemNamespace: systemNamespace,
-		procdPort:       procdPort,
+		client:              client,
+		networkPolicyLister: networkPolicyLister,
+		logger:              logger,
+		systemNamespace:     systemNamespace,
+		procdPort:           procdPort,
 	}, nil
 }
 
@@ -99,7 +102,10 @@ func (r *Reconciler) EnsureBaseline(ctx context.Context, namespace string) error
 }
 
 func (r *Reconciler) ensurePolicy(ctx context.Context, desired *networkingv1.NetworkPolicy) error {
-	_, err := r.client.NetworkingV1().NetworkPolicies(desired.Namespace).Get(ctx, desired.Name, metav1.GetOptions{})
+	current, err := r.getCachedPolicy(ctx, desired.Namespace, desired.Name)
+	if err == nil && networkPolicyMatches(current, desired) {
+		return nil
+	}
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
 			return fmt.Errorf("get networkpolicy %s/%s: %w", desired.Namespace, desired.Name, err)
@@ -132,6 +138,20 @@ func (r *Reconciler) ensurePolicy(ctx context.Context, desired *networkingv1.Net
 		return fmt.Errorf("update networkpolicy %s/%s: %w", desired.Namespace, desired.Name, err)
 	}
 	return nil
+}
+
+func (r *Reconciler) getCachedPolicy(ctx context.Context, namespace, name string) (*networkingv1.NetworkPolicy, error) {
+	if r.networkPolicyLister == nil {
+		return r.client.NetworkingV1().NetworkPolicies(namespace).Get(ctx, name, metav1.GetOptions{})
+	}
+	return r.networkPolicyLister.NetworkPolicies(namespace).Get(name)
+}
+
+func networkPolicyMatches(current, desired *networkingv1.NetworkPolicy) bool {
+	if current == nil || desired == nil {
+		return false
+	}
+	return reflect.DeepEqual(current.Labels, desired.Labels) && reflect.DeepEqual(current.Spec, desired.Spec)
 }
 
 func (r *Reconciler) desiredPolicies(namespace string) []*networkingv1.NetworkPolicy {

--- a/manager/pkg/namespacepolicy/reconciler_test.go
+++ b/manager/pkg/namespacepolicy/reconciler_test.go
@@ -12,11 +12,13 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+	networkinglisters "k8s.io/client-go/listers/networking/v1"
+	"k8s.io/client-go/tools/cache"
 )
 
 func TestEnsureBaselineCreatesPolicies(t *testing.T) {
 	client := fake.NewSimpleClientset()
-	reconciler, err := NewReconciler(client, Config{SystemNamespace: "sandbox0-system", ProcdPort: 49983}, zap.NewNop())
+	reconciler, err := NewReconciler(client, newNetworkPolicyLister(t), Config{SystemNamespace: "sandbox0-system", ProcdPort: 49983}, zap.NewNop())
 	require.NoError(t, err)
 
 	require.NoError(t, reconciler.EnsureBaseline(context.Background(), "tpl-demo"))
@@ -44,7 +46,7 @@ func TestEnsureBaselineCreatesPolicies(t *testing.T) {
 }
 
 func TestEnsureBaselineRepairsDrift(t *testing.T) {
-	client := fake.NewSimpleClientset(&networkingv1.NetworkPolicy{
+	drifted := &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      policyAllowSystemName,
 			Namespace: "tpl-demo",
@@ -55,9 +57,10 @@ func TestEnsureBaselineRepairsDrift(t *testing.T) {
 				MatchLabels: map[string]string{"app": "wrong"},
 			},
 		},
-	})
+	}
+	client := fake.NewSimpleClientset(drifted)
 
-	reconciler, err := NewReconciler(client, Config{SystemNamespace: "sandbox0-system", ProcdPort: 49983}, zap.NewNop())
+	reconciler, err := NewReconciler(client, newNetworkPolicyLister(t, drifted), Config{SystemNamespace: "sandbox0-system", ProcdPort: 49983}, zap.NewNop())
 	require.NoError(t, err)
 
 	require.NoError(t, reconciler.EnsureBaseline(context.Background(), "tpl-demo"))
@@ -71,4 +74,32 @@ func TestEnsureBaselineRepairsDrift(t *testing.T) {
 	deny, err := client.NetworkingV1().NetworkPolicies("tpl-demo").Get(context.Background(), policyDenyIngressName, metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, sandboxIDLabelKey, deny.Spec.PodSelector.MatchExpressions[0].Key)
+}
+
+func TestEnsureBaselineNoopsWhenCacheMatches(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	policies := desiredPoliciesForTest(t, "tpl-demo")
+	reconciler, err := NewReconciler(client, newNetworkPolicyLister(t, policies...), Config{SystemNamespace: "sandbox0-system", ProcdPort: 49983}, zap.NewNop())
+	require.NoError(t, err)
+
+	require.NoError(t, reconciler.EnsureBaseline(context.Background(), "tpl-demo"))
+	assert.Empty(t, client.Actions())
+}
+
+func desiredPoliciesForTest(t *testing.T, namespace string) []*networkingv1.NetworkPolicy {
+	t.Helper()
+	reconciler, err := NewReconciler(fake.NewSimpleClientset(), nil, Config{SystemNamespace: "sandbox0-system", ProcdPort: 49983}, zap.NewNop())
+	require.NoError(t, err)
+	return reconciler.desiredPolicies(namespace)
+}
+
+func newNetworkPolicyLister(t *testing.T, policies ...*networkingv1.NetworkPolicy) networkinglisters.NetworkPolicyLister {
+	t.Helper()
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+	})
+	for _, policy := range policies {
+		require.NoError(t, indexer.Add(policy))
+	}
+	return networkinglisters.NewNetworkPolicyLister(indexer)
 }

--- a/manager/pkg/service/sandbox_lifecycle_controller.go
+++ b/manager/pkg/service/sandbox_lifecycle_controller.go
@@ -213,7 +213,7 @@ func (c *SandboxLifecycleController) reconcile(ctx context.Context, item sandbox
 		return nil
 	}
 
-	pod, err := c.k8sClient.CoreV1().Pods(item.Namespace).Get(ctx, item.PodName, metav1.GetOptions{})
+	pod, err := c.getCachedPod(ctx, item.Namespace, item.PodName)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return c.cleanupDeletedSandbox(ctx, item)
@@ -245,6 +245,13 @@ func (c *SandboxLifecycleController) reconcile(ctx context.Context, item sandbox
 		return fmt.Errorf("remove sandbox cleanup finalizer: %w", err)
 	}
 	return nil
+}
+
+func (c *SandboxLifecycleController) getCachedPod(ctx context.Context, namespace, name string) (*corev1.Pod, error) {
+	if c.podLister != nil {
+		return c.podLister.Pods(namespace).Get(name)
+	}
+	return c.k8sClient.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
 }
 
 func (c *SandboxLifecycleController) ensurePodCleanupFinalizer(ctx context.Context, namespace, name string) error {

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -1426,7 +1426,7 @@ func (s *SandboxService) createNewPod(ctx context.Context, template *v1alpha1.Sa
 	if err := controller.EnsureProcdConfigSecret(ctx, s.k8sClient, s.secretLister, template); err != nil {
 		return nil, fmt.Errorf("ensure procd config secret: %w", err)
 	}
-	if err := controller.EnsureNetdMITMCASecret(ctx, s.k8sClient, template.Namespace); err != nil {
+	if err := controller.EnsureNetdMITMCASecret(ctx, s.k8sClient, s.secretLister, template.Namespace); err != nil {
 		return nil, fmt.Errorf("ensure netd MITM CA secret: %w", err)
 	}
 

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -573,17 +573,25 @@ func TestWaitForPodNetworkIdentityWaitsForNodeNameAndPodIP(t *testing.T) {
 	}
 }
 
-func TestWaitForPodNetworkIdentityUsesLivePodWhenInformerStale(t *testing.T) {
+func TestWaitForPodNetworkIdentityWaitsForInformerWhenLivePodIsReady(t *testing.T) {
 	cachedPod := newClaimTestPod("ns-a", "cold-pod", "template-a", false)
 	livePod := cachedPod.DeepCopy()
 	livePod.Spec.NodeName = "node-a"
 	livePod.Status.PodIP = "10.244.0.10"
 	indexer := newClaimTestPodIndexer(t, cachedPod)
+	client := fake.NewSimpleClientset(livePod)
 	svc := &SandboxService{
-		k8sClient: fake.NewSimpleClientset(livePod),
+		k8sClient: client,
 		podLister: corelisters.NewPodLister(indexer),
 		logger:    zap.NewNop(),
 	}
+
+	go func() {
+		time.Sleep(80 * time.Millisecond)
+		if err := indexer.Update(livePod.DeepCopy()); err != nil {
+			t.Errorf("update pod: %v", err)
+		}
+	}()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
@@ -596,6 +604,9 @@ func TestWaitForPodNetworkIdentityUsesLivePodWhenInformerStale(t *testing.T) {
 	}
 	if readyPod.Status.PodIP != "10.244.0.10" {
 		t.Fatalf("pod IP = %q, want 10.244.0.10", readyPod.Status.PodIP)
+	}
+	if actions := client.Actions(); len(actions) != 0 {
+		t.Fatalf("unexpected live Kubernetes client actions while waiting for network identity: %#v", actions)
 	}
 }
 

--- a/manager/pkg/service/sandbox_service_pod.go
+++ b/manager/pkg/service/sandbox_service_pod.go
@@ -13,10 +13,7 @@ import (
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-const podNetworkIdentityLiveProbeInterval = time.Second
 
 func (s *SandboxService) prodAddress(ctx context.Context, pod *corev1.Pod) (string, error) {
 	if pod == nil {
@@ -112,34 +109,6 @@ func (s *SandboxService) waitForPodNetworkIdentity(ctx context.Context, namespac
 	defer ticker.Stop()
 
 	lastReason := "pod network identity is not ready"
-	var lastLiveProbe time.Time
-	probeLive := func() (*corev1.Pod, bool, string) {
-		if s.k8sClient == nil {
-			return nil, false, ""
-		}
-		now := time.Now()
-		if !lastLiveProbe.IsZero() && now.Sub(lastLiveProbe) < podNetworkIdentityLiveProbeInterval {
-			return nil, false, ""
-		}
-		lastLiveProbe = now
-		pod, err := s.k8sClient.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
-		if err != nil {
-			if k8serrors.IsNotFound(err) {
-				reason := fmt.Sprintf("pod %s/%s is not visible", namespace, name)
-				s.observePodNetworkIdentityCheck("live", "waiting", reason)
-				return nil, false, reason
-			}
-			s.observePodNetworkIdentityCheck("live", "error", "get pod for network identity")
-			return nil, false, ""
-		}
-		ready, reason := isPodNetworkIdentityReady(pod)
-		if ready {
-			s.observePodNetworkIdentityCheck("live", "ready", "ready")
-			return pod, true, "ready"
-		}
-		s.observePodNetworkIdentityCheck("live", "waiting", reason)
-		return nil, false, reason
-	}
 	for {
 		if s.podLister == nil {
 			return nil, fmt.Errorf("pod lister is not configured")
@@ -148,11 +117,6 @@ func (s *SandboxService) waitForPodNetworkIdentity(ctx context.Context, namespac
 		if err != nil {
 			if k8serrors.IsNotFound(err) {
 				lastReason = fmt.Sprintf("pod %s/%s is not visible", namespace, name)
-				if livePod, ok, liveReason := probeLive(); ok {
-					return livePod, nil
-				} else if liveReason != "" {
-					lastReason = liveReason
-				}
 				select {
 				case <-readyCtx.Done():
 					s.observePodNetworkIdentityCheck("cache", "timeout", lastReason)
@@ -172,11 +136,6 @@ func (s *SandboxService) waitForPodNetworkIdentity(ctx context.Context, namespac
 		}
 		if reason != "" {
 			lastReason = reason
-		}
-		if livePod, ok, liveReason := probeLive(); ok {
-			return livePod, nil
-		} else if liveReason != "" {
-			lastReason = liveReason
 		}
 
 		select {

--- a/manager/pkg/service/sandbox_service_restore.go
+++ b/manager/pkg/service/sandbox_service_restore.go
@@ -312,19 +312,6 @@ func (s *SandboxService) waitForSandboxRuntimePodDeletion(ctx context.Context, n
 	ticker := time.NewTicker(sandboxLifecycleWaitInterval)
 	defer ticker.Stop()
 	for {
-		apiDeleting := false
-		if s != nil && s.k8sClient != nil {
-			pod, err := s.k8sClient.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
-			switch {
-			case k8serrors.IsNotFound(err):
-			case err != nil:
-				return err
-			case pod != nil && pod.DeletionTimestamp != nil:
-				apiDeleting = true
-			default:
-				return nil
-			}
-		}
 		if s != nil && s.podLister != nil {
 			pod, err := s.podLister.Pods(namespace).Get(name)
 			if k8serrors.IsNotFound(err) {
@@ -333,10 +320,20 @@ func (s *SandboxService) waitForSandboxRuntimePodDeletion(ctx context.Context, n
 			if err != nil {
 				return err
 			}
-			if pod != nil && pod.DeletionTimestamp == nil && !apiDeleting {
+			if pod != nil && pod.DeletionTimestamp == nil {
 				return nil
 			}
-		} else if !apiDeleting {
+		} else if s != nil && s.k8sClient != nil {
+			pod, err := s.k8sClient.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+			switch {
+			case k8serrors.IsNotFound(err):
+				return nil
+			case err != nil:
+				return err
+			case pod != nil && pod.DeletionTimestamp == nil:
+				return nil
+			}
+		} else {
 			return nil
 		}
 

--- a/manager/pkg/service/template_service.go
+++ b/manager/pkg/service/template_service.go
@@ -34,6 +34,9 @@ type TemplateService struct {
 	crdClient       clientset.Interface
 	templateLister  controller.TemplateLister
 	namespaceLister corelisters.NamespaceLister
+	podLister       corelisters.PodLister
+	secretLister    corelisters.SecretLister
+	saLister        corelisters.ServiceAccountLister
 	logger          *zap.Logger
 	network         network.Provider
 	registry        config.RegistryConfig
@@ -46,6 +49,9 @@ func NewTemplateService(
 	crdClient clientset.Interface,
 	templateLister controller.TemplateLister,
 	namespaceLister corelisters.NamespaceLister,
+	podLister corelisters.PodLister,
+	secretLister corelisters.SecretLister,
+	serviceAccountLister corelisters.ServiceAccountLister,
 	networkProvider network.Provider,
 	registryConfig config.RegistryConfig,
 	logger *zap.Logger,
@@ -58,6 +64,9 @@ func NewTemplateService(
 		crdClient:       crdClient,
 		templateLister:  templateLister,
 		namespaceLister: namespaceLister,
+		podLister:       podLister,
+		secretLister:    secretLister,
+		saLister:        serviceAccountLister,
 		logger:          logger,
 		network:         networkProvider,
 		registry:        registryConfig,
@@ -243,7 +252,7 @@ func (s *TemplateService) shouldDeleteNamespaceForTemplate(ctx context.Context, 
 }
 
 func (s *TemplateService) isManagedTemplateNamespace(ctx context.Context, namespace string) (bool, error) {
-	ns, err := s.k8sClient.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+	ns, err := s.getNamespace(ctx, namespace)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return false, nil
@@ -260,6 +269,19 @@ func (s *TemplateService) isManagedTemplateNamespace(ctx context.Context, namesp
 }
 
 func (s *TemplateService) namespaceHasOtherTemplates(ctx context.Context, namespace, deletingName string) (bool, error) {
+	if s.templateLister != nil {
+		templates, err := s.templateLister.List()
+		if err != nil {
+			return false, err
+		}
+		for _, template := range templates {
+			if template.Namespace == namespace && template.Name != deletingName {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+
 	templates, err := s.crdClient.Sandbox0V1alpha1().SandboxTemplates(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -296,7 +318,7 @@ func (s *TemplateService) deleteTemplatePods(ctx context.Context, namespace, tem
 		return nil
 	}
 	selector := labels.Set{controller.LabelTemplateID: templateID}.AsSelector().String()
-	pods, err := s.k8sClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: selector})
+	pods, err := s.listTemplatePods(ctx, namespace, selector)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil
@@ -304,7 +326,7 @@ func (s *TemplateService) deleteTemplatePods(ctx context.Context, namespace, tem
 		return fmt.Errorf("list template pods in namespace %s: %w", namespace, err)
 	}
 
-	for _, pod := range pods.Items {
+	for _, pod := range pods {
 		poolType := pod.Labels[controller.LabelPoolType]
 		if poolType != controller.PoolTypeIdle && poolType != controller.PoolTypeActive {
 			continue
@@ -314,6 +336,32 @@ func (s *TemplateService) deleteTemplatePods(ctx context.Context, namespace, tem
 		}
 	}
 	return nil
+}
+
+func (s *TemplateService) getNamespace(ctx context.Context, namespace string) (*corev1.Namespace, error) {
+	if s.namespaceLister != nil {
+		return s.namespaceLister.Get(namespace)
+	}
+	return s.k8sClient.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+}
+
+func (s *TemplateService) listTemplatePods(ctx context.Context, namespace, selector string) ([]*corev1.Pod, error) {
+	if s.podLister != nil {
+		parsed, err := labels.Parse(selector)
+		if err != nil {
+			return nil, err
+		}
+		return s.podLister.Pods(namespace).List(parsed)
+	}
+	pods, err := s.k8sClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: selector})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*corev1.Pod, 0, len(pods.Items))
+	for i := range pods.Items {
+		out = append(out, &pods.Items[i])
+	}
+	return out, nil
 }
 
 func (s *TemplateService) resolveTemplateNamespace(template *v1alpha1.SandboxTemplate) (string, error) {
@@ -355,7 +403,7 @@ func (s *TemplateService) ensureNamespace(ctx context.Context, namespace string)
 		if err := s.ensureRegistryPullSecret(ctx, namespace); err != nil {
 			return err
 		}
-		return controller.EnsureNetdMITMCASecret(ctx, s.k8sClient, namespace)
+		return controller.EnsureNetdMITMCASecret(ctx, s.k8sClient, s.secretLister, namespace)
 	} else if !errors.IsNotFound(err) {
 		return fmt.Errorf("get namespace %s from cache: %w", namespace, err)
 	}
@@ -374,7 +422,7 @@ func (s *TemplateService) ensureNamespace(ctx context.Context, namespace string)
 	if err := s.ensureRegistryPullSecret(ctx, namespace); err != nil {
 		return err
 	}
-	return controller.EnsureNetdMITMCASecret(ctx, s.k8sClient, namespace)
+	return controller.EnsureNetdMITMCASecret(ctx, s.k8sClient, s.secretLister, namespace)
 }
 
 func (s *TemplateService) ensureRegistryPullSecret(ctx context.Context, namespace string) error {
@@ -404,7 +452,10 @@ func (s *TemplateService) ensureRegistryPullSecret(ctx context.Context, namespac
 		},
 	}
 
-	_, err = s.k8sClient.CoreV1().Secrets(namespace).Get(ctx, s.registry.PullSecretName, metav1.GetOptions{})
+	current, err := s.getSecret(ctx, namespace, s.registry.PullSecretName)
+	if err == nil && current.Type == corev1.SecretTypeDockerConfigJson && string(current.Data[corev1.DockerConfigJsonKey]) == string(creds) {
+		return s.ensureDefaultServiceAccountPullSecret(ctx, namespace, s.registry.PullSecretName)
+	}
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			return fmt.Errorf("get registry pull secret: %w", err)
@@ -443,7 +494,7 @@ func (s *TemplateService) ensureDefaultServiceAccountPullSecret(ctx context.Cont
 	if secretName == "" {
 		return nil
 	}
-	sa, err := s.k8sClient.CoreV1().ServiceAccounts(namespace).Get(ctx, "default", metav1.GetOptions{})
+	sa, err := s.getServiceAccount(ctx, namespace, "default")
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			return fmt.Errorf("get default serviceaccount: %w", err)
@@ -496,4 +547,18 @@ func (s *TemplateService) ensureDefaultServiceAccountPullSecret(ctx context.Cont
 		return fmt.Errorf("update default serviceaccount: %w", err)
 	}
 	return nil
+}
+
+func (s *TemplateService) getSecret(ctx context.Context, namespace, name string) (*corev1.Secret, error) {
+	if s.secretLister != nil {
+		return s.secretLister.Secrets(namespace).Get(name)
+	}
+	return s.k8sClient.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
+}
+
+func (s *TemplateService) getServiceAccount(ctx context.Context, namespace, name string) (*corev1.ServiceAccount, error) {
+	if s.saLister != nil {
+		return s.saLister.ServiceAccounts(namespace).Get(name)
+	}
+	return s.k8sClient.CoreV1().ServiceAccounts(namespace).Get(ctx, name, metav1.GetOptions{})
 }

--- a/manager/pkg/service/template_service_test.go
+++ b/manager/pkg/service/template_service_test.go
@@ -39,15 +39,18 @@ func (r *recordingTemplateNamespacePolicy) EnsureBaseline(_ context.Context, nam
 	return r.err
 }
 
-func newTemplateServiceForTests() (*TemplateService, *fake.Clientset) {
+func newTemplateServiceForTests(t *testing.T) (*TemplateService, *fake.Clientset) {
 	k8sClient := fake.NewSimpleClientset()
 	crdClient := clientsetfake.NewSimpleClientset()
-	namespaceIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	namespaceLister, podLister, secretLister, serviceAccountLister := newTemplateServiceK8sListers(t, k8sClient)
 	service := NewTemplateService(
 		k8sClient,
 		crdClient,
 		stubTemplateLister{},
-		corelisters.NewNamespaceLister(namespaceIndexer),
+		namespaceLister,
+		podLister,
+		secretLister,
+		serviceAccountLister,
 		nil,
 		config.RegistryConfig{},
 		zap.NewNop(),
@@ -72,7 +75,7 @@ func (l *listBackedTemplateLister) Get(namespace, name string) (*v1alpha1.Sandbo
 	return nil, apierrors.NewNotFound(v1alpha1.Resource("sandboxtemplate"), name)
 }
 
-func newTemplateServiceForDeleteTests(k8sClient *fake.Clientset, templates ...*v1alpha1.SandboxTemplate) (*TemplateService, *clientsetfake.Clientset) {
+func newTemplateServiceForDeleteTests(t *testing.T, k8sClient *fake.Clientset, templates ...*v1alpha1.SandboxTemplate) (*TemplateService, *clientsetfake.Clientset) {
 	crdObjects := make([]runtime.Object, 0, len(templates))
 	listerTemplates := make([]*v1alpha1.SandboxTemplate, 0, len(templates))
 	for _, template := range templates {
@@ -80,12 +83,15 @@ func newTemplateServiceForDeleteTests(k8sClient *fake.Clientset, templates ...*v
 		listerTemplates = append(listerTemplates, template.DeepCopy())
 	}
 	crdClient := clientsetfake.NewSimpleClientset(crdObjects...)
-	namespaceIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	namespaceLister, podLister, secretLister, serviceAccountLister := newTemplateServiceK8sListers(t, k8sClient)
 	service := NewTemplateService(
 		k8sClient,
 		crdClient,
 		&listBackedTemplateLister{templates: listerTemplates},
-		corelisters.NewNamespaceLister(namespaceIndexer),
+		namespaceLister,
+		podLister,
+		secretLister,
+		serviceAccountLister,
 		nil,
 		config.RegistryConfig{},
 		zap.NewNop(),
@@ -94,7 +100,7 @@ func newTemplateServiceForDeleteTests(k8sClient *fake.Clientset, templates ...*v
 }
 
 func TestCreateTemplateEnsuresNamespaceBaseline(t *testing.T) {
-	service, k8sClient := newTemplateServiceForTests()
+	service, k8sClient := newTemplateServiceForTests(t)
 	reconciler := &recordingTemplateNamespacePolicy{}
 	service.SetNamespacePolicyReconciler(reconciler)
 
@@ -111,7 +117,7 @@ func TestCreateTemplateEnsuresNamespaceBaseline(t *testing.T) {
 }
 
 func TestCreateTeamTemplateEnsuresNamespaceBaseline(t *testing.T) {
-	service, k8sClient := newTemplateServiceForTests()
+	service, k8sClient := newTemplateServiceForTests(t)
 	reconciler := &recordingTemplateNamespacePolicy{}
 	service.SetNamespacePolicyReconciler(reconciler)
 
@@ -138,7 +144,7 @@ func TestCreateTeamTemplateEnsuresNamespaceBaseline(t *testing.T) {
 }
 
 func TestCreateTemplateFailsWhenNamespaceBaselineFails(t *testing.T) {
-	service, _ := newTemplateServiceForTests()
+	service, _ := newTemplateServiceForTests(t)
 	reconciler := &recordingTemplateNamespacePolicy{err: errors.New("boom")}
 	service.SetNamespacePolicyReconciler(reconciler)
 
@@ -160,7 +166,7 @@ func TestDeletePublicTemplateDeletesManagedNamespace(t *testing.T) {
 		},
 	}
 	k8sClient := fake.NewSimpleClientset(managedNamespace(namespace))
-	service, _ := newTemplateServiceForDeleteTests(k8sClient, template)
+	service, _ := newTemplateServiceForDeleteTests(t, k8sClient, template)
 
 	err = service.DeleteTemplate(ctx, "demo")
 	require.NoError(t, err)
@@ -172,7 +178,7 @@ func TestDeletePublicTemplateDeletesManagedNamespace(t *testing.T) {
 func TestDeleteMissingTemplateIsIdempotent(t *testing.T) {
 	ctx := context.Background()
 	k8sClient := fake.NewSimpleClientset()
-	service, _ := newTemplateServiceForDeleteTests(k8sClient)
+	service, _ := newTemplateServiceForDeleteTests(t, k8sClient)
 
 	err := service.DeleteTemplate(ctx, "missing")
 	require.NoError(t, err)
@@ -196,7 +202,7 @@ func TestDeleteTemplateKeepsUnmanagedNamespaceAndDeletesTemplatePods(t *testing.
 		targetPod,
 		otherPod,
 	)
-	service, crdClient := newTemplateServiceForDeleteTests(k8sClient, template)
+	service, crdClient := newTemplateServiceForDeleteTests(t, k8sClient, template)
 
 	err = service.DeleteTemplate(ctx, "demo")
 	require.NoError(t, err)
@@ -228,12 +234,15 @@ func TestDeleteTemplateCleansPodsWhenCRDAlreadyGone(t *testing.T) {
 		targetPod,
 	)
 	crdClient := clientsetfake.NewSimpleClientset()
-	namespaceIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	namespaceLister, podLister, secretLister, serviceAccountLister := newTemplateServiceK8sListers(t, k8sClient)
 	service := NewTemplateService(
 		k8sClient,
 		crdClient,
 		&listBackedTemplateLister{templates: []*v1alpha1.SandboxTemplate{template}},
-		corelisters.NewNamespaceLister(namespaceIndexer),
+		namespaceLister,
+		podLister,
+		secretLister,
+		serviceAccountLister,
 		nil,
 		config.RegistryConfig{},
 		zap.NewNop(),
@@ -262,7 +271,7 @@ func TestDeleteTeamTemplateKeepsSharedNamespaceAndDeletesTemplatePods(t *testing
 		targetPod,
 		otherPod,
 	)
-	service, crdClient := newTemplateServiceForDeleteTests(k8sClient, target, other)
+	service, crdClient := newTemplateServiceForDeleteTests(t, k8sClient, target, other)
 
 	err = service.DeleteTemplate(ctx, "demo")
 	require.NoError(t, err)
@@ -290,7 +299,7 @@ func TestDeleteLastTeamTemplateDeletesManagedNamespace(t *testing.T) {
 		managedNamespace(namespace),
 		pod,
 	)
-	service, crdClient := newTemplateServiceForDeleteTests(k8sClient, template)
+	service, crdClient := newTemplateServiceForDeleteTests(t, k8sClient, template)
 
 	err = service.DeleteTemplate(ctx, "demo")
 	require.NoError(t, err)
@@ -312,6 +321,41 @@ func managedNamespace(name string) *corev1.Namespace {
 			},
 		},
 	}
+}
+
+func newTemplateServiceK8sListers(t *testing.T, client *fake.Clientset) (corelisters.NamespaceLister, corelisters.PodLister, corelisters.SecretLister, corelisters.ServiceAccountLister) {
+	t.Helper()
+	ctx := context.Background()
+	namespaceIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	podIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	secretIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	serviceAccountIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+
+	namespaces, err := client.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+	require.NoError(t, err)
+	for i := range namespaces.Items {
+		require.NoError(t, namespaceIndexer.Add(namespaces.Items[i].DeepCopy()))
+	}
+	pods, err := client.CoreV1().Pods(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+	require.NoError(t, err)
+	for i := range pods.Items {
+		require.NoError(t, podIndexer.Add(pods.Items[i].DeepCopy()))
+	}
+	secrets, err := client.CoreV1().Secrets(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+	require.NoError(t, err)
+	for i := range secrets.Items {
+		require.NoError(t, secretIndexer.Add(secrets.Items[i].DeepCopy()))
+	}
+	serviceAccounts, err := client.CoreV1().ServiceAccounts(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+	require.NoError(t, err)
+	for i := range serviceAccounts.Items {
+		require.NoError(t, serviceAccountIndexer.Add(serviceAccounts.Items[i].DeepCopy()))
+	}
+
+	return corelisters.NewNamespaceLister(namespaceIndexer),
+		corelisters.NewPodLister(podIndexer),
+		corelisters.NewSecretLister(secretIndexer),
+		corelisters.NewServiceAccountLister(serviceAccountIndexer)
 }
 
 func teamTemplate(namespace, name, teamID string) *v1alpha1.SandboxTemplate {

--- a/tests/integration/internal/tests/manager/api_test.go
+++ b/tests/integration/internal/tests/manager/api_test.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	corelisters "k8s.io/client-go/listers/core/v1"
+	networkinglisters "k8s.io/client-go/listers/networking/v1"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -114,10 +115,14 @@ func newManagerTestEnvWithOptions(t *testing.T, opts managerTestEnvOptions) *man
 	nodeIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	secretIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	namespaceIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	serviceAccountIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	networkPolicyIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	podLister := corelisters.NewPodLister(podIndexer)
 	nodeLister := corelisters.NewNodeLister(nodeIndexer)
 	secretLister := corelisters.NewSecretLister(secretIndexer)
 	namespaceLister := corelisters.NewNamespaceLister(namespaceIndexer)
+	serviceAccountLister := corelisters.NewServiceAccountLister(serviceAccountIndexer)
+	networkPolicyLister := networkinglisters.NewNetworkPolicyLister(networkPolicyIndexer)
 	sandboxIndex := service.NewSandboxIndex()
 
 	templateLister := &testTemplateLister{
@@ -170,11 +175,14 @@ func newManagerTestEnvWithOptions(t *testing.T, opts managerTestEnvOptions) *man
 		crdClient,
 		templateLister,
 		namespaceLister,
+		podLister,
+		secretLister,
+		serviceAccountLister,
 		nil,
 		managerCfg.Registry,
 		logger,
 	)
-	baselineReconciler, err := namespacepolicy.NewReconciler(k8sClient, namespacepolicy.Config{
+	baselineReconciler, err := namespacepolicy.NewReconciler(k8sClient, networkPolicyLister, namespacepolicy.Config{
 		SystemNamespace: "sandbox0-system",
 		ProcdPort:       49983,
 	}, logger)


### PR DESCRIPTION
## Summary
- route manager read/no-op paths through shared informer listers for ReplicaSets, Secrets, Namespaces, Pods, ServiceAccounts, and NetworkPolicies
- remove the live Pod polling fallback from network-identity waits so manager relies on the Pod cache instead of periodic direct GETs
- add manager-wide Kubernetes client token bucket rate limiting, configurable from Sandbox0Infra via `services.manager.config.k8sClientQps` and `k8sClientBurst`
- regenerate the Sandbox0Infra CRD schema and document the new manager tuning knobs

## Tests
- `go test ./manager/cmd/manager ./manager/pkg/controller ./manager/pkg/namespacepolicy ./manager/pkg/service ./infra-operator/internal/runtimeconfig ./tests/integration/internal/tests/manager`
- `go test ./manager/... ./infra-operator/internal/runtimeconfig ./infra-operator/internal/controller/pkg/rbac ./infra-operator/internal/controller/services/manager`
- `make manifests`