### PR TITLE
Support forking running sandboxes

### DIFF
--- a/docs/integrations/vercel-eve/page.mdx
+++ b/docs/integrations/vercel-eve/page.mdx
@@ -6,7 +6,7 @@ Use this integration when you want Eve's agent runtime and tool model, but want 
 
 The adapter implements Eve's `SandboxBackend` lifecycle:
 
-- Eve `prewarm()` claims a Sandbox0 sandbox, runs `bootstrap`, writes seed files, pauses the sandbox, and captures a Sandbox0 rootfs snapshot
+- Eve `prewarm()` claims a Sandbox0 sandbox, runs `bootstrap`, writes seed files, and captures a Sandbox0 rootfs snapshot
 - Eve `create()` claims a fresh Sandbox0 sandbox from the prewarmed rootfs snapshot
 - Eve durable session metadata stores the Sandbox0 `sandboxId`, so later turns can resume the same sandbox
 - Eve file, command, and network policy calls are translated to Sandbox0 SDK calls
@@ -89,14 +89,13 @@ The Sandbox0 adapter performs this sequence:
 1. Claim a Sandbox0 sandbox from the configured template.
 2. Run Eve `bootstrap` inside that sandbox.
 3. Write Eve seed files into `/workspace`.
-4. Pause the sandbox and wait until Sandbox0 reports it as paused.
-5. Create a Sandbox0 rootfs snapshot.
-6. Store the mapping from Eve `templateKey` to Sandbox0 `snapshotId` under `.eve/sandbox0/`.
+4. Create a Sandbox0 rootfs snapshot from the prepared sandbox.
+5. Store the mapping from Eve `templateKey` to Sandbox0 `snapshotId` under `.eve/sandbox0/`.
 
 At runtime, Eve calls `create()` with the same `templateKey`. The adapter reads the stored mapping and claims a new Sandbox0 sandbox with `snapshotId`.
 
 <Callout variant="warning">
-Rootfs snapshot creation requires a paused Sandbox0 sandbox. The adapter handles the pause and polling step before snapshot creation.
+Sandbox0 rootfs snapshot creation accepts a running or paused source sandbox. A running prewarm sandbox is briefly checkpointed and remains running after snapshot creation.
 </Callout>
 
 ## Session Persistence

--- a/docs/sandbox/page.mdx
+++ b/docs/sandbox/page.mdx
@@ -467,7 +467,7 @@ Pause and resume is covered in a dedicated page because it affects TTL, `auto_re
 
 See [Pause And Resume](/docs/sandbox/pause-resume) for explicit pause, state inspection, resume, and auto-resume behavior.
 
-See [Snapshot And Restore](/docs/sandbox/snapshot-restore) for named rootfs snapshots, restore, and fork operations that require a paused sandbox.
+See [Snapshot And Restore](/docs/sandbox/snapshot-restore) for named rootfs snapshots, restore, and fork operations. Snapshot and fork accept a running or paused source sandbox; restore requires a paused target sandbox.
 
 ---
 

--- a/docs/sandbox/pause-resume/page.mdx
+++ b/docs/sandbox/pause-resume/page.mdx
@@ -207,6 +207,6 @@ For long-running agent workflows, a common pattern is:
   </Card>
 
   <Card title="Snapshot And Restore" href="/docs/sandbox/snapshot-restore" cta="Continue">
-    Create named restore points and fork paused sandbox rootfs state.
+    Create named restore points and fork sandbox rootfs state.
   </Card>
 </CardGroup>

--- a/docs/sandbox/snapshot-restore/page.mdx
+++ b/docs/sandbox/snapshot-restore/page.mdx
@@ -1,17 +1,17 @@
 # Snapshot And Restore
 
-Sandbox rootfs snapshots are point-in-time copies of a paused sandbox writable root filesystem. Use them when you want to checkpoint an initialized workspace, claim new sandboxes from that known filesystem state, roll an existing sandbox back, or fork a paused sandbox into an isolated child sandbox.
+Sandbox rootfs snapshots are point-in-time copies of a sandbox writable root filesystem. Use them when you want to checkpoint an initialized workspace, claim new sandboxes from that known filesystem state, roll an existing sandbox back, or fork a sandbox into an isolated child sandbox.
 
 Use this page when you need to:
 
-- create named rootfs snapshots from a paused sandbox
+- create named rootfs snapshots from a running or paused sandbox
 - claim a new sandbox with a named rootfs snapshot
 - restore a paused sandbox rootfs from a snapshot
-- fork a paused sandbox into another paused sandbox
+- fork a running or paused sandbox into another paused sandbox
 - understand how rootfs snapshots differ from pause/resume and Volumes
 
 <Callout variant="warning">
-Creating snapshots, restoring, and forking require a paused sandbox. Claiming with `snapshot_id` creates a new running sandbox from an existing snapshot and does not require a paused target sandbox. If you call paused-only operations while the sandbox is running, Sandbox0 returns `409 Conflict`.
+Creating snapshots and forking accept a running or paused source sandbox. Running sources are briefly barriered and checkpointed, then remain running. Restore still requires a paused target sandbox because it replaces that sandbox's rootfs head. Claiming with `snapshot_id` creates a new running sandbox from an existing snapshot and does not require a paused target sandbox.
 </Callout>
 
 ## How It Differs From Pause And Resume
@@ -19,10 +19,10 @@ Creating snapshots, restoring, and forking require a paused sandbox. Claiming wi
 | Capability | Purpose | Creates a named restore point | Creates another sandbox | Requires paused sandbox |
 |------------|---------|-------------------------------|-------------------------|-------------------------|
 | Pause/resume | Release compute and later continue the same sandbox identity from its latest checkpoint | No | No | Pause starts from a running sandbox; resume starts from a paused sandbox |
-| Snapshot | Publish an immutable point-in-time rootfs record | Yes | No | Yes |
+| Snapshot | Publish an immutable point-in-time rootfs record | Yes | No | No; running sources are checkpointed first |
 | Claim with `snapshot_id` | Create a running sandbox initialized from a named snapshot | Uses an existing snapshot | Yes | No target sandbox required |
 | Restore | Move a paused sandbox rootfs back to a snapshot | Uses an existing snapshot | No | Yes |
-| Fork | Create an isolated paused sandbox from a paused source sandbox rootfs | No | Yes | Yes |
+| Fork | Create an isolated paused sandbox from a source sandbox rootfs | No | Yes | No; running sources are checkpointed first |
 
 Pause/resume keeps the latest checkpoint for one sandbox identity. Rootfs snapshots are explicit records that you can list, fetch, claim from, restore, and delete. Fork creates a new sandbox with Copy-on-Write rootfs isolation from the source rootfs state.
 
@@ -30,10 +30,10 @@ Use [Volumes](/docs/sandbox/volume) when data must be mounted by multiple sandbo
 
 ## State Model
 
-- `Create snapshot` reads the paused sandbox's current rootfs head and creates a snapshot record.
+- `Create snapshot` creates a snapshot record from the source sandbox's current rootfs head. If the source is running, Sandbox0 briefly barriers the sandbox, checkpoints its writable rootfs, and then releases the source back to running.
 - `Claim with snapshot_id` creates a running sandbox and initializes its writable rootfs from the selected snapshot before process APIs are initialized.
 - `Restore` changes a paused target sandbox rootfs head to the selected snapshot and leaves the sandbox paused.
-- `Fork` creates a new paused sandbox with the source sandbox configuration and an isolated rootfs fork. The fork request can override lifecycle `ttl` and `hard_ttl`.
+- `Fork` creates a new paused sandbox with the source sandbox configuration and an isolated rootfs fork. If the source is running, Sandbox0 briefly barriers the sandbox, checkpoints its writable rootfs, and then releases the source back to running. The fork request can override lifecycle `ttl` and `hard_ttl`.
 - `Resume` is required before reading or writing files through sandbox process and file APIs after restore or fork. A sandbox claimed with `snapshot_id` starts running.
 - Deleting a snapshot does not modify any sandbox already claimed or restored from it, and it does not affect forks created from the same rootfs state.
 
@@ -56,18 +56,14 @@ Typical workflow:
 
 1. claim a sandbox from a builtin template backed by the platform warm pool
 2. install dependencies or prepare the workspace inside the sandbox rootfs
-3. pause the sandbox and wait until `status` is `paused`
-4. create a named rootfs snapshot for the initialized state
+3. create a named rootfs snapshot for the initialized state
+4. optionally pause or delete the seed sandbox after the snapshot is created
 5. claim each task sandbox with the same template and `snapshot_id`
 
 ```bash
 SEED_SANDBOX_ID="$(s0 -o json sandbox create --template default --hard-ttl 86400 | jq -r '.id')"
 
 # Initialize the rootfs with your normal sandbox commands, file writes, or SSH session.
