### PR TITLE
Avoid image volume subPath for procd binaries

### DIFF
--- a/docs/self-hosted/configuration/page.mdx
+++ b/docs/self-hosted/configuration/page.mdx
@@ -186,7 +186,7 @@ This field only controls the `runtimeClassName` written onto sandbox Pods. The n
 
 ### Procd Binary Image Volume
 
-Sandbox Pods mount Sandbox0 `procd` binaries from a small OCI artifact image by default. This avoids a per-Pod init container on the sandbox startup path.
+Sandbox Pods mount Sandbox0 `procd` binaries from a small OCI artifact image at `/procd-image` by default. This avoids a per-Pod init container on the sandbox startup path.
 
 When `procdBinImageRef` is omitted, `infra-operator` derives it from the deployed infra image tag by appending `-procd-bin`. For example, `sandbox0ai/infra:v0.8.0` uses `sandbox0ai/infra:v0.8.0-procd-bin`.
 
@@ -200,7 +200,7 @@ spec:
                 procdBinImageRef: registry.example.com/sandbox0/procd-bin:v0.8.0
 ```
 
-Kubernetes image volume support is part of the Sandbox0 cluster baseline. Unsupported runtimes fail sandbox Pod startup instead of falling back inside the Pod.
+Kubernetes image volume support is part of the Sandbox0 cluster baseline. Unsupported runtimes fail sandbox Pod startup instead of falling back inside the Pod. Sandbox0 mounts the whole image volume and starts `/procd-image/usr/local/bin/procd`, so clusters do not need container-runtime support for image volume `subPath`.
 
 ### Sandbox Memory Limits
 

--- a/infra-operator/api/config/manager.go
+++ b/infra-operator/api/config/manager.go
@@ -21,7 +21,7 @@ type ManagerConfig struct {
 
 	// ManagerImage is the manager service image.
 	ManagerImage string `yaml:"manager_image" json:"-"`
-	// ProcdBinImageRef is an OCI image mounted read-only at /procd/bin inside sandbox pods.
+	// ProcdBinImageRef is an OCI image mounted read-only at /procd-image inside sandbox pods.
 	ProcdBinImageRef string `yaml:"procd_bin_image_ref" json:"-"`
 
 	DefaultClusterId string `yaml:"default_cluster_id" json:"-"`

--- a/manager/pkg/apis/sandbox0/v1alpha1/helpers.go
+++ b/manager/pkg/apis/sandbox0/v1alpha1/helpers.go
@@ -16,6 +16,8 @@ import (
 
 const (
 	procdBinVolumeName = "procd-bin"
+	procdBinMountPath  = "/procd-image"
+	procdPath          = procdBinMountPath + "/usr/local/bin/procd"
 	procdConfigVolume  = "procd-config"
 	netdMITMCAVolume   = "netd-mitm-ca"
 	netdMITMCACertKey  = "ca.crt"
@@ -360,15 +362,14 @@ func buildContainer(spec *ContainerSpec, template *SandboxTemplate) corev1.Conta
 	}
 	envVars = appendProcdConfigEnvVars(envVars)
 	container.Env = envVars
-	container.Command = []string{"/procd/bin/procd"}
+	container.Command = []string{procdPath}
 	container.Ports = append(container.Ports, corev1.ContainerPort{
 		Name:          "http",
 		ContainerPort: int32(procdHTTPPort()),
 	})
 	container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
 		Name:      procdBinVolumeName,
-		MountPath: "/procd/bin",
-		SubPath:   "usr/local/bin",
+		MountPath: procdBinMountPath,
 		ReadOnly:  true,
 	})
 

--- a/manager/pkg/apis/sandbox0/v1alpha1/helpers_test.go
+++ b/manager/pkg/apis/sandbox0/v1alpha1/helpers_test.go
@@ -138,12 +138,12 @@ manager_image: sandbox0/manager:test
 		t.Fatalf("image volume reference = %q, want sandbox0/manager:test-procd-bin", volume.Image.Reference)
 	}
 	main := spec.Containers[0]
-	if len(main.Command) != 1 || main.Command[0] != "/procd/bin/procd" {
-		t.Fatalf("main command = %#v, want /procd/bin/procd", main.Command)
+	if len(main.Command) != 1 || main.Command[0] != "/procd-image/usr/local/bin/procd" {
+		t.Fatalf("main command = %#v, want /procd-image/usr/local/bin/procd", main.Command)
 	}
 	mount := findVolumeMount(main.VolumeMounts, procdBinVolumeName)
-	if mount == nil || mount.MountPath != "/procd/bin" || mount.SubPath != "usr/local/bin" || !mount.ReadOnly {
-		t.Fatalf("procd bin mount = %#v, want read-only /procd/bin subPath usr/local/bin", mount)
+	if mount == nil || mount.MountPath != "/procd-image" || mount.SubPath != "" || !mount.ReadOnly {
+		t.Fatalf("procd bin mount = %#v, want read-only /procd-image without subPath", mount)
 	}
 }
 
@@ -170,12 +170,12 @@ procd_bin_image_ref: sandbox0/manager:test-procd-bin
 		t.Fatalf("image volume pull policy = %q, want %q", volume.Image.PullPolicy, corev1.PullIfNotPresent)
 	}
 	main := spec.Containers[0]
-	if len(main.Command) != 1 || main.Command[0] != "/procd/bin/procd" {
-		t.Fatalf("main command = %#v, want /procd/bin/procd", main.Command)
+	if len(main.Command) != 1 || main.Command[0] != "/procd-image/usr/local/bin/procd" {
+		t.Fatalf("main command = %#v, want /procd-image/usr/local/bin/procd", main.Command)
 	}
 	mount := findVolumeMount(main.VolumeMounts, procdBinVolumeName)
-	if mount == nil || mount.MountPath != "/procd/bin" || mount.SubPath != "usr/local/bin" || !mount.ReadOnly {
-		t.Fatalf("procd bin mount = %#v, want read-only /procd/bin subPath usr/local/bin", mount)
+	if mount == nil || mount.MountPath != "/procd-image" || mount.SubPath != "" || !mount.ReadOnly {
+		t.Fatalf("procd bin mount = %#v, want read-only /procd-image without subPath", mount)
 	}
 }
 

--- a/manager/procd/pkg/http/handlers/function.go
+++ b/manager/procd/pkg/http/handlers/function.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	defaultFunctionRunnerPath = "/procd/bin/python-runner"
+	defaultFunctionRunnerPath = "/procd-image/usr/local/bin/python-runner"
 	defaultFunctionCacheRoot  = "/tmp/sandbox0-functions"
 	defaultFunctionTimeout    = 30 * time.Second
 	maxFunctionTimeout        = 120 * time.Second

--- a/pkg/template/http/template_validation.go
+++ b/pkg/template/http/template_validation.go
@@ -265,7 +265,7 @@ func validateTemplateClaimNameBudget(scope, teamID, templateID string, spec v1al
 
 func validateReservedMountPath(path, field string) error {
 	reserved := []string{
-		"/procd/bin",
+		"/procd-image",
 		"/config",
 		"/var/run/sandbox0/netd",
 	}


### PR DESCRIPTION
## Summary
- mount the procd-bin image volume as a whole image at `/procd-image` instead of using image volume `subPath`
- update procd and python-runner paths to `/procd-image/usr/local/bin/...`
- reserve `/procd-image` for image-volume based procd binaries

## Validation
- `go test ./manager/pkg/apis/sandbox0/v1alpha1`
- `go test ./manager/procd/pkg/http/handlers`
- `go test ./pkg/template/http`
- `go test ./infra-operator/api/config`

## ACK benchmark
Image: `sandbox0ai/infra:subpathfix-6c1f9b9`

Compared with rollback baseline `main-abe1b36` on ACK Terway cold-claim benchmark:
- client p90: `21.38s -> 16.04s` (`-25.0%`)
- client p99: `22.56s -> 16.84s` (`-25.4%`)
- cold pod created-to-ready avg: `20.86s -> 11.48s` (`-45.0%`)
- cold pod created-to-ready p90: `23s -> 14s` (`-39.1%`)
- cold pod count: `22 -> 25`

The new run removed init containers and used `procd-bin:/procd-image:` with no subPath.