### PR TITLE
Persist durable sandbox pod metadata

### DIFF
--- a/manager/pkg/service/migrations/00009_add_sandbox_runtime_metadata.sql
+++ b/manager/pkg/service/migrations/00009_add_sandbox_runtime_metadata.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+
+ALTER TABLE manager.sandboxes
+    ADD COLUMN IF NOT EXISTS webhook_state_volume_id TEXT NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS owner_kind TEXT NOT NULL DEFAULT '';
+
+-- +goose Down
+
+ALTER TABLE manager.sandboxes
+    DROP COLUMN IF EXISTS owner_kind,
+    DROP COLUMN IF EXISTS webhook_state_volume_id;

--- a/manager/pkg/service/sandbox_lifecycle_controller_test.go
+++ b/manager/pkg/service/sandbox_lifecycle_controller_test.go
@@ -571,6 +571,42 @@ func TestSystemVolumeReconcilerKeepsActiveOwnedVolume(t *testing.T) {
 	}
 }
 
+func TestSystemVolumeReconcilerKeepsPausedOwnedVolume(t *testing.T) {
+	volumeClient := &recordingSystemVolumeClient{
+		list: []SandboxSystemVolume{{
+			VolumeID:       "volume-a",
+			TeamID:         "team-a",
+			UserID:         "user-a",
+			OwnerSandboxID: "sandbox-a",
+			OwnerClusterID: "cluster-a",
+			Purpose:        "webhook-state",
+		}},
+	}
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	svc := &SandboxService{
+		podLister:           corelisters.NewPodLister(indexer),
+		webhookStateVolumes: volumeClient,
+		sandboxStore: &memorySandboxStore{records: map[string]*SandboxRecord{
+			"sandbox-a": {
+				ID:                   "sandbox-a",
+				TeamID:               "team-a",
+				UserID:               "user-a",
+				Status:               SandboxStatusPaused,
+				WebhookStateVolumeID: "volume-a",
+			},
+		}},
+		clock:  systemTime{},
+		logger: zap.NewNop(),
+	}
+
+	if err := svc.reconcileSystemVolumes(context.Background()); err != nil {
+		t.Fatalf("reconcileSystemVolumes() error = %v", err)
+	}
+	if len(volumeClient.marked) != 0 {
+		t.Fatalf("marked = %#v, want none", volumeClient.marked)
+	}
+}
+
 func TestSystemVolumeReconcilerDeletesCleanupRequestedVolume(t *testing.T) {
 	cleanupRequestedAt := time.Now().Add(-time.Minute)
 	volumeClient := &recordingSystemVolumeClient{

--- a/manager/pkg/service/sandbox_runtime_identity_test.go
+++ b/manager/pkg/service/sandbox_runtime_identity_test.go
@@ -253,7 +253,7 @@ func (s *memorySandboxStore) setSandboxStatus(sandboxID, status string) {
 	}
 }
 
-func (t memorySandboxStoreTx) SaveRuntime(_ context.Context, sandboxID, namespace, podName, status string, generation int64, expiresAt, hardExpiresAt time.Time) error {
+func (t memorySandboxStoreTx) SaveRuntime(_ context.Context, sandboxID, namespace, podName, status string, generation int64, expiresAt, hardExpiresAt time.Time, metadata SandboxRuntimeMetadata) error {
 	t.store.mu.Lock()
 	defer t.store.mu.Unlock()
 	record := t.store.records[sandboxID]
@@ -266,6 +266,12 @@ func (t memorySandboxStoreTx) SaveRuntime(_ context.Context, sandboxID, namespac
 	record.RuntimeGeneration = generation
 	record.ExpiresAt = expiresAt
 	record.HardExpiresAt = hardExpiresAt
+	if metadata.WebhookStateVolumeID != "" {
+		record.WebhookStateVolumeID = metadata.WebhookStateVolumeID
+	}
+	if metadata.OwnerKind != "" {
+		record.OwnerKind = metadata.OwnerKind
+	}
 	t.store.saves++
 	return nil
 }
@@ -1088,10 +1094,11 @@ func TestResumePausedSandboxRuntimeRejectsHardExpiredRecord(t *testing.T) {
 func TestTerminatePausedSandboxRecordRunsPersistentCleanup(t *testing.T) {
 	store := &memorySandboxStore{records: map[string]*SandboxRecord{
 		"sandbox-a": {
-			ID:     "sandbox-a",
-			TeamID: "team-a",
-			UserID: "user-a",
-			Status: SandboxStatusPaused,
+			ID:                   "sandbox-a",
+			TeamID:               "team-a",
+			UserID:               "user-a",
+			Status:               SandboxStatusPaused,
+			WebhookStateVolumeID: "volume-a",
 			Config: SandboxConfig{Webhook: &WebhookConfig{
 				URL:    "https://example.test/webhook",
 				Secret: "secret",
@@ -1122,6 +1129,9 @@ func TestTerminatePausedSandboxRecordRunsPersistentCleanup(t *testing.T) {
 	}
 	if len(emitter.calls) != 1 {
 		t.Fatalf("webhook calls = %d, want 1", len(emitter.calls))
+	}
+	if emitter.calls[0].WebhookStateVolumeID != "volume-a" {
+		t.Fatalf("webhook state volume = %q, want volume-a", emitter.calls[0].WebhookStateVolumeID)
 	}
 	if len(volumes.marked) != 1 || volumes.marked[0] != "sandbox-a:sandbox_deleted" {
 		t.Fatalf("marked volumes = %#v, want sandbox-a:sandbox_deleted", volumes.marked)

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -55,6 +55,8 @@ type ClaimRequest struct {
 	RuntimeGeneration int64 `json:"-"`
 	// HardExpiresAt preserves the absolute hard deadline when recreating a paused sandbox.
 	HardExpiresAt time.Time `json:"-"`
+	// WebhookStateVolumeID preserves the manager-owned webhook state volume across pod recreation.
+	WebhookStateVolumeID string `json:"-"`
 }
 
 type ClaimMount struct {
@@ -662,24 +664,26 @@ func sandboxRecordForClaimedPod(s *SandboxService, pod *corev1.Pod, template *v1
 	cfg := parseSandboxConfig(pod.Annotations[controller.AnnotationConfig])
 	mounts := parseClaimMounts(pod.Annotations[controller.AnnotationMounts])
 	return &SandboxRecord{
-		ID:                  sandboxID,
-		TeamID:              req.TeamID,
-		UserID:              req.UserID,
-		TemplateID:          controller.TemplateLogicalID(template),
-		TemplateName:        template.Name,
-		TemplateNamespace:   template.Namespace,
-		ClusterID:           naming.ClusterIDOrDefault(template.Spec.ClusterId),
-		Status:              s.podToSandboxStatus(pod),
-		Config:              cfg,
-		Mounts:              mounts,
-		TemplateSpec:        template.Spec,
-		CurrentPodName:      pod.Name,
-		CurrentPodNamespace: pod.Namespace,
-		RuntimeGeneration:   runtimeGenerationFromPod(pod),
-		ClaimedAt:           parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationClaimedAt),
-		ExpiresAt:           parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationExpiresAt),
-		HardExpiresAt:       parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationHardExpiresAt),
-		CreatedAt:           s.clock.Now(),
+		ID:                   sandboxID,
+		TeamID:               req.TeamID,
+		UserID:               req.UserID,
+		TemplateID:           controller.TemplateLogicalID(template),
+		TemplateName:         template.Name,
+		TemplateNamespace:    template.Namespace,
+		ClusterID:            naming.ClusterIDOrDefault(template.Spec.ClusterId),
+		Status:               s.podToSandboxStatus(pod),
+		Config:               cfg,
+		Mounts:               mounts,
+		TemplateSpec:         template.Spec,
+		CurrentPodName:       pod.Name,
+		CurrentPodNamespace:  pod.Namespace,
+		RuntimeGeneration:    runtimeGenerationFromPod(pod),
+		ClaimedAt:            parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationClaimedAt),
+		ExpiresAt:            parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationExpiresAt),
+		HardExpiresAt:        parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationHardExpiresAt),
+		WebhookStateVolumeID: webhookStateVolumeIDFromPod(pod),
+		OwnerKind:            ownerKindFromPod(pod),
+		CreatedAt:            s.clock.Now(),
 	}
 }
 
@@ -1183,7 +1187,7 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 			return fmt.Errorf("prepare webhook state volume: %w", err)
 		}
 		rollbackStateVolume := func() {
-			if stateVolume == nil {
+			if stateVolume == nil || !stateVolume.Created {
 				return
 			}
 			cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -1421,7 +1425,7 @@ func (s *SandboxService) createNewPod(ctx context.Context, template *v1alpha1.Sa
 		return nil, fmt.Errorf("prepare webhook state volume: %w", err)
 	}
 	rollbackStateVolume := func() {
-		if stateVolume == nil {
+		if stateVolume == nil || !stateVolume.Created {
 			return
 		}
 		cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/manager/pkg/service/sandbox_service_lifecycle.go
+++ b/manager/pkg/service/sandbox_service_lifecycle.go
@@ -984,6 +984,35 @@ func (s *SandboxService) now() time.Time {
 	return time.Now()
 }
 
+func webhookStateVolumeIDFromPod(pod *corev1.Pod) string {
+	if pod == nil || pod.Annotations == nil {
+		return ""
+	}
+	return strings.TrimSpace(pod.Annotations[controller.AnnotationWebhookStateVolumeID])
+}
+
+func ownerKindFromPod(pod *corev1.Pod) string {
+	if pod == nil {
+		return ""
+	}
+	if pod.Labels != nil {
+		if ownerKind := strings.TrimSpace(pod.Labels[controller.LabelOwnerKind]); ownerKind != "" {
+			return ownerKind
+		}
+	}
+	if pod.Annotations != nil {
+		return strings.TrimSpace(pod.Annotations[controller.AnnotationOwnerKind])
+	}
+	return ""
+}
+
+func sandboxRuntimeMetadataFromPod(pod *corev1.Pod) SandboxRuntimeMetadata {
+	return SandboxRuntimeMetadata{
+		WebhookStateVolumeID: webhookStateVolumeIDFromPod(pod),
+		OwnerKind:            ownerKindFromPod(pod),
+	}
+}
+
 func (s *SandboxService) persistUpdatedSandboxPod(ctx context.Context, pod *corev1.Pod) error {
 	if s == nil || s.sandboxStore == nil || pod == nil {
 		return nil
@@ -1013,24 +1042,26 @@ func (s *SandboxService) persistUpdatedSandboxPod(ctx context.Context, pod *core
 		return nil
 	}
 	record := &SandboxRecord{
-		ID:                  sandboxID,
-		TeamID:              pod.Annotations[controller.AnnotationTeamID],
-		UserID:              pod.Annotations[controller.AnnotationUserID],
-		TemplateID:          sandboxTemplateIDFromLabels(pod.Labels),
-		TemplateName:        template.Name,
-		TemplateNamespace:   template.Namespace,
-		ClusterID:           naming.ClusterIDOrDefault(template.Spec.ClusterId),
-		Status:              s.podToSandboxStatus(pod),
-		Config:              parseSandboxConfig(pod.Annotations[controller.AnnotationConfig]),
-		Mounts:              parseClaimMounts(pod.Annotations[controller.AnnotationMounts]),
-		TemplateSpec:        template.Spec,
-		CurrentPodName:      pod.Name,
-		CurrentPodNamespace: pod.Namespace,
-		RuntimeGeneration:   runtimeGenerationFromPod(pod),
-		ClaimedAt:           parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationClaimedAt),
-		ExpiresAt:           parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationExpiresAt),
-		HardExpiresAt:       parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationHardExpiresAt),
-		CreatedAt:           pod.CreationTimestamp.Time,
+		ID:                   sandboxID,
+		TeamID:               pod.Annotations[controller.AnnotationTeamID],
+		UserID:               pod.Annotations[controller.AnnotationUserID],
+		TemplateID:           sandboxTemplateIDFromLabels(pod.Labels),
+		TemplateName:         template.Name,
+		TemplateNamespace:    template.Namespace,
+		ClusterID:            naming.ClusterIDOrDefault(template.Spec.ClusterId),
+		Status:               s.podToSandboxStatus(pod),
+		Config:               parseSandboxConfig(pod.Annotations[controller.AnnotationConfig]),
+		Mounts:               parseClaimMounts(pod.Annotations[controller.AnnotationMounts]),
+		TemplateSpec:         template.Spec,
+		CurrentPodName:       pod.Name,
+		CurrentPodNamespace:  pod.Namespace,
+		RuntimeGeneration:    runtimeGenerationFromPod(pod),
+		ClaimedAt:            parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationClaimedAt),
+		ExpiresAt:            parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationExpiresAt),
+		HardExpiresAt:        parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationHardExpiresAt),
+		WebhookStateVolumeID: webhookStateVolumeIDFromPod(pod),
+		OwnerKind:            ownerKindFromPod(pod),
+		CreatedAt:            pod.CreationTimestamp.Time,
 	}
 	return s.sandboxStore.UpsertSandbox(ctx, record)
 }
@@ -1206,12 +1237,13 @@ func sandboxLifecycleInfoFromRecord(record *SandboxRecord) SandboxLifecycleInfo 
 		return SandboxLifecycleInfo{}
 	}
 	info := SandboxLifecycleInfo{
-		Namespace:         record.CurrentPodNamespace,
-		PodName:           record.CurrentPodName,
-		SandboxID:         record.ID,
-		TeamID:            record.TeamID,
-		UserID:            record.UserID,
-		RuntimeGeneration: record.RuntimeGeneration,
+		Namespace:            record.CurrentPodNamespace,
+		PodName:              record.CurrentPodName,
+		SandboxID:            record.ID,
+		TeamID:               record.TeamID,
+		UserID:               record.UserID,
+		WebhookStateVolumeID: record.WebhookStateVolumeID,
+		RuntimeGeneration:    record.RuntimeGeneration,
 	}
 	if record.Config.Webhook != nil {
 		info.WebhookURL = strings.TrimSpace(record.Config.Webhook.URL)
@@ -1319,6 +1351,7 @@ func (s *SandboxService) RefreshSandbox(ctx context.Context, sandboxID string, r
 	var ttlDuration time.Duration
 	var newExpiresAt time.Time
 	var newHardExpiresAt time.Time
+	var updatedPod *corev1.Pod
 
 	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		current, err := s.k8sClient.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
@@ -1384,11 +1417,14 @@ func (s *SandboxService) RefreshSandbox(ctx context.Context, sandboxID string, r
 		}
 
 		// Apply the update
-		_, err = s.k8sClient.CoreV1().Pods(pod.Namespace).Update(ctx, podCopy, metav1.UpdateOptions{})
+		updatedPod, err = s.k8sClient.CoreV1().Pods(pod.Namespace).Update(ctx, podCopy, metav1.UpdateOptions{})
 		return err
 	})
 	if err != nil {
 		return nil, fmt.Errorf("update pod: %w", err)
+	}
+	if err := s.persistUpdatedSandboxPod(ctx, updatedPod); err != nil {
+		return nil, fmt.Errorf("persist sandbox record: %w", err)
 	}
 
 	s.logger.Info("Sandbox TTL refreshed successfully",

--- a/manager/pkg/service/sandbox_service_network.go
+++ b/manager/pkg/service/sandbox_service_network.go
@@ -737,6 +737,9 @@ func (s *SandboxService) UpdateNetworkPolicy(
 	if err := s.applyNetworkProvider(ctx, updatedPod, teamID, policySpecFromState(networkState)); err != nil {
 		return nil, fmt.Errorf("apply network policy: %w", err)
 	}
+	if err := s.persistUpdatedSandboxPod(ctx, updatedPod); err != nil {
+		return nil, fmt.Errorf("persist sandbox record: %w", err)
+	}
 
 	return sandboxNetworkPolicyFromState(networkState), nil
 }

--- a/manager/pkg/service/sandbox_service_network_test.go
+++ b/manager/pkg/service/sandbox_service_network_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/network"
 	"github.com/sandbox0-ai/sandbox0/pkg/egressauth"
+	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -545,6 +546,8 @@ func TestTemplateCredentialBindingsUsesNestedNetworkBindings(t *testing.T) {
 func TestUpdateNetworkPolicyStoresBindingsOutsidePodConfig(t *testing.T) {
 	ctx := context.Background()
 	pod := testSandboxNetworkPod()
+	pod.Labels[controller.LabelTemplateID] = "default"
+	pod.Labels[controller.LabelTemplateLogicalID] = "default"
 	store := newMemoryBindingStore()
 	store.addStaticHeadersSource("team-1", "example-ref", 3, 1, map[string]string{"token": "stored"})
 	provider := &assertingNetworkProvider{
@@ -562,6 +565,13 @@ func TestUpdateNetworkPolicyStoresBindingsOutsidePodConfig(t *testing.T) {
 	}
 
 	svc, client, indexer := newSandboxServiceForNetworkTests(t, pod, store, provider)
+	sandboxStore := &memorySandboxStore{records: map[string]*SandboxRecord{}}
+	templateNamespace, err := naming.TemplateNamespaceForTeam("team-1")
+	require.NoError(t, err)
+	svc.sandboxStore = sandboxStore
+	svc.templateLister = staticTemplateLister{templates: []*v1alpha1.SandboxTemplate{{
+		ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: templateNamespace},
+	}}}
 
 	updated, err := svc.UpdateNetworkPolicy(ctx, pod.Name, testNetworkPolicy("example-ref", "Bearer stored"))
 	require.NoError(t, err)
@@ -581,6 +591,13 @@ func TestUpdateNetworkPolicyStoresBindingsOutsidePodConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, effective.CredentialBindings, 1)
 	assert.Equal(t, "example-ref", effective.CredentialBindings[0].Ref)
+
+	record, err := sandboxStore.GetSandbox(ctx, pod.Name)
+	require.NoError(t, err)
+	require.NotNil(t, record)
+	require.NotNil(t, record.Config.Network)
+	assert.Equal(t, v1alpha1.NetworkModeBlockAll, record.Config.Network.Mode)
+	assert.Nil(t, record.Config.Network.CredentialBindings)
 }
 
 func cloneCredentialSource(in *egressauth.CredentialSource) *egressauth.CredentialSource {

--- a/manager/pkg/service/sandbox_service_restore.go
+++ b/manager/pkg/service/sandbox_service_restore.go
@@ -94,7 +94,7 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 				}
 				pod = existing
 				record = nil
-				return tx.SaveRuntime(lockCtx, sandboxID, existing.Namespace, existing.Name, s.podToSandboxStatus(existing), runtimeGenerationFromPod(existing), parseRFC3339AnnotationTime(existing.Annotations, controller.AnnotationExpiresAt), parseRFC3339AnnotationTime(existing.Annotations, controller.AnnotationHardExpiresAt))
+				return tx.SaveRuntime(lockCtx, sandboxID, existing.Namespace, existing.Name, s.podToSandboxStatus(existing), runtimeGenerationFromPod(existing), parseRFC3339AnnotationTime(existing.Annotations, controller.AnnotationExpiresAt), parseRFC3339AnnotationTime(existing.Annotations, controller.AnnotationHardExpiresAt), sandboxRuntimeMetadataFromPod(existing))
 			}
 			if getErr != nil && !k8serrors.IsNotFound(getErr) {
 				return fmt.Errorf("get current runtime pod: %w", getErr)
@@ -117,14 +117,18 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 			generation := locked.RuntimeGeneration + 1
 			record = cloneSandboxRecordForLifecycle(locked)
 			req = &ClaimRequest{
-				TeamID:            locked.TeamID,
-				UserID:            locked.UserID,
-				Template:          locked.TemplateID,
-				Config:            &locked.Config,
-				Mounts:            locked.Mounts,
-				SandboxID:         locked.ID,
-				RuntimeGeneration: generation,
-				HardExpiresAt:     locked.HardExpiresAt,
+				TeamID:               locked.TeamID,
+				UserID:               locked.UserID,
+				Template:             locked.TemplateID,
+				Config:               &locked.Config,
+				Mounts:               locked.Mounts,
+				SandboxID:            locked.ID,
+				RuntimeGeneration:    generation,
+				HardExpiresAt:        locked.HardExpiresAt,
+				WebhookStateVolumeID: locked.WebhookStateVolumeID,
+			}
+			if strings.TrimSpace(locked.OwnerKind) != "" {
+				req.Metadata = &ClaimMetadata{OwnerKind: locked.OwnerKind}
 			}
 			restoreNeeded = true
 			txn = &SandboxLifecycleTxn{
@@ -262,7 +266,7 @@ func (s *SandboxService) commitResumedSandboxRuntime(ctx context.Context, pod *c
 		if podGeneration != txn.ToGeneration {
 			return fmt.Errorf("resume lifecycle generation changed: txn=%d pod=%d", txn.ToGeneration, podGeneration)
 		}
-		if err := tx.SaveRuntime(lockCtx, record.ID, pod.Namespace, pod.Name, s.podToSandboxStatus(pod), txn.ToGeneration, parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationExpiresAt), parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationHardExpiresAt)); err != nil {
+		if err := tx.SaveRuntime(lockCtx, record.ID, pod.Namespace, pod.Name, s.podToSandboxStatus(pod), txn.ToGeneration, parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationExpiresAt), parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationHardExpiresAt), sandboxRuntimeMetadataFromPod(pod)); err != nil {
 			return err
 		}
 		return tx.CommitLifecycleTxn(lockCtx, txn.ID, "")
@@ -364,13 +368,18 @@ func (s *SandboxService) finishRestoredSandboxRuntime(ctx context.Context, pod *
 		s.refreshSandboxProbeConditionsAsync(pod)
 	}
 	req := &ClaimRequest{
-		TeamID:            record.TeamID,
-		UserID:            record.UserID,
-		Template:          record.TemplateID,
-		Config:            &record.Config,
-		Mounts:            record.Mounts,
-		SandboxID:         record.ID,
-		RuntimeGeneration: record.RuntimeGeneration + 1,
+		TeamID:               record.TeamID,
+		UserID:               record.UserID,
+		Template:             record.TemplateID,
+		Config:               &record.Config,
+		Mounts:               record.Mounts,
+		SandboxID:            record.ID,
+		RuntimeGeneration:    record.RuntimeGeneration + 1,
+		HardExpiresAt:        record.HardExpiresAt,
+		WebhookStateVolumeID: record.WebhookStateVolumeID,
+	}
+	if strings.TrimSpace(record.OwnerKind) != "" {
+		req.Metadata = &ClaimMetadata{OwnerKind: record.OwnerKind}
 	}
 	rootFSState, err := s.latestRootFSState(ctx, record.ID)
 	if err != nil {

--- a/manager/pkg/service/sandbox_service_rootfs.go
+++ b/manager/pkg/service/sandbox_service_rootfs.go
@@ -325,7 +325,7 @@ func (s *SandboxService) saveRestoredRuntimePod(ctx context.Context, pod *corev1
 		return fmt.Errorf("sandbox_id is required")
 	}
 	return s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, _ *SandboxRecord) error {
-		return tx.SaveRuntime(lockCtx, sandboxID, pod.Namespace, pod.Name, status, runtimeGenerationFromPod(pod), parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationExpiresAt), parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationHardExpiresAt))
+		return tx.SaveRuntime(lockCtx, sandboxID, pod.Namespace, pod.Name, status, runtimeGenerationFromPod(pod), parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationExpiresAt), parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationHardExpiresAt), sandboxRuntimeMetadataFromPod(pod))
 	})
 }
 

