### PR TITLE
refactor(metering): deliver ClickHouse usage through PostgreSQL outbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Sandbox0 separates region-scoped control-plane services from cluster-scoped data
 | Control plane | Optional `regional-gateway`, optional `scheduler` | Tenant/API key management, cluster selection, internal routing, template distribution |
 | Data plane | `cluster-gateway`, `manager`, `ctld`, optional `storage-proxy`, optional `netd` | Sandbox lifecycle, rootfs checkpoints, process/file APIs, volume storage, network enforcement |
 | In-pod runtime | `procd` | PID 1 inside each sandbox pod, process abstraction, file I/O, volume mount operations |
-| Storage | PostgreSQL plus S3-compatible object storage | Metadata, usage truth, events, rootfs/volume data |
+| Storage | PostgreSQL, ClickHouse, and S3-compatible object storage | Transactional metadata and metering delivery, long-term usage truth, rootfs/volume data |
 
 Self-hosting is operator-first:
 

--- a/docs/self-hosted/configuration/page.mdx
+++ b/docs/self-hosted/configuration/page.mdx
@@ -72,7 +72,9 @@ Schedulers consume the manager cluster summary fields `claim_start_limit`, `clai
 
 ## Metering Boundary
 
-Sandbox0 records usage truth in the region usage ledger and exports it from the region-scoped metering endpoints. Metering is disabled by default. When `spec.metering.enabled` is `true`, metering requires `spec.clickHouse.type` to be `builtin` or `external` and writes usage truth only to ClickHouse. PostgreSQL remains the control-plane and data-plane state database; it is not a metering backend. Billing systems should rate exported usage windows outside the open-source data plane.
+Sandbox0 records usage truth in the region usage ledger and exports it from the region-scoped metering endpoints. Metering is disabled by default. When `spec.metering.enabled` is `true`, metering requires `spec.clickHouse.type` to be `builtin` or `external`. ClickHouse is the long-term usage ledger and the only metering query/export backend. PostgreSQL holds only a compact transactional delivery outbox and producer projection state; it is not a second queryable usage ledger. Producers capture stable, idempotent ClickHouse operations in that outbox, storage mutations use the same PostgreSQL business transaction, and manager retries the oldest transaction batch until ClickHouse accepts it.
+
+Metering export is therefore eventually consistent. Manager lifecycle events and storage mutations are normally visible after the projector poll (about two seconds). Netd byte windows add `meteringReportInterval` (10 seconds by default), while periodic storage byte-hour windows add up to one minute. A ClickHouse outage increases this delay without discarding committed outbox operations; after the one-time projection-state bootstrap has completed, producers can also restart while ClickHouse is unavailable. Export watermarks advance only after all older batches have been delivered. Monitor `manager_metering_outbox_pending_operations` and `manager_metering_outbox_oldest_pending_age_seconds` for delivery backlog. Billing systems should consume the exported watermark and rate usage windows outside the open-source data plane.
 
 Sandbox compute uses a serverless-style contract:
 

--- a/infra-operator/api/config/metering.go
+++ b/infra-operator/api/config/metering.go
@@ -6,7 +6,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // MeteringConfig is the runtime configuration for the optional region usage
 // ledger. When disabled, services must not emit usage records.
 type MeteringConfig struct {
-	// Enabled enables ClickHouse-backed metering.
+	// Enabled enables PostgreSQL-buffered, ClickHouse-backed metering.
 	// +optional
 	// +kubebuilder:default=false
 	Enabled bool `yaml:"enabled" json:"enabled"`
@@ -15,7 +15,7 @@ type MeteringConfig struct {
 	ClickHouse MeteringClickHouseConfig `yaml:"clickhouse" json:"clickHouse"`
 }
 
-// MeteringClickHouseConfig names the ClickHouse tables used for metering truth.
+// MeteringClickHouseConfig names the ClickHouse tables used for long-term metering truth.
 type MeteringClickHouseConfig struct {
 	// DSN is the ClickHouse database/sql connection string. It may include credentials.
 	// +optional

--- a/infra-operator/api/v1alpha1/service_api_config_types.go
+++ b/infra-operator/api/v1alpha1/service_api_config_types.go
@@ -530,7 +530,7 @@ type ClickHouseSchemaMigrationConfig struct {
 
 // MeteringConfig defines the region usage ledger backend.
 type MeteringConfig struct {
-	// Enabled enables ClickHouse-backed metering. Metering is disabled by default.
+	// Enabled enables PostgreSQL-buffered, ClickHouse-backed metering. Metering is disabled by default.
 	// +optional
 	// +kubebuilder:default=false
 	Enabled *bool `json:"enabled,omitempty"`

--- a/infra-operator/chart/crds/infra.sandbox0.ai_sandbox0infras.yaml
+++ b/infra-operator/chart/crds/infra.sandbox0.ai_sandbox0infras.yaml
@@ -1793,8 +1793,8 @@ spec:
                     type: object
                   enabled:
                     default: false
-                    description: Enabled enables ClickHouse-backed metering. Metering
-                      is disabled by default.
+                    description: Enabled enables PostgreSQL-buffered, ClickHouse-backed
+                      metering. Metering is disabled by default.
                     type: boolean
                 type: object
               observability:

--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -33,6 +34,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	s0k8s "github.com/sandbox0-ai/sandbox0/pkg/k8s"
 	meteringclickhouse "github.com/sandbox0-ai/sandbox0/pkg/metering/clickhouse"
+	meteringoutbox "github.com/sandbox0-ai/sandbox0/pkg/metering/outbox"
 	"github.com/sandbox0-ai/sandbox0/pkg/migrate"
 	"github.com/sandbox0-ai/sandbox0/pkg/observability"
 	httpobs "github.com/sandbox0-ai/sandbox0/pkg/observability/http"
@@ -140,6 +142,11 @@ func main() {
 	}
 	if err := runEgressAuthMigrations(ctx, pool, logger); err != nil {
 		logger.Fatal("Failed to run egress auth migrations", zap.Error(err))
+	}
+	if cfg.Metering.Enabled {
+		if err := meteringoutbox.RunMigrations(ctx, pool, observability.NewMigrateLogger(logger)); err != nil {
+			logger.Fatal("Failed to run metering outbox migrations", zap.Error(err))
+		}
 	}
 	if err := runSandboxStoreMigrations(ctx, pool, logger); err != nil {
 		logger.Fatal("Failed to run sandbox store migrations", zap.Error(err))
@@ -249,7 +256,7 @@ func main() {
 
 	sandboxIndex := service.NewSandboxIndex()
 	podInformer.Informer().AddEventHandler(sandboxIndex.ResourceEventHandler())
-	meteringDB, meteringRepo, err := initMetering(ctx, cfg, logger)
+	meteringDB, meteringSink, meteringSinkReady, err := initMetering(ctx, cfg, logger)
 	if err != nil {
 		logger.Fatal("Failed to initialize metering backend", zap.Error(err))
 	}
@@ -257,6 +264,39 @@ func main() {
 		defer meteringDB.Close()
 	}
 	sandboxStore := service.NewPGSandboxStore(pool)
+	var meteringRepo *meteringoutbox.Repository
+	if cfg.Metering.Enabled {
+		meteringRepo = meteringoutbox.NewRepository(pool)
+	}
+	if meteringRepo != nil && meteringSink != nil {
+		bootstrapCompleted, err := meteringRepo.ProjectionBootstrapCompleted(ctx)
+		if err != nil {
+			logger.Fatal("Failed to inspect metering projection bootstrap", zap.Error(err))
+		}
+		if !meteringSinkReady && !bootstrapCompleted {
+			logger.Fatal("ClickHouse must be reachable for the initial metering projection bootstrap")
+		}
+		if meteringSinkReady {
+			bootstrap, err := meteringRepo.BootstrapProjectionStates(ctx, meteringSink)
+			if err != nil {
+				logger.Fatal("Failed to bootstrap metering projection state", zap.Error(err))
+			}
+			logger.Info("Metering projection state bootstrapped",
+				zap.Int64("sandbox_states", bootstrap.SandboxStates),
+				zap.Int64("storage_states", bootstrap.StorageStates),
+			)
+		} else {
+			logger.Warn("Starting with deferred ClickHouse metering delivery; projection bootstrap is already complete")
+		}
+		projector := meteringoutbox.NewProjector(meteringRepo, meteringSink, meteringoutbox.ProjectorConfig{}, logger)
+		projector.SetMetrics(managerMetrics)
+		go func() {
+			if err := projector.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
+				logger.Error("Metering outbox projector stopped", zap.Error(err))
+			}
+		}()
+		logger.Info("Metering PostgreSQL outbox projector started")
+	}
 	if meteringRepo != nil {
 		lifecycleProjector := managermetering.NewLifecycleProjector(managermetering.NewStore(meteringRepo), cfg.RegionID, cfg.DefaultClusterId)
 		lifecycleProjector.SetLogger(logger)
@@ -377,8 +417,8 @@ func main() {
 		managerMetrics,
 	)
 	var quotaUsageStore quota.UsageStore
-	if meteringRepo != nil {
-		quotaUsageStore = meteringRepo
+	if meteringSink != nil {
+		quotaUsageStore = meteringSink
 	}
 	quotaRepo, err := buildQuotaRepository(pool, cfg, quotaUsageStore)
 	if err != nil {
@@ -726,9 +766,9 @@ func runEgressAuthMigrations(ctx context.Context, pool *pgxpool.Pool, logger *za
 	return nil
 }
 
-func initMetering(ctx context.Context, cfg *config.ManagerConfig, logger *zap.Logger) (*sql.DB, *meteringclickhouse.Repository, error) {
+func initMetering(ctx context.Context, cfg *config.ManagerConfig, logger *zap.Logger) (*sql.DB, *meteringclickhouse.Repository, bool, error) {
 	if cfg == nil || !cfg.Metering.Enabled {
-		return nil, nil, nil
+		return nil, nil, false, nil
 	}
 	ch := cfg.Metering.ClickHouse
 	timeout := ch.ConnectTimeout.Duration
@@ -737,7 +777,7 @@ func initMetering(ctx context.Context, cfg *config.ManagerConfig, logger *zap.Lo
 	}
 	connectCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-	db, repo, err := meteringclickhouse.Open(connectCtx, meteringclickhouse.OpenConfig{
+	openConfig := meteringclickhouse.OpenConfig{
 		DSN: strings.TrimSpace(ch.DSN),
 		Schema: meteringclickhouse.Config{
 			Database:          ch.Database,
@@ -748,9 +788,15 @@ func initMetering(ctx context.Context, cfg *config.ManagerConfig, logger *zap.Lo
 			StorageStateTable: ch.StorageStateTable,
 		},
 		Migrate: !ch.SkipSchemaMigration,
-	})
+	}
+	db, repo, err := meteringclickhouse.Open(connectCtx, openConfig)
 	if err != nil {
-		return nil, nil, fmt.Errorf("initialize clickhouse metering backend: %w", err)
+		deferredDB, deferredRepo, deferredErr := meteringclickhouse.OpenDeferred(openConfig)
+		if deferredErr != nil {
+			return nil, nil, false, fmt.Errorf("initialize deferred clickhouse metering backend after %v: %w", err, deferredErr)
+		}
+		logger.Warn("Metering ClickHouse backend is unavailable; delivery will retry from PostgreSQL", zap.Error(err))
+		return deferredDB, deferredRepo, false, nil
 	}
 	logger.Info("Metering ClickHouse backend initialized",
 		zap.String("database", ch.Database),
@@ -758,7 +804,7 @@ func initMetering(ctx context.Context, cfg *config.ManagerConfig, logger *zap.Lo
 		zap.String("windows_table", ch.WindowsTable),
 		zap.Bool("schema_migration", !ch.SkipSchemaMigration),
 	)
-	return db, repo, nil
+	return db, repo, true, nil
 }
 
 func buildQuotaRepository(pool *pgxpool.Pool, cfg *config.ManagerConfig, usageStore quota.UsageStore) (*quota.Repository, error) {

--- a/manager/pkg/metering/lifecycle_projector.go
+++ b/manager/pkg/metering/lifecycle_projector.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -102,14 +103,17 @@ type LifecycleProjector struct {
 	logger             *zap.Logger
 	metrics            *obsmetrics.ManagerMetrics
 	now                func() time.Time
+	projectionMu       sync.RWMutex
+	activeProjections  map[string]activeSandboxProjectionInputs
 }
 
 func NewLifecycleProjector(store Store, regionID string, clusterID string) *LifecycleProjector {
 	return &LifecycleProjector{
-		store:     store,
-		regionID:  regionID,
-		clusterID: clusterID,
-		logger:    zap.NewNop(),
+		store:             store,
+		regionID:          regionID,
+		clusterID:         clusterID,
+		logger:            zap.NewNop(),
+		activeProjections: make(map[string]activeSandboxProjectionInputs),
 		now: func() time.Time {
 			return time.Now().UTC()
 		},
@@ -152,8 +156,7 @@ func (p *LifecycleProjector) handleUpdate(oldObj, newObj any) {
 		p.handleUpsert(newObj)
 		return
 	}
-	if isClaimedActiveSandbox(oldPod) && isClaimedActiveSandbox(newPod) &&
-		activeSandboxProjectionInput(oldPod) == activeSandboxProjectionInput(newPod) {
+	if isClaimedActiveSandbox(newPod) && p.activeProjectionSucceeded(newPod) {
 		return
 	}
 	p.handleUpsert(newObj)
@@ -291,6 +294,7 @@ func (p *LifecycleProjector) handleUpsert(obj any) {
 	if err := p.commitProjection(ctx, sandboxID, state, pendingEvents, pendingWindows, observedAt); err != nil {
 		return
 	}
+	p.rememberActiveProjection(pod)
 }
 
 func (p *LifecycleProjector) handleDelete(obj any) {
@@ -377,6 +381,7 @@ func (p *LifecycleProjector) handleDelete(obj any) {
 		if err := p.commitProjection(ctx, sandboxID, state, pendingEvents, pendingWindows, observedAt); err != nil {
 			return
 		}
+		p.forgetActiveProjection(sandboxID)
 		return
 	}
 	if state.TerminatedAt == nil {
@@ -393,6 +398,37 @@ func (p *LifecycleProjector) handleDelete(obj any) {
 	if err := p.commitProjection(ctx, sandboxID, state, pendingEvents, pendingWindows, observedAt); err != nil {
 		return
 	}
+	p.forgetActiveProjection(sandboxID)
+}
+
+func (p *LifecycleProjector) activeProjectionSucceeded(pod *corev1.Pod) bool {
+	input := activeSandboxProjectionInput(pod)
+	if input.sandboxID == "" {
+		return false
+	}
+	p.projectionMu.RLock()
+	projected, ok := p.activeProjections[input.sandboxID]
+	p.projectionMu.RUnlock()
+	return ok && projected == input
+}
+
+func (p *LifecycleProjector) rememberActiveProjection(pod *corev1.Pod) {
+	input := activeSandboxProjectionInput(pod)
+	if input.sandboxID == "" {
+		return
+	}
+	p.projectionMu.Lock()
+	p.activeProjections[input.sandboxID] = input
+	p.projectionMu.Unlock()
+}
+
+func (p *LifecycleProjector) forgetActiveProjection(sandboxID string) {
+	if sandboxID == "" {
+		return
+	}
+	p.projectionMu.Lock()
+	delete(p.activeProjections, sandboxID)
+	p.projectionMu.Unlock()
 }
 
 func (p *LifecycleProjector) runtimeDeletionIsPause(ctx context.Context, info RuntimeDeletionInfo) (bool, error) {

--- a/manager/pkg/metering/lifecycle_projector_test.go
+++ b/manager/pkg/metering/lifecycle_projector_test.go
@@ -187,6 +187,33 @@ func TestLifecycleProjectorIgnoresStatusOnlySandboxUpdates(t *testing.T) {
 	}
 }
 
+func TestLifecycleProjectorRetriesStatusOnlyUpdateAfterFailedProjection(t *testing.T) {
+	recorder := &fakeRecorder{
+		states: map[string]*meteringpkg.SandboxProjectionState{},
+		txErr:  errors.New("postgres unavailable"),
+	}
+	projector := NewLifecycleProjector(recorder, "aws-us-east-1", "cluster-a")
+	claimedAt := time.Date(2026, 3, 12, 10, 0, 0, 0, time.UTC)
+	oldPod := withSandboxResources(buildSandboxPod(claimedAt, false, "", "1"), "1", "1Gi")
+	projector.handleUpsert(oldPod)
+
+	recorder.txErr = nil
+	newPod := oldPod.DeepCopy()
+	newPod.ResourceVersion = "2"
+	newPod.Status.Phase = corev1.PodRunning
+	projector.handleUpdate(oldPod, newPod)
+
+	if recorder.transactionCalls != 1 {
+		t.Fatalf("successful transaction calls = %d, want 1 retry", recorder.transactionCalls)
+	}
+	if len(recorder.events) != 1 || recorder.events[0].EventType != meteringpkg.EventTypeSandboxClaimed {
+		t.Fatalf("events after retry = %#v, want claimed event", recorder.events)
+	}
+	if state := recorder.states["sb-1"]; state == nil || state.LastResourceVer != "2" {
+		t.Fatalf("state after retry = %#v, want resource version 2", state)
+	}
+}
+
 func TestLifecycleProjectorPersistsMeteringRelevantSandboxUpdates(t *testing.T) {
 	recorder := &fakeRecorder{states: map[string]*meteringpkg.SandboxProjectionState{}}
 	projector := NewLifecycleProjector(recorder, "aws-us-east-1", "cluster-a")

--- a/netd/pkg/daemon/daemon.go
+++ b/netd/pkg/daemon/daemon.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/dbpool"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	meteringclickhouse "github.com/sandbox0-ai/sandbox0/pkg/metering/clickhouse"
+	meteringoutbox "github.com/sandbox0-ai/sandbox0/pkg/metering/outbox"
 	"github.com/sandbox0-ai/sandbox0/pkg/observability"
 	httpobs "github.com/sandbox0-ai/sandbox0/pkg/observability/http"
 	"github.com/sandbox0-ai/sandbox0/pkg/quota"
@@ -177,13 +178,16 @@ func (d *Daemon) runNetd(ctx context.Context, cancel context.CancelFunc, proxyEx
 		}
 	}
 	if d.cfg.Metering.Enabled {
-		db, repo, err := d.openMetering(ctx)
+		if databasePool == nil {
+			return fmt.Errorf("DATABASE_URL is required when metering is enabled")
+		}
+		db, usageStore, err := d.openMetering(ctx)
 		if err != nil {
 			return err
 		}
 		meteringDB = sqlRuntimeResource{db: db}
 		usageAggregator = netdmetering.NewAggregator(
-			netdmetering.NewRecorder(repo),
+			netdmetering.NewRecorder(meteringoutbox.NewRepository(databasePool)),
 			d.cfg.RegionID,
 			d.cfg.ClusterID,
 			d.cfg.NodeName,
@@ -191,7 +195,7 @@ func (d *Daemon) runNetd(ctx context.Context, cancel context.CancelFunc, proxyEx
 		)
 		if databasePool != nil {
 			quotaRepo := quota.NewRepository(databasePool)
-			quotaRepo.SetUsageStore(repo)
+			quotaRepo.SetUsageStore(usageStore)
 			usageAggregator.SetQuotaStore(quotaRepo)
 		}
 	}
@@ -356,7 +360,7 @@ func (d *Daemon) openMetering(ctx context.Context) (*sql.DB, *meteringclickhouse
 	}
 	connectCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-	db, repo, err := meteringclickhouse.Open(connectCtx, meteringclickhouse.OpenConfig{
+	openConfig := meteringclickhouse.OpenConfig{
 		DSN: strings.TrimSpace(ch.DSN),
 		Schema: meteringclickhouse.Config{
 			Database:          ch.Database,
@@ -367,9 +371,15 @@ func (d *Daemon) openMetering(ctx context.Context) (*sql.DB, *meteringclickhouse
 			StorageStateTable: ch.StorageStateTable,
 		},
 		Migrate: !ch.SkipSchemaMigration,
-	})
+	}
+	db, repo, err := meteringclickhouse.Open(connectCtx, openConfig)
 	if err != nil {
-		return nil, nil, fmt.Errorf("initialize clickhouse metering backend: %w", err)
+		deferredDB, deferredRepo, deferredErr := meteringclickhouse.OpenDeferred(openConfig)
+		if deferredErr != nil {
+			return nil, nil, fmt.Errorf("initialize deferred clickhouse metering backend after %v: %w", err, deferredErr)
+		}
+		d.logger.Warn("Metering ClickHouse backend is unavailable; usage capture will continue in PostgreSQL", zap.Error(err))
+		return deferredDB, deferredRepo, nil
 	}
 	d.logger.Info("Metering ClickHouse backend initialized",
 		zap.String("database", ch.Database),

--- a/netd/pkg/metering/aggregator.go
+++ b/netd/pkg/metering/aggregator.go
@@ -74,6 +74,12 @@ type usageTotals struct {
 	ingress   int64
 }
 
+type usageBatch struct {
+	start time.Time
+	end   time.Time
+	usage map[string]*usageTotals
+}
+
 type Aggregator struct {
 	recorder    Recorder
 	regionID    string
@@ -86,6 +92,7 @@ type Aggregator struct {
 	mu          sync.Mutex
 	windowStart time.Time
 	usage       map[string]*usageTotals
+	pending     *usageBatch
 }
 
 func NewAggregator(recorder Recorder, regionID, clusterID, nodeName string, logger *zap.Logger) *Aggregator {
@@ -189,15 +196,23 @@ func (a *Aggregator) allowNetworkUsage(ctx context.Context, compiled *policypkg.
 
 func (a *Aggregator) localNetworkUsageLocked(teamID string, dimension quota.Dimension) int64 {
 	var total int64
-	for _, usage := range a.usage {
+	add := func(usage *usageTotals) {
 		if usage == nil || usage.teamID != teamID {
-			continue
+			return
 		}
 		switch dimension {
 		case quota.DimensionEgress:
 			total += usage.egress
 		case quota.DimensionIngress:
 			total += usage.ingress
+		}
+	}
+	for _, usage := range a.usage {
+		add(usage)
+	}
+	if a.pending != nil {
+		for _, usage := range a.pending.usage {
+			add(usage)
 		}
 	}
 	return total
@@ -208,63 +223,67 @@ func (a *Aggregator) Flush(ctx context.Context) error {
 		return nil
 	}
 
-	end := a.now()
+	for {
+		batch, retrying := a.pendingBatch()
+		err := a.recorder.RunInTx(ctx, func(tx txRecorder) error {
+			for _, usage := range batch.usage {
+				if usage.egress > 0 {
+					if err := tx.AppendWindow(ctx, a.buildWindow(usage, meteringpkg.WindowTypeSandboxEgressBytes, batch.start, batch.end, usage.egress)); err != nil {
+						return err
+					}
+				}
+				if usage.ingress > 0 {
+					if err := tx.AppendWindow(ctx, a.buildWindow(usage, meteringpkg.WindowTypeSandboxIngressBytes, batch.start, batch.end, usage.ingress)); err != nil {
+						return err
+					}
+				}
+			}
+			return tx.UpsertProducerWatermark(ctx, a.producer, a.regionID, batch.end)
+		})
+		if err != nil {
+			a.logger.Error("Failed to flush netd metering windows",
+				zap.String("producer", a.producer),
+				zap.Time("window_start", batch.start),
+				zap.Time("window_end", batch.end),
+				zap.Error(err),
+			)
+			return err
+		}
+
+		a.mu.Lock()
+		if a.pending == batch {
+			a.pending = nil
+		}
+		hasResidual := len(a.usage) > 0
+		a.mu.Unlock()
+		if !retrying || !hasResidual {
+			return nil
+		}
+	}
+}
+
+func (a *Aggregator) pendingBatch() (*usageBatch, bool) {
 	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.pending != nil {
+		return a.pending, true
+	}
+	end := a.now()
 	start := a.windowStart
 	if start.IsZero() {
 		start = end
 	}
-	snapshot := cloneUsage(a.usage)
-	a.mu.Unlock()
-
 	if end.Before(start) {
 		end = start
 	}
-
-	err := a.recorder.RunInTx(ctx, func(tx txRecorder) error {
-		for _, usage := range snapshot {
-			if usage.egress > 0 {
-				if err := tx.AppendWindow(ctx, a.buildWindow(usage, meteringpkg.WindowTypeSandboxEgressBytes, start, end, usage.egress)); err != nil {
-					return err
-				}
-			}
-			if usage.ingress > 0 {
-				if err := tx.AppendWindow(ctx, a.buildWindow(usage, meteringpkg.WindowTypeSandboxIngressBytes, start, end, usage.ingress)); err != nil {
-					return err
-				}
-			}
-		}
-		return tx.UpsertProducerWatermark(ctx, a.producer, a.regionID, end)
-	})
-	if err != nil {
-		a.logger.Error("Failed to flush netd metering windows",
-			zap.String("producer", a.producer),
-			zap.Error(err),
-		)
-		return err
+	a.pending = &usageBatch{
+		start: start,
+		end:   end,
+		usage: a.usage,
 	}
-
-	a.mu.Lock()
-	defer a.mu.Unlock()
+	a.usage = make(map[string]*usageTotals)
 	a.windowStart = end
-	for sandboxID, usage := range snapshot {
-		current := a.usage[sandboxID]
-		if current == nil {
-			continue
-		}
-		current.egress -= usage.egress
-		current.ingress -= usage.ingress
-		if current.egress < 0 {
-			current.egress = 0
-		}
-		if current.ingress < 0 {
-			current.ingress = 0
-		}
-		if current.egress == 0 && current.ingress == 0 {
-			delete(a.usage, sandboxID)
-		}
-	}
-	return nil
+	return a.pending, false
 }
 
 func (a *Aggregator) buildWindow(usage *usageTotals, windowType string, start, end time.Time, value int64) *meteringpkg.Window {
@@ -305,18 +324,6 @@ func producerName(nodeName string) string {
 
 func windowID(producer, sandboxID, windowType string, start, end time.Time) string {
 	return fmt.Sprintf("%s/%s/%s/%d/%d", producer, sandboxID, windowType, start.UTC().UnixNano(), end.UTC().UnixNano())
-}
-
-func cloneUsage(in map[string]*usageTotals) map[string]*usageTotals {
-	out := make(map[string]*usageTotals, len(in))
-	for key, value := range in {
-		if value == nil {
-			continue
-		}
-		copied := *value
-		out[key] = &copied
-	}
-	return out
 }
 
 func mustJSON(value any) json.RawMessage {

--- a/netd/pkg/metering/aggregator_test.go
+++ b/netd/pkg/metering/aggregator_test.go
@@ -144,12 +144,32 @@ func TestAggregatorFlushFailureRetainsUsage(t *testing.T) {
 	}
 
 	agg.mu.Lock()
-	defer agg.mu.Unlock()
-	if agg.usage["sb-1"] == nil || agg.usage["sb-1"].egress != 50 {
-		t.Fatalf("usage not retained after failure: %#v", agg.usage["sb-1"])
+	if agg.pending == nil || agg.pending.usage["sb-1"] == nil || agg.pending.usage["sb-1"].egress != 50 {
+		t.Fatalf("pending usage not retained after failure: %#v", agg.pending)
 	}
-	if !agg.windowStart.Equal(start) {
-		t.Fatalf("window start advanced on failure: %v", agg.windowStart)
+	failedStart := agg.pending.start
+	failedEnd := agg.pending.end
+	agg.mu.Unlock()
+	if !failedStart.Equal(start) || !failedEnd.Equal(end) {
+		t.Fatalf("failed window = [%v, %v], want [%v, %v]", failedStart, failedEnd, start, end)
+	}
+
+	nextEnd := end.Add(10 * time.Second)
+	agg.now = func() time.Time { return nextEnd }
+	agg.RecordEgress(&policypkg.CompiledPolicy{SandboxID: "sb-1", TeamID: "team-1"}, 25)
+	recorder.tx.appendErr = nil
+	if err := agg.Flush(context.Background()); err != nil {
+		t.Fatalf("retry Flush: %v", err)
+	}
+	if len(recorder.tx.windows) != 2 {
+		t.Fatalf("window count after retry = %d, want 2", len(recorder.tx.windows))
+	}
+	first, second := recorder.tx.windows[0], recorder.tx.windows[1]
+	if first.Value != 50 || !first.WindowStart.Equal(start) || !first.WindowEnd.Equal(end) {
+		t.Fatalf("retried window = %#v, want stable failed interval", first)
+	}
+	if second.Value != 25 || !second.WindowStart.Equal(end) || !second.WindowEnd.Equal(nextEnd) {
+		t.Fatalf("residual window = %#v, want separate next interval", second)
 	}
 }
 

--- a/pkg/metering/clickhouse/open.go
+++ b/pkg/metering/clickhouse/open.go
@@ -16,22 +16,13 @@ type OpenConfig struct {
 }
 
 func Open(ctx context.Context, cfg OpenConfig) (*sql.DB, *Repository, error) {
-	dsn := strings.TrimSpace(cfg.DSN)
-	if dsn == "" {
-		return nil, nil, fmt.Errorf("clickhouse dsn is required")
-	}
-	db, err := sql.Open("clickhouse", dsn)
+	db, normalized, err := openDB(cfg)
 	if err != nil {
-		return nil, nil, fmt.Errorf("open clickhouse: %w", err)
+		return nil, nil, err
 	}
 	if err := db.PingContext(ctx); err != nil {
 		_ = db.Close()
 		return nil, nil, fmt.Errorf("ping clickhouse: %w", err)
-	}
-	normalized, err := normalizeConfig(cfg.Schema)
-	if err != nil {
-		_ = db.Close()
-		return nil, nil, err
 	}
 	if cfg.Migrate {
 		if err := ApplySchema(ctx, db, normalized); err != nil {
@@ -40,4 +31,31 @@ func Open(ctx context.Context, cfg OpenConfig) (*sql.DB, *Repository, error) {
 		}
 	}
 	return db, NewRepository(db, normalized), nil
+}
+
+// OpenDeferred validates the configuration without requiring ClickHouse to be
+// reachable. database/sql reconnects when the outbox projector retries later.
+func OpenDeferred(cfg OpenConfig) (*sql.DB, *Repository, error) {
+	db, normalized, err := openDB(cfg)
+	if err != nil {
+		return nil, nil, err
+	}
+	return db, NewRepository(db, normalized), nil
+}
+
+func openDB(cfg OpenConfig) (*sql.DB, Config, error) {
+	dsn := strings.TrimSpace(cfg.DSN)
+	if dsn == "" {
+		return nil, Config{}, fmt.Errorf("clickhouse dsn is required")
+	}
+	db, err := sql.Open("clickhouse", dsn)
+	if err != nil {
+		return nil, Config{}, fmt.Errorf("open clickhouse: %w", err)
+	}
+	normalized, err := normalizeConfig(cfg.Schema)
+	if err != nil {
+		_ = db.Close()
+		return nil, Config{}, err
+	}
+	return db, normalized, nil
 }

--- a/pkg/metering/clickhouse/open_test.go
+++ b/pkg/metering/clickhouse/open_test.go
@@ -1,0 +1,20 @@
+package clickhouse
+
+import "testing"
+
+func TestOpenDeferredDoesNotRequireReachableClickHouse(t *testing.T) {
+	db, repo, err := OpenDeferred(OpenConfig{
+		DSN: "clickhouse://127.0.0.1:1/default",
+		Schema: Config{
+			Database: "sandbox0_metering",
+		},
+		Migrate: true,
+	})
+	if err != nil {
+		t.Fatalf("OpenDeferred: %v", err)
+	}
+	defer db.Close()
+	if repo == nil {
+		t.Fatal("OpenDeferred returned nil repository")
+	}
+}

--- a/pkg/metering/clickhouse/repository.go
+++ b/pkg/metering/clickhouse/repository.go
@@ -5,11 +5,8 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"math"
-	"math/big"
 	"time"
 
-	"github.com/jackc/pgx/v5"
 	metering "github.com/sandbox0-ai/sandbox0/pkg/metering"
 	"github.com/sandbox0-ai/sandbox0/pkg/quota"
 )
@@ -31,18 +28,7 @@ func NewRepository(db *sql.DB, cfg Config) *Repository {
 	}
 }
 
-func (r *Repository) InTx(ctx context.Context, fn func(pgx.Tx) error) error {
-	if fn == nil {
-		return nil
-	}
-	return fn(nil)
-}
-
 func (r *Repository) AppendEvent(ctx context.Context, event *metering.Event) error {
-	return r.appendEvent(ctx, event)
-}
-
-func (r *Repository) AppendEventTx(ctx context.Context, _ pgx.Tx, event *metering.Event) error {
 	return r.appendEvent(ctx, event)
 }
 
@@ -100,10 +86,6 @@ INSERT INTO %s (
 }
 
 func (r *Repository) AppendWindow(ctx context.Context, window *metering.Window) error {
-	return r.appendWindow(ctx, window)
-}
-
-func (r *Repository) AppendWindowTx(ctx context.Context, _ pgx.Tx, window *metering.Window) error {
 	return r.appendWindow(ctx, window)
 }
 
@@ -172,10 +154,6 @@ INSERT INTO %s (
 }
 
 func (r *Repository) UpsertProducerWatermark(ctx context.Context, producer string, regionID string, completeBefore time.Time) error {
-	return r.upsertProducerWatermark(ctx, producer, regionID, completeBefore)
-}
-
-func (r *Repository) UpsertProducerWatermarkTx(ctx context.Context, _ pgx.Tx, producer string, regionID string, completeBefore time.Time) error {
 	return r.upsertProducerWatermark(ctx, producer, regionID, completeBefore)
 }
 
@@ -448,11 +426,49 @@ LIMIT 1
 	return state, nil
 }
 
-func (r *Repository) UpsertSandboxProjectionState(ctx context.Context, state *metering.SandboxProjectionState) error {
-	return r.upsertSandboxProjectionState(ctx, state)
+// ListActiveSandboxProjectionStates returns current producer state needed to
+// bootstrap the PostgreSQL delivery outbox during an upgrade.
+func (r *Repository) ListActiveSandboxProjectionStates(ctx context.Context) ([]*metering.SandboxProjectionState, error) {
+	rows, err := r.db.QueryContext(ctx, fmt.Sprintf(`
+SELECT
+    sandbox_id, namespace, team_id, user_id, template_id, cluster_id,
+    owner_kind, resource_millicpu, resource_memory_mib,
+    claimed_at, active_since, paused, paused_at, terminated_at,
+    last_observed_at, last_resource_version
+FROM %s FINAL
+WHERE terminated_at IS NULL
+`, qualified(r.cfg.Database, r.cfg.SandboxStateTable)))
+	if err != nil {
+		return nil, fmt.Errorf("query active sandbox projection states: %w", err)
+	}
+	defer rows.Close()
+	states := make([]*metering.SandboxProjectionState, 0)
+	for rows.Next() {
+		state := &metering.SandboxProjectionState{}
+		var paused uint8
+		var claimedAt, activeSince, pausedAt, terminatedAt sql.NullTime
+		if err := rows.Scan(
+			&state.SandboxID, &state.Namespace, &state.TeamID, &state.UserID, &state.TemplateID, &state.ClusterID,
+			&state.OwnerKind, &state.ResourceMillicpu, &state.ResourceMemoryMiB,
+			&claimedAt, &activeSince, &paused, &pausedAt, &terminatedAt,
+			&state.LastObservedAt, &state.LastResourceVer,
+		); err != nil {
+			return nil, fmt.Errorf("scan active sandbox projection state: %w", err)
+		}
+		state.Paused = paused != 0
+		state.ClaimedAt = nullableTimePtr(claimedAt)
+		state.ActiveSince = nullableTimePtr(activeSince)
+		state.PausedAt = nullableTimePtr(pausedAt)
+		state.TerminatedAt = nullableTimePtr(terminatedAt)
+		states = append(states, state)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate active sandbox projection states: %w", err)
+	}
+	return states, nil
 }
 
-func (r *Repository) UpsertSandboxProjectionStateTx(ctx context.Context, _ pgx.Tx, state *metering.SandboxProjectionState) error {
+func (r *Repository) UpsertSandboxProjectionState(ctx context.Context, state *metering.SandboxProjectionState) error {
 	return r.upsertSandboxProjectionState(ctx, state)
 }
 
@@ -488,209 +504,6 @@ INSERT INTO %s (
 	return nil
 }
 
-func (r *Repository) RecordStorageObservation(ctx context.Context, observation *metering.StorageObservation) error {
-	return r.recordStorageObservation(ctx, observation)
-}
-
-func (r *Repository) RecordStorageObservationTx(ctx context.Context, _ pgx.Tx, observation *metering.StorageObservation) error {
-	return r.recordStorageObservation(ctx, observation)
-}
-
-func (r *Repository) recordStorageObservation(ctx context.Context, observation *metering.StorageObservation) error {
-	state, err := r.normalizeStorageObservation(ctx, observation)
-	if err != nil {
-		return err
-	}
-	previous, err := r.getStorageProjectionState(ctx, state.SubjectType, state.SubjectID)
-	if err != nil {
-		return err
-	}
-	if previous != nil {
-		if state.ObservedAt.Before(previous.ObservedAt) {
-			return nil
-		}
-		window, remainder := storageWindowFromStateWithRemainder(previous, state.ObservedAt)
-		if window != nil {
-			if err := r.appendWindow(ctx, window); err != nil {
-				return err
-			}
-		}
-		state.UnbilledByteNanoseconds = remainder
-	}
-	return r.upsertStorageProjectionState(ctx, state)
-}
-
-func (r *Repository) CloseStorageObservation(ctx context.Context, observation *metering.StorageObservation) error {
-	return r.closeStorageObservation(ctx, observation)
-}
-
-func (r *Repository) CloseStorageObservationTx(ctx context.Context, _ pgx.Tx, observation *metering.StorageObservation) error {
-	return r.closeStorageObservation(ctx, observation)
-}
-
-func (r *Repository) closeStorageObservation(ctx context.Context, observation *metering.StorageObservation) error {
-	state, err := r.normalizeStorageObservation(ctx, observation)
-	if err != nil {
-		return err
-	}
-	previous, err := r.getStorageProjectionState(ctx, state.SubjectType, state.SubjectID)
-	if err != nil {
-		return err
-	}
-	if previous == nil {
-		if observation.ResourceCreatedAt.IsZero() || !state.ObservedAt.After(observation.ResourceCreatedAt) {
-			return nil
-		}
-		end := state.ObservedAt
-		state.ObservedAt = observation.ResourceCreatedAt.UTC()
-		if window, _ := storageWindowFromStateWithRemainder(state, end); window != nil {
-			return r.appendWindow(ctx, window)
-		}
-		return nil
-	}
-	if state.ObservedAt.Before(previous.ObservedAt) {
-		return r.deleteStorageProjectionState(ctx, previous, state.ObservedAt)
-	}
-	if window, _ := storageWindowFromStateWithRemainder(previous, state.ObservedAt); window != nil {
-		if err := r.appendWindow(ctx, window); err != nil {
-			return err
-		}
-	}
-	return r.deleteStorageProjectionState(ctx, previous, state.ObservedAt)
-}
-
-func (r *Repository) FlushStorageProjectionWindows(ctx context.Context, before time.Time, limit int) (int, error) {
-	if before.IsZero() {
-		before = r.now()
-	} else {
-		before = before.UTC()
-	}
-	if limit <= 0 {
-		limit = 500
-	}
-	rows, err := r.db.QueryContext(ctx, fmt.Sprintf(`
-SELECT
-    subject_type, subject_id, product, owner_kind,
-    team_id, user_id, sandbox_id, volume_id,
-    snapshot_id, cluster_id, region_id,
-    size_bytes, observed_at, unbilled_byte_nanoseconds
-FROM %s FINAL
-WHERE deleted = 0 AND observed_at < ?
-ORDER BY observed_at ASC
-LIMIT ?
-`, qualified(r.cfg.Database, r.cfg.StorageStateTable)), before, limit)
-	if err != nil {
-		return 0, fmt.Errorf("query storage projection states: %w", err)
-	}
-	defer rows.Close()
-	states := make([]*metering.StorageProjectionState, 0, limit)
-	for rows.Next() {
-		state := &metering.StorageProjectionState{}
-		if err := rows.Scan(
-			&state.SubjectType, &state.SubjectID, &state.Product, &state.OwnerKind,
-			&state.TeamID, &state.UserID, &state.SandboxID, &state.VolumeID,
-			&state.SnapshotID, &state.ClusterID, &state.RegionID,
-			&state.SizeBytes, &state.ObservedAt, &state.UnbilledByteNanoseconds,
-		); err != nil {
-			return 0, fmt.Errorf("scan storage projection state: %w", err)
-		}
-		states = append(states, state)
-	}
-	if err := rows.Err(); err != nil {
-		return 0, fmt.Errorf("iterate storage projection states: %w", err)
-	}
-	for _, state := range states {
-		window, remainder := storageWindowFromStateWithRemainder(state, before)
-		if window != nil {
-			if err := r.appendWindow(ctx, window); err != nil {
-				return 0, err
-			}
-		}
-		state.ObservedAt = before
-		state.UnbilledByteNanoseconds = remainder
-		if err := r.upsertStorageProjectionState(ctx, state); err != nil {
-			return 0, err
-		}
-	}
-	return len(states), nil
-}
-
-func (r *Repository) normalizeStorageObservation(ctx context.Context, observation *metering.StorageObservation) (*metering.StorageProjectionState, error) {
-	if observation == nil {
-		return nil, fmt.Errorf("storage observation is nil")
-	}
-	if observation.SubjectType == "" || observation.SubjectID == "" {
-		return nil, fmt.Errorf("storage subject_type and subject_id are required")
-	}
-	if observation.SubjectType != metering.SubjectTypeVolume && observation.SubjectType != metering.SubjectTypeSnapshot && observation.SubjectType != metering.SubjectTypeRootFS {
-		return nil, fmt.Errorf("unsupported storage subject_type %q", observation.SubjectType)
-	}
-	if observation.SizeBytes < 0 {
-		return nil, fmt.Errorf("storage size_bytes must be non-negative")
-	}
-	observedAt := observation.ObservedAt
-	if observedAt.IsZero() {
-		observedAt = r.now()
-	} else {
-		observedAt = observedAt.UTC()
-	}
-	product := observation.Product
-	if product == "" {
-		product = metering.ProductSandbox
-	}
-	state := &metering.StorageProjectionState{
-		SubjectType: observation.SubjectType,
-		SubjectID:   observation.SubjectID,
-		Product:     product,
-		OwnerKind:   observation.OwnerKind,
-		TeamID:      observation.TeamID,
-		UserID:      observation.UserID,
-		SandboxID:   observation.SandboxID,
-		VolumeID:    observation.VolumeID,
-		SnapshotID:  observation.SnapshotID,
-		ClusterID:   observation.ClusterID,
-		RegionID:    observation.RegionID,
-		SizeBytes:   observation.SizeBytes,
-		ObservedAt:  observedAt,
-	}
-	if state.SandboxID != "" {
-		sandbox, err := r.GetSandboxProjectionState(ctx, state.SandboxID)
-		if err != nil {
-			return nil, err
-		}
-		if sandbox != nil && state.OwnerKind == "" {
-			state.OwnerKind = sandbox.OwnerKind
-		}
-	}
-	return state, nil
-}
-
-func (r *Repository) getStorageProjectionState(ctx context.Context, subjectType, subjectID string) (*metering.StorageProjectionState, error) {
-	state := &metering.StorageProjectionState{}
-	err := r.db.QueryRowContext(ctx, fmt.Sprintf(`
-SELECT
-    subject_type, subject_id, product, owner_kind,
-    team_id, user_id, sandbox_id, volume_id,
-    snapshot_id, cluster_id, region_id,
-    size_bytes, observed_at, unbilled_byte_nanoseconds
-FROM %s FINAL
-WHERE subject_type = ? AND subject_id = ? AND deleted = 0
-LIMIT 1
-`, qualified(r.cfg.Database, r.cfg.StorageStateTable)), subjectType, subjectID).Scan(
-		&state.SubjectType, &state.SubjectID, &state.Product, &state.OwnerKind,
-		&state.TeamID, &state.UserID, &state.SandboxID, &state.VolumeID,
-		&state.SnapshotID, &state.ClusterID, &state.RegionID,
-		&state.SizeBytes, &state.ObservedAt, &state.UnbilledByteNanoseconds,
-	)
-	if err == sql.ErrNoRows {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, fmt.Errorf("query storage projection state: %w", err)
-	}
-	return state, nil
-}
-
 func (r *Repository) upsertStorageProjectionState(ctx context.Context, state *metering.StorageProjectionState) error {
 	_, err := r.db.ExecContext(ctx, fmt.Sprintf(`
 INSERT INTO %s (
@@ -709,6 +522,50 @@ INSERT INTO %s (
 		return fmt.Errorf("upsert storage projection state: %w", err)
 	}
 	return nil
+}
+
+// UpsertStorageProjectionState applies an idempotent storage-state mutation
+// captured by the PostgreSQL metering outbox.
+func (r *Repository) UpsertStorageProjectionState(ctx context.Context, state *metering.StorageProjectionState) error {
+	if state == nil {
+		return fmt.Errorf("storage projection state is nil")
+	}
+	return r.upsertStorageProjectionState(ctx, state)
+}
+
+// ListActiveStorageProjectionStates returns current producer state needed to
+// bootstrap the PostgreSQL delivery outbox during an upgrade.
+func (r *Repository) ListActiveStorageProjectionStates(ctx context.Context) ([]*metering.StorageProjectionState, error) {
+	rows, err := r.db.QueryContext(ctx, fmt.Sprintf(`
+SELECT
+    subject_type, subject_id, product, owner_kind,
+    team_id, user_id, sandbox_id, volume_id,
+    snapshot_id, cluster_id, region_id,
+    size_bytes, observed_at, unbilled_byte_nanoseconds
+FROM %s FINAL
+WHERE deleted = 0
+`, qualified(r.cfg.Database, r.cfg.StorageStateTable)))
+	if err != nil {
+		return nil, fmt.Errorf("query active storage projection states: %w", err)
+	}
+	defer rows.Close()
+	states := make([]*metering.StorageProjectionState, 0)
+	for rows.Next() {
+		state := &metering.StorageProjectionState{}
+		if err := rows.Scan(
+			&state.SubjectType, &state.SubjectID, &state.Product, &state.OwnerKind,
+			&state.TeamID, &state.UserID, &state.SandboxID, &state.VolumeID,
+			&state.SnapshotID, &state.ClusterID, &state.RegionID,
+			&state.SizeBytes, &state.ObservedAt, &state.UnbilledByteNanoseconds,
+		); err != nil {
+			return nil, fmt.Errorf("scan active storage projection state: %w", err)
+		}
+		states = append(states, state)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate active storage projection states: %w", err)
+	}
+	return states, nil
 }
 
 func (r *Repository) deleteStorageProjectionState(ctx context.Context, state *metering.StorageProjectionState, deletedAt time.Time) error {
@@ -732,6 +589,15 @@ INSERT INTO %s (
 		return fmt.Errorf("delete storage projection state: %w", err)
 	}
 	return nil
+}
+
+// DeleteStorageProjectionState applies an idempotent storage-state tombstone
+// captured by the PostgreSQL metering outbox.
+func (r *Repository) DeleteStorageProjectionState(ctx context.Context, state *metering.StorageProjectionState, deletedAt time.Time) error {
+	if state == nil {
+		return fmt.Errorf("storage projection state is nil")
+	}
+	return r.deleteStorageProjectionState(ctx, state, deletedAt)
 }
 
 func (r *Repository) CurrentUsage(ctx context.Context, teamID string, dimension quota.Dimension) (int64, error) {
@@ -839,89 +705,6 @@ func (r *Repository) currentScalar(ctx context.Context, query string, args ...an
 		return 0, err
 	}
 	return value, nil
-}
-
-func storageWindowFromStateWithRemainder(state *metering.StorageProjectionState, end time.Time) (*metering.Window, int64) {
-	if state == nil {
-		return nil, 0
-	}
-	remainder := normalizeStorageRemainder(state.UnbilledByteNanoseconds)
-	end = end.UTC()
-	start := state.ObservedAt.UTC()
-	if !end.After(start) {
-		return nil, remainder
-	}
-	value, remainder := storageByteHoursWithRemainder(state.SizeBytes, end.Sub(start), remainder)
-	if value <= 0 {
-		return nil, remainder
-	}
-	windowType := metering.WindowTypeSandboxVolumeByteHours
-	switch state.SubjectType {
-	case metering.SubjectTypeRootFS:
-		windowType = metering.WindowTypeSandboxRootFSByteHours
-	}
-	return &metering.Window{
-		WindowID:    fmt.Sprintf("storage/%s/%s/%d/%d", state.SubjectType, state.SubjectID, start.UnixNano(), end.UnixNano()),
-		Producer:    metering.ProducerStorage,
-		RegionID:    state.RegionID,
-		WindowType:  windowType,
-		SubjectType: state.SubjectType,
-		SubjectID:   state.SubjectID,
-		TeamID:      state.TeamID,
-		UserID:      state.UserID,
-		SandboxID:   state.SandboxID,
-		VolumeID:    state.VolumeID,
-		SnapshotID:  state.SnapshotID,
-		ClusterID:   state.ClusterID,
-		WindowStart: start,
-		WindowEnd:   end,
-		Value:       value,
-		Unit:        metering.WindowUnitByteHours,
-		Data:        storageWindowData(state, end.Sub(start)),
-	}, remainder
-}
-
-func storageByteHoursWithRemainder(sizeBytes int64, duration time.Duration, previousRemainder int64) (int64, int64) {
-	remainder := normalizeStorageRemainder(previousRemainder)
-	if sizeBytes <= 0 || duration <= 0 {
-		return 0, remainder
-	}
-	accumulator := big.NewInt(remainder)
-	var usage big.Int
-	usage.Mul(big.NewInt(sizeBytes), big.NewInt(duration.Nanoseconds()))
-	accumulator.Add(accumulator, &usage)
-
-	hourNanos := big.NewInt(int64(time.Hour))
-	var quotient big.Int
-	var modulo big.Int
-	quotient.QuoRem(accumulator, hourNanos, &modulo)
-	if !quotient.IsInt64() {
-		return math.MaxInt64, 0
-	}
-	return quotient.Int64(), modulo.Int64()
-}
-
-func normalizeStorageRemainder(value int64) int64 {
-	if value <= 0 {
-		return 0
-	}
-	return value % int64(time.Hour)
-}
-
-func storageWindowData(state *metering.StorageProjectionState, duration time.Duration) json.RawMessage {
-	data := map[string]any{
-		"product":               state.Product,
-		"size_bytes":            state.SizeBytes,
-		"duration_milliseconds": duration.Milliseconds(),
-	}
-	if state.OwnerKind != "" {
-		data["owner_kind"] = state.OwnerKind
-	}
-	raw, err := json.Marshal(data)
-	if err != nil {
-		return json.RawMessage(`{}`)
-	}
-	return raw
 }
 
 func storageDimensionMatchesSubjectType(dimension quota.Dimension, subjectType string) bool {

--- a/pkg/metering/outbox/bootstrap.go
+++ b/pkg/metering/outbox/bootstrap.go
@@ -1,0 +1,172 @@
+package outbox
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/sandbox0-ai/sandbox0/pkg/metering"
+)
+
+const bootstrapBatchSize = 500
+const clickHouseBootstrapSource = "clickhouse_projection_state_v1"
+
+// ProjectionStateSource exposes only the current ClickHouse producer state
+// needed to move an existing installation onto the PostgreSQL outbox.
+type ProjectionStateSource interface {
+	ListActiveSandboxProjectionStates(context.Context) ([]*metering.SandboxProjectionState, error)
+	ListActiveStorageProjectionStates(context.Context) ([]*metering.StorageProjectionState, error)
+}
+
+type BootstrapResult struct {
+	SandboxStates int64
+	StorageStates int64
+}
+
+// BootstrapProjectionStates copies current producer state, not historical
+// usage, from ClickHouse. PostgreSQL rows that are equally new or newer win.
+func (r *Repository) BootstrapProjectionStates(ctx context.Context, source ProjectionStateSource) (*BootstrapResult, error) {
+	if r == nil || r.pool == nil {
+		return nil, fmt.Errorf("metering outbox pool is not configured")
+	}
+	if source == nil {
+		return nil, fmt.Errorf("metering projection state source is not configured")
+	}
+	sandboxStates, err := source.ListActiveSandboxProjectionStates(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list active sandbox projection states: %w", err)
+	}
+	storageStates, err := source.ListActiveStorageProjectionStates(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list active storage projection states: %w", err)
+	}
+	result := &BootstrapResult{}
+	for start := 0; start < len(sandboxStates); start += bootstrapBatchSize {
+		end := min(start+bootstrapBatchSize, len(sandboxStates))
+		if err := r.InTx(ctx, func(tx pgx.Tx) error {
+			for _, state := range sandboxStates[start:end] {
+				if state == nil || state.SandboxID == "" || state.Namespace == "" || state.LastObservedAt.IsZero() {
+					return fmt.Errorf("invalid active sandbox projection state")
+				}
+				tag, err := tx.Exec(ctx, bootstrapSandboxStateSQL,
+					state.SandboxID, state.Namespace, state.TeamID, state.UserID, state.TemplateID, state.ClusterID,
+					state.OwnerKind, state.ResourceMillicpu, state.ResourceMemoryMiB,
+					state.ClaimedAt, state.ActiveSince, state.Paused, state.PausedAt, state.TerminatedAt,
+					state.LastObservedAt.UTC(), state.LastResourceVer,
+				)
+				if err != nil {
+					return fmt.Errorf("bootstrap sandbox projection state %q: %w", state.SandboxID, err)
+				}
+				result.SandboxStates += tag.RowsAffected()
+			}
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+	}
+	for start := 0; start < len(storageStates); start += bootstrapBatchSize {
+		end := min(start+bootstrapBatchSize, len(storageStates))
+		if err := r.InTx(ctx, func(tx pgx.Tx) error {
+			for _, state := range storageStates[start:end] {
+				if state == nil || state.SubjectType == "" || state.SubjectID == "" || state.ObservedAt.IsZero() {
+					return fmt.Errorf("invalid active storage projection state")
+				}
+				tag, err := tx.Exec(ctx, bootstrapStorageStateSQL,
+					state.SubjectType, state.SubjectID, state.Product, state.OwnerKind,
+					state.TeamID, state.UserID, nullableString(state.SandboxID), nullableString(state.VolumeID), nullableString(state.SnapshotID),
+					nullableString(state.ClusterID), state.RegionID, state.SizeBytes, state.ObservedAt.UTC(), state.UnbilledByteNanoseconds,
+				)
+				if err != nil {
+					return fmt.Errorf("bootstrap storage projection state %q/%q: %w", state.SubjectType, state.SubjectID, err)
+				}
+				result.StorageStates += tag.RowsAffected()
+			}
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+	}
+	if _, err := r.pool.Exec(ctx, `
+		INSERT INTO metering.projection_bootstrap (source, completed_at)
+		VALUES ($1, NOW())
+		ON CONFLICT (source) DO UPDATE SET completed_at = EXCLUDED.completed_at
+	`, clickHouseBootstrapSource); err != nil {
+		return nil, fmt.Errorf("mark ClickHouse projection state bootstrap complete: %w", err)
+	}
+	return result, nil
+}
+
+func (r *Repository) ProjectionBootstrapCompleted(ctx context.Context) (bool, error) {
+	if r == nil || r.pool == nil {
+		return false, fmt.Errorf("metering outbox pool is not configured")
+	}
+	var completed bool
+	if err := r.pool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM metering.projection_bootstrap
+			WHERE source = $1
+		)
+	`, clickHouseBootstrapSource).Scan(&completed); err != nil {
+		return false, fmt.Errorf("query ClickHouse projection state bootstrap: %w", err)
+	}
+	return completed, nil
+}
+
+const bootstrapSandboxStateSQL = `
+	INSERT INTO metering.manager_sandbox_projection_state (
+		sandbox_id, namespace, team_id, user_id, template_id, cluster_id,
+		owner_kind, resource_millicpu, resource_memory_mib,
+		claimed_at, active_since, paused, paused_at, terminated_at,
+		last_observed_at, last_resource_version
+	) VALUES (
+		$1, $2, $3, $4, $5, $6,
+		$7, $8, $9,
+		$10, $11, $12, $13, $14,
+		$15, $16
+	)
+	ON CONFLICT (sandbox_id) DO UPDATE
+	SET namespace = EXCLUDED.namespace,
+		team_id = EXCLUDED.team_id,
+		user_id = EXCLUDED.user_id,
+		template_id = EXCLUDED.template_id,
+		cluster_id = EXCLUDED.cluster_id,
+		owner_kind = EXCLUDED.owner_kind,
+		resource_millicpu = EXCLUDED.resource_millicpu,
+		resource_memory_mib = EXCLUDED.resource_memory_mib,
+		claimed_at = EXCLUDED.claimed_at,
+		active_since = EXCLUDED.active_since,
+		paused = EXCLUDED.paused,
+		paused_at = EXCLUDED.paused_at,
+		terminated_at = EXCLUDED.terminated_at,
+		last_observed_at = EXCLUDED.last_observed_at,
+		last_resource_version = EXCLUDED.last_resource_version
+	WHERE metering.manager_sandbox_projection_state.last_observed_at < EXCLUDED.last_observed_at
+`
+
+const bootstrapStorageStateSQL = `
+	INSERT INTO metering.storage_projection_state (
+		subject_type, subject_id, product, owner_kind,
+		team_id, user_id, sandbox_id, volume_id, snapshot_id,
+		cluster_id, region_id, size_bytes, observed_at, unbilled_byte_nanoseconds
+	) VALUES (
+		$1, $2, $3, $4,
+		$5, $6, $7, $8, $9,
+		$10, $11, $12, $13, $14
+	)
+	ON CONFLICT (subject_type, subject_id) DO UPDATE
+	SET product = EXCLUDED.product,
+		owner_kind = EXCLUDED.owner_kind,
+		team_id = EXCLUDED.team_id,
+		user_id = EXCLUDED.user_id,
+		sandbox_id = EXCLUDED.sandbox_id,
+		volume_id = EXCLUDED.volume_id,
+		snapshot_id = EXCLUDED.snapshot_id,
+		cluster_id = EXCLUDED.cluster_id,
+		region_id = EXCLUDED.region_id,
+		size_bytes = EXCLUDED.size_bytes,
+		observed_at = EXCLUDED.observed_at,
+		unbilled_byte_nanoseconds = EXCLUDED.unbilled_byte_nanoseconds,
+		updated_at = NOW()
+	WHERE metering.storage_projection_state.observed_at < EXCLUDED.observed_at
+`

--- a/pkg/metering/outbox/migrate.go
+++ b/pkg/metering/outbox/migrate.go
@@ -1,0 +1,30 @@
+package outbox
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/sandbox0-ai/sandbox0/pkg/metering/outbox/migrations"
+	"github.com/sandbox0-ai/sandbox0/pkg/migrate"
+)
+
+const SchemaName = "metering"
+
+type migrationLogger interface {
+	Printf(format string, args ...any)
+	Fatalf(format string, args ...any)
+}
+
+// RunMigrations creates the compact producer state and durable projection
+// outbox used to deliver metering records to ClickHouse.
+func RunMigrations(ctx context.Context, pool *pgxpool.Pool, logger migrationLogger) error {
+	if err := migrate.Up(ctx, pool, ".",
+		migrate.WithBaseFS(migrations.FS),
+		migrate.WithLogger(logger),
+		migrate.WithSchema(SchemaName),
+	); err != nil {
+		return fmt.Errorf("run metering outbox migrations: %w", err)
+	}
+	return nil
+}

--- a/pkg/metering/outbox/migrations/00006_add_projection_outbox.sql
+++ b/pkg/metering/outbox/migrations/00006_add_projection_outbox.sql
@@ -1,0 +1,95 @@
+-- +goose Up
+
+CREATE TABLE IF NOT EXISTS manager_sandbox_projection_state (
+    sandbox_id TEXT PRIMARY KEY,
+    namespace TEXT NOT NULL,
+    team_id TEXT NOT NULL DEFAULT '',
+    user_id TEXT NOT NULL DEFAULT '',
+    template_id TEXT NOT NULL DEFAULT '',
+    cluster_id TEXT NOT NULL DEFAULT '',
+    owner_kind TEXT NOT NULL DEFAULT '',
+    resource_millicpu BIGINT NOT NULL DEFAULT 0,
+    resource_memory_mib BIGINT NOT NULL DEFAULT 0,
+    claimed_at TIMESTAMPTZ,
+    active_since TIMESTAMPTZ,
+    paused BOOLEAN NOT NULL DEFAULT FALSE,
+    paused_at TIMESTAMPTZ,
+    terminated_at TIMESTAMPTZ,
+    last_observed_at TIMESTAMPTZ NOT NULL,
+    last_resource_version TEXT NOT NULL DEFAULT ''
+);
+
+ALTER TABLE manager_sandbox_projection_state
+    ADD COLUMN IF NOT EXISTS owner_kind TEXT NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS resource_millicpu BIGINT NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS resource_memory_mib BIGINT NOT NULL DEFAULT 0;
+
+CREATE INDEX IF NOT EXISTS idx_manager_sandbox_projection_state_observed_at
+    ON manager_sandbox_projection_state(last_observed_at);
+
+CREATE INDEX IF NOT EXISTS idx_manager_sandbox_projection_state_owner_kind
+    ON manager_sandbox_projection_state(owner_kind);
+
+CREATE TABLE IF NOT EXISTS storage_projection_state (
+    subject_type TEXT NOT NULL,
+    subject_id TEXT NOT NULL,
+    product TEXT NOT NULL DEFAULT 'sandbox',
+    owner_kind TEXT NOT NULL DEFAULT '',
+    team_id TEXT NOT NULL DEFAULT '',
+    user_id TEXT NOT NULL DEFAULT '',
+    sandbox_id TEXT,
+    volume_id TEXT,
+    snapshot_id TEXT,
+    cluster_id TEXT,
+    region_id TEXT NOT NULL DEFAULT '',
+    size_bytes BIGINT NOT NULL DEFAULT 0,
+    observed_at TIMESTAMPTZ NOT NULL,
+    unbilled_byte_nanoseconds BIGINT NOT NULL DEFAULT 0,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (subject_type, subject_id)
+);
+
+ALTER TABLE storage_projection_state
+    ADD COLUMN IF NOT EXISTS unbilled_byte_nanoseconds BIGINT NOT NULL DEFAULT 0;
+
+CREATE INDEX IF NOT EXISTS idx_storage_projection_state_observed_at
+    ON storage_projection_state(observed_at);
+
+CREATE INDEX IF NOT EXISTS idx_storage_projection_state_team_id
+    ON storage_projection_state(team_id);
+
+CREATE TABLE IF NOT EXISTS projection_bootstrap (
+    source TEXT PRIMARY KEY,
+    completed_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS projection_outbox (
+    sequence BIGSERIAL PRIMARY KEY,
+    batch_id BIGINT NOT NULL DEFAULT txid_current(),
+    operation_type TEXT NOT NULL,
+    dedupe_key TEXT NOT NULL,
+    payload JSONB NOT NULL,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    available_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    claimed_by TEXT NOT NULL DEFAULT '',
+    claim_expires_at TIMESTAMPTZ,
+    last_error TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    delivered_at TIMESTAMPTZ,
+    UNIQUE (operation_type, dedupe_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_projection_outbox_pending
+    ON projection_outbox(sequence)
+    WHERE delivered_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_projection_outbox_delivered
+    ON projection_outbox(delivered_at)
+    WHERE delivered_at IS NOT NULL;
+
+-- +goose Down
+
+DROP INDEX IF EXISTS idx_projection_outbox_delivered;
+DROP INDEX IF EXISTS idx_projection_outbox_pending;
+DROP TABLE IF EXISTS projection_outbox;
+DROP TABLE IF EXISTS projection_bootstrap;

--- a/pkg/metering/outbox/migrations/embed.go
+++ b/pkg/metering/outbox/migrations/embed.go
@@ -1,0 +1,8 @@
+package migrations
+
+import "embed"
+
+// FS contains the PostgreSQL metering outbox migrations.
+//
+//go:embed *.sql
+var FS embed.FS

--- a/pkg/metering/outbox/projector.go
+++ b/pkg/metering/outbox/projector.go
@@ -1,0 +1,279 @@
+package outbox
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sandbox0-ai/sandbox0/pkg/metering"
+	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
+	"go.uber.org/zap"
+)
+
+const (
+	defaultPollInterval = 2 * time.Second
+	defaultClaimLease   = 30 * time.Second
+	defaultCleanupAge   = 24 * time.Hour
+)
+
+type projectionStore interface {
+	ClaimNextBatch(context.Context, string, time.Duration) (*Batch, error)
+	MarkDelivered(context.Context, int64, string) error
+	MarkFailed(context.Context, int64, string, string, time.Time) error
+	DeleteDeliveredBefore(context.Context, time.Time, int) (int64, error)
+	Stats(context.Context) (*Stats, error)
+}
+
+// ProjectorConfig controls PostgreSQL outbox delivery to ClickHouse.
+type ProjectorConfig struct {
+	WorkerID     string
+	PollInterval time.Duration
+	ClaimLease   time.Duration
+	CleanupAge   time.Duration
+	CleanupBatch int
+}
+
+// Projector retries exact, idempotent operations until ClickHouse accepts the
+// complete PostgreSQL transaction batch.
+type Projector struct {
+	store       projectionStore
+	sink        Sink
+	config      ProjectorConfig
+	logger      *zap.Logger
+	metrics     *obsmetrics.ManagerMetrics
+	now         func() time.Time
+	lastStatsAt time.Time
+}
+
+func (p *Projector) SetMetrics(metrics *obsmetrics.ManagerMetrics) {
+	if p != nil {
+		p.metrics = metrics
+	}
+}
+
+func NewProjector(store projectionStore, sink Sink, config ProjectorConfig, logger *zap.Logger) *Projector {
+	if config.WorkerID == "" {
+		config.WorkerID = "metering-projector/" + uuid.NewString()
+	}
+	if config.PollInterval <= 0 {
+		config.PollInterval = defaultPollInterval
+	}
+	if config.ClaimLease <= 0 {
+		config.ClaimLease = defaultClaimLease
+	}
+	if config.CleanupAge <= 0 {
+		config.CleanupAge = defaultCleanupAge
+	}
+	if config.CleanupBatch <= 0 {
+		config.CleanupBatch = 1000
+	}
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	return &Projector{
+		store:  store,
+		sink:   sink,
+		config: config,
+		logger: logger,
+		now: func() time.Time {
+			return time.Now().UTC()
+		},
+	}
+}
+
+// Run drains ready work immediately and polls while the queue is empty or a
+// failed head batch is waiting for its retry time.
+func (p *Projector) Run(ctx context.Context) error {
+	if p == nil || p.store == nil {
+		return fmt.Errorf("metering outbox store is not configured")
+	}
+	if p.sink == nil {
+		return fmt.Errorf("metering projection sink is not configured")
+	}
+	ticker := time.NewTicker(p.config.PollInterval)
+	defer ticker.Stop()
+
+	cleanupTicker := time.NewTicker(time.Hour)
+	defer cleanupTicker.Stop()
+
+	for {
+		processed, err := p.ProjectOnce(ctx)
+		p.observeStats(ctx)
+		if err != nil && !errors.Is(err, context.Canceled) {
+			p.logger.Warn("Failed to project metering outbox batch", zap.Error(err))
+		}
+		if processed && err == nil {
+			continue
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-cleanupTicker.C:
+			p.cleanup(ctx)
+		case <-ticker.C:
+		}
+	}
+}
+
+// ProjectOnce applies the oldest pending transaction batch. A partially
+// applied batch is released for an exact-payload retry.
+func (p *Projector) ProjectOnce(ctx context.Context) (bool, error) {
+	if p == nil || p.store == nil {
+		return false, fmt.Errorf("metering outbox store is not configured")
+	}
+	if p.sink == nil {
+		return false, fmt.Errorf("metering projection sink is not configured")
+	}
+	batch, err := p.store.ClaimNextBatch(ctx, p.config.WorkerID, p.config.ClaimLease)
+	if err != nil || batch == nil {
+		return false, err
+	}
+	sort.Slice(batch.Operations, func(i, j int) bool {
+		return batch.Operations[i].Sequence < batch.Operations[j].Sequence
+	})
+	for _, operation := range batch.Operations {
+		if err := p.apply(ctx, operation); err != nil {
+			p.recordOperation(operation.Type, "error")
+			p.recordBatch("error")
+			retryAt := p.timestamp().Add(retryDelay(operation.Attempts))
+			markErr := p.store.MarkFailed(ctx, batch.ID, p.config.WorkerID, err.Error(), retryAt)
+			if markErr != nil {
+				return true, errors.Join(err, markErr)
+			}
+			return true, fmt.Errorf("apply metering outbox batch %d operation %d (%s): %w", batch.ID, operation.Sequence, operation.Type, err)
+		}
+		p.recordOperation(operation.Type, "success")
+	}
+	if err := p.store.MarkDelivered(ctx, batch.ID, p.config.WorkerID); err != nil {
+		p.recordBatch("error")
+		return true, err
+	}
+	p.recordBatch("success")
+	return true, nil
+}
+
+func (p *Projector) apply(ctx context.Context, operation *Operation) error {
+	if operation == nil {
+		return fmt.Errorf("metering outbox operation is nil")
+	}
+	switch operation.Type {
+	case OperationEvent:
+		value := &metering.Event{}
+		if err := json.Unmarshal(operation.Payload, value); err != nil {
+			return fmt.Errorf("decode event operation: %w", err)
+		}
+		return p.sink.AppendEvent(ctx, value)
+	case OperationWindow:
+		value := &metering.Window{}
+		if err := json.Unmarshal(operation.Payload, value); err != nil {
+			return fmt.Errorf("decode window operation: %w", err)
+		}
+		return p.sink.AppendWindow(ctx, value)
+	case OperationWatermark:
+		value := &WatermarkOperation{}
+		if err := json.Unmarshal(operation.Payload, value); err != nil {
+			return fmt.Errorf("decode watermark operation: %w", err)
+		}
+		return p.sink.UpsertProducerWatermark(ctx, value.Producer, value.RegionID, value.CompleteBefore)
+	case OperationSandboxState:
+		value := &metering.SandboxProjectionState{}
+		if err := json.Unmarshal(operation.Payload, value); err != nil {
+			return fmt.Errorf("decode sandbox state operation: %w", err)
+		}
+		return p.sink.UpsertSandboxProjectionState(ctx, value)
+	case OperationStorageState:
+		value := &metering.StorageProjectionState{}
+		if err := json.Unmarshal(operation.Payload, value); err != nil {
+			return fmt.Errorf("decode storage state operation: %w", err)
+		}
+		return p.sink.UpsertStorageProjectionState(ctx, value)
+	case OperationStorageStateDelete:
+		value := &StorageStateDeleteOperation{}
+		if err := json.Unmarshal(operation.Payload, value); err != nil {
+			return fmt.Errorf("decode storage state delete operation: %w", err)
+		}
+		if value.State == nil {
+			return fmt.Errorf("storage state delete operation is missing state")
+		}
+		return p.sink.DeleteStorageProjectionState(ctx, value.State, value.DeletedAt)
+	default:
+		return fmt.Errorf("unsupported metering outbox operation type %q", operation.Type)
+	}
+}
+
+func (p *Projector) cleanup(ctx context.Context) {
+	cutoff := p.timestamp().Add(-p.config.CleanupAge)
+	var total int64
+	for {
+		deleted, err := p.store.DeleteDeliveredBefore(ctx, cutoff, p.config.CleanupBatch)
+		if err != nil {
+			p.logger.Warn("Failed to clean delivered metering outbox operations", zap.Error(err))
+			return
+		}
+		total += deleted
+		if deleted < int64(p.config.CleanupBatch) {
+			break
+		}
+	}
+	if total > 0 {
+		p.logger.Debug("Cleaned delivered metering outbox operations", zap.Int64("operations", total))
+	}
+}
+
+func (p *Projector) observeStats(ctx context.Context) {
+	if p == nil || p.metrics == nil {
+		return
+	}
+	now := p.timestamp()
+	if !p.lastStatsAt.IsZero() && now.Sub(p.lastStatsAt) < 10*time.Second {
+		return
+	}
+	p.lastStatsAt = now
+	stats, err := p.store.Stats(ctx)
+	if err != nil {
+		p.logger.Warn("Failed to observe metering outbox backlog", zap.Error(err))
+		return
+	}
+	p.metrics.MeteringOutboxPendingOperations.Set(float64(stats.Pending))
+	age := 0.0
+	if stats.OldestPending != nil {
+		age = max(0, now.Sub(stats.OldestPending.UTC()).Seconds())
+	}
+	p.metrics.MeteringOutboxOldestPendingAge.Set(age)
+}
+
+func (p *Projector) recordBatch(result string) {
+	if p != nil && p.metrics != nil {
+		p.metrics.MeteringOutboxBatchesTotal.WithLabelValues(result).Inc()
+	}
+}
+
+func (p *Projector) recordOperation(operationType OperationType, result string) {
+	if p != nil && p.metrics != nil {
+		p.metrics.MeteringOutboxOperationsTotal.WithLabelValues(string(operationType), result).Inc()
+	}
+}
+
+func retryDelay(attempt int) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+	power := math.Min(float64(attempt-1), 6)
+	delay := time.Second * time.Duration(math.Pow(2, power))
+	if delay > time.Minute {
+		return time.Minute
+	}
+	return delay
+}
+
+func (p *Projector) timestamp() time.Time {
+	if p == nil || p.now == nil {
+		return time.Now().UTC()
+	}
+	return p.now().UTC()
+}

--- a/pkg/metering/outbox/projector_test.go
+++ b/pkg/metering/outbox/projector_test.go
@@ -1,0 +1,196 @@
+package outbox
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/sandbox0-ai/sandbox0/pkg/metering"
+)
+
+type fakeProjectionStore struct {
+	batch      *Batch
+	claimed    bool
+	delivered  bool
+	failed     int
+	retryAt    time.Time
+	lastError  string
+	cleanupHit int
+}
+
+func (f *fakeProjectionStore) ClaimNextBatch(context.Context, string, time.Duration) (*Batch, error) {
+	if f.batch == nil || f.claimed || f.delivered {
+		return nil, nil
+	}
+	f.claimed = true
+	return f.batch, nil
+}
+
+func (f *fakeProjectionStore) MarkDelivered(context.Context, int64, string) error {
+	f.delivered = true
+	f.claimed = false
+	return nil
+}
+
+func (f *fakeProjectionStore) MarkFailed(_ context.Context, _ int64, _, message string, retryAt time.Time) error {
+	f.failed++
+	f.claimed = false
+	f.lastError = message
+	f.retryAt = retryAt
+	return nil
+}
+
+func (f *fakeProjectionStore) DeleteDeliveredBefore(context.Context, time.Time, int) (int64, error) {
+	f.cleanupHit++
+	return 0, nil
+}
+
+func (f *fakeProjectionStore) Stats(context.Context) (*Stats, error) {
+	if f.delivered || f.batch == nil {
+		return &Stats{}, nil
+	}
+	createdAt := time.Now().UTC()
+	return &Stats{Pending: int64(len(f.batch.Operations)), OldestPending: &createdAt}, nil
+}
+
+type fakeSink struct {
+	events              []*metering.Event
+	windows             []*metering.Window
+	watermarks          []*WatermarkOperation
+	sandboxStates       []*metering.SandboxProjectionState
+	storageStates       []*metering.StorageProjectionState
+	storageStateDeletes []*StorageStateDeleteOperation
+	failWindowOnce      bool
+}
+
+func (f *fakeSink) AppendEvent(_ context.Context, value *metering.Event) error {
+	f.events = append(f.events, value)
+	return nil
+}
+
+func (f *fakeSink) AppendWindow(_ context.Context, value *metering.Window) error {
+	if f.failWindowOnce {
+		f.failWindowOnce = false
+		return errors.New("clickhouse unavailable")
+	}
+	f.windows = append(f.windows, value)
+	return nil
+}
+
+func (f *fakeSink) UpsertProducerWatermark(_ context.Context, producer, regionID string, completeBefore time.Time) error {
+	f.watermarks = append(f.watermarks, &WatermarkOperation{Producer: producer, RegionID: regionID, CompleteBefore: completeBefore})
+	return nil
+}
+
+func (f *fakeSink) UpsertSandboxProjectionState(_ context.Context, value *metering.SandboxProjectionState) error {
+	f.sandboxStates = append(f.sandboxStates, value)
+	return nil
+}
+
+func (f *fakeSink) UpsertStorageProjectionState(_ context.Context, value *metering.StorageProjectionState) error {
+	f.storageStates = append(f.storageStates, value)
+	return nil
+}
+
+func (f *fakeSink) DeleteStorageProjectionState(_ context.Context, state *metering.StorageProjectionState, deletedAt time.Time) error {
+	f.storageStateDeletes = append(f.storageStateDeletes, &StorageStateDeleteOperation{State: state, DeletedAt: deletedAt})
+	return nil
+}
+
+func TestProjectorRetriesTheExactTransactionBatch(t *testing.T) {
+	now := time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC)
+	event := &metering.Event{
+		EventID:     "event-1",
+		Producer:    "test",
+		EventType:   metering.EventTypeSandboxClaimed,
+		SubjectType: metering.SubjectTypeSandbox,
+		SubjectID:   "sandbox-1",
+		OccurredAt:  now,
+		RecordedAt:  now,
+	}
+	window := &metering.Window{
+		WindowID:    "window-1",
+		Producer:    "test",
+		WindowType:  metering.WindowTypeSandboxEgressBytes,
+		SubjectType: metering.SubjectTypeSandbox,
+		SubjectID:   "sandbox-1",
+		WindowStart: now,
+		WindowEnd:   now.Add(time.Second),
+		Value:       10,
+		Unit:        metering.WindowUnitBytes,
+		RecordedAt:  now,
+	}
+	store := &fakeProjectionStore{batch: &Batch{
+		ID: 42,
+		Operations: []*Operation{
+			{Sequence: 2, BatchID: 42, Type: OperationWindow, Payload: mustMarshal(t, window), Attempts: 1},
+			{Sequence: 1, BatchID: 42, Type: OperationEvent, Payload: mustMarshal(t, event), Attempts: 1},
+		},
+	}}
+	sink := &fakeSink{failWindowOnce: true}
+	projector := NewProjector(store, sink, ProjectorConfig{WorkerID: "worker-1"}, nil)
+	projector.now = func() time.Time { return now }
+
+	processed, err := projector.ProjectOnce(context.Background())
+	if !processed || err == nil {
+		t.Fatalf("first ProjectOnce = (%v, %v), want processed failure", processed, err)
+	}
+	if store.failed != 1 || !store.retryAt.Equal(now.Add(time.Second)) {
+		t.Fatalf("failed batch retry = (%d, %v), want one retry at %v", store.failed, store.retryAt, now.Add(time.Second))
+	}
+	if len(sink.events) != 1 || sink.events[0].EventID != event.EventID {
+		t.Fatalf("first event applications = %#v", sink.events)
+	}
+
+	processed, err = projector.ProjectOnce(context.Background())
+	if !processed || err != nil {
+		t.Fatalf("second ProjectOnce = (%v, %v), want success", processed, err)
+	}
+	if !store.delivered {
+		t.Fatal("batch was not marked delivered")
+	}
+	if len(sink.events) != 2 || sink.events[0].EventID != sink.events[1].EventID {
+		t.Fatalf("event retry did not preserve identity: %#v", sink.events)
+	}
+	if len(sink.windows) != 1 || sink.windows[0].WindowID != window.WindowID || !sink.windows[0].RecordedAt.Equal(now) {
+		t.Fatalf("window retry changed payload: %#v", sink.windows)
+	}
+}
+
+func TestProjectorAppliesProjectionStateOperations(t *testing.T) {
+	now := time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC)
+	sandboxState := &metering.SandboxProjectionState{SandboxID: "sandbox-1", Namespace: "default", LastObservedAt: now}
+	storageState := &metering.StorageProjectionState{SubjectType: metering.SubjectTypeVolume, SubjectID: "volume-1", ObservedAt: now}
+	deleted := &StorageStateDeleteOperation{State: storageState, DeletedAt: now.Add(time.Second)}
+	watermark := &WatermarkOperation{Producer: "producer-1", RegionID: "region-1", CompleteBefore: now}
+	store := &fakeProjectionStore{batch: &Batch{
+		ID: 7,
+		Operations: []*Operation{
+			{Sequence: 1, Type: OperationSandboxState, Payload: mustMarshal(t, sandboxState)},
+			{Sequence: 2, Type: OperationStorageState, Payload: mustMarshal(t, storageState)},
+			{Sequence: 3, Type: OperationStorageStateDelete, Payload: mustMarshal(t, deleted)},
+			{Sequence: 4, Type: OperationWatermark, Payload: mustMarshal(t, watermark)},
+		},
+	}}
+	sink := &fakeSink{}
+	projector := NewProjector(store, sink, ProjectorConfig{WorkerID: "worker-1"}, nil)
+
+	if processed, err := projector.ProjectOnce(context.Background()); !processed || err != nil {
+		t.Fatalf("ProjectOnce = (%v, %v)", processed, err)
+	}
+	if len(sink.sandboxStates) != 1 || len(sink.storageStates) != 1 || len(sink.storageStateDeletes) != 1 || len(sink.watermarks) != 1 {
+		t.Fatalf("applied operations = sandbox:%d storage:%d delete:%d watermark:%d",
+			len(sink.sandboxStates), len(sink.storageStates), len(sink.storageStateDeletes), len(sink.watermarks))
+	}
+}
+
+func mustMarshal(t *testing.T, value any) []byte {
+	t.Helper()
+	payload, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal test payload: %v", err)
+	}
+	return payload
+}

--- a/pkg/metering/outbox/repository.go
+++ b/pkg/metering/outbox/repository.go
@@ -1,0 +1,803 @@
+package outbox
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/sandbox0-ai/sandbox0/pkg/metering"
+)
+
+const claimLockID int64 = 0x6d65746572696e67
+
+type db interface {
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
+}
+
+// Repository captures metering mutations transactionally in PostgreSQL.
+// ClickHouse delivery is intentionally handled by Projector.
+type Repository struct {
+	pool *pgxpool.Pool
+	now  func() time.Time
+}
+
+func NewRepository(pool *pgxpool.Pool) *Repository {
+	return &Repository{
+		pool: pool,
+		now: func() time.Time {
+			return time.Now().UTC()
+		},
+	}
+}
+
+func (r *Repository) Pool() *pgxpool.Pool {
+	if r == nil {
+		return nil
+	}
+	return r.pool
+}
+
+func (r *Repository) InTx(ctx context.Context, fn func(pgx.Tx) error) error {
+	if fn == nil {
+		return nil
+	}
+	if r == nil || r.pool == nil {
+		return fmt.Errorf("metering outbox pool is not configured")
+	}
+	tx, err := r.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("begin metering outbox transaction: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+	if err := fn(tx); err != nil {
+		return err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit metering outbox transaction: %w", err)
+	}
+	return nil
+}
+
+func (r *Repository) AppendEvent(ctx context.Context, event *metering.Event) error {
+	return r.InTx(ctx, func(tx pgx.Tx) error {
+		return r.AppendEventTx(ctx, tx, event)
+	})
+}
+
+func (r *Repository) AppendEventTx(ctx context.Context, tx pgx.Tx, event *metering.Event) error {
+	if tx == nil {
+		return fmt.Errorf("metering event transaction is nil")
+	}
+	if err := validateEvent(event); err != nil {
+		return err
+	}
+	if event.RecordedAt.IsZero() {
+		event.RecordedAt = r.timestamp()
+	} else {
+		event.RecordedAt = event.RecordedAt.UTC()
+	}
+	return enqueue(ctx, tx, OperationEvent, event.EventID, event)
+}
+
+func (r *Repository) AppendWindow(ctx context.Context, window *metering.Window) error {
+	return r.InTx(ctx, func(tx pgx.Tx) error {
+		return r.AppendWindowTx(ctx, tx, window)
+	})
+}
+
+func (r *Repository) AppendWindowTx(ctx context.Context, tx pgx.Tx, window *metering.Window) error {
+	if tx == nil {
+		return fmt.Errorf("metering window transaction is nil")
+	}
+	if err := validateWindow(window); err != nil {
+		return err
+	}
+	if window.RecordedAt.IsZero() {
+		window.RecordedAt = r.timestamp()
+	} else {
+		window.RecordedAt = window.RecordedAt.UTC()
+	}
+	return enqueue(ctx, tx, OperationWindow, window.WindowID, window)
+}
+
+func (r *Repository) UpsertProducerWatermark(ctx context.Context, producer, regionID string, completeBefore time.Time) error {
+	return r.InTx(ctx, func(tx pgx.Tx) error {
+		return r.UpsertProducerWatermarkTx(ctx, tx, producer, regionID, completeBefore)
+	})
+}
+
+func (r *Repository) UpsertProducerWatermarkTx(ctx context.Context, tx pgx.Tx, producer, regionID string, completeBefore time.Time) error {
+	if tx == nil {
+		return fmt.Errorf("metering watermark transaction is nil")
+	}
+	if strings.TrimSpace(producer) == "" {
+		return fmt.Errorf("producer is required")
+	}
+	if completeBefore.IsZero() {
+		return fmt.Errorf("complete_before is required")
+	}
+	operation := &WatermarkOperation{
+		Producer:       producer,
+		RegionID:       regionID,
+		CompleteBefore: completeBefore.UTC(),
+	}
+	key := fmt.Sprintf("%s/%s/%d", producer, regionID, completeBefore.UTC().UnixNano())
+	return enqueue(ctx, tx, OperationWatermark, key, operation)
+}
+
+func (r *Repository) GetSandboxProjectionState(ctx context.Context, sandboxID string) (*metering.SandboxProjectionState, error) {
+	if r == nil || r.pool == nil {
+		return nil, fmt.Errorf("metering outbox pool is not configured")
+	}
+	return getSandboxProjectionState(ctx, r.pool, sandboxID, false)
+}
+
+func (r *Repository) GetSandboxProjectionStateTx(ctx context.Context, tx pgx.Tx, sandboxID string) (*metering.SandboxProjectionState, error) {
+	if tx == nil {
+		return nil, fmt.Errorf("metering sandbox state transaction is nil")
+	}
+	return getSandboxProjectionState(ctx, tx, sandboxID, true)
+}
+
+func (r *Repository) UpsertSandboxProjectionState(ctx context.Context, state *metering.SandboxProjectionState) error {
+	return r.InTx(ctx, func(tx pgx.Tx) error {
+		return r.UpsertSandboxProjectionStateTx(ctx, tx, state)
+	})
+}
+
+func (r *Repository) UpsertSandboxProjectionStateTx(ctx context.Context, tx pgx.Tx, state *metering.SandboxProjectionState) error {
+	if tx == nil {
+		return fmt.Errorf("metering sandbox state transaction is nil")
+	}
+	if state == nil {
+		return fmt.Errorf("sandbox projection state is nil")
+	}
+	if state.SandboxID == "" {
+		return fmt.Errorf("sandbox_id is required")
+	}
+	if state.Namespace == "" {
+		return fmt.Errorf("namespace is required")
+	}
+	if state.LastObservedAt.IsZero() {
+		state.LastObservedAt = r.timestamp()
+	} else {
+		state.LastObservedAt = state.LastObservedAt.UTC()
+	}
+	_, err := tx.Exec(ctx, `
+		INSERT INTO metering.manager_sandbox_projection_state (
+			sandbox_id, namespace, team_id, user_id, template_id, cluster_id,
+			owner_kind, resource_millicpu, resource_memory_mib,
+			claimed_at, active_since, paused, paused_at, terminated_at,
+			last_observed_at, last_resource_version
+		) VALUES (
+			$1, $2, $3, $4, $5, $6,
+			$7, $8, $9,
+			$10, $11, $12, $13, $14,
+			$15, $16
+		)
+		ON CONFLICT (sandbox_id) DO UPDATE
+		SET namespace = EXCLUDED.namespace,
+			team_id = EXCLUDED.team_id,
+			user_id = EXCLUDED.user_id,
+			template_id = EXCLUDED.template_id,
+			cluster_id = EXCLUDED.cluster_id,
+			owner_kind = EXCLUDED.owner_kind,
+			resource_millicpu = EXCLUDED.resource_millicpu,
+			resource_memory_mib = EXCLUDED.resource_memory_mib,
+			claimed_at = EXCLUDED.claimed_at,
+			active_since = EXCLUDED.active_since,
+			paused = EXCLUDED.paused,
+			paused_at = EXCLUDED.paused_at,
+			terminated_at = EXCLUDED.terminated_at,
+			last_observed_at = EXCLUDED.last_observed_at,
+			last_resource_version = EXCLUDED.last_resource_version
+	`, state.SandboxID, state.Namespace, state.TeamID, state.UserID, state.TemplateID, state.ClusterID,
+		state.OwnerKind, state.ResourceMillicpu, state.ResourceMemoryMiB,
+		state.ClaimedAt, state.ActiveSince, state.Paused, state.PausedAt, state.TerminatedAt,
+		state.LastObservedAt, state.LastResourceVer,
+	)
+	if err != nil {
+		return fmt.Errorf("upsert sandbox projection state: %w", err)
+	}
+	payload, err := json.Marshal(state)
+	if err != nil {
+		return fmt.Errorf("marshal sandbox projection state: %w", err)
+	}
+	key := versionedKey(state.SandboxID, state.LastObservedAt, payload)
+	return enqueueJSON(ctx, tx, OperationSandboxState, key, payload)
+}
+
+func (r *Repository) RecordStorageObservation(ctx context.Context, observation *metering.StorageObservation) error {
+	return r.InTx(ctx, func(tx pgx.Tx) error {
+		return r.RecordStorageObservationTx(ctx, tx, observation)
+	})
+}
+
+func (r *Repository) RecordStorageObservationTx(ctx context.Context, tx pgx.Tx, observation *metering.StorageObservation) error {
+	if tx == nil {
+		return fmt.Errorf("metering storage observation transaction is nil")
+	}
+	state, err := r.normalizeStorageObservation(ctx, tx, observation)
+	if err != nil {
+		return err
+	}
+	previous, err := getStorageProjectionStateForUpdate(ctx, tx, state.SubjectType, state.SubjectID)
+	if err != nil {
+		return err
+	}
+	if previous != nil {
+		if state.ObservedAt.Before(previous.ObservedAt) {
+			return nil
+		}
+		window, remainder := metering.StorageWindowFromState(previous, state.ObservedAt)
+		if window != nil {
+			if err := r.AppendWindowTx(ctx, tx, window); err != nil {
+				return err
+			}
+		}
+		state.UnbilledByteNanoseconds = remainder
+	}
+	return r.upsertStorageProjectionState(ctx, tx, state)
+}
+
+func (r *Repository) CloseStorageObservation(ctx context.Context, observation *metering.StorageObservation) error {
+	return r.InTx(ctx, func(tx pgx.Tx) error {
+		return r.CloseStorageObservationTx(ctx, tx, observation)
+	})
+}
+
+func (r *Repository) CloseStorageObservationTx(ctx context.Context, tx pgx.Tx, observation *metering.StorageObservation) error {
+	if tx == nil {
+		return fmt.Errorf("metering storage close transaction is nil")
+	}
+	state, err := r.normalizeStorageObservation(ctx, tx, observation)
+	if err != nil {
+		return err
+	}
+	previous, err := getStorageProjectionStateForUpdate(ctx, tx, state.SubjectType, state.SubjectID)
+	if err != nil {
+		return err
+	}
+	if previous == nil {
+		if observation.ResourceCreatedAt.IsZero() || !state.ObservedAt.After(observation.ResourceCreatedAt) {
+			return nil
+		}
+		end := state.ObservedAt
+		state.ObservedAt = observation.ResourceCreatedAt.UTC()
+		if window, _ := metering.StorageWindowFromState(state, end); window != nil {
+			return r.AppendWindowTx(ctx, tx, window)
+		}
+		return nil
+	}
+	if state.ObservedAt.Before(previous.ObservedAt) {
+		return r.deleteStorageProjectionState(ctx, tx, previous, state.ObservedAt)
+	}
+	if window, _ := metering.StorageWindowFromState(previous, state.ObservedAt); window != nil {
+		if err := r.AppendWindowTx(ctx, tx, window); err != nil {
+			return err
+		}
+	}
+	return r.deleteStorageProjectionState(ctx, tx, previous, state.ObservedAt)
+}
+
+func (r *Repository) FlushStorageProjectionWindows(ctx context.Context, before time.Time, limit int) (int, error) {
+	if before.IsZero() {
+		before = r.timestamp()
+	} else {
+		before = before.UTC()
+	}
+	if limit <= 0 {
+		limit = 500
+	}
+	processed := 0
+	err := r.InTx(ctx, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `
+			SELECT
+				subject_type, subject_id, product, owner_kind,
+				team_id, user_id, COALESCE(sandbox_id, ''), COALESCE(volume_id, ''),
+				COALESCE(snapshot_id, ''), COALESCE(cluster_id, ''), region_id,
+				size_bytes, observed_at, unbilled_byte_nanoseconds
+			FROM metering.storage_projection_state
+			WHERE observed_at < $1
+			ORDER BY observed_at ASC
+			LIMIT $2
+			FOR UPDATE SKIP LOCKED
+		`, before, limit)
+		if err != nil {
+			return fmt.Errorf("query storage projection states: %w", err)
+		}
+		defer rows.Close()
+		states := make([]*metering.StorageProjectionState, 0, limit)
+		for rows.Next() {
+			state := &metering.StorageProjectionState{}
+			if err := scanStorageState(rows, state); err != nil {
+				return fmt.Errorf("scan storage projection state: %w", err)
+			}
+			states = append(states, state)
+		}
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("iterate storage projection states: %w", err)
+		}
+		for _, state := range states {
+			window, remainder := metering.StorageWindowFromState(state, before)
+			if window != nil {
+				if err := r.AppendWindowTx(ctx, tx, window); err != nil {
+					return err
+				}
+			}
+			state.ObservedAt = before
+			state.UnbilledByteNanoseconds = remainder
+			if err := r.upsertStorageProjectionState(ctx, tx, state); err != nil {
+				return err
+			}
+		}
+		processed = len(states)
+		return nil
+	})
+	return processed, err
+}
+
+func (r *Repository) ClaimNextBatch(ctx context.Context, workerID string, lease time.Duration) (*Batch, error) {
+	if r == nil || r.pool == nil {
+		return nil, fmt.Errorf("metering outbox pool is not configured")
+	}
+	if strings.TrimSpace(workerID) == "" {
+		return nil, fmt.Errorf("worker_id is required")
+	}
+	if lease <= 0 {
+		lease = 30 * time.Second
+	}
+	var batch *Batch
+	err := r.InTx(ctx, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock($1)`, claimLockID); err != nil {
+			return fmt.Errorf("lock metering outbox claim: %w", err)
+		}
+		var batchID int64
+		var availableAt time.Time
+		var claimExpiresAt *time.Time
+		err := tx.QueryRow(ctx, `
+			SELECT batch_id, available_at, claim_expires_at
+			FROM metering.projection_outbox
+			WHERE delivered_at IS NULL
+			ORDER BY sequence ASC
+			LIMIT 1
+			FOR UPDATE
+		`).Scan(&batchID, &availableAt, &claimExpiresAt)
+		if err == pgx.ErrNoRows {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("select oldest metering outbox batch: %w", err)
+		}
+		now := r.timestamp()
+		if availableAt.After(now) || (claimExpiresAt != nil && claimExpiresAt.After(now)) {
+			return nil
+		}
+		rows, err := tx.Query(ctx, `
+			UPDATE metering.projection_outbox
+			SET claimed_by = $2,
+				claim_expires_at = $3,
+				attempts = attempts + 1
+			WHERE batch_id = $1 AND delivered_at IS NULL
+			RETURNING sequence, batch_id, operation_type, dedupe_key, payload,
+				attempts, created_at, claim_expires_at
+		`, batchID, workerID, now.Add(lease))
+		if err != nil {
+			return fmt.Errorf("claim metering outbox batch: %w", err)
+		}
+		defer rows.Close()
+		operations := make([]*Operation, 0, 4)
+		for rows.Next() {
+			operation := &Operation{}
+			if err := rows.Scan(
+				&operation.Sequence, &operation.BatchID, &operation.Type,
+				&operation.DedupeKey, &operation.Payload, &operation.Attempts,
+				&operation.CreatedAt, &operation.ClaimExpiresAt,
+			); err != nil {
+				return fmt.Errorf("scan claimed metering operation: %w", err)
+			}
+			operations = append(operations, operation)
+		}
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("iterate claimed metering operations: %w", err)
+		}
+		if len(operations) > 0 {
+			sort.Slice(operations, func(i, j int) bool {
+				return operations[i].Sequence < operations[j].Sequence
+			})
+			batch = &Batch{ID: batchID, Operations: operations}
+		}
+		return nil
+	})
+	return batch, err
+}
+
+func (r *Repository) MarkDelivered(ctx context.Context, batchID int64, workerID string) error {
+	if r == nil || r.pool == nil {
+		return fmt.Errorf("metering outbox pool is not configured")
+	}
+	tag, err := r.pool.Exec(ctx, `
+		UPDATE metering.projection_outbox
+		SET delivered_at = NOW(),
+			claimed_by = '',
+			claim_expires_at = NULL,
+			last_error = ''
+		WHERE batch_id = $1 AND delivered_at IS NULL AND claimed_by = $2
+	`, batchID, workerID)
+	if err != nil {
+		return fmt.Errorf("mark metering outbox batch delivered: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("metering outbox batch %d is not claimed by %q", batchID, workerID)
+	}
+	return nil
+}
+
+func (r *Repository) MarkFailed(ctx context.Context, batchID int64, workerID, message string, retryAt time.Time) error {
+	if r == nil || r.pool == nil {
+		return fmt.Errorf("metering outbox pool is not configured")
+	}
+	if retryAt.IsZero() {
+		retryAt = r.timestamp()
+	}
+	_, err := r.pool.Exec(ctx, `
+		UPDATE metering.projection_outbox
+		SET available_at = $3,
+			claimed_by = '',
+			claim_expires_at = NULL,
+			last_error = $4
+		WHERE batch_id = $1 AND delivered_at IS NULL AND claimed_by = $2
+	`, batchID, workerID, retryAt.UTC(), truncateError(message))
+	if err != nil {
+		return fmt.Errorf("release failed metering outbox batch: %w", err)
+	}
+	return nil
+}
+
+func (r *Repository) Stats(ctx context.Context) (*Stats, error) {
+	if r == nil || r.pool == nil {
+		return nil, fmt.Errorf("metering outbox pool is not configured")
+	}
+	stats := &Stats{}
+	if err := r.pool.QueryRow(ctx, `
+		SELECT COUNT(*), MIN(created_at)
+		FROM metering.projection_outbox
+		WHERE delivered_at IS NULL
+	`).Scan(&stats.Pending, &stats.OldestPending); err != nil {
+		return nil, fmt.Errorf("query metering outbox stats: %w", err)
+	}
+	return stats, nil
+}
+
+func (r *Repository) DeleteDeliveredBefore(ctx context.Context, before time.Time, limit int) (int64, error) {
+	if r == nil || r.pool == nil {
+		return 0, fmt.Errorf("metering outbox pool is not configured")
+	}
+	if before.IsZero() {
+		return 0, fmt.Errorf("cleanup cutoff is required")
+	}
+	if limit <= 0 {
+		limit = 1000
+	}
+	tag, err := r.pool.Exec(ctx, `
+		DELETE FROM metering.projection_outbox
+		WHERE sequence IN (
+			SELECT sequence
+			FROM metering.projection_outbox
+			WHERE delivered_at < $1
+			ORDER BY sequence ASC
+			LIMIT $2
+		)
+	`, before.UTC(), limit)
+	if err != nil {
+		return 0, fmt.Errorf("delete delivered metering outbox operations: %w", err)
+	}
+	return tag.RowsAffected(), nil
+}
+
+func (r *Repository) normalizeStorageObservation(ctx context.Context, tx pgx.Tx, observation *metering.StorageObservation) (*metering.StorageProjectionState, error) {
+	if observation == nil {
+		return nil, fmt.Errorf("storage observation is nil")
+	}
+	if observation.SubjectType == "" || observation.SubjectID == "" {
+		return nil, fmt.Errorf("storage subject_type and subject_id are required")
+	}
+	if observation.SubjectType != metering.SubjectTypeVolume && observation.SubjectType != metering.SubjectTypeSnapshot && observation.SubjectType != metering.SubjectTypeRootFS {
+		return nil, fmt.Errorf("unsupported storage subject_type %q", observation.SubjectType)
+	}
+	if observation.SizeBytes < 0 {
+		return nil, fmt.Errorf("storage size_bytes must be non-negative")
+	}
+	observedAt := observation.ObservedAt
+	if observedAt.IsZero() {
+		observedAt = r.timestamp()
+	} else {
+		observedAt = observedAt.UTC()
+	}
+	product := observation.Product
+	if product == "" {
+		product = metering.ProductSandbox
+	}
+	state := &metering.StorageProjectionState{
+		SubjectType: observation.SubjectType,
+		SubjectID:   observation.SubjectID,
+		Product:     product,
+		OwnerKind:   observation.OwnerKind,
+		TeamID:      observation.TeamID,
+		UserID:      observation.UserID,
+		SandboxID:   observation.SandboxID,
+		VolumeID:    observation.VolumeID,
+		SnapshotID:  observation.SnapshotID,
+		ClusterID:   observation.ClusterID,
+		RegionID:    observation.RegionID,
+		SizeBytes:   observation.SizeBytes,
+		ObservedAt:  observedAt,
+	}
+	if state.SandboxID != "" && state.OwnerKind == "" {
+		var ownerKind string
+		err := tx.QueryRow(ctx, `
+			SELECT owner_kind
+			FROM metering.manager_sandbox_projection_state
+			WHERE sandbox_id = $1
+		`, state.SandboxID).Scan(&ownerKind)
+		if err != nil && err != pgx.ErrNoRows {
+			return nil, fmt.Errorf("query sandbox storage owner state: %w", err)
+		}
+		if err == nil {
+			state.OwnerKind = ownerKind
+		}
+	}
+	return state, nil
+}
+
+func (r *Repository) upsertStorageProjectionState(ctx context.Context, tx pgx.Tx, state *metering.StorageProjectionState) error {
+	_, err := tx.Exec(ctx, `
+		INSERT INTO metering.storage_projection_state (
+			subject_type, subject_id, product, owner_kind,
+			team_id, user_id, sandbox_id, volume_id, snapshot_id,
+			cluster_id, region_id, size_bytes, observed_at, unbilled_byte_nanoseconds
+		) VALUES (
+			$1, $2, $3, $4,
+			$5, $6, $7, $8, $9,
+			$10, $11, $12, $13, $14
+		)
+		ON CONFLICT (subject_type, subject_id) DO UPDATE
+		SET product = EXCLUDED.product,
+			owner_kind = EXCLUDED.owner_kind,
+			team_id = EXCLUDED.team_id,
+			user_id = EXCLUDED.user_id,
+			sandbox_id = EXCLUDED.sandbox_id,
+			volume_id = EXCLUDED.volume_id,
+			snapshot_id = EXCLUDED.snapshot_id,
+			cluster_id = EXCLUDED.cluster_id,
+			region_id = EXCLUDED.region_id,
+			size_bytes = EXCLUDED.size_bytes,
+			observed_at = EXCLUDED.observed_at,
+			unbilled_byte_nanoseconds = EXCLUDED.unbilled_byte_nanoseconds,
+			updated_at = NOW()
+	`, state.SubjectType, state.SubjectID, state.Product, state.OwnerKind,
+		state.TeamID, state.UserID, nullableString(state.SandboxID), nullableString(state.VolumeID), nullableString(state.SnapshotID),
+		nullableString(state.ClusterID), state.RegionID, state.SizeBytes, state.ObservedAt, state.UnbilledByteNanoseconds)
+	if err != nil {
+		return fmt.Errorf("upsert storage projection state: %w", err)
+	}
+	payload, err := json.Marshal(state)
+	if err != nil {
+		return fmt.Errorf("marshal storage projection state: %w", err)
+	}
+	key := versionedKey(state.SubjectType+"/"+state.SubjectID, state.ObservedAt, payload)
+	return enqueueJSON(ctx, tx, OperationStorageState, key, payload)
+}
+
+func (r *Repository) deleteStorageProjectionState(ctx context.Context, tx pgx.Tx, state *metering.StorageProjectionState, deletedAt time.Time) error {
+	if deletedAt.IsZero() {
+		deletedAt = r.timestamp()
+	} else {
+		deletedAt = deletedAt.UTC()
+	}
+	if _, err := tx.Exec(ctx, `
+		DELETE FROM metering.storage_projection_state
+		WHERE subject_type = $1 AND subject_id = $2
+	`, state.SubjectType, state.SubjectID); err != nil {
+		return fmt.Errorf("delete storage projection state: %w", err)
+	}
+	operation := &StorageStateDeleteOperation{State: state, DeletedAt: deletedAt}
+	payload, err := json.Marshal(operation)
+	if err != nil {
+		return fmt.Errorf("marshal storage projection delete: %w", err)
+	}
+	key := versionedKey(state.SubjectType+"/"+state.SubjectID, deletedAt, payload)
+	return enqueueJSON(ctx, tx, OperationStorageStateDelete, key, payload)
+}
+
+func getSandboxProjectionState(ctx context.Context, source db, sandboxID string, forUpdate bool) (*metering.SandboxProjectionState, error) {
+	if strings.TrimSpace(sandboxID) == "" {
+		return nil, fmt.Errorf("sandbox_id is required")
+	}
+	query := `
+		SELECT
+			sandbox_id, namespace, team_id, user_id, template_id, cluster_id,
+			owner_kind, resource_millicpu, resource_memory_mib,
+			claimed_at, active_since, paused, paused_at, terminated_at,
+			last_observed_at, last_resource_version
+		FROM metering.manager_sandbox_projection_state
+		WHERE sandbox_id = $1
+	`
+	if forUpdate {
+		query += " FOR UPDATE"
+	}
+	state := &metering.SandboxProjectionState{}
+	err := source.QueryRow(ctx, query, sandboxID).Scan(
+		&state.SandboxID, &state.Namespace, &state.TeamID, &state.UserID, &state.TemplateID, &state.ClusterID,
+		&state.OwnerKind, &state.ResourceMillicpu, &state.ResourceMemoryMiB,
+		&state.ClaimedAt, &state.ActiveSince, &state.Paused, &state.PausedAt, &state.TerminatedAt,
+		&state.LastObservedAt, &state.LastResourceVer,
+	)
+	if err == pgx.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("query sandbox projection state: %w", err)
+	}
+	return state, nil
+}
+
+func getStorageProjectionStateForUpdate(ctx context.Context, tx pgx.Tx, subjectType, subjectID string) (*metering.StorageProjectionState, error) {
+	state := &metering.StorageProjectionState{}
+	err := tx.QueryRow(ctx, `
+		SELECT
+			subject_type, subject_id, product, owner_kind,
+			team_id, user_id, COALESCE(sandbox_id, ''), COALESCE(volume_id, ''),
+			COALESCE(snapshot_id, ''), COALESCE(cluster_id, ''), region_id,
+			size_bytes, observed_at, unbilled_byte_nanoseconds
+		FROM metering.storage_projection_state
+		WHERE subject_type = $1 AND subject_id = $2
+		FOR UPDATE
+	`, subjectType, subjectID).Scan(
+		&state.SubjectType, &state.SubjectID, &state.Product, &state.OwnerKind,
+		&state.TeamID, &state.UserID, &state.SandboxID, &state.VolumeID,
+		&state.SnapshotID, &state.ClusterID, &state.RegionID,
+		&state.SizeBytes, &state.ObservedAt, &state.UnbilledByteNanoseconds,
+	)
+	if err == pgx.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("query storage projection state: %w", err)
+	}
+	return state, nil
+}
+
+type rowScanner interface {
+	Scan(...any) error
+}
+
+func scanStorageState(row rowScanner, state *metering.StorageProjectionState) error {
+	return row.Scan(
+		&state.SubjectType, &state.SubjectID, &state.Product, &state.OwnerKind,
+		&state.TeamID, &state.UserID, &state.SandboxID, &state.VolumeID,
+		&state.SnapshotID, &state.ClusterID, &state.RegionID,
+		&state.SizeBytes, &state.ObservedAt, &state.UnbilledByteNanoseconds,
+	)
+}
+
+func enqueue(ctx context.Context, tx pgx.Tx, operationType OperationType, dedupeKey string, payload any) error {
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal metering %s operation: %w", operationType, err)
+	}
+	return enqueueJSON(ctx, tx, operationType, dedupeKey, raw)
+}
+
+func enqueueJSON(ctx context.Context, tx pgx.Tx, operationType OperationType, dedupeKey string, payload []byte) error {
+	if operationType == "" {
+		return fmt.Errorf("metering operation type is required")
+	}
+	if strings.TrimSpace(dedupeKey) == "" {
+		return fmt.Errorf("metering operation dedupe key is required")
+	}
+	if !json.Valid(payload) {
+		return fmt.Errorf("metering operation payload is not valid JSON")
+	}
+	_, err := tx.Exec(ctx, `
+		INSERT INTO metering.projection_outbox (operation_type, dedupe_key, payload)
+		VALUES ($1, $2, $3)
+		ON CONFLICT (operation_type, dedupe_key) DO NOTHING
+	`, operationType, dedupeKey, payload)
+	if err != nil {
+		return fmt.Errorf("enqueue metering %s operation: %w", operationType, err)
+	}
+	return nil
+}
+
+func validateEvent(event *metering.Event) error {
+	if event == nil {
+		return fmt.Errorf("event is nil")
+	}
+	if event.EventID == "" {
+		return fmt.Errorf("event_id is required")
+	}
+	if event.Producer == "" {
+		return fmt.Errorf("producer is required")
+	}
+	if event.EventType == "" {
+		return fmt.Errorf("event_type is required")
+	}
+	if event.SubjectType == "" || event.SubjectID == "" {
+		return fmt.Errorf("subject_type and subject_id are required")
+	}
+	if event.OccurredAt.IsZero() {
+		return fmt.Errorf("occurred_at is required")
+	}
+	return nil
+}
+
+func validateWindow(window *metering.Window) error {
+	if window == nil {
+		return fmt.Errorf("window is nil")
+	}
+	if window.WindowID == "" {
+		return fmt.Errorf("window_id is required")
+	}
+	if window.Producer == "" {
+		return fmt.Errorf("producer is required")
+	}
+	if window.WindowType == "" {
+		return fmt.Errorf("window_type is required")
+	}
+	if window.SubjectType == "" || window.SubjectID == "" {
+		return fmt.Errorf("subject_type and subject_id are required")
+	}
+	if window.WindowStart.IsZero() || window.WindowEnd.IsZero() {
+		return fmt.Errorf("window_start and window_end are required")
+	}
+	if window.WindowEnd.Before(window.WindowStart) {
+		return fmt.Errorf("window_end must be greater than or equal to window_start")
+	}
+	if window.Unit == "" {
+		return fmt.Errorf("unit is required")
+	}
+	if window.Value < 0 {
+		return fmt.Errorf("value must be non-negative")
+	}
+	return nil
+}
+
+func versionedKey(identity string, at time.Time, payload []byte) string {
+	hash := sha256.Sum256(payload)
+	return fmt.Sprintf("%s/%d/%s", identity, at.UTC().UnixNano(), hex.EncodeToString(hash[:8]))
+}
+
+func nullableString(value string) any {
+	if value == "" {
+		return nil
+	}
+	return value
+}
+
+func truncateError(value string) string {
+	const max = 4000
+	if len(value) <= max {
+		return value
+	}
+	return value[:max]
+}
+
+func (r *Repository) timestamp() time.Time {
+	if r == nil || r.now == nil {
+		return time.Now().UTC()
+	}
+	return r.now().UTC()
+}

