### PR TITLE
Add sandbox delete cleanup metrics

### DIFF
--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -405,6 +405,7 @@ func main() {
 	sandboxService.SetDeletionWebhookEmitter(service.NewHTTPSandboxDeletionWebhookEmitter(obsProvider.HTTP.NewClient(httpobs.Config{Timeout: cfg.ProcdClientTimeout.Duration})))
 	podInformer.Informer().AddEventHandler(sandboxService.PodEventHandler())
 	sandboxLifecycleController := service.NewSandboxLifecycleController(k8sClient, podLister, sandboxService, logger)
+	sandboxLifecycleController.SetMetrics(managerMetrics)
 	podInformer.Informer().AddEventHandler(sandboxLifecycleController.ResourceEventHandler())
 	sandboxPauseController := service.NewSandboxPauseController(sandboxService, logger)
 	sandboxService.SetPauseEnqueuer(sandboxPauseController)

--- a/manager/pkg/service/sandbox_lifecycle_controller.go
+++ b/manager/pkg/service/sandbox_lifecycle_controller.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
+	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
 	"github.com/sandbox0-ai/sandbox0/pkg/volumeportal"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
@@ -29,6 +30,10 @@ import (
 const (
 	sandboxCleanupFinalizer             = "sandbox0.ai/sandbox-cleanup"
 	defaultSandboxLifecycleResyncPeriod = 30 * time.Second
+
+	sandboxDeleteCleanupScopeSandboxDelete = "sandbox_delete"
+	sandboxDeleteCleanupScopeRuntimeOnly   = "runtime_only"
+	sandboxDeleteCleanupScopeUnknown       = "unknown"
 )
 
 // SandboxLifecycleInfo carries the durable identity needed to clean sandbox-scoped state.
@@ -83,6 +88,7 @@ type SandboxLifecycleController struct {
 	podLister      corelisters.PodLister
 	cleaner        SandboxDeletionCleaner
 	logger         *zap.Logger
+	metrics        *obsmetrics.ManagerMetrics
 	queue          workqueue.TypedRateLimitingInterface[sandboxLifecycleQueueItem]
 	resyncInterval time.Duration
 }
@@ -104,6 +110,13 @@ func NewSandboxLifecycleController(
 		queue:          workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[sandboxLifecycleQueueItem]()),
 		resyncInterval: defaultSandboxLifecycleResyncPeriod,
 	}
+}
+
+func (c *SandboxLifecycleController) SetMetrics(metrics *obsmetrics.ManagerMetrics) {
+	if c == nil {
+		return
+	}
+	c.metrics = metrics
 }
 
 func (c *SandboxLifecycleController) ResourceEventHandler() cache.ResourceEventHandlerFuncs {
@@ -241,9 +254,12 @@ func (c *SandboxLifecycleController) reconcile(ctx context.Context, item sandbox
 	if !hasSandboxCleanupFinalizer(pod) {
 		return nil
 	}
+	started := time.Now()
 	if err := c.removeSandboxCleanupFinalizer(ctx, pod.Namespace, pod.Name); err != nil {
+		observeSandboxDeleteCleanupPhase(c.metrics, "remove_cleanup_finalizer", sandboxDeleteCleanupScopeUnknown, started, err)
 		return fmt.Errorf("remove sandbox cleanup finalizer: %w", err)
 	}
+	observeSandboxDeleteCleanupPhase(c.metrics, "remove_cleanup_finalizer", sandboxDeleteCleanupScopeUnknown, started, nil)
 	return nil
 }
 
@@ -330,14 +346,20 @@ func (s *SandboxService) CleanupDeletedSandbox(ctx context.Context, info Sandbox
 		return nil
 	}
 
+	classifyStarted := time.Now()
 	runtimePaused, err := s.runtimeDeletionIsPause(ctx, info)
+	scope := sandboxDeleteCleanupScope(runtimePaused)
+	if err != nil {
+		scope = sandboxDeleteCleanupScopeUnknown
+	}
+	observeSandboxDeleteCleanupPhase(s.metrics, "classify_runtime_deletion", scope, classifyStarted, err)
 	if err != nil {
 		return err
 	}
 	return s.cleanupDeletedSandbox(ctx, info, runtimePaused)
 }
 
