### PR TITLE
Add procd image volume startup option

### DIFF
--- a/.github/actions/prepare-infra/action.yml
+++ b/.github/actions/prepare-infra/action.yml
@@ -73,7 +73,9 @@ runs:
       shell: bash
       run: |
         kind load docker-image sandbox0ai/infra:latest --name ${{ inputs.kind-cluster-name }}
+        kind load docker-image sandbox0ai/infra:latest-procd-bin --name ${{ inputs.kind-cluster-name }}
         docker image rm sandbox0ai/infra:latest 2>/dev/null || true
+        docker image rm sandbox0ai/infra:latest-procd-bin 2>/dev/null || true
         docker builder prune -af || true
         echo "=== df -h after infra image load ==="
         df -h

--- a/.github/workflows/publish-infra-images.yml
+++ b/.github/workflows/publish-infra-images.yml
@@ -79,11 +79,72 @@ jobs:
           TAG: ${{ steps.docker_tag.outputs.tag }}
         run: docker push "${TAG}"
 
+  publish-procd-bin-image:
+    name: Publish procd bin image (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Free runner space
+        uses: ./.github/actions/free-runner-space
+
+      - name: Restore shared infra build cache
+        id: infra-build-cache
+        uses: ./.github/actions/restore-infra-build-cache
+        with:
+          cache-key-suffix: ${{ matrix.arch }}-procd-bin
+
+      - name: Setup protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ github.token }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build local binaries
+        run: make build-local-all
+
+      - name: Save shared infra build cache
+        uses: ./.github/actions/save-infra-build-cache
+        with:
+          cache-key-suffix: ${{ matrix.arch }}-procd-bin
+          cache-hit: ${{ steps.infra-build-cache.outputs.cache-hit }}
+
+      - name: Determine arch procd bin image tag
+        id: docker_tag
+        run: |
+          VERSION="${{ inputs.version }}"
+          echo "tag=${IMAGE_REPO}:${VERSION}-${{ matrix.arch }}-procd-bin" >> "$GITHUB_OUTPUT"
+
+      - name: Build procd binary image with Dockerfile.local
+        env:
+          TAG: ${{ steps.docker_tag.outputs.tag }}
+        run: docker build --target procd-bin -t "${TAG}" -f Dockerfile.local .
+
+      - name: Push procd binary image
+        env:
+          TAG: ${{ steps.docker_tag.outputs.tag }}
+        run: docker push "${TAG}"
+
   publish-image-manifest:
     name: Publish infra image manifest
     runs-on: ubuntu-latest
     needs:
       - publish-image
+      - publish-procd-bin-image
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -99,15 +160,27 @@ jobs:
           VERSION="${{ inputs.version }}"
           AMD64_IMAGE="${IMAGE_REPO}:${VERSION}-amd64"
           ARM64_IMAGE="${IMAGE_REPO}:${VERSION}-arm64"
+          AMD64_PROCD_BIN_IMAGE="${IMAGE_REPO}:${VERSION}-amd64-procd-bin"
+          ARM64_PROCD_BIN_IMAGE="${IMAGE_REPO}:${VERSION}-arm64-procd-bin"
 
           docker buildx imagetools create \
             -t "${IMAGE_REPO}:${VERSION}" \
             "${AMD64_IMAGE}" \
             "${ARM64_IMAGE}"
 
+          docker buildx imagetools create \
+            -t "${IMAGE_REPO}:${VERSION}-procd-bin" \
+            "${AMD64_PROCD_BIN_IMAGE}" \
+            "${ARM64_PROCD_BIN_IMAGE}"
+
           if [[ "${{ inputs.publish_latest }}" == "true" ]]; then
             docker buildx imagetools create \
               -t "${IMAGE_REPO}:latest" \
               "${AMD64_IMAGE}" \
               "${ARM64_IMAGE}"