--- a/pkg/metering/outbox/repository_integration_test.go
+++ b/pkg/metering/outbox/repository_integration_test.go
@@ -1,0 +1,340 @@
+package outbox
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/sandbox0-ai/sandbox0/pkg/metering"
+)
+
+func TestRepositoryCapturesBusinessTransactionAndProjectionBatch(t *testing.T) {
+	pool := newMeteringTestDatabase(t)
+	ctx := context.Background()
+	if err := RunMigrations(ctx, pool, nil); err != nil {
+		t.Fatalf("RunMigrations: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `CREATE TABLE business_resource (id TEXT PRIMARY KEY)`); err != nil {
+		t.Fatalf("create business table: %v", err)
+	}
+
+	repo := NewRepository(pool)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	event := &metering.Event{
+		EventID:     "event-1",
+		Producer:    "test",
+		EventType:   metering.EventTypeSandboxClaimed,
+		SubjectType: metering.SubjectTypeSandbox,
+		SubjectID:   "sandbox-1",
+		OccurredAt:  now,
+	}
+	state := &metering.SandboxProjectionState{
+		SandboxID:      "sandbox-1",
+		Namespace:      "default",
+		LastObservedAt: now,
+	}
+	wantRollback := errors.New("rollback business transaction")
+	err := repo.InTx(ctx, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, `INSERT INTO business_resource (id) VALUES ('resource-1')`); err != nil {
+			return err
+		}
+		if err := repo.AppendEventTx(ctx, tx, event); err != nil {
+			return err
+		}
+		if err := repo.UpsertSandboxProjectionStateTx(ctx, tx, state); err != nil {
+			return err
+		}
+		return wantRollback
+	})
+	if !errors.Is(err, wantRollback) {
+		t.Fatalf("rolled back transaction error = %v", err)
+	}
+	assertCount(t, pool, `SELECT COUNT(*) FROM business_resource`, 0)
+	assertCount(t, pool, `SELECT COUNT(*) FROM metering.manager_sandbox_projection_state`, 0)
+	assertCount(t, pool, `SELECT COUNT(*) FROM metering.projection_outbox`, 0)
+
+	window := &metering.Window{
+		WindowID:    "window-1",
+		Producer:    "test",
+		WindowType:  metering.WindowTypeSandboxEgressBytes,
+		SubjectType: metering.SubjectTypeSandbox,
+		SubjectID:   "sandbox-1",
+		WindowStart: now,
+		WindowEnd:   now.Add(time.Second),
+		Value:       10,
+		Unit:        metering.WindowUnitBytes,
+	}
+	if err := repo.InTx(ctx, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, `INSERT INTO business_resource (id) VALUES ('resource-1')`); err != nil {
+			return err
+		}
+		if err := repo.AppendEventTx(ctx, tx, event); err != nil {
+			return err
+		}
+		if err := repo.AppendWindowTx(ctx, tx, window); err != nil {
+			return err
+		}
+		if err := repo.UpsertSandboxProjectionStateTx(ctx, tx, state); err != nil {
+			return err
+		}
+		return repo.UpsertProducerWatermarkTx(ctx, tx, "test", "region-1", now)
+	}); err != nil {
+		t.Fatalf("commit business transaction: %v", err)
+	}
+	assertCount(t, pool, `SELECT COUNT(*) FROM business_resource`, 1)
+	assertCount(t, pool, `SELECT COUNT(*) FROM metering.manager_sandbox_projection_state`, 1)
+	assertCount(t, pool, `SELECT COUNT(*) FROM metering.projection_outbox`, 4)
+	assertCount(t, pool, `SELECT COUNT(DISTINCT batch_id) FROM metering.projection_outbox`, 1)
+	if event.RecordedAt.IsZero() || window.RecordedAt.IsZero() {
+		t.Fatal("captured payloads must receive stable recorded_at values")
+	}
+
+	repo.now = func() time.Time { return now.Add(time.Minute) }
+	first, err := repo.ClaimNextBatch(ctx, "worker-1", 30*time.Second)
+	if err != nil || first == nil || len(first.Operations) != 4 {
+		t.Fatalf("first ClaimNextBatch = (%#v, %v)", first, err)
+	}
+	if err := repo.MarkFailed(ctx, first.ID, "worker-1", "clickhouse unavailable", repo.timestamp()); err != nil {
+		t.Fatalf("MarkFailed: %v", err)
+	}
+	second, err := repo.ClaimNextBatch(ctx, "worker-1", 30*time.Second)
+	if err != nil || second == nil || len(second.Operations) != len(first.Operations) {
+		t.Fatalf("second ClaimNextBatch = (%#v, %v)", second, err)
+	}
+	for i := range first.Operations {
+		if first.Operations[i].Sequence != second.Operations[i].Sequence || string(first.Operations[i].Payload) != string(second.Operations[i].Payload) {
+			t.Fatalf("operation %d changed across retry: %#v != %#v", i, first.Operations[i], second.Operations[i])
+		}
+	}
+	if err := repo.MarkDelivered(ctx, second.ID, "worker-1"); err != nil {
+		t.Fatalf("MarkDelivered: %v", err)
+	}
+	stats, err := repo.Stats(ctx)
+	if err != nil || stats.Pending != 0 || stats.OldestPending != nil {
+		t.Fatalf("Stats after delivery = (%#v, %v)", stats, err)
+	}
+}
+
+func TestRepositoryStorageProjectionIsAtomicWithCallerTransaction(t *testing.T) {
+	pool := newMeteringTestDatabase(t)
+	ctx := context.Background()
+	if err := RunMigrations(ctx, pool, nil); err != nil {
+		t.Fatalf("RunMigrations: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `CREATE TABLE business_volume (id TEXT PRIMARY KEY)`); err != nil {
+		t.Fatalf("create business table: %v", err)
+	}
+	repo := NewRepository(pool)
+	start := time.Now().UTC().Truncate(time.Microsecond).Add(-time.Hour)
+	observation := &metering.StorageObservation{
+		SubjectType: metering.SubjectTypeVolume,
+		SubjectID:   "volume-1",
+		VolumeID:    "volume-1",
+		TeamID:      "team-1",
+		SizeBytes:   1024,
+		ObservedAt:  start,
+	}
+	rollback := errors.New("rollback volume")
+	err := repo.InTx(ctx, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, `INSERT INTO business_volume (id) VALUES ('volume-1')`); err != nil {
+			return err
+		}
+		if err := repo.RecordStorageObservationTx(ctx, tx, observation); err != nil {
+			return err
+		}
+		return rollback
+	})
+	if !errors.Is(err, rollback) {
+		t.Fatalf("rollback error = %v", err)
+	}
+	assertCount(t, pool, `SELECT COUNT(*) FROM business_volume`, 0)
+	assertCount(t, pool, `SELECT COUNT(*) FROM metering.storage_projection_state`, 0)
+	assertCount(t, pool, `SELECT COUNT(*) FROM metering.projection_outbox`, 0)
+
+	if err := repo.InTx(ctx, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, `INSERT INTO business_volume (id) VALUES ('volume-1')`); err != nil {
+			return err
+		}
+		return repo.RecordStorageObservationTx(ctx, tx, observation)
+	}); err != nil {
+		t.Fatalf("record first storage observation: %v", err)
+	}
+	observation.ObservedAt = start.Add(time.Hour)
+	if err := repo.RecordStorageObservation(ctx, observation); err != nil {
+		t.Fatalf("record second storage observation: %v", err)
+	}
+	assertCount(t, pool, `SELECT COUNT(*) FROM metering.storage_projection_state`, 1)
+	assertCount(t, pool, `SELECT COUNT(*) FROM metering.projection_outbox WHERE operation_type = 'window'`, 1)
+	assertCount(t, pool, `SELECT COUNT(*) FROM metering.projection_outbox WHERE operation_type = 'storage_state'`, 2)
+}
+
+func TestMigrationsUpgradeLegacyVersionFiveSchema(t *testing.T) {
+	pool := newMeteringTestDatabase(t)
+	ctx := context.Background()
+	_, err := pool.Exec(ctx, `
+		CREATE SCHEMA metering;
+		CREATE TABLE metering.goose_db_version (
+			id SERIAL PRIMARY KEY,
+			version_id BIGINT NOT NULL,
+			is_applied BOOLEAN NOT NULL,
+			tstamp TIMESTAMP NOT NULL DEFAULT NOW()
+		);
+		INSERT INTO metering.goose_db_version (version_id, is_applied) VALUES (0, TRUE), (5, TRUE);
+		CREATE TABLE metering.manager_sandbox_projection_state (
+			sandbox_id TEXT PRIMARY KEY,
+			namespace TEXT NOT NULL,
+			team_id TEXT NOT NULL DEFAULT '', user_id TEXT NOT NULL DEFAULT '',
+			template_id TEXT NOT NULL DEFAULT '', cluster_id TEXT NOT NULL DEFAULT '',
+			owner_kind TEXT NOT NULL DEFAULT '', resource_millicpu BIGINT NOT NULL DEFAULT 0,
+			resource_memory_mib BIGINT NOT NULL DEFAULT 0, claimed_at TIMESTAMPTZ,
+			active_since TIMESTAMPTZ, paused BOOLEAN NOT NULL DEFAULT FALSE,
+			paused_at TIMESTAMPTZ, terminated_at TIMESTAMPTZ,
+			last_observed_at TIMESTAMPTZ NOT NULL, last_resource_version TEXT NOT NULL DEFAULT ''
+		);
+		CREATE TABLE metering.storage_projection_state (
+			subject_type TEXT NOT NULL, subject_id TEXT NOT NULL,
+			product TEXT NOT NULL DEFAULT 'sandbox', owner_kind TEXT NOT NULL DEFAULT '',
+			team_id TEXT NOT NULL DEFAULT '', user_id TEXT NOT NULL DEFAULT '',
+			sandbox_id TEXT, volume_id TEXT, snapshot_id TEXT, cluster_id TEXT,
+			region_id TEXT NOT NULL DEFAULT '', size_bytes BIGINT NOT NULL DEFAULT 0,
+			observed_at TIMESTAMPTZ NOT NULL, unbilled_byte_nanoseconds BIGINT NOT NULL DEFAULT 0,
+			updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(), PRIMARY KEY (subject_type, subject_id)
+		);
+	`)
+	if err != nil {
+		t.Fatalf("create legacy schema: %v", err)
+	}
+	if err := RunMigrations(ctx, pool, nil); err != nil {
+		t.Fatalf("upgrade legacy schema: %v", err)
+	}
+	assertCount(t, pool, `SELECT COUNT(*) FROM metering.goose_db_version WHERE version_id = 6 AND is_applied`, 1)
+	var tableName string
+	if err := pool.QueryRow(ctx, `SELECT to_regclass('metering.projection_outbox')::text`).Scan(&tableName); err != nil || tableName == "" {
+		t.Fatalf("projection_outbox after migration = %q, %v", tableName, err)
+	}
+}
+
+type fakeProjectionStateSource struct {
+	sandboxes []*metering.SandboxProjectionState
+	storage   []*metering.StorageProjectionState
+}
+
+func (f *fakeProjectionStateSource) ListActiveSandboxProjectionStates(context.Context) ([]*metering.SandboxProjectionState, error) {
+	return f.sandboxes, nil
+}
+
+func (f *fakeProjectionStateSource) ListActiveStorageProjectionStates(context.Context) ([]*metering.StorageProjectionState, error) {
+	return f.storage, nil
+}
+
+func TestBootstrapProjectionStatesKeepsNewerPostgresStateAndCopiesNoHistory(t *testing.T) {
+	pool := newMeteringTestDatabase(t)
+	ctx := context.Background()
+	if err := RunMigrations(ctx, pool, nil); err != nil {
+		t.Fatalf("RunMigrations: %v", err)
+	}
+	repo := NewRepository(pool)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	source := &fakeProjectionStateSource{
+		sandboxes: []*metering.SandboxProjectionState{{
+			SandboxID:      "sandbox-1",
+			Namespace:      "default",
+			TeamID:         "team-current",
+			LastObservedAt: now,
+		}},
+		storage: []*metering.StorageProjectionState{{
+			SubjectType: metering.SubjectTypeVolume,
+			SubjectID:   "volume-1",
+			TeamID:      "team-current",
+			SizeBytes:   1024,
+			ObservedAt:  now,
+		}},
+	}
+	result, err := repo.BootstrapProjectionStates(ctx, source)
+	if err != nil || result.SandboxStates != 1 || result.StorageStates != 1 {
+		t.Fatalf("first BootstrapProjectionStates = (%#v, %v)", result, err)
+	}
+	completed, err := repo.ProjectionBootstrapCompleted(ctx)
+	if err != nil || !completed {
+		t.Fatalf("ProjectionBootstrapCompleted = (%v, %v), want true", completed, err)
+	}
+	assertCount(t, pool, `SELECT COUNT(*) FROM metering.projection_outbox`, 0)
+
+	source.sandboxes[0].TeamID = "team-stale"
+	source.sandboxes[0].LastObservedAt = now.Add(-time.Minute)
+	source.storage[0].TeamID = "team-stale"
+	source.storage[0].ObservedAt = now.Add(-time.Minute)
+	result, err = repo.BootstrapProjectionStates(ctx, source)
+	if err != nil || result.SandboxStates != 0 || result.StorageStates != 0 {
+		t.Fatalf("stale BootstrapProjectionStates = (%#v, %v)", result, err)
+	}
+	var sandboxTeam, storageTeam string
+	if err := pool.QueryRow(ctx, `SELECT team_id FROM metering.manager_sandbox_projection_state WHERE sandbox_id = 'sandbox-1'`).Scan(&sandboxTeam); err != nil {
+		t.Fatalf("query sandbox bootstrap state: %v", err)
+	}
+	if err := pool.QueryRow(ctx, `SELECT team_id FROM metering.storage_projection_state WHERE subject_id = 'volume-1'`).Scan(&storageTeam); err != nil {
+		t.Fatalf("query storage bootstrap state: %v", err)
+	}
+	if sandboxTeam != "team-current" || storageTeam != "team-current" {
+		t.Fatalf("stale bootstrap overwrote state: sandbox=%q storage=%q", sandboxTeam, storageTeam)
+	}
+}
+
+func newMeteringTestDatabase(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	databaseURL := os.Getenv("INTEGRATION_DATABASE_URL")
+	if databaseURL == "" {
+		databaseURL = os.Getenv("TEST_DATABASE_URL")
+	}
+	if databaseURL == "" {
+		t.Skip("missing INTEGRATION_DATABASE_URL or TEST_DATABASE_URL")
+	}
+	ctx := context.Background()
+	adminConfig, err := pgxpool.ParseConfig(databaseURL)
+	if err != nil {
+		t.Fatalf("parse test database URL: %v", err)
+	}
+	admin, err := pgxpool.NewWithConfig(ctx, adminConfig)
+	if err != nil {
+		t.Fatalf("connect test database admin: %v", err)
+	}
+	databaseName := "metering_outbox_test_" + strings.ReplaceAll(uuid.NewString(), "-", "")
+	quotedName := `"` + strings.ReplaceAll(databaseName, `"`, `""`) + `"`
+	if _, err := admin.Exec(ctx, "CREATE DATABASE "+quotedName); err != nil {
+		admin.Close()
+		t.Fatalf("create test database: %v", err)
+	}
+	testConfig := adminConfig.Copy()
+	testConfig.ConnConfig.Database = databaseName
+	pool, err := pgxpool.NewWithConfig(ctx, testConfig)
+	if err != nil {
+		_, _ = admin.Exec(ctx, "DROP DATABASE "+quotedName)
+		admin.Close()
+		t.Fatalf("connect isolated test database: %v", err)
+	}
+	t.Cleanup(func() {
+		pool.Close()
+		if _, err := admin.Exec(context.Background(), "DROP DATABASE "+quotedName); err != nil {
+			t.Errorf("drop test database: %v", err)
+		}
+		admin.Close()
+	})
+	return pool
+}
+
+func assertCount(t *testing.T, pool *pgxpool.Pool, query string, want int64) {
+	t.Helper()
+	var got int64
+	if err := pool.QueryRow(context.Background(), query).Scan(&got); err != nil {
+		t.Fatalf("query count %q: %v", query, err)
+	}
+	if got != want {
+		t.Fatalf("count for %q = %d, want %d", query, got, want)
+	}
+}

