### PR TITLE
fix(ctld): report volume storage metering

### DIFF
--- a/ctld/cmd/ctld/main.go
+++ b/ctld/cmd/ctld/main.go
@@ -26,12 +26,15 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
 	"github.com/sandbox0-ai/sandbox0/pkg/dbpool"
 	"github.com/sandbox0-ai/sandbox0/pkg/k8s"
+	meteringoutbox "github.com/sandbox0-ai/sandbox0/pkg/metering/outbox"
+	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 	"github.com/sandbox0-ai/sandbox0/pkg/observability"
 	httpobs "github.com/sandbox0-ai/sandbox0/pkg/observability/http"
 	"github.com/sandbox0-ai/sandbox0/pkg/sandboxprobe"
 	"github.com/sandbox0-ai/sandbox0/pkg/volumeportal"
 	storagedb "github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/objectstore"
+	storagevolume "github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volume"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -221,6 +224,7 @@ func runPrimary(parent context.Context, options primaryRunOptions) error {
 		KubeletPodsRoot:    kubeletPodsRoot,
 		Logger:             zapLogger,
 		StorageConfig:      storageCfg,
+		StorageObserver:    newPortalStorageObserver(storageCfg, repo, dbPool),
 		Repository:         repo,
 		PodName:            podName,
 		PodNamespace:       podNamespace,
@@ -618,6 +622,22 @@ func initPortalDatabase(ctx context.Context, cfg *apiconfig.StorageProxyConfig, 
 		Schema:          schema,
 		ConfigModifier:  modifier,
 	})