-func (s *SandboxService) cleanupDeletedSandbox(ctx context.Context, info SandboxLifecycleInfo, runtimePaused bool) error {
+func (s *SandboxService) cleanupDeletedSandbox(ctx context.Context, info SandboxLifecycleInfo, runtimePaused bool) (cleanupErr error) {
 	logger := s.logger
 	if logger == nil {
 		logger = zap.NewNop()
@@ -349,19 +371,40 @@ func (s *SandboxService) cleanupDeletedSandbox(ctx context.Context, info Sandbox
 	if sandboxID == "" {
 		return nil
 	}
+	scope := sandboxDeleteCleanupScope(runtimePaused)
+	cleanupStarted := time.Now()
+	logger.Info("Cleaning sandbox deletion state",
+		zap.String("sandboxID", sandboxID),
+		zap.String("namespace", info.Namespace),
+		zap.String("pod", info.PodName),
+		zap.String("scope", scope),
+	)
+	defer func() {
+		observeSandboxDeleteCleanupPhase(s.metrics, "cleanup_total", scope, cleanupStarted, cleanupErr)
+		fields := []zap.Field{
+			zap.String("sandboxID", sandboxID),
+			zap.String("namespace", info.Namespace),
+			zap.String("pod", info.PodName),
+			zap.String("scope", scope),
+			zap.Duration("duration", time.Since(cleanupStarted)),
+		}
+		if cleanupErr != nil {
+			logger.Warn("Sandbox deletion state cleanup failed", append(fields, zap.Error(cleanupErr))...)
+			return
+		}
+		logger.Info("Sandbox deletion state cleanup completed", fields...)
+	}()
 
 	var errs []error
 	if !runtimePaused && s.deletionWebhookEmitter != nil && strings.TrimSpace(info.WebhookURL) != "" {
-		if err := s.deletionWebhookEmitter.EmitSandboxDeleted(ctx, info); err != nil {
-			logger.Warn("Failed to emit sandbox.deleted webhook",
-				zap.String("sandboxID", sandboxID),
-				zap.String("namespace", info.Namespace),
-				zap.Error(err),
-			)
-		}
+		_ = s.runSandboxDeleteCleanupPhase(ctx, info, scope, "emit_deletion_webhook", func() error {
+			return s.deletionWebhookEmitter.EmitSandboxDeleted(ctx, info)
+		})
 	}
 	if s.networkProvider != nil && info.Namespace != "" {
-		if err := s.networkProvider.RemoveSandboxPolicy(ctx, info.Namespace, sandboxID); err != nil {
+		if err := s.runSandboxDeleteCleanupPhase(ctx, info, scope, "remove_network_policy", func() error {
+			return s.networkProvider.RemoveSandboxPolicy(ctx, info.Namespace, sandboxID)
+		}); err != nil {
 			errs = append(errs, fmt.Errorf("remove network policy: %w", err))
 		}
 	}
@@ -372,19 +415,60 @@ func (s *SandboxService) cleanupDeletedSandbox(ctx context.Context, info Sandbox
 				zap.String("sandboxID", sandboxID),
 				zap.String("namespace", info.Namespace),
 			)
-		} else if err := s.credentialStore.DeleteBindings(ctx, teamID, sandboxID); err != nil {
+		} else if err := s.runSandboxDeleteCleanupPhase(ctx, info, scope, "delete_credential_bindings", func() error {
+			return s.credentialStore.DeleteBindings(ctx, teamID, sandboxID)
+		}); err != nil {
 			errs = append(errs, fmt.Errorf("delete credential bindings: %w", err))
 		}
 	}
-	if !runtimePaused {
-		if err := s.deleteWebhookStateVolume(ctx, info); err != nil {
+	if !runtimePaused && shouldDeleteWebhookStateVolume(info) {
+		if err := s.runSandboxDeleteCleanupPhase(ctx, info, scope, "mark_webhook_state_volume_cleanup", func() error {
+			return s.deleteWebhookStateVolume(ctx, info)
+		}); err != nil {
 			errs = append(errs, fmt.Errorf("delete webhook state volume: %w", err))
 		}
 	}
-	if err := s.unbindDeletedSandboxVolumePortals(ctx, info); err != nil {
-		errs = append(errs, fmt.Errorf("unbind sandbox volume portals: %w", err))
+	if s.shouldUnbindDeletedSandboxVolumePortals(info) {
+		if err := s.runSandboxDeleteCleanupPhase(ctx, info, scope, "unbind_volume_portals", func() error {
+			return s.unbindDeletedSandboxVolumePortals(ctx, info)
+		}); err != nil {
+			errs = append(errs, fmt.Errorf("unbind sandbox volume portals: %w", err))
+		}
 	}
-	return errors.Join(errs...)
+	cleanupErr = errors.Join(errs...)
+	return cleanupErr
+}
+
+func (s *SandboxService) runSandboxDeleteCleanupPhase(_ context.Context, info SandboxLifecycleInfo, scope, phase string, fn func() error) error {
+	started := time.Now()
+	err := fn()
+	observeSandboxDeleteCleanupPhase(s.metrics, phase, scope, started, err)
+	logger := s.logger
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	fields := []zap.Field{
+		zap.String("sandboxID", strings.TrimSpace(info.SandboxID)),
+		zap.String("namespace", info.Namespace),
+		zap.String("pod", info.PodName),
+		zap.String("phase", phase),
+		zap.String("scope", scope),
+		zap.Duration("duration", time.Since(started)),
+	}
+	if err != nil {
+		logger.Warn("Sandbox delete cleanup phase failed", append(fields, zap.Error(err))...)
+		return err
+	}
+	logger.Debug("Sandbox delete cleanup phase completed", fields...)
+	return nil
+}
+
+func shouldDeleteWebhookStateVolume(info SandboxLifecycleInfo) bool {
+	return strings.TrimSpace(info.WebhookStateVolumeID) != "" || strings.TrimSpace(info.WebhookURL) != ""
+}
+
+func (s *SandboxService) shouldUnbindDeletedSandboxVolumePortals(info SandboxLifecycleInfo) bool {
+	return s != nil && s.config.CtldEnabled && len(info.VolumePortals) > 0
 }
 
 func (s *SandboxService) runtimeDeletionIsPause(ctx context.Context, info SandboxLifecycleInfo) (bool, error) {
@@ -686,4 +770,30 @@ func removeFinalizer(finalizers []string, target string) []string {
 		}
 	}
 	return out
+}
+
+func observeSandboxDeleteCleanupPhase(metrics *obsmetrics.ManagerMetrics, phase, scope string, started time.Time, err error) {
+	if metrics == nil || metrics.SandboxDeleteCleanupPhase == nil {
+		return
+	}
+	phase = strings.TrimSpace(phase)
+	if phase == "" {
+		phase = "unknown"
+	}
+	scope = strings.TrimSpace(scope)
+	if scope == "" {
+		scope = sandboxDeleteCleanupScopeUnknown
+	}
+	status := "success"
+	if err != nil {
+		status = "error"
+	}
+	metrics.SandboxDeleteCleanupPhase.WithLabelValues(phase, status, scope).Observe(time.Since(started).Seconds())
+}
+
+func sandboxDeleteCleanupScope(runtimePaused bool) string {
+	if runtimePaused {
+		return sandboxDeleteCleanupScopeRuntimeOnly
+	}
+	return sandboxDeleteCleanupScopeSandboxDelete
 }

--- a/manager/pkg/service/sandbox_lifecycle_controller_test.go
+++ b/manager/pkg/service/sandbox_lifecycle_controller_test.go
@@ -11,9 +11,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
 	"github.com/sandbox0-ai/sandbox0/pkg/egressauth"
+	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
 	"github.com/sandbox0-ai/sandbox0/pkg/volumeportal"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
@@ -131,6 +133,44 @@ func TestSandboxLifecycleControllerCleansAndRemovesFinalizer(t *testing.T) {
 	}
 }
 
+func TestSandboxLifecycleControllerRecordsFinalizerRemovalMetric(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	deletionTime := metav1.NewTime(time.Now().UTC())
+	pod := newLifecycleTestPod()
+	pod.Finalizers = []string{sandboxCleanupFinalizer}
+	pod.DeletionTimestamp = &deletionTime
+	client := fake.NewSimpleClientset(pod.DeepCopy())
+	cleaner := &recordingSandboxCleaner{}
+	controller := NewSandboxLifecycleController(client, nil, cleaner, zap.NewNop())
+	controller.SetMetrics(obsmetrics.NewManager(registry))
+
+	err := controller.reconcile(context.Background(), sandboxLifecycleItemFromInfo(SandboxLifecycleInfo{
+		Namespace: pod.Namespace,
+		PodName:   pod.Name,
+		SandboxID: pod.Name,
+		TeamID:    "team-a",
+	}, false))
+	if err != nil {
+		t.Fatalf("reconcile() error = %v", err)
+	}
+
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("gather metrics: %v", err)
+	}
+	metric := findMetric(families, "manager_sandbox_delete_cleanup_phase_duration_seconds", map[string]string{
+		"phase":  "remove_cleanup_finalizer",
+		"status": "success",
+		"scope":  "unknown",
+	})
+	if metric == nil || metric.GetHistogram() == nil {
+		t.Fatal("delete cleanup finalizer metric not found")
+	}
+	if got := metric.GetHistogram().GetSampleCount(); got != 1 {
+		t.Fatalf("finalizer cleanup sample count = %d, want 1", got)
+	}
+}
+
 func TestSandboxLifecycleControllerRetriesCleanupBeforeRemovingFinalizer(t *testing.T) {
 	deletionTime := metav1.NewTime(time.Now().UTC())
 	pod := newLifecycleTestPod()
@@ -229,6 +269,50 @@ func TestSandboxServiceCleanupDeletedSandboxRemovesExternalState(t *testing.T) {
 	}
 	if store.deleteCalls != 1 {
 		t.Fatalf("DeleteBindings calls = %d, want 1", store.deleteCalls)
+	}
+}
+
+func TestSandboxServiceCleanupDeletedSandboxRecordsPhaseMetrics(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	store := &deleteRecordingBindingStore{}
+	svc := &SandboxService{
+		networkProvider: &assertingNetworkProvider{},
+		credentialStore: store,
+		logger:          zap.NewNop(),
+		metrics:         obsmetrics.NewManager(registry),
+	}
+
+	err := svc.CleanupDeletedSandbox(context.Background(), SandboxLifecycleInfo{
+		Namespace: "ns-a",
+		PodName:   "sandbox-a",
+		SandboxID: "sandbox-a",
+		TeamID:    "team-a",
+	})
+	if err != nil {
+		t.Fatalf("CleanupDeletedSandbox() error = %v", err)
+	}
+
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("gather metrics: %v", err)
+	}
+	for _, phase := range []string{
+		"classify_runtime_deletion",
+		"remove_network_policy",
+		"delete_credential_bindings",
+		"cleanup_total",
+	} {
+		metric := findMetric(families, "manager_sandbox_delete_cleanup_phase_duration_seconds", map[string]string{
+			"phase":  phase,
+			"status": "success",
+			"scope":  "sandbox_delete",
+		})
+		if metric == nil || metric.GetHistogram() == nil {
+			t.Fatalf("delete cleanup phase metric %q not found", phase)
+		}
+		if got := metric.GetHistogram().GetSampleCount(); got != 1 {
+			t.Fatalf("delete cleanup phase %q sample count = %d, want 1", phase, got)
+		}
 	}
 }
 

--- a/pkg/observability/metrics/manager.go
+++ b/pkg/observability/metrics/manager.go
@@ -13,6 +13,7 @@ type ManagerMetrics struct {
 	SandboxClaimsTotal              *prometheus.CounterVec
 	SandboxClaimDuration            *prometheus.HistogramVec
 	SandboxClaimPhaseDuration       *prometheus.HistogramVec
+	SandboxDeleteCleanupPhase       *prometheus.HistogramVec
 	SandboxIdleClaimsTotal          *prometheus.CounterVec
 	PodNetworkIdentityChecksTotal   *prometheus.CounterVec
 	PodNetworkIdentityStageDuration *prometheus.HistogramVec
@@ -75,6 +76,11 @@ func NewManager(registry prometheus.Registerer) *ManagerMetrics {
 			Help:    "Duration of sandbox claim phases",
 			Buckets: []float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 30, 60, 120},
 		}, []string{"template", "type", "phase", "status"}), // type: "hot", "cold", or "unknown"
+		SandboxDeleteCleanupPhase: factory.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "manager_sandbox_delete_cleanup_phase_duration_seconds",
+			Help:    "Duration of sandbox deletion cleanup phases",
+			Buckets: []float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 30, 60, 120, 300},
+		}, []string{"phase", "status", "scope"}), // scope: "sandbox_delete", "runtime_only", or "unknown"
 		SandboxIdleClaimsTotal: factory.NewCounterVec(prometheus.CounterOpts{
 			Name: "manager_sandbox_idle_claims_total",
 			Help: "Total number of idle-pool claim attempts by result",


### PR DESCRIPTION
## Summary
- add `manager_sandbox_delete_cleanup_phase_duration_seconds` for sandbox delete cleanup phases
- record delete cleanup total, runtime classification, external cleanup phases, and finalizer removal
- add structured logs around sandbox deletion cleanup start/completion and phase failures

## Tests
- go test ./manager/pkg/service -run 'TestSandbox(ServiceCleanupDeletedSandboxRecordsPhaseMetrics|LifecycleControllerRecordsFinalizerRemovalMetric)'\n- go test ./manager/...\n- go test ./pkg/observability/...\n