### PR TITLE
Allow S3 volume portals on gVisor

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -20,7 +20,7 @@ jobs:
   e2e:
     name: e2e
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     permissions:
       contents: read
     env:

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -51,7 +51,6 @@ jobs:
         env:
           E2E_CLUSTER_NAME: ${{ env.KIND_CLUSTER_NAME }}
           E2E_USE_EXISTING_CLUSTER: "true"
-          E2E_SANDBOX_RUNTIME_CLASS: ""
         run: make test-e2e-mountpoint-s3-compat
 
       - name: Dump cluster state on failure

--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,6 @@ test-e2e-mountpoint-s3-compat:
 		E2E_SINGLE_CLUSTER_SCENARIOS=volumes \
 		E2E_MOUNTPOINT_S3_COMPAT=true \
 		E2E_USE_EXISTING_CLUSTER=true \
-		E2E_SANDBOX_RUNTIME_CLASS= \
 		$(GO) test -v -count=1 ./tests/e2e/scenarios/single-cluster \
 		-run TestSingleCluster \
 		-ginkgo.focus="API volumes mode.*mountpoint-s3 general bucket compatibility semantics" \

--- a/ctld/internal/ctld/portal/s3_session.go
+++ b/ctld/internal/ctld/portal/s3_session.go
@@ -61,6 +61,7 @@ type s3Handle struct {
 	path      string
 	writable  bool
 	actor     *pb.PosixActor
+	read      bool
 	buffer    bytes.Buffer
 	committed bool
 	closed    bool
@@ -277,7 +278,7 @@ func (s *s3Session) Create(ctx context.Context, req *pb.CreateRequest) (*pb.Node
 		if req.Flags&uint32(syscall.O_EXCL) != 0 {
 			return nil, fserror.New(fserror.AlreadyExists, "entry already exists")
 		}
-		if s.hasConflictingOpenReader(existing.inode, req.Actor) || s.hasOpenWriter(existing.inode) {
+		if s.hasConflictingOpenReader(existing.inode, existing.path, req.Actor) || s.hasOpenWriter(existing.inode) {
 			return nil, syscall.EPERM
 		}
 		handleID := s.newHandle(&s3Handle{inode: existing.inode, path: existing.path, writable: true, actor: req.Actor})
@@ -456,7 +457,7 @@ func (s *s3Session) Open(ctx context.Context, req *pb.OpenRequest) (*pb.OpenResp
 		if handleID, ok := s.sameActorWritableHandle(node.inode, req.Actor); ok {
 			return &pb.OpenResponse{HandleId: handleID}, nil
 		}
-		if s.hasConflictingOpenReader(node.inode, req.Actor) || s.hasOpenWriter(node.inode) {
+		if s.hasConflictingOpenReader(node.inode, node.path, req.Actor) || s.hasOpenWriter(node.inode) {
 			return nil, syscall.EPERM
 		}
 		handleID := s.newHandle(&s3Handle{inode: node.inode, path: node.path, writable: true, actor: req.Actor})
@@ -503,6 +504,9 @@ func (s *s3Session) ReadInto(ctx context.Context, req *pb.ReadRequest, dest []by
 	}
 	if req.Offset >= node.size || len(dest) == 0 {
 		return 0, true, nil
+	}
+	if req.HandleId != 0 {
+		s.markReadHandle(req.HandleId, node.inode)
 	}
 	limit := int64(len(dest))
 	if remaining := node.size - req.Offset; remaining < limit {
@@ -1025,15 +1029,28 @@ func (s *s3Session) hasOpenWriter(inode uint64) bool {
 	return s.findWritableHandle(inode) != nil
 }
 
-func (s *s3Session) hasConflictingOpenReader(inode uint64, actor *pb.PosixActor) bool {
+func (s *s3Session) hasConflictingOpenReader(inode uint64, key string, actor *pb.PosixActor) bool {
+	key = cleanS3Path(key)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, handle := range s.handles {
-		if handle != nil && handle.inode == inode && !handle.writable && !handle.closed && !samePosixActor(handle.actor, actor) {
+		if handle == nil || handle.inode != inode || handle.path != key || handle.writable || handle.closed {
+			continue
+		}
+		if handle.read || !samePosixActor(handle.actor, actor) {
 			return true
 		}
 	}
 	return false
+}
+
+func (s *s3Session) markReadHandle(handleID, inode uint64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	handle := s.handles[handleID]
+	if handle != nil && handle.inode == inode && !handle.writable && !handle.closed {
+		handle.read = true
+	}
 }
 
 func (s *s3Session) sameActorWritableHandle(inode uint64, actor *pb.PosixActor) (uint64, bool) {

--- a/ctld/internal/ctld/portal/s3_session.go
+++ b/ctld/internal/ctld/portal/s3_session.go
@@ -277,9 +277,6 @@ func (s *s3Session) Create(ctx context.Context, req *pb.CreateRequest) (*pb.Node
 		if req.Flags&uint32(syscall.O_EXCL) != 0 {
 			return nil, fserror.New(fserror.AlreadyExists, "entry already exists")
 		}
-		if !existing.localOnly && req.Flags&uint32(syscall.O_TRUNC) == 0 {
-			return nil, syscall.EPERM
-		}
 		if s.hasConflictingOpenReader(existing.inode, req.Actor) || s.hasOpenWriter(existing.inode) {
 			return nil, syscall.EPERM
 		}
@@ -458,9 +455,6 @@ func (s *s3Session) Open(ctx context.Context, req *pb.OpenRequest) (*pb.OpenResp
 		}
 		if handleID, ok := s.sameActorWritableHandle(node.inode, req.Actor); ok {
 			return &pb.OpenResponse{HandleId: handleID}, nil
-		}
-		if !node.localOnly && req.Flags&uint32(syscall.O_TRUNC) == 0 {
-			return nil, syscall.EPERM
 		}
 		if s.hasConflictingOpenReader(node.inode, req.Actor) || s.hasOpenWriter(node.inode) {
 			return nil, syscall.EPERM

--- a/ctld/internal/ctld/portal/s3_session.go
+++ b/ctld/internal/ctld/portal/s3_session.go
@@ -277,6 +277,9 @@ func (s *s3Session) Create(ctx context.Context, req *pb.CreateRequest) (*pb.Node
 		if req.Flags&uint32(syscall.O_EXCL) != 0 {
 			return nil, fserror.New(fserror.AlreadyExists, "entry already exists")
 		}
+		if !existing.localOnly && req.Flags&uint32(syscall.O_TRUNC) == 0 {
+			return nil, syscall.EPERM
+		}
 		if s.hasConflictingOpenReader(existing.inode, req.Actor) || s.hasOpenWriter(existing.inode) {
 			return nil, syscall.EPERM
 		}
@@ -455,6 +458,9 @@ func (s *s3Session) Open(ctx context.Context, req *pb.OpenRequest) (*pb.OpenResp
 		}
 		if handleID, ok := s.sameActorWritableHandle(node.inode, req.Actor); ok {
 			return &pb.OpenResponse{HandleId: handleID}, nil
+		}
+		if !node.localOnly && req.Flags&uint32(syscall.O_TRUNC) == 0 {
+			return nil, syscall.EPERM
 		}
 		if s.hasConflictingOpenReader(node.inode, req.Actor) || s.hasOpenWriter(node.inode) {
 			return nil, syscall.EPERM

--- a/ctld/internal/ctld/portal/s3_session.go
+++ b/ctld/internal/ctld/portal/s3_session.go
@@ -174,13 +174,7 @@ func (s *s3Session) SetAttr(ctx context.Context, req *pb.SetAttrRequest) (*pb.Se
 	if req.Valid == 0 {
 		return &pb.SetAttrResponse{Attr: s.attr(node)}, nil
 	}
-	if node.kind == s3NodeFile && !node.localOnly && !s.hasOpenWriter(node.inode) && req.Valid&^(s3MetadataSetAttrNoopMask|fuseFattrNoopMask) == 0 && s.setAttrRequestsModeChange(req, node) {
-		return nil, syscall.EPERM
-	}
-	if node.kind == s3NodeDir && node.localOnly && req.Valid&^(s3MetadataSetAttrNoopMask|fuseFattrNoopMask) == 0 {
-		return &pb.SetAttrResponse{Attr: s.attr(node)}, nil
-	}
-	if node.kind == s3NodeFile && (node.localOnly || s.hasOpenWriter(node.inode)) && req.Valid&^(s3MetadataSetAttrNoopMask|fuseFattrNoopMask) == 0 {
+	if req.Valid&^(s3MetadataSetAttrNoopMask|fuseFattrNoopMask) == 0 {
 		return &pb.SetAttrResponse{Attr: s.attr(node)}, nil
 	}
 	if req.Valid&fuseFattrSize == 0 {
@@ -1177,18 +1171,6 @@ func (s *s3Session) discardFailedWrite(handle *s3Handle) {
 	if info, err := s.store.Head(handle.path); err == nil {
 		s.rememberPath(handle.path, s3NodeFile, info.Size, info.Modified)
 	}
-}
-
-func (s *s3Session) setAttrRequestsModeChange(req *pb.SetAttrRequest, node *s3Node) bool {
-	if req == nil || req.Attr == nil || node == nil {
-		return false
-	}
-	if req.Valid&uint32(fuse.FATTR_MODE) == 0 {
-		return false
-	}
-	currentPerm := s.attr(node).Mode & 0o7777
-	requestedPerm := req.Attr.Mode & 0o7777
-	return requestedPerm != currentPerm
 }
 
 func (s *s3Session) ensureWritable() error {

--- a/ctld/internal/ctld/portal/s3_session.go
+++ b/ctld/internal/ctld/portal/s3_session.go
@@ -23,11 +23,21 @@ import (
 )
 
 const (
-	s3RootInode       = uint64(fsmeta.RootInode)
-	s3DirMode         = uint32(syscall.S_IFDIR | 0o755)
-	s3FileMode        = uint32(syscall.S_IFREG | 0o644)
-	fuseFattrSize     = uint32(fuse.FATTR_SIZE)
-	fuseFattrNoopMask = uint32(fuse.FATTR_FH | fuse.FATTR_LOCKOWNER | fuse.FATTR_KILL_SUIDGID)
+	s3RootInode               = uint64(fsmeta.RootInode)
+	s3DirMode                 = uint32(syscall.S_IFDIR | 0o777)
+	s3FileMode                = uint32(syscall.S_IFREG | 0o666)
+	fuseFattrSize             = uint32(fuse.FATTR_SIZE)
+	fuseFattrNoopMask         = uint32(fuse.FATTR_FH | fuse.FATTR_LOCKOWNER | fuse.FATTR_KILL_SUIDGID)
+	s3MetadataSetAttrNoopMask = uint32(
+		fuse.FATTR_MODE |
+			fuse.FATTR_UID |
+			fuse.FATTR_GID |
+			fuse.FATTR_ATIME |
+			fuse.FATTR_MTIME |
+			fuse.FATTR_ATIME_NOW |
+			fuse.FATTR_MTIME_NOW |
+			fuse.FATTR_CTIME,
+	)
 )
 
 type s3NodeKind uint8
@@ -50,6 +60,7 @@ type s3Handle struct {
 	inode     uint64
 	path      string
 	writable  bool
+	actor     *pb.PosixActor
 	buffer    bytes.Buffer
 	committed bool
 	closed    bool
@@ -163,11 +174,23 @@ func (s *s3Session) SetAttr(ctx context.Context, req *pb.SetAttrRequest) (*pb.Se
 	if req.Valid == 0 {
 		return &pb.SetAttrResponse{Attr: s.attr(node)}, nil
 	}
-	if req.Valid&^(fuseFattrSize|fuseFattrNoopMask) != 0 {
-		return nil, syscall.EOPNOTSUPP
+	if node.kind == s3NodeFile && !node.localOnly && !s.hasOpenWriter(node.inode) && req.Valid&^(s3MetadataSetAttrNoopMask|fuseFattrNoopMask) == 0 && s.setAttrRequestsModeChange(req, node) {
+		return nil, syscall.EPERM
+	}
+	if node.kind == s3NodeDir && node.localOnly && req.Valid&^(s3MetadataSetAttrNoopMask|fuseFattrNoopMask) == 0 {
+		return &pb.SetAttrResponse{Attr: s.attr(node)}, nil
+	}
+	if node.kind == s3NodeFile && (node.localOnly || s.hasOpenWriter(node.inode)) && req.Valid&^(s3MetadataSetAttrNoopMask|fuseFattrNoopMask) == 0 {
+		return &pb.SetAttrResponse{Attr: s.attr(node)}, nil
 	}
 	if req.Valid&fuseFattrSize == 0 {
+		if req.Valid&^fuseFattrNoopMask != 0 {
+			return nil, syscall.EOPNOTSUPP
+		}
 		return &pb.SetAttrResponse{Attr: s.attr(node)}, nil
+	}
+	if req.Valid&^(fuseFattrSize|fuseFattrNoopMask|s3MetadataSetAttrNoopMask) != 0 {
+		return nil, syscall.EOPNOTSUPP
 	}
 	if err := s.ensureWritable(); err != nil {
 		return nil, err
@@ -206,17 +229,21 @@ func (s *s3Session) SetAttr(ctx context.Context, req *pb.SetAttrRequest) (*pb.Se
 }
 
 func (s *s3Session) Mkdir(ctx context.Context, req *pb.MkdirRequest) (*pb.NodeResponse, error) {
+	return s.createLocalDir(ctx, req.Parent, req.Name)
+}
+
+func (s *s3Session) createLocalDir(ctx context.Context, parentInode uint64, name string) (*pb.NodeResponse, error) {
 	if err := s.ensureWritable(); err != nil {
 		return nil, err
 	}
-	parent, err := s.nodeForInode(req.Parent)
+	parent, err := s.nodeForInode(parentInode)
 	if err != nil {
 		return nil, err
 	}
 	if parent.kind != s3NodeDir {
 		return nil, syscall.ENOTDIR
 	}
-	name, err := cleanS3Name(req.Name)
+	name, err = cleanS3Name(name)
 	if err != nil {
 		return nil, err
 	}
@@ -246,14 +273,60 @@ func (s *s3Session) Create(ctx context.Context, req *pb.CreateRequest) (*pb.Node
 		return nil, err
 	}
 	filePath := joinS3Path(parent.path, name)
+	if req.Flags&uint32(syscall.O_APPEND) != 0 {
+		return nil, fserror.New(fserror.InvalidArgument, "s3 backend does not support append writes")
+	}
+	if existing, err := s.resolvePath(ctx, filePath); err == nil {
+		if existing.kind != s3NodeFile {
+			return nil, syscall.EISDIR
+		}
+		if req.Flags&uint32(syscall.O_EXCL) != 0 {
+			return nil, fserror.New(fserror.AlreadyExists, "entry already exists")
+		}
+		if s.hasConflictingOpenReader(existing.inode, req.Actor) || s.hasOpenWriter(existing.inode) {
+			return nil, syscall.EPERM
+		}
+		handleID := s.newHandle(&s3Handle{inode: existing.inode, path: existing.path, writable: true, actor: req.Actor})
+		s.updateNodeSize(existing.inode, 0)
+		return s.nodeResponse(existing, handleID), nil
+	} else if fserror.CodeOf(err) != fserror.NotFound {
+		return nil, err
+	}
+	node := s.rememberLocalFile(filePath, time.Now().UTC())
+	handleID := s.newHandle(&s3Handle{
+		inode:    node.inode,
+		path:     node.path,
+		writable: true,
+		actor:    req.Actor,
+	})
+	return s.nodeResponse(node, handleID), nil
+}
+
+func (s *s3Session) createFileNode(ctx context.Context, parentInode uint64, name string, localOnly bool) (*s3Node, error) {
+	if err := s.ensureWritable(); err != nil {
+		return nil, err
+	}
+	parent, err := s.nodeForInode(parentInode)
+	if err != nil {
+		return nil, err
+	}
+	if parent.kind != s3NodeDir {
+		return nil, syscall.ENOTDIR
+	}
+	name, err = cleanS3Name(name)
+	if err != nil {
+		return nil, err
+	}
+	filePath := joinS3Path(parent.path, name)
 	if _, err := s.resolvePath(ctx, filePath); err == nil {
 		return nil, fserror.New(fserror.AlreadyExists, "entry already exists")
 	} else if fserror.CodeOf(err) != fserror.NotFound {
 		return nil, err
 	}
-	node := s.rememberPath(filePath, s3NodeFile, 0, time.Now().UTC())
-	handleID := s.newHandle(&s3Handle{inode: node.inode, path: filePath, writable: true})
-	return s.nodeResponse(node, handleID), nil
+	if localOnly {
+		return s.rememberLocalFile(filePath, time.Now().UTC()), nil
+	}
+	return s.rememberPath(filePath, s3NodeFile, 0, time.Now().UTC()), nil
 }
 
 func (s *s3Session) Unlink(ctx context.Context, req *pb.UnlinkRequest) (*pb.Empty, error) {
@@ -323,16 +396,31 @@ func (s *s3Session) Rmdir(ctx context.Context, req *pb.RmdirRequest) (*pb.Empty,
 	return &pb.Empty{}, nil
 }
 
-func (s *s3Session) Rename(context.Context, *pb.RenameRequest) (*pb.Empty, error) {
-	return nil, syscall.EOPNOTSUPP
+func (s *s3Session) Rename(_ context.Context, req *pb.RenameRequest) (*pb.Empty, error) {
+	if req == nil {
+		return nil, syscall.EOPNOTSUPP
+	}
+	if _, err := s.nodeForInode(req.OldParent); err != nil {
+		return nil, err
+	}
+	if _, err := s.nodeForInode(req.NewParent); err != nil {
+		return nil, err
+	}
+	if _, err := cleanS3Name(req.OldName); err != nil {
+		return nil, err
+	}
+	if _, err := cleanS3Name(req.NewName); err != nil {
+		return nil, err
+	}
+	return nil, syscall.EPERM
 }
 
 func (s *s3Session) Link(context.Context, *pb.LinkRequest) (*pb.NodeResponse, error) {
-	return nil, syscall.EOPNOTSUPP
+	return nil, syscall.EPERM
 }
 
 func (s *s3Session) Symlink(context.Context, *pb.SymlinkRequest) (*pb.NodeResponse, error) {
-	return nil, syscall.EOPNOTSUPP
+	return nil, syscall.EPERM
 }
 
 func (s *s3Session) Readlink(context.Context, *pb.ReadlinkRequest) (*pb.ReadlinkResponse, error) {
@@ -359,11 +447,6 @@ func (s *s3Session) Open(ctx context.Context, req *pb.OpenRequest) (*pb.OpenResp
 		if err := s.ensureWritable(); err != nil {
 			return nil, err
 		}
-		if s.hasOpenReader(node.inode) || s.hasOpenWriter(node.inode) {
-			return nil, syscall.EPERM
-		}
-	} else if s.hasOpenWriter(node.inode) {
-		return nil, syscall.EPERM
 	}
 	node, err = s.resolvePath(ctx, node.path)
 	if err != nil {
@@ -374,13 +457,22 @@ func (s *s3Session) Open(ctx context.Context, req *pb.OpenRequest) (*pb.OpenResp
 	}
 	if writable {
 		if req.Flags&uint32(syscall.O_APPEND) != 0 {
-			return nil, syscall.EOPNOTSUPP
+			return nil, fserror.New(fserror.InvalidArgument, "s3 backend does not support append writes")
 		}
-		handleID := s.newHandle(&s3Handle{inode: node.inode, path: node.path, writable: true})
+		if handleID, ok := s.sameActorWritableHandle(node.inode, req.Actor); ok {
+			return &pb.OpenResponse{HandleId: handleID}, nil
+		}
+		if s.hasConflictingOpenReader(node.inode, req.Actor) || s.hasOpenWriter(node.inode) {
+			return nil, syscall.EPERM
+		}
+		handleID := s.newHandle(&s3Handle{inode: node.inode, path: node.path, writable: true, actor: req.Actor})
 		s.updateNodeSize(node.inode, 0)
 		return &pb.OpenResponse{HandleId: handleID}, nil
 	}
-	handleID := s.newHandle(&s3Handle{inode: node.inode, path: node.path})
+	if s.hasOpenWriter(node.inode) {
+		return nil, syscall.EPERM
+	}
+	handleID := s.newHandle(&s3Handle{inode: node.inode, path: node.path, actor: req.Actor})
 	return &pb.OpenResponse{HandleId: handleID}, nil
 }
 
@@ -445,10 +537,20 @@ func (s *s3Session) Write(_ context.Context, req *pb.WriteRequest) (*pb.WriteRes
 	handle := s.handle(req.HandleId)
 	implicit := false
 	if handle == nil && req.HandleId == 0 {
+		if existing := s.findWritableHandle(req.Inode); existing != nil {
+			handle = existing
+		} else if req.Offset != 0 {
+			if node, err := s.nodeForInode(req.Inode); err == nil && node.localOnly {
+				s.forgetPath(node.path)
+			}
+			return nil, fserror.New(fserror.InvalidArgument, "s3 backend only supports sequential writes for new files")
+		}
 		var err error
-		handle, err = s.handlelessWritableHandle(req.Inode)
-		if err != nil {
-			return nil, err
+		if handle == nil {
+			handle, err = s.handlelessWritableHandle(req.Inode, req.Actor)
+			if err != nil {
+				return nil, err
+			}
 		}
 		implicit = true
 	}
@@ -460,6 +562,8 @@ func (s *s3Session) Write(_ context.Context, req *pb.WriteRequest) (*pb.WriteRes
 	}
 	if req.Offset != int64(handle.buffer.Len()) {
 		handle.failed = true
+		s.discardFailedWrite(handle)
+		s.dropFailedHandle(req.HandleId, req.Inode, handle)
 		return nil, fserror.New(fserror.InvalidArgument, "s3 backend only supports sequential writes for new files")
 	}
 	n, err := handle.buffer.Write(req.Data)
@@ -627,7 +731,7 @@ func (s *s3Session) addLocalDirEntries(node *s3Node, prefix string, plus bool, e
 			continue
 		}
 		entryPath := joinS3Path(node.path, name)
-		localOnly := entryNode.localOnly && kind == s3NodeDir
+		localOnly := entryNode.localOnly
 		remembered := s.rememberPathWithLocal(entryPath, kind, entryNode.size, entryNode.modified, localOnly)
 		dirEntry := &pb.DirEntry{
 			Inode: remembered.inode,
@@ -671,15 +775,27 @@ func (s *s3Session) SetXattr(context.Context, *pb.SetXattrRequest) (*pb.Empty, e
 }
 
 func (s *s3Session) ListXattr(context.Context, *pb.ListXattrRequest) (*pb.ListXattrResponse, error) {
-	return nil, syscall.EOPNOTSUPP
+	return &pb.ListXattrResponse{}, nil
 }
 
 func (s *s3Session) RemoveXattr(context.Context, *pb.RemoveXattrRequest) (*pb.Empty, error) {
 	return nil, syscall.EOPNOTSUPP
 }
 
-func (s *s3Session) Mknod(context.Context, *pb.MknodRequest) (*pb.NodeResponse, error) {
-	return nil, syscall.EOPNOTSUPP
+func (s *s3Session) Mknod(ctx context.Context, req *pb.MknodRequest) (*pb.NodeResponse, error) {
+	nodeType := req.Mode & uint32(syscall.S_IFMT)
+	switch nodeType {
+	case uint32(syscall.S_IFDIR):
+		return s.createLocalDir(ctx, req.Parent, req.Name)
+	case 0, uint32(syscall.S_IFREG):
+		node, err := s.createFileNode(ctx, req.Parent, req.Name, true)
+		if err != nil {
+			return nil, err
+		}
+		return s.nodeResponse(node, 0), nil
+	default:
+		return nil, syscall.EOPNOTSUPP
+	}
 }
 
 func (s *s3Session) GetLk(context.Context, *pb.GetLkRequest) (*pb.GetLkResponse, error) {
@@ -708,6 +824,17 @@ func (s *s3Session) resolvePath(ctx context.Context, key string) (*s3Node, error
 			return nil, err
 		} else if exists {
 			return s.rememberPath(key, s3NodeDir, 0, info.Modified), nil
+		}
+		return node, nil
+	}
+	if node, ok := s.nodeForPath(key); ok && node.kind == s3NodeFile && node.localOnly {
+		if s.hasOpenWriter(node.inode) {
+			return node, nil
+		}
+		if info, err := s.store.Head(key); err == nil {
+			return s.rememberPath(key, s3NodeFile, info.Size, info.Modified), nil
+		} else if !objectstore.IsNotFound(err) {
+			return nil, err
 		}
 		return node, nil
 	}
@@ -819,6 +946,10 @@ func (s *s3Session) rememberLocalDir(key string, modified time.Time) *s3Node {
 	return s.rememberPathWithLocal(key, s3NodeDir, 0, modified, true)
 }
 
+func (s *s3Session) rememberLocalFile(key string, modified time.Time) *s3Node {
+	return s.rememberPathWithLocal(key, s3NodeFile, 0, modified, true)
+}
+
 func (s *s3Session) rememberPathWithLocal(key string, kind s3NodeKind, size int64, modified time.Time, localOnly bool) *s3Node {
 	key = cleanS3Path(key)
 	if modified.IsZero() {
@@ -886,11 +1017,11 @@ func (s *s3Session) findWritableHandle(inode uint64) *s3Handle {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, handle := range s.handles {
-		if handle != nil && handle.inode == inode && handle.writable && !handle.closed {
+		if handle != nil && handle.inode == inode && handle.writable && !handle.closed && !handle.failed {
 			return handle
 		}
 	}
-	if handle := s.implicit[inode]; handle != nil && handle.writable && !handle.closed {
+	if handle := s.implicit[inode]; handle != nil && handle.writable && !handle.closed && !handle.failed {
 		return handle
 	}
 	return nil
@@ -900,15 +1031,26 @@ func (s *s3Session) hasOpenWriter(inode uint64) bool {
 	return s.findWritableHandle(inode) != nil
 }
 
-func (s *s3Session) hasOpenReader(inode uint64) bool {
+func (s *s3Session) hasConflictingOpenReader(inode uint64, actor *pb.PosixActor) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, handle := range s.handles {
-		if handle != nil && handle.inode == inode && !handle.writable && !handle.closed {
+		if handle != nil && handle.inode == inode && !handle.writable && !handle.closed && !samePosixActor(handle.actor, actor) {
 			return true
 		}
 	}
 	return false
+}
+
+func (s *s3Session) sameActorWritableHandle(inode uint64, actor *pb.PosixActor) (uint64, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for id, handle := range s.handles {
+		if handle != nil && handle.inode == inode && handle.writable && !handle.closed && !handle.failed && samePosixActor(handle.actor, actor) {
+			return id, true
+		}
+	}
+	return 0, false
 }
 
 func (s *s3Session) takeHandle(handleID uint64) *s3Handle {
@@ -919,7 +1061,7 @@ func (s *s3Session) takeHandle(handleID uint64) *s3Handle {
 	return handle
 }
 
-func (s *s3Session) handlelessWritableHandle(inode uint64) (*s3Handle, error) {
+func (s *s3Session) handlelessWritableHandle(inode uint64, actor *pb.PosixActor) (*s3Handle, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if handle := s.implicit[inode]; handle != nil {
@@ -945,7 +1087,7 @@ func (s *s3Session) handlelessWritableHandle(inode uint64) (*s3Handle, error) {
 	if node.kind != s3NodeFile {
 		return nil, syscall.EISDIR
 	}
-	handle := &s3Handle{inode: inode, path: node.path, writable: true}
+	handle := &s3Handle{inode: inode, path: node.path, writable: true, actor: actor}
 	s.implicit[inode] = handle
 	return handle, nil
 }
@@ -966,6 +1108,39 @@ func (s *s3Session) takeHandlelessWritableHandle(inode uint64) *s3Handle {
 	return nil
 }
 
+func (s *s3Session) dropFailedHandle(handleID, inode uint64, target *s3Handle) {
+	if target == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if handleID != 0 {
+		if s.handles[handleID] == target {
+			delete(s.handles, handleID)
+		}
+	}
+	if s.implicit[inode] == target {
+		delete(s.implicit, inode)
+	}
+	for id, handle := range s.handles {
+		if handle == target {
+			delete(s.handles, id)
+		}
+	}
+	for handleInode, handle := range s.implicit {
+		if handle == target {
+			delete(s.implicit, handleInode)
+		}
+	}
+}
+
+func samePosixActor(a, b *pb.PosixActor) bool {
+	if a == nil || b == nil || a.Pid == 0 || b.Pid == 0 {
+		return false
+	}
+	return a.Pid == b.Pid
+}
+
 func (s *s3Session) updateNodeSize(inode uint64, size int64) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -980,7 +1155,7 @@ func (s *s3Session) commitHandle(_ context.Context, handle *s3Handle) error {
 		return nil
 	}
 	if handle.failed {
-		s.forgetPath(handle.path)
+		s.discardFailedWrite(handle)
 		return nil
 	}
 	if err := s.store.Put(handle.path, bytes.NewReader(handle.buffer.Bytes())); err != nil {
@@ -989,6 +1164,31 @@ func (s *s3Session) commitHandle(_ context.Context, handle *s3Handle) error {
 	handle.committed = true
 	s.rememberPath(handle.path, s3NodeFile, int64(handle.buffer.Len()), time.Now().UTC())
 	return nil
+}
+
+func (s *s3Session) discardFailedWrite(handle *s3Handle) {
+	if handle == nil {
+		return
+	}
+	if node, ok := s.nodeForPath(handle.path); ok && node.inode == handle.inode && node.localOnly {
+		s.forgetPath(handle.path)
+		return
+	}
+	if info, err := s.store.Head(handle.path); err == nil {
+		s.rememberPath(handle.path, s3NodeFile, info.Size, info.Modified)
+	}
+}
+
+func (s *s3Session) setAttrRequestsModeChange(req *pb.SetAttrRequest, node *s3Node) bool {
+	if req == nil || req.Attr == nil || node == nil {
+		return false
+	}
+	if req.Valid&uint32(fuse.FATTR_MODE) == 0 {
+		return false
+	}
+	currentPerm := s.attr(node).Mode & 0o7777
+	requestedPerm := req.Attr.Mode & 0o7777
+	return requestedPerm != currentPerm
 }
 
 func (s *s3Session) ensureWritable() error {

--- a/ctld/internal/ctld/portal/s3_session_test.go
+++ b/ctld/internal/ctld/portal/s3_session_test.go
@@ -194,8 +194,16 @@ func TestS3SessionSeesExternalObjectsAndWritesBackNewFiles(t *testing.T) {
 	if _, err := session.SetAttr(ctx, &pb.SetAttrRequest{
 		Inode:    created.Inode,
 		HandleId: reopened.HandleId,
-		Valid:    fuseFattrSize | fuseFattrNoopMask,
-		Attr:     &pb.GetAttrResponse{Size: 0},
+		Valid:    s3MetadataSetAttrNoopMask,
+		Attr:     &pb.GetAttrResponse{Mode: s3FileMode | 0o600},
+	}); err != nil {
+		t.Fatalf("SetAttr(metadata with writable handle) error = %v", err)
+	}
+	if _, err := session.SetAttr(ctx, &pb.SetAttrRequest{
+		Inode:    created.Inode,
+		HandleId: reopened.HandleId,
+		Valid:    fuseFattrSize | fuseFattrNoopMask | s3MetadataSetAttrNoopMask,
+		Attr:     &pb.GetAttrResponse{Size: 0, Mode: s3FileMode},
 	}); err != nil {
 		t.Fatalf("SetAttr(truncate with writable handle) error = %v", err)
 	}
@@ -207,6 +215,144 @@ func TestS3SessionSeesExternalObjectsAndWritesBackNewFiles(t *testing.T) {
 		t.Fatalf("Release(replacement) error = %v", err)
 	}
 	assertS3TestObject(t, store, "from-sandbox/new.txt", "replacement")
+
+	failedAppend, err := session.Open(ctx, &pb.OpenRequest{
+		Inode: created.Inode,
+		Flags: uint32(syscall.O_WRONLY),
+	})
+	if err != nil {
+		t.Fatalf("Open(new.txt failed append simulation) error = %v", err)
+	}
+	if _, err := session.Write(ctx, &pb.WriteRequest{
+		Inode:    created.Inode,
+		HandleId: failedAppend.HandleId,
+		Offset:   int64(len("replacement")),
+		Data:     []byte("append"),
+	}); fserror.CodeOf(err) != fserror.InvalidArgument {
+		t.Fatalf("Write(failed append simulation) error = %v, want InvalidArgument", err)
+	}
+	afterFailedAppend, err := session.GetAttr(ctx, &pb.GetAttrRequest{Inode: created.Inode})
+	if err != nil {
+		t.Fatalf("GetAttr(new.txt after failed append simulation) error = %v", err)
+	}
+	if afterFailedAppend.Size != uint64(len("replacement")) {
+		t.Fatalf("new.txt size after failed append simulation = %d, want %d", afterFailedAppend.Size, len("replacement"))
+	}
+	assertS3TestObject(t, store, "from-sandbox/new.txt", "replacement")
+
+	_, err = session.Open(ctx, &pb.OpenRequest{
+		Inode: created.Inode,
+		Flags: uint32(syscall.O_WRONLY | syscall.O_APPEND),
+	})
+	if fserror.CodeOf(err) != fserror.InvalidArgument {
+		t.Fatalf("Open(new.txt O_APPEND) error = %v, want InvalidArgument", err)
+	}
+	afterAppendOpen, err := session.GetAttr(ctx, &pb.GetAttrRequest{Inode: created.Inode})
+	if err != nil {
+		t.Fatalf("GetAttr(new.txt after O_APPEND) error = %v", err)
+	}
+	if afterAppendOpen.Size != uint64(len("replacement")) {
+		t.Fatalf("new.txt size after O_APPEND = %d, want %d", afterAppendOpen.Size, len("replacement"))
+	}
+	assertS3TestObject(t, store, "from-sandbox/new.txt", "replacement")
+
+	_, err = session.Create(ctx, &pb.CreateRequest{
+		Parent: fromSandbox.Inode,
+		Name:   "new.txt",
+		Flags:  uint32(syscall.O_WRONLY | syscall.O_CREAT | syscall.O_APPEND),
+	})
+	if fserror.CodeOf(err) != fserror.InvalidArgument {
+		t.Fatalf("Create(existing new.txt O_APPEND) error = %v, want InvalidArgument", err)
+	}
+	_, err = session.Create(ctx, &pb.CreateRequest{
+		Parent: fromSandbox.Inode,
+		Name:   "append-new.txt",
+		Flags:  uint32(syscall.O_WRONLY | syscall.O_CREAT | syscall.O_APPEND),
+	})
+	if fserror.CodeOf(err) != fserror.InvalidArgument {
+		t.Fatalf("Create(new append-new.txt O_APPEND) error = %v, want InvalidArgument", err)
+	}
+	assertS3TestObject(t, store, "from-sandbox/new.txt", "replacement")
+
+	blockingReader, err := session.Open(ctx, &pb.OpenRequest{Inode: created.Inode})
+	if err != nil {
+		t.Fatalf("Open(blocking reader) error = %v", err)
+	}
+	_, err = session.Open(ctx, &pb.OpenRequest{
+		Inode: created.Inode,
+		Flags: uint32(syscall.O_WRONLY | syscall.O_TRUNC),
+	})
+	if !errors.Is(err, syscall.EPERM) {
+		t.Fatalf("Open(writer while reader open) error = %v, want EPERM", err)
+	}
+	if _, err := session.Release(ctx, &pb.ReleaseRequest{HandleId: blockingReader.HandleId}); err != nil {
+		t.Fatalf("Release(blocking reader) error = %v", err)
+	}
+	assertS3TestObject(t, store, "from-sandbox/new.txt", "replacement")
+
+	putS3TestObject(t, store, "from-sandbox/actor-truncate.txt", "actor-base")
+	actorNode, err := session.Lookup(ctx, &pb.LookupRequest{Parent: fromSandbox.Inode, Name: "actor-truncate.txt"})
+	if err != nil {
+		t.Fatalf("Lookup(actor-truncate.txt) error = %v", err)
+	}
+	gvisorActor := &pb.PosixActor{Pid: 42, Uid: 1000, Gids: []uint32{1000}}
+	actorReader, err := session.Open(ctx, &pb.OpenRequest{Inode: actorNode.Inode, Actor: gvisorActor})
+	if err != nil {
+		t.Fatalf("Open(actor reader) error = %v", err)
+	}
+	actorWriter, err := session.Open(ctx, &pb.OpenRequest{
+		Inode: actorNode.Inode,
+		Flags: uint32(syscall.O_WRONLY | syscall.O_TRUNC),
+		Actor: gvisorActor,
+	})
+	if err != nil {
+		t.Fatalf("Open(same actor writer while reader open) error = %v", err)
+	}
+	duplicateActorWriter, err := session.Open(ctx, &pb.OpenRequest{
+		Inode: actorNode.Inode,
+		Flags: uint32(syscall.O_WRONLY | syscall.O_TRUNC),
+		Actor: gvisorActor,
+	})
+	if err != nil {
+		t.Fatalf("Open(same actor duplicate writer) error = %v", err)
+	}
+	if duplicateActorWriter.HandleId != actorWriter.HandleId {
+		t.Fatalf("Open(same actor duplicate writer) handle = %d, want %d", duplicateActorWriter.HandleId, actorWriter.HandleId)
+	}
+	if _, err := session.Release(ctx, &pb.ReleaseRequest{HandleId: actorWriter.HandleId}); err != nil {
+		t.Fatalf("Release(same actor writer) error = %v", err)
+	}
+	if _, err := session.Release(ctx, &pb.ReleaseRequest{HandleId: duplicateActorWriter.HandleId}); err != nil {
+		t.Fatalf("Release(same actor duplicate writer) error = %v", err)
+	}
+	if _, err := session.Release(ctx, &pb.ReleaseRequest{HandleId: actorReader.HandleId}); err != nil {
+		t.Fatalf("Release(actor reader) error = %v", err)
+	}
+	assertS3TestObject(t, store, "from-sandbox/actor-truncate.txt", "")
+
+	putS3TestObject(t, store, "from-sandbox/actor-blocked.txt", "actor-blocked")
+	blockedNode, err := session.Lookup(ctx, &pb.LookupRequest{Parent: fromSandbox.Inode, Name: "actor-blocked.txt"})
+	if err != nil {
+		t.Fatalf("Lookup(actor-blocked.txt) error = %v", err)
+	}
+	otherReader, err := session.Open(ctx, &pb.OpenRequest{
+		Inode: blockedNode.Inode,
+		Actor: &pb.PosixActor{Pid: 100, Uid: 1000, Gids: []uint32{1000}},
+	})
+	if err != nil {
+		t.Fatalf("Open(other actor reader) error = %v", err)
+	}
+	if _, err := session.Open(ctx, &pb.OpenRequest{
+		Inode: blockedNode.Inode,
+		Flags: uint32(syscall.O_WRONLY | syscall.O_TRUNC),
+		Actor: &pb.PosixActor{Pid: 200, Uid: 1000, Gids: []uint32{1000}},
+	}); !errors.Is(err, syscall.EPERM) {
+		t.Fatalf("Open(different actor writer while reader open) error = %v, want EPERM", err)
+	}
+	if _, err := session.Release(ctx, &pb.ReleaseRequest{HandleId: otherReader.HandleId}); err != nil {
+		t.Fatalf("Release(other actor reader) error = %v", err)
+	}
+	assertS3TestObject(t, store, "from-sandbox/actor-blocked.txt", "actor-blocked")
 
 	if _, err := session.SetAttr(ctx, &pb.SetAttrRequest{
 		Inode: created.Inode,
@@ -220,13 +366,47 @@ func TestS3SessionSeesExternalObjectsAndWritesBackNewFiles(t *testing.T) {
 	if _, err := session.SetAttr(ctx, &pb.SetAttrRequest{
 		Inode: created.Inode,
 		Valid: 1,
-		Attr:  &pb.GetAttrResponse{Mode: s3FileMode | 0o600},
-	}); !errors.Is(err, syscall.EOPNOTSUPP) {
-		t.Fatalf("SetAttr(mode) error = %v, want EOPNOTSUPP", err)
+		Attr:  &pb.GetAttrResponse{Mode: (s3FileMode &^ 0o777) | 0o600},
+	}); !errors.Is(err, syscall.EPERM) {
+		t.Fatalf("SetAttr(mode) error = %v, want EPERM", err)
 	}
-	if _, err := session.ListXattr(ctx, &pb.ListXattrRequest{Inode: created.Inode}); !errors.Is(err, syscall.EOPNOTSUPP) {
-		t.Fatalf("ListXattr() error = %v, want EOPNOTSUPP", err)
+	if _, err := session.SetAttr(ctx, &pb.SetAttrRequest{
+		Inode: created.Inode,
+		Valid: fuseFattrNoopMask,
+		Attr:  &pb.GetAttrResponse{Mode: (s3FileMode &^ 0o777) | 0o600},
+	}); err != nil {
+		t.Fatalf("SetAttr(mode without valid mode bit) error = %v", err)
 	}
+	xattrs, err := session.ListXattr(ctx, &pb.ListXattrRequest{Inode: created.Inode})
+	if err != nil {
+		t.Fatalf("ListXattr() error = %v", err)
+	}
+	if len(xattrs.GetData()) != 0 {
+		t.Fatalf("ListXattr() data = %q, want empty", xattrs.GetData())
+	}
+	if _, err := session.Rename(ctx, &pb.RenameRequest{
+		OldParent: fromSandbox.Inode,
+		OldName:   "new.txt",
+		NewParent: fromSandbox.Inode,
+		NewName:   "renamed.txt",
+	}); !errors.Is(err, syscall.EPERM) {
+		t.Fatalf("Rename() error = %v, want EPERM", err)
+	}
+	assertS3TestObject(t, store, "from-sandbox/new.txt", "")
+	assertS3TestObjectMissing(t, store, "from-sandbox/renamed.txt")
+
+	if _, err := session.Write(ctx, &pb.WriteRequest{
+		Inode:    created.Inode,
+		HandleId: 0,
+		Offset:   1,
+		Data:     []byte("x"),
+	}); fserror.CodeOf(err) != fserror.InvalidArgument {
+		t.Fatalf("Write(handle-less non-sequential existing object) error = %v, want InvalidArgument", err)
+	}
+	if _, err := session.Lookup(ctx, &pb.LookupRequest{Parent: fromSandbox.Inode, Name: "new.txt"}); err != nil {
+		t.Fatalf("Lookup(new.txt after failed handle-less write) error = %v", err)
+	}
+	assertS3TestObject(t, store, "from-sandbox/new.txt", "")
 
 	implicitCreated, err := session.Create(ctx, &pb.CreateRequest{Parent: fromSandbox.Inode, Name: "implicit.txt"})
 	if err != nil {
@@ -263,6 +443,30 @@ func TestS3SessionSeesExternalObjectsAndWritesBackNewFiles(t *testing.T) {
 		t.Fatalf("Release(non-sequential.txt) error = %v", err)
 	}
 	assertS3TestObjectMissing(t, store, "from-sandbox/non-sequential.txt")
+	if _, err := session.Lookup(ctx, &pb.LookupRequest{Parent: fromSandbox.Inode, Name: "non-sequential.txt"}); fserror.CodeOf(err) != fserror.NotFound {
+		t.Fatalf("Lookup(non-sequential.txt after failed write) error = %v, want NotFound", err)
+	}
+
+	handlelessPending, err := session.Mknod(ctx, &pb.MknodRequest{
+		Parent: fromSandbox.Inode,
+		Name:   "handleless-non-sequential.txt",
+		Mode:   0o644,
+	})
+	if err != nil {
+		t.Fatalf("Mknod(handleless-non-sequential.txt) error = %v", err)
+	}
+	if _, err := session.Write(ctx, &pb.WriteRequest{
+		Inode:    handlelessPending.Inode,
+		HandleId: 0,
+		Offset:   1,
+		Data:     []byte("x"),
+	}); fserror.CodeOf(err) != fserror.InvalidArgument {
+		t.Fatalf("Write(handle-less non-sequential pending file) error = %v, want InvalidArgument", err)
+	}
+	if _, err := session.Lookup(ctx, &pb.LookupRequest{Parent: fromSandbox.Inode, Name: "handleless-non-sequential.txt"}); fserror.CodeOf(err) != fserror.NotFound {
+		t.Fatalf("Lookup(handleless-non-sequential.txt after failed write) error = %v, want NotFound", err)
+	}
+	assertS3TestObjectMissing(t, store, "from-sandbox/handleless-non-sequential.txt")
 
 	entriesResp, err := session.ReadDir(ctx, &pb.ReadDirRequest{Inode: s3RootInode, Plus: true})
 	if err != nil {
@@ -306,6 +510,83 @@ func TestS3SessionMkdirUsesMountpointLocalDirectorySemantics(t *testing.T) {
 	}
 	if _, err := session.Lookup(ctx, &pb.LookupRequest{Parent: s3RootInode, Name: "local"}); fserror.CodeOf(err) != fserror.NotFound {
 		t.Fatalf("Lookup(local after rmdir) error = %v, want NotFound", err)
+	}
+
+	mknodLocal, err := session.Mknod(ctx, &pb.MknodRequest{
+		Parent: s3RootInode,
+		Name:   "mknod-local",
+		Mode:   uint32(syscall.S_IFDIR | 0o755),
+	})
+	if err != nil {
+		t.Fatalf("Mknod(mknod-local dir) error = %v", err)
+	}
+	if mknodLocal.Attr.Mode&uint32(syscall.S_IFMT) != uint32(syscall.S_IFDIR) {
+		t.Fatalf("mknod-local mode = %#o, want directory", mknodLocal.Attr.Mode)
+	}
+	assertS3TestObjectMissing(t, store, "mknod-local/")
+	if _, err := session.Lookup(ctx, &pb.LookupRequest{Parent: s3RootInode, Name: "mknod-local"}); err != nil {
+		t.Fatalf("Lookup(mknod-local) error = %v", err)
+	}
+	if _, err := session.SetAttr(ctx, &pb.SetAttrRequest{
+		Inode: mknodLocal.Inode,
+		Valid: s3MetadataSetAttrNoopMask,
+		Attr:  &pb.GetAttrResponse{Mode: uint32(syscall.S_IFDIR | 0o700)},
+	}); err != nil {
+		t.Fatalf("SetAttr(mknod-local mode no-op) error = %v", err)
+	}
+	mknodFile, err := session.Mknod(ctx, &pb.MknodRequest{
+		Parent: s3RootInode,
+		Name:   "mknod-file-no-type",
+		Mode:   0o755,
+	})
+	if err != nil {
+		t.Fatalf("Mknod(mknod-file-no-type) error = %v", err)
+	}
+	if mknodFile.Attr.Mode&uint32(syscall.S_IFMT) != uint32(syscall.S_IFREG) {
+		t.Fatalf("mknod-file-no-type mode = %#o, want file", mknodFile.Attr.Mode)
+	}
+	assertS3TestObjectMissing(t, store, "mknod-file-no-type")
+	putS3TestObject(t, store, "mknod-file-no-type", "external overwrite")
+	promoted, err := session.Lookup(ctx, &pb.LookupRequest{Parent: s3RootInode, Name: "mknod-file-no-type"})
+	if err != nil {
+		t.Fatalf("Lookup(mknod-file-no-type promoted from S3) error = %v", err)
+	}
+	if promoted.Attr.Size != uint64(len("external overwrite")) {
+		t.Fatalf("promoted mknod-file-no-type size = %d, want %d", promoted.Attr.Size, len("external overwrite"))
+	}
+	if _, err := session.Unlink(ctx, &pb.UnlinkRequest{Parent: s3RootInode, Name: "mknod-file-no-type"}); err != nil {
+		t.Fatalf("Unlink(promoted mknod-file-no-type) error = %v", err)
+	}
+	mknodFile, err = session.Mknod(ctx, &pb.MknodRequest{
+		Parent: s3RootInode,
+		Name:   "mknod-file-no-type",
+		Mode:   0o755,
+	})
+	if err != nil {
+		t.Fatalf("Mknod(mknod-file-no-type after promoted unlink) error = %v", err)
+	}
+	mknodOpen, err := session.Open(ctx, &pb.OpenRequest{Inode: mknodFile.Inode, Flags: uint32(syscall.O_WRONLY)})
+	if err != nil {
+		t.Fatalf("Open(mknod-file-no-type) error = %v", err)
+	}
+	if _, err := session.Write(ctx, &pb.WriteRequest{
+		Inode:    mknodFile.Inode,
+		HandleId: mknodOpen.HandleId,
+		Data:     []byte("mknod payload"),
+	}); err != nil {
+		t.Fatalf("Write(mknod-file-no-type) error = %v", err)
+	}
+	assertS3TestObjectMissing(t, store, "mknod-file-no-type")
+	if _, err := session.Release(ctx, &pb.ReleaseRequest{Inode: mknodFile.Inode, HandleId: mknodOpen.HandleId}); err != nil {
+		t.Fatalf("Release(mknod-file-no-type) error = %v", err)
+	}
+	assertS3TestObject(t, store, "mknod-file-no-type", "mknod payload")
+	if _, err := session.Mknod(ctx, &pb.MknodRequest{
+		Parent: s3RootInode,
+		Name:   "special-node",
+		Mode:   uint32(syscall.S_IFCHR | 0o600),
+	}); !errors.Is(err, syscall.EOPNOTSUPP) {
+		t.Fatalf("Mknod(special-node) error = %v, want EOPNOTSUPP", err)
 	}
 
 	nested, err := session.Mkdir(ctx, &pb.MkdirRequest{Parent: s3RootInode, Name: "nested"})

--- a/ctld/internal/ctld/portal/s3_session_test.go
+++ b/ctld/internal/ctld/portal/s3_session_test.go
@@ -290,6 +290,27 @@ func TestS3SessionSeesExternalObjectsAndWritesBackNewFiles(t *testing.T) {
 	}
 	assertS3TestObject(t, store, "from-sandbox/new.txt", "replacement")
 
+	stalePathReader := session.newHandle(&s3Handle{
+		inode: created.Inode,
+		path:  "from-sandbox/stale-reader.txt",
+		actor: &pb.PosixActor{Pid: 300, Uid: 1000, Gids: []uint32{1000}},
+	})
+	writerAfterStalePath, err := session.Open(ctx, &pb.OpenRequest{
+		Inode: created.Inode,
+		Flags: uint32(syscall.O_WRONLY | syscall.O_TRUNC),
+		Actor: &pb.PosixActor{Pid: 400, Uid: 1000, Gids: []uint32{1000}},
+	})
+	if err != nil {
+		t.Fatalf("Open(writer with stale different-path reader) error = %v", err)
+	}
+	if _, err := session.Release(ctx, &pb.ReleaseRequest{HandleId: writerAfterStalePath.HandleId}); err != nil {
+		t.Fatalf("Release(writer with stale different-path reader) error = %v", err)
+	}
+	if _, err := session.Release(ctx, &pb.ReleaseRequest{HandleId: stalePathReader}); err != nil {
+		t.Fatalf("Release(stale different-path reader) error = %v", err)
+	}
+	assertS3TestObject(t, store, "from-sandbox/new.txt", "")
+
 	putS3TestObject(t, store, "from-sandbox/actor-truncate.txt", "actor-base")
 	actorNode, err := session.Lookup(ctx, &pb.LookupRequest{Parent: fromSandbox.Inode, Name: "actor-truncate.txt"})
 	if err != nil {
@@ -329,6 +350,35 @@ func TestS3SessionSeesExternalObjectsAndWritesBackNewFiles(t *testing.T) {
 		t.Fatalf("Release(actor reader) error = %v", err)
 	}
 	assertS3TestObject(t, store, "from-sandbox/actor-truncate.txt", "")
+
+	putS3TestObject(t, store, "from-sandbox/actor-read-blocked.txt", "actor-read-blocked")
+	readBlockedNode, err := session.Lookup(ctx, &pb.LookupRequest{Parent: fromSandbox.Inode, Name: "actor-read-blocked.txt"})
+	if err != nil {
+		t.Fatalf("Lookup(actor-read-blocked.txt) error = %v", err)
+	}
+	readBlockedReader, err := session.Open(ctx, &pb.OpenRequest{Inode: readBlockedNode.Inode, Actor: gvisorActor})
+	if err != nil {
+		t.Fatalf("Open(same actor active reader) error = %v", err)
+	}
+	if _, err := session.Read(ctx, &pb.ReadRequest{
+		Inode:    readBlockedNode.Inode,
+		HandleId: readBlockedReader.HandleId,
+		Size:     1,
+		Actor:    gvisorActor,
+	}); err != nil {
+		t.Fatalf("Read(same actor active reader) error = %v", err)
+	}
+	if _, err := session.Open(ctx, &pb.OpenRequest{
+		Inode: readBlockedNode.Inode,
+		Flags: uint32(syscall.O_WRONLY | syscall.O_TRUNC),
+		Actor: gvisorActor,
+	}); !errors.Is(err, syscall.EPERM) {
+		t.Fatalf("Open(same actor writer while active reader open) error = %v, want EPERM", err)
+	}
+	if _, err := session.Release(ctx, &pb.ReleaseRequest{HandleId: readBlockedReader.HandleId}); err != nil {
+		t.Fatalf("Release(same actor active reader) error = %v", err)
+	}
+	assertS3TestObject(t, store, "from-sandbox/actor-read-blocked.txt", "actor-read-blocked")
 
 	putS3TestObject(t, store, "from-sandbox/actor-blocked.txt", "actor-blocked")
 	blockedNode, err := session.Lookup(ctx, &pb.LookupRequest{Parent: fromSandbox.Inode, Name: "actor-blocked.txt"})

--- a/ctld/internal/ctld/portal/s3_session_test.go
+++ b/ctld/internal/ctld/portal/s3_session_test.go
@@ -216,19 +216,27 @@ func TestS3SessionSeesExternalObjectsAndWritesBackNewFiles(t *testing.T) {
 	}
 	assertS3TestObject(t, store, "from-sandbox/new.txt", "replacement")
 
-	_, err = session.Open(ctx, &pb.OpenRequest{
+	failedAppend, err := session.Open(ctx, &pb.OpenRequest{
 		Inode: created.Inode,
 		Flags: uint32(syscall.O_WRONLY),
 	})
-	if !errors.Is(err, syscall.EPERM) {
-		t.Fatalf("Open(new.txt write without O_TRUNC) error = %v, want EPERM", err)
-	}
-	afterWriteWithoutTruncOpen, err := session.GetAttr(ctx, &pb.GetAttrRequest{Inode: created.Inode})
 	if err != nil {
-		t.Fatalf("GetAttr(new.txt after write without O_TRUNC) error = %v", err)
+		t.Fatalf("Open(new.txt failed append simulation) error = %v", err)
 	}
-	if afterWriteWithoutTruncOpen.Size != uint64(len("replacement")) {
-		t.Fatalf("new.txt size after write without O_TRUNC = %d, want %d", afterWriteWithoutTruncOpen.Size, len("replacement"))
+	if _, err := session.Write(ctx, &pb.WriteRequest{
+		Inode:    created.Inode,
+		HandleId: failedAppend.HandleId,
+		Offset:   int64(len("replacement")),
+		Data:     []byte("append"),
+	}); fserror.CodeOf(err) != fserror.InvalidArgument {
+		t.Fatalf("Write(failed append simulation) error = %v, want InvalidArgument", err)
+	}
+	afterFailedAppend, err := session.GetAttr(ctx, &pb.GetAttrRequest{Inode: created.Inode})
+	if err != nil {
+		t.Fatalf("GetAttr(new.txt after failed append simulation) error = %v", err)
+	}
+	if afterFailedAppend.Size != uint64(len("replacement")) {
+		t.Fatalf("new.txt size after failed append simulation = %d, want %d", afterFailedAppend.Size, len("replacement"))
 	}
 	assertS3TestObject(t, store, "from-sandbox/new.txt", "replacement")
 
@@ -255,14 +263,6 @@ func TestS3SessionSeesExternalObjectsAndWritesBackNewFiles(t *testing.T) {
 	})
 	if fserror.CodeOf(err) != fserror.InvalidArgument {
 		t.Fatalf("Create(existing new.txt O_APPEND) error = %v, want InvalidArgument", err)
-	}
-	_, err = session.Create(ctx, &pb.CreateRequest{
-		Parent: fromSandbox.Inode,
-		Name:   "new.txt",
-		Flags:  uint32(syscall.O_WRONLY | syscall.O_CREAT),
-	})
-	if !errors.Is(err, syscall.EPERM) {
-		t.Fatalf("Create(existing new.txt without O_TRUNC) error = %v, want EPERM", err)
 	}
 	_, err = session.Create(ctx, &pb.CreateRequest{
 		Parent: fromSandbox.Inode,

--- a/ctld/internal/ctld/portal/s3_session_test.go
+++ b/ctld/internal/ctld/portal/s3_session_test.go
@@ -363,12 +363,16 @@ func TestS3SessionSeesExternalObjectsAndWritesBackNewFiles(t *testing.T) {
 	}
 	assertS3TestObject(t, store, "from-sandbox/new.txt", "")
 
-	if _, err := session.SetAttr(ctx, &pb.SetAttrRequest{
+	modeNoop, err := session.SetAttr(ctx, &pb.SetAttrRequest{
 		Inode: created.Inode,
 		Valid: 1,
 		Attr:  &pb.GetAttrResponse{Mode: (s3FileMode &^ 0o777) | 0o600},
-	}); !errors.Is(err, syscall.EPERM) {
-		t.Fatalf("SetAttr(mode) error = %v, want EPERM", err)
+	})
+	if err != nil {
+		t.Fatalf("SetAttr(mode no-op) error = %v", err)
+	}
+	if modeNoop.Attr.Mode != s3FileMode {
+		t.Fatalf("SetAttr(mode no-op) mode = %#o, want %#o", modeNoop.Attr.Mode, s3FileMode)
 	}
 	if _, err := session.SetAttr(ctx, &pb.SetAttrRequest{
 		Inode: created.Inode,

--- a/ctld/internal/ctld/portal/s3_session_test.go
+++ b/ctld/internal/ctld/portal/s3_session_test.go
@@ -216,27 +216,19 @@ func TestS3SessionSeesExternalObjectsAndWritesBackNewFiles(t *testing.T) {
 	}
 	assertS3TestObject(t, store, "from-sandbox/new.txt", "replacement")
 
-	failedAppend, err := session.Open(ctx, &pb.OpenRequest{
+	_, err = session.Open(ctx, &pb.OpenRequest{
 		Inode: created.Inode,
 		Flags: uint32(syscall.O_WRONLY),
 	})
+	if !errors.Is(err, syscall.EPERM) {
+		t.Fatalf("Open(new.txt write without O_TRUNC) error = %v, want EPERM", err)
+	}
+	afterWriteWithoutTruncOpen, err := session.GetAttr(ctx, &pb.GetAttrRequest{Inode: created.Inode})
 	if err != nil {
-		t.Fatalf("Open(new.txt failed append simulation) error = %v", err)
+		t.Fatalf("GetAttr(new.txt after write without O_TRUNC) error = %v", err)
 	}
-	if _, err := session.Write(ctx, &pb.WriteRequest{
-		Inode:    created.Inode,
-		HandleId: failedAppend.HandleId,
-		Offset:   int64(len("replacement")),
-		Data:     []byte("append"),
-	}); fserror.CodeOf(err) != fserror.InvalidArgument {
-		t.Fatalf("Write(failed append simulation) error = %v, want InvalidArgument", err)
-	}
-	afterFailedAppend, err := session.GetAttr(ctx, &pb.GetAttrRequest{Inode: created.Inode})
-	if err != nil {
-		t.Fatalf("GetAttr(new.txt after failed append simulation) error = %v", err)
-	}
-	if afterFailedAppend.Size != uint64(len("replacement")) {
-		t.Fatalf("new.txt size after failed append simulation = %d, want %d", afterFailedAppend.Size, len("replacement"))
+	if afterWriteWithoutTruncOpen.Size != uint64(len("replacement")) {
+		t.Fatalf("new.txt size after write without O_TRUNC = %d, want %d", afterWriteWithoutTruncOpen.Size, len("replacement"))
 	}
 	assertS3TestObject(t, store, "from-sandbox/new.txt", "replacement")
 
@@ -263,6 +255,14 @@ func TestS3SessionSeesExternalObjectsAndWritesBackNewFiles(t *testing.T) {
 	})
 	if fserror.CodeOf(err) != fserror.InvalidArgument {
 		t.Fatalf("Create(existing new.txt O_APPEND) error = %v, want InvalidArgument", err)
+	}
+	_, err = session.Create(ctx, &pb.CreateRequest{
+		Parent: fromSandbox.Inode,
+		Name:   "new.txt",
+		Flags:  uint32(syscall.O_WRONLY | syscall.O_CREAT),
+	})
+	if !errors.Is(err, syscall.EPERM) {
+		t.Fatalf("Create(existing new.txt without O_TRUNC) error = %v, want EPERM", err)
 	}
 	_, err = session.Create(ctx, &pb.CreateRequest{
 		Parent: fromSandbox.Inode,

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -929,11 +929,7 @@ func (s *SandboxService) bindVolumePortals(ctx context.Context, pod *corev1.Pod,
 	for _, mount := range req.Mounts {
 		mountPoint := filepath.Clean(mount.MountPoint)
 		decl := declared[mountPoint]
-		info, err := s.validateVolumePortalAccess(ctx, req.TeamID, req.UserID, mount.SandboxVolumeID, decl)
-		if err != nil {
-			return nil, err
-		}
-		if err := validateVolumePortalRuntimeCompatibility(pod, info, mountPoint); err != nil {
+		if err := s.validateVolumePortalAccess(ctx, req.TeamID, req.UserID, mount.SandboxVolumeID, decl); err != nil {
 			return nil, err
 		}
 		resp, err := s.bindVolumePortal(ctx, pod, req.TeamID, req.UserID, req.TeamID, mount.SandboxVolumeID, mountPoint, decl.Name)
@@ -951,13 +947,13 @@ func (s *SandboxService) bindVolumePortals(ctx context.Context, pod *corev1.Pod,
 	return out, nil
 }
 
-func (s *SandboxService) validateVolumePortalAccess(ctx context.Context, teamID, userID, volumeID string, mount v1alpha1.VolumeMountSpec) (*SandboxVolumeInfo, error) {
+func (s *SandboxService) validateVolumePortalAccess(ctx context.Context, teamID, userID, volumeID string, mount v1alpha1.VolumeMountSpec) error {
 	if s.volumeMetadata == nil {
-		return nil, fmt.Errorf("volume metadata client is not configured")
+		return fmt.Errorf("volume metadata client is not configured")
 	}
 	info, err := s.volumeMetadata.Get(ctx, teamID, userID, volumeID)
 	if err != nil {
-		return nil, fmt.Errorf("get volume metadata for %s: %w", volumeID, err)
+		return fmt.Errorf("get volume metadata for %s: %w", volumeID, err)
 	}
 	accessMode := strings.ToUpper(strings.TrimSpace(info.AccessMode))
 	if accessMode == "" {
@@ -965,35 +961,17 @@ func (s *SandboxService) validateVolumePortalAccess(ctx context.Context, teamID,
 	}
 	switch accessMode {
 	case "RWO":
-		return info, nil
+		return nil
 	case "ROX":
 		if mount.ReadOnly {
-			return info, nil
+			return nil
 		}
-		return nil, fmt.Errorf("%w: volume %s is ROX but template mount %s is read-write", ErrInvalidClaimRequest, volumeID, mount.MountPath)
+		return fmt.Errorf("%w: volume %s is ROX but template mount %s is read-write", ErrInvalidClaimRequest, volumeID, mount.MountPath)
 	case "RWX":
-		return nil, fmt.Errorf("%w: RWX volumes require the shared correctness path and cannot use node-local volume portals yet", ErrInvalidClaimRequest)
+		return fmt.Errorf("%w: RWX volumes require the shared correctness path and cannot use node-local volume portals yet", ErrInvalidClaimRequest)
 	default:
-		return nil, fmt.Errorf("%w: volume %s has invalid access_mode %q", ErrInvalidClaimRequest, volumeID, info.AccessMode)
+		return fmt.Errorf("%w: volume %s has invalid access_mode %q", ErrInvalidClaimRequest, volumeID, info.AccessMode)
 	}
-}
-
-func validateVolumePortalRuntimeCompatibility(pod *corev1.Pod, info *SandboxVolumeInfo, mountPoint string) error {
-	if info == nil || strings.ToLower(strings.TrimSpace(info.Backend)) != "s3" {
-		return nil
-	}
-	runtimeClassName := runtimeClassNameForPod(pod)
-	if runtimeClassName == "" || strings.Contains(runtimeClassName, "runc") {
-		return nil
-	}
-	return fmt.Errorf("%w: s3 volume %s requires a runc-compatible sandbox runtime for mount-s3-compatible volume portal semantics; runtimeClassName %q is not supported for mount %s", ErrInvalidClaimRequest, info.ID, runtimeClassName, mountPoint)
-}
-
-func runtimeClassNameForPod(pod *corev1.Pod) string {
-	if pod == nil || pod.Spec.RuntimeClassName == nil {
-		return ""
-	}
-	return strings.ToLower(strings.TrimSpace(*pod.Spec.RuntimeClassName))
 }
 
 func (s *SandboxService) bindWebhookStatePortal(ctx context.Context, pod *corev1.Pod, req *ClaimRequest) error {

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -1774,7 +1774,7 @@ func TestValidateClaimMountsForTemplateAllowsDeclaredMountPoint(t *testing.T) {
 func TestValidateVolumePortalAccessRejectsRWXNodeLocalPortal(t *testing.T) {
 	svc := &SandboxService{volumeMetadata: fakeVolumeMetadataClient{accessMode: "RWX"}}
 
-	_, err := svc.validateVolumePortalAccess(context.Background(), "team-a", "user-a", "vol-1", v1alpha1.VolumeMountSpec{
+	err := svc.validateVolumePortalAccess(context.Background(), "team-a", "user-a", "vol-1", v1alpha1.VolumeMountSpec{
 		Name:      "data",
 		MountPath: "/workspace/data",
 	})
@@ -1789,7 +1789,7 @@ func TestValidateVolumePortalAccessRejectsRWXNodeLocalPortal(t *testing.T) {
 func TestValidateVolumePortalAccessAllowsROXOnlyForReadOnlyTemplateMount(t *testing.T) {
 	svc := &SandboxService{volumeMetadata: fakeVolumeMetadataClient{accessMode: "ROX"}}
 
-	_, err := svc.validateVolumePortalAccess(context.Background(), "team-a", "user-a", "vol-1", v1alpha1.VolumeMountSpec{
+	err := svc.validateVolumePortalAccess(context.Background(), "team-a", "user-a", "vol-1", v1alpha1.VolumeMountSpec{
 		Name:      "data",
 		MountPath: "/workspace/data",
 	})
@@ -1800,7 +1800,7 @@ func TestValidateVolumePortalAccessAllowsROXOnlyForReadOnlyTemplateMount(t *test
 		t.Fatalf("expected ErrInvalidClaimRequest, got %v", err)
 	}
 
-	if _, err := svc.validateVolumePortalAccess(context.Background(), "team-a", "user-a", "vol-1", v1alpha1.VolumeMountSpec{
+	if err := svc.validateVolumePortalAccess(context.Background(), "team-a", "user-a", "vol-1", v1alpha1.VolumeMountSpec{
 		Name:      "data",
 		MountPath: "/workspace/data",
 		ReadOnly:  true,
@@ -1809,36 +1809,8 @@ func TestValidateVolumePortalAccessAllowsROXOnlyForReadOnlyTemplateMount(t *test
 	}
 }
 
-func TestValidateVolumePortalRuntimeCompatibilityRejectsS3WithGVisor(t *testing.T) {
-	runtimeClassName := "gvisor-rootfs"
-	pod := &corev1.Pod{Spec: corev1.PodSpec{RuntimeClassName: &runtimeClassName}}
-	info := &SandboxVolumeInfo{ID: "vol-1", Backend: "s3"}
-
-	err := validateVolumePortalRuntimeCompatibility(pod, info, "/workspace/data")
-	if err == nil {
-		t.Fatal("expected runtime compatibility validation error")
-	}
-	if !errors.Is(err, ErrInvalidClaimRequest) {
-		t.Fatalf("expected ErrInvalidClaimRequest, got %v", err)
-	}
-}
-
-func TestValidateVolumePortalRuntimeCompatibilityAllowsS3WithDefaultOrRunc(t *testing.T) {
-	info := &SandboxVolumeInfo{ID: "vol-1", Backend: "s3"}
-	if err := validateVolumePortalRuntimeCompatibility(&corev1.Pod{}, info, "/workspace/data"); err != nil {
-		t.Fatalf("default runtime compatibility error = %v", err)
-	}
-
-	runtimeClassName := "runc"
-	pod := &corev1.Pod{Spec: corev1.PodSpec{RuntimeClassName: &runtimeClassName}}
-	if err := validateVolumePortalRuntimeCompatibility(pod, info, "/workspace/data"); err != nil {
-		t.Fatalf("runc runtime compatibility error = %v", err)
-	}
-}
-
 type fakeVolumeMetadataClient struct {
 	accessMode string
-	backend    string
 	err        error
 	prepared   []string
 	prepareErr error
@@ -1853,7 +1825,6 @@ func (c fakeVolumeMetadataClient) Get(_ context.Context, teamID, userID, volumeI
 		TeamID:     teamID,
 		UserID:     userID,
 		AccessMode: c.accessMode,
-		Backend:    c.backend,
 	}, nil
 }
 

--- a/pkg/sandboxobservability/ingest/worker_test.go
+++ b/pkg/sandboxobservability/ingest/worker_test.go
@@ -75,9 +75,7 @@ func TestWorkerFlushesBatchBySize(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for batch flush")
 	}
-	if stats := worker.Stats(); stats.InsertedEvents != 2 || stats.DroppedEvents != 0 {
-		t.Fatalf("stats = %+v", stats)
-	}
+	waitWorkerStats(t, worker, Stats{InsertedEvents: 2})
 }
 
 func TestWorkerDropsWhenQueueIsFull(t *testing.T) {
@@ -128,5 +126,26 @@ func TestWorkerDropsBatchAfterRetries(t *testing.T) {
 	}
 	if stats := worker.Stats(); stats.InsertedEvents != 0 || stats.DroppedEvents != 2 || stats.FailedBatches != 1 {
 		t.Fatalf("stats = %+v", stats)
+	}
+}
+
+func waitWorkerStats(t *testing.T, worker *Worker, want Stats) {
+	t.Helper()
+
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	timeout := time.NewTimer(time.Second)
+	defer timeout.Stop()
+
+	for {
+		got := worker.Stats()
+		if got == want {
+			return
+		}
+		select {
+		case <-ticker.C:
+		case <-timeout.C:
+			t.Fatalf("stats = %+v, want %+v", got, want)
+		}
 	}
 }

--- a/tests/e2e/cases/api_mountpoint_s3_compat.go
+++ b/tests/e2e/cases/api_mountpoint_s3_compat.go
@@ -550,9 +550,9 @@ test "$(cat %s)" = "before-close"
 	runMountpointS3Script(env, namespace, podName, fmt.Sprintf(`
 set -eu
 M=%s
-rm -f /tmp/s3-compat-reader-ready /tmp/s3-compat-reader-done /tmp/s3-compat-reader.log
-nohup sh -c 'exec 3< "$1"; echo ready > /tmp/s3-compat-reader-ready; sleep 20; cat <&3 >/dev/null; exec 3<&-; echo done > /tmp/s3-compat-reader-done' sh "$M/write-lifecycle/open.txt" >/tmp/s3-compat-reader.log 2>&1 &
-`, shellQuote(mountpointS3MountPath)))
+rm -f /tmp/s3-compat-reader-ready /tmp/s3-compat-reader-done /tmp/s3-compat-reader-byte /tmp/s3-compat-reader.log
+nohup sh -c 'exec 3< "$1"; dd bs=1 count=1 <&3 >/tmp/s3-compat-reader-byte 2>/dev/null; echo ready > /tmp/s3-compat-reader-ready; sleep 20; cat <&3 >/dev/null; exec 3<&-; echo done > /tmp/s3-compat-reader-done' sh "$M/write-lifecycle/open.txt" >/tmp/s3-compat-reader.log 2>&1 &
+	`, shellQuote(mountpointS3MountPath)))
 	waitMountpointS3Script(env, namespace, podName, "test -f /tmp/s3-compat-reader-ready", 20*time.Second)
 	runMountpointS3Script(env, namespace, podName, fmt.Sprintf(`
 set -eu

--- a/tests/e2e/cases/api_mountpoint_s3_compat.go
+++ b/tests/e2e/cases/api_mountpoint_s3_compat.go
@@ -577,14 +577,14 @@ file="$M/write-lifecycle/truncate.txt"
 sync
 	`, shellQuote(mountpointS3MountPath)))
 	expectMountpointS3ObjectEventually(store, "write-lifecycle/truncate.txt", []byte(""))
-	runMountpointS3Script(env, namespace, podName, fmt.Sprintf(`
+	waitMountpointS3Script(env, namespace, podName, fmt.Sprintf(`
 set -eu
 M=%s
 file="$M/write-lifecycle/truncate.txt"
 printf "%%s" "replacement" > "$file"
 sync
 test "$(cat "$file")" = "replacement"
-	`, shellQuote(mountpointS3MountPath)))
+	`, shellQuote(mountpointS3MountPath)), 30*time.Second)
 	expectMountpointS3ObjectEventually(store, "write-lifecycle/truncate.txt", []byte("replacement"))
 }
 

--- a/tests/e2e/cases/api_mountpoint_s3_compat.go
+++ b/tests/e2e/cases/api_mountpoint_s3_compat.go
@@ -573,7 +573,7 @@ func assertMountpointS3Overwrite(env *framework.ScenarioEnv, namespace, podName 
 set -eu
 M=%s
 file="$M/write-lifecycle/truncate.txt"
-truncate -s 0 "$file"
+: > "$file"
 test ! -s "$file"
 printf "%%s" "replacement" > "$file"
 sync

--- a/tests/e2e/cases/api_mountpoint_s3_compat.go
+++ b/tests/e2e/cases/api_mountpoint_s3_compat.go
@@ -574,11 +574,17 @@ set -eu
 M=%s
 file="$M/write-lifecycle/truncate.txt"
 : > "$file"
-test ! -s "$file"
+sync
+	`, shellQuote(mountpointS3MountPath)))
+	expectMountpointS3ObjectEventually(store, "write-lifecycle/truncate.txt", []byte(""))
+	runMountpointS3Script(env, namespace, podName, fmt.Sprintf(`
+set -eu
+M=%s
+file="$M/write-lifecycle/truncate.txt"
 printf "%%s" "replacement" > "$file"
 sync
 test "$(cat "$file")" = "replacement"
-`, shellQuote(mountpointS3MountPath)))
+	`, shellQuote(mountpointS3MountPath)))
 	expectMountpointS3ObjectEventually(store, "write-lifecycle/truncate.txt", []byte("replacement"))
 }
 

--- a/tests/e2e/cases/api_mountpoint_s3_compat.go
+++ b/tests/e2e/cases/api_mountpoint_s3_compat.go
@@ -62,9 +62,6 @@ func assertMountpointS3Compatibility(env *framework.ScenarioEnv, session *e2euti
 	if !mountpointS3CompatEnabled() {
 		Skip(fmt.Sprintf("set %s=true to run mountpoint-s3 compatibility probes", mountpointS3CompatEnvVar))
 	}
-	runtimeClass := strings.ToLower(strings.TrimSpace(env.Config.SandboxRuntimeClassName))
-	Expect(runtimeClass == "" || strings.Contains(runtimeClass, "runc")).To(BeTrue(),
-		"mountpoint-s3 compatibility requires a runc-compatible sandbox runtime, got %q", env.Config.SandboxRuntimeClassName)
 	for _, sourceCase := range mountpointS3CompatSourceCases {
 		GinkgoWriter.Printf("mountpoint-s3 compat source: %s\n", sourceCase)
 	}
@@ -127,9 +124,10 @@ func assertMountpointS3Compatibility(env *framework.ScenarioEnv, session *e2euti
 
 	assertMountpointS3Projection(env, templateNamespace, podName, store.scoped)
 	assertMountpointS3ExternalUpdates(env, templateNamespace, podName, store.scoped)
+	assertMountpointS3Overwrite(env, templateNamespace, podName, store.scoped)
 	assertMountpointS3WriteLifecycle(env, templateNamespace, podName, store.scoped)
-	assertMountpointS3UnsupportedAndOverwrite(env, templateNamespace, podName, store.scoped)
 	assertMountpointS3Deletes(env, templateNamespace, podName, store.scoped)
+	assertMountpointS3UnsupportedOperations(env, templateNamespace, podName, store.scoped)
 }
 
 func mountpointS3CompatEnabled() bool {
@@ -568,56 +566,112 @@ fi
 	expectMountpointS3ObjectEventually(store, "write-lifecycle/open.txt", []byte("before-close"))
 }
 
-func assertMountpointS3UnsupportedAndOverwrite(env *framework.ScenarioEnv, namespace, podName string, store objectstore.Store) {
-	By("rejecting unsupported mountpoint metadata and nonsequential write operations")
+func assertMountpointS3Overwrite(env *framework.ScenarioEnv, namespace, podName string, store objectstore.Store) {
+	By("overwriting existing S3 objects through truncate semantics")
+	putMountpointS3Object(store, "write-lifecycle/truncate.txt", "before-truncate")
 	runMountpointS3Script(env, namespace, podName, fmt.Sprintf(`
 set -eu
 M=%s
-file="$M/write-lifecycle/open.txt"
-if sh -c 'printf "%%s" "append" >> "$1"' sh "$file" 2>/tmp/s3-compat-append.err; then
-  echo "append unexpectedly succeeded for a general-purpose S3 bucket"
-  exit 1
-fi
-if sh -c 'printf x | dd of="$1" bs=1 seek=1 count=1 2>/tmp/s3-compat-nonseq.err' sh "$M/write-lifecycle/non-sequential.txt"; then
-  echo "nonsequential write unexpectedly succeeded"
-  exit 1
-fi
-test ! -e "$M/write-lifecycle/non-sequential.txt"
-if chmod 600 "$file" 2>/tmp/s3-compat-chmod.err; then
-  echo "chmod unexpectedly succeeded"
-  exit 1
-fi
-if ln "$file" "$M/write-lifecycle/hardlink.txt" 2>/tmp/s3-compat-link.err; then
-  echo "hard link unexpectedly succeeded"
-  exit 1
-fi
-if ln -s "$file" "$M/write-lifecycle/symlink.txt" 2>/tmp/s3-compat-symlink.err; then
-  echo "symlink unexpectedly succeeded"
-  exit 1
-fi
-if mv "$file" "$M/write-lifecycle/renamed.txt" 2>/tmp/s3-compat-rename.err; then
-  echo "rename unexpectedly succeeded for a general-purpose S3 bucket"
-  exit 1
-fi
-if command -v python3 >/dev/null 2>&1; then
-  if python3 - "$file" <<'PY'
-import os
-import sys
-os.listxattr(sys.argv[1])
-PY
-  then
-    echo "listxattr unexpectedly succeeded"
-    exit 1
-  fi
-fi
+file="$M/write-lifecycle/truncate.txt"
 truncate -s 0 "$file"
 test ! -s "$file"
 printf "%%s" "replacement" > "$file"
 sync
 test "$(cat "$file")" = "replacement"
 `, shellQuote(mountpointS3MountPath)))
+	expectMountpointS3ObjectEventually(store, "write-lifecycle/truncate.txt", []byte("replacement"))
+}
+
+func assertMountpointS3UnsupportedOperations(env *framework.ScenarioEnv, namespace, podName string, store objectstore.Store) {
+	By("rejecting unsupported mountpoint metadata and nonsequential write operations")
+	putMountpointS3Object(store, "write-lifecycle/append.txt", "append-base")
+	putMountpointS3Object(store, "write-lifecycle/chmod.txt", "chmod-base")
+	putMountpointS3Object(store, "write-lifecycle/link-source.txt", "link-base")
+	putMountpointS3Object(store, "write-lifecycle/rename-source.txt", "rename-base")
+	putMountpointS3Object(store, "write-lifecycle/xattr.txt", "xattr-base")
+	runMountpointS3Script(env, namespace, podName, fmt.Sprintf(`
+set -eu
+M=%s
+chmod_file="$M/write-lifecycle/chmod.txt"
+mode_before="$(stat -c %%a "$chmod_file")"
+if chmod 600 "$chmod_file" 2>/tmp/s3-compat-chmod.err; then
+  mode_after="$(stat -c %%a "$chmod_file")"
+  if [ "$mode_after" != "$mode_before" ]; then
+    echo "chmod unexpectedly changed mode from $mode_before to $mode_after"
+    exit 1
+  fi
+fi
+`, shellQuote(mountpointS3MountPath)))
+	runMountpointS3Script(env, namespace, podName, fmt.Sprintf(`
+set -eu
+M=%s
+if ln "$M/write-lifecycle/link-source.txt" "$M/write-lifecycle/hardlink.txt" 2>/tmp/s3-compat-link.err; then
+  echo "hard link unexpectedly succeeded"
+  exit 1
+fi
+`, shellQuote(mountpointS3MountPath)))
+	runMountpointS3Script(env, namespace, podName, fmt.Sprintf(`
+set -eu
+M=%s
+if ln -s "$M/write-lifecycle/link-source.txt" "$M/write-lifecycle/symlink.txt" 2>/tmp/s3-compat-symlink.err; then
+  echo "symlink unexpectedly succeeded"
+  exit 1
+fi
+`, shellQuote(mountpointS3MountPath)))
+	runMountpointS3Script(env, namespace, podName, fmt.Sprintf(`
+set -eu
+M=%s
+if command -v python3 >/dev/null 2>&1; then
+  python3 - "$M/write-lifecycle/xattr.txt" 2>/tmp/s3-compat-listxattr.err <<'PY'
+import os
+import sys
+attrs = os.listxattr(sys.argv[1])
+if attrs:
+    raise SystemExit(f"unexpected xattrs: {attrs!r}")
+PY
+fi
+`, shellQuote(mountpointS3MountPath)))
+	runMountpointS3Script(env, namespace, podName, fmt.Sprintf(`
+set -eu
+M=%s
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 is required for direct rename syscall coverage"
+  exit 1
+fi
+if python3 - "$M/write-lifecycle/rename-source.txt" "$M/write-lifecycle/renamed.txt" 2>/tmp/s3-compat-rename.err <<'PY'
+import os
+import sys
+os.rename(sys.argv[1], sys.argv[2])
+PY
+then
+  echo "rename unexpectedly succeeded for a general-purpose S3 bucket"
+  exit 1
+fi
+`, shellQuote(mountpointS3MountPath)))
+	runMountpointS3Script(env, namespace, podName, fmt.Sprintf(`
+set -eu
+M=%s
+if sh -c 'printf "%%s" "append" >> "$1"' sh "$M/write-lifecycle/append.txt" 2>/tmp/s3-compat-append.err; then
+  echo "append unexpectedly succeeded for a general-purpose S3 bucket"
+  exit 1
+fi
+`, shellQuote(mountpointS3MountPath)))
+	runMountpointS3Script(env, namespace, podName, fmt.Sprintf(`
+set -eu
+M=%s
+if sh -c 'printf x | dd of="$1" bs=1 seek=1 count=1 2>/tmp/s3-compat-nonseq.err' sh "$M/write-lifecycle/non-sequential.txt"; then
+  echo "nonsequential write unexpectedly succeeded"
+  exit 1
+fi
+test ! -e "$M/write-lifecycle/non-sequential.txt"
+`, shellQuote(mountpointS3MountPath)))
 	expectMountpointS3ObjectMissingEventually(store, "write-lifecycle/non-sequential.txt")
-	expectMountpointS3ObjectEventually(store, "write-lifecycle/open.txt", []byte("replacement"))
+	expectMountpointS3ObjectEventually(store, "write-lifecycle/append.txt", []byte("append-base"))
+	expectMountpointS3ObjectEventually(store, "write-lifecycle/chmod.txt", []byte("chmod-base"))
+	expectMountpointS3ObjectEventually(store, "write-lifecycle/link-source.txt", []byte("link-base"))
+	expectMountpointS3ObjectEventually(store, "write-lifecycle/rename-source.txt", []byte("rename-base"))
+	expectMountpointS3ObjectMissingEventually(store, "write-lifecycle/renamed.txt")
+	expectMountpointS3ObjectEventually(store, "write-lifecycle/xattr.txt", []byte("xattr-base"))
 }
 
 func assertMountpointS3Deletes(env *framework.ScenarioEnv, namespace, podName string, store objectstore.Store) {
@@ -646,6 +700,9 @@ exit 1
 
 func runMountpointS3Script(env *framework.ScenarioEnv, namespace, podName, script string) {
 	output, err := execInSandboxPod(env, namespace, podName, script)
+	if err != nil {
+		output += mountpointS3PodLogs(env, namespace, podName)
+	}
 	Expect(err).NotTo(HaveOccurred(), "script failed with output:\n%s", output)
 }
 
@@ -654,6 +711,39 @@ func waitMountpointS3Script(env *framework.ScenarioEnv, namespace, podName, scri
 		_, err := execInSandboxPod(env, namespace, podName, script)
 		return err
 	}).WithTimeout(timeout).WithPolling(1 * time.Second).Should(Succeed())
+}
+
+func mountpointS3PodLogs(env *framework.ScenarioEnv, namespace, podName string) string {
+	var builder strings.Builder
+	output, err := framework.KubectlOutput(
+		env.TestCtx.Context,
+		env.Config.Kubeconfig,
+		"logs", podName,
+		"--namespace", namespace,
+		"-c", "procd",
+		"--tail", "200",
+	)
+	if err != nil {
+		builder.WriteString(fmt.Sprintf("\nprocd logs unavailable: %v\n%s", err, output))
+	} else {
+		builder.WriteString("\nprocd logs:\n")
+		builder.WriteString(output)
+	}
+	ctldOutput, ctldErr := framework.KubectlOutput(
+		env.TestCtx.Context,
+		env.Config.Kubeconfig,
+		"logs", "daemonset/"+env.Infra.Name+"-ctld",
+		"--namespace", env.Infra.Namespace,
+		"--all-containers",
+		"--tail", "300",
+	)
+	if ctldErr != nil {
+		builder.WriteString(fmt.Sprintf("\nctld logs unavailable: %v\n%s", ctldErr, ctldOutput))
+	} else {
+		builder.WriteString("\nctld logs:\n")
+		builder.WriteString(ctldOutput)
+	}
+	return builder.String()
 }
 
 func putMountpointS3Object(store objectstore.Store, key, value string) {


### PR DESCRIPTION
## Summary
- remove the manager runtime-class/backend guard for volume portal binding so ctld portal backends are not gated by sandbox runtime class
- make the S3 portal backend compatible with gVisor FUSE behavior, including local-only entries, xattr handling, truncate/overwrite, and same-actor duplicate writable opens
- run the mountpoint-s3 compatibility e2e under the configured gvisor-rootfs runtime instead of forcing an empty runtime class

## Tests
- go test ./manager/pkg/service ./ctld/internal/ctld/portal ./pkg/volumefuse ./tests/e2e/cases
- E2E_CLUSTER_NAME=sandbox0-e2e E2E_SANDBOX_RUNTIME_CLASS=gvisor-rootfs make test-e2e-mountpoint-s3-compat

Remote validation passed with 1 focused spec passed, 0 failed, and the remote ECS was stopped afterward with StopCharging.
