### PR TITLE
Allow rootfs layer-chain replay across template image upgrades

### DIFF
--- a/ctld/internal/ctld/rootfs/controller.go
+++ b/ctld/internal/ctld/rootfs/controller.go
@@ -205,12 +205,12 @@ func (c *Controller) ApplyRootFS(r *http.Request, req ctldapi.ApplyRootFSRequest
 		return ctldapi.ApplyRootFSResponse{Info: info, Error: err.Error()}, http.StatusConflict
 	}
 	if layered {
-		if err := validateStrictExpectedBase(info, req); err != nil {
-			return ctldapi.ApplyRootFSResponse{Info: info, Error: err.Error()}, http.StatusConflict
-		}
 		if err := validateBaselineLayerID(req); err != nil {
 			return ctldapi.ApplyRootFSResponse{Info: info, Error: err.Error()}, http.StatusBadRequest
 		}
+		// The layer chain represents the sandbox's writable rootfs state. Replaying
+		// it across template image upgrades is valid; actual path-level conflicts
+		// are surfaced by the runtime apply step below.
 		portalPaths := c.portalPathsForRequest(info, req.Target, req.ExcludedPaths, req.PortalPaths)
 		applied, err := c.applyLayers(ctx, info, req.Layers, req.ExcludedPaths, portalPaths)
 		if err != nil {
@@ -507,19 +507,6 @@ func validateExpectedBase(info ctldapi.RootFSInfo, req ctldapi.ApplyRootFSReques
 	return nil
 }
 
-func validateStrictExpectedBase(info ctldapi.RootFSInfo, req ctldapi.ApplyRootFSRequest) error {
-	if expected := strings.TrimSpace(req.ExpectedBaseImageDigest); expected != "" && strings.TrimSpace(info.BaseImageDigest) != expected {
-		return fmt.Errorf("%w: base image digest mismatch: expected %s, got %s", ErrConflict, expected, info.BaseImageDigest)
-	}
-	if expected := strings.TrimSpace(req.ExpectedSnapshotParent); expected != "" && strings.TrimSpace(info.SnapshotParent) != expected {
-		return fmt.Errorf("%w: snapshot parent mismatch: expected %s, got %s", ErrConflict, expected, info.SnapshotParent)
-	}
-	if len(req.ExpectedSnapshotParentChain) > 0 && !equalStringSlices(req.ExpectedSnapshotParentChain, info.SnapshotParentChain) {
-		return fmt.Errorf("%w: snapshot parent chain mismatch", ErrConflict)
-	}
-	return nil
-}
-
 func validateBaselineLayerID(req ctldapi.ApplyRootFSRequest) error {
 	if strings.TrimSpace(req.BaselineLayerID) == "" {
 		return nil
@@ -532,18 +519,6 @@ func validateBaselineLayerID(req ctldapi.ApplyRootFSRequest) error {
 		return fmt.Errorf("%w: baseline_layer_id must match the head layer", ErrBadRequest)
 	}
 	return nil
-}
-
-func equalStringSlices(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if strings.TrimSpace(a[i]) != strings.TrimSpace(b[i]) {
-			return false
-		}
-	}
-	return true
 }
 
 func defaultObjectKey(teamID, sandboxID string, generation int64, digest string) (string, error) {

--- a/ctld/internal/ctld/rootfs/controller_test.go
+++ b/ctld/internal/ctld/rootfs/controller_test.go
@@ -345,15 +345,25 @@ func TestControllerApplyRootFSForceAppliesBaseMismatch(t *testing.T) {
 	assert.Equal(t, "rootfs diff", runtime.applyContent)
 }
 
-func TestControllerApplyRootFSLayerChainRejectsBaseMismatch(t *testing.T) {
+func TestControllerApplyRootFSLayerChainReplaysBaseMismatch(t *testing.T) {
 	store := objectstore.NewMemoryStore(t.Name())
 	require.NoError(t, store.Put("rootfs/diff.tar", strings.NewReader("rootfs diff")))
-	runtime := &fakeRuntime{info: rootFSInfo("runc")}
+	runtime := &fakeRuntime{
+		info: rootFSInfo("runc"),
+		applyDesc: ctldapi.RootFSDiffDescriptor{
+			MediaType: "application/vnd.oci.image.layer.v1.tar",
+			Digest:    "sha256:feedface",
+			Size:      int64(len("rootfs diff")),
+		},
+	}
 	controller := NewController(Config{Runtime: runtime, Store: store})
 
 	resp, status := controller.ApplyRootFS(httptest.NewRequest(http.MethodPost, "/", nil), ctldapi.ApplyRootFSRequest{
-		Target:                  rootFSTarget(),
-		ExpectedBaseImageDigest: "sha256:other-base",
+		Target:                      rootFSTarget(),
+		ExpectedBaseImageDigest:     "sha256:other-base",
+		ExpectedSnapshotParent:      "other-parent",
+		ExpectedSnapshotParentChain: []string{"other-parent"},
+		BaselineLayerID:             "layer-1",
 		Layers: []ctldapi.RootFSLayerDescriptor{{
 			LayerID: "layer-1",
 			Descriptor: ctldapi.RootFSDiffDescriptor{
@@ -365,9 +375,12 @@ func TestControllerApplyRootFSLayerChainRejectsBaseMismatch(t *testing.T) {
 		}},
 	})
 
-	require.Equal(t, http.StatusConflict, status)
-	assert.Contains(t, resp.Error, "base image digest mismatch")
-	assert.False(t, runtime.applyCalled)
+	require.Equal(t, http.StatusOK, status, resp.Error)
+	assert.True(t, resp.Applied)
+	assert.True(t, runtime.applyCalled)
+	assert.Equal(t, "rootfs diff", runtime.applyContent)
+	assert.True(t, runtime.captureBaselineCalled)
+	assert.Equal(t, "layer-1", runtime.captureBaselineLayerID)
 }
 
 func TestControllerApplyRootFSRejectsRuntimeMismatch(t *testing.T) {


### PR DESCRIPTION
## Summary
- allow layered rootfs restore to replay writable layer chains on the current template image instead of rejecting base image digest/snapshot-parent mismatches before apply
- keep runtime/runtime-handler/snapshotter compatibility checks and let actual apply failures surface so manager fallback to checkpoint base image still works
- update the rootfs controller regression test to cover template-image-upgrade replay and baseline capture

## Tests
- go test ./ctld/internal/ctld/rootfs
- go test ./manager/pkg/service -run 'RootFS|RestoredSandboxRuntime|CheckpointBaseImage|FinishRestored'\n- go test ./manager/pkg/service\n- go test ./ctld/internal/ctld/rootfs ./manager/pkg/service ./pkg/ctldapi\n\nNote: `go test ./ctld/internal/ctld/...` still fails in `ctld/internal/ctld/portal` because generated `storage-proxy/proto/fs` is absent in this checkout; `ctld/internal/ctld/rootfs`, `power`, and `server` passed before the setup failure.