### PR TITLE
Use gvisor-rootfs for e2e kind sandboxes

### DIFF
--- a/.github/actions/prepare-infra/action.yml
+++ b/.github/actions/prepare-infra/action.yml
@@ -38,11 +38,21 @@ runs:
         infra-dir: ${{ inputs.infra-dir }}
         cache-key-suffix: ${{ inputs.cache-key-suffix }}
 
+    - name: Install gVisor rootfs runtime files
+      shell: bash
+      run: tests/e2e/setup-gvisor-rootfs.sh
+
     - uses: helm/kind-action@v1
       with:
         version: v0.30.0
         config: ${{ inputs.kind-config }}
         cluster_name: ${{ inputs.kind-cluster-name }}
+
+    - name: Apply gVisor rootfs RuntimeClass
+      shell: bash
+      run: |
+        kubectl --context "kind-${{ inputs.kind-cluster-name }}" apply -f tests/e2e/runtimeclasses/gvisor-rootfs.yaml
+        echo "E2E_SANDBOX_RUNTIME_CLASS=gvisor-rootfs" >> "${GITHUB_ENV}"
 
     - name: Install Helm
       uses: azure/setup-helm@v4

--- a/.github/workflows/sdk-e2e.yml
+++ b/.github/workflows/sdk-e2e.yml
@@ -78,7 +78,14 @@ jobs:
             --set config.imagePullPolicy=IfNotPresent
 
       - name: Apply infra manifest
-        run: kubectl apply -f "${INFRA_MANIFEST}"
+        shell: bash
+        run: |
+          kubectl apply -f "${INFRA_MANIFEST}"
+          if [[ -n "${E2E_SANDBOX_RUNTIME_CLASS:-}" ]]; then
+            kubectl -n "${INFRA_NAMESPACE}" patch sandbox0infra "${INFRA_NAME}" \
+              --type merge \
+              -p "{\"spec\":{\"services\":{\"manager\":{\"config\":{\"sandboxRuntimeClassName\":\"${E2E_SANDBOX_RUNTIME_CLASS}\"}}}}}"
+          fi
 
       - name: Wait for Sandbox0Infra ready
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build test test-all test-integration test-integration-verbose test-e2e test-e2e-kind test-e2e-destroy test-e2e-load-images test-e2e-prepare-kind test-e2e-specific test-e2e-s0fs-posix test-e2e-s0fs-posix-prepare test-e2e-netd-cni lint tidy vendor clean helm-update helm-configs release docker-build docker-build-local build-local-all docker-push proto manifests apispec oapi-codegen
+.PHONY: all build test test-all test-integration test-integration-verbose test-e2e test-e2e-kind test-e2e-destroy test-e2e-load-images test-e2e-prepare-kind test-e2e-setup-gvisor-rootfs test-e2e-specific test-e2e-s0fs-posix test-e2e-s0fs-posix-prepare test-e2e-netd-cni lint tidy vendor clean helm-update helm-configs release docker-build docker-build-local build-local-all docker-push proto manifests apispec oapi-codegen
 
 # Tool Binaries
 LOCALBIN ?= $(shell pwd)/bin
@@ -178,9 +178,14 @@ test-e2e-local:
 	@printf "$(CYAN)Running E2E tests locally...$(RESET)\n"
 	unset http_proxy && unset https_proxy && unset all_proxy && E2E_USE_EXISTING_CLUSTER=true $(GO) test -v -count=1 ./tests/e2e/... -timeout=30m
 
-test-e2e-kind:
+test-e2e-setup-gvisor-rootfs:
+	@printf "$(CYAN)Installing gVisor rootfs runtime files for Kind...$(RESET)\n"
+	unset http_proxy && unset https_proxy && unset all_proxy && bash tests/e2e/setup-gvisor-rootfs.sh
+
+test-e2e-kind: test-e2e-setup-gvisor-rootfs
 	@printf "$(CYAN)Creating Kind cluster...$(RESET)\n"
