### PR TITLE
Document builtin image pinning for self-hosted deployments

### DIFF
--- a/docs/self-hosted/configuration/page.mdx
+++ b/docs/self-hosted/configuration/page.mdx
@@ -29,6 +29,30 @@ In local-password mode it bootstraps the first admin credentials; in OIDC-only m
 
 When `spec.builtinTemplates` is omitted, infra-operator seeds public builtin templates for `default`, `openclaw`, `hermes`, and `browser`. Set `spec.builtinTemplates` explicitly when you want to pin images, adjust pools, disable one of the builtins, or provide a full template `spec` for a runtime-specific setup. Set it to `[]` to remove all operator-managed builtin templates.
 
+## Pin Builtin Images for Predictable Startup
+
+The self-hosted `openclaw`, `hermes`, and `browser` presets use upstream mutable `latest` tags by default. Sandbox0 sets the effective main-container pull policy to `IfNotPresent` unless a system template overrides it. A claim on a node that already has the image does not download it again, but a new or cache-miss node resolves the tag and pulls the current image. That pull can add substantial cold-start latency for large images, and different nodes can keep different digests for the same mutable tag.
+
+For production self-hosted deployments, replace the complete builtin template list and pin each mutable image to a reviewed digest:
+
+```yaml
+spec:
+    builtinTemplates:
+        - templateId: default
+        - templateId: openclaw
+          image: ghcr.io/openclaw/openclaw@sha256:<openclaw-digest>
+        - templateId: hermes
+          image: nousresearch/hermes-agent@sha256:<hermes-digest>
+        - templateId: browser
+          image: ghcr.io/steel-dev/steel-browser@sha256:<browser-digest>
+```
+
+`spec.builtinTemplates` has replacement semantics, so omitting an entry removes that operator-managed builtin. A version tag is easier to read than a digest but remains mutable if its publisher retags it. A digest is the immutable choice.
+
+Pinning makes the runtime version deterministic; it does not eliminate the first pull on an empty node. If image-pull latency is part of your cold-start budget, preload the pinned digests into node images or use a node-level pre-puller before admitting sandbox workloads.
+
+Sandbox0 Cloud handles the mutable-tag policy at the platform layer: managed-region configuration pins these images by digest and rolls upstream digest changes through deployment automation. Cloud users therefore do not maintain these pins themselves. A genuinely cold node can still need a missing pinned image, but cache and prewarming operations remain the managed platform's responsibility rather than part of the customer template configuration.
+
 ## Deployment Profiles
 
 | Profile | Typical fields | Use when |

--- a/docs/use-cases/page.mdx
+++ b/docs/use-cases/page.mdx
@@ -49,6 +49,10 @@ Operators can pin images, tune pools, or remove a template by setting `Sandbox0I
 | `hermes` | `nousresearch/hermes-agent:latest` |
 | `browser` | `ghcr.io/steel-dev/steel-browser:latest` |
 
+<Callout variant="warning">
+These are self-hosted convenience defaults, not immutable production pins. Sandbox0 uses `IfNotPresent`, so cached nodes reuse their local image; new or cache-miss nodes pull whichever digest `latest` currently names, which can add cold-start latency and create version drift between nodes. Pin reviewed digests in production. Sandbox0 Cloud manages digest pins and their rollout at the platform layer. See [Pin Builtin Images for Predictable Startup](/docs/self-hosted/configuration#pin-builtin-images-for-predictable-startup).
+</Callout>
+
 ## Lifecycle Choice
 
 The examples in this section deliberately do not set `ttl` or `hard_ttl`.

--- a/manager/pkg/apis/sandbox0/v1alpha1/helpers_test.go
+++ b/manager/pkg/apis/sandbox0/v1alpha1/helpers_test.go
@@ -202,6 +202,21 @@ manager_image: sandbox0/manager:test
 	}
 }
 
+func TestBuildPodSpecUsesIfNotPresentForMainContainerByDefault(t *testing.T) {
+	configPath := writeManagerConfig(t, `
+manager_image: sandbox0/manager:test
+`)
+	t.Setenv("CONFIG_PATH", configPath)
+
+	spec := BuildPodSpec(newTestTemplate())
+	if len(spec.Containers) == 0 {
+		t.Fatal("expected at least one container")
+	}
+	if spec.Containers[0].ImagePullPolicy != corev1.PullIfNotPresent {
+		t.Fatalf("main container image pull policy = %q, want %q", spec.Containers[0].ImagePullPolicy, corev1.PullIfNotPresent)
+	}
+}
+
 func TestBuildPodSpecAppliesMainContainerSecurityContext(t *testing.T) {
 	configPath := writeManagerConfig(t, `
 manager_image: sandbox0/manager:test


### PR DESCRIPTION
Summary:
- explain that the self-hosted OpenClaw, Hermes, and browser defaults use mutable latest tags
- document the actual IfNotPresent behavior: cached claims reuse the local image, while new or cache-miss nodes pull and may add cold-start latency
- show a complete digest-pinned builtinTemplates replacement list and explain version drift, preloading, and first-pull limits
- distinguish customer-managed self-hosted pins from Sandbox0 Cloud managed digest rollout
- add a regression test for the documented main-container pull-policy default

Companion infrastructure PR:
- sandbox0-ai/sandbox0-infra#92

Validation:
- GOTOOLCHAIN=go1.25.0+auto go test ./manager/pkg/apis/sandbox0/v1alpha1
- both changed MDX pages compile with @mdx-js/mdx
- git diff --check