### PR TITLE
feat(storage): expose metered volume usage

### DIFF
--- a/docs/volume/page.mdx
+++ b/docs/volume/page.mdx
@@ -51,6 +51,15 @@ Backend choice controls which operations are available. `s0fs` supports snapshot
 
 For the full compatibility matrix and S3 backend examples, see [Volume Backends](/docs/sandbox/volume/backends).
 
+## Metered Storage Usage
+
+Volume detail and list responses expose the latest storage observation for `s0fs` volumes:
+
+- `metered_storage_bytes` is the metered logical payload size in bytes
+- `storage_observed_at` is the time that size was observed
+
+Both fields are `null` for external `s3` volumes and when a current metering projection is unavailable. These fields describe the latest current size; they are separate from historical `sandbox.volume_byte_hours` usage windows.
+
 ## Correctness Model
 
 For mounted `RWO` volumes, Sandbox0 keeps one active writable owner at a time.

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -6865,6 +6865,17 @@ components:
         s3:
           $ref: "#/components/schemas/SandboxVolumeS3Config"
           description: Public S3-compatible backend metadata. Credentials are never returned.
+        metered_storage_bytes:
+          type: integer
+          format: int64
+          minimum: 0
+          nullable: true
+          description: Latest metered logical payload bytes stored by this S0FS volume. Null for external backends or when metering state is unavailable.
+        storage_observed_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: Time when metered_storage_bytes was last observed. Null for external backends or when metering state is unavailable.
         created_at:
           type: string
           format: date-time

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -2624,16 +2624,22 @@ type SandboxVolume struct {
 	AccessMode *VolumeAccessMode `json:"access_mode,omitempty"`
 
 	// Backend Storage backend for a SandboxVolume. s0fs is the default durable Sandbox0 volume backend. s3 mounts an existing S3-compatible prefix through the volume portal and supports mount-s3-like object projection.
-	Backend         VolumeBackend          `json:"backend"`
-	CreatedAt       time.Time              `json:"created_at"`
-	DefaultPosixGid *int64                 `json:"default_posix_gid"`
-	DefaultPosixUid *int64                 `json:"default_posix_uid"`
-	Id              string                 `json:"id"`
-	S3              *SandboxVolumeS3Config `json:"s3,omitempty"`
-	SourceVolumeId  *string                `json:"source_volume_id"`
-	TeamId          string                 `json:"team_id"`
-	UpdatedAt       time.Time              `json:"updated_at"`
-	UserId          string                 `json:"user_id"`
+	Backend         VolumeBackend `json:"backend"`
+	CreatedAt       time.Time     `json:"created_at"`
+	DefaultPosixGid *int64        `json:"default_posix_gid"`
+	DefaultPosixUid *int64        `json:"default_posix_uid"`
+	Id              string        `json:"id"`
+
+	// MeteredStorageBytes Latest metered logical payload bytes stored by this S0FS volume. Null for external backends or when metering state is unavailable.
+	MeteredStorageBytes *int64                 `json:"metered_storage_bytes"`
+	S3                  *SandboxVolumeS3Config `json:"s3,omitempty"`
+	SourceVolumeId      *string                `json:"source_volume_id"`
+
+	// StorageObservedAt Time when metered_storage_bytes was last observed. Null for external backends or when metering state is unavailable.
+	StorageObservedAt *time.Time `json:"storage_observed_at"`
+	TeamId            string     `json:"team_id"`
+	UpdatedAt         time.Time  `json:"updated_at"`
+	UserId            string     `json:"user_id"`
 }
 
 // SandboxVolumeS3Config defines model for SandboxVolumeS3Config.

--- a/pkg/metering/outbox/repository.go
+++ b/pkg/metering/outbox/repository.go
@@ -225,6 +225,52 @@ func (r *Repository) RecordStorageObservation(ctx context.Context, observation *
 	})
 }
 
