### PR TITLE
Fix ctld CSI cleanup across restarts

### DIFF
--- a/ctld/cmd/ctld/main.go
+++ b/ctld/cmd/ctld/main.go
@@ -28,7 +28,11 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/sandboxprobe"
 	storagedb "github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/objectstore"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/kubernetes"
 )
 
 var (
@@ -43,6 +47,7 @@ var (
 	containerdNamespace            = "k8s.io"
 	nodeName                       = os.Getenv("NODE_NAME")
 	portalRoot                     = "/var/lib/sandbox0/ctld"
+	kubeletPodsRoot                = "/var/lib/kubelet/pods"
 	csiSocket                      = "/var/lib/kubelet/plugins/volume.sandbox0.ai/csi.sock"
 	rootFSObjectCacheMaxBytes      = "20Gi"
 	rootFSObjectCacheMinFreeBytes  = "0"
@@ -50,6 +55,11 @@ var (
 	rootFSObjectCacheSweepInterval = time.Minute
 	podName                        = os.Getenv("POD_NAME")
 	podNamespace                   = os.Getenv("POD_NAMESPACE")
+)
+
+const (
+	httpShutdownTimeout   = 5 * time.Second
+	portalShutdownTimeout = 25 * time.Second
 )
 
 func main() {
@@ -64,6 +74,7 @@ func main() {
 	flag.StringVar(&containerdNamespace, "containerd-namespace", "k8s.io", "containerd namespace used by Kubernetes")
 	flag.StringVar(&nodeName, "node-name", os.Getenv("NODE_NAME"), "current node name used to validate local sandbox ownership")
 	flag.StringVar(&portalRoot, "volume-portal-root", "/var/lib/sandbox0/ctld", "host-local root for ctld volume portal WAL and cache")
+	flag.StringVar(&kubeletPodsRoot, "kubelet-pods-root", "/var/lib/kubelet/pods", "host kubelet pod directory used to recover stale sandbox0 CSI mounts")
 	flag.StringVar(&csiSocket, "csi-socket", "/var/lib/kubelet/plugins/volume.sandbox0.ai/csi.sock", "CSI endpoint socket for sandbox volume portals")
 	flag.StringVar(&rootFSObjectCacheMaxBytes, "rootfs-object-cache-max-bytes", "20Gi", "maximum node-local rootfs object cache size; set to 0 to disable")
 	flag.StringVar(&rootFSObjectCacheMinFreeBytes, "rootfs-object-cache-min-free-bytes", "0", "minimum free bytes to preserve on the rootfs object cache filesystem")
@@ -96,6 +107,13 @@ func main() {
 		}
 	}
 
+	var k8sClient kubernetes.Interface
+	if client, err := k8s.NewClientWithObservability(kubeconfig, obsProvider); err != nil {
+		log.Printf("ctld kubernetes client disabled: %v", err)
+	} else {
+		k8sClient = client
+	}
+
 	storageCfg := apiconfig.LoadStorageProxyConfig()
 	var repo *storagedb.Repository
 	var dbPool *pgxpool.Pool
@@ -109,15 +127,23 @@ func main() {
 		}
 	}
 
+	podUIDLister := activePodUIDLister(k8sClient, nodeName)
 	portalManager := ctldportal.NewManager(ctldportal.Config{
-		NodeName:      nodeName,
-		RootDir:       portalRoot,
-		Logger:        zapLogger,
-		StorageConfig: storageCfg,
-		Repository:    repo,
-		PodName:       podName,
-		PodNamespace:  podNamespace,
+		NodeName:           nodeName,
+		RootDir:            portalRoot,
+		KubeletPodsRoot:    kubeletPodsRoot,
+		Logger:             zapLogger,
+		StorageConfig:      storageCfg,
+		Repository:         repo,
+		PodName:            podName,
+		PodNamespace:       podNamespace,
+		ActivePodUIDLister: podUIDLister,
 	})
+	cleanupCtx, cleanupCancel := context.WithTimeout(ctx, 30*time.Second)
+	if err := portalManager.CleanupStaleCSIMounts(cleanupCtx); err != nil && cleanupCtx.Err() == nil {
+		log.Printf("ctld stale CSI mount cleanup completed with errors: %v", err)
+	}
+	cleanupCancel()
 	go portalManager.Run(ctx)
 	csiServer := ctldportal.NewCSIServer(nodeName, portalManager)
 	go func() {
@@ -127,7 +153,7 @@ func main() {
 	}()
 	defer csiServer.Stop()
 
-	probeController := buildProbeController(ctx, obsProvider)
+	probeController := buildProbeController(ctx, k8sClient, obsProvider)
 	httpServer := newHTTPServer(httpAddr, combinedController{
 		Controller: probeController,
 		Portal:     portalManager,
@@ -147,22 +173,27 @@ func main() {
 	s := <-sigs
 	log.Printf("Received signal \"%v\", shutting down.", s)
 	cancel()
-	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
-	_ = httpServer.Shutdown(shutdownCtx)
-	shutdownCancel()
+	httpShutdownCtx, httpShutdownCancel := context.WithTimeout(context.Background(), httpShutdownTimeout)
+	_ = httpServer.Shutdown(httpShutdownCtx)
+	httpShutdownCancel()
+	csiServer.Stop()
+	portalShutdownCtx, portalShutdownCancel := context.WithTimeout(context.Background(), portalShutdownTimeout)
+	if err := portalManager.Shutdown(portalShutdownCtx); err != nil {
+		log.Printf("ctld volume portal shutdown completed with errors: %v", err)
+	}
+	portalShutdownCancel()
 }
 
 func newHTTPServer(addr string, controller ctldserver.Controller) *http.Server {
 	return &http.Server{Addr: addr, Handler: ctldserver.NewMux(controller)}
 }
 
-func buildProbeController(ctx context.Context, obsProvider *observability.Provider) ctldserver.Controller {
+func buildProbeController(ctx context.Context, k8sClient kubernetes.Interface, obsProvider *observability.Provider) ctldserver.Controller {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	k8sClient, err := k8s.NewClientWithObservability(kubeconfig, obsProvider)
-	if err != nil {
-		log.Printf("ctld probe control disabled: build kubernetes client: %v", err)
+	if k8sClient == nil {
+		log.Printf("ctld probe control disabled: kubernetes client unavailable")
 		return ctldserver.NotImplementedController{}
 	}
 	resolver := ctldpower.NewPodResolver(k8sClient, nodeName)
@@ -185,6 +216,37 @@ func buildProbeController(ctx context.Context, obsProvider *observability.Provid
 		}()
 	}
 	return controller
+}
+
+func activePodUIDLister(k8sClient kubernetes.Interface, nodeName string) ctldportal.ActivePodUIDLister {
+	nodeName = strings.TrimSpace(nodeName)
+	if k8sClient == nil || nodeName == "" {
+		return nil
+	}
+	return func(ctx context.Context) (map[string]struct{}, error) {
+		pods, err := k8sClient.CoreV1().Pods(metav1.NamespaceAll).List(ctx, metav1.ListOptions{
+			FieldSelector: fields.OneTermEqualSelector("spec.nodeName", nodeName).String(),
+		})
+		if err != nil {
+			return nil, err
+		}
+		active := make(map[string]struct{}, len(pods.Items))
+		for i := range pods.Items {
+			pod := &pods.Items[i]
+			if podTerminalForMountCleanup(pod) || pod.UID == "" {
+				continue
+			}
+			active[string(pod.UID)] = struct{}{}
+		}
+		return active, nil
+	}
+}
+
+func podTerminalForMountCleanup(pod *corev1.Pod) bool {
+	if pod == nil {
+		return true
+	}
+	return pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed
 }
 
 func buildRootFSController(ctx context.Context, storageCfg *apiconfig.StorageProxyConfig, portalResolver ctldrootfs.PortalResolver) rootFSHandler {

--- a/ctld/internal/ctld/portal/csi.go
+++ b/ctld/internal/ctld/portal/csi.go
@@ -115,11 +115,11 @@ func (s *CSIServer) NodePublishVolume(ctx context.Context, req *csi.NodePublishV
 	return &csi.NodePublishVolumeResponse{}, nil
 }
 
-func (s *CSIServer) NodeUnpublishVolume(_ context.Context, req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
+func (s *CSIServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
 	if req.GetTargetPath() == "" {
 		return nil, status.Error(codes.InvalidArgument, "target path is required")
 	}
-	if err := s.manager.UnpublishPortal(req.GetTargetPath()); err != nil {
+	if err := s.manager.UnpublishPortalContext(ctx, req.GetTargetPath()); err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 	return &csi.NodeUnpublishVolumeResponse{}, nil

--- a/ctld/internal/ctld/portal/manager.go
+++ b/ctld/internal/ctld/portal/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"net"
 	"net/http"
 	"os"
@@ -30,10 +31,13 @@ import (
 const defaultRootDir = "/var/lib/sandbox0/ctld"
 const defaultVolumePortalCacheSizeLimit = "20Gi"
 const defaultVolumePortalRootMinFree = "5Gi"
+const defaultS0FSMaterializerConcurrency = 16
+const defaultVolumeMaterializeInterval = 2 * time.Second
 
 type Manager struct {
 	nodeName               string
 	rootDir                string
+	kubeletPodsRoot        string
 	logger                 *zap.Logger
 	logrus                 *logrus.Logger
 	storage                *apiconfig.StorageProxyConfig
@@ -48,6 +52,10 @@ type Manager struct {
 	portalCacheMaxBytes    int64
 	portalRootMinFreeBytes int64
 	volumeAPI              http.Handler
+	staleMountCleaner      staleMountCleaner
+	staleMountChecker      staleMountChecker
+	activePodUIDLister     ActivePodUIDLister
+	materializerLimiter    chan struct{}
 
 	mu              sync.Mutex
 	portals         map[string]*portalMount
@@ -88,22 +96,39 @@ type boundVolume struct {
 
 	materializeCancel context.CancelFunc
 	materializeDone   chan struct{}
+	closing           bool
+}
+
+type boundVolumeCleanup struct {
+	volumeID          string
+	bound             *boundVolume
+	materializeCancel context.CancelFunc
+	materializeDone   chan struct{}
 }
 
 type Config struct {
-	NodeName      string
-	RootDir       string
-	Logger        *zap.Logger
-	StorageConfig *apiconfig.StorageProxyConfig
-	Repository    *db.Repository
-	PodName       string
-	PodNamespace  string
+	NodeName                string
+	RootDir                 string
+	KubeletPodsRoot         string
+	Logger                  *zap.Logger
+	StorageConfig           *apiconfig.StorageProxyConfig
+	Repository              *db.Repository
+	PodName                 string
+	PodNamespace            string
+	StaleMountCleaner       staleMountCleaner
+	StaleMountChecker       staleMountChecker
+	ActivePodUIDLister      ActivePodUIDLister
+	MaterializerConcurrency int
 }
 
 func NewManager(cfg Config) *Manager {
 	rootDir := strings.TrimSpace(cfg.RootDir)
 	if rootDir == "" {
 		rootDir = defaultRootDir
+	}
+	kubeletPodsRoot := strings.TrimSpace(cfg.KubeletPodsRoot)
+	if kubeletPodsRoot == "" {
+		kubeletPodsRoot = defaultKubeletPodsRoot
 	}
 	logger := cfg.Logger
 	if logger == nil {
@@ -123,9 +148,22 @@ func NewManager(cfg Config) *Manager {
 	ownerOnlyIdleTTL, _ := time.ParseDuration(storageConfig.DirectVolumeFileIdleTTL)
 	portalCacheMaxBytes := parseQuantityBytesOrDefault(storageConfig.VolumePortalCacheSizeLimit, defaultVolumePortalCacheSizeLimit)
 	portalRootMinFreeBytes := parseQuantityBytesOrDefault(storageConfig.VolumePortalRootMinFree, defaultVolumePortalRootMinFree)
+	staleCleaner := cfg.StaleMountCleaner
+	if staleCleaner == nil {
+		staleCleaner = defaultStaleMountCleaner
+	}
+	staleChecker := cfg.StaleMountChecker
+	if staleChecker == nil {
+		staleChecker = defaultStaleMountChecker
+	}
+	materializerConcurrency := cfg.MaterializerConcurrency
+	if materializerConcurrency <= 0 {
+		materializerConcurrency = defaultS0FSMaterializerConcurrency
+	}
 	manager := &Manager{
 		nodeName:               strings.TrimSpace(cfg.NodeName),
 		rootDir:                rootDir,
+		kubeletPodsRoot:        kubeletPodsRoot,
 		logger:                 logger,
 		logrus:                 l,
 		storage:                storageConfig,
@@ -139,6 +177,10 @@ func NewManager(cfg Config) *Manager {
 		ownerOnlyIdleTTL:       ownerOnlyIdleTTL,
 		portalCacheMaxBytes:    portalCacheMaxBytes,
 		portalRootMinFreeBytes: portalRootMinFreeBytes,
+		staleMountCleaner:      staleCleaner,
+		staleMountChecker:      staleChecker,
+		activePodUIDLister:     cfg.ActivePodUIDLister,
+		materializerLimiter:    make(chan struct{}, materializerConcurrency),
 		portals:                make(map[string]*portalMount),
 		portalsByTarget:        make(map[string]*portalMount),
 		boundVolumes:           make(map[string]*boundVolume),
@@ -184,6 +226,54 @@ func (m *Manager) Run(ctx context.Context) {
 			m.cleanupIdleOwnerOnlyVolumes(ctx)
 		}
 	}
+}
+
+// Shutdown detaches portal mounts without waiting on FUSE servers that may already be unresponsive.
+func (m *Manager) Shutdown(ctx context.Context) error {
+	if m == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	m.mu.Lock()
+	targets := make([]string, 0, len(m.portalsByTarget))
+	for target := range m.portalsByTarget {
+		targets = append(targets, target)
+	}
+	ownerOnlyVolumeIDs := make([]string, 0, len(m.boundVolumes))
+	for volumeID, bound := range m.boundVolumes {
+		if bound == nil || bound.refCount > 0 || bound.closing {
+			continue
+		}
+		ownerOnlyVolumeIDs = append(ownerOnlyVolumeIDs, volumeID)
+	}
+	m.mu.Unlock()
+
+	var firstErr error
+	for _, target := range targets {
+		if err := ctx.Err(); err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			break
+		}
+		if err := m.unpublishPortalContext(ctx, target, true); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	for _, volumeID := range ownerOnlyVolumeIDs {
+		if err := ctx.Err(); err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			break
+		}
+		if err := m.releaseOwnerOnlyVolumeNow(ctx, volumeID); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
 }
 
 func (m *Manager) PublishPortal(ctx context.Context, req publishRequest) error {
@@ -266,33 +356,64 @@ func mountPortalFS(fs *volumefuse.FileSystem, targetPath string) (*fuse.Server, 
 }
 
 func (m *Manager) UnpublishPortal(targetPath string) error {
+	return m.UnpublishPortalContext(context.Background(), targetPath)
+}
+
+func (m *Manager) UnpublishPortalContext(ctx context.Context, targetPath string) error {
+	return m.unpublishPortalContext(ctx, targetPath, false)
+}
+
+func (m *Manager) unpublishPortalContext(ctx context.Context, targetPath string, detach bool) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	m.mu.Lock()
 	pm := m.portalsByTarget[targetPath]
-	var unbindErr error
+	var cleanup *boundVolumeCleanup
 	if pm != nil {
 		delete(m.portalsByTarget, targetPath)
 		delete(m.portals, portalKey(pm.podUID, pm.name))
-		unbindErr = m.unbindLockedSnapshot(pm)
+		cleanup = m.unbindLockedSnapshot(pm)
 	}
 	m.mu.Unlock()
 	if pm == nil {
-		return nil
+		return m.cleanUnknownStaleMountTarget(targetPath)
 	}
-	if unbindErr != nil {
-		return unbindErr
-	}
-	if pm.server != nil {
+	var firstErr error
+	if detach {
+		if err := m.cleanStaleMountTarget(pm.targetPath); err != nil {
+			firstErr = err
+		}
+	} else if pm.server != nil {
 		if err := pm.server.Unmount(); err != nil {
-			return err
+			if cleanupErr := m.cleanStaleMountTarget(pm.targetPath); cleanupErr != nil {
+				firstErr = err
+			}
 		}
 	}
 	if pm.rootfsSession != nil {
 		pm.rootfsSession.Close()
 	}
 	if pm.rootfsBackingPath != "" {
-		return os.RemoveAll(pm.rootfsBackingPath)
+		if err := os.RemoveAll(pm.rootfsBackingPath); err != nil && firstErr == nil {
+			firstErr = err
+		}
 	}
-	return nil
+	if err := m.finishBoundVolumeCleanup(ctx, cleanup); err != nil && firstErr == nil {
+		firstErr = err
+	}
+	return firstErr
+}
+
+func (m *Manager) cleanStaleMountTarget(targetPath string) error {
+	if strings.TrimSpace(targetPath) == "" {
+		return nil
+	}
+	cleaner := defaultStaleMountCleaner
+	if m != nil && m.staleMountCleaner != nil {
+		cleaner = m.staleMountCleaner
+	}
+	return cleaner(targetPath)
 }
 
 func (m *Manager) RootFSPortalPaths(podUID string) []ctldapi.RootFSPortalPath {
@@ -375,6 +496,10 @@ func (m *Manager) Bind(ctx context.Context, req ctldapi.BindVolumePortalRequest)
 		return response, nil
 	}
 	if bound := m.boundVolumes[req.SandboxVolumeID]; bound != nil {
+		if bound.closing {
+			m.mu.Unlock()
+			return ctldapi.BindVolumePortalResponse{}, fmt.Errorf("volume %s is closing", req.SandboxVolumeID)
+		}
 		if bound.refCount == 0 {
 			m.attachPortalLocked(pm, bound, mountedAt)
 			bound.refCount = 1
@@ -422,6 +547,11 @@ func (m *Manager) Bind(ctx context.Context, req ctldapi.BindVolumePortalRequest)
 		return response, nil
 	}
 	if bound := m.boundVolumes[req.SandboxVolumeID]; bound != nil {
+		if bound.closing {
+			m.mu.Unlock()
+			cleanupNewBound()
+			return ctldapi.BindVolumePortalResponse{}, fmt.Errorf("volume %s is closing", req.SandboxVolumeID)
+		}
 		if bound.refCount == 0 {
 			m.attachPortalLocked(pm, bound, mountedAt)
 			bound.refCount = 1
@@ -594,9 +724,9 @@ func (m *Manager) Unbind(ctx context.Context, req ctldapi.UnbindVolumePortalRequ
 		m.mu.Unlock()
 		return ctldapi.UnbindVolumePortalResponse{Unbound: true}, nil
 	}
-	err := m.unbindLockedSnapshot(pm)
+	cleanup := m.unbindLockedSnapshot(pm)
 	m.mu.Unlock()
-	if err != nil {
+	if err := m.finishBoundVolumeCleanup(ctx, cleanup); err != nil {
 		return ctldapi.UnbindVolumePortalResponse{}, err
 	}
 	return ctldapi.UnbindVolumePortalResponse{Unbound: true}, nil
@@ -655,6 +785,10 @@ func (m *Manager) AttachOwner(ctx context.Context, req ctldapi.AttachVolumeOwner
 
 	m.mu.Lock()
 	if bound := m.boundVolumes[req.SandboxVolumeID]; bound != nil {
+		if bound.closing {
+			m.mu.Unlock()
+			return ctldapi.AttachVolumeOwnerResponse{}, fmt.Errorf("volume %s is closing", req.SandboxVolumeID)
+		}
 		m.mu.Unlock()
 		m.volumes.touch(req.SandboxVolumeID)
 		return ctldapi.AttachVolumeOwnerResponse{Attached: true}, nil
@@ -707,6 +841,11 @@ func (m *Manager) AttachOwner(ctx context.Context, req ctldapi.AttachVolumeOwner
 
 	m.mu.Lock()
 	if bound := m.boundVolumes[req.SandboxVolumeID]; bound != nil {
+		if bound.closing {
+			m.mu.Unlock()
+			_ = engine.Close()
+			return ctldapi.AttachVolumeOwnerResponse{}, fmt.Errorf("volume %s is closing", req.SandboxVolumeID)
+		}
 		m.mu.Unlock()
 		_ = engine.Close()
 		m.volumes.touch(req.SandboxVolumeID)
@@ -750,6 +889,11 @@ func (m *Manager) ReleaseOwner(ctx context.Context, req ctldapi.ReleaseVolumeOwn
 		m.mu.Unlock()
 		return ctldapi.ReleaseVolumeOwnerResponse{Released: true}, nil
 	}
+	if bound.closing {
+		m.mu.Unlock()
+		err := fmt.Errorf("volume %s is closing", volumeID)
+		return ctldapi.ReleaseVolumeOwnerResponse{Busy: true, Error: err.Error()}, err
+	}
 	if bound.refCount > 0 {
 		m.mu.Unlock()
 		err := fmt.Errorf("volume %s is actively bound to a portal", volumeID)
@@ -760,11 +904,11 @@ func (m *Manager) ReleaseOwner(ctx context.Context, req ctldapi.ReleaseVolumeOwn
 		err := fmt.Errorf("volume %s %s", volumeID, reason)
 		return ctldapi.ReleaseVolumeOwnerResponse{Busy: true, Error: err.Error()}, err
 	}
-	if err := m.releaseOwnerOnlyVolumeLocked(ctx, volumeID, bound); err != nil {
-		m.mu.Unlock()
+	cleanup := m.releaseOwnerOnlyVolumeLocked(volumeID, bound)
+	m.mu.Unlock()
+	if err := m.finishBoundVolumeCleanup(ctx, cleanup); err != nil {
 		return ctldapi.ReleaseVolumeOwnerResponse{}, err
 	}
-	m.mu.Unlock()
 	return ctldapi.ReleaseVolumeOwnerResponse{Released: true}, nil
 }
 
@@ -775,9 +919,13 @@ func (m *Manager) PrepareSnapshotCheckpoint(ctx context.Context, req ctldapi.Pre
 	}
 	m.mu.Lock()
 	bound := m.boundVolumes[volumeID]
+	closing := bound != nil && bound.closing
 	m.mu.Unlock()
 	if bound == nil || bound.volCtx == nil || bound.volCtx.S0FS == nil {
 		return ctldapi.PrepareVolumeSnapshotCheckpointResponse{}, fmt.Errorf("volume %s is not owned by this ctld", volumeID)
+	}
+	if closing {
+		return ctldapi.PrepareVolumeSnapshotCheckpointResponse{}, fmt.Errorf("volume %s is closing", volumeID)
 	}
 	if err := m.volumes.prepareSnapshotCheckpoint(ctx, volumeID); err != nil {
 		return ctldapi.PrepareVolumeSnapshotCheckpointResponse{}, err
@@ -816,7 +964,7 @@ func (m *Manager) cleanupIdleOwnerOnlyVolumes(ctx context.Context) {
 	m.mu.Lock()
 	volumeIDs := make([]string, 0, len(m.boundVolumes))
 	for volumeID, bound := range m.boundVolumes {
-		if bound == nil || bound.refCount > 0 || !m.volumes.canCleanupOwnerOnly(volumeID, cutoff) {
+		if bound == nil || bound.closing || bound.refCount > 0 || !m.volumes.canCleanupOwnerOnly(volumeID, cutoff) {
 			continue
 		}
 		volumeIDs = append(volumeIDs, volumeID)
@@ -833,38 +981,52 @@ func (m *Manager) cleanupIdleOwnerOnlyVolumes(ctx context.Context) {
 func (m *Manager) releaseOwnerOnlyVolume(ctx context.Context, volumeID string) error {
 	m.mu.Lock()
 	bound := m.boundVolumes[volumeID]
-	if bound == nil || bound.refCount > 0 || !m.volumes.canCleanupOwnerOnly(volumeID, time.Now().UTC().Add(-m.ownerOnlyIdleTTL)) {
+	if bound == nil || bound.closing || bound.refCount > 0 || !m.volumes.canCleanupOwnerOnly(volumeID, time.Now().UTC().Add(-m.ownerOnlyIdleTTL)) {
 		m.mu.Unlock()
 		return nil
 	}
-	if err := m.releaseOwnerOnlyVolumeLocked(ctx, volumeID, bound); err != nil {
-		m.mu.Unlock()
-		return err
-	}
+	cleanup := m.releaseOwnerOnlyVolumeLocked(volumeID, bound)
 	m.mu.Unlock()
-	return nil
+	return m.finishBoundVolumeCleanup(ctx, cleanup)
 }
 
-func (m *Manager) releaseOwnerOnlyVolumeLocked(ctx context.Context, volumeID string, bound *boundVolume) error {
-	if bound.materializeCancel != nil {
-		bound.materializeCancel()
-		bound.materializeCancel = nil
+func (m *Manager) releaseOwnerOnlyVolumeNow(ctx context.Context, volumeID string) error {
+	m.mu.Lock()
+	bound := m.boundVolumes[volumeID]
+	if bound == nil || bound.closing {
+		m.mu.Unlock()
+		return nil
 	}
-	done := bound.materializeDone
+	if bound.refCount > 0 {
+		m.mu.Unlock()
+		return fmt.Errorf("volume %s is actively bound to a portal", volumeID)
+	}
+	if ok, reason := m.volumes.canReleaseOwnerOnly(volumeID); !ok {
+		m.mu.Unlock()
+		return fmt.Errorf("volume %s %s", volumeID, reason)
+	}
+	cleanup := m.releaseOwnerOnlyVolumeLocked(volumeID, bound)
+	m.mu.Unlock()
+	return m.finishBoundVolumeCleanup(ctx, cleanup)
+}
+
+func (m *Manager) releaseOwnerOnlyVolumeLocked(volumeID string, bound *boundVolume) *boundVolumeCleanup {
+	if bound == nil {
+		return nil
+	}
+	bound.closing = true
+	cleanup := &boundVolumeCleanup{
+		volumeID:          volumeID,
+		bound:             bound,
+		materializeCancel: bound.materializeCancel,
+		materializeDone:   bound.materializeDone,
+	}
+	bound.materializeCancel = nil
 	bound.materializeDone = nil
-	if done != nil {
-		<-done
-	}
-	closeBoundSession(bound)
-	if err := m.volumes.UnmountVolume(ctx, volumeID, ""); err != nil {
-		return err
-	}
-	delete(m.boundVolumes, volumeID)
-	m.unregisterOwner(bound)
-	return nil
+	return cleanup
 }
 
-func (m *Manager) unbindLockedSnapshot(pm *portalMount) error {
+func (m *Manager) unbindLockedSnapshot(pm *portalMount) *boundVolumeCleanup {
 	volumeID := pm.volumeID
 	m.clearPortalLocked(pm)
 	if volumeID == "" {
@@ -878,21 +1040,55 @@ func (m *Manager) unbindLockedSnapshot(pm *portalMount) error {
 		bound.refCount--
 		return nil
 	}
-	if bound.materializeCancel != nil {
-		bound.materializeCancel()
-		bound.materializeCancel = nil
+	bound.refCount = 0
+	return m.releaseOwnerOnlyVolumeLocked(volumeID, bound)
+}
+
+func (m *Manager) finishBoundVolumeCleanup(ctx context.Context, cleanup *boundVolumeCleanup) error {
+	if cleanup == nil || cleanup.bound == nil || strings.TrimSpace(cleanup.volumeID) == "" {
+		return nil
 	}
-	if bound.materializeDone != nil {
-		<-bound.materializeDone
-		bound.materializeDone = nil
+	if ctx == nil {
+		ctx = context.Background()
 	}
-	closeBoundSession(bound)
-	if err := m.volumes.UnmountVolume(context.Background(), volumeID, ""); err != nil {
+	if cleanup.materializeCancel != nil {
+		cleanup.materializeCancel()
+	}
+	if cleanup.materializeDone != nil {
+		select {
+		case <-cleanup.materializeDone:
+		case <-ctx.Done():
+			m.markBoundVolumeCleanupFailed(cleanup)
+			return ctx.Err()
+		}
+	}
+	closeBoundSession(cleanup.bound)
+	if err := m.volumes.UnmountVolume(ctx, cleanup.volumeID, ""); err != nil {
+		m.markBoundVolumeCleanupFailed(cleanup)
 		return err
 	}
-	delete(m.boundVolumes, volumeID)
-	m.unregisterOwner(bound)
+	unregister := false
+	m.mu.Lock()
+	if m.boundVolumes[cleanup.volumeID] == cleanup.bound {
+		delete(m.boundVolumes, cleanup.volumeID)
+		unregister = true
+	}
+	m.mu.Unlock()
+	if unregister {
+		m.unregisterOwner(cleanup.bound)
+	}
 	return nil
+}
+
+func (m *Manager) markBoundVolumeCleanupFailed(cleanup *boundVolumeCleanup) {
+	if m == nil || cleanup == nil || cleanup.bound == nil || strings.TrimSpace(cleanup.volumeID) == "" {
+		return
+	}
+	m.mu.Lock()
+	if m.boundVolumes[cleanup.volumeID] == cleanup.bound {
+		cleanup.bound.closing = false
+	}
+	m.mu.Unlock()
 }
 
 type publishRequest struct {
@@ -971,7 +1167,16 @@ func (m *Manager) startMaterializer(bound *boundVolume) {
 	bound.materializeDone = done
 	go func(volumeID string) {
 		defer close(done)
-		ticker := time.NewTicker(2 * time.Second)
+		if jitter := materializerInitialJitter(volumeID); jitter > 0 {
+			timer := time.NewTimer(jitter)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return
+			case <-timer.C:
+			}
+		}
+		ticker := time.NewTicker(defaultVolumeMaterializeInterval)
 		defer ticker.Stop()
 		var compactionTicker *time.Ticker
 		var compactionC <-chan time.Time
@@ -985,14 +1190,35 @@ func (m *Manager) startMaterializer(bound *boundVolume) {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				manifest, err := bound.volCtx.S0FS.SyncMaterialize(ctx)
-				if err != nil && m.logger != nil {
-					m.logger.Warn("ctld volume materialize failed", zap.String("volume_id", volumeID), zap.Error(err))
+				ran, err := m.tryRunMaterializer(ctx, func() error {
+					manifest, err := bound.volCtx.S0FS.SyncMaterialize(ctx)
+					if err != nil {
+						return err
+					}
+					m.garbageCollectBoundS0FS(ctx, bound, manifest)
+					return nil
+				})
+				if !ran {
 					continue
 				}
-				m.garbageCollectBoundS0FS(ctx, bound, manifest)
+				if err != nil && m.logger != nil {
+					m.logger.Warn("ctld volume materialize failed", zap.String("volume_id", volumeID), zap.Error(err))
+				}
 			case <-compactionC:
-				resultManifest, result, err := bound.volCtx.S0FS.Compact(ctx, compactionOptions)
+				var result *s0fs.CompactionResult
+				ran, err := m.tryRunMaterializer(ctx, func() error {
+					var resultManifest *s0fs.Manifest
+					var compactErr error
+					resultManifest, result, compactErr = bound.volCtx.S0FS.Compact(ctx, compactionOptions)
+					if compactErr != nil {
+						return compactErr
+					}
+					m.garbageCollectBoundS0FS(ctx, bound, resultManifest)
+					return nil
+				})
+				if !ran {
+					continue
+				}
 				if err != nil && m.logger != nil {
 					m.logger.Warn("ctld volume compaction failed", zap.String("volume_id", volumeID), zap.Error(err))
 					continue
@@ -1005,10 +1231,40 @@ func (m *Manager) startMaterializer(bound *boundVolume) {
 						zap.Uint64("reclaimable_bytes", result.ReclaimableBytes),
 					)
 				}
-				m.garbageCollectBoundS0FS(ctx, bound, resultManifest)
 			}
 		}
 	}(bound.volumeID)
+}
+
+func (m *Manager) tryRunMaterializer(ctx context.Context, fn func() error) (bool, error) {
+	if fn == nil {
+		return true, nil
+	}
+	if m == nil || m.materializerLimiter == nil {
+		return true, fn()
+	}
+	select {
+	case m.materializerLimiter <- struct{}{}:
+		defer func() { <-m.materializerLimiter }()
+	case <-ctx.Done():
+		return true, ctx.Err()
+	default:
+		return false, nil
+	}
+	return true, fn()
+}
+
+func materializerInitialJitter(volumeID string) time.Duration {
+	if strings.TrimSpace(volumeID) == "" || defaultVolumeMaterializeInterval <= time.Millisecond {
+		return 0
+	}
+	slots := uint32(defaultVolumeMaterializeInterval / time.Millisecond)
+	if slots == 0 {
+		return 0
+	}
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(volumeID))
+	return time.Duration(h.Sum32()%slots) * time.Millisecond
 }
 
 func (m *Manager) garbageCollectBoundS0FS(ctx context.Context, bound *boundVolume, manifest *s0fs.Manifest) {

--- a/ctld/internal/ctld/portal/manager_shared_test.go
+++ b/ctld/internal/ctld/portal/manager_shared_test.go
@@ -2,6 +2,7 @@ package portal
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -69,8 +70,9 @@ func TestUnbindLockedSnapshotKeepsSharedVolumeUntilLastPortal(t *testing.T) {
 		fs:        volumefuse.New("portal-b", time.Second, unboundSession{}),
 	}
 
-	if err := mgr.unbindLockedSnapshot(pmA); err != nil {
-		t.Fatalf("unbindLockedSnapshot(first) error = %v", err)
+	cleanup := mgr.unbindLockedSnapshot(pmA)
+	if cleanup != nil {
+		t.Fatalf("unbindLockedSnapshot(first) cleanup = %+v, want nil", cleanup)
 	}
 	if pmA.volumeID != "" {
 		t.Fatalf("first portal volumeID = %q, want cleared", pmA.volumeID)
@@ -86,8 +88,9 @@ func TestUnbindLockedSnapshotKeepsSharedVolumeUntilLastPortal(t *testing.T) {
 		t.Fatalf("GetVolume() after first unbind error = %v, want mounted volume to remain", err)
 	}
 
-	if err := mgr.unbindLockedSnapshot(pmB); err != nil {
-		t.Fatalf("unbindLockedSnapshot(last) error = %v", err)
+	cleanup = mgr.unbindLockedSnapshot(pmB)
+	if err := mgr.finishBoundVolumeCleanup(context.Background(), cleanup); err != nil {
+		t.Fatalf("finishBoundVolumeCleanup(last) error = %v", err)
 	}
 	if _, ok := mgr.boundVolumes["vol-1"]; ok {
 		t.Fatal("bound volume still present after last unbind")
@@ -121,6 +124,70 @@ func TestCheckPublishedReportsMissingPortals(t *testing.T) {
 	}
 	if len(resp.Missing) != 1 || resp.Missing[0] != "cache" {
 		t.Fatalf("CheckPublished() missing = %v, want [cache]", resp.Missing)
+	}
+}
+
+func TestShutdownDrainsPublishedAndOwnerOnlyVolumes(t *testing.T) {
+	rootDir := t.TempDir()
+	var detachedTarget string
+	mgr := &Manager{
+		staleMountCleaner: func(path string) error {
+			detachedTarget = path
+			return os.RemoveAll(path)
+		},
+		portals:         make(map[string]*portalMount),
+		portalsByTarget: make(map[string]*portalMount),
+		boundVolumes:    make(map[string]*boundVolume),
+		volumes:         newLocalVolumeManager(),
+	}
+	portalVolCtx := &volume.VolumeContext{VolumeID: "vol-portal"}
+	ownerVolCtx := &volume.VolumeContext{VolumeID: "vol-owner"}
+	mgr.volumes.add(portalVolCtx)
+	mgr.volumes.add(ownerVolCtx)
+	pm := &portalMount{
+		podUID:            "pod-1",
+		name:              "workspace",
+		targetPath:        filepath.Join(rootDir, "target"),
+		rootfsBackingPath: filepath.Join(rootDir, "rootfs"),
+		volumeID:          "vol-portal",
+	}
+	mgr.portals[portalKey(pm.podUID, pm.name)] = pm
+	mgr.portalsByTarget[pm.targetPath] = pm
+	mgr.boundVolumes["vol-portal"] = &boundVolume{
+		volumeID: "vol-portal",
+		refCount: 1,
+		volCtx:   portalVolCtx,
+	}
+	mgr.boundVolumes["vol-owner"] = &boundVolume{
+		volumeID: "vol-owner",
+		refCount: 0,
+		volCtx:   ownerVolCtx,
+	}
+	for _, path := range []string{pm.targetPath, pm.rootfsBackingPath} {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatalf("MkdirAll(%q) error = %v", path, err)
+		}
+	}
+
+	if err := mgr.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown() error = %v", err)
+	}
+	if len(mgr.portals) != 0 || len(mgr.portalsByTarget) != 0 {
+		t.Fatalf("portals after Shutdown = %d/%d, want empty", len(mgr.portals), len(mgr.portalsByTarget))
+	}
+	if len(mgr.boundVolumes) != 0 {
+		t.Fatalf("boundVolumes after Shutdown = %#v, want empty", mgr.boundVolumes)
+	}
+	if detachedTarget != pm.targetPath {
+		t.Fatalf("detached target = %q, want %q", detachedTarget, pm.targetPath)
+	}
+	for _, volumeID := range []string{"vol-portal", "vol-owner"} {
+		if _, err := mgr.volumes.GetVolume(volumeID); err == nil {
+			t.Fatalf("GetVolume(%q) after Shutdown error = nil, want removed", volumeID)
+		}
+	}
+	if _, err := os.Stat(pm.rootfsBackingPath); !os.IsNotExist(err) {
+		t.Fatalf("rootfs backing stat error = %v, want not exist", err)
 	}
 }
 

--- a/ctld/internal/ctld/portal/recovery.go
+++ b/ctld/internal/ctld/portal/recovery.go
@@ -1,0 +1,200 @@
+package portal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"go.uber.org/zap"
+	"golang.org/x/sys/unix"
+)
+
+const defaultKubeletPodsRoot = "/var/lib/kubelet/pods"
+const kubeletCSIVolumeDir = "kubernetes.io~csi"
+const sandboxVolumeNamePrefix = "sandbox0-volume-"
+
+type staleMountCleaner func(string) error
+type staleMountChecker func(string) (bool, error)
+
+// ActivePodUIDLister returns pod UIDs that still belong to live pods on this node.
+type ActivePodUIDLister func(context.Context) (map[string]struct{}, error)
+
+func defaultStaleMountCleaner(path string) error {
+	if err := unix.Unmount(path, unix.MNT_DETACH); err != nil &&
+		!errors.Is(err, unix.EINVAL) &&
+		!errors.Is(err, unix.ENOENT) {
+		return fmt.Errorf("lazy unmount stale CSI mount: %w", err)
+	}
+	if err := os.RemoveAll(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove stale CSI mount: %w", err)
+	}
+	return nil
+}
+
+func defaultStaleMountChecker(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil || errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if errors.Is(err, unix.ENOTCONN) || errors.Is(err, unix.EIO) || errors.Is(err, unix.ESTALE) {
+		return true, nil
+	}
+	return false, fmt.Errorf("check CSI mount target: %w", err)
+}
+
+func (m *Manager) cleanUnknownStaleMountTarget(targetPath string) error {
+	root := defaultKubeletPodsRoot
+	if m != nil && strings.TrimSpace(m.kubeletPodsRoot) != "" {
+		root = m.kubeletPodsRoot
+	}
+	if !isSandboxCSIMountPath(root, targetPath) {
+		return fmt.Errorf("refusing to clean unknown CSI target outside sandbox0 kubelet volume paths: %s", targetPath)
+	}
+	return m.cleanStaleMountTarget(targetPath)
+}
+
+func (m *Manager) CleanupStaleCSIMounts(ctx context.Context) error {
+	if m == nil || strings.TrimSpace(m.kubeletPodsRoot) == "" {
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	root := filepath.Clean(m.kubeletPodsRoot)
+	cleaner := m.staleMountCleaner
+	if cleaner == nil {
+		cleaner = defaultStaleMountCleaner
+	}
+	checker := m.staleMountChecker
+	if checker == nil {
+		checker = defaultStaleMountChecker
+	}
+	activePods, activeReliable := m.activePodUIDs(ctx)
+
+	var firstErr error
+	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return nil
+			}
+			if info, ok := sandboxCSIMountPathInfo(root, path); ok {
+				if !shouldCleanSandboxCSIMount(info, activePods, activeReliable, true) {
+					return filepath.SkipDir
+				}
+				if cleanupErr := cleaner(path); cleanupErr != nil {
+					if firstErr == nil {
+						firstErr = cleanupErr
+					}
+					if m.logger != nil {
+						m.logger.Warn("ctld stale CSI mount cleanup failed", zap.String("path", path), zap.Error(cleanupErr))
+					}
+					return filepath.SkipDir
+				}
+				if m.logger != nil {
+					m.logger.Info("ctld cleaned stale CSI mount", zap.String("path", path), zap.Error(err))
+				}
+				return filepath.SkipDir
+			}
+			if m.logger != nil {
+				m.logger.Warn("ctld stale CSI mount scan skipped path", zap.String("path", path), zap.Error(err))
+			}
+			return nil
+		}
+		if d == nil || !d.IsDir() || filepath.Base(path) != "mount" {
+			return nil
+		}
+		if !isSandboxCSIMountPath(root, path) {
+			return nil
+		}
+		info, _ := sandboxCSIMountPathInfo(root, path)
+		broken, checkErr := checker(path)
+		if checkErr != nil {
+			if m.logger != nil {
+				m.logger.Warn("ctld stale CSI mount health check failed", zap.String("path", path), zap.Error(checkErr))
+			}
+			return filepath.SkipDir
+		}
+		if !shouldCleanSandboxCSIMount(info, activePods, activeReliable, broken) {
+			return filepath.SkipDir
+		}
+		if err := cleaner(path); err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			if m.logger != nil {
+				m.logger.Warn("ctld stale CSI mount cleanup failed", zap.String("path", path), zap.Error(err))
+			}
+			return filepath.SkipDir
+		}
+		if m.logger != nil {
+			m.logger.Info("ctld cleaned stale CSI mount", zap.String("path", path))
+		}
+		return filepath.SkipDir
+	})
+	if walkErr != nil {
+		return walkErr
+	}
+	return firstErr
+}
+
+func (m *Manager) activePodUIDs(ctx context.Context) (map[string]struct{}, bool) {
+	if m == nil || m.activePodUIDLister == nil {
+		return nil, false
+	}
+	activePods, err := m.activePodUIDLister(ctx)
+	if err != nil {
+		if m.logger != nil {
+			m.logger.Warn("ctld stale CSI mount cleanup could not list active pods", zap.Error(err))
+		}
+		return nil, false
+	}
+	if activePods == nil {
+		activePods = map[string]struct{}{}
+	}
+	return activePods, true
+}
+
+type csiMountPathInfo struct {
+	podUID string
+}
+
+func shouldCleanSandboxCSIMount(info csiMountPathInfo, activePods map[string]struct{}, activeReliable bool, broken bool) bool {
+	if broken {
+		return true
+	}
+	if info.podUID != "" && activeReliable {
+		_, active := activePods[info.podUID]
+		return !active
+	}
+	return false
+}
+
+func isSandboxCSIMountPath(root, path string) bool {
+	_, ok := sandboxCSIMountPathInfo(root, path)
+	return ok
+}
+
+func sandboxCSIMountPathInfo(root, path string) (csiMountPathInfo, bool) {
+	rel, err := filepath.Rel(filepath.Clean(root), filepath.Clean(path))
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return csiMountPathInfo{}, false
+	}
+	parts := strings.Split(rel, string(os.PathSeparator))
+	if len(parts) != 5 {
+		return csiMountPathInfo{}, false
+	}
+	if parts[1] == "volumes" &&
+		parts[2] == kubeletCSIVolumeDir &&
+		strings.HasPrefix(parts[3], sandboxVolumeNamePrefix) &&
+		parts[4] == "mount" {
+		return csiMountPathInfo{podUID: parts[0]}, true
+	}
+	return csiMountPathInfo{}, false
+}

--- a/ctld/internal/ctld/portal/recovery_test.go
+++ b/ctld/internal/ctld/portal/recovery_test.go
@@ -1,0 +1,217 @@
+package portal
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+func TestCleanupStaleCSIMountsCleansOnlySandboxCSIMounts(t *testing.T) {
+	root := t.TempDir()
+	validA := filepath.Join(root, "pod-a", "volumes", kubeletCSIVolumeDir, "sandbox0-volume-0-state", "mount")
+	validB := filepath.Join(root, "pod-b", "volumes", kubeletCSIVolumeDir, "sandbox0-volume-1-workspace", "mount")
+	otherCSI := filepath.Join(root, "pod-c", "volumes", kubeletCSIVolumeDir, "other-volume", "mount")
+	otherPlugin := filepath.Join(root, "pod-d", "volumes", "kubernetes.io~secret", "sandbox0-volume-0-state", "mount")
+	for _, path := range []string{validA, validB, otherCSI, otherPlugin} {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatalf("MkdirAll(%q) error = %v", path, err)
+		}
+	}
+
+	var cleaned []string
+	mgr := NewManager(Config{
+		RootDir:         t.TempDir(),
+		KubeletPodsRoot: root,
+		ActivePodUIDLister: func(context.Context) (map[string]struct{}, error) {
+			return map[string]struct{}{}, nil
+		},
+		StaleMountCleaner: func(path string) error {
+			cleaned = append(cleaned, path)
+			return os.RemoveAll(path)
+		},
+	})
+	if err := mgr.CleanupStaleCSIMounts(context.Background()); err != nil {
+		t.Fatalf("CleanupStaleCSIMounts() error = %v", err)
+	}
+
+	slices.Sort(cleaned)
+	want := []string{validA, validB}
+	slices.Sort(want)
+	if !slices.Equal(cleaned, want) {
+		t.Fatalf("cleaned paths = %#v, want %#v", cleaned, want)
+	}
+	for _, path := range []string{otherCSI, otherPlugin} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected non-sandbox mount %q to remain, stat error = %v", path, err)
+		}
+	}
+}
+
+func TestCleanupStaleCSIMountsSkipsActivePodMounts(t *testing.T) {
+	root := t.TempDir()
+	inactive := filepath.Join(root, "pod-a", "volumes", kubeletCSIVolumeDir, "sandbox0-volume-0-state", "mount")
+	active := filepath.Join(root, "pod-b", "volumes", kubeletCSIVolumeDir, "sandbox0-volume-1-workspace", "mount")
+	for _, path := range []string{inactive, active} {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatalf("MkdirAll(%q) error = %v", path, err)
+		}
+	}
+
+	var cleaned []string
+	mgr := NewManager(Config{
+		RootDir:         t.TempDir(),
+		KubeletPodsRoot: root,
+		ActivePodUIDLister: func(context.Context) (map[string]struct{}, error) {
+			return map[string]struct{}{"pod-b": {}}, nil
+		},
+		StaleMountCleaner: func(path string) error {
+			cleaned = append(cleaned, path)
+			return os.RemoveAll(path)
+		},
+	})
+	if err := mgr.CleanupStaleCSIMounts(context.Background()); err != nil {
+		t.Fatalf("CleanupStaleCSIMounts() error = %v", err)
+	}
+	if !slices.Equal(cleaned, []string{inactive}) {
+		t.Fatalf("cleaned paths = %#v, want %#v", cleaned, []string{inactive})
+	}
+	if _, err := os.Stat(active); err != nil {
+		t.Fatalf("expected active mount %q to remain, stat error = %v", active, err)
+	}
+}
+
+func TestCleanupStaleCSIMountsCleansBrokenActivePodMount(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "pod-a", "volumes", kubeletCSIVolumeDir, "sandbox0-volume-1-workspace", "mount")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v", target, err)
+	}
+
+	var cleaned []string
+	mgr := NewManager(Config{
+		RootDir:         t.TempDir(),
+		KubeletPodsRoot: root,
+		ActivePodUIDLister: func(context.Context) (map[string]struct{}, error) {
+			return map[string]struct{}{"pod-a": {}}, nil
+		},
+		StaleMountChecker: func(path string) (bool, error) {
+			return path == target, nil
+		},
+		StaleMountCleaner: func(path string) error {
+			cleaned = append(cleaned, path)
+			return os.RemoveAll(path)
+		},
+	})
+	if err := mgr.CleanupStaleCSIMounts(context.Background()); err != nil {
+		t.Fatalf("CleanupStaleCSIMounts() error = %v", err)
+	}
+	if !slices.Equal(cleaned, []string{target}) {
+		t.Fatalf("cleaned paths = %#v, want %#v", cleaned, []string{target})
+	}
+}
+
+func TestShouldCleanSandboxCSIMountCleansBrokenActivePodMount(t *testing.T) {
+	info := csiMountPathInfo{podUID: "pod-a"}
+	activePods := map[string]struct{}{"pod-a": {}}
+
+	if shouldCleanSandboxCSIMount(info, activePods, true, false) {
+		t.Fatal("readable active pod mount should not be cleaned")
+	}
+	if !shouldCleanSandboxCSIMount(info, activePods, true, true) {
+		t.Fatal("broken active pod mount should be cleaned")
+	}
+}
+
+func TestUnpublishUnknownPortalCleansSandboxCSITarget(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "pod-a", "volumes", kubeletCSIVolumeDir, "sandbox0-volume-1-workspace", "mount")
+	var cleaned string
+	mgr := &Manager{
+		kubeletPodsRoot: root,
+		staleMountCleaner: func(path string) error {
+			cleaned = path
+			return nil
+		},
+	}
+
+	if err := mgr.UnpublishPortalContext(context.Background(), target); err != nil {
+		t.Fatalf("UnpublishPortalContext() error = %v", err)
+	}
+	if cleaned != target {
+		t.Fatalf("cleaned target = %q, want %q", cleaned, target)
+	}
+}
+
+func TestUnpublishUnknownPortalRejectsTargetOutsideSandboxCSIPaths(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "pod-a", "volumes", kubeletCSIVolumeDir, "other-volume", "mount")
+	cleaned := false
+	mgr := &Manager{
+		kubeletPodsRoot: root,
+		staleMountCleaner: func(string) error {
+			cleaned = true
+			return nil
+		},
+	}
+
+	if err := mgr.UnpublishPortalContext(context.Background(), target); err == nil {
+		t.Fatal("UnpublishPortalContext() error = nil, want unsafe target error")
+	}
+	if cleaned {
+		t.Fatal("unsafe target was passed to stale mount cleaner")
+	}
+}
+
+func TestCleanupStaleCSIMountsDoesNotCleanReadableMountsWithoutActivePods(t *testing.T) {
+	root := t.TempDir()
+	valid := filepath.Join(root, "pod-a", "volumes", kubeletCSIVolumeDir, "sandbox0-volume-0-state", "mount")
+	otherCSI := filepath.Join(root, "pod-b", "volumes", kubeletCSIVolumeDir, "other-volume", "mount")
+	for _, path := range []string{valid, otherCSI} {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatalf("MkdirAll(%q) error = %v", path, err)
+		}
+	}
+
+	var cleaned []string
+	mgr := NewManager(Config{
+		RootDir:         t.TempDir(),
+		KubeletPodsRoot: root,
+		StaleMountCleaner: func(path string) error {
+			cleaned = append(cleaned, path)
+			return os.RemoveAll(path)
+		},
+	})
+	if err := mgr.CleanupStaleCSIMounts(context.Background()); err != nil {
+		t.Fatalf("CleanupStaleCSIMounts() error = %v", err)
+	}
+	if len(cleaned) != 0 {
+		t.Fatalf("cleaned paths = %#v, want none", cleaned)
+	}
+	for _, path := range []string{valid, otherCSI} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected mount %q to remain, stat error = %v", path, err)
+		}
+	}
+}
+
+func TestIsSandboxCSIMountPathRequiresExactKubeletShape(t *testing.T) {
+	root := filepath.Clean("/var/lib/kubelet/pods")
+	valid := filepath.Join(root, "pod-a", "volumes", kubeletCSIVolumeDir, "sandbox0-volume-0-state", "mount")
+	if !isSandboxCSIMountPath(root, valid) {
+		t.Fatalf("expected %q to match sandbox CSI mount path", valid)
+	}
+
+	tests := []string{
+		filepath.Join(root, "pod-a", "volumes", kubeletCSIVolumeDir, "sandbox0-volume-0-state"),
+		filepath.Join(root, "pod-a", "volumes", kubeletCSIVolumeDir, "other-volume", "mount"),
+		filepath.Join(root, "pod-a", "volumes", "kubernetes.io~secret", "sandbox0-volume-0-state", "mount"),
+		filepath.Join(root+"-other", "pod-a", "volumes", kubeletCSIVolumeDir, "sandbox0-volume-0-state", "mount"),
+	}
+	for _, path := range tests {
+		if isSandboxCSIMountPath(root, path) {
+			t.Fatalf("expected %q not to match sandbox CSI mount path", path)
+		}
+	}
+}

--- a/infra-operator/internal/controller/services/ctld/ctld.go
+++ b/infra-operator/internal/controller/services/ctld/ctld.go
@@ -10,6 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -32,8 +33,11 @@ const (
 	containerdDataMountPath        = "/host-var-lib/containerd"
 	defaultContainerdHostDataRoot  = "/var/lib/containerd"
 	defaultContainerdHostStateRoot = "/run/containerd"
-	ctldProbeTimeoutSeconds        = 10
-	ctldProbeFailureThreshold      = 6
+	ctldProbeTimeoutSeconds        = 15
+	ctldProbeFailureThreshold      = 12
+	ctldTerminationGraceSeconds    = int64(30)
+	ctldCPURequest                 = "250m"
+	ctldMemoryRequest              = "256Mi"
 )
 
 func NewReconciler(resources *common.ResourceManager) *Reconciler {
@@ -82,6 +86,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 	nodeSelector, tolerations := common.ResolveSandboxNodePlacement(infra)
 	containerdHostDataRoot := ctldContainerdHostDataRoot(infra)
 	args := ctldArgs(infra, containerdHostDataRoot)
+	terminationGraceSeconds := ctldTerminationGraceSeconds
 	bidirectional := corev1.MountPropagationBidirectional
 	hostPathDirectoryOrCreate := corev1.HostPathDirectoryOrCreate
 	volumeMounts := []corev1.VolumeMount{
@@ -185,12 +190,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 					Annotations: common.EnsurePodTemplateAnnotations(podAnnotations),
 				},
 				Spec: corev1.PodSpec{
-					HostPID:            true,
-					ServiceAccountName: name,
-					NodeSelector:       nodeSelector,
-					Tolerations:        tolerations,
-					HostNetwork:        true,
-					DNSPolicy:          corev1.DNSClusterFirstWithHostNet,
+					HostPID:                       true,
+					ServiceAccountName:            name,
+					NodeSelector:                  nodeSelector,
+					Tolerations:                   tolerations,
+					HostNetwork:                   true,
+					DNSPolicy:                     corev1.DNSClusterFirstWithHostNet,
+					TerminationGracePeriodSeconds: &terminationGraceSeconds,
 					Containers: []corev1.Container{
 						{
 							Name:            "ctld",
@@ -254,6 +260,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 							SecurityContext: &corev1.SecurityContext{
 								Privileged: common.BoolPtr(true),
 							},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse(ctldCPURequest),
+									corev1.ResourceMemory: resource.MustParse(ctldMemoryRequest),
+								},
+							},
 							VolumeMounts: volumeMounts,
 						},
 						{
@@ -298,6 +310,7 @@ func ctldArgs(infra *infrav1alpha1.Sandbox0Infra, containerdHostDataRoot string)
 		"-containerd-data-root=" + containerdDataMountPath,
 		"-containerd-host-data-root=" + containerdHostDataRoot,
 		"-volume-portal-root=/var/lib/sandbox0/ctld",
+		"-kubelet-pods-root=/var/lib/kubelet/pods",
 		"-csi-socket=/csi/csi.sock",
 	}
 	if infra != nil && infra.Spec.Services != nil && infra.Spec.Services.Ctld != nil {

--- a/infra-operator/internal/controller/services/ctld/ctld_test.go
+++ b/infra-operator/internal/controller/services/ctld/ctld_test.go
@@ -9,6 +9,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -116,10 +117,20 @@ func reconcileCtldDaemonSet(t *testing.T, infra *infrav1alpha1.Sandbox0Infra) *a
 	if ds.Spec.Template.Spec.ServiceAccountName != "demo-ctld" {
 		t.Fatalf("expected service account demo-ctld, got %q", ds.Spec.Template.Spec.ServiceAccountName)
 	}
+	if ds.Spec.Template.Spec.TerminationGracePeriodSeconds == nil || *ds.Spec.Template.Spec.TerminationGracePeriodSeconds != ctldTerminationGraceSeconds {
+		t.Fatalf("expected ctld termination grace %ds, got %#v", ctldTerminationGraceSeconds, ds.Spec.Template.Spec.TerminationGracePeriodSeconds)
+	}
 	assertContainsArg(t, ds.Spec.Template.Spec.Containers[0].Args, "-cri-endpoint=/host-run/containerd/containerd.sock")
 	assertContainsArg(t, ds.Spec.Template.Spec.Containers[0].Args, "-containerd-data-root=/host-var-lib/containerd")
+	assertContainsArg(t, ds.Spec.Template.Spec.Containers[0].Args, "-kubelet-pods-root=/var/lib/kubelet/pods")
 	if ds.Spec.Template.Spec.Containers[0].SecurityContext == nil || ds.Spec.Template.Spec.Containers[0].SecurityContext.Privileged == nil || !*ds.Spec.Template.Spec.Containers[0].SecurityContext.Privileged {
 		t.Fatal("expected ctld container to run privileged")
+	}
+	if got := ds.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]; got.Cmp(resource.MustParse(ctldCPURequest)) != 0 {
+		t.Fatalf("expected ctld cpu request %s, got %s", ctldCPURequest, got.String())
+	}
+	if got := ds.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceMemory]; got.Cmp(resource.MustParse(ctldMemoryRequest)) != 0 {
+		t.Fatalf("expected ctld memory request %s, got %s", ctldMemoryRequest, got.String())
 	}
 	if len(ds.Spec.Template.Spec.Containers) != 2 || ds.Spec.Template.Spec.Containers[1].Name != "csi-node-driver-registrar" {
 		t.Fatalf("expected csi node-driver-registrar sidecar, got %#v", ds.Spec.Template.Spec.Containers)


### PR DESCRIPTION
## Summary

- recover stale sandbox0 CSI mount targets after ctld loses its in-memory registry
- drain portals on graceful shutdown and keep slow volume cleanup outside the manager mutex
- bound and jitter S0FS background materialization, and give ctld explicit resource/probe/termination settings

## Root cause

ctld owns each FUSE server and its target registry only in memory. After ctld restarted, kubelet later called `NodeUnpublishVolume` for an unknown target. ctld treated that as success without unmounting it, leaving an `ENOTCONN` mount under the pod CSI directory. The API had already accepted deletion, but kubelet could not finish pod teardown.

## Remote baseline

On the persistent two-node kind test environment, I claimed six default sandboxes and restarted ctld on both nodes:

- 6/6 pods had two CSI targets before restart
- 12/12 targets became `ENOTCONN` after restart
- delete API calls returned in 0.044-0.179s
- 6/6 pods and all 12 broken targets still remained after 90s

PR build validation on the same environment will be posted while CI runs.

## Tests

- `go test ./ctld/internal/ctld/portal ./ctld/cmd/ctld ./infra-operator/internal/controller/services/ctld ./infra-operator/internal/controller/pkg/rbac`
- `go test -race ./ctld/internal/ctld/portal`
- `go test ./ctld/... ./infra-operator/internal/controller/...`

Fixes #674.