### PR TITLE
fix(manager): batch warm pool scale-up under start limit

### DIFF
--- a/manager/pkg/controller/operator.go
+++ b/manager/pkg/controller/operator.go
@@ -259,7 +259,8 @@ func (op *Operator) syncHandler(ctx context.Context, key string) error {
 	}
 
 	// Reconcile the pool (ReplicaSet)
-	if err := op.poolManager.ReconcilePool(ctx, template); err != nil {
+	poolRequeueAfter, err := op.poolManager.ReconcilePool(ctx, template)
+	if err != nil {
 		return fmt.Errorf("reconcile pool: %w", err)
 	}
 
@@ -268,8 +269,12 @@ func (op *Operator) syncHandler(ctx context.Context, key string) error {
 	if err != nil {
 		return fmt.Errorf("update status: %w", err)
 	}
-	if needsProbeRequeue {
-		op.workqueue.AddAfter(key, sandboxProbeRequeueAfter)
+	requeueAfter := poolRequeueAfter
+	if needsProbeRequeue && (requeueAfter <= 0 || sandboxProbeRequeueAfter < requeueAfter) {
+		requeueAfter = sandboxProbeRequeueAfter
+	}
+	if requeueAfter > 0 {
+		op.workqueue.AddAfter(key, requeueAfter)
 	}
 
 	return nil

--- a/manager/pkg/controller/pool_manager.go
+++ b/manager/pkg/controller/pool_manager.go
@@ -134,8 +134,9 @@ func (pm *PoolManager) SetClaimStartLimiter(limiter *startlimiter.Limiter) {
 	pm.claimStartLimiter = limiter
 }
 
-// ReconcilePool reconciles the idle pool for a template
-func (pm *PoolManager) ReconcilePool(ctx context.Context, template *v1alpha1.SandboxTemplate) error {
+// ReconcilePool reconciles the idle pool for a template. A positive duration
+// requests another reconciliation after a start-limited scale-up.
+func (pm *PoolManager) ReconcilePool(ctx context.Context, template *v1alpha1.SandboxTemplate) (time.Duration, error) {
 	pm.logger.Info("Reconciling pool",
 		zap.String("template", template.Name),
 		zap.String("namespace", template.Namespace),
@@ -144,30 +145,30 @@ func (pm *PoolManager) ReconcilePool(ctx context.Context, template *v1alpha1.San
 
 	desiredTemplateHash, err := TemplateSpecHash(template)
 	if err != nil {
-		return fmt.Errorf("compute template hash: %w", err)
+		return 0, fmt.Errorf("compute template hash: %w", err)
 	}
 
 	// 1. Ensure ReplicaSet exists and is configured correctly
 	rs, err := pm.getOrCreateReplicaSet(ctx, template)
 	if err != nil {
-		return fmt.Errorf("get or create replicaset: %w", err)
+		return 0, fmt.Errorf("get or create replicaset: %w", err)
 	}
 
 	// 2. Ensure newly created pods use the latest template spec hash.
 	rs, err = pm.reconcileReplicaSetTemplate(ctx, template, rs, desiredTemplateHash)
 	if err != nil {
-		return fmt.Errorf("reconcile replicaset template: %w", err)
+		return 0, fmt.Errorf("reconcile replicaset template: %w", err)
 	}
 
 	// 3. Drain stale idle pods atomically with delete preconditions.
 	if err := pm.drainStaleIdlePods(ctx, template, desiredTemplateHash); err != nil {
-		return fmt.Errorf("drain stale idle pods: %w", err)
+		return 0, fmt.Errorf("drain stale idle pods: %w", err)
 	}
 
 	// 4. Repair current-hash idle pods that are stuck and will keep the
 	// ReplicaSet from creating replacements.
 	if err := pm.repairUnhealthyIdlePods(ctx, template, desiredTemplateHash); err != nil {
-		return fmt.Errorf("repair unhealthy idle pods: %w", err)
+		return 0, fmt.Errorf("repair unhealthy idle pods: %w", err)
 	}
 
 	// 5. Keep the warm pool fixed at minIdle. Template autoscaling is disabled
@@ -177,43 +178,114 @@ func (pm *PoolManager) ReconcilePool(ctx context.Context, template *v1alpha1.San
 	currentReplicas := getInt32Value(rs.Spec.Replicas)
 	desiredReplicas := desiredPoolReplicas(template)
 	if rs.Spec.Replicas == nil || currentReplicas != desiredReplicas {
-		pm.logger.Info("Updating ReplicaSet replicas",
-			zap.String("template", template.Name),
-			zap.Int32("current", currentReplicas),
-			zap.Int32("desired", desiredReplicas),
-		)
-
-		updateReplicas := func(updateCtx context.Context) error {
-			_, err = pm.updateReplicaSetReplicas(updateCtx, template.Namespace, rs.Name, desiredReplicas)
-			return err
-		}
-		if desiredReplicas > currentReplicas && pm.claimStartLimiter != nil {
-			_, err = pm.claimStartLimiter.Admit(ctx, startlimiter.ReasonPoolReconcile, desiredReplicas-currentReplicas, updateReplicas)
-			if stderrors.Is(err, startlimiter.ErrThrottled) {
-				pm.logger.Info("Delaying ReplicaSet scale-up due to claim start limit",
-					zap.String("template", template.Name),
-					zap.Int32("current", currentReplicas),
-					zap.Int32("desired", desiredReplicas),
-					zap.Error(err),
-				)
-				pm.recorder.Eventf(template, corev1.EventTypeNormal, "ReplicaSetScaleUpThrottled",
-					"Delayed ReplicaSet scale-up to %d replicas: %v", desiredReplicas, err)
-				return nil
-			}
-		} else {
-			err = updateReplicas(ctx)
-		}
-		if err != nil {
-			pm.recorder.Eventf(template, corev1.EventTypeWarning, "ReplicaSetUpdateFailed",
-				"Failed to update ReplicaSet: %v", err)
-			return fmt.Errorf("update replicaset: %w", err)
-		}
-
-		pm.recorder.Eventf(template, corev1.EventTypeNormal, "ReplicaSetUpdated",
-			"Updated ReplicaSet replicas to %d", desiredReplicas)
+		return pm.reconcileReplicaSetReplicas(ctx, template, rs, desiredReplicas)
 	}
 
-	return nil
+	return 0, nil
+}
+
+// reconcileReplicaSetReplicas updates the warm-pool size without admitting more
+// concurrent starts than the claim start limiter currently allows.
+func (pm *PoolManager) reconcileReplicaSetReplicas(
+	ctx context.Context,
+	template *v1alpha1.SandboxTemplate,
+	rs *appsv1.ReplicaSet,
+	desiredReplicas int32,
+) (time.Duration, error) {
+	liveRS, err := pm.k8sClient.AppsV1().ReplicaSets(rs.Namespace).Get(ctx, rs.Name, metav1.GetOptions{})
+	if err != nil {
+		return 0, fmt.Errorf("get replicaset for scale: %w", err)
+	}
+	currentReplicas := getInt32Value(liveRS.Spec.Replicas)
+	if liveRS.Spec.Replicas != nil && currentReplicas == desiredReplicas {
+		return 0, nil
+	}
+
+	pm.logger.Info("Updating ReplicaSet replicas",
+		zap.String("template", template.Name),
+		zap.Int32("current", currentReplicas),
+		zap.Int32("desired", desiredReplicas),
+	)
+
+	updateReplicas := func(target int32) func(context.Context) error {
+		return func(updateCtx context.Context) error {
+			_, err := pm.updateReplicaSetReplicas(updateCtx, template.Namespace, rs.Name, target)
+			return err
+		}
+	}
+	recordUpdateFailure := func(err error) (time.Duration, error) {
+		pm.recorder.Eventf(template, corev1.EventTypeWarning, "ReplicaSetUpdateFailed",
+			"Failed to update ReplicaSet: %v", err)
+		return 0, fmt.Errorf("update replicaset: %w", err)
+	}
+
+	if desiredReplicas <= currentReplicas || pm.claimStartLimiter == nil {
+		if err := updateReplicas(desiredReplicas)(ctx); err != nil {
+			return recordUpdateFailure(err)
+		}
+		pm.recorder.Eventf(template, corev1.EventTypeNormal, "ReplicaSetUpdated",
+			"Updated ReplicaSet replicas to %d", desiredReplicas)
+		return 0, nil
+	}
+
+	requested := desiredReplicas - currentReplicas
+	_, err = pm.claimStartLimiter.Admit(ctx, startlimiter.ReasonPoolReconcile, requested, updateReplicas(desiredReplicas))
+	if err == nil {
+		pm.recorder.Eventf(template, corev1.EventTypeNormal, "ReplicaSetUpdated",
+			"Updated ReplicaSet replicas to %d", desiredReplicas)
+		return 0, nil
+	}
+	if !stderrors.Is(err, startlimiter.ErrThrottled) {
+		return recordUpdateFailure(err)
+	}
+
+	retryAfter := startlimiter.RetryAfter(err)
+	var throttled *startlimiter.ThrottledError
+	if !stderrors.As(err, &throttled) || throttled.Snapshot.Available <= 0 {
+		pm.recordReplicaSetScaleUpThrottle(template, currentReplicas, desiredReplicas, retryAfter, err)
+		return retryAfter, nil
+	}
+
+	batchSize := min(requested, throttled.Snapshot.Available)
+	batchTarget := currentReplicas + batchSize
+	_, err = pm.claimStartLimiter.Admit(ctx, startlimiter.ReasonPoolReconcile, batchSize, updateReplicas(batchTarget))
+	if err != nil {
+		if stderrors.Is(err, startlimiter.ErrThrottled) {
+			retryAfter = startlimiter.RetryAfter(err)
+			pm.recordReplicaSetScaleUpThrottle(template, currentReplicas, desiredReplicas, retryAfter, err)
+			return retryAfter, nil
+		}
+		return recordUpdateFailure(err)
+	}
+
+	pm.logger.Info("Scaled ReplicaSet within available claim start budget",
+		zap.String("template", template.Name),
+		zap.Int32("current", currentReplicas),
+		zap.Int32("updated", batchTarget),
+		zap.Int32("desired", desiredReplicas),
+		zap.Duration("requeueAfter", retryAfter),
+	)
+	pm.recorder.Eventf(template, corev1.EventTypeNormal, "ReplicaSetScaleUpBatched",
+		"Updated ReplicaSet replicas to %d of desired %d; retrying in %s", batchTarget, desiredReplicas, retryAfter)
+	return retryAfter, nil
+}
+
+func (pm *PoolManager) recordReplicaSetScaleUpThrottle(
+	template *v1alpha1.SandboxTemplate,
+	currentReplicas int32,
+	desiredReplicas int32,
+	retryAfter time.Duration,
+	err error,
+) {
+	pm.logger.Info("Delaying ReplicaSet scale-up due to claim start limit",
+		zap.String("template", template.Name),
+		zap.Int32("current", currentReplicas),
+		zap.Int32("desired", desiredReplicas),
+		zap.Duration("requeueAfter", retryAfter),
+		zap.Error(err),
+	)
+	pm.recorder.Eventf(template, corev1.EventTypeNormal, "ReplicaSetScaleUpThrottled",
+		"Delayed ReplicaSet scale-up to %d replicas for %s: %v", desiredReplicas, retryAfter, err)
 }
 
 func (pm *PoolManager) updateReplicaSetReplicas(ctx context.Context, namespace, name string, replicas int32) (*appsv1.ReplicaSet, error) {

--- a/manager/pkg/controller/pool_manager_test.go
+++ b/manager/pkg/controller/pool_manager_test.go
@@ -3,14 +3,18 @@ package controller
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/alicebob/miniredis/v2"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/startlimiter"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
+	"github.com/sandbox0-ai/sandbox0/pkg/rediscache"
 	"github.com/sandbox0-ai/sandbox0/pkg/volumeportal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -109,6 +113,95 @@ func TestDesiredPoolReplicasUsesMinIdle(t *testing.T) {
 	}
 
 	assert.Equal(t, int32(15), desiredPoolReplicas(template))
+}
+
+func TestReconcileReplicaSetReplicasBatchesScaleUpAndRequeues(t *testing.T) {
+	ctx := context.Background()
+	redisServer := miniredis.RunT(t)
+	zero := int32(0)
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "template-a", Namespace: "default"},
+	}
+	rs := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rs-template-a",
+			Namespace: template.Namespace,
+			Labels: map[string]string{
+				LabelTemplateID: template.Name,
+			},
+		},
+		Spec: appsv1.ReplicaSetSpec{Replicas: &zero},
+	}
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "sandbox-a"},
+		Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{{
+			Type:   corev1.NodeReady,
+			Status: corev1.ConditionTrue,
+		}}},
+	}
+	client := fake.NewSimpleClientset(node, rs)
+	limiter, err := startlimiter.New(ctx, startlimiter.Config{
+		ClusterID:      "cluster-a",
+		K8sClient:      client,
+		PerSandboxNode: 30,
+		MaxLimit:       30,
+		Redis: rediscache.Config{
+			URL:       "redis://" + redisServer.Addr() + "/0",
+			KeyPrefix: "test",
+		},
+	})
+	require.NoError(t, err)
+
+	pm := &PoolManager{
+		k8sClient:         client,
+		recorder:          record.NewFakeRecorder(10),
+		logger:            zap.NewNop(),
+		claimStartLimiter: limiter,
+	}
+
+	requeueAfter, err := pm.reconcileReplicaSetReplicas(ctx, template, rs, 50)
+	require.NoError(t, err)
+	assert.Equal(t, time.Second, requeueAfter)
+	stored, err := client.AppsV1().ReplicaSets(template.Namespace).Get(ctx, rs.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, int32(30), getInt32Value(stored.Spec.Replicas))
+
+	// Reconcile with the original stale ReplicaSet object. The live read must keep
+	// the first batch at 30 instead of scaling it back down.
+	requeueAfter, err = pm.reconcileReplicaSetReplicas(ctx, template, rs, 50)
+	require.NoError(t, err)
+	assert.Equal(t, time.Second, requeueAfter)
+	stored, err = client.AppsV1().ReplicaSets(template.Namespace).Get(ctx, rs.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, int32(30), getInt32Value(stored.Spec.Replicas))
+
+	for i := 0; i < 30; i++ {
+		_, err := client.CoreV1().Pods(template.Namespace).Create(ctx, &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("idle-%02d", i),
+				Namespace: template.Namespace,
+				Labels: map[string]string{
+					LabelTemplateID: template.Name,
+					LabelPoolType:   PoolTypeIdle,
+				},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				Conditions: []corev1.PodCondition{{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+				}},
+			},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
+
+	requeueAfter, err = pm.reconcileReplicaSetReplicas(ctx, template, rs, 50)
+	require.NoError(t, err)
+	assert.Zero(t, requeueAfter)
+	stored, err = client.AppsV1().ReplicaSets(template.Namespace).Get(ctx, rs.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, int32(50), getInt32Value(stored.Spec.Replicas))
 }
 
 func TestUpdateReplicaSetReplicasRetriesConflict(t *testing.T) {


### PR DESCRIPTION
## Summary

- scale warm-pool ReplicaSets in batches that fit the current claim-start budget
- return limiter Retry-After to the operator and explicitly requeue incomplete pool scale-ups
- use a live ReplicaSet read before calculating a partial target to avoid stale-cache downscales
- cover the 0 to 30 to 50 flow, full-budget waiting, and stale informer input

## Tests

- go test ./manager/... -count=1
- go test -race ./manager/pkg/controller ./manager/pkg/startlimiter -count=1
- go vet ./manager/...

## Remote validation

Deployed PR head 4b0995d4 to the persistent Aliyun Singapore kind environment. With one schedulable sandbox node and a per-node claim-start limit of 30:

- minIdle 0 -> 50 first set ReplicaSet replicas to 30
- while 30 starts were in flight, reconciliation held at 30 and requeued with Retry-After 1s
- as pods became Ready, the controller automatically advanced 30 -> 45 -> 50
- all 50 pods became Ready; the temporary namespace was deleted and the cordoned node was restored