### PR TITLE
fix(manager): guard depleted warm pool claims

### DIFF
--- a/manager/pkg/http/handlers_sandbox_list_test.go
+++ b/manager/pkg/http/handlers_sandbox_list_test.go
@@ -215,7 +215,7 @@ func TestClaimSandboxReturnsUnavailableWhenDataPlaneNotReady(t *testing.T) {
 	}
 }
 
-func TestClaimSandboxReturnsTooManyRequestsWhenClaimStartThrottled(t *testing.T) {
+func TestClaimSandboxReturnsTooManyRequestsWhileWarmPoolReplenishes(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	withHTTPTestPublicKey(t)
 	withHTTPTestManagerConfig(t, `sandbox_pod_placement:
@@ -229,7 +229,14 @@ func TestClaimSandboxReturnsTooManyRequestsWhenClaimStartThrottled(t *testing.T)
 	}
 	template := &v1alpha1.SandboxTemplate{
 		ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: templateNamespace},
-		Spec:       v1alpha1.SandboxTemplateSpec{MainContainer: v1alpha1.ContainerSpec{Image: "busybox"}},
+		Spec: v1alpha1.SandboxTemplateSpec{
+			MainContainer: v1alpha1.ContainerSpec{Image: "busybox"},
+			Pool:          v1alpha1.PoolStrategy{MinIdle: 1},
+			VolumeMounts: []v1alpha1.VolumeMountSpec{{
+				Name:      "data",
+				MountPath: "/workspace/data",
+			}},
+		},
 	}
 	node := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
@@ -245,11 +252,11 @@ func TestClaimSandboxReturnsTooManyRequestsWhenClaimStartThrottled(t *testing.T)
 	}
 	startingPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "active-starting",
+			Name:      "idle-starting",
 			Namespace: templateNamespace,
 			Labels: map[string]string{
 				controller.LabelTemplateID: template.Name,
-				controller.LabelPoolType:   controller.PoolTypeActive,
+				controller.LabelPoolType:   controller.PoolTypeIdle,
 			},
 		},
 		Status: corev1.PodStatus{Phase: corev1.PodPending},
@@ -257,8 +264,8 @@ func TestClaimSandboxReturnsTooManyRequestsWhenClaimStartThrottled(t *testing.T)
 	k8sClient := fake.NewSimpleClientset(node, startingPod)
 	claimStartLimiter, err := startlimiter.New(context.Background(), startlimiter.Config{
 		K8sClient:      k8sClient,
-		PerSandboxNode: 1,
-		MaxLimit:       1,
+		PerSandboxNode: 2,
+		MaxLimit:       2,
 		SandboxNodeSelector: map[string]string{
 			"sandbox0.ai/data-plane-ready": "true",
 		},
@@ -282,6 +289,7 @@ func TestClaimSandboxReturnsTooManyRequestsWhenClaimStartThrottled(t *testing.T)
 		nil,
 	)
 	sandboxService.SetClaimStartLimiter(claimStartLimiter)
+	sandboxService.SetVolumeMetadataClient(conflictingHTTPVolumeMetadataClient{})
 
 	server := &Server{sandboxService: sandboxService, logger: zap.NewNop()}
 	recorder := httptest.NewRecorder()
@@ -306,6 +314,47 @@ func TestClaimSandboxReturnsTooManyRequestsWhenClaimStartThrottled(t *testing.T)
 	if response.Success || response.Error == nil || response.Error.Code != spec.CodeClaimStartThrottled {
 		t.Fatalf("response = %+v, want claim_start_throttled error", response)
 	}
+	if !strings.Contains(response.Error.Message, "in_flight=1 limit=2") {
+		t.Fatalf("error message = %q, want below-limit warm-pool pressure", response.Error.Message)
+	}
+
+	conflictRecorder := httptest.NewRecorder()
+	conflictCtx, _ := gin.CreateTestContext(conflictRecorder)
+	conflictRequest := httptest.NewRequest(http.MethodPost, "/api/v1/sandboxes", strings.NewReader(`{
+		"template":"default",
+		"mounts":[{"sandboxvolume_id":"vol-1","mount_point":"/workspace/data"}]
+	}`))
+	conflictRequest.Header.Set("Content-Type", "application/json")
+	conflictRequest = conflictRequest.WithContext(internalauth.WithClaims(conflictRequest.Context(), &internalauth.Claims{TeamID: "team-1", UserID: "user-1"}))
+	conflictCtx.Request = conflictRequest
+
+	server.claimSandbox(conflictCtx)
+
+	if conflictRecorder.Code != http.StatusConflict {
+		t.Fatalf("volume conflict status = %d, want %d; body = %s", conflictRecorder.Code, http.StatusConflict, conflictRecorder.Body.String())
+	}
+	response = spec.Response{}
+	if err := json.Unmarshal(conflictRecorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("unmarshal conflict response: %v", err)
+	}
+	if response.Success || response.Error == nil || response.Error.Code != spec.CodeConflict {
+		t.Fatalf("conflict response = %+v, want conflict error before claim backpressure", response)
+	}
+}
+
+type conflictingHTTPVolumeMetadataClient struct{}
+
+func (conflictingHTTPVolumeMetadataClient) Get(_ context.Context, teamID, userID, volumeID string) (*service.SandboxVolumeInfo, error) {
+	return &service.SandboxVolumeInfo{
+		ID:         volumeID,
+		TeamID:     teamID,
+		UserID:     userID,
+		AccessMode: "RWO",
+	}, nil
+}
+
+func (conflictingHTTPVolumeMetadataClient) PrepareForVolumePortalBind(context.Context, service.PrepareVolumePortalBindRequest) error {
+	return service.ErrVolumePortalBindConflict
 }
 
 func TestClaimSandboxReturnsNotFoundForMissingTemplate(t *testing.T) {

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -338,6 +338,30 @@ type ClaimResponse struct {
 	BootstrapMounts []BootstrapMountStatus `json:"bootstrap_mounts,omitempty"`
 }
 
+// deferColdClaimWhilePoolReplenishes keeps a depleted warm pool from falling
+// through to a latency-heavy cold create while replacement pods are starting.
+// Cold fallback remains available when the cluster has no start pressure.
+func (s *SandboxService) deferColdClaimWhilePoolReplenishes(ctx context.Context, template *v1alpha1.SandboxTemplate) error {
+	if s == nil || s.claimStartLimiter == nil || template == nil || template.Spec.Pool.MinIdle <= 0 {
+		return nil
+	}
+
+	snapshot, err := s.claimStartLimiter.Snapshot(ctx)
+	if err != nil {
+		return fmt.Errorf("inspect claim start pressure: %w", err)
+	}
+	if snapshot == nil || snapshot.InFlight <= 0 {
+		return nil
+	}
+
+	return &startlimiter.ThrottledError{
+		Reason:     startlimiter.ReasonColdCreate,
+		Units:      1,
+		RetryAfter: time.Second,
+		Snapshot:   *snapshot,
+	}
+}
+
 // ClaimSandbox claims a sandbox from the idle pool or creates a new one
 func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*ClaimResponse, error) {
 	start := time.Now()
@@ -471,6 +495,27 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 
 	// If no idle pod available, create a new one (cold start)
 	if pod == nil {
+		phaseStarted = time.Now()
+		err = s.deferColdClaimWhilePoolReplenishes(ctx, template)
+		s.observeClaimPhase(req.Template, "cold", "guard_cold_fallback", phaseStarted, err)
+		if err != nil {
+			if errors.Is(err, ErrClaimStartThrottled) {
+				phaseStarted = time.Now()
+				preflightErr := s.preflightClaimVolumePortalBinds(ctx, req, template)
+				s.observeClaimPhase(req.Template, "cold", "preflight_volume_portals", phaseStarted, preflightErr)
+				if preflightErr != nil {
+					if metrics != nil {
+						metrics.SandboxClaimsTotal.WithLabelValues(req.Template, "error").Inc()
+					}
+					return nil, fmt.Errorf("preflight volume portals: %w", preflightErr)
+				}
+			}
+			if metrics != nil {
+				metrics.SandboxClaimsTotal.WithLabelValues(req.Template, "error").Inc()
+			}
+			return nil, fmt.Errorf("guard cold fallback: %w", err)
+		}
+
 		claimType = "cold"
 		s.logger.Info("No idle pod available, creating new pod",
 			zap.String("template", req.Template),
@@ -886,6 +931,35 @@ func (s *SandboxService) validateVolumePortalAccess(ctx context.Context, teamID,
 	}
 }
 
+// preflightClaimVolumePortalBinds preserves deterministic volume errors when a
+// depleted warm pool would otherwise return transient claim backpressure. The
+// actual bind repeats preparation after a pod is selected to close over races.
+func (s *SandboxService) preflightClaimVolumePortalBinds(ctx context.Context, req *ClaimRequest, template *v1alpha1.SandboxTemplate) error {
+	if req == nil || len(req.Mounts) == 0 {
+		return nil
+	}
+	declared := declaredVolumeMountsByPath(template)
+	for _, mount := range req.Mounts {
+		mountPoint := filepath.Clean(mount.MountPoint)
+		decl := declared[mountPoint]
+		if err := s.validateVolumePortalAccess(ctx, req.TeamID, req.UserID, mount.SandboxVolumeID, decl); err != nil {
+			return err
+		}
+		if err := s.prepareVolumePortalBindForClaim(ctx, PrepareVolumePortalBindRequest{
+			TeamID:      req.TeamID,
+			UserID:      req.UserID,
+			VolumeID:    mount.SandboxVolumeID,
+			PortalName:  volumeportal.NormalizePortalName(decl.Name, mountPoint),
+			MountPath:   mountPoint,
+			SandboxID:   req.SandboxID,
+			OwnerTeamID: req.TeamID,
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (s *SandboxService) bindWebhookStatePortal(ctx context.Context, pod *corev1.Pod, req *ClaimRequest) error {
 	if req == nil || s.getWebhookInfo(req) == nil || pod == nil || pod.Annotations == nil {
 		return nil
@@ -909,6 +983,17 @@ func (s *SandboxService) prepareVolumePortalBind(ctx context.Context, req Prepar
 	return preparer.PrepareForVolumePortalBind(ctx, req)
 }
 
+func (s *SandboxService) prepareVolumePortalBindForClaim(ctx context.Context, req PrepareVolumePortalBindRequest) error {
+	err := s.prepareVolumePortalBind(ctx, req)
+	if errors.Is(err, ErrVolumePortalBindConflict) {
+		return fmt.Errorf("%w: %v", ErrClaimConflict, err)
+	}
+	if err != nil {
+		return fmt.Errorf("prepare volume portal bind: %w", err)
+	}
+	return nil
+}
+
 func (s *SandboxService) bindVolumePortal(ctx context.Context, pod *corev1.Pod, teamID, userID, ownerTeamID, volumeID, mountPoint, portalName string) (*ctldapi.BindVolumePortalResponse, error) {
 	if s == nil || s.ctldClient == nil {
 		return nil, fmt.Errorf("ctld client is not configured")
@@ -924,7 +1009,7 @@ func (s *SandboxService) bindVolumePortal(ctx context.Context, pod *corev1.Pod, 
 	if err != nil {
 		return nil, err
 	}
-	if err := s.prepareVolumePortalBind(ctx, PrepareVolumePortalBindRequest{
+	if err := s.prepareVolumePortalBindForClaim(ctx, PrepareVolumePortalBindRequest{
 		TeamID:      teamID,
 		UserID:      userID,
 		VolumeID:    volumeID,
@@ -936,10 +1021,7 @@ func (s *SandboxService) bindVolumePortal(ctx context.Context, pod *corev1.Pod, 
 		SandboxID:   sandboxID,
 		OwnerTeamID: ownerTeamID,
 	}); err != nil {
-		if errors.Is(err, ErrVolumePortalBindConflict) {
-			return nil, fmt.Errorf("%w: %v", ErrClaimConflict, err)
-		}
-		return nil, fmt.Errorf("prepare volume portal bind: %w", err)
+		return nil, err
 	}
 	resp, err := s.bindVolumePortalWithRetry(ctx, ctldAddress, ctldapi.BindVolumePortalRequest{
 		Namespace:       pod.Namespace,

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -940,6 +940,120 @@ func TestCreateNewPodAnnotatesClaimStartReservation(t *testing.T) {
 	}
 }
 
+func TestDeferColdClaimWhilePoolReplenishes(t *testing.T) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "sandbox-a"},
+		Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{{
+			Type:   corev1.NodeReady,
+			Status: corev1.ConditionTrue,
+		}}},
+	}
+	startingPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "idle-starting",
+			Namespace: "ns-a",
+			Labels: map[string]string{
+				controller.LabelTemplateID: "template-a",
+				controller.LabelPoolType:   controller.PoolTypeIdle,
+			},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodPending},
+	}
+	client := fake.NewSimpleClientset(node, startingPod)
+	limiter, err := startlimiter.New(context.Background(), startlimiter.Config{
+		ClusterID:      "cluster-a",
+		K8sClient:      client,
+		PerSandboxNode: 2,
+		MaxLimit:       2,
+	})
+	if err != nil {
+		t.Fatalf("create claim start limiter: %v", err)
+	}
+	svc := &SandboxService{claimStartLimiter: limiter}
+	template := &v1alpha1.SandboxTemplate{
+		Spec: v1alpha1.SandboxTemplateSpec{Pool: v1alpha1.PoolStrategy{MinIdle: 1}},
+	}
+
+	err = svc.deferColdClaimWhilePoolReplenishes(context.Background(), template)
+	if !errors.Is(err, ErrClaimStartThrottled) {
+		t.Fatalf("deferColdClaimWhilePoolReplenishes() error = %v, want claim start throttled", err)
+	}
+	var throttled *startlimiter.ThrottledError
+	if !errors.As(err, &throttled) {
+		t.Fatalf("error = %T, want *startlimiter.ThrottledError", err)
+	}
+	if throttled.Snapshot.InFlight != 1 || throttled.Snapshot.Limit != 2 || throttled.Snapshot.Available != 1 {
+		t.Fatalf("snapshot = %+v, want in-flight 1, limit 2, and one nominally available slot", throttled.Snapshot)
+	}
+}
+
+func TestDeferColdClaimAllowsFallbackWithoutPoolPressure(t *testing.T) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "sandbox-a"},
+		Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{{
+			Type:   corev1.NodeReady,
+			Status: corev1.ConditionTrue,
+		}}},
+	}
+	client := fake.NewSimpleClientset(node)
+	limiter, err := startlimiter.New(context.Background(), startlimiter.Config{
+		ClusterID:      "cluster-a",
+		K8sClient:      client,
+		PerSandboxNode: 2,
+		MaxLimit:       2,
+	})
+	if err != nil {
+		t.Fatalf("create claim start limiter: %v", err)
+	}
+	svc := &SandboxService{claimStartLimiter: limiter}
+	template := &v1alpha1.SandboxTemplate{
+		Spec: v1alpha1.SandboxTemplateSpec{Pool: v1alpha1.PoolStrategy{MinIdle: 1}},
+	}
+
+	if err := svc.deferColdClaimWhilePoolReplenishes(context.Background(), template); err != nil {
+		t.Fatalf("deferColdClaimWhilePoolReplenishes() error = %v, want cold fallback allowed", err)
+	}
+}
+
+func TestPreflightClaimVolumePortalBindsPreservesConflictBeforeBackpressure(t *testing.T) {
+	metadata := &fakeVolumeMetadataClient{
+		accessMode: "RWO",
+		prepareErr: ErrVolumePortalBindConflict,
+	}
+	svc := &SandboxService{volumeMetadata: metadata}
+	template := &v1alpha1.SandboxTemplate{
+		Spec: v1alpha1.SandboxTemplateSpec{
+			VolumeMounts: []v1alpha1.VolumeMountSpec{{
+				Name:      "data",
+				MountPath: "/workspace/data",
+			}},
+		},
+	}
+	req := &ClaimRequest{
+		TeamID:    "team-a",
+		UserID:    "user-a",
+		SandboxID: "sandbox-a",
+		Mounts: []ClaimMount{{
+			SandboxVolumeID: "vol-1",
+			MountPoint:      "/workspace/data",
+		}},
+	}
+
+	err := svc.preflightClaimVolumePortalBinds(context.Background(), req, template)
+	if !errors.Is(err, ErrClaimConflict) {
+		t.Fatalf("preflightClaimVolumePortalBinds() error = %v, want claim conflict", err)
+	}
+	if errors.Is(err, ErrClaimStartThrottled) {
+		t.Fatalf("preflightClaimVolumePortalBinds() error = %v, must not mask conflict with backpressure", err)
+	}
+	if len(metadata.prepared) != 1 {
+		t.Fatalf("prepared calls = %d, want 1", len(metadata.prepared))
+	}
+	if metadata.prepared[0] != "team-a:user-a:vol-1:" {
+		t.Fatalf("prepared call = %q, want preflight without pod uid", metadata.prepared[0])
+	}
+}
+
 func TestClaimSandboxDeletesColdPodAfterNetworkApplyFailure(t *testing.T) {
 	withClaimTestPublicKey(t)
 

--- a/tests/e2e/cases/api.go
+++ b/tests/e2e/cases/api.go
@@ -2,6 +2,7 @@ package cases
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
@@ -102,5 +103,22 @@ func claimSandboxEventually(env *framework.ScenarioEnv, session *e2eutils.Sessio
 		resp, err = session.ClaimSandbox(env.TestCtx.Context, GinkgoT(), templateID)
 		return err
 	}).WithTimeout(2 * time.Minute).WithPolling(3 * time.Second).Should(Succeed())
+	return resp
+}
+
+func claimSandboxWithRequestEventually(env *framework.ScenarioEnv, session *e2eutils.Session, req apispec.ClaimRequest) *apispec.ClaimResponse {
+	var resp *apispec.ClaimResponse
+	Eventually(func() error {
+		var status int
+		var err error
+		resp, status, err = session.ClaimSandboxDetailed(env.TestCtx.Context, GinkgoT(), req)
+		if err == nil {
+			return nil
+		}
+		if status == http.StatusTooManyRequests {
+			return TryAgainAfter(time.Second).Wrap(err)
+		}
+		return StopTrying("claim returned a non-retryable response").Wrap(err)
+	}).WithTimeout(2 * time.Minute).WithPolling(time.Second).Should(Succeed())
 	return resp
 }

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -2944,8 +2944,7 @@ func assertClaimMountedROXVolumeSharedReadOnly(env *framework.ScenarioEnv, sessi
 		_ = session.DeleteSandbox(env.TestCtx.Context, GinkgoT(), firstSandboxID)
 	})
 
-	secondClaim, err := session.ClaimSandboxWithRequest(env.TestCtx.Context, GinkgoT(), claimReq)
-	Expect(err).NotTo(HaveOccurred())
+	secondClaim := claimSandboxWithRequestEventually(env, session, claimReq)
 	Expect(secondClaim).NotTo(BeNil())
 	secondSandboxID := secondClaim.SandboxId
 	DeferCleanup(func() {


### PR DESCRIPTION
## Summary

- return `claim_start_throttled` when a configured warm pool has no claimable idle Pod while replacement starts are still in flight
- keep cold fallback available when the cluster has no start pressure
- preserve deterministic volume validation and active-RWO conflicts before transient warm-pool backpressure
- make the ROX E2E success path honor transient 429 backpressure without retrying deterministic errors

## Production evidence

A sequential 500-claim ACK run reached 47 Pending warm-pool replacements after a second sandbox node became ready. The limiter grew from 30 to 60 slots, so one no-idle claim bypassed the warm pool and cold-created a Pod. That claim took 24.145s; manager metrics attributed 21.700s to network/Pod readiness and only 43ms to initialization. The other 485 accepted hot claims had p99 0.935s.

## Validation

- `go test ./manager/...`
- `go test ./tests/e2e/cases`
- deployed runtime commit `969dd619` to the persistent Aliyun kind environment; current commit `9d53f9c5` has identical runtime code and only adds E2E retry coverage
- under warm-pool replacement pressure (`in_flight=1`, `limit=60`), an ordinary claim returned 429 with `Retry-After: 1` and `claim_start_throttled`; it created zero active or cold Pods
- under the same pressure, an active RWO volume produced first claim 201 and second claim 409 `conflict`, without `Retry-After`; it created zero cold Pods
- after cleanup, `Sandbox0Infra` remained 9/9 Ready and the default idle pool returned to 1/1
- PR E2E confirmed a second legal ROX claim can encounter this transient 429; that success-oriented test now retries only 429 with one-second backoff and stops immediately on non-retryable responses