-	unset http_proxy && unset https_proxy && unset all_proxy && kind create cluster --config tests/e2e/kind-config.yaml --name sandbox0-e2e
+	unset http_proxy && unset https_proxy && unset all_proxy && kind create cluster --config tests/e2e/kind-config.yaml --name "$(E2E_CLUSTER_NAME)"
+	kubectl --context "kind-$(E2E_CLUSTER_NAME)" apply -f tests/e2e/runtimeclasses/gvisor-rootfs.yaml
 
 test-e2e-load-images:
 	@printf "$(CYAN)Loading E2E images into Kind cluster...$(RESET)\n"

--- a/pkg/framework/config.go
+++ b/pkg/framework/config.go
@@ -27,7 +27,8 @@ type Config struct {
 	OperatorImageTag        string
 	OperatorImagePullPolicy string
 
-	InfraNamespace string
+	InfraNamespace          string
+	SandboxRuntimeClassName string
 }
 
 // LoadConfig reads E2E configuration from environment variables.
@@ -59,7 +60,8 @@ func LoadConfig() (Config, error) {
 		OperatorImageTag:        envString("E2E_OPERATOR_IMAGE_TAG", "latest"),
 		OperatorImagePullPolicy: envString("E2E_OPERATOR_IMAGE_PULL_POLICY", "IfNotPresent"),
 
-		InfraNamespace: envString("E2E_INFRA_NAMESPACE", "sandbox0-system"),
+		InfraNamespace:          envString("E2E_INFRA_NAMESPACE", "sandbox0-system"),
+		SandboxRuntimeClassName: envString("E2E_SANDBOX_RUNTIME_CLASS", ""),
 	}
 
 	if cfg.UseExistingCluster {

--- a/pkg/framework/runtimeclass.go
+++ b/pkg/framework/runtimeclass.go
@@ -1,0 +1,44 @@
+package framework
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// PatchScenarioSandboxRuntimeClass points scenario sandbox Pods at the requested RuntimeClass.
+func PatchScenarioSandboxRuntimeClass(ctx context.Context, kubeconfig string, infra InfraConfig, runtimeClassName string) error {
+	runtimeClassName = strings.TrimSpace(runtimeClassName)
+	if runtimeClassName == "" {
+		return nil
+	}
+	if infra.Name == "" || infra.Namespace == "" {
+		return fmt.Errorf("infra name and namespace are required")
+	}
+
+	patch, err := sandboxRuntimeClassPatch(runtimeClassName)
+	if err != nil {
+		return err
+	}
+	return KubectlPatch(ctx, kubeconfig, infra.Namespace, "sandbox0infra", infra.Name, patch)
+}
+
+func sandboxRuntimeClassPatch(runtimeClassName string) (string, error) {
+	patch := map[string]any{
+		"spec": map[string]any{
+			"services": map[string]any{
+				"manager": map[string]any{
+					"config": map[string]any{
+						"sandboxRuntimeClassName": runtimeClassName,
+					},
+				},
+			},
+		},
+	}
+	content, err := json.Marshal(patch)
+	if err != nil {
+		return "", fmt.Errorf("marshal sandbox runtime class patch: %w", err)
+	}
+	return string(content), nil
+}

--- a/pkg/framework/runtimeclass_test.go
+++ b/pkg/framework/runtimeclass_test.go
@@ -1,0 +1,31 @@
+package framework
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestSandboxRuntimeClassPatch(t *testing.T) {
+	got, err := sandboxRuntimeClassPatch(`gvisor-rootfs`)
+	if err != nil {
+		t.Fatalf("sandboxRuntimeClassPatch returned error: %v", err)
+	}
+
+	var patch struct {
+		Spec struct {
+			Services struct {
+				Manager struct {
+					Config struct {
+						SandboxRuntimeClassName string `json:"sandboxRuntimeClassName"`
+					} `json:"config"`
+				} `json:"manager"`
+			} `json:"services"`
+		} `json:"spec"`
+	}
+	if err := json.Unmarshal([]byte(got), &patch); err != nil {
+		t.Fatalf("patch is not valid JSON: %v", err)
+	}
+	if patch.Spec.Services.Manager.Config.SandboxRuntimeClassName != "gvisor-rootfs" {
+		t.Fatalf("sandbox runtime class = %q, want gvisor-rootfs", patch.Spec.Services.Manager.Config.SandboxRuntimeClassName)
+	}
+}

--- a/pkg/framework/setup.go
+++ b/pkg/framework/setup.go
@@ -153,6 +153,10 @@ func SetupScenario(cfg Config, scenario Scenario) (*ScenarioEnv, func(), error) 
 		cleanup()
 		return nil, nil, err
 	}
