### PR TITLE
Return 429 for claim start throttling

### DIFF
--- a/docs/sandbox/page.mdx
+++ b/docs/sandbox/page.mdx
@@ -77,6 +77,8 @@ Claim a sandbox from a template. The sandbox is created from a pre-warmed pool f
 | `auto_resume` | boolean | Auto-resume when accessed (default: true) |
 | `services` | array | Sandbox Services for public HTTP routes, including Sandbox Functions |
 
+When the cluster claim/start admission budget is full, the claim API returns `429` with `error.code` set to `claim_start_throttled` and a `Retry-After` header in seconds. Retry after that delay. Team quota failures also return `429`, but use `error.code` set to `quota_exceeded`.
+
 See [Network](/docs/sandbox/network) and [Protocol Controls](/docs/sandbox/protocol-controls) for outbound control, [Sandbox Services](/docs/sandbox/services) for public HTTP controls, [Sandbox Functions](/docs/sandbox/functions) for inline public handlers, and [Credential](/docs/sandbox/credential) for outbound auth and secret handling.
 
 Sandbox `env_vars` override template/container environment variables for new contexts, command services, and function executions. Per-context, per-command, service runtime, and function `env_vars` override sandbox `env_vars` for that narrower scope. Warm processes start before the sandbox is claimed, so they do not receive claim-time sandbox `env_vars`.

--- a/manager/pkg/http/handlers_sandbox.go
+++ b/manager/pkg/http/handlers_sandbox.go
@@ -61,7 +61,7 @@ func (s *Server) claimSandbox(c *gin.Context) {
 				retryAfter = 1
 			}
 			c.Header("Retry-After", strconv.Itoa(retryAfter))
-			spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, err.Error())
+			spec.JSONError(c, http.StatusTooManyRequests, spec.CodeClaimStartThrottled, err.Error())
 			return
 		}
 		if errors.Is(err, service.ErrDataPlaneNotReady) {

--- a/manager/pkg/http/handlers_sandbox_list_test.go
+++ b/manager/pkg/http/handlers_sandbox_list_test.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -14,6 +15,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/service"
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/startlimiter"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
@@ -213,6 +215,99 @@ func TestClaimSandboxReturnsUnavailableWhenDataPlaneNotReady(t *testing.T) {
 	}
 }
 
+func TestClaimSandboxReturnsTooManyRequestsWhenClaimStartThrottled(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	withHTTPTestPublicKey(t)
+	withHTTPTestManagerConfig(t, `sandbox_pod_placement:
+  node_selector:
+    sandbox0.ai/data-plane-ready: "true"
+`)
+
+	templateNamespace, err := naming.TemplateNamespaceForBuiltin("default")
+	if err != nil {
+		t.Fatalf("template namespace: %v", err)
+	}
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: templateNamespace},
+		Spec:       v1alpha1.SandboxTemplateSpec{MainContainer: v1alpha1.ContainerSpec{Image: "busybox"}},
+	}
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "sandbox-node",
+			Labels: map[string]string{
+				"sandbox0.ai/data-plane-ready": "true",
+			},
+		},
+		Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{{
+			Type:   corev1.NodeReady,
+			Status: corev1.ConditionTrue,
+		}}},
+	}
+	startingPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "active-starting",
+			Namespace: templateNamespace,
+			Labels: map[string]string{
+				controller.LabelTemplateID: template.Name,
+				controller.LabelPoolType:   controller.PoolTypeActive,
+			},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodPending},
+	}
+	k8sClient := fake.NewSimpleClientset(node, startingPod)
+	claimStartLimiter, err := startlimiter.New(context.Background(), startlimiter.Config{
+		K8sClient:      k8sClient,
+		PerSandboxNode: 1,
+		MaxLimit:       1,
+		SandboxNodeSelector: map[string]string{
+			"sandbox0.ai/data-plane-ready": "true",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create claim start limiter: %v", err)
+	}
+	sandboxService := service.NewSandboxService(
+		k8sClient,
+		newHTTPTestPodLister(t, startingPod),
+		newHTTPTestNodeLister(t, node),
+		nil,
+		newHTTPTestSecretLister(t),
+		staticHTTPTemplateLister{templates: []*v1alpha1.SandboxTemplate{template}},
+		nil,
+		nil,
+		nil,
+		nil,
+		service.SandboxServiceConfig{},
+		zap.NewNop(),
+		nil,
+	)
+	sandboxService.SetClaimStartLimiter(claimStartLimiter)
+
+	server := &Server{sandboxService: sandboxService, logger: zap.NewNop()}
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/sandboxes", strings.NewReader(`{"template":"default"}`))
+	request.Header.Set("Content-Type", "application/json")
+	request = request.WithContext(internalauth.WithClaims(request.Context(), &internalauth.Claims{TeamID: "team-1", UserID: "user-1"}))
+	ctx.Request = request
+
+	server.claimSandbox(ctx)
+
+	if recorder.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want %d; body = %s", recorder.Code, http.StatusTooManyRequests, recorder.Body.String())
+	}
+	if got := recorder.Header().Get("Retry-After"); got != "1" {
+		t.Fatalf("Retry-After = %q, want 1", got)
+	}
+	var response spec.Response
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if response.Success || response.Error == nil || response.Error.Code != spec.CodeClaimStartThrottled {
+		t.Fatalf("response = %+v, want claim_start_throttled error", response)
+	}
+}
+
 func TestClaimSandboxReturnsNotFoundForMissingTemplate(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
@@ -347,6 +442,19 @@ func newHTTPTestNodeLister(t *testing.T, nodes ...*corev1.Node) corelisters.Node
 	return corelisters.NewNodeLister(indexer)
 }
 
