### PR TITLE
Use informer events for pod network identity wait

### DIFF
--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -361,6 +361,7 @@ func main() {
 		logger.Warn("Webhook state volumes disabled; sandbox claims with webhooks will fail until storage-proxy is configured")
 	}
 	sandboxService.SetDeletionWebhookEmitter(service.NewHTTPSandboxDeletionWebhookEmitter(obsProvider.HTTP.NewClient(httpobs.Config{Timeout: cfg.ProcdClientTimeout.Duration})))
+	podInformer.Informer().AddEventHandler(sandboxService.PodNetworkIdentityEventHandler())
 	sandboxLifecycleController := service.NewSandboxLifecycleController(k8sClient, podLister, sandboxService, logger)
 	podInformer.Informer().AddEventHandler(sandboxLifecycleController.ResourceEventHandler())
 	sandboxPauseController := service.NewSandboxPauseController(sandboxService, logger)

--- a/manager/pkg/service/pod_network_identity_waiter.go
+++ b/manager/pkg/service/pod_network_identity_waiter.go
@@ -1,0 +1,106 @@
+package service
+
+import (
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+type podNetworkIdentityEvent struct {
+	pod     *corev1.Pod
+	deleted bool
+}
+
+type podNetworkIdentityWaiter struct {
+	mu      sync.Mutex
+	waiters map[string]map[chan podNetworkIdentityEvent]struct{}
+}
+
+func newPodNetworkIdentityWaiter() *podNetworkIdentityWaiter {
+	return &podNetworkIdentityWaiter{
+		waiters: make(map[string]map[chan podNetworkIdentityEvent]struct{}),
+	}
+}
+
+func (w *podNetworkIdentityWaiter) ResourceEventHandler() cache.ResourceEventHandlerFuncs {
+	if w == nil {
+		return cache.ResourceEventHandlerFuncs{}
+	}
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) {
+			w.notifyObject(obj, false)
+		},
+		UpdateFunc: func(_, newObj any) {
+			w.notifyObject(newObj, false)
+		},
+		DeleteFunc: func(obj any) {
+			w.notifyObject(obj, true)
+		},
+	}
+}
+
+func (w *podNetworkIdentityWaiter) register(namespace, name string) (<-chan podNetworkIdentityEvent, func()) {
+	ch := make(chan podNetworkIdentityEvent, 1)
+	if w == nil {
+		return ch, func() {}
+	}
+	key := podNetworkIdentityKey(namespace, name)
+
+	w.mu.Lock()
+	if w.waiters[key] == nil {
+		w.waiters[key] = make(map[chan podNetworkIdentityEvent]struct{})
+	}
+	w.waiters[key][ch] = struct{}{}
+	w.mu.Unlock()
+
+	return ch, func() {
+		w.mu.Lock()
+		defer w.mu.Unlock()
+		waiters := w.waiters[key]
+		if waiters == nil {
+			return
+		}
+		delete(waiters, ch)
+		if len(waiters) == 0 {
+			delete(w.waiters, key)
+		}
+	}
+}
+
+func (w *podNetworkIdentityWaiter) notifyObject(obj any, deleted bool) {
+	if w == nil {
+		return
+	}
+	pod := podFromInformerObject(obj)
+	if pod == nil {
+		return
+	}
+	key := podNetworkIdentityKey(pod.Namespace, pod.Name)
+	event := podNetworkIdentityEvent{pod: pod, deleted: deleted}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for ch := range w.waiters[key] {
+		select {
+		case ch <- event:
+		default:
+		}
+	}
+}
+
+func podFromInformerObject(obj any) *corev1.Pod {
+	if pod, ok := obj.(*corev1.Pod); ok {
+		return pod
+	}
+	tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+	if !ok {
+		return nil
+	}
+	pod, _ := tombstone.Obj.(*corev1.Pod)
+	return pod
+}
+
+func podNetworkIdentityKey(namespace, name string) string {
+	return namespace + "/" + name
+}

--- a/manager/pkg/service/sandbox_service.go
+++ b/manager/pkg/service/sandbox_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
@@ -17,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
 )
 
 // Sandbox represents a sandbox instance