+	if err := PatchScenarioSandboxRuntimeClass(testCtx.Context, workingCfg.Kubeconfig, env.Infra, workingCfg.SandboxRuntimeClassName); err != nil {
+		cleanup()
+		return nil, nil, err
+	}
 	for _, rollout := range scenario.Rollouts {
 		resourceID, err := rollout.ResourceID()
 		if err != nil {

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -1340,7 +1340,7 @@ func assertSandboxRootFSPersistsAcrossPauseResume(env *framework.ScenarioEnv, se
 	sandbox := waitForSandboxPodReadyEventually(env, session, sandboxID, templateNamespace)
 
 	marker := fmt.Sprintf("s0-rootfs-pause-resume-%d", time.Now().UnixNano())
-	rootDir := "/tmp/" + marker
+	rootDir := "/root/" + marker
 	filePath := rootDir + "/marker.txt"
 	nestedPath := rootDir + "/nested/value.txt"
 	linkPath := rootDir + "/marker.link"
@@ -1437,7 +1437,7 @@ func assertSandboxRootFSSnapshotRestoreFork(env *framework.ScenarioEnv, session 
 	source := waitForSandboxPodReadyEventually(env, session, sourceSandboxID, templateNamespace)
 
 	marker := fmt.Sprintf("s0-rootfs-snapshot-%d", time.Now().UnixNano())
-	rootDir := "/tmp/" + marker
+	rootDir := "/root/" + marker
 	filePath := rootDir + "/marker.txt"
 	nestedPath := rootDir + "/nested/value.txt"
 	v1Content := "snapshot v1 " + marker

--- a/tests/e2e/kind-config-no-cni.yaml
+++ b/tests/e2e/kind-config-no-cni.yaml
@@ -1,12 +1,39 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 name: sandbox0-e2e
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.gvisor-rootfs]
+    runtime_type = "io.containerd.runsc.v1"
+    pod_annotations = ["dev.gvisor.*"]
+
+  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.gvisor-rootfs.options]
+    TypeUrl = "io.containerd.runsc.v1.options"
+    ConfigPath = "/etc/containerd/runsc-rootfs.toml"
+
+  [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.gvisor-rootfs]
+    runtime_type = "io.containerd.runsc.v1"
+    pod_annotations = ["dev.gvisor.*"]
+
+  [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.gvisor-rootfs.options]
+    TypeUrl = "io.containerd.runsc.v1.options"
+    ConfigPath = "/etc/containerd/runsc-rootfs.toml"
 networking:
   disableDefaultCNI: true
   podSubnet: 10.244.0.0/16
 nodes:
 - role: control-plane
   image: kindest/node:v1.35.0
+  extraMounts:
+  - hostPath: /usr/local/bin/runsc
+    containerPath: /usr/local/bin/runsc
+    readOnly: true
+  - hostPath: /usr/local/bin/containerd-shim-runsc-v1
+    containerPath: /usr/local/bin/containerd-shim-runsc-v1
+    readOnly: true
+  - hostPath: /etc/containerd/runsc-rootfs.toml
+    containerPath: /etc/containerd/runsc-rootfs.toml
+    readOnly: true
   kubeadmConfigPatches:
   - |
     kind: ClusterConfiguration
@@ -28,5 +55,25 @@ nodes:
     hostPort: 30500
 - role: worker
   image: kindest/node:v1.35.0
+  extraMounts:
+  - hostPath: /usr/local/bin/runsc
+    containerPath: /usr/local/bin/runsc
+    readOnly: true
+  - hostPath: /usr/local/bin/containerd-shim-runsc-v1
+    containerPath: /usr/local/bin/containerd-shim-runsc-v1
+    readOnly: true
+  - hostPath: /etc/containerd/runsc-rootfs.toml
+    containerPath: /etc/containerd/runsc-rootfs.toml
+    readOnly: true
 - role: worker
   image: kindest/node:v1.35.0
+  extraMounts:
+  - hostPath: /usr/local/bin/runsc
+    containerPath: /usr/local/bin/runsc
+    readOnly: true
+  - hostPath: /usr/local/bin/containerd-shim-runsc-v1
+    containerPath: /usr/local/bin/containerd-shim-runsc-v1
+    readOnly: true
+  - hostPath: /etc/containerd/runsc-rootfs.toml
+    containerPath: /etc/containerd/runsc-rootfs.toml
+    readOnly: true

--- a/tests/e2e/kind-config.yaml
+++ b/tests/e2e/kind-config.yaml
@@ -1,9 +1,36 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 name: sandbox0-e2e
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.gvisor-rootfs]
+    runtime_type = "io.containerd.runsc.v1"
+    pod_annotations = ["dev.gvisor.*"]
+
+  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.gvisor-rootfs.options]
+    TypeUrl = "io.containerd.runsc.v1.options"
+    ConfigPath = "/etc/containerd/runsc-rootfs.toml"
+
+  [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.gvisor-rootfs]
+    runtime_type = "io.containerd.runsc.v1"
+    pod_annotations = ["dev.gvisor.*"]
+
+  [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.gvisor-rootfs.options]
+    TypeUrl = "io.containerd.runsc.v1.options"
+    ConfigPath = "/etc/containerd/runsc-rootfs.toml"
 nodes:
 - role: control-plane
   image: kindest/node:v1.35.0
