### PR TITLE
Add builtin browser template

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The sandbox is the execution boundary, not the durable source of truth. Sandbox 
 | Path | Use it when | Start here |
 | --- | --- | --- |
 | **Raw Sandboxes** | You want direct control over processes, files, volumes, ports, templates, and network policy. | [Get started](https://sandbox0.ai/docs/get-started) |
-| **Agent in Sandbox** | You want an agent framework gateway to run inside a sandbox, with state on a volume and its API exposed through Sandbox0 routes. | [Agent in Sandbox](https://sandbox0.ai/docs/agent-in-sandbox) |
+| **Use Cases** | You want an agent framework gateway, browser automation API, or similar tool to run inside a sandbox, with state on a volume and its API exposed through Sandbox0 routes. | [Use Cases](https://sandbox0.ai/docs/use-cases) |
 | **Self-hosted** | You need private deployment, data-plane ownership, regional storage boundaries, or custom runtime isolation. | [Self-hosted](https://sandbox0.ai/docs/self-hosted) |
 
 ## Quickstart
@@ -211,7 +211,7 @@ For API changes, `pkg/apispec/openapi.yaml` is the source of truth. Generated SD
 
 ## Known Boundaries
 
-- Sandbox0 is a runtime boundary, not a complete agent framework. Bring your own harness or use Agent in Sandbox when you want a framework gateway to live inside the sandbox boundary.
+- Sandbox0 is a runtime boundary, not a complete agent framework. Bring your own harness or use the documented use-case templates when you want a framework gateway to live inside the sandbox boundary.
 - Pause/resume does not preserve live processes, sockets, or memory. Runtime requests are routed to a committed generation; during lifecycle transitions they may wait for the transaction to commit and continue after resume.
 - Self-hosted production installs require deliberate choices for Kubernetes runtime isolation, CNI, PostgreSQL, S3-compatible storage, registry, ingress, and credential policy.
 - Browser and computer-use workloads require templates and integrations that include the browser/runtime tools you need.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -13,8 +13,15 @@
         "volume",
         "credential",
         "integrations",
-        "self-hosted",
-        "agent-in-sandbox"
+        "self-hosted"
+      ]
+    },
+    {
+      "slug": "use-cases",
+      "title": "use-cases",
+      "defaultPage": "use-cases",
+      "sections": [
+        "use-cases"
       ]
     },
     {
@@ -168,20 +175,28 @@
       ]
     },
     {
-      "label": "AGENT IN SANDBOX",
-      "slug": "agent-in-sandbox",
+      "label": "USE CASES",
+      "slug": "use-cases",
+      "aliases": [
+        "agent-in-sandbox",
+        "sandbox/agent-in-sandbox"
+      ],
       "pages": [
         {
           "slug": "",
-          "title": "Overview"
+          "title": "Use Cases"
         },
         {
           "slug": "openclaw",
-          "title": "OpenClaw"
+          "title": "Hosting OpenClaw"
         },
         {
           "slug": "hermes",
-          "title": "Hermes"
+          "title": "Hosting Hermes"
+        },
+        {
+          "slug": "browser",
+          "title": "Hosting Steel Browser"
         }
       ]
     },

--- a/docs/self-hosted/configuration/page.mdx
+++ b/docs/self-hosted/configuration/page.mdx
@@ -27,7 +27,7 @@ A `Sandbox0Infra` spec is easier to reason about when you split it into five lay
 `spec.initUser` is consumed by the gateway runtime, not created by the operator itself.
 In local-password mode it bootstraps the first admin credentials; in OIDC-only mode it pre-creates the admin user and initial team so the first OIDC login with the same email lands on the intended admin account.
 
-When `spec.builtinTemplates` is omitted, infra-operator seeds public builtin templates for `default`, `openclaw`, and `hermes`. Set `spec.builtinTemplates` explicitly when you want to pin images, adjust pools, disable one of the builtins, or provide a full template `spec` for a runtime-specific setup. Set it to `[]` to remove all operator-managed builtin templates.
+When `spec.builtinTemplates` is omitted, infra-operator seeds public builtin templates for `default`, `openclaw`, `hermes`, and `browser`. Set `spec.builtinTemplates` explicitly when you want to pin images, adjust pools, disable one of the builtins, or provide a full template `spec` for a runtime-specific setup. Set it to `[]` to remove all operator-managed builtin templates.
 
 ## Deployment Profiles
 

--- a/docs/use-cases/browser/page.mdx
+++ b/docs/use-cases/browser/page.mdx
@@ -1,0 +1,98 @@
+# Hosting Steel Browser
+
+Run a browser automation API inside a Sandbox0 sandbox when you want CDP, browser profile state, cookies, downloads, and a live browser view behind Sandbox0 lifecycle and public ingress.
+
+The builtin `browser` template uses the upstream Steel Browser image. It stores Chrome profile data under `/browser/profile` on the sandbox rootfs and declares `/files` as the SandboxVolume mount point for downloads and file exchange.
+
+## Create The Service
+
+Create a SandboxVolume, claim the builtin `browser` template, mount that volume at `/files`, and expose Steel Browser as a `cmd` Sandbox Service. The service command runs the Steel image entrypoint directly; no wrapper image or script is required.
+
+```json
+{
+    "id": "browser",
+    "display_name": "Browser",
+    "port": 3000,
+    "runtime": {
+        "type": "cmd",
+        "command": [
+            "sh",
+            "-lc",
+            "set -eu\nexport PORT=\"${SANDBOX0_SERVICE_PORT}\"\nexport HOST=\"0.0.0.0\"\nif [ -n \"${SANDBOX0_APP_DOMAIN:-}\" ]; then\n    export DOMAIN=\"${SANDBOX0_SANDBOX_ID}--p${SANDBOX0_SERVICE_PORT}.${SANDBOX0_APP_DOMAIN}\"\n    export USE_SSL=true\nfi\nexec /app/api/entrypoint.sh --no-nginx"
+        ]
+    },
+    "ingress": {
+        "public": true,
+        "routes": [
+            {
+                "id": "api",
+                "path_prefix": "/",
+                "rewrite_prefix": "/",
+                "timeout_seconds": 300,
+                "resume": true,
+                "auth": {
+                    "mode": "bearer",
+                    "bearer_token_sha256": "<sha256-of-route-token>"
+                }
+            }
+        ]
+    },
+    "health_check": {
+        "path": "/v1/health"
+    }
+}
+```
+
+`SANDBOX0_SANDBOX_ID`, `SANDBOX0_APP_DOMAIN`, and `SANDBOX0_SERVICE_PORT` are injected by Sandbox0. Steel uses `DOMAIN` and `USE_SSL=true` to return public `https` and `wss` URLs in session responses.
+
+## Use The Browser
+
+After the sandbox is claimed, list the sandbox services and use the `public_url` for the `browser` service as the Steel base URL.
+
+```bash
+export BROWSER_BASE_URL="https://<sandbox-id>--p3000.<region>.<root-domain>"
+export BROWSER_ROUTE_TOKEN="<route-token>"
+
+curl -sS "$BROWSER_BASE_URL/v1/sessions" \
+    -H "Authorization: Bearer $BROWSER_ROUTE_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d '{}'
+```
+
+The session response includes `websocketUrl` for CDP clients, `debugUrl` for the live browser view, `debuggerUrl` for DevTools, and `sessionViewerUrl` for the Steel session viewer.
+
+When route auth is enabled, CDP and WebSocket clients must send the configured auth header. For human live-view access in a normal browser, open `debugUrl` through a protected frontend that can authenticate the route, or use a route auth mode that matches your access boundary.
+
+Browser automation clients can connect to `websocketUrl` with Playwright or a CDP client:
+
+```js
+import { chromium } from "playwright";
+
+const browser = await chromium.connectOverCDP(session.websocketUrl, {
+    headers: { Authorization: `Bearer ${process.env.BROWSER_ROUTE_TOKEN}` },
+});
+const page = browser.contexts()[0].pages()[0];
+await page.goto("https://example.com");
+```
+
+## Persistence
+
+Chrome profile data, cookies, local storage, and extension state live in `/browser/profile`, which is part of the sandbox rootfs. Downloads and file exchange live under `/files`; mount a SandboxVolume there when the files need to outlive a runtime pod or be shared with other workflows.
+
+Do not pass Steel `persist` or `userDataDir` session options unless you intentionally want to override the template's `CHROME_USER_DATA_DIR`.
+
+Running processes, sockets, and memory are not preserved across pause/resume. Runtime requests are routed to a committed generation and may wait while lifecycle transactions commit.
+
+## Capabilities
+
+The browser API is provided by Steel Browser and Chromium inside the image:
+
+| Capability | Path |
+|------------|------|
+| CDP | Steel returns `websocketUrl` from `/v1/sessions` |
+| Extensions | Pass extension options through the Steel session API |
+| Profiles and cookies | Chrome user data directory at `/browser/profile` |
+| Downloads and files | Steel file service path `/files` |
+| Live view | Steel `debugUrl`, `sessionViewerUrl`, and cast WebSocket routes |
+
+The builtin template is configurable through `Sandbox0Infra.spec.builtinTemplates`. Remove `templateId: browser` from that list to delete the operator-managed public template, or replace its `image`, `pool`, or full `spec` to pin a reviewed Steel Browser image.

--- a/docs/use-cases/hermes/page.mdx
+++ b/docs/use-cases/hermes/page.mdx
@@ -1,4 +1,4 @@
-# Hermes
+# Hosting Hermes
 
 Run Hermes inside a Sandbox0 sandbox when you want Hermes sessions, memory, skills, and gateway state to live on a SandboxVolume while Sandbox0 controls runtime lifecycle and public ingress.
 
@@ -401,7 +401,7 @@ The builtin template is configurable through `Sandbox0Infra.spec.builtinTemplate
 ## Next Steps
 
 <CardGroup>
-  <Card title="OpenClaw" href="/docs/sandbox/agent-in-sandbox/openclaw" cta="Continue">
+  <Card title="Hosting OpenClaw" href="/docs/use-cases/openclaw" cta="Continue">
     Run OpenClaw from the builtin OpenClaw template.
   </Card>
 

--- a/docs/use-cases/openclaw/page.mdx
+++ b/docs/use-cases/openclaw/page.mdx
@@ -1,4 +1,4 @@
-# OpenClaw
+# Hosting OpenClaw
 
 Run OpenClaw inside a Sandbox0 sandbox when you want the OpenClaw gateway, workspace, logs, and session state to live behind Sandbox0 runtime controls.
 
@@ -351,7 +351,7 @@ The builtin template is configurable through `Sandbox0Infra.spec.builtinTemplate
 ## Next Steps
 
 <CardGroup>
-  <Card title="Hermes" href="/docs/sandbox/agent-in-sandbox/hermes" cta="Continue">
+  <Card title="Hosting Hermes" href="/docs/use-cases/hermes" cta="Continue">
     Run the Hermes gateway with a persistent `/opt/data` volume.
   </Card>
 

--- a/docs/use-cases/page.mdx
+++ b/docs/use-cases/page.mdx
@@ -1,8 +1,8 @@
-# Agent in Sandbox
+# Use Cases
 
-Agent in Sandbox runs an agent framework gateway inside a Sandbox0 sandbox instead of on a cloud VM, VPS, or developer workstation.
+Use these patterns when you want to host an agent framework gateway, browser automation API, or similar developer tool inside a Sandbox0 sandbox instead of on a cloud VM, VPS, or developer workstation.
 
-Use this pattern when the agent needs a long-lived workspace, controlled network access, and a service endpoint, but you do not want the sandbox runtime to become the place where broad production credentials live.
+Use these patterns when the runtime needs a long-lived workspace, controlled network access, and a service endpoint, but you do not want the sandbox runtime to become the place where broad production credentials live.
 
 ## Why Not A VM Or VPS?
 
@@ -31,21 +31,23 @@ This is a better fit for agents that process untrusted inputs, run tools, browse
 
 The agent framework still owns its own sessions, memory format, plugins, and application-level APIs. Sandbox0 owns the runtime boundary around it.
 
-## Builtin Agent Templates
+## Builtin Use-Case Templates
 
 Self-hosted deployments seed these public builtin templates when `spec.builtinTemplates` is omitted:
 
 ```bash
 s0 template get openclaw
 s0 template get hermes
+s0 template get browser
 ```
 
-Operators can pin images, tune pools, or remove either template by setting `Sandbox0Infra.spec.builtinTemplates` explicitly. The default builtin images are:
+Operators can pin images, tune pools, or remove a template by setting `Sandbox0Infra.spec.builtinTemplates` explicitly. The default builtin images are:
 
 | Template | Image |
 |----------|-------|
 | `openclaw` | `ghcr.io/openclaw/openclaw:latest` |
 | `hermes` | `nousresearch/hermes-agent:latest` |
+| `browser` | `ghcr.io/steel-dev/steel-browser:latest` |
 
 ## Lifecycle Choice
 
@@ -69,11 +71,15 @@ Prefer one of these patterns:
 ## Guides
 
 <CardGroup>
-  <Card title="OpenClaw" href="/docs/sandbox/agent-in-sandbox/openclaw" cta="Continue">
+  <Card title="Hosting OpenClaw" href="/docs/use-cases/openclaw" cta="Continue">
     Run the OpenClaw gateway from the builtin OpenClaw template with persistent state.
   </Card>
 
-  <Card title="Hermes" href="/docs/sandbox/agent-in-sandbox/hermes" cta="Continue">
+  <Card title="Hosting Hermes" href="/docs/use-cases/hermes" cta="Continue">
     Run the Hermes gateway from the builtin Hermes template with persistent state.
+  </Card>
+
+  <Card title="Hosting Steel Browser" href="/docs/use-cases/browser" cta="Continue">
+    Run Steel Browser from the builtin browser template with CDP and live view.
   </Card>
 </CardGroup>

--- a/infra-operator/chart/samples/multi-cluster/data-plane.yaml
+++ b/infra-operator/chart/samples/multi-cluster/data-plane.yaml
@@ -99,6 +99,13 @@ spec:
       pool:
         minIdle: 0
         maxIdle: 2
+    - templateId: browser
+      image: ghcr.io/steel-dev/steel-browser:latest
+      displayName: Browser
+      description: Builtin browser automation template installed by infra-operator.
+      pool:
+        minIdle: 0
+        maxIdle: 2
   # Shared placement for sandbox template Pods plus node-local helpers such as
   # netd and ctld. In production, point this at your dedicated sandbox
   # node pool and pair it with services.manager.config.sandboxRuntimeClassName.

--- a/infra-operator/chart/samples/single-cluster/fullmode-gke-gvisor.yaml
+++ b/infra-operator/chart/samples/single-cluster/fullmode-gke-gvisor.yaml
@@ -56,6 +56,13 @@ spec:
       pool:
         minIdle: 0
         maxIdle: 2
+    - templateId: browser
+      image: ghcr.io/steel-dev/steel-browser:latest
+      displayName: Browser
+      description: Builtin browser automation template installed by infra-operator.
+      pool:
+        minIdle: 0
+        maxIdle: 2
   # Shared placement for sandbox template Pods plus node-local helpers such as
   # netd and ctld.
   sandboxNodePlacement:

--- a/infra-operator/chart/samples/single-cluster/fullmode.yaml
+++ b/infra-operator/chart/samples/single-cluster/fullmode.yaml
@@ -106,6 +106,13 @@ spec:
       pool:
         minIdle: 0
         maxIdle: 2
+    - templateId: browser
+      image: ghcr.io/steel-dev/steel-browser:latest
+      displayName: Browser
+      description: Builtin browser automation template installed by infra-operator.
+      pool:
+        minIdle: 0
+        maxIdle: 2
   # Shared placement for sandbox template Pods plus node-local helpers such as
   # netd and ctld.
   # infra-operator manages sandbox0.ai/data-plane-ready; do not include it here.

--- a/infra-operator/chart/samples/single-cluster/minimal.yaml
+++ b/infra-operator/chart/samples/single-cluster/minimal.yaml
@@ -64,6 +64,13 @@ spec:
       pool:
         minIdle: 0
         maxIdle: 2
+    - templateId: browser
+      image: ghcr.io/steel-dev/steel-browser:latest
+      displayName: Browser
+      description: Builtin browser automation template installed by infra-operator.
+      pool:
+        minIdle: 0
+        maxIdle: 2
   services:
     clusterGateway:
       enabled: true

--- a/infra-operator/chart/samples/single-cluster/network-policy.yaml
+++ b/infra-operator/chart/samples/single-cluster/network-policy.yaml
@@ -68,6 +68,13 @@ spec:
       pool:
         minIdle: 0
         maxIdle: 2
+    - templateId: browser
+      image: ghcr.io/steel-dev/steel-browser:latest
+      displayName: Browser
+      description: Builtin browser automation template installed by infra-operator.
+      pool:
+        minIdle: 0
+        maxIdle: 2
   # Shared placement for sandbox template Pods plus node-local helpers such as
   # netd and ctld.
   # infra-operator manages sandbox0.ai/data-plane-ready; do not include it here.

--- a/infra-operator/chart/samples/single-cluster/volumes.yaml
+++ b/infra-operator/chart/samples/single-cluster/volumes.yaml
@@ -82,6 +82,13 @@ spec:
       pool:
         minIdle: 0
         maxIdle: 2
+    - templateId: browser
+      image: ghcr.io/steel-dev/steel-browser:latest
+      displayName: Browser
+      description: Builtin browser automation template installed by infra-operator.
+      pool:
+        minIdle: 0
+        maxIdle: 2
   services:
     clusterGateway:
       enabled: true

--- a/infra-operator/internal/controller/pkg/common/builtin_templates.go
+++ b/infra-operator/internal/controller/pkg/common/builtin_templates.go
@@ -174,6 +174,8 @@ func BuildBuiltinTemplateSpec(templateID string, builtin infrav1alpha1.BuiltinTe
 		spec = openClawTemplateSpec()
 	} else if templateID == template.HermesTemplateID {
 		spec = hermesTemplateSpec()
+	} else if templateID == template.BrowserTemplateID {
+		spec = browserTemplateSpec()
 	} else {
 		spec = defaultBuiltinTemplateSpec(templateID)
 	}
@@ -304,6 +306,53 @@ func hermesTemplateSpec() templatev1alpha1.SandboxTemplateSpec {
 			"HERMES_HOME":         template.HermesRuntimeHome,
 			"HERMES_PERSIST_HOME": template.HermesDataMount,
 			"HOME":                template.HermesRuntimeHome,
+		},
+		Pool: templatev1alpha1.PoolStrategy{
+			MinIdle: 0,
+			MaxIdle: 2,
+		},
+		Network: &templatev1alpha1.SandboxNetworkPolicy{
+			Mode: templatev1alpha1.NetworkModeAllowAll,
+		},
+	}
+}
+
+func browserTemplateSpec() templatev1alpha1.SandboxTemplateSpec {
+	runAsRoot := int64(0)
+	runAsNonRoot := false
+	devShmSize := resource.MustParse(template.BrowserDevShmSizeLimit)
+	return templatev1alpha1.SandboxTemplateSpec{
+		DisplayName: template.BrowserTemplateDisplayName,
+		Description: template.BrowserTemplateDescription,
+		MainContainer: templatev1alpha1.ContainerSpec{
+			Image: template.BrowserTemplateImage,
+			Resources: templatev1alpha1.ResourceQuota{
+				CPU:              resource.MustParse(template.BrowserCPU),
+				Memory:           resource.MustParse(template.BrowserMemory),
+				EphemeralStorage: resource.MustParse(template.BrowserEphemeralStorage),
+			},
+			SecurityContext: &templatev1alpha1.SecurityContext{
+				RunAsUser:    &runAsRoot,
+				RunAsGroup:   &runAsRoot,
+				RunAsNonRoot: &runAsNonRoot,
+			},
+		},
+		VolumeMounts: []templatev1alpha1.VolumeMountSpec{{
+			Name:      template.BrowserDownloadsMountName,
+			MountPath: template.BrowserDownloadsMount,
+		}},
+		Pod: &templatev1alpha1.PodSpecOverride{
+			EmptyDirMounts: []templatev1alpha1.EmptyDirMountSpec{{
+				MountPath: template.BrowserDevShmMount,
+				SizeLimit: &devShmSize,
+			}},
+		},
+		EnvVars: map[string]string{
+			"CHROME_HEADLESS":      "true",
+			"CHROME_USER_DATA_DIR": template.BrowserProfileDir,
+			"HOST":                 "0.0.0.0",
+			"NODE_ENV":             "production",
+			"PORT":                 "3000",
 		},
 		Pool: templatev1alpha1.PoolStrategy{
 			MinIdle: 0,

--- a/infra-operator/internal/controller/pkg/common/builtin_templates_test.go
+++ b/infra-operator/internal/controller/pkg/common/builtin_templates_test.go
@@ -169,6 +169,57 @@ func TestBuildBuiltinTemplateSpecUsesHermesPreset(t *testing.T) {
 	}
 }
 
+func TestBuildBuiltinTemplateSpecUsesBrowserPreset(t *testing.T) {
+	t.Parallel()
+
+	spec := BuildBuiltinTemplateSpec(template.BrowserTemplateID, infrav1alpha1.BuiltinTemplateConfig{})
+
+	if spec.DisplayName != template.BrowserTemplateDisplayName {
+		t.Fatalf("DisplayName = %q, want %q", spec.DisplayName, template.BrowserTemplateDisplayName)
+	}
+	if spec.MainContainer.Image != template.BrowserTemplateImage {
+		t.Fatalf("image = %q, want %q", spec.MainContainer.Image, template.BrowserTemplateImage)
+	}
+	if spec.MainContainer.Resources.CPU.Cmp(resource.MustParse(template.BrowserCPU)) != 0 {
+		t.Fatalf("cpu = %s, want %s", spec.MainContainer.Resources.CPU.String(), template.BrowserCPU)
+	}
+	if spec.MainContainer.Resources.Memory.Cmp(resource.MustParse(template.BrowserMemory)) != 0 {
+		t.Fatalf("memory = %s, want %s", spec.MainContainer.Resources.Memory.String(), template.BrowserMemory)
+	}
+	if spec.MainContainer.Resources.EphemeralStorage.Cmp(resource.MustParse(template.BrowserEphemeralStorage)) != 0 {
+		t.Fatalf("ephemeralStorage = %s, want %s", spec.MainContainer.Resources.EphemeralStorage.String(), template.BrowserEphemeralStorage)
+	}
+	if len(spec.VolumeMounts) != 1 {
+		t.Fatalf("volumeMounts = %#v, want one downloads mount", spec.VolumeMounts)
+	}
+	mount := spec.VolumeMounts[0]
+	if mount.Name != template.BrowserDownloadsMountName || mount.MountPath != template.BrowserDownloadsMount || mount.ReadOnly {
+		t.Fatalf("volumeMounts[0] = %#v, want writable %s at %s", mount, template.BrowserDownloadsMountName, template.BrowserDownloadsMount)
+	}
+	if spec.Pod == nil || len(spec.Pod.EmptyDirMounts) != 1 {
+		t.Fatalf("emptyDirMounts = %#v, want one /dev/shm mount", spec.Pod)
+	}
+	devShm := spec.Pod.EmptyDirMounts[0]
+	if devShm.MountPath != template.BrowserDevShmMount {
+		t.Fatalf("emptyDir mount path = %q, want %q", devShm.MountPath, template.BrowserDevShmMount)
+	}
+	if devShm.SizeLimit == nil || devShm.SizeLimit.Cmp(resource.MustParse(template.BrowserDevShmSizeLimit)) != 0 {
+		t.Fatalf("emptyDir sizeLimit = %#v, want %s", devShm.SizeLimit, template.BrowserDevShmSizeLimit)
+	}
+	if spec.EnvVars["CHROME_USER_DATA_DIR"] != template.BrowserProfileDir {
+		t.Fatalf("CHROME_USER_DATA_DIR = %q", spec.EnvVars["CHROME_USER_DATA_DIR"])
+	}
+	if spec.EnvVars["HOST"] != "0.0.0.0" {
+		t.Fatalf("HOST = %q, want 0.0.0.0", spec.EnvVars["HOST"])
+	}
+	if spec.Pool.MinIdle != 0 || spec.Pool.MaxIdle != 2 {
+		t.Fatalf("pool = %#v, want 0/2", spec.Pool)
+	}
+	if spec.Network == nil || spec.Network.Mode != templatev1alpha1.NetworkModeAllowAll {
+		t.Fatalf("network = %#v, want allow-all", spec.Network)
+	}
+}
+
 func TestBuiltinTemplatePresetsSatisfyResourceRatio(t *testing.T) {
 	t.Parallel()
 
@@ -176,6 +227,7 @@ func TestBuiltinTemplatePresetsSatisfyResourceRatio(t *testing.T) {
 		template.DefaultTemplateID,
 		template.OpenClawTemplateID,
 		template.HermesTemplateID,
+		template.BrowserTemplateID,
 	} {
 		t.Run(templateID, func(t *testing.T) {
 			t.Parallel()

--- a/infra-operator/internal/plan/plan_test.go
+++ b/infra-operator/internal/plan/plan_test.go
@@ -160,13 +160,14 @@ func TestBuiltinTemplatesDefaultsAndOverrides(t *testing.T) {
 	t.Parallel()
 
 	defaults := Compile(&infrav1alpha1.Sandbox0Infra{}).BuiltinTemplates()
-	if len(defaults) != 3 {
-		t.Fatalf("default builtin template count = %d, want 3", len(defaults))
+	if len(defaults) != 4 {
+		t.Fatalf("default builtin template count = %d, want 4", len(defaults))
 	}
 	wantDefaults := []string{
 		template.DefaultTemplateID,
 		template.OpenClawTemplateID,
 		template.HermesTemplateID,
+		template.BrowserTemplateID,
 	}
 	for i, want := range wantDefaults {
 		if defaults[i].TemplateID != want {

--- a/infra-operator/internal/plan/runtime_access.go
+++ b/infra-operator/internal/plan/runtime_access.go
@@ -37,6 +37,7 @@ func defaultBuiltinTemplates() []infrav1alpha1.BuiltinTemplateConfig {
 		{TemplateID: s0template.DefaultTemplateID},
 		{TemplateID: s0template.OpenClawTemplateID},
 		{TemplateID: s0template.HermesTemplateID},
+		{TemplateID: s0template.BrowserTemplateID},
 	}
 }
 

--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -317,6 +317,8 @@ func main() {
 		RootFSSquashDisabled:                cfg.RootFSMaintenance.SquashDisabled,
 		RootFSSquashMaxChainDepth:           cfg.RootFSMaintenance.SquashMaxChainDepth,
 		RootFSSquashMaxChainBytes:           cfg.RootFSMaintenance.SquashMaxChainBytes,
+		PublicRootDomain:                    cfg.PublicRootDomain,
+		PublicRegionID:                      cfg.PublicRegionID,
 	}
 
 	sandboxService := service.NewSandboxService(

--- a/manager/pkg/http/handlers_services.go
+++ b/manager/pkg/http/handlers_services.go
@@ -3,7 +3,6 @@ package http
 import (
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/service"
@@ -13,14 +12,7 @@ import (
 )
 
 func (s *Server) getExposureDomain() string {
-	rootDomain := strings.TrimSpace(s.publicRootDomain)
-	if rootDomain == "" {
-		rootDomain = "sandbox0.app"
-	}
-	if s.publicRegionID == "" {
-		return ""
-	}
-	return s.publicRegionID + "." + rootDomain
+	return service.SandboxAppDomain(s.publicRegionID, s.publicRootDomain)
 }
 
 func (s *Server) listSandboxServices(c *gin.Context) {

--- a/manager/pkg/service/sandbox_app_service.go
+++ b/manager/pkg/service/sandbox_app_service.go
@@ -312,6 +312,20 @@ func SandboxAppServiceViews(services []SandboxAppService) []SandboxAppServiceVie
 	return SandboxAppServiceViewsForExposure("", "", services)
 }
 
+// SandboxAppDomain returns the public app domain suffix used by sandbox service
+// exposure hosts.
+func SandboxAppDomain(publicRegionID, publicRootDomain string) string {
+	rootDomain := strings.Trim(strings.TrimSpace(publicRootDomain), ".")
+	if rootDomain == "" {
+		rootDomain = "sandbox0.app"
+	}
+	regionID := strings.Trim(strings.TrimSpace(publicRegionID), ".")
+	if regionID == "" {
+		return ""
+	}
+	return regionID + "." + rootDomain
+}
+
 // SandboxAppServiceViewsForExposure adds derived fields that depend on the
 // deployment exposure domain.
 func SandboxAppServiceViewsForExposure(sandboxID, exposureDomain string, services []SandboxAppService) []SandboxAppServiceView {

--- a/manager/pkg/service/sandbox_app_service_test.go
+++ b/manager/pkg/service/sandbox_app_service_test.go
@@ -78,6 +78,18 @@ func TestSandboxAppServiceViewsForExposureAddsPublicURL(t *testing.T) {
 	}
 }
 
+func TestSandboxAppDomain(t *testing.T) {
+	if got, want := SandboxAppDomain("aws-us-east-1", ""), "aws-us-east-1.sandbox0.app"; got != want {
+		t.Fatalf("SandboxAppDomain default root = %q, want %q", got, want)
+	}
+	if got, want := SandboxAppDomain(" aws-us-east-1. ", " example.com. "), "aws-us-east-1.example.com"; got != want {
+		t.Fatalf("SandboxAppDomain trims labels = %q, want %q", got, want)
+	}
+	if got := SandboxAppDomain("", "example.com"); got != "" {
+		t.Fatalf("SandboxAppDomain empty region = %q, want empty", got)
+	}
+}
+
 func TestSandboxAppServicePublishBlockersRequirePublicRestartableRuntime(t *testing.T) {
 	service := SandboxAppService{
 		ID:   "api",

--- a/manager/pkg/service/sandbox_env_test.go
+++ b/manager/pkg/service/sandbox_env_test.go
@@ -9,7 +9,7 @@ func TestSandboxEnvVarsForInitializeClonesConfigEnvVars(t *testing.T) {
 		},
 	}
 
-	got := sandboxEnvVarsForInitialize(cfg)
+	got := sandboxEnvVarsForInitialize(cfg, sandboxPlatformEnv{})
 	if got["APP_ENV"] != "test" {
 		t.Fatalf("APP_ENV = %q, want test", got["APP_ENV"])
 	}
@@ -17,6 +17,41 @@ func TestSandboxEnvVarsForInitializeClonesConfigEnvVars(t *testing.T) {
 	got["APP_ENV"] = "mutated"
 	if cfg.EnvVars["APP_ENV"] != "test" {
 		t.Fatalf("config env mutated to %q, want test", cfg.EnvVars["APP_ENV"])
+	}
+}
+
+func TestSandboxEnvVarsForInitializeAddsPlatformEnvVars(t *testing.T) {
+	got := sandboxEnvVarsForInitialize(nil, sandboxPlatformEnv{
+		SandboxID: "rs-browser-abcde",
+		AppDomain: "aws-us-east-1.sandbox0.app.",
+	})
+
+	if got[SandboxEnvSandboxID] != "rs-browser-abcde" {
+		t.Fatalf("%s = %q, want sandbox id", SandboxEnvSandboxID, got[SandboxEnvSandboxID])
+	}
+	if got[SandboxEnvAppDomain] != "aws-us-east-1.sandbox0.app" {
+		t.Fatalf("%s = %q, want app domain without trailing dot", SandboxEnvAppDomain, got[SandboxEnvAppDomain])
+	}
+}
+
+func TestSandboxEnvVarsForInitializePlatformEnvVarsOverrideConfig(t *testing.T) {
+	cfg := &SandboxConfig{
+		EnvVars: map[string]string{
+			SandboxEnvSandboxID: "wrong",
+			SandboxEnvAppDomain: "wrong.example.com",
+		},
+	}
+
+	got := sandboxEnvVarsForInitialize(cfg, sandboxPlatformEnv{
+		SandboxID: "rs-browser-abcde",
+		AppDomain: "aws-us-east-1.sandbox0.app",
+	})
+
+	if got[SandboxEnvSandboxID] != "rs-browser-abcde" {
+		t.Fatalf("%s = %q, want platform sandbox id", SandboxEnvSandboxID, got[SandboxEnvSandboxID])
+	}
+	if got[SandboxEnvAppDomain] != "aws-us-east-1.sandbox0.app" {
+		t.Fatalf("%s = %q, want platform app domain", SandboxEnvAppDomain, got[SandboxEnvAppDomain])
 	}
 }
 

--- a/manager/pkg/service/sandbox_service.go
+++ b/manager/pkg/service/sandbox_service.go
@@ -96,6 +96,8 @@ type SandboxServiceConfig struct {
 	RootFSSquashDisabled                bool
 	RootFSSquashMaxChainDepth           int
 	RootFSSquashMaxChainBytes           int64
+	PublicRootDomain                    string
+	PublicRegionID                      string
 }
 
 // SandboxService handles sandbox operations

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -32,6 +32,11 @@ const (
 	volumePortalBindRetryInterval = 100 * time.Millisecond
 )
 
+const (
+	SandboxEnvSandboxID = "SANDBOX0_SANDBOX_ID"
+	SandboxEnvAppDomain = "SANDBOX0_APP_DOMAIN"
+)
+
 var errIdlePodReservationConflict = errors.New("idle pod reservation conflict")
 
 // ClaimRequest represents a sandbox claim request
@@ -1664,7 +1669,13 @@ func (s *SandboxService) initializeProcd(
 	initReq := InitializeRequest{
 		SandboxID: sandboxID,
 		TeamID:    teamID,
-		EnvVars:   sandboxEnvVarsForInitialize(req.Config),
+		EnvVars: sandboxEnvVarsForInitialize(req.Config, sandboxPlatformEnv{
+			SandboxID: sandboxID,
+			AppDomain: SandboxAppDomain(
+				s.config.PublicRegionID,
+				s.config.PublicRootDomain,
+			),
+		}),
 		Webhook:   webhookConfig,
 		MountDirs: declaredVolumeMountDirs(template),
 	}
@@ -1697,9 +1708,27 @@ func (s *SandboxService) initializeProcd(
 	}
 }
 
-func sandboxEnvVarsForInitialize(cfg *SandboxConfig) map[string]string {
-	if cfg == nil {
+type sandboxPlatformEnv struct {
+	SandboxID string
+	AppDomain string
+}
+
+func sandboxEnvVarsForInitialize(cfg *SandboxConfig, platform sandboxPlatformEnv) map[string]string {
+	var envVars map[string]string
+	if cfg != nil {
+		envVars = cloneEnvVars(cfg.EnvVars)
+	}
+	if envVars == nil {
+		envVars = map[string]string{}
+	}
+	if sandboxID := strings.TrimSpace(platform.SandboxID); sandboxID != "" {
+		envVars[SandboxEnvSandboxID] = sandboxID
+	}
+	if appDomain := strings.Trim(strings.TrimSpace(platform.AppDomain), "."); appDomain != "" {
+		envVars[SandboxEnvAppDomain] = appDomain
+	}
+	if len(envVars) == 0 {
 		return nil
 	}
-	return cloneEnvVars(cfg.EnvVars)
+	return envVars
 }

--- a/pkg/template/defaults.go
+++ b/pkg/template/defaults.go
@@ -36,6 +36,19 @@ const (
 	HermesEphemeralStorage    = "4Gi"
 	HermesDataMount           = "/opt/data"
 	HermesRuntimeHome         = "/workspace/.hermes"
+
+	BrowserTemplateID          = "browser"
+	BrowserTemplateImage       = "ghcr.io/steel-dev/steel-browser:latest"
+	BrowserTemplateDisplayName = "Browser"
+	BrowserTemplateDescription = "Builtin browser automation template installed by infra-operator."
+	BrowserCPU                 = "2"
+	BrowserMemory              = "8Gi"
+	BrowserEphemeralStorage    = "16Gi"
+	BrowserProfileDir          = "/browser/profile"
+	BrowserDownloadsMountName  = "browser-downloads"
+	BrowserDownloadsMount      = "/files"
+	BrowserDevShmMount         = "/dev/shm"
+	BrowserDevShmSizeLimit     = "2Gi"
 )
 
 // ApplyDefaultPool applies default pool values when not explicitly set.


### PR DESCRIPTION
## Summary
- add a builtin `browser` template backed by the official Steel Browser image
- inject sandbox app domain and sandbox id into procd environments for service public URL composition
- rename the docs section from `agent-in-sandbox` to `use-cases`, with manifest aliases for old root/subpage URLs
- document browser service setup, CDP/live-view usage, persistence boundaries, and update builtin template samples

## Compatibility
- new canonical docs URLs are `/docs/use-cases`, `/docs/use-cases/openclaw`, `/docs/use-cases/hermes`, and `/docs/use-cases/browser`
- legacy aliases cover `/docs/agent-in-sandbox...` and `/docs/sandbox/agent-in-sandbox...`
- website redirect generation for section aliases is in sandbox0-cloud PR: https://github.com/sandbox0-ai/sandbox0-cloud/pull/214

## Tests
- `go test ./infra-operator/internal/controller/pkg/common ./infra-operator/internal/plan ./manager/pkg/service ./manager/pkg/http ./pkg/template/...`
- `go test ./manager/... ./infra-operator/...`
- `jq empty docs/manifest.json`
- `git diff --check`