### PR TITLE
fix(procd): prevent lifecycle shutdown deadlocks

### DIFF
--- a/manager/procd/pkg/context/context.go
+++ b/manager/procd/pkg/context/context.go
@@ -27,7 +27,8 @@ type Context struct {
 	FinishedAt     *time.Time          `json:"-"`
 	CleanupPolicy  CleanupPolicy       `json:"-"`
 
-	mu sync.RWMutex
+	mu          sync.RWMutex
+	lifecycleMu sync.Mutex
 }
 
 // CleanupPolicy defines when a context should be cleaned up.

--- a/manager/procd/pkg/context/manager.go
+++ b/manager/procd/pkg/context/manager.go
@@ -137,31 +137,28 @@ func (m *Manager) CreateContext(config process.ProcessConfig) (*Context, error) 
 
 // CreateContextWithPolicyAndREPLConfig creates a new context with a cleanup policy and optional REPL config.
 func (m *Manager) CreateContextWithPolicyAndREPLConfig(config process.ProcessConfig, replConfig *repl.REPLConfig, policy CleanupPolicy) (*Context, error) {
-	m.mu.Lock()
+	m.mu.RLock()
 	startHandler := m.onStart
+	exitHandler := m.onExit
 	defaultPolicy := m.defaultCleanupPolicy
-	config.EnvVars = process.MergeEnvVars(m.sandboxEnvVars, config.EnvVars)
-	// Define exit handler for the new context
-	exitHandler := func(event process.ExitEvent) {
-		if m.onExit != nil {
-			m.onExit(event)
-		}
-	}
+	sandboxEnvVars := process.CloneEnvVars(m.sandboxEnvVars)
+	supervisor := m.supervisor
+	m.mu.RUnlock()
+
+	config.EnvVars = process.MergeEnvVars(sandboxEnvVars, config.EnvVars)
 
 	var ctx *Context
 	var err error
-	if m.supervisor == nil {
+	if supervisor == nil {
 		ctx, err = NewContext(config, replConfig, exitHandler, startHandler)
 	} else {
 		ctx, err = NewUnstartedContext(config, replConfig, exitHandler, startHandler)
 	}
 	if err != nil {
-		m.mu.Unlock()
 		return nil, err
 	}
-	if m.supervisor != nil {
-		if err := m.supervisor.StartTransient(ctx.ID, ctx.MainProcess); err != nil {
-			m.mu.Unlock()
+	if supervisor != nil {
+		if err := supervisor.StartTransient(ctx.ID, ctx.MainProcess); err != nil {
 			return nil, err
 		}
 	}
@@ -171,6 +168,7 @@ func (m *Manager) CreateContextWithPolicyAndREPLConfig(config process.ProcessCon
 	}
 	ctx.SetCleanupPolicy(policy)
 
+	m.mu.Lock()
 	m.contexts[ctx.ID] = ctx
 	m.mu.Unlock()
 	return ctx, nil
@@ -205,62 +203,77 @@ func (m *Manager) ListContexts() []*Context {
 // DeleteContext deletes a context.
 func (m *Manager) DeleteContext(id string) error {
 	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	ctx, exists := m.contexts[id]
 	if !exists {
+		m.mu.Unlock()
 		return ErrContextNotFound
 	}
-
-	if m.supervisor != nil {
-		_ = m.supervisor.DeleteTransient(id)
-	} else {
-		_ = ctx.Stop()
-	}
-
 	delete(m.contexts, id)
-	return nil
+	supervisor := m.supervisor
+	m.mu.Unlock()
+
+	ctx.lifecycleMu.Lock()
+	defer ctx.lifecycleMu.Unlock()
+	var err error
+	if supervisor != nil {
+		err = supervisor.DeleteTransient(id)
+	} else {
+		err = ctx.Stop()
+	}
+	if err != nil {
+		m.mu.Lock()
+		if _, exists := m.contexts[id]; !exists {
+			m.contexts[id] = ctx
+		}
+		m.mu.Unlock()
+	}
+	return err
 }
 
 // RestartContext restarts a context.
 func (m *Manager) RestartContext(id string) (*Context, error) {
-	m.mu.Lock()
-
+	m.mu.RLock()
 	ctx, exists := m.contexts[id]
+	supervisor := m.supervisor
+	m.mu.RUnlock()
 	if !exists {
-		m.mu.Unlock()
+		return nil, ErrContextNotFound
+	}
+
+	ctx.lifecycleMu.Lock()
+	defer ctx.lifecycleMu.Unlock()
+	if !m.hasContext(id, ctx) {
 		return nil, ErrContextNotFound
 	}
 
 	var err error
-	if m.supervisor != nil {
-		err = m.supervisor.RestartTransient(id)
+	if supervisor != nil {
+		err = supervisor.RestartTransient(id)
 	} else {
 		err = ctx.Restart()
 	}
 	if err != nil {
-		m.mu.Unlock()
 		return nil, err
 	}
 	ctx.Touch()
 
-	m.mu.Unlock()
 	return ctx, nil
 }
 
 // PauseAll pauses all running contexts and their child processes.
 // Returns an error if any context fails to pause.
 func (m *Manager) PauseAll() error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	contexts := m.contextSnapshot()
 
 	var errs []error
-	for _, ctx := range m.contexts {
+	for _, ctx := range contexts {
+		ctx.lifecycleMu.Lock()
 		if ctx.IsRunning() {
 			if err := ctx.Pause(); err != nil {
 				errs = append(errs, fmt.Errorf("context %s: %w", ctx.ID, err))
 			}
 		}
+		ctx.lifecycleMu.Unlock()
 	}
 
 	return errors.Join(errs...)
@@ -269,16 +282,17 @@ func (m *Manager) PauseAll() error {
 // ResumeAll resumes all paused contexts and their child processes.
 // Returns an error if any context fails to resume.
 func (m *Manager) ResumeAll() error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	contexts := m.contextSnapshot()
 
 	var errs []error
-	for _, ctx := range m.contexts {
+	for _, ctx := range contexts {
+		ctx.lifecycleMu.Lock()
 		if ctx.IsPaused() {
 			if err := ctx.Resume(); err != nil {
 				errs = append(errs, fmt.Errorf("context %s: %w", ctx.ID, err))
 			}
 		}
+		ctx.lifecycleMu.Unlock()
 	}
 	return errors.Join(errs...)
 }
@@ -357,17 +371,23 @@ func (m *Manager) SendSignal(contextID string, sig syscall.Signal) error {
 // Cleanup cleans up all contexts.
 func (m *Manager) Cleanup() {
 	m.mu.Lock()
-	defer m.mu.Unlock()
-
+	contexts := make([]*Context, 0, len(m.contexts))
 	for _, ctx := range m.contexts {
-		if m.supervisor != nil {
-			_ = m.supervisor.DeleteTransient(ctx.ID)
+		contexts = append(contexts, ctx)
+	}
+	m.contexts = make(map[string]*Context)
+	supervisor := m.supervisor
+	m.mu.Unlock()
+
+	for _, ctx := range contexts {
+		ctx.lifecycleMu.Lock()
+		if supervisor != nil {
+			_ = supervisor.DeleteTransient(ctx.ID)
 		} else {
 			_ = ctx.Stop()
 		}
+		ctx.lifecycleMu.Unlock()
 	}
-
-	m.contexts = make(map[string]*Context)
 }
 
 func (m *Manager) cleanupExpired() {
@@ -390,9 +410,8 @@ func (m *Manager) cleanupExpired() {
 // GetResourceUsage returns resource usage for a specific context.
 func (m *Manager) GetResourceUsage(contextID string) (*ContextResourceUsage, error) {
 	m.mu.RLock()
-	defer m.mu.RUnlock()
-
 	ctx, exists := m.contexts[contextID]
+	m.mu.RUnlock()
 	if !exists {
 		return nil, ErrContextNotFound
 	}
@@ -409,11 +428,10 @@ func (m *Manager) GetResourceUsage(contextID string) (*ContextResourceUsage, err
 
 // GetAllResourceUsage returns aggregated resource usage for the entire sandbox.
 func (m *Manager) GetAllResourceUsage() *SandboxResourceUsage {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
+	contexts := m.contextSnapshot()
 
 	result := &SandboxResourceUsage{
-		Contexts: make([]ContextResourceUsage, 0, len(m.contexts)),
+		Contexts: make([]ContextResourceUsage, 0, len(contexts)),
 	}
 
 	if containerStats, err := process.GetContainerResourceUsage(); err == nil {
@@ -422,7 +440,7 @@ func (m *Manager) GetAllResourceUsage() *SandboxResourceUsage {
 		result.ContainerMemoryWorkingSet = containerStats.WorkingSet
 	}
 
-	for _, ctx := range m.contexts {
+	for _, ctx := range contexts {
 		usage := ctx.ResourceUsage()
 
 		ctxUsage := ContextResourceUsage{
@@ -454,4 +472,21 @@ func (m *Manager) GetAllResourceUsage() *SandboxResourceUsage {
 	}
 
 	return result
+}
+
+func (m *Manager) contextSnapshot() []*Context {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	contexts := make([]*Context, 0, len(m.contexts))
+	for _, ctx := range m.contexts {
+		contexts = append(contexts, ctx)
+	}
+	return contexts
+}
+
+func (m *Manager) hasContext(id string, ctx *Context) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.contexts[id] == ctx
 }

--- a/manager/procd/pkg/context/manager_test.go
+++ b/manager/procd/pkg/context/manager_test.go
@@ -267,6 +267,99 @@ func TestManager_DeleteContext(t *testing.T) {
 	m.Cleanup()
 }
 
+func TestManager_DeleteContextDoesNotHoldRegistryLockWhileStopping(t *testing.T) {
+	m := NewManager()
+	proc := newBlockingStopProcess("blocking-stop")
+	ctx := &Context{ID: "ctx-blocking", MainProcess: proc}
+	m.contexts[ctx.ID] = ctx
+
+	deleteDone := make(chan error, 1)
+	go func() {
+		deleteDone <- m.DeleteContext(ctx.ID)
+	}()
+
+	select {
+	case <-proc.stopStarted:
+	case <-time.After(time.Second):
+		t.Fatal("DeleteContext did not start stopping the process")
+	}
+
+	listDone := make(chan int, 1)
+	go func() {
+		listDone <- len(m.ListContexts())
+	}()
+
+	select {
+	case count := <-listDone:
+		if count != 0 {
+			t.Fatalf("ListContexts() count = %d, want deleted context hidden", count)
+		}
+	case <-time.After(200 * time.Millisecond):
+		close(proc.releaseStop)
+		<-deleteDone
+		t.Fatal("ListContexts blocked behind process shutdown")
+	}
+
+	close(proc.releaseStop)
+	if err := <-deleteDone; err != nil {
+		t.Fatalf("DeleteContext() failed = %v", err)
+	}
+}
+
+func TestManager_DeleteContextRestoresOwnershipWhenStopFails(t *testing.T) {
+	m := NewManager()
+	proc := newBlockingStopProcess("failed-stop")
+	proc.stopErr = process.ErrProcessStopTimeout
+	close(proc.releaseStop)
+	ctx := &Context{ID: "ctx-failed-stop", MainProcess: proc}
+	m.contexts[ctx.ID] = ctx
+
+	if err := m.DeleteContext(ctx.ID); err != process.ErrProcessStopTimeout {
+		t.Fatalf("DeleteContext() error = %v, want %v", err, process.ErrProcessStopTimeout)
+	}
+	got, err := m.GetContext(ctx.ID)
+	if err != nil {
+		t.Fatalf("GetContext() failed after stop error: %v", err)
+	}
+	if got != ctx {
+		t.Fatal("GetContext() returned a different context after stop error")
+	}
+}
+
+type blockingStopProcess struct {
+	*process.BaseProcess
+	stopStarted chan struct{}
+	releaseStop chan struct{}
+	stopOnce    sync.Once
+	stopErr     error
+}
+
+func newBlockingStopProcess(id string) *blockingStopProcess {
+	base := process.NewBaseProcess(id, process.ProcessTypeCMD, process.ProcessConfig{Type: process.ProcessTypeCMD})
+	base.SetState(process.ProcessStateRunning)
+	return &blockingStopProcess{
+		BaseProcess: base,
+		stopStarted: make(chan struct{}),
+		releaseStop: make(chan struct{}),
+	}
+}
+
+func (p *blockingStopProcess) Start() error {
+	p.SetState(process.ProcessStateRunning)
+	return nil
+}
+
+func (p *blockingStopProcess) Stop() error {
+	p.stopOnce.Do(func() { close(p.stopStarted) })
+	<-p.releaseStop
+	p.SetState(process.ProcessStateStopped)
+	return p.stopErr
+}
+
+func (p *blockingStopProcess) Restart() error {
+	return nil
+}
+
 // TestManager_ListContexts tests listing all contexts.
 func TestManager_ListContexts(t *testing.T) {
 	m := NewManager()

--- a/manager/procd/pkg/http/lifecycle_barrier.go
+++ b/manager/procd/pkg/http/lifecycle_barrier.go
@@ -2,12 +2,15 @@ package http
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
+	"go.uber.org/zap"
 )
 
 const defaultLifecycleBarrierWaitTimeout = 30 * time.Second
@@ -18,7 +21,15 @@ type lifecycleBarrier struct {
 	active            bool
 	epoch             int64
 	runtimeGeneration int64
-	inFlight          int
+	nextOperationID   uint64
+	inFlight          map[uint64]lifecycleBarrierOperation
+}
+
+type lifecycleBarrierOperation struct {
+	ID        uint64    `json:"id"`
+	Method    string    `json:"method"`
+	Path      string    `json:"path"`
+	StartedAt time.Time `json:"started_at"`
 }
 
 type lifecycleBarrierRequest struct {
@@ -29,14 +40,15 @@ type lifecycleBarrierRequest struct {
 }
 
 type lifecycleBarrierResponse struct {
-	Active            bool  `json:"active"`
-	Epoch             int64 `json:"epoch,omitempty"`
-	RuntimeGeneration int64 `json:"runtime_generation,omitempty"`
-	InFlight          int   `json:"in_flight"`
+	Active            bool                        `json:"active"`
+	Epoch             int64                       `json:"epoch,omitempty"`
+	RuntimeGeneration int64                       `json:"runtime_generation,omitempty"`
+	InFlight          int                         `json:"in_flight"`
+	Operations        []lifecycleBarrierOperation `json:"operations,omitempty"`
 }
 
 func newLifecycleBarrier() *lifecycleBarrier {
-	b := &lifecycleBarrier{}
+	b := &lifecycleBarrier{inFlight: make(map[uint64]lifecycleBarrierOperation)}
 	b.cond = sync.NewCond(&b.mu)
 	return b
 }
@@ -50,7 +62,7 @@ func (b *lifecycleBarrier) middleware(next http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 			return
 		}
-		release, ok := b.enter()
+		release, ok := b.enter(r)
 		if !ok {
 			_ = spec.WriteError(w, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox lifecycle barrier is active")
 			return
@@ -60,20 +72,30 @@ func (b *lifecycleBarrier) middleware(next http.Handler) http.Handler {
 	})
 }
 
-func (b *lifecycleBarrier) enter() (func(), bool) {
+func (b *lifecycleBarrier) enter(r *http.Request) (func(), bool) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if b.active {
 		return nil, false
 	}
-	b.inFlight++
+	if b.inFlight == nil {
+		b.inFlight = make(map[uint64]lifecycleBarrierOperation)
+	}
+	b.nextOperationID++
+	operationID := b.nextOperationID
+	operation := lifecycleBarrierOperation{ID: operationID, StartedAt: time.Now().UTC()}
+	if r != nil {
+		operation.Method = r.Method
+		if r.URL != nil {
+			operation.Path = r.URL.Path
+		}
+	}
+	b.inFlight[operationID] = operation
 	return func() {
 		b.mu.Lock()
 		defer b.mu.Unlock()
-		if b.inFlight > 0 {
-			b.inFlight--
-		}
-		if b.inFlight == 0 {
+		delete(b.inFlight, operationID)
+		if len(b.inFlight) == 0 {
 			b.cond.Broadcast()
 		}
 	}, true
@@ -122,20 +144,22 @@ func (b *lifecycleBarrier) setActive(r *http.Request, req lifecycleBarrierReques
 	}()
 	defer close(done)
 
-	for b.inFlight > 0 {
+	for len(b.inFlight) > 0 {
 		if err := r.Context().Err(); err != nil {
+			waitErr := b.waitErrorLocked(err)
 			b.active = false
 			b.epoch = 0
 			b.runtimeGeneration = 0
 			b.cond.Broadcast()
-			return b.snapshotLocked(), err
+			return b.snapshotLocked(), waitErr
 		}
 		if !deadline.IsZero() && time.Now().After(deadline) {
+			waitErr := b.waitErrorLocked(http.ErrHandlerTimeout)
 			b.active = false
 			b.epoch = 0
 			b.runtimeGeneration = 0
 			b.cond.Broadcast()
-			return b.snapshotLocked(), http.ErrHandlerTimeout
+			return b.snapshotLocked(), waitErr
 		}
 		b.cond.Wait()
 	}
@@ -143,12 +167,28 @@ func (b *lifecycleBarrier) setActive(r *http.Request, req lifecycleBarrierReques
 }
 
 func (b *lifecycleBarrier) snapshotLocked() lifecycleBarrierResponse {
+	operations := make([]lifecycleBarrierOperation, 0, len(b.inFlight))
+	for _, operation := range b.inFlight {
+		operations = append(operations, operation)
+	}
+	sort.Slice(operations, func(i, j int) bool { return operations[i].ID < operations[j].ID })
 	return lifecycleBarrierResponse{
 		Active:            b.active,
 		Epoch:             b.epoch,
 		RuntimeGeneration: b.runtimeGeneration,
-		InFlight:          b.inFlight,
+		InFlight:          len(operations),
+		Operations:        operations,
 	}
+}
+
+func (b *lifecycleBarrier) waitErrorLocked(cause error) error {
+	operations := b.snapshotLocked().Operations
+	details := make([]string, 0, len(operations))
+	now := time.Now()
+	for _, operation := range operations {
+		details = append(details, fmt.Sprintf("%s %s active for %s", operation.Method, operation.Path, now.Sub(operation.StartedAt).Round(time.Millisecond)))
+	}
+	return fmt.Errorf("%w waiting for %d runtime operation(s): %s", cause, len(operations), strings.Join(details, ", "))
 }
 
 func (s *Server) lifecycleBarrierHandler(w http.ResponseWriter, r *http.Request) {
@@ -159,6 +199,13 @@ func (s *Server) lifecycleBarrierHandler(w http.ResponseWriter, r *http.Request)
 	}
 	resp, err := s.barrier.setActive(r, req)
 	if err != nil {
+		if s.logger != nil {
+			s.logger.Warn("Lifecycle barrier wait failed",
+				zap.Error(err),
+				zap.Int("in_flight", resp.InFlight),
+				zap.Any("operations", resp.Operations),
+			)
+		}
 		_ = spec.WriteError(w, http.StatusServiceUnavailable, spec.CodeUnavailable, err.Error())
 		return
 	}

--- a/manager/procd/pkg/http/lifecycle_barrier_test.go
+++ b/manager/procd/pkg/http/lifecycle_barrier_test.go
@@ -3,6 +3,7 @@ package http
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -23,5 +24,31 @@ func TestProcdRequestMutatesRuntimeBlocksMutatingAPIRequests(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/files/write", nil)
 	if !procdRequestMutatesRuntime(req) {
 		t.Fatal("procdRequestMutatesRuntime(write) = false, want true")
+	}
+}
+
+func TestLifecycleBarrierReportsBlockingOperation(t *testing.T) {
+	barrier := newLifecycleBarrier()
+	request := httptest.NewRequest(http.MethodDelete, "/api/v1/contexts/ctx-stuck", nil)
+	release, ok := barrier.enter(request)
+	if !ok {
+		t.Fatal("enter() rejected request before barrier activation")
+	}
+	defer release()
+
+	barrierRequest := httptest.NewRequest(http.MethodPut, "/api/v1/lifecycle/barrier", nil)
+	response, err := barrier.setActive(barrierRequest, lifecycleBarrierRequest{Active: true, WaitTimeoutMS: 20})
+	if err == nil {
+		t.Fatal("setActive() succeeded with a blocking operation")
+	}
+	if !strings.Contains(err.Error(), "DELETE /api/v1/contexts/ctx-stuck") {
+		t.Fatalf("setActive() error = %q, want blocking operation details", err)
+	}
+	if response.InFlight != 1 || len(response.Operations) != 1 {
+		t.Fatalf("setActive() response = %#v, want one blocking operation", response)
+	}
+	operation := response.Operations[0]
+	if operation.Method != http.MethodDelete || operation.Path != "/api/v1/contexts/ctx-stuck" {
+		t.Fatalf("blocking operation = %#v", operation)
 	}
 }

--- a/manager/procd/pkg/process/cmd/cmd.go
+++ b/manager/procd/pkg/process/cmd/cmd.go
@@ -110,17 +110,18 @@ func (c *CMD) prepareExecCmd(ctx context.Context) *exec.Cmd {
 
 // Stop stops the command execution.
 func (c *CMD) Stop() error {
-	if !c.IsRunning() {
-		return nil
-	}
+	return c.StopWithOptions(process.StopOptions{})
+}
 
+// StopWithOptions stops the command with bounded graceful and forced termination.
+func (c *CMD) StopWithOptions(options process.StopOptions) error {
 	ptyRunner, directRunner := c.runners()
 	if ptyRunner != nil {
-		return ptyRunner.Stop()
+		return ptyRunner.StopWithOptions(options)
 	}
 
 	if directRunner != nil {
-		return directRunner.Stop()
+		return directRunner.StopWithOptions(options)
 	}
 
 	return nil

--- a/manager/procd/pkg/process/direct_runner.go
+++ b/manager/procd/pkg/process/direct_runner.go
@@ -26,6 +26,7 @@ type DirectRunner struct {
 	stderrBytes  int64
 	stdoutChunks int64
 	stderrChunks int64
+	stopMu       sync.Mutex
 }
 
 var _ OutputProvider = (*DirectRunner)(nil)
@@ -110,25 +111,18 @@ func (r *DirectRunner) Start(cmd *exec.Cmd) error {
 
 // Stop terminates the direct process.
 func (r *DirectRunner) Stop() error {
-	if !r.base.IsRunning() {
-		return nil
-	}
+	return r.StopWithOptions(StopOptions{})
+}
 
-	if r.onStop != nil {
-		r.onStop()
-	}
+// StopWithOptions terminates the direct process group without unbounded waits.
+func (r *DirectRunner) StopWithOptions(options StopOptions) error {
+	r.stopMu.Lock()
+	defer r.stopMu.Unlock()
 
-	if r.cmd != nil && r.cmd.Process != nil {
-		if err := r.cmd.Process.Signal(syscall.SIGTERM); err != nil {
-			_ = r.cmd.Process.Kill()
-		}
-	}
-	_ = r.base.CloseInput()
-
-	r.base.SetState(ProcessStateStopped)
+	_ = r.base.forceCloseInput()
+	err := terminateProcess(r.base, r.onStop, options)
 	r.base.CloseOutput()
-
-	return nil
+	return err
 }
 
 // GetOutput returns the captured stdout and stderr.
@@ -187,7 +181,7 @@ func (r *DirectRunner) monitorProcess() {
 		Config:        r.base.GetConfig(),
 	})
 
-	_ = r.base.CloseInput()
+	_ = r.base.forceCloseInput()
 	r.base.CloseOutput()
 }
 

--- a/manager/procd/pkg/process/errors.go
+++ b/manager/procd/pkg/process/errors.go
@@ -59,4 +59,13 @@ var (
 
 	// ErrInputBufferFull is returned when the input queue is full.
 	ErrInputBufferFull = errors.New("input buffer full")
+
+	// ErrInputCloseTimeout is returned when queued input cannot be drained before closing.
+	ErrInputCloseTimeout = errors.New("input close timed out")
+
+	// ErrProcessStopTimeout is returned when a process survives graceful and forced termination.
+	ErrProcessStopTimeout = errors.New("process stop timed out")
+
+	// ErrProcessIOCloseTimeout is returned when process I/O does not drain after termination.
+	ErrProcessIOCloseTimeout = errors.New("process I/O close timed out")
 )

--- a/manager/procd/pkg/process/process.go
+++ b/manager/procd/pkg/process/process.go
@@ -1,6 +1,7 @@
 package process
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -10,6 +11,8 @@ import (
 
 	"github.com/creack/pty"
 )
+
+const defaultInputCloseTimeout = 5 * time.Second
 
 // ProcessType defines the type of process.
 type ProcessType string
@@ -171,6 +174,7 @@ type Process interface {
 
 	// Lifecycle
 	Start() error
+	// Stop must terminate the process tree and return without unbounded waits.
 	Stop() error
 	Restart() error
 	IsRunning() bool
@@ -483,6 +487,10 @@ func (bp *BaseProcess) WriteInput(data []byte) error {
 
 // CloseInput closes the process stdin without stopping the process.
 func (bp *BaseProcess) CloseInput() error {
+	return bp.closeInput(defaultInputCloseTimeout)
+}
+
+func (bp *BaseProcess) closeInput(timeout time.Duration) error {
 	bp.mu.RLock()
 	input := bp.input
 	bp.mu.RUnlock()
@@ -499,18 +507,39 @@ func (bp *BaseProcess) CloseInput() error {
 		return input.Close()
 	default:
 	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
 	done := make(chan error, 1)
 	select {
 	case bp.inputQueue <- inputOperation{close: true, done: done}:
 	case <-bp.inputStop:
 		return nil
+	case <-timer.C:
+		return errors.Join(ErrInputCloseTimeout, bp.forceCloseInput())
 	}
 	select {
 	case err := <-done:
 		return err
 	case <-bp.inputStop:
 		return nil
+	case <-timer.C:
+		return errors.Join(ErrInputCloseTimeout, bp.forceCloseInput())
 	}
+}
+
+func (bp *BaseProcess) forceCloseInput() error {
+	bp.stopInputWriter()
+	bp.mu.Lock()
+	input := bp.input
+	bp.input = nil
+	if ptyFile, ok := input.(*os.File); ok && bp.pty == ptyFile {
+		bp.pty = nil
+	}
+	bp.mu.Unlock()
+	if input == nil {
+		return nil
+	}
+	return input.Close()
 }
 
 // ResizePTY resizes the attached PTY, if present.

--- a/manager/procd/pkg/process/process_test.go
+++ b/manager/procd/pkg/process/process_test.go
@@ -2,6 +2,7 @@
 package process
 
 import (
+	"errors"
 	"io"
 	"os"
 	"sync"
@@ -489,6 +490,25 @@ func TestBaseProcess_WriteInputFinished(t *testing.T) {
 	}
 
 	bp.stopInputWriter()
+}
+
+func TestBaseProcess_CloseInputBeforeReadyIsBounded(t *testing.T) {
+	bp := NewBaseProcess("not-ready", ProcessTypeREPL, ProcessConfig{Type: ProcessTypeREPL})
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	bp.SetPTY(w)
+
+	started := time.Now()
+	err = bp.closeInput(25 * time.Millisecond)
+	if !errors.Is(err, ErrInputCloseTimeout) {
+		t.Fatalf("closeInput() error = %v, want %v", err, ErrInputCloseTimeout)
+	}
+	if elapsed := time.Since(started); elapsed > 250*time.Millisecond {
+		t.Fatalf("closeInput() took %s, want a bounded close", elapsed)
+	}
 }
 
 // BenchmarkBaseProcess_StateRead benchmarks concurrent state reading.

--- a/manager/procd/pkg/process/pty_runner.go
+++ b/manager/procd/pkg/process/pty_runner.go
@@ -1,11 +1,11 @@
 package process
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/creack/pty"
@@ -21,6 +21,7 @@ type PTYRunner struct {
 	exitResolver func(error) (int, bool)
 
 	mu              sync.RWMutex
+	stopMu          sync.Mutex
 	readerDone      chan struct{}
 	closeOutputOnce sync.Once
 }
@@ -92,27 +93,22 @@ func (r *PTYRunner) Start(cmd *exec.Cmd, size *PTYSize) error {
 
 // Stop terminates the PTY-backed process.
 func (r *PTYRunner) Stop() error {
-	if !r.base.IsRunning() {
-		return nil
+	return r.StopWithOptions(StopOptions{})
+}
+
+// StopWithOptions terminates the PTY process group without unbounded waits.
+func (r *PTYRunner) StopWithOptions(options StopOptions) error {
+	r.stopMu.Lock()
+	defer r.stopMu.Unlock()
+	options = options.normalized()
+
+	_ = r.base.forceCloseInput()
+	stopErr := terminateProcess(r.base, r.onStop, options)
+	if !r.waitReaderDone(options.KillWait) {
+		stopErr = errors.Join(stopErr, ErrProcessIOCloseTimeout)
 	}
-
-	if r.onStop != nil {
-		r.onStop()
-	}
-
-	_ = r.base.CloseInput()
-
-	if r.cmd != nil && r.cmd.Process != nil {
-		if err := r.cmd.Process.Signal(syscall.SIGTERM); err != nil {
-			_ = r.cmd.Process.Kill()
-		}
-	}
-
-	r.waitReaderDone()
-	r.base.SetState(ProcessStateStopped)
 	r.closeOutput()
-
-	return nil
+	return stopErr
 }
 
 func (r *PTYRunner) readOutput(ptmx *os.File) {
@@ -194,8 +190,12 @@ func (r *PTYRunner) monitorProcess() {
 	})
 
 	r.base.stopInputWriter()
-	r.waitReaderDone()
-	_ = r.base.CloseInput()
+	if !r.waitReaderDone(defaultStopKillWait) {
+		_ = r.base.forceCloseInput()
+		r.waitReaderDone(defaultStopKillWait)
+	} else {
+		_ = r.base.forceCloseInput()
+	}
 	r.closeOutput()
 }
 
@@ -208,12 +208,20 @@ func (r *PTYRunner) markReaderDone() {
 	}
 }
 
-func (r *PTYRunner) waitReaderDone() {
+func (r *PTYRunner) waitReaderDone(timeout time.Duration) bool {
 	r.mu.RLock()
 	done := r.readerDone
 	r.mu.RUnlock()
-	if done != nil {
-		<-done
+	if done == nil {
+		return true
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-done:
+		return true
+	case <-timer.C:
+		return false
 	}
 }
 

--- a/manager/procd/pkg/process/pty_runner_test.go
+++ b/manager/procd/pkg/process/pty_runner_test.go
@@ -1,8 +1,12 @@
 package process
 
 import (
+	"errors"
+	"fmt"
+	"os"
 	"os/exec"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -26,6 +30,86 @@ func TestPTYRunner_FastCommandOutputReliableRepeat(t *testing.T) {
 		if !strings.Contains(output, "Hello, Sandbox0!") {
 			t.Fatalf("run %d: output = %q, want to contain message", i, output)
 		}
+	}
+}
+
+func TestPTYRunner_StopWithOptionsKillsTermIgnoringProcessGroup(t *testing.T) {
+	base := NewBaseProcess("pty-stop-test", ProcessTypeCMD, ProcessConfig{Type: ProcessTypeCMD})
+	runner := NewPTYRunner(base, nil, nil)
+	readyPath := t.TempDir() + "/ready"
+	cmd := exec.Command("/bin/sh", "-c", fmt.Sprintf("trap '' TERM; : > %q; while :; do sleep 30; done", readyPath))
+	if err := runner.Start(cmd, &PTYSize{Rows: 24, Cols: 80}); err != nil {
+		t.Fatalf("runner.Start() failed: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := os.Stat(readyPath); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			_ = syscall.Kill(-base.PID(), syscall.SIGKILL)
+			t.Fatal("term-ignoring process did not become ready")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	pid := base.PID()
+	started := time.Now()
+	err := runner.StopWithOptions(StopOptions{GracePeriod: 100 * time.Millisecond, KillWait: time.Second})
+	if err != nil {
+		t.Fatalf("StopWithOptions() failed: %v", err)
+	}
+	if elapsed := time.Since(started); elapsed > 2*time.Second {
+		t.Fatalf("StopWithOptions() took %s, want bounded termination", elapsed)
+	}
+
+	deadline = time.Now().Add(time.Second)
+	for {
+		err = syscall.Kill(-pid, 0)
+		if errors.Is(err, syscall.ESRCH) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("process group %d still exists after stop: %v", pid, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestPTYRunner_StopKillsChildrenAfterParentExits(t *testing.T) {
+	base := NewBaseProcess("pty-child-stop-test", ProcessTypeCMD, ProcessConfig{Type: ProcessTypeCMD})
+	runner := NewPTYRunner(base, nil, nil)
+	readyPath := t.TempDir() + "/ready"
+	script := fmt.Sprintf(`
+sh -c 'trap "" TERM; while :; do sleep 30; done' &
+trap 'exit 0' TERM
+: > %q
+while :; do sleep 30; done
+`, readyPath)
+	cmd := exec.Command("/bin/sh", "-c", script)
+	if err := runner.Start(cmd, &PTYSize{Rows: 24, Cols: 80}); err != nil {
+		t.Fatalf("runner.Start() failed: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := os.Stat(readyPath); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			_ = syscall.Kill(-base.PID(), syscall.SIGKILL)
+			t.Fatal("process tree did not become ready")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	pid := base.PID()
+	if err := runner.StopWithOptions(StopOptions{GracePeriod: 100 * time.Millisecond, KillWait: time.Second}); err != nil {
+		t.Fatalf("StopWithOptions() failed: %v", err)
+	}
+	if err := syscall.Kill(-pid, 0); !errors.Is(err, syscall.ESRCH) {
+		t.Fatalf("process group %d survived parent exit: %v", pid, err)
 	}
 }
 

--- a/manager/procd/pkg/process/repl/repl.go
+++ b/manager/procd/pkg/process/repl/repl.go
@@ -131,7 +131,12 @@ func (r *REPL) buildEnvVars(processConfig process.ProcessConfig) map[string]stri
 
 // Stop stops the REPL process.
 func (r *REPL) Stop() error {
-	return r.runner.Stop()
+	return r.StopWithOptions(process.StopOptions{})
+}
+
+// StopWithOptions stops the REPL with bounded graceful and forced termination.
+func (r *REPL) StopWithOptions(options process.StopOptions) error {
+	return r.runner.StopWithOptions(options)
 }
 func (r *REPL) WriteInput(data []byte) error {
 	return r.BaseProcess.WriteInput(data)

--- a/manager/procd/pkg/process/stop.go
+++ b/manager/procd/pkg/process/stop.go
@@ -1,0 +1,97 @@
+package process
+
+import (
+	"errors"
+	"syscall"
+	"time"
+)
+
+const (
+	defaultStopGracePeriod = 5 * time.Second
+	defaultStopKillWait    = 2 * time.Second
+)
+
+// StopOptions controls graceful process termination and forced-kill waiting.
+type StopOptions struct {
+	GracePeriod time.Duration
+	KillWait    time.Duration
+}
+
+func (o StopOptions) normalized() StopOptions {
+	if o.GracePeriod <= 0 {
+		o.GracePeriod = defaultStopGracePeriod
+	}
+	if o.KillWait <= 0 {
+		o.KillWait = defaultStopKillWait
+	}
+	return o
+}
+
+func terminateProcess(base *BaseProcess, onStop func(), options StopOptions) error {
+	options = options.normalized()
+	if onStop != nil {
+		defer onStop()
+	}
+
+	switch base.State() {
+	case ProcessStateCreated, ProcessStateStopped, ProcessStateKilled, ProcessStateCrashed:
+		if !processGroupExists(base.PID()) {
+			return nil
+		}
+	case ProcessStatePaused:
+		_ = signalProcessGroup(base.PID(), syscall.SIGCONT)
+	}
+
+	pid := base.PID()
+	termErr := signalProcessGroup(pid, syscall.SIGTERM)
+	if waitForProcessTreeFinish(base, pid, options.GracePeriod) {
+		return nil
+	}
+
+	killErr := signalProcessGroup(pid, syscall.SIGKILL)
+	if waitForProcessTreeFinish(base, pid, options.KillWait) {
+		return nil
+	}
+	return errors.Join(ErrProcessStopTimeout, termErr, killErr)
+}
+
+func waitForProcessTreeFinish(base *BaseProcess, pid int, timeout time.Duration) bool {
+	if base.IsFinished() && !processGroupExists(pid) {
+		return true
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-timer.C:
+			return base.IsFinished() && !processGroupExists(pid)
+		case <-ticker.C:
+			if base.IsFinished() && !processGroupExists(pid) {
+				return true
+			}
+		}
+	}
+}
+
+func signalProcessGroup(pid int, signal syscall.Signal) error {
+	if pid <= 0 {
+		return ErrProcessNotRunning
+	}
+	if err := syscall.Kill(-pid, signal); err == nil {
+		return nil
+	}
+	if err := syscall.Kill(pid, signal); err != nil {
+		return err
+	}
+	return nil
+}
+
+func processGroupExists(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	err := syscall.Kill(-pid, 0)
+	return err == nil || errors.Is(err, syscall.EPERM)
+}

--- a/manager/procd/pkg/session/supervisor.go
+++ b/manager/procd/pkg/session/supervisor.go
@@ -149,16 +149,21 @@ func (s *Supervisor) StartTransient(id string, proc process.Process) error {
 
 // DeleteTransient stops and removes a transient process.
 func (s *Supervisor) DeleteTransient(id string) error {
-	s.mu.Lock()
+	s.mu.RLock()
 	proc, exists := s.transients[id]
-	if exists {
-		delete(s.transients, id)
-	}
-	s.mu.Unlock()
+	s.mu.RUnlock()
 	if !exists {
 		return ErrSessionNotFound
 	}
-	return proc.Stop()
+	if err := proc.Stop(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	if s.transients[id] == proc {
+		delete(s.transients, id)
+	}
+	s.mu.Unlock()
+	return nil
 }
 
 // RestartTransient restarts a transient process without changing its identity.


### PR DESCRIPTION
## Summary

- keep context registry locks out of process start, stop, restart, pause, resume, cleanup, and resource reads
- make PTY and direct process shutdown bounded, process-group-aware, and safe when stdin or readers do not drain
- retain context and transient ownership when shutdown fails so cleanup can be retried
- report method, path, and age for requests blocking the lifecycle barrier

## Incident

A terminal context DELETE remained in flight while holding the context manager write lock. The lifecycle barrier could not drain, so sandbox pause retried every minute and dashboard pause timed out. The exact runner wait was not observable, and both PTY reader and input shutdown had unbounded waits.

## Tests

- `go test -buildvcs=false -race ./manager/procd/... -count=1`
- `go vet -buildvcs=false ./manager/procd/...`
- repeated TERM-ignoring PTY and parent-exit/child-survival process-group tests
- regression coverage for registry responsiveness during blocked stop and ownership restoration after failed stop

## Remote validation

Validated on the persistent Aliyun Singapore kind environment with gVisor-rootfs:

- rebuilt and loaded `sandbox0ai/infra:latest` plus `sandbox0ai/infra:latest-procd-bin`
- verified sandbox `/proc/1/exe` SHA256 matches the PR-built `bin/procd`
- ran a TERM/HUP-resistant PTY context DELETE concurrently with sandbox pause: DELETE returned 200 in 5.132s and the sandbox reached `paused` without a lifecycle barrier retry
- created and deleted 20 bash REPL contexts; every DELETE returned 200, maximum latency was 5.023s, and the final context list was empty
- completed a second pause in 1.036s, resumed twice, and verified the replacement pod still used the PR procd binary with no surviving child processes
- manager log count for `activate procd lifecycle barrier` failures: 0
