### PR TITLE
Keep warm-pool idle pods on low resources

### DIFF
--- a/docs/template/configuration/page.mdx
+++ b/docs/template/configuration/page.mdx
@@ -68,7 +68,7 @@ The main sandbox container configuration.
 | `env` | array | `[]` | Per-container environment variables. Each entry has `name` and `value`. |
 
 <Callout variant="info">
-`mainContainer.image`, `mainContainer.resources.cpu`, `mainContainer.resources.memory`, and `mainContainer.resources.ephemeralStorage` are strictly validated by the API when creating or updating templates. Template resources are the default for new sandboxes; `config.resources.memory` can override the sandbox memory limit at claim time or runtime.
+`mainContainer.image`, `mainContainer.resources.cpu`, `mainContainer.resources.memory`, and `mainContainer.resources.ephemeralStorage` are strictly validated by the API when creating or updating templates. Template resources are the default for claimed sandboxes; warm-pool idle pods may run with lower internal CPU and memory until claim. `config.resources.memory` can override the sandbox memory limit at claim time or runtime.
 </Callout>
 
 ---

--- a/docs/template/pool/page.mdx
+++ b/docs/template/pool/page.mdx
@@ -87,7 +87,7 @@ Warm-pool capacity is counted from idle pods that are ready for claiming.
 | Single-user tool | 1 |
 
 <Callout variant="warning">
-Each idle pod consumes CPU and memory as defined in `mainContainer.resources`. Setting `minIdle` too high wastes cluster resources. Monitor your claim rate and set `minIdle` to match your typical concurrency.
+Idle pods use a fixed low CPU and memory allocation while they wait in the warm pool. `mainContainer.resources` remains the default sandbox resource contract; Sandbox0 requests a hot-claimed idle pod resize to the template or claim-time resources during claim. Setting `minIdle` too high still consumes cluster capacity, image cache, ephemeral-storage headroom, and runtime overhead. Monitor your claim rate and set `minIdle` to match your typical concurrency.
 </Callout>
 
 ---