@@ -126,6 +128,8 @@ type SandboxService struct {
 	rootFSObjectDeleter    RootFSObjectDeleter
 	resumeGroup            singleflight.Group
 	idlePodReservations    *idlePodReservations
+	podNetworkWaiterMu     sync.Mutex
+	podNetworkWaiter       *podNetworkIdentityWaiter
 }
 
 type TeamQuotaLimitStore interface {
@@ -239,8 +243,26 @@ func NewSandboxService(
 		logger:                 logger,
 		metrics:                metrics,
 		idlePodReservations:    newIdlePodReservations(),
+		podNetworkWaiter:       newPodNetworkIdentityWaiter(),
 	}
 	return service
+}
+
+// PodNetworkIdentityEventHandler wakes cold-claim waiters from shared pod informer events.
+func (s *SandboxService) PodNetworkIdentityEventHandler() cache.ResourceEventHandlerFuncs {
+	if s == nil {
+		return cache.ResourceEventHandlerFuncs{}
+	}
+	return s.ensurePodNetworkIdentityWaiter().ResourceEventHandler()
+}
+
+func (s *SandboxService) ensurePodNetworkIdentityWaiter() *podNetworkIdentityWaiter {
+	s.podNetworkWaiterMu.Lock()
+	defer s.podNetworkWaiterMu.Unlock()
+	if s.podNetworkWaiter == nil {
+		s.podNetworkWaiter = newPodNetworkIdentityWaiter()
+	}
+	return s.podNetworkWaiter
 }
 
 // SupportsNetworkPolicy reports whether this deployment has an active network policy provider.

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -503,7 +503,7 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 		// patch the applied policy hash.
 		if s.networkProvider != nil {
 			phaseStarted = time.Now()
-			networkPod, err := s.waitForPodNetworkIdentity(ctx, pod.Namespace, pod.Name)
+			networkPod, err := s.waitForPodNetworkIdentity(ctx, req.Template, pod.Namespace, pod.Name)
 			s.observeClaimPhase(req.Template, claimType, "wait_for_pod_network_identity", phaseStarted, err)
 			if err != nil {
 				completeColdAdmission()

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -31,6 +33,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
@@ -548,20 +551,70 @@ func TestWaitForPodNetworkIdentityWaitsForNodeNameAndPodIP(t *testing.T) {
 		podLister: corelisters.NewPodLister(indexer),
 		logger:    zap.NewNop(),
 	}
+	handler := svc.PodNetworkIdentityEventHandler()
 
 	go func() {
 		time.Sleep(80 * time.Millisecond)
-		updated := pod.DeepCopy()
-		updated.Spec.NodeName = "node-a"
+		nodeOnly := pod.DeepCopy()
+		nodeOnly.Spec.NodeName = "node-a"
+		if err := indexer.Update(nodeOnly); err != nil {
+			t.Errorf("update pod: %v", err)
+		}
+		handler.UpdateFunc(pod, nodeOnly)
+
+		time.Sleep(80 * time.Millisecond)
+		updated := nodeOnly.DeepCopy()
 		updated.Status.PodIP = "10.244.0.10"
 		if err := indexer.Update(updated); err != nil {
 			t.Errorf("update pod: %v", err)
 		}
+		handler.UpdateFunc(nodeOnly, updated)
 	}()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	readyPod, err := svc.waitForPodNetworkIdentity(ctx, pod.Namespace, pod.Name)
+	readyPod, err := svc.waitForPodNetworkIdentity(ctx, "template-a", pod.Namespace, pod.Name)
+	if err != nil {
+		t.Fatalf("waitForPodNetworkIdentity() error = %v", err)
+	}
+	if readyPod.Spec.NodeName != "node-a" {
+		t.Fatalf("node name = %q, want node-a", readyPod.Spec.NodeName)
+	}
+	if readyPod.Status.PodIP != "10.244.0.10" {
+		t.Fatalf("pod IP = %q, want 10.244.0.10", readyPod.Status.PodIP)
+	}
+}
+
+func TestWaitForPodNetworkIdentityWaitsForNodeNameWhenPodIPArrivesFirst(t *testing.T) {
+	pod := newClaimTestPod("ns-a", "cold-pod", "template-a", false)
+	indexer := newClaimTestPodIndexer(t, pod)
+	svc := &SandboxService{
+		podLister: corelisters.NewPodLister(indexer),
+		logger:    zap.NewNop(),
+	}
+	handler := svc.PodNetworkIdentityEventHandler()
+
+	go func() {
+		time.Sleep(80 * time.Millisecond)
+		ipOnly := pod.DeepCopy()
+		ipOnly.Status.PodIP = "10.244.0.10"
+		if err := indexer.Update(ipOnly); err != nil {
+			t.Errorf("update pod: %v", err)
+		}
+		handler.UpdateFunc(pod, ipOnly)
+
+		time.Sleep(80 * time.Millisecond)
+		updated := ipOnly.DeepCopy()
+		updated.Spec.NodeName = "node-a"
+		if err := indexer.Update(updated); err != nil {
+			t.Errorf("update pod: %v", err)
+		}
+		handler.UpdateFunc(ipOnly, updated)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	readyPod, err := svc.waitForPodNetworkIdentity(ctx, "template-a", pod.Namespace, pod.Name)
 	if err != nil {
 		t.Fatalf("waitForPodNetworkIdentity() error = %v", err)
 	}
@@ -585,17 +638,19 @@ func TestWaitForPodNetworkIdentityWaitsForInformerWhenLivePodIsReady(t *testing.
 		podLister: corelisters.NewPodLister(indexer),
 		logger:    zap.NewNop(),
 	}
+	handler := svc.PodNetworkIdentityEventHandler()
 
 	go func() {
 		time.Sleep(80 * time.Millisecond)
 		if err := indexer.Update(livePod.DeepCopy()); err != nil {
 			t.Errorf("update pod: %v", err)
 		}
+		handler.UpdateFunc(cachedPod, livePod)
 	}()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	readyPod, err := svc.waitForPodNetworkIdentity(ctx, cachedPod.Namespace, cachedPod.Name)
+	readyPod, err := svc.waitForPodNetworkIdentity(ctx, "template-a", cachedPod.Namespace, cachedPod.Name)
 	if err != nil {
 		t.Fatalf("waitForPodNetworkIdentity() error = %v", err)
 	}
@@ -607,6 +662,129 @@ func TestWaitForPodNetworkIdentityWaitsForInformerWhenLivePodIsReady(t *testing.
 	}
 	if actions := client.Actions(); len(actions) != 0 {
 		t.Fatalf("unexpected live Kubernetes client actions while waiting for network identity: %#v", actions)
+	}
+}
+
+func TestWaitForPodNetworkIdentityReturnsReadyFromCache(t *testing.T) {
+	pod := newClaimTestPod("ns-a", "cold-pod", "template-a", false)
+	pod.Spec.NodeName = "node-a"
+	pod.Status.PodIP = "10.244.0.10"
+	indexer := newClaimTestPodIndexer(t, pod)
+	svc := &SandboxService{
+		podLister: corelisters.NewPodLister(indexer),
+		logger:    zap.NewNop(),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	readyPod, err := svc.waitForPodNetworkIdentity(ctx, "template-a", pod.Namespace, pod.Name)
+	if err != nil {
+		t.Fatalf("waitForPodNetworkIdentity() error = %v", err)
+	}
+	if readyPod.Name != pod.Name {
+		t.Fatalf("ready pod = %s, want %s", readyPod.Name, pod.Name)
+	}
+}
+
+func TestWaitForPodNetworkIdentityReturnsOnDeleteOrTerminal(t *testing.T) {
+	tests := []struct {
+		name      string
+		reason    string
+		updatePod func(*testing.T, cache.ResourceEventHandlerFuncs, cache.Indexer, *corev1.Pod)
+	}{
+		{
+			name:   "terminal",
+			reason: "terminal",
+			updatePod: func(t *testing.T, handler cache.ResourceEventHandlerFuncs, indexer cache.Indexer, pod *corev1.Pod) {
+				updated := pod.DeepCopy()
+				updated.Status.Phase = corev1.PodFailed
+				if err := indexer.Update(updated); err != nil {
+					t.Fatalf("update pod: %v", err)
+				}
+				handler.UpdateFunc(pod, updated)
+			},
+		},
+		{
+			name:   "deleted",
+			reason: "deleting",
+			updatePod: func(t *testing.T, handler cache.ResourceEventHandlerFuncs, indexer cache.Indexer, pod *corev1.Pod) {
+				if err := indexer.Delete(pod); err != nil {
+					t.Fatalf("delete pod: %v", err)
+				}
+				handler.DeleteFunc(pod)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := newClaimTestPod("ns-a", "cold-pod", "template-a", false)
+			indexer := newClaimTestPodIndexer(t, pod)
+			svc := &SandboxService{
+				podLister: corelisters.NewPodLister(indexer),
+				logger:    zap.NewNop(),
+			}
+			handler := svc.PodNetworkIdentityEventHandler()
+
+			go func() {
+				time.Sleep(80 * time.Millisecond)
+				tt.updatePod(t, handler, indexer, pod)
+			}()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			_, err := svc.waitForPodNetworkIdentity(ctx, "template-a", pod.Namespace, pod.Name)
+			if err == nil {
+				t.Fatal("waitForPodNetworkIdentity() error = nil, want error")
+			}
+			if !strings.Contains(err.Error(), tt.reason) {
+				t.Fatalf("waitForPodNetworkIdentity() error = %v, want reason containing %q", err, tt.reason)
+			}
+		})
+	}
+}
+
+func TestWaitForPodNetworkIdentityTimesOut(t *testing.T) {
+	pod := newClaimTestPod("ns-a", "cold-pod", "template-a", false)
+	indexer := newClaimTestPodIndexer(t, pod)
+	svc := &SandboxService{
+		podLister: corelisters.NewPodLister(indexer),
+		logger:    zap.NewNop(),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	_, err := svc.waitForPodNetworkIdentity(ctx, "template-a", pod.Namespace, pod.Name)
+	if err == nil {
+		t.Fatal("waitForPodNetworkIdentity() error = nil, want timeout")
+	}
+	if !strings.Contains(err.Error(), "network identity not ready") {
+		t.Fatalf("waitForPodNetworkIdentity() error = %v, want network identity timeout", err)
+	}
+}
+
+func TestWaitForPodNetworkIdentityUsesCacheRecheckForMissedEventRace(t *testing.T) {
+	notReady := newClaimTestPod("ns-a", "cold-pod", "template-a", false)
+	ready := notReady.DeepCopy()
+	ready.Spec.NodeName = "node-a"
+	ready.Status.PodIP = "10.244.0.10"
+	lister := &sequencePodLister{pods: []*corev1.Pod{notReady, ready}}
+	svc := &SandboxService{
+		podLister: lister,
+		logger:    zap.NewNop(),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	readyPod, err := svc.waitForPodNetworkIdentity(ctx, "template-a", notReady.Namespace, notReady.Name)
+	if err != nil {
+		t.Fatalf("waitForPodNetworkIdentity() error = %v", err)
+	}
+	if readyPod.Status.PodIP != "10.244.0.10" {
+		t.Fatalf("pod IP = %q, want 10.244.0.10", readyPod.Status.PodIP)
+	}
+	if got := lister.callCount(); got != 2 {
+		t.Fatalf("pod lister Get calls = %d, want 2", got)
 	}
 }
 
@@ -1130,6 +1308,33 @@ func TestObserveClaimPhaseRecordsMetric(t *testing.T) {
 	}
 	if got := metric.GetHistogram().GetSampleSum(); got <= 0 {
 		t.Fatalf("claim phase sample sum = %f, want > 0", got)
+	}
+}
+
+func TestObservePodNetworkIdentityStageRecordsMetric(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	svc := &SandboxService{metrics: obsmetrics.NewManager(registry)}
+
+	svc.observePodNetworkIdentityStage("managed-agents", "pod_ip_assigned", "timeout", "pod IP is not assigned", time.Now().Add(-20*time.Millisecond))
+
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("gather metrics: %v", err)
+	}
+	metric := findMetric(families, "manager_pod_network_identity_stage_duration_seconds", map[string]string{
+		"template": "managed-agents",
+		"stage":    "pod_ip_assigned",
+		"status":   "timeout",
+		"reason":   "ip_unassigned",
+	})
+	if metric == nil || metric.GetHistogram() == nil {
+		t.Fatal("pod network identity stage histogram metric not found")
+	}
+	if got := metric.GetHistogram().GetSampleCount(); got != 1 {
+		t.Fatalf("pod network identity stage sample count = %d, want 1", got)
+	}
+	if got := metric.GetHistogram().GetSampleSum(); got <= 0 {
+		t.Fatalf("pod network identity stage sample sum = %f, want > 0", got)
 	}
 }
 
@@ -1923,4 +2128,66 @@ func metricLabelsMatch(metric *dto.Metric, labels map[string]string) bool {
 		}
 	}
 	return true
+}
+
+type sequencePodLister struct {
+	mu    sync.Mutex
+	pods  []*corev1.Pod
+	calls int
+}
+
+func (l *sequencePodLister) List(_ labels.Selector) ([]*corev1.Pod, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if len(l.pods) == 0 {
+		return nil, nil
+	}
+	return []*corev1.Pod{l.pods[len(l.pods)-1].DeepCopy()}, nil
+}
+
+func (l *sequencePodLister) Pods(namespace string) corelisters.PodNamespaceLister {
+	return &sequencePodNamespaceLister{parent: l, namespace: namespace}
+}
+
+func (l *sequencePodLister) callCount() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.calls
+}
+
+type sequencePodNamespaceLister struct {
+	parent    *sequencePodLister
+	namespace string
+}
+
+func (l *sequencePodNamespaceLister) List(_ labels.Selector) ([]*corev1.Pod, error) {
+	pods, err := l.parent.List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*corev1.Pod, 0, len(pods))
+	for _, pod := range pods {
+		if pod.Namespace == l.namespace {
+			out = append(out, pod)
+		}
+	}
+	return out, nil
+}
+
+func (l *sequencePodNamespaceLister) Get(name string) (*corev1.Pod, error) {
+	l.parent.mu.Lock()
+	defer l.parent.mu.Unlock()
+	if len(l.parent.pods) == 0 {
+		return nil, apierrors.NewNotFound(corev1.Resource("pods"), name)
+	}
+	index := l.parent.calls
+	if index >= len(l.parent.pods) {
+		index = len(l.parent.pods) - 1
+	}
+	l.parent.calls++
+	pod := l.parent.pods[index]
+	if pod == nil || pod.Namespace != l.namespace || pod.Name != name {
+		return nil, apierrors.NewNotFound(corev1.Resource("pods"), name)
+	}
+	return pod.DeepCopy(), nil
 }

