### PR TITLE
fix: stabilize high-density claims and ctld portal serving

### DIFF
--- a/manager/pkg/metering/lifecycle_projector.go
+++ b/manager/pkg/metering/lifecycle_projector.go
@@ -144,7 +144,53 @@ func (p *LifecycleProjector) handleUpdate(oldObj, newObj any) {
 	if isTeamOwnedIdlePoolPod(oldPod) && !isTeamOwnedIdlePoolPod(newPod) {
 		p.handleWarmPoolDelete(oldPod)
 	}
+	// Warm-pool updates advance runtime windows, so they intentionally keep the
+	// resync behavior. Claimed sandboxes only need a projection write when an
+	// input used by metering changes; kubelet status updates are otherwise pure
+	// ClickHouse write amplification.
+	if isTeamOwnedIdlePoolPod(newPod) {
+		p.handleUpsert(newObj)
+		return
+	}
+	if isClaimedActiveSandbox(oldPod) && isClaimedActiveSandbox(newPod) &&
+		activeSandboxProjectionInput(oldPod) == activeSandboxProjectionInput(newPod) {
+		return
+	}
 	p.handleUpsert(newObj)
+}
+
+type activeSandboxProjectionInputs struct {
+	sandboxID         string
+	namespace         string
+	teamID            string
+	userID            string
+	templateID        string
+	claimedAt         string
+	paused            string
+	pausedAt          string
+	ownerKind         string
+	resourceMillicpu  int64
+	resourceMemoryMiB int64
+}
+
+func activeSandboxProjectionInput(pod *corev1.Pod) activeSandboxProjectionInputs {
+	if pod == nil {
+		return activeSandboxProjectionInputs{}
+	}
+	usage := sandboxUsageFromPod(pod)
+	return activeSandboxProjectionInputs{
+		sandboxID:         meteringSandboxIDFromPod(pod),
+		namespace:         pod.Namespace,
+		teamID:            pod.Annotations[controller.AnnotationTeamID],
+		userID:            pod.Annotations[controller.AnnotationUserID],
+		templateID:        pod.Labels[controller.LabelTemplateID],
+		claimedAt:         pod.Annotations[controller.AnnotationClaimedAt],
+		paused:            pod.Annotations[controller.AnnotationPaused],
+		pausedAt:          pod.Annotations[controller.AnnotationPausedAt],
+		ownerKind:         usage.OwnerKind,
+		resourceMillicpu:  usage.ResourceMillicpu,
+		resourceMemoryMiB: usage.ResourceMemoryMiB,
+	}
 }
 
 func (p *LifecycleProjector) handleUpsert(obj any) {

--- a/manager/pkg/metering/lifecycle_projector_test.go
+++ b/manager/pkg/metering/lifecycle_projector_test.go
@@ -163,6 +163,50 @@ func TestLifecycleProjectorRecordsClaimPauseResumeTerminate(t *testing.T) {
 	}
 }
 
