### PR TITLE
Hold Redis claim start reservations through cold readiness

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -17,14 +17,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  e2e:
-    name: e2e
+  e2e_suites:
+    name: e2e (${{ matrix.suite }})
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - suite: core
+            command: make test-e2e
+            cluster_suffix: core
+          - suite: s0fs-posix
+            command: make test-e2e-s0fs-posix
+            cluster_suffix: s0fs-posix
+          - suite: mountpoint-s3
+            command: make test-e2e-mountpoint-s3-compat
+            cluster_suffix: mountpoint-s3
     env:
-      KIND_CLUSTER_NAME: sandbox0-pr-e2e
+      KIND_CLUSTER_NAME: sandbox0-pr-e2e-${{ matrix.cluster_suffix }}
     steps:
       - uses: actions/checkout@v4
 
@@ -34,24 +47,13 @@ jobs:
           infra-dir: .
           kind-config: tests/e2e/kind-config.yaml
           kind-cluster-name: ${{ env.KIND_CLUSTER_NAME }}
-          cache-key-suffix: pr-amd64
+          cache-key-suffix: pr-amd64-${{ matrix.suite }}
 
-      - name: Run PR E2E
+      - name: Run ${{ matrix.suite }} E2E
         env:
           E2E_USE_EXISTING_CLUSTER: "true"
           E2E_CLUSTER_NAME: ${{ env.KIND_CLUSTER_NAME }}
-        run: make test-e2e
-
-      - name: Run S0FS POSIX suite
-        env:
-          E2E_CLUSTER_NAME: ${{ env.KIND_CLUSTER_NAME }}
-        run: make test-e2e-s0fs-posix
-
-      - name: Run mountpoint-s3 compatibility suite
-        env:
-          E2E_CLUSTER_NAME: ${{ env.KIND_CLUSTER_NAME }}
-          E2E_USE_EXISTING_CLUSTER: "true"
-        run: make test-e2e-mountpoint-s3-compat
+        run: ${{ matrix.command }}
 
       - name: Dump cluster state on failure
         if: failure()
@@ -65,16 +67,32 @@ jobs:
           kubectl -n infra-operator get events --sort-by=.lastTimestamp || true
           echo "=== infra-operator logs ==="
           kubectl -n infra-operator logs deploy/infra-operator --all-containers --tail=-1 || true
-          kind export logs "${RUNNER_TEMP}/kind-logs" --name "${KIND_CLUSTER_NAME}" || true
+          kind export logs "${RUNNER_TEMP}/kind-logs-${{ matrix.suite }}" --name "${KIND_CLUSTER_NAME}" || true
 
       - name: Upload kind logs
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: pr-e2e-kind-logs
-          path: ${{ runner.temp }}/kind-logs
+          name: pr-e2e-kind-logs-${{ matrix.suite }}
+          path: ${{ runner.temp }}/kind-logs-${{ matrix.suite }}
           if-no-files-found: ignore
 
       - name: Cleanup Kind cluster
         if: always()
         run: kind delete cluster --name "${KIND_CLUSTER_NAME}" || true
+
+  e2e:
+    name: e2e
+    runs-on: ubuntu-latest
+    needs: e2e_suites
+    if: ${{ always() }}
+    permissions:
+      contents: read
+    steps:
+      - name: Check PR E2E suite results
+        shell: bash
+        run: |
+          if [[ "${{ needs.e2e_suites.result }}" != "success" ]]; then
+            echo "PR E2E suites finished with result: ${{ needs.e2e_suites.result }}"
+            exit 1
+          fi