-
-s0 sandbox pause "$SEED_SANDBOX_ID"
-# Wait until this shows status "paused".
-s0 sandbox get "$SEED_SANDBOX_ID"
 
 SNAPSHOT_ID="$(s0 -o json sandbox snapshot create "$SEED_SANDBOX_ID" \
     --name python-deps-v1 \
@@ -81,7 +77,7 @@ TASK_SANDBOX_ID="$(s0 -o json sandbox create \
     | jq -r '.id')"
 ```
 
-Claiming with `snapshot_id` is the preferred path for reusable custom rootfs state because the result is a fresh running sandbox that still uses the builtin template's image, resources, mounts, services, and network defaults. Use restore when you need to roll an existing paused sandbox back to a snapshot. Use fork when you specifically need a paused child sandbox cloned from a paused seed.
+Claiming with `snapshot_id` is the preferred path for reusable custom rootfs state because the result is a fresh running sandbox that still uses the builtin template's image, resources, mounts, services, and network defaults. Use restore when you need to roll an existing paused sandbox back to a snapshot. Use fork when you specifically need a paused child sandbox cloned from a running or paused source.
 
 For a longer walkthrough of this pattern, see [Initialize Once, Claim Many](/blog/2026-06/initialize-once-fork-many-custom-ai-agent-sandboxes).
 
@@ -89,9 +85,9 @@ For a longer walkthrough of this pattern, see [Initialize Once, Claim Many](/blo
 This pattern does not replace template-level configuration. Use a custom template when you need a different container image, resource limits, mount declarations, default network policy, environment defaults, or privileged runtime fields. Mounted Sandbox Volumes are separate from the sandbox rootfs and should be managed with Volume snapshot and fork APIs.
 </Callout>
 
-## Pause Before Rootfs Operations
+## Rootfs Operation Lifecycle
 
-Pause the sandbox and wait until `status` is `paused` before creating a snapshot, restoring, or forking.
+Create a snapshot from a running or paused sandbox. Pause the sandbox and wait until `status` is `paused` before restoring into it. Forking also accepts a running or paused source sandbox.
 
 <Endpoint method="POST">
 /api/v1/sandboxes/{'{id}'}/pause
@@ -157,7 +153,7 @@ s0 sandbox get sb_abc123`
 
 ## Create A Snapshot
 
-Create a rootfs snapshot from a paused sandbox.
+Create a rootfs snapshot from a running or paused sandbox. A running source remains running after the snapshot is created.
 
 <Endpoint method="POST">
 /api/v1/sandboxes/{'{id}'}/snapshots
