### PR TITLE
feat: add generic procd session supervisor

### DIFF
--- a/cluster-gateway/pkg/http/handlers_procd_authz_test.go
+++ b/cluster-gateway/pkg/http/handlers_procd_authz_test.go
@@ -37,6 +37,36 @@ func TestSandboxProcdRoutesRequireReadWritePermissions(t *testing.T) {
 			permissions: []string{gatewayauthn.PermSandboxRead},
 		},
 		{
+			name:        "session create requires sandbox write",
+			method:      http.MethodPost,
+			path:        "/api/v1/sandboxes/sb-1/sessions",
+			permissions: []string{gatewayauthn.PermSandboxRead},
+		},
+		{
+			name:        "session input requires sandbox write",
+			method:      http.MethodPost,
+			path:        "/api/v1/sandboxes/sb-1/sessions/ses-1/inputs",
+			permissions: []string{gatewayauthn.PermSandboxRead},
+		},
+		{
+			name:        "session websocket requires sandbox write",
+			method:      http.MethodGet,
+			path:        "/api/v1/sandboxes/sb-1/sessions/ses-1/ws",
+			permissions: []string{gatewayauthn.PermSandboxRead},
+		},
+		{
+			name:        "session list requires sandbox read",
+			method:      http.MethodGet,
+			path:        "/api/v1/sandboxes/sb-1/sessions",
+			permissions: []string{gatewayauthn.PermSandboxWrite},
+		},
+		{
+			name:        "session event stream requires sandbox read",
+			method:      http.MethodGet,
+			path:        "/api/v1/sandboxes/sb-1/sessions/ses-1/events/stream",
+			permissions: []string{gatewayauthn.PermSandboxWrite},
+		},
+		{
 			name:        "context delete requires sandbox write",
 			method:      http.MethodDelete,
 			path:        "/api/v1/sandboxes/sb-1/contexts/ctx-1",

--- a/cluster-gateway/pkg/http/handlers_session.go
+++ b/cluster-gateway/pkg/http/handlers_session.go
@@ -1,0 +1,85 @@
+package http
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
+	"github.com/sandbox0-ai/sandbox0/pkg/proxy"
+)
+
+func (s *Server) proxySessionCollection(c *gin.Context) {
+	sandboxID, ok := requireSandboxID(c)
+	if !ok {
+		return
+	}
+	s.proxyToSandboxProcdPath(c, sandboxID, "/api/v1/sessions")
+}
+
+func (s *Server) proxySessionItem(c *gin.Context) {
+	s.proxySandboxSessionSuffix(c, "")
+}
+
+func (s *Server) proxySessionDesiredState(c *gin.Context) {
+	s.proxySandboxSessionSuffix(c, "/desired-state")
+}
+
+func (s *Server) proxySessionAttempts(c *gin.Context) {
+	s.proxySandboxSessionSuffix(c, "/attempts")
+}
+
+func (s *Server) proxySessionInputs(c *gin.Context) {
+	s.proxySandboxSessionSuffix(c, "/inputs")
+}
+
+func (s *Server) proxySessionSignals(c *gin.Context) {
+	s.proxySandboxSessionSuffix(c, "/signals")
+}
+
+func (s *Server) proxySessionTerminal(c *gin.Context) {
+	s.proxySandboxSessionSuffix(c, "/terminal")
+}
+
+func (s *Server) proxySessionEvents(c *gin.Context) {
+	s.proxySandboxSessionSuffix(c, "/events")
+}
+
+func (s *Server) proxySessionEventStream(c *gin.Context) {
+	s.proxySandboxSessionSuffix(c, "/events/stream")
+}
+
+func (s *Server) proxySessionWebSocket(c *gin.Context) {
+	sandboxID, sessionID, ok := requireSandboxSessionIDs(c)
+	if !ok {
+		return
+	}
+	procdURL, err := s.getProcdURL(c, sandboxID)
+	if err != nil {
+		return
+	}
+	requestModifier, err := s.buildProcdRequestModifier(c)
+	if err != nil {
+		return
+	}
+	c.Request.URL.Path = "/api/v1/sessions/" + url.PathEscape(sessionID) + "/ws"
+	proxy.NewWebSocketProxy(s.logger, proxy.WithRequestModifier(requestModifier)).Proxy(procdURL)(c)
+}
+
+func (s *Server) proxySandboxSessionSuffix(c *gin.Context, suffix string) {
+	sandboxID, sessionID, ok := requireSandboxSessionIDs(c)
+	if !ok {
+		return
+	}
+	s.proxyToSandboxProcdPath(c, sandboxID, "/api/v1/sessions/"+url.PathEscape(sessionID)+suffix)
+}
+
+func requireSandboxSessionIDs(c *gin.Context) (string, string, bool) {
+	sandboxID := c.Param("id")
+	sessionID := c.Param("session_id")
+	if sandboxID == "" || sessionID == "" {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "sandbox_id and session_id are required")
+		return "", "", false
+	}
+	return sandboxID, sessionID, true
+}

--- a/cluster-gateway/pkg/http/sandbox_service_policy_test.go
+++ b/cluster-gateway/pkg/http/sandbox_service_policy_test.go
@@ -587,25 +587,23 @@ func TestSandboxFunctionServiceProxiesWebSocketAfterPausedAutoResume(t *testing.
 	}
 }
 