+func TestLifecycleProjectorIgnoresStatusOnlySandboxUpdates(t *testing.T) {
+	recorder := &fakeRecorder{states: map[string]*meteringpkg.SandboxProjectionState{}}
+	projector := NewLifecycleProjector(recorder, "aws-us-east-1", "cluster-a")
+	claimedAt := time.Date(2026, 3, 12, 10, 0, 0, 0, time.UTC)
+	oldPod := withSandboxResources(buildSandboxPod(claimedAt, false, "", "1"), "1", "1Gi")
+	projector.handleUpsert(oldPod)
+
+	newPod := oldPod.DeepCopy()
+	newPod.ResourceVersion = "2"
+	newPod.Status.Phase = corev1.PodRunning
+	newPod.Status.PodIP = "10.0.0.10"
+	projector.handleUpdate(oldPod, newPod)
+
+	if recorder.transactionCalls != 1 {
+		t.Fatalf("transaction calls = %d, want 1 after status-only update", recorder.transactionCalls)
+	}
+	if recorder.watermarkHits != 1 {
+		t.Fatalf("watermark writes = %d, want 1 after status-only update", recorder.watermarkHits)
+	}
+	if state := recorder.states["sb-1"]; state == nil || state.LastResourceVer != "1" {
+		t.Fatalf("state after status-only update = %#v, want original resource version", state)
+	}
+}
+
+func TestLifecycleProjectorPersistsMeteringRelevantSandboxUpdates(t *testing.T) {
+	recorder := &fakeRecorder{states: map[string]*meteringpkg.SandboxProjectionState{}}
+	projector := NewLifecycleProjector(recorder, "aws-us-east-1", "cluster-a")
+	claimedAt := time.Date(2026, 3, 12, 10, 0, 0, 0, time.UTC)
+	oldPod := withSandboxResources(buildSandboxPod(claimedAt, false, "", "1"), "1", "1Gi")
+	projector.handleUpsert(oldPod)
+
+	newPod := withSandboxResources(oldPod.DeepCopy(), "2", "2Gi")
+	newPod.ResourceVersion = "2"
+	projector.handleUpdate(oldPod, newPod)
+
+	if recorder.transactionCalls != 2 {
+		t.Fatalf("transaction calls = %d, want 2 after resource update", recorder.transactionCalls)
+	}
+	state := recorder.states["sb-1"]
+	if state == nil || state.ResourceMillicpu != 2000 || state.ResourceMemoryMiB != 2048 || state.LastResourceVer != "2" {
+		t.Fatalf("state after resource update = %#v", state)
+	}
+}
+
 func TestLifecycleProjectorRecordsErrorsInMetrics(t *testing.T) {
 	recorder := &fakeRecorder{
 		states: map[string]*meteringpkg.SandboxProjectionState{},

--- a/pkg/fuseportal/multiplexer_linux.go
+++ b/pkg/fuseportal/multiplexer_linux.go
@@ -1,0 +1,170 @@
+//go:build linux
+
+package fuseportal
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	"golang.org/x/sys/unix"
+)
+
+const epollBatchSize = 128
+
+type epollRegistration struct {
+	server *Server
+	active sync.WaitGroup
+}
+
+// epollMultiplexer keeps all idle FUSE channels on one kernel wait queue. The
+// request handlers remain concurrent, while the number of blocking OS threads
+// no longer grows with the number of mounted portals.
+type epollMultiplexer struct {
+	fd            int
+	mu            sync.Mutex
+	nextToken     uint64
+	registrations map[uint64]*epollRegistration
+	runErr        error
+}
+
+var (
+	sharedMuxOnce sync.Once
+	sharedMux     *epollMultiplexer
+	sharedMuxErr  error
+)
+
+func sharedEpollMultiplexer() (*epollMultiplexer, error) {
+	sharedMuxOnce.Do(func() {
+		fd, err := unix.EpollCreate1(unix.EPOLL_CLOEXEC)
+		if err != nil {
+			sharedMuxErr = fmt.Errorf("create shared FUSE epoll multiplexer: %w", err)
+			return
+		}
+		sharedMux = &epollMultiplexer{
+			fd:            fd,
+			registrations: make(map[uint64]*epollRegistration),
+		}
+		go sharedMux.run()
+	})
+	return sharedMux, sharedMuxErr
+}
+
+func (m *epollMultiplexer) add(server *Server) error {
+	server.fdMu.Lock()
+	fd := server.fd
+	server.fdMu.Unlock()
+	if fd < 0 {
+		return fmt.Errorf("FUSE channel is unavailable")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.runErr != nil {
+		return m.runErr
+	}
+	m.nextToken++
+	if m.nextToken == 0 {
+		m.nextToken++
+	}
+	token := m.nextToken
+	event := unix.EpollEvent{Events: uint32(unix.EPOLLIN | unix.EPOLLERR | unix.EPOLLHUP)}
+	setEpollToken(&event, token)
+	if err := unix.EpollCtl(m.fd, unix.EPOLL_CTL_ADD, fd, &event); err != nil {
+		return fmt.Errorf("register FUSE channel with shared epoll: %w", err)
+	}
+	m.registrations[token] = &epollRegistration{server: server}
+	server.muxToken = token
+	return nil
+}
+
+func (m *epollMultiplexer) remove(server *Server) {
+	if m == nil || server == nil {
+		return
+	}
+	m.mu.Lock()
+	token := server.muxToken
+	registration := m.registrations[token]
+	if registration != nil && registration.server == server {
+		delete(m.registrations, token)
+		server.muxToken = 0
+	}
+	m.mu.Unlock()
+	if registration == nil || registration.server != server {
+		return
+	}
+
+	server.fdMu.Lock()
+	fd := server.fd
+	server.fdMu.Unlock()
+	if fd >= 0 {
+		_ = unix.EpollCtl(m.fd, unix.EPOLL_CTL_DEL, fd, nil)
+	}
+	registration.active.Wait()
+}
+
+func (m *epollMultiplexer) run() {
+	events := make([]unix.EpollEvent, epollBatchSize)
+	for {
+		count, err := unix.EpollWait(m.fd, events, -1)
+		if errors.Is(err, unix.EINTR) {
+			continue
+		}
+		if err != nil {
+			m.fail(fmt.Errorf("wait for shared FUSE epoll events: %w", err))
+			return
+		}
+		for i := 0; i < count; i++ {
+			m.dispatch(events[i])
+		}
+	}
+}
+
+func (m *epollMultiplexer) dispatch(event unix.EpollEvent) {
+	token := epollToken(event)
+	m.mu.Lock()
+	registration := m.registrations[token]
+	if registration != nil {
+		registration.active.Add(1)
+	}
+	m.mu.Unlock()
+	if registration == nil {
+		return
+	}
+
+	stop, err := registration.server.handleReady(event.Events)
+	registration.active.Done()
+	if stop {
+		registration.server.requestStop(err)
+	}
+}
+
+func (m *epollMultiplexer) fail(err error) {
+	m.mu.Lock()
+	if m.runErr == nil {
+		m.runErr = err
+	}
+	servers := make([]*Server, 0, len(m.registrations))
+	for _, registration := range m.registrations {
+		servers = append(servers, registration.server)
+	}
+	m.mu.Unlock()
+	for _, server := range servers {
+		server.requestStop(err)
+	}
+}
+
+func (m *epollMultiplexer) activeCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.registrations)
+}
+
+func setEpollToken(event *unix.EpollEvent, token uint64) {
+	event.Fd = int32(uint32(token))
+	event.Pad = int32(uint32(token >> 32))
+}
+
+func epollToken(event unix.EpollEvent) uint64 {
+	return uint64(uint32(event.Fd)) | uint64(uint32(event.Pad))<<32
+}

