### PR TITLE
Recover sandbox runtimes after ctld FUSE restarts

### DIFF
--- a/ctld/cmd/ctld/main.go
+++ b/ctld/cmd/ctld/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -17,15 +18,18 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	ctldportal "github.com/sandbox0-ai/sandbox0/ctld/internal/ctld/portal"
 	ctldpower "github.com/sandbox0-ai/sandbox0/ctld/internal/ctld/power"
+	ctldprocessrecovery "github.com/sandbox0-ai/sandbox0/ctld/internal/ctld/processrecovery"
 	ctldrootfs "github.com/sandbox0-ai/sandbox0/ctld/internal/ctld/rootfs"
 	ctldserver "github.com/sandbox0-ai/sandbox0/ctld/internal/ctld/server"
 	apiconfig "github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
 	"github.com/sandbox0-ai/sandbox0/pkg/dbpool"
 	"github.com/sandbox0-ai/sandbox0/pkg/k8s"
 	"github.com/sandbox0-ai/sandbox0/pkg/observability"
 	httpobs "github.com/sandbox0-ai/sandbox0/pkg/observability/http"
 	"github.com/sandbox0-ai/sandbox0/pkg/sandboxprobe"
+	"github.com/sandbox0-ai/sandbox0/pkg/volumeportal"
 	storagedb "github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/objectstore"
 	corev1 "k8s.io/api/core/v1"
@@ -127,21 +131,39 @@ func main() {
 		}
 	}
 
-	podUIDLister := activePodUIDLister(k8sClient, nodeName)
+	podPortalLister := activePodPortalLister(k8sClient, nodeName)
+	processRecoverer := ctldprocessrecovery.New(ctldprocessrecovery.Config{
+		CRIEndpoint:     criEndpoint,
+		KubeletPodsRoot: kubeletPodsRoot,
+		PendingDir:      filepath.Join(portalRoot, "process-recovery"),
+	})
 	portalManager := ctldportal.NewManager(ctldportal.Config{
-		NodeName:           nodeName,
-		RootDir:            portalRoot,
-		KubeletPodsRoot:    kubeletPodsRoot,
-		Logger:             zapLogger,
-		StorageConfig:      storageCfg,
-		Repository:         repo,
-		PodName:            podName,
-		PodNamespace:       podNamespace,
-		ActivePodUIDLister: podUIDLister,
+		NodeName:              nodeName,
+		RootDir:               portalRoot,
+		KubeletPodsRoot:       kubeletPodsRoot,
+		Logger:                zapLogger,
+		StorageConfig:         storageCfg,
+		Repository:            repo,
+		PodName:               podName,
+		PodNamespace:          podNamespace,
+		ActivePodPortalLister: podPortalLister,
+		ActivePodRuntimeRecoverer: func(ctx context.Context, target ctldportal.RuntimeRecoveryTarget, portalsRecovered bool) error {
+			return processRecoverer.Recover(ctx, ctldprocessrecovery.Target{
+				Namespace:       target.Namespace,
+				PodName:         target.PodName,
+				PodUID:          target.PodUID,
+				ContainerName:   target.ContainerName,
+				StateVolumeName: target.StateVolumeName,
+				ReplayProcesses: target.ReplayProcesses,
+			}, portalsRecovered)
+		},
 	})
 	cleanupCtx, cleanupCancel := context.WithTimeout(ctx, 30*time.Second)
 	if err := portalManager.CleanupStaleCSIMounts(cleanupCtx); err != nil && cleanupCtx.Err() == nil {
 		log.Printf("ctld stale CSI mount cleanup completed with errors: %v", err)
+	}
+	if err := processRecoverer.Close(); err != nil {
+		log.Printf("ctld process recovery CRI close failed: %v", err)
 	}
 	cleanupCancel()
 	go portalManager.Run(ctx)
@@ -218,28 +240,103 @@ func buildProbeController(ctx context.Context, k8sClient kubernetes.Interface, o
 	return controller
 }
 
