### PR TITLE
Add procd process session broker API

### DIFF
--- a/cluster-gateway/pkg/http/handlers_procd_authz_test.go
+++ b/cluster-gateway/pkg/http/handlers_procd_authz_test.go
@@ -61,6 +61,30 @@ func TestSandboxProcdRoutesRequireReadWritePermissions(t *testing.T) {
 			permissions: []string{gatewayauthn.PermSandboxWrite},
 		},
 		{
+			name:        "process create requires sandbox write",
+			method:      http.MethodPost,
+			path:        "/api/v1/sandboxes/sb-1/processes",
+			permissions: []string{gatewayauthn.PermSandboxRead},
+		},
+		{
+			name:        "process delete requires sandbox write",
+			method:      http.MethodDelete,
+			path:        "/api/v1/sandboxes/sb-1/processes/proc-1",
+			permissions: []string{gatewayauthn.PermSandboxRead},
+		},
+		{
+			name:        "process input event requires sandbox write",
+			method:      http.MethodPost,
+			path:        "/api/v1/sandboxes/sb-1/processes/proc-1/events",
+			permissions: []string{gatewayauthn.PermSandboxRead},
+		},
+		{
+			name:        "process event stream requires sandbox read",
+			method:      http.MethodGet,
+			path:        "/api/v1/sandboxes/sb-1/processes/proc-1/events",
+			permissions: []string{gatewayauthn.PermSandboxWrite},
+		},
+		{
 			name:        "file write requires sandbox write",
 			method:      http.MethodPost,
 			path:        "/api/v1/sandboxes/sb-1/files?path=/tmp/a.txt",

--- a/cluster-gateway/pkg/http/handlers_process.go
+++ b/cluster-gateway/pkg/http/handlers_process.go
@@ -1,0 +1,95 @@
+package http
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
+)
+
+// createProcess creates a process session in a sandbox.
+func (s *Server) createProcess(c *gin.Context) {
+	sandboxID, ok := requireSandboxID(c)
+	if !ok {
+		return
+	}
+	s.proxyToSandboxProcdPath(c, sandboxID, "/api/v1/processes")
+}
+
+// listProcesses lists process sessions in a sandbox.
+func (s *Server) listProcesses(c *gin.Context) {
+	sandboxID, ok := requireSandboxID(c)
+	if !ok {
+		return
+	}
+	s.proxyToSandboxProcdPath(c, sandboxID, "/api/v1/processes")
+}
+
+// getProcess gets a process session.
+func (s *Server) getProcess(c *gin.Context) {
+	sandboxID, processID, ok := requireSandboxProcessIDs(c)
+	if !ok {
+		return
+	}
+	s.proxyToSandboxProcdPath(c, sandboxID, "/api/v1/processes/"+processID)
+}
+
+// deleteProcess deletes a process session.
+func (s *Server) deleteProcess(c *gin.Context) {
+	sandboxID, processID, ok := requireSandboxProcessIDs(c)
+	if !ok {
+		return
+	}
+	s.proxyToSandboxProcdPath(c, sandboxID, "/api/v1/processes/"+processID)
+}
+
+// sendProcessEvent sends an input event to a process session.
+func (s *Server) sendProcessEvent(c *gin.Context) {
+	sandboxID, processID, ok := requireSandboxProcessIDs(c)
+	if !ok {
+		return
+	}
+	s.proxyToSandboxProcdPath(c, sandboxID, "/api/v1/processes/"+processID+"/events")
+}
+
+// streamProcessEvents streams process events.
+func (s *Server) streamProcessEvents(c *gin.Context) {
+	sandboxID, processID, ok := requireSandboxProcessIDs(c)
+	if !ok {
+		return
+	}
+	s.proxyToSandboxProcdPath(c, sandboxID, "/api/v1/processes/"+processID+"/events")
+}
+
+// processSignal sends a signal to a process session.
+func (s *Server) processSignal(c *gin.Context) {
+	sandboxID, processID, ok := requireSandboxProcessIDs(c)
+	if !ok {
+		return
+	}
+	s.proxyToSandboxProcdPath(c, sandboxID, "/api/v1/processes/"+processID+"/signal")
+}
+
+// processPTYSize resizes a process PTY channel.
+func (s *Server) processPTYSize(c *gin.Context) {
+	sandboxID, processID, ok := requireSandboxProcessIDs(c)
+	if !ok {
+		return
+	}
+	channel := c.Param("channel")
+	if channel == "" {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "channel is required")
+		return
+	}
+	s.proxyToSandboxProcdPath(c, sandboxID, "/api/v1/processes/"+processID+"/channels/"+channel+"/pty-size")
+}
+
+func requireSandboxProcessIDs(c *gin.Context) (string, string, bool) {
+	sandboxID := c.Param("id")
+	processID := c.Param("process_id")
+	if sandboxID == "" || processID == "" {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "sandbox_id and process_id are required")
+		return "", "", false
+	}
+	return sandboxID, processID, true
+}

--- a/cluster-gateway/pkg/http/server.go
+++ b/cluster-gateway/pkg/http/server.go
@@ -537,6 +537,18 @@ func (s *Server) registerSandboxProcdRoutes(sandboxes *gin.RouterGroup) {
 		contexts.GET("/:ctx_id/ws", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxWrite), s.contextWebSocket)
 	}
 
+	processes := sandboxes.Group("/:id/processes")
+	{
+		processes.POST("", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxWrite), s.createProcess)
+		processes.GET("", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxRead), s.listProcesses)
+		processes.GET("/:process_id", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxRead), s.getProcess)
+		processes.DELETE("/:process_id", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxWrite), s.deleteProcess)
+		processes.POST("/:process_id/events", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxWrite), s.sendProcessEvent)
+		processes.GET("/:process_id/events", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxRead), s.streamProcessEvents)
+		processes.POST("/:process_id/signal", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxWrite), s.processSignal)
+		processes.PUT("/:process_id/channels/:channel/pty-size", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxWrite), s.processPTYSize)
+	}
+
 	// === File System (→ Procd) ===
 	files := sandboxes.Group("/:id/files")
 	{

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -54,6 +54,10 @@
           "title": "Contexts"
         },
         {
+          "slug": "processes",
+          "title": "Process Sessions"
+        },
+        {
           "slug": "files",
           "title": "Files"
         },

--- a/docs/sandbox/page.mdx
+++ b/docs/sandbox/page.mdx
@@ -602,4 +602,8 @@ console.log('Sandbox deleted');`
   <Card title="Contexts" href="/docs/sandbox/contexts" cta="Continue">
     Run REPL and command contexts inside a sandbox and stream process output.
   </Card>
+
+  <Card title="Process Sessions" href="/docs/sandbox/processes" cta="Continue">
+    Broker long-running protocol processes with idempotent input events and replayable SSE output.
+  </Card>
 </CardGroup>

--- a/docs/sandbox/processes/page.mdx
+++ b/docs/sandbox/processes/page.mdx
@@ -5,7 +5,7 @@ level than contexts: a process session declares protocol channels, accepts
 idempotent input events, and exposes replayable output events over SSE.
 
 Use process sessions when the client connection should not own the child process
-transport. If the client disconnects from the SSE stream, `procd` keeps the
+transport. If the client disconnects from the event stream, `procd` keeps the
 process and its broker-owned stdin/stdout/stderr pipes, HTTP requests, or
 websocket connection alive until the process exits, is deleted, or reaches its
 cleanup policy.
@@ -30,30 +30,97 @@ REPLs.
 /api/v1/sandboxes/{'{id}'}/processes
 </Endpoint>
 
-    {
-      "alias": "codex-app-server",
-      "command": ["codex", "app-server", "--listen", "stdio://"],
-      "cwd": "/workspace",
-      "env_vars": {
-        "CODEX_HOME": "/var/lib/sandbox0/codex"
-      },
-      "channels": [
-        {
-          "name": "rpc",
-          "kind": "stdio",
-          "framing": "jsonl",
-          "stdin": true,
-          "stdout": true,
-          "stderr": true
-        }
-      ],
-      "cleanup": {
-        "idle_timeout_sec": 1800
-      }
-    }
+Create a process by declaring the command and channel protocol. The response data
+contains `process.id`, `state`, `pid`, declared `channels`, and `event_log`
+replay metadata.
 
-The response data contains `process.id`, `state`, `pid`, declared `channels`,
-and `event_log` replay metadata.
+<Tabs
+  tabs={[
+    {
+      label: "CLI",
+      language: "bash",
+      code: `SANDBOX_ID=sb_abc123
+
+s0 sandbox process create "$SANDBOX_ID" \\
+    --alias codex-app-server \\
+    --cwd /workspace \\
+    --channel rpc \\
+    --kind stdio \\
+    --framing jsonl \\
+    --event-buffer-size 1024 \\
+    --input-buffer-size 1024 \\
+    -- codex app-server --listen stdio://`
+    },
+    {
+      label: "Go",
+      language: "go",
+      code: `spec := sandbox0.StdioProcessSpec([]string{"codex", "app-server", "--listen", "stdio://"})
+spec.Alias = apispec.NewOptString("codex-app-server")
+spec.Cwd = apispec.NewOptString("/workspace")
+spec.EventBufferSize = apispec.NewOptInt32(1024)
+spec.InputBufferSize = apispec.NewOptInt32(1024)
+spec.Channels[0].Name = "rpc"
+spec.Channels[0].Framing = apispec.NewOptProcessChannelFraming(apispec.ProcessChannelFramingJsonl)
+
+session, err := sandbox.CreateProcess(ctx, spec)
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Println(session.ID)`
+    },
+    {
+      label: "TypeScript",
+      language: "typescript",
+      code: `const session = await sandbox.createProcess({
+    alias: 'codex-app-server',
+    command: ['codex', 'app-server', '--listen', 'stdio://'],
+    cwd: '/workspace',
+    eventBufferSize: 1024,
+    inputBufferSize: 1024,
+    channels: [
+        {
+            name: 'rpc',
+            kind: 'stdio',
+            framing: 'jsonl',
+            stdin: true,
+            stdout: true,
+            stderr: true,
+        },
+    ],
+});
+
+console.log(session.id);`
+    },
+    {
+      label: "Python",
+      language: "python",
+      code: `from sandbox0.apispec.models.process_channel_framing import ProcessChannelFraming
+from sandbox0.apispec.models.process_channel_kind import ProcessChannelKind
+from sandbox0.apispec.models.process_channel_spec import ProcessChannelSpec
+from sandbox0.apispec.models.process_spec import ProcessSpec
+
+session = sandbox.create_process(ProcessSpec(
+    alias="codex-app-server",
+    command=["codex", "app-server", "--listen", "stdio://"],
+    cwd="/workspace",
+    event_buffer_size=1024,
+    input_buffer_size=1024,
+    channels=[
+        ProcessChannelSpec(
+            name="rpc",
+            kind=ProcessChannelKind.STDIO,
+            framing=ProcessChannelFraming.JSONL,
+            stdin=True,
+            stdout=True,
+            stderr=True,
+        )
+    ],
+))
+
+print(session.id)`
+    }
+  ]}
+/>
 
 ## Send Input Event
 
@@ -61,38 +128,172 @@ and `event_log` replay metadata.
 /api/v1/sandboxes/{'{id}'}/processes/{'{process_id}'}/events
 </Endpoint>
 
-    {
-      "event_id": "evt_client_001",
-      "channel": "rpc",
-      "type": "stdin.write",
-      "payload": {
-        "data": "{\"id\":1,\"method\":\"initialize\",\"params\":{}}\n"
-      }
-    }
+Input events are idempotent. Repeating the same `event_id` with the same payload
+returns the original accepted event. Reusing the same `event_id` with a
+different payload is rejected.
 
-`event_id` is required. Repeating the same event with the same payload returns
-the original accepted event. Reusing the same `event_id` with a different payload
-is rejected.
+<Tabs
+  tabs={[
+    {
+      label: "CLI",
+      language: "bash",
+      code: `s0 sandbox process input "$SANDBOX_ID" "$PROCESS_ID" \\
+    --channel rpc \\
+    --event-id evt_client_001 \\
+    --data $'{"id":1,"method":"initialize","params":{}}\\n'`
+    },
+    {
+      label: "Go",
+      language: "go",
+      code: `event, err := sandbox0.NewProcessStdinEvent(
+    "evt_client_001",
+    "rpc",
+    "{\\"id\\":1,\\"method\\":\\"initialize\\",\\"params\\":{}}\\n",
+)
+if err != nil {
+    log.Fatal(err)
+}
+
+accepted, err := sandbox.SendProcessEvent(ctx, session.ID, event)
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Println(accepted.Seq)`
+    },
+    {
+      label: "TypeScript",
+      language: "typescript",
+      code: `const accepted = await sandbox.sendProcessEvent(session.id, {
+    eventId: 'evt_client_001',
+    channel: 'rpc',
+    type: 'stdin.write',
+    payload: {
+        data: '{"id":1,"method":"initialize","params":{}}\\n',
+    },
+});
+
+console.log(accepted.seq);`
+    },
+    {
+      label: "Python",
+      language: "python",
+      code: `from sandbox0.apispec.models.process_event_type import ProcessEventType
+from sandbox0.apispec.models.process_input_event import ProcessInputEvent
+from sandbox0.apispec.models.process_input_event_payload import ProcessInputEventPayload
+
+payload = ProcessInputEventPayload()
+payload["data"] = '{"id":1,"method":"initialize","params":{}}\\n'
+
+accepted = sandbox.send_process_event(session.id, ProcessInputEvent(
+    event_id="evt_client_001",
+    channel="rpc",
+    type_=ProcessEventType.STDIN_WRITE,
+    payload=payload,
+))
+
+print(accepted.seq)`
+    }
+  ]}
+/>
 
 Input backpressure is explicit. If `procd` has not accepted the event, the
 client can retry with the same `event_id`.
 
-## Stream Events
+## Stream And Reconnect
 
 <Endpoint method="GET">
 /api/v1/sandboxes/{'{id}'}/processes/{'{process_id}'}/events?cursor=42
 </Endpoint>
 
 The response is `text/event-stream`. Each SSE `data` field contains a
-`ProcessEvent` JSON object.
+`ProcessEvent` JSON object. Use `cursor` as the last event `seq` observed by the
+client. If the requested cursor is older than the retained event log, `procd`
+emits `cursor_lost` with the oldest available sequence.
 
-    id: 43
-    event: stdout.line
-    data: {"seq":43,"process_id":"proc_...","channel":"rpc","type":"stdout.line","payload":{"data":"..."}}
+<Tabs
+  tabs={[
+    {
+      label: "CLI",
+      language: "bash",
+      code: `s0 sandbox process events "$SANDBOX_ID" "$PROCESS_ID" > events.jsonl
 
-Use `cursor` as the last event `seq` observed by the client. If the requested
-cursor is older than the retained event log, `procd` emits `cursor_lost` with
-the oldest available sequence.
+LAST_SEQ=$(tail -n 1 events.jsonl | jq -r '.seq')
+s0 sandbox process events "$SANDBOX_ID" "$PROCESS_ID" --cursor "$LAST_SEQ"`
+    },
+    {
+      label: "Go",
+      language: "go",
+      code: `stream, err := sandbox.WatchProcessEvents(ctx, session.ID, nil)
+if err != nil {
+    log.Fatal(err)
+}
+
+event, err := stream.Recv()
+if err != nil {
+    log.Fatal(err)
+}
+lastSeq := event.Seq
+_ = stream.Close()
+
+resume, err := sandbox.WatchProcessEvents(ctx, session.ID, &sandbox0.ProcessEventWatchOptions{
+    Cursor: &lastSeq,
+})
+if err != nil {
+    log.Fatal(err)
+}
+defer resume.Close()
+
+for {
+    event, err := resume.Recv()
+    if errors.Is(err, io.EOF) {
+        break
+    }
+    if err != nil {
+        log.Fatal(err)
+    }
+    fmt.Printf("%d %s\\n", event.Seq, event.Type)
+}`
+    },
+    {
+      label: "TypeScript",
+      language: "typescript",
+      code: `const stream = await sandbox.watchProcessEvents(session.id);
+let lastSeq = 0;
+
+for await (const event of stream) {
+    lastSeq = event.seq;
+    break;
+}
+await stream.body.cancel();
+
+const resumed = await sandbox.watchProcessEvents(session.id, { cursor: lastSeq });
+for await (const event of resumed) {
+    console.log(event.seq, event.type);
+}`
+    },
+    {
+      label: "Python",
+      language: "python",
+      code: `from sandbox0 import ProcessEventWatchOptions
+
+with sandbox.watch_process_events(session.id) as stream:
+    first = next(stream.iter_events())
+
+last_seq = first.seq
+
+with sandbox.watch_process_events(
+    session.id,
+    ProcessEventWatchOptions(cursor=last_seq),
+) as stream:
+    for event in stream.iter_events():
+        print(event.seq, event.type_)`
+    }
+  ]}
+/>
+
+Closing the stream closes only the client subscription. It does not send EOF to
+the child process or close broker-owned channels. The client can send more input
+while disconnected and later resume from its last observed `seq`.
 
 ## Stop Process Session
 