--- a/pkg/metering/outbox/types.go
+++ b/pkg/metering/outbox/types.go
@@ -1,0 +1,64 @@
+package outbox
+
+import (
+	"context"
+	"time"
+
+	"github.com/sandbox0-ai/sandbox0/pkg/metering"
+)
+
+type OperationType string
+
+const (
+	OperationEvent              OperationType = "event"
+	OperationWindow             OperationType = "window"
+	OperationWatermark          OperationType = "watermark"
+	OperationSandboxState       OperationType = "sandbox_state"
+	OperationStorageState       OperationType = "storage_state"
+	OperationStorageStateDelete OperationType = "storage_state_delete"
+)
+
+type WatermarkOperation struct {
+	Producer       string    `json:"producer"`
+	RegionID       string    `json:"region_id,omitempty"`
+	CompleteBefore time.Time `json:"complete_before"`
+}
+
+type StorageStateDeleteOperation struct {
+	State     *metering.StorageProjectionState `json:"state"`
+	DeletedAt time.Time                        `json:"deleted_at"`
+}
+
+// Operation is one idempotent ClickHouse mutation captured in PostgreSQL.
+type Operation struct {
+	Sequence       int64
+	BatchID        int64
+	Type           OperationType
+	DedupeKey      string
+	Payload        []byte
+	Attempts       int
+	CreatedAt      time.Time
+	ClaimExpiresAt *time.Time
+}
+
+// Batch is the oldest pending PostgreSQL transaction worth of operations.
+type Batch struct {
+	ID         int64
+	Operations []*Operation
+}
+
+// Sink applies durable outbox operations to the long-term metering store.
+type Sink interface {
+	AppendEvent(context.Context, *metering.Event) error
+	AppendWindow(context.Context, *metering.Window) error
+	UpsertProducerWatermark(context.Context, string, string, time.Time) error
+	UpsertSandboxProjectionState(context.Context, *metering.SandboxProjectionState) error
+	UpsertStorageProjectionState(context.Context, *metering.StorageProjectionState) error
+	DeleteStorageProjectionState(context.Context, *metering.StorageProjectionState, time.Time) error
+}
+
+// Stats summarizes outstanding delivery work.
+type Stats struct {
+	Pending       int64
+	OldestPending *time.Time
+}

