### PR TITLE
fix(rootfs): squash checkpoints after large deletions

### DIFF
--- a/ctld/internal/ctld/rootfs/containerd_runtime.go
+++ b/ctld/internal/ctld/rootfs/containerd_runtime.go
@@ -158,96 +158,114 @@ func (r *ContainerdRuntime) Inspect(ctx context.Context, target ctldapi.RootFSCo
 	return info, nil
 }
 
-func (r *ContainerdRuntime) CreateDiff(ctx context.Context, info ctldapi.RootFSInfo, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error) {
+func (r *ContainerdRuntime) CreateDiff(ctx context.Context, info ctldapi.RootFSInfo, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath) (ctldapi.RootFSDiffDescriptor, *ctldapi.RootFSDiffStats, io.ReadSeekCloser, error) {
 	if strings.TrimSpace(info.SnapshotKey) == "" || strings.TrimSpace(info.Snapshotter) == "" {
-		return ctldapi.RootFSDiffDescriptor{}, nil, fmt.Errorf("%w: snapshot key and snapshotter are required", ErrBadRequest)
+		return ctldapi.RootFSDiffDescriptor{}, nil, nil, fmt.Errorf("%w: snapshot key and snapshotter are required", ErrBadRequest)
 	}
 	client, closeClient, err := r.client(ctx)
 	if err != nil {
-		return ctldapi.RootFSDiffDescriptor{}, nil, err
+		return ctldapi.RootFSDiffDescriptor{}, nil, nil, err
 	}
 
 	if desc, reader, ok, fastErr := r.createOverlayUpperDiff(ctx, client, info, excludedPaths, portalPaths); ok && fastErr == nil {
 		closeClient()
-		return desc, reader, nil
+		return desc, nil, reader, nil
 	} else if ok && fastErr != nil {
 		desc, err := crootfs.CreateDiff(ctx, info.SnapshotKey, client.SnapshotService(info.Snapshotter), client.DiffService())
 		if err != nil {
 			closeClient()
-			return ctldapi.RootFSDiffDescriptor{}, nil, fmt.Errorf("overlayfs fast diff: %v; containerd diff: %w", fastErr, err)
+			return ctldapi.RootFSDiffDescriptor{}, nil, nil, fmt.Errorf("overlayfs fast diff: %v; containerd diff: %w", fastErr, err)
 		}
 		rootDesc, reader, needsClient, err := rootFSDiffReaderFromContent(ctx, client, desc, excludedPaths, portalPaths)
 		if err != nil {
 			closeClient()
-			return ctldapi.RootFSDiffDescriptor{}, nil, err
+			return ctldapi.RootFSDiffDescriptor{}, nil, nil, err
 		}
 		if !needsClient {
 			closeClient()
-			return rootDesc, reader, nil
+			return rootDesc, nil, reader, nil
 		}
-		return rootDesc, closeReadSeekWithFunc{ReadSeekCloser: reader, closeFunc: closeClient}, nil
+		return rootDesc, nil, closeReadSeekWithFunc{ReadSeekCloser: reader, closeFunc: closeClient}, nil
 	}
 
 	desc, err := crootfs.CreateDiff(ctx, info.SnapshotKey, client.SnapshotService(info.Snapshotter), client.DiffService())
 	if err != nil {
 		closeClient()
-		return ctldapi.RootFSDiffDescriptor{}, nil, err
+		return ctldapi.RootFSDiffDescriptor{}, nil, nil, err
 	}
 	rootDesc, reader, needsClient, err := rootFSDiffReaderFromContent(ctx, client, desc, excludedPaths, portalPaths)
 	if err != nil {
 		closeClient()
-		return ctldapi.RootFSDiffDescriptor{}, nil, err
+		return ctldapi.RootFSDiffDescriptor{}, nil, nil, err
 	}
 	if !needsClient {
 		closeClient()
-		return rootDesc, reader, nil
+		return rootDesc, nil, reader, nil
 	}
-	return rootDesc, closeReadSeekWithFunc{ReadSeekCloser: reader, closeFunc: closeClient}, nil
+	return rootDesc, nil, closeReadSeekWithFunc{ReadSeekCloser: reader, closeFunc: closeClient}, nil
 }
 
-func (r *ContainerdRuntime) CreateDiffFromBaseline(ctx context.Context, info ctldapi.RootFSInfo, baselineLayerID string, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error) {
+func (r *ContainerdRuntime) CreateDiffFromBaseline(ctx context.Context, info ctldapi.RootFSInfo, baselineLayerID string, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath) (ctldapi.RootFSDiffDescriptor, *ctldapi.RootFSDiffStats, io.ReadSeekCloser, error) {
 	if strings.TrimSpace(baselineLayerID) == "" {
-		return ctldapi.RootFSDiffDescriptor{}, nil, fmt.Errorf("%w: baseline layer id is required", ErrBadRequest)
+		return ctldapi.RootFSDiffDescriptor{}, nil, nil, fmt.Errorf("%w: baseline layer id is required", ErrBadRequest)
 	}
 	client, closeClient, err := r.client(ctx)
 	if err != nil {
-		return ctldapi.RootFSDiffDescriptor{}, nil, err
+		return ctldapi.RootFSDiffDescriptor{}, nil, nil, err
 	}
 	defer closeClient()
 
 	upperdir, err := r.activeOverlayUpperdir(ctx, client, info)
 	if err != nil {
-		return ctldapi.RootFSDiffDescriptor{}, nil, err
+		return ctldapi.RootFSDiffDescriptor{}, nil, nil, err
 	}
-	baselineDir := r.rootFSBaselinePath(info, baselineLayerID)
+	baselineStateDir := r.rootFSBaselineStatePath(info, baselineLayerID)
+	baselineDir := filepath.Join(baselineStateDir, "upper")
+	indexPath := rootFSFileSizeIndexPath(baselineStateDir)
 	if st, err := os.Stat(baselineDir); err != nil {
 		if os.IsNotExist(err) {
-			return ctldapi.RootFSDiffDescriptor{}, nil, fmt.Errorf("%w: rootfs baseline %s is not captured", ErrNotFound, baselineLayerID)
+			baselineDir = r.rootFSLegacyBaselinePath(info, baselineLayerID)
+			indexPath = ""
+			if legacy, legacyErr := os.Stat(baselineDir); legacyErr != nil {
+				if os.IsNotExist(legacyErr) {
+					return ctldapi.RootFSDiffDescriptor{}, nil, nil, fmt.Errorf("%w: rootfs baseline %s is not captured", ErrNotFound, baselineLayerID)
+				}
+				return ctldapi.RootFSDiffDescriptor{}, nil, nil, fmt.Errorf("inspect rootfs baseline: %w", legacyErr)
+			} else if !legacy.IsDir() {
+				return ctldapi.RootFSDiffDescriptor{}, nil, nil, fmt.Errorf("%w: rootfs baseline path is not a directory", ErrConflict)
+			}
+		} else {
+			return ctldapi.RootFSDiffDescriptor{}, nil, nil, fmt.Errorf("inspect rootfs baseline: %w", err)
 		}
-		return ctldapi.RootFSDiffDescriptor{}, nil, fmt.Errorf("inspect rootfs baseline: %w", err)
 	} else if !st.IsDir() {
-		return ctldapi.RootFSDiffDescriptor{}, nil, fmt.Errorf("%w: rootfs baseline path is not a directory", ErrConflict)
+		return ctldapi.RootFSDiffDescriptor{}, nil, nil, fmt.Errorf("%w: rootfs baseline path is not a directory", ErrConflict)
 	}
-	return writeOverlayUpperDiffFromBaseline(ctx, baselineDir, upperdir, excludedPaths, portalPaths)
+	var fileSizes rootFSFileSizeIndex
+	if indexPath != "" {
+		// The index is advisory. Missing, corrupt, or newer metadata falls back to
+		// the legacy baseline filesystem walk without blocking pause.
+		fileSizes, _ = loadRootFSFileSizeIndex(indexPath)
+	}
+	return writeOverlayUpperDiffFromBaseline(ctx, baselineDir, upperdir, excludedPaths, portalPaths, fileSizes)
 }
 
-func (r *ContainerdRuntime) ApplyDiff(ctx context.Context, info ctldapi.RootFSInfo, desc ctldapi.RootFSDiffDescriptor, reader io.Reader, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath) (ctldapi.RootFSDiffDescriptor, error) {
+func (r *ContainerdRuntime) ApplyDiff(ctx context.Context, info ctldapi.RootFSInfo, desc ctldapi.RootFSDiffDescriptor, reader io.Reader, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath) (ctldapi.RootFSDiffDescriptor, []rootFSFileChange, error) {
 	if strings.TrimSpace(info.ContainerID) == "" {
-		return ctldapi.RootFSDiffDescriptor{}, fmt.Errorf("%w: container id is required", ErrBadRequest)
+		return ctldapi.RootFSDiffDescriptor{}, nil, fmt.Errorf("%w: container id is required", ErrBadRequest)
 	}
 	client, closeClient, err := r.client(ctx)
 	if err != nil {
-		return ctldapi.RootFSDiffDescriptor{}, err
+		return ctldapi.RootFSDiffDescriptor{}, nil, err
 	}
 	defer closeClient()
 
 	liveRootFS, err := liveRootFSPath(r.containerdRoot, r.containerdHostRoot, r.namespace, info)
 	if err != nil {
-		return ctldapi.RootFSDiffDescriptor{}, err
+		return ctldapi.RootFSDiffDescriptor{}, nil, err
 	}
-	filteredDesc, filteredReader, err := filterRootFSDiffTarForApply(desc, reader, excludedPaths, portalPaths)
+	filteredDesc, filteredReader, changes, err := filterRootFSDiffTarForApply(desc, reader, excludedPaths, portalPaths)
 	if err != nil {
-		return ctldapi.RootFSDiffDescriptor{}, fmt.Errorf("filter rootfs diff: %w", err)
+		return ctldapi.RootFSDiffDescriptor{}, nil, fmt.Errorf("filter rootfs diff: %w", err)
 	}
 	defer filteredReader.Close()
 	desc = filteredDesc
@@ -255,11 +273,11 @@ func (r *ContainerdRuntime) ApplyDiff(ctx context.Context, info ctldapi.RootFSIn
 
 	ociDesc, err := descriptorToOCI(desc)
 	if err != nil {
-		return ctldapi.RootFSDiffDescriptor{}, err
+		return ctldapi.RootFSDiffDescriptor{}, nil, err
 	}
 	ref := "sandbox0-rootfs-apply-" + strings.ReplaceAll(ociDesc.Digest.String(), ":", "-")
 	if err := content.WriteBlob(ctx, client.ContentStore(), ref, reader, ociDesc); err != nil {
-		return ctldapi.RootFSDiffDescriptor{}, fmt.Errorf("write rootfs diff into containerd content store: %w", err)
+		return ctldapi.RootFSDiffDescriptor{}, nil, fmt.Errorf("write rootfs diff into containerd content store: %w", err)
 	}
 	applied, err := client.DiffService().Apply(ctx, ociDesc, []mount.Mount{{
 		Type:    "bind",
@@ -267,12 +285,12 @@ func (r *ContainerdRuntime) ApplyDiff(ctx context.Context, info ctldapi.RootFSIn
 		Options: []string{"rbind", "rw"},
 	}})
 	if err != nil {
-		return ctldapi.RootFSDiffDescriptor{}, err
+		return ctldapi.RootFSDiffDescriptor{}, nil, err
 	}
-	return descriptorFromOCI(applied), nil
+	return descriptorFromOCI(applied), changes, nil
 }
 
-func (r *ContainerdRuntime) CaptureBaseline(ctx context.Context, info ctldapi.RootFSInfo, baselineLayerID string, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath) error {
+func (r *ContainerdRuntime) CaptureBaseline(ctx context.Context, info ctldapi.RootFSInfo, baselineLayerID string, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath, fileSizes rootFSFileSizeIndex) error {
 	if strings.TrimSpace(baselineLayerID) == "" {
 		return fmt.Errorf("%w: baseline layer id is required", ErrBadRequest)
 	}
@@ -286,7 +304,7 @@ func (r *ContainerdRuntime) CaptureBaseline(ctx context.Context, info ctldapi.Ro
 	if err != nil {
 		return err
 	}
-	target := r.rootFSBaselinePath(info, baselineLayerID)
+	target := r.rootFSBaselineStatePath(info, baselineLayerID)
 	parent := filepath.Dir(target)
 	if err := os.MkdirAll(parent, 0o700); err != nil {
 		return fmt.Errorf("create rootfs baseline parent: %w", err)
@@ -301,11 +319,23 @@ func (r *ContainerdRuntime) CaptureBaseline(ctx context.Context, info ctldapi.Ro
 			_ = os.RemoveAll(tmp)
 		}
 	}()
-	if err := fs.CopyDir(tmp, upperdir); err != nil {
+	upperTmp := filepath.Join(tmp, "upper")
+	if err := os.MkdirAll(upperTmp, 0o700); err != nil {
+		return fmt.Errorf("create rootfs baseline upper directory: %w", err)
+	}
+	if err := fs.CopyDir(upperTmp, upperdir); err != nil {
 		return fmt.Errorf("copy rootfs baseline: %w", err)
 	}
-	if err := newRootFSPathFilter(rootFSExcludedPathsWithPortals(excludedPaths, portalPaths)).RemoveAll(tmp); err != nil {
+	if err := newRootFSPathFilter(rootFSExcludedPathsWithPortals(excludedPaths, portalPaths)).RemoveAll(upperTmp); err != nil {
 		return fmt.Errorf("filter rootfs baseline: %w", err)
+	}
+	if fileSizes != nil {
+		indexTmp, err := writeRootFSFileSizeIndexTemp(tmp, fileSizes)
+		if err == nil {
+			if err := os.Rename(indexTmp, rootFSFileSizeIndexPath(tmp)); err != nil {
+				_ = os.Remove(indexTmp)
+			}
+		}
 	}
 	if err := os.RemoveAll(target); err != nil {
 		return fmt.Errorf("replace rootfs baseline: %w", err)
@@ -339,11 +369,23 @@ func rootFSDiffReaderFromContent(ctx context.Context, client containerdClient, d
 	return filteredDesc, filteredReader, false, nil
 }
 
-func (r *ContainerdRuntime) rootFSBaselinePath(info ctldapi.RootFSInfo, baselineLayerID string) string {
+func (r *ContainerdRuntime) rootFSBaselineStatePath(info ctldapi.RootFSInfo, baselineLayerID string) string {
+	return filepath.Join(r.rootFSBaselineRoot(), "baselines", "v2", rootFSBaselineKey(info, baselineLayerID))
+}
+
+func (r *ContainerdRuntime) rootFSLegacyBaselinePath(info ctldapi.RootFSInfo, baselineLayerID string) string {
+	return filepath.Join(r.rootFSBaselineRoot(), "baselines", rootFSBaselineKey(info, baselineLayerID))
+}
+
+func (r *ContainerdRuntime) rootFSBaselineRoot() string {
 	root := defaultRootFSCacheDir
 	if r != nil && strings.TrimSpace(r.rootFSCacheDir) != "" {
 		root = r.rootFSCacheDir
 	}
+	return root
+}
+
+func rootFSBaselineKey(info ctldapi.RootFSInfo, baselineLayerID string) string {
 	sum := sha256.Sum256([]byte(strings.Join([]string{
 		info.PodNamespace,
 		info.PodName,
@@ -352,7 +394,7 @@ func (r *ContainerdRuntime) rootFSBaselinePath(info ctldapi.RootFSInfo, baseline
 		info.ContainerID,
 		strings.TrimSpace(baselineLayerID),
 	}, "\x00")))
-	return filepath.Join(root, "baselines", hex.EncodeToString(sum[:]))
+	return hex.EncodeToString(sum[:])
 }
 
 func (r *ContainerdRuntime) resolveContainerID(ctx context.Context, target ctldapi.RootFSContainerRef) (string, string, error) {

--- a/ctld/internal/ctld/rootfs/controller.go
+++ b/ctld/internal/ctld/rootfs/controller.go
@@ -24,12 +24,14 @@ var (
 	ErrBadRequest = errors.New("invalid rootfs request")
 )
 
+const preparedRootFSSnapshotTTL = 15 * time.Minute
+
 type Runtime interface {
 	Inspect(ctx context.Context, target ctldapi.RootFSContainerRef) (ctldapi.RootFSInfo, error)
-	CreateDiff(ctx context.Context, info ctldapi.RootFSInfo, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error)
-	CreateDiffFromBaseline(ctx context.Context, info ctldapi.RootFSInfo, baselineLayerID string, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error)
-	ApplyDiff(ctx context.Context, info ctldapi.RootFSInfo, desc ctldapi.RootFSDiffDescriptor, content io.Reader, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath) (ctldapi.RootFSDiffDescriptor, error)
-	CaptureBaseline(ctx context.Context, info ctldapi.RootFSInfo, baselineLayerID string, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath) error
+	CreateDiff(ctx context.Context, info ctldapi.RootFSInfo, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath) (ctldapi.RootFSDiffDescriptor, *ctldapi.RootFSDiffStats, io.ReadSeekCloser, error)
+	CreateDiffFromBaseline(ctx context.Context, info ctldapi.RootFSInfo, baselineLayerID string, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath) (ctldapi.RootFSDiffDescriptor, *ctldapi.RootFSDiffStats, io.ReadSeekCloser, error)
+	ApplyDiff(ctx context.Context, info ctldapi.RootFSInfo, desc ctldapi.RootFSDiffDescriptor, content io.Reader, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath) (ctldapi.RootFSDiffDescriptor, []rootFSFileChange, error)
+	CaptureBaseline(ctx context.Context, info ctldapi.RootFSInfo, baselineLayerID string, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath, fileSizes rootFSFileSizeIndex) error
 }
 
 type PortalResolver interface {
@@ -59,7 +61,7 @@ func NewController(cfg Config) *Controller {
 	if timeout <= 0 {
 		timeout = 2 * time.Minute
 	}
-	return &Controller{
+	controller := &Controller{
 		runtime:          cfg.Runtime,
 		store:            cfg.Store,
 		operationTimeout: timeout,
@@ -67,6 +69,8 @@ func NewController(cfg Config) *Controller {
 		snapshotDir:      cfg.SnapshotDir,
 		objectCache:      cfg.ObjectCache,
 	}
+	_ = controller.cleanupStalePreparedSnapshots(time.Now().UTC())
+	return controller
 }
 
 func (c *Controller) InspectRootFS(r *http.Request, req ctldapi.InspectRootFSRequest) (ctldapi.InspectRootFSResponse, int) {
@@ -112,6 +116,7 @@ func (c *Controller) PrepareRootFSSnapshot(r *http.Request, req ctldapi.PrepareR
 	if err := validateTarget(req.Target); err != nil {
 		return ctldapi.PrepareRootFSSnapshotResponse{Error: err.Error()}, http.StatusBadRequest
 	}
+	_ = c.cleanupStalePreparedSnapshots(time.Now().UTC())
 	ctx, cancel := c.operationContext(requestContext(r))
 	defer cancel()
 
@@ -123,7 +128,7 @@ func (c *Controller) PrepareRootFSSnapshot(r *http.Request, req ctldapi.PrepareR
 		return ctldapi.PrepareRootFSSnapshotResponse{Info: info, Error: err.Error()}, http.StatusBadRequest
 	}
 	portalPaths := c.portalPathsForRequest(info, req.Target, req.ExcludedPaths, req.PortalPaths)
-	desc, reader, err := c.createDiff(ctx, info, strings.TrimSpace(req.ParentLayerID), req.ExcludedPaths, portalPaths)
+	desc, stats, reader, err := c.createDiff(ctx, info, strings.TrimSpace(req.ParentLayerID), req.ExcludedPaths, portalPaths)
 	if err != nil {
 		return ctldapi.PrepareRootFSSnapshotResponse{Info: info, Error: fmt.Sprintf("create rootfs diff: %v", err)}, statusForError(err)
 	}
@@ -133,7 +138,7 @@ func (c *Controller) PrepareRootFSSnapshot(r *http.Request, req ctldapi.PrepareR
 	if err := c.writePreparedSnapshot(handle, info, desc, reader); err != nil {
 		return ctldapi.PrepareRootFSSnapshotResponse{Info: info, Error: fmt.Sprintf("prepare rootfs snapshot: %v", err)}, http.StatusInternalServerError
 	}
-	return ctldapi.PrepareRootFSSnapshotResponse{Handle: handle, Info: info, Descriptor: desc}, http.StatusOK
+	return ctldapi.PrepareRootFSSnapshotResponse{Handle: handle, Info: info, Descriptor: desc, DiffStats: stats}, http.StatusOK
 }
 
 func (c *Controller) PublishRootFSSnapshot(r *http.Request, req ctldapi.PublishRootFSSnapshotRequest) (ctldapi.PublishRootFSSnapshotResponse, int) {
@@ -212,12 +217,12 @@ func (c *Controller) ApplyRootFS(r *http.Request, req ctldapi.ApplyRootFSRequest
 		// it across template image upgrades is valid; actual path-level conflicts
 		// are surfaced by the runtime apply step below.
 		portalPaths := c.portalPathsForRequest(info, req.Target, req.ExcludedPaths, req.PortalPaths)
-		applied, err := c.applyLayers(ctx, info, req.Layers, req.ExcludedPaths, portalPaths)
+		applied, fileSizes, err := c.applyLayers(ctx, info, req.Layers, req.ExcludedPaths, portalPaths)
 		if err != nil {
 			return ctldapi.ApplyRootFSResponse{Info: info, Error: err.Error()}, statusForError(err)
 		}
 		if req.BaselineLayerID != "" {
-			if err := c.runtime.CaptureBaseline(ctx, info, req.BaselineLayerID, req.ExcludedPaths, portalPaths); err != nil {
+			if err := c.runtime.CaptureBaseline(ctx, info, req.BaselineLayerID, req.ExcludedPaths, portalPaths, fileSizes); err != nil {
 				return ctldapi.ApplyRootFSResponse{Info: info, Error: fmt.Sprintf("capture rootfs baseline: %v", err)}, statusForError(err)
 			}
 		}
@@ -225,26 +230,32 @@ func (c *Controller) ApplyRootFS(r *http.Request, req ctldapi.ApplyRootFSRequest
 	}
 
 	portalPaths := c.portalPathsForRequest(info, req.Target, req.ExcludedPaths, req.PortalPaths)
-	applied, err := c.applyDescriptor(ctx, info, req.Descriptor, req.ExcludedPaths, portalPaths)
+	applied, _, err := c.applyDescriptor(ctx, info, req.Descriptor, req.ExcludedPaths, portalPaths)
 	if err != nil {
 		return ctldapi.ApplyRootFSResponse{Info: info, Error: err.Error()}, statusForError(err)
 	}
 	return ctldapi.ApplyRootFSResponse{Info: info, Descriptor: applied, Applied: true}, http.StatusOK
 }
 
-func (c *Controller) createDiff(ctx context.Context, info ctldapi.RootFSInfo, parentLayerID string, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error) {
+func (c *Controller) createDiff(ctx context.Context, info ctldapi.RootFSInfo, parentLayerID string, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath) (ctldapi.RootFSDiffDescriptor, *ctldapi.RootFSDiffStats, io.ReadSeekCloser, error) {
 	if parentLayerID != "" {
 		return c.runtime.CreateDiffFromBaseline(ctx, info, parentLayerID, excludedPaths, portalPaths)
 	}
 	return c.runtime.CreateDiff(ctx, info, excludedPaths, portalPaths)
 }
 
-func (c *Controller) applyLayers(ctx context.Context, info ctldapi.RootFSInfo, layers []ctldapi.RootFSLayerDescriptor, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath) ([]ctldapi.RootFSLayerDescriptor, error) {
+func (c *Controller) applyLayers(ctx context.Context, info ctldapi.RootFSInfo, layers []ctldapi.RootFSLayerDescriptor, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath) ([]ctldapi.RootFSLayerDescriptor, rootFSFileSizeIndex, error) {
 	applied := make([]ctldapi.RootFSLayerDescriptor, 0, len(layers))
+	fileSizes := make(rootFSFileSizeIndex)
 	for _, layer := range layers {
-		desc, err := c.applyDescriptor(ctx, info, layer.Descriptor, excludedPaths, portalPaths)
+		desc, changes, err := c.applyDescriptor(ctx, info, layer.Descriptor, excludedPaths, portalPaths)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
+		}
+		if changes == nil {
+			fileSizes = nil
+		} else if fileSizes != nil && !fileSizes.Apply(changes) {
+			fileSizes = nil
 		}
 		applied = append(applied, ctldapi.RootFSLayerDescriptor{
 			LayerID:       layer.LayerID,
@@ -252,10 +263,10 @@ func (c *Controller) applyLayers(ctx context.Context, info ctldapi.RootFSInfo, l
 			Descriptor:    desc,
 		})
 	}
-	return applied, nil
+	return applied, fileSizes, nil
 }
 
-func (c *Controller) applyDescriptor(ctx context.Context, info ctldapi.RootFSInfo, desc ctldapi.RootFSDiffDescriptor, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath) (ctldapi.RootFSDiffDescriptor, error) {
+func (c *Controller) applyDescriptor(ctx context.Context, info ctldapi.RootFSInfo, desc ctldapi.RootFSDiffDescriptor, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath) (ctldapi.RootFSDiffDescriptor, []rootFSFileChange, error) {
 	var (
 		reader io.ReadCloser
 		err    error
@@ -266,16 +277,16 @@ func (c *Controller) applyDescriptor(ctx context.Context, info ctldapi.RootFSInf
 		reader, err = c.store.Get(desc.ObjectKey, 0, -1)
 	}
 	if err != nil {
-		return ctldapi.RootFSDiffDescriptor{}, fmt.Errorf("download rootfs diff: %w", err)
+		return ctldapi.RootFSDiffDescriptor{}, nil, fmt.Errorf("download rootfs diff: %w", err)
 	}
 	defer reader.Close()
 
-	applied, err := c.runtime.ApplyDiff(ctx, info, desc, reader, excludedPaths, portalPaths)
+	applied, changes, err := c.runtime.ApplyDiff(ctx, info, desc, reader, excludedPaths, portalPaths)
 	if err != nil {
-		return ctldapi.RootFSDiffDescriptor{}, fmt.Errorf("apply rootfs diff: %w", err)
+		return ctldapi.RootFSDiffDescriptor{}, nil, fmt.Errorf("apply rootfs diff: %w", err)
 	}
 	applied.ObjectKey = desc.ObjectKey
-	return applied, nil
+	return applied, changes, nil
 }
 
 type preparedRootFSSnapshot struct {
@@ -375,6 +386,72 @@ func (c *Controller) removePreparedSnapshot(handle string) error {
 		return os.ErrNotExist
 	}
 	return nil
+}
+
+// cleanupStalePreparedSnapshots bounds node-local disk retained by interrupted
+// prepare/publish/abort sequences, including partially written handle files.
+func (c *Controller) cleanupStalePreparedSnapshots(now time.Time) error {
+	dir := c.preparedSnapshotDir()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	cutoff := now.Add(-preparedRootFSSnapshotTTL)
+	staleHandles := make(map[string]struct{})
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		handle, ok := preparedSnapshotHandleFromFilename(entry.Name())
+		if !ok {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		stale := info.ModTime().Before(cutoff)
+		if !stale && strings.HasSuffix(entry.Name(), ".json") {
+			metaFile, err := os.Open(filepath.Join(dir, entry.Name()))
+			if err == nil {
+				var prepared preparedRootFSSnapshot
+				decodeErr := json.NewDecoder(metaFile).Decode(&prepared)
+				_ = metaFile.Close()
+				stale = decodeErr == nil && !prepared.CreatedAt.IsZero() && prepared.CreatedAt.Before(cutoff)
+			}
+		}
+		if stale {
+			staleHandles[handle] = struct{}{}
+		}
+	}
+
+	var cleanupErr error
+	for handle := range staleHandles {
+		for _, path := range []string{
+			c.preparedSnapshotContentPath(handle),
+			c.preparedSnapshotMetaPath(handle),
+			c.preparedSnapshotContentPath(handle) + ".tmp",
+			c.preparedSnapshotMetaPath(handle) + ".tmp",
+		} {
+			if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+				cleanupErr = errors.Join(cleanupErr, err)
+			}
+		}
+	}
+	return cleanupErr
+}
+
+func preparedSnapshotHandleFromFilename(name string) (string, bool) {
+	for _, suffix := range []string{".tar.tmp", ".json.tmp", ".tar", ".json"} {
+		if strings.HasSuffix(name, suffix) {
+			handle := strings.TrimSuffix(name, suffix)
+			return handle, handle != "" && filepath.Base(handle) == handle
+		}
+	}
+	return "", false
 }
 
 func (c *Controller) preparedSnapshotContentPath(handle string) string {

--- a/ctld/internal/ctld/rootfs/controller_test.go
+++ b/ctld/internal/ctld/rootfs/controller_test.go
@@ -6,8 +6,10 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
+	"time"
 
 	godigest "github.com/opencontainers/go-digest"
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
@@ -104,6 +106,62 @@ func TestControllerSaveRootFSUsesParentBaseline(t *testing.T) {
 	payload, err := io.ReadAll(reader)
 	require.NoError(t, err)
 	assert.Equal(t, "child diff", string(payload))
+}
+
+func TestControllerPrepareRootFSSnapshotReturnsBaselineStats(t *testing.T) {
+	runtime := &fakeRuntime{
+		info: rootFSInfo("runc"),
+		createBaselineDesc: ctldapi.RootFSDiffDescriptor{
+			MediaType: "application/vnd.oci.image.layer.v1.tar",
+			Digest:    "sha256:child",
+			Size:      int64(len("child diff")),
+		},
+		createBaselineStats:   &ctldapi.RootFSDiffStats{DeletedBytes: 10 * 1024 * 1024},
+		createBaselineContent: "child diff",
+	}
+	controller := NewController(Config{Runtime: runtime, SnapshotDir: t.TempDir()})
+
+	resp, status := controller.PrepareRootFSSnapshot(httptest.NewRequest(http.MethodPost, "/", nil), ctldapi.PrepareRootFSSnapshotRequest{
+		Target:        rootFSTarget(),
+		ParentLayerID: "layer-parent",
+	})
+
+	require.Equal(t, http.StatusOK, status, resp.Error)
+	require.NotNil(t, resp.DiffStats)
+	assert.Equal(t, int64(10*1024*1024), resp.DiffStats.DeletedBytes)
+	_, abortStatus := controller.AbortRootFSSnapshot(httptest.NewRequest(http.MethodPost, "/", nil), ctldapi.AbortRootFSSnapshotRequest{Handle: resp.Handle})
+	assert.Equal(t, http.StatusOK, abortStatus)
+}
+
+func TestControllerCleanupStalePreparedSnapshots(t *testing.T) {
+	dir := t.TempDir()
+	controller := NewController(Config{SnapshotDir: dir})
+	desc := ctldapi.RootFSDiffDescriptor{MediaType: "application/vnd.oci.image.layer.v1.tar", Digest: "sha256:diff", Size: 4}
+	require.NoError(t, controller.writePreparedSnapshot("stale", ctldapi.RootFSInfo{}, desc, strings.NewReader("data")))
+	require.NoError(t, controller.writePreparedSnapshot("fresh", ctldapi.RootFSInfo{}, desc, strings.NewReader("data")))
+
+	now := time.Now().UTC()
+	staleTime := now.Add(-preparedRootFSSnapshotTTL - time.Minute)
+	for _, path := range []string{controller.preparedSnapshotContentPath("stale"), controller.preparedSnapshotMetaPath("stale")} {
+		require.NoError(t, os.Chtimes(path, staleTime, staleTime))
+	}
+	orphanPath := controller.preparedSnapshotContentPath("orphan") + ".tmp"
+	require.NoError(t, os.WriteFile(orphanPath, []byte("partial"), 0o600))
+	require.NoError(t, os.Chtimes(orphanPath, staleTime, staleTime))
+
+	require.NoError(t, controller.cleanupStalePreparedSnapshots(now))
+	for _, path := range []string{
+		controller.preparedSnapshotContentPath("stale"),
+		controller.preparedSnapshotMetaPath("stale"),
+		orphanPath,
+	} {
+		_, err := os.Stat(path)
+		assert.ErrorIs(t, err, os.ErrNotExist)
+	}
+	for _, path := range []string{controller.preparedSnapshotContentPath("fresh"), controller.preparedSnapshotMetaPath("fresh")} {
+		_, err := os.Stat(path)
+		assert.NoError(t, err)
+	}
 }
 
 func TestControllerSaveRootFSResolvesUnboundPortalPaths(t *testing.T) {
@@ -261,6 +319,16 @@ func TestControllerApplyRootFSAppliesLayerChainAndCapturesBaseline(t *testing.T)
 			Digest:    "sha256:applied",
 			Size:      int64(len("applied")),
 		},
+		applyChangeCalls: [][]rootFSFileChange{
+			{
+				{Path: "/workspace/removed.bin", Regular: true, Size: 10},
+				{Path: "/workspace/kept.bin", Regular: true, Size: 20},
+			},
+			{
+				{Path: "/workspace/removed.bin", Delete: true},
+				{Path: "/workspace/added.bin", Regular: true, Size: 30},
+			},
+		},
 	}
 	controller := NewController(Config{Runtime: runtime, Store: store})
 
@@ -311,6 +379,10 @@ func TestControllerApplyRootFSAppliesLayerChainAndCapturesBaseline(t *testing.T)
 	assert.Equal(t, "layer-child", runtime.captureBaselineLayerID)
 	assert.Equal(t, []string{"/workspace/data"}, runtime.captureBaselineExcludedPaths)
 	assert.Equal(t, rootFSInfo("runc"), runtime.captureInfo)
+	assert.Equal(t, rootFSFileSizeIndex{
+		"/workspace/added.bin": 30,
+		"/workspace/kept.bin":  20,
+	}, runtime.captureBaselineFileSizes)
 }
 
 func TestControllerApplyRootFSForceAppliesBaseMismatch(t *testing.T) {
@@ -457,12 +529,16 @@ type fakeRuntime struct {
 	info                  ctldapi.RootFSInfo
 	inspectErr            error
 	createDesc            ctldapi.RootFSDiffDescriptor
+	createStats           *ctldapi.RootFSDiffStats
 	createContent         string
 	createErr             error
 	createBaselineDesc    ctldapi.RootFSDiffDescriptor
+	createBaselineStats   *ctldapi.RootFSDiffStats
 	createBaselineContent string
 	createBaselineErr     error
 	applyDesc             ctldapi.RootFSDiffDescriptor
+	applyChanges          []rootFSFileChange
+	applyChangeCalls      [][]rootFSFileChange
 	applyErr              error
 	captureBaselineErr    error
 
@@ -491,6 +567,7 @@ type fakeRuntime struct {
 	captureBaselineLayerID       string
 	captureBaselineExcludedPaths []string
 	captureBaselinePortalPaths   []ctldapi.RootFSPortalPath
+	captureBaselineFileSizes     rootFSFileSizeIndex
 }
 
 func (r *fakeRuntime) Inspect(_ context.Context, target ctldapi.RootFSContainerRef) (ctldapi.RootFSInfo, error) {
@@ -498,30 +575,30 @@ func (r *fakeRuntime) Inspect(_ context.Context, target ctldapi.RootFSContainerR
 	return r.info, r.inspectErr
 }
 
-func (r *fakeRuntime) CreateDiff(_ context.Context, info ctldapi.RootFSInfo, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error) {
+func (r *fakeRuntime) CreateDiff(_ context.Context, info ctldapi.RootFSInfo, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath) (ctldapi.RootFSDiffDescriptor, *ctldapi.RootFSDiffStats, io.ReadSeekCloser, error) {
 	r.createCalled = true
 	r.createInfo = info
 	r.createExcludedPaths = append([]string(nil), excludedPaths...)
 	r.createPortalPaths = append([]ctldapi.RootFSPortalPath(nil), portalPaths...)
 	if r.createErr != nil {
-		return ctldapi.RootFSDiffDescriptor{}, nil, r.createErr
+		return ctldapi.RootFSDiffDescriptor{}, nil, nil, r.createErr
 	}
-	return r.createDesc, readSeekNopCloser{Reader: strings.NewReader(r.createContent)}, nil
+	return r.createDesc, r.createStats, readSeekNopCloser{Reader: strings.NewReader(r.createContent)}, nil
 }
 
-func (r *fakeRuntime) CreateDiffFromBaseline(_ context.Context, info ctldapi.RootFSInfo, baselineLayerID string, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error) {
+func (r *fakeRuntime) CreateDiffFromBaseline(_ context.Context, info ctldapi.RootFSInfo, baselineLayerID string, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath) (ctldapi.RootFSDiffDescriptor, *ctldapi.RootFSDiffStats, io.ReadSeekCloser, error) {
 	r.createBaselineCalled = true
 	r.createBaselineInfo = info
 	r.createBaselineLayerID = baselineLayerID
 	r.createBaselineExcludedPaths = append([]string(nil), excludedPaths...)
 	r.createBaselinePortalPaths = append([]ctldapi.RootFSPortalPath(nil), portalPaths...)
 	if r.createBaselineErr != nil {
-		return ctldapi.RootFSDiffDescriptor{}, nil, r.createBaselineErr
+		return ctldapi.RootFSDiffDescriptor{}, nil, nil, r.createBaselineErr
 	}
-	return r.createBaselineDesc, readSeekNopCloser{Reader: strings.NewReader(r.createBaselineContent)}, nil
+	return r.createBaselineDesc, r.createBaselineStats, readSeekNopCloser{Reader: strings.NewReader(r.createBaselineContent)}, nil
 }
 
-func (r *fakeRuntime) ApplyDiff(_ context.Context, info ctldapi.RootFSInfo, desc ctldapi.RootFSDiffDescriptor, content io.Reader, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath) (ctldapi.RootFSDiffDescriptor, error) {
+func (r *fakeRuntime) ApplyDiff(_ context.Context, info ctldapi.RootFSInfo, desc ctldapi.RootFSDiffDescriptor, content io.Reader, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath) (ctldapi.RootFSDiffDescriptor, []rootFSFileChange, error) {
 	r.applyCalled = true
 	r.applyInfo = info
 	r.applyInputDesc = desc
@@ -532,22 +609,34 @@ func (r *fakeRuntime) ApplyDiff(_ context.Context, info ctldapi.RootFSInfo, desc
 	r.applyPortalPathCalls = append(r.applyPortalPathCalls, append([]ctldapi.RootFSPortalPath(nil), portalPaths...))
 	payload, err := io.ReadAll(content)
 	if err != nil {
-		return ctldapi.RootFSDiffDescriptor{}, err
+		return ctldapi.RootFSDiffDescriptor{}, nil, err
 	}
 	r.applyContent = string(payload)
 	r.applyContents = append(r.applyContents, string(payload))
 	if r.applyErr != nil {
-		return ctldapi.RootFSDiffDescriptor{}, r.applyErr
+		return ctldapi.RootFSDiffDescriptor{}, nil, r.applyErr
 	}
-	return r.applyDesc, nil
+	changes := r.applyChanges
+	callIndex := len(r.applyContents) - 1
+	if callIndex >= 0 && callIndex < len(r.applyChangeCalls) {
+		changes = r.applyChangeCalls[callIndex]
+	}
+	if changes == nil {
+		return r.applyDesc, nil, nil
+	}
+	return r.applyDesc, append([]rootFSFileChange{}, changes...), nil
 }
 
-func (r *fakeRuntime) CaptureBaseline(_ context.Context, info ctldapi.RootFSInfo, baselineLayerID string, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath) error {
+func (r *fakeRuntime) CaptureBaseline(_ context.Context, info ctldapi.RootFSInfo, baselineLayerID string, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath, fileSizes rootFSFileSizeIndex) error {
 	r.captureBaselineCalled = true
 	r.captureInfo = info
 	r.captureBaselineLayerID = baselineLayerID
 	r.captureBaselineExcludedPaths = append([]string(nil), excludedPaths...)
 	r.captureBaselinePortalPaths = append([]ctldapi.RootFSPortalPath(nil), portalPaths...)
+	r.captureBaselineFileSizes = make(rootFSFileSizeIndex, len(fileSizes))
+	for filePath, size := range fileSizes {
+		r.captureBaselineFileSizes[filePath] = size
+	}
 	return r.captureBaselineErr
 }
 

--- a/ctld/internal/ctld/rootfs/file_size_index.go
+++ b/ctld/internal/ctld/rootfs/file_size_index.go
@@ -1,0 +1,239 @@
+package rootfs
+
+import (
+	"archive/tar"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const rootFSFileSizeIndexVersion = 1
+
+// rootFSFileChange captures the logical regular-file state change represented
+// by one filtered OCI layer tar header.
+type rootFSFileChange struct {
+	Path      string
+	Size      int64
+	Regular   bool
+	LinkPath  string
+	Directory bool
+	Delete    bool
+	Opaque    bool
+}
+
+// rootFSFileSizeIndex tracks positive logical sizes for regular files stored
+// in the persisted writable rootfs layer chain, including unbound portal
+// content embedded in that chain. Base-image files are excluded.
+type rootFSFileSizeIndex map[string]int64
+
+type rootFSFileSizeIndexFile struct {
+	Version int                 `json:"version"`
+	Files   rootFSFileSizeIndex `json:"files"`
+}
+
+func rootFSFileChangeFromTarHeader(header *tar.Header) (rootFSFileChange, bool) {
+	if header == nil {
+		return rootFSFileChange{}, false
+	}
+	if target, opaque, ok := rootFSTarWhiteoutTargetPath(header.Name); ok {
+		return rootFSFileChange{Path: target, Delete: true, Opaque: opaque}, true
+	}
+
+	changePath := cleanRootFSPath(header.Name)
+	if changePath == "/" {
+		return rootFSFileChange{}, false
+	}
+	change := rootFSFileChange{Path: changePath}
+	switch header.Typeflag {
+	case tar.TypeReg, tar.TypeRegA:
+		change.Regular = true
+		change.Size = header.Size
+	case tar.TypeLink:
+		change.Regular = true
+		change.LinkPath = cleanRootFSPath(header.Linkname)
+	case tar.TypeDir:
+		change.Directory = true
+	}
+	return change, true
+}
+
+func (index rootFSFileSizeIndex) Apply(changes []rootFSFileChange) bool {
+	if index == nil {
+		return false
+	}
+	lower := make(rootFSFileSizeIndex, len(index))
+	for filePath, size := range index {
+		lower[filePath] = size
+	}
+	// OCI opaque whiteouts remove entries inherited from lower layers. Entries
+	// added by the same layer survive regardless of tar-header ordering.
+	for _, change := range changes {
+		if !change.Delete || !change.Opaque {
+			continue
+		}
+		changePath := cleanRootFSPath(change.Path)
+		if changePath == "/" {
+			continue
+		}
+		index.deleteInheritedPath(lower, changePath, !change.Opaque)
+	}
+	for _, change := range changes {
+		changePath := cleanRootFSPath(change.Path)
+		if changePath == "/" {
+			continue
+		}
+		if change.Delete {
+			if !change.Opaque {
+				index.deletePath(changePath, true)
+			}
+			continue
+		}
+		if change.Directory {
+			delete(index, changePath)
+			continue
+		}
+		index.deletePath(changePath, true)
+		if change.Regular {
+			size := change.Size
+			if change.LinkPath != "" {
+				var ok bool
+				size, ok = index[cleanRootFSPath(change.LinkPath)]
+				if !ok {
+					return false
+				}
+			}
+			if size > 0 {
+				index[changePath] = size
+			}
+		}
+	}
+	return true
+}
+
+func (index rootFSFileSizeIndex) deleteInheritedPath(lower rootFSFileSizeIndex, target string, includeTarget bool) {
+	target = cleanRootFSPath(target)
+	prefix := strings.TrimSuffix(target, "/") + "/"
+	for filePath := range lower {
+		if (includeTarget && filePath == target) || strings.HasPrefix(filePath, prefix) {
+			delete(index, filePath)
+		}
+	}
+}
+
+func (index rootFSFileSizeIndex) deletePath(target string, includeTarget bool) {
+	target = cleanRootFSPath(target)
+	prefix := strings.TrimSuffix(target, "/") + "/"
+	for filePath := range index {
+		if (includeTarget && filePath == target) || strings.HasPrefix(filePath, prefix) {
+			delete(index, filePath)
+		}
+	}
+}
+
+func (index rootFSFileSizeIndex) deletedBytes(target string, includeTarget bool, filter rootFSPathFilter, counted map[string]struct{}) int64 {
+	if len(index) == 0 {
+		return 0
+	}
+	target = cleanRootFSPath(target)
+	prefix := strings.TrimSuffix(target, "/") + "/"
+	var total int64
+	for filePath, size := range index {
+		if size <= 0 || (!includeTarget || filePath != target) && !strings.HasPrefix(filePath, prefix) {
+			continue
+		}
+		if filter.Excludes(filePath) {
+			continue
+		}
+		if _, ok := counted[filePath]; ok {
+			continue
+		}
+		counted[filePath] = struct{}{}
+		total += size
+	}
+	return total
+}
+
+func (index rootFSFileSizeIndex) replacementDeletedBytes(target string, currentIsDir, currentIsRegular bool, filter rootFSPathFilter, counted map[string]struct{}) int64 {
+	target = cleanRootFSPath(target)
+	if currentIsDir {
+		size := index[target]
+		if size <= 0 || filter.Excludes(target) {
+			return 0
+		}
+		if _, ok := counted[target]; ok {
+			return 0
+		}
+		counted[target] = struct{}{}
+		return size
+	}
+	if currentIsRegular {
+		return index.deletedBytes(target, false, filter, counted)
+	}
+	return index.deletedBytes(target, true, filter, counted)
+}
+
+func rootFSFileSizeIndexPath(baselineDir string) string {
+	return filepath.Join(filepath.Clean(baselineDir), "files.json")
+}
+
+func writeRootFSFileSizeIndexTemp(parent string, index rootFSFileSizeIndex) (string, error) {
+	file, err := os.CreateTemp(parent, ".rootfs-file-sizes-*.json")
+	if err != nil {
+		return "", err
+	}
+	name := file.Name()
+	removeOnError := true
+	defer func() {
+		if removeOnError {
+			_ = os.Remove(name)
+		}
+	}()
+	if index == nil {
+		index = make(rootFSFileSizeIndex)
+	}
+	if err := json.NewEncoder(file).Encode(rootFSFileSizeIndexFile{
+		Version: rootFSFileSizeIndexVersion,
+		Files:   index,
+	}); err != nil {
+		_ = file.Close()
+		return "", err
+	}
+	if err := file.Close(); err != nil {
+		return "", err
+	}
+	removeOnError = false
+	return name, nil
+}
+
+func loadRootFSFileSizeIndex(indexPath string) (rootFSFileSizeIndex, error) {
+	file, err := os.Open(indexPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer file.Close()
+
+	var stored rootFSFileSizeIndexFile
+	if err := json.NewDecoder(file).Decode(&stored); err != nil {
+		return nil, err
+	}
+	if stored.Version != rootFSFileSizeIndexVersion {
+		return nil, fmt.Errorf("unsupported rootfs file-size index version %d", stored.Version)
+	}
+	index := make(rootFSFileSizeIndex, len(stored.Files))
+	for filePath, size := range stored.Files {
+		if size <= 0 {
+			continue
+		}
+		clean := cleanRootFSPath(filePath)
+		if clean == "/" {
+			continue
+		}
+		index[clean] = size
+	}
+	return index, nil
+}

--- a/ctld/internal/ctld/rootfs/file_size_index_test.go
+++ b/ctld/internal/ctld/rootfs/file_size_index_test.go
@@ -1,0 +1,207 @@
+package rootfs
+
+import (
+	"archive/tar"
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRootFSFileSizeIndexTracksFilteredTarLayers(t *testing.T) {
+	parentTar := bytes.NewBuffer(nil)
+	parentWriter := tar.NewWriter(parentTar)
+	writeTarEntry(t, parentWriter, "workspace/removed.bin", make([]byte, 10), 0o644)
+	writeTarEntry(t, parentWriter, "workspace/kept.bin", make([]byte, 20), 0o644)
+	require.NoError(t, parentWriter.Close())
+
+	childTar := bytes.NewBuffer(nil)
+	childWriter := tar.NewWriter(childTar)
+	writeTarEntry(t, childWriter, "workspace/.wh.removed.bin", nil, 0o000)
+	writeTarEntry(t, childWriter, "workspace/added.bin", make([]byte, 30), 0o644)
+	require.NoError(t, childWriter.Close())
+
+	index := make(rootFSFileSizeIndex)
+	for _, layer := range [][]byte{parentTar.Bytes(), childTar.Bytes()} {
+		_, reader, changes, err := filterRootFSDiffTarForApply(rootFSDiffDescriptorForTest(), bytes.NewReader(layer), nil, nil)
+		require.NoError(t, err)
+		require.NoError(t, reader.Close())
+		require.True(t, index.Apply(changes))
+	}
+	assert.Equal(t, rootFSFileSizeIndex{
+		"/workspace/added.bin": 30,
+		"/workspace/kept.bin":  20,
+	}, index)
+}
+
+func TestRootFSFileSizeIndexReplacesPortalSnapshotAcrossLayers(t *testing.T) {
+	portal := ctldapi.RootFSPortalPath{
+		PortalName:  "workspace",
+		MountPath:   "/workspace",
+		BackingPath: t.TempDir(),
+	}
+	parentTar := bytes.NewBuffer(nil)
+	parentWriter := tar.NewWriter(parentTar)
+	writeTarEntry(t, parentWriter, "workspace/", nil, 0o755)
+	writeTarEntry(t, parentWriter, "workspace/removed.bin", make([]byte, 10), 0o644)
+	writeTarEntry(t, parentWriter, "workspace/kept.bin", make([]byte, 20), 0o644)
+	require.NoError(t, parentWriter.Close())
+
+	childTar := bytes.NewBuffer(nil)
+	childWriter := tar.NewWriter(childTar)
+	writeTarEntry(t, childWriter, "workspace/", nil, 0o755)
+	writeTarEntry(t, childWriter, "workspace/kept.bin", make([]byte, 20), 0o644)
+	writeTarEntry(t, childWriter, "workspace/added.bin", make([]byte, 30), 0o644)
+	require.NoError(t, childWriter.Close())
+
+	index := make(rootFSFileSizeIndex)
+	for _, layer := range [][]byte{parentTar.Bytes(), childTar.Bytes()} {
+		_, reader, changes, err := filterRootFSDiffTarForApply(
+			rootFSDiffDescriptorForTest(),
+			bytes.NewReader(layer),
+			nil,
+			[]ctldapi.RootFSPortalPath{portal},
+		)
+		require.NoError(t, err)
+		require.NoError(t, reader.Close())
+		require.True(t, index.Apply(changes))
+	}
+
+	assert.Equal(t, rootFSFileSizeIndex{
+		"/workspace/added.bin": 30,
+		"/workspace/kept.bin":  20,
+	}, index)
+}
+
+func TestRootFSFileSizeIndexApplyPreservesSameLayerEntriesAcrossWhiteouts(t *testing.T) {
+	tests := []struct {
+		name    string
+		changes []rootFSFileChange
+		want    rootFSFileSizeIndex
+	}{
+		{
+			name: "opaque marker before entries",
+			changes: []rootFSFileChange{
+				{Path: "/workspace", Delete: true, Opaque: true},
+				{Path: "/workspace/new.bin", Regular: true, Size: 30},
+			},
+			want: rootFSFileSizeIndex{"/workspace/new.bin": 30},
+		},
+		{
+			name: "opaque marker after entries",
+			changes: []rootFSFileChange{
+				{Path: "/workspace/new.bin", Regular: true, Size: 30},
+				{Path: "/workspace", Delete: true, Opaque: true},
+			},
+			want: rootFSFileSizeIndex{"/workspace/new.bin": 30},
+		},
+		{
+			name: "file whiteout before replacement",
+			changes: []rootFSFileChange{
+				{Path: "/workspace/old.bin", Delete: true},
+				{Path: "/workspace/old.bin", Regular: true, Size: 30},
+			},
+			want: rootFSFileSizeIndex{
+				"/workspace/old.bin":    30,
+				"/workspace/nested.bin": 20,
+			},
+		},
+		{
+			name: "file whiteout after replacement",
+			changes: []rootFSFileChange{
+				{Path: "/workspace/old.bin", Regular: true, Size: 30},
+				{Path: "/workspace/old.bin", Delete: true},
+			},
+			want: rootFSFileSizeIndex{
+				"/workspace/nested.bin": 20,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			index := rootFSFileSizeIndex{
+				"/workspace/old.bin":    10,
+				"/workspace/nested.bin": 20,
+			}
+			index.Apply(tt.changes)
+
+			assert.Equal(t, tt.want, index)
+		})
+	}
+}
+
+func TestRootFSFileSizeIndexApplyTracksTypeReplacementAndHardlink(t *testing.T) {
+	index := rootFSFileSizeIndex{
+		"/workspace/tree/file.bin": 10,
+		"/workspace/plain.bin":     20,
+	}
+	index.Apply([]rootFSFileChange{
+		{Path: "/workspace/tree", Regular: true, Size: 30},
+		{Path: "/workspace/plain.bin", Directory: true},
+		{Path: "/workspace/tree-link", Regular: true, LinkPath: "/workspace/tree"},
+	})
+
+	assert.Equal(t, rootFSFileSizeIndex{
+		"/workspace/tree":      30,
+		"/workspace/tree-link": 30,
+	}, index)
+}
+
+func TestRootFSFileSizeIndexApplyInvalidatesUnknownHardlinkTarget(t *testing.T) {
+	index := make(rootFSFileSizeIndex)
+	assert.False(t, index.Apply([]rootFSFileChange{{
+		Path:     "/workspace/link",
+		Regular:  true,
+		LinkPath: "/workspace/missing",
+	}}))
+}
+
+func TestRootFSFileChangeFromTarHeader(t *testing.T) {
+	tests := []struct {
+		name   string
+		header *tar.Header
+		want   rootFSFileChange
+	}{
+		{name: "regular", header: &tar.Header{Name: "workspace/file", Typeflag: tar.TypeReg, Size: 10}, want: rootFSFileChange{Path: "/workspace/file", Regular: true, Size: 10}},
+		{name: "hardlink", header: &tar.Header{Name: "workspace/link", Typeflag: tar.TypeLink, Linkname: "workspace/file"}, want: rootFSFileChange{Path: "/workspace/link", Regular: true, LinkPath: "/workspace/file"}},
+		{name: "file whiteout", header: &tar.Header{Name: "workspace/.wh.file"}, want: rootFSFileChange{Path: "/workspace/file", Delete: true}},
+		{name: "opaque whiteout", header: &tar.Header{Name: "workspace/.wh..wh..opq"}, want: rootFSFileChange{Path: "/workspace", Delete: true, Opaque: true}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := rootFSFileChangeFromTarHeader(tt.header)
+			require.True(t, ok)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestRootFSFileSizeIndexRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	index := rootFSFileSizeIndex{
+		"/workspace/file.bin": 10,
+		"relative/path":       20,
+		"/ignored-zero":       0,
+	}
+	tmp, err := writeRootFSFileSizeIndexTemp(dir, index)
+	require.NoError(t, err)
+	target := filepath.Join(dir, "index.json")
+	require.NoError(t, os.Rename(tmp, target))
+
+	got, err := loadRootFSFileSizeIndex(target)
+	require.NoError(t, err)
+	assert.Equal(t, rootFSFileSizeIndex{
+		"/workspace/file.bin": 10,
+		"/relative/path":      20,
+	}, got)
+
+	missing, err := loadRootFSFileSizeIndex(filepath.Join(dir, "missing.json"))
+	require.NoError(t, err)
+	assert.Nil(t, missing)
+}

--- a/ctld/internal/ctld/rootfs/overlay_diff.go
+++ b/ctld/internal/ctld/rootfs/overlay_diff.go
@@ -145,8 +145,11 @@ func writeOverlayUpperDiff(ctx context.Context, upperdir string, excludedPaths [
 	return appendPortalRootFSToDiff(desc, reader, portalPaths)
 }
 
-func writeOverlayUpperDiffFromBaseline(ctx context.Context, baselineDir, upperdir string, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error) {
+func writeOverlayUpperDiffFromBaseline(ctx context.Context, baselineDir, upperdir string, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath, fileSizes rootFSFileSizeIndex) (ctldapi.RootFSDiffDescriptor, *ctldapi.RootFSDiffStats, io.ReadSeekCloser, error) {
 	filter := newRootFSPathFilter(rootFSExcludedPathsWithPortals(excludedPaths, portalPaths))
+	persistedFilter := newRootFSPathFilter(excludedPaths)
+	stats := &ctldapi.RootFSDiffStats{}
+	countedDeletedFiles := make(map[string]struct{})
 	desc, reader, err := writeOverlayDiffTar(upperdir, filter, func(changeFn fs.ChangeFunc) error {
 		return fs.Changes(ctx, baselineDir, upperdir, func(kind fs.ChangeKind, path string, info os.FileInfo, err error) error {
 			if err != nil {
@@ -161,13 +164,40 @@ func writeOverlayUpperDiffFromBaseline(ctx context.Context, baselineDir, upperdi
 				if filter.Excludes(path) {
 					return nil
 				}
+				deletedBytes, err := rootFSDeletedLogicalBytes(ctx, baselineDir, path, filter, fileSizes, countedDeletedFiles)
+				if err != nil {
+					return err
+				}
+				stats.DeletedBytes += deletedBytes
 				return changeFn(kind, path, nil, nil)
 			}
 			if filter.Excludes(path) {
 				return nil
 			}
 			if isOverlayWhiteout(info) {
+				deletedBytes, err := rootFSDeletedLogicalBytes(ctx, baselineDir, path, filter, fileSizes, countedDeletedFiles)
+				if err != nil {
+					return err
+				}
+				stats.DeletedBytes += deletedBytes
 				return changeFn(fs.ChangeKindDelete, path, nil, nil)
+			}
+			if info != nil {
+				deletedBytes := fileSizes.replacementDeletedBytes(path, info.IsDir(), info.Mode().IsRegular(), filter, countedDeletedFiles)
+				if kind == fs.ChangeKindModify {
+					baselineInfo, err := os.Lstat(rootFSBaselinePath(baselineDir, path))
+					if err != nil && !os.IsNotExist(err) {
+						return fmt.Errorf("inspect replaced rootfs baseline path %s: %w", path, err)
+					}
+					if err == nil && baselineInfo.Mode().Type() != info.Mode().Type() {
+						baselineDeletedBytes, err := rootFSDeletedLogicalBytes(ctx, baselineDir, path, filter, nil, countedDeletedFiles)
+						if err != nil {
+							return err
+						}
+						deletedBytes += baselineDeletedBytes
+					}
+				}
+				stats.DeletedBytes += deletedBytes
 			}
 			if info != nil && info.IsDir() {
 				sourcePath := filepath.Join(upperdir, strings.TrimPrefix(path, string(filepath.Separator)))
@@ -185,9 +215,143 @@ func writeOverlayUpperDiffFromBaseline(ctx context.Context, baselineDir, upperdi
 		})
 	})
 	if err != nil {
-		return ctldapi.RootFSDiffDescriptor{}, nil, err
+		return ctldapi.RootFSDiffDescriptor{}, nil, nil, err
 	}
-	return appendPortalRootFSToDiff(desc, reader, portalPaths)
+	desc, reader, err = appendPortalRootFSToDiff(desc, reader, portalPaths)
+	if err != nil {
+		return ctldapi.RootFSDiffDescriptor{}, nil, nil, err
+	}
+	portalDeletedBytes, err := rootFSPortalDeletedLogicalBytes(ctx, portalPaths, fileSizes, persistedFilter, countedDeletedFiles)
+	if err != nil {
+		_ = reader.Close()
+		return ctldapi.RootFSDiffDescriptor{}, nil, nil, err
+	}
+	stats.DeletedBytes += portalDeletedBytes
+	return desc, stats, reader, nil
+}
+
+func rootFSPortalDeletedLogicalBytes(ctx context.Context, portalPaths []ctldapi.RootFSPortalPath, fileSizes rootFSFileSizeIndex, filter rootFSPathFilter, counted map[string]struct{}) (int64, error) {
+	if len(fileSizes) == 0 {
+		return 0, nil
+	}
+	var total int64
+	for _, portal := range filterRootFSPortalPaths(portalPaths, nil) {
+		mountPath := cleanRootFSPath(portal.MountPath)
+		backingPath := filepath.Clean(strings.TrimSpace(portal.BackingPath))
+		currentRegularFiles := make(map[string]struct{})
+		err := filepath.Walk(backingPath, func(current string, info os.FileInfo, walkErr error) error {
+			if walkErr != nil {
+				if os.IsNotExist(walkErr) {
+					return nil
+				}
+				return walkErr
+			}
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
+			if !info.Mode().IsRegular() {
+				return nil
+			}
+			rel, err := filepath.Rel(backingPath, current)
+			if err != nil {
+				return err
+			}
+			currentPath := cleanRootFSPath(path.Join(mountPath, filepath.ToSlash(rel)))
+			if !filter.Excludes(currentPath) {
+				currentRegularFiles[currentPath] = struct{}{}
+			}
+			return nil
+		})
+		if err != nil && !os.IsNotExist(err) {
+			return 0, fmt.Errorf("inspect rootfs portal backing path %s: %w", backingPath, err)
+		}
+		prefix := strings.TrimSuffix(mountPath, "/") + "/"
+		for filePath, size := range fileSizes {
+			if size <= 0 || filePath != mountPath && !strings.HasPrefix(filePath, prefix) || filter.Excludes(filePath) {
+				continue
+			}
+			if _, ok := currentRegularFiles[filePath]; ok {
+				continue
+			}
+			if _, ok := counted[filePath]; ok {
+				continue
+			}
+			counted[filePath] = struct{}{}
+			total += size
+		}
+	}
+	return total, nil
+}
+
+// rootFSDeletedLogicalBytes measures regular-file bytes removed from a baseline
+// subtree while honoring paths that are stored outside the rootfs checkpoint.
+func rootFSDeletedLogicalBytes(ctx context.Context, baselineDir, changePath string, filter rootFSPathFilter, fileSizes rootFSFileSizeIndex, counted map[string]struct{}) (int64, error) {
+	clean := cleanRootFSPath(changePath)
+	if filter.Excludes(clean) {
+		return 0, nil
+	}
+	if counted == nil {
+		counted = make(map[string]struct{})
+	}
+	total := fileSizes.deletedBytes(clean, true, filter, counted)
+	target := rootFSBaselinePath(baselineDir, clean)
+	info, err := os.Lstat(target)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return total, nil
+		}
+		return 0, fmt.Errorf("inspect deleted rootfs baseline path %s: %w", clean, err)
+	}
+	if !info.IsDir() {
+		if info.Mode().IsRegular() && info.Size() > 0 {
+			if _, ok := counted[clean]; !ok {
+				counted[clean] = struct{}{}
+				total += info.Size()
+			}
+		}
+		return total, nil
+	}
+
+	err = filepath.Walk(target, func(current string, currentInfo os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		rel, err := filepath.Rel(baselineDir, current)
+		if err != nil {
+			return err
+		}
+		currentPath := string(filepath.Separator) + filepath.ToSlash(rel)
+		if filter.Excludes(currentPath) {
+			if currentInfo.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if currentInfo.Mode().IsRegular() && currentInfo.Size() > 0 {
+			if _, ok := counted[currentPath]; !ok {
+				counted[currentPath] = struct{}{}
+				total += currentInfo.Size()
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, fmt.Errorf("measure deleted rootfs baseline path %s: %w", clean, err)
+	}
+	return total, nil
+}
+
+func rootFSBaselinePath(baselineDir, changePath string) string {
+	clean := cleanRootFSPath(changePath)
+	relative := strings.TrimPrefix(clean, string(filepath.Separator))
+	return filepath.Join(baselineDir, filepath.FromSlash(relative))
 }
 
 func writeOverlayDiffTar(source string, filter rootFSPathFilter, walkChanges func(fs.ChangeFunc) error) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error) {
@@ -462,16 +626,17 @@ func filterRootFSDiffTarForSave(desc ctldapi.RootFSDiffDescriptor, reader io.Rea
 	return appendPortalRootFSToDiff(filteredDesc, filteredReader, portalPaths)
 }
 
-func filterRootFSDiffTarForApply(desc ctldapi.RootFSDiffDescriptor, reader io.Reader, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error) {
+func filterRootFSDiffTarForApply(desc ctldapi.RootFSDiffDescriptor, reader io.Reader, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, []rootFSFileChange, error) {
 	portalPaths = filterRootFSPortalPaths(portalPaths, excludedPaths)
 	if !shouldFilterRootFSDiffTar(desc) {
-		return desc, noopReadSeekCloser{Reader: reader}, nil
+		return desc, noopReadSeekCloser{Reader: reader}, nil, nil
 	}
 	filter := newRootFSPathFilter(rootFSExcludedPathsWithPortals(excludedPaths, portalPaths))
+	excludedFilter := newRootFSPathFilter(excludedPaths)
 
 	tmp, err := os.CreateTemp("", "sandbox0-rootfs-apply-filtered-diff-*.tar")
 	if err != nil {
-		return ctldapi.RootFSDiffDescriptor{}, nil, err
+		return ctldapi.RootFSDiffDescriptor{}, nil, nil, err
 	}
 	removeOnError := true
 	defer func() {
@@ -486,6 +651,8 @@ func filterRootFSDiffTarForApply(desc ctldapi.RootFSDiffDescriptor, reader io.Re
 	tarWriter := tar.NewWriter(writer)
 	tarReader := tar.NewReader(reader)
 	restored := make(map[string]struct{}, len(portalPaths))
+	indexedPortals := make(map[string]struct{}, len(portalPaths))
+	changes := make([]rootFSFileChange, 0)
 	for {
 		header, err := tarReader.Next()
 		if err == io.EOF {
@@ -493,40 +660,57 @@ func filterRootFSDiffTarForApply(desc ctldapi.RootFSDiffDescriptor, reader io.Re
 		}
 		if err != nil {
 			_ = tarWriter.Close()
-			return ctldapi.RootFSDiffDescriptor{}, nil, err
+			return ctldapi.RootFSDiffDescriptor{}, nil, nil, err
+		}
+		if excludedFilter.ExcludesTarHeader(header.Name) {
+			continue
 		}
 		if portal, rel, ok := matchRootFSPortalHeader(header.Name, portalPaths); ok {
+			mountPath := cleanRootFSPath(portal.MountPath)
+			if _, indexed := indexedPortals[mountPath]; !indexed {
+				// Portal contents are appended as a full snapshot on every layer.
+				// Mirror restoreRootFSPortalHeader's backing-directory reset so the
+				// logical-size index does not retain files omitted by a newer layer.
+				changes = append(changes, rootFSFileChange{Path: mountPath, Delete: true, Opaque: true})
+				indexedPortals[mountPath] = struct{}{}
+			}
+			if change, ok := rootFSFileChangeFromTarHeader(header); ok {
+				changes = append(changes, change)
+			}
 			if err := restoreRootFSPortalHeader(tarReader, header, portal, rel, restored); err != nil {
 				_ = tarWriter.Close()
-				return ctldapi.RootFSDiffDescriptor{}, nil, err
+				return ctldapi.RootFSDiffDescriptor{}, nil, nil, err
 			}
 			continue
 		}
 		if filter.ExcludesTarHeader(header.Name) {
 			continue
 		}
+		if change, ok := rootFSFileChangeFromTarHeader(header); ok {
+			changes = append(changes, change)
+		}
 
 		headerCopy := *header
 		if err := tarWriter.WriteHeader(&headerCopy); err != nil {
 			_ = tarWriter.Close()
-			return ctldapi.RootFSDiffDescriptor{}, nil, err
+			return ctldapi.RootFSDiffDescriptor{}, nil, nil, err
 		}
 		if header.Size > 0 {
 			if _, err := io.Copy(tarWriter, tarReader); err != nil {
 				_ = tarWriter.Close()
-				return ctldapi.RootFSDiffDescriptor{}, nil, err
+				return ctldapi.RootFSDiffDescriptor{}, nil, nil, err
 			}
 		}
 	}
 	if err := tarWriter.Close(); err != nil {
-		return ctldapi.RootFSDiffDescriptor{}, nil, err
+		return ctldapi.RootFSDiffDescriptor{}, nil, nil, err
 	}
 	stat, err := tmp.Stat()
 	if err != nil {
-		return ctldapi.RootFSDiffDescriptor{}, nil, err
+		return ctldapi.RootFSDiffDescriptor{}, nil, nil, err
 	}
 	if _, err := tmp.Seek(0, io.SeekStart); err != nil {
-		return ctldapi.RootFSDiffDescriptor{}, nil, err
+		return ctldapi.RootFSDiffDescriptor{}, nil, nil, err
 	}
 
 	desc.Digest = digester.Digest().String()
@@ -535,7 +719,7 @@ func filterRootFSDiffTarForApply(desc ctldapi.RootFSDiffDescriptor, reader io.Re
 		desc.MediaType = ocispec.MediaTypeImageLayer
 	}
 	removeOnError = false
-	return desc, removeOnCloseFile{File: tmp}, nil
+	return desc, removeOnCloseFile{File: tmp}, changes, nil
 }
 
 func appendPortalRootFSToDiff(desc ctldapi.RootFSDiffDescriptor, reader io.ReadSeekCloser, portalPaths []ctldapi.RootFSPortalPath) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error) {

--- a/ctld/internal/ctld/rootfs/overlay_diff_test.go
+++ b/ctld/internal/ctld/rootfs/overlay_diff_test.go
@@ -209,11 +209,13 @@ func TestWriteOverlayUpperDiffFromBaselineAppliesAsChildDelta(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(current, "etc", "added"), []byte("added"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(current, "etc", "same"), []byte("same"), 0o644))
 
-	desc, reader, err := writeOverlayUpperDiffFromBaseline(ctx, baseline, current, nil, nil)
+	desc, stats, reader, err := writeOverlayUpperDiffFromBaseline(ctx, baseline, current, nil, nil, nil)
 	require.NoError(t, err)
 	defer reader.Close()
 	require.NotEmpty(t, desc.Digest)
 	require.Positive(t, desc.Size)
+	require.NotNil(t, stats)
+	assert.Equal(t, int64(len("removed")), stats.DeletedBytes)
 
 	applied := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(applied, "etc"), 0o755))
@@ -230,6 +232,54 @@ func TestWriteOverlayUpperDiffFromBaselineAppliesAsChildDelta(t *testing.T) {
 	assert.True(t, os.IsNotExist(err))
 }
 
+func TestWriteOverlayUpperDiffFromBaselineUsesPersistedFileSizeIndexForRestoredWhiteout(t *testing.T) {
+	baseline := t.TempDir()
+	current := t.TempDir()
+	restoredPath := filepath.Join(current, "workspace", "restored.bin")
+	require.NoError(t, os.MkdirAll(filepath.Dir(restoredPath), 0o755))
+	if err := unix.Mknod(restoredPath, unix.S_IFCHR, 0); err != nil {
+		if err == unix.EPERM || err == unix.EACCES {
+			t.Skipf("creating overlay whiteout device is not permitted: %v", err)
+		}
+		require.NoError(t, err)
+	}
+
+	_, stats, reader, err := writeOverlayUpperDiffFromBaseline(
+		context.Background(),
+		baseline,
+		current,
+		nil,
+		nil,
+		rootFSFileSizeIndex{"/workspace/restored.bin": 10 * 1024 * 1024},
+	)
+	require.NoError(t, err)
+	defer reader.Close()
+	require.NotNil(t, stats)
+	assert.Equal(t, int64(10*1024*1024), stats.DeletedBytes)
+	assert.Contains(t, readTarEntries(t, reader), "workspace/.wh.restored.bin")
+}
+
+func TestRootFSDeletedLogicalBytesMergesBaselineAndIndexWithoutDoubleCounting(t *testing.T) {
+	baseline := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(baseline, "workspace"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(baseline, "workspace", "shared.bin"), make([]byte, 10), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(baseline, "workspace", "baseline-only.bin"), make([]byte, 20), 0o644))
+
+	deletedBytes, err := rootFSDeletedLogicalBytes(
+		context.Background(),
+		baseline,
+		"/workspace",
+		newRootFSPathFilter(nil),
+		rootFSFileSizeIndex{
+			"/workspace/shared.bin":   10,
+			"/workspace/restored.bin": 30,
+		},
+		make(map[string]struct{}),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, int64(60), deletedBytes)
+}
+
 func TestWriteOverlayUpperDiffFromBaselineExcludesConfiguredVolumePaths(t *testing.T) {
 	ctx := context.Background()
 	baseline := t.TempDir()
@@ -244,15 +294,71 @@ func TestWriteOverlayUpperDiffFromBaselineExcludesConfiguredVolumePaths(t *testi
 	require.NoError(t, os.MkdirAll(filepath.Join(current, "workspace", "database"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(current, "workspace", "database", "same"), []byte("changed"), 0o644))
 
-	_, reader, err := writeOverlayUpperDiffFromBaseline(ctx, baseline, current, []string{"/workspace/data"}, nil)
+	_, stats, reader, err := writeOverlayUpperDiffFromBaseline(ctx, baseline, current, []string{"/workspace/data"}, nil, nil)
 	require.NoError(t, err)
 	defer reader.Close()
+	require.NotNil(t, stats)
+	assert.Zero(t, stats.DeletedBytes)
 
 	entries := readTarEntries(t, reader)
 	assert.NotContains(t, entries, "workspace/data/")
 	assert.NotContains(t, entries, "workspace/data/old-volume.txt")
 	assert.NotContains(t, entries, "workspace/data/new-volume.txt")
 	assert.Contains(t, entries, "workspace/database/same")
+}
+
+func TestWriteOverlayUpperDiffFromBaselineCountsDeletedDirectoryBytesAndSkipsExcludedPaths(t *testing.T) {
+	ctx := context.Background()
+	baseline := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(baseline, "workspace", "removed", "nested"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(baseline, "workspace", "removed", "first"), []byte("1234"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(baseline, "workspace", "removed", "nested", "second"), []byte("123456"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(baseline, "workspace", "removed", "excluded"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(baseline, "workspace", "removed", "excluded", "volume"), []byte("not-rootfs"), 0o644))
+
+	current := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(current, "workspace"), 0o755))
+
+	_, stats, reader, err := writeOverlayUpperDiffFromBaseline(ctx, baseline, current, []string{"/workspace/removed/excluded"}, nil, nil)
+	require.NoError(t, err)
+	defer reader.Close()
+	require.NotNil(t, stats)
+	assert.Equal(t, int64(10), stats.DeletedBytes)
+}
+
+func TestWriteOverlayUpperDiffFromBaselineCountsDirectoryReplacedByFile(t *testing.T) {
+	ctx := context.Background()
+	baseline := t.TempDir()
+	replaced := filepath.Join(baseline, "workspace", "replaced")
+	require.NoError(t, os.MkdirAll(replaced, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(replaced, "first"), []byte("1234"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(replaced, "second"), []byte("123456"), 0o644))
+
+	current := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(current, "workspace"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(current, "workspace", "replaced"), []byte("replacement"), 0o644))
+
+	_, stats, reader, err := writeOverlayUpperDiffFromBaseline(ctx, baseline, current, nil, nil, nil)
+	require.NoError(t, err)
+	defer reader.Close()
+	require.NotNil(t, stats)
+	assert.Equal(t, int64(10), stats.DeletedBytes)
+}
+
+func TestWriteOverlayUpperDiffFromBaselineCountsFileReplacedByDirectory(t *testing.T) {
+	ctx := context.Background()
+	baseline := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(baseline, "workspace"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(baseline, "workspace", "replaced"), []byte("1234567890"), 0o644))
+
+	current := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(current, "workspace", "replaced"), 0o755))
+
+	_, stats, reader, err := writeOverlayUpperDiffFromBaseline(ctx, baseline, current, nil, nil, nil)
+	require.NoError(t, err)
+	defer reader.Close()
+	require.NotNil(t, stats)
+	assert.Equal(t, int64(10), stats.DeletedBytes)
 }
 
 func TestFilterRootFSDiffTarForApplyRestoresPortalBacking(t *testing.T) {
@@ -266,7 +372,7 @@ func TestFilterRootFSDiffTarForApplyRestoresPortalBacking(t *testing.T) {
 	backing := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(backing, "stale.txt"), []byte("stale"), 0o644))
 
-	desc, reader, err := filterRootFSDiffTarForApply(rootFSDiffDescriptorForTest(), bytes.NewReader(buf.Bytes()), nil, []ctldapi.RootFSPortalPath{{
+	desc, reader, changes, err := filterRootFSDiffTarForApply(rootFSDiffDescriptorForTest(), bytes.NewReader(buf.Bytes()), nil, []ctldapi.RootFSPortalPath{{
 		PortalName:  "cache",
 		MountPath:   "/workspace/cache",
 		BackingPath: backing,
@@ -279,9 +385,33 @@ func TestFilterRootFSDiffTarForApplyRestoresPortalBacking(t *testing.T) {
 	assert.Contains(t, entries, "workspace/root.txt")
 	assert.NotContains(t, entries, "workspace/cache/")
 	assert.NotContains(t, entries, "workspace/cache/old.txt")
+	index := make(rootFSFileSizeIndex)
+	require.True(t, index.Apply(changes))
+	assert.Equal(t, rootFSFileSizeIndex{
+		"/workspace/cache/old.txt": int64(len("new")),
+		"/workspace/root.txt":      int64(len("rootfs")),
+	}, index)
 	assertFileContent(t, filepath.Join(backing, "old.txt"), "new")
 	_, err = os.Stat(filepath.Join(backing, "stale.txt"))
 	assert.True(t, os.IsNotExist(err))
+}
+
+func TestRootFSPortalDeletedLogicalBytesCountsMissingIndexedFiles(t *testing.T) {
+	backing := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(backing, "survivor.bin"), make([]byte, 30), 0o644))
+
+	deletedBytes, err := rootFSPortalDeletedLogicalBytes(
+		context.Background(),
+		[]ctldapi.RootFSPortalPath{{MountPath: "/workspace", BackingPath: backing}},
+		rootFSFileSizeIndex{
+			"/workspace/deleted.bin":  10,
+			"/workspace/survivor.bin": 30,
+		},
+		newRootFSPathFilter(nil),
+		make(map[string]struct{}),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, int64(10), deletedBytes)
 }
 
 func TestFilterRootFSDiffTarExcludesRuntimePaths(t *testing.T) {

--- a/docs/sandbox/pause-resume/page.mdx
+++ b/docs/sandbox/pause-resume/page.mdx
@@ -30,6 +30,8 @@ The rootfs checkpoint covers files written inside the sandbox filesystem, includ
 
 On nodes using the containerd overlayfs snapshotter, `ctld` checkpoints only the active snapshot upperdir and stores it as a standard OCI layer diff. Other snapshotters, or nodes where the overlayfs upperdir is not readable by `ctld`, fall back to containerd's built-in diff path.
 
+Files created and deleted between checkpoints, without being included in an earlier checkpoint, are not retained as rootfs content. A file deleted after an earlier pause can remain in an immutable parent layer until the chain is compacted and garbage-collected. Sandbox0 detects large deletions while preparing an incremental checkpoint, discards that incremental layer, and uploads a parentless replacement; unreachable parent objects are removed asynchronously. Named snapshots and forks can keep older layers reachable for as long as they reference them.
+
 ## Pause A Sandbox
 
 Pause a sandbox to release compute while keeping its identity, configuration, services, mounted durable storage, and latest writable rootfs checkpoint available for a later resume.

--- a/infra-operator/api/config/manager.go
+++ b/infra-operator/api/config/manager.go
@@ -270,6 +270,8 @@ type RootFSMaintenanceConfig struct {
 	SquashDisabled          bool            `yaml:"squash_disabled" json:"-"`
 	SquashMaxChainDepth     int             `yaml:"squash_max_chain_depth" json:"-"`
 	SquashMaxChainBytes     int64           `yaml:"squash_max_chain_bytes" json:"-"`
+	SquashMinDeletedBytes   int64           `yaml:"squash_min_deleted_bytes" json:"-"`
+	SquashMinDeletedRatio   float64         `yaml:"squash_min_deleted_ratio" json:"-"`
 }
 
 type RootFSObjectStorageConfig struct {
@@ -616,6 +618,12 @@ func applyRootFSMaintenanceDefaults(cfg *ManagerConfig) {
 	}
 	if cfg.RootFSMaintenance.SquashMaxChainBytes <= 0 {
 		cfg.RootFSMaintenance.SquashMaxChainBytes = 512 * 1024 * 1024
+	}
+	if cfg.RootFSMaintenance.SquashMinDeletedBytes <= 0 {
+		cfg.RootFSMaintenance.SquashMinDeletedBytes = 8 * 1024 * 1024
+	}
+	if cfg.RootFSMaintenance.SquashMinDeletedRatio <= 0 {
+		cfg.RootFSMaintenance.SquashMinDeletedRatio = 0.25
 	}
 }
 

--- a/infra-operator/api/config/manager_test.go
+++ b/infra-operator/api/config/manager_test.go
@@ -51,3 +51,26 @@ sandbox_max_memory: 16Gi
 		t.Fatalf("sandbox max memory = %q, want 16Gi", cfg.SandboxMaxMemory)
 	}
 }
+
+func TestLoadManagerConfigRootFSSquashDeletionThresholds(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "manager.yaml")
+	if err := os.WriteFile(path, []byte(`
+rootfs_maintenance:
+  squash_min_deleted_bytes: 16777216
+  squash_min_deleted_ratio: 0.5
+`), 0o600); err != nil {
+		t.Fatalf("write manager config: %v", err)
+	}
+
+	cfg, err := loadManagerConfig(path)
+	if err != nil {
+		t.Fatalf("loadManagerConfig: %v", err)
+	}
+	if cfg.RootFSMaintenance.SquashMinDeletedBytes != 16*1024*1024 {
+		t.Fatalf("minimum deleted bytes = %d, want %d", cfg.RootFSMaintenance.SquashMinDeletedBytes, 16*1024*1024)
+	}
+	if cfg.RootFSMaintenance.SquashMinDeletedRatio != 0.5 {
+		t.Fatalf("minimum deleted ratio = %f, want 0.5", cfg.RootFSMaintenance.SquashMinDeletedRatio)
+	}
+}

--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -397,6 +397,8 @@ func main() {
 		RootFSSquashDisabled:                cfg.RootFSMaintenance.SquashDisabled,
 		RootFSSquashMaxChainDepth:           cfg.RootFSMaintenance.SquashMaxChainDepth,
 		RootFSSquashMaxChainBytes:           cfg.RootFSMaintenance.SquashMaxChainBytes,
+		RootFSSquashMinDeletedBytes:         cfg.RootFSMaintenance.SquashMinDeletedBytes,
+		RootFSSquashMinDeletedRatio:         cfg.RootFSMaintenance.SquashMinDeletedRatio,
 		PublicRootDomain:                    cfg.PublicRootDomain,
 		PublicRegionID:                      cfg.PublicRegionID,
 	}

--- a/manager/pkg/service/sandbox_service.go
+++ b/manager/pkg/service/sandbox_service.go
@@ -98,6 +98,8 @@ type SandboxServiceConfig struct {
 	RootFSSquashDisabled                bool
 	RootFSSquashMaxChainDepth           int
 	RootFSSquashMaxChainBytes           int64
+	RootFSSquashMinDeletedBytes         int64
+	RootFSSquashMinDeletedRatio         float64
 	PublicRootDomain                    string
 	PublicRegionID                      string
 }
@@ -194,6 +196,12 @@ func NewSandboxService(
 	}
 	if config.RootFSSquashMaxChainBytes <= 0 {
 		config.RootFSSquashMaxChainBytes = 512 * 1024 * 1024
+	}
+	if config.RootFSSquashMinDeletedBytes <= 0 {
+		config.RootFSSquashMinDeletedBytes = 8 * 1024 * 1024
+	}
+	if config.RootFSSquashMinDeletedRatio <= 0 {
+		config.RootFSSquashMinDeletedRatio = 0.25
 	}
 	if networkProvider == nil {
 		networkProvider = network.NewNoopProvider()

--- a/manager/pkg/service/sandbox_service_rootfs.go
+++ b/manager/pkg/service/sandbox_service_rootfs.go
@@ -21,6 +21,7 @@ import (
 const sandboxRootFSContainerName = "procd"
 
 const sandboxRootFSOperationTimeout = 5 * time.Minute
+const sandboxRootFSAbortTimeout = 5 * time.Second
 const sandboxRootFSSourceCheckpointLifecycleStaleAfter = sandboxRootFSOperationTimeout + time.Minute
 const sandboxRootFSUncommittedObjectDeleteDelay = 15 * time.Minute
 const sandboxRootFSUncommittedObjectDeleteTimeout = 30 * time.Second
@@ -71,9 +72,11 @@ func (s *SandboxService) prepareSandboxRootFSCheckpoint(ctx context.Context, pod
 	generation := runtimeGenerationFromPod(pod)
 	parentLayerID := ""
 	expectedHeadLayerID := ""
-	if parentState, err := s.latestRootFSState(ctx, sandboxID); err != nil {
+	var parentState *SandboxRootFSState
+	if loadedParentState, err := s.latestRootFSState(ctx, sandboxID); err != nil {
 		return nil, fmt.Errorf("load current rootfs head: %w", err)
-	} else if parentState != nil {
+	} else if loadedParentState != nil {
+		parentState = loadedParentState
 		expectedHeadLayerID = strings.TrimSpace(parentState.LayerID)
 		if squash, reason := s.shouldSquashSandboxRootFSCheckpoint(parentState); squash {
 			if s.logger != nil {
@@ -93,11 +96,53 @@ func (s *SandboxService) prepareSandboxRootFSCheckpoint(ctx context.Context, pod
 		ExcludedPaths: rootFSExcludedPathsForPod(pod),
 	}
 	layerID := uuid.NewString()
-	resp, err := s.prepareAndPublishSandboxRootFSSnapshot(ctx, ctldAddress, prepareReq, sandboxID, teamID, generation, layerID)
-	if err != nil && parentLayerID != "" && rootFSBaselineMissing(err, resp) {
+	prepared, err := s.ctldClient.PrepareRootFSSnapshotWithTimeout(ctx, ctldAddress, prepareReq, sandboxRootFSOperationTimeout)
+	if err != nil && parentLayerID != "" && rootFSBaselineMissing(err, prepareRootFSError(prepared)) {
 		parentLayerID = ""
 		prepareReq.ParentLayerID = ""
-		resp, err = s.prepareAndPublishSandboxRootFSSnapshot(ctx, ctldAddress, prepareReq, sandboxID, teamID, generation, layerID)
+		prepared, err = s.ctldClient.PrepareRootFSSnapshotWithTimeout(ctx, ctldAddress, prepareReq, sandboxRootFSOperationTimeout)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("save sandbox rootfs checkpoint: %w", rootFSResponseError(err, prepareRootFSError(prepared)))
+	}
+	var discardedPrepared *ctldapi.PrepareRootFSSnapshotResponse
+	if parentLayerID != "" {
+		if squash, reason := s.shouldSquashSandboxRootFSDeletion(parentState, prepared.DiffStats); squash {
+			squashReq := prepareReq
+			squashReq.ParentLayerID = ""
+			squashedPrepared, squashErr := s.ctldClient.PrepareRootFSSnapshotWithTimeout(ctx, ctldAddress, squashReq, sandboxRootFSOperationTimeout)
+			if squashErr != nil {
+				if s.logger != nil {
+					s.logger.Warn("Skipping sandbox rootfs deletion squash because the replacement snapshot could not be prepared",
+						zap.String("sandboxID", sandboxID),
+						zap.String("headLayerID", expectedHeadLayerID),
+						zap.String("reason", reason),
+						zap.Error(rootFSResponseError(squashErr, prepareRootFSError(squashedPrepared))),
+					)
+				}
+			} else {
+				if s.logger != nil {
+					s.logger.Info("Squashing sandbox rootfs checkpoint after a large deletion",
+						zap.String("sandboxID", sandboxID),
+						zap.String("headLayerID", expectedHeadLayerID),
+						zap.String("reason", reason),
+					)
+				}
+				discardedPrepared = prepared
+				prepared = squashedPrepared
+				parentLayerID = ""
+			}
+		}
+	}
+	resp, err := s.publishPreparedSandboxRootFSSnapshot(ctx, ctldAddress, prepared, sandboxID, teamID, generation, layerID)
+	if discardedPrepared != nil {
+		if cleanupErr := s.abortPreparedSandboxRootFSSnapshot(ctldAddress, discardedPrepared); cleanupErr != nil && s.logger != nil {
+			s.logger.Warn("Failed to clean up discarded incremental sandbox rootfs snapshot",
+				zap.String("sandboxID", sandboxID),
+				zap.String("headLayerID", expectedHeadLayerID),
+				zap.Error(cleanupErr),
+			)
+		}
 	}
 	if err != nil {
 		return nil, fmt.Errorf("save sandbox rootfs checkpoint: %w", rootFSResponseError(err, saveRootFSError(resp)))
@@ -112,25 +157,18 @@ func (s *SandboxService) prepareSandboxRootFSCheckpoint(ctx context.Context, pod
 	return state, nil
 }
 
-func (s *SandboxService) prepareAndPublishSandboxRootFSSnapshot(ctx context.Context, ctldAddress string, prepareReq ctldapi.PrepareRootFSSnapshotRequest, sandboxID, teamID string, generation int64, layerID string) (*ctldapi.SaveRootFSResponse, error) {
-	prepared, err := s.ctldClient.PrepareRootFSSnapshotWithTimeout(ctx, ctldAddress, prepareReq, sandboxRootFSOperationTimeout)
-	if err != nil {
-		resp := &ctldapi.SaveRootFSResponse{}
-		if prepared != nil {
-			resp.Info = prepared.Info
-			resp.Descriptor = prepared.Descriptor
-			resp.Error = prepared.Error
-		}
-		return resp, err
+func (s *SandboxService) publishPreparedSandboxRootFSSnapshot(ctx context.Context, ctldAddress string, prepared *ctldapi.PrepareRootFSSnapshotResponse, sandboxID, teamID string, generation int64, layerID string) (*ctldapi.SaveRootFSResponse, error) {
+	if prepared == nil {
+		return nil, fmt.Errorf("prepared rootfs snapshot is nil")
 	}
 	objectKey, err := defaultSandboxRootFSObjectKey(teamID, sandboxID, generation, prepared.Descriptor.Digest)
 	if err != nil {
-		_, _ = s.ctldClient.AbortRootFSSnapshotWithTimeout(context.Background(), ctldAddress, ctldapi.AbortRootFSSnapshotRequest{Handle: prepared.Handle}, sandboxRootFSOperationTimeout)
+		_ = s.abortPreparedSandboxRootFSSnapshot(ctldAddress, prepared)
 		return &ctldapi.SaveRootFSResponse{Info: prepared.Info, Descriptor: prepared.Descriptor}, err
 	}
 	pendingState := rootFSStateFromPreparedSnapshot(sandboxID, teamID, generation, layerID, objectKey, prepared)
 	if err := s.queueUncommittedRootFSObjectDeletion(ctx, pendingState, s.now().Add(sandboxRootFSUncommittedObjectDeleteDelay)); err != nil {
-		_, _ = s.ctldClient.AbortRootFSSnapshotWithTimeout(context.Background(), ctldAddress, ctldapi.AbortRootFSSnapshotRequest{Handle: prepared.Handle}, sandboxRootFSOperationTimeout)
+		_ = s.abortPreparedSandboxRootFSSnapshot(ctldAddress, prepared)
 		return &ctldapi.SaveRootFSResponse{Info: prepared.Info, Descriptor: prepared.Descriptor}, err
 	}
 	published, err := s.ctldClient.PublishRootFSSnapshotWithTimeout(ctx, ctldAddress, ctldapi.PublishRootFSSnapshotRequest{
@@ -141,7 +179,7 @@ func (s *SandboxService) prepareAndPublishSandboxRootFSSnapshot(ctx context.Cont
 		ObjectKey:                 objectKey,
 	}, sandboxRootFSOperationTimeout)
 	if err != nil {
-		_, _ = s.ctldClient.AbortRootFSSnapshotWithTimeout(context.Background(), ctldAddress, ctldapi.AbortRootFSSnapshotRequest{Handle: prepared.Handle}, sandboxRootFSOperationTimeout)
+		_ = s.abortPreparedSandboxRootFSSnapshot(ctldAddress, prepared)
 		s.deleteUncommittedRootFSObject(pendingState, "rootfs snapshot publish failed")
 		resp := &ctldapi.SaveRootFSResponse{Info: prepared.Info, Descriptor: prepared.Descriptor}
 		if published != nil {
@@ -158,6 +196,22 @@ func (s *SandboxService) prepareAndPublishSandboxRootFSSnapshot(ctx context.Cont
 	}, nil
 }
 
+func (s *SandboxService) abortPreparedSandboxRootFSSnapshot(ctldAddress string, prepared *ctldapi.PrepareRootFSSnapshotResponse) error {
+	if prepared == nil || strings.TrimSpace(prepared.Handle) == "" {
+		return fmt.Errorf("prepared rootfs snapshot handle is empty")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), sandboxRootFSAbortTimeout)
+	defer cancel()
+	resp, err := s.ctldClient.AbortRootFSSnapshotWithTimeout(ctx, ctldAddress, ctldapi.AbortRootFSSnapshotRequest{Handle: prepared.Handle}, sandboxRootFSAbortTimeout)
+	if err != nil {
+		return rootFSResponseError(err, abortRootFSError(resp))
+	}
+	if resp == nil || !resp.Aborted {
+		return fmt.Errorf("ctld did not report the prepared rootfs snapshot as aborted")
+	}
+	return nil
+}
+
 func (s *SandboxService) shouldSquashSandboxRootFSCheckpoint(state *SandboxRootFSState) (bool, string) {
 	if s == nil || s.config.RootFSSquashDisabled || state == nil {
 		return false, ""
@@ -170,20 +224,48 @@ func (s *SandboxService) shouldSquashSandboxRootFSCheckpoint(state *SandboxRootF
 		return true, fmt.Sprintf("chain_depth:%d", depth)
 	}
 	if maxBytes := s.config.RootFSSquashMaxChainBytes; maxBytes > 0 {
-		var totalBytes int64
-		for _, layer := range state.LayerChain {
-			if layer != nil && layer.DiffSize > 0 {
-				totalBytes += layer.DiffSize
-			}
-		}
-		if totalBytes == 0 && state.DiffSize > 0 {
-			totalBytes = state.DiffSize
-		}
+		totalBytes := sandboxRootFSChainBytes(state)
 		if totalBytes >= maxBytes {
 			return true, fmt.Sprintf("chain_bytes:%d", totalBytes)
 		}
 	}
 	return false, ""
+}
+
+// shouldSquashSandboxRootFSDeletion decides whether the current deletion delta
+// is large enough to justify replacing the reachable chain with a full layer.
+func (s *SandboxService) shouldSquashSandboxRootFSDeletion(state *SandboxRootFSState, stats *ctldapi.RootFSDiffStats) (bool, string) {
+	if s == nil || s.config.RootFSSquashDisabled || state == nil || stats == nil || stats.DeletedBytes <= 0 {
+		return false, ""
+	}
+	if minBytes := s.config.RootFSSquashMinDeletedBytes; minBytes <= 0 || stats.DeletedBytes < minBytes {
+		return false, ""
+	}
+	chainBytes := sandboxRootFSChainBytes(state)
+	if chainBytes <= 0 {
+		return false, ""
+	}
+	ratio := float64(stats.DeletedBytes) / float64(chainBytes)
+	if minRatio := s.config.RootFSSquashMinDeletedRatio; minRatio <= 0 || ratio < minRatio {
+		return false, ""
+	}
+	return true, fmt.Sprintf("deleted_bytes:%d,chain_bytes:%d,ratio:%.4f", stats.DeletedBytes, chainBytes, ratio)
+}
+
+func sandboxRootFSChainBytes(state *SandboxRootFSState) int64 {
+	if state == nil {
+		return 0
+	}
+	var totalBytes int64
+	for _, layer := range state.LayerChain {
+		if layer != nil && layer.DiffSize > 0 {
+			totalBytes += layer.DiffSize
+		}
+	}
+	if totalBytes == 0 && state.DiffSize > 0 {
+		totalBytes = state.DiffSize
+	}
+	return totalBytes
 }
 
 func (s *SandboxService) applySandboxRootFSCheckpoint(ctx context.Context, pod *corev1.Pod, state *SandboxRootFSState) error {
@@ -577,6 +659,20 @@ func saveRootFSError(resp *ctldapi.SaveRootFSResponse) string {
 	return strings.TrimSpace(resp.Error)
 }
 
+func prepareRootFSError(resp *ctldapi.PrepareRootFSSnapshotResponse) string {
+	if resp == nil {
+		return ""
+	}
+	return strings.TrimSpace(resp.Error)
+}
+
+func abortRootFSError(resp *ctldapi.AbortRootFSSnapshotResponse) string {
+	if resp == nil {
+		return ""
+	}
+	return strings.TrimSpace(resp.Error)
+}
+
 func applyRootFSError(resp *ctldapi.ApplyRootFSResponse) string {
 	if resp == nil {
 		return ""
@@ -584,12 +680,12 @@ func applyRootFSError(resp *ctldapi.ApplyRootFSResponse) string {
 	return strings.TrimSpace(resp.Error)
 }
 
-func rootFSBaselineMissing(err error, resp *ctldapi.SaveRootFSResponse) bool {
+func rootFSBaselineMissing(err error, message string) bool {
 	var reqErr *ctldapi.RequestError
 	if !errors.As(err, &reqErr) || reqErr == nil || reqErr.StatusCode != http.StatusNotFound {
 		return false
 	}
-	message := strings.ToLower(saveRootFSError(resp))
+	message = strings.ToLower(strings.TrimSpace(message))
 	return strings.Contains(message, "baseline") && strings.Contains(message, "not captured")
 }
 

--- a/manager/pkg/service/sandbox_service_rootfs_test.go
+++ b/manager/pkg/service/sandbox_service_rootfs_test.go
@@ -259,6 +259,153 @@ func TestPauseSandboxRuntimeSavesChildLayerFromParentHead(t *testing.T) {
 	assert.Equal(t, "sha256:child", state.DiffDigest)
 }
 
+func TestPrepareSandboxRootFSCheckpointUsesDeletionAwareSquashSafely(t *testing.T) {
+	const deletedBytes = int64(10 * 1024 * 1024)
+	tests := []struct {
+		name                string
+		squashPrepareFails  bool
+		discardCleanupFails bool
+		wantCalls           []string
+		wantParentLayerID   string
+		wantDigest          string
+	}{
+		{
+			name:       "publishes parentless replacement before cleaning incremental",
+			wantCalls:  []string{"prepare:layer-parent", "prepare:", "publish:squashed-handle", "abort:incremental-handle"},
+			wantDigest: "sha256:squashed",
+		},
+		{
+			name:                "cleanup failure does not discard replacement",
+			discardCleanupFails: true,
+			wantCalls:           []string{"prepare:layer-parent", "prepare:", "publish:squashed-handle", "abort:incremental-handle"},
+			wantDigest:          "sha256:squashed",
+		},
+		{
+			name:               "replacement prepare failure publishes intact incremental",
+			squashPrepareFails: true,
+			wantCalls:          []string{"prepare:layer-parent", "prepare:", "publish:incremental-handle"},
+			wantParentLayerID:  "layer-parent",
+			wantDigest:         "sha256:incremental",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calls []string
+			ctld := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/api/v1/rootfs/snapshots/prepare":
+					var req ctldapi.PrepareRootFSSnapshotRequest
+					require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+					calls = append(calls, "prepare:"+req.ParentLayerID)
+					if req.ParentLayerID == "" {
+						if tt.squashPrepareFails {
+							w.WriteHeader(http.StatusInternalServerError)
+							_ = json.NewEncoder(w).Encode(ctldapi.PrepareRootFSSnapshotResponse{Error: "replacement prepare failed"})
+							return
+						}
+						_ = json.NewEncoder(w).Encode(ctldapi.PrepareRootFSSnapshotResponse{
+							Handle:     "squashed-handle",
+							Descriptor: ctldapi.RootFSDiffDescriptor{MediaType: "application/vnd.oci.image.layer.v1.tar", Digest: "sha256:squashed", Size: 1024},
+						})
+						return
+					}
+					_ = json.NewEncoder(w).Encode(ctldapi.PrepareRootFSSnapshotResponse{
+						Handle:     "incremental-handle",
+						Descriptor: ctldapi.RootFSDiffDescriptor{MediaType: "application/vnd.oci.image.layer.v1.tar", Digest: "sha256:incremental", Size: 1536},
+						DiffStats:  &ctldapi.RootFSDiffStats{DeletedBytes: deletedBytes},
+					})
+				case "/api/v1/rootfs/snapshots/publish":
+					var req ctldapi.PublishRootFSSnapshotRequest
+					require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+					calls = append(calls, "publish:"+req.Handle)
+					digest := strings.TrimSuffix(req.Handle, "-handle")
+					_ = json.NewEncoder(w).Encode(ctldapi.PublishRootFSSnapshotResponse{
+						Published: true,
+						Descriptor: ctldapi.RootFSDiffDescriptor{
+							MediaType: "application/vnd.oci.image.layer.v1.tar",
+							Digest:    "sha256:" + digest,
+							Size:      1024,
+							ObjectKey: "sandbox-rootfs/team-1/sandbox-1/3/sha256/" + digest + ".tar",
+						},
+					})
+				case "/api/v1/rootfs/snapshots/abort":
+					var req ctldapi.AbortRootFSSnapshotRequest
+					require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+					calls = append(calls, "abort:"+req.Handle)
+					if tt.discardCleanupFails {
+						w.WriteHeader(http.StatusInternalServerError)
+						_ = json.NewEncoder(w).Encode(ctldapi.AbortRootFSSnapshotResponse{Error: "temporary cleanup failure"})
+						return
+					}
+					_ = json.NewEncoder(w).Encode(ctldapi.AbortRootFSSnapshotResponse{Aborted: true})
+				default:
+					t.Fatalf("unexpected ctld path %s", r.URL.Path)
+				}
+			}))
+			defer ctld.Close()
+			ctldURL, ctldPort := parsedTestServer(t, ctld.URL)
+
+			pod := rootFSTestPod("pod-1", "sandbox-1", "team-1")
+			pod.Status.HostIP = ctldURL.Hostname()
+			store := &memorySandboxStore{rootFSStates: map[string]*SandboxRootFSState{
+				"sandbox-1": {
+					LayerID:       "layer-parent",
+					SandboxID:     "sandbox-1",
+					TeamID:        "team-1",
+					DiffSize:      deletedBytes,
+					DiffObjectKey: "sandbox-rootfs/team-1/sandbox-1/2/sha256/parent.tar",
+				},
+			}}
+			svc := &SandboxService{
+				sandboxStore: store,
+				ctldClient:   NewCtldClient(CtldClientConfig{Timeout: time.Second}),
+				config: SandboxServiceConfig{
+					CtldEnabled:                 true,
+					CtldPort:                    ctldPort,
+					RootFSSquashMinDeletedBytes: 8 * 1024 * 1024,
+					RootFSSquashMinDeletedRatio: 0.25,
+				},
+				clock:  systemTime{},
+				logger: zap.NewNop(),
+			}
+
+			state, err := svc.prepareSandboxRootFSCheckpoint(context.Background(), pod, &SandboxRecord{ID: "sandbox-1", TeamID: "team-1", RuntimeGeneration: 3})
+			require.NoError(t, err)
+			require.NotNil(t, state)
+			assert.Equal(t, tt.wantCalls, calls)
+			assert.Equal(t, tt.wantParentLayerID, state.ParentLayerID)
+			assert.Equal(t, "layer-parent", state.ExpectedHeadLayerID)
+			assert.Equal(t, tt.wantDigest, state.DiffDigest)
+		})
+	}
+}
+
+func TestShouldSquashSandboxRootFSDeletion(t *testing.T) {
+	state := &SandboxRootFSState{LayerID: "layer-parent", DiffSize: 40 * 1024 * 1024}
+	svc := &SandboxService{config: SandboxServiceConfig{
+		RootFSSquashMinDeletedBytes: 8 * 1024 * 1024,
+		RootFSSquashMinDeletedRatio: 0.25,
+	}}
+
+	tests := []struct {
+		name  string
+		stats *ctldapi.RootFSDiffStats
+		want  bool
+	}{
+		{name: "unsupported stats", stats: nil},
+		{name: "below byte threshold", stats: &ctldapi.RootFSDiffStats{DeletedBytes: 4 * 1024 * 1024}},
+		{name: "below ratio threshold", stats: &ctldapi.RootFSDiffStats{DeletedBytes: 8 * 1024 * 1024}},
+		{name: "meets thresholds", stats: &ctldapi.RootFSDiffStats{DeletedBytes: 10 * 1024 * 1024}, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := svc.shouldSquashSandboxRootFSDeletion(state, tt.stats)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestCompletePausingSandboxRuntimeDoesNotCommitStaleCheckpoint(t *testing.T) {
 	store := &memorySandboxStore{
 		records: map[string]*SandboxRecord{

--- a/pkg/ctldapi/types.go
+++ b/pkg/ctldapi/types.go
@@ -67,6 +67,13 @@ type RootFSDiffDescriptor struct {
 	ObjectKey string `json:"object_key,omitempty"`
 }
 
+// RootFSDiffStats describes logical regular-file bytes removed by a rootfs
+// diff. These values are advisory and are not part of the immutable OCI
+// descriptor.
+type RootFSDiffStats struct {
+	DeletedBytes int64 `json:"deleted_bytes,omitempty"`
+}
+
 // RootFSLayerDescriptor identifies one immutable rootfs diff layer in a
 // sandbox rootfs head chain.
 type RootFSLayerDescriptor struct {
@@ -120,6 +127,7 @@ type PrepareRootFSSnapshotResponse struct {
 	Handle     string               `json:"handle,omitempty"`
 	Info       RootFSInfo           `json:"info,omitempty"`
 	Descriptor RootFSDiffDescriptor `json:"descriptor,omitempty"`
+	DiffStats  *RootFSDiffStats     `json:"diff_stats,omitempty"`
 	Error      string               `json:"error,omitempty"`
 }
 


### PR DESCRIPTION
## Summary

- persist an advisory logical file-size index for restored rootfs chains, including portal-backed rootfs content
- report logical `deleted_bytes` from incremental baseline diffs without changing OCI layer descriptors
- when a deletion is at least 8 MiB and 25% of the reachable chain, prepare and publish a parentless replacement checkpoint
- retain the incremental snapshot as a safe fallback, abort discarded prepared handles, and let existing asynchronous GC reclaim unreachable objects
- preserve the existing depth/byte squash conditions and document immutable-parent retention

## Testing

- `GOWORK=off go test ./ctld/... ./manager/... ./infra-operator/api/config/... ./pkg/ctldapi/... -count=1`
- `GOWORK=off go vet ./ctld/internal/ctld/rootfs ./manager/pkg/service ./infra-operator/api/config ./pkg/ctldapi`
- `GOWORK=off go test -race ./ctld/internal/ctld/rootfs ./manager/pkg/service -count=1`
- `git diff --check`
- Aliyun Singapore ECS / remote kind / `gvisor-rootfs`:
  - write then delete 10 MiB before the first pause: checkpoint 10,752 bytes, S3 object 11,248 bytes, file absent after resume
  - pause 10 MiB deleted target plus 3 MiB survivor, resume, delete target, pause again: `deleted_bytes=10,485,760`; new checkpoint is parentless and depth 1; S3 shrinks from 13,642,996 to 3,157,548 bytes; deleted file stays absent and survivor SHA-256 is preserved
  - old layer row and S3 object are reclaimed and the GC queue drains
  - unchanged follow-up pause reports `deleted_bytes=0`, preserves the replacement as parent, and grows normally to depth 2 instead of repeatedly squashing