### PR TITLE
Use pod informer events for claim readiness

### DIFF
--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -364,7 +364,7 @@ func main() {
 		logger.Warn("Webhook state volumes disabled; sandbox claims with webhooks will fail until storage-proxy is configured")
 	}
 	sandboxService.SetDeletionWebhookEmitter(service.NewHTTPSandboxDeletionWebhookEmitter(obsProvider.HTTP.NewClient(httpobs.Config{Timeout: cfg.ProcdClientTimeout.Duration})))
-	podInformer.Informer().AddEventHandler(sandboxService.PodNetworkIdentityEventHandler())
+	podInformer.Informer().AddEventHandler(sandboxService.PodEventHandler())
 	sandboxLifecycleController := service.NewSandboxLifecycleController(k8sClient, podLister, sandboxService, logger)
 	podInformer.Informer().AddEventHandler(sandboxLifecycleController.ResourceEventHandler())
 	sandboxPauseController := service.NewSandboxPauseController(sandboxService, logger)

--- a/manager/pkg/service/pod_network_identity_waiter.go
+++ b/manager/pkg/service/pod_network_identity_waiter.go
@@ -7,23 +7,23 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-type podNetworkIdentityEvent struct {
+type podEvent struct {
 	pod     *corev1.Pod
 	deleted bool
 }
 
-type podNetworkIdentityWaiter struct {
+type podEventWaiter struct {
 	mu      sync.Mutex
-	waiters map[string]map[chan podNetworkIdentityEvent]struct{}
+	waiters map[string]map[chan podEvent]struct{}
 }
 
-func newPodNetworkIdentityWaiter() *podNetworkIdentityWaiter {
-	return &podNetworkIdentityWaiter{
-		waiters: make(map[string]map[chan podNetworkIdentityEvent]struct{}),
+func newPodEventWaiter() *podEventWaiter {
+	return &podEventWaiter{
+		waiters: make(map[string]map[chan podEvent]struct{}),
 	}
 }
 
-func (w *podNetworkIdentityWaiter) ResourceEventHandler() cache.ResourceEventHandlerFuncs {
+func (w *podEventWaiter) ResourceEventHandler() cache.ResourceEventHandlerFuncs {
 	if w == nil {
 		return cache.ResourceEventHandlerFuncs{}
 	}
@@ -40,16 +40,16 @@ func (w *podNetworkIdentityWaiter) ResourceEventHandler() cache.ResourceEventHan
 	}
 }
 
-func (w *podNetworkIdentityWaiter) register(namespace, name string) (<-chan podNetworkIdentityEvent, func()) {
-	ch := make(chan podNetworkIdentityEvent, 1)
+func (w *podEventWaiter) register(namespace, name string) (<-chan podEvent, func()) {
+	ch := make(chan podEvent, 1)
 	if w == nil {
 		return ch, func() {}
 	}
-	key := podNetworkIdentityKey(namespace, name)
+	key := podEventKey(namespace, name)
 
 	w.mu.Lock()
 	if w.waiters[key] == nil {
-		w.waiters[key] = make(map[chan podNetworkIdentityEvent]struct{})
+		w.waiters[key] = make(map[chan podEvent]struct{})
 	}
 	w.waiters[key][ch] = struct{}{}
 	w.mu.Unlock()
@@ -68,7 +68,7 @@ func (w *podNetworkIdentityWaiter) register(namespace, name string) (<-chan podN
 	}
 }
 
-func (w *podNetworkIdentityWaiter) notifyObject(obj any, deleted bool) {
+func (w *podEventWaiter) notifyObject(obj any, deleted bool) {
 	if w == nil {
 		return
 	}
@@ -76,8 +76,8 @@ func (w *podNetworkIdentityWaiter) notifyObject(obj any, deleted bool) {
 	if pod == nil {
 		return
 	}
-	key := podNetworkIdentityKey(pod.Namespace, pod.Name)
-	event := podNetworkIdentityEvent{pod: pod, deleted: deleted}
+	key := podEventKey(pod.Namespace, pod.Name)
+	event := podEvent{pod: pod, deleted: deleted}
 
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -101,6 +101,6 @@ func podFromInformerObject(obj any) *corev1.Pod {
 	return pod
 }
 
-func podNetworkIdentityKey(namespace, name string) string {
+func podEventKey(namespace, name string) string {
 	return namespace + "/" + name
 }

--- a/manager/pkg/service/sandbox_service.go
+++ b/manager/pkg/service/sandbox_service.go
@@ -130,8 +130,8 @@ type SandboxService struct {
 	rootFSObjectDeleter    RootFSObjectDeleter
 	resumeGroup            singleflight.Group
 	idlePodReservations    *idlePodReservations
-	podNetworkWaiterMu     sync.Mutex
-	podNetworkWaiter       *podNetworkIdentityWaiter
+	podWaiterMu            sync.Mutex
+	podWaiter              *podEventWaiter
 }
 
 type TeamQuotaLimitStore interface {
@@ -245,26 +245,26 @@ func NewSandboxService(
 		logger:                 logger,
 		metrics:                metrics,
 		idlePodReservations:    newIdlePodReservations(),
-		podNetworkWaiter:       newPodNetworkIdentityWaiter(),
+		podWaiter:              newPodEventWaiter(),
 	}
 	return service
 }
 
-// PodNetworkIdentityEventHandler wakes cold-claim waiters from shared pod informer events.
-func (s *SandboxService) PodNetworkIdentityEventHandler() cache.ResourceEventHandlerFuncs {
+// PodEventHandler wakes cold-claim waiters from shared pod informer events.
+func (s *SandboxService) PodEventHandler() cache.ResourceEventHandlerFuncs {
 	if s == nil {
 		return cache.ResourceEventHandlerFuncs{}
 	}
-	return s.ensurePodNetworkIdentityWaiter().ResourceEventHandler()
+	return s.ensurePodEventWaiter().ResourceEventHandler()
 }
 
-func (s *SandboxService) ensurePodNetworkIdentityWaiter() *podNetworkIdentityWaiter {
-	s.podNetworkWaiterMu.Lock()
-	defer s.podNetworkWaiterMu.Unlock()
-	if s.podNetworkWaiter == nil {
-		s.podNetworkWaiter = newPodNetworkIdentityWaiter()
+func (s *SandboxService) ensurePodEventWaiter() *podEventWaiter {
+	s.podWaiterMu.Lock()
+	defer s.podWaiterMu.Unlock()
+	if s.podWaiter == nil {
+		s.podWaiter = newPodEventWaiter()
 	}
-	return s.podNetworkWaiter
+	return s.podWaiter
 }
 
 // SupportsNetworkPolicy reports whether this deployment has an active network policy provider.

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -596,7 +596,7 @@ func TestWaitForPodNetworkIdentityWaitsForNodeNameAndPodIP(t *testing.T) {
 		podLister: corelisters.NewPodLister(indexer),
 		logger:    zap.NewNop(),
 	}
-	handler := svc.PodNetworkIdentityEventHandler()
+	handler := svc.PodEventHandler()
 
 	go func() {
 		time.Sleep(80 * time.Millisecond)
@@ -637,7 +637,7 @@ func TestWaitForPodNetworkIdentityWaitsForNodeNameWhenPodIPArrivesFirst(t *testi
 		podLister: corelisters.NewPodLister(indexer),
 		logger:    zap.NewNop(),
 	}
-	handler := svc.PodNetworkIdentityEventHandler()
+	handler := svc.PodEventHandler()
 
 	go func() {
 		time.Sleep(80 * time.Millisecond)
@@ -683,7 +683,7 @@ func TestWaitForPodNetworkIdentityWaitsForInformerWhenLivePodIsReady(t *testing.
 		podLister: corelisters.NewPodLister(indexer),
 		logger:    zap.NewNop(),
 	}
-	handler := svc.PodNetworkIdentityEventHandler()
+	handler := svc.PodEventHandler()
 
 	go func() {
 		time.Sleep(80 * time.Millisecond)
@@ -769,7 +769,7 @@ func TestWaitForPodNetworkIdentityReturnsOnDeleteOrTerminal(t *testing.T) {
 				podLister: corelisters.NewPodLister(indexer),
 				logger:    zap.NewNop(),
 			}
-			handler := svc.PodNetworkIdentityEventHandler()
+			handler := svc.PodEventHandler()
 
 			go func() {
 				time.Sleep(80 * time.Millisecond)
@@ -1426,6 +1426,7 @@ func TestWaitForPodClaimReadyWaitsForProcdContainerRunning(t *testing.T) {
 		logger: zap.NewNop(),
 	}
 
+	handler := svc.PodEventHandler()
 	go func() {
 		time.Sleep(80 * time.Millisecond)
 		updated := pod.DeepCopy()
@@ -1436,7 +1437,9 @@ func TestWaitForPodClaimReadyWaitsForProcdContainerRunning(t *testing.T) {
 		}}
 		if err := indexer.Update(updated); err != nil {
 			t.Errorf("update pod: %v", err)
+			return
 		}
+		handler.UpdateFunc(pod, updated)
 	}()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -1447,6 +1450,83 @@ func TestWaitForPodClaimReadyWaitsForProcdContainerRunning(t *testing.T) {
 	}
 	if !podContainerRunning(readyPod, "procd") {
 		t.Fatal("waitForPodClaimReady() returned before procd container was running")
+	}
+}
+
+func TestWaitForPodClaimReadyReprobesOnlyAfterInformerEvent(t *testing.T) {
+	pod := newClaimReadyTestPod("ns-a", "cold-pod", "template-a")
+	indexer := newClaimTestPodIndexer(t, pod)
+
+	probeCalls := make(chan struct{}, 8)
+	var probeMu sync.Mutex
+	probeReady := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		probeMu.Lock()
+		ready := probeReady
+		probeMu.Unlock()
+
+		probeCalls <- struct{}{}
+		if ready {
+			_ = json.NewEncoder(w).Encode(sandboxprobe.Passed(sandboxprobe.KindReadiness, "SandboxProbePassed", "sandbox probe passed", nil))
+			return
+		}
+		_ = json.NewEncoder(w).Encode(sandboxprobe.Failed(sandboxprobe.KindReadiness, "SandboxProbePending", "sandbox probe pending", nil))
+	}))
+	defer server.Close()
+	host, port := splitTestServerAddress(t, server)
+
+	svc := &SandboxService{
+		k8sClient:  fake.NewSimpleClientset(pod.DeepCopy(), newClaimTestNode("node-a", host)),
+		podLister:  corelisters.NewPodLister(indexer),
+		ctldClient: NewCtldClient(CtldClientConfig{Timeout: time.Second}),
+		config: SandboxServiceConfig{
+			CtldPort: port,
+		},
+		logger: zap.NewNop(),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	resultCh := make(chan error, 1)
+	go func() {
+		_, err := svc.waitForPodClaimReady(ctx, pod.Namespace, pod.Name)
+		resultCh <- err
+	}()
+
+	for i := 0; i < 2; i++ {
+		select {
+		case <-probeCalls:
+		case <-time.After(time.Second):
+			t.Fatalf("probe call %d did not happen", i+1)
+		}
+	}
+
+	select {
+	case <-probeCalls:
+		t.Fatal("unexpected readiness probe before informer event")
+	case err := <-resultCh:
+		t.Fatalf("waitForPodClaimReady returned before informer event: %v", err)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	probeMu.Lock()
+	probeReady = true
+	probeMu.Unlock()
+
+	updated := pod.DeepCopy()
+	updated.ResourceVersion = "2"
+	if err := indexer.Update(updated); err != nil {
+		t.Fatalf("update pod: %v", err)
+	}
+	svc.PodEventHandler().UpdateFunc(pod, updated)
+
+	select {
+	case err := <-resultCh:
+		if err != nil {
+			t.Fatalf("waitForPodClaimReady() error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("waitForPodClaimReady did not return after informer event")
 	}
 }
 

--- a/manager/pkg/service/sandbox_service_pod.go
+++ b/manager/pkg/service/sandbox_service_pod.go
@@ -62,37 +62,59 @@ func (s *SandboxService) waitForPodClaimReady(ctx context.Context, namespace, na
 	readyCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	ticker := time.NewTicker(50 * time.Millisecond)
-	defer ticker.Stop()
-
+	waiter := s.ensurePodEventWaiter()
 	lastReason := "pod is not ready"
-	for {
+	evaluate := func() (*corev1.Pod, bool, error) {
+		if s.podLister == nil {
+			return nil, false, fmt.Errorf("pod lister is not configured")
+		}
 		pod, err := s.podLister.Pods(namespace).Get(name)
 		if err != nil {
 			if k8serrors.IsNotFound(err) {
 				lastReason = fmt.Sprintf("pod %s/%s is not visible", namespace, name)
-				select {
-				case <-readyCtx.Done():
-					return nil, fmt.Errorf("pod %s/%s not claim-ready after %s: %s", namespace, name, timeout, lastReason)
-				case <-ticker.C:
-					continue
-				}
+				return nil, false, nil
 			}
-			return nil, fmt.Errorf("get pod for claim readiness: %w", err)
+			return nil, false, fmt.Errorf("get pod for claim readiness: %w", err)
 		}
 
 		ready, reason := s.isPodClaimReady(readyCtx, pod)
 		if ready {
-			return pod, nil
+			return pod, true, nil
 		}
 		if reason != "" {
 			lastReason = reason
 		}
+		return nil, false, nil
+	}
 
+	if pod, ready, err := evaluate(); err != nil || ready {
+		return pod, err
+	}
+
+	events, unregister := waiter.register(namespace, name)
+	defer unregister()
+
+	// Recheck after registering to avoid missing an informer event that arrives
+	// between the initial cache read and waiter registration.
+	if pod, ready, err := evaluate(); err != nil || ready {
+		return pod, err
+	}
+
+	for {
 		select {
 		case <-readyCtx.Done():
+			if ctxErr := ctx.Err(); ctxErr != nil && !errors.Is(ctxErr, context.DeadlineExceeded) {
+				return nil, fmt.Errorf("pod %s/%s claim readiness wait canceled: %w", namespace, name, ctxErr)
+			}
 			return nil, fmt.Errorf("pod %s/%s not claim-ready after %s: %s", namespace, name, timeout, lastReason)
-		case <-ticker.C:
+		case event := <-events:
+			if event.deleted {
+				return nil, fmt.Errorf("pod %s/%s not claim-ready: pod is deleting", namespace, name)
+			}
+			pod, ready, err := evaluate()
+			if err != nil || ready {
+				return pod, err
+			}
 		}
 	}
 }
@@ -106,7 +128,7 @@ func (s *SandboxService) waitForPodNetworkIdentity(ctx context.Context, template
 	readyCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	waiter := s.ensurePodNetworkIdentityWaiter()
+	waiter := s.ensurePodEventWaiter()
 	tracker := newPodNetworkIdentityStageTracker(s, template)
 	lastReason := "pod network identity is not ready"
 


### PR DESCRIPTION
## Summary
- generalize the existing pod informer waiter so claim readiness and network identity waits share the same event source
- replace the `waitForPodClaimReady` 50ms ticker with cache check, waiter registration, cache recheck, and informer-event wakeups
- rename the manager pod informer hook to `PodEventHandler` and add regression coverage that readiness is only re-probed after an informer event

## Tests
- `go test ./manager/pkg/service`
- `go test ./manager/pkg/controller ./manager/pkg/http`
- `go test ./manager/cmd/manager`
- `go test ./manager/...`