--- a/pkg/metering/storage.go
+++ b/pkg/metering/storage.go
@@ -1,0 +1,93 @@
+package metering
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"math/big"
+	"time"
+)
+
+// StorageWindowFromState advances a storage projection state to end while
+// carrying sub-byte-hour usage forward without losing precision.
+func StorageWindowFromState(state *StorageProjectionState, end time.Time) (*Window, int64) {
+	if state == nil {
+		return nil, 0
+	}
+	remainder := normalizeStorageRemainder(state.UnbilledByteNanoseconds)
+	end = end.UTC()
+	start := state.ObservedAt.UTC()
+	if !end.After(start) {
+		return nil, remainder
+	}
+	value, remainder := storageByteHoursWithRemainder(state.SizeBytes, end.Sub(start), remainder)
+	if value <= 0 {
+		return nil, remainder
+	}
+	windowType := WindowTypeSandboxVolumeByteHours
+	if state.SubjectType == SubjectTypeRootFS {
+		windowType = WindowTypeSandboxRootFSByteHours
+	}
+	return &Window{
+		WindowID:    fmt.Sprintf("storage/%s/%s/%d/%d", state.SubjectType, state.SubjectID, start.UnixNano(), end.UnixNano()),
+		Producer:    ProducerStorage,
+		RegionID:    state.RegionID,
+		WindowType:  windowType,
+		SubjectType: state.SubjectType,
+		SubjectID:   state.SubjectID,
+		TeamID:      state.TeamID,
+		UserID:      state.UserID,
+		SandboxID:   state.SandboxID,
+		VolumeID:    state.VolumeID,
+		SnapshotID:  state.SnapshotID,
+		ClusterID:   state.ClusterID,
+		WindowStart: start,
+		WindowEnd:   end,
+		Value:       value,
+		Unit:        WindowUnitByteHours,
+		Data:        storageWindowData(state, end.Sub(start)),
+	}, remainder
+}
+
+func storageByteHoursWithRemainder(sizeBytes int64, duration time.Duration, previousRemainder int64) (int64, int64) {
+	remainder := normalizeStorageRemainder(previousRemainder)
+	if sizeBytes <= 0 || duration <= 0 {
+		return 0, remainder
+	}
+	accumulator := big.NewInt(remainder)
+	var usage big.Int
+	usage.Mul(big.NewInt(sizeBytes), big.NewInt(duration.Nanoseconds()))
+	accumulator.Add(accumulator, &usage)
+
+	hourNanos := big.NewInt(int64(time.Hour))
+	var quotient big.Int
+	var modulo big.Int
+	quotient.QuoRem(accumulator, hourNanos, &modulo)
+	if !quotient.IsInt64() {
+		return math.MaxInt64, 0
+	}
+	return quotient.Int64(), modulo.Int64()
+}
+
+func normalizeStorageRemainder(value int64) int64 {
+	if value <= 0 {
+		return 0
+	}
+	return value % int64(time.Hour)
+}
+
+func storageWindowData(state *StorageProjectionState, duration time.Duration) json.RawMessage {
+	data := map[string]any{
+		"product":               state.Product,
+		"size_bytes":            state.SizeBytes,
+		"duration_milliseconds": duration.Milliseconds(),
+	}
+	if state.OwnerKind != "" {
+		data["owner_kind"] = state.OwnerKind
+	}
+	raw, err := json.Marshal(data)
+	if err != nil {
+		return json.RawMessage(`{}`)
+	}
+	return raw
+}

