### PR TITLE
feat(auth): support invitation-oriented OIDC login

### DIFF
--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -213,6 +213,20 @@ paths:
             type: boolean
           required: false
           description: When true, the OIDC callback redirects to return_url with a short-lived login_code for server-side exchange.
+        - name: login_hint
+          in: query
+          schema:
+            type: string
+            maxLength: 320
+          required: false
+          description: Optional login identifier forwarded to the OIDC provider for account prefilling.
+        - name: screen_hint
+          in: query
+          schema:
+            type: string
+            enum: [signup]
+          required: false
+          description: Optional provider hint that starts a supported hosted login flow on its signup screen.
       responses:
         "302":
           description: Redirect to OIDC provider

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -749,6 +749,11 @@ const (
 	S3   VolumeBackend = "s3"
 )
 
+// Defines values for GetAuthOidcProviderLoginParamsScreenHint.
+const (
+	Signup GetAuthOidcProviderLoginParamsScreenHint = "signup"
+)
+
 // APIKey defines model for APIKey.
 type APIKey struct {
 	CreatedAt  time.Time  `json:"created_at"`
@@ -3708,7 +3713,16 @@ type GetAuthOidcProviderLoginParams struct {
 
 	// WebLogin When true, the OIDC callback redirects to return_url with a short-lived login_code for server-side exchange.
 	WebLogin *bool `form:"web_login,omitempty" json:"web_login,omitempty"`
+
+	// LoginHint Optional login identifier forwarded to the OIDC provider for account prefilling.
+	LoginHint *string `form:"login_hint,omitempty" json:"login_hint,omitempty"`
+
+	// ScreenHint Optional provider hint that starts a supported hosted login flow on its signup screen.
+	ScreenHint *GetAuthOidcProviderLoginParamsScreenHint `form:"screen_hint,omitempty" json:"screen_hint,omitempty"`
 }
+
+// GetAuthOidcProviderLoginParamsScreenHint defines parameters for GetAuthOidcProviderLogin.
+type GetAuthOidcProviderLoginParamsScreenHint string
 
 // GetTeamsIdMembersParams defines parameters for GetTeamsIdMembers.
 type GetTeamsIdMembersParams struct {

--- a/pkg/gateway/auth/oidc/manager.go
+++ b/pkg/gateway/auth/oidc/manager.go
@@ -37,6 +37,7 @@ type CallbackResult struct {
 type identityStore interface {
 	GetUserIdentityByProviderSubject(ctx context.Context, provider, subject string) (*identity.UserIdentity, error)
 	GetUserByID(ctx context.Context, id string) (*identity.User, error)
+	UpdateUser(ctx context.Context, user *identity.User) error
 	UpdateUserIdentityClaims(ctx context.Context, id string, rawClaims []byte) error
 	GetUserByEmail(ctx context.Context, email string) (*identity.User, error)
 	CreateUser(ctx context.Context, user *identity.User) error
@@ -124,6 +125,8 @@ func (m *Manager) ListProviders() []*Provider {
 
 type authURLConfig struct {
 	webLoginHandoff bool
+	loginHint       string
+	screenHint      string
 }
 
 // AuthURLOption configures OIDC authorization URL generation.
@@ -133,6 +136,20 @@ type AuthURLOption func(*authURLConfig)
 func WithWebLoginHandoff() AuthURLOption {
 	return func(cfg *authURLConfig) {
 		cfg.webLoginHandoff = true
+	}
+}
+
+// WithLoginHint asks the upstream provider to prefill the login identifier.
+func WithLoginHint(value string) AuthURLOption {
+	return func(cfg *authURLConfig) {
+		cfg.loginHint = strings.TrimSpace(value)
+	}
+}
+
+// WithSignupScreen asks providers that support screen_hint to start on signup.
+func WithSignupScreen() AuthURLOption {
+	return func(cfg *authURLConfig) {
+		cfg.screenHint = "signup"
 	}
 }
 
@@ -150,6 +167,9 @@ func (m *Manager) GenerateAuthURL(providerID, returnURL string, opts ...AuthURLO
 	}
 	if cfg.webLoginHandoff && !m.IsAllowedWebReturnURL(returnURL) {
 		return "", ErrInvalidReturnURL
+	}
+	if len(cfg.loginHint) > 320 || strings.ContainsAny(cfg.loginHint, "\r\n") {
+		return "", ErrInvalidAuthorizationHint
 	}
 
 	// Generate state
@@ -172,7 +192,10 @@ func (m *Manager) GenerateAuthURL(providerID, returnURL string, opts ...AuthURLO
 	}
 	m.statesMu.Unlock()
 
-	return provider.AuthURL(state, verifier), nil
+	return provider.AuthURL(state, verifier, authorizationHints{
+		LoginHint:  cfg.loginHint,
+		ScreenHint: cfg.screenHint,
+	}), nil
 }
 
 // GenerateLogoutURL builds a provider logout URL for browser logout flows.
@@ -360,6 +383,10 @@ func (m *Manager) findOrCreateUser(ctx context.Context, provider *Provider, user
 			return nil, fmt.Errorf("get user: %w", err)
 		}
 
+		if err := m.syncUserClaims(ctx, user, userInfo); err != nil {
+			return nil, err
+		}
+
 		// Update claims
 		_ = m.repo.UpdateUserIdentityClaims(ctx, identityRecord.ID, userInfo.RawClaims)
 
@@ -373,6 +400,9 @@ func (m *Manager) findOrCreateUser(ctx context.Context, provider *Provider, user
 	// Check if user exists by email
 	user, err := m.repo.GetUserByEmail(ctx, userInfo.Email)
 	if err == nil {
+		if err := m.syncUserClaims(ctx, user, userInfo); err != nil {
+			return nil, err
+		}
 		// User exists, link identity
 		identityRecord := &identity.UserIdentity{
 			UserID:    user.ID,
@@ -420,6 +450,34 @@ func (m *Manager) findOrCreateUser(ctx context.Context, provider *Provider, user
 	}
 
 	return user, nil
+}
+
+// syncUserClaims promotes provider-verified state only when the stored and
+// asserted emails match, while refreshing non-security profile fields.
+func (m *Manager) syncUserClaims(ctx context.Context, user *identity.User, userInfo *UserInfo) error {
+	changed := false
+	if name := strings.TrimSpace(userInfo.Name); name != "" && name != user.Name {
+		user.Name = name
+		changed = true
+	}
+	if picture := strings.TrimSpace(userInfo.Picture); picture != "" && picture != user.AvatarURL {
+		user.AvatarURL = picture
+		changed = true
+	}
+	if userInfo.EmailVerified && !user.EmailVerified && strings.EqualFold(
+		strings.TrimSpace(user.Email),
+		strings.TrimSpace(userInfo.Email),
+	) {
+		user.EmailVerified = true
+		changed = true
+	}
+	if !changed {
+		return nil
+	}
+	if err := m.repo.UpdateUser(ctx, user); err != nil {
+		return fmt.Errorf("update user from OIDC claims: %w", err)
+	}
+	return nil
 }
 
 // cleanupStates periodically cleans up expired states

--- a/pkg/gateway/auth/oidc/manager_test.go
+++ b/pkg/gateway/auth/oidc/manager_test.go
@@ -16,6 +16,7 @@ type fakeIdentityStore struct {
 	identitiesByKey     map[string]*identity.UserIdentity
 	createUserCalls     int
 	createIdentityCalls int
+	updateUserCalls     int
 }
 
 func newFakeIdentityStore() *fakeIdentityStore {
@@ -46,6 +47,17 @@ func (f *fakeIdentityStore) GetUserByID(_ context.Context, id string) (*identity
 	}
 	copied := *user
 	return &copied, nil
+}
+
+func (f *fakeIdentityStore) UpdateUser(_ context.Context, user *identity.User) error {
+	if _, ok := f.usersByID[user.ID]; !ok {
+		return identity.ErrUserNotFound
+	}
+	f.updateUserCalls++
+	copied := *user
+	f.usersByID[user.ID] = &copied
+	f.usersByEmail[user.Email] = &copied
+	return nil
 }
 
 func (f *fakeIdentityStore) UpdateUserIdentityClaims(_ context.Context, id string, rawClaims []byte) error {
@@ -132,5 +144,77 @@ func TestManagerFindOrCreateUserAutoProvisionCreatesUserWithoutDefaultTeam(t *te
 	}
 	if record.UserID != user.ID {
 		t.Fatalf("identity user id = %q, want %q", record.UserID, user.ID)
+	}
+}
+
+func TestManagerFindOrCreateUserPromotesVerifiedOIDCClaims(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeIdentityStore()
+	store.usersByID["user-1"] = &identity.User{
+		ID:            "user-1",
+		Email:         "invitee@example.com",
+		Name:          "Old Name",
+		EmailVerified: false,
+	}
+	store.usersByEmail["invitee@example.com"] = store.usersByID["user-1"]
+	store.identitiesByKey[identityKey("auth0", "subject-1")] = &identity.UserIdentity{
+		ID:       "identity-1",
+		UserID:   "user-1",
+		Provider: "auth0",
+		Subject:  "subject-1",
+	}
+	manager := &Manager{repo: store, logger: zap.NewNop()}
+	provider := &Provider{id: "auth0"}
+
+	user, err := manager.findOrCreateUser(context.Background(), provider, &UserInfo{
+		Subject:       "subject-1",
+		Email:         "invitee@example.com",
+		Name:          "Updated Name",
+		Picture:       "https://example.com/avatar.png",
+		EmailVerified: true,
+		RawClaims:     json.RawMessage(`{"sub":"subject-1","email_verified":true}`),
+	})
+	if err != nil {
+		t.Fatalf("findOrCreateUser: %v", err)
+	}
+	if !user.EmailVerified || user.Name != "Updated Name" || user.AvatarURL != "https://example.com/avatar.png" {
+		t.Fatalf("user claims were not synchronized: %+v", user)
+	}
+	if store.updateUserCalls != 1 {
+		t.Fatalf("expected one user update, got %d", store.updateUserCalls)
+	}
+}
+
+func TestManagerFindOrCreateUserDoesNotVerifyDifferentStoredEmail(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeIdentityStore()
+	store.usersByID["user-1"] = &identity.User{
+		ID:            "user-1",
+		Email:         "old@example.com",
+		EmailVerified: false,
+	}
+	store.identitiesByKey[identityKey("auth0", "subject-1")] = &identity.UserIdentity{
+		ID:       "identity-1",
+		UserID:   "user-1",
+		Provider: "auth0",
+		Subject:  "subject-1",
+	}
+	manager := &Manager{repo: store, logger: zap.NewNop()}
+
+	user, err := manager.findOrCreateUser(context.Background(), &Provider{id: "auth0"}, &UserInfo{
+		Subject:       "subject-1",
+		Email:         "new@example.com",
+		EmailVerified: true,
+	})
+	if err != nil {
+		t.Fatalf("findOrCreateUser: %v", err)
+	}
+	if user.EmailVerified {
+		t.Fatal("different stored email must not inherit verified status")
+	}
+	if store.updateUserCalls != 0 {
+		t.Fatalf("unexpected user update count %d", store.updateUserCalls)
 	}
 }

--- a/pkg/gateway/auth/oidc/provider.go
+++ b/pkg/gateway/auth/oidc/provider.go
@@ -23,6 +23,7 @@ var (
 	ErrInvalidState                = errors.New("invalid OAuth state")
 	ErrInvalidCode                 = errors.New("invalid authorization code")
 	ErrInvalidReturnURL            = errors.New("invalid return URL")
+	ErrInvalidAuthorizationHint    = errors.New("invalid authorization hint")
 	ErrProviderLogoutNotSupported  = errors.New("OIDC provider logout is not supported")
 	ErrMissingEmail                = errors.New("email not provided by IdP")
 	ErrHomeRegionNotRoutable       = errors.New("home region is not routable")
@@ -42,6 +43,11 @@ type UserInfo struct {
 	Name          string          `json:"name"`
 	Picture       string          `json:"picture"`
 	RawClaims     json.RawMessage `json:"raw_claims"`
+}
+
+type authorizationHints struct {
+	LoginHint  string
+	ScreenHint string
 }
 
 // Provider represents a configured OIDC provider
@@ -221,13 +227,20 @@ func (p *Provider) Config() *config.OIDCProviderConfig {
 	return p.config
 }
 
-// AuthURL returns the authorization URL with the given state and PKCE verifier.
-func (p *Provider) AuthURL(state, verifier string) string {
-	return p.oauth2Config.AuthCodeURL(
-		state,
+// AuthURL returns the authorization URL with the given state, PKCE verifier,
+// and optional provider-neutral login hints.
+func (p *Provider) AuthURL(state, verifier string, hints authorizationHints) string {
+	options := []oauth2.AuthCodeOption{
 		oauth2.AccessTypeOffline,
 		oauth2.S256ChallengeOption(verifier),
-	)
+	}
+	if hints.LoginHint != "" {
+		options = append(options, oauth2.SetAuthURLParam("login_hint", hints.LoginHint))
+	}
+	if hints.ScreenHint != "" {
+		options = append(options, oauth2.SetAuthURLParam("screen_hint", hints.ScreenHint))
+	}
+	return p.oauth2Config.AuthCodeURL(state, options...)
 }
 
 // Exchange exchanges an authorization code for tokens

--- a/pkg/gateway/auth/oidc/provider_test.go
+++ b/pkg/gateway/auth/oidc/provider_test.go
@@ -35,7 +35,10 @@ func TestProviderAuthURLIncludesPKCEChallenge(t *testing.T) {
 		verifier = "verifier-123"
 	)
 
-	authURL := provider.AuthURL(state, verifier)
+	authURL := provider.AuthURL(state, verifier, authorizationHints{
+		LoginHint:  "invitee@example.com",
+		ScreenHint: "signup",
+	})
 	parsed, err := url.Parse(authURL)
 	if err != nil {
 		t.Fatalf("parse auth url: %v", err)
@@ -50,6 +53,12 @@ func TestProviderAuthURLIncludesPKCEChallenge(t *testing.T) {
 	}
 	if got := query.Get("code_challenge"); got == "" {
 		t.Fatal("expected code_challenge to be present")
+	}
+	if got := query.Get("login_hint"); got != "invitee@example.com" {
+		t.Fatalf("unexpected login_hint %q", got)
+	}
+	if got := query.Get("screen_hint"); got != "signup" {
+		t.Fatalf("unexpected screen_hint %q", got)
 	}
 }
 
@@ -570,7 +579,12 @@ func TestManagerGenerateAuthURLStoresVerifierInState(t *testing.T) {
 		states:   map[string]*StateData{},
 	}
 
-	authURL, err := manager.GenerateAuthURL("supabase", "/")
+	authURL, err := manager.GenerateAuthURL(
+		"supabase",
+		"/",
+		WithLoginHint(" invitee@example.com "),
+		WithSignupScreen(),
+	)
 	if err != nil {
 		t.Fatalf("generate auth url: %v", err)
 	}
@@ -582,6 +596,12 @@ func TestManagerGenerateAuthURLStoresVerifierInState(t *testing.T) {
 	state := parsed.Query().Get("state")
 	if state == "" {
 		t.Fatal("expected state query parameter")
+	}
+	if got := parsed.Query().Get("login_hint"); got != "invitee@example.com" {
+		t.Fatalf("unexpected login_hint %q", got)
+	}
+	if got := parsed.Query().Get("screen_hint"); got != "signup" {
+		t.Fatalf("unexpected screen_hint %q", got)
 	}
 
 	stateData, err := manager.ValidateState(state)

--- a/pkg/gateway/http/handlers/auth.go
+++ b/pkg/gateway/http/handlers/auth.go
@@ -445,6 +445,12 @@ func (h *AuthHandler) OIDCLogin(c *gin.Context) {
 	if isTruthyQuery(c.Query("web_login")) {
 		authOpts = append(authOpts, oidc.WithWebLoginHandoff())
 	}
+	if loginHint := strings.TrimSpace(c.Query("login_hint")); loginHint != "" {
+		authOpts = append(authOpts, oidc.WithLoginHint(loginHint))
+	}
+	if strings.EqualFold(strings.TrimSpace(c.Query("screen_hint")), "signup") {
+		authOpts = append(authOpts, oidc.WithSignupScreen())
+	}
 	authURL, err := h.oidcManager.GenerateAuthURL(providerID, returnURL, authOpts...)
 	if err != nil {
 		status := http.StatusBadRequest


### PR DESCRIPTION
## Summary

- extend the spec-first OIDC login endpoint with optional `login_hint` and `screen_hint=signup` parameters and forward them through PKCE authorization URL generation
- refresh mutable OIDC profile claims on successful login and promote `email_verified` only when the stored and asserted emails match
- cover provider URL generation, state handling, verified-email recovery, and the mismatched-email safety boundary

This enables invitation links to prefill Auth0 Universal Login and start new invitees on signup while allowing users who verify their email after initial provisioning to continue without manual database repair.

Auth0 documents both parameters for Universal Login: https://auth0.com/docs/authenticate/login/auth0-universal-login/universal-login-vs-classic-login/universal-experience

## Validation

- `make proto manifests apispec`
- `go test ./pkg/gateway/...`
- all Go unit packages excluding `tests/e2e` and `tests/integration`
- `helm lint infra-operator/chart`
- `go mod tidy` with no module diff
