### PR TITLE
feat: add coding agent builtin template

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -111,6 +111,10 @@
           "title": "Use Cases"
         },
         {
+          "slug": "coding-agents",
+          "title": "Coding Agents"
+        },
+        {
           "slug": "openclaw",
           "title": "Hosting OpenClaw"
         },

--- a/docs/self-hosted/configuration/page.mdx
+++ b/docs/self-hosted/configuration/page.mdx
@@ -27,7 +27,7 @@ A `Sandbox0Infra` spec is easier to reason about when you split it into five lay
 `spec.initUser` is consumed by the gateway runtime, not created by the operator itself.
 In local-password mode it bootstraps the first admin credentials; in OIDC-only mode it pre-creates the admin user and initial team so the first OIDC login with the same email lands on the intended admin account.
 
-When `spec.builtinTemplates` is omitted, infra-operator seeds public builtin templates for `default`, `openclaw`, `hermes`, and `browser`. Set `spec.builtinTemplates` explicitly when you want to pin images, adjust pools, disable one of the builtins, or provide a full template `spec` for a runtime-specific setup. Set it to `[]` to remove all operator-managed builtin templates.
+When `spec.builtinTemplates` is omitted, infra-operator seeds public builtin templates for `default`, `openclaw`, `hermes`, `browser`, and `coding-agent`. Set `spec.builtinTemplates` explicitly when you want to pin images, adjust pools, disable one of the builtins, or provide a full template `spec` for a runtime-specific setup. Set it to `[]` to remove all operator-managed builtin templates.
 
 ## Deployment Profiles
 

--- a/docs/use-cases/coding-agents/page.mdx
+++ b/docs/use-cases/coding-agents/page.mdx
@@ -3,293 +3,603 @@
 Use the builtin `coding-agent` template when an application needs to run Codex, Claude Code, OpenCode, or Pi inside the same Sandbox0 execution environment. The template installs all four native CLIs and declares two writable mount points:
 
 - `/workspace` for the repository and generated files
-- `/agent-state` for harness configuration, credentials, and native conversation state
+- `/agent-state` for harness configuration and native conversation state
 
 Each coding agent remains a native subprocess. Session Supervisor owns process lifetime, stdin/stdout transport, restart attempts, and the replayable event journal; it does not translate one harness protocol into another.
 
-| Harness | Installed command | Native supervised transport |
-|---------|-------------------|-----------------------------|
-| Codex | `codex app-server --stdio` | Codex JSON-RPC messages over JSONL |
+| Harness | Native command | Protocol |
+|---------|----------------|----------|
+| Codex | `codex app-server --stdio` | Codex JSON-RPC over JSONL |
 | Claude Code | `claude -p --input-format stream-json --output-format stream-json` | Claude Code stream-json |
 | OpenCode | `opencode acp --cwd /workspace` | Agent Client Protocol over nd-JSON |
 | Pi | `pi --mode rpc` | Pi RPC over JSONL |
 
 <Callout variant="warning">
-The example grants the selected coding agent broad control inside its sandbox. Keep model credentials narrow, restrict network policy for production workloads, and do not mount a developer home directory or host Docker socket into the sandbox.
+The examples grant the selected coding agent broad control inside its sandbox. Keep model credentials narrow, restrict network policy for production workloads, and do not mount a developer home directory or host Docker socket into the sandbox.
 </Callout>
 
 ## Create The Environment
 
-The template has a zero-sized warm pool by default because the image is large and not every deployment needs a coding agent. Claiming it pulls the image on demand.
+The SDK snippets assume you already configured a `client` as shown in [Get Started](/docs/get-started). They create separate SandboxVolumes for repository and harness state, then claim the builtin template. The examples leave `ttl` and `hard_ttl` unset.
 
-Create separate volumes for the repository and harness state, then claim the template:
+<Tabs
+  tabs={[
+    {
+      label: "Go",
+      language: "go",
+      code: `workspaceVolume, err := client.CreateVolume(ctx, apispec.CreateSandboxVolumeRequest{
+    AccessMode: apispec.NewOptVolumeAccessMode(apispec.VolumeAccessModeRWO),
+})
+if err != nil {
+    log.Fatal(err)
+}
 
-```bash
-WORKSPACE_VOLUME_ID="$(s0 -o json volume create --access-mode RWO | jq -r '.id')"
+agentStateVolume, err := client.CreateVolume(ctx, apispec.CreateSandboxVolumeRequest{
+    AccessMode: apispec.NewOptVolumeAccessMode(apispec.VolumeAccessModeRWO),
+})
+if err != nil {
+    log.Fatal(err)
+}
+
+sandbox, err := client.ClaimSandbox(ctx, "coding-agent",
+    sandbox0.WithSandboxBootstrapMount(workspaceVolume.ID, "/workspace"),
+    sandbox0.WithSandboxBootstrapMount(agentStateVolume.ID, "/agent-state"),
+)
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Println("Sandbox ID:", sandbox.ID)`
+    },
+    {
+      label: "Python",
+      language: "python",
+      code: `from sandbox0.apispec.models.claim_mount_request import ClaimMountRequest
+from sandbox0.apispec.models.create_sandbox_volume_request import CreateSandboxVolumeRequest
+
+workspace_volume = client.volumes.create(CreateSandboxVolumeRequest.from_dict({
+    "access_mode": "RWO",
+}))
+agent_state_volume = client.volumes.create(CreateSandboxVolumeRequest.from_dict({
+    "access_mode": "RWO",
+}))
+
+sandbox = client.sandboxes.claim(
+    "coding-agent",
+    mounts=[
+        ClaimMountRequest(
+            sandboxvolume_id=workspace_volume.id,
+            mount_point="/workspace",
+        ),
+        ClaimMountRequest(
+            sandboxvolume_id=agent_state_volume.id,
+            mount_point="/agent-state",
+        ),
+    ],
+)
+print("Sandbox ID:", sandbox.id)`
+    },
+    {
+      label: "TypeScript",
+      language: "typescript",
+      code: `import { models } from "sandbox0";
+
+const workspaceVolume = await client.volumes.create({
+    accessMode: models.VolumeAccessMode.Rwo,
+});
+const agentStateVolume = await client.volumes.create({
+    accessMode: models.VolumeAccessMode.Rwo,
+});
+
+const sandbox = await client.sandboxes.claim("coding-agent", {
+    mounts: [
+        {
+            sandboxvolumeId: workspaceVolume.id,
+            mountPoint: "/workspace",
+        },
+        {
+            sandboxvolumeId: agentStateVolume.id,
+            mountPoint: "/agent-state",
+        },
+    ],
+});
+console.log("Sandbox ID:", sandbox.id);`
+    },
+    {
+      label: "CLI",
+      language: "bash",
+      code: `WORKSPACE_VOLUME_ID="$(s0 -o json volume create --access-mode RWO | jq -r '.id')"
 AGENT_STATE_VOLUME_ID="$(s0 -o json volume create --access-mode RWO | jq -r '.id')"
 
-SANDBOX_ID="$(s0 -o json sandbox create \
-    --template coding-agent \
-    --mount "$WORKSPACE_VOLUME_ID:/workspace" \
-    --mount "$AGENT_STATE_VOLUME_ID:/agent-state" \
+SANDBOX_ID="$(s0 -o json sandbox create \\
+    --template coding-agent \\
+    --mount "$WORKSPACE_VOLUME_ID:/workspace" \\
+    --mount "$AGENT_STATE_VOLUME_ID:/agent-state" \\
     | jq -r '.id')"
 
-export SANDBOX_ID
-```
+printf 'Sandbox ID: %s\\n' "$SANDBOX_ID"`
+    }
+  ]}
+/>
 
-The volumes are optional. If they are omitted, both paths are writable directories in the sandbox rootfs and follow that sandbox identity's checkpoint lifecycle. Use volumes when workspace or harness state must be managed independently from the sandbox.
+The volumes are optional. If omitted, both paths are writable directories in the sandbox rootfs and follow that sandbox identity's checkpoint lifecycle. Use volumes when repository or harness state must be managed independently from the sandbox.
 
-Do not bake provider credentials into the template image. For a local test, add the required provider environment variables to the supervised session. For production, prefer [egress auth](/docs/credential/egress-auth), LLMProxy, or another narrowly scoped external model proxy. Session environment variables are part of the session specification and should not be treated as a secret store.
+Do not bake provider credentials into the template image. For production, prefer [egress auth](/docs/credential/egress-auth), LLMProxy, or another narrowly scoped external model proxy. Session environment variables are returned as part of the session specification and should not be treated as a secret store.
 
-## Read And Write Native JSONL
+## Start A Native Harness
 
-Run this in a second terminal to replay retained output and then follow live output. The CLI decodes the event payload for display:
+Select one harness and create one pipe-based supervised session. These examples use Codex; replace `harnessName` with `claude-code`, `opencode`, or `pi` to select another native command from the same map.
 
-```bash
-s0 sandbox session events "$SANDBOX_ID" "$SESSION_ID" --follow
-```
-
-Use this helper in the examples below to write one or more newline-delimited native messages:
-
-```bash
-send_jsonl() {
-    local session_id="$1"
-    local input_id="$2"
-    s0 sandbox session input "$SANDBOX_ID" "$session_id" \
-        --input-id "$input_id" \
-        --file -
+<Tabs
+  tabs={[
+    {
+      label: "Go",
+      language: "go",
+      code: `type harnessSpec struct {
+    Command []string
+    Env     apispec.ExecutionSessionSpecEnv
 }
-```
 
-Applications should consume the SDK event stream instead of parsing the CLI table. Output events contain base64-encoded byte chunks, and chunk boundaries are not JSONL record boundaries. Buffer stdout bytes until LF before decoding a native message:
+harnesses := map[string]harnessSpec{
+    "codex": {
+        Command: []string{"codex", "app-server", "--stdio"},
+        Env: apispec.ExecutionSessionSpecEnv{
+            "CODEX_HOME": "/agent-state/codex",
+        },
+    },
+    "claude-code": {
+        Command: []string{
+            "claude", "-p",
+            "--input-format", "stream-json",
+            "--output-format", "stream-json",
+            "--verbose",
+            "--replay-user-messages",
+            "--permission-mode", "bypassPermissions",
+            "--dangerously-skip-permissions",
+        },
+        Env: apispec.ExecutionSessionSpecEnv{
+            "CLAUDE_CONFIG_DIR": "/agent-state/claude",
+        },
+    },
+    "opencode": {
+        Command: []string{"opencode", "acp", "--cwd", "/workspace"},
+        Env: apispec.ExecutionSessionSpecEnv{
+            "XDG_CONFIG_HOME": "/agent-state/opencode/config",
+            "XDG_DATA_HOME":   "/agent-state/opencode/data",
+            "XDG_CACHE_HOME":  "/agent-state/opencode/cache",
+        },
+    },
+    "pi": {
+        Command: []string{
+            "pi", "--mode", "rpc",
+            "--session-dir", "/agent-state/pi/sessions",
+            "--approve",
+        },
+        Env: apispec.ExecutionSessionSpecEnv{
+            "PI_CODING_AGENT_DIR":         "/agent-state/pi",
+            "PI_CODING_AGENT_SESSION_DIR": "/agent-state/pi/sessions",
+        },
+    },
+}
 
-```typescript
-import type { Sandbox } from 'sandbox0';
+harnessName := "codex"
+harness := harnesses[harnessName]
+session, err := sandbox.CreateSession(ctx, apispec.ExecutionSessionSpec{
+    Name:    apispec.NewOptString(harnessName),
+    Command: harness.Command,
+    Cwd:     apispec.NewOptString("/workspace"),
+    Env:     apispec.NewOptExecutionSessionSpecEnv(harness.Env),
+    Lifecycle: apispec.NewOptExecutionSessionLifecycleSpec(
+        apispec.ExecutionSessionLifecycleSpec{
+            Restart: apispec.NewOptExecutionSessionRestartSpec(
+                apispec.ExecutionSessionRestartSpec{
+                    Policy: apispec.NewOptExecutionSessionRestartPolicy(
+                        apispec.ExecutionSessionRestartPolicyOnFailure,
+                    ),
+                },
+            ),
+            RuntimeRecovery: apispec.NewOptExecutionSessionRuntimeRecoveryPolicy(
+                apispec.ExecutionSessionRuntimeRecoveryPolicyRestart,
+            ),
+        },
+    ),
+    Readiness: apispec.NewOptExecutionSessionReadinessSpec(
+        apispec.ExecutionSessionReadinessSpec{
+            Type: apispec.NewOptExecutionSessionReadinessType(
+                apispec.ExecutionSessionReadinessTypeProcess,
+            ),
+        },
+    ),
+}, &sandbox0.CreateSessionOptions{
+    IdempotencyKey: "coding-agent-" + harnessName + "-v1",
+})
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Println("Session ID:", session.ID)`
+    },
+    {
+      label: "Python",
+      language: "python",
+      code: `from sandbox0 import SessionCreateOptions
+from sandbox0.apispec.models.execution_session_spec import ExecutionSessionSpec
 
