### PR TITLE
Link S3 backend docs to bucket mount blog

### DIFF
--- a/docs/volume/backends/page.mdx
+++ b/docs/volume/backends/page.mdx
@@ -49,6 +49,8 @@ s0 volume create --access-mode RWO
 
 The `s3` backend projects object keys into a filesystem-like tree. It is useful when data already lives in object storage and the Sandbox should work against that bucket prefix directly.
 
+For a workflow-oriented walkthrough, see [Mount an S3 Bucket in an AI Agent Sandbox](/blog/2026-07/mount-s3-bucket-ai-agent-sandbox).
+
 Create an S3 backend volume with the SDKs or CLI:
 
 <Tabs


### PR DESCRIPTION
## Summary
- add a docs link from the S3 Volume backend section to the new S3 bucket mount blog walkthrough
- keep the change scoped to `docs/volume/backends/page.mdx`

Companion blog PR: sandbox0-ai/sandbox0-cloud#228

## Validation
- `SANDBOX0_ROOT=/root/sandbox0ai/sandbox0 npm run build -w @sandbox0-cloud/website`