### PR TITLE
docs: nest use cases under sandbox docs

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -13,14 +13,7 @@
         "volume",
         "credential",
         "integrations",
-        "self-hosted"
-      ]
-    },
-    {
-      "slug": "use-cases",
-      "title": "use-cases",
-      "defaultPage": "use-cases",
-      "sections": [
+        "self-hosted",
         "use-cases"
       ]
     },


### PR DESCRIPTION
## Summary
- move the `use-cases` docs section under the `sandbox` docs product
- keep the website top-level docs products limited to Sandbox and Managed Agents
- rely on the existing docs generator to redirect legacy `/docs/use-cases/*` and `/docs/sandbox/agent-in-sandbox/*` URLs to `/docs/sandbox/use-cases/*`

## Validation
- `node -e 'JSON.parse(require("fs").readFileSync("docs/manifest.json", "utf8")); console.log("manifest json ok")'`
- `DOCS_GENERATED_ROOT=/tmp/tmp.aKtKcTkYSa SANDBOX0_ROOT=/root/sandbox0ai/sandbox0 node ./scripts/generate_docs_content.mjs` from `sandbox0-cloud/apps/website`
- custom assertion over generated `navigation.ts`, `content.tsx`, and `redirects.json` to verify Use Cases is not a product, appears under Sandbox, and legacy redirects exist
