### PR TITLE
perf(ctld): pace sandbox runtime metrics collection

### DIFF
--- a/ctld/cmd/ctld/runtime_metrics.go
+++ b/ctld/cmd/ctld/runtime_metrics.go
@@ -76,7 +76,7 @@ func startCtldRuntimeMetrics(ctx context.Context, cfg *config.CtldConfig, statsC
 	if closer, ok := statsClient.(interface{ Close() error }); ok {
 		handle.statsClose = closer.Close
 	}
-	log.Printf("ctld runtime metric producer started: sample_interval=%s sample_jitter=%s", cfg.SandboxObservabilityRuntimeSampleInterval.Duration, cfg.SandboxObservabilityRuntimeSampleJitter.Duration)
+	log.Printf("ctld runtime metric producer started: sample_interval=%s sample_jitter=%s max_concurrency=%d", cfg.SandboxObservabilityRuntimeSampleInterval.Duration, cfg.SandboxObservabilityRuntimeSampleJitter.Duration, cfg.SandboxObservabilityRuntimeSampleMaxConcurrency)
 	return handle
 }
 
@@ -169,15 +169,16 @@ func newCtldRuntimeMetricsProducer(cfg *config.CtldConfig, statsClient ctldrunti
 		return nil, fmt.Errorf("create runtime sample worker: %w", err)
 	}
 	collector, err := ctldruntimemetrics.NewCollector(ctldruntimemetrics.CollectorConfig{
-		RegionID:    cfg.RegionID,
-		ClusterID:   cfg.DefaultClusterId,
-		NodeName:    nodeName,
-		Interval:    cfg.SandboxObservabilityRuntimeSampleInterval.Duration,
-		Jitter:      cfg.SandboxObservabilityRuntimeSampleJitter.Duration,
-		Logger:      logger,
-		StatsClient: statsClient,
-		PodLister:   podLister,
-		Sink:        worker,
+		RegionID:       cfg.RegionID,
+		ClusterID:      cfg.DefaultClusterId,
+		NodeName:       nodeName,
+		Interval:       cfg.SandboxObservabilityRuntimeSampleInterval.Duration,
+		Jitter:         cfg.SandboxObservabilityRuntimeSampleJitter.Duration,
+		MaxConcurrency: cfg.SandboxObservabilityRuntimeSampleMaxConcurrency,
+		Logger:         logger,
+		StatsClient:    statsClient,
+		PodLister:      podLister,
+		Sink:           worker,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create runtime metric collector: %w", err)

--- a/ctld/cmd/ctld/runtime_metrics_test.go
+++ b/ctld/cmd/ctld/runtime_metrics_test.go
@@ -186,11 +186,31 @@ type staticStatsClient struct {
 	onCall chan<- struct{}
 }
 
-func (c staticStatsClient) ListPodSandboxStats(context.Context) ([]*runtimeapi.PodSandboxStats, error) {
+func (c staticStatsClient) ListPodSandboxes(context.Context) ([]*runtimeapi.PodSandbox, error) {
+	items := make([]*runtimeapi.PodSandbox, 0, len(c.stats))
+	for _, stats := range c.stats {
+		if stats == nil || stats.Attributes == nil {
+			continue
+		}
+		items = append(items, &runtimeapi.PodSandbox{
+			Id:       stats.Attributes.Id,
+			Metadata: stats.Attributes.Metadata,
+			State:    runtimeapi.PodSandboxState_SANDBOX_READY,
+		})
+	}
+	return items, nil
+}
+
+func (c staticStatsClient) PodSandboxStats(_ context.Context, id string) (*runtimeapi.PodSandboxStats, error) {
 	if c.onCall != nil {
 		c.onCall <- struct{}{}
 	}
-	return c.stats, nil
+	for _, stats := range c.stats {
+		if stats != nil && stats.Attributes != nil && stats.Attributes.Id == id {
+			return stats, nil
+		}
+	}
+	return nil, nil
 }
 
 var _ ctldruntimemetrics.StatsClient = staticStatsClient{}

--- a/ctld/internal/ctld/rootfs/containerd_runtime.go
+++ b/ctld/internal/ctld/rootfs/containerd_runtime.go
@@ -42,7 +42,8 @@ const (
 
 type criRuntimeService interface {
 	ListContainers(ctx context.Context, in *runtimeapi.ListContainersRequest, opts ...grpc.CallOption) (*runtimeapi.ListContainersResponse, error)
-	ListPodSandboxStats(ctx context.Context, in *runtimeapi.ListPodSandboxStatsRequest, opts ...grpc.CallOption) (*runtimeapi.ListPodSandboxStatsResponse, error)
+	ListPodSandbox(ctx context.Context, in *runtimeapi.ListPodSandboxRequest, opts ...grpc.CallOption) (*runtimeapi.ListPodSandboxResponse, error)
+	PodSandboxStats(ctx context.Context, in *runtimeapi.PodSandboxStatsRequest, opts ...grpc.CallOption) (*runtimeapi.PodSandboxStatsResponse, error)
 }
 
 type ContainerdRuntimeConfig struct {
@@ -389,15 +390,30 @@ func (r *ContainerdRuntime) resolveContainerID(ctx context.Context, target ctlda
 	return "", "", fmt.Errorf("%w: running container %s in pod %s/%s", ErrNotFound, target.ContainerName, target.Namespace, target.PodName)
 }
 
-// ListPodSandboxStats returns one bulk node-local CRI stats snapshot.
-func (r *ContainerdRuntime) ListPodSandboxStats(ctx context.Context) ([]*runtimeapi.PodSandboxStats, error) {
+// ListPodSandboxes returns the ready node-local CRI pod sandboxes.
+func (r *ContainerdRuntime) ListPodSandboxes(ctx context.Context) ([]*runtimeapi.PodSandbox, error) {
 	client, err := r.runtimeClient(ctx)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListPodSandboxStats(ctx, &runtimeapi.ListPodSandboxStatsRequest{})
+	resp, err := client.ListPodSandbox(ctx, &runtimeapi.ListPodSandboxRequest{Filter: &runtimeapi.PodSandboxFilter{
+		State: &runtimeapi.PodSandboxStateValue{State: runtimeapi.PodSandboxState_SANDBOX_READY},
+	}})
 	if err != nil {
-		return nil, fmt.Errorf("list CRI pod sandbox stats: %w", err)
+		return nil, fmt.Errorf("list CRI pod sandboxes: %w", err)
+	}
+	return resp.GetItems(), nil
+}
+
+// PodSandboxStats returns one CRI pod sandbox stats sample without node-wide fan-out.
+func (r *ContainerdRuntime) PodSandboxStats(ctx context.Context, sandboxID string) (*runtimeapi.PodSandboxStats, error) {
+	client, err := r.runtimeClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.PodSandboxStats(ctx, &runtimeapi.PodSandboxStatsRequest{PodSandboxId: sandboxID})
+	if err != nil {
+		return nil, fmt.Errorf("get CRI pod sandbox %s stats: %w", sandboxID, err)
 	}
 	return resp.GetStats(), nil
 }

--- a/ctld/internal/ctld/rootfs/containerd_runtime_test.go
+++ b/ctld/internal/ctld/rootfs/containerd_runtime_test.go
@@ -42,7 +42,7 @@ func TestRuntimeFamily(t *testing.T) {
 
 func TestResolveContainerIDUsesCRILabels(t *testing.T) {
 	runtime := NewContainerdRuntime(ContainerdRuntimeConfig{
-		CRIClient: fakeCRIClient{containers: []*runtimeapi.Container{
+		CRIClient: &fakeCRIClient{containers: []*runtimeapi.Container{
 			{
 				Id:       "wrong-container",
 				Metadata: &runtimeapi.ContainerMetadata{Name: "sandbox"},
@@ -79,7 +79,7 @@ func TestResolveContainerIDUsesCRILabels(t *testing.T) {
 
 func TestResolveContainerIDPrefersRunningAttempt(t *testing.T) {
 	runtime := NewContainerdRuntime(ContainerdRuntimeConfig{
-		CRIClient: fakeCRIClient{containers: []*runtimeapi.Container{
+		CRIClient: &fakeCRIClient{containers: []*runtimeapi.Container{
 			{
 				Id:       "exited-container",
 				State:    runtimeapi.ContainerState_CONTAINER_EXITED,
@@ -116,7 +116,7 @@ func TestResolveContainerIDPrefersRunningAttempt(t *testing.T) {
 }
 
 func TestResolveContainerIDReturnsNotFound(t *testing.T) {
-	runtime := NewContainerdRuntime(ContainerdRuntimeConfig{CRIClient: fakeCRIClient{}})
+	runtime := NewContainerdRuntime(ContainerdRuntimeConfig{CRIClient: &fakeCRIClient{}})
 
 	_, _, err := runtime.resolveContainerID(context.Background(), ctldapi.RootFSContainerRef{
 		Namespace:     "default",
@@ -128,24 +128,38 @@ func TestResolveContainerIDReturnsNotFound(t *testing.T) {
 	assert.True(t, errors.Is(err, ErrNotFound))
 }
 
-func TestListPodSandboxStatsUsesBulkCRIRequest(t *testing.T) {
-	want := []*runtimeapi.PodSandboxStats{{
-		Attributes: &runtimeapi.PodSandboxAttributes{Id: "sandbox-1"},
-	}}
-	runtime := NewContainerdRuntime(ContainerdRuntimeConfig{CRIClient: fakeCRIClient{stats: want}})
+func TestListPodSandboxesUsesReadyCRIRequest(t *testing.T) {
+	want := []*runtimeapi.PodSandbox{{Id: "sandbox-1"}}
+	client := &fakeCRIClient{sandboxes: want}
+	runtime := NewContainerdRuntime(ContainerdRuntimeConfig{CRIClient: client})
 
-	got, err := runtime.ListPodSandboxStats(context.Background())
+	got, err := runtime.ListPodSandboxes(context.Background())
 
 	require.NoError(t, err)
 	assert.Equal(t, want, got)
+	require.NotNil(t, client.listSandboxFilter)
+	require.NotNil(t, client.listSandboxFilter.State)
+	assert.Equal(t, runtimeapi.PodSandboxState_SANDBOX_READY, client.listSandboxFilter.State.State)
 }
 
-func TestListPodSandboxStatsWrapsCRIError(t *testing.T) {
-	runtime := NewContainerdRuntime(ContainerdRuntimeConfig{CRIClient: fakeCRIClient{err: errors.New("unavailable")}})
+func TestPodSandboxStatsUsesSingleCRIRequest(t *testing.T) {
+	want := &runtimeapi.PodSandboxStats{Attributes: &runtimeapi.PodSandboxAttributes{Id: "sandbox-1"}}
+	client := &fakeCRIClient{statsByID: map[string]*runtimeapi.PodSandboxStats{"sandbox-1": want}}
+	runtime := NewContainerdRuntime(ContainerdRuntimeConfig{CRIClient: client})
 
-	_, err := runtime.ListPodSandboxStats(context.Background())
+	got, err := runtime.PodSandboxStats(context.Background(), "sandbox-1")
 
-	require.ErrorContains(t, err, "list CRI pod sandbox stats")
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+	assert.Equal(t, []string{"sandbox-1"}, client.statsRequests)
+}
+
+func TestListPodSandboxesWrapsCRIError(t *testing.T) {
+	runtime := NewContainerdRuntime(ContainerdRuntimeConfig{CRIClient: &fakeCRIClient{err: errors.New("unavailable")}})
+
+	_, err := runtime.ListPodSandboxes(context.Background())
+
+	require.ErrorContains(t, err, "list CRI pod sandboxes")
 }
 
 func TestContainerdRuntimeReusesAndClosesCRIConnection(t *testing.T) {
@@ -181,9 +195,9 @@ func TestContainerdRuntimeReusesAndClosesCRIConnection(t *testing.T) {
 		},
 	})
 
-	_, err := runtime.ListPodSandboxStats(context.Background())
+	_, err := runtime.ListPodSandboxes(context.Background())
 	require.NoError(t, err)
-	_, err = runtime.ListPodSandboxStats(context.Background())
+	_, err = runtime.PodSandboxStats(context.Background(), "sandbox-1")
 	require.NoError(t, err)
 	assert.Equal(t, int32(1), dialCount.Load())
 
@@ -256,33 +270,49 @@ func TestNormalizeCRIEndpoint(t *testing.T) {
 }
 
 type fakeCRIClient struct {
-	containers []*runtimeapi.Container
-	stats      []*runtimeapi.PodSandboxStats
-	err        error
+	containers        []*runtimeapi.Container
+	sandboxes         []*runtimeapi.PodSandbox
+	statsByID         map[string]*runtimeapi.PodSandboxStats
+	listSandboxFilter *runtimeapi.PodSandboxFilter
+	statsRequests     []string
+	err               error
 }
 
 type fakeRuntimeServiceServer struct {
 	runtimeapi.UnimplementedRuntimeServiceServer
 }
 
-func (*fakeRuntimeServiceServer) ListPodSandboxStats(context.Context, *runtimeapi.ListPodSandboxStatsRequest) (*runtimeapi.ListPodSandboxStatsResponse, error) {
-	return &runtimeapi.ListPodSandboxStatsResponse{Stats: []*runtimeapi.PodSandboxStats{{
-		Attributes: &runtimeapi.PodSandboxAttributes{Id: "sandbox-1"},
-	}}}, nil
+func (*fakeRuntimeServiceServer) ListPodSandbox(context.Context, *runtimeapi.ListPodSandboxRequest) (*runtimeapi.ListPodSandboxResponse, error) {
+	return &runtimeapi.ListPodSandboxResponse{Items: []*runtimeapi.PodSandbox{{Id: "sandbox-1"}}}, nil
 }
 
-func (c fakeCRIClient) ListContainers(_ context.Context, _ *runtimeapi.ListContainersRequest, _ ...grpc.CallOption) (*runtimeapi.ListContainersResponse, error) {
+func (*fakeRuntimeServiceServer) PodSandboxStats(context.Context, *runtimeapi.PodSandboxStatsRequest) (*runtimeapi.PodSandboxStatsResponse, error) {
+	return &runtimeapi.PodSandboxStatsResponse{Stats: &runtimeapi.PodSandboxStats{
+		Attributes: &runtimeapi.PodSandboxAttributes{Id: "sandbox-1"},
+	}}, nil
+}
+
+func (c *fakeCRIClient) ListContainers(_ context.Context, _ *runtimeapi.ListContainersRequest, _ ...grpc.CallOption) (*runtimeapi.ListContainersResponse, error) {
 	if c.err != nil {
 		return nil, c.err
 	}
 	return &runtimeapi.ListContainersResponse{Containers: c.containers}, nil
 }
 
-func (c fakeCRIClient) ListPodSandboxStats(_ context.Context, _ *runtimeapi.ListPodSandboxStatsRequest, _ ...grpc.CallOption) (*runtimeapi.ListPodSandboxStatsResponse, error) {
+func (c *fakeCRIClient) ListPodSandbox(_ context.Context, req *runtimeapi.ListPodSandboxRequest, _ ...grpc.CallOption) (*runtimeapi.ListPodSandboxResponse, error) {
 	if c.err != nil {
 		return nil, c.err
 	}
-	return &runtimeapi.ListPodSandboxStatsResponse{Stats: c.stats}, nil
+	c.listSandboxFilter = req.Filter
+	return &runtimeapi.ListPodSandboxResponse{Items: c.sandboxes}, nil
+}
+
+func (c *fakeCRIClient) PodSandboxStats(_ context.Context, req *runtimeapi.PodSandboxStatsRequest, _ ...grpc.CallOption) (*runtimeapi.PodSandboxStatsResponse, error) {
+	if c.err != nil {
+		return nil, c.err
+	}
+	c.statsRequests = append(c.statsRequests, req.PodSandboxId)
+	return &runtimeapi.PodSandboxStatsResponse{Stats: c.statsByID[req.PodSandboxId]}, nil
 }
 
 func writeTaskConfig(t *testing.T, taskDir string, annotations map[string]string) {

--- a/ctld/internal/ctld/runtimemetrics/collector.go
+++ b/ctld/internal/ctld/runtimemetrics/collector.go
@@ -3,7 +3,9 @@ package runtimemetrics
 import (
 	"context"
 	"fmt"
+	"hash/fnv"
 	"math/rand"
+	"sort"
 	"sync"
 	"time"
 
@@ -13,9 +15,10 @@ import (
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
-// StatsClient exposes the CRI node-wide pod sandbox stats snapshot.
+// StatsClient exposes CRI discovery and one-sandbox stats calls.
 type StatsClient interface {
-	ListPodSandboxStats(context.Context) ([]*runtimeapi.PodSandboxStats, error)
+	ListPodSandboxes(context.Context) ([]*runtimeapi.PodSandbox, error)
+	PodSandboxStats(context.Context, string) (*runtimeapi.PodSandboxStats, error)
 }
 
 // SampleSink is the bounded asynchronous handoff used by the collector.
@@ -25,45 +28,53 @@ type SampleSink interface {
 
 // CollectorConfig configures node identity, cadence, and producer dependencies.
 type CollectorConfig struct {
-	RegionID    string
-	ClusterID   string
-	NodeName    string
-	Interval    time.Duration
-	Jitter      time.Duration
-	Now         func() time.Time
-	Random      func() float64
-	Logger      *zap.Logger
-	StatsClient StatsClient
-	PodLister   corelisters.PodLister
-	Sink        SampleSink
+	RegionID       string
+	ClusterID      string
+	NodeName       string
+	Interval       time.Duration
+	Jitter         time.Duration
+	MaxConcurrency int
+	Now            func() time.Time
+	Random         func() float64
+	Logger         *zap.Logger
+	StatsClient    StatsClient
+	PodLister      corelisters.PodLister
+	Sink           SampleSink
 }
 
 // Collector maps CRI pod sandbox stats to sandbox runtime samples.
 type Collector struct {
-	collectMu   sync.Mutex
-	regionID    string
-	clusterID   string
-	nodeName    string
-	interval    time.Duration
-	jitter      time.Duration
-	now         func() time.Time
-	random      func() float64
-	logger      *zap.Logger
-	statsClient StatsClient
-	podLister   corelisters.PodLister
-	sink        SampleSink
-	cpuUsage    *cpuUsageTracker
+	collectMu      sync.Mutex
+	regionID       string
+	clusterID      string
+	nodeName       string
+	interval       time.Duration
+	jitter         time.Duration
+	maxConcurrency int
+	now            func() time.Time
+	random         func() float64
+	logger         *zap.Logger
+	statsClient    StatsClient
+	podLister      corelisters.PodLister
+	sink           SampleSink
+	cpuUsage       *cpuUsageTracker
 }
 
-// CollectResult summarizes one bulk collection attempt.
+// CollectResult summarizes one node-local collection attempt.
 type CollectResult struct {
 	StatsReceived int
 	Matched       int
 	Enqueued      int
 	Dropped       int
+	Failed        int
 }
 
-// NewCollector creates a node-local bulk CRI runtime metric collector.
+type sandboxTarget struct {
+	id       string
+	identity sandboxIdentity
+}
+
+// NewCollector creates a node-local paced CRI runtime metric collector.
 func NewCollector(cfg CollectorConfig) (*Collector, error) {
 	if cfg.StatsClient == nil {
 		return nil, fmt.Errorf("stats client is nil")
@@ -86,6 +97,9 @@ func NewCollector(cfg CollectorConfig) (*Collector, error) {
 	if cfg.Jitter >= cfg.Interval {
 		cfg.Jitter = cfg.Interval / 2
 	}
+	if cfg.MaxConcurrency <= 0 {
+		cfg.MaxConcurrency = sandboxobservability.DefaultRuntimeSampleMaxConcurrency
+	}
 	if cfg.Now == nil {
 		cfg.Now = time.Now
 	}
@@ -96,48 +110,73 @@ func NewCollector(cfg CollectorConfig) (*Collector, error) {
 		cfg.Logger = zap.NewNop()
 	}
 	return &Collector{
-		regionID:    cfg.RegionID,
-		clusterID:   cfg.ClusterID,
-		nodeName:    cfg.NodeName,
-		interval:    cfg.Interval,
-		jitter:      cfg.Jitter,
-		now:         cfg.Now,
-		random:      cfg.Random,
-		logger:      cfg.Logger,
-		statsClient: cfg.StatsClient,
-		podLister:   cfg.PodLister,
-		sink:        cfg.Sink,
-		cpuUsage:    &cpuUsageTracker{},
+		regionID:       cfg.RegionID,
+		clusterID:      cfg.ClusterID,
+		nodeName:       cfg.NodeName,
+		interval:       cfg.Interval,
+		jitter:         cfg.Jitter,
+		maxConcurrency: cfg.MaxConcurrency,
+		now:            cfg.Now,
+		random:         cfg.Random,
+		logger:         cfg.Logger,
+		statsClient:    cfg.StatsClient,
+		podLister:      cfg.PodLister,
+		sink:           cfg.Sink,
+		cpuUsage:       &cpuUsageTracker{},
 	}, nil
 }
 
-// Run collects immediately, then repeats with bounded jitter until cancellation.
+// Run continuously spreads per-sandbox CRI calls across each sampling window.
 func (c *Collector) Run(ctx context.Context) {
 	if c == nil {
 		return
 	}
 	for {
-		result, err := c.Collect(ctx)
+		cycleInterval := c.nextDelay()
+		startedAt := time.Now()
+		result, err := c.collect(ctx, cycleInterval)
+		elapsed := time.Since(startedAt)
 		if err != nil && ctx.Err() == nil {
-			c.logger.Warn("Failed to collect sandbox runtime metrics", zap.Error(err))
+			c.logger.Warn("Failed to collect some sandbox runtime metrics",
+				zap.Error(err),
+				zap.Int("matched", result.Matched),
+				zap.Int("received", result.StatsReceived),
+				zap.Int("failed", result.Failed),
+			)
 		} else if result.Dropped > 0 {
 			c.logger.Warn("Dropped sandbox runtime metric samples", zap.Int("dropped", result.Dropped))
 		}
-
-		timer := time.NewTimer(c.nextDelay())
-		select {
-		case <-ctx.Done():
-			if !timer.Stop() {
-				<-timer.C
-			}
+		if ctx.Err() != nil {
 			return
-		case <-timer.C:
+		}
+		if elapsed > cycleInterval {
+			c.logger.Warn("Sandbox runtime metric collection exceeded its sampling window",
+				zap.Duration("duration", elapsed),
+				zap.Duration("sample_interval", cycleInterval),
+				zap.Int("matched", result.Matched),
+				zap.Int("max_concurrency", c.maxConcurrency),
+			)
+		} else {
+			c.logger.Debug("Collected sandbox runtime metrics",
+				zap.Duration("duration", elapsed),
+				zap.Int("matched", result.Matched),
+				zap.Int("enqueued", result.Enqueued),
+				zap.Int("failed", result.Failed),
+			)
+		}
+
+		if !waitFor(ctx, cycleInterval-elapsed) {
+			return
 		}
 	}
 }
 
-// Collect projects one bulk CRI snapshot against the current node pod cache.
+// Collect immediately collects all current sandbox samples with bounded concurrency.
 func (c *Collector) Collect(ctx context.Context) (CollectResult, error) {
+	return c.collect(ctx, 0)
+}
+
+func (c *Collector) collect(ctx context.Context, spreadWindow time.Duration) (CollectResult, error) {
 	if c == nil {
 		return CollectResult{}, fmt.Errorf("collector is nil")
 	}
@@ -147,44 +186,150 @@ func (c *Collector) Collect(ctx context.Context) (CollectResult, error) {
 	if err != nil {
 		return CollectResult{}, err
 	}
-	stats, err := c.statsClient.ListPodSandboxStats(ctx)
+	sandboxes, err := c.statsClient.ListPodSandboxes(ctx)
 	if err != nil {
-		return CollectResult{}, fmt.Errorf("list CRI pod sandbox stats: %w", err)
+		return CollectResult{}, fmt.Errorf("list CRI pod sandboxes: %w", err)
 	}
-	result := CollectResult{StatsReceived: len(stats)}
-	collectedAt := c.now().UTC()
+	targets := matchedSandboxTargets(identities, sandboxes)
+	result := CollectResult{Matched: len(targets)}
 	activeCPUSeries := make(map[cpuSeriesKey]struct{})
 	if c.cpuUsage == nil {
 		c.cpuUsage = &cpuUsageTracker{}
 	}
-	for _, item := range stats {
-		if item == nil {
-			continue
-		}
-		identity, ok := identities.resolve(item.Attributes)
-		if !ok {
-			continue
-		}
-		var derivedCPUUsage *float64
-		if key, valid := cpuSeriesKeyFor(identity, item.Attributes); valid {
+	for _, target := range targets {
+		attributes := &runtimeapi.PodSandboxAttributes{Id: target.id}
+		if key, valid := cpuSeriesKeyFor(target.identity, attributes); valid {
 			activeCPUSeries[key] = struct{}{}
-			if item.Linux != nil {
-				derivedCPUUsage = c.cpuUsage.observe(key, item.Linux.Cpu)
-			}
-		}
-		sample, ok := projectRuntimeSample(identity, item, c.regionID, c.clusterID, collectedAt, derivedCPUUsage)
-		if !ok {
-			continue
-		}
-		result.Matched++
-		if c.sink.TryEnqueue(sample) {
-			result.Enqueued++
-		} else {
-			result.Dropped++
 		}
 	}
+
+	var resultMu sync.Mutex
+	var firstErr error
+	semaphore := make(chan struct{}, c.maxConcurrency)
+	var wg sync.WaitGroup
+	startedAt := time.Now()
+dispatch:
+	for index, target := range targets {
+		if spreadWindow > 0 && !waitUntil(ctx, startedAt.Add(cycleOffset(index, len(targets), spreadWindow))) {
+			break
+		}
+		select {
+		case semaphore <- struct{}{}:
+		case <-ctx.Done():
+			break dispatch
+		}
+		wg.Add(1)
+		go func(target sandboxTarget) {
+			defer wg.Done()
+			defer func() { <-semaphore }()
+			statsCtx, cancel := context.WithTimeout(ctx, c.interval)
+			stats, statsErr := c.statsClient.PodSandboxStats(statsCtx, target.id)
+			cancel()
+			if statsErr != nil {
+				resultMu.Lock()
+				result.Failed++
+				if firstErr == nil {
+					firstErr = fmt.Errorf("collect CRI pod sandbox %s stats: %w", target.id, statsErr)
+				}
+				resultMu.Unlock()
+				return
+			}
+			if stats == nil {
+				resultMu.Lock()
+				result.Failed++
+				if firstErr == nil {
+					firstErr = fmt.Errorf("collect CRI pod sandbox %s stats: empty response", target.id)
+				}
+				resultMu.Unlock()
+				return
+			}
+
+			var derivedCPUUsage *float64
+			if key, valid := cpuSeriesKeyFor(target.identity, stats.Attributes); valid && stats.Linux != nil {
+				derivedCPUUsage = c.cpuUsage.observe(key, stats.Linux.Cpu)
+			}
+			sample, ok := projectRuntimeSample(target.identity, stats, c.regionID, c.clusterID, c.now().UTC(), derivedCPUUsage)
+			resultMu.Lock()
+			defer resultMu.Unlock()
+			result.StatsReceived++
+			if !ok {
+				result.Failed++
+				if firstErr == nil {
+					firstErr = fmt.Errorf("project CRI pod sandbox %s stats: missing runtime identity", target.id)
+				}
+				return
+			}
+			if c.sink.TryEnqueue(sample) {
+				result.Enqueued++
+			} else {
+				result.Dropped++
+			}
+		}(target)
+	}
+	wg.Wait()
 	c.cpuUsage.prune(activeCPUSeries)
-	return result, nil
+	if firstErr != nil {
+		return result, fmt.Errorf("%d sandbox runtime metric collection(s) failed; first error: %w", result.Failed, firstErr)
+	}
+	return result, ctx.Err()
+}
+
+func matchedSandboxTargets(identities identityIndex, sandboxes []*runtimeapi.PodSandbox) []sandboxTarget {
+	targets := make([]sandboxTarget, 0, len(sandboxes))
+	seen := make(map[string]struct{}, len(sandboxes))
+	for _, sandbox := range sandboxes {
+		if sandbox == nil || sandbox.Id == "" || sandbox.Metadata == nil {
+			continue
+		}
+		if _, ok := seen[sandbox.Id]; ok {
+			continue
+		}
+		identity, ok := identities.resolve(&runtimeapi.PodSandboxAttributes{Metadata: sandbox.Metadata})
+		if !ok {
+			continue
+		}
+		seen[sandbox.Id] = struct{}{}
+		targets = append(targets, sandboxTarget{id: sandbox.Id, identity: identity})
+	}
+	sort.Slice(targets, func(i, j int) bool {
+		left, right := targetOrder(targets[i].id), targetOrder(targets[j].id)
+		if left == right {
+			return targets[i].id < targets[j].id
+		}
+		return left < right
+	})
+	return targets
+}
+
+func targetOrder(id string) uint64 {
+	hash := fnv.New64a()
+	_, _ = hash.Write([]byte(id))
+	return hash.Sum64()
+}
+
+func cycleOffset(index, total int, interval time.Duration) time.Duration {
+	if index <= 0 || total <= 0 || interval <= 0 {
+		return 0
+	}
+	return time.Duration(index) * interval / time.Duration(total)
+}
+
+func waitUntil(ctx context.Context, deadline time.Time) bool {
+	return waitFor(ctx, time.Until(deadline))
+}
+
+func waitFor(ctx context.Context, delay time.Duration) bool {
+	if delay <= 0 {
+		return ctx.Err() == nil
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
 }
 
 func (c *Collector) nextDelay() time.Duration {

--- a/ctld/internal/ctld/runtimemetrics/collector_test.go
+++ b/ctld/internal/ctld/runtimemetrics/collector_test.go
@@ -15,14 +15,21 @@ import (
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
-func TestCollectorUsesOneBulkCallAndEnqueuesMatchedSandboxes(t *testing.T) {
+func TestCollectorUsesFilteredStatsCallsAndEnqueuesMatchedSandboxes(t *testing.T) {
 	podA := runtimeMetricPod("ns-a", "pod-a", "pod-uid-a", "node-a", "team-a", "sandbox-a", "2")
 	podB := runtimeMetricPod("ns-a", "pod-b", "pod-uid-b", "node-a", "team-a", "sandbox-b", "3")
-	client := &fakeStatsClient{stats: []*runtimeapi.PodSandboxStats{
-		minimalPodStats("cri-a", "ns-a", "pod-a", "pod-uid-a"),
-		minimalPodStats("cri-b", "ns-a", "pod-b", "pod-uid-b"),
-		minimalPodStats("cri-other", "ns-a", "other", "pod-uid-other"),
-	}}
+	client := &fakeStatsClient{
+		sandboxes: []*runtimeapi.PodSandbox{
+			podSandbox("cri-a", "ns-a", "pod-a", "pod-uid-a"),
+			podSandbox("cri-b", "ns-a", "pod-b", "pod-uid-b"),
+			podSandbox("cri-other", "ns-a", "other", "pod-uid-other"),
+		},
+		statsByID: map[string]*runtimeapi.PodSandboxStats{
+			"cri-a":     minimalPodStats("cri-a", "ns-a", "pod-a", "pod-uid-a"),
+			"cri-b":     minimalPodStats("cri-b", "ns-a", "pod-b", "pod-uid-b"),
+			"cri-other": minimalPodStats("cri-other", "ns-a", "other", "pod-uid-other"),
+		},
+	}
 	sink := &recordingSampleSink{}
 	collector, err := NewCollector(CollectorConfig{
 		RegionID: "region-a", ClusterID: "cluster-a", NodeName: "node-a",
@@ -33,11 +40,11 @@ func TestCollectorUsesOneBulkCallAndEnqueuesMatchedSandboxes(t *testing.T) {
 
 	result, err := collector.Collect(context.Background())
 	require.NoError(t, err)
-	assert.Equal(t, 1, client.calls)
-	assert.Equal(t, CollectResult{StatsReceived: 3, Matched: 2, Enqueued: 2}, result)
+	assert.Equal(t, 1, client.listCalls)
+	assert.ElementsMatch(t, []string{"cri-a", "cri-b"}, client.statsCalls)
+	assert.Equal(t, CollectResult{StatsReceived: 2, Matched: 2, Enqueued: 2}, result)
 	require.Len(t, sink.samples, 2)
-	assert.Equal(t, "sandbox-a", sink.samples[0].SandboxID)
-	assert.Equal(t, "sandbox-b", sink.samples[1].SandboxID)
+	assert.ElementsMatch(t, []string{"sandbox-a", "sandbox-b"}, []string{sink.samples[0].SandboxID, sink.samples[1].SandboxID})
 }
 
 func TestCollectorDerivesCPUUsageFromLinuxCumulativeStats(t *testing.T) {
@@ -45,9 +52,12 @@ func TestCollectorDerivesCPUUsageFromLinuxCumulativeStats(t *testing.T) {
 	pod.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
 		corev1.ResourceCPU: resource.MustParse("2"),
 	}
-	client := &fakeStatsClient{stats: []*runtimeapi.PodSandboxStats{
-		cpuOnlyPodStats("cri-a", "ns-a", "pod-a", "pod-uid-a", 10_000_000_000, 10_000_000_000),
-	}}
+	client := &fakeStatsClient{
+		sandboxes: []*runtimeapi.PodSandbox{podSandbox("cri-a", "ns-a", "pod-a", "pod-uid-a")},
+		statsByID: map[string]*runtimeapi.PodSandboxStats{
+			"cri-a": cpuOnlyPodStats("cri-a", "ns-a", "pod-a", "pod-uid-a", 10_000_000_000, 10_000_000_000),
+		},
+	}
 	sink := &recordingSampleSink{}
 	collector, err := NewCollector(CollectorConfig{
 		RegionID: "region-a", ClusterID: "cluster-a", NodeName: "node-a",
@@ -61,9 +71,7 @@ func TestCollectorDerivesCPUUsageFromLinuxCumulativeStats(t *testing.T) {
 	assert.Nil(t, sink.samples[0].CPU.Usage)
 	assertMissing(t, sink.samples[0].Missing, sandboxobservability.RuntimeMetricCPUUsage, nil)
 
-	client.setStats([]*runtimeapi.PodSandboxStats{
-		cpuOnlyPodStats("cri-a", "ns-a", "pod-a", "pod-uid-a", 20_000_000_000, 15_000_000_000),
-	})
+	client.setStats("cri-a", cpuOnlyPodStats("cri-a", "ns-a", "pod-a", "pod-uid-a", 20_000_000_000, 15_000_000_000))
 	_, err = collector.Collect(context.Background())
 	require.NoError(t, err)
 	require.Len(t, sink.samples, 2)
@@ -76,8 +84,8 @@ func TestCollectorDerivesCPUUsageFromLinuxCumulativeStats(t *testing.T) {
 	assertNotMissing(t, second.Missing, sandboxobservability.RuntimeMetricCPUUtilization, nil)
 }
 
-func TestCollectorReportsCRIErrorWithoutEnqueuing(t *testing.T) {
-	client := &fakeStatsClient{err: errors.New("containerd unavailable")}
+func TestCollectorReportsCRIListErrorWithoutEnqueuing(t *testing.T) {
+	client := &fakeStatsClient{listErr: errors.New("containerd unavailable")}
 	sink := &recordingSampleSink{}
 	collector, err := NewCollector(CollectorConfig{
 		StatsClient: client,
@@ -88,17 +96,46 @@ func TestCollectorReportsCRIErrorWithoutEnqueuing(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = collector.Collect(context.Background())
-	require.ErrorContains(t, err, "list CRI pod sandbox stats")
+	require.ErrorContains(t, err, "list CRI pod sandboxes")
 	assert.Empty(t, sink.samples)
+}
+
+func TestCollectorContinuesAfterOneSandboxStatsError(t *testing.T) {
+	podA := runtimeMetricPod("ns-a", "pod-a", "uid-a", "node-a", "team-a", "sandbox-a", "1")
+	podB := runtimeMetricPod("ns-a", "pod-b", "uid-b", "node-a", "team-a", "sandbox-b", "1")
+	client := &fakeStatsClient{
+		sandboxes: []*runtimeapi.PodSandbox{
+			podSandbox("cri-a", "ns-a", "pod-a", "uid-a"),
+			podSandbox("cri-b", "ns-a", "pod-b", "uid-b"),
+		},
+		statsByID: map[string]*runtimeapi.PodSandboxStats{
+			"cri-b": minimalPodStats("cri-b", "ns-a", "pod-b", "uid-b"),
+		},
+		statsErrByID: map[string]error{"cri-a": errors.New("stats unavailable")},
+	}
+	sink := &recordingSampleSink{}
+	collector, err := NewCollector(CollectorConfig{
+		StatsClient: client, PodLister: podLister(t, podA, podB), Sink: sink, NodeName: "node-a",
+	})
+	require.NoError(t, err)
+
+	result, err := collector.Collect(context.Background())
+	require.ErrorContains(t, err, "1 sandbox runtime metric collection(s) failed")
+	assert.Equal(t, CollectResult{StatsReceived: 1, Matched: 2, Enqueued: 1, Failed: 1}, result)
+	require.Len(t, sink.samples, 1)
+	assert.Equal(t, "sandbox-b", sink.samples[0].SandboxID)
 }
 
 func TestCollectorCountsFullQueueDrops(t *testing.T) {
 	sink := &recordingSampleSink{accept: func(sandboxobservability.RuntimeSample) bool { return false }}
 	collector, err := NewCollector(CollectorConfig{
-		StatsClient: &fakeStatsClient{stats: []*runtimeapi.PodSandboxStats{minimalPodStats("cri-a", "ns-a", "pod-a", "uid-a")}},
-		PodLister:   podLister(t, runtimeMetricPod("ns-a", "pod-a", "uid-a", "node-a", "team-a", "sandbox-a", "1")),
-		Sink:        sink,
-		NodeName:    "node-a",
+		StatsClient: &fakeStatsClient{
+			sandboxes: []*runtimeapi.PodSandbox{podSandbox("cri-a", "ns-a", "pod-a", "uid-a")},
+			statsByID: map[string]*runtimeapi.PodSandboxStats{"cri-a": minimalPodStats("cri-a", "ns-a", "pod-a", "uid-a")},
+		},
+		PodLister: podLister(t, runtimeMetricPod("ns-a", "pod-a", "uid-a", "node-a", "team-a", "sandbox-a", "1")),
+		Sink:      sink,
+		NodeName:  "node-a",
 	})
 	require.NoError(t, err)
 
@@ -108,13 +145,65 @@ func TestCollectorCountsFullQueueDrops(t *testing.T) {
 	assert.Zero(t, result.Enqueued)
 }
 
+func TestCollectorBoundsConcurrentStatsCalls(t *testing.T) {
+	const sandboxCount = 6
+	release := make(chan struct{})
+	started := make(chan string, sandboxCount)
+	client := &fakeStatsClient{
+		statsByID: make(map[string]*runtimeapi.PodSandboxStats, sandboxCount),
+		block:     release,
+		onCall:    func(id string) { started <- id },
+	}
+	pods := make([]*corev1.Pod, 0, sandboxCount)
+	for i := 0; i < sandboxCount; i++ {
+		id := string(rune('a' + i))
+		uid := "uid-" + id
+		name := "pod-" + id
+		criID := "cri-" + id
+		pods = append(pods, runtimeMetricPod("ns-a", name, uid, "node-a", "team-a", "sandbox-"+id, "1"))
+		client.sandboxes = append(client.sandboxes, podSandbox(criID, "ns-a", name, uid))
+		client.statsByID[criID] = minimalPodStats(criID, "ns-a", name, uid)
+	}
+	collector, err := NewCollector(CollectorConfig{
+		StatsClient: client, PodLister: podLister(t, pods...), Sink: &recordingSampleSink{}, NodeName: "node-a", MaxConcurrency: 2,
+	})
+	require.NoError(t, err)
+
+	done := make(chan error, 1)
+	go func() {
+		_, collectErr := collector.Collect(context.Background())
+		done <- collectErr
+	}()
+	for i := 0; i < 2; i++ {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatal("collector did not start the expected concurrent stats calls")
+		}
+	}
+	select {
+	case id := <-started:
+		t.Fatalf("collector exceeded max concurrency with %s", id)
+	case <-time.After(30 * time.Millisecond):
+	}
+	close(release)
+	require.NoError(t, <-done)
+	assert.LessOrEqual(t, client.maxActive, 2)
+}
+
 func TestCollectorRunCollectsImmediately(t *testing.T) {
 	called := make(chan struct{}, 1)
-	client := &fakeStatsClient{onCall: func() { called <- struct{}{} }}
+	pod := runtimeMetricPod("ns-a", "pod-a", "uid-a", "node-a", "team-a", "sandbox-a", "1")
+	client := &fakeStatsClient{
+		sandboxes: []*runtimeapi.PodSandbox{podSandbox("cri-a", "ns-a", "pod-a", "uid-a")},
+		statsByID: map[string]*runtimeapi.PodSandboxStats{"cri-a": minimalPodStats("cri-a", "ns-a", "pod-a", "uid-a")},
+		onCall:    func(string) { called <- struct{}{} },
+	}
 	collector, err := NewCollector(CollectorConfig{
 		StatsClient: client,
-		PodLister:   podLister(t),
+		PodLister:   podLister(t, pod),
 		Sink:        &recordingSampleSink{},
+		NodeName:    "node-a",
 		Interval:    time.Hour,
 		Random:      func() float64 { return 0.5 },
 	})
@@ -149,6 +238,13 @@ func TestCollectorJitterIsBounded(t *testing.T) {
 	assert.Equal(t, 15*time.Second, collector.nextDelay())
 }
 
+func TestCycleOffsetSpreadsTargetsAcrossWindow(t *testing.T) {
+	assert.Equal(t, time.Duration(0), cycleOffset(0, 4, 100*time.Millisecond))
+	assert.Equal(t, 25*time.Millisecond, cycleOffset(1, 4, 100*time.Millisecond))
+	assert.Equal(t, 50*time.Millisecond, cycleOffset(2, 4, 100*time.Millisecond))
+	assert.Equal(t, 75*time.Millisecond, cycleOffset(3, 4, 100*time.Millisecond))
+}
+
 func TestCollectorUsesSharedRuntimeSampleCadenceDefaults(t *testing.T) {
 	collector, err := NewCollector(CollectorConfig{
 		StatsClient: &fakeStatsClient{},
@@ -159,6 +255,15 @@ func TestCollectorUsesSharedRuntimeSampleCadenceDefaults(t *testing.T) {
 
 	assert.Equal(t, sandboxobservability.DefaultRuntimeSampleInterval, collector.interval)
 	assert.Equal(t, sandboxobservability.DefaultRuntimeSampleJitter, collector.jitter)
+	assert.Equal(t, sandboxobservability.DefaultRuntimeSampleMaxConcurrency, collector.maxConcurrency)
+}
+
+func podSandbox(id, namespace, name, uid string) *runtimeapi.PodSandbox {
+	return &runtimeapi.PodSandbox{
+		Id:       id,
+		Metadata: &runtimeapi.PodSandboxMetadata{Namespace: namespace, Name: name, Uid: uid},
+		State:    runtimeapi.PodSandboxState_SANDBOX_READY,
+	}
 }
 
 func minimalPodStats(epoch, namespace, name, uid string) *runtimeapi.PodSandboxStats {
@@ -181,30 +286,63 @@ func cpuOnlyPodStats(epoch, namespace, name, uid string, timestamp int64, cumula
 }
 
 type fakeStatsClient struct {
-	mu     sync.Mutex
-	stats  []*runtimeapi.PodSandboxStats
-	err    error
-	calls  int
-	onCall func()
+	mu           sync.Mutex
+	sandboxes    []*runtimeapi.PodSandbox
+	statsByID    map[string]*runtimeapi.PodSandboxStats
+	statsErrByID map[string]error
+	listErr      error
+	listCalls    int
+	statsCalls   []string
+	onCall       func(string)
+	block        <-chan struct{}
+	active       int
+	maxActive    int
 }
 
-func (c *fakeStatsClient) ListPodSandboxStats(context.Context) ([]*runtimeapi.PodSandboxStats, error) {
+func (c *fakeStatsClient) ListPodSandboxes(context.Context) ([]*runtimeapi.PodSandbox, error) {
 	c.mu.Lock()
-	c.calls++
+	defer c.mu.Unlock()
+	c.listCalls++
+	return append([]*runtimeapi.PodSandbox(nil), c.sandboxes...), c.listErr
+}
+
+func (c *fakeStatsClient) PodSandboxStats(ctx context.Context, id string) (*runtimeapi.PodSandboxStats, error) {
+	c.mu.Lock()
+	c.statsCalls = append(c.statsCalls, id)
+	c.active++
+	if c.active > c.maxActive {
+		c.maxActive = c.active
+	}
 	onCall := c.onCall
-	stats := c.stats
-	err := c.err
+	block := c.block
+	stats := c.statsByID[id]
+	err := c.statsErrByID[id]
 	c.mu.Unlock()
+	defer func() {
+		c.mu.Lock()
+		c.active--
+		c.mu.Unlock()
+	}()
 	if onCall != nil {
-		onCall()
+		onCall(id)
+	}
+	if block != nil {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-block:
+		}
 	}
 	return stats, err
 }
 
-func (c *fakeStatsClient) setStats(stats []*runtimeapi.PodSandboxStats) {
+func (c *fakeStatsClient) setStats(id string, stats *runtimeapi.PodSandboxStats) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.stats = stats
+	if c.statsByID == nil {
+		c.statsByID = make(map[string]*runtimeapi.PodSandboxStats)
+	}
+	c.statsByID[id] = stats
 }
 
 type recordingSampleSink struct {

--- a/infra-operator/api/config/ctld.go
+++ b/infra-operator/api/config/ctld.go
@@ -19,12 +19,13 @@ type CtldConfig struct {
 	SandboxObservabilityIngestQueueSize         int    `yaml:"sandbox_observability_ingest_queue_size" json:"-"`
 	SandboxObservabilityIngestBatchSize         int    `yaml:"sandbox_observability_ingest_batch_size" json:"-"`
 
-	SandboxObservabilityIngestFlushInterval   metav1.Duration `yaml:"sandbox_observability_ingest_flush_interval" json:"-"`
-	SandboxObservabilityIngestRequestTimeout  metav1.Duration `yaml:"sandbox_observability_ingest_request_timeout" json:"-"`
-	SandboxObservabilityIngestMaxRetries      int             `yaml:"sandbox_observability_ingest_max_retries" json:"-"`
-	SandboxObservabilityIngestRetryBackoff    metav1.Duration `yaml:"sandbox_observability_ingest_retry_backoff" json:"-"`
-	SandboxObservabilityRuntimeSampleInterval metav1.Duration `yaml:"sandbox_observability_runtime_sample_interval" json:"-"`
-	SandboxObservabilityRuntimeSampleJitter   metav1.Duration `yaml:"sandbox_observability_runtime_sample_jitter" json:"-"`
+	SandboxObservabilityIngestFlushInterval         metav1.Duration `yaml:"sandbox_observability_ingest_flush_interval" json:"-"`
+	SandboxObservabilityIngestRequestTimeout        metav1.Duration `yaml:"sandbox_observability_ingest_request_timeout" json:"-"`
+	SandboxObservabilityIngestMaxRetries            int             `yaml:"sandbox_observability_ingest_max_retries" json:"-"`
+	SandboxObservabilityIngestRetryBackoff          metav1.Duration `yaml:"sandbox_observability_ingest_retry_backoff" json:"-"`
+	SandboxObservabilityRuntimeSampleInterval       metav1.Duration `yaml:"sandbox_observability_runtime_sample_interval" json:"-"`
+	SandboxObservabilityRuntimeSampleJitter         metav1.Duration `yaml:"sandbox_observability_runtime_sample_jitter" json:"-"`
+	SandboxObservabilityRuntimeSampleMaxConcurrency int             `yaml:"sandbox_observability_runtime_sample_max_concurrency" json:"-"`
 }
 
 // LoadCtldConfig loads the shared ctld configuration file.
@@ -92,5 +93,8 @@ func applyCtldDefaults(cfg *CtldConfig) {
 	}
 	if cfg.SandboxObservabilityRuntimeSampleJitter.Duration <= 0 {
 		cfg.SandboxObservabilityRuntimeSampleJitter.Duration = sandboxobservability.DefaultRuntimeSampleJitter
+	}
+	if cfg.SandboxObservabilityRuntimeSampleMaxConcurrency <= 0 {
+		cfg.SandboxObservabilityRuntimeSampleMaxConcurrency = sandboxobservability.DefaultRuntimeSampleMaxConcurrency
 	}
 }

--- a/infra-operator/api/config/ctld_test.go
+++ b/infra-operator/api/config/ctld_test.go
@@ -31,6 +31,7 @@ sandbox_observability_runtime_sample_interval:
   duration: 20s
 sandbox_observability_runtime_sample_jitter:
   duration: 2s
+sandbox_observability_runtime_sample_max_concurrency: 7
 `), 0o600))
 
 	cfg, err := loadCtldConfig(path)
@@ -46,6 +47,7 @@ sandbox_observability_runtime_sample_jitter:
 	assert.Equal(t, 250*time.Millisecond, cfg.SandboxObservabilityIngestRetryBackoff.Duration)
 	assert.Equal(t, 20*time.Second, cfg.SandboxObservabilityRuntimeSampleInterval.Duration)
 	assert.Equal(t, 2*time.Second, cfg.SandboxObservabilityRuntimeSampleJitter.Duration)
+	assert.Equal(t, 7, cfg.SandboxObservabilityRuntimeSampleMaxConcurrency)
 }
 
 func TestLoadCtldConfigAppliesProducerDefaults(t *testing.T) {
@@ -59,6 +61,7 @@ func TestLoadCtldConfigAppliesProducerDefaults(t *testing.T) {
 	assert.Equal(t, 100*time.Millisecond, cfg.SandboxObservabilityIngestRetryBackoff.Duration)
 	assert.Equal(t, sandboxobservability.DefaultRuntimeSampleInterval, cfg.SandboxObservabilityRuntimeSampleInterval.Duration)
 	assert.Equal(t, sandboxobservability.DefaultRuntimeSampleJitter, cfg.SandboxObservabilityRuntimeSampleJitter.Duration)
+	assert.Equal(t, sandboxobservability.DefaultRuntimeSampleMaxConcurrency, cfg.SandboxObservabilityRuntimeSampleMaxConcurrency)
 }
 
 func TestLoadCtldConfigPreservesStorageProxyLoaderValues(t *testing.T) {

--- a/pkg/sandboxobservability/runtime_defaults.go
+++ b/pkg/sandboxobservability/runtime_defaults.go
@@ -7,4 +7,6 @@ const (
 	DefaultRuntimeSampleInterval = 15 * time.Second
 	// DefaultRuntimeSampleJitter spreads node-local CRI collection across the interval.
 	DefaultRuntimeSampleJitter = 1500 * time.Millisecond
+	// DefaultRuntimeSampleMaxConcurrency bounds concurrent CRI stats calls per node.
+	DefaultRuntimeSampleMaxConcurrency = 4
 )


### PR DESCRIPTION
## Summary

- replace the unfiltered node-wide `ListPodSandboxStats` call with cheap ready-sandbox discovery plus per-sandbox `PodSandboxStats` requests
- filter unmatched idle/system sandboxes before requesting stats
- spread active sandbox samples across each 15-second window and bound CRI stats concurrency to 4 by default
- keep partial samples when one sandbox stats request fails and expose collection overrun details in logs

## Why

At high density, the bulk CRI request fans out one stats operation per ready sandbox. With gVisor each operation forks `runsc events --stats`, producing hundreds of simultaneous processes and periodic node CPU saturation. This change preserves the runtime metric catalog and sampling target while removing the ctld-triggered thundering herd.

## Validation

- `go test -race ./ctld/internal/ctld/runtimemetrics ./ctld/internal/ctld/rootfs ./ctld/cmd/ctld ./infra-operator/api/config`
- `go test ./ctld/...`
- `go test ./infra-operator/...`
- `go vet ./ctld/... ./infra-operator/... ./pkg/sandboxobservability/...`
- `make proto manifests apispec` followed by a clean generated-artifact diff
- `GOFLAGS=-buildvcs=false make build ctld`

A local full `go test ./...` passed all ordinary packages; the scenario e2e package could not start because `kind` is not installed locally and is left to PR CI.