+
+            docker buildx imagetools create \
+              -t "${IMAGE_REPO}:latest-procd-bin" \
+              "${AMD64_PROCD_BIN_IMAGE}" \
+              "${ARM64_PROCD_BIN_IMAGE}"
           fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,11 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 GOOS="${BUILD_GOOS}" GOARCH="${BUILD_GOARCH}" go build -o /out/ctld ./ctld/cmd/ctld && \
     CGO_ENABLED=0 GOOS="${BUILD_GOOS}" GOARCH="${BUILD_GOARCH}" go build -o /out/netd ./netd/cmd/netd
 
+FROM scratch AS procd-bin
+
+COPY --from=builder /out/procd /usr/local/bin/procd
+COPY --from=builder /out/python-runner /usr/local/bin/python-runner
+
 FROM alpine:3.19
 
 RUN apk add --no-cache ca-certificates tzdata zstd-libs lz4-libs iptables ipset nftables iproute2

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,3 +1,8 @@
+FROM scratch AS procd-bin
+
+COPY bin/procd /usr/local/bin/procd
+COPY bin/python-runner /usr/local/bin/python-runner
+
 FROM debian:bookworm-slim
 
 # Install runtime dependencies

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ S0FS_POSIX_CI_FSSTRESS_PROCESSES ?= 4
 # Default version
 VERSION ?= latest
 TAG ?= $(VERSION)
+PROCD_BIN_TAG ?= $(TAG)-procd-bin
 
 # Colors for output
 YELLOW := \033[1;33m
@@ -94,11 +95,13 @@ build: manifests proto apispec
 docker-build:
 	@printf "$(GREEN)Docker building unified infra image...$(RESET)\n"
 	docker build -t sandbox0ai/infra:$(TAG) -f Dockerfile .
+	docker build --target procd-bin -t sandbox0ai/infra:$(PROCD_BIN_TAG) -f Dockerfile .
 	#docker buildx build --platform=linux/amd64 -t sandbox0ai/infra:$(TAG) -f Dockerfile .
 
 docker-push:
 	@printf "$(GREEN)Docker pushing unified infra image...$(RESET)\n"
 	docker push sandbox0ai/infra:$(TAG)
+	docker push sandbox0ai/infra:$(PROCD_BIN_TAG)
 
 build-local-all: manifests proto apispec
 	@for service in $(SERVICES); do \
@@ -108,6 +111,7 @@ build-local-all: manifests proto apispec
 docker-build-local: build-local-all
 	@printf "$(GREEN)Docker building with local binaries...$(RESET)\n"
 	docker build -t sandbox0ai/infra:$(TAG) -f Dockerfile.local .
+	docker build --target procd-bin -t sandbox0ai/infra:$(PROCD_BIN_TAG) -f Dockerfile.local .
 
 test:
 	@service="$(filter-out build test test-all lint tidy vendor clean helm-update,$(MAKECMDGOALS))"; \
@@ -184,6 +188,10 @@ test-e2e-load-images:
 		echo "sandbox0ai/infra:$(TAG) is missing; run make docker-build-local first"; \
 		exit 1; \
 	fi
+	@if ! docker image inspect sandbox0ai/infra:$(PROCD_BIN_TAG) >/dev/null 2>&1; then \
+		echo "sandbox0ai/infra:$(PROCD_BIN_TAG) is missing; run make docker-build-local first"; \
+		exit 1; \
+	fi
 	@if ! docker image inspect "$(E2E_SSH_FIXTURE_IMAGE)" >/dev/null 2>&1; then \
 		printf "$(YELLOW)Pulling SSH fixture source $(E2E_SSH_FIXTURE_SOURCE_IMAGE)...$(RESET)\n"; \
 		docker pull --platform "$(E2E_IMAGE_PLATFORM)" "$(E2E_SSH_FIXTURE_SOURCE_IMAGE)" || exit 1; \
@@ -197,6 +205,7 @@ test-e2e-load-images:
 		done; \
 	}; \
 	load_image sandbox0ai/infra:$(TAG); \
