### PR TITLE
feat(template): make resources memory-only

### DIFF
--- a/docs/integrations/github-ci/page.mdx
+++ b/docs/integrations/github-ci/page.mdx
@@ -122,7 +122,6 @@ spec:
     mainContainer:
         image: registry.sandbox0-system.svc.cluster.local:5000/t-<team-key>/my-app:${GITHUB_SHA}
         resources:
-            cpu: "2"
             memory: 8Gi
     pool:
         minIdle: 1

--- a/docs/template/configuration/page.mdx
+++ b/docs/template/configuration/page.mdx
@@ -15,7 +15,6 @@ spec:
     mainContainer:
         image: registry.sandbox0-system.svc.cluster.local:5000/my-ds-env:v2.0
         resources:
-            cpu: "2"
             memory: 8Gi
             ephemeralStorage: 8Gi
         env:
@@ -62,13 +61,12 @@ The main sandbox container configuration.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `image` | string | — | Container image reference. Use a public image (e.g., `python:3.12-slim`) or the `Template image reference` returned by `s0 template image push` for private images. |
-| `resources.cpu` | string | — | CPU limit for the sandbox (e.g., `"1"`, `"2"`, `"500m"`). |
-| `resources.memory` | string | — | Memory limit for the sandbox (e.g., `"2Gi"`, `"512Mi"`). |
+| `resources.memory` | string | — | Memory limit for the sandbox (e.g., `"2Gi"`, `"512Mi"`). This is the default when a claim does not provide `config.resources.memory`; Sandbox0 manages CPU from platform configuration. |
 | `resources.ephemeralStorage` | string | `8Gi` | Writable-layer and container-log storage for the sandbox runtime. Checkpointed pause/resume saves and restores the writable root filesystem, but this quota still bounds writes to `/tmp` or image-local paths. Use rootfs snapshots and claim-time `snapshot_id` to version initialized sandbox files, and use Sandbox Volumes for sharing or long-lived durable data independent of sandbox identity. |
 | `env` | array | `[]` | Per-container environment variables. Each entry has `name` and `value`. |
 
 <Callout variant="info">
-`mainContainer.image`, `mainContainer.resources.cpu`, `mainContainer.resources.memory`, and `mainContainer.resources.ephemeralStorage` are strictly validated by the API when creating or updating templates. Template resources are the default for claimed sandboxes, with an effective minimum CPU limit of `150m`; warm-pool idle pods may run with lower internal CPU and memory until claim. `config.resources.memory` can override the sandbox memory limit at claim time or runtime.
+Set only `mainContainer.resources.memory`; CPU is platform-managed and is not part of the template API. The memory value becomes the default for claimed sandboxes, while `config.resources.memory` can override it at claim time or runtime. Warm-pool pods wait with a `128Mi` memory limit to reduce idle cost, then resize to the template default when claimed.
 </Callout>
 
 ---

--- a/docs/template/images/page.mdx
+++ b/docs/template/images/page.mdx
@@ -24,7 +24,6 @@ spec:
     mainContainer:
         image: python:3.12-slim
         resources:
-            cpu: "0.5"
             memory: 2Gi
     pool:
         minIdle: 2
@@ -116,7 +115,6 @@ spec:
     mainContainer:
         image: registry.sandbox0-system.svc.cluster.local:5000/t-<team-key>/my-app:v1.2.3
         resources:
-            cpu: "2"
             memory: 8Gi
     pool:
         minIdle: 2
@@ -149,7 +147,6 @@ spec:
     mainContainer:
         image: registry.sandbox0-system.svc.cluster.local:5000/t-<team-key>/my-app:v1.2.3
         resources:
-            cpu: "2"
             memory: 8Gi
     pool:
         minIdle: 2

--- a/docs/template/page.mdx
+++ b/docs/template/page.mdx
@@ -71,7 +71,6 @@ spec:
     mainContainer:
         image: python:3.12-slim
         resources:
-            cpu: "1"
             memory: 4Gi
             ephemeralStorage: 8Gi
     pool:
