### PR TITLE
feat: consolidate storage-proxy into manager and netd into ctld

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -64,6 +64,12 @@ jobs:
         run: |
           echo "=== pods ==="
           kubectl get pods -A -o wide || true
+          echo "=== consolidated workloads ==="
+          kubectl -n sandbox0-system get deployments,daemonsets,services -o wide || true
+          echo "=== manager/storage logs ==="
+          kubectl -n sandbox0-system logs -l app.kubernetes.io/component=manager --all-containers --tail=-1 || true
+          echo "=== ctld/netd logs ==="
+          kubectl -n sandbox0-system logs -l app.kubernetes.io/component=ctld --all-containers --tail=-1 || true
           echo "=== sandbox0-system events ==="
           kubectl -n sandbox0-system get events --sort-by=.lastTimestamp || true
           echo "=== infra-operator events ==="

--- a/.github/workflows/netd-cni-e2e.yml
+++ b/.github/workflows/netd-cni-e2e.yml
@@ -8,9 +8,12 @@ on:
       - "Dockerfile"
       - "Dockerfile.local"
       - "Makefile"
+      - "ctld/**"
+      - "infra-operator/**"
       - "manager/**"
       - "netd/**"
       - "pkg/**"
+      - "storage-proxy/**"
       - "tests/e2e/**"
       - "go.mod"
       - "go.sum"
@@ -79,8 +82,10 @@ jobs:
           kubectl get nodes -o wide || true
           echo "=== pods ==="
           kubectl get pods -A -o wide || true
-          echo "=== netd logs ==="
-          kubectl -n sandbox0-system logs -l app.kubernetes.io/name=netd --all-containers --tail=-1 || true
+          echo "=== consolidated workloads ==="
+          kubectl -n sandbox0-system get deployments,daemonsets,services -o wide || true
+          echo "=== ctld/netd logs ==="
+          kubectl -n sandbox0-system logs -l app.kubernetes.io/component=ctld --all-containers --tail=-1 || true
           echo "=== sandbox0-system events ==="
           kubectl -n sandbox0-system get events --sort-by=.lastTimestamp || true
           kind export logs "${RUNNER_TEMP}/kind-logs-${{ matrix.short }}" --name "${KIND_CLUSTER_NAME}" || true

--- a/README.md
+++ b/README.md
@@ -163,26 +163,24 @@ Sandboxing reduces blast radius and gives policy a real enforcement point. It do
 ```mermaid
 flowchart TB
     client["Client, SDK, CLI, or agent platform"] --> cgw["cluster-gateway"]
-    cgw --> mgr["manager"]
+    cgw --> mgr["manager<br/>lifecycle + storage-proxy runtime"]
     cgw --> pod["sandbox pod with procd"]
     mgr --> pod
-    mgr --> ctld["ctld (node-local)"]
-    mgr <--> netd["netd (optional)"]
+    mgr --> ctld["ctld HA pair (node-local)<br/>active process runs netd"]
     pod --> ctld
-    pod --> sp["storage-proxy (optional)"]
     mgr --> pg[("PostgreSQL")]
     mgr --> s3[("S3-compatible storage")]
     ctld --> s3
-    sp --> pg
-    sp --> s3
 ```
 
 Sandbox0 separates region-scoped control-plane services from cluster-scoped data-plane services. In single-cluster mode, `cluster-gateway` can act as the entrypoint. In multi-cluster mode, `regional-gateway` and `scheduler` select and route to one of the data-plane clusters in the same region.
 
+The operator keeps `storage-proxy` and `netd` as logical feature and configuration names, but it does not deploy separate workloads for them. The storage-proxy API runtime runs inside `manager`; its existing routes, internal-auth audience, and compatibility Service remain unchanged. Each sandbox node runs `ctld-a` and `ctld-b`; only the elected primary runs the embedded netd runtime, and the standby starts it when promoted.
+
 | Layer | Components | Responsibility |
 | --- | --- | --- |
 | Control plane | Optional `regional-gateway`, optional `scheduler` | Tenant/API key management, cluster selection, internal routing, template distribution |
-| Data plane | `cluster-gateway`, `manager`, `ctld`, optional `storage-proxy`, optional `netd` | Sandbox lifecycle, rootfs checkpoints, process/file APIs, volume storage, network enforcement |
+| Data plane | `cluster-gateway`, `manager` (including storage-proxy), `ctld-a` / `ctld-b` (active includes netd) | Sandbox lifecycle, rootfs checkpoints, process/file APIs, volume storage, network enforcement |
 | In-pod runtime | `procd` | PID 1 inside each sandbox pod, process abstraction, file I/O, volume mount operations |
 | Storage | PostgreSQL, ClickHouse, and S3-compatible object storage | Transactional metadata and metering delivery, long-term usage truth, rootfs/volume data |
 

--- a/ctld/HA.md
+++ b/ctld/HA.md
@@ -12,7 +12,8 @@ of both processes.
   kernel FUSE connection and the corresponding recovery manifest.
 - The primary is the only process that binds the CSI socket, serves the node
   control port, exposes the kubelet plugin-registration socket, heartbeats
-  volume ownership, or opens a writable S0FS engine.
+  volume ownership, opens a writable S0FS engine, or runs the embedded netd
+  daemon.
 - Promotion starts only after the previous primary has been fenced by release
   of the kernel-backed primary lock.
 - A returning process joins as a standby. Role changes never perform automatic
@@ -33,13 +34,25 @@ Each slot attempts a non-blocking exclusive lock on
 epoch and starts active services. A synchronized standby waits for the lock;
 acquiring it is the fencing boundary for promotion.
 
+During the one-time migration from standalone netd, the legacy DaemonSet and
+embedded runtime use a second node-local flock scoped by namespace and infra
+name. The operator first validates the guarded legacy runtime with its normal
+health probes, then rolls that exact Pod template into a delayed-lock fallback.
+The fallback stays until embedded netd is Ready. If it must serve after an
+embedded startup failure, it releases the lock every two minutes and yields
+briefly so a recovered ctld primary can retry without operator or user action.
+
 The primary creates the CSI socket before advertising its registration socket.
 It becomes ready only after kubelet validates the CSI endpoint and reports a
-successful registration. On graceful shutdown it removes the registration
-socket before releasing the primary lease. After a crash, the promoted process
-removes the stale socket after acquiring the lock and registers again. Existing
-mounts continue through the cloned FUSE channels, while new publish operations
-resume through the promoted primary and may need to retry during the handoff.
+successful registration, and after embedded netd completes its first redirect
+rule synchronization. On graceful shutdown it stops netd and removes the
+registration socket before releasing the primary lease. A fatal netd error is
+treated as a primary service failure, so the process shuts down and releases
+the same kernel-backed lease used for ctld promotion. After a crash, the
+promoted process removes the stale socket after acquiring the lock, registers
+again, and starts a fresh netd runtime. Existing mounts continue through the
+cloned FUSE channels, while new publish operations resume through the promoted
+primary and may need to retry during the handoff.
 
 ## Portal handoff
 

--- a/ctld/cmd/ctld/main.go
+++ b/ctld/cmd/ctld/main.go
@@ -65,6 +65,7 @@ var (
 	haSlot                         = os.Getenv("CTLD_HA_SLOT")
 	haProbe                        string
 	haProbeSocket                  = "/run/sandbox0/ctld-ha.sock"
+	netdConfigPath                 = strings.TrimSpace(os.Getenv("NETD_CONFIG_PATH"))
 )
 
 const (
@@ -99,6 +100,7 @@ func main() {
 	flag.StringVar(&haSlot, "ha-slot", os.Getenv("CTLD_HA_SLOT"), "stable ctld HA deployment slot")
 	flag.StringVar(&haProbe, "ha-probe", "", "run one ctld HA probe (live or ready) and exit")
 	flag.StringVar(&haProbeSocket, "ha-probe-socket", "/run/sandbox0/ctld-ha.sock", "container-local ctld HA probe socket")
+	flag.StringVar(&netdConfigPath, "netd-config-path", strings.TrimSpace(os.Getenv("NETD_CONFIG_PATH")), "explicit netd config path; empty disables embedded netd")
 	flag.Parse()
 
 	log.Println("Starting ctld")
@@ -116,8 +118,12 @@ func run() error {
 	}
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 	defer cancel()
+	netdFactory, err := configuredEmbeddedNetdFactory(netdConfigPath, httpAddr)
+	if err != nil {
+		return fmt.Errorf("validate embedded netd config: %w", err)
+	}
 	if !haEnabled {
-		return runPrimary(ctx, primaryRunOptions{})
+		return runPrimary(ctx, primaryRunOptions{netdFactory: netdFactory})
 	}
 	coordinator, err := ctldha.NewCoordinator(ctldha.Config{RootDir: portalRoot, Slot: haSlot})
 	if err != nil {
@@ -128,6 +134,18 @@ func run() error {
 		return err
 	}
 	defer probeServer.Close()
+	return runHAPrimary(ctx, coordinator, probeServer.SetServiceReady, netdFactory, runPrimary)
+}
+
+type primaryRunner func(context.Context, primaryRunOptions) error
+
+func runHAPrimary(
+	ctx context.Context,
+	coordinator *ctldha.Coordinator,
+	setReady func(bool),
+	netdFactory primaryServiceFactory,
+	runPrimaryFn primaryRunner,
+) error {
 	lease, err := coordinator.WaitForPrimary(ctx)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
@@ -140,12 +158,13 @@ func run() error {
 	if strings.TrimSpace(nodeName) != "" {
 		ownerID = "ctld-node/" + strings.TrimSpace(nodeName)
 	}
-	return runPrimary(ctx, primaryRunOptions{
+	return runPrimaryFn(ctx, primaryRunOptions{
 		replicator:     lease.Replicator,
 		requireStandby: true,
 		ownerID:        ownerID,
 		recovery:       lease.Recovery,
-		setReady:       probeServer.SetServiceReady,
+		setReady:       setReady,
+		netdFactory:    netdFactory,
 	})
 }
 
@@ -155,6 +174,7 @@ type primaryRunOptions struct {
 	ownerID        string
 	recovery       []ctldha.RecoveredPortal
 	setReady       func(bool)
+	netdFactory    primaryServiceFactory
 }
 
 func runPrimary(parent context.Context, options primaryRunOptions) error {
@@ -275,6 +295,13 @@ func runPrimary(parent context.Context, options primaryRunOptions) error {
 		registrationErrors = registrationServer.Errors()
 	}
 	serviceErrors := make(chan error, 1)
+	netdRequired := options.netdFactory != nil
+	var netdHandle *primaryServiceHandle
+	serviceReady := func() bool {
+		return ctx.Err() == nil && portalManager.RecoveryError() == nil &&
+			(registrationServer == nil || registrationServer.Registered()) &&
+			(!netdRequired || (netdHandle != nil && netdHandle.Ready()))
+	}
 
 	podCache := buildNodePodCache(ctx, k8sClient)
 	probeController := buildProbeController(k8sClient, obsProvider, podCache)
@@ -285,6 +312,7 @@ func runPrimary(parent context.Context, options primaryRunOptions) error {
 		Controller: probeController,
 		Portal:     portalManager,
 		RootFS:     buildRootFSController(ctx, storageCfg, portalManager, containerdRuntime),
+		ReadyCheck: serviceReady,
 	})
 	if obsProvider != nil {
 		httpServer.Handler = httpobs.ServerMiddleware(obsProvider.HTTPServerConfig(zapLogger))(httpServer.Handler)
@@ -294,6 +322,19 @@ func runPrimary(parent context.Context, options primaryRunOptions) error {
 	if err != nil {
 		return fmt.Errorf("listen for ctld HTTP server: %w", err)
 	}
+	if options.netdFactory != nil {
+		netdService, err := options.netdFactory()
+		if err != nil {
+			_ = httpListener.Close()
+			return fmt.Errorf("initialize embedded netd: %w", err)
+		}
+		if netdService == nil {
+			_ = httpListener.Close()
+			return fmt.Errorf("initialize embedded netd: factory returned a nil service")
+		}
+		netdHandle = startPrimaryService(ctx, netdService)
+		log.Printf("ctld primary started embedded netd")
+	}
 	go func() {
 		if err := httpServer.Serve(httpListener); err != nil && !errors.Is(err, http.ErrServerClosed) && ctx.Err() == nil {
 			serviceErrors <- fmt.Errorf("ctld HTTP server: %w", err)
@@ -301,9 +342,6 @@ func runPrimary(parent context.Context, options primaryRunOptions) error {
 	}()
 
 	if options.setReady != nil {
-		serviceReady := func() bool {
-			return portalManager.RecoveryError() == nil && (registrationServer == nil || registrationServer.Registered())
-		}
 		options.setReady(serviceReady())
 		defer options.setReady(false)
 		go func() {
@@ -319,7 +357,12 @@ func runPrimary(parent context.Context, options primaryRunOptions) error {
 			}
 		}()
 	}
+	var netdErrors <-chan error
+	if netdHandle != nil {
+		netdErrors = netdHandle.Errors()
+	}
 	var runErr error
+	netdFailed := false
 	select {
 	case <-parent.Done():
 		log.Printf("ctld primary shutting down: %v", parent.Err())
@@ -331,11 +374,25 @@ func runPrimary(parent context.Context, options primaryRunOptions) error {
 		log.Printf("ctld primary service failed: %v", runErr)
 	case runErr = <-serviceErrors:
 		log.Printf("ctld primary service failed: %v", runErr)
+	case err := <-netdErrors:
+		if netdRunErr, failed := embeddedNetdExitError(parent.Err(), err); !failed {
+			log.Printf("ctld primary shutting down: %v", parent.Err())
+		} else {
+			netdFailed = true
+			runErr = netdRunErr
+			log.Printf("ctld primary service failed: %v", runErr)
+		}
 	}
+	cancel()
 	if options.setReady != nil {
 		options.setReady(false)
 	}
-	cancel()
+	var netdShutdownCtx context.Context
+	var netdShutdownCancel context.CancelFunc
+	if netdHandle != nil {
+		netdShutdownCtx, netdShutdownCancel = context.WithTimeout(context.Background(), embeddedNetdShutdownTimeout)
+		defer netdShutdownCancel()
+	}
 	httpShutdownCtx, httpShutdownCancel := context.WithTimeout(context.Background(), httpShutdownTimeout)
 	_ = httpServer.Shutdown(httpShutdownCtx)
 	httpShutdownCancel()
@@ -353,7 +410,22 @@ func runPrimary(parent context.Context, options primaryRunOptions) error {
 		log.Printf("ctld volume portal shutdown completed with errors: %v", err)
 	}
 	portalShutdownCancel()
+	if netdHandle != nil {
+		if err := netdHandle.Wait(netdShutdownCtx); err != nil && !netdFailed {
+			runErr = errors.Join(runErr, fmt.Errorf("shutdown embedded netd: %w", err))
+		}
+	}
 	return runErr
+}
+
+func embeddedNetdExitError(parentErr, netdErr error) (error, bool) {
+	if parentErr != nil && (netdErr == nil || errors.Is(netdErr, context.Canceled)) {
+		return nil, false
+	}
+	if netdErr == nil {
+		netdErr = fmt.Errorf("service stopped unexpectedly")
+	}
+	return fmt.Errorf("embedded netd: %w", netdErr), true
 }
 
 func newHTTPServer(addr string, controller ctldserver.Controller) *http.Server {
@@ -557,8 +629,13 @@ func initPortalDatabase(ctx context.Context, cfg *apiconfig.StorageProxyConfig, 
 
 type combinedController struct {
 	ctldserver.Controller
-	Portal volumePortalHandler
-	RootFS rootFSHandler
+	Portal     volumePortalHandler
+	RootFS     rootFSHandler
+	ReadyCheck func() bool
+}
+
+func (c combinedController) Ready() bool {
+	return c.ReadyCheck == nil || c.ReadyCheck()
 }
 
 func (c combinedController) BindVolumePortal(r *http.Request, req ctldapi.BindVolumePortalRequest) (ctldapi.BindVolumePortalResponse, int) {

--- a/ctld/cmd/ctld/main_test.go
+++ b/ctld/cmd/ctld/main_test.go
@@ -21,6 +21,7 @@ func TestCtldShutdownBudgetFitsDeploymentGracePeriod(t *testing.T) {
 
 	shutdownBudget := httpShutdownTimeout + runtimeMetricsShutdownTimeout + portalShutdownTimeout
 	assert.LessOrEqual(t, shutdownBudget+shutdownGraceMargin, deployedTerminationGrace)
+	assert.LessOrEqual(t, max(shutdownBudget, embeddedNetdShutdownTimeout)+shutdownGraceMargin, deployedTerminationGrace)
 	assert.Equal(t, minimumTerminationGrace, shutdownBudget+shutdownGraceMargin)
 }
 

--- a/ctld/cmd/ctld/netd_embedded.go
+++ b/ctld/cmd/ctld/netd_embedded.go
@@ -1,0 +1,235 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	apiconfig "github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
+	"github.com/sandbox0-ai/sandbox0/netd/pkg/activeguard"
+	netddaemon "github.com/sandbox0-ai/sandbox0/netd/pkg/daemon"
+	"github.com/sandbox0-ai/sandbox0/pkg/observability"
+	"go.uber.org/zap"
+)
+
+const (
+	embeddedNetdShutdownTimeout      = 7 * time.Second
+	embeddedNetdTelemetryStopTimeout = 5 * time.Second
+	embeddedNetdStartupTimeout       = 45 * time.Second
+)
+
+type primaryService interface {
+	Run(context.Context) error
+	Ready() bool
+}
+
+type primaryServiceFactory func() (primaryService, error)
+
+type primaryServiceHandle struct {
+	service primaryService
+	errors  chan error
+	done    chan struct{}
+
+	mu  sync.RWMutex
+	err error
+}
+
+func startPrimaryService(ctx context.Context, service primaryService) *primaryServiceHandle {
+	handle := &primaryServiceHandle{
+		service: service,
+		errors:  make(chan error, 1),
+		done:    make(chan struct{}),
+	}
+	go func() {
+		err := service.Run(ctx)
+		if errors.Is(err, context.Canceled) && ctx.Err() != nil {
+			err = nil
+		}
+		if err == nil && ctx.Err() == nil {
+			err = fmt.Errorf("service stopped unexpectedly")
+		}
+		handle.mu.Lock()
+		handle.err = err
+		handle.mu.Unlock()
+		handle.errors <- err
+		close(handle.done)
+	}()
+	return handle
+}
+
+func (h *primaryServiceHandle) Ready() bool {
+	return h != nil && h.service != nil && h.service.Ready()
+}
+
+func (h *primaryServiceHandle) Errors() <-chan error {
+	if h == nil {
+		return nil
+	}
+	return h.errors
+}
+
+func (h *primaryServiceHandle) Wait(ctx context.Context) error {
+	if h == nil {
+		return nil
+	}
+	select {
+	case <-h.done:
+		h.mu.RLock()
+		defer h.mu.RUnlock()
+		return h.err
+	default:
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-h.done:
+		h.mu.RLock()
+		defer h.mu.RUnlock()
+		return h.err
+	}
+}
+
+func configuredEmbeddedNetdFactory(path, ctldHTTPAddr string) (primaryServiceFactory, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil, nil
+	}
+	cfg, err := loadEmbeddedNetdConfig(path)
+	if err != nil {
+		return nil, err
+	}
+	_, rawPort, err := net.SplitHostPort(ctldHTTPAddr)
+	if err != nil {
+		return nil, fmt.Errorf("parse ctld HTTP address %q: %w", ctldHTTPAddr, err)
+	}
+	ctldPort, err := strconv.Atoi(rawPort)
+	if err != nil {
+		return nil, fmt.Errorf("parse ctld HTTP port %q: %w", rawPort, err)
+	}
+	if err := cfg.ValidateListenerPorts(map[int]string{ctldPort: "ctld HTTP port"}); err != nil {
+		return nil, err
+	}
+	return func() (primaryService, error) {
+		return newEmbeddedNetdService(cfg.DeepCopy())
+	}, nil
+}
+
+type embeddedNetdService struct {
+	daemon        *netddaemon.Daemon
+	logger        *zap.Logger
+	observability *observability.Provider
+}
+
+func loadEmbeddedNetdConfig(configPath string) (*apiconfig.NetdConfig, error) {
+	cfg, err := apiconfig.LoadNetdConfigFromPath(configPath)
+	if err != nil {
+		return nil, err
+	}
+	cfg.NodeName = strings.TrimSpace(cfg.NodeName)
+	if cfg.NodeName == "" {
+		cfg.NodeName = strings.TrimSpace(nodeName)
+	}
+	if expected := strings.TrimSpace(nodeName); expected != "" && cfg.NodeName != expected {
+		return nil, fmt.Errorf("netd node name %q does not match ctld node name %q", cfg.NodeName, expected)
+	}
+	return cfg, nil
+}
+
+func newEmbeddedNetdService(cfg *apiconfig.NetdConfig) (*embeddedNetdService, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("netd config is nil")
+	}
+	logger, err := observability.NewLogger(observability.LoggerConfig{
+		ServiceName: "netd",
+		Level:       cfg.LogLevel,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create netd logger: %w", err)
+	}
+	provider, err := observability.New(observability.ConfigFromEnv("netd", logger))
+	if err != nil {
+		_ = logger.Sync()
+		return nil, fmt.Errorf("create netd observability: %w", err)
+	}
+	logger.Info("Starting embedded netd",
+		zap.String("node", cfg.NodeName),
+		zap.Int("health_port", cfg.HealthPort),
+		zap.Int("metrics_port", cfg.MetricsPort),
+		zap.Int("proxy_http_port", cfg.ProxyHTTPPort),
+		zap.Int("proxy_https_port", cfg.ProxyHTTPSPort),
+	)
+	return &embeddedNetdService{
+		daemon:        netddaemon.New(cfg, logger, provider),
+		logger:        logger,
+		observability: provider,
+	}, nil
+}
+
+func (s *embeddedNetdService) Run(ctx context.Context) (runErr error) {
+	if s == nil || s.daemon == nil {
+		return fmt.Errorf("embedded netd is not initialized")
+	}
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), embeddedNetdTelemetryStopTimeout)
+		defer cancel()
+		if s.observability != nil {
+			runErr = errors.Join(runErr, s.observability.Shutdown(shutdownCtx))
+		}
+		if s.logger != nil {
+			s.logger.Info("Stopped embedded netd")
+			_ = s.logger.Sync()
+		}
+	}()
+	if lockPath := strings.TrimSpace(os.Getenv(activeguard.EnvPath)); lockPath != "" {
+		if s.logger != nil {
+			s.logger.Info("Waiting for node-local netd active lock", zap.String("path", lockPath))
+		}
+		guard, err := activeguard.Acquire(ctx, lockPath)
+		if err != nil {
+			return err
+		}
+		defer guard.Close()
+		if s.logger != nil {
+			s.logger.Info("Acquired node-local netd active lock", zap.String("path", lockPath))
+		}
+	}
+	return s.runDaemonWithStartupDeadline(ctx)
+}
+
+func (s *embeddedNetdService) runDaemonWithStartupDeadline(ctx context.Context) error {
+	daemonCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- s.daemon.Run(daemonCtx) }()
+	timer := time.NewTimer(embeddedNetdStartupTimeout)
+	defer timer.Stop()
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case err := <-done:
+			return err
+		case <-ctx.Done():
+			cancel()
+			return <-done
+		case <-ticker.C:
+			if s.daemon.Ready() {
+				return <-done
+			}
+		case <-timer.C:
+			cancel()
+			err := <-done
+			return errors.Join(fmt.Errorf("embedded netd did not become ready within %s", embeddedNetdStartupTimeout), err)
+		}
+	}
+}
+
+func (s *embeddedNetdService) Ready() bool {
+	return s != nil && s.daemon != nil && s.daemon.Ready()
+}

--- a/ctld/cmd/ctld/netd_embedded_test.go
+++ b/ctld/cmd/ctld/netd_embedded_test.go
@@ -1,0 +1,203 @@
+//go:build linux
+
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	ctldha "github.com/sandbox0-ai/sandbox0/ctld/internal/ctld/ha"
+	ctldportal "github.com/sandbox0-ai/sandbox0/ctld/internal/ctld/portal"
+)
+
+type fakePrimaryService struct {
+	started         chan struct{}
+	fail            chan error
+	shutdownStarted chan struct{}
+	finishShutdown  chan struct{}
+	ready           atomic.Bool
+}
+
+func newFakePrimaryService() *fakePrimaryService {
+	return &fakePrimaryService{
+		started:         make(chan struct{}),
+		fail:            make(chan error, 1),
+		shutdownStarted: make(chan struct{}),
+		finishShutdown:  make(chan struct{}),
+	}
+}
+
+func (s *fakePrimaryService) Run(ctx context.Context) error {
+	close(s.started)
+	select {
+	case err := <-s.fail:
+		return err
+	case <-ctx.Done():
+		close(s.shutdownStarted)
+		<-s.finishShutdown
+		return nil
+	}
+}
+
+func (s *fakePrimaryService) Ready() bool {
+	return s.ready.Load()
+}
+
+func TestPrimaryServiceHandlePropagatesFailureAndReadiness(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	service := newFakePrimaryService()
+	handle := startPrimaryService(ctx, service)
+	<-service.started
+	if handle.Ready() {
+		t.Fatal("service is ready before its runtime synchronized")
+	}
+	service.ready.Store(true)
+	if !handle.Ready() {
+		t.Fatal("service readiness was not propagated")
+	}
+
+	wantErr := errors.New("netd proxy failed")
+	service.fail <- wantErr
+	select {
+	case err := <-handle.Errors():
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("Errors() = %v, want %v", err, wantErr)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("service failure was not propagated")
+	}
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), time.Second)
+	defer waitCancel()
+	if err := handle.Wait(waitCtx); !errors.Is(err, wantErr) {
+		t.Fatalf("Wait() = %v, want %v", err, wantErr)
+	}
+}
+
+func TestPrimaryServiceHandleWaitsForGracefulShutdown(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	service := newFakePrimaryService()
+	handle := startPrimaryService(ctx, service)
+	<-service.started
+	cancel()
+	<-service.shutdownStarted
+
+	shortCtx, shortCancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer shortCancel()
+	if err := handle.Wait(shortCtx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Wait() before shutdown completed = %v, want deadline exceeded", err)
+	}
+	close(service.finishShutdown)
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), time.Second)
+	defer waitCancel()
+	if err := handle.Wait(waitCtx); err != nil {
+		t.Fatalf("Wait() after shutdown completed = %v", err)
+	}
+}
+
+func TestEmbeddedNetdExitErrorTreatsCanceledParentAsGraceful(t *testing.T) {
+	for _, netdErr := range []error{nil, context.Canceled} {
+		if err, failed := embeddedNetdExitError(context.Canceled, netdErr); err != nil || failed {
+			t.Fatalf("embeddedNetdExitError(parent canceled, %v) = (%v, %t), want (nil, false)", netdErr, err, failed)
+		}
+	}
+	if err, failed := embeddedNetdExitError(nil, nil); err == nil || !failed {
+		t.Fatalf("embeddedNetdExitError(active parent, nil) = (%v, %t), want failure", err, failed)
+	}
+}
+
+func TestConfiguredEmbeddedNetdFactoryValidatesBeforePrimaryElection(t *testing.T) {
+	factory, err := configuredEmbeddedNetdFactory("", ":8095")
+	if err != nil || factory != nil {
+		t.Fatalf("configuredEmbeddedNetdFactory(empty) = (%v, %v), want (nil, nil)", factory, err)
+	}
+
+	if _, err := configuredEmbeddedNetdFactory(t.TempDir()+"/missing.yaml", ":8095"); err == nil {
+		t.Fatal("configuredEmbeddedNetdFactory(missing) succeeded, want validation error")
+	}
+
+	path := filepath.Join(t.TempDir(), "netd.yaml")
+	if err := os.WriteFile(path, []byte("node_name: node-a\nhealth_port: 8095\n"), 0o600); err != nil {
+		t.Fatalf("write netd config: %v", err)
+	}
+	if _, err := configuredEmbeddedNetdFactory(path, ":8095"); err == nil {
+		t.Fatal("configuredEmbeddedNetdFactory accepted a ctld port collision")
+	}
+}
+
+func TestRunHAPrimaryReleasesLeaseAfterEmbeddedNetdFailure(t *testing.T) {
+	root := t.TempDir()
+	primaryCoordinator, err := ctldha.NewCoordinator(ctldha.Config{RootDir: root, Slot: "a"})
+	if err != nil {
+		t.Fatalf("NewCoordinator(primary) error = %v", err)
+	}
+	standbyCoordinator, err := ctldha.NewCoordinator(ctldha.Config{RootDir: root, Slot: "b"})
+	if err != nil {
+		t.Fatalf("NewCoordinator(standby) error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	replicatorReady := make(chan *ctldha.Replicator, 1)
+	failPrimary := make(chan struct{})
+	wantErr := errors.New("embedded netd failed")
+	primaryResult := make(chan error, 1)
+	go func() {
+		primaryResult <- runHAPrimary(ctx, primaryCoordinator, nil, nil, func(_ context.Context, options primaryRunOptions) error {
+			options.replicator.SetSnapshotProvider(func(context.Context, ctldportal.PortalReplicator) error { return nil })
+			replicatorReady <- options.replicator
+			<-failPrimary
+			return wantErr
+		})
+	}()
+	replicator := <-replicatorReady
+
+	standbyResult := make(chan *ctldha.PrimaryLease, 1)
+	standbyErrors := make(chan error, 1)
+	go func() {
+		lease, waitErr := standbyCoordinator.WaitForPrimary(ctx)
+		if waitErr != nil {
+			standbyErrors <- waitErr
+			return
+		}
+		standbyResult <- lease
+	}()
+	waitForReplicatorReady(t, replicator)
+	close(failPrimary)
+
+	select {
+	case err := <-primaryResult:
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("runHAPrimary() error = %v, want %v", err, wantErr)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("failed primary did not exit")
+	}
+	select {
+	case promoted := <-standbyResult:
+		defer promoted.Close()
+		if promoted.Epoch != 2 {
+			t.Fatalf("promoted epoch = %d, want 2", promoted.Epoch)
+		}
+	case err := <-standbyErrors:
+		t.Fatalf("standby promotion error = %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("standby was not promoted after primary netd failure")
+	}
+}
+
+func waitForReplicatorReady(t *testing.T, replicator *ctldha.Replicator) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for !replicator.Ready() {
+		if time.Now().After(deadline) {
+			t.Fatal("standby did not synchronize with the primary")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/ctld/internal/ctld/server/server.go
+++ b/ctld/internal/ctld/server/server.go
@@ -44,6 +44,12 @@ type MountedVolumeController interface {
 	MountedVolumeHandler() http.Handler
 }
 
+// ReadinessController contributes primary service state to the ctld ready
+// endpoint.
+type ReadinessController interface {
+	Ready() bool
+}
+
 type NotImplementedController struct{}
 
 func (NotImplementedController) Pause(_ *http.Request, _ string) (ctldapi.PauseResponse, int) {
@@ -96,6 +102,11 @@ func NewMux(controller Controller) http.Handler {
 		_, _ = w.Write([]byte("ok"))
 	})
 	mux.HandleFunc("/readyz", func(w http.ResponseWriter, _ *http.Request) {
+		if readinessController, ok := controller.(ReadinessController); ok && !readinessController.Ready() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte("not ready"))
+			return
+		}
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))
 	})

--- a/ctld/internal/ctld/server/server_test.go
+++ b/ctld/internal/ctld/server/server_test.go
@@ -114,6 +114,32 @@ func TestNewMuxDefaultsToNotImplementedController(t *testing.T) {
 	assert.False(t, resp.Paused)
 }
 
+func TestNewMuxReadinessIncludesControllerState(t *testing.T) {
+	controller := &readinessTestController{}
+	handler := NewMux(controller)
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("not-ready status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+	}
+
+	controller.ready = true
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("ready status = %d, want %d", rec.Code, http.StatusOK)
+	}
+}
+
+type readinessTestController struct {
+	NotImplementedController
+	ready bool
+}
+
+func (c *readinessTestController) Ready() bool { return c.ready }
+
 func TestNewMuxRoutesRootFS(t *testing.T) {
 	controller := &recordingController{}
 	handler := NewMux(controller)

--- a/docs/get-started/page.mdx
+++ b/docs/get-started/page.mdx
@@ -19,9 +19,11 @@ Sandbox0 follows a control plane / data plane architecture:
 | Layer | Components | Purpose |
 |-------|------------|---------|
 | **Control Plane** | regional-gateway, scheduler | Multi-cluster routing, tenant management, request forwarding |
-| **Data Plane** | cluster-gateway, manager, storage-proxy, netd | Sandbox lifecycle, process execution, file operations, storage |
+| **Data Plane** | cluster-gateway, manager (including storage-proxy), ctld HA pair (active includes netd) | Sandbox lifecycle, process execution, file operations, storage, network enforcement |
 
 Each provider/region (e.g., `aws-us-east-1`) has an independent data plane and control plane deployment with dedicated PostgreSQL and S3 storage.
+
+`storage-proxy` and `netd` remain logical feature and configuration names. The storage API runtime is hosted by `manager`, while only the active process in each node's `ctld` HA pair runs netd. This keeps existing storage routes and internal service authentication compatible without separate storage-proxy or netd workloads.
 
 ---
 

--- a/docs/self-hosted/configuration/page.mdx
+++ b/docs/self-hosted/configuration/page.mdx
@@ -62,6 +62,8 @@ Sandbox0 Cloud handles the mutable-tag policy at the platform layer: managed-reg
 | Multi-cluster control plane | `services.regionalGateway`, `services.scheduler` | You coordinate multiple data-plane clusters in one region |
 | Multi-cluster data plane | `controlPlane`, `cluster`, `services.clusterGateway`, `services.manager`, optional `storageProxy`/`netd` | You attach a cluster to an external control plane |
 
+`services.storageProxy` and `services.netd` are stable logical configuration surfaces, not separate workload selectors. When storage-proxy is enabled, its API runtime and storage cache run in the manager Deployment; the operator preserves the storage-proxy Service and internal-auth audience for compatible routing. Existing independent replica settings remain upgrade-compatible: the shared manager Deployment uses the larger of `services.manager.replicas` and `services.storageProxy.replicas`. A storage-only profile also creates that Deployment as the process host without implicitly enabling ctld or manager-dependent node readiness. If the old storage-proxy listen port collides with a manager listener, the operator chooses a private in-Pod target port while keeping the configured storage-proxy Service port unchanged. When netd is enabled, its runtime runs only in the elected primary of the node's `ctld-a` / `ctld-b` pair. A promoted standby starts netd as part of becoming primary. A full data-plane installation therefore uses the manager Deployment plus the two ctld DaemonSets for these formerly separate service workloads.
+
 ## Cold Claim Admission
 
 Manager enforces one cluster-wide admission budget for every sandbox claim that can trigger pod startup pressure: hot claims from warm pool, cold pod creates, and asynchronous warm-pool ReplicaSet replenishment. The default budget is `min(30 * N, 80)`, where `N` is the number of ready, schedulable sandbox nodes. Sandbox node eligibility follows the manager `sandboxPodPlacement` selector and tolerations, so ordinary control-plane or unschedulable nodes do not increase the claim budget.
@@ -96,11 +98,11 @@ Platform telemetry export is disabled by default. The operator owns collection a
 
 For cold-start diagnosis, manager exposes `manager_pod_lifecycle_stage_duration_seconds`. Its `stage` label separates scheduling, the `PodReadyToStartContainers` sandbox/network boundary, procd container start, first PodIP observation, and Sandbox0 startup/readiness probe completion. The sandbox boundary is a Kubernetes lifecycle timestamp, not the duration of an individual CRI call. Collect kubelet `kubelet_runtime_operations_duration_seconds{operation_type=~"run_podsandbox|create_container|start_container"}` when exact node-level CRI operation latency is required.
 
-ClickHouse is configured once on the `Sandbox0Infra` CR under `spec.clickHouse`. The infra-operator owns builtin provisioning or external DSN resolution, the same way it owns built-in or external PostgreSQL and Redis wiring. Feature configs such as `spec.sandboxObservability` and `spec.metering` consume this region component. Do not configure the ClickHouse backend separately on cluster-gateway, ctld, manager, storage-proxy, or netd service configs when deploying through `Sandbox0Infra`.
+ClickHouse is configured once on the `Sandbox0Infra` CR under `spec.clickHouse`. The infra-operator owns builtin provisioning or external DSN resolution, the same way it owns built-in or external PostgreSQL and Redis wiring. Feature configs such as `spec.sandboxObservability` and `spec.metering` consume this region component. Do not configure the ClickHouse backend separately on cluster-gateway, ctld, manager, or the logical storage-proxy and netd service configs when deploying through `Sandbox0Infra`.
 
 Historical logs and runtime metrics are available whenever sandbox observability is enabled. Centralized sandbox audit is an enterprise feature: set `spec.sandboxObservability.audit.enabled` to `true` and provide a signed enterprise license containing the `sandbox_audit` feature. The license is mounted only into cluster-gateway, which authorizes audit ingestion and the public observability-event query and watch API.
 
-ClickHouse is the canonical audit store. Audit facts are written to `sandbox_audit_events` with stable event IDs, trusted actor and producer identity, a canonical payload digest, and an Ed25519 gateway signature. PostgreSQL is not a second audit store. The infra-operator creates separate netd producer and audit-signing key pairs: netd receives only the producer private key, while cluster-gateway receives its public key and the independent signing key. Fsync-backed buffers are delivery state, not competing audit ledgers or query sources; the public observability-event list and watch responses read only canonical ClickHouse rows and include `signature_status`, with event-ID payload conflicts reported separately as `event_id_conflict`. A buffered event is therefore not visible to audit readers until ClickHouse acknowledges it. Cluster-gateway uses a persistent volume claim for pending audit events, while each node-local netd instance keeps its flow buffer on that node. Delivery records are deleted only after ClickHouse acknowledges the exact event.
+ClickHouse is the canonical audit store. Audit facts are written to `sandbox_audit_events` with stable event IDs, trusted actor and producer identity, a canonical payload digest, and an Ed25519 gateway signature. PostgreSQL is not a second audit store. The infra-operator creates separate netd producer and audit-signing key pairs: the netd runtime in active ctld receives only the producer private key, while cluster-gateway receives its public key and the independent signing key. Fsync-backed buffers are delivery state, not competing audit ledgers or query sources; the public observability-event list and watch responses read only canonical ClickHouse rows and include `signature_status`, with event-ID payload conflicts reported separately as `event_id_conflict`. A buffered event is therefore not visible to audit readers until ClickHouse acknowledges it. Cluster-gateway uses a persistent volume claim for pending audit events, while each node-local netd runtime keeps its flow buffer on that node. Delivery records are deleted only after ClickHouse acknowledges the exact event.
 
 The v2 audit schema deliberately uses a new `sandbox_audit_events` table. Older `sandbox_events` rows do not have trustworthy actor or signature data and are retained as legacy observability history rather than being retroactively signed. Existing CRs whose persisted table value is the old default are routed to the new canonical table. At startup, audit-enabled cluster-gateway validates the actual ClickHouse engine, partition key, sorting key, and required columns, and refuses to serve audit operations against an old or incompatible custom table.
 
@@ -398,7 +400,7 @@ metadata:
 handler: gvisor-rootfs
 ```
 
-Keep `services.netd.runtimeClassName` unset, or set it only to a host-compatible runtime such as `runc`. `netd` should not run under `gvisor`, `gvisor-rootfs`, or `kata`.
+Keep `services.netd.runtimeClassName` unset, or set it only to the same host-compatible runtime used by ctld, such as `runc`. This field remains a compatibility setting; netd runs inside the elected ctld process and cannot use a different Pod runtime. Neither ctld nor its netd runtime should run under `gvisor`, `gvisor-rootfs`, or `kata`.
 
 `ctld` assumes the node's containerd data root is `/var/lib/containerd` by default. If your nodes move containerd data to another host path, configure the same path so rootfs pause/resume can use the overlayfs fast path:
 
@@ -639,10 +641,10 @@ Examples:
 - `services.manager.config.sandboxMaxMemory` caps per-sandbox memory overrides; the default is `32Gi`
 - `services.manager.config.procdBinImageRef` overrides the derived procd artifact image used by sandbox Pods
 - `services.manager.config.allowColdStartWithoutReadyDataPlane` lets cold claims create Pending pods for external node autoscaler scale-from-zero deployments; keep it disabled unless the cluster autoscaler can provision matching sandbox nodes
-- `services.storageProxy.config.filesystem*` tunes filesystem behavior; `services.manager.config.procdConfig.volume*` tunes mounted volume cache sizing
+- `services.storageProxy.config.filesystem*` tunes the storage-proxy runtime hosted by manager; `services.manager.config.procdConfig.volume*` tunes mounted volume cache sizing
 - `services.storageProxy.config.s0fsSegmentTargetSize` sets the target S0FS segment size for materialized volume data; the default is `4Mi`
 - `services.storageProxy.config.s0fsCompaction*` tunes background S0FS compaction for RWO volume owners; `s0fsCompactionInterval` accepts `0`, `off`, or `disabled` to turn it off
-- `services.storageProxy.config.cacheSizeLimit`, `logSizeLimit`, `volumePortalCacheSizeLimit`, and `volumePortalRootMinFree` cap node-local storage used by storage-proxy cache, logs, and mounted volume portals
+- `services.storageProxy.config.cacheSizeLimit` and `logSizeLimit` cap storage-proxy cache and logs in the manager Pod; `volumePortalCacheSizeLimit` and `volumePortalRootMinFree` tune the volume portals used by ctld
 - `services.storageProxy.config.objectEncryptionEnabled` controls application-layer encryption for S0FS object storage and node-local volume cache files; it is enabled by default
 - `services.netd.config.egressBandwidthBytesPerSecond`, `ingressBandwidthBytesPerSecond`, and `bandwidthBurstBytes` apply per-sandbox bandwidth throttling when set above zero
 - `services.netd.config.teamEgressBandwidthBytesPerSecond`, `teamIngressBandwidthBytesPerSecond`, and `teamBandwidthBurstBytes` apply cluster-scoped per-team aggregate throttling when set above zero and `spec.redis` is configured
@@ -675,14 +677,14 @@ spec:
                 teamBandwidthBurstBytes: 104857600
 ```
 
-Use `spec.sandboxNodePlacement` for the shared node placement consumed by sandbox template Pods, `netd`, and `ctld`. `infra-operator` owns `sandbox0.ai/data-plane-ready` and adds it to sandbox Pod placement after the required node-local components are Ready. The older `services.netd.nodeSelector` and `services.netd.tolerations` fields remain as compatibility aliases when the shared placement is unset.
+Use `spec.sandboxNodePlacement` for the shared node placement consumed by sandbox template Pods and ctld, including its embedded netd runtime. `infra-operator` owns `sandbox0.ai/data-plane-ready` and adds it to sandbox Pod placement after the required node-local components are Ready. The older `services.netd.nodeSelector` and `services.netd.tolerations` fields remain as compatibility aliases when the shared placement is unset.
 
 <Callout variant="info">
 Use the generated reference below for exact field names, defaults, enums, and required flags. Use the sample manifests for operator-friendly starting points.
 </Callout>
 
 <Callout variant="warning">
-Not every operational rule is expressible in CRD schema. Some defaults are applied at runtime inside services, and some validations are conditional. Examples include service runtime defaults in `netd` and conditional checks such as storage-proxy encryption requiring a key path.
+Not every operational rule is expressible in CRD schema. Some defaults are applied inside the embedded runtimes, and some validations are conditional. Examples include netd runtime defaults and conditional checks such as storage-proxy encryption requiring a key path.
 </Callout>
 
 ## Full Reference
@@ -695,11 +697,11 @@ The reference below is generated from the `Sandbox0Infra` CRD schema produced by
 
 - Pin the `infra-operator` chart version in production instead of relying on floating tags.
 - Prefer external PostgreSQL and external object storage for serious deployments.
-- Enable `storageProxy` only when you need volume and snapshot features.
-- Enable `netd` only on Linux nodes and only when you need network policy enforcement.
-- Use `sandboxNodePlacement` to keep sandbox workloads and node-local sandbox services on the same node set.
+- Enable the logical `storageProxy` feature only when you need volume and snapshot features; it does not create a separate Deployment.
+- Enable the logical `netd` feature only on Linux nodes and only when you need network policy enforcement; it runs in the active ctld process.
+- Use `sandboxNodePlacement` to keep sandbox workloads and the node-local ctld pair on the same node set.
 - Treat `sandbox0.ai/data-plane-ready` as operator-owned; use your own labels under `sandboxNodePlacement` and let `infra-operator` manage readiness.
-- If sandbox workloads use `gvisor` or `kata`, keep `services.netd.runtimeClassName` on a host-compatible runtime such as the cluster default runtime.
+- If sandbox workloads use `gvisor` or `kata`, keep ctld and the compatible `services.netd.runtimeClassName` setting on a host-compatible runtime such as the cluster default runtime.
 - `services.manager.config.sandboxRuntimeClassName` references an existing Kubernetes `RuntimeClass`; it does not install the node-level containerd handler.
 - Keep control-plane and data-plane components in the same storage and latency domain for a given region.
 

--- a/docs/self-hosted/install/page.mdx
+++ b/docs/self-hosted/install/page.mdx
@@ -210,7 +210,7 @@ gcloud container clusters get-credentials sandbox0-gke-gvisor --region us-east1
 kubectl get nodes -o wide
 ```
 
-Keep a regular node pool for core system services. In the current GKE `gVisor` sample, components such as `cluster-gateway`, `manager`, `storage-proxy`, PostgreSQL, and the builtin registry run on the regular pool, while sandbox workloads run on the `gVisor` pool.
+Keep a regular node pool for core system services. In the current GKE `gVisor` sample, components such as `cluster-gateway`, `manager` (including the storage-proxy runtime), PostgreSQL, and the builtin registry run on the regular pool. The ctld HA pair, including netd in its active process, and sandbox workloads run on the `gVisor` node pool while using the host-compatible runtime where required.
 
 ### 3) Add a `gVisor` Node Pool
 
@@ -277,8 +277,16 @@ Expected result:
 
 1. `Sandbox0Infra` becomes `Ready`
 2. `fullmode-cluster-gateway` is exposed as `LoadBalancer` on port `80`
-3. `fullmode-netd`, `fullmode-ctld-a`, and `fullmode-ctld-b` run on `gvisor-lite`
+3. `fullmode-ctld-a` and `fullmode-ctld-b` run on `gvisor-lite`; the elected primary runs netd in-process
 4. sandbox pods in `tpl-default` run on `gvisor-lite`
+
+There is no separate `fullmode-netd` DaemonSet or `fullmode-storage-proxy` Deployment. The compatibility storage-proxy Service routes to the storage runtime in `fullmode-manager`.
+
+When upgrading an installation that still has the standalone workloads, infra-operator first upgrades the old netd DaemonSet to the new image and proves it Ready while it owns a shared node-local active lock. After both current ctld HA templates are running, that exact validated legacy template rolls into a delayed-lock fallback. The elected ctld primary gets the first opportunity to acquire the lock and initialize embedded netd. The fallback remains present until ctld recovery, kubelet registration, and netd's initial policy sync are all Ready; if embedded initialization fails, it temporarily reacquires the lock and periodically yields it for automatic ctld retry. Only then does the operator remove the standalone DaemonSet and its legacy RBAC. This prevents two netd runtimes from programming the same node concurrently without making the cutover destructive.
+
+For storage, the operator starts the embedded runtime in manager and waits for its rollout before repointing the compatibility storage-proxy Service and removing the old Deployment. Existing API paths, the `storage-proxy` internal-auth audience, and `services.storageProxy` configuration do not change. Existing manager/storage replica differences are normalized to the larger replica count for the shared Deployment, and a storage listen-port collision is remapped only inside the Pod; the compatibility Service keeps its configured port. Storage-only installations use the manager Deployment as the runtime host without enabling ctld or manager node-readiness gates.
+
+Rolling back to a release from before process consolidation is a maintenance operation, not a one-step image rollback. First stop new claims and drain sandbox workloads from the affected nodes. With infra-operator paused, roll both ctld slots to the old template and wait for embedded netd to stop before starting the old unguarded netd DaemonSet. Start and verify the old storage-proxy Deployment before switching its compatibility Service away from manager, then roll manager back and resume the old operator. Re-enabling an old operator before those workload transitions can overlap guarded embedded netd with an unguarded legacy process. Forward upgrades and rollbacks between releases that both contain process consolidation use the normal HA rollout.
 
 This sample uses the native GKE node label `sandbox.gke.io/runtime=gvisor` for sandbox placement. You do not need to add a separate custom node label just to target `gVisor` nodes.
 
@@ -329,7 +337,7 @@ spec:
                 sandboxRuntimeClassName: gvisor-rootfs
 ```
 
-Do not set `services.netd.runtimeClassName` to `gvisor`, `gvisor-rootfs`, or `kata`. `netd` should keep running on the node's default host-compatible runtime.
+Do not set `services.netd.runtimeClassName` to `gvisor`, `gvisor-rootfs`, or `kata`. The field remains for configuration compatibility, but netd runs inside the elected ctld process and therefore uses the same host-compatible Pod runtime as ctld.
 
 `ctld` assumes the node's containerd data root is `/var/lib/containerd` by default. If your node bootstrap stores containerd data somewhere else, set `services.ctld.containerdHostDataRoot` to the actual host path:
 
@@ -406,19 +414,19 @@ If `s0 sandbox create` returns a sandbox ID and the sandbox reaches `running`, t
 
 - Sandbox0 requires different runtime behavior for different components. On GKE, keep a regular node pool for system services and a `gVisor` node pool for sandbox workloads.
 - Sandbox workload runtime selection should be handled by cluster defaults or administrator-managed service configuration, and the GCP `gVisor` sample places sandbox workloads onto nodes labeled `sandbox.gke.io/runtime=gvisor`.
-- Use `sandboxNodePlacement` to place sandbox workloads, `netd`, and `ctld` onto the same sandbox node pool.
-- Do not set `services.netd.runtimeClassName: gvisor`.
+- Use `sandboxNodePlacement` to place sandbox workloads and the ctld HA pair, including its embedded netd runtime, onto the same sandbox node pool.
+- Do not set `services.netd.runtimeClassName: gvisor`; it must remain compatible with the ctld Pod runtime.
 - `infra-operator` does not install containerd runtime handlers. Install `runsc`/`containerd-shim-runsc-v1`, configure the handler, restart containerd, and create the `RuntimeClass` before using a custom `sandboxRuntimeClassName`.
 - If containerd uses a non-default data root, set `services.ctld.containerdHostDataRoot` to that host path so rootfs pause/resume can use the overlayfs fast path.
-- `infra-operator` runs two independent ctld DaemonSets per sandbox node, with one ctld container in each Pod. The elected primary owns the CSI endpoint, kubelet registration, and FUSE request channels; the synchronized standby preserves existing mounts across a single ctld process or Pod failure. Registration follows the primary automatically, so new volume mounts resume after promotion. A filesystem or mount call in progress during the handoff can return an error and should be retried. Node reboot, kernel failure, and simultaneous loss of both ctld Pods remain outside this protection boundary.
+- `infra-operator` runs two independent ctld DaemonSets per sandbox node, with one ctld container in each Pod. The elected primary owns the CSI endpoint, kubelet registration, FUSE request channels, and the embedded netd runtime. The synchronized standby preserves existing mounts across a single ctld process or Pod failure, then starts netd as part of promotion. Registration and network enforcement follow the primary automatically. A filesystem, mount, or newly established network flow in progress during handoff can return an error and should be retried. Node reboot, kernel failure, and simultaneous loss of both ctld Pods remain outside this protection boundary.
 - Before the first upgrade from the historical single-DaemonSet ctld deployment, drain running Sandboxes from the affected nodes. The legacy process cannot transfer FUSE connections created before the primary/standby protocol. Later image rollouts use surge-before-delete standby synchronization and do not require this drain.
-- `netd` and `ctld` depend on host features such as `hostNetwork` and `hostPath`. This is why GKE Autopilot is not a good fit for full Sandbox0 deployments.
-- Even when `netd` and `ctld` are scheduled onto `gVisor` nodes, they still run on the node's default host runtime because `services.netd.runtimeClassName` remains unset.
+- `ctld` and its embedded netd runtime depend on host features such as `hostNetwork` and `hostPath`. This is why GKE Autopilot is not a good fit for full Sandbox0 deployments.
+- Even when ctld is scheduled onto `gVisor` nodes, its Pod still uses the node's default host runtime; the compatibility `services.netd.runtimeClassName` setting remains unset.
 - If you hit GCP `SSD_TOTAL_GB` quota limits while creating node pools, reduce `--disk-size` explicitly instead of relying on the larger default boot disk size.
 
 ### Why Not Autopilot
 
-Autopilot is not suitable for the full `fullmode` deployment because Sandbox0 host-level components need capabilities that Autopilot restricts. In practice, `netd` and `ctld` need node-level access, while template sandbox pods run on the `gVisor` pool.
+Autopilot is not suitable for the full `fullmode` deployment because Sandbox0 host-level components need capabilities that Autopilot restricts. In practice, ctld and its embedded netd runtime need node-level access, while template sandbox pods run on the `gVisor` pool.
 
 ## Next Steps
 

--- a/docs/self-hosted/page.mdx
+++ b/docs/self-hosted/page.mdx
@@ -15,7 +15,7 @@ Sandbox0 self-hosted is **operator-first**.
 ### Planes and Core Services
 
 - **Control plane** (optional in single-cluster): `regional-gateway`, `scheduler`
-- **Data plane** (runtime): `cluster-gateway`, `manager`, optional `storage-proxy`, optional `netd`
+- **Data plane** (runtime): `cluster-gateway`, `manager` with the optional storage-proxy runtime, and a node-local `ctld` HA pair whose active process can run netd
 - **In-pod runtime**: `procd` runs inside each sandbox pod and handles process/files/volume mount operations
 
 ### Single-Cluster vs Multi-Cluster
@@ -36,12 +36,11 @@ flowchart TD
 
         subgraph s0[Sandbox0 Services]
             direction LR
-            igw --> mgr[manager]
+            igw --> mgr[manager - lifecycle and storage-proxy API]
             igw --> pods[Sandbox Pods - procd inside]
             mgr --> pods
-            mgr --> netd[netd]
-            netd --> mgr
-            mgr --> sp[storage-proxy]
+            mgr --> ctld[ctld-a / ctld-b - active runs netd]
+            pods --> ctld
         end
 
         subgraph mw[Middleware Dependencies]
@@ -52,18 +51,21 @@ flowchart TD
         end
 
         igw --> pg
-        sp --> pg
-        sp --> s3
+        mgr --> pg
+        mgr --> s3
+        ctld --> s3
         mgr --> reg
     end
 ```
 
-In full mode single-cluster, `cluster-gateway`, `manager`, `storage-proxy`, and `netd` are Sandbox0 services. PostgreSQL, S3/OSS, and optional image registry are middleware dependencies.
+In full mode single-cluster, `storage-proxy` and `netd` remain logical Sandbox0 components, but they are not separate workloads. The storage-proxy API runtime runs in the `manager` Deployment. Each sandbox node has `ctld-a` and `ctld-b` DaemonSet Pods; only the elected primary runs netd, and the synchronized standby starts it after promotion. The existing storage API paths, storage-proxy internal-auth audience, compatibility Service, and `services.storageProxy` / `services.netd` configuration blocks remain stable. PostgreSQL, S3/OSS, and the optional image registry are middleware dependencies.
 
 ### Request Flow
 
 - **Single-cluster (typical)**: client -> `cluster-gateway` -> `manager` -> sandbox pod (`procd`)
 - **Single-cluster (direct pod path)**: client -> `cluster-gateway` -> sandbox pod (`procd`) (for applicable traffic paths)
+- **Volume API**: client -> `cluster-gateway` -> storage-proxy compatibility Service -> embedded runtime in `manager` -> object storage or the active ctld mount owner
+- **Sandbox network**: sandbox pod -> embedded netd runtime in the active `ctld` process -> allowed upstream
 - **Multi-cluster**: client -> `regional-gateway` -> `scheduler` -> target cluster `cluster-gateway` -> `manager`
 
 ### Regional Boundary

--- a/docs/volume/http/page.mdx
+++ b/docs/volume/http/page.mdx
@@ -5,7 +5,7 @@ Use direct Volume file operations to operate on files in a Volume by volume ID, 
 Start with the Go, Python, TypeScript SDKs, or the `s0` CLI. The endpoint reference below is for advanced integrations and custom clients that need to call the HTTP and WebSocket API directly.
 
 <Callout variant="info">
-Requests still go through the normal gateway chain and team-scoped auth. For `s0fs` Volumes, `storage-proxy` lazily attaches the Volume and reclaims idle direct mounts later. For `s3` backend Volumes, direct file requests are supported only while an active ctld mount owner can serve the request. See [Volume Backends](/docs/sandbox/volume/backends).
+Requests still go through the normal gateway chain and team-scoped auth. For `s0fs` Volumes, the storage-proxy runtime embedded in manager lazily attaches the Volume and reclaims idle direct mounts later; its API routes and internal-auth audience remain unchanged. For `s3` backend Volumes, direct file requests are supported only while an active ctld mount owner can serve the request. See [Volume Backends](/docs/sandbox/volume/backends).
 </Callout>
 
 ## Base Model

--- a/docs/volume/page.mdx
+++ b/docs/volume/page.mdx
@@ -57,7 +57,7 @@ For mounted `RWO` volumes, Sandbox0 keeps one active writable owner at a time.
 
 - when a sandbox mounts an `RWO` volume, the node-local mount owner becomes authoritative for reads and writes
 - direct volume file API requests are routed to that mounted owner instead of opening a second writable mount
-- for `s0fs` volumes that are not mounted into a sandbox, `storage-proxy` serves direct file API requests itself
+- for `s0fs` volumes that are not mounted into a sandbox, the storage-proxy runtime embedded in manager serves direct file API requests itself
 
 This keeps the mounted filesystem view and the direct volume API view consistent in both directions. For `s3` backend Volumes, direct file API requests require an active ctld mount owner; otherwise use S3 APIs directly or mount the Volume into a Sandbox first.
 
@@ -68,10 +68,10 @@ Sandbox0 encrypts persisted S0FS volume data at the application layer before it 
 Manifest objects are encrypted as full blobs. Segment objects are encrypted in independently authenticated chunks, so cold file reads can still fetch only the ciphertext chunks needed for the requested byte range. Node-local cache files, including the S0FS WAL, head state, and snapshot state, are also encrypted before they are written to disk.
 
 <Callout variant="info">
-This is service-side application-layer encryption. `storage-proxy` and `ctld` hold the volume encryption key so they can serve normal POSIX filesystem reads and writes. It is not end-to-end encryption where Sandbox0 services cannot decrypt volume data.
+This is service-side application-layer encryption. The storage-proxy runtime in manager and the active ctld process hold the volume encryption key so they can serve normal POSIX filesystem reads and writes. It is not end-to-end encryption where Sandbox0 services cannot decrypt volume data.
 </Callout>
 
-For self-hosted deployments, see [Self-hosted Configuration](/docs/sandbox/self-hosted/configuration) for the storage-proxy encryption setting.
+For self-hosted deployments, see [Self-hosted Configuration](/docs/sandbox/self-hosted/configuration) for the `services.storageProxy` encryption setting. The configuration name is retained even though the runtime is hosted by manager.
 
 ## Direct File Operations
 
@@ -80,7 +80,7 @@ For `s0fs` Volumes, you can operate on files directly by Volume ID without mount
 This is useful for SDK workflows, developer tooling, and small control-plane style file tasks where starting or reusing a Sandbox would only add latency.
 
 <Callout variant="info">
-Direct volume file APIs still go through the normal gateway chain and team-scoped auth. When an `s0fs` volume is already mounted into a sandbox, the API request is served by that mounted owner. When it is not mounted, `storage-proxy` lazily attaches the volume on demand and reclaims idle direct mounts later. `s3` backend Volumes require an active mounted owner for direct file API requests.
+Direct volume file APIs still go through the normal gateway chain and team-scoped auth. When an `s0fs` volume is already mounted into a sandbox, the API request is served by that mounted owner. When it is not mounted, the storage-proxy runtime in manager lazily attaches the volume on demand and reclaims idle direct mounts later. The API routes and storage-proxy internal-auth audience are unchanged. `s3` backend Volumes require an active mounted owner for direct file API requests.
 </Callout>
 
 The direct file API surface mirrors the Sandbox file API:

--- a/infra-operator/api/config/netd.go
+++ b/infra-operator/api/config/netd.go
@@ -219,14 +219,26 @@ func LoadNetdConfig() *NetdConfig {
 		path = "/config/config.yaml"
 	}
 
-	cfg, err := loadNetdConfig(path)
+	cfg, err := LoadNetdConfigFromPath(path)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to load config from %s: %v, using defaults\n", path, err)
 		cfg = &NetdConfig{}
+		applyNetdDefaults(cfg)
 	}
-
-	applyNetdDefaults(cfg)
 	return cfg
+}
+
+// LoadNetdConfigFromPath loads netd configuration from an explicit path. It
+// allows another binary, such as ctld, to embed netd without sharing its own
+// CONFIG_PATH or silently falling back to defaults when the netd config is
+// invalid.
+func LoadNetdConfigFromPath(path string) (*NetdConfig, error) {
+	cfg, err := loadNetdConfig(path)
+	if err != nil {
+		return nil, err
+	}
+	applyNetdDefaults(cfg)
+	return cfg, nil
 }
 
 func loadNetdConfig(path string) (*NetdConfig, error) {
@@ -248,6 +260,37 @@ func loadNetdConfig(path string) (*NetdConfig, error) {
 	}
 
 	return cfg, nil
+}
+
+// ValidateListenerPorts rejects listener collisions inside netd and with
+// ports reserved by an embedding process such as ctld.
+func (c *NetdConfig) ValidateListenerPorts(reserved map[int]string) error {
+	if c == nil {
+		return fmt.Errorf("netd config is required")
+	}
+	listeners := []struct {
+		name string
+		port int
+	}{
+		{name: "health", port: c.HealthPort},
+		{name: "metrics", port: c.MetricsPort},
+		{name: "HTTP proxy", port: c.ProxyHTTPPort},
+		{name: "HTTPS proxy", port: c.ProxyHTTPSPort},
+	}
+	seen := make(map[int]string, len(listeners))
+	for _, listener := range listeners {
+		if listener.port <= 0 || listener.port > 65535 {
+			return fmt.Errorf("netd %s port %d is outside 1-65535", listener.name, listener.port)
+		}
+		if previous := seen[listener.port]; previous != "" {
+			return fmt.Errorf("netd %s port %d conflicts with netd %s port", listener.name, listener.port, previous)
+		}
+		if owner := reserved[listener.port]; owner != "" {
+			return fmt.Errorf("netd %s port %d conflicts with %s", listener.name, listener.port, owner)
+		}
+		seen[listener.port] = listener.name
+	}
+	return nil
 }
 
 func applyNetdDefaults(cfg *NetdConfig) {

--- a/infra-operator/api/config/netd_test.go
+++ b/infra-operator/api/config/netd_test.go
@@ -27,6 +27,27 @@ sandbox_observability_audit_delivery_mode: canonical_sync
 	}
 }
 
+func TestLoadNetdConfigFromPathAppliesDefaults(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "netd.yaml")
+	if err := os.WriteFile(path, []byte("node_name: node-a\nhealth_port: 18081\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := LoadNetdConfigFromPath(path)
+	if err != nil {
+		t.Fatalf("LoadNetdConfigFromPath() error = %v", err)
+	}
+	if cfg.NodeName != "node-a" {
+		t.Fatalf("node name = %q, want node-a", cfg.NodeName)
+	}
+	if cfg.HealthPort != 18081 {
+		t.Fatalf("health port = %d, want 18081", cfg.HealthPort)
+	}
+	if cfg.MetricsPort != 9091 {
+		t.Fatalf("metrics port = %d, want default 9091", cfg.MetricsPort)
+	}
+}
+
 func TestApplyNetdDefaultsAuditDeliveryMode(t *testing.T) {
 	t.Run("empty defaults to durable async", func(t *testing.T) {
 		cfg := &NetdConfig{}
@@ -43,4 +64,19 @@ func TestApplyNetdDefaultsAuditDeliveryMode(t *testing.T) {
 			t.Fatalf("audit delivery mode = %q, want canonical_sync", cfg.SandboxObservabilityAuditDeliveryMode)
 		}
 	})
+}
+
+func TestNetdConfigValidateListenerPorts(t *testing.T) {
+	cfg := &NetdConfig{HealthPort: 8081, MetricsPort: 9091, ProxyHTTPPort: 18080, ProxyHTTPSPort: 18443}
+	if err := cfg.ValidateListenerPorts(map[int]string{8095: "ctld HTTP port"}); err != nil {
+		t.Fatalf("valid ports rejected: %v", err)
+	}
+	cfg.HealthPort = 8095
+	if err := cfg.ValidateListenerPorts(map[int]string{8095: "ctld HTTP port"}); err == nil {
+		t.Fatal("reserved ctld port collision accepted")
+	}
+	cfg.HealthPort = 9091
+	if err := cfg.ValidateListenerPorts(nil); err == nil {
+		t.Fatal("netd listener collision accepted")
+	}
 }

--- a/infra-operator/api/config/storage_proxy.go
+++ b/infra-operator/api/config/storage_proxy.go
@@ -196,13 +196,18 @@ func LoadStorageProxyConfig() *StorageProxyConfig {
 	if path == "" {
 		path = "/config/config.yaml"
 	}
-
 	cfg, err := loadStorageProxyConfig(path)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to load config from %s: %v, using empty config\n", path, err)
 		cfg = &StorageProxyConfig{}
 	}
 	return cfg
+}
+
+// ReadStorageProxyConfig loads storage-proxy configuration from an explicit
+// path and returns parsing errors to the embedding process.
+func ReadStorageProxyConfig(path string) (*StorageProxyConfig, error) {
+	return loadStorageProxyConfig(path)
 }
 
 func loadStorageProxyConfig(path string) (*StorageProxyConfig, error) {

--- a/infra-operator/api/config/storage_proxy_test.go
+++ b/infra-operator/api/config/storage_proxy_test.go
@@ -1,0 +1,32 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadStorageProxyConfig(t *testing.T) {
+	t.Setenv("TEST_STORAGE_DATABASE_URL", "postgres://storage")
+	path := filepath.Join(t.TempDir(), "storage-proxy.yaml")
+	if err := os.WriteFile(path, []byte("http_port: 18081\ndatabase_url: ${TEST_STORAGE_DATABASE_URL}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := ReadStorageProxyConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.HTTPPort != 18081 {
+		t.Fatalf("HTTPPort = %d, want 18081", cfg.HTTPPort)
+	}
+	if cfg.DatabaseURL != "postgres://storage" {
+		t.Fatalf("DatabaseURL = %q, want expanded value", cfg.DatabaseURL)
+	}
+}
+
+func TestReadStorageProxyConfigReturnsReadError(t *testing.T) {
+	if _, err := ReadStorageProxyConfig(filepath.Join(t.TempDir(), "missing.yaml")); err == nil {
+		t.Fatal("ReadStorageProxyConfig() error = nil, want read error")
+	}
+}

--- a/infra-operator/chart/samples/multi-cluster/data-plane.yaml
+++ b/infra-operator/chart/samples/multi-cluster/data-plane.yaml
@@ -1,4 +1,4 @@
-# Example: Multi-cluster data plane (cluster-gateway + manager + storage-proxy)
+# Example: Multi-cluster data plane (cluster-gateway + manager-hosted storage + ctld)
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/infra-operator/chart/samples/single-cluster/network-policy.yaml
+++ b/infra-operator/chart/samples/single-cluster/network-policy.yaml
@@ -1,4 +1,4 @@
-# Example: Single-cluster network policy mode (netd)
+# Example: Single-cluster network policy mode (ctld-hosted netd)
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/infra-operator/chart/samples/single-cluster/volumes.yaml
+++ b/infra-operator/chart/samples/single-cluster/volumes.yaml
@@ -1,4 +1,4 @@
-# Example: Single-cluster volumes mode (minimal + storage-proxy)
+# Example: Single-cluster volumes mode (manager-hosted storage API)
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/infra-operator/internal/controller/pkg/common/common.go
+++ b/infra-operator/internal/controller/pkg/common/common.go
@@ -130,19 +130,7 @@ func (r *ResourceManager) ReconcileDeploymentWithScope(ctx context.Context, scop
 		return err
 	}
 
-	defaultResources := corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("100m"),
-			corev1.ResourceMemory: resource.MustParse("256Mi"),
-		},
-		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("500m"),
-			corev1.ResourceMemory: resource.MustParse("512Mi"),
-		},
-	}
-	if def.Resources != nil {
-		defaultResources = *def.Resources
-	}
+	resolvedResources := ResolveDeploymentResources(def.Resources)
 
 	desiredLabels := EnsureManagedLabels(labels, name)
 	desiredDeploy := &appsv1.Deployment{
@@ -173,7 +161,7 @@ func (r *ResourceManager) ReconcileDeploymentWithScope(ctx context.Context, scop
 							Env:             def.EnvVars,
 							VolumeMounts:    def.VolumeMounts,
 							Ports:           ResolveContainerPorts(def),
-							Resources:       defaultResources,
+							Resources:       resolvedResources,
 							LivenessProbe:   def.LivenessProbe,
 							ReadinessProbe:  def.ReadinessProbe,
 						},
@@ -207,6 +195,26 @@ func (r *ResourceManager) ReconcileDeploymentWithScope(ctx context.Context, scop
 	})
 }
 
+// ResolveDeploymentResources returns the effective resources used by a
+// deployment container. Callers embedding a former standalone workload can
+// use it before summing both workloads' effective requests and limits.
+func ResolveDeploymentResources(explicit *corev1.ResourceRequirements) corev1.ResourceRequirements {
+	defaults := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("500m"),
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+		},
+	}
+	if explicit == nil {
+		return defaults
+	}
+	return *explicit.DeepCopy()
+}
+
 // EnsureDeploymentReady validates deployment readiness before reporting success.
 func (r *ResourceManager) EnsureDeploymentReady(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, name string, replicas int32) error {
 	return r.EnsureDeploymentReadyWithScope(ctx, NewObjectScope(infra), name, replicas)
@@ -231,6 +239,45 @@ func (r *ResourceManager) EnsureDeploymentReadyWithScope(ctx context.Context, sc
 	}
 	if deploy.Status.ReadyReplicas < desired {
 		return fmt.Errorf("deployment %q not ready: %d/%d ready", name, deploy.Status.ReadyReplicas, desired)
+	}
+	return nil
+}
+
+// EnsureDeploymentRolloutComplete validates that every desired replica is from
+// the current Deployment generation and is both ready and available. This is
+// stronger than EnsureDeploymentReady and is required before switching a
+// compatibility Service to a newly added listener in an existing process.
+func (r *ResourceManager) EnsureDeploymentRolloutComplete(ctx context.Context, scope ObjectScope, name string, replicas int32) error {
+	if replicas == 0 {
+		return nil
+	}
+
+	deploy := &appsv1.Deployment{}
+	if err := r.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: scope.Namespace}, deploy); err != nil {
+		return err
+	}
+
+	desired := replicas
+	if deploy.Spec.Replicas != nil {
+		desired = *deploy.Spec.Replicas
+	}
+	if desired == 0 {
+		return nil
+	}
+	if deploy.Status.ObservedGeneration < deploy.Generation {
+		return fmt.Errorf("deployment %q rollout pending: observed generation %d, desired generation %d", name, deploy.Status.ObservedGeneration, deploy.Generation)
+	}
+	if deploy.Status.Replicas != desired || deploy.Status.UpdatedReplicas != desired || deploy.Status.ReadyReplicas != desired || deploy.Status.AvailableReplicas != desired || deploy.Status.UnavailableReplicas != 0 {
+		return fmt.Errorf(
+			"deployment %q rollout pending: replicas=%d updated=%d ready=%d available=%d unavailable=%d desired=%d",
+			name,
+			deploy.Status.Replicas,
+			deploy.Status.UpdatedReplicas,
+			deploy.Status.ReadyReplicas,
+			deploy.Status.AvailableReplicas,
+			deploy.Status.UnavailableReplicas,
+			desired,
+		)
 	}
 	return nil
 }

--- a/infra-operator/internal/controller/pkg/common/common_test.go
+++ b/infra-operator/internal/controller/pkg/common/common_test.go
@@ -868,6 +868,56 @@ func newCommonTestScheme(t *testing.T) *runtime.Scheme {
 	return scheme
 }
 
+func TestEnsureDeploymentRolloutCompleteRejectsReadyOldReplica(t *testing.T) {
+	testCases := []struct {
+		name    string
+		status  appsv1.DeploymentStatus
+		wantErr bool
+	}{
+		{
+			name: "old replica is still serving",
+			status: appsv1.DeploymentStatus{
+				ObservedGeneration: 2,
+				Replicas:           2,
+				UpdatedReplicas:    1,
+				ReadyReplicas:      2,
+				AvailableReplicas:  2,
+			},
+			wantErr: true,
+		},
+		{
+			name: "current replica is ready and available",
+			status: appsv1.DeploymentStatus{
+				ObservedGeneration: 2,
+				Replicas:           1,
+				UpdatedReplicas:    1,
+				ReadyReplicas:      1,
+				AvailableReplicas:  1,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			infra := newCommonTestInfra()
+			replicas := int32(1)
+			deployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "demo-manager", Namespace: infra.Namespace, Generation: 2},
+				Spec:       appsv1.DeploymentSpec{Replicas: &replicas},
+				Status:     testCase.status,
+			}
+			resources, _ := newCommonTestResourceManager(t, interceptor.Funcs{}, deployment)
+			err := resources.EnsureDeploymentRolloutComplete(context.Background(), NewObjectScope(infra), deployment.Name, replicas)
+			if testCase.wantErr && err == nil {
+				t.Fatal("EnsureDeploymentRolloutComplete() error = nil, want rollout pending")
+			}
+			if !testCase.wantErr && err != nil {
+				t.Fatalf("EnsureDeploymentRolloutComplete() error = %v", err)
+			}
+		})
+	}
+}
+
 func newCommonTestInfra() *infrav1alpha1.Sandbox0Infra {
 	return &infrav1alpha1.Sandbox0Infra{
 		ObjectMeta: metav1.ObjectMeta{

--- a/infra-operator/internal/controller/pkg/rbac/rbac.go
+++ b/infra-operator/internal/controller/pkg/rbac/rbac.go
@@ -52,7 +52,7 @@ func (r *Reconciler) ReconcileManagerRBAC(ctx context.Context, infra *infrav1alp
 		"app.kubernetes.io/managed-by": "sandbox0infra-operator",
 	}
 
-	if err := r.reconcileServiceAccount(ctx, infra, name, labels, nil); err != nil {
+	if err := r.reconcileServiceAccount(ctx, infra, name, labels, storageWorkloadIdentityAnnotations(infra)); err != nil {
 		return err
 	}
 
@@ -146,39 +146,6 @@ func (r *Reconciler) ReconcileSchedulerRBAC(ctx context.Context, infra *infrav1a
 	return r.reconcileServiceAccount(ctx, infra, name, labels, nil)
 }
 
-// ReconcileStorageProxyRBAC reconciles RBAC for the storage-proxy service.
-func (r *Reconciler) ReconcileStorageProxyRBAC(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra) error {
-	name := fmt.Sprintf("%s-storage-proxy", infra.Name)
-	labels := map[string]string{
-		"app.kubernetes.io/name":       "storage-proxy",
-		"app.kubernetes.io/instance":   infra.Name,
-		"app.kubernetes.io/managed-by": "sandbox0infra-operator",
-	}
-
-	if err := r.reconcileServiceAccount(ctx, infra, name, labels, storageWorkloadIdentityAnnotations(infra)); err != nil {
-		return err
-	}
-
-	rules := []rbacv1.PolicyRule{
-		{
-			APIGroups: []string{""},
-			Resources: []string{"pods", "events"},
-			Verbs:     []string{"get", "list", "watch", "create", "patch"},
-		},
-		{
-			APIGroups: []string{""},
-			Resources: []string{"nodes"},
-			Verbs:     []string{"get"},
-		},
-	}
-
-	if err := r.reconcileClusterRole(ctx, name, labels, rules); err != nil {
-		return err
-	}
-
-	return r.reconcileClusterRoleBinding(ctx, infra, name, labels, name, name)
-}
-
 // ReconcileCtldRBAC reconciles RBAC for the ctld daemonset.
 func (r *Reconciler) ReconcileCtldRBAC(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra) error {
 	name := fmt.Sprintf("%s-ctld", infra.Name)
@@ -195,13 +162,23 @@ func (r *Reconciler) ReconcileCtldRBAC(ctx context.Context, infra *infrav1alpha1
 	rules := []rbacv1.PolicyRule{
 		{
 			APIGroups: []string{""},
-			Resources: []string{"pods"},
+			Resources: []string{"pods", "pods/status"},
 			Verbs:     []string{"get", "list", "watch", "update", "patch"},
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{"nodes", "services", "endpoints"},
+			Verbs:     []string{"get", "list", "watch"},
 		},
 		{
 			APIGroups: []string{""},
 			Resources: []string{"pods/resize"},
 			Verbs:     []string{"update", "patch"},
+		},
+		{
+			APIGroups: []string{"discovery.k8s.io"},
+			Resources: []string{"endpointslices"},
+			Verbs:     []string{"get", "list", "watch"},
 		},
 	}
 

--- a/infra-operator/internal/controller/pkg/rbac/rbac_test.go
+++ b/infra-operator/internal/controller/pkg/rbac/rbac_test.go
@@ -162,6 +162,16 @@ func TestReconcileCtldRBACIncludesPodReadPermissions(t *testing.T) {
 
 	found = false
 	for _, rule := range role.Rules {
+		if !contains(rule.Resources, "nodes") || !contains(rule.Resources, "services") || !contains(rule.Resources, "endpoints") {
+			continue
+		}
+		assert.ElementsMatch(t, []string{"get", "list", "watch"}, rule.Verbs)
+		found = true
+	}
+	assert.True(t, found, "expected embedded netd discovery resources to remain read-only")
+
+	found = false
+	for _, rule := range role.Rules {
 		if !contains(rule.Resources, "pods/resize") {
 			continue
 		}
@@ -169,43 +179,19 @@ func TestReconcileCtldRBACIncludesPodReadPermissions(t *testing.T) {
 		found = true
 	}
 	assert.True(t, found, "expected ctld cluster role to include pod resize permissions")
-}
 
-func TestReconcileStorageProxyRBACIncludesNodeReadPermission(t *testing.T) {
-	scheme := runtime.NewScheme()
-	require.NoError(t, corev1.AddToScheme(scheme))
-	require.NoError(t, rbacv1.AddToScheme(scheme))
-	require.NoError(t, infrav1alpha1.AddToScheme(scheme))
-
-	infra := &infrav1alpha1.Sandbox0Infra{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "demo",
-			Namespace: "sandbox0-system",
-		},
-	}
-	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(infra).Build()
-	reconciler := NewReconciler(&common.ResourceManager{Client: client, Scheme: scheme})
-
-	require.NoError(t, reconciler.ReconcileStorageProxyRBAC(context.Background(), infra))
-
-	role := &rbacv1.ClusterRole{}
-	require.NoError(t, client.Get(context.Background(), types.NamespacedName{Name: "demo-storage-proxy"}, role))
-
-	found := false
+	found = false
 	for _, rule := range role.Rules {
-		if !contains(rule.APIGroups, "") {
+		if !contains(rule.APIGroups, "discovery.k8s.io") || !contains(rule.Resources, "endpointslices") {
 			continue
 		}
-		if !contains(rule.Resources, "nodes") {
-			continue
-		}
-		assert.ElementsMatch(t, []string{"get"}, rule.Verbs)
+		assert.ElementsMatch(t, []string{"get", "list", "watch"}, rule.Verbs)
 		found = true
 	}
-	assert.True(t, found, "expected storage-proxy cluster role to include node read permission")
+	assert.True(t, found, "expected ctld cluster role to include embedded netd endpoint slice permissions")
 }
 
-func TestReconcileStorageClientRBACAppliesGCSWorkloadIdentity(t *testing.T) {
+func TestReconcileConsolidatedStorageClientsAppliesGCSWorkloadIdentity(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))
 	require.NoError(t, rbacv1.AddToScheme(scheme))
@@ -229,12 +215,12 @@ func TestReconcileStorageClientRBACAppliesGCSWorkloadIdentity(t *testing.T) {
 	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(infra).Build()
 	reconciler := NewReconciler(&common.ResourceManager{Client: client, Scheme: scheme})
 
-	require.NoError(t, reconciler.ReconcileStorageProxyRBAC(context.Background(), infra))
+	require.NoError(t, reconciler.ReconcileManagerRBAC(context.Background(), infra))
 	require.NoError(t, reconciler.ReconcileCtldRBAC(context.Background(), infra))
 
-	storageProxySA := &corev1.ServiceAccount{}
-	require.NoError(t, client.Get(context.Background(), types.NamespacedName{Name: "demo-storage-proxy", Namespace: "sandbox0-system"}, storageProxySA))
-	assert.Equal(t, "storage@example.iam.gserviceaccount.com", storageProxySA.Annotations[gkeWorkloadIdentityAnnotation])
+	managerSA := &corev1.ServiceAccount{}
+	require.NoError(t, client.Get(context.Background(), types.NamespacedName{Name: "demo-manager", Namespace: "sandbox0-system"}, managerSA))
+	assert.Equal(t, "storage@example.iam.gserviceaccount.com", managerSA.Annotations[gkeWorkloadIdentityAnnotation])
 
 	ctldSA := &corev1.ServiceAccount{}
 	require.NoError(t, client.Get(context.Background(), types.NamespacedName{Name: "demo-ctld", Namespace: "sandbox0-system"}, ctldSA))

--- a/infra-operator/internal/controller/sandbox0infra_cleanup_test.go
+++ b/infra-operator/internal/controller/sandbox0infra_cleanup_test.go
@@ -6,6 +6,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -96,6 +97,13 @@ func TestCleanupDisabledServiceResourcesCleansBuiltinDependencies(t *testing.T) 
 				common.ServiceConfigBaseNameAnnotation: "demo-manager",
 			},
 		}},
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo-manager-storage-config-def456",
+			Namespace: "sandbox0-system",
+			Annotations: map[string]string{
+				common.ServiceConfigBaseNameAnnotation: "demo-manager-storage",
+			},
+		}},
 		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "demo-manager", Namespace: "sandbox0-system"}},
 		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "demo-manager"}},
 		&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "demo-manager"}},
@@ -145,6 +153,7 @@ func TestCleanupDisabledServiceResourcesCleansBuiltinDependencies(t *testing.T) 
 	assertClientObjectMissing(t, client, types.NamespacedName{Namespace: "sandbox0-system", Name: "demo-manager"}, &corev1.Service{})
 	assertClientObjectMissing(t, client, types.NamespacedName{Namespace: "sandbox0-system", Name: "demo-manager"}, &corev1.ConfigMap{})
 	assertClientObjectMissing(t, client, types.NamespacedName{Namespace: "sandbox0-system", Name: "demo-manager-config-abc123"}, &corev1.ConfigMap{})
+	assertClientObjectMissing(t, client, types.NamespacedName{Namespace: "sandbox0-system", Name: "demo-manager-storage-config-def456"}, &corev1.ConfigMap{})
 	assertClientObjectMissing(t, client, types.NamespacedName{Namespace: "sandbox0-system", Name: "demo-manager"}, &corev1.ServiceAccount{})
 	assertClientObjectMissing(t, client, types.NamespacedName{Name: "demo-manager"}, &rbacv1.ClusterRole{})
 	assertClientObjectMissing(t, client, types.NamespacedName{Name: "demo-manager"}, &rbacv1.ClusterRoleBinding{})
@@ -201,6 +210,9 @@ func newCleanupTestReconciler(t *testing.T, objects ...ctrlclient.Object) (*Sand
 	}
 	if err := corev1.AddToScheme(scheme); err != nil {
 		t.Fatalf("add core scheme: %v", err)
+	}
+	if err := discoveryv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add discovery scheme: %v", err)
 	}
 	if err := networkingv1.AddToScheme(scheme); err != nil {
 		t.Fatalf("add networking scheme: %v", err)

--- a/infra-operator/internal/controller/sandbox0infra_controller.go
+++ b/infra-operator/internal/controller/sandbox0infra_controller.go
@@ -26,6 +26,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -65,8 +66,8 @@ import (
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/scheduler"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/sshgateway"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/storage"
-	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/storageproxy"
 	infraplan "github.com/sandbox0-ai/sandbox0/infra-operator/internal/plan"
+	"github.com/sandbox0-ai/sandbox0/pkg/dataplane"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 )
 
@@ -262,7 +263,6 @@ func (r *Sandbox0InfraReconciler) reconcileComponentPlan(ctx context.Context, in
 	schedulerReconciler := scheduler.NewReconciler(resources)
 	clusterGatewayReconciler := clustergateway.NewReconciler(resources)
 	managerReconciler := manager.NewReconciler(resources)
-	storageProxyReconciler := storageproxy.NewReconciler(resources)
 	ctldReconciler := ctldsvc.NewReconciler(resources)
 	netdReconciler := netd.NewReconciler(resources)
 	nodeReadinessReconciler := nodereadiness.NewReconciler(resources)
@@ -272,11 +272,43 @@ func (r *Sandbox0InfraReconciler) reconcileComponentPlan(ctx context.Context, in
 		return ctrl.Result{RequeueAfter: requeueInterval}, err
 	}
 
-	steps, err := r.bindWorkflowSteps(infra, compiledPlan, resources, imageRepo, imageTag, authReconciler, dbReconciler, redisReconciler, credentialStoreReconciler, storageReconciler, registryReconciler, observabilityReconciler, clickHouseReconciler, meteringReconciler, sandboxObservabilityReconciler, globalGatewayReconciler, regionalGatewayReconciler, sshGatewayReconciler, schedulerReconciler, clusterGatewayReconciler, managerReconciler, storageProxyReconciler, ctldReconciler, netdReconciler, nodeReadinessReconciler, rbacReconciler)
+	steps, err := r.bindWorkflowSteps(infra, compiledPlan, resources, imageRepo, imageTag, authReconciler, dbReconciler, redisReconciler, credentialStoreReconciler, storageReconciler, registryReconciler, observabilityReconciler, clickHouseReconciler, meteringReconciler, sandboxObservabilityReconciler, globalGatewayReconciler, regionalGatewayReconciler, sshGatewayReconciler, schedulerReconciler, clusterGatewayReconciler, managerReconciler, ctldReconciler, netdReconciler, nodeReadinessReconciler, rbacReconciler)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	return r.runSteps(ctx, infra, steps)
+	return r.runStepsWithNodeReadinessRefresh(ctx, infra, compiledPlan, nodeReadinessReconciler, steps)
+}
+
+// runStepsWithNodeReadinessRefresh updates the safety labels after every
+// workflow attempt, including attempts stopped by an earlier ctld or netd
+// step. Refresh failures are logged but never replace the workflow result;
+// the normal node-readiness Check remains the gating step on the success path.
+func (r *Sandbox0InfraReconciler) runStepsWithNodeReadinessRefresh(
+	ctx context.Context,
+	infra *infrav1alpha1.Sandbox0Infra,
+	compiledPlan *infraplan.InfraPlan,
+	nodeReadinessReconciler *nodereadiness.Reconciler,
+	steps []reconcileStep,
+) (ctrl.Result, error) {
+	result, workflowErr := r.runSteps(ctx, infra, steps)
+	if nodeReadinessReconciler == nil {
+		return result, workflowErr
+	}
+
+	// A newer generation must own its own node labels. Avoid projecting an old
+	// plan if the resource changed while this workflow attempt was running.
+	fresh, err := r.isLatestReconcileTarget(ctx, infra)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "Could not verify node-readiness refresh target")
+		return result, workflowErr
+	}
+	if !fresh {
+		return result, workflowErr
+	}
+	if _, err := nodeReadinessReconciler.Refresh(ctx, infra, compiledPlan); err != nil {
+		log.FromContext(ctx).Error(err, "Could not refresh data-plane node readiness after workflow attempt")
+	}
+	return result, workflowErr
 }
 
 func (r *Sandbox0InfraReconciler) bindWorkflowSteps(
@@ -300,7 +332,6 @@ func (r *Sandbox0InfraReconciler) bindWorkflowSteps(
 	schedulerReconciler *scheduler.Reconciler,
 	clusterGatewayReconciler *clustergateway.Reconciler,
 	managerReconciler *manager.Reconciler,
-	storageProxyReconciler *storageproxy.Reconciler,
 	ctldReconciler *ctldsvc.Reconciler,
 	netdReconciler *netd.Reconciler,
 	nodeReadinessReconciler *nodereadiness.Reconciler,
@@ -308,7 +339,7 @@ func (r *Sandbox0InfraReconciler) bindWorkflowSteps(
 ) ([]reconcileStep, error) {
 	steps := make([]reconcileStep, 0, len(compiledPlan.Workflow.Steps))
 	for _, planned := range compiledPlan.Workflow.Steps {
-		run, err := r.workflowStepRunner(infra, compiledPlan, resources, imageRepo, imageTag, planned.Name, authReconciler, dbReconciler, redisReconciler, credentialStoreReconciler, storageReconciler, registryReconciler, observabilityReconciler, clickHouseReconciler, meteringReconciler, sandboxObservabilityReconciler, globalGatewayReconciler, regionalGatewayReconciler, sshGatewayReconciler, schedulerReconciler, clusterGatewayReconciler, managerReconciler, storageProxyReconciler, ctldReconciler, netdReconciler, nodeReadinessReconciler, rbacReconciler)
+		run, err := r.workflowStepRunner(infra, compiledPlan, resources, imageRepo, imageTag, planned.Name, authReconciler, dbReconciler, redisReconciler, credentialStoreReconciler, storageReconciler, registryReconciler, observabilityReconciler, clickHouseReconciler, meteringReconciler, sandboxObservabilityReconciler, globalGatewayReconciler, regionalGatewayReconciler, sshGatewayReconciler, schedulerReconciler, clusterGatewayReconciler, managerReconciler, ctldReconciler, netdReconciler, nodeReadinessReconciler, rbacReconciler)
 		if err != nil {
 			return nil, err
 		}
@@ -346,7 +377,6 @@ func (r *Sandbox0InfraReconciler) workflowStepRunner(
 	schedulerReconciler *scheduler.Reconciler,
 	clusterGatewayReconciler *clustergateway.Reconciler,
 	managerReconciler *manager.Reconciler,
-	storageProxyReconciler *storageproxy.Reconciler,
 	ctldReconciler *ctldsvc.Reconciler,
 	netdReconciler *netd.Reconciler,
 	nodeReadinessReconciler *nodereadiness.Reconciler,
@@ -432,6 +462,17 @@ func (r *Sandbox0InfraReconciler) workflowStepRunner(
 			}
 			return ctldReconciler.Reconcile(ctx, infra, imageRepo, imageTag, compiledPlan.Services.ClusterGateway.URL)
 		}, nil
+	case "ctld-ready":
+		return func(ctx context.Context) error {
+			ready, err := ctldReconciler.Ready(ctx, infra)
+			if err != nil {
+				return err
+			}
+			if !ready {
+				return fmt.Errorf("ctld daemonsets are not ready")
+			}
+			return nil
+		}, nil
 	case "manager-rbac":
 		return func(ctx context.Context) error { return rbacReconciler.ReconcileManagerRBAC(ctx, infra) }, nil
 	case "manager":
@@ -440,27 +481,379 @@ func (r *Sandbox0InfraReconciler) workflowStepRunner(
 		}, nil
 	case "builtin-template-pods":
 		return func(ctx context.Context) error { return r.waitBuiltinTemplatePodsReady(ctx, infra, compiledPlan) }, nil
-	case "netd-rbac":
-		return func(ctx context.Context) error { return rbacReconciler.ReconcileNetdRBAC(ctx, infra) }, nil
-	case "netd":
+	case "legacy-netd-handoff":
 		return func(ctx context.Context) error {
-			return netdReconciler.Reconcile(ctx, imageRepo, imageTag, compiledPlan)
+			return r.prepareLegacyNetdHandoff(ctx, infra, imageRepo, imageTag, compiledPlan, netdReconciler, rbacReconciler)
+		}, nil
+	case "legacy-netd-standby":
+		return func(ctx context.Context) error {
+			return r.prepareLegacyNetdStandby(ctx, infra, compiledPlan, netdReconciler)
+		}, nil
+	case "netd-ready":
+		return func(ctx context.Context) error {
+			ready, err := ctldReconciler.EmbeddedNetdReady(ctx, infra)
+			if err != nil {
+				return err
+			}
+			if !ready {
+				return fmt.Errorf("embedded netd is not ready")
+			}
+			return nil
+		}, nil
+	case "legacy-netd-cleanup":
+		return func(ctx context.Context) error {
+			return r.cleanupLegacyNetd(ctx, infra, compiledPlan, netdReconciler)
 		}, nil
 	case "data-plane-node-readiness":
 		return func(ctx context.Context) error {
-			return nodeReadinessReconciler.Reconcile(ctx, infra, compiledPlan)
+			return nodeReadinessReconciler.Check(ctx, infra, compiledPlan)
 		}, nil
-	case "storage-proxy-rbac":
-		return func(ctx context.Context) error { return rbacReconciler.ReconcileStorageProxyRBAC(ctx, infra) }, nil
 	case "storage-proxy":
 		return func(ctx context.Context) error {
-			return storageProxyReconciler.Reconcile(ctx, infra, imageRepo, imageTag)
+			return r.cleanupLegacyStorageProxy(ctx, infra)
 		}, nil
 	case "register-cluster":
 		return func(ctx context.Context) error { return r.registerCluster(ctx, infra) }, nil
 	default:
 		return nil, fmt.Errorf("unsupported workflow step %q", name)
 	}
+}
+
+// cleanupLegacyStorageProxy removes only the standalone storage-proxy runtime.
+// The compatibility Service is deliberately retained and must already select
+// manager pods before the old Deployment is allowed to terminate.
+func (r *Sandbox0InfraReconciler) cleanupLegacyStorageProxy(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra) error {
+	if infra == nil {
+		return fmt.Errorf("sandbox0infra is required")
+	}
+	name := fmt.Sprintf("%s-storage-proxy", infra.Name)
+	alias := &corev1.Service{}
+	if err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: infra.Namespace}, alias); err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("storage-proxy compatibility service %q is not ready", name)
+		}
+		return err
+	}
+	managerLabels := common.GetServiceLabels(infra.Name, "manager")
+	for key, expected := range managerLabels {
+		if alias.Spec.Selector[key] != expected {
+			return fmt.Errorf("storage-proxy compatibility service %q does not select manager pods", name)
+		}
+	}
+	endpointsReady, err := r.storageProxyAliasEndpointsReady(ctx, infra, name, managerLabels)
+	if err != nil {
+		return err
+	}
+	if !endpointsReady {
+		return fmt.Errorf("storage-proxy compatibility service %q endpoints have not converged on manager pods", name)
+	}
+
+	deployment := &appsv1.Deployment{}
+	key := types.NamespacedName{Name: name, Namespace: infra.Namespace}
+	if err := r.Get(ctx, key, deployment); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+	} else if deployment.DeletionTimestamp.IsZero() {
+		propagation := metav1.DeletePropagationForeground
+		if err := r.Delete(ctx, deployment, &client.DeleteOptions{PropagationPolicy: &propagation}); err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+	}
+
+	pods := &corev1.PodList{}
+	if err := r.List(ctx, pods,
+		client.InNamespace(infra.Namespace),
+		client.MatchingLabels(common.GetServiceLabels(infra.Name, "storage-proxy")),
+	); err != nil {
+		return err
+	}
+	if len(pods.Items) > 0 {
+		return fmt.Errorf("legacy storage-proxy pods are still terminating")
+	}
+
+	if err := r.deleteObjectIfExists(ctx, types.NamespacedName{Name: name, Namespace: infra.Namespace}, &corev1.ServiceAccount{}); err != nil {
+		return err
+	}
+	if err := r.deleteObjectIfExists(ctx, types.NamespacedName{Name: name}, &rbacv1.ClusterRoleBinding{}); err != nil {
+		return err
+	}
+	if err := r.deleteObjectIfExists(ctx, types.NamespacedName{Name: name}, &rbacv1.ClusterRole{}); err != nil {
+		return err
+	}
+	if err := r.deleteObjectIfExists(ctx, key, &corev1.ConfigMap{}); err != nil {
+		return err
+	}
+	return r.deleteHashedServiceConfigMaps(ctx, infra.Namespace, name)
+}
+
+// storageProxyAliasEndpointsReady prevents a selector update from racing the
+// EndpointSlice controller. The old workload remains alive until the alias has
+// at least one ready manager endpoint and no endpoint still references a
+// non-manager pod.
+func (r *Sandbox0InfraReconciler) storageProxyAliasEndpointsReady(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, serviceName string, managerLabels map[string]string) (bool, error) {
+	if infra == nil {
+		return false, fmt.Errorf("sandbox0infra is required")
+	}
+	slices := &discoveryv1.EndpointSliceList{}
+	if err := r.List(ctx, slices,
+		client.InNamespace(infra.Namespace),
+		client.MatchingLabels{discoveryv1.LabelServiceName: serviceName},
+	); err != nil {
+		return false, err
+	}
+	readyManagers := 0
+	for i := range slices.Items {
+		for j := range slices.Items[i].Endpoints {
+			endpoint := &slices.Items[i].Endpoints[j]
+			if endpoint.TargetRef == nil || endpoint.TargetRef.Name == "" {
+				return false, nil
+			}
+			podNamespace := endpoint.TargetRef.Namespace
+			if podNamespace == "" {
+				podNamespace = infra.Namespace
+			}
+			pod := &corev1.Pod{}
+			if err := r.Get(ctx, types.NamespacedName{Name: endpoint.TargetRef.Name, Namespace: podNamespace}, pod); err != nil {
+				if apierrors.IsNotFound(err) {
+					return false, nil
+				}
+				return false, err
+			}
+			if !pod.DeletionTimestamp.IsZero() || !labelsContain(pod.Labels, managerLabels) {
+				return false, nil
+			}
+			if endpoint.Conditions.Ready == nil || *endpoint.Conditions.Ready {
+				readyManagers++
+			}
+		}
+	}
+	return readyManagers > 0, nil
+}
+
+func labelsContain(actual, expected map[string]string) bool {
+	for key, value := range expected {
+		if actual[key] != value {
+			return false
+		}
+	}
+	return true
+}
+
+// legacyNetdDaemonSetExists returns true only while an existing standalone
+// netd workload can still own a node lock. A fresh install can proceed without
+// waiting for migration candidates.
+func (r *Sandbox0InfraReconciler) legacyNetdDaemonSetExists(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra) (bool, error) {
+	if infra == nil {
+		return false, fmt.Errorf("sandbox0infra is required")
+	}
+	ds := &appsv1.DaemonSet{}
+	key := types.NamespacedName{Name: fmt.Sprintf("%s-netd", infra.Name), Namespace: infra.Namespace}
+	if err := r.Get(ctx, key, ds); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	if ds.Status.DesiredNumberScheduled > 0 {
+		return true, nil
+	}
+	pods := &corev1.PodList{}
+	if err := r.List(ctx, pods,
+		client.InNamespace(infra.Namespace),
+		client.MatchingLabels(common.GetServiceLabels(infra.Name, "netd")),
+	); err != nil {
+		return false, err
+	}
+	for i := range pods.Items {
+		if pods.Items[i].DeletionTimestamp.IsZero() {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// ctldHandoffCandidatesRunning waits for both HA slot DaemonSets to have a
+// running replacement pod on every desired node. At least one current-template
+// slot must also be PodReady on each node, proving the HA standby synchronized
+// before the legacy netd is asked to yield its active lock.
+func (r *Sandbox0InfraReconciler) ctldHandoffCandidatesRunning(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra) (bool, error) {
+	if infra == nil {
+		return false, fmt.Errorf("sandbox0infra is required")
+	}
+	baseLabels := common.GetServiceLabels(infra.Name, "ctld")
+	var desiredNodes map[string]struct{}
+	readyNodes := map[string]struct{}{}
+	for _, slot := range []string{dataplane.CtldHASlotA, dataplane.CtldHASlotB} {
+		ds := &appsv1.DaemonSet{}
+		key := types.NamespacedName{Name: fmt.Sprintf("%s-ctld-%s", infra.Name, slot), Namespace: infra.Namespace}
+		if err := r.Get(ctx, key, ds); err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		if ds.Status.DesiredNumberScheduled == 0 ||
+			ds.Status.ObservedGeneration < ds.Generation ||
+			ds.Status.UpdatedNumberScheduled != ds.Status.DesiredNumberScheduled ||
+			ds.Status.CurrentNumberScheduled != ds.Status.DesiredNumberScheduled {
+			return false, nil
+		}
+
+		labels := common.CloneStringMap(baseLabels)
+		labels[dataplane.CtldHASlotLabel] = slot
+		pods := &corev1.PodList{}
+		if err := r.List(ctx, pods, client.InNamespace(infra.Namespace), client.MatchingLabels(labels)); err != nil {
+			return false, err
+		}
+		slotNodes := map[string]struct{}{}
+		for i := range pods.Items {
+			pod := &pods.Items[i]
+			if pod.Spec.NodeName != "" && ctldsvc.CtldContainerRunning(pod) && !ctldsvc.PodMatchesCurrentTemplate(pod, ds) {
+				return false, nil
+			}
+			if pod.DeletionTimestamp.IsZero() && pod.Spec.NodeName != "" && ctldsvc.PodMatchesCurrentTemplate(pod, ds) {
+				slotNodes[pod.Spec.NodeName] = struct{}{}
+				if ctldsvc.PodReadyForCurrentTemplate(pod, ds) {
+					readyNodes[pod.Spec.NodeName] = struct{}{}
+				}
+			}
+		}
+		if int32(len(slotNodes)) < ds.Status.DesiredNumberScheduled {
+			return false, nil
+		}
+		if desiredNodes == nil {
+			desiredNodes = slotNodes
+		} else if !sameStringSet(desiredNodes, slotNodes) {
+			return false, nil
+		}
+	}
+	for node := range desiredNodes {
+		if _, ok := readyNodes[node]; !ok {
+			return false, nil
+		}
+	}
+	return len(desiredNodes) > 0, nil
+}
+
+func sameStringSet(left, right map[string]struct{}) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for value := range left {
+		if _, ok := right[value]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func (r *Sandbox0InfraReconciler) prepareLegacyNetdHandoff(
+	ctx context.Context,
+	infra *infrav1alpha1.Sandbox0Infra,
+	imageRepo, imageTag string,
+	compiledPlan *infraplan.InfraPlan,
+	netdReconciler *netd.Reconciler,
+	rbacReconciler *rbac.Reconciler,
+) error {
+	if netdReconciler == nil {
+		return fmt.Errorf("netd reconciler is required")
+	}
+	legacyExists, err := r.legacyNetdDaemonSetExists(ctx, infra)
+	if err != nil {
+		return err
+	}
+	if legacyExists {
+		if rbacReconciler == nil {
+			return fmt.Errorf("rbac reconciler is required")
+		}
+		if err := rbacReconciler.ReconcileNetdRBAC(ctx, infra); err != nil {
+			return err
+		}
+		if err := netdReconciler.PrepareLegacyHandoff(ctx, imageRepo, imageTag, compiledPlan); err != nil {
+			return err
+		}
+	}
+	ready, err := netdReconciler.LegacyHandoffReady(ctx, compiledPlan)
+	if err != nil {
+		return err
+	}
+	if !ready {
+		return fmt.Errorf("legacy netd handoff is not ready")
+	}
+	return nil
+}
+
+func (r *Sandbox0InfraReconciler) prepareLegacyNetdStandby(
+	ctx context.Context,
+	infra *infrav1alpha1.Sandbox0Infra,
+	compiledPlan *infraplan.InfraPlan,
+	netdReconciler *netd.Reconciler,
+) error {
+	if netdReconciler == nil {
+		return fmt.Errorf("netd reconciler is required")
+	}
+	legacyExists, err := r.legacyNetdDaemonSetExists(ctx, infra)
+	if err != nil {
+		return err
+	}
+	if legacyExists {
+		ready, err := r.ctldHandoffCandidatesRunning(ctx, infra)
+		if err != nil {
+			return err
+		}
+		if !ready {
+			return fmt.Errorf("embedded ctld netd candidates are not running")
+		}
+	}
+	if err := netdReconciler.PrepareLegacyStandby(ctx, compiledPlan); err != nil {
+		return err
+	}
+	ready, err := netdReconciler.LegacyStandbyReady(ctx, compiledPlan)
+	if err != nil {
+		return err
+	}
+	if !ready {
+		return fmt.Errorf("legacy netd standby rollout is not ready")
+	}
+	return nil
+}
+
+func (r *Sandbox0InfraReconciler) cleanupLegacyNetd(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, compiledPlan *infraplan.InfraPlan, netdReconciler *netd.Reconciler) error {
+	if netdReconciler == nil {
+		return fmt.Errorf("netd reconciler is required")
+	}
+	if err := netdReconciler.CleanupLegacyDaemonSet(ctx, compiledPlan); err != nil {
+		return err
+	}
+	return r.cleanupLegacyNetdAccess(ctx, infra)
+}
+
+func (r *Sandbox0InfraReconciler) cleanupLegacyNetdAccess(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra) error {
+	if infra == nil {
+		return fmt.Errorf("sandbox0infra is required")
+	}
+	name := fmt.Sprintf("%s-netd", infra.Name)
+	if err := r.deleteObjectIfExists(ctx, types.NamespacedName{Name: name}, &rbacv1.ClusterRoleBinding{}); err != nil {
+		return err
+	}
+	if err := r.deleteObjectIfExists(ctx, types.NamespacedName{Name: name}, &rbacv1.ClusterRole{}); err != nil {
+		return err
+	}
+	return r.deleteObjectIfExists(ctx, types.NamespacedName{Name: name, Namespace: infra.Namespace}, &corev1.ServiceAccount{})
+}
+
+func (r *Sandbox0InfraReconciler) deleteObjectIfExists(ctx context.Context, key types.NamespacedName, obj client.Object) error {
+	if err := r.Get(ctx, key, obj); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	if err := r.Delete(ctx, obj); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	return nil
 }
 
 func (r *Sandbox0InfraReconciler) cleanupDisabledServiceResources(

--- a/infra-operator/internal/controller/sandbox0infra_controller.go
+++ b/infra-operator/internal/controller/sandbox0infra_controller.go
@@ -693,6 +693,9 @@ func (r *Sandbox0InfraReconciler) ctldHandoffCandidatesRunning(ctx context.Conte
 			}
 			return false, err
 		}
+		if !ctldsvc.DaemonSetEmbedsNetd(ds, netd.ScopedActiveLockPath(infra.Namespace, infra.Name)) {
+			return false, nil
+		}
 		if ds.Status.DesiredNumberScheduled == 0 ||
 			ds.Status.ObservedGeneration < ds.Generation ||
 			ds.Status.UpdatedNumberScheduled != ds.Status.DesiredNumberScheduled ||

--- a/infra-operator/internal/controller/sandbox0infra_node_readiness_test.go
+++ b/infra-operator/internal/controller/sandbox0infra_node_readiness_test.go
@@ -1,0 +1,171 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	infrav1alpha1 "github.com/sandbox0-ai/sandbox0/infra-operator/api/v1alpha1"
+	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/pkg/common"
+	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/nodereadiness"
+	infraplan "github.com/sandbox0-ai/sandbox0/infra-operator/internal/plan"
+	"github.com/sandbox0-ai/sandbox0/pkg/dataplane"
+)
+
+func TestRunStepsRefreshesNodeReadinessAfterEarlierFailure(t *testing.T) {
+	ctx := context.Background()
+	infra := newWorkflowNodeReadinessInfra()
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name: "node-a",
+		Labels: map[string]string{
+			"sandbox0.ai/node-role":           "sandbox",
+			dataplane.NodeDataPlaneReadyLabel: dataplane.ReadyLabelValue,
+			dataplane.NodeNetdReadyLabel:      dataplane.ReadyLabelValue,
+			dataplane.NodeCtldReadyLabel:      dataplane.ReadyLabelValue,
+		},
+	}}
+	scheme := newWorkflowNodeReadinessScheme(t)
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(infra.DeepCopy(), node).Build()
+	reconciler := &Sandbox0InfraReconciler{Client: client, Scheme: scheme}
+	readiness := nodereadiness.NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
+	primaryFailure := errors.New("ctld rollout failed")
+	laterStepRan := false
+	compiledPlan := infraplan.Compile(infra)
+
+	result, err := reconciler.runStepsWithNodeReadinessRefresh(ctx, infra, compiledPlan, readiness, []reconcileStep{
+		{
+			Name:          "ctld",
+			Run:           func(context.Context) error { return primaryFailure },
+			ConditionType: infrav1alpha1.ConditionTypeCtldReady,
+			ErrorReason:   "CtldFailed",
+		},
+		{
+			Name: "netd-ready",
+			Run: func(context.Context) error {
+				laterStepRan = true
+				return nil
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("runStepsWithNodeReadinessRefresh() error = %v", err)
+	}
+	if result.RequeueAfter != requeueInterval {
+		t.Fatalf("requeue after = %v, want %v", result.RequeueAfter, requeueInterval)
+	}
+	if laterStepRan {
+		t.Fatal("workflow continued after the primary ctld failure")
+	}
+	if infra.Status.LastMessage != primaryFailure.Error() {
+		t.Fatalf("last message = %q, want primary failure %q", infra.Status.LastMessage, primaryFailure)
+	}
+	got := &corev1.Node{}
+	if err := client.Get(ctx, types.NamespacedName{Name: node.Name}, got); err != nil {
+		t.Fatalf("get refreshed node: %v", err)
+	}
+	assertWorkflowNodeLabel(t, got, dataplane.NodeDataPlaneReadyLabel, dataplane.NotReadyLabelValue)
+	assertWorkflowNodeLabel(t, got, dataplane.NodeNetdReadyLabel, dataplane.NotReadyLabelValue)
+	assertWorkflowNodeLabel(t, got, dataplane.NodeCtldReadyLabel, dataplane.NotReadyLabelValue)
+}
+
+func TestNodeReadinessRefreshFailureDoesNotMaskWorkflowError(t *testing.T) {
+	ctx := context.Background()
+	infra := newWorkflowNodeReadinessInfra()
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name:   "node-a",
+		Labels: map[string]string{"sandbox0.ai/node-role": "sandbox"},
+	}}
+	scheme := newWorkflowNodeReadinessScheme(t)
+	workflowErr := errors.New("workflow freshness failed")
+	refreshErr := errors.New("node label patch failed")
+	infraGetCalls := 0
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(infra.DeepCopy(), node).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, client ctrlclient.WithWatch, key ctrlclient.ObjectKey, obj ctrlclient.Object, opts ...ctrlclient.GetOption) error {
+				if _, ok := obj.(*infrav1alpha1.Sandbox0Infra); ok {
+					infraGetCalls++
+					if infraGetCalls == 1 {
+						return workflowErr
+					}
+				}
+				return client.Get(ctx, key, obj, opts...)
+			},
+			Patch: func(ctx context.Context, client ctrlclient.WithWatch, obj ctrlclient.Object, patch ctrlclient.Patch, opts ...ctrlclient.PatchOption) error {
+				if _, ok := obj.(*corev1.Node); ok {
+					return refreshErr
+				}
+				return client.Patch(ctx, obj, patch, opts...)
+			},
+		}).
+		Build()
+	reconciler := &Sandbox0InfraReconciler{Client: client, Scheme: scheme}
+	readiness := nodereadiness.NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
+
+	_, err := reconciler.runStepsWithNodeReadinessRefresh(
+		ctx,
+		infra,
+		infraplan.Compile(infra),
+		readiness,
+		[]reconcileStep{{Name: "ctld", Run: func(context.Context) error { return nil }}},
+	)
+	if !errors.Is(err, workflowErr) {
+		t.Fatalf("error = %v, want original workflow error %v", err, workflowErr)
+	}
+	if errors.Is(err, refreshErr) {
+		t.Fatalf("refresh error %v masked workflow error", refreshErr)
+	}
+}
+
+func newWorkflowNodeReadinessScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add apps scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+	if err := storagev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add storage scheme: %v", err)
+	}
+	if err := infrav1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add infra scheme: %v", err)
+	}
+	return scheme
+}
+
+func newWorkflowNodeReadinessInfra() *infrav1alpha1.Sandbox0Infra {
+	return &infrav1alpha1.Sandbox0Infra{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "sandbox0-system"},
+		Spec: infrav1alpha1.Sandbox0InfraSpec{
+			SandboxNodePlacement: &infrav1alpha1.SandboxNodePlacementConfig{
+				NodeSelector: map[string]string{"sandbox0.ai/node-role": "sandbox"},
+			},
+			Services: &infrav1alpha1.ServicesConfig{
+				Manager: &infrav1alpha1.ManagerServiceConfig{WorkloadServiceConfig: infrav1alpha1.WorkloadServiceConfig{
+					EnabledServiceConfig: infrav1alpha1.EnabledServiceConfig{Enabled: true},
+				}},
+				Netd: &infrav1alpha1.NetdServiceConfig{EnabledServiceConfig: infrav1alpha1.EnabledServiceConfig{Enabled: true}},
+			},
+		},
+	}
+}
+
+func assertWorkflowNodeLabel(t *testing.T, node *corev1.Node, key, want string) {
+	t.Helper()
+	if got := node.Labels[key]; got != want {
+		t.Fatalf("node %s label %s = %q, want %q", node.Name, key, got, want)
+	}
+}

--- a/infra-operator/internal/controller/sandbox0infra_service_consolidation_test.go
+++ b/infra-operator/internal/controller/sandbox0infra_service_consolidation_test.go
@@ -1,0 +1,311 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	infrav1alpha1 "github.com/sandbox0-ai/sandbox0/infra-operator/api/v1alpha1"
+	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/pkg/common"
+	rbacsvc "github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/pkg/rbac"
+	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/netd"
+	infraplan "github.com/sandbox0-ai/sandbox0/infra-operator/internal/plan"
+	"github.com/sandbox0-ai/sandbox0/pkg/dataplane"
+)
+
+func TestCleanupLegacyStorageProxyWaitsForManagerAliasAndPods(t *testing.T) {
+	ctx := context.Background()
+	infra := &infrav1alpha1.Sandbox0Infra{ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "sandbox0-system"}}
+	legacyLabels := common.GetServiceLabels(infra.Name, "storage-proxy")
+	managerLabels := common.GetServiceLabels(infra.Name, "manager")
+	name := infra.Name + "-storage-proxy"
+	reconciler, client, _ := newCleanupTestReconciler(t,
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: infra.Namespace},
+			Spec:       corev1.ServiceSpec{Selector: legacyLabels},
+		},
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: infra.Namespace}},
+		&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "legacy-storage-proxy", Namespace: infra.Namespace, Labels: legacyLabels}},
+		&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "manager-0", Namespace: infra.Namespace, Labels: managerLabels}},
+		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: infra.Namespace}},
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: name}},
+		&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: name}},
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: infra.Namespace}},
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+			Name:        name + "-config-old",
+			Namespace:   infra.Namespace,
+			Annotations: map[string]string{common.ServiceConfigBaseNameAnnotation: name},
+		}},
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+			Name:        infra.Name + "-manager-storage-config-current",
+			Namespace:   infra.Namespace,
+			Annotations: map[string]string{common.ServiceConfigBaseNameAnnotation: infra.Name + "-manager-storage"},
+		}},
+	)
+
+	if err := reconciler.cleanupLegacyStorageProxy(ctx, infra); err == nil {
+		t.Fatal("cleanup succeeded before the compatibility service selected manager")
+	}
+	assertClientObjectPresent(t, client, types.NamespacedName{Name: name, Namespace: infra.Namespace}, &appsv1.Deployment{})
+
+	alias := &corev1.Service{}
+	if err := client.Get(ctx, types.NamespacedName{Name: name, Namespace: infra.Namespace}, alias); err != nil {
+		t.Fatalf("get compatibility service: %v", err)
+	}
+	alias.Spec.Selector = managerLabels
+	if err := client.Update(ctx, alias); err != nil {
+		t.Fatalf("update compatibility service: %v", err)
+	}
+
+	if err := reconciler.cleanupLegacyStorageProxy(ctx, infra); err == nil {
+		t.Fatal("cleanup succeeded before compatibility endpoints converged")
+	}
+	assertClientObjectPresent(t, client, types.NamespacedName{Name: name, Namespace: infra.Namespace}, &appsv1.Deployment{})
+
+	ready := true
+	if err := client.Create(ctx, &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name + "-manager",
+			Namespace: infra.Namespace,
+			Labels:    map[string]string{discoveryv1.LabelServiceName: name},
+		},
+		AddressType: discoveryv1.AddressTypeIPv4,
+		Endpoints: []discoveryv1.Endpoint{{
+			Addresses:  []string{"10.0.0.10"},
+			Conditions: discoveryv1.EndpointConditions{Ready: &ready},
+			TargetRef:  &corev1.ObjectReference{Kind: "Pod", Namespace: infra.Namespace, Name: "manager-0"},
+		}},
+	}); err != nil {
+		t.Fatalf("create manager endpoint slice: %v", err)
+	}
+
+	if err := reconciler.cleanupLegacyStorageProxy(ctx, infra); err == nil {
+		t.Fatal("cleanup succeeded while a legacy storage-proxy pod remained")
+	}
+	assertClientObjectPresent(t, client, types.NamespacedName{Name: name, Namespace: infra.Namespace}, &corev1.ServiceAccount{})
+	assertClientObjectPresent(t, client, types.NamespacedName{Name: name}, &rbacv1.ClusterRole{})
+	assertClientObjectPresent(t, client, types.NamespacedName{Name: name, Namespace: infra.Namespace}, &corev1.ConfigMap{})
+
+	legacyPod := &corev1.Pod{}
+	if err := client.Get(ctx, types.NamespacedName{Name: "legacy-storage-proxy", Namespace: infra.Namespace}, legacyPod); err != nil {
+		t.Fatalf("get legacy storage-proxy pod: %v", err)
+	}
+	if err := client.Delete(ctx, legacyPod); err != nil {
+		t.Fatalf("delete legacy storage-proxy pod: %v", err)
+	}
+	if err := reconciler.cleanupLegacyStorageProxy(ctx, infra); err != nil {
+		t.Fatalf("cleanup after legacy pod removal: %v", err)
+	}
+
+	assertClientObjectMissing(t, client, types.NamespacedName{Name: name, Namespace: infra.Namespace}, &appsv1.Deployment{})
+	assertClientObjectMissing(t, client, types.NamespacedName{Name: name, Namespace: infra.Namespace}, &corev1.ServiceAccount{})
+	assertClientObjectMissing(t, client, types.NamespacedName{Name: name}, &rbacv1.ClusterRole{})
+	assertClientObjectMissing(t, client, types.NamespacedName{Name: name}, &rbacv1.ClusterRoleBinding{})
+	assertClientObjectMissing(t, client, types.NamespacedName{Name: name, Namespace: infra.Namespace}, &corev1.ConfigMap{})
+	assertClientObjectMissing(t, client, types.NamespacedName{Name: name + "-config-old", Namespace: infra.Namespace}, &corev1.ConfigMap{})
+	assertClientObjectPresent(t, client, types.NamespacedName{Name: name, Namespace: infra.Namespace}, &corev1.Service{})
+	assertClientObjectPresent(t, client, types.NamespacedName{Name: infra.Name + "-manager-storage-config-current", Namespace: infra.Namespace}, &corev1.ConfigMap{})
+}
+
+func TestCtldHandoffCandidatesRequireCurrentTemplateAndReadySlot(t *testing.T) {
+	ctx := context.Background()
+	infra := &infrav1alpha1.Sandbox0Infra{ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "sandbox0-system"}}
+	ctldLabels := common.GetServiceLabels(infra.Name, "ctld")
+	ctldDaemonSets := make(map[string]*appsv1.DaemonSet, 2)
+	objects := make([]ctrlclient.Object, 0, 4)
+	for _, slot := range []string{dataplane.CtldHASlotA, dataplane.CtldHASlotB} {
+		labels := common.CloneStringMap(ctldLabels)
+		labels[dataplane.CtldHASlotLabel] = slot
+		ds := readyDaemonSet(infra.Name+"-ctld-"+slot, infra.Namespace, labels)
+		ds.Spec.Template.Annotations = map[string]string{netd.ConfigHashAnnotation: "netd-config-v2"}
+		ds.Spec.Template.Spec.Containers = []corev1.Container{{Name: "ctld", Image: "sandbox0ai/infra:v2"}}
+		ctldDaemonSets[slot] = ds
+		objects = append(objects, ds, &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "old-ctld-" + slot, Namespace: infra.Namespace, Labels: labels, Finalizers: []string{"test.sandbox0.ai/hold"}},
+			Spec:       corev1.PodSpec{NodeName: "node-a", Containers: []corev1.Container{{Name: "ctld", Image: "sandbox0ai/infra:v1"}}},
+			Status: corev1.PodStatus{
+				Phase:             corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{{Name: "ctld", State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}}},
+			},
+		})
+	}
+	reconciler, client, _ := newCleanupTestReconciler(t, objects...)
+
+	ready, err := reconciler.ctldHandoffCandidatesRunning(ctx, infra)
+	if err != nil {
+		t.Fatalf("check predecessor candidates: %v", err)
+	}
+	if ready {
+		t.Fatal("surge predecessor ctld pods satisfied the current-template handoff gate")
+	}
+
+	for _, slot := range []string{dataplane.CtldHASlotA, dataplane.CtldHASlotB} {
+		ds := ctldDaemonSets[slot]
+		conditions := []corev1.PodCondition(nil)
+		if slot == dataplane.CtldHASlotB {
+			conditions = []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}}
+		}
+		if err := client.Create(ctx, &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "new-ctld-" + slot,
+				Namespace:   infra.Namespace,
+				Labels:      ds.Spec.Template.Labels,
+				Annotations: ds.Spec.Template.Annotations,
+			},
+			Spec: func() corev1.PodSpec {
+				spec := *ds.Spec.Template.Spec.DeepCopy()
+				spec.NodeName = "node-a"
+				return spec
+			}(),
+			Status: corev1.PodStatus{
+				Phase:             corev1.PodRunning,
+				Conditions:        conditions,
+				ContainerStatuses: []corev1.ContainerStatus{{Name: "ctld", State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}}},
+			},
+		}); err != nil {
+			t.Fatalf("create updated ctld %s pod: %v", slot, err)
+		}
+	}
+
+	ready, err = reconciler.ctldHandoffCandidatesRunning(ctx, infra)
+	if err != nil {
+		t.Fatalf("check current candidates: %v", err)
+	}
+	if ready {
+		t.Fatal("live surge predecessor satisfied the handoff gate after current candidates started")
+	}
+	for _, slot := range []string{dataplane.CtldHASlotA, dataplane.CtldHASlotB} {
+		oldPod := &corev1.Pod{}
+		key := types.NamespacedName{Name: "old-ctld-" + slot, Namespace: infra.Namespace}
+		if err := client.Get(ctx, key, oldPod); err != nil {
+			t.Fatalf("get old ctld %s pod: %v", slot, err)
+		}
+		if err := client.Delete(ctx, oldPod); err != nil {
+			t.Fatalf("delete old ctld %s pod: %v", slot, err)
+		}
+	}
+	ready, err = reconciler.ctldHandoffCandidatesRunning(ctx, infra)
+	if err != nil {
+		t.Fatalf("check terminating predecessor candidates: %v", err)
+	}
+	if ready {
+		t.Fatal("terminating but still-running surge predecessor satisfied the handoff gate")
+	}
+	for _, slot := range []string{dataplane.CtldHASlotA, dataplane.CtldHASlotB} {
+		oldPod := &corev1.Pod{}
+		key := types.NamespacedName{Name: "old-ctld-" + slot, Namespace: infra.Namespace}
+		if err := client.Get(ctx, key, oldPod); err != nil {
+			t.Fatalf("get terminating old ctld %s pod: %v", slot, err)
+		}
+		oldPod.Status.ContainerStatuses = nil
+		if err := client.Status().Update(ctx, oldPod); err != nil {
+			t.Fatalf("mark old ctld %s process stopped: %v", slot, err)
+		}
+	}
+	ready, err = reconciler.ctldHandoffCandidatesRunning(ctx, infra)
+	if err != nil {
+		t.Fatalf("check candidates after predecessors stopped: %v", err)
+	}
+	if !ready {
+		t.Fatal("current-template ctld pods with one ready HA slot did not satisfy the handoff gate")
+	}
+}
+
+func TestFreshLegacyNetdHandoffDoesNotChurnRBAC(t *testing.T) {
+	ctx := context.Background()
+	infra := &infrav1alpha1.Sandbox0Infra{ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "sandbox0-system"}}
+	reconciler, client, scheme := newCleanupTestReconciler(t)
+	resources := common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{})
+	netdReconciler := netd.NewReconciler(resources)
+	rbacReconciler := rbacsvc.NewReconciler(resources)
+	compiled := infraplan.Compile(infra)
+
+	for i := 0; i < 2; i++ {
+		if err := reconciler.prepareLegacyNetdHandoff(ctx, infra, "sandbox0ai/infra", "v2", compiled, netdReconciler, rbacReconciler); err != nil {
+			t.Fatalf("fresh handoff reconcile %d: %v", i+1, err)
+		}
+	}
+	name := infra.Name + "-netd"
+	assertClientObjectMissing(t, client, types.NamespacedName{Name: name, Namespace: infra.Namespace}, &corev1.ServiceAccount{})
+	assertClientObjectMissing(t, client, types.NamespacedName{Name: name}, &rbacv1.ClusterRole{})
+	assertClientObjectMissing(t, client, types.NamespacedName{Name: name}, &rbacv1.ClusterRoleBinding{})
+}
+
+func TestCleanupLegacyNetdWaitsForPodsBeforeRemovingAccess(t *testing.T) {
+	ctx := context.Background()
+	infra := &infrav1alpha1.Sandbox0Infra{ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "sandbox0-system"}}
+	name := infra.Name + "-netd"
+	legacyLabels := common.GetServiceLabels(infra.Name, "netd")
+	legacyPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "legacy-netd", Namespace: infra.Namespace, Labels: legacyLabels}}
+	reconciler, client, scheme := newCleanupTestReconciler(t,
+		readyDaemonSet(name, infra.Namespace, legacyLabels),
+		legacyPod,
+		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: infra.Namespace}},
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: name}},
+		&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: name}},
+	)
+	netdReconciler := netd.NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
+	compiled := infraplan.Compile(infra)
+
+	if err := reconciler.cleanupLegacyNetd(ctx, infra, compiled, netdReconciler); err == nil {
+		t.Fatal("cleanup succeeded while a legacy netd pod remained")
+	}
+	assertClientObjectMissing(t, client, types.NamespacedName{Name: name, Namespace: infra.Namespace}, &appsv1.DaemonSet{})
+	assertClientObjectPresent(t, client, types.NamespacedName{Name: name}, &rbacv1.ClusterRole{})
+
+	if err := client.Delete(ctx, legacyPod); err != nil {
+		t.Fatalf("delete legacy netd pod: %v", err)
+	}
+	if err := reconciler.cleanupLegacyNetd(ctx, infra, compiled, netdReconciler); err != nil {
+		t.Fatalf("cleanup after legacy netd pod removal: %v", err)
+	}
+	assertClientObjectMissing(t, client, types.NamespacedName{Name: name, Namespace: infra.Namespace}, &appsv1.DaemonSet{})
+	assertClientObjectMissing(t, client, types.NamespacedName{Name: name, Namespace: infra.Namespace}, &corev1.ServiceAccount{})
+	assertClientObjectMissing(t, client, types.NamespacedName{Name: name}, &rbacv1.ClusterRole{})
+	assertClientObjectMissing(t, client, types.NamespacedName{Name: name}, &rbacv1.ClusterRoleBinding{})
+}
+
+func TestCleanupLegacyNetdFreshInstallDoesNotWaitForCtldCandidates(t *testing.T) {
+	ctx := context.Background()
+	infra := &infrav1alpha1.Sandbox0Infra{ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "sandbox0-system"}}
+	name := infra.Name + "-netd"
+	reconciler, client, scheme := newCleanupTestReconciler(t,
+		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: infra.Namespace}},
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: name}},
+		&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: name}},
+	)
+	netdReconciler := netd.NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
+
+	if err := reconciler.cleanupLegacyNetd(ctx, infra, infraplan.Compile(infra), netdReconciler); err != nil {
+		t.Fatalf("fresh-install cleanup: %v", err)
+	}
+	assertClientObjectMissing(t, client, types.NamespacedName{Name: name, Namespace: infra.Namespace}, &appsv1.DaemonSet{})
+	assertClientObjectMissing(t, client, types.NamespacedName{Name: name, Namespace: infra.Namespace}, &corev1.ServiceAccount{})
+	assertClientObjectMissing(t, client, types.NamespacedName{Name: name}, &rbacv1.ClusterRole{})
+	assertClientObjectMissing(t, client, types.NamespacedName{Name: name}, &rbacv1.ClusterRoleBinding{})
+}
+
+func readyDaemonSet(name, namespace string, labels map[string]string) *appsv1.DaemonSet {
+	return &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, Generation: 1},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: labels},
+			Template: corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{Labels: labels}},
+		},
+		Status: appsv1.DaemonSetStatus{
+			ObservedGeneration:     1,
+			DesiredNumberScheduled: 1,
+			CurrentNumberScheduled: 1,
+			UpdatedNumberScheduled: 1,
+			NumberReady:            1,
+			NumberAvailable:        1,
+		},
+	}
+}

--- a/infra-operator/internal/controller/sandbox0infra_service_consolidation_test.go
+++ b/infra-operator/internal/controller/sandbox0infra_service_consolidation_test.go
@@ -218,6 +218,60 @@ func TestCtldHandoffCandidatesRequireCurrentTemplateAndReadySlot(t *testing.T) {
 	}
 }
 
+func TestCtldHandoffCandidatesAllowStagedBWithReadyA(t *testing.T) {
+	ctx := context.Background()
+	infra := &infrav1alpha1.Sandbox0Infra{ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "sandbox0-system"}}
+	baseLabels := common.GetServiceLabels(infra.Name, "ctld")
+
+	labelsA := common.CloneStringMap(baseLabels)
+	labelsA[dataplane.CtldHASlotLabel] = dataplane.CtldHASlotA
+	slotA := readyDaemonSet(infra.Name+"-ctld-a", infra.Namespace, labelsA)
+	slotA.Spec.Template.Spec.Containers = []corev1.Container{{Name: "ctld", Image: "sandbox0ai/infra:v1"}}
+	podA := currentCtldHandoffPod(slotA, "old-ready-ctld-a", "node-a", true)
+
+	labelsB := common.CloneStringMap(baseLabels)
+	labelsB[dataplane.CtldHASlotLabel] = dataplane.CtldHASlotB
+	slotB := readyDaemonSet(infra.Name+"-ctld-b", infra.Namespace, labelsB)
+	slotB.Spec.Template.Annotations = map[string]string{netd.ConfigHashAnnotation: "netd-config-v2"}
+	slotB.Spec.Template.Spec.Containers = []corev1.Container{{Name: "ctld", Image: "sandbox0ai/infra:v2"}}
+	slotB.Status.NumberReady = 0
+	slotB.Status.NumberAvailable = 0
+	slotB.Status.NumberUnavailable = 1
+	podB := currentCtldHandoffPod(slotB, "new-running-ctld-b", "node-a", false)
+
+	reconciler, _, _ := newCleanupTestReconciler(t, slotA, podA, slotB, podB)
+	ready, err := reconciler.ctldHandoffCandidatesRunning(ctx, infra)
+	if err != nil {
+		t.Fatalf("check staged handoff candidates: %v", err)
+	}
+	if !ready {
+		t.Fatal("ready old slot A plus running current slot B did not satisfy the staged handoff gate")
+	}
+}
+
+func currentCtldHandoffPod(ds *appsv1.DaemonSet, name, node string, ready bool) *corev1.Pod {
+	conditions := []corev1.PodCondition(nil)
+	if ready {
+		conditions = []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}}
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   ds.Namespace,
+			Labels:      common.CloneStringMap(ds.Spec.Template.Labels),
+			Annotations: common.CloneStringMap(ds.Spec.Template.Annotations),
+		},
+		Spec: *ds.Spec.Template.Spec.DeepCopy(),
+		Status: corev1.PodStatus{
+			Phase:             corev1.PodRunning,
+			Conditions:        conditions,
+			ContainerStatuses: []corev1.ContainerStatus{{Name: "ctld", State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}}},
+		},
+	}
+	pod.Spec.NodeName = node
+	return pod
+}
+
 func TestFreshLegacyNetdHandoffDoesNotChurnRBAC(t *testing.T) {
 	ctx := context.Background()
 	infra := &infrav1alpha1.Sandbox0Infra{ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "sandbox0-system"}}

--- a/infra-operator/internal/controller/sandbox0infra_service_consolidation_test.go
+++ b/infra-operator/internal/controller/sandbox0infra_service_consolidation_test.go
@@ -124,8 +124,8 @@ func TestCtldHandoffCandidatesRequireCurrentTemplateAndReadySlot(t *testing.T) {
 		labels := common.CloneStringMap(ctldLabels)
 		labels[dataplane.CtldHASlotLabel] = slot
 		ds := readyDaemonSet(infra.Name+"-ctld-"+slot, infra.Namespace, labels)
-		ds.Spec.Template.Annotations = map[string]string{netd.ConfigHashAnnotation: "netd-config-v2"}
 		ds.Spec.Template.Spec.Containers = []corev1.Container{{Name: "ctld", Image: "sandbox0ai/infra:v2"}}
+		configureCtldEmbeddedNetd(ds, infra)
 		ctldDaemonSets[slot] = ds
 		objects = append(objects, ds, &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{Name: "old-ctld-" + slot, Namespace: infra.Namespace, Labels: labels, Finalizers: []string{"test.sandbox0.ai/hold"}},
@@ -218,7 +218,7 @@ func TestCtldHandoffCandidatesRequireCurrentTemplateAndReadySlot(t *testing.T) {
 	}
 }
 
-func TestCtldHandoffCandidatesAllowStagedBWithReadyA(t *testing.T) {
+func TestCtldHandoffCandidatesRejectSlotWithoutEmbeddedNetd(t *testing.T) {
 	ctx := context.Background()
 	infra := &infrav1alpha1.Sandbox0Infra{ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "sandbox0-system"}}
 	baseLabels := common.GetServiceLabels(infra.Name, "ctld")
@@ -232,8 +232,8 @@ func TestCtldHandoffCandidatesAllowStagedBWithReadyA(t *testing.T) {
 	labelsB := common.CloneStringMap(baseLabels)
 	labelsB[dataplane.CtldHASlotLabel] = dataplane.CtldHASlotB
 	slotB := readyDaemonSet(infra.Name+"-ctld-b", infra.Namespace, labelsB)
-	slotB.Spec.Template.Annotations = map[string]string{netd.ConfigHashAnnotation: "netd-config-v2"}
 	slotB.Spec.Template.Spec.Containers = []corev1.Container{{Name: "ctld", Image: "sandbox0ai/infra:v2"}}
+	configureCtldEmbeddedNetd(slotB, infra)
 	slotB.Status.NumberReady = 0
 	slotB.Status.NumberAvailable = 0
 	slotB.Status.NumberUnavailable = 1
@@ -242,11 +242,60 @@ func TestCtldHandoffCandidatesAllowStagedBWithReadyA(t *testing.T) {
 	reconciler, _, _ := newCleanupTestReconciler(t, slotA, podA, slotB, podB)
 	ready, err := reconciler.ctldHandoffCandidatesRunning(ctx, infra)
 	if err != nil {
-		t.Fatalf("check staged handoff candidates: %v", err)
+		t.Fatalf("check mixed-runtime handoff candidates: %v", err)
+	}
+	if ready {
+		t.Fatal("handoff accepted a slot that did not embed guarded netd")
+	}
+}
+
+func TestCtldHandoffCandidatesAllowReadyAWithWaitingB(t *testing.T) {
+	ctx := context.Background()
+	infra := &infrav1alpha1.Sandbox0Infra{ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "sandbox0-system"}}
+	baseLabels := common.GetServiceLabels(infra.Name, "ctld")
+
+	labelsA := common.CloneStringMap(baseLabels)
+	labelsA[dataplane.CtldHASlotLabel] = dataplane.CtldHASlotA
+	slotA := readyDaemonSet(infra.Name+"-ctld-a", infra.Namespace, labelsA)
+	slotA.Spec.Template.Spec.Containers = []corev1.Container{{Name: "ctld", Image: "sandbox0ai/infra:v2"}}
+	configureCtldEmbeddedNetd(slotA, infra)
+	podA := currentCtldHandoffPod(slotA, "new-ready-ctld-a", "node-a", true)
+
+	labelsB := common.CloneStringMap(baseLabels)
+	labelsB[dataplane.CtldHASlotLabel] = dataplane.CtldHASlotB
+	slotB := readyDaemonSet(infra.Name+"-ctld-b", infra.Namespace, labelsB)
+	slotB.Spec.Template.Spec.Containers = []corev1.Container{{Name: "ctld", Image: "sandbox0ai/infra:v2"}}
+	configureCtldEmbeddedNetd(slotB, infra)
+	slotB.Status.NumberReady = 0
+	slotB.Status.NumberAvailable = 0
+	slotB.Status.NumberUnavailable = 1
+	podB := currentCtldHandoffPod(slotB, "new-ctld-b-waiting-for-netd-lock", "node-a", false)
+
+	reconciler, _, _ := newCleanupTestReconciler(t, slotA, podA, slotB, podB)
+	ready, err := reconciler.ctldHandoffCandidatesRunning(ctx, infra)
+	if err != nil {
+		t.Fatalf("check guarded handoff candidates: %v", err)
 	}
 	if !ready {
-		t.Fatal("ready old slot A plus running current slot B did not satisfy the staged handoff gate")
+		t.Fatal("ready embedded slot A plus running embedded slot B did not satisfy the handoff gate")
 	}
+}
+
+func configureCtldEmbeddedNetd(ds *appsv1.DaemonSet, infra *infrav1alpha1.Sandbox0Infra) {
+	ds.Spec.Template.Annotations = common.CloneStringMap(ds.Spec.Template.Annotations)
+	if ds.Spec.Template.Annotations == nil {
+		ds.Spec.Template.Annotations = map[string]string{}
+	}
+	ds.Spec.Template.Annotations[netd.ConfigHashAnnotation] = "netd-config-v2"
+	container := &ds.Spec.Template.Spec.Containers[0]
+	container.Env = append(container.Env,
+		corev1.EnvVar{Name: "NETD_CONFIG_PATH", Value: netd.ConfigPath},
+		corev1.EnvVar{Name: netd.ActiveLockEnv, Value: netd.ScopedActiveLockPath(infra.Namespace, infra.Name)},
+	)
+	container.VolumeMounts = append(container.VolumeMounts,
+		corev1.VolumeMount{Name: netd.ConfigVolumeName, MountPath: netd.ConfigPath},
+		corev1.VolumeMount{Name: netd.ActiveLockVolumeName, MountPath: netd.ActiveLockMountDirectory},
+	)
 }
 
 func currentCtldHandoffPod(ds *appsv1.DaemonSet, name, node string, ready bool) *corev1.Pod {

--- a/infra-operator/internal/controller/services/ctld/ctld.go
+++ b/infra-operator/internal/controller/services/ctld/ctld.go
@@ -50,6 +50,7 @@ const (
 	ctldHAProbeSocket              = "/run/sandbox0/ctld-ha.sock"
 	ctldKubeletRegistrationSocket  = "/var/lib/kubelet/plugins_registry/" + volumeportal.DriverName + "-reg.sock"
 	ctldKubeletCSIEndpoint         = "/var/lib/kubelet/plugins/" + volumeportal.DriverName + "/csi.sock"
+	ctldRolloutRevisionAnnotation  = "infra.sandbox0.ai/ctld-rollout-revision"
 )
 
 func NewReconciler(resources *common.ResourceManager) *Reconciler {
@@ -224,6 +225,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 	if err := r.removeLegacyDaemonSet(ctx, infra, name); err != nil {
 		return err
 	}
+	desiredBySlot := make(map[string]*appsv1.DaemonSet, 2)
 	for _, slot := range []string{dataplane.CtldHASlotA, dataplane.CtldHASlotB} {
 		desired := buildCtldDaemonSet(ctldDaemonSetConfig{
 			Name:                    name,
@@ -252,11 +254,118 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 				desired.Spec.Template.Spec.Containers[0].Ports = netdMetricsDiscoveryPort(netdAssets.Ports)
 			}
 		}
-		if err := r.Resources.ApplyDaemonSet(ctx, infra, desired); err != nil {
+		revision, err := common.ConfigHash(desired.Spec)
+		if err != nil {
+			return fmt.Errorf("hash ctld slot %s rollout: %w", slot, err)
+		}
+		desired.Spec.Template.Annotations[ctldRolloutRevisionAnnotation] = revision
+		desiredBySlot[slot] = desired
+	}
+	return r.reconcileHASlots(ctx, infra, desiredBySlot[dataplane.CtldHASlotA], desiredBySlot[dataplane.CtldHASlotB])
+}
+
+// reconcileHASlots rolls ctld-b completely before changing ctld-a. Both
+// DaemonSets use host networking, so a same-slot surge can conflict with the
+// predecessor's listening ports. Serializing the slots keeps one HA peer
+// running on every node while the other slot is replaced in place.
+func (r *Reconciler) reconcileHASlots(
+	ctx context.Context,
+	infra *infrav1alpha1.Sandbox0Infra,
+	desiredA, desiredB *appsv1.DaemonSet,
+) error {
+	currentA, aExists, err := r.getDaemonSet(ctx, desiredA)
+	if err != nil {
+		return err
+	}
+	currentB, bExists, err := r.getDaemonSet(ctx, desiredB)
+	if err != nil {
+		return err
+	}
+
+	// A fresh install has no availability to preserve, so create both peers in
+	// one pass. If only one peer is missing, repair it without mutating the
+	// surviving peer during the same reconciliation.
+	if !aExists && !bExists {
+		if err := r.Resources.ApplyDaemonSet(ctx, infra, desiredA); err != nil {
 			return err
 		}
+		return r.Resources.ApplyDaemonSet(ctx, infra, desiredB)
 	}
-	return nil
+	if !aExists {
+		return r.Resources.ApplyDaemonSet(ctx, infra, desiredA)
+	}
+	if !bExists {
+		return r.Resources.ApplyDaemonSet(ctx, infra, desiredB)
+	}
+
+	aReady, err := r.daemonSetCurrentPodsReady(ctx, currentA)
+	if err != nil {
+		return err
+	}
+	bReady, err := r.daemonSetCurrentPodsReady(ctx, currentB)
+	if err != nil {
+		return err
+	}
+	aDesired := daemonSetHasDesiredRevision(currentA, desiredA)
+	bDesired := daemonSetHasDesiredRevision(currentB, desiredB)
+
+	if !bDesired {
+		if aReady {
+			// A healthy peer protects every node while B rolls. Return after the
+			// write because controller-runtime cached reads are not read-your-writes.
+			return r.Resources.ApplyDaemonSet(ctx, infra, desiredB)
+		}
+		if bReady {
+			// Recover a degraded or stalled A under the still-healthy old B before
+			// resuming the normal B-then-A order.
+			return r.Resources.ApplyDaemonSet(ctx, infra, desiredA)
+		}
+		// Neither peer can currently protect the other. Leave both processes in
+		// place and let their existing controllers recover readiness first.
+		return nil
+	}
+	if !bReady {
+		// B already carries the desired revision; wait for its DaemonSet and
+		// current-template Pods to converge before touching A.
+		return nil
+	}
+	if !aDesired || !aReady {
+		return r.Resources.ApplyDaemonSet(ctx, infra, desiredA)
+	}
+
+	// Both slots are current and healthy. These calls are normally no-ops and
+	// keep non-rollout metadata or strategy drift reconciled.
+	if err := r.Resources.ApplyDaemonSet(ctx, infra, desiredB); err != nil {
+		return err
+	}
+	return r.Resources.ApplyDaemonSet(ctx, infra, desiredA)
+}
+
+func daemonSetHasDesiredRevision(current, desired *appsv1.DaemonSet) bool {
+	if current == nil || desired == nil {
+		return false
+	}
+	desiredRevision := desired.Spec.Template.Annotations[ctldRolloutRevisionAnnotation]
+	return desiredRevision != "" && current.Spec.Template.Annotations[ctldRolloutRevisionAnnotation] == desiredRevision
+}
+
+func (r *Reconciler) daemonSetCurrentPodsReady(ctx context.Context, ds *appsv1.DaemonSet) (bool, error) {
+	if !daemonSetReady(ds) {
+		return false, nil
+	}
+	return r.currentTemplatePodsReady(ctx, ds)
+}
+
+func (r *Reconciler) getDaemonSet(ctx context.Context, desired *appsv1.DaemonSet) (*appsv1.DaemonSet, bool, error) {
+	current := &appsv1.DaemonSet{}
+	err := r.Resources.Client.Get(ctx, types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, current)
+	if apierrors.IsNotFound(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	return current, true, nil
 }
 
 type ctldDaemonSetConfig struct {
@@ -353,8 +462,8 @@ func buildCtldDaemonSet(cfg ctldDaemonSetConfig) *appsv1.DaemonSet {
 			corev1.EnvVar{Name: netdsvc.ActiveLockEnv, Value: cfg.NetdActiveLockPath},
 		)
 	}
-	maxUnavailable := intstr.FromInt(0)
-	maxSurge := intstr.FromInt(1)
+	maxUnavailable := intstr.FromInt(1)
+	maxSurge := intstr.FromInt(0)
 	return &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{Name: cfg.Name + "-" + cfg.Slot, Namespace: cfg.Namespace},
 		Spec: appsv1.DaemonSetSpec{
@@ -479,19 +588,19 @@ func (r *Reconciler) currentTemplatePodsReady(ctx context.Context, ds *appsv1.Da
 	); err != nil {
 		return false, err
 	}
-	ready := int32(0)
+	readyNodes := make(map[string]struct{}, ds.Status.DesiredNumberScheduled)
 	for i := range pods.Items {
 		if CtldContainerRunning(&pods.Items[i]) && !PodMatchesCurrentTemplate(&pods.Items[i], ds) {
 			return false, nil
 		}
-		if PodReadyForCurrentTemplate(&pods.Items[i], ds) {
-			ready++
+		if pods.Items[i].DeletionTimestamp.IsZero() && pods.Items[i].Spec.NodeName != "" && PodReadyForCurrentTemplate(&pods.Items[i], ds) {
+			readyNodes[pods.Items[i].Spec.NodeName] = struct{}{}
 		}
 	}
-	return ready >= ds.Status.DesiredNumberScheduled, nil
+	return int32(len(readyNodes)) >= ds.Status.DesiredNumberScheduled, nil
 }
 
-// PodMatchesCurrentTemplate rejects a surge predecessor and verifies that the
+// PodMatchesCurrentTemplate rejects a live predecessor and verifies that the
 // ctld container carrying embedded netd is actually running with the desired
 // config, lock, mounts, and image.
 func PodMatchesCurrentTemplate(pod *corev1.Pod, ds *appsv1.DaemonSet) bool {

--- a/infra-operator/internal/controller/services/ctld/ctld.go
+++ b/infra-operator/internal/controller/services/ctld/ctld.go
@@ -51,6 +51,7 @@ const (
 	ctldKubeletRegistrationSocket  = "/var/lib/kubelet/plugins_registry/" + volumeportal.DriverName + "-reg.sock"
 	ctldKubeletCSIEndpoint         = "/var/lib/kubelet/plugins/" + volumeportal.DriverName + "/csi.sock"
 	ctldRolloutRevisionAnnotation  = "infra.sandbox0.ai/ctld-rollout-revision"
+	netdMetricsServiceSuffix       = "-netd-metrics"
 )
 
 func NewReconciler(resources *common.ResourceManager) *Reconciler {
@@ -100,6 +101,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 	}
 	if err := r.ensureCSIDriver(ctx, labels); err != nil {
 		return err
+	}
+	if netdAssets != nil {
+		if err := r.ensureNetdMetricsService(ctx, infra, int32(netdAssets.Config.MetricsPort)); err != nil {
+			return err
+		}
 	}
 
 	image := fmt.Sprintf("%s:%s", imageRepo, imageTag)
@@ -247,12 +253,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 		})
 		if netdAssets != nil {
 			desired.Spec.Template.Spec.RuntimeClassName = netdAssets.RuntimeClassName
-			// One slot supplies the stable Prometheus discovery target. Both HA
-			// processes share the node IP, so declaring the metrics port twice
-			// would scrape the active listener twice.
-			if slot == dataplane.CtldHASlotA {
-				desired.Spec.Template.Spec.Containers[0].Ports = netdMetricsDiscoveryPort(netdAssets.Ports)
-			}
+			// Do not declare netd listener ports on host-networked ctld Pods.
+			// Kubernetes reserves every declared container port as a HostPort in
+			// this mode, which prevents a replacement from coexisting with the
+			// guarded legacy netd during handoff. The active lock still guarantees
+			// that exactly one process binds each configured node-local port.
 		}
 		revision, err := common.ConfigHash(desired.Spec)
 		if err != nil {
@@ -492,15 +497,6 @@ func buildCtldDaemonSet(cfg ctldDaemonSetConfig) *appsv1.DaemonSet {
 			},
 		},
 	}
-}
-
-func netdMetricsDiscoveryPort(ports []corev1.ContainerPort) []corev1.ContainerPort {
-	for i := range ports {
-		if ports[i].Name == "metrics" {
-			return []corev1.ContainerPort{ports[i]}
-		}
-	}
-	return nil
 }
 
 func appendUniqueVolumes(existing []corev1.Volume, additions ...corev1.Volume) []corev1.Volume {
@@ -807,6 +803,28 @@ func (r *Reconciler) ensureCSIDriver(ctx context.Context, labels map[string]stri
 		current.Labels = desired.Labels
 		current.Spec = desired.Spec
 	})
+}
+
+// ensureNetdMetricsService preserves named-port endpoint discovery without
+// reserving netd's node-local listener on both host-networked ctld HA Pods.
+// Slot A supplies one endpoint per node; the numeric target reaches whichever
+// lock-fenced ctld peer currently owns the node-local metrics listener.
+func (r *Reconciler) ensureNetdMetricsService(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, metricsPort int32) error {
+	labels := common.GetServiceLabels(infra.Name, "netd")
+	selector := common.GetServiceLabels(infra.Name, "ctld")
+	selector[dataplane.CtldHASlotLabel] = dataplane.CtldHASlotA
+	return r.Resources.ReconcileServicePortsWithSpecMutator(
+		ctx,
+		infra,
+		infra.Name+netdMetricsServiceSuffix,
+		labels,
+		corev1.ServiceTypeClusterIP,
+		nil,
+		[]corev1.ServicePort{common.BuildServicePort("metrics", metricsPort, metricsPort, corev1.ServiceTypeClusterIP)},
+		func(spec *corev1.ServiceSpec) {
+			spec.Selector = selector
+		},
+	)
 }
 
 func (r *Reconciler) buildStorageConfig(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra) (*apiconfig.StorageProxyConfig, error) {

--- a/infra-operator/internal/controller/services/ctld/ctld.go
+++ b/infra-operator/internal/controller/services/ctld/ctld.go
@@ -632,6 +632,27 @@ func PodMatchesCurrentTemplate(pod *corev1.Pod, ds *appsv1.DaemonSet) bool {
 	return CtldContainerRunning(pod)
 }
 
+// DaemonSetEmbedsNetd verifies the guarded netd runtime contract required
+// before the standalone netd DaemonSet may yield its active lock.
+func DaemonSetEmbedsNetd(ds *appsv1.DaemonSet, activeLockPath string) bool {
+	if ds == nil || ds.Spec.Template.Annotations[netdsvc.ConfigHashAnnotation] == "" {
+		return false
+	}
+	container := containerByName(ds.Spec.Template.Spec.Containers, "ctld")
+	if container == nil {
+		return false
+	}
+	configPath, hasConfigPath := envValue(container.Env, "NETD_CONFIG_PATH")
+	lockPath, hasLockPath := envValue(container.Env, netdsvc.ActiveLockEnv)
+	if !hasConfigPath || configPath != netdsvc.ConfigPath || !hasLockPath || lockPath != activeLockPath {
+		return false
+	}
+	configMount, hasConfigMount := volumeMountByName(container.VolumeMounts, netdsvc.ConfigVolumeName)
+	lockMount, hasLockMount := volumeMountByName(container.VolumeMounts, netdsvc.ActiveLockVolumeName)
+	return hasConfigMount && configMount.MountPath == netdsvc.ConfigPath &&
+		hasLockMount && lockMount.MountPath == netdsvc.ActiveLockMountDirectory
+}
+
 // CtldContainerRunning reports whether a Pod can still own the node-local HA
 // primary lock. A terminating predecessor remains relevant until its process
 // has actually stopped.

--- a/infra-operator/internal/controller/services/ctld/ctld.go
+++ b/infra-operator/internal/controller/services/ctld/ctld.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	infrav1alpha1 "github.com/sandbox0-ai/sandbox0/infra-operator/api/v1alpha1"
@@ -21,8 +22,10 @@ import (
 	credentialstoresvc "github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/credentialstore"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/database"
 	internalauthsvc "github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/internalauth"
+	netdsvc "github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/netd"
 	sandboxobssvc "github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/sandboxobservability"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/storage"
+	infraplan "github.com/sandbox0-ai/sandbox0/infra-operator/internal/plan"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/runtimeconfig"
 	"github.com/sandbox0-ai/sandbox0/pkg/dataplane"
 	pkginternalauth "github.com/sandbox0-ai/sandbox0/pkg/internalauth"
@@ -42,6 +45,8 @@ const (
 	ctldTerminationGraceSeconds    = int64(45)
 	ctldCPURequest                 = "250m"
 	ctldMemoryRequest              = "256Mi"
+	embeddedNetdCPURequest         = "100m"
+	embeddedNetdMemoryRequest      = "128Mi"
 	ctldHAProbeSocket              = "/run/sandbox0/ctld-ha.sock"
 	ctldKubeletRegistrationSocket  = "/var/lib/kubelet/plugins_registry/" + volumeportal.DriverName + "-reg.sock"
 	ctldKubeletCSIEndpoint         = "/var/lib/kubelet/plugins/" + volumeportal.DriverName + "/csi.sock"
@@ -82,6 +87,16 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 		return err
 	}
 	podAnnotations := configRef.PodAnnotations()
+	compiledPlan := infraplan.Compile(infra)
+	compiledPlan.Services.ClusterGateway.URL = clusterGatewayURL
+	var netdAssets *netdsvc.RuntimeAssets
+	if compiledPlan.Netd.Enabled {
+		netdAssets, err = netdsvc.NewReconciler(r.Resources).BuildRuntimeAssets(ctx, compiledPlan)
+		if err != nil {
+			return err
+		}
+		podAnnotations[netdsvc.ConfigHashAnnotation] = netdAssets.ConfigRef.Hash
+	}
 	if err := r.ensureCSIDriver(ctx, labels); err != nil {
 		return err
 	}
@@ -105,7 +120,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 		{Name: "ctld-data", MountPath: "/var/lib/sandbox0/ctld"},
 		{Name: "containerd-sock", MountPath: "/host-run/containerd"},
 		{Name: "containerd-data", MountPath: containerdDataMountPath, ReadOnly: true},
-		{Name: "ha-run", MountPath: "/run/sandbox0"},
+		{Name: netdsvc.RunVolumeName, MountPath: netdsvc.RunMountDirectory},
 	}
 	volumes := []corev1.Volume{
 		{
@@ -152,10 +167,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 				HostPath: &corev1.HostPathVolumeSource{Path: containerdHostDataRoot},
 			},
 		},
-		{
-			Name:         "ha-run",
-			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
-		},
+		{Name: netdsvc.RunVolumeName, VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
 	}
 	if strings.TrimSpace(config.SandboxObservabilityRuntimeSamplesIngestURL) != "" {
 		keySecretName, privateKeyKey, _ := internalauthsvc.GetDataPlaneKeyRefs(infra)
@@ -200,6 +212,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 			},
 		})
 	}
+	if netdAssets != nil {
+		volumeMounts = appendUniqueVolumeMounts(volumeMounts, netdAssets.VolumeMounts...)
+		volumes = appendUniqueVolumes(volumes, netdAssets.Volumes...)
+	}
+	netdActiveLockPath := ""
+	if netdAssets != nil {
+		netdActiveLockPath = netdAssets.ActiveLockPath
+	}
 
 	if err := r.removeLegacyDaemonSet(ctx, infra, name); err != nil {
 		return err
@@ -220,7 +240,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 			VolumeMounts:            volumeMounts,
 			Volumes:                 volumes,
 			Infra:                   infra,
+			NetdEnabled:             netdAssets != nil,
+			NetdActiveLockPath:      netdActiveLockPath,
 		})
+		if netdAssets != nil {
+			desired.Spec.Template.Spec.RuntimeClassName = netdAssets.RuntimeClassName
+			// One slot supplies the stable Prometheus discovery target. Both HA
+			// processes share the node IP, so declaring the metrics port twice
+			// would scrape the active listener twice.
+			if slot == dataplane.CtldHASlotA {
+				desired.Spec.Template.Spec.Containers[0].Ports = netdMetricsDiscoveryPort(netdAssets.Ports)
+			}
+		}
 		if err := r.Resources.ApplyDaemonSet(ctx, infra, desired); err != nil {
 			return err
 		}
@@ -243,6 +274,8 @@ type ctldDaemonSetConfig struct {
 	VolumeMounts            []corev1.VolumeMount
 	Volumes                 []corev1.Volume
 	Infra                   *infrav1alpha1.Sandbox0Infra
+	NetdEnabled             bool
+	NetdActiveLockPath      string
 }
 
 func buildCtldDaemonSet(cfg ctldDaemonSetConfig) *appsv1.DaemonSet {
@@ -266,6 +299,18 @@ func buildCtldDaemonSet(cfg ctldDaemonSetConfig) *appsv1.DaemonSet {
 			"-ha-probe-socket=" + ctldHAProbeSocket,
 			"-http-addr=:8095",
 		}
+	}
+	requests := corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse(ctldCPURequest),
+		corev1.ResourceMemory: resource.MustParse(ctldMemoryRequest),
+	}
+	if cfg.NetdEnabled {
+		cpu := requests[corev1.ResourceCPU]
+		cpu.Add(resource.MustParse(embeddedNetdCPURequest))
+		requests[corev1.ResourceCPU] = cpu
+		memory := requests[corev1.ResourceMemory]
+		memory.Add(resource.MustParse(embeddedNetdMemoryRequest))
+		requests[corev1.ResourceMemory] = memory
 	}
 	ctldContainer := corev1.Container{
 		Name:            "ctld",
@@ -299,11 +344,14 @@ func buildCtldDaemonSet(cfg ctldDaemonSetConfig) *appsv1.DaemonSet {
 			FailureThreshold:    ctldProbeFailureThreshold,
 		},
 		SecurityContext: &corev1.SecurityContext{Privileged: common.BoolPtr(true)},
-		Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse(ctldCPURequest),
-			corev1.ResourceMemory: resource.MustParse(ctldMemoryRequest),
-		}},
-		VolumeMounts: cfg.VolumeMounts,
+		Resources:       corev1.ResourceRequirements{Requests: requests},
+		VolumeMounts:    cfg.VolumeMounts,
+	}
+	if cfg.NetdEnabled {
+		ctldContainer.Env = append(ctldContainer.Env,
+			corev1.EnvVar{Name: "NETD_CONFIG_PATH", Value: netdsvc.ConfigPath},
+			corev1.EnvVar{Name: netdsvc.ActiveLockEnv, Value: cfg.NetdActiveLockPath},
+		)
 	}
 	maxUnavailable := intstr.FromInt(0)
 	maxSurge := intstr.FromInt(1)
@@ -335,6 +383,215 @@ func buildCtldDaemonSet(cfg ctldDaemonSetConfig) *appsv1.DaemonSet {
 			},
 		},
 	}
+}
+
+func netdMetricsDiscoveryPort(ports []corev1.ContainerPort) []corev1.ContainerPort {
+	for i := range ports {
+		if ports[i].Name == "metrics" {
+			return []corev1.ContainerPort{ports[i]}
+		}
+	}
+	return nil
+}
+
+func appendUniqueVolumes(existing []corev1.Volume, additions ...corev1.Volume) []corev1.Volume {
+	names := make(map[string]struct{}, len(existing)+len(additions))
+	for i := range existing {
+		names[existing[i].Name] = struct{}{}
+	}
+	for i := range additions {
+		if _, ok := names[additions[i].Name]; ok {
+			continue
+		}
+		existing = append(existing, additions[i])
+		names[additions[i].Name] = struct{}{}
+	}
+	return existing
+}
+
+func appendUniqueVolumeMounts(existing []corev1.VolumeMount, additions ...corev1.VolumeMount) []corev1.VolumeMount {
+	names := make(map[string]struct{}, len(existing)+len(additions))
+	for i := range existing {
+		names[existing[i].Name] = struct{}{}
+	}
+	for i := range additions {
+		if _, ok := names[additions[i].Name]; ok {
+			continue
+		}
+		existing = append(existing, additions[i])
+		names[additions[i].Name] = struct{}{}
+	}
+	return existing
+}
+
+// Ready reports whether both ctld HA slots completed their rollout and all
+// desired Pods pass the role-aware readiness probe.
+func (r *Reconciler) Ready(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra) (bool, error) {
+	if infra == nil {
+		return false, fmt.Errorf("sandbox0infra is required")
+	}
+	name := fmt.Sprintf("%s-ctld", infra.Name)
+	for _, slot := range []string{dataplane.CtldHASlotA, dataplane.CtldHASlotB} {
+		ds := &appsv1.DaemonSet{}
+		key := types.NamespacedName{Name: name + "-" + slot, Namespace: infra.Namespace}
+		if err := r.Resources.Client.Get(ctx, key, ds); err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		if !daemonSetReady(ds) {
+			return false, nil
+		}
+		ready, err := r.currentTemplatePodsReady(ctx, ds)
+		if err != nil {
+			return false, err
+		}
+		if !ready {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// EmbeddedNetdReady reports embedded netd readiness through the ctld primary
+// probe. Standby probes validate FUSE synchronization without starting netd.
+func (r *Reconciler) EmbeddedNetdReady(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra) (bool, error) {
+	return r.Ready(ctx, infra)
+}
+
+func daemonSetReady(ds *appsv1.DaemonSet) bool {
+	return ds != nil &&
+		ds.Status.ObservedGeneration >= ds.Generation &&
+		ds.Status.UpdatedNumberScheduled == ds.Status.DesiredNumberScheduled &&
+		ds.Status.NumberReady == ds.Status.DesiredNumberScheduled &&
+		ds.Status.NumberUnavailable == 0
+}
+
+func (r *Reconciler) currentTemplatePodsReady(ctx context.Context, ds *appsv1.DaemonSet) (bool, error) {
+	if ds == nil || ds.Status.DesiredNumberScheduled == 0 {
+		return true, nil
+	}
+	pods := &corev1.PodList{}
+	if err := r.Resources.Client.List(ctx, pods,
+		ctrlclient.InNamespace(ds.Namespace),
+		ctrlclient.MatchingLabels(ds.Spec.Selector.MatchLabels),
+	); err != nil {
+		return false, err
+	}
+	ready := int32(0)
+	for i := range pods.Items {
+		if CtldContainerRunning(&pods.Items[i]) && !PodMatchesCurrentTemplate(&pods.Items[i], ds) {
+			return false, nil
+		}
+		if PodReadyForCurrentTemplate(&pods.Items[i], ds) {
+			ready++
+		}
+	}
+	return ready >= ds.Status.DesiredNumberScheduled, nil
+}
+
+// PodMatchesCurrentTemplate rejects a surge predecessor and verifies that the
+// ctld container carrying embedded netd is actually running with the desired
+// config, lock, mounts, and image.
+func PodMatchesCurrentTemplate(pod *corev1.Pod, ds *appsv1.DaemonSet) bool {
+	if pod == nil || ds == nil || !mapContains(pod.Labels, ds.Spec.Template.Labels) || !mapContains(pod.Annotations, ds.Spec.Template.Annotations) {
+		return false
+	}
+	if pod.Annotations[netdsvc.ConfigHashAnnotation] != ds.Spec.Template.Annotations[netdsvc.ConfigHashAnnotation] {
+		return false
+	}
+	desired := containerByName(ds.Spec.Template.Spec.Containers, "ctld")
+	actual := containerByName(pod.Spec.Containers, "ctld")
+	if desired == nil || actual == nil || desired.Image != actual.Image {
+		return false
+	}
+	for _, name := range []string{"NETD_CONFIG_PATH", netdsvc.ActiveLockEnv} {
+		desiredValue, desiredFound := envValue(desired.Env, name)
+		actualValue, actualFound := envValue(actual.Env, name)
+		if desiredFound != actualFound || desiredValue != actualValue {
+			return false
+		}
+	}
+	for _, name := range []string{netdsvc.ConfigVolumeName, netdsvc.ActiveLockVolumeName} {
+		desiredMount, desiredFound := volumeMountByName(desired.VolumeMounts, name)
+		actualMount, actualFound := volumeMountByName(actual.VolumeMounts, name)
+		if desiredFound != actualFound || (desiredFound && desiredMount.MountPath != actualMount.MountPath) {
+			return false
+		}
+	}
+	return CtldContainerRunning(pod)
+}
+
+// CtldContainerRunning reports whether a Pod can still own the node-local HA
+// primary lock. A terminating predecessor remains relevant until its process
+// has actually stopped.
+func CtldContainerRunning(pod *corev1.Pod) bool {
+	if pod == nil {
+		return false
+	}
+	status := containerStatusByName(pod.Status.ContainerStatuses, "ctld")
+	return status != nil && status.State.Running != nil
+}
+
+// PodReadyForCurrentTemplate adds the Kubernetes PodReady condition to the
+// current-template and running-container checks.
+func PodReadyForCurrentTemplate(pod *corev1.Pod, ds *appsv1.DaemonSet) bool {
+	if !PodMatchesCurrentTemplate(pod, ds) {
+		return false
+	}
+	for i := range pod.Status.Conditions {
+		condition := pod.Status.Conditions[i]
+		if condition.Type == corev1.PodReady {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+func mapContains(actual, expected map[string]string) bool {
+	for key, value := range expected {
+		if actual[key] != value {
+			return false
+		}
+	}
+	return true
+}
+
+func containerByName(containers []corev1.Container, name string) *corev1.Container {
+	for i := range containers {
+		if containers[i].Name == name {
+			return &containers[i]
+		}
+	}
+	return nil
+}
+
+func containerStatusByName(statuses []corev1.ContainerStatus, name string) *corev1.ContainerStatus {
+	for i := range statuses {
+		if statuses[i].Name == name {
+			return &statuses[i]
+		}
+	}
+	return nil
+}
+
+func envValue(env []corev1.EnvVar, name string) (string, bool) {
+	for i := range env {
+		if env[i].Name == name {
+			return env[i].Value, true
+		}
+	}
+	return "", false
+}
+
+func volumeMountByName(mounts []corev1.VolumeMount, name string) (corev1.VolumeMount, bool) {
+	for i := range mounts {
+		if mounts[i].Name == name {
+			return mounts[i], true
+		}
+	}
+	return corev1.VolumeMount{}, false
 }
 
 func (r *Reconciler) removeLegacyDaemonSet(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, name string) error {

--- a/infra-operator/internal/controller/services/ctld/ctld_test.go
+++ b/infra-operator/internal/controller/services/ctld/ctld_test.go
@@ -86,6 +86,7 @@ func TestReconcileEmbedsNetdRuntimeAssetsInBothHASlots(t *testing.T) {
 	runtimeClass := "runc"
 	infra.Spec.Services.Netd.Enabled = true
 	infra.Spec.Services.Netd.RuntimeClassName = &runtimeClass
+	infra.Spec.Services.Netd.Config = &infrav1alpha1.NetdConfig{MetricsPort: 9191}
 
 	primary, client := reconcileCtldResources(t, infra, &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: "kube-dns", Namespace: "kube-system"},
@@ -119,11 +120,27 @@ func TestReconcileEmbedsNetdRuntimeAssetsInBothHASlots(t *testing.T) {
 			t.Fatalf("%s embedded memory request = %s, want 384Mi", ds.Name, got.String())
 		}
 	}
-	if !hasContainerPort(primary.Spec.Template.Spec.Containers[0].Ports, "metrics", 9091) {
-		t.Fatalf("slot A netd metrics discovery port = %#v", primary.Spec.Template.Spec.Containers[0].Ports)
+	for _, ds := range []*appsv1.DaemonSet{primary, standby} {
+		if len(ds.Spec.Template.Spec.Containers[0].Ports) != 0 {
+			t.Fatalf("%s reserves host-network netd ports during handoff: %#v", ds.Name, ds.Spec.Template.Spec.Containers[0].Ports)
+		}
 	}
-	if len(standby.Spec.Template.Spec.Containers[0].Ports) != 0 {
-		t.Fatalf("slot B duplicates the node-local metrics target: %#v", standby.Spec.Template.Spec.Containers[0].Ports)
+	metricsService := &corev1.Service{}
+	if err := client.Get(context.Background(), types.NamespacedName{Name: infra.Name + netdMetricsServiceSuffix, Namespace: infra.Namespace}, metricsService); err != nil {
+		t.Fatalf("get netd metrics service: %v", err)
+	}
+	if got := metricsService.Labels["app.kubernetes.io/component"]; got != "netd" {
+		t.Fatalf("netd metrics service component label = %q, want netd", got)
+	}
+	wantSelector := common.GetServiceLabels(infra.Name, "ctld")
+	wantSelector[dataplane.CtldHASlotLabel] = dataplane.CtldHASlotA
+	assert.Equal(t, wantSelector, metricsService.Spec.Selector)
+	if len(metricsService.Spec.Ports) != 1 {
+		t.Fatalf("netd metrics service ports = %#v, want one port", metricsService.Spec.Ports)
+	}
+	metricsServicePort := metricsService.Spec.Ports[0]
+	if metricsServicePort.Name != "metrics" || metricsServicePort.Port != 9191 || metricsServicePort.TargetPort.IntVal != 9191 {
+		t.Fatalf("netd metrics service port = %#v, want named numeric port 9191", metricsServicePort)
 	}
 	legacy := &appsv1.DaemonSet{}
 	err := client.Get(context.Background(), types.NamespacedName{Name: infra.Name + "-netd", Namespace: infra.Namespace}, legacy)
@@ -763,15 +780,6 @@ func assertContainerEnv(t *testing.T, env []corev1.EnvVar, name, value string) {
 		return
 	}
 	t.Fatalf("expected environment %q, got %#v", name, env)
-}
-
-func hasContainerPort(ports []corev1.ContainerPort, name string, port int32) bool {
-	for i := range ports {
-		if ports[i].Name == name && ports[i].ContainerPort == port {
-			return true
-		}
-	}
-	return false
 }
 
 func assertNoContainerVolumeMount(t *testing.T, mounts []corev1.VolumeMount, name string) {

--- a/infra-operator/internal/controller/services/ctld/ctld_test.go
+++ b/infra-operator/internal/controller/services/ctld/ctld_test.go
@@ -98,6 +98,9 @@ func TestReconcileEmbedsNetdRuntimeAssetsInBothHASlots(t *testing.T) {
 	wantLockPath := filepath.Join(netdsvc.ActiveLockMountDirectory, infra.Namespace, infra.Name, "netd.lock")
 	for _, ds := range []*appsv1.DaemonSet{primary, standby} {
 		container := ds.Spec.Template.Spec.Containers[0]
+		if ds.Spec.Template.Annotations[ctldRolloutRevisionAnnotation] == "" {
+			t.Fatalf("%s is missing the staged rollout revision", ds.Name)
+		}
 		assertContainerEnv(t, container.Env, "NETD_CONFIG_PATH", netdsvc.ConfigPath)
 		assertContainerEnv(t, container.Env, netdsvc.ActiveLockEnv, wantLockPath)
 		if ds.Spec.Template.Spec.RuntimeClassName == nil || *ds.Spec.Template.Spec.RuntimeClassName != runtimeClass {
@@ -136,6 +139,105 @@ func TestCtldTerminationGraceCoversStaticShutdownBudget(t *testing.T) {
 	)
 
 	assert.LessOrEqual(t, shutdownBudgetSeconds+shutdownMarginSeconds, ctldTerminationGraceSeconds)
+}
+
+func TestReconcileStagesHASlotRolloutBThenA(t *testing.T) {
+	ctx := context.Background()
+	infra := newCtldTestInfra()
+	infra.Spec.Services.Netd.Enabled = true
+	primary, client := reconcileCtldResources(t, infra, &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "kube-dns", Namespace: "kube-system"},
+		Spec:       corev1.ServiceSpec{ClusterIP: "10.96.0.10"},
+	})
+	standby := &appsv1.DaemonSet{}
+	require.NoError(t, client.Get(ctx, types.NamespacedName{Name: infra.Name + "-ctld-b", Namespace: infra.Namespace}, standby))
+	markCtldDaemonSetReady(t, ctx, client, primary)
+	markCtldDaemonSetReady(t, ctx, client, standby)
+	primaryPod := readyCtldPodForDaemonSet(primary, "ctld-a-old", "node-a")
+	standbyPod := readyCtldPodForDaemonSet(standby, "ctld-b-old", "node-a")
+	require.NoError(t, client.Create(ctx, primaryPod))
+	require.NoError(t, client.Create(ctx, standbyPod))
+
+	reconciler := NewReconciler(common.NewResourceManager(client, newCtldTestScheme(t), nil, common.LocalDevConfig{}))
+	require.NoError(t, reconciler.Reconcile(ctx, infra, "ghcr.io/sandbox0-ai/sandbox0", "next", "http://demo-cluster-gateway:8443"))
+	primary = getCtldDaemonSet(t, ctx, client, infra, dataplane.CtldHASlotA)
+	standby = getCtldDaemonSet(t, ctx, client, infra, dataplane.CtldHASlotB)
+	assert.Equal(t, "ghcr.io/sandbox0-ai/sandbox0:latest", primary.Spec.Template.Spec.Containers[0].Image)
+	assert.Equal(t, "ghcr.io/sandbox0-ai/sandbox0:next", standby.Spec.Template.Spec.Containers[0].Image)
+	assertCtldRollingUpdate(t, primary, 1, 0)
+	assertCtldRollingUpdate(t, standby, 1, 0)
+
+	// An observed DaemonSet status is not enough while its live predecessor is
+	// still present; slot A must remain untouched.
+	require.NoError(t, reconciler.Reconcile(ctx, infra, "ghcr.io/sandbox0-ai/sandbox0", "next", "http://demo-cluster-gateway:8443"))
+	primary = getCtldDaemonSet(t, ctx, client, infra, dataplane.CtldHASlotA)
+	assert.Equal(t, "ghcr.io/sandbox0-ai/sandbox0:latest", primary.Spec.Template.Spec.Containers[0].Image)
+
+	require.NoError(t, client.Delete(ctx, standbyPod))
+	standby = getCtldDaemonSet(t, ctx, client, infra, dataplane.CtldHASlotB)
+	markCtldDaemonSetReady(t, ctx, client, standby)
+	require.NoError(t, client.Create(ctx, readyCtldPodForDaemonSet(standby, "ctld-b-next", "node-a")))
+	require.NoError(t, reconciler.Reconcile(ctx, infra, "ghcr.io/sandbox0-ai/sandbox0", "next", "http://demo-cluster-gateway:8443"))
+	primary = getCtldDaemonSet(t, ctx, client, infra, dataplane.CtldHASlotA)
+	assert.Equal(t, "ghcr.io/sandbox0-ai/sandbox0:next", primary.Spec.Template.Spec.Containers[0].Image)
+}
+
+func TestReconcileRepairsMissingSlotBeforeRollingPeer(t *testing.T) {
+	ctx := context.Background()
+	infra := newCtldTestInfra()
+	primary, client := reconcileCtldResources(t, infra)
+	standby := getCtldDaemonSet(t, ctx, client, infra, dataplane.CtldHASlotB)
+	markCtldDaemonSetReady(t, ctx, client, standby)
+	require.NoError(t, client.Create(ctx, readyCtldPodForDaemonSet(standby, "ctld-b-old", "node-a")))
+	require.NoError(t, client.Delete(ctx, primary))
+
+	reconciler := NewReconciler(common.NewResourceManager(client, newCtldTestScheme(t), nil, common.LocalDevConfig{}))
+	require.NoError(t, reconciler.Reconcile(ctx, infra, "ghcr.io/sandbox0-ai/sandbox0", "next", "http://demo-cluster-gateway:8443"))
+	primary = getCtldDaemonSet(t, ctx, client, infra, dataplane.CtldHASlotA)
+	standby = getCtldDaemonSet(t, ctx, client, infra, dataplane.CtldHASlotB)
+	assert.Equal(t, "ghcr.io/sandbox0-ai/sandbox0:next", primary.Spec.Template.Spec.Containers[0].Image)
+	assert.Equal(t, "ghcr.io/sandbox0-ai/sandbox0:latest", standby.Spec.Template.Spec.Containers[0].Image)
+	// The fake client does not assign metadata.generation on create. Mirror the
+	// API server so an unobserved replacement cannot look vacuously ready.
+	primary.Generation = 1
+	require.NoError(t, client.Update(ctx, primary))
+
+	// The surviving peer remains unchanged until the repaired slot is actually
+	// ready on its desired nodes.
+	require.NoError(t, reconciler.Reconcile(ctx, infra, "ghcr.io/sandbox0-ai/sandbox0", "next", "http://demo-cluster-gateway:8443"))
+	standby = getCtldDaemonSet(t, ctx, client, infra, dataplane.CtldHASlotB)
+	assert.Equal(t, "ghcr.io/sandbox0-ai/sandbox0:latest", standby.Spec.Template.Spec.Containers[0].Image)
+	markCtldDaemonSetReady(t, ctx, client, primary)
+	require.NoError(t, client.Create(ctx, readyCtldPodForDaemonSet(primary, "ctld-a-next", "node-a")))
+	require.NoError(t, reconciler.Reconcile(ctx, infra, "ghcr.io/sandbox0-ai/sandbox0", "next", "http://demo-cluster-gateway:8443"))
+	standby = getCtldDaemonSet(t, ctx, client, infra, dataplane.CtldHASlotB)
+	assert.Equal(t, "ghcr.io/sandbox0-ai/sandbox0:next", standby.Spec.Template.Spec.Containers[0].Image)
+}
+
+func TestReconcileDoesNotMutateEitherDegradedPeer(t *testing.T) {
+	ctx := context.Background()
+	infra := newCtldTestInfra()
+	primary, client := reconcileCtldResources(t, infra)
+	standby := getCtldDaemonSet(t, ctx, client, infra, dataplane.CtldHASlotB)
+	markCtldDaemonSetNotReady(t, ctx, client, primary)
+	markCtldDaemonSetNotReady(t, ctx, client, standby)
+
+	reconciler := NewReconciler(common.NewResourceManager(client, newCtldTestScheme(t), nil, common.LocalDevConfig{}))
+	require.NoError(t, reconciler.Reconcile(ctx, infra, "ghcr.io/sandbox0-ai/sandbox0", "next", "http://demo-cluster-gateway:8443"))
+	primary = getCtldDaemonSet(t, ctx, client, infra, dataplane.CtldHASlotA)
+	standby = getCtldDaemonSet(t, ctx, client, infra, dataplane.CtldHASlotB)
+	assert.Equal(t, "ghcr.io/sandbox0-ai/sandbox0:latest", primary.Spec.Template.Spec.Containers[0].Image)
+	assert.Equal(t, "ghcr.io/sandbox0-ai/sandbox0:latest", standby.Spec.Template.Spec.Containers[0].Image)
+
+	// Once B is a verified peer, A may be recovered first without risking a
+	// simultaneous restart.
+	markCtldDaemonSetReady(t, ctx, client, standby)
+	require.NoError(t, client.Create(ctx, readyCtldPodForDaemonSet(standby, "ctld-b-old", "node-a")))
+	require.NoError(t, reconciler.Reconcile(ctx, infra, "ghcr.io/sandbox0-ai/sandbox0", "next", "http://demo-cluster-gateway:8443"))
+	primary = getCtldDaemonSet(t, ctx, client, infra, dataplane.CtldHASlotA)
+	standby = getCtldDaemonSet(t, ctx, client, infra, dataplane.CtldHASlotB)
+	assert.Equal(t, "ghcr.io/sandbox0-ai/sandbox0:next", primary.Spec.Template.Spec.Containers[0].Image)
+	assert.Equal(t, "ghcr.io/sandbox0-ai/sandbox0:latest", standby.Spec.Template.Spec.Containers[0].Image)
 }
 
 func TestDaemonSetReadyRequiresObservedFullyReadyRollout(t *testing.T) {
@@ -225,6 +327,42 @@ func TestReadyRejectsLiveSurgePredecessor(t *testing.T) {
 	}
 }
 
+func TestCurrentTemplatePodsReadyRequiresUniqueNonTerminatingNodes(t *testing.T) {
+	ctx := context.Background()
+	infra := newCtldTestInfra()
+	primary, client := reconcileCtldResources(t, infra)
+	primary.Status.ObservedGeneration = primary.Generation
+	primary.Status.DesiredNumberScheduled = 2
+	primary.Status.CurrentNumberScheduled = 2
+	primary.Status.UpdatedNumberScheduled = 2
+	primary.Status.NumberReady = 2
+	primary.Status.NumberAvailable = 2
+	require.NoError(t, client.Status().Update(ctx, primary))
+	require.NoError(t, client.Create(ctx, readyCtldPodForDaemonSet(primary, "ctld-a-duplicate-1", "node-a")))
+	require.NoError(t, client.Create(ctx, readyCtldPodForDaemonSet(primary, "ctld-a-duplicate-2", "node-a")))
+
+	reconciler := NewReconciler(common.NewResourceManager(client, newCtldTestScheme(t), nil, common.LocalDevConfig{}))
+	ready, err := reconciler.currentTemplatePodsReady(ctx, primary)
+	require.NoError(t, err)
+	assert.False(t, ready, "duplicate pods on one node must not satisfy a two-node rollout")
+
+	terminating := readyCtldPodForDaemonSet(primary, "ctld-a-terminating", "node-b")
+	terminating.Finalizers = []string{"test.sandbox0.ai/hold"}
+	require.NoError(t, client.Create(ctx, terminating))
+	require.NoError(t, client.Delete(ctx, terminating))
+	terminating = &corev1.Pod{}
+	require.NoError(t, client.Get(ctx, types.NamespacedName{Name: "ctld-a-terminating", Namespace: primary.Namespace}, terminating))
+	require.False(t, terminating.DeletionTimestamp.IsZero())
+	ready, err = reconciler.currentTemplatePodsReady(ctx, primary)
+	require.NoError(t, err)
+	assert.False(t, ready, "a terminating pod must not satisfy the node readiness gate")
+
+	require.NoError(t, client.Create(ctx, readyCtldPodForDaemonSet(primary, "ctld-a-node-b", "node-b")))
+	ready, err = reconciler.currentTemplatePodsReady(ctx, primary)
+	require.NoError(t, err)
+	assert.True(t, ready)
+}
+
 func TestReconcileRemovesLegacySingleDaemonSet(t *testing.T) {
 	infra := newCtldTestInfra()
 	legacy := &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: infra.Name + "-ctld", Namespace: infra.Namespace}}
@@ -245,19 +383,7 @@ func reconcileCtldDaemonSet(t *testing.T, infra *infrav1alpha1.Sandbox0Infra) *a
 func reconcileCtldResources(t *testing.T, infra *infrav1alpha1.Sandbox0Infra, extraObjects ...ctrlclient.Object) (*appsv1.DaemonSet, ctrlclient.Client) {
 	t.Helper()
 
-	scheme := runtime.NewScheme()
-	if err := appsv1.AddToScheme(scheme); err != nil {
-		t.Fatalf("add appsv1 scheme: %v", err)
-	}
-	if err := corev1.AddToScheme(scheme); err != nil {
-		t.Fatalf("add corev1 scheme: %v", err)
-	}
-	if err := storagev1.AddToScheme(scheme); err != nil {
-		t.Fatalf("add storagev1 scheme: %v", err)
-	}
-	if err := infrav1alpha1.AddToScheme(scheme); err != nil {
-		t.Fatalf("add infra scheme: %v", err)
-	}
+	scheme := newCtldTestScheme(t)
 
 	objects := []ctrlclient.Object{infra.DeepCopy()}
 	objects = append(objects, extraObjects...)
@@ -271,20 +397,8 @@ func reconcileCtldResources(t *testing.T, infra *infrav1alpha1.Sandbox0Infra, ex
 		t.Fatalf("reconcile returned error: %v", err)
 	}
 
-	ds := &appsv1.DaemonSet{}
-	if err := client.Get(context.Background(), types.NamespacedName{
-		Name:      infra.Name + "-ctld-a",
-		Namespace: infra.Namespace,
-	}, ds); err != nil {
-		t.Fatalf("expected daemonset to be created: %v", err)
-	}
-	standby := &appsv1.DaemonSet{}
-	if err := client.Get(context.Background(), types.NamespacedName{
-		Name:      infra.Name + "-ctld-b",
-		Namespace: infra.Namespace,
-	}, standby); err != nil {
-		t.Fatalf("expected standby daemonset to be created: %v", err)
-	}
+	ds := getCtldDaemonSet(t, context.Background(), client, infra, dataplane.CtldHASlotA)
+	standby := getCtldDaemonSet(t, context.Background(), client, infra, dataplane.CtldHASlotB)
 
 	if got := ds.Spec.Template.Spec.Containers[0].Env[0].Value; got != "ctld" {
 		t.Fatalf("expected SERVICE=ctld, got %q", got)
@@ -334,8 +448,8 @@ func reconcileCtldResources(t *testing.T, infra *infrav1alpha1.Sandbox0Infra, ex
 			t.Fatalf("ctld hostNetwork pod %s reserves node ports: %#v", workload.Name, workload.Spec.Template.Spec.Containers[0].Ports)
 		}
 	}
-	assertCtldRollingUpdate(t, ds, 0, 1)
-	assertCtldRollingUpdate(t, standby, 0, 1)
+	assertCtldRollingUpdate(t, ds, 1, 0)
+	assertCtldRollingUpdate(t, standby, 1, 0)
 	if len(ds.Spec.Template.Spec.Containers[0].VolumeMounts) < 7 {
 		t.Fatalf("expected ctld config, csi, kubelet, data, containerd socket, and containerd data mounts, got %#v", ds.Spec.Template.Spec.Containers[0].VolumeMounts)
 	}
@@ -350,6 +464,74 @@ func reconcileCtldResources(t *testing.T, infra *infrav1alpha1.Sandbox0Infra, ex
 	}
 
 	return ds, client
+}
+
+func newCtldTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add appsv1 scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1 scheme: %v", err)
+	}
+	if err := storagev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add storagev1 scheme: %v", err)
+	}
+	if err := infrav1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add infra scheme: %v", err)
+	}
+	return scheme
+}
+
+func getCtldDaemonSet(t *testing.T, ctx context.Context, client ctrlclient.Client, infra *infrav1alpha1.Sandbox0Infra, slot string) *appsv1.DaemonSet {
+	t.Helper()
+	ds := &appsv1.DaemonSet{}
+	require.NoError(t, client.Get(ctx, types.NamespacedName{Name: infra.Name + "-ctld-" + slot, Namespace: infra.Namespace}, ds))
+	return ds
+}
+
+func markCtldDaemonSetReady(t *testing.T, ctx context.Context, client ctrlclient.Client, ds *appsv1.DaemonSet) {
+	t.Helper()
+	ds.Status.ObservedGeneration = ds.Generation
+	ds.Status.DesiredNumberScheduled = 1
+	ds.Status.CurrentNumberScheduled = 1
+	ds.Status.UpdatedNumberScheduled = 1
+	ds.Status.NumberReady = 1
+	ds.Status.NumberAvailable = 1
+	ds.Status.NumberUnavailable = 0
+	require.NoError(t, client.Status().Update(ctx, ds))
+}
+
+func markCtldDaemonSetNotReady(t *testing.T, ctx context.Context, client ctrlclient.Client, ds *appsv1.DaemonSet) {
+	t.Helper()
+	ds.Status.ObservedGeneration = ds.Generation
+	ds.Status.DesiredNumberScheduled = 1
+	ds.Status.CurrentNumberScheduled = 1
+	ds.Status.UpdatedNumberScheduled = 0
+	ds.Status.NumberReady = 0
+	ds.Status.NumberAvailable = 0
+	ds.Status.NumberUnavailable = 1
+	require.NoError(t, client.Status().Update(ctx, ds))
+}
+
+func readyCtldPodForDaemonSet(ds *appsv1.DaemonSet, name, node string) *corev1.Pod {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   ds.Namespace,
+			Labels:      common.CloneStringMap(ds.Spec.Template.Labels),
+			Annotations: common.CloneStringMap(ds.Spec.Template.Annotations),
+		},
+		Spec: *ds.Spec.Template.Spec.DeepCopy(),
+		Status: corev1.PodStatus{
+			Phase:             corev1.PodRunning,
+			Conditions:        []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+			ContainerStatuses: []corev1.ContainerStatus{{Name: "ctld", State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}}},
+		},
+	}
+	pod.Spec.NodeName = node
+	return pod
 }
 
 func assertCtldRollingUpdate(t *testing.T, daemonSet *appsv1.DaemonSet, maxUnavailable, maxSurge int) {

--- a/infra-operator/internal/controller/services/ctld/ctld_test.go
+++ b/infra-operator/internal/controller/services/ctld/ctld_test.go
@@ -2,6 +2,7 @@ package ctld
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -23,6 +24,8 @@ import (
 
 	infrav1alpha1 "github.com/sandbox0-ai/sandbox0/infra-operator/api/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/pkg/common"
+	netdsvc "github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/netd"
+	infraplan "github.com/sandbox0-ai/sandbox0/infra-operator/internal/plan"
 	"github.com/sandbox0-ai/sandbox0/pkg/dataplane"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 )
@@ -78,6 +81,54 @@ func TestReconcileFallsBackToLegacyNetdPlacement(t *testing.T) {
 	}
 }
 
+func TestReconcileEmbedsNetdRuntimeAssetsInBothHASlots(t *testing.T) {
+	infra := newCtldTestInfra()
+	runtimeClass := "runc"
+	infra.Spec.Services.Netd.Enabled = true
+	infra.Spec.Services.Netd.RuntimeClassName = &runtimeClass
+
+	primary, client := reconcileCtldResources(t, infra, &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "kube-dns", Namespace: "kube-system"},
+		Spec:       corev1.ServiceSpec{ClusterIP: "10.96.0.10"},
+	})
+	standby := &appsv1.DaemonSet{}
+	if err := client.Get(context.Background(), types.NamespacedName{Name: infra.Name + "-ctld-b", Namespace: infra.Namespace}, standby); err != nil {
+		t.Fatalf("get standby ctld: %v", err)
+	}
+	wantLockPath := filepath.Join(netdsvc.ActiveLockMountDirectory, infra.Namespace, infra.Name, "netd.lock")
+	for _, ds := range []*appsv1.DaemonSet{primary, standby} {
+		container := ds.Spec.Template.Spec.Containers[0]
+		assertContainerEnv(t, container.Env, "NETD_CONFIG_PATH", netdsvc.ConfigPath)
+		assertContainerEnv(t, container.Env, netdsvc.ActiveLockEnv, wantLockPath)
+		if ds.Spec.Template.Spec.RuntimeClassName == nil || *ds.Spec.Template.Spec.RuntimeClassName != runtimeClass {
+			t.Fatalf("%s runtimeClassName = %#v, want %q", ds.Name, ds.Spec.Template.Spec.RuntimeClassName, runtimeClass)
+		}
+		assertContainerVolumeMount(t, container.VolumeMounts, netdsvc.ConfigVolumeName, netdsvc.ConfigPath)
+		assertContainerVolumeMount(t, container.VolumeMounts, "bpf-fs", "/sys/fs/bpf")
+		assertContainerVolumeMount(t, container.VolumeMounts, "modules", "/lib/modules")
+		assertContainerVolumeMount(t, container.VolumeMounts, "internal-jwt-private-key", "/secrets/internal_jwt_private.key")
+		assertContainerVolumeMount(t, container.VolumeMounts, "mitm-ca", "/tls")
+		assertContainerVolumeMount(t, container.VolumeMounts, netdsvc.ActiveLockVolumeName, netdsvc.ActiveLockMountDirectory)
+		if got := container.Resources.Requests[corev1.ResourceCPU]; got.Cmp(resource.MustParse("350m")) != 0 {
+			t.Fatalf("%s embedded cpu request = %s, want 350m", ds.Name, got.String())
+		}
+		if got := container.Resources.Requests[corev1.ResourceMemory]; got.Cmp(resource.MustParse("384Mi")) != 0 {
+			t.Fatalf("%s embedded memory request = %s, want 384Mi", ds.Name, got.String())
+		}
+	}
+	if !hasContainerPort(primary.Spec.Template.Spec.Containers[0].Ports, "metrics", 9091) {
+		t.Fatalf("slot A netd metrics discovery port = %#v", primary.Spec.Template.Spec.Containers[0].Ports)
+	}
+	if len(standby.Spec.Template.Spec.Containers[0].Ports) != 0 {
+		t.Fatalf("slot B duplicates the node-local metrics target: %#v", standby.Spec.Template.Spec.Containers[0].Ports)
+	}
+	legacy := &appsv1.DaemonSet{}
+	err := client.Get(context.Background(), types.NamespacedName{Name: infra.Name + "-netd", Namespace: infra.Namespace}, legacy)
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("ctld reconcile created a standalone netd daemonset: %v", err)
+	}
+}
+
 func TestCtldTerminationGraceCoversStaticShutdownBudget(t *testing.T) {
 	const (
 		shutdownBudgetSeconds = int64(5 + 7 + 25)
@@ -85,6 +136,93 @@ func TestCtldTerminationGraceCoversStaticShutdownBudget(t *testing.T) {
 	)
 
 	assert.LessOrEqual(t, shutdownBudgetSeconds+shutdownMarginSeconds, ctldTerminationGraceSeconds)
+}
+
+func TestDaemonSetReadyRequiresObservedFullyReadyRollout(t *testing.T) {
+	ds := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{Generation: 2},
+		Status: appsv1.DaemonSetStatus{
+			ObservedGeneration:     2,
+			DesiredNumberScheduled: 3,
+			UpdatedNumberScheduled: 3,
+			NumberReady:            3,
+		},
+	}
+	if !daemonSetReady(ds) {
+		t.Fatal("fully rolled daemonset is not ready")
+	}
+	ds.Status.NumberReady = 2
+	ds.Status.NumberUnavailable = 1
+	if daemonSetReady(ds) {
+		t.Fatal("partially ready daemonset is ready")
+	}
+}
+
+func TestReadyRejectsLiveSurgePredecessor(t *testing.T) {
+	ctx := context.Background()
+	infra := newCtldTestInfra()
+	primary, client := reconcileCtldResources(t, infra, &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "kube-dns", Namespace: "kube-system"},
+		Spec:       corev1.ServiceSpec{ClusterIP: "10.96.0.10"},
+	})
+	sets := []*appsv1.DaemonSet{primary, &appsv1.DaemonSet{}}
+	if err := client.Get(ctx, types.NamespacedName{Name: infra.Name + "-ctld-b", Namespace: infra.Namespace}, sets[1]); err != nil {
+		t.Fatalf("get slot B daemonset: %v", err)
+	}
+	for _, ds := range sets {
+		ds.Status.ObservedGeneration = ds.Generation
+		ds.Status.DesiredNumberScheduled = 1
+		ds.Status.CurrentNumberScheduled = 1
+		ds.Status.UpdatedNumberScheduled = 1
+		ds.Status.NumberReady = 1
+		ds.Status.NumberAvailable = 1
+		if err := client.Status().Update(ctx, ds); err != nil {
+			t.Fatalf("update %s status: %v", ds.Name, err)
+		}
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        ds.Name + "-current",
+				Namespace:   ds.Namespace,
+				Labels:      common.CloneStringMap(ds.Spec.Template.Labels),
+				Annotations: common.CloneStringMap(ds.Spec.Template.Annotations),
+			},
+			Spec: *ds.Spec.Template.Spec.DeepCopy(),
+			Status: corev1.PodStatus{
+				Phase:             corev1.PodRunning,
+				Conditions:        []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+				ContainerStatuses: []corev1.ContainerStatus{{Name: "ctld", State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}}},
+			},
+		}
+		pod.Spec.NodeName = "node-a"
+		if err := client.Create(ctx, pod); err != nil {
+			t.Fatalf("create current %s pod: %v", ds.Name, err)
+		}
+	}
+	reconciler := NewReconciler(common.NewResourceManager(client, nil, nil, common.LocalDevConfig{}))
+	if ready, err := reconciler.Ready(ctx, infra); err != nil || !ready {
+		t.Fatalf("Ready() before predecessor = %v, %v; want true, nil", ready, err)
+	}
+	predecessor := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      primary.Name + "-previous",
+			Namespace: primary.Namespace,
+			Labels:    common.CloneStringMap(primary.Spec.Template.Labels),
+		},
+		Spec: corev1.PodSpec{
+			NodeName:   "node-a",
+			Containers: []corev1.Container{{Name: "ctld", Image: "sandbox0ai/infra:previous"}},
+		},
+		Status: corev1.PodStatus{
+			Phase:             corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{{Name: "ctld", State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}}},
+		},
+	}
+	if err := client.Create(ctx, predecessor); err != nil {
+		t.Fatalf("create live predecessor: %v", err)
+	}
+	if ready, err := reconciler.Ready(ctx, infra); err != nil || ready {
+		t.Fatalf("Ready() with live predecessor = %v, %v; want false, nil", ready, err)
+	}
 }
 
 func TestReconcileRemovesLegacySingleDaemonSet(t *testing.T) {
@@ -170,11 +308,17 @@ func reconcileCtldResources(t *testing.T, infra *infrav1alpha1.Sandbox0Infra, ex
 	if ds.Spec.Template.Spec.Containers[0].SecurityContext == nil || ds.Spec.Template.Spec.Containers[0].SecurityContext.Privileged == nil || !*ds.Spec.Template.Spec.Containers[0].SecurityContext.Privileged {
 		t.Fatal("expected ctld container to run privileged")
 	}
-	if got := ds.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]; got.Cmp(resource.MustParse(ctldCPURequest)) != 0 {
-		t.Fatalf("expected ctld cpu request %s, got %s", ctldCPURequest, got.String())
+	wantCPU := resource.MustParse(ctldCPURequest)
+	wantMemory := resource.MustParse(ctldMemoryRequest)
+	if infraplan.Compile(infra).Netd.Enabled {
+		wantCPU.Add(resource.MustParse(embeddedNetdCPURequest))
+		wantMemory.Add(resource.MustParse(embeddedNetdMemoryRequest))
 	}
-	if got := ds.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceMemory]; got.Cmp(resource.MustParse(ctldMemoryRequest)) != 0 {
-		t.Fatalf("expected ctld memory request %s, got %s", ctldMemoryRequest, got.String())
+	if got := ds.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]; got.Cmp(wantCPU) != 0 {
+		t.Fatalf("expected ctld cpu request %s, got %s", wantCPU.String(), got.String())
+	}
+	if got := ds.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceMemory]; got.Cmp(wantMemory) != 0 {
+		t.Fatalf("expected ctld memory request %s, got %s", wantMemory.String(), got.String())
 	}
 	if len(ds.Spec.Template.Spec.Containers) != 1 {
 		t.Fatalf("expected slot A to run only ctld, got %#v", ds.Spec.Template.Spec.Containers)
@@ -186,7 +330,7 @@ func reconcileCtldResources(t *testing.T, infra *infrav1alpha1.Sandbox0Infra, ex
 		t.Fatalf("unexpected ctld HA slot labels: slot A=%q slot B=%q", ds.Spec.Template.Labels[dataplane.CtldHASlotLabel], standby.Spec.Template.Labels[dataplane.CtldHASlotLabel])
 	}
 	for _, workload := range []*appsv1.DaemonSet{ds, standby} {
-		if len(workload.Spec.Template.Spec.Containers[0].Ports) != 0 {
+		if !infrav1alpha1.IsNetdEnabled(infra) && len(workload.Spec.Template.Spec.Containers[0].Ports) != 0 {
 			t.Fatalf("ctld hostNetwork pod %s reserves node ports: %#v", workload.Name, workload.Spec.Template.Spec.Containers[0].Ports)
 		}
 	}
@@ -423,6 +567,29 @@ func assertContainerVolumeMount(t *testing.T, mounts []corev1.VolumeMount, name,
 		}
 	}
 	t.Fatalf("expected volume mount %q, got %#v", name, mounts)
+}
+
+func assertContainerEnv(t *testing.T, env []corev1.EnvVar, name, value string) {
+	t.Helper()
+	for i := range env {
+		if env[i].Name != name {
+			continue
+		}
+		if env[i].Value != value {
+			t.Fatalf("environment %q = %q, want %q", name, env[i].Value, value)
+		}
+		return
+	}
+	t.Fatalf("expected environment %q, got %#v", name, env)
+}
+
+func hasContainerPort(ports []corev1.ContainerPort, name string, port int32) bool {
+	for i := range ports {
+		if ports[i].Name == name && ports[i].ContainerPort == port {
+			return true
+		}
+	}
+	return false
 }
 
 func assertNoContainerVolumeMount(t *testing.T, mounts []corev1.VolumeMount, name string) {

--- a/infra-operator/internal/controller/services/manager/manager.go
+++ b/infra-operator/internal/controller/services/manager/manager.go
@@ -26,12 +26,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	apiconfig "github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
+	infrav1alpha1 "github.com/sandbox0-ai/sandbox0/infra-operator/api/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/pkg/common"
 	credentialstoresvc "github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/credentialstore"
 	meteringsvc "github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/metering"
 	netdservice "github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/netd"
 	redissvc "github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/redis"
 	sandboxobssvc "github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/sandboxobservability"
+	storageproxysvc "github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/storageproxy"
 	infraplan "github.com/sandbox0-ai/sandbox0/infra-operator/internal/plan"
 	pkginternalauth "github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 )
@@ -40,7 +42,13 @@ type Reconciler struct {
 	Resources *common.ResourceManager
 }
 
-const registryCredentialsPath = "/etc/sandbox0/registry/.dockerconfigjson"
+const (
+	registryCredentialsPath     = "/etc/sandbox0/registry/.dockerconfigjson"
+	embeddedStorageConfigPath   = "/config/storage-proxy.yaml"
+	managerConfigHashAnnotation = "infra.sandbox0.ai/manager-config-hash"
+	storageConfigHashAnnotation = "infra.sandbox0.ai/storage-config-hash"
+	embeddedStorageFallbackPort = int32(18081)
+)
 
 func NewReconciler(resources *common.ResourceManager) *Reconciler {
 	return &Reconciler{Resources: resources}
@@ -53,15 +61,25 @@ func (r *Reconciler) Reconcile(ctx context.Context, imageRepo, imageTag string, 
 		return fmt.Errorf("compiled plan is required")
 	}
 
-	// Skip if not enabled
-	if !compiledPlan.Manager.Enabled {
-		logger.Info("Manager is disabled, skipping")
+	// Storage-only installations still need the manager Deployment as the
+	// process host, without enabling the logical manager feature elsewhere in
+	// the compiled plan.
+	if !compiledPlan.Components.EnableManagerHost {
+		logger.Info("Manager host is disabled, skipping")
 		return nil
 	}
 
 	scope := compiledPlan.Scope
 	deploymentName := fmt.Sprintf("%s-manager", scope.Name)
 	replicas := compiledPlan.Manager.Replicas
+	var storageResources *corev1.ResourceRequirements
+	if compiledPlan.Components.EnableStorageProxy && scope.Owner() != nil && scope.Owner().Spec.Services != nil && scope.Owner().Spec.Services.StorageProxy != nil {
+		storageService := scope.Owner().Spec.Services.StorageProxy
+		if replicas < 1 {
+			return fmt.Errorf("embedded storage-proxy requires at least one manager host replica")
+		}
+		storageResources = storageService.Resources
+	}
 
 	labels := common.GetServiceLabels(scope.Name, "manager")
 	keySecretName, privateKeyKey, publicKeyKey := compiledPlan.DataPlaneKeyRefs()
@@ -70,17 +88,51 @@ func (r *Reconciler) Reconcile(ctx context.Context, imageRepo, imageTag string, 
 	if err != nil {
 		return err
 	}
+	httpPort := int32(config.HTTPPort)
+	metricsPort := int32(config.MetricsPort)
+	webhookPort := int32(config.WebhookPort)
 	configRef, err := r.Resources.ReconcileHashedServiceConfigMapWithScope(ctx, scope, deploymentName, labels, config)
 	if err != nil {
 		return err
 	}
 	podAnnotations := configRef.PodAnnotations()
-
-	httpPort := int32(config.HTTPPort)
-	metricsPort := int32(config.MetricsPort)
-	webhookPort := int32(config.WebhookPort)
+	var storageConfig *apiconfig.StorageProxyConfig
+	var storageConfigRef common.ServiceConfigRef
+	var storageServiceHTTPPort int32
+	if compiledPlan.Components.EnableStorageProxy {
+		if scope.Owner() == nil {
+			return fmt.Errorf("infra owner is required to embed storage-proxy")
+		}
+		storageConfig, err = storageproxysvc.BuildRuntimeConfig(ctx, r.Resources, scope.Owner())
+		if err != nil {
+			return fmt.Errorf("build embedded storage-proxy config: %w", err)
+		}
+		storageServiceHTTPPort = int32(storageConfig.HTTPPort)
+		storageConfig.HTTPPort, err = resolveEmbeddedStorageHTTPPort(storageServiceHTTPPort, httpPort, metricsPort, webhookPort)
+		if err != nil {
+			return err
+		}
+		storageConfigRef, err = r.Resources.ReconcileHashedServiceConfigMapWithScope(
+			ctx,
+			scope,
+			deploymentName+"-storage",
+			common.GetServiceLabels(scope.Name, "storage-proxy"),
+			storageConfig,
+		)
+		if err != nil {
+			return err
+		}
+		podAnnotations = map[string]string{
+			common.PodTemplateConfigHashAnnotation: configRef.Hash + "." + storageConfigRef.Hash,
+			managerConfigHashAnnotation:            configRef.Hash,
+			storageConfigHashAnnotation:            storageConfigRef.Hash,
+		}
+	}
 
 	resources := compiledPlan.Manager.Resources
+	if storageConfig != nil {
+		resources = mergeEmbeddedServiceResources(resources, storageResources)
+	}
 	serviceConfig := compiledPlan.Manager.ServiceConfig
 
 	volumeMounts := []corev1.VolumeMount{
@@ -142,6 +194,20 @@ func (r *Reconciler) Reconcile(ctx context.Context, imageRepo, imageTag string, 
 			},
 		},
 	}
+	if storageConfig != nil {
+		storageMounts, storageVolumes, err := storageproxysvc.BuildRuntimeVolumes(scope, storageConfig, storageproxysvc.RuntimeVolumeOptions{
+			ConfigMapName:    storageConfigRef.ConfigMapName,
+			ConfigVolumeName: "storage-config",
+			ConfigMountPath:  embeddedStorageConfigPath,
+			CacheVolumeName:  "storage-cache",
+			LogVolumeName:    "storage-logs",
+		})
+		if err != nil {
+			return err
+		}
+		volumeMounts = append(volumeMounts, storageMounts...)
+		volumes = append(volumes, storageVolumes...)
+	}
 
 	registrySecretName, registrySecretKey := compiledPlan.ManagerRegistryCredentialsSource()
 	if registrySecretName != "" && registrySecretKey != "" {
@@ -171,37 +237,32 @@ func (r *Reconciler) Reconcile(ctx context.Context, imageRepo, imageTag string, 
 	volumeMounts = append(volumeMounts, credentialStoreMounts...)
 	volumes = append(volumes, credentialStoreVolumes...)
 
+	containerPorts := []corev1.ContainerPort{
+		{Name: "http", ContainerPort: httpPort},
+		{Name: "metrics", ContainerPort: metricsPort},
+		{Name: "webhook", ContainerPort: webhookPort},
+	}
+	envVars := []corev1.EnvVar{
+		{Name: "SERVICE", Value: "manager"},
+		{Name: "CONFIG_PATH", Value: "/config/config.yaml"},
+	}
+	if storageConfig != nil {
+		storageHTTPPort := int32(storageConfig.HTTPPort)
+		containerPorts = append(containerPorts,
+			corev1.ContainerPort{Name: "storage-http", ContainerPort: storageHTTPPort},
+		)
+		envVars = append(envVars, corev1.EnvVar{Name: "STORAGE_PROXY_CONFIG_PATH", Value: embeddedStorageConfigPath})
+	}
+
 	// Create deployment
 	if err := r.Resources.ReconcileDeploymentWithScope(ctx, scope, deploymentName, labels, replicas, common.ServiceDefinition{
 		Name:               "manager",
 		Port:               httpPort,
 		TargetPort:         httpPort,
 		ServiceAccountName: fmt.Sprintf("%s-manager", scope.Name),
-		Ports: []corev1.ContainerPort{
-			{
-				Name:          "http",
-				ContainerPort: httpPort,
-			},
-			{
-				Name:          "metrics",
-				ContainerPort: metricsPort,
-			},
-			{
-				Name:          "webhook",
-				ContainerPort: webhookPort,
-			},
-		},
-		Image: fmt.Sprintf("%s:%s", imageRepo, imageTag),
-		EnvVars: common.AppendObservabilityEnvVars([]corev1.EnvVar{
-			{
-				Name:  "SERVICE",
-				Value: "manager",
-			},
-			{
-				Name:  "CONFIG_PATH",
-				Value: "/config/config.yaml",
-			},
-		}, scope.Owner(), common.ObservabilityEnvConfig{
+		Ports:              containerPorts,
+		Image:              fmt.Sprintf("%s:%s", imageRepo, imageTag),
+		EnvVars: common.AppendObservabilityEnvVars(envVars, scope.Owner(), common.ObservabilityEnvConfig{
 			ServiceName: "manager",
 			RegionID:    compiledPlan.Manager.RegionID,
 			ClusterID:   compiledPlan.Manager.DefaultClusterID,
@@ -249,6 +310,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, imageRepo, imageTag string, 
 	if err := r.Resources.EnsureDeploymentReadyWithScope(ctx, scope, deploymentName, replicas); err != nil {
 		return err
 	}
+	if storageConfig != nil {
+		if err := r.Resources.EnsureDeploymentRolloutComplete(ctx, scope, deploymentName, replicas); err != nil {
+			return err
+		}
+		if err := r.reconcileStorageProxyAliasService(ctx, compiledPlan, storageConfig, storageServiceHTTPPort, metricsPort, labels); err != nil {
+			return err
+		}
+	}
 
 	// Reconcile runtime resources first so dependent services do not observe a
 	// new manager port before the manager service/config have converged.
@@ -265,6 +334,88 @@ func (r *Reconciler) Reconcile(ctx context.Context, imageRepo, imageTag string, 
 
 	logger.Info("Manager reconciled successfully")
 	return nil
+}
+
+func resolveEmbeddedStorageHTTPPort(requested int32, reserved ...int32) (int, error) {
+	if requested < 1 || requested > 65535 {
+		return 0, fmt.Errorf("embedded storage-proxy HTTP port %d is outside 1-65535", requested)
+	}
+	available := func(candidate int32) bool {
+		for _, port := range reserved {
+			if candidate == port {
+				return false
+			}
+		}
+		return true
+	}
+	if available(requested) {
+		return int(requested), nil
+	}
+	for candidate := embeddedStorageFallbackPort; candidate <= 65535; candidate++ {
+		if available(candidate) {
+			return int(candidate), nil
+		}
+	}
+	for candidate := int32(1024); candidate < embeddedStorageFallbackPort; candidate++ {
+		if available(candidate) {
+			return int(candidate), nil
+		}
+	}
+	return 0, fmt.Errorf("no available HTTP port for embedded storage-proxy")
+}
+
+func mergeEmbeddedServiceResources(managerResources, storageResources *corev1.ResourceRequirements) *corev1.ResourceRequirements {
+	managerResolved := common.ResolveDeploymentResources(managerResources)
+	storageResolved := common.ResolveDeploymentResources(storageResources)
+	return &corev1.ResourceRequirements{
+		Requests: addResourceLists(managerResolved.Requests, storageResolved.Requests),
+		Limits:   addResourceLists(managerResolved.Limits, storageResolved.Limits),
+		Claims:   append(append([]corev1.ResourceClaim(nil), managerResolved.Claims...), storageResolved.Claims...),
+	}
+}
+
+func addResourceLists(left, right corev1.ResourceList) corev1.ResourceList {
+	out := make(corev1.ResourceList, len(left)+len(right))
+	for name, quantity := range left {
+		out[name] = quantity.DeepCopy()
+	}
+	for name, quantity := range right {
+		current := out[name]
+		current.Add(quantity)
+		out[name] = current
+	}
+	return out
+}
+
+func (r *Reconciler) reconcileStorageProxyAliasService(ctx context.Context, compiledPlan *infraplan.InfraPlan, storageConfig *apiconfig.StorageProxyConfig, storageServiceHTTPPort, managerMetricsPort int32, managerLabels map[string]string) error {
+	infra := compiledPlan.Scope.Owner()
+	if infra == nil || storageConfig == nil {
+		return fmt.Errorf("infra and storage-proxy config are required")
+	}
+	var serviceConfig *infrav1alpha1.ServiceNetworkConfig
+	if infra.Spec.Services != nil && infra.Spec.Services.StorageProxy != nil {
+		serviceConfig = infra.Spec.Services.StorageProxy.Service
+	}
+	serviceType := common.ResolveServiceType(serviceConfig)
+	httpServicePort := common.ResolveServicePort(serviceConfig, storageServiceHTTPPort)
+	serviceAnnotations := common.ResolveServiceAnnotations(serviceConfig)
+	aliasName := fmt.Sprintf("%s-storage-proxy", compiledPlan.Scope.Name)
+	storageLabels := common.GetServiceLabels(compiledPlan.Scope.Name, "storage-proxy")
+	return r.Resources.ReconcileServicePortsWithScopeAndSpecMutator(
+		ctx,
+		compiledPlan.Scope,
+		aliasName,
+		storageLabels,
+		serviceType,
+		serviceAnnotations,
+		[]corev1.ServicePort{
+			common.BuildServicePort("http", httpServicePort, int32(storageConfig.HTTPPort), serviceType),
+			common.BuildServicePort("metrics", int32(storageConfig.MetricsPort), managerMetricsPort, serviceType),
+		},
+		func(spec *corev1.ServiceSpec) {
+			spec.Selector = common.CloneStringMap(managerLabels)
+		},
+	)
 }
 
 func (r *Reconciler) buildConfig(ctx context.Context, imageRepo, imageTag string, compiledPlan *infraplan.InfraPlan) (*apiconfig.ManagerConfig, error) {

--- a/infra-operator/internal/controller/services/manager/manager_test.go
+++ b/infra-operator/internal/controller/services/manager/manager_test.go
@@ -8,13 +8,16 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"math/big"
+	"strings"
 	"testing"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	infrav1alpha1 "github.com/sandbox0-ai/sandbox0/infra-operator/api/v1alpha1"
@@ -387,6 +390,205 @@ func TestBuildConfigInjectsRootFSObjectStorage(t *testing.T) {
 	}
 }
 
+func TestReconcileStorageOnlyUsesManagerHostAndSwitchesAliasAfterFullRollout(t *testing.T) {
+	reconciler := newManagerTestReconciler(t)
+	ctx := context.Background()
+	infra := &infrav1alpha1.Sandbox0Infra{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "sandbox0-system", UID: types.UID("demo-uid")},
+		Spec: infrav1alpha1.Sandbox0InfraSpec{
+			Database: &infrav1alpha1.DatabaseConfig{
+				Type: infrav1alpha1.DatabaseTypeBuiltin,
+				Builtin: &infrav1alpha1.BuiltinDatabaseConfig{
+					Enabled: true, Port: 5432, Username: "sandbox0", Database: "sandbox0", SSLMode: "disable",
+				},
+			},
+			Storage: &infrav1alpha1.StorageConfig{
+				Type: infrav1alpha1.StorageTypeBuiltin,
+				Builtin: &infrav1alpha1.BuiltinStorageConfig{
+					Enabled: true, Bucket: "sandbox0", Region: "us-east-1",
+				},
+			},
+			Services: &infrav1alpha1.ServicesConfig{
+				Manager: &infrav1alpha1.ManagerServiceConfig{
+					WorkloadServiceConfig: infrav1alpha1.WorkloadServiceConfig{
+						EnabledServiceConfig: infrav1alpha1.EnabledServiceConfig{Enabled: false},
+						Replicas:             9,
+					},
+					Config: &infrav1alpha1.ManagerConfig{HTTPPort: 8080, MetricsPort: 9090},
+				},
+				StorageProxy: &infrav1alpha1.StorageProxyServiceConfig{
+					WorkloadServiceConfig: infrav1alpha1.WorkloadServiceConfig{
+						EnabledServiceConfig: infrav1alpha1.EnabledServiceConfig{Enabled: true},
+						Replicas:             1,
+					},
+					ServiceExposureConfig: infrav1alpha1.ServiceExposureConfig{Service: &infrav1alpha1.ServiceNetworkConfig{
+						Port:        18083,
+						Annotations: map[string]string{"service.test/alias": "storage"},
+					}},
+					Config: &infrav1alpha1.StorageProxyConfig{
+						// A standalone storage-proxy could share manager's port because it
+						// ran in a different Pod. Embedding must remap only the target.
+						HTTPPort: 8080, MetricsPort: 19090,
+						CacheSizeLimit: "512Mi", LogSizeLimit: "64Mi", ObjectEncryptionEnabled: true,
+					},
+				},
+			},
+		},
+	}
+	for _, object := range []ctrlclient.Object{
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "demo-sandbox0-rustfs-credentials", Namespace: infra.Namespace},
+			Data: map[string][]byte{
+				"endpoint": []byte("http://demo-rustfs.sandbox0-system.svc:9000"), "RUSTFS_ACCESS_KEY": []byte("access-key"), "RUSTFS_SECRET_KEY": []byte("secret-key"),
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: "demo-storage-proxy", Namespace: infra.Namespace},
+			Spec: corev1.ServiceSpec{
+				Selector: common.GetServiceLabels(infra.Name, "storage-proxy"),
+				Ports:    []corev1.ServicePort{common.BuildServicePort("http", 18083, 8080, corev1.ServiceTypeClusterIP)},
+			},
+		},
+	} {
+		if err := reconciler.Resources.Client.Create(ctx, object); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	compiled := infraplan.Compile(infra)
+	err := reconciler.Reconcile(ctx, "sandbox0ai/infra", "test", compiled)
+	if err == nil || !strings.Contains(err.Error(), "not ready") {
+		t.Fatalf("first Reconcile() error = %v, want rollout not ready", err)
+	}
+
+	deployment := &appsv1.Deployment{}
+	if err := reconciler.Resources.Client.Get(ctx, types.NamespacedName{Name: "demo-manager", Namespace: infra.Namespace}, deployment); err != nil {
+		t.Fatal(err)
+	}
+	if deployment.Spec.Replicas == nil || *deployment.Spec.Replicas != 1 {
+		t.Fatalf("storage-only manager host replicas = %v, want 1", deployment.Spec.Replicas)
+	}
+	container := deployment.Spec.Template.Spec.Containers[0]
+	assertUniqueManagerPodNames(t, container.Ports, container.VolumeMounts, deployment.Spec.Template.Spec.Volumes)
+	assertManagerEnv(t, container.Env, "STORAGE_PROXY_CONFIG_PATH", embeddedStorageConfigPath)
+	assertManagerPort(t, container.Ports, "storage-http", 18081)
+	assertManagerVolumeMount(t, container.VolumeMounts, "storage-config", embeddedStorageConfigPath)
+	assertManagerVolumeMount(t, container.VolumeMounts, "storage-cache", "/var/lib/storage-proxy/cache")
+	assertManagerVolumeMount(t, container.VolumeMounts, "storage-logs", "/var/log/storage-proxy")
+	assertManagerVolumeMount(t, container.VolumeMounts, "object-encryption-key", common.ObjectEncryptionMountDir)
+	if deployment.Spec.Template.Annotations[managerConfigHashAnnotation] == "" || deployment.Spec.Template.Annotations[storageConfigHashAnnotation] == "" {
+		t.Fatalf("pod annotations do not contain both config hashes: %#v", deployment.Spec.Template.Annotations)
+	}
+	assertManagerEmptyDirSizeLimit(t, deployment.Spec.Template.Spec.Volumes, "storage-cache", "512Mi")
+	assertManagerEmptyDirSizeLimit(t, deployment.Spec.Template.Spec.Volumes, "storage-logs", "64Mi")
+	if got := container.Resources.Requests.Cpu().String(); got != "200m" {
+		t.Fatalf("combined CPU request = %q, want 200m", got)
+	}
+	if got := container.Resources.Requests.Memory().String(); got != "512Mi" {
+		t.Fatalf("combined memory request = %q, want 512Mi", got)
+	}
+	if got := container.Resources.Limits.Cpu().String(); got != "1" {
+		t.Fatalf("combined CPU limit = %q, want 1", got)
+	}
+	if got := container.Resources.Limits.Memory().String(); got != "1Gi" {
+		t.Fatalf("combined memory limit = %q, want 1Gi", got)
+	}
+
+	alias := &corev1.Service{}
+	if err := reconciler.Resources.Client.Get(ctx, types.NamespacedName{Name: "demo-storage-proxy", Namespace: infra.Namespace}, alias); err != nil {
+		t.Fatal(err)
+	}
+	if got := alias.Spec.Selector["app.kubernetes.io/component"]; got != "storage-proxy" {
+		t.Fatalf("alias switched before rollout: component selector = %q", got)
+	}
+	initialPodConfigHash := deployment.Spec.Template.Annotations[common.PodTemplateConfigHashAnnotation]
+	infra.Spec.Services.StorageProxy.Config.CacheSizeLimit = "768Mi"
+	compiled = infraplan.Compile(infra)
+	if err := reconciler.Reconcile(ctx, "sandbox0ai/infra", "test", compiled); err == nil || !strings.Contains(err.Error(), "not ready") {
+		t.Fatalf("storage config update Reconcile() error = %v, want rollout not ready", err)
+	}
+	if err := reconciler.Resources.Client.Get(ctx, types.NamespacedName{Name: "demo-manager", Namespace: infra.Namespace}, deployment); err != nil {
+		t.Fatal(err)
+	}
+	if got := deployment.Spec.Template.Annotations[common.PodTemplateConfigHashAnnotation]; got == initialPodConfigHash {
+		t.Fatalf("storage-only config change did not update manager pod hash %q", got)
+	}
+
+	deployment.Status.ObservedGeneration = deployment.Generation
+	deployment.Status.Replicas = 2
+	deployment.Status.UpdatedReplicas = 1
+	deployment.Status.ReadyReplicas = 1
+	deployment.Status.AvailableReplicas = 1
+	if err := reconciler.Resources.Client.Status().Update(ctx, deployment); err != nil {
+		t.Fatal(err)
+	}
+	if err := reconciler.Reconcile(ctx, "sandbox0ai/infra", "test", compiled); err == nil || !strings.Contains(err.Error(), "rollout pending") {
+		t.Fatalf("surge Reconcile() error = %v, want rollout pending", err)
+	}
+	if err := reconciler.Resources.Client.Get(ctx, types.NamespacedName{Name: "demo-storage-proxy", Namespace: infra.Namespace}, alias); err != nil {
+		t.Fatal(err)
+	}
+	if got := alias.Spec.Selector["app.kubernetes.io/component"]; got != "storage-proxy" {
+		t.Fatalf("alias switched while old pod remained: component selector = %q", got)
+	}
+
+	if err := reconciler.Resources.Client.Get(ctx, types.NamespacedName{Name: "demo-manager", Namespace: infra.Namespace}, deployment); err != nil {
+		t.Fatal(err)
+	}
+	deployment.Status.ObservedGeneration = deployment.Generation
+	deployment.Status.Replicas = 1
+	deployment.Status.UpdatedReplicas = 1
+	deployment.Status.ReadyReplicas = 1
+	deployment.Status.AvailableReplicas = 1
+	deployment.Status.UnavailableReplicas = 0
+	if err := reconciler.Resources.Client.Status().Update(ctx, deployment); err != nil {
+		t.Fatal(err)
+	}
+	if err := reconciler.Reconcile(ctx, "sandbox0ai/infra", "test", compiled); err != nil {
+		t.Fatalf("complete Reconcile() error = %v", err)
+	}
+	if err := reconciler.Resources.Client.Get(ctx, types.NamespacedName{Name: "demo-storage-proxy", Namespace: infra.Namespace}, alias); err != nil {
+		t.Fatal(err)
+	}
+	if got := alias.Spec.Selector["app.kubernetes.io/component"]; got != "manager" {
+		t.Fatalf("alias component selector = %q, want manager", got)
+	}
+	if got := alias.Annotations["service.test/alias"]; got != "storage" {
+		t.Fatalf("alias annotation = %q, want storage", got)
+	}
+	assertManagerServicePort(t, alias, "http", 18083, 18081)
+	assertManagerServicePort(t, alias, "metrics", 19090, 9090)
+}
+
+func TestResolveEmbeddedStorageHTTPPortRemapsManagerListeners(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		port int32
+	}{
+		{name: "http", port: 8080},
+		{name: "metrics", port: 9090},
+		{name: "webhook", port: 9443},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveEmbeddedStorageHTTPPort(tc.port, 8080, 9090, 9443)
+			if err != nil {
+				t.Fatalf("resolve port %d: %v", tc.port, err)
+			}
+			if got != int(embeddedStorageFallbackPort) {
+				t.Fatalf("resolve port %d = %d, want %d", tc.port, got, embeddedStorageFallbackPort)
+			}
+		})
+	}
+	got, err := resolveEmbeddedStorageHTTPPort(8081, 8080, 9090, 9443)
+	if err != nil || got != 8081 {
+		t.Fatalf("non-conflicting storage port = %d, %v; want 8081, nil", got, err)
+	}
+	got, err = resolveEmbeddedStorageHTTPPort(8080, 8080, 9090, 9443, embeddedStorageFallbackPort)
+	if err != nil || got != int(embeddedStorageFallbackPort+1) {
+		t.Fatalf("occupied fallback port = %d, %v; want %d, nil", got, err, embeddedStorageFallbackPort+1)
+	}
+}
+
 func newManagerTestReconciler(t *testing.T) *Reconciler {
 	t.Helper()
 
@@ -396,6 +598,9 @@ func newManagerTestReconciler(t *testing.T) *Reconciler {
 	}
 	if err := infrav1alpha1.AddToScheme(scheme); err != nil {
 		t.Fatalf("add infra scheme: %v", err)
+	}
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add apps scheme: %v", err)
 	}
 
 	client := fake.NewClientBuilder().
@@ -414,6 +619,104 @@ func newManagerTestReconciler(t *testing.T) *Reconciler {
 		}).
 		Build()
 	return NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
+}
+
+func assertManagerEnv(t *testing.T, env []corev1.EnvVar, name, want string) {
+	t.Helper()
+	for _, item := range env {
+		if item.Name == name {
+			if item.Value != want {
+				t.Fatalf("env %s = %q, want %q", name, item.Value, want)
+			}
+			return
+		}
+	}
+	t.Fatalf("env %s not found", name)
+}
+
+func assertManagerPort(t *testing.T, ports []corev1.ContainerPort, name string, want int32) {
+	t.Helper()
+	seenNames := make(map[string]struct{}, len(ports))
+	for _, port := range ports {
+		if _, exists := seenNames[port.Name]; exists {
+			t.Fatalf("duplicate container port name %q", port.Name)
+		}
+		seenNames[port.Name] = struct{}{}
+		if port.Name == name {
+			if port.ContainerPort != want {
+				t.Fatalf("container port %s = %d, want %d", name, port.ContainerPort, want)
+			}
+			return
+		}
+	}
+	t.Fatalf("container port %s not found", name)
+}
+
+func assertManagerVolumeMount(t *testing.T, mounts []corev1.VolumeMount, name, wantPath string) {
+	t.Helper()
+	for _, mount := range mounts {
+		if mount.Name == name {
+			if mount.MountPath != wantPath {
+				t.Fatalf("mount %s path = %q, want %q", name, mount.MountPath, wantPath)
+			}
+			return
+		}
+	}
+	t.Fatalf("mount %s not found", name)
+}
+
+func assertManagerEmptyDirSizeLimit(t *testing.T, volumes []corev1.Volume, name, want string) {
+	t.Helper()
+	for _, volume := range volumes {
+		if volume.Name == name {
+			if volume.EmptyDir == nil || volume.EmptyDir.SizeLimit == nil {
+				t.Fatalf("volume %s has no emptyDir size limit", name)
+			}
+			if got := volume.EmptyDir.SizeLimit.String(); got != want {
+				t.Fatalf("volume %s size limit = %q, want %q", name, got, want)
+			}
+			return
+		}
+	}
+	t.Fatalf("volume %s not found", name)
+}
+
+func assertManagerServicePort(t *testing.T, service *corev1.Service, name string, wantPort, wantTarget int32) {
+	t.Helper()
+	for _, port := range service.Spec.Ports {
+		if port.Name == name {
+			if port.Port != wantPort || int32(port.TargetPort.IntValue()) != wantTarget {
+				t.Fatalf("service port %s = %d->%d, want %d->%d", name, port.Port, port.TargetPort.IntValue(), wantPort, wantTarget)
+			}
+			return
+		}
+	}
+	t.Fatalf("service port %s not found", name)
+}
+
+func assertUniqueManagerPodNames(t *testing.T, ports []corev1.ContainerPort, mounts []corev1.VolumeMount, volumes []corev1.Volume) {
+	t.Helper()
+	portNames := make(map[string]struct{}, len(ports))
+	for _, port := range ports {
+		if _, exists := portNames[port.Name]; exists {
+			t.Fatalf("duplicate container port name %q", port.Name)
+		}
+		portNames[port.Name] = struct{}{}
+	}
+	mountNames := make(map[string]struct{}, len(mounts))
+	for _, mount := range mounts {
+		if _, exists := mountNames[mount.Name]; exists {
+			t.Fatalf("duplicate volume mount name %q", mount.Name)
+		}
+		mountNames[mount.Name] = struct{}{}
+	}
+	volumeNames := make(map[string]struct{}, len(volumes))
+	for _, volume := range volumes {
+		if _, exists := volumeNames[volume.Name]; exists {
+			t.Fatalf("duplicate volume name %q", volume.Name)
+		}
+		volumeNames[volume.Name] = struct{}{}
+	}
 }
 
 func newValidMITMCASecret(t *testing.T, namespace, name string) *corev1.Secret {

--- a/infra-operator/internal/controller/services/netd/netd.go
+++ b/infra-operator/internal/controller/services/netd/netd.go
@@ -4,35 +4,46 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"path/filepath"
 
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	apiconfig "github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/pkg/common"
-	meteringsvc "github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/metering"
-	redissvc "github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/redis"
-	sandboxobssvc "github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/sandboxobservability"
 	infraplan "github.com/sandbox0-ai/sandbox0/infra-operator/internal/plan"
-	pkginternalauth "github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+	"github.com/sandbox0-ai/sandbox0/netd/pkg/activeguard"
 )
 
 type Reconciler struct {
 	Resources *common.ResourceManager
 }
 
+const (
+	LegacyHandoffStateAnnotation = "infra.sandbox0.ai/netd-handoff-state"
+	LegacyHandoffStateActive     = "active"
+	LegacyHandoffStateStandby    = "standby"
+	LegacyStandbyInitialDelay    = "30s"
+	LegacyStandbyMaxHold         = "2m"
+)
+
 func NewReconciler(resources *common.ResourceManager) *Reconciler {
 	return &Reconciler{Resources: resources}
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, imageRepo, imageTag string, compiledPlan *infraplan.InfraPlan) error {
+	return r.PrepareLegacyHandoff(ctx, imageRepo, imageTag, compiledPlan)
+}
+
+// PrepareLegacyHandoff upgrades an existing standalone netd DaemonSet to use
+// the shared active lock. It intentionally does not create a DaemonSet on new
+// installations, where ctld is the only netd workload.
+func (r *Reconciler) PrepareLegacyHandoff(ctx context.Context, imageRepo, imageTag string, compiledPlan *infraplan.InfraPlan) error {
 	logger := log.FromContext(ctx)
 	if compiledPlan == nil {
 		return fmt.Errorf("compiled plan is required")
@@ -48,6 +59,69 @@ func (r *Reconciler) Reconcile(ctx context.Context, imageRepo, imageTag string, 
 
 	scope := compiledPlan.Scope
 	name := fmt.Sprintf("%s-netd", scope.Name)
+	existing := &appsv1.DaemonSet{}
+	if err := r.Resources.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: scope.Namespace}, existing); err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.Info("legacy netd daemonset is absent; embedded ctld owns netd")
+			return nil
+		}
+		return err
+	}
+	// Once the legacy workload has entered standby, subsequent reconciles must
+	// not turn it active again while ctld is still proving embedded netd ready.
+	if legacyHandoffState(existing) == LegacyHandoffStateStandby {
+		return nil
+	}
+	return r.applyLegacyDaemonSet(ctx, imageRepo, imageTag, compiledPlan, false)
+}
+
+// PrepareLegacyStandby keeps the guarded legacy DaemonSet as a delayed lock
+// contender while embedded netd starts. If embedded initialization fails, the
+// standby acquires the lock and restores the previous node-local runtime.
+func (r *Reconciler) PrepareLegacyStandby(ctx context.Context, compiledPlan *infraplan.InfraPlan) error {
+	if compiledPlan == nil {
+		return fmt.Errorf("compiled plan is required")
+	}
+	scope := compiledPlan.Scope
+	name := fmt.Sprintf("%s-netd", scope.Name)
+	existing := &appsv1.DaemonSet{}
+	if err := r.Resources.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: scope.Namespace}, existing); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	// Preserve the exact image, config, mounts, and security context that passed
+	// the active handoff probes. Only lock acquisition and probes differ in the
+	// standby template, so the fallback runtime was already exercised end to end.
+	desired := existing.DeepCopy()
+	desired.Annotations = common.CloneStringMap(desired.Annotations)
+	desired.Annotations[LegacyHandoffStateAnnotation] = LegacyHandoffStateStandby
+	desired.Spec.Template.Annotations = common.CloneStringMap(desired.Spec.Template.Annotations)
+	desired.Spec.Template.Annotations[LegacyHandoffStateAnnotation] = LegacyHandoffStateStandby
+	if len(desired.Spec.Template.Spec.Containers) == 0 {
+		return fmt.Errorf("legacy netd daemonset has no container")
+	}
+	container := &desired.Spec.Template.Spec.Containers[0]
+	container.LivenessProbe = nil
+	container.ReadinessProbe = nil
+	container.Env = setContainerEnv(container.Env, activeguard.EnvInitialDelay, LegacyStandbyInitialDelay)
+	container.Env = setContainerEnv(container.Env, activeguard.EnvMaxHold, LegacyStandbyMaxHold)
+	maxSurge := intstr.FromInt(1)
+	maxUnavailable := intstr.FromInt(0)
+	desired.Spec.UpdateStrategy = appsv1.DaemonSetUpdateStrategy{
+		Type: appsv1.RollingUpdateDaemonSetStrategyType,
+		RollingUpdate: &appsv1.RollingUpdateDaemonSet{
+			MaxSurge:       &maxSurge,
+			MaxUnavailable: &maxUnavailable,
+		},
+	}
+	return r.Resources.ApplyDaemonSetWithScope(ctx, scope, desired)
+}
+
+func (r *Reconciler) applyLegacyDaemonSet(ctx context.Context, imageRepo, imageTag string, compiledPlan *infraplan.InfraPlan, standby bool) error {
+	scope := compiledPlan.Scope
+	name := fmt.Sprintf("%s-netd", scope.Name)
 	labels := common.GetServiceLabels(scope.Name, "netd")
 	image := fmt.Sprintf("%s:%s", imageRepo, imageTag)
 	pullPolicy := corev1.PullIfNotPresent
@@ -55,279 +129,267 @@ func (r *Reconciler) Reconcile(ctx context.Context, imageRepo, imageTag string, 
 		pullPolicy = *r.Resources.ImagePullPolicy
 	}
 
-	config := &apiconfig.NetdConfig{}
-	if compiledPlan.Netd.Config != nil {
-		config = compiledPlan.Netd.Config.DeepCopy()
-	}
-	runtimeClassName := compiledPlan.Netd.RuntimeClassName
-	nodeSelector := compiledPlan.Netd.NodeSelector
-	tolerations := compiledPlan.Netd.Tolerations
-	if config.NodeName == "" {
-		config.NodeName = "${NODE_NAME}"
-	}
-	if config.MetricsPort == 0 {
-		config.MetricsPort = 9091
-	}
-	if config.HealthPort == 0 {
-		config.HealthPort = 8081
-	}
-	if config.ClusterDNSCIDR == "" {
-		cidr, err := resolveClusterDNSCIDR(ctx, r.Resources.Client, logger)
-		if err != nil {
-			return err
-		}
-		config.ClusterDNSCIDR = cidr
-	}
-	if err := redissvc.ApplyNetdRedisConfig(ctx, r.Resources.Client, compiledPlan.Scope.Owner(), config); err != nil {
-		return err
-	}
-	if dsn, err := compiledPlan.DatabaseDSN(ctx, r.Resources.Client); err == nil {
-		config.DatabaseURL = dsn
-	}
-	config.RegionID = compiledPlan.Netd.RegionID
-	config.ClusterID = compiledPlan.Netd.ClusterID
-	if err := meteringsvc.ApplyNetdConfig(ctx, r.Resources.Client, compiledPlan.Scope.Owner(), config); err != nil {
-		return err
-	}
-	if config.EgressAuthResolverURL == "" {
-		config.EgressAuthResolverURL = compiledPlan.Netd.EgressAuthResolverURL
-	}
-	if err := sandboxobssvc.ApplyNetdConfig(ctx, r.Resources.Client, compiledPlan.Scope.Owner(), compiledPlan.Services.ClusterGateway.URL, config); err != nil {
-		return err
-	}
-	mitmCASecretName, err := r.resolveMITMCASecretName(ctx, compiledPlan, labels)
+	assets, err := r.BuildRuntimeAssets(ctx, compiledPlan)
 	if err != nil {
 		return err
 	}
-	keySecretName, privateKeyKey, _ := compiledPlan.DataPlaneKeyRefs()
-	auditKeySecretName, auditPrivateKeyKey, _ := compiledPlan.AuditNetdKeyRefs()
-	if mitmCASecretName != "" {
-		if config.MITMCACertPath == "" {
-			config.MITMCACertPath = "/tls/ca.crt"
-		}
-		if config.MITMCAKeyPath == "" {
-			config.MITMCAKeyPath = "/tls/ca.key"
-		}
-	}
-	configRef, err := r.Resources.ReconcileHashedServiceConfigMapWithScope(ctx, scope, name, labels, config)
-	if err != nil {
-		return err
-	}
-	podAnnotations := configRef.PodAnnotations()
 
-	volumes := []corev1.Volume{
+	desired := buildLegacyDaemonSet(legacyDaemonSetConfig{
+		Name:       name,
+		Namespace:  scope.Namespace,
+		Labels:     labels,
+		Image:      image,
+		PullPolicy: pullPolicy,
+		Assets:     assets,
+		Plan:       compiledPlan,
+		Standby:    standby,
+	})
+	return r.Resources.ApplyDaemonSetWithScope(ctx, scope, desired)
+}
+
+type legacyDaemonSetConfig struct {
+	Name       string
+	Namespace  string
+	Labels     map[string]string
+	Image      string
+	PullPolicy corev1.PullPolicy
+	Assets     *RuntimeAssets
+	Plan       *infraplan.InfraPlan
+	Standby    bool
+}
+
+func buildLegacyDaemonSet(cfg legacyDaemonSetConfig) *appsv1.DaemonSet {
+	assets := cfg.Assets
+	state := LegacyHandoffStateActive
+	if cfg.Standby {
+		state = LegacyHandoffStateStandby
+	}
+	podAnnotations := common.EnsurePodTemplateAnnotations(assets.PodAnnotations)
+	podAnnotations[LegacyHandoffStateAnnotation] = state
+	env := []corev1.EnvVar{
+		{Name: "SERVICE", Value: "netd"},
+		{Name: "CONFIG_PATH", Value: ConfigPath},
+		{Name: activeguard.EnvPath, Value: assets.ActiveLockPath},
 		{
-			Name: "config",
-			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
-					LocalObjectReference: corev1.LocalObjectReference{Name: configRef.ConfigMapName},
-				},
-			},
-		},
-		{
-			Name: "bpf-fs",
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: "/sys/fs/bpf",
-					Type: func() *corev1.HostPathType { t := corev1.HostPathDirectoryOrCreate; return &t }(),
-				},
-			},
-		},
-		{
-			Name: "modules",
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: "/lib/modules",
-					Type: func() *corev1.HostPathType { t := corev1.HostPathDirectoryOrCreate; return &t }(),
-				},
-			},
-		},
-		{
-			Name: "run",
-			VolumeSource: corev1.VolumeSource{
-				EmptyDir: &corev1.EmptyDirVolumeSource{},
-			},
-		},
-		{
-			Name: "internal-jwt-private-key",
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: keySecretName,
-					Items: []corev1.KeyToPath{{
-						Key:  privateKeyKey,
-						Path: "internal_jwt_private.key",
-					}},
-				},
+			Name: "NODE_NAME",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
 			},
 		},
 	}
-	if config.SandboxObservabilityIngestURL != "" {
-		volumes = append(volumes,
-			corev1.Volume{
-				Name: "audit-spool",
-				VolumeSource: corev1.VolumeSource{
-					HostPath: &corev1.HostPathVolumeSource{
-						Path: filepath.Join("/var/lib/sandbox0/netd", scope.Namespace, scope.Name),
-						Type: func() *corev1.HostPathType { t := corev1.HostPathDirectoryOrCreate; return &t }(),
-					},
-				},
-			},
-			corev1.Volume{
-				Name: "audit-jwt-private-key",
-				VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{
-					SecretName: auditKeySecretName,
-					Items:      []corev1.KeyToPath{{Key: auditPrivateKeyKey, Path: "audit_jwt_private.key"}},
-				}},
-			},
+	if cfg.Standby {
+		env = append(env,
+			corev1.EnvVar{Name: activeguard.EnvInitialDelay, Value: LegacyStandbyInitialDelay},
+			corev1.EnvVar{Name: activeguard.EnvMaxHold, Value: LegacyStandbyMaxHold},
 		)
 	}
-	if mitmCASecretName != "" {
-		volumes = append(volumes, corev1.Volume{
-			Name: "mitm-ca",
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: mitmCASecretName,
-				},
+	container := corev1.Container{
+		Name:            "netd",
+		Image:           cfg.Image,
+		ImagePullPolicy: cfg.PullPolicy,
+		Env: common.AppendObservabilityEnvVars(env, cfg.Plan.Scope.Owner(), common.ObservabilityEnvConfig{
+			ServiceName: "netd",
+			RegionID:    cfg.Plan.Netd.RegionID,
+			ClusterID:   cfg.Plan.Netd.ClusterID,
+		}),
+		Ports: assets.Ports,
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: common.BoolPtr(false),
+			Privileged:               common.BoolPtr(false),
+			Capabilities: &corev1.Capabilities{
+				Add: []corev1.Capability{"NET_ADMIN", "NET_RAW"},
 			},
-		})
+		},
+		VolumeMounts: assets.VolumeMounts,
 	}
-
-	volumeMounts := []corev1.VolumeMount{
-		{
-			Name:      "config",
-			MountPath: "/config/config.yaml",
-			SubPath:   "config.yaml",
-			ReadOnly:  true,
-		},
-		{
-			Name:      "bpf-fs",
-			MountPath: "/sys/fs/bpf",
-		},
-		{
-			Name:      "modules",
-			MountPath: "/lib/modules",
-			ReadOnly:  true,
-		},
-		{
-			Name:      "run",
-			MountPath: "/run",
-		},
-		{
-			Name:      "internal-jwt-private-key",
-			MountPath: pkginternalauth.DefaultInternalJWTPrivateKeyPath,
-			SubPath:   "internal_jwt_private.key",
-			ReadOnly:  true,
-		},
+	if !cfg.Standby {
+		container.LivenessProbe = &corev1.Probe{
+			ProbeHandler:        corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/healthz", Port: intstr.FromString("health")}},
+			InitialDelaySeconds: 10,
+			PeriodSeconds:       10,
+		}
+		container.ReadinessProbe = &corev1.Probe{
+			ProbeHandler:        corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/readyz", Port: intstr.FromString("health")}},
+			InitialDelaySeconds: 5,
+			PeriodSeconds:       5,
+		}
 	}
-	if config.SandboxObservabilityIngestURL != "" {
-		volumeMounts = append(volumeMounts,
-			corev1.VolumeMount{
-				Name:      "audit-spool",
-				MountPath: "/var/lib/sandbox0/netd",
-			},
-			corev1.VolumeMount{
-				Name:      "audit-jwt-private-key",
-				MountPath: pkginternalauth.DefaultAuditJWTPrivateKeyPath,
-				SubPath:   "audit_jwt_private.key",
-				ReadOnly:  true,
-			},
-		)
-	}
-	if mitmCASecretName != "" {
-		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      "mitm-ca",
-			MountPath: "/tls",
-			ReadOnly:  true,
-		})
-	}
-
-	desired := &appsv1.DaemonSet{
+	return &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: scope.Namespace,
+			Name:      cfg.Name,
+			Namespace: cfg.Namespace,
+			Annotations: map[string]string{
+				LegacyHandoffStateAnnotation: state,
+			},
 		},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{
-				MatchLabels: labels,
+				MatchLabels: cfg.Labels,
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      labels,
-					Annotations: common.EnsurePodTemplateAnnotations(podAnnotations),
+					Labels:      cfg.Labels,
+					Annotations: podAnnotations,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: name,
-					RuntimeClassName:   runtimeClassName,
+					ServiceAccountName: cfg.Name,
+					RuntimeClassName:   assets.RuntimeClassName,
 					HostNetwork:        true,
 					DNSPolicy:          corev1.DNSClusterFirstWithHostNet,
-					NodeSelector:       nodeSelector,
-					Tolerations:        tolerations,
-					Containers: []corev1.Container{
-						{
-							Name:            "netd",
-							Image:           image,
-							ImagePullPolicy: pullPolicy,
-							Env: common.AppendObservabilityEnvVars([]corev1.EnvVar{
-								{
-									Name:  "SERVICE",
-									Value: "netd",
-								},
-								{
-									Name:  "CONFIG_PATH",
-									Value: "/config/config.yaml",
-								},
-								{
-									Name: "NODE_NAME",
-									ValueFrom: &corev1.EnvVarSource{
-										FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
-									},
-								},
-							}, scope.Owner(), common.ObservabilityEnvConfig{
-								ServiceName: "netd",
-								RegionID:    compiledPlan.Netd.RegionID,
-								ClusterID:   compiledPlan.Netd.ClusterID,
-							}),
-							Ports: []corev1.ContainerPort{
-								{Name: "metrics", ContainerPort: int32(config.MetricsPort)},
-								{Name: "health", ContainerPort: int32(config.HealthPort)},
-							},
-							SecurityContext: &corev1.SecurityContext{
-								AllowPrivilegeEscalation: common.BoolPtr(false),
-								Privileged:               common.BoolPtr(false),
-								Capabilities: &corev1.Capabilities{
-									Add: []corev1.Capability{"NET_ADMIN", "NET_RAW"},
-								},
-							},
-							LivenessProbe: &corev1.Probe{
-								ProbeHandler: corev1.ProbeHandler{
-									HTTPGet: &corev1.HTTPGetAction{
-										Path: "/healthz",
-										Port: intstr.FromString("health"),
-									},
-								},
-								InitialDelaySeconds: 10,
-								PeriodSeconds:       10,
-							},
-							ReadinessProbe: &corev1.Probe{
-								ProbeHandler: corev1.ProbeHandler{
-									HTTPGet: &corev1.HTTPGetAction{
-										Path: "/readyz",
-										Port: intstr.FromString("health"),
-									},
-								},
-								InitialDelaySeconds: 5,
-								PeriodSeconds:       5,
-							},
-							VolumeMounts: volumeMounts,
-						},
-					},
-					Volumes: volumes,
+					NodeSelector:       assets.NodeSelector,
+					Tolerations:        assets.Tolerations,
+					Containers:         []corev1.Container{container},
+					Volumes:            assets.Volumes,
 				},
 			},
 		},
 	}
+}
 
-	return r.Resources.ApplyDaemonSetWithScope(ctx, scope, desired)
+// LegacyHandoffReady reports whether an existing guarded legacy DaemonSet has
+// completed its rollout. An absent DaemonSet is ready on fresh installations.
+func (r *Reconciler) LegacyHandoffReady(ctx context.Context, compiledPlan *infraplan.InfraPlan) (bool, error) {
+	if compiledPlan == nil {
+		return false, fmt.Errorf("compiled plan is required")
+	}
+	ds := &appsv1.DaemonSet{}
+	key := types.NamespacedName{Name: fmt.Sprintf("%s-netd", compiledPlan.Scope.Name), Namespace: compiledPlan.Scope.Namespace}
+	if err := r.Resources.Client.Get(ctx, key, ds); err != nil {
+		if apierrors.IsNotFound(err) {
+			return r.legacyPodsGone(ctx, compiledPlan)
+		}
+		return false, err
+	}
+	if ds.Status.DesiredNumberScheduled == 0 {
+		return r.legacyPodsGone(ctx, compiledPlan)
+	}
+	if legacyHandoffState(ds) == LegacyHandoffStateStandby {
+		return legacyDaemonSetRolloutReady(ds) && legacyDaemonSetIsStandby(ds) &&
+			legacyDaemonSetUsesActiveLock(ds, ScopedActiveLockPath(compiledPlan.Scope.Namespace, compiledPlan.Scope.Name)), nil
+	}
+	ready := legacyDaemonSetRolloutReady(ds) &&
+		legacyDaemonSetUsesActiveLock(ds, ScopedActiveLockPath(compiledPlan.Scope.Namespace, compiledPlan.Scope.Name))
+	return ready, nil
+}
+
+// LegacyStandbyReady reports whether the delayed-lock standby template has a
+// ready successor on every desired node. With maxSurge enabled, the previous
+// active pods may still be running until their successors become ready.
+func (r *Reconciler) LegacyStandbyReady(ctx context.Context, compiledPlan *infraplan.InfraPlan) (bool, error) {
+	if compiledPlan == nil {
+		return false, fmt.Errorf("compiled plan is required")
+	}
+	ds := &appsv1.DaemonSet{}
+	key := types.NamespacedName{Name: fmt.Sprintf("%s-netd", compiledPlan.Scope.Name), Namespace: compiledPlan.Scope.Namespace}
+	if err := r.Resources.Client.Get(ctx, key, ds); err != nil {
+		if apierrors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
+	}
+	if ds.Status.DesiredNumberScheduled == 0 {
+		return r.legacyPodsGone(ctx, compiledPlan)
+	}
+	return legacyDaemonSetRolloutReady(ds) && legacyDaemonSetIsStandby(ds) &&
+		legacyDaemonSetUsesActiveLock(ds, ScopedActiveLockPath(compiledPlan.Scope.Namespace, compiledPlan.Scope.Name)), nil
+}
+
+func legacyDaemonSetRolloutReady(ds *appsv1.DaemonSet) bool {
+	return ds != nil && ds.Status.ObservedGeneration >= ds.Generation &&
+		ds.Status.DesiredNumberScheduled > 0 &&
+		ds.Status.UpdatedNumberScheduled == ds.Status.DesiredNumberScheduled &&
+		ds.Status.NumberReady == ds.Status.DesiredNumberScheduled &&
+		ds.Status.NumberAvailable == ds.Status.DesiredNumberScheduled &&
+		ds.Status.NumberUnavailable == 0
+}
+
+func legacyHandoffState(ds *appsv1.DaemonSet) string {
+	if ds == nil {
+		return ""
+	}
+	return ds.Annotations[LegacyHandoffStateAnnotation]
+}
+
+func legacyDaemonSetIsStandby(ds *appsv1.DaemonSet) bool {
+	if ds == nil || legacyHandoffState(ds) != LegacyHandoffStateStandby || len(ds.Spec.Template.Spec.Containers) == 0 {
+		return false
+	}
+	container := ds.Spec.Template.Spec.Containers[0]
+	if container.LivenessProbe != nil || container.ReadinessProbe != nil {
+		return false
+	}
+	return containerEnvEquals(container.Env, activeguard.EnvInitialDelay, LegacyStandbyInitialDelay) &&
+		containerEnvEquals(container.Env, activeguard.EnvMaxHold, LegacyStandbyMaxHold)
+}
+
+func containerEnvEquals(envs []corev1.EnvVar, name, value string) bool {
+	for i := range envs {
+		if envs[i].Name == name {
+			return envs[i].Value == value
+		}
+	}
+	return false
+}
+
+func setContainerEnv(envs []corev1.EnvVar, name, value string) []corev1.EnvVar {
+	for i := range envs {
+		if envs[i].Name == name {
+			envs[i].Value = value
+			envs[i].ValueFrom = nil
+			return envs
+		}
+	}
+	return append(envs, corev1.EnvVar{Name: name, Value: value})
+}
+
+func legacyDaemonSetUsesActiveLock(ds *appsv1.DaemonSet, wantPath string) bool {
+	if ds == nil || len(ds.Spec.Template.Spec.Containers) == 0 {
+		return false
+	}
+	for i := range ds.Spec.Template.Spec.Containers[0].Env {
+		env := ds.Spec.Template.Spec.Containers[0].Env[i]
+		if env.Name == activeguard.EnvPath {
+			return env.Value == wantPath
+		}
+	}
+	return false
+}
+
+// CleanupLegacyDaemonSet removes the standalone netd workload after embedded
+// ctld netd is ready to acquire the shared active lock.
+func (r *Reconciler) CleanupLegacyDaemonSet(ctx context.Context, compiledPlan *infraplan.InfraPlan) error {
+	if compiledPlan == nil {
+		return fmt.Errorf("compiled plan is required")
+	}
+	ds := &appsv1.DaemonSet{}
+	key := types.NamespacedName{Name: fmt.Sprintf("%s-netd", compiledPlan.Scope.Name), Namespace: compiledPlan.Scope.Namespace}
+	if err := r.Resources.Client.Get(ctx, key, ds); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+	} else if ds.DeletionTimestamp == nil {
+		propagation := metav1.DeletePropagationForeground
+		if err := r.Resources.Client.Delete(ctx, ds, &ctrlclient.DeleteOptions{PropagationPolicy: &propagation}); err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+	}
+	gone, err := r.legacyPodsGone(ctx, compiledPlan)
+	if err != nil {
+		return err
+	}
+	if !gone {
+		return fmt.Errorf("legacy netd pods are still terminating")
+	}
+	return nil
+}
+
+func (r *Reconciler) legacyPodsGone(ctx context.Context, compiledPlan *infraplan.InfraPlan) (bool, error) {
+	pods := &corev1.PodList{}
+	labels := common.GetServiceLabels(compiledPlan.Scope.Name, "netd")
+	if err := r.Resources.Client.List(ctx, pods, ctrlclient.InNamespace(compiledPlan.Scope.Namespace), ctrlclient.MatchingLabels(labels)); err != nil {
+		return false, err
+	}
+	return len(pods.Items) == 0, nil
 }
 
 func (r *Reconciler) resolveMITMCASecretName(ctx context.Context, compiledPlan *infraplan.InfraPlan, labels map[string]string) (string, error) {

--- a/infra-operator/internal/controller/services/netd/netd.go
+++ b/infra-operator/internal/controller/services/netd/netd.go
@@ -72,7 +72,7 @@ func (r *Reconciler) PrepareLegacyHandoff(ctx context.Context, imageRepo, imageT
 	if legacyHandoffState(existing) == LegacyHandoffStateStandby {
 		return nil
 	}
-	return r.applyLegacyDaemonSet(ctx, imageRepo, imageTag, compiledPlan, false)
+	return r.applyLegacyDaemonSet(ctx, imageRepo, imageTag, compiledPlan)
 }
 
 // PrepareLegacyStandby keeps the guarded legacy DaemonSet as a delayed lock
@@ -92,8 +92,9 @@ func (r *Reconciler) PrepareLegacyStandby(ctx context.Context, compiledPlan *inf
 		return err
 	}
 	// Preserve the exact image, config, mounts, and security context that passed
-	// the active handoff probes. Only lock acquisition and probes differ in the
-	// standby template, so the fallback runtime was already exercised end to end.
+	// the active handoff probes. Only lock acquisition behavior, probes, and
+	// declarative port reservations differ in the standby template, so the
+	// fallback runtime was already exercised end to end.
 	desired := existing.DeepCopy()
 	desired.Annotations = common.CloneStringMap(desired.Annotations)
 	desired.Annotations[LegacyHandoffStateAnnotation] = LegacyHandoffStateStandby
@@ -105,6 +106,10 @@ func (r *Reconciler) PrepareLegacyStandby(ctx context.Context, compiledPlan *inf
 	container := &desired.Spec.Template.Spec.Containers[0]
 	container.LivenessProbe = nil
 	container.ReadinessProbe = nil
+	// A standby does not bind listeners until after its delay and active-lock
+	// acquisition. Omitting host-network container ports lets it surge beside
+	// the still-active predecessor without creating HostPort conflicts.
+	container.Ports = nil
 	container.Env = setContainerEnv(container.Env, activeguard.EnvInitialDelay, LegacyStandbyInitialDelay)
 	container.Env = setContainerEnv(container.Env, activeguard.EnvMaxHold, LegacyStandbyMaxHold)
 	maxSurge := intstr.FromInt(1)
@@ -119,7 +124,7 @@ func (r *Reconciler) PrepareLegacyStandby(ctx context.Context, compiledPlan *inf
 	return r.Resources.ApplyDaemonSetWithScope(ctx, scope, desired)
 }
 
-func (r *Reconciler) applyLegacyDaemonSet(ctx context.Context, imageRepo, imageTag string, compiledPlan *infraplan.InfraPlan, standby bool) error {
+func (r *Reconciler) applyLegacyDaemonSet(ctx context.Context, imageRepo, imageTag string, compiledPlan *infraplan.InfraPlan) error {
 	scope := compiledPlan.Scope
 	name := fmt.Sprintf("%s-netd", scope.Name)
 	labels := common.GetServiceLabels(scope.Name, "netd")
@@ -142,7 +147,6 @@ func (r *Reconciler) applyLegacyDaemonSet(ctx context.Context, imageRepo, imageT
 		PullPolicy: pullPolicy,
 		Assets:     assets,
 		Plan:       compiledPlan,
-		Standby:    standby,
 	})
 	return r.Resources.ApplyDaemonSetWithScope(ctx, scope, desired)
 }
@@ -155,17 +159,12 @@ type legacyDaemonSetConfig struct {
 	PullPolicy corev1.PullPolicy
 	Assets     *RuntimeAssets
 	Plan       *infraplan.InfraPlan
-	Standby    bool
 }
 
 func buildLegacyDaemonSet(cfg legacyDaemonSetConfig) *appsv1.DaemonSet {
 	assets := cfg.Assets
-	state := LegacyHandoffStateActive
-	if cfg.Standby {
-		state = LegacyHandoffStateStandby
-	}
 	podAnnotations := common.EnsurePodTemplateAnnotations(assets.PodAnnotations)
-	podAnnotations[LegacyHandoffStateAnnotation] = state
+	podAnnotations[LegacyHandoffStateAnnotation] = LegacyHandoffStateActive
 	env := []corev1.EnvVar{
 		{Name: "SERVICE", Value: "netd"},
 		{Name: "CONFIG_PATH", Value: ConfigPath},
@@ -176,12 +175,6 @@ func buildLegacyDaemonSet(cfg legacyDaemonSetConfig) *appsv1.DaemonSet {
 				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
 			},
 		},
-	}
-	if cfg.Standby {
-		env = append(env,
-			corev1.EnvVar{Name: activeguard.EnvInitialDelay, Value: LegacyStandbyInitialDelay},
-			corev1.EnvVar{Name: activeguard.EnvMaxHold, Value: LegacyStandbyMaxHold},
-		)
 	}
 	container := corev1.Container{
 		Name:            "netd",
@@ -202,24 +195,22 @@ func buildLegacyDaemonSet(cfg legacyDaemonSetConfig) *appsv1.DaemonSet {
 		},
 		VolumeMounts: assets.VolumeMounts,
 	}
-	if !cfg.Standby {
-		container.LivenessProbe = &corev1.Probe{
-			ProbeHandler:        corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/healthz", Port: intstr.FromString("health")}},
-			InitialDelaySeconds: 10,
-			PeriodSeconds:       10,
-		}
-		container.ReadinessProbe = &corev1.Probe{
-			ProbeHandler:        corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/readyz", Port: intstr.FromString("health")}},
-			InitialDelaySeconds: 5,
-			PeriodSeconds:       5,
-		}
+	container.LivenessProbe = &corev1.Probe{
+		ProbeHandler:        corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/healthz", Port: intstr.FromString("health")}},
+		InitialDelaySeconds: 10,
+		PeriodSeconds:       10,
+	}
+	container.ReadinessProbe = &corev1.Probe{
+		ProbeHandler:        corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/readyz", Port: intstr.FromString("health")}},
+		InitialDelaySeconds: 5,
+		PeriodSeconds:       5,
 	}
 	return &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cfg.Name,
 			Namespace: cfg.Namespace,
 			Annotations: map[string]string{
-				LegacyHandoffStateAnnotation: state,
+				LegacyHandoffStateAnnotation: LegacyHandoffStateActive,
 			},
 		},
 		Spec: appsv1.DaemonSetSpec{
@@ -315,6 +306,9 @@ func legacyDaemonSetIsStandby(ds *appsv1.DaemonSet) bool {
 		return false
 	}
 	container := ds.Spec.Template.Spec.Containers[0]
+	if len(container.Ports) != 0 {
+		return false
+	}
 	if container.LivenessProbe != nil || container.ReadinessProbe != nil {
 		return false
 	}

--- a/infra-operator/internal/controller/services/netd/netd_test.go
+++ b/infra-operator/internal/controller/services/netd/netd_test.go
@@ -288,6 +288,9 @@ func TestPrepareLegacyStandbyPreservesFallbackUntilReady(t *testing.T) {
 	if got := netdConfigMapName(t, ds); got != activeConfigMap {
 		t.Fatalf("standby config = %q, want validated active config %q", got, activeConfigMap)
 	}
+	if len(ds.Spec.Template.Spec.Containers[0].Ports) != 0 {
+		t.Fatalf("standby reserves active host-network ports: %#v", ds.Spec.Template.Spec.Containers[0].Ports)
+	}
 	rolling := ds.Spec.UpdateStrategy.RollingUpdate
 	if ds.Spec.UpdateStrategy.Type != appsv1.RollingUpdateDaemonSetStrategyType || rolling == nil ||
 		rolling.MaxSurge == nil || rolling.MaxSurge.IntValue() != 1 ||

--- a/infra-operator/internal/controller/services/netd/netd_test.go
+++ b/infra-operator/internal/controller/services/netd/netd_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -231,8 +232,157 @@ func reconcileNetdDaemonSet(t *testing.T, infra *infrav1alpha1.Sandbox0Infra) *a
 	}, ds); err != nil {
 		t.Fatalf("expected daemonset to be created: %v", err)
 	}
+	wantLockPath := filepath.Join(ActiveLockMountDirectory, infra.Namespace, infra.Name, "netd.lock")
+	if got := containerEnvValue(ds.Spec.Template.Spec.Containers[0], ActiveLockEnv); got != wantLockPath {
+		t.Fatalf("active lock path = %q, want %q", got, wantLockPath)
+	}
+	if !netdHasVolume(ds, ActiveLockVolumeName) || !netdHasMount(ds, ActiveLockVolumeName) {
+		t.Fatalf("legacy handoff lock volume is missing: volumes=%#v mounts=%#v", ds.Spec.Template.Spec.Volumes, ds.Spec.Template.Spec.Containers[0].VolumeMounts)
+	}
+	if got := ds.Annotations[LegacyHandoffStateAnnotation]; got != LegacyHandoffStateActive {
+		t.Fatalf("legacy handoff state = %q, want %q", got, LegacyHandoffStateActive)
+	}
+	container := ds.Spec.Template.Spec.Containers[0]
+	if container.LivenessProbe == nil || container.ReadinessProbe == nil ||
+		container.LivenessProbe.HTTPGet == nil || container.ReadinessProbe.HTTPGet == nil ||
+		container.LivenessProbe.HTTPGet.Port.StrVal != "health" || container.ReadinessProbe.HTTPGet.Port.StrVal != "health" {
+		t.Fatalf("legacy active probes do not target the named health port: %#v %#v", container.LivenessProbe, container.ReadinessProbe)
+	}
 
 	return ds
+}
+
+func TestPrepareLegacyStandbyPreservesFallbackUntilReady(t *testing.T) {
+	ctx := context.Background()
+	infra := newNetdTestInfra()
+	client, scheme := newNetdTestClient(t, infra.DeepCopy())
+	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
+	compiled := infraplan.Compile(infra)
+	if err := reconciler.PrepareLegacyHandoff(ctx, "ghcr.io/sandbox0-ai/sandbox0", "v2", compiled); err != nil {
+		t.Fatalf("PrepareLegacyHandoff() error = %v", err)
+	}
+	key := types.NamespacedName{Name: infra.Name + "-netd", Namespace: infra.Namespace}
+	active := &appsv1.DaemonSet{}
+	if err := client.Get(ctx, key, active); err != nil {
+		t.Fatalf("get validated active daemonset: %v", err)
+	}
+	activeImage := active.Spec.Template.Spec.Containers[0].Image
+	activeConfigMap := netdConfigMapName(t, active)
+	if err := reconciler.PrepareLegacyStandby(ctx, compiled); err != nil {
+		t.Fatalf("PrepareLegacyStandby() error = %v", err)
+	}
+
+	ds := &appsv1.DaemonSet{}
+	if err := client.Get(ctx, key, ds); err != nil {
+		t.Fatalf("get standby daemonset: %v", err)
+	}
+	if !legacyDaemonSetIsStandby(ds) {
+		t.Fatalf("legacy daemonset is not a delayed-lock standby: %#v", ds.Spec.Template.Spec.Containers[0])
+	}
+	if got := ds.Spec.Template.Annotations[LegacyHandoffStateAnnotation]; got != LegacyHandoffStateStandby {
+		t.Fatalf("standby pod state annotation = %q", got)
+	}
+	if got := ds.Spec.Template.Spec.Containers[0].Image; got != activeImage {
+		t.Fatalf("standby image = %q, want validated active image %q", got, activeImage)
+	}
+	if got := netdConfigMapName(t, ds); got != activeConfigMap {
+		t.Fatalf("standby config = %q, want validated active config %q", got, activeConfigMap)
+	}
+	rolling := ds.Spec.UpdateStrategy.RollingUpdate
+	if ds.Spec.UpdateStrategy.Type != appsv1.RollingUpdateDaemonSetStrategyType || rolling == nil ||
+		rolling.MaxSurge == nil || rolling.MaxSurge.IntValue() != 1 ||
+		rolling.MaxUnavailable == nil || rolling.MaxUnavailable.IntValue() != 0 {
+		t.Fatalf("standby rollout does not start before stopping active: %#v", ds.Spec.UpdateStrategy)
+	}
+	ds.Status.ObservedGeneration = ds.Generation
+	ds.Status.DesiredNumberScheduled = 1
+	ds.Status.CurrentNumberScheduled = 1
+	ds.Status.UpdatedNumberScheduled = 0
+	ds.Status.NumberReady = 1
+	ds.Status.NumberAvailable = 1
+	if err := client.Status().Update(ctx, ds); err != nil {
+		t.Fatalf("update pending standby rollout status: %v", err)
+	}
+	if ready, err := reconciler.LegacyStandbyReady(ctx, compiled); err != nil || ready {
+		t.Fatalf("LegacyStandbyReady() before rollout = %v, %v; want false, nil", ready, err)
+	}
+
+	// The next full reconcile must not reactivate the fallback while embedded
+	// netd is still proving readiness.
+	if err := reconciler.PrepareLegacyHandoff(ctx, "ghcr.io/sandbox0-ai/sandbox0", "v2", compiled); err != nil {
+		t.Fatalf("repeated PrepareLegacyHandoff() error = %v", err)
+	}
+	if err := client.Get(ctx, key, ds); err != nil {
+		t.Fatalf("get standby after repeated handoff: %v", err)
+	}
+	if !legacyDaemonSetIsStandby(ds) {
+		t.Fatal("repeated handoff reactivated the legacy daemonset")
+	}
+
+	ds.Status.ObservedGeneration = ds.Generation
+	ds.Status.DesiredNumberScheduled = 1
+	ds.Status.UpdatedNumberScheduled = 1
+	ds.Status.CurrentNumberScheduled = 1
+	ds.Status.NumberReady = 1
+	ds.Status.NumberAvailable = 1
+	ds.Status.NumberUnavailable = 0
+	if err := client.Status().Update(ctx, ds); err != nil {
+		t.Fatalf("update standby rollout status: %v", err)
+	}
+	if ready, err := reconciler.LegacyStandbyReady(ctx, compiled); err != nil || !ready {
+		t.Fatalf("LegacyStandbyReady() = %v, %v; want true, nil", ready, err)
+	}
+}
+
+func TestReconcileDoesNotCreateLegacyDaemonSetOnFreshInstall(t *testing.T) {
+	infra := newNetdTestInfra()
+	client, scheme := newNetdTestClientWithLegacy(t, false, infra.DeepCopy())
+	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
+	if err := reconciler.Reconcile(context.Background(), "ghcr.io/sandbox0-ai/sandbox0", "latest", infraplan.Compile(infra)); err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	ds := &appsv1.DaemonSet{}
+	err := client.Get(context.Background(), types.NamespacedName{Name: infra.Name + "-netd", Namespace: infra.Namespace}, ds)
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("fresh reconcile created legacy netd: %v", err)
+	}
+}
+
+func TestScopedActiveLockPathIsolatesInfraInstances(t *testing.T) {
+	first := ScopedActiveLockPath("sandbox0-system", "first")
+	second := ScopedActiveLockPath("sandbox0-system", "second")
+	otherNamespace := ScopedActiveLockPath("tenant-system", "first")
+	if first == second || first == otherNamespace || second == otherNamespace {
+		t.Fatalf("active lock paths are not scope-specific: %q %q %q", first, second, otherNamespace)
+	}
+}
+
+func TestCleanupLegacyDaemonSetWaitsForPodsToDisappear(t *testing.T) {
+	infra := newNetdTestInfra()
+	labels := common.GetServiceLabels(infra.Name, "netd")
+	legacyPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "legacy-netd-pod", Namespace: infra.Namespace, Labels: labels}}
+	client, scheme := newNetdTestClient(t, infra.DeepCopy(), legacyPod)
+	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
+	compiled := infraplan.Compile(infra)
+
+	if err := reconciler.CleanupLegacyDaemonSet(context.Background(), compiled); err == nil {
+		t.Fatal("CleanupLegacyDaemonSet() succeeded while a legacy pod remained")
+	}
+	if err := client.Delete(context.Background(), legacyPod); err != nil {
+		t.Fatalf("delete legacy pod: %v", err)
+	}
+	if err := reconciler.CleanupLegacyDaemonSet(context.Background(), compiled); err != nil {
+		t.Fatalf("CleanupLegacyDaemonSet() after pod deletion = %v", err)
+	}
+}
+
+func containerEnvValue(container corev1.Container, name string) string {
+	for i := range container.Env {
+		if container.Env[i].Name == name {
+			return container.Env[i].Value
+		}
+	}
+	return ""
 }
 
 func TestReconcileUsesCompiledPlanForEgressAuthResolverURL(t *testing.T) {
@@ -425,6 +575,10 @@ func getReconciledNetdConfig(t *testing.T, client ctrlclient.Client, infra *infr
 }
 
 func newNetdTestClient(t *testing.T, objects ...ctrlclient.Object) (ctrlclient.Client, *runtime.Scheme) {
+	return newNetdTestClientWithLegacy(t, true, objects...)
+}
+
+func newNetdTestClientWithLegacy(t *testing.T, includeLegacy bool, objects ...ctrlclient.Object) (ctrlclient.Client, *runtime.Scheme) {
 	t.Helper()
 
 	scheme := runtime.NewScheme()
@@ -447,6 +601,23 @@ func newNetdTestClient(t *testing.T, objects ...ctrlclient.Object) (ctrlclient.C
 			ClusterIP: "10.96.0.10",
 		},
 	})
+	if includeLegacy {
+		for _, object := range objects {
+			infra, ok := object.(*infrav1alpha1.Sandbox0Infra)
+			if !ok {
+				continue
+			}
+			labels := common.GetServiceLabels(infra.Name, "netd")
+			objects = append(objects, &appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{Name: infra.Name + "-netd", Namespace: infra.Namespace},
+				Spec: appsv1.DaemonSetSpec{
+					Selector: &metav1.LabelSelector{MatchLabels: labels},
+					Template: corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{Labels: labels}},
+				},
+			})
+			break
+		}
+	}
 
 	client := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -497,7 +668,7 @@ func assertNetdMITMSecretMounted(t *testing.T, client ctrlclient.Client, infra *
 func netdConfigMapName(t *testing.T, ds *appsv1.DaemonSet) string {
 	t.Helper()
 	for _, volume := range ds.Spec.Template.Spec.Volumes {
-		if volume.Name == "config" && volume.ConfigMap != nil {
+		if volume.Name == ConfigVolumeName && volume.ConfigMap != nil {
 			return volume.ConfigMap.Name
 		}
 	}

--- a/infra-operator/internal/controller/services/netd/runtime.go
+++ b/infra-operator/internal/controller/services/netd/runtime.go
@@ -1,0 +1,216 @@
+package netd
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	apiconfig "github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
+	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/pkg/common"
+	meteringsvc "github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/metering"
+	redissvc "github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/redis"
+	sandboxobssvc "github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/sandboxobservability"
+	infraplan "github.com/sandbox0-ai/sandbox0/infra-operator/internal/plan"
+	"github.com/sandbox0-ai/sandbox0/netd/pkg/activeguard"
+	pkginternalauth "github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+)
+
+const (
+	ConfigPath               = "/config/netd.yaml"
+	ConfigVolumeName         = "netd-config"
+	ActiveLockEnv            = activeguard.EnvPath
+	ActiveLockVolumeName     = "netd-active-lock"
+	ActiveLockHostDirectory  = "/var/lib/sandbox0/netd-locks"
+	ActiveLockMountDirectory = "/var/lib/sandbox0/netd-locks"
+	RunVolumeName            = "netd-run"
+	RunMountDirectory        = "/run"
+	ConfigHashAnnotation     = "infra.sandbox0.ai/netd-config-hash"
+)
+
+// RuntimeAssets are the config, host access, secrets, and placement required
+// to run netd either as a legacy DaemonSet or inside the ctld process.
+type RuntimeAssets struct {
+	Config           *apiconfig.NetdConfig
+	ConfigRef        common.ServiceConfigRef
+	PodAnnotations   map[string]string
+	Volumes          []corev1.Volume
+	VolumeMounts     []corev1.VolumeMount
+	Ports            []corev1.ContainerPort
+	RuntimeClassName *string
+	NodeSelector     map[string]string
+	Tolerations      []corev1.Toleration
+	ActiveLockPath   string
+}
+
+// ScopedActiveLockPath isolates netd fencing between Sandbox0Infra instances
+// that share a Kubernetes node.
+func ScopedActiveLockPath(namespace, name string) string {
+	return filepath.Join(ActiveLockMountDirectory, namespace, name, "netd.lock")
+}
+
+// BuildRuntimeAssets materializes the single netd config and workload assets
+// shared by legacy handoff and embedded ctld runtimes.
+func (r *Reconciler) BuildRuntimeAssets(ctx context.Context, compiledPlan *infraplan.InfraPlan) (*RuntimeAssets, error) {
+	if compiledPlan == nil {
+		return nil, fmt.Errorf("compiled plan is required")
+	}
+	if r == nil || r.Resources == nil || r.Resources.Client == nil {
+		return nil, fmt.Errorf("netd resource manager is required")
+	}
+	scope := compiledPlan.Scope
+	name := fmt.Sprintf("%s-netd", scope.Name)
+	labels := common.GetServiceLabels(scope.Name, "netd")
+	config := &apiconfig.NetdConfig{}
+	if compiledPlan.Netd.Config != nil {
+		config = compiledPlan.Netd.Config.DeepCopy()
+	}
+	if config.NodeName == "" {
+		config.NodeName = "${NODE_NAME}"
+	}
+	if config.MetricsPort == 0 {
+		config.MetricsPort = 9091
+	}
+	if config.HealthPort == 0 {
+		config.HealthPort = 8081
+	}
+	if config.ProxyHTTPPort == 0 {
+		config.ProxyHTTPPort = 18080
+	}
+	if config.ProxyHTTPSPort == 0 {
+		config.ProxyHTTPSPort = 18443
+	}
+	if err := config.ValidateListenerPorts(map[int]string{8095: "ctld HTTP port"}); err != nil {
+		return nil, err
+	}
+	if config.ClusterDNSCIDR == "" {
+		cidr, err := resolveClusterDNSCIDR(ctx, r.Resources.Client, log.FromContext(ctx))
+		if err != nil {
+			return nil, err
+		}
+		config.ClusterDNSCIDR = cidr
+	}
+	if err := redissvc.ApplyNetdRedisConfig(ctx, r.Resources.Client, scope.Owner(), config); err != nil {
+		return nil, err
+	}
+	if dsn, err := compiledPlan.DatabaseDSN(ctx, r.Resources.Client); err == nil {
+		config.DatabaseURL = dsn
+	}
+	config.RegionID = compiledPlan.Netd.RegionID
+	config.ClusterID = compiledPlan.Netd.ClusterID
+	if err := meteringsvc.ApplyNetdConfig(ctx, r.Resources.Client, scope.Owner(), config); err != nil {
+		return nil, err
+	}
+	if config.EgressAuthResolverURL == "" {
+		config.EgressAuthResolverURL = compiledPlan.Netd.EgressAuthResolverURL
+	}
+	if err := sandboxobssvc.ApplyNetdConfig(ctx, r.Resources.Client, scope.Owner(), compiledPlan.Services.ClusterGateway.URL, config); err != nil {
+		return nil, err
+	}
+	mitmCASecretName, err := r.resolveMITMCASecretName(ctx, compiledPlan, labels)
+	if err != nil {
+		return nil, err
+	}
+	keySecretName, privateKeyKey, _ := compiledPlan.DataPlaneKeyRefs()
+	auditKeySecretName, auditPrivateKeyKey, _ := compiledPlan.AuditNetdKeyRefs()
+	if mitmCASecretName != "" {
+		if config.MITMCACertPath == "" {
+			config.MITMCACertPath = "/tls/ca.crt"
+		}
+		if config.MITMCAKeyPath == "" {
+			config.MITMCAKeyPath = "/tls/ca.key"
+		}
+	}
+	configRef, err := r.Resources.ReconcileHashedServiceConfigMapWithScope(ctx, scope, name, labels, config)
+	if err != nil {
+		return nil, err
+	}
+	directoryOrCreate := corev1.HostPathDirectoryOrCreate
+	volumes := []corev1.Volume{
+		{
+			Name: ConfigVolumeName,
+			VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{Name: configRef.ConfigMapName},
+			}},
+		},
+		{
+			Name: "bpf-fs",
+			VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{
+				Path: "/sys/fs/bpf", Type: &directoryOrCreate,
+			}},
+		},
+		{
+			Name: "modules",
+			VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{
+				Path: "/lib/modules", Type: &directoryOrCreate,
+			}},
+		},
+		{Name: RunVolumeName, VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+		{
+			Name: ActiveLockVolumeName,
+			VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{
+				Path: ActiveLockHostDirectory, Type: &directoryOrCreate,
+			}},
+		},
+		{
+			Name: "internal-jwt-private-key",
+			VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{
+				SecretName: keySecretName,
+				Items:      []corev1.KeyToPath{{Key: privateKeyKey, Path: "internal_jwt_private.key"}},
+			}},
+		},
+	}
+	volumeMounts := []corev1.VolumeMount{
+		{Name: ConfigVolumeName, MountPath: ConfigPath, SubPath: "config.yaml", ReadOnly: true},
+		{Name: "bpf-fs", MountPath: "/sys/fs/bpf"},
+		{Name: "modules", MountPath: "/lib/modules", ReadOnly: true},
+		{Name: RunVolumeName, MountPath: RunMountDirectory},
+		{Name: ActiveLockVolumeName, MountPath: ActiveLockMountDirectory},
+		{Name: "internal-jwt-private-key", MountPath: pkginternalauth.DefaultInternalJWTPrivateKeyPath, SubPath: "internal_jwt_private.key", ReadOnly: true},
+	}
+	if config.SandboxObservabilityIngestURL != "" {
+		volumes = append(volumes,
+			corev1.Volume{
+				Name: "audit-spool",
+				VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{
+					Path: filepath.Join("/var/lib/sandbox0/netd", scope.Namespace, scope.Name), Type: &directoryOrCreate,
+				}},
+			},
+			corev1.Volume{
+				Name: "audit-jwt-private-key",
+				VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{
+					SecretName: auditKeySecretName,
+					Items:      []corev1.KeyToPath{{Key: auditPrivateKeyKey, Path: "audit_jwt_private.key"}},
+				}},
+			},
+		)
+		volumeMounts = append(volumeMounts,
+			corev1.VolumeMount{Name: "audit-spool", MountPath: "/var/lib/sandbox0/netd"},
+			corev1.VolumeMount{Name: "audit-jwt-private-key", MountPath: pkginternalauth.DefaultAuditJWTPrivateKeyPath, SubPath: "audit_jwt_private.key", ReadOnly: true},
+		)
+	}
+	if mitmCASecretName != "" {
+		volumes = append(volumes, corev1.Volume{
+			Name:         "mitm-ca",
+			VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: mitmCASecretName}},
+		})
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{Name: "mitm-ca", MountPath: "/tls", ReadOnly: true})
+	}
+	return &RuntimeAssets{
+		Config:         config,
+		ConfigRef:      configRef,
+		PodAnnotations: configRef.PodAnnotations(),
+		Volumes:        volumes,
+		VolumeMounts:   volumeMounts,
+		Ports: []corev1.ContainerPort{
+			{Name: "metrics", ContainerPort: int32(config.MetricsPort)},
+			{Name: "health", ContainerPort: int32(config.HealthPort)},
+		},
+		RuntimeClassName: compiledPlan.Netd.RuntimeClassName,
+		NodeSelector:     compiledPlan.Netd.NodeSelector,
+		Tolerations:      compiledPlan.Netd.Tolerations,
+		ActiveLockPath:   ScopedActiveLockPath(scope.Namespace, scope.Name),
+	}, nil
+}

--- a/infra-operator/internal/controller/services/nodereadiness/nodereadiness.go
+++ b/infra-operator/internal/controller/services/nodereadiness/nodereadiness.go
@@ -4,21 +4,26 @@ import (
 	"context"
 	"fmt"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	infrav1alpha1 "github.com/sandbox0-ai/sandbox0/infra-operator/api/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/pkg/common"
+	ctldsvc "github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/ctld"
 	infraplan "github.com/sandbox0-ai/sandbox0/infra-operator/internal/plan"
 	"github.com/sandbox0-ai/sandbox0/pkg/dataplane"
 	"github.com/sandbox0-ai/sandbox0/pkg/volumeportal"
 )
 
 const (
-	labelManagedBy = "app.kubernetes.io/managed-by"
-	labelInstance  = "app.kubernetes.io/instance"
-	labelComponent = "app.kubernetes.io/component"
+	labelManagedBy        = "app.kubernetes.io/managed-by"
+	labelInstance         = "app.kubernetes.io/instance"
+	labelComponent        = "app.kubernetes.io/component"
+	embeddedNetdConfigEnv = "NETD_CONFIG_PATH"
 )
 
 type Reconciler struct {
@@ -29,12 +34,23 @@ func NewReconciler(resources *common.ResourceManager) *Reconciler {
 	return &Reconciler{Resources: resources}
 }
 
+// Summary describes the latest node-scoped data-plane readiness observation.
+type Summary struct {
+	MatchedNodes int
+	ReadyNodes   int
+}
+
+// Reconcile preserves the original gating behavior for existing callers.
 func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, compiledPlan *infraplan.InfraPlan) error {
-	if r == nil || r.Resources == nil || r.Resources.Client == nil {
-		return fmt.Errorf("node readiness reconciler is not configured")
-	}
-	if infra == nil {
-		return fmt.Errorf("infra is required")
+	return r.Check(ctx, infra, compiledPlan)
+}
+
+// Check refreshes node labels and gates workflow progress on at least one
+// ready data-plane node.
+func (r *Reconciler) Check(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, compiledPlan *infraplan.InfraPlan) error {
+	summary, err := r.Refresh(ctx, infra, compiledPlan)
+	if err != nil {
+		return err
 	}
 	if compiledPlan == nil {
 		compiledPlan = infraplan.Compile(infra)
@@ -42,63 +58,130 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 	if !compiledPlan.Components.EnableManager {
 		return nil
 	}
+	if summary.MatchedNodes == 0 {
+		return fmt.Errorf("no nodes match sandbox placement")
+	}
+	if summary.ReadyNodes == 0 {
+		return fmt.Errorf("sandbox0 data-plane nodes are not ready: 0/%d ready", summary.MatchedNodes)
+	}
+	return nil
+}
+
+// Refresh patches node readiness labels from current runtime state without
+// gating workflow progress. Controllers call it after every workflow attempt
+// so an earlier component failure cannot leave stale ready labels behind.
+func (r *Reconciler) Refresh(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, compiledPlan *infraplan.InfraPlan) (Summary, error) {
+	var summary Summary
+	if r == nil || r.Resources == nil || r.Resources.Client == nil {
+		return summary, fmt.Errorf("node readiness reconciler is not configured")
+	}
+	if infra == nil {
+		return summary, fmt.Errorf("infra is required")
+	}
+	if compiledPlan == nil {
+		compiledPlan = infraplan.Compile(infra)
+	}
 
 	nodeSelector, _ := common.ResolveSandboxNodePlacement(infra)
+	managerEnabled := compiledPlan.Components.EnableManager
 	requireNetd := compiledPlan.Components.EnableNetd
 	requireCtld := compiledPlan.Components.EnableCtld
 
-	podList := &corev1.PodList{}
-	if err := r.Resources.Client.List(ctx, podList,
-		client.InNamespace(compiledPlan.Scope.Namespace),
-		client.MatchingLabels{
-			labelManagedBy: "sandbox0infra-operator",
-			labelInstance:  compiledPlan.Scope.Name,
-		},
-	); err != nil {
-		return fmt.Errorf("list data-plane daemon pods: %w", err)
-	}
-	netdReadyByNode := readyPodsByNode(podList.Items, "netd")
-	ctldReadyByNode := readyCtldPodsByNode(podList.Items)
+	ctldReadyByNode := make(map[string]bool)
 	csiRegisteredByNode := make(map[string]bool)
-	if requireCtld {
+	if managerEnabled && (requireCtld || requireNetd) {
+		podList := &corev1.PodList{}
+		if err := r.Resources.Client.List(ctx, podList,
+			client.InNamespace(compiledPlan.Scope.Namespace),
+			client.MatchingLabels{
+				labelManagedBy: "sandbox0infra-operator",
+				labelInstance:  compiledPlan.Scope.Name,
+			},
+		); err != nil {
+			return summary, fmt.Errorf("list data-plane daemon pods: %w", err)
+		}
+		ctldDaemonSets, err := r.currentCtldDaemonSets(ctx, compiledPlan)
+		if err != nil {
+			return summary, err
+		}
+		ctldReadyByNode = readyCtldPodsByNode(podList.Items, ctldDaemonSets, requireNetd)
+	}
+	if managerEnabled && requireCtld {
 		csiNodeList := &storagev1.CSINodeList{}
 		if err := r.Resources.Client.List(ctx, csiNodeList); err != nil {
-			return fmt.Errorf("list CSI nodes: %w", err)
+			return summary, fmt.Errorf("list CSI nodes: %w", err)
 		}
 		csiRegisteredByNode = registeredCSIDriverByNode(csiNodeList.Items, volumeportal.DriverName)
 	}
 
 	nodeList := &corev1.NodeList{}
 	if err := r.Resources.Client.List(ctx, nodeList); err != nil {
-		return fmt.Errorf("list nodes: %w", err)
+		return summary, fmt.Errorf("list nodes: %w", err)
 	}
 
-	matchedNodes := 0
-	readyNodes := 0
 	for i := range nodeList.Items {
 		node := &nodeList.Items[i]
 		if !nodeMatchesSelector(node, nodeSelector) {
 			continue
 		}
-		matchedNodes++
+		summary.MatchedNodes++
 
-		netdReady := !requireNetd || netdReadyByNode[node.Name]
+		if !managerEnabled {
+			if err := r.clearNodeReadiness(ctx, node); err != nil {
+				return summary, err
+			}
+			continue
+		}
+
 		ctldReady := !requireCtld || (ctldReadyByNode[node.Name] && csiRegisteredByNode[node.Name])
+		// netd runs only in the active ctld process. The active ctld readiness
+		// includes netd and the standby readiness requires HA synchronization, so
+		// the two-slot ctld signal is also the node-scoped netd signal.
+		netdReady := !requireNetd || ctldReady
 		ready := netdReady && ctldReady
 		if ready {
-			readyNodes++
+			summary.ReadyNodes++
 		}
 
 		if err := r.patchNodeReadiness(ctx, node, ready, requireNetd, netdReady, requireCtld, ctldReady); err != nil {
-			return err
+			return summary, err
 		}
 	}
+	return summary, nil
+}
 
-	if matchedNodes == 0 {
-		return fmt.Errorf("no nodes match sandbox placement")
+func (r *Reconciler) currentCtldDaemonSets(ctx context.Context, compiledPlan *infraplan.InfraPlan) (map[string]*appsv1.DaemonSet, error) {
+	sets := make(map[string]*appsv1.DaemonSet, 2)
+	for _, slot := range []string{dataplane.CtldHASlotA, dataplane.CtldHASlotB} {
+		ds := &appsv1.DaemonSet{}
+		key := types.NamespacedName{
+			Name:      fmt.Sprintf("%s-ctld-%s", compiledPlan.Scope.Name, slot),
+			Namespace: compiledPlan.Scope.Namespace,
+		}
+		if err := r.Resources.Client.Get(ctx, key, ds); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return nil, fmt.Errorf("get ctld %s daemonset: %w", slot, err)
+		}
+		sets[slot] = ds
 	}
-	if readyNodes == 0 {
-		return fmt.Errorf("sandbox0 data-plane nodes are not ready: 0/%d ready", matchedNodes)
+	return sets, nil
+}
+
+func (r *Reconciler) clearNodeReadiness(ctx context.Context, node *corev1.Node) error {
+	if node == nil {
+		return nil
+	}
+	original := node.DeepCopy()
+	delete(node.Labels, dataplane.NodeDataPlaneReadyLabel)
+	delete(node.Labels, dataplane.NodeNetdReadyLabel)
+	delete(node.Labels, dataplane.NodeCtldReadyLabel)
+	if labelsEqual(original.Labels, node.Labels) {
+		return nil
+	}
+	if err := r.Resources.Client.Patch(ctx, node, client.MergeFrom(original)); err != nil {
+		return fmt.Errorf("clear node %s data-plane readiness: %w", node.Name, err)
 	}
 	return nil
 }
@@ -133,32 +216,33 @@ func (r *Reconciler) patchNodeReadiness(
 	return nil
 }
 
-func readyPodsByNode(pods []corev1.Pod, component string) map[string]bool {
-	out := make(map[string]bool)
-	for i := range pods {
-		pod := &pods[i]
-		if pod.Spec.NodeName == "" || pod.Labels[labelComponent] != component {
-			continue
-		}
-		if podReady(pod) {
-			out[pod.Spec.NodeName] = true
-		}
-	}
-	return out
-}
-
 // readyCtldPodsByNode requires one ready pod from each HA slot. A synchronized
 // standby can become ready before the active ctld has completed kubelet CSI
 // registration, so a single ready ctld pod is not a sufficient node signal.
-func readyCtldPodsByNode(pods []corev1.Pod) map[string]bool {
+func readyCtldPodsByNode(pods []corev1.Pod, daemonSets map[string]*appsv1.DaemonSet, requireEmbeddedNetd bool) map[string]bool {
 	readySlotsByNode := make(map[string]map[string]struct{})
+	blockedByPredecessor := make(map[string]bool)
 	for i := range pods {
 		pod := &pods[i]
-		if pod.Spec.NodeName == "" || pod.Labels[labelComponent] != "ctld" || !podReady(pod) {
+		if pod.Spec.NodeName == "" || pod.Labels[labelComponent] != "ctld" {
 			continue
 		}
 		slot := pod.Labels[dataplane.CtldHASlotLabel]
 		if slot != dataplane.CtldHASlotA && slot != dataplane.CtldHASlotB {
+			continue
+		}
+		ds := daemonSets[slot]
+		if requireEmbeddedNetd && !daemonSetEmbedsNetd(ds) {
+			continue
+		}
+		if ctldsvc.CtldContainerRunning(pod) && !ctldsvc.PodMatchesCurrentTemplate(pod, ds) {
+			blockedByPredecessor[pod.Spec.NodeName] = true
+			continue
+		}
+		if !pod.DeletionTimestamp.IsZero() {
+			continue
+		}
+		if !ctldsvc.PodReadyForCurrentTemplate(pod, ds) {
 			continue
 		}
 		if readySlotsByNode[pod.Spec.NodeName] == nil {
@@ -170,9 +254,28 @@ func readyCtldPodsByNode(pods []corev1.Pod) map[string]bool {
 	for nodeName, slots := range readySlotsByNode {
 		_, slotAReady := slots[dataplane.CtldHASlotA]
 		_, slotBReady := slots[dataplane.CtldHASlotB]
-		readyByNode[nodeName] = slotAReady && slotBReady
+		readyByNode[nodeName] = slotAReady && slotBReady && !blockedByPredecessor[nodeName]
 	}
 	return readyByNode
+}
+
+func daemonSetEmbedsNetd(ds *appsv1.DaemonSet) bool {
+	if ds == nil {
+		return false
+	}
+	for i := range ds.Spec.Template.Spec.Containers {
+		container := &ds.Spec.Template.Spec.Containers[i]
+		if container.Name != "ctld" {
+			continue
+		}
+		for _, env := range container.Env {
+			if env.Name == embeddedNetdConfigEnv && env.Value != "" {
+				return true
+			}
+		}
+		return false
+	}
+	return false
 }
 
 func registeredCSIDriverByNode(csiNodes []storagev1.CSINode, driverName string) map[string]bool {
@@ -187,18 +290,6 @@ func registeredCSIDriverByNode(csiNodes []storagev1.CSINode, driverName string) 
 		}
 	}
 	return registeredByNode
-}
-
-func podReady(pod *corev1.Pod) bool {
-	if pod == nil || pod.DeletionTimestamp != nil || pod.Status.Phase != corev1.PodRunning {
-		return false
-	}
-	for _, condition := range pod.Status.Conditions {
-		if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
-			return true
-		}
-	}
-	return false
 }
 
 func nodeMatchesSelector(node *corev1.Node, selector map[string]string) bool {

--- a/infra-operator/internal/controller/services/nodereadiness/nodereadiness_test.go
+++ b/infra-operator/internal/controller/services/nodereadiness/nodereadiness_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,11 +30,11 @@ func TestReconcileLabelsNodesFromComponentReadiness(t *testing.T) {
 		nodeA,
 		nodeB,
 		nodeSystem,
-		newNodeReadinessPod(infra.Namespace, infra.Name, "netd", "netd-a", "node-a", true),
+		newNodeReadinessCtldDaemonSet(infra.Namespace, infra.Name, dataplane.CtldHASlotA),
+		newNodeReadinessCtldDaemonSet(infra.Namespace, infra.Name, dataplane.CtldHASlotB),
 		newNodeReadinessCtldPod(infra.Namespace, infra.Name, "ctld-a-a", "node-a", dataplane.CtldHASlotA, true),
 		newNodeReadinessCtldPod(infra.Namespace, infra.Name, "ctld-a-b", "node-a", dataplane.CtldHASlotB, true),
 		newNodeReadinessCSINode("node-a", true),
-		newNodeReadinessPod(infra.Namespace, infra.Name, "netd", "netd-b", "node-b", true),
 		newNodeReadinessCtldPod(infra.Namespace, infra.Name, "ctld-b-a", "node-b", dataplane.CtldHASlotA, true),
 		newNodeReadinessCtldPod(infra.Namespace, infra.Name, "ctld-b-b", "node-b", dataplane.CtldHASlotB, false),
 		newNodeReadinessCSINode("node-b", true),
@@ -48,7 +49,7 @@ func TestReconcileLabelsNodesFromComponentReadiness(t *testing.T) {
 	assertNodeReadinessLabels(t, gotNodeA, dataplane.ReadyLabelValue, dataplane.ReadyLabelValue, dataplane.ReadyLabelValue)
 
 	gotNodeB := getNodeReadinessNode(t, client, "node-b")
-	assertNodeReadinessLabels(t, gotNodeB, dataplane.NotReadyLabelValue, dataplane.ReadyLabelValue, dataplane.NotReadyLabelValue)
+	assertNodeReadinessLabels(t, gotNodeB, dataplane.NotReadyLabelValue, dataplane.NotReadyLabelValue, dataplane.NotReadyLabelValue)
 
 	gotSystem := getNodeReadinessNode(t, client, "node-system")
 	if _, ok := gotSystem.Labels[dataplane.NodeDataPlaneReadyLabel]; ok {
@@ -61,7 +62,8 @@ func TestReconcileReturnsErrorAndClearsReadinessWhenNoNodeReady(t *testing.T) {
 	node := newNodeReadinessNode("node-a", map[string]string{"sandbox0.ai/node-role": "sandbox"})
 	client, scheme := newNodeReadinessClient(t,
 		node,
-		newNodeReadinessPod(infra.Namespace, infra.Name, "netd", "netd-a", "node-a", true),
+		newNodeReadinessCtldDaemonSet(infra.Namespace, infra.Name, dataplane.CtldHASlotA),
+		newNodeReadinessCtldDaemonSet(infra.Namespace, infra.Name, dataplane.CtldHASlotB),
 	)
 	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
 
@@ -74,7 +76,7 @@ func TestReconcileReturnsErrorAndClearsReadinessWhenNoNodeReady(t *testing.T) {
 	}
 
 	gotNode := getNodeReadinessNode(t, client, "node-a")
-	assertNodeReadinessLabels(t, gotNode, dataplane.NotReadyLabelValue, dataplane.ReadyLabelValue, dataplane.NotReadyLabelValue)
+	assertNodeReadinessLabels(t, gotNode, dataplane.NotReadyLabelValue, dataplane.NotReadyLabelValue, dataplane.NotReadyLabelValue)
 }
 
 func TestReconcileDeletesDisabledComponentReadinessLabels(t *testing.T) {
@@ -88,6 +90,8 @@ func TestReconcileDeletesDisabledComponentReadinessLabels(t *testing.T) {
 	})
 	client, scheme := newNodeReadinessClient(t,
 		node,
+		newNodeReadinessCtldDaemonSet(infra.Namespace, infra.Name, dataplane.CtldHASlotA),
+		newNodeReadinessCtldDaemonSet(infra.Namespace, infra.Name, dataplane.CtldHASlotB),
 		newNodeReadinessCtldPod(infra.Namespace, infra.Name, "ctld-a-a", "node-a", dataplane.CtldHASlotA, true),
 		newNodeReadinessCtldPod(infra.Namespace, infra.Name, "ctld-a-b", "node-a", dataplane.CtldHASlotB, true),
 		newNodeReadinessCSINode("node-a", true),
@@ -115,7 +119,8 @@ func TestReconcileRequiresKubeletCSIRegistration(t *testing.T) {
 	node := newNodeReadinessNode("node-a", map[string]string{"sandbox0.ai/node-role": "sandbox"})
 	client, scheme := newNodeReadinessClient(t,
 		node,
-		newNodeReadinessPod(infra.Namespace, infra.Name, "netd", "netd-a", "node-a", true),
+		newNodeReadinessCtldDaemonSet(infra.Namespace, infra.Name, dataplane.CtldHASlotA),
+		newNodeReadinessCtldDaemonSet(infra.Namespace, infra.Name, dataplane.CtldHASlotB),
 		newNodeReadinessCtldPod(infra.Namespace, infra.Name, "ctld-a", "node-a", dataplane.CtldHASlotA, true),
 		newNodeReadinessCtldPod(infra.Namespace, infra.Name, "ctld-b", "node-a", dataplane.CtldHASlotB, true),
 		newNodeReadinessCSINode("node-a", false),
@@ -126,7 +131,77 @@ func TestReconcileRequiresKubeletCSIRegistration(t *testing.T) {
 		t.Fatal("Reconcile() error = nil before kubelet CSI registration")
 	}
 	gotNode := getNodeReadinessNode(t, client, "node-a")
-	assertNodeReadinessLabels(t, gotNode, dataplane.NotReadyLabelValue, dataplane.ReadyLabelValue, dataplane.NotReadyLabelValue)
+	assertNodeReadinessLabels(t, gotNode, dataplane.NotReadyLabelValue, dataplane.NotReadyLabelValue, dataplane.NotReadyLabelValue)
+}
+
+func TestRefreshRejectsReadySurgePredecessorsWithoutGating(t *testing.T) {
+	infra := newNodeReadinessInfra()
+	node := newNodeReadinessNode("node-a", map[string]string{
+		"sandbox0.ai/node-role":           "sandbox",
+		dataplane.NodeDataPlaneReadyLabel: dataplane.ReadyLabelValue,
+		dataplane.NodeNetdReadyLabel:      dataplane.ReadyLabelValue,
+		dataplane.NodeCtldReadyLabel:      dataplane.ReadyLabelValue,
+	})
+	oldSlotA := newNodeReadinessCtldPod(infra.Namespace, infra.Name, "old-ctld-a", node.Name, dataplane.CtldHASlotA, true)
+	oldSlotA.Spec.Containers[0].Image = "ctld:previous"
+	oldSlotB := newNodeReadinessCtldPod(infra.Namespace, infra.Name, "old-ctld-b", node.Name, dataplane.CtldHASlotB, true)
+	oldSlotB.Spec.Containers[0].Image = "ctld:previous"
+	client, scheme := newNodeReadinessClient(t,
+		node,
+		newNodeReadinessCtldDaemonSet(infra.Namespace, infra.Name, dataplane.CtldHASlotA),
+		newNodeReadinessCtldDaemonSet(infra.Namespace, infra.Name, dataplane.CtldHASlotB),
+		oldSlotA,
+		oldSlotB,
+		newNodeReadinessCtldPod(infra.Namespace, infra.Name, "current-ctld-a", node.Name, dataplane.CtldHASlotA, true),
+		newNodeReadinessCtldPod(infra.Namespace, infra.Name, "current-ctld-b", node.Name, dataplane.CtldHASlotB, true),
+		newNodeReadinessCSINode(node.Name, true),
+	)
+	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
+
+	summary, err := reconciler.Refresh(context.Background(), infra, infraplan.Compile(infra))
+	if err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+	if summary.MatchedNodes != 1 || summary.ReadyNodes != 0 {
+		t.Fatalf("Refresh() summary = %+v, want 1 matched and 0 ready", summary)
+	}
+	gotNode := getNodeReadinessNode(t, client, node.Name)
+	assertNodeReadinessLabels(t, gotNode, dataplane.NotReadyLabelValue, dataplane.NotReadyLabelValue, dataplane.NotReadyLabelValue)
+}
+
+func TestRefreshRejectsTerminatingRunningSurgePredecessor(t *testing.T) {
+	infra := newNodeReadinessInfra()
+	node := newNodeReadinessNode("node-a", map[string]string{
+		"sandbox0.ai/node-role":           "sandbox",
+		dataplane.NodeDataPlaneReadyLabel: dataplane.ReadyLabelValue,
+		dataplane.NodeNetdReadyLabel:      dataplane.ReadyLabelValue,
+		dataplane.NodeCtldReadyLabel:      dataplane.ReadyLabelValue,
+	})
+	predecessor := newNodeReadinessCtldPod(infra.Namespace, infra.Name, "old-ctld-a", node.Name, dataplane.CtldHASlotA, true)
+	predecessor.Spec.Containers[0].Image = "ctld:previous"
+	deletionTimestamp := metav1.Now()
+	predecessor.DeletionTimestamp = &deletionTimestamp
+	predecessor.Finalizers = []string{"test.sandbox0.ai/hold-termination"}
+	client, scheme := newNodeReadinessClient(t,
+		node,
+		newNodeReadinessCtldDaemonSet(infra.Namespace, infra.Name, dataplane.CtldHASlotA),
+		newNodeReadinessCtldDaemonSet(infra.Namespace, infra.Name, dataplane.CtldHASlotB),
+		predecessor,
+		newNodeReadinessCtldPod(infra.Namespace, infra.Name, "current-ctld-a", node.Name, dataplane.CtldHASlotA, true),
+		newNodeReadinessCtldPod(infra.Namespace, infra.Name, "current-ctld-b", node.Name, dataplane.CtldHASlotB, true),
+		newNodeReadinessCSINode(node.Name, true),
+	)
+	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
+
+	summary, err := reconciler.Refresh(context.Background(), infra, infraplan.Compile(infra))
+	if err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+	if summary.MatchedNodes != 1 || summary.ReadyNodes != 0 {
+		t.Fatalf("Refresh() summary = %+v, want 1 matched and 0 ready", summary)
+	}
+	gotNode := getNodeReadinessNode(t, client, node.Name)
+	assertNodeReadinessLabels(t, gotNode, dataplane.NotReadyLabelValue, dataplane.NotReadyLabelValue, dataplane.NotReadyLabelValue)
 }
 
 func TestReadyCtldPodsByNodeRequiresDistinctHASlots(t *testing.T) {
@@ -136,12 +211,39 @@ func TestReadyCtldPodsByNodeRequiresDistinctHASlots(t *testing.T) {
 		*newNodeReadinessCtldPod("sandbox0-system", "demo", "ctld-b-a", "node-b", dataplane.CtldHASlotA, true),
 		*newNodeReadinessCtldPod("sandbox0-system", "demo", "ctld-b-b", "node-b", dataplane.CtldHASlotB, true),
 	}
-	readyByNode := readyCtldPodsByNode(pods)
+	readyByNode := readyCtldPodsByNode(pods, map[string]*appsv1.DaemonSet{
+		dataplane.CtldHASlotA: newNodeReadinessCtldDaemonSet("sandbox0-system", "demo", dataplane.CtldHASlotA),
+		dataplane.CtldHASlotB: newNodeReadinessCtldDaemonSet("sandbox0-system", "demo", dataplane.CtldHASlotB),
+	}, true)
 	if readyByNode["node-a"] {
 		t.Fatal("node-a is ready with two pods from the same ctld HA slot")
 	}
 	if !readyByNode["node-b"] {
 		t.Fatal("node-b is not ready with one ready pod from each ctld HA slot")
+	}
+}
+
+func TestReadyCtldPodsByNodeRequiresEmbeddedNetdTemplate(t *testing.T) {
+	sets := map[string]*appsv1.DaemonSet{
+		dataplane.CtldHASlotA: newNodeReadinessCtldDaemonSet("sandbox0-system", "demo", dataplane.CtldHASlotA),
+		dataplane.CtldHASlotB: newNodeReadinessCtldDaemonSet("sandbox0-system", "demo", dataplane.CtldHASlotB),
+	}
+	pods := []corev1.Pod{
+		*newNodeReadinessCtldPod("sandbox0-system", "demo", "ctld-a", "node-a", dataplane.CtldHASlotA, true),
+		*newNodeReadinessCtldPod("sandbox0-system", "demo", "ctld-b", "node-a", dataplane.CtldHASlotB, true),
+	}
+	for _, ds := range sets {
+		ds.Spec.Template.Spec.Containers[0].Env = nil
+	}
+	for i := range pods {
+		pods[i].Spec.Containers[0].Env = nil
+	}
+
+	if readyCtldPodsByNode(pods, sets, true)["node-a"] {
+		t.Fatal("node-a is netd-ready before the current ctld template embeds netd")
+	}
+	if !readyCtldPodsByNode(pods, sets, false)["node-a"] {
+		t.Fatal("node-a is not ctld-ready when embedded netd is not required")
 	}
 }
 
@@ -169,6 +271,9 @@ func newNodeReadinessInfra() *infrav1alpha1.Sandbox0Infra {
 func newNodeReadinessClient(t *testing.T, objects ...ctrlclient.Object) (ctrlclient.Client, *runtime.Scheme) {
 	t.Helper()
 	scheme := runtime.NewScheme()
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add appsv1 scheme: %v", err)
+	}
 	if err := corev1.AddToScheme(scheme); err != nil {
 		t.Fatalf("add corev1 scheme: %v", err)
 	}
@@ -214,8 +319,50 @@ func newNodeReadinessPod(namespace, instance, component, name, nodeName string, 
 
 func newNodeReadinessCtldPod(namespace, instance, name, nodeName, slot string, ready bool) *corev1.Pod {
 	pod := newNodeReadinessPod(namespace, instance, "ctld", name, nodeName, ready)
-	pod.Labels[dataplane.CtldHASlotLabel] = slot
+	ds := newNodeReadinessCtldDaemonSet(namespace, instance, slot)
+	pod.Labels = cloneNodeReadinessStrings(ds.Spec.Template.Labels)
+	pod.Annotations = cloneNodeReadinessStrings(ds.Spec.Template.Annotations)
+	pod.Spec = *ds.Spec.Template.Spec.DeepCopy()
+	pod.Spec.NodeName = nodeName
+	pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+		Name:  "ctld",
+		Ready: ready,
+		State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+	}}
 	return pod
+}
+
+func newNodeReadinessCtldDaemonSet(namespace, instance, slot string) *appsv1.DaemonSet {
+	labels := map[string]string{
+		labelManagedBy:            "sandbox0infra-operator",
+		labelInstance:             instance,
+		labelComponent:            "ctld",
+		dataplane.CtldHASlotLabel: slot,
+	}
+	return &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      instance + "-ctld-" + slot,
+			Namespace: namespace,
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: labels},
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{
+					Name:  "ctld",
+					Image: "ctld:test",
+					Env:   []corev1.EnvVar{{Name: embeddedNetdConfigEnv, Value: "/config/netd.yaml"}},
+				}}},
+			},
+		},
+	}
+}
+
+func cloneNodeReadinessStrings(values map[string]string) map[string]string {
+	cloned := make(map[string]string, len(values))
+	for key, value := range values {
+		cloned[key] = value
+	}
+	return cloned
 }
 
 func newNodeReadinessCSINode(nodeName string, registered bool) *storagev1.CSINode {

--- a/infra-operator/internal/controller/services/storageproxy/storageproxy.go
+++ b/infra-operator/internal/controller/services/storageproxy/storageproxy.go
@@ -22,19 +22,15 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	apiconfig "github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
 	infrav1alpha1 "github.com/sandbox0-ai/sandbox0/infra-operator/api/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/pkg/common"
 	credentialstoresvc "github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/credentialstore"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/database"
-	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/internalauth"
 	meteringsvc "github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/metering"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/storage"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/runtimeconfig"
-	pkginternalauth "github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 )
 
 const (
@@ -43,254 +39,47 @@ const (
 	defaultLogSizeLimit           = "1Gi"
 )
 
-type Reconciler struct {
-	Resources *common.ResourceManager
+// RuntimeVolumeOptions customizes storage runtime volume names when the
+// runtime is embedded in another workload.
+type RuntimeVolumeOptions struct {
+	ConfigMapName          string
+	ConfigVolumeName       string
+	ConfigMountPath        string
+	CacheVolumeName        string
+	LogVolumeName          string
+	IncludeCredentialStore bool
 }
 
-func NewReconciler(resources *common.ResourceManager) *Reconciler {
-	return &Reconciler{Resources: resources}
-}
-
-// Reconcile reconciles the storage-proxy deployment.
-func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, imageRepo, imageTag string) error {
-	logger := log.FromContext(ctx)
-
-	// Skip if not enabled
-	if infra.Spec.Services != nil && infra.Spec.Services.StorageProxy != nil && !infra.Spec.Services.StorageProxy.Enabled {
-		logger.Info("Storage proxy is disabled, skipping")
-		return nil
+// BuildRuntimeConfig resolves the storage-proxy config without creating a
+// workload. Manager embedding uses it while preserving the logical
+// storage-proxy configuration contract.
+func BuildRuntimeConfig(ctx context.Context, resources *common.ResourceManager, infra *infrav1alpha1.Sandbox0Infra) (*apiconfig.StorageProxyConfig, error) {
+	if resources == nil {
+		return nil, fmt.Errorf("resource manager is required")
 	}
-
-	deploymentName := fmt.Sprintf("%s-storage-proxy", infra.Name)
-	serviceName := deploymentName
-
-	replicas := int32(1)
-	if infra.Spec.Services != nil && infra.Spec.Services.StorageProxy != nil {
-		replicas = infra.Spec.Services.StorageProxy.Replicas
+	if infra == nil {
+		return nil, fmt.Errorf("infra is required")
 	}
-
-	labels := common.GetServiceLabels(infra.Name, "storage-proxy")
-	keySecretName, _, publicKeyKey := internalauth.GetDataPlaneKeyRefs(infra)
-
-	config, err := r.buildConfig(ctx, infra)
-	if err != nil {
-		return err
-	}
-	if config.ObjectEncryptionEnabled {
-		if err := common.EnsureObjectEncryptionKeySecret(ctx, r.Resources, infra); err != nil {
-			return err
-		}
-		config.ObjectEncryptionKeyPath = common.ObjectEncryptionKeyPath
-	}
-	if err := credentialstoresvc.ApplyEncryptedPGCredentialStoreConfig(ctx, r.Resources, common.NewObjectScope(infra), &config.CredentialStore); err != nil {
-		return err
-	}
-	cacheSizeLimit, err := parseSizeLimit(config.CacheSizeLimit, defaultCacheSizeLimit, "storage-proxy cache size limit")
-	if err != nil {
-		return err
-	}
-	logSizeLimit, err := parseSizeLimit(config.LogSizeLimit, defaultLogSizeLimit, "storage-proxy log size limit")
-	if err != nil {
-		return err
-	}
-	configRef, err := r.Resources.ReconcileHashedServiceConfigMap(ctx, infra, deploymentName, labels, config)
-	if err != nil {
-		return err
-	}
-	podAnnotations := configRef.PodAnnotations()
-
-	httpPort := int32(config.HTTPPort)
-	metricsPort := int32(config.MetricsPort)
-
-	var resources *corev1.ResourceRequirements
-	serviceConfig := (*infrav1alpha1.ServiceNetworkConfig)(nil)
-	if infra.Spec.Services != nil && infra.Spec.Services.StorageProxy != nil {
-		resources = infra.Spec.Services.StorageProxy.Resources
-		serviceConfig = infra.Spec.Services.StorageProxy.Service
-	}
-
-	volumeMounts := []corev1.VolumeMount{
-		{
-			Name:      "config",
-			MountPath: "/config/config.yaml",
-			SubPath:   "config.yaml",
-			ReadOnly:  true,
-		},
-		{
-			Name:      "internal-jwt-public-key",
-			MountPath: pkginternalauth.DefaultInternalJWTPublicKeyPath,
-			SubPath:   "internal_jwt_public.key",
-			ReadOnly:  true,
-		},
-		{
-			Name:      "cache",
-			MountPath: "/var/lib/storage-proxy/cache",
-		},
-		{
-			Name:      "logs",
-			MountPath: "/var/log/storage-proxy",
-		},
-	}
-	volumes := []corev1.Volume{
-		{
-			Name: "config",
-			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
-					LocalObjectReference: corev1.LocalObjectReference{Name: configRef.ConfigMapName},
-				},
-			},
-		},
-		{
-			Name: "internal-jwt-public-key",
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: keySecretName,
-					Items: []corev1.KeyToPath{
-						{
-							Key:  publicKeyKey,
-							Path: "internal_jwt_public.key",
-						},
-					},
-				},
-			},
-		},
-		{
-			Name: "cache",
-			VolumeSource: corev1.VolumeSource{
-				EmptyDir: &corev1.EmptyDirVolumeSource{SizeLimit: cacheSizeLimit},
-			},
-		},
-		{
-			Name: "logs",
-			VolumeSource: corev1.VolumeSource{
-				EmptyDir: &corev1.EmptyDirVolumeSource{SizeLimit: logSizeLimit},
-			},
-		},
-	}
-	credentialStoreMounts, credentialStoreVolumes := credentialstoresvc.CredentialStoreVolumes(common.NewObjectScope(infra), &config.CredentialStore)
-	volumeMounts = append(volumeMounts, credentialStoreMounts...)
-	volumes = append(volumes, credentialStoreVolumes...)
-	if config.ObjectEncryptionEnabled {
-		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      "object-encryption-key",
-			MountPath: common.ObjectEncryptionMountDir,
-			ReadOnly:  true,
-		})
-		volumes = append(volumes, corev1.Volume{
-			Name: "object-encryption-key",
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: common.ObjectEncryptionSecretName(infra.Name),
-					Items: []corev1.KeyToPath{
-						{
-							Key:  common.ObjectEncryptionSecretKey,
-							Path: common.ObjectEncryptionKeyFilename,
-						},
-					},
-				},
-			},
-		})
-	}
-
-	// Create deployment
-	if err := r.Resources.ReconcileDeployment(ctx, infra, deploymentName, labels, replicas, common.ServiceDefinition{
-		Name:               "storage-proxy",
-		Port:               httpPort,
-		TargetPort:         httpPort,
-		ServiceAccountName: fmt.Sprintf("%s-storage-proxy", infra.Name),
-		Ports: []corev1.ContainerPort{
-			{
-				Name:          "http",
-				ContainerPort: httpPort,
-			},
-			{
-				Name:          "metrics",
-				ContainerPort: metricsPort,
-			},
-		},
-		Image: fmt.Sprintf("%s:%s", imageRepo, imageTag),
-		EnvVars: common.AppendObservabilityEnvVars([]corev1.EnvVar{
-			{
-				Name:  "SERVICE",
-				Value: "storage-proxy",
-			},
-			{
-				Name:  "CONFIG_PATH",
-				Value: "/config/config.yaml",
-			},
-		}, infra, common.ObservabilityEnvConfig{
-			ServiceName: "storage-proxy",
-			RegionID:    common.ResolveRegionID(infra),
-			ClusterID:   common.ResolveClusterID(infra),
-		}),
-		VolumeMounts:   volumeMounts,
-		Volumes:        volumes,
-		PodAnnotations: podAnnotations,
-		LivenessProbe: &corev1.Probe{
-			ProbeHandler: corev1.ProbeHandler{
-				HTTPGet: &corev1.HTTPGetAction{
-					Path: "/healthz",
-					Port: intstr.FromString("http"),
-				},
-			},
-			InitialDelaySeconds: 10,
-			PeriodSeconds:       10,
-		},
-		ReadinessProbe: &corev1.Probe{
-			ProbeHandler: corev1.ProbeHandler{
-				HTTPGet: &corev1.HTTPGetAction{
-					Path: "/readyz",
-					Port: intstr.FromString("http"),
-				},
-			},
-			InitialDelaySeconds: 5,
-			PeriodSeconds:       5,
-		},
-		Resources: resources,
-	}); err != nil {
-		return err
-	}
-
-	// Create service.
-	serviceType := common.ResolveServiceType(serviceConfig)
-	httpServicePort := common.ResolveServicePort(serviceConfig, httpPort)
-	serviceAnnotations := common.ResolveServiceAnnotations(serviceConfig)
-	if err := r.Resources.ReconcileServicePorts(ctx, infra, serviceName, labels, serviceType, serviceAnnotations, []corev1.ServicePort{
-		common.BuildServicePort("http", httpServicePort, httpPort, serviceType),
-		common.BuildServicePort("metrics", metricsPort, metricsPort, serviceType),
-	}); err != nil {
-		return err
-	}
-
-	if err := r.Resources.EnsureDeploymentReady(ctx, infra, deploymentName, replicas); err != nil {
-		return err
-	}
-
-	logger.Info("Storage proxy reconciled successfully")
-	return nil
-}
-
-func (r *Reconciler) buildConfig(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra) (*apiconfig.StorageProxyConfig, error) {
 	cfg := &apiconfig.StorageProxyConfig{}
 	if infra.Spec.Services != nil && infra.Spec.Services.StorageProxy != nil {
 		cfg = runtimeconfig.ToStorageProxy(infra.Spec.Services.StorageProxy.Config)
 	}
 
-	if dsn, err := database.GetDatabaseDSN(ctx, r.Resources.Client, infra); err == nil {
+	if dsn, err := database.GetDatabaseDSN(ctx, resources.Client, infra); err == nil {
 		cfg.DatabaseURL = dsn
 	}
 
-	metaURL, err := database.GetStorageMetadataDSN(ctx, r.Resources.Client, infra)
+	metaURL, err := database.GetStorageMetadataDSN(ctx, resources.Client, infra)
 	if err != nil {
 		return nil, err
 	}
 	cfg.MetaURL = metaURL
 	cfg.RegionID = common.ResolveRegionID(infra)
-	if err := meteringsvc.ApplyStorageProxyConfig(ctx, r.Resources.Client, infra, cfg); err != nil {
+	if err := meteringsvc.ApplyStorageProxyConfig(ctx, resources.Client, infra, cfg); err != nil {
 		return nil, fmt.Errorf("apply metering config: %w", err)
 	}
 
-	storageConfig, err := storage.GetStorageConfig(ctx, r.Resources.Client, infra)
+	storageConfig, err := storage.GetStorageConfig(ctx, resources.Client, infra)
 	if err != nil {
 		return nil, err
 	}
@@ -304,8 +93,79 @@ func (r *Reconciler) buildConfig(ctx context.Context, infra *infrav1alpha1.Sandb
 	cfg.S3SessionToken = storageConfig.SessionToken
 
 	cfg.DefaultClusterId = common.ResolveClusterID(infra)
+	if cfg.ObjectEncryptionEnabled {
+		if err := common.EnsureObjectEncryptionKeySecret(ctx, resources, infra); err != nil {
+			return nil, err
+		}
+		cfg.ObjectEncryptionKeyPath = common.ObjectEncryptionKeyPath
+	}
+	if err := credentialstoresvc.ApplyEncryptedPGCredentialStoreConfig(ctx, resources, common.NewObjectScope(infra), &cfg.CredentialStore); err != nil {
+		return nil, err
+	}
 
 	return cfg, nil
+}
+
+// BuildRuntimeVolumes returns the storage runtime's config, cache, log,
+// credential, and encryption mounts without creating a workload.
+func BuildRuntimeVolumes(scope common.ObjectScope, cfg *apiconfig.StorageProxyConfig, opts RuntimeVolumeOptions) ([]corev1.VolumeMount, []corev1.Volume, error) {
+	if cfg == nil {
+		return nil, nil, fmt.Errorf("storage-proxy config is required")
+	}
+	if opts.ConfigMapName == "" {
+		return nil, nil, fmt.Errorf("storage-proxy config map name is required")
+	}
+	configVolumeName := valueOrDefault(opts.ConfigVolumeName, "config")
+	configMountPath := valueOrDefault(opts.ConfigMountPath, "/config/config.yaml")
+	cacheVolumeName := valueOrDefault(opts.CacheVolumeName, "cache")
+	logVolumeName := valueOrDefault(opts.LogVolumeName, "logs")
+	cacheSizeLimit, err := parseSizeLimit(cfg.CacheSizeLimit, defaultCacheSizeLimit, "storage-proxy cache size limit")
+	if err != nil {
+		return nil, nil, err
+	}
+	logSizeLimit, err := parseSizeLimit(cfg.LogSizeLimit, defaultLogSizeLimit, "storage-proxy log size limit")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	mounts := []corev1.VolumeMount{
+		{Name: configVolumeName, MountPath: configMountPath, SubPath: "config.yaml", ReadOnly: true},
+		{Name: cacheVolumeName, MountPath: "/var/lib/storage-proxy/cache"},
+		{Name: logVolumeName, MountPath: "/var/log/storage-proxy"},
+	}
+	volumes := []corev1.Volume{
+		{
+			Name: configVolumeName,
+			VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{Name: opts.ConfigMapName},
+			}},
+		},
+		{Name: cacheVolumeName, VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{SizeLimit: cacheSizeLimit}}},
+		{Name: logVolumeName, VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{SizeLimit: logSizeLimit}}},
+	}
+	if opts.IncludeCredentialStore {
+		credentialMounts, credentialVolumes := credentialstoresvc.CredentialStoreVolumes(scope, &cfg.CredentialStore)
+		mounts = append(mounts, credentialMounts...)
+		volumes = append(volumes, credentialVolumes...)
+	}
+	if cfg.ObjectEncryptionEnabled {
+		mounts = append(mounts, corev1.VolumeMount{Name: "object-encryption-key", MountPath: common.ObjectEncryptionMountDir, ReadOnly: true})
+		volumes = append(volumes, corev1.Volume{
+			Name: "object-encryption-key",
+			VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{
+				SecretName: common.ObjectEncryptionSecretName(scope.Name),
+				Items:      []corev1.KeyToPath{{Key: common.ObjectEncryptionSecretKey, Path: common.ObjectEncryptionKeyFilename}},
+			}},
+		})
+	}
+	return mounts, volumes, nil
+}
+
+func valueOrDefault(value, fallback string) string {
+	if value == "" {
+		return fallback
+	}
+	return value
 }
 
 func normalizeObjectStorageType(storageType infrav1alpha1.StorageType) string {

--- a/infra-operator/internal/controller/services/storageproxy/storageproxy_test.go
+++ b/infra-operator/internal/controller/services/storageproxy/storageproxy_test.go
@@ -2,73 +2,42 @@ package storageproxy
 
 import (
 	"context"
-	"strings"
 	"testing"
 
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
-	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	apiconfig "github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
 	infrav1alpha1 "github.com/sandbox0-ai/sandbox0/infra-operator/api/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/pkg/common"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 )
 
-func TestReconcileUsesServicePortForHTTPServiceExposure(t *testing.T) {
+func TestBuildRuntimeConfigMapsBuiltinStorageAndDefaultsIdentity(t *testing.T) {
 	infra := &infrav1alpha1.Sandbox0Infra{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "demo",
-			Namespace: "sandbox0-system",
-		},
+		ObjectMeta: metav1.ObjectMeta{Name: "fullmode", Namespace: "sandbox0-system"},
 		Spec: infrav1alpha1.Sandbox0InfraSpec{
+			PublicExposure: &infrav1alpha1.PublicExposureConfig{RegionID: "aws-us-east-1"},
 			Database: &infrav1alpha1.DatabaseConfig{
 				Type: infrav1alpha1.DatabaseTypeBuiltin,
 				Builtin: &infrav1alpha1.BuiltinDatabaseConfig{
-					Enabled:  true,
-					Port:     5432,
-					Username: "sandbox0",
-					Database: "sandbox0",
-					SSLMode:  "disable",
+					Enabled: true, Port: 5432, Username: "sandbox0", Database: "sandbox0", SSLMode: "disable",
 				},
 			},
 			Storage: &infrav1alpha1.StorageConfig{
 				Type: infrav1alpha1.StorageTypeBuiltin,
 				Builtin: &infrav1alpha1.BuiltinStorageConfig{
-					Enabled: true,
-					Bucket:  "sandbox0",
-					Region:  "us-east-1",
-				},
-			},
-			Services: &infrav1alpha1.ServicesConfig{
-				StorageProxy: &infrav1alpha1.StorageProxyServiceConfig{
-					WorkloadServiceConfig: infrav1alpha1.WorkloadServiceConfig{
-						EnabledServiceConfig: infrav1alpha1.EnabledServiceConfig{Enabled: true},
-						Replicas:             1,
-					},
-					ServiceExposureConfig: infrav1alpha1.ServiceExposureConfig{
-						Service: &infrav1alpha1.ServiceNetworkConfig{
-							Port: 18083,
-						},
-					},
-					Config: &infrav1alpha1.StorageProxyConfig{
-						HTTPPort: 8081,
-					},
+					Enabled: true, Bucket: "sandbox0", Region: "us-east-1",
 				},
 			},
 		},
 	}
-
-	reconciler, client := newStorageProxyTestReconciler(t,
+	resources := newStorageRuntimeTestResources(t,
 		infra.DeepCopy(),
 		&corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "demo-sandbox0-database-credentials",
-				Namespace: infra.Namespace,
-			},
+			ObjectMeta: metav1.ObjectMeta{Name: "fullmode-sandbox0-database-credentials", Namespace: infra.Namespace},
 			Data: map[string][]byte{
 				"username": []byte("sandbox0"),
 				"password": []byte("db-password"),
@@ -77,322 +46,7 @@ func TestReconcileUsesServicePortForHTTPServiceExposure(t *testing.T) {
 			},
 		},
 		&corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "demo-sandbox0-rustfs-credentials",
-				Namespace: infra.Namespace,
-			},
-			Data: map[string][]byte{
-				"endpoint":          []byte("http://demo-rustfs.sandbox0-system.svc:9000"),
-				"RUSTFS_ACCESS_KEY": []byte("access-key"),
-				"RUSTFS_SECRET_KEY": []byte("secret-key"),
-			},
-		},
-	)
-
-	if err := reconciler.Reconcile(context.Background(), infra, "sandbox0ai/infra", "latest"); err != nil && !strings.Contains(err.Error(), "not ready") {
-		t.Fatalf("reconcile returned unexpected error: %v", err)
-	}
-
-	service := &corev1.Service{}
-	if err := client.Get(context.Background(), types.NamespacedName{
-		Name:      "demo-storage-proxy",
-		Namespace: infra.Namespace,
-	}, service); err != nil {
-		t.Fatalf("get service: %v", err)
-	}
-
-	httpPort := findServicePort(t, service, "http")
-	if httpPort.Port != 18083 {
-		t.Fatalf("expected http service port 18083, got %d", httpPort.Port)
-	}
-	if httpPort.TargetPort.IntValue() != 8081 {
-		t.Fatalf("expected http target port 8081, got %d", httpPort.TargetPort.IntValue())
-	}
-
-}
-
-func TestReconcileMountsObjectEncryptionKeyWhenEnabled(t *testing.T) {
-	infra := &infrav1alpha1.Sandbox0Infra{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "demo",
-			Namespace: "sandbox0-system",
-		},
-		Spec: infrav1alpha1.Sandbox0InfraSpec{
-			Database: &infrav1alpha1.DatabaseConfig{
-				Type: infrav1alpha1.DatabaseTypeBuiltin,
-				Builtin: &infrav1alpha1.BuiltinDatabaseConfig{
-					Enabled:  true,
-					Port:     5432,
-					Username: "sandbox0",
-					Database: "sandbox0",
-					SSLMode:  "disable",
-				},
-			},
-			Storage: &infrav1alpha1.StorageConfig{
-				Type: infrav1alpha1.StorageTypeBuiltin,
-				Builtin: &infrav1alpha1.BuiltinStorageConfig{
-					Enabled: true,
-					Bucket:  "sandbox0",
-					Region:  "us-east-1",
-				},
-			},
-			Services: &infrav1alpha1.ServicesConfig{
-				StorageProxy: &infrav1alpha1.StorageProxyServiceConfig{
-					WorkloadServiceConfig: infrav1alpha1.WorkloadServiceConfig{
-						EnabledServiceConfig: infrav1alpha1.EnabledServiceConfig{Enabled: true},
-						Replicas:             1,
-					},
-					Config: &infrav1alpha1.StorageProxyConfig{
-						ObjectEncryptionEnabled: true,
-					},
-				},
-			},
-		},
-	}
-
-	reconciler, client := newStorageProxyTestReconciler(t,
-		infra.DeepCopy(),
-		&corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "demo-sandbox0-database-credentials",
-				Namespace: infra.Namespace,
-			},
-			Data: map[string][]byte{
-				"username": []byte("sandbox0"),
-				"password": []byte("db-password"),
-				"database": []byte("sandbox0"),
-				"port":     []byte("5432"),
-			},
-		},
-		&corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "demo-sandbox0-rustfs-credentials",
-				Namespace: infra.Namespace,
-			},
-			Data: map[string][]byte{
-				"endpoint":          []byte("http://demo-rustfs.sandbox0-system.svc:9000"),
-				"RUSTFS_ACCESS_KEY": []byte("access-key"),
-				"RUSTFS_SECRET_KEY": []byte("secret-key"),
-			},
-		},
-	)
-
-	if err := reconciler.Reconcile(context.Background(), infra, "sandbox0ai/infra", "latest"); err != nil && !strings.Contains(err.Error(), "not ready") {
-		t.Fatalf("reconcile returned unexpected error: %v", err)
-	}
-
-	deployment := &appsv1.Deployment{}
-	if err := client.Get(context.Background(), types.NamespacedName{Name: "demo-storage-proxy", Namespace: infra.Namespace}, deployment); err != nil {
-		t.Fatalf("get storage-proxy deployment: %v", err)
-	}
-	assertStorageProxyVolumeMount(t, deployment.Spec.Template.Spec.Containers[0].VolumeMounts, "object-encryption-key", common.ObjectEncryptionMountDir)
-	assertStorageProxyVolume(t, deployment.Spec.Template.Spec.Volumes, "object-encryption-key")
-
-	secret := &corev1.Secret{}
-	if err := client.Get(context.Background(), types.NamespacedName{Name: common.ObjectEncryptionSecretName(infra.Name), Namespace: infra.Namespace}, secret); err != nil {
-		t.Fatalf("get object encryption secret: %v", err)
-	}
-	if len(secret.Data[common.ObjectEncryptionSecretKey]) == 0 {
-		t.Fatal("expected object encryption secret to contain a private key")
-	}
-}
-
-func TestReconcileSetsCacheAndLogEmptyDirSizeLimits(t *testing.T) {
-	infra := &infrav1alpha1.Sandbox0Infra{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "demo",
-			Namespace: "sandbox0-system",
-		},
-		Spec: infrav1alpha1.Sandbox0InfraSpec{
-			Database: &infrav1alpha1.DatabaseConfig{
-				Type: infrav1alpha1.DatabaseTypeBuiltin,
-				Builtin: &infrav1alpha1.BuiltinDatabaseConfig{
-					Enabled:  true,
-					Port:     5432,
-					Username: "sandbox0",
-					Database: "sandbox0",
-					SSLMode:  "disable",
-				},
-			},
-			Storage: &infrav1alpha1.StorageConfig{
-				Type: infrav1alpha1.StorageTypeBuiltin,
-				Builtin: &infrav1alpha1.BuiltinStorageConfig{
-					Enabled: true,
-					Bucket:  "sandbox0",
-					Region:  "us-east-1",
-				},
-			},
-			Services: &infrav1alpha1.ServicesConfig{
-				StorageProxy: &infrav1alpha1.StorageProxyServiceConfig{
-					WorkloadServiceConfig: infrav1alpha1.WorkloadServiceConfig{
-						EnabledServiceConfig: infrav1alpha1.EnabledServiceConfig{Enabled: true},
-						Replicas:             1,
-					},
-					Config: &infrav1alpha1.StorageProxyConfig{
-						CacheSizeLimit: "512Mi",
-						LogSizeLimit:   "64Mi",
-					},
-				},
-			},
-		},
-	}
-
-	reconciler, client := newStorageProxyTestReconciler(t,
-		infra.DeepCopy(),
-		&corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "demo-sandbox0-database-credentials",
-				Namespace: infra.Namespace,
-			},
-			Data: map[string][]byte{
-				"username": []byte("sandbox0"),
-				"password": []byte("db-password"),
-				"database": []byte("sandbox0"),
-				"port":     []byte("5432"),
-			},
-		},
-		&corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "demo-sandbox0-rustfs-credentials",
-				Namespace: infra.Namespace,
-			},
-			Data: map[string][]byte{
-				"endpoint":          []byte("http://demo-rustfs.sandbox0-system.svc:9000"),
-				"RUSTFS_ACCESS_KEY": []byte("access-key"),
-				"RUSTFS_SECRET_KEY": []byte("secret-key"),
-			},
-		},
-	)
-
-	if err := reconciler.Reconcile(context.Background(), infra, "sandbox0ai/infra", "latest"); err != nil && !strings.Contains(err.Error(), "not ready") {
-		t.Fatalf("reconcile returned unexpected error: %v", err)
-	}
-
-	deployment := &appsv1.Deployment{}
-	if err := client.Get(context.Background(), types.NamespacedName{Name: "demo-storage-proxy", Namespace: infra.Namespace}, deployment); err != nil {
-		t.Fatalf("get storage-proxy deployment: %v", err)
-	}
-	assertEmptyDirSizeLimit(t, deployment.Spec.Template.Spec.Volumes, "cache", "512Mi")
-	assertEmptyDirSizeLimit(t, deployment.Spec.Template.Spec.Volumes, "logs", "64Mi")
-}
-
-func TestBuildConfigMapsBuiltinStorageToS3CompatibleType(t *testing.T) {
-	infra := &infrav1alpha1.Sandbox0Infra{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "demo",
-			Namespace: "sandbox0-system",
-		},
-		Spec: infrav1alpha1.Sandbox0InfraSpec{
-			Database: &infrav1alpha1.DatabaseConfig{
-				Type: infrav1alpha1.DatabaseTypeBuiltin,
-				Builtin: &infrav1alpha1.BuiltinDatabaseConfig{
-					Enabled:  true,
-					Port:     5432,
-					Username: "sandbox0",
-					Database: "sandbox0",
-					SSLMode:  "disable",
-				},
-			},
-			Storage: &infrav1alpha1.StorageConfig{
-				Type: infrav1alpha1.StorageTypeBuiltin,
-				Builtin: &infrav1alpha1.BuiltinStorageConfig{
-					Enabled: true,
-					Bucket:  "sandbox0",
-					Region:  "us-east-1",
-				},
-			},
-		},
-	}
-
-	reconciler, _ := newStorageProxyTestReconciler(t,
-		infra.DeepCopy(),
-		&corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "demo-sandbox0-database-credentials",
-				Namespace: infra.Namespace,
-			},
-			Data: map[string][]byte{
-				"username": []byte("sandbox0"),
-				"password": []byte("db-password"),
-				"database": []byte("sandbox0"),
-				"port":     []byte("5432"),
-			},
-		},
-		&corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "demo-sandbox0-rustfs-credentials",
-				Namespace: infra.Namespace,
-			},
-			Data: map[string][]byte{
-				"endpoint":          []byte("http://demo-rustfs.sandbox0-system.svc:9000"),
-				"RUSTFS_ACCESS_KEY": []byte("access-key"),
-				"RUSTFS_SECRET_KEY": []byte("secret-key"),
-			},
-		},
-	)
-
-	cfg, err := reconciler.buildConfig(context.Background(), infra)
-	if err != nil {
-		t.Fatalf("buildConfig returned error: %v", err)
-	}
-	if cfg.ObjectStorageType != "s3" {
-		t.Fatalf("expected builtin storage to map to s3-compatible object storage, got %q", cfg.ObjectStorageType)
-	}
-	if cfg.S3Endpoint != "http://demo-rustfs.sandbox0-system.svc:9000" {
-		t.Fatalf("unexpected s3 endpoint: %q", cfg.S3Endpoint)
-	}
-}
-
-func TestBuildConfigDefaultsDataPlaneIdentity(t *testing.T) {
-	infra := &infrav1alpha1.Sandbox0Infra{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "fullmode",
-			Namespace: "sandbox0-system",
-		},
-		Spec: infrav1alpha1.Sandbox0InfraSpec{
-			PublicExposure: &infrav1alpha1.PublicExposureConfig{
-				RegionID: "aws-us-east-1",
-			},
-			Database: &infrav1alpha1.DatabaseConfig{
-				Type: infrav1alpha1.DatabaseTypeBuiltin,
-				Builtin: &infrav1alpha1.BuiltinDatabaseConfig{
-					Enabled:  true,
-					Port:     5432,
-					Username: "sandbox0",
-					Database: "sandbox0",
-					SSLMode:  "disable",
-				},
-			},
-			Storage: &infrav1alpha1.StorageConfig{
-				Type: infrav1alpha1.StorageTypeBuiltin,
-				Builtin: &infrav1alpha1.BuiltinStorageConfig{
-					Enabled: true,
-					Bucket:  "sandbox0",
-					Region:  "us-east-1",
-				},
-			},
-		},
-	}
-
-	reconciler, _ := newStorageProxyTestReconciler(t,
-		infra.DeepCopy(),
-		&corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "fullmode-sandbox0-database-credentials",
-				Namespace: infra.Namespace,
-			},
-			Data: map[string][]byte{
-				"username": []byte("sandbox0"),
-				"password": []byte("db-password"),
-				"database": []byte("sandbox0"),
-				"port":     []byte("5432"),
-			},
-		},
-		&corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "fullmode-sandbox0-rustfs-credentials",
-				Namespace: infra.Namespace,
-			},
+			ObjectMeta: metav1.ObjectMeta{Name: "fullmode-sandbox0-rustfs-credentials", Namespace: infra.Namespace},
 			Data: map[string][]byte{
 				"endpoint":          []byte("http://fullmode-rustfs.sandbox0-system.svc:9000"),
 				"RUSTFS_ACCESS_KEY": []byte("access-key"),
@@ -401,21 +55,52 @@ func TestBuildConfigDefaultsDataPlaneIdentity(t *testing.T) {
 		},
 	)
 
-	cfg, err := reconciler.buildConfig(context.Background(), infra)
+	cfg, err := BuildRuntimeConfig(context.Background(), resources, infra)
 	if err != nil {
-		t.Fatalf("buildConfig returned error: %v", err)
+		t.Fatalf("BuildRuntimeConfig() error = %v", err)
+	}
+	if cfg.ObjectStorageType != "s3" {
+		t.Fatalf("object storage type = %q, want s3", cfg.ObjectStorageType)
+	}
+	if cfg.S3Endpoint != "http://fullmode-rustfs.sandbox0-system.svc:9000" {
+		t.Fatalf("S3 endpoint = %q", cfg.S3Endpoint)
 	}
 	if cfg.RegionID != "aws-us-east-1" {
-		t.Fatalf("region_id = %q, want aws-us-east-1", cfg.RegionID)
+		t.Fatalf("region ID = %q, want aws-us-east-1", cfg.RegionID)
 	}
 	if cfg.DefaultClusterId != naming.DefaultClusterID {
-		t.Fatalf("default_cluster_id = %q, want %q", cfg.DefaultClusterId, naming.DefaultClusterID)
+		t.Fatalf("cluster ID = %q, want %q", cfg.DefaultClusterId, naming.DefaultClusterID)
 	}
 }
 
-func newStorageProxyTestReconciler(t *testing.T, objects ...runtime.Object) (*Reconciler, ctrlclient.Client) {
-	t.Helper()
+func TestBuildRuntimeVolumesSetsLimitsAndEncryptionMount(t *testing.T) {
+	cfg := &apiconfig.StorageProxyConfig{
+		CacheSizeLimit:          "512Mi",
+		LogSizeLimit:            "64Mi",
+		ObjectEncryptionEnabled: true,
+	}
+	scope := common.ObjectScope{Name: "demo", Namespace: "sandbox0-system"}
+	mounts, volumes, err := BuildRuntimeVolumes(scope, cfg, RuntimeVolumeOptions{
+		ConfigMapName:    "demo-manager-storage-config",
+		ConfigVolumeName: "storage-config",
+		ConfigMountPath:  "/config/storage-proxy.yaml",
+		CacheVolumeName:  "storage-cache",
+		LogVolumeName:    "storage-logs",
+	})
+	if err != nil {
+		t.Fatalf("BuildRuntimeVolumes() error = %v", err)
+	}
+	assertVolumeMount(t, mounts, "storage-config", "/config/storage-proxy.yaml")
+	assertVolumeMount(t, mounts, "storage-cache", "/var/lib/storage-proxy/cache")
+	assertVolumeMount(t, mounts, "storage-logs", "/var/log/storage-proxy")
+	assertVolumeMount(t, mounts, "object-encryption-key", common.ObjectEncryptionMountDir)
+	assertEmptyDirLimit(t, volumes, "storage-cache", "512Mi")
+	assertEmptyDirLimit(t, volumes, "storage-logs", "64Mi")
+	assertVolume(t, volumes, "object-encryption-key")
+}
 
+func newStorageRuntimeTestResources(t *testing.T, objects ...runtime.Object) *common.ResourceManager {
+	t.Helper()
 	scheme := runtime.NewScheme()
 	if err := infrav1alpha1.AddToScheme(scheme); err != nil {
 		t.Fatalf("add infra scheme: %v", err)
@@ -423,65 +108,46 @@ func newStorageProxyTestReconciler(t *testing.T, objects ...runtime.Object) (*Re
 	if err := corev1.AddToScheme(scheme); err != nil {
 		t.Fatalf("add core scheme: %v", err)
 	}
-	if err := appsv1.AddToScheme(scheme); err != nil {
-		t.Fatalf("add apps scheme: %v", err)
-	}
-
-	client := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithRuntimeObjects(objects...).
-		Build()
-
-	return NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{})), client
+	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objects...).Build()
+	return common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{})
 }
 
-func findServicePort(t *testing.T, service *corev1.Service, name string) corev1.ServicePort {
-	t.Helper()
-	for _, port := range service.Spec.Ports {
-		if port.Name == name {
-			return port
-		}
-	}
-	t.Fatalf("expected service port %q to exist", name)
-	return corev1.ServicePort{}
-}
-
-func assertStorageProxyVolumeMount(t *testing.T, mounts []corev1.VolumeMount, name, mountPath string) {
+func assertVolumeMount(t *testing.T, mounts []corev1.VolumeMount, name, path string) {
 	t.Helper()
 	for _, mount := range mounts {
 		if mount.Name == name {
-			if mount.MountPath != mountPath {
-				t.Fatalf("volume mount %q path = %q, want %q", name, mount.MountPath, mountPath)
+			if mount.MountPath != path {
+				t.Fatalf("mount %q path = %q, want %q", name, mount.MountPath, path)
 			}
 			return
 		}
 	}
-	t.Fatalf("expected volume mount %q, got %#v", name, mounts)
+	t.Fatalf("mount %q not found", name)
 }
 
-func assertStorageProxyVolume(t *testing.T, volumes []corev1.Volume, name string) {
+func assertVolume(t *testing.T, volumes []corev1.Volume, name string) {
 	t.Helper()
 	for _, volume := range volumes {
 		if volume.Name == name {
 			return
 		}
 	}
-	t.Fatalf("expected volume %q, got %#v", name, volumes)
+	t.Fatalf("volume %q not found", name)
 }
 
-func assertEmptyDirSizeLimit(t *testing.T, volumes []corev1.Volume, name, want string) {
+func assertEmptyDirLimit(t *testing.T, volumes []corev1.Volume, name, want string) {
 	t.Helper()
 	for _, volume := range volumes {
 		if volume.Name != name {
 			continue
 		}
 		if volume.EmptyDir == nil || volume.EmptyDir.SizeLimit == nil {
-			t.Fatalf("expected volume %q to have an emptyDir size limit, got %#v", name, volume)
+			t.Fatalf("volume %q has no emptyDir size limit", name)
 		}
 		if got := volume.EmptyDir.SizeLimit.String(); got != want {
 			t.Fatalf("volume %q size limit = %q, want %q", name, got, want)
 		}
 		return
 	}
-	t.Fatalf("expected volume %q, got %#v", name, volumes)
+	t.Fatalf("volume %q not found", name)
 }

--- a/infra-operator/internal/plan/plan.go
+++ b/infra-operator/internal/plan/plan.go
@@ -819,6 +819,7 @@ func compileCleanupPlan(infra *infrav1alpha1.Sandbox0Infra, compiled *InfraPlan)
 	if !compiled.Components.EnableNetd {
 		cleanup.DeleteNamespaced = append(cleanup.DeleteNamespaced,
 			namespacedRef("DaemonSet", infra.Namespace, fmt.Sprintf("%s-netd", infra.Name)),
+			namespacedRef("Service", infra.Namespace, fmt.Sprintf("%s-netd-metrics", infra.Name)),
 			namespacedRef("ConfigMap", infra.Namespace, fmt.Sprintf("%s-netd", infra.Name)),
 			namespacedRef("ServiceAccount", infra.Namespace, fmt.Sprintf("%s-netd", infra.Name)),
 		)

--- a/infra-operator/internal/plan/plan.go
+++ b/infra-operator/internal/plan/plan.go
@@ -43,14 +43,17 @@ type InfraPlan struct {
 }
 
 type ComponentPlan struct {
-	EnableGlobalGateway        bool
-	HasControlPlane            bool
-	HasDataPlane               bool
-	EnableRegionalGateway      bool
-	EnableSSHGateway           bool
-	EnableScheduler            bool
-	EnableClusterGateway       bool
+	EnableGlobalGateway   bool
+	HasControlPlane       bool
+	HasDataPlane          bool
+	EnableRegionalGateway bool
+	EnableSSHGateway      bool
+	EnableScheduler       bool
+	EnableClusterGateway  bool
+	// EnableManager tracks the user-facing manager service, while EnableManagerHost
+	// also covers the compatibility case where the manager workload hosts storage only.
 	EnableManager              bool
+	EnableManagerHost          bool
 	EnableStorageProxy         bool
 	EnableCtld                 bool
 	EnableNetd                 bool
@@ -209,12 +212,13 @@ func compileComponents(infra *infrav1alpha1.Sandbox0Infra) ComponentPlan {
 	enableClusterGateway := infrav1alpha1.IsClusterGatewayEnabled(infra)
 	enableManager := infrav1alpha1.IsManagerEnabled(infra)
 	enableStorageProxy := infrav1alpha1.IsStorageProxyEnabled(infra)
+	enableManagerHost := enableManager || enableStorageProxy
 	enableDatabase := infrav1alpha1.IsDatabaseEnabled(infra)
 	enableRedis := infrav1alpha1.IsRedisEnabled(infra)
 	enableCredentialVault := infrav1alpha1.IsCredentialVaultEnabled(infra)
 
 	hasControlPlane := enableRegionalGateway || enableSSHGateway || enableScheduler
-	hasDataPlane := enableClusterGateway || enableManager || enableStorageProxy
+	hasDataPlane := enableClusterGateway || enableManagerHost
 
 	return ComponentPlan{
 		EnableGlobalGateway:        enableGlobalGateway,
@@ -225,6 +229,7 @@ func compileComponents(infra *infrav1alpha1.Sandbox0Infra) ComponentPlan {
 		EnableScheduler:            enableScheduler,
 		EnableClusterGateway:       enableClusterGateway,
 		EnableManager:              enableManager,
+		EnableManagerHost:          enableManagerHost,
 		EnableStorageProxy:         enableStorageProxy,
 		EnableCtld:                 enableManager,
 		EnableNetd:                 infrav1alpha1.IsNetdEnabled(infra),
@@ -374,7 +379,7 @@ func compileManagerPlan(infra *infrav1alpha1.Sandbox0Infra, compiled *InfraPlan)
 	}
 
 	managerPlan := ManagerPlan{
-		Enabled:               infrav1alpha1.IsManagerEnabled(infra),
+		Enabled:               compiled != nil && compiled.Components.EnableManagerHost,
 		Config:                &apiconfig.ManagerConfig{},
 		TemplateStoreEnabled:  templateStoreEnabled,
 		NetworkPolicyProvider: "noop",
@@ -392,7 +397,6 @@ func compileManagerPlan(infra *infrav1alpha1.Sandbox0Infra, compiled *InfraPlan)
 		managerPlan.DefaultClusterID = common.ResolveClusterID(infra)
 		if infra.Spec.Services != nil && infra.Spec.Services.Manager != nil {
 			svc := infra.Spec.Services.Manager
-			managerPlan.Replicas = svc.Replicas
 			if svc.Resources != nil {
 				managerPlan.Resources = svc.Resources.DeepCopy()
 			}
@@ -403,10 +407,27 @@ func compileManagerPlan(infra *infrav1alpha1.Sandbox0Infra, compiled *InfraPlan)
 				managerPlan.Config = runtimeconfig.ToManager(svc.Config)
 			}
 		}
+		managerPlan.Replicas = managerHostReplicas(infra)
 		compileManagerRuntimeConfig(&managerPlan, infra)
 	}
 
 	return managerPlan
+}
+
+func managerHostReplicas(infra *infrav1alpha1.Sandbox0Infra) int32 {
+	if infra == nil || infra.Spec.Services == nil {
+		return 0
+	}
+
+	var replicas int32
+	if infrav1alpha1.IsManagerEnabled(infra) && infra.Spec.Services.Manager != nil {
+		replicas = infra.Spec.Services.Manager.Replicas
+	}
+	if infrav1alpha1.IsStorageProxyEnabled(infra) && infra.Spec.Services.StorageProxy != nil &&
+		infra.Spec.Services.StorageProxy.Replicas > replicas {
+		replicas = infra.Spec.Services.StorageProxy.Replicas
+	}
+	return replicas
 }
 
 func withDataPlaneReadyNodeSelector(selector map[string]string, compiled *InfraPlan) map[string]string {
@@ -447,7 +468,7 @@ func compileManagerRuntimeConfig(managerPlan *ManagerPlan, infra *infrav1alpha1.
 	cfg.SandboxPodPlacement = managerPlan.SandboxPodPlacement
 	cfg.DefaultClusterId = managerPlan.DefaultClusterID
 	cfg.RegionID = managerPlan.RegionID
-	cfg.CtldEnabled = managerPlan.Enabled
+	cfg.CtldEnabled = infrav1alpha1.IsManagerEnabled(infra)
 	if cfg.CtldEnabled && cfg.CtldPort == 0 {
 		cfg.CtldPort = 8095
 	}
@@ -681,6 +702,12 @@ func compileValidationPlan(infra *infrav1alpha1.Sandbox0Infra, compiled *InfraPl
 			plan.FatalErrors = append(plan.FatalErrors, "cluster configuration requires at least one data-plane service")
 		}
 	}
+	if compiled != nil && compiled.Components.EnableStorageProxy && compiled.Manager.Replicas < 1 {
+		plan.FatalErrors = append(plan.FatalErrors, "manager host replicas must be at least 1 when the storage API is enabled")
+	}
+	if compiled != nil && compiled.Components.EnableNetd && !compiled.Components.EnableCtld {
+		plan.FatalErrors = append(plan.FatalErrors, "netd requires ctld to be enabled because its runtime is embedded in ctld")
+	}
 	if compiled != nil && compiled.Components.EnableNetd && netdEgressAuthEnabled(infra) && !compiled.Components.EnableManager {
 		plan.FatalErrors = append(plan.FatalErrors, "netd egress auth requires manager to be enabled")
 	}
@@ -757,7 +784,7 @@ func compileCleanupPlan(infra *infrav1alpha1.Sandbox0Infra, compiled *InfraPlan)
 			namespacedRef("ConfigMap", infra.Namespace, fmt.Sprintf("%s-cluster-gateway", infra.Name)),
 		)
 	}
-	if !compiled.Components.EnableManager {
+	if !compiled.Components.EnableManagerHost {
 		cleanup.DeleteNamespaced = append(cleanup.DeleteNamespaced,
 			namespacedRef("Deployment", infra.Namespace, fmt.Sprintf("%s-manager", infra.Name)),
 			namespacedRef("Service", infra.Namespace, fmt.Sprintf("%s-manager", infra.Name)),
@@ -774,6 +801,7 @@ func compileCleanupPlan(infra *infrav1alpha1.Sandbox0Infra, compiled *InfraPlan)
 			namespacedRef("Deployment", infra.Namespace, fmt.Sprintf("%s-storage-proxy", infra.Name)),
 			namespacedRef("Service", infra.Namespace, fmt.Sprintf("%s-storage-proxy", infra.Name)),
 			namespacedRef("ConfigMap", infra.Namespace, fmt.Sprintf("%s-storage-proxy", infra.Name)),
+			namespacedRef("ConfigMap", infra.Namespace, fmt.Sprintf("%s-manager-storage", infra.Name)),
 			namespacedRef("ServiceAccount", infra.Namespace, fmt.Sprintf("%s-storage-proxy", infra.Name)),
 		)
 		cleanup.DeleteClusterScoped = append(cleanup.DeleteClusterScoped,
@@ -1022,30 +1050,46 @@ func compileWorkflowPlan(compiled *InfraPlan) WorkflowPlan {
 		appendCheckStep("scheduler-rbac", infrav1alpha1.ConditionTypeSchedulerReady, "SchedulerRBACFailed")
 		appendSuccessStep("scheduler", infrav1alpha1.ConditionTypeSchedulerReady, "SchedulerReady", "Scheduler is ready", "SchedulerFailed")
 	}
+	if compiled.Components.EnableManagerHost {
+		conditionType := infrav1alpha1.ConditionTypeStorageProxyReady
+		successReason := "ManagerHostReady"
+		successMessage := "Manager host is ready"
+		if compiled.Components.EnableManager {
+			conditionType = infrav1alpha1.ConditionTypeManagerReady
+			successReason = "ManagerReady"
+			successMessage = "Manager is ready"
+		}
+		appendCheckStep("manager-rbac", conditionType, "ManagerRBACFailed")
+		appendSuccessStep("manager", conditionType, successReason, successMessage, "ManagerFailed")
+	}
 	if compiled.Components.EnableClusterGateway && compiled.Enterprise.ClusterGateway {
 		appendCheckStep("cluster-gateway-enterprise-license", infrav1alpha1.ConditionTypeClusterGatewayReady, "EnterpriseLicenseMissing")
 	}
 	if compiled.Components.EnableClusterGateway {
 		appendSuccessStep("cluster-gateway", infrav1alpha1.ConditionTypeClusterGatewayReady, "ClusterGatewayReady", "Internal gateway is ready", "ClusterGatewayFailed")
 	}
-	if compiled.Components.EnableCtld {
-		appendSuccessStep("ctld", infrav1alpha1.ConditionTypeCtldReady, "CtldReady", "ctld is ready", "CtldFailed")
-	}
-	if compiled.Components.EnableManager {
-		appendCheckStep("manager-rbac", infrav1alpha1.ConditionTypeManagerReady, "ManagerRBACFailed")
-		appendSuccessStep("manager", infrav1alpha1.ConditionTypeManagerReady, "ManagerReady", "Manager is ready", "ManagerFailed")
+	if compiled.Components.EnableStorageProxy {
+		appendSuccessStep("storage-proxy", infrav1alpha1.ConditionTypeStorageProxyReady, "StorageProxyReady", "Storage API is ready in manager", "StorageProxyFailed")
 	}
 	if compiled.Components.EnableNetd {
-		appendCheckStep("netd-rbac", infrav1alpha1.ConditionTypeNetdReady, "NetdRBACFailed")
-		appendSuccessStep("netd", infrav1alpha1.ConditionTypeNetdReady, "NetdReady", "netd is ready", "NetdFailed")
+		appendCheckStep("legacy-netd-handoff", infrav1alpha1.ConditionTypeNetdReady, "NetdHandoffPrepareFailed")
+	}
+	if compiled.Components.EnableCtld {
+		appendCheckStep("ctld", infrav1alpha1.ConditionTypeCtldReady, "CtldFailed")
+	}
+	if compiled.Components.EnableNetd {
+		appendCheckStep("legacy-netd-standby", infrav1alpha1.ConditionTypeNetdReady, "NetdHandoffFailed")
+	}
+	if compiled.Components.EnableCtld {
+		appendSuccessStep("ctld-ready", infrav1alpha1.ConditionTypeCtldReady, "CtldReady", "ctld is ready", "CtldFailed")
+	}
+	if compiled.Components.EnableNetd {
+		appendSuccessStep("netd-ready", infrav1alpha1.ConditionTypeNetdReady, "NetdReady", "netd is ready in the active ctld", "NetdFailed")
+		appendCheckStep("legacy-netd-cleanup", infrav1alpha1.ConditionTypeNetdReady, "NetdCleanupFailed")
 	}
 	if compiled.Components.EnableManager {
 		appendCheckStep("data-plane-node-readiness", infrav1alpha1.ConditionTypeManagerReady, "DataPlaneNodesNotReady")
 		appendCheckStep("builtin-template-pods", infrav1alpha1.ConditionTypeManagerReady, "BuiltinTemplatePodsNotReady")
-	}
-	if compiled.Components.EnableStorageProxy {
-		appendCheckStep("storage-proxy-rbac", infrav1alpha1.ConditionTypeStorageProxyReady, "StorageProxyRBACFailed")
-		appendSuccessStep("storage-proxy", infrav1alpha1.ConditionTypeStorageProxyReady, "StorageProxyReady", "Storage proxy is ready", "StorageProxyFailed")
 	}
 	if compiled.Components.EnableClusterRegistration {
 		appendSuccessStep("register-cluster", infrav1alpha1.ConditionTypeClusterRegistered, "ClusterRegistered", "Cluster registration completed", "ClusterRegistrationFailed")

--- a/infra-operator/internal/plan/plan_test.go
+++ b/infra-operator/internal/plan/plan_test.go
@@ -992,7 +992,7 @@ func TestCompileTracksValidationRequirements(t *testing.T) {
 		}
 	})
 
-	t.Run("netd egress auth without manager is invalid", func(t *testing.T) {
+	t.Run("netd without ctld is invalid and egress auth still requires manager", func(t *testing.T) {
 		infra := &infrav1alpha1.Sandbox0Infra{
 			Spec: infrav1alpha1.Sandbox0InfraSpec{
 				Services: &infrav1alpha1.ServicesConfig{
@@ -1007,8 +1007,31 @@ func TestCompileTracksValidationRequirements(t *testing.T) {
 		}
 
 		compiled := Compile(infra)
+		if !containsString(compiled.Validation.FatalErrors, "netd requires ctld to be enabled because its runtime is embedded in ctld") {
+			t.Fatalf("expected netd/ctld validation error, got %#v", compiled.Validation.FatalErrors)
+		}
 		if !containsString(compiled.Validation.FatalErrors, "netd egress auth requires manager to be enabled") {
-			t.Fatalf("expected netd/manager validation error, got %#v", compiled.Validation.FatalErrors)
+			t.Fatalf("expected netd egress-auth/manager validation error, got %#v", compiled.Validation.FatalErrors)
+		}
+	})
+
+	t.Run("storage proxy requires at least one manager host replica", func(t *testing.T) {
+		infra := &infrav1alpha1.Sandbox0Infra{
+			Spec: infrav1alpha1.Sandbox0InfraSpec{
+				Services: &infrav1alpha1.ServicesConfig{
+					StorageProxy: &infrav1alpha1.StorageProxyServiceConfig{
+						WorkloadServiceConfig: infrav1alpha1.WorkloadServiceConfig{
+							EnabledServiceConfig: infrav1alpha1.EnabledServiceConfig{Enabled: true},
+							Replicas:             0,
+						},
+					},
+				},
+			},
+		}
+
+		compiled := Compile(infra)
+		if !containsString(compiled.Validation.FatalErrors, "manager host replicas must be at least 1 when the storage API is enabled") {
+			t.Fatalf("expected manager-host replica validation error, got %#v", compiled.Validation.FatalErrors)
 		}
 	})
 
@@ -1069,6 +1092,119 @@ func TestCompileTracksValidationRequirements(t *testing.T) {
 			t.Fatalf("expected regional/cluster auth mode validation error, got %#v", compiled.Validation.FatalErrors)
 		}
 	})
+}
+
+func TestCompileStorageOnlyUsesManagerHost(t *testing.T) {
+	infra := &infrav1alpha1.Sandbox0Infra{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "sandbox0-system"},
+		Spec: infrav1alpha1.Sandbox0InfraSpec{
+			Services: &infrav1alpha1.ServicesConfig{
+				Manager: &infrav1alpha1.ManagerServiceConfig{
+					WorkloadServiceConfig: infrav1alpha1.WorkloadServiceConfig{
+						EnabledServiceConfig: infrav1alpha1.EnabledServiceConfig{Enabled: false},
+						Replicas:             9,
+					},
+				},
+				StorageProxy: &infrav1alpha1.StorageProxyServiceConfig{
+					WorkloadServiceConfig: infrav1alpha1.WorkloadServiceConfig{
+						EnabledServiceConfig: infrav1alpha1.EnabledServiceConfig{Enabled: true},
+						Replicas:             2,
+					},
+				},
+			},
+		},
+	}
+
+	compiled := Compile(infra)
+
+	if compiled.Components.EnableManager {
+		t.Fatal("storage-only compatibility must not enable the full manager component")
+	}
+	if !compiled.Components.EnableManagerHost || !compiled.Manager.Enabled {
+		t.Fatalf("expected storage-only compatibility to enable the manager host: components=%#v manager=%#v", compiled.Components, compiled.Manager)
+	}
+	if compiled.Manager.Replicas != 2 {
+		t.Fatalf("manager host replicas = %d, want storage replicas 2", compiled.Manager.Replicas)
+	}
+	if compiled.Components.EnableCtld || compiled.Manager.Config.CtldEnabled {
+		t.Fatalf("storage-only compatibility must not enable ctld: components=%#v config=%#v", compiled.Components, compiled.Manager.Config)
+	}
+	if _, ok := compiled.Manager.SandboxPodPlacement.NodeSelector[dataplane.NodeDataPlaneReadyLabel]; ok {
+		t.Fatalf("storage-only compatibility must not require data-plane-ready nodes: %#v", compiled.Manager.SandboxPodPlacement.NodeSelector)
+	}
+	if containsString(compiled.Status.ExpectedConditions, infrav1alpha1.ConditionTypeManagerReady) {
+		t.Fatalf("storage-only compatibility must not expose ManagerReady: %#v", compiled.Status.ExpectedConditions)
+	}
+	if !containsString(compiled.Status.ExpectedConditions, infrav1alpha1.ConditionTypeStorageProxyReady) {
+		t.Fatalf("expected StorageProxyReady condition: %#v", compiled.Status.ExpectedConditions)
+	}
+
+	for _, name := range []string{"manager-rbac", "manager", "storage-proxy"} {
+		step, ok := findWorkflowStep(compiled.Workflow.Steps, name)
+		if !ok {
+			t.Fatalf("expected %q workflow step: %#v", name, compiled.Workflow.Steps)
+		}
+		if step.ConditionType != infrav1alpha1.ConditionTypeStorageProxyReady {
+			t.Fatalf("%s condition = %q, want %q", name, step.ConditionType, infrav1alpha1.ConditionTypeStorageProxyReady)
+		}
+		if name == "manager" && step.SuccessReason != "ManagerHostReady" {
+			t.Fatalf("manager host success reason = %q, want ManagerHostReady", step.SuccessReason)
+		}
+	}
+	for _, name := range []string{"ctld", "ctld-ready", "data-plane-node-readiness", "builtin-template-pods"} {
+		if _, ok := findWorkflowStep(compiled.Workflow.Steps, name); ok {
+			t.Fatalf("storage-only compatibility must not add %q: %#v", name, compiled.Workflow.Steps)
+		}
+	}
+
+	for _, retained := range []ResourceRef{
+		{Kind: "Deployment", Namespace: infra.Namespace, Name: "demo-manager"},
+		{Kind: "Service", Namespace: infra.Namespace, Name: "demo-manager"},
+		{Kind: "ClusterRole", Name: "demo-manager"},
+	} {
+		if containsResourceRef(compiled.Cleanup.DeleteNamespaced, compiled.Cleanup.DeleteClusterScoped, retained) {
+			t.Fatalf("manager host resource should be retained for storage-only compatibility: %#v", retained)
+		}
+	}
+}
+
+func TestCompileManagerHostUsesMaximumEnabledReplicaCount(t *testing.T) {
+	infra := &infrav1alpha1.Sandbox0Infra{
+		Spec: infrav1alpha1.Sandbox0InfraSpec{
+			Services: &infrav1alpha1.ServicesConfig{
+				Manager: &infrav1alpha1.ManagerServiceConfig{
+					WorkloadServiceConfig: infrav1alpha1.WorkloadServiceConfig{
+						EnabledServiceConfig: infrav1alpha1.EnabledServiceConfig{Enabled: true},
+						Replicas:             2,
+					},
+				},
+				StorageProxy: &infrav1alpha1.StorageProxyServiceConfig{
+					WorkloadServiceConfig: infrav1alpha1.WorkloadServiceConfig{
+						EnabledServiceConfig: infrav1alpha1.EnabledServiceConfig{Enabled: true},
+						Replicas:             3,
+					},
+				},
+			},
+		},
+	}
+
+	compiled := Compile(infra)
+
+	if compiled.Manager.Replicas != 3 {
+		t.Fatalf("manager host replicas = %d, want max(manager=2, storage=3)=3", compiled.Manager.Replicas)
+	}
+	if len(compiled.Validation.FatalErrors) != 0 {
+		t.Fatalf("replica normalization should not be fatal: %#v", compiled.Validation.FatalErrors)
+	}
+	for _, name := range []string{"manager-rbac", "manager"} {
+		step, ok := findWorkflowStep(compiled.Workflow.Steps, name)
+		if !ok || step.ConditionType != infrav1alpha1.ConditionTypeManagerReady {
+			t.Fatalf("full manager workflow step %q should use ManagerReady: %#v", name, step)
+		}
+		if name == "manager" && step.SuccessReason != "ManagerReady" {
+			t.Fatalf("full manager success reason = %q, want ManagerReady", step.SuccessReason)
+		}
+	}
 }
 
 func TestCompileTracksWorkflowRequirements(t *testing.T) {
@@ -1169,17 +1305,19 @@ func TestCompileTracksWorkflowRequirements(t *testing.T) {
 		"scheduler-enterprise-license",
 		"scheduler-rbac",
 		"scheduler",
-		"cluster-gateway-enterprise-license",
-		"cluster-gateway",
-		"ctld",
 		"manager-rbac",
 		"manager",
-		"netd-rbac",
-		"netd",
+		"cluster-gateway-enterprise-license",
+		"cluster-gateway",
+		"storage-proxy",
+		"legacy-netd-handoff",
+		"ctld",
+		"legacy-netd-standby",
+		"ctld-ready",
+		"netd-ready",
+		"legacy-netd-cleanup",
 		"data-plane-node-readiness",
 		"builtin-template-pods",
-		"storage-proxy-rbac",
-		"storage-proxy",
 		"register-cluster",
 	}
 	if len(got) != len(want) {
@@ -1325,6 +1463,7 @@ func TestCompileTracksCleanupPlan(t *testing.T) {
 		{Kind: "Deployment", Namespace: "sandbox0-system", Name: "demo-egress-broker"},
 		{Kind: "ClusterRole", Name: "demo-manager"},
 		{Kind: "ClusterRoleBinding", Name: "demo-netd"},
+		{Kind: "ConfigMap", Namespace: "sandbox0-system", Name: "demo-manager-storage"},
 	} {
 		if !containsResourceRef(compiled.Cleanup.DeleteNamespaced, compiled.Cleanup.DeleteClusterScoped, want) {
 			t.Fatalf("expected cleanup target %#v, got namespaced=%#v cluster=%#v", want, compiled.Cleanup.DeleteNamespaced, compiled.Cleanup.DeleteClusterScoped)
@@ -1360,4 +1499,13 @@ func workflowStepNames(steps []WorkflowStepPlan) []string {
 		names = append(names, step.Name)
 	}
 	return names
+}
+
+func findWorkflowStep(steps []WorkflowStepPlan, name string) (WorkflowStepPlan, bool) {
+	for _, step := range steps {
+		if step.Name == name {
+			return step, true
+		}
+	}
+	return WorkflowStepPlan{}, false
 }

--- a/infra-operator/internal/plan/plan_test.go
+++ b/infra-operator/internal/plan/plan_test.go
@@ -1459,6 +1459,7 @@ func TestCompileTracksCleanupPlan(t *testing.T) {
 		{Kind: "Deployment", Namespace: "sandbox0-system", Name: "demo-global-gateway"},
 		{Kind: "Deployment", Namespace: "sandbox0-system", Name: "demo-manager"},
 		{Kind: "DaemonSet", Namespace: "sandbox0-system", Name: "demo-netd"},
+		{Kind: "Service", Namespace: "sandbox0-system", Name: "demo-netd-metrics"},
 		{Kind: "StatefulSet", Namespace: "sandbox0-system", Name: "demo-postgres"},
 		{Kind: "Deployment", Namespace: "sandbox0-system", Name: "demo-egress-broker"},
 		{Kind: "ClusterRole", Name: "demo-manager"},

--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -45,6 +45,8 @@ import (
 	templreconciler "github.com/sandbox0-ai/sandbox0/pkg/template/reconciler"
 	templstorepg "github.com/sandbox0-ai/sandbox0/pkg/template/store/pg"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/objectstore"
+	storageproxyruntime "github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/runtime"
+	"github.com/sirupsen/logrus"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/informers"
@@ -369,6 +371,56 @@ func main() {
 		logger.Info("Internal auth generators initialized for procd and storage-proxy communication")
 	}
 
+	// The embedded storage runtime has an independent config file because the
+	// manager and storage-proxy schemas contain overlapping keys such as
+	// http_port and database_schema.
+	var embeddedStorageRuntime *storageproxyruntime.Runtime
+	if storageConfigPath := strings.TrimSpace(os.Getenv("STORAGE_PROXY_CONFIG_PATH")); storageConfigPath != "" {
+		storageCfg, loadErr := config.ReadStorageProxyConfig(storageConfigPath)
+		if loadErr != nil {
+			logger.Fatal("Failed to load embedded storage-proxy config",
+				zap.String("path", storageConfigPath),
+				zap.Error(loadErr),
+			)
+		}
+		storageLogrusLogger := logrus.New()
+		storageLogrusLogger.SetFormatter(&logrus.JSONFormatter{})
+		storageLogrusLogger.SetOutput(os.Stdout)
+		storageLogLevel, parseErr := logrus.ParseLevel(storageCfg.LogLevel)
+		if parseErr != nil {
+			storageLogLevel = logrus.InfoLevel
+		}
+		storageLogrusLogger.SetLevel(storageLogLevel)
+
+		embeddedStorageRuntime, err = storageproxyruntime.New(ctx, storageproxyruntime.Options{
+			Config:        storageCfg,
+			Logger:        logger,
+			LogrusLogger:  storageLogrusLogger,
+			Observability: obsProvider,
+			K8sClient:     k8sClient,
+		})
+		if err != nil {
+			logger.Fatal("Failed to initialize embedded storage-proxy runtime", zap.Error(err))
+		}
+		if err := embeddedStorageRuntime.Start(ctx); err != nil {
+			logger.Fatal("Failed to start embedded storage-proxy runtime", zap.Error(err))
+		}
+		go func() {
+			select {
+			case runtimeErr := <-embeddedStorageRuntime.Errors():
+				logger.Error("Embedded storage-proxy runtime failed", zap.Error(runtimeErr))
+				cancel()
+			case <-ctx.Done():
+			}
+		}()
+		logger.Info("Embedded storage-proxy runtime started",
+			zap.String("configPath", storageConfigPath),
+			zap.String("address", embeddedStorageRuntime.Address()),
+		)
+	} else {
+		logger.Info("Embedded storage-proxy runtime disabled; STORAGE_PROXY_CONFIG_PATH is not set")
+	}
+
 	// Parse ratios
 	pauseMemoryBufferRatio, err := strconv.ParseFloat(cfg.PauseMemoryBufferRatio, 64)
 	if err != nil {
@@ -434,7 +486,17 @@ func main() {
 	} else if rootFSObjectStore != nil {
 		sandboxService.SetRootFSObjectDeleter(rootFSObjectStore)
 	}
-	if cfg.StorageProxyBaseURL != "" && cfg.StorageProxyHTTPPort > 0 && storageProxyAdminTokenGenerator != nil {
+	if embeddedStorageRuntime != nil && storageProxyAdminTokenGenerator != nil {
+		internalHTTPClient := embeddedStorageRuntime.InternalHTTPClient()
+		internalHTTPClient.Timeout = cfg.ProcdClientTimeout.Duration
+		sandboxService.SetWebhookStateVolumeClient(service.NewStorageProxyVolumeClient(service.StorageProxyVolumeClientConfig{
+			BaseURL:        "http://storage-proxy",
+			HTTPClient:     internalHTTPClient,
+			TokenGenerator: storageProxyAdminTokenGenerator,
+			ClusterID:      cfg.DefaultClusterId,
+		}))
+		logger.Info("Webhook state volumes use the embedded storage-proxy runtime")
+	} else if cfg.StorageProxyBaseURL != "" && cfg.StorageProxyHTTPPort > 0 && storageProxyAdminTokenGenerator != nil {
 		storageProxyBaseURL := fmt.Sprintf("http://%s:%d", strings.TrimSpace(cfg.StorageProxyBaseURL), cfg.StorageProxyHTTPPort)
 		sandboxService.SetWebhookStateVolumeClient(service.NewStorageProxyVolumeClient(service.StorageProxyVolumeClientConfig{
 			BaseURL:        storageProxyBaseURL,
@@ -664,6 +726,13 @@ func main() {
 	// Wait for termination signal
 	<-ctx.Done()
 	logger.Info("Shutting down gracefully")
+	if embeddedStorageRuntime != nil {
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		if err := embeddedStorageRuntime.Shutdown(shutdownCtx); err != nil {
+			logger.Error("Embedded storage-proxy shutdown reported errors", zap.Error(err))
+		}
+		shutdownCancel()
+	}
 
 	// Give components time to shut down
 	time.Sleep(2 * time.Second)

--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -84,6 +84,9 @@ func main() {
 	// Create context that cancels on signal
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
+	templateReconcilerQuiesceSignals := make(chan os.Signal, 1)
+	signal.Notify(templateReconcilerQuiesceSignals, syscall.SIGUSR1)
+	defer signal.Stop(templateReconcilerQuiesceSignals)
 
 	// Initialize observability provider
 	obsProvider, err := observability.New(observability.ConfigFromEnv("manager", logger))
@@ -572,6 +575,14 @@ func main() {
 	} else {
 		logger.Info("Template store disabled; manager will apply templates directly")
 	}
+	go serveTemplateReconcilerQuiesceSignals(
+		ctx,
+		templateReconcilerQuiesceSignals,
+		templateReconciler,
+		defaultTemplateReconcilerQuiesceSupportedMarkerPath,
+		defaultTemplateReconcilerQuiescedMarkerPath,
+		logger,
+	)
 
 	// Create cluster service (for scheduler)
 	clusterService := service.NewClusterService(
@@ -738,6 +749,57 @@ func main() {
 	time.Sleep(2 * time.Second)
 
 	logger.Info("Manager stopped")
+}
+
+type templateReconcilerQuiescer interface {
+	Quiesce(context.Context) error
+}
+
+const (
+	defaultTemplateReconcilerQuiesceSupportedMarkerPath = "/tmp/sandbox0-manager-template-reconciler-quiesce-supported"
+	defaultTemplateReconcilerQuiescedMarkerPath         = "/tmp/sandbox0-manager-template-reconciler-quiesced"
+)
+
+// serveTemplateReconcilerQuiesceSignals exposes a process-local maintenance
+// barrier without stopping the manager APIs needed to drain sandbox volumes.
+func serveTemplateReconcilerQuiesceSignals(
+	ctx context.Context,
+	signals <-chan os.Signal,
+	reconciler templateReconcilerQuiescer,
+	supportedMarkerPath string,
+	quiescedMarkerPath string,
+	logger *zap.Logger,
+) {
+	if err := os.Remove(quiescedMarkerPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		logger.Error("Failed to clear stale template reconciliation quiesce acknowledgement", zap.Error(err))
+		return
+	}
+	if err := os.WriteFile(supportedMarkerPath, nil, 0o600); err != nil {
+		logger.Error("Failed to publish template reconciliation quiesce support", zap.Error(err))
+	} else {
+		logger.Info("Template reconciliation quiesce signal enabled")
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-signals:
+			if reconciler != nil {
+				quiesceCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+				err := reconciler.Quiesce(quiesceCtx)
+				cancel()
+				if err != nil {
+					logger.Error("Failed to quiesce template reconciliation", zap.Error(err))
+					continue
+				}
+			}
+			if err := os.WriteFile(quiescedMarkerPath, nil, 0o600); err != nil {
+				logger.Error("Failed to acknowledge quiesced template reconciliation", zap.Error(err))
+				continue
+			}
+			logger.Info("Template reconciliation quiesced")
+		}
+	}
 }
 
 // buildKubeConfig builds Kubernetes config

--- a/manager/cmd/manager/main_test.go
+++ b/manager/cmd/manager/main_test.go
@@ -1,11 +1,77 @@
 package main
 
 import (
+	"context"
+	"os"
+	"path/filepath"
+	"syscall"
 	"testing"
+	"time"
 
 	s0k8s "github.com/sandbox0-ai/sandbox0/pkg/k8s"
+	"go.uber.org/zap"
 	"k8s.io/client-go/rest"
 )
+
+type recordingTemplateReconcilerQuiescer struct {
+	called  chan struct{}
+	release chan struct{}
+}
+
+func (q *recordingTemplateReconcilerQuiescer) Quiesce(context.Context) error {
+	close(q.called)
+	<-q.release
+	return nil
+}
+
+func TestServeTemplateReconcilerQuiesceSignals(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	signals := make(chan os.Signal, 1)
+	quiescer := &recordingTemplateReconcilerQuiescer{
+		called:  make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	tempDir := t.TempDir()
+	supportedMarkerPath := filepath.Join(tempDir, "supported")
+	quiescedMarkerPath := filepath.Join(tempDir, "quiesced")
+
+	go serveTemplateReconcilerQuiesceSignals(
+		ctx,
+		signals,
+		quiescer,
+		supportedMarkerPath,
+		quiescedMarkerPath,
+		zap.NewNop(),
+	)
+	waitForTestFile(t, supportedMarkerPath)
+	signals <- syscall.SIGUSR1
+
+	select {
+	case <-quiescer.called:
+	case <-time.After(time.Second):
+		t.Fatal("quiesce signal was not handled")
+	}
+	if _, err := os.Stat(quiescedMarkerPath); !os.IsNotExist(err) {
+		t.Fatalf("quiesced marker exists before reconciliation drained: %v", err)
+	}
+	close(quiescer.release)
+	waitForTestFile(t, quiescedMarkerPath)
+}
+
+func waitForTestFile(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for {
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("marker %q was not created", path)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
 
 func TestConfigureK8sClientRateLimiterUsesConfiguredValues(t *testing.T) {
 	cfg := &rest.Config{}

--- a/netd/cmd/netd/main.go
+++ b/netd/cmd/netd/main.go
@@ -2,16 +2,33 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
+	"time"
 
 	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
+	"github.com/sandbox0-ai/sandbox0/netd/pkg/activeguard"
 	"github.com/sandbox0-ai/sandbox0/netd/pkg/daemon"
 	"github.com/sandbox0-ai/sandbox0/pkg/observability"
 	"go.uber.org/zap"
 )
+
+const standbyReacquireYield = time.Second
+
+type activeLock interface {
+	Close() error
+}
+
+type netdRunner interface {
+	Run(context.Context) error
+}
+
+type activeLockAcquire func(context.Context, string) (activeLock, error)
+type netdRunnerFactory func() netdRunner
 
 func main() {
 	cfg := config.LoadNetdConfig()
@@ -43,8 +60,129 @@ func main() {
 	}
 	defer obsProvider.Shutdown(ctx)
 
-	daemon := daemon.New(cfg, logger, obsProvider)
-	if err := daemon.Run(ctx); err != nil {
+	runnerFactory := func() netdRunner { return daemon.New(cfg, logger, obsProvider) }
+	lockPath := strings.TrimSpace(os.Getenv(activeguard.EnvPath))
+	if lockPath != "" {
+		initialDelay, err := parseActiveLockInitialDelay(os.Getenv(activeguard.EnvInitialDelay))
+		if err != nil {
+			logger.Fatal("Invalid node-local netd active lock initial delay", zap.Error(err))
+		}
+		maxHold, err := parseActiveLockDuration(activeguard.EnvMaxHold, os.Getenv(activeguard.EnvMaxHold))
+		if err != nil {
+			logger.Fatal("Invalid node-local netd active lock maximum hold", zap.Error(err))
+		}
+		if maxHold > 0 {
+			logger.Info("Configured bounded node-local netd active lock hold", zap.Duration("max_hold", maxHold))
+		}
+		err = runGuardedNetd(
+			ctx,
+			lockPath,
+			initialDelay,
+			maxHold,
+			standbyReacquireYield,
+			func(ctx context.Context, path string) (activeLock, error) {
+				logger.Info("Waiting for node-local netd active lock", zap.String("path", path))
+				guard, acquireErr := activeguard.Acquire(ctx, path)
+				if acquireErr == nil {
+					logger.Info("Acquired node-local netd active lock", zap.String("path", path))
+				}
+				return guard, acquireErr
+			},
+			runnerFactory,
+			func(runErr error) {
+				logger.Info("Yielding node-local netd active lock for embedded ctld retry", zap.Error(runErr))
+			},
+		)
+	} else {
+		err = runnerFactory().Run(ctx)
+	}
+	if err != nil && !errors.Is(err, context.Canceled) {
 		logger.Fatal("netd exited with error", zap.Error(err))
 	}
+}
+
+func runGuardedNetd(
+	ctx context.Context,
+	lockPath string,
+	initialDelay, maxHold, reacquireYield time.Duration,
+	acquire activeLockAcquire,
+	newRunner netdRunnerFactory,
+	onYield func(error),
+) error {
+	if acquire == nil || newRunner == nil {
+		return fmt.Errorf("active lock acquire and netd runner factory are required")
+	}
+	if err := waitForDuration(ctx, initialDelay); err != nil {
+		return err
+	}
+	for {
+		guard, err := acquire(ctx, lockPath)
+		if err != nil {
+			return err
+		}
+
+		runCtx := ctx
+		cancel := func() {}
+		if maxHold > 0 {
+			runCtx, cancel = context.WithTimeout(ctx, maxHold)
+		}
+		runErr := newRunner().Run(runCtx)
+		cycleExpired := errors.Is(runCtx.Err(), context.DeadlineExceeded)
+		cancel()
+		closeErr := guard.Close()
+		if closeErr != nil {
+			return errors.Join(runErr, fmt.Errorf("release node-local netd active lock: %w", closeErr))
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if maxHold <= 0 {
+			if runErr == nil {
+				return fmt.Errorf("netd stopped unexpectedly")
+			}
+			return runErr
+		}
+		if runErr == nil && !cycleExpired {
+			runErr = fmt.Errorf("netd stopped unexpectedly")
+		}
+		if onYield != nil {
+			onYield(runErr)
+		}
+		if err := waitForDuration(ctx, reacquireYield); err != nil {
+			return err
+		}
+	}
+}
+
+func waitForDuration(ctx context.Context, delay time.Duration) error {
+	if delay <= 0 {
+		return ctx.Err()
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func parseActiveLockInitialDelay(raw string) (time.Duration, error) {
+	return parseActiveLockDuration(activeguard.EnvInitialDelay, raw)
+}
+
+func parseActiveLockDuration(envName, raw string) (time.Duration, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0, nil
+	}
+	delay, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("parse %s: %w", envName, err)
+	}
+	if delay < 0 {
+		return 0, fmt.Errorf("%s must not be negative", envName)
+	}
+	return delay, nil
 }

--- a/netd/cmd/netd/main.go
+++ b/netd/cmd/netd/main.go
@@ -62,19 +62,20 @@ func main() {
 
 	runnerFactory := func() netdRunner { return daemon.New(cfg, logger, obsProvider) }
 	lockPath := strings.TrimSpace(os.Getenv(activeguard.EnvPath))
+	var runErr error
 	if lockPath != "" {
-		initialDelay, err := parseActiveLockInitialDelay(os.Getenv(activeguard.EnvInitialDelay))
-		if err != nil {
-			logger.Fatal("Invalid node-local netd active lock initial delay", zap.Error(err))
+		initialDelay, parseErr := parseActiveLockInitialDelay(os.Getenv(activeguard.EnvInitialDelay))
+		if parseErr != nil {
+			logger.Fatal("Invalid node-local netd active lock initial delay", zap.Error(parseErr))
 		}
-		maxHold, err := parseActiveLockDuration(activeguard.EnvMaxHold, os.Getenv(activeguard.EnvMaxHold))
-		if err != nil {
-			logger.Fatal("Invalid node-local netd active lock maximum hold", zap.Error(err))
+		maxHold, parseErr := parseActiveLockDuration(activeguard.EnvMaxHold, os.Getenv(activeguard.EnvMaxHold))
+		if parseErr != nil {
+			logger.Fatal("Invalid node-local netd active lock maximum hold", zap.Error(parseErr))
 		}
 		if maxHold > 0 {
 			logger.Info("Configured bounded node-local netd active lock hold", zap.Duration("max_hold", maxHold))
 		}
-		err = runGuardedNetd(
+		runErr = runGuardedNetd(
 			ctx,
 			lockPath,
 			initialDelay,
@@ -94,10 +95,10 @@ func main() {
 			},
 		)
 	} else {
-		err = runnerFactory().Run(ctx)
+		runErr = runnerFactory().Run(ctx)
 	}
-	if err != nil && !errors.Is(err, context.Canceled) {
-		logger.Fatal("netd exited with error", zap.Error(err))
+	if runErr != nil && !errors.Is(runErr, context.Canceled) {
+		logger.Fatal("netd exited with error", zap.Error(runErr))
 	}
 }
 

--- a/netd/cmd/netd/main_test.go
+++ b/netd/cmd/netd/main_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestParseActiveLockInitialDelay(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    time.Duration
+		wantErr bool
+	}{
+		{name: "empty"},
+		{name: "duration", raw: " 30s ", want: 30 * time.Second},
+		{name: "invalid", raw: "later", wantErr: true},
+		{name: "negative", raw: "-1s", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseActiveLockInitialDelay(tt.raw)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseActiveLockInitialDelay(%q) error = %v, wantErr %v", tt.raw, err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Fatalf("parseActiveLockInitialDelay(%q) = %s, want %s", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+type testActiveLock struct {
+	onClose func()
+}
+
+func (g *testActiveLock) Close() error {
+	if g.onClose != nil {
+		g.onClose()
+	}
+	return nil
+}
+
+type testNetdRunner struct {
+	run func(context.Context) error
+}
+
+func (r testNetdRunner) Run(ctx context.Context) error { return r.run(ctx) }
+
+func TestRunGuardedNetdRepeatedlyYieldsAndReacquiresInProcess(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var mu sync.Mutex
+	events := make([]string, 0, 5)
+	acquires := 0
+	runs := 0
+	err := runGuardedNetd(
+		ctx,
+		"/tmp/test-netd.lock",
+		0,
+		10*time.Millisecond,
+		time.Millisecond,
+		func(context.Context, string) (activeLock, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			acquires++
+			cycle := acquires
+			events = append(events, "acquire")
+			return &testActiveLock{onClose: func() {
+				mu.Lock()
+				defer mu.Unlock()
+				events = append(events, "close")
+				if cycle == 2 {
+					cancel()
+				}
+			}}, nil
+		},
+		func() netdRunner {
+			runs++
+			return testNetdRunner{run: func(runCtx context.Context) error {
+				<-runCtx.Done()
+				return runCtx.Err()
+			}}
+		},
+		nil,
+	)
+	if err == nil || err != context.Canceled {
+		t.Fatalf("runGuardedNetd() error = %v, want context canceled", err)
+	}
+	if acquires != 2 || runs != 2 {
+		t.Fatalf("acquires=%d runs=%d, want two in-process cycles", acquires, runs)
+	}
+	wantEvents := []string{"acquire", "close", "acquire", "close"}
+	for i := range wantEvents {
+		if i >= len(events) || events[i] != wantEvents[i] {
+			t.Fatalf("events = %#v, want %#v", events, wantEvents)
+		}
+	}
+}

--- a/netd/pkg/activeguard/guard_linux.go
+++ b/netd/pkg/activeguard/guard_linux.go
@@ -1,0 +1,96 @@
+//go:build linux
+
+// Package activeguard fences node-local netd runtimes during workload and ctld
+// HA transitions.
+package activeguard
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	// EnvPath configures the shared node-local lock path.
+	EnvPath = "NETD_ACTIVE_LOCK_PATH"
+	// EnvInitialDelay gives a migration standby an acquisition head start to
+	// the embedded ctld runtime before it begins waiting on the shared lock.
+	EnvInitialDelay = "NETD_ACTIVE_LOCK_INITIAL_DELAY"
+	// EnvMaxHold makes a migration fallback periodically yield the lock so a
+	// recovered embedded ctld runtime can retry without manual intervention.
+	EnvMaxHold = "NETD_ACTIVE_LOCK_MAX_HOLD"
+	retryDelay = 100 * time.Millisecond
+)
+
+// Guard owns the node-local exclusive netd lock.
+type Guard struct {
+	file      *os.File
+	closeOnce sync.Once
+	closeErr  error
+}
+
+// Acquire waits until ctx is canceled or this process exclusively owns path.
+func Acquire(ctx context.Context, path string) (*Guard, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil, fmt.Errorf("netd active lock path is required")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, fmt.Errorf("create netd active lock directory: %w", err)
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open netd active lock: %w", err)
+	}
+	for {
+		if err := ctx.Err(); err != nil {
+			_ = file.Close()
+			return nil, err
+		}
+		err = unix.Flock(int(file.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+		if err == nil {
+			return &Guard{file: file}, nil
+		}
+		if !errors.Is(err, unix.EWOULDBLOCK) && !errors.Is(err, unix.EAGAIN) {
+			_ = file.Close()
+			return nil, fmt.Errorf("acquire netd active lock: %w", err)
+		}
+		timer := time.NewTimer(retryDelay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			_ = file.Close()
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+// Close releases the active lock.
+func (g *Guard) Close() error {
+	if g == nil {
+		return nil
+	}
+	g.closeOnce.Do(func() {
+		if g.file == nil {
+			return
+		}
+		if err := unix.Flock(int(g.file.Fd()), unix.LOCK_UN); err != nil {
+			g.closeErr = err
+		}
+		if err := g.file.Close(); err != nil && g.closeErr == nil {
+			g.closeErr = err
+		}
+	})
+	return g.closeErr
+}

--- a/netd/pkg/activeguard/guard_linux_test.go
+++ b/netd/pkg/activeguard/guard_linux_test.go
@@ -1,0 +1,74 @@
+//go:build linux
+
+package activeguard
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestGuardSerializesActiveNetdAndTransfersOwnership(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "netd.lock")
+	first, err := Acquire(context.Background(), path)
+	if err != nil {
+		t.Fatalf("Acquire(first) error = %v", err)
+	}
+
+	secondResult := make(chan *Guard, 1)
+	secondErrors := make(chan error, 1)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	go func() {
+		second, acquireErr := Acquire(ctx, path)
+		if acquireErr != nil {
+			secondErrors <- acquireErr
+			return
+		}
+		secondResult <- second
+	}()
+	select {
+	case second := <-secondResult:
+		_ = second.Close()
+		t.Fatal("second guard acquired before first released")
+	case err := <-secondErrors:
+		t.Fatalf("Acquire(second) early error = %v", err)
+	case <-time.After(150 * time.Millisecond):
+	}
+	if err := first.Close(); err != nil {
+		t.Fatalf("Close(first) error = %v", err)
+	}
+	select {
+	case second := <-secondResult:
+		defer second.Close()
+	case err := <-secondErrors:
+		t.Fatalf("Acquire(second) error = %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("second guard did not acquire after release")
+	}
+}
+
+func TestGuardWaitHonorsCancellation(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "netd.lock")
+	first, err := Acquire(context.Background(), path)
+	if err != nil {
+		t.Fatalf("Acquire(first) error = %v", err)
+	}
+	defer first.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := Acquire(ctx, path); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Acquire(canceled) error = %v, want context canceled", err)
+	}
+}
+
+func TestGuardDoesNotAcquireAnAvailableLockAfterCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := Acquire(ctx, filepath.Join(t.TempDir(), "netd.lock")); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Acquire(canceled, available) error = %v, want context canceled", err)
+	}
+}

--- a/netd/pkg/activeguard/guard_stub.go
+++ b/netd/pkg/activeguard/guard_stub.go
@@ -1,0 +1,24 @@
+//go:build !linux
+
+// Package activeguard fences node-local netd runtimes during workload and ctld
+// HA transitions.
+package activeguard
+
+import (
+	"context"
+	"fmt"
+)
+
+const (
+	EnvPath         = "NETD_ACTIVE_LOCK_PATH"
+	EnvInitialDelay = "NETD_ACTIVE_LOCK_INITIAL_DELAY"
+	EnvMaxHold      = "NETD_ACTIVE_LOCK_MAX_HOLD"
+)
+
+type Guard struct{}
+
+func Acquire(context.Context, string) (*Guard, error) {
+	return nil, fmt.Errorf("netd active guard is only supported on Linux")
+}
+
+func (*Guard) Close() error { return nil }

--- a/netd/pkg/daemon/daemon.go
+++ b/netd/pkg/daemon/daemon.go
@@ -85,14 +85,22 @@ func (d *Daemon) Run(ctx context.Context) error {
 	if d.cfg == nil {
 		return fmt.Errorf("netd config is nil")
 	}
+	d.ready.Store(false)
+	defer d.ready.Store(false)
 	runCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	if err := d.startServers(); err != nil {
+	serverExitCh := make(chan error, 2)
+	if err := d.startServers(serverExitCh); err != nil {
+		shutdownCtx, shutdownCancel := d.shutdownContext()
+		defer shutdownCancel()
+		_ = d.shutdown(shutdownCtx)
 		return err
 	}
 	proxyExitCh := make(chan error, 1)
 	if err := d.runNetd(runCtx, cancel, proxyExitCh); err != nil {
-		return err
+		shutdownCtx, shutdownCancel := d.shutdownContext()
+		defer shutdownCancel()
+		return errors.Join(err, d.shutdown(shutdownCtx))
 	}
 
 	var runErr error
@@ -100,16 +108,14 @@ func (d *Daemon) Run(ctx context.Context) error {
 	case <-ctx.Done():
 	case runErr = <-proxyExitCh:
 		cancel()
+	case runErr = <-serverExitCh:
+		cancel()
 	}
 
 	<-runCtx.Done()
 
-	shutdownCtx := context.Background()
-	if d.cfg.ShutdownDelay.Duration > 0 {
-		var cancel context.CancelFunc
-		shutdownCtx, cancel = context.WithTimeout(context.Background(), d.cfg.ShutdownDelay.Duration)
-		defer cancel()
-	}
+	shutdownCtx, shutdownCancel := d.shutdownContext()
+	defer shutdownCancel()
 	shutdownErr := d.shutdown(shutdownCtx)
 	if runErr != nil && !errors.Is(runErr, context.Canceled) {
 		if shutdownErr != nil {
@@ -118,6 +124,19 @@ func (d *Daemon) Run(ctx context.Context) error {
 		return runErr
 	}
 	return shutdownErr
+}
+
+// Ready reports whether netd has successfully synchronized node redirect
+// state. Embedded runtimes use it to include netd in their own readiness gate.
+func (d *Daemon) Ready() bool {
+	return d != nil && d.ready.Load()
+}
+
+func (d *Daemon) shutdownContext() (context.Context, context.CancelFunc) {
+	if d.cfg != nil && d.cfg.ShutdownDelay.Duration > 0 {
+		return context.WithTimeout(context.Background(), d.cfg.ShutdownDelay.Duration)
+	}
+	return context.WithCancel(context.Background())
 }
 
 func (d *Daemon) runNetd(ctx context.Context, cancel context.CancelFunc, proxyExitCh chan<- error) error {
@@ -702,7 +721,7 @@ func cleanupDeniedTrackedFlows(
 	return len(flowsToKill)
 }
 
-func (d *Daemon) startServers() error {
+func (d *Daemon) startServers(serverErrors chan<- error) error {
 	healthMux := http.NewServeMux()
 	healthMux.HandleFunc("/healthz", d.handleHealth)
 	healthMux.HandleFunc("/readyz", d.handleReady)
@@ -721,17 +740,17 @@ func (d *Daemon) startServers() error {
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 
-	if err := d.listenAndServe(d.healthServer, "health"); err != nil {
+	if err := d.listenAndServe(d.healthServer, "health", serverErrors); err != nil {
 		return err
 	}
-	if err := d.listenAndServe(d.metricsServer, "metrics"); err != nil {
+	if err := d.listenAndServe(d.metricsServer, "metrics", serverErrors); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (d *Daemon) listenAndServe(server *http.Server, name string) error {
+func (d *Daemon) listenAndServe(server *http.Server, name string, serverErrors chan<- error) error {
 	if server == nil {
 		return fmt.Errorf("server %s is nil", name)
 	}
@@ -746,16 +765,22 @@ func (d *Daemon) listenAndServe(server *http.Server, name string) error {
 
 	go func() {
 		if err := server.Serve(ln); err != nil && err != http.ErrServerClosed {
+			wrapped := fmt.Errorf("%s HTTP server: %w", name, err)
 			d.logger.Error("HTTP server error",
 				zap.String("name", name),
 				zap.Error(err),
 			)
+			select {
+			case serverErrors <- wrapped:
+			default:
+			}
 		}
 	}()
 	return nil
 }
 
 func (d *Daemon) shutdown(ctx context.Context) error {
+	d.ready.Store(false)
 	var shutdownErr error
 	if d.proxyServer != nil {
 		if err := d.proxyServer.Shutdown(ctx); err != nil {

--- a/netd/pkg/daemon/daemon_lifecycle_test.go
+++ b/netd/pkg/daemon/daemon_lifecycle_test.go
@@ -58,6 +58,23 @@ func TestShutdownClosesRuntimeResourcesAfterMeteringLoopStops(t *testing.T) {
 	}
 }
 
+func TestReadyReflectsSynchronizedRuntimeState(t *testing.T) {
+	d := &Daemon{}
+	if d.Ready() {
+		t.Fatal("new daemon is ready")
+	}
+
+	d.ready.Store(true)
+	if !d.Ready() {
+		t.Fatal("daemon did not report synchronized state")
+	}
+
+	d.ready.Store(false)
+	if d.Ready() {
+		t.Fatal("daemon remained ready after synchronization was lost")
+	}
+}
+
 func TestRedirectBypassCIDRsIncludesClusterDNSCIDRs(t *testing.T) {
 	got := redirectBypassCIDRs(
 		[]string{"10.96.0.10", "10.244.0.53"},

--- a/pkg/framework/kubectl.go
+++ b/pkg/framework/kubectl.go
@@ -224,6 +224,251 @@ func KubectlDeleteNamespace(ctx context.Context, kubeconfig, namespace string) e
 	return Kubectl(ctx, kubeconfig, "delete", "namespace", namespace, "--ignore-not-found=true", "--wait=false")
 }
 
+const (
+	managerTemplateReconcilerQuiesceSupportedMarkerPath = "/tmp/sandbox0-manager-template-reconciler-quiesce-supported"
+	managerTemplateReconcilerQuiescedMarkerPath         = "/tmp/sandbox0-manager-template-reconciler-quiesced"
+)
+
+// KubectlQuiesceManagerTemplateReconcilers stops background template syncing in
+// every running manager Pod while leaving manager-hosted storage available.
+func KubectlQuiesceManagerTemplateReconcilers(ctx context.Context, kubeconfig, namespace, timeout string) error {
+	if ctx == nil {
+		return fmt.Errorf("context is required")
+	}
+	if namespace == "" {
+		return fmt.Errorf("namespace is required")
+	}
+	timeoutDuration, err := time.ParseDuration(timeout)
+	if err != nil {
+		return fmt.Errorf("parse timeout %q: %w", timeout, err)
+	}
+	namespaceResource, err := KubectlOutput(
+		ctx,
+		kubeconfig,
+		"get",
+		"namespace",
+		namespace,
+		"--ignore-not-found=true",
+		"-o",
+		"name",
+	)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(namespaceResource) == "" {
+		return nil
+	}
+
+	deadline := time.Now().Add(timeoutDuration)
+	quiescedPods := make(map[string]struct{})
+	for {
+		runningPods, ready, err := kubectlReadyManagerPods(ctx, kubeconfig, namespace)
+		if err != nil {
+			return err
+		}
+		if !ready {
+			if err := waitForManagerQuiesceRetry(ctx, deadline, namespace); err != nil {
+				return err
+			}
+			continue
+		}
+
+		newPods := make([]managerPodRef, 0, len(runningPods))
+		for _, pod := range runningPods {
+			if _, ok := quiescedPods[pod.Identity]; ok {
+				continue
+			}
+			if _, err := KubectlExecContainerOutput(
+				ctx,
+				kubeconfig,
+				namespace,
+				pod.Name,
+				"manager",
+				"/bin/sh",
+				"-c",
+				"test -f "+managerTemplateReconcilerQuiesceSupportedMarkerPath,
+			); err != nil {
+				return fmt.Errorf("manager Pod %s/%s does not advertise template reconciliation quiesce support", namespace, pod.Name)
+			}
+			newPods = append(newPods, pod)
+		}
+		for _, pod := range newPods {
+			if _, err := KubectlExecContainerOutput(
+				ctx,
+				kubeconfig,
+				namespace,
+				pod.Name,
+				"manager",
+				"/bin/sh",
+				"-c",
+				"kill -USR1 1",
+			); err != nil {
+				return fmt.Errorf("quiesce manager Pod %s/%s: %w", namespace, pod.Name, err)
+			}
+		}
+		for _, pod := range newPods {
+			if err := kubectlWaitForManagerQuiesceAck(ctx, kubeconfig, namespace, pod.Name, deadline); err != nil {
+				return err
+			}
+			quiescedPods[pod.Identity] = struct{}{}
+		}
+
+		confirmedPods, ready, err := kubectlReadyManagerPods(ctx, kubeconfig, namespace)
+		if err != nil {
+			return err
+		}
+		if ready && sameManagerPodSet(runningPods, confirmedPods) {
+			return nil
+		}
+		if err := waitForManagerQuiesceRetry(ctx, deadline, namespace); err != nil {
+			return err
+		}
+	}
+}
+
+type managerPodRef struct {
+	Name     string
+	Identity string
+}
+
+func kubectlReadyManagerPods(ctx context.Context, kubeconfig, namespace string) ([]managerPodRef, bool, error) {
+	output, err := KubectlOutput(
+		ctx,
+		kubeconfig,
+		"get",
+		"pods",
+		"--namespace",
+		namespace,
+		"-l",
+		"app.kubernetes.io/component=manager",
+		"-o",
+		"json",
+	)
+	if err != nil {
+		return nil, false, err
+	}
+	var pods podList
+	if err := json.Unmarshal([]byte(output), &pods); err != nil {
+		return nil, false, fmt.Errorf("decode manager Pods: %w", err)
+	}
+	deploymentsOutput, err := KubectlOutput(
+		ctx,
+		kubeconfig,
+		"get",
+		"deployments",
+		"--namespace",
+		namespace,
+		"-l",
+		"app.kubernetes.io/component=manager",
+		"-o",
+		"json",
+	)
+	if err != nil {
+		return nil, false, err
+	}
+	var deployments deploymentList
+	if err := json.Unmarshal([]byte(deploymentsOutput), &deployments); err != nil {
+		return nil, false, fmt.Errorf("decode manager Deployments: %w", err)
+	}
+	desiredReplicas := int32(0)
+	for _, deployment := range deployments.Items {
+		if deployment.Spec.Replicas == nil {
+			desiredReplicas++
+		} else {
+			desiredReplicas += *deployment.Spec.Replicas
+		}
+	}
+
+	runningPods := make([]managerPodRef, 0, len(pods.Items))
+	unreadyPods := make([]string, 0)
+	for _, pod := range pods.Items {
+		managerStatus, found := containerStatusByName(pod.Status.ContainerStatuses, "manager")
+		if pod.Status.Phase != "Running" || pod.Metadata.DeletionTimestamp != "" || !found || !managerStatus.Ready {
+			unreadyPods = append(unreadyPods, pod.Metadata.Name+"("+pod.Status.Phase+")")
+			continue
+		}
+		runningPods = append(runningPods, managerPodRef{
+			Name: pod.Metadata.Name,
+			Identity: fmt.Sprintf(
+				"%s/%s/%s/%d",
+				pod.Metadata.UID,
+				pod.Metadata.Name,
+				managerStatus.ContainerID,
+				managerStatus.RestartCount,
+			),
+		})
+	}
+	if len(unreadyPods) > 0 || int32(len(runningPods)) < desiredReplicas {
+		fmt.Printf(
+			"Waiting for manager Pods to stabilize before quiescing: running=%d desired=%d unready=%s\n",
+			len(runningPods),
+			desiredReplicas,
+			strings.Join(unreadyPods, ", "),
+		)
+		return runningPods, false, nil
+	}
+	return runningPods, true, nil
+}
+
+func kubectlWaitForManagerQuiesceAck(ctx context.Context, kubeconfig, namespace, pod string, deadline time.Time) error {
+	var lastErr error
+	for {
+		_, err := KubectlExecContainerOutput(
+			ctx,
+			kubeconfig,
+			namespace,
+			pod,
+			"manager",
+			"/bin/sh",
+			"-c",
+			"test -f "+managerTemplateReconcilerQuiescedMarkerPath,
+		)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		if time.Now().After(deadline) {
+			if lastErr != nil {
+				return fmt.Errorf("wait for manager Pod %s/%s to quiesce: %w", namespace, pod, lastErr)
+			}
+			return fmt.Errorf("timeout waiting for manager Pod %s/%s to quiesce", namespace, pod)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+}
+
+func waitForManagerQuiesceRetry(ctx context.Context, deadline time.Time, namespace string) error {
+	if time.Now().After(deadline) {
+		return fmt.Errorf("timeout waiting for manager Pods in namespace %s to stabilize", namespace)
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(500 * time.Millisecond):
+		return nil
+	}
+}
+
+func sameManagerPodSet(left, right []managerPodRef) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	values := make(map[string]struct{}, len(left))
+	for _, value := range left {
+		values[value.Identity] = struct{}{}
+	}
+	for _, value := range right {
+		if _, ok := values[value.Identity]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
 func withNamespace(namespace string) []string {
 	if namespace == "" {
 		return nil
@@ -263,7 +508,9 @@ type pod struct {
 }
 
 type podMetadata struct {
-	Name string `json:"name"`
+	Name              string `json:"name"`
+	UID               string `json:"uid"`
+	DeletionTimestamp string `json:"deletionTimestamp"`
 }
 
 type podStatus struct {
@@ -272,6 +519,18 @@ type podStatus struct {
 	Message               string            `json:"message"`
 	ContainerStatuses     []containerStatus `json:"containerStatuses"`
 	InitContainerStatuses []containerStatus `json:"initContainerStatuses"`
+}
+
+type deploymentList struct {
+	Items []deployment `json:"items"`
+}
+
+type deployment struct {
+	Spec deploymentSpec `json:"spec"`
+}
+
+type deploymentSpec struct {
+	Replicas *int32 `json:"replicas"`
 }
 
 type namespaceList struct {
@@ -375,9 +634,21 @@ func namespacePhaseDescriptions(items []namespace) []string {
 }
 
 type containerStatus struct {
-	Name      string         `json:"name"`
-	State     containerState `json:"state"`
-	LastState containerState `json:"lastState"`
+	Name         string         `json:"name"`
+	Ready        bool           `json:"ready"`
+	RestartCount int32          `json:"restartCount"`
+	ContainerID  string         `json:"containerID"`
+	State        containerState `json:"state"`
+	LastState    containerState `json:"lastState"`
+}
+
+func containerStatusByName(statuses []containerStatus, name string) (containerStatus, bool) {
+	for _, status := range statuses {
+		if status.Name == name {
+			return status, true
+		}
+	}
+	return containerStatus{}, false
 }
 
 type containerState struct {

--- a/pkg/framework/scenario.go
+++ b/pkg/framework/scenario.go
@@ -173,10 +173,11 @@ func buildScenarioRollouts(infra *infrav1alpha1.Sandbox0Infra, infraName, namesp
 		rollouts = append(rollouts, RolloutTarget{Kind: "deployment", Name: infraName + "-cluster-gateway", Namespace: namespace, Timeout: "5m"})
 	}
 	if infrav1alpha1.IsManagerEnabled(infra) {
-		rollouts = append(rollouts, RolloutTarget{Kind: "deployment", Name: infraName + "-manager", Namespace: namespace, Timeout: "5m"})
-	}
-	if infrav1alpha1.IsStorageProxyEnabled(infra) {
-		rollouts = append(rollouts, RolloutTarget{Kind: "deployment", Name: infraName + "-storage-proxy", Namespace: namespace, Timeout: "5m"})
+		rollouts = append(rollouts,
+			RolloutTarget{Kind: "deployment", Name: infraName + "-manager", Namespace: namespace, Timeout: "5m"},
+			RolloutTarget{Kind: "daemonset", Name: infraName + "-ctld-a", Namespace: namespace, Timeout: "5m"},
+			RolloutTarget{Kind: "daemonset", Name: infraName + "-ctld-b", Namespace: namespace, Timeout: "5m"},
+		)
 	}
 	return rollouts
 }

--- a/pkg/framework/scenario_test.go
+++ b/pkg/framework/scenario_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	infrav1alpha1 "github.com/sandbox0-ai/sandbox0/infra-operator/api/v1alpha1"
 )
 
 func TestBuildScenarioFromManifestIncludesGlobalGatewayRolloutAndSecrets(t *testing.T) {
@@ -84,5 +86,42 @@ spec:
 	}
 	if strings.Contains(got, "sandbox0-system\n") {
 		t.Fatalf("rewritten manifest still contains source namespace:\n%s", got)
+	}
+}
+
+func TestBuildScenarioRolloutsUsesConsolidatedDataPlaneWorkloads(t *testing.T) {
+	infra := &infrav1alpha1.Sandbox0Infra{
+		Spec: infrav1alpha1.Sandbox0InfraSpec{
+			Services: &infrav1alpha1.ServicesConfig{
+				Manager: &infrav1alpha1.ManagerServiceConfig{
+					WorkloadServiceConfig: infrav1alpha1.WorkloadServiceConfig{
+						EnabledServiceConfig: infrav1alpha1.EnabledServiceConfig{Enabled: true},
+					},
+				},
+				StorageProxy: &infrav1alpha1.StorageProxyServiceConfig{
+					WorkloadServiceConfig: infrav1alpha1.WorkloadServiceConfig{
+						EnabledServiceConfig: infrav1alpha1.EnabledServiceConfig{Enabled: true},
+					},
+				},
+				Netd: &infrav1alpha1.NetdServiceConfig{
+					EnabledServiceConfig: infrav1alpha1.EnabledServiceConfig{Enabled: true},
+				},
+			},
+		},
+	}
+
+	got := buildScenarioRollouts(infra, "s0", "sandbox0-system")
+	want := []RolloutTarget{
+		{Kind: "deployment", Name: "s0-manager", Namespace: "sandbox0-system", Timeout: "5m"},
+		{Kind: "daemonset", Name: "s0-ctld-a", Namespace: "sandbox0-system", Timeout: "5m"},
+		{Kind: "daemonset", Name: "s0-ctld-b", Namespace: "sandbox0-system", Timeout: "5m"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("unexpected rollout count: got %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("unexpected rollout %d: got %#v, want %#v", i, got[i], want[i])
+		}
 	}
 }

--- a/pkg/framework/setup.go
+++ b/pkg/framework/setup.go
@@ -91,6 +91,9 @@ func SetupScenario(cfg Config, scenario Scenario) (*ScenarioEnv, func(), error) 
 
 	namespaceCleanupErr, managerStopErr := cleanupManagerNamespacesBeforeStoppingManager(
 		func() error {
+			return KubectlQuiesceManagerTemplateReconcilers(testCtx.Context, workingCfg.Kubeconfig, scenario.InfraNamespace, "30s")
+		},
+		func() error {
 			return CleanupManagerOwnedNamespaces(testCtx.Context, workingCfg.Kubeconfig, managerOwnedNamespaceCleanupTimeout)
 		},
 		func() error {
@@ -188,9 +191,12 @@ func SetupScenario(cfg Config, scenario Scenario) (*ScenarioEnv, func(), error) 
 	} else {
 		appendCleanup(func() {
 			// Pods can mount sandbox0 CSI volumes. Keep manager and its embedded storage
-			// API running until namespace deletion completes kubelet unpublish, then stop
-			// manager reconciliation before removing the infra manifest.
+			// API running until namespace deletion completes kubelet unpublish. Quiesce
+			// template syncing first so it cannot recreate namespaces during teardown.
 			namespaceCleanupErr, managerStopErr := cleanupManagerNamespacesBeforeStoppingManager(
+				func() error {
+					return KubectlQuiesceManagerTemplateReconcilers(testCtx.Context, workingCfg.Kubeconfig, scenario.InfraNamespace, "30s")
+				},
 				func() error {
 					return CleanupManagerOwnedNamespaces(testCtx.Context, workingCfg.Kubeconfig, managerOwnedNamespaceCleanupTimeout)
 				},
@@ -219,11 +225,14 @@ func SetupScenario(cfg Config, scenario Scenario) (*ScenarioEnv, func(), error) 
 	return env, cleanup, nil
 }
 
-// cleanupManagerNamespacesBeforeStoppingManager preserves manager-hosted storage until
-// namespace deletion has completed all kubelet unpublish operations. If namespace
-// cleanup fails, stopManager is deliberately not called so a later cleanup pass can
-// continue using the storage API.
-func cleanupManagerNamespacesBeforeStoppingManager(cleanupNamespaces, stopManager func() error) (namespaceCleanupErr, managerStopErr error) {
+// cleanupManagerNamespacesBeforeStoppingManager quiesces template syncing while
+// preserving manager-hosted storage until kubelet unpublish operations complete.
+// If namespace cleanup fails, stopManager is deliberately not called so a later
+// cleanup pass can continue using the storage API.
+func cleanupManagerNamespacesBeforeStoppingManager(quiesceManager, cleanupNamespaces, stopManager func() error) (namespaceCleanupErr, managerStopErr error) {
+	if err := quiesceManager(); err != nil {
+		return fmt.Errorf("quiesce manager template reconciliation: %w", err), nil
+	}
 	if err := cleanupNamespaces(); err != nil {
 		return err, nil
 	}

--- a/pkg/framework/setup.go
+++ b/pkg/framework/setup.go
@@ -89,12 +89,20 @@ func SetupScenario(cfg Config, scenario Scenario) (*ScenarioEnv, func(), error) 
 		})
 	}
 
-	if err := ScaleScenarioManagerToZero(testCtx.Context, workingCfg.Kubeconfig, env.Infra); err != nil {
-		fmt.Printf("Failed to scale scenario manager down before setup cleanup: %v\n", err)
+	namespaceCleanupErr, managerStopErr := cleanupManagerNamespacesBeforeStoppingManager(
+		func() error {
+			return CleanupManagerOwnedNamespaces(testCtx.Context, workingCfg.Kubeconfig, managerOwnedNamespaceCleanupTimeout)
+		},
+		func() error {
+			return ScaleScenarioManagerToZero(testCtx.Context, workingCfg.Kubeconfig, env.Infra)
+		},
+	)
+	if managerStopErr != nil {
+		fmt.Printf("Failed to scale scenario manager down after setup namespace cleanup: %v\n", managerStopErr)
 	}
-	if err := CleanupManagerOwnedNamespaces(testCtx.Context, workingCfg.Kubeconfig, managerOwnedNamespaceCleanupTimeout); err != nil {
+	if namespaceCleanupErr != nil {
 		cleanup()
-		return nil, nil, err
+		return nil, nil, namespaceCleanupErr
 	}
 	if err := CleanupNamespace(testCtx.Context, workingCfg.Kubeconfig, scenario.InfraNamespace, "3m"); err != nil {
 		cleanup()
@@ -179,14 +187,23 @@ func SetupScenario(cfg Config, scenario Scenario) (*ScenarioEnv, func(), error) 
 		fmt.Printf("Preserving scenario %q for follow-up tests.\n", scenario.Name)
 	} else {
 		appendCleanup(func() {
-			// Pods can mount sandbox0 CSI volumes. Delete sandbox namespaces before the
-			// infra manifest so storage-proxy is still available for kubelet unpublish.
-			if err := ScaleScenarioManagerToZero(testCtx.Context, workingCfg.Kubeconfig, env.Infra); err != nil {
-				fmt.Printf("Failed to scale scenario manager down before namespace cleanup: %v\n", err)
+			// Pods can mount sandbox0 CSI volumes. Keep manager and its embedded storage
+			// API running until namespace deletion completes kubelet unpublish, then stop
+			// manager reconciliation before removing the infra manifest.
+			namespaceCleanupErr, managerStopErr := cleanupManagerNamespacesBeforeStoppingManager(
+				func() error {
+					return CleanupManagerOwnedNamespaces(testCtx.Context, workingCfg.Kubeconfig, managerOwnedNamespaceCleanupTimeout)
+				},
+				func() error {
+					return ScaleScenarioManagerToZero(testCtx.Context, workingCfg.Kubeconfig, env.Infra)
+				},
+			)
+			if managerStopErr != nil {
+				fmt.Printf("Failed to scale scenario manager down after namespace cleanup: %v\n", managerStopErr)
 			}
-			if err := CleanupManagerOwnedNamespaces(testCtx.Context, workingCfg.Kubeconfig, managerOwnedNamespaceCleanupTimeout); err != nil {
+			if namespaceCleanupErr != nil {
 				preserveInfraForNamespaceCleanup = true
-				fmt.Printf("Failed to clean up manager-owned namespaces: %v\n", err)
+				fmt.Printf("Failed to clean up manager-owned namespaces: %v\n", namespaceCleanupErr)
 				fmt.Printf("Preserving scenario infra so CSI drivers remain available for the next cleanup pass.\n")
 				return
 			}
@@ -202,7 +219,19 @@ func SetupScenario(cfg Config, scenario Scenario) (*ScenarioEnv, func(), error) 
 	return env, cleanup, nil
 }
 
-// ScaleScenarioManagerToZero stops manager reconciliation while preserving CSI components.
+// cleanupManagerNamespacesBeforeStoppingManager preserves manager-hosted storage until
+// namespace deletion has completed all kubelet unpublish operations. If namespace
+// cleanup fails, stopManager is deliberately not called so a later cleanup pass can
+// continue using the storage API.
+func cleanupManagerNamespacesBeforeStoppingManager(cleanupNamespaces, stopManager func() error) (namespaceCleanupErr, managerStopErr error) {
+	if err := cleanupNamespaces(); err != nil {
+		return err, nil
+	}
+	return nil, stopManager()
+}
+
+// ScaleScenarioManagerToZero stops manager reconciliation and its embedded storage API.
+// Call it only after manager-owned namespaces have finished terminating.
 func ScaleScenarioManagerToZero(ctx context.Context, kubeconfig string, infra InfraConfig) error {
 	if ctx == nil {
 		return fmt.Errorf("context is required")

--- a/pkg/framework/setup_test.go
+++ b/pkg/framework/setup_test.go
@@ -11,6 +11,10 @@ func TestCleanupManagerNamespacesBeforeStoppingManagerPreservesStorageUntilClean
 
 	namespaceCleanupErr, managerStopErr := cleanupManagerNamespacesBeforeStoppingManager(
 		func() error {
+			calls = append(calls, "quiesce-manager")
+			return nil
+		},
+		func() error {
 			calls = append(calls, "cleanup-namespaces")
 			return nil
 		},
@@ -26,7 +30,7 @@ func TestCleanupManagerNamespacesBeforeStoppingManagerPreservesStorageUntilClean
 	if managerStopErr != nil {
 		t.Fatalf("manager stop returned error: %v", managerStopErr)
 	}
-	wantCalls := []string{"cleanup-namespaces", "stop-manager"}
+	wantCalls := []string{"quiesce-manager", "cleanup-namespaces", "stop-manager"}
 	if !reflect.DeepEqual(calls, wantCalls) {
 		t.Fatalf("cleanup order = %v, want %v", calls, wantCalls)
 	}
@@ -37,6 +41,7 @@ func TestCleanupManagerNamespacesBeforeStoppingManagerKeepsManagerRunningOnClean
 	managerStopped := false
 
 	namespaceCleanupErr, managerStopErr := cleanupManagerNamespacesBeforeStoppingManager(
+		func() error { return nil },
 		func() error { return wantErr },
 		func() error {
 			managerStopped = true
@@ -60,6 +65,7 @@ func TestCleanupManagerNamespacesBeforeStoppingManagerReportsStopFailureAfterCle
 
 	namespaceCleanupErr, managerStopErr := cleanupManagerNamespacesBeforeStoppingManager(
 		func() error { return nil },
+		func() error { return nil },
 		func() error { return wantErr },
 	)
 
@@ -68,5 +74,33 @@ func TestCleanupManagerNamespacesBeforeStoppingManagerReportsStopFailureAfterCle
 	}
 	if !errors.Is(managerStopErr, wantErr) {
 		t.Fatalf("manager stop error = %v, want %v", managerStopErr, wantErr)
+	}
+}
+
+func TestCleanupManagerNamespacesBeforeStoppingManagerDoesNotDeleteWhenQuiesceFails(t *testing.T) {
+	wantErr := errors.New("signal failed")
+	cleanupCalled := false
+	stopCalled := false
+
+	namespaceCleanupErr, managerStopErr := cleanupManagerNamespacesBeforeStoppingManager(
+		func() error { return wantErr },
+		func() error {
+			cleanupCalled = true
+			return nil
+		},
+		func() error {
+			stopCalled = true
+			return nil
+		},
+	)
+
+	if !errors.Is(namespaceCleanupErr, wantErr) {
+		t.Fatalf("namespace cleanup error = %v, want wrapped %v", namespaceCleanupErr, wantErr)
+	}
+	if managerStopErr != nil {
+		t.Fatalf("manager stop error = %v", managerStopErr)
+	}
+	if cleanupCalled || stopCalled {
+		t.Fatalf("cleanup called = %t, stop called = %t", cleanupCalled, stopCalled)
 	}
 }

--- a/pkg/framework/setup_test.go
+++ b/pkg/framework/setup_test.go
@@ -1,0 +1,72 @@
+package framework
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestCleanupManagerNamespacesBeforeStoppingManagerPreservesStorageUntilCleanupCompletes(t *testing.T) {
+	var calls []string
+
+	namespaceCleanupErr, managerStopErr := cleanupManagerNamespacesBeforeStoppingManager(
+		func() error {
+			calls = append(calls, "cleanup-namespaces")
+			return nil
+		},
+		func() error {
+			calls = append(calls, "stop-manager")
+			return nil
+		},
+	)
+
+	if namespaceCleanupErr != nil {
+		t.Fatalf("namespace cleanup returned error: %v", namespaceCleanupErr)
+	}
+	if managerStopErr != nil {
+		t.Fatalf("manager stop returned error: %v", managerStopErr)
+	}
+	wantCalls := []string{"cleanup-namespaces", "stop-manager"}
+	if !reflect.DeepEqual(calls, wantCalls) {
+		t.Fatalf("cleanup order = %v, want %v", calls, wantCalls)
+	}
+}
+
+func TestCleanupManagerNamespacesBeforeStoppingManagerKeepsManagerRunningOnCleanupFailure(t *testing.T) {
+	wantErr := errors.New("namespace still terminating")
+	managerStopped := false
+
+	namespaceCleanupErr, managerStopErr := cleanupManagerNamespacesBeforeStoppingManager(
+		func() error { return wantErr },
+		func() error {
+			managerStopped = true
+			return nil
+		},
+	)
+
+	if !errors.Is(namespaceCleanupErr, wantErr) {
+		t.Fatalf("namespace cleanup error = %v, want %v", namespaceCleanupErr, wantErr)
+	}
+	if managerStopErr != nil {
+		t.Fatalf("manager stop returned error: %v", managerStopErr)
+	}
+	if managerStopped {
+		t.Fatal("manager was stopped while namespace cleanup still needed its embedded storage API")
+	}
+}
+
+func TestCleanupManagerNamespacesBeforeStoppingManagerReportsStopFailureAfterCleanup(t *testing.T) {
+	wantErr := errors.New("scale failed")
+
+	namespaceCleanupErr, managerStopErr := cleanupManagerNamespacesBeforeStoppingManager(
+		func() error { return nil },
+		func() error { return wantErr },
+	)
+
+	if namespaceCleanupErr != nil {
+		t.Fatalf("namespace cleanup returned error: %v", namespaceCleanupErr)
+	}
+	if !errors.Is(managerStopErr, wantErr) {
+		t.Fatalf("manager stop error = %v, want %v", managerStopErr, wantErr)
+	}
+}

--- a/pkg/template/reconciler/singlecluster.go
+++ b/pkg/template/reconciler/singlecluster.go
@@ -25,6 +25,11 @@ type SingleClusterReconciler struct {
 	lastReconcileAt  time.Time
 	lastReconcileErr error
 	statusMu         sync.RWMutex
+
+	lifecycleMu sync.Mutex
+	quiesced    bool
+	inFlight    sync.WaitGroup
+	quiesceCh   chan struct{}
 }
 
 const singleClusterManagedByLabel = "sandbox0.ai/template-managed-by"
@@ -49,6 +54,7 @@ func NewSingleClusterReconciler(
 		interval:      interval,
 		clock:         clk,
 		logger:        logger,
+		quiesceCh:     make(chan struct{}),
 	}
 }
 
@@ -57,22 +63,49 @@ func (r *SingleClusterReconciler) Start(ctx context.Context) {
 	ticker := time.NewTicker(r.interval)
 	defer ticker.Stop()
 
-	r.reconcile(ctx)
+	r.runReconcile(ctx)
 
 	for {
 		select {
 		case <-ctx.Done():
 			r.logger.Info("Reconciler stopped")
 			return
+		case <-r.quiesceCh:
+			r.logger.Info("Reconciler quiesced")
+			return
 		case <-ticker.C:
-			r.reconcile(ctx)
+			r.runReconcile(ctx)
 		}
 	}
 }
 
 // TriggerReconcile triggers an immediate reconciliation.
 func (r *SingleClusterReconciler) TriggerReconcile(ctx context.Context) {
-	go r.reconcile(ctx)
+	go r.runReconcile(ctx)
+}
+
+// Quiesce permanently stops new reconciliation and waits for in-flight work.
+// The manager keeps serving its HTTP and embedded storage APIs while quiesced.
+func (r *SingleClusterReconciler) Quiesce(ctx context.Context) error {
+	r.lifecycleMu.Lock()
+	if !r.quiesced {
+		r.quiesced = true
+		close(r.quiesceCh)
+	}
+	r.lifecycleMu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		r.inFlight.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 // GetStatus returns the current reconciler status.
@@ -87,6 +120,19 @@ func (r *SingleClusterReconciler) now() time.Time {
 		return r.clock.Now()
 	}
 	return time.Now()
+}
+
+func (r *SingleClusterReconciler) runReconcile(ctx context.Context) {
+	r.lifecycleMu.Lock()
+	if r.quiesced {
+		r.lifecycleMu.Unlock()
+		return
+	}
+	r.inFlight.Add(1)
+	r.lifecycleMu.Unlock()
+
+	defer r.inFlight.Done()
+	r.reconcile(ctx)
 }
 
 func (r *SingleClusterReconciler) reconcile(ctx context.Context) {

--- a/pkg/template/reconciler/singlecluster_test.go
+++ b/pkg/template/reconciler/singlecluster_test.go
@@ -1,0 +1,131 @@
+package reconciler
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
+	"github.com/sandbox0-ai/sandbox0/pkg/template"
+	"go.uber.org/zap"
+)
+
+type countingTemplateStore struct {
+	mu      sync.Mutex
+	calls   int
+	started chan struct{}
+	release chan struct{}
+}
+
+func (s *countingTemplateStore) ListTemplates(ctx context.Context) ([]*template.Template, error) {
+	s.mu.Lock()
+	s.calls++
+	s.mu.Unlock()
+
+	if s.started != nil {
+		select {
+		case s.started <- struct{}{}:
+		default:
+		}
+	}
+	if s.release != nil {
+		select {
+		case <-s.release:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	return nil, nil
+}
+
+func (s *countingTemplateStore) callCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+type emptyTemplateApplier struct{}
+
+func (emptyTemplateApplier) ListTemplates(context.Context) ([]*v1alpha1.SandboxTemplate, error) {
+	return nil, nil
+}
+
+func (emptyTemplateApplier) GetTemplate(context.Context, string) (*v1alpha1.SandboxTemplate, error) {
+	return nil, nil
+}
+
+func (emptyTemplateApplier) CreateTemplate(context.Context, *v1alpha1.SandboxTemplate) (*v1alpha1.SandboxTemplate, error) {
+	return nil, nil
+}
+
+func (emptyTemplateApplier) UpdateTemplate(context.Context, *v1alpha1.SandboxTemplate) (*v1alpha1.SandboxTemplate, error) {
+	return nil, nil
+}
+
+func (emptyTemplateApplier) DeleteTemplate(context.Context, string) error { return nil }
+
+func TestSingleClusterReconcilerQuiesceBlocksNewWork(t *testing.T) {
+	store := &countingTemplateStore{}
+	reconciler := NewSingleClusterReconciler(
+		store,
+		emptyTemplateApplier{},
+		"cluster-a",
+		time.Minute,
+		nil,
+		zap.NewNop(),
+	)
+
+	reconciler.runReconcile(context.Background())
+	if err := reconciler.Quiesce(context.Background()); err != nil {
+		t.Fatalf("Quiesce: %v", err)
+	}
+	reconciler.runReconcile(context.Background())
+
+	if got := store.callCount(); got != 1 {
+		t.Fatalf("ListTemplates calls = %d, want 1", got)
+	}
+}
+
+func TestSingleClusterReconcilerQuiesceWaitsForInFlightWork(t *testing.T) {
+	store := &countingTemplateStore{
+		started: make(chan struct{}, 1),
+		release: make(chan struct{}),
+	}
+	reconciler := NewSingleClusterReconciler(
+		store,
+		emptyTemplateApplier{},
+		"cluster-a",
+		time.Minute,
+		nil,
+		zap.NewNop(),
+	)
+
+	go reconciler.runReconcile(context.Background())
+	select {
+	case <-store.started:
+	case <-time.After(time.Second):
+		t.Fatal("reconciliation did not start")
+	}
+
+	quiesced := make(chan error, 1)
+	go func() {
+		quiesced <- reconciler.Quiesce(context.Background())
+	}()
+
+	select {
+	case err := <-quiesced:
+		t.Fatalf("Quiesce returned before in-flight work completed: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	close(store.release)
+	select {
+	case err := <-quiesced:
+		if err != nil {
+			t.Fatalf("Quiesce: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Quiesce did not return after in-flight work completed")
+	}
+}

--- a/storage-proxy/cmd/storage-proxy/main.go
+++ b/storage-proxy/cmd/storage-proxy/main.go
@@ -2,569 +2,78 @@ package main
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
-	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
-	"github.com/sandbox0-ai/sandbox0/pkg/clock"
-	"github.com/sandbox0-ai/sandbox0/pkg/dbpool"
-	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
-	"github.com/sandbox0-ai/sandbox0/pkg/k8s"
-	meteringpkg "github.com/sandbox0-ai/sandbox0/pkg/metering"
-	meteringclickhouse "github.com/sandbox0-ai/sandbox0/pkg/metering/clickhouse"
-	meteringoutbox "github.com/sandbox0-ai/sandbox0/pkg/metering/outbox"
-	"github.com/sandbox0-ai/sandbox0/pkg/migrate"
 	"github.com/sandbox0-ai/sandbox0/pkg/observability"
-	httpobs "github.com/sandbox0-ai/sandbox0/pkg/observability/http"
-	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
-	"github.com/sandbox0-ai/sandbox0/pkg/quota"
-	spmigrations "github.com/sandbox0-ai/sandbox0/storage-proxy/migrations"
-	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/auth"
-	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/coordinator"
-	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
-	fsserver "github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/fsserver"
-	httpserver "github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/http"
-	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/notify"
-	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/snapshot"
-	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volume"
-	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volumelock"
+	storageproxyruntime "github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/runtime"
 	"github.com/sirupsen/logrus"
 	"go.uber.org/zap"
 )
 
 func main() {
-	// Setup logger (logrus for compatibility)
+	cfg := config.LoadStorageProxyConfig()
+	if err := cfg.Validate(); err != nil {
+		fmt.Fprintf(os.Stderr, "Invalid storage-proxy configuration: %v\n", err)
+		os.Exit(1)
+	}
+
 	logrusLogger := logrus.New()
 	logrusLogger.SetFormatter(&logrus.JSONFormatter{})
 	logrusLogger.SetOutput(os.Stdout)
-
-	// Load configuration
-	cfg := config.LoadStorageProxyConfig()
-
-	if err := cfg.Validate(); err != nil {
-		logrusLogger.WithError(err).Fatal("Invalid configuration")
-	}
-
-	// Set log level
 	level, err := logrus.ParseLevel(cfg.LogLevel)
 	if err != nil {
-		logrusLogger.WithError(err).Warn("Invalid log level, using info")
 		level = logrus.InfoLevel
 	}
 	logrusLogger.SetLevel(level)
 
-	// Setup zap logger for new components.
-	zapLogger, err := observability.NewLogger(observability.LoggerConfig{
+	logger, err := observability.NewLogger(observability.LoggerConfig{
 		ServiceName: "storage-proxy",
 		Level:       cfg.LogLevel,
 	})
 	if err != nil {
-		logrusLogger.WithError(err).Fatal("Failed to create zap logger")
+		logrusLogger.WithError(err).Fatal("Failed to create storage-proxy logger")
 	}
-	defer zapLogger.Sync()
+	defer logger.Sync()
 
-	zapLogger.Info("Starting storage-proxy",
-		zap.Int("http_port", cfg.HTTPPort),
-		zap.String("log_level", cfg.LogLevel),
-		zap.String("cache_dir", cfg.CacheDir),
-	)
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
 
-	// Initialize observability provider
-	obsProvider, err := observability.New(observability.ConfigFromEnv("storage-proxy", zapLogger))
+	obsProvider, err := observability.New(observability.ConfigFromEnv("storage-proxy", logger))
 	if err != nil {
-		zapLogger.Fatal("Failed to initialize observability", zap.Error(err))
+		logger.Fatal("Failed to initialize storage-proxy observability", zap.Error(err))
 	}
 	defer obsProvider.Shutdown(context.Background())
 
-	storageProxyMetrics := obsmetrics.NewStorageProxy(obsProvider.MetricsRegistryOrNil())
-
-	// Initialize database connection pool
-	var repo *db.Repository
-	var meteringRepo *meteringoutbox.Repository
-	var meteringSink *meteringclickhouse.Repository
-	var quotaRepo *quota.Repository
-	var pool *pgxpool.Pool
-	var sharedClock *clock.Clock
-	if cfg.DatabaseURL != "" {
-		pool, err = initDatabase(context.Background(), cfg.DatabaseURL, cfg, zapLogger, obsProvider)
-		if err != nil {
-			zapLogger.Fatal("Failed to connect to database", zap.Error(err))
-		}
-		defer pool.Close()
-
-		sharedClock, err = clock.New(context.Background(), &pgxPoolClockAdapter{pool: pool},
-			clock.WithLogger(&zapClockLogger{logger: zapLogger}),
-		)
-		if err != nil {
-			zapLogger.Fatal("Failed to initialize shared clock", zap.Error(err))
-		}
-		defer sharedClock.Close()
-
-		// Run database migrations
-		if err := runMigrations(context.Background(), pool, cfg.DatabaseSchema, zapLogger); err != nil {
-			zapLogger.Fatal("Failed to run database migrations", zap.Error(err))
-		}
-		if cfg.Metering.Enabled {
-			if err := quota.RunMigrations(context.Background(), pool, observability.NewMigrateLogger(zapLogger)); err != nil {
-				zapLogger.Fatal("Failed to run quota migrations", zap.Error(err))
-			}
-			if err := meteringoutbox.RunMigrations(context.Background(), pool, observability.NewMigrateLogger(zapLogger)); err != nil {
-				zapLogger.Fatal("Failed to run metering outbox migrations", zap.Error(err))
-			}
-		}
-
-		repo = db.NewRepository(pool)
-		if cfg.Metering.Enabled {
-			quotaRepo = quota.NewRepository(pool)
-			meteringRepo = meteringoutbox.NewRepository(pool)
-		}
-	} else {
-		zapLogger.Warn("DATABASE_URL not set, running without database persistence")
-	}
-	if cfg.Metering.Enabled && pool == nil {
-		zapLogger.Fatal("DATABASE_URL is required when metering is enabled")
-	}
-	meteringDB, meteringSink, meteringSinkReady, err := initMetering(context.Background(), cfg, zapLogger)
-	if err != nil {
-		zapLogger.Fatal("Failed to initialize metering backend", zap.Error(err))
-	}
-	if meteringDB != nil {
-		defer meteringDB.Close()
-	}
-	if meteringRepo != nil && meteringSink != nil {
-		bootstrapCompleted, err := meteringRepo.ProjectionBootstrapCompleted(context.Background())
-		if err != nil {
-			zapLogger.Fatal("Failed to inspect metering projection bootstrap", zap.Error(err))
-		}
-		if !meteringSinkReady && !bootstrapCompleted {
-			zapLogger.Fatal("ClickHouse must be reachable for the initial metering projection bootstrap")
-		}
-		if meteringSinkReady {
-			bootstrap, err := meteringRepo.BootstrapProjectionStates(context.Background(), meteringSink)
-			if err != nil {
-				zapLogger.Fatal("Failed to bootstrap metering projection state", zap.Error(err))
-			}
-			zapLogger.Info("Metering projection state bootstrapped",
-				zap.Int64("sandbox_states", bootstrap.SandboxStates),
-				zap.Int64("storage_states", bootstrap.StorageStates),
-			)
-		} else {
-			zapLogger.Warn("Starting with deferred ClickHouse metering delivery; projection bootstrap is already complete")
-		}
-	}
-	if quotaRepo != nil {
-		quotaRepo.SetUsageStore(meteringSink)
-	}
-
-	// Create volume manager
-	volMgr := volume.NewManager(logrusLogger, cfg, repo)
-	volMgr.SetMetrics(storageProxyMetrics)
-	directVolumeFileIdleTTL := buildDirectVolumeFileIdleTTL(cfg)
-	directVolumeFileCleanupInterval := buildDirectVolumeFileCleanupInterval(cfg, directVolumeFileIdleTTL)
-	var volumeBarrier *volumelock.Locker
-	if pool != nil {
-		volumeBarrier = volumelock.New(pool)
-	}
-
-	// Create watch event hub
-	var eventHub *notify.Hub
-	var eventBroadcaster notify.Broadcaster
-	if cfg.WatchEventsEnabled {
-		eventHub = notify.NewHub(logrusLogger, cfg.WatchEventQueueSize)
-		eventBroadcaster = notify.NewLocalBroadcaster(eventHub)
-	}
-
-	// Create Kubernetes client used by coordinator orphan cleanup.
-	k8sClient, err := k8s.NewClientWithObservability(cfg.KubeconfigPath, obsProvider)
-	if err != nil {
-		zapLogger.Warn("Failed to create Kubernetes client",
-			zap.Error(err),
-		)
-		k8sClient = nil
-	}
-
-	// Create and start coordinator for distributed flush coordination
-	var coord *coordinator.Coordinator
-	if pool != nil && repo != nil {
-		// Create volume provider adapter for coordinator
-		volProvider := &volumeProviderAdapter{volMgr: volMgr}
-		coord = coordinator.NewCoordinator(pool, repo, volProvider, eventHub, k8sClient, cfg, logrusLogger, storageProxyMetrics)
-
-		// Set coordinator as mount registrar for volume manager
-		volMgr.SetMountRegistrar(coord)
-
-		// Start coordinator
-		if err := coord.Start(context.Background()); err != nil {
-			zapLogger.Fatal("Failed to start coordinator", zap.Error(err))
-		}
-		defer coord.Stop(context.Background())
-
-		zapLogger.Info("Distributed flush coordinator started",
-			zap.String("instance_id", coord.GetInstanceID()),
-		)
-
-		if eventHub != nil {
-			eventBroadcaster = coord
-		}
-	}
-
-	directMountCleanupCtx, directMountCleanupCancel := context.WithCancel(context.Background())
-	go func() {
-		ticker := time.NewTicker(directVolumeFileCleanupInterval)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-directMountCleanupCtx.Done():
-				return
-			case <-ticker.C:
-				if errs := volMgr.CleanupIdleDirectVolumeFileMounts(context.Background(), directVolumeFileIdleTTL); len(errs) > 0 {
-					zapLogger.Warn("Idle direct volume file cleanup reported errors",
-						zap.Int("error_count", len(errs)),
-					)
-				}
-			}
-		}
-	}()
-	zapLogger.Info("Direct volume file idle cleanup started",
-		zap.Duration("idle_ttl", directVolumeFileIdleTTL),
-		zap.Duration("cleanup_interval", directVolumeFileCleanupInterval),
-	)
-
-	// Create authenticators based on config.
-	var httpAuthenticator *auth.HTTPAuthenticator
-	publicKey, err := internalauth.LoadEd25519PublicKeyFromFile(internalauth.DefaultInternalJWTPublicKeyPath)
-	if err != nil {
-		zapLogger.Fatal("Failed to load internal auth public key",
-			zap.String("path", internalauth.DefaultInternalJWTPublicKeyPath),
-			zap.Error(err),
-		)
-	}
-
-	validator := internalauth.NewValidator(internalauth.ValidatorConfig{
-		Target:                 "storage-proxy",
-		PublicKey:              publicKey,
-		AllowedCallers:         []string{"cluster-gateway", "manager"},
-		ClockSkewTolerance:     5 * time.Second,
-		ReplayDetectionEnabled: false, // Disable for high-throughput scenarios
-	})
-
-	httpAuthenticator = auth.NewHTTPAuthenticator(validator, zapLogger)
-
-	zapLogger.Info("Using internalauth validator for HTTP authentication")
-
-	fsServer := fsserver.NewFileSystemServer(volMgr, repo, eventHub, eventBroadcaster, logrusLogger, volumeBarrier)
-	if sharedClock != nil {
-		fsServer.SetNowFunc(sharedClock.Now)
-	}
-
-	// Create snapshot manager
-	snapshotMgr, err := snapshot.NewManager(repo, volMgr, cfg, logrusLogger, storageProxyMetrics)
-	if err != nil {
-		zapLogger.Fatal("Failed to initialize snapshot manager", zap.Error(err))
-	}
-	snapshotMgr.SetMeteringRepository(meteringRepo)
-	snapshotMgr.SetQuotaRepository(quotaRepo)
-	volMgr.SetStorageObserver(snapshotMgr)
-	if eventBroadcaster != nil {
-		snapshotMgr.SetEventPublisher(eventBroadcaster)
-	}
-
-	storageMeteringCtx, storageMeteringCancel := context.WithCancel(context.Background())
-	defer storageMeteringCancel()
-	if meteringRepo != nil {
-		go runStorageMeteringFlushLoop(storageMeteringCtx, meteringRepo, cfg.RegionID, zapLogger)
-	}
-
-	// Set coordinator for snapshot manager (for distributed flush)
-	if coord != nil {
-		snapshotMgr.SetFlushCoordinator(coord)
-	}
-
-	// Create HTTP server
-	httpSrv := httpserver.NewServer(logrusLogger, cfg, k8sClient, repo, meteringRepo, cfg.RegionID, httpAuthenticator, snapshotMgr, volumeBarrier, volMgr, fsServer, eventHub)
-	httpSrv.SetQuotaRepository(quotaRepo)
-	httpAddr := fmt.Sprintf("%s:%d", cfg.HTTPAddr, cfg.HTTPPort)
-
-	readTimeout, _ := time.ParseDuration(cfg.HTTPReadTimeout)
-	if readTimeout == 0 {
-		readTimeout = 15 * time.Second
-	}
-	writeTimeout, _ := time.ParseDuration(cfg.HTTPWriteTimeout)
-	if writeTimeout == 0 {
-		writeTimeout = 15 * time.Second
-	}
-	idleTimeout, _ := time.ParseDuration(cfg.HTTPIdleTimeout)
-	if idleTimeout == 0 {
-		idleTimeout = 60 * time.Second
-	}
-
-	httpHandler := httpobs.ServerMiddleware(obsProvider.HTTPServerConfig(nil))(httpSrv)
-
-	httpServer := &http.Server{
-		Addr:         httpAddr,
-		Handler:      httpHandler,
-		ReadTimeout:  readTimeout,
-		WriteTimeout: writeTimeout,
-		IdleTimeout:  idleTimeout,
-	}
-	httpServer.ConnState = httpobs.NewConnStateTracker(obsProvider.HTTPServerConfig(nil)).Wrap(httpServer.ConnState)
-
-	go func() {
-		logrusLogger.WithField("address", httpAddr).Info("Starting HTTP server")
-		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			logrusLogger.WithError(err).Fatal("Failed to serve HTTP")
-		}
-	}()
-
-	// Wait for interrupt signal
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
-	<-sigChan
-
-	zapLogger.Info("Shutting down gracefully...")
-
-	directMountCleanupCancel()
-
-	// Shutdown HTTP server
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	if err := httpServer.Shutdown(ctx); err != nil {
-		zapLogger.Error("HTTP server shutdown error", zap.Error(err))
-	}
-
-	// Unmount all volumes
-	for _, volumeID := range volMgr.ListVolumes() {
-		zapLogger.Info("Unmounting volume", zap.String("volume_id", volumeID))
-		for _, sessionID := range volMgr.ListMountSessions(volumeID) {
-			if err := volMgr.UnmountVolume(context.Background(), volumeID, sessionID); err != nil {
-				zapLogger.Error("Failed to unmount volume",
-					zap.String("volume_id", volumeID),
-					zap.Error(err),
-				)
-			}
-		}
-	}
-
-	zapLogger.Info("Shutdown complete")
-}
-
-// initDatabase initializes the database connection pool
-func initDatabase(ctx context.Context, databaseURL string, cfg *config.StorageProxyConfig, logger *zap.Logger, obsProvider *observability.Provider) (*pgxpool.Pool, error) {
-	if databaseURL == "" {
-		return nil, fmt.Errorf("database URL is empty")
-	}
-
-	schema := cfg.DatabaseSchema
-	if schema == "" {
-		schema = "storage_proxy"
-	}
-
-	pool, err := dbpool.New(ctx, dbpool.Options{
-		DatabaseURL:     databaseURL,
-		MaxConns:        int32(cfg.DatabaseMaxConns),
-		MinConns:        int32(cfg.DatabaseMinConns),
-		DefaultMaxConns: 30,
-		DefaultMinConns: 5,
-		Schema:          schema,
-		ConfigModifier:  obsProvider.Pgx.ConfigModifier(),
+	runtime, err := storageproxyruntime.New(ctx, storageproxyruntime.Options{
+		Config:        cfg,
+		Logger:        logger,
+		LogrusLogger:  logrusLogger,
+		Observability: obsProvider,
 	})
 	if err != nil {
-		return nil, err
+		logger.Fatal("Failed to initialize storage-proxy runtime", zap.Error(err))
+	}
+	if err := runtime.Start(ctx); err != nil {
+		logger.Fatal("Failed to start storage-proxy runtime", zap.Error(err))
 	}
 
-	logger.Info("Database connection established",
-		zap.Int32("max_conns", pool.Config().MaxConns),
-		zap.Int32("min_conns", pool.Config().MinConns),
-	)
-
-	return pool, nil
-}
-
-// runMigrations runs database migrations on startup
-func runMigrations(ctx context.Context, pool *pgxpool.Pool, schema string, logger *zap.Logger) error {
-	logger.Info("Running database migrations")
-
-	if schema == "" {
-		schema = "storage_proxy"
+	logger.Info("Storage-proxy is running", zap.String("address", runtime.Address()))
+	select {
+	case <-ctx.Done():
+	case err := <-runtime.Errors():
+		logger.Error("Storage-proxy runtime failed", zap.Error(err))
+		cancel()
 	}
 
-	if err := migrate.Up(ctx, pool, ".",
-		migrate.WithBaseFS(spmigrations.FS),
-		migrate.WithLogger(observability.NewMigrateLogger(logger)),
-		migrate.WithSchema(schema),
-	); err != nil {
-		return fmt.Errorf("migrate up: %w", err)
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer shutdownCancel()
+	if err := runtime.Shutdown(shutdownCtx); err != nil {
+		logger.Error("Storage-proxy shutdown reported errors", zap.Error(err))
 	}
-
-	logger.Info("Database migrations completed successfully")
-	return nil
-}
-
-func initMetering(ctx context.Context, cfg *config.StorageProxyConfig, logger *zap.Logger) (*sql.DB, *meteringclickhouse.Repository, bool, error) {
-	if cfg == nil || !cfg.Metering.Enabled {
-		return nil, nil, false, nil
-	}
-	ch := cfg.Metering.ClickHouse
-	timeout := ch.ConnectTimeout.Duration
-	if timeout <= 0 {
-		timeout = 10 * time.Second
-	}
-	connectCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-	openConfig := meteringclickhouse.OpenConfig{
-		DSN: ch.DSN,
-		Schema: meteringclickhouse.Config{
-			Database:          ch.Database,
-			EventsTable:       ch.EventsTable,
-			WindowsTable:      ch.WindowsTable,
-			WatermarksTable:   ch.WatermarksTable,
-			SandboxStateTable: ch.SandboxStateTable,
-			StorageStateTable: ch.StorageStateTable,
-		},
-		Migrate: !ch.SkipSchemaMigration,
-	}
-	db, repo, err := meteringclickhouse.Open(connectCtx, openConfig)
-	if err != nil {
-		deferredDB, deferredRepo, deferredErr := meteringclickhouse.OpenDeferred(openConfig)
-		if deferredErr != nil {
-			return nil, nil, false, fmt.Errorf("initialize deferred clickhouse metering backend after %v: %w", err, deferredErr)
-		}
-		logger.Warn("Metering ClickHouse backend is unavailable; delivery will retry from PostgreSQL", zap.Error(err))
-		return deferredDB, deferredRepo, false, nil
-	}
-	logger.Info("Metering ClickHouse backend initialized",
-		zap.String("database", ch.Database),
-		zap.String("events_table", ch.EventsTable),
-		zap.String("windows_table", ch.WindowsTable),
-		zap.Bool("schema_migration", !ch.SkipSchemaMigration),
-	)
-	return db, repo, true, nil
-}
-
-func runStorageMeteringFlushLoop(ctx context.Context, repo *meteringoutbox.Repository, regionID string, logger *zap.Logger) {
-	const (
-		flushInterval = time.Minute
-		flushBatch    = 500
-	)
-	ticker := time.NewTicker(flushInterval)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-			before := time.Now().UTC()
-			for {
-				processed, err := repo.FlushStorageProjectionWindows(ctx, before, flushBatch)
-				if err != nil {
-					logger.Warn("Failed to flush storage metering windows", zap.Error(err))
-					break
-				}
-				if err := repo.UpsertProducerWatermark(ctx, meteringpkg.ProducerStorage, regionID, before); err != nil {
-					logger.Warn("Failed to update storage metering watermark", zap.Error(err))
-					break
-				}
-				if processed < flushBatch {
-					break
-				}
-			}
-		}
-	}
-}
-
-type pgxPoolClockAdapter struct {
-	pool *pgxpool.Pool
-}
-
-type pgxClockRowAdapter struct {
-	row interface {
-		Scan(dest ...any) error
-	}
-}
-
-func (r *pgxClockRowAdapter) Scan(dest ...any) error {
-	return r.row.Scan(dest...)
-}
-
-func (a *pgxPoolClockAdapter) QueryRow(ctx context.Context, sql string, args ...any) clock.Row {
-	return &pgxClockRowAdapter{row: a.pool.QueryRow(ctx, sql, args...)}
-}
-
-type zapClockLogger struct {
-	logger *zap.Logger
-}
-
-func (z *zapClockLogger) Info(msg string, keysAndValues ...any) {
-	z.logger.Info(msg, toZapFields(keysAndValues)...)
-}
-
-func (z *zapClockLogger) Warn(msg string, keysAndValues ...any) {
-	z.logger.Warn(msg, toZapFields(keysAndValues)...)
-}
-
-func (z *zapClockLogger) Error(msg string, keysAndValues ...any) {
-	z.logger.Error(msg, toZapFields(keysAndValues)...)
-}
-
-func toZapFields(keysAndValues []any) []zap.Field {
-	if len(keysAndValues)%2 != 0 {
-		return []zap.Field{zap.Any("args", keysAndValues)}
-	}
-
-	fields := make([]zap.Field, 0, len(keysAndValues)/2)
-	for i := 0; i < len(keysAndValues); i += 2 {
-		key, ok := keysAndValues[i].(string)
-		if !ok {
-			continue
-		}
-		fields = append(fields, zap.Any(key, keysAndValues[i+1]))
-	}
-	return fields
-}
-
-// volumeProviderAdapter adapts volume.Manager to coordinator.VolumeProvider interface
-type volumeProviderAdapter struct {
-	volMgr *volume.Manager
-}
-
-func (a *volumeProviderAdapter) GetVolume(volumeID string) (coordinator.VolumeContext, error) {
-	volCtx, err := a.volMgr.GetVolume(volumeID)
-	if err != nil {
-		return nil, err
-	}
-	return volCtx, nil
-}
-
-func (a *volumeProviderAdapter) ListVolumes() []string {
-	return a.volMgr.ListVolumes()
-}
-
-func buildDirectVolumeFileIdleTTL(cfg *config.StorageProxyConfig) time.Duration {
-	idleTTL, _ := time.ParseDuration(cfg.DirectVolumeFileIdleTTL)
-	if idleTTL <= 0 {
-		idleTTL = 30 * time.Second
-	}
-	return idleTTL
-}
-
-func buildDirectVolumeFileCleanupInterval(cfg *config.StorageProxyConfig, idleTTL time.Duration) time.Duration {
-	cleanupInterval, _ := time.ParseDuration(cfg.CleanupInterval)
-	if cleanupInterval <= 0 {
-		cleanupInterval = 15 * time.Second
-	}
-	if idleTTL > 0 && cleanupInterval > idleTTL {
-		cleanupInterval = idleTTL
-	}
-	if cleanupInterval < time.Second {
-		cleanupInterval = time.Second
-	}
-	return cleanupInterval
+	logger.Info("Storage-proxy stopped")
 }

--- a/storage-proxy/pkg/runtime/runtime.go
+++ b/storage-proxy/pkg/runtime/runtime.go
@@ -1,0 +1,769 @@
+// Package runtime assembles and runs the storage-proxy service. It is shared by
+// the standalone storage-proxy command and processes embedding the service.
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
+	"github.com/sandbox0-ai/sandbox0/pkg/clock"
+	"github.com/sandbox0-ai/sandbox0/pkg/dbpool"
+	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+	"github.com/sandbox0-ai/sandbox0/pkg/k8s"
+	meteringpkg "github.com/sandbox0-ai/sandbox0/pkg/metering"
+	meteringclickhouse "github.com/sandbox0-ai/sandbox0/pkg/metering/clickhouse"
+	meteringoutbox "github.com/sandbox0-ai/sandbox0/pkg/metering/outbox"
+	"github.com/sandbox0-ai/sandbox0/pkg/migrate"
+	"github.com/sandbox0-ai/sandbox0/pkg/observability"
+	httpobs "github.com/sandbox0-ai/sandbox0/pkg/observability/http"
+	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
+	"github.com/sandbox0-ai/sandbox0/pkg/quota"
+	spmigrations "github.com/sandbox0-ai/sandbox0/storage-proxy/migrations"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/auth"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/coordinator"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
+	fsserver "github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/fsserver"
+	httpserver "github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/http"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/notify"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/snapshot"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volume"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volumelock"
+	"github.com/sirupsen/logrus"
+	"go.uber.org/zap"
+	"k8s.io/client-go/kubernetes"
+)
+
+const defaultShutdownTimeout = 30 * time.Second
+
+// Options provides process-owned dependencies to a storage-proxy Runtime.
+// The runtime owns resources it creates, but never closes the supplied loggers,
+// observability provider, or Kubernetes client.
+type Options struct {
+	Config        *config.StorageProxyConfig
+	Logger        *zap.Logger
+	LogrusLogger  *logrus.Logger
+	Observability *observability.Provider
+	K8sClient     kubernetes.Interface
+	Listen        func(network, address string) (net.Listener, error)
+}
+
+// Runtime owns one storage-proxy HTTP endpoint and all of its background
+// workers. Runtime is safe to embed in another process.
+type Runtime struct {
+	cfg           *config.StorageProxyConfig
+	logger        *zap.Logger
+	logrusLogger  *logrus.Logger
+	observability *observability.Provider
+	k8sClient     kubernetes.Interface
+	listen        func(network, address string) (net.Listener, error)
+
+	pool               *pgxpool.Pool
+	sharedClock        *clock.Clock
+	meteringDB         *sql.DB
+	meteringRepo       *meteringoutbox.Repository
+	volMgr             *volume.Manager
+	coordinator        *coordinator.Coordinator
+	httpHandler        http.Handler
+	httpServer         *http.Server
+	listener           net.Listener
+	runCancel          context.CancelFunc
+	coordinatorStarted bool
+
+	mu           sync.RWMutex
+	started      bool
+	stopped      bool
+	workers      sync.WaitGroup
+	internalHTTP sync.WaitGroup
+	shutdownOnce sync.Once
+	shutdownErr  error
+	errors       chan error
+	done         chan struct{}
+}
+
+// New initializes the storage subsystem without accepting traffic. Call Start
+// after the parent process has finished assembling its own dependencies.
+func New(ctx context.Context, opts Options) (_ *Runtime, retErr error) {
+	if opts.Config == nil {
+		return nil, fmt.Errorf("storage-proxy config is required")
+	}
+	if err := opts.Config.Validate(); err != nil {
+		return nil, fmt.Errorf("validate storage-proxy config: %w", err)
+	}
+	if opts.Logger == nil {
+		return nil, fmt.Errorf("storage-proxy zap logger is required")
+	}
+	if opts.LogrusLogger == nil {
+		return nil, fmt.Errorf("storage-proxy logrus logger is required")
+	}
+	listen := opts.Listen
+	if listen == nil {
+		listen = net.Listen
+	}
+
+	r := &Runtime{
+		cfg:           opts.Config,
+		logger:        opts.Logger,
+		logrusLogger:  opts.LogrusLogger,
+		observability: opts.Observability,
+		k8sClient:     opts.K8sClient,
+		listen:        listen,
+		errors:        make(chan error, 1),
+		done:          make(chan struct{}),
+	}
+	defer func() {
+		if retErr != nil {
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), defaultShutdownTimeout)
+			defer cancel()
+			_ = r.closeResources(cleanupCtx)
+		}
+	}()
+
+	storageProxyMetrics := obsmetrics.NewStorageProxy(metricsRegisterer(opts.Observability))
+
+	var repo *db.Repository
+	var meteringRepo *meteringoutbox.Repository
+	var meteringSink *meteringclickhouse.Repository
+	var quotaRepo *quota.Repository
+	if r.cfg.DatabaseURL != "" {
+		pool, err := initDatabase(ctx, r.cfg.DatabaseURL, r.cfg, r.logger, r.observability)
+		if err != nil {
+			return nil, fmt.Errorf("connect storage-proxy database: %w", err)
+		}
+		r.pool = pool
+
+		sharedClock, err := clock.New(ctx, &pgxPoolClockAdapter{pool: pool},
+			clock.WithLogger(&zapClockLogger{logger: r.logger}),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("initialize storage-proxy shared clock: %w", err)
+		}
+		r.sharedClock = sharedClock
+
+		if err := runMigrations(ctx, pool, r.cfg.DatabaseSchema, r.logger); err != nil {
+			return nil, fmt.Errorf("run storage-proxy migrations: %w", err)
+		}
+		if r.cfg.Metering.Enabled {
+			if err := quota.RunMigrations(ctx, pool, observability.NewMigrateLogger(r.logger)); err != nil {
+				return nil, fmt.Errorf("run storage quota migrations: %w", err)
+			}
+			if err := meteringoutbox.RunMigrations(ctx, pool, observability.NewMigrateLogger(r.logger)); err != nil {
+				return nil, fmt.Errorf("run storage metering outbox migrations: %w", err)
+			}
+		}
+
+		repo = db.NewRepository(pool)
+		if r.cfg.Metering.Enabled {
+			quotaRepo = quota.NewRepository(pool)
+			meteringRepo = meteringoutbox.NewRepository(pool)
+		}
+	} else {
+		r.logger.Warn("DATABASE_URL not set, running storage-proxy without database persistence")
+	}
+	if r.cfg.Metering.Enabled && r.pool == nil {
+		return nil, fmt.Errorf("DATABASE_URL is required when storage metering is enabled")
+	}
+
+	meteringDB, sink, sinkReady, err := initMetering(ctx, r.cfg, r.logger)
+	if err != nil {
+		return nil, fmt.Errorf("initialize storage metering backend: %w", err)
+	}
+	r.meteringDB = meteringDB
+	meteringSink = sink
+	if meteringRepo != nil && meteringSink != nil {
+		bootstrapCompleted, err := meteringRepo.ProjectionBootstrapCompleted(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("inspect storage metering projection bootstrap: %w", err)
+		}
+		if !sinkReady && !bootstrapCompleted {
+			return nil, fmt.Errorf("ClickHouse must be reachable for the initial metering projection bootstrap")
+		}
+		if sinkReady {
+			bootstrap, err := meteringRepo.BootstrapProjectionStates(ctx, meteringSink)
+			if err != nil {
+				return nil, fmt.Errorf("bootstrap storage metering projection state: %w", err)
+			}
+			r.logger.Info("Storage metering projection state bootstrapped",
+				zap.Int64("sandbox_states", bootstrap.SandboxStates),
+				zap.Int64("storage_states", bootstrap.StorageStates),
+			)
+		} else {
+			r.logger.Warn("Starting storage runtime with deferred ClickHouse delivery; projection bootstrap is complete")
+		}
+	}
+	if quotaRepo != nil {
+		quotaRepo.SetUsageStore(meteringSink)
+	}
+
+	r.volMgr = volume.NewManager(r.logrusLogger, r.cfg, repo)
+	r.volMgr.SetMetrics(storageProxyMetrics)
+	var volumeBarrier *volumelock.Locker
+	if r.pool != nil {
+		volumeBarrier = volumelock.New(r.pool)
+	}
+
+	var eventHub *notify.Hub
+	var eventBroadcaster notify.Broadcaster
+	if r.cfg.WatchEventsEnabled {
+		eventHub = notify.NewHub(r.logrusLogger, r.cfg.WatchEventQueueSize)
+		eventBroadcaster = notify.NewLocalBroadcaster(eventHub)
+	}
+
+	if r.k8sClient == nil {
+		client, err := k8s.NewClientWithObservability(r.cfg.KubeconfigPath, r.observability)
+		if err != nil {
+			r.logger.Warn("Failed to create storage-proxy Kubernetes client", zap.Error(err))
+		} else {
+			r.k8sClient = client
+		}
+	}
+
+	if r.pool != nil && repo != nil {
+		volProvider := &volumeProviderAdapter{volMgr: r.volMgr}
+		r.coordinator = coordinator.NewCoordinator(r.pool, repo, volProvider, eventHub, r.k8sClient, r.cfg, r.logrusLogger, storageProxyMetrics)
+		r.volMgr.SetMountRegistrar(r.coordinator)
+		if eventHub != nil {
+			eventBroadcaster = r.coordinator
+		}
+	}
+
+	publicKey, err := internalauth.LoadEd25519PublicKeyFromFile(internalauth.DefaultInternalJWTPublicKeyPath)
+	if err != nil {
+		return nil, fmt.Errorf("load storage-proxy internal auth public key from %s: %w", internalauth.DefaultInternalJWTPublicKeyPath, err)
+	}
+	validator := internalauth.NewValidator(internalauth.ValidatorConfig{
+		Target:                 internalauth.ServiceStorageProxy,
+		PublicKey:              publicKey,
+		AllowedCallers:         []string{internalauth.ServiceClusterGateway, internalauth.ServiceManager},
+		ClockSkewTolerance:     5 * time.Second,
+		ReplayDetectionEnabled: false,
+	})
+	httpAuthenticator := auth.NewHTTPAuthenticator(validator, r.logger)
+
+	fsServer := fsserver.NewFileSystemServer(r.volMgr, repo, eventHub, eventBroadcaster, r.logrusLogger, volumeBarrier)
+	if r.sharedClock != nil {
+		fsServer.SetNowFunc(r.sharedClock.Now)
+	}
+
+	snapshotMgr, err := snapshot.NewManager(repo, r.volMgr, r.cfg, r.logrusLogger, storageProxyMetrics)
+	if err != nil {
+		return nil, fmt.Errorf("initialize snapshot manager: %w", err)
+	}
+	snapshotMgr.SetMeteringRepository(meteringRepo)
+	snapshotMgr.SetQuotaRepository(quotaRepo)
+	r.volMgr.SetStorageObserver(snapshotMgr)
+	if eventBroadcaster != nil {
+		snapshotMgr.SetEventPublisher(eventBroadcaster)
+	}
+	if r.coordinator != nil {
+		snapshotMgr.SetFlushCoordinator(r.coordinator)
+	}
+
+	storageHTTP := httpserver.NewServer(r.logrusLogger, r.cfg, r.k8sClient, repo, meteringRepo, r.cfg.RegionID, httpAuthenticator, snapshotMgr, volumeBarrier, r.volMgr, fsServer, eventHub)
+	storageHTTP.SetQuotaRepository(quotaRepo)
+	r.httpHandler = storageHTTP
+	if r.observability != nil {
+		r.httpHandler = httpobs.ServerMiddleware(r.observability.HTTPServerConfig(nil))(r.httpHandler)
+	}
+	r.httpServer = &http.Server{
+		Addr:         fmt.Sprintf("%s:%d", r.cfg.HTTPAddr, r.cfg.HTTPPort),
+		Handler:      r.httpHandler,
+		ReadTimeout:  durationOrDefault(r.cfg.HTTPReadTimeout, 15*time.Second),
+		WriteTimeout: durationOrDefault(r.cfg.HTTPWriteTimeout, 15*time.Second),
+		IdleTimeout:  durationOrDefault(r.cfg.HTTPIdleTimeout, 60*time.Second),
+	}
+	if r.observability != nil {
+		r.httpServer.ConnState = httpobs.NewConnStateTracker(r.observability.HTTPServerConfig(nil)).Wrap(r.httpServer.ConnState)
+	}
+	r.meteringRepo = meteringRepo
+
+	return r, nil
+}
+
+// Start begins accepting HTTP traffic and runs background workers until ctx is
+// canceled or Shutdown is called.
+func (r *Runtime) Start(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	r.mu.Lock()
+	if r.stopped {
+		r.mu.Unlock()
+		return fmt.Errorf("storage-proxy runtime is stopped")
+	}
+	if r.started {
+		r.mu.Unlock()
+		return nil
+	}
+	listener, err := r.listen("tcp", r.httpServer.Addr)
+	if err != nil {
+		r.mu.Unlock()
+		return fmt.Errorf("listen on storage-proxy address %s: %w", r.httpServer.Addr, err)
+	}
+	r.listener = listener
+	runCtx, runCancel := context.WithCancel(ctx)
+	r.runCancel = runCancel
+
+	if r.coordinator != nil {
+		if err := r.coordinator.Start(runCtx); err != nil {
+			runCancel()
+			_ = listener.Close()
+			r.stopped = true
+			r.mu.Unlock()
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), defaultShutdownTimeout)
+			defer cancel()
+			_ = r.Shutdown(shutdownCtx)
+			return fmt.Errorf("start storage-proxy coordinator: %w", err)
+		}
+		r.coordinatorStarted = true
+		r.logger.Info("Distributed storage coordinator started", zap.String("instance_id", r.coordinator.GetInstanceID()))
+	}
+	if r.volMgr != nil {
+		r.workers.Add(1)
+	}
+	if r.meteringRepo != nil {
+		r.workers.Add(1)
+	}
+	r.started = true
+	r.mu.Unlock()
+
+	directVolumeFileIdleTTL := buildDirectVolumeFileIdleTTL(r.cfg)
+	directVolumeFileCleanupInterval := buildDirectVolumeFileCleanupInterval(r.cfg, directVolumeFileIdleTTL)
+	if r.volMgr != nil {
+		go func() {
+			defer r.workers.Done()
+			r.runDirectMountCleanup(runCtx, directVolumeFileIdleTTL, directVolumeFileCleanupInterval)
+		}()
+	}
+	if r.meteringRepo != nil {
+		go func() {
+			defer r.workers.Done()
+			runStorageMeteringFlushLoop(runCtx, r.meteringRepo, r.cfg.RegionID, r.logger)
+		}()
+	}
+
+	go func() {
+		err := r.httpServer.Serve(listener)
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			wrapped := fmt.Errorf("serve storage-proxy HTTP: %w", err)
+			select {
+			case r.errors <- wrapped:
+			default:
+			}
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), defaultShutdownTimeout)
+			defer cancel()
+			_ = r.Shutdown(shutdownCtx)
+		}
+	}()
+	go func() {
+		select {
+		case <-ctx.Done():
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), defaultShutdownTimeout)
+			defer cancel()
+			_ = r.Shutdown(shutdownCtx)
+		case <-r.done:
+		}
+	}()
+
+	r.logger.Info("Storage-proxy runtime started", zap.String("address", listener.Addr().String()))
+	return nil
+}
+
+// Handler returns the authenticated storage-proxy HTTP handler. It is useful
+// for trusted in-process callers that still need the exact wire semantics.
+func (r *Runtime) Handler() http.Handler {
+	if r == nil {
+		return nil
+	}
+	return r.httpHandler
+}
+
+// InternalHTTPClient returns an in-process HTTP client backed by Handler. The
+// client is intended for manager-owned volume calls and does not open sockets.
+func (r *Runtime) InternalHTTPClient() *http.Client {
+	return &http.Client{Transport: &handlerRoundTripper{runtime: r}}
+}
+
+// Errors reports fatal serving errors. Normal context cancellation and server
+// shutdown are not reported.
+func (r *Runtime) Errors() <-chan error {
+	return r.errors
+}
+
+// Done is closed after all runtime-owned resources have been released.
+func (r *Runtime) Done() <-chan struct{} {
+	return r.done
+}
+
+// Address returns the bound address after Start.
+func (r *Runtime) Address() string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.listener == nil {
+		return ""
+	}
+	return r.listener.Addr().String()
+}
+
+// Shutdown drains HTTP requests, stops background workers, unmounts local
+// volumes, and closes runtime-owned database resources.
+func (r *Runtime) Shutdown(ctx context.Context) error {
+	if r == nil {
+		return nil
+	}
+	r.shutdownOnce.Do(func() {
+		r.shutdownErr = r.closeResources(ctx)
+		close(r.done)
+	})
+	return r.shutdownErr
+}
+
+func (r *Runtime) closeResources(ctx context.Context) error {
+	var errs []error
+	r.mu.Lock()
+	r.stopped = true
+	runCancel := r.runCancel
+	httpServer := r.httpServer
+	listener := r.listener
+	coord := r.coordinator
+	coordinatorStarted := r.coordinatorStarted
+	volMgr := r.volMgr
+	sharedClock := r.sharedClock
+	meteringDB := r.meteringDB
+	pool := r.pool
+	r.mu.Unlock()
+
+	if runCancel != nil {
+		runCancel()
+	}
+	if httpServer != nil {
+		if err := httpServer.Shutdown(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errs = append(errs, fmt.Errorf("shutdown HTTP server: %w", err))
+		}
+	}
+	if listener != nil {
+		_ = listener.Close()
+	}
+	if err := r.waitForInternalHTTP(ctx); err != nil {
+		errs = append(errs, err)
+	}
+	if err := r.waitForWorkers(ctx); err != nil {
+		errs = append(errs, err)
+	}
+	if volMgr != nil {
+		for _, volumeID := range volMgr.ListVolumes() {
+			for _, sessionID := range volMgr.ListMountSessions(volumeID) {
+				if err := volMgr.UnmountVolume(ctx, volumeID, sessionID); err != nil {
+					errs = append(errs, fmt.Errorf("unmount volume %s session %s: %w", volumeID, sessionID, err))
+				}
+			}
+		}
+	}
+	if coord != nil && coordinatorStarted {
+		if err := coord.Stop(ctx); err != nil {
+			errs = append(errs, fmt.Errorf("stop coordinator: %w", err))
+		}
+	}
+	if sharedClock != nil {
+		sharedClock.Close()
+	}
+	if meteringDB != nil {
+		if err := meteringDB.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("close metering database: %w", err))
+		}
+	}
+	if pool != nil {
+		pool.Close()
+	}
+	return errors.Join(errs...)
+}
+
+func (r *Runtime) waitForInternalHTTP(ctx context.Context) error {
+	done := make(chan struct{})
+	go func() {
+		r.internalHTTP.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("wait for storage-proxy internal HTTP requests: %w", ctx.Err())
+	}
+}
+
+func (r *Runtime) waitForWorkers(ctx context.Context) error {
+	done := make(chan struct{})
+	go func() {
+		r.workers.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("wait for storage-proxy workers: %w", ctx.Err())
+	}
+}
+
+func (r *Runtime) runDirectMountCleanup(ctx context.Context, idleTTL, cleanupInterval time.Duration) {
+	ticker := time.NewTicker(cleanupInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if errs := r.volMgr.CleanupIdleDirectVolumeFileMounts(ctx, idleTTL); len(errs) > 0 {
+				r.logger.Warn("Idle direct volume file cleanup reported errors", zap.Int("error_count", len(errs)))
+			}
+		}
+	}
+}
+
+func metricsRegisterer(provider *observability.Provider) prometheus.Registerer {
+	if provider == nil {
+		return nil
+	}
+	return provider.MetricsRegistryOrNil()
+}
+
+func initDatabase(ctx context.Context, databaseURL string, cfg *config.StorageProxyConfig, logger *zap.Logger, obsProvider *observability.Provider) (*pgxpool.Pool, error) {
+	if databaseURL == "" {
+		return nil, fmt.Errorf("database URL is empty")
+	}
+	schema := cfg.DatabaseSchema
+	if schema == "" {
+		schema = "storage_proxy"
+	}
+	options := dbpool.Options{
+		DatabaseURL:     databaseURL,
+		MaxConns:        int32(cfg.DatabaseMaxConns),
+		MinConns:        int32(cfg.DatabaseMinConns),
+		DefaultMaxConns: 30,
+		DefaultMinConns: 5,
+		Schema:          schema,
+	}
+	if obsProvider != nil {
+		options.ConfigModifier = obsProvider.Pgx.ConfigModifier()
+	}
+	pool, err := dbpool.New(ctx, options)
+	if err != nil {
+		return nil, err
+	}
+	logger.Info("Storage-proxy database connection established",
+		zap.Int32("max_conns", pool.Config().MaxConns),
+		zap.Int32("min_conns", pool.Config().MinConns),
+	)
+	return pool, nil
+}
+
+func runMigrations(ctx context.Context, pool *pgxpool.Pool, schema string, logger *zap.Logger) error {
+	if schema == "" {
+		schema = "storage_proxy"
+	}
+	return migrate.Up(ctx, pool, ".",
+		migrate.WithBaseFS(spmigrations.FS),
+		migrate.WithLogger(observability.NewMigrateLogger(logger)),
+		migrate.WithSchema(schema),
+	)
+}
+
+func initMetering(ctx context.Context, cfg *config.StorageProxyConfig, logger *zap.Logger) (*sql.DB, *meteringclickhouse.Repository, bool, error) {
+	if cfg == nil || !cfg.Metering.Enabled {
+		return nil, nil, false, nil
+	}
+	ch := cfg.Metering.ClickHouse
+	timeout := ch.ConnectTimeout.Duration
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+	connectCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	openConfig := meteringclickhouse.OpenConfig{
+		DSN: ch.DSN,
+		Schema: meteringclickhouse.Config{
+			Database:          ch.Database,
+			EventsTable:       ch.EventsTable,
+			WindowsTable:      ch.WindowsTable,
+			WatermarksTable:   ch.WatermarksTable,
+			SandboxStateTable: ch.SandboxStateTable,
+			StorageStateTable: ch.StorageStateTable,
+		},
+		Migrate: !ch.SkipSchemaMigration,
+	}
+	database, repo, err := meteringclickhouse.Open(connectCtx, openConfig)
+	if err != nil {
+		deferredDB, deferredRepo, deferredErr := meteringclickhouse.OpenDeferred(openConfig)
+		if deferredErr != nil {
+			return nil, nil, false, fmt.Errorf("initialize deferred ClickHouse metering backend after %v: %w", err, deferredErr)
+		}
+		logger.Warn("Metering ClickHouse backend is unavailable; delivery will retry from PostgreSQL", zap.Error(err))
+		return deferredDB, deferredRepo, false, nil
+	}
+	return database, repo, true, nil
+}
+
+func runStorageMeteringFlushLoop(ctx context.Context, repo *meteringoutbox.Repository, regionID string, logger *zap.Logger) {
+	const (
+		flushInterval = time.Minute
+		flushBatch    = 500
+	)
+	ticker := time.NewTicker(flushInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			before := time.Now().UTC()
+			for {
+				processed, err := repo.FlushStorageProjectionWindows(ctx, before, flushBatch)
+				if err != nil {
+					logger.Warn("Failed to flush storage metering windows", zap.Error(err))
+					break
+				}
+				if err := repo.UpsertProducerWatermark(ctx, meteringpkg.ProducerStorage, regionID, before); err != nil {
+					logger.Warn("Failed to update storage metering watermark", zap.Error(err))
+					break
+				}
+				if processed < flushBatch {
+					break
+				}
+			}
+		}
+	}
+}
+
+func durationOrDefault(raw string, fallback time.Duration) time.Duration {
+	parsed, _ := time.ParseDuration(raw)
+	if parsed <= 0 {
+		return fallback
+	}
+	return parsed
+}
+
+func buildDirectVolumeFileIdleTTL(cfg *config.StorageProxyConfig) time.Duration {
+	return durationOrDefault(cfg.DirectVolumeFileIdleTTL, 30*time.Second)
+}
+
+func buildDirectVolumeFileCleanupInterval(cfg *config.StorageProxyConfig, idleTTL time.Duration) time.Duration {
+	cleanupInterval := durationOrDefault(cfg.CleanupInterval, 15*time.Second)
+	if idleTTL > 0 && cleanupInterval > idleTTL {
+		cleanupInterval = idleTTL
+	}
+	if cleanupInterval < time.Second {
+		cleanupInterval = time.Second
+	}
+	return cleanupInterval
+}
+
+type pgxPoolClockAdapter struct{ pool *pgxpool.Pool }
+
+func (a *pgxPoolClockAdapter) QueryRow(ctx context.Context, query string, args ...any) clock.Row {
+	return &pgxClockRowAdapter{row: a.pool.QueryRow(ctx, query, args...)}
+}
+
+type pgxClockRowAdapter struct {
+	row interface{ Scan(dest ...any) error }
+}
+
+func (r *pgxClockRowAdapter) Scan(dest ...any) error { return r.row.Scan(dest...) }
+
+type zapClockLogger struct{ logger *zap.Logger }
+
+func (z *zapClockLogger) Info(msg string, keysAndValues ...any) {
+	z.logger.Info(msg, toZapFields(keysAndValues)...)
+}
+func (z *zapClockLogger) Warn(msg string, keysAndValues ...any) {
+	z.logger.Warn(msg, toZapFields(keysAndValues)...)
+}
+func (z *zapClockLogger) Error(msg string, keysAndValues ...any) {
+	z.logger.Error(msg, toZapFields(keysAndValues)...)
+}
+
+func toZapFields(keysAndValues []any) []zap.Field {
+	if len(keysAndValues)%2 != 0 {
+		return []zap.Field{zap.Any("args", keysAndValues)}
+	}
+	fields := make([]zap.Field, 0, len(keysAndValues)/2)
+	for i := 0; i < len(keysAndValues); i += 2 {
+		key, ok := keysAndValues[i].(string)
+		if ok {
+			fields = append(fields, zap.Any(key, keysAndValues[i+1]))
+		}
+	}
+	return fields
+}
+
+type volumeProviderAdapter struct{ volMgr *volume.Manager }
+
+func (a *volumeProviderAdapter) GetVolume(volumeID string) (coordinator.VolumeContext, error) {
+	return a.volMgr.GetVolume(volumeID)
+}
+func (a *volumeProviderAdapter) ListVolumes() []string { return a.volMgr.ListVolumes() }
+
+type handlerRoundTripper struct{ runtime *Runtime }
+
+func (t *handlerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t == nil || t.runtime == nil || t.runtime.Handler() == nil {
+		return nil, fmt.Errorf("storage-proxy in-process handler is not configured")
+	}
+	if err := req.Context().Err(); err != nil {
+		return nil, err
+	}
+	t.runtime.mu.Lock()
+	if !t.runtime.started || t.runtime.stopped {
+		t.runtime.mu.Unlock()
+		return nil, fmt.Errorf("storage-proxy runtime is not accepting internal requests")
+	}
+	t.runtime.internalHTTP.Add(1)
+	t.runtime.mu.Unlock()
+	defer t.runtime.internalHTTP.Done()
+
+	handlerRequest := req.Clone(req.Context())
+	recorder := &responseRecorder{header: make(http.Header), status: http.StatusOK}
+	t.runtime.Handler().ServeHTTP(recorder, handlerRequest)
+	body := recorder.body.Bytes()
+	return &http.Response{
+		StatusCode:    recorder.status,
+		Status:        fmt.Sprintf("%d %s", recorder.status, http.StatusText(recorder.status)),
+		Header:        recorder.header.Clone(),
+		Body:          io.NopCloser(bytes.NewReader(body)),
+		ContentLength: int64(len(body)),
+		Request:       handlerRequest,
+	}, nil
+}
+
+type responseRecorder struct {
+	header      http.Header
+	body        bytes.Buffer
+	status      int
+	wroteHeader bool
+}
+
+func (w *responseRecorder) Header() http.Header { return w.header }
+func (w *responseRecorder) WriteHeader(status int) {
+	if w.wroteHeader {
+		return
+	}
+	w.status = status
+	w.wroteHeader = true
+}
+func (w *responseRecorder) Write(data []byte) (int, error) {
+	if !w.wroteHeader {
+		w.WriteHeader(http.StatusOK)
+	}
+	return w.body.Write(data)
+}
+func (w *responseRecorder) Flush() {}

--- a/storage-proxy/pkg/runtime/runtime_test.go
+++ b/storage-proxy/pkg/runtime/runtime_test.go
@@ -1,0 +1,170 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
+	"go.uber.org/zap"
+)
+
+func TestInternalHTTPClientUsesRuntimeHandlerWithoutSocket(t *testing.T) {
+	r := &Runtime{
+		httpHandler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			if got := req.Header.Get("X-Test"); got != "value" {
+				t.Errorf("X-Test = %q, want value", got)
+			}
+			w.Header().Set("X-Result", "ok")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte("created"))
+		}),
+		started: true,
+	}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://storage-proxy/internal", strings.NewReader("body"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-Test", "value")
+
+	resp, err := r.InternalHTTPClient().Do(req)
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusCreated)
+	}
+	if got := resp.Header.Get("X-Result"); got != "ok" {
+		t.Fatalf("X-Result = %q, want ok", got)
+	}
+	if got := string(body); got != "created" {
+		t.Fatalf("body = %q, want created", got)
+	}
+}
+
+func TestShutdownDrainsInternalHTTPRequestsAndRejectsNewOnes(t *testing.T) {
+	requestStarted := make(chan struct{})
+	releaseRequest := make(chan struct{})
+	r := newHTTPOnlyRuntimeForTest(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(requestStarted)
+		<-releaseRequest
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	if err := r.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	requestDone := make(chan error, 1)
+	go func() {
+		resp, err := r.InternalHTTPClient().Get("http://storage-proxy/internal")
+		if resp != nil {
+			_ = resp.Body.Close()
+		}
+		requestDone <- err
+	}()
+	<-requestStarted
+
+	shutdownDone := make(chan error, 1)
+	go func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		shutdownDone <- r.Shutdown(shutdownCtx)
+	}()
+	select {
+	case err := <-shutdownDone:
+		t.Fatalf("Shutdown() returned before internal request drained: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(releaseRequest)
+	if err := <-requestDone; err != nil {
+		t.Fatalf("internal request error = %v", err)
+	}
+	if err := <-shutdownDone; err != nil {
+		t.Fatalf("Shutdown() error = %v", err)
+	}
+	if _, err := r.InternalHTTPClient().Get("http://storage-proxy/after-shutdown"); err == nil {
+		t.Fatal("internal request after shutdown succeeded")
+	}
+}
+
+func TestRuntimeStartStopsOnParentContext(t *testing.T) {
+	r := newHTTPOnlyRuntimeForTest(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	ctx, cancel := context.WithCancel(context.Background())
+	if err := r.Start(ctx); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	resp, err := http.Get("http://" + r.Address())
+	if err != nil {
+		t.Fatalf("GET runtime: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusNoContent)
+	}
+
+	cancel()
+	select {
+	case <-r.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("runtime did not stop after parent context cancellation")
+	}
+	if err := r.Start(context.Background()); err == nil || !strings.Contains(err.Error(), "stopped") {
+		t.Fatalf("Start() after shutdown error = %v, want stopped error", err)
+	}
+	if err := r.Shutdown(context.Background()); err != nil {
+		t.Fatalf("second Shutdown() error = %v", err)
+	}
+}
+
+func TestRuntimeStartReturnsListenError(t *testing.T) {
+	wantErr := errors.New("bind failed")
+	r := newHTTPOnlyRuntimeForTest(http.NotFoundHandler())
+	r.listen = func(string, string) (net.Listener, error) { return nil, wantErr }
+
+	err := r.Start(context.Background())
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("Start() error = %v, want %v", err, wantErr)
+	}
+	if err := r.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown() error = %v", err)
+	}
+}
+
+func TestBuildDirectVolumeFileCleanupInterval(t *testing.T) {
+	cfg := &config.StorageProxyConfig{CleanupInterval: "2m"}
+	if got := buildDirectVolumeFileCleanupInterval(cfg, 30*time.Second); got != 30*time.Second {
+		t.Fatalf("cleanup interval = %s, want 30s", got)
+	}
+	cfg.CleanupInterval = "100ms"
+	if got := buildDirectVolumeFileCleanupInterval(cfg, 30*time.Second); got != time.Second {
+		t.Fatalf("cleanup interval = %s, want 1s", got)
+	}
+}
+
+func newHTTPOnlyRuntimeForTest(handler http.Handler) *Runtime {
+	return &Runtime{
+		cfg:         &config.StorageProxyConfig{},
+		logger:      zap.NewNop(),
+		listen:      net.Listen,
+		httpHandler: handler,
+		httpServer: &http.Server{
+			Addr:    "127.0.0.1:0",
+			Handler: handler,
+		},
+		errors: make(chan error, 1),
+		done:   make(chan struct{}),
+	}
+}

--- a/storage-proxy/pkg/s0fs/engine.go
+++ b/storage-proxy/pkg/s0fs/engine.go
@@ -734,8 +734,8 @@ func (e *Engine) CreateSnapshot(snapshotID string) (*SnapshotState, error) {
 	if err := e.checkOpen(); err != nil {
 		return nil, err
 	}
-	if snapshotID == "" {
-		return nil, fmt.Errorf("%w: snapshot id is required", ErrInvalidInput)
+	if err := validateSnapshotID(snapshotID); err != nil {
+		return nil, err
 	}
 	state := e.snapshotStateLocked()
 	if err := e.reserveLocalDiskLocked(estimatedStateBytes(state)); err != nil {
@@ -749,6 +749,9 @@ func (e *Engine) CreateSnapshot(snapshotID string) (*SnapshotState, error) {
 }
 
 func (e *Engine) RestoreSnapshot(snapshotID string) error {
+	if err := validateSnapshotID(snapshotID); err != nil {
+		return err
+	}
 	e.mutationMu.Lock()
 	defer e.mutationMu.Unlock()
 
@@ -761,6 +764,30 @@ func (e *Engine) RestoreSnapshot(snapshotID string) error {
 	if err != nil {
 		return err
 	}
+	return e.restoreStateLocked(state)
+}
+
+// RestoreState replaces the current filesystem state with an immutable
+// snapshot loaded independently from local engine storage.
+func (e *Engine) RestoreState(state *SnapshotState) error {
+	if state == nil {
+		return fmt.Errorf("%w: snapshot state is required", ErrInvalidInput)
+	}
+	state = cloneState(state)
+	normalizeState(state)
+
+	e.mutationMu.Lock()
+	defer e.mutationMu.Unlock()
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if err := e.checkOpen(); err != nil {
+		return err
+	}
+	return e.restoreStateLocked(state)
+}
+
+func (e *Engine) restoreStateLocked(state *SnapshotState) error {
 	minNextSeq := e.nextSeq + 1
 	if committedNext := e.lastCommittedManifest + 2; committedNext > minNextSeq {
 		minNextSeq = committedNext
@@ -813,8 +840,8 @@ func (e *Engine) DeleteSnapshot(snapshotID string) error {
 	if err := e.checkOpen(); err != nil {
 		return err
 	}
-	if snapshotID == "" {
-		return fmt.Errorf("%w: snapshot id is required", ErrInvalidInput)
+	if err := validateSnapshotID(snapshotID); err != nil {
+		return err
 	}
 	if err := os.Remove(snapshotFilePath(e.wal.path, snapshotID)); err != nil {
 		if os.IsNotExist(err) {

--- a/storage-proxy/pkg/s0fs/materializer.go
+++ b/storage-proxy/pkg/s0fs/materializer.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -278,6 +279,214 @@ func (m *Materializer) LoadLatestState(ctx context.Context) (*SnapshotState, *Ma
 	return state, manifest, nil
 }
 
+func (m *Materializer) persistSnapshot(ctx context.Context, snapshotID string, state *SnapshotState) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if !m.Enabled() {
+		return fmt.Errorf("%w: materializer is not configured", ErrInvalidInput)
+	}
+	if err := validateSnapshotID(snapshotID); err != nil {
+		return err
+	}
+	if state == nil {
+		return fmt.Errorf("%w: snapshot state is required", ErrInvalidInput)
+	}
+	return m.putJSON(ctx, snapshotObjectKey(snapshotID), state)
+}
+
+func (m *Materializer) loadSnapshot(ctx context.Context, snapshotID string) (*SnapshotState, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if !m.Enabled() {
+		return nil, ErrSnapshotNotFound
+	}
+	if err := validateSnapshotID(snapshotID); err != nil {
+		return nil, err
+	}
+	var state SnapshotState
+	if err := m.getJSON(ctx, snapshotObjectKey(snapshotID), &state); err != nil {
+		if objectstore.IsNotFound(err) {
+			return nil, ErrSnapshotNotFound
+		}
+		return nil, fmt.Errorf("load snapshot object %s: %w", snapshotID, err)
+	}
+	normalizeState(&state)
+	defaultSegmentVolumeIDs(&state, m.volumeID)
+	return &state, nil
+}
+
+func (m *Materializer) deleteSnapshot(ctx context.Context, snapshotID string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if !m.Enabled() {
+		return nil
+	}
+	if err := validateSnapshotID(snapshotID); err != nil {
+		return err
+	}
+	if err := m.store.Delete(snapshotObjectKey(snapshotID)); err != nil && !objectstore.IsNotFound(err) {
+		return fmt.Errorf("delete snapshot object %s: %w", snapshotID, err)
+	}
+	return nil
+}
+
+func (m *Materializer) loadUniqueManifestAtOrBefore(ctx context.Context, cutoff time.Time, expectedSizeBytes int64) (*Manifest, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if !m.Enabled() {
+		return nil, ErrMaterializedManifestNotFound
+	}
+	if cutoff.IsZero() {
+		return nil, fmt.Errorf("%w: manifest cutoff is required", ErrInvalidInput)
+	}
+	if expectedSizeBytes < 0 {
+		return nil, fmt.Errorf("%w: expected snapshot size must be non-negative", ErrInvalidInput)
+	}
+	headBefore, err := m.loadRecoveryHead(ctx)
+	if err != nil {
+		return nil, err
+	}
+	keys, err := listObjectKeys(ctx, m.store, manifestDir+"/")
+	if err != nil {
+		return nil, err
+	}
+
+	var candidates []*Manifest
+	for _, key := range keys {
+		keySequence, ok := immutableManifestSequence(key)
+		if !ok || keySequence > headBefore.ManifestSeq {
+			continue
+		}
+		manifest, err := m.loadManifestByKey(ctx, key)
+		if err != nil {
+			return nil, err
+		}
+		if err := m.validateRecoveryManifest(key, keySequence, manifest); err != nil {
+			return nil, err
+		}
+		if manifest.CreatedAt.After(cutoff) || StateStorageBytes(manifest.State) != expectedSizeBytes {
+			continue
+		}
+		candidates = append(candidates, manifest)
+	}
+	if len(candidates) == 0 {
+		return nil, ErrMaterializedManifestNotFound
+	}
+	if len(candidates) != 1 {
+		return nil, fmt.Errorf("%w: %d immutable manifests match legacy snapshot metadata", ErrInvalidInput, len(candidates))
+	}
+	if err := m.validateRecoverySegments(ctx, candidates[0].State); err != nil {
+		return nil, err
+	}
+	headAfter, err := m.loadRecoveryHead(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if headBefore.ManifestSeq != headAfter.ManifestSeq || headBefore.ManifestKey != headAfter.ManifestKey {
+		return nil, fmt.Errorf("%w: committed head changed during legacy snapshot recovery", ErrCommittedHeadConflict)
+	}
+	return candidates[0], nil
+}
+
+func (m *Materializer) loadRecoveryHead(ctx context.Context) (*CommittedHead, error) {
+	if m.headStore != nil {
+		head, err := m.headStore.LoadCommittedHead(ctx, m.volumeID)
+		if err != nil {
+			if errors.Is(err, ErrCommittedHeadNotFound) {
+				return nil, ErrMaterializedManifestNotFound
+			}
+			return nil, err
+		}
+		if head == nil || head.VolumeID != m.volumeID || head.ManifestSeq == 0 ||
+			head.CheckpointSeq != head.ManifestSeq || head.ManifestKey != manifestKey(head.ManifestSeq) {
+			return nil, fmt.Errorf("%w: invalid committed head for volume %s", ErrInvalidInput, m.volumeID)
+		}
+		copy := *head
+		return &copy, nil
+	}
+
+	manifest, err := m.loadLegacyLatestManifest(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := m.validateRecoveryManifest(manifestKey(manifest.ManifestSeq), manifest.ManifestSeq, manifest); err != nil {
+		return nil, err
+	}
+	return &CommittedHead{
+		VolumeID:      manifest.VolumeID,
+		ManifestSeq:   manifest.ManifestSeq,
+		CheckpointSeq: manifest.CheckpointSeq,
+		ManifestKey:   manifestKey(manifest.ManifestSeq),
+		UpdatedAt:     manifest.CreatedAt,
+	}, nil
+}
+
+func (m *Materializer) validateRecoveryManifest(key string, keySequence uint64, manifest *Manifest) error {
+	if manifest == nil || manifest.State == nil {
+		return fmt.Errorf("%w: manifest %s has no state", ErrInvalidInput, key)
+	}
+	if manifest.Version != 1 {
+		return fmt.Errorf("%w: manifest %s has unsupported version %d", ErrInvalidInput, key, manifest.Version)
+	}
+	if manifest.VolumeID != m.volumeID {
+		return fmt.Errorf("%w: manifest %s belongs to volume %s", ErrInvalidInput, key, manifest.VolumeID)
+	}
+	if manifest.ManifestSeq != keySequence || manifest.CheckpointSeq != keySequence || checkpointSequence(manifest.State) != keySequence {
+		return fmt.Errorf("%w: manifest %s has inconsistent sequence metadata", ErrInvalidInput, key)
+	}
+	if manifest.CreatedAt.IsZero() {
+		return fmt.Errorf("%w: manifest %s has no creation time", ErrInvalidInput, key)
+	}
+	root := manifest.State.Nodes[RootInode]
+	if root == nil || root.Type != TypeDirectory {
+		return fmt.Errorf("%w: manifest %s has no valid root inode", ErrInvalidInput, key)
+	}
+	return nil
+}
+
+func (m *Materializer) validateRecoverySegments(ctx context.Context, state *SnapshotState) error {
+	seen := make(map[string]struct{})
+	for _, extents := range state.ColdFiles {
+		for _, extent := range extents {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			if extent.SegmentID == "" {
+				continue
+			}
+			segment := state.Segments[extent.SegmentID]
+			if segment == nil || segment.ID != extent.SegmentID {
+				return fmt.Errorf("%w: recovery state is missing segment %s", ErrInvalidInput, extent.SegmentID)
+			}
+			if extent.Offset > segment.Length || extent.Length > segment.Length-extent.Offset {
+				return fmt.Errorf("%w: recovery extent exceeds segment %s", ErrInvalidInput, extent.SegmentID)
+			}
+			if _, ok := seen[extent.SegmentID]; ok {
+				continue
+			}
+			seen[extent.SegmentID] = struct{}{}
+			if isInlineSegment(segment) {
+				continue
+			}
+			if strings.TrimSpace(segment.Key) == "" {
+				return fmt.Errorf("%w: recovery segment %s has no object key", ErrInvalidInput, segment.ID)
+			}
+			_, store, err := m.storeForSegment(segment)
+			if err != nil {
+				return err
+			}
+			if _, err := store.Head(segment.Key); err != nil {
+				return fmt.Errorf("validate recovery segment %s: %w", segment.ID, err)
+			}
+		}
+	}
+	return nil
+}
+
 type materializedSegment struct {
 	ID         string
 	VolumeID   string
@@ -476,6 +685,27 @@ func (b *segmentBuilder) finish() []*materializedSegment {
 
 func manifestKey(seq uint64) string {
 	return fmt.Sprintf("%s/%020d.json", manifestDir, seq)
+}
+
+func snapshotObjectKey(snapshotID string) string {
+	return fmt.Sprintf("snapshots/%s.json", snapshotID)
+}
+
+func immutableManifestSequence(key string) (uint64, bool) {
+	const suffix = ".json"
+	name := strings.TrimPrefix(key, manifestDir+"/")
+	if name == key || !strings.HasSuffix(name, suffix) {
+		return 0, false
+	}
+	digits := strings.TrimSuffix(name, suffix)
+	if len(digits) != 20 {
+		return 0, false
+	}
+	sequence, err := strconv.ParseUint(digits, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return sequence, true
 }
 
 func checkpointSequence(state *SnapshotState) uint64 {

--- a/storage-proxy/pkg/s0fs/snapshot.go
+++ b/storage-proxy/pkg/s0fs/snapshot.go
@@ -9,15 +9,160 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"time"
 )
 
 var ErrSnapshotNotFound = fmt.Errorf("%w: snapshot not found", ErrNotFound)
 
-func LoadSnapshot(_ context.Context, cfg Config, snapshotID string) (*SnapshotState, error) {
-	if cfg.WALPath == "" {
-		return nil, fmt.Errorf("%w: wal path is required", ErrInvalidInput)
+// PersistSnapshot stores immutable snapshot state in object storage and keeps
+// a local copy as a disposable cache. Object storage is the canonical copy
+// whenever it is configured.
+func PersistSnapshot(ctx context.Context, cfg Config, snapshotID string, state *SnapshotState) error {
+	if err := validateSnapshotConfig(cfg, snapshotID); err != nil {
+		return err
 	}
+	if state == nil {
+		return fmt.Errorf("%w: snapshot state is required", ErrInvalidInput)
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	if materializer := snapshotMaterializer(cfg); materializer != nil {
+		if err := materializer.persistSnapshot(ctx, snapshotID, state); err != nil {
+			return err
+		}
+		// The object is canonical. Failure to refresh the disposable local
+		// cache must not turn a durable snapshot into a failed operation.
+		_ = saveSnapshotState(snapshotFilePath(cfg.WALPath, snapshotID), cfg.VolumeID, "snapshot:"+snapshotID, state, cfg.Encryption)
+		return nil
+	}
+	return saveSnapshotState(snapshotFilePath(cfg.WALPath, snapshotID), cfg.VolumeID, "snapshot:"+snapshotID, state, cfg.Encryption)
+}
+
+// LoadSnapshot loads canonical snapshot state from object storage. When only a
+// legacy local snapshot exists, it is durably backfilled before being returned.
+func LoadSnapshot(ctx context.Context, cfg Config, snapshotID string) (*SnapshotState, error) {
+	if err := validateSnapshotConfig(cfg, snapshotID); err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	if materializer := snapshotMaterializer(cfg); materializer != nil {
+		state, err := materializer.loadSnapshot(ctx, snapshotID)
+		if err == nil {
+			// A local cache write must not make a durable snapshot unavailable.
+			_ = saveSnapshotState(snapshotFilePath(cfg.WALPath, snapshotID), cfg.VolumeID, "snapshot:"+snapshotID, state, cfg.Encryption)
+			return state, nil
+		}
+		if !errors.Is(err, ErrSnapshotNotFound) {
+			return nil, err
+		}
+
+		state, localErr := loadLocalSnapshot(cfg, snapshotID)
+		if localErr != nil {
+			return nil, localErr
+		}
+		if err := materializer.persistSnapshot(ctx, snapshotID, state); err != nil {
+			return nil, fmt.Errorf("backfill legacy snapshot %s: %w", snapshotID, err)
+		}
+		return state, nil
+	}
+
+	return loadLocalSnapshot(cfg, snapshotID)
+}
+
+// DeleteSnapshot removes both the canonical object and the disposable local
+// cache. Missing copies are treated as already deleted.
+func DeleteSnapshot(ctx context.Context, cfg Config, snapshotID string) error {
+	if err := validateSnapshotConfig(cfg, snapshotID); err != nil {
+		return err
+	}
+	var errs []error
+	if materializer := snapshotMaterializer(cfg); materializer != nil {
+		if err := materializer.deleteSnapshot(ctx, snapshotID); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if err := deleteLocalSnapshot(cfg, snapshotID); err != nil {
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
+}
+
+// RecoverSnapshotFromManifest returns the only committed-head-bounded
+// materialized state that matches the legacy snapshot time and size metadata.
+// It is a fail-closed, best-effort migration primitive for snapshots whose
+// local-only state has already disappeared.
+func RecoverSnapshotFromManifest(ctx context.Context, cfg Config, cutoff time.Time, expectedSizeBytes int64) (*SnapshotState, *Manifest, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
+	}
+	if strings.TrimSpace(cfg.VolumeID) == "" {
+		return nil, nil, fmt.Errorf("%w: volume id is required", ErrInvalidInput)
+	}
+	if cutoff.IsZero() {
+		return nil, nil, fmt.Errorf("%w: manifest cutoff is required", ErrInvalidInput)
+	}
+	if expectedSizeBytes < 0 {
+		return nil, nil, fmt.Errorf("%w: expected snapshot size must be non-negative", ErrInvalidInput)
+	}
+	materializer := snapshotMaterializer(cfg)
+	if materializer == nil {
+		return nil, nil, ErrMaterializedManifestNotFound
+	}
+	manifest, err := materializer.loadUniqueManifestAtOrBefore(ctx, cutoff, expectedSizeBytes)
+	if err != nil {
+		return nil, nil, err
+	}
+	return cloneState(manifest.State), manifest, nil
+}
+
+func validateSnapshotConfig(cfg Config, snapshotID string) error {
+	if cfg.WALPath == "" {
+		return fmt.Errorf("%w: wal path is required", ErrInvalidInput)
+	}
+	if err := validateSnapshotID(snapshotID); err != nil {
+		return err
+	}
+	if cfg.ObjectStore != nil && strings.TrimSpace(cfg.VolumeID) == "" {
+		return fmt.Errorf("%w: volume id is required", ErrInvalidInput)
+	}
+	return nil
+}
+
+func validateSnapshotID(snapshotID string) error {
+	if strings.TrimSpace(snapshotID) == "" {
+		return fmt.Errorf("%w: snapshot id is required", ErrInvalidInput)
+	}
+	if snapshotID != strings.TrimSpace(snapshotID) || snapshotID == "." || snapshotID == ".." || strings.ContainsAny(snapshotID, `/\`) {
+		return fmt.Errorf("%w: snapshot id must be a single path-safe segment", ErrInvalidInput)
+	}
+	return nil
+}
+
+func snapshotMaterializer(cfg Config) *Materializer {
+	materializer := NewMaterializer(cfg.VolumeID, cfg.ObjectStore, cfg.HeadStore, cfg.ObjectStoreForVolume)
+	if materializer != nil {
+		materializer.SetEncryption(cfg.Encryption)
+	}
+	return materializer
+}
+
+func loadLocalSnapshot(cfg Config, snapshotID string) (*SnapshotState, error) {
 	return loadSnapshotState(snapshotFilePath(cfg.WALPath, snapshotID), cfg.VolumeID, "snapshot:"+snapshotID, cfg.Encryption)
+}
+
+func deleteLocalSnapshot(cfg Config, snapshotID string) error {
+	if err := os.Remove(snapshotFilePath(cfg.WALPath, snapshotID)); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("delete local snapshot state: %w", err)
+	}
+	return nil
 }
 
 func LoadLocalSnapshots(ctx context.Context, cfg Config) ([]*SnapshotState, error) {

--- a/storage-proxy/pkg/s0fs/snapshot_persistence_test.go
+++ b/storage-proxy/pkg/s0fs/snapshot_persistence_test.go
@@ -1,0 +1,498 @@
+package s0fs
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/objectstore"
+)
+
+func TestPersistedSnapshotLoadsFromFreshCache(t *testing.T) {
+	ctx := context.Background()
+	store := objectstore.NewMemoryStore(t.Name())
+	cfg := Config{
+		VolumeID:    "vol-durable",
+		WALPath:     filepath.Join(t.TempDir(), "engine.wal"),
+		ObjectStore: store,
+		Encryption:  testEncryptionConfig(16),
+	}
+	state := snapshotStateWithFile(t, "durable.txt", "durable snapshot payload")
+
+	if err := PersistSnapshot(ctx, cfg, "snap-durable", state); err != nil {
+		t.Fatalf("PersistSnapshot() error = %v", err)
+	}
+	assertObjectDoesNotContain(t, store, snapshotObjectKey("snap-durable"), []byte("durable snapshot payload"))
+
+	freshCfg := cfg
+	freshCfg.WALPath = filepath.Join(t.TempDir(), "engine.wal")
+	loaded, err := LoadSnapshot(ctx, freshCfg, "snap-durable")
+	if err != nil {
+		t.Fatalf("LoadSnapshot() from fresh cache error = %v", err)
+	}
+	assertSnapshotFilePayload(t, loaded, "durable.txt", "durable snapshot payload")
+	if _, err := os.Stat(snapshotFilePath(freshCfg.WALPath, "snap-durable")); err != nil {
+		t.Fatalf("local snapshot cache stat error = %v", err)
+	}
+}
+
+func TestPersistSnapshotDoesNotFailWhenCanonicalObjectOutlivesLocalCache(t *testing.T) {
+	ctx := context.Background()
+	store := objectstore.NewMemoryStore(t.Name())
+	blockedParent := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(blockedParent, []byte("block local cache"), 0o600); err != nil {
+		t.Fatalf("WriteFile(blocked parent) error = %v", err)
+	}
+	cfg := Config{
+		VolumeID:    "vol-cache-failure",
+		WALPath:     filepath.Join(blockedParent, "engine.wal"),
+		ObjectStore: store,
+	}
+	state := snapshotStateWithFile(t, "durable.txt", "canonical")
+
+	if err := PersistSnapshot(ctx, cfg, "snap-cache-failure", state); err != nil {
+		t.Fatalf("PersistSnapshot() local cache failure error = %v", err)
+	}
+	freshCfg := cfg
+	freshCfg.WALPath = filepath.Join(t.TempDir(), "engine.wal")
+	loaded, err := LoadSnapshot(ctx, freshCfg, "snap-cache-failure")
+	if err != nil {
+		t.Fatalf("LoadSnapshot() canonical object error = %v", err)
+	}
+	assertSnapshotFilePayload(t, loaded, "durable.txt", "canonical")
+}
+
+func TestLoadSnapshotBackfillsLegacyLocalState(t *testing.T) {
+	ctx := context.Background()
+	store := objectstore.NewMemoryStore(t.Name())
+	cfg := Config{
+		VolumeID:    "vol-legacy",
+		WALPath:     filepath.Join(t.TempDir(), "engine.wal"),
+		ObjectStore: store,
+	}
+	state := snapshotStateWithFile(t, "legacy.txt", "legacy payload")
+	if err := saveSnapshotState(snapshotFilePath(cfg.WALPath, "snap-legacy"), cfg.VolumeID, "snapshot:snap-legacy", state, nil); err != nil {
+		t.Fatalf("saveSnapshotState() error = %v", err)
+	}
+	if _, err := store.Head(snapshotObjectKey("snap-legacy")); !objectstore.IsNotFound(err) {
+		t.Fatalf("legacy snapshot object Head() error = %v, want not found", err)
+	}
+
+	loaded, err := LoadSnapshot(ctx, cfg, "snap-legacy")
+	if err != nil {
+		t.Fatalf("LoadSnapshot() legacy error = %v", err)
+	}
+	assertSnapshotFilePayload(t, loaded, "legacy.txt", "legacy payload")
+	if _, err := store.Head(snapshotObjectKey("snap-legacy")); err != nil {
+		t.Fatalf("backfilled snapshot object Head() error = %v", err)
+	}
+
+	freshCfg := cfg
+	freshCfg.WALPath = filepath.Join(t.TempDir(), "engine.wal")
+	loaded, err = LoadSnapshot(ctx, freshCfg, "snap-legacy")
+	if err != nil {
+		t.Fatalf("LoadSnapshot() backfilled snapshot from fresh cache error = %v", err)
+	}
+	assertSnapshotFilePayload(t, loaded, "legacy.txt", "legacy payload")
+}
+
+func TestLoadSnapshotRequiresSuccessfulLegacyBackfill(t *testing.T) {
+	ctx := context.Background()
+	store := &snapshotPutFailingStore{Store: objectstore.NewMemoryStore(t.Name())}
+	cfg := Config{
+		VolumeID:    "vol-backfill-failure",
+		WALPath:     filepath.Join(t.TempDir(), "engine.wal"),
+		ObjectStore: store,
+	}
+	state := snapshotStateWithFile(t, "legacy.txt", "legacy payload")
+	if err := saveSnapshotState(snapshotFilePath(cfg.WALPath, "snap-legacy"), cfg.VolumeID, "snapshot:snap-legacy", state, nil); err != nil {
+		t.Fatalf("saveSnapshotState() error = %v", err)
+	}
+
+	_, err := LoadSnapshot(ctx, cfg, "snap-legacy")
+	if err == nil || !errors.Is(err, errSnapshotPutFailed) {
+		t.Fatalf("LoadSnapshot() error = %v, want snapshot put failure", err)
+	}
+}
+
+func TestLoadSnapshotPrefersCanonicalObject(t *testing.T) {
+	ctx := context.Background()
+	store := objectstore.NewMemoryStore(t.Name())
+	cfg := Config{
+		VolumeID:    "vol-canonical",
+		WALPath:     filepath.Join(t.TempDir(), "engine.wal"),
+		ObjectStore: store,
+	}
+	canonical := snapshotStateWithFile(t, "state.txt", "canonical")
+	if err := PersistSnapshot(ctx, cfg, "snap-canonical", canonical); err != nil {
+		t.Fatalf("PersistSnapshot() error = %v", err)
+	}
+	stale := snapshotStateWithFile(t, "state.txt", "stale-local")
+	if err := saveSnapshotState(snapshotFilePath(cfg.WALPath, "snap-canonical"), cfg.VolumeID, "snapshot:snap-canonical", stale, nil); err != nil {
+		t.Fatalf("save stale local snapshot error = %v", err)
+	}
+
+	loaded, err := LoadSnapshot(ctx, cfg, "snap-canonical")
+	if err != nil {
+		t.Fatalf("LoadSnapshot() error = %v", err)
+	}
+	assertSnapshotFilePayload(t, loaded, "state.txt", "canonical")
+}
+
+func TestDeleteSnapshotRemovesCanonicalAndLocalCopies(t *testing.T) {
+	ctx := context.Background()
+	store := objectstore.NewMemoryStore(t.Name())
+	cfg := Config{
+		VolumeID:    "vol-delete",
+		WALPath:     filepath.Join(t.TempDir(), "engine.wal"),
+		ObjectStore: store,
+	}
+	if err := PersistSnapshot(ctx, cfg, "snap-delete", snapshotStateWithFile(t, "delete.txt", "payload")); err != nil {
+		t.Fatalf("PersistSnapshot() error = %v", err)
+	}
+
+	if err := DeleteSnapshot(ctx, cfg, "snap-delete"); err != nil {
+		t.Fatalf("DeleteSnapshot() error = %v", err)
+	}
+	if _, err := store.Head(snapshotObjectKey("snap-delete")); !objectstore.IsNotFound(err) {
+		t.Fatalf("deleted snapshot object Head() error = %v, want not found", err)
+	}
+	if _, err := os.Stat(snapshotFilePath(cfg.WALPath, "snap-delete")); !os.IsNotExist(err) {
+		t.Fatalf("deleted local snapshot stat error = %v, want not exist", err)
+	}
+	if err := DeleteSnapshot(ctx, cfg, "snap-delete"); err != nil {
+		t.Fatalf("DeleteSnapshot() repeated error = %v", err)
+	}
+}
+
+func TestRecoverSnapshotFromManifestSelectsNewestBeforeCutoff(t *testing.T) {
+	ctx := context.Background()
+	store := objectstore.NewMemoryStore(t.Name())
+	cfg := Config{
+		VolumeID:    "vol-recover",
+		WALPath:     filepath.Join(t.TempDir(), "engine.wal"),
+		ObjectStore: store,
+	}
+	materializer := snapshotMaterializer(cfg)
+	base := time.Date(2026, 7, 16, 8, 0, 0, 0, time.UTC)
+	manifests := []*Manifest{
+		recoveryManifest(t, cfg.VolumeID, 2, base.Add(time.Minute), "first"),
+		recoveryManifest(t, cfg.VolumeID, 4, base, "selected"),
+		recoveryManifest(t, cfg.VolumeID, 6, base.Add(2*time.Minute), "future"),
+	}
+	for _, manifest := range manifests {
+		if err := materializer.putJSON(ctx, manifestKey(manifest.ManifestSeq), manifest); err != nil {
+			t.Fatalf("put manifest %d error = %v", manifest.ManifestSeq, err)
+		}
+	}
+	legacyLatest := recoveryManifest(t, cfg.VolumeID, 100, base.Add(3*time.Minute), "legacy-latest")
+	if err := materializer.putJSON(ctx, manifestLatestKey, legacyLatest); err != nil {
+		t.Fatalf("put legacy latest manifest error = %v", err)
+	}
+	if err := store.Put("manifests/not-an-immutable-manifest.json", bytes.NewBufferString("not-json")); err != nil {
+		t.Fatalf("put non-immutable manifest object error = %v", err)
+	}
+
+	expectedSize := StateStorageBytes(manifests[1].State)
+	state, manifest, err := RecoverSnapshotFromManifest(ctx, cfg, base.Add(90*time.Second), expectedSize)
+	if err != nil {
+		t.Fatalf("RecoverSnapshotFromManifest() error = %v", err)
+	}
+	if manifest.ManifestSeq != 4 {
+		t.Fatalf("recovered manifest seq = %d, want 4", manifest.ManifestSeq)
+	}
+	assertSnapshotFilePayload(t, state, "state.txt", "selected")
+
+	_, _, err = RecoverSnapshotFromManifest(ctx, cfg, base.Add(-time.Second), expectedSize)
+	if !errors.Is(err, ErrMaterializedManifestNotFound) {
+		t.Fatalf("RecoverSnapshotFromManifest() before first error = %v, want ErrMaterializedManifestNotFound", err)
+	}
+}
+
+func TestRecoverSnapshotFromManifestRejectsInvalidCandidates(t *testing.T) {
+	ctx := context.Background()
+	base := time.Date(2026, 7, 16, 8, 0, 0, 0, time.UTC)
+
+	t.Run("corrupt object", func(t *testing.T) {
+		store := objectstore.NewMemoryStore(t.Name())
+		cfg := Config{VolumeID: "vol-corrupt", WALPath: filepath.Join(t.TempDir(), "engine.wal"), ObjectStore: store}
+		if err := snapshotMaterializer(cfg).putJSON(ctx, manifestLatestKey, recoveryManifest(t, cfg.VolumeID, 2, base, "head")); err != nil {
+			t.Fatalf("put recovery head error = %v", err)
+		}
+		if err := store.Put(manifestKey(2), bytes.NewBufferString("not-json")); err != nil {
+			t.Fatalf("Put() error = %v", err)
+		}
+		if _, _, err := RecoverSnapshotFromManifest(ctx, cfg, base, 0); err == nil {
+			t.Fatal("RecoverSnapshotFromManifest() corrupt object returned nil error")
+		}
+	})
+
+	t.Run("encrypted object without key", func(t *testing.T) {
+		store := objectstore.NewMemoryStore(t.Name())
+		cfg := Config{
+			VolumeID: "vol-encrypted", WALPath: filepath.Join(t.TempDir(), "engine.wal"),
+			ObjectStore: store, Encryption: testEncryptionConfig(16),
+		}
+		manifest := recoveryManifest(t, cfg.VolumeID, 2, base, "encrypted")
+		if err := snapshotMaterializer(cfg).putJSON(ctx, manifestKey(2), manifest); err != nil {
+			t.Fatalf("put encrypted manifest error = %v", err)
+		}
+		if err := snapshotMaterializer(cfg).putJSON(ctx, manifestLatestKey, manifest); err != nil {
+			t.Fatalf("put encrypted recovery head error = %v", err)
+		}
+		cfg.Encryption = nil
+		if _, _, err := RecoverSnapshotFromManifest(ctx, cfg, base, StateStorageBytes(manifest.State)); err == nil {
+			t.Fatal("RecoverSnapshotFromManifest() encrypted object without key returned nil error")
+		}
+	})
+
+	tests := []struct {
+		name     string
+		volumeID string
+		state    *SnapshotState
+	}{
+		{name: "wrong volume", volumeID: "another-volume", state: snapshotStateWithFile(t, "state.txt", "wrong-volume")},
+		{name: "nil state", volumeID: "vol-invalid", state: nil},
+		{name: "missing root", volumeID: "vol-invalid", state: &SnapshotState{NextSeq: 3, Nodes: map[uint64]*Node{}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := objectstore.NewMemoryStore(t.Name())
+			cfg := Config{VolumeID: "vol-invalid", WALPath: filepath.Join(t.TempDir(), "engine.wal"), ObjectStore: store}
+			if tt.state != nil && tt.state.NextSeq == 0 {
+				tt.state.NextSeq = 3
+			}
+			manifest := &Manifest{Version: 1, VolumeID: tt.volumeID, ManifestSeq: 2, CheckpointSeq: 2, CreatedAt: base, State: tt.state}
+			if err := snapshotMaterializer(cfg).putJSON(ctx, manifestLatestKey, recoveryManifest(t, cfg.VolumeID, 2, base, "head")); err != nil {
+				t.Fatalf("put recovery head error = %v", err)
+			}
+			if err := snapshotMaterializer(cfg).putJSON(ctx, manifestKey(2), manifest); err != nil {
+				t.Fatalf("put invalid manifest error = %v", err)
+			}
+			if _, _, err := RecoverSnapshotFromManifest(ctx, cfg, base, 0); err == nil {
+				t.Fatal("RecoverSnapshotFromManifest() invalid candidate returned nil error")
+			}
+		})
+	}
+}
+
+func TestRecoverSnapshotFromManifestBoundsHeadAndRejectsAmbiguity(t *testing.T) {
+	ctx := context.Background()
+	base := time.Date(2026, 7, 16, 8, 0, 0, 0, time.UTC)
+
+	t.Run("ignores manifest above committed head", func(t *testing.T) {
+		store := objectstore.NewMemoryStore(t.Name())
+		cfg := Config{VolumeID: "vol-bounded", WALPath: filepath.Join(t.TempDir(), "engine.wal"), ObjectStore: store}
+		materializer := snapshotMaterializer(cfg)
+		committed := recoveryManifest(t, cfg.VolumeID, 4, base, "committed")
+		orphan := recoveryManifest(t, cfg.VolumeID, 6, base.Add(time.Second), "orphaned!")
+		for _, manifest := range []*Manifest{committed, orphan} {
+			if err := materializer.putJSON(ctx, manifestKey(manifest.ManifestSeq), manifest); err != nil {
+				t.Fatalf("put manifest %d error = %v", manifest.ManifestSeq, err)
+			}
+		}
+		if err := materializer.putJSON(ctx, manifestLatestKey, committed); err != nil {
+			t.Fatalf("put recovery head error = %v", err)
+		}
+		state, manifest, err := RecoverSnapshotFromManifest(ctx, cfg, base.Add(2*time.Second), StateStorageBytes(committed.State))
+		if err != nil {
+			t.Fatalf("RecoverSnapshotFromManifest() error = %v", err)
+		}
+		if manifest.ManifestSeq != committed.ManifestSeq {
+			t.Fatalf("manifest seq = %d, want %d", manifest.ManifestSeq, committed.ManifestSeq)
+		}
+		assertSnapshotFilePayload(t, state, "state.txt", "committed")
+	})
+
+	t.Run("rejects multiple size matches", func(t *testing.T) {
+		store := objectstore.NewMemoryStore(t.Name())
+		cfg := Config{VolumeID: "vol-ambiguous", WALPath: filepath.Join(t.TempDir(), "engine.wal"), ObjectStore: store}
+		materializer := snapshotMaterializer(cfg)
+		first := recoveryManifest(t, cfg.VolumeID, 2, base, "first")
+		second := recoveryManifest(t, cfg.VolumeID, 4, base.Add(time.Second), "other")
+		for _, manifest := range []*Manifest{first, second} {
+			if err := materializer.putJSON(ctx, manifestKey(manifest.ManifestSeq), manifest); err != nil {
+				t.Fatalf("put manifest %d error = %v", manifest.ManifestSeq, err)
+			}
+		}
+		if err := materializer.putJSON(ctx, manifestLatestKey, second); err != nil {
+			t.Fatalf("put recovery head error = %v", err)
+		}
+		_, _, err := RecoverSnapshotFromManifest(ctx, cfg, base.Add(2*time.Second), StateStorageBytes(first.State))
+		if !errors.Is(err, ErrInvalidInput) {
+			t.Fatalf("RecoverSnapshotFromManifest() error = %v, want ErrInvalidInput", err)
+		}
+	})
+
+	t.Run("rejects committed head changes", func(t *testing.T) {
+		store := objectstore.NewMemoryStore(t.Name())
+		committed := recoveryManifest(t, "vol-head-change", 2, base, "committed")
+		advanced := recoveryManifest(t, "vol-head-change", 4, base.Add(time.Second), "advanced!")
+		heads := &changingRecoveryHeadStore{heads: []*CommittedHead{
+			recoveryHeadForManifest(committed),
+			recoveryHeadForManifest(advanced),
+		}}
+		cfg := Config{
+			VolumeID: "vol-head-change", WALPath: filepath.Join(t.TempDir(), "engine.wal"),
+			ObjectStore: store, HeadStore: heads,
+		}
+		if err := snapshotMaterializer(cfg).putJSON(ctx, manifestKey(committed.ManifestSeq), committed); err != nil {
+			t.Fatalf("put committed manifest error = %v", err)
+		}
+		_, _, err := RecoverSnapshotFromManifest(ctx, cfg, base.Add(2*time.Second), StateStorageBytes(committed.State))
+		if !errors.Is(err, ErrCommittedHeadConflict) {
+			t.Fatalf("RecoverSnapshotFromManifest() error = %v, want ErrCommittedHeadConflict", err)
+		}
+	})
+}
+
+func TestSnapshotIDMustBePathSafe(t *testing.T) {
+	cfg := Config{
+		VolumeID:    "vol-safe-id",
+		WALPath:     filepath.Join(t.TempDir(), "engine.wal"),
+		ObjectStore: objectstore.NewMemoryStore(t.Name()),
+	}
+	state := snapshotStateWithFile(t, "state.txt", "payload")
+	for _, snapshotID := range []string{"../escape", "nested/id", `nested\id`, " padded "} {
+		t.Run(snapshotID, func(t *testing.T) {
+			if err := PersistSnapshot(context.Background(), cfg, snapshotID, state); !errors.Is(err, ErrInvalidInput) {
+				t.Fatalf("PersistSnapshot(%q) error = %v, want ErrInvalidInput", snapshotID, err)
+			}
+		})
+	}
+}
+
+func TestEngineRestoreStateDoesNotMutateInput(t *testing.T) {
+	ctx := context.Background()
+	engine, err := Open(ctx, Config{
+		VolumeID: "vol-restore-state",
+		WALPath:  filepath.Join(t.TempDir(), "engine.wal"),
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer engine.Close()
+
+	current, err := engine.CreateFile(RootInode, "current.txt", 0o644)
+	if err != nil {
+		t.Fatalf("CreateFile() error = %v", err)
+	}
+	if _, err := engine.Write(current.Inode, 0, []byte("current")); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	state := snapshotStateWithFile(t, "restored.txt", "restored")
+	originalNextSeq := state.NextSeq
+
+	if err := engine.RestoreState(state); err != nil {
+		t.Fatalf("RestoreState() error = %v", err)
+	}
+	if state.NextSeq != originalNextSeq {
+		t.Fatalf("RestoreState() mutated input next seq = %d, want %d", state.NextSeq, originalNextSeq)
+	}
+	if _, err := engine.Lookup(RootInode, "current.txt"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Lookup(current.txt) error = %v, want ErrNotFound", err)
+	}
+	restored, err := engine.Lookup(RootInode, "restored.txt")
+	if err != nil {
+		t.Fatalf("Lookup(restored.txt) error = %v", err)
+	}
+	payload, err := engine.Read(restored.Inode, 0, restored.Size)
+	if err != nil {
+		t.Fatalf("Read(restored.txt) error = %v", err)
+	}
+	if !bytes.Equal(payload, []byte("restored")) {
+		t.Fatalf("restored payload = %q, want restored", payload)
+	}
+}
+
+func snapshotStateWithFile(t *testing.T, name, payload string) *SnapshotState {
+	t.Helper()
+	engine, err := Open(context.Background(), Config{
+		VolumeID: "state-builder",
+		WALPath:  filepath.Join(t.TempDir(), "engine.wal"),
+	})
+	if err != nil {
+		t.Fatalf("Open(state builder) error = %v", err)
+	}
+	defer engine.Close()
+	node, err := engine.CreateFile(RootInode, name, 0o644)
+	if err != nil {
+		t.Fatalf("CreateFile(%q) error = %v", name, err)
+	}
+	if _, err := engine.Write(node.Inode, 0, []byte(payload)); err != nil {
+		t.Fatalf("Write(%q) error = %v", name, err)
+	}
+	return engine.SnapshotState()
+}
+
+func recoveryManifest(t *testing.T, volumeID string, sequence uint64, createdAt time.Time, payload string) *Manifest {
+	t.Helper()
+	state := snapshotStateWithFile(t, "state.txt", payload)
+	state.NextSeq = sequence + 1
+	return &Manifest{
+		Version:       1,
+		VolumeID:      volumeID,
+		ManifestSeq:   sequence,
+		CheckpointSeq: sequence,
+		CreatedAt:     createdAt,
+		State:         state,
+	}
+}
+
+func recoveryHeadForManifest(manifest *Manifest) *CommittedHead {
+	return &CommittedHead{
+		VolumeID:      manifest.VolumeID,
+		ManifestSeq:   manifest.ManifestSeq,
+		CheckpointSeq: manifest.CheckpointSeq,
+		ManifestKey:   manifestKey(manifest.ManifestSeq),
+		UpdatedAt:     manifest.CreatedAt,
+	}
+}
+
+type changingRecoveryHeadStore struct {
+	heads []*CommittedHead
+	loads int
+}
+
+func (s *changingRecoveryHeadStore) LoadCommittedHead(context.Context, string) (*CommittedHead, error) {
+	if len(s.heads) == 0 {
+		return nil, ErrCommittedHeadNotFound
+	}
+	index := s.loads
+	if index >= len(s.heads) {
+		index = len(s.heads) - 1
+	}
+	s.loads++
+	copy := *s.heads[index]
+	return &copy, nil
+}
+
+func (s *changingRecoveryHeadStore) CompareAndSwapCommittedHead(context.Context, string, uint64, *CommittedHead) error {
+	return nil
+}
+
+func assertSnapshotFilePayload(t *testing.T, state *SnapshotState, name, want string) {
+	t.Helper()
+	node, err := state.Lookup(RootInode, name)
+	if err != nil {
+		t.Fatalf("snapshot Lookup(%q) error = %v", name, err)
+	}
+	if got := string(state.Data[node.Inode]); got != want {
+		t.Fatalf("snapshot payload for %q = %q, want %q", name, got, want)
+	}
+}
+
+var errSnapshotPutFailed = errors.New("snapshot put failed")
+
+type snapshotPutFailingStore struct {
+	objectstore.Store
+}
+
+func (s *snapshotPutFailingStore) Put(_ string, _ io.Reader) error {
+	return errSnapshotPutFailed
+}

--- a/storage-proxy/pkg/snapshot/casefold.go
+++ b/storage-proxy/pkg/snapshot/casefold.go
@@ -126,7 +126,7 @@ func (m *Manager) openSnapshotArchiveSession(
 		return volume, snap, session, rootInode, rootAttr, nil
 	}
 
-	session, rootInode, rootAttr, err := m.openS0FSSnapshotArchiveSession(ctx, volumeID, snapshotID)
+	session, rootInode, rootAttr, err := m.openS0FSSnapshotArchiveSession(ctx, volumeID, snap)
 	if err != nil {
 		if errors.Is(err, s0fs.ErrSnapshotNotFound) {
 			return nil, nil, nil, 0, nil, ErrSnapshotNotFound

--- a/storage-proxy/pkg/snapshot/manager.go
+++ b/storage-proxy/pkg/snapshot/manager.go
@@ -597,10 +597,14 @@ func (m *Manager) DeleteSnapshot(ctx context.Context, volumeID, snapshotID, team
 
 	// 3. Clean up snapshot state outside the transaction.
 	// This is done after the DB transaction to avoid long-running transactions.
-	if cleanupErr := m.deleteS0FSSnapshot(ctx, volumeID, snapshotID); cleanupErr != nil {
+	// Once the catalog deletion commits, cleanup must not inherit a canceled
+	// client request or it can permanently strand the canonical object.
+	cleanupCtx, cancelCleanup := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	defer cancelCleanup()
+	if cleanupErr := m.deleteS0FSSnapshot(cleanupCtx, volumeID, snapshotID); cleanupErr != nil {
 		m.logger.WithError(cleanupErr).Warn("Failed to delete s0fs snapshot state")
 	}
-	if gcResult, gcErr := m.garbageCollectS0FSVolumeObjects(ctx, volumeID, teamID); gcErr != nil {
+	if gcResult, gcErr := m.garbageCollectS0FSVolumeObjects(cleanupCtx, volumeID, teamID); gcErr != nil {
 		m.logger.WithError(gcErr).Warn("Failed to garbage collect unreferenced s0fs objects")
 	} else if gcResult != nil && (len(gcResult.DeletedSegments) > 0 || len(gcResult.DeletedManifests) > 0) {
 		m.logger.WithFields(logrus.Fields{

--- a/storage-proxy/pkg/snapshot/manager_s0fs_test.go
+++ b/storage-proxy/pkg/snapshot/manager_s0fs_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/objectstore"
@@ -81,6 +82,181 @@ func TestS0FSSnapshotCreateRestoreAndDelete(t *testing.T) {
 	}
 	if len(repo.deleted) != 1 || repo.deleted[0] != snap.ID {
 		t.Fatalf("deleted snapshots = %v", repo.deleted)
+	}
+}
+
+func TestS0FSSnapshotDeleteCleansCanonicalObjectAfterRequestCancellation(t *testing.T) {
+	t.Parallel()
+
+	mgr, repo, _, engine := newS0FSSnapshotTestManager(t, "vol-delete-canceled")
+	writeS0FSFile(t, engine, "state.txt", "payload")
+	snap, err := mgr.CreateSnapshot(context.Background(), &CreateSnapshotRequest{
+		VolumeID: "vol-delete-canceled",
+		Name:     "snap-delete-canceled",
+		TeamID:   "team-1",
+		UserID:   "user-1",
+	})
+	if err != nil {
+		t.Fatalf("CreateSnapshot() error = %v", err)
+	}
+	cfg, err := mgr.s0fsConfig("team-1", "vol-delete-canceled")
+	if err != nil {
+		t.Fatalf("s0fsConfig() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	mgr.repo = &cancelAfterTxRepo{fakeRepo: repo, cancel: cancel}
+	if err := mgr.DeleteSnapshot(ctx, "vol-delete-canceled", snap.ID, "team-1"); err != nil {
+		t.Fatalf("DeleteSnapshot() error = %v", err)
+	}
+	if ctx.Err() == nil {
+		t.Fatal("delete request context was not canceled after transaction")
+	}
+	if _, err := s0fs.LoadSnapshot(context.Background(), cfg, snap.ID); !errors.Is(err, s0fs.ErrSnapshotNotFound) {
+		t.Fatalf("LoadSnapshot() after canceled delete error = %v, want ErrSnapshotNotFound", err)
+	}
+}
+
+func TestS0FSSnapshotRestoreSurvivesCacheReplacement(t *testing.T) {
+	t.Parallel()
+
+	mgr, _, _, engine := newS0FSSnapshotTestManager(t, "vol-restart")
+	writeS0FSFile(t, engine, "state.txt", "alpha")
+
+	snap, err := mgr.CreateSnapshot(context.Background(), &CreateSnapshotRequest{
+		VolumeID: "vol-restart",
+		Name:     "snap-restart",
+		TeamID:   "team-1",
+		UserID:   "user-1",
+	})
+	if err != nil {
+		t.Fatalf("CreateSnapshot() error = %v", err)
+	}
+	writeS0FSFile(t, engine, "state.txt", "beta")
+	if _, err := engine.SyncMaterialize(context.Background()); err != nil {
+		t.Fatalf("SyncMaterialize() before cache replacement error = %v", err)
+	}
+
+	// The manager cache is an EmptyDir in Kubernetes. Replacing it models the
+	// standalone storage-proxy Pod being removed during service consolidation.
+	mgr.config.CacheDir = t.TempDir()
+	mgr.volMgr = nil
+	if err := mgr.RestoreSnapshot(context.Background(), &RestoreSnapshotRequest{
+		VolumeID:   "vol-restart",
+		SnapshotID: snap.ID,
+		TeamID:     "team-1",
+		UserID:     "user-1",
+	}); err != nil {
+		t.Fatalf("RestoreSnapshot() after cache replacement error = %v", err)
+	}
+
+	fresh := openFreshS0FSEngine(t, mgr, "team-1", "vol-restart")
+	defer fresh.Close()
+	if got := readS0FSFile(t, fresh, "state.txt"); got != "alpha" {
+		t.Fatalf("fresh engine read after restore = %q, want alpha", got)
+	}
+}
+
+func TestS0FSLegacySnapshotRecoversFromMatchingManifest(t *testing.T) {
+	t.Parallel()
+
+	mgr, _, _, engine := newS0FSSnapshotTestManager(t, "vol-legacy-recovery")
+	writeS0FSFile(t, engine, "state.txt", "alpha")
+	snap, err := mgr.CreateSnapshot(context.Background(), &CreateSnapshotRequest{
+		VolumeID: "vol-legacy-recovery",
+		Name:     "snap-legacy",
+		TeamID:   "team-1",
+		UserID:   "user-1",
+	})
+	if err != nil {
+		t.Fatalf("CreateSnapshot() error = %v", err)
+	}
+
+	writeS0FSFile(t, engine, "state.txt", "beta")
+	if _, err := engine.SyncMaterialize(context.Background()); err != nil {
+		t.Fatalf("SyncMaterialize() after snapshot error = %v", err)
+	}
+	legacyCfg, err := mgr.s0fsConfig("team-1", "vol-legacy-recovery")
+	if err != nil {
+		t.Fatalf("s0fsConfig() error = %v", err)
+	}
+	if err := s0fs.DeleteSnapshot(context.Background(), legacyCfg, snap.ID); err != nil {
+		t.Fatalf("DeleteSnapshotState() error = %v", err)
+	}
+
+	mgr.config.CacheDir = t.TempDir()
+	mgr.volMgr = nil
+	if err := mgr.RestoreSnapshot(context.Background(), &RestoreSnapshotRequest{
+		VolumeID:   "vol-legacy-recovery",
+		SnapshotID: snap.ID,
+		TeamID:     "team-1",
+		UserID:     "user-1",
+	}); err != nil {
+		t.Fatalf("RestoreSnapshot() with legacy manifest recovery error = %v", err)
+	}
+
+	fresh := openFreshS0FSEngine(t, mgr, "team-1", "vol-legacy-recovery")
+	defer fresh.Close()
+	if got := readS0FSFile(t, fresh, "state.txt"); got != "alpha" {
+		t.Fatalf("fresh engine read after legacy recovery = %q, want alpha", got)
+	}
+
+	// A second cache replacement must use the backfilled durable snapshot
+	// object, without depending on the historical manifest fallback again.
+	mgr.config.CacheDir = t.TempDir()
+	backfilledCfg, err := mgr.s0fsConfig("team-1", "vol-legacy-recovery")
+	if err != nil {
+		t.Fatalf("s0fsConfig(backfilled) error = %v", err)
+	}
+	state, err := s0fs.LoadSnapshot(context.Background(), backfilledCfg, snap.ID)
+	if err != nil {
+		t.Fatalf("LoadSnapshot() after recovery backfill error = %v", err)
+	}
+	if got := snapshotSizeBytes(state); got != snap.SizeBytes {
+		t.Fatalf("backfilled snapshot size = %d, want %d", got, snap.SizeBytes)
+	}
+}
+
+func TestS0FSLegacySnapshotRejectsManifestSizeMismatch(t *testing.T) {
+	t.Parallel()
+
+	mgr, repo, _, engine := newS0FSSnapshotTestManager(t, "vol-legacy-mismatch")
+	writeS0FSFile(t, engine, "state.txt", "alpha")
+	snap, err := mgr.CreateSnapshot(context.Background(), &CreateSnapshotRequest{
+		VolumeID: "vol-legacy-mismatch",
+		Name:     "snap-legacy-mismatch",
+		TeamID:   "team-1",
+		UserID:   "user-1",
+	})
+	if err != nil {
+		t.Fatalf("CreateSnapshot() error = %v", err)
+	}
+	cfg, err := mgr.s0fsConfig("team-1", "vol-legacy-mismatch")
+	if err != nil {
+		t.Fatalf("s0fsConfig() error = %v", err)
+	}
+	if err := s0fs.DeleteSnapshot(context.Background(), cfg, snap.ID); err != nil {
+		t.Fatalf("DeleteSnapshotState() error = %v", err)
+	}
+	repo.snapshots[snap.ID].SizeBytes++
+
+	mgr.config.CacheDir = t.TempDir()
+	mgr.volMgr = nil
+	err = mgr.RestoreSnapshot(context.Background(), &RestoreSnapshotRequest{
+		VolumeID:   "vol-legacy-mismatch",
+		SnapshotID: snap.ID,
+		TeamID:     "team-1",
+		UserID:     "user-1",
+	})
+	if !errors.Is(err, s0fs.ErrSnapshotNotFound) {
+		t.Fatalf("RestoreSnapshot() error = %v, want ErrSnapshotNotFound", err)
+	}
+	newCfg, cfgErr := mgr.s0fsConfig("team-1", "vol-legacy-mismatch")
+	if cfgErr != nil {
+		t.Fatalf("s0fsConfig(new cache) error = %v", cfgErr)
+	}
+	if _, loadErr := s0fs.LoadSnapshot(context.Background(), newCfg, snap.ID); !errors.Is(loadErr, s0fs.ErrSnapshotNotFound) {
+		t.Fatalf("LoadSnapshot() after rejected recovery error = %v, want ErrSnapshotNotFound", loadErr)
 	}
 }
 
@@ -233,6 +409,7 @@ func TestS0FSCreateVolumeFromSnapshotUsesCopyOnWriteState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateSnapshot() error = %v", err)
 	}
+	mgr.config.CacheDir = t.TempDir()
 
 	child, err := mgr.CreateVolumeFromSnapshot(context.Background(), &CreateVolumeFromSnapshotRequest{
 		SnapshotID: snap.ID,
@@ -428,6 +605,7 @@ func TestExportSnapshotArchiveS0FS(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateSnapshot() error = %v", err)
 	}
+	mgr.config.CacheDir = t.TempDir()
 
 	var archive bytes.Buffer
 	if err := mgr.ExportSnapshotArchive(context.Background(), &ExportSnapshotRequest{
@@ -441,6 +619,45 @@ func TestExportSnapshotArchiveS0FS(t *testing.T) {
 	files := untarSnapshotArchive(t, archive.Bytes())
 	if got := string(files["dir/hello.txt"]); got != "archive-body" {
 		t.Fatalf("archive file = %q, want archive-body", got)
+	}
+}
+
+func TestExportSnapshotArchiveS0FSMissingLegacyStateRemainsNotFound(t *testing.T) {
+	t.Parallel()
+
+	mgr, _, _, engine := newS0FSSnapshotTestManager(t, "vol-missing-legacy")
+	writeS0FSFile(t, engine, "state.txt", "payload")
+	snap, err := mgr.CreateSnapshot(context.Background(), &CreateSnapshotRequest{
+		VolumeID: "vol-missing-legacy",
+		Name:     "snap-missing-legacy",
+		TeamID:   "team-1",
+		UserID:   "user-1",
+	})
+	if err != nil {
+		t.Fatalf("CreateSnapshot() error = %v", err)
+	}
+	cfg, err := mgr.s0fsConfig("team-1", "vol-missing-legacy")
+	if err != nil {
+		t.Fatalf("s0fsConfig() error = %v", err)
+	}
+	if err := s0fs.DeleteSnapshot(context.Background(), cfg, snap.ID); err != nil {
+		t.Fatalf("DeleteSnapshotState() error = %v", err)
+	}
+	for _, key := range listS0FSKeys(t, cfg.ObjectStore, "manifests/") {
+		if err := cfg.ObjectStore.Delete(key); err != nil {
+			t.Fatalf("Delete(%q) error = %v", key, err)
+		}
+	}
+	mgr.config.CacheDir = t.TempDir()
+
+	var archive bytes.Buffer
+	err = mgr.ExportSnapshotArchive(context.Background(), &ExportSnapshotRequest{
+		VolumeID:   "vol-missing-legacy",
+		SnapshotID: snap.ID,
+		TeamID:     "team-1",
+	}, &archive)
+	if !errors.Is(err, ErrSnapshotNotFound) {
+		t.Fatalf("ExportSnapshotArchive() error = %v, want ErrSnapshotNotFound", err)
 	}
 }
 
@@ -610,4 +827,15 @@ func sameStrings(a, b []string) bool {
 		}
 	}
 	return true
+}
+
+type cancelAfterTxRepo struct {
+	*fakeRepo
+	cancel context.CancelFunc
+}
+
+func (r *cancelAfterTxRepo) WithTx(ctx context.Context, fn func(tx pgx.Tx) error) error {
+	err := fn(nil)
+	r.cancel()
+	return err
 }

--- a/storage-proxy/pkg/snapshot/s0fs.go
+++ b/storage-proxy/pkg/snapshot/s0fs.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/objectstore"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/s0fs"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volume"
+	"github.com/sirupsen/logrus"
 )
 
 type s0fsHeadRepository interface {
@@ -103,6 +104,49 @@ func (m *Manager) s0fsConfig(teamID, volumeID string) (s0fs.Config, error) {
 		return m.s0fsObjectStore(teamID, sourceVolumeID)
 	}
 	return cfg, nil
+}
+
+// loadS0FSSnapshotState loads the durable snapshot object and performs a
+// guarded, one-time recovery for snapshots created before snapshot state was
+// persisted to object storage. The manifest fallback is deliberately narrow:
+// the committed head and manifest structure must be stable, and exactly one
+// state may match the PostgreSQL snapshot timestamp and storage size.
+func (m *Manager) loadS0FSSnapshotState(ctx context.Context, cfg s0fs.Config, snapshot *db.Snapshot) (*s0fs.SnapshotState, error) {
+	if snapshot == nil {
+		return nil, fmt.Errorf("snapshot is required")
+	}
+	state, err := s0fs.LoadSnapshot(ctx, cfg, snapshot.ID)
+	if err == nil {
+		return state, nil
+	}
+	if !errors.Is(err, s0fs.ErrSnapshotNotFound) {
+		return nil, err
+	}
+
+	state, manifest, err := s0fs.RecoverSnapshotFromManifest(ctx, cfg, snapshot.CreatedAt, snapshot.SizeBytes)
+	if err != nil {
+		if errors.Is(err, s0fs.ErrMaterializedManifestNotFound) {
+			return nil, fmt.Errorf("%w: no durable state or eligible legacy manifest", s0fs.ErrSnapshotNotFound)
+		}
+		return nil, err
+	}
+	if got := snapshotSizeBytes(state); got != snapshot.SizeBytes {
+		return nil, fmt.Errorf(
+			"%w: recovered manifest storage size %d does not match snapshot catalog size %d",
+			s0fs.ErrSnapshotNotFound,
+			got,
+			snapshot.SizeBytes,
+		)
+	}
+	if err := s0fs.PersistSnapshot(ctx, cfg, snapshot.ID, state); err != nil {
+		return nil, fmt.Errorf("persist recovered snapshot state: %w", err)
+	}
+	m.logger.WithFields(logrus.Fields{
+		"volume_id":    snapshot.VolumeID,
+		"snapshot_id":  snapshot.ID,
+		"manifest_seq": manifest.ManifestSeq,
+	}).Warn("Recovered legacy s0fs snapshot state from an immutable manifest")
+	return state, nil
 }
 
 func (m *Manager) hasMountedCtldOwner(ctx context.Context, volumeID string) (bool, error) {
@@ -360,7 +404,10 @@ func (m *Manager) resolveS0FSForkState(ctx context.Context, teamID, sourceVolume
 	return s0fs.PrepareForkState(state, sourceVolumeID)
 }
 
-func (m *Manager) openS0FSSnapshotArchiveSession(ctx context.Context, volumeID, snapshotID string) (*snapshotArchiveSession, fsmeta.Ino, *fsmeta.Attr, error) {
+func (m *Manager) openS0FSSnapshotArchiveSession(ctx context.Context, volumeID string, snapshot *db.Snapshot) (*snapshotArchiveSession, fsmeta.Ino, *fsmeta.Attr, error) {
+	if snapshot == nil {
+		return nil, 0, nil, fmt.Errorf("snapshot is required")
+	}
 	volumeRecord, err := m.repo.GetSandboxVolume(ctx, volumeID)
 	if err != nil {
 		return nil, 0, nil, err
@@ -369,7 +416,7 @@ func (m *Manager) openS0FSSnapshotArchiveSession(ctx context.Context, volumeID, 
 	if err != nil {
 		return nil, 0, nil, err
 	}
-	state, err := s0fs.LoadSnapshot(ctx, cfg, snapshotID)
+	state, err := m.loadS0FSSnapshotState(ctx, cfg, snapshot)
 	if err != nil {
 		return nil, 0, nil, err
 	}
@@ -418,6 +465,20 @@ func (m *Manager) createS0FSSnapshot(ctx context.Context, req *CreateSnapshotReq
 	if err != nil {
 		return nil, err
 	}
+	cfg, err := m.s0fsConfig(vol.TeamID, req.VolumeID)
+	if err != nil {
+		_ = engine.DeleteSnapshot(snapshotID)
+		return nil, err
+	}
+	cleanupSnapshotState := func() {
+		if cleanupErr := s0fs.DeleteSnapshot(context.Background(), cfg, snapshotID); cleanupErr != nil && !errors.Is(cleanupErr, s0fs.ErrSnapshotNotFound) {
+			m.logger.WithError(cleanupErr).Warn("Failed to clean up uncommitted s0fs snapshot state")
+		}
+	}
+	if err := s0fs.PersistSnapshot(ctx, cfg, snapshotID, state); err != nil {
+		cleanupSnapshotState()
+		return nil, fmt.Errorf("persist snapshot state: %w", err)
+	}
 	snapshot := &db.Snapshot{
 		ID:          snapshotID,
 		VolumeID:    req.VolumeID,
@@ -434,11 +495,11 @@ func (m *Manager) createS0FSSnapshot(ctx context.Context, req *CreateSnapshotReq
 		m.snapshotStorageObservation(ctx, snapshot, snapshot.CreatedAt),
 		req.StorageMetadata,
 	)); err != nil {
-		_ = engine.DeleteSnapshot(snapshotID)
+		cleanupSnapshotState()
 		return nil, err
 	}
 	if err := m.repo.CreateSnapshot(ctx, snapshot); err != nil {
-		_ = engine.DeleteSnapshot(snapshotID)
+		cleanupSnapshotState()
 		return nil, err
 	}
 	if err := m.recordVolumeStorageState(ctx, vol, state, snapshot.CreatedAt); err != nil {
@@ -627,7 +688,7 @@ func (m *Manager) createS0FSVolumeFromSnapshot(ctx context.Context, req *CreateV
 	if err != nil {
 		return nil, err
 	}
-	state, err := s0fs.LoadSnapshot(ctx, cfg, snapshotRecord.ID)
+	state, err := m.loadS0FSSnapshotState(ctx, cfg, snapshotRecord)
 	if err != nil {
 		return nil, err
 	}
@@ -712,13 +773,21 @@ func (m *Manager) createS0FSVolumeFromSnapshot(ctx context.Context, req *CreateV
 }
 
 func (m *Manager) restoreS0FSSnapshot(ctx context.Context, req *RestoreSnapshotRequest, snapshot *db.Snapshot) error {
+	cfg, err := m.s0fsConfig(snapshot.TeamID, req.VolumeID)
+	if err != nil {
+		return err
+	}
+	state, err := m.loadS0FSSnapshotState(ctx, cfg, snapshot)
+	if err != nil {
+		return err
+	}
 	engine, closeFn, err := m.openS0FSEngine(ctx, snapshot.TeamID, req.VolumeID)
 	if err != nil {
 		return err
 	}
 	defer closeFn()
 
-	if err := engine.RestoreSnapshot(req.SnapshotID); err != nil {
+	if err := engine.RestoreState(state); err != nil {
 		return err
 	}
 	manifest, err := engine.SyncMaterialize(ctx)
@@ -769,12 +838,11 @@ func (m *Manager) deleteS0FSSnapshot(ctx context.Context, volumeID, snapshotID s
 	if err != nil {
 		return err
 	}
-	engine, closeFn, err := m.openS0FSEngine(ctx, volumeRecord.TeamID, volumeID)
+	cfg, err := m.s0fsConfig(volumeRecord.TeamID, volumeID)
 	if err != nil {
 		return err
 	}
-	defer closeFn()
-	if err := engine.DeleteSnapshot(snapshotID); err != nil && !errors.Is(err, s0fs.ErrSnapshotNotFound) {
+	if err := s0fs.DeleteSnapshot(ctx, cfg, snapshotID); err != nil && !errors.Is(err, s0fs.ErrSnapshotNotFound) {
 		return err
 	}
 	return nil
@@ -850,7 +918,7 @@ func (m *Manager) garbageCollectS0FSVolumeObjects(ctx context.Context, volumeID,
 		return nil, err
 	}
 	for _, snapshot := range snapshots {
-		state, err := s0fs.LoadSnapshot(ctx, cfg, snapshot.ID)
+		state, err := m.loadS0FSSnapshotState(ctx, cfg, snapshot)
 		if err != nil {
 			if errors.Is(err, s0fs.ErrSnapshotNotFound) {
 				return nil, nil

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -2406,9 +2406,10 @@ func assertObjectEncryptionLifecycle(env *framework.ScenarioEnv, session *e2euti
 	privateKey := getSecretValueWithEscapedKey(env, secretName, "private\\.key")
 	Expect(privateKey).To(ContainSubstring("BEGIN"))
 
-	assertWorkloadConfigMapContains(env, "deployment", env.Infra.Name+"-storage-proxy", "object_encryption_enabled: true")
+	assertWorkloadConfigMapContains(env, "deployment", env.Infra.Name+"-manager", "storage-config", "object_encryption_enabled: true")
+	assertServiceSelectsComponent(env, env.Infra.Name+"-storage-proxy", "manager")
 	for _, slot := range []string{"a", "b"} {
-		assertWorkloadConfigMapContains(env, "daemonset", env.Infra.Name+"-ctld-"+slot, "object_encryption_enabled: true")
+		assertWorkloadConfigMapContains(env, "daemonset", env.Infra.Name+"-ctld-"+slot, "config", "object_encryption_enabled: true")
 	}
 
 	volume, status, err := session.CreateSandboxVolume(env.TestCtx.Context, GinkgoT(), apispec.CreateSandboxVolumeRequest{})
@@ -2436,7 +2437,7 @@ func assertObjectEncryptionLifecycle(env *framework.ScenarioEnv, session *e2euti
 	Expect(status).To(Equal(http.StatusOK))
 	Expect(body).To(Equal(beforeContent))
 
-	assertNoPlaintextInStorage(env, "deploy/"+env.Infra.Name+"-storage-proxy", "/var/lib/storage-proxy/cache", sentinel)
+	assertNoPlaintextInStorage(env, "deploy/"+env.Infra.Name+"-manager", "/var/lib/storage-proxy/cache", sentinel)
 
 	snapshot := createSnapshotEventually(env, session, volumeID, "object-encryption-e2e")
 	Expect(snapshot).NotTo(BeNil())
@@ -2458,7 +2459,7 @@ func assertObjectEncryptionLifecycle(env *framework.ScenarioEnv, session *e2euti
 	Expect(status).To(Equal(http.StatusOK))
 	Expect(body).To(Equal(beforeContent))
 
-	assertNoPlaintextInStorage(env, "deploy/"+env.Infra.Name+"-storage-proxy", "/var/lib/storage-proxy/cache", sentinel)
+	assertNoPlaintextInStorage(env, "deploy/"+env.Infra.Name+"-manager", "/var/lib/storage-proxy/cache", sentinel)
 	assertNoPlaintextInStorage(env, "pod/"+env.Infra.Name+"-rustfs-0", "/data", sentinel)
 }
 
@@ -2527,12 +2528,12 @@ func assertConfigMapContains(env *framework.ScenarioEnv, configMapName, expected
 	Expect(output).To(ContainSubstring(expected))
 }
 
-func assertWorkloadConfigMapContains(env *framework.ScenarioEnv, workloadKind, workloadName, expected string) {
-	configMapName := workloadConfigMapName(env, workloadKind, workloadName)
+func assertWorkloadConfigMapContains(env *framework.ScenarioEnv, workloadKind, workloadName, volumeName, expected string) {
+	configMapName := workloadConfigMapName(env, workloadKind, workloadName, volumeName)
 	assertConfigMapContains(env, configMapName, expected)
 }
 
-func workloadConfigMapName(env *framework.ScenarioEnv, workloadKind, workloadName string) string {
+func workloadConfigMapName(env *framework.ScenarioEnv, workloadKind, workloadName, volumeName string) string {
 	output, err := framework.KubectlOutput(
 		env.TestCtx.Context,
 		env.Config.Kubeconfig,
@@ -2540,7 +2541,7 @@ func workloadConfigMapName(env *framework.ScenarioEnv, workloadKind, workloadNam
 		workloadKind,
 		workloadName,
 		"-o",
-		`jsonpath={.spec.template.spec.volumes[?(@.name=="config")].configMap.name}`,
+		fmt.Sprintf(`jsonpath={.spec.template.spec.volumes[?(@.name=="%s")].configMap.name}`, volumeName),
 		"--namespace",
 		env.Infra.Namespace,
 	)
@@ -2548,6 +2549,22 @@ func workloadConfigMapName(env *framework.ScenarioEnv, workloadKind, workloadNam
 	name := strings.TrimSpace(output)
 	Expect(name).NotTo(BeEmpty())
 	return name
+}
+
+func assertServiceSelectsComponent(env *framework.ScenarioEnv, serviceName, component string) {
+	output, err := framework.KubectlOutput(
+		env.TestCtx.Context,
+		env.Config.Kubeconfig,
+		"get",
+		"service",
+		serviceName,
+		"-o",
+		`jsonpath={.spec.selector.app\.kubernetes\.io/component}`,
+		"--namespace",
+		env.Infra.Namespace,
+	)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(strings.TrimSpace(output)).To(Equal(component))
 }
 
 func assertNoPlaintextInStorage(env *framework.ScenarioEnv, target, root, sentinel string) {

--- a/tests/e2e/cases/api_network_policy_netd.go
+++ b/tests/e2e/cases/api_network_policy_netd.go
@@ -43,6 +43,7 @@ type netdHTTPFixture struct {
 }
 
 func assertNetdTransparentEgressPolicy(env *framework.ScenarioEnv, session *e2eutils.Session, sandboxID string) {
+	assertEmbeddedNetdCtldRollout(env)
 	Expect(sandboxID).NotTo(BeEmpty())
 
 	sandbox, status, err := session.GetSandbox(env.TestCtx.Context, GinkgoT(), sandboxID)
@@ -80,6 +81,7 @@ func assertNetdTransparentEgressPolicy(env *framework.ScenarioEnv, session *e2eu
 }
 
 func assertNetdClusterDNSUDP(env *framework.ScenarioEnv, session *e2eutils.Session, sandboxID string) {
+	assertEmbeddedNetdCtldRollout(env)
 	Expect(sandboxID).NotTo(BeEmpty())
 
 	sandbox, status, err := session.GetSandbox(env.TestCtx.Context, GinkgoT(), sandboxID)
@@ -111,6 +113,7 @@ func assertNetdClusterDNSUDP(env *framework.ScenarioEnv, session *e2eutils.Sessi
 }
 
 func assertNetdRedisTeamBandwidthLimit(env *framework.ScenarioEnv, session *e2eutils.Session, adminPassword string) {
+	assertEmbeddedNetdCtldRollout(env)
 	if !netdRedisTeamBandwidthConfigured(env) {
 		Skip("netd Redis team bandwidth limit is not configured for this scenario")
 	}
@@ -205,7 +208,7 @@ func netdRedisTeamBandwidthConfig(env *framework.ScenarioEnv) (*apiconfig.NetdCo
 	output, err := framework.KubectlOutput(
 		env.TestCtx.Context,
 		env.Config.Kubeconfig,
-		"get", "daemonset", env.Infra.Name+"-netd",
+		"get", "daemonset", env.Infra.Name+"-ctld-a",
 		"--namespace", env.Infra.Namespace,
 		"-o", "json",
 	)
@@ -218,7 +221,7 @@ func netdRedisTeamBandwidthConfig(env *framework.ScenarioEnv) (*apiconfig.NetdCo
 	}
 	configMapName := ""
 	for _, volume := range ds.Spec.Template.Spec.Volumes {
-		if volume.Name == "config" && volume.ConfigMap != nil {
+		if volume.Name == "netd-config" && volume.ConfigMap != nil {
 			configMapName = volume.ConfigMap.Name
 			break
 		}
@@ -245,6 +248,31 @@ func netdRedisTeamBandwidthConfig(env *framework.ScenarioEnv) (*apiconfig.NetdCo
 		return nil, false
 	}
 	return &cfg, true
+}
+
+func assertEmbeddedNetdCtldRollout(env *framework.ScenarioEnv) {
+	Expect(env).NotTo(BeNil())
+	for _, slot := range []string{"a", "b"} {
+		name := env.Infra.Name + "-ctld-" + slot
+		err := framework.KubectlRolloutStatus(
+			env.TestCtx.Context,
+			env.Config.Kubeconfig,
+			env.Infra.Namespace,
+			"daemonset/"+name,
+			"5m",
+		)
+		Expect(err).NotTo(HaveOccurred(), "embedded netd ctld slot %s did not finish rolling out", slot)
+	}
+	legacy, err := framework.KubectlOutput(
+		env.TestCtx.Context,
+		env.Config.Kubeconfig,
+		"get", "daemonset", env.Infra.Name+"-netd",
+		"--namespace", env.Infra.Namespace,
+		"--ignore-not-found",
+		"-o", "name",
+	)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(strings.TrimSpace(legacy)).To(BeEmpty(), "standalone netd DaemonSet must be removed after ctld takes ownership")
 }
 
 func clearNetdRedisTeamBandwidthKeys(env *framework.ScenarioEnv, teamID string) error {


### PR DESCRIPTION
## Summary

- run the storage-proxy API/runtime inside the manager process while preserving the storage-proxy Service, internal-auth audience, routes, and wire contracts
- run netd only in the elected ctld primary and bind netd failure to the existing ctld HA lease lifecycle
- migrate existing standalone workloads through guarded storage cutover and a node-local netd active lock with a bounded legacy fallback
- remove standalone operator reconciliation/RBAC after cutover, and update docs, samples, CI diagnostics, and E2E assertions
- persist canonical S0FS snapshot state in object storage so storage-proxy-to-manager Pod replacement cannot invalidate existing snapshots

## Compatibility and migration

- `pkg/apispec/openapi.yaml` is unchanged
- manager waits for a complete storage-enabled rollout and manager-only EndpointSlices before deleting the old storage-proxy Deployment
- existing storage-only specs remain valid; manager becomes the process host without implicitly enabling ctld or manager node-readiness gates
- differing manager/storage replica settings converge to the larger count; colliding legacy listen ports are remapped only inside the Pod while the compatibility Service port stays unchanged
- existing netd is first upgraded to a guarded current image, then rolled to a delayed/retryable fallback; it is deleted only after both ctld slot templates embed guarded netd, initial sync, CSI registration, and node readiness all converge
- S0FS snapshot objects are written before catalog insertion and read remote-first; local JSON is only a cache
- pre-change snapshots with lost local cache use a fail-closed recovery path bounded by a stable committed head, manifest invariants, segment existence, and a unique timestamp/size match before durable backfill
- E2E teardown quiesces only single-cluster template syncing through a process-local barrier, keeping manager-hosted storage and sandbox finalizers alive until namespace volume unpublish completes
- rollback to a pre-consolidation release is documented as a maintenance workflow to avoid overlapping an old unguarded netd with the embedded runtime

## Validation

- all Go package tests except launching E2E scenario packages
- targeted race tests across storage runtime/S0FS/snapshots, manager, ctld/netd, operator plan/reconcilers, framework, and E2E case helpers
- `go vet ./...`, `go build ./...`, and golangci-lint v2.5.0 (`0 issues`)
- `pkg/apispec/openapi.yaml` zero diff
- remote kind upgrade, legacy and new snapshot restore, storage/network compatibility, and ctld HA failover evidence attached in the PR discussion