+	load_image sandbox0ai/infra:$(PROCD_BIN_TAG); \
 	for image in $(E2E_DEPENDENCY_IMAGES); do \
 		if ! docker image inspect "$$image" >/dev/null 2>&1; then \
 			printf "$(YELLOW)Pulling $$image for $(E2E_IMAGE_PLATFORM)...$(RESET)\n"; \

--- a/docs/self-hosted/configuration/page.mdx
+++ b/docs/self-hosted/configuration/page.mdx
@@ -184,6 +184,24 @@ This field only controls the `runtimeClassName` written onto sandbox Pods. The n
 
 `infra-operator` does not install node runtime handlers. It does not install `runsc`, write `/etc/containerd/config.toml`, restart containerd, or create a `gvisor-rootfs` handler. Do that through your node image, node bootstrap automation, or a dedicated privileged node setup process before scheduling sandbox workloads there.
 
+### Procd Binary Image Volume
+
+Sandbox Pods mount Sandbox0 `procd` binaries from a small OCI artifact image by default. This avoids a per-Pod init container on the sandbox startup path.
+
+When `procdBinImageRef` is omitted, `infra-operator` derives it from the deployed infra image tag by appending `-procd-bin`. For example, `sandbox0ai/infra:v0.8.0` uses `sandbox0ai/infra:v0.8.0-procd-bin`.
+
+Set `procdBinImageRef` only when you publish the procd binary artifact image separately:
+
+```yaml
+spec:
+    services:
+        manager:
+            config:
+                procdBinImageRef: registry.example.com/sandbox0/procd-bin:v0.8.0
+```
+
+Kubernetes image volume support is part of the Sandbox0 cluster baseline. Unsupported runtimes fail sandbox Pod startup instead of falling back inside the Pod.
+
 ### Sandbox Memory Limits
 
 Sandbox claims and runtime updates can set `config.resources.memory`. The minimum accepted value is `128Mi`. The platform maximum defaults to `32Gi`.
@@ -468,6 +486,7 @@ Examples:
 - `services.manager.config.autoscaler.*` tunes pool scale behavior
 - `services.manager.config.k8sClientQps` and `k8sClientBurst` tune the manager Kubernetes client token bucket rate limit; defaults are `50` and `100`
 - `services.manager.config.sandboxMaxMemory` caps per-sandbox memory overrides; the default is `32Gi`
+- `services.manager.config.procdBinImageRef` overrides the derived procd artifact image used by sandbox Pods
 - `services.manager.config.allowColdStartWithoutReadyDataPlane` lets cold claims create Pending pods for external node autoscaler scale-from-zero deployments; keep it disabled unless the cluster autoscaler can provision matching sandbox nodes
 - `services.storageProxy.config.filesystem*` tunes filesystem behavior; `services.manager.config.procdConfig.volume*` tunes mounted volume cache sizing
 - `services.storageProxy.config.s0fsSegmentTargetSize` sets the target S0FS segment size for materialized volume data; the default is `4Mi`