@@ -103,53 +304,90 @@ the oldest available sequence.
 Deleting a process session terminates the process, closes broker-owned channels,
 and removes it from `procd`.
 
+<Tabs
+  tabs={[
+    {
+      label: "CLI",
+      language: "bash",
+      code: `s0 sandbox process delete "$SANDBOX_ID" "$PROCESS_ID"`
+    },
+    {
+      label: "Go",
+      language: "go",
+      code: `_, err := sandbox.DeleteProcess(ctx, session.ID)
+if err != nil {
+    log.Fatal(err)
+}`
+    },
+    {
+      label: "TypeScript",
+      language: "typescript",
+      code: `await sandbox.deleteProcess(session.id);`
+    },
+    {
+      label: "Python",
+      language: "python",
+      code: `sandbox.delete_process(session.id)`
+    }
+  ]}
+/>
+
 ## Signals And PTY Resize
 
 <Endpoint method="POST">
 /api/v1/sandboxes/{'{id}'}/processes/{'{process_id}'}/signal
 </Endpoint>
 
-    {
-      "signal": "TERM"
-    }
-
 <Endpoint method="PUT">
 /api/v1/sandboxes/{'{id}'}/processes/{'{process_id}'}/channels/{'{channel}'}/pty-size
 </Endpoint>
 
-    {
-      "rows": 40,
-      "cols": 120
-    }
-
 PTY resize is valid only for `pty` channels.
+
+<Tabs
+  tabs={[
+    {
+      label: "CLI",
+      language: "bash",
+      code: `s0 sandbox process signal "$SANDBOX_ID" "$PROCESS_ID" TERM
+s0 sandbox process resize "$SANDBOX_ID" "$PROCESS_ID" --channel pty --rows 40 --cols 120`
+    },
+    {
+      label: "Go",
+      language: "go",
+      code: `_, err := sandbox.SignalProcess(ctx, session.ID, "TERM")
+if err != nil {
+    log.Fatal(err)
+}
+
+_, err = sandbox.ResizeProcessPTY(ctx, session.ID, "pty", 40, 120)
+if err != nil {
+    log.Fatal(err)
+}`
+    },
+    {
+      label: "TypeScript",
+      language: "typescript",
+      code: `await sandbox.signalProcess(session.id, 'TERM');
+await sandbox.resizeProcessPty(session.id, 'pty', 40, 120);`
+    },
+    {
+      label: "Python",
+      language: "python",
+      code: `sandbox.signal_process(session.id, "TERM")
+sandbox.resize_process_pty(session.id, "pty", 40, 120)`
+    }
+  ]}
+/>
 
 ## Codex App Server Over Stdio
 
 Codex app-server can run as a normal process session. `procd` does not need a
-Codex-specific adapter.
+Codex-specific adapter. The SDK sends JSON-RPC messages as `stdin.write` events
+and reads JSONL output through SSE.
 
-    {
-      "alias": "codex-app-server",
-      "command": ["codex", "app-server", "--listen", "stdio://"],
-      "cwd": "/workspace",
-      "channels": [
-        {
-          "name": "rpc",
-          "kind": "stdio",
-          "framing": "jsonl",
-          "stdin": true,
-          "stdout": true,
-          "stderr": true
-        }
-      ]
-    }
-
-The SDK sends JSON-RPC messages as `stdin.write` events and reads JSONL output
-through SSE. A client disconnect closes only the SSE subscription; it does not
-send EOF to the Codex app-server child process.
-
-If the child process exits or crashes, application-level recovery still belongs
-to that protocol. For Codex, that usually means reconnecting to a new app-server
-process and using Codex thread resume semantics.
-
+A client disconnect closes only the SSE subscription; it does not send EOF to
+the Codex app-server child process. If the child process exits or crashes,
+application-level recovery still belongs to that protocol. For Codex, that
+usually means reconnecting to a new app-server process and using Codex thread
+resume semantics.

--- a/docs/sandbox/processes/page.mdx
+++ b/docs/sandbox/processes/page.mdx
@@ -1,0 +1,155 @@
+# Process Sessions
+
+Process sessions are broker-owned user processes inside a sandbox. They are lower
+level than contexts: a process session declares protocol channels, accepts
+idempotent input events, and exposes replayable output events over SSE.
+
+Use process sessions when the client connection should not own the child process
+transport. If the client disconnects from the SSE stream, `procd` keeps the
+process and its broker-owned stdin/stdout/stderr pipes, HTTP requests, or
+websocket connection alive until the process exits, is deleted, or reaches its
+cleanup policy.
+
+## Resource Model
+
+| Resource | Description |
+|----------|-------------|
+| Process session | A running command plus lifecycle state, PID, cleanup policy, and event log |
+| Channel | A named protocol surface: `stdio`, `pty`, `http`, or `websocket` |
+| Event | A monotonic `seq` item for input acceptance, output, lifecycle, errors, or cursor loss |
+| Subscription | A client SSE connection reading replayed and live events from a cursor |
+
+`stdio` channels use real child pipes and are appropriate for JSONL, JSON-RPC,
+MCP stdio servers, language servers, and app-server style processes. `pty`
+channels use terminal semantics and are appropriate for shells and interactive
+REPLs.
+
+## Create Process Session
+
+<Endpoint method="POST">
+/api/v1/sandboxes/{'{id}'}/processes
+</Endpoint>
+
+    {
+      "alias": "codex-app-server",
+      "command": ["codex", "app-server", "--listen", "stdio://"],
+      "cwd": "/workspace",
+      "env_vars": {
+        "CODEX_HOME": "/var/lib/sandbox0/codex"
+      },
+      "channels": [
+        {
+          "name": "rpc",
+          "kind": "stdio",
+          "framing": "jsonl",
+          "stdin": true,
+          "stdout": true,
+          "stderr": true
+        }
+      ],
+      "cleanup": {
+        "idle_timeout_sec": 1800
+      }
+    }
+
+The response data contains `process.id`, `state`, `pid`, declared `channels`,
+and `event_log` replay metadata.
+
+## Send Input Event
+
+<Endpoint method="POST">
+/api/v1/sandboxes/{'{id}'}/processes/{'{process_id}'}/events
+</Endpoint>
+
+    {
+      "event_id": "evt_client_001",
+      "channel": "rpc",
+      "type": "stdin.write",
+      "payload": {
+        "data": "{\"id\":1,\"method\":\"initialize\",\"params\":{}}\n"
+      }
+    }
+
+`event_id` is required. Repeating the same event with the same payload returns
+the original accepted event. Reusing the same `event_id` with a different payload
+is rejected.
+
+Input backpressure is explicit. If `procd` has not accepted the event, the
+client can retry with the same `event_id`.
+
+## Stream Events
+
+<Endpoint method="GET">
+/api/v1/sandboxes/{'{id}'}/processes/{'{process_id}'}/events?cursor=42
+</Endpoint>
+
+The response is `text/event-stream`. Each SSE `data` field contains a
+`ProcessEvent` JSON object.
+
+    id: 43
+    event: stdout.line
+    data: {"seq":43,"process_id":"proc_...","channel":"rpc","type":"stdout.line","payload":{"data":"..."}}
+
+Use `cursor` as the last event `seq` observed by the client. If the requested
+cursor is older than the retained event log, `procd` emits `cursor_lost` with
+the oldest available sequence.
+
+## Stop Process Session
+
+<Endpoint method="DELETE">
+/api/v1/sandboxes/{'{id}'}/processes/{'{process_id}'}
+</Endpoint>
+
+Deleting a process session terminates the process, closes broker-owned channels,
+and removes it from `procd`.
+
+## Signals And PTY Resize
+
+<Endpoint method="POST">
+/api/v1/sandboxes/{'{id}'}/processes/{'{process_id}'}/signal
+</Endpoint>
+
+    {
+      "signal": "TERM"
+    }
+
+<Endpoint method="PUT">
+/api/v1/sandboxes/{'{id}'}/processes/{'{process_id}'}/channels/{'{channel}'}/pty-size
+</Endpoint>
+
+    {
+      "rows": 40,
+      "cols": 120
+    }
+
+PTY resize is valid only for `pty` channels.
+
+## Codex App Server Over Stdio
+
+Codex app-server can run as a normal process session. `procd` does not need a
+Codex-specific adapter.
+
+    {
+      "alias": "codex-app-server",
+      "command": ["codex", "app-server", "--listen", "stdio://"],
+      "cwd": "/workspace",
+      "channels": [
+        {
+          "name": "rpc",
+          "kind": "stdio",
+          "framing": "jsonl",
+          "stdin": true,
+          "stdout": true,
+          "stderr": true
+        }
+      ]
+    }
+
+The SDK sends JSON-RPC messages as `stdin.write` events and reads JSONL output
+through SSE. A client disconnect closes only the SSE subscription; it does not
+send EOF to the Codex app-server child process.
+
+If the child process exits or crashes, application-level recovery still belongs
+to that protocol. For Codex, that usually means reconnecting to a new app-server
+process and using Codex thread resume semantics.
+

--- a/manager/cmd/procd/main.go
+++ b/manager/cmd/procd/main.go
@@ -76,6 +76,11 @@ func main() {
 		MaxLifetime: cfg.ContextMaxLifetime.Duration,
 		FinishedTTL: cfg.ContextFinishedTTL.Duration,
 	})
+	processManager := process.NewSessionManager()
+	processManager.SetDefaultCleanupPolicy(process.ProcessCleanupSpec{
+		IdleTimeoutSec: int32(cfg.ContextIdleTimeout.Duration / time.Second),
+		TTLSec:         int32(cfg.ContextMaxLifetime.Duration / time.Second),
+	})
 
 	webhookDispatcher := webhook.NewDispatcher(webhook.Options{
 		QueueSize:      cfg.WebhookQueueSize,
@@ -162,6 +167,7 @@ func main() {
 	server := procdhttp.NewServer(
 		cfg,
 		contextManager,
+		processManager,
 		fileManager,
 		authValidator,
 		webhookDispatcher,
@@ -172,6 +178,7 @@ func main() {
 
 	cleanupCtx, cleanupCancel := context.WithCancel(context.Background())
 	contextManager.StartCleanup(cleanupCtx, cfg.ContextCleanupInterval.Duration)
+	processManager.StartCleanup(cleanupCtx, cfg.ContextCleanupInterval.Duration)
 
 	// Handle shutdown signals
 	done := make(chan bool, 1)
@@ -205,6 +212,7 @@ func main() {
 
 		// Cleanup managers
 		contextManager.Cleanup()
+		processManager.Cleanup()
 		fileManager.Close()
 
 		if err := webhookDispatcher.Shutdown(context.Background()); err != nil {

--- a/manager/procd/pkg/http/handlers/initialize.go
+++ b/manager/procd/pkg/http/handlers/initialize.go
@@ -11,6 +11,7 @@ import (
 
 	ctxpkg "github.com/sandbox0-ai/sandbox0/manager/procd/pkg/context"
 	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/file"
+	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/process"
 	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/webhook"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"go.uber.org/zap"
@@ -21,6 +22,7 @@ type InitializeHandler struct {
 	dispatcher     *webhook.Dispatcher
 	fileManager    *file.Manager
 	contextManager *ctxpkg.Manager
+	processManager *process.SessionManager
 	httpPort       int
 	logger         *zap.Logger
 	readyMu        sync.Mutex
@@ -39,6 +41,11 @@ func NewInitializeHandler(dispatcher *webhook.Dispatcher, fileManager *file.Mana
 		httpPort:       httpPort,
 		logger:         logger,
 	}
+}
+
+// SetProcessSessionManager wires process sessions into sandbox initialization.
+func (h *InitializeHandler) SetProcessSessionManager(manager *process.SessionManager) {
+	h.processManager = manager
 }
 
 // InitializeRequest is the request body for initializing sandbox settings.
@@ -118,6 +125,9 @@ func (h *InitializeHandler) Initialize(w http.ResponseWriter, r *http.Request) {
 	if h.contextManager != nil {
 		h.contextManager.SetSandboxEnvVars(req.EnvVars)
 	}
+	if h.processManager != nil {
+		h.processManager.SetSandboxEnvVars(req.EnvVars)
+	}
 
 	h.dispatcher.SetConfig(webhookURL, webhookSecret)
 	h.dispatcher.SetIdentity(req.SandboxID, teamID)
@@ -186,6 +196,14 @@ func (h *InitializeHandler) UpdateSandboxEnvVars(w http.ResponseWriter, r *http.
 		h.contextManager.SetSandboxEnvVars(req.EnvVars)
 		if current := h.contextManager.SandboxEnvVars(); current != nil {
 			envVars = current
+		}
+	}
+	if h.processManager != nil {
+		h.processManager.SetSandboxEnvVars(req.EnvVars)
+		if len(envVars) == 0 {
+			if current := h.processManager.SandboxEnvVars(); current != nil {
+				envVars = current
+			}
 		}
 	}
 	writeJSON(w, http.StatusOK, UpdateSandboxEnvVarsResponse{EnvVars: envVars})

--- a/manager/procd/pkg/http/handlers/process.go
+++ b/manager/procd/pkg/http/handlers/process.go
@@ -1,0 +1,284 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"syscall"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/process"
+	"go.uber.org/zap"
+)
+
+// ProcessHandler handles process-session HTTP requests.
+type ProcessHandler struct {
+	manager *process.SessionManager
+	logger  *zap.Logger
+}
+
+// NewProcessHandler creates a process-session handler.
+func NewProcessHandler(manager *process.SessionManager, logger *zap.Logger) *ProcessHandler {
+	return &ProcessHandler{
+		manager: manager,
+		logger:  logger,
+	}
+}
+
+// ProcessSessionResponse wraps a process session.
+type ProcessSessionResponse struct {
+	Process process.ProcessSessionSnapshot `json:"process"`
+}
+
+// ProcessSessionListResponse wraps process sessions.
+type ProcessSessionListResponse struct {
+	Processes []process.ProcessSessionSnapshot `json:"processes"`
+}
+
+// ProcessEventResponse wraps an accepted process event.
+type ProcessEventResponse struct {
+	Event process.ProcessEvent `json:"event"`
+}
+
+// ProcessPTYSizeRequest is the request body for resizing a process PTY channel.
+type ProcessPTYSizeRequest struct {
+	Rows uint16 `json:"rows"`
+	Cols uint16 `json:"cols"`
+}
+
+// List lists all process sessions.
+func (h *ProcessHandler) List(w http.ResponseWriter, r *http.Request) {
+	sessions := h.manager.ListSessions()
+	response := ProcessSessionListResponse{
+		Processes: make([]process.ProcessSessionSnapshot, 0, len(sessions)),
+	}
+	for _, session := range sessions {
+		response.Processes = append(response.Processes, session.Snapshot())
+	}
+	writeJSON(w, http.StatusOK, response)
+}
+
+// Create creates a process session.
+func (h *ProcessHandler) Create(w http.ResponseWriter, r *http.Request) {
+	var spec process.ProcessSpec
+	if err := json.NewDecoder(r.Body).Decode(&spec); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	session, err := h.manager.CreateSession(spec)
+	if err != nil {
+		h.writeProcessError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, ProcessSessionResponse{Process: session.Snapshot()})
+}
+
+// Get gets a process session.
+func (h *ProcessHandler) Get(w http.ResponseWriter, r *http.Request) {
+	session, ok := h.getSession(w, r)
+	if !ok {
+		return
+	}
+	writeJSON(w, http.StatusOK, ProcessSessionResponse{Process: session.Snapshot()})
+}
+
+// Delete stops and removes a process session.
+func (h *ProcessHandler) Delete(w http.ResponseWriter, r *http.Request) {
+	id := mux.Vars(r)["id"]
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "invalid_request", "process id is required")
+		return
+	}
+	if err := h.manager.DeleteSession(id); err != nil {
+		h.writeProcessError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]bool{"deleted": true})
+}
+
+// SendEvent sends an input event to a process channel.
+func (h *ProcessHandler) SendEvent(w http.ResponseWriter, r *http.Request) {
+	session, ok := h.getSession(w, r)
+	if !ok {
+		return
+	}
+	var event process.ProcessInputEvent
+	if err := json.NewDecoder(r.Body).Decode(&event); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	accepted, err := session.HandleInput(event)
+	if err != nil {
+		h.writeProcessError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusAccepted, ProcessEventResponse{Event: accepted})
+}
+
+// StreamEvents streams replayed and live process events as SSE.
+func (h *ProcessHandler) StreamEvents(w http.ResponseWriter, r *http.Request) {
+	session, ok := h.getSession(w, r)
+	if !ok {
+		return
+	}
+	cursor, err := parseCursor(r.URL.Query().Get("cursor"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeError(w, http.StatusInternalServerError, "streaming_unavailable", "response writer does not support flushing")
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.WriteHeader(http.StatusOK)
+
+	events, cancel := session.Subscribe(cursor)
+	defer cancel()
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case event, open := <-events:
+			if !open {
+				return
+			}
+			if event.ProcessID == "" {
+				event.ProcessID = session.ID()
+			}
+			if err := writeSSEEvent(w, event); err != nil {
+				h.logger.Debug("Failed to write process SSE event", zap.String("process_id", session.ID()), zap.Error(err))
+				return
+			}
+			flusher.Flush()
+		}
+	}
+}
+
+// SendSignal sends a signal to a process session.
+func (h *ProcessHandler) SendSignal(w http.ResponseWriter, r *http.Request) {
+	session, ok := h.getSession(w, r)
+	if !ok {
+		return
+	}
+	var req SignalContextRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	sig, err := parseSignal(req.Signal)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	if err := session.SendSignal(sig); err != nil {
+		h.writeProcessError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]bool{"signaled": true})
+}
+
+// ResizePTY resizes a process PTY channel.
+func (h *ProcessHandler) ResizePTY(w http.ResponseWriter, r *http.Request) {
+	session, ok := h.getSession(w, r)
+	if !ok {
+		return
+	}
+	channel := mux.Vars(r)["channel"]
+	var req ProcessPTYSizeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	if req.Rows == 0 || req.Cols == 0 {
+		writeError(w, http.StatusBadRequest, "invalid_request", "rows and cols must be > 0")
+		return
+	}
+	if err := session.ResizePTY(channel, process.PTYSize{Rows: req.Rows, Cols: req.Cols}); err != nil {
+		h.writeProcessError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]bool{"resized": true})
+}
+
+func (h *ProcessHandler) getSession(w http.ResponseWriter, r *http.Request) (*process.Session, bool) {
+	id := mux.Vars(r)["id"]
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "invalid_request", "process id is required")
+		return nil, false
+	}
+	session, err := h.manager.GetSession(id)
+	if err != nil {
+		h.writeProcessError(w, err)
+		return nil, false
+	}
+	return session, true
+}
+
+func parseCursor(value string) (int64, error) {
+	if value == "" {
+		return 0, nil
+	}
+	cursor, err := strconv.ParseInt(value, 10, 64)
+	if err != nil || cursor < 0 {
+		return 0, errors.New("cursor must be a non-negative integer")
+	}
+	return cursor, nil
+}
+
+func writeSSEEvent(w http.ResponseWriter, event process.ProcessEvent) error {
+	if event.Timestamp.IsZero() {
+		event.Timestamp = time.Now().UTC()
+	}
+	body, err := json.Marshal(event)
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "id: %d\n", event.Seq); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "event: %s\n", event.Type); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "data: %s\n\n", string(body)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (h *ProcessHandler) writeProcessError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, process.ErrProcessSessionNotFound):
+		writeError(w, http.StatusNotFound, "process_not_found", err.Error())
+	case errors.Is(err, process.ErrInvalidProcessSpec),
+		errors.Is(err, process.ErrInvalidProcessEvent),
+		errors.Is(err, process.ErrUnsupportedChannelKind),
+		errors.Is(err, process.ErrUnsupportedChannelEvent),
+		errors.Is(err, process.ErrDuplicateEventID),
+		errors.Is(err, process.ErrInvalidCommand),
+		errors.Is(err, process.ErrInvalidPTYSize):
+		writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+	case errors.Is(err, process.ErrInputBufferFull):
+		writeError(w, http.StatusConflict, "input_buffer_full", err.Error())
+	case errors.Is(err, process.ErrProcessFinished):
+		writeError(w, http.StatusGone, "process_finished", err.Error())
+	case errors.Is(err, process.ErrProcessNotRunning),
+		errors.Is(err, process.ErrPTYNotAvailable):
+		writeError(w, http.StatusConflict, "process_not_running", err.Error())
+	case errors.Is(err, process.ErrSignalFailed):
+		writeError(w, http.StatusInternalServerError, "signal_failed", err.Error())
+	default:
+		if errors.Is(err, syscall.EINVAL) {
+			writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "process_failed", err.Error())
+	}
+}

