### PR TITLE
fix(cluster-gateway): preserve mounts in sandbox detail responses

### DIFF
--- a/cluster-gateway/pkg/http/handlers_sandbox.go
+++ b/cluster-gateway/pkg/http/handlers_sandbox.go
@@ -86,7 +86,7 @@ func (s *Server) getSandbox(c *gin.Context) {
 		return
 	}
 
-	payload := sharedssh.SandboxToAPI(sandbox, sharedssh.BuildConnectionInfo(s.cfg.SSHEndpointHost, s.cfg.SSHEndpointPort, sandbox.ID))
+	payload := sandboxToAPI(sandbox, sharedssh.BuildConnectionInfo(s.cfg.SSHEndpointHost, s.cfg.SSHEndpointPort, sandbox.ID))
 	spec.JSONSuccess(c, http.StatusOK, payload)
 }
 

--- a/cluster-gateway/pkg/http/sandbox_response.go
+++ b/cluster-gateway/pkg/http/sandbox_response.go
@@ -1,13 +1,14 @@
-package sshgateway
+package http
 
 import (
 	mgr "github.com/sandbox0-ai/sandbox0/manager/pkg/service"
 	"github.com/sandbox0-ai/sandbox0/pkg/apispec"
+	sharedssh "github.com/sandbox0-ai/sandbox0/pkg/sshgateway"
 )
 