--- a/manager/pkg/service/sandbox_service_network.go
+++ b/manager/pkg/service/sandbox_service_network.go
@@ -566,7 +566,7 @@ func (s *SandboxService) waitForColdPodNetworkPolicy(ctx context.Context, pod *c
 	if s.networkProvider == nil {
 		return pod, nil
 	}
-	networkPod, err := s.waitForPodNetworkIdentity(ctx, pod.Namespace, pod.Name)
+	networkPod, err := s.waitForPodNetworkIdentity(ctx, podNetworkIdentityTemplateLabel(pod), pod.Namespace, pod.Name)
 	if err != nil {
 		return pod, fmt.Errorf("wait for pod network identity: %w", err)
 	}
@@ -574,6 +574,19 @@ func (s *SandboxService) waitForColdPodNetworkPolicy(ctx context.Context, pod *c
 		return networkPod, fmt.Errorf("apply network policy: %w", err)
 	}
 	return networkPod, nil
+}
+
+func podNetworkIdentityTemplateLabel(pod *corev1.Pod) string {
+	if pod == nil || pod.Labels == nil {
+		return "unknown"
+	}
+	if template := strings.TrimSpace(pod.Labels[controller.LabelTemplateID]); template != "" {
+		return template
+	}
+	if template := strings.TrimSpace(pod.Labels[controller.LabelTemplateLogicalID]); template != "" {
+		return template
+	}
+	return "unknown"
 }
 
 // GetNetworkPolicy gets the effective sandbox network policy.

