### PR TITLE
fix(storage): preserve POSIX errno through volume portals

### DIFF
--- a/ctld/internal/ctld/portal/rootfs_session.go
+++ b/ctld/internal/ctld/portal/rootfs_session.go
@@ -267,7 +267,7 @@ func (s *rootFSBackedSession) Unlink(_ context.Context, req *pb.UnlinkRequest) (
 	} else if preserved {
 		return &pb.Empty{}, nil
 	}
-	if err := os.Remove(s.hostPath(rel)); err != nil {
+	if err := unix.Unlink(s.hostPath(rel)); err != nil {
 		return nil, mapRootFSBackedError(err)
 	}
 	s.dropPath(rel)
@@ -283,7 +283,7 @@ func (s *rootFSBackedSession) Rmdir(_ context.Context, req *pb.RmdirRequest) (*p
 	if err != nil {
 		return nil, err
 	}
-	if err := os.Remove(s.hostPath(rel)); err != nil {
+	if err := unix.Rmdir(s.hostPath(rel)); err != nil {
 		return nil, mapRootFSBackedError(err)
 	}
 	s.dropPathTree(rel)
@@ -1088,21 +1088,19 @@ func actorPrimaryGID(actor *pb.PosixActor) int {
 }
 
 func mapRootFSBackedError(err error) error {
-	switch {
-	case err == nil:
+	if err == nil {
 		return nil
+	}
+	if errno, ok := fserror.ErrnoOf(err); ok {
+		return fserror.NewErrno(errno, err.Error())
+	}
+	switch {
 	case errors.Is(err, os.ErrNotExist):
-		return fserror.New(fserror.NotFound, err.Error())
+		return fserror.NewErrno(syscall.ENOENT, err.Error())
 	case errors.Is(err, os.ErrExist):
-		return fserror.New(fserror.AlreadyExists, err.Error())
+		return fserror.NewErrno(syscall.EEXIST, err.Error())
 	case errors.Is(err, os.ErrPermission):
-		return fserror.New(fserror.PermissionDenied, err.Error())
-	case errors.Is(err, syscall.ENOTEMPTY), errors.Is(err, syscall.EISDIR):
-		return fserror.New(fserror.FailedPrecondition, err.Error())
-	case errors.Is(err, syscall.ENOTDIR), errors.Is(err, syscall.EINVAL):
-		return fserror.New(fserror.InvalidArgument, err.Error())
-	case errors.Is(err, syscall.ENOSPC):
-		return fserror.New(fserror.ResourceExhausted, err.Error())
+		return fserror.NewErrno(syscall.EACCES, err.Error())
 	default:
 		return err
 	}

--- a/ctld/internal/ctld/portal/rootfs_session_test.go
+++ b/ctld/internal/ctld/portal/rootfs_session_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"syscall"
 	"testing"
 
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/fserror"
@@ -64,6 +65,61 @@ func TestRootFSBackedSessionWritesThroughBackingDir(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, list.Entries, 1)
 	assert.Equal(t, "state.txt", list.Entries[0].Name)
+}
+
+func TestRootFSBackedSessionPreservesRemoveErrnos(t *testing.T) {
+	backing := t.TempDir()
+	session := newRootFSBackedSession(backing)
+	defer session.Close()
+	ctx := context.Background()
+
+	nonEmpty, err := session.Mkdir(ctx, &pb.MkdirRequest{
+		Parent: s0fs.RootInode,
+		Name:   "non-empty",
+		Mode:   0o755,
+	})
+	require.NoError(t, err)
+	child, err := session.Create(ctx, &pb.CreateRequest{
+		Parent: nonEmpty.Inode,
+		Name:   "child",
+		Mode:   0o644,
+		Flags:  uint32(os.O_RDWR),
+	})
+	require.NoError(t, err)
+	_, err = session.Release(ctx, &pb.ReleaseRequest{HandleId: child.HandleId})
+	require.NoError(t, err)
+
+	_, err = session.Rmdir(ctx, &pb.RmdirRequest{Parent: s0fs.RootInode, Name: "non-empty"})
+	require.ErrorIs(t, err, syscall.ENOTEMPTY)
+	_, statErr := os.Stat(filepath.Join(backing, "non-empty", "child"))
+	require.NoError(t, statErr)
+
+	_, err = session.Mkdir(ctx, &pb.MkdirRequest{
+		Parent: s0fs.RootInode,
+		Name:   "empty-dir",
+		Mode:   0o755,
+	})
+	require.NoError(t, err)
+	_, err = session.Unlink(ctx, &pb.UnlinkRequest{Parent: s0fs.RootInode, Name: "empty-dir"})
+	require.ErrorIs(t, err, syscall.EISDIR)
+	info, statErr := os.Stat(filepath.Join(backing, "empty-dir"))
+	require.NoError(t, statErr)
+	require.True(t, info.IsDir())
+
+	file, err := session.Create(ctx, &pb.CreateRequest{
+		Parent: s0fs.RootInode,
+		Name:   "regular-file",
+		Mode:   0o644,
+		Flags:  uint32(os.O_RDWR),
+	})
+	require.NoError(t, err)
+	_, err = session.Release(ctx, &pb.ReleaseRequest{HandleId: file.HandleId})
+	require.NoError(t, err)
+	_, err = session.Rmdir(ctx, &pb.RmdirRequest{Parent: s0fs.RootInode, Name: "regular-file"})
+	require.ErrorIs(t, err, syscall.ENOTDIR)
+	info, statErr = os.Stat(filepath.Join(backing, "regular-file"))
+	require.NoError(t, statErr)
+	require.False(t, info.IsDir())
 }
 
 func TestRootFSBackedSessionRestoresKernelInodeMapping(t *testing.T) {

--- a/ctld/internal/ctld/portal/session.go
+++ b/ctld/internal/ctld/portal/session.go
@@ -2,7 +2,6 @@ package portal
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"slices"
@@ -567,7 +566,7 @@ func (s *localSession) ReadInto(ctx context.Context, req *pb.ReadRequest, dest [
 	}
 	n, err := volCtx.S0FS.ReadInto(req.Inode, uint64(req.Offset), dest)
 	if err != nil {
-		return 0, false, mapLocalS0FSError(err)
+		return 0, false, fsserver.MapS0FSError(err)
 	}
 	if n <= len(dest) && n <= maxLocalReadCacheFileSize && n < len(dest) && req.Offset == 0 {
 		s.storeCompleteReadCache(volCtx, req.Inode, dest[:n])
@@ -977,27 +976,6 @@ func (s *localSession) putReadCacheLocked(key string, data []byte) {
 	}
 	s.readCache[key] = data
 	s.readCacheBytes += len(data) - oldLen
-}
-
-func mapLocalS0FSError(err error) error {
-	switch {
-	case err == nil:
-		return nil
-	case errors.Is(err, s0fs.ErrNotFound):
-		return fserror.New(fserror.NotFound, err.Error())
-	case errors.Is(err, s0fs.ErrExists):
-		return fserror.New(fserror.AlreadyExists, err.Error())
-	case errors.Is(err, s0fs.ErrNotEmpty), errors.Is(err, s0fs.ErrIsDir):
-		return fserror.New(fserror.FailedPrecondition, err.Error())
-	case errors.Is(err, s0fs.ErrInvalidInput), errors.Is(err, s0fs.ErrNotDir):
-		return fserror.New(fserror.InvalidArgument, err.Error())
-	case errors.Is(err, s0fs.ErrNoSpace):
-		return fserror.New(fserror.ResourceExhausted, err.Error())
-	case errors.Is(err, s0fs.ErrClosed):
-		return fserror.New(fserror.FailedPrecondition, err.Error())
-	default:
-		return fserror.New(fserror.Internal, err.Error())
-	}
 }
 
 type unboundSession struct{}

--- a/ctld/internal/ctld/portal/session_test.go
+++ b/ctld/internal/ctld/portal/session_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
@@ -110,6 +111,45 @@ func TestLocalSessionReadIntoUsesMountedS0FS(t *testing.T) {
 	}
 	if !bytes.Equal(buf[3:], bytes.Repeat([]byte{0xff}, 5)) {
 		t.Fatalf("ReadInto() modified bytes past requested size: %#v", buf)
+	}
+}
+
+func TestLocalSessionRmdirPreservesENOTEMPTY(t *testing.T) {
+	engine, err := s0fs.Open(context.Background(), s0fs.Config{
+		VolumeID: "vol-errno",
+		WALPath:  filepath.Join(t.TempDir(), "volume.wal"),
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer engine.Close()
+	dir, err := engine.Mkdir(s0fs.RootInode, "non-empty", 0o755)
+	if err != nil {
+		t.Fatalf("Mkdir() error = %v", err)
+	}
+	if _, err := engine.CreateFile(dir.Inode, "child", 0o644); err != nil {
+		t.Fatalf("CreateFile() error = %v", err)
+	}
+
+	mgr := newLocalVolumeManager()
+	mgr.add(&volume.VolumeContext{
+		VolumeID:  "vol-errno",
+		TeamID:    "team-a",
+		Backend:   volume.BackendS0FS,
+		S0FS:      engine,
+		Access:    volume.AccessModeRWO,
+		MountedAt: time.Now().UTC(),
+		RootInode: 1,
+		RootPath:  "/",
+	})
+	session := newLocalSession("vol-errno", mgr, nil)
+
+	_, err = session.Rmdir(context.Background(), &pb.RmdirRequest{
+		Parent: s0fs.RootInode,
+		Name:   "non-empty",
+	})
+	if !errors.Is(err, syscall.ENOTEMPTY) {
+		t.Fatalf("Rmdir(non-empty) error = %v, want ENOTEMPTY", err)
 	}
 }
 

--- a/pkg/volumefuse/fs.go
+++ b/pkg/volumefuse/fs.go
@@ -1074,6 +1074,9 @@ func statusToFuse(err error) fuse.Status {
 	if err == context.DeadlineExceeded {
 		return fuse.EIO
 	}
+	if errno, ok := fserror.ErrnoOf(err); ok {
+		return fuse.Status(errno)
+	}
 	var fsErr *fserror.Error
 	if errors.As(err, &fsErr) {
 		switch fsErr.Code() {
@@ -1094,9 +1097,6 @@ func statusToFuse(err error) fuse.Status {
 		default:
 			return fuse.EIO
 		}
-	}
-	if errno, ok := err.(syscall.Errno); ok {
-		return fuse.Status(errno)
 	}
 	return fuse.EIO
 }

--- a/pkg/volumefuse/fs_test.go
+++ b/pkg/volumefuse/fs_test.go
@@ -4,10 +4,13 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
+	"syscall"
 	"testing"
 	"time"
 
 	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/fserror"
 	pb "github.com/sandbox0-ai/sandbox0/storage-proxy/proto/fs"
 )
 
@@ -85,5 +88,47 @@ func TestOpenUsesSessionOpenFlags(t *testing.T) {
 	}
 	if out.OpenFlags != fuse.FOPEN_DIRECT_IO {
 		t.Fatalf("Open() flags = %#x, want DIRECT_IO", out.OpenFlags)
+	}
+}
+
+func TestStatusToFusePreservesPOSIXErrno(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want fuse.Status
+	}{
+		{
+			name: "structured not empty",
+			err:  fserror.NewErrno(syscall.ENOTEMPTY, "directory not empty"),
+			want: fuse.Status(syscall.ENOTEMPTY),
+		},
+		{
+			name: "structured is directory",
+			err:  fserror.NewErrno(syscall.EISDIR, "is a directory"),
+			want: fuse.Status(syscall.EISDIR),
+		},
+		{
+			name: "wrapped raw not directory",
+			err:  fmt.Errorf("readdir: %w", syscall.ENOTDIR),
+			want: fuse.Status(syscall.ENOTDIR),
+		},
+		{
+			name: "generic failed precondition",
+			err:  fserror.New(fserror.FailedPrecondition, "portal is not bound"),
+			want: fuse.EIO,
+		},
+		{
+			name: "internal error",
+			err:  fserror.New(fserror.Internal, "storage failure"),
+			want: fuse.EIO,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := statusToFuse(tt.err); got != tt.want {
+				t.Fatalf("statusToFuse() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/storage-proxy/pkg/fserror/error.go
+++ b/storage-proxy/pkg/fserror/error.go
@@ -2,6 +2,7 @@ package fserror
 
 import (
 	"errors"
+	"syscall"
 
 	pb "github.com/sandbox0-ai/sandbox0/storage-proxy/proto/fs"
 )
@@ -32,10 +33,50 @@ type Error struct {
 	code     Code
 	message  string
 	redirect *pb.PrimaryRedirect
+	cause    error
 }
 
 func New(code Code, message string) error {
 	return &Error{code: code, message: message}
+}
+
+// NewErrno creates a filesystem error that retains its POSIX errno while also
+// exposing the closest high-level error code to non-FUSE callers.
+func NewErrno(errno syscall.Errno, message string) error {
+	return &Error{code: codeForErrno(errno), message: message, cause: errno}
+}
+
+// ErrnoOf returns the POSIX errno carried by err, including wrapped errors.
+func ErrnoOf(err error) (syscall.Errno, bool) {
+	if err == nil {
+		return 0, false
+	}
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		return errno, true
+	}
+	return 0, false
+}
+
+func codeForErrno(errno syscall.Errno) Code {
+	switch errno {
+	case syscall.ENOENT:
+		return NotFound
+	case syscall.EEXIST:
+		return AlreadyExists
+	case syscall.EACCES, syscall.EPERM:
+		return PermissionDenied
+	case syscall.ENOSPC, syscall.EDQUOT:
+		return ResourceExhausted
+	case syscall.EINVAL, syscall.ENOTDIR:
+		return InvalidArgument
+	case syscall.ENOSYS, syscall.EOPNOTSUPP:
+		return Unimplemented
+	case syscall.ENOTEMPTY, syscall.EISDIR:
+		return FailedPrecondition
+	default:
+		return Internal
+	}
 }
 
 func WithRedirect(err error, redirect *pb.PrimaryRedirect) error {
@@ -94,6 +135,13 @@ func (e *Error) Error() string {
 		return ""
 	}
 	return e.message
+}
+
+func (e *Error) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.cause
 }
 
 func (e *Error) Code() Code {

--- a/storage-proxy/pkg/fserror/error_test.go
+++ b/storage-proxy/pkg/fserror/error_test.go
@@ -1,0 +1,59 @@
+package fserror
+
+import (
+	"errors"
+	"syscall"
+	"testing"
+
+	pb "github.com/sandbox0-ai/sandbox0/storage-proxy/proto/fs"
+)
+
+func TestNewErrnoPreservesPOSIXAndHighLevelCodes(t *testing.T) {
+	tests := []struct {
+		name  string
+		errno syscall.Errno
+		code  Code
+	}{
+		{name: "not found", errno: syscall.ENOENT, code: NotFound},
+		{name: "already exists", errno: syscall.EEXIST, code: AlreadyExists},
+		{name: "permission denied", errno: syscall.EPERM, code: PermissionDenied},
+		{name: "no space", errno: syscall.ENOSPC, code: ResourceExhausted},
+		{name: "not a directory", errno: syscall.ENOTDIR, code: InvalidArgument},
+		{name: "directory not empty", errno: syscall.ENOTEMPTY, code: FailedPrecondition},
+		{name: "is a directory", errno: syscall.EISDIR, code: FailedPrecondition},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := NewErrno(tt.errno, tt.name)
+			if got := CodeOf(err); got != tt.code {
+				t.Fatalf("CodeOf() = %v, want %v", got, tt.code)
+			}
+			if !errors.Is(err, tt.errno) {
+				t.Fatalf("errors.Is(%v) = false", tt.errno)
+			}
+			if got, ok := ErrnoOf(err); !ok || got != tt.errno {
+				t.Fatalf("ErrnoOf() = (%v, %v), want (%v, true)", got, ok, tt.errno)
+			}
+		})
+	}
+}
+
+func TestWithRedirectPreservesErrno(t *testing.T) {
+	redirect := &pb.PrimaryRedirect{VolumeId: "vol-1"}
+	err := WithRedirect(NewErrno(syscall.ENOTEMPTY, "directory not empty"), redirect)
+
+	if !errors.Is(err, syscall.ENOTEMPTY) {
+		t.Fatal("WithRedirect() discarded ENOTEMPTY")
+	}
+	if got := RedirectOf(err); got != redirect {
+		t.Fatalf("RedirectOf() = %v, want %v", got, redirect)
+	}
+}
+
+func TestErrnoOfWrappedRawErrno(t *testing.T) {
+	err := errors.Join(errors.New("operation failed"), syscall.ENOTDIR)
+	if got, ok := ErrnoOf(err); !ok || got != syscall.ENOTDIR {
+		t.Fatalf("ErrnoOf() = (%v, %v), want (%v, true)", got, ok, syscall.ENOTDIR)
+	}
+}

--- a/storage-proxy/pkg/fsserver/server.go
+++ b/storage-proxy/pkg/fsserver/server.go
@@ -197,7 +197,7 @@ func (s *FileSystemServer) syncS0FSHandle(volCtx *volume.VolumeContext, inode ui
 		return nil
 	}
 	if err := volCtx.S0FS.Fsync(inode); err != nil {
-		return mapS0FSError(err)
+		return MapS0FSError(err)
 	}
 	return nil
 }
@@ -417,7 +417,7 @@ func (s *FileSystemServer) GetAttr(ctx context.Context, req *pb.GetAttrRequest) 
 	if isS0FSVolume(volCtx) {
 		node, err := volCtx.S0FS.GetAttr(req.Inode)
 		if err != nil {
-			return nil, mapS0FSError(err)
+			return nil, MapS0FSError(err)
 		}
 		return s0fsAttr(node), nil
 	}
@@ -435,7 +435,7 @@ func (s *FileSystemServer) Lookup(ctx context.Context, req *pb.LookupRequest) (*
 	if isS0FSVolume(volCtx) {
 		node, err := volCtx.S0FS.Lookup(req.Parent, req.Name)
 		if err != nil {
-			return nil, mapS0FSError(err)
+			return nil, MapS0FSError(err)
 		}
 		return s0fsNodeResponse(node, 0), nil
 	}
@@ -473,7 +473,7 @@ func (s *FileSystemServer) Read(ctx context.Context, req *pb.ReadRequest) (*pb.R
 		inode := requestInodeForHandle(volCtx, req.Inode, req.HandleId)
 		data, err := volCtx.S0FS.Read(inode, uint64(req.Offset), uint64(req.Size))
 		if err != nil {
-			return nil, mapS0FSError(err)
+			return nil, MapS0FSError(err)
 		}
 		return &pb.ReadResponse{
 			Data: data,
@@ -490,7 +490,7 @@ func (s *FileSystemServer) Write(ctx context.Context, req *pb.WriteRequest) (*pb
 		if isS0FSVolume(volCtx) {
 			inode := requestInodeForHandle(volCtx, req.Inode, req.HandleId)
 			if _, err := volCtx.S0FS.Write(inode, uint64(req.Offset), req.Data); err != nil {
-				return nil, mapS0FSError(err)
+				return nil, MapS0FSError(err)
 			}
 			s.markDirtyWrite(req.VolumeId, inode, req.HandleId)
 			if s.shouldPublishEvents() {
@@ -536,7 +536,7 @@ func (s *FileSystemServer) Create(ctx context.Context, req *pb.CreateRequest) (*
 				node, err = volCtx.S0FS.CreateFile(req.Parent, req.Name, req.Mode)
 			}
 			if err != nil {
-				return nil, mapS0FSError(err)
+				return nil, MapS0FSError(err)
 			}
 			if s.shouldPublishEvents() {
 				path := resolveChildPath(volCtx, req.Parent, req.Name)
@@ -569,7 +569,7 @@ func (s *FileSystemServer) Mkdir(ctx context.Context, req *pb.MkdirRequest) (*pb
 			}
 			node, err := volCtx.S0FS.Mkdir(req.Parent, req.Name, req.Mode)
 			if err != nil {
-				return nil, mapS0FSError(err)
+				return nil, MapS0FSError(err)
 			}
 			if req.Actor != nil && len(req.Actor.Gids) > 0 {
 				if err := volCtx.S0FS.SetOwner(node.Inode, req.Actor.Uid, req.Actor.Gids[0]); err != nil {
@@ -577,7 +577,7 @@ func (s *FileSystemServer) Mkdir(ctx context.Context, req *pb.MkdirRequest) (*pb
 				}
 				node, err = volCtx.S0FS.GetAttr(node.Inode)
 				if err != nil {
-					return nil, mapS0FSError(err)
+					return nil, MapS0FSError(err)
 				}
 			}
 			if s.shouldPublishEvents() {
@@ -615,17 +615,17 @@ func (s *FileSystemServer) Mknod(ctx context.Context, req *pb.MknodRequest) (*pb
 func (s *FileSystemServer) openS0FS(ctx context.Context, volCtx *volume.VolumeContext, req *pb.OpenRequest) (*pb.OpenResponse, error) {
 	node, err := volCtx.S0FS.GetAttr(req.Inode)
 	if err != nil {
-		return nil, mapS0FSError(err)
+		return nil, MapS0FSError(err)
 	}
 	if node.Type == s0fs.TypeDirectory {
-		return nil, fserror.New(fserror.FailedPrecondition, "inode is a directory")
+		return nil, fserror.NewErrno(syscall.EISDIR, "inode is a directory")
 	}
 	if err := checkS0FSAccess(node, req.Actor, s0fsOpenAccessMask(req.Flags)); err != nil {
 		return nil, err
 	}
 	if req.Flags&uint32(syscall.O_TRUNC) != 0 {
 		if err := volCtx.S0FS.Truncate(req.Inode, 0); err != nil {
-			return nil, mapS0FSError(err)
+			return nil, MapS0FSError(err)
 		}
 		if s.shouldPublishEvents() {
 			path := resolveInodePath(volCtx, req.Inode)
@@ -650,7 +650,7 @@ func (s *FileSystemServer) Unlink(ctx context.Context, req *pb.UnlinkRequest) (*
 		if isS0FSVolume(volCtx) {
 			inode, err := volCtx.S0FS.UnlinkWithInode(req.Parent, req.Name)
 			if err != nil {
-				return nil, mapS0FSError(err)
+				return nil, MapS0FSError(err)
 			}
 			if !volCtx.MarkUnlinkedFileIfOpen(inode) {
 				_ = volCtx.S0FS.Forget(inode)
@@ -684,7 +684,7 @@ func (s *FileSystemServer) ReadDir(ctx context.Context, req *pb.ReadDirRequest) 
 	if isS0FSVolume(volCtx) {
 		entries, err := volCtx.S0FS.ReadDir(req.Inode)
 		if err != nil {
-			return nil, mapS0FSError(err)
+			return nil, MapS0FSError(err)
 		}
 		start := int(req.Offset)
 		if start < 0 {
@@ -704,7 +704,7 @@ func (s *FileSystemServer) ReadDir(ctx context.Context, req *pb.ReadDirRequest) 
 			if req.Plus {
 				node, err := volCtx.S0FS.GetAttr(entry.Inode)
 				if err != nil {
-					return nil, mapS0FSError(err)
+					return nil, MapS0FSError(err)
 				}
 				item.Attr = s0fsAttr(node)
 			}
@@ -723,8 +723,12 @@ func (s *FileSystemServer) OpenDir(ctx context.Context, req *pb.OpenDirRequest) 
 		return nil, err
 	}
 	if isS0FSVolume(volCtx) {
-		if _, err := volCtx.S0FS.GetAttr(req.Inode); err != nil {
-			return nil, mapS0FSError(err)
+		node, err := volCtx.S0FS.GetAttr(req.Inode)
+		if err != nil {
+			return nil, MapS0FSError(err)
+		}
+		if node.Type != s0fs.TypeDirectory {
+			return nil, fserror.NewErrno(syscall.ENOTDIR, "inode is not a directory")
 		}
 		return &pb.OpenDirResponse{HandleId: volCtx.OpenDirHandle(req.Inode)}, nil
 	}
@@ -751,7 +755,7 @@ func (s *FileSystemServer) Rename(ctx context.Context, req *pb.RenameRequest) (*
 	return withAuthorizedVolumeMutation(s, ctx, req.VolumeId, func(runCtx context.Context, volCtx *volume.VolumeContext) (*pb.Empty, error) {
 		if isS0FSVolume(volCtx) {
 			if err := volCtx.S0FS.Rename(req.OldParent, req.OldName, req.NewParent, req.NewName); err != nil {
-				return nil, mapS0FSError(err)
+				return nil, MapS0FSError(err)
 			}
 			if s.shouldPublishEvents() {
 				oldPath := resolveChildPath(volCtx, req.OldParent, req.OldName)
@@ -783,13 +787,13 @@ func (s *FileSystemServer) SetAttr(ctx context.Context, req *pb.SetAttrRequest) 
 			}
 			if req.Valid&uint32(fsmeta.SetAttrMode) != 0 {
 				if err := volCtx.S0FS.SetMode(req.Inode, attr.Mode&0o7777); err != nil {
-					return nil, mapS0FSError(err)
+					return nil, MapS0FSError(err)
 				}
 			}
 			if req.Valid&(uint32(fsmeta.SetAttrUID)|uint32(fsmeta.SetAttrGID)) != 0 {
 				current, err := volCtx.S0FS.GetAttr(req.Inode)
 				if err != nil {
-					return nil, mapS0FSError(err)
+					return nil, MapS0FSError(err)
 				}
 				uid := current.UID
 				gid := current.GID
@@ -800,17 +804,17 @@ func (s *FileSystemServer) SetAttr(ctx context.Context, req *pb.SetAttrRequest) 
 					gid = attr.Gid
 				}
 				if err := volCtx.S0FS.SetOwner(req.Inode, uid, gid); err != nil {
-					return nil, mapS0FSError(err)
+					return nil, MapS0FSError(err)
 				}
 			}
 			if req.Valid&uint32(fsmeta.SetAttrSize) != 0 {
 				if err := volCtx.S0FS.Truncate(req.Inode, attr.Size); err != nil {
-					return nil, mapS0FSError(err)
+					return nil, MapS0FSError(err)
 				}
 			}
 			updated, err := volCtx.S0FS.GetAttr(req.Inode)
 			if err != nil {
-				return nil, mapS0FSError(err)
+				return nil, MapS0FSError(err)
 			}
 			if s.shouldPublishEvents() {
 				path := resolveInodePath(volCtx, req.Inode)
@@ -910,7 +914,7 @@ func (s *FileSystemServer) Rmdir(ctx context.Context, req *pb.RmdirRequest) (*pb
 	return withAuthorizedVolumeMutation(s, ctx, req.VolumeId, func(runCtx context.Context, volCtx *volume.VolumeContext) (*pb.Empty, error) {
 		if isS0FSVolume(volCtx) {
 			if err := volCtx.S0FS.RemoveDir(req.Parent, req.Name); err != nil {
-				return nil, mapS0FSError(err)
+				return nil, MapS0FSError(err)
 			}
 			if s.shouldPublishEvents() {
 				path := resolveChildPath(volCtx, req.Parent, req.Name)
@@ -961,7 +965,7 @@ func (s *FileSystemServer) Symlink(ctx context.Context, req *pb.SymlinkRequest) 
 			}
 			node, err := volCtx.S0FS.Symlink(req.Parent, req.Name, req.Target, 0o777)
 			if err != nil {
-				return nil, mapS0FSError(err)
+				return nil, MapS0FSError(err)
 			}
 			if req.Actor != nil && len(req.Actor.Gids) > 0 {
 				if err := volCtx.S0FS.SetOwner(node.Inode, req.Actor.Uid, req.Actor.Gids[0]); err != nil {
@@ -969,7 +973,7 @@ func (s *FileSystemServer) Symlink(ctx context.Context, req *pb.SymlinkRequest) 
 				}
 				node, err = volCtx.S0FS.GetAttr(node.Inode)
 				if err != nil {
-					return nil, mapS0FSError(err)
+					return nil, MapS0FSError(err)
 				}
 			}
 			if s.shouldPublishEvents() {
@@ -1003,10 +1007,10 @@ func (s *FileSystemServer) Readlink(ctx context.Context, req *pb.ReadlinkRequest
 	if isS0FSVolume(volCtx) {
 		node, err := volCtx.S0FS.GetAttr(req.Inode)
 		if err != nil {
-			return nil, mapS0FSError(err)
+			return nil, MapS0FSError(err)
 		}
 		if node.Type != s0fs.TypeSymlink {
-			return nil, fserror.New(fserror.FailedPrecondition, "inode is not a symbolic link")
+			return nil, fserror.NewErrno(syscall.EINVAL, "inode is not a symbolic link")
 		}
 		return &pb.ReadlinkResponse{Target: node.Target}, nil
 	}
@@ -1020,7 +1024,10 @@ func (s *FileSystemServer) Link(ctx context.Context, req *pb.LinkRequest) (*pb.N
 		if isS0FSVolume(volCtx) {
 			node, err := volCtx.S0FS.Link(req.Inode, req.NewParent, req.NewName)
 			if err != nil {
-				return nil, mapS0FSError(err)
+				if errors.Is(err, s0fs.ErrIsDir) {
+					return nil, fserror.NewErrno(syscall.EPERM, err.Error())
+				}
+				return nil, MapS0FSError(err)
 			}
 			if s.shouldPublishEvents() {
 				path := resolveChildPath(volCtx, req.NewParent, req.NewName)
@@ -1050,7 +1057,7 @@ func (s *FileSystemServer) Access(ctx context.Context, req *pb.AccessRequest) (*
 	if isS0FSVolume(volCtx) {
 		node, err := volCtx.S0FS.GetAttr(req.Inode)
 		if err != nil {
-			return nil, mapS0FSError(err)
+			return nil, MapS0FSError(err)
 		}
 		if err := checkS0FSAccess(node, accessActor(req), req.Mask); err != nil {
 			return nil, err
@@ -1358,20 +1365,26 @@ func s0fsTypeNumber(typ s0fs.FileType) uint32 {
 	}
 }
 
-func mapS0FSError(err error) error {
+// MapS0FSError translates S0FS engine errors without discarding their POSIX
+// filesystem semantics.
+func MapS0FSError(err error) error {
 	switch {
 	case err == nil:
 		return nil
 	case errors.Is(err, s0fs.ErrNotFound):
-		return fserror.New(fserror.NotFound, err.Error())
+		return fserror.NewErrno(syscall.ENOENT, err.Error())
 	case errors.Is(err, s0fs.ErrExists):
-		return fserror.New(fserror.AlreadyExists, err.Error())
-	case errors.Is(err, s0fs.ErrNotEmpty), errors.Is(err, s0fs.ErrIsDir):
-		return fserror.New(fserror.FailedPrecondition, err.Error())
-	case errors.Is(err, s0fs.ErrInvalidInput), errors.Is(err, s0fs.ErrNotDir):
-		return fserror.New(fserror.InvalidArgument, err.Error())
+		return fserror.NewErrno(syscall.EEXIST, err.Error())
+	case errors.Is(err, s0fs.ErrNotEmpty):
+		return fserror.NewErrno(syscall.ENOTEMPTY, err.Error())
+	case errors.Is(err, s0fs.ErrIsDir):
+		return fserror.NewErrno(syscall.EISDIR, err.Error())
+	case errors.Is(err, s0fs.ErrNotDir):
+		return fserror.NewErrno(syscall.ENOTDIR, err.Error())
+	case errors.Is(err, s0fs.ErrInvalidInput):
+		return fserror.NewErrno(syscall.EINVAL, err.Error())
 	case errors.Is(err, s0fs.ErrNoSpace):
-		return fserror.New(fserror.ResourceExhausted, err.Error())
+		return fserror.NewErrno(syscall.ENOSPC, err.Error())
 	case errors.Is(err, s0fs.ErrClosed):
 		return fserror.New(fserror.FailedPrecondition, err.Error())
 	default:

--- a/storage-proxy/pkg/fsserver/server_s0fs_test.go
+++ b/storage-proxy/pkg/fsserver/server_s0fs_test.go
@@ -3,6 +3,7 @@ package fsserver
 import (
 	"bytes"
 	"context"
+	"errors"
 	"path/filepath"
 	"sync/atomic"
 	"syscall"
@@ -103,6 +104,78 @@ func TestS0FSFileLifecycle(t *testing.T) {
 		HandleId: createResp.HandleId,
 	}); err != nil {
 		t.Fatalf("Release() error = %v", err)
+	}
+}
+
+func TestS0FSOperationsPreservePOSIXErrnos(t *testing.T) {
+	t.Parallel()
+
+	volCtx := newMountedS0FSVolumeContext(t, "vol-errno", "team-a")
+	server := newTestFileSystemServer(&fakeVolumeManager{
+		volumes: map[string]*volume.VolumeContext{
+			"vol-errno": volCtx,
+		},
+	}, nil, nil)
+	ctx := authContext("team-a", "")
+
+	nonEmpty, err := volCtx.S0FS.Mkdir(s0fs.RootInode, "non-empty", 0o755)
+	if err != nil {
+		t.Fatalf("Mkdir(non-empty) error = %v", err)
+	}
+	if _, err := volCtx.S0FS.CreateFile(nonEmpty.Inode, "child", 0o644); err != nil {
+		t.Fatalf("CreateFile(child) error = %v", err)
+	}
+	_, err = server.Rmdir(ctx, &pb.RmdirRequest{VolumeId: "vol-errno", Parent: s0fs.RootInode, Name: "non-empty"})
+	if !errors.Is(err, syscall.ENOTEMPTY) {
+		t.Fatalf("Rmdir(non-empty) error = %v, want ENOTEMPTY", err)
+	}
+	if got := fserror.CodeOf(err); got != fserror.FailedPrecondition {
+		t.Fatalf("Rmdir(non-empty) code = %v, want FailedPrecondition", got)
+	}
+
+	empty, err := volCtx.S0FS.Mkdir(s0fs.RootInode, "empty", 0o755)
+	if err != nil {
+		t.Fatalf("Mkdir(empty) error = %v", err)
+	}
+	_, err = server.Unlink(ctx, &pb.UnlinkRequest{VolumeId: "vol-errno", Parent: s0fs.RootInode, Name: "empty"})
+	if !errors.Is(err, syscall.EISDIR) {
+		t.Fatalf("Unlink(empty directory) error = %v, want EISDIR", err)
+	}
+	if _, err := volCtx.S0FS.GetAttr(empty.Inode); err != nil {
+		t.Fatalf("GetAttr(empty directory) error = %v after failed unlink", err)
+	}
+
+	file, err := volCtx.S0FS.CreateFile(s0fs.RootInode, "regular-file", 0o644)
+	if err != nil {
+		t.Fatalf("CreateFile(regular-file) error = %v", err)
+	}
+	_, err = server.Rmdir(ctx, &pb.RmdirRequest{VolumeId: "vol-errno", Parent: s0fs.RootInode, Name: "regular-file"})
+	if !errors.Is(err, syscall.ENOTDIR) {
+		t.Fatalf("Rmdir(regular-file) error = %v, want ENOTDIR", err)
+	}
+	if _, err := volCtx.S0FS.GetAttr(file.Inode); err != nil {
+		t.Fatalf("GetAttr(regular-file) error = %v after failed rmdir", err)
+	}
+
+	if _, err := server.Open(ctx, &pb.OpenRequest{VolumeId: "vol-errno", Inode: empty.Inode}); !errors.Is(err, syscall.EISDIR) {
+		t.Fatalf("Open(directory) error = %v, want EISDIR", err)
+	}
+	if _, err := server.Readlink(ctx, &pb.ReadlinkRequest{VolumeId: "vol-errno", Inode: file.Inode}); !errors.Is(err, syscall.EINVAL) {
+		t.Fatalf("Readlink(regular-file) error = %v, want EINVAL", err)
+	}
+	if _, err := server.OpenDir(ctx, &pb.OpenDirRequest{VolumeId: "vol-errno", Inode: file.Inode}); !errors.Is(err, syscall.ENOTDIR) {
+		t.Fatalf("OpenDir(regular-file) error = %v, want ENOTDIR", err)
+	}
+	if _, err := server.ReadDir(ctx, &pb.ReadDirRequest{VolumeId: "vol-errno", Inode: file.Inode}); !errors.Is(err, syscall.ENOTDIR) {
+		t.Fatalf("ReadDir(regular-file) error = %v, want ENOTDIR", err)
+	}
+	if _, err := server.Link(ctx, &pb.LinkRequest{
+		VolumeId:  "vol-errno",
+		Inode:     empty.Inode,
+		NewParent: s0fs.RootInode,
+		NewName:   "directory-link",
+	}); !errors.Is(err, syscall.EPERM) {
+		t.Fatalf("Link(directory) error = %v, want EPERM", err)
 	}
 }
 

--- a/storage-proxy/pkg/http/handlers_volume_files.go
+++ b/storage-proxy/pkg/http/handlers_volume_files.go
@@ -1467,6 +1467,12 @@ func translateVolumeRPCError(err error) error {
 	if err == nil {
 		return nil
 	}
+	if errors.Is(err, syscall.ENOTEMPTY) {
+		return errDirectoryNotEmpty
+	}
+	if errors.Is(err, syscall.ENOTDIR) {
+		return errPathNotDir
+	}
 	switch fserror.CodeOf(err) {
 	case fserror.NotFound:
 		return errFileNotFound
@@ -1474,11 +1480,6 @@ func translateVolumeRPCError(err error) error {
 		return errPermissionDenied
 	case fserror.AlreadyExists:
 		return errPathAlreadyExists
-	case fserror.FailedPrecondition:
-		if strings.Contains(strings.ToLower(err.Error()), "not empty") {
-			return errDirectoryNotEmpty
-		}
-		return err
 	default:
 		return err
 	}

--- a/storage-proxy/pkg/http/handlers_volume_files_test.go
+++ b/storage-proxy/pkg/http/handlers_volume_files_test.go
@@ -45,6 +45,20 @@ type fakeHTTPVolumeMountManager struct {
 	syncFunc          func(context.Context, string) error
 }
 
+func TestTranslateVolumeRPCErrorUsesStructuredErrno(t *testing.T) {
+	if got := translateVolumeRPCError(fserror.NewErrno(syscall.ENOTEMPTY, "opaque failure")); !errors.Is(got, errDirectoryNotEmpty) {
+		t.Fatalf("translateVolumeRPCError(ENOTEMPTY) = %v, want directory-not-empty", got)
+	}
+	if got := translateVolumeRPCError(fserror.NewErrno(syscall.ENOTDIR, "opaque failure")); !errors.Is(got, errPathNotDir) {
+		t.Fatalf("translateVolumeRPCError(ENOTDIR) = %v, want path-not-directory", got)
+	}
+
+	generic := fserror.New(fserror.FailedPrecondition, "directory not empty")
+	if got := translateVolumeRPCError(generic); got != generic {
+		t.Fatalf("translateVolumeRPCError(generic precondition) = %v, want original error", got)
+	}
+}
+
 type fakeVolumeFilePodResolver struct {
 	urls map[string]string
 }


### PR DESCRIPTION
Fixes #706

## Summary

- retain POSIX errno details alongside high-level filesystem error codes
- preserve `ENOTEMPTY`, `EISDIR`, and `ENOTDIR` through S0FS, ctld portal, and FUSE mappings
- keep generic `FailedPrecondition` errors mapped to `EIO`
- use operation-specific `unlink(2)` and `rmdir(2)` behavior for rootfs-backed portals
- replace the volume-file API error-message match with structured errno handling
- centralize the shared S0FS error mapping and add regression coverage

## Validation

- `make proto manifests apispec`
- `go mod tidy`
- `go vet ./storage-proxy/pkg/fserror ./pkg/volumefuse ./storage-proxy/pkg/fsserver ./storage-proxy/pkg/http ./ctld/internal/ctld/portal`
- targeted `go test -race -count=1` for all changed packages
- CI-equivalent non-e2e race suite completed with one unrelated `netd/pkg/proxy` SSH EOF; the failed test passed on an isolated race rerun
- remote kind mounted-volume verification will be posted while PR CI runs