+  extraMounts:
+  - hostPath: /usr/local/bin/runsc
+    containerPath: /usr/local/bin/runsc
+    readOnly: true
+  - hostPath: /usr/local/bin/containerd-shim-runsc-v1
+    containerPath: /usr/local/bin/containerd-shim-runsc-v1
+    readOnly: true
+  - hostPath: /etc/containerd/runsc-rootfs.toml
+    containerPath: /etc/containerd/runsc-rootfs.toml
+    readOnly: true
   kubeadmConfigPatches:
   - |
     kind: ClusterConfiguration
@@ -25,5 +52,25 @@ nodes:
     hostPort: 30500
 - role: worker
   image: kindest/node:v1.35.0
+  extraMounts:
+  - hostPath: /usr/local/bin/runsc
+    containerPath: /usr/local/bin/runsc
+    readOnly: true
+  - hostPath: /usr/local/bin/containerd-shim-runsc-v1
+    containerPath: /usr/local/bin/containerd-shim-runsc-v1
+    readOnly: true
+  - hostPath: /etc/containerd/runsc-rootfs.toml
+    containerPath: /etc/containerd/runsc-rootfs.toml
+    readOnly: true
 - role: worker
   image: kindest/node:v1.35.0
+  extraMounts:
+  - hostPath: /usr/local/bin/runsc
+    containerPath: /usr/local/bin/runsc
+    readOnly: true
+  - hostPath: /usr/local/bin/containerd-shim-runsc-v1
+    containerPath: /usr/local/bin/containerd-shim-runsc-v1
+    readOnly: true
+  - hostPath: /etc/containerd/runsc-rootfs.toml
+    containerPath: /etc/containerd/runsc-rootfs.toml
+    readOnly: true

--- a/tests/e2e/runtimeclasses/gvisor-rootfs.yaml
+++ b/tests/e2e/runtimeclasses/gvisor-rootfs.yaml
@@ -1,0 +1,5 @@
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: gvisor-rootfs
+handler: gvisor-rootfs