--- a/pkg/fuseportal/server_linux.go
+++ b/pkg/fuseportal/server_linux.go
@@ -69,10 +69,13 @@ type Server struct {
 	mountPoint  string
 	initRequest []byte
 	fd          int
-	wakeFD      int
 	fdMu        sync.Mutex
 	serving     bool
 	serveMu     sync.Mutex
+	mux         *epollMultiplexer
+	muxToken    uint64
+	serveResult chan error
+	stopOnce    sync.Once
 	requests    sync.WaitGroup
 	done        chan struct{}
 	doneOnce    sync.Once
@@ -163,18 +166,19 @@ func Attach(fs fuse.RawFileSystem, channel *os.File, mountPoint string, initRequ
 }
 
 func newServer(fs fuse.RawFileSystem, fd int, mountPoint string, opts *fuse.MountOptions) (*Server, error) {
-	wakeFD, err := unix.Eventfd(0, unix.EFD_CLOEXEC|unix.EFD_NONBLOCK)
+	mux, err := sharedEpollMultiplexer()
 	if err != nil {
-		return nil, fmt.Errorf("create FUSE wake event: %w", err)
+		return nil, err
 	}
 	return &Server{
-		fs:         fs,
-		protocol:   fuse.NewProtocolServer(fs, opts),
-		opts:       *opts,
-		mountPoint: mountPoint,
-		fd:         fd,
-		wakeFD:     wakeFD,
-		done:       make(chan struct{}),
+		fs:          fs,
+		protocol:    fuse.NewProtocolServer(fs, opts),
+		opts:        *opts,
+		mountPoint:  mountPoint,
+		fd:          fd,
+		mux:         mux,
+		serveResult: make(chan error, 1),
+		done:        make(chan struct{}),
 	}, nil
 }
 
@@ -190,52 +194,16 @@ func (s *Server) Serve() error {
 		return fmt.Errorf("FUSE server is already serving")
 	}
 	s.serving = true
+	if err := s.mux.add(s); err != nil {
+		s.serveMu.Unlock()
+		s.finish()
+		return err
+	}
 	s.serveMu.Unlock()
 
-	defer s.finish()
-	s.fdMu.Lock()
-	channelFD := s.fd
-	wakeFD := s.wakeFD
-	s.fdMu.Unlock()
-	pollFDs := []unix.PollFd{
-		{Fd: int32(channelFD), Events: unix.POLLIN},
-		{Fd: int32(wakeFD), Events: unix.POLLIN},
-	}
-	for {
-		_, err := unix.Poll(pollFDs, -1)
-		if errors.Is(err, unix.EINTR) {
-			continue
-		}
-		if err != nil {
-			return fmt.Errorf("poll FUSE channel: %w", err)
-		}
-		if pollFDs[1].Revents != 0 {
-			return nil
-		}
-		if pollFDs[0].Revents&(unix.POLLERR|unix.POLLHUP|unix.POLLNVAL) != 0 {
-			return nil
-		}
-		if pollFDs[0].Revents&unix.POLLIN == 0 {
-			continue
-		}
-		request, err := readRequest(channelFD, s.opts.MaxWrite)
-		if errors.Is(err, unix.ENODEV) || errors.Is(err, unix.EBADF) {
-			return nil
-		}
-		if err != nil {
-			return fmt.Errorf("read FUSE request: %w", err)
-		}
-		s.requests.Add(1)
-		go func() {
-			defer s.requests.Done()
-			if err := s.handleAndReply(request); err != nil {
-				if s.opts.Logger != nil {
-					s.opts.Logger.Printf("handle FUSE request: %v", err)
-				}
-				_ = s.replyError(request, fuse.EIO)
-			}
-		}()
-	}
+	err := <-s.serveResult
+	s.finish()
+	return err
 }
 
 // CloneChannel creates a second device channel attached to the same kernel
