### PR TITLE
Add S3 volume portal backend

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -47,6 +47,13 @@ jobs:
           E2E_CLUSTER_NAME: ${{ env.KIND_CLUSTER_NAME }}
         run: make test-e2e-s0fs-posix
 
+      - name: Run mountpoint-s3 compatibility suite
+        env:
+          E2E_CLUSTER_NAME: ${{ env.KIND_CLUSTER_NAME }}
+          E2E_USE_EXISTING_CLUSTER: "true"
+          E2E_SANDBOX_RUNTIME_CLASS: ""
+        run: make test-e2e-mountpoint-s3-compat
+
       - name: Dump cluster state on failure
         if: failure()
         shell: bash

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build test test-all test-integration test-integration-verbose test-e2e test-e2e-kind test-e2e-destroy test-e2e-load-images test-e2e-prepare-kind test-e2e-setup-gvisor-rootfs test-e2e-specific test-e2e-s0fs-posix test-e2e-s0fs-posix-prepare test-e2e-netd-cni lint tidy vendor clean helm-update helm-configs release docker-build docker-build-local build-local-all docker-push proto manifests apispec oapi-codegen
+.PHONY: all build test test-all test-integration test-integration-verbose test-e2e test-e2e-kind test-e2e-destroy test-e2e-load-images test-e2e-prepare-kind test-e2e-setup-gvisor-rootfs test-e2e-specific test-e2e-mountpoint-s3-compat test-e2e-s0fs-posix test-e2e-s0fs-posix-prepare test-e2e-netd-cni lint tidy vendor clean helm-update helm-configs release docker-build docker-build-local build-local-all docker-push proto manifests apispec oapi-codegen
 
 # Tool Binaries
 LOCALBIN ?= $(shell pwd)/bin
@@ -233,6 +233,18 @@ test-e2e-specific:
 	fi
 	@printf "$(CYAN)Running E2E test: $(SPEC)...$(RESET)\n"
 	unset http_proxy && unset https_proxy && unset all_proxy && $(GO) test -v ./tests/e2e/... -focus="$(SPEC)" -timeout=30m
+
+test-e2e-mountpoint-s3-compat:
+	@printf "$(CYAN)Running mountpoint-s3 compatibility E2E suite...$(RESET)\n"
+	unset http_proxy && unset https_proxy && unset all_proxy && \
+		E2E_SINGLE_CLUSTER_SCENARIOS=volumes \
+		E2E_MOUNTPOINT_S3_COMPAT=true \
+		E2E_USE_EXISTING_CLUSTER=true \
+		E2E_SANDBOX_RUNTIME_CLASS= \
+		$(GO) test -v -count=1 ./tests/e2e/scenarios/single-cluster \
+		-run TestSingleCluster \
+		-ginkgo.focus="API volumes mode.*mountpoint-s3 general bucket compatibility semantics" \
+		-timeout=30m
 
 test-e2e-s0fs-posix-prepare:
 	@printf "$(CYAN)Preparing fullmode infra for S0FS POSIX E2E suite...$(RESET)\n"

--- a/ctld/internal/ctld/portal/manager.go
+++ b/ctld/internal/ctld/portal/manager.go
@@ -79,6 +79,7 @@ type boundVolume struct {
 	mountedAt time.Time
 	refCount  int
 	volCtx    *volume.VolumeContext
+	session   volumefuse.Session
 
 	heartbeatCancel context.CancelFunc
 	heartbeatDone   chan struct{}
@@ -370,7 +371,7 @@ func (m *Manager) Bind(ctx context.Context, req ctldapi.BindVolumePortalRequest)
 	}
 	if bound := m.boundVolumes[req.SandboxVolumeID]; bound != nil {
 		if bound.refCount == 0 {
-			m.attachPortalLocked(pm, req.SandboxVolumeID, volumeRecord.TeamID, mountedAt)
+			m.attachPortalLocked(pm, bound, mountedAt)
 			bound.refCount = 1
 			response := boundResponse(pm)
 			m.mu.Unlock()
@@ -381,7 +382,7 @@ func (m *Manager) Bind(ctx context.Context, req ctldapi.BindVolumePortalRequest)
 			m.mu.Unlock()
 			return ctldapi.BindVolumePortalResponse{}, fmt.Errorf("volume %s is already bound to %s", req.SandboxVolumeID, conflictPath)
 		}
-		m.attachPortalLocked(pm, req.SandboxVolumeID, volumeRecord.TeamID, mountedAt)
+		m.attachPortalLocked(pm, bound, mountedAt)
 		bound.refCount++
 		response := boundResponse(pm)
 		m.mu.Unlock()
@@ -394,21 +395,104 @@ func (m *Manager) Bind(ctx context.Context, req ctldapi.BindVolumePortalRequest)
 	}
 	m.mu.Unlock()
 
+	newBound, cleanupNewBound, err := m.openBoundVolume(ctx, req, volumeRecord, accessMode, mountedAt)
+	if err != nil {
+		return ctldapi.BindVolumePortalResponse{}, err
+	}
+
+	m.mu.Lock()
+	pm = m.portals[key]
+	if pm == nil {
+		m.mu.Unlock()
+		cleanupNewBound()
+		return ctldapi.BindVolumePortalResponse{}, fmt.Errorf("volume portal %s for pod %s is not published", portalName, req.PodUID)
+	}
+	if pm.volumeID != "" {
+		response := boundResponse(pm)
+		m.mu.Unlock()
+		cleanupNewBound()
+		if response.SandboxVolumeID != req.SandboxVolumeID {
+			return ctldapi.BindVolumePortalResponse{}, fmt.Errorf("volume portal already bound to %s", response.SandboxVolumeID)
+		}
+		return response, nil
+	}
+	if bound := m.boundVolumes[req.SandboxVolumeID]; bound != nil {
+		if bound.refCount == 0 {
+			m.attachPortalLocked(pm, bound, mountedAt)
+			bound.refCount = 1
+			response := boundResponse(pm)
+			m.mu.Unlock()
+			cleanupNewBound()
+			return response, nil
+		}
+		if accessMode != volume.AccessModeROX {
+			conflictPath := boundMountPath(m.portals, req.SandboxVolumeID, key)
+			m.mu.Unlock()
+			cleanupNewBound()
+			return ctldapi.BindVolumePortalResponse{}, fmt.Errorf("volume %s is already bound to %s", req.SandboxVolumeID, conflictPath)
+		}
+		m.attachPortalLocked(pm, bound, mountedAt)
+		bound.refCount++
+		response := boundResponse(pm)
+		m.mu.Unlock()
+		cleanupNewBound()
+		return response, nil
+	}
+	if existing := findBoundPortalForVolume(m.portals, req.SandboxVolumeID, key); existing != nil {
+		conflictPath := existing.mountPath
+		m.mu.Unlock()
+		cleanupNewBound()
+		return ctldapi.BindVolumePortalResponse{}, fmt.Errorf("volume %s is already bound to %s", req.SandboxVolumeID, conflictPath)
+	}
+	bound := newBound
+	m.boundVolumes[req.SandboxVolumeID] = bound
+	m.volumes.add(bound.volCtx)
+	m.attachPortalLocked(pm, bound, mountedAt)
+	if err := m.registerOwner(ctx, bound); err != nil {
+		m.clearPortalLocked(pm)
+		delete(m.boundVolumes, req.SandboxVolumeID)
+		m.volumes.remove(req.SandboxVolumeID)
+		m.mu.Unlock()
+		cleanupNewBound()
+		return ctldapi.BindVolumePortalResponse{}, fmt.Errorf("register ctld volume owner: %w", err)
+	}
+	m.startMaterializer(bound)
+	response := boundResponse(pm)
+	m.mu.Unlock()
+
+	return response, nil
+}
+
+func (m *Manager) openBoundVolume(ctx context.Context, req ctldapi.BindVolumePortalRequest, volumeRecord *db.SandboxVolume, accessMode volume.AccessMode, mountedAt time.Time) (*boundVolume, func(), error) {
+	if volumeRecord == nil {
+		return nil, nil, fmt.Errorf("volume record is required")
+	}
+	switch volume.NormalizeBackend(volumeRecord.Backend) {
+	case volume.BackendS0FS:
+		return m.openS0FSBoundVolume(ctx, req, volumeRecord, accessMode, mountedAt)
+	case volume.BackendS3:
+		return m.openS3BoundVolume(req, volumeRecord, accessMode, mountedAt)
+	default:
+		return nil, nil, fmt.Errorf("unsupported volume backend %q", volumeRecord.Backend)
+	}
+}
+
+func (m *Manager) openS0FSBoundVolume(ctx context.Context, req ctldapi.BindVolumePortalRequest, volumeRecord *db.SandboxVolume, accessMode volume.AccessMode, mountedAt time.Time) (*boundVolume, func(), error) {
 	cacheDir := filepath.Join(m.rootDir, "volumes", safePath(req.TeamID), safePath(req.SandboxVolumeID))
 	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
-		return ctldapi.BindVolumePortalResponse{}, fmt.Errorf("create local volume dir: %w", err)
+		return nil, nil, fmt.Errorf("create local volume dir: %w", err)
 	}
 	remoteStore, err := m.createObjectStore(req.TeamID, req.SandboxVolumeID)
 	if err != nil {
-		return ctldapi.BindVolumePortalResponse{}, fmt.Errorf("create object storage: %w", err)
+		return nil, nil, fmt.Errorf("create object storage: %w", err)
 	}
 	encryption, err := volume.S0FSEncryptionConfig(m.storage)
 	if err != nil {
-		return ctldapi.BindVolumePortalResponse{}, err
+		return nil, nil, err
 	}
 	segmentTargetSize, err := volume.S0FSSegmentTargetSize(m.storage)
 	if err != nil {
-		return ctldapi.BindVolumePortalResponse{}, err
+		return nil, nil, err
 	}
 	engine, err := s0fs.Open(ctx, s0fs.Config{
 		VolumeID:          req.SandboxVolumeID,
@@ -423,7 +507,7 @@ func (m *Manager) Bind(ctx context.Context, req ctldapi.BindVolumePortalRequest)
 		LocalDiskGuard: m.localDiskGuard(cacheDir),
 	})
 	if err != nil {
-		return ctldapi.BindVolumePortalResponse{}, fmt.Errorf("open local s0fs engine: %w", err)
+		return nil, nil, fmt.Errorf("open local s0fs engine: %w", err)
 	}
 	volCtx := &volume.VolumeContext{
 		VolumeID:  req.SandboxVolumeID,
@@ -436,50 +520,45 @@ func (m *Manager) Bind(ctx context.Context, req ctldapi.BindVolumePortalRequest)
 		RootPath:  "/",
 		CacheDir:  cacheDir,
 	}
+	bound := &boundVolume{
+		volumeID:  req.SandboxVolumeID,
+		teamID:    volumeRecord.TeamID,
+		access:    accessMode,
+		mountedAt: mountedAt,
+		refCount:  1,
+		volCtx:    volCtx,
+		session:   newLocalSession(req.SandboxVolumeID, m.volumes, m.logrus),
+	}
+	return bound, func() { _ = engine.Close() }, nil
+}
 
