### PR TITLE
Raise Kubernetes client rate limit defaults

### DIFF
--- a/docs/self-hosted/configuration/page.mdx
+++ b/docs/self-hosted/configuration/page.mdx
@@ -466,7 +466,7 @@ Examples:
 
 - `services.clusterGateway.config.authMode` switches between `public`, `internal`, and `both`
 - `services.manager.config.autoscaler.*` tunes pool scale behavior
-- `services.manager.config.k8sClientQps` and `k8sClientBurst` tune the manager Kubernetes client token bucket rate limit
+- `services.manager.config.k8sClientQps` and `k8sClientBurst` tune the manager Kubernetes client token bucket rate limit; defaults are `50` and `100`
 - `services.manager.config.sandboxMaxMemory` caps per-sandbox memory overrides; the default is `32Gi`
 - `services.manager.config.allowColdStartWithoutReadyDataPlane` lets cold claims create Pending pods for external node autoscaler scale-from-zero deployments; keep it disabled unless the cluster autoscaler can provision matching sandbox nodes
 - `services.storageProxy.config.filesystem*` tunes filesystem behavior; `services.manager.config.procdConfig.volume*` tunes mounted volume cache sizing

--- a/infra-operator/api/config/manager.go
+++ b/infra-operator/api/config/manager.go
@@ -32,11 +32,11 @@ type ManagerConfig struct {
 	// +optional
 	KubeConfig string `yaml:"kube_config" json:"kubeConfig"`
 	// K8sClientQPS configures the manager-wide Kubernetes client token bucket rate.
-	// When unset, manager uses the client-go default.
+	// When unset, manager uses the Sandbox0 Kubernetes client default.
 	// +optional
 	K8sClientQPS int `yaml:"k8s_client_qps" json:"k8sClientQps"`
 	// K8sClientBurst configures the manager-wide Kubernetes client burst.
-	// When unset, manager uses the client-go default.
+	// When unset, manager uses the Sandbox0 Kubernetes client default.
 	// +optional
 	K8sClientBurst int `yaml:"k8s_client_burst" json:"k8sClientBurst"`
 	// +optional

--- a/infra-operator/api/v1alpha1/service_api_config_types.go
+++ b/infra-operator/api/v1alpha1/service_api_config_types.go
@@ -407,10 +407,10 @@ type ManagerConfig struct {
 	// +optional
 	KubeConfig string `json:"kubeConfig,omitempty"`
 	// +optional
-	// +kubebuilder:default=5
+	// +kubebuilder:default=50
 	K8sClientQPS int `json:"k8sClientQps,omitempty"`
 	// +optional
-	// +kubebuilder:default=10
+	// +kubebuilder:default=100
 	K8sClientBurst int `json:"k8sClientBurst,omitempty"`
 	// +optional
 	// +kubebuilder:default=true

--- a/infra-operator/chart/crds/infra.sandbox0.ai_sandbox0infras.yaml
+++ b/infra-operator/chart/crds/infra.sandbox0.ai_sandbox0infras.yaml
@@ -3114,10 +3114,10 @@ spec:
                             default: 8080
                             type: integer
                           k8sClientBurst:
-                            default: 10
+                            default: 100
                             type: integer
                           k8sClientQps:
-                            default: 5
+                            default: 50
                             type: integer
                           kubeConfig:
                             type: string

--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/egressauth"
 	egressauthruntime "github.com/sandbox0-ai/sandbox0/pkg/egressauth/runtime"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+	s0k8s "github.com/sandbox0-ai/sandbox0/pkg/k8s"
 	"github.com/sandbox0-ai/sandbox0/pkg/metering"
 	"github.com/sandbox0-ai/sandbox0/pkg/migrate"
 	"github.com/sandbox0-ai/sandbox0/pkg/observability"
@@ -588,42 +589,42 @@ func buildKubeConfig(kubeconfig string) (*rest.Config, error) {
 	return rest.InClusterConfig()
 }
 
-func configureK8sClientRateLimiter(config *rest.Config, qps int, burst int) {
-	if config == nil {
+func configureK8sClientRateLimiter(restConfig *rest.Config, qps int, burst int) {
+	if restConfig == nil {
 		return
 	}
 	rate := float32(qps)
 	if rate <= 0 {
-		rate = rest.DefaultQPS
+		rate = s0k8s.DefaultClientQPS
 	}
 	if burst <= 0 {
-		burst = rest.DefaultBurst
+		burst = s0k8s.DefaultClientBurst
 	}
-	config.QPS = rate
-	config.Burst = burst
-	config.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(rate, burst)
+	restConfig.QPS = rate
+	restConfig.Burst = burst
+	restConfig.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(rate, burst)
 }
 
-func observeK8sClientRateLimit(metrics *obsmetrics.ManagerMetrics, config *rest.Config) {
-	if metrics == nil || metrics.K8sClientRateLimit == nil || config == nil {
+func observeK8sClientRateLimit(metrics *obsmetrics.ManagerMetrics, restConfig *rest.Config) {
+	if metrics == nil || metrics.K8sClientRateLimit == nil || restConfig == nil {
 		return
 	}
-	metrics.K8sClientRateLimit.WithLabelValues("qps").Set(float64(effectiveK8sClientQPS(config)))
-	metrics.K8sClientRateLimit.WithLabelValues("burst").Set(float64(effectiveK8sClientBurst(config)))
+	metrics.K8sClientRateLimit.WithLabelValues("qps").Set(float64(effectiveK8sClientQPS(restConfig)))
+	metrics.K8sClientRateLimit.WithLabelValues("burst").Set(float64(effectiveK8sClientBurst(restConfig)))
 }
 
-func effectiveK8sClientQPS(config *rest.Config) float32 {
-	if config == nil || config.QPS <= 0 {
-		return rest.DefaultQPS
+func effectiveK8sClientQPS(restConfig *rest.Config) float32 {
+	if restConfig == nil || restConfig.QPS <= 0 {
+		return s0k8s.DefaultClientQPS
 	}
-	return config.QPS
+	return restConfig.QPS
 }
 
-func effectiveK8sClientBurst(config *rest.Config) int {
-	if config == nil || config.Burst <= 0 {
-		return rest.DefaultBurst
+func effectiveK8sClientBurst(restConfig *rest.Config) int {
+	if restConfig == nil || restConfig.Burst <= 0 {
+		return s0k8s.DefaultClientBurst
 	}
-	return config.Burst
+	return restConfig.Burst
 }
 
 // startMetricsServer starts the Prometheus metrics server

--- a/manager/cmd/manager/main_test.go
+++ b/manager/cmd/manager/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"testing"
 
+	s0k8s "github.com/sandbox0-ai/sandbox0/pkg/k8s"
 	"k8s.io/client-go/rest"
 )
 
@@ -27,11 +28,11 @@ func TestConfigureK8sClientRateLimiterDefaultsWhenUnset(t *testing.T) {
 
 	configureK8sClientRateLimiter(cfg, 0, 0)
 
-	if cfg.QPS != rest.DefaultQPS {
-		t.Fatalf("qps = %v, want %v", cfg.QPS, rest.DefaultQPS)
+	if cfg.QPS != s0k8s.DefaultClientQPS {
+		t.Fatalf("qps = %v, want %v", cfg.QPS, s0k8s.DefaultClientQPS)
 	}
-	if cfg.Burst != rest.DefaultBurst {
-		t.Fatalf("burst = %d, want %d", cfg.Burst, rest.DefaultBurst)
+	if cfg.Burst != s0k8s.DefaultClientBurst {
+		t.Fatalf("burst = %d, want %d", cfg.Burst, s0k8s.DefaultClientBurst)
 	}
 	if cfg.RateLimiter == nil {
 		t.Fatal("expected shared rate limiter")

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -11,12 +11,20 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+const (
+	// DefaultClientQPS is the Sandbox0 Kubernetes client token bucket rate.
+	DefaultClientQPS float32 = 50
+	// DefaultClientBurst is the Sandbox0 Kubernetes client burst.
+	DefaultClientBurst = 100
+)
+
 // BuildRestConfig creates a Kubernetes rest config using in-cluster config or kubeconfig
 func BuildRestConfig(kubeconfigPath string) (*rest.Config, error) {
 	// If kubeconfigPath is empty, try in-cluster config first
 	if kubeconfigPath == "" {
 		config, err := rest.InClusterConfig()
 		if err == nil {
+			ApplyDefaultRateLimit(config)
 			return config, nil
 		}
 	}
@@ -36,11 +44,25 @@ func BuildRestConfig(kubeconfigPath string) (*rest.Config, error) {
 			if err != nil {
 				return nil, fmt.Errorf("build kubeconfig from %s: %w", kubeconfigPath, err)
 			}
+			ApplyDefaultRateLimit(config)
 			return config, nil
 		}
 	}
 
 	return nil, fmt.Errorf("no Kubernetes config found")
+}
+
+// ApplyDefaultRateLimit sets Sandbox0 Kubernetes client defaults when QPS or burst are unset.
+func ApplyDefaultRateLimit(config *rest.Config) {
+	if config == nil {
+		return
+	}
+	if config.QPS <= 0 {
+		config.QPS = DefaultClientQPS
+	}
+	if config.Burst <= 0 {
+		config.Burst = DefaultClientBurst
+	}
 }
 
 // NewClient creates a new Kubernetes clientset using in-cluster config or kubeconfig

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -1,0 +1,33 @@
+package k8s
+
+import (
+	"testing"
+
+	"k8s.io/client-go/rest"
+)
+
+func TestApplyDefaultRateLimitUsesSandbox0DefaultsWhenUnset(t *testing.T) {
+	cfg := &rest.Config{}
+
+	ApplyDefaultRateLimit(cfg)
+
+	if cfg.QPS != DefaultClientQPS {
+		t.Fatalf("qps = %v, want %v", cfg.QPS, DefaultClientQPS)
+	}
+	if cfg.Burst != DefaultClientBurst {
+		t.Fatalf("burst = %d, want %d", cfg.Burst, DefaultClientBurst)
+	}
+}
+
+func TestApplyDefaultRateLimitPreservesConfiguredValues(t *testing.T) {
+	cfg := &rest.Config{QPS: 25, Burst: 50}
+
+	ApplyDefaultRateLimit(cfg)
+
+	if cfg.QPS != 25 {
+		t.Fatalf("qps = %v, want 25", cfg.QPS)
+	}
+	if cfg.Burst != 50 {
+		t.Fatalf("burst = %d, want 50", cfg.Burst)
+	}
+}


### PR DESCRIPTION
## Summary
- raise Sandbox0 Kubernetes client defaults from client-go 5/10 to 50/100
- route ctld shared Kubernetes client construction through the new Sandbox0 defaults
- keep manager explicit config overrides, update manager CRD defaults, generated manifests, docs, and tests

## Notes
- manager still installs a shared token bucket on its rest.Config so core, manager CRD, and informer clients share the same limit
- ctld has no operator-exposed QPS/Burst config today; this PR raises its default by applying the shared pkg/k8s defaults during client construction

## Tests
- make manifests
- go test ./pkg/k8s ./manager/cmd/manager ./infra-operator/api/config ./infra-operator/internal/runtimeconfig ./infra-operator/internal/controller/services/manager
- go test ./ctld/...

Refs sandbox0-ai/sandbox0#630
Refs sandbox0-ai/sandbox0-infra#85