### PR TITLE
docs: fix snapshot fork request body MDX

### DIFF
--- a/docs/sandbox/snapshot-restore/page.mdx
+++ b/docs/sandbox/snapshot-restore/page.mdx
@@ -415,12 +415,14 @@ Fork creates a new paused sandbox from a paused source sandbox rootfs. The fork 
 
 Omit the request body to inherit the source sandbox lifecycle configuration. To set a new lifecycle window for the fork, pass `config.ttl` and/or `config.hard_ttl`. Positive values are counted from the fork creation time, and `0` disables that expiration path.
 
-    {
-        "config": {
-            "ttl": 300,
-            "hard_ttl": 3600
-        }
+```json
+{
+    "config": {
+        "ttl": 300,
+        "hard_ttl": 3600
     }
+}
+```
 
 <Tabs
   tabs={[


### PR DESCRIPTION
## Summary
- render the fork lifecycle override request body as a fenced JSON block
- avoid MDX parsing the request body braces as JSX expressions during website builds

## Validation
- SANDBOX0_ROOT=/root/sandbox0ai/sandbox0-snapshot-restore-mdx-fix npm run build:website (from sandbox0-cloud PR worktree)
- npm run lint:website (from sandbox0-cloud PR worktree)