### PR TITLE
Warn when Cilium bypasses netd interception

### DIFF
--- a/docs/self-hosted/configuration/page.mdx
+++ b/docs/self-hosted/configuration/page.mdx
@@ -652,6 +652,10 @@ The reference below is generated from the `Sandbox0Infra` CRD schema produced by
 - Prefer external PostgreSQL and external object storage for serious deployments.
 - Enable `storageProxy` only when you need volume and snapshot features.
 - Enable `netd` only on Linux nodes and only when you need network policy enforcement.
+- When using Cilium, set `bpf.hostLegacyRouting=true` so sandbox TCP/UDP traffic reaches netd's
+  iptables/TPROXY path. For ACK Terway, add `--enable-host-legacy-routing=true` to `cilium_args`.
+  Netd logs a warning when `kube-system/cilium-config` or Terway's `kube-system/eni-config`
+  confirms that BPF host routing can bypass enforcement and network audit.
 - Use `sandboxNodePlacement` to keep sandbox workloads and node-local sandbox services on the same node set.
 - Treat `sandbox0.ai/data-plane-ready` as operator-owned; use your own labels under `sandboxNodePlacement` and let `infra-operator` manage readiness.
 - If sandbox workloads use `gvisor` or `kata`, keep `services.netd.runtimeClassName` on a host-compatible runtime such as the cluster default runtime.

--- a/infra-operator/internal/controller/pkg/rbac/rbac.go
+++ b/infra-operator/internal/controller/pkg/rbac/rbac.go
@@ -121,6 +121,12 @@ func (r *Reconciler) ReconcileNetdRBAC(ctx context.Context, infra *infrav1alpha1
 			Verbs:     []string{"get", "list", "watch", "patch"},
 		},
 		{
+			APIGroups:     []string{""},
+			Resources:     []string{"configmaps"},
+			ResourceNames: []string{"cilium-config", "eni-config"},
+			Verbs:         []string{"get"},
+		},
+		{
 			APIGroups: []string{"discovery.k8s.io"},
 			Resources: []string{"endpointslices"},
 			Verbs:     []string{"get", "list", "watch"},

--- a/infra-operator/internal/controller/pkg/rbac/rbac_test.go
+++ b/infra-operator/internal/controller/pkg/rbac/rbac_test.go
@@ -127,6 +127,37 @@ func TestReconcileManagerRBACIncludesPodLogsReadPermission(t *testing.T) {
 	assert.True(t, found, "expected manager cluster role to include pods/log read permission")
 }
 
+func TestReconcileNetdRBACLimitsCNIConfigMapRead(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, rbacv1.AddToScheme(scheme))
+	require.NoError(t, infrav1alpha1.AddToScheme(scheme))
+
+	infra := &infrav1alpha1.Sandbox0Infra{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "sandbox0-system",
+		},
+	}
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(infra).Build()
+	reconciler := NewReconciler(&common.ResourceManager{Client: client, Scheme: scheme})
+
+	require.NoError(t, reconciler.ReconcileNetdRBAC(context.Background(), infra))
+
+	role := &rbacv1.ClusterRole{}
+	require.NoError(t, client.Get(context.Background(), types.NamespacedName{Name: "demo-netd"}, role))
+
+	for _, rule := range role.Rules {
+		if !contains(rule.APIGroups, "") || !contains(rule.Resources, "configmaps") {
+			continue
+		}
+		assert.ElementsMatch(t, []string{"get"}, rule.Verbs)
+		assert.ElementsMatch(t, []string{"cilium-config", "eni-config"}, rule.ResourceNames)
+		return
+	}
+	t.Fatal("expected netd cluster role to include limited CNI ConfigMap read permission")
+}
+
 func TestReconcileCtldRBACIncludesPodReadPermissions(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))

