### PR TITLE
fix: prioritize netd TPROXY policy routing

### DIFF
--- a/netd/pkg/redirect/manager.go
+++ b/netd/pkg/redirect/manager.go
@@ -16,9 +16,10 @@ import (
 )
 
 const (
-	ruleTableID = 100
-	mangleTable = "mangle"
-	natTable    = "nat"
+	ruleTableID        = 100
+	policyRulePriority = 100
+	mangleTable        = "mangle"
+	natTable           = "nat"
 )
 
 type iptablesManager struct {
@@ -206,13 +207,26 @@ func (m *iptablesManager) ensurePolicyRouting(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	if !ruleExists(rules, uint32(1), uint32(1), ruleTableID) {
+	if !ruleExists(rules, uint32(1), uint32(1), ruleTableID, policyRulePriority) {
 		rule := netlink.NewRule()
 		rule.Mark = 1
 		mask := uint32(1)
 		rule.Mask = &mask
 		rule.Table = ruleTableID
+		// The TPROXY mark must win before CNI source-based rules. Terway installs
+		// per-pod source rules at priority 2048, while an unspecified priority is
+		// assigned near 32765 and routes marked packets away from the local proxy.
+		rule.Priority = policyRulePriority
 		if err := netlink.RuleAdd(rule); err != nil && !isExist(err) {
+			return err
+		}
+	}
+	for i := range rules {
+		rule := rules[i]
+		if !ruleMatches(rule, uint32(1), uint32(1), ruleTableID) || rule.Priority == policyRulePriority {
+			continue
+		}
+		if err := netlink.RuleDel(&rule); err != nil && !isNotExist(err) {
 			return err
 		}
 	}
@@ -245,19 +259,17 @@ func (m *iptablesManager) ensurePolicyRouting(ctx context.Context) error {
 	return nil
 }
 
-func ruleExists(rules []netlink.Rule, mark, mask uint32, table int) bool {
+func ruleExists(rules []netlink.Rule, mark, mask uint32, table, priority int) bool {
 	for _, rule := range rules {
-		if rule.Table != table || rule.Mark != mark {
-			continue
-		}
-		if rule.Mask == nil {
-			continue
-		}
-		if *rule.Mask == mask {
+		if ruleMatches(rule, mark, mask, table) && rule.Priority == priority {
 			return true
 		}
 	}
 	return false
+}
+
+func ruleMatches(rule netlink.Rule, mark, mask uint32, table int) bool {
+	return rule.Table == table && rule.Mark == mark && rule.Mask != nil && *rule.Mask == mask
 }
 
 func localRouteExists(routes []netlink.Route) bool {
@@ -303,4 +315,12 @@ func isExist(err error) bool {
 		return false
 	}
 	return strings.Contains(strings.ToLower(err.Error()), "exists")
+}
+
+func isNotExist(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "no such") || strings.Contains(message, "not found")
 }

--- a/netd/pkg/redirect/manager_test.go
+++ b/netd/pkg/redirect/manager_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/vishvananda/netlink"
 )
 
 func TestBuildIPTablesRestoreInputRoutesSpecificAndGenericTraffic(t *testing.T) {
@@ -133,6 +135,49 @@ func TestNormalizeInputsDeduplicateAndTrim(t *testing.T) {
 	cidrs := normalizeCIDRs([]string{" 10.0.0.0/8 ", "", "10.0.0.0/8", "192.168.0.0/16"})
 	if len(cidrs) != 2 || cidrs[0] != "10.0.0.0/8" || cidrs[1] != "192.168.0.0/16" {
 		t.Fatalf("unexpected normalized cidrs: %#v", cidrs)
+	}
+}
+
+func TestRuleExistsRequiresPriorityBeforeCNISourceRules(t *testing.T) {
+	mask := uint32(1)
+	rules := []netlink.Rule{
+		{Mark: 1, Mask: &mask, Table: ruleTableID, Priority: 32765},
+	}
+
+	if ruleExists(rules, 1, 1, ruleTableID, policyRulePriority) {
+		t.Fatal("late fallback rule must not satisfy the required TPROXY policy rule")
+	}
+
+	rules = append(rules, netlink.Rule{
+		Mark:     1,
+		Mask:     &mask,
+		Table:    ruleTableID,
+		Priority: policyRulePriority,
+	})
+	if !ruleExists(rules, 1, 1, ruleTableID, policyRulePriority) {
+		t.Fatal("expected the high-priority TPROXY policy rule to match")
+	}
+}
+
+func TestRuleMatchesRequiresExactMarkMaskAndTable(t *testing.T) {
+	mask := uint32(1)
+	rule := netlink.Rule{Mark: 1, Mask: &mask, Table: ruleTableID}
+
+	if !ruleMatches(rule, 1, 1, ruleTableID) {
+		t.Fatal("expected exact rule signature to match")
+	}
+	if ruleMatches(rule, 2, 1, ruleTableID) {
+		t.Fatal("unexpected mark match")
+	}
+	if ruleMatches(rule, 1, 2, ruleTableID) {
+		t.Fatal("unexpected mask match")
+	}
+	if ruleMatches(rule, 1, 1, ruleTableID+1) {
+		t.Fatal("unexpected table match")
+	}
+	rule.Mask = nil
+	if ruleMatches(rule, 1, 1, ruleTableID) {
+		t.Fatal("rule without a mask must not match")
 	}
 }
 


### PR DESCRIPTION
## Summary

- install netd's `fwmark 0x1/0x1 lookup 100` policy rule at priority `100`
- treat the previous auto-assigned low-priority rule as stale and remove it after the high-priority rule exists
- add regression coverage for the required priority and exact rule signature

## Root cause

The ACK/Terway rollout of `--enable-host-legacy-routing=true` restored host-netfilter visibility: a temporary sandbox HTTPS SYN incremented netd's TPROXY counter. The connection still timed out before reaching the transparent listener, and no audit event was emitted.

Live node routing showed why:

```text
2048: from <pod-ip> lookup 1003
32765: from all fwmark 0x1/0x1 lookup 100
```

netd did not set a policy-rule priority, so the kernel assigned `32765`. Terway's per-pod source rule at `2048` won first and routed the marked packet away from netd's `local default dev lo` route in table 100.

Priority `100` runs after the kernel local rule but before Terway's destination/source rules (`512`/`2048`), so marked TPROXY traffic reaches the host-local transparent listener.

## Validation

- `git diff --check`
- `go test ./netd/pkg/redirect`
- `go test ./netd/...`

Production currently remains rolled back to Cilium `Host: BPF`; sandbox HTTPS is healthy. After this PR is merged and a fixed netd image is deployed, host legacy routing will be re-enabled with a controlled Terraform target and validated using HTTPS plus `network_audit` evidence.