-export async function writeJsonLine(
+harnesses = {
+    "codex": {
+        "command": ["codex", "app-server", "--stdio"],
+        "env": {"CODEX_HOME": "/agent-state/codex"},
+    },
+    "claude-code": {
+        "command": [
+            "claude", "-p",
+            "--input-format", "stream-json",
+            "--output-format", "stream-json",
+            "--verbose",
+            "--replay-user-messages",
+            "--permission-mode", "bypassPermissions",
+            "--dangerously-skip-permissions",
+        ],
+        "env": {"CLAUDE_CONFIG_DIR": "/agent-state/claude"},
+    },
+    "opencode": {
+        "command": ["opencode", "acp", "--cwd", "/workspace"],
+        "env": {
+            "XDG_CONFIG_HOME": "/agent-state/opencode/config",
+            "XDG_DATA_HOME": "/agent-state/opencode/data",
+            "XDG_CACHE_HOME": "/agent-state/opencode/cache",
+        },
+    },
+    "pi": {
+        "command": [
+            "pi", "--mode", "rpc",
+            "--session-dir", "/agent-state/pi/sessions",
+            "--approve",
+        ],
+        "env": {
+            "PI_CODING_AGENT_DIR": "/agent-state/pi",
+            "PI_CODING_AGENT_SESSION_DIR": "/agent-state/pi/sessions",
+        },
+    },
+}
+
+harness_name = "codex"
+harness = harnesses[harness_name]
+session = sandbox.create_session(
+    ExecutionSessionSpec.from_dict({
+        "name": harness_name,
+        "command": harness["command"],
+        "cwd": "/workspace",
+        "env": harness["env"],
+        "lifecycle": {
+            "restart": {"policy": "on_failure"},
+            "runtime_recovery": "restart",
+        },
+        "readiness": {"type": "process"},
+    }),
+    SessionCreateOptions(
+        idempotency_key="coding-agent-" + harness_name + "-v1",
+    ),
+)
+print("Session ID:", session.id)`
+    },
+    {
+      label: "TypeScript",
+      language: "typescript",
+      code: `type HarnessSpec = {
+    command: string[];
+    env: Record<string, string>;
+};
+
+const harnesses: Record<string, HarnessSpec> = {
+    codex: {
+        command: ["codex", "app-server", "--stdio"],
+        env: { CODEX_HOME: "/agent-state/codex" },
+    },
+    "claude-code": {
+        command: [
+            "claude", "-p",
+            "--input-format", "stream-json",
+            "--output-format", "stream-json",
+            "--verbose",
+            "--replay-user-messages",
+            "--permission-mode", "bypassPermissions",
+            "--dangerously-skip-permissions",
+        ],
+        env: { CLAUDE_CONFIG_DIR: "/agent-state/claude" },
+    },
+    opencode: {
+        command: ["opencode", "acp", "--cwd", "/workspace"],
+        env: {
+            XDG_CONFIG_HOME: "/agent-state/opencode/config",
+            XDG_DATA_HOME: "/agent-state/opencode/data",
+            XDG_CACHE_HOME: "/agent-state/opencode/cache",
+        },
+    },
+    pi: {
+        command: [
+            "pi", "--mode", "rpc",
+            "--session-dir", "/agent-state/pi/sessions",
+            "--approve",
+        ],
+        env: {
+            PI_CODING_AGENT_DIR: "/agent-state/pi",
+            PI_CODING_AGENT_SESSION_DIR: "/agent-state/pi/sessions",
+        },
+    },
+};
+
+const harnessName = "codex";
+const harness = harnesses[harnessName];
+const session = await sandbox.createSession({
+    name: harnessName,
+    command: harness.command,
+    cwd: "/workspace",
+    env: harness.env,
+    lifecycle: {
+        restart: { policy: "on_failure" },
+        runtimeRecovery: "restart",
+    },
+    readiness: { type: "process" },
+}, {
+    idempotencyKey: "coding-agent-" + harnessName + "-v1",
+});
+console.log("Session ID:", session.id);`
+    },
+    {
+      label: "CLI",
+      language: "bash",
+      code: `HARNESS="codex"
+
+case "$HARNESS" in
+    codex)
+        ENV_ARGS=(--env CODEX_HOME=/agent-state/codex)
+        COMMAND=(codex app-server --stdio)
+        ;;
+    claude-code)
+        ENV_ARGS=(--env CLAUDE_CONFIG_DIR=/agent-state/claude)
+        COMMAND=(claude -p --input-format stream-json --output-format stream-json --verbose --replay-user-messages --permission-mode bypassPermissions --dangerously-skip-permissions)
+        ;;
+    opencode)
+        ENV_ARGS=(--env XDG_CONFIG_HOME=/agent-state/opencode/config --env XDG_DATA_HOME=/agent-state/opencode/data --env XDG_CACHE_HOME=/agent-state/opencode/cache)
+        COMMAND=(opencode acp --cwd /workspace)
+        ;;
+    pi)
+        ENV_ARGS=(--env PI_CODING_AGENT_DIR=/agent-state/pi --env PI_CODING_AGENT_SESSION_DIR=/agent-state/pi/sessions)
+        COMMAND=(pi --mode rpc --session-dir /agent-state/pi/sessions --approve)
+        ;;
+esac
+
+SESSION_ID="$(s0 -o json sandbox session create "$SANDBOX_ID" \\
+    --name "$HARNESS" \\
+    --cwd /workspace \\
+    --idempotency-key "coding-agent-$HARNESS-v1" \\
+    --restart on_failure \\
+    --runtime-recovery restart \\
+    --readiness process \\
+    "\${ENV_ARGS[@]}" \\
+    -- "\${COMMAND[@]}" \\
+    | jq -r '.id')"
+
+printf 'Session ID: %s\\n' "$SESSION_ID"`
+    }
+  ]}
+/>
+
+Use one active coding agent per workspace. Multiple supervised sessions can run in one sandbox, but concurrent writers can race on repository files and the Git index.
+
+## Exchange Native Messages
+
+All four commands use pipes, not a PTY. Write one LF-terminated native record at a time and fence the write to the current process attempt. The helper below accepts any JSON-compatible value; each harness section provides the native messages to send.
+
+<Tabs
+  tabs={[
+    {
+      label: "Go",
+      language: "go",
+      code: `func writeJSONLine(
+    ctx context.Context,
+    sandbox *sandbox0.Sandbox,
+    sessionID string,
+    value any,
+) error {
+    session, err := sandbox.GetSession(ctx, sessionID)
+    if err != nil {
+        return err
+    }
+    attempt, ok := session.Attempt.Get()
+    if !ok {
+        return fmt.Errorf("session has no running attempt")
+    }
+
+    data, err := json.Marshal(value)
+    if err != nil {
+        return err
+    }
+    data = append(data, '\\n')
+
+    _, err = sandbox.WriteSessionInput(ctx, sessionID, apispec.ExecutionSessionInputRequest{
+        InputID:           uuid.NewString(),
+        ExpectedAttemptID: apispec.NewOptString(attempt.ID),
+        DataBase64:        apispec.NewOptString(base64.StdEncoding.EncodeToString(data)),
+    })
+    return err
+}`
+    },
+    {
+      label: "Python",
+      language: "python",
+      code: `import base64
+import json
+from uuid import uuid4
+
+from sandbox0.apispec.models.execution_session_input_request import ExecutionSessionInputRequest
+
+def write_json_line(sandbox, session_id: str, value: object) -> None:
+    session = sandbox.get_session(session_id)
+    attempt = session.to_dict().get("attempt")
+    if not attempt:
+        raise RuntimeError("session has no running attempt")
+
+    data = (json.dumps(value, separators=(",", ":")) + "\\n").encode()
+    sandbox.write_session_input(
+        session_id,
+        ExecutionSessionInputRequest(
+            input_id=str(uuid4()),
+            expected_attempt_id=attempt["id"],
+            data_base64=base64.b64encode(data).decode(),
+        ),
+    )`
+    },
+    {
+      label: "TypeScript",
+      language: "typescript",
+      code: `import type { Sandbox } from "sandbox0";
+
+async function writeJsonLine(
     sandbox: Sandbox,
     sessionId: string,
     value: unknown,
 ) {
     const session = await sandbox.getSession(sessionId);
-    if (!session.attempt) throw new Error('session has no running attempt');
+    if (!session.attempt) throw new Error("session has no running attempt");
 
     await sandbox.writeSessionInput(sessionId, {
         inputId: crypto.randomUUID(),
         expectedAttemptId: session.attempt.id,
-        dataBase64: Buffer.from(`${JSON.stringify(value)}\n`).toString('base64'),
+        dataBase64: Buffer.from(JSON.stringify(value) + "\\n").toString("base64"),
     });
+}`
+    },
+    {
+      label: "CLI",
+      language: "bash",
+      code: `send_jsonl() {
+    session_id="$1"
+    input_id="$2"
+    s0 sandbox session input "$SANDBOX_ID" "$session_id" \\
+        --input-id "$input_id" \\
+        --file -
 }
 
-export async function* readJsonLines(
-    sandbox: Sandbox,
-    sessionId: string,
-    after = 0,
-) {
-    const stream = await sandbox.watchSessionEvents(sessionId, { after });
-    let buffered = '';
-
-    try {
-        for await (const event of stream) {
-            if (event.stream !== 'stdout' || !event.dataBase64) continue;
-            buffered += Buffer.from(event.dataBase64, 'base64').toString('utf8');
-
-            for (;;) {
-                const newline = buffered.indexOf('\n');
-                if (newline < 0) break;
-                const record = buffered.slice(0, newline).replace(/\r$/, '');
-                buffered = buffered.slice(newline + 1);
-                if (record) yield { seq: event.seq, message: JSON.parse(record) };
-            }
-        }
-    } finally {
-        await stream.close();
+send_jsonl "$SESSION_ID" native-request-1 <<'JSON'
+{"replace":"with a native harness message"}
+JSON`
     }
-}
-```
+  ]}
+/>
 
-Commit the last processed event `seq` outside the sandbox and reconnect with `after`. Also put a native request ID in messages where the harness supports one. Sandbox0 can make input submission idempotent, but it cannot guarantee that a subprocess consumes a message exactly once.
+Consume output through the resumable session event stream. Events contain base64-encoded byte chunks, and chunk boundaries are not native protocol record boundaries. Buffer stdout bytes until LF before parsing JSON. The complete Go, Python, TypeScript, and CLI event-stream examples are in [Supervised Sessions](/docs/sandbox/session-supervisor#follow-output-and-reconnect).
 
-## Codex App Server
+Commit the last processed event `seq` outside the sandbox and reconnect with `after`. Put a native request ID in messages where the harness supports one. Sandbox0 can deduplicate an input submission, but it cannot guarantee that the subprocess consumed that input exactly once.
 
-Create a pipe-based Session Supervisor session. `CODEX_HOME` keeps Codex configuration and native thread history separate from the repository:
+## Drive The Selected Harness
 
-```bash
-SESSION_ID="$(s0 -o json sandbox session create "$SANDBOX_ID" \
-    --name codex \
-    --cwd /workspace \
-    --env CODEX_HOME=/agent-state/codex \
-    --idempotency-key coding-agent-codex-v1 \
-    --restart on_failure \
-    --runtime-recovery restart \
-    --readiness process \
-    -- codex app-server --stdio \
-    | jq -r '.id')"
-export SESSION_ID
-```
+Use the native message shape for the command you selected. Send the initialization records first, wait for their responses, save the returned native thread or session ID, and then send the prompt record with that ID.
 
-Initialize the native app-server connection, acknowledge initialization, and start a Codex thread:
-
-```bash
-send_jsonl "$SESSION_ID" codex-bootstrap-1 <<'JSON'
-{"method":"initialize","id":1,"params":{"clientInfo":{"name":"sandpi","title":"SandPi","version":"0.1.0"}}}
+<Tabs
+  tabs={[
+    {
+      label: "Codex",
+      language: "json",
+      code: `{"method":"initialize","id":1,"params":{"clientInfo":{"name":"sandpi","title":"SandPi","version":"0.1.0"}}}
 {"method":"initialized","params":{}}
 {"method":"thread/start","id":2,"params":{"cwd":"/workspace","approvalPolicy":"never","sandbox":"dangerFullAccess"}}
-JSON
-```
 
-Read the response with `id: 2`, save `result.thread.id`, and use it for turns:
+{"method":"turn/start","id":3,"params":{"threadId":"<thread-id-from-response-2>","clientUserMessageId":"task-1","input":[{"type":"text","text":"Inspect this repository and run the relevant tests."}]}}`
+    },
+    {
+      label: "Claude Code",
+      language: "json",
+      code: `{"type":"user","message":{"role":"user","content":"Inspect this repository and run the relevant tests."}}`
+    },
+    {
+      label: "OpenCode",
+      language: "json",
+      code: `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1,"clientCapabilities":{},"clientInfo":{"name":"sandpi","version":"0.1.0"}}}
+{"jsonrpc":"2.0","id":2,"method":"session/new","params":{"cwd":"/workspace","mcpServers":[]}}
 
-```bash
-CODEX_THREAD_ID="replace-with-thread-id"
+{"jsonrpc":"2.0","id":3,"method":"session/prompt","params":{"sessionId":"<session-id-from-response-2>","prompt":[{"type":"text","text":"Inspect this repository and run the relevant tests."}]}}`
+    },
+    {
+      label: "Pi",
+      language: "json",
+      code: `{"id":"state-1","type":"get_state"}
+{"id":"prompt-1","type":"prompt","message":"Inspect this repository and run the relevant tests."}
 
-send_jsonl "$SESSION_ID" codex-turn-1 <<JSON
-{"method":"turn/start","id":3,"params":{"threadId":"$CODEX_THREAD_ID","clientUserMessageId":"task-1","input":[{"type":"text","text":"Inspect this repository and run the relevant tests."}]}}
-JSON
-```
+{"id":"steer-1","type":"steer","message":"Focus on the failing integration test first."}
+{"id":"follow-up-1","type":"follow_up","message":"After the fix, summarize the changed files."}
+{"id":"abort-1","type":"abort"}`
+    }
+  ]}
+/>
 