@@ -407,7 +403,7 @@ s0 sandbox resume sb_abc123`
 
 ## Fork A Sandbox
 
-Fork creates a new paused sandbox from a paused source sandbox rootfs. The fork receives its own sandbox ID. Writes made after resuming the fork do not modify the source sandbox rootfs.
+Fork creates a new paused sandbox from a running or paused source sandbox rootfs. A running source is briefly barriered and checkpointed during the operation, then remains running. The fork receives its own sandbox ID. Writes made after resuming the fork do not modify the source sandbox rootfs.
 
 <Endpoint method="POST">
 /api/v1/sandboxes/{'{id}'}/fork

--- a/docs/template/page.mdx
+++ b/docs/template/page.mdx
@@ -21,7 +21,7 @@ Builtin templates use curated public images and are ready to use immediately. Cu
 
 ## Custom Template Or Rootfs Snapshot
 
-You do not need a custom template for every initialized environment. If the base image, default resources, network policy, and mount declarations already fit, you can claim a sandbox from a builtin template, install dependencies or clone repositories inside the writable root filesystem, pause it, create a rootfs snapshot, then claim future sandboxes with that `snapshot_id`.
+You do not need a custom template for every initialized environment. If the base image, default resources, network policy, and mount declarations already fit, you can claim a sandbox from a builtin template, install dependencies or clone repositories inside the writable root filesystem, create a rootfs snapshot, then claim future sandboxes with that `snapshot_id`.
 
 This is useful for dependency-heavy agent workspaces:
 
@@ -39,7 +39,7 @@ For platform-owned builtin templates, the operator manages the warm pool. That l
 | User-space dependencies, repository checkout, package cache, generated files, or per-project tool configuration on an existing base image | Builtin template plus rootfs snapshot and claim with `snapshot_id` |
 | Data that must outlive sandbox identity, be mounted by multiple sandboxes, or be accessed through direct storage APIs | Sandbox Volume |
 
-Rootfs snapshots do not create template IDs and do not appear in `s0 template list`. Claiming with `snapshot_id` creates a new running sandbox from the selected rootfs snapshot while the requested template still controls image, default resources, mounts, services, and network defaults. A claim or runtime update can override only the sandbox memory limit; CPU is derived from the platform memory-per-CPU ratio. Restore remains useful for rolling back an existing paused sandbox, and fork remains useful when you specifically need a paused child sandbox. See [Snapshot And Restore](/docs/sandbox/snapshot-restore) for the paused-state requirements and API workflow, or read [Initialize Once, Claim Many](/blog/2026-06/initialize-once-fork-many-custom-ai-agent-sandboxes) for the custom-rootfs pattern.
+Rootfs snapshots do not create template IDs and do not appear in `s0 template list`. Claiming with `snapshot_id` creates a new running sandbox from the selected rootfs snapshot while the requested template still controls image, default resources, mounts, services, and network defaults. A claim or runtime update can override only the sandbox memory limit; CPU is derived from the platform memory-per-CPU ratio. Snapshot and fork accept a running or paused source sandbox. Restore remains useful for rolling back an existing paused sandbox. See [Snapshot And Restore](/docs/sandbox/snapshot-restore) for the lifecycle requirements and API workflow, or read [Initialize Once, Claim Many](/blog/2026-06/initialize-once-fork-many-custom-ai-agent-sandboxes) for the custom-rootfs pattern.
 
 ---
 

--- a/manager/pkg/http/handlers_sandbox_rootfs.go
+++ b/manager/pkg/http/handlers_sandbox_rootfs.go
@@ -149,12 +149,18 @@ func (s *Server) writeSandboxRootFSError(c *gin.Context, action, sandboxID strin
 		spec.JSONError(c, http.StatusNotFound, spec.CodeNotFound, "not found")
 	case apierrors.IsForbidden(err):
 		spec.JSONError(c, http.StatusForbidden, spec.CodeForbidden, "forbidden")
+	case apierrors.IsConflict(err):
+		spec.JSONError(c, http.StatusConflict, spec.CodeConflict, err.Error())
 	case errors.Is(err, service.ErrSandboxRootFSRequiresPausedSandbox):
 		spec.JSONError(c, http.StatusConflict, spec.CodeConflict, "sandbox rootfs operation requires a paused sandbox")
+	case errors.Is(err, service.ErrSandboxRootFSSourceRequiresRunningOrPaused):
+		spec.JSONError(c, http.StatusConflict, spec.CodeConflict, "sandbox rootfs source operation requires a running or paused sandbox")
 	case errors.Is(err, service.ErrRootFSSnapshotExpired):
 		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
 	case errors.Is(err, service.ErrRootFSFilesystemConflict), errors.Is(err, service.ErrRootFSHeadConflict), errors.Is(err, service.ErrRootFSFilesystemNotFound):
 		spec.JSONError(c, http.StatusConflict, spec.CodeConflict, err.Error())
+	case errors.Is(err, service.ErrSandboxCheckpointRequiresCtld):
+		spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox checkpoint requires ctld")
 	case errors.Is(err, service.ErrSandboxRootFSStoreUnavailable):
 		spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox rootfs store is unavailable")
 	default:

--- a/manager/pkg/service/sandbox_service.go
+++ b/manager/pkg/service/sandbox_service.go
@@ -59,7 +59,7 @@ var ErrClaimConflict = errors.New("claim conflict")
 var ErrDataPlaneNotReady = errors.New("data plane not ready")
 var ErrQuotaExceeded = errors.New("quota exceeded")
 var ErrInvalidNetworkPolicy = errors.New("invalid network policy")
-var ErrSandboxCheckpointRequiresCtld = errors.New("sandbox checkpoint pause requires ctld")
+var ErrSandboxCheckpointRequiresCtld = errors.New("sandbox checkpoint requires ctld")
 var ErrClaimStartThrottled = startlimiter.ErrThrottled
 
 const defaultPodClaimReadyTimeout = 90 * time.Second

--- a/manager/pkg/service/sandbox_service_lifecycle.go
+++ b/manager/pkg/service/sandbox_service_lifecycle.go
@@ -1217,6 +1217,21 @@ func sandboxLifecycleTxnCancelRequested(txn *SandboxLifecycleTxn) bool {
 	return txn != nil && !txn.CancelRequestedAt.IsZero()
 }
 
+func sandboxLifecycleRootFSSourceCheckpointTxnStale(txn *SandboxLifecycleTxn, now time.Time) bool {
+	if txn == nil || txn.UpdatedAt.IsZero() {
+		return false
+	}
+	switch txn.Kind {
+	case SandboxLifecycleKindFork, SandboxLifecycleKindSnapshot:
+	default:
+		return false
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+	return now.Sub(txn.UpdatedAt) > sandboxRootFSSourceCheckpointLifecycleStaleAfter
+}
+
 func sandboxLifecycleTxnCancelableAutoPause(txn *SandboxLifecycleTxn) bool {
 	if txn == nil {
 		return false

--- a/manager/pkg/service/sandbox_service_restore.go
+++ b/manager/pkg/service/sandbox_service_restore.go
@@ -274,9 +274,10 @@ func (s *SandboxService) commitResumedSandboxRuntime(ctx context.Context, pod *c
 }
 
 var (
-	errSandboxLifecyclePausing  = errors.New("sandbox lifecycle pause is in progress")
-	errSandboxLifecycleResuming = errors.New("sandbox lifecycle resume is in progress")
-	errSandboxRuntimeDeleting   = errors.New("sandbox runtime pod deletion is in progress")
+	errSandboxLifecyclePausing             = errors.New("sandbox lifecycle pause is in progress")
+	errSandboxLifecycleResuming            = errors.New("sandbox lifecycle resume is in progress")
+	errSandboxLifecycleRootFSCheckpointing = errors.New("sandbox lifecycle rootfs checkpoint is in progress")
+	errSandboxRuntimeDeleting              = errors.New("sandbox runtime pod deletion is in progress")
 )
 
 type sandboxRuntimePodRef struct {
@@ -300,6 +301,19 @@ func (s *SandboxService) waitForSandboxLifecycleTxnExit(ctx context.Context, san
 		}
 		if txn == nil {
 			return nil
+		}
+		if sandboxLifecycleRootFSSourceCheckpointTxnStale(txn, s.now()) {
+			reason := "stale rootfs checkpoint transaction"
+			switch txn.Kind {
+			case SandboxLifecycleKindFork:
+				reason = "stale fork transaction"
+			case SandboxLifecycleKindSnapshot:
+				reason = "stale snapshot transaction"
+			}
+			if err := s.abortLifecycleTxn(ctx, sandboxID, txn.ID, reason); err != nil {
+				return err
+			}
+			continue
 		}
 		select {
 		case <-ctx.Done():

--- a/manager/pkg/service/sandbox_service_rootfs.go
+++ b/manager/pkg/service/sandbox_service_rootfs.go
@@ -21,6 +21,7 @@ import (
 const sandboxRootFSContainerName = "procd"
 
 const sandboxRootFSOperationTimeout = 5 * time.Minute
+const sandboxRootFSSourceCheckpointLifecycleStaleAfter = sandboxRootFSOperationTimeout + time.Minute
 const sandboxRootFSUncommittedObjectDeleteDelay = 15 * time.Minute
 const sandboxRootFSUncommittedObjectDeleteTimeout = 30 * time.Second
 

--- a/manager/pkg/service/sandbox_service_rootfs_product.go
+++ b/manager/pkg/service/sandbox_service_rootfs_product.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 	"go.uber.org/zap"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -16,6 +17,7 @@ import (
 
 var ErrSandboxRootFSStoreUnavailable = errors.New("sandbox rootfs store is unavailable")
 var ErrSandboxRootFSRequiresPausedSandbox = errors.New("sandbox rootfs operation requires a paused sandbox")
+var ErrSandboxRootFSSourceRequiresRunningOrPaused = errors.New("sandbox rootfs source operation requires a running or paused sandbox")
 var ErrRootFSSnapshotExpired = errors.New("rootfs snapshot expires_at must be in the future")
 
 type SandboxRootFSProductStore interface {
@@ -106,28 +108,38 @@ func (s *SandboxService) CreateSandboxRootFSSnapshot(ctx context.Context, sandbo
 	if !req.ExpiresAt.IsZero() && !req.ExpiresAt.After(s.now().UTC()) {
 		return nil, ErrRootFSSnapshotExpired
 	}
-	var snapshot *RootFSSnapshot
-	err = s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, record *SandboxRecord) error {
-		if err := validateRootFSSandboxRecord(record, sandboxID, teamID, true); err != nil {
-			return err
+	snapshotID := generateRootFSSnapshotID()
+	name := strings.TrimSpace(req.Name)
+	description := strings.TrimSpace(req.Description)
+	var checkpoint *rootFSSourceCheckpoint
+	for {
+		_, checkpoint, err = s.prepareRootFSSourceCheckpoint(ctx, sandboxID, teamID, SandboxLifecycleKindSnapshot)
+		if err == nil {
+			break
 		}
-		creator := sandboxRootFSSnapshotCreator(store)
-		if txCreator, ok := tx.(sandboxRootFSSnapshotCreator); ok {
-			creator = txCreator
+		switch {
+		case errors.Is(err, errSandboxLifecyclePausing),
+			errors.Is(err, errSandboxLifecycleResuming),
+			errors.Is(err, errSandboxLifecycleRootFSCheckpointing):
+			if waitErr := s.waitForSandboxLifecycleTxnExit(ctx, sandboxID); waitErr != nil {
+				return nil, waitErr
+			}
+			continue
+		default:
+			return nil, err
 		}
-		var createErr error
-		snapshot, createErr = creator.CreateRootFSSnapshot(lockCtx, &CreateRootFSSnapshotRequest{
-			SandboxID:   sandboxID,
-			SnapshotID:  generateRootFSSnapshotID(),
-			Name:        strings.TrimSpace(req.Name),
-			Description: strings.TrimSpace(req.Description),
-			ExpiresAt:   req.ExpiresAt,
-		})
-		return createErr
-	})
+	}
+	checkpointCommitted := false
+	if checkpoint != nil {
+		defer func() {
+			checkpoint.close(s, checkpointCommitted)
+		}()
+	}
+	snapshot, err := s.commitRootFSSnapshot(ctx, store, sandboxID, teamID, snapshotID, name, description, req.ExpiresAt, checkpoint)
 	if err != nil {
 		return nil, err
 	}
+	checkpointCommitted = true
 	return sandboxRootFSSnapshotFromStore(snapshot), nil
 }
 
@@ -251,21 +263,36 @@ func (s *SandboxService) ForkSandbox(ctx context.Context, sourceSandboxID, teamI
 	}
 
 	var source *SandboxRecord
-	if err := s.sandboxStore.WithSandboxLock(ctx, sourceSandboxID, func(lockCtx context.Context, _ SandboxStoreTx, record *SandboxRecord) error {
-		if err := validateForkSourceSandboxRecord(record, sourceSandboxID, teamID, s.now()); err != nil {
-			return err
+	var checkpoint *rootFSSourceCheckpoint
+	for {
+		source, checkpoint, err = s.prepareRootFSSourceCheckpoint(ctx, sourceSandboxID, teamID, SandboxLifecycleKindFork)
+		if err == nil {
+			break
 		}
-		source = cloneSandboxRecordForRootFSProduct(record)
-		return nil
-	}); err != nil {
-		return nil, err
+		switch {
+		case errors.Is(err, errSandboxLifecyclePausing),
+			errors.Is(err, errSandboxLifecycleResuming),
+			errors.Is(err, errSandboxLifecycleRootFSCheckpointing):
+			if waitErr := s.waitForSandboxLifecycleTxnExit(ctx, sourceSandboxID); waitErr != nil {
+				return nil, waitErr
+			}
+			continue
+		default:
+			return nil, err
+		}
 	}
 	template, err := s.templateForSandboxRecord(source)
 	if err != nil {
+		if checkpoint != nil {
+			checkpoint.close(s, false)
+		}
 		return nil, err
 	}
 	targetID, err := s.generateAvailableForkSandboxID(ctx, template)
 	if err != nil {
+		if checkpoint != nil {
+			checkpoint.close(s, false)
+		}
 		return nil, err
 	}
 	now := s.now().UTC()
@@ -279,6 +306,9 @@ func (s *SandboxService) ForkSandbox(ctx context.Context, sourceSandboxID, teamI
 		}
 	}
 	if err := validateSandboxConfigLifecycle(targetConfig.TTL, targetConfig.HardTTL); err != nil {
+		if checkpoint != nil {
+			checkpoint.close(s, false)
+		}
 		return nil, err
 	}
 	expiresAt := expirationFromTTL(now, targetConfig.TTL)
@@ -306,10 +336,285 @@ func (s *SandboxService) ForkSandbox(ctx context.Context, sourceSandboxID, teamI
 		CreatedAt:         now,
 		UpdatedAt:         now,
 	}
-	err = s.sandboxStore.WithSandboxLock(ctx, sourceSandboxID, func(lockCtx context.Context, tx SandboxStoreTx, record *SandboxRecord) error {
-		if err := validateForkSourceSandboxRecord(record, sourceSandboxID, teamID, s.now()); err != nil {
+	checkpointCommitted := false
+	if checkpoint != nil {
+		defer func() {
+			checkpoint.close(s, checkpointCommitted)
+		}()
+	}
+	err = s.commitForkSandbox(ctx, store, sourceSandboxID, teamID, target, checkpoint)
+	if err != nil {
+		return nil, err
+	}
+	checkpointCommitted = true
+	return &ForkSandboxResponse{
+		SourceSandboxID: sourceSandboxID,
+		Sandbox:         s.recordToSandbox(target),
+	}, nil
+}
+
+type rootFSSourceCheckpoint struct {
+	txn           *SandboxLifecycleTxn
+	rootFSState   *SandboxRootFSState
+	procdAddress  string
+	internalToken string
+}
+
+func (c *rootFSSourceCheckpoint) close(s *SandboxService, committed bool) {
+	if c == nil || s == nil {
+		return
+	}
+	if !committed {
+		reason := rootFSSourceCheckpointTxnReason(c.txn, "transaction did not commit")
+		s.deleteUncommittedRootFSObject(c.rootFSState, reason)
+		if c.txn != nil {
+			_ = s.abortLifecycleTxn(context.Background(), c.txn.SandboxID, c.txn.ID, reason)
+		}
+	}
+	s.releasePauseRuntimeBarrier(context.Background(), c.procdAddress, c.internalToken)
+}
+
+func rootFSSourceCheckpointTxnReason(txn *SandboxLifecycleTxn, suffix string) string {
+	kind := "rootfs checkpoint"
+	if txn != nil {
+		switch txn.Kind {
+		case SandboxLifecycleKindFork:
+			kind = "fork"
+		case SandboxLifecycleKindSnapshot:
+			kind = "snapshot"
+		}
+	}
+	return kind + " " + suffix
+}
+
+func (s *SandboxService) prepareRootFSSourceCheckpoint(ctx context.Context, sourceSandboxID, teamID, kind string) (*SandboxRecord, *rootFSSourceCheckpoint, error) {
+	switch kind {
+	case SandboxLifecycleKindFork, SandboxLifecycleKindSnapshot:
+	default:
+		return nil, nil, fmt.Errorf("unsupported rootfs source checkpoint kind %q", kind)
+	}
+	var source *SandboxRecord
+	var txn *SandboxLifecycleTxn
+	var waitErr error
+	err := s.sandboxStore.WithSandboxLock(ctx, sourceSandboxID, func(lockCtx context.Context, tx SandboxStoreTx, record *SandboxRecord) error {
+		if err := validateRootFSSourceSandboxRecord(record, sourceSandboxID, teamID, s.now()); err != nil {
 			return err
 		}
+		activeTxn, err := tx.GetActiveLifecycleTxn(lockCtx, sourceSandboxID)
+		if err != nil {
+			return err
+		}
+		if activeTxn != nil {
+			switch activeTxn.Kind {
+			case SandboxLifecycleKindPause:
+				if sandboxLifecycleTxnCancelableAutoPause(activeTxn) {
+					if _, err := tx.RequestLifecycleTxnCancel(lockCtx, activeTxn.ID, kind+" arrived during auto pause"); err != nil {
+						return err
+					}
+				}
+				waitErr = errSandboxLifecyclePausing
+			case SandboxLifecycleKindResume:
+				waitErr = errSandboxLifecycleResuming
+			default:
+				waitErr = errSandboxLifecycleRootFSCheckpointing
+			}
+			return nil
+		}
+		source = cloneSandboxRecordForRootFSProduct(record)
+		if record.Status == SandboxStatusPaused {
+			return nil
+		}
+		if !s.config.CtldEnabled || s.ctldClient == nil {
+			return ErrSandboxCheckpointRequiresCtld
+		}
+		pod, err := s.getSandboxPod(lockCtx, sourceSandboxID)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return apierrors.NewConflict(schema.GroupResource{Resource: "sandbox"}, sourceSandboxID, fmt.Errorf("running sandbox has no runtime pod"))
+			}
+			return fmt.Errorf("get runtime pod: %w", err)
+		}
+		if pod.DeletionTimestamp != nil {
+			return apierrors.NewConflict(schema.GroupResource{Resource: "sandbox"}, sourceSandboxID, fmt.Errorf("runtime pod deletion is in progress"))
+		}
+		txn = &SandboxLifecycleTxn{
+			ID:               uuid.NewString(),
+			SandboxID:        sourceSandboxID,
+			Kind:             kind,
+			Phase:            SandboxLifecyclePhasePreparing,
+			Source:           SandboxLifecycleSourceManual,
+			FromGeneration:   runtimeGenerationFromPod(pod),
+			FromPodNamespace: pod.Namespace,
+			FromPodName:      pod.Name,
+		}
+		return tx.BeginLifecycleTxn(lockCtx, txn)
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	if waitErr != nil {
+		return nil, nil, waitErr
+	}
+	if source == nil {
+		return nil, nil, fmt.Errorf("sandbox record is required")
+	}
+	if txn == nil {
+		return source, nil, nil
+	}
+	checkpoint, err := s.prepareRunningRootFSSourceCheckpoint(ctx, source, txn)
+	if err != nil {
+		_ = s.abortLifecycleTxn(context.Background(), sourceSandboxID, txn.ID, err.Error())
+		if checkpoint != nil {
+			checkpoint.close(s, false)
+		}
+		return nil, nil, err
+	}
+	return source, checkpoint, nil
+}
+
+func (s *SandboxService) prepareRunningRootFSSourceCheckpoint(ctx context.Context, source *SandboxRecord, txn *SandboxLifecycleTxn) (*rootFSSourceCheckpoint, error) {
+	if source == nil || txn == nil {
+		return nil, fmt.Errorf("rootfs checkpoint source is required")
+	}
+	pod, err := s.getSandboxPod(ctx, source.ID)
+	if err != nil {
+		return nil, fmt.Errorf("get runtime pod: %w", err)
+	}
+	generation := runtimeGenerationFromPod(pod)
+	if generation != txn.FromGeneration {
+		return nil, fmt.Errorf("sandbox runtime generation changed during rootfs checkpoint: txn=%d pod=%d", txn.FromGeneration, generation)
+	}
+	if txn.FromPodName != "" && pod.Name != txn.FromPodName {
+		return nil, apierrors.NewConflict(schema.GroupResource{Resource: "pod"}, pod.Name, fmt.Errorf("rootfs checkpoint transaction points at runtime pod %s", txn.FromPodName))
+	}
+	if txn.FromPodNamespace != "" && pod.Namespace != txn.FromPodNamespace {
+		return nil, apierrors.NewConflict(schema.GroupResource{Resource: "pod"}, pod.Name, fmt.Errorf("rootfs checkpoint transaction points at runtime namespace %s", txn.FromPodNamespace))
+	}
+	if err := s.markLifecycleTxnPhase(ctx, source.ID, txn.ID, SandboxLifecyclePhaseBarriered); err != nil {
+		return nil, err
+	}
+	procdAddress, internalToken, err := s.activatePauseRuntimeBarrier(ctx, pod, source, txn)
+	if err != nil {
+		return nil, err
+	}
+	checkpoint := &rootFSSourceCheckpoint{
+		txn:           txn,
+		procdAddress:  procdAddress,
+		internalToken: internalToken,
+	}
+	if err := s.markLifecycleTxnPhase(ctx, source.ID, txn.ID, SandboxLifecyclePhasePublishing); err != nil {
+		return checkpoint, err
+	}
+	rootFSState, err := s.prepareSandboxRootFSCheckpoint(ctx, pod, source)
+	if err != nil {
+		return checkpoint, err
+	}
+	if rootFSState == nil {
+		return checkpoint, fmt.Errorf("rootfs checkpoint produced no state")
+	}
+	checkpoint.rootFSState = rootFSState
+	if err := s.markLifecycleTxnPreparedHead(ctx, source.ID, txn.ID, rootFSState.LayerID); err != nil {
+		return checkpoint, err
+	}
+	return checkpoint, nil
+}
+
+func (s *SandboxService) commitRootFSSnapshot(ctx context.Context, store SandboxRootFSProductStore, sandboxID, teamID, snapshotID, name, description string, expiresAt time.Time, checkpoint *rootFSSourceCheckpoint) (*RootFSSnapshot, error) {
+	var snapshot *RootFSSnapshot
+	err := s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, record *SandboxRecord) error {
+		if err := validateRootFSSourceSandboxRecord(record, sandboxID, teamID, s.now()); err != nil {
+			return err
+		}
+		activeTxn, err := tx.GetActiveLifecycleTxn(lockCtx, sandboxID)
+		if err != nil {
+			return err
+		}
+		if checkpoint != nil {
+			if activeTxn == nil || checkpoint.txn == nil || activeTxn.ID != checkpoint.txn.ID || activeTxn.Kind != SandboxLifecycleKindSnapshot {
+				return fmt.Errorf("snapshot lifecycle transaction is no longer active")
+			}
+			if err := tx.UpdateLifecycleTxnPhase(lockCtx, checkpoint.txn.ID, SandboxLifecyclePhaseCommitting); err != nil {
+				return err
+			}
+			if checkpoint.rootFSState != nil {
+				if err := tx.SaveRootFSState(lockCtx, checkpoint.rootFSState); err != nil {
+					return err
+				}
+			}
+		} else {
+			if activeTxn != nil {
+				return errSandboxLifecycleRootFSCheckpointing
+			}
+			if record.Status != SandboxStatusPaused {
+				return errSandboxLifecycleRootFSCheckpointing
+			}
+		}
+
+		creator := sandboxRootFSSnapshotCreator(store)
+		if txCreator, ok := tx.(sandboxRootFSSnapshotCreator); ok {
+			creator = txCreator
+		}
+		var createErr error
+		snapshot, createErr = creator.CreateRootFSSnapshot(lockCtx, &CreateRootFSSnapshotRequest{
+			SandboxID:   sandboxID,
+			SnapshotID:  snapshotID,
+			Name:        name,
+			Description: description,
+			ExpiresAt:   expiresAt,
+		})
+		if createErr != nil {
+			return createErr
+		}
+		if checkpoint != nil && checkpoint.txn != nil {
+			preparedHead := ""
+			if checkpoint.rootFSState != nil {
+				preparedHead = checkpoint.rootFSState.LayerID
+			}
+			if err := tx.CommitLifecycleTxn(lockCtx, checkpoint.txn.ID, preparedHead); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return snapshot, nil
+}
+
+func (s *SandboxService) commitForkSandbox(ctx context.Context, store SandboxRootFSProductStore, sourceSandboxID, teamID string, target *SandboxRecord, checkpoint *rootFSSourceCheckpoint) error {
+	if target == nil {
+		return fmt.Errorf("target sandbox record is required")
+	}
+	err := s.sandboxStore.WithSandboxLock(ctx, sourceSandboxID, func(lockCtx context.Context, tx SandboxStoreTx, record *SandboxRecord) error {
+		if err := validateRootFSSourceSandboxRecord(record, sourceSandboxID, teamID, s.now()); err != nil {
+			return err
+		}
+		activeTxn, err := tx.GetActiveLifecycleTxn(lockCtx, sourceSandboxID)
+		if err != nil {
+			return err
+		}
+		if checkpoint != nil {
+			if activeTxn == nil || checkpoint.txn == nil || activeTxn.ID != checkpoint.txn.ID || activeTxn.Kind != SandboxLifecycleKindFork {
+				return fmt.Errorf("fork lifecycle transaction is no longer active")
+			}
+			if err := tx.UpdateLifecycleTxnPhase(lockCtx, checkpoint.txn.ID, SandboxLifecyclePhaseCommitting); err != nil {
+				return err
+			}
+			if checkpoint.rootFSState != nil {
+				if err := tx.SaveRootFSState(lockCtx, checkpoint.rootFSState); err != nil {
+					return err
+				}
+			}
+		} else {
+			if activeTxn != nil {
+				return errSandboxLifecycleRootFSCheckpointing
+			}
+			if record.Status != SandboxStatusPaused {
+				return errSandboxLifecycleRootFSCheckpointing
+			}
+		}
+
 		upserter := sandboxRecordUpserter(s.sandboxStore)
 		txBacked := false
 		if txUpserter, ok := tx.(sandboxRecordUpserter); ok {
@@ -326,29 +631,35 @@ func (s *SandboxService) ForkSandbox(ctx context.Context, sourceSandboxID, teamI
 		}
 		if _, err := forker.ForkRootFSFilesystem(lockCtx, &ForkRootFSFilesystemRequest{
 			SourceSandboxID: sourceSandboxID,
-			TargetSandboxID: targetID,
+			TargetSandboxID: target.ID,
 			TargetTeamID:    teamID,
 		}); err != nil {
 			if txBacked {
 				return err
 			}
-			if cleanupErr := s.sandboxStore.MarkSandboxDeleted(lockCtx, targetID, s.now().UTC()); cleanupErr != nil && s.logger != nil {
+			if cleanupErr := s.sandboxStore.MarkSandboxDeleted(lockCtx, target.ID, s.now().UTC()); cleanupErr != nil && s.logger != nil {
 				s.logger.Warn("Failed to clean up sandbox record after rootfs fork failure",
-					zap.String("sandboxID", targetID),
+					zap.String("sandboxID", target.ID),
 					zap.Error(cleanupErr),
 				)
 			}
 			return err
 		}
+		if checkpoint != nil && checkpoint.txn != nil {
+			preparedHead := ""
+			if checkpoint.rootFSState != nil {
+				preparedHead = checkpoint.rootFSState.LayerID
+			}
+			if err := tx.CommitLifecycleTxn(lockCtx, checkpoint.txn.ID, preparedHead); err != nil {
+				return err
+			}
+		}
 		return nil
 	})
 	if err != nil {
-		return nil, err
+		return err
 	}
-	return &ForkSandboxResponse{
-		SourceSandboxID: sourceSandboxID,
-		Sandbox:         s.recordToSandbox(target),
-	}, nil
+	return nil
 }
 
 func (s *SandboxService) rootFSProductStore() (SandboxRootFSProductStore, error) {
@@ -409,9 +720,12 @@ func validateRootFSSandboxRecord(record *SandboxRecord, sandboxID, teamID string
 	return nil
 }
 
-func validateForkSourceSandboxRecord(record *SandboxRecord, sandboxID, teamID string, now time.Time) error {
-	if err := validateRootFSSandboxRecord(record, sandboxID, teamID, true); err != nil {
+func validateRootFSSourceSandboxRecord(record *SandboxRecord, sandboxID, teamID string, now time.Time) error {
+	if err := validateRootFSSandboxRecord(record, sandboxID, teamID, false); err != nil {
 		return err
+	}
+	if record.Status != SandboxStatusPaused && record.Status != SandboxStatusRunning {
+		return fmt.Errorf("%w: current status is %s", ErrSandboxRootFSSourceRequiresRunningOrPaused, record.Status)
 	}
 	if sandboxHardExpired(record.HardExpiresAt, now) {
 		return apierrors.NewNotFound(schema.GroupResource{Resource: "sandbox"}, sandboxID)

--- a/manager/pkg/service/sandbox_service_rootfs_product_test.go
+++ b/manager/pkg/service/sandbox_service_rootfs_product_test.go
@@ -2,17 +2,22 @@ package service
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
+	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
-func TestSandboxRootFSProductRequiresPausedSandbox(t *testing.T) {
+func TestSandboxRootFSProductRequiresPausedSandboxForRestore(t *testing.T) {
 	now := time.Now().UTC()
 	store := &memorySandboxStore{
 		records: map[string]*SandboxRecord{
@@ -35,13 +40,13 @@ func TestSandboxRootFSProductRequiresPausedSandbox(t *testing.T) {
 	svc := rootFSProductTestService(store)
 
 	_, err := svc.CreateSandboxRootFSSnapshot(context.Background(), "sandbox-1", "team-1", nil)
-	require.ErrorIs(t, err, ErrSandboxRootFSRequiresPausedSandbox)
+	require.ErrorIs(t, err, ErrSandboxCheckpointRequiresCtld)
 
 	_, err = svc.RestoreSandboxRootFS(context.Background(), "sandbox-1", "team-1", &RestoreSandboxRootFSRequest{SnapshotID: "snapshot-1"})
 	require.ErrorIs(t, err, ErrSandboxRootFSRequiresPausedSandbox)
 
 	_, err = svc.ForkSandbox(context.Background(), "sandbox-1", "team-1", "user-1", nil)
-	require.ErrorIs(t, err, ErrSandboxRootFSRequiresPausedSandbox)
+	require.ErrorIs(t, err, ErrSandboxCheckpointRequiresCtld)
 }
 
 func TestSandboxRootFSProductSnapshotsRestoresAndForksPausedSandbox(t *testing.T) {
@@ -110,6 +115,287 @@ func TestSandboxRootFSProductSnapshotsRestoresAndForksPausedSandbox(t *testing.T
 	require.NoError(t, svc.DeleteSandboxRootFSSnapshot(context.Background(), snapshot.ID, "team-1"))
 	_, err = svc.GetSandboxRootFSSnapshot(context.Background(), snapshot.ID, "team-1")
 	require.ErrorIs(t, err, ErrRootFSSnapshotNotFound)
+}
+
+func TestSandboxRootFSProductSnapshotRunningSandboxCheckpointsWithoutPausingSource(t *testing.T) {
+	now := time.Now().UTC()
+	var prepareReq ctldapi.PrepareRootFSSnapshotRequest
+	var publishReq ctldapi.PublishRootFSSnapshotRequest
+	ctld := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/rootfs/snapshots/prepare":
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&prepareReq))
+			require.NoError(t, json.NewEncoder(w).Encode(ctldapi.PrepareRootFSSnapshotResponse{
+				Handle: "handle-1",
+				Info: ctldapi.RootFSInfo{
+					Runtime:             "runc",
+					RuntimeHandler:      "io.containerd.runc.v2",
+					BaseImageRef:        "docker.io/library/busybox:1.36",
+					BaseImageDigest:     "sha256:base",
+					Snapshotter:         "overlayfs",
+					SnapshotParent:      "parent-1",
+					SnapshotParentChain: []string{"parent-1", "parent-0"},
+				},
+				Descriptor: ctldapi.RootFSDiffDescriptor{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    "sha256:diff-v2",
+					Size:      456,
+				},
+			}))
+		case "/api/v1/rootfs/snapshots/publish":
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&publishReq))
+			require.NoError(t, json.NewEncoder(w).Encode(ctldapi.PublishRootFSSnapshotResponse{
+				Published: true,
+				Info: ctldapi.RootFSInfo{
+					Runtime:             "runc",
+					RuntimeHandler:      "io.containerd.runc.v2",
+					BaseImageRef:        "docker.io/library/busybox:1.36",
+					BaseImageDigest:     "sha256:base",
+					Snapshotter:         "overlayfs",
+					SnapshotParent:      "parent-1",
+					SnapshotParentChain: []string{"parent-1", "parent-0"},
+				},
+				Descriptor: ctldapi.RootFSDiffDescriptor{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    "sha256:diff-v2",
+					Size:      456,
+					ObjectKey: "sandbox-rootfs/team-1/sandbox-1/3/sha256/diff-v2.tar",
+				},
+			}))
+		default:
+			t.Fatalf("unexpected ctld path %s", r.URL.Path)
+		}
+	}))
+	defer ctld.Close()
+	ctldURL, ctldPort := parsedTestServer(t, ctld.URL)
+
+	pod := rootFSTestPod("pod-1", "sandbox-1", "team-1")
+	pod.Status.HostIP = ctldURL.Hostname()
+	source := rootFSProductTestRecord("sandbox-1", "team-1", SandboxStatusRunning, now)
+	source.CurrentPodNamespace = pod.Namespace
+	source.CurrentPodName = pod.Name
+	source.RuntimeGeneration = runtimeGenerationFromPod(pod)
+	store := &memorySandboxStore{
+		records: map[string]*SandboxRecord{
+			"sandbox-1": source,
+		},
+		rootFSStates: map[string]*SandboxRootFSState{
+			"sandbox-1": rootFSProductTestState("sandbox-1", "team-1", "layer-v1"),
+		},
+	}
+	svc := &SandboxService{
+		k8sClient:    fake.NewSimpleClientset(pod),
+		podLister:    newTestPodLister(t, pod),
+		sandboxStore: store,
+		ctldClient:   NewCtldClient(CtldClientConfig{Timeout: time.Second}),
+		config:       SandboxServiceConfig{CtldEnabled: true, CtldPort: ctldPort},
+		clock:        systemTime{},
+		logger:       zap.NewNop(),
+	}
+	var procdCalls []string
+	defer attachRootFSTestProcd(t, pod, svc, &procdCalls)()
+
+	snapshot, err := svc.CreateSandboxRootFSSnapshot(context.Background(), "sandbox-1", "team-1", &CreateSandboxRootFSSnapshotRequest{
+		Name: "running-state",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, snapshot)
+	assert.Equal(t, "sandbox-1", snapshot.SandboxID)
+	assert.Equal(t, "running-state", snapshot.Name)
+	assert.Equal(t, "layer-v1", prepareReq.ParentLayerID)
+	assert.Equal(t, "sandbox-1", publishReq.SandboxID)
+	assert.Equal(t, int64(3), publishReq.ExpectedRuntimeGeneration)
+	assert.Equal(t, []string{"barrier:true", "pause", "resume", "barrier:false"}, procdCalls)
+
+	sourceRecord := store.records["sandbox-1"]
+	require.NotNil(t, sourceRecord)
+	assert.Equal(t, SandboxStatusRunning, sourceRecord.Status)
+	assert.Equal(t, pod.Name, sourceRecord.CurrentPodName)
+	assert.Equal(t, pod.Namespace, sourceRecord.CurrentPodNamespace)
+	assert.Equal(t, 0, store.pauses)
+
+	sourceState := store.rootFSStates["sandbox-1"]
+	require.NotNil(t, sourceState)
+	assert.NotEqual(t, "layer-v1", sourceState.LayerID)
+	assert.Equal(t, int64(3), sourceState.RuntimeGeneration)
+	assert.Equal(t, "sha256:diff-v2", sourceState.DiffDigest)
+	storedSnapshot := store.rootFSSnapshots[snapshot.ID]
+	require.NotNil(t, storedSnapshot)
+	assert.Equal(t, sourceState.LayerID, storedSnapshot.HeadLayerID)
+
+	activeTxn, err := store.GetActiveLifecycleTxn(context.Background(), "sandbox-1")
+	require.NoError(t, err)
+	assert.Nil(t, activeTxn)
+}
+
+func TestSandboxRootFSProductForkRunningSandboxCheckpointsWithoutPausingSource(t *testing.T) {
+	now := time.Now().UTC()
+	var prepareReq ctldapi.PrepareRootFSSnapshotRequest
+	var publishReq ctldapi.PublishRootFSSnapshotRequest
+	ctld := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/rootfs/snapshots/prepare":
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&prepareReq))
+			require.NoError(t, json.NewEncoder(w).Encode(ctldapi.PrepareRootFSSnapshotResponse{
+				Handle: "handle-1",
+				Info: ctldapi.RootFSInfo{
+					Runtime:             "runc",
+					RuntimeHandler:      "io.containerd.runc.v2",
+					BaseImageRef:        "docker.io/library/busybox:1.36",
+					BaseImageDigest:     "sha256:base",
+					Snapshotter:         "overlayfs",
+					SnapshotParent:      "parent-1",
+					SnapshotParentChain: []string{"parent-1", "parent-0"},
+				},
+				Descriptor: ctldapi.RootFSDiffDescriptor{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    "sha256:diff-v2",
+					Size:      456,
+				},
+			}))
+		case "/api/v1/rootfs/snapshots/publish":
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&publishReq))
+			require.NoError(t, json.NewEncoder(w).Encode(ctldapi.PublishRootFSSnapshotResponse{
+				Published: true,
+				Info: ctldapi.RootFSInfo{
+					Runtime:             "runc",
+					RuntimeHandler:      "io.containerd.runc.v2",
+					BaseImageRef:        "docker.io/library/busybox:1.36",
+					BaseImageDigest:     "sha256:base",
+					Snapshotter:         "overlayfs",
+					SnapshotParent:      "parent-1",
+					SnapshotParentChain: []string{"parent-1", "parent-0"},
+				},
+				Descriptor: ctldapi.RootFSDiffDescriptor{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    "sha256:diff-v2",
+					Size:      456,
+					ObjectKey: "sandbox-rootfs/team-1/sandbox-1/3/sha256/diff-v2.tar",
+				},
+			}))
+		default:
+			t.Fatalf("unexpected ctld path %s", r.URL.Path)
+		}
+	}))
+	defer ctld.Close()
+	ctldURL, ctldPort := parsedTestServer(t, ctld.URL)
+
+	pod := rootFSTestPod("pod-1", "sandbox-1", "team-1")
+	pod.Status.HostIP = ctldURL.Hostname()
+	source := rootFSProductTestRecord("sandbox-1", "team-1", SandboxStatusRunning, now)
+	source.CurrentPodNamespace = pod.Namespace
+	source.CurrentPodName = pod.Name
+	source.RuntimeGeneration = runtimeGenerationFromPod(pod)
+	store := &memorySandboxStore{
+		records: map[string]*SandboxRecord{
+			"sandbox-1": source,
+		},
+		rootFSStates: map[string]*SandboxRootFSState{
+			"sandbox-1": rootFSProductTestState("sandbox-1", "team-1", "layer-v1"),
+		},
+	}
+	svc := &SandboxService{
+		k8sClient:    fake.NewSimpleClientset(pod),
+		podLister:    newTestPodLister(t, pod),
+		sandboxStore: store,
+		ctldClient:   NewCtldClient(CtldClientConfig{Timeout: time.Second}),
+		config:       SandboxServiceConfig{CtldEnabled: true, CtldPort: ctldPort},
+		clock:        systemTime{},
+		logger:       zap.NewNop(),
+	}
+	var procdCalls []string
+	defer attachRootFSTestProcd(t, pod, svc, &procdCalls)()
+
+	forkResp, err := svc.ForkSandbox(context.Background(), "sandbox-1", "team-1", "user-2", nil)
+
+	require.NoError(t, err)
+	require.NotNil(t, forkResp)
+	require.NotNil(t, forkResp.Sandbox)
+	assert.Equal(t, "sandbox-1", forkResp.SourceSandboxID)
+	assert.Equal(t, SandboxStatusPaused, forkResp.Sandbox.Status)
+	assert.Equal(t, "user-2", forkResp.Sandbox.UserID)
+	assert.Equal(t, "layer-v1", prepareReq.ParentLayerID)
+	assert.Equal(t, "sandbox-1", publishReq.SandboxID)
+	assert.Equal(t, int64(3), publishReq.ExpectedRuntimeGeneration)
+	assert.Equal(t, []string{"barrier:true", "pause", "resume", "barrier:false"}, procdCalls)
+
+	sourceRecord := store.records["sandbox-1"]
+	require.NotNil(t, sourceRecord)
+	assert.Equal(t, SandboxStatusRunning, sourceRecord.Status)
+	assert.Equal(t, pod.Name, sourceRecord.CurrentPodName)
+	assert.Equal(t, pod.Namespace, sourceRecord.CurrentPodNamespace)
+	assert.Equal(t, 0, store.pauses)
+
+	sourceState := store.rootFSStates["sandbox-1"]
+	require.NotNil(t, sourceState)
+	assert.NotEqual(t, "layer-v1", sourceState.LayerID)
+	assert.Equal(t, int64(3), sourceState.RuntimeGeneration)
+	assert.Equal(t, "sha256:diff-v2", sourceState.DiffDigest)
+	forkState := store.rootFSStates[forkResp.Sandbox.ID]
+	require.NotNil(t, forkState)
+	assert.Equal(t, sourceState.LayerID, forkState.LayerID)
+	assert.Equal(t, "team-1", forkState.TeamID)
+
+	activeTxn, err := store.GetActiveLifecycleTxn(context.Background(), "sandbox-1")
+	require.NoError(t, err)
+	assert.Nil(t, activeTxn)
+}
+
+func TestSandboxRootFSProductWaitAbortsStaleForkTxn(t *testing.T) {
+	now := time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
+	store := &memorySandboxStore{
+		records: map[string]*SandboxRecord{
+			"sandbox-1": rootFSProductTestRecord("sandbox-1", "team-1", SandboxStatusRunning, now),
+		},
+		lifecycleTxns: map[string]*SandboxLifecycleTxn{
+			"txn-1": {
+				ID:        "txn-1",
+				SandboxID: "sandbox-1",
+				Kind:      SandboxLifecycleKindFork,
+				Phase:     SandboxLifecyclePhasePublishing,
+				UpdatedAt: now.Add(-sandboxRootFSSourceCheckpointLifecycleStaleAfter - time.Second),
+			},
+		},
+	}
+	svc := rootFSProductTestService(store)
+	svc.clock = fixedClock{now: now}
+
+	err := svc.waitForSandboxLifecycleTxnExit(context.Background(), "sandbox-1")
+
+	require.NoError(t, err)
+	txn := store.lifecycleTxns["txn-1"]
+	require.NotNil(t, txn)
+	assert.Equal(t, SandboxLifecyclePhaseAborted, txn.Phase)
+	assert.Equal(t, "stale fork transaction", txn.Error)
+}
+
+func TestSandboxRootFSProductWaitAbortsStaleSnapshotTxn(t *testing.T) {
+	now := time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
+	store := &memorySandboxStore{
+		records: map[string]*SandboxRecord{
+			"sandbox-1": rootFSProductTestRecord("sandbox-1", "team-1", SandboxStatusRunning, now),
+		},
+		lifecycleTxns: map[string]*SandboxLifecycleTxn{
+			"txn-1": {
+				ID:        "txn-1",
+				SandboxID: "sandbox-1",
+				Kind:      SandboxLifecycleKindSnapshot,
+				Phase:     SandboxLifecyclePhasePublishing,
+				UpdatedAt: now.Add(-sandboxRootFSSourceCheckpointLifecycleStaleAfter - time.Second),
+			},
+		},
+	}
+	svc := rootFSProductTestService(store)
+	svc.clock = fixedClock{now: now}
+
+	err := svc.waitForSandboxLifecycleTxnExit(context.Background(), "sandbox-1")
+
+	require.NoError(t, err)
+	txn := store.lifecycleTxns["txn-1"]
+	require.NotNil(t, txn)
+	assert.Equal(t, SandboxLifecyclePhaseAborted, txn.Phase)
+	assert.Equal(t, "stale snapshot transaction", txn.Error)
 }
 
 func TestSandboxRootFSProductForkSetsLifecycleExpirations(t *testing.T) {

--- a/manager/pkg/service/sandbox_store.go
+++ b/manager/pkg/service/sandbox_store.go
@@ -100,8 +100,10 @@ type SandboxRootFSLayer struct {
 }
 
 const (
-	SandboxLifecycleKindPause  = "pause"
-	SandboxLifecycleKindResume = "resume"
+	SandboxLifecycleKindPause    = "pause"
+	SandboxLifecycleKindResume   = "resume"
+	SandboxLifecycleKindFork     = "fork"
+	SandboxLifecycleKindSnapshot = "snapshot"
 
 	SandboxLifecycleSourceManual = "manual"
 	SandboxLifecycleSourceAuto   = "auto"

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -1880,6 +1880,11 @@ paths:
     post:
       tags: [sandbox-rootfs]
       summary: Create sandbox rootfs snapshot
+      description: |
+        Creates an immutable snapshot record from the source sandbox writable
+        rootfs. A paused source is snapshotted from its current rootfs head. A
+        running source is briefly barriered and checkpointed first; the source
+        sandbox remains running after the snapshot operation completes.
       security:
         - bearerAuth: []
       x-upstream-service: manager
@@ -1900,7 +1905,13 @@ paths:
               schema:
                 $ref: "#/components/schemas/SuccessSandboxRootFSSnapshotResponse"
         "409":
-          description: Sandbox is not paused or rootfs state is unavailable
+          description: Source sandbox is not running or paused, another lifecycle operation is active, or rootfs state is unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "503":
+          description: Running-source snapshot requires ctld checkpoint support
           content:
             application/json:
               schema:
@@ -1971,7 +1982,12 @@ paths:
   /api/v1/sandboxes/{id}/fork:
     post:
       tags: [sandbox-rootfs]
-      summary: Fork sandbox from paused rootfs
+      summary: Fork sandbox rootfs
+      description: |
+        Forks the source sandbox writable rootfs into a new paused sandbox. A paused
+        source is forked from its current rootfs head. A running source is briefly
+        barriered and checkpointed first; the source sandbox remains running after
+        the fork operation completes.
       security:
         - bearerAuth: []
       x-upstream-service: manager
@@ -1992,7 +2008,13 @@ paths:
               schema:
                 $ref: "#/components/schemas/SuccessForkSandboxResponse"
         "409":
-          description: Source sandbox is not paused or rootfs state is unavailable
+          description: Source sandbox is not running or paused, another lifecycle operation is active, or rootfs state is unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "503":
+          description: Running-source fork requires ctld checkpoint support
           content:
             application/json:
               schema:
@@ -4715,6 +4737,9 @@ components:
               $ref: "#/components/schemas/Sandbox"
     CreateSandboxRootFSSnapshotRequest:
       type: object
+      description: |
+        Optional snapshot metadata. The source sandbox may be running or paused;
+        running sources are checkpointed before the snapshot record is created.
       properties:
         name:
           type: string
@@ -4777,6 +4802,8 @@ components:
           $ref: "#/components/schemas/ForkSandboxConfig"
       description: |
         Optional fork overrides. Omit config to inherit the source sandbox configuration.
+        The source sandbox may be running or paused; running sources are checkpointed
+        before the paused child sandbox is created.
     ForkSandboxConfig:
       type: object
       additionalProperties: false

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -846,7 +846,8 @@ type CreateSSHPublicKeyRequest struct {
 	PublicKey string `json:"public_key"`
 }
 
-// CreateSandboxRootFSSnapshotRequest defines model for CreateSandboxRootFSSnapshotRequest.
+// CreateSandboxRootFSSnapshotRequest Optional snapshot metadata. The source sandbox may be running or paused;
+// running sources are checkpointed before the snapshot record is created.
 type CreateSandboxRootFSSnapshotRequest struct {
 	Description *string `json:"description,omitempty"`
 
@@ -1114,6 +1115,8 @@ type ForkSandboxConfig struct {
 }
 
 // ForkSandboxRequest Optional fork overrides. Omit config to inherit the source sandbox configuration.
+// The source sandbox may be running or paused; running sources are checkpointed
+// before the paused child sandbox is created.
 type ForkSandboxRequest struct {
 	Config *ForkSandboxConfig `json:"config,omitempty"`
 }

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -230,7 +230,7 @@ func registerApiModeSuite(envProvider func() *framework.ScenarioEnv, opts apiMod
 					assertSandboxRootFSPersistsAcrossPauseResume(env, session)
 				})
 
-				It("snapshots restores and forks paused sandbox rootfs", func() {
+				It("snapshots restores and forks sandbox rootfs", func() {
 					assertSandboxRootFSSnapshotRestoreFork(env, session)
 				})
 			}
@@ -1433,13 +1433,21 @@ func assertSandboxRootFSSnapshotRestoreFork(env *framework.ScenarioEnv, session 
 	sourceSandboxID := claimResp.SandboxId
 	Expect(sourceSandboxID).NotTo(BeEmpty())
 	forkSandboxID := ""
-	snapshotID := ""
+	runningForkSandboxID := ""
+	runningSnapshotID := ""
+	pausedSnapshotID := ""
 	DeferCleanup(func() {
-		if snapshotID != "" {
-			_, _ = session.DeleteSandboxRootFSSnapshot(env.TestCtx.Context, GinkgoT(), snapshotID)
+		if runningSnapshotID != "" {
+			_, _ = session.DeleteSandboxRootFSSnapshot(env.TestCtx.Context, GinkgoT(), runningSnapshotID)
+		}
+		if pausedSnapshotID != "" {
+			_, _ = session.DeleteSandboxRootFSSnapshot(env.TestCtx.Context, GinkgoT(), pausedSnapshotID)
 		}
 		if forkSandboxID != "" {
 			_ = session.DeleteSandbox(env.TestCtx.Context, GinkgoT(), forkSandboxID)
+		}
+		if runningForkSandboxID != "" {
+			_ = session.DeleteSandbox(env.TestCtx.Context, GinkgoT(), runningForkSandboxID)
 		}
 		_ = session.DeleteSandbox(env.TestCtx.Context, GinkgoT(), sourceSandboxID)
 	})
@@ -1475,21 +1483,18 @@ test "$(cat %s)" = nested-v1
 	_, err = execInSandboxPod(env, templateNamespace, source.PodName, writeV1Script)
 	Expect(err).NotTo(HaveOccurred())
 
-	pausedResp, status, err := session.PauseSandbox(env.TestCtx.Context, GinkgoT(), sourceSandboxID)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(status).To(Equal(http.StatusOK))
-	Expect(pausedResp).NotTo(BeNil())
-	waitForSandboxLifecycleStatusEventually(env, session, sourceSandboxID, apispec.SandboxLifecycleStatusPaused)
-
-	name := "e2e-rootfs-" + marker
-	snapshot, status, err := session.CreateSandboxRootFSSnapshot(env.TestCtx.Context, GinkgoT(), sourceSandboxID, apispec.CreateSandboxRootFSSnapshotRequest{
-		Name: ptr(name),
+	runningSnapshotName := "e2e-running-rootfs-" + marker
+	runningSnapshot, status, err := session.CreateSandboxRootFSSnapshot(env.TestCtx.Context, GinkgoT(), sourceSandboxID, apispec.CreateSandboxRootFSSnapshotRequest{
+		Name: ptr(runningSnapshotName),
 	})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(status).To(Equal(http.StatusCreated))
-	Expect(snapshot).NotTo(BeNil())
-	Expect(snapshot.Id).NotTo(BeEmpty())
-	snapshotID = snapshot.Id
+	Expect(runningSnapshot).NotTo(BeNil())
+	Expect(runningSnapshot.Id).NotTo(BeEmpty())
+	runningSnapshotID = runningSnapshot.Id
+
+	sourceAfterRunningSnapshot := waitForSandboxLifecycleStatusEventually(env, session, sourceSandboxID, apispec.SandboxLifecycleStatusRunning)
+	Expect(sourceAfterRunningSnapshot.PodName).To(Equal(source.PodName))
 
 	listResp, status, err := session.ListSandboxRootFSSnapshots(env.TestCtx.Context, GinkgoT(), sourceSandboxID)
 	Expect(err).NotTo(HaveOccurred())
@@ -1497,18 +1502,11 @@ test "$(cat %s)" = nested-v1
 	Expect(listResp).NotTo(BeNil())
 	Expect(listResp.Count).To(BeNumerically(">=", 1))
 
-	loaded, status, err := session.GetSandboxRootFSSnapshot(env.TestCtx.Context, GinkgoT(), snapshotID)
+	loaded, status, err := session.GetSandboxRootFSSnapshot(env.TestCtx.Context, GinkgoT(), runningSnapshotID)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(status).To(Equal(http.StatusOK))
 	Expect(loaded).NotTo(BeNil())
-	Expect(loaded.Id).To(Equal(snapshotID))
-
-	resumeResp, status, err := session.ResumeSandbox(env.TestCtx.Context, GinkgoT(), sourceSandboxID)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(status).To(Equal(http.StatusOK))
-	Expect(resumeResp).NotTo(BeNil())
-	Expect(resumeResp.Resumed).To(BeTrue())
-	source = waitForSandboxPodReadyEventually(env, session, sourceSandboxID, templateNamespace)
+	Expect(loaded.Id).To(Equal(runningSnapshotID))
 
 	writeV2Script := fmt.Sprintf(`set -eu
 printf %%s %s > %s