--- a/netd/pkg/daemon/cni_compatibility.go
+++ b/netd/pkg/daemon/cni_compatibility.go
@@ -1,0 +1,168 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	cniConfigNamespace           = "kube-system"
+	ciliumConfigMapName          = "cilium-config"
+	terwayConfigMapName          = "eni-config"
+	terwayCNIConfigKey           = "10-terway.conf"
+	ciliumHostLegacyRoutingKey   = "enable-host-legacy-routing"
+	cniCompatibilityCheckTimeout = 5 * time.Second
+)
+
+type ciliumHostRoutingStatus struct {
+	CNI               string
+	ConfigMap         string
+	HostLegacyRouting bool
+}
+
+type terwayCNIConfig struct {
+	Type                  string `json:"type"`
+	NetworkPolicyProvider string `json:"network_policy_provider"`
+	ENIIPVirtualType      string `json:"eniip_virtual_type"`
+	CiliumArgs            string `json:"cilium_args"`
+}
+
+// warnIfCiliumMayBypassNetd emits one startup warning when the installed CNI
+// configuration can route sandbox traffic around netd's host-netfilter rules.
+func warnIfCiliumMayBypassNetd(ctx context.Context, client kubernetes.Interface, nodeName string, logger *zap.Logger) {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	checkCtx, cancel := context.WithTimeout(ctx, cniCompatibilityCheckTimeout)
+	defer cancel()
+
+	status, err := detectCiliumHostRouting(checkCtx, client)
+	if err != nil {
+		logger.Warn("Unable to verify Cilium host-routing compatibility",
+			zap.String("node", nodeName),
+			zap.Error(err),
+		)
+		return
+	}
+	if status == nil || status.HostLegacyRouting {
+		return
+	}
+
+	logger.Warn("Cilium is configured without host legacy routing; netd iptables interception may be bypassed",
+		zap.String("node", nodeName),
+		zap.String("cni", status.CNI),
+		zap.String("config_map", status.ConfigMap),
+		zap.Bool("host_legacy_routing", false),
+		zap.String("required_setting", ciliumHostLegacyRoutingKey+"=true"),
+		zap.String("impact", "sandbox network policy and audit may be incomplete"),
+	)
+}
+
+// detectCiliumHostRouting reads the standard Cilium and ACK Terway config maps.
+// A missing host-legacy setting means Cilium's default BPF host-routing mode.
+func detectCiliumHostRouting(ctx context.Context, client kubernetes.Interface) (*ciliumHostRoutingStatus, error) {
+	if client == nil {
+		return nil, fmt.Errorf("kubernetes client is nil")
+	}
+	configMaps := client.CoreV1().ConfigMaps(cniConfigNamespace)
+
+	ciliumConfig, err := configMaps.Get(ctx, ciliumConfigMapName, metav1.GetOptions{})
+	if err == nil {
+		return standardCiliumHostRouting(ciliumConfig)
+	}
+	if !apierrors.IsNotFound(err) {
+		return nil, fmt.Errorf("get configmap %s/%s: %w", cniConfigNamespace, ciliumConfigMapName, err)
+	}
+
+	terwayConfig, err := configMaps.Get(ctx, terwayConfigMapName, metav1.GetOptions{})
+	if err == nil {
+		return terwayCiliumHostRouting(terwayConfig)
+	}
+	if !apierrors.IsNotFound(err) {
+		return nil, fmt.Errorf("get configmap %s/%s: %w", cniConfigNamespace, terwayConfigMapName, err)
+	}
+
+	return nil, nil
+}
+
+func standardCiliumHostRouting(configMap *corev1.ConfigMap) (*ciliumHostRoutingStatus, error) {
+	hostLegacyRouting := false
+	if raw, ok := configMap.Data[ciliumHostLegacyRoutingKey]; ok {
+		parsed, err := strconv.ParseBool(strings.TrimSpace(raw))
+		if err != nil {
+			return nil, fmt.Errorf("parse %s in configmap %s/%s: %w", ciliumHostLegacyRoutingKey, configMap.Namespace, configMap.Name, err)
+		}
+		hostLegacyRouting = parsed
+	}
+	return &ciliumHostRoutingStatus{
+		CNI:               "cilium",
+		ConfigMap:         configMap.Namespace + "/" + configMap.Name,
+		HostLegacyRouting: hostLegacyRouting,
+	}, nil
+}
+
+func terwayCiliumHostRouting(configMap *corev1.ConfigMap) (*ciliumHostRoutingStatus, error) {
+	raw, ok := configMap.Data[terwayCNIConfigKey]
+	if !ok {
+		return nil, nil
+	}
+
+	var config terwayCNIConfig
+	if err := json.Unmarshal([]byte(raw), &config); err != nil {
+		return nil, fmt.Errorf("parse %s in configmap %s/%s: %w", terwayCNIConfigKey, configMap.Namespace, configMap.Name, err)
+	}
+	if config.Type != "terway" {
+		return nil, nil
+	}
+
+	hostLegacyRouting, hostLegacyConfigured, err := parseCiliumBoolArg(config.CiliumArgs, ciliumHostLegacyRoutingKey)
+	if err != nil {
+		return nil, fmt.Errorf("parse cilium_args in configmap %s/%s: %w", configMap.Namespace, configMap.Name, err)
+	}
+	usesCilium := config.NetworkPolicyProvider == "ebpf" || config.ENIIPVirtualType == "datapathv2" || hostLegacyConfigured
+	if !usesCilium {
+		return nil, nil
+	}
+
+	return &ciliumHostRoutingStatus{
+		CNI:               "terway-cilium",
+		ConfigMap:         configMap.Namespace + "/" + configMap.Name,
+		HostLegacyRouting: hostLegacyRouting,
+	}, nil
+}
+
+func parseCiliumBoolArg(args, name string) (value bool, found bool, err error) {
+	for _, part := range strings.Split(args, "--") {
+		fields := strings.Fields(part)
+		if len(fields) == 0 {
+			continue
+		}
+		arg := fields[0]
+		if arg == name {
+			value = true
+			found = true
+			continue
+		}
+		prefix := name + "="
+		if !strings.HasPrefix(arg, prefix) {
+			continue
+		}
+		parsed, parseErr := strconv.ParseBool(strings.TrimPrefix(arg, prefix))
+		if parseErr != nil {
+			return false, true, parseErr
+		}
+		value = parsed
+		found = true
+	}
+	return value, found, nil
+}

