### PR TITLE
docs: add Managed Agents skills guide

### DIFF
--- a/docs/managed-agents/agents/page.mdx
+++ b/docs/managed-agents/agents/page.mdx
@@ -77,6 +77,7 @@ If the MCP server needs credentials, attach a vault to the session. The agent de
 
 - Reserved `sandbox0.managed_agents.*` metadata keys are not accepted on agents.
 - The agent model defaults to the Claude harness unless a session attaches an LLM vault that selects another supported harness.
+- Only custom skills are supported. Use `type: "custom"` with a `skill_*` id from the Skills API.
 - The agent object is copied into the session snapshot. Later agent updates do not mutate existing sessions.
 
 ## Next Steps
@@ -84,6 +85,10 @@ If the MCP server needs credentials, attach a vault to the session. The agent de
 <CardGroup>
   <Card title="Environments" href="/docs/managed-agents/environments" cta="Continue">
     Prepare reusable environments with packages and network policy.
+  </Card>
+
+  <Card title="Skills" href="/docs/managed-agents/skills" cta="Continue">
+    Upload reusable skill bundles and attach versions to agents.
   </Card>
 
   <Card title="Sessions" href="/docs/managed-agents/sessions" cta="Continue">

--- a/docs/managed-agents/compatibility/page.mdx
+++ b/docs/managed-agents/compatibility/page.mdx
@@ -18,7 +18,7 @@ Official reference: [Claude Managed Agents quickstart](https://platform.claude.c
 | Events | Supported for list, send, and event streaming |
 | Files | Supported for upload, metadata, download, delete, session-scoped resources, scoped listing, captured output files, and file-backed message content |
 | Vaults and credentials | Supported for LLM credentials, MCP credentials, Sandbox0 HTTP header credential projection, and sandbox environment variable credentials |
-| Custom skills | Supported through uploaded skill versions |
+| Custom skills | Supported through uploaded skill versions. See [Skills](/docs/managed-agents/skills). |
 | MCP servers | Supported for URL MCP servers and vault-backed credentials |
 | GitHub repository resources | Supported at session creation |
 | Agent harnesses | Supported for `claude` and `codex` |

--- a/docs/managed-agents/page.mdx
+++ b/docs/managed-agents/page.mdx
@@ -84,6 +84,7 @@ The official Claude Managed Agents documentation is still the canonical SDK refe
 
 - [Quickstart](https://platform.claude.com/docs/en/managed-agents/quickstart)
 - [Agent setup](https://platform.claude.com/docs/en/managed-agents/agent-setup)
+- [Skills](https://platform.claude.com/docs/en/managed-agents/skills)
 - [Environments](https://platform.claude.com/docs/en/managed-agents/environments)
 - [Sessions](https://platform.claude.com/docs/en/managed-agents/sessions)
 - [Files](https://platform.claude.com/docs/en/build-with-claude/files)
@@ -99,6 +100,10 @@ The official Claude Managed Agents documentation is still the canonical SDK refe
 
   <Card title="Agents" href="/docs/managed-agents/agents" cta="Continue">
     Define versioned agents with prompts, tools, MCP servers, and skills.
+  </Card>
+
+  <Card title="Skills" href="/docs/managed-agents/skills" cta="Continue">
+    Upload custom skill bundles and attach versioned expertise to agents.
   </Card>
 
   <Card title="Files" href="/docs/managed-agents/files" cta="Continue">

--- a/docs/managed-agents/sdk/page.mdx
+++ b/docs/managed-agents/sdk/page.mdx
@@ -156,6 +156,10 @@ curl -fsS "https://agents.sandbox0.ai/v1/sessions" \
     Define versioned agents with prompts, tools, MCP servers, and skills.
   </Card>
 
+  <Card title="Skills" href="/docs/managed-agents/skills" cta="Continue">
+    Upload custom skill bundles with the official SDK.
+  </Card>
+
   <Card title="Environments" href="/docs/managed-agents/environments" cta="Continue">
     Prepare reusable environments with packages and network policy.
   </Card>

--- a/docs/managed-agents/skills/page.mdx
+++ b/docs/managed-agents/skills/page.mdx
@@ -1,0 +1,201 @@
+# Skills
+
+Skills attach reusable, filesystem-backed expertise to a Managed Agents agent. Use them for workflows, reference material, examples, and helper files that should be available across sessions without copying the same instructions into every prompt.
+
+Official references:
+
+- [Claude Managed Agents skills](https://platform.claude.com/docs/en/managed-agents/skills)
+- [Agent Skills overview](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview)
+- [Skill authoring best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices)
+
+<Callout variant="warning">
+Sandbox0 Managed Agents currently supports custom skills uploaded through the Skills API. Anthropic pre-built skills such as `pptx`, `xlsx`, `docx`, and `pdf` are not supported in Sandbox0 Managed Agents.
+</Callout>
+
+## Create A Skill
+
+A custom skill is a directory with a `SKILL.md` file at the root. Upload every file with the same top-level directory prefix.
+
+```typescript
+import { toFile } from "@anthropic-ai/sdk";
+
+const skill = await client.beta.skills.create({
+    display_title: "Repository Review",
+    files: [
+        await toFile(
+            Buffer.from([
+                "---",
+                "name: repository-review",
+                "description: Review repository changes and identify risks before merge.",
+                "---",
+                "",
+                "# Repository Review",
+                "",
+                "Check the changed files, run the relevant tests, and report blocking risks first.",
+                "",
+            ].join("\n")),
+            "repository-review/SKILL.md",
+            { type: "text/markdown" },
+        ),
+        await toFile(
+            Buffer.from("Prefer focused tests before full-suite validation.\n"),
+            "repository-review/guidance.md",
+            { type: "text/markdown" },
+        ),
+    ],
+});
+
+console.log(skill.id, skill.latest_version);
+```
+
+The returned `skill.id` is the `skill_*` identifier used when attaching the skill to an agent. `latest_version` is the first uploaded version.
+
+## Skill Structure
+
+`SKILL.md` must begin with YAML front matter:
+
+```markdown
+---
+name: repository-review
+description: Review repository changes and identify risks before merge.
+---
+
+# Repository Review
+
+## Instructions
+
+Check the changed files, run the relevant tests, and report blocking risks first.
+```
+
+The front matter drives skill discovery. The body and supporting files are loaded by the selected agent harness when the skill is relevant.
+
+Sandbox0 validates the uploaded bundle:
+
+| Requirement | Value |
+|-------------|-------|
+| Descriptor path | Top-level `SKILL.md` inside one skill directory |
+| Required front matter | `name`, `description` |
+| `name` | Lowercase letters, numbers, and hyphens; at most 64 characters |
+| `description` | Non-empty; at most 1024 characters |
+| Reserved names | `anthropic`, `claude`, `codex`, `openai` |
+| Upload size | 30 MiB combined multipart payload |
+
+All uploaded paths must stay within the same top-level directory and must not contain parent directory segments.
+
+## Version A Skill
+
+Create a new version when the skill content changes:
+
+```typescript
+const nextVersion = await client.beta.skills.versions.create(skill.id, {
+    files: [
+        await toFile(
+            Buffer.from([
+                "---",
+                "name: repository-review",
+                "description: Review repository changes and identify risks before merge.",
+                "---",
+                "",
+                "# Repository Review",
+                "",
+                "Check the diff, tests, deployment impact, and rollback path.",
+                "",
+            ].join("\n")),
+            "repository-review/SKILL.md",
+            { type: "text/markdown" },
+        ),
+    ],
+});
+
+console.log(nextVersion.skill_id, nextVersion.version);
+```
+
+List and retrieve versions with the official SDK:
+
+```typescript
+for await (const version of client.beta.skills.versions.list(skill.id, { limit: 20 })) {
+    console.log(version.version, version.description);
+}
+
+const pinned = await client.beta.skills.versions.retrieve(nextVersion.version, {
+    skill_id: skill.id,
+});
+```
+
+Use version pinning when reproducibility matters. If you omit `version` when attaching a custom skill to an agent, Sandbox0 resolves the skill's current `latest_version` during agent creation or update.
+
+## Attach Skills To Agents
+
+Attach skills on the agent definition:
+
+```typescript
+const agent = await client.beta.agents.create({
+    name: "Code Reviewer",
+    model: { id: "claude-sonnet-4-20250514" },
+    system: "Review code changes and keep feedback concise.",
+    tools: [{ type: "agent_toolset_20260401" }],
+    skills: [{
+        type: "custom",
+        skill_id: skill.id,
+        version: nextVersion.version,
+    }],
+});
+```
+
+An agent can reference up to 20 skills. Sessions snapshot the agent definition at creation time, so changing a skill attachment on the agent does not mutate already-created sessions.
+
+## Runtime Behavior
+
+When a session starts, Sandbox0 resolves the agent's custom skill versions, reads the stored bundles from the team asset store, and materializes them into the session workspace for the selected harness.
+
+| Harness | Skill directory |
+|---------|-----------------|
+| `claude` | `<working_directory>/.claude/skills/<skill-directory>/SKILL.md` |
+| `codex` | `<working_directory>/.agents/skills/<skill-directory>/SKILL.md` |
+
+These paths are harness integration details. Application code should attach skills through the agent `skills` field rather than writing directly into those directories.
+
+## List And Delete Skills
+
+List custom skills:
+
+```typescript
+for await (const item of client.beta.skills.list({ source: "custom", limit: 20 })) {
+    console.log(item.id, item.latest_version);
+}
+```
+
+Delete a skill or a single version when it is no longer needed:
+
+```typescript
+await client.beta.skills.versions.delete(nextVersion.version, { skill_id: skill.id });
+await client.beta.skills.delete(skill.id);
+```
+
+Deleting a skill removes all of its versions. Deleting a version removes only that version and updates `latest_version` when an older version remains.
+
+## Compatibility Notes
+
+Sandbox0 accepts `source: "anthropic"` in `skills.list()` for SDK compatibility, but currently returns an empty list. Agent definitions with `type: "anthropic"` skills are rejected because Sandbox0 does not provide Anthropic's pre-built skill catalog.
+
+For direct HTTP calls to `/v1/skills`, include either `anthropic-beta: managed-agents-2026-04-01` or `anthropic-beta: skills-2025-10-02`. SDK users do not need to set these headers manually.
+
+## Security
+
+Treat skills like installed software. Review `SKILL.md`, scripts, examples, and supporting files before uploading them. Be especially careful with skills that instruct the agent to fetch remote content, run shell commands, or handle sensitive data.
+
+## Next Steps
+
+<CardGroup>
+  <Card title="Agents" href="/docs/managed-agents/agents" cta="Continue">
+    Attach skill versions to versioned agent definitions.
+  </Card>
+
+  <Card title="Agent Harnesses" href="/docs/managed-agents/agent-harnesses" cta="Continue">
+    Review how each runtime adapter projects skills into the workspace.
+  </Card>
+
+  <Card title="Compatibility" href="/docs/managed-agents/compatibility" cta="Continue">
+    Check current compatibility boundaries, including pre-built skill support.
+  </Card>
+</CardGroup>

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -123,6 +123,10 @@
           "title": "Agents"
         },
         {
+          "slug": "skills",
+          "title": "Skills"
+        },
+        {
           "slug": "environments",
           "title": "Environments"
         },


### PR DESCRIPTION
## Summary
- add a standalone Managed Agents Skills docs page
- document custom skill upload, SKILL.md structure, versioning, agent attachment, runtime projection, limits, and compatibility boundaries
- link the new page from the Managed Agents overview, Agents, SDK, and Compatibility docs

## Verification
- generated docs registry to a temporary output root with the website docs generator
- confirmed generated navigation, raw sources, and content registry include /docs/managed-agents/skills
- ran git diff --check
- type-checked the documented TypeScript SDK snippets against @anthropic-ai/sdk 0.88.0 with tsc --noEmit