-func TestSandboxCMDServiceStartsContextBeforeProxy(t *testing.T) {
+func TestSandboxCMDServiceStartsSessionBeforeProxy(t *testing.T) {
 	var created atomic.Bool
-	var createReq procdCreateContextRequest
+	var createReq procdSessionSpec
 	procd := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/contexts":
-			_ = spec.WriteSuccess(w, http.StatusOK, procdContextListResponse{})
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/contexts":
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/sessions":
+			_ = spec.WriteSuccess(w, http.StatusOK, procdSessionListResponse{})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/sessions":
 			if err := json.NewDecoder(r.Body).Decode(&createReq); err != nil {
-				t.Fatalf("decode create context request: %v", err)
+				t.Fatalf("decode create session request: %v", err)
+			}
+			if got := r.Header.Get("Idempotency-Key"); got != "sandbox-service-runtime:api" {
+				t.Fatalf("Idempotency-Key = %q", got)
 			}
 			created.Store(true)
-			_ = spec.WriteSuccess(w, http.StatusCreated, procdContextResponse{
-				ID:      "ctx-service",
-				Type:    "cmd",
-				Command: createReq.Cmd.Command,
-				CWD:     createReq.CWD,
-				EnvVars: createReq.EnvVars,
-				Running: true,
+			_ = spec.WriteSuccess(w, http.StatusCreated, procdSessionResponse{
+				ID: "ses-service", Spec: createReq, Phase: "running",
 			})
 		default:
 			t.Fatalf("unexpected procd request %s %s", r.Method, r.URL.Path)
@@ -615,7 +613,7 @@ func TestSandboxCMDServiceStartsContextBeforeProxy(t *testing.T) {
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !created.Load() {
-			t.Fatalf("upstream hit before cmd context was created")
+			t.Fatalf("upstream hit before cmd session was created")
 		}
 		if r.URL.Path == "/healthz" {
 			w.WriteHeader(http.StatusNoContent)
@@ -672,14 +670,115 @@ func TestSandboxCMDServiceStartsContextBeforeProxy(t *testing.T) {
 	if string(body) != "cmd ok" {
 		t.Fatalf("body = %q, want cmd ok", string(body))
 	}
-	if createReq.Type != "cmd" || createReq.Cmd == nil || len(createReq.Cmd.Command) == 0 {
-		t.Fatalf("create context request = %+v, want cmd command", createReq)
+	if createReq.Name != "sandbox-service:api" || len(createReq.Command) == 0 || createReq.IO.Mode != "pipes" {
+		t.Fatalf("create session request = %+v, want supervised pipe command", createReq)
 	}
-	if createReq.EnvVars[sandboxServiceRuntimeServiceIDEnv] != "api" || createReq.EnvVars[sandboxServiceRuntimePortEnv] != strconv.Itoa(port) {
-		t.Fatalf("service env vars = %#v, want service identity and port", createReq.EnvVars)
+	if createReq.Env[sandboxServiceRuntimeServiceIDEnv] != "api" || createReq.Env[sandboxServiceRuntimePortEnv] != strconv.Itoa(port) {
+		t.Fatalf("service env vars = %#v, want service identity and port", createReq.Env)
 	}
-	if createReq.EnvVars["APP_ENV"] != "test" {
-		t.Fatalf("APP_ENV = %q, want test", createReq.EnvVars["APP_ENV"])
+	if createReq.Env["APP_ENV"] != "test" {
+		t.Fatalf("APP_ENV = %q, want test", createReq.Env["APP_ENV"])
+	}
+	if createReq.Lifecycle.Restart.Policy != "on_failure" || createReq.Lifecycle.RuntimeRecovery != "restart" {
+		t.Fatalf("lifecycle = %#v, want restartable session", createReq.Lifecycle)
+	}
+}
+
+func TestEnsureSandboxCMDServiceReconcilesExistingSession(t *testing.T) {
+	service := &mgr.SandboxAppService{
+		ID:   "api",
+		Port: 8080,
+		Runtime: &mgr.SandboxAppServiceRuntime{
+			Type:    mgr.SandboxAppServiceRuntimeCMD,
+			Command: []string{"server", "--port", "8080"},
+			CWD:     "/workspace",
+			EnvVars: map[string]string{"APP_ENV": "test"},
+		},
+	}
+	desired := sandboxServiceCMDSessionSpec(service)
+
+	tests := []struct {
+		name          string
+		candidate     procdSessionResponse
+		wantPath      string
+		assertRequest func(*testing.T, *http.Request)
+	}{
+		{
+			name:      "restart exited matching session",
+			candidate: procdSessionResponse{ID: "ses-service", Spec: desired, Phase: "exited"},
+			wantPath:  "/api/v1/sessions/ses-service/desired-state",
+			assertRequest: func(t *testing.T, r *http.Request) {
+				var request map[string]string
+				if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+					t.Fatal(err)
+				}
+				if request["state"] != "running" {
+					t.Fatalf("desired state request = %#v", request)
+				}
+			},
+		},
+		{
+			name: "replace drifted session spec",
+			candidate: procdSessionResponse{
+				ID: "ses-service",
+				Spec: procdSessionSpec{
+					Name:      desired.Name,
+					Command:   []string{"old-server"},
+					CWD:       desired.CWD,
+					Env:       desired.Env,
+					IO:        desired.IO,
+					Lifecycle: desired.Lifecycle,
+				},
+				Phase: "running",
+			},
+			wantPath: "/api/v1/sessions/ses-service",
+			assertRequest: func(t *testing.T, r *http.Request) {
+				var request procdSessionSpec
+				if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+					t.Fatal(err)
+				}
+				if !sandboxServiceSessionSpecMatches(request, desired) {
+					t.Fatalf("updated spec = %#v, want %#v", request, desired)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var reconciled atomic.Bool
+			procd := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodGet && r.URL.Path == "/api/v1/sessions":
+					_ = spec.WriteSuccess(w, http.StatusOK, procdSessionListResponse{Sessions: []procdSessionResponse{tt.candidate}})
+				case r.Method == http.MethodPut && r.URL.Path == tt.wantPath:
+					tt.assertRequest(t, r)
+					reconciled.Store(true)
+					_ = spec.WriteSuccess(w, http.StatusOK, procdSessionResponse{ID: tt.candidate.ID, Spec: desired, Phase: "running"})
+				default:
+					t.Fatalf("unexpected procd request %s %s", r.Method, r.URL.Path)
+				}
+			}))
+			defer procd.Close()
+
+			_, privateKey, err := ed25519.GenerateKey(nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			server := &Server{
+				logger: zap.NewNop(),
+				internalAuthGen: internalauth.NewGenerator(internalauth.GeneratorConfig{
+					Caller: "cluster-gateway", PrivateKey: privateKey, TTL: time.Minute,
+				}),
+			}
+			sandbox := &mgr.Sandbox{ID: "sb-demo", TeamID: "team-1", UserID: "user-1", InternalAddr: procd.URL}
+			if err := server.ensureSandboxServiceCMDSession(t.Context(), sandbox, service); err != nil {
+				t.Fatal(err)
+			}
+			if !reconciled.Load() {
+				t.Fatal("existing session was not reconciled")
+			}
+		})
 	}
 }
 
@@ -687,11 +786,11 @@ func TestSandboxCMDServiceStartsAfterPausedAutoResume(t *testing.T) {
 	var created atomic.Bool
 	procd := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/contexts":
-			_ = spec.WriteSuccess(w, http.StatusOK, procdContextListResponse{})
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/contexts":
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/sessions":
+			_ = spec.WriteSuccess(w, http.StatusOK, procdSessionListResponse{})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/sessions":
 			created.Store(true)
-			_ = spec.WriteSuccess(w, http.StatusCreated, procdContextResponse{ID: "ctx-service", Type: "cmd", Running: true})
+			_ = spec.WriteSuccess(w, http.StatusCreated, procdSessionResponse{ID: "ses-service", Phase: "running"})
 		default:
 			t.Fatalf("unexpected procd request %s %s", r.Method, r.URL.Path)
 		}
@@ -700,7 +799,7 @@ func TestSandboxCMDServiceStartsAfterPausedAutoResume(t *testing.T) {
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !created.Load() {
-			t.Fatalf("upstream hit before cmd context was created")
+			t.Fatalf("upstream hit before cmd session was created")
 		}
 		_, _ = w.Write([]byte("resumed cmd ok"))
 	}))
@@ -764,7 +863,7 @@ func TestSandboxCMDServiceStartsAfterPausedAutoResume(t *testing.T) {
 		t.Fatal("manager resume was not called")
 	}
 	if !created.Load() {
-		t.Fatal("cmd context was not created after resume")
+		t.Fatal("cmd session was not created after resume")
 	}
 }
 

--- a/cluster-gateway/pkg/http/sandbox_service_runtime.go
+++ b/cluster-gateway/pkg/http/sandbox_service_runtime.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -29,29 +28,37 @@ const (
 
 var errSandboxServiceReadinessTimeout = errors.New("sandbox service did not become ready")
 
-type procdContextListResponse struct {
-	Contexts []procdContextResponse `json:"contexts"`
+type procdSessionListResponse struct {
+	Sessions []procdSessionResponse `json:"sessions"`
 }
 
-type procdContextResponse struct {
-	ID      string            `json:"id"`
-	Type    string            `json:"type"`
-	Command []string          `json:"command,omitempty"`
-	CWD     string            `json:"cwd"`
-	EnvVars map[string]string `json:"env_vars"`
-	Running bool              `json:"running"`
-	Paused  bool              `json:"paused"`
+type procdSessionResponse struct {
+	ID    string           `json:"id"`
+	Spec  procdSessionSpec `json:"spec"`
+	Phase string           `json:"phase"`
 }
 
-type procdCreateContextRequest struct {
-	Type    string                        `json:"type"`
-	Cmd     *procdCreateCMDContextRequest `json:"cmd,omitempty"`
-	CWD     string                        `json:"cwd,omitempty"`
-	EnvVars map[string]string             `json:"env_vars,omitempty"`
+type procdSessionSpec struct {
+	Name      string                `json:"name,omitempty"`
+	Command   []string              `json:"command"`
+	CWD       string                `json:"cwd,omitempty"`
+	Env       map[string]string     `json:"env,omitempty"`
+	IO        procdSessionIO        `json:"io,omitempty"`
+	Lifecycle procdSessionLifecycle `json:"lifecycle,omitempty"`
 }
 
-type procdCreateCMDContextRequest struct {
-	Command []string `json:"command"`
+type procdSessionIO struct {
+	Mode string `json:"mode"`
+}
+
+type procdSessionLifecycle struct {
+	DesiredState    string              `json:"desired_state"`
+	Restart         procdSessionRestart `json:"restart"`
+	RuntimeRecovery string              `json:"runtime_recovery"`
+}
+
+type procdSessionRestart struct {
+	Policy string `json:"policy"`
 }
 
 func (s *Server) ensureSandboxServiceRuntime(ctx context.Context, sandbox *mgr.Sandbox, service *mgr.SandboxAppService, route *mgr.SandboxAppServiceRoute) error {
@@ -63,14 +70,8 @@ func (s *Server) ensureSandboxServiceRuntime(ctx context.Context, sandbox *mgr.S
 		if len(service.Runtime.Command) == 0 {
 			return errors.New("cmd runtime command is required")
 		}
-		running, err := s.sandboxServiceCMDContextRunning(ctx, sandbox, service)
-		if err != nil {
+		if err := s.ensureSandboxServiceCMDSession(ctx, sandbox, service); err != nil {
 			return err
-		}
-		if !running {
-			if err := s.createSandboxServiceCMDContext(ctx, sandbox, service); err != nil {
-				return err
-			}
 		}
 		return s.waitSandboxServiceReady(ctx, sandbox, service, route)
 	default:
@@ -78,46 +79,81 @@ func (s *Server) ensureSandboxServiceRuntime(ctx context.Context, sandbox *mgr.S
 	}
 }
 
-func (s *Server) sandboxServiceCMDContextRunning(ctx context.Context, sandbox *mgr.Sandbox, service *mgr.SandboxAppService) (bool, error) {
-	var list procdContextListResponse
-	if err := s.doSandboxProcdJSON(ctx, sandbox, http.MethodGet, "/api/v1/contexts", nil, &list); err != nil {
-		return false, err
+func (s *Server) ensureSandboxServiceCMDSession(ctx context.Context, sandbox *mgr.Sandbox, service *mgr.SandboxAppService) error {
+	var list procdSessionListResponse
+	if err := s.doSandboxProcdJSON(ctx, sandbox, http.MethodGet, "/api/v1/sessions", nil, &list); err != nil {
+		return err
 	}
-	for _, candidate := range list.Contexts {
-		if sandboxServiceContextMatchesCMD(candidate, service) {
-			return true, nil
+	desired := sandboxServiceCMDSessionSpec(service)
+	for _, candidate := range list.Sessions {
+		if candidate.Spec.Name != desired.Name {
+			continue
+		}
+		if !sandboxServiceSessionSpecMatches(candidate.Spec, desired) {
+			var updated procdSessionResponse
+			return s.doSandboxProcdJSON(ctx, sandbox, http.MethodPut, "/api/v1/sessions/"+url.PathEscape(candidate.ID), desired, &updated)
+		}
+		switch candidate.Phase {
+		case "pending", "starting", "running", "backoff":
+			return nil
+		default:
+			request := map[string]string{"state": "running"}
+			var updated procdSessionResponse
+			return s.doSandboxProcdJSON(ctx, sandbox, http.MethodPut, "/api/v1/sessions/"+url.PathEscape(candidate.ID)+"/desired-state", request, &updated)
 		}
 	}
-	return false, nil
+	return s.createSandboxServiceCMDSession(ctx, sandbox, service)
 }
 
-func sandboxServiceContextMatchesCMD(ctx procdContextResponse, service *mgr.SandboxAppService) bool {
-	if service == nil || service.Runtime == nil {
+func sandboxServiceSessionSpecMatches(value, desired procdSessionSpec) bool {
+	if value.Name != desired.Name || !equalStrings(value.Command, desired.Command) {
 		return false
 	}
-	if ctx.Type != "cmd" || !ctx.Running || ctx.Paused {
+	if strings.TrimSpace(value.CWD) != strings.TrimSpace(desired.CWD) || value.IO.Mode != desired.IO.Mode {
 		return false
 	}
-	if ctx.EnvVars[sandboxServiceRuntimeServiceIDEnv] != service.ID {
+	if value.Lifecycle.DesiredState != desired.Lifecycle.DesiredState ||
+		value.Lifecycle.Restart.Policy != desired.Lifecycle.Restart.Policy ||
+		value.Lifecycle.RuntimeRecovery != desired.Lifecycle.RuntimeRecovery {
 		return false
 	}
-	if !slices.Equal(ctx.Command, service.Runtime.Command) {
+	if len(value.Env) != len(desired.Env) {
 		return false
 	}
-	return strings.TrimSpace(ctx.CWD) == strings.TrimSpace(service.Runtime.CWD)
+	for key, desiredValue := range desired.Env {
+		if value.Env[key] != desiredValue {
+			return false
+		}
+	}
+	return true
 }
 
-func (s *Server) createSandboxServiceCMDContext(ctx context.Context, sandbox *mgr.Sandbox, service *mgr.SandboxAppService) error {
-	req := procdCreateContextRequest{
-		Type: "cmd",
-		Cmd: &procdCreateCMDContextRequest{
-			Command: service.Runtime.Command,
-		},
+func sandboxServiceCMDSessionSpec(service *mgr.SandboxAppService) procdSessionSpec {
+	return procdSessionSpec{
+		Name:    sandboxServiceRuntimeSessionName(service.ID),
+		Command: service.Runtime.Command,
 		CWD:     service.Runtime.CWD,
-		EnvVars: sandboxServiceRuntimeEnvVars(service),
+		Env:     sandboxServiceRuntimeEnvVars(service),
+		IO:      procdSessionIO{Mode: "pipes"},
+		Lifecycle: procdSessionLifecycle{
+			DesiredState: "running",
+			Restart: procdSessionRestart{
+				Policy: "on_failure",
+			},
+			RuntimeRecovery: "restart",
+		},
 	}
-	var created procdContextResponse
-	return s.doSandboxProcdJSON(ctx, sandbox, http.MethodPost, "/api/v1/contexts", req, &created)
+}
+
+func (s *Server) createSandboxServiceCMDSession(ctx context.Context, sandbox *mgr.Sandbox, service *mgr.SandboxAppService) error {
+	req := sandboxServiceCMDSessionSpec(service)
+	var created procdSessionResponse
+	headers := http.Header{"Idempotency-Key": []string{"sandbox-service-runtime:" + service.ID}}
+	return s.doSandboxProcdJSONWithHeaders(ctx, sandbox, http.MethodPost, "/api/v1/sessions", req, headers, &created)
+}
+
+func sandboxServiceRuntimeSessionName(serviceID string) string {
+	return "sandbox-service:" + serviceID
 }
 
 func sandboxServiceRuntimeEnvVars(service *mgr.SandboxAppService) map[string]string {
@@ -132,6 +168,10 @@ func sandboxServiceRuntimeEnvVars(service *mgr.SandboxAppService) map[string]str
 }
 
 func (s *Server) doSandboxProcdJSON(ctx context.Context, sandbox *mgr.Sandbox, method, path string, payload any, out any) error {
+	return s.doSandboxProcdJSONWithHeaders(ctx, sandbox, method, path, payload, nil, out)
+}
+
+func (s *Server) doSandboxProcdJSONWithHeaders(ctx context.Context, sandbox *mgr.Sandbox, method, path string, payload any, headers http.Header, out any) error {
 	if sandbox == nil {
 		return errors.New("sandbox is required")
 	}
@@ -157,6 +197,11 @@ func (s *Server) doSandboxProcdJSON(ctx context.Context, sandbox *mgr.Sandbox, m
 	}
 	req.Header.Set(internalauth.DefaultTokenHeader, token)
 	req.Header.Set("Content-Type", "application/json")
+	for key, values := range headers {
+		for _, value := range values {
+			req.Header.Add(key, value)
+		}
+	}
 
 	resp, err := s.outboundHTTPClient().Do(req)
 	if err != nil {
@@ -188,6 +233,18 @@ func (s *Server) doSandboxProcdJSON(ctx context.Context, sandbox *mgr.Sandbox, m
 		return err
 	}
 	return nil
+}
+
+func equalStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func (s *Server) waitSandboxServiceReady(ctx context.Context, sandbox *mgr.Sandbox, service *mgr.SandboxAppService, route *mgr.SandboxAppServiceRoute) error {

--- a/cluster-gateway/pkg/http/server.go
+++ b/cluster-gateway/pkg/http/server.go
@@ -514,6 +514,24 @@ func (s *Server) setupRoutes() {
 }
 
 func (s *Server) registerSandboxProcdRoutes(sandboxes *gin.RouterGroup) {
+	// === Durable execution sessions (→ Procd) ===
+	sessions := sandboxes.Group("/:id/sessions")
+	{
+		sessions.GET("", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxRead), s.proxySessionCollection)
+		sessions.POST("", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxWrite), s.proxySessionCollection)
+		sessions.GET("/:session_id", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxRead), s.proxySessionItem)
+		sessions.PUT("/:session_id", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxWrite), s.proxySessionItem)
+		sessions.DELETE("/:session_id", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxWrite), s.proxySessionItem)
+		sessions.PUT("/:session_id/desired-state", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxWrite), s.proxySessionDesiredState)
+		sessions.POST("/:session_id/attempts", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxWrite), s.proxySessionAttempts)
+		sessions.POST("/:session_id/inputs", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxWrite), s.proxySessionInputs)
+		sessions.POST("/:session_id/signals", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxWrite), s.proxySessionSignals)
+		sessions.PUT("/:session_id/terminal", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxWrite), s.proxySessionTerminal)
+		sessions.GET("/:session_id/events", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxRead), s.proxySessionEvents)
+		sessions.GET("/:session_id/events/stream", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxRead), s.proxySessionEventStream)
+		sessions.GET("/:session_id/ws", s.authMiddleware.RequirePermission(gatewayauthn.PermSandboxWrite), s.proxySessionWebSocket)
+	}
+
 	// === Process/Context Management (→ Procd) ===
 	contexts := sandboxes.Group("/:id/contexts")
 	{

--- a/ctld/internal/ctld/portal/manager.go
+++ b/ctld/internal/ctld/portal/manager.go
@@ -428,9 +428,6 @@ func (m *Manager) RootFSPortalPaths(podUID string) []ctldapi.RootFSPortalPath {
 		if pm == nil || pm.podUID != podUID || pm.volumeID != "" {
 			continue
 		}
-		if pm.name == volumeportal.WebhookStatePortalName || pm.mountPath == volumeportal.WebhookStateMountPath {
-			continue
-		}
 		if strings.TrimSpace(pm.mountPath) == "" || strings.TrimSpace(pm.rootfsBackingPath) == "" {
 			continue
 		}

--- a/ctld/internal/ctld/portal/manager_shared_test.go
+++ b/ctld/internal/ctld/portal/manager_shared_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 	"github.com/sandbox0-ai/sandbox0/pkg/volumefuse"
+	"github.com/sandbox0-ai/sandbox0/pkg/volumeportal"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volume"
 )
 
@@ -124,6 +125,33 @@ func TestCheckPublishedReportsMissingPortals(t *testing.T) {
 	}
 	if len(resp.Missing) != 1 || resp.Missing[0] != "cache" {
 		t.Fatalf("CheckPublished() missing = %v, want [cache]", resp.Missing)
+	}
+}
+
+func TestRootFSPortalPathsIncludesUnboundSystemState(t *testing.T) {
+	mgr := &Manager{portals: map[string]*portalMount{
+		"system": {
+			podUID:            "pod-uid",
+			name:              volumeportal.WebhookStatePortalName,
+			mountPath:         volumeportal.WebhookStateMountPath,
+			rootfsBackingPath: "/var/lib/sandbox0/ctld/rootfs/pod-uid/system",
+		},
+		"bound": {
+			podUID:            "pod-uid",
+			name:              "workspace",
+			mountPath:         "/workspace",
+			rootfsBackingPath: "/var/lib/sandbox0/ctld/rootfs/pod-uid/workspace",
+			volumeID:          "vol-1",
+		},
+	}}
+
+	got := mgr.RootFSPortalPaths("pod-uid")
+	if len(got) != 1 {
+		t.Fatalf("RootFSPortalPaths() = %#v, want one unbound portal", got)
+	}
+	if got[0].PortalName != volumeportal.WebhookStatePortalName ||
+		got[0].MountPath != volumeportal.WebhookStateMountPath {
+		t.Fatalf("RootFSPortalPaths()[0] = %#v, want system state portal", got[0])
 	}
 }
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -54,6 +54,10 @@
           "title": "Contexts"
         },
         {
+          "slug": "session-supervisor",
+          "title": "Session Supervisor"
+        },
+        {
           "slug": "files",
           "title": "Files"
         },

--- a/docs/sandbox/contexts/page.mdx
+++ b/docs/sandbox/contexts/page.mdx
@@ -2,6 +2,10 @@
 
 Contexts are execution units within a sandbox. Each context runs a process and can be either a **REPL** (stateful) or **Cmd** (stateless) type.
 
+<Callout variant="info">
+Use the [Session Supervisor](/docs/sandbox/session-supervisor) when the process needs a stable identity, replayable output, explicit EOF, reconnect-safe attachments, or recovery as a new attempt after sandbox runtime replacement.
+</Callout>
+
 ## Context Types
 
 | Type | Description | Use Case |

--- a/docs/sandbox/page.mdx
+++ b/docs/sandbox/page.mdx
@@ -81,7 +81,7 @@ When the cluster claim/start admission budget is full, the claim API returns `42
 
 See [Network](/docs/sandbox/network) and [Protocol Controls](/docs/sandbox/protocol-controls) for outbound control, [Sandbox Services](/docs/sandbox/services) for public HTTP controls, [Sandbox Functions](/docs/sandbox/functions) for inline public handlers, and [Credential](/docs/sandbox/credential) for outbound auth and secret handling.
 
-Sandbox `env_vars` override template/container environment variables for new contexts, command services, and function executions. Per-context, per-command, service runtime, and function `env_vars` override sandbox `env_vars` for that narrower scope. Warm processes start before the sandbox is claimed, so they do not receive claim-time sandbox `env_vars`.
+Sandbox `env_vars` override template/container environment variables for new contexts, supervised session attempts, command services, and function executions. Per-context, per-session, per-command, service runtime, and function `env_vars` override sandbox `env_vars` for that narrower scope. Warm processes start before the sandbox is claimed, so they do not receive claim-time sandbox `env_vars`.
 
 ### Sandbox Resources
 
@@ -648,5 +648,9 @@ console.log('Sandbox deleted');`
 
   <Card title="Contexts" href="/docs/sandbox/contexts" cta="Continue">
     Run REPL and command contexts inside a sandbox and stream process output.
+  </Card>
+
+  <Card title="Session Supervisor" href="/docs/sandbox/session-supervisor" cta="Continue">
+    Run reconnect-safe processes with stable identities, attempts, and retained events.
   </Card>
 </CardGroup>

--- a/docs/sandbox/pause-resume/page.mdx
+++ b/docs/sandbox/pause-resume/page.mdx
@@ -177,17 +177,19 @@ console.log("runtimeGeneration=", sb.runtimeGeneration);`
 
 Common auto-resume entrypoints:
 
-- sandbox runtime APIs such as files and contexts
+- sandbox runtime APIs such as files, contexts, and supervised sessions
 - service routes configured with `resume: true`; public service requests require sandbox `auto_resume: true`, route `resume: true`, and a restartable service runtime (`cmd` or `function`)
 - SSH access through Sandbox0 SSH Gateway
 
 For a paused sandbox, auto-resume creates a new runtime pod for the same sandbox identity and restores the saved rootfs checkpoint before the sandbox is used. Public service URLs remain stable until the sandbox is explicitly deleted or `hard_ttl` expires.
 
+Running PIDs, memory, sockets, and client attachments do not survive pause. A [supervised session](/docs/sandbox/session-supervisor) keeps its logical identity and retained journal, then follows its `runtime_recovery` policy in the new runtime generation.
+
 See [Sandbox Services](/docs/sandbox/services), [Sandbox Functions](/docs/sandbox/functions), and [SSH](/docs/sandbox/ssh) for the user-facing flows.
 
 ## Typical Pattern
 
-For long-running agent workflows, a common pattern is:
+For long-running workflows, a common pattern is:
 
 1. claim a sandbox with `ttl` set
 2. do active work through contexts and files
@@ -200,6 +202,10 @@ For long-running agent workflows, a common pattern is:
 <CardGroup>
   <Card title="Contexts" href="/docs/sandbox/contexts" cta="Continue">
     Run REPL and command contexts inside a sandbox and stream process output.
+  </Card>
+
+  <Card title="Session Supervisor" href="/docs/sandbox/session-supervisor" cta="Continue">
+    Preserve logical process identity and replayable events across reconnects and runtime replacement.
   </Card>
 
   <Card title="Files" href="/docs/sandbox/files" cta="Continue">

--- a/docs/sandbox/session-supervisor/page.mdx
+++ b/docs/sandbox/session-supervisor/page.mdx
@@ -1,0 +1,369 @@
+# Session Supervisor
+
+The Session Supervisor runs and observes long-lived processes inside a sandbox. A session has a stable identity, one current process attempt, and a retained event journal. Client connections are attachments to that state; they do not own it.
+
+Use a supervised session when a process must continue across API reconnects, expose replayable output, accept explicit stdin and EOF, or recover after the sandbox runtime is replaced. Use [Contexts](/docs/sandbox/contexts) for short-lived command execution and REPL-oriented workflows that do not need a durable event journal.
+
+<Callout variant="info">
+Closing an HTTP response, SSE stream, or WebSocket never stops the session and never closes process stdin. Stop, delete, signal, and EOF are explicit operations.
+</Callout>
+
+## Execution Model
+
+| Object | Lifetime | Meaning |
+|--------|----------|---------|
+| Session | Stable until deleted, sandbox hard TTL, or sandbox deletion | Desired process specification and lifecycle policy |
+| Attempt | One operating-system process execution | Changes after a restart, replacement, or runtime recovery |
+| Event | Retained according to the session policy | Ordered state, output, control, and exit record |
+| Attachment | One SSE or WebSocket connection | Ephemeral view over retained and live events |
+
+Every event has a monotonically increasing `seq`. Process-bound operations can include `expected_attempt_id` so stale clients cannot write to, signal, or resize a newer attempt accidentally.
+
+### Connection Choice
+
+| Connection | Use it for | Reconnect behavior |
+|------------|------------|--------------------|
+| HTTP | Create, inspect, update, stop, delete, input, signal, resize, and paged event reads | Retry normal requests; use `Idempotency-Key`, `input_id`, and `expected_attempt_id` where applicable |
+| SSE | One-way retained and live event consumption | Reconnect with `Last-Event-ID` or `after`; deduplicate by `seq` |
+| WebSocket | Duplex input/control plus retained and live events | Reconnect with `after`; the session and stdin remain unchanged while disconnected |
+
+SSE is the simplest default for output consumers. WebSocket is useful for interactive PTY attachments, but it does not change the lifecycle or delivery model.
+
+## SDK Quickstart
+
+These examples attach to an existing sandbox from `SANDBOX0_SANDBOX_ID`, start `/bin/cat`, send one input followed by explicit EOF, consume the journal, then prove the session still exists after the stream is closed.
+
+<Tabs
+  tabs={[
+    {
+      label: "Go",
+      language: "go",
+      code: `package main
+
+import (
+    "context"
+    "encoding/base64"
+    "fmt"
+    "io"
+    "log"
+    "os"
+    "time"
+
+    sandbox0 "github.com/sandbox0-ai/sdk-go"
+    "github.com/sandbox0-ai/sdk-go/pkg/apispec"
+)
+
+func main() {
+    ctx := context.Background()
+    options := []sandbox0.Option{
+        sandbox0.WithToken(os.Getenv("SANDBOX0_TOKEN")),
+    }
+    if baseURL := os.Getenv("SANDBOX0_BASE_URL"); baseURL != "" {
+        options = append(options, sandbox0.WithBaseURL(baseURL))
+    }
+    client, err := sandbox0.NewClient(options...)
+    if err != nil {
+        log.Fatal(err)
+    }
+    sandbox := client.Sandbox(os.Getenv("SANDBOX0_SANDBOX_ID"))
+
+    created, err := sandbox.CreateSession(ctx, apispec.ExecutionSessionSpec{
+        Name:    apispec.NewOptString("docs-pipe"),
+        Command: []string{"/bin/cat"},
+        Io: apispec.NewOptExecutionSessionIOSpec(apispec.ExecutionSessionIOSpec{
+            Mode: apispec.NewOptExecutionSessionIOMode(apispec.ExecutionSessionIOModePipes),
+        }),
+    }, &sandbox0.CreateSessionOptions{
+        IdempotencyKey: fmt.Sprintf("docs-%d", time.Now().UnixNano()),
+    })
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer sandbox.DeleteSession(ctx, created.ID)
+
+    attempt, ok := created.Attempt.Get()
+    if !ok {
+        log.Fatal("session has no current attempt")
+    }
+    stream, err := sandbox.WatchSessionEvents(ctx, created.ID, nil)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    _, err = sandbox.WriteSessionInput(ctx, created.ID, apispec.ExecutionSessionInputRequest{
+        InputID:           fmt.Sprintf("input-%d", time.Now().UnixNano()),
+        ExpectedAttemptID: apispec.NewOptString(attempt.ID),
+        DataBase64:        apispec.NewOptString(base64.StdEncoding.EncodeToString([]byte("hello from Go\\n"))),
+        EOF:               apispec.NewOptBool(true),
+    })
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    var lastSeq int64
+    for {
+        event, err := stream.Recv()
+        if err != nil {
+            if err == io.EOF {
+                break
+            }
+            log.Fatal(err)
+        }
+        lastSeq = event.Seq
+        if encoded, ok := event.DataBase64.Get(); ok {
+            data, err := base64.StdEncoding.DecodeString(encoded)
+            if err != nil {
+                log.Fatal(err)
+            }
+            fmt.Print(string(data))
+        }
+        if event.Type == "attempt.exited" {
+            break
+        }
+    }
+    if err := stream.Close(); err != nil {
+        log.Fatal(err)
+    }
+    current, err := sandbox.GetSession(ctx, created.ID)
+    if err != nil {
+        log.Fatal(err)
+    }
+    fmt.Printf("session=%s phase=%s cursor=%d\\n", current.ID, current.Phase, lastSeq)
+}`
+    },
+    {
+      label: "Python",
+      language: "python",
+      code: `import base64
+import os
+import time
+
+from sandbox0 import Client, SessionCreateOptions
+from sandbox0.apispec.models.execution_session_input_request import ExecutionSessionInputRequest
+from sandbox0.apispec.models.execution_session_io_mode import ExecutionSessionIOMode
+from sandbox0.apispec.models.execution_session_io_spec import ExecutionSessionIOSpec
+from sandbox0.apispec.models.execution_session_spec import ExecutionSessionSpec
+
+with Client(
+    token=os.environ["SANDBOX0_TOKEN"],
+    base_url=os.environ.get("SANDBOX0_BASE_URL", "https://api.sandbox0.ai"),
+) as client:
+    sandbox = client.sandbox(os.environ["SANDBOX0_SANDBOX_ID"])
+    session = sandbox.create_session(
+        ExecutionSessionSpec(
+            name="docs-pipe",
+            command=["/bin/cat"],
+            io=ExecutionSessionIOSpec(mode=ExecutionSessionIOMode.PIPES),
+        ),
+        SessionCreateOptions(idempotency_key=f"docs-{time.time_ns()}"),
+    )
+    try:
+        attempt_id = session.to_dict()["attempt"]["id"]
+        stream = sandbox.watch_session_events(session.id)
+        sandbox.write_session_input(
+            session.id,
+            ExecutionSessionInputRequest(
+                input_id=f"input-{time.time_ns()}",
+                expected_attempt_id=attempt_id,
+                data_base64=base64.b64encode(b"hello from Python\\n").decode(),
+                eof=True,
+            ),
+        )
+
+        last_seq = 0
+        with stream:
+            for event in stream.iter_events():
+                value = event.to_dict()
+                last_seq = value["seq"]
+                if "data_base64" in value:
+                    print(base64.b64decode(value["data_base64"]).decode(), end="")
+                if value["type"] == "attempt.exited":
+                    break
+
+        current = sandbox.get_session(session.id)
+        print(f"session={current.id} phase={current.phase} cursor={last_seq}")
+    finally:
+        sandbox.delete_session(session.id)`
+    },
+    {
+      label: "TypeScript",
+      language: "typescript",
+      code: `import { randomUUID } from 'node:crypto';
+import { Client } from 'sandbox0';
+
+const client = new Client({
+    token: process.env.SANDBOX0_TOKEN!,
+    baseUrl: process.env.SANDBOX0_BASE_URL || 'https://api.sandbox0.ai',
+});
+const sandbox = client.sandbox(process.env.SANDBOX0_SANDBOX_ID!);
+
+const session = await sandbox.createSession({
+    name: 'docs-pipe',
+    command: ['/bin/cat'],
+    io: { mode: 'pipes' },
+}, { idempotencyKey: \`docs-\${randomUUID()}\` });
+
+try {
+    const attemptId = session.attempt?.id;
+    if (!attemptId) throw new Error('session has no current attempt');
+    const stream = await sandbox.watchSessionEvents(session.id);
+    await sandbox.writeSessionInput(session.id, {
+        inputId: \`input-\${randomUUID()}\`,
+        expectedAttemptId: attemptId,
+        dataBase64: Buffer.from('hello from TypeScript\\n').toString('base64'),
+        eof: true,
+    });
+
+    let lastSeq = 0;
+    for await (const event of stream) {
+        lastSeq = event.seq;
+        if (event.dataBase64) {
+            process.stdout.write(Buffer.from(event.dataBase64, 'base64'));
+        }
+        if (event.type === 'attempt.exited') break;
+    }
+    await stream.close();
+    const current = await sandbox.getSession(session.id);
+    console.log(\`session=\${current.id} phase=\${current.phase} cursor=\${lastSeq}\`);
+} finally {
+    await sandbox.deleteSession(session.id);
+}`
+    },
+    {
+      label: "CLI",
+      language: "bash",
+      code: `set -euo pipefail
+
+SANDBOX_ID="\${SANDBOX0_SANDBOX_ID}"
+SESSION_ID=""
+cleanup() {
+    if [[ -n "\${SESSION_ID}" ]]; then
+        s0 sandbox session delete "\${SANDBOX_ID}" "\${SESSION_ID}" >/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+created="$(s0 -o json sandbox session create "\${SANDBOX_ID}" \\
+    --name docs-pipe --idempotency-key "docs-\${RANDOM}-$$" -- /bin/cat)"
+SESSION_ID="$(jq -r '.id' <<<"\${created}")"
+ATTEMPT_ID="$(jq -r '.attempt.id' <<<"\${created}")"
+
+s0 sandbox session input "\${SANDBOX_ID}" "\${SESSION_ID}" \\
+    --attempt-id "\${ATTEMPT_ID}" --input-id "input-\${RANDOM}-$$" \\
+    --data $'hello from CLI\\n' --eof
+
+for _ in $(seq 1 50); do
+    phase="$(s0 -o json sandbox session get "\${SANDBOX_ID}" "\${SESSION_ID}" | jq -r '.phase')"
+    [[ "\${phase}" == "exited" ]] && break
+    sleep 0.1
+done
+
+s0 -o json sandbox session events "\${SANDBOX_ID}" "\${SESSION_ID}" \\
+    | jq -r '.events[] | select(.type == "output") | .data_base64' \\
+    | base64 -d`
+    }
+  ]}
+/>
+
+## Input, EOF, and Attempt Fencing
+
+`POST /inputs` accepts base64-encoded bytes, explicit EOF, or both. The response means the operation was accepted into the current attempt's input queue; it does not mean the application consumed the bytes.
+
+- Generate a unique `input_id` for each logical write.
+- Reuse the same `input_id` and content when retrying an ambiguous request. Once its receipt is durable, the server returns `duplicate: true` without queueing it again.
+- Include `expected_attempt_id` when input belongs to a particular process attempt. A newer attempt causes `409 session_conflict` instead of receiving stale input.
+- Set `eof: true` to close stdin after earlier queued bytes. Disconnecting an attachment is never EOF.
+
+No process API can provide exactly-once application consumption. If the runtime fails after bytes reach the process but before the input receipt is durable, a retry can replay them. Design the application protocol to tolerate this ambiguity when it matters.
+
+## Retained Events and Reconnect
+
+Paged reads and streams share the same journal cursor:
+
+1. Process each event and remember its `seq` after the side effect commits.
+2. Reconnect SSE with `Last-Event-ID: <seq>` or reconnect SSE/WebSocket with `?after=<seq>`.
+3. Deduplicate by `seq`; replay is expected.
+
+For a limited HTTP page, continue with the final event's `seq`. The page's `cursor.earliest` and `cursor.latest` describe the full retained window, not the next-page position.
+
+The default retention is 64 MiB and 24 hours per session. A cursor older than retained history returns `410 event_cursor_expired` and reports the earliest sequence in the retained window. Reconcile current session state with `GET /sessions/{'{session_id}'}`, then resume with `after=earliest-1` (or `after=latest` when the retained window is empty), or apply application-specific recovery.
+
+Slow live subscribers can be detached when their in-memory delivery buffer fills. This does not lose retained journal data; reconnect from the last committed sequence.
+
+## Attempts, Restart, and Runtime Recovery
+
+An attempt ID identifies one process execution. It changes when:
+
+- the restart policy starts the process again after exit
+- a client creates or replaces an attempt
+- an execution-relevant session specification is replaced
+- a paused or replaced sandbox runtime is restored and `runtime_recovery` is `restart`
+
+The session ID and event sequence remain stable across these boundaries. `runtime_generation` distinguishes events and attempts produced by different sandbox runtime instances.
+
+| Policy | Values | Default behavior |
+|--------|--------|------------------|
+| `restart.policy` | `never`, `on_failure`, `always` | `never` |
+| `restart.max_restarts` | Non-negative integer | 5 restarts within the window |
+| `restart.window_seconds` | Non-negative integer | 60 seconds |
+| `restart.initial_backoff_ms` / `max_backoff_ms` | Non-negative integers | Exponential backoff from 250 ms to 5 s |
+| `runtime_recovery` | `restart`, `stop` | Start a new attempt after runtime replacement |
+| `idle_timeout_seconds` | 0 or positive integer | 0 disables session idle expiry |
+| `max_lifetime_seconds` | 0 or positive integer | 0 disables session lifetime expiry |
+
+Sandbox pause stops the current runtime after flushing session state into the checkpointed root filesystem. Resume creates a new runtime generation. It does not restore the old PID, memory, sockets, or terminal connection; it either creates a new attempt or leaves the session stopped according to `runtime_recovery`.
+
+## Readiness
+
+Readiness controls when an attempt moves from `starting` to `running`:
+
+| Type | Ready when |
+|------|------------|
+| `process` | The operating-system process starts |
+| `delay` | `delay_ms` elapses while the attempt remains alive |
+| `output` | The configured byte sequence appears across stdout, stderr, or PTY output |
+
+For `delay` and `output`, `timeout_ms` terminates an attempt that never becomes ready. Readiness observes process bytes only; it does not interpret an application protocol.
+
+## PTY Sessions
+
+Set `io.mode` to `pty` with initial `rows`, `cols`, and `term`. Use `PUT /terminal` or a WebSocket `resize` message to update the terminal size. Use `expected_attempt_id` on resize and signal messages to prevent a stale terminal attachment from controlling a replacement attempt.
+
+PTY output is emitted as `stream: "pty"`. Pipe sessions keep stdout and stderr separate.
+
+## CLI Reference
+
+| Command | Purpose |
+|---------|---------|
+| `s0 sandbox session list <sandbox-id>` | List sessions |
+| `s0 sandbox session create <sandbox-id> -- <command...>` | Create and start a session |
+| `s0 sandbox session create <sandbox-id> --spec-file session.yaml` | Create from the complete API specification |
+| `s0 sandbox session get <sandbox-id> <session-id>` | Inspect phase, attempt, generation, and cursor |
+| `s0 sandbox session update <sandbox-id> <session-id> --spec-file session.yaml` | Replace the specification with `PUT` semantics |
+| `s0 sandbox session start\|stop <sandbox-id> <session-id>` | Set desired state |
+| `s0 sandbox session attempt <sandbox-id> <session-id> --replace` | Replace the current attempt explicitly |
+| `s0 sandbox session input <sandbox-id> <session-id> ...` | Queue UTF-8, base64, or file input and optional EOF |
+| `s0 sandbox session signal <sandbox-id> <session-id> TERM` | Signal the current attempt |
+| `s0 sandbox session resize <sandbox-id> <session-id> <rows> <cols>` | Resize a PTY |
+| `s0 sandbox session events <sandbox-id> <session-id> --after <seq>` | Read retained events |
+| `s0 sandbox session events <sandbox-id> <session-id> --follow --last-event-id <seq>` | Follow retained and live events over SSE |
+| `s0 sandbox session delete <sandbox-id> <session-id>` | Stop and delete the identity and journal |
+
+## HTTP API
+
+All public paths are scoped by sandbox:
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET`, `POST` | `/api/v1/sandboxes/{'{id}'}/sessions` | List or create |
+| `GET`, `PUT`, `DELETE` | `/api/v1/sandboxes/{'{id}'}/sessions/{'{session_id}'}` | Inspect, replace, or delete |
+| `PUT` | `/api/v1/sandboxes/{'{id}'}/sessions/{'{session_id}'}/desired-state` | Start or stop |
+| `POST` | `/api/v1/sandboxes/{'{id}'}/sessions/{'{session_id}'}/attempts` | Create or replace an attempt |
+| `POST` | `/api/v1/sandboxes/{'{id}'}/sessions/{'{session_id}'}/inputs` | Queue input or EOF |
+| `POST` | `/api/v1/sandboxes/{'{id}'}/sessions/{'{session_id}'}/signals` | Send a signal |
+| `PUT` | `/api/v1/sandboxes/{'{id}'}/sessions/{'{session_id}'}/terminal` | Resize a PTY |
+| `GET` | `/api/v1/sandboxes/{'{id}'}/sessions/{'{session_id}'}/events` | Read retained events |
+| `GET` | `/api/v1/sandboxes/{'{id}'}/sessions/{'{session_id}'}/events/stream` | Attach with SSE |
+| `GET` | `/api/v1/sandboxes/{'{id}'}/sessions/{'{session_id}'}/ws` | Attach with WebSocket |
+
+Deleting the sandbox or reaching its hard TTL deletes its sessions. Deleting an individual session stops its current attempt and removes its retained state.

--- a/docs/sandbox/ssh/page.mdx
+++ b/docs/sandbox/ssh/page.mdx
@@ -127,7 +127,7 @@ sftp -i ~/.ssh/sandbox0_ed25519 -P "$SSH_PORT" "$SSH_USER@$SSH_HOST"
 - SSH authorization stays at the platform layer. You do not manage `authorized_keys` inside each sandbox.
 - Uploaded SSH public keys belong to the user account, not to one sandbox.
 - A key can access any sandbox that the user is authorized to access in that region.
-- SSH is best for human shell access and standard file transfer. For programmatic process control, use [Contexts](/docs/sandbox/contexts).
+- SSH is best for human shell access and standard file transfer. For programmatic process control, use [Contexts](/docs/sandbox/contexts), or use the [Session Supervisor](/docs/sandbox/session-supervisor) when reconnect and runtime recovery matter.
 
 ---
 

--- a/infra-operator/api/config/procd.go
+++ b/infra-operator/api/config/procd.go
@@ -57,11 +57,15 @@ type ProcdConfig struct {
 	// +optional
 	// +kubebuilder:default="/var/lib/sandbox0/procd/webhook-outbox"
 	WebhookOutboxDir string `yaml:"webhook_outbox_dir" json:"webhookOutboxDir"`
+	// +optional
+	// +kubebuilder:default="/var/lib/sandbox0/procd/sessions"
+	SessionStateDir string `yaml:"session_state_dir" json:"sessionStateDir"`
 
 	setKeys map[string]bool `yaml:"-" json:"-"`
 }
 
 const DefaultWebhookOutboxDir = "/var/lib/sandbox0/procd/webhook-outbox"
+const DefaultSessionStateDir = "/var/lib/sandbox0/procd/sessions"
 
 // UnmarshalYAML captures configured keys without hardcoding them.
 func (c *ProcdConfig) UnmarshalYAML(value *yaml.Node) error {
@@ -128,13 +132,23 @@ var (
 // LoadProcdConfig returns the procd configuration.
 func LoadProcdConfig() *ProcdConfig {
 	procdCfgOnce.Do(func() {
-		cfg := ProcdConfig{WebhookOutboxDir: DefaultWebhookOutboxDir}
+		cfg := ProcdConfig{
+			WebhookOutboxDir: DefaultWebhookOutboxDir,
+			SessionStateDir:  DefaultSessionStateDir,
+		}
 		if err := applyProcdEnvOverrides(&cfg); err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to apply procd env overrides: %v\n", err)
 		}
+		cfg.applyDefaults()
 		procdCfg = &cfg
 	})
 	return procdCfg
+}
+
+func (c *ProcdConfig) applyDefaults() {
+	if strings.TrimSpace(c.SessionStateDir) == "" {
+		c.SessionStateDir = DefaultSessionStateDir
+	}
 }
 
 // Validate checks if the configuration is valid.

--- a/infra-operator/api/config/procd_test.go
+++ b/infra-operator/api/config/procd_test.go
@@ -1,0 +1,19 @@
+package config
+
+import "testing"
+
+func TestProcdConfigApplyDefaultsRestoresEmptySessionStateDir(t *testing.T) {
+	cfg := ProcdConfig{SessionStateDir: "  "}
+	cfg.applyDefaults()
+	if cfg.SessionStateDir != DefaultSessionStateDir {
+		t.Fatalf("session state dir = %q, want %q", cfg.SessionStateDir, DefaultSessionStateDir)
+	}
+}
+
+func TestProcdConfigApplyDefaultsPreservesCustomSessionStateDir(t *testing.T) {
+	cfg := ProcdConfig{SessionStateDir: "/custom/procd/sessions"}
+	cfg.applyDefaults()
+	if cfg.SessionStateDir != "/custom/procd/sessions" {
+		t.Fatalf("session state dir = %q, want custom path", cfg.SessionStateDir)
+	}
+}

--- a/infra-operator/internal/runtimeconfig/dataplane.go
+++ b/infra-operator/internal/runtimeconfig/dataplane.go
@@ -59,6 +59,7 @@ func ToManager(spec *infrav1alpha1.ManagerConfig) *apiconfig.ManagerConfig {
 		WebhookMaxRetries:      spec.ProcdConfig.WebhookMaxRetries,
 		WebhookBaseBackoff:     spec.ProcdConfig.WebhookBaseBackoff,
 		WebhookOutboxDir:       webhookOutboxDir,
+		SessionStateDir:        apiconfig.DefaultSessionStateDir,
 	}
 	cfg.Autoscaler = apiconfig.AutoscalerConfig{
 		MinScaleInterval:        spec.Autoscaler.MinScaleInterval,

--- a/infra-operator/internal/runtimeconfig/dataplane_test.go
+++ b/infra-operator/internal/runtimeconfig/dataplane_test.go
@@ -22,6 +22,9 @@ func TestToManagerLeavesProcdWebhookOutboxDirUnsetWhenOmitted(t *testing.T) {
 	if cfg.ProcdConfig.WebhookOutboxDir != "" {
 		t.Fatalf("webhook outbox dir = %q, want empty path", cfg.ProcdConfig.WebhookOutboxDir)
 	}
+	if cfg.ProcdConfig.SessionStateDir != "/var/lib/sandbox0/procd/sessions" {
+		t.Fatalf("session state dir = %q, want persistent procd path", cfg.ProcdConfig.SessionStateDir)
+	}
 }
 
 func TestToManagerPreservesProcdWebhookOutboxDir(t *testing.T) {

--- a/manager/cmd/procd/main.go
+++ b/manager/cmd/procd/main.go
@@ -16,6 +16,8 @@ import (
 	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/file"
 	procdhttp "github.com/sandbox0-ai/sandbox0/manager/procd/pkg/http"
 	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/process"
+	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/reaper"
+	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/session"
 	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/trust"
 	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/webhook"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
@@ -24,9 +26,6 @@ import (
 )
 
 func main() {
-	// // Start the reaper to clean up zombie processes
-	// go reaper.Reap()
-
 	// Load configuration
 	cfg := config.LoadProcdConfig()
 
@@ -45,6 +44,9 @@ func main() {
 		os.Exit(1)
 	}
 	defer logger.Sync()
+	reaperCtx, reaperCancel := context.WithCancel(context.Background())
+	defer reaperCancel()
+	go reaper.Run(reaperCtx, logger)
 
 	logger.Info("Starting Procd",
 		zap.String("version", "1.0.0"),
@@ -70,7 +72,15 @@ func main() {
 	// Initialize managers
 	configureProcessOutputForwarding(logger)
 
-	contextManager := ctxpkg.NewManager()
+	sessionStore, err := session.NewFileStore(cfg.SessionStateDir)
+	if err != nil {
+		logger.Fatal("Failed to create session state store", zap.Error(err))
+	}
+	sessionSupervisor, err := session.NewSupervisor(sessionStore, logger)
+	if err != nil {
+		logger.Fatal("Failed to create session supervisor", zap.Error(err))
+	}
+	contextManager := ctxpkg.NewManagerWithSupervisor(sessionSupervisor)
 	contextManager.SetDefaultCleanupPolicy(ctxpkg.CleanupPolicy{
 		IdleTimeout: cfg.ContextIdleTimeout.Duration,
 		MaxLifetime: cfg.ContextMaxLifetime.Duration,
@@ -162,6 +172,7 @@ func main() {
 	server := procdhttp.NewServer(
 		cfg,
 		contextManager,
+		sessionSupervisor,
 		fileManager,
 		authValidator,
 		webhookDispatcher,
@@ -183,6 +194,7 @@ func main() {
 		logger.Info("Received shutdown signal", zap.String("signal", sig.String()))
 
 		cleanupCancel()
+		reaperCancel()
 
 		if _, err := webhookDispatcher.Enqueue(webhook.Event{
 			EventType: webhook.EventTypeSandboxKilled,
@@ -205,6 +217,9 @@ func main() {
 
 		// Cleanup managers
 		contextManager.Cleanup()
+		if err := sessionSupervisor.Close(); err != nil {
+			logger.Warn("Session supervisor shutdown error", zap.Error(err))
+		}
 		fileManager.Close()
 
 		if err := webhookDispatcher.Shutdown(context.Background()); err != nil {

--- a/manager/pkg/service/procd_client.go
+++ b/manager/pkg/service/procd_client.go
@@ -122,11 +122,12 @@ type ProcdResumeResponse struct {
 
 // InitializeRequest represents the procd initialize request.
 type InitializeRequest struct {
-	SandboxID string             `json:"sandbox_id"`
-	TeamID    string             `json:"team_id,omitempty"`
-	EnvVars   map[string]string  `json:"env_vars,omitempty"`
-	Webhook   *InitializeWebhook `json:"webhook,omitempty"`
-	MountDirs []string           `json:"mount_dirs,omitempty"`
+	SandboxID         string             `json:"sandbox_id"`
+	TeamID            string             `json:"team_id,omitempty"`
+	RuntimeGeneration int64              `json:"runtime_generation,omitempty"`
+	EnvVars           map[string]string  `json:"env_vars,omitempty"`
+	Webhook           *InitializeWebhook `json:"webhook,omitempty"`
+	MountDirs         []string           `json:"mount_dirs,omitempty"`
 }
 
 // InitializeWebhook represents webhook configuration for initialization.

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -1615,8 +1615,9 @@ func (s *SandboxService) initializeProcd(
 	}
 
 	initReq := InitializeRequest{
-		SandboxID: sandboxID,
-		TeamID:    teamID,
+		SandboxID:         sandboxID,
+		TeamID:            teamID,
+		RuntimeGeneration: req.RuntimeGeneration,
 		EnvVars: sandboxEnvVarsForInitialize(req.Config, sandboxPlatformEnv{
 			SandboxID: sandboxID,
 			AppDomain: SandboxAppDomain(

--- a/manager/procd/pkg/context/context.go
+++ b/manager/procd/pkg/context/context.go
@@ -41,8 +41,17 @@ func (p CleanupPolicy) isZero() bool {
 	return p.IdleTimeout == 0 && p.MaxLifetime == 0 && p.FinishedTTL == 0
 }
 
-// NewContext creates a new context with the given configuration.
+// NewContext creates and starts a new context with the given configuration.
 func NewContext(config process.ProcessConfig, replConfig *repl.REPLConfig, exitHandler process.ExitHandler, startHandler process.StartHandler) (*Context, error) {
+	return newContext(config, replConfig, exitHandler, startHandler, true)
+}
+
+// NewUnstartedContext creates a context whose process lifecycle is owned by a caller.
+func NewUnstartedContext(config process.ProcessConfig, replConfig *repl.REPLConfig, exitHandler process.ExitHandler, startHandler process.StartHandler) (*Context, error) {
+	return newContext(config, replConfig, exitHandler, startHandler, false)
+}
+
+func newContext(config process.ProcessConfig, replConfig *repl.REPLConfig, exitHandler process.ExitHandler, startHandler process.StartHandler, start bool) (*Context, error) {
 	id := "ctx-" + uuid.New().String()[:8]
 
 	var proc process.Process
@@ -92,8 +101,10 @@ func NewContext(config process.ProcessConfig, replConfig *repl.REPLConfig, exitH
 		proc.AddStartHandler(startHandler)
 	}
 
-	if err := proc.Start(); err != nil {
-		return nil, err
+	if start {
+		if err := proc.Start(); err != nil {
+			return nil, err
+		}
 	}
 
 	return ctx, nil

--- a/manager/procd/pkg/context/manager.go
+++ b/manager/procd/pkg/context/manager.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/process"
 	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/process/repl"
+	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/session"
 )
 
 // ContextResourceUsage represents resource usage for a single context.
@@ -55,6 +56,7 @@ type Manager struct {
 	onStart              process.StartHandler
 	defaultCleanupPolicy CleanupPolicy
 	cleanupOnce          sync.Once
+	supervisor           *session.Supervisor
 }
 
 // NewManager creates a new context manager.
@@ -62,6 +64,14 @@ func NewManager() *Manager {
 	return &Manager{
 		contexts: make(map[string]*Context),
 	}
+}
+
+// NewManagerWithSupervisor creates a compatibility context manager whose
+// process lifecycle is owned by the shared session supervisor.
+func NewManagerWithSupervisor(supervisor *session.Supervisor) *Manager {
+	manager := NewManager()
+	manager.supervisor = supervisor
+	return manager
 }
 
 // SetExitHandler sets a global exit handler for new contexts.
@@ -138,10 +148,22 @@ func (m *Manager) CreateContextWithPolicyAndREPLConfig(config process.ProcessCon
 		}
 	}
 
-	ctx, err := NewContext(config, replConfig, exitHandler, startHandler)
+	var ctx *Context
+	var err error
+	if m.supervisor == nil {
+		ctx, err = NewContext(config, replConfig, exitHandler, startHandler)
+	} else {
+		ctx, err = NewUnstartedContext(config, replConfig, exitHandler, startHandler)
+	}
 	if err != nil {
 		m.mu.Unlock()
 		return nil, err
+	}
+	if m.supervisor != nil {
+		if err := m.supervisor.StartTransient(ctx.ID, ctx.MainProcess); err != nil {
+			m.mu.Unlock()
+			return nil, err
+		}
 	}
 
 	if policy.isZero() {
@@ -190,7 +212,11 @@ func (m *Manager) DeleteContext(id string) error {
 		return ErrContextNotFound
 	}
 
-	_ = ctx.Stop()
+	if m.supervisor != nil {
+		_ = m.supervisor.DeleteTransient(id)
+	} else {
+		_ = ctx.Stop()
+	}
 
 	delete(m.contexts, id)
 	return nil
@@ -206,10 +232,17 @@ func (m *Manager) RestartContext(id string) (*Context, error) {
 		return nil, ErrContextNotFound
 	}
 
-	if err := ctx.Restart(); err != nil {
+	var err error
+	if m.supervisor != nil {
+		err = m.supervisor.RestartTransient(id)
+	} else {
+		err = ctx.Restart()
+	}
+	if err != nil {
 		m.mu.Unlock()
 		return nil, err
 	}
+	ctx.Touch()
 
 	m.mu.Unlock()
 	return ctx, nil
@@ -281,6 +314,26 @@ func (m *Manager) ReadOutput(contextID string) (<-chan process.ProcessOutput, er
 	return ctx.MainProcess.ReadOutput(), nil
 }
 
+// SubscribeOutput returns a cancellable output subscription for a context.
+func (m *Manager) SubscribeOutput(contextID string) (<-chan process.ProcessOutput, func(), error) {
+	ctx, err := m.GetContext(contextID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if ctx.MainProcess == nil {
+		return nil, nil, process.ErrProcessNotRunning
+	}
+	if subscriber, ok := ctx.MainProcess.(interface {
+		SubscribeOutput() (<-chan process.ProcessOutput, func())
+	}); ok {
+		output, cancel := subscriber.SubscribeOutput()
+		return output, cancel, nil
+	}
+
+	return ctx.MainProcess.ReadOutput(), func() {}, nil
+}
+
 // ResizePTY resizes the PTY for a context.
 func (m *Manager) ResizePTY(contextID string, size process.PTYSize) error {
 	ctx, err := m.GetContext(contextID)
@@ -307,7 +360,11 @@ func (m *Manager) Cleanup() {
 	defer m.mu.Unlock()
 
 	for _, ctx := range m.contexts {
-		ctx.Stop()
+		if m.supervisor != nil {
+			_ = m.supervisor.DeleteTransient(ctx.ID)
+		} else {
+			_ = ctx.Stop()
+		}
 	}
 
 	m.contexts = make(map[string]*Context)

--- a/manager/procd/pkg/context/manager_test.go
+++ b/manager/procd/pkg/context/manager_test.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/process"
+	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/session"
+	"go.uber.org/zap"
 )
 
 // TestNewManager tests manager creation.
@@ -23,6 +25,50 @@ func TestNewManager(t *testing.T) {
 	}
 	if len(ctxs) != 0 {
 		t.Errorf("ListContexts() returned %d contexts, want 0", len(ctxs))
+	}
+}
+
+func TestManagerWithSupervisorUsesSharedLifecycle(t *testing.T) {
+	store, err := session.NewFileStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	supervisor, err := session.NewSupervisor(store, zap.NewNop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer supervisor.Close()
+
+	manager := NewManagerWithSupervisor(supervisor)
+	ctx, err := manager.CreateContext(process.ProcessConfig{
+		Type:    process.ProcessTypeCMD,
+		Command: []string{"/bin/sleep", "30"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer manager.Cleanup()
+	if !ctx.IsRunning() {
+		t.Fatal("supervisor did not start transient context process")
+	}
+
+	if err := supervisor.PauseAll(); err != nil {
+		t.Fatal(err)
+	}
+	if !ctx.IsPaused() {
+		t.Fatal("supervisor did not pause transient context process")
+	}
+	if err := supervisor.ResumeAll(); err != nil {
+		t.Fatal(err)
+	}
+	if ctx.IsPaused() {
+		t.Fatal("supervisor did not resume transient context process")
+	}
+	if err := manager.DeleteContext(ctx.ID); err != nil {
+		t.Fatal(err)
+	}
+	if ctx.IsRunning() {
+		t.Fatal("context process is still running after compatibility view deletion")
 	}
 }
 

--- a/manager/procd/pkg/http/handlers/context.go
+++ b/manager/procd/pkg/http/handlers/context.go
@@ -928,10 +928,11 @@ func (h *ContextHandler) WebSocket(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get output channel
-	outputCh, err := h.manager.ReadOutput(id)
+	outputCh, cancelOutput, err := h.manager.SubscribeOutput(id)
 	if err != nil {
 		return
 	}
+	defer cancelOutput()
 
 	// Write output to WebSocket
 	go func() {

--- a/manager/procd/pkg/http/handlers/function.go
+++ b/manager/procd/pkg/http/handlers/function.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/process"
+	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/reaper"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/sandbox0-ai/sandbox0/pkg/proxy"
 	"github.com/sandbox0-ai/sandbox0/pkg/sandboxfunction"
@@ -388,7 +389,11 @@ func (h *FunctionHandler) run(ctx context.Context, modulePath, handler string, e
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 
-	err := cmd.Run()
+	err := reaper.StartManaged(cmd.Start, func() int { return cmd.Process.Pid })
+	if err == nil {
+		err = cmd.Wait()
+		reaper.Untrack(cmd.Process.Pid)
+	}
 	return stdout.Bytes(), stderr.String(), functionRunTruncation{
 		stdout: stdout.Truncated(),
 		stderr: stderr.Truncated(),
@@ -427,9 +432,10 @@ func (h *FunctionHandler) runStream(ctx context.Context, w http.ResponseWriter, 
 	if err != nil {
 		return err
 	}
-	if err := cmd.Start(); err != nil {
+	if err := reaper.StartManaged(cmd.Start, func() int { return cmd.Process.Pid }); err != nil {
 		return err
 	}
+	defer reaper.Untrack(cmd.Process.Pid)
 	_, _ = stdin.Write(payload)
 	_, _ = stdin.Write([]byte("\n"))
 	_ = stdin.Close()
@@ -541,9 +547,10 @@ func (h *FunctionHandler) runWebSocket(ctx context.Context, conn *websocket.Conn
 	if err != nil {
 		return err
 	}
-	if err := cmd.Start(); err != nil {
+	if err := reaper.StartManaged(cmd.Start, func() int { return cmd.Process.Pid }); err != nil {
 		return err
 	}
+	defer reaper.Untrack(cmd.Process.Pid)
 	_, _ = stdin.Write(payload)
 	_, _ = stdin.Write([]byte("\n"))
 

--- a/manager/procd/pkg/http/handlers/initialize.go
+++ b/manager/procd/pkg/http/handlers/initialize.go
@@ -11,6 +11,7 @@ import (
 
 	ctxpkg "github.com/sandbox0-ai/sandbox0/manager/procd/pkg/context"
 	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/file"
+	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/session"
 	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/webhook"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"go.uber.org/zap"
@@ -18,16 +19,17 @@ import (
 
 // InitializeHandler handles sandbox initialization requests.
 type InitializeHandler struct {
-	dispatcher     *webhook.Dispatcher
-	fileManager    *file.Manager
-	contextManager *ctxpkg.Manager
-	httpPort       int
-	logger         *zap.Logger
-	readyMu        sync.Mutex
-	readySentKey   string
-	watchMu        sync.Mutex
-	watchPath      string
-	unsubscribe    func() error
+	dispatcher        *webhook.Dispatcher
+	fileManager       *file.Manager
+	contextManager    *ctxpkg.Manager
+	sessionSupervisor *session.Supervisor
+	httpPort          int
+	logger            *zap.Logger
+	readyMu           sync.Mutex
+	readySentKey      string
+	watchMu           sync.Mutex
+	watchPath         string
+	unsubscribe       func() error
 }
 
 // NewInitializeHandler creates a new initialize handler.
@@ -43,11 +45,17 @@ func NewInitializeHandler(dispatcher *webhook.Dispatcher, fileManager *file.Mana
 
 // InitializeRequest is the request body for initializing sandbox settings.
 type InitializeRequest struct {
-	SandboxID string             `json:"sandbox_id"`
-	TeamID    string             `json:"team_id,omitempty"`
-	EnvVars   map[string]string  `json:"env_vars,omitempty"`
-	Webhook   *InitializeWebhook `json:"webhook,omitempty"`
-	MountDirs []string           `json:"mount_dirs,omitempty"`
+	SandboxID         string             `json:"sandbox_id"`
+	TeamID            string             `json:"team_id,omitempty"`
+	RuntimeGeneration int64              `json:"runtime_generation,omitempty"`
+	EnvVars           map[string]string  `json:"env_vars,omitempty"`
+	Webhook           *InitializeWebhook `json:"webhook,omitempty"`
+	MountDirs         []string           `json:"mount_dirs,omitempty"`
+}
+
+// SetSessionSupervisor configures persisted session reconciliation during initialization.
+func (h *InitializeHandler) SetSessionSupervisor(supervisor *session.Supervisor) {
+	h.sessionSupervisor = supervisor
 }
 
 // InitializeWebhook represents webhook configuration.
@@ -118,6 +126,12 @@ func (h *InitializeHandler) Initialize(w http.ResponseWriter, r *http.Request) {
 	if h.contextManager != nil {
 		h.contextManager.SetSandboxEnvVars(req.EnvVars)
 	}
+	if h.sessionSupervisor != nil {
+		if err := h.sessionSupervisor.Initialize(req.SandboxID, req.RuntimeGeneration, req.EnvVars); err != nil {
+			writeError(w, http.StatusInternalServerError, "session_initialize_failed", err.Error())
+			return
+		}
+	}
 
 	h.dispatcher.SetConfig(webhookURL, webhookSecret)
 	h.dispatcher.SetIdentity(req.SandboxID, teamID)
@@ -186,6 +200,14 @@ func (h *InitializeHandler) UpdateSandboxEnvVars(w http.ResponseWriter, r *http.
 		h.contextManager.SetSandboxEnvVars(req.EnvVars)
 		if current := h.contextManager.SandboxEnvVars(); current != nil {
 			envVars = current
+		}
+	}
+	if h.sessionSupervisor != nil {
+		h.sessionSupervisor.SetSandboxEnvVars(req.EnvVars)
+	}
+	if h.contextManager == nil {
+		for key, value := range req.EnvVars {
+			envVars[key] = value
 		}
 	}
 	writeJSON(w, http.StatusOK, UpdateSandboxEnvVarsResponse{EnvVars: envVars})

--- a/manager/procd/pkg/http/handlers/sandbox.go
+++ b/manager/procd/pkg/http/handlers/sandbox.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	ctxpkg "github.com/sandbox0-ai/sandbox0/manager/procd/pkg/context"
+	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/session"
 	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/webhook"
 	"go.uber.org/zap"
 )
@@ -12,14 +13,16 @@ import (
 // SandboxHandler handles sandbox-level HTTP requests.
 type SandboxHandler struct {
 	manager    *ctxpkg.Manager
+	supervisor *session.Supervisor
 	dispatcher *webhook.Dispatcher
 	logger     *zap.Logger
 }
 
 // NewSandboxHandler creates a new sandbox handler.
-func NewSandboxHandler(manager *ctxpkg.Manager, dispatcher *webhook.Dispatcher, logger *zap.Logger) *SandboxHandler {
+func NewSandboxHandler(manager *ctxpkg.Manager, supervisor *session.Supervisor, dispatcher *webhook.Dispatcher, logger *zap.Logger) *SandboxHandler {
 	return &SandboxHandler{
 		manager:    manager,
+		supervisor: supervisor,
 		dispatcher: dispatcher,
 		logger:     logger,
 	}
@@ -52,7 +55,12 @@ func (h *SandboxHandler) Pause(w http.ResponseWriter, r *http.Request) {
 	// Get resource usage before pausing (while processes are still running)
 	resourceUsage := h.manager.GetAllResourceUsage()
 
-	err := h.manager.PauseAll()
+	var err error
+	if h.supervisor != nil {
+		err = h.supervisor.PauseAll()
+	} else {
+		err = h.manager.PauseAll()
+	}
 	if err != nil {
 		h.logger.Error("Failed to pause all contexts", zap.Error(err))
 		writeJSON(w, http.StatusInternalServerError, PauseAllResponse{
@@ -99,7 +107,12 @@ func (h *SandboxHandler) Stats(w http.ResponseWriter, r *http.Request) {
 func (h *SandboxHandler) Resume(w http.ResponseWriter, r *http.Request) {
 	h.logger.Info("Resuming all contexts")
 
-	err := h.manager.ResumeAll()
+	var err error
+	if h.supervisor != nil {
+		err = h.supervisor.ResumeAll()
+	} else {
+		err = h.manager.ResumeAll()
+	}
 	if err != nil {
 		h.logger.Error("Failed to resume all contexts", zap.Error(err))
 		writeJSON(w, http.StatusInternalServerError, ResumeAllResponse{

--- a/manager/procd/pkg/http/handlers/session.go
+++ b/manager/procd/pkg/http/handlers/session.go
@@ -1,0 +1,423 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/gorilla/websocket"
+	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/process"
+	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/session"
+	"github.com/sandbox0-ai/sandbox0/pkg/proxy"
+	"go.uber.org/zap"
+)
+
+const sessionStreamHeartbeat = 15 * time.Second
+
+type SessionHandler struct {
+	supervisor *session.Supervisor
+	logger     *zap.Logger
+	upgrader   websocket.Upgrader
+}
+
+func NewSessionHandler(supervisor *session.Supervisor, logger *zap.Logger) *SessionHandler {
+	return &SessionHandler{
+		supervisor: supervisor,
+		logger:     logger,
+		upgrader: websocket.Upgrader{
+			ReadBufferSize:  4096,
+			WriteBufferSize: 4096,
+			CheckOrigin:     func(*http.Request) bool { return true },
+		},
+	}
+}
+
+func (h *SessionHandler) List(w http.ResponseWriter, _ *http.Request) {
+	sessions := h.supervisor.List()
+	writeJSON(w, http.StatusOK, map[string]any{"sessions": sessions})
+}
+
+func (h *SessionHandler) Create(w http.ResponseWriter, r *http.Request) {
+	var request session.SessionSpec
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	created, duplicate, err := h.supervisor.Create(request, r.Header.Get("Idempotency-Key"))
+	if err != nil {
+		h.writeSessionError(w, "create_session", err)
+		return
+	}
+	status := http.StatusCreated
+	if duplicate {
+		status = http.StatusOK
+	}
+	writeJSON(w, status, created)
+}
+
+func (h *SessionHandler) Get(w http.ResponseWriter, r *http.Request) {
+	value, err := h.supervisor.Get(mux.Vars(r)["id"])
+	if err != nil {
+		h.writeSessionError(w, "get_session", err)
+		return
+	}
+	writeJSON(w, http.StatusOK, value)
+}
+
+func (h *SessionHandler) Update(w http.ResponseWriter, r *http.Request) {
+	var request session.SessionSpec
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	value, err := h.supervisor.Update(mux.Vars(r)["id"], request)
+	if err != nil {
+		h.writeSessionError(w, "update_session", err)
+		return
+	}
+	writeJSON(w, http.StatusOK, value)
+}
+
+func (h *SessionHandler) Delete(w http.ResponseWriter, r *http.Request) {
+	if err := h.supervisor.Delete(mux.Vars(r)["id"]); err != nil {
+		h.writeSessionError(w, "delete_session", err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]bool{"deleted": true})
+}
+
+func (h *SessionHandler) SetDesiredState(w http.ResponseWriter, r *http.Request) {
+	var request session.DesiredStateRequest
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	value, err := h.supervisor.SetDesiredState(mux.Vars(r)["id"], request.State)
+	if err != nil {
+		h.writeSessionError(w, "set_session_desired_state", err)
+		return
+	}
+	writeJSON(w, http.StatusOK, value)
+}
+
+func (h *SessionHandler) CreateAttempt(w http.ResponseWriter, r *http.Request) {
+	var request session.CreateAttemptRequest
+	if r.Body != nil && r.ContentLength != 0 {
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+			return
+		}
+	}
+	value, err := h.supervisor.CreateAttempt(mux.Vars(r)["id"], request.ReplaceCurrent)
+	if err != nil {
+		h.writeSessionError(w, "create_session_attempt", err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, value)
+}
+
+func (h *SessionHandler) WriteInput(w http.ResponseWriter, r *http.Request) {
+	var request session.InputRequest
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	value, err := h.supervisor.WriteInput(mux.Vars(r)["id"], request)
+	if err != nil {
+		h.writeSessionError(w, "write_session_input", err)
+		return
+	}
+	writeJSON(w, http.StatusAccepted, value)
+}
+
+func (h *SessionHandler) SendSignal(w http.ResponseWriter, r *http.Request) {
+	var request session.SignalRequest
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	signal, err := parseSessionSignal(request.Signal)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	if err := h.supervisor.SendSignal(mux.Vars(r)["id"], request.ExpectedAttemptID, signal); err != nil {
+		h.writeSessionError(w, "signal_session", err)
+		return
+	}
+	writeJSON(w, http.StatusAccepted, map[string]bool{"accepted": true})
+}
+
+func (h *SessionHandler) ResizeTerminal(w http.ResponseWriter, r *http.Request) {
+	var request session.TerminalResizeRequest
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	if err := h.supervisor.ResizeTerminal(mux.Vars(r)["id"], request.ExpectedAttemptID, request.Rows, request.Cols); err != nil {
+		h.writeSessionError(w, "resize_session_terminal", err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]bool{"resized": true})
+}
+
+func (h *SessionHandler) Events(w http.ResponseWriter, r *http.Request) {
+	after, limit, err := sessionEventQuery(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	page, err := h.supervisor.Events(mux.Vars(r)["id"], after, limit)
+	if err != nil {
+		h.writeSessionError(w, "list_session_events", err)
+		return
+	}
+	writeJSON(w, http.StatusOK, page)
+}
+
+func (h *SessionHandler) EventStream(w http.ResponseWriter, r *http.Request) {
+	after, _, err := sessionEventQuery(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	if header := strings.TrimSpace(r.Header.Get("Last-Event-ID")); header != "" {
+		after, err = strconv.ParseInt(header, 10, 64)
+		if err != nil || after < 0 {
+			writeError(w, http.StatusBadRequest, "invalid_request", "Last-Event-ID must be a non-negative integer")
+			return
+		}
+	}
+	backlog, events, cancel, _, err := h.supervisor.Subscribe(mux.Vars(r)["id"], after)
+	if err != nil {
+		h.writeSessionError(w, "stream_session_events", err)
+		return
+	}
+	defer cancel()
+	if err := proxy.DisableResponseDeadlines(w); err != nil {
+		h.logger.Debug("Failed to disable session event stream deadlines", zap.Error(err))
+	}
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeError(w, http.StatusInternalServerError, "stream_unavailable", "response streaming is unavailable")
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("X-Accel-Buffering", "no")
+	w.WriteHeader(http.StatusOK)
+	for _, event := range backlog {
+		if err := writeSessionSSE(w, event); err != nil {
+			return
+		}
+	}
+	flusher.Flush()
+	heartbeat := time.NewTicker(sessionStreamHeartbeat)
+	defer heartbeat.Stop()
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case event, ok := <-events:
+			if !ok {
+				return
+			}
+			if err := writeSessionSSE(w, event); err != nil {
+				return
+			}
+			flusher.Flush()
+		case <-heartbeat.C:
+			if _, err := fmt.Fprint(w, ": heartbeat\n\n"); err != nil {
+				return
+			}
+			flusher.Flush()
+		}
+	}
+}
+
+type sessionWSRequest struct {
+	Type              string `json:"type"`
+	RequestID         string `json:"request_id,omitempty"`
+	InputID           string `json:"input_id,omitempty"`
+	ExpectedAttemptID string `json:"expected_attempt_id,omitempty"`
+	DataBase64        string `json:"data_base64,omitempty"`
+	EOF               bool   `json:"eof,omitempty"`
+	Signal            string `json:"signal,omitempty"`
+	Rows              uint16 `json:"rows,omitempty"`
+	Cols              uint16 `json:"cols,omitempty"`
+}
+
+type sessionWSResponse struct {
+	Type      string         `json:"type"`
+	RequestID string         `json:"request_id,omitempty"`
+	Event     *session.Event `json:"event,omitempty"`
+	Error     string         `json:"error,omitempty"`
+}
+
+func (h *SessionHandler) WebSocket(w http.ResponseWriter, r *http.Request) {
+	after, _, err := sessionEventQuery(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	backlog, events, cancel, _, err := h.supervisor.Subscribe(mux.Vars(r)["id"], after)
+	if err != nil {
+		h.writeSessionError(w, "attach_session", err)
+		return
+	}
+	defer cancel()
+	if err := proxy.DisableResponseDeadlines(w); err != nil {
+		h.logger.Debug("Failed to disable session websocket response deadlines", zap.Error(err))
+	}
+	conn, err := h.upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+	if err := proxy.DisableConnectionDeadlines(conn.UnderlyingConn()); err != nil {
+		h.logger.Debug("Failed to disable session websocket deadlines", zap.Error(err))
+	}
+	var writeMu sync.Mutex
+	write := func(value sessionWSResponse) error {
+		writeMu.Lock()
+		defer writeMu.Unlock()
+		return conn.WriteJSON(value)
+	}
+	for _, event := range backlog {
+		copy := event
+		if err := write(sessionWSResponse{Type: "event", Event: &copy}); err != nil {
+			return
+		}
+	}
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		for {
+			select {
+			case <-done:
+				return
+			case event, ok := <-events:
+				if !ok {
+					_ = conn.Close()
+					return
+				}
+				copy := event
+				if err := write(sessionWSResponse{Type: "event", Event: &copy}); err != nil {
+					_ = conn.Close()
+					return
+				}
+			}
+		}
+	}()
+	for {
+		var request sessionWSRequest
+		if err := conn.ReadJSON(&request); err != nil {
+			return
+		}
+		requestErr := h.handleWSRequest(mux.Vars(r)["id"], request)
+		response := sessionWSResponse{Type: "ack", RequestID: request.RequestID}
+		if requestErr != nil {
+			response.Type = "error"
+			response.Error = requestErr.Error()
+		}
+		if err := write(response); err != nil {
+			return
+		}
+	}
+}
+
+func (h *SessionHandler) handleWSRequest(id string, request sessionWSRequest) error {
+	switch request.Type {
+	case "input":
+		_, err := h.supervisor.WriteInput(id, session.InputRequest{
+			InputID: request.InputID, ExpectedAttemptID: request.ExpectedAttemptID,
+			DataBase64: request.DataBase64, EOF: request.EOF,
+		})
+		return err
+	case "signal":
+		signal, err := parseSessionSignal(request.Signal)
+		if err != nil {
+			return err
+		}
+		return h.supervisor.SendSignal(id, request.ExpectedAttemptID, signal)
+	case "resize":
+		return h.supervisor.ResizeTerminal(id, request.ExpectedAttemptID, request.Rows, request.Cols)
+	default:
+		return errors.New("unsupported websocket message type")
+	}
+}
+
+func (h *SessionHandler) writeSessionError(w http.ResponseWriter, action string, err error) {
+	switch {
+	case errors.Is(err, session.ErrSessionNotFound):
+		writeError(w, http.StatusNotFound, "session_not_found", err.Error())
+	case errors.Is(err, session.ErrCursorExpired):
+		writeError(w, http.StatusGone, "event_cursor_expired", err.Error())
+	case errors.Is(err, session.ErrAttemptMismatch),
+		errors.Is(err, session.ErrSessionNotRunning),
+		errors.Is(err, session.ErrSessionExists),
+		errors.Is(err, session.ErrInputAlreadyExists):
+		writeError(w, http.StatusConflict, "session_conflict", err.Error())
+	case errors.Is(err, process.ErrInputBufferFull):
+		writeError(w, http.StatusTooManyRequests, "input_buffer_full", err.Error())
+	default:
+		if strings.Contains(err.Error(), "required") || strings.Contains(err.Error(), "invalid") || strings.Contains(err.Error(), "must be") {
+			writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+			return
+		}
+		writeError(w, http.StatusInternalServerError, action+"_failed", err.Error())
+	}
+}
+
+func sessionEventQuery(r *http.Request) (int64, int, error) {
+	after := int64(0)
+	limit := 1000
+	var err error
+	if value := strings.TrimSpace(r.URL.Query().Get("after")); value != "" {
+		after, err = strconv.ParseInt(value, 10, 64)
+		if err != nil || after < 0 {
+			return 0, 0, errors.New("after must be a non-negative integer")
+		}
+	}
+	if value := strings.TrimSpace(r.URL.Query().Get("limit")); value != "" {
+		limit, err = strconv.Atoi(value)
+		if err != nil || limit <= 0 || limit > 10_000 {
+			return 0, 0, errors.New("limit must be between 1 and 10000")
+		}
+	}
+	return after, limit, nil
+}
+
+func writeSessionSSE(w http.ResponseWriter, event session.Event) error {
+	data, err := json.Marshal(event)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(w, "id: %d\nevent: %s\ndata: %s\n\n", event.Seq, event.Type, data)
+	return err
+}
+
+func parseSessionSignal(value string) (syscall.Signal, error) {
+	value = strings.TrimSpace(strings.ToUpper(value))
+	value = strings.TrimPrefix(value, "SIG")
+	signals := map[string]syscall.Signal{
+		"HUP": syscall.SIGHUP, "INT": syscall.SIGINT, "QUIT": syscall.SIGQUIT,
+		"KILL": syscall.SIGKILL, "TERM": syscall.SIGTERM, "USR1": syscall.SIGUSR1,
+		"USR2": syscall.SIGUSR2, "STOP": syscall.SIGSTOP, "CONT": syscall.SIGCONT,
+		"WINCH": syscall.SIGWINCH,
+	}
+	if signal, ok := signals[value]; ok {
+		return signal, nil
+	}
+	if number, err := strconv.Atoi(value); err == nil && number > 0 && number <= 64 {
+		return syscall.Signal(number), nil
+	}
+	return 0, errors.New("unsupported signal")
+}

--- a/manager/procd/pkg/http/handlers/session_test.go
+++ b/manager/procd/pkg/http/handlers/session_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -208,5 +207,5 @@ func waitHandlerSessionPhase(t *testing.T, supervisor *session.Supervisor, id st
 		time.Sleep(10 * time.Millisecond)
 	}
 	value, _ := supervisor.Get(id)
-	t.Fatal(fmt.Sprintf("phase = %s, want %s; session=%#v", value.Phase, expected, value))
+	t.Fatalf("phase = %s, want %s; session=%#v", value.Phase, expected, value)
 }

--- a/manager/procd/pkg/http/handlers/session_test.go
+++ b/manager/procd/pkg/http/handlers/session_test.go
@@ -1,0 +1,212 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/gorilla/websocket"
+	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/session"
+	"go.uber.org/zap"
+)
+
+func TestSessionWebSocketDisconnectOnlyDetachesAndReconnectReplays(t *testing.T) {
+	supervisor := newHandlerTestSupervisor(t)
+	value, _, err := supervisor.Create(session.SessionSpec{
+		Command: []string{"/bin/sh", "-c", "while IFS= read -r line; do printf 'echo:%s\\n' \"$line\"; done"},
+		IO:      session.IOSpec{Mode: session.IOModePipes},
+		Lifecycle: session.LifecycleSpec{
+			DesiredState:           session.DesiredStateRunning,
+			StopGracePeriodSeconds: 1,
+		},
+	}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	waitHandlerSessionPhase(t, supervisor, value.ID, session.PhaseRunning)
+	value, _ = supervisor.Get(value.ID)
+	attemptID := value.Attempt.ID
+
+	handler := NewSessionHandler(supervisor, zap.NewNop())
+	router := mux.NewRouter()
+	router.HandleFunc("/sessions/{id}/ws", handler.WebSocket)
+	router.HandleFunc("/sessions/{id}/inputs", handler.WriteInput).Methods(http.MethodPost)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/sessions/" + value.ID + "/ws"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = conn.Close()
+	time.Sleep(20 * time.Millisecond)
+	afterDetach, err := supervisor.Get(value.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if afterDetach.Phase != session.PhaseRunning || afterDetach.Attempt.ID != attemptID {
+		t.Fatalf("disconnect changed session: %#v", afterDetach)
+	}
+	cursor := afterDetach.Cursor.Latest
+
+	input := session.InputRequest{
+		InputID: "input-after-detach", ExpectedAttemptID: attemptID,
+		DataBase64: base64.StdEncoding.EncodeToString([]byte("hello\n")),
+	}
+	body, _ := json.Marshal(input)
+	resp, err := http.Post(server.URL+"/sessions/"+value.ID+"/inputs", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("input status = %d, want %d", resp.StatusCode, http.StatusAccepted)
+	}
+
+	reconnectURL := wsURL + "?after=" + strconv.FormatInt(cursor, 10)
+	conn, _, err = websocket.DefaultDialer.Dial(reconnectURL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	var output string
+	for output == "" {
+		var message sessionWSResponse
+		if err := conn.ReadJSON(&message); err != nil {
+			t.Fatal(err)
+		}
+		if message.Event == nil || message.Event.Type != "output" {
+			continue
+		}
+		data, err := base64.StdEncoding.DecodeString(message.Event.DataBase64)
+		if err != nil {
+			t.Fatal(err)
+		}
+		output += string(data)
+	}
+	if output != "echo:hello\n" {
+		t.Fatalf("replayed output = %q, want %q", output, "echo:hello\n")
+	}
+	current, _ := supervisor.Get(value.ID)
+	if current.Attempt.ID != attemptID {
+		t.Fatalf("reconnect changed attempt: %s -> %s", attemptID, current.Attempt.ID)
+	}
+}
+
+func TestSessionEventStreamUsesCursorIDs(t *testing.T) {
+	supervisor := newHandlerTestSupervisor(t)
+	value, _, err := supervisor.Create(session.SessionSpec{Command: []string{"/bin/printf", "hello"}}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	waitHandlerSessionPhase(t, supervisor, value.ID, session.PhaseExited)
+	handler := NewSessionHandler(supervisor, zap.NewNop())
+	router := mux.NewRouter()
+	router.HandleFunc("/sessions/{id}/events/stream", handler.EventStream)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+"/sessions/"+value.ID+"/events/stream", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	buffer := make([]byte, 4096)
+	n, err := resp.Body.Read(buffer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := string(buffer[:n])
+	if !strings.Contains(payload, "id: 1\n") || !strings.Contains(payload, "data: {") {
+		t.Fatalf("SSE payload = %q", payload)
+	}
+}
+
+func TestSessionHandlerRejectsExpiredCursor(t *testing.T) {
+	store, err := session.NewFileStore(filepath.Join(t.TempDir(), "sessions"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	supervisor, err := session.NewSupervisor(store, zap.NewNop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := supervisor.Initialize("sandbox-1", 1, nil); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = supervisor.Close() })
+	value, _, err := supervisor.Create(session.SessionSpec{
+		Command:        []string{"/bin/printf", "hello"},
+		EventRetention: session.EventRetentionSpec{MaxBytes: 250, MaxAgeSeconds: 3600},
+	}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	waitHandlerSessionPhase(t, supervisor, value.ID, session.PhaseExited)
+	handler := NewSessionHandler(supervisor, zap.NewNop())
+	req := httptest.NewRequest(http.MethodGet, "/sessions/"+url.PathEscape(value.ID)+"/events?after=1", nil)
+	req = mux.SetURLVars(req, map[string]string{"id": value.ID})
+	recorder := httptest.NewRecorder()
+	handler.Events(recorder, req)
+	if recorder.Code != http.StatusGone {
+		t.Fatalf("status = %d, want %d; body=%s", recorder.Code, http.StatusGone, recorder.Body.String())
+	}
+}
+
+func newHandlerTestSupervisor(t *testing.T) *session.Supervisor {
+	t.Helper()
+	store, err := session.NewFileStore(filepath.Join(t.TempDir(), "sessions"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	supervisor, err := session.NewSupervisor(store, zap.NewNop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := supervisor.Initialize("sandbox-1", 1, nil); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		for _, value := range supervisor.List() {
+			_ = supervisor.Delete(value.ID)
+		}
+		_ = supervisor.Close()
+	})
+	return supervisor
+}
+
+func waitHandlerSessionPhase(t *testing.T, supervisor *session.Supervisor, id string, expected session.Phase) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		value, err := supervisor.Get(id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if value.Phase == expected {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	value, _ := supervisor.Get(id)
+	t.Fatal(fmt.Sprintf("phase = %s, want %s; session=%#v", value.Phase, expected, value))
+}

--- a/manager/procd/pkg/http/server.go
+++ b/manager/procd/pkg/http/server.go
@@ -16,6 +16,7 @@ import (
 	ctxpkg "github.com/sandbox0-ai/sandbox0/manager/procd/pkg/context"
 	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/file"
 	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/http/handlers"
+	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/session"
 	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/webhook"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
@@ -35,8 +36,9 @@ type Server struct {
 	obsProvider *observability.Provider
 
 	// Managers
-	contextManager *ctxpkg.Manager
-	fileManager    *file.Manager
+	contextManager    *ctxpkg.Manager
+	sessionSupervisor *session.Supervisor
+	fileManager       *file.Manager
 
 	// Internal auth validator
 	authValidator *internalauth.Validator
@@ -52,6 +54,7 @@ type Server struct {
 func NewServer(
 	cfg *config.ProcdConfig,
 	contextManager *ctxpkg.Manager,
+	sessionSupervisor *session.Supervisor,
 	fileManager *file.Manager,
 	authValidator *internalauth.Validator,
 	webhookDispatcher *webhook.Dispatcher,
@@ -63,6 +66,7 @@ func NewServer(
 		router:            mux.NewRouter(),
 		cfg:               cfg,
 		contextManager:    contextManager,
+		sessionSupervisor: sessionSupervisor,
 		fileManager:       fileManager,
 		authValidator:     authValidator,
 		barrier:           newLifecycleBarrier(),
@@ -103,7 +107,7 @@ func (s *Server) setupRoutes() {
 	api.Use(s.barrier.middleware)
 
 	// Sandbox-level handlers (pause/resume all processes)
-	sandboxHandler := handlers.NewSandboxHandler(s.contextManager, s.webhookDispatcher, s.logger)
+	sandboxHandler := handlers.NewSandboxHandler(s.contextManager, s.sessionSupervisor, s.webhookDispatcher, s.logger)
 	api.HandleFunc("/lifecycle/barrier", s.lifecycleBarrierHandler).Methods("PUT")
 	api.HandleFunc("/sandbox/pause", sandboxHandler.Pause).Methods("POST")
 	api.HandleFunc("/sandbox/resume", sandboxHandler.Resume).Methods("POST")
@@ -123,6 +127,23 @@ func (s *Server) setupRoutes() {
 	api.HandleFunc("/contexts/{id}/stats", contextHandler.Stats).Methods("GET")
 	api.HandleFunc("/contexts/{id}/ws", contextHandler.WebSocket).Methods("GET")
 
+	if s.sessionSupervisor != nil {
+		sessionHandler := handlers.NewSessionHandler(s.sessionSupervisor, s.logger)
+		api.HandleFunc("/sessions", sessionHandler.List).Methods("GET")
+		api.HandleFunc("/sessions", sessionHandler.Create).Methods("POST")
+		api.HandleFunc("/sessions/{id}", sessionHandler.Get).Methods("GET")
+		api.HandleFunc("/sessions/{id}", sessionHandler.Update).Methods("PUT")
+		api.HandleFunc("/sessions/{id}", sessionHandler.Delete).Methods("DELETE")
+		api.HandleFunc("/sessions/{id}/desired-state", sessionHandler.SetDesiredState).Methods("PUT")
+		api.HandleFunc("/sessions/{id}/attempts", sessionHandler.CreateAttempt).Methods("POST")
+		api.HandleFunc("/sessions/{id}/inputs", sessionHandler.WriteInput).Methods("POST")
+		api.HandleFunc("/sessions/{id}/signals", sessionHandler.SendSignal).Methods("POST")
+		api.HandleFunc("/sessions/{id}/terminal", sessionHandler.ResizeTerminal).Methods("PUT")
+		api.HandleFunc("/sessions/{id}/events", sessionHandler.Events).Methods("GET")
+		api.HandleFunc("/sessions/{id}/events/stream", sessionHandler.EventStream).Methods("GET")
+		api.HandleFunc("/sessions/{id}/ws", sessionHandler.WebSocket).Methods("GET")
+	}
+
 	functionHandler := handlers.NewFunctionHandler(s.logger)
 	if s.contextManager != nil {
 		functionHandler.SetSandboxEnvVarsProvider(s.contextManager.SandboxEnvVars)
@@ -133,6 +154,7 @@ func (s *Server) setupRoutes() {
 
 	// Initialize handler
 	initializeHandler := handlers.NewInitializeHandler(s.webhookDispatcher, s.fileManager, s.contextManager, s.cfg.HTTPPort, s.logger)
+	initializeHandler.SetSessionSupervisor(s.sessionSupervisor)
 	api.HandleFunc("/initialize", initializeHandler.Initialize).Methods("POST")
 	api.HandleFunc("/sandbox/env_vars", initializeHandler.UpdateSandboxEnvVars).Methods("PUT")
 

--- a/manager/procd/pkg/process/cmd/cmd_test.go
+++ b/manager/procd/pkg/process/cmd/cmd_test.go
@@ -483,10 +483,11 @@ func TestCMD_WithEnvironment(t *testing.T) {
 	}
 }
 
-// TestCMD_WriteInputNoPTY tests writing input to a non-PTY command.
+// TestCMD_WriteInputNoPTY tests pipe-backed input for a non-PTY command.
 func TestCMD_WriteInputNoPTY(t *testing.T) {
 	config := process.ProcessConfig{
-		Type: process.ProcessTypeCMD,
+		Type:      process.ProcessTypeCMD,
+		PipeStdin: true,
 	}
 
 	cmd, err := NewCMD("test-input", config, []string{"/bin/cat"})
@@ -499,13 +500,40 @@ func TestCMD_WriteInputNoPTY(t *testing.T) {
 		t.Fatalf("Start() failed = %v", err)
 	}
 
-	// Writing to a non-PTY command should fail
-	err = cmd.WriteInput([]byte("test input"))
-	if err != process.ErrProcessNotRunning {
-		t.Errorf("WriteInput() error = %v, want %v", err, process.ErrProcessNotRunning)
+	if err := cmd.WriteInput([]byte("test input")); err != nil {
+		t.Fatalf("WriteInput() failed = %v", err)
 	}
+	if err := cmd.CloseInput(); err != nil {
+		t.Fatalf("CloseInput() failed = %v", err)
+	}
+	for i := 0; i < 100 && cmd.IsRunning(); i++ {
+		time.Sleep(10 * time.Millisecond)
+	}
+	stdout, stderr := cmd.GetOutput()
+	if stdout != "test input" || stderr != "" {
+		t.Fatalf("output = (%q, %q), want (%q, %q)", stdout, stderr, "test input", "")
+	}
+}
 
-	cmd.Stop()
+func TestCMD_NoPTYKeepsLegacyClosedStdinByDefault(t *testing.T) {
+	config := process.ProcessConfig{Type: process.ProcessTypeCMD}
+	cmd, err := NewCMD("test-closed-input", config, []string{"/bin/cat"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 100 && cmd.IsRunning(); i++ {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if cmd.IsRunning() {
+		_ = cmd.Stop()
+		t.Fatal("pipe stdin stayed open without PipeStdin")
+	}
+	if err := cmd.WriteInput([]byte("unexpected")); err != process.ErrProcessNotRunning {
+		t.Fatalf("WriteInput() error = %v, want %v", err, process.ErrProcessNotRunning)
+	}
 }
 
 // TestCMD_CommandWithSpaces tests command with spaces in arguments.

--- a/manager/procd/pkg/process/direct_runner.go
+++ b/manager/procd/pkg/process/direct_runner.go
@@ -3,11 +3,14 @@ package process
 import (
 	"context"
 	"fmt"
+	"io"
 	"os/exec"
 	"sync"
 	"sync/atomic"
 	"syscall"
 	"time"
+
+	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/reaper"
 )
 
 // DirectRunner manages non-PTY process execution with stdout/stderr pipes.
@@ -66,13 +69,28 @@ func (r *DirectRunner) Start(cmd *exec.Cmd) error {
 		source: OutputSourceStderr,
 		buffer: r.stderr,
 	}
+	var stdin io.WriteCloser
+	if r.base.GetConfig().PipeStdin {
+		var err error
+		stdin, err = cmd.StdinPipe()
+		if err != nil {
+			r.base.SetState(ProcessStateCrashed)
+			return fmt.Errorf("create stdin pipe: %w", err)
+		}
+	}
 
-	if err := cmd.Start(); err != nil {
+	if err := reaper.StartManaged(cmd.Start, func() int { return cmd.Process.Pid }); err != nil {
+		if stdin != nil {
+			_ = stdin.Close()
+		}
 		r.base.SetState(ProcessStateCrashed)
 		return fmt.Errorf("%w: %v", ErrProcessStartFailed, err)
 	}
 
 	r.cmd = cmd
+	if stdin != nil {
+		r.base.SetInput(stdin)
+	}
 	r.base.SetPID(cmd.Process.Pid)
 	r.base.SetStartTime(time.Now())
 	r.base.SetState(ProcessStateRunning)
@@ -105,6 +123,7 @@ func (r *DirectRunner) Stop() error {
 			_ = r.cmd.Process.Kill()
 		}
 	}
+	_ = r.base.CloseInput()
 
 	r.base.SetState(ProcessStateStopped)
 	r.base.CloseOutput()
@@ -122,6 +141,7 @@ func (r *DirectRunner) monitorProcess() {
 		return
 	}
 
+	defer reaper.Untrack(r.cmd.Process.Pid)
 	err := r.cmd.Wait()
 
 	exitCode := 0
@@ -167,6 +187,7 @@ func (r *DirectRunner) monitorProcess() {
 		Config:        r.base.GetConfig(),
 	})
 
+	_ = r.base.CloseInput()
 	r.base.CloseOutput()
 }
 

--- a/manager/procd/pkg/process/process.go
+++ b/manager/procd/pkg/process/process.go
@@ -2,6 +2,7 @@ package process
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"sync"
 	"syscall"
@@ -60,6 +61,7 @@ type ProcessConfig struct {
 	PTYSize    *PTYSize          `json:"pty_size"`
 	Term       string            `json:"term"`
 	BufferSize int               `json:"buffer_size"` // Number of messages to buffer for the output multiplexer, default is 64 if not set
+	PipeStdin  bool              `json:"-"`           // Keep a pipe-backed stdin open for explicit input and EOF operations.
 }
 
 // ProcessDescriptor identifies the process that emitted an output event.
@@ -202,6 +204,8 @@ type BaseProcess struct {
 	pid             int
 	exitCode        int
 	pty             *os.File
+	input           io.WriteCloser
+	reliableOutput  chan ProcessOutput
 	outputMultiplex *MultiplexedChannel[ProcessOutput]
 	outputForwarder OutputForwarder
 	startTime       time.Time
@@ -214,12 +218,18 @@ type BaseProcess struct {
 
 	mu sync.RWMutex
 
-	inputQueue      chan []byte
+	inputQueue      chan inputOperation
 	inputReady      chan struct{}
 	inputStop       chan struct{}
 	inputReadyOnce  sync.Once
 	inputWriterOnce sync.Once
 	inputStopOnce   sync.Once
+}
+
+type inputOperation struct {
+	data  []byte
+	close bool
+	done  chan error
 }
 
 // NewBaseProcess creates a new base process.
@@ -235,7 +245,7 @@ func NewBaseProcess(id string, processType ProcessType, config ProcessConfig) *B
 		outputMultiplex: NewMultiplexedChannel[ProcessOutput](config.BufferSize),
 		outputForwarder: defaultOutputForwarderSnapshot(),
 		cpuTracker:      newCPUTracker(),
-		inputQueue:      make(chan []byte, config.BufferSize),
+		inputQueue:      make(chan inputOperation, config.BufferSize),
 		inputReady:      make(chan struct{}),
 		inputStop:       make(chan struct{}),
 	}
@@ -430,16 +440,30 @@ func (bp *BaseProcess) ReadOutput() <-chan ProcessOutput {
 	return ch
 }
 
+// SubscribeOutput returns a cancellable subscription to process output.
+func (bp *BaseProcess) SubscribeOutput() (<-chan ProcessOutput, func()) {
+	return bp.outputMultiplex.Fork()
+}
+
+// SetReliableOutput installs a lossless output sink for a process owner. The
+// process applies backpressure when the sink cannot keep up; ordinary fan-out
+// subscribers retain their existing best-effort behavior.
+func (bp *BaseProcess) SetReliableOutput(output chan ProcessOutput) {
+	bp.mu.Lock()
+	bp.reliableOutput = output
+	bp.mu.Unlock()
+}
+
 // WriteInput writes data to the process input.
 func (bp *BaseProcess) WriteInput(data []byte) error {
 	bp.mu.RLock()
-	pty := bp.pty
+	input := bp.input
 	bp.mu.RUnlock()
 
 	if len(data) == 0 {
 		return nil
 	}
-	if pty == nil {
+	if input == nil {
 		return ErrProcessNotRunning
 	}
 	if bp.IsFinished() {
@@ -450,10 +474,42 @@ func (bp *BaseProcess) WriteInput(data []byte) error {
 	copy(payload, data)
 
 	select {
-	case bp.inputQueue <- payload:
+	case bp.inputQueue <- inputOperation{data: payload}:
 		return nil
 	default:
 		return ErrInputBufferFull
+	}
+}
+
+// CloseInput closes the process stdin without stopping the process.
+func (bp *BaseProcess) CloseInput() error {
+	bp.mu.RLock()
+	input := bp.input
+	bp.mu.RUnlock()
+	if input == nil {
+		return nil
+	}
+	select {
+	case <-bp.inputStop:
+		bp.mu.Lock()
+		if bp.input == input {
+			bp.input = nil
+		}
+		bp.mu.Unlock()
+		return input.Close()
+	default:
+	}
+	done := make(chan error, 1)
+	select {
+	case bp.inputQueue <- inputOperation{close: true, done: done}:
+	case <-bp.inputStop:
+		return nil
+	}
+	select {
+	case err := <-done:
+		return err
+	case <-bp.inputStop:
+		return nil
 	}
 }
 
@@ -504,9 +560,19 @@ func (bp *BaseProcess) SetState(state ProcessState) {
 // SetPTY sets the PTY file descriptor.
 func (bp *BaseProcess) SetPTY(pty *os.File) {
 	bp.mu.Lock()
-	defer bp.mu.Unlock()
 	bp.pty = pty
-	bp.startInputWriter(pty)
+	bp.mu.Unlock()
+	bp.SetInput(pty)
+}
+
+// SetInput attaches a writable stdin stream to the process.
+func (bp *BaseProcess) SetInput(input io.WriteCloser) {
+	bp.mu.Lock()
+	bp.input = input
+	bp.mu.Unlock()
+	if input != nil {
+		bp.startInputWriter(input)
+	}
 }
 
 func (bp *BaseProcess) signalInputReady() {
@@ -526,7 +592,7 @@ func (bp *BaseProcess) stopInputWriter() {
 	})
 }
 
-func (bp *BaseProcess) startInputWriter(pty *os.File) {
+func (bp *BaseProcess) startInputWriter(input io.WriteCloser) {
 	bp.inputWriterOnce.Do(func() {
 		go func() {
 			select {
@@ -538,15 +604,33 @@ func (bp *BaseProcess) startInputWriter(pty *os.File) {
 				select {
 				case <-bp.inputStop:
 					return
-				case data := <-bp.inputQueue:
-					if len(data) == 0 {
+				case operation := <-bp.inputQueue:
+					if operation.close {
+						err := bp.closeInputWriter(input)
+						if operation.done != nil {
+							operation.done <- err
+						}
+						bp.stopInputWriter()
+						return
+					}
+					if len(operation.data) == 0 {
 						continue
 					}
-					_, _ = pty.Write(data)
+					_, _ = input.Write(operation.data)
 				}
 			}
 		}()
 	})
+}
+
+func (bp *BaseProcess) closeInputWriter(input io.WriteCloser) error {
+	err := input.Close()
+	bp.mu.Lock()
+	if bp.input == input {
+		bp.input = nil
+	}
+	bp.mu.Unlock()
+	return err
 }
 
 // SetPID sets the system process ID.
@@ -607,6 +691,11 @@ func (bp *BaseProcess) NotifyStart(event StartEvent) {
 
 // PublishOutput publishes output to all subscribers.
 func (bp *BaseProcess) PublishOutput(output ProcessOutput) {
+	bp.mu.RLock()
+	if bp.reliableOutput != nil {
+		bp.reliableOutput <- output
+	}
+	bp.mu.RUnlock()
 	bp.outputMultiplex.Publish(output)
 	if forwarder := bp.outputForwarderSnapshot(); forwarder != nil {
 		forwarder.ForwardOutput(bp.descriptor(), output)
@@ -618,6 +707,12 @@ func (bp *BaseProcess) CloseOutput() {
 	if forwarder, ok := bp.outputForwarderSnapshot().(FlushableOutputForwarder); ok && forwarder != nil {
 		forwarder.FlushProcessOutput(bp.descriptor())
 	}
+	bp.mu.Lock()
+	if bp.reliableOutput != nil {
+		close(bp.reliableOutput)
+		bp.reliableOutput = nil
+	}
+	bp.mu.Unlock()
 	bp.outputMultiplex.Close()
 }
 

--- a/manager/procd/pkg/process/pty_runner.go
+++ b/manager/procd/pkg/process/pty_runner.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/creack/pty"
+	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/reaper"
 )
 
 // PTYRunner manages PTY lifecycle for exec-based processes.
@@ -51,10 +52,15 @@ func (r *PTYRunner) Start(cmd *exec.Cmd, size *PTYSize) error {
 		ptySize = &PTYSize{Rows: 100, Cols: 500}
 	}
 
-	ptmx, err := pty.StartWithSize(cmd, &pty.Winsize{
-		Rows: ptySize.Rows,
-		Cols: ptySize.Cols,
-	})
+	var ptmx *os.File
+	err := reaper.StartManaged(func() error {
+		var startErr error
+		ptmx, startErr = pty.StartWithSize(cmd, &pty.Winsize{
+			Rows: ptySize.Rows,
+			Cols: ptySize.Cols,
+		})
+		return startErr
+	}, func() int { return cmd.Process.Pid })
 	if err != nil {
 		r.base.SetState(ProcessStateCrashed)
 		return fmt.Errorf("%w: %v", ErrProcessStartFailed, err)
@@ -94,16 +100,12 @@ func (r *PTYRunner) Stop() error {
 		r.onStop()
 	}
 
-	r.base.stopInputWriter()
+	_ = r.base.CloseInput()
 
 	if r.cmd != nil && r.cmd.Process != nil {
 		if err := r.cmd.Process.Signal(syscall.SIGTERM); err != nil {
 			_ = r.cmd.Process.Kill()
 		}
-	}
-
-	if ptyFile := r.base.GetPTY(); ptyFile != nil {
-		ptyFile.Close()
 	}
 
 	r.waitReaderDone()
@@ -149,6 +151,7 @@ func (r *PTYRunner) monitorProcess() {
 		return
 	}
 
+	defer reaper.Untrack(r.cmd.Process.Pid)
 	err := r.cmd.Wait()
 
 	exitCode := 0
@@ -192,6 +195,7 @@ func (r *PTYRunner) monitorProcess() {
 
 	r.base.stopInputWriter()
 	r.waitReaderDone()
+	_ = r.base.CloseInput()
 	r.closeOutput()
 }
 

--- a/manager/procd/pkg/reaper/reaper.go
+++ b/manager/procd/pkg/reaper/reaper.go
@@ -1,0 +1,124 @@
+// Package reaper removes orphaned zombie processes adopted by procd as PID 1.
+package reaper
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+var managedPIDs = struct {
+	sync.RWMutex
+	values map[int]struct{}
+}{values: map[int]struct{}{}}
+
+// StartManaged starts a child and registers its PID atomically with respect to
+// orphan scans. pid must return the child PID after start succeeds.
+func StartManaged(start func() error, pid func() int) error {
+	managedPIDs.Lock()
+	defer managedPIDs.Unlock()
+	if err := start(); err != nil {
+		return err
+	}
+	if childPID := pid(); childPID > 0 {
+		managedPIDs.values[childPID] = struct{}{}
+	}
+	return nil
+}
+
+// Untrack removes a child after its owning wait path has completed.
+func Untrack(pid int) {
+	if pid <= 0 {
+		return
+	}
+	managedPIDs.Lock()
+	delete(managedPIDs.values, pid)
+	managedPIDs.Unlock()
+}
+
+// Run periodically reaps untracked zombie children adopted by procd.
+func Run(ctx context.Context, logger *zap.Logger) {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			reapOrphans(logger)
+		}
+	}
+}
+
+func reapOrphans(logger *zap.Logger) {
+	entries, err := filepath.Glob("/proc/[0-9]*/stat")
+	if err != nil {
+		return
+	}
+	parentPID := os.Getpid()
+	for _, path := range entries {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		pid, ppid, state, ok := parseProcStat(string(data))
+		if !ok || ppid != parentPID || state != "Z" {
+			continue
+		}
+		managedPIDs.RLock()
+		if _, managed := managedPIDs.values[pid]; managed {
+			managedPIDs.RUnlock()
+			continue
+		}
+		var status syscall.WaitStatus
+		var usage syscall.Rusage
+		reaped, err := syscall.Wait4(pid, &status, syscall.WNOHANG, &usage)
+		managedPIDs.RUnlock()
+		if err != nil && !errors.Is(err, syscall.ECHILD) {
+			logger.Debug("Failed to reap orphaned process", zap.Int("pid", pid), zap.Error(err))
+			continue
+		}
+		if reaped == pid {
+			logger.Debug("Reaped orphaned process", zap.Int("pid", pid))
+		}
+	}
+}
+
+func isManaged(pid int) bool {
+	managedPIDs.RLock()
+	_, ok := managedPIDs.values[pid]
+	managedPIDs.RUnlock()
+	return ok
+}
+
+func parseProcStat(value string) (pid, ppid int, state string, ok bool) {
+	closing := strings.LastIndex(value, ")")
+	opening := strings.Index(value, "(")
+	if opening <= 0 || closing <= opening || closing+2 >= len(value) {
+		return 0, 0, "", false
+	}
+	parsedPID, err := strconv.Atoi(strings.TrimSpace(value[:opening]))
+	if err != nil {
+		return 0, 0, "", false
+	}
+	fields := strings.Fields(value[closing+1:])
+	if len(fields) < 2 {
+		return 0, 0, "", false
+	}
+	parsedPPID, err := strconv.Atoi(fields[1])
+	if err != nil {
+		return 0, 0, "", false
+	}
+	return parsedPID, parsedPPID, fields[0], true
+}

--- a/manager/procd/pkg/reaper/reaper_test.go
+++ b/manager/procd/pkg/reaper/reaper_test.go
@@ -1,0 +1,31 @@
+package reaper
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestParseProcStatHandlesSpacesAndParenthesesInCommand(t *testing.T) {
+	pid, ppid, state, ok := parseProcStat("123 (worker (copy) job) Z 42 1 1 0")
+	if !ok || pid != 123 || ppid != 42 || state != "Z" {
+		t.Fatalf("parseProcStat() = (%d, %d, %q, %v)", pid, ppid, state, ok)
+	}
+}
+
+func TestStartManagedRegistersBeforeReturning(t *testing.T) {
+	cmd := exec.Command("/bin/true")
+	if err := StartManaged(cmd.Start, func() int { return cmd.Process.Pid }); err != nil {
+		t.Fatal(err)
+	}
+	pid := cmd.Process.Pid
+	if !isManaged(pid) {
+		t.Fatal("started child was not registered")
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatal(err)
+	}
+	Untrack(pid)
+	if isManaged(pid) {
+		t.Fatal("waited child remained registered")
+	}
+}

--- a/manager/procd/pkg/session/journal.go
+++ b/manager/procd/pkg/session/journal.go
@@ -1,0 +1,391 @@
+package session
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+type journalSubscriber struct {
+	ch chan Event
+}
+
+// Journal is a bounded, cursor-addressable event log with live subscriptions.
+type Journal struct {
+	mu          sync.Mutex
+	path        string
+	file        *os.File
+	retention   EventRetentionSpec
+	events      []Event
+	eventSizes  []int64
+	totalBytes  int64
+	nextSeq     int64
+	subscribers map[uint64]*journalSubscriber
+	nextSubID   uint64
+	closed      bool
+}
+
+func OpenJournal(path string, retention EventRetentionSpec, lastSeq int64) (*Journal, error) {
+	retention = normalizeSpec(SessionSpec{EventRetention: retention}).EventRetention
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, fmt.Errorf("create event journal directory: %w", err)
+	}
+	events, sizes, validBytes, err := loadJournal(path)
+	if err != nil {
+		return nil, err
+	}
+	if info, statErr := os.Stat(path); statErr == nil && info.Size() > validBytes {
+		if err := os.Truncate(path, validBytes); err != nil {
+			return nil, fmt.Errorf("truncate incomplete event journal tail: %w", err)
+		}
+	} else if statErr != nil && !errors.Is(statErr, os.ErrNotExist) {
+		return nil, fmt.Errorf("stat event journal: %w", statErr)
+	}
+	latest := lastSeq
+	var total int64
+	for i := range events {
+		if events[i].Seq > latest {
+			latest = events[i].Seq
+		}
+		total += sizes[i]
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open event journal: %w", err)
+	}
+	journal := &Journal{
+		path:        path,
+		file:        file,
+		retention:   retention,
+		events:      events,
+		eventSizes:  sizes,
+		totalBytes:  total,
+		nextSeq:     latest + 1,
+		subscribers: map[uint64]*journalSubscriber{},
+	}
+	if journal.nextSeq <= 0 {
+		journal.nextSeq = 1
+	}
+	if journal.trimLocked(time.Now()) {
+		if err := journal.compactLocked(); err != nil {
+			return nil, err
+		}
+	}
+	return journal, nil
+}
+
+func loadJournal(path string) ([]Event, []int64, int64, error) {
+	file, err := os.Open(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil, 0, nil
+	}
+	if err != nil {
+		return nil, nil, 0, fmt.Errorf("open event journal for replay: %w", err)
+	}
+	defer file.Close()
+
+	reader := bufio.NewReaderSize(file, 64*1024)
+	var events []Event
+	var sizes []int64
+	var previous int64
+	var validBytes int64
+	for {
+		line, readErr := reader.ReadBytes('\n')
+		if len(bytes.TrimSpace(line)) > 0 {
+			if readErr == io.EOF && !bytes.HasSuffix(line, []byte{'\n'}) {
+				break
+			}
+			var event Event
+			if err := json.Unmarshal(bytes.TrimSpace(line), &event); err != nil {
+				return nil, nil, 0, fmt.Errorf("decode event journal: %w", err)
+			}
+			if event.Seq <= previous {
+				return nil, nil, 0, fmt.Errorf("event journal sequence %d is not greater than %d", event.Seq, previous)
+			}
+			previous = event.Seq
+			events = append(events, event)
+			sizes = append(sizes, int64(len(line)))
+		}
+		if bytes.HasSuffix(line, []byte{'\n'}) {
+			validBytes += int64(len(line))
+		}
+		if readErr != nil {
+			if errors.Is(readErr, io.EOF) {
+				break
+			}
+			return nil, nil, 0, fmt.Errorf("read event journal: %w", readErr)
+		}
+	}
+	return events, sizes, validBytes, nil
+}
+
+func (j *Journal) Append(event Event) (Event, error) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if j.closed {
+		return Event{}, errors.New("event journal is closed")
+	}
+	event.Seq = j.nextSeq
+	if event.OccurredAt.IsZero() {
+		event.OccurredAt = time.Now().UTC()
+	}
+	line, err := json.Marshal(event)
+	if err != nil {
+		return Event{}, fmt.Errorf("encode event: %w", err)
+	}
+	line = append(line, '\n')
+	info, err := j.file.Stat()
+	if err != nil {
+		return Event{}, fmt.Errorf("stat event journal before append: %w", err)
+	}
+	written, err := j.file.Write(line)
+	if err != nil || written != len(line) {
+		writeErr := err
+		if writeErr == nil {
+			writeErr = io.ErrShortWrite
+		}
+		if truncateErr := j.file.Truncate(info.Size()); truncateErr != nil {
+			return Event{}, errors.Join(fmt.Errorf("append event journal: %w", writeErr), fmt.Errorf("rollback partial event journal append: %w", truncateErr))
+		}
+		return Event{}, fmt.Errorf("append event journal: %w", writeErr)
+	}
+	j.nextSeq++
+	j.events = append(j.events, event)
+	j.eventSizes = append(j.eventSizes, int64(len(line)))
+	j.totalBytes += int64(len(line))
+	trimmed := j.trimLocked(event.OccurredAt)
+	if trimmed {
+		if err := j.compactLocked(); err != nil {
+			return event, err
+		}
+	}
+	for id, subscriber := range j.subscribers {
+		select {
+		case subscriber.ch <- event:
+		default:
+			close(subscriber.ch)
+			delete(j.subscribers, id)
+		}
+	}
+	return event, nil
+}
+
+func (j *Journal) Read(after int64, limit int) (EventPage, error) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if j.trimLocked(time.Now()) {
+		if err := j.compactLocked(); err != nil {
+			return EventPage{}, err
+		}
+	}
+	if err := j.validateCursorLocked(after); err != nil {
+		return EventPage{}, err
+	}
+	if limit <= 0 || limit > 10_000 {
+		limit = 1000
+	}
+	events := make([]Event, 0, min(limit, len(j.events)))
+	for _, event := range j.events {
+		if event.Seq <= after {
+			continue
+		}
+		events = append(events, event)
+		if len(events) == limit {
+			break
+		}
+	}
+	return EventPage{Events: events, Cursor: j.cursorLocked()}, nil
+}
+
+func (j *Journal) Subscribe(after int64) ([]Event, <-chan Event, func(), EventCursor, error) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if j.closed {
+		return nil, nil, nil, EventCursor{}, errors.New("event journal is closed")
+	}
+	if j.trimLocked(time.Now()) {
+		if err := j.compactLocked(); err != nil {
+			return nil, nil, nil, EventCursor{}, err
+		}
+	}
+	if err := j.validateCursorLocked(after); err != nil {
+		return nil, nil, nil, EventCursor{}, err
+	}
+	backlog := make([]Event, 0)
+	for _, event := range j.events {
+		if event.Seq > after {
+			backlog = append(backlog, event)
+		}
+	}
+	j.nextSubID++
+	id := j.nextSubID
+	buffer := defaultSubscriptionBacklog
+	if len(backlog) > buffer {
+		buffer = len(backlog)
+	}
+	subscriber := &journalSubscriber{ch: make(chan Event, buffer)}
+	j.subscribers[id] = subscriber
+	var once sync.Once
+	cancel := func() {
+		once.Do(func() {
+			j.mu.Lock()
+			defer j.mu.Unlock()
+			current, ok := j.subscribers[id]
+			if !ok {
+				return
+			}
+			delete(j.subscribers, id)
+			close(current.ch)
+		})
+	}
+	return backlog, subscriber.ch, cancel, j.cursorLocked(), nil
+}
+
+func (j *Journal) Cursor() EventCursor {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	return j.cursorLocked()
+}
+
+func (j *Journal) SetRetention(retention EventRetentionSpec) error {
+	retention = normalizeSpec(SessionSpec{EventRetention: retention}).EventRetention
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	j.retention = retention
+	if !j.trimLocked(time.Now()) {
+		return nil
+	}
+	return j.compactLocked()
+}
+
+// Prune applies time- and size-based retention without requiring a new event.
+func (j *Journal) Prune(now time.Time) error {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if j.closed || !j.trimLocked(now) {
+		return nil
+	}
+	return j.compactLocked()
+}
+
+func (j *Journal) Flush() error {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if j.closed || j.file == nil {
+		return nil
+	}
+	return j.file.Sync()
+}
+
+func (j *Journal) Close() error {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if j.closed {
+		return nil
+	}
+	j.closed = true
+	for id, subscriber := range j.subscribers {
+		close(subscriber.ch)
+		delete(j.subscribers, id)
+	}
+	if j.file == nil {
+		return nil
+	}
+	if err := j.file.Sync(); err != nil {
+		_ = j.file.Close()
+		return err
+	}
+	return j.file.Close()
+}
+
+func (j *Journal) validateCursorLocked(after int64) error {
+	if after < 0 {
+		return errors.New("event cursor must be non-negative")
+	}
+	cursor := j.cursorLocked()
+	if after > cursor.Latest {
+		return fmt.Errorf("event cursor must not be greater than latest sequence %d", cursor.Latest)
+	}
+	if cursor.Earliest > 1 && after < cursor.Earliest-1 {
+		return &CursorExpiredError{Earliest: cursor.Earliest}
+	}
+	return nil
+}
+
+func (j *Journal) cursorLocked() EventCursor {
+	latest := j.nextSeq - 1
+	if latest < 0 {
+		latest = 0
+	}
+	earliest := int64(0)
+	if len(j.events) > 0 {
+		earliest = j.events[0].Seq
+	} else if latest > 0 {
+		// No event is retained, so the next sequence is the lower bound of the
+		// retained window. A client can resume only after the current latest.
+		earliest = j.nextSeq
+	}
+	return EventCursor{Earliest: earliest, Latest: latest}
+}
+
+func (j *Journal) trimLocked(now time.Time) bool {
+	removed := 0
+	if j.retention.MaxAgeSeconds > 0 {
+		cutoff := now.Add(-time.Duration(j.retention.MaxAgeSeconds) * time.Second)
+		for removed < len(j.events) && j.events[removed].OccurredAt.Before(cutoff) {
+			j.totalBytes -= j.eventSizes[removed]
+			removed++
+		}
+	}
+	if j.retention.MaxBytes > 0 {
+		for removed < len(j.events) && j.totalBytes > j.retention.MaxBytes {
+			j.totalBytes -= j.eventSizes[removed]
+			removed++
+		}
+	}
+	if removed == 0 {
+		return false
+	}
+	j.events = append([]Event(nil), j.events[removed:]...)
+	j.eventSizes = append([]int64(nil), j.eventSizes[removed:]...)
+	return true
+}
+
+func (j *Journal) compactLocked() error {
+	if err := j.file.Close(); err != nil {
+		return fmt.Errorf("close event journal before compaction: %w", err)
+	}
+	var data bytes.Buffer
+	for _, event := range j.events {
+		line, err := json.Marshal(event)
+		if err != nil {
+			return fmt.Errorf("encode compacted event: %w", err)
+		}
+		data.Write(line)
+		data.WriteByte('\n')
+	}
+	if err := writeFileAtomic(j.path, data.Bytes(), 0o600); err != nil {
+		return fmt.Errorf("compact event journal: %w", err)
+	}
+	file, err := os.OpenFile(j.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return fmt.Errorf("reopen compacted event journal: %w", err)
+	}
+	j.file = file
+	j.totalBytes = 0
+	j.eventSizes = j.eventSizes[:0]
+	for _, event := range j.events {
+		line, _ := json.Marshal(event)
+		size := int64(len(line) + 1)
+		j.eventSizes = append(j.eventSizes, size)
+		j.totalBytes += size
+	}
+	return nil
+}

--- a/manager/procd/pkg/session/journal_test.go
+++ b/manager/procd/pkg/session/journal_test.go
@@ -1,0 +1,181 @@
+package session
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestJournalCursorRetentionAndReopen(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "events.jsonl")
+	journal, err := OpenJournal(path, EventRetentionSpec{MaxBytes: 350, MaxAgeSeconds: 3600}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 8; i++ {
+		if _, err := journal.Append(Event{SessionID: "ses-test", Type: "output", DataBase64: "dGVzdC1ldmVudA=="}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cursor := journal.Cursor()
+	if cursor.Latest != 8 || cursor.Earliest <= 1 {
+		t.Fatalf("cursor = %#v, want compacted history ending at 8", cursor)
+	}
+	if _, err := journal.Read(1, 100); !errors.Is(err, ErrCursorExpired) {
+		t.Fatalf("Read() error = %v, want cursor expired", err)
+	}
+	backlog, live, cancel, _, err := journal.Subscribe(cursor.Latest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(backlog) != 0 {
+		t.Fatalf("backlog length = %d, want 0", len(backlog))
+	}
+	appended, err := journal.Append(Event{SessionID: "ses-test", Type: "session.ready"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case got := <-live:
+		if got.Seq != appended.Seq {
+			t.Fatalf("live seq = %d, want %d", got.Seq, appended.Seq)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for live event")
+	}
+	cancel()
+	if _, ok := <-live; ok {
+		t.Fatal("subscription remained open after cancellation")
+	}
+	if err := journal.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := OpenJournal(path, EventRetentionSpec{MaxBytes: 350, MaxAgeSeconds: 3600}, cursor.Latest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reopened.Close()
+	next, err := reopened.Append(Event{SessionID: "ses-test", Type: "session.updated"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if next.Seq != appended.Seq+1 {
+		t.Fatalf("reopened seq = %d, want %d", next.Seq, appended.Seq+1)
+	}
+}
+
+func TestJournalCursorWhenRetentionRemovesEveryEvent(t *testing.T) {
+	journal, err := OpenJournal(
+		filepath.Join(t.TempDir(), "events.jsonl"),
+		EventRetentionSpec{MaxBytes: 1, MaxAgeSeconds: 3600},
+		0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer journal.Close()
+
+	if _, err := journal.Append(Event{SessionID: "ses-test", Type: "session.created"}); err != nil {
+		t.Fatal(err)
+	}
+	cursor := journal.Cursor()
+	if cursor.Earliest != 2 || cursor.Latest != 1 {
+		t.Fatalf("cursor = %#v, want empty retained window [2, 1]", cursor)
+	}
+	if _, err := journal.Read(0, 100); !errors.Is(err, ErrCursorExpired) {
+		t.Fatalf("Read(0) error = %v, want cursor expired", err)
+	}
+	page, err := journal.Read(1, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Events) != 0 {
+		t.Fatalf("Read(1) returned %d events, want 0", len(page.Events))
+	}
+	if _, err := journal.Read(2, 100); err == nil {
+		t.Fatal("Read(2) succeeded with a cursor newer than the journal")
+	}
+}
+
+func TestJournalReadPrunesEventsThatExpiredWhileIdle(t *testing.T) {
+	journal, err := OpenJournal(
+		filepath.Join(t.TempDir(), "events.jsonl"),
+		EventRetentionSpec{MaxBytes: 1 << 20, MaxAgeSeconds: 1},
+		0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer journal.Close()
+
+	if _, err := journal.Append(Event{
+		SessionID:  "ses-test",
+		Type:       "session.created",
+		OccurredAt: time.Now().Add(-2 * time.Second),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := journal.Read(0, 100); !errors.Is(err, ErrCursorExpired) {
+		t.Fatalf("Read(0) error = %v, want cursor expired after idle age pruning", err)
+	}
+	if cursor := journal.Cursor(); cursor.Earliest != 2 || cursor.Latest != 1 {
+		t.Fatalf("cursor = %#v, want empty retained window [2, 1]", cursor)
+	}
+}
+
+func TestJournalReopenTruncatesIncompleteTail(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "events.jsonl")
+	retention := EventRetentionSpec{MaxBytes: 1 << 20, MaxAgeSeconds: 3600}
+	journal, err := OpenJournal(path, retention, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := journal.Append(Event{SessionID: "ses-test", Type: "session.created"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := journal.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := file.WriteString(`{"seq":2`); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := OpenJournal(path, retention, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := reopened.Append(Event{SessionID: "ses-test", Type: "session.updated"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.Seq != 2 {
+		t.Fatalf("second sequence = %d, want 2", second.Seq)
+	}
+	if err := reopened.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	verified, err := OpenJournal(path, retention, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer verified.Close()
+	page, err := verified.Read(0, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Events) != 2 || page.Events[1].Seq != 2 {
+		t.Fatalf("events = %#v, want two complete records", page.Events)
+	}
+}

--- a/manager/procd/pkg/session/store.go
+++ b/manager/procd/pkg/session/store.go
@@ -1,0 +1,201 @@
+package session
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	sessionStateFile  = "state.json"
+	sessionEventsFile = "events.jsonl"
+	sandboxIDFile     = "sandbox-id"
+)
+
+type persistedSession struct {
+	Session
+	InputReceipts []InputReceipt `json:"input_receipts,omitempty"`
+	CreationKey   string         `json:"creation_key,omitempty"`
+}
+
+// FileStore persists session control state under a procd-owned state directory.
+type FileStore struct {
+	root string
+}
+
+func NewFileStore(root string) (*FileStore, error) {
+	root = filepath.Clean(strings.TrimSpace(root))
+	if root == "." || !filepath.IsAbs(root) {
+		return nil, errors.New("session state directory must be absolute")
+	}
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		return nil, fmt.Errorf("create session state directory: %w", err)
+	}
+	return &FileStore{root: root}, nil
+}
+
+func (s *FileStore) Load() ([]Session, error) {
+	entries, err := os.ReadDir(s.root)
+	if err != nil {
+		return nil, fmt.Errorf("read session state directory: %w", err)
+	}
+	sessions := make([]Session, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() || !strings.HasPrefix(entry.Name(), "ses-") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(s.root, entry.Name(), sessionStateFile))
+		if errors.Is(err, fs.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read session %s: %w", entry.Name(), err)
+		}
+		var stored persistedSession
+		if err := json.Unmarshal(data, &stored); err != nil {
+			return nil, fmt.Errorf("decode session %s: %w", entry.Name(), err)
+		}
+		if stored.ID == "" || stored.ID != entry.Name() {
+			return nil, fmt.Errorf("session state directory %s has mismatched id %q", entry.Name(), stored.ID)
+		}
+		stored.Spec = normalizeSpec(stored.Spec)
+		stored.Session.InputReceipts = append([]InputReceipt(nil), stored.InputReceipts...)
+		stored.Session.CreationKey = stored.CreationKey
+		sessions = append(sessions, stored.Session)
+	}
+	return sessions, nil
+}
+
+// BindSandbox binds persisted sessions to one sandbox identity. Legacy stores
+// without an identity are adopted in place. A copied store is cleared before
+// it is rebound so a fork cannot execute the source sandbox's sessions.
+func (s *FileStore) BindSandbox(sandboxID string) (bool, error) {
+	sandboxID = strings.TrimSpace(sandboxID)
+	if sandboxID == "" || strings.ContainsAny(sandboxID, "\r\n") {
+		return false, errors.New("sandbox id is required")
+	}
+	path := filepath.Join(s.root, sandboxIDFile)
+	data, err := os.ReadFile(path)
+	switch {
+	case err == nil:
+		if strings.TrimSpace(string(data)) == sandboxID {
+			return true, nil
+		}
+		return false, nil
+	case errors.Is(err, fs.ErrNotExist):
+		if err := writeFileAtomic(path, []byte(sandboxID+"\n"), 0o600); err != nil {
+			return false, fmt.Errorf("persist sandbox identity: %w", err)
+		}
+		return true, nil
+	default:
+		return false, fmt.Errorf("read sandbox identity: %w", err)
+	}
+}
+
+// ResetForSandbox removes copied session state before changing its owner.
+func (s *FileStore) ResetForSandbox(sandboxID string) error {
+	sandboxID = strings.TrimSpace(sandboxID)
+	if sandboxID == "" || strings.ContainsAny(sandboxID, "\r\n") {
+		return errors.New("sandbox id is required")
+	}
+	entries, err := os.ReadDir(s.root)
+	if err != nil {
+		return fmt.Errorf("read session state directory: %w", err)
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() || !strings.HasPrefix(entry.Name(), "ses-") {
+			continue
+		}
+		if err := os.RemoveAll(filepath.Join(s.root, entry.Name())); err != nil {
+			return fmt.Errorf("remove copied session %s: %w", entry.Name(), err)
+		}
+	}
+	if err := writeFileAtomic(filepath.Join(s.root, sandboxIDFile), []byte(sandboxID+"\n"), 0o600); err != nil {
+		return fmt.Errorf("persist sandbox identity: %w", err)
+	}
+	return nil
+}
+
+func (s *FileStore) Save(value Session) error {
+	dir, err := s.sessionDir(value.ID)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create session directory: %w", err)
+	}
+	stored := persistedSession{
+		Session:       cloneSession(value),
+		InputReceipts: append([]InputReceipt(nil), value.InputReceipts...),
+		CreationKey:   value.CreationKey,
+	}
+	data, err := json.MarshalIndent(stored, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode session state: %w", err)
+	}
+	data = append(data, '\n')
+	if err := writeFileAtomic(filepath.Join(dir, sessionStateFile), data, 0o600); err != nil {
+		return fmt.Errorf("persist session state: %w", err)
+	}
+	return nil
+}
+
+func (s *FileStore) Delete(id string) error {
+	dir, err := s.sessionDir(id)
+	if err != nil {
+		return err
+	}
+	if err := os.RemoveAll(dir); err != nil {
+		return fmt.Errorf("delete session state: %w", err)
+	}
+	return nil
+}
+
+func (s *FileStore) JournalPath(id string) (string, error) {
+	dir, err := s.sessionDir(id)
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("create session directory: %w", err)
+	}
+	return filepath.Join(dir, sessionEventsFile), nil
+}
+
+func (s *FileStore) sessionDir(id string) (string, error) {
+	id = strings.TrimSpace(id)
+	if id == "" || filepath.Base(id) != id || !strings.HasPrefix(id, "ses-") {
+		return "", errors.New("invalid session id")
+	}
+	return filepath.Join(s.root, id), nil
+}
+
+func writeFileAtomic(path string, data []byte, mode fs.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".state-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if err := tmp.Chmod(mode); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}

--- a/manager/procd/pkg/session/store.go
+++ b/manager/procd/pkg/session/store.go
@@ -176,6 +176,9 @@ func (s *FileStore) sessionDir(id string) (string, error) {
 
 func writeFileAtomic(path string, data []byte, mode fs.FileMode) error {
 	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
 	tmp, err := os.CreateTemp(dir, ".state-*.tmp")
 	if err != nil {
 		return err

--- a/manager/procd/pkg/session/store_test.go
+++ b/manager/procd/pkg/session/store_test.go
@@ -1,0 +1,34 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestFileStoreBindSandboxRecreatesStateDirectory(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "sessions")
+	store, err := NewFileStore(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(root); err != nil {
+		t.Fatal(err)
+	}
+
+	bound, err := store.BindSandbox("sandbox-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bound {
+		t.Fatal("BindSandbox() reported an identity conflict for a recreated store")
+	}
+	data, err := os.ReadFile(filepath.Join(root, sandboxIDFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(data)) != "sandbox-a" {
+		t.Fatalf("sandbox identity = %q, want sandbox-a", data)
+	}
+}

--- a/manager/procd/pkg/session/supervisor.go
+++ b/manager/procd/pkg/session/supervisor.go
@@ -1,0 +1,1377 @@
+package session
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/process"
+	cmdproc "github.com/sandbox0-ai/sandbox0/manager/procd/pkg/process/cmd"
+	"go.uber.org/zap"
+)
+
+const maxInputReceipts = 1024
+
+type attemptRuntime struct {
+	attemptID       string
+	proc            process.Process
+	exitEvents      chan process.ExitEvent
+	done            chan struct{}
+	doneOnce        sync.Once
+	ready           bool
+	outputTail      []byte
+	exitReason      string
+	suppressRestart bool
+}
+
+type managedSession struct {
+	mu            sync.Mutex
+	inputMu       sync.Mutex
+	record        Session
+	journal       *Journal
+	runtime       *attemptRuntime
+	restartTimes  []time.Time
+	restartCancel context.CancelFunc
+	deleting      bool
+}
+
+// Supervisor owns process attempts, session state, and event journals.
+type Supervisor struct {
+	mu                sync.RWMutex
+	store             *FileStore
+	sessions          map[string]*managedSession
+	creationKeys      map[string]string
+	transients        map[string]process.Process
+	sandboxID         string
+	sandboxEnv        map[string]string
+	runtimeGeneration int64
+	initialized       bool
+	ctx               context.Context
+	cancel            context.CancelFunc
+	logger            *zap.Logger
+}
+
+func NewSupervisor(store *FileStore, logger *zap.Logger) (*Supervisor, error) {
+	if store == nil {
+		return nil, errors.New("session store is required")
+	}
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &Supervisor{
+		store:        store,
+		sessions:     map[string]*managedSession{},
+		creationKeys: map[string]string{},
+		transients:   map[string]process.Process{},
+		sandboxEnv:   map[string]string{},
+		ctx:          ctx,
+		cancel:       cancel,
+		logger:       logger,
+	}
+	go s.cleanupLoop()
+	return s, nil
+}
+
+func (s *Supervisor) loadPersistedSessionsLocked() error {
+	if len(s.sessions) > 0 {
+		return nil
+	}
+	stored, err := s.store.Load()
+	if err != nil {
+		return err
+	}
+	loadedSessions := make(map[string]*managedSession, len(stored))
+	loadedKeys := make(map[string]string)
+	closeLoaded := func() {
+		for _, managed := range loadedSessions {
+			_ = managed.journal.Close()
+		}
+	}
+	for _, record := range stored {
+		if record.CreationKey != "" {
+			if existingID, exists := loadedKeys[record.CreationKey]; exists {
+				closeLoaded()
+				return fmt.Errorf("sessions %s and %s share creation key %q", existingID, record.ID, record.CreationKey)
+			}
+			loadedKeys[record.CreationKey] = record.ID
+		}
+		path, err := s.store.JournalPath(record.ID)
+		if err != nil {
+			closeLoaded()
+			return err
+		}
+		journal, err := OpenJournal(path, record.Spec.EventRetention, record.Cursor.Latest)
+		if err != nil {
+			closeLoaded()
+			return fmt.Errorf("open journal for %s: %w", record.ID, err)
+		}
+		record.Cursor = journal.Cursor()
+		loadedSessions[record.ID] = &managedSession{record: record, journal: journal}
+	}
+	s.sessions = loadedSessions
+	s.creationKeys = loadedKeys
+	return nil
+}
+
+// StartTransient registers and starts a legacy process through the shared supervisor.
+// Transient processes are not persisted or exposed as execution sessions.
+func (s *Supervisor) StartTransient(id string, proc process.Process) error {
+	if strings.TrimSpace(id) == "" || proc == nil {
+		return errors.New("transient id and process are required")
+	}
+	s.mu.Lock()
+	if _, exists := s.transients[id]; exists {
+		s.mu.Unlock()
+		return ErrSessionExists
+	}
+	s.transients[id] = proc
+	s.mu.Unlock()
+	if err := proc.Start(); err != nil {
+		s.mu.Lock()
+		delete(s.transients, id)
+		s.mu.Unlock()
+		return err
+	}
+	return nil
+}
+
+// DeleteTransient stops and removes a transient process.
+func (s *Supervisor) DeleteTransient(id string) error {
+	s.mu.Lock()
+	proc, exists := s.transients[id]
+	if exists {
+		delete(s.transients, id)
+	}
+	s.mu.Unlock()
+	if !exists {
+		return ErrSessionNotFound
+	}
+	return proc.Stop()
+}
+
+// RestartTransient restarts a transient process without changing its identity.
+func (s *Supervisor) RestartTransient(id string) error {
+	s.mu.RLock()
+	proc, exists := s.transients[id]
+	s.mu.RUnlock()
+	if !exists {
+		return ErrSessionNotFound
+	}
+	return proc.Restart()
+}
+
+// Initialize binds persisted state to the sandbox, provides sandbox-scoped
+// defaults, and reconciles sessions after a runtime replacement.
+func (s *Supervisor) Initialize(sandboxID string, runtimeGeneration int64, sandboxEnv map[string]string) error {
+	sandboxID = strings.TrimSpace(sandboxID)
+	s.mu.Lock()
+	if s.initialized {
+		if s.sandboxID != sandboxID {
+			s.mu.Unlock()
+			return fmt.Errorf("session supervisor is already bound to sandbox %q", s.sandboxID)
+		}
+		s.runtimeGeneration = runtimeGeneration
+		s.sandboxEnv = process.CloneEnvVars(sandboxEnv)
+		s.mu.Unlock()
+		return nil
+	}
+	bound, err := s.store.BindSandbox(sandboxID)
+	if err != nil {
+		s.mu.Unlock()
+		return err
+	}
+	if !bound {
+		if err := s.store.ResetForSandbox(sandboxID); err != nil {
+			s.mu.Unlock()
+			return err
+		}
+		s.sessions = map[string]*managedSession{}
+		s.creationKeys = map[string]string{}
+	}
+	// Rootfs restore happens after the new procd process starts. Load only now,
+	// after manager has applied the checkpoint into the portal backing store.
+	if err := s.loadPersistedSessionsLocked(); err != nil {
+		s.mu.Unlock()
+		return err
+	}
+	s.initialized = true
+	s.sandboxID = sandboxID
+	s.runtimeGeneration = runtimeGeneration
+	s.sandboxEnv = process.CloneEnvVars(sandboxEnv)
+	sessions := make([]*managedSession, 0, len(s.sessions))
+	for _, managed := range s.sessions {
+		sessions = append(sessions, managed)
+	}
+	s.mu.Unlock()
+
+	for _, managed := range sessions {
+		shouldStart, err := s.recoverPersistedSession(managed, runtimeGeneration)
+		if err != nil {
+			return err
+		}
+		if shouldStart {
+			if err := s.startAttempt(managed, "runtime_recovered"); err != nil {
+				s.logger.Warn("Failed to recover session attempt",
+					zap.String("session_id", managed.record.ID),
+					zap.Error(err),
+				)
+			}
+		}
+	}
+	return nil
+}
+
+// SetSandboxEnvVars replaces sandbox-scoped defaults used by future attempts.
+func (s *Supervisor) SetSandboxEnvVars(sandboxEnv map[string]string) {
+	s.mu.Lock()
+	s.sandboxEnv = process.CloneEnvVars(sandboxEnv)
+	s.mu.Unlock()
+}
+
+func (s *Supervisor) Create(spec SessionSpec, creationKey string) (*Session, bool, error) {
+	spec = normalizeSpec(spec)
+	if err := validateSpec(spec); err != nil {
+		return nil, false, err
+	}
+	creationKey = strings.TrimSpace(creationKey)
+
+	// Serialize creation so the idempotency key is a true uniqueness boundary,
+	// including when identical retries arrive concurrently.
+	s.mu.Lock()
+	if existingID, exists := s.creationKeys[creationKey]; creationKey != "" && exists {
+		existing := s.sessions[existingID]
+		if existing == nil {
+			delete(s.creationKeys, creationKey)
+		} else {
+			existing.mu.Lock()
+			matchesSpec := reflect.DeepEqual(existing.record.Spec, spec)
+			deleting := existing.deleting
+			snapshot := cloneSession(existing.record)
+			existing.mu.Unlock()
+			s.mu.Unlock()
+			if deleting || !matchesSpec {
+				return nil, false, ErrSessionExists
+			}
+			return &snapshot, true, nil
+		}
+	}
+
+	now := time.Now().UTC()
+	id := ""
+	for id == "" {
+		candidate := "ses-" + uuid.NewString()[:12]
+		if _, exists := s.sessions[candidate]; !exists {
+			id = candidate
+		}
+	}
+	record := Session{
+		ID:                id,
+		Spec:              spec,
+		SpecVersion:       1,
+		Phase:             PhasePending,
+		RuntimeGeneration: s.runtimeGeneration,
+		CreatedAt:         now,
+		UpdatedAt:         now,
+		LastActivityAt:    now,
+		CreationKey:       creationKey,
+	}
+	path, err := s.store.JournalPath(record.ID)
+	if err != nil {
+		s.mu.Unlock()
+		return nil, false, err
+	}
+	journal, err := OpenJournal(path, spec.EventRetention, 0)
+	if err != nil {
+		s.mu.Unlock()
+		return nil, false, err
+	}
+	managed := &managedSession{record: record, journal: journal}
+	managed.mu.Lock()
+	if _, err := s.appendEventLocked(managed, Event{Type: "session.created"}); err != nil {
+		managed.mu.Unlock()
+		_ = journal.Close()
+		_ = s.store.Delete(record.ID)
+		s.mu.Unlock()
+		return nil, false, err
+	}
+	if err := s.saveLocked(managed); err != nil {
+		managed.mu.Unlock()
+		_ = journal.Close()
+		_ = s.store.Delete(record.ID)
+		s.mu.Unlock()
+		return nil, false, err
+	}
+	managed.mu.Unlock()
+
+	s.sessions[record.ID] = managed
+	if creationKey != "" {
+		s.creationKeys[creationKey] = record.ID
+	}
+	initialized := s.initialized
+	s.mu.Unlock()
+
+	if initialized && spec.Lifecycle.DesiredState == DesiredStateRunning {
+		if err := s.startAttempt(managed, "created"); err != nil {
+			s.logger.Warn("Failed to start created session",
+				zap.String("session_id", record.ID),
+				zap.Error(err),
+			)
+		}
+	}
+	snapshot := s.snapshot(managed)
+	return &snapshot, false, nil
+}
+
+func (s *Supervisor) List() []Session {
+	s.mu.RLock()
+	managed := make([]*managedSession, 0, len(s.sessions))
+	for _, item := range s.sessions {
+		managed = append(managed, item)
+	}
+	s.mu.RUnlock()
+	result := make([]Session, 0, len(managed))
+	for _, item := range managed {
+		result = append(result, s.snapshot(item))
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].CreatedAt.Equal(result[j].CreatedAt) {
+			return result[i].ID < result[j].ID
+		}
+		return result[i].CreatedAt.Before(result[j].CreatedAt)
+	})
+	return result
+}
+
+func (s *Supervisor) Get(id string) (*Session, error) {
+	managed, err := s.getManaged(id)
+	if err != nil {
+		return nil, err
+	}
+	snapshot := s.snapshot(managed)
+	return &snapshot, nil
+}
+
+func (s *Supervisor) Update(id string, spec SessionSpec) (*Session, error) {
+	spec = normalizeSpec(spec)
+	if err := validateSpec(spec); err != nil {
+		return nil, err
+	}
+	managed, err := s.getManaged(id)
+	if err != nil {
+		return nil, err
+	}
+	managed.mu.Lock()
+	oldSpec := managed.record.Spec
+	hadRuntime := managed.runtime != nil
+	managed.record.Spec = spec
+	managed.record.SpecVersion++
+	managed.record.UpdatedAt = time.Now().UTC()
+	if _, err := s.appendEventLocked(managed, Event{Type: "session.updated"}); err != nil {
+		managed.mu.Unlock()
+		return nil, err
+	}
+	if err := managed.journal.SetRetention(spec.EventRetention); err != nil {
+		managed.mu.Unlock()
+		return nil, err
+	}
+	if err := s.saveLocked(managed); err != nil {
+		managed.mu.Unlock()
+		return nil, err
+	}
+	managed.mu.Unlock()
+
+	executionChanged := !reflect.DeepEqual(executionSpec(oldSpec), executionSpec(spec))
+	if spec.Lifecycle.DesiredState == DesiredStateStopped {
+		if err := s.stopAttempt(managed, "desired_state_stopped"); err != nil {
+			return nil, err
+		}
+	} else if executionChanged && hadRuntime {
+		if err := s.stopAttempt(managed, "spec_replaced"); err != nil {
+			return nil, err
+		}
+		if err := s.startAttempt(managed, "spec_updated"); err != nil {
+			return nil, err
+		}
+	} else if !hadRuntime {
+		if err := s.startAttempt(managed, "desired_state_running"); err != nil {
+			return nil, err
+		}
+	}
+	snapshot := s.snapshot(managed)
+	return &snapshot, nil
+}
+
+func (s *Supervisor) SetDesiredState(id string, state DesiredState) (*Session, error) {
+	if state != DesiredStateRunning && state != DesiredStateStopped {
+		return nil, errors.New("invalid desired state")
+	}
+	managed, err := s.getManaged(id)
+	if err != nil {
+		return nil, err
+	}
+	managed.mu.Lock()
+	managed.record.Spec.Lifecycle.DesiredState = state
+	managed.record.SpecVersion++
+	managed.record.UpdatedAt = time.Now().UTC()
+	if _, err := s.appendEventLocked(managed, Event{Type: "session.desired_state", Reason: string(state)}); err != nil {
+		managed.mu.Unlock()
+		return nil, err
+	}
+	if err := s.saveLocked(managed); err != nil {
+		managed.mu.Unlock()
+		return nil, err
+	}
+	hasRuntime := managed.runtime != nil
+	managed.mu.Unlock()
+	if state == DesiredStateStopped {
+		if err := s.stopAttempt(managed, "desired_state_stopped"); err != nil {
+			return nil, err
+		}
+	} else if !hasRuntime {
+		if err := s.startAttempt(managed, "desired_state_running"); err != nil {
+			return nil, err
+		}
+	}
+	snapshot := s.snapshot(managed)
+	return &snapshot, nil
+}
+
+func (s *Supervisor) CreateAttempt(id string, replaceCurrent bool) (*Session, error) {
+	managed, err := s.getManaged(id)
+	if err != nil {
+		return nil, err
+	}
+	managed.mu.Lock()
+	hasRuntime := managed.runtime != nil
+	managed.mu.Unlock()
+	if hasRuntime && !replaceCurrent {
+		return nil, errors.New("session already has a running attempt")
+	}
+	if hasRuntime {
+		if err := s.stopAttempt(managed, "attempt_replaced"); err != nil {
+			return nil, err
+		}
+	}
+	managed.mu.Lock()
+	managed.record.Spec.Lifecycle.DesiredState = DesiredStateRunning
+	managed.record.SpecVersion++
+	if err := s.saveLocked(managed); err != nil {
+		managed.mu.Unlock()
+		return nil, err
+	}
+	managed.mu.Unlock()
+	if err := s.startAttempt(managed, "attempt_created"); err != nil {
+		return nil, err
+	}
+	snapshot := s.snapshot(managed)
+	return &snapshot, nil
+}
+
+func (s *Supervisor) Delete(id string) error {
+	managed, err := s.getManaged(id)
+	if err != nil {
+		return err
+	}
+	managed.mu.Lock()
+	managed.deleting = true
+	managed.record.Spec.Lifecycle.DesiredState = DesiredStateStopped
+	managed.mu.Unlock()
+	if err := s.stopAttempt(managed, "session_deleted"); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	delete(s.sessions, id)
+	if managed.record.CreationKey != "" {
+		delete(s.creationKeys, managed.record.CreationKey)
+	}
+	s.mu.Unlock()
+	managed.mu.Lock()
+	if managed.restartCancel != nil {
+		managed.restartCancel()
+		managed.restartCancel = nil
+	}
+	managed.mu.Unlock()
+	if err := managed.journal.Close(); err != nil {
+		return err
+	}
+	return s.store.Delete(id)
+}
+
+func (s *Supervisor) WriteInput(id string, request InputRequest) (*InputResponse, error) {
+	managed, err := s.getManaged(id)
+	if err != nil {
+		return nil, err
+	}
+	request.InputID = strings.TrimSpace(request.InputID)
+	if request.InputID == "" {
+		return nil, errors.New("input_id is required")
+	}
+	data, err := base64.StdEncoding.DecodeString(request.DataBase64)
+	if err != nil {
+		return nil, errors.New("data_base64 is invalid")
+	}
+	if len(data) == 0 && !request.EOF {
+		return nil, errors.New("data_base64 or eof is required")
+	}
+	managed.inputMu.Lock()
+	defer managed.inputMu.Unlock()
+
+	managed.mu.Lock()
+	runtime := managed.runtime
+	attemptID := ""
+	if managed.record.Attempt != nil {
+		attemptID = managed.record.Attempt.ID
+	}
+	if request.ExpectedAttemptID != "" && request.ExpectedAttemptID != attemptID {
+		managed.mu.Unlock()
+		return nil, ErrAttemptMismatch
+	}
+	digest := inputDigest(attemptID, data, request.EOF)
+	for _, receipt := range managed.record.InputReceipts {
+		if receipt.InputID != request.InputID {
+			continue
+		}
+		if receipt.Digest != digest || receipt.AttemptID != attemptID {
+			managed.mu.Unlock()
+			return nil, ErrInputAlreadyExists
+		}
+		response := &InputResponse{InputID: request.InputID, AttemptID: attemptID, Accepted: true, Duplicate: true}
+		managed.mu.Unlock()
+		return response, nil
+	}
+	if runtime == nil {
+		managed.mu.Unlock()
+		return nil, ErrSessionNotRunning
+	}
+	proc := runtime.proc
+	attemptID = runtime.attemptID
+	managed.mu.Unlock()
+
+	if len(data) > 0 {
+		if err := proc.WriteInput(data); err != nil {
+			return nil, err
+		}
+	}
+	if request.EOF {
+		closer, ok := proc.(interface{ CloseInput() error })
+		if !ok {
+			return nil, errors.New("process input cannot be closed")
+		}
+		if err := closer.CloseInput(); err != nil {
+			return nil, err
+		}
+	}
+
+	managed.mu.Lock()
+	if managed.runtime == nil || managed.runtime.attemptID != attemptID {
+		managed.mu.Unlock()
+		return nil, ErrAttemptMismatch
+	}
+	now := time.Now().UTC()
+	managed.record.InputReceipts = append(managed.record.InputReceipts, InputReceipt{
+		InputID: request.InputID, AttemptID: attemptID, Digest: digest, AcceptedAt: now,
+	})
+	if len(managed.record.InputReceipts) > maxInputReceipts {
+		managed.record.InputReceipts = append([]InputReceipt(nil), managed.record.InputReceipts[len(managed.record.InputReceipts)-maxInputReceipts:]...)
+	}
+	managed.record.LastActivityAt = now
+	managed.record.UpdatedAt = now
+	_, _ = s.appendEventLocked(managed, Event{Type: "input.accepted", AttemptID: attemptID})
+	if err := s.saveLocked(managed); err != nil {
+		managed.mu.Unlock()
+		return nil, err
+	}
+	managed.mu.Unlock()
+	return &InputResponse{InputID: request.InputID, AttemptID: attemptID, Accepted: true}, nil
+}
+
+func (s *Supervisor) SendSignal(id, expectedAttemptID string, signal syscall.Signal) error {
+	managed, err := s.getManaged(id)
+	if err != nil {
+		return err
+	}
+	managed.mu.Lock()
+	runtime := managed.runtime
+	if runtime == nil {
+		managed.mu.Unlock()
+		return ErrSessionNotRunning
+	}
+	if expectedAttemptID != "" && expectedAttemptID != runtime.attemptID {
+		managed.mu.Unlock()
+		return ErrAttemptMismatch
+	}
+	proc := runtime.proc
+	attemptID := runtime.attemptID
+	managed.mu.Unlock()
+	if err := proc.SendSignal(signal); err != nil {
+		return err
+	}
+	managed.mu.Lock()
+	_, _ = s.appendEventLocked(managed, Event{Type: "signal.sent", AttemptID: attemptID, Reason: signal.String()})
+	managed.record.LastActivityAt = time.Now().UTC()
+	err = s.saveLocked(managed)
+	managed.mu.Unlock()
+	return err
+}
+
+func (s *Supervisor) ResizeTerminal(id, expectedAttemptID string, rows, cols uint16) error {
+	if rows == 0 || cols == 0 {
+		return errors.New("rows and cols must be greater than zero")
+	}
+	managed, err := s.getManaged(id)
+	if err != nil {
+		return err
+	}
+	managed.mu.Lock()
+	runtime := managed.runtime
+	if runtime == nil {
+		managed.mu.Unlock()
+		return ErrSessionNotRunning
+	}
+	if expectedAttemptID != "" && expectedAttemptID != runtime.attemptID {
+		managed.mu.Unlock()
+		return ErrAttemptMismatch
+	}
+	proc := runtime.proc
+	attemptID := runtime.attemptID
+	managed.mu.Unlock()
+	if err := proc.ResizePTY(process.PTYSize{Rows: rows, Cols: cols}); err != nil {
+		return err
+	}
+	managed.mu.Lock()
+	_, _ = s.appendEventLocked(managed, Event{Type: "terminal.resized", AttemptID: attemptID})
+	managed.record.LastActivityAt = time.Now().UTC()
+	err = s.saveLocked(managed)
+	managed.mu.Unlock()
+	return err
+}
+
+func (s *Supervisor) Events(id string, after int64, limit int) (EventPage, error) {
+	managed, err := s.getManaged(id)
+	if err != nil {
+		return EventPage{}, err
+	}
+	return managed.journal.Read(after, limit)
+}
+
+func (s *Supervisor) Subscribe(id string, after int64) ([]Event, <-chan Event, func(), EventCursor, error) {
+	managed, err := s.getManaged(id)
+	if err != nil {
+		return nil, nil, nil, EventCursor{}, err
+	}
+	return managed.journal.Subscribe(after)
+}
+
+func (s *Supervisor) PauseAll() error {
+	s.mu.RLock()
+	sessions := make([]*managedSession, 0, len(s.sessions))
+	for _, managed := range s.sessions {
+		sessions = append(sessions, managed)
+	}
+	transients := make([]process.Process, 0, len(s.transients))
+	for _, proc := range s.transients {
+		transients = append(transients, proc)
+	}
+	s.mu.RUnlock()
+	var errs []error
+	for _, proc := range transients {
+		if proc.IsRunning() {
+			errs = append(errs, proc.Pause())
+		}
+	}
+	for _, managed := range sessions {
+		managed.mu.Lock()
+		runtime := managed.runtime
+		if runtime == nil || !runtime.proc.IsRunning() {
+			managed.mu.Unlock()
+			continue
+		}
+		proc := runtime.proc
+		attemptID := runtime.attemptID
+		managed.mu.Unlock()
+		if err := proc.Pause(); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		managed.mu.Lock()
+		managed.record.Phase = PhasePaused
+		managed.record.UpdatedAt = time.Now().UTC()
+		_, _ = s.appendEventLocked(managed, Event{Type: "session.paused", AttemptID: attemptID})
+		if err := s.saveLocked(managed); err != nil {
+			errs = append(errs, err)
+		}
+		if err := managed.journal.Flush(); err != nil {
+			errs = append(errs, err)
+		}
+		managed.mu.Unlock()
+	}
+	return errors.Join(errs...)
+}
+
+func (s *Supervisor) ResumeAll() error {
+	s.mu.RLock()
+	sessions := make([]*managedSession, 0, len(s.sessions))
+	for _, managed := range s.sessions {
+		sessions = append(sessions, managed)
+	}
+	transients := make([]process.Process, 0, len(s.transients))
+	for _, proc := range s.transients {
+		transients = append(transients, proc)
+	}
+	s.mu.RUnlock()
+	var errs []error
+	for _, proc := range transients {
+		if proc.IsPaused() {
+			errs = append(errs, proc.Resume())
+		}
+	}
+	for _, managed := range sessions {
+		managed.mu.Lock()
+		runtime := managed.runtime
+		if runtime == nil || !runtime.proc.IsPaused() {
+			managed.mu.Unlock()
+			continue
+		}
+		proc := runtime.proc
+		attemptID := runtime.attemptID
+		managed.mu.Unlock()
+		if err := proc.Resume(); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		managed.mu.Lock()
+		managed.record.Phase = PhaseRunning
+		managed.record.UpdatedAt = time.Now().UTC()
+		_, _ = s.appendEventLocked(managed, Event{Type: "session.resumed", AttemptID: attemptID})
+		if err := s.saveLocked(managed); err != nil {
+			errs = append(errs, err)
+		}
+		managed.mu.Unlock()
+	}
+	return errors.Join(errs...)
+}
+
+func (s *Supervisor) Flush() error {
+	s.mu.RLock()
+	sessions := make([]*managedSession, 0, len(s.sessions))
+	for _, managed := range s.sessions {
+		sessions = append(sessions, managed)
+	}
+	s.mu.RUnlock()
+	var errs []error
+	for _, managed := range sessions {
+		managed.mu.Lock()
+		managed.record.Cursor = managed.journal.Cursor()
+		if err := s.saveLocked(managed); err != nil {
+			errs = append(errs, err)
+		}
+		if err := managed.journal.Flush(); err != nil {
+			errs = append(errs, err)
+		}
+		managed.mu.Unlock()
+	}
+	return errors.Join(errs...)
+}
+
+func (s *Supervisor) Close() error {
+	s.cancel()
+	s.mu.RLock()
+	sessions := make([]*managedSession, 0, len(s.sessions))
+	for _, managed := range s.sessions {
+		sessions = append(sessions, managed)
+	}
+	s.mu.RUnlock()
+	var errs []error
+	for _, managed := range sessions {
+		managed.mu.Lock()
+		if managed.restartCancel != nil {
+			managed.restartCancel()
+		}
+		managed.record.Cursor = managed.journal.Cursor()
+		if err := s.saveLocked(managed); err != nil {
+			errs = append(errs, err)
+		}
+		managed.mu.Unlock()
+		if err := managed.journal.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (s *Supervisor) startAttempt(managed *managedSession, reason string) error {
+	s.mu.RLock()
+	initialized := s.initialized
+	runtimeGeneration := s.runtimeGeneration
+	sandboxEnv := process.CloneEnvVars(s.sandboxEnv)
+	s.mu.RUnlock()
+	if !initialized {
+		return nil
+	}
+
+	managed.mu.Lock()
+	if managed.deleting || managed.record.Spec.Lifecycle.DesiredState != DesiredStateRunning {
+		managed.mu.Unlock()
+		return nil
+	}
+	if managed.runtime != nil {
+		managed.mu.Unlock()
+		return nil
+	}
+	if managed.restartCancel != nil {
+		managed.restartCancel()
+		managed.restartCancel = nil
+	}
+	number := int64(1)
+	if managed.record.Attempt != nil {
+		number = managed.record.Attempt.Number + 1
+	}
+	attemptID := "att-" + uuid.NewString()[:12]
+	attempt := &Attempt{ID: attemptID, Number: number, RuntimeGeneration: runtimeGeneration}
+	managed.record.Attempt = attempt
+	managed.record.RuntimeGeneration = runtimeGeneration
+	managed.record.Phase = PhaseStarting
+	managed.record.UpdatedAt = time.Now().UTC()
+	config := process.ProcessConfig{
+		Type:       process.ProcessTypeCMD,
+		Command:    append([]string(nil), managed.record.Spec.Command...),
+		CWD:        managed.record.Spec.CWD,
+		EnvVars:    process.MergeEnvVars(sandboxEnv, managed.record.Spec.Env),
+		BufferSize: 256,
+		PipeStdin:  managed.record.Spec.IO.Mode == IOModePipes,
+	}
+	if managed.record.Spec.IO.Mode == IOModePTY {
+		terminal := managed.record.Spec.IO.Terminal
+		config.PTYSize = &process.PTYSize{Rows: terminal.Rows, Cols: terminal.Cols}
+		config.Term = terminal.Term
+	}
+	proc, err := cmdproc.NewCMD(attemptID, config, config.Command)
+	if err != nil {
+		managed.record.Phase = PhaseFailed
+		managed.mu.Unlock()
+		return err
+	}
+	output := make(chan process.ProcessOutput, 256)
+	proc.SetReliableOutput(output)
+	runtime := &attemptRuntime{
+		attemptID:  attemptID,
+		proc:       proc,
+		exitEvents: make(chan process.ExitEvent, 1),
+		done:       make(chan struct{}),
+	}
+	proc.AddExitHandler(func(event process.ExitEvent) {
+		select {
+		case runtime.exitEvents <- event:
+		default:
+		}
+	})
+	managed.runtime = runtime
+	if _, err := s.appendEventLocked(managed, Event{Type: "attempt.starting", AttemptID: attemptID, Reason: reason}); err != nil {
+		managed.runtime = nil
+		managed.mu.Unlock()
+		return err
+	}
+	if err := s.saveLocked(managed); err != nil {
+		managed.runtime = nil
+		managed.mu.Unlock()
+		return err
+	}
+	managed.mu.Unlock()
+
+	if err := proc.Start(); err != nil {
+		s.handleStartFailure(managed, runtime, err)
+		return err
+	}
+	go s.pumpOutput(managed, runtime, output)
+
+	managed.mu.Lock()
+	if managed.runtime != runtime {
+		managed.mu.Unlock()
+		return nil
+	}
+	now := time.Now().UTC()
+	managed.record.Attempt.PID = proc.PID()
+	managed.record.Attempt.StartedAt = &now
+	managed.record.UpdatedAt = now
+	_, _ = s.appendEventLocked(managed, Event{Type: "attempt.started", AttemptID: attemptID})
+	readiness := managed.record.Spec.Readiness
+	_ = s.saveLocked(managed)
+	managed.mu.Unlock()
+
+	s.startReadiness(managed, runtime, readiness)
+	return nil
+}
+
+func (s *Supervisor) startReadiness(managed *managedSession, runtime *attemptRuntime, readiness ReadinessSpec) {
+	switch readiness.Type {
+	case ReadinessProcess:
+		s.markReady(managed, runtime)
+	case ReadinessDelay:
+		go func() {
+			timer := time.NewTimer(time.Duration(readiness.DelayMS) * time.Millisecond)
+			defer timer.Stop()
+			select {
+			case <-s.ctx.Done():
+			case <-runtime.done:
+			case <-timer.C:
+				s.markReady(managed, runtime)
+			}
+		}()
+	case ReadinessOutput:
+	}
+	if readiness.Type != ReadinessProcess && readiness.TimeoutMS > 0 {
+		go func() {
+			timer := time.NewTimer(time.Duration(readiness.TimeoutMS) * time.Millisecond)
+			defer timer.Stop()
+			select {
+			case <-s.ctx.Done():
+			case <-runtime.done:
+			case <-timer.C:
+				s.failReadiness(managed, runtime)
+			}
+		}()
+	}
+}
+
+func (s *Supervisor) pumpOutput(managed *managedSession, runtime *attemptRuntime, output <-chan process.ProcessOutput) {
+	for item := range output {
+		managed.mu.Lock()
+		if managed.runtime != runtime {
+			managed.mu.Unlock()
+			return
+		}
+		now := time.Now().UTC()
+		managed.record.LastActivityAt = now
+		managed.record.UpdatedAt = now
+		_, err := s.appendEventLocked(managed, Event{
+			Type:       "output",
+			AttemptID:  runtime.attemptID,
+			Stream:     string(item.Source),
+			DataBase64: base64.StdEncoding.EncodeToString(item.Data),
+		})
+		ready := s.observeReadinessLocked(managed, runtime, item.Data)
+		managed.mu.Unlock()
+		if err != nil {
+			s.logger.Warn("Failed to append session output", zap.String("session_id", managed.record.ID), zap.Error(err))
+		}
+		if ready {
+			s.markReady(managed, runtime)
+		}
+	}
+	var event process.ExitEvent
+	select {
+	case event = <-runtime.exitEvents:
+	case <-s.ctx.Done():
+		return
+	}
+	s.handleExit(managed, runtime, event)
+}
+
+func (s *Supervisor) observeReadinessLocked(managed *managedSession, runtime *attemptRuntime, data []byte) bool {
+	if runtime.ready || managed.record.Spec.Readiness.Type != ReadinessOutput {
+		return false
+	}
+	token := []byte(managed.record.Spec.Readiness.Output)
+	combined := make([]byte, 0, len(runtime.outputTail)+len(data))
+	combined = append(combined, runtime.outputTail...)
+	combined = append(combined, data...)
+	if bytes.Contains(combined, token) {
+		return true
+	}
+	keep := len(token) - 1
+	if keep < 0 {
+		keep = 0
+	}
+	if len(combined) > keep {
+		combined = combined[len(combined)-keep:]
+	}
+	runtime.outputTail = append(runtime.outputTail[:0], combined...)
+	return false
+}
+
+func (s *Supervisor) markReady(managed *managedSession, runtime *attemptRuntime) {
+	managed.mu.Lock()
+	defer managed.mu.Unlock()
+	if managed.runtime != runtime || runtime.ready {
+		return
+	}
+	runtime.ready = true
+	managed.record.Phase = PhaseRunning
+	managed.record.UpdatedAt = time.Now().UTC()
+	_, _ = s.appendEventLocked(managed, Event{Type: "session.ready", AttemptID: runtime.attemptID})
+	if err := s.saveLocked(managed); err != nil {
+		s.logger.Warn("Failed to persist ready session", zap.String("session_id", managed.record.ID), zap.Error(err))
+	}
+}
+
+func (s *Supervisor) failReadiness(managed *managedSession, runtime *attemptRuntime) {
+	managed.mu.Lock()
+	if managed.runtime != runtime || runtime.ready {
+		managed.mu.Unlock()
+		return
+	}
+	runtime.exitReason = "readiness_timeout"
+	proc := runtime.proc
+	grace := time.Duration(managed.record.Spec.Lifecycle.StopGracePeriodSeconds) * time.Second
+	managed.mu.Unlock()
+	_ = proc.SendSignal(syscall.SIGTERM)
+	go s.killAfterGrace(runtime, proc, grace)
+}
+
+func (s *Supervisor) handleStartFailure(managed *managedSession, runtime *attemptRuntime, startErr error) {
+	managed.mu.Lock()
+	if managed.runtime != runtime {
+		managed.mu.Unlock()
+		return
+	}
+	now := time.Now().UTC()
+	managed.record.Attempt.FinishedAt = &now
+	managed.record.Attempt.Reason = "start_failed"
+	managed.record.Phase = PhaseFailed
+	managed.record.UpdatedAt = now
+	_, _ = s.appendEventLocked(managed, Event{Type: "attempt.exited", AttemptID: runtime.attemptID, Reason: "start_failed"})
+	managed.runtime = nil
+	runtime.doneOnce.Do(func() { close(runtime.done) })
+	shouldRestart, delay := s.restartDecisionLocked(managed, 1)
+	_ = s.saveLocked(managed)
+	managed.mu.Unlock()
+	s.logger.Warn("Session attempt failed to start", zap.String("session_id", managed.record.ID), zap.Error(startErr))
+	if shouldRestart {
+		s.scheduleRestart(managed, delay)
+	}
+}
+
+func (s *Supervisor) handleExit(managed *managedSession, runtime *attemptRuntime, event process.ExitEvent) {
+	managed.mu.Lock()
+	if managed.runtime != runtime {
+		managed.mu.Unlock()
+		return
+	}
+	now := time.Now().UTC()
+	exitCode := event.ExitCode
+	managed.record.Attempt.FinishedAt = &now
+	managed.record.Attempt.ExitCode = &exitCode
+	managed.record.Attempt.PID = 0
+	reason := runtime.exitReason
+	if reason == "" {
+		reason = string(event.State)
+	}
+	managed.record.Attempt.Reason = reason
+	managed.record.UpdatedAt = now
+	managed.record.LastActivityAt = now
+	_, _ = s.appendEventLocked(managed, Event{
+		Type: "attempt.exited", AttemptID: runtime.attemptID, ExitCode: &exitCode, Reason: reason,
+	})
+	managed.runtime = nil
+	runtime.doneOnce.Do(func() { close(runtime.done) })
+	shouldRestart := false
+	delay := time.Duration(0)
+	if managed.deleting || runtime.suppressRestart || managed.record.Spec.Lifecycle.DesiredState == DesiredStateStopped {
+		managed.record.Phase = PhaseStopped
+	} else {
+		shouldRestart, delay = s.restartDecisionLocked(managed, exitCode)
+		if !shouldRestart && managed.record.Phase != PhaseFailed {
+			managed.record.Phase = PhaseExited
+		}
+	}
+	if err := s.saveLocked(managed); err != nil {
+		s.logger.Warn("Failed to persist exited session", zap.String("session_id", managed.record.ID), zap.Error(err))
+	}
+	managed.mu.Unlock()
+	if shouldRestart {
+		s.scheduleRestart(managed, delay)
+	}
+}
+
+func (s *Supervisor) restartDecisionLocked(managed *managedSession, exitCode int) (bool, time.Duration) {
+	restart := managed.record.Spec.Lifecycle.Restart
+	shouldRestart := restart.Policy == RestartPolicyAlways || (restart.Policy == RestartPolicyOnFailure && exitCode != 0)
+	if !shouldRestart {
+		return false, 0
+	}
+	now := time.Now()
+	window := time.Duration(restart.WindowSeconds) * time.Second
+	kept := managed.restartTimes[:0]
+	for _, attempt := range managed.restartTimes {
+		if window == 0 || now.Sub(attempt) <= window {
+			kept = append(kept, attempt)
+		}
+	}
+	managed.restartTimes = kept
+	if restart.MaxRestarts > 0 && len(managed.restartTimes) >= int(restart.MaxRestarts) {
+		managed.record.Phase = PhaseFailed
+		_, _ = s.appendEventLocked(managed, Event{Type: "session.failed", Reason: "restart_limit_exceeded"})
+		return false, 0
+	}
+	managed.restartTimes = append(managed.restartTimes, now)
+	managed.record.RestartCount++
+	managed.record.Phase = PhaseBackoff
+	backoff := time.Duration(restart.InitialBackoffMS) * time.Millisecond
+	for i := 1; i < len(managed.restartTimes); i++ {
+		backoff *= 2
+		maximum := time.Duration(restart.MaxBackoffMS) * time.Millisecond
+		if maximum > 0 && backoff >= maximum {
+			backoff = maximum
+			break
+		}
+	}
+	_, _ = s.appendEventLocked(managed, Event{Type: "session.backoff", Reason: backoff.String()})
+	return true, backoff
+}
+
+func (s *Supervisor) scheduleRestart(managed *managedSession, delay time.Duration) {
+	ctx, cancel := context.WithCancel(s.ctx)
+	managed.mu.Lock()
+	if managed.deleting || managed.record.Spec.Lifecycle.DesiredState != DesiredStateRunning {
+		managed.mu.Unlock()
+		cancel()
+		return
+	}
+	if managed.restartCancel != nil {
+		managed.restartCancel()
+	}
+	managed.restartCancel = cancel
+	managed.mu.Unlock()
+	go func() {
+		timer := time.NewTimer(delay)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+		}
+		if err := s.startAttempt(managed, "restart_policy"); err != nil {
+			s.logger.Warn("Failed to restart session", zap.String("session_id", managed.record.ID), zap.Error(err))
+		}
+	}()
+}
+
+func (s *Supervisor) stopAttempt(managed *managedSession, reason string) error {
+	managed.mu.Lock()
+	runtime := managed.runtime
+	if runtime == nil {
+		managed.record.Phase = PhaseStopped
+		managed.record.UpdatedAt = time.Now().UTC()
+		err := s.saveLocked(managed)
+		managed.mu.Unlock()
+		return err
+	}
+	runtime.exitReason = reason
+	runtime.suppressRestart = true
+	managed.record.Phase = PhaseStopping
+	managed.record.UpdatedAt = time.Now().UTC()
+	_, _ = s.appendEventLocked(managed, Event{Type: "attempt.stopping", AttemptID: runtime.attemptID, Reason: reason})
+	if err := s.saveLocked(managed); err != nil {
+		managed.mu.Unlock()
+		return err
+	}
+	proc := runtime.proc
+	done := runtime.done
+	grace := time.Duration(managed.record.Spec.Lifecycle.StopGracePeriodSeconds) * time.Second
+	managed.mu.Unlock()
+
+	if err := proc.SendSignal(syscall.SIGTERM); err != nil && !errors.Is(err, process.ErrProcessNotRunning) {
+		return err
+	}
+	if grace <= 0 {
+		grace = time.Duration(defaultStopGraceSeconds) * time.Second
+	}
+	timer := time.NewTimer(grace)
+	defer timer.Stop()
+	select {
+	case <-done:
+		return nil
+	case <-timer.C:
+		_ = proc.SendSignal(syscall.SIGKILL)
+	}
+	select {
+	case <-done:
+		return nil
+	case <-time.After(5 * time.Second):
+		return errors.New("timed out waiting for session process to stop")
+	}
+}
+
+func (s *Supervisor) killAfterGrace(runtime *attemptRuntime, proc process.Process, grace time.Duration) {
+	if grace <= 0 {
+		grace = time.Duration(defaultStopGraceSeconds) * time.Second
+	}
+	timer := time.NewTimer(grace)
+	defer timer.Stop()
+	select {
+	case <-runtime.done:
+	case <-s.ctx.Done():
+	case <-timer.C:
+		_ = proc.SendSignal(syscall.SIGKILL)
+	}
+}
+
+func (s *Supervisor) recoverPersistedSession(managed *managedSession, runtimeGeneration int64) (bool, error) {
+	managed.mu.Lock()
+	defer managed.mu.Unlock()
+	now := time.Now().UTC()
+	wasActive := managed.record.Phase == PhasePending || managed.record.Phase == PhaseStarting || managed.record.Phase == PhaseRunning || managed.record.Phase == PhasePaused || managed.record.Phase == PhaseBackoff || managed.record.Phase == PhaseSuspended
+	if managed.record.Attempt != nil && managed.record.Attempt.FinishedAt == nil {
+		wasActive = true
+		managed.record.Attempt.FinishedAt = &now
+		managed.record.Attempt.PID = 0
+		managed.record.Attempt.Reason = "runtime_replaced"
+		managed.record.Phase = PhaseSuspended
+		_, _ = s.appendEventLocked(managed, Event{
+			Type: "attempt.exited", AttemptID: managed.record.Attempt.ID, Reason: "runtime_replaced",
+		})
+	}
+	managed.record.RuntimeGeneration = runtimeGeneration
+	managed.record.UpdatedAt = now
+	if managed.record.Spec.Lifecycle.DesiredState != DesiredStateRunning {
+		managed.record.Phase = PhaseStopped
+		return false, s.saveLocked(managed)
+	}
+	if !wasActive {
+		return false, s.saveLocked(managed)
+	}
+	if managed.record.Spec.Lifecycle.RuntimeRecovery == RuntimeRecoveryStop {
+		managed.record.Spec.Lifecycle.DesiredState = DesiredStateStopped
+		managed.record.Phase = PhaseStopped
+		_, _ = s.appendEventLocked(managed, Event{Type: "session.stopped", Reason: "runtime_recovery_policy"})
+		return false, s.saveLocked(managed)
+	}
+	if err := s.saveLocked(managed); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (s *Supervisor) appendEventLocked(managed *managedSession, event Event) (Event, error) {
+	event.SessionID = managed.record.ID
+	event.RuntimeGeneration = managed.record.RuntimeGeneration
+	if event.AttemptID == "" && managed.record.Attempt != nil {
+		event.AttemptID = managed.record.Attempt.ID
+	}
+	appended, err := managed.journal.Append(event)
+	if err != nil {
+		return Event{}, err
+	}
+	managed.record.Cursor = managed.journal.Cursor()
+	return appended, nil
+}
+
+func (s *Supervisor) saveLocked(managed *managedSession) error {
+	managed.record.Cursor = managed.journal.Cursor()
+	return s.store.Save(managed.record)
+}
+
+func (s *Supervisor) getManaged(id string) (*managedSession, error) {
+	s.mu.RLock()
+	managed, ok := s.sessions[id]
+	s.mu.RUnlock()
+	if !ok {
+		return nil, ErrSessionNotFound
+	}
+	return managed, nil
+}
+
+func (s *Supervisor) snapshot(managed *managedSession) Session {
+	managed.mu.Lock()
+	defer managed.mu.Unlock()
+	managed.record.Cursor = managed.journal.Cursor()
+	value := cloneSession(managed.record)
+	value.InputReceipts = nil
+	value.CreationKey = ""
+	return value
+}
+
+func (s *Supervisor) cleanupLoop() {
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-s.ctx.Done():
+			return
+		case now := <-ticker.C:
+			s.pruneJournals(now)
+			s.expireSessions(now)
+		}
+	}
+}
+
+func (s *Supervisor) pruneJournals(now time.Time) {
+	s.mu.RLock()
+	sessions := make([]*managedSession, 0, len(s.sessions))
+	for _, managed := range s.sessions {
+		sessions = append(sessions, managed)
+	}
+	s.mu.RUnlock()
+	for _, managed := range sessions {
+		if err := managed.journal.Prune(now); err != nil {
+			s.logger.Warn("Failed to prune session journal", zap.String("session_id", managed.record.ID), zap.Error(err))
+		}
+	}
+}
+
+func (s *Supervisor) expireSessions(now time.Time) {
+	s.mu.RLock()
+	sessions := make([]*managedSession, 0, len(s.sessions))
+	for _, managed := range s.sessions {
+		sessions = append(sessions, managed)
+	}
+	s.mu.RUnlock()
+	for _, managed := range sessions {
+		managed.mu.Lock()
+		lifecycle := managed.record.Spec.Lifecycle
+		if lifecycle.DesiredState == DesiredStateStopped {
+			managed.mu.Unlock()
+			continue
+		}
+		expired := lifecycle.MaxLifetimeSeconds > 0 && now.Sub(managed.record.CreatedAt) >= time.Duration(lifecycle.MaxLifetimeSeconds)*time.Second
+		if !expired && lifecycle.IdleTimeoutSeconds > 0 {
+			expired = now.Sub(managed.record.LastActivityAt) >= time.Duration(lifecycle.IdleTimeoutSeconds)*time.Second
+		}
+		if expired {
+			managed.record.Spec.Lifecycle.DesiredState = DesiredStateStopped
+			_, _ = s.appendEventLocked(managed, Event{Type: "session.expired"})
+			_ = s.saveLocked(managed)
+		}
+		managed.mu.Unlock()
+		if expired {
+			if err := s.stopAttempt(managed, "session_expired"); err != nil {
+				s.logger.Warn("Failed to stop expired session", zap.String("session_id", managed.record.ID), zap.Error(err))
+			}
+		}
+	}
+}
+
+func executionSpec(spec SessionSpec) any {
+	return struct {
+		Command   []string
+		CWD       string
+		Env       map[string]string
+		IO        IOSpec
+		Readiness ReadinessSpec
+	}{spec.Command, spec.CWD, spec.Env, spec.IO, spec.Readiness}
+}
+
+func inputDigest(attemptID string, data []byte, eof bool) string {
+	hash := sha256.New()
+	hash.Write([]byte(attemptID))
+	hash.Write([]byte{0})
+	hash.Write(data)
+	if eof {
+		hash.Write([]byte{1})
+	} else {
+		hash.Write([]byte{0})
+	}
+	return hex.EncodeToString(hash.Sum(nil))
+}

--- a/manager/procd/pkg/session/supervisor_test.go
+++ b/manager/procd/pkg/session/supervisor_test.go
@@ -1,0 +1,560 @@
+package session
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+func TestSupervisorConcurrentCreateDeduplicatesByKey(t *testing.T) {
+	supervisor := newTestSupervisor(t)
+	spec := SessionSpec{
+		Command:   []string{"/bin/true"},
+		Lifecycle: LifecycleSpec{DesiredState: DesiredStateStopped},
+	}
+
+	const workers = 32
+	start := make(chan struct{})
+	ids := make(chan string, workers)
+	duplicates := make(chan bool, workers)
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			value, duplicate, err := supervisor.Create(spec, "concurrent-create")
+			if err != nil {
+				errs <- err
+				return
+			}
+			ids <- value.ID
+			duplicates <- duplicate
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(ids)
+	close(duplicates)
+	close(errs)
+	for err := range errs {
+		t.Fatal(err)
+	}
+
+	firstID := ""
+	count := 0
+	for id := range ids {
+		count++
+		if firstID == "" {
+			firstID = id
+		}
+		if id != firstID {
+			t.Fatalf("create ids differ: %q and %q", firstID, id)
+		}
+	}
+	if count != workers {
+		t.Fatalf("create results = %d, want %d", count, workers)
+	}
+	nonDuplicates := 0
+	for duplicate := range duplicates {
+		if !duplicate {
+			nonDuplicates++
+		}
+	}
+	if nonDuplicates != 1 {
+		t.Fatalf("non-duplicate creates = %d, want 1", nonDuplicates)
+	}
+	if values := supervisor.List(); len(values) != 1 {
+		t.Fatalf("sessions = %d, want 1", len(values))
+	}
+}
+
+func TestSupervisorPipeInputReplayAndDeduplication(t *testing.T) {
+	supervisor := newTestSupervisor(t)
+	value, duplicate, err := supervisor.Create(SessionSpec{
+		Command: []string{"/bin/sh", "-c", "IFS= read -r line; printf 'out:%s' \"$line\"; printf 'err:%s' \"$line\" >&2"},
+		IO:      IOSpec{Mode: IOModePipes},
+	}, "create-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if duplicate {
+		t.Fatal("first create was reported as duplicate")
+	}
+	waitForSessionPhase(t, supervisor, value.ID, PhaseRunning)
+	value, err = supervisor.Get(value.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	attemptID := value.Attempt.ID
+	input := InputRequest{
+		InputID:           "input-1",
+		ExpectedAttemptID: attemptID,
+		DataBase64:        base64.StdEncoding.EncodeToString([]byte("hello\n")),
+		EOF:               true,
+	}
+	response, err := supervisor.WriteInput(value.ID, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !response.Accepted || response.Duplicate {
+		t.Fatalf("input response = %#v", response)
+	}
+	waitForSessionPhase(t, supervisor, value.ID, PhaseExited)
+	response, err = supervisor.WriteInput(value.ID, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !response.Duplicate {
+		t.Fatalf("retried input response = %#v, want duplicate", response)
+	}
+	page, err := supervisor.Events(value.ID, 0, 1000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr string
+	for _, event := range page.Events {
+		data, err := base64.StdEncoding.DecodeString(event.DataBase64)
+		if err != nil {
+			t.Fatal(err)
+		}
+		switch event.Stream {
+		case "stdout":
+			stdout += string(data)
+		case "stderr":
+			stderr += string(data)
+		}
+	}
+	if stdout != "out:hello" || stderr != "err:hello" {
+		t.Fatalf("streams = (%q, %q), want (%q, %q)", stdout, stderr, "out:hello", "err:hello")
+	}
+	createdAgain, duplicate, err := supervisor.Create(value.Spec, "create-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !duplicate || createdAgain.ID != value.ID {
+		t.Fatalf("idempotent create = (%s, %v), want (%s, true)", createdAgain.ID, duplicate, value.ID)
+	}
+}
+
+func TestSupervisorRetainsBurstOutputWithoutLoss(t *testing.T) {
+	const (
+		helperEnv = "SANDBOX0_SESSION_BURST_HELPER"
+		chunks    = 640
+		chunkSize = 32 * 1024
+	)
+	if os.Getenv(helperEnv) == "1" {
+		for i := range chunks {
+			chunk := bytes.Repeat([]byte{byte(i % 251)}, chunkSize)
+			if _, err := os.Stdout.Write(chunk); err != nil {
+				os.Exit(2)
+			}
+		}
+		os.Exit(0)
+	}
+
+	supervisor := newTestSupervisor(t)
+	value, _, err := supervisor.Create(SessionSpec{
+		Command: []string{os.Args[0], "-test.run=TestSupervisorRetainsBurstOutputWithoutLoss"},
+		Env:     map[string]string{helperEnv: "1"},
+		IO:      IOSpec{Mode: IOModePipes},
+	}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		current, err := supervisor.Get(value.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if current.Phase == PhaseExited {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	current, err := supervisor.Get(value.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current.Phase != PhaseExited {
+		t.Fatalf("session phase = %s, want exited", current.Phase)
+	}
+
+	page, err := supervisor.Events(value.ID, 0, 10_000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantHash := sha256.New()
+	for i := range chunks {
+		_, _ = wantHash.Write(bytes.Repeat([]byte{byte(i % 251)}, chunkSize))
+	}
+	gotHash := sha256.New()
+	gotBytes := 0
+	for _, event := range page.Events {
+		if event.Type != "output" || event.Stream != "stdout" {
+			continue
+		}
+		data, err := base64.StdEncoding.DecodeString(event.DataBase64)
+		if err != nil {
+			t.Fatal(err)
+		}
+		gotBytes += len(data)
+		_, _ = gotHash.Write(data)
+	}
+	if gotBytes != chunks*chunkSize || !bytes.Equal(gotHash.Sum(nil), wantHash.Sum(nil)) {
+		t.Fatalf("retained output = %d bytes hash %x, want %d bytes hash %x", gotBytes, gotHash.Sum(nil), chunks*chunkSize, wantHash.Sum(nil))
+	}
+}
+
+func TestSupervisorSerializesConcurrentDuplicateInput(t *testing.T) {
+	supervisor := newTestSupervisor(t)
+	value, _, err := supervisor.Create(SessionSpec{
+		Command: []string{"/bin/cat"},
+		IO:      IOSpec{Mode: IOModePipes},
+	}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	waitForSessionPhase(t, supervisor, value.ID, PhaseRunning)
+	value, err = supervisor.Get(value.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := InputRequest{
+		InputID:           "same-input",
+		ExpectedAttemptID: value.Attempt.ID,
+		DataBase64:        base64.StdEncoding.EncodeToString([]byte("once\n")),
+	}
+
+	start := make(chan struct{})
+	responses := make(chan *InputResponse, 2)
+	errs := make(chan error, 2)
+	var wg sync.WaitGroup
+	for range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			response, err := supervisor.WriteInput(value.ID, request)
+			if err != nil {
+				errs <- err
+				return
+			}
+			responses <- response
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(responses)
+	close(errs)
+	for err := range errs {
+		t.Fatal(err)
+	}
+	duplicates := 0
+	for response := range responses {
+		if response.Duplicate {
+			duplicates++
+		}
+	}
+	if duplicates != 1 {
+		t.Fatalf("duplicate responses = %d, want 1", duplicates)
+	}
+	if _, err := supervisor.WriteInput(value.ID, InputRequest{
+		InputID:           "eof",
+		ExpectedAttemptID: value.Attempt.ID,
+		EOF:               true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	waitForSessionPhase(t, supervisor, value.ID, PhaseExited)
+	page, err := supervisor.Events(value.ID, 0, 1000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stdout := ""
+	for _, event := range page.Events {
+		if event.Stream != "stdout" {
+			continue
+		}
+		data, err := base64.StdEncoding.DecodeString(event.DataBase64)
+		if err != nil {
+			t.Fatal(err)
+		}
+		stdout += string(data)
+	}
+	if stdout != "once\n" {
+		t.Fatalf("stdout = %q, want one input", stdout)
+	}
+}
+
+func TestSupervisorRestartPolicyAndAttemptIdentity(t *testing.T) {
+	supervisor := newTestSupervisor(t)
+	value, _, err := supervisor.Create(SessionSpec{
+		Command: []string{"/bin/sh", "-c", "exit 7"},
+		Lifecycle: LifecycleSpec{
+			DesiredState: DesiredStateRunning,
+			Restart: RestartSpec{
+				Policy: RestartPolicyOnFailure, MaxRestarts: 2, WindowSeconds: 60,
+				InitialBackoffMS: 5, MaxBackoffMS: 10,
+			},
+			RuntimeRecovery:        RuntimeRecoveryRestart,
+			StopGracePeriodSeconds: 1,
+		},
+	}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	waitForSessionPhase(t, supervisor, value.ID, PhaseFailed)
+	value, err = supervisor.Get(value.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if value.Attempt == nil || value.Attempt.Number != 3 || value.RestartCount != 2 {
+		t.Fatalf("session = %#v, want three attempts and two restarts", value)
+	}
+	if _, err := supervisor.WriteInput(value.ID, InputRequest{
+		InputID: "stale", ExpectedAttemptID: "att-stale", DataBase64: base64.StdEncoding.EncodeToString([]byte("x")),
+	}); !errors.Is(err, ErrSessionNotRunning) && !errors.Is(err, ErrAttemptMismatch) {
+		t.Fatalf("stale input error = %v", err)
+	}
+}
+
+func TestSupervisorRecoversPersistedRunningSessionAsNewAttempt(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "sessions")
+	store, err := NewFileStore(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The replacement process starts before manager applies the restored rootfs.
+	supervisor, err := NewSupervisor(store, zap.NewNop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC().Add(-time.Minute)
+	record := Session{
+		ID: "ses-persisted",
+		Spec: normalizeSpec(SessionSpec{
+			Command: []string{"/bin/sh", "-c", "printf recovered"},
+			Lifecycle: LifecycleSpec{
+				DesiredState: DesiredStateRunning, RuntimeRecovery: RuntimeRecoveryRestart,
+			},
+		}),
+		SpecVersion: 1,
+		Phase:       PhaseRunning,
+		Attempt: &Attempt{
+			ID: "att-before", Number: 1, RuntimeGeneration: 4, PID: 123, StartedAt: &now,
+		},
+		RuntimeGeneration: 4,
+		CreatedAt:         now,
+		UpdatedAt:         now,
+		LastActivityAt:    now,
+	}
+	if err := store.Save(record); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { cleanupSupervisor(t, supervisor) })
+	if err := supervisor.Initialize("sandbox-1", 5, nil); err != nil {
+		t.Fatal(err)
+	}
+	waitForSessionPhase(t, supervisor, record.ID, PhaseExited)
+	recovered, err := supervisor.Get(record.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recovered.RuntimeGeneration != 5 || recovered.Attempt.Number != 2 || recovered.Attempt.ID == "att-before" {
+		t.Fatalf("recovered session = %#v", recovered)
+	}
+	page, err := supervisor.Events(record.ID, 0, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sawReplacement, sawRecovered bool
+	for _, event := range page.Events {
+		if event.AttemptID == "att-before" && event.Reason == "runtime_replaced" {
+			sawReplacement = true
+		}
+		if event.Type == "output" {
+			data, _ := base64.StdEncoding.DecodeString(event.DataBase64)
+			if string(data) == "recovered" {
+				sawRecovered = true
+			}
+		}
+	}
+	if !sawReplacement || !sawRecovered {
+		t.Fatalf("events did not record recovery boundary and output: %#v", page.Events)
+	}
+}
+
+func TestSupervisorDropsSessionsCopiedFromAnotherSandbox(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "sessions")
+	store, err := NewFileStore(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	source, err := NewSupervisor(store, zap.NewNop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := source.Initialize("sandbox-source", 1, nil); err != nil {
+		t.Fatal(err)
+	}
+	created, _, err := source.Create(SessionSpec{
+		Command: []string{"/bin/sh", "-c", "exit 0"},
+		Lifecycle: LifecycleSpec{
+			DesiredState:    DesiredStateStopped,
+			RuntimeRecovery: RuntimeRecoveryRestart,
+		},
+	}, "copied-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := source.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	copiedStore, err := NewFileStore(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	target, err := NewSupervisor(copiedStore, zap.NewNop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { cleanupSupervisor(t, target) })
+	if err := target.Initialize("sandbox-target", 1, nil); err != nil {
+		t.Fatal(err)
+	}
+	if got := target.List(); len(got) != 0 {
+		t.Fatalf("target sessions = %#v, want copied state cleared", got)
+	}
+	if _, err := os.Stat(filepath.Join(root, created.ID)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("copied session directory still exists: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(root, sandboxIDFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(data)) != "sandbox-target" {
+		t.Fatalf("sandbox identity = %q, want sandbox-target", data)
+	}
+}
+
+func TestSupervisorRejectsRebindingRunningProcessToAnotherSandbox(t *testing.T) {
+	supervisor := newTestSupervisor(t)
+	if err := supervisor.Initialize("sandbox-other", 2, nil); err == nil {
+		t.Fatal("Initialize() rebound one procd process to another sandbox")
+	}
+}
+
+func TestSupervisorEmitsSessionExpiryOnce(t *testing.T) {
+	supervisor := newTestSupervisor(t)
+	value, _, err := supervisor.Create(SessionSpec{
+		Command: []string{"/bin/sh", "-c", "while :; do sleep 1; done"},
+		Lifecycle: LifecycleSpec{
+			DesiredState:       DesiredStateRunning,
+			MaxLifetimeSeconds: 1,
+		},
+	}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	waitForSessionPhase(t, supervisor, value.ID, PhaseRunning)
+	supervisor.expireSessions(value.CreatedAt.Add(2 * time.Second))
+	waitForSessionPhase(t, supervisor, value.ID, PhaseStopped)
+	supervisor.expireSessions(value.CreatedAt.Add(3 * time.Second))
+	page, err := supervisor.Events(value.ID, 0, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expiredEvents := 0
+	for _, event := range page.Events {
+		if event.Type == "session.expired" {
+			expiredEvents++
+		}
+	}
+	if expiredEvents != 1 {
+		t.Fatalf("session.expired events = %d, want 1", expiredEvents)
+	}
+}
+
+func TestSupervisorPauseResumeKeepsAttempt(t *testing.T) {
+	supervisor := newTestSupervisor(t)
+	value, _, err := supervisor.Create(SessionSpec{
+		Command:   []string{"/bin/sh", "-c", "while :; do sleep 1; done"},
+		Lifecycle: LifecycleSpec{DesiredState: DesiredStateRunning, StopGracePeriodSeconds: 1},
+	}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	waitForSessionPhase(t, supervisor, value.ID, PhaseRunning)
+	before, _ := supervisor.Get(value.ID)
+	if err := supervisor.PauseAll(); err != nil {
+		t.Fatal(err)
+	}
+	waitForSessionPhase(t, supervisor, value.ID, PhasePaused)
+	if err := supervisor.ResumeAll(); err != nil {
+		t.Fatal(err)
+	}
+	waitForSessionPhase(t, supervisor, value.ID, PhaseRunning)
+	after, _ := supervisor.Get(value.ID)
+	if before.Attempt.ID != after.Attempt.ID {
+		t.Fatalf("attempt changed across in-runtime pause: %s -> %s", before.Attempt.ID, after.Attempt.ID)
+	}
+}
+
+func newTestSupervisor(t *testing.T) *Supervisor {
+	t.Helper()
+	store, err := NewFileStore(filepath.Join(t.TempDir(), "sessions"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	supervisor, err := NewSupervisor(store, zap.NewNop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := supervisor.Initialize("sandbox-1", 1, map[string]string{"SANDBOX_DEFAULT": "true"}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { cleanupSupervisor(t, supervisor) })
+	return supervisor
+}
+
+func cleanupSupervisor(t *testing.T, supervisor *Supervisor) {
+	t.Helper()
+	for _, value := range supervisor.List() {
+		if err := supervisor.Delete(value.ID); err != nil && !errors.Is(err, ErrSessionNotFound) {
+			t.Errorf("delete session %s: %v", value.ID, err)
+		}
+	}
+	if err := supervisor.Close(); err != nil {
+		t.Errorf("close supervisor: %v", err)
+	}
+}
+
+func waitForSessionPhase(t *testing.T, supervisor *Supervisor, id string, phase Phase) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		value, err := supervisor.Get(id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if value.Phase == phase {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	value, _ := supervisor.Get(id)
+	t.Fatalf("session phase = %s, want %s; session=%#v", value.Phase, phase, value)
+}

--- a/manager/procd/pkg/session/types.go
+++ b/manager/procd/pkg/session/types.go
@@ -1,0 +1,367 @@
+// Package session supervises durable, process-backed execution sessions.
+package session
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	defaultEventMaxBytes       int64 = 64 << 20
+	defaultEventMaxAgeSeconds  int64 = 24 * 60 * 60
+	defaultStopGraceSeconds    int32 = 10
+	defaultRestartWindow       int32 = 60
+	defaultRestartMaxAttempts  int32 = 5
+	defaultInitialBackoffMS    int32 = 250
+	defaultMaximumBackoffMS    int32 = 5000
+	defaultSubscriptionBacklog       = 256
+)
+
+var (
+	ErrSessionNotFound    = errors.New("session not found")
+	ErrSessionExists      = errors.New("session already exists")
+	ErrSessionNotRunning  = errors.New("session is not running")
+	ErrAttemptMismatch    = errors.New("session attempt mismatch")
+	ErrInputAlreadyExists = errors.New("input id was already used with different content")
+	ErrCursorExpired      = errors.New("event cursor expired")
+)
+
+type IOMode string
+
+const (
+	IOModePipes IOMode = "pipes"
+	IOModePTY   IOMode = "pty"
+)
+
+type DesiredState string
+
+const (
+	DesiredStateRunning DesiredState = "running"
+	DesiredStateStopped DesiredState = "stopped"
+)
+
+type Phase string
+
+const (
+	PhasePending   Phase = "pending"
+	PhaseStarting  Phase = "starting"
+	PhaseRunning   Phase = "running"
+	PhasePaused    Phase = "paused"
+	PhaseStopping  Phase = "stopping"
+	PhaseStopped   Phase = "stopped"
+	PhaseExited    Phase = "exited"
+	PhaseBackoff   Phase = "backoff"
+	PhaseFailed    Phase = "failed"
+	PhaseSuspended Phase = "suspended"
+)
+
+type RestartPolicy string
+
+const (
+	RestartPolicyNever     RestartPolicy = "never"
+	RestartPolicyOnFailure RestartPolicy = "on_failure"
+	RestartPolicyAlways    RestartPolicy = "always"
+)
+
+type RuntimeRecoveryPolicy string
+
+const (
+	RuntimeRecoveryRestart RuntimeRecoveryPolicy = "restart"
+	RuntimeRecoveryStop    RuntimeRecoveryPolicy = "stop"
+)
+
+type ReadinessType string
+
+const (
+	ReadinessProcess ReadinessType = "process"
+	ReadinessDelay   ReadinessType = "delay"
+	ReadinessOutput  ReadinessType = "output"
+)
+
+type IOSpec struct {
+	Mode     IOMode        `json:"mode"`
+	Terminal *TerminalSpec `json:"terminal,omitempty"`
+}
+
+type TerminalSpec struct {
+	Rows uint16 `json:"rows"`
+	Cols uint16 `json:"cols"`
+	Term string `json:"term,omitempty"`
+}
+
+type RestartSpec struct {
+	Policy           RestartPolicy `json:"policy"`
+	MaxRestarts      int32         `json:"max_restarts,omitempty"`
+	WindowSeconds    int32         `json:"window_seconds,omitempty"`
+	InitialBackoffMS int32         `json:"initial_backoff_ms,omitempty"`
+	MaxBackoffMS     int32         `json:"max_backoff_ms,omitempty"`
+}
+
+type LifecycleSpec struct {
+	DesiredState           DesiredState          `json:"desired_state"`
+	Restart                RestartSpec           `json:"restart"`
+	RuntimeRecovery        RuntimeRecoveryPolicy `json:"runtime_recovery"`
+	IdleTimeoutSeconds     int64                 `json:"idle_timeout_seconds,omitempty"`
+	MaxLifetimeSeconds     int64                 `json:"max_lifetime_seconds,omitempty"`
+	StopGracePeriodSeconds int32                 `json:"stop_grace_period_seconds,omitempty"`
+}
+
+type ReadinessSpec struct {
+	Type      ReadinessType `json:"type"`
+	DelayMS   int32         `json:"delay_ms,omitempty"`
+	Output    string        `json:"output,omitempty"`
+	TimeoutMS int32         `json:"timeout_ms,omitempty"`
+}
+
+type EventRetentionSpec struct {
+	MaxBytes      int64 `json:"max_bytes,omitempty"`
+	MaxAgeSeconds int64 `json:"max_age_seconds,omitempty"`
+}
+
+type SessionSpec struct {
+	Name           string             `json:"name,omitempty"`
+	Command        []string           `json:"command"`
+	CWD            string             `json:"cwd,omitempty"`
+	Env            map[string]string  `json:"env,omitempty"`
+	IO             IOSpec             `json:"io"`
+	Lifecycle      LifecycleSpec      `json:"lifecycle"`
+	Readiness      ReadinessSpec      `json:"readiness"`
+	EventRetention EventRetentionSpec `json:"event_retention"`
+}
+
+type Attempt struct {
+	ID                string     `json:"id"`
+	Number            int64      `json:"number"`
+	RuntimeGeneration int64      `json:"runtime_generation"`
+	PID               int        `json:"pid,omitempty"`
+	StartedAt         *time.Time `json:"started_at,omitempty"`
+	FinishedAt        *time.Time `json:"finished_at,omitempty"`
+	ExitCode          *int       `json:"exit_code,omitempty"`
+	Reason            string     `json:"reason,omitempty"`
+}
+
+type EventCursor struct {
+	Earliest int64 `json:"earliest"`
+	Latest   int64 `json:"latest"`
+}
+
+type Session struct {
+	ID                string         `json:"id"`
+	Spec              SessionSpec    `json:"spec"`
+	SpecVersion       int64          `json:"spec_version"`
+	Phase             Phase          `json:"phase"`
+	RuntimeGeneration int64          `json:"runtime_generation"`
+	Attempt           *Attempt       `json:"attempt,omitempty"`
+	RestartCount      int32          `json:"restart_count"`
+	Cursor            EventCursor    `json:"cursor"`
+	CreatedAt         time.Time      `json:"created_at"`
+	UpdatedAt         time.Time      `json:"updated_at"`
+	LastActivityAt    time.Time      `json:"last_activity_at"`
+	InputReceipts     []InputReceipt `json:"-"`
+	CreationKey       string         `json:"-"`
+}
+
+type InputRequest struct {
+	InputID           string `json:"input_id"`
+	ExpectedAttemptID string `json:"expected_attempt_id,omitempty"`
+	DataBase64        string `json:"data_base64,omitempty"`
+	EOF               bool   `json:"eof,omitempty"`
+}
+
+type InputReceipt struct {
+	InputID    string    `json:"input_id"`
+	AttemptID  string    `json:"attempt_id"`
+	Digest     string    `json:"digest"`
+	AcceptedAt time.Time `json:"accepted_at"`
+}
+
+type InputResponse struct {
+	InputID   string `json:"input_id"`
+	AttemptID string `json:"attempt_id"`
+	Accepted  bool   `json:"accepted"`
+	Duplicate bool   `json:"duplicate"`
+}
+
+type DesiredStateRequest struct {
+	State DesiredState `json:"state"`
+}
+
+type CreateAttemptRequest struct {
+	ReplaceCurrent bool `json:"replace_current,omitempty"`
+}
+
+type SignalRequest struct {
+	Signal            string `json:"signal"`
+	ExpectedAttemptID string `json:"expected_attempt_id,omitempty"`
+}
+
+type TerminalResizeRequest struct {
+	Rows              uint16 `json:"rows"`
+	Cols              uint16 `json:"cols"`
+	ExpectedAttemptID string `json:"expected_attempt_id,omitempty"`
+}
+
+type Event struct {
+	Seq               int64     `json:"seq"`
+	SessionID         string    `json:"session_id"`
+	RuntimeGeneration int64     `json:"runtime_generation"`
+	AttemptID         string    `json:"attempt_id,omitempty"`
+	Type              string    `json:"type"`
+	Stream            string    `json:"stream,omitempty"`
+	DataBase64        string    `json:"data_base64,omitempty"`
+	ExitCode          *int      `json:"exit_code,omitempty"`
+	Reason            string    `json:"reason,omitempty"`
+	OccurredAt        time.Time `json:"occurred_at"`
+}
+
+type EventPage struct {
+	Events []Event     `json:"events"`
+	Cursor EventCursor `json:"cursor"`
+}
+
+type CursorExpiredError struct {
+	Earliest int64
+}
+
+func (e *CursorExpiredError) Error() string {
+	return fmt.Sprintf("%s; earliest available sequence is %d", ErrCursorExpired, e.Earliest)
+}
+
+func (e *CursorExpiredError) Unwrap() error {
+	return ErrCursorExpired
+}
+
+func normalizeSpec(spec SessionSpec) SessionSpec {
+	spec.Name = strings.TrimSpace(spec.Name)
+	spec.Command = append([]string(nil), spec.Command...)
+	if spec.Env == nil {
+		spec.Env = map[string]string{}
+	} else {
+		env := make(map[string]string, len(spec.Env))
+		for key, value := range spec.Env {
+			env[key] = value
+		}
+		spec.Env = env
+	}
+	if spec.IO.Mode == "" {
+		spec.IO.Mode = IOModePipes
+	}
+	if spec.IO.Mode == IOModePTY {
+		if spec.IO.Terminal == nil {
+			spec.IO.Terminal = &TerminalSpec{Rows: 24, Cols: 80, Term: "xterm-256color"}
+		} else {
+			terminal := *spec.IO.Terminal
+			if terminal.Rows == 0 {
+				terminal.Rows = 24
+			}
+			if terminal.Cols == 0 {
+				terminal.Cols = 80
+			}
+			if terminal.Term == "" {
+				terminal.Term = "xterm-256color"
+			}
+			spec.IO.Terminal = &terminal
+		}
+	} else {
+		spec.IO.Terminal = nil
+	}
+	if spec.Lifecycle.DesiredState == "" {
+		spec.Lifecycle.DesiredState = DesiredStateRunning
+	}
+	if spec.Lifecycle.Restart.Policy == "" {
+		spec.Lifecycle.Restart.Policy = RestartPolicyNever
+	}
+	if spec.Lifecycle.RuntimeRecovery == "" {
+		spec.Lifecycle.RuntimeRecovery = RuntimeRecoveryRestart
+	}
+	if spec.Lifecycle.StopGracePeriodSeconds == 0 {
+		spec.Lifecycle.StopGracePeriodSeconds = defaultStopGraceSeconds
+	}
+	if spec.Lifecycle.Restart.MaxRestarts == 0 {
+		spec.Lifecycle.Restart.MaxRestarts = defaultRestartMaxAttempts
+	}
+	if spec.Lifecycle.Restart.WindowSeconds == 0 {
+		spec.Lifecycle.Restart.WindowSeconds = defaultRestartWindow
+	}
+	if spec.Lifecycle.Restart.InitialBackoffMS == 0 {
+		spec.Lifecycle.Restart.InitialBackoffMS = defaultInitialBackoffMS
+	}
+	if spec.Lifecycle.Restart.MaxBackoffMS == 0 {
+		spec.Lifecycle.Restart.MaxBackoffMS = defaultMaximumBackoffMS
+	}
+	if spec.Readiness.Type == "" {
+		spec.Readiness.Type = ReadinessProcess
+	}
+	if spec.Readiness.TimeoutMS == 0 {
+		spec.Readiness.TimeoutMS = 30_000
+	}
+	if spec.EventRetention.MaxBytes == 0 {
+		spec.EventRetention.MaxBytes = defaultEventMaxBytes
+	}
+	if spec.EventRetention.MaxAgeSeconds == 0 {
+		spec.EventRetention.MaxAgeSeconds = defaultEventMaxAgeSeconds
+	}
+	return spec
+}
+
+func validateSpec(spec SessionSpec) error {
+	if len(spec.Command) == 0 || strings.TrimSpace(spec.Command[0]) == "" {
+		return errors.New("command is required")
+	}
+	switch spec.IO.Mode {
+	case IOModePipes, IOModePTY:
+	default:
+		return fmt.Errorf("io.mode must be %q or %q", IOModePipes, IOModePTY)
+	}
+	switch spec.Lifecycle.DesiredState {
+	case DesiredStateRunning, DesiredStateStopped:
+	default:
+		return fmt.Errorf("lifecycle.desired_state must be %q or %q", DesiredStateRunning, DesiredStateStopped)
+	}
+	switch spec.Lifecycle.Restart.Policy {
+	case RestartPolicyNever, RestartPolicyOnFailure, RestartPolicyAlways:
+	default:
+		return errors.New("lifecycle.restart.policy is invalid")
+	}
+	switch spec.Lifecycle.RuntimeRecovery {
+	case RuntimeRecoveryRestart, RuntimeRecoveryStop:
+	default:
+		return errors.New("lifecycle.runtime_recovery is invalid")
+	}
+	if spec.Lifecycle.IdleTimeoutSeconds < 0 || spec.Lifecycle.MaxLifetimeSeconds < 0 || spec.Lifecycle.StopGracePeriodSeconds < 0 {
+		return errors.New("lifecycle timeouts must be non-negative")
+	}
+	if spec.Lifecycle.Restart.MaxRestarts < 0 || spec.Lifecycle.Restart.WindowSeconds < 0 || spec.Lifecycle.Restart.InitialBackoffMS < 0 || spec.Lifecycle.Restart.MaxBackoffMS < 0 {
+		return errors.New("restart limits and backoff must be non-negative")
+	}
+	if spec.Lifecycle.Restart.MaxBackoffMS < spec.Lifecycle.Restart.InitialBackoffMS {
+		return errors.New("restart max_backoff_ms must be greater than or equal to initial_backoff_ms")
+	}
+	switch spec.Readiness.Type {
+	case ReadinessProcess, ReadinessDelay, ReadinessOutput:
+	default:
+		return errors.New("readiness.type is invalid")
+	}
+	if spec.Readiness.Type == ReadinessOutput && spec.Readiness.Output == "" {
+		return errors.New("readiness.output is required for output readiness")
+	}
+	if spec.Readiness.DelayMS < 0 || spec.Readiness.TimeoutMS < 0 {
+		return errors.New("readiness durations must be non-negative")
+	}
+	if spec.EventRetention.MaxBytes < 0 || spec.EventRetention.MaxAgeSeconds < 0 {
+		return errors.New("event retention limits must be non-negative")
+	}
+	return nil
+}
+
+func cloneSession(value Session) Session {
+	value.Spec = normalizeSpec(value.Spec)
+	if value.Attempt != nil {
+		attempt := *value.Attempt
+		value.Attempt = &attempt
+	}
+	value.InputReceipts = append([]InputReceipt(nil), value.InputReceipts...)
+	return value
+}

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -2345,6 +2345,338 @@ paths:
       responses:
         "101":
           description: Switching Protocols
+  /api/v1/sandboxes/{id}/sessions:
+    get:
+      tags: [sessions]
+      summary: List execution sessions
+      description: Lists durable process-backed sessions in the sandbox.
+      security:
+        - bearerAuth: []
+      x-upstream-service: procd
+      x-upstream-path: /api/v1/sessions
+      parameters:
+        - $ref: "#/components/parameters/SandboxID"
+      responses:
+        "200":
+          description: Execution session list
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessExecutionSessionListResponse"
+    post:
+      tags: [sessions]
+      summary: Create an execution session
+      description: Creates a durable process-backed session. The client connection does not own the session lifecycle.
+      security:
+        - bearerAuth: []
+      x-upstream-service: procd
+      x-upstream-path: /api/v1/sessions
+      parameters:
+        - $ref: "#/components/parameters/SandboxID"
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+          description: Optional key for retrying creation without creating a duplicate session.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ExecutionSessionSpec"
+      responses:
+        "201":
+          description: Execution session created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessExecutionSessionResponse"
+        "200":
+          description: Existing execution session returned for an idempotent retry
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessExecutionSessionResponse"
+  /api/v1/sandboxes/{id}/sessions/{session_id}:
+    get:
+      tags: [sessions]
+      summary: Get an execution session
+      security:
+        - bearerAuth: []
+      x-upstream-service: procd
+      x-upstream-path: /api/v1/sessions/{session_id}
+      parameters:
+        - $ref: "#/components/parameters/SandboxID"
+        - $ref: "#/components/parameters/SessionID"
+      responses:
+        "200":
+          description: Execution session
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessExecutionSessionResponse"
+    put:
+      tags: [sessions]
+      summary: Replace an execution session specification
+      description: Replaces the specification. Changes to command, environment, I/O, or readiness create a new process attempt when the desired state is running.
+      security:
+        - bearerAuth: []
+      x-upstream-service: procd
+      x-upstream-path: /api/v1/sessions/{session_id}
+      parameters:
+        - $ref: "#/components/parameters/SandboxID"
+        - $ref: "#/components/parameters/SessionID"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ExecutionSessionSpec"
+      responses:
+        "200":
+          description: Execution session updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessExecutionSessionResponse"
+    delete:
+      tags: [sessions]
+      summary: Delete an execution session
+      security:
+        - bearerAuth: []
+      x-upstream-service: procd
+      x-upstream-path: /api/v1/sessions/{session_id}
+      parameters:
+        - $ref: "#/components/parameters/SandboxID"
+        - $ref: "#/components/parameters/SessionID"
+      responses:
+        "200":
+          description: Execution session deleted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessDeletedResponse"
+  /api/v1/sandboxes/{id}/sessions/{session_id}/desired-state:
+    put:
+      tags: [sessions]
+      summary: Set execution session desired state
+      security:
+        - bearerAuth: []
+      x-upstream-service: procd
+      x-upstream-path: /api/v1/sessions/{session_id}/desired-state
+      parameters:
+        - $ref: "#/components/parameters/SandboxID"
+        - $ref: "#/components/parameters/SessionID"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ExecutionSessionDesiredStateRequest"
+      responses:
+        "200":
+          description: Desired state updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessExecutionSessionResponse"
+  /api/v1/sandboxes/{id}/sessions/{session_id}/attempts:
+    post:
+      tags: [sessions]
+      summary: Create a new execution session attempt
+      description: Starts a new process attempt. Set replace_current to stop and replace a running attempt.
+      security:
+        - bearerAuth: []
+      x-upstream-service: procd
+      x-upstream-path: /api/v1/sessions/{session_id}/attempts
+      parameters:
+        - $ref: "#/components/parameters/SandboxID"
+        - $ref: "#/components/parameters/SessionID"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateExecutionSessionAttemptRequest"
+      responses:
+        "201":
+          description: Attempt created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessExecutionSessionResponse"
+  /api/v1/sandboxes/{id}/sessions/{session_id}/inputs:
+    post:
+      tags: [sessions]
+      summary: Append execution session input
+      description: Writes binary-safe input to the current attempt. Once an input receipt is recorded, retrying the same input_id and content is deduplicated. A transport failure before the receipt is durable can make delivery ambiguous, so consumers must tolerate replay.
+      security:
+        - bearerAuth: []
+      x-upstream-service: procd
+      x-upstream-path: /api/v1/sessions/{session_id}/inputs
+      parameters:
+        - $ref: "#/components/parameters/SandboxID"
+        - $ref: "#/components/parameters/SessionID"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ExecutionSessionInputRequest"
+      responses:
+        "202":
+          description: Input accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessExecutionSessionInputResponse"
+  /api/v1/sandboxes/{id}/sessions/{session_id}/signals:
+    post:
+      tags: [sessions]
+      summary: Send a signal to an execution session attempt
+      security:
+        - bearerAuth: []
+      x-upstream-service: procd
+      x-upstream-path: /api/v1/sessions/{session_id}/signals
+      parameters:
+        - $ref: "#/components/parameters/SandboxID"
+        - $ref: "#/components/parameters/SessionID"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ExecutionSessionSignalRequest"
+      responses:
+        "202":
+          description: Signal accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessAcceptedResponse"
+  /api/v1/sandboxes/{id}/sessions/{session_id}/terminal:
+    put:
+      tags: [sessions]
+      summary: Resize an execution session terminal
+      security:
+        - bearerAuth: []
+      x-upstream-service: procd
+      x-upstream-path: /api/v1/sessions/{session_id}/terminal
+      parameters:
+        - $ref: "#/components/parameters/SandboxID"
+        - $ref: "#/components/parameters/SessionID"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ExecutionSessionTerminalResizeRequest"
+      responses:
+        "200":
+          description: Terminal resized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResizedResponse"
+  /api/v1/sandboxes/{id}/sessions/{session_id}/events:
+    get:
+      tags: [sessions]
+      summary: List execution session events
+      description: Returns retained events after the supplied sequence. Delivery is cursor-based and at least once.
+      security:
+        - bearerAuth: []
+      x-upstream-service: procd
+      x-upstream-path: /api/v1/sessions/{session_id}/events
+      parameters:
+        - $ref: "#/components/parameters/SandboxID"
+        - $ref: "#/components/parameters/SessionID"
+        - name: after
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+            minimum: 0
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 10000
+            default: 1000
+      responses:
+        "200":
+          description: Execution session events
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessExecutionSessionEventPageResponse"
+        "410":
+          description: The requested cursor is older than retained history
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+  /api/v1/sandboxes/{id}/sessions/{session_id}/events/stream:
+    get:
+      tags: [sessions]
+      summary: Stream execution session events
+      description: Streams retained and live events using SSE. Reconnect with Last-Event-ID or the after query parameter.
+      security:
+        - bearerAuth: []
+      x-upstream-service: procd
+      x-upstream-path: /api/v1/sessions/{session_id}/events/stream
+      parameters:
+        - $ref: "#/components/parameters/SandboxID"
+        - $ref: "#/components/parameters/SessionID"
+        - name: after
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+            minimum: 0
+        - name: Last-Event-ID
+          in: header
+          required: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Server-sent event stream
+          content:
+            text/event-stream:
+              schema:
+                type: string
+  /api/v1/sandboxes/{id}/sessions/{session_id}/ws:
+    get:
+      tags: [sessions]
+      summary: Attach to an execution session with WebSocket
+      description: A WebSocket is an ephemeral attachment. Closing it does not stop the session or close process input.
+      security:
+        - bearerAuth: []
+      x-upstream-service: procd
+      x-upstream-path: /api/v1/sessions/{session_id}/ws
+      x-websocket:
+        inbound:
+          $ref: "#/components/schemas/ExecutionSessionWebSocketRequest"
+        outbound:
+          $ref: "#/components/schemas/ExecutionSessionWebSocketResponse"
+      parameters:
+        - $ref: "#/components/parameters/SandboxID"
+        - $ref: "#/components/parameters/SessionID"
+        - name: after
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+            minimum: 0
+      responses:
+        "101":
+          description: Switching Protocols
   /api/v1/sandboxes/{id}/files/move:
     post:
       tags: [files]
@@ -3231,6 +3563,12 @@ components:
         type: string
     ContextID:
       name: ctx_id
+      in: path
+      required: true
+      schema:
+        type: string
+    SessionID:
+      name: session_id
       in: path
       required: true
       schema:
@@ -5330,6 +5668,451 @@ components:
           properties:
             data:
               $ref: "#/components/schemas/RefreshResponse"
+    ExecutionSessionIOMode:
+      type: string
+      enum: [pipes, pty]
+      x-enum-varnames: [ExecutionSessionIOModePipes, ExecutionSessionIOModePTY]
+      default: pipes
+    ExecutionSessionDesiredState:
+      type: string
+      enum: [running, stopped]
+      x-enum-varnames: [ExecutionSessionDesiredStateRunning, ExecutionSessionDesiredStateStopped]
+      default: running
+    ExecutionSessionPhase:
+      type: string
+      enum: [pending, starting, running, paused, stopping, stopped, exited, backoff, failed, suspended]
+      x-enum-varnames: [ExecutionSessionPhasePending, ExecutionSessionPhaseStarting, ExecutionSessionPhaseRunning, ExecutionSessionPhasePaused, ExecutionSessionPhaseStopping, ExecutionSessionPhaseStopped, ExecutionSessionPhaseExited, ExecutionSessionPhaseBackoff, ExecutionSessionPhaseFailed, ExecutionSessionPhaseSuspended]
+    ExecutionSessionRestartPolicy:
+      type: string
+      enum: [never, on_failure, always]
+      x-enum-varnames: [ExecutionSessionRestartPolicyNever, ExecutionSessionRestartPolicyOnFailure, ExecutionSessionRestartPolicyAlways]
+      default: never
+    ExecutionSessionRuntimeRecoveryPolicy:
+      type: string
+      enum: [restart, stop]
+      x-enum-varnames: [ExecutionSessionRuntimeRecoveryRestart, ExecutionSessionRuntimeRecoveryStop]
+      default: restart
+    ExecutionSessionReadinessType:
+      type: string
+      enum: [process, delay, output]
+      x-enum-varnames: [ExecutionSessionReadinessProcess, ExecutionSessionReadinessDelay, ExecutionSessionReadinessOutput]
+      default: process
+    ExecutionSessionTerminalSpec:
+      type: object
+      properties:
+        rows:
+          type: integer
+          format: int32
+          minimum: 1
+          maximum: 65535
+          default: 24
+        cols:
+          type: integer
+          format: int32
+          minimum: 1
+          maximum: 65535
+          default: 80
+        term:
+          type: string
+          default: xterm-256color
+    ExecutionSessionIOSpec:
+      type: object
+      properties:
+        mode:
+          $ref: "#/components/schemas/ExecutionSessionIOMode"
+        terminal:
+          $ref: "#/components/schemas/ExecutionSessionTerminalSpec"
+    ExecutionSessionRestartSpec:
+      type: object
+      properties:
+        policy:
+          $ref: "#/components/schemas/ExecutionSessionRestartPolicy"
+        max_restarts:
+          type: integer
+          format: int32
+          minimum: 0
+          default: 5
+        window_seconds:
+          type: integer
+          format: int32
+          minimum: 0
+          default: 60
+        initial_backoff_ms:
+          type: integer
+          format: int32
+          minimum: 0
+          default: 250
+        max_backoff_ms:
+          type: integer
+          format: int32
+          minimum: 0
+          default: 5000
+    ExecutionSessionLifecycleSpec:
+      type: object
+      properties:
+        desired_state:
+          $ref: "#/components/schemas/ExecutionSessionDesiredState"
+        restart:
+          $ref: "#/components/schemas/ExecutionSessionRestartSpec"
+        runtime_recovery:
+          $ref: "#/components/schemas/ExecutionSessionRuntimeRecoveryPolicy"
+        idle_timeout_seconds:
+          type: integer
+          format: int64
+          minimum: 0
+        max_lifetime_seconds:
+          type: integer
+          format: int64
+          minimum: 0
+        stop_grace_period_seconds:
+          type: integer
+          format: int32
+          minimum: 0
+          default: 10
+    ExecutionSessionReadinessSpec:
+      type: object
+      properties:
+        type:
+          $ref: "#/components/schemas/ExecutionSessionReadinessType"
+        delay_ms:
+          type: integer
+          format: int32
+          minimum: 0
+        output:
+          type: string
+          description: Byte sequence whose appearance in process output marks the attempt ready when type is output.
+        timeout_ms:
+          type: integer
+          format: int32
+          minimum: 0
+          default: 30000
+    ExecutionSessionEventRetentionSpec:
+      type: object
+      properties:
+        max_bytes:
+          type: integer
+          format: int64
+          minimum: 0
+          default: 67108864
+        max_age_seconds:
+          type: integer
+          format: int64
+          minimum: 0
+          default: 86400
+    ExecutionSessionSpec:
+      type: object
+      description: Generic process-backed session specification. The supervisor does not interpret application protocols.
+      properties:
+        name:
+          type: string
+        command:
+          type: array
+          minItems: 1
+          items:
+            type: string
+        cwd:
+          type: string
+        env:
+          type: object
+          additionalProperties:
+            type: string
+        io:
+          $ref: "#/components/schemas/ExecutionSessionIOSpec"
+        lifecycle:
+          $ref: "#/components/schemas/ExecutionSessionLifecycleSpec"
+        readiness:
+          $ref: "#/components/schemas/ExecutionSessionReadinessSpec"
+        event_retention:
+          $ref: "#/components/schemas/ExecutionSessionEventRetentionSpec"
+      required: [command]
+    ExecutionSessionAttempt:
+      type: object
+      properties:
+        id:
+          type: string
+        number:
+          type: integer
+          format: int64
+        runtime_generation:
+          type: integer
+          format: int64
+        pid:
+          type: integer
+          format: int32
+        started_at:
+          type: string
+          format: date-time
+        finished_at:
+          type: string
+          format: date-time
+        exit_code:
+          type: integer
+          format: int32
+        reason:
+          type: string
+      required: [id, number, runtime_generation]
+    ExecutionSessionEventCursor:
+      type: object
+      properties:
+        earliest:
+          type: integer
+          format: int64
+        latest:
+          type: integer
+          format: int64
+      required: [earliest, latest]
+    ExecutionSession:
+      type: object
+      properties:
+        id:
+          type: string
+        spec:
+          $ref: "#/components/schemas/ExecutionSessionSpec"
+        spec_version:
+          type: integer
+          format: int64
+        phase:
+          $ref: "#/components/schemas/ExecutionSessionPhase"
+        runtime_generation:
+          type: integer
+          format: int64
+        attempt:
+          $ref: "#/components/schemas/ExecutionSessionAttempt"
+        restart_count:
+          type: integer
+          format: int32
+        cursor:
+          $ref: "#/components/schemas/ExecutionSessionEventCursor"
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        last_activity_at:
+          type: string
+          format: date-time
+      required: [id, spec, spec_version, phase, runtime_generation, restart_count, cursor, created_at, updated_at, last_activity_at]
+    ExecutionSessionDesiredStateRequest:
+      type: object
+      properties:
+        state:
+          $ref: "#/components/schemas/ExecutionSessionDesiredState"
+      required: [state]
+    CreateExecutionSessionAttemptRequest:
+      type: object
+      properties:
+        replace_current:
+          type: boolean
+          default: false
+    ExecutionSessionInputRequest:
+      type: object
+      properties:
+        input_id:
+          type: string
+          description: Client-generated operation identifier used to deduplicate recorded retries.
+        expected_attempt_id:
+          type: string
+        data_base64:
+          type: string
+          description: Base64-encoded input bytes accepted into the current attempt input queue. WebSocket closure never implies EOF.
+        eof:
+          type: boolean
+          default: false
+      required: [input_id]
+    ExecutionSessionInputResponse:
+      type: object
+      properties:
+        input_id:
+          type: string
+        attempt_id:
+          type: string
+        accepted:
+          type: boolean
+        duplicate:
+          type: boolean
+      required: [input_id, attempt_id, accepted, duplicate]
+    ExecutionSessionSignalRequest:
+      type: object
+      properties:
+        signal:
+          type: string
+        expected_attempt_id:
+          type: string
+      required: [signal]
+    ExecutionSessionTerminalResizeRequest:
+      type: object
+      properties:
+        rows:
+          type: integer
+          format: int32
+          minimum: 1
+          maximum: 65535
+        cols:
+          type: integer
+          format: int32
+          minimum: 1
+          maximum: 65535
+        expected_attempt_id:
+          type: string
+      required: [rows, cols]
+    ExecutionSessionEvent:
+      type: object
+      properties:
+        seq:
+          type: integer
+          format: int64
+        session_id:
+          type: string
+        runtime_generation:
+          type: integer
+          format: int64
+        attempt_id:
+          type: string
+        type:
+          type: string
+        stream:
+          type: string
+          enum: [stdout, stderr, pty]
+        data_base64:
+          type: string
+          description: Base64-encoded event bytes.
+        exit_code:
+          type: integer
+          format: int32
+        reason:
+          type: string
+        occurred_at:
+          type: string
+          format: date-time
+      required: [seq, session_id, runtime_generation, type, occurred_at]
+    ExecutionSessionEventPage:
+      type: object
+      properties:
+        events:
+          type: array
+          items:
+            $ref: "#/components/schemas/ExecutionSessionEvent"
+        cursor:
+          $ref: "#/components/schemas/ExecutionSessionEventCursor"
+      required: [events, cursor]
+    SuccessExecutionSessionResponse:
+      allOf:
+        - $ref: "#/components/schemas/SuccessEnvelope"
+        - type: object
+          properties:
+            data:
+              $ref: "#/components/schemas/ExecutionSession"
+    SuccessExecutionSessionListResponse:
+      allOf:
+        - $ref: "#/components/schemas/SuccessEnvelope"
+        - type: object
+          properties:
+            data:
+              type: object
+              properties:
+                sessions:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/ExecutionSession"
+              required: [sessions]
+    SuccessExecutionSessionInputResponse:
+      allOf:
+        - $ref: "#/components/schemas/SuccessEnvelope"
+        - type: object
+          properties:
+            data:
+              $ref: "#/components/schemas/ExecutionSessionInputResponse"
+    SuccessExecutionSessionEventPageResponse:
+      allOf:
+        - $ref: "#/components/schemas/SuccessEnvelope"
+        - type: object
+          properties:
+            data:
+              $ref: "#/components/schemas/ExecutionSessionEventPage"
+    SuccessAcceptedResponse:
+      allOf:
+        - $ref: "#/components/schemas/SuccessEnvelope"
+        - type: object
+          properties:
+            data:
+              type: object
+              properties:
+                accepted:
+                  type: boolean
+              required: [accepted]
+    ExecutionSessionWebSocketRequest:
+      oneOf:
+        - $ref: "#/components/schemas/ExecutionSessionWebSocketInput"
+        - $ref: "#/components/schemas/ExecutionSessionWebSocketSignal"
+        - $ref: "#/components/schemas/ExecutionSessionWebSocketResize"
+    ExecutionSessionWebSocketInput:
+      allOf:
+        - $ref: "#/components/schemas/ExecutionSessionInputRequest"
+        - type: object
+          properties:
+            type:
+              type: string
+              enum: [input]
+            request_id:
+              type: string
+          required: [type]
+    ExecutionSessionWebSocketSignal:
+      allOf:
+        - $ref: "#/components/schemas/ExecutionSessionSignalRequest"
+        - type: object
+          properties:
+            type:
+              type: string
+              enum: [signal]
+            request_id:
+              type: string
+          required: [type]
+    ExecutionSessionWebSocketResize:
+      allOf:
+        - $ref: "#/components/schemas/ExecutionSessionTerminalResizeRequest"
+        - type: object
+          properties:
+            type:
+              type: string
+              enum: [resize]
+            request_id:
+              type: string
+          required: [type]
+    ExecutionSessionWebSocketResponse:
+      oneOf:
+        - $ref: "#/components/schemas/ExecutionSessionWebSocketEvent"
+        - $ref: "#/components/schemas/ExecutionSessionWebSocketAck"
+        - $ref: "#/components/schemas/ExecutionSessionWebSocketError"
+    ExecutionSessionWebSocketEvent:
+      type: object
+      properties:
+        type:
+          type: string
+          enum: [event]
+        event:
+          $ref: "#/components/schemas/ExecutionSessionEvent"
+      required: [type, event]
+    ExecutionSessionWebSocketAck:
+      type: object
+      properties:
+        type:
+          type: string
+          enum: [ack]
+        request_id:
+          type: string
+      required: [type]
+    ExecutionSessionWebSocketError:
+      type: object
+      properties:
+        type:
+          type: string
+          enum: [error]
+        request_id:
+          type: string
+        error:
+          type: string
+      required: [type, error]
     ProcessType:
       type: string
       enum: [repl, cmd]

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -101,6 +101,59 @@ const (
 	False ErrorEnvelopeSuccess = false
 )
 
+// Defines values for ExecutionSessionDesiredState.
+const (
+	ExecutionSessionDesiredStateRunning ExecutionSessionDesiredState = "running"
+	ExecutionSessionDesiredStateStopped ExecutionSessionDesiredState = "stopped"
+)
+
+// Defines values for ExecutionSessionEventStream.
+const (
+	ExecutionSessionEventStreamPty    ExecutionSessionEventStream = "pty"
+	ExecutionSessionEventStreamStderr ExecutionSessionEventStream = "stderr"
+	ExecutionSessionEventStreamStdout ExecutionSessionEventStream = "stdout"
+)
+
+// Defines values for ExecutionSessionIOMode.
+const (
+	ExecutionSessionIOModePTY   ExecutionSessionIOMode = "pty"
+	ExecutionSessionIOModePipes ExecutionSessionIOMode = "pipes"
+)
+
+// Defines values for ExecutionSessionPhase.
+const (
+	ExecutionSessionPhaseBackoff   ExecutionSessionPhase = "backoff"
+	ExecutionSessionPhaseExited    ExecutionSessionPhase = "exited"
+	ExecutionSessionPhaseFailed    ExecutionSessionPhase = "failed"
+	ExecutionSessionPhasePaused    ExecutionSessionPhase = "paused"
+	ExecutionSessionPhasePending   ExecutionSessionPhase = "pending"
+	ExecutionSessionPhaseRunning   ExecutionSessionPhase = "running"
+	ExecutionSessionPhaseStarting  ExecutionSessionPhase = "starting"
+	ExecutionSessionPhaseStopped   ExecutionSessionPhase = "stopped"
+	ExecutionSessionPhaseStopping  ExecutionSessionPhase = "stopping"
+	ExecutionSessionPhaseSuspended ExecutionSessionPhase = "suspended"
+)
+
+// Defines values for ExecutionSessionReadinessType.
+const (
+	ExecutionSessionReadinessDelay   ExecutionSessionReadinessType = "delay"
+	ExecutionSessionReadinessOutput  ExecutionSessionReadinessType = "output"
+	ExecutionSessionReadinessProcess ExecutionSessionReadinessType = "process"
+)
+
+// Defines values for ExecutionSessionRestartPolicy.
+const (
+	ExecutionSessionRestartPolicyAlways    ExecutionSessionRestartPolicy = "always"
+	ExecutionSessionRestartPolicyNever     ExecutionSessionRestartPolicy = "never"
+	ExecutionSessionRestartPolicyOnFailure ExecutionSessionRestartPolicy = "on_failure"
+)
+
+// Defines values for ExecutionSessionRuntimeRecoveryPolicy.
+const (
+	ExecutionSessionRuntimeRecoveryRestart ExecutionSessionRuntimeRecoveryPolicy = "restart"
+	ExecutionSessionRuntimeRecoveryStop    ExecutionSessionRuntimeRecoveryPolicy = "stop"
+)
+
 // Defines values for FileContentResponseEncoding.
 const (
 	Base64 FileContentResponseEncoding = "base64"
@@ -218,9 +271,9 @@ const (
 
 // Defines values for SandboxObservabilityLogStream.
 const (
-	Pty    SandboxObservabilityLogStream = "pty"
-	Stderr SandboxObservabilityLogStream = "stderr"
-	Stdout SandboxObservabilityLogStream = "stdout"
+	SandboxObservabilityLogStreamPty    SandboxObservabilityLogStream = "pty"
+	SandboxObservabilityLogStreamStderr SandboxObservabilityLogStream = "stderr"
+	SandboxObservabilityLogStreamStdout SandboxObservabilityLogStream = "stdout"
 )
 
 // Defines values for SandboxObservabilityOutcome.
@@ -321,6 +374,11 @@ const (
 	SuccessAPIKeyListResponseSuccessTrue SuccessAPIKeyListResponseSuccess = true
 )
 
+// Defines values for SuccessAcceptedResponseSuccess.
+const (
+	SuccessAcceptedResponseSuccessTrue SuccessAcceptedResponseSuccess = true
+)
+
 // Defines values for SuccessAuthProvidersResponseSuccess.
 const (
 	SuccessAuthProvidersResponseSuccessTrue SuccessAuthProvidersResponseSuccess = true
@@ -389,6 +447,26 @@ const (
 // Defines values for SuccessEnvelopeSuccess.
 const (
 	SuccessEnvelopeSuccessTrue SuccessEnvelopeSuccess = true
+)
+
+// Defines values for SuccessExecutionSessionEventPageResponseSuccess.
+const (
+	SuccessExecutionSessionEventPageResponseSuccessTrue SuccessExecutionSessionEventPageResponseSuccess = true
+)
+
+// Defines values for SuccessExecutionSessionInputResponseSuccess.
+const (
+	SuccessExecutionSessionInputResponseSuccessTrue SuccessExecutionSessionInputResponseSuccess = true
+)
+
+// Defines values for SuccessExecutionSessionListResponseSuccess.
+const (
+	SuccessExecutionSessionListResponseSuccessTrue SuccessExecutionSessionListResponseSuccess = true
+)
+
+// Defines values for SuccessExecutionSessionResponseSuccess.
+const (
+	SuccessExecutionSessionResponseSuccessTrue SuccessExecutionSessionResponseSuccess = true
 )
 
 // Defines values for SuccessFileListResponseSuccess.
@@ -618,7 +696,7 @@ const (
 
 // Defines values for SuccessWrittenResponseSuccess.
 const (
-	True SuccessWrittenResponseSuccess = true
+	SuccessWrittenResponseSuccessTrue SuccessWrittenResponseSuccess = true
 )
 
 // Defines values for TeamQuotaUnit.
@@ -888,6 +966,11 @@ type CreateContextRequest struct {
 	WaitUntilDone  *bool                     `json:"wait_until_done,omitempty"`
 }
 
+// CreateExecutionSessionAttemptRequest defines model for CreateExecutionSessionAttemptRequest.
+type CreateExecutionSessionAttemptRequest struct {
+	ReplaceCurrent *bool `json:"replace_current,omitempty"`
+}
+
 // CreateREPLContextRequest defines model for CreateREPLContextRequest.
 type CreateREPLContextRequest struct {
 	// Alias Alias for the REPL or CLI tool (e.g., python, node, bash, redis-cli)
@@ -1144,6 +1227,181 @@ type ErrorEnvelopeSuccess bool
 type ExecCandidate struct {
 	Args *[]string `json:"args,omitempty"`
 	Name string    `json:"name"`
+}
+
+// ExecutionSession defines model for ExecutionSession.
+type ExecutionSession struct {
+	Attempt           *ExecutionSessionAttempt    `json:"attempt,omitempty"`
+	CreatedAt         time.Time                   `json:"created_at"`
+	Cursor            ExecutionSessionEventCursor `json:"cursor"`
+	Id                string                      `json:"id"`
+	LastActivityAt    time.Time                   `json:"last_activity_at"`
+	Phase             ExecutionSessionPhase       `json:"phase"`
+	RestartCount      int32                       `json:"restart_count"`
+	RuntimeGeneration int64                       `json:"runtime_generation"`
+
+	// Spec Generic process-backed session specification. The supervisor does not interpret application protocols.
+	Spec        ExecutionSessionSpec `json:"spec"`
+	SpecVersion int64                `json:"spec_version"`
+	UpdatedAt   time.Time            `json:"updated_at"`
+}
+
+// ExecutionSessionAttempt defines model for ExecutionSessionAttempt.
+type ExecutionSessionAttempt struct {
+	ExitCode          *int32     `json:"exit_code,omitempty"`
+	FinishedAt        *time.Time `json:"finished_at,omitempty"`
+	Id                string     `json:"id"`
+	Number            int64      `json:"number"`
+	Pid               *int32     `json:"pid,omitempty"`
+	Reason            *string    `json:"reason,omitempty"`
+	RuntimeGeneration int64      `json:"runtime_generation"`
+	StartedAt         *time.Time `json:"started_at,omitempty"`
+}
+
+// ExecutionSessionDesiredState defines model for ExecutionSessionDesiredState.
+type ExecutionSessionDesiredState string
+
+// ExecutionSessionDesiredStateRequest defines model for ExecutionSessionDesiredStateRequest.
+type ExecutionSessionDesiredStateRequest struct {
+	State ExecutionSessionDesiredState `json:"state"`
+}
+
+// ExecutionSessionEvent defines model for ExecutionSessionEvent.
+type ExecutionSessionEvent struct {
+	AttemptId *string `json:"attempt_id,omitempty"`
+
+	// DataBase64 Base64-encoded event bytes.
+	DataBase64        *string                      `json:"data_base64,omitempty"`
+	ExitCode          *int32                       `json:"exit_code,omitempty"`
+	OccurredAt        time.Time                    `json:"occurred_at"`
+	Reason            *string                      `json:"reason,omitempty"`
+	RuntimeGeneration int64                        `json:"runtime_generation"`
+	Seq               int64                        `json:"seq"`
+	SessionId         string                       `json:"session_id"`
+	Stream            *ExecutionSessionEventStream `json:"stream,omitempty"`
+	Type              string                       `json:"type"`
+}
+
+// ExecutionSessionEventStream defines model for ExecutionSessionEvent.Stream.
+type ExecutionSessionEventStream string
+
+// ExecutionSessionEventCursor defines model for ExecutionSessionEventCursor.
+type ExecutionSessionEventCursor struct {
+	Earliest int64 `json:"earliest"`
+	Latest   int64 `json:"latest"`
+}
+
+// ExecutionSessionEventPage defines model for ExecutionSessionEventPage.
+type ExecutionSessionEventPage struct {
+	Cursor ExecutionSessionEventCursor `json:"cursor"`
+	Events []ExecutionSessionEvent     `json:"events"`
+}
+
+// ExecutionSessionEventRetentionSpec defines model for ExecutionSessionEventRetentionSpec.
+type ExecutionSessionEventRetentionSpec struct {
+	MaxAgeSeconds *int64 `json:"max_age_seconds,omitempty"`
+	MaxBytes      *int64 `json:"max_bytes,omitempty"`
+}
+
+// ExecutionSessionIOMode defines model for ExecutionSessionIOMode.
+type ExecutionSessionIOMode string
+
+// ExecutionSessionIOSpec defines model for ExecutionSessionIOSpec.
+type ExecutionSessionIOSpec struct {
+	Mode     *ExecutionSessionIOMode       `json:"mode,omitempty"`
+	Terminal *ExecutionSessionTerminalSpec `json:"terminal,omitempty"`
+}
+
+// ExecutionSessionInputRequest defines model for ExecutionSessionInputRequest.
+type ExecutionSessionInputRequest struct {
+	// DataBase64 Base64-encoded input bytes accepted into the current attempt input queue. WebSocket closure never implies EOF.
+	DataBase64        *string `json:"data_base64,omitempty"`
+	Eof               *bool   `json:"eof,omitempty"`
+	ExpectedAttemptId *string `json:"expected_attempt_id,omitempty"`
+
+	// InputId Client-generated operation identifier used to deduplicate recorded retries.
+	InputId string `json:"input_id"`
+}
+
+// ExecutionSessionInputResponse defines model for ExecutionSessionInputResponse.
+type ExecutionSessionInputResponse struct {
+	Accepted  bool   `json:"accepted"`
+	AttemptId string `json:"attempt_id"`
+	Duplicate bool   `json:"duplicate"`
+	InputId   string `json:"input_id"`
+}
+
+// ExecutionSessionLifecycleSpec defines model for ExecutionSessionLifecycleSpec.
+type ExecutionSessionLifecycleSpec struct {
+	DesiredState           *ExecutionSessionDesiredState          `json:"desired_state,omitempty"`
+	IdleTimeoutSeconds     *int64                                 `json:"idle_timeout_seconds,omitempty"`
+	MaxLifetimeSeconds     *int64                                 `json:"max_lifetime_seconds,omitempty"`
+	Restart                *ExecutionSessionRestartSpec           `json:"restart,omitempty"`
+	RuntimeRecovery        *ExecutionSessionRuntimeRecoveryPolicy `json:"runtime_recovery,omitempty"`
+	StopGracePeriodSeconds *int32                                 `json:"stop_grace_period_seconds,omitempty"`
+}
+
+// ExecutionSessionPhase defines model for ExecutionSessionPhase.
+type ExecutionSessionPhase string
+
+// ExecutionSessionReadinessSpec defines model for ExecutionSessionReadinessSpec.
+type ExecutionSessionReadinessSpec struct {
+	DelayMs *int32 `json:"delay_ms,omitempty"`
+
+	// Output Byte sequence whose appearance in process output marks the attempt ready when type is output.
+	Output    *string                        `json:"output,omitempty"`
+	TimeoutMs *int32                         `json:"timeout_ms,omitempty"`
+	Type      *ExecutionSessionReadinessType `json:"type,omitempty"`
+}
+
+// ExecutionSessionReadinessType defines model for ExecutionSessionReadinessType.
+type ExecutionSessionReadinessType string
+
+// ExecutionSessionRestartPolicy defines model for ExecutionSessionRestartPolicy.
+type ExecutionSessionRestartPolicy string
+
+// ExecutionSessionRestartSpec defines model for ExecutionSessionRestartSpec.
+type ExecutionSessionRestartSpec struct {
+	InitialBackoffMs *int32                         `json:"initial_backoff_ms,omitempty"`
+	MaxBackoffMs     *int32                         `json:"max_backoff_ms,omitempty"`
+	MaxRestarts      *int32                         `json:"max_restarts,omitempty"`
+	Policy           *ExecutionSessionRestartPolicy `json:"policy,omitempty"`
+	WindowSeconds    *int32                         `json:"window_seconds,omitempty"`
+}
+
+// ExecutionSessionRuntimeRecoveryPolicy defines model for ExecutionSessionRuntimeRecoveryPolicy.
+type ExecutionSessionRuntimeRecoveryPolicy string
+
+// ExecutionSessionSignalRequest defines model for ExecutionSessionSignalRequest.
+type ExecutionSessionSignalRequest struct {
+	ExpectedAttemptId *string `json:"expected_attempt_id,omitempty"`
+	Signal            string  `json:"signal"`
+}
+
+// ExecutionSessionSpec Generic process-backed session specification. The supervisor does not interpret application protocols.
+type ExecutionSessionSpec struct {
+	Command        []string                            `json:"command"`
+	Cwd            *string                             `json:"cwd,omitempty"`
+	Env            *map[string]string                  `json:"env,omitempty"`
+	EventRetention *ExecutionSessionEventRetentionSpec `json:"event_retention,omitempty"`
+	Io             *ExecutionSessionIOSpec             `json:"io,omitempty"`
+	Lifecycle      *ExecutionSessionLifecycleSpec      `json:"lifecycle,omitempty"`
+	Name           *string                             `json:"name,omitempty"`
+	Readiness      *ExecutionSessionReadinessSpec      `json:"readiness,omitempty"`
+}
+
+// ExecutionSessionTerminalResizeRequest defines model for ExecutionSessionTerminalResizeRequest.
+type ExecutionSessionTerminalResizeRequest struct {
+	Cols              int32   `json:"cols"`
+	ExpectedAttemptId *string `json:"expected_attempt_id,omitempty"`
+	Rows              int32   `json:"rows"`
+}
+
+// ExecutionSessionTerminalSpec defines model for ExecutionSessionTerminalSpec.
+type ExecutionSessionTerminalSpec struct {
+	Cols *int32  `json:"cols,omitempty"`
+	Rows *int32  `json:"rows,omitempty"`
+	Term *string `json:"term,omitempty"`
 }
 
 // FileContentResponse defines model for FileContentResponse.
@@ -2350,6 +2608,17 @@ type SuccessAPIKeyListResponse struct {
 // SuccessAPIKeyListResponseSuccess defines model for SuccessAPIKeyListResponse.Success.
 type SuccessAPIKeyListResponseSuccess bool
 
+// SuccessAcceptedResponse defines model for SuccessAcceptedResponse.
+type SuccessAcceptedResponse struct {
+	Data *struct {
+		Accepted bool `json:"accepted"`
+	} `json:"data,omitempty"`
+	Success SuccessAcceptedResponseSuccess `json:"success"`
+}
+
+// SuccessAcceptedResponseSuccess defines model for SuccessAcceptedResponse.Success.
+type SuccessAcceptedResponseSuccess bool
+
 // SuccessAuthProvidersResponse defines model for SuccessAuthProvidersResponse.
 type SuccessAuthProvidersResponse struct {
 	Data *struct {
@@ -2485,6 +2754,44 @@ type SuccessEnvelope struct {
 
 // SuccessEnvelopeSuccess defines model for SuccessEnvelope.Success.
 type SuccessEnvelopeSuccess bool
+
+// SuccessExecutionSessionEventPageResponse defines model for SuccessExecutionSessionEventPageResponse.
+type SuccessExecutionSessionEventPageResponse struct {
+	Data    *ExecutionSessionEventPage                      `json:"data,omitempty"`
+	Success SuccessExecutionSessionEventPageResponseSuccess `json:"success"`
+}
+
+// SuccessExecutionSessionEventPageResponseSuccess defines model for SuccessExecutionSessionEventPageResponse.Success.
+type SuccessExecutionSessionEventPageResponseSuccess bool
+
+// SuccessExecutionSessionInputResponse defines model for SuccessExecutionSessionInputResponse.
+type SuccessExecutionSessionInputResponse struct {
+	Data    *ExecutionSessionInputResponse              `json:"data,omitempty"`
+	Success SuccessExecutionSessionInputResponseSuccess `json:"success"`
+}
+
+// SuccessExecutionSessionInputResponseSuccess defines model for SuccessExecutionSessionInputResponse.Success.
+type SuccessExecutionSessionInputResponseSuccess bool
+
+// SuccessExecutionSessionListResponse defines model for SuccessExecutionSessionListResponse.
+type SuccessExecutionSessionListResponse struct {
+	Data *struct {
+		Sessions []ExecutionSession `json:"sessions"`
+	} `json:"data,omitempty"`
+	Success SuccessExecutionSessionListResponseSuccess `json:"success"`
+}
+
+// SuccessExecutionSessionListResponseSuccess defines model for SuccessExecutionSessionListResponse.Success.
+type SuccessExecutionSessionListResponseSuccess bool
+
+// SuccessExecutionSessionResponse defines model for SuccessExecutionSessionResponse.
+type SuccessExecutionSessionResponse struct {
+	Data    *ExecutionSession                      `json:"data,omitempty"`
+	Success SuccessExecutionSessionResponseSuccess `json:"success"`
+}
+
+// SuccessExecutionSessionResponseSuccess defines model for SuccessExecutionSessionResponse.Success.
+type SuccessExecutionSessionResponseSuccess bool
 
 // SuccessFileListResponse defines model for SuccessFileListResponse.
 type SuccessFileListResponse struct {
@@ -3204,6 +3511,9 @@ type SandboxID = string
 // SandboxVolumeID defines model for SandboxVolumeID.
 type SandboxVolumeID = string
 
+// SessionID defines model for SessionID.
+type SessionID = string
+
 // SnapshotID defines model for SnapshotID.
 type SnapshotID = string
 
@@ -3325,6 +3635,29 @@ type GetApiV1SandboxesIdObservabilityLogsParams struct {
 	Stream    *SandboxObservabilityLogStream `form:"stream,omitempty" json:"stream,omitempty"`
 }
 
+// PostApiV1SandboxesIdSessionsParams defines parameters for PostApiV1SandboxesIdSessions.
+type PostApiV1SandboxesIdSessionsParams struct {
+	// IdempotencyKey Optional key for retrying creation without creating a duplicate session.
+	IdempotencyKey *string `json:"Idempotency-Key,omitempty"`
+}
+
+// GetApiV1SandboxesIdSessionsSessionIdEventsParams defines parameters for GetApiV1SandboxesIdSessionsSessionIdEvents.
+type GetApiV1SandboxesIdSessionsSessionIdEventsParams struct {
+	After *int64 `form:"after,omitempty" json:"after,omitempty"`
+	Limit *int   `form:"limit,omitempty" json:"limit,omitempty"`
+}
+
+// GetApiV1SandboxesIdSessionsSessionIdEventsStreamParams defines parameters for GetApiV1SandboxesIdSessionsSessionIdEventsStream.
+type GetApiV1SandboxesIdSessionsSessionIdEventsStreamParams struct {
+	After       *int64  `form:"after,omitempty" json:"after,omitempty"`
+	LastEventID *string `json:"Last-Event-ID,omitempty"`
+}
+
+// GetApiV1SandboxesIdSessionsSessionIdWsParams defines parameters for GetApiV1SandboxesIdSessionsSessionIdWs.
+type GetApiV1SandboxesIdSessionsSessionIdWsParams struct {
+	After *int64 `form:"after,omitempty" json:"after,omitempty"`
+}
+
 // DeleteApiV1SandboxvolumesIdParams defines parameters for DeleteApiV1SandboxvolumesId.
 type DeleteApiV1SandboxvolumesIdParams struct {
 	// Force Force delete even if volume has active mounts
@@ -3433,6 +3766,27 @@ type PostApiV1SandboxesIdRootfsRestoreJSONRequestBody = RestoreSandboxRootFSRequ
 
 // PutApiV1SandboxesIdServicesJSONRequestBody defines body for PutApiV1SandboxesIdServices for application/json ContentType.
 type PutApiV1SandboxesIdServicesJSONRequestBody = SandboxServicesUpdateRequest
+
+// PostApiV1SandboxesIdSessionsJSONRequestBody defines body for PostApiV1SandboxesIdSessions for application/json ContentType.
+type PostApiV1SandboxesIdSessionsJSONRequestBody = ExecutionSessionSpec
+
+// PutApiV1SandboxesIdSessionsSessionIdJSONRequestBody defines body for PutApiV1SandboxesIdSessionsSessionId for application/json ContentType.
+type PutApiV1SandboxesIdSessionsSessionIdJSONRequestBody = ExecutionSessionSpec
+
+// PostApiV1SandboxesIdSessionsSessionIdAttemptsJSONRequestBody defines body for PostApiV1SandboxesIdSessionsSessionIdAttempts for application/json ContentType.
+type PostApiV1SandboxesIdSessionsSessionIdAttemptsJSONRequestBody = CreateExecutionSessionAttemptRequest
+
+// PutApiV1SandboxesIdSessionsSessionIdDesiredStateJSONRequestBody defines body for PutApiV1SandboxesIdSessionsSessionIdDesiredState for application/json ContentType.
+type PutApiV1SandboxesIdSessionsSessionIdDesiredStateJSONRequestBody = ExecutionSessionDesiredStateRequest
+
+// PostApiV1SandboxesIdSessionsSessionIdInputsJSONRequestBody defines body for PostApiV1SandboxesIdSessionsSessionIdInputs for application/json ContentType.
+type PostApiV1SandboxesIdSessionsSessionIdInputsJSONRequestBody = ExecutionSessionInputRequest
+
+// PostApiV1SandboxesIdSessionsSessionIdSignalsJSONRequestBody defines body for PostApiV1SandboxesIdSessionsSessionIdSignals for application/json ContentType.
+type PostApiV1SandboxesIdSessionsSessionIdSignalsJSONRequestBody = ExecutionSessionSignalRequest
+
+// PutApiV1SandboxesIdSessionsSessionIdTerminalJSONRequestBody defines body for PutApiV1SandboxesIdSessionsSessionIdTerminal for application/json ContentType.
+type PutApiV1SandboxesIdSessionsSessionIdTerminalJSONRequestBody = ExecutionSessionTerminalResizeRequest
 
 // PostApiV1SandboxesIdSnapshotsJSONRequestBody defines body for PostApiV1SandboxesIdSnapshots for application/json ContentType.
 type PostApiV1SandboxesIdSnapshotsJSONRequestBody = CreateSandboxRootFSSnapshotRequest

--- a/pkg/gateway/middleware/long_lived.go
+++ b/pkg/gateway/middleware/long_lived.go
@@ -29,7 +29,15 @@ func RequestShouldBeLongLived(req *http.Request) bool {
 	if proxy.IsWebSocketUpgrade(req) {
 		return true
 	}
-	return isSandboxObservabilityWatchRequest(req)
+	return isSandboxObservabilityWatchRequest(req) || isSandboxSessionEventStreamRequest(req)
+}
+
+func isSandboxSessionEventStreamRequest(req *http.Request) bool {
+	if req.Method != http.MethodGet || req.URL == nil {
+		return false
+	}
+	path := strings.TrimRight(req.URL.Path, "/")
+	return strings.HasPrefix(path, "/api/v1/sandboxes/") && strings.HasSuffix(path, "/events/stream") && strings.Contains(path, "/sessions/")
 }
 
 func isSandboxObservabilityWatchRequest(req *http.Request) bool {

--- a/pkg/gateway/middleware/long_lived_test.go
+++ b/pkg/gateway/middleware/long_lived_test.go
@@ -28,6 +28,16 @@ func TestRequestShouldBeLongLived(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "session event stream",
+			req:  httptest.NewRequest(http.MethodGet, "/api/v1/sandboxes/sb_123/sessions/ses_123/events/stream?after=4", nil),
+			want: true,
+		},
+		{
+			name: "session event page",
+			req:  httptest.NewRequest(http.MethodGet, "/api/v1/sandboxes/sb_123/sessions/ses_123/events", nil),
+			want: false,
+		},
+		{
 			name: "websocket context stream",
 			req: func() *http.Request {
 				req := httptest.NewRequest(http.MethodGet, "/api/v1/sandboxes/sb_123/contexts/ctx_123/ws", nil)


### PR DESCRIPTION
## Summary

- add generic, process-backed execution sessions with a stable session identity, current attempt, and retained event journal
- expose lifecycle and control over HTTP, replayable output over SSE, and duplex attachments over WebSocket; attachment loss never stops a session or closes stdin
- support pipes and PTY, binary-safe input receipts, attempt fencing, explicit EOF, signals, resize, readiness, restart policy, runtime recovery, lifecycle expiry, and bounded retention
- persist supervisor state through sandbox pause/resume while preventing copied state from executing after a sandbox fork
- route the public API through cluster-gateway, migrate command-backed sandbox services to supervised sessions, and make procd a safe PID 1 reaper
- add the canonical OpenAPI contract and a new Session Supervisor documentation chapter with Go, Python, TypeScript, CLI, and HTTP guidance

## Validation

- `go test -race ./manager/... ./cluster-gateway/... ./pkg/... ./ctld/... ./infra-operator/api/config ./infra-operator/internal/runtimeconfig`
- `go build -buildvcs=false ./manager/cmd/procd ./manager/cmd/manager ./cluster-gateway/cmd/cluster-gateway ./ctld/cmd/ctld`
- `make apispec` and MDX compilation
- executed the documented Go, Python, TypeScript, and CLI examples against the remote Kind environment
- remote API validation covered SSE disconnect/replay, input deduplication and fencing, explicit EOF, PTY resize, signals, restart/readiness, pause/resume recovery, WebSocket reconnect, fork isolation, and an 8 MiB burst-output hash check
- remote Sandbox0Infra returned `Ready 9/9`; the ECS test instance was stopped with `StopCharging` after cleanup

Local e2e was intentionally not run; PR CI owns the e2e suite.

## Downstream PRs

- sandbox0-ai/sdk-go#70
- sandbox0-ai/sdk-js#63
- sandbox0-ai/sdk-py#60
- sandbox0-ai/s0#84

The CLI PR depends on the sdk-go PR. The documentation examples in this PR were executed from these matching SDK and CLI branches.