--- a/netd/pkg/daemon/cni_compatibility_test.go
+++ b/netd/pkg/daemon/cni_compatibility_test.go
@@ -1,0 +1,163 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestDetectCiliumHostRouting(t *testing.T) {
+	tests := []struct {
+		name       string
+		objects    []runtime.Object
+		wantCNI    string
+		wantLegacy bool
+		wantNil    bool
+		wantErr    bool
+	}{
+		{
+			name: "standard Cilium defaults to BPF host routing",
+			objects: []runtime.Object{cniConfigMap(ciliumConfigMapName, map[string]string{
+				"routing-mode": "native",
+			})},
+			wantCNI: "cilium",
+		},
+		{
+			name: "standard Cilium enables host legacy routing",
+			objects: []runtime.Object{cniConfigMap(ciliumConfigMapName, map[string]string{
+				ciliumHostLegacyRoutingKey: "true",
+			})},
+			wantCNI:    "cilium",
+			wantLegacy: true,
+		},
+		{
+			name: "Terway datapath v2 defaults to BPF host routing",
+			objects: []runtime.Object{cniConfigMap(terwayConfigMapName, map[string]string{
+				terwayCNIConfigKey: `{"type":"terway","network_policy_provider":"ebpf","eniip_virtual_type":"datapathv2"}`,
+			})},
+			wantCNI: "terway-cilium",
+		},
+		{
+			name: "Terway preserves an enabled host legacy argument",
+			objects: []runtime.Object{cniConfigMap(terwayConfigMapName, map[string]string{
+				terwayCNIConfigKey: `{"type":"terway","network_policy_provider":"ebpf","eniip_virtual_type":"datapathv2","cilium_args":"--enable-hubble=true --enable-host-legacy-routing=true"}`,
+			})},
+			wantCNI:    "terway-cilium",
+			wantLegacy: true,
+		},
+		{
+			name: "Terway without Cilium is ignored",
+			objects: []runtime.Object{cniConfigMap(terwayConfigMapName, map[string]string{
+				terwayCNIConfigKey: `{"type":"terway","network_policy_provider":"calico","eniip_virtual_type":"veth"}`,
+			})},
+			wantNil: true,
+		},
+		{
+			name:    "non-Cilium cluster is ignored",
+			wantNil: true,
+		},
+		{
+			name: "invalid Cilium boolean is reported",
+			objects: []runtime.Object{cniConfigMap(ciliumConfigMapName, map[string]string{
+				ciliumHostLegacyRoutingKey: "sometimes",
+			})},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			status, err := detectCiliumHostRouting(context.Background(), fake.NewSimpleClientset(tt.objects...))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected an error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("detect Cilium host routing: %v", err)
+			}
+			if tt.wantNil {
+				if status != nil {
+					t.Fatalf("status = %+v, want nil", status)
+				}
+				return
+			}
+			if status == nil {
+				t.Fatal("status is nil")
+			}
+			if status.CNI != tt.wantCNI || status.HostLegacyRouting != tt.wantLegacy {
+				t.Fatalf("status = %+v, want CNI %q legacy=%t", status, tt.wantCNI, tt.wantLegacy)
+			}
+		})
+	}
+}
+
+func TestWarnIfCiliumMayBypassNetd(t *testing.T) {
+	client := fake.NewSimpleClientset(cniConfigMap(terwayConfigMapName, map[string]string{
+		terwayCNIConfigKey: `{"type":"terway","network_policy_provider":"ebpf","eniip_virtual_type":"datapathv2"}`,
+	}))
+	core, logs := observer.New(zap.WarnLevel)
+
+	warnIfCiliumMayBypassNetd(context.Background(), client, "sandbox-node-a", zap.New(core))
+
+	entries := logs.All()
+	if len(entries) != 1 {
+		t.Fatalf("warning count = %d, want 1", len(entries))
+	}
+	if entries[0].Message != "Cilium is configured without host legacy routing; netd iptables interception may be bypassed" {
+		t.Fatalf("warning message = %q", entries[0].Message)
+	}
+	fields := entries[0].ContextMap()
+	if fields["node"] != "sandbox-node-a" || fields["cni"] != "terway-cilium" {
+		t.Fatalf("warning fields = %#v", fields)
+	}
+	if fields["config_map"] != "kube-system/eni-config" || fields["host_legacy_routing"] != false {
+		t.Fatalf("routing fields = %#v", fields)
+	}
+	if fields["required_setting"] != "enable-host-legacy-routing=true" {
+		t.Fatalf("required_setting = %v", fields["required_setting"])
+	}
+	if fields["impact"] != "sandbox network policy and audit may be incomplete" {
+		t.Fatalf("impact = %v", fields["impact"])
+	}
+}
+
+func TestWarnIfCiliumMayBypassNetdStaysQuietForHostLegacyRouting(t *testing.T) {
+	client := fake.NewSimpleClientset(cniConfigMap(ciliumConfigMapName, map[string]string{
+		ciliumHostLegacyRoutingKey: "true",
+	}))
+	core, logs := observer.New(zap.WarnLevel)
+
+	warnIfCiliumMayBypassNetd(context.Background(), client, "sandbox-node-a", zap.New(core))
+
+	if logs.Len() != 0 {
+		t.Fatalf("warning count = %d, want 0", logs.Len())
+	}
+}
+
+func TestParseCiliumBoolArgUsesLastValue(t *testing.T) {
+	value, found, err := parseCiliumBoolArg(
+		"--enable-host-legacy-routing=false--debug=true --enable-host-legacy-routing=true",
+		ciliumHostLegacyRoutingKey,
+	)
+	if err != nil {
+		t.Fatalf("parse Cilium bool argument: %v", err)
+	}
+	if !found || !value {
+		t.Fatalf("value=%t found=%t, want true true", value, found)
+	}
+}
+
+func cniConfigMap(name string, data map[string]string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: cniConfigNamespace},
+		Data:       data,
+	}
+}

