### PR TITLE
refactor: prepare manager storage auth audience

### DIFF
--- a/pkg/internalauth/internalauth_test.go
+++ b/pkg/internalauth/internalauth_test.go
@@ -106,6 +106,33 @@ func TestValidatorInvalidTarget(t *testing.T) {
 	}
 }
 
+func TestValidatorAcceptsAdditionalTarget(t *testing.T) {
+	generator := NewGenerator(DefaultGeneratorConfig(ServiceClusterGateway, testPrivateKey))
+	validator := NewValidator(ValidatorConfig{
+		Target:            ServiceManagerStorage,
+		AdditionalTargets: []string{ServiceStorageProxy},
+		PublicKey:         testPublicKey,
+	})
+
+	for _, target := range []string{ServiceManagerStorage, ServiceStorageProxy} {
+		token, err := generator.Generate(target, "team-123", "user-456", GenerateOptions{})
+		if err != nil {
+			t.Fatalf("generate token for %s: %v", target, err)
+		}
+		if _, err := validator.Validate(token); err != nil {
+			t.Fatalf("validate token for %s: %v", target, err)
+		}
+	}
+
+	token, err := generator.Generate(ServiceManager, "team-123", "user-456", GenerateOptions{})
+	if err != nil {
+		t.Fatalf("generate token for rejected target: %v", err)
+	}
+	if _, err := validator.Validate(token); !errors.Is(err, ErrInvalidTarget) {
+		t.Fatalf("validate rejected target error = %v, want ErrInvalidTarget", err)
+	}
+}
+
 func TestValidatorInvalidSignature(t *testing.T) {
 	// Generate a different key pair for signing
 	otherPublicKey, otherPrivateKey, err := ed25519.GenerateKey(nil)

--- a/pkg/internalauth/options.go
+++ b/pkg/internalauth/options.go
@@ -39,6 +39,10 @@ type ValidatorConfig struct {
 	// Tokens must have aud == Target to be valid.
 	Target string
 
+	// AdditionalTargets contains other audiences accepted by a shared or
+	// transitioning endpoint. Target remains the canonical audience.
+	AdditionalTargets []string
+
 	// PublicKey is the Ed25519 public key used for verifying tokens.
 	// Required.
 	PublicKey ed25519.PublicKey
@@ -64,6 +68,7 @@ type ValidatorConfig struct {
 func DefaultValidatorConfig(target string, publicKey ed25519.PublicKey) ValidatorConfig {
 	return ValidatorConfig{
 		Target:                 target,
+		AdditionalTargets:      nil,
 		PublicKey:              publicKey,
 		AllowedCallers:         nil, // Allow all
 		ClockSkewTolerance:     5 * time.Second,

--- a/pkg/internalauth/services.go
+++ b/pkg/internalauth/services.go
@@ -5,6 +5,7 @@ const (
 	ServiceCtld            = "ctld"
 	ServiceGlobalGateway   = "global-gateway"
 	ServiceManager         = "manager"
+	ServiceManagerStorage  = "manager-storage"
 	ServiceNetd            = "netd"
 	ServiceProcd           = "procd"
 	ServiceRegionalGateway = "regional-gateway"

--- a/pkg/internalauth/token.go
+++ b/pkg/internalauth/token.go
@@ -239,7 +239,7 @@ func (v *Validator) ValidateWithOptions(tokenString string, opts ValidateOptions
 
 	// Validate target (audience)
 	if !opts.SkipTargetCheck {
-		if claims.Audience != v.config.Target {
+		if !v.acceptsTarget(claims.Audience) {
 			return nil, fmt.Errorf("%w: expected %s, got %s", ErrInvalidTarget, v.config.Target, claims.Audience)
 		}
 	}
@@ -285,6 +285,18 @@ func (v *Validator) ValidateWithOptions(tokenString string, opts ValidateOptions
 	}
 
 	return claims, nil
+}
+
+func (v *Validator) acceptsTarget(target string) bool {
+	if target == v.config.Target {
+		return true
+	}
+	for _, additionalTarget := range v.config.AdditionalTargets {
+		if target == additionalTarget {
+			return true
+		}
+	}
+	return false
 }
 
 // isReplay checks if the JTI has been used before.

--- a/storage-proxy/pkg/runtime/runtime.go
+++ b/storage-proxy/pkg/runtime/runtime.go
@@ -242,7 +242,8 @@ func New(ctx context.Context, opts Options) (_ *Runtime, retErr error) {
 		return nil, fmt.Errorf("load storage-proxy internal auth public key from %s: %w", internalauth.DefaultInternalJWTPublicKeyPath, err)
 	}
 	validator := internalauth.NewValidator(internalauth.ValidatorConfig{
-		Target:                 internalauth.ServiceStorageProxy,
+		Target:                 internalauth.ServiceManagerStorage,
+		AdditionalTargets:      []string{internalauth.ServiceStorageProxy},
 		PublicKey:              publicKey,
 		AllowedCallers:         []string{internalauth.ServiceClusterGateway, internalauth.ServiceManager},
 		ClockSkewTolerance:     5 * time.Second,


### PR DESCRIPTION
## Summary

- introduce `manager-storage` as the canonical internal-auth audience for the storage HTTP surface hosted by manager
- let that listener temporarily accept the existing `storage-proxy` audience so old and new callers can coexist during a rolling deployment
- keep all callers on the existing audience in this PR; a following cleanup PR will switch callers only after this compatibility release is deployed

The public OpenAPI contract and request routing are unchanged.

## Validation

- `make proto`
- `go test -count=1 ./pkg/internalauth ./storage-proxy/pkg/runtime`
- `git diff --check`
- verified `pkg/apispec/openapi.yaml` SHA-256 is unchanged