-The outer Sandbox0 sandbox is the isolation boundary in this example, so Codex is configured with `dangerFullAccess` inside that boundary. If the process attempt changes, send `initialize` and `initialized` again, then use `thread/resume` with the saved native thread ID before starting another turn. See the upstream [Codex app-server protocol](https://github.com/openai/codex/blob/main/codex-rs/app-server/README.md) for approval requests and the complete event schema.
+### Codex
 
-## Claude Code Stream JSON
+Codex requires `initialize` followed by `initialized` once per app-server process. Save `result.thread.id` from `thread/start`. After a new process attempt, initialize again and call `thread/resume` with the saved thread ID. The outer Sandbox0 sandbox is the isolation boundary in this example, so Codex uses `dangerFullAccess` inside that boundary. See the upstream [Codex app-server protocol](https://github.com/openai/codex/blob/main/codex-rs/app-server/README.md).
 
-Claude Code requires a native UUID for reliable conversation recovery. The small shell condition below only selects Claude Code's native `--session-id` or `--resume` flag; it does not translate the stream-json protocol.
+### Claude Code
 
-```bash
-CLAUDE_NATIVE_SESSION_ID="$(uuidgen)"
-
-SESSION_ID="$(s0 -o json sandbox session create "$SANDBOX_ID" \
-    --name claude-code \
-    --cwd /workspace \
-    --env CLAUDE_CONFIG_DIR=/agent-state/claude \
-    --env CLAUDE_NATIVE_SESSION_ID="$CLAUDE_NATIVE_SESSION_ID" \
-    --idempotency-key coding-agent-claude-v1 \
-    --restart on_failure \
-    --runtime-recovery restart \
-    --readiness process \
-    -- /bin/sh -lc '
-        if find "$CLAUDE_CONFIG_DIR/projects" -name "$CLAUDE_NATIVE_SESSION_ID.jsonl" -print -quit 2>/dev/null | grep -q .; then
-            session_flag="--resume"
-        else
-            session_flag="--session-id"
-        fi
-        exec claude -p \
-            --input-format stream-json \
-            --output-format stream-json \
-            --verbose \
-            --replay-user-messages \
-            --permission-mode bypassPermissions \
-            --dangerously-skip-permissions \
-            "$session_flag" "$CLAUDE_NATIVE_SESSION_ID"
-    ' | jq -r '.id')"
-export SESSION_ID
-```
-
-Send Claude Code's native streaming user message:
-
-```bash
-send_jsonl "$SESSION_ID" claude-prompt-1 <<'JSON'
-{"type":"user","message":{"role":"user","content":"Inspect this repository and run the relevant tests."}}
-JSON
-```
-
-The first stdout record is normally a `system` message with subtype `init`; record its `session_id`. Subsequent records include user acknowledgements, assistant messages, tool activity, and a final `result`. See the upstream [Claude Code headless documentation](https://code.claude.com/docs/en/headless) for the current stream-json contract.
+The first stdout record is normally a `system` message with subtype `init`; save its `session_id`. Subsequent records include user acknowledgements, assistant messages, tool activity, and a final `result`. To continue after replacing the supervised session, append `--resume` and the saved native session ID to the Claude command. See the upstream [Claude Code headless documentation](https://code.claude.com/docs/en/headless).
 
 <Callout variant="warning">
 Claude Code's package is not published under an open-source license. Review the license bundled with the package and Anthropic's applicable terms before publicly redistributing a derived template image. Use API-key or supported cloud-provider authentication for third-party products; do not proxy a user's Claude subscription login.
 </Callout>
 
-## OpenCode ACP
+### OpenCode
 
-OpenCode exposes the standard Agent Client Protocol over nd-JSON. Keep its XDG state below the agent-state mount:
+OpenCode implements Agent Client Protocol. An ACP client must handle server requests such as permission decisions instead of assuming stdout only contains responses and notifications. After a new process attempt, initialize ACP again and call `session/load` or `session/resume` with the saved native session ID. See the upstream [OpenCode ACP command](https://opencode.ai/docs/cli/#acp) and [Agent Client Protocol](https://agentclientprotocol.com/).
 
-```bash
-SESSION_ID="$(s0 -o json sandbox session create "$SANDBOX_ID" \
-    --name opencode \
-    --cwd /workspace \
-    --env XDG_CONFIG_HOME=/agent-state/opencode/config \
-    --env XDG_DATA_HOME=/agent-state/opencode/data \
-    --env XDG_CACHE_HOME=/agent-state/opencode/cache \
-    --idempotency-key coding-agent-opencode-v1 \
-    --restart on_failure \
-    --runtime-recovery restart \
-    --readiness process \
-    -- opencode acp --cwd /workspace \
-    | jq -r '.id')"
-export SESSION_ID
-```
+### Pi
 
-Initialize ACP and create its native session:
-
-```bash
-send_jsonl "$SESSION_ID" opencode-bootstrap-1 <<'JSON'
-{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1,"clientCapabilities":{},"clientInfo":{"name":"sandpi","version":"0.1.0"}}}
-{"jsonrpc":"2.0","id":2,"method":"session/new","params":{"cwd":"/workspace","mcpServers":[]}}
-JSON
-```
-
-Save `result.sessionId` from response `id: 2`, then submit a prompt:
-
-```bash
-OPENCODE_SESSION_ID="replace-with-session-id"
-
-send_jsonl "$SESSION_ID" opencode-prompt-1 <<JSON
-{"jsonrpc":"2.0","id":3,"method":"session/prompt","params":{"sessionId":"$OPENCODE_SESSION_ID","prompt":[{"type":"text","text":"Inspect this repository and run the relevant tests."}]}}
-JSON
-```
-
-An ACP client must also handle native server requests such as permission decisions instead of assuming stdout only contains responses and notifications. After a process attempt changes, initialize ACP again and call `session/load` or `session/resume` with the saved native session ID. See the upstream [OpenCode ACP command](https://opencode.ai/docs/cli/#acp) and the [Agent Client Protocol](https://agentclientprotocol.com/) for the complete contract.
-
-## Pi RPC
-
-Pi provides a direct JSONL RPC mode with request IDs, steering, follow-up, abort, model selection, and state inspection:
-
-```bash
-SESSION_ID="$(s0 -o json sandbox session create "$SANDBOX_ID" \
-    --name pi \
-    --cwd /workspace \
-    --env PI_CODING_AGENT_DIR=/agent-state/pi \
-    --env PI_CODING_AGENT_SESSION_DIR=/agent-state/pi/sessions \
-    --idempotency-key coding-agent-pi-v1 \
-    --restart on_failure \
-    --runtime-recovery restart \
-    --readiness process \
-    -- pi --mode rpc --session-dir /agent-state/pi/sessions --approve \
-    | jq -r '.id')"
-export SESSION_ID
-```
-
-Inspect native state and submit a prompt:
-
-```bash
-send_jsonl "$SESSION_ID" pi-state-1 <<'JSON'
-{"id":"state-1","type":"get_state"}
-JSON
-
-send_jsonl "$SESSION_ID" pi-prompt-1 <<'JSON'
-{"id":"prompt-1","type":"prompt","message":"Inspect this repository and run the relevant tests."}
-JSON
-```
-
-While Pi is running, its native protocol can steer, enqueue a follow-up, or abort:
-
-```json
-{"id":"steer-1","type":"steer","message":"Focus on the failing integration test first."}
-{"id":"follow-up-1","type":"follow_up","message":"After the fix, summarize the changed files."}
-{"id":"abort-1","type":"abort"}
-```
-
-Persist the `sessionFile` or `sessionId` returned by `get_state` and use Pi's native session options when recovering a conversation. See the upstream [Pi RPC protocol](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/rpc.md) for all commands and streamed event types.
+Pi RPC supports request IDs, state inspection, prompting, steering, follow-up, and abort without an additional adapter. Save the `sessionFile` or `sessionId` returned by `get_state`, then use Pi's native `--session` or `--session-id` option when creating a replacement supervised session. See the upstream [Pi RPC protocol](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/rpc.md).
 
 ## Switch Harnesses
 
-Use one active writer per workspace. Stop and delete the current supervised session before starting another harness:
+Stop and delete the current supervised session before starting another harness against the same sandbox.
 
-```bash
-s0 sandbox session stop "$SANDBOX_ID" "$SESSION_ID"
-s0 sandbox session delete "$SANDBOX_ID" "$SESSION_ID"
-```
+<Tabs
+  tabs={[
+    {
+      label: "Go",
+      language: "go",
+      code: `_, err := sandbox.SetSessionDesiredState(
+    ctx,
+    session.ID,
+    apispec.ExecutionSessionDesiredStateStopped,
+)
+if err != nil {
+    log.Fatal(err)
+}
+if _, err := sandbox.DeleteSession(ctx, session.ID); err != nil {
+    log.Fatal(err)
+}`
+    },
+    {
+      label: "Python",
+      language: "python",
+      code: `from sandbox0.apispec.models.execution_session_desired_state import ExecutionSessionDesiredState
 
-Then create the next harness session against the same sandbox. `/workspace` preserves the repository, while each harness keeps its native state in a separate directory below `/agent-state`.
+sandbox.set_session_desired_state(
+    session.id,
+    ExecutionSessionDesiredState.STOPPED,
+)
+sandbox.delete_session(session.id)`
+    },
+    {
+      label: "TypeScript",
+      language: "typescript",
+      code: `await sandbox.setSessionDesiredState(session.id, "stopped");
+await sandbox.deleteSession(session.id);`
+    },
+    {
+      label: "CLI",
+      language: "bash",
+      code: `s0 sandbox session stop "$SANDBOX_ID" "$SESSION_ID"
+s0 sandbox session delete "$SANDBOX_ID" "$SESSION_ID"`
+    }
+  ]}
+/>
+
+Then select the next entry from the harness map and create a new supervised session. `/workspace` preserves the repository, while each harness keeps native state in a separate directory below `/agent-state`.
 
 Do not replace a Codex session specification with a Claude Code, OpenCode, or Pi command. A new supervised session keeps each event journal, process attempt history, and native protocol stream internally consistent.
 

--- a/docs/use-cases/coding-agents/page.mdx
+++ b/docs/use-cases/coding-agents/page.mdx
@@ -2,10 +2,12 @@
 
 Use the builtin `coding-agent` template when an application needs to run Codex, Claude Code, OpenCode, or Pi inside the same Sandbox0 execution environment. The template installs all four native CLIs and declares two writable mount points:
 
-- `/workspace` for the repository and generated files
+- `/workspace` as every harness's process working directory, containing the repository and generated files
 - `/agent-state` for harness configuration and native conversation state
 
 Each coding agent remains a native subprocess. Session Supervisor owns process lifetime, stdin/stdout transport, restart attempts, and the replayable event journal; it does not translate one harness protocol into another.
+
+The template declares `/workspace` as a SandboxVolume mount point. A claim binds the selected workspace Volume there, and every supervised session sets its `cwd` to the same path. `/agent-state` is separate native harness state; it is not the coding workspace. The container's operating-system `HOME` remains `/root` and is not used as the coding workspace.
 
 | Harness | Native command | Protocol |
 |---------|----------------|----------|

--- a/docs/use-cases/coding-agents/page.mdx
+++ b/docs/use-cases/coding-agents/page.mdx
@@ -1,0 +1,306 @@
+# Run Coding Agents With Supervised Sessions
+
+Use the builtin `coding-agent` template when an application needs to run Codex, Claude Code, OpenCode, or Pi inside the same Sandbox0 execution environment. The template installs all four native CLIs and declares two writable mount points:
+
+- `/workspace` for the repository and generated files
+- `/agent-state` for harness configuration, credentials, and native conversation state
+
+Each coding agent remains a native subprocess. Session Supervisor owns process lifetime, stdin/stdout transport, restart attempts, and the replayable event journal; it does not translate one harness protocol into another.
+
+| Harness | Installed command | Native supervised transport |
+|---------|-------------------|-----------------------------|
+| Codex | `codex app-server --stdio` | Codex JSON-RPC messages over JSONL |
+| Claude Code | `claude -p --input-format stream-json --output-format stream-json` | Claude Code stream-json |
+| OpenCode | `opencode acp --cwd /workspace` | Agent Client Protocol over nd-JSON |
+| Pi | `pi --mode rpc` | Pi RPC over JSONL |
+
+<Callout variant="warning">
+The example grants the selected coding agent broad control inside its sandbox. Keep model credentials narrow, restrict network policy for production workloads, and do not mount a developer home directory or host Docker socket into the sandbox.
+</Callout>
+
+## Create The Environment
+
+The template has a zero-sized warm pool by default because the image is large and not every deployment needs a coding agent. Claiming it pulls the image on demand.
+
+Create separate volumes for the repository and harness state, then claim the template:
+
+```bash
+WORKSPACE_VOLUME_ID="$(s0 -o json volume create --access-mode RWO | jq -r '.id')"
+AGENT_STATE_VOLUME_ID="$(s0 -o json volume create --access-mode RWO | jq -r '.id')"
+
+SANDBOX_ID="$(s0 -o json sandbox create \
+    --template coding-agent \
+    --mount "$WORKSPACE_VOLUME_ID:/workspace" \
+    --mount "$AGENT_STATE_VOLUME_ID:/agent-state" \
+    | jq -r '.id')"
+
+export SANDBOX_ID
+```
+
+The volumes are optional. If they are omitted, both paths are writable directories in the sandbox rootfs and follow that sandbox identity's checkpoint lifecycle. Use volumes when workspace or harness state must be managed independently from the sandbox.
+
+Do not bake provider credentials into the template image. For a local test, add the required provider environment variables to the supervised session. For production, prefer [egress auth](/docs/credential/egress-auth), LLMProxy, or another narrowly scoped external model proxy. Session environment variables are part of the session specification and should not be treated as a secret store.
+
+## Read And Write Native JSONL
+
+Run this in a second terminal to replay retained output and then follow live output. The CLI decodes the event payload for display:
+
+```bash
+s0 sandbox session events "$SANDBOX_ID" "$SESSION_ID" --follow
+```
+
+Use this helper in the examples below to write one or more newline-delimited native messages:
+
+```bash
+send_jsonl() {
+    local session_id="$1"
+    local input_id="$2"
+    s0 sandbox session input "$SANDBOX_ID" "$session_id" \
+        --input-id "$input_id" \
+        --file -
+}
+```
+
+Applications should consume the SDK event stream instead of parsing the CLI table. Output events contain base64-encoded byte chunks, and chunk boundaries are not JSONL record boundaries. Buffer stdout bytes until LF before decoding a native message:
+
+```typescript
+import type { Sandbox } from 'sandbox0';
+
+export async function writeJsonLine(
+    sandbox: Sandbox,
+    sessionId: string,
+    value: unknown,
+) {
+    const session = await sandbox.getSession(sessionId);
+    if (!session.attempt) throw new Error('session has no running attempt');
+
+    await sandbox.writeSessionInput(sessionId, {
+        inputId: crypto.randomUUID(),
+        expectedAttemptId: session.attempt.id,
+        dataBase64: Buffer.from(`${JSON.stringify(value)}\n`).toString('base64'),
+    });
+}
+
+export async function* readJsonLines(
+    sandbox: Sandbox,
+    sessionId: string,
+    after = 0,
+) {
+    const stream = await sandbox.watchSessionEvents(sessionId, { after });
+    let buffered = '';
+
+    try {
+        for await (const event of stream) {
+            if (event.stream !== 'stdout' || !event.dataBase64) continue;
+            buffered += Buffer.from(event.dataBase64, 'base64').toString('utf8');
+
+            for (;;) {
+                const newline = buffered.indexOf('\n');
+                if (newline < 0) break;
+                const record = buffered.slice(0, newline).replace(/\r$/, '');
+                buffered = buffered.slice(newline + 1);
+                if (record) yield { seq: event.seq, message: JSON.parse(record) };
+            }
+        }
+    } finally {
+        await stream.close();
+    }
+}
+```
+
+Commit the last processed event `seq` outside the sandbox and reconnect with `after`. Also put a native request ID in messages where the harness supports one. Sandbox0 can make input submission idempotent, but it cannot guarantee that a subprocess consumes a message exactly once.
+
+## Codex App Server
+
+Create a pipe-based Session Supervisor session. `CODEX_HOME` keeps Codex configuration and native thread history separate from the repository:
+
+```bash
+SESSION_ID="$(s0 -o json sandbox session create "$SANDBOX_ID" \
+    --name codex \
+    --cwd /workspace \
+    --env CODEX_HOME=/agent-state/codex \
+    --idempotency-key coding-agent-codex-v1 \
+    --restart on_failure \
+    --runtime-recovery restart \
+    --readiness process \
+    -- codex app-server --stdio \
+    | jq -r '.id')"
+export SESSION_ID
+```
+
+Initialize the native app-server connection, acknowledge initialization, and start a Codex thread:
+
+```bash
+send_jsonl "$SESSION_ID" codex-bootstrap-1 <<'JSON'
+{"method":"initialize","id":1,"params":{"clientInfo":{"name":"sandpi","title":"SandPi","version":"0.1.0"}}}
+{"method":"initialized","params":{}}
+{"method":"thread/start","id":2,"params":{"cwd":"/workspace","approvalPolicy":"never","sandbox":"dangerFullAccess"}}
+JSON
+```
+
+Read the response with `id: 2`, save `result.thread.id`, and use it for turns:
+
+```bash
+CODEX_THREAD_ID="replace-with-thread-id"
+
+send_jsonl "$SESSION_ID" codex-turn-1 <<JSON
+{"method":"turn/start","id":3,"params":{"threadId":"$CODEX_THREAD_ID","clientUserMessageId":"task-1","input":[{"type":"text","text":"Inspect this repository and run the relevant tests."}]}}
+JSON
+```
+
+The outer Sandbox0 sandbox is the isolation boundary in this example, so Codex is configured with `dangerFullAccess` inside that boundary. If the process attempt changes, send `initialize` and `initialized` again, then use `thread/resume` with the saved native thread ID before starting another turn. See the upstream [Codex app-server protocol](https://github.com/openai/codex/blob/main/codex-rs/app-server/README.md) for approval requests and the complete event schema.
+
+## Claude Code Stream JSON
+
+Claude Code requires a native UUID for reliable conversation recovery. The small shell condition below only selects Claude Code's native `--session-id` or `--resume` flag; it does not translate the stream-json protocol.
+
+```bash
+CLAUDE_NATIVE_SESSION_ID="$(uuidgen)"
+
+SESSION_ID="$(s0 -o json sandbox session create "$SANDBOX_ID" \
+    --name claude-code \
+    --cwd /workspace \
+    --env CLAUDE_CONFIG_DIR=/agent-state/claude \
+    --env CLAUDE_NATIVE_SESSION_ID="$CLAUDE_NATIVE_SESSION_ID" \
+    --idempotency-key coding-agent-claude-v1 \
+    --restart on_failure \
+    --runtime-recovery restart \
+    --readiness process \
+    -- /bin/sh -lc '
+        if find "$CLAUDE_CONFIG_DIR/projects" -name "$CLAUDE_NATIVE_SESSION_ID.jsonl" -print -quit 2>/dev/null | grep -q .; then
+            session_flag="--resume"
+        else
+            session_flag="--session-id"
+        fi
+        exec claude -p \
+            --input-format stream-json \
+            --output-format stream-json \
+            --verbose \
+            --replay-user-messages \
+            --permission-mode bypassPermissions \
+            --dangerously-skip-permissions \
+            "$session_flag" "$CLAUDE_NATIVE_SESSION_ID"
+    ' | jq -r '.id')"
+export SESSION_ID
+```
+
+Send Claude Code's native streaming user message:
+
+```bash
+send_jsonl "$SESSION_ID" claude-prompt-1 <<'JSON'
+{"type":"user","message":{"role":"user","content":"Inspect this repository and run the relevant tests."}}
+JSON
+```
+
+The first stdout record is normally a `system` message with subtype `init`; record its `session_id`. Subsequent records include user acknowledgements, assistant messages, tool activity, and a final `result`. See the upstream [Claude Code headless documentation](https://code.claude.com/docs/en/headless) for the current stream-json contract.
+
+<Callout variant="warning">
+Claude Code's package is not published under an open-source license. Review the license bundled with the package and Anthropic's applicable terms before publicly redistributing a derived template image. Use API-key or supported cloud-provider authentication for third-party products; do not proxy a user's Claude subscription login.
+</Callout>
+
+## OpenCode ACP
+
+OpenCode exposes the standard Agent Client Protocol over nd-JSON. Keep its XDG state below the agent-state mount:
+
+```bash
+SESSION_ID="$(s0 -o json sandbox session create "$SANDBOX_ID" \
+    --name opencode \
+    --cwd /workspace \
+    --env XDG_CONFIG_HOME=/agent-state/opencode/config \
+    --env XDG_DATA_HOME=/agent-state/opencode/data \
+    --env XDG_CACHE_HOME=/agent-state/opencode/cache \
+    --idempotency-key coding-agent-opencode-v1 \
+    --restart on_failure \
+    --runtime-recovery restart \
+    --readiness process \
+    -- opencode acp --cwd /workspace \
+    | jq -r '.id')"
+export SESSION_ID
+```
+
+Initialize ACP and create its native session:
+
+```bash
+send_jsonl "$SESSION_ID" opencode-bootstrap-1 <<'JSON'
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1,"clientCapabilities":{},"clientInfo":{"name":"sandpi","version":"0.1.0"}}}
+{"jsonrpc":"2.0","id":2,"method":"session/new","params":{"cwd":"/workspace","mcpServers":[]}}
+JSON
+```
+
+Save `result.sessionId` from response `id: 2`, then submit a prompt:
+
+```bash
+OPENCODE_SESSION_ID="replace-with-session-id"
+
+send_jsonl "$SESSION_ID" opencode-prompt-1 <<JSON
+{"jsonrpc":"2.0","id":3,"method":"session/prompt","params":{"sessionId":"$OPENCODE_SESSION_ID","prompt":[{"type":"text","text":"Inspect this repository and run the relevant tests."}]}}
+JSON
+```
+
+An ACP client must also handle native server requests such as permission decisions instead of assuming stdout only contains responses and notifications. After a process attempt changes, initialize ACP again and call `session/load` or `session/resume` with the saved native session ID. See the upstream [OpenCode ACP command](https://opencode.ai/docs/cli/#acp) and the [Agent Client Protocol](https://agentclientprotocol.com/) for the complete contract.
+
+## Pi RPC
+
+Pi provides a direct JSONL RPC mode with request IDs, steering, follow-up, abort, model selection, and state inspection:
+
+```bash
+SESSION_ID="$(s0 -o json sandbox session create "$SANDBOX_ID" \
+    --name pi \
+    --cwd /workspace \
+    --env PI_CODING_AGENT_DIR=/agent-state/pi \
+    --env PI_CODING_AGENT_SESSION_DIR=/agent-state/pi/sessions \
+    --idempotency-key coding-agent-pi-v1 \
+    --restart on_failure \
+    --runtime-recovery restart \
+    --readiness process \
+    -- pi --mode rpc --session-dir /agent-state/pi/sessions --approve \
+    | jq -r '.id')"
+export SESSION_ID
+```
+
+Inspect native state and submit a prompt:
+
+```bash
+send_jsonl "$SESSION_ID" pi-state-1 <<'JSON'
+{"id":"state-1","type":"get_state"}
+JSON
+
+send_jsonl "$SESSION_ID" pi-prompt-1 <<'JSON'
+{"id":"prompt-1","type":"prompt","message":"Inspect this repository and run the relevant tests."}
+JSON
+```
+
+While Pi is running, its native protocol can steer, enqueue a follow-up, or abort:
+
+```json
+{"id":"steer-1","type":"steer","message":"Focus on the failing integration test first."}
+{"id":"follow-up-1","type":"follow_up","message":"After the fix, summarize the changed files."}
+{"id":"abort-1","type":"abort"}
+```
+
+Persist the `sessionFile` or `sessionId` returned by `get_state` and use Pi's native session options when recovering a conversation. See the upstream [Pi RPC protocol](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/rpc.md) for all commands and streamed event types.
+
+## Switch Harnesses
+
+Use one active writer per workspace. Stop and delete the current supervised session before starting another harness:
+
+```bash
+s0 sandbox session stop "$SANDBOX_ID" "$SESSION_ID"
+s0 sandbox session delete "$SANDBOX_ID" "$SESSION_ID"
+```
+
+Then create the next harness session against the same sandbox. `/workspace` preserves the repository, while each harness keeps its native state in a separate directory below `/agent-state`.
+
+Do not replace a Codex session specification with a Claude Code, OpenCode, or Pi command. A new supervised session keeps each event journal, process attempt history, and native protocol stream internally consistent.
+
+## Recovery Responsibilities
+
+Session Supervisor restores the process, not the harness connection. When an event reports a new `attempt_id` or `runtime_generation`:
+
+1. stop writing to the old attempt
+2. reconnect to the Sandbox0 event journal from the last committed `seq`
+3. perform the harness's native initialize handshake again
+4. resume the saved native thread or conversation ID where supported
+5. reconcile any request whose acceptance was ambiguous before retrying it
+
+See [Supervised Sessions](/docs/sandbox/session-supervisor) for attempt fencing, event retention, reconnect cursors, and input-delivery semantics.

--- a/docs/use-cases/coding-agents/page.mdx
+++ b/docs/use-cases/coding-agents/page.mdx
@@ -125,8 +125,10 @@ harnesses := map[string]harnessSpec{
             "--output-format", "stream-json",
             "--verbose",
             "--replay-user-messages",
-            "--permission-mode", "bypassPermissions",
-            "--dangerously-skip-permissions",
+            "--permission-mode", "dontAsk",
+            "--allowedTools",
+            "Bash", "Edit", "Write", "Read", "Glob", "Grep",
+            "WebFetch", "WebSearch", "Agent",
         },
         Env: apispec.ExecutionSessionSpecEnv{
             "HOME": "/workspace",
@@ -200,8 +202,10 @@ harnesses = {
             "--output-format", "stream-json",
             "--verbose",
             "--replay-user-messages",
-            "--permission-mode", "bypassPermissions",
-            "--dangerously-skip-permissions",
+            "--permission-mode", "dontAsk",
+            "--allowedTools",
+            "Bash", "Edit", "Write", "Read", "Glob", "Grep",
+            "WebFetch", "WebSearch", "Agent",
         ],
         "env": {"HOME": "/workspace"},
     },
@@ -255,8 +259,10 @@ const harnesses: Record<string, HarnessSpec> = {
             "--output-format", "stream-json",
             "--verbose",
             "--replay-user-messages",
-            "--permission-mode", "bypassPermissions",
-            "--dangerously-skip-permissions",
+            "--permission-mode", "dontAsk",
+            "--allowedTools",
+            "Bash", "Edit", "Write", "Read", "Glob", "Grep",
+            "WebFetch", "WebSearch", "Agent",
         ],
         env: { HOME: "/workspace" },
     },
@@ -297,7 +303,15 @@ case "$HARNESS" in
         COMMAND=(codex app-server --stdio)
         ;;
     claude-code)
-        COMMAND=(claude -p --input-format stream-json --output-format stream-json --verbose --replay-user-messages --permission-mode bypassPermissions --dangerously-skip-permissions)
+        COMMAND=(
+            claude -p
+            --input-format stream-json
+            --output-format stream-json
+            --verbose
+            --replay-user-messages
+            --permission-mode dontAsk
+            --allowedTools Bash Edit Write Read Glob Grep WebFetch WebSearch Agent
+        )
         ;;
     opencode)
         COMMAND=(opencode acp --cwd /workspace)
@@ -443,7 +457,7 @@ Use the native message shape for the command you selected. Send the initializati
       language: "json",
       code: `{"method":"initialize","id":1,"params":{"clientInfo":{"name":"sandpi","title":"SandPi","version":"0.1.0"}}}
 {"method":"initialized","params":{}}
-{"method":"thread/start","id":2,"params":{"cwd":"/workspace","approvalPolicy":"never","sandbox":"dangerFullAccess"}}
+{"method":"thread/start","id":2,"params":{"cwd":"/workspace","approvalPolicy":"never","sandbox":"danger-full-access"}}
 
 {"method":"turn/start","id":3,"params":{"threadId":"<thread-id-from-response-2>","clientUserMessageId":"task-1","input":[{"type":"text","text":"Inspect this repository and run the relevant tests."}]}}`
     },
@@ -475,11 +489,13 @@ Use the native message shape for the command you selected. Send the initializati
 
 ### Codex
 
-Codex requires `initialize` followed by `initialized` once per app-server process. Save `result.thread.id` from `thread/start`. After a new process attempt, initialize again and call `thread/resume` with the saved thread ID. The outer Sandbox0 sandbox is the isolation boundary in this example, so Codex uses `dangerFullAccess` inside that boundary. See the upstream [Codex app-server protocol](https://github.com/openai/codex/blob/main/codex-rs/app-server/README.md).
+Codex requires `initialize` followed by `initialized` once per app-server process. Save `result.thread.id` from `thread/start`. After a new process attempt, initialize again and call `thread/resume` with the saved thread ID. The outer Sandbox0 sandbox is the isolation boundary in this example, so Codex uses `danger-full-access` inside that boundary. See the upstream [Codex app-server protocol](https://github.com/openai/codex/blob/main/codex-rs/app-server/README.md).
 
 ### Claude Code
 
 The first stdout record is normally a `system` message with subtype `init`; save its `session_id`. Subsequent records include user acknowledgements, assistant messages, tool activity, and a final `result`. To continue after replacing the supervised session, append `--resume` and the saved native session ID to the Claude command. See the upstream [Claude Code headless documentation](https://code.claude.com/docs/en/headless).
+
+The builtin template currently runs supervised processes as root. Claude Code [refuses `bypassPermissions` and its equivalent `--dangerously-skip-permissions` when running as root](https://code.claude.com/docs/en/permission-modes#skip-all-checks-with-bypasspermissions-mode), so the example uses native `dontAsk` mode with an explicit coding-tool allowlist. Add project-specific MCP tools to that allowlist when needed; unlisted permission requests are denied instead of blocking a headless session.
 
 <Callout variant="warning">
 Claude Code's package is not published under an open-source license. Review the license bundled with the package and Anthropic's applicable terms before publicly redistributing a derived template image. Use API-key or supported cloud-provider authentication for third-party products; do not proxy a user's Claude subscription login.

--- a/docs/use-cases/coding-agents/page.mdx
+++ b/docs/use-cases/coding-agents/page.mdx
@@ -1,13 +1,10 @@
 # Run Coding Agents With Supervised Sessions
 
-Use the builtin `coding-agent` template when an application needs to run Codex, Claude Code, OpenCode, or Pi inside the same Sandbox0 execution environment. The template installs all four native CLIs and declares two writable mount points:
-
-- `/workspace` as every harness's process working directory, containing the repository and generated files
-- `/agent-state` for harness configuration and native conversation state
+Use the builtin `coding-agent` template when an application needs to run Codex, Claude Code, OpenCode, or Pi inside the same Sandbox0 execution environment. The template installs all four native CLIs and declares `/workspace` as its writable mount point.
 
 Each coding agent remains a native subprocess. Session Supervisor owns process lifetime, stdin/stdout transport, restart attempts, and the replayable event journal; it does not translate one harness protocol into another.
 
-The template declares `/workspace` as a SandboxVolume mount point. A claim binds the selected workspace Volume there, and every supervised session sets its `cwd` to the same path. `/agent-state` is separate native harness state; it is not the coding workspace. The container's operating-system `HOME` remains `/root` and is not used as the coding workspace.
+The template sets both the container's operating-system `HOME` and every supervised session's `cwd` to `/workspace`. A claim binds the selected workspace Volume there, so the repository and each harness's native home-relative state share the same persistent mount. For example, Codex uses `/workspace/.codex`, Claude Code uses `/workspace/.claude`, OpenCode follows XDG defaults below `/workspace`, and Pi uses `/workspace/.pi/agent`.
 
 | Harness | Native command | Protocol |
 |---------|----------------|----------|
@@ -22,7 +19,7 @@ The examples grant the selected coding agent broad control inside its sandbox. K
 
 ## Create The Environment
 
-The SDK snippets assume you already configured a `client` as shown in [Get Started](/docs/get-started). They create separate SandboxVolumes for repository and harness state, then claim the builtin template. The examples leave `ttl` and `hard_ttl` unset.
+The SDK snippets assume you already configured a `client` as shown in [Get Started](/docs/get-started). They create one SandboxVolume for the complete workspace, then claim the builtin template. The examples leave `ttl` and `hard_ttl` unset.
 
 <Tabs
   tabs={[
@@ -36,16 +33,8 @@ if err != nil {
     log.Fatal(err)
 }
 
-agentStateVolume, err := client.CreateVolume(ctx, apispec.CreateSandboxVolumeRequest{
-    AccessMode: apispec.NewOptVolumeAccessMode(apispec.VolumeAccessModeRWO),
-})
-if err != nil {
-    log.Fatal(err)
-}
-
 sandbox, err := client.ClaimSandbox(ctx, "coding-agent",
     sandbox0.WithSandboxBootstrapMount(workspaceVolume.ID, "/workspace"),
-    sandbox0.WithSandboxBootstrapMount(agentStateVolume.ID, "/agent-state"),
 )
 if err != nil {
     log.Fatal(err)
@@ -61,20 +50,12 @@ from sandbox0.apispec.models.create_sandbox_volume_request import CreateSandboxV
 workspace_volume = client.volumes.create(CreateSandboxVolumeRequest.from_dict({
     "access_mode": "RWO",
 }))
-agent_state_volume = client.volumes.create(CreateSandboxVolumeRequest.from_dict({
-    "access_mode": "RWO",
-}))
-
 sandbox = client.sandboxes.claim(
     "coding-agent",
     mounts=[
         ClaimMountRequest(
             sandboxvolume_id=workspace_volume.id,
             mount_point="/workspace",
-        ),
-        ClaimMountRequest(
-            sandboxvolume_id=agent_state_volume.id,
-            mount_point="/agent-state",
         ),
     ],
 )
@@ -88,19 +69,11 @@ print("Sandbox ID:", sandbox.id)`
 const workspaceVolume = await client.volumes.create({
     accessMode: models.VolumeAccessMode.Rwo,
 });
-const agentStateVolume = await client.volumes.create({
-    accessMode: models.VolumeAccessMode.Rwo,
-});
-
 const sandbox = await client.sandboxes.claim("coding-agent", {
     mounts: [
         {
             sandboxvolumeId: workspaceVolume.id,
             mountPoint: "/workspace",
-        },
-        {
-            sandboxvolumeId: agentStateVolume.id,
-            mountPoint: "/agent-state",
         },
     ],
 });
@@ -110,12 +83,9 @@ console.log("Sandbox ID:", sandbox.id);`
       label: "CLI",
       language: "bash",
       code: `WORKSPACE_VOLUME_ID="$(s0 -o json volume create --access-mode RWO | jq -r '.id')"
-AGENT_STATE_VOLUME_ID="$(s0 -o json volume create --access-mode RWO | jq -r '.id')"
-
 SANDBOX_ID="$(s0 -o json sandbox create \\
     --template coding-agent \\
     --mount "$WORKSPACE_VOLUME_ID:/workspace" \\
-    --mount "$AGENT_STATE_VOLUME_ID:/agent-state" \\
     | jq -r '.id')"
 
 printf 'Sandbox ID: %s\\n' "$SANDBOX_ID"`
@@ -123,7 +93,7 @@ printf 'Sandbox ID: %s\\n' "$SANDBOX_ID"`
   ]}
 />
 
-The volumes are optional. If omitted, both paths are writable directories in the sandbox rootfs and follow that sandbox identity's checkpoint lifecycle. Use volumes when repository or harness state must be managed independently from the sandbox.
+The Volume is optional. If omitted, `/workspace` is a writable directory in the sandbox rootfs and follows that sandbox identity's checkpoint lifecycle. Use a Volume when the repository and native harness state must persist independently from the sandbox.
 
 Do not bake provider credentials into the template image. For production, prefer [egress auth](/docs/credential/egress-auth), LLMProxy, or another narrowly scoped external model proxy. Session environment variables are returned as part of the session specification and should not be treated as a secret store.
 
@@ -145,7 +115,7 @@ harnesses := map[string]harnessSpec{
     "codex": {
         Command: []string{"codex", "app-server", "--stdio"},
         Env: apispec.ExecutionSessionSpecEnv{
-            "CODEX_HOME": "/agent-state/codex",
+            "HOME": "/workspace",
         },
     },
     "claude-code": {
@@ -159,26 +129,19 @@ harnesses := map[string]harnessSpec{
             "--dangerously-skip-permissions",
         },
         Env: apispec.ExecutionSessionSpecEnv{
-            "CLAUDE_CONFIG_DIR": "/agent-state/claude",
+            "HOME": "/workspace",
         },
     },
     "opencode": {
         Command: []string{"opencode", "acp", "--cwd", "/workspace"},
         Env: apispec.ExecutionSessionSpecEnv{
-            "XDG_CONFIG_HOME": "/agent-state/opencode/config",
-            "XDG_DATA_HOME":   "/agent-state/opencode/data",
-            "XDG_CACHE_HOME":  "/agent-state/opencode/cache",
+            "HOME": "/workspace",
         },
     },
     "pi": {
-        Command: []string{
-            "pi", "--mode", "rpc",
-            "--session-dir", "/agent-state/pi/sessions",
-            "--approve",
-        },
+        Command: []string{"pi", "--mode", "rpc", "--approve"},
         Env: apispec.ExecutionSessionSpecEnv{
-            "PI_CODING_AGENT_DIR":         "/agent-state/pi",
-            "PI_CODING_AGENT_SESSION_DIR": "/agent-state/pi/sessions",
+            "HOME": "/workspace",
         },
     },
 }
@@ -228,7 +191,7 @@ from sandbox0.apispec.models.execution_session_spec import ExecutionSessionSpec
 harnesses = {
     "codex": {
         "command": ["codex", "app-server", "--stdio"],
-        "env": {"CODEX_HOME": "/agent-state/codex"},
+        "env": {"HOME": "/workspace"},
     },
     "claude-code": {
         "command": [
@@ -240,26 +203,15 @@ harnesses = {
             "--permission-mode", "bypassPermissions",
             "--dangerously-skip-permissions",
         ],
-        "env": {"CLAUDE_CONFIG_DIR": "/agent-state/claude"},
+        "env": {"HOME": "/workspace"},
     },
     "opencode": {
         "command": ["opencode", "acp", "--cwd", "/workspace"],
-        "env": {
-            "XDG_CONFIG_HOME": "/agent-state/opencode/config",
-            "XDG_DATA_HOME": "/agent-state/opencode/data",
-            "XDG_CACHE_HOME": "/agent-state/opencode/cache",
-        },
+        "env": {"HOME": "/workspace"},
     },
     "pi": {
-        "command": [
-            "pi", "--mode", "rpc",
-            "--session-dir", "/agent-state/pi/sessions",
-            "--approve",
-        ],
-        "env": {
-            "PI_CODING_AGENT_DIR": "/agent-state/pi",
-            "PI_CODING_AGENT_SESSION_DIR": "/agent-state/pi/sessions",
-        },
+        "command": ["pi", "--mode", "rpc", "--approve"],
+        "env": {"HOME": "/workspace"},
     },
 }
 
@@ -294,7 +246,7 @@ print("Session ID:", session.id)`
 const harnesses: Record<string, HarnessSpec> = {
     codex: {
         command: ["codex", "app-server", "--stdio"],
-        env: { CODEX_HOME: "/agent-state/codex" },
+        env: { HOME: "/workspace" },
     },
     "claude-code": {
         command: [
@@ -306,26 +258,15 @@ const harnesses: Record<string, HarnessSpec> = {
             "--permission-mode", "bypassPermissions",
             "--dangerously-skip-permissions",
         ],
-        env: { CLAUDE_CONFIG_DIR: "/agent-state/claude" },
+        env: { HOME: "/workspace" },
     },
     opencode: {
         command: ["opencode", "acp", "--cwd", "/workspace"],
-        env: {
-            XDG_CONFIG_HOME: "/agent-state/opencode/config",
-            XDG_DATA_HOME: "/agent-state/opencode/data",
-            XDG_CACHE_HOME: "/agent-state/opencode/cache",
-        },
+        env: { HOME: "/workspace" },
     },
     pi: {
-        command: [
-            "pi", "--mode", "rpc",
-            "--session-dir", "/agent-state/pi/sessions",
-            "--approve",
-        ],
-        env: {
-            PI_CODING_AGENT_DIR: "/agent-state/pi",
-            PI_CODING_AGENT_SESSION_DIR: "/agent-state/pi/sessions",
-        },
+        command: ["pi", "--mode", "rpc", "--approve"],
+        env: { HOME: "/workspace" },
     },
 };
 
@@ -353,22 +294,20 @@ console.log("Session ID:", session.id);`
 
 case "$HARNESS" in
     codex)
-        ENV_ARGS=(--env CODEX_HOME=/agent-state/codex)
         COMMAND=(codex app-server --stdio)
         ;;
     claude-code)
-        ENV_ARGS=(--env CLAUDE_CONFIG_DIR=/agent-state/claude)
         COMMAND=(claude -p --input-format stream-json --output-format stream-json --verbose --replay-user-messages --permission-mode bypassPermissions --dangerously-skip-permissions)
         ;;
     opencode)
-        ENV_ARGS=(--env XDG_CONFIG_HOME=/agent-state/opencode/config --env XDG_DATA_HOME=/agent-state/opencode/data --env XDG_CACHE_HOME=/agent-state/opencode/cache)
         COMMAND=(opencode acp --cwd /workspace)
         ;;
     pi)
-        ENV_ARGS=(--env PI_CODING_AGENT_DIR=/agent-state/pi --env PI_CODING_AGENT_SESSION_DIR=/agent-state/pi/sessions)
-        COMMAND=(pi --mode rpc --session-dir /agent-state/pi/sessions --approve)
+        COMMAND=(pi --mode rpc --approve)
         ;;
 esac
+
+ENV_ARGS=(--env HOME=/workspace)
 
 SESSION_ID="$(s0 -o json sandbox session create "$SANDBOX_ID" \\
     --name "$HARNESS" \\
@@ -601,7 +540,7 @@ s0 sandbox session delete "$SANDBOX_ID" "$SESSION_ID"`
   ]}
 />
 
-Then select the next entry from the harness map and create a new supervised session. `/workspace` preserves the repository, while each harness keeps native state in a separate directory below `/agent-state`.
+Then select the next entry from the harness map and create a new supervised session. The same `/workspace` Volume preserves both the repository and each harness's native home-relative state. Decide which metadata belongs in version control, and keep credentials and caches out of the repository.
 
 Do not replace a Codex session specification with a Claude Code, OpenCode, or Pi command. A new supervised session keeps each event journal, process attempt history, and native protocol stream internally consistent.
 

--- a/docs/use-cases/page.mdx
+++ b/docs/use-cases/page.mdx
@@ -39,12 +39,14 @@ Self-hosted deployments seed these public builtin templates when `spec.builtinTe
 s0 template get openclaw
 s0 template get hermes
 s0 template get browser
+s0 template get coding-agent
 ```
 
 Operators can pin images, tune pools, or remove a template by setting `Sandbox0Infra.spec.builtinTemplates` explicitly. The default builtin images are:
 
 | Template | Image |
 |----------|-------|
+| `coding-agent` | `sandbox0ai/otemplates:coding-agent-v0.1.0` |
 | `openclaw` | `ghcr.io/openclaw/openclaw:latest` |
 | `hermes` | `nousresearch/hermes-agent:latest` |
 | `browser` | `ghcr.io/steel-dev/steel-browser:latest` |
@@ -71,6 +73,10 @@ Prefer one of these patterns:
 ## Guides
 
 <CardGroup>
+  <Card title="Coding Agents" href="/docs/sandbox/use-cases/coding-agents" cta="Continue">
+    Drive Codex, Claude Code, OpenCode, or Pi through native protocols and supervised sessions.
+  </Card>
+
   <Card title="Hosting OpenClaw" href="/docs/sandbox/use-cases/openclaw" cta="Continue">
     Run the OpenClaw gateway from the builtin OpenClaw template with persistent state.
   </Card>

--- a/infra-operator/chart/samples/multi-cluster/data-plane.yaml
+++ b/infra-operator/chart/samples/multi-cluster/data-plane.yaml
@@ -106,6 +106,13 @@ spec:
       pool:
         minIdle: 0
         maxIdle: 2
+    - templateId: coding-agent
+      image: sandbox0ai/otemplates:coding-agent-v0.1.0
+      displayName: Coding Agents
+      description: Builtin coding-agent template with Codex, Claude Code, OpenCode, and Pi installed by infra-operator.
+      pool:
+        minIdle: 0
+        maxIdle: 2
   # Shared placement for sandbox template Pods plus node-local helpers such as
   # netd and ctld. In production, point this at your dedicated sandbox
   # node pool and pair it with services.manager.config.sandboxRuntimeClassName.

--- a/infra-operator/chart/samples/single-cluster/fullmode-gke-gvisor.yaml
+++ b/infra-operator/chart/samples/single-cluster/fullmode-gke-gvisor.yaml
@@ -63,6 +63,13 @@ spec:
       pool:
         minIdle: 0
         maxIdle: 2
+    - templateId: coding-agent
+      image: sandbox0ai/otemplates:coding-agent-v0.1.0
+      displayName: Coding Agents
+      description: Builtin coding-agent template with Codex, Claude Code, OpenCode, and Pi installed by infra-operator.
+      pool:
+        minIdle: 0
+        maxIdle: 2
   # Shared placement for sandbox template Pods plus node-local helpers such as
   # netd and ctld.
   sandboxNodePlacement:

--- a/infra-operator/chart/samples/single-cluster/fullmode.yaml
+++ b/infra-operator/chart/samples/single-cluster/fullmode.yaml
@@ -113,6 +113,13 @@ spec:
       pool:
         minIdle: 0
         maxIdle: 2
+    - templateId: coding-agent
+      image: sandbox0ai/otemplates:coding-agent-v0.1.0
+      displayName: Coding Agents
+      description: Builtin coding-agent template with Codex, Claude Code, OpenCode, and Pi installed by infra-operator.
+      pool:
+        minIdle: 0
+        maxIdle: 2
   # Shared placement for sandbox template Pods plus node-local helpers such as
   # netd and ctld.
   # infra-operator manages sandbox0.ai/data-plane-ready; do not include it here.

--- a/infra-operator/chart/samples/single-cluster/minimal.yaml
+++ b/infra-operator/chart/samples/single-cluster/minimal.yaml
@@ -71,6 +71,13 @@ spec:
       pool:
         minIdle: 0
         maxIdle: 2
+    - templateId: coding-agent
+      image: sandbox0ai/otemplates:coding-agent-v0.1.0
+      displayName: Coding Agents
+      description: Builtin coding-agent template with Codex, Claude Code, OpenCode, and Pi installed by infra-operator.
+      pool:
+        minIdle: 0
+        maxIdle: 2
   services:
     clusterGateway:
       enabled: true

--- a/infra-operator/chart/samples/single-cluster/network-policy.yaml
+++ b/infra-operator/chart/samples/single-cluster/network-policy.yaml
@@ -75,6 +75,13 @@ spec:
       pool:
         minIdle: 0
         maxIdle: 2
+    - templateId: coding-agent
+      image: sandbox0ai/otemplates:coding-agent-v0.1.0
+      displayName: Coding Agents
+      description: Builtin coding-agent template with Codex, Claude Code, OpenCode, and Pi installed by infra-operator.
+      pool:
+        minIdle: 0
+        maxIdle: 2
   # Shared placement for sandbox template Pods plus node-local helpers such as
   # netd and ctld.
   # infra-operator manages sandbox0.ai/data-plane-ready; do not include it here.

--- a/infra-operator/chart/samples/single-cluster/volumes.yaml
+++ b/infra-operator/chart/samples/single-cluster/volumes.yaml
@@ -89,6 +89,13 @@ spec:
       pool:
         minIdle: 0
         maxIdle: 2
+    - templateId: coding-agent
+      image: sandbox0ai/otemplates:coding-agent-v0.1.0
+      displayName: Coding Agents
+      description: Builtin coding-agent template with Codex, Claude Code, OpenCode, and Pi installed by infra-operator.
+      pool:
+        minIdle: 0
+        maxIdle: 2
   services:
     clusterGateway:
       enabled: true

--- a/infra-operator/internal/controller/pkg/common/builtin_templates.go
+++ b/infra-operator/internal/controller/pkg/common/builtin_templates.go
@@ -170,6 +170,8 @@ func BuildBuiltinTemplateSpec(templateID string, builtin infrav1alpha1.BuiltinTe
 	var spec templatev1alpha1.SandboxTemplateSpec
 	if builtin.Spec != nil {
 		spec = *builtin.Spec.DeepCopy()
+	} else if templateID == template.CodingAgentTemplateID {
+		spec = codingAgentTemplateSpec()
 	} else if templateID == template.OpenClawTemplateID {
 		spec = openClawTemplateSpec()
 	} else if templateID == template.HermesTemplateID {
@@ -182,6 +184,51 @@ func BuildBuiltinTemplateSpec(templateID string, builtin infrav1alpha1.BuiltinTe
 
 	applyBuiltinTemplateConfig(&spec, templateID, builtin)
 	return spec
+}
+
+func codingAgentTemplateSpec() templatev1alpha1.SandboxTemplateSpec {
+	runAsRoot := int64(0)
+	runAsNonRoot := false
+	return templatev1alpha1.SandboxTemplateSpec{
+		DisplayName: template.CodingAgentTemplateDisplayName,
+		Description: template.CodingAgentTemplateDescription,
+		MainContainer: templatev1alpha1.ContainerSpec{
+			Image: template.CodingAgentTemplateImage,
+			Resources: templatev1alpha1.ResourceQuota{
+				CPU:              resource.MustParse(template.CodingAgentCPU),
+				Memory:           resource.MustParse(template.CodingAgentMemory),
+				EphemeralStorage: resource.MustParse(template.CodingAgentEphemeralStorage),
+			},
+			SecurityContext: &templatev1alpha1.SecurityContext{
+				RunAsUser:    &runAsRoot,
+				RunAsGroup:   &runAsRoot,
+				RunAsNonRoot: &runAsNonRoot,
+			},
+		},
+		VolumeMounts: []templatev1alpha1.VolumeMountSpec{
+			{
+				Name:      template.DefaultTemplateWorkspaceName,
+				MountPath: template.DefaultTemplateWorkspaceMount,
+			},
+			{
+				Name:      template.CodingAgentStateMountName,
+				MountPath: template.CodingAgentStateMount,
+			},
+		},
+		EnvVars: map[string]string{
+			"DISABLE_AUTOUPDATER":         "1",
+			"OPENCODE_DISABLE_AUTOUPDATE": "1",
+			"PI_SKIP_VERSION_CHECK":       "1",
+			"PI_TELEMETRY":                "0",
+		},
+		Pool: templatev1alpha1.PoolStrategy{
+			MinIdle: 0,
+			MaxIdle: 2,
+		},
+		Network: &templatev1alpha1.SandboxNetworkPolicy{
+			Mode: templatev1alpha1.NetworkModeAllowAll,
+		},
+	}
 }
 
 func defaultBuiltinTemplateSpec(templateID string) templatev1alpha1.SandboxTemplateSpec {

--- a/infra-operator/internal/controller/pkg/common/builtin_templates.go
+++ b/infra-operator/internal/controller/pkg/common/builtin_templates.go
@@ -210,13 +210,10 @@ func codingAgentTemplateSpec() templatev1alpha1.SandboxTemplateSpec {
 				Name:      template.DefaultTemplateWorkspaceName,
 				MountPath: template.DefaultTemplateWorkspaceMount,
 			},
-			{
-				Name:      template.CodingAgentStateMountName,
-				MountPath: template.CodingAgentStateMount,
-			},
 		},
 		EnvVars: map[string]string{
 			"DISABLE_AUTOUPDATER":         "1",
+			"HOME":                        template.DefaultTemplateWorkspaceMount,
 			"OPENCODE_DISABLE_AUTOUPDATE": "1",
 			"PI_SKIP_VERSION_CHECK":       "1",
 			"PI_TELEMETRY":                "0",

--- a/infra-operator/internal/controller/pkg/common/builtin_templates_test.go
+++ b/infra-operator/internal/controller/pkg/common/builtin_templates_test.go
@@ -92,14 +92,11 @@ func TestBuildBuiltinTemplateSpecUsesCodingAgentPreset(t *testing.T) {
 	if spec.MainContainer.Resources.EphemeralStorage.Cmp(resource.MustParse(template.CodingAgentEphemeralStorage)) != 0 {
 		t.Fatalf("ephemeralStorage = %s, want %s", spec.MainContainer.Resources.EphemeralStorage.String(), template.CodingAgentEphemeralStorage)
 	}
-	if len(spec.VolumeMounts) != 2 {
-		t.Fatalf("volumeMounts = %#v, want workspace and agent state mounts", spec.VolumeMounts)
+	if len(spec.VolumeMounts) != 1 {
+		t.Fatalf("volumeMounts = %#v, want one workspace mount", spec.VolumeMounts)
 	}
 	if spec.VolumeMounts[0].Name != template.DefaultTemplateWorkspaceName || spec.VolumeMounts[0].MountPath != template.DefaultTemplateWorkspaceMount {
 		t.Fatalf("volumeMounts[0] = %#v, want workspace mount", spec.VolumeMounts[0])
-	}
-	if spec.VolumeMounts[1].Name != template.CodingAgentStateMountName || spec.VolumeMounts[1].MountPath != template.CodingAgentStateMount {
-		t.Fatalf("volumeMounts[1] = %#v, want agent state mount", spec.VolumeMounts[1])
 	}
 	security := spec.MainContainer.SecurityContext
 	if security == nil || security.RunAsUser == nil || *security.RunAsUser != 0 || security.RunAsNonRoot == nil || *security.RunAsNonRoot {
@@ -110,6 +107,7 @@ func TestBuildBuiltinTemplateSpecUsesCodingAgentPreset(t *testing.T) {
 	}
 	for key, want := range map[string]string{
 		"DISABLE_AUTOUPDATER":         "1",
+		"HOME":                        template.DefaultTemplateWorkspaceMount,
 		"OPENCODE_DISABLE_AUTOUPDATE": "1",
 		"PI_SKIP_VERSION_CHECK":       "1",
 		"PI_TELEMETRY":                "0",

--- a/infra-operator/internal/controller/pkg/common/builtin_templates_test.go
+++ b/infra-operator/internal/controller/pkg/common/builtin_templates_test.go
@@ -72,6 +72,60 @@ func TestBuildBuiltinTemplateSpecDoesNotAddDefaultRuntimeShapeToGenericPreset(t 
 	}
 }
 
+func TestBuildBuiltinTemplateSpecUsesCodingAgentPreset(t *testing.T) {
+	t.Parallel()
+
+	spec := BuildBuiltinTemplateSpec(template.CodingAgentTemplateID, infrav1alpha1.BuiltinTemplateConfig{})
+
+	if spec.DisplayName != template.CodingAgentTemplateDisplayName {
+		t.Fatalf("DisplayName = %q, want %q", spec.DisplayName, template.CodingAgentTemplateDisplayName)
+	}
+	if spec.MainContainer.Image != template.CodingAgentTemplateImage {
+		t.Fatalf("image = %q, want %q", spec.MainContainer.Image, template.CodingAgentTemplateImage)
+	}
+	if spec.MainContainer.Resources.CPU.Cmp(resource.MustParse(template.CodingAgentCPU)) != 0 {
+		t.Fatalf("cpu = %s, want %s", spec.MainContainer.Resources.CPU.String(), template.CodingAgentCPU)
+	}
+	if spec.MainContainer.Resources.Memory.Cmp(resource.MustParse(template.CodingAgentMemory)) != 0 {
+		t.Fatalf("memory = %s, want %s", spec.MainContainer.Resources.Memory.String(), template.CodingAgentMemory)
+	}
+	if spec.MainContainer.Resources.EphemeralStorage.Cmp(resource.MustParse(template.CodingAgentEphemeralStorage)) != 0 {
+		t.Fatalf("ephemeralStorage = %s, want %s", spec.MainContainer.Resources.EphemeralStorage.String(), template.CodingAgentEphemeralStorage)
+	}
+	if len(spec.VolumeMounts) != 2 {
+		t.Fatalf("volumeMounts = %#v, want workspace and agent state mounts", spec.VolumeMounts)
+	}
+	if spec.VolumeMounts[0].Name != template.DefaultTemplateWorkspaceName || spec.VolumeMounts[0].MountPath != template.DefaultTemplateWorkspaceMount {
+		t.Fatalf("volumeMounts[0] = %#v, want workspace mount", spec.VolumeMounts[0])
+	}
+	if spec.VolumeMounts[1].Name != template.CodingAgentStateMountName || spec.VolumeMounts[1].MountPath != template.CodingAgentStateMount {
+		t.Fatalf("volumeMounts[1] = %#v, want agent state mount", spec.VolumeMounts[1])
+	}
+	security := spec.MainContainer.SecurityContext
+	if security == nil || security.RunAsUser == nil || *security.RunAsUser != 0 || security.RunAsNonRoot == nil || *security.RunAsNonRoot {
+		t.Fatalf("securityContext = %#v, want root without privileged mode", security)
+	}
+	if security.Privileged != nil || security.AllowPrivilegeEscalation != nil {
+		t.Fatalf("securityContext = %#v, want no privileged settings", security)
+	}
+	for key, want := range map[string]string{
+		"DISABLE_AUTOUPDATER":         "1",
+		"OPENCODE_DISABLE_AUTOUPDATE": "1",
+		"PI_SKIP_VERSION_CHECK":       "1",
+		"PI_TELEMETRY":                "0",
+	} {
+		if spec.EnvVars[key] != want {
+			t.Fatalf("EnvVars[%q] = %q, want %q", key, spec.EnvVars[key], want)
+		}
+	}
+	if spec.Pool.MinIdle != 0 || spec.Pool.MaxIdle != 2 {
+		t.Fatalf("pool = %#v, want 0/2", spec.Pool)
+	}
+	if spec.Network == nil || spec.Network.Mode != templatev1alpha1.NetworkModeAllowAll {
+		t.Fatalf("network = %#v, want allow-all", spec.Network)
+	}
+}
+
 func TestBuildBuiltinTemplateSpecAllowsFullSpecOverride(t *testing.T) {
 	t.Parallel()
 
@@ -225,6 +279,7 @@ func TestBuiltinTemplatePresetsSatisfyResourceRatio(t *testing.T) {
 
 	for _, templateID := range []string{
 		template.DefaultTemplateID,
+		template.CodingAgentTemplateID,
 		template.OpenClawTemplateID,
 		template.HermesTemplateID,
 		template.BrowserTemplateID,

--- a/infra-operator/internal/plan/plan_test.go
+++ b/infra-operator/internal/plan/plan_test.go
@@ -160,14 +160,15 @@ func TestBuiltinTemplatesDefaultsAndOverrides(t *testing.T) {
 	t.Parallel()
 
 	defaults := Compile(&infrav1alpha1.Sandbox0Infra{}).BuiltinTemplates()
-	if len(defaults) != 4 {
-		t.Fatalf("default builtin template count = %d, want 4", len(defaults))
+	if len(defaults) != 5 {
+		t.Fatalf("default builtin template count = %d, want 5", len(defaults))
 	}
 	wantDefaults := []string{
 		template.DefaultTemplateID,
 		template.OpenClawTemplateID,
 		template.HermesTemplateID,
 		template.BrowserTemplateID,
+		template.CodingAgentTemplateID,
 	}
 	for i, want := range wantDefaults {
 		if defaults[i].TemplateID != want {

--- a/infra-operator/internal/plan/runtime_access.go
+++ b/infra-operator/internal/plan/runtime_access.go
@@ -38,6 +38,7 @@ func defaultBuiltinTemplates() []infrav1alpha1.BuiltinTemplateConfig {
 		{TemplateID: s0template.OpenClawTemplateID},
 		{TemplateID: s0template.HermesTemplateID},
 		{TemplateID: s0template.BrowserTemplateID},
+		{TemplateID: s0template.CodingAgentTemplateID},
 	}
 }
 

--- a/manager/procd/Dockerfile.coding-agent
+++ b/manager/procd/Dockerfile.coding-agent
@@ -1,0 +1,48 @@
+# Sandbox0 coding-agent template.
+# This image intentionally does NOT define an ENTRYPOINT/CMD. The platform
+# injects and starts procd, then Session Supervisor owns each coding agent.
+
+FROM sandbox0ai/otemplates:default-v0.2.0
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    NPM_CONFIG_AUDIT=false \
+    NPM_CONFIG_FUND=false \
+    NPM_CONFIG_UPDATE_NOTIFIER=false \
+    DISABLE_AUTOUPDATER=1 \
+    OPENCODE_DISABLE_AUTOUPDATE=1 \
+    PI_SKIP_VERSION_CHECK=1 \
+    PI_TELEMETRY=0
+
+# Claude Code and Pi require Node.js 22. Pi currently requires Node.js 22.19+
+# specifically, so fail the build if the repository ever resolves an older 22.x.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates curl gnupg \
+  && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+  && apt-get install -y --no-install-recommends nodejs \
+  && node -e 'const [major, minor] = process.versions.node.split(".").map(Number); if (major < 22 || (major === 22 && minor < 19)) process.exit(1)' \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt/coding-agents
+
+COPY manager/procd/coding-agents/package.json manager/procd/coding-agents/package-lock.json ./
+COPY manager/procd/coding-agents/THIRD_PARTY.md ./
+
+RUN npm ci --omit=dev \
+  && for agent in codex claude opencode pi; do ln -sf "/opt/coding-agents/node_modules/.bin/$agent" "/usr/local/bin/$agent"; done \
+  && codex --version \
+  && claude --version \
+  && opencode --version \
+  && pi --version \
+  && npm cache clean --force
+
+RUN mkdir -p \
+    /workspace \
+    /agent-state/codex \
+    /agent-state/claude \
+    /agent-state/opencode/config \
+    /agent-state/opencode/data \
+    /agent-state/pi/sessions
+
+WORKDIR /workspace
+
+# Intentionally no ENTRYPOINT/CMD here.

--- a/manager/procd/Dockerfile.coding-agent
+++ b/manager/procd/Dockerfile.coding-agent
@@ -35,13 +35,9 @@ RUN npm ci --omit=dev \
   && pi --version \
   && npm cache clean --force
 
-RUN mkdir -p \
-    /workspace \
-    /agent-state/codex \
-    /agent-state/claude \
-    /agent-state/opencode/config \
-    /agent-state/opencode/data \
-    /agent-state/pi/sessions
+RUN mkdir -p /workspace
+
+ENV HOME=/workspace
 
 WORKDIR /workspace
 

--- a/manager/procd/coding-agents/THIRD_PARTY.md
+++ b/manager/procd/coding-agents/THIRD_PARTY.md
@@ -1,0 +1,12 @@
+# Coding Agent Packages
+
+The `coding-agent` template installs these pinned third-party packages:
+
+| Package | Version | Upstream license |
+|---------|---------|------------------|
+| `@openai/codex` | `0.144.1` | Apache-2.0 |
+| `@anthropic-ai/claude-code` | `2.1.207` | See the license distributed with the package and Anthropic's applicable terms |
+| `opencode-ai` | `1.17.18` | MIT |
+| `@earendil-works/pi-coding-agent` | `0.80.6` | MIT |
+
+This inventory does not replace the license and notice files distributed in each npm package. Review the current upstream terms before publishing a derived image, especially for packages that do not use an open-source license.

--- a/manager/procd/coding-agents/package-lock.json
+++ b/manager/procd/coding-agents/package-lock.json
@@ -1,0 +1,2299 @@
+{
+  "name": "sandbox0-coding-agents",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sandbox0-coding-agents",
+      "version": "0.1.0",
+      "license": "UNLICENSED",
+      "dependencies": {
+        "@anthropic-ai/claude-code": "2.1.207",
+        "@earendil-works/pi-coding-agent": "0.80.6",
+        "@openai/codex": "0.144.1",
+        "opencode-ai": "1.17.18"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-code": {
+      "version": "2.1.207",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.207.tgz",
+      "integrity": "sha512-30D3lGMO0iPmWnz6rCSHKd6d6gWtQ8CV2zKHHspEHZFyjDJsNOr2Xg6Kb/XEPsaFFu4BGIJz/7L6FQkcFq5cNA==",
+      "hasInstallScript": true,
+      "license": "SEE LICENSE IN README.md",
+      "bin": {
+        "claude": "bin/claude.exe"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "@anthropic-ai/claude-code-darwin-arm64": "2.1.207",
+        "@anthropic-ai/claude-code-darwin-x64": "2.1.207",
+        "@anthropic-ai/claude-code-linux-arm64": "2.1.207",
+        "@anthropic-ai/claude-code-linux-arm64-musl": "2.1.207",
+        "@anthropic-ai/claude-code-linux-x64": "2.1.207",
+        "@anthropic-ai/claude-code-linux-x64-musl": "2.1.207",
+        "@anthropic-ai/claude-code-win32-arm64": "2.1.207",
+        "@anthropic-ai/claude-code-win32-x64": "2.1.207"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-code-darwin-arm64": {
+      "version": "2.1.207",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-arm64/-/claude-code-darwin-arm64-2.1.207.tgz",
+      "integrity": "sha512-Sp2dbq04SQXu6N9X4ujdJfDIX4hVvBcaTyGLwsWChsq9w96iXv/dsIXkh+vQ/BmsPdsHQuaJgYDW5BscErlOrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-darwin-x64": {
+      "version": "2.1.207",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-x64/-/claude-code-darwin-x64-2.1.207.tgz",
+      "integrity": "sha512-4oDg3fbRT9cdLcrmCyPVy6+xFwsuiPxgb6s8LUe3lP5EsCpkkfr8t61Xjg8iGdXMpjxyHCpBL7g39ZUqwNzb1w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-linux-arm64": {
+      "version": "2.1.207",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64/-/claude-code-linux-arm64-2.1.207.tgz",
+      "integrity": "sha512-Jmcvn8Sg8+FaPLOy9t4h7ip+K1i5YYrimT1+iZL1YHBTA44WHJ9H/F8DW3QKnVyqUGqEza9Tg5PPVjzhi5fwyg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-linux-arm64-musl": {
+      "version": "2.1.207",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64-musl/-/claude-code-linux-arm64-musl-2.1.207.tgz",
+      "integrity": "sha512-H6KHgBc515+2zj33ijRKwbXIVfH1UFLPU322e1O6A1DDpKIfkAsoY/yWobs+EWYEob/piv1Q9sYt69cwCfGzjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-linux-x64": {
+      "version": "2.1.207",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64/-/claude-code-linux-x64-2.1.207.tgz",
+      "integrity": "sha512-WC4u+bRuR3EXY7fFFkuVnb9jB5IX5JLduzRwe6ZcIu08tT/PDUWT8bnnS07qwc2jzkUSqcL3kQbeHX5avnFASw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-linux-x64-musl": {
+      "version": "2.1.207",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64-musl/-/claude-code-linux-x64-musl-2.1.207.tgz",
+      "integrity": "sha512-C4IYbZhPCAh2epxYDVUeoyVC4S8ZTDaoUlClXH98G085ID/zilwI4cekZyYRZ1k0rbpkskaEkz7XnK0IyvAzHg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-win32-arm64": {
+      "version": "2.1.207",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-arm64/-/claude-code-win32-arm64-2.1.207.tgz",
+      "integrity": "sha512-u4crbHf5Pu6E4dsJuDZzsJLlBhF9UcjkueTt5j0EfmDjkTsplY9nDCoq1vB+eA3O/bNV+yGP+1aIvBSe2i+brw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-win32-x64": {
+      "version": "2.1.207",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-x64/-/claude-code-win32-x64-2.1.207.tgz",
+      "integrity": "sha512-8s0p6jrwVSX8bB9VZA/ud7BZDtPwCGvFpGaOtJYVmYPPHSl41N91KCfOF29zRBu3pKQ63C2Kq1COqE2F4BVJSA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@earendil-works/pi-coding-agent": {
+      "version": "0.80.6",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.6.tgz",
+      "integrity": "sha512-vcfD6tOk402isLl3Cm/qbn2O10TvgroMp1+/fEGM24ZdvETFCdOYv5VZ7m59EI5fPsjfSJh+CpQ5bhBrhfOg7g==",
+      "hasShrinkwrap": true,
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-agent-core": "^0.80.6",
+        "@earendil-works/pi-ai": "^0.80.6",
+        "@earendil-works/pi-tui": "^0.80.6",
+        "@silvia-odwyer/photon-node": "0.3.4",
+        "chalk": "5.6.2",
+        "cross-spawn": "7.0.6",
+        "diff": "8.0.4",
+        "glob": "13.0.6",
+        "highlight.js": "10.7.3",
+        "hosted-git-info": "9.0.3",
+        "ignore": "7.0.5",
+        "jiti": "2.7.0",
+        "minimatch": "10.2.5",
+        "proper-lockfile": "4.1.2",
+        "semver": "7.8.0",
+        "typebox": "1.1.38",
+        "undici": "8.5.0",
+        "yaml": "2.9.0"
+      },
+      "bin": {
+        "pi": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard": "0.3.9"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@anthropic-ai/sdk": {
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+      "integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-node": "^3.972.42",
+        "@aws-sdk/eventstream-handler-node": "^3.972.16",
+        "@aws-sdk/middleware-eventstream": "^3.972.12",
+        "@aws-sdk/middleware-websocket": "^3.972.19",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/core": {
+      "version": "3.974.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.11.tgz",
+      "integrity": "sha512-QpnINq5FZH6EOaDEkmHdT7eUunbvD27pDNQypaWjFyYz7Zl1q3UCMQErBZxpmfGfI7MvI2TlK8KTkgNpv8b1ug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.24",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.37.tgz",
+      "integrity": "sha512-/jpPvEh6f7ntmIzf7dNxoNX6Q8vt8UpesCjbW6mFfk4V1NW6bIy9qxcQ6WbA8As5yQhsZOe+xeNd4xHX8kdY2Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.39.tgz",
+      "integrity": "sha512-pIgTpisWyWg7X1bUbzSjuUYosYTD0Ghz2M0hkSTmb3a6i3qV3uU+NYJPI/E2XSC0HcsZh5rsLPzeXrkb2DS0Cg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.41.tgz",
+      "integrity": "sha512-u2tyjaxJJzW8UtW4SM1ZcPMDwO6y+kV+llvou+Adts0FAKyzes5jG4izQN+KX3yE8ZROpS5y1LJ//xL2iSf76w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-env": "^3.972.37",
+        "@aws-sdk/credential-provider-http": "^3.972.39",
+        "@aws-sdk/credential-provider-login": "^3.972.41",
+        "@aws-sdk/credential-provider-process": "^3.972.37",
+        "@aws-sdk/credential-provider-sso": "^3.972.41",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.41.tgz",
+      "integrity": "sha512-0LBitxXiAiaE5nlFPfpNIww/8FRY/I7WIndWsc9GmNFOM7cE1wNpVNQEGEk9Outg5l8xl+3vybxFyUy4l9q/LQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.42.tgz",
+      "integrity": "sha512-D4oon2zbqqsWOJUM99Gm3/ZyJ0IJvTXVN3PyloGb3kQEyI36fjCZheZj422lAgTWWd6TSHgiImLt3RIaLdv3dQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.37",
+        "@aws-sdk/credential-provider-http": "^3.972.39",
+        "@aws-sdk/credential-provider-ini": "^3.972.41",
+        "@aws-sdk/credential-provider-process": "^3.972.37",
+        "@aws-sdk/credential-provider-sso": "^3.972.41",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.37.tgz",
+      "integrity": "sha512-7nVaHBUaWIddASYfVaA9O4D5ZVjewU3sCol9WqZPGfW0nR+0WqE0xHZnD/U2L33PlOB8KNXGKZ6wOES/QijKzg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.41.tgz",
+      "integrity": "sha512-IOWAWEHe5LkjSKkkUUX9ciV6Y1scHTsnfEkdt5yyC4Slrc7AGbkLPrpntjqh18ksJAMOaVhoBsO8p2WyTcY2wQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.41.tgz",
+      "integrity": "sha512-mbACk9Yypa8nm4iGZLs0PofOXEcTDOUw6wDnsPXNDNSd2WNXs1tSo+6nc/fh0jLYdfVZThhBL98PHW4aXFsG5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.16.tgz",
+      "integrity": "sha512-yedpPgKftqjU5SlPFHfqWpOw6xSCRieWRG1euWOlXn4WJxt2VX92VprCa2PpSOXjVCAeK6dTjW9eJRXVig9yGA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.12.tgz",
+      "integrity": "sha512-tHTHHCHNrq6XklQvlzHBDJG4Iuhh7NVPRdtmvP+nHFA+5sxPlIDzlAHHgfoYHGvT3NXP1yVP/L5c3opUn6T3Qg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.19.tgz",
+      "integrity": "sha512-mkEhOGYozqKQkbFaVrjwr0faiwwZza1v5/jSY6Tucm3bD+uKTazIUH/4Yo6aMnQD2ua2W9cMP6s8mvwTcjtqHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.9.tgz",
+      "integrity": "sha512-jPR3rnmRI4hWYyzfmTGBr7NblMp8QYYeflHXba1H6+7CGrWVqWKQzaXFQ4qbExqPRsXN3T3L3JxFhr6aouXUGQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.27.tgz",
+      "integrity": "sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+      "integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/types": {
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
+      "integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@nodable/entities": "2.1.0",
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.7.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
+      "version": "0.80.6",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.6.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-ai": "^0.80.6",
+        "ignore": "7.0.5",
+        "typebox": "1.1.38",
+        "yaml": "2.9.0"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
+      "version": "0.80.6",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.6.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "0.91.1",
+        "@aws-sdk/client-bedrock-runtime": "3.1048.0",
+        "@google/genai": "1.52.0",
+        "@mistralai/mistralai": "2.2.6",
+        "@opentelemetry/api": "1.9.0",
+        "@smithy/node-http-handler": "4.7.3",
+        "http-proxy-agent": "7.0.2",
+        "https-proxy-agent": "7.0.6",
+        "openai": "6.26.0",
+        "partial-json": "0.1.7",
+        "typebox": "1.1.38"
+      },
+      "bin": {
+        "pi-ai": "./dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
+      "version": "0.80.6",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.6.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "1.6.0",
+        "marked": "18.0.5"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@google/genai": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.9.tgz",
+      "integrity": "sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard-darwin-arm64": "0.3.9",
+        "@mariozechner/clipboard-darwin-universal": "0.3.9",
+        "@mariozechner/clipboard-darwin-x64": "0.3.9",
+        "@mariozechner/clipboard-linux-arm64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-arm64-musl": "0.3.9",
+        "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-x64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-x64-musl": "0.3.9",
+        "@mariozechner/clipboard-win32-arm64-msvc": "0.3.9",
+        "@mariozechner/clipboard-win32-x64-msvc": "0.3.9"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-arm64": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.9.tgz",
+      "integrity": "sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-universal": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.9.tgz",
+      "integrity": "sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-x64": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.9.tgz",
+      "integrity": "sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.9.tgz",
+      "integrity": "sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-musl": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.9.tgz",
+      "integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.9.tgz",
+      "integrity": "sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-gnu": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.9.tgz",
+      "integrity": "sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-musl": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.9.tgz",
+      "integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.9.tgz",
+      "integrity": "sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-x64-msvc": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.9.tgz",
+      "integrity": "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mistralai/mistralai": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
+      "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.40.0",
+        "ws": "^8.18.0",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@silvia-odwyer/photon-node": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
+      "integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/core": {
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
+      "integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/credential-provider-imds": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.3.tgz",
+      "integrity": "sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/fetch-http-handler": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.3.tgz",
+      "integrity": "sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/node-http-handler": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/signature-v4": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
+      "integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/types": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
+      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/hosted-git-info": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^11.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/lru-cache": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.4.0.tgz",
+      "integrity": "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/marked": {
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/openai": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
+      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry/node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/partial-json": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile/node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/protobufjs": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/typebox": {
+      "version": "1.1.38",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
+      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/undici": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
+      "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    },
+    "node_modules/@openai/codex": {
+      "version": "0.144.1",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1.tgz",
+      "integrity": "sha512-Xir1zqPfpenhdoAoshN53uonzbBXj18COyzRkFlVZpSNyEl5XtkuYu9oddELePFN7K/0sXUcSO34Ad5IeCXPbw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "codex": "bin/codex.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.144.1-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.144.1-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.144.1-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.144.1-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.144.1-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.144.1-win32-x64"
+      }
+    },
+    "node_modules/@openai/codex-darwin-arm64": {
+      "name": "@openai/codex",
+      "version": "0.144.1-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-darwin-arm64.tgz",
+      "integrity": "sha512-dABeDK+ATqMG54MGBd3VjpKfh5EOoqx9PKVQB2QYDaEXx3F6CdUCXue5QIMfr4OxziUj8pUcLAQyd+KFqiTUFw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-darwin-x64": {
+      "name": "@openai/codex",
+      "version": "0.144.1-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-darwin-x64.tgz",
+      "integrity": "sha512-K2g3Q3tNxzFhV0SuzO6HcsYK7EQrp/o4HyeReyhkwVrwwUPoYwyIbB0IRjHIiDzRhbKriDccid2iyF5aPqdTcg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-linux-arm64": {
+      "name": "@openai/codex",
+      "version": "0.144.1-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-linux-arm64.tgz",
+      "integrity": "sha512-451o15+XtaXCCb35t/KCyyPqXHnTPxPxtdqEYOnE3e4sH5AfnI/uVJwfdjOksMG6vRLy6R+fLvSDOMguRFLmQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-linux-x64": {
+      "name": "@openai/codex",
+      "version": "0.144.1-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-linux-x64.tgz",
+      "integrity": "sha512-HNGVI+BulrOaC/0IzBvd6EL62j7LrlbFKibrhw6hZjjCjAeUYzRB2jB4qDzXN1NfqDi6Xrvniof3kwbwab24lg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-win32-arm64": {
+      "name": "@openai/codex",
+      "version": "0.144.1-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-win32-arm64.tgz",
+      "integrity": "sha512-L4aDVEh9o1u7WYoxpSyv3un9Bz26YZYocOFqE2oHdEQDL2s6/LdtutLQc3oUZruLlEbkNsjSU0HI1OKsP0+Ctg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-win32-x64": {
+      "name": "@openai/codex",
+      "version": "0.144.1-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-win32-x64.tgz",
+      "integrity": "sha512-qv2HOp6v/nVP31p5I5GxYyL0wa79PMzim1+W9CKSV0UldjFV9AMbualA8PeXcYhbvvh9Y1UASXxwjuQdlyfAvw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/opencode-ai": {
+      "version": "1.17.18",
+      "resolved": "https://registry.npmjs.org/opencode-ai/-/opencode-ai-1.17.18.tgz",
+      "integrity": "sha512-gpCE5X3dwvYam2ba9r3mw+FTPBTDlmKkguiOoYF1nv9MVA3sDIXje3tPQ+EMNxYkWD43FN3+eVC1GW6tRO9Aiw==",
+      "cpu": [
+        "arm64",
+        "x64"
+      ],
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "bin": {
+        "opencode": "bin/opencode.exe"
+      },
+      "optionalDependencies": {
+        "opencode-darwin-arm64": "1.17.18",
+        "opencode-darwin-x64": "1.17.18",
+        "opencode-darwin-x64-baseline": "1.17.18",
+        "opencode-linux-arm64": "1.17.18",
+        "opencode-linux-arm64-musl": "1.17.18",
+        "opencode-linux-x64": "1.17.18",
+        "opencode-linux-x64-baseline": "1.17.18",
+        "opencode-linux-x64-baseline-musl": "1.17.18",
+        "opencode-linux-x64-musl": "1.17.18",
+        "opencode-windows-arm64": "1.17.18",
+        "opencode-windows-x64": "1.17.18",
+        "opencode-windows-x64-baseline": "1.17.18"
+      }
+    },
+    "node_modules/opencode-darwin-arm64": {
+      "version": "1.17.18",
+      "resolved": "https://registry.npmjs.org/opencode-darwin-arm64/-/opencode-darwin-arm64-1.17.18.tgz",
+      "integrity": "sha512-wcnsPXxNnIggdva8rQ2KAWi17GdyDL4joAT+M/+UqkRFXhTBgfScWiWyCAGpZitDlpxd0K5W79NPjal54A8aiw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/opencode-darwin-x64": {
+      "version": "1.17.18",
+      "resolved": "https://registry.npmjs.org/opencode-darwin-x64/-/opencode-darwin-x64-1.17.18.tgz",
+      "integrity": "sha512-WwTwf6pCMkJ4ed3l6mLn2+eVz+Yli+5ijine0Hx7r+LVUYv9Odo46lHO4ZLd2m/dbnnDcX5xHNklasBNfCkBEQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/opencode-darwin-x64-baseline": {
+      "version": "1.17.18",
+      "resolved": "https://registry.npmjs.org/opencode-darwin-x64-baseline/-/opencode-darwin-x64-baseline-1.17.18.tgz",
+      "integrity": "sha512-kkUWjHQBtYtbtoAxV7N8srXpAdWu7ajynnrUQ/raHhJc2HnsR3Ud6/Ms60YSpNWOuCZ/WgtISpXkg12E7opvcA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/opencode-linux-arm64": {
+      "version": "1.17.18",
+      "resolved": "https://registry.npmjs.org/opencode-linux-arm64/-/opencode-linux-arm64-1.17.18.tgz",
+      "integrity": "sha512-VrTs+uQndp+B442Bfxf1a7BX9599gARjQCJ+MVCkcxl4Dr4gbBw7EfjKgGvhCqKUN5Hv2I7hUG/EZ1Ix3T6xrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-linux-arm64-musl": {
+      "version": "1.17.18",
+      "resolved": "https://registry.npmjs.org/opencode-linux-arm64-musl/-/opencode-linux-arm64-musl-1.17.18.tgz",
+      "integrity": "sha512-KW+77OknysG0gkD8tRzIcFKuv2mJR3jDtEQcCOhXmkAEWv7rEIqaDehWDa35F7AKjNJnJ4f6P7dDLMDJeQztHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-linux-x64": {
+      "version": "1.17.18",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64/-/opencode-linux-x64-1.17.18.tgz",
+      "integrity": "sha512-8BmT22yp7pCXXu/HvAMaJsNNd6xhmlUrGs5YZSfU0neZfkSZg+Dkf9IGsuOugOtL0x2erDg2/6rRBpcJAGmTrA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-linux-x64-baseline": {
+      "version": "1.17.18",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64-baseline/-/opencode-linux-x64-baseline-1.17.18.tgz",
+      "integrity": "sha512-ZHgobRKdHocQJSAzrz/ekKBjN1cScB+u07Zgr5Hzks2zm+ZyuN5zvx/NOKM7ImPEy3TQ0+swXvtoYKCOE4Tpbw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-linux-x64-baseline-musl": {
+      "version": "1.17.18",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64-baseline-musl/-/opencode-linux-x64-baseline-musl-1.17.18.tgz",
+      "integrity": "sha512-e4/FLdohz2euPXsziktv7mKrYLO01R4n7bwMvhAcPDaYc9zCagHUoALZVYm0BXtVB6YikaIfnHsbAIAgNlC37w==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-linux-x64-musl": {
+      "version": "1.17.18",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64-musl/-/opencode-linux-x64-musl-1.17.18.tgz",
+      "integrity": "sha512-3pWmNMZ08vsOVnQcOydqnE66NTZjqMZllcX6M9w+nCbQ2Edi6xWL1NMiW9MFvjyJMuOxTqzif6RvpIcK3CZHxw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-windows-arm64": {
+      "version": "1.17.18",
+      "resolved": "https://registry.npmjs.org/opencode-windows-arm64/-/opencode-windows-arm64-1.17.18.tgz",
+      "integrity": "sha512-5vtCGvt3k1RbhiB31Sg4Q0H1Qy+npFMD1y4N3fhx8X+Dyrzfly7SPQNQPtSt8nDluRhcCB0oFl9suDew2q2YOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/opencode-windows-x64": {
+      "version": "1.17.18",
+      "resolved": "https://registry.npmjs.org/opencode-windows-x64/-/opencode-windows-x64-1.17.18.tgz",
+      "integrity": "sha512-6i17BI5tmQvopBm6lwerPu2I7p2BYneX7XDlHYeVCy9+INL0T8sD8Ww+Lobqs76E8kepwP1NVqEFzs5DkLYVJw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/opencode-windows-x64-baseline": {
+      "version": "1.17.18",
+      "resolved": "https://registry.npmjs.org/opencode-windows-x64-baseline/-/opencode-windows-x64-baseline-1.17.18.tgz",
+      "integrity": "sha512-pt9ga2UcoTUo6+/rFvZZ+KOxHXkVMHPqBi3tVjI/B96icAGtpXNPDznK+HuahBFKKMr9y8pwu17yd94Vn+gMMg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    }
+  }
+}

--- a/manager/procd/coding-agents/package.json
+++ b/manager/procd/coding-agents/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "sandbox0-coding-agents",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Pinned coding agents installed in the Sandbox0 coding-agent template.",
+  "license": "UNLICENSED",
+  "dependencies": {
+    "@anthropic-ai/claude-code": "2.1.207",
+    "@earendil-works/pi-coding-agent": "0.80.6",
+    "@openai/codex": "0.144.1",
+    "opencode-ai": "1.17.18"
+  }
+}

--- a/pkg/template/defaults.go
+++ b/pkg/template/defaults.go
@@ -16,6 +16,16 @@ const (
 	DefaultTemplateDockerRoot       = "/var/lib/docker"
 	DefaultTemplateDockerRootSize   = v1alpha1.DefaultSandboxEphemeralStorage
 
+	CodingAgentTemplateID          = "coding-agent"
+	CodingAgentTemplateImage       = "sandbox0ai/otemplates:coding-agent-v0.1.0"
+	CodingAgentTemplateDisplayName = "Coding Agents"
+	CodingAgentTemplateDescription = "Builtin coding-agent template with Codex, Claude Code, OpenCode, and Pi installed by infra-operator."
+	CodingAgentCPU                 = "1"
+	CodingAgentMemory              = "4Gi"
+	CodingAgentEphemeralStorage    = "16Gi"
+	CodingAgentStateMountName      = "agent-state"
+	CodingAgentStateMount          = "/agent-state"
+
 	OpenClawTemplateID          = "openclaw"
 	OpenClawTemplateImage       = "ghcr.io/openclaw/openclaw:latest"
 	OpenClawTemplateDisplayName = "OpenClaw"

--- a/pkg/template/defaults.go
+++ b/pkg/template/defaults.go
@@ -23,8 +23,6 @@ const (
 	CodingAgentCPU                 = "1"
 	CodingAgentMemory              = "4Gi"
 	CodingAgentEphemeralStorage    = "16Gi"
-	CodingAgentStateMountName      = "agent-state"
-	CodingAgentStateMount          = "/agent-state"
 
 	OpenClawTemplateID          = "openclaw"
 	OpenClawTemplateImage       = "ghcr.io/openclaw/openclaw:latest"


### PR DESCRIPTION
## Summary

- add the `coding-agent` builtin template with one `/workspace` mount used as both `HOME` and the supervised session working directory
- keep each native harness's home-relative configuration and conversation state on the same workspace Volume
- add a locked multi-arch template image definition containing Codex, Claude Code, OpenCode, and Pi
- document environment creation, supervised session startup, native protocol I/O, and harness switching with matching Go, Python, TypeScript, and CLI tabs
- keep Codex JSON-RPC, Claude stream-json, OpenCode ACP, and Pi RPC native instead of translating them into a shared harness protocol
- update builtin template samples, navigation, and preset tests

## Validation

- `go test ./infra-operator/... ./pkg/...`
- `go test -race ./infra-operator/internal/controller/pkg/common ./infra-operator/internal/plan ./pkg/template`
- clean `npm ci` with Node.js 22.19.0, followed by version checks for all four CLIs
- protocol smoke checks: Codex app-server initialize, Claude stream-json init, OpenCode ACP initialize, Pi RPC get_state
- Go documentation snippets compiled against the current local sdk-go
- Python documentation snippets imported and constructed current generated SDK models
- TypeScript documentation snippets typechecked against the current local sdk-js build
- CLI snippets passed `bash -n`
- MDX compile, sandbox0-cloud docs registry generation to a temporary output root, JSON validation, YAML parsing, and `git diff --check`

A local Docker build was not run because this host does not have Docker or another OCI builder.

## Before marking ready

- [ ] Confirm that publicly redistributing Claude Code in `sandbox0ai/otemplates` is permitted by Anthropic's applicable terms.
- [ ] Build and publish `sandbox0ai/otemplates:coding-agent-v0.1.0` for amd64 and arm64 using `manager/procd/Dockerfile.coding-agent`.
- [ ] Claim the published template in a live Sandbox0 deployment and run one authenticated prompt through each native protocol.

The PR stays draft because the builtin default must not merge while its image tag is unpublished; the Docker Hub tag currently returns 404.