@@ -90,7 +89,6 @@ spec:
         MainContainer: apispec.NewOptContainerSpec(apispec.ContainerSpec{
             Image: "python:3.12-slim",
             Resources: apispec.ResourceQuota{
-                CPU:              apispec.NewOptString("1"),
                 Memory:           apispec.NewOptString("4Gi"),
                 EphemeralStorage: apispec.NewOptString("8Gi"),
             },
@@ -117,7 +115,7 @@ tpl = client.create_template(TemplateCreateRequest(
     spec=SandboxTemplateSpec.from_dict({
         "mainContainer": {
             "image": "python:3.12-slim",
-            "resources": {"cpu": "1", "memory": "4Gi", "ephemeralStorage": "8Gi"},
+            "resources": {"memory": "4Gi", "ephemeralStorage": "8Gi"},
         },
         "pool": {"minIdle": 2, "maxIdle": 10},
     }),
@@ -132,7 +130,7 @@ print(f"Template created: {tpl.template_id}")`
     spec: {
         mainContainer: {
             image: "python:3.12-slim",
-            resources: { cpu: "1", memory: "4Gi", ephemeralStorage: "8Gi" },
+            resources: { memory: "4Gi", ephemeralStorage: "8Gi" },
         },
         pool: { minIdle: 2, maxIdle: 10 },
     },
@@ -260,7 +258,6 @@ Updating a template does not affect already-running Sandboxes. New Sandboxes cla
         MainContainer: apispec.NewOptContainerSpec(apispec.ContainerSpec{
             Image: "python:3.12-slim",
             Resources: apispec.ResourceQuota{
-                CPU:              apispec.NewOptString("2"),
                 Memory:           apispec.NewOptString("8Gi"),
                 EphemeralStorage: apispec.NewOptString("8Gi"),
             },
@@ -288,7 +285,7 @@ tpl = client.update_template(
         spec=SandboxTemplateSpec.from_dict({
             "mainContainer": {
                 "image": "python:3.12-slim",
-                "resources": {"cpu": "2", "memory": "8Gi", "ephemeralStorage": "8Gi"},
+                "resources": {"memory": "8Gi", "ephemeralStorage": "8Gi"},
             },
             "pool": {"minIdle": 3, "maxIdle": 10},
         }),
@@ -303,7 +300,7 @@ print(f"Template updated: {tpl.template_id}")`
     spec: {
         mainContainer: {
             image: "python:3.12-slim",
-            resources: { cpu: "2", memory: "8Gi", ephemeralStorage: "8Gi" },
+            resources: { memory: "8Gi", ephemeralStorage: "8Gi" },
         },
         pool: { minIdle: 3, maxIdle: 10 },
     },

--- a/docs/template/pool/page.mdx
+++ b/docs/template/pool/page.mdx
@@ -84,7 +84,7 @@ Warm-pool capacity is counted from idle pods that are ready for claiming.
 | Single-user tool | 1 |
 
 <Callout variant="warning">
-Idle pods use a fixed low CPU and memory allocation while they wait in the warm pool. `mainContainer.resources` remains the default sandbox resource contract; if `config.resources` is omitted during claim, Sandbox0 resizes the hot-claimed pod to the template's `mainContainer.resources`, subject to the `150m` minimum CPU limit. Claim-time `config.resources.memory` overrides that default and Sandbox0 derives CPU from the platform memory-per-CPU ratio with the same minimum. At the minimum limit, the CPU request remains `10m` to preserve sandbox density. Setting `minIdle` too high still consumes cluster capacity, image cache, ephemeral-storage headroom, and runtime overhead. Monitor your claim rate and set `minIdle` to match your typical concurrency.
+Idle pods wait with a `128Mi` memory limit to reduce warm-pool cost. `mainContainer.resources.memory` remains the default sandbox memory contract; if `config.resources` is omitted during claim, Sandbox0 resizes the hot-claimed pod to the template default. Claim-time `config.resources.memory` overrides that default. Setting `minIdle` too high still consumes cluster capacity, image cache, ephemeral-storage headroom, and runtime overhead. Monitor your claim rate and set `minIdle` to match your typical concurrency.
 </Callout>
 
 ---

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -7093,13 +7093,13 @@ components:
     ResourceQuota:
       type: object
       properties:
-        cpu:
-          type: string
         memory:
           type: string
+          description: Memory limit used by default when a sandbox claim does not provide a memory override. Sandbox0 derives the internal CPU limit from platform configuration.
         ephemeralStorage:
           type: string
           description: Ephemeral storage limit for the sandbox writable layer and container logs. Defaults to 8Gi when omitted.
+      required: [memory]
     SecurityContext:
       type: object
       properties:

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -1953,11 +1953,11 @@ type ResizeContextRequest struct {
 
 // ResourceQuota defines model for ResourceQuota.
 type ResourceQuota struct {
-	Cpu *string `json:"cpu,omitempty"`
-
 	// EphemeralStorage Ephemeral storage limit for the sandbox writable layer and container logs. Defaults to 8Gi when omitted.
 	EphemeralStorage *string `json:"ephemeralStorage,omitempty"`
-	Memory           *string `json:"memory,omitempty"`
+
+	// Memory Memory limit used by default when a sandbox claim does not provide a memory override. Sandbox0 derives the internal CPU limit from platform configuration.
+	Memory string `json:"memory"`
 }
 
 // ResourceUsage defines model for ResourceUsage.

--- a/pkg/template/http/handlers.go
+++ b/pkg/template/http/handlers.go
@@ -10,12 +10,14 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
+	"github.com/sandbox0-ai/sandbox0/pkg/apispec"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 	"github.com/sandbox0-ai/sandbox0/pkg/template"
 	"github.com/sandbox0-ai/sandbox0/pkg/template/store"
 	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 // ClusterStore provides cluster lookup for delete warnings.
@@ -82,9 +84,15 @@ func (h *Handler) ListTemplates(c *gin.Context) {
 		return
 	}
 	h.enrichTemplatesStatus(c.Request.Context(), templates)
+	responseTemplates, err := templatesForResponse(templates, claims)
+	if err != nil {
+		h.Logger.Error("Failed to project template response", zap.Error(err))
+		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to list templates")
+		return
+	}
 
 	spec.JSONSuccess(c, http.StatusOK, gin.H{
-		"templates": templatesForResponse(templates, claims),
+		"templates": responseTemplates,
 		"count":     len(templates),
 	})
 }
@@ -132,7 +140,13 @@ func (h *Handler) GetTemplate(c *gin.Context) {
 	}
 	h.enrichTemplatesStatus(c.Request.Context(), []*template.Template{tpl})
 
-	spec.JSONSuccess(c, http.StatusOK, templateForResponse(tpl, claims))
+	responseTemplate, err := templateForResponse(tpl, claims)
+	if err != nil {
+		h.Logger.Error("Failed to project template response", zap.Error(err))
+		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to get template")
+		return
+	}
+	spec.JSONSuccess(c, http.StatusOK, responseTemplate)
 }
 
 func (h *Handler) enrichTemplatesStatus(ctx context.Context, templates []*template.Template) {
@@ -188,17 +202,23 @@ func templateStatKey(namespace, templateID string) string {
 	return namespace + "\x00" + templateID
 }
 
-func templatesForResponse(templates []*template.Template, claims *internalauth.Claims) []*template.Template {
-	out := make([]*template.Template, 0, len(templates))
+func templatesForResponse(templates []*template.Template, claims *internalauth.Claims) ([]*apispec.Template, error) {
+	out := make([]*apispec.Template, 0, len(templates))
 	for _, tpl := range templates {
-		out = append(out, templateForResponse(tpl, claims))
+		projected, err := templateForResponse(tpl, claims)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, projected)
 	}
-	return out
+	return out, nil
 }
 
-func templateForResponse(tpl *template.Template, claims *internalauth.Claims) *template.Template {
+// templateForResponse projects the internal template model through the generated
+// public API type so internal fields such as the platform-derived CPU are omitted.
+func templateForResponse(tpl *template.Template, claims *internalauth.Claims) (*apispec.Template, error) {
 	if tpl == nil {
-		return nil
+		return nil, nil
 	}
 	out := *tpl
 	out.Spec = *tpl.Spec.DeepCopy()
@@ -211,7 +231,15 @@ func templateForResponse(tpl *template.Template, claims *internalauth.Claims) *t
 		out.Spec.MainContainer.ImagePullPolicy = ""
 		out.Spec.ClusterId = nil
 	}
-	return &out
+	raw, err := json.Marshal(&out)
+	if err != nil {
+		return nil, fmt.Errorf("marshal internal template: %w", err)
+	}
+	var projected apispec.Template
+	if err := json.Unmarshal(raw, &projected); err != nil {
+		return nil, fmt.Errorf("decode public template: %w", err)
+	}
+	return &projected, nil
 }
 
 func templateScopeForClaims(claims *internalauth.Claims) (string, string, error) {
@@ -241,6 +269,17 @@ func decodeTemplateRequestSpec(raw json.RawMessage) (v1alpha1.SandboxTemplateSpe
 	return out, nil
 }
 
+// deriveTemplateCPU materializes the platform-managed CPU before persistence.
+func deriveTemplateCPU(spec *v1alpha1.SandboxTemplateSpec, memoryPerCPU resource.Quantity) {
+	if spec == nil || spec.MainContainer.Resources.Memory.Sign() <= 0 {
+		return
+	}
+	spec.MainContainer.Resources.CPU = template.CPUForMemory(
+		spec.MainContainer.Resources.Memory,
+		memoryPerCPU,
+	)
+}
+
 func rejectUnsupportedTemplateSpecFields(raw json.RawMessage) error {
 	if strings.TrimSpace(string(raw)) == "null" {
 		return nil
@@ -252,6 +291,19 @@ func rejectUnsupportedTemplateSpecFields(raw json.RawMessage) error {
 	for _, field := range []string{"lifecycle", "public", "allowedTeams"} {
 		if _, ok := fields[field]; ok {
 			return fmt.Errorf("spec.%s is not supported", field)
+		}
+	}
+	var mainContainerFields map[string]json.RawMessage
+	if err := json.Unmarshal(fields["mainContainer"], &mainContainerFields); err != nil {
+		return nil
+	}
+	var resourceFields map[string]json.RawMessage
+	if err := json.Unmarshal(mainContainerFields["resources"], &resourceFields); err != nil {
+		return nil
+	}
+	for field := range resourceFields {
+		if strings.EqualFold(field, "cpu") {
+			return fmt.Errorf("spec.mainContainer.resources.cpu is not supported; set memory only")
 		}
 	}
 	return nil
@@ -291,11 +343,13 @@ func (h *Handler) CreateTemplate(c *gin.Context) {
 		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
 		return
 	}
+	memoryPerCPU := configuredTemplateMemoryPerCPU()
+	deriveTemplateCPU(&templateSpec, memoryPerCPU)
 	if err := validateTemplateSpec(templateSpec); err != nil {
 		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
 		return
 	}
-	if err := validateTemplateSpecForClaims(templateSpec, claims); err != nil {
+	if err := validateTemplateSpecForClaimsWithMemoryPerCPU(templateSpec, claims, memoryPerCPU); err != nil {
 		spec.JSONError(c, http.StatusForbidden, spec.CodeForbidden, err.Error())
 		return
 	}
@@ -344,11 +398,16 @@ func (h *Handler) CreateTemplate(c *gin.Context) {
 	h.triggerReconcile()
 
 	created, _ := h.Store.GetTemplate(c.Request.Context(), scope, teamID, templateID)
-	if created != nil {
-		spec.JSONSuccess(c, http.StatusCreated, created)
-	} else {
-		spec.JSONSuccess(c, http.StatusCreated, tpl)
+	if created == nil {
+		created = tpl
 	}
+	responseTemplate, err := templateForResponse(created, claims)
+	if err != nil {
+		h.Logger.Error("Failed to project template response", zap.Error(err))
+		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to create template")
+		return
+	}
+	spec.JSONSuccess(c, http.StatusCreated, responseTemplate)
 }
 
 // UpdateTemplate updates an existing template.
@@ -385,11 +444,13 @@ func (h *Handler) UpdateTemplate(c *gin.Context) {
 		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
 		return
 	}
+	memoryPerCPU := configuredTemplateMemoryPerCPU()
+	deriveTemplateCPU(&templateSpec, memoryPerCPU)
 	if err := validateTemplateSpec(templateSpec); err != nil {
 		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
 		return
 	}
-	if err := validateTemplateSpecForClaims(templateSpec, claims); err != nil {
+	if err := validateTemplateSpecForClaimsWithMemoryPerCPU(templateSpec, claims, memoryPerCPU); err != nil {
 		spec.JSONError(c, http.StatusForbidden, spec.CodeForbidden, err.Error())
 		return
 	}
@@ -436,11 +497,16 @@ func (h *Handler) UpdateTemplate(c *gin.Context) {
 	h.triggerReconcile()
 
 	updated, _ := h.Store.GetTemplate(c.Request.Context(), scope, teamID, templateID)
-	if updated != nil {
-		spec.JSONSuccess(c, http.StatusOK, updated)
-	} else {
-		spec.JSONSuccess(c, http.StatusOK, tpl)
+	if updated == nil {
+		updated = tpl
 	}
+	responseTemplate, err := templateForResponse(updated, claims)
+	if err != nil {
+		h.Logger.Error("Failed to project template response", zap.Error(err))
+		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to update template")
+		return
+	}
+	spec.JSONSuccess(c, http.StatusOK, responseTemplate)
 }
 
 // DeleteTemplate deletes a template.

--- a/pkg/template/http/handlers_test.go
+++ b/pkg/template/http/handlers_test.go
@@ -108,7 +108,7 @@ func TestCreateTemplate_RejectsPrivilegedFieldsForRegularTeam(t *testing.T) {
 	body := []byte(`{
 		"template_id":"demo",
 		"spec":{
-			"mainContainer":{"image":"ubuntu:22.04","resources":{"cpu":"1","memory":"4Gi"}},
+			"mainContainer":{"image":"ubuntu:22.04","resources":{"memory":"4Gi"}},
 			"pool":{"minIdle":0,"maxIdle":1},
 			"pod":{"serviceAccountName":"custom-sa"}
 		}
@@ -145,7 +145,7 @@ func TestCreateTemplate_RejectsImagePullPolicyForRegularTeam(t *testing.T) {
 			"mainContainer":{
 				"image":"ubuntu:22.04",
 				"imagePullPolicy":"Always",
-				"resources":{"cpu":"1","memory":"4Gi"}
+				"resources":{"memory":"4Gi"}
 			},
 			"pool":{"minIdle":0,"maxIdle":1}
 		}
@@ -183,7 +183,7 @@ func TestCreateTemplate_RejectsPrivateImageFromDifferentTeam(t *testing.T) {
 	body := []byte(`{
 		"template_id":"demo",
 		"spec":{
-			"mainContainer":{"image":"registry.internal.svc:5000/t-other/my-app:v1","resources":{"cpu":"1","memory":"4Gi"}},
+			"mainContainer":{"image":"registry.internal.svc:5000/t-other/my-app:v1","resources":{"memory":"4Gi"}},
 			"pool":{"minIdle":0,"maxIdle":1}
 		}
 	}`)
@@ -225,7 +225,7 @@ func TestCreateTemplate_AllowsTeamScopedPrivateImage(t *testing.T) {
 	body := []byte(`{
 		"template_id":"demo",
 		"spec":{
-			"mainContainer":{"image":"registry.internal.svc:5000/` + prefix + `/my-app:v1","resources":{"cpu":"1","memory":"4Gi"}},
+			"mainContainer":{"image":"registry.internal.svc:5000/` + prefix + `/my-app:v1","resources":{"memory":"4Gi"}},
 			"pool":{"minIdle":0,"maxIdle":1}
 		}
 	}`)
@@ -262,7 +262,7 @@ func TestCreateTemplate_AllowsNetworkForRegularTeam(t *testing.T) {
 	body := []byte(`{
 		"template_id":"demo",
 		"spec":{
-			"mainContainer":{"image":"ubuntu:22.04","resources":{"cpu":"1","memory":"4Gi"}},
+			"mainContainer":{"image":"ubuntu:22.04","resources":{"memory":"4Gi"}},
 			"pool":{"minIdle":0,"maxIdle":1},
 			"network":{"mode":"block-all"}
 		}
@@ -300,7 +300,7 @@ func TestCreateTemplate_PreservesEphemeralStorage(t *testing.T) {
 	body := []byte(`{
 		"template_id":"demo",
 		"spec":{
-			"mainContainer":{"image":"ubuntu:22.04","resources":{"cpu":"1","memory":"4Gi","ephemeralStorage":"768Mi"}},
+			"mainContainer":{"image":"ubuntu:22.04","resources":{"memory":"4Gi","ephemeralStorage":"768Mi"}},
 			"pool":{"minIdle":0,"maxIdle":1}
 		}
 	}`)
@@ -318,6 +318,110 @@ func TestCreateTemplate_PreservesEphemeralStorage(t *testing.T) {
 	got := store.createdOrUpdatedSpec.MainContainer.Resources.EphemeralStorage
 	if got.Cmp(resource.MustParse("768Mi")) != 0 {
 		t.Fatalf("ephemeralStorage = %s, want 768Mi", got.String())
+	}
+}
+
+func TestCreateTemplate_DerivesCPUWhenOmitted(t *testing.T) {
+	t.Parallel()
+
+	store := &testTemplateStore{
+		getTemplateFn: func(context.Context, string, string, string) (*template.Template, error) {
+			return nil, nil
+		},
+	}
+	h := &Handler{Store: store, Logger: zap.NewNop()}
+
+	router := gin.New()
+	router.Use(withClaims(&internalauth.Claims{
+		TeamID: "team-1",
+		UserID: "user-1",
+	}))
+	router.POST("/api/v1/templates", h.CreateTemplate)
+
+	body := []byte(`{
+		"template_id":"demo",
+		"spec":{
+			"mainContainer":{"image":"ubuntu:22.04","resources":{"memory":"129Mi"}},
+			"pool":{"minIdle":0,"maxIdle":1}
+		}
+	}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/templates", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusCreated, rec.Code, rec.Body.String())
+	}
+	if !store.createCalled {
+		t.Fatal("expected create to be called")
+	}
+	got := store.createdOrUpdatedSpec.MainContainer.Resources.CPU
+	if got.Cmp(resource.MustParse("32m")) != 0 {
+		t.Fatalf("cpu = %s, want 32m", got.String())
+	}
+	assertTemplateResponseOmitsCPU(t, rec.Body.Bytes())
+}
+
+func TestDeriveTemplateCPUUsesConfiguredMemoryPerCPU(t *testing.T) {
+	t.Parallel()
+
+	raw := json.RawMessage(`{
+		"mainContainer":{"image":"ubuntu:22.04","resources":{"memory":"2Gi"}},
+		"pool":{"minIdle":0,"maxIdle":1}
+	}`)
+	spec, err := decodeTemplateRequestSpec(raw)
+	if err != nil {
+		t.Fatalf("decodeTemplateRequestSpec() error = %v", err)
+	}
+	deriveTemplateCPU(&spec, resource.MustParse("8Gi"))
+	got := spec.MainContainer.Resources.CPU
+	if got.Cmp(resource.MustParse("250m")) != 0 {
+		t.Fatalf("cpu = %s, want 250m", got.String())
+	}
+}
+
+func TestCreateTemplate_RejectsExplicitCPU(t *testing.T) {
+	t.Parallel()
+
+	store := &testTemplateStore{}
+	h := &Handler{Store: store, Logger: zap.NewNop()}
+
+	router := gin.New()
+	router.Use(withClaims(&internalauth.Claims{
+		TeamID: "team-1",
+		UserID: "user-1",
+	}))
+	router.POST("/api/v1/templates", h.CreateTemplate)
+
+	body := []byte(`{
+		"template_id":"demo",
+		"spec":{
+			"mainContainer":{"image":"ubuntu:22.04","resources":{"cpu":"1","memory":"2Gi"}},
+			"pool":{"minIdle":0,"maxIdle":1}
+		}
+	}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/templates", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusBadRequest, rec.Code, rec.Body.String())
+	}
+	var response struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Error.Message != "spec.mainContainer.resources.cpu is not supported; set memory only" {
+		t.Fatalf("error message = %q, want unsupported cpu error", response.Error.Message)
+	}
+	if store.createCalled {
+		t.Fatal("expected create not called for invalid request")
 	}
 }
 
@@ -344,7 +448,7 @@ func TestCreateTemplate_AllowsPrivilegedFieldForSystemToken(t *testing.T) {
 		"spec":{
 			"mainContainer":{
 				"image":"ubuntu:22.04",
-				"resources":{"cpu":"1","memory":"4Gi"},
+				"resources":{"memory":"4Gi"},
 				"securityContext":{"runAsUser":1000}
 			},
 			"pool":{"minIdle":0,"maxIdle":1}
@@ -386,7 +490,7 @@ func TestCreateTemplate_SystemWithoutTeamCreatesPublicTemplate(t *testing.T) {
 	body := []byte(`{
 		"template_id":"demo",
 		"spec":{
-			"mainContainer":{"image":"ubuntu:22.04","resources":{"cpu":"1","memory":"4Gi"}},
+			"mainContainer":{"image":"ubuntu:22.04","resources":{"memory":"4Gi"}},
 			"pool":{"minIdle":0,"maxIdle":1}
 		}
 	}`)
@@ -600,7 +704,7 @@ func TestCreateTemplate_RejectsMissingMainContainerImage(t *testing.T) {
 	body := []byte(`{
 		"template_id":"demo",
 		"spec":{
-			"mainContainer":{"resources":{"cpu":"1","memory":"4Gi"}},
+			"mainContainer":{"resources":{"memory":"4Gi"}},
 			"pool":{"minIdle":0,"maxIdle":1}
 		}
 	}`)
@@ -647,7 +751,7 @@ func TestCreateTemplate_RejectsUnsupportedDocumentedSpecFields(t *testing.T) {
 			body := []byte(`{
 				"template_id":"demo",
 				"spec":{
-					"mainContainer":{"image":"ubuntu:22.04","resources":{"cpu":"1","memory":"4Gi"}},
+					"mainContainer":{"image":"ubuntu:22.04","resources":{"memory":"4Gi"}},
 					"pool":{"minIdle":0,"maxIdle":1},
 					` + fieldJSON + `
 				}
@@ -668,6 +772,52 @@ func TestCreateTemplate_RejectsUnsupportedDocumentedSpecFields(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestUpdateTemplate_DerivesCPUWhenOmitted(t *testing.T) {
+	t.Parallel()
+
+	store := &testTemplateStore{
+		getTemplateFn: func(context.Context, string, string, string) (*template.Template, error) {
+			return &template.Template{
+				TemplateID: "demo",
+				Scope:      "team",
+				TeamID:     "team-1",
+				Spec:       validTemplateSpec(),
+			}, nil
+		},
+	}
+	h := &Handler{Store: store, Logger: zap.NewNop()}
+
+	router := gin.New()
+	router.Use(withClaims(&internalauth.Claims{
+		TeamID: "team-1",
+		UserID: "user-1",
+	}))
+	router.PUT("/api/v1/templates/:id", h.UpdateTemplate)
+
+	body := []byte(`{
+		"spec":{
+			"mainContainer":{"image":"ubuntu:22.04","resources":{"memory":"8Gi"}},
+			"pool":{"minIdle":0,"maxIdle":1}
+		}
+	}`)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/templates/demo", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+	if !store.updateCalled {
+		t.Fatal("expected update to be called")
+	}
+	got := store.createdOrUpdatedSpec.MainContainer.Resources.CPU
+	if got.Cmp(resource.MustParse("2")) != 0 {
+		t.Fatalf("cpu = %s, want 2", got.String())
+	}
+	assertTemplateResponseOmitsCPU(t, rec.Body.Bytes())
 }
 
 func TestUpdateTemplate_RejectsInvalidPoolRange(t *testing.T) {
@@ -703,7 +853,7 @@ func TestUpdateTemplate_RejectsInvalidPoolRange(t *testing.T) {
 
 	body := []byte(`{
 		"spec":{
-			"mainContainer":{"image":"ubuntu:22.04","resources":{"cpu":"1","memory":"4Gi"}},
+			"mainContainer":{"image":"ubuntu:22.04","resources":{"memory":"4Gi"}},
 			"pool":{"minIdle":2,"maxIdle":1}
 		}
 	}`)
@@ -739,7 +889,7 @@ func TestUpdateTemplate_RejectsUnsupportedDocumentedSpecFields(t *testing.T) {
 
 	body := []byte(`{
 		"spec":{
-			"mainContainer":{"image":"ubuntu:22.04","resources":{"cpu":"1","memory":"4Gi"}},
+			"mainContainer":{"image":"ubuntu:22.04","resources":{"memory":"4Gi"}},
 			"pool":{"minIdle":0,"maxIdle":1},
 			"allowedTeams":["team-1"]
 		}
@@ -782,7 +932,7 @@ func TestUpdateTemplate_SystemWithoutTeamUpdatesPublicTemplate(t *testing.T) {
 
 	body := []byte(`{
 		"spec":{
-			"mainContainer":{"image":"ubuntu:22.04","resources":{"cpu":"1","memory":"4Gi"}},
+			"mainContainer":{"image":"ubuntu:22.04","resources":{"memory":"4Gi"}},
 			"pool":{"minIdle":0,"maxIdle":1}
 		}
 	}`)
@@ -838,7 +988,7 @@ func TestUpdateTemplate_RejectsImagePullPolicyForRegularTeam(t *testing.T) {
 			"mainContainer":{
 				"image":"ubuntu:22.04",
 				"imagePullPolicy":"Always",
-				"resources":{"cpu":"1","memory":"4Gi"}
+				"resources":{"memory":"4Gi"}
 			},
 			"pool":{"minIdle":0,"maxIdle":1}
 		}
@@ -871,7 +1021,7 @@ func TestCreateTemplate_RejectsUnclaimableNameBudget(t *testing.T) {
 		"template_id":"demo",
 		"spec":{
 			"clusterId":"` + clusterID + `",
-			"mainContainer":{"image":"ubuntu:22.04","resources":{"cpu":"1","memory":"4Gi"}},
+			"mainContainer":{"image":"ubuntu:22.04","resources":{"memory":"4Gi"}},
 			"pool":{"minIdle":0,"maxIdle":1}
 		}
 	}`)
@@ -962,11 +1112,11 @@ func TestValidateTemplateSpec_StrictValidation(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name: "reject missing cpu",
+			name: "reject missing derived cpu",
 			mutate: func(s *v1alpha1.SandboxTemplateSpec) {
 				s.MainContainer.Resources.CPU = resource.MustParse("0")
 			},
-			wantErr: "spec.mainContainer.resources.cpu must be > 0",
+			wantErr: "derived spec.mainContainer.resources.cpu must be > 0",
 		},
 		{
 			name: "reject negative ephemeral storage",
@@ -1250,7 +1400,7 @@ func TestValidateTemplateSpecForClaims_RejectsMismatchedMainResources(t *testing
 	if err == nil {
 		t.Fatal("expected aggregate resource ratio to be rejected")
 	}
-	if got := err.Error(); !strings.Contains(got, "team-owned template total memory must equal total cpu") {
+	if got := err.Error(); !strings.Contains(got, "team-owned template total cpu must match the value derived from memory") {
 		t.Fatalf("unexpected error %q", got)
 	}
 }
@@ -1274,7 +1424,7 @@ func TestValidateTemplateSpecForClaims_RejectsSystemOwnedMismatchedMainResources
 	if err == nil {
 		t.Fatal("expected system token to reject resource ratio mismatch")
 	}
-	if got := err.Error(); !strings.Contains(got, "system template total memory must equal total cpu") {
+	if got := err.Error(); !strings.Contains(got, "system template total cpu must match the value derived from memory") {
 		t.Fatalf("unexpected error %q", got)
 	}
 }
@@ -1401,6 +1551,25 @@ func assertSystemOnlyFieldsStripped(t *testing.T, spec v1alpha1.SandboxTemplateS
 	}
 	if spec.ClusterId != nil {
 		t.Fatalf("clusterId = %#v, want nil", spec.ClusterId)
+	}
+}
+
+func assertTemplateResponseOmitsCPU(t *testing.T, body []byte) {
+	t.Helper()
+	var response struct {
+		Data struct {
+			Spec struct {
+				MainContainer struct {
+					Resources map[string]json.RawMessage `json:"resources"`
+				} `json:"mainContainer"`
+			} `json:"spec"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
+		t.Fatalf("decode template response: %v", err)
+	}
+	if _, ok := response.Data.Spec.MainContainer.Resources["cpu"]; ok {
+		t.Fatalf("template response exposes platform-derived cpu: %s", body)
 	}
 }
 

--- a/pkg/template/http/template_validation.go
+++ b/pkg/template/http/template_validation.go
@@ -16,6 +16,14 @@ import (
 )
 
 func validateTemplateSpecForClaims(spec v1alpha1.SandboxTemplateSpec, claims *internalauth.Claims) error {
+	return validateTemplateSpecForClaimsWithMemoryPerCPU(spec, claims, configuredTemplateMemoryPerCPU())
+}
+
+func validateTemplateSpecForClaimsWithMemoryPerCPU(
+	spec v1alpha1.SandboxTemplateSpec,
+	claims *internalauth.Claims,
+	memoryPerCPU resource.Quantity,
+) error {
 	isSystem := claims != nil && claims.IsSystemToken()
 	if !isSystem {
 		if spec.Pod != nil {
@@ -36,7 +44,7 @@ func validateTemplateSpecForClaims(spec v1alpha1.SandboxTemplateSpec, claims *in
 	if isSystem {
 		subject = "system template"
 	}
-	if err := validateTemplateResourceRatio(spec, subject); err != nil {
+	if err := s0template.ValidateResourceRatio(spec, memoryPerCPU, subject); err != nil {
 		return err
 	}
 	return nil
@@ -63,11 +71,11 @@ func validateTemplateSpec(spec v1alpha1.SandboxTemplateSpec) error {
 	if strings.TrimSpace(spec.MainContainer.Image) == "" {
 		return fmt.Errorf("spec.mainContainer.image is required")
 	}
-	if spec.MainContainer.Resources.CPU.Sign() <= 0 {
-		return fmt.Errorf("spec.mainContainer.resources.cpu must be > 0")
-	}
 	if spec.MainContainer.Resources.Memory.Sign() <= 0 {
 		return fmt.Errorf("spec.mainContainer.resources.memory must be > 0")
+	}
+	if spec.MainContainer.Resources.CPU.Sign() <= 0 {
+		return fmt.Errorf("derived spec.mainContainer.resources.cpu must be > 0")
 	}
 	if spec.MainContainer.Resources.EphemeralStorage.Sign() < 0 {
 		return fmt.Errorf("spec.mainContainer.resources.ephemeralStorage must be >= 0")
@@ -275,10 +283,6 @@ func validateReservedMountPath(path, field string) error {
 		}
 	}
 	return nil
-}
-
-func validateTemplateResourceRatio(spec v1alpha1.SandboxTemplateSpec, subject string) error {
-	return s0template.ValidateResourceRatio(spec, configuredTemplateMemoryPerCPU(), subject)
 }
 
 func configuredTemplateMemoryPerCPU() resource.Quantity {

--- a/pkg/template/resource_policy.go
+++ b/pkg/template/resource_policy.go
@@ -20,15 +20,6 @@ func MemoryPerCPUOrDefault(value string) resource.Quantity {
 	return parsed
 }
 
-// MemoryForCPU returns the memory limit required for a CPU limit at the given memory-per-CPU ratio.
-func MemoryForCPU(cpu, memoryPerCPU resource.Quantity) resource.Quantity {
-	if cpu.Sign() <= 0 || memoryPerCPU.Sign() <= 0 {
-		return resource.Quantity{}
-	}
-	requiredBytes := cpu.MilliValue() * memoryPerCPU.Value() / 1000
-	return *resource.NewQuantity(requiredBytes, resource.BinarySI)
-}
-
 // CPUForMemory returns the CPU limit required for a memory limit at the given
 // memory-per-CPU ratio, rounded up to Kubernetes millicpu precision.
 func CPUForMemory(memory, memoryPerCPU resource.Quantity) resource.Quantity {
@@ -48,7 +39,7 @@ func CPUForMemory(memory, memoryPerCPU resource.Quantity) resource.Quantity {
 	return *resource.NewMilliQuantity(quotient.Int64(), resource.DecimalSI)
 }
 
-// ValidateResourceRatio enforces the platform CPU-to-memory resource shape for template specs.
+// ValidateResourceRatio enforces the platform memory-derived CPU shape for template specs.
 func ValidateResourceRatio(spec v1alpha1.SandboxTemplateSpec, memoryPerCPU resource.Quantity, subject string) error {
 	if subject == "" {
 		subject = "template"
@@ -58,15 +49,14 @@ func ValidateResourceRatio(spec v1alpha1.SandboxTemplateSpec, memoryPerCPU resou
 	}
 	totalCPU := spec.MainContainer.Resources.CPU.DeepCopy()
 	totalMemory := spec.MainContainer.Resources.Memory.DeepCopy()
-	requiredMemory := MemoryForCPU(totalCPU, memoryPerCPU)
-	if totalMemory.Cmp(requiredMemory) != 0 {
+	requiredCPU := CPUForMemory(totalMemory, memoryPerCPU)
+	if totalCPU.Cmp(requiredCPU) != 0 {
 		return fmt.Errorf(
-			"%s total memory must equal total cpu * %s (got cpu=%s memory=%s expectedMemory=%s)",
+			"%s total cpu must match the value derived from memory (got cpu=%s memory=%s expectedCPU=%s)",
 			subject,
-			memoryPerCPU.String(),
 			totalCPU.String(),
 			totalMemory.String(),
-			requiredMemory.String(),
+			requiredCPU.String(),
 		)
 	}
 	return nil

--- a/pkg/template/resource_policy_test.go
+++ b/pkg/template/resource_policy_test.go
@@ -34,16 +34,6 @@ func TestMemoryPerCPUOrDefault(t *testing.T) {
 	}
 }
 
-func TestMemoryForCPU(t *testing.T) {
-	t.Parallel()
-
-	got := MemoryForCPU(resource.MustParse("500m"), resource.MustParse("4Gi"))
-	want := resource.MustParse("2Gi")
-	if got.Cmp(want) != 0 {
-		t.Fatalf("MemoryForCPU = %s, want %s", got.String(), want.String())
-	}
-}
-
 func TestCPUForMemory(t *testing.T) {
 	t.Parallel()
 
@@ -85,12 +75,19 @@ func TestValidateResourceRatio(t *testing.T) {
 		t.Fatalf("expected ratio to pass, got %v", err)
 	}
 
+	spec.MainContainer.Resources.CPU = resource.MustParse("32m")
+	spec.MainContainer.Resources.Memory = resource.MustParse("129Mi")
+	if err := ValidateResourceRatio(spec, resource.MustParse("4Gi"), "rounded template"); err != nil {
+		t.Fatalf("expected rounded memory-derived cpu to pass, got %v", err)
+	}
+
+	spec.MainContainer.Resources.CPU = resource.MustParse("1")
 	spec.MainContainer.Resources.Memory = resource.MustParse("1Gi")
 	err := ValidateResourceRatio(spec, resource.MustParse("4Gi"), "builtin template default")
 	if err == nil {
 		t.Fatal("expected ratio validation to fail")
 	}
-	if got := err.Error(); !strings.Contains(got, "builtin template default total memory must equal total cpu * 4Gi") {
+	if got := err.Error(); !strings.Contains(got, "builtin template default total cpu must match the value derived from memory") {
 		t.Fatalf("unexpected error %q", got)
 	}
 }

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -744,8 +744,7 @@ func assertTemplatePoolReadinessGate(env *framework.ScenarioEnv, session *e2euti
 	Expect(templateReq.Spec.Pool).NotTo(BeNil())
 	Expect(templateReq.Spec.MainContainer).NotTo(BeNil())
 	templateReq.Spec.MainContainer.Resources = apispec.ResourceQuota{
-		Cpu:    ptr("500m"),
-		Memory: ptr("2Gi"),
+		Memory: "2Gi",
 	}
 	templateReq.Spec.Pool.MinIdle = 1
 	templateReq.Spec.Pool.MaxIdle = 1
@@ -822,8 +821,7 @@ func assertTemplateRolloutClaimFallsBackToColdStart(env *framework.ScenarioEnv, 
 	Expect(templateReq.Spec.Pool).NotTo(BeNil())
 	Expect(templateReq.Spec.MainContainer).NotTo(BeNil())
 	templateReq.Spec.MainContainer.Resources = apispec.ResourceQuota{
-		Cpu:    ptr("500m"),
-		Memory: ptr("2Gi"),
+		Memory: "2Gi",
 	}
 	templateReq.Spec.Pool.MinIdle = 1
 	templateReq.Spec.Pool.MaxIdle = 1

--- a/tests/e2e/utils/template.go
+++ b/tests/e2e/utils/template.go
@@ -7,8 +7,6 @@ import (
 	"net/http"
 
 	"github.com/sandbox0-ai/sandbox0/pkg/apispec"
-	s0template "github.com/sandbox0-ai/sandbox0/pkg/template"
-	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func (s *Session) ListTemplates(ctx context.Context, t ContractT) ([]apispec.Template, error) {
@@ -117,48 +115,6 @@ func (s *Session) DeleteTemplate(ctx context.Context, t ContractT, templateID st
 func CloneTemplateForCreate(base apispec.Template, name string) apispec.TemplateCreateRequest {
 	return apispec.TemplateCreateRequest{
 		TemplateId: name,
-		Spec:       cloneSandboxTemplateSpec(base.Spec),
+		Spec:       base.Spec,
 	}
-}
-
-func cloneSandboxTemplateSpec(base apispec.SandboxTemplateSpec) apispec.SandboxTemplateSpec {
-	spec := base
-	normalizeTeamTemplateResourceRatioForCreate(&spec)
-	return spec
-}
-
-func normalizeTeamTemplateResourceRatioForCreate(spec *apispec.SandboxTemplateSpec) {
-	if spec == nil || spec.MainContainer == nil {
-		return
-	}
-
-	mainCPU, ok := parseQuotaQuantity(spec.MainContainer.Resources.Cpu)
-	if !ok {
-		return
-	}
-	mainMemory, ok := parseQuotaQuantity(spec.MainContainer.Resources.Memory)
-	if !ok {
-		return
-	}
-
-	requiredMemory := s0template.MemoryForCPU(mainCPU, s0template.MemoryPerCPUOrDefault(""))
-	if mainMemory.Cmp(requiredMemory) == 0 {
-		return
-	}
-	spec.MainContainer.Resources.Memory = ptr(requiredMemory.String())
-}
-
-func parseQuotaQuantity(value *string) (resource.Quantity, bool) {
-	if value == nil || *value == "" {
-		return resource.Quantity{}, false
-	}
-	parsed, err := resource.ParseQuantity(*value)
-	if err != nil {
-		return resource.Quantity{}, false
-	}
-	return parsed, true
-}
-
-func ptr[T any](value T) *T {
-	return &value
 }

--- a/tests/e2e/utils/template_test.go
+++ b/tests/e2e/utils/template_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/apispec"
 )
 
-func TestCloneTemplateForCreateNormalizesTeamTemplateMemoryRatio(t *testing.T) {
+func TestCloneTemplateForCreatePreservesMemory(t *testing.T) {
 	t.Parallel()
 
 	base := apispec.Template{
@@ -14,8 +14,7 @@ func TestCloneTemplateForCreateNormalizesTeamTemplateMemoryRatio(t *testing.T) {
 			MainContainer: &apispec.ContainerSpec{
 				Image: "nginx:1.27-alpine",
 				Resources: apispec.ResourceQuota{
-					Cpu:    ptr("500m"),
-					Memory: ptr("512Mi"),
+					Memory: "512Mi",
 				},
 			},
 		},
@@ -26,10 +25,7 @@ func TestCloneTemplateForCreateNormalizesTeamTemplateMemoryRatio(t *testing.T) {
 	if created.Spec.MainContainer == nil {
 		t.Fatal("main container should be set")
 	}
-	if created.Spec.MainContainer.Resources.Memory == nil {
-		t.Fatal("main memory should be set")
-	}
-	if got := *created.Spec.MainContainer.Resources.Memory; got != "2Gi" {
-		t.Fatalf("main memory = %q, want %q", got, "2Gi")
+	if got := created.Spec.MainContainer.Resources.Memory; got != "512Mi" {
+		t.Fatalf("main memory = %q, want %q", got, "512Mi")
 	}
 }


### PR DESCRIPTION
## Summary

- remove `cpu` from the Template `ResourceQuota` OpenAPI schema and make `memory` required
- reject create/update requests that explicitly submit CPU
- derive CPU from the platform resource configuration before persisting the internal template
- omit the internally derived CPU from Template API responses
- remove obsolete CPU-normalization helpers and update generated types, E2E fixtures, examples, and resource docs
- document template memory as the claim default and the `128Mi` warm-pool idle memory behavior

## Why

Sandbox claims already expose memory as the user-facing resource input. Template creation should follow the same contract: clients set memory, while Sandbox0 owns CPU policy. Keeping CPU writable in OpenAPI would duplicate platform policy across clients and allow those values to drift.

The internal `SandboxTemplate` and Pod resource model still stores the derived CPU required by Kubernetes; it is no longer part of the external Template API.

## API change

Explicit `mainContainer.resources.cpu` is no longer accepted. Clients must send `mainContainer.resources.memory` only (plus optional `ephemeralStorage`).

## Validation

- `make apispec`
- `go test ./pkg/template/... ./manager/pkg/apis/sandbox0/v1alpha1 ./manager/pkg/service/... ./tests/e2e/utils`
- full non-E2E package run completed with all affected packages passing; one unrelated procd timing test passed on a 10-run retry
- `git diff --check`
- Sandbox0 docs rendered and verified through the sandbox0-cloud website build