--- a/manager/procd/pkg/http/handlers/process_test.go
+++ b/manager/procd/pkg/http/handlers/process_test.go
@@ -1,0 +1,72 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/process"
+	"go.uber.org/zap"
+)
+
+func TestProcessHandlerListReturnsEmptyArray(t *testing.T) {
+	handler := NewProcessHandler(process.NewSessionManager(), zap.NewNop())
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/processes", nil)
+
+	handler.List(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+	if !strings.Contains(recorder.Body.String(), `"processes":[]`) {
+		t.Fatalf("response = %s, want empty processes array", recorder.Body.String())
+	}
+}
+
+func TestProcessHandlerStreamEventsReplaysClosedSession(t *testing.T) {
+	manager := process.NewSessionManager()
+	session, err := manager.CreateSession(process.ProcessSpec{
+		Command: []string{"/bin/sh", "-c", "echo hello"},
+		Channels: []process.ChannelSpec{{
+			Name:    "rpc",
+			Kind:    process.ChannelKindStdio,
+			Framing: process.ChannelFramingLine,
+			Stdout:  true,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateSession() error = %v", err)
+	}
+	waitForProcessState(t, session, process.ProcessSessionStateStopped)
+
+	handler := NewProcessHandler(manager, zap.NewNop())
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/processes/"+session.ID()+"/events?cursor=0", nil)
+	req = mux.SetURLVars(req, map[string]string{"id": session.ID()})
+
+	handler.StreamEvents(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+	body := recorder.Body.String()
+	if !strings.Contains(body, "event: stdout.line") || !strings.Contains(body, `"data":"hello"`) {
+		t.Fatalf("SSE body = %s, want replayed stdout.line", body)
+	}
+}
+
+func waitForProcessState(t *testing.T, session *process.Session, state process.ProcessSessionState) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if session.Snapshot().State == state {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("state = %s, want %s", session.Snapshot().State, state)
+}

--- a/manager/procd/pkg/http/server.go
+++ b/manager/procd/pkg/http/server.go
@@ -16,6 +16,7 @@ import (
 	ctxpkg "github.com/sandbox0-ai/sandbox0/manager/procd/pkg/context"
 	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/file"
 	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/http/handlers"
+	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/process"
 	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/webhook"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
@@ -36,6 +37,7 @@ type Server struct {
 
 	// Managers
 	contextManager *ctxpkg.Manager
+	processManager *process.SessionManager
 	fileManager    *file.Manager
 
 	// Internal auth validator
@@ -52,6 +54,7 @@ type Server struct {
 func NewServer(
 	cfg *config.ProcdConfig,
 	contextManager *ctxpkg.Manager,
+	processManager *process.SessionManager,
 	fileManager *file.Manager,
 	authValidator *internalauth.Validator,
 	webhookDispatcher *webhook.Dispatcher,
@@ -63,6 +66,7 @@ func NewServer(
 		router:            mux.NewRouter(),
 		cfg:               cfg,
 		contextManager:    contextManager,
+		processManager:    processManager,
 		fileManager:       fileManager,
 		authValidator:     authValidator,
 		barrier:           newLifecycleBarrier(),
@@ -123,6 +127,16 @@ func (s *Server) setupRoutes() {
 	api.HandleFunc("/contexts/{id}/stats", contextHandler.Stats).Methods("GET")
 	api.HandleFunc("/contexts/{id}/ws", contextHandler.WebSocket).Methods("GET")
 
+	processHandler := handlers.NewProcessHandler(s.processManager, s.logger)
+	api.HandleFunc("/processes", processHandler.List).Methods("GET")
+	api.HandleFunc("/processes", processHandler.Create).Methods("POST")
+	api.HandleFunc("/processes/{id}", processHandler.Get).Methods("GET")
+	api.HandleFunc("/processes/{id}", processHandler.Delete).Methods("DELETE")
+	api.HandleFunc("/processes/{id}/events", processHandler.SendEvent).Methods("POST")
+	api.HandleFunc("/processes/{id}/events", processHandler.StreamEvents).Methods("GET")
+	api.HandleFunc("/processes/{id}/signal", processHandler.SendSignal).Methods("POST")
+	api.HandleFunc("/processes/{id}/channels/{channel}/pty-size", processHandler.ResizePTY).Methods("PUT")
+
 	functionHandler := handlers.NewFunctionHandler(s.logger)
 	if s.contextManager != nil {
 		functionHandler.SetSandboxEnvVarsProvider(s.contextManager.SandboxEnvVars)
@@ -133,6 +147,7 @@ func (s *Server) setupRoutes() {
 
 	// Initialize handler
 	initializeHandler := handlers.NewInitializeHandler(s.webhookDispatcher, s.fileManager, s.contextManager, s.cfg.HTTPPort, s.logger)
+	initializeHandler.SetProcessSessionManager(s.processManager)
 	api.HandleFunc("/initialize", initializeHandler.Initialize).Methods("POST")
 	api.HandleFunc("/sandbox/env_vars", initializeHandler.UpdateSandboxEnvVars).Methods("PUT")
 

--- a/manager/procd/pkg/process/event_log.go
+++ b/manager/procd/pkg/process/event_log.go
@@ -1,0 +1,131 @@
+package process
+
+import (
+	"sync"
+	"time"
+)
+
+const defaultEventLogCapacity = 4096
+
+// EventLog is a bounded replay log plus live fan-out for process events.
+type EventLog struct {
+	mu          sync.Mutex
+	nextSeq     int64
+	capacity    int
+	events      []ProcessEvent
+	subscribers map[chan ProcessEvent]struct{}
+	closed      bool
+}
+
+// NewEventLog creates a bounded event log.
+func NewEventLog(capacity int) *EventLog {
+	if capacity <= 0 {
+		capacity = defaultEventLogCapacity
+	}
+	return &EventLog{
+		nextSeq:     1,
+		capacity:    capacity,
+		events:      make([]ProcessEvent, 0, capacity),
+		subscribers: make(map[chan ProcessEvent]struct{}),
+	}
+}
+
+// Publish assigns a sequence number, stores the event, and broadcasts it.
+func (l *EventLog) Publish(event ProcessEvent) ProcessEvent {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if event.Timestamp.IsZero() {
+		event.Timestamp = time.Now().UTC()
+	}
+	event.Seq = l.nextSeq
+	l.nextSeq++
+
+	if len(l.events) >= l.capacity {
+		copy(l.events, l.events[1:])
+		l.events[len(l.events)-1] = event
+	} else {
+		l.events = append(l.events, event)
+	}
+
+	for sub := range l.subscribers {
+		select {
+		case sub <- event:
+		default:
+		}
+	}
+
+	return event
+}
+
+// Snapshot returns replay metadata.
+func (l *EventLog) Snapshot() EventLogSnapshot {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.snapshotLocked()
+}
+
+func (l *EventLog) snapshotLocked() EventLogSnapshot {
+	oldestSeq := l.nextSeq
+	if len(l.events) > 0 {
+		oldestSeq = l.events[0].Seq
+	}
+	return EventLogSnapshot{
+		NextSeq:   l.nextSeq,
+		OldestSeq: oldestSeq,
+		Capacity:  l.capacity,
+	}
+}
+
+// Subscribe replays events newer than cursor and then streams live events.
+func (l *EventLog) Subscribe(cursor int64) (<-chan ProcessEvent, func()) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	sub := make(chan ProcessEvent, l.capacity+1)
+	snapshot := l.snapshotLocked()
+	if cursor > 0 && len(l.events) > 0 && cursor < snapshot.OldestSeq {
+		sub <- ProcessEvent{
+			Seq:       snapshot.OldestSeq - 1,
+			Type:      EventTypeCursorLost,
+			Timestamp: time.Now().UTC(),
+			Payload: map[string]any{
+				"requested_cursor": cursor,
+				"oldest_seq":       snapshot.OldestSeq,
+			},
+		}
+	}
+	for _, event := range l.events {
+		if cursor == 0 || event.Seq > cursor {
+			sub <- event
+		}
+	}
+	if l.closed {
+		close(sub)
+		return sub, func() {}
+	}
+	l.subscribers[sub] = struct{}{}
+	cancel := func() {
+		l.mu.Lock()
+		defer l.mu.Unlock()
+		if _, ok := l.subscribers[sub]; ok {
+			delete(l.subscribers, sub)
+			close(sub)
+		}
+	}
+	return sub, cancel
+}
+
+// Close closes all live subscriptions. History remains replayable.
+func (l *EventLog) Close() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.closed {
+		return
+	}
+	l.closed = true
+	for sub := range l.subscribers {
+		close(sub)
+		delete(l.subscribers, sub)
+	}
+}

--- a/manager/procd/pkg/process/session.go
+++ b/manager/procd/pkg/process/session.go
@@ -1,0 +1,1055 @@
+package process
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/creack/pty"
+	"github.com/gorilla/websocket"
+)
+
+const (
+	defaultProcessInputBuffer = 128
+	defaultHTTPTimeout        = 30 * time.Second
+	stopGracePeriod           = 5 * time.Second
+)
+
+// Session owns a running process, brokered channels, and replayable events.
+type Session struct {
+	id        string
+	spec      ProcessSpec
+	state     ProcessSessionState
+	pid       int
+	createdAt time.Time
+	startedAt *time.Time
+	exitedAt  *time.Time
+	exitCode  *int
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	cmd    *exec.Cmd
+
+	stdio *stdioSessionChannel
+	pty   *ptySessionChannel
+	http  map[string]*httpSessionChannel
+	ws    map[string]*websocketSessionChannel
+
+	eventLog *EventLog
+
+	inputMu           sync.Mutex
+	inputFingerprints map[string]string
+	inputResults      map[string]ProcessEvent
+
+	mu            sync.RWMutex
+	waitDone      chan struct{}
+	stopRequested bool
+	lastActive    time.Time
+}
+
+// NewSession validates and creates a process session.
+func NewSession(id string, spec ProcessSpec) (*Session, error) {
+	if strings.TrimSpace(id) == "" {
+		return nil, fmt.Errorf("%w: id is required", ErrInvalidProcessSpec)
+	}
+	normalized, err := normalizeProcessSpec(spec)
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	now := time.Now().UTC()
+	return &Session{
+		id:                id,
+		spec:              normalized,
+		state:             ProcessSessionStateCreated,
+		createdAt:         now,
+		ctx:               ctx,
+		cancel:            cancel,
+		http:              make(map[string]*httpSessionChannel),
+		ws:                make(map[string]*websocketSessionChannel),
+		eventLog:          NewEventLog(normalized.EventBufferSize),
+		inputFingerprints: make(map[string]string),
+		inputResults:      make(map[string]ProcessEvent),
+		waitDone:          make(chan struct{}),
+		lastActive:        now,
+	}, nil
+}
+
+func normalizeProcessSpec(spec ProcessSpec) (ProcessSpec, error) {
+	if len(spec.Command) == 0 || strings.TrimSpace(spec.Command[0]) == "" {
+		return spec, fmt.Errorf("%w: command is required", ErrInvalidProcessSpec)
+	}
+	if len(spec.Channels) == 0 {
+		return spec, fmt.Errorf("%w: at least one channel is required", ErrInvalidProcessSpec)
+	}
+	if spec.Restart.Policy == "" {
+		spec.Restart.Policy = "never"
+	}
+	if spec.Restart.Policy != "never" {
+		return spec, fmt.Errorf("%w: restart policy %q is not supported", ErrInvalidProcessSpec, spec.Restart.Policy)
+	}
+	if spec.InputBufferSize <= 0 {
+		spec.InputBufferSize = defaultProcessInputBuffer
+	}
+
+	seen := map[string]struct{}{}
+	stdioCount := 0
+	ptyCount := 0
+	for i := range spec.Channels {
+		ch := &spec.Channels[i]
+		ch.Name = strings.TrimSpace(ch.Name)
+		if ch.Name == "" {
+			return spec, fmt.Errorf("%w: channel name is required", ErrInvalidProcessSpec)
+		}
+		if _, ok := seen[ch.Name]; ok {
+			return spec, fmt.Errorf("%w: duplicate channel %q", ErrInvalidProcessSpec, ch.Name)
+		}
+		seen[ch.Name] = struct{}{}
+		if ch.Framing == "" {
+			ch.Framing = ChannelFramingRaw
+		}
+		switch ch.Kind {
+		case ChannelKindStdio:
+			stdioCount++
+			if !ch.Stdin && !ch.Stdout && !ch.Stderr {
+				ch.Stdin = true
+				ch.Stdout = true
+				ch.Stderr = true
+			}
+		case ChannelKindPTY:
+			ptyCount++
+		case ChannelKindHTTP:
+			if ch.HTTP == nil || strings.TrimSpace(ch.HTTP.BaseURL) == "" {
+				return spec, fmt.Errorf("%w: http channel %q requires base_url", ErrInvalidProcessSpec, ch.Name)
+			}
+			if _, err := url.Parse(ch.HTTP.BaseURL); err != nil {
+				return spec, fmt.Errorf("%w: invalid http base_url for channel %q", ErrInvalidProcessSpec, ch.Name)
+			}
+		case ChannelKindWebSocket:
+			if ch.WebSocket == nil || strings.TrimSpace(ch.WebSocket.URL) == "" {
+				return spec, fmt.Errorf("%w: websocket channel %q requires url", ErrInvalidProcessSpec, ch.Name)
+			}
+			if _, err := url.Parse(ch.WebSocket.URL); err != nil {
+				return spec, fmt.Errorf("%w: invalid websocket url for channel %q", ErrInvalidProcessSpec, ch.Name)
+			}
+		default:
+			return spec, fmt.Errorf("%w: %s", ErrUnsupportedChannelKind, ch.Kind)
+		}
+	}
+	if stdioCount > 1 {
+		return spec, fmt.Errorf("%w: only one stdio channel is supported per process", ErrInvalidProcessSpec)
+	}
+	if ptyCount > 1 {
+		return spec, fmt.Errorf("%w: only one pty channel is supported per process", ErrInvalidProcessSpec)
+	}
+	if stdioCount > 0 && ptyCount > 0 {
+		return spec, fmt.Errorf("%w: stdio and pty channels are mutually exclusive", ErrInvalidProcessSpec)
+	}
+	return spec, nil
+}
+
+// ID returns the session ID.
+func (s *Session) ID() string {
+	return s.id
+}
+
+// Start launches the process and starts configured channels.
+func (s *Session) Start() error {
+	s.mu.Lock()
+	if s.state != ProcessSessionStateCreated {
+		s.mu.Unlock()
+		return ErrProcessAlreadyRunning
+	}
+	s.state = ProcessSessionStateStarting
+	s.mu.Unlock()
+
+	cmd := s.prepareCommand()
+	var err error
+	if ptySpec, ok := s.findChannel(ChannelKindPTY); ok {
+		err = s.startPTY(cmd, ptySpec)
+	} else {
+		err = s.startPiped(cmd)
+	}
+	if err != nil {
+		s.setTerminalState(ProcessSessionStateCrashed, 1)
+		return err
+	}
+	s.cmd = cmd
+	now := time.Now().UTC()
+	s.mu.Lock()
+	s.pid = cmd.Process.Pid
+	s.startedAt = &now
+	s.state = ProcessSessionStateRunning
+	s.lastActive = now
+	s.mu.Unlock()
+
+	for _, ch := range s.spec.Channels {
+		switch ch.Kind {
+		case ChannelKindHTTP:
+			s.http[ch.Name] = newHTTPSessionChannel(ch, s.eventLog, s.id)
+		case ChannelKindWebSocket:
+			s.ws[ch.Name] = newWebSocketSessionChannel(ch, s.eventLog, s.id)
+		}
+	}
+
+	s.eventLog.Publish(ProcessEvent{
+		ProcessID: s.id,
+		Type:      EventTypeProcessStarted,
+		Payload: map[string]any{
+			"pid":     s.pid,
+			"command": append([]string(nil), s.spec.Command...),
+			"cwd":     s.spec.CWD,
+			"alias":   s.spec.Alias,
+		},
+	})
+
+	go s.monitorProcess()
+	return nil
+}
+
+func (s *Session) prepareCommand() *exec.Cmd {
+	cmdPath := s.spec.Command[0]
+	args := []string{}
+	if len(s.spec.Command) > 1 {
+		args = s.spec.Command[1:]
+	}
+	cmd := exec.CommandContext(s.ctx, cmdPath, args...)
+	if s.spec.CWD != "" {
+		cmd.Dir = s.spec.CWD
+	}
+	cmd.Env = MergeEnvironment(os.Environ(), s.spec.EnvVars)
+	return cmd
+}
+
+func (s *Session) startPiped(cmd *exec.Cmd) error {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	stdioSpec, hasStdio := s.findChannel(ChannelKindStdio)
+	if !hasStdio {
+		cmd.Stdout = io.Discard
+		cmd.Stderr = io.Discard
+		if err := cmd.Start(); err != nil {
+			return fmt.Errorf("%w: %v", ErrProcessStartFailed, err)
+		}
+		return nil
+	}
+
+	stdio := newStdioSessionChannel(stdioSpec, s.spec.InputBufferSize, s.eventLog, s.id)
+	if stdioSpec.Stdin {
+		stdin, err := cmd.StdinPipe()
+		if err != nil {
+			return err
+		}
+		stdio.stdin = stdin
+	}
+	var stdout io.ReadCloser
+	if stdioSpec.Stdout {
+		var err error
+		stdout, err = cmd.StdoutPipe()
+		if err != nil {
+			return err
+		}
+	} else {
+		cmd.Stdout = io.Discard
+	}
+	var stderr io.ReadCloser
+	if stdioSpec.Stderr {
+		var err error
+		stderr, err = cmd.StderrPipe()
+		if err != nil {
+			return err
+		}
+	} else {
+		cmd.Stderr = io.Discard
+	}
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("%w: %v", ErrProcessStartFailed, err)
+	}
+	s.stdio = stdio
+	stdio.start()
+	if stdout != nil {
+		stdio.wg.Add(1)
+		go stdio.readStream(stdout, OutputSourceStdout)
+	}
+	if stderr != nil {
+		stdio.wg.Add(1)
+		go stdio.readStream(stderr, OutputSourceStderr)
+	}
+	return nil
+}
+
+func (s *Session) startPTY(cmd *exec.Cmd, spec ChannelSpec) error {
+	size := spec.PTYSize
+	if size == nil {
+		size = &PTYSize{Rows: 100, Cols: 500}
+	}
+	ptmx, err := pty.StartWithSize(cmd, &pty.Winsize{Rows: size.Rows, Cols: size.Cols})
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrProcessStartFailed, err)
+	}
+	ptyCh := newPTYSessionChannel(spec, s.spec.InputBufferSize, ptmx, s.eventLog, s.id)
+	s.pty = ptyCh
+	ptyCh.start()
+	return nil
+}
+
+func (s *Session) monitorProcess() {
+	err := s.cmd.Wait()
+	exitCode := 0
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+		} else if s.ctx.Err() == context.Canceled {
+			exitCode = 137
+		} else {
+			exitCode = 1
+		}
+	}
+
+	s.mu.RLock()
+	stopRequested := s.stopRequested
+	s.mu.RUnlock()
+
+	state := ProcessSessionStateStopped
+	eventType := EventTypeProcessExited
+	if exitCode != 0 {
+		if stopRequested || s.ctx.Err() == context.Canceled {
+			state = ProcessSessionStateKilled
+			eventType = EventTypeProcessStopped
+		} else {
+			state = ProcessSessionStateCrashed
+			eventType = EventTypeProcessCrashed
+		}
+	}
+	s.setTerminalState(state, exitCode)
+	if s.stdio != nil {
+		s.stdio.wait()
+	}
+	s.stopChannels()
+	s.eventLog.Publish(ProcessEvent{
+		ProcessID: s.id,
+		Type:      eventType,
+		Payload: map[string]any{
+			"exit_code": exitCode,
+			"state":     string(state),
+		},
+	})
+	s.eventLog.Close()
+	close(s.waitDone)
+}
+
+func (s *Session) stopChannels() {
+	if s.stdio != nil {
+		s.stdio.stop()
+	}
+	if s.pty != nil {
+		s.pty.stop()
+	}
+	for _, ch := range s.ws {
+		ch.stop()
+	}
+}
+
+func (s *Session) findChannel(kind ChannelKind) (ChannelSpec, bool) {
+	for _, ch := range s.spec.Channels {
+		if ch.Kind == kind {
+			return ch, true
+		}
+	}
+	return ChannelSpec{}, false
+}
+
+func (s *Session) setTerminalState(state ProcessSessionState, exitCode int) {
+	now := time.Now().UTC()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.state = state
+	s.exitedAt = &now
+	s.exitCode = &exitCode
+	s.lastActive = now
+}
+
+// Stop terminates the process session.
+func (s *Session) Stop() error {
+	s.mu.Lock()
+	if s.state == ProcessSessionStateStopped || s.state == ProcessSessionStateKilled || s.state == ProcessSessionStateCrashed {
+		s.mu.Unlock()
+		return nil
+	}
+	s.state = ProcessSessionStateStopping
+	s.stopRequested = true
+	pid := s.pid
+	s.mu.Unlock()
+
+	if pid > 0 {
+		if err := syscall.Kill(-pid, syscall.SIGTERM); err != nil {
+			_ = syscall.Kill(pid, syscall.SIGTERM)
+		}
+	}
+
+	select {
+	case <-s.waitDone:
+	case <-time.After(stopGracePeriod):
+		if pid > 0 {
+			if err := syscall.Kill(-pid, syscall.SIGKILL); err != nil {
+				_ = syscall.Kill(pid, syscall.SIGKILL)
+			}
+		}
+		s.cancel()
+		<-s.waitDone
+	}
+	return nil
+}
+
+// Snapshot returns the current process-session state.
+func (s *Session) Snapshot() ProcessSessionSnapshot {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return ProcessSessionSnapshot{
+		ID:        s.id,
+		Alias:     s.spec.Alias,
+		Command:   append([]string(nil), s.spec.Command...),
+		CWD:       s.spec.CWD,
+		EnvVars:   CloneEnvVars(s.spec.EnvVars),
+		State:     s.state,
+		PID:       s.pid,
+		CreatedAt: s.createdAt,
+		StartedAt: cloneTimePtr(s.startedAt),
+		ExitedAt:  cloneTimePtr(s.exitedAt),
+		ExitCode:  cloneIntPtr(s.exitCode),
+		Channels:  append([]ChannelSpec(nil), s.spec.Channels...),
+		EventLog:  s.eventLog.Snapshot(),
+		Cleanup:   s.spec.Cleanup,
+		Restart:   s.spec.Restart,
+	}
+}
+
+func cloneTimePtr(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	copied := *value
+	return &copied
+}
+
+func cloneIntPtr(value *int) *int {
+	if value == nil {
+		return nil
+	}
+	copied := *value
+	return &copied
+}
+
+// HandleInput accepts a client input event and routes it to a channel.
+func (s *Session) HandleInput(event ProcessInputEvent) (ProcessEvent, error) {
+	if strings.TrimSpace(event.EventID) == "" {
+		return ProcessEvent{}, fmt.Errorf("%w: event_id is required", ErrInvalidProcessEvent)
+	}
+	fingerprint := fingerprintInputEvent(event)
+	s.inputMu.Lock()
+	if existingFingerprint, ok := s.inputFingerprints[event.EventID]; ok {
+		result, hasResult := s.inputResults[event.EventID]
+		s.inputMu.Unlock()
+		if existingFingerprint != fingerprint {
+			return ProcessEvent{}, ErrDuplicateEventID
+		}
+		if hasResult {
+			return result, nil
+		}
+		return ProcessEvent{}, ErrDuplicateEventID
+	}
+	s.inputFingerprints[event.EventID] = fingerprint
+	s.inputMu.Unlock()
+
+	result, err := s.routeInput(event)
+	if err != nil {
+		s.inputMu.Lock()
+		delete(s.inputFingerprints, event.EventID)
+		s.inputMu.Unlock()
+		return ProcessEvent{}, err
+	}
+
+	s.inputMu.Lock()
+	s.inputResults[event.EventID] = result
+	s.inputMu.Unlock()
+	s.Touch()
+	return result, nil
+}
+
+func fingerprintInputEvent(event ProcessInputEvent) string {
+	body, _ := json.Marshal(event)
+	return string(body)
+}
+
+func (s *Session) routeInput(event ProcessInputEvent) (ProcessEvent, error) {
+	switch event.Type {
+	case EventTypeStdinWrite:
+		if s.stdio == nil {
+			return ProcessEvent{}, ErrUnsupportedChannelEvent
+		}
+		if event.Channel != s.stdio.name {
+			return ProcessEvent{}, ErrUnsupportedChannelEvent
+		}
+		data := stringPayload(event.Payload, "data")
+		if err := s.stdio.write([]byte(data)); err != nil {
+			return ProcessEvent{}, err
+		}
+		return s.eventLog.Publish(ProcessEvent{
+			EventID:   event.EventID,
+			ProcessID: s.id,
+			Channel:   s.stdio.name,
+			Type:      EventTypeStdinWrite,
+			Payload:   map[string]any{"data": data},
+		}), nil
+	case EventTypePTYInput:
+		if s.pty == nil {
+			return ProcessEvent{}, ErrUnsupportedChannelEvent
+		}
+		if event.Channel != s.pty.name {
+			return ProcessEvent{}, ErrUnsupportedChannelEvent
+		}
+		data := stringPayload(event.Payload, "data")
+		if err := s.pty.write([]byte(data)); err != nil {
+			return ProcessEvent{}, err
+		}
+		return s.eventLog.Publish(ProcessEvent{
+			EventID:   event.EventID,
+			ProcessID: s.id,
+			Channel:   s.pty.name,
+			Type:      EventTypePTYInput,
+			Payload:   map[string]any{"data": data},
+		}), nil
+	case EventTypeHTTPRequest:
+		ch, ok := s.http[event.Channel]
+		if !ok {
+			return ProcessEvent{}, ErrUnsupportedChannelEvent
+		}
+		accepted := s.eventLog.Publish(ProcessEvent{
+			EventID:   event.EventID,
+			ProcessID: s.id,
+			Channel:   ch.name,
+			Type:      EventTypeHTTPRequest,
+			Payload:   clonePayload(event.Payload),
+		})
+		go ch.doRequest(event)
+		return accepted, nil
+	case EventTypeWebSocketMsg:
+		ch, ok := s.ws[event.Channel]
+		if !ok {
+			return ProcessEvent{}, ErrUnsupportedChannelEvent
+		}
+		if err := ch.writeMessage(event); err != nil {
+			return ProcessEvent{}, err
+		}
+		return s.eventLog.Publish(ProcessEvent{
+			EventID:   event.EventID,
+			ProcessID: s.id,
+			Channel:   ch.name,
+			Type:      EventTypeWebSocketMsg,
+			Payload:   clonePayload(event.Payload),
+		}), nil
+	default:
+		return ProcessEvent{}, ErrUnsupportedChannelEvent
+	}
+}
+
+// Subscribe subscribes to replay and live process events.
+func (s *Session) Subscribe(cursor int64) (<-chan ProcessEvent, func()) {
+	s.Touch()
+	return s.eventLog.Subscribe(cursor)
+}
+
+// SendSignal sends a signal to the process group, falling back to the PID.
+func (s *Session) SendSignal(sig syscall.Signal) error {
+	s.mu.RLock()
+	pid := s.pid
+	state := s.state
+	s.mu.RUnlock()
+	if pid <= 0 || (state != ProcessSessionStateRunning && state != ProcessSessionStatePaused) {
+		return ErrProcessNotRunning
+	}
+	if err := syscall.Kill(-pid, sig); err != nil {
+		if err := syscall.Kill(pid, sig); err != nil {
+			return fmt.Errorf("%w: %v", ErrSignalFailed, err)
+		}
+	}
+	s.Touch()
+	return nil
+}
+
+// ResizePTY resizes a PTY channel.
+func (s *Session) ResizePTY(channel string, size PTYSize) error {
+	if s.pty == nil || s.pty.name != channel {
+		return ErrPTYNotAvailable
+	}
+	return s.pty.resize(size)
+}
+
+// Touch records session activity.
+func (s *Session) Touch() {
+	s.mu.Lock()
+	s.lastActive = time.Now().UTC()
+	s.mu.Unlock()
+}
+
+func (s *Session) shouldCleanup(now time.Time) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.spec.Cleanup.TTLSec > 0 && now.Sub(s.createdAt) >= time.Duration(s.spec.Cleanup.TTLSec)*time.Second {
+		return true
+	}
+	if s.spec.Cleanup.IdleTimeoutSec > 0 && now.Sub(s.lastActive) >= time.Duration(s.spec.Cleanup.IdleTimeoutSec)*time.Second {
+		return true
+	}
+	return false
+}
+
+type stdioSessionChannel struct {
+	name      string
+	framing   ChannelFraming
+	stdin     io.WriteCloser
+	inputCh   chan []byte
+	stopCh    chan struct{}
+	stopOnce  sync.Once
+	wg        sync.WaitGroup
+	eventLog  *EventLog
+	processID string
+}
+
+func newStdioSessionChannel(spec ChannelSpec, inputBuffer int, log *EventLog, processID string) *stdioSessionChannel {
+	return &stdioSessionChannel{
+		name:      spec.Name,
+		framing:   spec.Framing,
+		inputCh:   make(chan []byte, inputBuffer),
+		stopCh:    make(chan struct{}),
+		eventLog:  log,
+		processID: processID,
+	}
+}
+
+func (c *stdioSessionChannel) start() {
+	if c.stdin != nil {
+		go c.writeLoop()
+	}
+}
+
+func (c *stdioSessionChannel) write(data []byte) error {
+	if c.stdin == nil {
+		return ErrUnsupportedChannelEvent
+	}
+	payload := append([]byte(nil), data...)
+	select {
+	case c.inputCh <- payload:
+		return nil
+	default:
+		return ErrInputBufferFull
+	}
+}
+
+func (c *stdioSessionChannel) writeLoop() {
+	for {
+		select {
+		case <-c.stopCh:
+			return
+		case data := <-c.inputCh:
+			if len(data) == 0 {
+				continue
+			}
+			if _, err := c.stdin.Write(data); err != nil {
+				c.eventLog.Publish(ProcessEvent{
+					ProcessID: c.processID,
+					Channel:   c.name,
+					Type:      EventTypeError,
+					Payload:   map[string]any{"message": err.Error(), "source": "stdin"},
+				})
+			}
+		}
+	}
+}
+
+func (c *stdioSessionChannel) readStream(reader io.ReadCloser, source OutputSource) {
+	defer c.wg.Done()
+	defer reader.Close()
+	if c.framing == ChannelFramingRaw {
+		c.readRaw(reader, source)
+		return
+	}
+	c.readLines(reader, source)
+}
+
+func (c *stdioSessionChannel) readRaw(reader io.Reader, source OutputSource) {
+	buf := make([]byte, 4096)
+	for {
+		n, err := reader.Read(buf)
+		if n > 0 {
+			eventType := EventTypeStdoutChunk
+			if source == OutputSourceStderr {
+				eventType = EventTypeStderrChunk
+			}
+			c.eventLog.Publish(ProcessEvent{
+				ProcessID: c.processID,
+				Channel:   c.name,
+				Type:      eventType,
+				Payload: map[string]any{
+					"data": string(buf[:n]),
+				},
+			})
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+func (c *stdioSessionChannel) readLines(reader io.Reader, source OutputSource) {
+	buf := bufio.NewReader(reader)
+	for {
+		line, err := buf.ReadBytes('\n')
+		if len(line) > 0 {
+			line = bytes.TrimSuffix(line, []byte("\n"))
+			line = bytes.TrimSuffix(line, []byte("\r"))
+			eventType := EventTypeStdoutLine
+			if source == OutputSourceStderr {
+				eventType = EventTypeStderrLine
+			}
+			if (c.framing == ChannelFramingJSONL || c.framing == ChannelFramingJSONRPC) && len(bytes.TrimSpace(line)) > 0 && !json.Valid(line) {
+				c.eventLog.Publish(ProcessEvent{
+					ProcessID: c.processID,
+					Channel:   c.name,
+					Type:      EventTypeError,
+					Payload: map[string]any{
+						"message": "invalid json line",
+						"source":  string(source),
+						"data":    string(line),
+					},
+				})
+			}
+			c.eventLog.Publish(ProcessEvent{
+				ProcessID: c.processID,
+				Channel:   c.name,
+				Type:      eventType,
+				Payload: map[string]any{
+					"data": string(line),
+				},
+			})
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+func (c *stdioSessionChannel) stop() {
+	c.stopOnce.Do(func() {
+		close(c.stopCh)
+		if c.stdin != nil {
+			_ = c.stdin.Close()
+		}
+	})
+}
+
+func (c *stdioSessionChannel) wait() {
+	c.wg.Wait()
+}
+
+type ptySessionChannel struct {
+	name      string
+	ptmx      *os.File
+	inputCh   chan []byte
+	stopCh    chan struct{}
+	stopOnce  sync.Once
+	eventLog  *EventLog
+	processID string
+}
+
+func newPTYSessionChannel(spec ChannelSpec, inputBuffer int, ptmx *os.File, log *EventLog, processID string) *ptySessionChannel {
+	return &ptySessionChannel{
+		name:      spec.Name,
+		ptmx:      ptmx,
+		inputCh:   make(chan []byte, inputBuffer),
+		stopCh:    make(chan struct{}),
+		eventLog:  log,
+		processID: processID,
+	}
+}
+
+func (c *ptySessionChannel) start() {
+	go c.writeLoop()
+	go c.readLoop()
+}
+
+func (c *ptySessionChannel) write(data []byte) error {
+	payload := append([]byte(nil), data...)
+	select {
+	case c.inputCh <- payload:
+		return nil
+	default:
+		return ErrInputBufferFull
+	}
+}
+
+func (c *ptySessionChannel) writeLoop() {
+	for {
+		select {
+		case <-c.stopCh:
+			return
+		case data := <-c.inputCh:
+			if len(data) == 0 {
+				continue
+			}
+			_, _ = c.ptmx.Write(data)
+		}
+	}
+}
+
+func (c *ptySessionChannel) readLoop() {
+	buf := make([]byte, 4096)
+	for {
+		n, err := c.ptmx.Read(buf)
+		if n > 0 {
+			c.eventLog.Publish(ProcessEvent{
+				ProcessID: c.processID,
+				Channel:   c.name,
+				Type:      EventTypePTYOutput,
+				Payload: map[string]any{
+					"data": string(buf[:n]),
+				},
+			})
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+func (c *ptySessionChannel) resize(size PTYSize) error {
+	if size.Rows == 0 || size.Cols == 0 {
+		return fmt.Errorf("%w: rows and cols must be > 0", ErrInvalidPTYSize)
+	}
+	return pty.Setsize(c.ptmx, &pty.Winsize{Rows: size.Rows, Cols: size.Cols})
+}
+
+func (c *ptySessionChannel) stop() {
+	c.stopOnce.Do(func() {
+		close(c.stopCh)
+		_ = c.ptmx.Close()
+	})
+}
+
+type httpSessionChannel struct {
+	name      string
+	spec      HTTPChannelSpec
+	client    *http.Client
+	eventLog  *EventLog
+	processID string
+}
+
+func newHTTPSessionChannel(spec ChannelSpec, log *EventLog, processID string) *httpSessionChannel {
+	timeout := defaultHTTPTimeout
+	if spec.HTTP.Timeout > 0 {
+		timeout = time.Duration(spec.HTTP.Timeout) * time.Second
+	}
+	return &httpSessionChannel{
+		name:      spec.Name,
+		spec:      *spec.HTTP,
+		client:    &http.Client{Timeout: timeout},
+		eventLog:  log,
+		processID: processID,
+	}
+}
+
+func (c *httpSessionChannel) doRequest(event ProcessInputEvent) {
+	method := strings.ToUpper(stringPayload(event.Payload, "method"))
+	if method == "" {
+		method = http.MethodGet
+	}
+	target := joinURL(c.spec.BaseURL, stringPayload(event.Payload, "path"))
+	body := strings.NewReader(stringPayload(event.Payload, "body"))
+	req, err := http.NewRequest(method, target, body)
+	if err != nil {
+		c.publishError(err)
+		return
+	}
+	for k, v := range c.spec.Headers {
+		req.Header.Set(k, v)
+	}
+	for k, v := range stringMapPayload(event.Payload, "headers") {
+		req.Header.Set(k, v)
+	}
+	resp, err := c.client.Do(req)
+	if err != nil {
+		c.publishError(err)
+		return
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	c.eventLog.Publish(ProcessEvent{
+		EventID:   event.EventID,
+		ProcessID: c.processID,
+		Channel:   c.name,
+		Type:      EventTypeHTTPResponse,
+		Payload: map[string]any{
+			"status_code": resp.StatusCode,
+			"body":        string(respBody),
+		},
+	})
+}
+
+func (c *httpSessionChannel) publishError(err error) {
+	c.eventLog.Publish(ProcessEvent{
+		ProcessID: c.processID,
+		Channel:   c.name,
+		Type:      EventTypeError,
+		Payload:   map[string]any{"message": err.Error()},
+	})
+}
+
+type websocketSessionChannel struct {
+	name      string
+	spec      WebSocketChannelSpec
+	eventLog  *EventLog
+	processID string
+
+	mu     sync.Mutex
+	conn   *websocket.Conn
+	closed bool
+}
+
+func newWebSocketSessionChannel(spec ChannelSpec, log *EventLog, processID string) *websocketSessionChannel {
+	return &websocketSessionChannel{
+		name:      spec.Name,
+		spec:      *spec.WebSocket,
+		eventLog:  log,
+		processID: processID,
+	}
+}
+
+func (c *websocketSessionChannel) writeMessage(event ProcessInputEvent) error {
+	conn, err := c.ensureConnected()
+	if err != nil {
+		return err
+	}
+	return conn.WriteMessage(websocket.TextMessage, []byte(stringPayload(event.Payload, "data")))
+}
+
+func (c *websocketSessionChannel) ensureConnected() (*websocket.Conn, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return nil, ErrProcessFinished
+	}
+	if c.conn != nil {
+		return c.conn, nil
+	}
+	header := http.Header{}
+	for k, v := range c.spec.Headers {
+		header.Set(k, v)
+	}
+	conn, _, err := websocket.DefaultDialer.Dial(c.spec.URL, header)
+	if err != nil {
+		return nil, err
+	}
+	c.conn = conn
+	c.eventLog.Publish(ProcessEvent{
+		ProcessID: c.processID,
+		Channel:   c.name,
+		Type:      EventTypeWebSocketOpen,
+	})
+	go c.readLoop(conn)
+	return conn, nil
+}
+
+func (c *websocketSessionChannel) readLoop(conn *websocket.Conn) {
+	for {
+		_, data, err := conn.ReadMessage()
+		if err != nil {
+			c.eventLog.Publish(ProcessEvent{
+				ProcessID: c.processID,
+				Channel:   c.name,
+				Type:      EventTypeWebSocketClose,
+				Payload:   map[string]any{"message": err.Error()},
+			})
+			return
+		}
+		c.eventLog.Publish(ProcessEvent{
+			ProcessID: c.processID,
+			Channel:   c.name,
+			Type:      EventTypeWebSocketMsg,
+			Payload:   map[string]any{"data": string(data)},
+		})
+	}
+}
+
+func (c *websocketSessionChannel) stop() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.closed = true
+	if c.conn != nil {
+		_ = c.conn.Close()
+		c.conn = nil
+	}
+}
+
+func stringPayload(payload map[string]any, key string) string {
+	if payload == nil {
+		return ""
+	}
+	value, ok := payload[key]
+	if !ok || value == nil {
+		return ""
+	}
+	switch typed := value.(type) {
+	case string:
+		return typed
+	default:
+		return fmt.Sprint(typed)
+	}
+}
+
+func stringMapPayload(payload map[string]any, key string) map[string]string {
+	result := map[string]string{}
+	if payload == nil {
+		return result
+	}
+	value, ok := payload[key]
+	if !ok || value == nil {
+		return result
+	}
+	body, err := json.Marshal(value)
+	if err != nil {
+		return result
+	}
+	_ = json.Unmarshal(body, &result)
+	return result
+}
+
+func clonePayload(payload map[string]any) map[string]any {
+	if payload == nil {
+		return nil
+	}
+	cloned := make(map[string]any, len(payload))
+	for k, v := range payload {
+		cloned[k] = v
+	}
+	return cloned
+}
+
+func joinURL(base, path string) string {
+	if path == "" {
+		return base
+	}
+	base = strings.TrimRight(base, "/")
+	path = "/" + strings.TrimLeft(path, "/")
+	return base + path
+}

--- a/manager/procd/pkg/process/session_broker_test.go
+++ b/manager/procd/pkg/process/session_broker_test.go
@@ -1,0 +1,237 @@
+package process
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestProcessSessionStdioWritesInputAndSeparatesOutput(t *testing.T) {
+	session := startTestSession(t, ProcessSpec{
+		Command: []string{"/bin/sh", "-c", "read line; echo stdout:$line; echo stderr:$line >&2"},
+		Channels: []ChannelSpec{{
+			Name:    "rpc",
+			Kind:    ChannelKindStdio,
+			Framing: ChannelFramingLine,
+			Stdin:   true,
+			Stdout:  true,
+			Stderr:  true,
+		}},
+	})
+	defer session.Stop()
+
+	events, cancel := session.Subscribe(0)
+	defer cancel()
+
+	accepted, err := session.HandleInput(ProcessInputEvent{
+		EventID: "evt-input",
+		Channel: "rpc",
+		Type:    EventTypeStdinWrite,
+		Payload: map[string]any{"data": "hello\n"},
+	})
+	if err != nil {
+		t.Fatalf("HandleInput() error = %v", err)
+	}
+	if accepted.Type != EventTypeStdinWrite {
+		t.Fatalf("accepted type = %s, want %s", accepted.Type, EventTypeStdinWrite)
+	}
+
+	stdout, stderr := waitForStdioLines(t, events)
+	if stdout.Channel != "rpc" || stdout.Payload["data"] != "stdout:hello" {
+		t.Fatalf("stdout event = %#v", stdout)
+	}
+	if stderr.Channel != "rpc" || stderr.Payload["data"] != "stderr:hello" {
+		t.Fatalf("stderr event = %#v", stderr)
+	}
+}
+
+func TestProcessSessionSubscriptionCloseDoesNotStopProcess(t *testing.T) {
+	session := startTestSession(t, ProcessSpec{
+		Command: []string{"/bin/sh", "-c", "while read line; do echo $line; done"},
+		Channels: []ChannelSpec{{
+			Name:    "rpc",
+			Kind:    ChannelKindStdio,
+			Framing: ChannelFramingLine,
+			Stdin:   true,
+			Stdout:  true,
+		}},
+	})
+	defer session.Stop()
+
+	_, cancel := session.Subscribe(0)
+	cancel()
+
+	if _, err := session.HandleInput(ProcessInputEvent{
+		EventID: "evt-after-cancel",
+		Channel: "rpc",
+		Type:    EventTypeStdinWrite,
+		Payload: map[string]any{"data": "still-running\n"},
+	}); err != nil {
+		t.Fatalf("HandleInput() after cancel error = %v", err)
+	}
+
+	events, replayCancel := session.Subscribe(0)
+	defer replayCancel()
+	output := waitForEventType(t, events, EventTypeStdoutLine)
+	if output.Payload["data"] != "still-running" {
+		t.Fatalf("output data = %#v, want still-running", output.Payload["data"])
+	}
+	if got := session.Snapshot().State; got != ProcessSessionStateRunning {
+		t.Fatalf("state = %s, want running", got)
+	}
+}
+
+func TestProcessSessionDuplicateEventIDIsIdempotent(t *testing.T) {
+	session := startTestSession(t, ProcessSpec{
+		Command: []string{"/bin/sh", "-c", "while read line; do echo $line; done"},
+		Channels: []ChannelSpec{{
+			Name:   "rpc",
+			Kind:   ChannelKindStdio,
+			Stdin:  true,
+			Stdout: true,
+		}},
+	})
+	defer session.Stop()
+
+	event := ProcessInputEvent{
+		EventID: "evt-repeat",
+		Channel: "rpc",
+		Type:    EventTypeStdinWrite,
+		Payload: map[string]any{"data": "hello\n"},
+	}
+	first, err := session.HandleInput(event)
+	if err != nil {
+		t.Fatalf("first HandleInput() error = %v", err)
+	}
+	second, err := session.HandleInput(event)
+	if err != nil {
+		t.Fatalf("second HandleInput() error = %v", err)
+	}
+	if first.Seq != second.Seq {
+		t.Fatalf("duplicate seq = %d, want %d", second.Seq, first.Seq)
+	}
+
+	event.Payload = map[string]any{"data": "different\n"}
+	if _, err := session.HandleInput(event); err != ErrDuplicateEventID {
+		t.Fatalf("changed duplicate error = %v, want ErrDuplicateEventID", err)
+	}
+}
+
+func TestEventLogReportsCursorLost(t *testing.T) {
+	log := NewEventLog(2)
+	log.Publish(ProcessEvent{ProcessID: "proc", Type: EventTypeStdoutLine})
+	log.Publish(ProcessEvent{ProcessID: "proc", Type: EventTypeStdoutLine})
+	log.Publish(ProcessEvent{ProcessID: "proc", Type: EventTypeStdoutLine})
+
+	events, cancel := log.Subscribe(1)
+	defer cancel()
+	event := waitForEventType(t, events, EventTypeCursorLost)
+	if event.Payload["oldest_seq"] == nil {
+		t.Fatalf("cursor_lost payload missing oldest_seq: %#v", event.Payload)
+	}
+}
+
+func TestProcessSessionHTTPChannelPublishesResponse(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/work" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	session := startTestSession(t, ProcessSpec{
+		Command: []string{"/bin/sleep", "5"},
+		Channels: []ChannelSpec{{
+			Name: "api",
+			Kind: ChannelKindHTTP,
+			HTTP: &HTTPChannelSpec{BaseURL: upstream.URL},
+		}},
+	})
+	defer session.Stop()
+
+	events, cancel := session.Subscribe(0)
+	defer cancel()
+
+	if _, err := session.HandleInput(ProcessInputEvent{
+		EventID: "evt-http",
+		Channel: "api",
+		Type:    EventTypeHTTPRequest,
+		Payload: map[string]any{
+			"method": "POST",
+			"path":   "/work",
+			"body":   "payload",
+		},
+	}); err != nil {
+		t.Fatalf("HandleInput(http.request) error = %v", err)
+	}
+	response := waitForEventType(t, events, EventTypeHTTPResponse)
+	if response.Channel != "api" || response.Payload["body"] != "ok" {
+		t.Fatalf("http response event = %#v", response)
+	}
+}
+
+func startTestSession(t *testing.T, spec ProcessSpec) *Session {
+	t.Helper()
+	session, err := NewSession("proc-test", spec)
+	if err != nil {
+		t.Fatalf("NewSession() error = %v", err)
+	}
+	if err := session.Start(); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	return session
+}
+
+func waitForEventType(t *testing.T, events <-chan ProcessEvent, eventType ProcessEventType) ProcessEvent {
+	t.Helper()
+	timeout := time.After(3 * time.Second)
+	for {
+		select {
+		case event, ok := <-events:
+			if !ok {
+				t.Fatalf("event stream closed before %s", eventType)
+			}
+			if event.Type == eventType {
+				return event
+			}
+		case <-timeout:
+			seen := make([]ProcessEvent, 0)
+			for {
+				select {
+				case event := <-events:
+					seen = append(seen, event)
+				default:
+					body, _ := json.Marshal(seen)
+					t.Fatalf("timed out waiting for %s; buffered=%s", eventType, string(body))
+				}
+			}
+		}
+	}
+}
+
+func waitForStdioLines(t *testing.T, events <-chan ProcessEvent) (ProcessEvent, ProcessEvent) {
+	t.Helper()
+	timeout := time.After(3 * time.Second)
+	var stdout ProcessEvent
+	var stderr ProcessEvent
+	for stdout.Type == "" || stderr.Type == "" {
+		select {
+		case event, ok := <-events:
+			if !ok {
+				t.Fatalf("event stream closed before stdout/stderr lines")
+			}
+			switch event.Type {
+			case EventTypeStdoutLine:
+				stdout = event
+			case EventTypeStderrLine:
+				stderr = event
+			}
+		case <-timeout:
+			t.Fatalf("timed out waiting for stdout/stderr lines; stdout=%#v stderr=%#v", stdout, stderr)
+		}
+	}
+	return stdout, stderr
+}

--- a/manager/procd/pkg/process/session_errors.go
+++ b/manager/procd/pkg/process/session_errors.go
@@ -1,0 +1,23 @@
+package process
+
+import "errors"
+
+var (
+	// ErrProcessSessionNotFound is returned when a process session is missing.
+	ErrProcessSessionNotFound = errors.New("process session not found")
+
+	// ErrInvalidProcessSpec is returned for malformed process-session specs.
+	ErrInvalidProcessSpec = errors.New("invalid process spec")
+
+	// ErrInvalidProcessEvent is returned for malformed input events.
+	ErrInvalidProcessEvent = errors.New("invalid process event")
+
+	// ErrUnsupportedChannelKind is returned for unsupported channel kinds.
+	ErrUnsupportedChannelKind = errors.New("unsupported channel kind")
+
+	// ErrUnsupportedChannelEvent is returned when an event does not match a channel.
+	ErrUnsupportedChannelEvent = errors.New("unsupported channel event")
+
+	// ErrDuplicateEventID is returned when an input event id is reused with a different payload.
+	ErrDuplicateEventID = errors.New("duplicate event id")
+)

--- a/manager/procd/pkg/process/session_manager.go
+++ b/manager/procd/pkg/process/session_manager.go
@@ -1,0 +1,157 @@
+package process
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// SessionManager owns process sessions in a sandbox.
+type SessionManager struct {
+	mu                   sync.RWMutex
+	sessions             map[string]*Session
+	sandboxEnvVars       map[string]string
+	defaultCleanupPolicy ProcessCleanupSpec
+	cleanupOnce          sync.Once
+}
+
+// NewSessionManager creates a process-session manager.
+func NewSessionManager() *SessionManager {
+	return &SessionManager{
+		sessions: make(map[string]*Session),
+	}
+}
+
+// SetDefaultCleanupPolicy sets cleanup defaults for newly created sessions.
+func (m *SessionManager) SetDefaultCleanupPolicy(policy ProcessCleanupSpec) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.defaultCleanupPolicy = policy
+}
+
+// SetSandboxEnvVars sets sandbox-level environment variables for new sessions.
+func (m *SessionManager) SetSandboxEnvVars(envVars map[string]string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.sandboxEnvVars = CloneEnvVars(envVars)
+}
+
+// SandboxEnvVars returns a copy of sandbox-level environment variables.
+func (m *SessionManager) SandboxEnvVars() map[string]string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return CloneEnvVars(m.sandboxEnvVars)
+}
+
+// CreateSession creates and starts a process session.
+func (m *SessionManager) CreateSession(spec ProcessSpec) (*Session, error) {
+	m.mu.Lock()
+	defaultCleanup := m.defaultCleanupPolicy
+	spec.EnvVars = MergeEnvVars(m.sandboxEnvVars, spec.EnvVars)
+	if spec.Cleanup == (ProcessCleanupSpec{}) {
+		spec.Cleanup = defaultCleanup
+	}
+	m.mu.Unlock()
+
+	session, err := NewSession("proc_"+uuid.NewString(), spec)
+	if err != nil {
+		return nil, err
+	}
+	if err := session.Start(); err != nil {
+		return nil, err
+	}
+
+	m.mu.Lock()
+	m.sessions[session.ID()] = session
+	m.mu.Unlock()
+	return session, nil
+}
+
+// GetSession returns a process session by ID.
+func (m *SessionManager) GetSession(id string) (*Session, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	session, ok := m.sessions[id]
+	if !ok {
+		return nil, ErrProcessSessionNotFound
+	}
+	return session, nil
+}
+
+// ListSessions returns all process sessions.
+func (m *SessionManager) ListSessions() []*Session {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	result := make([]*Session, 0, len(m.sessions))
+	for _, session := range m.sessions {
+		result = append(result, session)
+	}
+	return result
+}
+
+// DeleteSession stops and removes a process session.
+func (m *SessionManager) DeleteSession(id string) error {
+	m.mu.Lock()
+	session, ok := m.sessions[id]
+	if !ok {
+		m.mu.Unlock()
+		return ErrProcessSessionNotFound
+	}
+	delete(m.sessions, id)
+	m.mu.Unlock()
+	return session.Stop()
+}
+
+// Cleanup stops and removes all process sessions.
+func (m *SessionManager) Cleanup() {
+	m.mu.Lock()
+	sessions := make([]*Session, 0, len(m.sessions))
+	for _, session := range m.sessions {
+		sessions = append(sessions, session)
+	}
+	m.sessions = make(map[string]*Session)
+	m.mu.Unlock()
+	for _, session := range sessions {
+		_ = session.Stop()
+	}
+}
+
+// StartCleanup starts cleanup for expired process sessions.
+func (m *SessionManager) StartCleanup(ctx context.Context, interval time.Duration) {
+	if interval <= 0 {
+		return
+	}
+	m.cleanupOnce.Do(func() {
+		ticker := time.NewTicker(interval)
+		go func() {
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-ticker.C:
+					m.cleanupExpired()
+				}
+			}
+		}()
+	})
+}
+
+func (m *SessionManager) cleanupExpired() {
+	now := time.Now()
+	expiredIDs := make([]string, 0)
+
+	m.mu.RLock()
+	for id, session := range m.sessions {
+		if session.shouldCleanup(now) {
+			expiredIDs = append(expiredIDs, id)
+		}
+	}
+	m.mu.RUnlock()
+
+	for _, id := range expiredIDs {
+		_ = m.DeleteSession(id)
+	}
+}

--- a/manager/procd/pkg/process/session_types.go
+++ b/manager/procd/pkg/process/session_types.go
@@ -1,0 +1,158 @@
+package process
+
+import "time"
+
+// ChannelKind describes how procd communicates with a process capability.
+type ChannelKind string
+
+const (
+	ChannelKindStdio     ChannelKind = "stdio"
+	ChannelKindPTY       ChannelKind = "pty"
+	ChannelKindHTTP      ChannelKind = "http"
+	ChannelKindWebSocket ChannelKind = "websocket"
+)
+
+// ChannelFraming describes how byte streams are turned into process events.
+type ChannelFraming string
+
+const (
+	ChannelFramingRaw     ChannelFraming = "raw"
+	ChannelFramingLine    ChannelFraming = "line"
+	ChannelFramingJSONL   ChannelFraming = "jsonl"
+	ChannelFramingJSONRPC ChannelFraming = "jsonrpc"
+)
+
+// ProcessEventType is the normalized event vocabulary for process sessions.
+type ProcessEventType string
+
+const (
+	EventTypeProcessStarted ProcessEventType = "process.started"
+	EventTypeProcessExited  ProcessEventType = "process.exited"
+	EventTypeProcessCrashed ProcessEventType = "process.crashed"
+	EventTypeProcessStopped ProcessEventType = "process.stopped"
+	EventTypeStdinWrite     ProcessEventType = "stdin.write"
+	EventTypeStdoutChunk    ProcessEventType = "stdout.chunk"
+	EventTypeStdoutLine     ProcessEventType = "stdout.line"
+	EventTypeStderrChunk    ProcessEventType = "stderr.chunk"
+	EventTypeStderrLine     ProcessEventType = "stderr.line"
+	EventTypePTYInput       ProcessEventType = "pty.input"
+	EventTypePTYOutput      ProcessEventType = "pty.output"
+	EventTypeHTTPRequest    ProcessEventType = "http.request"
+	EventTypeHTTPResponse   ProcessEventType = "http.response"
+	EventTypeWebSocketOpen  ProcessEventType = "websocket.open"
+	EventTypeWebSocketMsg   ProcessEventType = "websocket.message"
+	EventTypeWebSocketClose ProcessEventType = "websocket.close"
+	EventTypeError          ProcessEventType = "error"
+	EventTypeCursorLost     ProcessEventType = "cursor_lost"
+)
+
+// ProcessSessionState is the lifecycle state for a process session.
+type ProcessSessionState string
+
+const (
+	ProcessSessionStateCreated  ProcessSessionState = "created"
+	ProcessSessionStateStarting ProcessSessionState = "starting"
+	ProcessSessionStateRunning  ProcessSessionState = "running"
+	ProcessSessionStatePaused   ProcessSessionState = "paused"
+	ProcessSessionStateStopping ProcessSessionState = "stopping"
+	ProcessSessionStateStopped  ProcessSessionState = "stopped"
+	ProcessSessionStateKilled   ProcessSessionState = "killed"
+	ProcessSessionStateCrashed  ProcessSessionState = "crashed"
+)
+
+// ProcessSpec declares a process session and its brokered channels.
+type ProcessSpec struct {
+	Alias           string             `json:"alias,omitempty"`
+	Command         []string           `json:"command"`
+	CWD             string             `json:"cwd,omitempty"`
+	EnvVars         map[string]string  `json:"env_vars,omitempty"`
+	Channels        []ChannelSpec      `json:"channels"`
+	Cleanup         ProcessCleanupSpec `json:"cleanup,omitempty"`
+	Restart         ProcessRestartSpec `json:"restart,omitempty"`
+	EventBufferSize int                `json:"event_buffer_size,omitempty"`
+	InputBufferSize int                `json:"input_buffer_size,omitempty"`
+}
+
+// ChannelSpec declares one brokered communication channel.
+type ChannelSpec struct {
+	Name      string                `json:"name"`
+	Kind      ChannelKind           `json:"kind"`
+	Framing   ChannelFraming        `json:"framing,omitempty"`
+	Stdin     bool                  `json:"stdin,omitempty"`
+	Stdout    bool                  `json:"stdout,omitempty"`
+	Stderr    bool                  `json:"stderr,omitempty"`
+	PTYSize   *PTYSize              `json:"pty_size,omitempty"`
+	HTTP      *HTTPChannelSpec      `json:"http,omitempty"`
+	WebSocket *WebSocketChannelSpec `json:"websocket,omitempty"`
+}
+
+// HTTPChannelSpec configures event-driven HTTP requests through procd.
+type HTTPChannelSpec struct {
+	BaseURL string            `json:"base_url"`
+	Headers map[string]string `json:"headers,omitempty"`
+	Timeout int32             `json:"timeout_sec,omitempty"`
+}
+
+// WebSocketChannelSpec configures an upstream websocket owned by procd.
+type WebSocketChannelSpec struct {
+	URL     string            `json:"url"`
+	Headers map[string]string `json:"headers,omitempty"`
+}
+
+// ProcessCleanupSpec controls process-session cleanup.
+type ProcessCleanupSpec struct {
+	IdleTimeoutSec int32 `json:"idle_timeout_sec,omitempty"`
+	TTLSec         int32 `json:"ttl_sec,omitempty"`
+}
+
+// ProcessRestartSpec declares restart policy. Only "never" is currently
+// accepted; the type is present so the API shape matches the broker contract.
+type ProcessRestartSpec struct {
+	Policy      string `json:"policy,omitempty"`
+	MaxRestarts int32  `json:"max_restarts,omitempty"`
+}
+
+// EventLogSnapshot summarizes replay state.
+type EventLogSnapshot struct {
+	NextSeq   int64 `json:"next_seq"`
+	OldestSeq int64 `json:"oldest_seq"`
+	Capacity  int   `json:"capacity"`
+}
+
+// ProcessSessionSnapshot is the wire representation of a process session.
+type ProcessSessionSnapshot struct {
+	ID        string              `json:"id"`
+	Alias     string              `json:"alias,omitempty"`
+	Command   []string            `json:"command"`
+	CWD       string              `json:"cwd,omitempty"`
+	EnvVars   map[string]string   `json:"env_vars,omitempty"`
+	State     ProcessSessionState `json:"state"`
+	PID       int                 `json:"pid,omitempty"`
+	CreatedAt time.Time           `json:"created_at"`
+	StartedAt *time.Time          `json:"started_at,omitempty"`
+	ExitedAt  *time.Time          `json:"exited_at,omitempty"`
+	ExitCode  *int                `json:"exit_code,omitempty"`
+	Channels  []ChannelSpec       `json:"channels"`
+	EventLog  EventLogSnapshot    `json:"event_log"`
+	Cleanup   ProcessCleanupSpec  `json:"cleanup,omitempty"`
+	Restart   ProcessRestartSpec  `json:"restart,omitempty"`
+}
+
+// ProcessEvent is a normalized process-session event.
+type ProcessEvent struct {
+	Seq       int64            `json:"seq"`
+	EventID   string           `json:"event_id,omitempty"`
+	ProcessID string           `json:"process_id"`
+	Channel   string           `json:"channel,omitempty"`
+	Type      ProcessEventType `json:"type"`
+	Timestamp time.Time        `json:"timestamp"`
+	Payload   map[string]any   `json:"payload,omitempty"`
+}
+
+// ProcessInputEvent is a client-supplied event sent to a process channel.
+type ProcessInputEvent struct {
+	EventID string           `json:"event_id"`
+	Channel string           `json:"channel"`
+	Type    ProcessEventType `json:"type"`
+	Payload map[string]any   `json:"payload,omitempty"`
+}

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -16,6 +16,7 @@ tags:
   - name: api-keys
   - name: sandboxes
   - name: contexts
+  - name: processes
   - name: observability
   - name: audit
   - name: files
@@ -2395,6 +2396,188 @@ paths:
       responses:
         "101":
           description: Switching Protocols
+  /api/v1/sandboxes/{id}/processes:
+    post:
+      tags: [processes]
+      summary: Create a process session
+      description: Creates a broker-owned process session with declared protocol channels. Client disconnects from event subscriptions do not close child process descriptors.
+      security:
+        - bearerAuth: []
+      x-upstream-service: procd
+      x-upstream-path: /api/v1/processes
+      parameters:
+        - $ref: "#/components/parameters/SandboxID"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProcessSpec"
+      responses:
+        "201":
+          description: Process session created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessProcessSessionResponse"
+    get:
+      tags: [processes]
+      summary: List process sessions
+      security:
+        - bearerAuth: []
+      x-upstream-service: procd
+      x-upstream-path: /api/v1/processes
+      parameters:
+        - $ref: "#/components/parameters/SandboxID"
+      responses:
+        "200":
+          description: Process session list
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessProcessSessionListResponse"
+  /api/v1/sandboxes/{id}/processes/{process_id}:
+    get:
+      tags: [processes]
+      summary: Get process session
+      security:
+        - bearerAuth: []
+      x-upstream-service: procd
+      x-upstream-path: /api/v1/processes/{process_id}
+      parameters:
+        - $ref: "#/components/parameters/SandboxID"
+        - $ref: "#/components/parameters/ProcessID"
+      responses:
+        "200":
+          description: Process session
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessProcessSessionResponse"
+    delete:
+      tags: [processes]
+      summary: Delete process session
+      description: Stops the process session, closes broker-owned channels, and removes it from procd.
+      security:
+        - bearerAuth: []
+      x-upstream-service: procd
+      x-upstream-path: /api/v1/processes/{process_id}
+      parameters:
+        - $ref: "#/components/parameters/SandboxID"
+        - $ref: "#/components/parameters/ProcessID"
+      responses:
+        "200":
+          description: Process session deleted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessDeletedResponse"
+  /api/v1/sandboxes/{id}/processes/{process_id}/events:
+    post:
+      tags: [processes]
+      summary: Send process input event
+      description: Sends an idempotent input event to one process channel. event_id is required and repeated identical events return the original accepted event.
+      security:
+        - bearerAuth: []
+      x-upstream-service: procd
+      x-upstream-path: /api/v1/processes/{process_id}/events
+      parameters:
+        - $ref: "#/components/parameters/SandboxID"
+        - $ref: "#/components/parameters/ProcessID"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProcessInputEvent"
+      responses:
+        "202":
+          description: Process input event accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessProcessEventResponse"
+        "409":
+          description: Input backpressure or process state conflict
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+    get:
+      tags: [processes]
+      summary: Stream process events
+      description: Streams replayed and live process events as Server-Sent Events. cursor is the last observed event seq; procd emits cursor_lost if the requested cursor is older than the retained log.
+      security:
+        - bearerAuth: []
+      x-upstream-service: procd
+      x-upstream-path: /api/v1/processes/{process_id}/events
+      parameters:
+        - $ref: "#/components/parameters/SandboxID"
+        - $ref: "#/components/parameters/ProcessID"
+        - name: cursor
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+            minimum: 0
+      responses:
+        "200":
+          description: Process event stream
+          content:
+            text/event-stream:
+              schema:
+                type: string
+                description: SSE stream whose data field contains a ProcessEvent JSON object.
+  /api/v1/sandboxes/{id}/processes/{process_id}/signal:
+    post:
+      tags: [processes]
+      summary: Send signal to process session
+      security:
+        - bearerAuth: []
+      x-upstream-service: procd
+      x-upstream-path: /api/v1/processes/{process_id}/signal
+      parameters:
+        - $ref: "#/components/parameters/SandboxID"
+        - $ref: "#/components/parameters/ProcessID"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SignalContextRequest"
+      responses:
+        "200":
+          description: Signal sent
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessSignaledResponse"
+  /api/v1/sandboxes/{id}/processes/{process_id}/channels/{channel}/pty-size:
+    put:
+      tags: [processes]
+      summary: Resize process PTY channel
+      security:
+        - bearerAuth: []
+      x-upstream-service: procd
+      x-upstream-path: /api/v1/processes/{process_id}/channels/{channel}/pty-size
+      parameters:
+        - $ref: "#/components/parameters/SandboxID"
+        - $ref: "#/components/parameters/ProcessID"
+        - $ref: "#/components/parameters/ProcessChannel"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ResizeContextRequest"
+      responses:
+        "200":
+          description: Resized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResizedResponse"
   /api/v1/sandboxes/{id}/files/move:
     post:
       tags: [files]
@@ -3281,6 +3464,18 @@ components:
         type: string
     ContextID:
       name: ctx_id
+      in: path
+      required: true
+      schema:
+        type: string
+    ProcessID:
+      name: process_id
+      in: path
+      required: true
+      schema:
+        type: string
+    ProcessChannel:
+      name: channel
       in: path
       required: true
       schema:
@@ -5494,6 +5689,264 @@ components:
           properties:
             data:
               $ref: "#/components/schemas/ContextExecResponse"
+    ProcessSessionState:
+      type: string
+      enum: [created, starting, running, paused, stopping, stopped, killed, crashed]
+      x-enum-varnames:
+        - ProcessSessionStateCreated
+        - ProcessSessionStateStarting
+        - ProcessSessionStateRunning
+        - ProcessSessionStatePaused
+        - ProcessSessionStateStopping
+        - ProcessSessionStateStopped
+        - ProcessSessionStateKilled
+        - ProcessSessionStateCrashed
+    ProcessChannelKind:
+      type: string
+      enum: [stdio, pty, http, websocket]
+    ProcessChannelFraming:
+      type: string
+      enum: [raw, line, jsonl, jsonrpc]
+    HTTPChannelSpec:
+      type: object
+      properties:
+        base_url:
+          type: string
+        headers:
+          type: object
+          additionalProperties:
+            type: string
+        timeout_sec:
+          type: integer
+          format: int32
+      required: [base_url]
+    WebSocketChannelSpec:
+      type: object
+      properties:
+        url:
+          type: string
+        headers:
+          type: object
+          additionalProperties:
+            type: string
+      required: [url]
+    ProcessChannelSpec:
+      type: object
+      properties:
+        name:
+          type: string
+        kind:
+          $ref: "#/components/schemas/ProcessChannelKind"
+        framing:
+          $ref: "#/components/schemas/ProcessChannelFraming"
+        stdin:
+          type: boolean
+        stdout:
+          type: boolean
+        stderr:
+          type: boolean
+        pty_size:
+          $ref: "#/components/schemas/PTYSize"
+        http:
+          $ref: "#/components/schemas/HTTPChannelSpec"
+        websocket:
+          $ref: "#/components/schemas/WebSocketChannelSpec"
+      required: [name, kind]
+    ProcessCleanupSpec:
+      type: object
+      properties:
+        idle_timeout_sec:
+          type: integer
+          format: int32
+        ttl_sec:
+          type: integer
+          format: int32
+    ProcessRestartSpec:
+      type: object
+      properties:
+        policy:
+          type: string
+          enum: [never]
+        max_restarts:
+          type: integer
+          format: int32
+    ProcessSpec:
+      type: object
+      properties:
+        alias:
+          type: string
+        command:
+          type: array
+          items:
+            type: string
+          description: argv array. procd does not shell-expand command strings.
+        cwd:
+          type: string
+        env_vars:
+          type: object
+          additionalProperties:
+            type: string
+        channels:
+          type: array
+          items:
+            $ref: "#/components/schemas/ProcessChannelSpec"
+        cleanup:
+          $ref: "#/components/schemas/ProcessCleanupSpec"
+        restart:
+          $ref: "#/components/schemas/ProcessRestartSpec"
+        event_buffer_size:
+          type: integer
+          format: int32
+        input_buffer_size:
+          type: integer
+          format: int32
+      required: [command, channels]
+    ProcessEventLogSnapshot:
+      type: object
+      properties:
+        next_seq:
+          type: integer
+          format: int64
+        oldest_seq:
+          type: integer
+          format: int64
+        capacity:
+          type: integer
+          format: int32
+      required: [next_seq, oldest_seq, capacity]
+    ProcessSession:
+      type: object
+      properties:
+        id:
+          type: string
+        alias:
+          type: string
+        command:
+          type: array
+          items:
+            type: string
+        cwd:
+          type: string
+        env_vars:
+          type: object
+          additionalProperties:
+            type: string
+        state:
+          $ref: "#/components/schemas/ProcessSessionState"
+        pid:
+          type: integer
+          format: int32
+        created_at:
+          type: string
+          format: date-time
+        started_at:
+          type: string
+          format: date-time
+        exited_at:
+          type: string
+          format: date-time
+        exit_code:
+          type: integer
+          format: int32
+        channels:
+          type: array
+          items:
+            $ref: "#/components/schemas/ProcessChannelSpec"
+        event_log:
+          $ref: "#/components/schemas/ProcessEventLogSnapshot"
+        cleanup:
+          $ref: "#/components/schemas/ProcessCleanupSpec"
+        restart:
+          $ref: "#/components/schemas/ProcessRestartSpec"
+      required: [id, command, state, created_at, channels, event_log]
+    ProcessEventType:
+      type: string
+      enum:
+        - process.started
+        - process.exited
+        - process.crashed
+        - process.stopped
+        - stdin.write
+        - stdout.chunk
+        - stdout.line
+        - stderr.chunk
+        - stderr.line
+        - pty.input
+        - pty.output
+        - http.request
+        - http.response
+        - websocket.open
+        - websocket.message
+        - websocket.close
+        - error
+        - cursor_lost
+    ProcessEvent:
+      type: object
+      properties:
+        seq:
+          type: integer
+          format: int64
+        event_id:
+          type: string
+        process_id:
+          type: string
+        channel:
+          type: string
+        type:
+          $ref: "#/components/schemas/ProcessEventType"
+        timestamp:
+          type: string
+          format: date-time
+        payload:
+          type: object
+          additionalProperties: true
+      required: [seq, process_id, type, timestamp]
+    ProcessInputEvent:
+      type: object
+      properties:
+        event_id:
+          type: string
+          description: Idempotency key for retries.
+        channel:
+          type: string
+        type:
+          $ref: "#/components/schemas/ProcessEventType"
+        payload:
+          type: object
+          additionalProperties: true
+      required: [event_id, channel, type]
+    SuccessProcessSessionResponse:
+      allOf:
+        - $ref: "#/components/schemas/SuccessEnvelope"
+        - type: object
+          properties:
+            data:
+              type: object
+              properties:
+                process:
+                  $ref: "#/components/schemas/ProcessSession"
+    SuccessProcessSessionListResponse:
+      allOf:
+        - $ref: "#/components/schemas/SuccessEnvelope"
+        - type: object
+          properties:
+            data:
+              type: object
+              properties:
+                processes:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/ProcessSession"
+    SuccessProcessEventResponse:
+      allOf:
+        - $ref: "#/components/schemas/SuccessEnvelope"
+        - type: object
+          properties:
+            data:
+              type: object
+              properties:
+                event:
+                  $ref: "#/components/schemas/ProcessEvent"
     FileInfo:
       type: object
       properties:

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -141,6 +141,61 @@ const (
 	PlaceholderSubstitutionLocationQuery  PlaceholderSubstitutionLocation = "query"
 )
 
+// Defines values for ProcessChannelFraming.
+const (
+	Jsonl   ProcessChannelFraming = "jsonl"
+	Jsonrpc ProcessChannelFraming = "jsonrpc"
+	Line    ProcessChannelFraming = "line"
+	Raw     ProcessChannelFraming = "raw"
+)
+
+// Defines values for ProcessChannelKind.
+const (
+	ProcessChannelKindHttp      ProcessChannelKind = "http"
+	ProcessChannelKindPty       ProcessChannelKind = "pty"
+	ProcessChannelKindStdio     ProcessChannelKind = "stdio"
+	ProcessChannelKindWebsocket ProcessChannelKind = "websocket"
+)
+
+// Defines values for ProcessEventType.
+const (
+	ProcessEventTypeCursorLost       ProcessEventType = "cursor_lost"
+	ProcessEventTypeError            ProcessEventType = "error"
+	ProcessEventTypeHttpRequest      ProcessEventType = "http.request"
+	ProcessEventTypeHttpResponse     ProcessEventType = "http.response"
+	ProcessEventTypeProcessCrashed   ProcessEventType = "process.crashed"
+	ProcessEventTypeProcessExited    ProcessEventType = "process.exited"
+	ProcessEventTypeProcessStarted   ProcessEventType = "process.started"
+	ProcessEventTypeProcessStopped   ProcessEventType = "process.stopped"
+	ProcessEventTypePtyInput         ProcessEventType = "pty.input"
+	ProcessEventTypePtyOutput        ProcessEventType = "pty.output"
+	ProcessEventTypeStderrChunk      ProcessEventType = "stderr.chunk"
+	ProcessEventTypeStderrLine       ProcessEventType = "stderr.line"
+	ProcessEventTypeStdinWrite       ProcessEventType = "stdin.write"
+	ProcessEventTypeStdoutChunk      ProcessEventType = "stdout.chunk"
+	ProcessEventTypeStdoutLine       ProcessEventType = "stdout.line"
+	ProcessEventTypeWebsocketClose   ProcessEventType = "websocket.close"
+	ProcessEventTypeWebsocketMessage ProcessEventType = "websocket.message"
+	ProcessEventTypeWebsocketOpen    ProcessEventType = "websocket.open"
+)
+
+// Defines values for ProcessRestartSpecPolicy.
+const (
+	Never ProcessRestartSpecPolicy = "never"
+)
+
+// Defines values for ProcessSessionState.
+const (
+	ProcessSessionStateCrashed  ProcessSessionState = "crashed"
+	ProcessSessionStateCreated  ProcessSessionState = "created"
+	ProcessSessionStateKilled   ProcessSessionState = "killed"
+	ProcessSessionStatePaused   ProcessSessionState = "paused"
+	ProcessSessionStateRunning  ProcessSessionState = "running"
+	ProcessSessionStateStarting ProcessSessionState = "starting"
+	ProcessSessionStateStopped  ProcessSessionState = "stopped"
+	ProcessSessionStateStopping ProcessSessionState = "stopping"
+)
+
 // Defines values for ProcessType.
 const (
 	ProcessTypeCmd  ProcessType = "cmd"
@@ -218,9 +273,9 @@ const (
 
 // Defines values for SandboxObservabilityLogStream.
 const (
-	Pty    SandboxObservabilityLogStream = "pty"
-	Stderr SandboxObservabilityLogStream = "stderr"
-	Stdout SandboxObservabilityLogStream = "stdout"
+	SandboxObservabilityLogStreamPty    SandboxObservabilityLogStream = "pty"
+	SandboxObservabilityLogStreamStderr SandboxObservabilityLogStream = "stderr"
+	SandboxObservabilityLogStreamStdout SandboxObservabilityLogStream = "stdout"
 )
 
 // Defines values for SandboxObservabilityOutcome.
@@ -379,6 +434,21 @@ const (
 // Defines values for SuccessPauseSandboxResponseSuccess.
 const (
 	SuccessPauseSandboxResponseSuccessTrue SuccessPauseSandboxResponseSuccess = true
+)
+
+// Defines values for SuccessProcessEventResponseSuccess.
+const (
+	SuccessProcessEventResponseSuccessTrue SuccessProcessEventResponseSuccess = true
+)
+
+// Defines values for SuccessProcessSessionListResponseSuccess.
+const (
+	SuccessProcessSessionListResponseSuccessTrue SuccessProcessSessionListResponseSuccess = true
+)
+
+// Defines values for SuccessProcessSessionResponseSuccess.
+const (
+	SuccessProcessSessionResponseSuccessTrue SuccessProcessSessionResponseSuccess = true
 )
 
 // Defines values for SuccessRefreshResponseSuccess.
@@ -553,7 +623,7 @@ const (
 
 // Defines values for SuccessWrittenResponseSuccess.
 const (
-	SuccessWrittenResponseSuccessTrue SuccessWrittenResponseSuccess = true
+	True SuccessWrittenResponseSuccess = true
 )
 
 // Defines values for TeamQuotaUnit.
@@ -1145,6 +1215,13 @@ type GatewayMetadata struct {
 // GatewayMetadataGatewayMode defines model for GatewayMetadata.GatewayMode.
 type GatewayMetadataGatewayMode string
 
+// HTTPChannelSpec defines model for HTTPChannelSpec.
+type HTTPChannelSpec struct {
+	BaseUrl    string             `json:"base_url"`
+	Headers    *map[string]string `json:"headers,omitempty"`
+	TimeoutSec *int32             `json:"timeout_sec,omitempty"`
+}
+
 // HTTPHeadersProjection defines model for HTTPHeadersProjection.
 type HTTPHeadersProjection struct {
 	// Headers Outbound headers synthesized from the resolved credential source.
@@ -1434,6 +1511,108 @@ type PortSpec struct {
 type PreferredSchedulingTerm struct {
 	Preference NodeSelectorTerm `json:"preference"`
 	Weight     int32            `json:"weight"`
+}
+
+// ProcessChannelFraming defines model for ProcessChannelFraming.
+type ProcessChannelFraming string
+
+// ProcessChannelKind defines model for ProcessChannelKind.
+type ProcessChannelKind string
+
+// ProcessChannelSpec defines model for ProcessChannelSpec.
+type ProcessChannelSpec struct {
+	Framing   *ProcessChannelFraming `json:"framing,omitempty"`
+	Http      *HTTPChannelSpec       `json:"http,omitempty"`
+	Kind      ProcessChannelKind     `json:"kind"`
+	Name      string                 `json:"name"`
+	PtySize   *PTYSize               `json:"pty_size,omitempty"`
+	Stderr    *bool                  `json:"stderr,omitempty"`
+	Stdin     *bool                  `json:"stdin,omitempty"`
+	Stdout    *bool                  `json:"stdout,omitempty"`
+	Websocket *WebSocketChannelSpec  `json:"websocket,omitempty"`
+}
+
+// ProcessCleanupSpec defines model for ProcessCleanupSpec.
+type ProcessCleanupSpec struct {
+	IdleTimeoutSec *int32 `json:"idle_timeout_sec,omitempty"`
+	TtlSec         *int32 `json:"ttl_sec,omitempty"`
+}
+
+// ProcessEvent defines model for ProcessEvent.
+type ProcessEvent struct {
+	Channel   *string                 `json:"channel,omitempty"`
+	EventId   *string                 `json:"event_id,omitempty"`
+	Payload   *map[string]interface{} `json:"payload,omitempty"`
+	ProcessId string                  `json:"process_id"`
+	Seq       int64                   `json:"seq"`
+	Timestamp time.Time               `json:"timestamp"`
+	Type      ProcessEventType        `json:"type"`
+}
+
+// ProcessEventLogSnapshot defines model for ProcessEventLogSnapshot.
+type ProcessEventLogSnapshot struct {
+	Capacity  int32 `json:"capacity"`
+	NextSeq   int64 `json:"next_seq"`
+	OldestSeq int64 `json:"oldest_seq"`
+}
+
+// ProcessEventType defines model for ProcessEventType.
+type ProcessEventType string
+
+// ProcessInputEvent defines model for ProcessInputEvent.
+type ProcessInputEvent struct {
+	Channel string `json:"channel"`
+
+	// EventId Idempotency key for retries.
+	EventId string                  `json:"event_id"`
+	Payload *map[string]interface{} `json:"payload,omitempty"`
+	Type    ProcessEventType        `json:"type"`
+}
+
+// ProcessRestartSpec defines model for ProcessRestartSpec.
+type ProcessRestartSpec struct {
+	MaxRestarts *int32                    `json:"max_restarts,omitempty"`
+	Policy      *ProcessRestartSpecPolicy `json:"policy,omitempty"`
+}
+
+// ProcessRestartSpecPolicy defines model for ProcessRestartSpec.Policy.
+type ProcessRestartSpecPolicy string
+
+// ProcessSession defines model for ProcessSession.
+type ProcessSession struct {
+	Alias     *string                 `json:"alias,omitempty"`
+	Channels  []ProcessChannelSpec    `json:"channels"`
+	Cleanup   *ProcessCleanupSpec     `json:"cleanup,omitempty"`
+	Command   []string                `json:"command"`
+	CreatedAt time.Time               `json:"created_at"`
+	Cwd       *string                 `json:"cwd,omitempty"`
+	EnvVars   *map[string]string      `json:"env_vars,omitempty"`
+	EventLog  ProcessEventLogSnapshot `json:"event_log"`
+	ExitCode  *int32                  `json:"exit_code,omitempty"`
+	ExitedAt  *time.Time              `json:"exited_at,omitempty"`
+	Id        string                  `json:"id"`
+	Pid       *int32                  `json:"pid,omitempty"`
+	Restart   *ProcessRestartSpec     `json:"restart,omitempty"`
+	StartedAt *time.Time              `json:"started_at,omitempty"`
+	State     ProcessSessionState     `json:"state"`
+}
+
+// ProcessSessionState defines model for ProcessSessionState.
+type ProcessSessionState string
+
+// ProcessSpec defines model for ProcessSpec.
+type ProcessSpec struct {
+	Alias    *string              `json:"alias,omitempty"`
+	Channels []ProcessChannelSpec `json:"channels"`
+	Cleanup  *ProcessCleanupSpec  `json:"cleanup,omitempty"`
+
+	// Command argv array. procd does not shell-expand command strings.
+	Command         []string            `json:"command"`
+	Cwd             *string             `json:"cwd,omitempty"`
+	EnvVars         *map[string]string  `json:"env_vars,omitempty"`
+	EventBufferSize *int32              `json:"event_buffer_size,omitempty"`
+	InputBufferSize *int32              `json:"input_buffer_size,omitempty"`
+	Restart         *ProcessRestartSpec `json:"restart,omitempty"`
 }
 
 // ProcessType defines model for ProcessType.
@@ -2460,6 +2639,39 @@ type SuccessPauseSandboxResponse struct {
 // SuccessPauseSandboxResponseSuccess defines model for SuccessPauseSandboxResponse.Success.
 type SuccessPauseSandboxResponseSuccess bool
 
+// SuccessProcessEventResponse defines model for SuccessProcessEventResponse.
+type SuccessProcessEventResponse struct {
+	Data *struct {
+		Event *ProcessEvent `json:"event,omitempty"`
+	} `json:"data,omitempty"`
+	Success SuccessProcessEventResponseSuccess `json:"success"`
+}
+
+// SuccessProcessEventResponseSuccess defines model for SuccessProcessEventResponse.Success.
+type SuccessProcessEventResponseSuccess bool
+
+// SuccessProcessSessionListResponse defines model for SuccessProcessSessionListResponse.
+type SuccessProcessSessionListResponse struct {
+	Data *struct {
+		Processes *[]ProcessSession `json:"processes,omitempty"`
+	} `json:"data,omitempty"`
+	Success SuccessProcessSessionListResponseSuccess `json:"success"`
+}
+
+// SuccessProcessSessionListResponseSuccess defines model for SuccessProcessSessionListResponse.Success.
+type SuccessProcessSessionListResponseSuccess bool
+
+// SuccessProcessSessionResponse defines model for SuccessProcessSessionResponse.
+type SuccessProcessSessionResponse struct {
+	Data *struct {
+		Process *ProcessSession `json:"process,omitempty"`
+	} `json:"data,omitempty"`
+	Success SuccessProcessSessionResponseSuccess `json:"success"`
+}
+
+// SuccessProcessSessionResponseSuccess defines model for SuccessProcessSessionResponse.Success.
+type SuccessProcessSessionResponseSuccess bool
+
 // SuccessRefreshResponse defines model for SuccessRefreshResponse.
 type SuccessRefreshResponse struct {
 	Data    *RefreshResponse              `json:"data,omitempty"`
@@ -3017,6 +3229,12 @@ type WebLoginExchangeRequest struct {
 	ReturnUrl string `json:"return_url"`
 }
 
+// WebSocketChannelSpec defines model for WebSocketChannelSpec.
+type WebSocketChannelSpec struct {
+	Headers *map[string]string `json:"headers,omitempty"`
+	Url     string             `json:"url"`
+}
+
 // WebhookConfig Per-sandbox webhook configuration. Sandbox0 delivers webhook events at least once and consumers should deduplicate by event_id. For sandbox lifecycle events, procd persists signed delivery records to a manager-owned SandboxVolume outside the workspace before dispatch; manager also emits sandbox.deleted during pod deletion cleanup.
 type WebhookConfig struct {
 	// Secret Optional. Shared secret used to sign webhook payloads.
@@ -3049,6 +3267,12 @@ type IdentityID = string
 
 // OIDCProvider defines model for OIDCProvider.
 type OIDCProvider = string
+
+// ProcessChannel defines model for ProcessChannel.
+type ProcessChannel = string
+
+// ProcessID defines model for ProcessID.
+type ProcessID = string
 
 // QueryMkdir defines model for QueryMkdir.
 type QueryMkdir = bool
@@ -3216,6 +3440,11 @@ type GetApiV1SandboxesIdObservabilityMetricsParams struct {
 	Names *string `form:"names,omitempty" json:"names,omitempty"`
 }
 
+// GetApiV1SandboxesIdProcessesProcessIdEventsParams defines parameters for GetApiV1SandboxesIdProcessesProcessIdEvents.
+type GetApiV1SandboxesIdProcessesProcessIdEventsParams struct {
+	Cursor *int64 `form:"cursor,omitempty" json:"cursor,omitempty"`
+}
+
 // DeleteApiV1SandboxvolumesIdParams defines parameters for DeleteApiV1SandboxvolumesId.
 type DeleteApiV1SandboxvolumesIdParams struct {
 	// Force Force delete even if volume has active mounts
@@ -3315,6 +3544,18 @@ type PostApiV1SandboxesIdForkJSONRequestBody = ForkSandboxRequest
 
 // PutApiV1SandboxesIdNetworkJSONRequestBody defines body for PutApiV1SandboxesIdNetwork for application/json ContentType.
 type PutApiV1SandboxesIdNetworkJSONRequestBody = SandboxNetworkPolicy
+
+// PostApiV1SandboxesIdProcessesJSONRequestBody defines body for PostApiV1SandboxesIdProcesses for application/json ContentType.
+type PostApiV1SandboxesIdProcessesJSONRequestBody = ProcessSpec
+
+// PutApiV1SandboxesIdProcessesProcessIdChannelsChannelPtySizeJSONRequestBody defines body for PutApiV1SandboxesIdProcessesProcessIdChannelsChannelPtySize for application/json ContentType.
+type PutApiV1SandboxesIdProcessesProcessIdChannelsChannelPtySizeJSONRequestBody = ResizeContextRequest
+
+// PostApiV1SandboxesIdProcessesProcessIdEventsJSONRequestBody defines body for PostApiV1SandboxesIdProcessesProcessIdEvents for application/json ContentType.
+type PostApiV1SandboxesIdProcessesProcessIdEventsJSONRequestBody = ProcessInputEvent
+
+// PostApiV1SandboxesIdProcessesProcessIdSignalJSONRequestBody defines body for PostApiV1SandboxesIdProcessesProcessIdSignal for application/json ContentType.
+type PostApiV1SandboxesIdProcessesProcessIdSignalJSONRequestBody = SignalContextRequest
 
 // PostApiV1SandboxesIdRefreshJSONRequestBody defines body for PostApiV1SandboxesIdRefresh for application/json ContentType.
 type PostApiV1SandboxesIdRefreshJSONRequestBody = SandboxRefreshRequest

--- a/pkg/gateway/middleware/long_lived.go
+++ b/pkg/gateway/middleware/long_lived.go
@@ -29,7 +29,18 @@ func RequestShouldBeLongLived(req *http.Request) bool {
 	if proxy.IsWebSocketUpgrade(req) {
 		return true
 	}
+	if isSandboxProcessEventStreamRequest(req) {
+		return true
+	}
 	return isSandboxObservabilityWatchRequest(req)
+}
+
+func isSandboxProcessEventStreamRequest(req *http.Request) bool {
+	if req.Method != http.MethodGet || req.URL == nil {
+		return false
+	}
+	path := req.URL.Path
+	return strings.HasPrefix(path, "/api/v1/sandboxes/") && strings.Contains(path, "/processes/") && strings.HasSuffix(path, "/events")
 }
 
 func isSandboxObservabilityWatchRequest(req *http.Request) bool {

--- a/pkg/gateway/middleware/long_lived_test.go
+++ b/pkg/gateway/middleware/long_lived_test.go
@@ -28,6 +28,11 @@ func TestRequestShouldBeLongLived(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "process event stream",
+			req:  httptest.NewRequest(http.MethodGet, "/api/v1/sandboxes/sb_123/processes/proc_123/events?cursor=10", nil),
+			want: true,
+		},
+		{
 			name: "websocket context stream",
 			req: func() *http.Request {
 				req := httptest.NewRequest(http.MethodGet, "/api/v1/sandboxes/sb_123/contexts/ctx_123/ws", nil)


### PR DESCRIPTION
## Summary
- add procd process sessions with broker-owned channels, bounded event logs, idempotent input events, and SSE replay
- expose `/api/v1/processes` inside procd and `/api/v1/sandboxes/{id}/processes` through cluster-gateway
- update OpenAPI/generated apispec and add docs for Process Sessions

## Tests
- `go test ./pkg/apispec ./manager/cmd/procd ./manager/procd/... ./cluster-gateway/... ./pkg/gateway/...`