--- a/tests/e2e/setup-gvisor-rootfs.sh
+++ b/tests/e2e/setup-gvisor-rootfs.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RUNSC_RELEASE="${RUNSC_RELEASE:-release/latest}"
+RUNSC_BIN="${RUNSC_BIN:-/usr/local/bin/runsc}"
+RUNSC_SHIM_BIN="${RUNSC_SHIM_BIN:-/usr/local/bin/containerd-shim-runsc-v1}"
+RUNSC_ROOTFS_CONFIG="${RUNSC_ROOTFS_CONFIG:-/etc/containerd/runsc-rootfs.toml}"
+
+log() {
+  printf '[%s] %s\n' "$(date -Is)" "$*"
+}
+
+run_as_root() {
+  if [[ "$(id -u)" == "0" ]]; then
+    "$@"
+    return
+  fi
+  if command -v sudo >/dev/null 2>&1; then
+    sudo "$@"
+    return
+  fi
+  echo "root privileges are required to install gVisor runtime files" >&2
+  exit 1
+}
+
+runsc_arch() {
+  case "$(uname -m)" in
+    x86_64)
+      printf 'x86_64\n'
+      ;;
+    aarch64|arm64)
+      printf 'arm64\n'
+      ;;
+    *)
+      echo "unsupported architecture for gVisor runsc: $(uname -m)" >&2
+      exit 1
+      ;;
+  esac
+}
+
+retry() {
+  local attempts="$1"
+  shift
+  local delay=3
+  local i=1
+  while true; do
+    if "$@"; then
+      return 0
+    fi
+    if (( i >= attempts )); then
+      return 1
+    fi
+    sleep "${delay}"
+    i=$((i + 1))
+    delay=$((delay * 2))
+    (( delay > 30 )) && delay=30
+  done
+}
+
+install_runsc_binaries() {
+  if [[ -x "${RUNSC_BIN}" && -x "${RUNSC_SHIM_BIN}" ]]; then
+    log "Using existing gVisor binaries at ${RUNSC_BIN} and ${RUNSC_SHIM_BIN}"
+    return
+  fi
+
+  local arch tmp
+  arch="$(runsc_arch)"
+  tmp="$(mktemp -d)"
+
+  log "Installing gVisor runsc ${RUNSC_RELEASE} for ${arch}"
+  retry 5 curl -fsSL -o "${tmp}/runsc" "https://storage.googleapis.com/gvisor/releases/${RUNSC_RELEASE}/${arch}/runsc"
+  retry 5 curl -fsSL -o "${tmp}/containerd-shim-runsc-v1" "https://storage.googleapis.com/gvisor/releases/${RUNSC_RELEASE}/${arch}/containerd-shim-runsc-v1"
+  run_as_root install -m 0755 "${tmp}/runsc" "${RUNSC_BIN}"
+  run_as_root install -m 0755 "${tmp}/containerd-shim-runsc-v1" "${RUNSC_SHIM_BIN}"
+  rm -rf "${tmp}"
+}
+
+write_runsc_rootfs_config() {
+  local tmp
+  tmp="$(mktemp)"
+  cat >"${tmp}" <<'EOF'
+[runsc_config]
+  systemd-cgroup = "false"
+  overlay2 = "none"
+  file-access = "shared"
+EOF
+
+  run_as_root mkdir -p "$(dirname "${RUNSC_ROOTFS_CONFIG}")"
+  run_as_root install -m 0644 "${tmp}" "${RUNSC_ROOTFS_CONFIG}"
+  rm -f "${tmp}"
+}
+
+install_runsc_binaries
+write_runsc_rootfs_config
+
+log "Prepared $(${RUNSC_BIN} --version | head -n1)"
+log "Prepared gvisor-rootfs config at ${RUNSC_ROOTFS_CONFIG}"


### PR DESCRIPTION
## Summary
- install gVisor rootfs runtime files before GitHub e2e creates kind clusters
- register gvisor-rootfs in kind containerd config and apply the matching RuntimeClass
- patch e2e Sandbox0Infra manager config to use gvisor-rootfs without changing public samples

## Validation
- bash -n tests/e2e/setup-gvisor-rootfs.sh
- go test ./pkg/framework
- go test ./tests/e2e/scenarios/single-cluster -run 'TestSelectScenarioManifestPaths|TestSelectScenarioManifestPathsReturnsErrorForNoMatches|TestLoadScenariosUsesManifestInfraNamespace'
- remote kind smoke: RuntimeClass/gvisor-rootfs pod reached Ready
- remote fullmode Ready with tpl-default sandbox pod runtimeClassName=gvisor-rootfs
- remote API claim and egress smoke succeeded
- remote trafficRules allowed example.com and denied example.org