@@ -281,7 +249,7 @@ func (s *Server) Detach() error {
 	if s.stopIdle() {
 		return nil
 	}
-	s.wake()
+	s.requestStop(nil)
 	<-s.done
 	return nil
 }
@@ -300,7 +268,7 @@ func (s *Server) Unmount() error {
 	if s.stopIdle() {
 		return unmountErr
 	}
-	s.wake()
+	s.requestStop(nil)
 	<-s.done
 	return unmountErr
 }
@@ -312,22 +280,21 @@ func (s *Server) stopIdle() bool {
 		return false
 	}
 	s.serving = true
+	s.requestStop(nil)
 	s.finish()
 	return true
 }
 
-func (s *Server) wake() {
+func (s *Server) requestStop(err error) {
 	if s == nil {
 		return
 	}
-	s.fdMu.Lock()
-	defer s.fdMu.Unlock()
-	if s.wakeFD < 0 {
-		return
-	}
-	var value [8]byte
-	binary.LittleEndian.PutUint64(value[:], 1)
-	_, _ = unix.Write(s.wakeFD, value[:])
+	s.stopOnce.Do(func() {
+		if s.mux != nil {
+			s.mux.remove(s)
+		}
+		s.serveResult <- err
+	})
 }
 
 func (s *Server) finish() {
@@ -347,13 +314,43 @@ func (s *Server) closeDescriptors() error {
 		}
 		s.fd = -1
 	}
-	if s.wakeFD >= 0 {
-		if err := unix.Close(s.wakeFD); err != nil && !errors.Is(err, unix.EBADF) && firstErr == nil {
-			firstErr = err
-		}
-		s.wakeFD = -1
-	}
 	return firstErr
+}
+
+func (s *Server) handleReady(events uint32) (bool, error) {
+	if events&uint32(unix.EPOLLIN) == 0 {
+		if events&uint32(unix.EPOLLERR|unix.EPOLLHUP) != 0 {
+			return true, nil
+		}
+		return false, nil
+	}
+	s.fdMu.Lock()
+	channelFD := s.fd
+	s.fdMu.Unlock()
+	if channelFD < 0 {
+		return true, nil
+	}
+	request, err := readRequest(channelFD, s.opts.MaxWrite)
+	if errors.Is(err, unix.ENODEV) || errors.Is(err, unix.EBADF) {
+		return true, nil
+	}
+	if err != nil {
+		return true, fmt.Errorf("read FUSE request: %w", err)
+	}
+	s.requests.Add(1)
+	go func() {
+		defer s.requests.Done()
+		if err := s.handleAndReply(request); err != nil {
+			if s.opts.Logger != nil {
+				s.opts.Logger.Printf("handle FUSE request: %v", err)
+			}
+			_ = s.replyError(request, fuse.EIO)
+		}
+	}()
+	if events&uint32(unix.EPOLLERR|unix.EPOLLHUP) != 0 {
+		return true, nil
+	}
+	return false, nil
 }
 
 func (s *Server) initializeProtocol(request []byte) error {

--- a/pkg/fuseportal/server_linux_test.go
+++ b/pkg/fuseportal/server_linux_test.go
@@ -4,7 +4,11 @@ package fuseportal
 
 import (
 	"encoding/binary"
+	"errors"
+	"io"
 	"os"
+	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"testing"
@@ -262,4 +266,155 @@ func TestHandleAndReplyReturnsProtocolErrorToKernel(t *testing.T) {
 	if got := int32(binary.LittleEndian.Uint32(response[4:8])); got != -int32(fuse.ENOSYS) {
 		t.Fatalf("response error = %d, want %d", got, -int32(fuse.ENOSYS))
 	}
+}
+
+func TestSharedEpollMultiplexesPortalChannels(t *testing.T) {
+	mux, err := sharedEpollMultiplexer()
+	if err != nil {
+		t.Fatalf("sharedEpollMultiplexer() error = %v", err)
+	}
+	baseline := mux.activeCount()
+	baselineThreads, threadCountErr := processThreadCount()
+	const serverCount = 128
+	portalFS := newTakeoverTestFS("")
+	type portalPair struct {
+		server *Server
+		peerFD int
+		done   chan error
+	}
+	pairs := make([]portalPair, 0, serverCount)
+	for i := 0; i < serverCount; i++ {
+		fds, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM|unix.SOCK_CLOEXEC, 0)
+		if err != nil {
+			t.Fatalf("Socketpair(%d) error = %v", i, err)
+		}
+		server, err := newServer(portalFS, fds[0], "", &fuse.MountOptions{})
+		if err != nil {
+			_ = unix.Close(fds[0])
+			_ = unix.Close(fds[1])
+			t.Fatalf("newServer(%d) error = %v", i, err)
+		}
+		readTimeout := unix.NsecToTimeval((3 * time.Second).Nanoseconds())
+		if err := unix.SetsockoptTimeval(fds[1], unix.SOL_SOCKET, unix.SO_RCVTIMEO, &readTimeout); err != nil {
+			_ = server.Detach()
+			_ = unix.Close(fds[1])
+			t.Fatalf("SetsockoptTimeval(%d) error = %v", i, err)
+		}
+		done := make(chan error, 1)
+		go func() { done <- server.Serve() }()
+		pairs = append(pairs, portalPair{server: server, peerFD: fds[1], done: done})
+	}
+	t.Cleanup(func() {
+		for _, pair := range pairs {
+			_ = pair.server.Detach()
+			if pair.peerFD >= 0 {
+				_ = unix.Close(pair.peerFD)
+			}
+		}
+	})
+
+	deadline := time.Now().Add(3 * time.Second)
+	for mux.activeCount() != baseline+serverCount {
+		if time.Now().After(deadline) {
+			t.Fatalf("active epoll registrations = %d, want %d", mux.activeCount(), baseline+serverCount)
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if threadCountErr == nil {
+		threads, err := processThreadCount()
+		if err != nil {
+			t.Fatalf("processThreadCount() error = %v", err)
+		}
+		if delta := threads - baselineThreads; delta > 32 {
+			t.Fatalf("OS thread count grew by %d for %d idle portals; want at most 32", delta, serverCount)
+		}
+	}
+
+	request := make([]byte, int(unsafe.Sizeof(fuse.GetAttrIn{})))
+	binary.LittleEndian.PutUint32(request[0:4], uint32(len(request)))
+	binary.LittleEndian.PutUint32(request[4:8], opGetattr)
+	binary.LittleEndian.PutUint64(request[16:24], fuseRootID)
+	for i, pair := range pairs {
+		binary.LittleEndian.PutUint64(request[8:16], uint64(i+1))
+		if _, err := unix.Write(pair.peerFD, request); err != nil {
+			t.Fatalf("Write(request %d) error = %v", i, err)
+		}
+	}
+	for i, pair := range pairs {
+		response, err := readTestResponse(pair.peerFD)
+		if err != nil {
+			t.Fatalf("Read(response %d) error = %v", i, err)
+		}
+		if got := binary.LittleEndian.Uint64(response[8:16]); got != uint64(i+1) {
+			t.Fatalf("response %d unique = %d, want %d", i, got, i+1)
+		}
+		if got := int32(binary.LittleEndian.Uint32(response[4:8])); got != 0 {
+			t.Fatalf("response %d error = %d, want 0", i, got)
+		}
+	}
+	for i, pair := range pairs {
+		if err := pair.server.Detach(); err != nil {
+			t.Fatalf("Detach(%d) error = %v", i, err)
+		}
+		if err := <-pair.done; err != nil {
+			t.Fatalf("Serve(%d) error = %v", i, err)
+		}
+		_ = unix.Close(pair.peerFD)
+		pairs[i].peerFD = -1
+	}
+	if got := mux.activeCount(); got != baseline {
+		t.Fatalf("active epoll registrations after detach = %d, want %d", got, baseline)
+	}
+}
+
+func readTestResponse(fd int) ([]byte, error) {
+	header := make([]byte, fuseOutSize)
+	if err := readFullFD(fd, header); err != nil {
+		return nil, err
+	}
+	length := int(binary.LittleEndian.Uint32(header[:4]))
+	if length < fuseOutSize || length > 1<<20 {
+		return nil, syscall.EPROTO
+	}
+	response := make([]byte, length)
+	copy(response, header)
+	if err := readFullFD(fd, response[fuseOutSize:]); err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+func readFullFD(fd int, buffer []byte) error {
+	for len(buffer) > 0 {
+		count, err := unix.Read(fd, buffer)
+		if errors.Is(err, unix.EINTR) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if count == 0 {
+			return io.ErrUnexpectedEOF
+		}
+		buffer = buffer[count:]
+	}
+	return nil
+}
+
+func processThreadCount() (int, error) {
+	payload, err := os.ReadFile("/proc/self/status")
+	if err != nil {
+		return 0, err
+	}
+	for _, line := range strings.Split(string(payload), "\n") {
+		if !strings.HasPrefix(line, "Threads:") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			return 0, syscall.EINVAL
+		}
+		return strconv.Atoi(fields[1])
+	}
+	return 0, syscall.ENOENT
 }

--- a/pkg/metering/clickhouse/cursor_test.go
+++ b/pkg/metering/clickhouse/cursor_test.go
@@ -1,0 +1,52 @@
+package clickhouse
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sandbox0-ai/sandbox0/pkg/metering"
+)
+
+func TestNextPageCursorAdvancesForPartialPages(t *testing.T) {
+	recordedAt := time.Date(2026, 7, 11, 21, 0, 0, 123, time.UTC)
+
+	eventCursor, err := nextEventCursor([]*metering.Event{{
+		EventID:    "event-1",
+		Producer:   "manager.sandbox_lifecycle",
+		RecordedAt: recordedAt,
+	}})
+	if err != nil {
+		t.Fatalf("nextEventCursor() error = %v", err)
+	}
+	assertPageCursor(t, eventCursor, recordedAt, "manager.sandbox_lifecycle", "event-1")
+
+	windowCursor, err := nextWindowCursor([]*metering.Window{{
+		WindowID:   "window-1",
+		Producer:   "manager.sandbox_lifecycle",
+		RecordedAt: recordedAt,
+	}})
+	if err != nil {
+		t.Fatalf("nextWindowCursor() error = %v", err)
+	}
+	assertPageCursor(t, windowCursor, recordedAt, "manager.sandbox_lifecycle", "window-1")
+}
+
+func TestNextPageCursorIsEmptyForEmptyPages(t *testing.T) {
+	if cursor, err := nextEventCursor(nil); err != nil || cursor != "" {
+		t.Fatalf("nextEventCursor(nil) = %q, %v; want empty cursor", cursor, err)
+	}
+	if cursor, err := nextWindowCursor(nil); err != nil || cursor != "" {
+		t.Fatalf("nextWindowCursor(nil) = %q, %v; want empty cursor", cursor, err)
+	}
+}
+
+func assertPageCursor(t *testing.T, encoded string, recordedAt time.Time, producer, id string) {
+	t.Helper()
+	cursor, err := decodeCursor(encoded)
+	if err != nil {
+		t.Fatalf("decodeCursor() error = %v", err)
+	}
+	if !cursor.RecordedAt.Equal(recordedAt) || cursor.Producer != producer || cursor.ID != id {
+		t.Fatalf("cursor = %+v, want recorded_at=%s producer=%q id=%q", cursor, recordedAt, producer, id)
+	}
+}

--- a/pkg/metering/clickhouse/repository.go
+++ b/pkg/metering/clickhouse/repository.go
@@ -319,13 +319,9 @@ LIMIT ?
 	if err := rows.Err(); err != nil {
 		return nil, "", fmt.Errorf("iterate usage events: %w", err)
 	}
-	next := ""
-	if len(events) == limit {
-		last := events[len(events)-1]
-		next, err = encodeCursor(last.RecordedAt, last.Producer, last.EventID)
-		if err != nil {
-			return nil, "", err
-		}
+	next, err := nextEventCursor(events)
+	if err != nil {
+		return nil, "", err
 	}
 	return events, next, nil
 }
@@ -380,15 +376,33 @@ LIMIT ?
 	if err := rows.Err(); err != nil {
 		return nil, "", fmt.Errorf("iterate usage windows: %w", err)
 	}
-	next := ""
-	if len(windows) == limit {
-		last := windows[len(windows)-1]
-		next, err = encodeCursor(last.RecordedAt, last.Producer, last.WindowID)
-		if err != nil {
-			return nil, "", err
-		}
+	next, err := nextWindowCursor(windows)
+	if err != nil {
+		return nil, "", err
 	}
 	return windows, next, nil
+}
+
+func nextEventCursor(events []*metering.Event) (string, error) {
+	if len(events) == 0 {
+		return "", nil
+	}
+	last := events[len(events)-1]
+	if last == nil {
+		return "", fmt.Errorf("last usage event is nil")
+	}
+	return encodeCursor(last.RecordedAt, last.Producer, last.EventID)
+}
+
+func nextWindowCursor(windows []*metering.Window) (string, error) {
+	if len(windows) == 0 {
+		return "", nil
+	}
+	last := windows[len(windows)-1]
+	if last == nil {
+		return "", fmt.Errorf("last usage window is nil")
+	}
+	return encodeCursor(last.RecordedAt, last.Producer, last.WindowID)
 }
 
 func cursorWhere(cursor *pageCursor, idColumn string) (string, []any) {


### PR DESCRIPTION
## Summary

- return a ClickHouse export cursor for every non-empty metering page, including partial pages
- skip manager metering state/watermark writes for Pod updates that only change status or resourceVersion
- replace one blocking poll plus eventfd per FUSE portal with one process-wide epoll multiplexer
- keep FUSE request handling concurrent while bounding idle portal OS-thread growth

## Why

The 500-claim production benchmark exposed three independent amplification paths:

- the billing importer repeatedly fetched the first usage_windows page because its numeric cursor never advanced against the opaque cursor API
- manager wrote 6,666 sandbox projection states and 6,770 producer watermarks for 500 claims, mostly from kubelet status updates
- the primary ctld grew from 52 to 934 threads and retained them after cleanup; 897 were parked in futex wait after per-portal blocking poll goroutines had forced Go to create OS threads

The epoll regression test registers 128 idle portal channels and asserts that OS-thread count stays bounded. It also sends and validates a FUSE request through every channel.

## Validation

- make proto
- go test -race ./pkg/fuseportal
- go test ./ctld/... ./manager/pkg/metering ./pkg/metering/clickhouse ./pkg/gateway/http/handlers
- go vet ./ctld/... ./manager/pkg/metering ./pkg/fuseportal ./pkg/metering/clickhouse ./pkg/gateway/http/handlers
- all non-e2e packages in go test ./... passed; the single-cluster e2e package requires kind, which is not installed in the local environment

## Rollout

Deploy this change before the sandbox0-cloud opaque-cursor importer PR. Until both sides are deployed, the current billing worker can still repeat the first full page.