--- a/infra-operator/api/config/manager.go
+++ b/infra-operator/api/config/manager.go
@@ -19,8 +19,10 @@ type ManagerConfig struct {
 	// +kubebuilder:default=8080
 	HTTPPort int `yaml:"http_port" json:"httpPort"`
 
-	// manager docker image, used to copy the procd binary to sandbox pod
+	// ManagerImage is the manager service image.
 	ManagerImage string `yaml:"manager_image" json:"-"`
+	// ProcdBinImageRef is an OCI image mounted read-only at /procd/bin inside sandbox pods.
+	ProcdBinImageRef string `yaml:"procd_bin_image_ref" json:"-"`
 
 	DefaultClusterId string `yaml:"default_cluster_id" json:"-"`
 	RegionID         string `yaml:"region_id" json:"-"`

--- a/infra-operator/api/v1alpha1/service_api_config_types.go
+++ b/infra-operator/api/v1alpha1/service_api_config_types.go
@@ -454,6 +454,9 @@ type ManagerConfig struct {
 	SandboxMaxMemory string `json:"sandboxMaxMemory,omitempty"`
 	// +optional
 	SandboxRuntimeClassName string `json:"sandboxRuntimeClassName,omitempty"`
+	// ProcdBinImageRef overrides the OCI image used for the procd binary image volume.
+	// +optional
+	ProcdBinImageRef string `json:"procdBinImageRef,omitempty"`
 	// DefaultTeamQuotas configures region-wide fallback team quota limits.
 	// Team-specific quota rows in the database override these defaults.
 	// +optional

--- a/infra-operator/chart/crds/infra.sandbox0.ai_sandbox0infras.yaml
+++ b/infra-operator/chart/crds/infra.sandbox0.ai_sandbox0infras.yaml
@@ -3148,6 +3148,10 @@ spec:
                           pauseMinMemoryRequest:
                             default: 10Mi
                             type: string
+                          procdBinImageRef:
+                            description: ProcdBinImageRef overrides the OCI image
+                              used for the procd binary image volume.
+                            type: string
                           procdClientTimeout:
                             default: 30s
                             type: string

--- a/infra-operator/internal/controller/services/manager/manager.go
+++ b/infra-operator/internal/controller/services/manager/manager.go
@@ -294,6 +294,9 @@ func (r *Reconciler) buildConfig(ctx context.Context, imageRepo, imageTag string
 	}
 
 	cfg.ManagerImage = fmt.Sprintf("%s:%s", imageRepo, imageTag)
+	if cfg.ProcdBinImageRef == "" {
+		cfg.ProcdBinImageRef = fmt.Sprintf("%s:%s-procd-bin", imageRepo, imageTag)
+	}
 
 	return cfg, nil
 }

--- a/infra-operator/internal/controller/services/manager/manager_test.go
+++ b/infra-operator/internal/controller/services/manager/manager_test.go
@@ -210,6 +210,81 @@ func TestBuildConfigPreservesSandboxRuntimeClassName(t *testing.T) {
 	}
 }
 