-func activePodUIDLister(k8sClient kubernetes.Interface, nodeName string) ctldportal.ActivePodUIDLister {
+type recoveryClaimMount struct {
+	SandboxVolumeID string `json:"sandboxvolume_id"`
+	MountPoint      string `json:"mount_point"`
+}
+
+func activePodPortalLister(k8sClient kubernetes.Interface, nodeName string) ctldportal.ActivePodPortalLister {
 	nodeName = strings.TrimSpace(nodeName)
 	if k8sClient == nil || nodeName == "" {
 		return nil
 	}
-	return func(ctx context.Context) (map[string]struct{}, error) {
+	return func(ctx context.Context) (map[string]ctldportal.ActivePodPortals, error) {
 		pods, err := k8sClient.CoreV1().Pods(metav1.NamespaceAll).List(ctx, metav1.ListOptions{
 			FieldSelector: fields.OneTermEqualSelector("spec.nodeName", nodeName).String(),
 		})
 		if err != nil {
 			return nil, err
 		}
-		active := make(map[string]struct{}, len(pods.Items))
+		active := make(map[string]ctldportal.ActivePodPortals, len(pods.Items))
 		for i := range pods.Items {
 			pod := &pods.Items[i]
 			if podTerminalForMountCleanup(pod) || pod.UID == "" {
 				continue
 			}
-			active[string(pod.UID)] = struct{}{}
+			podUID := string(pod.UID)
+			portalSet := ctldportal.ActivePodPortals{Portals: map[string]ctldportal.RecoverablePortal{}}
+			bindings, err := recoveryVolumeBindings(pod)
+			if err != nil {
+				portalSet.RecoveryError = fmt.Errorf("read recovery bindings for pod %s/%s: %w", pod.Namespace, pod.Name, err)
+				active[podUID] = portalSet
+				continue
+			}
+			teamID := strings.TrimSpace(pod.Annotations[controller.AnnotationTeamID])
+			stateVolumeName := ""
+			for _, volume := range pod.Spec.Volumes {
+				if volume.CSI == nil || volume.CSI.Driver != volumeportal.DriverName {
+					continue
+				}
+				mountPath := strings.TrimSpace(volume.CSI.VolumeAttributes[volumeportal.AttributeMountPath])
+				portalName := volumeportal.NormalizePortalName(volume.CSI.VolumeAttributes[volumeportal.AttributePortalName], mountPath)
+				if portalName == "" || mountPath == "" {
+					continue
+				}
+				portalSet.Portals[volume.Name] = ctldportal.RecoverablePortal{
+					VolumeName:      volume.Name,
+					Namespace:       pod.Namespace,
+					PodName:         pod.Name,
+					PodUID:          podUID,
+					PortalName:      portalName,
+					MountPath:       mountPath,
+					TeamID:          teamID,
+					SandboxVolumeID: bindings[mountPath],
+				}
+				if portalName == volumeportal.WebhookStatePortalName && mountPath == volumeportal.WebhookStateMountPath {
+					stateVolumeName = volume.Name
+				}
+			}
+			poolType := pod.Labels[controller.LabelPoolType]
+			activeSandbox := poolType == controller.PoolTypeActive && strings.TrimSpace(pod.Annotations[controller.AnnotationSandboxID]) != ""
+			if pod.Status.Phase == corev1.PodRunning && pod.DeletionTimestamp == nil && stateVolumeName != "" &&
+				(poolType == controller.PoolTypeIdle || activeSandbox) {
+				portalSet.RuntimeRecovery = &ctldportal.RuntimeRecoveryTarget{
+					Namespace:       pod.Namespace,
+					PodName:         pod.Name,
+					PodUID:          podUID,
+					ContainerName:   "procd",
+					StateVolumeName: stateVolumeName,
+					ReplayProcesses: activeSandbox,
+				}
+			}
+			active[podUID] = portalSet
 		}
 		return active, nil
 	}
+}
+
+func recoveryVolumeBindings(pod *corev1.Pod) (map[string]string, error) {
+	bindings := map[string]string{}
+	if pod == nil || pod.Annotations == nil {
+		return bindings, nil
+	}
+	var mounts []recoveryClaimMount
+	if raw := strings.TrimSpace(pod.Annotations[controller.AnnotationMounts]); raw != "" {
+		if err := json.Unmarshal([]byte(raw), &mounts); err != nil {
+			return nil, fmt.Errorf("decode %s annotation: %w", controller.AnnotationMounts, err)
+		}
+	}
+	for _, mount := range mounts {
+		mountPath := filepath.Clean(strings.TrimSpace(mount.MountPoint))
+		volumeID := strings.TrimSpace(mount.SandboxVolumeID)
+		if filepath.IsAbs(mountPath) && volumeID != "" {
+			bindings[mountPath] = volumeID
+		}
+	}
+	if volumeID := strings.TrimSpace(pod.Annotations[controller.AnnotationWebhookStateVolumeID]); volumeID != "" {
+		bindings[volumeportal.WebhookStateMountPath] = volumeID
+	}
+	return bindings, nil
 }
 
 func podTerminalForMountCleanup(pod *corev1.Pod) bool {

--- a/ctld/cmd/ctld/main_test.go
+++ b/ctld/cmd/ctld/main_test.go
@@ -10,10 +10,123 @@ import (
 	"testing"
 
 	ctldserver "github.com/sandbox0-ai/sandbox0/ctld/internal/ctld/server"
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
+	"github.com/sandbox0-ai/sandbox0/pkg/volumeportal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
 )
+
+func TestActivePodPortalListerBuildsRecoveryBindings(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "tpl-default",
+			Name:      "sandbox-a",
+			UID:       types.UID("pod-uid"),
+			Labels: map[string]string{
+				controller.LabelPoolType: controller.PoolTypeActive,
+			},
+			Annotations: map[string]string{
+				controller.AnnotationTeamID:               "team-a",
+				controller.AnnotationSandboxID:            "sandbox-a",
+				controller.AnnotationMounts:               `[{"sandboxvolume_id":"vol-workspace","mount_point":"/workspace"}]`,
+				controller.AnnotationWebhookStateVolumeID: "vol-state",
+			},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+		Spec: corev1.PodSpec{
+			NodeName: "node-a",
+			Volumes: []corev1.Volume{
+				{
+					Name: "sandbox0-volume-0-sandbox0-webhook-state",
+					VolumeSource: corev1.VolumeSource{CSI: &corev1.CSIVolumeSource{
+						Driver: volumeportal.DriverName,
+						VolumeAttributes: map[string]string{
+							volumeportal.AttributePortalName: volumeportal.WebhookStatePortalName,
+							volumeportal.AttributeMountPath:  volumeportal.WebhookStateMountPath,
+						},
+					}},
+				},
+				{
+					Name: "sandbox0-volume-1-workspace",
+					VolumeSource: corev1.VolumeSource{CSI: &corev1.CSIVolumeSource{
+						Driver: volumeportal.DriverName,
+						VolumeAttributes: map[string]string{
+							volumeportal.AttributePortalName: "workspace",
+							volumeportal.AttributeMountPath:  "/workspace",
+						},
+					}},
+				},
+			},
+		},
+	}
+	lister := activePodPortalLister(fake.NewSimpleClientset(pod), "node-a")
+	require.NotNil(t, lister)
+
+	active, err := lister(context.Background())
+	require.NoError(t, err)
+	require.Contains(t, active, "pod-uid")
+	portals := active["pod-uid"].Portals
+	require.Len(t, portals, 2)
+	assert.Equal(t, "vol-workspace", portals["sandbox0-volume-1-workspace"].SandboxVolumeID)
+	assert.Equal(t, "vol-state", portals["sandbox0-volume-0-sandbox0-webhook-state"].SandboxVolumeID)
+	assert.Equal(t, "team-a", portals["sandbox0-volume-1-workspace"].TeamID)
+	require.NotNil(t, active["pod-uid"].RuntimeRecovery)
+	assert.Equal(t, "procd", active["pod-uid"].RuntimeRecovery.ContainerName)
+	assert.Equal(t, "sandbox0-volume-0-sandbox0-webhook-state", active["pod-uid"].RuntimeRecovery.StateVolumeName)
+	assert.True(t, active["pod-uid"].RuntimeRecovery.ReplayProcesses)
+}
+
+func TestActivePodPortalListerDoesNotRecoverIdlePodRuntime(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "tpl-default",
+			Name:      "sandbox-idle",
+			UID:       types.UID("pod-idle"),
+			Labels:    map[string]string{controller.LabelPoolType: controller.PoolTypeIdle},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "node-a",
+			Volumes: []corev1.Volume{{
+				Name: "sandbox0-volume-0-sandbox0-webhook-state",
+				VolumeSource: corev1.VolumeSource{CSI: &corev1.CSIVolumeSource{
+					Driver: volumeportal.DriverName,
+					VolumeAttributes: map[string]string{
+						volumeportal.AttributePortalName: volumeportal.WebhookStatePortalName,
+						volumeportal.AttributeMountPath:  volumeportal.WebhookStateMountPath,
+					},
+				}},
+			}},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	active, err := activePodPortalLister(fake.NewSimpleClientset(pod), "node-a")(context.Background())
+	require.NoError(t, err)
+	require.Contains(t, active, "pod-idle")
+	require.NotNil(t, active["pod-idle"].RuntimeRecovery)
+	assert.False(t, active["pod-idle"].RuntimeRecovery.ReplayProcesses)
+}
+
+func TestActivePodPortalListerRejectsMalformedRecoveryBindings(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   "tpl-default",
+			Name:        "sandbox-a",
+			UID:         types.UID("pod-uid"),
+			Annotations: map[string]string{controller.AnnotationMounts: "{"},
+		},
+		Spec: corev1.PodSpec{NodeName: "node-a"},
+	}
+	active, err := activePodPortalLister(fake.NewSimpleClientset(pod), "node-a")(context.Background())
+	require.NoError(t, err)
+	require.Contains(t, active, "pod-uid")
+	require.Error(t, active["pod-uid"].RecoveryError)
+	assert.Contains(t, active["pod-uid"].RecoveryError.Error(), controller.AnnotationMounts)
+}
 
 func TestCtldHealthEndpoints(t *testing.T) {
 	server := newHTTPServer(":0", nil)

--- a/ctld/internal/ctld/portal/manager.go
+++ b/ctld/internal/ctld/portal/manager.go
@@ -35,27 +35,30 @@ const defaultS0FSMaterializerConcurrency = 16
 const defaultVolumeMaterializeInterval = 2 * time.Second
 
 type Manager struct {
-	nodeName               string
-	rootDir                string
-	kubeletPodsRoot        string
-	logger                 *zap.Logger
-	logrus                 *logrus.Logger
-	storage                *apiconfig.StorageProxyConfig
-	s3CredentialCodec      *volume.S3BackendCredentialCodec
-	s3CredentialCodecErr   error
-	repo                   *db.Repository
-	clusterID              string
-	podName                string
-	podNamespace           string
-	heartbeatInterval      time.Duration
-	ownerOnlyIdleTTL       time.Duration
-	portalCacheMaxBytes    int64
-	portalRootMinFreeBytes int64
-	volumeAPI              http.Handler
-	staleMountCleaner      staleMountCleaner
-	staleMountChecker      staleMountChecker
-	activePodUIDLister     ActivePodUIDLister
-	materializerLimiter    chan struct{}
+	nodeName                  string
+	rootDir                   string
+	kubeletPodsRoot           string
+	logger                    *zap.Logger
+	logrus                    *logrus.Logger
+	storage                   *apiconfig.StorageProxyConfig
+	s3CredentialCodec         *volume.S3BackendCredentialCodec
+	s3CredentialCodecErr      error
+	repo                      *db.Repository
+	clusterID                 string
+	podName                   string
+	podNamespace              string
+	heartbeatInterval         time.Duration
+	ownerOnlyIdleTTL          time.Duration
+	portalCacheMaxBytes       int64
+	portalRootMinFreeBytes    int64
+	volumeAPI                 http.Handler
+	staleMountCleaner         staleMountCleaner
+	staleMountChecker         staleMountChecker
+	activePodUIDLister        ActivePodUIDLister
+	activePodPortalLister     ActivePodPortalLister
+	activePodRuntimeRecoverer ActivePodRuntimeRecoverer
+	staleMountRecoverer       staleMountRecoverer
+	materializerLimiter       chan struct{}
 
 	mu              sync.Mutex
 	portals         map[string]*portalMount
@@ -107,18 +110,21 @@ type boundVolumeCleanup struct {
 }
 
 type Config struct {
-	NodeName                string
-	RootDir                 string
-	KubeletPodsRoot         string
-	Logger                  *zap.Logger
-	StorageConfig           *apiconfig.StorageProxyConfig
-	Repository              *db.Repository
-	PodName                 string
-	PodNamespace            string
-	StaleMountCleaner       staleMountCleaner
-	StaleMountChecker       staleMountChecker
-	ActivePodUIDLister      ActivePodUIDLister
-	MaterializerConcurrency int
+	NodeName                  string
+	RootDir                   string
+	KubeletPodsRoot           string
+	Logger                    *zap.Logger
+	StorageConfig             *apiconfig.StorageProxyConfig
+	Repository                *db.Repository
+	PodName                   string
+	PodNamespace              string
+	StaleMountCleaner         staleMountCleaner
+	StaleMountChecker         staleMountChecker
+	ActivePodUIDLister        ActivePodUIDLister
+	ActivePodPortalLister     ActivePodPortalLister
+	ActivePodRuntimeRecoverer ActivePodRuntimeRecoverer
+	StaleMountRecoverer       staleMountRecoverer
+	MaterializerConcurrency   int
 }
 
 func NewManager(cfg Config) *Manager {
@@ -161,30 +167,36 @@ func NewManager(cfg Config) *Manager {
 		materializerConcurrency = defaultS0FSMaterializerConcurrency
 	}
 	manager := &Manager{
-		nodeName:               strings.TrimSpace(cfg.NodeName),
-		rootDir:                rootDir,
-		kubeletPodsRoot:        kubeletPodsRoot,
-		logger:                 logger,
-		logrus:                 l,
-		storage:                storageConfig,
-		s3CredentialCodec:      s3CredentialCodec,
-		s3CredentialCodecErr:   s3CredentialCodecErr,
-		repo:                   cfg.Repository,
-		clusterID:              naming.ClusterIDOrDefault(&storageConfig.DefaultClusterId),
-		podName:                strings.TrimSpace(cfg.PodName),
-		podNamespace:           strings.TrimSpace(cfg.PodNamespace),
-		heartbeatInterval:      heartbeatInterval,
-		ownerOnlyIdleTTL:       ownerOnlyIdleTTL,
-		portalCacheMaxBytes:    portalCacheMaxBytes,
-		portalRootMinFreeBytes: portalRootMinFreeBytes,
-		staleMountCleaner:      staleCleaner,
-		staleMountChecker:      staleChecker,
-		activePodUIDLister:     cfg.ActivePodUIDLister,
-		materializerLimiter:    make(chan struct{}, materializerConcurrency),
-		portals:                make(map[string]*portalMount),
-		portalsByTarget:        make(map[string]*portalMount),
-		boundVolumes:           make(map[string]*boundVolume),
-		volumes:                newLocalVolumeManager(),
+		nodeName:                  strings.TrimSpace(cfg.NodeName),
+		rootDir:                   rootDir,
+		kubeletPodsRoot:           kubeletPodsRoot,
+		logger:                    logger,
+		logrus:                    l,
+		storage:                   storageConfig,
+		s3CredentialCodec:         s3CredentialCodec,
+		s3CredentialCodecErr:      s3CredentialCodecErr,
+		repo:                      cfg.Repository,
+		clusterID:                 naming.ClusterIDOrDefault(&storageConfig.DefaultClusterId),
+		podName:                   strings.TrimSpace(cfg.PodName),
+		podNamespace:              strings.TrimSpace(cfg.PodNamespace),
+		heartbeatInterval:         heartbeatInterval,
+		ownerOnlyIdleTTL:          ownerOnlyIdleTTL,
+		portalCacheMaxBytes:       portalCacheMaxBytes,
+		portalRootMinFreeBytes:    portalRootMinFreeBytes,
+		staleMountCleaner:         staleCleaner,
+		staleMountChecker:         staleChecker,
+		activePodUIDLister:        cfg.ActivePodUIDLister,
+		activePodPortalLister:     cfg.ActivePodPortalLister,
+		activePodRuntimeRecoverer: cfg.ActivePodRuntimeRecoverer,
+		materializerLimiter:       make(chan struct{}, materializerConcurrency),
+		portals:                   make(map[string]*portalMount),
+		portalsByTarget:           make(map[string]*portalMount),
+		boundVolumes:              make(map[string]*boundVolume),
+		volumes:                   newLocalVolumeManager(),
+	}
+	manager.staleMountRecoverer = cfg.StaleMountRecoverer
+	if manager.staleMountRecoverer == nil {
+		manager.staleMountRecoverer = manager.recoverStaleMount
 	}
 	manager.volumeAPI = newMountedVolumeAPIHandler(storageConfig, cfg.Repository, manager.volumes, l)
 	return manager
@@ -258,7 +270,7 @@ func (m *Manager) Shutdown(ctx context.Context) error {
 			}
 			break
 		}
-		if err := m.unpublishPortalContext(ctx, target, true); err != nil && firstErr == nil {
+		if err := m.unpublishPortalContext(ctx, target, true, true); err != nil && firstErr == nil {
 			firstErr = err
 		}
 	}
@@ -360,10 +372,10 @@ func (m *Manager) UnpublishPortal(targetPath string) error {
 }
 
 func (m *Manager) UnpublishPortalContext(ctx context.Context, targetPath string) error {
-	return m.unpublishPortalContext(ctx, targetPath, false)
+	return m.unpublishPortalContext(ctx, targetPath, false, false)
 }
 
-func (m *Manager) unpublishPortalContext(ctx context.Context, targetPath string, detach bool) error {
+func (m *Manager) unpublishPortalContext(ctx context.Context, targetPath string, detach, preserveRootFSBacking bool) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -394,7 +406,7 @@ func (m *Manager) unpublishPortalContext(ctx context.Context, targetPath string,
 	if pm.rootfsSession != nil {
 		pm.rootfsSession.Close()
 	}
-	if pm.rootfsBackingPath != "" {
+	if pm.rootfsBackingPath != "" && !preserveRootFSBacking {
 		if err := os.RemoveAll(pm.rootfsBackingPath); err != nil && firstErr == nil {
 			firstErr = err
 		}

--- a/ctld/internal/ctld/portal/manager_shared_test.go
+++ b/ctld/internal/ctld/portal/manager_shared_test.go
@@ -186,8 +186,8 @@ func TestShutdownDrainsPublishedAndOwnerOnlyVolumes(t *testing.T) {
 			t.Fatalf("GetVolume(%q) after Shutdown error = nil, want removed", volumeID)
 		}
 	}
-	if _, err := os.Stat(pm.rootfsBackingPath); !os.IsNotExist(err) {
-		t.Fatalf("rootfs backing stat error = %v, want not exist", err)
+	if _, err := os.Stat(pm.rootfsBackingPath); err != nil {
+		t.Fatalf("rootfs backing stat error = %v, want preserved", err)
 	}
 }
 

--- a/ctld/internal/ctld/portal/recovery.go
+++ b/ctld/internal/ctld/portal/recovery.go
@@ -7,8 +7,12 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
+	"sync"
 
+	"github.com/moby/sys/mountinfo"
+	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
 	"go.uber.org/zap"
 	"golang.org/x/sys/unix"
 )
@@ -16,12 +20,57 @@ import (
 const defaultKubeletPodsRoot = "/var/lib/kubelet/pods"
 const kubeletCSIVolumeDir = "kubernetes.io~csi"
 const sandboxVolumeNamePrefix = "sandbox0-volume-"
+const runtimeRecoveryConcurrency = 16
 
 type staleMountCleaner func(string) error
 type staleMountChecker func(string) (bool, error)
+type staleMountRecoverer func(context.Context, string, RecoverablePortal) error
+
+// RuntimeRecoveryTarget identifies the procd container and durable state portal
+// used after all of an active sandbox's CSI portals have been reconstructed.
+type RuntimeRecoveryTarget struct {
+	Namespace       string
+	PodName         string
+	PodUID          string
+	ContainerName   string
+	StateVolumeName string
+	ReplayProcesses bool
+}
+
+// ActivePodRuntimeRecoverer replaces a stale procd container. portalsRecovered
+// is true only when this reconciliation rebuilt at least one portal for the pod.
+type ActivePodRuntimeRecoverer func(context.Context, RuntimeRecoveryTarget, bool) error
+
+type runtimeRecoveryRequest struct {
+	target           RuntimeRecoveryTarget
+	portalsRecovered bool
+}
 
 // ActivePodUIDLister returns pod UIDs that still belong to live pods on this node.
 type ActivePodUIDLister func(context.Context) (map[string]struct{}, error)
+
+// RecoverablePortal contains the pod and binding metadata needed to recreate a
+// CSI portal after ctld loses its in-memory mount registry.
+type RecoverablePortal struct {
+	VolumeName      string
+	Namespace       string
+	PodName         string
+	PodUID          string
+	PortalName      string
+	MountPath       string
+	TeamID          string
+	SandboxVolumeID string
+}
+
+// ActivePodPortals contains recoverable CSI portals keyed by Kubernetes volume name.
+type ActivePodPortals struct {
+	Portals         map[string]RecoverablePortal
+	RuntimeRecovery *RuntimeRecoveryTarget
+	RecoveryError   error
+}
+
+// ActivePodPortalLister returns live pods and their sandbox0 CSI portal metadata.
+type ActivePodPortalLister func(context.Context) (map[string]ActivePodPortals, error)
 
 func defaultStaleMountCleaner(path string) error {
 	if err := unix.Unmount(path, unix.MNT_DETACH); err != nil &&
@@ -73,12 +122,19 @@ func (m *Manager) CleanupStaleCSIMounts(ctx context.Context) error {
 	if checker == nil {
 		checker = defaultStaleMountChecker
 	}
-	activePods, activeReliable := m.activePodUIDs(ctx)
+	activePods, activePortals, activeReliable := m.activePodState(ctx)
 
 	var firstErr error
+	handledTargets, reconcileErr := m.reconcileActivePodMounts(ctx, root, cleaner, checker, activePortals, activeReliable)
+	if reconcileErr != nil {
+		firstErr = reconcileErr
+	}
 	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return ctxErr
+		}
+		if _, handled := handledTargets[path]; handled {
+			return filepath.SkipDir
 		}
 		if err != nil {
 			if errors.Is(err, os.ErrNotExist) {
@@ -99,6 +155,14 @@ func (m *Manager) CleanupStaleCSIMounts(ctx context.Context) error {
 				}
 				if m.logger != nil {
 					m.logger.Info("ctld cleaned stale CSI mount", zap.String("path", path), zap.Error(err))
+				}
+				if recoverErr := m.recoverActivePodMount(ctx, path, info, activePods, activePortals, activeReliable); recoverErr != nil {
+					if firstErr == nil {
+						firstErr = recoverErr
+					}
+					if m.logger != nil {
+						m.logger.Warn("ctld stale CSI mount recovery failed", zap.String("path", path), zap.Error(recoverErr))
+					}
 				}
 				return filepath.SkipDir
 			}
@@ -136,12 +200,209 @@ func (m *Manager) CleanupStaleCSIMounts(ctx context.Context) error {
 		if m.logger != nil {
 			m.logger.Info("ctld cleaned stale CSI mount", zap.String("path", path))
 		}
+		if broken {
+			if recoverErr := m.recoverActivePodMount(ctx, path, info, activePods, activePortals, activeReliable); recoverErr != nil {
+				if firstErr == nil {
+					firstErr = recoverErr
+				}
+				if m.logger != nil {
+					m.logger.Warn("ctld stale CSI mount recovery failed", zap.String("path", path), zap.Error(recoverErr))
+				}
+			}
+		}
 		return filepath.SkipDir
 	})
 	if walkErr != nil {
 		return walkErr
 	}
 	return firstErr
+}
+
+func (m *Manager) reconcileActivePodMounts(ctx context.Context, root string, cleaner staleMountCleaner, checker staleMountChecker, activePortals map[string]ActivePodPortals, activeReliable bool) (map[string]struct{}, error) {
+	handled := map[string]struct{}{}
+	if !activeReliable || activePortals == nil || m == nil || m.staleMountRecoverer == nil {
+		return handled, nil
+	}
+
+	podUIDs := make([]string, 0, len(activePortals))
+	for podUID := range activePortals {
+		podUIDs = append(podUIDs, podUID)
+	}
+	sort.Strings(podUIDs)
+	var errs []error
+	runtimeRequests := make([]runtimeRecoveryRequest, 0)
+	for _, podUID := range podUIDs {
+		portalSet := activePortals[podUID]
+		if portalSet.RecoveryError != nil {
+			errs = append(errs, fmt.Errorf("read active pod recovery metadata %s: %w", podUID, portalSet.RecoveryError))
+			continue
+		}
+		podErrorCount := len(errs)
+		portalsRecovered := false
+		volumeNames := make([]string, 0, len(portalSet.Portals))
+		for volumeName := range portalSet.Portals {
+			volumeNames = append(volumeNames, volumeName)
+		}
+		sort.Strings(volumeNames)
+		for _, volumeName := range volumeNames {
+			if err := ctx.Err(); err != nil {
+				return handled, errors.Join(append(errs, err)...)
+			}
+			portal := portalSet.Portals[volumeName]
+			targetPath := filepath.Join(root, podUID, "volumes", kubeletCSIVolumeDir, volumeName, "mount")
+			if !isSandboxCSIMountPath(root, targetPath) {
+				errs = append(errs, fmt.Errorf("refusing to recover invalid active portal path %s", targetPath))
+				continue
+			}
+			mounted, mountErr := mountinfo.Mounted(targetPath)
+			broken := false
+			if mounted && mountErr == nil {
+				broken, mountErr = checker(targetPath)
+			}
+			if mountErr == nil && mounted && !broken {
+				continue
+			}
+
+			handled[targetPath] = struct{}{}
+			if mounted || mountErr != nil {
+				if err := cleaner(targetPath); err != nil {
+					errs = append(errs, fmt.Errorf("clean active portal %s: %w", targetPath, err))
+					continue
+				}
+			} else if _, err := os.Lstat(targetPath); err == nil {
+				if err := cleaner(targetPath); err != nil {
+					errs = append(errs, fmt.Errorf("clean unmounted active portal %s: %w", targetPath, err))
+					continue
+				}
+			} else if !errors.Is(err, os.ErrNotExist) {
+				errs = append(errs, fmt.Errorf("inspect active portal %s: %w", targetPath, err))
+				continue
+			}
+			if err := m.staleMountRecoverer(ctx, targetPath, portal); err != nil {
+				errs = append(errs, fmt.Errorf("recover active portal %s: %w", targetPath, err))
+				continue
+			}
+			portalsRecovered = true
+			if m.logger != nil {
+				m.logger.Info("ctld recovered active CSI mount", zap.String("path", targetPath), zap.String("pod_uid", podUID), zap.String("volume", volumeName))
+			}
+		}
+		if portalSet.RuntimeRecovery != nil && m.activePodRuntimeRecoverer != nil && len(errs) == podErrorCount {
+			runtimeRequests = append(runtimeRequests, runtimeRecoveryRequest{
+				target:           *portalSet.RuntimeRecovery,
+				portalsRecovered: portalsRecovered,
+			})
+		}
+	}
+	errs = append(errs, m.recoverActivePodRuntimes(ctx, runtimeRequests)...)
+	return handled, errors.Join(errs...)
+}
+
+func (m *Manager) recoverActivePodRuntimes(ctx context.Context, requests []runtimeRecoveryRequest) []error {
+	if m == nil || m.activePodRuntimeRecoverer == nil || len(requests) == 0 {
+		return nil
+	}
+	errs := make([]error, len(requests))
+	sem := make(chan struct{}, runtimeRecoveryConcurrency)
+	var wg sync.WaitGroup
+	for i := range requests {
+		if err := ctx.Err(); err != nil {
+			errs[i] = err
+			continue
+		}
+		sem <- struct{}{}
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			request := requests[index]
+			if err := m.activePodRuntimeRecoverer(ctx, request.target, request.portalsRecovered); err != nil {
+				errs[index] = fmt.Errorf("recover active pod runtime %s: %w", request.target.PodUID, err)
+				return
+			}
+			if request.portalsRecovered && m.logger != nil {
+				m.logger.Info("ctld requested sandbox runtime recovery", zap.String("pod_uid", request.target.PodUID), zap.Bool("replay_processes", request.target.ReplayProcesses))
+			}
+		}(i)
+	}
+	wg.Wait()
+	result := make([]error, 0)
+	for _, err := range errs {
+		if err != nil {
+			result = append(result, err)
+		}
+	}
+	return result
+}
+
+func (m *Manager) activePodState(ctx context.Context) (map[string]struct{}, map[string]ActivePodPortals, bool) {
+	if m != nil && m.activePodPortalLister != nil {
+		portals, err := m.activePodPortalLister(ctx)
+		if err != nil {
+			if m.logger != nil {
+				m.logger.Warn("ctld stale CSI mount recovery could not list active pod portals", zap.Error(err))
+			}
+			return nil, nil, false
+		}
+		if portals == nil {
+			portals = map[string]ActivePodPortals{}
+		}
+		active := make(map[string]struct{}, len(portals))
+		for podUID := range portals {
+			active[podUID] = struct{}{}
+		}
+		return active, portals, true
+	}
+	active, reliable := m.activePodUIDs(ctx)
+	return active, nil, reliable
+}
+
+func (m *Manager) recoverActivePodMount(ctx context.Context, targetPath string, info csiMountPathInfo, activePods map[string]struct{}, activePortals map[string]ActivePodPortals, activeReliable bool) error {
+	if !activeReliable || activePortals == nil || m == nil || m.staleMountRecoverer == nil {
+		return nil
+	}
+	if _, active := activePods[info.podUID]; !active {
+		return nil
+	}
+	podPortals, ok := activePortals[info.podUID]
+	if !ok {
+		return fmt.Errorf("active pod %s has no portal recovery metadata", info.podUID)
+	}
+	portal, ok := podPortals.Portals[info.volumeName]
+	if !ok {
+		return fmt.Errorf("active pod %s has no recovery metadata for volume %s", info.podUID, info.volumeName)
+	}
+	return m.staleMountRecoverer(ctx, targetPath, portal)
+}
+
+func (m *Manager) recoverStaleMount(ctx context.Context, targetPath string, portal RecoverablePortal) error {
+	if err := m.PublishPortal(ctx, publishRequest{
+		Namespace:  portal.Namespace,
+		PodName:    portal.PodName,
+		PodUID:     portal.PodUID,
+		Name:       portal.PortalName,
+		MountPath:  portal.MountPath,
+		TargetPath: targetPath,
+	}); err != nil {
+		return fmt.Errorf("republish portal: %w", err)
+	}
+	if strings.TrimSpace(portal.SandboxVolumeID) == "" {
+		return nil
+	}
+	if _, err := m.Bind(ctx, ctldapi.BindVolumePortalRequest{
+		Namespace:       portal.Namespace,
+		PodName:         portal.PodName,
+		PodUID:          portal.PodUID,
+		PortalName:      portal.PortalName,
+		MountPath:       portal.MountPath,
+		SandboxID:       "",
+		TeamID:          portal.TeamID,
+		SandboxVolumeID: portal.SandboxVolumeID,
+	}); err != nil {
+		_ = m.unpublishPortalContext(ctx, targetPath, true, true)
+		return fmt.Errorf("rebind portal: %w", err)
+	}
+	return nil
 }
 
 func (m *Manager) activePodUIDs(ctx context.Context) (map[string]struct{}, bool) {
@@ -162,7 +423,8 @@ func (m *Manager) activePodUIDs(ctx context.Context) (map[string]struct{}, bool)
 }
 
 type csiMountPathInfo struct {
-	podUID string
+	podUID     string
+	volumeName string
 }
 
 func shouldCleanSandboxCSIMount(info csiMountPathInfo, activePods map[string]struct{}, activeReliable bool, broken bool) bool {
@@ -194,7 +456,7 @@ func sandboxCSIMountPathInfo(root, path string) (csiMountPathInfo, bool) {
 		parts[2] == kubeletCSIVolumeDir &&
 		strings.HasPrefix(parts[3], sandboxVolumeNamePrefix) &&
 		parts[4] == "mount" {
-		return csiMountPathInfo{podUID: parts[0]}, true
+		return csiMountPathInfo{podUID: parts[0], volumeName: parts[3]}, true
 	}
 	return csiMountPathInfo{}, false
 }

--- a/ctld/internal/ctld/portal/recovery_test.go
+++ b/ctld/internal/ctld/portal/recovery_test.go
@@ -112,6 +112,101 @@ func TestCleanupStaleCSIMountsCleansBrokenActivePodMount(t *testing.T) {
 	}
 }
 
+func TestCleanupStaleCSIMountsRecoversBrokenActivePodMount(t *testing.T) {
+	root := t.TempDir()
+	volumeName := "sandbox0-volume-1-workspace"
+	target := filepath.Join(root, "pod-a", "volumes", kubeletCSIVolumeDir, volumeName, "mount")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v", target, err)
+	}
+
+	var recovered RecoverablePortal
+	var recoveredRuntime RuntimeRecoveryTarget
+	var portalsRecovered bool
+	mgr := NewManager(Config{
+		RootDir:         t.TempDir(),
+		KubeletPodsRoot: root,
+		ActivePodPortalLister: func(context.Context) (map[string]ActivePodPortals, error) {
+			return map[string]ActivePodPortals{
+				"pod-a": {Portals: map[string]RecoverablePortal{
+					volumeName: {
+						VolumeName: volumeName,
+						Namespace:  "tpl-default",
+						PodName:    "sandbox-a",
+						PodUID:     "pod-a",
+						PortalName: "workspace",
+						MountPath:  "/workspace",
+					},
+				}, RuntimeRecovery: &RuntimeRecoveryTarget{
+					Namespace:       "tpl-default",
+					PodName:         "sandbox-a",
+					PodUID:          "pod-a",
+					ContainerName:   "procd",
+					StateVolumeName: "sandbox0-volume-0-state",
+				}},
+			}, nil
+		},
+		StaleMountChecker: func(string) (bool, error) { return true, nil },
+		StaleMountCleaner: func(path string) error { return os.RemoveAll(path) },
+		StaleMountRecoverer: func(_ context.Context, path string, portal RecoverablePortal) error {
+			if path != target {
+				t.Fatalf("recovery path = %q, want %q", path, target)
+			}
+			recovered = portal
+			return nil
+		},
+		ActivePodRuntimeRecoverer: func(_ context.Context, target RuntimeRecoveryTarget, rebuilt bool) error {
+			recoveredRuntime = target
+			portalsRecovered = rebuilt
+			return nil
+		},
+	})
+	if err := mgr.CleanupStaleCSIMounts(context.Background()); err != nil {
+		t.Fatalf("CleanupStaleCSIMounts() error = %v", err)
+	}
+	if recovered.PodUID != "pod-a" || recovered.VolumeName != volumeName {
+		t.Fatalf("recovered portal = %#v", recovered)
+	}
+	if recoveredRuntime.PodUID != "pod-a" || !portalsRecovered {
+		t.Fatalf("runtime recovery = %#v, portals recovered = %v", recoveredRuntime, portalsRecovered)
+	}
+}
+
+func TestCleanupStaleCSIMountsChecksPendingRuntimeWithoutRebuildingPortal(t *testing.T) {
+	var called bool
+	mgr := NewManager(Config{
+		RootDir:         t.TempDir(),
+		KubeletPodsRoot: t.TempDir(),
+		ActivePodPortalLister: func(context.Context) (map[string]ActivePodPortals, error) {
+			return map[string]ActivePodPortals{
+				"pod-a": {
+					Portals: map[string]RecoverablePortal{},
+					RuntimeRecovery: &RuntimeRecoveryTarget{
+						Namespace:       "tpl-default",
+						PodName:         "sandbox-a",
+						PodUID:          "pod-a",
+						ContainerName:   "procd",
+						StateVolumeName: "sandbox0-volume-0-state",
+					},
+				},
+			}, nil
+		},
+		ActivePodRuntimeRecoverer: func(_ context.Context, _ RuntimeRecoveryTarget, rebuilt bool) error {
+			called = true
+			if rebuilt {
+				t.Fatal("rebuilt = true, want false")
+			}
+			return nil
+		},
+	})
+	if err := mgr.CleanupStaleCSIMounts(context.Background()); err != nil {
+		t.Fatalf("CleanupStaleCSIMounts() error = %v", err)
+	}
+	if !called {
+		t.Fatal("runtime recoverer was not called")
+	}
+}
+
 func TestShouldCleanSandboxCSIMountCleansBrokenActivePodMount(t *testing.T) {
 	info := csiMountPathInfo{podUID: "pod-a"}
 	activePods := map[string]struct{}{"pod-a": {}}

--- a/ctld/internal/ctld/processrecovery/recoverer.go
+++ b/ctld/internal/ctld/processrecovery/recoverer.go
@@ -1,0 +1,367 @@
+// Package processrecovery coordinates procd replacement after ctld rebuilds a
+// sandbox's FUSE portals.
+package processrecovery
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sandbox0-ai/sandbox0/pkg/procdstate"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+const (
+	defaultCRIEndpoint     = "/host-run/containerd/containerd.sock"
+	defaultKubeletPodsRoot = "/var/lib/kubelet/pods"
+	defaultPendingDir      = "/var/lib/sandbox0/ctld/process-recovery"
+	defaultDialTimeout     = 10 * time.Second
+	defaultStopTimeout     = 10 * time.Second
+	kubeletCSIVolumeDir    = "kubernetes.io~csi"
+)
+
+type runtimeService interface {
+	ListContainers(context.Context, *runtimeapi.ListContainersRequest, ...grpc.CallOption) (*runtimeapi.ListContainersResponse, error)
+	StopContainer(context.Context, *runtimeapi.StopContainerRequest, ...grpc.CallOption) (*runtimeapi.StopContainerResponse, error)
+}
+
+// Target identifies a live sandbox pod's procd container and webhook-state portal.
+type Target struct {
+	Namespace       string
+	PodName         string
+	PodUID          string
+	ContainerName   string
+	StateVolumeName string
+	ReplayProcesses bool
+}
+
+// Config controls node-local process recovery coordination.
+type Config struct {
+	CRIEndpoint     string
+	KubeletPodsRoot string
+	PendingDir      string
+	DialTimeout     time.Duration
+	StopTimeout     time.Duration
+	RuntimeService  runtimeService
+	DialContext     func(context.Context, string) (*grpc.ClientConn, error)
+}
+
+// Recoverer replaces stale procd containers and optionally requests context replay.
+type Recoverer struct {
+	criEndpoint       string
+	kubeletPodsRoot   string
+	pendingDir        string
+	dialTimeout       time.Duration
+	stopTimeout       time.Duration
+	configuredRuntime runtimeService
+	dialContext       func(context.Context, string) (*grpc.ClientConn, error)
+
+	mu               sync.Mutex
+	client           runtimeService
+	conn             *grpc.ClientConn
+	containersLoaded bool
+	containers       map[string]string
+	loadErr          error
+}
+
+type pendingRecovery struct {
+	PodUID          string    `json:"pod_uid"`
+	ContainerID     string    `json:"container_id,omitempty"`
+	ReplayProcesses bool      `json:"replay_processes"`
+	RequestedAt     time.Time `json:"requested_at"`
+}
+
+func New(cfg Config) *Recoverer {
+	criEndpoint := strings.TrimSpace(cfg.CRIEndpoint)
+	if criEndpoint == "" {
+		criEndpoint = defaultCRIEndpoint
+	}
+	kubeletPodsRoot := strings.TrimSpace(cfg.KubeletPodsRoot)
+	if kubeletPodsRoot == "" {
+		kubeletPodsRoot = defaultKubeletPodsRoot
+	}
+	pendingDir := strings.TrimSpace(cfg.PendingDir)
+	if pendingDir == "" {
+		pendingDir = defaultPendingDir
+	}
+	dialTimeout := cfg.DialTimeout
+	if dialTimeout <= 0 {
+		dialTimeout = defaultDialTimeout
+	}
+	stopTimeout := cfg.StopTimeout
+	if stopTimeout <= 0 {
+		stopTimeout = defaultStopTimeout
+	}
+	return &Recoverer{
+		criEndpoint:       criEndpoint,
+		kubeletPodsRoot:   filepath.Clean(kubeletPodsRoot),
+		pendingDir:        filepath.Clean(pendingDir),
+		dialTimeout:       dialTimeout,
+		stopTimeout:       stopTimeout,
+		configuredRuntime: cfg.RuntimeService,
+		dialContext:       cfg.DialContext,
+	}
+}
+
+// Recover resumes a pending replacement, or starts one when portalsRecovered
+// reports that this ctld instance rebuilt at least one portal for the pod.
+func (r *Recoverer) Recover(ctx context.Context, target Target, portalsRecovered bool) error {
+	if err := validateTarget(target); err != nil {
+		return err
+	}
+	pendingPath := filepath.Join(r.pendingDir, target.PodUID+".json")
+	pending, hasPending, err := readPending(pendingPath)
+	if err != nil {
+		return err
+	}
+	if !hasPending && !portalsRecovered {
+		return nil
+	}
+
+	client, containerID, err := r.runtimeForTarget(ctx, target)
+	if err != nil {
+		return err
+	}
+	if hasPending && pending.PodUID != target.PodUID {
+		return fmt.Errorf("pending process recovery pod UID %q does not match %q", pending.PodUID, target.PodUID)
+	}
+	if hasPending && pending.ContainerID != "" && containerID != "" && pending.ContainerID != containerID {
+		return removePending(pendingPath)
+	}
+	if !hasPending {
+		pending = pendingRecovery{
+			PodUID:          target.PodUID,
+			ContainerID:     containerID,
+			ReplayProcesses: target.ReplayProcesses,
+			RequestedAt:     time.Now().UTC(),
+		}
+		if err := writeJSONAtomic(r.pendingDir, pendingPath, pending); err != nil {
+			return fmt.Errorf("write pending process recovery: %w", err)
+		}
+	}
+
+	if pending.ReplayProcesses {
+		markerPath, err := r.recoveryMarkerPath(target)
+		if err != nil {
+			return err
+		}
+		if err := writeJSONAtomic(filepath.Dir(markerPath), markerPath, pending); err != nil {
+			return fmt.Errorf("write procd recovery marker: %w", err)
+		}
+	}
+	if containerID == "" {
+		return removePending(pendingPath)
+	}
+	if _, err := client.StopContainer(ctx, &runtimeapi.StopContainerRequest{
+		ContainerId: containerID,
+		Timeout:     int64(r.stopTimeout.Seconds()),
+	}); err != nil {
+		return fmt.Errorf("stop procd container %s: %w", containerID, err)
+	}
+	r.removeRunningContainer(target, containerID)
+	return removePending(pendingPath)
+}
+
+func (r *Recoverer) recoveryMarkerPath(target Target) (string, error) {
+	stateMount := filepath.Join(r.kubeletPodsRoot, target.PodUID, "volumes", kubeletCSIVolumeDir, target.StateVolumeName, "mount")
+	rel, err := filepath.Rel(r.kubeletPodsRoot, stateMount)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("webhook-state portal escapes kubelet pod root")
+	}
+	if info, err := os.Stat(stateMount); err != nil {
+		return "", fmt.Errorf("inspect webhook-state portal: %w", err)
+	} else if !info.IsDir() {
+		return "", fmt.Errorf("webhook-state portal is not a directory")
+	}
+	return filepath.Join(stateMount, procdstate.RecoveryRequestFilename), nil
+}
+
+func (r *Recoverer) runtimeForTarget(ctx context.Context, target Target) (runtimeService, string, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if !r.containersLoaded {
+		r.loadRunningContainersLocked(ctx)
+	}
+	if r.loadErr != nil {
+		return nil, "", r.loadErr
+	}
+	return r.client, r.containers[containerKey(target.Namespace, target.PodName, target.PodUID, target.ContainerName)], nil
+}
+
+func (r *Recoverer) loadRunningContainersLocked(ctx context.Context) {
+	r.containersLoaded = true
+	client := r.configuredRuntime
+	if client == nil {
+		dialCtx, cancel := context.WithTimeout(ctx, r.dialTimeout)
+		defer cancel()
+		dial := r.dialContext
+		if dial == nil {
+			dial = func(ctx context.Context, endpoint string) (*grpc.ClientConn, error) {
+				return grpc.DialContext(ctx, endpoint, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
+			}
+		}
+		conn, err := dial(dialCtx, normalizeEndpoint(r.criEndpoint))
+		if err != nil {
+			r.loadErr = fmt.Errorf("dial CRI endpoint %s: %w", r.criEndpoint, err)
+			return
+		}
+		r.conn = conn
+		client = runtimeapi.NewRuntimeServiceClient(conn)
+	}
+	r.client = client
+	resp, err := client.ListContainers(ctx, &runtimeapi.ListContainersRequest{
+		Filter: &runtimeapi.ContainerFilter{State: &runtimeapi.ContainerStateValue{State: runtimeapi.ContainerState_CONTAINER_RUNNING}},
+	})
+	if err != nil {
+		r.loadErr = fmt.Errorf("list CRI containers: %w", err)
+		return
+	}
+	r.containers = make(map[string]string, len(resp.GetContainers()))
+	for _, container := range resp.GetContainers() {
+		metadata := container.GetMetadata()
+		labels := container.GetLabels()
+		if metadata == nil || container.GetState() != runtimeapi.ContainerState_CONTAINER_RUNNING {
+			continue
+		}
+		key := containerKey(
+			labels["io.kubernetes.pod.namespace"],
+			labels["io.kubernetes.pod.name"],
+			labels["io.kubernetes.pod.uid"],
+			metadata.GetName(),
+		)
+		r.containers[key] = container.GetId()
+	}
+}
+
+func (r *Recoverer) removeRunningContainer(target Target, containerID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	key := containerKey(target.Namespace, target.PodName, target.PodUID, target.ContainerName)
+	if r.containers[key] == containerID {
+		delete(r.containers, key)
+	}
+}
+
+// Close releases the shared CRI connection after startup reconciliation.
+func (r *Recoverer) Close() error {
+	r.mu.Lock()
+	conn := r.conn
+	r.conn = nil
+	r.mu.Unlock()
+	if conn == nil {
+		return nil
+	}
+	return conn.Close()
+}
+
+func containerKey(namespace, podName, podUID, containerName string) string {
+	return strings.Join([]string{namespace, podName, podUID, containerName}, "\x00")
+}
+
+func validateTarget(target Target) error {
+	fields := []struct {
+		name  string
+		value string
+	}{
+		{name: "namespace", value: target.Namespace},
+		{name: "pod name", value: target.PodName},
+		{name: "pod UID", value: target.PodUID},
+		{name: "container name", value: target.ContainerName},
+		{name: "state volume name", value: target.StateVolumeName},
+	}
+	for _, field := range fields {
+		value := strings.TrimSpace(field.value)
+		if value == "" || filepath.Base(value) != value || strings.ContainsAny(value, `/\\`) {
+			return fmt.Errorf("invalid %s %q", field.name, value)
+		}
+	}
+	if !strings.HasPrefix(target.StateVolumeName, "sandbox0-volume-") {
+		return fmt.Errorf("invalid state volume name %q", target.StateVolumeName)
+	}
+	return nil
+}
+
+func readPending(path string) (pendingRecovery, bool, error) {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return pendingRecovery{}, false, nil
+	}
+	if err != nil {
+		return pendingRecovery{}, false, fmt.Errorf("read pending process recovery: %w", err)
+	}
+	var pending pendingRecovery
+	if err := json.Unmarshal(data, &pending); err != nil {
+		return pendingRecovery{}, false, fmt.Errorf("decode pending process recovery: %w", err)
+	}
+	return pending, true, nil
+}
+
+func writeJSONAtomic(dir, path string, value any) error {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	data, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".recovery-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return err
+	}
+	return syncDirectory(dir)
+}
+
+func removePending(path string) error {
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove pending process recovery: %w", err)
+	}
+	return syncDirectory(filepath.Dir(path))
+}
+
+func syncDirectory(path string) error {
+	dir, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer dir.Close()
+	return dir.Sync()
+}
+
+func normalizeEndpoint(endpoint string) string {
+	endpoint = strings.TrimSpace(endpoint)
+	if strings.Contains(endpoint, "://") {
+		return endpoint
+	}
+	if strings.HasPrefix(endpoint, "/") {
+		return "unix://" + endpoint
+	}
+	return endpoint
+}