--- a/manager/pkg/apis/sandbox0/v1alpha1/helpers.go
+++ b/manager/pkg/apis/sandbox0/v1alpha1/helpers.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 import (
 	"fmt"
+	"math/big"
 	"path"
 	"sort"
 	"strings"
@@ -30,6 +31,7 @@ const (
 	minSandboxCPURequestMilli                        = int64(10)
 	minSandboxMemoryRequestBytes                     = int64(64 * 1024 * 1024)
 	minSandboxEphemeralStorageRequestBytes           = int64(64 * 1024 * 1024)
+	defaultIdleSandboxMemoryLimitBytes               = int64(128 * 1024 * 1024)
 )
 
 // BuildPodSpec builds a pod spec with every template-declared user volume portal.
@@ -40,7 +42,9 @@ func BuildPodSpec(template *SandboxTemplate) corev1.PodSpec {
 // BuildIdlePodSpec builds the idle-pool pod spec. User volume portals stay
 // pre-mounted so hot claims can bind selected portals without recreating pods.
 func BuildIdlePodSpec(template *SandboxTemplate) corev1.PodSpec {
-	return BuildPodSpec(template)
+	spec := BuildPodSpec(template)
+	applyIdleResourceQuotaToPodSpec(&spec, template)
+	return spec
 }
 
 func buildPodSpec(template *SandboxTemplate, volumeMounts []VolumeMountSpec) corev1.PodSpec {
@@ -380,6 +384,36 @@ func buildContainer(spec *ContainerSpec, template *SandboxTemplate) corev1.Conta
 	return container
 }
 
+func applyIdleResourceQuotaToPodSpec(spec *corev1.PodSpec, template *SandboxTemplate) {
+	if spec == nil || template == nil {
+		return
+	}
+	quota := idleResourceQuota(template.Spec.MainContainer.Resources)
+	for i := range spec.Containers {
+		if spec.Containers[i].Name != "procd" {
+			continue
+		}
+		spec.Containers[i].Resources = BuildResourceRequirements(quota)
+		return
+	}
+}
+
+func idleResourceQuota(templateQuota ResourceQuota) ResourceQuota {
+	quota := templateQuota.DeepCopy()
+	if quota == nil {
+		return ResourceQuota{}
+	}
+	if quota.Memory.Sign() > 0 {
+		idleMemory := *resource.NewQuantity(defaultIdleSandboxMemoryLimitBytes, resource.BinarySI)
+		if quota.Memory.Cmp(idleMemory) < 0 {
+			idleMemory = quota.Memory.DeepCopy()
+		}
+		quota.CPU = scaledCPUForMemory(quota.CPU, quota.Memory, idleMemory)
+		quota.Memory = idleMemory
+	}
+	return *quota
+}
+
 // BuildResourceRequirements converts a sandbox resource quota into Kubernetes
 // container requests and limits.
 func BuildResourceRequirements(quota ResourceQuota) corev1.ResourceRequirements {
@@ -414,6 +448,22 @@ func scaledCPURequest(limit resource.Quantity) resource.Quantity {
 	limitMilli := limit.MilliValue()
 	requestMilli := scaleResource(limitMilli, defaultSandboxCPURequestRatioMillis, minSandboxCPURequestMilli)
 	return *resource.NewMilliQuantity(requestMilli, resource.DecimalSI)
+}
+
+func scaledCPUForMemory(cpu, fromMemory, toMemory resource.Quantity) resource.Quantity {
+	if cpu.Sign() <= 0 || fromMemory.Sign() <= 0 || toMemory.Sign() <= 0 {
+		return resource.Quantity{}
+	}
+	numerator := big.NewInt(cpu.MilliValue())
+	numerator.Mul(numerator, big.NewInt(toMemory.Value()))
+	quotient, remainder := new(big.Int).QuoRem(numerator, big.NewInt(fromMemory.Value()), new(big.Int))
+	if remainder.Sign() > 0 {
+		quotient.Add(quotient, big.NewInt(1))
+	}
+	if !quotient.IsInt64() {
+		return *resource.NewMilliQuantity(1<<63-1, resource.DecimalSI)
+	}
+	return *resource.NewMilliQuantity(quotient.Int64(), resource.DecimalSI)
 }
 
 func scaledMemoryRequest(limit resource.Quantity) resource.Quantity {

--- a/manager/pkg/apis/sandbox0/v1alpha1/helpers_test.go
+++ b/manager/pkg/apis/sandbox0/v1alpha1/helpers_test.go
@@ -357,6 +357,29 @@ manager_image: sandbox0/manager:test
 	assertResourceQuantity(t, resources.Limits[corev1.ResourceEphemeralStorage], "8Gi")
 }
 
+func TestBuildIdlePodSpecUsesLowCPUAndMemoryLimits(t *testing.T) {
+	configPath := writeManagerConfig(t, `
+manager_image: sandbox0/manager:test
+`)
+	t.Setenv("CONFIG_PATH", configPath)
+
+	template := newTestTemplate()
+	template.Spec.MainContainer.Resources = ResourceQuota{
+		CPU:    resource.MustParse("500m"),
+		Memory: resource.MustParse("2Gi"),
+	}
+
+	spec := BuildIdlePodSpec(template)
+	resources := spec.Containers[0].Resources
+
+	assertResourceQuantity(t, resources.Requests[corev1.ResourceCPU], "10m")
+	assertResourceQuantity(t, resources.Limits[corev1.ResourceCPU], "32m")
+	assertResourceQuantity(t, resources.Requests[corev1.ResourceMemory], "64Mi")
+	assertResourceQuantity(t, resources.Limits[corev1.ResourceMemory], "128Mi")
+	assertResourceQuantity(t, resources.Requests[corev1.ResourceEphemeralStorage], "1Gi")
+	assertResourceQuantity(t, resources.Limits[corev1.ResourceEphemeralStorage], "8Gi")
+}
+
 func TestBuildPodSpecUsesRestartFreeResourceResizePolicy(t *testing.T) {
 	configPath := writeManagerConfig(t, `
 manager_image: sandbox0/manager:test

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -1197,12 +1197,12 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 		// Update pod labels and annotations
 		originalIdlePod := pod.DeepCopy()
 		pod = pod.DeepCopy()
+		resourceQuota, err := s.effectiveSandboxResourceQuota(template, req.Config)
+		if err != nil {
+			return err
+		}
 		var resizeQuota *v1alpha1.ResourceQuota
-		if req.Config != nil && req.Config.Resources != nil {
-			resourceQuota, err := s.effectiveSandboxResourceQuota(template, req.Config)
-			if err != nil {
-				return err
-			}
+		if sandboxPodNeedsResourceResize(pod, resourceQuota) {
 			resizeQuota = &resourceQuota
 		}
 

--- a/manager/pkg/service/sandbox_service_resources.go
+++ b/manager/pkg/service/sandbox_service_resources.go
@@ -120,6 +120,44 @@ func applySandboxResourceQuotaToPodSpec(spec *corev1.PodSpec, quota v1alpha1.Res
 	return fmt.Errorf("%w: sandbox runtime container not found", ErrInvalidClaimRequest)
 }
 
+func sandboxPodNeedsResourceResize(pod *corev1.Pod, quota v1alpha1.ResourceQuota) bool {
+	if quota.CPU.Sign() <= 0 && quota.Memory.Sign() <= 0 {
+		return false
+	}
+	if pod == nil {
+		return true
+	}
+	desired := v1alpha1.BuildResourceRequirements(quota)
+	for _, container := range pod.Spec.Containers {
+		if container.Name != "procd" {
+			continue
+		}
+		return !resizeResourcesEqual(container.Resources, desired)
+	}
+	return true
+}
+
+func resizeResourcesEqual(a, b corev1.ResourceRequirements) bool {
+	for _, name := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
+		if !resourceListQuantityEqual(a.Requests, b.Requests, name) {
+			return false
+		}
+		if !resourceListQuantityEqual(a.Limits, b.Limits, name) {
+			return false
+		}
+	}
+	return true
+}
+
+func resourceListQuantityEqual(a, b corev1.ResourceList, name corev1.ResourceName) bool {
+	aValue, aOK := a[name]
+	bValue, bOK := b[name]
+	if !aOK || aValue.IsZero() {
+		return !bOK || bValue.IsZero()
+	}
+	return bOK && aValue.Cmp(bValue) == 0
+}
+
 func ensureSandboxResizePolicy(container *corev1.Container) {
 	if container == nil {
 		return

--- a/manager/pkg/service/sandbox_service_resources_test.go
+++ b/manager/pkg/service/sandbox_service_resources_test.go
@@ -104,6 +104,63 @@ func TestCreateNewPodAppliesClaimMemoryResources(t *testing.T) {
 	assertResizePolicy(t, container.ResizePolicy, corev1.ResourceMemory, corev1.NotRequired)
 }
 
+func TestCreateNewPodAppliesTemplateResourcesByDefault(t *testing.T) {
+	withClaimTestPublicKey(t)
+	template := newSandboxResourceTestTemplate(t)
+	client := fake.NewSimpleClientset()
+	svc := &SandboxService{
+		k8sClient:    client,
+		secretLister: newClaimTestSecretLister(t),
+		clock:        systemTime{},
+		config:       SandboxServiceConfig{SandboxMemoryPerCPU: "4Gi"},
+		logger:       zap.NewNop(),
+	}
+
+	pod, err := svc.createNewPod(context.Background(), template, &ClaimRequest{
+		TeamID: "team-a",
+		UserID: "user-a",
+	})
+	if err != nil {
+		t.Fatalf("createNewPod() error = %v", err)
+	}
+	container := sandboxRuntimeContainer(t, pod)
+	assertQuantity(t, container.Resources.Limits[corev1.ResourceMemory], "1Gi")
+	assertQuantity(t, container.Resources.Limits[corev1.ResourceCPU], "250m")
+	assertQuantity(t, container.Resources.Requests[corev1.ResourceMemory], "256Mi")
+	assertQuantity(t, container.Resources.Requests[corev1.ResourceCPU], "25m")
+}
+
+func TestClaimIdlePodAppliesTemplateResourcesByDefault(t *testing.T) {
+	template := newSandboxResourceTestTemplate(t)
+	idlePod := newSandboxResourceTestIdlePod(t, template, "idle-ready")
+	node := newClaimTestNode("node-a", "10.0.0.1")
+	node.Labels = map[string]string{dataplane.NodeDataPlaneReadyLabel: dataplane.ReadyLabelValue}
+	idlePod.Spec.NodeName = node.Name
+	client := fake.NewSimpleClientset(idlePod.DeepCopy(), node.DeepCopy())
+	svc := &SandboxService{
+		k8sClient:  client,
+		podLister:  newClaimTestPodLister(t, idlePod),
+		nodeLister: newClaimTestNodeLister(t, node),
+		clock:      systemTime{},
+		config:     SandboxServiceConfig{SandboxMemoryPerCPU: "4Gi"},
+		logger:     zap.NewNop(),
+	}
+
+	pod, err := svc.claimIdlePod(context.Background(), template, &ClaimRequest{
+		TeamID: "team-a",
+		UserID: "user-a",
+	})
+	if err != nil {
+		t.Fatalf("claimIdlePod() error = %v", err)
+	}
+	container := sandboxRuntimeContainer(t, pod)
+	assertQuantity(t, container.Resources.Limits[corev1.ResourceMemory], "1Gi")
+	assertQuantity(t, container.Resources.Limits[corev1.ResourceCPU], "250m")
+	assertQuantity(t, container.Resources.Requests[corev1.ResourceMemory], "256Mi")
+	assertQuantity(t, container.Resources.Requests[corev1.ResourceCPU], "25m")
+	assertResizeSubresourceUpdate(t, client.Actions())
+}
+
 func TestClaimIdlePodAppliesMemoryOverride(t *testing.T) {
 	template := newSandboxResourceTestTemplate(t)
 	idlePod := newSandboxResourceTestIdlePod(t, template, "idle-ready")
@@ -361,7 +418,7 @@ func newSandboxResourceTestTemplate(t *testing.T) *v1alpha1.SandboxTemplate {
 func newSandboxResourceTestIdlePod(t *testing.T, template *v1alpha1.SandboxTemplate, name string) *corev1.Pod {
 	t.Helper()
 	pod := newClaimTestPod(template.Namespace, name, template.Name, true)
-	pod.Spec = v1alpha1.BuildPodSpec(template)
+	pod.Spec = v1alpha1.BuildIdlePodSpec(template)
 	pod.Status.Conditions = append(pod.Status.Conditions, corev1.PodCondition{
 		Type:   v1alpha1.SandboxPodReadinessConditionType,
 		Status: corev1.ConditionTrue,
@@ -377,6 +434,7 @@ func newSandboxResourceTestIdlePod(t *testing.T, template *v1alpha1.SandboxTempl
 func newSandboxResourceTestActivePod(t *testing.T, template *v1alpha1.SandboxTemplate, name string) *corev1.Pod {
 	t.Helper()
 	pod := newSandboxResourceTestIdlePod(t, template, name)
+	pod.Spec = v1alpha1.BuildPodSpec(template)
 	pod.Labels[controller.LabelPoolType] = controller.PoolTypeActive
 	pod.Labels[controller.LabelSandboxID] = name
 	pod.Annotations[controller.AnnotationSandboxID] = name


### PR DESCRIPTION
## Summary
- cap warm-pool idle sandbox pod CPU/memory to a fixed low allocation while preserving the template CPU:memory ratio
- resize hot-claimed idle pods to the effective sandbox resources even when the claim omits `config.resources`
- keep cold claims on the same template-default resource contract and document the idle-pool internal allocation behavior

Related: #641

## Testing
- `git diff --check`
- `go test ./manager/pkg/apis/sandbox0/v1alpha1 ./manager/pkg/service ./manager/pkg/controller`
- `go test ./manager/pkg/... ./pkg/template/...`
- `go test ./...` currently does not complete locally: generated `storage-proxy/proto/fs` is absent for several packages, and the local e2e packages attempt to run `kind`, which is not installed in this environment.

## Notes
This PR intentionally does not add priority/eviction behavior for idle pods; that is tracked separately in #641.