### PR TITLE
Fix autoscaler retry and hot claim fallback

### DIFF
--- a/manager/pkg/controller/autoscaler.go
+++ b/manager/pkg/controller/autoscaler.go
@@ -16,7 +16,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
-	appslisters "k8s.io/client-go/listers/apps/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/util/retry"
 )
@@ -30,10 +29,9 @@ import (
 //   - cold claims are admitted only while the pod-network backlog is healthy,
 //   - scale-down returns the pool target to minIdle after no traffic.
 type AutoScaler struct {
-	k8sClient        kubernetes.Interface
-	podLister        corelisters.PodLister
-	replicaSetLister appslisters.ReplicaSetLister
-	logger           *zap.Logger
+	k8sClient kubernetes.Interface
+	podLister corelisters.PodLister
+	logger    *zap.Logger
 
 	rateLimiter *scaleRateLimiter
 	coldClaims  *coldClaimLimiter
@@ -75,7 +73,9 @@ type AutoScaleConfig struct {
 }
 
 type autoScalerTemplateState struct {
-	lastClaimAt time.Time
+	lastClaimAt           time.Time
+	scaleRetryScheduled   bool
+	pendingScaleClaimType string
 }
 
 type autoScalerPoolStats struct {
@@ -107,17 +107,15 @@ func DefaultAutoScaleConfig() AutoScaleConfig {
 func NewAutoScaler(
 	k8sClient kubernetes.Interface,
 	podLister corelisters.PodLister,
-	replicaSetLister appslisters.ReplicaSetLister,
 	logger *zap.Logger,
 ) *AutoScaler {
-	return NewAutoScalerWithConfig(k8sClient, podLister, replicaSetLister, logger, DefaultAutoScaleConfig())
+	return NewAutoScalerWithConfig(k8sClient, podLister, logger, DefaultAutoScaleConfig())
 }
 
 // NewAutoScalerWithConfig creates a new AutoScaler with custom configuration.
 func NewAutoScalerWithConfig(
 	k8sClient kubernetes.Interface,
 	podLister corelisters.PodLister,
-	replicaSetLister appslisters.ReplicaSetLister,
 	logger *zap.Logger,
 	config AutoScaleConfig,
 ) *AutoScaler {
@@ -126,14 +124,13 @@ func NewAutoScalerWithConfig(
 		logger = zap.NewNop()
 	}
 	return &AutoScaler{
-		k8sClient:        k8sClient,
-		podLister:        podLister,
-		replicaSetLister: replicaSetLister,
-		logger:           logger,
-		rateLimiter:      newScaleRateLimiter(config.MinScaleInterval),
-		coldClaims:       newColdClaimLimiter(),
-		state:            make(map[string]*autoScalerTemplateState),
-		config:           config,
+		k8sClient:   k8sClient,
+		podLister:   podLister,
+		logger:      logger,
+		rateLimiter: newScaleRateLimiter(config.MinScaleInterval),
+		coldClaims:  newColdClaimLimiter(),
+		state:       make(map[string]*autoScalerTemplateState),
+		config:      config,
 	}
 }
 
@@ -250,8 +247,9 @@ func (s *AutoScaler) scaleForClaim(ctx context.Context, template *v1alpha1.Sandb
 
 	key := autoscalerTemplateKey(template)
 	templateName := autoscalerMetricTemplate(template)
-	if !s.rateLimiter.TryAcquire(key) {
+	if acquired, retryAfter := s.rateLimiter.TryAcquire(key); !acquired {
 		s.observeDecision(templateName, "scale_up", "rate_limited", "skipped")
+		s.scheduleScaleRetry(template, claimType, retryAfter)
 		return &ScaleDecision{ShouldScale: false, Reason: "rate limited"}, nil
 	}
 	defer s.rateLimiter.Complete(key)
@@ -445,16 +443,6 @@ func (s *AutoScaler) getCurrentReplicas(ctx context.Context, template *v1alpha1.
 		return 0, fmt.Errorf("generate replicaset name: %w", err)
 	}
 
-	if s.replicaSetLister != nil {
-		rs, err := s.replicaSetLister.ReplicaSets(template.Namespace).Get(rsName)
-		if err == nil {
-			return getInt32Value(rs.Spec.Replicas), nil
-		}
-		if !errors.IsNotFound(err) {
-			return 0, err
-		}
-	}
-
 	rs, err := s.k8sClient.AppsV1().ReplicaSets(template.Namespace).Get(ctx, rsName, metav1.GetOptions{})
 	if err != nil {
 		return 0, err
@@ -488,42 +476,51 @@ func (s *AutoScaler) executeScale(ctx context.Context, template *v1alpha1.Sandbo
 }
 
 // ReconcileScaleDown returns the idle pool target to minIdle after no traffic.
-func (s *AutoScaler) ReconcileScaleDown(ctx context.Context, template *v1alpha1.SandboxTemplate, now time.Time) error {
+// It returns a positive duration when the caller should requeue the template to
+// check again after the recent-traffic window expires.
+func (s *AutoScaler) ReconcileScaleDown(ctx context.Context, template *v1alpha1.SandboxTemplate, now time.Time) (time.Duration, error) {
 	if template == nil {
-		return nil
+		return 0, nil
 	}
 
 	currentReplicas, err := s.getCurrentReplicas(ctx, template)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			return nil
+			return 0, nil
 		}
-		return err
+		return 0, err
 	}
 
 	minIdle, _ := normalizedPoolBounds(template)
 	if currentReplicas <= minIdle {
-		return nil
+		return 0, nil
 	}
 
 	stats, err := s.getPoolStatsDetailed(template)
 	if err != nil {
-		return fmt.Errorf("get pool stats: %w", err)
+		return 0, fmt.Errorf("get pool stats: %w", err)
 	}
 	templateName := autoscalerMetricTemplate(template)
 	s.observePool(templateName, stats, currentReplicas, minIdle)
 	if stats.activeTotal() > 0 {
 		s.observeDecision(templateName, "scale_down", "active_pods", "skipped")
-		return nil
+		return 0, nil
 	}
 
 	lastClaimTime := s.lastClaimTime(template)
 	if observed := s.getLastClaimTime(template); observed.After(lastClaimTime) {
 		lastClaimTime = observed
 	}
-	if !lastClaimTime.IsZero() && now.Sub(lastClaimTime) < s.config.NoTrafficScaleDownAfter {
-		s.observeDecision(templateName, "scale_down", "recent_claim", "skipped")
-		return nil
+	if !lastClaimTime.IsZero() {
+		elapsed := now.Sub(lastClaimTime)
+		if elapsed < s.config.NoTrafficScaleDownAfter {
+			requeueAfter := s.config.NoTrafficScaleDownAfter - elapsed
+			if requeueAfter < time.Second {
+				requeueAfter = time.Second
+			}
+			s.observeDecision(templateName, "scale_down", "recent_claim", "skipped")
+			return requeueAfter, nil
+		}
 	}
 
 	s.logger.Info("Scale down due to no traffic",
@@ -532,11 +529,80 @@ func (s *AutoScaler) ReconcileScaleDown(ctx context.Context, template *v1alpha1.
 		zap.Int32("newReplicas", minIdle),
 	)
 	if err := s.executeScale(ctx, template, minIdle); err != nil {
-		return err
+		return 0, err
 	}
 	s.observeDecision(templateName, "scale_down", "no_recent_claims", "scaled")
 	s.observeScaleDelta(templateName, minIdle-currentReplicas)
-	return nil
+	return 0, nil
+}
+
+func (s *AutoScaler) scheduleScaleRetry(template *v1alpha1.SandboxTemplate, claimType string, retryAfter time.Duration) {
+	if s == nil || template == nil {
+		return
+	}
+	if retryAfter <= 0 {
+		retryAfter = s.config.MinScaleInterval
+	}
+	if retryAfter <= 0 {
+		retryAfter = time.Millisecond
+	}
+
+	key := autoscalerTemplateKey(template)
+	s.stateMu.Lock()
+	state := s.state[key]
+	if state == nil {
+		state = &autoScalerTemplateState{}
+		s.state[key] = state
+	}
+	state.pendingScaleClaimType = mergeScaleRetryClaimType(state.pendingScaleClaimType, claimType)
+	if state.scaleRetryScheduled {
+		s.stateMu.Unlock()
+		return
+	}
+	state.scaleRetryScheduled = true
+	s.stateMu.Unlock()
+
+	templateCopy := template.DeepCopy()
+	go func() {
+		timer := time.NewTimer(retryAfter)
+		defer timer.Stop()
+		<-timer.C
+
+		s.stateMu.Lock()
+		state := s.state[key]
+		pendingClaimType := "hot"
+		if state != nil {
+			pendingClaimType = state.pendingScaleClaimType
+			if pendingClaimType == "" {
+				pendingClaimType = "hot"
+			}
+			state.pendingScaleClaimType = ""
+			state.scaleRetryScheduled = false
+		}
+		s.stateMu.Unlock()
+
+		if _, err := s.scaleForClaim(context.Background(), templateCopy, pendingClaimType); err != nil {
+			s.logger.Warn("Auto scale retry failed",
+				zap.String("template", templateCopy.Name),
+				zap.String("namespace", templateCopy.Namespace),
+				zap.String("claimType", pendingClaimType),
+				zap.Error(err),
+			)
+		}
+	}()
+}
+
+func mergeScaleRetryClaimType(existing, next string) string {
+	if existing == "cold" || next == "cold" {
+		return "cold"
+	}
+	if existing != "" {
+		return existing
+	}
+	if next != "" {
+		return next
+	}
+	return "hot"
 }
 
 func (s *AutoScaler) getLastClaimTime(template *v1alpha1.SandboxTemplate) time.Time {

--- a/manager/pkg/controller/autoscaler_test.go
+++ b/manager/pkg/controller/autoscaler_test.go
@@ -21,7 +21,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/fake"
-	appslisters "k8s.io/client-go/listers/apps/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -49,7 +48,7 @@ func TestAutoScalerColdClaimRefillsIdleDeficitByStep(t *testing.T) {
 	assert.Equal(t, int32(25), *rs.Spec.Replicas)
 }
 
-func TestAutoScalerColdClaimUsesCachedReplicaSetTarget(t *testing.T) {
+func TestAutoScalerColdClaimUsesLiveReplicaSetTarget(t *testing.T) {
 	template := autoscalerTestTemplate("template-a", 15, 50)
 	scaler, client := newAutoScalerTestHarness(t, template, 15, nil, AutoScaleConfig{
 		MinScaleInterval:        time.Millisecond,
@@ -69,11 +68,11 @@ func TestAutoScalerColdClaimUsesCachedReplicaSetTarget(t *testing.T) {
 	decision, err := scaler.OnColdClaim(context.Background(), template)
 	require.NoError(t, err)
 	require.True(t, decision.ShouldScale)
-	assert.Equal(t, int32(15), decision.OldReplicas)
-	assert.Equal(t, int32(25), decision.NewReplicas)
+	assert.Equal(t, int32(25), decision.OldReplicas)
+	assert.Equal(t, int32(35), decision.NewReplicas)
 
 	rs = getAutoscalerTestReplicaSet(t, client, template)
-	assert.Equal(t, int32(25), *rs.Spec.Replicas)
+	assert.Equal(t, int32(35), *rs.Spec.Replicas)
 }
 
 func TestAutoScalerHotClaimSkipsWhenPendingIdleCoversTarget(t *testing.T) {
@@ -139,11 +138,62 @@ func TestAutoScalerReconcileScaleDownReturnsToMinIdle(t *testing.T) {
 		ScaleDownPercent:        0.1,
 	})
 
-	err := scaler.ReconcileScaleDown(context.Background(), template, time.Now().Add(2*time.Minute))
+	requeueAfter, err := scaler.ReconcileScaleDown(context.Background(), template, time.Now().Add(2*time.Minute))
 	require.NoError(t, err)
+	assert.Zero(t, requeueAfter)
 
 	rs := getAutoscalerTestReplicaSet(t, client, template)
 	assert.Equal(t, int32(15), *rs.Spec.Replicas)
+}
+
+func TestAutoScalerReconcileScaleDownRequestsRequeueAfterRecentClaim(t *testing.T) {
+	template := autoscalerTestTemplate("template-a", 15, 50)
+	scaler, client := newAutoScalerTestHarness(t, template, 30, nil, AutoScaleConfig{
+		MinScaleInterval:        time.Millisecond,
+		ScaleUpFactor:           1.5,
+		MaxScaleStep:            10,
+		MinIdleBuffer:           2,
+		TargetIdleRatio:         0.2,
+		NoTrafficScaleDownAfter: time.Minute,
+		ScaleDownPercent:        0.1,
+	})
+	scaler.recordClaim(template)
+
+	requeueAfter, err := scaler.ReconcileScaleDown(context.Background(), template, time.Now())
+	require.NoError(t, err)
+	assert.Greater(t, requeueAfter, time.Duration(0))
+	assert.LessOrEqual(t, requeueAfter, time.Minute)
+
+	rs := getAutoscalerTestReplicaSet(t, client, template)
+	assert.Equal(t, int32(30), *rs.Spec.Replicas)
+}
+
+func TestAutoScalerRateLimitedScaleUpSchedulesCoalescedRetry(t *testing.T) {
+	template := autoscalerTestTemplate("template-a", 15, 50)
+	scaler, client := newAutoScalerTestHarness(t, template, 15, nil, AutoScaleConfig{
+		MinScaleInterval:        5 * time.Millisecond,
+		ScaleUpFactor:           1.5,
+		MaxScaleStep:            10,
+		MinIdleBuffer:           2,
+		TargetIdleRatio:         0.2,
+		NoTrafficScaleDownAfter: time.Minute,
+		ScaleDownPercent:        0.1,
+	})
+
+	decision, err := scaler.OnColdClaim(context.Background(), template)
+	require.NoError(t, err)
+	require.True(t, decision.ShouldScale)
+	assert.Equal(t, int32(25), decision.NewReplicas)
+
+	decision, err = scaler.OnColdClaim(context.Background(), template)
+	require.NoError(t, err)
+	require.False(t, decision.ShouldScale)
+	assert.Equal(t, "rate limited", decision.Reason)
+
+	assert.Eventually(t, func() bool {
+		rs := getAutoscalerTestReplicaSet(t, client, template)
+		return rs.Spec.Replicas != nil && *rs.Spec.Replicas == 35
+	}, time.Second, 10*time.Millisecond)
 }
 
 func TestAutoScalerPoolStatsCountsBacklog(t *testing.T) {
@@ -178,7 +228,6 @@ func TestNewAutoScalerWithConfigAppliesZeroDefaults(t *testing.T) {
 	scaler := NewAutoScalerWithConfig(
 		fake.NewSimpleClientset(),
 		corelisters.NewPodLister(cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})),
-		appslisters.NewReplicaSetLister(cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})),
 		zap.NewNop(),
 		AutoScaleConfig{},
 	)
@@ -194,12 +243,20 @@ func TestScaleRateLimiter(t *testing.T) {
 	limiter := newScaleRateLimiter(100 * time.Millisecond)
 	key := "test-template"
 
-	assert.True(t, limiter.TryAcquire(key))
-	assert.False(t, limiter.TryAcquire(key))
+	acquired, retryAfter := limiter.TryAcquire(key)
+	assert.True(t, acquired)
+	assert.Zero(t, retryAfter)
+	acquired, retryAfter = limiter.TryAcquire(key)
+	assert.False(t, acquired)
+	assert.Equal(t, 100*time.Millisecond, retryAfter)
 	limiter.Complete(key)
-	assert.False(t, limiter.TryAcquire(key))
+	acquired, retryAfter = limiter.TryAcquire(key)
+	assert.False(t, acquired)
+	assert.Greater(t, retryAfter, time.Duration(0))
 	time.Sleep(110 * time.Millisecond)
-	assert.True(t, limiter.TryAcquire(key))
+	acquired, retryAfter = limiter.TryAcquire(key)
+	assert.True(t, acquired)
+	assert.Zero(t, retryAfter)
 }
 
 func TestScaleRateLimiterConcurrency(t *testing.T) {
@@ -212,7 +269,7 @@ func TestScaleRateLimiterConcurrency(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			if limiter.TryAcquire(key) {
+			if acquired, _ := limiter.TryAcquire(key); acquired {
 				successCount++
 			}
 		}()
@@ -267,13 +324,9 @@ func newAutoScalerTestHarness(
 	for _, pod := range pods {
 		require.NoError(t, podIndexer.Add(pod))
 	}
-	rsIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
-	require.NoError(t, rsIndexer.Add(rs))
-
 	return NewAutoScalerWithConfig(
 		client,
 		corelisters.NewPodLister(podIndexer),
-		appslisters.NewReplicaSetLister(rsIndexer),
 		zap.NewNop(),
 		config,
 	), client

--- a/manager/pkg/controller/operator.go
+++ b/manager/pkg/controller/operator.go
@@ -121,7 +121,7 @@ func NewOperator(
 	replicaSetLister := appslisters.NewReplicaSetLister(replicaSetInformer.GetIndexer())
 	secretLister := corelisters.NewSecretLister(secretInformer.GetIndexer())
 	poolManager := NewPoolManager(k8sClient, podLister, replicaSetLister, secretLister, recorder, logger)
-	autoScaler := NewAutoScalerWithConfig(k8sClient, podLister, replicaSetLister, logger, toAutoScaleConfig(autoscalerConfig))
+	autoScaler := NewAutoScalerWithConfig(k8sClient, podLister, logger, toAutoScaleConfig(autoscalerConfig))
 	autoScaler.SetMetrics(metrics)
 
 	op := &Operator{
@@ -273,13 +273,16 @@ func (op *Operator) syncHandler(ctx context.Context, key string) error {
 	// Scale down for idle templates (async, background operation)
 	// Scale up is handled synchronously in SandboxService.OnColdClaim
 	if op.autoScaler != nil {
-		if err := op.autoScaler.ReconcileScaleDown(ctx, template, op.clock.Now()); err != nil {
+		requeueAfter, err := op.autoScaler.ReconcileScaleDown(ctx, template, op.clock.Now())
+		if err != nil {
 			op.logger.Warn("Scale down reconcile failed",
 				zap.String("template", template.Name),
 				zap.String("namespace", template.Namespace),
 				zap.Error(err),
 			)
 			// Don't fail the reconcile; pool + status are still correct.
+		} else if requeueAfter > 0 {
+			op.workqueue.AddAfter(key, requeueAfter)
 		}
 	}
 

--- a/manager/pkg/controller/ratelimit.go
+++ b/manager/pkg/controller/ratelimit.go
@@ -26,29 +26,31 @@ func newScaleRateLimiter(minInterval time.Duration) *scaleRateLimiter {
 }
 
 // TryAcquire attempts to acquire the rate limiter for the given key.
-// Returns true if this call should proceed with scaling, false if rate limited.
+// It returns true when this call should proceed with scaling. When it returns
+// false, retryAfter is the earliest useful delay before recomputing the target.
 // Conditions for success:
 // 1. No scale operation is currently in progress for this key
 // 2. Enough time has passed since the last scale COMPLETED (minInterval)
 // This is an atomic check-and-record operation to prevent race conditions.
-func (r *scaleRateLimiter) TryAcquire(key string) bool {
+func (r *scaleRateLimiter) TryAcquire(key string) (bool, time.Duration) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	// Check if there's an ongoing scale operation
 	if r.inProgress[key] {
-		return false // Previous scale still in progress
+		return false, r.minInterval // Previous scale still in progress
 	}
 
 	// Check time interval since last completion
 	lastComplete, exists := r.lastCompleteAt[key]
-	if exists && time.Since(lastComplete) < r.minInterval {
-		return false // Rate limited by time since last completion
+	elapsed := time.Since(lastComplete)
+	if exists && elapsed < r.minInterval {
+		return false, r.minInterval - elapsed // Rate limited by time since last completion
 	}
 
 	// Mark as in progress
 	r.inProgress[key] = true
-	return true
+	return true, 0
 }
 
 // Complete marks the scale operation as done for the given key.

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -38,6 +38,7 @@ const (
 )
 
 var errIdlePodReservationConflict = errors.New("idle pod reservation conflict")
+var errIdlePodClaimLost = errors.New("idle pod claim lost")
 
 // ClaimRequest represents a sandbox claim request
 type ClaimRequest struct {
@@ -1122,7 +1123,9 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 	}
 	templateID := controller.TemplateLogicalID(template)
 	err = retry.OnError(claimIdlePodBackoff, func(err error) bool {
-		return k8serrors.IsConflict(err) || errors.Is(err, errIdlePodReservationConflict)
+		return k8serrors.IsConflict(err) ||
+			errors.Is(err, errIdlePodReservationConflict) ||
+			errors.Is(err, errIdlePodClaimLost)
 	}, func() error {
 		// Get all idle pods for this template
 		pods, listErr := s.podLister.Pods(template.Namespace).List(labels.SelectorFromSet(map[string]string{
@@ -1279,6 +1282,7 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 			if k8serrors.IsConflict(updateErr) {
 				s.observeIdleClaim(templateID, "update_conflict")
 				keepReservationUntilTTL()
+				return fmt.Errorf("%w: update pod %s/%s: %w", errIdlePodClaimLost, pod.Namespace, pod.Name, updateErr)
 			} else {
 				s.observeIdleClaim(templateID, "update_error")
 			}
@@ -1308,6 +1312,7 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 					}
 					cancel()
 					keepReservationUntilTTL()
+					return fmt.Errorf("%w: resize pod %s/%s: %w", errIdlePodClaimLost, updatedPod.Namespace, updatedPod.Name, resizeErr)
 				} else {
 					s.observeIdleClaim(templateID, "resize_error")
 					s.requestSandboxDeletionAfterClaimFailure(updatedPod, "sandbox resource resize failed")
@@ -1334,7 +1339,9 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 		return nil
 	})
 	if err != nil {
-		if errors.Is(err, errNoIdlePod) {
+		if errors.Is(err, errNoIdlePod) ||
+			errors.Is(err, errIdlePodReservationConflict) ||
+			errors.Is(err, errIdlePodClaimLost) {
 			return nil, nil // No idle pod available
 		}
 		return nil, err

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -413,6 +413,51 @@ func TestClaimIdlePodFallsBackWhenPodStartsDeletingDuringClaim(t *testing.T) {
 	}
 }
 
+func TestClaimIdlePodFallsBackAfterRepeatedUpdateConflicts(t *testing.T) {
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "template-a",
+			Namespace: "ns-a",
+		},
+	}
+	idlePods := []*corev1.Pod{
+		newClaimTestPod("ns-a", "idle-a", "template-a", true),
+		newClaimTestPod("ns-a", "idle-b", "template-a", true),
+		newClaimTestPod("ns-a", "idle-c", "template-a", true),
+	}
+
+	clientObjects := make([]runtime.Object, 0, len(idlePods))
+	for _, pod := range idlePods {
+		clientObjects = append(clientObjects, pod.DeepCopy())
+	}
+	client := fake.NewSimpleClientset(clientObjects...)
+	updateConflicts := 0
+	client.PrependReactor("update", "pods", func(k8stesting.Action) (bool, runtime.Object, error) {
+		updateConflicts++
+		return true, nil, &apierrors.StatusError{ErrStatus: metav1.Status{
+			Reason:  metav1.StatusReasonConflict,
+			Message: "pod was claimed by another manager",
+		}}
+	})
+	svc := &SandboxService{
+		k8sClient: client,
+		podLister: newClaimTestPodLister(t, idlePods...),
+		clock:     systemTime{},
+		logger:    zap.NewNop(),
+	}
+
+	pod, err := svc.claimIdlePod(context.Background(), template, &ClaimRequest{TeamID: "team-a", UserID: "user-a"})
+	if err != nil {
+		t.Fatalf("claimIdlePod() error = %v, want nil fallback", err)
+	}
+	if pod != nil {
+		t.Fatalf("claimIdlePod() = %s, want nil after repeated update conflicts", pod.Name)
+	}
+	if updateConflicts != claimIdlePodBackoff.Steps {
+		t.Fatalf("update conflicts = %d, want %d", updateConflicts, claimIdlePodBackoff.Steps)
+	}
+}
+
 func TestClaimIdlePodRequiresDataPlaneReadyNode(t *testing.T) {
 	template := &v1alpha1.SandboxTemplate{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Summary
- coalesce autoscaler requeues and retry scale writes from the existing branch update
- treat lost hot-claim pod update/resize conflicts as idle-pool misses after retries, so claims fall back to cold start instead of surfacing transient conflicts
- add coverage for repeated stale idle-pod update conflicts

## Tests
- go test ./manager/pkg/service -run 'TestClaimIdlePod|TestClaimSandbox'\n- go test ./manager/pkg/controller -run 'TestAutoScaler|TestColdClaim|TestPool'\n- go test ./manager/pkg/...\n