--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -199,6 +199,7 @@ func main() {
 	namespaceLister := informerFactory.Core().V1().Namespaces().Lister()
 	serviceAccountLister := informerFactory.Core().V1().ServiceAccounts().Lister()
 	networkPolicyLister := informerFactory.Networking().V1().NetworkPolicies().Lister()
+	replicaSetLister := informerFactory.Apps().V1().ReplicaSets().Lister()
 
 	// Create operator
 	operator := controller.NewOperator(
@@ -216,9 +217,12 @@ func main() {
 		operator.SetTemplateStatsPublisher(controller.NewPGTemplateStatsPublisher(pool, cfg.DefaultClusterId, clk, logger))
 	}
 	claimStartLimiter, err := startlimiter.New(ctx, startlimiter.Config{
-		ClusterID: cfg.DefaultClusterId,
-		K8sClient: k8sClient,
-		PGPool:    pool,
+		ClusterID:        cfg.DefaultClusterId,
+		K8sClient:        k8sClient,
+		NodeLister:       nodeLister,
+		PodLister:        podLister,
+		ReplicaSetLister: replicaSetLister,
+		PGPool:           pool,
 		Redis: rediscache.Config{
 			URL:       cfg.RedisURL,
 			KeyPrefix: cfg.RedisKeyPrefix,

--- a/manager/pkg/controller/pool_manager.go
+++ b/manager/pkg/controller/pool_manager.go
@@ -61,6 +61,7 @@ const (
 	AnnotationNetworkPolicyAppliedHash     = "sandbox0.ai/network-policy-applied-hash"
 	AnnotationSandboxID                    = "sandbox0.ai/sandbox-id"
 	AnnotationRuntimeGeneration            = "sandbox0.ai/runtime-generation"
+	AnnotationClaimStartReservation        = startlimiter.AnnotationClaimStartReservation
 	AnnotationWebhookStateVolumeID         = "sandbox0.ai/webhook-state-volume-id"
 	AnnotationTemplateSpecHash             = "sandbox0.ai/template-spec-hash"
 	AnnotationTemplateTeamID               = "sandbox0.ai/template-team-id"

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -475,8 +475,20 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 			zap.String("template", req.Template),
 		)
 
+		var claimStartReservation *startlimiter.Reservation
+		if s.claimStartLimiter != nil && s.claimStartLimiter.SupportsReservations() {
+			claimStartReservation, _, err = s.claimStartLimiter.Reserve(ctx, startlimiter.ReasonColdCreate, 1)
+			if err != nil {
+				if metrics != nil {
+					metrics.SandboxClaimsTotal.WithLabelValues(req.Template, "error").Inc()
+				}
+				return nil, fmt.Errorf("create new pod: reserve claim start budget: %w", err)
+			}
+			defer claimStartReservation.Release()
+		}
+
 		phaseStarted = time.Now()
-		pod, err = s.createNewPod(ctx, template, req)
+		pod, err = s.createNewPodWithReservation(ctx, template, req, claimStartReservation)
 		s.observeClaimPhase(req.Template, claimType, "create_new_pod", phaseStarted, err)
 		if err != nil {
 			if metrics != nil {
@@ -1302,6 +1314,10 @@ func isIdlePodLostDuringClaim(err error) bool {
 }
 
 func (s *SandboxService) createNewPod(ctx context.Context, template *v1alpha1.SandboxTemplate, req *ClaimRequest) (*corev1.Pod, error) {
+	return s.createNewPodWithReservation(ctx, template, req, nil)
+}
+
+func (s *SandboxService) createNewPodWithReservation(ctx context.Context, template *v1alpha1.SandboxTemplate, req *ClaimRequest, reservation *startlimiter.Reservation) (*corev1.Pod, error) {
 	// Simulate K8s pod name generation: rs-name + "-" + 5 random chars
 	clusterID := naming.ClusterIDOrDefault(template.Spec.ClusterId)
 	podName, err := naming.SandboxName(clusterID, template.Name, utilrand.String(5))
@@ -1360,6 +1376,9 @@ func (s *SandboxService) createNewPod(ctx context.Context, template *v1alpha1.Sa
 		controller.AnnotationClaimedAt:         s.clock.Now().Format(time.RFC3339),
 		controller.AnnotationClaimType:         "cold",
 	})
+	if token := reservation.Token(); token != "" {
+		annotations[controller.AnnotationClaimStartReservation] = token
+	}
 	if stateVolume != nil {
 		annotations[controller.AnnotationWebhookStateVolumeID] = stateVolume.VolumeID
 	}
@@ -1418,7 +1437,9 @@ func (s *SandboxService) createNewPod(ctx context.Context, template *v1alpha1.Sa
 		createdPod, createErr = s.k8sClient.CoreV1().Pods(template.ObjectMeta.Namespace).Create(createCtx, pod, metav1.CreateOptions{})
 		return createErr
 	}
-	if s.claimStartLimiter != nil {
+	if reservation != nil {
+		err = createPod(ctx)
+	} else if s.claimStartLimiter != nil {
 		_, err = s.claimStartLimiter.Admit(ctx, startlimiter.ReasonColdCreate, 1, createPod)
 	} else {
 		err = createPod(ctx)

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -16,17 +16,20 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alicebob/miniredis/v2"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/network"
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/startlimiter"
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
 	"github.com/sandbox0-ai/sandbox0/pkg/dataplane"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
+	"github.com/sandbox0-ai/sandbox0/pkg/rediscache"
 	"github.com/sandbox0-ai/sandbox0/pkg/sandboxprobe"
 	"github.com/sandbox0-ai/sandbox0/pkg/volumeportal"
 	"go.uber.org/zap"
@@ -878,6 +881,62 @@ func TestCreateNewPodDefersNetworkApplyUntilPodHasNetworkIdentity(t *testing.T) 
 	}
 	if len(pods.Items) != 1 {
 		t.Fatalf("pods after createNewPod() = %d, want 1", len(pods.Items))
+	}
+}
+
+func TestCreateNewPodAnnotatesClaimStartReservation(t *testing.T) {
+	withClaimTestPublicKey(t)
+
+	redisServer := miniredis.RunT(t)
+	client := fake.NewSimpleClientset(&corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "sandbox-a"},
+		Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{{
+			Type:   corev1.NodeReady,
+			Status: corev1.ConditionTrue,
+		}}},
+	})
+	limiter, err := startlimiter.New(context.Background(), startlimiter.Config{
+		ClusterID:      "cluster-a",
+		K8sClient:      client,
+		PerSandboxNode: 1,
+		MaxLimit:       1,
+		Redis: rediscache.Config{
+			URL:       "redis://" + redisServer.Addr() + "/0",
+			KeyPrefix: "test",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create claim start limiter: %v", err)
+	}
+	reservation, _, err := limiter.Reserve(context.Background(), startlimiter.ReasonColdCreate, 1)
+	if err != nil {
+		t.Fatalf("Reserve() error = %v", err)
+	}
+	defer reservation.Release()
+
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "template-a",
+			Namespace: "ns-a",
+		},
+		Spec: v1alpha1.SandboxTemplateSpec{
+			MainContainer: v1alpha1.ContainerSpec{Image: "busybox"},
+		},
+	}
+	svc := &SandboxService{
+		k8sClient:            client,
+		secretLister:         newClaimTestSecretLister(t),
+		NetworkPolicyService: NewNetworkPolicyService(zap.NewNop()),
+		clock:                systemTime{},
+		logger:               zap.NewNop(),
+	}
+
+	pod, err := svc.createNewPodWithReservation(context.Background(), template, &ClaimRequest{TeamID: "team-a", UserID: "user-a"}, reservation)
+	if err != nil {
+		t.Fatalf("createNewPodWithReservation() error = %v", err)
+	}
+	if got := pod.Annotations[controller.AnnotationClaimStartReservation]; got != reservation.Token() {
+		t.Fatalf("claim start reservation annotation = %q, want %q", got, reservation.Token())
 	}
 }
 

--- a/manager/pkg/startlimiter/limiter.go
+++ b/manager/pkg/startlimiter/limiter.go
@@ -22,6 +22,8 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/client-go/kubernetes"
+	appslisters "k8s.io/client-go/listers/apps/v1"
+	corelisters "k8s.io/client-go/listers/core/v1"
 )
 
 const (
@@ -106,6 +108,9 @@ type Snapshot struct {
 type Config struct {
 	ClusterID           string
 	K8sClient           kubernetes.Interface
+	NodeLister          corelisters.NodeLister
+	PodLister           corelisters.PodLister
+	ReplicaSetLister    appslisters.ReplicaSetLister
 	PGPool              *pgxpool.Pool
 	Redis               rediscache.Config
 	PerSandboxNode      int32
@@ -119,6 +124,9 @@ type Config struct {
 
 type Limiter struct {
 	k8sClient           kubernetes.Interface
+	nodeLister          corelisters.NodeLister
+	podLister           corelisters.PodLister
+	replicaSetLister    appslisters.ReplicaSetLister
 	pgLocker            *pglock.Locker
 	redisClient         *redis.Client
 	redisTimeout        time.Duration
@@ -168,8 +176,8 @@ func (r *Reservation) Release() {
 
 // New creates a cluster-wide limiter for claim and warm-pool pod starts.
 func New(ctx context.Context, cfg Config) (*Limiter, error) {
-	if cfg.K8sClient == nil {
-		return nil, fmt.Errorf("kubernetes client is required")
+	if cfg.K8sClient == nil && !hasCachedListers(cfg) {
+		return nil, fmt.Errorf("kubernetes client or cached listers are required")
 	}
 	if cfg.PerSandboxNode <= 0 {
 		cfg.PerSandboxNode = defaultPerSandboxNode
@@ -198,6 +206,9 @@ func New(ctx context.Context, cfg Config) (*Limiter, error) {
 
 	limiter := &Limiter{
 		k8sClient:          cfg.K8sClient,
+		nodeLister:         cfg.NodeLister,
+		podLister:          cfg.PodLister,
+		replicaSetLister:   cfg.ReplicaSetLister,
 		pgLocker:           pglock.New(cfg.PGPool),
 		backend:            BackendPostgres,
 		lockResource:       fmt.Sprintf("manager:claim-start:%s", cfg.ClusterID),
@@ -437,23 +448,23 @@ type activeReservationSnapshot struct {
 }
 
 func (l *Limiter) snapshotLockedWithReservations(ctx context.Context, reservations *activeReservationSnapshot) (*Snapshot, error) {
-	nodes, err := l.k8sClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	nodes, err := l.listNodes(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("list nodes for claim start limiter: %w", err)
 	}
-	warmReadyNodes := countWarmReadySandboxNodes(nodes.Items, l.sandboxSelector, l.sandboxTolerations)
+	warmReadyNodes := countWarmReadySandboxNodes(nodes, l.sandboxSelector, l.sandboxTolerations)
 	limit := l.limitForNodes(warmReadyNodes)
 
-	pods, err := l.k8sClient.CoreV1().Pods("").List(ctx, metav1.ListOptions{LabelSelector: l.podSelector})
+	pods, err := l.listPods(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("list sandbox pods for claim start limiter: %w", err)
 	}
-	replicaSets, err := l.k8sClient.AppsV1().ReplicaSets("").List(ctx, metav1.ListOptions{LabelSelector: l.replicaSetSelector})
+	replicaSets, err := l.listReplicaSets(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("list pool replicasets for claim start limiter: %w", err)
 	}
 
-	inFlight := startPressure(pods.Items, replicaSets.Items, reservationTokens(reservations))
+	inFlight := startPressure(pods, replicaSets, reservationTokens(reservations))
 	if reservations != nil {
 		inFlight += reservations.units
 	}
@@ -515,6 +526,59 @@ func (l *Limiter) activeReservations(ctx context.Context) (*activeReservationSna
 		snapshot.units += units
 	}
 	return snapshot, nil
+}
+
+func (l *Limiter) listNodes(ctx context.Context) ([]*corev1.Node, error) {
+	if l.nodeLister != nil {
+		return l.nodeLister.List(labels.Everything())
+	}
+	nodes, err := l.k8sClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*corev1.Node, 0, len(nodes.Items))
+	for idx := range nodes.Items {
+		out = append(out, &nodes.Items[idx])
+	}
+	return out, nil
+}
+
+func (l *Limiter) listPods(ctx context.Context) ([]*corev1.Pod, error) {
+	selector, err := labels.Parse(l.podSelector)
+	if err != nil {
+		return nil, err
+	}
+	if l.podLister != nil {
+		return l.podLister.List(selector)
+	}
+	pods, err := l.k8sClient.CoreV1().Pods("").List(ctx, metav1.ListOptions{LabelSelector: l.podSelector})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*corev1.Pod, 0, len(pods.Items))
+	for idx := range pods.Items {
+		out = append(out, &pods.Items[idx])
+	}
+	return out, nil
+}
+
+func (l *Limiter) listReplicaSets(ctx context.Context) ([]*appsv1.ReplicaSet, error) {
+	selector, err := labels.Parse(l.replicaSetSelector)
+	if err != nil {
+		return nil, err
+	}
+	if l.replicaSetLister != nil {
+		return l.replicaSetLister.List(selector)
+	}
+	replicaSets, err := l.k8sClient.AppsV1().ReplicaSets("").List(ctx, metav1.ListOptions{LabelSelector: l.replicaSetSelector})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*appsv1.ReplicaSet, 0, len(replicaSets.Items))
+	for idx := range replicaSets.Items {
+		out = append(out, &replicaSets.Items[idx])
+	}
+	return out, nil
 }
 
 func (l *Limiter) addReservation(ctx context.Context, token string, units int32) error {
@@ -603,13 +667,12 @@ type poolKey struct {
 	templateID string
 }
 
-func startPressure(pods []corev1.Pod, replicaSets []appsv1.ReplicaSet, activeReservations map[string]struct{}) int32 {
+func startPressure(pods []*corev1.Pod, replicaSets []*appsv1.ReplicaSet, activeReservations map[string]struct{}) int32 {
 	readyIdleByPool := make(map[poolKey]int32)
 	startingIdleByPool := make(map[poolKey]int32)
 	var inFlight int32
 
-	for i := range pods {
-		pod := &pods[i]
+	for _, pod := range pods {
 		if !countsForStartPressure(pod) {
 			continue
 		}
@@ -632,9 +695,8 @@ func startPressure(pods []corev1.Pod, replicaSets []appsv1.ReplicaSet, activeRes
 		}
 	}
 
-	for i := range replicaSets {
-		rs := &replicaSets[i]
-		if rs.DeletionTimestamp != nil {
+	for _, rs := range replicaSets {
+		if rs == nil || rs.DeletionTimestamp != nil {
 			continue
 		}
 		key := poolKey{namespace: rs.Namespace, templateID: rs.Labels[labelTemplateID]}
@@ -720,10 +782,9 @@ func hasSandboxReadinessGate(pod *corev1.Pod) bool {
 	return false
 }
 
-func countWarmReadySandboxNodes(nodes []corev1.Node, selector map[string]string, tolerations []corev1.Toleration) int {
+func countWarmReadySandboxNodes(nodes []*corev1.Node, selector map[string]string, tolerations []corev1.Toleration) int {
 	count := 0
-	for i := range nodes {
-		node := &nodes[i]
+	for _, node := range nodes {
 		if node == nil || node.Spec.Unschedulable {
 			continue
 		}
@@ -818,6 +879,10 @@ func randomToken() (string, error) {
 		return "", fmt.Errorf("generate claim start lock token: %w", err)
 	}
 	return hex.EncodeToString(b[:]), nil
+}
+
+func hasCachedListers(cfg Config) bool {
+	return cfg.NodeLister != nil && cfg.PodLister != nil && cfg.ReplicaSetLister != nil
 }
 
 func cloneStringMap(src map[string]string) map[string]string {

--- a/manager/pkg/startlimiter/limiter.go
+++ b/manager/pkg/startlimiter/limiter.go
@@ -6,6 +6,8 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"strconv"
+	"sync"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -28,9 +30,14 @@ const (
 	defaultLockTTL        = 5 * time.Second
 	defaultAcquireTimeout = 250 * time.Millisecond
 	defaultRetryAfter     = time.Second
+	defaultReservationTTL = 5 * time.Minute
 
 	labelTemplateID = "sandbox0.ai/template-id"
 	labelPoolType   = "sandbox0.ai/pool-type"
+
+	// AnnotationClaimStartReservation marks a pod whose start is covered by an
+	// active Redis reservation, so pressure snapshots do not double-count it.
+	AnnotationClaimStartReservation = "sandbox0.ai/claim-start-reservation"
 
 	poolTypeIdle   = "idle"
 	poolTypeActive = "active"
@@ -111,22 +118,52 @@ type Config struct {
 }
 
 type Limiter struct {
-	k8sClient          kubernetes.Interface
-	pgLocker           *pglock.Locker
-	redisClient        *redis.Client
-	redisTimeout       time.Duration
-	backend            string
-	lockResource       string
-	lockKey            string
-	lockTTL            time.Duration
-	acquireTimeout     time.Duration
-	perSandboxNode     int32
-	maxLimit           int32
-	sandboxSelector    map[string]string
-	sandboxTolerations []corev1.Toleration
-	podSelector        string
-	replicaSetSelector string
-	logger             *zap.Logger
+	k8sClient           kubernetes.Interface
+	pgLocker            *pglock.Locker
+	redisClient         *redis.Client
+	redisTimeout        time.Duration
+	backend             string
+	lockResource        string
+	lockKey             string
+	reservationKey      string
+	reservationUnitsKey string
+	lockTTL             time.Duration
+	reservationTTL      time.Duration
+	acquireTimeout      time.Duration
+	perSandboxNode      int32
+	maxLimit            int32
+	sandboxSelector     map[string]string
+	sandboxTolerations  []corev1.Toleration
+	podSelector         string
+	replicaSetSelector  string
+	logger              *zap.Logger
+}
+
+// Reservation holds cluster-wide start budget for a claim that has passed
+// admission but is still waiting for the sandbox runtime to become ready.
+type Reservation struct {
+	limiter *Limiter
+	token   string
+	once    sync.Once
+}
+
+// Token returns the opaque reservation token that should be copied to created
+// pods via AnnotationClaimStartReservation.
+func (r *Reservation) Token() string {
+	if r == nil {
+		return ""
+	}
+	return r.token
+}
+
+// Release releases a Redis reservation. It is safe to call more than once.
+func (r *Reservation) Release() {
+	if r == nil || r.limiter == nil || r.token == "" {
+		return
+	}
+	r.once.Do(func() {
+		r.limiter.releaseReservation(r.token)
+	})
 }
 
 // New creates a cluster-wide limiter for claim and warm-pool pod starts.
@@ -185,7 +222,11 @@ func New(ctx context.Context, cfg Config) (*Limiter, error) {
 		limiter.redisClient = redisClient
 		limiter.redisTimeout = normalized.Timeout
 		limiter.backend = BackendRedis
-		limiter.lockKey = rediscache.JoinKeyPrefix(normalized.KeyPrefix, "manager", "claim-start", cfg.ClusterID, "lock")
+		keyPrefix := rediscache.JoinKeyPrefix(normalized.KeyPrefix, "manager", "claim-start", cfg.ClusterID)
+		limiter.lockKey = rediscache.JoinKeyPrefix(keyPrefix, "lock")
+		limiter.reservationKey = rediscache.JoinKeyPrefix(keyPrefix, "reservations")
+		limiter.reservationUnitsKey = rediscache.JoinKeyPrefix(keyPrefix, "reservation-units")
+		limiter.reservationTTL = defaultReservationTTL
 	}
 
 	return limiter, nil
@@ -198,6 +239,12 @@ func (l *Limiter) Backend() string {
 	return l.backend
 }
 
+// SupportsReservations reports whether this limiter can hold admission slots
+// beyond the immediate Kubernetes mutation.
+func (l *Limiter) SupportsReservations() bool {
+	return l != nil && l.redisClient != nil
+}
+
 // Admit runs mutate only if the cluster has enough remaining start budget.
 func (l *Limiter) Admit(ctx context.Context, reason Reason, units int32, mutate func(context.Context) error) (*Snapshot, error) {
 	if l == nil {
@@ -208,6 +255,18 @@ func (l *Limiter) Admit(ctx context.Context, reason Reason, units int32, mutate 
 	}
 	if units <= 0 {
 		units = 1
+	}
+
+	if l.redisClient != nil {
+		reservation, snapshot, err := l.Reserve(ctx, reason, units)
+		if err != nil {
+			return snapshot, err
+		}
+		defer reservation.Release()
+		if mutate == nil {
+			return snapshot, nil
+		}
+		return snapshot, mutate(ctx)
 	}
 
 	var snapshot *Snapshot
@@ -233,12 +292,79 @@ func (l *Limiter) Admit(ctx context.Context, reason Reason, units int32, mutate 
 	return snapshot, err
 }
 
+// Reserve takes start budget without running a mutation. Redis-backed limiters
+// hold the reservation until Release; other backends only perform the same
+// guarded admission check as Admit.
+func (l *Limiter) Reserve(ctx context.Context, reason Reason, units int32) (*Reservation, *Snapshot, error) {
+	if l == nil {
+		return nil, &Snapshot{}, nil
+	}
+	if units <= 0 {
+		units = 1
+	}
+	if l.redisClient == nil {
+		var snapshot *Snapshot
+		err := l.withLock(ctx, func(lockCtx context.Context) error {
+			s, err := l.snapshotLocked(lockCtx)
+			if err != nil {
+				return err
+			}
+			snapshot = s
+			if s.Available < units {
+				return &ThrottledError{
+					Reason:     reason,
+					Units:      units,
+					RetryAfter: defaultRetryAfter,
+					Snapshot:   *s,
+				}
+			}
+			return nil
+		})
+		return nil, snapshot, err
+	}
+
+	var snapshot *Snapshot
+	var token string
+	err := l.withLock(ctx, func(lockCtx context.Context) error {
+		reservations, err := l.activeReservations(lockCtx)
+		if err != nil {
+			return err
+		}
+		s, err := l.snapshotLockedWithReservations(lockCtx, reservations)
+		if err != nil {
+			return err
+		}
+		snapshot = s
+		if s.Available < units {
+			return &ThrottledError{
+				Reason:     reason,
+				Units:      units,
+				RetryAfter: defaultRetryAfter,
+				Snapshot:   *s,
+			}
+		}
+		token, err = randomToken()
+		if err != nil {
+			return err
+		}
+		return l.addReservation(lockCtx, token, units)
+	})
+	if err != nil {
+		return nil, snapshot, err
+	}
+	return &Reservation{limiter: l, token: token}, snapshot, nil
+}
+
 // Snapshot returns the current limiter pressure without taking the admission lock.
 func (l *Limiter) Snapshot(ctx context.Context) (*Snapshot, error) {
 	if l == nil {
 		return nil, nil
 	}
-	return l.snapshotLocked(ctx)
+	reservations, err := l.activeReservations(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return l.snapshotLockedWithReservations(ctx, reservations)
 }
 
 func (l *Limiter) withLock(ctx context.Context, fn func(context.Context) error) error {
@@ -259,6 +385,15 @@ func (l *Limiter) withRedisLock(ctx context.Context, fn func(context.Context) er
 		ok, setErr := l.redisClient.SetNX(opCtx, l.lockKey, token, l.lockTTL).Result()
 		cancel()
 		if setErr != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if errors.Is(setErr, context.DeadlineExceeded) {
+				return &ThrottledError{
+					RetryAfter: defaultRetryAfter,
+					Message:    "claim start admission lock is unavailable",
+				}
+			}
 			return fmt.Errorf("acquire redis claim start lock: %w", setErr)
 		}
 		if ok {
@@ -293,6 +428,15 @@ func (l *Limiter) releaseRedisLock(token string) {
 }
 
 func (l *Limiter) snapshotLocked(ctx context.Context) (*Snapshot, error) {
+	return l.snapshotLockedWithReservations(ctx, nil)
+}
+
+type activeReservationSnapshot struct {
+	tokens map[string]struct{}
+	units  int32
+}
+
+func (l *Limiter) snapshotLockedWithReservations(ctx context.Context, reservations *activeReservationSnapshot) (*Snapshot, error) {
 	nodes, err := l.k8sClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("list nodes for claim start limiter: %w", err)
@@ -309,7 +453,10 @@ func (l *Limiter) snapshotLocked(ctx context.Context) (*Snapshot, error) {
 		return nil, fmt.Errorf("list pool replicasets for claim start limiter: %w", err)
 	}
 
-	inFlight := startPressure(pods.Items, replicaSets.Items)
+	inFlight := startPressure(pods.Items, replicaSets.Items, reservationTokens(reservations))
+	if reservations != nil {
+		inFlight += reservations.units
+	}
 	available := limit - inFlight
 	if available < 0 {
 		available = 0
@@ -321,6 +468,123 @@ func (l *Limiter) snapshotLocked(ctx context.Context) (*Snapshot, error) {
 		InFlight:              inFlight,
 		Available:             available,
 	}, nil
+}
+
+func reservationTokens(reservations *activeReservationSnapshot) map[string]struct{} {
+	if reservations == nil {
+		return nil
+	}
+	return reservations.tokens
+}
+
+func (l *Limiter) activeReservations(ctx context.Context) (*activeReservationSnapshot, error) {
+	if l == nil || l.redisClient == nil {
+		return nil, nil
+	}
+	nowMs := time.Now().UnixMilli()
+	expired, err := l.redisZRangeByScore(ctx, l.reservationKey, "-inf", strconv.FormatInt(nowMs, 10))
+	if err != nil {
+		return nil, fmt.Errorf("list expired claim start reservations: %w", err)
+	}
+	if len(expired) > 0 {
+		if err := l.removeReservations(ctx, expired...); err != nil {
+			return nil, err
+		}
+	}
+	active, err := l.redisZRangeByScore(ctx, l.reservationKey, strconv.FormatInt(nowMs+1, 10), "+inf")
+	if err != nil {
+		return nil, fmt.Errorf("list active claim start reservations: %w", err)
+	}
+	if len(active) == 0 {
+		return &activeReservationSnapshot{}, nil
+	}
+	values, err := l.redisHMGet(ctx, active...)
+	if err != nil {
+		return nil, err
+	}
+	snapshot := &activeReservationSnapshot{tokens: make(map[string]struct{}, len(active))}
+	for idx, token := range active {
+		units := int32(1)
+		if idx < len(values) && values[idx] != nil {
+			parsed, parseErr := strconv.ParseInt(fmt.Sprint(values[idx]), 10, 32)
+			if parseErr == nil && parsed > 0 {
+				units = int32(parsed)
+			}
+		}
+		snapshot.tokens[token] = struct{}{}
+		snapshot.units += units
+	}
+	return snapshot, nil
+}
+
+func (l *Limiter) addReservation(ctx context.Context, token string, units int32) error {
+	if l == nil || l.redisClient == nil || token == "" {
+		return nil
+	}
+	if units <= 0 {
+		units = 1
+	}
+	expireAtMs := time.Now().Add(l.reservationTTL).UnixMilli()
+	opCtx, cancel := rediscache.WithTimeout(ctx, l.redisTimeout)
+	defer cancel()
+	pipe := l.redisClient.TxPipeline()
+	pipe.ZAdd(opCtx, l.reservationKey, redis.Z{Score: float64(expireAtMs), Member: token})
+	pipe.HSet(opCtx, l.reservationUnitsKey, token, strconv.FormatInt(int64(units), 10))
+	pipe.PExpire(opCtx, l.reservationKey, l.reservationTTL)
+	pipe.PExpire(opCtx, l.reservationUnitsKey, l.reservationTTL)
+	if _, err := pipe.Exec(opCtx); err != nil {
+		return fmt.Errorf("add claim start reservation: %w", err)
+	}
+	return nil
+}
+
+func (l *Limiter) releaseReservation(token string) {
+	if l == nil || l.redisClient == nil || token == "" {
+		return
+	}
+	if err := l.removeReservations(context.Background(), token); err != nil {
+		l.logger.Warn("Failed to release claim start reservation", zap.String("token", token), zap.Error(err))
+	}
+}
+
+func (l *Limiter) removeReservations(ctx context.Context, tokens ...string) error {
+	if l == nil || l.redisClient == nil || len(tokens) == 0 {
+		return nil
+	}
+	args := make([]interface{}, 0, len(tokens))
+	for _, token := range tokens {
+		if token != "" {
+			args = append(args, token)
+		}
+	}
+	if len(args) == 0 {
+		return nil
+	}
+	opCtx, cancel := rediscache.WithTimeout(ctx, l.redisTimeout)
+	defer cancel()
+	pipe := l.redisClient.TxPipeline()
+	pipe.ZRem(opCtx, l.reservationKey, args...)
+	pipe.HDel(opCtx, l.reservationUnitsKey, tokens...)
+	if _, err := pipe.Exec(opCtx); err != nil {
+		return fmt.Errorf("remove claim start reservation: %w", err)
+	}
+	return nil
+}
+
+func (l *Limiter) redisZRangeByScore(ctx context.Context, key, min, max string) ([]string, error) {
+	opCtx, cancel := rediscache.WithTimeout(ctx, l.redisTimeout)
+	defer cancel()
+	return l.redisClient.ZRangeByScore(opCtx, key, &redis.ZRangeBy{Min: min, Max: max}).Result()
+}
+
+func (l *Limiter) redisHMGet(ctx context.Context, tokens ...string) ([]interface{}, error) {
+	opCtx, cancel := rediscache.WithTimeout(ctx, l.redisTimeout)
+	defer cancel()
+	values, err := l.redisClient.HMGet(opCtx, l.reservationUnitsKey, tokens...).Result()
+	if err != nil {
+		return nil, fmt.Errorf("read claim start reservation units: %w", err)
+	}
+	return values, nil
 }
 
 func (l *Limiter) limitForNodes(nodes int) int32 {
@@ -339,7 +603,7 @@ type poolKey struct {
 	templateID string
 }
 
-func startPressure(pods []corev1.Pod, replicaSets []appsv1.ReplicaSet) int32 {
+func startPressure(pods []corev1.Pod, replicaSets []appsv1.ReplicaSet, activeReservations map[string]struct{}) int32 {
 	readyIdleByPool := make(map[poolKey]int32)
 	startingIdleByPool := make(map[poolKey]int32)
 	var inFlight int32
@@ -347,6 +611,9 @@ func startPressure(pods []corev1.Pod, replicaSets []appsv1.ReplicaSet) int32 {
 	for i := range pods {
 		pod := &pods[i]
 		if !countsForStartPressure(pod) {
+			continue
+		}
+		if podCoveredByActiveReservation(pod, activeReservations) {
 			continue
 		}
 		key := poolKey{namespace: pod.Namespace, templateID: pod.Labels[labelTemplateID]}
@@ -387,6 +654,18 @@ func startPressure(pods []corev1.Pod, replicaSets []appsv1.ReplicaSet) int32 {
 		}
 	}
 	return inFlight
+}
+
+func podCoveredByActiveReservation(pod *corev1.Pod, activeReservations map[string]struct{}) bool {
+	if pod == nil || len(activeReservations) == 0 {
+		return false
+	}
+	token := pod.Annotations[AnnotationClaimStartReservation]
+	if token == "" {
+		return false
+	}
+	_, ok := activeReservations[token]
+	return ok
 }
 
 func countsForStartPressure(pod *corev1.Pod) bool {

--- a/manager/pkg/startlimiter/limiter_test.go
+++ b/manager/pkg/startlimiter/limiter_test.go
@@ -12,6 +12,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+	appslisters "k8s.io/client-go/listers/apps/v1"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
 )
 
 func TestSnapshotCountsWarmReadyNodesAndStartPressure(t *testing.T) {
@@ -92,6 +95,45 @@ func TestAdmitThrottlesWhenBudgetIsFull(t *testing.T) {
 	}
 	if called {
 		t.Fatal("Admit() called mutation despite full budget")
+	}
+}
+
+func TestSnapshotUsesCachedListersWhenConfigured(t *testing.T) {
+	ctx := context.Background()
+	nodeLister, podLister, replicaSetLister := cachedListers(t,
+		[]*corev1.Node{readyNode("sandbox-a", map[string]string{"role": "sandbox"}, nil)},
+		nil,
+		[]*appsv1.ReplicaSet{replicaSet("default", "tmpl-a-rs", "tmpl-a", 2)},
+	)
+	limiter, err := New(ctx, Config{
+		NodeLister:       nodeLister,
+		PodLister:        podLister,
+		ReplicaSetLister: replicaSetLister,
+		PerSandboxNode:   10,
+		MaxLimit:         10,
+		SandboxNodeSelector: map[string]string{
+			"role": "sandbox",
+		},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	snapshot, err := limiter.Snapshot(ctx)
+	if err != nil {
+		t.Fatalf("Snapshot() error = %v", err)
+	}
+	if snapshot.WarmReadySandboxNodes != 1 {
+		t.Fatalf("WarmReadySandboxNodes = %d, want 1", snapshot.WarmReadySandboxNodes)
+	}
+	if snapshot.Limit != 10 {
+		t.Fatalf("Limit = %d, want 10", snapshot.Limit)
+	}
+	if snapshot.InFlight != 2 {
+		t.Fatalf("InFlight = %d, want ReplicaSet desired gap 2", snapshot.InFlight)
+	}
+	if snapshot.Available != 8 {
+		t.Fatalf("Available = %d, want 8", snapshot.Available)
 	}
 }
 
@@ -336,4 +378,29 @@ func replicaSet(namespace, name, templateID string, replicas int32) *appsv1.Repl
 		},
 		Spec: appsv1.ReplicaSetSpec{Replicas: &replicas},
 	}
+}
+
+func cachedListers(t *testing.T, nodes []*corev1.Node, pods []*corev1.Pod, replicaSets []*appsv1.ReplicaSet) (corelisters.NodeLister, corelisters.PodLister, appslisters.ReplicaSetLister) {
+	t.Helper()
+	nodeIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	for _, node := range nodes {
+		if err := nodeIndexer.Add(node); err != nil {
+			t.Fatalf("add node to indexer: %v", err)
+		}
+	}
+	podIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	for _, pod := range pods {
+		if err := podIndexer.Add(pod); err != nil {
+			t.Fatalf("add pod to indexer: %v", err)
+		}
+	}
+	replicaSetIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	for _, replicaSet := range replicaSets {
+		if err := replicaSetIndexer.Add(replicaSet); err != nil {
+			t.Fatalf("add ReplicaSet to indexer: %v", err)
+		}
+	}
+	return corelisters.NewNodeLister(nodeIndexer),
+		corelisters.NewPodLister(podIndexer),
+		appslisters.NewReplicaSetLister(replicaSetIndexer)
 }

--- a/manager/pkg/startlimiter/limiter_test.go
+++ b/manager/pkg/startlimiter/limiter_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/sandbox0-ai/sandbox0/pkg/rediscache"
@@ -111,6 +112,154 @@ func TestNewUsesRedisWhenConfigured(t *testing.T) {
 	}
 	if got := limiter.Backend(); got != BackendRedis {
 		t.Fatalf("Backend() = %q, want %q", got, BackendRedis)
+	}
+}
+
+func TestRedisReserveHoldsBudgetUntilReleased(t *testing.T) {
+	ctx := context.Background()
+	redisServer := miniredis.RunT(t)
+	client := fake.NewSimpleClientset(readyNode("sandbox-a", nil, nil))
+	limiter, err := New(ctx, Config{
+		ClusterID:      "cluster-a",
+		K8sClient:      client,
+		PerSandboxNode: 1,
+		MaxLimit:       1,
+		Redis: rediscache.Config{
+			URL:       "redis://" + redisServer.Addr() + "/0",
+			KeyPrefix: "test",
+		},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	reservation, snapshot, err := limiter.Reserve(ctx, ReasonColdCreate, 1)
+	if err != nil {
+		t.Fatalf("Reserve() error = %v", err)
+	}
+	defer reservation.Release()
+	if reservation.Token() == "" {
+		t.Fatal("Reservation token is empty")
+	}
+	if snapshot.Available != 1 {
+		t.Fatalf("pre-reservation Available = %d, want 1", snapshot.Available)
+	}
+
+	snapshot, err = limiter.Snapshot(ctx)
+	if err != nil {
+		t.Fatalf("Snapshot() error = %v", err)
+	}
+	if snapshot.InFlight != 1 || snapshot.Available != 0 {
+		t.Fatalf("Snapshot() inFlight/available = %d/%d, want 1/0", snapshot.InFlight, snapshot.Available)
+	}
+
+	called := false
+	_, err = limiter.Admit(ctx, ReasonColdCreate, 1, func(context.Context) error {
+		called = true
+		return nil
+	})
+	if !errors.Is(err, ErrThrottled) {
+		t.Fatalf("Admit() error = %v, want ErrThrottled", err)
+	}
+	if called {
+		t.Fatal("Admit() called mutation while reservation held all budget")
+	}
+
+	reservation.Release()
+	_, err = limiter.Admit(ctx, ReasonColdCreate, 1, func(context.Context) error {
+		called = true
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Admit() after release error = %v", err)
+	}
+	if !called {
+		t.Fatal("Admit() after release did not call mutation")
+	}
+}
+
+func TestRedisReservationAvoidsDoubleCountingAnnotatedPod(t *testing.T) {
+	ctx := context.Background()
+	redisServer := miniredis.RunT(t)
+	client := fake.NewSimpleClientset(readyNode("sandbox-a", nil, nil))
+	limiter, err := New(ctx, Config{
+		ClusterID:      "cluster-a",
+		K8sClient:      client,
+		PerSandboxNode: 10,
+		MaxLimit:       10,
+		Redis: rediscache.Config{
+			URL:       "redis://" + redisServer.Addr() + "/0",
+			KeyPrefix: "test",
+		},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	reservation, _, err := limiter.Reserve(ctx, ReasonColdCreate, 1)
+	if err != nil {
+		t.Fatalf("Reserve() error = %v", err)
+	}
+	defer reservation.Release()
+
+	pod := startingActivePod("default", "active-starting", "tmpl-a")
+	pod.Annotations = map[string]string{
+		AnnotationClaimStartReservation: reservation.Token(),
+	}
+	if _, err := client.CoreV1().Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create pod: %v", err)
+	}
+
+	snapshot, err := limiter.Snapshot(ctx)
+	if err != nil {
+		t.Fatalf("Snapshot() error = %v", err)
+	}
+	if snapshot.InFlight != 1 {
+		t.Fatalf("InFlight with active reservation and annotated pod = %d, want 1", snapshot.InFlight)
+	}
+
+	reservation.Release()
+	snapshot, err = limiter.Snapshot(ctx)
+	if err != nil {
+		t.Fatalf("Snapshot() after release error = %v", err)
+	}
+	if snapshot.InFlight != 1 {
+		t.Fatalf("InFlight after reservation release = %d, want pod pressure 1", snapshot.InFlight)
+	}
+}
+
+func TestRedisLockBusyReturnsThrottled(t *testing.T) {
+	ctx := context.Background()
+	redisServer := miniredis.RunT(t)
+	client := fake.NewSimpleClientset(readyNode("sandbox-a", nil, nil))
+	limiter, err := New(ctx, Config{
+		ClusterID:      "cluster-a",
+		K8sClient:      client,
+		PerSandboxNode: 1,
+		MaxLimit:       1,
+		AcquireTimeout: time.Millisecond,
+		Redis: rediscache.Config{
+			URL:       "redis://" + redisServer.Addr() + "/0",
+			KeyPrefix: "test",
+		},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if err := limiter.redisClient.Set(ctx, limiter.lockKey, "busy", time.Minute).Err(); err != nil {
+		t.Fatalf("seed redis lock: %v", err)
+	}
+
+	called := false
+	_, err = limiter.Admit(ctx, ReasonColdCreate, 1, func(context.Context) error {
+		called = true
+		return nil
+	})
+	if !errors.Is(err, ErrThrottled) {
+		t.Fatalf("Admit() error = %v, want ErrThrottled", err)
+	}
+	if called {
+		t.Fatal("Admit() called mutation while redis lock was busy")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add Redis-backed claim-start reservations so cold claims keep admission budget until network identity and claim readiness finish.
- Include active reservations in cluster pressure snapshots and mark cold pods with a reservation annotation to avoid double-counting the same start.
- Treat Redis lock acquisition deadline failures as claim-start throttling instead of surfacing them as internal claim errors.
- Read claim-start pressure snapshots from the manager informer cache, with direct Kubernetes reads kept as a fallback for tests and non-standard wiring.
- Split the PR e2e suites into parallel matrix jobs while preserving the aggregate `e2e` check name.

## Why
The production 500-claim benchmark showed many retries and some `acquire redis claim start lock: context deadline exceeded` failures. The existing limiter only guarded the immediate pod mutation, so scheduler summaries and manager admission could still amplify concurrent cold starts while the long readiness tail was running.

The limiter also used live Kubernetes LIST calls for nodes, pods, and ReplicaSets on every pressure snapshot. Wiring it to the already-synced manager informer cache keeps admission checks off the apiserver hot path while preserving the live Get/Update paths used for ReplicaSet mutations.

The PR e2e workflow also ran the core, S0FS POSIX, and mountpoint-s3 compatibility suites serially in one job. Running them as independent Kind-backed matrix jobs reduces PR wall-clock time while keeping per-suite failure diagnostics.

## Tests
- `go test ./manager/pkg/startlimiter`
- `go test ./manager/...`
- `go test ./scheduler/...`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/pr-e2e.yml`