--- a/manager/pkg/service/sandbox_service_pod.go
+++ b/manager/pkg/service/sandbox_service_pod.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -96,7 +97,7 @@ func (s *SandboxService) waitForPodClaimReady(ctx context.Context, namespace, na
 	}
 }
 
-func (s *SandboxService) waitForPodNetworkIdentity(ctx context.Context, namespace, name string) (*corev1.Pod, error) {
+func (s *SandboxService) waitForPodNetworkIdentity(ctx context.Context, template, namespace, name string) (*corev1.Pod, error) {
 	timeout := s.config.ProcdInitTimeout
 	if timeout < defaultPodClaimReadyTimeout {
 		timeout = defaultPodClaimReadyTimeout
@@ -105,44 +106,82 @@ func (s *SandboxService) waitForPodNetworkIdentity(ctx context.Context, namespac
 	readyCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	ticker := time.NewTicker(50 * time.Millisecond)
-	defer ticker.Stop()
-
+	waiter := s.ensurePodNetworkIdentityWaiter()
+	tracker := newPodNetworkIdentityStageTracker(s, template)
 	lastReason := "pod network identity is not ready"
-	for {
+
+	evaluate := func(source string) (*corev1.Pod, bool, error) {
 		if s.podLister == nil {
-			return nil, fmt.Errorf("pod lister is not configured")
+			return nil, false, fmt.Errorf("pod lister is not configured")
 		}
 		pod, err := s.podLister.Pods(namespace).Get(name)
 		if err != nil {
 			if k8serrors.IsNotFound(err) {
 				lastReason = fmt.Sprintf("pod %s/%s is not visible", namespace, name)
-				select {
-				case <-readyCtx.Done():
-					s.observePodNetworkIdentityCheck("cache", "timeout", lastReason)
-					return nil, fmt.Errorf("pod %s/%s network identity not ready after %s: %s", namespace, name, timeout, lastReason)
-				case <-ticker.C:
-					continue
-				}
+				s.observePodNetworkIdentityCheck(source, "not_ready", lastReason)
+				return nil, false, nil
 			}
-			s.observePodNetworkIdentityCheck("cache", "error", "get pod for network identity")
-			return nil, fmt.Errorf("get pod for network identity: %w", err)
+			reason := "get pod for network identity"
+			s.observePodNetworkIdentityCheck(source, "error", reason)
+			tracker.observeFailure("error", reason)
+			return nil, false, fmt.Errorf("get pod for network identity: %w", err)
 		}
 
+		tracker.observePod(pod)
 		ready, reason := isPodNetworkIdentityReady(pod)
 		if ready {
-			s.observePodNetworkIdentityCheck("cache", "ready", "ready")
-			return pod, nil
+			s.observePodNetworkIdentityCheck(source, "ready", "ready")
+			return pod, true, nil
 		}
 		if reason != "" {
 			lastReason = reason
 		}
+		if isTerminalPodNetworkIdentityReason(lastReason) {
+			s.observePodNetworkIdentityCheck(source, "error", lastReason)
+			tracker.observeFailure("error", lastReason)
+			return nil, false, fmt.Errorf("pod %s/%s network identity not ready: %s", namespace, name, lastReason)
+		}
+		s.observePodNetworkIdentityCheck(source, "not_ready", lastReason)
+		return nil, false, nil
+	}
 
+	if pod, ready, err := evaluate("cache"); err != nil || ready {
+		return pod, err
+	}
+
+	events, unregister := waiter.register(namespace, name)
+	defer unregister()
+
+	// Recheck after registering to avoid missing an informer event that arrives
+	// between the initial cache read and waiter registration.
+	if pod, ready, err := evaluate("cache_recheck"); err != nil || ready {
+		return pod, err
+	}
+
+	for {
 		select {
 		case <-readyCtx.Done():
-			s.observePodNetworkIdentityCheck("cache", "timeout", lastReason)
+			if ctxErr := ctx.Err(); ctxErr != nil && !errors.Is(ctxErr, context.DeadlineExceeded) {
+				lastReason = ctxErr.Error()
+				s.observePodNetworkIdentityCheck("context", "canceled", lastReason)
+				tracker.observeFailure("canceled", lastReason)
+				return nil, fmt.Errorf("pod %s/%s network identity wait canceled: %w", namespace, name, ctxErr)
+			}
+			s.observePodNetworkIdentityCheck("informer", "timeout", lastReason)
+			tracker.observeFailure("timeout", lastReason)
 			return nil, fmt.Errorf("pod %s/%s network identity not ready after %s: %s", namespace, name, timeout, lastReason)
-		case <-ticker.C:
+		case event := <-events:
+			if event.deleted {
+				tracker.observePod(event.pod)
+				lastReason = "pod is deleting"
+				s.observePodNetworkIdentityCheck("informer", "error", lastReason)
+				tracker.observeFailure("error", lastReason)
+				return nil, fmt.Errorf("pod %s/%s network identity not ready: %s", namespace, name, lastReason)
+			}
+			pod, ready, err := evaluate("informer")
+			if err != nil || ready {
+				return pod, err
+			}
 		}
 	}
 }
@@ -158,6 +197,29 @@ func (s *SandboxService) observePodNetworkIdentityCheck(source, result, reason s
 		result = "unknown"
 	}
 	s.metrics.PodNetworkIdentityChecksTotal.WithLabelValues(source, result, podNetworkIdentityReasonLabel(reason)).Inc()
+}
+
+func (s *SandboxService) observePodNetworkIdentityStage(template, stage, status, reason string, started time.Time) {
+	s.observePodNetworkIdentityStageDuration(template, stage, status, reason, time.Since(started))
+}
+
+func (s *SandboxService) observePodNetworkIdentityStageDuration(template, stage, status, reason string, duration time.Duration) {
+	if s == nil || s.metrics == nil || s.metrics.PodNetworkIdentityStageDuration == nil {
+		return
+	}
+	if template == "" {
+		template = "unknown"
+	}
+	if stage == "" {
+		stage = "unknown"
+	}
+	if status == "" {
+		status = "unknown"
+	}
+	if duration < 0 {
+		duration = 0
+	}
+	s.metrics.PodNetworkIdentityStageDuration.WithLabelValues(template, stage, status, podNetworkIdentityReasonLabel(reason)).Observe(duration.Seconds())
 }
 
 func podNetworkIdentityReasonLabel(reason string) string {
@@ -177,9 +239,72 @@ func podNetworkIdentityReasonLabel(reason string) string {
 		return "deleting"
 	case strings.Contains(reason, "get pod"):
 		return "get_error"
+	case strings.Contains(reason, "context canceled"):
+		return "context_canceled"
+	case strings.Contains(reason, "deadline exceeded"):
+		return "deadline"
 	default:
 		return "not_ready"
 	}
+}
+
+type podNetworkIdentityStageTracker struct {
+	service   *SandboxService
+	template  string
+	started   time.Time
+	visibleAt time.Time
+	nodeAt    time.Time
+	podIPAt   time.Time
+}
+
+func newPodNetworkIdentityStageTracker(service *SandboxService, template string) *podNetworkIdentityStageTracker {
+	return &podNetworkIdentityStageTracker{
+		service:  service,
+		template: template,
+		started:  time.Now(),
+	}
+}
+
+func (t *podNetworkIdentityStageTracker) observePod(pod *corev1.Pod) {
+	if t == nil || pod == nil {
+		return
+	}
+	now := time.Now()
+	if t.visibleAt.IsZero() {
+		t.service.observePodNetworkIdentityStageDuration(t.template, "cache_visible", "success", "ready", now.Sub(t.started))
+		t.visibleAt = now
+	}
+	if strings.TrimSpace(pod.Spec.NodeName) != "" && t.nodeAt.IsZero() {
+		t.service.observePodNetworkIdentityStageDuration(t.template, "node_assigned", "success", "ready", now.Sub(t.visibleAt))
+		t.nodeAt = now
+	}
+	if strings.TrimSpace(pod.Spec.NodeName) != "" && strings.TrimSpace(pod.Status.PodIP) != "" && t.podIPAt.IsZero() {
+		t.service.observePodNetworkIdentityStageDuration(t.template, "pod_ip_assigned", "success", "ready", now.Sub(t.nodeAt))
+		t.podIPAt = now
+	}
+}
+
+func (t *podNetworkIdentityStageTracker) observeFailure(status, reason string) {
+	if t == nil || !t.podIPAt.IsZero() {
+		return
+	}
+	now := time.Now()
+	stage := "cache_visible"
+	started := t.started
+	if !t.visibleAt.IsZero() {
+		stage = "node_assigned"
+		started = t.visibleAt
+	}
+	if !t.nodeAt.IsZero() {
+		stage = "pod_ip_assigned"
+		started = t.nodeAt
+	}
+	t.service.observePodNetworkIdentityStageDuration(t.template, stage, status, reason, now.Sub(started))
+}
+
+func isTerminalPodNetworkIdentityReason(reason string) bool {
+	label := podNetworkIdentityReasonLabel(reason)
+	return label == "terminal" || label == "deleting"
 }
 
 func isPodNetworkIdentityReady(pod *corev1.Pod) (bool, string) {

--- a/pkg/observability/metrics/manager.go
+++ b/pkg/observability/metrics/manager.go
@@ -7,35 +7,36 @@ import (
 
 // ManagerMetrics holds Prometheus metrics for the manager service.
 type ManagerMetrics struct {
-	TemplatesTotal                 prometheus.Gauge
-	IdlePodsTotal                  *prometheus.GaugeVec
-	ActivePodsTotal                *prometheus.GaugeVec
-	SandboxClaimsTotal             *prometheus.CounterVec
-	SandboxClaimDuration           *prometheus.HistogramVec
-	SandboxClaimPhaseDuration      *prometheus.HistogramVec
-	SandboxIdleClaimsTotal         *prometheus.CounterVec
-	PodNetworkIdentityChecksTotal  *prometheus.CounterVec
-	NetworkPolicyApplyTotal        *prometheus.CounterVec
-	NetworkPolicyApplyDuration     *prometheus.HistogramVec
-	K8sClientRateLimit             *prometheus.GaugeVec
-	AutoscalerDecisionsTotal       *prometheus.CounterVec
-	AutoscalerPoolReplicas         *prometheus.GaugeVec
-	AutoscalerPoolPods             *prometheus.GaugeVec
-	AutoscalerColdClaimsInFlight   *prometheus.GaugeVec
-	AutoscalerScaleDelta           *prometheus.HistogramVec
-	PodsCleanedTotal               *prometheus.CounterVec
-	ReconcileTotal                 *prometheus.CounterVec
-	ReconcileDuration              *prometheus.HistogramVec
-	MeteringEventsTotal            *prometheus.CounterVec
-	MeteringWindowsTotal           *prometheus.CounterVec
-	MeteringErrorsTotal            *prometheus.CounterVec
-	RootFSMaintenanceRunsTotal     *prometheus.CounterVec
-	RootFSMaintenanceDuration      *prometheus.HistogramVec
-	RootFSGCLayersTotal            prometheus.Counter
-	RootFSObjectDeletesTotal       *prometheus.CounterVec
-	RootFSObjectDeletionQueueDepth *prometheus.GaugeVec
-	RootFSStorageBytes             prometheus.Gauge
-	RootFSStorageObjects           prometheus.Gauge
+	TemplatesTotal                  prometheus.Gauge
+	IdlePodsTotal                   *prometheus.GaugeVec
+	ActivePodsTotal                 *prometheus.GaugeVec
+	SandboxClaimsTotal              *prometheus.CounterVec
+	SandboxClaimDuration            *prometheus.HistogramVec
+	SandboxClaimPhaseDuration       *prometheus.HistogramVec
+	SandboxIdleClaimsTotal          *prometheus.CounterVec
+	PodNetworkIdentityChecksTotal   *prometheus.CounterVec
+	PodNetworkIdentityStageDuration *prometheus.HistogramVec
+	NetworkPolicyApplyTotal         *prometheus.CounterVec
+	NetworkPolicyApplyDuration      *prometheus.HistogramVec
+	K8sClientRateLimit              *prometheus.GaugeVec
+	AutoscalerDecisionsTotal        *prometheus.CounterVec
+	AutoscalerPoolReplicas          *prometheus.GaugeVec
+	AutoscalerPoolPods              *prometheus.GaugeVec
+	AutoscalerColdClaimsInFlight    *prometheus.GaugeVec
+	AutoscalerScaleDelta            *prometheus.HistogramVec
+	PodsCleanedTotal                *prometheus.CounterVec
+	ReconcileTotal                  *prometheus.CounterVec
+	ReconcileDuration               *prometheus.HistogramVec
+	MeteringEventsTotal             *prometheus.CounterVec
+	MeteringWindowsTotal            *prometheus.CounterVec
+	MeteringErrorsTotal             *prometheus.CounterVec
+	RootFSMaintenanceRunsTotal      *prometheus.CounterVec
+	RootFSMaintenanceDuration       *prometheus.HistogramVec
+	RootFSGCLayersTotal             prometheus.Counter
+	RootFSObjectDeletesTotal        *prometheus.CounterVec
+	RootFSObjectDeletionQueueDepth  *prometheus.GaugeVec
+	RootFSStorageBytes              prometheus.Gauge
+	RootFSStorageObjects            prometheus.Gauge
 }
 
 // NewManager registers and returns manager metrics.
@@ -82,6 +83,11 @@ func NewManager(registry prometheus.Registerer) *ManagerMetrics {
 			Name: "manager_pod_network_identity_checks_total",
 			Help: "Total number of pod network identity readiness checks by source, result, and reason",
 		}, []string{"source", "result", "reason"}),
+		PodNetworkIdentityStageDuration: factory.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "manager_pod_network_identity_stage_duration_seconds",
+			Help:    "Duration of pod network identity wait stages",
+			Buckets: []float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 30, 60, 120},
+		}, []string{"template", "stage", "status", "reason"}),
 		NetworkPolicyApplyTotal: factory.NewCounterVec(prometheus.CounterOpts{
 			Name: "manager_network_policy_apply_total",
 			Help: "Total number of network policy apply attempts by provider and result",


### PR DESCRIPTION
## Summary
- replace cold-claim pod network identity polling with a shared pod informer event waiter
- keep cache fast path and add a post-registration cache recheck for missed-event races
- add pod network identity stage histogram metrics for cache visibility, node assignment, and PodIP assignment
- cover ready, nodeName-only, PodIP-only, deletion, terminal, timeout, and missed-event race cases

## Tests
- `GOTOOLCHAIN=go1.25.0+auto GOWORK=off go test ./manager/pkg/service -run 'TestWaitForPodNetworkIdentity|TestObservePodNetworkIdentityStageRecordsMetric|TestObserveClaimPhaseRecordsMetric' -count=1`
- `GOTOOLCHAIN=go1.25.0+auto GOWORK=off go test ./manager/pkg/service -count=1`\n- `GOTOOLCHAIN=go1.25.0+auto GOWORK=off go test ./manager/cmd/manager ./pkg/observability/metrics -count=1`
- `GOTOOLCHAIN=go1.25.0+auto GOWORK=off go test ./manager/pkg/controller -count=1`\n- `GOTOOLCHAIN=go1.25.0+auto GOWORK=off go test ./manager/... -count=1`
- Fixes #635