+func newHTTPTestSecretLister(t *testing.T, secrets ...*corev1.Secret) corelisters.SecretLister {
+	t.Helper()
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+	})
+	for _, secret := range secrets {
+		if err := indexer.Add(secret); err != nil {
+			t.Fatalf("add secret: %v", err)
+		}
+	}
+	return corelisters.NewSecretLister(indexer)
+}
+
 type staticHTTPTemplateLister struct {
 	templates []*v1alpha1.SandboxTemplate
 }
@@ -380,5 +488,18 @@ func withHTTPTestManagerConfig(t *testing.T, content string) {
 			return
 		}
 		_ = os.Unsetenv("CONFIG_PATH")
+	})
+}
+
+func withHTTPTestPublicKey(t *testing.T) {
+	t.Helper()
+	keyPath := filepath.Join(t.TempDir(), "internal_jwt_public.key")
+	if err := os.WriteFile(keyPath, []byte("test-public-key"), 0o600); err != nil {
+		t.Fatalf("write public key: %v", err)
+	}
+	previousPath := internalauth.DefaultInternalJWTPublicKeyPath
+	internalauth.DefaultInternalJWTPublicKeyPath = keyPath
+	t.Cleanup(func() {
+		internalauth.DefaultInternalJWTPublicKeyPath = previousPath
 	})
 }

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -1293,13 +1293,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorEnvelope"
         "429":
-          description: Team quota exceeded
+          description: Team quota exceeded or claim/start admission throttled
+          headers:
+            Retry-After:
+              description: Suggested retry delay in seconds when claim/start admission is throttled
+              schema:
+                type: integer
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorEnvelope"
         "503":
-          description: Cluster claim/start capacity temporarily unavailable
+          description: Data plane temporarily unavailable
           headers:
             Retry-After:
               description: Suggested retry delay in seconds

--- a/pkg/gateway/spec/response.go
+++ b/pkg/gateway/spec/response.go
@@ -32,14 +32,15 @@ type rawResponse struct {
 }
 
 const (
-	CodeBadRequest   = "bad_request"
-	CodeUnauthorized = "unauthorized"
-	CodeForbidden    = "forbidden"
-	CodeNotFound     = "not_found"
-	CodeConflict     = "conflict"
-	CodeUnavailable  = "unavailable"
-	CodeInternal     = "internal_error"
-	CodeNotLicensed  = "feature_not_licensed"
+	CodeBadRequest          = "bad_request"
+	CodeUnauthorized        = "unauthorized"
+	CodeForbidden           = "forbidden"
+	CodeNotFound            = "not_found"
+	CodeConflict            = "conflict"
+	CodeClaimStartThrottled = "claim_start_throttled"
+	CodeUnavailable         = "unavailable"
+	CodeInternal            = "internal_error"
+	CodeNotLicensed         = "feature_not_licensed"
 )
 
 // successresp builds a success envelope.


### PR DESCRIPTION
## Summary
- return `429 Too Many Requests` with `error.code=claim_start_throttled` for claim/start admission throttling
- keep data-plane readiness failures as `503 unavailable`
- document the claim/start throttling contract and update the OpenAPI response headers

## Validation
- `make apispec`
- `go test ./manager/pkg/http ./manager/pkg/startlimiter ./pkg/gateway/spec`
- `go test ./manager/pkg/service -run 'Test.*Claim|Test.*DataPlane|Test.*Resource'`
- `git diff --check`