--- a/manager/pkg/service/sandbox_service_ttl_test.go
+++ b/manager/pkg/service/sandbox_service_ttl_test.go
@@ -12,7 +12,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
+	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -207,6 +209,61 @@ func TestPersistUpdatedSandboxPodDoesNotOverwritePausedRecord(t *testing.T) {
 	require.NotNil(t, record.Config.TTL)
 	assert.Equal(t, SandboxStatusPaused, record.Status)
 	assert.Equal(t, int32(300), *record.Config.TTL)
+}
+
+func TestPersistUpdatedSandboxPodStoresRuntimeMetadata(t *testing.T) {
+	pod := testSandboxPod()
+	pod.Labels[controller.LabelTemplateID] = "default"
+	pod.Labels[controller.LabelTemplateLogicalID] = "default"
+	pod.Labels[controller.LabelOwnerKind] = "managed-agent"
+	pod.Annotations[controller.AnnotationOwnerKind] = "managed-agent"
+	pod.Annotations[controller.AnnotationConfig] = `{"ttl":300}`
+	pod.Annotations[controller.AnnotationWebhookStateVolumeID] = "webhook-volume-1"
+
+	svc, _ := newSandboxServiceForTTLTests(t, pod, 0)
+	store := &memorySandboxStore{records: map[string]*SandboxRecord{}}
+	templateNamespace, err := naming.TemplateNamespaceForTeam("team-1")
+	require.NoError(t, err)
+	svc.sandboxStore = store
+	svc.templateLister = staticTemplateLister{templates: []*v1alpha1.SandboxTemplate{{
+		ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: templateNamespace},
+	}}}
+
+	require.NoError(t, svc.persistUpdatedSandboxPod(context.Background(), pod))
+	record, err := store.GetSandbox(context.Background(), "sandbox-1")
+	require.NoError(t, err)
+	require.NotNil(t, record)
+	assert.Equal(t, "webhook-volume-1", record.WebhookStateVolumeID)
+	assert.Equal(t, "managed-agent", record.OwnerKind)
+}
+
+func TestRefreshSandboxPersistsExpirationRecord(t *testing.T) {
+	pod := testSandboxPod()
+	pod.Labels[controller.LabelTemplateID] = "default"
+	pod.Labels[controller.LabelTemplateLogicalID] = "default"
+	pod.Annotations[controller.AnnotationConfig] = `{"ttl":60,"hard_ttl":120}`
+	pod.Annotations[controller.AnnotationExpiresAt] = "2026-03-07T12:01:00Z"
+	pod.Annotations[controller.AnnotationHardExpiresAt] = "2026-03-07T12:02:00Z"
+
+	svc, _ := newSandboxServiceForTTLTests(t, pod, 0)
+	store := &memorySandboxStore{records: map[string]*SandboxRecord{}}
+	templateNamespace, err := naming.TemplateNamespaceForTeam("team-1")
+	require.NoError(t, err)
+	svc.sandboxStore = store
+	svc.templateLister = staticTemplateLister{templates: []*v1alpha1.SandboxTemplate{{
+		ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: templateNamespace},
+	}}}
+
+	resp, err := svc.RefreshSandbox(context.Background(), "sandbox-1", &RefreshRequest{Duration: 90})
+	require.NoError(t, err)
+
+	record, err := store.GetSandbox(context.Background(), "sandbox-1")
+	require.NoError(t, err)
+	require.NotNil(t, record)
+	assert.Equal(t, resp.ExpiresAt, record.ExpiresAt)
+	assert.Equal(t, resp.HardExpiresAt, record.HardExpiresAt)
+	assert.Equal(t, time.Date(2026, time.March, 7, 12, 1, 30, 0, time.UTC), record.ExpiresAt)
+	assert.Equal(t, time.Date(2026, time.March, 7, 12, 2, 0, 0, time.UTC), record.HardExpiresAt)
 }
 
 func TestUpdateSandboxEnvVarsUpdatesProcdAndConfig(t *testing.T) {

--- a/manager/pkg/service/sandbox_store.go
+++ b/manager/pkg/service/sandbox_store.go
@@ -26,27 +26,29 @@ const (
 
 // SandboxRecord is the durable sandbox identity and configuration.
 type SandboxRecord struct {
-	ID                  string
-	TeamID              string
-	UserID              string
-	TemplateID          string
-	TemplateName        string
-	TemplateNamespace   string
-	ClusterID           string
-	Status              string
-	Config              SandboxConfig
-	Mounts              []ClaimMount
-	TemplateSpec        v1alpha1.SandboxTemplateSpec
-	CurrentPodName      string
-	CurrentPodNamespace string
-	RuntimeGeneration   int64
-	LifecycleEpoch      int64
-	ClaimedAt           time.Time
-	ExpiresAt           time.Time
-	HardExpiresAt       time.Time
-	DeletedAt           time.Time
-	CreatedAt           time.Time
-	UpdatedAt           time.Time
+	ID                   string
+	TeamID               string
+	UserID               string
+	TemplateID           string
+	TemplateName         string
+	TemplateNamespace    string
+	ClusterID            string
+	Status               string
+	Config               SandboxConfig
+	Mounts               []ClaimMount
+	TemplateSpec         v1alpha1.SandboxTemplateSpec
+	CurrentPodName       string
+	CurrentPodNamespace  string
+	RuntimeGeneration    int64
+	LifecycleEpoch       int64
+	WebhookStateVolumeID string
+	OwnerKind            string
+	ClaimedAt            time.Time
+	ExpiresAt            time.Time
+	HardExpiresAt        time.Time
+	DeletedAt            time.Time
+	CreatedAt            time.Time
+	UpdatedAt            time.Time
 }
 
 // SandboxRootFSState is manager-internal metadata for one persisted sandbox
@@ -139,6 +141,12 @@ type SandboxLifecycleTxn struct {
 	AbortedAt           time.Time
 }
 
+// SandboxRuntimeMetadata is durable metadata projected onto a runtime pod.
+type SandboxRuntimeMetadata struct {
+	WebhookStateVolumeID string
+	OwnerKind            string
+}
+
 // SandboxStore persists sandbox identities independently of runtime pods.
 type SandboxStore interface {
 	UpsertSandbox(ctx context.Context, record *SandboxRecord) error
@@ -155,7 +163,7 @@ type SandboxStore interface {
 
 // SandboxStoreTx is a locked sandbox store transaction.
 type SandboxStoreTx interface {
-	SaveRuntime(ctx context.Context, sandboxID, namespace, podName, status string, generation int64, expiresAt, hardExpiresAt time.Time) error
+	SaveRuntime(ctx context.Context, sandboxID, namespace, podName, status string, generation int64, expiresAt, hardExpiresAt time.Time, metadata SandboxRuntimeMetadata) error
 	MarkRuntimePaused(ctx context.Context, sandboxID string, generation int64, pausedAt time.Time) error
 	SaveRootFSState(ctx context.Context, state *SandboxRootFSState) error
 	GetActiveLifecycleTxn(ctx context.Context, sandboxID string) (*SandboxLifecycleTxn, error)
@@ -218,9 +226,10 @@ func upsertSandboxRecord(ctx context.Context, exec rootFSStateExecutor, record *
 			sandbox_id, team_id, user_id, template_id, template_name, template_namespace,
 			cluster_id, status, config, mounts, template_spec,
 			current_pod_name, current_pod_namespace, runtime_generation, lifecycle_epoch,
+			webhook_state_volume_id, owner_kind,
 			claimed_at, expires_at, hard_expires_at, deleted_at, created_at, updated_at
 		)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, COALESCE($20, NOW()), NOW())
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, COALESCE($22, NOW()), NOW())
 		ON CONFLICT (sandbox_id) DO UPDATE SET
 			team_id = EXCLUDED.team_id,
 			user_id = EXCLUDED.user_id,
@@ -236,6 +245,8 @@ func upsertSandboxRecord(ctx context.Context, exec rootFSStateExecutor, record *
 			current_pod_namespace = EXCLUDED.current_pod_namespace,
 			runtime_generation = EXCLUDED.runtime_generation,
 			lifecycle_epoch = GREATEST(manager.sandboxes.lifecycle_epoch, EXCLUDED.lifecycle_epoch),
+			webhook_state_volume_id = EXCLUDED.webhook_state_volume_id,
+			owner_kind = EXCLUDED.owner_kind,
 			claimed_at = EXCLUDED.claimed_at,
 			expires_at = EXCLUDED.expires_at,
 			hard_expires_at = EXCLUDED.hard_expires_at,
@@ -244,6 +255,7 @@ func upsertSandboxRecord(ctx context.Context, exec rootFSStateExecutor, record *
 	`, record.ID, record.TeamID, record.UserID, record.TemplateID, record.TemplateName, record.TemplateNamespace,
 		record.ClusterID, record.Status, configJSON, mountsJSON, specJSON,
 		record.CurrentPodName, record.CurrentPodNamespace, record.RuntimeGeneration, record.LifecycleEpoch,
+		strings.TrimSpace(record.WebhookStateVolumeID), strings.TrimSpace(record.OwnerKind),
 		nullableTime(record.ClaimedAt), nullableTime(record.ExpiresAt), nullableTime(record.HardExpiresAt), nullableTime(record.DeletedAt), nullableTime(record.CreatedAt))
 	if err != nil {
 		return fmt.Errorf("upsert sandbox: %w", err)
@@ -517,7 +529,7 @@ type sandboxStoreTx struct {
 	tx pgx.Tx
 }
 
-func (t sandboxStoreTx) SaveRuntime(ctx context.Context, sandboxID, namespace, podName, status string, generation int64, expiresAt, hardExpiresAt time.Time) error {
+func (t sandboxStoreTx) SaveRuntime(ctx context.Context, sandboxID, namespace, podName, status string, generation int64, expiresAt, hardExpiresAt time.Time, metadata SandboxRuntimeMetadata) error {
 	tag, err := t.tx.Exec(ctx, `
 		UPDATE manager.sandboxes
 		SET status = $2,
@@ -526,11 +538,13 @@ func (t sandboxStoreTx) SaveRuntime(ctx context.Context, sandboxID, namespace, p
 			runtime_generation = $5,
 			expires_at = $6,
 			hard_expires_at = $7,
+			webhook_state_volume_id = COALESCE(NULLIF($8, ''), webhook_state_volume_id),
+			owner_kind = COALESCE(NULLIF($9, ''), owner_kind),
 			deleted_at = NULL,
 			updated_at = NOW()
 		WHERE sandbox_id = $1
 			AND deleted_at IS NULL
-	`, sandboxID, status, namespace, podName, generation, nullableTime(expiresAt), nullableTime(hardExpiresAt))
+	`, sandboxID, status, namespace, podName, generation, nullableTime(expiresAt), nullableTime(hardExpiresAt), strings.TrimSpace(metadata.WebhookStateVolumeID), strings.TrimSpace(metadata.OwnerKind))
 	if err != nil {
 		return fmt.Errorf("save sandbox runtime: %w", err)
 	}
@@ -779,6 +793,7 @@ func sandboxRecordSelectSQL() string {
 		SELECT sandbox_id, team_id, user_id, template_id, template_name, template_namespace,
 			cluster_id, status, config, mounts, template_spec,
 			current_pod_name, current_pod_namespace, runtime_generation, lifecycle_epoch,
+			webhook_state_volume_id, owner_kind,
 			claimed_at, expires_at, hard_expires_at, deleted_at, created_at, updated_at
 		FROM manager.sandboxes`
 }
@@ -1126,6 +1141,7 @@ func scanSandboxRecordInto(scanner sandboxRecordScanner) (*SandboxRecord, error)
 		&record.ID, &record.TeamID, &record.UserID, &record.TemplateID, &record.TemplateName, &record.TemplateNamespace,
 		&record.ClusterID, &record.Status, &configJSON, &mountsJSON, &specJSON,
 		&record.CurrentPodName, &record.CurrentPodNamespace, &record.RuntimeGeneration, &record.LifecycleEpoch,
+		&record.WebhookStateVolumeID, &record.OwnerKind,
 		&claimedAt, &expiresAt, &hardExpiresAt, &deletedAt, &record.CreatedAt, &record.UpdatedAt,
 	); err != nil {
 		return nil, err

--- a/manager/pkg/service/sandbox_system_volume_reconciler.go
+++ b/manager/pkg/service/sandbox_system_volume_reconciler.go
@@ -76,6 +76,21 @@ func (s *SandboxService) reconcileSystemVolumes(ctx context.Context) error {
 		if s.systemVolumeOwnerPodActive(sandboxID) {
 			continue
 		}
+		exists, err := s.systemVolumeOwnerSandboxExists(ctx, sandboxID)
+		if err != nil {
+			if s.logger != nil {
+				s.logger.Warn("Failed to load system volume owner sandbox",
+					zap.String("sandboxID", sandboxID),
+					zap.String("volumeID", volume.VolumeID),
+					zap.String("purpose", volume.Purpose),
+					zap.Error(err),
+				)
+			}
+			continue
+		}
+		if exists {
+			continue
+		}
 		if err := s.webhookStateVolumes.MarkSandboxForCleanup(ctx, volume.TeamID, volume.UserID, sandboxID, "orphaned_sandbox"); err != nil {
 			if s.logger != nil {
 				s.logger.Warn("Failed to mark orphaned system volume for cleanup",
@@ -109,4 +124,15 @@ func (s *SandboxService) systemVolumeOwnerPodActive(sandboxID string) bool {
 		}
 	}
 	return false
+}
+
+func (s *SandboxService) systemVolumeOwnerSandboxExists(ctx context.Context, sandboxID string) (bool, error) {
+	if s == nil || s.sandboxStore == nil || sandboxID == "" {
+		return false, nil
+	}
+	record, err := s.sandboxStore.GetSandbox(ctx, sandboxID)
+	if err != nil {
+		return false, err
+	}
+	return record != nil && record.Status != SandboxStatusDeleted && record.DeletedAt.IsZero(), nil
 }

--- a/manager/pkg/service/sandbox_webhook_state.go
+++ b/manager/pkg/service/sandbox_webhook_state.go
@@ -388,11 +388,15 @@ func (c *StorageProxyVolumeClient) generateToken(teamID, userID, sandboxID strin
 
 type webhookStateVolume struct {
 	VolumeID string
+	Created  bool
 }
 
 func (s *SandboxService) prepareWebhookStateVolume(ctx context.Context, req *ClaimRequest, sandboxID string) (*webhookStateVolume, error) {
 	if s == nil || s.getWebhookInfo(req) == nil {
 		return nil, nil
+	}
+	if existing := strings.TrimSpace(req.WebhookStateVolumeID); existing != "" {
+		return &webhookStateVolume{VolumeID: existing}, nil
 	}
 	if s.webhookStateVolumes == nil {
 		return nil, fmt.Errorf("webhook state volume client is not configured")
@@ -403,6 +407,7 @@ func (s *SandboxService) prepareWebhookStateVolume(ctx context.Context, req *Cla
 	}
 	return &webhookStateVolume{
 		VolumeID: volumeID,
+		Created:  true,
 	}, nil
 }
 

--- a/manager/pkg/service/sandbox_webhook_state_test.go
+++ b/manager/pkg/service/sandbox_webhook_state_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -43,6 +44,32 @@ func TestStorageProxyVolumeClientDefaultsClusterID(t *testing.T) {
 	}
 	if gotClusterID != naming.DefaultClusterID {
 		t.Fatalf("clusterID = %q, want %q", gotClusterID, naming.DefaultClusterID)
+	}
+}
+
+func TestPrepareWebhookStateVolumeReusesDurableVolume(t *testing.T) {
+	volumeClient := &recordingSystemVolumeClient{}
+	svc := &SandboxService{webhookStateVolumes: volumeClient}
+
+	volume, err := svc.prepareWebhookStateVolume(context.Background(), &ClaimRequest{
+		TeamID:               "team-1",
+		UserID:               "user-1",
+		WebhookStateVolumeID: "volume-existing",
+		Config: &SandboxConfig{Webhook: &WebhookConfig{
+			URL: "https://example.test/webhook",
+		}},
+	}, "sandbox-1")
+	if err != nil {
+		t.Fatalf("prepareWebhookStateVolume() error = %v", err)
+	}
+	if volume == nil || volume.VolumeID != "volume-existing" {
+		t.Fatalf("volume = %#v, want volume-existing", volume)
+	}
+	if volume.Created {
+		t.Fatal("reused webhook state volume was marked created")
+	}
+	if len(volumeClient.created) != 0 {
+		t.Fatalf("created volumes = %#v, want none", volumeClient.created)
 	}
 }
 

--- a/tests/integration/internal/tests/manager/api_test.go
+++ b/tests/integration/internal/tests/manager/api_test.go
@@ -1168,7 +1168,7 @@ type memorySandboxStoreTxForManagerIntegration struct {
 	store *memorySandboxStoreForManagerIntegration
 }
 
-func (t memorySandboxStoreTxForManagerIntegration) SaveRuntime(_ context.Context, sandboxID, namespace, podName, status string, generation int64, expiresAt, hardExpiresAt time.Time) error {
+func (t memorySandboxStoreTxForManagerIntegration) SaveRuntime(_ context.Context, sandboxID, namespace, podName, status string, generation int64, expiresAt, hardExpiresAt time.Time, metadata service.SandboxRuntimeMetadata) error {
 	record := t.store.records[sandboxID]
 	if record == nil || !record.DeletedAt.IsZero() {
 		return service.ErrSandboxRecordNotFound
@@ -1179,6 +1179,12 @@ func (t memorySandboxStoreTxForManagerIntegration) SaveRuntime(_ context.Context
 	record.RuntimeGeneration = generation
 	record.ExpiresAt = expiresAt
 	record.HardExpiresAt = hardExpiresAt
+	if metadata.WebhookStateVolumeID != "" {
+		record.WebhookStateVolumeID = metadata.WebhookStateVolumeID
+	}
+	if metadata.OwnerKind != "" {
+		record.OwnerKind = metadata.OwnerKind
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- add durable sandbox store fields for webhook state volume id and owner kind
- persist active sandbox config/TTL/network updates back into the sandbox store
- keep manager-owned system volumes while the owning sandbox record is still alive, including paused sandboxes
- reuse durable webhook state volumes across pod recreation and avoid deleting reused volumes on claim rollback

## Tests
- go test ./manager/pkg/service
- go test ./manager/pkg/... ./tests/integration/internal/tests/manager

Note: local `go test ./...` was not used as a passing signal because this checkout lacks generated `storage-proxy/proto/fs` packages and local `kind`, which also triggers e2e setup failures.