### PR TITLE
Batch database writes in metering paths

### DIFF
--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -226,10 +226,13 @@ func main() {
 	lifecycleProjector.SetMetrics(managerMetrics)
 	lifecycleProjector.SetRuntimePauseLookup(func(ctx context.Context, info managermetering.RuntimeDeletionInfo) (bool, error) {
 		record, err := sandboxStore.GetSandbox(ctx, info.SandboxID)
-		if err != nil || record == nil {
+		if err != nil {
 			return false, err
 		}
-		return service.SandboxRecordDeletionIsRuntimeOnly(record, info.Namespace, info.PodName, info.RuntimeGeneration), nil
+		if service.SandboxRecordDeletionIsRuntimeOnly(record, info.Namespace, info.PodName, info.RuntimeGeneration) {
+			return true, nil
+		}
+		return sandboxStore.RuntimeDeletionMatchesCommittedPause(ctx, info.SandboxID, info.Namespace, info.PodName, info.RuntimeGeneration)
 	})
 	podInformer.Informer().AddEventHandler(lifecycleProjector.ResourceEventHandler())
 

--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -347,6 +347,7 @@ func main() {
 	sandboxService.SetCredentialStore(credentialStore)
 	sandboxService.SetQuotaStore(quotaRepo)
 	sandboxService.SetSandboxStore(sandboxStore)
+	sandboxService.SetLifecycleMeteringRecorder(service.NewSandboxLifecycleMeteringRecorder(meteringRepo, cfg.RegionID, cfg.DefaultClusterId))
 	sandboxService.SetAutoScaler(operator.GetAutoScaler())
 	rootFSObjectStore, rootFSObjectStoreErr := buildRootFSObjectStore(cfg)
 	if rootFSObjectStoreErr != nil {

--- a/manager/pkg/controller/pool_manager.go
+++ b/manager/pkg/controller/pool_manager.go
@@ -48,8 +48,6 @@ const (
 	AnnotationMounts                       = "sandbox0.ai/mounts"
 	AnnotationPaused                       = "sandbox0.ai/paused"
 	AnnotationPausedAt                     = "sandbox0.ai/paused-at"
-	AnnotationPausedState                  = "sandbox0.ai/paused-state"
-	AnnotationPausedStateRuntimePaused     = "runtime-paused"
 	AnnotationPowerStateDesired            = "sandbox0.ai/power-state-desired"
 	AnnotationPowerStateDesiredGeneration  = "sandbox0.ai/power-state-desired-generation"
 	AnnotationPowerStateObserved           = "sandbox0.ai/power-state-observed"

--- a/manager/pkg/controller/pool_manager.go
+++ b/manager/pkg/controller/pool_manager.go
@@ -49,6 +49,7 @@ const (
 	AnnotationPaused                       = "sandbox0.ai/paused"
 	AnnotationPausedAt                     = "sandbox0.ai/paused-at"
 	AnnotationPausedState                  = "sandbox0.ai/paused-state"
+	AnnotationPausedStateRuntimePaused     = "runtime-paused"
 	AnnotationPowerStateDesired            = "sandbox0.ai/power-state-desired"
 	AnnotationPowerStateDesiredGeneration  = "sandbox0.ai/power-state-desired-generation"
 	AnnotationPowerStateObserved           = "sandbox0.ai/power-state-observed"

--- a/manager/pkg/http/handlers_egress_auth_test.go
+++ b/manager/pkg/http/handlers_egress_auth_test.go
@@ -35,7 +35,7 @@ func (s *egressAuthBindingStore) DeleteBindings(context.Context, string, string)
 	return nil
 }
 
-func (s *egressAuthBindingStore) GetSourceByRef(context.Context, string, string) (*egressauth.CredentialSource, error) {
+func (s *egressAuthBindingStore) GetSourcesByRef(context.Context, string, []string) (map[string]*egressauth.CredentialSource, error) {
 	return nil, nil
 }
 

--- a/manager/pkg/metering/lifecycle_projector.go
+++ b/manager/pkg/metering/lifecycle_projector.go
@@ -265,6 +265,12 @@ func (p *LifecycleProjector) handleDelete(obj any) {
 	templateID := pod.Labels[controller.LabelTemplateID]
 	podUsage := sandboxUsageFromPod(pod)
 	claimedAt, claimedAtSet := parseRFC3339(pod.Annotations[controller.AnnotationClaimedAt])
+	podPaused := pod.Annotations[controller.AnnotationPaused] == "true"
+	podRuntimePaused := podPaused && pod.Annotations[controller.AnnotationPausedState] == controller.AnnotationPausedStateRuntimePaused
+	pauseObservedAt := observedAt
+	if parsedPausedAt, ok := parseRFC3339(pod.Annotations[controller.AnnotationPausedAt]); ok {
+		pauseObservedAt = parsedPausedAt
+	}
 	runtimePaused, lookupErr := p.runtimeDeletionIsPause(ctx, RuntimeDeletionInfo{
 		SandboxID:         sandboxID,
 		Namespace:         pod.Namespace,
@@ -296,26 +302,17 @@ func (p *LifecycleProjector) handleDelete(obj any) {
 			state.ClaimedAt = &claimedAt
 			state.ActiveSince = &claimedAt
 		}
-		if pod.Annotations[controller.AnnotationPaused] == "true" {
-			pausedAt := observedAt
-			if parsedPausedAt, ok := parseRFC3339(pod.Annotations[controller.AnnotationPausedAt]); ok {
-				pausedAt = parsedPausedAt
-			}
-			pendingEvents = append(pendingEvents, p.buildSandboxEvent(sandboxID, teamID, userID, templateID, pausedAt, meteringpkg.EventTypeSandboxPaused, pauseEventID(sandboxID, pausedAt), nil))
-			pendingWindows = append(pendingWindows, p.buildSandboxRuntimeWindow(state, teamID, userID, templateID, state.ActiveSince, pausedAt))
-			state.Paused = true
-			state.PausedAt = &pausedAt
-			state.ActiveSince = nil
-		}
 	}
-	if runtimePaused {
+	if runtimePaused || podPaused {
 		if !state.Paused {
-			pendingWindows = append(pendingWindows, p.buildSandboxRuntimeWindow(state, teamID, userID, templateID, state.ActiveSince, observedAt))
-			pendingEvents = append(pendingEvents, p.buildSandboxEvent(sandboxID, teamID, userID, templateID, observedAt, meteringpkg.EventTypeSandboxPaused, pauseEventID(sandboxID, observedAt), nil))
+			pendingWindows = append(pendingWindows, p.buildSandboxRuntimeWindow(state, teamID, userID, templateID, state.ActiveSince, pauseObservedAt))
+			pendingEvents = append(pendingEvents, p.buildSandboxEvent(sandboxID, teamID, userID, templateID, pauseObservedAt, meteringpkg.EventTypeSandboxPaused, pauseEventID(sandboxID, pauseObservedAt), nil))
 		}
 		state.Paused = true
-		state.PausedAt = &observedAt
+		state.PausedAt = &pauseObservedAt
 		state.ActiveSince = nil
+	}
+	if runtimePaused || podRuntimePaused {
 		state.TerminatedAt = nil
 		state.LastObservedAt = observedAt
 		state.LastResourceVer = pod.ResourceVersion
@@ -330,7 +327,10 @@ func (p *LifecycleProjector) handleDelete(obj any) {
 		}
 		pendingEvents = append(pendingEvents, p.buildSandboxEvent(sandboxID, teamID, userID, templateID, observedAt, meteringpkg.EventTypeSandboxTerminated, terminateEventID(sandboxID, pod.ResourceVersion), nil))
 	}
-	state.Paused = pod.Annotations[controller.AnnotationPaused] == "true"
+	state.Paused = podPaused
+	if !podPaused {
+		state.PausedAt = nil
+	}
 	state.ActiveSince = nil
 	state.LastObservedAt = observedAt
 	state.LastResourceVer = pod.ResourceVersion

--- a/manager/pkg/metering/lifecycle_projector.go
+++ b/manager/pkg/metering/lifecycle_projector.go
@@ -20,8 +20,8 @@ import (
 const sandboxLifecycleProducer = "manager.sandbox_lifecycle"
 
 type txStore interface {
-	AppendEvent(ctx context.Context, event *meteringpkg.Event) error
-	AppendWindow(ctx context.Context, window *meteringpkg.Window) error
+	AppendEvents(ctx context.Context, events []*meteringpkg.Event) error
+	AppendWindows(ctx context.Context, windows []*meteringpkg.Window) error
 	UpsertProducerWatermark(ctx context.Context, producer string, regionID string, completeBefore time.Time) error
 	UpsertSandboxProjectionState(ctx context.Context, state *meteringpkg.SandboxProjectionState) error
 }
@@ -69,12 +69,12 @@ func (s *repositoryStore) RunInTx(ctx context.Context, fn func(tx txStore) error
 	})
 }
 
-func (s *repositoryTxStore) AppendEvent(ctx context.Context, event *meteringpkg.Event) error {
-	return s.repo.AppendEventTx(ctx, s.tx, event)
+func (s *repositoryTxStore) AppendEvents(ctx context.Context, events []*meteringpkg.Event) error {
+	return s.repo.AppendEventsTx(ctx, s.tx, events)
 }
 
-func (s *repositoryTxStore) AppendWindow(ctx context.Context, window *meteringpkg.Window) error {
-	return s.repo.AppendWindowTx(ctx, s.tx, window)
+func (s *repositoryTxStore) AppendWindows(ctx context.Context, windows []*meteringpkg.Window) error {
+	return s.repo.AppendWindowsTx(ctx, s.tx, windows)
 }
 
 func (s *repositoryTxStore) UpsertProducerWatermark(ctx context.Context, producer string, regionID string, completeBefore time.Time) error {
@@ -492,22 +492,14 @@ func (p *LifecycleProjector) commitProjection(ctx context.Context, sandboxID str
 		p.recordError("commit_projection", sandboxID, err)
 		return err
 	}
+	events = compactEvents(events)
+	windows = compactWindows(windows)
 	if err := p.store.RunInTx(ctx, func(tx txStore) error {
-		for _, event := range events {
-			if event == nil {
-				continue
-			}
-			if err := tx.AppendEvent(ctx, event); err != nil {
-				return fmt.Errorf("append event %s: %w", event.EventType, err)
-			}
+		if err := tx.AppendEvents(ctx, events); err != nil {
+			return fmt.Errorf("append events: %w", err)
 		}
-		for _, window := range windows {
-			if window == nil {
-				continue
-			}
-			if err := tx.AppendWindow(ctx, window); err != nil {
-				return fmt.Errorf("append window %s: %w", window.WindowType, err)
-			}
+		if err := tx.AppendWindows(ctx, windows); err != nil {
+			return fmt.Errorf("append windows: %w", err)
 		}
 		if err := tx.UpsertSandboxProjectionState(ctx, state); err != nil {
 			return fmt.Errorf("upsert state: %w", err)
@@ -518,29 +510,41 @@ func (p *LifecycleProjector) commitProjection(ctx context.Context, sandboxID str
 		return nil
 	}); err != nil {
 		for _, event := range events {
-			if event != nil {
-				p.recordEventResult(event.EventType, "error")
-			}
+			p.recordEventResult(event.EventType, "error")
 		}
 		for _, window := range windows {
-			if window != nil {
-				p.recordWindowResult(window.WindowType, "error")
-			}
+			p.recordWindowResult(window.WindowType, "error")
 		}
 		p.recordError("commit_projection", sandboxID, err)
 		return err
 	}
 	for _, event := range events {
-		if event != nil {
-			p.recordEventResult(event.EventType, "success")
-		}
+		p.recordEventResult(event.EventType, "success")
 	}
 	for _, window := range windows {
-		if window != nil {
-			p.recordWindowResult(window.WindowType, "success")
-		}
+		p.recordWindowResult(window.WindowType, "success")
 	}
 	return nil
+}
+
+func compactEvents(events []*meteringpkg.Event) []*meteringpkg.Event {
+	out := events[:0]
+	for _, event := range events {
+		if event != nil {
+			out = append(out, event)
+		}
+	}
+	return out
+}
+
+func compactWindows(windows []*meteringpkg.Window) []*meteringpkg.Window {
+	out := windows[:0]
+	for _, window := range windows {
+		if window != nil {
+			out = append(out, window)
+		}
+	}
+	return out
 }
 
 func (p *LifecycleProjector) recordEventResult(eventType string, result string) {

--- a/manager/pkg/metering/lifecycle_projector.go
+++ b/manager/pkg/metering/lifecycle_projector.go
@@ -214,6 +214,14 @@ func (p *LifecycleProjector) handleUpsert(obj any) {
 		state.PausedAt = &eventTime
 		state.ActiveSince = nil
 	} else if state.Paused {
+		if pod.DeletionTimestamp != nil {
+			state.LastObservedAt = observedAt
+			state.LastResourceVer = pod.ResourceVersion
+			if err := p.commitProjection(ctx, sandboxID, state, pendingEvents, pendingWindows, observedAt); err != nil {
+				return
+			}
+			return
+		}
 		pendingEvents = append(pendingEvents, p.buildSandboxEvent(sandboxID, teamID, userID, templateID, observedAt, meteringpkg.EventTypeSandboxResumed, resumeEventID(sandboxID, pod.ResourceVersion), nil))
 		state.Paused = false
 		state.PausedAt = nil

--- a/manager/pkg/metering/lifecycle_projector.go
+++ b/manager/pkg/metering/lifecycle_projector.go
@@ -266,7 +266,6 @@ func (p *LifecycleProjector) handleDelete(obj any) {
 	podUsage := sandboxUsageFromPod(pod)
 	claimedAt, claimedAtSet := parseRFC3339(pod.Annotations[controller.AnnotationClaimedAt])
 	podPaused := pod.Annotations[controller.AnnotationPaused] == "true"
-	podRuntimePaused := podPaused && pod.Annotations[controller.AnnotationPausedState] == controller.AnnotationPausedStateRuntimePaused
 	pauseObservedAt := observedAt
 	if parsedPausedAt, ok := parseRFC3339(pod.Annotations[controller.AnnotationPausedAt]); ok {
 		pauseObservedAt = parsedPausedAt
@@ -303,17 +302,22 @@ func (p *LifecycleProjector) handleDelete(obj any) {
 			state.ActiveSince = &claimedAt
 		}
 	}
+	alreadyTerminated := state.TerminatedAt != nil
 	if runtimePaused || podPaused {
 		if !state.Paused {
 			pendingWindows = append(pendingWindows, p.buildSandboxRuntimeWindow(state, teamID, userID, templateID, state.ActiveSince, pauseObservedAt))
 			pendingEvents = append(pendingEvents, p.buildSandboxEvent(sandboxID, teamID, userID, templateID, pauseObservedAt, meteringpkg.EventTypeSandboxPaused, pauseEventID(sandboxID, pauseObservedAt), nil))
 		}
-		state.Paused = true
-		state.PausedAt = &pauseObservedAt
-		state.ActiveSince = nil
+		if !alreadyTerminated {
+			state.Paused = true
+			state.PausedAt = &pauseObservedAt
+			state.ActiveSince = nil
+		}
 	}
-	if runtimePaused || podRuntimePaused {
-		state.TerminatedAt = nil
+	if runtimePaused {
+		if !alreadyTerminated {
+			state.TerminatedAt = nil
+		}
 		state.LastObservedAt = observedAt
 		state.LastResourceVer = pod.ResourceVersion
 		if err := p.commitProjection(ctx, sandboxID, state, pendingEvents, pendingWindows, observedAt); err != nil {

--- a/manager/pkg/metering/lifecycle_projector_test.go
+++ b/manager/pkg/metering/lifecycle_projector_test.go
@@ -261,43 +261,6 @@ func TestLifecycleProjectorRecordsPauseFromDurableStatusOnPodDelete(t *testing.T
 	}
 }
 
-func TestLifecycleProjectorTreatsRuntimePausedMarkerDeleteAsPause(t *testing.T) {
-	recorder := &fakeRecorder{states: map[string]*meteringpkg.SandboxProjectionState{}}
-	projector := NewLifecycleProjector(recorder, "aws-us-east-1", "cluster-a")
-	projector.SetRuntimePauseLookup(func(context.Context, RuntimeDeletionInfo) (bool, error) {
-		return false, nil
-	})
-
-	now := time.Date(2026, 3, 12, 10, 0, 0, 0, time.UTC)
-	projector.now = func() time.Time { return now }
-	claimedAt := now
-	pod := withSandboxResources(buildSandboxPod(claimedAt, false, "", "1"), "1", "1Gi")
-	projector.handleUpsert(pod)
-
-	pausedAt := now.Add(2 * time.Minute)
-	pausedPod := pod.DeepCopy()
-	pausedPod.ResourceVersion = "2"
-	pausedPod.Annotations[controller.AnnotationPaused] = "true"
-	pausedPod.Annotations[controller.AnnotationPausedAt] = pausedAt.Format(time.RFC3339)
-	pausedPod.Annotations[controller.AnnotationPausedState] = controller.AnnotationPausedStateRuntimePaused
-	projector.now = func() time.Time { return now.Add(3 * time.Minute) }
-	projector.handleDelete(pausedPod)
-
-	if len(recorder.events) != 2 {
-		t.Fatalf("event count = %d, want claim and pause", len(recorder.events))
-	}
-	if recorder.events[1].EventType != meteringpkg.EventTypeSandboxPaused {
-		t.Fatalf("second event type = %q, want pause", recorder.events[1].EventType)
-	}
-	if !recorder.events[1].OccurredAt.Equal(pausedAt) {
-		t.Fatalf("pause occurred_at = %v, want %v", recorder.events[1].OccurredAt, pausedAt)
-	}
-	state := recorder.states["sb-1"]
-	if state == nil || !state.Paused || state.TerminatedAt != nil {
-		t.Fatalf("state after runtime paused marker delete = %#v, want paused without termination", state)
-	}
-}
-
 func TestLifecycleProjectorTreatsStaleRuntimeDeleteAsPause(t *testing.T) {
 	recorder := &fakeRecorder{states: map[string]*meteringpkg.SandboxProjectionState{}}
 	projector := NewLifecycleProjector(recorder, "aws-us-east-1", "cluster-a")
@@ -326,6 +289,46 @@ func TestLifecycleProjectorTreatsStaleRuntimeDeleteAsPause(t *testing.T) {
 	state := recorder.states["sb-1"]
 	if state == nil || !state.Paused || state.TerminatedAt != nil {
 		t.Fatalf("state after stale runtime delete = %#v, want paused", state)
+	}
+}
+
+func TestLifecycleProjectorLateRuntimePauseDeleteDoesNotReactivateTerminatedSandbox(t *testing.T) {
+	recorder := &fakeRecorder{states: map[string]*meteringpkg.SandboxProjectionState{}}
+	projector := NewLifecycleProjector(recorder, "aws-us-east-1", "cluster-a")
+	projector.SetRuntimePauseLookup(func(_ context.Context, info RuntimeDeletionInfo) (bool, error) {
+		return info.RuntimeGeneration == 1, nil
+	})
+
+	now := time.Date(2026, 3, 12, 10, 0, 0, 0, time.UTC)
+	projector.now = func() time.Time { return now }
+	oldPod := withSandboxResources(buildSandboxPod(now, false, "", "1"), "1", "1Gi")
+	oldPod.Annotations[controller.AnnotationRuntimeGeneration] = "1"
+	projector.handleUpsert(oldPod)
+
+	currentPod := oldPod.DeepCopy()
+	currentPod.Name = "sb-2"
+	currentPod.ResourceVersion = "2"
+	currentPod.Annotations[controller.AnnotationRuntimeGeneration] = "2"
+	projector.now = func() time.Time { return now.Add(5 * time.Minute) }
+	projector.handleDelete(currentPod)
+
+	state := recorder.states["sb-1"]
+	if state == nil || state.TerminatedAt == nil {
+		t.Fatalf("state after current runtime delete = %#v, want terminated", state)
+	}
+
+	projector.now = func() time.Time { return now.Add(6 * time.Minute) }
+	projector.handleDelete(oldPod)
+
+	if len(recorder.events) != 3 {
+		t.Fatalf("event count = %d, want claim, terminate, late pause", len(recorder.events))
+	}
+	if recorder.events[2].EventType != meteringpkg.EventTypeSandboxPaused {
+		t.Fatalf("third event type = %q, want pause", recorder.events[2].EventType)
+	}
+	state = recorder.states["sb-1"]
+	if state == nil || state.TerminatedAt == nil || state.Paused {
+		t.Fatalf("state after late pause delete = %#v, want still terminated", state)
 	}
 }
 

--- a/manager/pkg/metering/lifecycle_projector_test.go
+++ b/manager/pkg/metering/lifecycle_projector_test.go
@@ -261,6 +261,43 @@ func TestLifecycleProjectorRecordsPauseFromDurableStatusOnPodDelete(t *testing.T
 	}
 }
 
+func TestLifecycleProjectorTreatsRuntimePausedMarkerDeleteAsPause(t *testing.T) {
+	recorder := &fakeRecorder{states: map[string]*meteringpkg.SandboxProjectionState{}}
+	projector := NewLifecycleProjector(recorder, "aws-us-east-1", "cluster-a")
+	projector.SetRuntimePauseLookup(func(context.Context, RuntimeDeletionInfo) (bool, error) {
+		return false, nil
+	})
+
+	now := time.Date(2026, 3, 12, 10, 0, 0, 0, time.UTC)
+	projector.now = func() time.Time { return now }
+	claimedAt := now
+	pod := withSandboxResources(buildSandboxPod(claimedAt, false, "", "1"), "1", "1Gi")
+	projector.handleUpsert(pod)
+
+	pausedAt := now.Add(2 * time.Minute)
+	pausedPod := pod.DeepCopy()
+	pausedPod.ResourceVersion = "2"
+	pausedPod.Annotations[controller.AnnotationPaused] = "true"
+	pausedPod.Annotations[controller.AnnotationPausedAt] = pausedAt.Format(time.RFC3339)
+	pausedPod.Annotations[controller.AnnotationPausedState] = controller.AnnotationPausedStateRuntimePaused
+	projector.now = func() time.Time { return now.Add(3 * time.Minute) }
+	projector.handleDelete(pausedPod)
+
+	if len(recorder.events) != 2 {
+		t.Fatalf("event count = %d, want claim and pause", len(recorder.events))
+	}
+	if recorder.events[1].EventType != meteringpkg.EventTypeSandboxPaused {
+		t.Fatalf("second event type = %q, want pause", recorder.events[1].EventType)
+	}
+	if !recorder.events[1].OccurredAt.Equal(pausedAt) {
+		t.Fatalf("pause occurred_at = %v, want %v", recorder.events[1].OccurredAt, pausedAt)
+	}
+	state := recorder.states["sb-1"]
+	if state == nil || !state.Paused || state.TerminatedAt != nil {
+		t.Fatalf("state after runtime paused marker delete = %#v, want paused without termination", state)
+	}
+}
+
 func TestLifecycleProjectorTreatsStaleRuntimeDeleteAsPause(t *testing.T) {
 	recorder := &fakeRecorder{states: map[string]*meteringpkg.SandboxProjectionState{}}
 	projector := NewLifecycleProjector(recorder, "aws-us-east-1", "cluster-a")
@@ -289,6 +326,38 @@ func TestLifecycleProjectorTreatsStaleRuntimeDeleteAsPause(t *testing.T) {
 	state := recorder.states["sb-1"]
 	if state == nil || !state.Paused || state.TerminatedAt != nil {
 		t.Fatalf("state after stale runtime delete = %#v, want paused", state)
+	}
+}
+
+func TestLifecycleProjectorRecordsPauseBeforeTerminatingPausedAnnotatedDelete(t *testing.T) {
+	recorder := &fakeRecorder{states: map[string]*meteringpkg.SandboxProjectionState{}}
+	projector := NewLifecycleProjector(recorder, "aws-us-east-1", "cluster-a")
+
+	now := time.Date(2026, 3, 12, 10, 0, 0, 0, time.UTC)
+	projector.now = func() time.Time { return now }
+	claimedAt := now
+	pod := withSandboxResources(buildSandboxPod(claimedAt, false, "", "1"), "1", "1Gi")
+	projector.handleUpsert(pod)
+
+	pausedAt := now.Add(2 * time.Minute)
+	pausedPod := pod.DeepCopy()
+	pausedPod.ResourceVersion = "2"
+	pausedPod.Annotations[controller.AnnotationPaused] = "true"
+	pausedPod.Annotations[controller.AnnotationPausedAt] = pausedAt.Format(time.RFC3339)
+	projector.now = func() time.Time { return now.Add(3 * time.Minute) }
+	projector.handleDelete(pausedPod)
+
+	if len(recorder.events) != 3 {
+		t.Fatalf("event count = %d, want claim, pause, terminate", len(recorder.events))
+	}
+	if recorder.events[1].EventType != meteringpkg.EventTypeSandboxPaused {
+		t.Fatalf("second event type = %q, want pause", recorder.events[1].EventType)
+	}
+	if recorder.events[2].EventType != meteringpkg.EventTypeSandboxTerminated {
+		t.Fatalf("third event type = %q, want terminate", recorder.events[2].EventType)
+	}
+	if len(recorder.windows) != 1 {
+		t.Fatalf("window count = %d, want 1", len(recorder.windows))
 	}
 }
 

--- a/manager/pkg/metering/lifecycle_projector_test.go
+++ b/manager/pkg/metering/lifecycle_projector_test.go
@@ -292,6 +292,41 @@ func TestLifecycleProjectorTreatsStaleRuntimeDeleteAsPause(t *testing.T) {
 	}
 }
 
+func TestLifecycleProjectorDoesNotResumePausedStateFromDeletingPodUpdate(t *testing.T) {
+	now := time.Date(2026, 3, 12, 10, 0, 0, 0, time.UTC)
+	pausedAt := now.Add(time.Minute)
+	recorder := &fakeRecorder{states: map[string]*meteringpkg.SandboxProjectionState{
+		"sb-1": {
+			SandboxID:         "sb-1",
+			Namespace:         "sandbox0",
+			TeamID:            "team-1",
+			UserID:            "user-1",
+			TemplateID:        "tpl-1",
+			ClusterID:         "cluster-a",
+			ResourceMillicpu:  1000,
+			ResourceMemoryMiB: 1024,
+			ClaimedAt:         ptrTime(now),
+			Paused:            true,
+			PausedAt:          ptrTime(pausedAt),
+			LastObservedAt:    pausedAt,
+		},
+	}}
+	projector := NewLifecycleProjector(recorder, "aws-us-east-1", "cluster-a")
+	projector.now = func() time.Time { return now.Add(2 * time.Minute) }
+
+	pod := buildSandboxPod(now, false, "", "3")
+	pod.DeletionTimestamp = ptrMetaTime(now.Add(2 * time.Minute))
+	projector.handleUpsert(pod)
+
+	if len(recorder.events) != 0 {
+		t.Fatalf("events = %#v, want none", recorder.events)
+	}
+	state := recorder.states["sb-1"]
+	if state == nil || !state.Paused || state.PausedAt == nil || !state.PausedAt.Equal(pausedAt) {
+		t.Fatalf("state after deleting pod update = %#v, want still paused", state)
+	}
+}
+
 func TestLifecycleProjectorLateRuntimePauseDeleteDoesNotReactivateTerminatedSandbox(t *testing.T) {
 	recorder := &fakeRecorder{states: map[string]*meteringpkg.SandboxProjectionState{}}
 	projector := NewLifecycleProjector(recorder, "aws-us-east-1", "cluster-a")

--- a/manager/pkg/metering/lifecycle_projector_test.go
+++ b/manager/pkg/metering/lifecycle_projector_test.go
@@ -36,19 +36,19 @@ type fakeTxStore struct {
 	states  map[string]*meteringpkg.SandboxProjectionState
 }
 
-func (f *fakeTxStore) AppendEvent(_ context.Context, event *meteringpkg.Event) error {
+func (f *fakeTxStore) AppendEvents(_ context.Context, events []*meteringpkg.Event) error {
 	if f.parent.appendErr != nil {
 		return f.parent.appendErr
 	}
-	f.events = append(f.events, event)
+	f.events = append(f.events, events...)
 	return nil
 }
 
-func (f *fakeTxStore) AppendWindow(_ context.Context, window *meteringpkg.Window) error {
+func (f *fakeTxStore) AppendWindows(_ context.Context, windows []*meteringpkg.Window) error {
 	if f.parent.appendErr != nil {
 		return f.parent.appendErr
 	}
-	f.windows = append(f.windows, window)
+	f.windows = append(f.windows, windows...)
 	return nil
 }
 

--- a/manager/pkg/service/rootfs_persistent_filesystem.go
+++ b/manager/pkg/service/rootfs_persistent_filesystem.go
@@ -132,7 +132,7 @@ type RootFSObjectInspector interface {
 }
 
 type RootFSStorageMeteringRecorder interface {
-	RecordStorageObservation(context.Context, *meteringpkg.StorageObservation) error
+	RecordStorageObservations(context.Context, []*meteringpkg.StorageObservation) error
 }
 
 type rootFSStoreDB interface {
@@ -767,18 +767,20 @@ func (s *PGSandboxStore) RecordRootFSStorageObservations(ctx context.Context, re
 	if err != nil {
 		return nil, err
 	}
+	observations := make([]*meteringpkg.StorageObservation, 0, len(usages))
 	for i := range usages {
 		usages[i].ObservedAt = observedAt
-		if err := recorder.RecordStorageObservation(ctx, &meteringpkg.StorageObservation{
+		observations = append(observations, &meteringpkg.StorageObservation{
 			SubjectType: meteringpkg.SubjectTypeRootFS,
 			SubjectID:   usages[i].TeamID,
 			Product:     meteringpkg.ProductSandbox,
 			TeamID:      usages[i].TeamID,
 			SizeBytes:   usages[i].StorageBytes,
 			ObservedAt:  observedAt,
-		}); err != nil {
-			return usages, fmt.Errorf("record rootfs storage observation for team %q: %w", usages[i].TeamID, err)
-		}
+		})
+	}
+	if err := recorder.RecordStorageObservations(ctx, observations); err != nil {
+		return usages, fmt.Errorf("record rootfs storage observations: %w", err)
 	}
 	return usages, nil
 }

--- a/manager/pkg/service/rootfs_persistent_filesystem_integration_test.go
+++ b/manager/pkg/service/rootfs_persistent_filesystem_integration_test.go
@@ -747,8 +747,8 @@ type recordingRootFSStorageMeteringRecorder struct {
 	observations []*meteringpkg.StorageObservation
 }
 
-func (r *recordingRootFSStorageMeteringRecorder) RecordStorageObservation(_ context.Context, observation *meteringpkg.StorageObservation) error {
-	r.observations = append(r.observations, observation)
+func (r *recordingRootFSStorageMeteringRecorder) RecordStorageObservations(_ context.Context, observations []*meteringpkg.StorageObservation) error {
+	r.observations = append(r.observations, observations...)
 	return nil
 }
 

--- a/manager/pkg/service/sandbox_lifecycle_controller.go
+++ b/manager/pkg/service/sandbox_lifecycle_controller.go
@@ -523,52 +523,6 @@ func (s *SandboxService) ensureSandboxDeletionFinalizer(ctx context.Context, pod
 	return updated, nil
 }
 
-func (s *SandboxService) markRuntimePodPausedForMetering(ctx context.Context, pod *corev1.Pod, pausedAt time.Time) (*corev1.Pod, error) {
-	if s == nil || pod == nil || s.k8sClient == nil {
-		return pod, nil
-	}
-	if pausedAt.IsZero() {
-		pausedAt = s.clock.Now()
-	}
-	var updated *corev1.Pod
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		current, err := s.k8sClient.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
-		if err != nil {
-			if k8serrors.IsNotFound(err) {
-				updated = pod
-				return nil
-			}
-			return err
-		}
-		if current.DeletionTimestamp != nil {
-			updated = current
-			return nil
-		}
-		if current.Annotations[controller.AnnotationPaused] == "true" &&
-			current.Annotations[controller.AnnotationPausedAt] != "" &&
-			current.Annotations[controller.AnnotationPausedState] == controller.AnnotationPausedStateRuntimePaused {
-			updated = current
-			return nil
-		}
-		next := current.DeepCopy()
-		if next.Annotations == nil {
-			next.Annotations = map[string]string{}
-		}
-		next.Annotations[controller.AnnotationPaused] = "true"
-		next.Annotations[controller.AnnotationPausedAt] = pausedAt.UTC().Format(time.RFC3339)
-		next.Annotations[controller.AnnotationPausedState] = controller.AnnotationPausedStateRuntimePaused
-		updated, err = s.k8sClient.CoreV1().Pods(next.Namespace).Update(ctx, next, metav1.UpdateOptions{})
-		return err
-	})
-	if err != nil {
-		return pod, err
-	}
-	if updated == nil {
-		return pod, nil
-	}
-	return updated, nil
-}
-
 func sandboxLifecycleItemFromInfo(info SandboxLifecycleInfo, deleted bool) sandboxLifecycleQueueItem {
 	return sandboxLifecycleQueueItem{
 		Namespace:            info.Namespace,

--- a/manager/pkg/service/sandbox_lifecycle_controller.go
+++ b/manager/pkg/service/sandbox_lifecycle_controller.go
@@ -523,6 +523,52 @@ func (s *SandboxService) ensureSandboxDeletionFinalizer(ctx context.Context, pod
 	return updated, nil
 }
 
+func (s *SandboxService) markRuntimePodPausedForMetering(ctx context.Context, pod *corev1.Pod, pausedAt time.Time) (*corev1.Pod, error) {
+	if s == nil || pod == nil || s.k8sClient == nil {
+		return pod, nil
+	}
+	if pausedAt.IsZero() {
+		pausedAt = s.clock.Now()
+	}
+	var updated *corev1.Pod
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current, err := s.k8sClient.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				updated = pod
+				return nil
+			}
+			return err
+		}
+		if current.DeletionTimestamp != nil {
+			updated = current
+			return nil
+		}
+		if current.Annotations[controller.AnnotationPaused] == "true" &&
+			current.Annotations[controller.AnnotationPausedAt] != "" &&
+			current.Annotations[controller.AnnotationPausedState] == controller.AnnotationPausedStateRuntimePaused {
+			updated = current
+			return nil
+		}
+		next := current.DeepCopy()
+		if next.Annotations == nil {
+			next.Annotations = map[string]string{}
+		}
+		next.Annotations[controller.AnnotationPaused] = "true"
+		next.Annotations[controller.AnnotationPausedAt] = pausedAt.UTC().Format(time.RFC3339)
+		next.Annotations[controller.AnnotationPausedState] = controller.AnnotationPausedStateRuntimePaused
+		updated, err = s.k8sClient.CoreV1().Pods(next.Namespace).Update(ctx, next, metav1.UpdateOptions{})
+		return err
+	})
+	if err != nil {
+		return pod, err
+	}
+	if updated == nil {
+		return pod, nil
+	}
+	return updated, nil
+}
+
 func sandboxLifecycleItemFromInfo(info SandboxLifecycleInfo, deleted bool) sandboxLifecycleQueueItem {
 	return sandboxLifecycleQueueItem{
 		Namespace:            info.Namespace,

--- a/manager/pkg/service/sandbox_lifecycle_controller_test.go
+++ b/manager/pkg/service/sandbox_lifecycle_controller_test.go
@@ -65,7 +65,7 @@ func (s *deleteRecordingBindingStore) DeleteBindings(context.Context, string, st
 	return nil
 }
 
-func (s *deleteRecordingBindingStore) GetSourceByRef(context.Context, string, string) (*egressauth.CredentialSource, error) {
+func (s *deleteRecordingBindingStore) GetSourcesByRef(context.Context, string, []string) (map[string]*egressauth.CredentialSource, error) {
 	return nil, nil
 }
 

--- a/manager/pkg/service/sandbox_lifecycle_metering.go
+++ b/manager/pkg/service/sandbox_lifecycle_metering.go
@@ -67,7 +67,6 @@ func (r *repositorySandboxLifecycleMeteringRecorder) RecordSandboxPaused(ctx con
 	}
 
 	pendingEvents := make([]*meteringpkg.Event, 0, 2)
-	pendingWindows := make([]*meteringpkg.Window, 0, 1)
 	if state == nil {
 		state = &meteringpkg.SandboxProjectionState{
 			SandboxID:         fact.SandboxID,
@@ -84,23 +83,14 @@ func (r *repositorySandboxLifecycleMeteringRecorder) RecordSandboxPaused(ctx con
 			claimedAt := fact.ClaimedAt.UTC()
 			state.ClaimedAt = ptrMeteringTime(claimedAt)
 			state.ActiveSince = ptrMeteringTime(firstNonZeroTime(fact.ActiveSince, claimedAt).UTC())
-			pendingEvents = append(pendingEvents, buildSandboxLifecycleEvent(r.regionID, state, claimedAt, meteringpkg.EventTypeSandboxClaimed, sandboxClaimedEventID(fact.SandboxID, claimedAt), sandboxClaimEventData(fact)))
+			pendingEvents = appendMeteringEvent(pendingEvents, buildSandboxLifecycleEvent(r.regionID, state, claimedAt, meteringpkg.EventTypeSandboxClaimed, sandboxClaimedEventID(fact.SandboxID, claimedAt), sandboxClaimEventData(fact)))
 		}
 	} else {
 		mergeSandboxPauseFactIntoState(state, fact, r.clusterID)
 	}
 
-	if !state.Paused {
-		activeSince := state.ActiveSince
-		if activeSince == nil && !fact.ActiveSince.IsZero() {
-			activeSince = ptrMeteringTime(fact.ActiveSince.UTC())
-		}
-		if activeSince == nil && !fact.ClaimedAt.IsZero() {
-			activeSince = ptrMeteringTime(fact.ClaimedAt.UTC())
-		}
-		pendingWindows = append(pendingWindows, buildSandboxLifecycleRuntimeWindow(r.regionID, state, activeSince, pausedAt))
-		pendingEvents = append(pendingEvents, buildSandboxLifecycleEvent(r.regionID, state, pausedAt, meteringpkg.EventTypeSandboxPaused, sandboxPausedEventID(fact.SandboxID, pausedAt), nil))
-	}
+	activeSince := sandboxPauseActiveSince(state, fact)
+	pauseEventID := sandboxPausedEventID(fact.SandboxID, pausedAt)
 
 	state.Paused = true
 	state.PausedAt = ptrMeteringTime(pausedAt)
@@ -109,10 +99,22 @@ func (r *repositorySandboxLifecycleMeteringRecorder) RecordSandboxPaused(ctx con
 	state.LastObservedAt = pausedAt
 
 	return r.repo.InTx(ctx, func(tx pgx.Tx) error {
-		if err := r.repo.AppendEventsTx(ctx, tx, pendingEvents); err != nil {
+		events := append([]*meteringpkg.Event(nil), pendingEvents...)
+		windows := make([]*meteringpkg.Window, 0, 1)
+
+		pauseEventExists, err := r.repo.EventExistsTx(ctx, tx, pauseEventID)
+		if err != nil {
+			return fmt.Errorf("check pause event: %w", err)
+		}
+		if !pauseEventExists {
+			windows = appendMeteringWindow(windows, buildSandboxLifecycleRuntimeWindow(r.regionID, state, activeSince, pausedAt))
+			events = appendMeteringEvent(events, buildSandboxLifecycleEvent(r.regionID, state, pausedAt, meteringpkg.EventTypeSandboxPaused, pauseEventID, nil))
+		}
+
+		if err := r.repo.AppendEventsTx(ctx, tx, events); err != nil {
 			return fmt.Errorf("append lifecycle events: %w", err)
 		}
-		if err := r.repo.AppendWindowsTx(ctx, tx, pendingWindows); err != nil {
+		if err := r.repo.AppendWindowsTx(ctx, tx, windows); err != nil {
 			return fmt.Errorf("append lifecycle windows: %w", err)
 		}
 		if err := r.repo.UpsertSandboxProjectionStateTx(ctx, tx, state); err != nil {
@@ -211,6 +213,33 @@ func mergeSandboxPauseFactIntoState(state *meteringpkg.SandboxProjectionState, f
 		claimedAt := fact.ClaimedAt.UTC()
 		state.ClaimedAt = &claimedAt
 	}
+}
+
+func sandboxPauseActiveSince(state *meteringpkg.SandboxProjectionState, fact *SandboxPauseMeteringFact) *time.Time {
+	if state != nil && state.ActiveSince != nil {
+		return state.ActiveSince
+	}
+	if fact != nil && !fact.ActiveSince.IsZero() {
+		return ptrMeteringTime(fact.ActiveSince.UTC())
+	}
+	if fact != nil && !fact.ClaimedAt.IsZero() {
+		return ptrMeteringTime(fact.ClaimedAt.UTC())
+	}
+	return nil
+}
+
+func appendMeteringEvent(events []*meteringpkg.Event, event *meteringpkg.Event) []*meteringpkg.Event {
+	if event == nil {
+		return events
+	}
+	return append(events, event)
+}
+
+func appendMeteringWindow(windows []*meteringpkg.Window, window *meteringpkg.Window) []*meteringpkg.Window {
+	if window == nil {
+		return windows
+	}
+	return append(windows, window)
 }
 
 func buildSandboxLifecycleEvent(regionID string, state *meteringpkg.SandboxProjectionState, occurredAt time.Time, eventType, eventID string, data any) *meteringpkg.Event {

--- a/manager/pkg/service/sandbox_lifecycle_metering.go
+++ b/manager/pkg/service/sandbox_lifecycle_metering.go
@@ -14,6 +14,7 @@ import (
 )
 
 const sandboxLifecycleMeteringProducer = "manager.sandbox_lifecycle"
+const sandboxLifecycleMeteringUnknownNamespace = "unknown"
 
 // SandboxLifecycleMeteringRecorder records durable sandbox lifecycle facts.
 type SandboxLifecycleMeteringRecorder interface {
@@ -70,7 +71,7 @@ func (r *repositorySandboxLifecycleMeteringRecorder) RecordSandboxPaused(ctx con
 	if state == nil {
 		state = &meteringpkg.SandboxProjectionState{
 			SandboxID:         fact.SandboxID,
-			Namespace:         fact.Namespace,
+			Namespace:         sandboxPauseNamespace(fact.Namespace),
 			TeamID:            fact.TeamID,
 			UserID:            fact.UserID,
 			TemplateID:        fact.TemplateID,
@@ -189,7 +190,7 @@ func mergeSandboxPauseFactIntoState(state *meteringpkg.SandboxProjectionState, f
 		return
 	}
 	if state.Namespace == "" {
-		state.Namespace = fact.Namespace
+		state.Namespace = sandboxPauseNamespace(fact.Namespace)
 	}
 	if state.TeamID == "" {
 		state.TeamID = fact.TeamID
@@ -213,6 +214,10 @@ func mergeSandboxPauseFactIntoState(state *meteringpkg.SandboxProjectionState, f
 		claimedAt := fact.ClaimedAt.UTC()
 		state.ClaimedAt = &claimedAt
 	}
+}
+
+func sandboxPauseNamespace(namespace string) string {
+	return firstNonEmpty(namespace, sandboxLifecycleMeteringUnknownNamespace)
 }
 
 func sandboxPauseActiveSince(state *meteringpkg.SandboxProjectionState, fact *SandboxPauseMeteringFact) *time.Time {

--- a/manager/pkg/service/sandbox_lifecycle_metering.go
+++ b/manager/pkg/service/sandbox_lifecycle_metering.go
@@ -1,0 +1,330 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
+	meteringpkg "github.com/sandbox0-ai/sandbox0/pkg/metering"
+	s0template "github.com/sandbox0-ai/sandbox0/pkg/template"
+	"go.uber.org/zap"
+)
+
+const sandboxLifecycleMeteringProducer = "manager.sandbox_lifecycle"
+
+// SandboxLifecycleMeteringRecorder records durable sandbox lifecycle facts.
+type SandboxLifecycleMeteringRecorder interface {
+	RecordSandboxPaused(ctx context.Context, fact *SandboxPauseMeteringFact) error
+}
+
+// SandboxPauseMeteringFact carries the durable pause fact emitted by the
+// sandbox lifecycle store.
+type SandboxPauseMeteringFact struct {
+	SandboxID         string
+	Namespace         string
+	TeamID            string
+	UserID            string
+	TemplateID        string
+	ClusterID         string
+	ResourceMillicpu  int64
+	ResourceMemoryMiB int64
+	ClaimedAt         time.Time
+	ActiveSince       time.Time
+	PausedAt          time.Time
+	ExpiresAt         time.Time
+	HardExpiresAt     time.Time
+}
+
+type repositorySandboxLifecycleMeteringRecorder struct {
+	repo      *meteringpkg.Repository
+	regionID  string
+	clusterID string
+}
+
+// NewSandboxLifecycleMeteringRecorder creates a recorder backed by the metering repository.
+func NewSandboxLifecycleMeteringRecorder(repo *meteringpkg.Repository, regionID, clusterID string) SandboxLifecycleMeteringRecorder {
+	if repo == nil {
+		return nil
+	}
+	return &repositorySandboxLifecycleMeteringRecorder{
+		repo:      repo,
+		regionID:  regionID,
+		clusterID: clusterID,
+	}
+}
+
+func (r *repositorySandboxLifecycleMeteringRecorder) RecordSandboxPaused(ctx context.Context, fact *SandboxPauseMeteringFact) error {
+	if r == nil || r.repo == nil || fact == nil || fact.SandboxID == "" || fact.PausedAt.IsZero() {
+		return nil
+	}
+	pausedAt := fact.PausedAt.UTC()
+	state, err := r.repo.GetSandboxProjectionState(ctx, fact.SandboxID)
+	if err != nil {
+		return fmt.Errorf("load sandbox projection state: %w", err)
+	}
+
+	pendingEvents := make([]*meteringpkg.Event, 0, 2)
+	pendingWindows := make([]*meteringpkg.Window, 0, 1)
+	if state == nil {
+		state = &meteringpkg.SandboxProjectionState{
+			SandboxID:         fact.SandboxID,
+			Namespace:         fact.Namespace,
+			TeamID:            fact.TeamID,
+			UserID:            fact.UserID,
+			TemplateID:        fact.TemplateID,
+			ClusterID:         firstNonEmpty(fact.ClusterID, r.clusterID),
+			ResourceMillicpu:  fact.ResourceMillicpu,
+			ResourceMemoryMiB: fact.ResourceMemoryMiB,
+			LastObservedAt:    pausedAt,
+		}
+		if !fact.ClaimedAt.IsZero() {
+			claimedAt := fact.ClaimedAt.UTC()
+			state.ClaimedAt = ptrMeteringTime(claimedAt)
+			state.ActiveSince = ptrMeteringTime(firstNonZeroTime(fact.ActiveSince, claimedAt).UTC())
+			pendingEvents = append(pendingEvents, buildSandboxLifecycleEvent(r.regionID, state, claimedAt, meteringpkg.EventTypeSandboxClaimed, sandboxClaimedEventID(fact.SandboxID, claimedAt), sandboxClaimEventData(fact)))
+		}
+	} else {
+		mergeSandboxPauseFactIntoState(state, fact, r.clusterID)
+	}
+
+	if !state.Paused {
+		activeSince := state.ActiveSince
+		if activeSince == nil && !fact.ActiveSince.IsZero() {
+			activeSince = ptrMeteringTime(fact.ActiveSince.UTC())
+		}
+		if activeSince == nil && !fact.ClaimedAt.IsZero() {
+			activeSince = ptrMeteringTime(fact.ClaimedAt.UTC())
+		}
+		pendingWindows = append(pendingWindows, buildSandboxLifecycleRuntimeWindow(r.regionID, state, activeSince, pausedAt))
+		pendingEvents = append(pendingEvents, buildSandboxLifecycleEvent(r.regionID, state, pausedAt, meteringpkg.EventTypeSandboxPaused, sandboxPausedEventID(fact.SandboxID, pausedAt), nil))
+	}
+
+	state.Paused = true
+	state.PausedAt = ptrMeteringTime(pausedAt)
+	state.ActiveSince = nil
+	state.TerminatedAt = nil
+	state.LastObservedAt = pausedAt
+
+	return r.repo.InTx(ctx, func(tx pgx.Tx) error {
+		if err := r.repo.AppendEventsTx(ctx, tx, pendingEvents); err != nil {
+			return fmt.Errorf("append lifecycle events: %w", err)
+		}
+		if err := r.repo.AppendWindowsTx(ctx, tx, pendingWindows); err != nil {
+			return fmt.Errorf("append lifecycle windows: %w", err)
+		}
+		if err := r.repo.UpsertSandboxProjectionStateTx(ctx, tx, state); err != nil {
+			return fmt.Errorf("upsert sandbox projection state: %w", err)
+		}
+		if err := r.repo.UpsertProducerWatermarkTx(ctx, tx, sandboxLifecycleMeteringProducer, r.regionID, pausedAt); err != nil {
+			return fmt.Errorf("upsert lifecycle watermark: %w", err)
+		}
+		return nil
+	})
+}
+
+func (s *SandboxService) SetLifecycleMeteringRecorder(recorder SandboxLifecycleMeteringRecorder) {
+	if s == nil {
+		return
+	}
+	s.lifecycleMetering = recorder
+}
+
+func (s *SandboxService) recordSandboxPausedMetering(ctx context.Context, record *SandboxRecord, pausedAt time.Time) {
+	if s == nil || s.lifecycleMetering == nil || record == nil {
+		return
+	}
+	fact := s.sandboxPauseMeteringFact(record, pausedAt)
+	if err := s.lifecycleMetering.RecordSandboxPaused(ctx, fact); err != nil && s.logger != nil {
+		s.logger.Warn("Failed to record sandbox pause metering fact",
+			zap.String("sandboxID", record.ID),
+			zap.Error(err),
+		)
+	}
+}
+
+func (s *SandboxService) sandboxPauseMeteringFact(record *SandboxRecord, pausedAt time.Time) *SandboxPauseMeteringFact {
+	if record == nil {
+		return nil
+	}
+	cpuMillis, memoryMiB := s.sandboxRecordMeteringResources(record)
+	return &SandboxPauseMeteringFact{
+		SandboxID:         record.ID,
+		Namespace:         record.CurrentPodNamespace,
+		TeamID:            record.TeamID,
+		UserID:            record.UserID,
+		TemplateID:        record.TemplateID,
+		ClusterID:         record.ClusterID,
+		ResourceMillicpu:  cpuMillis,
+		ResourceMemoryMiB: memoryMiB,
+		ClaimedAt:         record.ClaimedAt,
+		ActiveSince:       record.ClaimedAt,
+		PausedAt:          pausedAt,
+		ExpiresAt:         record.ExpiresAt,
+		HardExpiresAt:     record.HardExpiresAt,
+	}
+}
+
+func (s *SandboxService) sandboxRecordMeteringResources(record *SandboxRecord) (int64, int64) {
+	if record == nil {
+		return 0, 0
+	}
+	quota := *record.TemplateSpec.MainContainer.Resources.DeepCopy()
+	if record.Config.Resources != nil {
+		if memory, err := s.validateSandboxMemory(record.Config.Resources.Memory); err == nil {
+			quota.Memory = memory
+			quota.CPU = s0template.CPUForMemory(memory, s.sandboxMemoryPerCPU())
+		}
+	}
+	requirements := v1alpha1.BuildResourceRequirements(quota)
+	return resourceListCPU(requirements), bytesToMiBRoundUp(resourceListMemory(requirements))
+}
+
+func mergeSandboxPauseFactIntoState(state *meteringpkg.SandboxProjectionState, fact *SandboxPauseMeteringFact, defaultClusterID string) {
+	if state == nil || fact == nil {
+		return
+	}
+	if state.Namespace == "" {
+		state.Namespace = fact.Namespace
+	}
+	if state.TeamID == "" {
+		state.TeamID = fact.TeamID
+	}
+	if state.UserID == "" {
+		state.UserID = fact.UserID
+	}
+	if state.TemplateID == "" {
+		state.TemplateID = fact.TemplateID
+	}
+	if state.ClusterID == "" {
+		state.ClusterID = firstNonEmpty(fact.ClusterID, defaultClusterID)
+	}
+	if state.ResourceMillicpu == 0 {
+		state.ResourceMillicpu = fact.ResourceMillicpu
+	}
+	if state.ResourceMemoryMiB == 0 {
+		state.ResourceMemoryMiB = fact.ResourceMemoryMiB
+	}
+	if state.ClaimedAt == nil && !fact.ClaimedAt.IsZero() {
+		claimedAt := fact.ClaimedAt.UTC()
+		state.ClaimedAt = &claimedAt
+	}
+}
+
+func buildSandboxLifecycleEvent(regionID string, state *meteringpkg.SandboxProjectionState, occurredAt time.Time, eventType, eventID string, data any) *meteringpkg.Event {
+	if state == nil || eventID == "" || occurredAt.IsZero() {
+		return nil
+	}
+	return &meteringpkg.Event{
+		EventID:     eventID,
+		Producer:    sandboxLifecycleMeteringProducer,
+		RegionID:    regionID,
+		EventType:   eventType,
+		SubjectType: meteringpkg.SubjectTypeSandbox,
+		SubjectID:   state.SandboxID,
+		TeamID:      state.TeamID,
+		UserID:      state.UserID,
+		SandboxID:   state.SandboxID,
+		TemplateID:  state.TemplateID,
+		ClusterID:   state.ClusterID,
+		OccurredAt:  occurredAt.UTC(),
+		Data:        mustMeteringJSON(data),
+	}
+}
+
+func buildSandboxLifecycleRuntimeWindow(regionID string, state *meteringpkg.SandboxProjectionState, start *time.Time, end time.Time) *meteringpkg.Window {
+	if state == nil || start == nil || start.IsZero() || end.IsZero() || !end.After(*start) {
+		return nil
+	}
+	durationMS := end.Sub(*start).Milliseconds()
+	if durationMS <= 0 || state.ResourceMemoryMiB <= 0 {
+		return nil
+	}
+	return &meteringpkg.Window{
+		WindowID:    sandboxRuntimeWindowID(state.SandboxID, meteringpkg.WindowTypeSandboxRuntimeMiBMilliseconds, *start, end),
+		Producer:    sandboxLifecycleMeteringProducer,
+		RegionID:    regionID,
+		WindowType:  meteringpkg.WindowTypeSandboxRuntimeMiBMilliseconds,
+		SubjectType: meteringpkg.SubjectTypeSandbox,
+		SubjectID:   state.SandboxID,
+		TeamID:      state.TeamID,
+		UserID:      state.UserID,
+		SandboxID:   state.SandboxID,
+		TemplateID:  state.TemplateID,
+		ClusterID:   state.ClusterID,
+		WindowStart: start.UTC(),
+		WindowEnd:   end.UTC(),
+		Value:       state.ResourceMemoryMiB * durationMS,
+		Unit:        meteringpkg.WindowUnitMiBMilliseconds,
+		Data: mustMeteringJSON(map[string]any{
+			"product":               meteringpkg.ProductSandbox,
+			"resource_millicpu":     state.ResourceMillicpu,
+			"resource_memory_mib":   state.ResourceMemoryMiB,
+			"duration_milliseconds": durationMS,
+		}),
+	}
+}
+
+func sandboxClaimEventData(fact *SandboxPauseMeteringFact) map[string]any {
+	if fact == nil {
+		return nil
+	}
+	return map[string]any{
+		"expires_at":      formatOptionalTime(fact.ExpiresAt),
+		"hard_expires_at": formatOptionalTime(fact.HardExpiresAt),
+	}
+}
+
+func sandboxClaimedEventID(sandboxID string, claimedAt time.Time) string {
+	return fmt.Sprintf("sandbox/%s/claimed/%d", sandboxID, claimedAt.UTC().UnixNano())
+}
+
+func sandboxPausedEventID(sandboxID string, pausedAt time.Time) string {
+	return fmt.Sprintf("sandbox/%s/paused/%d", sandboxID, pausedAt.UTC().UnixNano())
+}
+
+func sandboxRuntimeWindowID(sandboxID, windowType string, start, end time.Time) string {
+	return fmt.Sprintf("sandbox/%s/windows/%s/%d/%d", sandboxID, windowType, start.UTC().UnixNano(), end.UTC().UnixNano())
+}
+
+func mustMeteringJSON(value any) json.RawMessage {
+	if value == nil {
+		return json.RawMessage(`{}`)
+	}
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return json.RawMessage(`{}`)
+	}
+	return payload
+}
+
+func formatOptionalTime(value time.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return value.UTC().Format(time.RFC3339)
+}
+
+func firstNonZeroTime(values ...time.Time) time.Time {
+	for _, value := range values {
+		if !value.IsZero() {
+			return value
+		}
+	}
+	return time.Time{}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func ptrMeteringTime(value time.Time) *time.Time {
+	return &value
+}

--- a/manager/pkg/service/sandbox_lifecycle_metering_test.go
+++ b/manager/pkg/service/sandbox_lifecycle_metering_test.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
+	meteringpkg "github.com/sandbox0-ai/sandbox0/pkg/metering"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
@@ -66,4 +68,52 @@ func TestRecordSandboxPausedMeteringBuildsFactFromRecord(t *testing.T) {
 	if !fact.PausedAt.Equal(pausedAt) || !fact.ClaimedAt.Equal(claimedAt) {
 		t.Fatalf("fact times = claimed %v paused %v", fact.ClaimedAt, fact.PausedAt)
 	}
+}
+
+func TestRepositorySandboxLifecycleMeteringRecorderKeepsPauseEventWhenWindowMissing(t *testing.T) {
+	ctx := context.Background()
+	pool := newSandboxStoreIntegrationPool(t)
+	_, _ = pool.Exec(ctx, "DROP SCHEMA IF EXISTS metering CASCADE")
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), "DROP SCHEMA IF EXISTS metering CASCADE")
+	})
+	require.NoError(t, meteringpkg.RunMigrations(ctx, pool, noopSandboxStoreMigrateLogger{}))
+
+	repo := meteringpkg.NewRepository(pool)
+	recorder := NewSandboxLifecycleMeteringRecorder(repo, "region-1", "cluster-1")
+	claimedAt := time.Date(2026, 7, 2, 10, 0, 0, 0, time.UTC)
+	pausedAt := claimedAt.Add(5 * time.Minute)
+
+	require.NoError(t, recorder.RecordSandboxPaused(ctx, &SandboxPauseMeteringFact{
+		SandboxID:   "sandbox-1",
+		Namespace:   "ns-1",
+		TeamID:      "team-1",
+		UserID:      "user-1",
+		TemplateID:  "template-1",
+		ClaimedAt:   claimedAt,
+		ActiveSince: claimedAt,
+		PausedAt:    pausedAt,
+	}))
+
+	events, err := repo.ListEventsAfter(ctx, 0, 10)
+	require.NoError(t, err)
+	require.True(t, meteringTestHasEvent(events, meteringpkg.EventTypeSandboxPaused, "sandbox-1"), "missing sandbox.paused event: %#v", events)
+
+	windows, err := repo.ListWindowsAfter(ctx, 0, 10)
+	require.NoError(t, err)
+	require.Empty(t, windows)
+
+	state, err := repo.GetSandboxProjectionState(ctx, "sandbox-1")
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	require.True(t, state.Paused)
+}
+
+func meteringTestHasEvent(events []*meteringpkg.Event, eventType, sandboxID string) bool {
+	for _, event := range events {
+		if event != nil && event.EventType == eventType && event.SubjectID == sandboxID {
+			return true
+		}
+	}
+	return false
 }

--- a/manager/pkg/service/sandbox_lifecycle_metering_test.go
+++ b/manager/pkg/service/sandbox_lifecycle_metering_test.go
@@ -1,0 +1,69 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+type recordingSandboxLifecycleMeteringRecorder struct {
+	facts []*SandboxPauseMeteringFact
+	err   error
+}
+
+func (r *recordingSandboxLifecycleMeteringRecorder) RecordSandboxPaused(_ context.Context, fact *SandboxPauseMeteringFact) error {
+	if fact != nil {
+		copied := *fact
+		r.facts = append(r.facts, &copied)
+	}
+	return r.err
+}
+
+func TestRecordSandboxPausedMeteringBuildsFactFromRecord(t *testing.T) {
+	recorder := &recordingSandboxLifecycleMeteringRecorder{}
+	svc := &SandboxService{
+		config: SandboxServiceConfig{
+			SandboxMemoryPerCPU: "4Gi",
+			SandboxMaxMemory:    "32Gi",
+		},
+		lifecycleMetering: recorder,
+	}
+	claimedAt := time.Date(2026, 7, 2, 10, 0, 0, 0, time.UTC)
+	pausedAt := claimedAt.Add(5 * time.Minute)
+	record := &SandboxRecord{
+		ID:                  "sandbox-1",
+		TeamID:              "team-1",
+		UserID:              "user-1",
+		TemplateID:          "template-1",
+		ClusterID:           "cluster-1",
+		CurrentPodNamespace: "ns-1",
+		ClaimedAt:           claimedAt,
+		TemplateSpec: v1alpha1.SandboxTemplateSpec{
+			MainContainer: v1alpha1.ContainerSpec{
+				Resources: v1alpha1.ResourceQuota{
+					CPU:    resource.MustParse("500m"),
+					Memory: resource.MustParse("1Gi"),
+				},
+			},
+		},
+	}
+
+	svc.recordSandboxPausedMetering(context.Background(), record, pausedAt)
+
+	if len(recorder.facts) != 1 {
+		t.Fatalf("recorded facts = %d, want 1", len(recorder.facts))
+	}
+	fact := recorder.facts[0]
+	if fact.SandboxID != "sandbox-1" || fact.TeamID != "team-1" || fact.TemplateID != "template-1" {
+		t.Fatalf("fact identity = %#v", fact)
+	}
+	if fact.ResourceMillicpu != 500 || fact.ResourceMemoryMiB != 1024 {
+		t.Fatalf("fact resources = %dm/%dMiB, want 500m/1024MiB", fact.ResourceMillicpu, fact.ResourceMemoryMiB)
+	}
+	if !fact.PausedAt.Equal(pausedAt) || !fact.ClaimedAt.Equal(claimedAt) {
+		t.Fatalf("fact times = claimed %v paused %v", fact.ClaimedAt, fact.PausedAt)
+	}
+}

--- a/manager/pkg/service/sandbox_lifecycle_metering_test.go
+++ b/manager/pkg/service/sandbox_lifecycle_metering_test.go
@@ -86,7 +86,6 @@ func TestRepositorySandboxLifecycleMeteringRecorderKeepsPauseEventWhenWindowMiss
 
 	require.NoError(t, recorder.RecordSandboxPaused(ctx, &SandboxPauseMeteringFact{
 		SandboxID:   "sandbox-1",
-		Namespace:   "ns-1",
 		TeamID:      "team-1",
 		UserID:      "user-1",
 		TemplateID:  "template-1",
@@ -107,6 +106,7 @@ func TestRepositorySandboxLifecycleMeteringRecorderKeepsPauseEventWhenWindowMiss
 	require.NoError(t, err)
 	require.NotNil(t, state)
 	require.True(t, state.Paused)
+	require.Equal(t, sandboxLifecycleMeteringUnknownNamespace, state.Namespace)
 }
 
 func meteringTestHasEvent(events []*meteringpkg.Event, eventType, sandboxID string) bool {

--- a/manager/pkg/service/sandbox_service.go
+++ b/manager/pkg/service/sandbox_service.go
@@ -127,6 +127,7 @@ type SandboxService struct {
 	deletionWebhookEmitter SandboxDeletionWebhookEmitter
 	quotaStore             TeamQuotaLimitStore
 	sandboxStore           SandboxStore
+	lifecycleMetering      SandboxLifecycleMeteringRecorder
 	rootFSObjectDeleter    RootFSObjectDeleter
 	resumeGroup            singleflight.Group
 	idlePodReservations    *idlePodReservations

--- a/manager/pkg/service/sandbox_service_lifecycle.go
+++ b/manager/pkg/service/sandbox_service_lifecycle.go
@@ -271,10 +271,6 @@ func (s *SandboxService) pauseSandboxRuntime(ctx context.Context, sandboxID stri
 			return fmt.Errorf("ensure sandbox cleanup finalizer: %w", err)
 		}
 		pausedAt := s.clock.Now()
-		pod, err = s.markRuntimePodPausedForMetering(ctx, pod, pausedAt)
-		if err != nil {
-			return fmt.Errorf("mark runtime pod paused for metering: %w", err)
-		}
 		if err := s.k8sClient.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{}); err != nil && !k8serrors.IsNotFound(err) {
 			return fmt.Errorf("delete runtime pod: %w", err)
 		}
@@ -424,17 +420,6 @@ func (s *SandboxService) CompletePausingSandboxRuntime(ctx context.Context, sand
 	}
 	rootFSCommitted = true
 	barrierActive = false
-	if markedPod, err := s.markRuntimePodPausedForMetering(ctx, pod, pausedAt); err != nil {
-		if s.logger != nil {
-			s.logger.Warn("Committed sandbox pause but failed to mark runtime pod paused for metering",
-				zap.String("sandboxID", sandboxID),
-				zap.String("pod", pod.Name),
-				zap.Error(err),
-			)
-		}
-	} else if markedPod != nil {
-		pod = markedPod
-	}
 	if err := s.k8sClient.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{}); err != nil && !k8serrors.IsNotFound(err) {
 		if s.logger != nil {
 			s.logger.Warn("Committed sandbox pause but failed to delete old runtime pod",

--- a/manager/pkg/service/sandbox_service_lifecycle.go
+++ b/manager/pkg/service/sandbox_service_lifecycle.go
@@ -234,6 +234,8 @@ func (s *SandboxService) pauseSandboxRuntime(ctx context.Context, sandboxID stri
 	if s.logger != nil {
 		s.logger.Info("Pausing sandbox runtime", zap.String("sandboxID", sandboxID))
 	}
+	var meteringRecord *SandboxRecord
+	var meteringPausedAt time.Time
 	pause := func(ctx context.Context, tx SandboxStoreTx, record *SandboxRecord) error {
 		if record != nil {
 			switch record.Status {
@@ -251,7 +253,9 @@ func (s *SandboxService) pauseSandboxRuntime(ctx context.Context, sandboxID stri
 		if err != nil {
 			if k8serrors.IsNotFound(err) {
 				if tx != nil {
-					return tx.MarkRuntimePaused(ctx, sandboxID, 0, s.clock.Now())
+					meteringPausedAt = s.clock.Now()
+					meteringRecord = cloneSandboxRecordForLifecycle(record)
+					return tx.MarkRuntimePaused(ctx, sandboxID, 0, meteringPausedAt)
 				}
 				return nil
 			}
@@ -275,6 +279,8 @@ func (s *SandboxService) pauseSandboxRuntime(ctx context.Context, sandboxID stri
 			return fmt.Errorf("delete runtime pod: %w", err)
 		}
 		if tx != nil {
+			meteringRecord = cloneSandboxRecordForLifecycle(record)
+			meteringPausedAt = pausedAt
 			return tx.MarkRuntimePaused(ctx, sandboxID, generation, pausedAt)
 		}
 		return nil
@@ -285,6 +291,10 @@ func (s *SandboxService) pauseSandboxRuntime(ctx context.Context, sandboxID stri
 				return pause(ctx, nil, nil)
 			}
 			return err
+		}
+		if meteringRecord != nil {
+			meteringRecord.Status = SandboxStatusPaused
+			s.recordSandboxPausedMetering(ctx, meteringRecord, meteringPausedAt)
 		}
 		return nil
 	}
@@ -475,7 +485,8 @@ func (s *SandboxService) commitPausingRuntimePaused(ctx context.Context, sandbox
 	if pausedAt.IsZero() {
 		pausedAt = s.clock.Now()
 	}
-	return s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, record *SandboxRecord) error {
+	var meteringRecord *SandboxRecord
+	if err := s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, record *SandboxRecord) error {
 		activeTxn, err := tx.GetActiveLifecycleTxn(lockCtx, sandboxID)
 		if err != nil {
 			return err
@@ -488,6 +499,7 @@ func (s *SandboxService) commitPausingRuntimePaused(ctx context.Context, sandbox
 				return err
 			}
 		}
+		meteringRecord = cloneSandboxRecordForLifecycle(record)
 		if err := tx.MarkRuntimePaused(lockCtx, sandboxID, generation, pausedAt); err != nil {
 			return err
 		}
@@ -496,7 +508,17 @@ func (s *SandboxService) commitPausingRuntimePaused(ctx context.Context, sandbox
 			preparedHead = rootFSState.LayerID
 		}
 		return tx.CommitLifecycleTxn(lockCtx, txn.ID, preparedHead)
-	})
+	}); err != nil {
+		return err
+	}
+	if meteringRecord != nil {
+		meteringRecord.Status = SandboxStatusPaused
+		if generation > meteringRecord.RuntimeGeneration {
+			meteringRecord.RuntimeGeneration = generation
+		}
+		s.recordSandboxPausedMetering(ctx, meteringRecord, pausedAt)
+	}
+	return nil
 }
 
 func (s *SandboxService) markLifecycleTxnPhase(ctx context.Context, sandboxID, txnID, phase string) error {

--- a/manager/pkg/service/sandbox_service_lifecycle.go
+++ b/manager/pkg/service/sandbox_service_lifecycle.go
@@ -270,11 +270,16 @@ func (s *SandboxService) pauseSandboxRuntime(ctx context.Context, sandboxID stri
 		if err != nil {
 			return fmt.Errorf("ensure sandbox cleanup finalizer: %w", err)
 		}
+		pausedAt := s.clock.Now()
+		pod, err = s.markRuntimePodPausedForMetering(ctx, pod, pausedAt)
+		if err != nil {
+			return fmt.Errorf("mark runtime pod paused for metering: %w", err)
+		}
 		if err := s.k8sClient.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{}); err != nil && !k8serrors.IsNotFound(err) {
 			return fmt.Errorf("delete runtime pod: %w", err)
 		}
 		if tx != nil {
-			return tx.MarkRuntimePaused(ctx, sandboxID, generation, s.clock.Now())
+			return tx.MarkRuntimePaused(ctx, sandboxID, generation, pausedAt)
 		}
 		return nil
 	}
@@ -328,7 +333,7 @@ func (s *SandboxService) CompletePausingSandboxRuntime(ctx context.Context, sand
 	pod, err := s.getSandboxPod(ctx, sandboxID)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			return s.commitPausingRuntimePaused(ctx, sandboxID, txn, record.RuntimeGeneration, nil)
+			return s.commitPausingRuntimePaused(ctx, sandboxID, txn, record.RuntimeGeneration, nil, s.clock.Now())
 		}
 		return fmt.Errorf("get pod: %w", err)
 	}
@@ -412,12 +417,24 @@ func (s *SandboxService) CompletePausingSandboxRuntime(ctx context.Context, sand
 		_ = s.abortLifecycleTxn(ctx, sandboxID, txn.ID, err.Error())
 		return err
 	}
-	if err := s.commitPausingRuntimePaused(ctx, sandboxID, txn, generation, rootFSState); err != nil {
+	pausedAt := s.clock.Now()
+	if err := s.commitPausingRuntimePaused(ctx, sandboxID, txn, generation, rootFSState, pausedAt); err != nil {
 		_ = s.abortLifecycleTxn(ctx, sandboxID, txn.ID, err.Error())
 		return err
 	}
 	rootFSCommitted = true
 	barrierActive = false
+	if markedPod, err := s.markRuntimePodPausedForMetering(ctx, pod, pausedAt); err != nil {
+		if s.logger != nil {
+			s.logger.Warn("Committed sandbox pause but failed to mark runtime pod paused for metering",
+				zap.String("sandboxID", sandboxID),
+				zap.String("pod", pod.Name),
+				zap.Error(err),
+			)
+		}
+	} else if markedPod != nil {
+		pod = markedPod
+	}
 	if err := s.k8sClient.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{}); err != nil && !k8serrors.IsNotFound(err) {
 		if s.logger != nil {
 			s.logger.Warn("Committed sandbox pause but failed to delete old runtime pod",
@@ -466,9 +483,12 @@ func (s *SandboxService) markLifecycleTxnPreparedHead(ctx context.Context, sandb
 	return err
 }
 
-func (s *SandboxService) commitPausingRuntimePaused(ctx context.Context, sandboxID string, txn *SandboxLifecycleTxn, generation int64, rootFSState *SandboxRootFSState) error {
+func (s *SandboxService) commitPausingRuntimePaused(ctx context.Context, sandboxID string, txn *SandboxLifecycleTxn, generation int64, rootFSState *SandboxRootFSState, pausedAt time.Time) error {
 	if s == nil || s.sandboxStore == nil {
 		return nil
+	}
+	if pausedAt.IsZero() {
+		pausedAt = s.clock.Now()
 	}
 	return s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, record *SandboxRecord) error {
 		activeTxn, err := tx.GetActiveLifecycleTxn(lockCtx, sandboxID)
@@ -483,7 +503,7 @@ func (s *SandboxService) commitPausingRuntimePaused(ctx context.Context, sandbox
 				return err
 			}
 		}
-		if err := tx.MarkRuntimePaused(lockCtx, sandboxID, generation, s.clock.Now()); err != nil {
+		if err := tx.MarkRuntimePaused(lockCtx, sandboxID, generation, pausedAt); err != nil {
 			return err
 		}
 		preparedHead := ""

--- a/manager/pkg/service/sandbox_service_lifecycle.go
+++ b/manager/pkg/service/sandbox_service_lifecycle.go
@@ -110,6 +110,8 @@ func (s *SandboxService) requestPauseSandboxRuntime(ctx context.Context, sandbox
 	}
 
 	status := SandboxStatusRunning
+	var meteringRecord *SandboxRecord
+	var meteringPausedAt time.Time
 	err := s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, record *SandboxRecord) error {
 		activeTxn, err := tx.GetActiveLifecycleTxn(lockCtx, sandboxID)
 		if err != nil {
@@ -135,8 +137,11 @@ func (s *SandboxService) requestPauseSandboxRuntime(ctx context.Context, sandbox
 		pod, err := s.getSandboxPod(lockCtx, sandboxID)
 		if err != nil {
 			if k8serrors.IsNotFound(err) {
+				pausedAt := s.clock.Now()
 				status = SandboxStatusPaused
-				return tx.MarkRuntimePaused(lockCtx, sandboxID, 0, s.clock.Now())
+				meteringPausedAt = pausedAt
+				meteringRecord = cloneSandboxRecordForLifecycle(record)
+				return tx.MarkRuntimePaused(lockCtx, sandboxID, 0, pausedAt)
 			}
 			return fmt.Errorf("get pod: %w", err)
 		}
@@ -175,6 +180,10 @@ func (s *SandboxService) requestPauseSandboxRuntime(ctx context.Context, sandbox
 			return SandboxStatusPaused, nil
 		}
 		return "", err
+	}
+	if meteringRecord != nil {
+		meteringRecord.Status = SandboxStatusPaused
+		s.recordSandboxPausedMetering(ctx, meteringRecord, meteringPausedAt)
 	}
 	if status != SandboxStatusPaused {
 		s.enqueueSandboxPause(sandboxID)
@@ -280,6 +289,9 @@ func (s *SandboxService) pauseSandboxRuntime(ctx context.Context, sandboxID stri
 		}
 		if tx != nil {
 			meteringRecord = cloneSandboxRecordForLifecycle(record)
+			if meteringRecord != nil && meteringRecord.CurrentPodNamespace == "" {
+				meteringRecord.CurrentPodNamespace = pod.Namespace
+			}
 			meteringPausedAt = pausedAt
 			return tx.MarkRuntimePaused(ctx, sandboxID, generation, pausedAt)
 		}
@@ -515,6 +527,9 @@ func (s *SandboxService) commitPausingRuntimePaused(ctx context.Context, sandbox
 		meteringRecord.Status = SandboxStatusPaused
 		if generation > meteringRecord.RuntimeGeneration {
 			meteringRecord.RuntimeGeneration = generation
+		}
+		if txn != nil && meteringRecord.CurrentPodNamespace == "" {
+			meteringRecord.CurrentPodNamespace = txn.FromPodNamespace
 		}
 		s.recordSandboxPausedMetering(ctx, meteringRecord, pausedAt)
 	}

--- a/manager/pkg/service/sandbox_service_network.go
+++ b/manager/pkg/service/sandbox_service_network.go
@@ -289,12 +289,17 @@ func toStoreCredentialBindings(
 	if len(in) == 0 {
 		return nil, nil
 	}
+	refs := make([]string, 0, len(in))
+	for _, binding := range in {
+		refs = append(refs, binding.SourceRef)
+	}
+	sources, err := store.GetSourcesByRef(ctx, teamID, refs)
+	if err != nil {
+		return nil, fmt.Errorf("resolve credential sources: %w", err)
+	}
 	out := make([]egressauth.CredentialBinding, 0, len(in))
 	for _, binding := range in {
-		source, err := store.GetSourceByRef(ctx, teamID, binding.SourceRef)
-		if err != nil {
-			return nil, fmt.Errorf("resolve credential source %q: %w", binding.SourceRef, err)
-		}
+		source := sources[binding.SourceRef]
 		if source == nil {
 			return nil, fmt.Errorf("credential source %q not found", binding.SourceRef)
 		}

--- a/manager/pkg/service/sandbox_service_network_test.go
+++ b/manager/pkg/service/sandbox_service_network_test.go
@@ -62,8 +62,15 @@ func (s *memoryBindingStore) DeleteBindings(_ context.Context, teamID, sandboxID
 	return nil
 }
 
-func (s *memoryBindingStore) GetSourceByRef(_ context.Context, teamID, ref string) (*egressauth.CredentialSource, error) {
-	return cloneCredentialSource(s.sourcesByRef[s.sourceRefKey(teamID, ref)]), nil
+func (s *memoryBindingStore) GetSourcesByRef(_ context.Context, teamID string, refs []string) (map[string]*egressauth.CredentialSource, error) {
+	out := make(map[string]*egressauth.CredentialSource, len(refs))
+	for _, ref := range refs {
+		source := cloneCredentialSource(s.sourcesByRef[s.sourceRefKey(teamID, ref)])
+		if source != nil {
+			out[ref] = source
+		}
+	}
+	return out, nil
 }
 
 func (s *memoryBindingStore) GetSourceVersion(_ context.Context, sourceID, version int64) (*egressauth.CredentialSourceVersion, error) {

--- a/manager/pkg/service/sandbox_store.go
+++ b/manager/pkg/service/sandbox_store.go
@@ -325,6 +325,52 @@ func (s *PGSandboxStore) GetActiveLifecycleTxn(ctx context.Context, sandboxID st
 	return getActiveLifecycleTxn(ctx, s.pool, sandboxID)
 }
 
+// RuntimeDeletionMatchesCommittedPause reports whether a runtime pod deletion
+// belongs to a committed pause transaction.
+func (s *PGSandboxStore) RuntimeDeletionMatchesCommittedPause(ctx context.Context, sandboxID, namespace, podName string, runtimeGeneration int64) (bool, error) {
+	if s == nil || s.pool == nil {
+		return false, nil
+	}
+	sandboxID = strings.TrimSpace(sandboxID)
+	namespace = strings.TrimSpace(namespace)
+	podName = strings.TrimSpace(podName)
+	if sandboxID == "" || (runtimeGeneration <= 0 && podName == "") {
+		return false, nil
+	}
+	var txnID string
+	err := s.pool.QueryRow(ctx, `
+		SELECT txn_id
+		FROM manager.sandbox_lifecycle_txns
+		WHERE sandbox_id = $1
+			AND kind = $2
+			AND phase = $3
+			AND committed_at IS NOT NULL
+			AND (
+				(
+					$4::bigint > 0
+					AND from_generation = $4
+					AND ($5::text = '' OR from_pod_name = '' OR from_pod_name = $5)
+					AND ($6::text = '' OR from_pod_namespace = '' OR from_pod_namespace = $6)
+				)
+				OR (
+					$4::bigint <= 0
+					AND $5::text <> ''
+					AND from_pod_name = $5
+					AND ($6::text = '' OR from_pod_namespace = $6)
+				)
+			)
+		ORDER BY committed_at DESC
+		LIMIT 1
+	`, sandboxID, SandboxLifecycleKindPause, SandboxLifecyclePhaseCommitted, runtimeGeneration, podName, namespace).Scan(&txnID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("match committed pause runtime deletion: %w", err)
+	}
+	return txnID != "", nil
+}
+
 func (s *PGSandboxStore) ListHardExpiredSandboxes(ctx context.Context, now time.Time, limit int) ([]*SandboxRecord, error) {
 	if s == nil || s.pool == nil {
 		return nil, nil

--- a/manager/pkg/service/sandbox_store_integration_test.go
+++ b/manager/pkg/service/sandbox_store_integration_test.go
@@ -1,0 +1,70 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestPGSandboxStoreRuntimeDeletionMatchesCommittedPause(t *testing.T) {
+	pool := newSandboxStoreIntegrationPool(t)
+	store := NewPGSandboxStore(pool)
+	ctx := context.Background()
+
+	record := rootFSTestSandboxRecord("sandbox-pause-match", "team-1")
+	record.CurrentPodNamespace = "ns-a"
+	record.CurrentPodName = "pod-old"
+	record.RuntimeGeneration = 7
+	if err := store.UpsertSandbox(ctx, record); err != nil {
+		t.Fatalf("UpsertSandbox() error = %v", err)
+	}
+
+	err := store.WithSandboxLock(ctx, record.ID, func(lockCtx context.Context, tx SandboxStoreTx, _ *SandboxRecord) error {
+		txn := &SandboxLifecycleTxn{
+			ID:               "txn-pause-match",
+			SandboxID:        record.ID,
+			Kind:             SandboxLifecycleKindPause,
+			Phase:            SandboxLifecyclePhasePreparing,
+			FromGeneration:   7,
+			FromPodNamespace: "ns-a",
+			FromPodName:      "pod-old",
+		}
+		if err := tx.BeginLifecycleTxn(lockCtx, txn); err != nil {
+			return err
+		}
+		if err := tx.MarkRuntimePaused(lockCtx, record.ID, 7, time.Now().UTC()); err != nil {
+			return err
+		}
+		return tx.CommitLifecycleTxn(lockCtx, txn.ID, "")
+	})
+	if err != nil {
+		t.Fatalf("commit pause txn error = %v", err)
+	}
+
+	matched, err := store.RuntimeDeletionMatchesCommittedPause(ctx, record.ID, "ns-a", "pod-old", 7)
+	if err != nil {
+		t.Fatalf("RuntimeDeletionMatchesCommittedPause() error = %v", err)
+	}
+	if !matched {
+		t.Fatalf("RuntimeDeletionMatchesCommittedPause() = false, want true")
+	}
+
+	if err := store.MarkSandboxDeleted(ctx, record.ID, time.Now().UTC()); err != nil {
+		t.Fatalf("MarkSandboxDeleted() error = %v", err)
+	}
+	matched, err = store.RuntimeDeletionMatchesCommittedPause(ctx, record.ID, "ns-a", "pod-old", 7)
+	if err != nil {
+		t.Fatalf("RuntimeDeletionMatchesCommittedPause() after delete error = %v", err)
+	}
+	if !matched {
+		t.Fatalf("RuntimeDeletionMatchesCommittedPause() after delete = false, want true")
+	}
+
+	matched, err = store.RuntimeDeletionMatchesCommittedPause(ctx, record.ID, "ns-a", "pod-new", 8)
+	if err != nil {
+		t.Fatalf("RuntimeDeletionMatchesCommittedPause() mismatch error = %v", err)
+	}
+	if matched {
+		t.Fatalf("RuntimeDeletionMatchesCommittedPause() mismatch = true, want false")
+	}
+}

--- a/netd/pkg/metering/aggregator.go
+++ b/netd/pkg/metering/aggregator.go
@@ -17,7 +17,7 @@ import (
 const producerPrefix = "netd.byte_windows"
 
 type txRecorder interface {
-	AppendWindow(ctx context.Context, window *meteringpkg.Window) error
+	AppendWindows(ctx context.Context, windows []*meteringpkg.Window) error
 	UpsertProducerWatermark(ctx context.Context, producer string, regionID string, completeBefore time.Time) error
 }
 
@@ -52,8 +52,8 @@ type repositoryTxAdapter struct {
 	tx   pgx.Tx
 }
 
-func (r *repositoryTxAdapter) AppendWindow(ctx context.Context, window *meteringpkg.Window) error {
-	return r.repo.AppendWindowTx(ctx, r.tx, window)
+func (r *repositoryTxAdapter) AppendWindows(ctx context.Context, windows []*meteringpkg.Window) error {
+	return r.repo.AppendWindowsTx(ctx, r.tx, windows)
 }
 
 func (r *repositoryTxAdapter) UpsertProducerWatermark(ctx context.Context, producer string, regionID string, completeBefore time.Time) error {
@@ -215,18 +215,19 @@ func (a *Aggregator) Flush(ctx context.Context) error {
 		end = start
 	}
 
+	windows := make([]*meteringpkg.Window, 0, len(snapshot)*2)
+	for _, usage := range snapshot {
+		if usage.egress > 0 {
+			windows = append(windows, a.buildWindow(usage, meteringpkg.WindowTypeSandboxEgressBytes, start, end, usage.egress))
+		}
+		if usage.ingress > 0 {
+			windows = append(windows, a.buildWindow(usage, meteringpkg.WindowTypeSandboxIngressBytes, start, end, usage.ingress))
+		}
+	}
+
 	err := a.recorder.RunInTx(ctx, func(tx txRecorder) error {
-		for _, usage := range snapshot {
-			if usage.egress > 0 {
-				if err := tx.AppendWindow(ctx, a.buildWindow(usage, meteringpkg.WindowTypeSandboxEgressBytes, start, end, usage.egress)); err != nil {
-					return err
-				}
-			}
-			if usage.ingress > 0 {
-				if err := tx.AppendWindow(ctx, a.buildWindow(usage, meteringpkg.WindowTypeSandboxIngressBytes, start, end, usage.ingress)); err != nil {
-					return err
-				}
-			}
+		if err := tx.AppendWindows(ctx, windows); err != nil {
+			return err
 		}
 		return tx.UpsertProducerWatermark(ctx, a.producer, a.regionID, end)
 	})

--- a/netd/pkg/metering/aggregator_test.go
+++ b/netd/pkg/metering/aggregator_test.go
@@ -21,11 +21,11 @@ type fakeTxRecorder struct {
 	watermarkErr      error
 }
 
-func (f *fakeTxRecorder) AppendWindow(_ context.Context, window *meteringpkg.Window) error {
+func (f *fakeTxRecorder) AppendWindows(_ context.Context, windows []*meteringpkg.Window) error {
 	if f.appendErr != nil {
 		return f.appendErr
 	}
-	f.windows = append(f.windows, window)
+	f.windows = append(f.windows, windows...)
 	return nil
 }
 

--- a/pkg/egressauth/repository.go
+++ b/pkg/egressauth/repository.go
@@ -210,7 +210,7 @@ func (r *Repository) UpsertBindings(ctx context.Context, record *BindingRecord) 
 			SourceID:      binding.SourceID,
 			SourceVersion: binding.SourceVersion,
 			Projection:    projectionJSON,
-			CachePolicy:   cachePolicyJSON,
+			CachePolicy:   emptyObjectIfJSONNull(cachePolicyJSON),
 		})
 	}
 
@@ -233,9 +233,9 @@ func (r *Repository) UpsertBindings(ctx context.Context, record *BindingRecord) 
 		INSERT INTO sandbox_egress_credential_bindings (
 			team_id, sandbox_id, ref, source_ref, source_id, source_version, projection, cache_policy, updated_at
 		)
-		SELECT $1, $2, ref, source_ref, source_id, source_version, projection, cache_policy, $4
+		SELECT $1, $2, ref, source_ref, source_id, source_version, COALESCE(projection, '{}'::jsonb), COALESCE(cache_policy, '{}'::jsonb), $4
 		FROM input
-	`, record.TeamID, record.SandboxID, payload, record.UpdatedAt); err != nil {
+		`, record.TeamID, record.SandboxID, payload, record.UpdatedAt); err != nil {
 		return fmt.Errorf("insert bindings: %w", err)
 	}
 
@@ -635,6 +635,13 @@ type credentialBindingRow struct {
 	SourceVersion int64           `json:"source_version"`
 	Projection    json.RawMessage `json:"projection"`
 	CachePolicy   json.RawMessage `json:"cache_policy"`
+}
+
+func emptyObjectIfJSONNull(raw []byte) json.RawMessage {
+	if len(raw) == 0 || string(raw) == "null" {
+		return json.RawMessage(`{}`)
+	}
+	return raw
 }
 
 func (r *Repository) scanSourceMetadata(rows pgx.Rows) (*CredentialSourceMetadata, error) {

--- a/pkg/egressauth/repository.go
+++ b/pkg/egressauth/repository.go
@@ -26,7 +26,7 @@ type BindingStore interface {
 	GetBindings(ctx context.Context, teamID, sandboxID string) (*BindingRecord, error)
 	UpsertBindings(ctx context.Context, record *BindingRecord) error
 	DeleteBindings(ctx context.Context, teamID, sandboxID string) error
-	GetSourceByRef(ctx context.Context, teamID, ref string) (*CredentialSource, error)
+	GetSourcesByRef(ctx context.Context, teamID string, refs []string) (map[string]*CredentialSource, error)
 	GetSourceVersion(ctx context.Context, sourceID, version int64) (*CredentialSourceVersion, error)
 }
 
@@ -187,6 +187,14 @@ func (r *Repository) UpsertBindings(ctx context.Context, record *BindingRecord) 
 		return fmt.Errorf("delete existing bindings: %w", err)
 	}
 
+	if len(record.Bindings) == 0 {
+		if err := tx.Commit(ctx); err != nil {
+			return fmt.Errorf("commit binding upsert: %w", err)
+		}
+		return nil
+	}
+
+	bindings := make([]credentialBindingRow, 0, len(record.Bindings))
 	for _, binding := range record.Bindings {
 		projectionJSON, err := json.Marshal(binding.Projection)
 		if err != nil {
@@ -196,14 +204,39 @@ func (r *Repository) UpsertBindings(ctx context.Context, record *BindingRecord) 
 		if err != nil {
 			return fmt.Errorf("marshal cache policy for %q: %w", binding.Ref, err)
 		}
+		bindings = append(bindings, credentialBindingRow{
+			Ref:           binding.Ref,
+			SourceRef:     binding.SourceRef,
+			SourceID:      binding.SourceID,
+			SourceVersion: binding.SourceVersion,
+			Projection:    projectionJSON,
+			CachePolicy:   cachePolicyJSON,
+		})
+	}
 
-		if _, err := tx.Exec(ctx, `
-			INSERT INTO sandbox_egress_credential_bindings (
-				team_id, sandbox_id, ref, source_ref, source_id, source_version, projection, cache_policy, updated_at
-			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-		`, record.TeamID, record.SandboxID, binding.Ref, binding.SourceRef, binding.SourceID, binding.SourceVersion, projectionJSON, cachePolicyJSON, record.UpdatedAt); err != nil {
-			return fmt.Errorf("insert binding %q: %w", binding.Ref, err)
-		}
+	payload, err := json.Marshal(bindings)
+	if err != nil {
+		return fmt.Errorf("marshal credential binding batch: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `
+		WITH input AS (
+			SELECT *
+			FROM jsonb_to_recordset($3::jsonb) AS binding(
+				ref text,
+				source_ref text,
+				source_id bigint,
+				source_version bigint,
+				projection jsonb,
+				cache_policy jsonb
+			)
+		)
+		INSERT INTO sandbox_egress_credential_bindings (
+			team_id, sandbox_id, ref, source_ref, source_id, source_version, projection, cache_policy, updated_at
+		)
+		SELECT $1, $2, ref, source_ref, source_id, source_version, projection, cache_policy, $4
+		FROM input
+	`, record.TeamID, record.SandboxID, payload, record.UpdatedAt); err != nil {
+		return fmt.Errorf("insert bindings: %w", err)
 	}
 
 	if err := tx.Commit(ctx); err != nil {
@@ -265,6 +298,72 @@ func (r *Repository) GetSourceByRef(ctx context.Context, teamID, ref string) (*C
 		return nil, fmt.Errorf("get source by ref: %w", err)
 	}
 	return &source, nil
+}
+
+func (r *Repository) GetSourcesByRef(ctx context.Context, teamID string, refs []string) (map[string]*CredentialSource, error) {
+	if r == nil || r.db == nil {
+		return nil, fmt.Errorf("binding repository is not configured")
+	}
+	if teamID == "" {
+		return nil, fmt.Errorf("team_id is required")
+	}
+	if len(refs) == 0 {
+		return map[string]*CredentialSource{}, nil
+	}
+	uniqueRefs := make([]string, 0, len(refs))
+	seen := make(map[string]struct{}, len(refs))
+	for _, ref := range refs {
+		ref = strings.TrimSpace(ref)
+		if ref == "" {
+			return nil, fmt.Errorf("source ref is required")
+		}
+		if _, ok := seen[ref]; ok {
+			continue
+		}
+		seen[ref] = struct{}{}
+		uniqueRefs = append(uniqueRefs, ref)
+	}
+	payload, err := json.Marshal(uniqueRefs)
+	if err != nil {
+		return nil, fmt.Errorf("marshal source refs: %w", err)
+	}
+	rows, err := r.db.Query(ctx, `
+		WITH refs AS (
+			SELECT value AS name
+			FROM jsonb_array_elements_text($2::jsonb)
+		)
+		SELECT s.id, s.team_id, s.name, s.resolver_kind, s.current_version, s.status, s.created_at, s.updated_at
+		FROM credential_sources s
+		JOIN refs ON refs.name = s.name
+		WHERE s.team_id = $1
+		ORDER BY s.name
+	`, teamID, payload)
+	if err != nil {
+		return nil, fmt.Errorf("get sources by ref: %w", err)
+	}
+	defer rows.Close()
+
+	sources := make(map[string]*CredentialSource, len(uniqueRefs))
+	for rows.Next() {
+		source := &CredentialSource{}
+		if err := rows.Scan(
+			&source.ID,
+			&source.TeamID,
+			&source.Name,
+			&source.ResolverKind,
+			&source.CurrentVersion,
+			&source.Status,
+			&source.CreatedAt,
+			&source.UpdatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan source by ref: %w", err)
+		}
+		sources[source.Name] = source
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate sources by ref: %w", err)
+	}
+	return sources, nil
 }
 
 func (r *Repository) GetSourceVersion(ctx context.Context, sourceID, version int64) (*CredentialSourceVersion, error) {
@@ -527,6 +626,15 @@ func (r *Repository) DeleteSource(ctx context.Context, teamID, name string) erro
 		return fmt.Errorf("delete source record: %w", err)
 	}
 	return nil
+}
+
+type credentialBindingRow struct {
+	Ref           string          `json:"ref"`
+	SourceRef     string          `json:"source_ref"`
+	SourceID      int64           `json:"source_id"`
+	SourceVersion int64           `json:"source_version"`
+	Projection    json.RawMessage `json:"projection"`
+	CachePolicy   json.RawMessage `json:"cache_policy"`
 }
 
 func (r *Repository) scanSourceMetadata(rows pgx.Rows) (*CredentialSourceMetadata, error) {

--- a/pkg/egressauth/repository_test.go
+++ b/pkg/egressauth/repository_test.go
@@ -92,6 +92,16 @@ func TestRepositoryPutSourceAdvancesExistingBindings(t *testing.T) {
 	}
 }
 
+func TestEmptyObjectIfJSONNullDefaultsNilCachePolicy(t *testing.T) {
+	raw, err := json.Marshal((*CachePolicySpec)(nil))
+	if err != nil {
+		t.Fatalf("marshal nil cache policy: %v", err)
+	}
+	if got := string(emptyObjectIfJSONNull(raw)); got != "{}" {
+		t.Fatalf("normalized cache policy = %s, want {}", got)
+	}
+}
+
 func TestRepositoryPutSourcePublishesRotationEvent(t *testing.T) {
 	ctx := context.Background()
 	repo, pool := newRepositoryTestStore(t)

--- a/pkg/egressauth/runtime/service_test.go
+++ b/pkg/egressauth/runtime/service_test.go
@@ -36,7 +36,7 @@ func (f *fakeBindingStore) DeleteBindings(context.Context, string, string) error
 	return errors.New("not implemented")
 }
 
-func (f *fakeBindingStore) GetSourceByRef(context.Context, string, string) (*egressauth.CredentialSource, error) {
+func (f *fakeBindingStore) GetSourcesByRef(context.Context, string, []string) (map[string]*egressauth.CredentialSource, error) {
 	return nil, errors.New("not implemented")
 }
 

--- a/pkg/metering/repository.go
+++ b/pkg/metering/repository.go
@@ -64,24 +64,17 @@ func (r *Repository) AppendEventTx(ctx context.Context, tx pgx.Tx, event *Event)
 	return r.appendEvent(ctx, tx, event)
 }
 
+func (r *Repository) AppendEvents(ctx context.Context, events []*Event) error {
+	return r.appendEvents(ctx, r.db, events)
+}
+
+func (r *Repository) AppendEventsTx(ctx context.Context, tx pgx.Tx, events []*Event) error {
+	return r.appendEvents(ctx, tx, events)
+}
+
 func (r *Repository) appendEvent(ctx context.Context, db DB, event *Event) error {
-	if event == nil {
-		return fmt.Errorf("event is nil")
-	}
-	if event.EventID == "" {
-		return fmt.Errorf("event_id is required")
-	}
-	if event.Producer == "" {
-		return fmt.Errorf("producer is required")
-	}
-	if event.EventType == "" {
-		return fmt.Errorf("event_type is required")
-	}
-	if event.SubjectType == "" || event.SubjectID == "" {
-		return fmt.Errorf("subject_type and subject_id are required")
-	}
-	if event.OccurredAt.IsZero() {
-		return fmt.Errorf("occurred_at is required")
+	if err := validateEvent(event); err != nil {
+		return err
 	}
 
 	data := event.Data
@@ -121,6 +114,86 @@ func (r *Repository) appendEvent(ctx context.Context, db DB, event *Event) error
 	return nil
 }
 
+func (r *Repository) appendEvents(ctx context.Context, db DB, events []*Event) error {
+	if len(events) == 0 {
+		return nil
+	}
+	rows := make([]usageEventRow, 0, len(events))
+	for _, event := range events {
+		if err := validateEvent(event); err != nil {
+			return err
+		}
+		data := event.Data
+		if len(data) == 0 {
+			data = json.RawMessage(`{}`)
+		}
+		rows = append(rows, usageEventRow{
+			EventID:     event.EventID,
+			Producer:    event.Producer,
+			RegionID:    event.RegionID,
+			EventType:   event.EventType,
+			SubjectType: event.SubjectType,
+			SubjectID:   event.SubjectID,
+			TeamID:      event.TeamID,
+			UserID:      event.UserID,
+			SandboxID:   event.SandboxID,
+			VolumeID:    event.VolumeID,
+			SnapshotID:  event.SnapshotID,
+			TemplateID:  event.TemplateID,
+			ClusterID:   event.ClusterID,
+			OccurredAt:  event.OccurredAt,
+			Data:        data,
+		})
+	}
+	payload, err := json.Marshal(rows)
+	if err != nil {
+		return fmt.Errorf("marshal usage event batch: %w", err)
+	}
+	_, err = db.Exec(ctx, `
+		WITH input AS (
+			SELECT *
+			FROM jsonb_to_recordset($1::jsonb) AS event(
+				event_id text,
+				producer text,
+				region_id text,
+				event_type text,
+				subject_type text,
+				subject_id text,
+				team_id text,
+				user_id text,
+				sandbox_id text,
+				volume_id text,
+				snapshot_id text,
+				template_id text,
+				cluster_id text,
+				occurred_at timestamptz,
+				data jsonb
+			)
+		)
+		INSERT INTO metering.usage_events (
+			event_id, producer, region_id, event_type,
+			subject_type, subject_id,
+			team_id, user_id,
+			sandbox_id, volume_id, snapshot_id,
+			template_id, cluster_id,
+			occurred_at, data
+		)
+		SELECT
+			event_id, producer, region_id, event_type,
+			subject_type, subject_id,
+			team_id, user_id,
+			NULLIF(sandbox_id, ''), NULLIF(volume_id, ''), NULLIF(snapshot_id, ''),
+			NULLIF(template_id, ''), NULLIF(cluster_id, ''),
+			occurred_at, data
+		FROM input
+		ON CONFLICT (event_id) DO NOTHING
+	`, payload)
+	if err != nil {
+		return fmt.Errorf("insert usage events: %w", err)
+	}
+	return nil
+}
+
 func (r *Repository) AppendWindow(ctx context.Context, window *Window) error {
 	return r.appendWindow(ctx, r.db, window)
 }
@@ -129,33 +202,17 @@ func (r *Repository) AppendWindowTx(ctx context.Context, tx pgx.Tx, window *Wind
 	return r.appendWindow(ctx, tx, window)
 }
 
+func (r *Repository) AppendWindows(ctx context.Context, windows []*Window) error {
+	return r.appendWindows(ctx, r.db, windows)
+}
+
+func (r *Repository) AppendWindowsTx(ctx context.Context, tx pgx.Tx, windows []*Window) error {
+	return r.appendWindows(ctx, tx, windows)
+}
+
 func (r *Repository) appendWindow(ctx context.Context, db DB, window *Window) error {
-	if window == nil {
-		return fmt.Errorf("window is nil")
-	}
-	if window.WindowID == "" {
-		return fmt.Errorf("window_id is required")
-	}
-	if window.Producer == "" {
-		return fmt.Errorf("producer is required")
-	}
-	if window.WindowType == "" {
-		return fmt.Errorf("window_type is required")
-	}
-	if window.SubjectType == "" || window.SubjectID == "" {
-		return fmt.Errorf("subject_type and subject_id are required")
-	}
-	if window.WindowStart.IsZero() || window.WindowEnd.IsZero() {
-		return fmt.Errorf("window_start and window_end are required")
-	}
-	if window.WindowEnd.Before(window.WindowStart) {
-		return fmt.Errorf("window_end must be greater than or equal to window_start")
-	}
-	if window.Unit == "" {
-		return fmt.Errorf("unit is required")
-	}
-	if window.Value < 0 {
-		return fmt.Errorf("value must be non-negative")
+	if err := validateWindow(window); err != nil {
+		return err
 	}
 
 	data := window.Data
@@ -195,6 +252,94 @@ func (r *Repository) appendWindow(ctx context.Context, db DB, window *Window) er
 		return fmt.Errorf("insert usage window: %w", err)
 	}
 
+	return nil
+}
+
+func (r *Repository) appendWindows(ctx context.Context, db DB, windows []*Window) error {
+	if len(windows) == 0 {
+		return nil
+	}
+	rows := make([]usageWindowRow, 0, len(windows))
+	for _, window := range windows {
+		if err := validateWindow(window); err != nil {
+			return err
+		}
+		data := window.Data
+		if len(data) == 0 {
+			data = json.RawMessage(`{}`)
+		}
+		rows = append(rows, usageWindowRow{
+			WindowID:    window.WindowID,
+			Producer:    window.Producer,
+			RegionID:    window.RegionID,
+			WindowType:  window.WindowType,
+			SubjectType: window.SubjectType,
+			SubjectID:   window.SubjectID,
+			TeamID:      window.TeamID,
+			UserID:      window.UserID,
+			SandboxID:   window.SandboxID,
+			VolumeID:    window.VolumeID,
+			SnapshotID:  window.SnapshotID,
+			TemplateID:  window.TemplateID,
+			ClusterID:   window.ClusterID,
+			WindowStart: window.WindowStart,
+			WindowEnd:   window.WindowEnd,
+			Value:       window.Value,
+			Unit:        window.Unit,
+			Data:        data,
+		})
+	}
+	payload, err := json.Marshal(rows)
+	if err != nil {
+		return fmt.Errorf("marshal usage window batch: %w", err)
+	}
+	_, err = db.Exec(ctx, `
+		WITH input AS (
+			SELECT *
+			FROM jsonb_to_recordset($1::jsonb) AS window(
+				window_id text,
+				producer text,
+				region_id text,
+				window_type text,
+				subject_type text,
+				subject_id text,
+				team_id text,
+				user_id text,
+				sandbox_id text,
+				volume_id text,
+				snapshot_id text,
+				template_id text,
+				cluster_id text,
+				window_start timestamptz,
+				window_end timestamptz,
+				value bigint,
+				unit text,
+				data jsonb
+			)
+		)
+		INSERT INTO metering.usage_windows (
+			window_id, producer, region_id, window_type,
+			subject_type, subject_id,
+			team_id, user_id,
+			sandbox_id, volume_id, snapshot_id,
+			template_id, cluster_id,
+			window_start, window_end,
+			value, unit, data
+		)
+		SELECT
+			window_id, producer, region_id, window_type,
+			subject_type, subject_id,
+			team_id, user_id,
+			NULLIF(sandbox_id, ''), NULLIF(volume_id, ''), NULLIF(snapshot_id, ''),
+			NULLIF(template_id, ''), NULLIF(cluster_id, ''),
+			window_start, window_end,
+			value, unit, data
+		FROM input
+		ON CONFLICT (window_id) DO NOTHING
+	`, payload)
+	if err != nil {
+		return fmt.Errorf("insert usage windows: %w", err)
+	}
 	return nil
 }
 
@@ -243,6 +388,27 @@ func (r *Repository) RecordStorageObservationTx(ctx context.Context, tx pgx.Tx, 
 	return r.recordStorageObservation(ctx, tx, observation)
 }
 
+func (r *Repository) RecordStorageObservations(ctx context.Context, observations []*StorageObservation) error {
+	if len(observations) == 0 {
+		return nil
+	}
+	if r.pool == nil {
+		for _, observation := range observations {
+			if err := r.recordStorageObservation(ctx, r.db, observation); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	return r.InTx(ctx, func(tx pgx.Tx) error {
+		return r.recordStorageObservations(ctx, tx, observations)
+	})
+}
+
+func (r *Repository) RecordStorageObservationsTx(ctx context.Context, tx pgx.Tx, observations []*StorageObservation) error {
+	return r.recordStorageObservations(ctx, tx, observations)
+}
+
 func (r *Repository) recordStorageObservation(ctx context.Context, db DB, observation *StorageObservation) error {
 	state, err := r.normalizeStorageObservation(ctx, db, observation)
 	if err != nil {
@@ -267,6 +433,45 @@ func (r *Repository) recordStorageObservation(ctx context.Context, db DB, observ
 	}
 
 	return r.upsertStorageProjectionState(ctx, db, state)
+}
+
+func (r *Repository) recordStorageObservations(ctx context.Context, db DB, observations []*StorageObservation) error {
+	if len(observations) == 0 {
+		return nil
+	}
+	states, err := r.normalizeStorageObservations(ctx, db, observations)
+	if err != nil {
+		return err
+	}
+	if len(states) == 0 {
+		return nil
+	}
+
+	previousStates, err := r.getStorageProjectionStatesForUpdate(ctx, db, storageProjectionKeysFromStates(states))
+	if err != nil {
+		return err
+	}
+
+	windows := make([]*Window, 0, len(states))
+	upserts := make([]*StorageProjectionState, 0, len(states))
+	for _, state := range states {
+		previous := previousStates[storageProjectionKeyString(state.SubjectType, state.SubjectID)]
+		if previous != nil {
+			if state.ObservedAt.Before(previous.ObservedAt) {
+				continue
+			}
+			window, remainder := storageWindowFromStateWithRemainder(previous, state.ObservedAt)
+			if window != nil {
+				windows = append(windows, window)
+			}
+			state.UnbilledByteNanoseconds = remainder
+		}
+		upserts = append(upserts, state)
+	}
+	if err := r.appendWindows(ctx, db, windows); err != nil {
+		return err
+	}
+	return r.upsertStorageProjectionStates(ctx, db, upserts)
 }
 
 func (r *Repository) CloseStorageObservation(ctx context.Context, observation *StorageObservation) error {
@@ -362,22 +567,24 @@ func (r *Repository) FlushStorageProjectionWindows(ctx context.Context, before t
 			return fmt.Errorf("iterate storage projection states: %w", err)
 		}
 
+		windows := make([]*Window, 0, len(states))
+		advances := make([]storageProjectionAdvanceRow, 0, len(states))
 		for _, state := range states {
 			window, remainder := storageWindowFromStateWithRemainder(state, before)
 			if window != nil {
-				if err := r.appendWindow(ctx, tx, window); err != nil {
-					return err
-				}
+				windows = append(windows, window)
 			}
-			if _, err := tx.Exec(ctx, `
-				UPDATE metering.storage_projection_state
-				SET observed_at = $3,
-					unbilled_byte_nanoseconds = $4,
-					updated_at = NOW()
-				WHERE subject_type = $1 AND subject_id = $2
-			`, state.SubjectType, state.SubjectID, before, remainder); err != nil {
-				return fmt.Errorf("advance storage projection state: %w", err)
-			}
+			advances = append(advances, storageProjectionAdvanceRow{
+				SubjectType:             state.SubjectType,
+				SubjectID:               state.SubjectID,
+				UnbilledByteNanoseconds: remainder,
+			})
+		}
+		if err := r.appendWindows(ctx, tx, windows); err != nil {
+			return err
+		}
+		if err := r.advanceStorageProjectionStates(ctx, tx, before, advances); err != nil {
+			return err
 		}
 		processed = len(states)
 		return nil
@@ -603,6 +810,58 @@ func (r *Repository) upsertSandboxProjectionState(ctx context.Context, db DB, st
 }
 
 func (r *Repository) normalizeStorageObservation(ctx context.Context, db DB, observation *StorageObservation) (*StorageProjectionState, error) {
+	state, err := normalizeStorageObservationInput(observation)
+	if err != nil {
+		return nil, err
+	}
+	if state.SandboxID != "" {
+		if err := r.applySandboxStorageProduct(ctx, db, state); err != nil {
+			return nil, err
+		}
+	}
+	return state, nil
+}
+
+func (r *Repository) normalizeStorageObservations(ctx context.Context, db DB, observations []*StorageObservation) ([]*StorageProjectionState, error) {
+	states := make([]*StorageProjectionState, 0, len(observations))
+	seen := make(map[string]struct{}, len(observations))
+	sandboxIDs := make([]string, 0, len(observations))
+	sandboxSeen := make(map[string]struct{}, len(observations))
+	for _, observation := range observations {
+		state, err := normalizeStorageObservationInput(observation)
+		if err != nil {
+			return nil, err
+		}
+		key := storageProjectionKeyString(state.SubjectType, state.SubjectID)
+		if _, ok := seen[key]; ok {
+			return nil, fmt.Errorf("duplicate storage observation for %s/%s", state.SubjectType, state.SubjectID)
+		}
+		seen[key] = struct{}{}
+		if state.SandboxID != "" {
+			if _, ok := sandboxSeen[state.SandboxID]; !ok {
+				sandboxSeen[state.SandboxID] = struct{}{}
+				sandboxIDs = append(sandboxIDs, state.SandboxID)
+			}
+		}
+		states = append(states, state)
+	}
+	if len(sandboxIDs) == 0 {
+		return states, nil
+	}
+	ownerKinds, err := r.sandboxStorageOwnerKinds(ctx, db, sandboxIDs)
+	if err != nil {
+		return nil, err
+	}
+	for _, state := range states {
+		if state.SandboxID == "" || state.OwnerKind != "" {
+			continue
+		}
+		state.OwnerKind = ownerKinds[state.SandboxID]
+	}
+	return states, nil
+}
+
+func normalizeStorageObservationInput(observation *StorageObservation) (*StorageProjectionState, error) {
 	if observation == nil {
 		return nil, fmt.Errorf("storage observation is nil")
 	}
@@ -625,7 +884,7 @@ func (r *Repository) normalizeStorageObservation(ctx context.Context, db DB, obs
 	if product == "" {
 		product = ProductSandbox
 	}
-	state := &StorageProjectionState{
+	return &StorageProjectionState{
 		SubjectType: observation.SubjectType,
 		SubjectID:   observation.SubjectID,
 		Product:     product,
@@ -639,13 +898,7 @@ func (r *Repository) normalizeStorageObservation(ctx context.Context, db DB, obs
 		RegionID:    observation.RegionID,
 		SizeBytes:   observation.SizeBytes,
 		ObservedAt:  observedAt,
-	}
-	if state.SandboxID != "" {
-		if err := r.applySandboxStorageProduct(ctx, db, state); err != nil {
-			return nil, err
-		}
-	}
-	return state, nil
+	}, nil
 }
 
 func (r *Repository) applySandboxStorageProduct(ctx context.Context, db DB, state *StorageProjectionState) error {
@@ -665,6 +918,38 @@ func (r *Repository) applySandboxStorageProduct(ctx context.Context, db DB, stat
 		state.OwnerKind = ownerKind
 	}
 	return nil
+}
+
+func (r *Repository) sandboxStorageOwnerKinds(ctx context.Context, db DB, sandboxIDs []string) (map[string]string, error) {
+	payload, err := json.Marshal(sandboxIDs)
+	if err != nil {
+		return nil, fmt.Errorf("marshal sandbox ids: %w", err)
+	}
+	rows, err := db.Query(ctx, `
+		WITH sandbox_ids AS (
+			SELECT value AS sandbox_id
+			FROM jsonb_array_elements_text($1::jsonb)
+		)
+		SELECT p.sandbox_id, p.owner_kind
+		FROM metering.manager_sandbox_projection_state p
+		JOIN sandbox_ids ON sandbox_ids.sandbox_id = p.sandbox_id
+	`, payload)
+	if err != nil {
+		return nil, fmt.Errorf("query sandbox storage owner states: %w", err)
+	}
+	defer rows.Close()
+	out := make(map[string]string, len(sandboxIDs))
+	for rows.Next() {
+		var sandboxID, ownerKind string
+		if err := rows.Scan(&sandboxID, &ownerKind); err != nil {
+			return nil, fmt.Errorf("scan sandbox storage owner state: %w", err)
+		}
+		out[sandboxID] = ownerKind
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate sandbox storage owner states: %w", err)
+	}
+	return out, nil
 }
 
 func (r *Repository) getStorageProjectionStateForUpdate(ctx context.Context, db DB, subjectType, subjectID string) (*StorageProjectionState, error) {
@@ -691,6 +976,52 @@ func (r *Repository) getStorageProjectionStateForUpdate(ctx context.Context, db 
 		return nil, fmt.Errorf("query storage projection state: %w", err)
 	}
 	return state, nil
+}
+
+func (r *Repository) getStorageProjectionStatesForUpdate(ctx context.Context, db DB, keys []storageProjectionKey) (map[string]*StorageProjectionState, error) {
+	if len(keys) == 0 {
+		return map[string]*StorageProjectionState{}, nil
+	}
+	payload, err := json.Marshal(keys)
+	if err != nil {
+		return nil, fmt.Errorf("marshal storage projection keys: %w", err)
+	}
+	rows, err := db.Query(ctx, `
+		WITH input AS (
+			SELECT *
+			FROM jsonb_to_recordset($1::jsonb) AS key(subject_type text, subject_id text)
+		)
+		SELECT
+			s.subject_type, s.subject_id, s.product, s.owner_kind,
+			s.team_id, s.user_id, COALESCE(s.sandbox_id, ''), COALESCE(s.volume_id, ''),
+			COALESCE(s.snapshot_id, ''), COALESCE(s.cluster_id, ''), s.region_id,
+			s.size_bytes, s.observed_at, s.unbilled_byte_nanoseconds
+		FROM metering.storage_projection_state s
+		JOIN input ON input.subject_type = s.subject_type AND input.subject_id = s.subject_id
+		FOR UPDATE OF s
+	`, payload)
+	if err != nil {
+		return nil, fmt.Errorf("query storage projection states: %w", err)
+	}
+	defer rows.Close()
+
+	states := make(map[string]*StorageProjectionState, len(keys))
+	for rows.Next() {
+		state := &StorageProjectionState{}
+		if err := rows.Scan(
+			&state.SubjectType, &state.SubjectID, &state.Product, &state.OwnerKind,
+			&state.TeamID, &state.UserID, &state.SandboxID, &state.VolumeID,
+			&state.SnapshotID, &state.ClusterID, &state.RegionID,
+			&state.SizeBytes, &state.ObservedAt, &state.UnbilledByteNanoseconds,
+		); err != nil {
+			return nil, fmt.Errorf("scan storage projection state: %w", err)
+		}
+		states[storageProjectionKeyString(state.SubjectType, state.SubjectID)] = state
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate storage projection states: %w", err)
+	}
+	return states, nil
 }
 
 func (r *Repository) upsertStorageProjectionState(ctx context.Context, db DB, state *StorageProjectionState) error {
@@ -728,6 +1059,117 @@ func (r *Repository) upsertStorageProjectionState(ctx context.Context, db DB, st
 	return nil
 }
 
+func (r *Repository) upsertStorageProjectionStates(ctx context.Context, db DB, states []*StorageProjectionState) error {
+	if len(states) == 0 {
+		return nil
+	}
+	rows := make([]storageProjectionStateRow, 0, len(states))
+	for _, state := range states {
+		if state == nil {
+			return fmt.Errorf("storage projection state is nil")
+		}
+		rows = append(rows, storageProjectionStateRow{
+			SubjectType:             state.SubjectType,
+			SubjectID:               state.SubjectID,
+			Product:                 state.Product,
+			OwnerKind:               state.OwnerKind,
+			TeamID:                  state.TeamID,
+			UserID:                  state.UserID,
+			SandboxID:               state.SandboxID,
+			VolumeID:                state.VolumeID,
+			SnapshotID:              state.SnapshotID,
+			ClusterID:               state.ClusterID,
+			RegionID:                state.RegionID,
+			SizeBytes:               state.SizeBytes,
+			ObservedAt:              state.ObservedAt,
+			UnbilledByteNanoseconds: state.UnbilledByteNanoseconds,
+		})
+	}
+	payload, err := json.Marshal(rows)
+	if err != nil {
+		return fmt.Errorf("marshal storage projection states: %w", err)
+	}
+	_, err = db.Exec(ctx, `
+		WITH input AS (
+			SELECT *
+			FROM jsonb_to_recordset($1::jsonb) AS state(
+				subject_type text,
+				subject_id text,
+				product text,
+				owner_kind text,
+				team_id text,
+				user_id text,
+				sandbox_id text,
+				volume_id text,
+				snapshot_id text,
+				cluster_id text,
+				region_id text,
+				size_bytes bigint,
+				observed_at timestamptz,
+				unbilled_byte_nanoseconds bigint
+			)
+		)
+		INSERT INTO metering.storage_projection_state (
+			subject_type, subject_id, product, owner_kind,
+			team_id, user_id, sandbox_id, volume_id, snapshot_id,
+			cluster_id, region_id, size_bytes, observed_at, unbilled_byte_nanoseconds
+		)
+		SELECT
+			subject_type, subject_id, product, owner_kind,
+			team_id, user_id, NULLIF(sandbox_id, ''), NULLIF(volume_id, ''), NULLIF(snapshot_id, ''),
+			NULLIF(cluster_id, ''), region_id, size_bytes, observed_at, unbilled_byte_nanoseconds
+		FROM input
+		ON CONFLICT (subject_type, subject_id) DO UPDATE
+		SET product = EXCLUDED.product,
+			owner_kind = EXCLUDED.owner_kind,
+			team_id = EXCLUDED.team_id,
+			user_id = EXCLUDED.user_id,
+			sandbox_id = EXCLUDED.sandbox_id,
+			volume_id = EXCLUDED.volume_id,
+			snapshot_id = EXCLUDED.snapshot_id,
+			cluster_id = EXCLUDED.cluster_id,
+			region_id = EXCLUDED.region_id,
+			size_bytes = EXCLUDED.size_bytes,
+			observed_at = EXCLUDED.observed_at,
+			unbilled_byte_nanoseconds = EXCLUDED.unbilled_byte_nanoseconds,
+			updated_at = NOW()
+	`, payload)
+	if err != nil {
+		return fmt.Errorf("upsert storage projection states: %w", err)
+	}
+	return nil
+}
+
+func (r *Repository) advanceStorageProjectionStates(ctx context.Context, db DB, observedAt time.Time, advances []storageProjectionAdvanceRow) error {
+	if len(advances) == 0 {
+		return nil
+	}
+	payload, err := json.Marshal(advances)
+	if err != nil {
+		return fmt.Errorf("marshal storage projection advances: %w", err)
+	}
+	if _, err := db.Exec(ctx, `
+		WITH input AS (
+			SELECT *
+			FROM jsonb_to_recordset($2::jsonb) AS advance(
+				subject_type text,
+				subject_id text,
+				unbilled_byte_nanoseconds bigint
+			)
+		)
+		UPDATE metering.storage_projection_state state
+		SET observed_at = $1,
+			unbilled_byte_nanoseconds = input.unbilled_byte_nanoseconds,
+			updated_at = NOW()
+		FROM input
+		WHERE state.subject_type = input.subject_type
+			AND state.subject_id = input.subject_id
+	`, observedAt, payload); err != nil {
+		return fmt.Errorf("advance storage projection states: %w", err)
+	}
+	return nil
+}
+
 func (r *Repository) deleteStorageProjectionState(ctx context.Context, db DB, subjectType, subjectID string) error {
 	_, err := db.Exec(ctx, `
 		DELETE FROM metering.storage_projection_state
@@ -737,6 +1179,91 @@ func (r *Repository) deleteStorageProjectionState(ctx context.Context, db DB, su
 		return fmt.Errorf("delete storage projection state: %w", err)
 	}
 	return nil
+}
+
+type usageEventRow struct {
+	EventID     string          `json:"event_id"`
+	Producer    string          `json:"producer"`
+	RegionID    string          `json:"region_id"`
+	EventType   string          `json:"event_type"`
+	SubjectType string          `json:"subject_type"`
+	SubjectID   string          `json:"subject_id"`
+	TeamID      string          `json:"team_id"`
+	UserID      string          `json:"user_id"`
+	SandboxID   string          `json:"sandbox_id"`
+	VolumeID    string          `json:"volume_id"`
+	SnapshotID  string          `json:"snapshot_id"`
+	TemplateID  string          `json:"template_id"`
+	ClusterID   string          `json:"cluster_id"`
+	OccurredAt  time.Time       `json:"occurred_at"`
+	Data        json.RawMessage `json:"data"`
+}
+
+type usageWindowRow struct {
+	WindowID    string          `json:"window_id"`
+	Producer    string          `json:"producer"`
+	RegionID    string          `json:"region_id"`
+	WindowType  string          `json:"window_type"`
+	SubjectType string          `json:"subject_type"`
+	SubjectID   string          `json:"subject_id"`
+	TeamID      string          `json:"team_id"`
+	UserID      string          `json:"user_id"`
+	SandboxID   string          `json:"sandbox_id"`
+	VolumeID    string          `json:"volume_id"`
+	SnapshotID  string          `json:"snapshot_id"`
+	TemplateID  string          `json:"template_id"`
+	ClusterID   string          `json:"cluster_id"`
+	WindowStart time.Time       `json:"window_start"`
+	WindowEnd   time.Time       `json:"window_end"`
+	Value       int64           `json:"value"`
+	Unit        string          `json:"unit"`
+	Data        json.RawMessage `json:"data"`
+}
+
+type storageProjectionKey struct {
+	SubjectType string `json:"subject_type"`
+	SubjectID   string `json:"subject_id"`
+}
+
+type storageProjectionStateRow struct {
+	SubjectType             string    `json:"subject_type"`
+	SubjectID               string    `json:"subject_id"`
+	Product                 string    `json:"product"`
+	OwnerKind               string    `json:"owner_kind"`
+	TeamID                  string    `json:"team_id"`
+	UserID                  string    `json:"user_id"`
+	SandboxID               string    `json:"sandbox_id"`
+	VolumeID                string    `json:"volume_id"`
+	SnapshotID              string    `json:"snapshot_id"`
+	ClusterID               string    `json:"cluster_id"`
+	RegionID                string    `json:"region_id"`
+	SizeBytes               int64     `json:"size_bytes"`
+	ObservedAt              time.Time `json:"observed_at"`
+	UnbilledByteNanoseconds int64     `json:"unbilled_byte_nanoseconds"`
+}
+
+type storageProjectionAdvanceRow struct {
+	SubjectType             string `json:"subject_type"`
+	SubjectID               string `json:"subject_id"`
+	UnbilledByteNanoseconds int64  `json:"unbilled_byte_nanoseconds"`
+}
+
+func storageProjectionKeysFromStates(states []*StorageProjectionState) []storageProjectionKey {
+	keys := make([]storageProjectionKey, 0, len(states))
+	for _, state := range states {
+		if state == nil {
+			continue
+		}
+		keys = append(keys, storageProjectionKey{
+			SubjectType: state.SubjectType,
+			SubjectID:   state.SubjectID,
+		})
+	}
+	return keys
+}
+
+func storageProjectionKeyString(subjectType, subjectID string) string {
+	return subjectType + "\x00" + subjectID
 }
 
 func storageWindowFromState(state *StorageProjectionState, end time.Time) *Window {
@@ -833,4 +1360,57 @@ func nullableString(value string) any {
 		return nil
 	}
 	return value
+}
+
+func validateEvent(event *Event) error {
+	if event == nil {
+		return fmt.Errorf("event is nil")
+	}
+	if event.EventID == "" {
+		return fmt.Errorf("event_id is required")
+	}
+	if event.Producer == "" {
+		return fmt.Errorf("producer is required")
+	}
+	if event.EventType == "" {
+		return fmt.Errorf("event_type is required")
+	}
+	if event.SubjectType == "" || event.SubjectID == "" {
+		return fmt.Errorf("subject_type and subject_id are required")
+	}
+	if event.OccurredAt.IsZero() {
+		return fmt.Errorf("occurred_at is required")
+	}
+	return nil
+}
+
+func validateWindow(window *Window) error {
+	if window == nil {
+		return fmt.Errorf("window is nil")
+	}
+	if window.WindowID == "" {
+		return fmt.Errorf("window_id is required")
+	}
+	if window.Producer == "" {
+		return fmt.Errorf("producer is required")
+	}
+	if window.WindowType == "" {
+		return fmt.Errorf("window_type is required")
+	}
+	if window.SubjectType == "" || window.SubjectID == "" {
+		return fmt.Errorf("subject_type and subject_id are required")
+	}
+	if window.WindowStart.IsZero() || window.WindowEnd.IsZero() {
+		return fmt.Errorf("window_start and window_end are required")
+	}
+	if window.WindowEnd.Before(window.WindowStart) {
+		return fmt.Errorf("window_end must be greater than or equal to window_start")
+	}
+	if window.Unit == "" {
+		return fmt.Errorf("unit is required")
+	}
+	if window.Value < 0 {
+		return fmt.Errorf("value must be non-negative")
+	}
+	return nil
 }

--- a/pkg/metering/repository.go
+++ b/pkg/metering/repository.go
@@ -296,7 +296,7 @@ func (r *Repository) appendWindows(ctx context.Context, db DB, windows []*Window
 	_, err = db.Exec(ctx, `
 		WITH input AS (
 			SELECT *
-			FROM jsonb_to_recordset($1::jsonb) AS window(
+			FROM jsonb_to_recordset($1::jsonb) AS usage_window(
 				window_id text,
 				producer text,
 				region_id text,

--- a/pkg/metering/repository.go
+++ b/pkg/metering/repository.go
@@ -639,6 +639,31 @@ func (r *Repository) ListEventsAfter(ctx context.Context, afterSequence int64, l
 	return events, nil
 }
 
+func (r *Repository) EventExists(ctx context.Context, eventID string) (bool, error) {
+	return r.eventExists(ctx, r.db, eventID)
+}
+
+func (r *Repository) EventExistsTx(ctx context.Context, tx pgx.Tx, eventID string) (bool, error) {
+	return r.eventExists(ctx, tx, eventID)
+}
+
+func (r *Repository) eventExists(ctx context.Context, db DB, eventID string) (bool, error) {
+	if eventID == "" {
+		return false, nil
+	}
+	var exists bool
+	if err := db.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM metering.usage_events
+			WHERE event_id = $1
+		)
+	`, eventID).Scan(&exists); err != nil {
+		return false, fmt.Errorf("query usage event existence: %w", err)
+	}
+	return exists, nil
+}
+
 func (r *Repository) ListWindowsAfter(ctx context.Context, afterSequence int64, limit int) ([]*Window, error) {
 	if limit <= 0 {
 		limit = 100

--- a/pkg/metering/repository_test.go
+++ b/pkg/metering/repository_test.go
@@ -56,6 +56,8 @@ func (r fakeRow) Scan(dest ...any) error {
 			*typed = r.values[i].(int)
 		case *string:
 			*typed = r.values[i].(string)
+		case *bool:
+			*typed = r.values[i].(bool)
 		case **time.Time:
 			*typed = r.values[i].(*time.Time)
 		case *time.Time:
@@ -259,6 +261,30 @@ func TestAppendEventsBatchesRows(t *testing.T) {
 	}
 	if execCalls != 1 {
 		t.Fatalf("Exec calls = %d, want 1", execCalls)
+	}
+}
+
+func TestEventExistsQueriesByEventID(t *testing.T) {
+	repo := &Repository{
+		db: &fakeDB{
+			queryRowFn: func(ctx context.Context, sql string, args ...any) pgx.Row {
+				if !strings.Contains(sql, "usage_events") || !strings.Contains(sql, "event_id = $1") {
+					t.Fatalf("unexpected SQL: %s", sql)
+				}
+				if args[0] != "evt-1" {
+					t.Fatalf("event id arg = %v, want evt-1", args[0])
+				}
+				return fakeRow{values: []any{true}}
+			},
+		},
+	}
+
+	exists, err := repo.EventExists(context.Background(), "evt-1")
+	if err != nil {
+		t.Fatalf("EventExists: %v", err)
+	}
+	if !exists {
+		t.Fatal("EventExists = false, want true")
 	}
 }
 

--- a/pkg/metering/repository_test.go
+++ b/pkg/metering/repository_test.go
@@ -299,6 +299,9 @@ func TestAppendWindowsBatchesRows(t *testing.T) {
 				if !strings.Contains(sql, "jsonb_to_recordset") || !strings.Contains(sql, "usage_windows") {
 					t.Fatalf("unexpected SQL: %s", sql)
 				}
+				if strings.Contains(sql, " AS window(") {
+					t.Fatalf("batch SQL uses reserved alias: %s", sql)
+				}
 				payload, ok := args[0].([]byte)
 				if !ok {
 					t.Fatalf("payload type = %T, want []byte", args[0])

--- a/pkg/metering/repository_test.go
+++ b/pkg/metering/repository_test.go
@@ -205,6 +205,127 @@ func TestAppendWindowUsesDefaultPayload(t *testing.T) {
 	}
 }
 
+func TestAppendEventsBatchesRows(t *testing.T) {
+	occurredAt := time.Date(2026, 3, 12, 12, 0, 0, 0, time.UTC)
+	execCalls := 0
+	repo := &Repository{
+		db: &fakeDB{
+			execFn: func(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+				execCalls++
+				if !strings.Contains(sql, "jsonb_to_recordset") || !strings.Contains(sql, "usage_events") {
+					t.Fatalf("unexpected SQL: %s", sql)
+				}
+				payload, ok := args[0].([]byte)
+				if !ok {
+					t.Fatalf("payload type = %T, want []byte", args[0])
+				}
+				var rows []usageEventRow
+				if err := json.Unmarshal(payload, &rows); err != nil {
+					t.Fatalf("unmarshal payload: %v", err)
+				}
+				if len(rows) != 2 {
+					t.Fatalf("row count = %d, want 2", len(rows))
+				}
+				for _, row := range rows {
+					if string(row.Data) != "{}" {
+						t.Fatalf("row data = %s, want {}", row.Data)
+					}
+				}
+				return pgconn.CommandTag{}, nil
+			},
+		},
+	}
+
+	err := repo.AppendEvents(context.Background(), []*Event{
+		{
+			EventID:     "evt-1",
+			Producer:    "manager.sandbox_lifecycle",
+			EventType:   EventTypeSandboxClaimed,
+			SubjectType: SubjectTypeSandbox,
+			SubjectID:   "sb-1",
+			OccurredAt:  occurredAt,
+		},
+		{
+			EventID:     "evt-2",
+			Producer:    "manager.sandbox_lifecycle",
+			EventType:   EventTypeSandboxTerminated,
+			SubjectType: SubjectTypeSandbox,
+			SubjectID:   "sb-2",
+			OccurredAt:  occurredAt,
+		},
+	})
+	if err != nil {
+		t.Fatalf("AppendEvents: %v", err)
+	}
+	if execCalls != 1 {
+		t.Fatalf("Exec calls = %d, want 1", execCalls)
+	}
+}
+
+func TestAppendWindowsBatchesRows(t *testing.T) {
+	windowStart := time.Date(2026, 3, 12, 12, 0, 0, 0, time.UTC)
+	windowEnd := windowStart.Add(5 * time.Minute)
+	execCalls := 0
+	repo := &Repository{
+		db: &fakeDB{
+			execFn: func(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+				execCalls++
+				if !strings.Contains(sql, "jsonb_to_recordset") || !strings.Contains(sql, "usage_windows") {
+					t.Fatalf("unexpected SQL: %s", sql)
+				}
+				payload, ok := args[0].([]byte)
+				if !ok {
+					t.Fatalf("payload type = %T, want []byte", args[0])
+				}
+				var rows []usageWindowRow
+				if err := json.Unmarshal(payload, &rows); err != nil {
+					t.Fatalf("unmarshal payload: %v", err)
+				}
+				if len(rows) != 2 {
+					t.Fatalf("row count = %d, want 2", len(rows))
+				}
+				for _, row := range rows {
+					if string(row.Data) != "{}" {
+						t.Fatalf("row data = %s, want {}", row.Data)
+					}
+				}
+				return pgconn.CommandTag{}, nil
+			},
+		},
+	}
+
+	err := repo.AppendWindows(context.Background(), []*Window{
+		{
+			WindowID:    "win-1",
+			Producer:    "manager.sandbox_lifecycle",
+			WindowType:  WindowTypeSandboxRuntimeMiBMilliseconds,
+			SubjectType: SubjectTypeSandbox,
+			SubjectID:   "sb-1",
+			WindowStart: windowStart,
+			WindowEnd:   windowEnd,
+			Value:       300_000,
+			Unit:        WindowUnitMiBMilliseconds,
+		},
+		{
+			WindowID:    "win-2",
+			Producer:    "manager.sandbox_lifecycle",
+			WindowType:  WindowTypeSandboxRuntimeMiBMilliseconds,
+			SubjectType: SubjectTypeSandbox,
+			SubjectID:   "sb-2",
+			WindowStart: windowStart,
+			WindowEnd:   windowEnd,
+			Value:       600_000,
+			Unit:        WindowUnitMiBMilliseconds,
+		},
+	})
+	if err != nil {
+		t.Fatalf("AppendWindows: %v", err)
+	}
+	if execCalls != 1 {
+		t.Fatalf("Exec calls = %d, want 1", execCalls)
+	}
+}
+
 func TestGetStatusUsesMinProducerWatermark(t *testing.T) {
 	earliest := time.Date(2026, 3, 12, 11, 0, 0, 0, time.UTC)
 	rowCall := 0

--- a/storage-proxy/pkg/coordinator/coordinator.go
+++ b/storage-proxy/pkg/coordinator/coordinator.go
@@ -769,29 +769,35 @@ func (c *Coordinator) updateHeartbeats(ctx context.Context) {
 	}
 	c.mu.RUnlock()
 
-	for _, volumeID := range volumes {
-		if err := c.repo.UpdateMountHeartbeat(ctx, volumeID, c.clusterID, c.podID); err != nil {
+	missing, err := c.repo.UpdateMountHeartbeats(ctx, volumes, c.clusterID, c.podID)
+	if err != nil {
+		if metrics != nil {
+			for range volumes {
+				metrics.CoordinatorHeartbeatErrors.Inc()
+			}
+		}
+		c.logger.WithError(err).Warn("Failed to update mount heartbeats")
+		return
+	}
+	if metrics != nil {
+		for i := 0; i < len(volumes)-len(missing); i++ {
+			metrics.CoordinatorHeartbeatsTotal.Inc()
+		}
+		for range missing {
+			metrics.CoordinatorHeartbeatErrors.Inc()
+		}
+	}
+	for _, volumeID := range missing {
+		c.logger.WithField("volume_id", volumeID).Debug("Mount record not found, re-registering")
+		c.mu.Lock()
+		delete(c.mountedVolumes, volumeID)
+		c.mu.Unlock()
+
+		if err := c.RegisterMount(ctx, volumeID, volume.MountOptions{}); err != nil {
 			if metrics != nil {
 				metrics.CoordinatorHeartbeatErrors.Inc()
 			}
-			// If update fails (e.g., mount record deleted), re-register
-			if strings.Contains(err.Error(), "not found") {
-				c.logger.WithField("volume_id", volumeID).Debug("Mount record not found, re-registering")
-				c.mu.Lock()
-				delete(c.mountedVolumes, volumeID)
-				c.mu.Unlock()
-
-				// Try to re-register
-				if err := c.RegisterMount(ctx, volumeID, volume.MountOptions{}); err != nil {
-					c.logger.WithError(err).WithField("volume_id", volumeID).Warn("Failed to re-register mount")
-				}
-			} else {
-				c.logger.WithError(err).WithField("volume_id", volumeID).Warn("Failed to update heartbeat")
-			}
-		} else {
-			if metrics != nil {
-				metrics.CoordinatorHeartbeatsTotal.Inc()
-			}
+			c.logger.WithError(err).WithField("volume_id", volumeID).Warn("Failed to re-register mount")
 		}
 	}
 }
@@ -821,7 +827,7 @@ func (c *Coordinator) runCleanup(ctx context.Context) {
 			if err != nil {
 				c.logger.WithError(err).Warn("Failed to list mounts for orphan cleanup")
 			} else {
-				var orphaned int64
+				orphanRefs := make([]db.MountPodRef, 0)
 				seenPods := make(map[string]struct{}, len(mounts))
 				for _, mount := range mounts {
 					podKey := mount.ClusterID + "/" + mount.PodID
@@ -832,16 +838,12 @@ func (c *Coordinator) runCleanup(ctx context.Context) {
 					if c.podExists(ctx, mount.PodID) {
 						continue
 					}
-					if err := c.repo.DeleteMountByPodID(ctx, mount.ClusterID, mount.PodID); err != nil {
-						c.logger.WithError(err).WithFields(logrus.Fields{
-							"cluster_id": mount.ClusterID,
-							"pod_id":     mount.PodID,
-						}).Warn("Failed to delete orphaned mounts by pod")
-						continue
-					}
-					orphaned++
+					orphanRefs = append(orphanRefs, db.MountPodRef{ClusterID: mount.ClusterID, PodID: mount.PodID})
 				}
-				if orphaned > 0 {
+				orphaned, err := c.repo.DeleteMountsByPodID(ctx, orphanRefs)
+				if err != nil {
+					c.logger.WithError(err).Warn("Failed to delete orphaned mounts by pod")
+				} else if orphaned > 0 {
 					c.logger.WithField("orphaned_pods", orphaned).Info("Cleaned up orphaned mounts by pod lookup")
 				}
 			}

--- a/storage-proxy/pkg/coordinator/coordinator_test.go
+++ b/storage-proxy/pkg/coordinator/coordinator_test.go
@@ -22,8 +22,11 @@ type MockRepository struct {
 	acquireMountFunc             func(ctx context.Context, mount *db.VolumeMount, heartbeatTimeout int) error
 	createMountFunc              func(ctx context.Context, mount *db.VolumeMount) error
 	updateMountHeartbeatFunc     func(ctx context.Context, volumeID, clusterID, podID string) error
+	updateMountHeartbeatsFunc    func(ctx context.Context, volumeIDs []string, clusterID, podID string) ([]string, error)
 	deleteMountFunc              func(ctx context.Context, volumeID, clusterID, podID string) error
+	deleteMountsFunc             func(ctx context.Context, volumeID string, mounts []*db.VolumeMount) error
 	deleteMountByPodIDFunc       func(ctx context.Context, clusterID, podID string) error
+	deleteMountsByPodIDFunc      func(ctx context.Context, refs []db.MountPodRef) (int64, error)
 	getActiveMountsFunc          func(ctx context.Context, volumeID string, timeout int) ([]*db.VolumeMount, error)
 	getAllMountsFunc             func(ctx context.Context) ([]*db.VolumeMount, error)
 	deleteStaleMountsFunc        func(ctx context.Context, timeout int) (int64, error)
@@ -59,9 +62,33 @@ func (m *MockRepository) UpdateMountHeartbeat(ctx context.Context, volumeID, clu
 	return nil
 }
 
+func (m *MockRepository) UpdateMountHeartbeats(ctx context.Context, volumeIDs []string, clusterID, podID string) ([]string, error) {
+	if m.updateMountHeartbeatsFunc != nil {
+		return m.updateMountHeartbeatsFunc(ctx, volumeIDs, clusterID, podID)
+	}
+	for _, volumeID := range volumeIDs {
+		if err := m.UpdateMountHeartbeat(ctx, volumeID, clusterID, podID); err != nil {
+			return nil, err
+		}
+	}
+	return nil, nil
+}
+
 func (m *MockRepository) DeleteMount(ctx context.Context, volumeID, clusterID, podID string) error {
 	if m.deleteMountFunc != nil {
 		return m.deleteMountFunc(ctx, volumeID, clusterID, podID)
+	}
+	return nil
+}
+
+func (m *MockRepository) DeleteMounts(ctx context.Context, volumeID string, mounts []*db.VolumeMount) error {
+	if m.deleteMountsFunc != nil {
+		return m.deleteMountsFunc(ctx, volumeID, mounts)
+	}
+	for _, mount := range mounts {
+		if err := m.DeleteMount(ctx, volumeID, mount.ClusterID, mount.PodID); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -71,6 +98,20 @@ func (m *MockRepository) DeleteMountByPodID(ctx context.Context, clusterID, podI
 		return m.deleteMountByPodIDFunc(ctx, clusterID, podID)
 	}
 	return nil
+}
+
+func (m *MockRepository) DeleteMountsByPodID(ctx context.Context, refs []db.MountPodRef) (int64, error) {
+	if m.deleteMountsByPodIDFunc != nil {
+		return m.deleteMountsByPodIDFunc(ctx, refs)
+	}
+	var deleted int64
+	for _, ref := range refs {
+		if err := m.DeleteMountByPodID(ctx, ref.ClusterID, ref.PodID); err != nil {
+			return deleted, err
+		}
+		deleted++
+	}
+	return deleted, nil
 }
 
 func (m *MockRepository) GetActiveMounts(ctx context.Context, volumeID string, timeout int) ([]*db.VolumeMount, error) {

--- a/storage-proxy/pkg/db/repository.go
+++ b/storage-proxy/pkg/db/repository.go
@@ -24,8 +24,11 @@ type CoordinatorRepository interface {
 	AcquireMount(ctx context.Context, mount *VolumeMount, heartbeatTimeout int) error
 	CreateMount(ctx context.Context, mount *VolumeMount) error
 	UpdateMountHeartbeat(ctx context.Context, volumeID, clusterID, podID string) error
+	UpdateMountHeartbeats(ctx context.Context, volumeIDs []string, clusterID, podID string) ([]string, error)
 	DeleteMount(ctx context.Context, volumeID, clusterID, podID string) error
+	DeleteMounts(ctx context.Context, volumeID string, mounts []*VolumeMount) error
 	DeleteMountByPodID(ctx context.Context, clusterID, podID string) error
+	DeleteMountsByPodID(ctx context.Context, refs []MountPodRef) (int64, error)
 	GetActiveMounts(ctx context.Context, volumeID string, heartbeatTimeout int) ([]*VolumeMount, error)
 	GetAllMounts(ctx context.Context) ([]*VolumeMount, error)
 	DeleteStaleMounts(ctx context.Context, heartbeatTimeout int) (int64, error)
@@ -41,6 +44,11 @@ type CoordinatorRepository interface {
 
 type mountOptionsEnvelope struct {
 	AccessMode string `json:"access_mode"`
+}
+
+type MountPodRef struct {
+	ClusterID string `json:"cluster_id"`
+	PodID     string `json:"pod_id"`
 }
 
 func normalizeMountAccessMode(value string) string {
@@ -782,6 +790,70 @@ func (r *Repository) UpdateMountHeartbeat(ctx context.Context, volumeID, cluster
 	return nil
 }
 
+func (r *Repository) UpdateMountHeartbeats(ctx context.Context, volumeIDs []string, clusterID, podID string) ([]string, error) {
+	if len(volumeIDs) == 0 {
+		return nil, nil
+	}
+	uniqueVolumeIDs := make([]string, 0, len(volumeIDs))
+	seen := make(map[string]struct{}, len(volumeIDs))
+	for _, volumeID := range volumeIDs {
+		volumeID = strings.TrimSpace(volumeID)
+		if volumeID == "" {
+			continue
+		}
+		if _, ok := seen[volumeID]; ok {
+			continue
+		}
+		seen[volumeID] = struct{}{}
+		uniqueVolumeIDs = append(uniqueVolumeIDs, volumeID)
+	}
+	if len(uniqueVolumeIDs) == 0 {
+		return nil, nil
+	}
+	payload, err := json.Marshal(uniqueVolumeIDs)
+	if err != nil {
+		return nil, fmt.Errorf("marshal mount heartbeat volume ids: %w", err)
+	}
+	rows, err := r.pool.Query(ctx, `
+		WITH input AS (
+			SELECT value AS volume_id
+			FROM jsonb_array_elements_text($1::jsonb)
+		),
+		updated AS (
+			UPDATE sandbox_volume_mounts m
+			SET last_heartbeat = NOW()
+			FROM input
+			WHERE m.volume_id = input.volume_id
+				AND m.cluster_id = $2
+				AND m.pod_id = $3
+			RETURNING m.volume_id
+		)
+		SELECT input.volume_id, updated.volume_id IS NOT NULL
+		FROM input
+		LEFT JOIN updated ON updated.volume_id = input.volume_id
+	`, payload, clusterID, podID)
+	if err != nil {
+		return nil, fmt.Errorf("update mount heartbeats: %w", err)
+	}
+	defer rows.Close()
+
+	var missing []string
+	for rows.Next() {
+		var volumeID string
+		var updated bool
+		if err := rows.Scan(&volumeID, &updated); err != nil {
+			return nil, fmt.Errorf("scan mount heartbeat result: %w", err)
+		}
+		if !updated {
+			missing = append(missing, volumeID)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate mount heartbeat results: %w", err)
+	}
+	return missing, nil
+}
+
 // DeleteMount deletes a mount record
 func (r *Repository) DeleteMount(ctx context.Context, volumeID, clusterID, podID string) error {
 	_, err := r.pool.Exec(ctx, `
@@ -796,6 +868,53 @@ func (r *Repository) DeleteMount(ctx context.Context, volumeID, clusterID, podID
 	return nil
 }
 
+func (r *Repository) DeleteMounts(ctx context.Context, volumeID string, mounts []*VolumeMount) error {
+	if len(mounts) == 0 {
+		return nil
+	}
+	refs := make([]MountPodRef, 0, len(mounts))
+	seen := make(map[string]struct{}, len(mounts))
+	for _, mount := range mounts {
+		if mount == nil {
+			continue
+		}
+		ref := MountPodRef{
+			ClusterID: strings.TrimSpace(mount.ClusterID),
+			PodID:     strings.TrimSpace(mount.PodID),
+		}
+		if ref.ClusterID == "" || ref.PodID == "" {
+			continue
+		}
+		key := ref.ClusterID + "\x00" + ref.PodID
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		refs = append(refs, ref)
+	}
+	if len(refs) == 0 {
+		return nil
+	}
+	payload, err := json.Marshal(refs)
+	if err != nil {
+		return fmt.Errorf("marshal mount delete refs: %w", err)
+	}
+	if _, err := r.pool.Exec(ctx, `
+		WITH input AS (
+			SELECT *
+			FROM jsonb_to_recordset($2::jsonb) AS ref(cluster_id text, pod_id text)
+		)
+		DELETE FROM sandbox_volume_mounts m
+		USING input
+		WHERE m.volume_id = $1
+			AND m.cluster_id = input.cluster_id
+			AND m.pod_id = input.pod_id
+	`, volumeID, payload); err != nil {
+		return fmt.Errorf("delete mounts: %w", err)
+	}
+	return nil
+}
+
 // DeleteMountByPodID deletes all mount records for a pod in a cluster.
 func (r *Repository) DeleteMountByPodID(ctx context.Context, clusterID, podID string) error {
 	_, err := r.pool.Exec(ctx, `
@@ -806,6 +925,48 @@ func (r *Repository) DeleteMountByPodID(ctx context.Context, clusterID, podID st
 		return fmt.Errorf("delete mount by pod id: %w", err)
 	}
 	return nil
+}
+
+func (r *Repository) DeleteMountsByPodID(ctx context.Context, refs []MountPodRef) (int64, error) {
+	if len(refs) == 0 {
+		return 0, nil
+	}
+	uniqueRefs := make([]MountPodRef, 0, len(refs))
+	seen := make(map[string]struct{}, len(refs))
+	for _, ref := range refs {
+		ref.ClusterID = strings.TrimSpace(ref.ClusterID)
+		ref.PodID = strings.TrimSpace(ref.PodID)
+		if ref.ClusterID == "" || ref.PodID == "" {
+			continue
+		}
+		key := ref.ClusterID + "\x00" + ref.PodID
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		uniqueRefs = append(uniqueRefs, ref)
+	}
+	if len(uniqueRefs) == 0 {
+		return 0, nil
+	}
+	payload, err := json.Marshal(uniqueRefs)
+	if err != nil {
+		return 0, fmt.Errorf("marshal pod mount delete refs: %w", err)
+	}
+	tag, err := r.pool.Exec(ctx, `
+		WITH input AS (
+			SELECT *
+			FROM jsonb_to_recordset($1::jsonb) AS ref(cluster_id text, pod_id text)
+		)
+		DELETE FROM sandbox_volume_mounts m
+		USING input
+		WHERE m.cluster_id = input.cluster_id
+			AND m.pod_id = input.pod_id
+	`, payload)
+	if err != nil {
+		return 0, fmt.Errorf("delete mounts by pod id: %w", err)
+	}
+	return tag.RowsAffected(), nil
 }
 
 // GetActiveMounts retrieves active mounts for a volume (heartbeat within threshold)

--- a/storage-proxy/pkg/http/handlers_metering_test.go
+++ b/storage-proxy/pkg/http/handlers_metering_test.go
@@ -125,6 +125,18 @@ func (r *fakeHTTPRepo) DeleteMount(ctx context.Context, volumeID, clusterID, pod
 	return nil
 }
 
+func (r *fakeHTTPRepo) DeleteMounts(ctx context.Context, volumeID string, mounts []*db.VolumeMount) error {
+	for _, mount := range mounts {
+		if mount == nil {
+			continue
+		}
+		if err := r.DeleteMount(ctx, volumeID, mount.ClusterID, mount.PodID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (r *fakeHTTPRepo) DeleteSandboxVolumeTx(ctx context.Context, tx pgx.Tx, id string) error {
 	delete(r.volumes, id)
 	delete(r.owners, id)

--- a/storage-proxy/pkg/http/handlers_sandboxvolume.go
+++ b/storage-proxy/pkg/http/handlers_sandboxvolume.go
@@ -365,16 +365,13 @@ func (s *Server) deleteSandboxVolume(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if len(mounts) > 0 && force {
-		for _, mount := range mounts {
-			if err := s.repo.DeleteMount(r.Context(), id, mount.ClusterID, mount.PodID); err != nil {
-				s.logger.WithError(err).WithFields(map[string]any{
-					"volume_id":  id,
-					"cluster_id": mount.ClusterID,
-					"pod_id":     mount.PodID,
-				}).Error("Failed to delete mount during force delete")
-				_ = spec.WriteError(w, http.StatusInternalServerError, spec.CodeInternal, "failed to cleanup mount records")
-				return
-			}
+		if err := s.repo.DeleteMounts(r.Context(), id, mounts); err != nil {
+			s.logger.WithError(err).WithFields(map[string]any{
+				"volume_id": id,
+				"mounts":    len(mounts),
+			}).Error("Failed to delete mounts during force delete")
+			_ = spec.WriteError(w, http.StatusInternalServerError, spec.CodeInternal, "failed to cleanup mount records")
+			return
 		}
 	}
 
@@ -437,10 +434,8 @@ func (s *Server) deleteSandboxVolumeRecord(ctx context.Context, id string, force
 		return nil, errVolumeHasActiveMounts
 	}
 	if len(mounts) > 0 && force {
-		for _, mount := range mounts {
-			if err := s.repo.DeleteMount(ctx, id, mount.ClusterID, mount.PodID); err != nil {
-				return nil, fmt.Errorf("cleanup mount records: %w", err)
-			}
+		if err := s.repo.DeleteMounts(ctx, id, mounts); err != nil {
+			return nil, fmt.Errorf("cleanup mount records: %w", err)
 		}
 	}
 	if err := s.repo.WithTx(ctx, func(tx pgx.Tx) error {

--- a/storage-proxy/pkg/http/server.go
+++ b/storage-proxy/pkg/http/server.go
@@ -40,6 +40,7 @@ type volumeRepository interface {
 	GetOwnedSandboxVolumeByOwner(ctx context.Context, clusterID, sandboxID, purpose string) (*db.OwnedSandboxVolume, error)
 	GetActiveMounts(ctx context.Context, volumeID string, heartbeatTimeout int) ([]*db.VolumeMount, error)
 	DeleteMount(ctx context.Context, volumeID, clusterID, podID string) error
+	DeleteMounts(ctx context.Context, volumeID string, mounts []*db.VolumeMount) error
 	DeleteSandboxVolumeTx(ctx context.Context, tx pgx.Tx, id string) error
 	MarkOwnedSandboxVolumesForCleanup(ctx context.Context, clusterID, sandboxID, reason string) (int64, error)
 	MarkOwnedSandboxVolumeCleanupAttempt(ctx context.Context, volumeID string, cleanupErr error) error


### PR DESCRIPTION
## Summary
- batch credential source lookups and credential binding inserts for sandbox network credential bindings
- batch metering event/window inserts, storage observation projection updates, netd flush windows, and rootfs storage observations
- batch storage-proxy mount heartbeats, force-delete mount cleanup, and orphan pod mount cleanup
- remove now-unneeded single-item interface methods from internal fakes/interfaces while keeping public repository compatibility methods still used elsewhere

## Testing
- `go test ./manager/pkg/metering ./storage-proxy/pkg/db ./storage-proxy/pkg/http ./storage-proxy/pkg/coordinator ./pkg/egressauth ./manager/pkg/service ./manager/pkg/http ./pkg/metering ./netd/pkg/metering`
- `go test ./ctld/internal/ctld/portal ./manager/pkg/controller`
- `go test -buildvcs=false $(go list -buildvcs=false ./... | grep -v '/tests/e2e/scenarios/single-cluster$')`
- `go test ./...` reaches the e2e single-cluster suite and fails because `kind` is not installed in the current PATH