--- a/ctld/internal/ctld/processrecovery/recoverer_test.go
+++ b/ctld/internal/ctld/processrecovery/recoverer_test.go
@@ -1,0 +1,234 @@
+package processrecovery
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/sandbox0-ai/sandbox0/pkg/procdstate"
+	"google.golang.org/grpc"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+type fakeRuntimeService struct {
+	mu         sync.Mutex
+	containers []*runtimeapi.Container
+	stopIDs    []string
+	stopErr    error
+	listCalls  int
+}
+
+func (f *fakeRuntimeService) ListContainers(context.Context, *runtimeapi.ListContainersRequest, ...grpc.CallOption) (*runtimeapi.ListContainersResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.listCalls++
+	return &runtimeapi.ListContainersResponse{Containers: append([]*runtimeapi.Container(nil), f.containers...)}, nil
+}
+
+func (f *fakeRuntimeService) StopContainer(_ context.Context, req *runtimeapi.StopContainerRequest, _ ...grpc.CallOption) (*runtimeapi.StopContainerResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.stopIDs = append(f.stopIDs, req.GetContainerId())
+	return &runtimeapi.StopContainerResponse{}, f.stopErr
+}
+
+func TestRecoverSkipsHealthyPodWithoutPendingRecovery(t *testing.T) {
+	fake := &fakeRuntimeService{}
+	recoverer := New(Config{
+		KubeletPodsRoot: t.TempDir(),
+		PendingDir:      filepath.Join(t.TempDir(), "pending"),
+		RuntimeService:  fake,
+	})
+	if err := recoverer.Recover(context.Background(), testTarget(), false); err != nil {
+		t.Fatalf("Recover() error = %v", err)
+	}
+	if fake.listCalls != 0 {
+		t.Fatalf("ListContainers calls = %d, want 0", fake.listCalls)
+	}
+}
+
+func TestRecoverMarksStateAndStopsCurrentProcd(t *testing.T) {
+	recoverer, fake, markerPath, pendingPath := newRecovererFixture(t, "container-old")
+	if err := recoverer.Recover(context.Background(), testTarget(), true); err != nil {
+		t.Fatalf("Recover() error = %v", err)
+	}
+	if len(fake.stopIDs) != 1 || fake.stopIDs[0] != "container-old" {
+		t.Fatalf("stopped containers = %v, want [container-old]", fake.stopIDs)
+	}
+	if _, err := os.Stat(markerPath); err != nil {
+		t.Fatalf("recovery marker does not exist: %v", err)
+	}
+	if _, err := os.Stat(pendingPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("pending recovery still exists: %v", err)
+	}
+}
+
+func TestRecoverRetriesPendingStop(t *testing.T) {
+	recoverer, fake, _, pendingPath := newRecovererFixture(t, "container-old")
+	fake.stopErr = errors.New("temporary CRI failure")
+	if err := recoverer.Recover(context.Background(), testTarget(), true); err == nil {
+		t.Fatal("Recover() error = nil, want CRI failure")
+	}
+	if _, err := os.Stat(pendingPath); err != nil {
+		t.Fatalf("pending recovery does not exist: %v", err)
+	}
+
+	fake.stopErr = nil
+	if err := recoverer.Recover(context.Background(), testTarget(), false); err != nil {
+		t.Fatalf("Recover() retry error = %v", err)
+	}
+	if len(fake.stopIDs) != 2 {
+		t.Fatalf("stop calls = %v, want two attempts", fake.stopIDs)
+	}
+	if fake.listCalls != 1 {
+		t.Fatalf("list calls = %d, want one shared CRI snapshot", fake.listCalls)
+	}
+	if _, err := os.Stat(pendingPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("pending recovery still exists after retry: %v", err)
+	}
+}
+
+func TestRecoverDoesNotStopReplacementContainerForOldPendingRecord(t *testing.T) {
+	recoverer, fake, _, pendingPath := newRecovererFixture(t, "container-old")
+	fake.stopErr = errors.New("stop interrupted")
+	if err := recoverer.Recover(context.Background(), testTarget(), true); err == nil {
+		t.Fatal("Recover() error = nil, want interrupted stop")
+	}
+	fake.stopErr = nil
+	fake.containers = []*runtimeapi.Container{testContainer("container-new")}
+	replacementRecoverer := New(Config{
+		KubeletPodsRoot: recoverer.kubeletPodsRoot,
+		PendingDir:      recoverer.pendingDir,
+		RuntimeService:  fake,
+	})
+	if err := replacementRecoverer.Recover(context.Background(), testTarget(), false); err != nil {
+		t.Fatalf("Recover() replacement check error = %v", err)
+	}
+	if len(fake.stopIDs) != 1 {
+		t.Fatalf("stop calls = %v, replacement container must not be stopped", fake.stopIDs)
+	}
+	if _, err := os.Stat(pendingPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("pending recovery still exists: %v", err)
+	}
+}
+
+func TestRecoverWritesMarkerWhenContainerAlreadyStopped(t *testing.T) {
+	recoverer, fake, markerPath, _ := newRecovererFixture(t, "")
+	if err := recoverer.Recover(context.Background(), testTarget(), true); err != nil {
+		t.Fatalf("Recover() error = %v", err)
+	}
+	if len(fake.stopIDs) != 0 {
+		t.Fatalf("stop calls = %v, want none", fake.stopIDs)
+	}
+	if _, err := os.Stat(markerPath); err != nil {
+		t.Fatalf("recovery marker does not exist: %v", err)
+	}
+}
+
+func TestRecoverReplacesIdleProcdWithoutRequestingProcessReplay(t *testing.T) {
+	recoverer, fake, markerPath, _ := newRecovererFixture(t, "container-idle")
+	target := testTarget()
+	target.ReplayProcesses = false
+	if err := recoverer.Recover(context.Background(), target, true); err != nil {
+		t.Fatalf("Recover() error = %v", err)
+	}
+	if len(fake.stopIDs) != 1 || fake.stopIDs[0] != "container-idle" {
+		t.Fatalf("stopped containers = %v, want [container-idle]", fake.stopIDs)
+	}
+	if _, err := os.Stat(markerPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("idle recovery marker exists: %v", err)
+	}
+}
+
+func TestRecoverSharesCRIContainerSnapshotAcrossConcurrentPods(t *testing.T) {
+	kubeletRoot := t.TempDir()
+	pendingDir := filepath.Join(t.TempDir(), "pending")
+	fake := &fakeRuntimeService{}
+	targets := make([]Target, 32)
+	for i := range targets {
+		target := testTarget()
+		target.PodName = fmt.Sprintf("sandbox-%d", i)
+		target.PodUID = fmt.Sprintf("pod-%d", i)
+		targets[i] = target
+		fake.containers = append(fake.containers, testContainerForTarget(fmt.Sprintf("container-%d", i), target))
+		stateMount := filepath.Join(kubeletRoot, target.PodUID, "volumes", kubeletCSIVolumeDir, target.StateVolumeName, "mount")
+		if err := os.MkdirAll(stateMount, 0o700); err != nil {
+			t.Fatalf("create state mount: %v", err)
+		}
+	}
+	recoverer := New(Config{KubeletPodsRoot: kubeletRoot, PendingDir: pendingDir, RuntimeService: fake})
+	errs := make(chan error, len(targets))
+	var wg sync.WaitGroup
+	for _, target := range targets {
+		wg.Add(1)
+		go func(target Target) {
+			defer wg.Done()
+			errs <- recoverer.Recover(context.Background(), target, true)
+		}(target)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("Recover() error = %v", err)
+		}
+	}
+	if fake.listCalls != 1 {
+		t.Fatalf("list calls = %d, want 1", fake.listCalls)
+	}
+	if len(fake.stopIDs) != len(targets) {
+		t.Fatalf("stop calls = %d, want %d", len(fake.stopIDs), len(targets))
+	}
+}
+
+func newRecovererFixture(t *testing.T, containerID string) (*Recoverer, *fakeRuntimeService, string, string) {
+	t.Helper()
+	kubeletRoot := t.TempDir()
+	pendingDir := filepath.Join(t.TempDir(), "pending")
+	target := testTarget()
+	stateMount := filepath.Join(kubeletRoot, target.PodUID, "volumes", kubeletCSIVolumeDir, target.StateVolumeName, "mount")
+	if err := os.MkdirAll(stateMount, 0o700); err != nil {
+		t.Fatalf("create state mount: %v", err)
+	}
+	fake := &fakeRuntimeService{}
+	if containerID != "" {
+		fake.containers = []*runtimeapi.Container{testContainer(containerID)}
+	}
+	return New(Config{
+		KubeletPodsRoot: kubeletRoot,
+		PendingDir:      pendingDir,
+		RuntimeService:  fake,
+	}), fake, filepath.Join(stateMount, procdstate.RecoveryRequestFilename), filepath.Join(pendingDir, target.PodUID+".json")
+}
+
+func testTarget() Target {
+	return Target{
+		Namespace:       "sandbox0",
+		PodName:         "sandbox-pod",
+		PodUID:          "pod-uid",
+		ContainerName:   "procd",
+		StateVolumeName: "sandbox0-volume-0-sandbox0-webhook-state",
+		ReplayProcesses: true,
+	}
+}
+
+func testContainer(id string) *runtimeapi.Container {
+	return testContainerForTarget(id, testTarget())
+}
+
+func testContainerForTarget(id string, target Target) *runtimeapi.Container {
+	return &runtimeapi.Container{
+		Id:       id,
+		Metadata: &runtimeapi.ContainerMetadata{Name: target.ContainerName},
+		State:    runtimeapi.ContainerState_CONTAINER_RUNNING,
+		Labels: map[string]string{
+			"io.kubernetes.pod.namespace": target.Namespace,
+			"io.kubernetes.pod.name":      target.PodName,
+			"io.kubernetes.pod.uid":       target.PodUID,
+		},
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/hanwen/go-fuse/v2 v2.8.0
 	github.com/jackc/pgx/v5 v5.7.5
+	github.com/moby/sys/mountinfo v0.7.2
 	github.com/oapi-codegen/runtime v1.1.1
 	github.com/onsi/ginkgo/v2 v2.27.5
 	github.com/onsi/gomega v1.39.0
@@ -158,7 +159,6 @@ require (
 	github.com/mdlayher/socket v0.5.1 // indirect
 	github.com/mfridman/interpolate v0.0.2 // indirect
 	github.com/moby/locker v1.0.1 // indirect
-	github.com/moby/sys/mountinfo v0.7.2 // indirect
 	github.com/moby/sys/sequential v0.6.0 // indirect
 	github.com/moby/sys/signal v0.7.1 // indirect
 	github.com/moby/sys/user v0.4.0 // indirect

--- a/manager/cmd/procd/main.go
+++ b/manager/cmd/procd/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/webhook"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"github.com/sandbox0-ai/sandbox0/pkg/observability"
+	"github.com/sandbox0-ai/sandbox0/pkg/procdstate"
 	"go.uber.org/zap"
 )
 
@@ -71,6 +72,11 @@ func main() {
 	configureProcessOutputForwarding(logger)
 
 	contextManager := ctxpkg.NewManager()
+	contextStateStore, err := ctxpkg.NewFileStateStore(procdstate.ContextStateDir)
+	if err != nil {
+		logger.Fatal("Failed to initialize context state store", zap.Error(err))
+	}
+	contextManager.SetStateStore(contextStateStore)
 	contextManager.SetDefaultCleanupPolicy(ctxpkg.CleanupPolicy{
 		IdleTimeout: cfg.ContextIdleTimeout.Duration,
 		MaxLifetime: cfg.ContextMaxLifetime.Duration,
@@ -135,6 +141,11 @@ func main() {
 	fileManager, err := file.NewManager(cfg.RootPath)
 	if err != nil {
 		logger.Fatal("Failed to create file manager", zap.Error(err))
+	}
+
+	if err := initializeContextRecovery(contextManager, contextStateStore, logger); err != nil {
+		contextManager.CleanupPreservingState()
+		logger.Fatal("Failed to recover contexts", zap.Error(err))
 	}
 
 	// Initialize internal auth validator
@@ -204,7 +215,7 @@ func main() {
 		}
 
 		// Cleanup managers
-		contextManager.Cleanup()
+		contextManager.CleanupPreservingState()
 		fileManager.Close()
 
 		if err := webhookDispatcher.Shutdown(context.Background()); err != nil {
@@ -221,4 +232,29 @@ func main() {
 
 	<-done
 	logger.Info("Procd shutdown complete")
+}
+
+func initializeContextRecovery(manager *ctxpkg.Manager, store *ctxpkg.FileStateStore, logger *zap.Logger) error {
+	requested, err := store.RecoveryRequested()
+	if err != nil {
+		return err
+	}
+	if !requested {
+		return store.Clear()
+	}
+	restored, err := manager.RestoreContexts()
+	if err != nil {
+		return err
+	}
+	consumed, err := store.ConsumeRecoveryRequest()
+	if err != nil {
+		return err
+	}
+	if !consumed {
+		return errors.New("context recovery request disappeared before completion")
+	}
+	if logger != nil {
+		logger.Info("Recovered procd contexts", zap.Int("contexts", len(restored)))
+	}
+	return nil
 }

--- a/manager/cmd/procd/main_test.go
+++ b/manager/cmd/procd/main_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	ctxpkg "github.com/sandbox0-ai/sandbox0/manager/procd/pkg/context"
+	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/process"
+	"github.com/sandbox0-ai/sandbox0/pkg/procdstate"
+	"go.uber.org/zap"
+)
+
+func TestInitializeContextRecoveryRequiresMarker(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		withMarker  bool
+		wantContext int
+	}{
+		{name: "ordinary restart clears definitions"},
+		{name: "ctld recovery replays definitions", withMarker: true, wantContext: 1},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			store, err := ctxpkg.NewFileStateStore(filepath.Join(root, "contexts"))
+			if err != nil {
+				t.Fatalf("NewFileStateStore() error = %v", err)
+			}
+			first := ctxpkg.NewManager()
+			first.SetStateStore(store)
+			if _, err := first.CreateContext(process.ProcessConfig{
+				Type:    process.ProcessTypeCMD,
+				Command: []string{"/bin/sh", "-c", "while :; do sleep 1; done"},
+			}); err != nil {
+				t.Fatalf("CreateContext() error = %v", err)
+			}
+			first.CleanupPreservingState()
+
+			if tt.withMarker {
+				markerPath := filepath.Join(root, procdstate.RecoveryRequestFilename)
+				if err := os.WriteFile(markerPath, []byte("{}"), 0o600); err != nil {
+					t.Fatalf("write recovery marker: %v", err)
+				}
+			}
+			second := ctxpkg.NewManager()
+			second.SetStateStore(store)
+			if err := initializeContextRecovery(second, store, zap.NewNop()); err != nil {
+				t.Fatalf("initializeContextRecovery() error = %v", err)
+			}
+			t.Cleanup(second.Cleanup)
+			if got := len(second.ListContexts()); got != tt.wantContext {
+				t.Fatalf("context count = %d, want %d", got, tt.wantContext)
+			}
+		})
+	}
+}

--- a/manager/procd/pkg/context/context.go
+++ b/manager/procd/pkg/context/context.go
@@ -27,7 +27,10 @@ type Context struct {
 	FinishedAt     *time.Time          `json:"-"`
 	CleanupPolicy  CleanupPolicy       `json:"-"`
 
-	mu sync.RWMutex
+	processConfig process.ProcessConfig
+	replConfig    *repl.REPLConfig
+	persistence   *contextPersistence
+	mu            sync.RWMutex
 }
 
 // CleanupPolicy defines when a context should be cleaned up.
@@ -43,7 +46,21 @@ func (p CleanupPolicy) isZero() bool {
 
 // NewContext creates a new context with the given configuration.
 func NewContext(config process.ProcessConfig, replConfig *repl.REPLConfig, exitHandler process.ExitHandler, startHandler process.StartHandler) (*Context, error) {
-	id := "ctx-" + uuid.New().String()[:8]
+	return newContextWithID(newContextID(), time.Time{}, config, replConfig, exitHandler, startHandler)
+}
+
+func newContextID() string {
+	return "ctx-" + uuid.New().String()[:8]
+}
+
+func newContextWithID(id string, createdAt time.Time, config process.ProcessConfig, replConfig *repl.REPLConfig, exitHandler process.ExitHandler, startHandler process.StartHandler) (*Context, error) {
+	if id == "" {
+		return nil, fmt.Errorf("context id is required")
+	}
+	config = cloneProcessConfig(config)
+	if replConfig != nil {
+		replConfig = replConfig.Clone()
+	}
 
 	var proc process.Process
 	var err error
@@ -69,17 +86,22 @@ func NewContext(config process.ProcessConfig, replConfig *repl.REPLConfig, exitH
 	}
 
 	now := time.Now()
+	if createdAt.IsZero() {
+		createdAt = now
+	}
 	ctx := &Context{
 		ID:             id,
 		Type:           config.Type,
 		Alias:          config.Alias,
 		Command:        append([]string(nil), config.Command...),
 		CWD:            config.CWD,
-		EnvVars:        config.EnvVars,
+		EnvVars:        process.CloneEnvVars(config.EnvVars),
 		MainProcess:    proc,
-		CreatedAt:      now,
+		CreatedAt:      createdAt,
 		UpdatedAt:      now,
 		LastActivityAt: now,
+		processConfig:  cloneProcessConfig(config),
+		replConfig:     replConfig,
 	}
 
 	proc.AddExitHandler(func(event process.ExitEvent) {
@@ -97,6 +119,32 @@ func NewContext(config process.ProcessConfig, replConfig *repl.REPLConfig, exitH
 	}
 
 	return ctx, nil
+}
+
+func cloneProcessConfig(config process.ProcessConfig) process.ProcessConfig {
+	config.Command = append([]string(nil), config.Command...)
+	config.EnvVars = process.CloneEnvVars(config.EnvVars)
+	if config.PTYSize != nil {
+		ptySize := *config.PTYSize
+		config.PTYSize = &ptySize
+	}
+	return config
+}
+
+func (ctx *Context) persistedState(state process.ProcessState) persistedContext {
+	ctx.mu.RLock()
+	defer ctx.mu.RUnlock()
+	record := persistedContext{
+		ID:            ctx.ID,
+		Config:        cloneProcessConfig(ctx.processConfig),
+		CleanupPolicy: ctx.CleanupPolicy,
+		DesiredState:  state,
+		CreatedAt:     ctx.CreatedAt,
+	}
+	if ctx.replConfig != nil {
+		record.REPLConfig = ctx.replConfig.Clone()
+	}
+	return record
 }
 
 // Stop stops the context and its main process.

--- a/manager/procd/pkg/context/manager.go
+++ b/manager/procd/pkg/context/manager.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -55,6 +56,59 @@ type Manager struct {
 	onStart              process.StartHandler
 	defaultCleanupPolicy CleanupPolicy
 	cleanupOnce          sync.Once
+	stateStore           contextStateStore
+	preserveStateOnExit  atomic.Bool
+}
+
+type contextPersistence struct {
+	mu                  sync.Mutex
+	store               contextStateStore
+	record              persistedContext
+	preserveStateOnExit *atomic.Bool
+	disabled            bool
+	hasState            bool
+	lastState           process.ProcessState
+}
+
+func (p *contextPersistence) save(state process.ProcessState, preserveOnExit bool) error {
+	if p == nil || p.store == nil {
+		return nil
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.disabled || (preserveOnExit && p.preserveStateOnExit != nil && p.preserveStateOnExit.Load()) {
+		return nil
+	}
+	if p.hasState && p.lastState == state {
+		return nil
+	}
+	record := p.record
+	record.DesiredState = state
+	if err := p.store.Save(record); err != nil {
+		return err
+	}
+	p.hasState = true
+	p.lastState = state
+	return nil
+}
+
+func (p *contextPersistence) disable() {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	p.disabled = true
+	p.mu.Unlock()
+}
+
+func (p *contextPersistence) disableAndDelete() error {
+	if p == nil || p.store == nil {
+		return nil
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.disabled = true
+	return p.store.Delete(p.record.ID)
 }
 
 // NewManager creates a new context manager.
@@ -62,6 +116,13 @@ func NewManager() *Manager {
 	return &Manager{
 		contexts: make(map[string]*Context),
 	}
+}
+
+// SetStateStore enables durable context-definition persistence.
+func (m *Manager) SetStateStore(store contextStateStore) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.stateStore = store
 }
 
 // SetExitHandler sets a global exit handler for new contexts.
@@ -128,30 +189,116 @@ func (m *Manager) CreateContext(config process.ProcessConfig) (*Context, error) 
 // CreateContextWithPolicyAndREPLConfig creates a new context with a cleanup policy and optional REPL config.
 func (m *Manager) CreateContextWithPolicyAndREPLConfig(config process.ProcessConfig, replConfig *repl.REPLConfig, policy CleanupPolicy) (*Context, error) {
 	m.mu.Lock()
-	startHandler := m.onStart
-	defaultPolicy := m.defaultCleanupPolicy
-	config.EnvVars = process.MergeEnvVars(m.sandboxEnvVars, config.EnvVars)
-	// Define exit handler for the new context
-	exitHandler := func(event process.ExitEvent) {
-		if m.onExit != nil {
-			m.onExit(event)
+	defer m.mu.Unlock()
+	return m.createContextLocked(newContextID(), time.Time{}, config, replConfig, policy, true, true)
+}
+
+func (m *Manager) createContextLocked(id string, createdAt time.Time, config process.ProcessConfig, replConfig *repl.REPLConfig, policy CleanupPolicy, mergeSandboxEnv, persistBeforeStart bool) (*Context, error) {
+	if _, exists := m.contexts[id]; exists {
+		return nil, fmt.Errorf("context %s already exists", id)
+	}
+	if mergeSandboxEnv {
+		config.EnvVars = process.MergeEnvVars(m.sandboxEnvVars, config.EnvVars)
+	} else {
+		config = cloneProcessConfig(config)
+	}
+	if mergeSandboxEnv && policy.isZero() {
+		policy = m.defaultCleanupPolicy
+	}
+	if createdAt.IsZero() {
+		createdAt = time.Now()
+	}
+
+	baseRecord := persistedContext{
+		ID:            id,
+		Config:        cloneProcessConfig(config),
+		CleanupPolicy: policy,
+		DesiredState:  process.ProcessStateRunning,
+		CreatedAt:     createdAt,
+	}
+	if replConfig != nil {
+		baseRecord.REPLConfig = replConfig.Clone()
+	}
+	persistence := &contextPersistence{
+		store:               m.stateStore,
+		record:              baseRecord,
+		preserveStateOnExit: &m.preserveStateOnExit,
+	}
+	if persistBeforeStart {
+		if err := persistence.save(process.ProcessStateRunning, false); err != nil {
+			return nil, fmt.Errorf("persist context before start: %w", err)
 		}
 	}
 
-	ctx, err := NewContext(config, replConfig, exitHandler, startHandler)
+	onExit := m.onExit
+	onStart := m.onStart
+	exitHandler := func(event process.ExitEvent) {
+		_ = persistence.save(event.State, true)
+		if onExit != nil {
+			onExit(event)
+		}
+	}
+	startHandler := func(event process.StartEvent) {
+		_ = persistence.save(process.ProcessStateRunning, false)
+		if onStart != nil {
+			onStart(event)
+		}
+	}
+
+	ctx, err := newContextWithID(id, createdAt, config, replConfig, exitHandler, startHandler)
 	if err != nil {
-		m.mu.Unlock()
+		if persistBeforeStart {
+			_ = persistence.disableAndDelete()
+		}
 		return nil, err
 	}
-
-	if policy.isZero() {
-		policy = defaultPolicy
-	}
 	ctx.SetCleanupPolicy(policy)
-
-	m.contexts[ctx.ID] = ctx
-	m.mu.Unlock()
+	ctx.persistence = persistence
+	m.contexts[id] = ctx
 	return ctx, nil
+}
+
+// RestoreContexts recreates contexts that were running or paused before ctld
+// replaced the procd container. Process memory, PIDs, and open descriptors are
+// intentionally not restored.
+func (m *Manager) RestoreContexts() ([]*Context, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.stateStore == nil {
+		return nil, nil
+	}
+	records, err := m.stateStore.Load()
+	if err != nil {
+		return nil, err
+	}
+	restored := make([]*Context, 0, len(records))
+	var errs []error
+	for _, record := range records {
+		if record.DesiredState != process.ProcessStateRunning && record.DesiredState != process.ProcessStatePaused {
+			continue
+		}
+		ctx, createErr := m.createContextLocked(record.ID, record.CreatedAt, record.Config, record.REPLConfig, record.CleanupPolicy, false, false)
+		if createErr != nil {
+			errs = append(errs, fmt.Errorf("restore context %s: %w", record.ID, createErr))
+			continue
+		}
+		if record.DesiredState == process.ProcessStatePaused {
+			if pauseErr := ctx.Pause(); pauseErr != nil {
+				ctx.persistence.disable()
+				_ = ctx.Stop()
+				delete(m.contexts, ctx.ID)
+				_ = m.stateStore.Save(record)
+				errs = append(errs, fmt.Errorf("restore paused context %s: %w", record.ID, pauseErr))
+				continue
+			}
+			if persistErr := m.stateStore.Save(ctx.persistedState(process.ProcessStatePaused)); persistErr != nil {
+				errs = append(errs, fmt.Errorf("persist restored context %s: %w", record.ID, persistErr))
+				continue
+			}
+		}
+		restored = append(restored, ctx)
+	}
+	return restored, errors.Join(errs...)
 }
 
 // GetContext returns a context by ID.
@@ -190,10 +337,17 @@ func (m *Manager) DeleteContext(id string) error {
 		return ErrContextNotFound
 	}
 
+	var persistErr error
+	if ctx.persistence != nil {
+		persistErr = ctx.persistence.disableAndDelete()
+	}
 	_ = ctx.Stop()
 
 	delete(m.contexts, id)
-	return nil
+	if ctx.persistence == nil && m.stateStore != nil {
+		persistErr = m.stateStore.Delete(id)
+	}
+	return persistErr
 }
 
 // RestartContext restarts a context.
@@ -209,6 +363,12 @@ func (m *Manager) RestartContext(id string) (*Context, error) {
 	if err := ctx.Restart(); err != nil {
 		m.mu.Unlock()
 		return nil, err
+	}
+	if m.stateStore != nil {
+		if err := ctx.persistence.save(process.ProcessStateRunning, false); err != nil {
+			m.mu.Unlock()
+			return nil, fmt.Errorf("persist restarted context: %w", err)
+		}
 	}
 
 	m.mu.Unlock()
@@ -226,6 +386,10 @@ func (m *Manager) PauseAll() error {
 		if ctx.IsRunning() {
 			if err := ctx.Pause(); err != nil {
 				errs = append(errs, fmt.Errorf("context %s: %w", ctx.ID, err))
+			} else if m.stateStore != nil {
+				if err := ctx.persistence.save(process.ProcessStatePaused, false); err != nil {
+					errs = append(errs, fmt.Errorf("persist context %s: %w", ctx.ID, err))
+				}
 			}
 		}
 	}
@@ -244,6 +408,10 @@ func (m *Manager) ResumeAll() error {
 		if ctx.IsPaused() {
 			if err := ctx.Resume(); err != nil {
 				errs = append(errs, fmt.Errorf("context %s: %w", ctx.ID, err))
+			} else if m.stateStore != nil {
+				if err := ctx.persistence.save(process.ProcessStateRunning, false); err != nil {
+					errs = append(errs, fmt.Errorf("persist context %s: %w", ctx.ID, err))
+				}
 			}
 		}
 	}
@@ -303,14 +471,31 @@ func (m *Manager) SendSignal(contextID string, sig syscall.Signal) error {
 
 // Cleanup cleans up all contexts.
 func (m *Manager) Cleanup() {
+	m.cleanup(false)
+}
+
+// CleanupPreservingState stops local processes without changing their durable
+// desired state. A subsequent procd only replays it when ctld supplied a marker.
+func (m *Manager) CleanupPreservingState() {
+	m.cleanup(true)
+}
+
+func (m *Manager) cleanup(preserveState bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	m.preserveStateOnExit.Store(preserveState)
 
 	for _, ctx := range m.contexts {
+		if !preserveState && ctx.persistence != nil {
+			ctx.persistence.disable()
+		}
 		ctx.Stop()
 	}
 
 	m.contexts = make(map[string]*Context)
+	if !preserveState && m.stateStore != nil {
+		_ = m.stateStore.Clear()
+	}
 }
 
 func (m *Manager) cleanupExpired() {

--- a/manager/procd/pkg/context/state_store.go
+++ b/manager/procd/pkg/context/state_store.go
@@ -1,0 +1,216 @@
+package context
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/process"
+	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/process/repl"
+	"github.com/sandbox0-ai/sandbox0/pkg/procdstate"
+)
+
+type persistedContext struct {
+	Version       int                   `json:"version"`
+	ID            string                `json:"id"`
+	Config        process.ProcessConfig `json:"config"`
+	REPLConfig    *repl.REPLConfig      `json:"repl_config,omitempty"`
+	CleanupPolicy CleanupPolicy         `json:"cleanup_policy"`
+	DesiredState  process.ProcessState  `json:"desired_state"`
+	CreatedAt     time.Time             `json:"created_at"`
+	UpdatedAt     time.Time             `json:"updated_at"`
+}
+
+type contextStateStore interface {
+	Save(persistedContext) error
+	Delete(string) error
+	Load() ([]persistedContext, error)
+	Clear() error
+}
+
+// FileStateStore persists context definitions in the sandbox webhook-state volume.
+type FileStateStore struct {
+	dir         string
+	requestPath string
+}
+
+func NewFileStateStore(dir string) (*FileStateStore, error) {
+	dir = filepath.Clean(strings.TrimSpace(dir))
+	if dir == "." || !filepath.IsAbs(dir) {
+		return nil, fmt.Errorf("context state directory must be absolute")
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("create context state directory: %w", err)
+	}
+	return &FileStateStore{
+		dir:         dir,
+		requestPath: filepath.Join(filepath.Dir(dir), procdstate.RecoveryRequestFilename),
+	}, nil
+}
+
+func (s *FileStateStore) Save(record persistedContext) error {
+	if s == nil {
+		return nil
+	}
+	path, err := s.contextPath(record.ID)
+	if err != nil {
+		return err
+	}
+	record.Version = 1
+	record.UpdatedAt = time.Now().UTC()
+	data, err := json.Marshal(record)
+	if err != nil {
+		return fmt.Errorf("marshal context state: %w", err)
+	}
+	tmp, err := os.CreateTemp(s.dir, ".context-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create context state temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return fmt.Errorf("chmod context state temp file: %w", err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write context state: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return fmt.Errorf("sync context state: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close context state: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("publish context state: %w", err)
+	}
+	return syncDirectory(s.dir)
+}
+
+func (s *FileStateStore) Delete(id string) error {
+	if s == nil {
+		return nil
+	}
+	path, err := s.contextPath(id)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("delete context state: %w", err)
+	}
+	return syncDirectory(s.dir)
+}
+
+func (s *FileStateStore) Load() ([]persistedContext, error) {
+	if s == nil {
+		return nil, nil
+	}
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		return nil, fmt.Errorf("list context states: %w", err)
+	}
+	records := make([]persistedContext, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(s.dir, entry.Name()))
+		if err != nil {
+			return nil, fmt.Errorf("read context state %s: %w", entry.Name(), err)
+		}
+		var record persistedContext
+		if err := json.Unmarshal(data, &record); err != nil {
+			return nil, fmt.Errorf("decode context state %s: %w", entry.Name(), err)
+		}
+		if record.Version != 1 || record.ID == "" {
+			return nil, fmt.Errorf("unsupported context state %s", entry.Name())
+		}
+		recordPath, err := s.contextPath(record.ID)
+		if err != nil || filepath.Base(recordPath) != entry.Name() {
+			return nil, fmt.Errorf("context state %s has invalid id %q", entry.Name(), record.ID)
+		}
+		records = append(records, record)
+	}
+	sort.Slice(records, func(i, j int) bool { return records[i].ID < records[j].ID })
+	return records, nil
+}
+
+func (s *FileStateStore) Clear() error {
+	if s == nil {
+		return nil
+	}
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		return fmt.Errorf("list context states: %w", err)
+	}
+	var errs []error
+	for _, entry := range entries {
+		isRecord := strings.HasSuffix(entry.Name(), ".json")
+		isTemporary := strings.HasPrefix(entry.Name(), ".context-") && strings.HasSuffix(entry.Name(), ".tmp")
+		if entry.IsDir() || (!isRecord && !isTemporary) {
+			continue
+		}
+		if err := os.Remove(filepath.Join(s.dir, entry.Name())); err != nil && !errors.Is(err, os.ErrNotExist) {
+			errs = append(errs, fmt.Errorf("delete context state %s: %w", entry.Name(), err))
+		}
+	}
+	if len(errs) == 0 {
+		return syncDirectory(s.dir)
+	}
+	return errors.Join(errs...)
+}
+
+// ConsumeRecoveryRequest removes and reports the one-shot ctld recovery marker.
+func (s *FileStateStore) ConsumeRecoveryRequest() (bool, error) {
+	if s == nil {
+		return false, nil
+	}
+	if _, err := os.Stat(s.requestPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, fmt.Errorf("inspect context recovery request: %w", err)
+	}
+	if err := os.Remove(s.requestPath); err != nil {
+		return false, fmt.Errorf("consume context recovery request: %w", err)
+	}
+	return true, syncDirectory(filepath.Dir(s.requestPath))
+}
+
+func (s *FileStateStore) RecoveryRequested() (bool, error) {
+	if s == nil {
+		return false, nil
+	}
+	_, err := os.Stat(s.requestPath)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	return false, fmt.Errorf("inspect context recovery request: %w", err)
+}
+
+func (s *FileStateStore) contextPath(id string) (string, error) {
+	id = strings.TrimSpace(id)
+	if id == "" || filepath.Base(id) != id || strings.ContainsAny(id, `/\\`) {
+		return "", fmt.Errorf("invalid context id %q", id)
+	}
+	return filepath.Join(s.dir, id+".json"), nil
+}
+
+func syncDirectory(path string) error {
+	dir, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer dir.Close()
+	return dir.Sync()
+}

--- a/manager/procd/pkg/context/state_store_test.go
+++ b/manager/procd/pkg/context/state_store_test.go
@@ -1,0 +1,198 @@
+package context
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/process"
+)
+
+func TestFileStateStoreRoundTripAndRecoveryRequest(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "contexts")
+	store, err := NewFileStateStore(dir)
+	if err != nil {
+		t.Fatalf("NewFileStateStore() error = %v", err)
+	}
+	record := persistedContext{
+		ID:           "ctx-test",
+		Config:       process.ProcessConfig{Type: process.ProcessTypeCMD, Command: []string{"/bin/sleep", "10"}},
+		DesiredState: process.ProcessStateRunning,
+		CreatedAt:    time.Now().UTC(),
+	}
+	if err := store.Save(record); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	records, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(records) != 1 || records[0].ID != record.ID || records[0].DesiredState != process.ProcessStateRunning {
+		t.Fatalf("Load() = %#v, want running %s", records, record.ID)
+	}
+
+	if err := os.WriteFile(store.requestPath, []byte("requested\n"), 0o600); err != nil {
+		t.Fatalf("write recovery request: %v", err)
+	}
+	requested, err := store.RecoveryRequested()
+	if err != nil || !requested {
+		t.Fatalf("RecoveryRequested() = %v, %v, want true, nil", requested, err)
+	}
+	consumed, err := store.ConsumeRecoveryRequest()
+	if err != nil || !consumed {
+		t.Fatalf("ConsumeRecoveryRequest() = %v, %v, want true, nil", consumed, err)
+	}
+	requested, err = store.RecoveryRequested()
+	if err != nil || requested {
+		t.Fatalf("RecoveryRequested() after consume = %v, %v, want false, nil", requested, err)
+	}
+}
+
+func TestFileStateStoreClearRemovesMalformedRecords(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "contexts")
+	store, err := NewFileStateStore(dir)
+	if err != nil {
+		t.Fatalf("NewFileStateStore() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "broken.json"), []byte("{"), 0o600); err != nil {
+		t.Fatalf("write malformed record: %v", err)
+	}
+	if err := store.Clear(); err != nil {
+		t.Fatalf("Clear() error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "broken.json")); !os.IsNotExist(err) {
+		t.Fatalf("malformed record still exists: %v", err)
+	}
+}
+
+func TestManagerRestoreContextsReplaysRunningAndPausedDefinitions(t *testing.T) {
+	tests := []struct {
+		name   string
+		paused bool
+	}{
+		{name: "running"},
+		{name: "paused", paused: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store, err := NewFileStateStore(filepath.Join(t.TempDir(), "contexts"))
+			if err != nil {
+				t.Fatalf("NewFileStateStore() error = %v", err)
+			}
+			first := NewManager()
+			first.SetStateStore(store)
+			created, err := first.CreateContext(process.ProcessConfig{
+				Type:    process.ProcessTypeCMD,
+				Command: []string{"/bin/sh", "-c", "while :; do sleep 1; done"},
+				EnvVars: map[string]string{"RECOVERED": "true"},
+			})
+			if err != nil {
+				t.Fatalf("CreateContext() error = %v", err)
+			}
+			if tt.paused {
+				if err := first.PauseAll(); err != nil {
+					t.Fatalf("PauseAll() error = %v", err)
+				}
+			}
+			first.CleanupPreservingState()
+
+			second := NewManager()
+			second.SetStateStore(store)
+			restored, err := second.RestoreContexts()
+			if err != nil {
+				t.Fatalf("RestoreContexts() error = %v", err)
+			}
+			t.Cleanup(second.Cleanup)
+			if len(restored) != 1 {
+				t.Fatalf("len(restored) = %d, want 1", len(restored))
+			}
+			if restored[0].ID != created.ID {
+				t.Fatalf("restored ID = %q, want %q", restored[0].ID, created.ID)
+			}
+			if restored[0].EnvVars["RECOVERED"] != "true" {
+				t.Fatalf("restored env = %#v", restored[0].EnvVars)
+			}
+			if tt.paused && !restored[0].IsPaused() {
+				t.Fatal("restored context is not paused")
+			}
+			if !tt.paused && !restored[0].IsRunning() {
+				t.Fatal("restored context is not running")
+			}
+		})
+	}
+}
+
+func TestManagerRestoreContextsSkipsFinishedContext(t *testing.T) {
+	store, err := NewFileStateStore(filepath.Join(t.TempDir(), "contexts"))
+	if err != nil {
+		t.Fatalf("NewFileStateStore() error = %v", err)
+	}
+	first := NewManager()
+	first.SetStateStore(store)
+	_, err = first.CreateContext(process.ProcessConfig{
+		Type:    process.ProcessTypeCMD,
+		Command: []string{"/bin/true"},
+	})
+	if err != nil {
+		t.Fatalf("CreateContext() error = %v", err)
+	}
+	waitForCondition(t, func() bool {
+		records, loadErr := store.Load()
+		return loadErr == nil && len(records) == 1 &&
+			records[0].DesiredState != process.ProcessStateRunning &&
+			records[0].DesiredState != process.ProcessStatePaused
+	})
+	first.CleanupPreservingState()
+
+	second := NewManager()
+	second.SetStateStore(store)
+	restored, err := second.RestoreContexts()
+	if err != nil {
+		t.Fatalf("RestoreContexts() error = %v", err)
+	}
+	if len(restored) != 0 {
+		second.Cleanup()
+		t.Fatalf("len(restored) = %d, want 0", len(restored))
+	}
+}
+
+func TestManagerDeleteContextDoesNotRecreateStateFromAsyncExit(t *testing.T) {
+	store, err := NewFileStateStore(filepath.Join(t.TempDir(), "contexts"))
+	if err != nil {
+		t.Fatalf("NewFileStateStore() error = %v", err)
+	}
+	manager := NewManager()
+	manager.SetStateStore(store)
+	ctx, err := manager.CreateContext(process.ProcessConfig{
+		Type:    process.ProcessTypeCMD,
+		Command: []string{"/bin/sh", "-c", "while :; do sleep 1; done"},
+	})
+	if err != nil {
+		t.Fatalf("CreateContext() error = %v", err)
+	}
+	if err := manager.DeleteContext(ctx.ID); err != nil {
+		t.Fatalf("DeleteContext() error = %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+	records, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(records) != 0 {
+		t.Fatalf("persisted records = %#v, want none", records)
+	}
+}
+
+func waitForCondition(t *testing.T, condition func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("condition was not met before timeout")
+}

--- a/pkg/procdstate/paths.go
+++ b/pkg/procdstate/paths.go
@@ -1,0 +1,9 @@
+// Package procdstate defines the durable paths shared by procd and node recovery.
+package procdstate
+
+const (
+	RootDir                 = "/var/lib/sandbox0/procd"
+	ContextStateDir         = RootDir + "/contexts"
+	RecoveryRequestFilename = ".context-recovery-requested"
+	RecoveryRequestPath     = RootDir + "/" + RecoveryRequestFilename
+)

--- a/tests/e2e/cases/api_fullmode.go
+++ b/tests/e2e/cases/api_fullmode.go
@@ -4,16 +4,17 @@ import "github.com/sandbox0-ai/sandbox0/pkg/framework"
 
 func registerApiFullModeSuite(envProvider func() *framework.ScenarioEnv) {
 	registerApiModeSuite(envProvider, apiModeSuiteOptions{
-		name:                     "fullmode",
-		describe:                 "API full mode",
-		templateNamePrefix:       "e2e-fullmode",
-		fileContent:              "hello fullmode",
-		includeTemplateStatus:    true,
-		includePoolReadinessGate: true,
-		includeNetworkPolicy:     true,
-		includeVolumeLifecycle:   true,
-		includeObjectEncryption:  true,
-		includeWebhookLifecycle:  true,
-		includeRootFSPauseResume: true,
+		name:                       "fullmode",
+		describe:                   "API full mode",
+		templateNamePrefix:         "e2e-fullmode",
+		fileContent:                "hello fullmode",
+		includeTemplateStatus:      true,
+		includePoolReadinessGate:   true,
+		includeNetworkPolicy:       true,
+		includeVolumeLifecycle:     true,
+		includeObjectEncryption:    true,
+		includeWebhookLifecycle:    true,
+		includeRootFSPauseResume:   true,
+		includeCtldRestartRecovery: true,
 	})
 }

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -40,6 +40,7 @@ type apiModeSuiteOptions struct {
 	includeObjectEncryption     bool
 	includeWebhookLifecycle     bool
 	includeRootFSPauseResume    bool
+	includeCtldRestartRecovery  bool
 	includeMeteringAssertions   bool
 	includeUsageQuotaAssertions bool
 	expectStorageUnavailable    bool
@@ -240,6 +241,12 @@ func registerApiModeSuite(envProvider func() *framework.ScenarioEnv, opts apiMod
 			It("performs file operations and process management", func() {
 				assertFilesystemAndProcessCapabilities(env, session, sandboxID, opts.name, opts.fileContent)
 			})
+
+			if opts.includeCtldRestartRecovery {
+				It("recovers process definitions after ctld restarts", func() {
+					assertProcessRecoveryAfterCtldRestart(env, session, sandboxID)
+				})
+			}
 		})
 
 		if opts.includeNetworkPolicy {
@@ -1729,6 +1736,117 @@ func assertFilesystemAndProcessCapabilities(env *framework.ScenarioEnv, session 
 	status, err = session.DeleteContext(env.TestCtx.Context, GinkgoT(), sandboxID, ctxResp.Id)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(status).To(Equal(http.StatusOK))
+}
+
+func assertProcessRecoveryAfterCtldRestart(env *framework.ScenarioEnv, session *e2eutils.Session, sandboxID string) {
+	templateNamespace, err := naming.TemplateNamespaceForBuiltin("default")
+	Expect(err).NotTo(HaveOccurred())
+	sandbox := waitForSandboxPodReadyEventually(env, session, sandboxID, templateNamespace)
+
+	markerPath := fmt.Sprintf("/workspace/ctld-recovery-%d.log", time.Now().UnixNano())
+	processType := apispec.ProcessTypeCmd
+	ttlSec := int32(300)
+	ctxResp, status, err := session.CreateContext(env.TestCtx.Context, GinkgoT(), sandboxID, apispec.CreateContextRequest{
+		Type: &processType,
+		Cmd: &apispec.CreateCMDContextRequest{Command: []string{
+			"/bin/sh", "-lc", fmt.Sprintf("printf 'start\\n' >> %s; while :; do sleep 1; done", shellQuote(markerPath)),
+		}},
+		TtlSec: &ttlSec,
+	})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusCreated))
+	Expect(ctxResp).NotTo(BeNil())
+	DeferCleanup(func() {
+		_, _ = session.DeleteContext(env.TestCtx.Context, GinkgoT(), sandboxID, ctxResp.Id)
+	})
+
+	Eventually(func() (string, error) {
+		body, _, readErr := session.ReadFile(env.TestCtx.Context, GinkgoT(), sandboxID, markerPath)
+		return string(body), readErr
+	}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Equal("start\n"))
+
+	nodeName, err := framework.KubectlGetJSONPath(
+		env.TestCtx.Context, env.Config.Kubeconfig, templateNamespace, "pod", sandbox.PodName, "{.spec.nodeName}",
+	)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(nodeName).NotTo(BeEmpty())
+	originalContainerID, err := framework.KubectlGetJSONPath(
+		env.TestCtx.Context, env.Config.Kubeconfig, templateNamespace, "pod", sandbox.PodName,
+		`{.status.containerStatuses[?(@.name=="procd")].containerID}`,
+	)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(originalContainerID).NotTo(BeEmpty())
+
+	selector := fmt.Sprintf("app.kubernetes.io/instance=%s,app.kubernetes.io/component=ctld", env.Infra.Name)
+	ctldPod, err := framework.KubectlOutput(
+		env.TestCtx.Context,
+		env.Config.Kubeconfig,
+		"get", "pods",
+		"--namespace", env.Infra.Namespace,
+		"--selector", selector,
+		"--field-selector", "spec.nodeName="+nodeName,
+		"-o", "jsonpath={.items[0].metadata.name}",
+	)
+	Expect(err).NotTo(HaveOccurred())
+	ctldPod = strings.TrimSpace(ctldPod)
+	Expect(ctldPod).NotTo(BeEmpty())
+	Expect(framework.Kubectl(
+		env.TestCtx.Context, env.Config.Kubeconfig,
+		"delete", "pod", ctldPod, "--namespace", env.Infra.Namespace, "--wait=true", "--timeout=2m",
+	)).To(Succeed())
+
+	Eventually(func() error {
+		replacement, getErr := framework.KubectlOutput(
+			env.TestCtx.Context,
+			env.Config.Kubeconfig,
+			"get", "pods",
+			"--namespace", env.Infra.Namespace,
+			"--selector", selector,
+			"--field-selector", "spec.nodeName="+nodeName,
+			"-o", "jsonpath={.items[0].metadata.name}",
+		)
+		if getErr != nil {
+			return getErr
+		}
+		replacement = strings.TrimSpace(replacement)
+		if replacement == "" || replacement == ctldPod {
+			return fmt.Errorf("ctld replacement pod is not ready")
+		}
+		return framework.KubectlWaitForCondition(
+			env.TestCtx.Context, env.Config.Kubeconfig, env.Infra.Namespace, "pod", replacement, "Ready", "10s",
+		)
+	}).WithTimeout(3 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
+
+	Eventually(func() error {
+		containerID, getErr := framework.KubectlGetJSONPath(
+			env.TestCtx.Context, env.Config.Kubeconfig, templateNamespace, "pod", sandbox.PodName,
+			`{.status.containerStatuses[?(@.name=="procd")].containerID}`,
+		)
+		if getErr != nil {
+			return getErr
+		}
+		if containerID == "" || containerID == originalContainerID {
+			return fmt.Errorf("procd container has not been replaced")
+		}
+		contexts, listStatus, listErr := session.ListContexts(env.TestCtx.Context, GinkgoT(), sandboxID)
+		if listErr != nil {
+			return listErr
+		}
+		if listStatus != http.StatusOK {
+			return fmt.Errorf("list contexts status = %d", listStatus)
+		}
+		for _, recovered := range contexts {
+			if recovered.Id == ctxResp.Id && recovered.Running {
+				return nil
+			}
+		}
+		return fmt.Errorf("running recovered context %s not found", ctxResp.Id)
+	}).WithTimeout(3 * time.Minute).WithPolling(3 * time.Second).Should(Succeed())
+
+	Eventually(func() (int, error) {
+		body, _, readErr := session.ReadFile(env.TestCtx.Context, GinkgoT(), sandboxID, markerPath)
+		return strings.Count(string(body), "start\n"), readErr
+	}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(BeNumerically(">=", 2))
 }
 
 func assertSandboxNetworkIsolation(env *framework.ScenarioEnv, session *e2eutils.Session) {


### PR DESCRIPTION
## Summary

- reconstruct CSI/FUSE portals for every live sandbox pod after ctld loses its in-memory portal registry, preserving unbound rootfs backing and rebinding SandboxVolumes from pod metadata
- replace stale procd containers after all portals for a pod are healthy; idle-pool pods restart without replay, while active sandboxes receive a one-shot recovery marker
- persist effective procd context definitions in the existing webhook-state SandboxVolume and replay running or paused contexts with the same context ID after the replacement container starts
- use one CRI container snapshot and 16-way bounded replacement concurrency so recovery remains linear at high pod density
- add a fullmode e2e that deletes ctld on the sandbox node and verifies procd replacement, stable context identity, and command replay on the preserved rootfs

This is a follow-up to #674. Reconstructing the host mount alone is insufficient because the existing gVisor gofer still holds file descriptors for the dead FUSE session.

## Recovery contract

Recovered:

- context ID and creation time
- process type, command, CWD, effective environment, PTY settings, and custom REPL configuration
- running versus paused desired state
- unbound rootfs-backed portal data and bound SandboxVolume contents

Not recovered:

- PID, process memory, open file descriptors, sockets, REPL input history, or existing WebSocket connections
- completed or deleted contexts

## Validation

- `go test -race -count=1 ./ctld/... ./manager/procd/... ./manager/cmd/procd`
- CI-equivalent full non-e2e `go test -race -count=1` package set
- `go test ./tests/e2e/cases`
- `golangci-lint v2.5.0 run ./...`
- `go vet ./manager/procd/... ./manager/cmd/procd ./ctld/... ./pkg/procdstate`
- `make proto manifests apispec`
- `helm lint infra-operator/chart`