@@ -1526,34 +1524,59 @@ test "$(cat %s)" = nested-v2
 	_, err = execInSandboxPod(env, templateNamespace, source.PodName, writeV2Script)
 	Expect(err).NotTo(HaveOccurred())
 
-	pausedResp, status, err = session.PauseSandbox(env.TestCtx.Context, GinkgoT(), sourceSandboxID)
+	runningForkResp, status, err := session.ForkSandbox(env.TestCtx.Context, GinkgoT(), sourceSandboxID)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusCreated))
+	Expect(runningForkResp).NotTo(BeNil())
+	Expect(runningForkResp.SourceSandboxId).To(Equal(sourceSandboxID))
+	Expect(runningForkResp.Sandbox.Id).NotTo(BeEmpty())
+	Expect(runningForkResp.Sandbox.Id).NotTo(Equal(sourceSandboxID))
+	Expect(runningForkResp.Sandbox.Status).To(Equal(apispec.SandboxLifecycleStatusPaused))
+	runningForkSandboxID = runningForkResp.Sandbox.Id
+
+	sourceAfterRunningFork := waitForSandboxLifecycleStatusEventually(env, session, sourceSandboxID, apispec.SandboxLifecycleStatusRunning)
+	Expect(sourceAfterRunningFork.PodName).To(Equal(source.PodName))
+
+	resumeResp, status, err := session.ResumeSandbox(env.TestCtx.Context, GinkgoT(), runningForkSandboxID)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+	Expect(resumeResp).NotTo(BeNil())
+	Expect(resumeResp.Resumed).To(BeTrue())
+	runningForked := waitForSandboxPodReadyEventually(env, session, runningForkSandboxID, templateNamespace)
+	verifyV2Script := fmt.Sprintf(`set -eu
+test "$(cat %s)" = %s
+test "$(cat %s)" = nested-v2
+`,
+		shellQuote(filePath),
+		shellQuote(v2Content),
+		shellQuote(nestedPath),
+	)
+	_, err = execInSandboxPod(env, templateNamespace, runningForked.PodName, verifyV2Script)
+	Expect(err).NotTo(HaveOccurred())
+
+	pausedResp, status, err := session.PauseSandbox(env.TestCtx.Context, GinkgoT(), sourceSandboxID)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(status).To(Equal(http.StatusOK))
 	Expect(pausedResp).NotTo(BeNil())
 	waitForSandboxLifecycleStatusEventually(env, session, sourceSandboxID, apispec.SandboxLifecycleStatusPaused)
 