-// SandboxToAPI converts a manager sandbox record into the public API payload
-// shape and optionally attaches SSH connection information.
-func SandboxToAPI(sandbox *mgr.Sandbox, sshInfo *ConnectionInfo) *apispec.Sandbox {
+// sandboxToAPI removes manager-only runtime fields while preserving the public
+// sandbox detail contract and optionally attaching cluster-scoped SSH details.
+func sandboxToAPI(sandbox *mgr.Sandbox, sshInfo *sharedssh.ConnectionInfo) *apispec.Sandbox {
 	if sandbox == nil {
 		return nil
 	}
@@ -33,6 +34,16 @@ func SandboxToAPI(sandbox *mgr.Sandbox, sshInfo *ConnectionInfo) *apispec.Sandbo
 	if sandbox.Resources != nil && sandbox.Resources.Memory != "" {
 		memory := sandbox.Resources.Memory
 		payload.Resources = &apispec.SandboxResourceConfig{Memory: &memory}
+	}
+	if sandbox.Mounts != nil {
+		mounts := make([]apispec.ClaimMountRequest, len(sandbox.Mounts))
+		for i, mount := range sandbox.Mounts {
+			mounts[i] = apispec.ClaimMountRequest{
+				MountPoint:      mount.MountPoint,
+				SandboxvolumeId: mount.SandboxVolumeID,
+			}
+		}
+		payload.Mounts = &mounts
 	}
 	if sshInfo != nil {
 		payload.Ssh = &apispec.SandboxSSHConnection{

--- a/cluster-gateway/pkg/http/sandbox_response_test.go
+++ b/cluster-gateway/pkg/http/sandbox_response_test.go
@@ -1,0 +1,61 @@
+package http
+
+import (
+	"testing"
+	"time"
+
+	mgr "github.com/sandbox0-ai/sandbox0/manager/pkg/service"
+	sharedssh "github.com/sandbox0-ai/sandbox0/pkg/sshgateway"
+)
+
+func TestSandboxToAPIPreservesPublicDetailFields(t *testing.T) {
+	now := time.Now().UTC()
+	sandbox := &mgr.Sandbox{
+		ID:         "sb_123",
+		TemplateID: "default",
+		TeamID:     "team-1",
+		UserID:     "user-1",
+		Status:     "running",
+		PodName:    "pod-1",
+		AutoResume: true,
+		Paused:     false,
+		Resources:  &mgr.SandboxResourceConfig{Memory: "512Mi"},
+		Mounts: []mgr.ClaimMount{
+			{
+				SandboxVolumeID: "volume-1",
+				MountPoint:      "/workspace",
+			},
+		},
+		ClaimedAt:     now,
+		CreatedAt:     now,
+		ExpiresAt:     now,
+		HardExpiresAt: now,
+	}
+
+	payload := sandboxToAPI(sandbox, sharedssh.BuildConnectionInfo("aws-us-east-1.ssh.sandbox0.app", 30222, sandbox.ID))
+	if payload == nil {
+		t.Fatal("expected payload")
+	}
+	if payload.Ssh == nil {
+		t.Fatal("expected SSH connection")
+	}
+	if payload.Ssh.Host != "aws-us-east-1.ssh.sandbox0.app" {
+		t.Fatalf("ssh host = %q", payload.Ssh.Host)
+	}
+	if payload.Ssh.Port != 30222 {
+		t.Fatalf("ssh port = %d", payload.Ssh.Port)
+	}
+	if payload.Ssh.Username != sandbox.ID {
+		t.Fatalf("ssh username = %q", payload.Ssh.Username)
+	}
+	if payload.Resources == nil || payload.Resources.Memory == nil || *payload.Resources.Memory != "512Mi" {
+		t.Fatalf("resources = %#v, want memory 512Mi", payload.Resources)
+	}
+	if payload.Mounts == nil || len(*payload.Mounts) != 1 {
+		t.Fatalf("mounts = %#v, want one mount", payload.Mounts)
+	}
+	mount := (*payload.Mounts)[0]
+	if mount.SandboxvolumeId != "volume-1" || mount.MountPoint != "/workspace" {
+		t.Fatalf("mount = %#v, want volume-1 at /workspace", mount)
+	}
+}

--- a/pkg/sshgateway/connection_test.go
+++ b/pkg/sshgateway/connection_test.go
@@ -2,9 +2,6 @@ package sshgateway
 
 import (
 	"testing"
-	"time"
-
-	mgr "github.com/sandbox0-ai/sandbox0/manager/pkg/service"
 )
 
 func TestBuildConnectionInfo(t *testing.T) {
@@ -20,44 +17,5 @@ func TestBuildConnectionInfo(t *testing.T) {
 	}
 	if info.Username != "sb_123" {
 		t.Fatalf("username = %q", info.Username)
-	}
-}
-
-func TestSandboxToAPIIncludesSSHInfo(t *testing.T) {
-	now := time.Now().UTC()
-	sandbox := &mgr.Sandbox{
-		ID:            "sb_123",
-		TemplateID:    "default",
-		TeamID:        "team-1",
-		UserID:        "user-1",
-		Status:        "running",
-		PodName:       "pod-1",
-		AutoResume:    true,
-		Paused:        false,
-		Resources:     &mgr.SandboxResourceConfig{Memory: "512Mi"},
-		ClaimedAt:     now,
-		CreatedAt:     now,
-		ExpiresAt:     now,
-		HardExpiresAt: now,
-	}
-
-	payload := SandboxToAPI(sandbox, BuildConnectionInfo("aws-us-east-1.ssh.sandbox0.app", 30222, sandbox.ID))
-	if payload == nil {
-		t.Fatal("expected payload")
-	}
-	if payload.Ssh == nil {
-		t.Fatal("expected ssh payload")
-	}
-	if payload.Ssh.Host != "aws-us-east-1.ssh.sandbox0.app" {
-		t.Fatalf("ssh host = %q", payload.Ssh.Host)
-	}
-	if payload.Ssh.Port != 30222 {
-		t.Fatalf("ssh port = %d", payload.Ssh.Port)
-	}
-	if payload.Ssh.Username != sandbox.ID {
-		t.Fatalf("ssh username = %q", payload.Ssh.Username)
-	}
-	if payload.Resources == nil || payload.Resources.Memory == nil || *payload.Resources.Memory != "512Mi" {
-		t.Fatalf("resources = %#v, want memory 512Mi", payload.Resources)
 	}
 }


### PR DESCRIPTION
## Summary

- move the manager-to-public sandbox detail projection from `pkg/sshgateway` into `cluster-gateway/pkg/http`
- keep `pkg/sshgateway` focused on SSH connection information
- preserve `sandboxvolume_id` and `mount_point` when projecting mounted volumes
- consolidate SSH, resource, and mount projection coverage under cluster-gateway

## Why

Dashboard does not route through the SSH gateway. It consumes `GET /api/v1/sandboxes/{id}` through the regional and cluster gateways. The cluster-gateway handler used a full sandbox response mapper that happened to live in `pkg/sshgateway`; that mapper omitted `mounts`, so the public response reported no bindings even while the runtime pod had a SandboxVolume mounted.

The response mapper now lives with the cluster-gateway handler that owns this public projection. The SSH package only supplies the optional connection information attached by that handler.

## Testing

- `go test ./cluster-gateway/... ./pkg/sshgateway`
- `go test ./regional-gateway/...`