+func TestBuildConfigDerivesProcdBinImageRef(t *testing.T) {
+	reconciler := newManagerTestReconciler(t)
+	infra := &infrav1alpha1.Sandbox0Infra{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "sandbox0-system",
+		},
+		Spec: infrav1alpha1.Sandbox0InfraSpec{
+			Database: &infrav1alpha1.DatabaseConfig{
+				Type: infrav1alpha1.DatabaseTypeBuiltin,
+				Builtin: &infrav1alpha1.BuiltinDatabaseConfig{
+					Enabled:  true,
+					Port:     5432,
+					Username: "sandbox0",
+					Database: "sandbox0",
+					SSLMode:  "disable",
+				},
+			},
+			Services: &infrav1alpha1.ServicesConfig{
+				Manager: &infrav1alpha1.ManagerServiceConfig{
+					Config: &infrav1alpha1.ManagerConfig{},
+				},
+			},
+		},
+	}
+
+	cfg, err := reconciler.buildConfig(context.Background(), "sandbox0ai/infra", "test", infraplan.Compile(infra))
+	if err != nil {
+		t.Fatalf("buildConfig returned error: %v", err)
+	}
+	if cfg.ManagerImage != "sandbox0ai/infra:test" {
+		t.Fatalf("manager image = %q, want sandbox0ai/infra:test", cfg.ManagerImage)
+	}
+	if cfg.ProcdBinImageRef != "sandbox0ai/infra:test-procd-bin" {
+		t.Fatalf("procd bin image ref = %q, want sandbox0ai/infra:test-procd-bin", cfg.ProcdBinImageRef)
+	}
+}
+
+func TestBuildConfigPreservesExplicitProcdBinImageRef(t *testing.T) {
+	reconciler := newManagerTestReconciler(t)
+	infra := &infrav1alpha1.Sandbox0Infra{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "sandbox0-system",
+		},
+		Spec: infrav1alpha1.Sandbox0InfraSpec{
+			Database: &infrav1alpha1.DatabaseConfig{
+				Type: infrav1alpha1.DatabaseTypeBuiltin,
+				Builtin: &infrav1alpha1.BuiltinDatabaseConfig{
+					Enabled:  true,
+					Port:     5432,
+					Username: "sandbox0",
+					Database: "sandbox0",
+					SSLMode:  "disable",
+				},
+			},
+			Services: &infrav1alpha1.ServicesConfig{
+				Manager: &infrav1alpha1.ManagerServiceConfig{
+					Config: &infrav1alpha1.ManagerConfig{
+						ProcdBinImageRef: "registry.example.com/procd-bin:v1",
+					},
+				},
+			},
+		},
+	}
+
+	cfg, err := reconciler.buildConfig(context.Background(), "sandbox0ai/infra", "test", infraplan.Compile(infra))
+	if err != nil {
+		t.Fatalf("buildConfig returned error: %v", err)
+	}
+	if cfg.ProcdBinImageRef != "registry.example.com/procd-bin:v1" {
+		t.Fatalf("procd bin image ref = %q, want registry.example.com/procd-bin:v1", cfg.ProcdBinImageRef)
+	}
+}
+
 func TestBuildConfigEnablesCtldWhenManagerIsEnabled(t *testing.T) {
 	reconciler := newManagerTestReconciler(t)
 	infra := &infrav1alpha1.Sandbox0Infra{

--- a/infra-operator/internal/runtimeconfig/dataplane.go
+++ b/infra-operator/internal/runtimeconfig/dataplane.go
@@ -33,6 +33,7 @@ func ToManager(spec *infrav1alpha1.ManagerConfig) *apiconfig.ManagerConfig {
 	cfg.TeamTemplateMemoryPerCPU = spec.TeamTemplateMemoryPerCPU
 	cfg.SandboxMaxMemory = spec.SandboxMaxMemory
 	cfg.SandboxRuntimeClassName = spec.SandboxRuntimeClassName
+	cfg.ProcdBinImageRef = spec.ProcdBinImageRef
 	cfg.DefaultTeamQuotas = cloneTeamQuotaLimitConfigs(spec.DefaultTeamQuotas)
 	cfg.AllowColdStartWithoutReadyDataPlane = spec.AllowColdStartWithoutReadyDataPlane
 	cfg.NetdPolicyApplyTimeout = spec.NetdPolicyApplyTimeout

--- a/infra-operator/internal/runtimeconfig/dataplane_test.go
+++ b/infra-operator/internal/runtimeconfig/dataplane_test.go
@@ -36,6 +36,15 @@ func TestToManagerPreservesProcdWebhookOutboxDir(t *testing.T) {
 	}
 }
 
+func TestToManagerPreservesProcdBinImageRef(t *testing.T) {
+	cfg := ToManager(&infrav1alpha1.ManagerConfig{
+		ProcdBinImageRef: "sandbox0ai/infra:test-procd-bin",
+	})
+	if cfg.ProcdBinImageRef != "sandbox0ai/infra:test-procd-bin" {
+		t.Fatalf("procd bin image ref = %q, want sandbox0ai/infra:test-procd-bin", cfg.ProcdBinImageRef)
+	}
+}
+
 func TestToManagerPreservesExplicitEmptyProcdWebhookOutboxDir(t *testing.T) {
 	outboxDir := ""
 	cfg := ToManager(&infrav1alpha1.ManagerConfig{

--- a/manager/pkg/apis/sandbox0/v1alpha1/helpers.go
+++ b/manager/pkg/apis/sandbox0/v1alpha1/helpers.go
@@ -62,7 +62,7 @@ func buildPodSpec(template *SandboxTemplate, volumeMounts []VolumeMountSpec) cor
 	applyNetdMITMCATrustMaterial(&spec)
 	applyVolumePortals(&spec, volumeMounts)
 	applyEmptyDirMounts(&spec, template)
-	applyProcdInit(&spec)
+	applyProcdBinImageVolume(&spec)
 	applyDefaultSandboxPlacement(&spec)
 
 	if runtimeClassName := configuredSandboxRuntimeClassName(); runtimeClassName != nil {
@@ -368,6 +368,8 @@ func buildContainer(spec *ContainerSpec, template *SandboxTemplate) corev1.Conta
 	container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
 		Name:      procdBinVolumeName,
 		MountPath: "/procd/bin",
+		SubPath:   "usr/local/bin",
+		ReadOnly:  true,
 	})
 
 	// Security context
@@ -550,30 +552,22 @@ func upsertProcdEnvVar(envIndex map[string]int, envVars *[]corev1.EnvVar, envVar
 	envIndex[envVar.Name] = len(*envVars) - 1
 }
 
-func applyProcdInit(spec *corev1.PodSpec) {
+func applyProcdBinImageVolume(spec *corev1.PodSpec) {
 	cfg := config.LoadManagerConfig()
-	managerImage := cfg.ManagerImage
+	imageRef := ""
+	if cfg != nil {
+		imageRef = strings.TrimSpace(cfg.ProcdBinImageRef)
+	}
+	if imageRef == "" && cfg != nil {
+		imageRef = strings.TrimSpace(cfg.ManagerImage) + "-procd-bin"
+	}
 
 	spec.Volumes = append(spec.Volumes, corev1.Volume{
 		Name: procdBinVolumeName,
 		VolumeSource: corev1.VolumeSource{
-			EmptyDir: &corev1.EmptyDirVolumeSource{},
-		},
-	})
-
-	spec.InitContainers = append(spec.InitContainers, corev1.Container{
-		Name:            "procd-init",
-		Image:           managerImage,
-		ImagePullPolicy: corev1.PullIfNotPresent,
-		Command: []string{
-			"/bin/sh",
-			"-c",
-			"cp /usr/local/bin/procd /procd/bin/procd && cp /usr/local/bin/python-runner /procd/bin/python-runner && chmod 0755 /procd/bin/procd /procd/bin/python-runner",
-		},
-		VolumeMounts: []corev1.VolumeMount{
-			{
-				Name:      procdBinVolumeName,
-				MountPath: "/procd/bin",
+			Image: &corev1.ImageVolumeSource{
+				Reference:  imageRef,
+				PullPolicy: corev1.PullIfNotPresent,
 			},
 		},
 	})

--- a/manager/pkg/apis/sandbox0/v1alpha1/helpers_test.go
+++ b/manager/pkg/apis/sandbox0/v1alpha1/helpers_test.go
@@ -119,6 +119,66 @@ manager_image: sandbox0/manager:test
 	}
 }
 
+func TestBuildPodSpecUsesProcdImageVolumeByDefault(t *testing.T) {
+	configPath := writeManagerConfig(t, `
+manager_image: sandbox0/manager:test
+`)
+	t.Setenv("CONFIG_PATH", configPath)
+
+	spec := BuildPodSpec(newTestTemplate())
+
+	if len(spec.InitContainers) != 0 {
+		t.Fatalf("expected no init containers, got %#v", spec.InitContainers)
+	}
+	volume := findVolume(spec.Volumes, procdBinVolumeName)
+	if volume == nil || volume.Image == nil {
+		t.Fatalf("expected procd bin image volume, got %#v", volume)
+	}
+	if volume.Image.Reference != "sandbox0/manager:test-procd-bin" {
+		t.Fatalf("image volume reference = %q, want sandbox0/manager:test-procd-bin", volume.Image.Reference)
+	}
+	main := spec.Containers[0]
+	if len(main.Command) != 1 || main.Command[0] != "/procd/bin/procd" {
+		t.Fatalf("main command = %#v, want /procd/bin/procd", main.Command)
+	}
+	mount := findVolumeMount(main.VolumeMounts, procdBinVolumeName)
+	if mount == nil || mount.MountPath != "/procd/bin" || mount.SubPath != "usr/local/bin" || !mount.ReadOnly {
+		t.Fatalf("procd bin mount = %#v, want read-only /procd/bin subPath usr/local/bin", mount)
+	}
+}
+
+func TestBuildPodSpecUsesExplicitProcdImageVolumeRef(t *testing.T) {
+	configPath := writeManagerConfig(t, `
+manager_image: sandbox0/manager:test
+procd_bin_image_ref: sandbox0/manager:test-procd-bin
+`)
+	t.Setenv("CONFIG_PATH", configPath)
+
+	spec := BuildPodSpec(newTestTemplate())
+
+	if len(spec.InitContainers) != 0 {
+		t.Fatalf("expected no init containers, got %#v", spec.InitContainers)
+	}
+	volume := findVolume(spec.Volumes, procdBinVolumeName)
+	if volume == nil || volume.Image == nil {
+		t.Fatalf("expected procd bin image volume, got %#v", volume)
+	}
+	if volume.Image.Reference != "sandbox0/manager:test-procd-bin" {
+		t.Fatalf("image volume reference = %q, want sandbox0/manager:test-procd-bin", volume.Image.Reference)
+	}
+	if volume.Image.PullPolicy != corev1.PullIfNotPresent {
+		t.Fatalf("image volume pull policy = %q, want %q", volume.Image.PullPolicy, corev1.PullIfNotPresent)
+	}
+	main := spec.Containers[0]
+	if len(main.Command) != 1 || main.Command[0] != "/procd/bin/procd" {
+		t.Fatalf("main command = %#v, want /procd/bin/procd", main.Command)
+	}
+	mount := findVolumeMount(main.VolumeMounts, procdBinVolumeName)
+	if mount == nil || mount.MountPath != "/procd/bin" || mount.SubPath != "usr/local/bin" || !mount.ReadOnly {
+		t.Fatalf("procd bin mount = %#v, want read-only /procd/bin subPath usr/local/bin", mount)
+	}
+}
+
 func TestBuildPodSpecLeavesOrdinarySandboxNonPrivileged(t *testing.T) {
 	configPath := writeManagerConfig(t, `
 manager_image: sandbox0/manager:test


### PR DESCRIPTION
## Summary

- Publish a small `-procd-bin` infra artifact image containing `/usr/local/bin/procd` and `/usr/local/bin/python-runner`.
- Replace the sandbox `procd-init` copy path with a Kubernetes image volume mounted read-only at `/procd/bin` via `subPath: usr/local/bin`.
- Keep `services.manager.config.procdBinImageRef` as an optional override; otherwise `infra-operator` derives `<infra-image-tag>-procd-bin` automatically.
- Build and publish the main infra image and the procd-bin artifact image in separate arch-matrix CI jobs so both image families are produced by the same workflow version without serializing the procd-bin build behind the main image build.

Refs #630

## Validation

- `make manifests`
- `go test ./manager/pkg/apis/sandbox0/v1alpha1`
- `go test ./infra-operator/internal/runtimeconfig ./infra-operator/internal/controller/services/manager ./infra-operator/api/config ./infra-operator/api/v1alpha1`
- `git diff --check`

Remote kind validation on the persistent Aliyun test host:

- Kubernetes `v1.35.0`, containerd `v2.2.0`.
- Built and loaded `sandbox0ai/infra:latest` and `sandbox0ai/infra:latest-procd-bin` into every kind node.
- Fullmode deploy with default config reached `Sandbox0Infra Ready`.
- Default sandbox pod used `volumes[].image.reference: sandbox0ai/infra:latest-procd-bin`, had no init containers, and mounted it at `/procd/bin` with `subPath: usr/local/bin`.
- API claim succeeded; claimed pod stayed Ready with no init containers and the same image-volume mount; `procd` probes were healthy.
- Earlier refill A/B samples on the same remote kind cluster:
  - init-container baseline: `7s, 7s, 7s` create-to-ready
  - image-volume path: `4s, 5s, 5s` create-to-ready