+	pausedSnapshotName := "e2e-paused-rootfs-" + marker
+	pausedSnapshot, status, err := session.CreateSandboxRootFSSnapshot(env.TestCtx.Context, GinkgoT(), sourceSandboxID, apispec.CreateSandboxRootFSSnapshotRequest{
+		Name: ptr(pausedSnapshotName),
+	})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusCreated))
+	Expect(pausedSnapshot).NotTo(BeNil())
+	Expect(pausedSnapshot.Id).NotTo(BeEmpty())
+	pausedSnapshotID = pausedSnapshot.Id
+
 	restoreResp, status, err := session.RestoreSandboxRootFS(env.TestCtx.Context, GinkgoT(), sourceSandboxID, apispec.RestoreSandboxRootFSRequest{
-		SnapshotId: snapshotID,
+		SnapshotId: runningSnapshotID,
 	})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(status).To(Equal(http.StatusOK))
 	Expect(restoreResp).NotTo(BeNil())
 	Expect(restoreResp.Status).To(Equal(apispec.SandboxLifecycleStatusPaused))
-
-	forkResp, status, err := session.ForkSandbox(env.TestCtx.Context, GinkgoT(), sourceSandboxID)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(status).To(Equal(http.StatusCreated))
-	Expect(forkResp).NotTo(BeNil())
-	Expect(forkResp.SourceSandboxId).To(Equal(sourceSandboxID))
-	Expect(forkResp.Sandbox.Id).NotTo(BeEmpty())
-	Expect(forkResp.Sandbox.Id).NotTo(Equal(sourceSandboxID))
-	Expect(forkResp.Sandbox.Status).To(Equal(apispec.SandboxLifecycleStatusPaused))
-	forkSandboxID = forkResp.Sandbox.Id
-
-	status, err = session.DeleteSandboxRootFSSnapshot(env.TestCtx.Context, GinkgoT(), snapshotID)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(status).To(Equal(http.StatusOK))
-	snapshotID = ""
 
 	resumeResp, status, err = session.ResumeSandbox(env.TestCtx.Context, GinkgoT(), sourceSandboxID)
 	Expect(err).NotTo(HaveOccurred())
