### PR TITLE
docs: keep use cases under sandbox

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -13,14 +13,7 @@
         "volume",
         "credential",
         "integrations",
-        "self-hosted"
-      ]
-    },
-    {
-      "slug": "use-cases",
-      "title": "use-cases",
-      "defaultPage": "use-cases",
-      "sections": [
+        "self-hosted",
         "use-cases"
       ]
     },
@@ -195,8 +188,11 @@
           "title": "Hosting Hermes"
         },
         {
-          "slug": "browser",
-          "title": "Hosting Steel Browser"
+          "slug": "steel-browser",
+          "title": "Steel Browser",
+          "aliases": [
+            "browser"
+          ]
         }
       ]
     },

--- a/docs/use-cases/hermes/page.mdx
+++ b/docs/use-cases/hermes/page.mdx
@@ -401,7 +401,7 @@ The builtin template is configurable through `Sandbox0Infra.spec.builtinTemplate
 ## Next Steps
 
 <CardGroup>
-  <Card title="Hosting OpenClaw" href="/docs/use-cases/openclaw" cta="Continue">
+  <Card title="Hosting OpenClaw" href="/docs/sandbox/use-cases/openclaw" cta="Continue">
     Run OpenClaw from the builtin OpenClaw template.
   </Card>
 

--- a/docs/use-cases/openclaw/page.mdx
+++ b/docs/use-cases/openclaw/page.mdx
@@ -351,7 +351,7 @@ The builtin template is configurable through `Sandbox0Infra.spec.builtinTemplate
 ## Next Steps
 
 <CardGroup>
-  <Card title="Hosting Hermes" href="/docs/use-cases/hermes" cta="Continue">
+  <Card title="Hosting Hermes" href="/docs/sandbox/use-cases/hermes" cta="Continue">
     Run the Hermes gateway with a persistent `/opt/data` volume.
   </Card>
 

--- a/docs/use-cases/page.mdx
+++ b/docs/use-cases/page.mdx
@@ -71,15 +71,15 @@ Prefer one of these patterns:
 ## Guides
 
 <CardGroup>
-  <Card title="Hosting OpenClaw" href="/docs/use-cases/openclaw" cta="Continue">
+  <Card title="Hosting OpenClaw" href="/docs/sandbox/use-cases/openclaw" cta="Continue">
     Run the OpenClaw gateway from the builtin OpenClaw template with persistent state.
   </Card>
 
-  <Card title="Hosting Hermes" href="/docs/use-cases/hermes" cta="Continue">
+  <Card title="Hosting Hermes" href="/docs/sandbox/use-cases/hermes" cta="Continue">
     Run the Hermes gateway from the builtin Hermes template with persistent state.
   </Card>
 
-  <Card title="Hosting Steel Browser" href="/docs/use-cases/browser" cta="Continue">
+  <Card title="Steel Browser" href="/docs/sandbox/use-cases/steel-browser" cta="Continue">
     Run Steel Browser from the builtin browser template with CDP and live view.
   </Card>
 </CardGroup>

--- a/docs/use-cases/steel-browser/page.mdx
+++ b/docs/use-cases/steel-browser/page.mdx
@@ -11,7 +11,7 @@ Create a SandboxVolume, claim the builtin `browser` template, mount that volume 
 ```json
 {
     "id": "browser",
-    "display_name": "Browser",
+    "display_name": "Steel Browser",
     "port": 3000,
     "runtime": {
         "type": "cmd",
@@ -45,7 +45,7 @@ Create a SandboxVolume, claim the builtin `browser` template, mount that volume 
 
 `SANDBOX0_SANDBOX_ID`, `SANDBOX0_APP_DOMAIN`, and `SANDBOX0_SERVICE_PORT` are injected by Sandbox0. Steel uses `DOMAIN` and `USE_SSL=true` to return public `https` and `wss` URLs in session responses.
 
-## Use The Browser
+## Use Steel Browser
 
 After the sandbox is claimed, list the sandbox services and use the `public_url` for the `browser` service as the Steel base URL.
 
@@ -63,7 +63,7 @@ The session response includes `websocketUrl` for CDP clients, `debugUrl` for the
 
 When route auth is enabled, CDP and WebSocket clients must send the configured auth header. For human live-view access in a normal browser, open `debugUrl` through a protected frontend that can authenticate the route, or use a route auth mode that matches your access boundary.
 
-Browser automation clients can connect to `websocketUrl` with Playwright or a CDP client:
+Steel Browser automation clients can connect to `websocketUrl` with Playwright or a CDP client:
 
 ```js
 import { chromium } from "playwright";
@@ -96,3 +96,19 @@ The browser API is provided by Steel Browser and Chromium inside the image:
 | Live view | Steel `debugUrl`, `sessionViewerUrl`, and cast WebSocket routes |
 
 The builtin template is configurable through `Sandbox0Infra.spec.builtinTemplates`. Remove `templateId: browser` from that list to delete the operator-managed public template, or replace its `image`, `pool`, or full `spec` to pin a reviewed Steel Browser image.
+
+## Next Steps
+
+<CardGroup>
+  <Card title="Use Cases" href="/docs/sandbox/use-cases" cta="Back">
+    Compare Steel Browser with the other Sandbox0-hosted use cases.
+  </Card>
+
+  <Card title="Sandbox Services" href="/docs/sandbox/services" cta="Continue">
+    Tune route auth, resume behavior, timeouts, and public service exposure.
+  </Card>
+
+  <Card title="Volume Mounts" href="/docs/sandbox/volume/mounts" cta="Continue">
+    Keep downloads and shared browser artifacts on a SandboxVolume.
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Summary
- keep the renamed Use Cases section under the Sandbox docs product instead of exposing it as a top-level docs product
- rename the browser use case entry to Steel Browser with canonical path `/docs/sandbox/use-cases/steel-browser`
- keep `browser` as a page alias and update use-case links to the canonical Sandbox docs paths
- add Next Steps to the Steel Browser guide

## Companion PR
- Depends on sandbox0-cloud PR https://github.com/sandbox0-ai/sandbox0-cloud/pull/215 for full legacy redirects when both the section and page slug are renamed, including `/docs/sandbox/agent-in-sandbox/browser` -> `/docs/sandbox/use-cases/steel-browser`.

## Validation
- `node -e 'JSON.parse(require("fs").readFileSync("docs/manifest.json", "utf8")); console.log("manifest json ok")'`
- `DOCS_GENERATED_ROOT=/tmp/tmp.hYbTKlIGDJ SANDBOX0_ROOT=/root/sandbox0ai/worktrees/sandbox0-use-cases-docs node ./apps/website/scripts/generate_docs_content.mjs` from the sandbox0-cloud companion worktree
- custom assertion over generated `navigation.ts`, `content.tsx`, and `redirects.json` verifying Use Cases remains under Sandbox, Steel Browser is canonical, and old use-cases/agent-in-sandbox browser URLs redirect
- `git diff --check`