--- a/pkg/metering/storage_test.go
+++ b/pkg/metering/storage_test.go
@@ -1,0 +1,48 @@
+package metering
+
+import (
+	"testing"
+	"time"
+)
+
+func TestStorageWindowFromStateCarriesFractionalByteHours(t *testing.T) {
+	start := time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC)
+	state := &StorageProjectionState{
+		SubjectType: SubjectTypeVolume,
+		SubjectID:   "volume-1",
+		SizeBytes:   1,
+		ObservedAt:  start,
+	}
+
+	window, remainder := StorageWindowFromState(state, start.Add(30*time.Minute))
+	if window != nil {
+		t.Fatalf("first half-hour window = %#v, want nil", window)
+	}
+	if remainder != int64(30*time.Minute) {
+		t.Fatalf("first remainder = %d, want %d", remainder, int64(30*time.Minute))
+	}
+
+	state.ObservedAt = start.Add(30 * time.Minute)
+	state.UnbilledByteNanoseconds = remainder
+	window, remainder = StorageWindowFromState(state, start.Add(time.Hour))
+	if window == nil || window.Value != 1 || window.Unit != WindowUnitByteHours {
+		t.Fatalf("second half-hour window = %#v, want one byte-hour", window)
+	}
+	if remainder != 0 {
+		t.Fatalf("second remainder = %d, want 0", remainder)
+	}
+}
+
+func TestStorageWindowFromStateUsesRootFSWindowType(t *testing.T) {
+	start := time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC)
+	state := &StorageProjectionState{
+		SubjectType: SubjectTypeRootFS,
+		SubjectID:   "sandbox-1",
+		SizeBytes:   1024,
+		ObservedAt:  start,
+	}
+	window, _ := StorageWindowFromState(state, start.Add(time.Hour))
+	if window == nil || window.WindowType != WindowTypeSandboxRootFSByteHours || window.Value != 1024 {
+		t.Fatalf("rootfs window = %#v", window)
+	}
+}

