### PR TITLE
fix: serialize ctld CSI registrar rollouts

### DIFF
--- a/infra-operator/internal/controller/services/ctld/ctld.go
+++ b/infra-operator/internal/controller/services/ctld/ctld.go
@@ -330,6 +330,12 @@ func buildCtldDaemonSet(cfg ctldDaemonSetConfig) *appsv1.DaemonSet {
 	}
 	maxUnavailable := intstr.FromInt(0)
 	maxSurge := intstr.FromInt(1)
+	if cfg.IncludeRegistrar {
+		// The registrar owns one node-global socket. If slot A surges, the old
+		// sidecar can unlink the new sidecar's socket while it terminates.
+		maxUnavailable = intstr.FromInt(1)
+		maxSurge = intstr.FromInt(0)
+	}
 	return &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{Name: cfg.Name + "-" + cfg.Slot, Namespace: cfg.Namespace},
 		Spec: appsv1.DaemonSetSpec{

--- a/infra-operator/internal/controller/services/ctld/ctld_test.go
+++ b/infra-operator/internal/controller/services/ctld/ctld_test.go
@@ -186,13 +186,9 @@ func reconcileCtldResources(t *testing.T, infra *infrav1alpha1.Sandbox0Infra, ex
 		if len(workload.Spec.Template.Spec.Containers[0].Ports) != 0 {
 			t.Fatalf("ctld hostNetwork pod %s reserves node ports: %#v", workload.Name, workload.Spec.Template.Spec.Containers[0].Ports)
 		}
-		if workload.Spec.UpdateStrategy.RollingUpdate == nil || workload.Spec.UpdateStrategy.RollingUpdate.MaxSurge == nil || workload.Spec.UpdateStrategy.RollingUpdate.MaxSurge.IntValue() != 1 {
-			t.Fatalf("expected ctld maxSurge=1, got %#v", workload.Spec.UpdateStrategy)
-		}
-		if workload.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable == nil || workload.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable.IntValue() != 0 {
-			t.Fatalf("expected ctld maxUnavailable=0, got %#v", workload.Spec.UpdateStrategy)
-		}
 	}
+	assertCtldRollingUpdate(t, ds, 1, 0)
+	assertCtldRollingUpdate(t, standby, 0, 1)
 	if len(ds.Spec.Template.Spec.Containers[0].VolumeMounts) < 7 {
 		t.Fatalf("expected ctld config, csi, kubelet, data, containerd socket, and containerd data mounts, got %#v", ds.Spec.Template.Spec.Containers[0].VolumeMounts)
 	}
@@ -206,6 +202,21 @@ func reconcileCtldResources(t *testing.T, infra *infrav1alpha1.Sandbox0Infra, ex
 	}
 
 	return ds, client
+}
+
+func assertCtldRollingUpdate(t *testing.T, daemonSet *appsv1.DaemonSet, maxUnavailable, maxSurge int) {
+	t.Helper()
+
+	rollingUpdate := daemonSet.Spec.UpdateStrategy.RollingUpdate
+	if rollingUpdate == nil || rollingUpdate.MaxUnavailable == nil || rollingUpdate.MaxSurge == nil {
+		t.Fatalf("expected ctld rolling update strategy, got %#v", daemonSet.Spec.UpdateStrategy)
+	}
+	if got := rollingUpdate.MaxUnavailable.IntValue(); got != maxUnavailable {
+		t.Fatalf("expected %s maxUnavailable=%d, got %d", daemonSet.Name, maxUnavailable, got)
+	}
+	if got := rollingUpdate.MaxSurge.IntValue(); got != maxSurge {
+		t.Fatalf("expected %s maxSurge=%d, got %d", daemonSet.Name, maxSurge, got)
+	}
 }
 
 func assertCtldProbe(t *testing.T, name string, probe *corev1.Probe, kind string, periodSeconds int32) {


### PR DESCRIPTION
## Summary
- roll ctld slot A with maxUnavailable=1 and maxSurge=0
- keep zero-unavailable surge updates for registrar-free slot B
- test both slot-specific update strategies

## Why
The CSI node-driver registrar uses one node-global registration socket. During the production image rollout, the new slot-A registrar registered successfully, then the old surged Pod terminated and unlinked that shared socket. The new process kept listening on an unlinked inode, so the Pod stayed 2/2 Ready while CSINode no longer listed `volume.sandbox0.ai`; all new sandbox Pods failed to mount volumes.

Slot B remains available for ctld HA while slot A is replaced, so slot A can safely stop before its replacement starts. This prevents two registrar sidecars on one node from racing over the same socket.

## Validation
- `go test ./infra-operator/internal/controller/services/ctld`
- `go test ./infra-operator/internal/controller/...`
- live recovery confirmed that replacing slot A without a concurrent old registrar restored the CSINode driver and the default pool to 15/15 Ready