+func (r *Repository) GetStorageProjectionState(ctx context.Context, subjectType, subjectID string) (*metering.StorageProjectionState, error) {
+	if r == nil || r.pool == nil {
+		return nil, fmt.Errorf("metering outbox pool is not configured")
+	}
+	return getStorageProjectionState(ctx, r.pool, subjectType, subjectID, false)
+}
+
+func (r *Repository) ListStorageProjectionStatesByTeam(ctx context.Context, subjectType, teamID string) ([]*metering.StorageProjectionState, error) {
+	if r == nil || r.pool == nil {
+		return nil, fmt.Errorf("metering outbox pool is not configured")
+	}
+	if strings.TrimSpace(subjectType) == "" {
+		return nil, fmt.Errorf("storage subject_type is required")
+	}
+	if strings.TrimSpace(teamID) == "" {
+		return nil, fmt.Errorf("team_id is required")
+	}
+	rows, err := r.pool.Query(ctx, `
+		SELECT
+			subject_type, subject_id, product, owner_kind,
+			team_id, user_id, COALESCE(sandbox_id, ''), COALESCE(volume_id, ''),
+			COALESCE(snapshot_id, ''), COALESCE(cluster_id, ''), region_id,
+			size_bytes, observed_at, unbilled_byte_nanoseconds
+		FROM metering.storage_projection_state
+		WHERE subject_type = $1 AND team_id = $2
+		ORDER BY subject_id
+	`, subjectType, teamID)
+	if err != nil {
+		return nil, fmt.Errorf("query storage projection states by team: %w", err)
+	}
+	defer rows.Close()
+
+	states := make([]*metering.StorageProjectionState, 0)
+	for rows.Next() {
+		state := &metering.StorageProjectionState{}
+		if err := scanStorageState(rows, state); err != nil {
+			return nil, fmt.Errorf("scan storage projection state: %w", err)
+		}
+		states = append(states, state)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate storage projection states: %w", err)
+	}
+	return states, nil
+}
+
 func (r *Repository) RecordStorageObservationTx(ctx context.Context, tx pgx.Tx, observation *metering.StorageObservation) error {
 	if tx == nil {
 		return fmt.Errorf("metering storage observation transaction is nil")
@@ -233,7 +279,7 @@ func (r *Repository) RecordStorageObservationTx(ctx context.Context, tx pgx.Tx, 
 	if err != nil {
 		return err
 	}
-	previous, err := getStorageProjectionStateForUpdate(ctx, tx, state.SubjectType, state.SubjectID)
+	previous, err := getStorageProjectionState(ctx, tx, state.SubjectType, state.SubjectID, true)
 	if err != nil {
 		return err
 	}
@@ -266,7 +312,7 @@ func (r *Repository) CloseStorageObservationTx(ctx context.Context, tx pgx.Tx, o
 	if err != nil {
 		return err
 	}
-	previous, err := getStorageProjectionStateForUpdate(ctx, tx, state.SubjectType, state.SubjectID)
+	previous, err := getStorageProjectionState(ctx, tx, state.SubjectType, state.SubjectID, true)
 	if err != nil {
 		return err
 	}
@@ -654,9 +700,11 @@ func getSandboxProjectionState(ctx context.Context, source db, sandboxID string,
 	return state, nil
 }
 
-func getStorageProjectionStateForUpdate(ctx context.Context, tx pgx.Tx, subjectType, subjectID string) (*metering.StorageProjectionState, error) {
-	state := &metering.StorageProjectionState{}
-	err := tx.QueryRow(ctx, `
+func getStorageProjectionState(ctx context.Context, source db, subjectType, subjectID string, forUpdate bool) (*metering.StorageProjectionState, error) {
+	if strings.TrimSpace(subjectType) == "" || strings.TrimSpace(subjectID) == "" {
+		return nil, fmt.Errorf("storage subject_type and subject_id are required")
+	}
+	query := `
 		SELECT
 			subject_type, subject_id, product, owner_kind,
 			team_id, user_id, COALESCE(sandbox_id, ''), COALESCE(volume_id, ''),
@@ -664,13 +712,12 @@ func getStorageProjectionStateForUpdate(ctx context.Context, tx pgx.Tx, subjectT
 			size_bytes, observed_at, unbilled_byte_nanoseconds
 		FROM metering.storage_projection_state
 		WHERE subject_type = $1 AND subject_id = $2
-		FOR UPDATE
-	`, subjectType, subjectID).Scan(
-		&state.SubjectType, &state.SubjectID, &state.Product, &state.OwnerKind,
-		&state.TeamID, &state.UserID, &state.SandboxID, &state.VolumeID,
-		&state.SnapshotID, &state.ClusterID, &state.RegionID,
-		&state.SizeBytes, &state.ObservedAt, &state.UnbilledByteNanoseconds,
-	)
+	`
+	if forUpdate {
+		query += " FOR UPDATE"
+	}
+	state := &metering.StorageProjectionState{}
+	err := scanStorageState(source.QueryRow(ctx, query, subjectType, subjectID), state)
 	if err == pgx.ErrNoRows {
 		return nil, nil
 	}

--- a/pkg/metering/outbox/repository_integration_test.go
+++ b/pkg/metering/outbox/repository_integration_test.go
@@ -172,6 +172,28 @@ func TestRepositoryStorageProjectionIsAtomicWithCallerTransaction(t *testing.T) 
 	assertCount(t, pool, `SELECT COUNT(*) FROM metering.storage_projection_state`, 1)
 	assertCount(t, pool, `SELECT COUNT(*) FROM metering.projection_outbox WHERE operation_type = 'window'`, 1)
 	assertCount(t, pool, `SELECT COUNT(*) FROM metering.projection_outbox WHERE operation_type = 'storage_state'`, 2)
+
+	state, err := repo.GetStorageProjectionState(ctx, metering.SubjectTypeVolume, "volume-1")
+	if err != nil {
+		t.Fatalf("get storage projection state: %v", err)
+	}
+	if state == nil || state.SizeBytes != 1024 || !state.ObservedAt.Equal(start.Add(time.Hour)) {
+		t.Fatalf("storage projection state = %+v, want size 1024 observed at %s", state, start.Add(time.Hour))
+	}
+	states, err := repo.ListStorageProjectionStatesByTeam(ctx, metering.SubjectTypeVolume, "team-1")
+	if err != nil {
+		t.Fatalf("list storage projection states: %v", err)
+	}
+	if len(states) != 1 || states[0].SubjectID != "volume-1" {
+		t.Fatalf("storage projection states = %+v, want volume-1", states)
+	}
+	otherTeamStates, err := repo.ListStorageProjectionStatesByTeam(ctx, metering.SubjectTypeVolume, "team-2")
+	if err != nil {
+		t.Fatalf("list other team storage projection states: %v", err)
+	}
+	if len(otherTeamStates) != 0 {
+		t.Fatalf("other team storage projection states = %+v, want empty", otherTeamStates)
+	}
 }
 
 func TestMigrationsUpgradeLegacyVersionFiveSchema(t *testing.T) {

--- a/storage-proxy/pkg/db/models.go
+++ b/storage-proxy/pkg/db/models.go
@@ -23,22 +23,29 @@ type SandboxVolume struct {
 	// omitted from JSON responses because S3 configs may contain credentials.
 	BackendConfig json.RawMessage `json:"-"`
 
+	// MeteredStorageBytes and StorageObservedAt are populated from the metering
+	// projection when volumes are returned by the public API.
+	MeteredStorageBytes *int64     `json:"metered_storage_bytes"`
+	StorageObservedAt   *time.Time `json:"storage_observed_at"`
+
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
 type sandboxVolumeJSON struct {
-	ID              string                     `json:"id"`
-	TeamID          string                     `json:"team_id"`
-	UserID          string                     `json:"user_id"`
-	SourceVolumeID  *string                    `json:"source_volume_id,omitempty"`
-	DefaultPosixUID *int64                     `json:"default_posix_uid,omitempty"`
-	DefaultPosixGID *int64                     `json:"default_posix_gid,omitempty"`
-	AccessMode      string                     `json:"access_mode"`
-	Backend         string                     `json:"backend"`
-	S3              *sandboxVolumeS3PublicJSON `json:"s3,omitempty"`
-	CreatedAt       time.Time                  `json:"created_at"`
-	UpdatedAt       time.Time                  `json:"updated_at"`
+	ID                  string                     `json:"id"`
+	TeamID              string                     `json:"team_id"`
+	UserID              string                     `json:"user_id"`
+	SourceVolumeID      *string                    `json:"source_volume_id,omitempty"`
+	DefaultPosixUID     *int64                     `json:"default_posix_uid,omitempty"`
+	DefaultPosixGID     *int64                     `json:"default_posix_gid,omitempty"`
+	AccessMode          string                     `json:"access_mode"`
+	Backend             string                     `json:"backend"`
+	S3                  *sandboxVolumeS3PublicJSON `json:"s3,omitempty"`
+	MeteredStorageBytes *int64                     `json:"metered_storage_bytes"`
+	StorageObservedAt   *time.Time                 `json:"storage_observed_at"`
+	CreatedAt           time.Time                  `json:"created_at"`
+	UpdatedAt           time.Time                  `json:"updated_at"`
 }
 
 type sandboxVolumeS3PublicJSON struct {
@@ -55,16 +62,18 @@ func (v SandboxVolume) MarshalJSON() ([]byte, error) {
 		backend = "s0fs"
 	}
 	out := sandboxVolumeJSON{
-		ID:              v.ID,
-		TeamID:          v.TeamID,
-		UserID:          v.UserID,
-		SourceVolumeID:  v.SourceVolumeID,
-		DefaultPosixUID: v.DefaultPosixUID,
-		DefaultPosixGID: v.DefaultPosixGID,
-		AccessMode:      v.AccessMode,
-		Backend:         backend,
-		CreatedAt:       v.CreatedAt,
-		UpdatedAt:       v.UpdatedAt,
+		ID:                  v.ID,
+		TeamID:              v.TeamID,
+		UserID:              v.UserID,
+		SourceVolumeID:      v.SourceVolumeID,
+		DefaultPosixUID:     v.DefaultPosixUID,
+		DefaultPosixGID:     v.DefaultPosixGID,
+		AccessMode:          v.AccessMode,
+		Backend:             backend,
+		MeteredStorageBytes: v.MeteredStorageBytes,
+		StorageObservedAt:   v.StorageObservedAt,
+		CreatedAt:           v.CreatedAt,
+		UpdatedAt:           v.UpdatedAt,
 	}
 	if backend == "s3" && len(v.BackendConfig) > 0 {
 		var cfg struct {

--- a/storage-proxy/pkg/http/handlers_metering_test.go
+++ b/storage-proxy/pkg/http/handlers_metering_test.go
@@ -164,35 +164,57 @@ func (r *fakeHTTPRepo) MarkOwnedSandboxVolumeCleanupAttempt(ctx context.Context,
 	return nil
 }
 
-type fakeHTTPMeteringWriter struct {
+type fakeHTTPMeteringRepository struct {
 	events              []*metering.Event
 	storageObservations []*metering.StorageObservation
 	closedStorage       []*metering.StorageObservation
 	watermarks          []metering.ProducerWatermark
+	storageStates       map[string]*metering.StorageProjectionState
+	storageReadErr      error
 }
 
-func (f *fakeHTTPMeteringWriter) AppendEventTx(ctx context.Context, tx pgx.Tx, event *metering.Event) error {
+func (f *fakeHTTPMeteringRepository) AppendEventTx(ctx context.Context, tx pgx.Tx, event *metering.Event) error {
 	f.events = append(f.events, event)
 	return nil
 }
 
-func (f *fakeHTTPMeteringWriter) RecordStorageObservationTx(ctx context.Context, tx pgx.Tx, observation *metering.StorageObservation) error {
+func (f *fakeHTTPMeteringRepository) RecordStorageObservationTx(ctx context.Context, tx pgx.Tx, observation *metering.StorageObservation) error {
 	f.storageObservations = append(f.storageObservations, observation)
 	return nil
 }
 
-func (f *fakeHTTPMeteringWriter) CloseStorageObservationTx(ctx context.Context, tx pgx.Tx, observation *metering.StorageObservation) error {
+func (f *fakeHTTPMeteringRepository) CloseStorageObservationTx(ctx context.Context, tx pgx.Tx, observation *metering.StorageObservation) error {
 	f.closedStorage = append(f.closedStorage, observation)
 	return nil
 }
 
-func (f *fakeHTTPMeteringWriter) UpsertProducerWatermarkTx(ctx context.Context, tx pgx.Tx, producer string, regionID string, completeBefore time.Time) error {
+func (f *fakeHTTPMeteringRepository) UpsertProducerWatermarkTx(ctx context.Context, tx pgx.Tx, producer string, regionID string, completeBefore time.Time) error {
 	f.watermarks = append(f.watermarks, metering.ProducerWatermark{
 		Producer:       producer,
 		RegionID:       regionID,
 		CompleteBefore: completeBefore,
 	})
 	return nil
+}
+
+func (f *fakeHTTPMeteringRepository) GetStorageProjectionState(ctx context.Context, subjectType, subjectID string) (*metering.StorageProjectionState, error) {
+	if f.storageReadErr != nil {
+		return nil, f.storageReadErr
+	}
+	return f.storageStates[subjectType+"/"+subjectID], nil
+}
+
+func (f *fakeHTTPMeteringRepository) ListStorageProjectionStatesByTeam(ctx context.Context, subjectType, teamID string) ([]*metering.StorageProjectionState, error) {
+	if f.storageReadErr != nil {
+		return nil, f.storageReadErr
+	}
+	states := make([]*metering.StorageProjectionState, 0)
+	for _, state := range f.storageStates {
+		if state.SubjectType == subjectType && state.TeamID == teamID {
+			states = append(states, state)
+		}
+	}
+	return states, nil
 }
 
 type fakeHTTPSnapshotManager struct {
@@ -293,7 +315,7 @@ func (f *fakeHTTPSnapshotManager) CreateVolumeFromSnapshot(ctx context.Context, 
 
 func TestCreateSandboxVolumeRecordsMetering(t *testing.T) {
 	repo := newFakeHTTPRepo()
-	meteringWriter := &fakeHTTPMeteringWriter{}
+	meteringWriter := &fakeHTTPMeteringRepository{}
 	snapshotMgr := &fakeHTTPSnapshotManager{}
 	server := &Server{
 		logger:       logrus.New(),
@@ -370,7 +392,7 @@ func TestDeleteSandboxVolumeForceRecordsMetering(t *testing.T) {
 		ClusterID: "cluster-a",
 		PodID:     "pod-a",
 	}}
-	meteringWriter := &fakeHTTPMeteringWriter{}
+	meteringWriter := &fakeHTTPMeteringRepository{}
 	snapshotMgr := &fakeHTTPSnapshotManager{}
 	server := &Server{
 		logger:       logrus.New(),
@@ -451,7 +473,7 @@ func TestDeleteSandboxVolumeCleansIdleDirectMountBeforeDelete(t *testing.T) {
 			return true, nil
 		},
 	}
-	meteringWriter := &fakeHTTPMeteringWriter{}
+	meteringWriter := &fakeHTTPMeteringRepository{}
 	server := &Server{
 		logger:       logrus.New(),
 		repo:         repo,
@@ -526,15 +548,15 @@ func TestDeleteSandboxVolumeReturnsConflictWhenDirectMountStillInflight(t *testi
 	}
 }
 
-func TestConfiguredMeteringWriterRejectsTypedNil(t *testing.T) {
-	var writer *fakeHTTPMeteringWriter
-	if _, ok := configuredMeteringWriter(writer); ok {
-		t.Fatal("typed-nil metering writer should be treated as disabled")
+func TestConfiguredMeteringRepositoryRejectsTypedNil(t *testing.T) {
+	var writer *fakeHTTPMeteringRepository
+	if _, ok := configuredMeteringRepository(writer); ok {
+		t.Fatal("typed-nil metering repository should be treated as disabled")
 	}
 }
 
 func TestAppendStorageObservationTxIgnoresTypedNilMeteringWriter(t *testing.T) {
-	var writer *fakeHTTPMeteringWriter
+	var writer *fakeHTTPMeteringRepository
 	server := &Server{meteringRepo: writer}
 
 	err := server.appendStorageObservationTx(context.Background(), nil, &metering.StorageObservation{})

--- a/storage-proxy/pkg/http/handlers_sandboxvolume.go
+++ b/storage-proxy/pkg/http/handlers_sandboxvolume.go
@@ -309,6 +309,7 @@ func (s *Server) listSandboxVolumes(w http.ResponseWriter, r *http.Request) {
 	if volumes == nil {
 		volumes = []*db.SandboxVolume{}
 	}
+	s.populateSandboxVolumeStorageUsage(r.Context(), teamID, volumes)
 
 	_ = spec.WriteSuccess(w, http.StatusOK, volumes)
 }
@@ -350,7 +351,83 @@ func (s *Server) getSandboxVolume(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	s.populateSingleSandboxVolumeStorageUsage(r.Context(), vol)
 	_ = spec.WriteSuccess(w, http.StatusOK, vol)
+}
+
+func (s *Server) populateSandboxVolumeStorageUsage(ctx context.Context, teamID string, volumes []*db.SandboxVolume) {
+	for _, vol := range volumes {
+		clearSandboxVolumeStorageUsage(vol)
+	}
+	repo, ok := configuredMeteringRepository(s.meteringRepo)
+	if !ok || len(volumes) == 0 {
+		return
+	}
+	states, err := repo.ListStorageProjectionStatesByTeam(ctx, meteringpkg.SubjectTypeVolume, teamID)
+	if err != nil {
+		s.logger.WithError(err).WithField("team_id", teamID).Warn("Failed to read metered sandbox volume storage usage")
+		return
+	}
+	statesByVolumeID := make(map[string]*meteringpkg.StorageProjectionState, len(states))
+	for _, state := range states {
+		if state != nil {
+			statesByVolumeID[state.SubjectID] = state
+		}
+	}
+	for _, vol := range volumes {
+		if vol == nil {
+			continue
+		}
+		applySandboxVolumeStorageUsage(vol, statesByVolumeID[vol.ID])
+	}
+}
+
+func (s *Server) populateSingleSandboxVolumeStorageUsage(ctx context.Context, vol *db.SandboxVolume) {
+	clearSandboxVolumeStorageUsage(vol)
+	if !isS0FSVolume(vol) {
+		return
+	}
+	repo, ok := configuredMeteringRepository(s.meteringRepo)
+	if !ok {
+		return
+	}
+	state, err := repo.GetStorageProjectionState(ctx, meteringpkg.SubjectTypeVolume, vol.ID)
+	if err != nil {
+		s.logger.WithError(err).WithField("volume_id", vol.ID).Warn("Failed to read metered sandbox volume storage usage")
+		return
+	}
+	applySandboxVolumeStorageUsage(vol, state)
+}
+
+func applySandboxVolumeStorageUsage(vol *db.SandboxVolume, state *meteringpkg.StorageProjectionState) {
+	if !isS0FSVolume(vol) || state == nil ||
+		state.SubjectType != meteringpkg.SubjectTypeVolume ||
+		state.SubjectID != vol.ID ||
+		state.TeamID != vol.TeamID ||
+		state.SizeBytes < 0 ||
+		state.ObservedAt.IsZero() {
+		return
+	}
+	sizeBytes := state.SizeBytes
+	observedAt := state.ObservedAt.UTC()
+	vol.MeteredStorageBytes = &sizeBytes
+	vol.StorageObservedAt = &observedAt
+}
+
+func clearSandboxVolumeStorageUsage(vol *db.SandboxVolume) {
+	if vol == nil {
+		return
+	}
+	vol.MeteredStorageBytes = nil
+	vol.StorageObservedAt = nil
+}
+
+func isS0FSVolume(vol *db.SandboxVolume) bool {
+	if vol == nil {
+		return false
+	}
+	backend := strings.TrimSpace(vol.Backend)
+	return backend == "" || backend == "s0fs"
 }
 
 func (s *Server) deleteSandboxVolume(w http.ResponseWriter, r *http.Request) {

--- a/storage-proxy/pkg/http/handlers_sandboxvolume_test.go
+++ b/storage-proxy/pkg/http/handlers_sandboxvolume_test.go
@@ -4,15 +4,19 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strconv"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+	"github.com/sandbox0-ai/sandbox0/pkg/metering"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/snapshot"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volume"
@@ -42,7 +46,7 @@ func TestCreateSandboxVolumeStoresDefaultPosixIdentity(t *testing.T) {
 	server := &Server{
 		logger:       logrus.New(),
 		repo:         repo,
-		meteringRepo: &fakeHTTPMeteringWriter{},
+		meteringRepo: &fakeHTTPMeteringRepository{},
 		snapshotMgr:  &fakeHTTPSnapshotManager{},
 	}
 
@@ -87,7 +91,7 @@ func TestCreateSandboxVolumeDefaultsPosixIdentityToRoot(t *testing.T) {
 	server := &Server{
 		logger:       logrus.New(),
 		repo:         repo,
-		meteringRepo: &fakeHTTPMeteringWriter{},
+		meteringRepo: &fakeHTTPMeteringRepository{},
 		snapshotMgr:  &fakeHTTPSnapshotManager{},
 	}
 
@@ -117,7 +121,7 @@ func TestCreateSandboxVolumeStoresS3BackendConfigAndRedactsResponse(t *testing.T
 	server := &Server{
 		logger:            logrus.New(),
 		repo:              repo,
-		meteringRepo:      &fakeHTTPMeteringWriter{},
+		meteringRepo:      &fakeHTTPMeteringRepository{},
 		snapshotMgr:       &fakeHTTPSnapshotManager{},
 		s3CredentialCodec: testHTTPS3BackendCredentialCodec(t),
 	}
@@ -261,7 +265,7 @@ func TestCreateSandboxVolumeRejectsUnsupportedS3Combinations(t *testing.T) {
 			server := &Server{
 				logger:       logrus.New(),
 				repo:         repo,
-				meteringRepo: &fakeHTTPMeteringWriter{},
+				meteringRepo: &fakeHTTPMeteringRepository{},
 				snapshotMgr:  &fakeHTTPSnapshotManager{},
 			}
 
@@ -286,7 +290,7 @@ func TestCreateSandboxVolumeRejectsS3BackendWithoutCredentialCodec(t *testing.T)
 	server := &Server{
 		logger:       logrus.New(),
 		repo:         repo,
-		meteringRepo: &fakeHTTPMeteringWriter{},
+		meteringRepo: &fakeHTTPMeteringRepository{},
 		snapshotMgr:  &fakeHTTPSnapshotManager{},
 	}
 
@@ -330,7 +334,7 @@ func TestCreateSandboxVolumeRejectsNullOrBlankSnapshotID(t *testing.T) {
 			server := &Server{
 				logger:       logrus.New(),
 				repo:         repo,
-				meteringRepo: &fakeHTTPMeteringWriter{},
+				meteringRepo: &fakeHTTPMeteringRepository{},
 				snapshotMgr:  snapshotMgr,
 			}
 
@@ -380,6 +384,168 @@ func TestListSandboxVolumesReturnsEmptyArray(t *testing.T) {
 	}
 	if len(*resp) != 0 {
 		t.Fatalf("volumes = %d, want 0", len(*resp))
+	}
+}
+
+func TestListSandboxVolumesIncludesMeteredS0FSStorageUsage(t *testing.T) {
+	repo := newFakeHTTPRepo()
+	repo.volumes["vol-s0fs"] = &db.SandboxVolume{
+		ID:      "vol-s0fs",
+		TeamID:  "team-1",
+		UserID:  "user-1",
+		Backend: "s0fs",
+	}
+	repo.volumes["vol-s3"] = &db.SandboxVolume{
+		ID:      "vol-s3",
+		TeamID:  "team-1",
+		UserID:  "user-1",
+		Backend: "s3",
+	}
+	observedAt := time.Date(2026, 7, 18, 8, 30, 0, 0, time.UTC)
+	meteringRepo := &fakeHTTPMeteringRepository{
+		storageStates: map[string]*metering.StorageProjectionState{
+			metering.SubjectTypeVolume + "/vol-s0fs": {
+				SubjectType: metering.SubjectTypeVolume,
+				SubjectID:   "vol-s0fs",
+				TeamID:      "team-1",
+				SizeBytes:   12345,
+				ObservedAt:  observedAt,
+			},
+			metering.SubjectTypeVolume + "/vol-s3": {
+				SubjectType: metering.SubjectTypeVolume,
+				SubjectID:   "vol-s3",
+				TeamID:      "team-1",
+				SizeBytes:   99999,
+				ObservedAt:  observedAt,
+			},
+		},
+	}
+	server := &Server{
+		logger:       logrus.New(),
+		repo:         repo,
+		meteringRepo: meteringRepo,
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/sandboxvolumes", nil)
+	req = req.WithContext(internalauth.WithClaims(req.Context(), &internalauth.Claims{TeamID: "team-1", UserID: "user-1"}))
+	recorder := httptest.NewRecorder()
+
+	server.listSandboxVolumes(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	responseBody := recorder.Body.String()
+	resp, apiErr, err := spec.DecodeResponse[[]db.SandboxVolume](recorder.Body)
+	if err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if apiErr != nil {
+		t.Fatalf("unexpected api error: %+v", apiErr)
+	}
+	volumesByID := make(map[string]db.SandboxVolume, len(*resp))
+	for _, vol := range *resp {
+		volumesByID[vol.ID] = vol
+	}
+	s0fs := volumesByID["vol-s0fs"]
+	if s0fs.MeteredStorageBytes == nil || *s0fs.MeteredStorageBytes != 12345 {
+		t.Fatalf("s0fs metered_storage_bytes = %v, want 12345", s0fs.MeteredStorageBytes)
+	}
+	if s0fs.StorageObservedAt == nil || !s0fs.StorageObservedAt.Equal(observedAt) {
+		t.Fatalf("s0fs storage_observed_at = %v, want %s", s0fs.StorageObservedAt, observedAt)
+	}
+	s3 := volumesByID["vol-s3"]
+	if s3.MeteredStorageBytes != nil || s3.StorageObservedAt != nil {
+		t.Fatalf("external volume storage usage = (%v, %v), want null", s3.MeteredStorageBytes, s3.StorageObservedAt)
+	}
+	if !strings.Contains(responseBody, `"metered_storage_bytes":null`) {
+		t.Fatalf("response does not expose unavailable storage as null: %s", responseBody)
+	}
+}
+
+func TestGetSandboxVolumeIncludesMeteredStorageUsage(t *testing.T) {
+	repo := newFakeHTTPRepo()
+	repo.volumes["vol-1"] = &db.SandboxVolume{
+		ID:     "vol-1",
+		TeamID: "team-1",
+		UserID: "user-1",
+	}
+	observedAt := time.Date(2026, 7, 18, 9, 0, 0, 0, time.UTC)
+	server := &Server{
+		logger: logrus.New(),
+		repo:   repo,
+		meteringRepo: &fakeHTTPMeteringRepository{
+			storageStates: map[string]*metering.StorageProjectionState{
+				metering.SubjectTypeVolume + "/vol-1": {
+					SubjectType: metering.SubjectTypeVolume,
+					SubjectID:   "vol-1",
+					TeamID:      "team-1",
+					SizeBytes:   67890,
+					ObservedAt:  observedAt,
+				},
+			},
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/sandboxvolumes/vol-1", nil)
+	req.SetPathValue("id", "vol-1")
+	req = req.WithContext(internalauth.WithClaims(req.Context(), &internalauth.Claims{TeamID: "team-1", UserID: "user-1"}))
+	recorder := httptest.NewRecorder()
+
+	server.getSandboxVolume(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	resp, apiErr, err := spec.DecodeResponse[db.SandboxVolume](recorder.Body)
+	if err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if apiErr != nil {
+		t.Fatalf("unexpected api error: %+v", apiErr)
+	}
+	if resp.MeteredStorageBytes == nil || *resp.MeteredStorageBytes != 67890 {
+		t.Fatalf("metered_storage_bytes = %v, want 67890", resp.MeteredStorageBytes)
+	}
+	if resp.StorageObservedAt == nil || !resp.StorageObservedAt.Equal(observedAt) {
+		t.Fatalf("storage_observed_at = %v, want %s", resp.StorageObservedAt, observedAt)
+	}
+}
+
+func TestGetSandboxVolumeToleratesUnavailableMeteringState(t *testing.T) {
+	repo := newFakeHTTPRepo()
+	repo.volumes["vol-1"] = &db.SandboxVolume{
+		ID:     "vol-1",
+		TeamID: "team-1",
+		UserID: "user-1",
+	}
+	server := &Server{
+		logger: logrus.New(),
+		repo:   repo,
+		meteringRepo: &fakeHTTPMeteringRepository{
+			storageReadErr: errors.New("metering unavailable"),
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/sandboxvolumes/vol-1", nil)
+	req.SetPathValue("id", "vol-1")
+	req = req.WithContext(internalauth.WithClaims(req.Context(), &internalauth.Claims{TeamID: "team-1", UserID: "user-1"}))
+	recorder := httptest.NewRecorder()
+
+	server.getSandboxVolume(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	resp, apiErr, err := spec.DecodeResponse[db.SandboxVolume](recorder.Body)
+	if err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if apiErr != nil {
+		t.Fatalf("unexpected api error: %+v", apiErr)
+	}
+	if resp.MeteredStorageBytes != nil || resp.StorageObservedAt != nil {
+		t.Fatalf("unavailable metering state = (%v, %v), want null", resp.MeteredStorageBytes, resp.StorageObservedAt)
 	}
 }
 
@@ -452,7 +618,7 @@ func TestCreateSandboxVolumeRejectsPartialDefaultPosixIdentity(t *testing.T) {
 	server := &Server{
 		logger:       logrus.New(),
 		repo:         newFakeHTTPRepo(),
-		meteringRepo: &fakeHTTPMeteringWriter{},
+		meteringRepo: &fakeHTTPMeteringRepository{},
 		snapshotMgr:  &fakeHTTPSnapshotManager{},
 	}
 
@@ -472,7 +638,7 @@ func TestCreateOwnedSandboxVolumeStoresOwnerMetadata(t *testing.T) {
 	server := &Server{
 		logger:       logrus.New(),
 		repo:         repo,
-		meteringRepo: &fakeHTTPMeteringWriter{},
+		meteringRepo: &fakeHTTPMeteringRepository{},
 	}
 
 	req := httptest.NewRequest(http.MethodPost, "/internal/v1/sandboxvolumes/owned", bytes.NewReader([]byte(`{"sandbox_id":"sandbox-a","cluster_id":"cluster-a","purpose":"webhook-state"}`)))

--- a/storage-proxy/pkg/http/server.go
+++ b/storage-proxy/pkg/http/server.go
@@ -46,25 +46,27 @@ type volumeRepository interface {
 	MarkOwnedSandboxVolumeCleanupAttempt(ctx context.Context, volumeID string, cleanupErr error) error
 }
 
-type meteringWriter interface {
+type meteringRepository interface {
 	AppendEventTx(ctx context.Context, tx pgx.Tx, event *meteringpkg.Event) error
 	RecordStorageObservationTx(ctx context.Context, tx pgx.Tx, observation *meteringpkg.StorageObservation) error
 	CloseStorageObservationTx(ctx context.Context, tx pgx.Tx, observation *meteringpkg.StorageObservation) error
 	UpsertProducerWatermarkTx(ctx context.Context, tx pgx.Tx, producer string, regionID string, completeBefore time.Time) error
+	GetStorageProjectionState(ctx context.Context, subjectType, subjectID string) (*meteringpkg.StorageProjectionState, error)
+	ListStorageProjectionStatesByTeam(ctx context.Context, subjectType, teamID string) ([]*meteringpkg.StorageProjectionState, error)
 }
 
-func configuredMeteringWriter(writer meteringWriter) (meteringWriter, bool) {
-	if writer == nil {
+func configuredMeteringRepository(repo meteringRepository) (meteringRepository, bool) {
+	if repo == nil {
 		return nil, false
 	}
-	value := reflect.ValueOf(writer)
+	value := reflect.ValueOf(repo)
 	switch value.Kind() {
 	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
 		if value.IsNil() {
 			return nil, false
 		}
 	}
-	return writer, true
+	return repo, true
 }
 
 type snapshotManager interface {
@@ -126,7 +128,7 @@ type Server struct {
 	mux                  *http.ServeMux
 	cfg                  *config.StorageProxyConfig
 	repo                 volumeRepository
-	meteringRepo         meteringWriter
+	meteringRepo         meteringRepository
 	quotaRepo            *quota.Repository
 	regionID             string
 	authenticator        *auth.HTTPAuthenticator
@@ -149,7 +151,7 @@ func (s *Server) SetQuotaRepository(repo *quota.Repository) {
 }
 
 // NewServer creates a new HTTP server
-func NewServer(logger *logrus.Logger, cfg *config.StorageProxyConfig, k8sClient kubernetes.Interface, repo volumeRepository, meteringRepo meteringWriter, regionID string, authenticator *auth.HTTPAuthenticator, snapshotMgr snapshotManager, barrier volumeMutationBarrier, volMgr volumeMountManager, fileRPC volumeFileRPC, eventHub *notify.Hub) *Server {
+func NewServer(logger *logrus.Logger, cfg *config.StorageProxyConfig, k8sClient kubernetes.Interface, repo volumeRepository, meteringRepo meteringRepository, regionID string, authenticator *auth.HTTPAuthenticator, snapshotMgr snapshotManager, barrier volumeMutationBarrier, volMgr volumeMountManager, fileRPC volumeFileRPC, eventHub *notify.Hub) *Server {
 	selfPodID, err := os.Hostname()
 	if err != nil {
 		selfPodID = ""
@@ -310,7 +312,7 @@ func (s *Server) handleReady(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) appendMeteringEventTx(ctx context.Context, tx pgx.Tx, event *meteringpkg.Event) error {
-	writer, ok := configuredMeteringWriter(s.meteringRepo)
+	writer, ok := configuredMeteringRepository(s.meteringRepo)
 	if !ok || event == nil {
 		return nil
 	}
@@ -321,7 +323,7 @@ func (s *Server) appendMeteringEventTx(ctx context.Context, tx pgx.Tx, event *me
 }
 
 func (s *Server) appendStorageObservationTx(ctx context.Context, tx pgx.Tx, observation *meteringpkg.StorageObservation) error {
-	writer, ok := configuredMeteringWriter(s.meteringRepo)
+	writer, ok := configuredMeteringRepository(s.meteringRepo)
 	if !ok || observation == nil {
 		return nil
 	}
@@ -335,7 +337,7 @@ func (s *Server) appendStorageObservationTx(ctx context.Context, tx pgx.Tx, obse
 }
 
 func (s *Server) closeStorageObservationTx(ctx context.Context, tx pgx.Tx, observation *meteringpkg.StorageObservation) error {
-	writer, ok := configuredMeteringWriter(s.meteringRepo)
+	writer, ok := configuredMeteringRepository(s.meteringRepo)
 	if !ok || observation == nil {
 		return nil
 	}


### PR DESCRIPTION
## Summary
- add nullable current storage usage fields to the public `SandboxVolume` contract
- hydrate S0FS volume list/detail responses from PostgreSQL metering projection state
- keep external S3 and unavailable metering state explicit as `null`
- document current-size semantics separately from historical byte-hour windows

## Testing
- `go test ./pkg/metering/...`
- `go test ./storage-proxy/pkg/...`
- `go test ./storage-proxy/pkg/runtime ./storage-proxy/pkg/snapshot`
- `make apispec`

A broad `go test ./...` also passed regular packages; its e2e suite could not start because `kind` is not installed in this environment, and two existing manager integration fixtures failed outside the changed packages.