--- a/netd/pkg/daemon/daemon.go
+++ b/netd/pkg/daemon/daemon.go
@@ -134,6 +134,7 @@ func (d *Daemon) runNetd(ctx context.Context, cancel context.CancelFunc, proxyEx
 	if err != nil {
 		return fmt.Errorf("create k8s client: %w", err)
 	}
+	warnIfCiliumMayBypassNetd(ctx, client, d.cfg.NodeName, d.logger)
 
 	netdWatcher := watcher.NewWatcher(client, d.cfg.ResyncPeriod.Duration, d.logger)
 	policyStore := policy.NewStore(d.logger)


### PR DESCRIPTION
## Summary

- inspect the cluster CNI configuration once when netd starts
- warn when standard Cilium or ACK Terway is configured without host legacy routing, because Cilium's BPF host-routing path can bypass netd's iptables/TPROXY interception
- grant netd least-privilege `get` access only to `kube-system/cilium-config` and `kube-system/eni-config`
- document the required Cilium and Terway settings

## Why

Netd can successfully install its iptables rules and report an applied policy hash even when the CNI datapath routes sandbox traffic around host netfilter. In that state, enforcement, metering, and per-sandbox network audit can all be incomplete without an obvious netd error.

The production-effective routing fix remains sandbox0-infra PR [#93](https://github.com/sandbox0-ai/sandbox0-infra/pull/93). This PR adds the missing Sandbox0-side diagnostic so an incompatible CNI configuration is visible in netd logs instead of appearing as an empty audit stream.

The warning includes:

- node and detected CNI (`cilium` or `terway-cilium`)
- source ConfigMap
- `host_legacy_routing=false`
- required setting `enable-host-legacy-routing=true`
- impact: sandbox network policy and audit may be incomplete

Host-legacy and non-Cilium clusters stay quiet. Failure to inspect the CNI configuration produces a separate warning without blocking netd startup.

## Validation

- `go test -race -count=1 ./netd/...`
- `go test -race -count=1 ./infra-operator/internal/controller/pkg/rbac ./infra-operator/internal/controller/services/netd ./infra-operator/internal/plan/...`
- `make proto manifests apispec` followed by a clean generated-artifact diff
- `go mod tidy` followed by a clean `go.mod` / `go.sum` diff
- `gofmt` and `git diff --check`