--- a/pkg/observability/metrics/manager.go
+++ b/pkg/observability/metrics/manager.go
@@ -31,6 +31,10 @@ type ManagerMetrics struct {
 	MeteringEventsTotal             *prometheus.CounterVec
 	MeteringWindowsTotal            *prometheus.CounterVec
 	MeteringErrorsTotal             *prometheus.CounterVec
+	MeteringOutboxBatchesTotal      *prometheus.CounterVec
+	MeteringOutboxOperationsTotal   *prometheus.CounterVec
+	MeteringOutboxPendingOperations prometheus.Gauge
+	MeteringOutboxOldestPendingAge  prometheus.Gauge
 	RootFSMaintenanceRunsTotal      *prometheus.CounterVec
 	RootFSMaintenanceDuration       *prometheus.HistogramVec
 	RootFSGCLayersTotal             prometheus.Counter
@@ -153,6 +157,22 @@ func NewManager(registry prometheus.Registerer) *ManagerMetrics {
 			Name: "manager_metering_errors_total",
 			Help: "Total number of manager metering projector errors",
 		}, []string{"operation"}),
+		MeteringOutboxBatchesTotal: factory.NewCounterVec(prometheus.CounterOpts{
+			Name: "manager_metering_outbox_batches_total",
+			Help: "Total number of PostgreSQL metering outbox batches by delivery result",
+		}, []string{"result"}),
+		MeteringOutboxOperationsTotal: factory.NewCounterVec(prometheus.CounterOpts{
+			Name: "manager_metering_outbox_operations_total",
+			Help: "Total number of metering outbox operation delivery attempts by type and result",
+		}, []string{"operation_type", "result"}),
+		MeteringOutboxPendingOperations: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "manager_metering_outbox_pending_operations",
+			Help: "Number of metering outbox operations awaiting ClickHouse delivery",
+		}),
+		MeteringOutboxOldestPendingAge: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "manager_metering_outbox_oldest_pending_age_seconds",
+			Help: "Age in seconds of the oldest metering outbox operation awaiting ClickHouse delivery",
+		}),
 		RootFSMaintenanceRunsTotal: factory.NewCounterVec(prometheus.CounterOpts{
 			Name: "manager_rootfs_maintenance_runs_total",
 			Help: "Total number of rootfs maintenance cycles",

--- a/storage-proxy/cmd/storage-proxy/main.go
+++ b/storage-proxy/cmd/storage-proxy/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/k8s"
 	meteringpkg "github.com/sandbox0-ai/sandbox0/pkg/metering"
 	meteringclickhouse "github.com/sandbox0-ai/sandbox0/pkg/metering/clickhouse"
+	meteringoutbox "github.com/sandbox0-ai/sandbox0/pkg/metering/outbox"
 	"github.com/sandbox0-ai/sandbox0/pkg/migrate"
 	"github.com/sandbox0-ai/sandbox0/pkg/observability"
 	httpobs "github.com/sandbox0-ai/sandbox0/pkg/observability/http"
@@ -85,7 +86,8 @@ func main() {
 
 	// Initialize database connection pool
 	var repo *db.Repository
-	var meteringRepo *meteringclickhouse.Repository
+	var meteringRepo *meteringoutbox.Repository
+	var meteringSink *meteringclickhouse.Repository
 	var quotaRepo *quota.Repository
 	var pool *pgxpool.Pool
 	var sharedClock *clock.Clock
@@ -112,24 +114,52 @@ func main() {
 			if err := quota.RunMigrations(context.Background(), pool, observability.NewMigrateLogger(zapLogger)); err != nil {
 				zapLogger.Fatal("Failed to run quota migrations", zap.Error(err))
 			}
+			if err := meteringoutbox.RunMigrations(context.Background(), pool, observability.NewMigrateLogger(zapLogger)); err != nil {
+				zapLogger.Fatal("Failed to run metering outbox migrations", zap.Error(err))
+			}
 		}
 
 		repo = db.NewRepository(pool)
 		if cfg.Metering.Enabled {
 			quotaRepo = quota.NewRepository(pool)
+			meteringRepo = meteringoutbox.NewRepository(pool)
 		}
 	} else {
 		zapLogger.Warn("DATABASE_URL not set, running without database persistence")
 	}
-	meteringDB, meteringRepo, err := initMetering(context.Background(), cfg, zapLogger)
+	if cfg.Metering.Enabled && pool == nil {
+		zapLogger.Fatal("DATABASE_URL is required when metering is enabled")
+	}
+	meteringDB, meteringSink, meteringSinkReady, err := initMetering(context.Background(), cfg, zapLogger)
 	if err != nil {
 		zapLogger.Fatal("Failed to initialize metering backend", zap.Error(err))
 	}
 	if meteringDB != nil {
 		defer meteringDB.Close()
 	}
+	if meteringRepo != nil && meteringSink != nil {
+		bootstrapCompleted, err := meteringRepo.ProjectionBootstrapCompleted(context.Background())
+		if err != nil {
+			zapLogger.Fatal("Failed to inspect metering projection bootstrap", zap.Error(err))
+		}
+		if !meteringSinkReady && !bootstrapCompleted {
+			zapLogger.Fatal("ClickHouse must be reachable for the initial metering projection bootstrap")
+		}
+		if meteringSinkReady {
+			bootstrap, err := meteringRepo.BootstrapProjectionStates(context.Background(), meteringSink)
+			if err != nil {
+				zapLogger.Fatal("Failed to bootstrap metering projection state", zap.Error(err))
+			}
+			zapLogger.Info("Metering projection state bootstrapped",
+				zap.Int64("sandbox_states", bootstrap.SandboxStates),
+				zap.Int64("storage_states", bootstrap.StorageStates),
+			)
+		} else {
+			zapLogger.Warn("Starting with deferred ClickHouse metering delivery; projection bootstrap is already complete")
+		}
+	}
 	if quotaRepo != nil {
-		quotaRepo.SetUsageStore(meteringRepo)
+		quotaRepo.SetUsageStore(meteringSink)
 	}
 
 	// Create volume manager
@@ -378,9 +408,9 @@ func runMigrations(ctx context.Context, pool *pgxpool.Pool, schema string, logge
 	return nil
 }
 
-func initMetering(ctx context.Context, cfg *config.StorageProxyConfig, logger *zap.Logger) (*sql.DB, *meteringclickhouse.Repository, error) {
+func initMetering(ctx context.Context, cfg *config.StorageProxyConfig, logger *zap.Logger) (*sql.DB, *meteringclickhouse.Repository, bool, error) {
 	if cfg == nil || !cfg.Metering.Enabled {
-		return nil, nil, nil
+		return nil, nil, false, nil
 	}
 	ch := cfg.Metering.ClickHouse
 	timeout := ch.ConnectTimeout.Duration
@@ -389,7 +419,7 @@ func initMetering(ctx context.Context, cfg *config.StorageProxyConfig, logger *z
 	}
 	connectCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-	db, repo, err := meteringclickhouse.Open(connectCtx, meteringclickhouse.OpenConfig{
+	openConfig := meteringclickhouse.OpenConfig{
 		DSN: ch.DSN,
 		Schema: meteringclickhouse.Config{
 			Database:          ch.Database,
@@ -400,9 +430,15 @@ func initMetering(ctx context.Context, cfg *config.StorageProxyConfig, logger *z
 			StorageStateTable: ch.StorageStateTable,
 		},
 		Migrate: !ch.SkipSchemaMigration,
-	})
+	}
+	db, repo, err := meteringclickhouse.Open(connectCtx, openConfig)
 	if err != nil {
-		return nil, nil, fmt.Errorf("initialize clickhouse metering backend: %w", err)
+		deferredDB, deferredRepo, deferredErr := meteringclickhouse.OpenDeferred(openConfig)
+		if deferredErr != nil {
+			return nil, nil, false, fmt.Errorf("initialize deferred clickhouse metering backend after %v: %w", err, deferredErr)
+		}
+		logger.Warn("Metering ClickHouse backend is unavailable; delivery will retry from PostgreSQL", zap.Error(err))
+		return deferredDB, deferredRepo, false, nil
 	}
 	logger.Info("Metering ClickHouse backend initialized",
 		zap.String("database", ch.Database),
@@ -410,10 +446,10 @@ func initMetering(ctx context.Context, cfg *config.StorageProxyConfig, logger *z
 		zap.String("windows_table", ch.WindowsTable),
 		zap.Bool("schema_migration", !ch.SkipSchemaMigration),
 	)
-	return db, repo, nil
+	return db, repo, true, nil
 }
 
-func runStorageMeteringFlushLoop(ctx context.Context, repo *meteringclickhouse.Repository, regionID string, logger *zap.Logger) {
+func runStorageMeteringFlushLoop(ctx context.Context, repo *meteringoutbox.Repository, regionID string, logger *zap.Logger) {
 	const (
 		flushInterval = time.Minute
 		flushBatch    = 500


### PR DESCRIPTION
## Summary

- keep ClickHouse as the long-term metering truth and sole query/export backend
- capture stable ClickHouse operations in a short-lived PostgreSQL transactional outbox
- project the oldest transaction batch from manager with exact-payload retries
- move manager and storage projection state to compact PostgreSQL producer-state tables
- bootstrap active producer state from ClickHouse during upgrade without copying historical events or windows
- make manager, storage-proxy, and netd defer ClickHouse reconnection after the one-time bootstrap

## Why

The ClickHouse repository exposed `InTx` and `*Tx` methods but ignored the supplied PostgreSQL transaction. That made storage resource mutations and metering writes look atomic when they were not. A partial ClickHouse failure could commit only part of a logical batch. Manager status-only early returns also assumed the preceding projection succeeded, and netd retries recomputed the window end, producing a different logical window after a partial failure.

## Design

PostgreSQL stores only:

- pending/delivered projection operations, retained briefly for retry and dedupe
- current manager sandbox projection state
- current storage projection state and fractional byte-hour remainder
- a one-time ClickHouse state-bootstrap marker

It does not store a second historical usage ledger. Event/window history, export cursors, watermarks, and quota query projections remain in ClickHouse.

Operations captured by one PostgreSQL transaction share a batch ID. Manager claims the globally oldest pending batch, applies operations in sequence, and advances a watermark only after every older operation succeeds. ClickHouse `ReplacingMergeTree` IDs/versions make exact retries idempotent. A failed batch retries forever with bounded exponential backoff.

Expected normal visibility is about 2 seconds for lifecycle/storage mutations, the netd report interval plus projector polling (10s + ~2s by default), and up to one minute plus polling for periodic storage byte-hour windows.

## Validation

- real PostgreSQL transaction commit/rollback and stable batch retry tests
- legacy metering migration version 5 to version 6 upgrade test
- active ClickHouse projection-state bootstrap test, including stale-state protection
- manager early-return retry regression test
- netd stable failed-window/residual-window regression test
- projector partial failure and exact-payload replay tests
- race suites: manager, netd, storage-proxy, infra-operator, and `pkg/...`
- `go vet` on changed packages
- manager, storage-proxy, and netd binary builds

Remote kind validation will run while CI is active, including ClickHouse outage, PostgreSQL backlog inspection, recovery drain, and export verification.