### PR TITLE
perf(ctld): reduce S0FS recovery syncs

### DIFF
--- a/ctld/HA.md
+++ b/ctld/HA.md
@@ -70,7 +70,10 @@ input. Runtime state uses backend-specific recovery:
 
 - S0FS reopens its node-local WAL only after promotion. Kernel inode IDs remain
   stable because S0FS persists them, and a separate handle state preserves
-  open and open-unlinked inode references.
+  open and open-unlinked inode references. Handle updates use atomic renames so
+  they are visible to the same-node standby before the FUSE operation returns;
+  graceful handoff additionally syncs the final snapshot file before replacing
+  the previous state.
 - Rootfs-backed portals persist their inode-to-path and handle journal.
   Open-unlinked files move into a hidden orphan directory until the restored
   final handle is released.

--- a/ctld/internal/ctld/portal/s0fs_recovery.go
+++ b/ctld/internal/ctld/portal/s0fs_recovery.go
@@ -43,6 +43,18 @@ func loadS0FSHandleState(path, volumeID string) (volume.HandleState, error) {
 }
 
 func persistS0FSHandleState(path, volumeID string, handles volume.HandleState) error {
+	return persistS0FSHandleStateWithDurability(path, volumeID, handles, true)
+}
+
+// persistProcessLocalS0FSHandleState makes the latest handle snapshot visible
+// to a standby process without forcing it to stable storage. S0FS portal HA
+// protects against a process or Pod failure on the same node, so the shared
+// kernel page cache remains available to the promoted process.
+func persistProcessLocalS0FSHandleState(path, volumeID string, handles volume.HandleState) error {
+	return persistS0FSHandleStateWithDurability(path, volumeID, handles, false)
+}
+
+func persistS0FSHandleStateWithDurability(path, volumeID string, handles volume.HandleState, durable bool) error {
 	if strings.TrimSpace(path) == "" {
 		return nil
 	}
@@ -54,7 +66,7 @@ func persistS0FSHandleState(path, volumeID string, handles volume.HandleState) e
 	if err != nil {
 		return err
 	}
-	return writeAtomicRecoveryState(path, ".s0fs-*.tmp", payload)
+	return writeAtomicRecoveryStateWithDurability(path, ".s0fs-*.tmp", payload, durable)
 }
 
 func retainedUnlinkedInodes(state volume.HandleState) map[uint64]struct{} {

--- a/ctld/internal/ctld/portal/s0fs_recovery_test.go
+++ b/ctld/internal/ctld/portal/s0fs_recovery_test.go
@@ -1,0 +1,70 @@
+package portal
+
+import (
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volume"
+)
+
+func TestPersistProcessLocalS0FSHandleStateReplacesSnapshot(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "handles.json")
+	initial := volume.HandleState{
+		NextHandleID: 1,
+		FileHandles:  map[uint64]uint64{1: 10},
+	}
+	if err := persistS0FSHandleState(path, "vol-1", initial); err != nil {
+		t.Fatalf("persistS0FSHandleState() error = %v", err)
+	}
+
+	want := volume.HandleState{
+		NextHandleID:  3,
+		FileHandles:   map[uint64]uint64{2: 20},
+		DirHandles:    map[uint64]uint64{3: 30},
+		UnlinkedFiles: []uint64{20},
+	}
+	if err := persistProcessLocalS0FSHandleState(path, "vol-1", want); err != nil {
+		t.Fatalf("persistProcessLocalS0FSHandleState() error = %v", err)
+	}
+
+	got, err := loadS0FSHandleState(path, "vol-1")
+	if err != nil {
+		t.Fatalf("loadS0FSHandleState() error = %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("loadS0FSHandleState() = %#v, want %#v", got, want)
+	}
+}
+
+func BenchmarkPersistS0FSHandleState(b *testing.B) {
+	handles := volume.HandleState{
+		NextHandleID: 64,
+		FileHandles:  make(map[uint64]uint64, 32),
+		DirHandles:   make(map[uint64]uint64, 32),
+	}
+	for handle := uint64(1); handle <= 32; handle++ {
+		handles.FileHandles[handle] = 1000 + handle
+		handles.DirHandles[handle+32] = 2000 + handle
+	}
+
+	benchmarks := []struct {
+		name    string
+		persist func(string, string, volume.HandleState) error
+	}{
+		{name: "Durable", persist: persistS0FSHandleState},
+		{name: "ProcessLocal", persist: persistProcessLocalS0FSHandleState},
+	}
+	for _, benchmark := range benchmarks {
+		b.Run(benchmark.name, func(b *testing.B) {
+			path := filepath.Join(b.TempDir(), "handles.json")
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				if err := benchmark.persist(path, "vol-1", handles); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/ctld/internal/ctld/portal/s3_recovery.go
+++ b/ctld/internal/ctld/portal/s3_recovery.go
@@ -338,6 +338,10 @@ func loadS3RecoveryState(path string) (*s3RecoveryState, error) {
 }
 
 func writeAtomicRecoveryState(path, pattern string, payload []byte) error {
+	return writeAtomicRecoveryStateWithDurability(path, pattern, payload, true)
+}
+
+func writeAtomicRecoveryStateWithDurability(path, pattern string, payload []byte, durable bool) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return fmt.Errorf("create recovery state directory: %w", err)
 	}
@@ -355,9 +359,11 @@ func writeAtomicRecoveryState(path, pattern string, payload []byte) error {
 		_ = tmp.Close()
 		return err
 	}
-	if err := tmp.Sync(); err != nil {
-		_ = tmp.Close()
-		return err
+	if durable {
+		if err := tmp.Sync(); err != nil {
+			_ = tmp.Close()
+			return err
+		}
 	}
 	if err := tmp.Close(); err != nil {
 		return err

--- a/ctld/internal/ctld/portal/session.go
+++ b/ctld/internal/ctld/portal/session.go
@@ -329,10 +329,10 @@ func newLocalSession(volumeID string, mgr *localVolumeManager, logger *logrus.Lo
 	}
 }
 
-func (s *localSession) Close() { _ = s.persistRecoveryState() }
+func (s *localSession) Close() { _ = s.persistDurableRecoveryState() }
 
 func (s *localSession) Handoff() error {
-	return s.persistRecoveryState()
+	return s.persistDurableRecoveryState()
 }
 
 func (s *localSession) RecoveryError() error {
@@ -345,6 +345,14 @@ func (s *localSession) RecoveryError() error {
 }
 
 func (s *localSession) persistRecoveryState() error {
+	return s.persistRecoveryStateWithDurability(false)
+}
+
+func (s *localSession) persistDurableRecoveryState() error {
+	return s.persistRecoveryStateWithDurability(true)
+}
+
+func (s *localSession) persistRecoveryStateWithDurability(durable bool) error {
 	if s == nil || strings.TrimSpace(s.statePath) == "" || s.mgr == nil {
 		return nil
 	}
@@ -357,7 +365,12 @@ func (s *localSession) persistRecoveryState() error {
 	}
 	s.stateMu.Lock()
 	defer s.stateMu.Unlock()
-	err = persistS0FSHandleState(s.statePath, s.volumeID, volCtx.SnapshotHandleState())
+	handles := volCtx.SnapshotHandleState()
+	if durable {
+		err = persistS0FSHandleState(s.statePath, s.volumeID, handles)
+	} else {
+		err = persistProcessLocalS0FSHandleState(s.statePath, s.volumeID, handles)
+	}
 	s.stateErr = err
 	return err
 }

--- a/ctld/internal/ctld/portal/session_test.go
+++ b/ctld/internal/ctld/portal/session_test.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"sort"
 	"sync/atomic"
 	"syscall"
 	"testing"
@@ -786,6 +788,133 @@ func TestLocalSessionRestoresOpenUnlinkedS0FSHandle(t *testing.T) {
 	if _, err := secondEngine.GetAttr(created.Inode); !errors.Is(err, s0fs.ErrNotFound) {
 		t.Fatalf("GetAttr(released unlinked inode) error = %v, want ErrNotFound", err)
 	}
+}
+
+func TestLocalSessionRestoresOpenUnlinkedS0FSHandleAfterProcessKill(t *testing.T) {
+	dir := t.TempDir()
+	cmd := exec.Command(os.Args[0], "-test.run=^TestLocalSessionS0FSProcessKillHelper$")
+	cmd.Env = append(os.Environ(), "S0FS_PROCESS_KILL_DIR="+dir)
+	output, err := cmd.CombinedOutput()
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("process-kill helper error = %v, want signal exit\n%s", err, output)
+	}
+	status, ok := exitErr.Sys().(syscall.WaitStatus)
+	if !ok || !status.Signaled() || status.Signal() != syscall.SIGKILL {
+		t.Fatalf("process-kill helper status = %v, want SIGKILL\n%s", exitErr.Sys(), output)
+	}
+
+	statePath := filepath.Join(dir, "handles.json")
+	handleState, err := loadS0FSHandleState(statePath, "vol-1")
+	if err != nil {
+		t.Fatalf("loadS0FSHandleState() error = %v", err)
+	}
+	if len(handleState.FileHandles) != 2 || len(handleState.UnlinkedFiles) != 1 {
+		t.Fatalf("recovered handle state = %#v, want two handles for one open-unlinked file", handleState)
+	}
+	handleIDs := make([]uint64, 0, len(handleState.FileHandles))
+	var inode uint64
+	for handleID, handleInode := range handleState.FileHandles {
+		if inode != 0 && inode != handleInode {
+			t.Fatalf("recovered handles reference different inodes: %#v", handleState.FileHandles)
+		}
+		inode = handleInode
+		handleIDs = append(handleIDs, handleID)
+	}
+	sort.Slice(handleIDs, func(i, j int) bool { return handleIDs[i] < handleIDs[j] })
+
+	engine, err := s0fs.Open(context.Background(), s0fs.Config{
+		VolumeID:       "vol-1",
+		WALPath:        filepath.Join(dir, "engine.wal"),
+		RetainUnlinked: true,
+	})
+	if err != nil {
+		t.Fatalf("Open(recovered) error = %v", err)
+	}
+	defer engine.Close()
+	volCtx := &volume.VolumeContext{
+		VolumeID: "vol-1", TeamID: "team-a", Backend: volume.BackendS0FS,
+		S0FS: engine, Access: volume.AccessModeRWO, RootInode: 1, RootPath: "/", CacheDir: dir,
+	}
+	volCtx.RestoreHandleState(handleState)
+	engine.PruneUnlinked(retainedUnlinkedInodes(handleState))
+	mgr := newLocalVolumeManager()
+	mgr.add(volCtx)
+	session := newLocalSession("vol-1", mgr, nil)
+	session.statePath = statePath
+
+	read, err := session.Read(context.Background(), &pb.ReadRequest{
+		Inode: inode, HandleId: handleIDs[0], Size: 64,
+	})
+	if err != nil {
+		t.Fatalf("Read(recovered handle) error = %v", err)
+	}
+	if string(read.Data) != "survives" {
+		t.Fatalf("Read(recovered handle) = %q, want survives", read.Data)
+	}
+	if _, err := session.Release(context.Background(), &pb.ReleaseRequest{
+		Inode: inode, HandleId: handleIDs[0],
+	}); err != nil {
+		t.Fatalf("Release(first recovered handle) error = %v", err)
+	}
+	if _, err := engine.GetAttr(inode); err != nil {
+		t.Fatalf("GetAttr(after first release) error = %v, want retained inode", err)
+	}
+	if _, err := session.Release(context.Background(), &pb.ReleaseRequest{
+		Inode: inode, HandleId: handleIDs[1],
+	}); err != nil {
+		t.Fatalf("Release(final recovered handle) error = %v", err)
+	}
+	if _, err := engine.GetAttr(inode); !errors.Is(err, s0fs.ErrNotFound) {
+		t.Fatalf("GetAttr(released unlinked inode) error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestLocalSessionS0FSProcessKillHelper(t *testing.T) {
+	dir := os.Getenv("S0FS_PROCESS_KILL_DIR")
+	if dir == "" {
+		t.Skip("process-kill helper")
+	}
+	engine, err := s0fs.Open(context.Background(), s0fs.Config{
+		VolumeID:       "vol-1",
+		WALPath:        filepath.Join(dir, "engine.wal"),
+		RetainUnlinked: true,
+	})
+	if err != nil {
+		t.Fatalf("Open(primary) error = %v", err)
+	}
+	mgr := newLocalVolumeManager()
+	mgr.add(&volume.VolumeContext{
+		VolumeID: "vol-1", TeamID: "team-a", Backend: volume.BackendS0FS,
+		S0FS: engine, Access: volume.AccessModeRWO, RootInode: 1, RootPath: "/", CacheDir: dir,
+	})
+	session := newLocalSession("vol-1", mgr, nil)
+	session.statePath = filepath.Join(dir, "handles.json")
+	created, err := session.Create(context.Background(), &pb.CreateRequest{
+		Parent: s0fs.RootInode, Name: "transient.txt", Mode: 0o644,
+	})
+	if err != nil {
+		t.Fatalf("Create(transient.txt) error = %v", err)
+	}
+	if _, err := session.Write(context.Background(), &pb.WriteRequest{
+		Inode: created.Inode, HandleId: created.HandleId, Data: []byte("survives"),
+	}); err != nil {
+		t.Fatalf("Write(transient.txt) error = %v", err)
+	}
+	if _, err := session.Open(context.Background(), &pb.OpenRequest{
+		Inode: created.Inode, Flags: syscall.O_RDONLY,
+	}); err != nil {
+		t.Fatalf("Open(second handle) error = %v", err)
+	}
+	if _, err := session.Unlink(context.Background(), &pb.UnlinkRequest{
+		Parent: s0fs.RootInode, Name: "transient.txt",
+	}); err != nil {
+		t.Fatalf("Unlink(transient.txt) error = %v", err)
+	}
+	if err := syscall.Kill(os.Getpid(), syscall.SIGKILL); err != nil {
+		t.Fatalf("Kill(self) error = %v", err)
+	}
+	t.Fatal("process survived SIGKILL")
 }
 
 func TestLocalVolumeManagerHandoffPreservesS0FSCache(t *testing.T) {

--- a/scripts/volume_mount_bench.py
+++ b/scripts/volume_mount_bench.py
@@ -357,7 +357,13 @@ def parse_args() -> argparse.Namespace:
 
 
 def run_command(args: list[str], *, check: bool = True) -> str:
-    completed = subprocess.run(args, check=check, text=True, capture_output=True)
+    completed = subprocess.run(args, check=False, text=True, capture_output=True)
+    if check and completed.returncode != 0:
+        raise RuntimeError(
+            f"command failed with exit code {completed.returncode}: {args!r}\n"
+            f"stdout:\n{completed.stdout}\n"
+            f"stderr:\n{completed.stderr}"
+        )
     return completed.stdout.strip()
 
 


### PR DESCRIPTION
## Summary

- keep per-operation S0FS handle snapshots atomically visible to the same-node standby without forcing each snapshot to stable storage
- retain durable snapshots for graceful Close/Handoff and retain the existing durable S3 recovery path
- add real-S0FS SIGKILL recovery coverage for two handles on an open-unlinked inode
- add recovery microbenchmarks, HA documentation, and benchmark subprocess diagnostics

The state schema and recovery path are unchanged, so mixed-version upgrade and rollback remain compatible.

## Performance

Remote Aliyun kind paired A/B (base 726df7a2, candidate e722e97a; performance patch unchanged after rebase) in the same gVisor sandbox pod, RWO volume, 5,000 files x 17,476 bytes, parallelism 32, three rounds:

| S0FS phase | main | candidate | change |
| --- | ---: | ---: | ---: |
| write | 331.8 ops/s | 634.1 ops/s | +91.1% |
| read | 329.2 ops/s | 803.1 ops/s | +144.0% |
| list + stat | 639.5 ops/s | 1,494.6 ops/s | +133.7% |
| write p95 | 152.26 ms | 77.64 ms | -49.0% |
| read p95 | 168.91 ms | 68.01 ms | -59.7% |
| list + stat p95 | 1.82 ms | 0.76 ms | -58.4% |

The pod-local control remained stable (write 1,427.3 to 1,421.9 ops/s; read 1,790.7 to 1,844.5 ops/s).

Recovery microbenchmark median with 64 handles:

- durable: 3.436 ms/op
- process-local: 0.518 ms/op
- 6.64x faster / 84.9% lower latency

A FUSE no-copy pool prototype was intentionally excluded: the large regression workload exposed read EIO with that prototype, while this focused recovery change completed all rounds with content verification.

## Validation

- make test ctld
- go test -count=1 for s0fs, fsserver, volume, volumefuse, fuseportal, ctld portal, and ctld HA packages
- go test -race -count=1 ./ctld/internal/ctld/portal
- SIGKILL recovery test: 50 normal repetitions and 10 race repetitions
- real FUSE channel failover tests: three repetitions
- remote kind benchmark: three rounds with per-file read verification