-	m.mu.Lock()
-	pm = m.portals[key]
-	if pm == nil {
-		m.mu.Unlock()
-		_ = engine.Close()
-		return ctldapi.BindVolumePortalResponse{}, fmt.Errorf("volume portal %s for pod %s is not published", portalName, req.PodUID)
+func (m *Manager) openS3BoundVolume(req ctldapi.BindVolumePortalRequest, volumeRecord *db.SandboxVolume, accessMode volume.AccessMode, mountedAt time.Time) (*boundVolume, func(), error) {
+	if accessMode == volume.AccessModeRWX {
+		return nil, nil, fmt.Errorf("s3 backend does not support RWX access_mode")
 	}
-	if pm.volumeID != "" {
-		response := boundResponse(pm)
-		m.mu.Unlock()
-		_ = engine.Close()
-		if response.SandboxVolumeID != req.SandboxVolumeID {
-			return ctldapi.BindVolumePortalResponse{}, fmt.Errorf("volume portal already bound to %s", response.SandboxVolumeID)
-		}
-		return response, nil
+	cfg, err := volume.DecodeS3BackendConfig(volumeRecord.BackendConfig)
+	if err != nil {
+		return nil, nil, err
 	}
-	if bound := m.boundVolumes[req.SandboxVolumeID]; bound != nil {
-		if bound.refCount == 0 {
-			m.attachPortalLocked(pm, req.SandboxVolumeID, volumeRecord.TeamID, mountedAt)
-			bound.refCount = 1
-			response := boundResponse(pm)
-			m.mu.Unlock()
-			_ = engine.Close()
-			return response, nil
-		}
-		if accessMode != volume.AccessModeROX {
-			conflictPath := boundMountPath(m.portals, req.SandboxVolumeID, key)
-			m.mu.Unlock()
-			_ = engine.Close()
-			return ctldapi.BindVolumePortalResponse{}, fmt.Errorf("volume %s is already bound to %s", req.SandboxVolumeID, conflictPath)
-		}
-		m.attachPortalLocked(pm, req.SandboxVolumeID, volumeRecord.TeamID, mountedAt)
-		bound.refCount++
-		response := boundResponse(pm)
-		m.mu.Unlock()
-		_ = engine.Close()
-		return response, nil
+	store, err := objectstore.Create(volume.S3ObjectStoreConfig(cfg, m.storage, nil))
+	if err != nil {
+		return nil, nil, fmt.Errorf("create s3 object storage: %w", err)
 	}
-	if existing := findBoundPortalForVolume(m.portals, req.SandboxVolumeID, key); existing != nil {
-		conflictPath := existing.mountPath
-		m.mu.Unlock()
-		_ = engine.Close()
-		return ctldapi.BindVolumePortalResponse{}, fmt.Errorf("volume %s is already bound to %s", req.SandboxVolumeID, conflictPath)
+	if cfg.Prefix != "" {
+		store = objectstore.Prefix(store, cfg.Prefix)
+	}
+	if store == nil {
+		return nil, nil, fmt.Errorf("s3 object storage is not configured")
+	}
+	session := newS3Session(req.SandboxVolumeID, store, accessMode, m.logrus)
+	volCtx := &volume.VolumeContext{
+		VolumeID:  req.SandboxVolumeID,
+		TeamID:    volumeRecord.TeamID,
+		Backend:   volume.BackendS3,
+		Access:    accessMode,
+		MountedAt: mountedAt,
+		RootInode: 1,
+		RootPath:  "/",
 	}
 	bound := &boundVolume{
 		volumeID:  req.SandboxVolumeID,
@@ -488,23 +567,9 @@ func (m *Manager) Bind(ctx context.Context, req ctldapi.BindVolumePortalRequest)
 		mountedAt: mountedAt,
 		refCount:  1,
 		volCtx:    volCtx,
+		session:   session,
 	}
-	m.boundVolumes[req.SandboxVolumeID] = bound
-	m.volumes.add(volCtx)
-	m.attachPortalLocked(pm, req.SandboxVolumeID, volumeRecord.TeamID, mountedAt)
-	if err := m.registerOwner(ctx, bound); err != nil {
-		m.clearPortalLocked(pm)
-		delete(m.boundVolumes, req.SandboxVolumeID)
-		m.volumes.remove(req.SandboxVolumeID)
-		m.mu.Unlock()
-		_ = engine.Close()
-		return ctldapi.BindVolumePortalResponse{}, fmt.Errorf("register ctld volume owner: %w", err)
-	}
-	m.startMaterializer(bound)
-	response := boundResponse(pm)
-	m.mu.Unlock()
-
-	return response, nil
+	return bound, session.Close, nil
 }
 
 func (m *Manager) Unbind(ctx context.Context, req ctldapi.UnbindVolumePortalRequest) (ctldapi.UnbindVolumePortalResponse, error) {
@@ -576,6 +641,9 @@ func (m *Manager) AttachOwner(ctx context.Context, req ctldapi.AttachVolumeOwner
 	if err != nil {
 		return ctldapi.AttachVolumeOwnerResponse{}, err
 	}
+	if volume.NormalizeBackend(volumeRecord.Backend) != volume.BackendS0FS {
+		return ctldapi.AttachVolumeOwnerResponse{}, fmt.Errorf("ctld owner attach is only supported for s0fs volumes")
+	}
 
 	m.mu.Lock()
 	if bound := m.boundVolumes[req.SandboxVolumeID]; bound != nil {
@@ -643,6 +711,7 @@ func (m *Manager) AttachOwner(ctx context.Context, req ctldapi.AttachVolumeOwner
 		mountedAt: mountedAt,
 		refCount:  0,
 		volCtx:    volCtx,
+		session:   newLocalSession(req.SandboxVolumeID, m.volumes, m.logrus),
 	}
 	m.boundVolumes[req.SandboxVolumeID] = bound
 	m.volumes.add(volCtx)
@@ -778,6 +847,7 @@ func (m *Manager) releaseOwnerOnlyVolumeLocked(ctx context.Context, volumeID str
 	if done != nil {
 		<-done
 	}
+	closeBoundSession(bound)
 	if err := m.volumes.UnmountVolume(ctx, volumeID, ""); err != nil {
 		return err
 	}
@@ -808,6 +878,7 @@ func (m *Manager) unbindLockedSnapshot(pm *portalMount) error {
 		<-bound.materializeDone
 		bound.materializeDone = nil
 	}
+	closeBoundSession(bound)
 	if err := m.volumes.UnmountVolume(context.Background(), volumeID, ""); err != nil {
 		return err
 	}
@@ -1049,15 +1120,20 @@ func sameS0FSHeadKey(a, b *s0fs.CommittedHead) bool {
 	return strings.TrimSpace(a.ManifestKey) == strings.TrimSpace(b.ManifestKey)
 }
 
-func (m *Manager) attachPortalLocked(pm *portalMount, volumeID, teamID string, mountedAt time.Time) {
-	if pm == nil {
+func (m *Manager) attachPortalLocked(pm *portalMount, bound *boundVolume, mountedAt time.Time) {
+	if pm == nil || bound == nil {
 		return
 	}
 	if pm.fs != nil {
-		pm.fs.SetSession(newLocalSession(volumeID, m.volumes, m.logrus))
+		session := bound.session
+		if session == nil {
+			session = newLocalSession(bound.volumeID, m.volumes, m.logrus)
+			bound.session = session
+		}
+		pm.fs.SetSession(session)
 	}
-	pm.volumeID = volumeID
-	pm.teamID = teamID
+	pm.volumeID = bound.volumeID
+	pm.teamID = bound.teamID
 	pm.mountedAt = mountedAt
 }
 
@@ -1071,6 +1147,14 @@ func (m *Manager) clearPortalLocked(pm *portalMount) {
 	pm.volumeID = ""
 	pm.teamID = ""
 	pm.mountedAt = time.Time{}
+}
+
+func closeBoundSession(bound *boundVolume) {
+	if bound == nil || bound.session == nil {
+		return
+	}
+	bound.session.Close()
+	bound.session = nil
 }
 
 func boundResponse(pm *portalMount) ctldapi.BindVolumePortalResponse {

--- a/ctld/internal/ctld/portal/s3_session.go
+++ b/ctld/internal/ctld/portal/s3_session.go
@@ -731,21 +731,22 @@ func (s *s3Session) resolvePath(ctx context.Context, key string) (*s3Node, error
 
 func (s *s3Session) dirInfo(ctx context.Context, key string) (objectstore.Info, bool, error) {
 	prefix := strings.TrimRight(key, "/") + "/"
+	infos, err := s.listAllLimited(ctx, prefix, "", 1)
+	if err != nil {
+		return objectstore.Info{}, false, err
+	}
+	if len(infos) > 0 {
+		return infos[0], true, nil
+	}
 	if info, err := s.store.Head(prefix); err == nil {
 		return info, true, nil
 	}
-	infos, err := s.listAllLimited(ctx, prefix, "/", 1)
+	infos, err = s.listAllLimited(ctx, prefix, "/", 1)
 	if err != nil {
 		return objectstore.Info{}, false, err
 	}
 	if len(infos) == 0 {
-		infos, err = s.listAllLimited(ctx, prefix, "", 1)
-		if err != nil {
-			return objectstore.Info{}, false, err
-		}
-		if len(infos) == 0 {
-			return objectstore.Info{}, false, nil
-		}
+		return objectstore.Info{}, false, nil
 	}
 	return infos[0], true, nil
 }

--- a/ctld/internal/ctld/portal/s3_session.go
+++ b/ctld/internal/ctld/portal/s3_session.go
@@ -267,6 +267,9 @@ func (s *s3Session) Unlink(ctx context.Context, req *pb.UnlinkRequest) (*pb.Empt
 		return nil, err
 	}
 	filePath := joinS3Path(parent.path, name)
+	if node, ok := s.nodeForPath(filePath); ok && s.hasOpenWriter(node.inode) {
+		return nil, syscall.EPERM
+	}
 	node, err := s.resolvePath(ctx, filePath)
 	if err != nil {
 		return nil, err
@@ -531,6 +534,7 @@ func (s *s3Session) ReadDir(ctx context.Context, req *pb.ReadDirRequest) (*pb.Re
 		return nil, err
 	}
 	entriesByName := make(map[string]*pb.DirEntry)
+	s.addLocalDirEntries(node, prefix, req.Plus, entriesByName)
 	for _, info := range infos {
 		if info.Key == prefix {
 			continue
@@ -573,6 +577,49 @@ func (s *s3Session) ReadDir(ctx context.Context, req *pb.ReadDirRequest) (*pb.Re
 		out = append(out, entry)
 	}
 	return &pb.ReadDirResponse{Entries: out, Eof: true}, nil
+}
+
+func (s *s3Session) addLocalDirEntries(node *s3Node, prefix string, plus bool, entriesByName map[string]*pb.DirEntry) {
+	s.mu.Lock()
+	nodes := make([]s3Node, 0, len(s.nodesByInode))
+	for _, entry := range s.nodesByInode {
+		if entry == nil || entry.inode == node.inode || entry.path == "" {
+			continue
+		}
+		copyNode := *entry
+		nodes = append(nodes, copyNode)
+	}
+	s.mu.Unlock()
+
+	for i := range nodes {
+		entryNode := &nodes[i]
+		if !strings.HasPrefix(entryNode.path, prefix) {
+			continue
+		}
+		name, kind, ok := directS3Entry(prefix, objectstore.Info{
+			Key:      entryNode.path,
+			Size:     entryNode.size,
+			Modified: entryNode.modified,
+			IsPrefix: entryNode.kind == s3NodeDir,
+		})
+		if !ok {
+			continue
+		}
+		entryPath := joinS3Path(node.path, name)
+		remembered := s.rememberPath(entryPath, kind, entryNode.size, entryNode.modified)
+		dirEntry := &pb.DirEntry{
+			Inode: remembered.inode,
+			Name:  name,
+			Type:  s3TypeNumber(kind),
+		}
+		if plus {
+			dirEntry.Attr = s.attr(remembered)
+		}
+		if existing := entriesByName[name]; existing != nil && existing.Type&uint32(syscall.S_IFMT) == uint32(syscall.S_IFDIR) {
+			continue
+		}
+		entriesByName[name] = dirEntry
+	}
 }
 
 func (s *s3Session) ReleaseDir(_ context.Context, req *pb.ReleaseDirRequest) (*pb.Empty, error) {
@@ -633,6 +680,9 @@ func (s *s3Session) resolvePath(ctx context.Context, key string) (*s3Node, error
 	key = cleanS3Path(key)
 	if key == "" {
 		return s.rememberPath("", s3NodeDir, 0, time.Now().UTC()), nil
+	}
+	if node, ok := s.nodeForPath(key); ok && s.hasOpenWriter(node.inode) {
+		return node, nil
 	}
 	if info, ok, err := s.dirInfo(ctx, key); err != nil {
 		return nil, err

--- a/ctld/internal/ctld/portal/s3_session.go
+++ b/ctld/internal/ctld/portal/s3_session.go
@@ -488,16 +488,16 @@ func (s *s3Session) Release(ctx context.Context, req *pb.ReleaseRequest) (*pb.Em
 	return &pb.Empty{}, nil
 }
 
-func (s *s3Session) Flush(ctx context.Context, req *pb.FlushRequest) (*pb.Empty, error) {
+func (s *s3Session) Flush(_ context.Context, _ *pb.FlushRequest) (*pb.Empty, error) {
+	return &pb.Empty{}, nil
+}
+
+func (s *s3Session) Fsync(ctx context.Context, req *pb.FsyncRequest) (*pb.Empty, error) {
 	handle := s.handle(req.HandleId)
 	if handle == nil || !handle.writable {
 		return &pb.Empty{}, nil
 	}
 	return &pb.Empty{}, s.commitHandle(ctx, handle)
-}
-
-func (s *s3Session) Fsync(ctx context.Context, req *pb.FsyncRequest) (*pb.Empty, error) {
-	return s.Flush(ctx, &pb.FlushRequest{HandleId: req.HandleId})
 }
 
 func (s *s3Session) Fallocate(context.Context, *pb.FallocateRequest) (*pb.Empty, error) {

--- a/ctld/internal/ctld/portal/s3_session.go
+++ b/ctld/internal/ctld/portal/s3_session.go
@@ -38,11 +38,12 @@ const (
 )
 
 type s3Node struct {
-	inode    uint64
-	path     string
-	kind     s3NodeKind
-	size     int64
-	modified time.Time
+	inode     uint64
+	path      string
+	kind      s3NodeKind
+	size      int64
+	modified  time.Time
+	localOnly bool
 }
 
 type s3Handle struct {
@@ -222,10 +223,7 @@ func (s *s3Session) Mkdir(ctx context.Context, req *pb.MkdirRequest) (*pb.NodeRe
 	} else if fserror.CodeOf(err) != fserror.NotFound {
 		return nil, err
 	}
-	if err := s.store.Put(dirPath+"/", bytes.NewReader(nil)); err != nil {
-		return nil, err
-	}
-	node := s.rememberPath(dirPath, s3NodeDir, 0, time.Now().UTC())
+	node := s.rememberLocalDir(dirPath, time.Now().UTC())
 	return s.nodeResponse(node, 0), nil
 }
 
@@ -298,21 +296,25 @@ func (s *s3Session) Rmdir(ctx context.Context, req *pb.RmdirRequest) (*pb.Empty,
 		return nil, err
 	}
 	dirPath := joinS3Path(parent.path, name)
-	if _, err := s.resolvePath(ctx, dirPath); err != nil {
-		return nil, err
-	}
-	prefix := dirPath + "/"
-	entries, _, _, err := s.store.List(prefix, "", "", "", 2)
+	node, err := s.resolvePath(ctx, dirPath)
 	if err != nil {
 		return nil, err
 	}
-	for _, entry := range entries {
-		if entry.Key != prefix {
-			return nil, syscall.ENOTEMPTY
-		}
+	if node.kind != s3NodeDir {
+		return nil, syscall.ENOTDIR
 	}
-	if err := s.store.Delete(prefix); err != nil && !objectstore.IsNotFound(err) {
+	if _, exists, err := s.dirInfo(ctx, dirPath); err != nil {
 		return nil, err
+	} else if exists {
+		return nil, syscall.ENOTEMPTY
+	}
+	if !node.localOnly {
+		s.forgetPath(dirPath)
+		return nil, fserror.New(fserror.NotFound, "entry not found")
+	}
+	prefix := dirPath + "/"
+	if s.hasRememberedChild(prefix) {
+		return nil, syscall.ENOTEMPTY
 	}
 	s.forgetPath(dirPath)
 	return &pb.Empty{}, nil
@@ -697,6 +699,14 @@ func (s *s3Session) resolvePath(ctx context.Context, key string) (*s3Node, error
 	if key == "" {
 		return s.rememberPath("", s3NodeDir, 0, time.Now().UTC()), nil
 	}
+	if node, ok := s.nodeForPath(key); ok && node.kind == s3NodeDir && node.localOnly {
+		if info, exists, err := s.dirInfo(ctx, key); err != nil {
+			return nil, err
+		} else if exists {
+			return s.rememberPath(key, s3NodeDir, 0, info.Modified), nil
+		}
+		return node, nil
+	}
 	if node, ok := s.nodeForPath(key); ok && s.hasOpenWriter(node.inode) {
 		return node, nil
 	}
@@ -797,6 +807,14 @@ func (s *s3Session) nodeForPath(key string) (*s3Node, bool) {
 }
 
 func (s *s3Session) rememberPath(key string, kind s3NodeKind, size int64, modified time.Time) *s3Node {
+	return s.rememberPathWithLocal(key, kind, size, modified, false)
+}
+
+func (s *s3Session) rememberLocalDir(key string, modified time.Time) *s3Node {
+	return s.rememberPathWithLocal(key, s3NodeDir, 0, modified, true)
+}
+
+func (s *s3Session) rememberPathWithLocal(key string, kind s3NodeKind, size int64, modified time.Time, localOnly bool) *s3Node {
 	key = cleanS3Path(key)
 	if modified.IsZero() {
 		modified = time.Now().UTC()
@@ -809,7 +827,7 @@ func (s *s3Session) rememberPath(key string, kind s3NodeKind, size int64, modifi
 		s.nextInode++
 		s.inodeByPath[key] = inode
 	}
-	node := &s3Node{inode: inode, path: key, kind: kind, size: size, modified: modified}
+	node := &s3Node{inode: inode, path: key, kind: kind, size: size, modified: modified, localOnly: localOnly}
 	s.nodesByInode[inode] = node
 	copyNode := *node
 	return &copyNode
@@ -824,6 +842,24 @@ func (s *s3Session) forgetPath(key string) {
 		delete(s.nodesByInode, inode)
 	}
 	delete(s.inodeByPath, key)
+}
+
+func (s *s3Session) hasRememberedChild(prefix string) bool {
+	prefix = cleanS3Path(prefix)
+	if prefix != "" {
+		prefix += "/"
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, node := range s.nodesByInode {
+		if node == nil || node.path == "" || node.path == strings.TrimSuffix(prefix, "/") {
+			continue
+		}
+		if strings.HasPrefix(node.path, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *s3Session) newHandle(handle *s3Handle) uint64 {

--- a/ctld/internal/ctld/portal/s3_session.go
+++ b/ctld/internal/ctld/portal/s3_session.go
@@ -549,6 +549,17 @@ func (s *s3Session) ReadDir(ctx context.Context, req *pb.ReadDirRequest) (*pb.Re
 			continue
 		}
 		entryPath := joinS3Path(node.path, name)
+		if kind == s3NodeFile {
+			dir, exists, err := s.dirInfo(ctx, entryPath)
+			if err != nil {
+				return nil, err
+			}
+			if exists {
+				kind = s3NodeDir
+				info.Size = 0
+				info.Modified = dir.Modified
+			}
+		}
 		entryNode := s.rememberPath(entryPath, kind, info.Size, info.Modified)
 		entry := &pb.DirEntry{
 			Inode: entryNode.inode,
@@ -714,7 +725,13 @@ func (s *s3Session) dirInfo(ctx context.Context, key string) (objectstore.Info, 
 		return objectstore.Info{}, false, err
 	}
 	if len(infos) == 0 {
-		return objectstore.Info{}, false, nil
+		infos, err = s.listAllLimited(ctx, prefix, "", 1)
+		if err != nil {
+			return objectstore.Info{}, false, err
+		}
+		if len(infos) == 0 {
+			return objectstore.Info{}, false, nil
+		}
 	}
 	return infos[0], true, nil
 }

--- a/ctld/internal/ctld/portal/s3_session.go
+++ b/ctld/internal/ctld/portal/s3_session.go
@@ -1,0 +1,908 @@
+package portal
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"path"
+	"sort"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/sandbox0-ai/sandbox0/pkg/volumefuse"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/fserror"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/fsmeta"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/objectstore"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volume"
+	pb "github.com/sandbox0-ai/sandbox0/storage-proxy/proto/fs"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	s3RootInode = uint64(fsmeta.RootInode)
+	s3DirMode   = uint32(syscall.S_IFDIR | 0o755)
+	s3FileMode  = uint32(syscall.S_IFREG | 0o644)
+
+	fuseFattrSize = uint32(1 << 3)
+)
+
+type s3NodeKind uint8
+
+const (
+	s3NodeFile s3NodeKind = iota + 1
+	s3NodeDir
+)
+
+type s3Node struct {
+	inode    uint64
+	path     string
+	kind     s3NodeKind
+	size     int64
+	modified time.Time
+}
+
+type s3Handle struct {
+	inode     uint64
+	path      string
+	writable  bool
+	buffer    bytes.Buffer
+	committed bool
+	closed    bool
+}
+
+type s3Session struct {
+	volumeID string
+	store    objectstore.Store
+	access   volume.AccessMode
+	logger   *logrus.Logger
+
+	mu           sync.Mutex
+	nextInode    uint64
+	nextHandleID uint64
+	nodesByInode map[uint64]*s3Node
+	inodeByPath  map[string]uint64
+	handles      map[uint64]*s3Handle
+	implicit     map[uint64]*s3Handle
+}
+
+func newS3Session(volumeID string, store objectstore.Store, access volume.AccessMode, logger *logrus.Logger) *s3Session {
+	if logger == nil {
+		logger = logrus.New()
+	}
+	now := time.Now().UTC()
+	root := &s3Node{inode: s3RootInode, kind: s3NodeDir, modified: now}
+	return &s3Session{
+		volumeID:     volumeID,
+		store:        store,
+		access:       volume.NormalizeAccessMode(string(access)),
+		logger:       logger,
+		nextInode:    s3RootInode + 1,
+		nodesByInode: map[uint64]*s3Node{s3RootInode: root},
+		inodeByPath:  map[string]uint64{"": s3RootInode},
+		handles:      make(map[uint64]*s3Handle),
+		implicit:     make(map[uint64]*s3Handle),
+	}
+}
+
+func (s *s3Session) OpenFlags() uint32 {
+	return fuse.FOPEN_DIRECT_IO
+}
+
+func (s *s3Session) Close() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	handles := make([]*s3Handle, 0, len(s.handles))
+	for id, handle := range s.handles {
+		if handle != nil && handle.writable && !handle.closed {
+			handles = append(handles, handle)
+		}
+		delete(s.handles, id)
+	}
+	for inode, handle := range s.implicit {
+		if handle != nil && handle.writable && !handle.closed {
+			handles = append(handles, handle)
+		}
+		delete(s.implicit, inode)
+	}
+	s.mu.Unlock()
+	for _, handle := range handles {
+		if err := s.commitHandle(context.Background(), handle); err != nil && s.logger != nil {
+			s.logger.WithError(err).WithField("key", handle.path).Warn("Failed to commit s3 handle during close")
+		}
+	}
+}
+
+func (s *s3Session) Lookup(ctx context.Context, req *pb.LookupRequest) (*pb.NodeResponse, error) {
+	parent, err := s.nodeForInode(req.Parent)
+	if err != nil {
+		return nil, err
+	}
+	if parent.kind != s3NodeDir {
+		return nil, syscall.ENOTDIR
+	}
+	name, err := cleanS3Name(req.Name)
+	if err != nil {
+		return nil, err
+	}
+	childPath := joinS3Path(parent.path, name)
+	node, err := s.resolvePath(ctx, childPath)
+	if err != nil {
+		return nil, err
+	}
+	return s.nodeResponse(node, 0), nil
+}
+
+func (s *s3Session) GetAttr(ctx context.Context, req *pb.GetAttrRequest) (*pb.GetAttrResponse, error) {
+	node, err := s.nodeForInode(req.Inode)
+	if err != nil {
+		return nil, err
+	}
+	if node.inode != s3RootInode {
+		if refreshed, refreshErr := s.resolvePath(ctx, node.path); refreshErr == nil {
+			node = refreshed
+		} else {
+			return nil, refreshErr
+		}
+	}
+	return s.attr(node), nil
+}
+
+func (s *s3Session) SetAttr(ctx context.Context, req *pb.SetAttrRequest) (*pb.SetAttrResponse, error) {
+	node, err := s.nodeForInode(req.Inode)
+	if err != nil {
+		return nil, err
+	}
+	if req.Valid&fuseFattrSize == 0 {
+		return &pb.SetAttrResponse{Attr: s.attr(node)}, nil
+	}
+	if err := s.ensureWritable(); err != nil {
+		return nil, err
+	}
+	if node.kind != s3NodeFile {
+		return nil, syscall.EISDIR
+	}
+	if req.Attr == nil || req.Attr.Size != 0 {
+		return nil, syscall.EOPNOTSUPP
+	}
+	if _, err := s.resolvePath(ctx, node.path); err != nil {
+		return nil, err
+	}
+	if err := s.store.Put(node.path, bytes.NewReader(nil)); err != nil {
+		return nil, err
+	}
+	node = s.rememberPath(node.path, s3NodeFile, 0, time.Now().UTC())
+	return &pb.SetAttrResponse{Attr: s.attr(node)}, nil
+}
+
+func (s *s3Session) Mkdir(ctx context.Context, req *pb.MkdirRequest) (*pb.NodeResponse, error) {
+	if err := s.ensureWritable(); err != nil {
+		return nil, err
+	}
+	parent, err := s.nodeForInode(req.Parent)
+	if err != nil {
+		return nil, err
+	}
+	if parent.kind != s3NodeDir {
+		return nil, syscall.ENOTDIR
+	}
+	name, err := cleanS3Name(req.Name)
+	if err != nil {
+		return nil, err
+	}
+	dirPath := joinS3Path(parent.path, name)
+	if _, err := s.resolvePath(ctx, dirPath); err == nil {
+		return nil, fserror.New(fserror.AlreadyExists, "entry already exists")
+	} else if fserror.CodeOf(err) != fserror.NotFound {
+		return nil, err
+	}
+	if err := s.store.Put(dirPath+"/", bytes.NewReader(nil)); err != nil {
+		return nil, err
+	}
+	node := s.rememberPath(dirPath, s3NodeDir, 0, time.Now().UTC())
+	return s.nodeResponse(node, 0), nil
+}
+
+func (s *s3Session) Create(ctx context.Context, req *pb.CreateRequest) (*pb.NodeResponse, error) {
+	if err := s.ensureWritable(); err != nil {
+		return nil, err
+	}
+	parent, err := s.nodeForInode(req.Parent)
+	if err != nil {
+		return nil, err
+	}
+	if parent.kind != s3NodeDir {
+		return nil, syscall.ENOTDIR
+	}
+	name, err := cleanS3Name(req.Name)
+	if err != nil {
+		return nil, err
+	}
+	filePath := joinS3Path(parent.path, name)
+	if _, err := s.resolvePath(ctx, filePath); err == nil {
+		return nil, fserror.New(fserror.AlreadyExists, "entry already exists")
+	} else if fserror.CodeOf(err) != fserror.NotFound {
+		return nil, err
+	}
+	if err := s.store.Put(filePath, bytes.NewReader(nil)); err != nil {
+		return nil, err
+	}
+	node := s.rememberPath(filePath, s3NodeFile, 0, time.Now().UTC())
+	handleID := s.newHandle(&s3Handle{inode: node.inode, path: filePath, writable: true, committed: true})
+	return s.nodeResponse(node, handleID), nil
+}
+
+func (s *s3Session) Unlink(ctx context.Context, req *pb.UnlinkRequest) (*pb.Empty, error) {
+	if err := s.ensureWritable(); err != nil {
+		return nil, err
+	}
+	parent, err := s.nodeForInode(req.Parent)
+	if err != nil {
+		return nil, err
+	}
+	name, err := cleanS3Name(req.Name)
+	if err != nil {
+		return nil, err
+	}
+	filePath := joinS3Path(parent.path, name)
+	node, err := s.resolvePath(ctx, filePath)
+	if err != nil {
+		return nil, err
+	}
+	if node.kind != s3NodeFile {
+		return nil, syscall.EISDIR
+	}
+	if err := s.store.Delete(filePath); err != nil && !objectstore.IsNotFound(err) {
+		return nil, err
+	}
+	s.forgetPath(filePath)
+	return &pb.Empty{}, nil
+}
+
+func (s *s3Session) Rmdir(ctx context.Context, req *pb.RmdirRequest) (*pb.Empty, error) {
+	if err := s.ensureWritable(); err != nil {
+		return nil, err
+	}
+	parent, err := s.nodeForInode(req.Parent)
+	if err != nil {
+		return nil, err
+	}
+	name, err := cleanS3Name(req.Name)
+	if err != nil {
+		return nil, err
+	}
+	dirPath := joinS3Path(parent.path, name)
+	if _, err := s.resolvePath(ctx, dirPath); err != nil {
+		return nil, err
+	}
+	prefix := dirPath + "/"
+	entries, _, _, err := s.store.List(prefix, "", "", "", 2)
+	if err != nil {
+		return nil, err
+	}
+	for _, entry := range entries {
+		if entry.Key != prefix {
+			return nil, syscall.ENOTEMPTY
+		}
+	}
+	if err := s.store.Delete(prefix); err != nil && !objectstore.IsNotFound(err) {
+		return nil, err
+	}
+	s.forgetPath(dirPath)
+	return &pb.Empty{}, nil
+}
+
+func (s *s3Session) Rename(context.Context, *pb.RenameRequest) (*pb.Empty, error) {
+	return nil, syscall.EOPNOTSUPP
+}
+
+func (s *s3Session) Link(context.Context, *pb.LinkRequest) (*pb.NodeResponse, error) {
+	return nil, syscall.EOPNOTSUPP
+}
+
+func (s *s3Session) Symlink(context.Context, *pb.SymlinkRequest) (*pb.NodeResponse, error) {
+	return nil, syscall.EOPNOTSUPP
+}
+
+func (s *s3Session) Readlink(context.Context, *pb.ReadlinkRequest) (*pb.ReadlinkResponse, error) {
+	return nil, syscall.EINVAL
+}
+
+func (s *s3Session) Access(ctx context.Context, req *pb.AccessRequest) (*pb.Empty, error) {
+	if _, err := s.GetAttr(ctx, &pb.GetAttrRequest{Inode: req.Inode}); err != nil {
+		return nil, err
+	}
+	if req.Mask&2 != 0 {
+		return &pb.Empty{}, s.ensureWritable()
+	}
+	return &pb.Empty{}, nil
+}
+
+func (s *s3Session) Open(ctx context.Context, req *pb.OpenRequest) (*pb.OpenResponse, error) {
+	node, err := s.nodeForInode(req.Inode)
+	if err != nil {
+		return nil, err
+	}
+	node, err = s.resolvePath(ctx, node.path)
+	if err != nil {
+		return nil, err
+	}
+	if node.kind == s3NodeDir {
+		return nil, syscall.EISDIR
+	}
+	writable := req.Flags&uint32(syscall.O_ACCMODE) != uint32(syscall.O_RDONLY)
+	if writable {
+		if err := s.ensureWritable(); err != nil {
+			return nil, err
+		}
+		if req.Flags&uint32(syscall.O_APPEND) != 0 {
+			return nil, syscall.EOPNOTSUPP
+		}
+		handleID := s.newHandle(&s3Handle{inode: node.inode, path: node.path, writable: true})
+		s.updateNodeSize(node.inode, 0)
+		return &pb.OpenResponse{HandleId: handleID}, nil
+	}
+	handleID := s.newHandle(&s3Handle{inode: node.inode, path: node.path})
+	return &pb.OpenResponse{HandleId: handleID}, nil
+}
+
+func (s *s3Session) Read(ctx context.Context, req *pb.ReadRequest) (*pb.ReadResponse, error) {
+	size := req.Size
+	if size < 0 {
+		return nil, fserror.New(fserror.InvalidArgument, "negative read size")
+	}
+	buf := make([]byte, size)
+	n, eof, err := s.ReadInto(ctx, req, buf)
+	if err != nil {
+		return nil, err
+	}
+	return &pb.ReadResponse{Data: buf[:n], Eof: eof}, nil
+}
+
+func (s *s3Session) ReadInto(ctx context.Context, req *pb.ReadRequest, dest []byte) (int, bool, error) {
+	if req.Offset < 0 {
+		return 0, false, fserror.New(fserror.InvalidArgument, "negative read offset")
+	}
+	node, err := s.nodeForInode(req.Inode)
+	if err != nil {
+		return 0, false, err
+	}
+	node, err = s.resolvePath(ctx, node.path)
+	if err != nil {
+		return 0, false, err
+	}
+	if node.kind != s3NodeFile {
+		return 0, false, syscall.EISDIR
+	}
+	if req.Offset >= node.size || len(dest) == 0 {
+		return 0, true, nil
+	}
+	limit := int64(len(dest))
+	if remaining := node.size - req.Offset; remaining < limit {
+		limit = remaining
+		dest = dest[:remaining]
+	}
+	reader, err := s.store.Get(node.path, req.Offset, limit)
+	if err != nil {
+		if objectstore.IsNotFound(err) {
+			return 0, false, fserror.New(fserror.NotFound, "entry not found")
+		}
+		return 0, false, err
+	}
+	defer reader.Close()
+	n, err := io.ReadFull(reader, dest)
+	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+		return 0, false, err
+	}
+	return n, req.Offset+int64(n) >= node.size, nil
+}
+
+func (s *s3Session) Write(_ context.Context, req *pb.WriteRequest) (*pb.WriteResponse, error) {
+	if err := s.ensureWritable(); err != nil {
+		return nil, err
+	}
+	handle := s.handle(req.HandleId)
+	implicit := false
+	if handle == nil && req.HandleId == 0 {
+		var err error
+		handle, err = s.handlelessWritableHandle(req.Inode)
+		if err != nil {
+			return nil, err
+		}
+		implicit = true
+	}
+	if handle == nil || !handle.writable || handle.closed {
+		return nil, syscall.EBADF
+	}
+	if req.Offset != int64(handle.buffer.Len()) {
+		return nil, fserror.New(fserror.InvalidArgument, "s3 backend only supports sequential writes for new files")
+	}
+	n, err := handle.buffer.Write(req.Data)
+	if err != nil {
+		return nil, err
+	}
+	handle.committed = false
+	s.updateNodeSize(handle.inode, int64(handle.buffer.Len()))
+	if implicit {
+		if err := s.commitHandle(context.Background(), handle); err != nil {
+			return nil, err
+		}
+	}
+	return &pb.WriteResponse{BytesWritten: int64(n)}, nil
+}
+
+func (s *s3Session) Release(ctx context.Context, req *pb.ReleaseRequest) (*pb.Empty, error) {
+	handle := s.takeHandle(req.HandleId)
+	if handle == nil && req.HandleId == 0 {
+		handle = s.takeHandlelessWritableHandle(req.Inode)
+	}
+	if handle == nil {
+		return &pb.Empty{}, nil
+	}
+	handle.closed = true
+	if handle.writable {
+		return &pb.Empty{}, s.commitHandle(ctx, handle)
+	}
+	return &pb.Empty{}, nil
+}
+
+func (s *s3Session) Flush(ctx context.Context, req *pb.FlushRequest) (*pb.Empty, error) {
+	handle := s.handle(req.HandleId)
+	if handle == nil || !handle.writable {
+		return &pb.Empty{}, nil
+	}
+	return &pb.Empty{}, s.commitHandle(ctx, handle)
+}
+
+func (s *s3Session) Fsync(ctx context.Context, req *pb.FsyncRequest) (*pb.Empty, error) {
+	return s.Flush(ctx, &pb.FlushRequest{HandleId: req.HandleId})
+}
+
+func (s *s3Session) Fallocate(context.Context, *pb.FallocateRequest) (*pb.Empty, error) {
+	return nil, syscall.EOPNOTSUPP
+}
+
+func (s *s3Session) CopyFileRange(context.Context, *pb.CopyFileRangeRequest) (*pb.CopyFileRangeResponse, error) {
+	return nil, syscall.EOPNOTSUPP
+}
+
+func (s *s3Session) OpenDir(ctx context.Context, req *pb.OpenDirRequest) (*pb.OpenDirResponse, error) {
+	node, err := s.nodeForInode(req.Inode)
+	if err != nil {
+		return nil, err
+	}
+	node, err = s.resolvePath(ctx, node.path)
+	if err != nil {
+		return nil, err
+	}
+	if node.kind != s3NodeDir {
+		return nil, syscall.ENOTDIR
+	}
+	handleID := s.newHandle(&s3Handle{inode: node.inode, path: node.path})
+	return &pb.OpenDirResponse{HandleId: handleID}, nil
+}
+
+func (s *s3Session) ReadDir(ctx context.Context, req *pb.ReadDirRequest) (*pb.ReadDirResponse, error) {
+	node, err := s.nodeForInode(req.Inode)
+	if err != nil {
+		return nil, err
+	}
+	if node.kind != s3NodeDir {
+		return nil, syscall.ENOTDIR
+	}
+	prefix := ""
+	if node.path != "" {
+		prefix = node.path + "/"
+	}
+	infos, err := s.listAll(ctx, prefix, "/")
+	if err != nil {
+		return nil, err
+	}
+	entriesByName := make(map[string]*pb.DirEntry)
+	for _, info := range infos {
+		if info.Key == prefix {
+			continue
+		}
+		name, kind, ok := directS3Entry(prefix, info)
+		if !ok {
+			continue
+		}
+		entryPath := joinS3Path(node.path, name)
+		entryNode := s.rememberPath(entryPath, kind, info.Size, info.Modified)
+		entry := &pb.DirEntry{
+			Inode: entryNode.inode,
+			Name:  name,
+			Type:  s3TypeNumber(kind),
+		}
+		if req.Plus {
+			entry.Attr = s.attr(entryNode)
+		}
+		if existing := entriesByName[name]; existing != nil && existing.Type&uint32(syscall.S_IFMT) == uint32(syscall.S_IFDIR) {
+			continue
+		}
+		entriesByName[name] = entry
+	}
+	names := make([]string, 0, len(entriesByName))
+	for name := range entriesByName {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	start := int(req.Offset)
+	if start < 0 {
+		start = 0
+	}
+	if start > len(names) {
+		start = len(names)
+	}
+	out := make([]*pb.DirEntry, 0, len(names)-start)
+	for i, name := range names[start:] {
+		entry := entriesByName[name]
+		entry.Offset = uint64(start + i + 1)
+		out = append(out, entry)
+	}
+	return &pb.ReadDirResponse{Entries: out, Eof: true}, nil
+}
+
+func (s *s3Session) ReleaseDir(_ context.Context, req *pb.ReleaseDirRequest) (*pb.Empty, error) {
+	s.takeHandle(req.HandleId)
+	return &pb.Empty{}, nil
+}
+
+func (s *s3Session) StatFs(context.Context, *pb.StatFsRequest) (*pb.StatFsResponse, error) {
+	return &pb.StatFsResponse{
+		Blocks:  1 << 30,
+		Bfree:   1 << 30,
+		Bavail:  1 << 30,
+		Files:   1 << 30,
+		Ffree:   1 << 30,
+		Bsize:   4096,
+		Frsize:  4096,
+		Namelen: 255,
+	}, nil
+}
+
+func (s *s3Session) GetXattr(context.Context, *pb.GetXattrRequest) (*pb.GetXattrResponse, error) {
+	return nil, syscall.ENODATA
+}
+
+func (s *s3Session) SetXattr(context.Context, *pb.SetXattrRequest) (*pb.Empty, error) {
+	return nil, syscall.EOPNOTSUPP
+}
+
+func (s *s3Session) ListXattr(context.Context, *pb.ListXattrRequest) (*pb.ListXattrResponse, error) {
+	return &pb.ListXattrResponse{}, nil
+}
+
+func (s *s3Session) RemoveXattr(context.Context, *pb.RemoveXattrRequest) (*pb.Empty, error) {
+	return nil, syscall.EOPNOTSUPP
+}
+
+func (s *s3Session) Mknod(context.Context, *pb.MknodRequest) (*pb.NodeResponse, error) {
+	return nil, syscall.EOPNOTSUPP
+}
+
+func (s *s3Session) GetLk(context.Context, *pb.GetLkRequest) (*pb.GetLkResponse, error) {
+	return nil, syscall.EOPNOTSUPP
+}
+
+func (s *s3Session) SetLk(context.Context, *pb.SetLkRequest) (*pb.Empty, error) {
+	return nil, syscall.EOPNOTSUPP
+}
+
+func (s *s3Session) SetLkw(context.Context, *pb.SetLkRequest) (*pb.Empty, error) {
+	return nil, syscall.EOPNOTSUPP
+}
+
+func (s *s3Session) Flock(context.Context, *pb.FlockRequest) (*pb.Empty, error) {
+	return nil, syscall.EOPNOTSUPP
+}
+
+func (s *s3Session) resolvePath(ctx context.Context, key string) (*s3Node, error) {
+	key = cleanS3Path(key)
+	if key == "" {
+		return s.rememberPath("", s3NodeDir, 0, time.Now().UTC()), nil
+	}
+	if info, ok, err := s.dirInfo(ctx, key); err != nil {
+		return nil, err
+	} else if ok {
+		return s.rememberPath(key, s3NodeDir, 0, info.Modified), nil
+	}
+	info, err := s.store.Head(key)
+	if err != nil {
+		if objectstore.IsNotFound(err) {
+			return nil, fserror.New(fserror.NotFound, "entry not found")
+		}
+		return nil, err
+	}
+	return s.rememberPath(key, s3NodeFile, info.Size, info.Modified), nil
+}
+
+func (s *s3Session) dirInfo(ctx context.Context, key string) (objectstore.Info, bool, error) {
+	prefix := strings.TrimRight(key, "/") + "/"
+	if info, err := s.store.Head(prefix); err == nil {
+		return info, true, nil
+	}
+	infos, err := s.listAllLimited(ctx, prefix, "/", 1)
+	if err != nil {
+		return objectstore.Info{}, false, err
+	}
+	if len(infos) == 0 {
+		return objectstore.Info{}, false, nil
+	}
+	return infos[0], true, nil
+}
+
+func (s *s3Session) listAll(ctx context.Context, prefix, delimiter string) ([]objectstore.Info, error) {
+	return s.listAllLimited(ctx, prefix, delimiter, 0)
+}
+
+func (s *s3Session) listAllLimited(ctx context.Context, prefix, delimiter string, max int) ([]objectstore.Info, error) {
+	out := make([]objectstore.Info, 0)
+	token := ""
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		limit := int64(1000)
+		if max > 0 && max-len(out) < 1000 {
+			limit = int64(max - len(out))
+		}
+		if limit <= 0 {
+			return out, nil
+		}
+		items, more, next, err := s.store.List(prefix, "", token, delimiter, limit)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, items...)
+		if max > 0 && len(out) >= max {
+			return out[:max], nil
+		}
+		if !more || next == "" {
+			return out, nil
+		}
+		token = next
+	}
+}
+
+func (s *s3Session) nodeForInode(inode uint64) (*s3Node, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	node := s.nodesByInode[inode]
+	if node == nil {
+		return nil, fserror.New(fserror.NotFound, "inode not found")
+	}
+	copyNode := *node
+	return &copyNode, nil
+}
+
+func (s *s3Session) rememberPath(key string, kind s3NodeKind, size int64, modified time.Time) *s3Node {
+	key = cleanS3Path(key)
+	if modified.IsZero() {
+		modified = time.Now().UTC()
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	inode := s.inodeByPath[key]
+	if inode == 0 {
+		inode = s.nextInode
+		s.nextInode++
+		s.inodeByPath[key] = inode
+	}
+	node := &s3Node{inode: inode, path: key, kind: kind, size: size, modified: modified}
+	s.nodesByInode[inode] = node
+	copyNode := *node
+	return &copyNode
+}
+
+func (s *s3Session) forgetPath(key string) {
+	key = cleanS3Path(key)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	inode := s.inodeByPath[key]
+	if inode != 0 {
+		delete(s.nodesByInode, inode)
+	}
+	delete(s.inodeByPath, key)
+}
+
+func (s *s3Session) newHandle(handle *s3Handle) uint64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.nextHandleID++
+	s.handles[s.nextHandleID] = handle
+	return s.nextHandleID
+}
+
+func (s *s3Session) handle(handleID uint64) *s3Handle {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	handle := s.handles[handleID]
+	return handle
+}
+
+func (s *s3Session) takeHandle(handleID uint64) *s3Handle {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	handle := s.handles[handleID]
+	delete(s.handles, handleID)
+	return handle
+}
+
+func (s *s3Session) handlelessWritableHandle(inode uint64) (*s3Handle, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if handle := s.implicit[inode]; handle != nil {
+		return handle, nil
+	}
+	var existing *s3Handle
+	for _, handle := range s.handles {
+		if handle == nil || handle.inode != inode || !handle.writable || handle.closed {
+			continue
+		}
+		if existing != nil {
+			return nil, fserror.New(fserror.InvalidArgument, "ambiguous handle-less write")
+		}
+		existing = handle
+	}
+	if existing != nil {
+		return existing, nil
+	}
+	node := s.nodesByInode[inode]
+	if node == nil {
+		return nil, fserror.New(fserror.NotFound, "inode not found")
+	}
+	if node.kind != s3NodeFile {
+		return nil, syscall.EISDIR
+	}
+	handle := &s3Handle{inode: inode, path: node.path, writable: true}
+	s.implicit[inode] = handle
+	return handle, nil
+}
+
+func (s *s3Session) takeHandlelessWritableHandle(inode uint64) *s3Handle {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if handle := s.implicit[inode]; handle != nil {
+		delete(s.implicit, inode)
+		return handle
+	}
+	for id, handle := range s.handles {
+		if handle != nil && handle.inode == inode && handle.writable && !handle.closed {
+			delete(s.handles, id)
+			return handle
+		}
+	}
+	return nil
+}
+
+func (s *s3Session) updateNodeSize(inode uint64, size int64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if node := s.nodesByInode[inode]; node != nil {
+		node.size = size
+		node.modified = time.Now().UTC()
+	}
+}
+
+func (s *s3Session) commitHandle(_ context.Context, handle *s3Handle) error {
+	if handle == nil || !handle.writable || handle.committed {
+		return nil
+	}
+	if err := s.store.Put(handle.path, bytes.NewReader(handle.buffer.Bytes())); err != nil {
+		return err
+	}
+	handle.committed = true
+	s.rememberPath(handle.path, s3NodeFile, int64(handle.buffer.Len()), time.Now().UTC())
+	return nil
+}
+
+func (s *s3Session) ensureWritable() error {
+	if volume.NormalizeAccessMode(string(s.access)) == volume.AccessModeROX {
+		return syscall.EROFS
+	}
+	return nil
+}
+
+func (s *s3Session) attr(node *s3Node) *pb.GetAttrResponse {
+	if node == nil {
+		return &pb.GetAttrResponse{}
+	}
+	mode := s3FileMode
+	nlink := uint32(1)
+	size := uint64(0)
+	if node.kind == s3NodeDir {
+		mode = s3DirMode
+		nlink = 2
+	} else if node.size > 0 {
+		size = uint64(node.size)
+	}
+	modified := node.modified
+	if modified.IsZero() {
+		modified = time.Now().UTC()
+	}
+	return &pb.GetAttrResponse{
+		Ino:       node.inode,
+		Mode:      mode,
+		Nlink:     nlink,
+		Size:      size,
+		Blocks:    (size + 511) / 512,
+		AtimeSec:  modified.Unix(),
+		AtimeNsec: int64(modified.Nanosecond()),
+		MtimeSec:  modified.Unix(),
+		MtimeNsec: int64(modified.Nanosecond()),
+		CtimeSec:  modified.Unix(),
+		CtimeNsec: int64(modified.Nanosecond()),
+	}
+}
+
+func (s *s3Session) nodeResponse(node *s3Node, handleID uint64) *pb.NodeResponse {
+	return &pb.NodeResponse{
+		Inode:      node.inode,
+		Generation: 1,
+		Attr:       s.attr(node),
+		HandleId:   handleID,
+	}
+}
+
+func directS3Entry(prefix string, info objectstore.Info) (string, s3NodeKind, bool) {
+	key := strings.TrimPrefix(info.Key, prefix)
+	key = strings.TrimLeft(key, "/")
+	if key == "" {
+		return "", 0, false
+	}
+	kind := s3NodeFile
+	if info.IsPrefix || strings.HasSuffix(key, "/") {
+		kind = s3NodeDir
+		key = strings.TrimRight(key, "/")
+	}
+	if strings.Contains(key, "/") {
+		parts := strings.SplitN(key, "/", 2)
+		key = parts[0]
+		kind = s3NodeDir
+	}
+	if key == "" || key == "." || key == ".." || strings.ContainsRune(key, 0) {
+		return "", 0, false
+	}
+	return key, kind, true
+}
+
+func cleanS3Name(name string) (string, error) {
+	name = strings.TrimSpace(name)
+	if name == "" || name == "." || name == ".." || strings.Contains(name, "/") || strings.ContainsRune(name, 0) {
+		return "", fserror.New(fserror.InvalidArgument, "invalid path segment")
+	}
+	return name, nil
+}
+
+func joinS3Path(parent, name string) string {
+	if parent == "" {
+		return name
+	}
+	return cleanS3Path(parent + "/" + name)
+}
+
+func cleanS3Path(value string) string {
+	value = strings.Trim(strings.TrimSpace(value), "/")
+	if value == "" {
+		return ""
+	}
+	cleaned := path.Clean("/" + value)
+	return strings.Trim(cleaned, "/")
+}
+
+func s3TypeNumber(kind s3NodeKind) uint32 {
+	if kind == s3NodeDir {
+		return s3DirMode
+	}
+	return s3FileMode
+}
+
+var _ volumefuse.Session = (*s3Session)(nil)
+var _ volumefuse.ReadIntoSession = (*s3Session)(nil)
+var _ volumefuse.OpenFlagsSession = (*s3Session)(nil)

--- a/ctld/internal/ctld/portal/s3_session.go
+++ b/ctld/internal/ctld/portal/s3_session.go
@@ -52,6 +52,7 @@ type s3Handle struct {
 	buffer    bytes.Buffer
 	committed bool
 	closed    bool
+	failed    bool
 }
 
 type s3Session struct {
@@ -449,7 +450,11 @@ func (s *s3Session) Write(_ context.Context, req *pb.WriteRequest) (*pb.WriteRes
 	if handle == nil || !handle.writable || handle.closed {
 		return nil, syscall.EBADF
 	}
+	if handle.failed {
+		return nil, syscall.EBADF
+	}
 	if req.Offset != int64(handle.buffer.Len()) {
+		handle.failed = true
 		return nil, fserror.New(fserror.InvalidArgument, "s3 backend only supports sequential writes for new files")
 	}
 	n, err := handle.buffer.Write(req.Data)
@@ -914,6 +919,10 @@ func (s *s3Session) updateNodeSize(inode uint64, size int64) {
 
 func (s *s3Session) commitHandle(_ context.Context, handle *s3Handle) error {
 	if handle == nil || !handle.writable || handle.committed {
+		return nil
+	}
+	if handle.failed {
+		s.forgetPath(handle.path)
 		return nil
 	}
 	if err := s.store.Put(handle.path, bytes.NewReader(handle.buffer.Bytes())); err != nil {

--- a/ctld/internal/ctld/portal/s3_session.go
+++ b/ctld/internal/ctld/portal/s3_session.go
@@ -624,7 +624,8 @@ func (s *s3Session) addLocalDirEntries(node *s3Node, prefix string, plus bool, e
 			continue
 		}
 		entryPath := joinS3Path(node.path, name)
-		remembered := s.rememberPath(entryPath, kind, entryNode.size, entryNode.modified)
+		localOnly := entryNode.localOnly && kind == s3NodeDir
+		remembered := s.rememberPathWithLocal(entryPath, kind, entryNode.size, entryNode.modified, localOnly)
 		dirEntry := &pb.DirEntry{
 			Inode: remembered.inode,
 			Name:  name,

--- a/ctld/internal/ctld/portal/s3_session.go
+++ b/ctld/internal/ctld/portal/s3_session.go
@@ -23,11 +23,11 @@ import (
 )
 
 const (
-	s3RootInode = uint64(fsmeta.RootInode)
-	s3DirMode   = uint32(syscall.S_IFDIR | 0o755)
-	s3FileMode  = uint32(syscall.S_IFREG | 0o644)
-
-	fuseFattrSize = uint32(1 << 3)
+	s3RootInode       = uint64(fsmeta.RootInode)
+	s3DirMode         = uint32(syscall.S_IFDIR | 0o755)
+	s3FileMode        = uint32(syscall.S_IFREG | 0o644)
+	fuseFattrSize     = uint32(fuse.FATTR_SIZE)
+	fuseFattrNoopMask = uint32(fuse.FATTR_FH | fuse.FATTR_LOCKOWNER | fuse.FATTR_KILL_SUIDGID)
 )
 
 type s3NodeKind uint8
@@ -163,8 +163,11 @@ func (s *s3Session) SetAttr(ctx context.Context, req *pb.SetAttrRequest) (*pb.Se
 	if req.Valid == 0 {
 		return &pb.SetAttrResponse{Attr: s.attr(node)}, nil
 	}
-	if req.Valid&^uint32(fuse.FATTR_SIZE) != 0 {
+	if req.Valid&^(fuseFattrSize|fuseFattrNoopMask) != 0 {
 		return nil, syscall.EOPNOTSUPP
+	}
+	if req.Valid&fuseFattrSize == 0 {
+		return &pb.SetAttrResponse{Attr: s.attr(node)}, nil
 	}
 	if err := s.ensureWritable(); err != nil {
 		return nil, err

--- a/ctld/internal/ctld/portal/s3_session.go
+++ b/ctld/internal/ctld/portal/s3_session.go
@@ -158,8 +158,11 @@ func (s *s3Session) SetAttr(ctx context.Context, req *pb.SetAttrRequest) (*pb.Se
 	if err != nil {
 		return nil, err
 	}
-	if req.Valid&fuseFattrSize == 0 {
+	if req.Valid == 0 {
 		return &pb.SetAttrResponse{Attr: s.attr(node)}, nil
+	}
+	if req.Valid&^uint32(fuse.FATTR_SIZE) != 0 {
+		return nil, syscall.EOPNOTSUPP
 	}
 	if err := s.ensureWritable(); err != nil {
 		return nil, err
@@ -170,8 +173,25 @@ func (s *s3Session) SetAttr(ctx context.Context, req *pb.SetAttrRequest) (*pb.Se
 	if req.Attr == nil || req.Attr.Size != 0 {
 		return nil, syscall.EOPNOTSUPP
 	}
-	if _, err := s.resolvePath(ctx, node.path); err != nil {
-		return nil, err
+	if _, ok := s.nodeForPath(node.path); !ok {
+		if _, err := s.resolvePath(ctx, node.path); err != nil {
+			return nil, err
+		}
+	}
+	handle := s.handle(req.HandleId)
+	if handle != nil && handle.writable && !handle.closed {
+		handle.buffer.Reset()
+		handle.committed = false
+		s.updateNodeSize(handle.inode, 0)
+		node = s.rememberPath(handle.path, s3NodeFile, 0, time.Now().UTC())
+		return &pb.SetAttrResponse{Attr: s.attr(node)}, nil
+	}
+	if writer := s.findWritableHandle(node.inode); writer != nil {
+		writer.buffer.Reset()
+		writer.committed = false
+		s.updateNodeSize(writer.inode, 0)
+		node = s.rememberPath(writer.path, s3NodeFile, 0, time.Now().UTC())
+		return &pb.SetAttrResponse{Attr: s.attr(node)}, nil
 	}
 	if err := s.store.Put(node.path, bytes.NewReader(nil)); err != nil {
 		return nil, err
@@ -229,11 +249,8 @@ func (s *s3Session) Create(ctx context.Context, req *pb.CreateRequest) (*pb.Node
 	} else if fserror.CodeOf(err) != fserror.NotFound {
 		return nil, err
 	}
-	if err := s.store.Put(filePath, bytes.NewReader(nil)); err != nil {
-		return nil, err
-	}
 	node := s.rememberPath(filePath, s3NodeFile, 0, time.Now().UTC())
-	handleID := s.newHandle(&s3Handle{inode: node.inode, path: filePath, writable: true, committed: true})
+	handleID := s.newHandle(&s3Handle{inode: node.inode, path: filePath, writable: true})
 	return s.nodeResponse(node, handleID), nil
 }
 
@@ -328,6 +345,17 @@ func (s *s3Session) Open(ctx context.Context, req *pb.OpenRequest) (*pb.OpenResp
 	if err != nil {
 		return nil, err
 	}
+	writable := req.Flags&uint32(syscall.O_ACCMODE) != uint32(syscall.O_RDONLY)
+	if writable {
+		if err := s.ensureWritable(); err != nil {
+			return nil, err
+		}
+		if s.hasOpenReader(node.inode) || s.hasOpenWriter(node.inode) {
+			return nil, syscall.EPERM
+		}
+	} else if s.hasOpenWriter(node.inode) {
+		return nil, syscall.EPERM
+	}
 	node, err = s.resolvePath(ctx, node.path)
 	if err != nil {
 		return nil, err
@@ -335,11 +363,7 @@ func (s *s3Session) Open(ctx context.Context, req *pb.OpenRequest) (*pb.OpenResp
 	if node.kind == s3NodeDir {
 		return nil, syscall.EISDIR
 	}
-	writable := req.Flags&uint32(syscall.O_ACCMODE) != uint32(syscall.O_RDONLY)
 	if writable {
-		if err := s.ensureWritable(); err != nil {
-			return nil, err
-		}
 		if req.Flags&uint32(syscall.O_APPEND) != 0 {
 			return nil, syscall.EOPNOTSUPP
 		}
@@ -371,6 +395,9 @@ func (s *s3Session) ReadInto(ctx context.Context, req *pb.ReadRequest, dest []by
 	node, err := s.nodeForInode(req.Inode)
 	if err != nil {
 		return 0, false, err
+	}
+	if s.hasOpenWriter(node.inode) {
+		return 0, false, syscall.EPERM
 	}
 	node, err = s.resolvePath(ctx, node.path)
 	if err != nil {
@@ -575,7 +602,7 @@ func (s *s3Session) SetXattr(context.Context, *pb.SetXattrRequest) (*pb.Empty, e
 }
 
 func (s *s3Session) ListXattr(context.Context, *pb.ListXattrRequest) (*pb.ListXattrResponse, error) {
-	return &pb.ListXattrResponse{}, nil
+	return nil, syscall.EOPNOTSUPP
 }
 
 func (s *s3Session) RemoveXattr(context.Context, *pb.RemoveXattrRequest) (*pb.Empty, error) {
@@ -681,6 +708,22 @@ func (s *s3Session) nodeForInode(inode uint64) (*s3Node, error) {
 	return &copyNode, nil
 }
 
+func (s *s3Session) nodeForPath(key string) (*s3Node, bool) {
+	key = cleanS3Path(key)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	inode := s.inodeByPath[key]
+	if inode == 0 {
+		return nil, false
+	}
+	node := s.nodesByInode[inode]
+	if node == nil {
+		return nil, false
+	}
+	copyNode := *node
+	return &copyNode, true
+}
+
 func (s *s3Session) rememberPath(key string, kind s3NodeKind, size int64, modified time.Time) *s3Node {
 	key = cleanS3Path(key)
 	if modified.IsZero() {
@@ -724,6 +767,35 @@ func (s *s3Session) handle(handleID uint64) *s3Handle {
 	defer s.mu.Unlock()
 	handle := s.handles[handleID]
 	return handle
+}
+
+func (s *s3Session) findWritableHandle(inode uint64) *s3Handle {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, handle := range s.handles {
+		if handle != nil && handle.inode == inode && handle.writable && !handle.closed {
+			return handle
+		}
+	}
+	if handle := s.implicit[inode]; handle != nil && handle.writable && !handle.closed {
+		return handle
+	}
+	return nil
+}
+
+func (s *s3Session) hasOpenWriter(inode uint64) bool {
+	return s.findWritableHandle(inode) != nil
+}
+
+func (s *s3Session) hasOpenReader(inode uint64) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, handle := range s.handles {
+		if handle != nil && handle.inode == inode && !handle.writable && !handle.closed {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *s3Session) takeHandle(handleID uint64) *s3Handle {
@@ -852,7 +924,6 @@ func (s *s3Session) nodeResponse(node *s3Node, handleID uint64) *pb.NodeResponse
 
 func directS3Entry(prefix string, info objectstore.Info) (string, s3NodeKind, bool) {
 	key := strings.TrimPrefix(info.Key, prefix)
-	key = strings.TrimLeft(key, "/")
 	if key == "" {
 		return "", 0, false
 	}

--- a/ctld/internal/ctld/portal/s3_session_test.go
+++ b/ctld/internal/ctld/portal/s3_session_test.go
@@ -118,6 +118,7 @@ func TestS3SessionSeesExternalObjectsAndWritesBackNewFiles(t *testing.T) {
 	if _, err := session.Mkdir(ctx, &pb.MkdirRequest{Parent: s3RootInode, Name: "from-sandbox"}); err != nil {
 		t.Fatalf("Mkdir(from-sandbox) error = %v", err)
 	}
+	assertS3TestObjectMissing(t, store, "from-sandbox/")
 	fromSandbox, err := session.Lookup(ctx, &pb.LookupRequest{Parent: s3RootInode, Name: "from-sandbox"})
 	if err != nil {
 		t.Fatalf("Lookup(from-sandbox after mkdir) error = %v", err)
@@ -246,6 +247,50 @@ func TestS3SessionSeesExternalObjectsAndWritesBackNewFiles(t *testing.T) {
 	want := []string{"dir:external", "dir:from-sandbox"}
 	if !equalPortalStringSlices(got, want) {
 		t.Fatalf("ReadDir(root) = %#v, want %#v", got, want)
+	}
+}
+
+func TestS3SessionMkdirUsesMountpointLocalDirectorySemantics(t *testing.T) {
+	ctx := context.Background()
+	store := objectstore.NewMemoryStore(t.Name())
+	putS3TestObject(t, store, "marker/", "")
+	putS3TestObject(t, store, "implicit/file.txt", "payload")
+	session := newS3Session("vol-s3", store, volume.AccessModeRWO, nil)
+
+	local, err := session.Mkdir(ctx, &pb.MkdirRequest{Parent: s3RootInode, Name: "local"})
+	if err != nil {
+		t.Fatalf("Mkdir(local) error = %v", err)
+	}
+	assertS3TestObjectMissing(t, store, "local/")
+	if _, err := session.Lookup(ctx, &pb.LookupRequest{Parent: s3RootInode, Name: "local"}); err != nil {
+		t.Fatalf("Lookup(local) error = %v", err)
+	}
+	if _, err := session.Rmdir(ctx, &pb.RmdirRequest{Parent: s3RootInode, Name: "local"}); err != nil {
+		t.Fatalf("Rmdir(local) error = %v", err)
+	}
+	if _, err := session.Lookup(ctx, &pb.LookupRequest{Parent: s3RootInode, Name: "local"}); fserror.CodeOf(err) != fserror.NotFound {
+		t.Fatalf("Lookup(local after rmdir) error = %v, want NotFound", err)
+	}
+
+	nested, err := session.Mkdir(ctx, &pb.MkdirRequest{Parent: s3RootInode, Name: "nested"})
+	if err != nil {
+		t.Fatalf("Mkdir(nested) error = %v", err)
+	}
+	if _, err := session.Mkdir(ctx, &pb.MkdirRequest{Parent: nested.Inode, Name: "child"}); err != nil {
+		t.Fatalf("Mkdir(nested/child) error = %v", err)
+	}
+	if _, err := session.Rmdir(ctx, &pb.RmdirRequest{Parent: s3RootInode, Name: "nested"}); !errors.Is(err, syscall.ENOTEMPTY) {
+		t.Fatalf("Rmdir(nested) error = %v, want ENOTEMPTY", err)
+	}
+
+	if _, err := session.Rmdir(ctx, &pb.RmdirRequest{Parent: s3RootInode, Name: "marker"}); !errors.Is(err, syscall.ENOTEMPTY) {
+		t.Fatalf("Rmdir(marker) error = %v, want ENOTEMPTY", err)
+	}
+	if _, err := session.Rmdir(ctx, &pb.RmdirRequest{Parent: s3RootInode, Name: "implicit"}); !errors.Is(err, syscall.ENOTEMPTY) {
+		t.Fatalf("Rmdir(implicit) error = %v, want ENOTEMPTY", err)
+	}
+	if _, err := session.Create(ctx, &pb.CreateRequest{Parent: local.Inode, Name: "after-rmdir.txt"}); fserror.CodeOf(err) != fserror.NotFound {
+		t.Fatalf("Create(using removed local inode) error = %v, want NotFound", err)
 	}
 }
 

--- a/ctld/internal/ctld/portal/s3_session_test.go
+++ b/ctld/internal/ctld/portal/s3_session_test.go
@@ -1,0 +1,254 @@
+package portal
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"sort"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/objectstore"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volume"
+	pb "github.com/sandbox0-ai/sandbox0/storage-proxy/proto/fs"
+)
+
+func TestS3SessionProjectsObjectsAsDirectoriesAndFiles(t *testing.T) {
+	ctx := context.Background()
+	store := objectstore.NewMemoryStore(t.Name())
+	putS3TestObject(t, store, "docs/readme.txt", "hello from s3")
+	putS3TestObject(t, store, "blue", "file-shadowed-by-directory")
+	putS3TestObject(t, store, "blue/nested.txt", "nested")
+	session := newS3Session("vol-s3", store, volume.AccessModeRWO, nil)
+
+	docs, err := session.Lookup(ctx, &pb.LookupRequest{Parent: s3RootInode, Name: "docs"})
+	if err != nil {
+		t.Fatalf("Lookup(docs) error = %v", err)
+	}
+	if docs.Attr.Mode&uint32(syscall.S_IFMT) != uint32(syscall.S_IFDIR) {
+		t.Fatalf("docs mode = %#o, want directory", docs.Attr.Mode)
+	}
+
+	readme, err := session.Lookup(ctx, &pb.LookupRequest{Parent: docs.Inode, Name: "readme.txt"})
+	if err != nil {
+		t.Fatalf("Lookup(readme.txt) error = %v", err)
+	}
+	openResp, err := session.Open(ctx, &pb.OpenRequest{Inode: readme.Inode})
+	if err != nil {
+		t.Fatalf("Open(readme.txt) error = %v", err)
+	}
+	readResp, err := session.Read(ctx, &pb.ReadRequest{
+		Inode:    readme.Inode,
+		HandleId: openResp.HandleId,
+		Offset:   0,
+		Size:     64,
+	})
+	if err != nil {
+		t.Fatalf("Read(readme.txt) error = %v", err)
+	}
+	if string(readResp.Data) != "hello from s3" || !readResp.Eof {
+		t.Fatalf("Read(readme.txt) = %q eof=%v, want payload and eof", string(readResp.Data), readResp.Eof)
+	}
+
+	blue, err := session.Lookup(ctx, &pb.LookupRequest{Parent: s3RootInode, Name: "blue"})
+	if err != nil {
+		t.Fatalf("Lookup(blue) error = %v", err)
+	}
+	if blue.Attr.Mode&uint32(syscall.S_IFMT) != uint32(syscall.S_IFDIR) {
+		t.Fatalf("blue mode = %#o, want directory because directory prefixes shadow files", blue.Attr.Mode)
+	}
+}
+
+func TestS3SessionSeesExternalObjectsAndWritesBackNewFiles(t *testing.T) {
+	ctx := context.Background()
+	store := objectstore.NewMemoryStore(t.Name())
+	session := newS3Session("vol-s3", store, volume.AccessModeRWO, nil)
+
+	putS3TestObject(t, store, "external/created-before-lookup.txt", "external")
+	externalDir, err := session.Lookup(ctx, &pb.LookupRequest{Parent: s3RootInode, Name: "external"})
+	if err != nil {
+		t.Fatalf("Lookup(external) error = %v", err)
+	}
+	externalFile, err := session.Lookup(ctx, &pb.LookupRequest{Parent: externalDir.Inode, Name: "created-before-lookup.txt"})
+	if err != nil {
+		t.Fatalf("Lookup(created-before-lookup.txt) error = %v", err)
+	}
+	buf := bytes.Repeat([]byte{0xff}, 16)
+	n, eof, err := session.ReadInto(ctx, &pb.ReadRequest{Inode: externalFile.Inode, Size: 8}, buf)
+	if err != nil {
+		t.Fatalf("ReadInto(external) error = %v", err)
+	}
+	if !eof || string(buf[:n]) != "external" {
+		t.Fatalf("ReadInto(external) = %q eof=%v, want external and eof", string(buf[:n]), eof)
+	}
+	if !bytes.Equal(buf[n:], bytes.Repeat([]byte{0xff}, len(buf)-n)) {
+		t.Fatalf("ReadInto modified bytes past read size: %#v", buf)
+	}
+
+	if _, err := session.Mkdir(ctx, &pb.MkdirRequest{Parent: s3RootInode, Name: "from-sandbox"}); err != nil {
+		t.Fatalf("Mkdir(from-sandbox) error = %v", err)
+	}
+	fromSandbox, err := session.Lookup(ctx, &pb.LookupRequest{Parent: s3RootInode, Name: "from-sandbox"})
+	if err != nil {
+		t.Fatalf("Lookup(from-sandbox after mkdir) error = %v", err)
+	}
+	created, err := session.Create(ctx, &pb.CreateRequest{Parent: fromSandbox.Inode, Name: "new.txt"})
+	if err != nil {
+		t.Fatalf("Create(new.txt) error = %v", err)
+	}
+	if _, err := session.Write(ctx, &pb.WriteRequest{HandleId: created.HandleId, Offset: 0, Data: []byte("first ")}); err != nil {
+		t.Fatalf("Write(first) error = %v", err)
+	}
+	if _, err := session.Write(ctx, &pb.WriteRequest{HandleId: created.HandleId, Offset: 6, Data: []byte("second")}); err != nil {
+		t.Fatalf("Write(second) error = %v", err)
+	}
+	if _, err := session.Release(ctx, &pb.ReleaseRequest{HandleId: created.HandleId}); err != nil {
+		t.Fatalf("Release(new.txt) error = %v", err)
+	}
+	assertS3TestObject(t, store, "from-sandbox/new.txt", "first second")
+
+	reopened, err := session.Open(ctx, &pb.OpenRequest{
+		Inode: created.Inode,
+		Flags: uint32(syscall.O_WRONLY | syscall.O_TRUNC),
+	})
+	if err != nil {
+		t.Fatalf("Open(new.txt writable) error = %v", err)
+	}
+	if _, err := session.Write(ctx, &pb.WriteRequest{HandleId: reopened.HandleId, Offset: 0, Data: []byte("replacement")}); err != nil {
+		t.Fatalf("Write(replacement) error = %v", err)
+	}
+	if _, err := session.Release(ctx, &pb.ReleaseRequest{HandleId: reopened.HandleId}); err != nil {
+		t.Fatalf("Release(replacement) error = %v", err)
+	}
+	assertS3TestObject(t, store, "from-sandbox/new.txt", "replacement")
+
+	if _, err := session.SetAttr(ctx, &pb.SetAttrRequest{
+		Inode: created.Inode,
+		Valid: fuseFattrSize,
+		Attr:  &pb.GetAttrResponse{Size: 0},
+	}); err != nil {
+		t.Fatalf("SetAttr(truncate) error = %v", err)
+	}
+	assertS3TestObject(t, store, "from-sandbox/new.txt", "")
+
+	implicitCreated, err := session.Create(ctx, &pb.CreateRequest{Parent: fromSandbox.Inode, Name: "implicit.txt"})
+	if err != nil {
+		t.Fatalf("Create(implicit.txt) error = %v", err)
+	}
+	if _, err := session.SetAttr(ctx, &pb.SetAttrRequest{
+		Inode: implicitCreated.Inode,
+		Valid: fuseFattrSize,
+		Attr:  &pb.GetAttrResponse{Size: 0},
+	}); err != nil {
+		t.Fatalf("SetAttr(implicit truncate) error = %v", err)
+	}
+	if _, err := session.Write(ctx, &pb.WriteRequest{
+		Inode:    implicitCreated.Inode,
+		HandleId: 0,
+		Offset:   0,
+		Data:     []byte("implicit"),
+	}); err != nil {
+		t.Fatalf("Write(implicit handle) error = %v", err)
+	}
+	if _, err := session.Release(ctx, &pb.ReleaseRequest{HandleId: implicitCreated.HandleId}); err != nil {
+		t.Fatalf("Release(implicit explicit handle) error = %v", err)
+	}
+	assertS3TestObject(t, store, "from-sandbox/implicit.txt", "implicit")
+
+	entriesResp, err := session.ReadDir(ctx, &pb.ReadDirRequest{Inode: s3RootInode, Plus: true})
+	if err != nil {
+		t.Fatalf("ReadDir(root) error = %v", err)
+	}
+	got := make([]string, 0, len(entriesResp.Entries))
+	for _, entry := range entriesResp.Entries {
+		kind := "file"
+		if entry.Type&uint32(syscall.S_IFMT) == uint32(syscall.S_IFDIR) {
+			kind = "dir"
+		}
+		got = append(got, kind+":"+entry.Name)
+	}
+	sort.Strings(got)
+	want := []string{"dir:external", "dir:from-sandbox"}
+	if !equalPortalStringSlices(got, want) {
+		t.Fatalf("ReadDir(root) = %#v, want %#v", got, want)
+	}
+}
+
+func TestS3SessionDirectoryLookupFallsBackToListWhenMarkerHeadFails(t *testing.T) {
+	ctx := context.Background()
+	base := objectstore.NewMemoryStore(t.Name())
+	putS3TestObject(t, base, "external/file.txt", "payload")
+	store := headErrorForDirectoryMarkersStore{Store: base}
+	session := newS3Session("vol-s3", store, volume.AccessModeRWO, nil)
+
+	externalDir, err := session.Lookup(ctx, &pb.LookupRequest{Parent: s3RootInode, Name: "external"})
+	if err != nil {
+		t.Fatalf("Lookup(external) error = %v", err)
+	}
+	if externalDir.Attr.Mode&uint32(syscall.S_IFMT) != uint32(syscall.S_IFDIR) {
+		t.Fatalf("external mode = %#o, want directory", externalDir.Attr.Mode)
+	}
+}
+
+func TestS3SessionReadOnlyAccessRejectsWrites(t *testing.T) {
+	ctx := context.Background()
+	store := objectstore.NewMemoryStore(t.Name())
+	session := newS3Session("vol-s3", store, volume.AccessModeROX, nil)
+
+	_, err := session.Create(ctx, &pb.CreateRequest{Parent: s3RootInode, Name: "blocked.txt"})
+	if !errors.Is(err, syscall.EROFS) {
+		t.Fatalf("Create() error = %v, want EROFS", err)
+	}
+	_, err = session.Mkdir(ctx, &pb.MkdirRequest{Parent: s3RootInode, Name: "blocked"})
+	if !errors.Is(err, syscall.EROFS) {
+		t.Fatalf("Mkdir() error = %v, want EROFS", err)
+	}
+}
+
+type headErrorForDirectoryMarkersStore struct {
+	objectstore.Store
+}
+
+func (s headErrorForDirectoryMarkersStore) Head(key string) (objectstore.Info, error) {
+	if strings.HasSuffix(strings.TrimSpace(key), "/") {
+		return objectstore.Info{}, errors.New("bad request")
+	}
+	return s.Store.Head(key)
+}
+
+func putS3TestObject(t *testing.T, store objectstore.Store, key, value string) {
+	t.Helper()
+	if err := store.Put(key, bytes.NewReader([]byte(value))); err != nil {
+		t.Fatalf("Put(%q) error = %v", key, err)
+	}
+}
+
+func assertS3TestObject(t *testing.T, store objectstore.Store, key, want string) {
+	t.Helper()
+	reader, err := store.Get(key, 0, -1)
+	if err != nil {
+		t.Fatalf("Get(%q) error = %v", key, err)
+	}
+	defer reader.Close()
+	got, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("ReadAll(%q) error = %v", key, err)
+	}
+	if string(got) != want {
+		t.Fatalf("object %q = %q, want %q", key, string(got), want)
+	}
+}
+
+func equalPortalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/ctld/internal/ctld/portal/s3_session_test.go
+++ b/ctld/internal/ctld/portal/s3_session_test.go
@@ -135,6 +135,10 @@ func TestS3SessionSeesExternalObjectsAndWritesBackNewFiles(t *testing.T) {
 		t.Fatalf("Write(second) error = %v", err)
 	}
 	assertS3TestObjectMissing(t, store, "from-sandbox/new.txt")
+	if _, err := session.Flush(ctx, &pb.FlushRequest{HandleId: created.HandleId}); err != nil {
+		t.Fatalf("Flush(new.txt) error = %v", err)
+	}
+	assertS3TestObjectMissing(t, store, "from-sandbox/new.txt")
 	lookedUp, err := session.Lookup(ctx, &pb.LookupRequest{Parent: fromSandbox.Inode, Name: "new.txt"})
 	if err != nil {
 		t.Fatalf("Lookup(uncommitted new.txt) error = %v", err)
@@ -159,6 +163,26 @@ func TestS3SessionSeesExternalObjectsAndWritesBackNewFiles(t *testing.T) {
 		t.Fatalf("Release(new.txt) error = %v", err)
 	}
 	assertS3TestObject(t, store, "from-sandbox/new.txt", "first second")
+
+	fsynced, err := session.Create(ctx, &pb.CreateRequest{Parent: fromSandbox.Inode, Name: "fsynced.txt"})
+	if err != nil {
+		t.Fatalf("Create(fsynced.txt) error = %v", err)
+	}
+	if _, err := session.Write(ctx, &pb.WriteRequest{HandleId: fsynced.HandleId, Offset: 0, Data: []byte("first")}); err != nil {
+		t.Fatalf("Write(fsynced first) error = %v", err)
+	}
+	if _, err := session.Fsync(ctx, &pb.FsyncRequest{HandleId: fsynced.HandleId}); err != nil {
+		t.Fatalf("Fsync(fsynced.txt) error = %v", err)
+	}
+	assertS3TestObject(t, store, "from-sandbox/fsynced.txt", "first")
+	if _, err := session.Write(ctx, &pb.WriteRequest{HandleId: fsynced.HandleId, Offset: 5, Data: []byte(" second")}); err != nil {
+		t.Fatalf("Write(fsynced second) error = %v", err)
+	}
+	assertS3TestObject(t, store, "from-sandbox/fsynced.txt", "first")
+	if _, err := session.Release(ctx, &pb.ReleaseRequest{HandleId: fsynced.HandleId}); err != nil {
+		t.Fatalf("Release(fsynced.txt) error = %v", err)
+	}
+	assertS3TestObject(t, store, "from-sandbox/fsynced.txt", "first second")
 
 	reopened, err := session.Open(ctx, &pb.OpenRequest{
 		Inode: created.Inode,

--- a/ctld/internal/ctld/portal/s3_session_test.go
+++ b/ctld/internal/ctld/portal/s3_session_test.go
@@ -265,6 +265,9 @@ func TestS3SessionMkdirUsesMountpointLocalDirectorySemantics(t *testing.T) {
 	if _, err := session.Lookup(ctx, &pb.LookupRequest{Parent: s3RootInode, Name: "local"}); err != nil {
 		t.Fatalf("Lookup(local) error = %v", err)
 	}
+	if _, err := session.ReadDir(ctx, &pb.ReadDirRequest{Inode: s3RootInode, Plus: true}); err != nil {
+		t.Fatalf("ReadDir(root after local mkdir) error = %v", err)
+	}
 	if _, err := session.Rmdir(ctx, &pb.RmdirRequest{Parent: s3RootInode, Name: "local"}); err != nil {
 		t.Fatalf("Rmdir(local) error = %v", err)
 	}

--- a/ctld/internal/ctld/portal/s3_session_test.go
+++ b/ctld/internal/ctld/portal/s3_session_test.go
@@ -191,6 +191,15 @@ func TestS3SessionSeesExternalObjectsAndWritesBackNewFiles(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open(new.txt writable) error = %v", err)
 	}
+	if _, err := session.SetAttr(ctx, &pb.SetAttrRequest{
+		Inode:    created.Inode,
+		HandleId: reopened.HandleId,
+		Valid:    fuseFattrSize | fuseFattrNoopMask,
+		Attr:     &pb.GetAttrResponse{Size: 0},
+	}); err != nil {
+		t.Fatalf("SetAttr(truncate with writable handle) error = %v", err)
+	}
+	assertS3TestObject(t, store, "from-sandbox/new.txt", "first second")
 	if _, err := session.Write(ctx, &pb.WriteRequest{HandleId: reopened.HandleId, Offset: 0, Data: []byte("replacement")}); err != nil {
 		t.Fatalf("Write(replacement) error = %v", err)
 	}

--- a/ctld/internal/ctld/portal/s3_session_test.go
+++ b/ctld/internal/ctld/portal/s3_session_test.go
@@ -226,21 +226,25 @@ func TestS3SessionHidesObjectKeysWithEmptyPathSegments(t *testing.T) {
 	ctx := context.Background()
 	store := objectstore.NewMemoryStore(t.Name())
 	putS3TestObject(t, store, "invalid//hidden.txt", "hidden")
+	putS3TestObject(t, store, "dots/./hidden.txt", "hidden")
+	putS3TestObject(t, store, "parents/../hidden.txt", "hidden")
 	session := newS3Session("vol-s3", store, volume.AccessModeRWO, nil)
 
-	dir, err := session.Lookup(ctx, &pb.LookupRequest{Parent: s3RootInode, Name: "invalid"})
-	if err != nil {
-		t.Fatalf("Lookup(invalid) error = %v", err)
-	}
-	entries, err := session.ReadDir(ctx, &pb.ReadDirRequest{Inode: dir.Inode, Plus: true})
-	if err != nil {
-		t.Fatalf("ReadDir(invalid) error = %v", err)
-	}
-	if len(entries.Entries) != 0 {
-		t.Fatalf("ReadDir(invalid) entries = %#v, want none for empty path segment object", entries.Entries)
-	}
-	if _, err := session.Lookup(ctx, &pb.LookupRequest{Parent: dir.Inode, Name: "hidden.txt"}); fserror.CodeOf(err) != fserror.NotFound {
-		t.Fatalf("Lookup(hidden.txt) error = %v, want NotFound", err)
+	for _, name := range []string{"invalid", "dots", "parents"} {
+		dir, err := session.Lookup(ctx, &pb.LookupRequest{Parent: s3RootInode, Name: name})
+		if err != nil {
+			t.Fatalf("Lookup(%s) error = %v", name, err)
+		}
+		entries, err := session.ReadDir(ctx, &pb.ReadDirRequest{Inode: dir.Inode, Plus: true})
+		if err != nil {
+			t.Fatalf("ReadDir(%s) error = %v", name, err)
+		}
+		if len(entries.Entries) != 0 {
+			t.Fatalf("ReadDir(%s) entries = %#v, want none for invalid path segment object", name, entries.Entries)
+		}
+		if _, err := session.Lookup(ctx, &pb.LookupRequest{Parent: dir.Inode, Name: "hidden.txt"}); fserror.CodeOf(err) != fserror.NotFound {
+			t.Fatalf("Lookup(%s/hidden.txt) error = %v, want NotFound", name, err)
+		}
 	}
 }
 

--- a/ctld/internal/ctld/portal/s3_session_test.go
+++ b/ctld/internal/ctld/portal/s3_session_test.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/fserror"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/objectstore"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volume"
 	pb "github.com/sandbox0-ai/sandbox0/storage-proxy/proto/fs"
@@ -98,11 +99,16 @@ func TestS3SessionSeesExternalObjectsAndWritesBackNewFiles(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create(new.txt) error = %v", err)
 	}
+	assertS3TestObjectMissing(t, store, "from-sandbox/new.txt")
 	if _, err := session.Write(ctx, &pb.WriteRequest{HandleId: created.HandleId, Offset: 0, Data: []byte("first ")}); err != nil {
 		t.Fatalf("Write(first) error = %v", err)
 	}
 	if _, err := session.Write(ctx, &pb.WriteRequest{HandleId: created.HandleId, Offset: 6, Data: []byte("second")}); err != nil {
 		t.Fatalf("Write(second) error = %v", err)
+	}
+	assertS3TestObjectMissing(t, store, "from-sandbox/new.txt")
+	if _, err := session.Open(ctx, &pb.OpenRequest{Inode: created.Inode}); !errors.Is(err, syscall.EPERM) {
+		t.Fatalf("Open(reader while writer open) error = %v, want EPERM", err)
 	}
 	if _, err := session.Release(ctx, &pb.ReleaseRequest{HandleId: created.HandleId}); err != nil {
 		t.Fatalf("Release(new.txt) error = %v", err)
@@ -132,6 +138,17 @@ func TestS3SessionSeesExternalObjectsAndWritesBackNewFiles(t *testing.T) {
 		t.Fatalf("SetAttr(truncate) error = %v", err)
 	}
 	assertS3TestObject(t, store, "from-sandbox/new.txt", "")
+
+	if _, err := session.SetAttr(ctx, &pb.SetAttrRequest{
+		Inode: created.Inode,
+		Valid: 1,
+		Attr:  &pb.GetAttrResponse{Mode: s3FileMode | 0o600},
+	}); !errors.Is(err, syscall.EOPNOTSUPP) {
+		t.Fatalf("SetAttr(mode) error = %v, want EOPNOTSUPP", err)
+	}
+	if _, err := session.ListXattr(ctx, &pb.ListXattrRequest{Inode: created.Inode}); !errors.Is(err, syscall.EOPNOTSUPP) {
+		t.Fatalf("ListXattr() error = %v, want EOPNOTSUPP", err)
+	}
 
 	implicitCreated, err := session.Create(ctx, &pb.CreateRequest{Parent: fromSandbox.Inode, Name: "implicit.txt"})
 	if err != nil {
@@ -173,6 +190,28 @@ func TestS3SessionSeesExternalObjectsAndWritesBackNewFiles(t *testing.T) {
 	want := []string{"dir:external", "dir:from-sandbox"}
 	if !equalPortalStringSlices(got, want) {
 		t.Fatalf("ReadDir(root) = %#v, want %#v", got, want)
+	}
+}
+
+func TestS3SessionHidesObjectKeysWithEmptyPathSegments(t *testing.T) {
+	ctx := context.Background()
+	store := objectstore.NewMemoryStore(t.Name())
+	putS3TestObject(t, store, "invalid//hidden.txt", "hidden")
+	session := newS3Session("vol-s3", store, volume.AccessModeRWO, nil)
+
+	dir, err := session.Lookup(ctx, &pb.LookupRequest{Parent: s3RootInode, Name: "invalid"})
+	if err != nil {
+		t.Fatalf("Lookup(invalid) error = %v", err)
+	}
+	entries, err := session.ReadDir(ctx, &pb.ReadDirRequest{Inode: dir.Inode, Plus: true})
+	if err != nil {
+		t.Fatalf("ReadDir(invalid) error = %v", err)
+	}
+	if len(entries.Entries) != 0 {
+		t.Fatalf("ReadDir(invalid) entries = %#v, want none for empty path segment object", entries.Entries)
+	}
+	if _, err := session.Lookup(ctx, &pb.LookupRequest{Parent: dir.Inode, Name: "hidden.txt"}); fserror.CodeOf(err) != fserror.NotFound {
+		t.Fatalf("Lookup(hidden.txt) error = %v, want NotFound", err)
 	}
 }
 
@@ -238,6 +277,18 @@ func assertS3TestObject(t *testing.T, store objectstore.Store, key, want string)
 	}
 	if string(got) != want {
 		t.Fatalf("object %q = %q, want %q", key, string(got), want)
+	}
+}
+
+func assertS3TestObjectMissing(t *testing.T, store objectstore.Store, key string) {
+	t.Helper()
+	reader, err := store.Get(key, 0, -1)
+	if err == nil {
+		_ = reader.Close()
+		t.Fatalf("Get(%q) succeeded, want missing object", key)
+	}
+	if !objectstore.IsNotFound(err) {
+		t.Fatalf("Get(%q) error = %v, want not found", key, err)
 	}
 }
 

--- a/ctld/internal/ctld/portal/s3_session_test.go
+++ b/ctld/internal/ctld/portal/s3_session_test.go
@@ -62,6 +62,33 @@ func TestS3SessionProjectsObjectsAsDirectoriesAndFiles(t *testing.T) {
 	}
 }
 
+func TestS3SessionReadDirShadowsFileWhenBackendOmitsCommonPrefix(t *testing.T) {
+	ctx := context.Background()
+	base := objectstore.NewMemoryStore(t.Name())
+	putS3TestObject(t, base, "blue", "file-shadowed-by-directory")
+	putS3TestObject(t, base, "blue/image.jpg", "nested")
+	store := commonPrefixBlindStore{Store: base}
+	session := newS3Session("vol-s3", store, volume.AccessModeRWO, nil)
+
+	entriesResp, err := session.ReadDir(ctx, &pb.ReadDirRequest{Inode: s3RootInode, Plus: true})
+	if err != nil {
+		t.Fatalf("ReadDir(root) error = %v", err)
+	}
+	got := make([]string, 0, len(entriesResp.Entries))
+	for _, entry := range entriesResp.Entries {
+		kind := "file"
+		if entry.Type&uint32(syscall.S_IFMT) == uint32(syscall.S_IFDIR) {
+			kind = "dir"
+		}
+		got = append(got, kind+":"+entry.Name)
+	}
+	sort.Strings(got)
+	want := []string{"dir:blue"}
+	if !equalPortalStringSlices(got, want) {
+		t.Fatalf("ReadDir(root) = %#v, want %#v", got, want)
+	}
+}
+
 func TestS3SessionSeesExternalObjectsAndWritesBackNewFiles(t *testing.T) {
 	ctx := context.Background()
 	store := objectstore.NewMemoryStore(t.Name())
@@ -288,6 +315,24 @@ func (s headErrorForDirectoryMarkersStore) Head(key string) (objectstore.Info, e
 		return objectstore.Info{}, errors.New("bad request")
 	}
 	return s.Store.Head(key)
+}
+
+type commonPrefixBlindStore struct {
+	objectstore.Store
+}
+
+func (s commonPrefixBlindStore) List(prefix, startAfter, token, delimiter string, limit int64) ([]objectstore.Info, bool, string, error) {
+	infos, more, next, err := s.Store.List(prefix, startAfter, token, delimiter, limit)
+	if err != nil || delimiter == "" {
+		return infos, more, next, err
+	}
+	filtered := infos[:0]
+	for _, info := range infos {
+		if !info.IsPrefix {
+			filtered = append(filtered, info)
+		}
+	}
+	return filtered, more, next, nil
 }
 
 func putS3TestObject(t *testing.T, store objectstore.Store, key, value string) {

--- a/ctld/internal/ctld/portal/s3_session_test.go
+++ b/ctld/internal/ctld/portal/s3_session_test.go
@@ -191,6 +191,18 @@ func TestS3SessionSeesExternalObjectsAndWritesBackNewFiles(t *testing.T) {
 	}
 	assertS3TestObject(t, store, "from-sandbox/implicit.txt", "implicit")
 
+	nonSequential, err := session.Create(ctx, &pb.CreateRequest{Parent: fromSandbox.Inode, Name: "non-sequential.txt"})
+	if err != nil {
+		t.Fatalf("Create(non-sequential.txt) error = %v", err)
+	}
+	if _, err := session.Write(ctx, &pb.WriteRequest{HandleId: nonSequential.HandleId, Offset: 1, Data: []byte("x")}); fserror.CodeOf(err) != fserror.InvalidArgument {
+		t.Fatalf("Write(non-sequential) error = %v, want InvalidArgument", err)
+	}
+	if _, err := session.Release(ctx, &pb.ReleaseRequest{HandleId: nonSequential.HandleId}); err != nil {
+		t.Fatalf("Release(non-sequential.txt) error = %v", err)
+	}
+	assertS3TestObjectMissing(t, store, "from-sandbox/non-sequential.txt")
+
 	entriesResp, err := session.ReadDir(ctx, &pb.ReadDirRequest{Inode: s3RootInode, Plus: true})
 	if err != nil {
 		t.Fatalf("ReadDir(root) error = %v", err)

--- a/ctld/internal/ctld/portal/s3_session_test.go
+++ b/ctld/internal/ctld/portal/s3_session_test.go
@@ -107,8 +107,25 @@ func TestS3SessionSeesExternalObjectsAndWritesBackNewFiles(t *testing.T) {
 		t.Fatalf("Write(second) error = %v", err)
 	}
 	assertS3TestObjectMissing(t, store, "from-sandbox/new.txt")
+	lookedUp, err := session.Lookup(ctx, &pb.LookupRequest{Parent: fromSandbox.Inode, Name: "new.txt"})
+	if err != nil {
+		t.Fatalf("Lookup(uncommitted new.txt) error = %v", err)
+	}
+	if lookedUp.Inode != created.Inode {
+		t.Fatalf("Lookup(uncommitted new.txt) inode = %d, want %d", lookedUp.Inode, created.Inode)
+	}
+	entriesDuringWrite, err := session.ReadDir(ctx, &pb.ReadDirRequest{Inode: fromSandbox.Inode})
+	if err != nil {
+		t.Fatalf("ReadDir(from-sandbox during write) error = %v", err)
+	}
+	if got := portalDirEntryNames(entriesDuringWrite.Entries); !equalPortalStringSlices(got, []string{"new.txt"}) {
+		t.Fatalf("ReadDir(from-sandbox during write) = %#v, want new.txt", got)
+	}
 	if _, err := session.Open(ctx, &pb.OpenRequest{Inode: created.Inode}); !errors.Is(err, syscall.EPERM) {
 		t.Fatalf("Open(reader while writer open) error = %v, want EPERM", err)
+	}
+	if _, err := session.Unlink(ctx, &pb.UnlinkRequest{Parent: fromSandbox.Inode, Name: "new.txt"}); !errors.Is(err, syscall.EPERM) {
+		t.Fatalf("Unlink(writer open) error = %v, want EPERM", err)
 	}
 	if _, err := session.Release(ctx, &pb.ReleaseRequest{HandleId: created.HandleId}); err != nil {
 		t.Fatalf("Release(new.txt) error = %v", err)
@@ -302,4 +319,13 @@ func equalPortalStringSlices(a, b []string) bool {
 		}
 	}
 	return true
+}
+
+func portalDirEntryNames(entries []*pb.DirEntry) []string {
+	out := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		out = append(out, entry.Name)
+	}
+	sort.Strings(out)
+	return out
 }

--- a/docs/volume/mounts/page.mdx
+++ b/docs/volume/mounts/page.mdx
@@ -73,6 +73,12 @@ Only mounts present in the claim request are treated as bound Sandbox Volume pat
 
 `RWX` is not accepted for Sandbox mounts in this node-local implementation. Use direct file APIs for control-plane file operations, or use separate `RWO` volumes for write-heavy Sandbox workloads.
 
+## S3 Backend Mounts
+
+Volumes created with `backend: "s3"` are mounted through the same template-declared volume portal. The mounted path exposes the configured S3-compatible prefix as a filesystem: keys use `/` as directory separators, common prefixes appear as directories, and files created inside the Sandbox are uploaded as S3 objects when the file handle is closed or flushed.
+
+The S3 backend supports `RWO` and `ROX` mounts. Writable opens replace the target object and must write sequentially; random in-place overwrites are not supported. It does not support `RWX`, snapshots, restore, forks, renames, hard links, symlinks, xattrs, file locks, or fallocate. Use it when the desired source of truth is an existing S3/OSS/R2 prefix rather than a Sandbox0-managed `s0fs` volume.
+
 ## Correctness Guarantees
 
 Mounted `RWO` volumes use one active writable owner at a time.

--- a/docs/volume/page.mdx
+++ b/docs/volume/page.mdx
@@ -43,6 +43,38 @@ Volumes support three access modes:
 The default access mode is `RWO`. Sandbox mounts are declared by the template and bound at claim time. `RWO` mounts use node-local write-ahead logging for low-latency small-file workloads, `ROX` is for read-only sharing, and `RWX` is not accepted for sandbox mounts in the current node-local mount path.
 </Callout>
 
+## Volume Backends
+
+The default backend is `s0fs`, Sandbox0's durable POSIX-oriented volume store backed by S3-compatible object storage. `s0fs` supports Sandbox mounts, direct file APIs, snapshots, restore, and forks.
+
+Sandbox0 can also create a `s3` backend volume that exposes an existing S3-compatible bucket prefix through the volume portal:
+
+```json
+{
+    "backend": "s3",
+    "access_mode": "RWO",
+    "s3": {
+        "provider": "aws",
+        "bucket": "sandbox-data",
+        "prefix": "team-a/workspace-a",
+        "region": "us-east-1"
+    }
+}
+```
+
+`provider` can be `aws`, `ali`, or `r2`. Use `ali` for Aliyun OSS and `r2` for Cloudflare R2. `endpoint_url` is required for `ali` and `r2`; credentials can be provided per volume with `access_key`, `secret_key`, and optional `session_token`, or inherited from the storage-proxy configuration when omitted.
+
+The `s3` backend is mount-s3-like rather than a full `s0fs` replacement:
+
+- object keys are projected into directories using `/`
+- directory entries are synthetic, or represented by zero-byte marker objects ending in `/`
+- new files are written back to S3 on close, flush, or fsync
+- external S3 object changes are visible through the mounted path on later lookup/read/list operations
+- Writable opens replace the target object and must write sequentially; random in-place overwrites are not supported
+- `RWX`, snapshots, restore, forks, direct file APIs without an active mounted owner, rename, hard links, symlinks, xattrs, locks, and fallocate are not supported
+
+When a `s3` volume is actively mounted, direct volume file API requests can still be proxied to that active ctld owner. When it is not mounted, use S3 APIs directly or mount it into a Sandbox first.
+
 ## Correctness Model
 
 For mounted `RWO` volumes, Sandbox0 keeps one active writable owner at a time.

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.55.1
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.72.3
 	github.com/aws/aws-sdk-go-v2/service/sts v1.33.14
+	github.com/aws/smithy-go v1.24.0
 	github.com/container-storage-interface/spec v1.12.0
 	github.com/containerd/containerd/v2 v2.2.0
 	github.com/containerd/continuity v0.4.5
@@ -94,7 +95,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.18.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.24.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.28.14 // indirect
-	github.com/aws/smithy-go v1.24.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bytedance/sonic v1.10.0-rc3 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -929,7 +929,11 @@ func (s *SandboxService) bindVolumePortals(ctx context.Context, pod *corev1.Pod,
 	for _, mount := range req.Mounts {
 		mountPoint := filepath.Clean(mount.MountPoint)
 		decl := declared[mountPoint]
-		if err := s.validateVolumePortalAccess(ctx, req.TeamID, req.UserID, mount.SandboxVolumeID, decl); err != nil {
+		info, err := s.validateVolumePortalAccess(ctx, req.TeamID, req.UserID, mount.SandboxVolumeID, decl)
+		if err != nil {
+			return nil, err
+		}
+		if err := validateVolumePortalRuntimeCompatibility(pod, info, mountPoint); err != nil {
 			return nil, err
 		}
 		resp, err := s.bindVolumePortal(ctx, pod, req.TeamID, req.UserID, req.TeamID, mount.SandboxVolumeID, mountPoint, decl.Name)
@@ -947,13 +951,13 @@ func (s *SandboxService) bindVolumePortals(ctx context.Context, pod *corev1.Pod,
 	return out, nil
 }
 
-func (s *SandboxService) validateVolumePortalAccess(ctx context.Context, teamID, userID, volumeID string, mount v1alpha1.VolumeMountSpec) error {
+func (s *SandboxService) validateVolumePortalAccess(ctx context.Context, teamID, userID, volumeID string, mount v1alpha1.VolumeMountSpec) (*SandboxVolumeInfo, error) {
 	if s.volumeMetadata == nil {
-		return fmt.Errorf("volume metadata client is not configured")
+		return nil, fmt.Errorf("volume metadata client is not configured")
 	}
 	info, err := s.volumeMetadata.Get(ctx, teamID, userID, volumeID)
 	if err != nil {
-		return fmt.Errorf("get volume metadata for %s: %w", volumeID, err)
+		return nil, fmt.Errorf("get volume metadata for %s: %w", volumeID, err)
 	}
 	accessMode := strings.ToUpper(strings.TrimSpace(info.AccessMode))
 	if accessMode == "" {
@@ -961,17 +965,35 @@ func (s *SandboxService) validateVolumePortalAccess(ctx context.Context, teamID,
 	}
 	switch accessMode {
 	case "RWO":
-		return nil
+		return info, nil
 	case "ROX":
 		if mount.ReadOnly {
-			return nil
+			return info, nil
 		}
-		return fmt.Errorf("%w: volume %s is ROX but template mount %s is read-write", ErrInvalidClaimRequest, volumeID, mount.MountPath)
+		return nil, fmt.Errorf("%w: volume %s is ROX but template mount %s is read-write", ErrInvalidClaimRequest, volumeID, mount.MountPath)
 	case "RWX":
-		return fmt.Errorf("%w: RWX volumes require the shared correctness path and cannot use node-local volume portals yet", ErrInvalidClaimRequest)
+		return nil, fmt.Errorf("%w: RWX volumes require the shared correctness path and cannot use node-local volume portals yet", ErrInvalidClaimRequest)
 	default:
-		return fmt.Errorf("%w: volume %s has invalid access_mode %q", ErrInvalidClaimRequest, volumeID, info.AccessMode)
+		return nil, fmt.Errorf("%w: volume %s has invalid access_mode %q", ErrInvalidClaimRequest, volumeID, info.AccessMode)
 	}
+}
+
+func validateVolumePortalRuntimeCompatibility(pod *corev1.Pod, info *SandboxVolumeInfo, mountPoint string) error {
+	if info == nil || strings.ToLower(strings.TrimSpace(info.Backend)) != "s3" {
+		return nil
+	}
+	runtimeClassName := runtimeClassNameForPod(pod)
+	if runtimeClassName == "" || strings.Contains(runtimeClassName, "runc") {
+		return nil
+	}
+	return fmt.Errorf("%w: s3 volume %s requires a runc-compatible sandbox runtime for mount-s3-compatible volume portal semantics; runtimeClassName %q is not supported for mount %s", ErrInvalidClaimRequest, info.ID, runtimeClassName, mountPoint)
+}
+
+func runtimeClassNameForPod(pod *corev1.Pod) string {
+	if pod == nil || pod.Spec.RuntimeClassName == nil {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(*pod.Spec.RuntimeClassName))
 }
 
 func (s *SandboxService) bindWebhookStatePortal(ctx context.Context, pod *corev1.Pod, req *ClaimRequest) error {

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -1774,7 +1774,7 @@ func TestValidateClaimMountsForTemplateAllowsDeclaredMountPoint(t *testing.T) {
 func TestValidateVolumePortalAccessRejectsRWXNodeLocalPortal(t *testing.T) {
 	svc := &SandboxService{volumeMetadata: fakeVolumeMetadataClient{accessMode: "RWX"}}
 
-	err := svc.validateVolumePortalAccess(context.Background(), "team-a", "user-a", "vol-1", v1alpha1.VolumeMountSpec{
+	_, err := svc.validateVolumePortalAccess(context.Background(), "team-a", "user-a", "vol-1", v1alpha1.VolumeMountSpec{
 		Name:      "data",
 		MountPath: "/workspace/data",
 	})
@@ -1789,7 +1789,7 @@ func TestValidateVolumePortalAccessRejectsRWXNodeLocalPortal(t *testing.T) {
 func TestValidateVolumePortalAccessAllowsROXOnlyForReadOnlyTemplateMount(t *testing.T) {
 	svc := &SandboxService{volumeMetadata: fakeVolumeMetadataClient{accessMode: "ROX"}}
 
-	err := svc.validateVolumePortalAccess(context.Background(), "team-a", "user-a", "vol-1", v1alpha1.VolumeMountSpec{
+	_, err := svc.validateVolumePortalAccess(context.Background(), "team-a", "user-a", "vol-1", v1alpha1.VolumeMountSpec{
 		Name:      "data",
 		MountPath: "/workspace/data",
 	})
@@ -1800,7 +1800,7 @@ func TestValidateVolumePortalAccessAllowsROXOnlyForReadOnlyTemplateMount(t *test
 		t.Fatalf("expected ErrInvalidClaimRequest, got %v", err)
 	}
 
-	if err := svc.validateVolumePortalAccess(context.Background(), "team-a", "user-a", "vol-1", v1alpha1.VolumeMountSpec{
+	if _, err := svc.validateVolumePortalAccess(context.Background(), "team-a", "user-a", "vol-1", v1alpha1.VolumeMountSpec{
 		Name:      "data",
 		MountPath: "/workspace/data",
 		ReadOnly:  true,
@@ -1809,8 +1809,36 @@ func TestValidateVolumePortalAccessAllowsROXOnlyForReadOnlyTemplateMount(t *test
 	}
 }
 
+func TestValidateVolumePortalRuntimeCompatibilityRejectsS3WithGVisor(t *testing.T) {
+	runtimeClassName := "gvisor-rootfs"
+	pod := &corev1.Pod{Spec: corev1.PodSpec{RuntimeClassName: &runtimeClassName}}
+	info := &SandboxVolumeInfo{ID: "vol-1", Backend: "s3"}
+
+	err := validateVolumePortalRuntimeCompatibility(pod, info, "/workspace/data")
+	if err == nil {
+		t.Fatal("expected runtime compatibility validation error")
+	}
+	if !errors.Is(err, ErrInvalidClaimRequest) {
+		t.Fatalf("expected ErrInvalidClaimRequest, got %v", err)
+	}
+}
+
+func TestValidateVolumePortalRuntimeCompatibilityAllowsS3WithDefaultOrRunc(t *testing.T) {
+	info := &SandboxVolumeInfo{ID: "vol-1", Backend: "s3"}
+	if err := validateVolumePortalRuntimeCompatibility(&corev1.Pod{}, info, "/workspace/data"); err != nil {
+		t.Fatalf("default runtime compatibility error = %v", err)
+	}
+
+	runtimeClassName := "runc"
+	pod := &corev1.Pod{Spec: corev1.PodSpec{RuntimeClassName: &runtimeClassName}}
+	if err := validateVolumePortalRuntimeCompatibility(pod, info, "/workspace/data"); err != nil {
+		t.Fatalf("runc runtime compatibility error = %v", err)
+	}
+}
+
 type fakeVolumeMetadataClient struct {
 	accessMode string
+	backend    string
 	err        error
 	prepared   []string
 	prepareErr error
@@ -1825,6 +1853,7 @@ func (c fakeVolumeMetadataClient) Get(_ context.Context, teamID, userID, volumeI
 		TeamID:     teamID,
 		UserID:     userID,
 		AccessMode: c.accessMode,
+		Backend:    c.backend,
 	}, nil
 }
 

--- a/manager/pkg/service/sandbox_webhook_state.go
+++ b/manager/pkg/service/sandbox_webhook_state.go
@@ -95,6 +95,7 @@ type SandboxVolumeInfo struct {
 	TeamID     string `json:"team_id"`
 	UserID     string `json:"user_id"`
 	AccessMode string `json:"access_mode"`
+	Backend    string `json:"backend,omitempty"`
 }
 
 func (c *StorageProxyVolumeClient) Create(ctx context.Context, teamID, userID, sandboxID, purpose string) (string, error) {

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -5722,6 +5722,55 @@ components:
       enum: [RWO, ROX, RWX]
       description: >-
         Access mode for sandbox volumes. Enforcement is scoped to storage-proxy instances. RWO allows read-write mounts on a single instance; ROX allows read-only mounts across instances; RWX allows read-write mounts across instances.
+    VolumeBackend:
+      type: string
+      enum: [s0fs, s3]
+      description: >-
+        Storage backend for a SandboxVolume. s0fs is the default durable Sandbox0 volume backend. s3 mounts an existing S3-compatible prefix through the volume portal and supports mount-s3-like object projection.
+    CreateSandboxVolumeS3Config:
+      type: object
+      properties:
+        provider:
+          type: string
+          enum: [aws, ali, r2]
+          default: aws
+          description: S3-compatible provider. ali is Aliyun OSS; r2 is Cloudflare R2.
+        bucket:
+          type: string
+        prefix:
+          type: string
+          description: Optional object key prefix to expose as the volume root.
+        region:
+          type: string
+          description: Optional region override. Defaults to the storage-proxy S3 region when omitted.
+        endpoint_url:
+          type: string
+          description: Optional endpoint override. Required for ali and r2.
+        access_key:
+          type: string
+          description: Optional access key override. Must be provided together with secret_key.
+        secret_key:
+          type: string
+          description: Optional secret key override. Must be provided together with access_key.
+        session_token:
+          type: string
+          description: Optional temporary credential session token.
+      required: [bucket]
+    SandboxVolumeS3Config:
+      type: object
+      properties:
+        provider:
+          type: string
+          enum: [aws, ali, r2]
+        bucket:
+          type: string
+        prefix:
+          type: string
+        region:
+          type: string
+        endpoint_url:
+          type: string
+      required: [provider, bucket]
     MountStatus:
       type: object
       properties:
@@ -5748,6 +5797,12 @@ components:
         snapshot_id:
           type: string
           description: Optional snapshot ID used to initialize the new volume from immutable snapshot state.
+        backend:
+          $ref: "#/components/schemas/VolumeBackend"
+          description: Volume backend. Defaults to s0fs when omitted. If s3 is provided without backend, backend is inferred as s3.
+        s3:
+          $ref: "#/components/schemas/CreateSandboxVolumeS3Config"
+          description: S3-compatible backend configuration. Only valid with backend s3; s3 volumes do not support snapshot_id or RWX access mode.
         default_posix_uid:
           type: integer
           format: int64
@@ -5804,13 +5859,19 @@ components:
         access_mode:
           $ref: "#/components/schemas/VolumeAccessMode"
           description: Configured access mode for the volume.
+        backend:
+          $ref: "#/components/schemas/VolumeBackend"
+          description: Configured storage backend for the volume.
+        s3:
+          $ref: "#/components/schemas/SandboxVolumeS3Config"
+          description: Public S3-compatible backend metadata. Credentials are never returned.
         created_at:
           type: string
           format: date-time
         updated_at:
           type: string
           format: date-time
-      required: [id, team_id, user_id, created_at, updated_at]
+      required: [id, team_id, user_id, backend, created_at, updated_at]
     SuccessSandboxVolumeResponse:
       allOf:
         - $ref: "#/components/schemas/SuccessEnvelope"

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -30,6 +30,13 @@ const (
 	AppArmorProfileTypeUnconfined     AppArmorProfileType = "Unconfined"
 )
 
+// Defines values for CreateSandboxVolumeS3ConfigProvider.
+const (
+	CreateSandboxVolumeS3ConfigProviderAli CreateSandboxVolumeS3ConfigProvider = "ali"
+	CreateSandboxVolumeS3ConfigProviderAws CreateSandboxVolumeS3ConfigProvider = "aws"
+	CreateSandboxVolumeS3ConfigProviderR2  CreateSandboxVolumeS3ConfigProvider = "r2"
+)
+
 // Defines values for CredentialProjectionType.
 const (
 	HttpHeaders             CredentialProjectionType = "http_headers"
@@ -233,6 +240,13 @@ const (
 	SandboxObservabilityWatchLineTypeLog          SandboxObservabilityWatchLineType = "log"
 	SandboxObservabilityWatchLineTypeMetricSample SandboxObservabilityWatchLineType = "metric_sample"
 	SandboxObservabilityWatchLineTypeWatermark    SandboxObservabilityWatchLineType = "watermark"
+)
+
+// Defines values for SandboxVolumeS3ConfigProvider.
+const (
+	SandboxVolumeS3ConfigProviderAli SandboxVolumeS3ConfigProvider = "ali"
+	SandboxVolumeS3ConfigProviderAws SandboxVolumeS3ConfigProvider = "aws"
+	SandboxVolumeS3ConfigProviderR2  SandboxVolumeS3ConfigProvider = "r2"
 )
 
 // Defines values for SeccompProfileType.
@@ -586,6 +600,12 @@ const (
 	RWX VolumeAccessMode = "RWX"
 )
 
+// Defines values for VolumeBackend.
+const (
+	S0fs VolumeBackend = "s0fs"
+	S3   VolumeBackend = "s3"
+)
+
 // APIKey defines model for APIKey.
 type APIKey struct {
 	CreatedAt  time.Time  `json:"created_at"`
@@ -840,15 +860,47 @@ type CreateSandboxVolumeRequest struct {
 	// AccessMode Access mode for sandbox volumes. Enforcement is scoped to storage-proxy instances. RWO allows read-write mounts on a single instance; ROX allows read-only mounts across instances; RWX allows read-write mounts across instances.
 	AccessMode *VolumeAccessMode `json:"access_mode,omitempty"`
 
+	// Backend Storage backend for a SandboxVolume. s0fs is the default durable Sandbox0 volume backend. s3 mounts an existing S3-compatible prefix through the volume portal and supports mount-s3-like object projection.
+	Backend *VolumeBackend `json:"backend,omitempty"`
+
 	// DefaultPosixGid Default POSIX GID used by external volume access paths that do not carry caller identity. Defaults to 0 when omitted on create.
 	DefaultPosixGid *int64 `json:"default_posix_gid,omitempty"`
 
 	// DefaultPosixUid Default POSIX UID used by external volume access paths that do not carry caller identity. Defaults to 0 when omitted on create.
-	DefaultPosixUid *int64 `json:"default_posix_uid,omitempty"`
+	DefaultPosixUid *int64                       `json:"default_posix_uid,omitempty"`
+	S3              *CreateSandboxVolumeS3Config `json:"s3,omitempty"`
 
 	// SnapshotId Optional snapshot ID used to initialize the new volume from immutable snapshot state.
 	SnapshotId *string `json:"snapshot_id,omitempty"`
 }
+
+// CreateSandboxVolumeS3Config defines model for CreateSandboxVolumeS3Config.
+type CreateSandboxVolumeS3Config struct {
+	// AccessKey Optional access key override. Must be provided together with secret_key.
+	AccessKey *string `json:"access_key,omitempty"`
+	Bucket    string  `json:"bucket"`
+
+	// EndpointUrl Optional endpoint override. Required for ali and r2.
+	EndpointUrl *string `json:"endpoint_url,omitempty"`
+
+	// Prefix Optional object key prefix to expose as the volume root.
+	Prefix *string `json:"prefix,omitempty"`
+
+	// Provider S3-compatible provider. ali is Aliyun OSS; r2 is Cloudflare R2.
+	Provider *CreateSandboxVolumeS3ConfigProvider `json:"provider,omitempty"`
+
+	// Region Optional region override. Defaults to the storage-proxy S3 region when omitted.
+	Region *string `json:"region,omitempty"`
+
+	// SecretKey Optional secret key override. Must be provided together with access_key.
+	SecretKey *string `json:"secret_key,omitempty"`
+
+	// SessionToken Optional temporary credential session token.
+	SessionToken *string `json:"session_token,omitempty"`
+}
+
+// CreateSandboxVolumeS3ConfigProvider S3-compatible provider. ali is Aliyun OSS; r2 is Cloudflare R2.
+type CreateSandboxVolumeS3ConfigProvider string
 
 // CreateSnapshotRequest defines model for CreateSnapshotRequest.
 type CreateSnapshotRequest struct {
@@ -2071,16 +2123,32 @@ type SandboxUpdateRequest struct {
 // SandboxVolume defines model for SandboxVolume.
 type SandboxVolume struct {
 	// AccessMode Access mode for sandbox volumes. Enforcement is scoped to storage-proxy instances. RWO allows read-write mounts on a single instance; ROX allows read-only mounts across instances; RWX allows read-write mounts across instances.
-	AccessMode      *VolumeAccessMode `json:"access_mode,omitempty"`
-	CreatedAt       time.Time         `json:"created_at"`
-	DefaultPosixGid *int64            `json:"default_posix_gid"`
-	DefaultPosixUid *int64            `json:"default_posix_uid"`
-	Id              string            `json:"id"`
-	SourceVolumeId  *string           `json:"source_volume_id"`
-	TeamId          string            `json:"team_id"`
-	UpdatedAt       time.Time         `json:"updated_at"`
-	UserId          string            `json:"user_id"`
+	AccessMode *VolumeAccessMode `json:"access_mode,omitempty"`
+
+	// Backend Storage backend for a SandboxVolume. s0fs is the default durable Sandbox0 volume backend. s3 mounts an existing S3-compatible prefix through the volume portal and supports mount-s3-like object projection.
+	Backend         VolumeBackend          `json:"backend"`
+	CreatedAt       time.Time              `json:"created_at"`
+	DefaultPosixGid *int64                 `json:"default_posix_gid"`
+	DefaultPosixUid *int64                 `json:"default_posix_uid"`
+	Id              string                 `json:"id"`
+	S3              *SandboxVolumeS3Config `json:"s3,omitempty"`
+	SourceVolumeId  *string                `json:"source_volume_id"`
+	TeamId          string                 `json:"team_id"`
+	UpdatedAt       time.Time              `json:"updated_at"`
+	UserId          string                 `json:"user_id"`
 }
+
+// SandboxVolumeS3Config defines model for SandboxVolumeS3Config.
+type SandboxVolumeS3Config struct {
+	Bucket      string                        `json:"bucket"`
+	EndpointUrl *string                       `json:"endpoint_url,omitempty"`
+	Prefix      *string                       `json:"prefix,omitempty"`
+	Provider    SandboxVolumeS3ConfigProvider `json:"provider"`
+	Region      *string                       `json:"region,omitempty"`
+}
+
+// SandboxVolumeS3ConfigProvider defines model for SandboxVolumeS3Config.Provider.
+type SandboxVolumeS3ConfigProvider string
 
 // SeccompProfile defines model for SeccompProfile.
 type SeccompProfile struct {
@@ -2921,6 +2989,9 @@ type UsernamePasswordProjection = map[string]interface{}
 
 // VolumeAccessMode Access mode for sandbox volumes. Enforcement is scoped to storage-proxy instances. RWO allows read-write mounts on a single instance; ROX allows read-only mounts across instances; RWX allows read-write mounts across instances.
 type VolumeAccessMode string
+
+// VolumeBackend Storage backend for a SandboxVolume. s0fs is the default durable Sandbox0 volume backend. s3 mounts an existing S3-compatible prefix through the volume portal and supports mount-s3-like object projection.
+type VolumeBackend string
 
 // VolumeFileArchiveImportResponse defines model for VolumeFileArchiveImportResponse.
 type VolumeFileArchiveImportResponse struct {

--- a/pkg/volumefuse/fs.go
+++ b/pkg/volumefuse/fs.go
@@ -20,7 +20,7 @@ type FileSystem struct {
 	cacheTTL time.Duration
 }
 
-const fileOpenFlags = fuse.FOPEN_KEEP_CACHE | fuse.FOPEN_NOFLUSH
+const fileOpenFlags = fuse.FOPEN_KEEP_CACHE
 
 func New(volumeID string, cacheTTL time.Duration, session Session) *FileSystem {
 	if cacheTTL < 0 {
@@ -420,7 +420,7 @@ func (fs *FileSystem) Create(cancel <-chan struct{}, input *fuse.CreateIn, name 
 	fs.invalidateKernelAttr(input.NodeId)
 	setEntryOut(&out.EntryOut, resp.Inode, resp.Attr, fs.cacheTTL)
 	out.Fh = resp.HandleId
-	out.OpenFlags = fileOpenFlags
+	out.OpenFlags = sessionOpenFlags(session)
 	return fuse.OK
 }
 
@@ -443,7 +443,7 @@ func (fs *FileSystem) Open(cancel <-chan struct{}, input *fuse.OpenIn, out *fuse
 		return statusToFuse(err)
 	}
 	out.Fh = resp.HandleId
-	out.OpenFlags = fileOpenFlags
+	out.OpenFlags = sessionOpenFlags(session)
 	return fuse.OK
 }
 
@@ -1053,6 +1053,13 @@ func setAttr(out *fuse.Attr, attr *pb.GetAttrResponse) {
 	out.Ctime = uint64(attr.CtimeSec)
 	out.Ctimensec = uint32(attr.CtimeNsec)
 	out.Blksize = 4096
+}
+
+func sessionOpenFlags(session Session) uint32 {
+	if provider, ok := session.(OpenFlagsSession); ok {
+		return provider.OpenFlags()
+	}
+	return fileOpenFlags
 }
 
 func statusToFuse(err error) fuse.Status {

--- a/pkg/volumefuse/fs_test.go
+++ b/pkg/volumefuse/fs_test.go
@@ -55,3 +55,35 @@ func TestReadUsesReadIntoSession(t *testing.T) {
 		t.Fatal("Read fallback was called")
 	}
 }
+
+type openFlagsTestSession struct {
+	Session
+	flags uint32
+}
+
+func (s openFlagsTestSession) OpenFlags() uint32 {
+	return s.flags
+}
+
+func (s openFlagsTestSession) Open(context.Context, *pb.OpenRequest) (*pb.OpenResponse, error) {
+	return &pb.OpenResponse{HandleId: 7}, nil
+}
+
+func TestOpenUsesSessionOpenFlags(t *testing.T) {
+	session := openFlagsTestSession{flags: fuse.FOPEN_DIRECT_IO}
+	fs := New("vol-1", time.Second, session)
+
+	var out fuse.OpenOut
+	st := fs.Open(nil, &fuse.OpenIn{
+		InHeader: fuse.InHeader{NodeId: 42},
+	}, &out)
+	if st != fuse.OK {
+		t.Fatalf("Open() status = %v, want OK", st)
+	}
+	if out.Fh != 7 {
+		t.Fatalf("Open() handle = %d, want 7", out.Fh)
+	}
+	if out.OpenFlags != fuse.FOPEN_DIRECT_IO {
+		t.Fatalf("Open() flags = %#x, want DIRECT_IO", out.OpenFlags)
+	}
+}

--- a/pkg/volumefuse/session.go
+++ b/pkg/volumefuse/session.go
@@ -46,3 +46,7 @@ type Session interface {
 type ReadIntoSession interface {
 	ReadInto(context.Context, *pb.ReadRequest, []byte) (int, bool, error)
 }
+
+type OpenFlagsSession interface {
+	OpenFlags() uint32
+}

--- a/storage-proxy/migrations/00014_add_sandbox_volume_backend_config.sql
+++ b/storage-proxy/migrations/00014_add_sandbox_volume_backend_config.sql
@@ -1,0 +1,17 @@
+-- +goose Up
+ALTER TABLE sandbox_volumes
+ADD COLUMN IF NOT EXISTS backend TEXT NOT NULL DEFAULT 's0fs',
+ADD COLUMN IF NOT EXISTS backend_config JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+UPDATE sandbox_volumes
+SET backend = 's0fs'
+WHERE trim(coalesce(backend, '')) = '';
+
+UPDATE sandbox_volumes
+SET backend_config = '{}'::jsonb
+WHERE backend_config IS NULL;
+
+-- +goose Down
+ALTER TABLE sandbox_volumes
+DROP COLUMN IF EXISTS backend_config,
+DROP COLUMN IF EXISTS backend;

--- a/storage-proxy/pkg/db/models.go
+++ b/storage-proxy/pkg/db/models.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"encoding/json"
+	"strings"
 	"time"
 )
 
@@ -17,9 +18,73 @@ type SandboxVolume struct {
 	DefaultPosixGID *int64 `json:"default_posix_gid,omitempty"`
 
 	AccessMode string `json:"access_mode"`
+	Backend    string `json:"backend"`
+	// BackendConfig stores backend-specific configuration. It is intentionally
+	// omitted from JSON responses because S3 configs may contain credentials.
+	BackendConfig json.RawMessage `json:"-"`
 
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
+}
+
+type sandboxVolumeJSON struct {
+	ID              string                     `json:"id"`
+	TeamID          string                     `json:"team_id"`
+	UserID          string                     `json:"user_id"`
+	SourceVolumeID  *string                    `json:"source_volume_id,omitempty"`
+	DefaultPosixUID *int64                     `json:"default_posix_uid,omitempty"`
+	DefaultPosixGID *int64                     `json:"default_posix_gid,omitempty"`
+	AccessMode      string                     `json:"access_mode"`
+	Backend         string                     `json:"backend"`
+	S3              *sandboxVolumeS3PublicJSON `json:"s3,omitempty"`
+	CreatedAt       time.Time                  `json:"created_at"`
+	UpdatedAt       time.Time                  `json:"updated_at"`
+}
+
+type sandboxVolumeS3PublicJSON struct {
+	Provider    string `json:"provider,omitempty"`
+	Bucket      string `json:"bucket,omitempty"`
+	Prefix      string `json:"prefix,omitempty"`
+	Region      string `json:"region,omitempty"`
+	EndpointURL string `json:"endpoint_url,omitempty"`
+}
+
+func (v SandboxVolume) MarshalJSON() ([]byte, error) {
+	backend := strings.TrimSpace(v.Backend)
+	if backend == "" {
+		backend = "s0fs"
+	}
+	out := sandboxVolumeJSON{
+		ID:              v.ID,
+		TeamID:          v.TeamID,
+		UserID:          v.UserID,
+		SourceVolumeID:  v.SourceVolumeID,
+		DefaultPosixUID: v.DefaultPosixUID,
+		DefaultPosixGID: v.DefaultPosixGID,
+		AccessMode:      v.AccessMode,
+		Backend:         backend,
+		CreatedAt:       v.CreatedAt,
+		UpdatedAt:       v.UpdatedAt,
+	}
+	if backend == "s3" && len(v.BackendConfig) > 0 {
+		var cfg struct {
+			Provider    string `json:"provider,omitempty"`
+			Bucket      string `json:"bucket,omitempty"`
+			Prefix      string `json:"prefix,omitempty"`
+			Region      string `json:"region,omitempty"`
+			EndpointURL string `json:"endpoint_url,omitempty"`
+		}
+		if err := json.Unmarshal(v.BackendConfig, &cfg); err == nil {
+			out.S3 = &sandboxVolumeS3PublicJSON{
+				Provider:    cfg.Provider,
+				Bucket:      cfg.Bucket,
+				Prefix:      cfg.Prefix,
+				Region:      cfg.Region,
+				EndpointURL: cfg.EndpointURL,
+			}
+		}
+	}
+	return json.Marshal(out)
 }
 
 // S0FSCommittedHead stores the current committed immutable manifest pointer for one volume.

--- a/storage-proxy/pkg/db/repository.go
+++ b/storage-proxy/pkg/db/repository.go
@@ -65,6 +65,29 @@ func decodeMountAccessMode(raw *json.RawMessage) string {
 	return normalizeMountAccessMode(opts.AccessMode)
 }
 
+func coalesceVolumeBackend(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "s0fs"
+	}
+	return value
+}
+
+func coalesceVolumeBackendConfig(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return json.RawMessage(`{}`)
+	}
+	return raw
+}
+
+func normalizeSandboxVolumeBackend(v *SandboxVolume) {
+	if v == nil {
+		return
+	}
+	v.Backend = coalesceVolumeBackend(v.Backend)
+	v.BackendConfig = coalesceVolumeBackendConfig(v.BackendConfig)
+}
+
 // Repository provides database access for storage-proxy
 type Repository struct {
 	pool *pgxpool.Pool
@@ -136,24 +159,24 @@ func (r *Repository) CreateSandboxVolumeTx(ctx context.Context, tx pgx.Tx, volum
 
 func (r *Repository) createSandboxVolume(ctx context.Context, db DB, volume *SandboxVolume) error {
 	_, err := db.Exec(ctx, `
-		INSERT INTO sandbox_volumes (
-			id, team_id, user_id,
-			source_volume_id,
-			default_posix_uid, default_posix_gid,
-			access_mode,
-			created_at, updated_at
-		) VALUES (
-			$1, $2, $3,
-			$4,
-			$5, $6,
-			$7,
-			$8, $9
-		)
-	`,
+			INSERT INTO sandbox_volumes (
+				id, team_id, user_id,
+				source_volume_id,
+				default_posix_uid, default_posix_gid,
+				access_mode, backend, backend_config,
+				created_at, updated_at
+			) VALUES (
+				$1, $2, $3,
+				$4,
+				$5, $6,
+				$7, $8, $9,
+				$10, $11
+			)
+		`,
 		volume.ID, volume.TeamID, volume.UserID,
 		volume.SourceVolumeID,
 		volume.DefaultPosixUID, volume.DefaultPosixGID,
-		volume.AccessMode,
+		volume.AccessMode, coalesceVolumeBackend(volume.Backend), coalesceVolumeBackendConfig(volume.BackendConfig),
 		volume.CreatedAt, volume.UpdatedAt,
 	)
 
@@ -185,7 +208,7 @@ func (r *Repository) getSandboxVolume(ctx context.Context, db DB, id string, for
 			id, team_id, user_id,
 			source_volume_id,
 			default_posix_uid, default_posix_gid,
-			access_mode,
+			access_mode, backend, backend_config,
 			created_at, updated_at
 		FROM sandbox_volumes
 		WHERE id = $1
@@ -200,7 +223,7 @@ func (r *Repository) getSandboxVolume(ctx context.Context, db DB, id string, for
 		&v.ID, &v.TeamID, &v.UserID,
 		&v.SourceVolumeID,
 		&v.DefaultPosixUID, &v.DefaultPosixGID,
-		&v.AccessMode,
+		&v.AccessMode, &v.Backend, &v.BackendConfig,
 		&v.CreatedAt, &v.UpdatedAt,
 	)
 
@@ -211,6 +234,7 @@ func (r *Repository) getSandboxVolume(ctx context.Context, db DB, id string, for
 		return nil, fmt.Errorf("query sandbox volume: %w", err)
 	}
 
+	normalizeSandboxVolumeBackend(&v)
 	return &v, nil
 }
 
@@ -221,12 +245,16 @@ func (r *Repository) UpdateSandboxVolume(ctx context.Context, volume *SandboxVol
 			default_posix_uid = $2,
 			default_posix_gid = $3,
 			access_mode = $4,
+			backend = $5,
+			backend_config = $6,
 			updated_at = NOW()
 		WHERE id = $1
 	`,
 		volume.ID,
 		volume.DefaultPosixUID, volume.DefaultPosixGID,
 		volume.AccessMode,
+		coalesceVolumeBackend(volume.Backend),
+		coalesceVolumeBackendConfig(volume.BackendConfig),
 	)
 
 	if err != nil {
@@ -244,11 +272,11 @@ func (r *Repository) UpdateSandboxVolume(ctx context.Context, volume *SandboxVol
 func (r *Repository) ListSandboxVolumesByTeam(ctx context.Context, teamID string) ([]*SandboxVolume, error) {
 	rows, err := r.pool.Query(ctx, `
 		SELECT
-			id, team_id, user_id,
-			source_volume_id,
-			default_posix_uid, default_posix_gid,
-			access_mode,
-			created_at, updated_at
+				id, team_id, user_id,
+				source_volume_id,
+				default_posix_uid, default_posix_gid,
+				access_mode, backend, backend_config,
+				created_at, updated_at
 		FROM sandbox_volumes
 		WHERE team_id = $1
 			AND NOT EXISTS (
@@ -269,12 +297,13 @@ func (r *Repository) ListSandboxVolumesByTeam(ctx context.Context, teamID string
 			&v.ID, &v.TeamID, &v.UserID,
 			&v.SourceVolumeID,
 			&v.DefaultPosixUID, &v.DefaultPosixGID,
-			&v.AccessMode,
+			&v.AccessMode, &v.Backend, &v.BackendConfig,
 			&v.CreatedAt, &v.UpdatedAt,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("scan sandbox volume: %w", err)
 		}
+		normalizeSandboxVolumeBackend(&v)
 		volumes = append(volumes, &v)
 	}
 	if err := rows.Err(); err != nil {
@@ -288,11 +317,11 @@ func (r *Repository) ListSandboxVolumesByTeam(ctx context.Context, teamID string
 func (r *Repository) ListSandboxVolumesBySource(ctx context.Context, sourceVolumeID string) ([]*SandboxVolume, error) {
 	rows, err := r.pool.Query(ctx, `
 		SELECT
-			id, team_id, user_id,
-			source_volume_id,
-			default_posix_uid, default_posix_gid,
-			access_mode,
-			created_at, updated_at
+				id, team_id, user_id,
+				source_volume_id,
+				default_posix_uid, default_posix_gid,
+				access_mode, backend, backend_config,
+				created_at, updated_at
 		FROM sandbox_volumes
 		WHERE source_volume_id = $1
 		ORDER BY created_at DESC
@@ -309,12 +338,13 @@ func (r *Repository) ListSandboxVolumesBySource(ctx context.Context, sourceVolum
 			&v.ID, &v.TeamID, &v.UserID,
 			&v.SourceVolumeID,
 			&v.DefaultPosixUID, &v.DefaultPosixGID,
-			&v.AccessMode,
+			&v.AccessMode, &v.Backend, &v.BackendConfig,
 			&v.CreatedAt, &v.UpdatedAt,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("scan sandbox volume by source: %w", err)
 		}
+		normalizeSandboxVolumeBackend(&v)
 		volumes = append(volumes, &v)
 	}
 	if err := rows.Err(); err != nil {
@@ -496,12 +526,12 @@ func (r *Repository) MarkOwnedSandboxVolumeCleanupAttempt(ctx context.Context, v
 
 func (r *Repository) queryOwnedSandboxVolumes(ctx context.Context, suffix string, args ...any) (pgx.Rows, error) {
 	rows, err := r.pool.Query(ctx, `
-		SELECT
-			v.id, v.team_id, v.user_id,
-			v.source_volume_id,
-			v.default_posix_uid, v.default_posix_gid,
-			v.access_mode,
-			v.created_at, v.updated_at,
+			SELECT
+				v.id, v.team_id, v.user_id,
+				v.source_volume_id,
+				v.default_posix_uid, v.default_posix_gid,
+				v.access_mode, v.backend, v.backend_config,
+				v.created_at, v.updated_at,
 			o.volume_id, o.owner_kind, o.owner_sandbox_id, o.owner_cluster_id, o.purpose,
 			o.created_at, o.cleanup_requested_at, o.cleanup_reason,
 			o.last_cleanup_attempt_at, o.last_cleanup_error, o.updated_at
@@ -520,7 +550,7 @@ func scanOwnedSandboxVolume(rows pgx.Rows) (*OwnedSandboxVolume, error) {
 		&item.Volume.ID, &item.Volume.TeamID, &item.Volume.UserID,
 		&item.Volume.SourceVolumeID,
 		&item.Volume.DefaultPosixUID, &item.Volume.DefaultPosixGID,
-		&item.Volume.AccessMode,
+		&item.Volume.AccessMode, &item.Volume.Backend, &item.Volume.BackendConfig,
 		&item.Volume.CreatedAt, &item.Volume.UpdatedAt,
 		&item.Owner.VolumeID, &item.Owner.OwnerKind, &item.Owner.OwnerSandboxID, &item.Owner.OwnerClusterID, &item.Owner.Purpose,
 		&item.Owner.CreatedAt, &item.Owner.CleanupRequestedAt, &item.Owner.CleanupReason,
@@ -529,6 +559,7 @@ func scanOwnedSandboxVolume(rows pgx.Rows) (*OwnedSandboxVolume, error) {
 	if err != nil {
 		return nil, fmt.Errorf("scan owned sandbox volume: %w", err)
 	}
+	normalizeSandboxVolumeBackend(&item.Volume)
 	return &item, nil
 }
 

--- a/storage-proxy/pkg/db/repository_s0fs_head_test.go
+++ b/storage-proxy/pkg/db/repository_s0fs_head_test.go
@@ -152,6 +152,69 @@ func TestListSandboxVolumesBySource(t *testing.T) {
 	}
 }
 
+func TestSandboxVolumeBackendConfigRoundTrip(t *testing.T) {
+	repo := newS0FSCommittedHeadTestRepository(t)
+	if repo == nil {
+		return
+	}
+
+	ctx := context.Background()
+	now := time.Now().UTC()
+	defaultID := "vol-" + uuid.NewString()
+	if err := repo.CreateSandboxVolume(ctx, &SandboxVolume{
+		ID:         defaultID,
+		TeamID:     "team-1",
+		UserID:     "user-1",
+		AccessMode: "RWO",
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}); err != nil {
+		t.Fatalf("CreateSandboxVolume(default) error = %v", err)
+	}
+	defaultVol, err := repo.GetSandboxVolume(ctx, defaultID)
+	if err != nil {
+		t.Fatalf("GetSandboxVolume(default) error = %v", err)
+	}
+	if defaultVol.Backend != "s0fs" {
+		t.Fatalf("default backend = %q, want s0fs", defaultVol.Backend)
+	}
+	if string(defaultVol.BackendConfig) != "{}" {
+		t.Fatalf("default backend_config = %s, want {}", string(defaultVol.BackendConfig))
+	}
+
+	s3ID := "vol-" + uuid.NewString()
+	rawConfig := json.RawMessage(`{"provider":"aws","bucket":"sandbox-data","prefix":"team-a/vol-a","access_key":"ak","secret_key":"sk"}`)
+	if err := repo.CreateSandboxVolume(ctx, &SandboxVolume{
+		ID:            s3ID,
+		TeamID:        "team-1",
+		UserID:        "user-1",
+		AccessMode:    "RWO",
+		Backend:       "s3",
+		BackendConfig: rawConfig,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}); err != nil {
+		t.Fatalf("CreateSandboxVolume(s3) error = %v", err)
+	}
+	s3Vol, err := repo.GetSandboxVolume(ctx, s3ID)
+	if err != nil {
+		t.Fatalf("GetSandboxVolume(s3) error = %v", err)
+	}
+	if s3Vol.Backend != "s3" {
+		t.Fatalf("s3 backend = %q, want s3", s3Vol.Backend)
+	}
+	if !json.Valid(s3Vol.BackendConfig) {
+		t.Fatalf("backend_config is not valid JSON: %s", string(s3Vol.BackendConfig))
+	}
+	var decoded map[string]string
+	if err := json.Unmarshal(s3Vol.BackendConfig, &decoded); err != nil {
+		t.Fatalf("unmarshal backend_config: %v", err)
+	}
+	if decoded["bucket"] != "sandbox-data" || decoded["prefix"] != "team-a/vol-a" || decoded["secret_key"] != "sk" {
+		t.Fatalf("backend_config = %#v", decoded)
+	}
+}
+
 func TestAcquireMountRejectsConflictingRWOMount(t *testing.T) {
 	repo := newS0FSCommittedHeadTestRepository(t)
 	if repo == nil {

--- a/storage-proxy/pkg/http/handlers_sandboxvolume.go
+++ b/storage-proxy/pkg/http/handlers_sandboxvolume.go
@@ -23,10 +23,12 @@ import (
 )
 
 type createSandboxVolumeRequest struct {
-	SnapshotID      string `json:"snapshot_id,omitempty"`
-	AccessMode      string `json:"access_mode"`
-	DefaultPosixUID *int64 `json:"default_posix_uid,omitempty"`
-	DefaultPosixGID *int64 `json:"default_posix_gid,omitempty"`
+	SnapshotID      string                  `json:"snapshot_id,omitempty"`
+	AccessMode      string                  `json:"access_mode"`
+	Backend         string                  `json:"backend,omitempty"`
+	S3              *volume.S3BackendConfig `json:"s3,omitempty"`
+	DefaultPosixUID *int64                  `json:"default_posix_uid,omitempty"`
+	DefaultPosixGID *int64                  `json:"default_posix_gid,omitempty"`
 	snapshotIDSet   bool
 }
 
@@ -36,16 +38,20 @@ func (r *createSandboxVolumeRequest) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	var decoded struct {
-		SnapshotID      string `json:"snapshot_id,omitempty"`
-		AccessMode      string `json:"access_mode"`
-		DefaultPosixUID *int64 `json:"default_posix_uid,omitempty"`
-		DefaultPosixGID *int64 `json:"default_posix_gid,omitempty"`
+		SnapshotID      string                  `json:"snapshot_id,omitempty"`
+		AccessMode      string                  `json:"access_mode"`
+		Backend         string                  `json:"backend,omitempty"`
+		S3              *volume.S3BackendConfig `json:"s3,omitempty"`
+		DefaultPosixUID *int64                  `json:"default_posix_uid,omitempty"`
+		DefaultPosixGID *int64                  `json:"default_posix_gid,omitempty"`
 	}
 	if err := json.Unmarshal(data, &decoded); err != nil {
 		return err
 	}
 	r.SnapshotID = decoded.SnapshotID
 	r.AccessMode = decoded.AccessMode
+	r.Backend = decoded.Backend
+	r.S3 = decoded.S3
 	r.DefaultPosixUID = decoded.DefaultPosixUID
 	r.DefaultPosixGID = decoded.DefaultPosixGID
 	_, r.snapshotIDSet = fields["snapshot_id"]
@@ -105,6 +111,52 @@ func validateDefaultPosixIdentity(uid, gid *int64) error {
 	return nil
 }
 
+func validateCreateVolumeBackend(req *createSandboxVolumeRequest) (string, json.RawMessage, error) {
+	if req == nil {
+		return volume.BackendS0FS, json.RawMessage(`{}`), nil
+	}
+	backend := volume.NormalizeBackend(req.Backend)
+	if req.S3 != nil && strings.TrimSpace(req.Backend) == "" {
+		backend = volume.BackendS3
+	}
+	if !volume.IsValidBackend(backend) {
+		return "", nil, fmt.Errorf("invalid backend")
+	}
+	switch backend {
+	case volume.BackendS0FS:
+		if req.S3 != nil {
+			return "", nil, fmt.Errorf("s3 config is only valid when backend is s3")
+		}
+		return volume.BackendS0FS, json.RawMessage(`{}`), nil
+	case volume.BackendS3:
+		if req.snapshotIDSet {
+			return "", nil, fmt.Errorf("snapshot_id is only supported for s0fs volumes")
+		}
+		if req.S3 == nil {
+			return "", nil, fmt.Errorf("s3 config is required")
+		}
+		accessMode := volume.NormalizeAccessMode(req.AccessMode)
+		if req.AccessMode != "" && !volume.IsValidAccessMode(accessMode) {
+			return "", nil, fmt.Errorf("invalid access_mode")
+		}
+		if accessMode == volume.AccessModeRWX {
+			return "", nil, fmt.Errorf("s3 backend does not support RWX access_mode")
+		}
+		cfg := volume.NormalizeS3BackendConfig(*req.S3)
+		if err := volume.ValidateS3BackendConfig(cfg); err != nil {
+			return "", nil, err
+		}
+		raw, err := volume.MarshalS3BackendConfig(cfg)
+		if err != nil {
+			return "", nil, err
+		}
+		*req.S3 = cfg
+		return volume.BackendS3, raw, nil
+	default:
+		return "", nil, fmt.Errorf("invalid backend")
+	}
+}
+
 func (s *Server) createSandboxVolume(w http.ResponseWriter, r *http.Request) {
 	// Get claims from context (populated by middleware)
 	claims := internalauth.ClaimsFromContext(r.Context())
@@ -138,6 +190,11 @@ func (s *Server) createSandboxVolume(w http.ResponseWriter, r *http.Request) {
 	}
 	if !ok {
 		_ = spec.WriteError(w, http.StatusBadRequest, spec.CodeBadRequest, "invalid access_mode")
+		return
+	}
+	backend, backendConfig, err := validateCreateVolumeBackend(req)
+	if err != nil {
+		_ = spec.WriteError(w, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
 		return
 	}
 	if err := validateDefaultPosixIdentity(req.DefaultPosixUID, req.DefaultPosixGID); err != nil {
@@ -190,6 +247,8 @@ func (s *Server) createSandboxVolume(w http.ResponseWriter, r *http.Request) {
 		DefaultPosixUID: req.DefaultPosixUID,
 		DefaultPosixGID: req.DefaultPosixGID,
 		AccessMode:      string(accessMode),
+		Backend:         backend,
+		BackendConfig:   backendConfig,
 		CreatedAt:       time.Now(),
 		UpdatedAt:       time.Now(),
 	}
@@ -558,6 +617,8 @@ func (s *Server) createOwnedSandboxVolume(w http.ResponseWriter, r *http.Request
 		DefaultPosixUID: req.DefaultPosixUID,
 		DefaultPosixGID: req.DefaultPosixGID,
 		AccessMode:      string(accessMode),
+		Backend:         volume.BackendS0FS,
+		BackendConfig:   json.RawMessage(`{}`),
 		CreatedAt:       now,
 		UpdatedAt:       now,
 	}
@@ -885,6 +946,8 @@ func (s *Server) forkVolume(w http.ResponseWriter, r *http.Request) {
 			_ = spec.WriteError(w, http.StatusBadRequest, spec.CodeBadRequest, "invalid access_mode")
 		case errors.Is(err, snapshot.ErrMountedCtldOwner), errors.Is(err, errCtldOwnerBusy):
 			_ = spec.WriteError(w, http.StatusConflict, spec.CodeConflict, "volume has active ctld mounts")
+		case errors.Is(err, snapshot.ErrUnsupportedBackend):
+			_ = spec.WriteError(w, http.StatusBadRequest, spec.CodeBadRequest, "volume backend does not support fork")
 		case errors.Is(err, snapshot.ErrCloneFailed):
 			_ = spec.WriteError(w, http.StatusInternalServerError, spec.CodeInternal, "clone operation failed")
 		default:

--- a/storage-proxy/pkg/http/handlers_sandboxvolume_test.go
+++ b/storage-proxy/pkg/http/handlers_sandboxvolume_test.go
@@ -112,6 +112,144 @@ func TestCreateSandboxVolumeDefaultsPosixIdentityToRoot(t *testing.T) {
 	}
 }
 
+func TestCreateSandboxVolumeStoresS3BackendConfigAndRedactsResponse(t *testing.T) {
+	repo := newFakeHTTPRepo()
+	server := &Server{
+		logger:       logrus.New(),
+		repo:         repo,
+		meteringRepo: &fakeHTTPMeteringWriter{},
+		snapshotMgr:  &fakeHTTPSnapshotManager{},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/sandboxvolumes", bytes.NewReader([]byte(`{
+		"access_mode":"RWO",
+		"s3":{
+			"provider":"cloudflare-r2",
+			"bucket":"sandbox-data",
+			"prefix":"/team-a/volume-a/",
+			"region":"",
+			"endpoint_url":"https://account-id.r2.cloudflarestorage.com/",
+			"access_key":"access-secret",
+			"secret_key":"secret-secret"
+		}
+	}`)))
+	req = req.WithContext(internalauth.WithClaims(req.Context(), &internalauth.Claims{TeamID: "team-1", UserID: "user-1"}))
+	recorder := httptest.NewRecorder()
+
+	server.createSandboxVolume(recorder, req)
+
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusCreated, recorder.Body.String())
+	}
+	if len(repo.createdVolumes) != 1 {
+		t.Fatalf("created volumes = %d, want 1", len(repo.createdVolumes))
+	}
+	created := repo.createdVolumes[0]
+	if created.Backend != volume.BackendS3 {
+		t.Fatalf("Backend = %q, want %q", created.Backend, volume.BackendS3)
+	}
+	cfg, err := volume.DecodeS3BackendConfig(created.BackendConfig)
+	if err != nil {
+		t.Fatalf("DecodeS3BackendConfig() error = %v", err)
+	}
+	if cfg.Provider != volume.S3ProviderR2 {
+		t.Fatalf("provider = %q, want %q", cfg.Provider, volume.S3ProviderR2)
+	}
+	if cfg.Prefix != "team-a/volume-a" {
+		t.Fatalf("prefix = %q, want team-a/volume-a", cfg.Prefix)
+	}
+	if cfg.EndpointURL != "https://account-id.r2.cloudflarestorage.com" {
+		t.Fatalf("endpoint_url = %q", cfg.EndpointURL)
+	}
+	if cfg.AccessKey != "access-secret" || cfg.SecretKey != "secret-secret" {
+		t.Fatalf("credentials were not stored in backend config")
+	}
+	if bytes.Contains(recorder.Body.Bytes(), []byte("access-secret")) || bytes.Contains(recorder.Body.Bytes(), []byte("secret-secret")) {
+		t.Fatalf("response leaked s3 credentials: %s", recorder.Body.String())
+	}
+	var envelope struct {
+		Data struct {
+			Backend string `json:"backend"`
+			S3      struct {
+				Provider    string `json:"provider"`
+				Bucket      string `json:"bucket"`
+				Prefix      string `json:"prefix"`
+				EndpointURL string `json:"endpoint_url"`
+			} `json:"s3"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if envelope.Data.Backend != volume.BackendS3 {
+		t.Fatalf("response backend = %q, want %q", envelope.Data.Backend, volume.BackendS3)
+	}
+	if envelope.Data.S3.Provider != volume.S3ProviderR2 || envelope.Data.S3.Bucket != "sandbox-data" || envelope.Data.S3.Prefix != "team-a/volume-a" {
+		t.Fatalf("response s3 config = %+v", envelope.Data.S3)
+	}
+}
+
+func TestCreateSandboxVolumeRejectsUnsupportedS3Combinations(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "snapshot",
+			body: `{
+				"snapshot_id":"snap-1",
+				"s3":{"provider":"aws","bucket":"sandbox-data"}
+			}`,
+		},
+		{
+			name: "rwx",
+			body: `{
+				"access_mode":"RWX",
+				"s3":{"provider":"aws","bucket":"sandbox-data"}
+			}`,
+		},
+		{
+			name: "s0fs with s3 config",
+			body: `{
+				"backend":"s0fs",
+				"s3":{"provider":"aws","bucket":"sandbox-data"}
+			}`,
+		},
+		{
+			name: "missing endpoint for r2",
+			body: `{
+				"s3":{"provider":"r2","bucket":"sandbox-data"}
+			}`,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			repo := newFakeHTTPRepo()
+			server := &Server{
+				logger:       logrus.New(),
+				repo:         repo,
+				meteringRepo: &fakeHTTPMeteringWriter{},
+				snapshotMgr:  &fakeHTTPSnapshotManager{},
+			}
+
+			req := httptest.NewRequest(http.MethodPost, "/sandboxvolumes", bytes.NewReader([]byte(tc.body)))
+			req = req.WithContext(internalauth.WithClaims(req.Context(), &internalauth.Claims{TeamID: "team-1", UserID: "user-1"}))
+			recorder := httptest.NewRecorder()
+
+			server.createSandboxVolume(recorder, req)
+
+			if recorder.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusBadRequest, recorder.Body.String())
+			}
+			if len(repo.createdVolumes) != 0 {
+				t.Fatalf("created volumes = %d, want 0", len(repo.createdVolumes))
+			}
+		})
+	}
+}
+
 func TestCreateSandboxVolumeRejectsNullOrBlankSnapshotID(t *testing.T) {
 	cases := []struct {
 		name string

--- a/storage-proxy/pkg/http/handlers_snapshot.go
+++ b/storage-proxy/pkg/http/handlers_snapshot.go
@@ -277,6 +277,8 @@ func (s *Server) handleSnapshotError(w http.ResponseWriter, err error) {
 		_ = spec.WriteError(w, http.StatusConflict, spec.CodeConflict, "volume is busy, try again later")
 	case errors.Is(err, snapshot.ErrActiveRWXSnapshotUnsupported):
 		_ = spec.WriteError(w, http.StatusConflict, spec.CodeConflict, "active RWX volume snapshots are not supported")
+	case errors.Is(err, snapshot.ErrUnsupportedBackend):
+		_ = spec.WriteError(w, http.StatusBadRequest, spec.CodeBadRequest, "volume backend does not support snapshots")
 	case errors.Is(err, snapshot.ErrFlushFailed):
 		_ = spec.WriteError(w, http.StatusInternalServerError, spec.CodeInternal, "failed to flush data")
 	case errors.Is(err, snapshot.ErrCloneFailed):

--- a/storage-proxy/pkg/http/handlers_volume_files.go
+++ b/storage-proxy/pkg/http/handlers_volume_files.go
@@ -48,6 +48,7 @@ var (
 	errDirectoryNotEmpty     = errors.New("directory not empty")
 	errInvalidPath           = errors.New("invalid path")
 	errInvalidArchive        = errors.New("invalid archive")
+	errVolumeFileUnsupported = errors.New("volume backend does not support direct file operations without an active owner")
 )
 
 type volumeFileArchiveImportResponse struct {
@@ -1505,7 +1506,7 @@ func (s *Server) writeVolumeFileError(w http.ResponseWriter, err error) {
 		_ = spec.WriteError(w, http.StatusForbidden, spec.CodeForbidden, err.Error())
 	case errors.Is(err, errPathAlreadyExists), errors.Is(err, errPathNotDir), errors.Is(err, errDirectoryNotEmpty):
 		_ = spec.WriteError(w, http.StatusConflict, spec.CodeConflict, err.Error())
-	case errors.Is(err, errInvalidPath), errors.Is(err, errInvalidArchive):
+	case errors.Is(err, errInvalidPath), errors.Is(err, errInvalidArchive), errors.Is(err, errVolumeFileUnsupported):
 		_ = spec.WriteError(w, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
 	case quota.IsExceeded(err):
 		_ = spec.WriteError(w, http.StatusTooManyRequests, "quota_exceeded", err.Error())

--- a/storage-proxy/pkg/http/handlers_volume_files_test.go
+++ b/storage-proxy/pkg/http/handlers_volume_files_test.go
@@ -1140,6 +1140,88 @@ func TestHandleVolumeFileStatProxiesToRemoteOwnerPod(t *testing.T) {
 	}
 }
 
+func TestHandleVolumeFileStatRejectsUnownedS3Backend(t *testing.T) {
+	fileRPC := &fakeHTTPVolumeFileRPC{}
+	server, volMgr := newVolumeFileTestServer(fileRPC)
+	repo := server.repo.(*fakeHTTPRepo)
+	repo.volumes["vol-1"].Backend = volume.BackendS3
+	repo.volumes["vol-1"].AccessMode = string(volume.AccessModeROX)
+
+	req := httptest.NewRequest(http.MethodGet, "/sandboxvolumes/vol-1/files/stat?path=/docs/report.txt", nil)
+	req.SetPathValue("id", "vol-1")
+	req = req.WithContext(internalauth.WithClaims(req.Context(), &internalauth.Claims{TeamID: "team-a"}))
+	recorder := httptest.NewRecorder()
+
+	server.handleVolumeFileStat(recorder, req)
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusBadRequest, recorder.Body.String())
+	}
+	if volMgr.acquireCalls != 0 {
+		t.Fatalf("AcquireDirectVolumeFileMount() calls = %d, want 0", volMgr.acquireCalls)
+	}
+}
+
+func TestHandleVolumeFileStatProxiesMountedS3BackendToCtldOwner(t *testing.T) {
+	remoteSeen := make(chan *http.Request, 1)
+	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case remoteSeen <- r.Clone(r.Context()):
+		default:
+		}
+		_, _ = io.WriteString(w, `{"success":true,"data":{"name":"proxied.txt","path":"/proxied.txt","type":"file","size":7}}`)
+	}))
+	defer remote.Close()
+	remoteURL, err := url.Parse(remote.URL)
+	if err != nil {
+		t.Fatalf("parse remote url: %v", err)
+	}
+	remotePort, err := strconv.Atoi(remoteURL.Port())
+	if err != nil {
+		t.Fatalf("parse remote port: %v", err)
+	}
+
+	fileRPC := &fakeHTTPVolumeFileRPC{}
+	server, volMgr := newVolumeFileTestServer(fileRPC)
+	repo := server.repo.(*fakeHTTPRepo)
+	repo.volumes["vol-1"].Backend = volume.BackendS3
+	repo.volumes["vol-1"].AccessMode = string(volume.AccessModeRWO)
+	repo.activeMounts["vol-1"] = []*db.VolumeMount{
+		{
+			VolumeID:     "vol-1",
+			ClusterID:    "cluster-a",
+			PodID:        "sandbox0-system/ctld-node-a",
+			MountedAt:    time.Unix(10, 0),
+			MountOptions: mustMountOptionsRaw(t, volume.MountOptions{AccessMode: volume.AccessModeRWO, OwnerKind: volume.OwnerKindCtld, OwnerPort: remotePort}),
+		},
+	}
+	server.podResolver = &fakeVolumeFilePodResolver{
+		urls: map[string]string{"sandbox0-system/ctld-node-a": "http://127.0.0.1"},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/sandboxvolumes/vol-1/files/stat?path=/docs/report.txt", nil)
+	req.SetPathValue("id", "vol-1")
+	req = req.WithContext(internalauth.WithClaims(req.Context(), &internalauth.Claims{TeamID: "team-a"}))
+	recorder := httptest.NewRecorder()
+
+	server.handleVolumeFileStat(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	if volMgr.acquireCalls != 0 {
+		t.Fatalf("AcquireDirectVolumeFileMount() calls = %d, want 0", volMgr.acquireCalls)
+	}
+	select {
+	case seen := <-remoteSeen:
+		if got := seen.Header.Get(volumeFileAffinityRoutedPodHeader); got != "sandbox0-system/ctld-node-a" {
+			t.Fatalf("routed pod header = %q, want %q", got, "sandbox0-system/ctld-node-a")
+		}
+	default:
+		t.Fatal("expected request to be proxied to mounted s3 ctld owner")
+	}
+}
+
 func TestHandleVolumeFileStatPrefersStorageProxyOwnerOverCtld(t *testing.T) {
 	remoteSeen := make(chan *http.Request, 1)
 	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/storage-proxy/pkg/http/volume_affinity.go
+++ b/storage-proxy/pkg/http/volume_affinity.go
@@ -124,9 +124,12 @@ func (s *Server) prepareOrProxyVolumeFileRequest(w http.ResponseWriter, r *http.
 		s.writeVolumeFileError(w, err)
 		return r.Context(), nil, func() {}, true
 	}
-	if err := s.ensureCtldVolumeOwner(r.Context(), volumeRecord); err != nil {
-		s.writeVolumeFileError(w, err)
-		return r.Context(), nil, func() {}, true
+	backend := volume.NormalizeBackend(volumeRecord.Backend)
+	if backend == volume.BackendS0FS {
+		if err := s.ensureCtldVolumeOwner(r.Context(), volumeRecord); err != nil {
+			s.writeVolumeFileError(w, err)
+			return r.Context(), nil, func() {}, true
+		}
 	}
 
 	proxied, err := s.proxyVolumeRequestToOwnerIfNeeded(w, r, volumeRecord)
@@ -136,6 +139,10 @@ func (s *Server) prepareOrProxyVolumeFileRequest(w http.ResponseWriter, r *http.
 	}
 	if proxied {
 		return r.Context(), volumeRecord, func() {}, true
+	}
+	if backend != volume.BackendS0FS {
+		s.writeVolumeFileError(w, errVolumeFileUnsupported)
+		return r.Context(), nil, func() {}, true
 	}
 
 	actor, err := defaultVolumeFileActor(volumeRecord)

--- a/storage-proxy/pkg/http/volume_snapshot_checkpoint.go
+++ b/storage-proxy/pkg/http/volume_snapshot_checkpoint.go
@@ -69,6 +69,9 @@ func (s *Server) prepareVolumeSnapshotCheckpoint(ctx context.Context, volumeID, 
 	if volumeRecord.TeamID != teamID {
 		return nil, snapshot.ErrVolumeNotFound
 	}
+	if volume.NormalizeBackend(volumeRecord.Backend) != volume.BackendS0FS {
+		return nil, snapshot.ErrUnsupportedBackend
+	}
 
 	mounts, err := s.getActiveVolumeMounts(ctx, volumeID)
 	if err != nil {

--- a/storage-proxy/pkg/objectstore/store.go
+++ b/storage-proxy/pkg/objectstore/store.go
@@ -198,6 +198,8 @@ func newS3Store(cfg Config) (Store, error) {
 
 	loadOptions := []func(*awsconfig.LoadOptions) error{
 		awsconfig.WithRegion(region),
+		awsconfig.WithRequestChecksumCalculation(aws.RequestChecksumCalculationWhenRequired),
+		awsconfig.WithResponseChecksumValidation(aws.ResponseChecksumValidationWhenRequired),
 	}
 	if cfg.AccessKey != "" || cfg.SecretKey != "" || cfg.SessionToken != "" {
 		loadOptions = append(loadOptions, awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(

--- a/storage-proxy/pkg/objectstore/store.go
+++ b/storage-proxy/pkg/objectstore/store.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -19,6 +20,7 @@ import (
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/smithy-go"
 	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
 	"golang.org/x/oauth2/google"
 )
@@ -45,6 +47,7 @@ type Info struct {
 	Key      string
 	Size     int64
 	Modified time.Time
+	IsPrefix bool
 }
 
 type Store interface {
@@ -126,6 +129,24 @@ func Create(cfg Config) (Store, error) {
 	default:
 		return nil, fmt.Errorf("unsupported object storage type: %s", storageType)
 	}
+}
+
+func IsNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		switch strings.ToLower(apiErr.ErrorCode()) {
+		case "notfound", "nosuchkey", "nosuchbucket", "404":
+			return true
+		}
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "not found") ||
+		strings.Contains(message, "nosuchkey") ||
+		strings.Contains(message, "no such key") ||
+		strings.Contains(message, "status=404")
 }
 
 func Prefix(store Store, prefix string) Store {
@@ -294,7 +315,7 @@ func (s *s3Store) List(prefix, startAfter, token, delimiter string, limit int64)
 	if err != nil {
 		return nil, false, "", err
 	}
-	objects := make([]Info, 0, len(resp.Contents))
+	objects := make([]Info, 0, len(resp.Contents)+len(resp.CommonPrefixes))
 	for _, item := range resp.Contents {
 		objects = append(objects, Info{
 			Key:      aws.ToString(item.Key),
@@ -302,6 +323,14 @@ func (s *s3Store) List(prefix, startAfter, token, delimiter string, limit int64)
 			Modified: aws.ToTime(item.LastModified),
 		})
 	}
+	for _, item := range resp.CommonPrefixes {
+		prefix := aws.ToString(item.Prefix)
+		if prefix == "" {
+			continue
+		}
+		objects = append(objects, Info{Key: prefix, IsPrefix: true})
+	}
+	sortInfos(objects)
 	return objects, resp.IsTruncated != nil && *resp.IsTruncated, aws.ToString(resp.NextContinuationToken), nil
 }
 
@@ -488,7 +517,7 @@ func (s *gcsStore) List(prefix, startAfter, token, delimiter string, limit int64
 	if err != nil {
 		return nil, false, "", err
 	}
-	objects := make([]Info, 0, len(result.Items))
+	objects := make([]Info, 0, len(result.Items)+len(result.Prefixes))
 	for _, item := range result.Items {
 		if item.Name == "" {
 			continue
@@ -503,6 +532,13 @@ func (s *gcsStore) List(prefix, startAfter, token, delimiter string, limit int64
 			Modified: item.Updated,
 		})
 	}
+	for _, prefix := range result.Prefixes {
+		if prefix == "" {
+			continue
+		}
+		objects = append(objects, Info{Key: gcsObjectName(prefix), IsPrefix: true})
+	}
+	sortInfos(objects)
 	return objects, result.NextPageToken != "", result.NextPageToken, nil
 }
 
@@ -518,6 +554,7 @@ type gcsObjectAttrs struct {
 
 type gcsListResult struct {
 	Items         []gcsObjectAttrs `json:"items"`
+	Prefixes      []string         `json:"prefixes"`
 	NextPageToken string           `json:"nextPageToken"`
 }
 
@@ -632,7 +669,11 @@ func (s *prefixedStore) Head(key string) (Info, error) {
 }
 
 func (s *prefixedStore) List(prefix, startAfter, token, delimiter string, limit int64) ([]Info, bool, string, error) {
-	objects, hasMore, nextToken, err := s.store.List(s.prefixed(prefix), s.prefixed(startAfter), token, delimiter, limit)
+	listPrefix := s.prefixed(prefix)
+	if strings.TrimLeft(strings.TrimSpace(prefix), "/") == "" {
+		listPrefix = s.prefix
+	}
+	objects, hasMore, nextToken, err := s.store.List(listPrefix, s.prefixed(startAfter), token, delimiter, limit)
 	if err != nil {
 		return nil, false, "", err
 	}
@@ -723,39 +764,54 @@ func (s *memoryStore) Head(key string) (Info, error) {
 	}, nil
 }
 
-func (s *memoryStore) List(prefix, startAfter, _ string, _ string, limit int64) ([]Info, bool, string, error) {
+func (s *memoryStore) List(prefix, startAfter, token, delimiter string, limit int64) ([]Info, bool, string, error) {
 	s.state.mu.RLock()
 	defer s.state.mu.RUnlock()
 	prefix = strings.TrimLeft(prefix, "/")
-	startAfter = strings.TrimLeft(startAfter, "/")
-	keys := make([]string, 0, len(s.state.objects))
-	for key := range s.state.objects {
-		if strings.HasPrefix(key, prefix) && key > startAfter {
-			keys = append(keys, key)
-		}
+	cursor := strings.TrimLeft(token, "/")
+	if cursor == "" {
+		cursor = strings.TrimLeft(startAfter, "/")
 	}
-	slicesSort(keys)
-	max := len(keys)
+	delimiter = strings.TrimSpace(delimiter)
+	seenPrefixes := make(map[string]struct{})
+	objects := make([]Info, 0, len(s.state.objects))
+	for key := range s.state.objects {
+		if !strings.HasPrefix(key, prefix) || key <= cursor {
+			continue
+		}
+		if delimiter != "" {
+			suffix := strings.TrimPrefix(key, prefix)
+			if idx := strings.Index(suffix, delimiter); idx >= 0 {
+				dir := prefix + suffix[:idx+len(delimiter)]
+				if dir <= cursor {
+					continue
+				}
+				if _, ok := seenPrefixes[dir]; ok {
+					continue
+				}
+				seenPrefixes[dir] = struct{}{}
+				objects = append(objects, Info{Key: dir, IsPrefix: true})
+				continue
+			}
+		}
+		objects = append(objects, Info{Key: key, Size: int64(len(s.state.objects[key]))})
+	}
+	sortInfos(objects)
+	max := len(objects)
 	hasMore := false
 	nextToken := ""
 	if limit > 0 && int(limit) < max {
 		hasMore = true
 		max = int(limit)
-		nextToken = keys[max-1]
+		nextToken = objects[max-1].Key
 	}
-	objects := make([]Info, 0, max)
-	for _, key := range keys[:max] {
-		objects = append(objects, Info{Key: key, Size: int64(len(s.state.objects[key]))})
-	}
-	return objects, hasMore, nextToken, nil
+	return objects[:max], hasMore, nextToken, nil
 }
 
-func slicesSort(values []string) {
-	for i := 1; i < len(values); i++ {
-		for j := i; j > 0 && values[j] < values[j-1]; j-- {
-			values[j], values[j-1] = values[j-1], values[j]
-		}
-	}
+func sortInfos(values []Info) {
+	sort.Slice(values, func(i, j int) bool {
+		return values[i].Key < values[j].Key
+	})
 }
 
 type observedStore struct {

--- a/storage-proxy/pkg/objectstore/store.go
+++ b/storage-proxy/pkg/objectstore/store.go
@@ -675,7 +675,11 @@ func (s *prefixedStore) List(prefix, startAfter, token, delimiter string, limit 
 	if strings.TrimLeft(strings.TrimSpace(prefix), "/") == "" {
 		listPrefix = s.prefix
 	}
-	objects, hasMore, nextToken, err := s.store.List(listPrefix, s.prefixed(startAfter), token, delimiter, limit)
+	listStartAfter := ""
+	if strings.TrimLeft(strings.TrimSpace(startAfter), "/") != "" {
+		listStartAfter = s.prefixed(startAfter)
+	}
+	objects, hasMore, nextToken, err := s.store.List(listPrefix, listStartAfter, token, delimiter, limit)
 	if err != nil {
 		return nil, false, "", err
 	}

--- a/storage-proxy/pkg/objectstore/store_test.go
+++ b/storage-proxy/pkg/objectstore/store_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"io"
+	"sort"
 	"testing"
 )
 
@@ -147,4 +148,91 @@ func TestNewMemoryStoreSharesNamespace(t *testing.T) {
 	if got := string(payload); got != "alpha" {
 		t.Fatalf("payload = %q, want alpha", got)
 	}
+}
+
+func TestMemoryStoreListDelimiterReturnsCommonPrefixes(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStore(t.Name())
+	for key, data := range map[string]string{
+		"root.txt":           "root",
+		"dir/child.txt":      "child",
+		"dir/nested/a.txt":   "nested",
+		"other/another.txt":  "other",
+		"other/deeper/b.txt": "deep",
+	} {
+		if err := store.Put(key, bytes.NewReader([]byte(data))); err != nil {
+			t.Fatalf("Put(%q) error = %v", key, err)
+		}
+	}
+
+	infos, more, _, err := store.List("", "", "", "/", 100)
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if more {
+		t.Fatal("List() more = true, want false")
+	}
+	got := make([]string, 0, len(infos))
+	for _, info := range infos {
+		kind := "file"
+		if info.IsPrefix {
+			kind = "prefix"
+		}
+		got = append(got, kind+":"+info.Key)
+	}
+	sort.Strings(got)
+	want := []string{"file:root.txt", "prefix:dir/", "prefix:other/"}
+	if !equalStringSlices(got, want) {
+		t.Fatalf("List() = %#v, want %#v", got, want)
+	}
+}
+
+func TestPrefixedStoreListPreservesCommonPrefixes(t *testing.T) {
+	t.Parallel()
+
+	base := NewMemoryStore(t.Name())
+	store := Prefix(base, "tenant-a/volume-a")
+	if err := store.Put("visible.txt", bytes.NewReader([]byte("visible"))); err != nil {
+		t.Fatalf("Put(visible.txt) error = %v", err)
+	}
+	if err := store.Put("dir/child.txt", bytes.NewReader([]byte("child"))); err != nil {
+		t.Fatalf("Put(dir/child.txt) error = %v", err)
+	}
+	if err := base.Put("tenant-a/other/hidden.txt", bytes.NewReader([]byte("hidden"))); err != nil {
+		t.Fatalf("base.Put(hidden) error = %v", err)
+	}
+
+	infos, more, _, err := store.List("", "", "", "/", 100)
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if more {
+		t.Fatal("List() more = true, want false")
+	}
+	got := make([]string, 0, len(infos))
+	for _, info := range infos {
+		kind := "file"
+		if info.IsPrefix {
+			kind = "prefix"
+		}
+		got = append(got, kind+":"+info.Key)
+	}
+	sort.Strings(got)
+	want := []string{"file:visible.txt", "prefix:dir/"}
+	if !equalStringSlices(got, want) {
+		t.Fatalf("List() = %#v, want %#v", got, want)
+	}
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/storage-proxy/pkg/objectstore/store_test.go
+++ b/storage-proxy/pkg/objectstore/store_test.go
@@ -225,6 +225,35 @@ func TestPrefixedStoreListPreservesCommonPrefixes(t *testing.T) {
 	}
 }
 
+func TestPrefixedStoreListDoesNotInjectStartAfterForEmptyCursor(t *testing.T) {
+	t.Parallel()
+
+	recorder := &recordingListStore{Store: NewMemoryStore(t.Name())}
+	store := Prefix(recorder, "tenant-a/volume-a")
+	if _, _, _, err := store.List("dir/", "", "", "/", 100); err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if recorder.lastPrefix != "tenant-a/volume-a/dir/" {
+		t.Fatalf("List prefix = %q, want tenant-a/volume-a/dir/", recorder.lastPrefix)
+	}
+	if recorder.lastStartAfter != "" {
+		t.Fatalf("List startAfter = %q, want empty", recorder.lastStartAfter)
+	}
+}
+
+type recordingListStore struct {
+	Store
+
+	lastPrefix     string
+	lastStartAfter string
+}
+
+func (s *recordingListStore) List(prefix, startAfter, token, delimiter string, limit int64) ([]Info, bool, string, error) {
+	s.lastPrefix = prefix
+	s.lastStartAfter = startAfter
+	return s.Store.List(prefix, startAfter, token, delimiter, limit)
+}
+
 func equalStringSlices(a, b []string) bool {
 	if len(a) != len(b) {
 		return false

--- a/storage-proxy/pkg/snapshot/manager.go
+++ b/storage-proxy/pkg/snapshot/manager.go
@@ -79,6 +79,7 @@ var (
 	ErrInvalidAccessMode            = errors.New("invalid access mode")
 	ErrMountedCtldOwner             = errors.New("snapshot operations require ctld-mounted volumes to be unmounted")
 	ErrActiveRWXSnapshotUnsupported = errors.New("active RWX volume snapshots are not supported")
+	ErrUnsupportedBackend           = errors.New("volume backend does not support snapshots")
 )
 
 // Manager handles snapshot operations for SandboxVolumes
@@ -270,6 +271,9 @@ func (m *Manager) CreateSnapshot(ctx context.Context, req *CreateSnapshotRequest
 	}
 	if vol.TeamID != req.TeamID {
 		return nil, ErrVolumeNotFound
+	}
+	if volume.NormalizeBackend(vol.Backend) != volume.BackendS0FS {
+		return nil, ErrUnsupportedBackend
 	}
 	accessMode := volume.NormalizeAccessMode(vol.AccessMode)
 	if accessMode == volume.AccessModeRWX {
@@ -479,6 +483,16 @@ func (m *Manager) RestoreSnapshot(ctx context.Context, req *RestoreSnapshotReque
 
 	if snapshot.VolumeID != req.VolumeID || snapshot.TeamID != req.TeamID {
 		return ErrSnapshotNotBelongToVolume
+	}
+	vol, err := m.repo.GetSandboxVolume(ctx, req.VolumeID)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return ErrVolumeNotFound
+		}
+		return fmt.Errorf("get volume: %w", err)
+	}
+	if volume.NormalizeBackend(vol.Backend) != volume.BackendS0FS {
+		return ErrUnsupportedBackend
 	}
 
 	// 2. Acquire volume lock

--- a/storage-proxy/pkg/snapshot/s0fs.go
+++ b/storage-proxy/pkg/snapshot/s0fs.go
@@ -464,6 +464,9 @@ func (m *Manager) forkS0FSVolume(ctx context.Context, req *ForkVolumeRequest) (*
 	if sourceVol.TeamID != req.TeamID {
 		return nil, ErrVolumeNotFound
 	}
+	if volume.NormalizeBackend(sourceVol.Backend) != volume.BackendS0FS {
+		return nil, ErrUnsupportedBackend
+	}
 
 	if volume.NormalizeAccessMode(sourceVol.AccessMode) != volume.AccessModeROX {
 		ctldMounted, err := m.hasMountedCtldOwner(ctx, req.SourceVolumeID)
@@ -524,6 +527,8 @@ func (m *Manager) forkS0FSVolume(ctx context.Context, req *ForkVolumeRequest) (*
 		DefaultPosixUID: defaultPosixUID,
 		DefaultPosixGID: defaultPosixGID,
 		AccessMode:      string(accessMode),
+		Backend:         volume.BackendS0FS,
+		BackendConfig:   []byte(`{}`),
 		CreatedAt:       now,
 		UpdatedAt:       now,
 	}
@@ -605,6 +610,9 @@ func (m *Manager) createS0FSVolumeFromSnapshot(ctx context.Context, req *CreateV
 	if sourceVol.TeamID != req.TeamID {
 		return nil, ErrVolumeNotFound
 	}
+	if volume.NormalizeBackend(sourceVol.Backend) != volume.BackendS0FS {
+		return nil, ErrUnsupportedBackend
+	}
 
 	accessMode := volume.AccessModeRWO
 	if strings.TrimSpace(req.AccessMode) != "" {
@@ -639,6 +647,8 @@ func (m *Manager) createS0FSVolumeFromSnapshot(ctx context.Context, req *CreateV
 		DefaultPosixUID: req.DefaultPosixUID,
 		DefaultPosixGID: req.DefaultPosixGID,
 		AccessMode:      string(accessMode),
+		Backend:         volume.BackendS0FS,
+		BackendConfig:   []byte(`{}`),
 		CreatedAt:       now,
 		UpdatedAt:       now,
 	}
@@ -772,6 +782,9 @@ func (m *Manager) deleteS0FSSnapshot(ctx context.Context, volumeID, snapshotID s
 
 func (m *Manager) DeleteVolumeObjectsIfUnreferenced(ctx context.Context, vol *db.SandboxVolume) error {
 	if vol == nil || strings.TrimSpace(vol.ID) == "" || strings.TrimSpace(vol.TeamID) == "" {
+		return nil
+	}
+	if volume.NormalizeBackend(vol.Backend) != volume.BackendS0FS {
 		return nil
 	}
 	safe, err := m.canCollectS0FSVolume(ctx, vol.ID)

--- a/storage-proxy/pkg/volume/backend.go
+++ b/storage-proxy/pkg/volume/backend.go
@@ -11,6 +11,7 @@ import (
 
 const (
 	BackendS0FS = "s0fs"
+	BackendS3   = "s3"
 )
 
 func DefaultBackendType() string {

--- a/storage-proxy/pkg/volume/s3_backend_config.go
+++ b/storage-proxy/pkg/volume/s3_backend_config.go
@@ -1,0 +1,162 @@
+package volume
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
+	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/objectstore"
+)
+
+const (
+	S3ProviderAWS = "aws"
+	S3ProviderAli = "ali"
+	S3ProviderR2  = "r2"
+)
+
+type S3BackendConfig struct {
+	Provider     string `json:"provider,omitempty"`
+	Bucket       string `json:"bucket,omitempty"`
+	Prefix       string `json:"prefix,omitempty"`
+	Region       string `json:"region,omitempty"`
+	EndpointURL  string `json:"endpoint_url,omitempty"`
+	AccessKey    string `json:"access_key,omitempty"`
+	SecretKey    string `json:"secret_key,omitempty"`
+	SessionToken string `json:"session_token,omitempty"`
+}
+
+func NormalizeBackend(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", BackendS0FS:
+		return BackendS0FS
+	case BackendS3:
+		return BackendS3
+	default:
+		return strings.ToLower(strings.TrimSpace(value))
+	}
+}
+
+func IsValidBackend(value string) bool {
+	switch NormalizeBackend(value) {
+	case BackendS0FS, BackendS3:
+		return true
+	default:
+		return false
+	}
+}
+
+func NormalizeS3Provider(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "s3", S3ProviderAWS:
+		return S3ProviderAWS
+	case "aliyun", "alicloud", "oss", S3ProviderAli:
+		return S3ProviderAli
+	case "cloudflare", "cloudflare-r2", S3ProviderR2:
+		return S3ProviderR2
+	default:
+		return strings.ToLower(strings.TrimSpace(value))
+	}
+}
+
+func NormalizeS3BackendConfig(cfg S3BackendConfig) S3BackendConfig {
+	cfg.Provider = NormalizeS3Provider(cfg.Provider)
+	cfg.Bucket = strings.TrimSpace(cfg.Bucket)
+	cfg.Prefix = strings.Trim(strings.TrimSpace(cfg.Prefix), "/")
+	cfg.Region = strings.TrimSpace(cfg.Region)
+	cfg.EndpointURL = strings.TrimRight(strings.TrimSpace(cfg.EndpointURL), "/")
+	cfg.AccessKey = strings.TrimSpace(cfg.AccessKey)
+	cfg.SecretKey = strings.TrimSpace(cfg.SecretKey)
+	cfg.SessionToken = strings.TrimSpace(cfg.SessionToken)
+	return cfg
+}
+
+func ValidateS3BackendConfig(cfg S3BackendConfig) error {
+	cfg = NormalizeS3BackendConfig(cfg)
+	if cfg.Bucket == "" {
+		return fmt.Errorf("s3.bucket is required")
+	}
+	switch cfg.Provider {
+	case S3ProviderAWS, S3ProviderAli, S3ProviderR2:
+	default:
+		return fmt.Errorf("unsupported s3.provider %q", cfg.Provider)
+	}
+	if cfg.Provider == S3ProviderAli && cfg.EndpointURL == "" {
+		return fmt.Errorf("s3.endpoint_url is required for provider ali")
+	}
+	if cfg.Provider == S3ProviderR2 && cfg.EndpointURL == "" {
+		return fmt.Errorf("s3.endpoint_url is required for provider r2")
+	}
+	if (cfg.AccessKey == "") != (cfg.SecretKey == "") {
+		return fmt.Errorf("s3.access_key and s3.secret_key must be set together")
+	}
+	return nil
+}
+
+func MarshalS3BackendConfig(cfg S3BackendConfig) (json.RawMessage, error) {
+	cfg = NormalizeS3BackendConfig(cfg)
+	raw, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return json.RawMessage(raw), nil
+}
+
+func DecodeS3BackendConfig(raw json.RawMessage) (S3BackendConfig, error) {
+	if len(raw) == 0 {
+		return S3BackendConfig{}, fmt.Errorf("s3 backend config is required")
+	}
+	var cfg S3BackendConfig
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return S3BackendConfig{}, fmt.Errorf("decode s3 backend config: %w", err)
+	}
+	cfg = NormalizeS3BackendConfig(cfg)
+	if err := ValidateS3BackendConfig(cfg); err != nil {
+		return S3BackendConfig{}, err
+	}
+	return cfg, nil
+}
+
+func SanitizeS3BackendConfig(cfg S3BackendConfig) S3BackendConfig {
+	cfg = NormalizeS3BackendConfig(cfg)
+	cfg.AccessKey = ""
+	cfg.SecretKey = ""
+	cfg.SessionToken = ""
+	return cfg
+}
+
+func S3ObjectStoreConfig(cfg S3BackendConfig, fallback *config.StorageProxyConfig, metrics *obsmetrics.StorageProxyMetrics) objectstore.Config {
+	cfg = NormalizeS3BackendConfig(cfg)
+	storeType := objectstore.TypeS3
+	if cfg.Provider == S3ProviderAli {
+		storeType = objectstore.TypeOSS
+	}
+	out := objectstore.Config{
+		Type:         storeType,
+		Bucket:       cfg.Bucket,
+		Region:       cfg.Region,
+		Endpoint:     cfg.EndpointURL,
+		AccessKey:    cfg.AccessKey,
+		SecretKey:    cfg.SecretKey,
+		SessionToken: cfg.SessionToken,
+		Metrics:      metrics,
+	}
+	if fallback != nil {
+		if out.Region == "" {
+			out.Region = fallback.S3Region
+		}
+		if out.Endpoint == "" {
+			out.Endpoint = fallback.S3Endpoint
+		}
+		if out.AccessKey == "" && out.SecretKey == "" && out.SessionToken == "" {
+			out.AccessKey = fallback.S3AccessKey
+			out.SecretKey = fallback.S3SecretKey
+			out.SessionToken = fallback.S3SessionToken
+		}
+	}
+	if cfg.Provider == S3ProviderR2 && out.Region == "" {
+		out.Region = "auto"
+	}
+	return out
+}

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -36,6 +36,7 @@ type apiModeSuiteOptions struct {
 	includePoolReadinessGate  bool
 	includeNetworkPolicy      bool
 	includeVolumeLifecycle    bool
+	includeMountpointS3Compat bool
 	includeObjectEncryption   bool
 	includeWebhookLifecycle   bool
 	includeRootFSPauseResume  bool
@@ -344,6 +345,12 @@ func registerApiModeSuite(envProvider func() *framework.ScenarioEnv, opts apiMod
 				It("rejects invalid bootstrap mount requests at claim time", func() {
 					assertClaimBootstrapMountValidation(env, session)
 				})
+
+				if opts.includeMountpointS3Compat {
+					It("matches mountpoint-s3 general bucket compatibility semantics", func() {
+						assertMountpointS3Compatibility(env, session)
+					})
+				}
 
 				if opts.includeObjectEncryption {
 					It("keeps encrypted volume objects and local cache opaque", func() {

--- a/tests/e2e/cases/api_mountpoint_s3_compat.go
+++ b/tests/e2e/cases/api_mountpoint_s3_compat.go
@@ -1,0 +1,441 @@
+package cases
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/sandbox0-ai/sandbox0/pkg/apispec"
+	"github.com/sandbox0-ai/sandbox0/pkg/framework"
+	"github.com/sandbox0-ai/sandbox0/pkg/naming"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/objectstore"
+	e2eutils "github.com/sandbox0-ai/sandbox0/tests/e2e/utils"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	mountpointS3CompatEnvVar = "E2E_MOUNTPOINT_S3_COMPAT"
+	mountpointS3Bucket       = "sandbox0"
+	mountpointS3MountPath    = "/workspace/mountpoint-s3"
+)
+
+var mountpointS3CompatSourceCases = []string{
+	"semantics_doc_test::basic_directory_structure_s3",
+	"semantics_doc_test::keys_ending_in_delimiter_s3",
+	"semantics_doc_test::files_shadowed_by_directories_s3",
+	"lookup_test::lookup_previously_shadowed_file_test_s3",
+	"mkdir_test::mkdir_visible_locally_test_s3",
+	"readdir_test::readdir_while_writing_s3",
+	"write_test::sequential_write_test_s3",
+	"write_test::flush_test_s3",
+	"write_test::out_of_order_write_test_s3",
+	"write_test::overwrite_disallowed_on_concurrent_read_test_s3",
+	"write_test::overwrite_truncate_test_s3",
+	"unlink_test::simple_unlink_test_s3",
+	"unlink_test::unlink_writehandle_test_s3",
+	"setattr_test::setattr_test_s3",
+	"rename_test::general-purpose-bucket-renames-rejected",
+}
+
+type mountpointS3CompatStore struct {
+	scoped      objectstore.Store
+	prefix      string
+	stopForward func()
+}
+
+func assertMountpointS3Compatibility(env *framework.ScenarioEnv, session *e2eutils.Session) {
+	if !mountpointS3CompatEnabled() {
+		Skip(fmt.Sprintf("set %s=true to run mountpoint-s3 compatibility probes", mountpointS3CompatEnvVar))
+	}
+	runtimeClass := strings.ToLower(strings.TrimSpace(env.Config.SandboxRuntimeClassName))
+	Expect(runtimeClass == "" || strings.Contains(runtimeClass, "runc")).To(BeTrue(),
+		"mountpoint-s3 compatibility requires a runc-compatible sandbox runtime, got %q", env.Config.SandboxRuntimeClassName)
+	for _, sourceCase := range mountpointS3CompatSourceCases {
+		GinkgoWriter.Printf("mountpoint-s3 compat source: %s\n", sourceCase)
+	}
+
+	store := openMountpointS3CompatStore(env)
+	DeferCleanup(store.cleanup)
+	seedMountpointS3CompatObjects(store.scoped)
+
+	backend := apispec.S3
+	accessMode := apispec.RWO
+	provider := apispec.CreateSandboxVolumeS3ConfigProviderAws
+	volume, status, err := session.CreateSandboxVolume(env.TestCtx.Context, GinkgoT(), apispec.CreateSandboxVolumeRequest{
+		Backend:    &backend,
+		AccessMode: &accessMode,
+		S3: &apispec.CreateSandboxVolumeS3Config{
+			Provider: &provider,
+			Bucket:   mountpointS3Bucket,
+			Prefix:   &store.prefix,
+		},
+	})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusCreated))
+	Expect(volume).NotTo(BeNil())
+	volumeID := expectStringPtr(volume.Id, "s3 volume id")
+	DeferCleanup(func() {
+		deleteSandboxVolumeForCleanup(env, session, volumeID)
+	})
+
+	templateID := createVolumePortalTemplate(env, session, mountpointS3MountPath)
+	template, err := session.GetTemplate(env.TestCtx.Context, GinkgoT(), templateID)
+	Expect(err).NotTo(HaveOccurred())
+	templateNamespace, err := naming.TemplateNamespaceForTeam(expectStringPtr(template.TeamId, "team id"))
+	Expect(err).NotTo(HaveOccurred())
+
+	claimResp, err := session.ClaimSandboxWithRequest(env.TestCtx.Context, GinkgoT(), apispec.ClaimRequest{
+		Template: &templateID,
+		Mounts: &[]apispec.ClaimMountRequest{{
+			SandboxvolumeId: volumeID,
+			MountPoint:      mountpointS3MountPath,
+		}},
+	})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(claimResp).NotTo(BeNil())
+	sandboxID := claimResp.SandboxId
+	DeferCleanup(func() {
+		_ = session.DeleteSandbox(env.TestCtx.Context, GinkgoT(), sandboxID)
+	})
+	Expect(claimResp.BootstrapMounts).NotTo(BeNil())
+	Expect(*claimResp.BootstrapMounts).NotTo(BeEmpty())
+	Expect((*claimResp.BootstrapMounts)[0].State).To(Equal(apispec.MountStatusStateMounted))
+
+	sandbox := waitForSandboxPodReadyEventually(env, session, sandboxID, templateNamespace)
+	podName := sandbox.PodName
+	Expect(podName).NotTo(BeEmpty())
+
+	assertMountpointS3Projection(env, templateNamespace, podName, store.scoped)
+	assertMountpointS3ExternalUpdates(env, templateNamespace, podName, store.scoped)
+	assertMountpointS3WriteLifecycle(env, templateNamespace, podName, store.scoped)
+	assertMountpointS3UnsupportedAndOverwrite(env, templateNamespace, podName, store.scoped)
+	assertMountpointS3Deletes(env, templateNamespace, podName, store.scoped)
+}
+
+func mountpointS3CompatEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(mountpointS3CompatEnvVar))) {
+	case "1", "true", "yes", "y":
+		return true
+	default:
+		return false
+	}
+}
+
+func openMountpointS3CompatStore(env *framework.ScenarioEnv) *mountpointS3CompatStore {
+	serviceName := env.Infra.Name + "-rustfs"
+	endpoint, stopForward, err := framework.PortForwardService(env.TestCtx.Context, env.Config.Kubeconfig, env.Infra.Namespace, serviceName, 9000)
+	Expect(err).NotTo(HaveOccurred())
+
+	secretName := env.Infra.Name + "-sandbox0-rustfs-credentials"
+	accessKey, err := framework.GetSecretValue(env.TestCtx.Context, env.Config.Kubeconfig, env.Infra.Namespace, secretName, "RUSTFS_ACCESS_KEY")
+	Expect(err).NotTo(HaveOccurred())
+	secretKey, err := framework.GetSecretValue(env.TestCtx.Context, env.Config.Kubeconfig, env.Infra.Namespace, secretName, "RUSTFS_SECRET_KEY")
+	Expect(err).NotTo(HaveOccurred())
+
+	base, err := objectstore.Create(objectstore.Config{
+		Type:      objectstore.TypeS3,
+		Bucket:    mountpointS3Bucket,
+		Region:    "us-east-1",
+		Endpoint:  endpoint,
+		AccessKey: accessKey,
+		SecretKey: secretKey,
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	prefix := fmt.Sprintf("e2e/mountpoint-s3-compat/%d", time.Now().UnixNano())
+	return &mountpointS3CompatStore{
+		scoped:      objectstore.Prefix(base, prefix),
+		prefix:      prefix,
+		stopForward: stopForward,
+	}
+}
+
+func (s *mountpointS3CompatStore) cleanup() {
+	if s == nil {
+		return
+	}
+	if s.scoped != nil {
+		cleanupMountpointS3Prefix(s.scoped)
+	}
+	if s.stopForward != nil {
+		s.stopForward()
+	}
+}
+
+func cleanupMountpointS3Prefix(store objectstore.Store) {
+	token := ""
+	for {
+		infos, more, next, err := store.List("", "", token, "", 1000)
+		if err != nil {
+			GinkgoWriter.Printf("cleanup mountpoint-s3 compat prefix list failed: %v\n", err)
+			return
+		}
+		for _, info := range infos {
+			if info.IsPrefix || strings.TrimSpace(info.Key) == "" {
+				continue
+			}
+			if err := store.Delete(info.Key); err != nil && !objectstore.IsNotFound(err) {
+				GinkgoWriter.Printf("cleanup mountpoint-s3 compat object %q failed: %v\n", info.Key, err)
+			}
+		}
+		if !more || next == "" {
+			return
+		}
+		token = next
+	}
+}
+
+func seedMountpointS3CompatObjects(store objectstore.Store) {
+	putMountpointS3Object(store, "colors/blue/image.jpg", "blue image")
+	putMountpointS3Object(store, "colors/red/image.jpg", "red image")
+	putMountpointS3Object(store, "colors/list.txt", "list")
+	putMountpointS3Object(store, "blue", "shadowed")
+	putMountpointS3Object(store, "blue/image.jpg", "nested")
+	putMountpointS3Object(store, "marker/", "")
+	putMountpointS3Object(store, "external/before.txt", "external-before")
+	putMountpointS3Object(store, "random/read.txt", "0123456789abcdef")
+}
+
+func assertMountpointS3Projection(env *framework.ScenarioEnv, namespace, podName string, store objectstore.Store) {
+	By("projecting S3 object keys using mountpoint directory semantics")
+	runMountpointS3Script(env, namespace, podName, fmt.Sprintf(`
+set -eu
+M=%s
+test -d "$M/colors"
+test -d "$M/colors/blue"
+test -d "$M/colors/red"
+test "$(cat "$M/colors/list.txt")" = "list"
+test "$(cat "$M/colors/blue/image.jpg")" = "blue image"
+test "$(cat "$M/colors/red/image.jpg")" = "red image"
+test -d "$M/blue"
+test "$(cat "$M/blue/image.jpg")" = "nested"
+test ! -f "$M/blue"
+test -d "$M/marker"
+slice="$(dd if="$M/random/read.txt" bs=1 skip=5 count=8 2>/dev/null)"
+test "$slice" = "56789abc"
+mkdir "$M/local-only"
+test -d "$M/local-only"
+if rmdir "$M/marker"; then
+  echo "rmdir unexpectedly removed S3 directory marker"
+  exit 1
+fi
+rmdir "$M/local-only"
+test ! -e "$M/local-only"
+rm "$M/blue/image.jpg"
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  if [ -f "$M/blue" ] && [ "$(cat "$M/blue")" = "shadowed" ]; then
+    exit 0
+  fi
+  sleep 1
+done
+echo "shadowed file did not reappear after deleting directory child"
+exit 1
+`, shellQuote(mountpointS3MountPath)))
+	expectMountpointS3ObjectMissingEventually(store, "local-only/")
+	expectMountpointS3ObjectMissingEventually(store, "blue/image.jpg")
+	expectMountpointS3ObjectEventually(store, "blue", []byte("shadowed"))
+}
+
+func assertMountpointS3ExternalUpdates(env *framework.ScenarioEnv, namespace, podName string, store objectstore.Store) {
+	By("making external S3 object writes visible inside the sandbox")
+	putMountpointS3Object(store, "external/after.txt", "external-after")
+	waitMountpointS3Script(env, namespace, podName, fmt.Sprintf(`
+set -eu
+M=%s
+test "$(cat "$M/external/before.txt")" = "external-before"
+test "$(cat "$M/external/after.txt")" = "external-after"
+`, shellQuote(mountpointS3MountPath)), 30*time.Second)
+}
+
+func assertMountpointS3WriteLifecycle(env *framework.ScenarioEnv, namespace, podName string, store objectstore.Store) {
+	By("deferring S3 visibility until writer close and blocking readers while writing")
+	runMountpointS3Script(env, namespace, podName, fmt.Sprintf(`
+set -eu
+M=%s
+mkdir -p "$M/write-lifecycle"
+rm -f /tmp/s3-compat-writer-ready /tmp/s3-compat-writer-done /tmp/s3-compat-writer.log
+nohup sh -c 'exec 3> "$1"; printf "%%s" "before-close" >&3; echo ready > /tmp/s3-compat-writer-ready; sleep 20; exec 3>&-; echo done > /tmp/s3-compat-writer-done' sh "$M/write-lifecycle/open.txt" >/tmp/s3-compat-writer.log 2>&1 &
+	`, shellQuote(mountpointS3MountPath)))
+	waitMountpointS3Script(env, namespace, podName, "test -f /tmp/s3-compat-writer-ready", 20*time.Second)
+	expectMountpointS3ObjectMissingConsistently(store, "write-lifecycle/open.txt", 3*time.Second)
+
+	runMountpointS3Script(env, namespace, podName, fmt.Sprintf(`
+set -eu
+M=%s
+if cat "$M/write-lifecycle/open.txt" >/tmp/s3-compat-reader-while-writer 2>/tmp/s3-compat-reader-while-writer.err; then
+  echo "read unexpectedly succeeded while writer was open"
+  exit 1
+fi
+if rm "$M/write-lifecycle/open.txt" 2>/tmp/s3-compat-unlink-while-writer.err; then
+  echo "unlink unexpectedly succeeded while writer was open"
+  exit 1
+fi
+`, shellQuote(mountpointS3MountPath)))
+
+	waitMountpointS3Script(env, namespace, podName, "test -f /tmp/s3-compat-writer-done", 30*time.Second)
+	expectMountpointS3ObjectEventually(store, "write-lifecycle/open.txt", []byte("before-close"))
+	runMountpointS3Script(env, namespace, podName, fmt.Sprintf(`
+set -eu
+test "$(cat %s)" = "before-close"
+`, shellQuote(mountpointS3MountPath+"/write-lifecycle/open.txt")))
+
+	By("blocking overwrite while a reader is open")
+	runMountpointS3Script(env, namespace, podName, fmt.Sprintf(`
+set -eu
+M=%s
+rm -f /tmp/s3-compat-reader-ready /tmp/s3-compat-reader-done /tmp/s3-compat-reader.log
+nohup sh -c 'exec 3< "$1"; echo ready > /tmp/s3-compat-reader-ready; sleep 20; cat <&3 >/dev/null; exec 3<&-; echo done > /tmp/s3-compat-reader-done' sh "$M/write-lifecycle/open.txt" >/tmp/s3-compat-reader.log 2>&1 &
+`, shellQuote(mountpointS3MountPath)))
+	waitMountpointS3Script(env, namespace, podName, "test -f /tmp/s3-compat-reader-ready", 20*time.Second)
+	runMountpointS3Script(env, namespace, podName, fmt.Sprintf(`
+set -eu
+M=%s
+if sh -c 'printf "%%s" "blocked" > "$1"' sh "$M/write-lifecycle/open.txt" 2>/tmp/s3-compat-overwrite-while-reader.err; then
+  echo "overwrite unexpectedly succeeded while reader was open"
+  exit 1
+fi
+`, shellQuote(mountpointS3MountPath)))
+	waitMountpointS3Script(env, namespace, podName, "test -f /tmp/s3-compat-reader-done", 30*time.Second)
+	expectMountpointS3ObjectEventually(store, "write-lifecycle/open.txt", []byte("before-close"))
+}
+
+func assertMountpointS3UnsupportedAndOverwrite(env *framework.ScenarioEnv, namespace, podName string, store objectstore.Store) {
+	By("rejecting unsupported mountpoint metadata and nonsequential write operations")
+	runMountpointS3Script(env, namespace, podName, fmt.Sprintf(`
+set -eu
+M=%s
+file="$M/write-lifecycle/open.txt"
+if sh -c 'printf "%%s" "append" >> "$1"' sh "$file" 2>/tmp/s3-compat-append.err; then
+  echo "append unexpectedly succeeded for a general-purpose S3 bucket"
+  exit 1
+fi
+if sh -c 'printf x | dd of="$1" bs=1 seek=1 count=1 2>/tmp/s3-compat-nonseq.err' sh "$M/write-lifecycle/non-sequential.txt"; then
+  echo "nonsequential write unexpectedly succeeded"
+  exit 1
+fi
+test ! -e "$M/write-lifecycle/non-sequential.txt"
+if chmod 600 "$file" 2>/tmp/s3-compat-chmod.err; then
+  echo "chmod unexpectedly succeeded"
+  exit 1
+fi
+if ln "$file" "$M/write-lifecycle/hardlink.txt" 2>/tmp/s3-compat-link.err; then
+  echo "hard link unexpectedly succeeded"
+  exit 1
+fi
+if ln -s "$file" "$M/write-lifecycle/symlink.txt" 2>/tmp/s3-compat-symlink.err; then
+  echo "symlink unexpectedly succeeded"
+  exit 1
+fi
+if mv "$file" "$M/write-lifecycle/renamed.txt" 2>/tmp/s3-compat-rename.err; then
+  echo "rename unexpectedly succeeded for a general-purpose S3 bucket"
+  exit 1
+fi
+if command -v python3 >/dev/null 2>&1; then
+  if python3 - "$file" <<'PY'
+import os
+import sys
+os.listxattr(sys.argv[1])
+PY
+  then
+    echo "listxattr unexpectedly succeeded"
+    exit 1
+  fi
+fi
+truncate -s 0 "$file"
+test ! -s "$file"
+printf "%%s" "replacement" > "$file"
+sync
+test "$(cat "$file")" = "replacement"
+`, shellQuote(mountpointS3MountPath)))
+	expectMountpointS3ObjectMissingEventually(store, "write-lifecycle/non-sequential.txt")
+	expectMountpointS3ObjectEventually(store, "write-lifecycle/open.txt", []byte("replacement"))
+}
+
+func assertMountpointS3Deletes(env *framework.ScenarioEnv, namespace, podName string, store objectstore.Store) {
+	By("reflecting sandbox deletes in S3 and external S3 deletes in the sandbox")
+	runMountpointS3Script(env, namespace, podName, fmt.Sprintf(`
+set -eu
+M=%s
+rm "$M/write-lifecycle/open.txt"
+`, shellQuote(mountpointS3MountPath)))
+	expectMountpointS3ObjectMissingEventually(store, "write-lifecycle/open.txt")
+
+	Expect(store.Delete("external/after.txt")).To(Succeed())
+	waitMountpointS3Script(env, namespace, podName, fmt.Sprintf(`
+set -eu
+M=%s
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  if ! ls "$M/external/after.txt" >/dev/null 2>&1; then
+    exit 0
+  fi
+  sleep 1
+done
+echo "externally deleted object remained visible in sandbox"
+exit 1
+`, shellQuote(mountpointS3MountPath)), 20*time.Second)
+}
+
+func runMountpointS3Script(env *framework.ScenarioEnv, namespace, podName, script string) {
+	output, err := execInSandboxPod(env, namespace, podName, script)
+	Expect(err).NotTo(HaveOccurred(), "script failed with output:\n%s", output)
+}
+
+func waitMountpointS3Script(env *framework.ScenarioEnv, namespace, podName, script string, timeout time.Duration) {
+	Eventually(func() error {
+		_, err := execInSandboxPod(env, namespace, podName, script)
+		return err
+	}).WithTimeout(timeout).WithPolling(1 * time.Second).Should(Succeed())
+}
+
+func putMountpointS3Object(store objectstore.Store, key, value string) {
+	Expect(store.Put(key, strings.NewReader(value))).To(Succeed(), "put S3 compat object %q", key)
+}
+
+func expectMountpointS3ObjectEventually(store objectstore.Store, key string, want []byte) {
+	Eventually(func(g Gomega) {
+		got, err := readMountpointS3Object(store, key)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(got).To(Equal(want))
+	}).WithTimeout(30*time.Second).WithPolling(1*time.Second).Should(Succeed(), "object %q should match expected content", key)
+}
+
+func expectMountpointS3ObjectMissingEventually(store objectstore.Store, key string) {
+	Eventually(func(g Gomega) {
+		reader, err := store.Get(key, 0, -1)
+		if err == nil {
+			_ = reader.Close()
+		}
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(objectstore.IsNotFound(err)).To(BeTrue(), "object %q error = %v", key, err)
+	}).WithTimeout(30*time.Second).WithPolling(1*time.Second).Should(Succeed(), "object %q should be missing", key)
+}
+
+func expectMountpointS3ObjectMissingConsistently(store objectstore.Store, key string, duration time.Duration) {
+	Consistently(func(g Gomega) {
+		reader, err := store.Get(key, 0, -1)
+		if err == nil {
+			_ = reader.Close()
+		}
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(objectstore.IsNotFound(err)).To(BeTrue(), "object %q error = %v", key, err)
+	}).WithTimeout(duration).WithPolling(500*time.Millisecond).Should(Succeed(), "object %q should stay missing", key)
+}
+
+func readMountpointS3Object(store objectstore.Store, key string) ([]byte, error) {
+	reader, err := store.Get(key, 0, -1)
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, reader); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/tests/e2e/cases/api_mountpoint_s3_compat.go
+++ b/tests/e2e/cases/api_mountpoint_s3_compat.go
@@ -21,8 +21,13 @@ import (
 
 const (
 	mountpointS3CompatEnvVar = "E2E_MOUNTPOINT_S3_COMPAT"
-	mountpointS3Bucket       = "sandbox0"
+	mountpointS3Bucket       = "sandbox0-mountpoint-compat"
 	mountpointS3MountPath    = "/workspace/mountpoint-s3"
+	mountpointS3FixtureImage = "sandbox0ai/otemplates:default-v0.2.0"
+	mountpointS3FixtureName  = "mountpoint-s3-compat-s3"
+	mountpointS3AccessKey    = "mountpointcompat"
+	mountpointS3SecretKey    = "mountpointcompat-secret"
+	mountpointS3Region       = "us-east-1"
 )
 
 var mountpointS3CompatSourceCases = []string{
@@ -44,9 +49,13 @@ var mountpointS3CompatSourceCases = []string{
 }
 
 type mountpointS3CompatStore struct {
-	scoped      objectstore.Store
-	prefix      string
-	stopForward func()
+	scoped         objectstore.Store
+	prefix         string
+	endpointURL    string
+	accessKey      string
+	secretKey      string
+	stopForward    func()
+	cleanupFixture func()
 }
 
 func assertMountpointS3Compatibility(env *framework.ScenarioEnv, session *e2eutils.Session) {
@@ -67,13 +76,18 @@ func assertMountpointS3Compatibility(env *framework.ScenarioEnv, session *e2euti
 	backend := apispec.S3
 	accessMode := apispec.RWO
 	provider := apispec.CreateSandboxVolumeS3ConfigProviderAws
+	region := mountpointS3Region
 	volume, status, err := session.CreateSandboxVolume(env.TestCtx.Context, GinkgoT(), apispec.CreateSandboxVolumeRequest{
 		Backend:    &backend,
 		AccessMode: &accessMode,
 		S3: &apispec.CreateSandboxVolumeS3Config{
-			Provider: &provider,
-			Bucket:   mountpointS3Bucket,
-			Prefix:   &store.prefix,
+			Provider:    &provider,
+			Bucket:      mountpointS3Bucket,
+			Prefix:      &store.prefix,
+			Region:      &region,
+			EndpointUrl: &store.endpointURL,
+			AccessKey:   &store.accessKey,
+			SecretKey:   &store.secretKey,
 		},
 	})
 	Expect(err).NotTo(HaveOccurred())
@@ -128,32 +142,257 @@ func mountpointS3CompatEnabled() bool {
 }
 
 func openMountpointS3CompatStore(env *framework.ScenarioEnv) *mountpointS3CompatStore {
-	serviceName := env.Infra.Name + "-rustfs"
-	endpoint, stopForward, err := framework.PortForwardService(env.TestCtx.Context, env.Config.Kubeconfig, env.Infra.Namespace, serviceName, 9000)
-	Expect(err).NotTo(HaveOccurred())
-
-	secretName := env.Infra.Name + "-sandbox0-rustfs-credentials"
-	accessKey, err := framework.GetSecretValue(env.TestCtx.Context, env.Config.Kubeconfig, env.Infra.Namespace, secretName, "RUSTFS_ACCESS_KEY")
-	Expect(err).NotTo(HaveOccurred())
-	secretKey, err := framework.GetSecretValue(env.TestCtx.Context, env.Config.Kubeconfig, env.Infra.Namespace, secretName, "RUSTFS_SECRET_KEY")
+	cleanupFixture := ensureMountpointS3Fixture(env)
+	endpoint, stopForward, err := framework.PortForwardService(env.TestCtx.Context, env.Config.Kubeconfig, env.Infra.Namespace, mountpointS3FixtureName, 9000)
 	Expect(err).NotTo(HaveOccurred())
 
 	base, err := objectstore.Create(objectstore.Config{
 		Type:      objectstore.TypeS3,
 		Bucket:    mountpointS3Bucket,
-		Region:    "us-east-1",
+		Region:    mountpointS3Region,
 		Endpoint:  endpoint,
-		AccessKey: accessKey,
-		SecretKey: secretKey,
+		AccessKey: mountpointS3AccessKey,
+		SecretKey: mountpointS3SecretKey,
 	})
 	Expect(err).NotTo(HaveOccurred())
+	createMountpointS3Bucket(base)
 
 	prefix := fmt.Sprintf("e2e/mountpoint-s3-compat/%d", time.Now().UnixNano())
 	return &mountpointS3CompatStore{
-		scoped:      objectstore.Prefix(base, prefix),
-		prefix:      prefix,
-		stopForward: stopForward,
+		scoped:         objectstore.Prefix(base, prefix),
+		prefix:         prefix,
+		endpointURL:    fmt.Sprintf("http://%s.%s.svc.cluster.local:9000", mountpointS3FixtureName, env.Infra.Namespace),
+		accessKey:      mountpointS3AccessKey,
+		secretKey:      mountpointS3SecretKey,
+		stopForward:    stopForward,
+		cleanupFixture: cleanupFixture,
 	}
+}
+
+func ensureMountpointS3Fixture(env *framework.ScenarioEnv) func() {
+	manifest := fmt.Sprintf(`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: %[1]s
+  namespace: %[2]s
+data:
+  fake_s3.py: |
+    from email.utils import formatdate
+    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+    from urllib.parse import parse_qs, unquote, urlparse
+    from xml.sax.saxutils import escape
+
+    objects = {}
+    buckets = set()
+
+    def http_date():
+        return formatdate(usegmt=True)
+
+    def s3_time():
+        return "2026-01-01T00:00:00.000Z"
+
+    def split_path(path):
+        raw = unquote(urlparse(path).path).lstrip("/")
+        if not raw:
+            return "", ""
+        parts = raw.split("/", 1)
+        bucket = parts[0]
+        key = parts[1] if len(parts) > 1 else ""
+        return bucket, key
+
+    class Handler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def log_message(self, fmt, *args):
+            return
+
+        def send_empty(self, status):
+            self.send_response(status)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
+        def do_HEAD(self):
+            bucket, key = split_path(self.path)
+            if bucket and not key:
+                buckets.add(bucket)
+                self.send_empty(200)
+                return
+            body = objects.get((bucket, key))
+            if body is None:
+                self.send_empty(404)
+                return
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.send_header("Last-Modified", http_date())
+            self.send_header("ETag", "\"test\"")
+            self.end_headers()
+
+        def do_PUT(self):
+            bucket, key = split_path(self.path)
+            length = int(self.headers.get("Content-Length") or "0")
+            body = self.rfile.read(length) if length > 0 else b""
+            if bucket and not key:
+                buckets.add(bucket)
+                self.send_empty(200)
+                return
+            buckets.add(bucket)
+            objects[(bucket, key)] = body
+            self.send_response(200)
+            self.send_header("ETag", "\"test\"")
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
+        def do_DELETE(self):
+            bucket, key = split_path(self.path)
+            objects.pop((bucket, key), None)
+            self.send_empty(204)
+
+        def do_GET(self):
+            parsed = urlparse(self.path)
+            query = parse_qs(parsed.query)
+            if query.get("list-type", [""])[0] == "2":
+                self.list_objects_v2(query)
+                return
+            bucket, key = split_path(self.path)
+            body = objects.get((bucket, key))
+            if body is None:
+                self.send_empty(404)
+                return
+            start = 0
+            end = len(body) - 1
+            status = 200
+            range_header = self.headers.get("Range", "")
+            if range_header.startswith("bytes="):
+                status = 206
+                raw_start, _, raw_end = range_header[len("bytes="):].partition("-")
+                start = int(raw_start or "0")
+                end = int(raw_end) if raw_end else len(body) - 1
+                if end >= len(body):
+                    end = len(body) - 1
+            chunk = body[start:end + 1] if body else b""
+            self.send_response(status)
+            self.send_header("Content-Length", str(len(chunk)))
+            self.send_header("Last-Modified", http_date())
+            self.send_header("ETag", "\"test\"")
+            if status == 206:
+                self.send_header("Content-Range", f"bytes {start}-{end}/{len(body)}")
+            self.end_headers()
+            self.wfile.write(chunk)
+
+        def list_objects_v2(self, query):
+            bucket, _ = split_path(self.path)
+            prefix = query.get("prefix", [""])[0]
+            delimiter = query.get("delimiter", [""])[0]
+            start_after = query.get("start-after", [""])[0]
+            max_keys = int(query.get("max-keys", ["1000"])[0])
+            contents = []
+            prefixes = set()
+            for obj_bucket, key in sorted(objects.keys()):
+                if obj_bucket != bucket or not key.startswith(prefix) or key <= start_after:
+                    continue
+                suffix = key[len(prefix):]
+                if delimiter and delimiter in suffix:
+                    prefixes.add(prefix + suffix.split(delimiter, 1)[0] + delimiter)
+                    continue
+                contents.append(key)
+                if len(contents) + len(prefixes) >= max_keys:
+                    break
+            body = ['<?xml version="1.0" encoding="UTF-8"?>',
+                    '<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">',
+                    f'<Name>{escape(bucket)}</Name>',
+                    f'<Prefix>{escape(prefix)}</Prefix>',
+                    f'<KeyCount>{len(contents) + len(prefixes)}</KeyCount>',
+                    f'<MaxKeys>{max_keys}</MaxKeys>',
+                    '<IsTruncated>false</IsTruncated>']
+            for key in contents:
+                value = objects[(bucket, key)]
+                body.extend(['<Contents>',
+                             f'<Key>{escape(key)}</Key>',
+                             f'<LastModified>{s3_time()}</LastModified>',
+                             '<ETag>"test"</ETag>',
+                             f'<Size>{len(value)}</Size>',
+                             '<StorageClass>STANDARD</StorageClass>',
+                             '</Contents>'])
+            for common_prefix in sorted(prefixes):
+                body.extend(['<CommonPrefixes>',
+                             f'<Prefix>{escape(common_prefix)}</Prefix>',
+                             '</CommonPrefixes>'])
+            body.append('</ListBucketResult>')
+            payload = ''.join(body).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/xml")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+    ThreadingHTTPServer(("0.0.0.0", 9000), Handler).serve_forever()
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: %[1]s
+  namespace: %[2]s
+spec:
+  selector:
+    app.kubernetes.io/name: %[1]s
+  ports:
+    - name: s3
+      port: 9000
+      targetPort: 9000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: %[1]s
+  namespace: %[2]s
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: %[1]s
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: %[1]s
+    spec:
+      containers:
+        - name: fake-s3
+          image: %[3]s
+          imagePullPolicy: IfNotPresent
+          command:
+            - python3
+            - /app/fake_s3.py
+          ports:
+            - name: s3
+              containerPort: 9000
+          readinessProbe:
+            tcpSocket:
+              port: 9000
+            periodSeconds: 2
+            failureThreshold: 30
+          volumeMounts:
+            - name: script
+              mountPath: /app
+      volumes:
+        - name: script
+          configMap:
+            name: %[1]s
+`, mountpointS3FixtureName, env.Infra.Namespace, mountpointS3FixtureImage)
+	Expect(framework.ApplyManifestContent(env.TestCtx.Context, env.Config.Kubeconfig, "sandbox0-e2e-mountpoint-s3-fixture-", manifest)).To(Succeed())
+	Expect(framework.WaitForDeployment(env.TestCtx.Context, env.Config.Kubeconfig, env.Infra.Namespace, mountpointS3FixtureName, "3m")).To(Succeed())
+	return func() {
+		_ = framework.Kubectl(env.TestCtx.Context, env.Config.Kubeconfig, "delete", "deployment/"+mountpointS3FixtureName, "service/"+mountpointS3FixtureName, "configmap/"+mountpointS3FixtureName, "--namespace", env.Infra.Namespace, "--ignore-not-found=true")
+	}
+}
+
+func createMountpointS3Bucket(store objectstore.Store) {
+	err := store.Create()
+	if err == nil {
+		return
+	}
+	message := strings.ToLower(err.Error())
+	Expect(message).To(Or(ContainSubstring("already"), ContainSubstring("bucketalready")), "create bucket failed: %v", err)
 }
 
 func (s *mountpointS3CompatStore) cleanup() {
@@ -165,6 +404,9 @@ func (s *mountpointS3CompatStore) cleanup() {
 	}
 	if s.stopForward != nil {
 		s.stopForward()
+	}
+	if s.cleanupFixture != nil {
+		s.cleanupFixture()
 	}
 }
 
@@ -207,29 +449,50 @@ func assertMountpointS3Projection(env *framework.ScenarioEnv, namespace, podName
 	runMountpointS3Script(env, namespace, podName, fmt.Sprintf(`
 set -eu
 M=%s
+S0_STEP=start
+trap 'code=$?; echo "failed at: $S0_STEP"; ls -la "$M" || true; [ -e "$M/blue" ] && ls -la "$M/blue" || true; [ -e "$M/marker" ] && ls -la "$M/marker" || true; exit $code' EXIT
+step() { S0_STEP="$1"; }
+step "colors directory"
 test -d "$M/colors"
+step "colors blue directory"
 test -d "$M/colors/blue"
+step "colors red directory"
 test -d "$M/colors/red"
+step "colors list content"
 test "$(cat "$M/colors/list.txt")" = "list"
+step "colors blue image content"
 test "$(cat "$M/colors/blue/image.jpg")" = "blue image"
+step "colors red image content"
 test "$(cat "$M/colors/red/image.jpg")" = "red image"
+step "shadowed blue directory"
 test -d "$M/blue"
+step "shadowed blue child content"
 test "$(cat "$M/blue/image.jpg")" = "nested"
+step "shadowed blue is not file"
 test ! -f "$M/blue"
+step "delimiter marker directory"
 test -d "$M/marker"
+step "random ranged read"
 slice="$(dd if="$M/random/read.txt" bs=1 skip=5 count=8 2>/dev/null)"
 test "$slice" = "56789abc"
+step "local mkdir"
 mkdir "$M/local-only"
 test -d "$M/local-only"
+step "remote marker rmdir rejected"
 if rmdir "$M/marker"; then
   echo "rmdir unexpectedly removed S3 directory marker"
   exit 1
 fi
+step "local rmdir"
 rmdir "$M/local-only"
+step "local rmdir hidden"
 test ! -e "$M/local-only"
+step "remove shadowing child"
 rm "$M/blue/image.jpg"
+step "shadowed file reappears"
 for _ in 1 2 3 4 5 6 7 8 9 10; do
   if [ -f "$M/blue" ] && [ "$(cat "$M/blue")" = "shadowed" ]; then
+    trap - EXIT
     exit 0
   fi
   sleep 1

--- a/tests/e2e/cases/api_volumes.go
+++ b/tests/e2e/cases/api_volumes.go
@@ -4,11 +4,12 @@ import "github.com/sandbox0-ai/sandbox0/pkg/framework"
 
 func registerApiVolumesSuite(envProvider func() *framework.ScenarioEnv) {
 	registerApiModeSuite(envProvider, apiModeSuiteOptions{
-		name:                     "volumes",
-		describe:                 "API volumes mode",
-		templateNamePrefix:       "e2e-volumes",
-		fileContent:              "hello volumes",
-		includeVolumeLifecycle:   true,
-		expectNetworkUnavailable: true,
+		name:                      "volumes",
+		describe:                  "API volumes mode",
+		templateNamePrefix:        "e2e-volumes",
+		fileContent:               "hello volumes",
+		includeVolumeLifecycle:    true,
+		includeMountpointS3Compat: true,
+		expectNetworkUnavailable:  true,
 	})
 }


### PR DESCRIPTION
## Summary
- add an S3-compatible SandboxVolume backend (`backend: s3`) with provider metadata for aws/ali/r2
- expose S3-backed volumes through ctld volume portals using a FUSE projection
- persist/redact backend config, update OpenAPI/generated types, and document the new backend
- add S3/common-prefix objectstore behavior and portal tests, including direct-I/O handling for S3-backed sessions

## POSIX compatibility target
The S3 backend is intended to be at least as compatible as Mountpoint for Amazon S3 for general-purpose S3-style buckets: random reads, sequential writes for new files, O_TRUNC replacement, deletion, directory inference, and explicit failures for unsupported rich POSIX features.

## Tests
- `git diff --check`
- `go test ./pkg/volumefuse ./storage-proxy/pkg/objectstore ./storage-proxy/pkg/volume ./storage-proxy/pkg/db ./storage-proxy/pkg/http ./storage-proxy/pkg/snapshot ./ctld/internal/ctld/portal ./pkg/apispec`
- remote kind validation against RustFS S3-compatible backend: S3->sandbox reads, post-mount S3 changes, sandbox direct redirect write -> S3, sandbox delete -> S3, S3 delete -> sandbox

## Follow-up validation in progress
Running an expanded remote compatibility matrix against Mountpoint S3 semantics while PR CI is running.