@@ -1573,13 +1596,57 @@ test "$(cat %s)" = nested-v1
 	_, err = execInSandboxPod(env, templateNamespace, source.PodName, verifyV1Script)
 	Expect(err).NotTo(HaveOccurred())
 
+	pausedResp, status, err = session.PauseSandbox(env.TestCtx.Context, GinkgoT(), sourceSandboxID)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+	Expect(pausedResp).NotTo(BeNil())
+	waitForSandboxLifecycleStatusEventually(env, session, sourceSandboxID, apispec.SandboxLifecycleStatusPaused)
+
+	restoreResp, status, err = session.RestoreSandboxRootFS(env.TestCtx.Context, GinkgoT(), sourceSandboxID, apispec.RestoreSandboxRootFSRequest{
+		SnapshotId: pausedSnapshotID,
+	})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+	Expect(restoreResp).NotTo(BeNil())
+	Expect(restoreResp.Status).To(Equal(apispec.SandboxLifecycleStatusPaused))
+
+	forkResp, status, err := session.ForkSandbox(env.TestCtx.Context, GinkgoT(), sourceSandboxID)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusCreated))
+	Expect(forkResp).NotTo(BeNil())
+	Expect(forkResp.SourceSandboxId).To(Equal(sourceSandboxID))
+	Expect(forkResp.Sandbox.Id).NotTo(BeEmpty())
+	Expect(forkResp.Sandbox.Id).NotTo(Equal(sourceSandboxID))
+	Expect(forkResp.Sandbox.Status).To(Equal(apispec.SandboxLifecycleStatusPaused))
+	forkSandboxID = forkResp.Sandbox.Id
+
+	status, err = session.DeleteSandboxRootFSSnapshot(env.TestCtx.Context, GinkgoT(), runningSnapshotID)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+	runningSnapshotID = ""
+
+	status, err = session.DeleteSandboxRootFSSnapshot(env.TestCtx.Context, GinkgoT(), pausedSnapshotID)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+	pausedSnapshotID = ""
+
+	resumeResp, status, err = session.ResumeSandbox(env.TestCtx.Context, GinkgoT(), sourceSandboxID)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+	Expect(resumeResp).NotTo(BeNil())
+	Expect(resumeResp.Resumed).To(BeTrue())
+	source = waitForSandboxPodReadyEventually(env, session, sourceSandboxID, templateNamespace)
+
+	_, err = execInSandboxPod(env, templateNamespace, source.PodName, verifyV2Script)
+	Expect(err).NotTo(HaveOccurred())
+
 	resumeResp, status, err = session.ResumeSandbox(env.TestCtx.Context, GinkgoT(), forkSandboxID)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(status).To(Equal(http.StatusOK))
 	Expect(resumeResp).NotTo(BeNil())
 	Expect(resumeResp.Resumed).To(BeTrue())
 	forked := waitForSandboxPodReadyEventually(env, session, forkSandboxID, templateNamespace)