+}
+
+func newPortalStorageObserver(
+	cfg *apiconfig.StorageProxyConfig,
+	repo *storagedb.Repository,
+	pool *pgxpool.Pool,
+) storagevolume.StorageObserver {
+	if cfg == nil || !cfg.Metering.Enabled || repo == nil || pool == nil {
+		return nil
+	}
+	return storagevolume.NewVolumeStorageObserverWithRecorder(
+		repo,
+		meteringoutbox.NewRepository(pool),
+		cfg.RegionID,
+		naming.ClusterIDOrDefault(&cfg.DefaultClusterId),
+	)
 }
 
 type combinedController struct {

--- a/ctld/cmd/ctld/main_test.go
+++ b/ctld/cmd/ctld/main_test.go
@@ -10,8 +10,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgxpool"
 	ctldserver "github.com/sandbox0-ai/sandbox0/ctld/internal/ctld/server"
+	apiconfig "github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
+	storagedb "github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -23,6 +26,23 @@ func TestCtldShutdownBudgetFitsDeploymentGracePeriod(t *testing.T) {
 	assert.LessOrEqual(t, shutdownBudget+shutdownGraceMargin, deployedTerminationGrace)
 	assert.LessOrEqual(t, max(shutdownBudget, networkRuntimeShutdownTimeout)+shutdownGraceMargin, deployedTerminationGrace)
 	assert.Equal(t, minimumTerminationGrace, shutdownBudget+shutdownGraceMargin)
+}
+
+func TestNewPortalStorageObserverRequiresEnabledMeteringDependencies(t *testing.T) {
+	var pool pgxpool.Pool
+	repo := storagedb.NewRepository(&pool)
+
+	assert.Nil(t, newPortalStorageObserver(&apiconfig.StorageProxyConfig{}, repo, &pool))
+	assert.Nil(t, newPortalStorageObserver(&apiconfig.StorageProxyConfig{
+		Metering: apiconfig.MeteringConfig{Enabled: true},
+	}, nil, &pool))
+
+	observer := newPortalStorageObserver(&apiconfig.StorageProxyConfig{
+		RegionID:         "region-1",
+		DefaultClusterId: "cluster-1",
+		Metering:         apiconfig.MeteringConfig{Enabled: true},
+	}, repo, &pool)
+	assert.NotNil(t, observer)
 }
 
 func TestCtldHealthEndpoints(t *testing.T) {

--- a/ctld/internal/ctld/portal/manager.go
+++ b/ctld/internal/ctld/portal/manager.go
@@ -45,6 +45,7 @@ type Manager struct {
 	logger                 *zap.Logger
 	logrus                 *logrus.Logger
 	storage                *apiconfig.StorageProxyConfig
+	storageObserver        volume.StorageObserver
 	s3CredentialCodec      *volume.S3BackendCredentialCodec
 	s3CredentialCodecErr   error
 	repo                   *db.Repository
@@ -124,6 +125,7 @@ type Config struct {
 	KubeletPodsRoot         string
 	Logger                  *zap.Logger
 	StorageConfig           *apiconfig.StorageProxyConfig
+	StorageObserver         volume.StorageObserver
 	Repository              *db.Repository
 	PodName                 string
 	PodNamespace            string
@@ -182,6 +184,7 @@ func NewManager(cfg Config) *Manager {
 		logger:                 logger,
 		logrus:                 l,
 		storage:                storageConfig,
+		storageObserver:        cfg.StorageObserver,
 		s3CredentialCodec:      s3CredentialCodec,
 		s3CredentialCodecErr:   s3CredentialCodecErr,
 		repo:                   cfg.Repository,
@@ -1004,17 +1007,7 @@ func (m *Manager) openS0FSBoundVolume(ctx context.Context, req ctldapi.BindVolum
 	if err != nil {
 		return nil, nil, fmt.Errorf("open local s0fs engine: %w", err)
 	}
-	volCtx := &volume.VolumeContext{
-		VolumeID:  req.SandboxVolumeID,
-		TeamID:    volumeRecord.TeamID,
-		Backend:   volume.BackendS0FS,
-		S0FS:      engine,
-		Access:    accessMode,
-		MountedAt: mountedAt,
-		RootInode: 1,
-		RootPath:  "/",
-		CacheDir:  cacheDir,
-	}
+	volCtx := m.newS0FSVolumeContext(req.SandboxVolumeID, volumeRecord.TeamID, engine, accessMode, mountedAt, cacheDir)
 	volCtx.RestoreHandleState(handleState)
 	engine.PruneUnlinked(retainedUnlinkedInodes(handleState))
 	session := newLocalSession(req.SandboxVolumeID, m.volumes, m.logrus)
@@ -1034,6 +1027,27 @@ func (m *Manager) openS0FSBoundVolume(ctx context.Context, req ctldapi.BindVolum
 		statePath: statePath,
 	}
 	return bound, func() { _ = engine.Close() }, nil
+}
+
+func (m *Manager) newS0FSVolumeContext(
+	volumeID, teamID string,
+	engine *s0fs.Engine,
+	accessMode volume.AccessMode,
+	mountedAt time.Time,
+	cacheDir string,
+) *volume.VolumeContext {
+	return &volume.VolumeContext{
+		VolumeID:  volumeID,
+		TeamID:    teamID,
+		Backend:   volume.BackendS0FS,
+		S0FS:      engine,
+		Access:    accessMode,
+		MountedAt: mountedAt,
+		RootInode: 1,
+		RootPath:  "/",
+		CacheDir:  cacheDir,
+		Observer:  m.storageObserver,
+	}
 }
 
 func (m *Manager) openS3BoundVolume(req ctldapi.BindVolumePortalRequest, volumeRecord *db.SandboxVolume, accessMode volume.AccessMode, mountedAt time.Time) (*boundVolume, func(), error) {
@@ -1204,17 +1218,7 @@ func (m *Manager) AttachOwner(ctx context.Context, req ctldapi.AttachVolumeOwner
 	if err != nil {
 		return ctldapi.AttachVolumeOwnerResponse{}, fmt.Errorf("open local s0fs engine: %w", err)
 	}
-	volCtx := &volume.VolumeContext{
-		VolumeID:  req.SandboxVolumeID,
-		TeamID:    volumeRecord.TeamID,
-		Backend:   volume.BackendS0FS,
-		S0FS:      engine,
-		Access:    accessMode,
-		MountedAt: mountedAt,
-		RootInode: 1,
-		RootPath:  "/",
-		CacheDir:  cacheDir,
-	}
+	volCtx := m.newS0FSVolumeContext(req.SandboxVolumeID, volumeRecord.TeamID, engine, accessMode, mountedAt, cacheDir)
 
 	m.mu.Lock()
 	if bound := m.boundVolumes[req.SandboxVolumeID]; bound != nil {
@@ -1307,10 +1311,12 @@ func (m *Manager) PrepareSnapshotCheckpoint(ctx context.Context, req ctldapi.Pre
 	if err := m.volumes.prepareSnapshotCheckpoint(ctx, volumeID); err != nil {
 		return ctldapi.PrepareVolumeSnapshotCheckpointResponse{}, err
 	}
-	if _, err := bound.volCtx.S0FS.SyncMaterialize(ctx); err != nil {
+	materialization, err := bound.volCtx.SyncMaterialize(ctx)
+	if err != nil {
 		m.volumes.completeSnapshotCheckpoint(volumeID)
 		return ctldapi.PrepareVolumeSnapshotCheckpointResponse{}, err
 	}
+	m.logStorageObservationError(volumeID, materialization.ObservationError)
 	return ctldapi.PrepareVolumeSnapshotCheckpointResponse{Prepared: true}, nil
 }
 
@@ -1605,11 +1611,12 @@ func (m *Manager) startMaterializer(bound *boundVolume) {
 				return
 			case <-ticker.C:
 				ran, err := m.tryRunMaterializer(ctx, func() error {
-					manifest, err := bound.volCtx.S0FS.SyncMaterialize(ctx)
+					materialization, err := bound.volCtx.SyncMaterialize(ctx)
 					if err != nil {
 						return err
 					}
-					m.garbageCollectBoundS0FS(ctx, bound, manifest)
+					m.logStorageObservationError(volumeID, materialization.ObservationError)
+					m.garbageCollectBoundS0FS(ctx, bound, materialization.Manifest)
 					return nil
 				})
 				if !ran {
@@ -1621,13 +1628,14 @@ func (m *Manager) startMaterializer(bound *boundVolume) {
 			case <-compactionC:
 				var result *s0fs.CompactionResult
 				ran, err := m.tryRunMaterializer(ctx, func() error {
-					var resultManifest *s0fs.Manifest
+					var materialization volume.MaterializationResult
 					var compactErr error
-					resultManifest, result, compactErr = bound.volCtx.S0FS.Compact(ctx, compactionOptions)
+					materialization, result, compactErr = bound.volCtx.Compact(ctx, compactionOptions)
 					if compactErr != nil {
 						return compactErr
 					}
-					m.garbageCollectBoundS0FS(ctx, bound, resultManifest)
+					m.logStorageObservationError(volumeID, materialization.ObservationError)
+					m.garbageCollectBoundS0FS(ctx, bound, materialization.Manifest)
 					return nil
 				})
 				if !ran {
@@ -1648,6 +1656,13 @@ func (m *Manager) startMaterializer(bound *boundVolume) {
 			}
 		}
 	}(bound.volumeID)
+}
+
+func (m *Manager) logStorageObservationError(volumeID string, err error) {
+	if err == nil || m == nil || m.logger == nil {
+		return
+	}
+	m.logger.Warn("ctld volume storage observation failed", zap.String("volume_id", volumeID), zap.Error(err))
 }
 
 func (m *Manager) tryRunMaterializer(ctx context.Context, fn func() error) (bool, error) {

--- a/ctld/internal/ctld/portal/manager_shared_test.go
+++ b/ctld/internal/ctld/portal/manager_shared_test.go
@@ -13,13 +13,40 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 	"github.com/sandbox0-ai/sandbox0/pkg/volumefuse"
 	"github.com/sandbox0-ai/sandbox0/pkg/volumeportal"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/s0fs"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volume"
 )
+
+type testStorageObserver struct{}
+
+func (*testStorageObserver) ObserveVolumeState(context.Context, string, string, *s0fs.SnapshotState, time.Time) error {
+	return nil
+}
 
 func TestPortalMountOptionsDisableUnsupportedIDMapCapability(t *testing.T) {
 	opts := portalMountOptions()
 	if opts.DisabledCapabilities&fuse.CAP_ALLOW_IDMAP == 0 {
 		t.Fatal("portal mount options enable FUSE_ALLOW_IDMAP without default_permissions")
+	}
+}
+
+func TestNewS0FSVolumeContextWiresStorageObserver(t *testing.T) {
+	observer := &testStorageObserver{}
+	mgr := NewManager(Config{
+		RootDir:         t.TempDir(),
+		StorageObserver: observer,
+	})
+	mountedAt := time.Now().UTC()
+	volCtx := mgr.newS0FSVolumeContext("vol-1", "team-1", nil, volume.AccessModeRWO, mountedAt, "/cache")
+
+	if volCtx.Observer != observer {
+		t.Fatal("newS0FSVolumeContext() did not wire the configured storage observer")
+	}
+	if volCtx.VolumeID != "vol-1" || volCtx.TeamID != "team-1" || volCtx.Backend != volume.BackendS0FS {
+		t.Fatalf("newS0FSVolumeContext() identity = %#v", volCtx)
+	}
+	if volCtx.Access != volume.AccessModeRWO || !volCtx.MountedAt.Equal(mountedAt) || volCtx.CacheDir != "/cache" {
+		t.Fatalf("newS0FSVolumeContext() mount metadata = %#v", volCtx)
 	}
 }
 

--- a/ctld/internal/ctld/portal/session.go
+++ b/ctld/internal/ctld/portal/session.go
@@ -220,7 +220,7 @@ func (m *localVolumeManager) UnmountVolume(ctx context.Context, volumeID, _ stri
 		m.remove(volumeID)
 		return nil
 	}
-	if _, err := volCtx.S0FS.SyncMaterialize(ctx); err != nil {
+	if _, err := volCtx.SyncMaterialize(ctx); err != nil {
 		return err
 	}
 	if err := volCtx.S0FS.Close(); err != nil {
@@ -282,7 +282,7 @@ func (m *localVolumeManager) SyncDirectVolumeFileMount(_ context.Context, volume
 	if volCtx == nil || volCtx.S0FS == nil {
 		return fmt.Errorf("volume %s not mounted", volumeID)
 	}
-	_, err := volCtx.S0FS.SyncMaterialize(context.Background())
+	_, err := volCtx.SyncMaterialize(context.Background())
 	return err
 }
 

--- a/infra-operator/internal/controller/services/ctld/ctld.go
+++ b/infra-operator/internal/controller/services/ctld/ctld.go
@@ -20,13 +20,11 @@ import (
 	infrav1alpha1 "github.com/sandbox0-ai/sandbox0/infra-operator/api/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/pkg/common"
 	credentialstoresvc "github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/credentialstore"
-	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/database"
 	internalauthsvc "github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/internalauth"
 	netdsvc "github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/netd"
 	sandboxobssvc "github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/sandboxobservability"
-	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/storage"
+	storageruntimesvc "github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/storageruntime"
 	infraplan "github.com/sandbox0-ai/sandbox0/infra-operator/internal/plan"
-	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/runtimeconfig"
 	"github.com/sandbox0-ai/sandbox0/pkg/dataplane"
 	pkginternalauth "github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"github.com/sandbox0-ai/sandbox0/pkg/volumeportal"
@@ -70,15 +68,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 	labels := common.GetServiceLabels(infra.Name, "ctld")
 	storageConfig, err := r.buildStorageConfig(ctx, infra)
 	if err != nil {
-		return err
-	}
-	if storageConfig.ObjectEncryptionEnabled {
-		if err := common.EnsureObjectEncryptionKeySecret(ctx, r.Resources, infra); err != nil {
-			return err
-		}
-		storageConfig.ObjectEncryptionKeyPath = common.ObjectEncryptionKeyPath
-	}
-	if err := credentialstoresvc.ApplyEncryptedPGCredentialStoreConfig(ctx, r.Resources, common.NewObjectScope(infra), &storageConfig.CredentialStore); err != nil {
 		return err
 	}
 	config := &apiconfig.CtldConfig{StorageProxyConfig: *storageConfig}
@@ -809,37 +798,8 @@ func (r *Reconciler) cleanupNetworkMetricsService(ctx context.Context, infra *in
 }
 
 func (r *Reconciler) buildStorageConfig(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra) (*apiconfig.StorageProxyConfig, error) {
-	cfg := &apiconfig.StorageProxyConfig{}
-	if runtimeConfig := infrav1alpha1.ResolveStorageRuntimeConfig(infra); runtimeConfig != nil {
-		cfg = runtimeconfig.ToStorageProxy(runtimeConfig)
+	if r == nil {
+		return nil, fmt.Errorf("ctld reconciler is required")
 	}
-	cfg.RegionID = common.ResolveRegionID(infra)
-	cfg.DefaultClusterId = common.ResolveClusterID(infra)
-	if infra != nil && infra.Spec.Database != nil && r != nil && r.Resources != nil && r.Resources.Client != nil {
-		if dsn, err := database.GetDatabaseDSN(ctx, r.Resources.Client, infra); err == nil {
-			cfg.DatabaseURL = dsn
-		}
-	}
-	if infra == nil || infra.Spec.Storage == nil {
-		return cfg, nil
-	}
-	storageConfig, err := storage.GetStorageConfig(ctx, r.Resources.Client, infra)
-	if err != nil {
-		return nil, err
-	}
-	cfg.ObjectStorageType = normalizeObjectStorageType(storageConfig.Type)
-	cfg.S3Bucket = storageConfig.Bucket
-	cfg.S3Region = storageConfig.Region
-	cfg.S3Endpoint = storageConfig.Endpoint
-	cfg.S3AccessKey = storageConfig.AccessKey
-	cfg.S3SecretKey = storageConfig.SecretKey
-	cfg.S3SessionToken = storageConfig.SessionToken
-	return cfg, nil
-}
-
-func normalizeObjectStorageType(storageType infrav1alpha1.StorageType) string {
-	if storageType == infrav1alpha1.StorageTypeBuiltin {
-		return "s3"
-	}
-	return string(storageType)
+	return storageruntimesvc.BuildRuntimeConfig(ctx, r.Resources, infra)
 }

--- a/infra-operator/internal/controller/services/ctld/ctld_test.go
+++ b/infra-operator/internal/controller/services/ctld/ctld_test.go
@@ -401,7 +401,26 @@ func reconcileCtldResources(t *testing.T, infra *infrav1alpha1.Sandbox0Infra, ex
 
 	scheme := newCtldTestScheme(t)
 
-	objects := []ctrlclient.Object{infra.DeepCopy()}
+	objects := []ctrlclient.Object{
+		infra.DeepCopy(),
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: infra.Name + "-sandbox0-database-credentials", Namespace: infra.Namespace},
+			Data: map[string][]byte{
+				"username": []byte("sandbox0"),
+				"password": []byte("db-password"),
+				"database": []byte("sandbox0"),
+				"port":     []byte("5432"),
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: infra.Name + "-sandbox0-rustfs-credentials", Namespace: infra.Namespace},
+			Data: map[string][]byte{
+				"endpoint":          []byte("http://demo-rustfs.sandbox0-system.svc:9000"),
+				"RUSTFS_ACCESS_KEY": []byte("access-key"),
+				"RUSTFS_SECRET_KEY": []byte("secret-key"),
+			},
+		},
+	}
 	objects = append(objects, extraObjects...)
 	client := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -718,13 +737,49 @@ func TestReconcileInjectsRuntimeSampleProducerConfigAndJWTKey(t *testing.T) {
 	assert.Equal(t, 3*time.Second, cfg.SandboxObservabilityIngestRequestTimeout.Duration)
 }
 
+func TestReconcileInjectsMeteringIntoCtldStorageConfig(t *testing.T) {
+	infra := newCtldTestInfra()
+	enabled := true
+	infra.Spec.ClickHouse = &infrav1alpha1.ClickHouseConfig{
+		Type: infrav1alpha1.ClickHouseTypeExternal,
+		External: &infrav1alpha1.ExternalClickHouseConfig{
+			DSNSecret: infrav1alpha1.ClickHouseDSNSecretRef{Name: "metering-clickhouse", Key: "dsn"},
+		},
+	}
+	infra.Spec.Metering = &infrav1alpha1.MeteringConfig{Enabled: &enabled}
+	dsn := "clickhouse://sandbox0:password@clickhouse:9000/sandbox0_metering"
+	dsnSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "metering-clickhouse", Namespace: infra.Namespace},
+		Data:       map[string][]byte{"dsn": []byte(dsn)},
+	}
+
+	ds, client := reconcileCtldResources(t, infra, dsnSecret)
+	configMapName := ""
+	for _, volume := range ds.Spec.Template.Spec.Volumes {
+		if volume.Name == "config" && volume.ConfigMap != nil {
+			configMapName = volume.ConfigMap.Name
+			break
+		}
+	}
+	require.NotEmpty(t, configMapName)
+	configMap := &corev1.ConfigMap{}
+	require.NoError(t, client.Get(context.Background(), types.NamespacedName{Name: configMapName, Namespace: infra.Namespace}, configMap))
+	cfg := &apiconfig.CtldConfig{}
+	require.NoError(t, yaml.Unmarshal([]byte(configMap.Data["config.yaml"]), cfg))
+	assert.True(t, cfg.Metering.Enabled)
+	assert.Equal(t, dsn, cfg.Metering.ClickHouse.DSN)
+	assert.Equal(t, "sandbox0_metering", cfg.Metering.ClickHouse.Database)
+	assert.Equal(t, "storage_projection_state", cfg.Metering.ClickHouse.StorageStateTable)
+}
+
 func TestBuildStorageConfigDefaultsDataPlaneIdentity(t *testing.T) {
 	infra := newCtldTestInfra()
 	infra.Spec.PublicExposure = &infrav1alpha1.PublicExposureConfig{
 		RegionID: "aws-us-east-1",
 	}
 
-	reconciler := NewReconciler(common.NewResourceManager(nil, nil, nil, common.LocalDevConfig{}))
+	_, client := reconcileCtldResources(t, infra)
+	reconciler := NewReconciler(common.NewResourceManager(client, newCtldTestScheme(t), nil, common.LocalDevConfig{}))
 	cfg, err := reconciler.buildStorageConfig(context.Background(), infra)
 	if err != nil {
 		t.Fatalf("buildStorageConfig returned error: %v", err)
@@ -849,6 +904,18 @@ func newCtldTestInfra() *infrav1alpha1.Sandbox0Infra {
 			Namespace: "sandbox0-system",
 		},
 		Spec: infrav1alpha1.Sandbox0InfraSpec{
+			Database: &infrav1alpha1.DatabaseConfig{
+				Type: infrav1alpha1.DatabaseTypeBuiltin,
+				Builtin: &infrav1alpha1.BuiltinDatabaseConfig{
+					Enabled: true, Port: 5432, Username: "sandbox0", Database: "sandbox0", SSLMode: "disable",
+				},
+			},
+			Storage: &infrav1alpha1.StorageConfig{
+				Type: infrav1alpha1.StorageTypeBuiltin,
+				Builtin: &infrav1alpha1.BuiltinStorageConfig{
+					Enabled: true, Bucket: "sandbox0", Region: "us-east-1",
+				},
+			},
 			Services: &infrav1alpha1.ServicesConfig{
 				Manager: &infrav1alpha1.ManagerServiceConfig{
 					WorkloadServiceConfig: infrav1alpha1.WorkloadServiceConfig{

--- a/storage-proxy/pkg/snapshot/manager.go
+++ b/storage-proxy/pkg/snapshot/manager.go
@@ -113,6 +113,7 @@ type Manager struct {
 	meteringRepo      meteringRecorder
 	quotaRepo         *quota.Repository
 	metrics           *obsmetrics.StorageProxyMetrics
+	volumeObserver    *volume.VolumeStorageObserver
 }
 
 // NewManager creates a new snapshot manager
@@ -123,7 +124,7 @@ func NewManager(
 	logger *logrus.Logger,
 	metrics *obsmetrics.StorageProxyMetrics,
 ) (*Manager, error) {
-	return &Manager{
+	manager := &Manager{
 		locks:     make(map[string]time.Time),
 		repo:      repo,
 		volMgr:    volMgr,
@@ -132,7 +133,14 @@ func NewManager(
 		clusterID: cfg.DefaultClusterId,
 		podID:     uuid.New().String(), // Unique pod identifier
 		metrics:   metrics,
-	}, nil
+	}
+	manager.volumeObserver = volume.NewVolumeStorageObserver(
+		repo,
+		cfg.RegionID,
+		manager.clusterID,
+		manager.appendStorageObservation,
+	)
+	return manager, nil
 }
 
 // SetEventPublisher wires a watcher event publisher (optional).
@@ -184,10 +192,7 @@ func (m *Manager) appendStorageObservation(ctx context.Context, observation *met
 	if err := m.enforceStorageObservationQuota(ctx, observation); err != nil {
 		return err
 	}
-	if err := recorder.RecordStorageObservation(ctx, observation); err != nil {
-		return err
-	}
-	return recorder.UpsertProducerWatermark(ctx, meteringpkg.ProducerStorage, observation.RegionID, observation.ObservedAt)
+	return volume.RecordStorageObservation(ctx, recorder, observation)
 }
 
 func (m *Manager) appendStorageObservationTx(ctx context.Context, tx pgx.Tx, observation *meteringpkg.StorageObservation) error {

--- a/storage-proxy/pkg/snapshot/s0fs.go
+++ b/storage-proxy/pkg/snapshot/s0fs.go
@@ -543,14 +543,12 @@ func (m *Manager) forkS0FSVolume(ctx context.Context, req *ForkVolumeRequest) (*
 		if volCtx, getErr := m.volMgr.GetVolume(req.SourceVolumeID); getErr == nil && volCtx != nil {
 			_ = volCtx.FlushAll("")
 			if volCtx.IsS0FS() {
-				manifest, err := volCtx.S0FS.SyncMaterialize(ctx)
+				materialization, err := volCtx.SyncMaterialize(ctx)
 				if err != nil {
 					return nil, err
 				}
-				if manifest != nil && manifest.State != nil {
-					if err := m.recordVolumeStorageState(ctx, sourceVol, manifest.State, time.Now().UTC()); err != nil {
-						return nil, err
-					}
+				if materialization.ObservationError != nil {
+					return nil, materialization.ObservationError
 				}
 			}
 		}

--- a/storage-proxy/pkg/snapshot/storage_metering.go
+++ b/storage-proxy/pkg/snapshot/storage_metering.go
@@ -2,29 +2,19 @@ package snapshot
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	meteringpkg "github.com/sandbox0-ai/sandbox0/pkg/metering"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/s0fs"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volume"
 )
 
 func (m *Manager) ObserveVolumeState(ctx context.Context, volumeID, teamID string, state *s0fs.SnapshotState, observedAt time.Time) error {
-	if m == nil || state == nil || volumeID == "" {
+	if m == nil || m.volumeObserver == nil {
 		return nil
 	}
-	vol, err := m.repo.GetSandboxVolume(ctx, volumeID)
-	if err != nil {
-		if errors.Is(err, db.ErrNotFound) {
-			return nil
-		}
-		return err
-	}
-	if teamID != "" && vol.TeamID != teamID {
-		return nil
-	}
-	return m.appendStorageObservation(ctx, m.volumeStorageObservation(ctx, vol, s0fs.StateStorageBytes(state), observedAt))
+	return m.volumeObserver.ObserveVolumeState(ctx, volumeID, teamID, state, observedAt)
 }
 
 func (m *Manager) recordVolumeStorageState(ctx context.Context, vol *db.SandboxVolume, state *s0fs.SnapshotState, observedAt time.Time) error {
@@ -52,30 +42,7 @@ func (m *Manager) recordSnapshotStorageWithMetadata(ctx context.Context, snapsho
 }
 
 func (m *Manager) volumeStorageObservation(ctx context.Context, vol *db.SandboxVolume, sizeBytes int64, observedAt time.Time) *meteringpkg.StorageObservation {
-	if observedAt.IsZero() {
-		observedAt = time.Now().UTC()
-	}
-	obs := &meteringpkg.StorageObservation{
-		SubjectType:       meteringpkg.SubjectTypeVolume,
-		SubjectID:         vol.ID,
-		Product:           meteringpkg.ProductSandbox,
-		TeamID:            vol.TeamID,
-		UserID:            vol.UserID,
-		VolumeID:          vol.ID,
-		RegionID:          m.regionID(),
-		ClusterID:         m.clusterID,
-		SizeBytes:         sizeBytes,
-		ResourceCreatedAt: vol.CreatedAt,
-		ObservedAt:        observedAt,
-	}
-	if owner, err := m.repo.GetSandboxVolumeOwner(ctx, vol.ID); err == nil && owner != nil {
-		obs.OwnerKind = owner.OwnerKind
-		obs.SandboxID = owner.OwnerSandboxID
-		if owner.OwnerClusterID != "" {
-			obs.ClusterID = owner.OwnerClusterID
-		}
-	}
-	return obs
+	return volume.VolumeStorageObservation(ctx, m.repo, vol, m.regionID(), m.clusterID, sizeBytes, observedAt)
 }
 
 func applyStorageObservationMetadata(obs *meteringpkg.StorageObservation, metadata *meteringpkg.StorageObservation) *meteringpkg.StorageObservation {

--- a/storage-proxy/pkg/volume/manager.go
+++ b/storage-proxy/pkg/volume/manager.go
@@ -552,22 +552,14 @@ func (m *Manager) SyncDirectVolumeFileMount(ctx context.Context, volumeID string
 	if err != nil || volCtx == nil || volCtx.S0FS == nil {
 		return err
 	}
-	manifest, err := volCtx.S0FS.SyncMaterialize(ctx)
+	result, err := volCtx.SyncMaterialize(ctx)
 	if err != nil {
 		return err
 	}
-	return m.observeMaterializedManifest(ctx, volCtx, manifest)
-}
-
-func (m *Manager) observeMaterializedManifest(ctx context.Context, volCtx *VolumeContext, manifest *s0fs.Manifest) error {
-	if volCtx == nil || volCtx.Observer == nil || manifest == nil || manifest.State == nil {
-		return nil
+	if result.ObservationError != nil {
+		m.logger.WithError(result.ObservationError).WithField("volume_id", volCtx.VolumeID).Warn("Failed to record volume storage observation")
 	}
-	if err := volCtx.Observer.ObserveVolumeState(ctx, volCtx.VolumeID, volCtx.TeamID, manifest.State, time.Now().UTC()); err != nil {
-		m.logger.WithError(err).WithField("volume_id", volCtx.VolumeID).Warn("Failed to record volume storage observation")
-		return err
-	}
-	return nil
+	return result.ObservationError
 }
 
 func (m *Manager) releaseDirectVolumeFileMount(volumeID, sessionID string) func() {

--- a/storage-proxy/pkg/volume/materialization.go
+++ b/storage-proxy/pkg/volume/materialization.go
@@ -1,0 +1,65 @@
+package volume
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/s0fs"
+)
+
+// MaterializationResult separates durable materialization failures from
+// best-effort storage observation failures.
+type MaterializationResult struct {
+	Manifest         *s0fs.Manifest
+	ObservationError error
+}
+
+// SyncMaterialize persists pending S0FS changes and observes the resulting
+// storage state. Volume callers should use this method instead of calling the
+// S0FS engine directly so metering remains consistent across runtimes.
+func (v *VolumeContext) SyncMaterialize(ctx context.Context) (MaterializationResult, error) {
+	if v == nil || v.S0FS == nil {
+		return MaterializationResult{}, fmt.Errorf("volume does not expose an s0fs engine")
+	}
+	manifest, err := v.S0FS.SyncMaterialize(ctx)
+	if err != nil {
+		return MaterializationResult{Manifest: manifest}, err
+	}
+	return MaterializationResult{
+		Manifest:         manifest,
+		ObservationError: v.observeMaterializedManifest(ctx, manifest),
+	}, nil
+}
+
+// Compact materializes pending S0FS changes, compacts persisted segments, and
+// observes the resulting storage state.
+func (v *VolumeContext) Compact(ctx context.Context, opts s0fs.CompactionOptions) (MaterializationResult, *s0fs.CompactionResult, error) {
+	if v == nil || v.S0FS == nil {
+		return MaterializationResult{}, nil, fmt.Errorf("volume does not expose an s0fs engine")
+	}
+	materialization, err := v.SyncMaterialize(ctx)
+	if err != nil {
+		return materialization, nil, err
+	}
+	manifest, result, err := v.S0FS.Compact(ctx, opts)
+	if err != nil {
+		return materialization, result, err
+	}
+	if manifest != nil {
+		materialization.Manifest = manifest
+	}
+	materialization.ObservationError = errors.Join(
+		materialization.ObservationError,
+		v.observeMaterializedManifest(ctx, manifest),
+	)
+	return materialization, result, nil
+}
+
+func (v *VolumeContext) observeMaterializedManifest(ctx context.Context, manifest *s0fs.Manifest) error {
+	if v == nil || v.Observer == nil || manifest == nil || manifest.State == nil {
+		return nil
+	}
+	return v.Observer.ObserveVolumeState(ctx, v.VolumeID, v.TeamID, manifest.State, time.Now().UTC())
+}

--- a/storage-proxy/pkg/volume/materialization_test.go
+++ b/storage-proxy/pkg/volume/materialization_test.go
@@ -1,0 +1,144 @@
+package volume
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/objectstore"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/s0fs"
+)
+
+type recordingStorageObserver struct {
+	volumeID  string
+	teamID    string
+	sizeBytes int64
+	calls     int
+	err       error
+}
+
+func (o *recordingStorageObserver) ObserveVolumeState(
+	_ context.Context,
+	volumeID, teamID string,
+	state *s0fs.SnapshotState,
+	_ time.Time,
+) error {
+	o.volumeID = volumeID
+	o.teamID = teamID
+	o.sizeBytes = s0fs.StateStorageBytes(state)
+	o.calls++
+	return o.err
+}
+
+func TestVolumeContextSyncMaterializeObservesStorageState(t *testing.T) {
+	volCtx := newMaterializationTestVolume(t)
+	observer := &recordingStorageObserver{}
+	volCtx.Observer = observer
+	writeMaterializationTestFile(t, volCtx.S0FS, "first.txt", "hello world")
+
+	result, err := volCtx.SyncMaterialize(context.Background())
+	if err != nil {
+		t.Fatalf("SyncMaterialize() error = %v", err)
+	}
+	if result.Manifest == nil {
+		t.Fatal("SyncMaterialize() returned no manifest")
+	}
+	if result.ObservationError != nil {
+		t.Fatalf("SyncMaterialize() observation error = %v", result.ObservationError)
+	}
+	if observer.calls != 1 {
+		t.Fatalf("observer calls = %d, want 1", observer.calls)
+	}
+	if observer.volumeID != "vol-1" || observer.teamID != "team-1" {
+		t.Fatalf("observer identity = %q/%q, want vol-1/team-1", observer.volumeID, observer.teamID)
+	}
+	if observer.sizeBytes != int64(len("hello world")) {
+		t.Fatalf("observer size = %d, want %d", observer.sizeBytes, len("hello world"))
+	}
+
+	cleanResult, err := volCtx.SyncMaterialize(context.Background())
+	if err != nil {
+		t.Fatalf("second SyncMaterialize() error = %v", err)
+	}
+	if cleanResult.Manifest != nil {
+		t.Fatal("second SyncMaterialize() unexpectedly returned a manifest")
+	}
+	if observer.calls != 1 {
+		t.Fatalf("observer calls after clean sync = %d, want 1", observer.calls)
+	}
+}
+
+func TestVolumeContextSyncMaterializeSeparatesObservationFailure(t *testing.T) {
+	volCtx := newMaterializationTestVolume(t)
+	observationErr := errors.New("metering unavailable")
+	volCtx.Observer = &recordingStorageObserver{err: observationErr}
+	writeMaterializationTestFile(t, volCtx.S0FS, "first.txt", "payload")
+
+	result, err := volCtx.SyncMaterialize(context.Background())
+	if err != nil {
+		t.Fatalf("SyncMaterialize() durable error = %v", err)
+	}
+	if result.Manifest == nil {
+		t.Fatal("SyncMaterialize() returned no manifest")
+	}
+	if !errors.Is(result.ObservationError, observationErr) {
+		t.Fatalf("SyncMaterialize() observation error = %v, want %v", result.ObservationError, observationErr)
+	}
+}
+
+func TestVolumeContextCompactObservesInitialMaterialization(t *testing.T) {
+	volCtx := newMaterializationTestVolume(t)
+	observer := &recordingStorageObserver{}
+	volCtx.Observer = observer
+	writeMaterializationTestFile(t, volCtx.S0FS, "first.txt", "payload")
+
+	result, _, err := volCtx.Compact(context.Background(), s0fs.CompactionOptions{})
+	if err != nil {
+		t.Fatalf("Compact() error = %v", err)
+	}
+	if result.Manifest == nil {
+		t.Fatal("Compact() returned no materialized manifest")
+	}
+	if result.ObservationError != nil {
+		t.Fatalf("Compact() observation error = %v", result.ObservationError)
+	}
+	if observer.calls != 1 {
+		t.Fatalf("observer calls = %d, want 1", observer.calls)
+	}
+}
+
+func newMaterializationTestVolume(t *testing.T) *VolumeContext {
+	t.Helper()
+	engine, err := s0fs.Open(context.Background(), s0fs.Config{
+		VolumeID:    "vol-1",
+		WALPath:     filepath.Join(t.TempDir(), "engine.wal"),
+		ObjectStore: objectstore.NewMemoryStore(t.Name()),
+	})
+	if err != nil {
+		t.Fatalf("s0fs.Open() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := engine.Close(); err != nil {
+			t.Errorf("Close() error = %v", err)
+		}
+	})
+	return &VolumeContext{
+		VolumeID: "vol-1",
+		TeamID:   "team-1",
+		Backend:  BackendS0FS,
+		S0FS:     engine,
+	}
+}
+
+func writeMaterializationTestFile(t *testing.T, engine *s0fs.Engine, name, contents string) {
+	t.Helper()
+	node, err := engine.CreateFile(s0fs.RootInode, name, 0o644)
+	if err != nil {
+		t.Fatalf("CreateFile() error = %v", err)
+	}
+	if _, err := engine.Write(node.Inode, 0, []byte(contents)); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+}

--- a/storage-proxy/pkg/volume/s0fs_backend.go
+++ b/storage-proxy/pkg/volume/s0fs_backend.go
@@ -176,12 +176,12 @@ func (b *S0FSBackend) UnmountVolume(ctx context.Context, volCtx *VolumeContext) 
 			<-volCtx.materializeDone
 		}
 	}
-	manifest, err := volCtx.S0FS.SyncMaterialize(ctx)
+	result, err := volCtx.SyncMaterialize(ctx)
 	if err != nil {
 		return fmt.Errorf("materialize s0fs volume: %w", err)
 	}
-	b.observeMaterializedManifest(ctx, volCtx, manifest)
-	b.garbageCollectRWO(ctx, volCtx, manifest)
+	b.logObservationError(volCtx.VolumeID, result.ObservationError)
+	b.garbageCollectRWO(ctx, volCtx, result.Manifest)
 	return volCtx.S0FS.Close()
 }
 
@@ -258,15 +258,15 @@ func (b *S0FSBackend) startMaterializer(volCtx *VolumeContext) {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				manifest, err := volCtx.S0FS.SyncMaterialize(ctx)
+				result, err := volCtx.SyncMaterialize(ctx)
 				if err != nil {
 					b.logger.WithError(err).WithField("volume_id", volCtx.VolumeID).Warn("Failed to materialize s0fs volume")
 					continue
 				}
-				b.observeMaterializedManifest(ctx, volCtx, manifest)
-				b.garbageCollectRWO(ctx, volCtx, manifest)
+				b.logObservationError(volCtx.VolumeID, result.ObservationError)
+				b.garbageCollectRWO(ctx, volCtx, result.Manifest)
 			case <-compactionC:
-				manifest, result, err := volCtx.S0FS.Compact(ctx, compactionOptions)
+				materialization, result, err := volCtx.Compact(ctx, compactionOptions)
 				if err != nil {
 					b.logger.WithError(err).WithField("volume_id", volCtx.VolumeID).Warn("Failed to compact s0fs volume")
 					continue
@@ -279,20 +279,18 @@ func (b *S0FSBackend) startMaterializer(volCtx *VolumeContext) {
 						"reclaimable_bytes": result.ReclaimableBytes,
 					}).Info("Compacted s0fs volume")
 				}
-				b.observeMaterializedManifest(ctx, volCtx, manifest)
-				b.garbageCollectRWO(ctx, volCtx, manifest)
+				b.logObservationError(volCtx.VolumeID, materialization.ObservationError)
+				b.garbageCollectRWO(ctx, volCtx, materialization.Manifest)
 			}
 		}
 	}()
 }
 
-func (b *S0FSBackend) observeMaterializedManifest(ctx context.Context, volCtx *VolumeContext, manifest *s0fs.Manifest) {
-	if volCtx == nil || volCtx.Observer == nil || manifest == nil || manifest.State == nil {
+func (b *S0FSBackend) logObservationError(volumeID string, err error) {
+	if err == nil {
 		return
 	}
-	if err := volCtx.Observer.ObserveVolumeState(ctx, volCtx.VolumeID, volCtx.TeamID, manifest.State, time.Now().UTC()); err != nil {
-		b.logger.WithError(err).WithField("volume_id", volCtx.VolumeID).Warn("Failed to record volume storage observation")
-	}
+	b.logger.WithError(err).WithField("volume_id", volumeID).Warn("Failed to record volume storage observation")
 }
 
 func (b *S0FSBackend) garbageCollectRWO(ctx context.Context, volCtx *VolumeContext, manifest *s0fs.Manifest) {

--- a/storage-proxy/pkg/volume/storage_metering.go
+++ b/storage-proxy/pkg/volume/storage_metering.go
@@ -1,0 +1,139 @@
+package volume
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	meteringpkg "github.com/sandbox0-ai/sandbox0/pkg/metering"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/s0fs"
+)
+
+// StorageObservationRepository provides volume identity and ownership metadata
+// needed to produce storage metering observations.
+type StorageObservationRepository interface {
+	GetSandboxVolume(context.Context, string) (*db.SandboxVolume, error)
+	GetSandboxVolumeOwner(context.Context, string) (*db.SandboxVolumeOwner, error)
+}
+
+// StorageObservationRecorder stores a volume observation and advances the
+// shared storage producer watermark.
+type StorageObservationRecorder interface {
+	RecordStorageObservation(context.Context, *meteringpkg.StorageObservation) error
+	UpsertProducerWatermark(context.Context, string, string, time.Time) error
+}
+
+// StorageObservationWriter records one fully populated storage observation.
+type StorageObservationWriter func(context.Context, *meteringpkg.StorageObservation) error
+
+// VolumeStorageObserver converts materialized S0FS states into metering
+// observations using the same metadata rules in every storage runtime.
+type VolumeStorageObserver struct {
+	repo      StorageObservationRepository
+	regionID  string
+	clusterID string
+	write     StorageObservationWriter
+}
+
+// NewVolumeStorageObserver creates an observer with a caller-supplied writer,
+// allowing runtimes to apply their own quota or persistence policy.
+func NewVolumeStorageObserver(repo StorageObservationRepository, regionID, clusterID string, write StorageObservationWriter) *VolumeStorageObserver {
+	return &VolumeStorageObserver{
+		repo:      repo,
+		regionID:  regionID,
+		clusterID: clusterID,
+		write:     write,
+	}
+}
+
+// NewVolumeStorageObserverWithRecorder creates an observer that writes
+// directly to a storage observation recorder.
+func NewVolumeStorageObserverWithRecorder(
+	repo StorageObservationRepository,
+	recorder StorageObservationRecorder,
+	regionID, clusterID string,
+) *VolumeStorageObserver {
+	return NewVolumeStorageObserver(repo, regionID, clusterID, func(ctx context.Context, observation *meteringpkg.StorageObservation) error {
+		return RecordStorageObservation(ctx, recorder, observation)
+	})
+}
+
+func (o *VolumeStorageObserver) ObserveVolumeState(ctx context.Context, volumeID, teamID string, state *s0fs.SnapshotState, observedAt time.Time) error {
+	if o == nil || o.repo == nil || o.write == nil || state == nil || volumeID == "" {
+		return nil
+	}
+	vol, err := o.repo.GetSandboxVolume(ctx, volumeID)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return nil
+		}
+		return err
+	}
+	if teamID != "" && vol.TeamID != teamID {
+		return nil
+	}
+	return o.write(ctx, VolumeStorageObservation(
+		ctx,
+		o.repo,
+		vol,
+		o.regionID,
+		o.clusterID,
+		s0fs.StateStorageBytes(state),
+		observedAt,
+	))
+}
+
+// VolumeStorageObservation builds the canonical metering identity for a
+// SandboxVolume and enriches it with durable ownership metadata when present.
+func VolumeStorageObservation(
+	ctx context.Context,
+	repo StorageObservationRepository,
+	vol *db.SandboxVolume,
+	regionID, clusterID string,
+	sizeBytes int64,
+	observedAt time.Time,
+) *meteringpkg.StorageObservation {
+	if vol == nil {
+		return nil
+	}
+	if observedAt.IsZero() {
+		observedAt = time.Now().UTC()
+	}
+	obs := &meteringpkg.StorageObservation{
+		SubjectType:       meteringpkg.SubjectTypeVolume,
+		SubjectID:         vol.ID,
+		Product:           meteringpkg.ProductSandbox,
+		TeamID:            vol.TeamID,
+		UserID:            vol.UserID,
+		VolumeID:          vol.ID,
+		RegionID:          regionID,
+		ClusterID:         clusterID,
+		SizeBytes:         sizeBytes,
+		ResourceCreatedAt: vol.CreatedAt,
+		ObservedAt:        observedAt,
+	}
+	if repo == nil {
+		return obs
+	}
+	if owner, err := repo.GetSandboxVolumeOwner(ctx, vol.ID); err == nil && owner != nil {
+		obs.OwnerKind = owner.OwnerKind
+		obs.SandboxID = owner.OwnerSandboxID
+		if owner.OwnerClusterID != "" {
+			obs.ClusterID = owner.OwnerClusterID
+		}
+	}
+	return obs
+}
+
+// RecordStorageObservation records a storage state transition, then advances
+// the storage producer watermark through the same recorder.
+func RecordStorageObservation(ctx context.Context, recorder StorageObservationRecorder, observation *meteringpkg.StorageObservation) error {
+	if recorder == nil || observation == nil {
+		return nil
+	}
+	if err := recorder.RecordStorageObservation(ctx, observation); err != nil {
+		return err
+	}
+	return recorder.UpsertProducerWatermark(ctx, meteringpkg.ProducerStorage, observation.RegionID, observation.ObservedAt)
+}

--- a/storage-proxy/pkg/volume/storage_metering_test.go
+++ b/storage-proxy/pkg/volume/storage_metering_test.go
@@ -1,0 +1,159 @@
+package volume
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	meteringpkg "github.com/sandbox0-ai/sandbox0/pkg/metering"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/s0fs"
+)
+
+type fakeStorageObservationRepository struct {
+	volume    *db.SandboxVolume
+	owner     *db.SandboxVolumeOwner
+	volumeErr error
+	ownerErr  error
+}
+
+func (r *fakeStorageObservationRepository) GetSandboxVolume(context.Context, string) (*db.SandboxVolume, error) {
+	return r.volume, r.volumeErr
+}
+
+func (r *fakeStorageObservationRepository) GetSandboxVolumeOwner(context.Context, string) (*db.SandboxVolumeOwner, error) {
+	return r.owner, r.ownerErr
+}
+
+type fakeStorageObservationRecorder struct {
+	observation *meteringpkg.StorageObservation
+	producer    string
+	regionID    string
+	watermark   time.Time
+	recordErr   error
+}
+
+func (r *fakeStorageObservationRecorder) RecordStorageObservation(_ context.Context, observation *meteringpkg.StorageObservation) error {
+	r.observation = observation
+	return r.recordErr
+}
+
+func (r *fakeStorageObservationRecorder) UpsertProducerWatermark(_ context.Context, producer, regionID string, watermark time.Time) error {
+	r.producer = producer
+	r.regionID = regionID
+	r.watermark = watermark
+	return nil
+}
+
+func TestVolumeStorageObserverBuildsCanonicalObservation(t *testing.T) {
+	createdAt := time.Date(2026, 7, 1, 2, 3, 4, 0, time.UTC)
+	observedAt := createdAt.Add(time.Hour)
+	repo := &fakeStorageObservationRepository{
+		volume: &db.SandboxVolume{
+			ID:        "vol-1",
+			TeamID:    "team-1",
+			UserID:    "user-1",
+			CreatedAt: createdAt,
+		},
+		owner: &db.SandboxVolumeOwner{
+			OwnerKind:      db.SandboxVolumeOwnerKindSandbox,
+			OwnerSandboxID: "sandbox-1",
+			OwnerClusterID: "owner-cluster",
+		},
+	}
+	var got *meteringpkg.StorageObservation
+	observer := NewVolumeStorageObserver(repo, "region-1", "default-cluster", func(_ context.Context, observation *meteringpkg.StorageObservation) error {
+		got = observation
+		return nil
+	})
+	state := &s0fs.SnapshotState{
+		Data: map[uint64][]byte{2: []byte("hello")},
+	}
+
+	if err := observer.ObserveVolumeState(context.Background(), "vol-1", "team-1", state, observedAt); err != nil {
+		t.Fatalf("ObserveVolumeState() error = %v", err)
+	}
+	if got == nil {
+		t.Fatal("ObserveVolumeState() did not write an observation")
+	}
+	if got.SubjectType != meteringpkg.SubjectTypeVolume || got.SubjectID != "vol-1" || got.VolumeID != "vol-1" {
+		t.Fatalf("observation subject = %#v", got)
+	}
+	if got.TeamID != "team-1" || got.UserID != "user-1" {
+		t.Fatalf("observation tenant identity = %q/%q", got.TeamID, got.UserID)
+	}
+	if got.RegionID != "region-1" || got.ClusterID != "owner-cluster" {
+		t.Fatalf("observation location = %q/%q", got.RegionID, got.ClusterID)
+	}
+	if got.OwnerKind != db.SandboxVolumeOwnerKindSandbox || got.SandboxID != "sandbox-1" {
+		t.Fatalf("observation owner = %q/%q", got.OwnerKind, got.SandboxID)
+	}
+	if got.SizeBytes != 5 || !got.ResourceCreatedAt.Equal(createdAt) || !got.ObservedAt.Equal(observedAt) {
+		t.Fatalf("observation usage = %#v", got)
+	}
+}
+
+func TestVolumeStorageObserverIgnoresUnknownOrMismatchedVolume(t *testing.T) {
+	state := &s0fs.SnapshotState{}
+	tests := []struct {
+		name   string
+		repo   *fakeStorageObservationRepository
+		teamID string
+	}{
+		{
+			name:   "not found",
+			repo:   &fakeStorageObservationRepository{volumeErr: db.ErrNotFound},
+			teamID: "team-1",
+		},
+		{
+			name: "team mismatch",
+			repo: &fakeStorageObservationRepository{
+				volume: &db.SandboxVolume{ID: "vol-1", TeamID: "team-2"},
+			},
+			teamID: "team-1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			writes := 0
+			observer := NewVolumeStorageObserver(tt.repo, "region-1", "cluster-1", func(context.Context, *meteringpkg.StorageObservation) error {
+				writes++
+				return nil
+			})
+			if err := observer.ObserveVolumeState(context.Background(), "vol-1", tt.teamID, state, time.Now()); err != nil {
+				t.Fatalf("ObserveVolumeState() error = %v", err)
+			}
+			if writes != 0 {
+				t.Fatalf("writes = %d, want 0", writes)
+			}
+		})
+	}
+}
+
+func TestRecordStorageObservationUpdatesWatermarkAfterRecord(t *testing.T) {
+	observedAt := time.Date(2026, 7, 2, 3, 4, 5, 0, time.UTC)
+	observation := &meteringpkg.StorageObservation{
+		RegionID:   "region-1",
+		ObservedAt: observedAt,
+	}
+	recorder := &fakeStorageObservationRecorder{}
+	if err := RecordStorageObservation(context.Background(), recorder, observation); err != nil {
+		t.Fatalf("RecordStorageObservation() error = %v", err)
+	}
+	if recorder.observation != observation {
+		t.Fatal("RecordStorageObservation() did not record the observation")
+	}
+	if recorder.producer != meteringpkg.ProducerStorage || recorder.regionID != "region-1" || !recorder.watermark.Equal(observedAt) {
+		t.Fatalf("watermark = %q/%q/%s", recorder.producer, recorder.regionID, recorder.watermark)
+	}
+
+	recordErr := errors.New("record failed")
+	failing := &fakeStorageObservationRecorder{recordErr: recordErr}
+	if err := RecordStorageObservation(context.Background(), failing, observation); !errors.Is(err, recordErr) {
+		t.Fatalf("RecordStorageObservation() error = %v, want %v", err, recordErr)
+	}
+	if failing.producer != "" {
+		t.Fatal("watermark advanced after record failure")
+	}
+}


### PR DESCRIPTION
## Summary

- route S0FS sync and compaction through a shared VolumeContext materialization API that always invokes storage observation
- share canonical volume observation construction and outbox watermark recording between manager and ctld
- wire the regional PostgreSQL metering outbox into ctld volume portals when metering is enabled
- make the operator build manager and ctld storage runtime configuration through the same storageruntime.BuildRuntimeConfig path
- consolidate ctld S0FS VolumeContext construction so bind and owner-only mounts cannot diverge again

## Root cause

The embedded manager storage runtime observed every materialized manifest, but ctld portal paths called the S0FS engine directly. Writes served through ctld were durable in S3 but did not update the volume storage projection used by metering.

A second duplicated path existed in the operator: ctld independently assembled StorageProxyConfig and omitted metering, while manager used the shared storage-runtime builder. As a result, ctld still received metering.enabled=false even when the Sandbox0Infra enabled metering.

## Validation

- go test ./infra-operator/internal/controller/services/...
- go test ./storage-proxy/pkg/... ./ctld/internal/... ./ctld/cmd/...
- go vet ./infra-operator/internal/controller/services/ctld ./infra-operator/internal/controller/services/storageruntime ./storage-proxy/pkg/volume ./storage-proxy/pkg/snapshot ./ctld/internal/ctld/portal ./ctld/cmd/ctld
- remote persistent kind environment with builtin ClickHouse and metering enabled:
  - generated ctld ConfigMap had metering.enabled=true
  - created and mounted a SandboxVolume through ctld
  - wrote and read back 131072 bytes through the sandbox file API
  - mount ownership was ctld-node/sandbox0-e2e-worker
  - PostgreSQL storage projection reported 131072 bytes and emitted two outbox rows
  - ClickHouse storage_projection_state contained the 131072-byte volume observation