-	_, err = execInSandboxPod(env, templateNamespace, forked.PodName, verifyV1Script)
+	_, err = execInSandboxPod(env, templateNamespace, forked.PodName, verifyV2Script)
 	Expect(err).NotTo(HaveOccurred())
 }
 

--- a/tests/integration/internal/tests/manager/api_test.go
+++ b/tests/integration/internal/tests/manager/api_test.go
@@ -628,7 +628,7 @@ func TestSandboxRootFSProductAPI(t *testing.T) {
 	store.records["sandbox-1"].Status = service.SandboxStatusRunning
 	store.mu.Unlock()
 	resp, body = doRequest(t, env.server.Client(), http.MethodPost, env.server.URL+"/api/v1/sandboxes/sandbox-1/snapshots", env.token, nil)
-	if resp.StatusCode != http.StatusConflict {
+	if resp.StatusCode != http.StatusServiceUnavailable {
 		t.Fatalf("running rootfs snapshot status = %d, body = %s", resp.StatusCode, string(body))
 	}
 }


### PR DESCRIPTION
## Summary
- allow sandbox rootfs fork from running sources by taking a direct procd-barriered rootfs checkpoint without changing the source sandbox status to paused
- add a `fork` lifecycle transaction kind so pause/resume/fork operations serialize safely, with stale fork transaction cleanup for crash recovery
- update OpenAPI, docs, generated apispec comments, and e2e coverage for running-source fork behavior

## Tests
- `make apispec`
- `go test ./manager/...`
- `go test ./tests/integration/internal/tests/manager ./tests/integration/internal/tests/cluster-gateway ./pkg/apispec`
- `go test ./tests/e2e/... -run '^$'`
- `git diff --check`