### PR TITLE
perf(ctld): make S0FS handle recovery incremental

### DIFF
--- a/ctld/HA.md
+++ b/ctld/HA.md
@@ -70,10 +70,14 @@ input. Runtime state uses backend-specific recovery:
 
 - S0FS reopens its node-local WAL only after promotion. Kernel inode IDs remain
   stable because S0FS persists them, and a separate handle state preserves
-  open and open-unlinked inode references. Handle updates use atomic renames so
-  they are visible to the same-node standby before the FUSE operation returns;
-  graceful handoff additionally syncs the final snapshot file before replacing
-  the previous state.
+  open and open-unlinked inode references. File-handle opens and closes append
+  constant-size recovery events that are visible to the same-node standby
+  before the FUSE operation returns. Periodic compaction and graceful handoff
+  replace the legacy snapshot atomically; handoff also syncs the final
+  snapshot. Directory handles are stateless because directory requests carry
+  the inode they operate on. During a rolling upgrade, a primary falls back to
+  snapshot updates until every connected standby advertises journal replay
+  support.
 - Rootfs-backed portals persist their inode-to-path and handle journal.
   Open-unlinked files move into a hidden orphan directory until the restored
   final handle is released.

--- a/ctld/internal/ctld/ha/coordinator_linux.go
+++ b/ctld/internal/ctld/ha/coordinator_linux.go
@@ -344,13 +344,14 @@ func (l *PrimaryLease) Close() error {
 }
 
 type wireMessage struct {
-	Version  int                          `json:"version"`
-	Type     string                       `json:"type"`
-	Sequence uint64                       `json:"sequence"`
-	Epoch    uint64                       `json:"epoch"`
-	Manifest *ctldportal.RecoveryManifest `json:"manifest,omitempty"`
-	Key      string                       `json:"key,omitempty"`
-	Error    string                       `json:"error,omitempty"`
+	Version      int                          `json:"version"`
+	Type         string                       `json:"type"`
+	Sequence     uint64                       `json:"sequence"`
+	Epoch        uint64                       `json:"epoch"`
+	Manifest     *ctldportal.RecoveryManifest `json:"manifest,omitempty"`
+	Key          string                       `json:"key,omitempty"`
+	Error        string                       `json:"error,omitempty"`
+	Capabilities []string                     `json:"capabilities,omitempty"`
 }
 
 const (
@@ -391,7 +392,13 @@ func (s *standbyState) receive(ctx context.Context, conn *net.UnixConn, onState 
 			return fmt.Errorf("decode ctld HA message: %w", err)
 		}
 		ackErr := s.apply(message, oob[:oobn])
-		ack := wireMessage{Version: protocolVersion, Type: messageAck, Sequence: message.Sequence, Epoch: message.Epoch}
+		ack := wireMessage{
+			Version:      protocolVersion,
+			Type:         messageAck,
+			Sequence:     message.Sequence,
+			Epoch:        message.Epoch,
+			Capabilities: []string{ctldportal.RecoveryCapabilityS0FSHandleJournal},
+		}
 		if ackErr != nil {
 			ack.Error = ackErr.Error()
 		}

--- a/ctld/internal/ctld/ha/coordinator_linux_test.go
+++ b/ctld/internal/ctld/ha/coordinator_linux_test.go
@@ -28,13 +28,24 @@ func TestCoordinatorTransfersPortalAndPromotesStandby(t *testing.T) {
 		t.Fatalf("WaitForPrimary(primary) error = %v", err)
 	}
 	t.Cleanup(func() { _ = primary.Close() })
-	primary.Replicator.SetSnapshotProvider(func(context.Context, ctldportal.PortalReplicator) error { return nil })
+	capabilityDuringSnapshot := make(chan bool, 1)
+	primary.Replicator.SetSnapshotProvider(func(_ context.Context, target ctldportal.PortalReplicator) error {
+		provider, ok := target.(ctldportal.PortalRecoveryCapabilityProvider)
+		capabilityDuringSnapshot <- ok && provider.SupportsRecoveryCapability(ctldportal.RecoveryCapabilityS0FSHandleJournal)
+		return nil
+	})
 
 	standbyCoordinator := newTestCoordinator(t, root, "b")
 	standbyCtx, standbyCancel := context.WithCancel(context.Background())
 	defer standbyCancel()
 	standbyResult := waitForPrimaryAsync(standbyCtx, standbyCoordinator)
 	waitForStandbys(t, primary.Replicator, 1)
+	if supported := <-capabilityDuringSnapshot; !supported {
+		t.Fatal("standby capability was not negotiated before snapshot synchronization")
+	}
+	if !primary.Replicator.SupportsRecoveryCapability(ctldportal.RecoveryCapabilityS0FSHandleJournal) {
+		t.Fatal("standby did not advertise S0FS handle journal recovery")
+	}
 
 	channel := writeTestChannel(t, "portal-channel")
 	manifest := testManifest("pod-1\x00workspace")
@@ -276,6 +287,27 @@ func waitForStandbys(t *testing.T, replicator *Replicator, want int) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf("standby count = %d, want %d", replicator.StandbyCount(), want)
+}
+
+func TestReplicatorRecoveryCapabilityRequiresEveryConnectedStandby(t *testing.T) {
+	replicator := &Replicator{clients: make(map[*standbyClient]struct{})}
+	if !replicator.SupportsRecoveryCapability(ctldportal.RecoveryCapabilityS0FSHandleJournal) {
+		t.Fatal("SupportsRecoveryCapability() = false without a standby, want true")
+	}
+
+	current := &standbyClient{capabilities: map[string]struct{}{
+		ctldportal.RecoveryCapabilityS0FSHandleJournal: {},
+	}}
+	replicator.clients[current] = struct{}{}
+	if !replicator.SupportsRecoveryCapability(ctldportal.RecoveryCapabilityS0FSHandleJournal) {
+		t.Fatal("SupportsRecoveryCapability() = false for current standby, want true")
+	}
+
+	legacy := &standbyClient{}
+	replicator.clients[legacy] = struct{}{}
+	if replicator.SupportsRecoveryCapability(ctldportal.RecoveryCapabilityS0FSHandleJournal) {
+		t.Fatal("SupportsRecoveryCapability() = true with legacy standby, want false")
+	}
 }
 
 func onlyReadyClient(t *testing.T, replicator *Replicator) *standbyClient {

--- a/ctld/internal/ctld/ha/replicator_linux.go
+++ b/ctld/internal/ctld/ha/replicator_linux.go
@@ -43,8 +43,9 @@ type Replicator struct {
 }
 
 type standbyClient struct {
-	conn  *net.UnixConn
-	ready bool
+	conn         *net.UnixConn
+	ready        bool
+	capabilities map[string]struct{}
 }
 
 func newReplicator(socket string, epoch uint64, logger *zap.Logger, onReady func(int)) (*Replicator, error) {
@@ -103,6 +104,27 @@ func (r *Replicator) StandbyCount() int {
 		}
 	}
 	return count
+}
+
+// SupportsRecoveryCapability reports whether incremental recovery state is
+// safe for every connected standby. No clients is safe because a newly
+// accepted client is added before capability negotiation and immediately
+// disables the incremental path until its first acknowledgement.
+func (r *Replicator) SupportsRecoveryCapability(capability string) bool {
+	if r == nil || strings.TrimSpace(capability) == "" {
+		return false
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if len(r.clients) == 0 {
+		return true
+	}
+	for client := range r.clients {
+		if _, ok := client.capabilities[capability]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func (r *Replicator) Publish(ctx context.Context, manifest ctldportal.RecoveryManifest, channel *os.File) error {
@@ -197,6 +219,11 @@ func (r *Replicator) initializeClient(client *standbyClient) {
 		r.removeClient(client, fmt.Errorf("ctld HA snapshot provider unavailable"))
 		return
 	}
+	if err := r.send(r.ctx, client, wireMessage{Type: messagePing}, nil); err != nil {
+		r.opMu.Unlock()
+		r.removeClient(client, fmt.Errorf("negotiate ctld HA standby capabilities: %w", err))
+		return
+	}
 	target := &singleClientReplicator{parent: r, client: client}
 	if err := provider(r.ctx, target); err != nil {
 		r.opMu.Unlock()
@@ -274,6 +301,17 @@ func (r *Replicator) send(ctx context.Context, client *standbyClient, message wi
 	if ack.Error != "" {
 		return errors.New(ack.Error)
 	}
+	capabilities := make(map[string]struct{}, len(ack.Capabilities))
+	for _, capability := range ack.Capabilities {
+		if capability = strings.TrimSpace(capability); capability != "" {
+			capabilities[capability] = struct{}{}
+		}
+	}
+	r.mu.Lock()
+	if _, ok := r.clients[client]; ok {
+		client.capabilities = capabilities
+	}
+	r.mu.Unlock()
 	return nil
 }
 
@@ -343,6 +381,16 @@ type singleClientReplicator struct {
 
 func (r *singleClientReplicator) Ready() bool { return r != nil && r.client != nil }
 
+func (r *singleClientReplicator) SupportsRecoveryCapability(capability string) bool {
+	if r == nil || r.parent == nil || r.client == nil || strings.TrimSpace(capability) == "" {
+		return false
+	}
+	r.parent.mu.RLock()
+	defer r.parent.mu.RUnlock()
+	_, ok := r.client.capabilities[capability]
+	return ok
+}
+
 func (r *singleClientReplicator) Publish(ctx context.Context, manifest ctldportal.RecoveryManifest, channel *os.File) error {
 	return r.parent.send(ctx, r.client, wireMessage{Type: messagePublish, Manifest: &manifest}, channel)
 }
@@ -357,3 +405,5 @@ func (r *singleClientReplicator) Remove(ctx context.Context, key string) error {
 
 var _ ctldportal.PortalReplicator = (*Replicator)(nil)
 var _ ctldportal.PortalReplicator = (*singleClientReplicator)(nil)
+var _ ctldportal.PortalRecoveryCapabilityProvider = (*Replicator)(nil)
+var _ ctldportal.PortalRecoveryCapabilityProvider = (*singleClientReplicator)(nil)

--- a/ctld/internal/ctld/portal/manager.go
+++ b/ctld/internal/ctld/portal/manager.go
@@ -583,6 +583,11 @@ func (m *Manager) SyncTo(ctx context.Context, target PortalReplicator) error {
 	if m == nil || target == nil || !target.Ready() {
 		return fmt.Errorf("ctld standby is not synchronized")
 	}
+	if !supportsRecoveryCapability(target, RecoveryCapabilityS0FSHandleJournal) {
+		if err := m.compactS0FSHandleRecoveryStates(false); err != nil {
+			return fmt.Errorf("compact S0FS recovery state for legacy standby: %w", err)
+		}
+	}
 	m.mu.Lock()
 	portals := make([]*portalMount, 0, len(m.portals))
 	for _, pm := range m.portals {
@@ -1012,7 +1017,8 @@ func (m *Manager) openS0FSBoundVolume(ctx context.Context, req ctldapi.BindVolum
 	engine.PruneUnlinked(retainedUnlinkedInodes(handleState))
 	session := newLocalSession(req.SandboxVolumeID, m.volumes, m.logrus)
 	session.statePath = statePath
-	if err := persistS0FSHandleState(statePath, req.SandboxVolumeID, volCtx.SnapshotHandleState()); err != nil {
+	session.incrementalReady = m.incrementalS0FSHandleRecoveryReady
+	if err := compactS0FSHandleState(statePath, req.SandboxVolumeID, volCtx.SnapshotHandleState(), true, nil); err != nil {
 		_ = engine.Close()
 		return nil, nil, err
 	}
@@ -1461,7 +1467,7 @@ func (m *Manager) finishBoundVolumeCleanup(ctx context.Context, cleanup *boundVo
 		m.unregisterOwner(cleanup.bound)
 	}
 	if cleanup.bound.statePath != "" {
-		if err := os.Remove(cleanup.bound.statePath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		if err := removeS0FSHandleRecoveryState(cleanup.bound.statePath); err != nil {
 			return err
 		}
 	}
@@ -1823,6 +1829,7 @@ func (m *Manager) attachPortalLocked(pm *portalMount, bound *boundVolume, mounte
 			session = newLocalSession(bound.volumeID, m.volumes, m.logrus)
 			if local, ok := session.(*localSession); ok {
 				local.statePath = bound.statePath
+				local.incrementalReady = m.incrementalS0FSHandleRecoveryReady
 			}
 			bound.session = session
 		}
@@ -1855,6 +1862,36 @@ func closeBoundSession(bound *boundVolume) {
 	}
 	bound.session.Close()
 	bound.session = nil
+}
+
+func (m *Manager) incrementalS0FSHandleRecoveryReady() bool {
+	if m == nil || m.replicator == nil {
+		return true
+	}
+	return supportsRecoveryCapability(m.replicator, RecoveryCapabilityS0FSHandleJournal)
+}
+
+func (m *Manager) compactS0FSHandleRecoveryStates(durable bool) error {
+	if m == nil {
+		return nil
+	}
+	m.mu.Lock()
+	sessions := make([]*localSession, 0, len(m.boundVolumes))
+	for _, bound := range m.boundVolumes {
+		if bound == nil {
+			continue
+		}
+		if session, ok := bound.session.(*localSession); ok {
+			sessions = append(sessions, session)
+		}
+	}
+	m.mu.Unlock()
+	for _, session := range sessions {
+		if err := session.persistRecoveryStateWithDurability(durable); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 type handoffSession interface {

--- a/ctld/internal/ctld/portal/recovery_state.go
+++ b/ctld/internal/ctld/portal/recovery_state.go
@@ -15,6 +15,10 @@ import (
 
 const portalRecoveryVersion = 1
 
+// RecoveryCapabilityS0FSHandleJournal identifies peers that replay incremental
+// S0FS file-handle recovery events in addition to legacy snapshot files.
+const RecoveryCapabilityS0FSHandleJournal = "s0fs_handle_journal_v1"
+
 // RecoveryManifest contains the durable and replicated state needed to attach
 // a standby process to an existing portal's kernel FUSE connection.
 type RecoveryManifest struct {
@@ -44,6 +48,17 @@ type PortalReplicator interface {
 	Publish(context.Context, RecoveryManifest, *os.File) error
 	Update(context.Context, RecoveryManifest) error
 	Remove(context.Context, string) error
+}
+
+// PortalRecoveryCapabilityProvider allows compatible peers to opt into recovery
+// formats without changing the wire protocol used during rolling upgrades.
+type PortalRecoveryCapabilityProvider interface {
+	SupportsRecoveryCapability(string) bool
+}
+
+func supportsRecoveryCapability(replicator PortalReplicator, capability string) bool {
+	provider, ok := replicator.(PortalRecoveryCapabilityProvider)
+	return ok && provider.SupportsRecoveryCapability(capability)
 }
 
 type portalRecoveryStore struct {

--- a/ctld/internal/ctld/portal/s0fs_recovery.go
+++ b/ctld/internal/ctld/portal/s0fs_recovery.go
@@ -1,16 +1,26 @@
 package portal
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
+	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volume"
 )
 
-const s0fsHandleStateVersion = 1
+const (
+	s0fsHandleStateVersion          = 1
+	s0fsHandleJournalVersion        = 1
+	s0fsHandleJournalCompactEvents  = 4096
+	s0fsHandleJournalOperationOpen  = "open"
+	s0fsHandleJournalOperationClose = "close"
+)
 
 type s0fsHandleRecoveryState struct {
 	Version  int                `json:"version"`
@@ -18,7 +28,28 @@ type s0fsHandleRecoveryState struct {
 	Handles  volume.HandleState `json:"handles"`
 }
 
+type s0fsHandleJournalEvent struct {
+	Version   int    `json:"version"`
+	VolumeID  string `json:"volume_id"`
+	Operation string `json:"operation"`
+	HandleID  uint64 `json:"handle_id"`
+	Inode     uint64 `json:"inode,omitempty"`
+}
+
+type s0fsHandleStateJournal struct {
+	file   *os.File
+	events int
+}
+
 func loadS0FSHandleState(path, volumeID string) (volume.HandleState, error) {
+	state, err := loadS0FSHandleSnapshot(path, volumeID)
+	if err != nil {
+		return volume.HandleState{}, err
+	}
+	return replayS0FSHandleJournal(s0fsHandleJournalPath(path), volumeID, state)
+}
+
+func loadS0FSHandleSnapshot(path, volumeID string) (volume.HandleState, error) {
 	if strings.TrimSpace(path) == "" {
 		return volume.HandleState{}, nil
 	}
@@ -39,7 +70,143 @@ func loadS0FSHandleState(path, volumeID string) (volume.HandleState, error) {
 	if state.VolumeID != volumeID {
 		return volume.HandleState{}, fmt.Errorf("s0fs handle recovery state belongs to volume %q", state.VolumeID)
 	}
-	return state.Handles, nil
+	return normalizeS0FSHandleState(state.Handles), nil
+}
+
+func replayS0FSHandleJournal(path, volumeID string, state volume.HandleState) (volume.HandleState, error) {
+	payload, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return normalizeS0FSHandleState(state), nil
+	}
+	if err != nil {
+		return volume.HandleState{}, fmt.Errorf("read s0fs handle recovery journal: %w", err)
+	}
+	replayer := newS0FSHandleJournalReplayer(state)
+	lines := bytes.Split(payload, []byte{'\n'})
+	for index, line := range lines {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+		var event s0fsHandleJournalEvent
+		if err := json.Unmarshal(line, &event); err != nil {
+			if index == len(lines)-1 && len(payload) > 0 && payload[len(payload)-1] != '\n' {
+				break
+			}
+			return volume.HandleState{}, fmt.Errorf("decode s0fs handle recovery journal event: %w", err)
+		}
+		if err := validateS0FSHandleJournalEvent(event, volumeID); err != nil {
+			return volume.HandleState{}, err
+		}
+		replayer.apply(event)
+	}
+	return replayer.state(), nil
+}
+
+type s0fsHandleJournalReplayer struct {
+	handles       volume.HandleState
+	openByInode   map[uint64]int
+	unlinkedFiles map[uint64]struct{}
+}
+
+func newS0FSHandleJournalReplayer(state volume.HandleState) *s0fsHandleJournalReplayer {
+	state = normalizeS0FSHandleState(state)
+	replayer := &s0fsHandleJournalReplayer{
+		handles:       state,
+		openByInode:   make(map[uint64]int),
+		unlinkedFiles: make(map[uint64]struct{}, len(state.UnlinkedFiles)),
+	}
+	for _, inode := range state.FileHandles {
+		replayer.openByInode[inode]++
+	}
+	for _, inode := range state.UnlinkedFiles {
+		replayer.unlinkedFiles[inode] = struct{}{}
+	}
+	return replayer
+}
+
+func (r *s0fsHandleJournalReplayer) apply(event s0fsHandleJournalEvent) {
+	if event.HandleID > r.handles.NextHandleID {
+		r.handles.NextHandleID = event.HandleID
+	}
+	switch event.Operation {
+	case s0fsHandleJournalOperationOpen:
+		if previous, ok := r.handles.FileHandles[event.HandleID]; ok {
+			if previous == event.Inode {
+				return
+			}
+			r.decrement(previous)
+		}
+		r.handles.FileHandles[event.HandleID] = event.Inode
+		r.openByInode[event.Inode]++
+	case s0fsHandleJournalOperationClose:
+		inode, ok := r.handles.FileHandles[event.HandleID]
+		if !ok {
+			return
+		}
+		delete(r.handles.FileHandles, event.HandleID)
+		r.decrement(inode)
+	}
+}
+
+func (r *s0fsHandleJournalReplayer) decrement(inode uint64) {
+	if r.openByInode[inode] > 1 {
+		r.openByInode[inode]--
+		return
+	}
+	delete(r.openByInode, inode)
+	delete(r.unlinkedFiles, inode)
+}
+
+func (r *s0fsHandleJournalReplayer) state() volume.HandleState {
+	r.handles.UnlinkedFiles = nil
+	for inode := range r.unlinkedFiles {
+		r.handles.UnlinkedFiles = append(r.handles.UnlinkedFiles, inode)
+	}
+	sort.Slice(r.handles.UnlinkedFiles, func(i, j int) bool {
+		return r.handles.UnlinkedFiles[i] < r.handles.UnlinkedFiles[j]
+	})
+	return r.handles
+}
+
+func validateS0FSHandleJournalEvent(event s0fsHandleJournalEvent, volumeID string) error {
+	if event.Version != s0fsHandleJournalVersion {
+		return fmt.Errorf("unsupported s0fs handle recovery journal version %d", event.Version)
+	}
+	if event.VolumeID != volumeID {
+		return fmt.Errorf("s0fs handle recovery journal belongs to volume %q", event.VolumeID)
+	}
+	if event.HandleID == 0 {
+		return fmt.Errorf("s0fs handle recovery journal event is missing handle_id")
+	}
+	switch event.Operation {
+	case s0fsHandleJournalOperationOpen:
+		if event.Inode == 0 {
+			return fmt.Errorf("s0fs handle open recovery event is missing inode")
+		}
+	case s0fsHandleJournalOperationClose:
+	default:
+		return fmt.Errorf("unsupported s0fs handle recovery journal operation %q", event.Operation)
+	}
+	return nil
+}
+
+func normalizeS0FSHandleState(state volume.HandleState) volume.HandleState {
+	if state.FileHandles == nil {
+		state.FileHandles = make(map[uint64]uint64)
+	}
+	for handle := range state.FileHandles {
+		if handle > state.NextHandleID {
+			state.NextHandleID = handle
+		}
+	}
+	for handle := range state.DirHandles {
+		if handle > state.NextHandleID {
+			state.NextHandleID = handle
+		}
+	}
+	state.DirHandles = nil
+	return state
 }
 
 func persistS0FSHandleState(path, volumeID string, handles volume.HandleState) error {
@@ -61,12 +228,105 @@ func persistS0FSHandleStateWithDurability(path, volumeID string, handles volume.
 	payload, err := json.Marshal(s0fsHandleRecoveryState{
 		Version:  s0fsHandleStateVersion,
 		VolumeID: volumeID,
-		Handles:  handles,
+		Handles:  normalizeS0FSHandleState(handles),
 	})
 	if err != nil {
 		return err
 	}
 	return writeAtomicRecoveryStateWithDurability(path, ".s0fs-*.tmp", payload, durable)
+}
+
+// compactS0FSHandleState replaces the snapshot before clearing the journal.
+// Journal events use unique handle IDs and are idempotent against the newer
+// snapshot, so a crash between those steps can safely replay the old events.
+func compactS0FSHandleState(
+	path, volumeID string,
+	handles volume.HandleState,
+	durable bool,
+	journal *s0fsHandleStateJournal,
+) error {
+	if err := persistS0FSHandleStateWithDurability(path, volumeID, handles, durable); err != nil {
+		return err
+	}
+	if journal != nil {
+		return journal.Reset()
+	}
+	if err := os.Remove(s0fsHandleJournalPath(path)); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove s0fs handle recovery journal: %w", err)
+	}
+	return nil
+}
+
+func openS0FSHandleStateJournal(path string) (*s0fsHandleStateJournal, error) {
+	if strings.TrimSpace(path) == "" {
+		return &s0fsHandleStateJournal{}, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, fmt.Errorf("create s0fs handle recovery directory: %w", err)
+	}
+	file, err := os.OpenFile(s0fsHandleJournalPath(path), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open s0fs handle recovery journal: %w", err)
+	}
+	return &s0fsHandleStateJournal{file: file}, nil
+}
+
+func (j *s0fsHandleStateJournal) Append(event s0fsHandleJournalEvent) error {
+	if j == nil || j.file == nil {
+		return nil
+	}
+	payload, err := json.Marshal(event)
+	if err != nil {
+		return err
+	}
+	payload = append(payload, '\n')
+	written, err := j.file.Write(payload)
+	if err != nil {
+		return fmt.Errorf("append s0fs handle recovery journal: %w", err)
+	}
+	if written != len(payload) {
+		return fmt.Errorf("append s0fs handle recovery journal: %w", io.ErrShortWrite)
+	}
+	j.events++
+	return nil
+}
+
+func (j *s0fsHandleStateJournal) Reset() error {
+	if j == nil || j.file == nil {
+		return nil
+	}
+	if err := j.file.Truncate(0); err != nil {
+		return fmt.Errorf("reset s0fs handle recovery journal: %w", err)
+	}
+	j.events = 0
+	return nil
+}
+
+func (j *s0fsHandleStateJournal) Close() error {
+	if j == nil || j.file == nil {
+		return nil
+	}
+	err := j.file.Close()
+	j.file = nil
+	return err
+}
+
+func (j *s0fsHandleStateJournal) ShouldCompact() bool {
+	return j != nil && j.events >= s0fsHandleJournalCompactEvents
+}
+
+func s0fsHandleJournalPath(statePath string) string {
+	return statePath + ".journal"
+}
+
+func removeS0FSHandleRecoveryState(path string) error {
+	var firstErr error
+	for _, candidate := range []string{path, s0fsHandleJournalPath(path)} {
+		if err := os.Remove(candidate); err != nil && !errors.Is(err, os.ErrNotExist) && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
 }
 
 func retainedUnlinkedInodes(state volume.HandleState) map[uint64]struct{} {

--- a/ctld/internal/ctld/portal/s0fs_recovery_test.go
+++ b/ctld/internal/ctld/portal/s0fs_recovery_test.go
@@ -1,30 +1,26 @@
 package portal
 
 import (
+	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volume"
 )
 
-func TestPersistProcessLocalS0FSHandleStateReplacesSnapshot(t *testing.T) {
+func TestPersistProcessLocalS0FSHandleStateDropsLegacyDirectoryHandles(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "handles.json")
-	initial := volume.HandleState{
-		NextHandleID: 1,
-		FileHandles:  map[uint64]uint64{1: 10},
-	}
-	if err := persistS0FSHandleState(path, "vol-1", initial); err != nil {
-		t.Fatalf("persistS0FSHandleState() error = %v", err)
-	}
-
 	want := volume.HandleState{
 		NextHandleID:  3,
 		FileHandles:   map[uint64]uint64{2: 20},
-		DirHandles:    map[uint64]uint64{3: 30},
 		UnlinkedFiles: []uint64{20},
 	}
-	if err := persistProcessLocalS0FSHandleState(path, "vol-1", want); err != nil {
+	legacy := want
+	legacy.DirHandles = map[uint64]uint64{3: 30}
+	if err := persistProcessLocalS0FSHandleState(path, "vol-1", legacy); err != nil {
 		t.Fatalf("persistProcessLocalS0FSHandleState() error = %v", err)
 	}
 
@@ -35,36 +31,195 @@ func TestPersistProcessLocalS0FSHandleStateReplacesSnapshot(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("loadS0FSHandleState() = %#v, want %#v", got, want)
 	}
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if strings.Contains(string(payload), "dir_handles") {
+		t.Fatalf("persisted recovery state retained directory handles: %s", payload)
+	}
+}
+
+func TestLoadS0FSHandleStateReplaysJournalAndClearsFinalUnlinkedHandle(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "handles.json")
+	initial := volume.HandleState{
+		NextHandleID:  2,
+		FileHandles:   map[uint64]uint64{1: 10, 2: 10},
+		UnlinkedFiles: []uint64{10},
+	}
+	if err := persistS0FSHandleState(path, "vol-1", initial); err != nil {
+		t.Fatalf("persistS0FSHandleState() error = %v", err)
+	}
+	journal, err := openS0FSHandleStateJournal(path)
+	if err != nil {
+		t.Fatalf("openS0FSHandleStateJournal() error = %v", err)
+	}
+	for _, event := range []s0fsHandleJournalEvent{
+		{Version: 1, VolumeID: "vol-1", Operation: "close", HandleID: 1},
+		{Version: 1, VolumeID: "vol-1", Operation: "open", HandleID: 3, Inode: 20},
+		{Version: 1, VolumeID: "vol-1", Operation: "close", HandleID: 2},
+	} {
+		if err := journal.Append(event); err != nil {
+			t.Fatalf("Append(%+v) error = %v", event, err)
+		}
+	}
+	if err := journal.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	got, err := loadS0FSHandleState(path, "vol-1")
+	if err != nil {
+		t.Fatalf("loadS0FSHandleState() error = %v", err)
+	}
+	want := volume.HandleState{
+		NextHandleID: 3,
+		FileHandles:  map[uint64]uint64{3: 20},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("loadS0FSHandleState() = %#v, want %#v", got, want)
+	}
+}
+
+func TestLoadS0FSHandleStateIgnoresPartialTrailingJournalEvent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "handles.json")
+	if err := persistS0FSHandleState(path, "vol-1", volume.HandleState{}); err != nil {
+		t.Fatalf("persistS0FSHandleState() error = %v", err)
+	}
+	payload := strings.Join([]string{
+		`{"version":1,"volume_id":"vol-1","operation":"open","handle_id":1,"inode":10}`,
+		`{"version":1,"volume_id":"vol-1","operation":"open"`,
+	}, "\n")
+	if err := os.WriteFile(s0fsHandleJournalPath(path), []byte(payload), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	got, err := loadS0FSHandleState(path, "vol-1")
+	if err != nil {
+		t.Fatalf("loadS0FSHandleState() error = %v", err)
+	}
+	if got.NextHandleID != 1 || !reflect.DeepEqual(got.FileHandles, map[uint64]uint64{1: 10}) {
+		t.Fatalf("loadS0FSHandleState() = %#v, want first complete event only", got)
+	}
+}
+
+func TestCompactS0FSHandleStateResetsJournal(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "handles.json")
+	journal, err := openS0FSHandleStateJournal(path)
+	if err != nil {
+		t.Fatalf("openS0FSHandleStateJournal() error = %v", err)
+	}
+	if err := journal.Append(s0fsHandleJournalEvent{
+		Version: 1, VolumeID: "vol-1", Operation: "open", HandleID: 1, Inode: 10,
+	}); err != nil {
+		t.Fatalf("Append() error = %v", err)
+	}
+	want := volume.HandleState{NextHandleID: 2, FileHandles: map[uint64]uint64{2: 20}}
+	if err := compactS0FSHandleState(path, "vol-1", want, false, journal); err != nil {
+		t.Fatalf("compactS0FSHandleState() error = %v", err)
+	}
+	if journal.events != 0 {
+		t.Fatalf("journal event count = %d, want 0", journal.events)
+	}
+	info, err := os.Stat(s0fsHandleJournalPath(path))
+	if err != nil {
+		t.Fatalf("Stat(journal) error = %v", err)
+	}
+	if info.Size() != 0 {
+		t.Fatalf("journal size = %d, want 0", info.Size())
+	}
+	got, err := loadS0FSHandleState(path, "vol-1")
+	if err != nil {
+		t.Fatalf("loadS0FSHandleState() error = %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("loadS0FSHandleState() = %#v, want %#v", got, want)
+	}
+	if err := journal.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+}
+
+func TestLoadS0FSHandleStateReplaysPreCompactionJournalIdempotently(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "handles.json")
+	final := volume.HandleState{
+		NextHandleID: 2,
+		FileHandles:  map[uint64]uint64{2: 20},
+	}
+	if err := persistS0FSHandleState(path, "vol-1", final); err != nil {
+		t.Fatalf("persistS0FSHandleState() error = %v", err)
+	}
+	journal, err := openS0FSHandleStateJournal(path)
+	if err != nil {
+		t.Fatalf("openS0FSHandleStateJournal() error = %v", err)
+	}
+	for _, event := range []s0fsHandleJournalEvent{
+		{Version: 1, VolumeID: "vol-1", Operation: "open", HandleID: 1, Inode: 10},
+		{Version: 1, VolumeID: "vol-1", Operation: "close", HandleID: 1},
+		{Version: 1, VolumeID: "vol-1", Operation: "open", HandleID: 2, Inode: 20},
+	} {
+		if err := journal.Append(event); err != nil {
+			t.Fatalf("Append(%+v) error = %v", event, err)
+		}
+	}
+	if err := journal.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	got, err := loadS0FSHandleState(path, "vol-1")
+	if err != nil {
+		t.Fatalf("loadS0FSHandleState() error = %v", err)
+	}
+	if !reflect.DeepEqual(got, final) {
+		t.Fatalf("loadS0FSHandleState() = %#v, want %#v", got, final)
+	}
 }
 
 func BenchmarkPersistS0FSHandleState(b *testing.B) {
-	handles := volume.HandleState{
-		NextHandleID: 64,
-		FileHandles:  make(map[uint64]uint64, 32),
-		DirHandles:   make(map[uint64]uint64, 32),
-	}
-	for handle := uint64(1); handle <= 32; handle++ {
-		handles.FileHandles[handle] = 1000 + handle
-		handles.DirHandles[handle+32] = 2000 + handle
-	}
-
-	benchmarks := []struct {
-		name    string
-		persist func(string, string, volume.HandleState) error
-	}{
-		{name: "Durable", persist: persistS0FSHandleState},
-		{name: "ProcessLocal", persist: persistProcessLocalS0FSHandleState},
-	}
-	for _, benchmark := range benchmarks {
-		b.Run(benchmark.name, func(b *testing.B) {
+	for _, count := range []int{64, 1024, 10_000} {
+		handles := benchmarkS0FSHandleState(count)
+		b.Run("Snapshot/"+strconv.Itoa(count), func(b *testing.B) {
 			path := filepath.Join(b.TempDir(), "handles.json")
 			b.ReportAllocs()
 			b.ResetTimer()
 			for range b.N {
-				if err := benchmark.persist(path, "vol-1", handles); err != nil {
+				if err := persistProcessLocalS0FSHandleState(path, "vol-1", handles); err != nil {
 					b.Fatal(err)
 				}
 			}
 		})
 	}
+	b.Run("JournalAppend", func(b *testing.B) {
+		path := filepath.Join(b.TempDir(), "handles.json")
+		journal, err := openS0FSHandleStateJournal(path)
+		if err != nil {
+			b.Fatal(err)
+		}
+		defer journal.Close()
+		b.ReportAllocs()
+		b.ResetTimer()
+		for index := range b.N {
+			handleID := uint64(index + 1)
+			if err := journal.Append(s0fsHandleJournalEvent{
+				Version: 1, VolumeID: "vol-1", Operation: "open", HandleID: handleID, Inode: handleID + 1000,
+			}); err != nil {
+				b.Fatal(err)
+			}
+			if journal.ShouldCompact() {
+				if err := journal.Reset(); err != nil {
+					b.Fatal(err)
+				}
+			}
+		}
+	})
+}
+
+func benchmarkS0FSHandleState(count int) volume.HandleState {
+	handles := volume.HandleState{
+		NextHandleID: uint64(count),
+		FileHandles:  make(map[uint64]uint64, count),
+	}
+	for handle := 1; handle <= count; handle++ {
+		handles.FileHandles[uint64(handle)] = uint64(1000 + handle)
+	}
+	return handles
 }

--- a/ctld/internal/ctld/portal/session.go
+++ b/ctld/internal/ctld/portal/session.go
@@ -2,6 +2,7 @@ package portal
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"slices"
@@ -309,6 +310,8 @@ type localSession struct {
 	statePath        string
 	stateMu          sync.Mutex
 	stateErr         error
+	recoveryJournal  *s0fsHandleStateJournal
+	incrementalReady func() bool
 }
 
 func newLocalSession(volumeID string, mgr *localVolumeManager, logger *logrus.Logger) *localSession {
@@ -329,10 +332,17 @@ func newLocalSession(volumeID string, mgr *localVolumeManager, logger *logrus.Lo
 	}
 }
 
-func (s *localSession) Close() { _ = s.persistDurableRecoveryState() }
+func (s *localSession) Close() {
+	_ = s.persistDurableRecoveryState()
+	_ = s.closeRecoveryJournal()
+}
 
 func (s *localSession) Handoff() error {
-	return s.persistDurableRecoveryState()
+	if err := s.persistDurableRecoveryState(); err != nil {
+		_ = s.closeRecoveryJournal()
+		return err
+	}
+	return s.closeRecoveryJournal()
 }
 
 func (s *localSession) RecoveryError() error {
@@ -356,22 +366,95 @@ func (s *localSession) persistRecoveryStateWithDurability(durable bool) error {
 	if s == nil || strings.TrimSpace(s.statePath) == "" || s.mgr == nil {
 		return nil
 	}
+	s.stateMu.Lock()
+	defer s.stateMu.Unlock()
+	return s.persistRecoveryStateLocked(durable)
+}
+
+func (s *localSession) persistRecoveryStateLocked(durable bool) error {
 	volCtx, err := s.mgr.GetVolume(s.volumeID)
 	if err != nil {
-		s.stateMu.Lock()
 		s.stateErr = err
-		s.stateMu.Unlock()
 		return err
+	}
+	handles := volCtx.SnapshotHandleState()
+	err = compactS0FSHandleState(s.statePath, s.volumeID, handles, durable, s.recoveryJournal)
+	s.stateErr = err
+	return err
+}
+
+func (s *localSession) persistFileHandleOpen(handleID, inode uint64) error {
+	if handleID == 0 {
+		return nil
+	}
+	return s.persistFileHandleEvent(s0fsHandleJournalEvent{
+		Version:   s0fsHandleJournalVersion,
+		VolumeID:  s.volumeID,
+		Operation: s0fsHandleJournalOperationOpen,
+		HandleID:  handleID,
+		Inode:     inode,
+	})
+}
+
+func (s *localSession) persistFileHandleClose(handleID uint64) error {
+	if handleID == 0 {
+		return nil
+	}
+	return s.persistFileHandleEvent(s0fsHandleJournalEvent{
+		Version:   s0fsHandleJournalVersion,
+		VolumeID:  s.volumeID,
+		Operation: s0fsHandleJournalOperationClose,
+		HandleID:  handleID,
+	})
+}
+
+func (s *localSession) persistFileHandleEvent(event s0fsHandleJournalEvent) error {
+	if s == nil || strings.TrimSpace(s.statePath) == "" || s.mgr == nil {
+		return nil
 	}
 	s.stateMu.Lock()
 	defer s.stateMu.Unlock()
-	handles := volCtx.SnapshotHandleState()
-	if durable {
-		err = persistS0FSHandleState(s.statePath, s.volumeID, handles)
-	} else {
-		err = persistProcessLocalS0FSHandleState(s.statePath, s.volumeID, handles)
+	if s.incrementalReady != nil && !s.incrementalReady() {
+		return s.persistRecoveryStateLocked(false)
 	}
-	s.stateErr = err
+	if s.recoveryJournal == nil {
+		journal, err := openS0FSHandleStateJournal(s.statePath)
+		if err != nil {
+			s.stateErr = err
+			return err
+		}
+		s.recoveryJournal = journal
+	}
+	if err := s.recoveryJournal.Append(event); err != nil {
+		appendErr := err
+		if snapshotErr := s.persistRecoveryStateLocked(false); snapshotErr != nil {
+			s.stateErr = errors.Join(appendErr, snapshotErr)
+			return s.stateErr
+		}
+		s.stateErr = nil
+		return nil
+	}
+	if s.recoveryJournal.ShouldCompact() {
+		return s.persistRecoveryStateLocked(false)
+	}
+	s.stateErr = nil
+	return nil
+}
+
+func (s *localSession) closeRecoveryJournal() error {
+	if s == nil {
+		return nil
+	}
+	s.stateMu.Lock()
+	defer s.stateMu.Unlock()
+	if s.recoveryJournal == nil {
+		return nil
+	}
+	err := s.recoveryJournal.Close()
+	s.recoveryJournal = nil
+	if err != nil {
+		s.stateErr = err
+	}
 	return err
 }
 
@@ -453,7 +536,7 @@ func (s *localSession) Create(ctx context.Context, req *pb.CreateRequest) (*pb.N
 	if err != nil {
 		return nil, err
 	}
-	if err := s.persistRecoveryState(); err != nil {
+	if err := s.persistFileHandleOpen(resp.HandleId, resp.Inode); err != nil {
 		return nil, err
 	}
 	return resp, nil
@@ -541,7 +624,7 @@ func (s *localSession) Open(ctx context.Context, req *pb.OpenRequest) (*pb.OpenR
 			s.trackReadOnlyHandle(req.VolumeId, resp.HandleId)
 		}
 	}
-	if err := s.persistRecoveryState(); err != nil {
+	if err := s.persistFileHandleOpen(resp.HandleId, req.Inode); err != nil {
 		return nil, err
 	}
 	return resp, nil
@@ -618,7 +701,7 @@ func (s *localSession) Release(ctx context.Context, req *pb.ReleaseRequest) (*pb
 				s.evictReadCache(volCtx, inode)
 				_ = volCtx.S0FS.Forget(inode)
 			}
-			if err := s.persistRecoveryState(); err != nil {
+			if err := s.persistFileHandleClose(req.HandleId); err != nil {
 				return nil, err
 			}
 			return &pb.Empty{}, nil
@@ -628,7 +711,7 @@ func (s *localSession) Release(ctx context.Context, req *pb.ReleaseRequest) (*pb
 	if err != nil {
 		return nil, err
 	}
-	if err := s.persistRecoveryState(); err != nil {
+	if err := s.persistFileHandleClose(req.HandleId); err != nil {
 		return nil, err
 	}
 	return resp, nil
@@ -687,9 +770,6 @@ func (s *localSession) OpenDir(ctx context.Context, req *pb.OpenDirRequest) (*pb
 	if err != nil {
 		return nil, err
 	}
-	if err := s.persistRecoveryState(); err != nil {
-		return nil, err
-	}
 	return resp, nil
 }
 func (s *localSession) ReadDir(ctx context.Context, req *pb.ReadDirRequest) (*pb.ReadDirResponse, error) {
@@ -700,9 +780,6 @@ func (s *localSession) ReleaseDir(ctx context.Context, req *pb.ReleaseDirRequest
 	s.fix(&req.VolumeId)
 	resp, err := s.fs.ReleaseDir(s.ctx(ctx), req)
 	if err != nil {
-		return nil, err
-	}
-	if err := s.persistRecoveryState(); err != nil {
 		return nil, err
 	}
 	return resp, nil

--- a/ctld/internal/ctld/portal/session_test.go
+++ b/ctld/internal/ctld/portal/session_test.go
@@ -790,6 +790,117 @@ func TestLocalSessionRestoresOpenUnlinkedS0FSHandle(t *testing.T) {
 	}
 }
 
+func TestLocalSessionPersistsFileHandlesIncrementallyAndSkipsDirectories(t *testing.T) {
+	engine, err := s0fs.Open(context.Background(), s0fs.Config{
+		VolumeID: "vol-1",
+		WALPath:  filepath.Join(t.TempDir(), "engine.wal"),
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer engine.Close()
+	node, err := engine.CreateFile(s0fs.RootInode, "file.txt", 0o644)
+	if err != nil {
+		t.Fatalf("CreateFile() error = %v", err)
+	}
+	mgr := newLocalVolumeManager()
+	mgr.add(&volume.VolumeContext{
+		VolumeID: "vol-1", TeamID: "team-a", Backend: volume.BackendS0FS,
+		S0FS: engine, Access: volume.AccessModeRWO, RootInode: fsmeta.Ino(s0fs.RootInode), RootPath: "/",
+	})
+	session := newLocalSession("vol-1", mgr, nil)
+	session.statePath = filepath.Join(t.TempDir(), "handles.json")
+	defer session.Close()
+
+	opened, err := session.Open(context.Background(), &pb.OpenRequest{Inode: node.Inode})
+	if err != nil {
+		t.Fatalf("Open(file) error = %v", err)
+	}
+	if _, err := os.Stat(session.statePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("snapshot Stat() error = %v, want not exist before compaction", err)
+	}
+	journalInfo, err := os.Stat(s0fsHandleJournalPath(session.statePath))
+	if err != nil {
+		t.Fatalf("journal Stat() error = %v", err)
+	}
+	state, err := loadS0FSHandleState(session.statePath, "vol-1")
+	if err != nil {
+		t.Fatalf("loadS0FSHandleState() error = %v", err)
+	}
+	if got := state.FileHandles[opened.HandleId]; got != node.Inode {
+		t.Fatalf("replayed handle inode = %d, want %d", got, node.Inode)
+	}
+
+	dir, err := session.OpenDir(context.Background(), &pb.OpenDirRequest{Inode: s0fs.RootInode})
+	if err != nil {
+		t.Fatalf("OpenDir() error = %v", err)
+	}
+	if _, err := session.ReleaseDir(context.Background(), &pb.ReleaseDirRequest{
+		Inode: s0fs.RootInode, HandleId: dir.HandleId,
+	}); err != nil {
+		t.Fatalf("ReleaseDir() error = %v", err)
+	}
+	afterDirInfo, err := os.Stat(s0fsHandleJournalPath(session.statePath))
+	if err != nil {
+		t.Fatalf("journal Stat(after directory operations) error = %v", err)
+	}
+	if afterDirInfo.Size() != journalInfo.Size() {
+		t.Fatalf("journal size after directory operations = %d, want %d", afterDirInfo.Size(), journalInfo.Size())
+	}
+
+	if _, err := session.Release(context.Background(), &pb.ReleaseRequest{
+		Inode: node.Inode, HandleId: opened.HandleId,
+	}); err != nil {
+		t.Fatalf("Release(file) error = %v", err)
+	}
+	state, err = loadS0FSHandleState(session.statePath, "vol-1")
+	if err != nil {
+		t.Fatalf("loadS0FSHandleState(after release) error = %v", err)
+	}
+	if len(state.FileHandles) != 0 {
+		t.Fatalf("replayed file handles after release = %#v, want empty", state.FileHandles)
+	}
+}
+
+func TestLocalSessionFallsBackToSnapshotForLegacyStandby(t *testing.T) {
+	engine, err := s0fs.Open(context.Background(), s0fs.Config{
+		VolumeID: "vol-1",
+		WALPath:  filepath.Join(t.TempDir(), "engine.wal"),
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer engine.Close()
+	node, err := engine.CreateFile(s0fs.RootInode, "file.txt", 0o644)
+	if err != nil {
+		t.Fatalf("CreateFile() error = %v", err)
+	}
+	mgr := newLocalVolumeManager()
+	mgr.add(&volume.VolumeContext{
+		VolumeID: "vol-1", TeamID: "team-a", Backend: volume.BackendS0FS,
+		S0FS: engine, Access: volume.AccessModeRWO, RootInode: fsmeta.Ino(s0fs.RootInode), RootPath: "/",
+	})
+	session := newLocalSession("vol-1", mgr, nil)
+	session.statePath = filepath.Join(t.TempDir(), "handles.json")
+	session.incrementalReady = func() bool { return false }
+	defer session.Close()
+
+	opened, err := session.Open(context.Background(), &pb.OpenRequest{Inode: node.Inode})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	state, err := loadS0FSHandleSnapshot(session.statePath, "vol-1")
+	if err != nil {
+		t.Fatalf("loadS0FSHandleSnapshot() error = %v", err)
+	}
+	if got := state.FileHandles[opened.HandleId]; got != node.Inode {
+		t.Fatalf("snapshot handle inode = %d, want %d", got, node.Inode)
+	}
+	if _, err := os.Stat(s0fsHandleJournalPath(session.statePath)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("legacy fallback journal Stat() error = %v, want not exist", err)
+	}
+}
+
 func TestLocalSessionRestoresOpenUnlinkedS0FSHandleAfterProcessKill(t *testing.T) {
 	dir := t.TempDir()
 	cmd := exec.Command(os.Args[0], "-test.run=^TestLocalSessionS0FSProcessKillHelper$")
@@ -809,8 +920,8 @@ func TestLocalSessionRestoresOpenUnlinkedS0FSHandleAfterProcessKill(t *testing.T
 	if err != nil {
 		t.Fatalf("loadS0FSHandleState() error = %v", err)
 	}
-	if len(handleState.FileHandles) != 2 || len(handleState.UnlinkedFiles) != 1 {
-		t.Fatalf("recovered handle state = %#v, want two handles for one open-unlinked file", handleState)
+	if len(handleState.FileHandles) != 1 || len(handleState.UnlinkedFiles) != 1 {
+		t.Fatalf("recovered handle state = %#v, want one journal-replayed handle for an open-unlinked file", handleState)
 	}
 	handleIDs := make([]uint64, 0, len(handleState.FileHandles))
 	var inode uint64
@@ -854,14 +965,6 @@ func TestLocalSessionRestoresOpenUnlinkedS0FSHandleAfterProcessKill(t *testing.T
 	}
 	if _, err := session.Release(context.Background(), &pb.ReleaseRequest{
 		Inode: inode, HandleId: handleIDs[0],
-	}); err != nil {
-		t.Fatalf("Release(first recovered handle) error = %v", err)
-	}
-	if _, err := engine.GetAttr(inode); err != nil {
-		t.Fatalf("GetAttr(after first release) error = %v, want retained inode", err)
-	}
-	if _, err := session.Release(context.Background(), &pb.ReleaseRequest{
-		Inode: inode, HandleId: handleIDs[1],
 	}); err != nil {
 		t.Fatalf("Release(final recovered handle) error = %v", err)
 	}
@@ -910,6 +1013,11 @@ func TestLocalSessionS0FSProcessKillHelper(t *testing.T) {
 		Parent: s0fs.RootInode, Name: "transient.txt",
 	}); err != nil {
 		t.Fatalf("Unlink(transient.txt) error = %v", err)
+	}
+	if _, err := session.Release(context.Background(), &pb.ReleaseRequest{
+		Inode: created.Inode, HandleId: created.HandleId,
+	}); err != nil {
+		t.Fatalf("Release(first handle) error = %v", err)
 	}
 	if err := syscall.Kill(os.Getpid(), syscall.SIGKILL); err != nil {
 		t.Fatalf("Kill(self) error = %v", err)

--- a/storage-proxy/pkg/fsserver/server.go
+++ b/storage-proxy/pkg/fsserver/server.go
@@ -743,7 +743,6 @@ func (s *FileSystemServer) ReleaseDir(ctx context.Context, req *pb.ReleaseDirReq
 		return nil, err
 	}
 	if isS0FSVolume(volCtx) {
-		_, _, _ = volCtx.ReleaseHandle(req.HandleId)
 		return &pb.Empty{}, nil
 	}
 

--- a/storage-proxy/pkg/volume/backend.go
+++ b/storage-proxy/pkg/volume/backend.go
@@ -31,8 +31,10 @@ type StorageObserver interface {
 }
 
 type HandleState struct {
-	NextHandleID  uint64            `json:"next_handle_id"`
-	FileHandles   map[uint64]uint64 `json:"file_handles,omitempty"`
+	NextHandleID uint64            `json:"next_handle_id"`
+	FileHandles  map[uint64]uint64 `json:"file_handles,omitempty"`
+	// DirHandles is accepted when loading legacy recovery snapshots. Directory
+	// operations use the request inode and do not need handle recovery.
 	DirHandles    map[uint64]uint64 `json:"dir_handles,omitempty"`
 	UnlinkedFiles []uint64          `json:"unlinked_files,omitempty"`
 }
@@ -78,31 +80,11 @@ func (v *VolumeContext) OpenFileHandle(inode uint64) uint64 {
 	return v.nextHandleID
 }
 
-func (v *VolumeContext) OpenDirHandle(inode uint64) uint64 {
+func (v *VolumeContext) OpenDirHandle(uint64) uint64 {
 	v.handleMu.Lock()
 	defer v.handleMu.Unlock()
 	v.nextHandleID++
-	if v.dirHandleIDs == nil {
-		v.dirHandleIDs = make(map[uint64]uint64)
-	}
-	v.dirHandleIDs[v.nextHandleID] = inode
 	return v.nextHandleID
-}
-
-func (v *VolumeContext) ReleaseHandle(handleID uint64) (uint64, int, bool) {
-	v.handleMu.Lock()
-	defer v.handleMu.Unlock()
-	inode, ok := v.fileHandles[handleID]
-	if ok {
-		if v.openFileCount[inode] > 1 {
-			v.openFileCount[inode]--
-		} else {
-			delete(v.openFileCount, inode)
-		}
-	}
-	delete(v.fileHandles, handleID)
-	delete(v.dirHandleIDs, handleID)
-	return inode, v.openFileCount[inode], ok
 }
 
 func (v *VolumeContext) MarkUnlinkedFileIfOpen(inode uint64) bool {
@@ -160,13 +142,9 @@ func (v *VolumeContext) SnapshotHandleState() HandleState {
 	state := HandleState{
 		NextHandleID: v.nextHandleID,
 		FileHandles:  make(map[uint64]uint64, len(v.fileHandles)),
-		DirHandles:   make(map[uint64]uint64, len(v.dirHandleIDs)),
 	}
 	for handle, inode := range v.fileHandles {
 		state.FileHandles[handle] = inode
-	}
-	for handle, inode := range v.dirHandleIDs {
-		state.DirHandles[handle] = inode
 	}
 	for inode := range v.unlinkedFiles {
 		state.UnlinkedFiles = append(state.UnlinkedFiles, inode)
@@ -182,15 +160,19 @@ func (v *VolumeContext) RestoreHandleState(state HandleState) {
 	defer v.handleMu.Unlock()
 	v.nextHandleID = state.NextHandleID
 	v.fileHandles = make(map[uint64]uint64, len(state.FileHandles))
-	v.dirHandleIDs = make(map[uint64]uint64, len(state.DirHandles))
 	v.openFileCount = make(map[uint64]int)
 	v.unlinkedFiles = make(map[uint64]struct{}, len(state.UnlinkedFiles))
 	for handle, inode := range state.FileHandles {
 		v.fileHandles[handle] = inode
 		v.openFileCount[inode]++
+		if handle > v.nextHandleID {
+			v.nextHandleID = handle
+		}
 	}
-	for handle, inode := range state.DirHandles {
-		v.dirHandleIDs[handle] = inode
+	for handle := range state.DirHandles {
+		if handle > v.nextHandleID {
+			v.nextHandleID = handle
+		}
 	}
 	for _, inode := range state.UnlinkedFiles {
 		v.unlinkedFiles[inode] = struct{}{}

--- a/storage-proxy/pkg/volume/backend_test.go
+++ b/storage-proxy/pkg/volume/backend_test.go
@@ -194,3 +194,36 @@ func TestVolumeContextMarkUnlinkedFileIfOpenReturnsFalseForClosedInode(t *testin
 		t.Fatal("MarkUnlinkedFileIfOpen() after release = true, want false")
 	}
 }
+
+func TestVolumeContextDirectoryHandlesAreStateless(t *testing.T) {
+	volCtx := &VolumeContext{}
+	fileHandle := volCtx.OpenFileHandle(10)
+	dirHandle := volCtx.OpenDirHandle(20)
+	if dirHandle <= fileHandle {
+		t.Fatalf("directory handle = %d, want greater than file handle %d", dirHandle, fileHandle)
+	}
+	state := volCtx.SnapshotHandleState()
+	if len(state.DirHandles) != 0 {
+		t.Fatalf("SnapshotHandleState().DirHandles = %#v, want empty", state.DirHandles)
+	}
+	if state.NextHandleID != dirHandle {
+		t.Fatalf("SnapshotHandleState().NextHandleID = %d, want %d", state.NextHandleID, dirHandle)
+	}
+
+	restored := &VolumeContext{}
+	restored.RestoreHandleState(HandleState{
+		NextHandleID: 1,
+		FileHandles:  map[uint64]uint64{5: 50},
+		DirHandles:   map[uint64]uint64{9: 90},
+	})
+	if next := restored.OpenDirHandle(100); next != 10 {
+		t.Fatalf("OpenDirHandle() after legacy restore = %d, want 10", next)
+	}
+	restoredState := restored.SnapshotHandleState()
+	if len(restoredState.DirHandles) != 0 {
+		t.Fatalf("restored DirHandles = %#v, want empty", restoredState.DirHandles)
+	}
+	if got := restoredState.FileHandles[5]; got != 50 {
+		t.Fatalf("restored file handle inode = %d, want 50", got)
+	}
+}

--- a/storage-proxy/pkg/volume/manager.go
+++ b/storage-proxy/pkg/volume/manager.go
@@ -38,7 +38,6 @@ type VolumeContext struct {
 	handleMu      sync.Mutex
 	nextHandleID  uint64
 	fileHandles   map[uint64]uint64
-	dirHandleIDs  map[uint64]uint64
 	openFileCount map[uint64]int
 	unlinkedFiles map[uint64]struct{}
 


### PR DESCRIPTION
## Summary

- stop retaining, restoring, and persisting S0FS directory handles because directory operations use the request inode
- replace full handle-map rewrites on every file open/release with constant-size JSONL recovery events
- compact the journal periodically, on unlink, and on graceful close/handoff while preserving open-unlinked inode recovery
- negotiate journal replay support before standby synchronization and fall back to legacy snapshots during mixed-version rollouts

## Why

A production high-density node showed one active `ctld` consuming about 1.1 cores. Its S0FS recovery state contained 1,035 file handles and 8,411 directory handles while the workload allocated 122.7 handles/s. `ctld` rewrote the complete state about 228 times/s, and profiles attributed roughly 80% of its CPU to state copying and JSON encoding.

Directory handle state was not read by `ReadDir`; file handles must remain recoverable for open-unlinked files and open counts across same-node failover.

## Microbenchmark

Linux arm64, process-local recovery path, `-benchtime=2s -count=3`:

| Path | Time/op | Bytes/op | Allocs/op |
|---|---:|---:|---:|
| snapshot, 64 handles | 443-486 us | 5.8 KiB | 146 |
| snapshot, 1,024 handles | 837-889 us | 78.8 KiB | 2,991 |
| snapshot, 10,000 handles | 5.94-6.25 ms | 768-777 KiB | 29,919-29,920 |
| journal append | 1.90-2.17 us | 160 B | 2 |

The journal benchmark includes periodic truncation every 4,096 events.

## Correctness

- recovery events are appended before the FUSE operation returns; this does not use an asynchronous debounce
- snapshots are replaced before journal truncation, and replay is idempotent if the process dies between those steps
- graceful handoff syncs a compacted snapshot
- the final release of an open-unlinked inode removes it during live operation and journal replay
- legacy `dir_handles` snapshots remain readable but are normalized away
- a capability ping runs before any portal channel is sent to a standby; legacy standbys receive a current compacted snapshot

## Validation

- `go test ./ctld/...`
- `go test ./storage-proxy/...`
- `go test -race ./ctld/internal/ctld/portal`
- `go test -race ./ctld/internal/ctld/ha`
- `go test -race ./storage-proxy/pkg/volume ./storage-proxy/pkg/fsserver`
- `go vet ./ctld/... ./storage-proxy/...`
- process-kill recovery test covering a journaled release of an open-unlinked file

All required PR checks are green, including core, S0FS POSIX, mountpoint-S3, and all network E2E matrices.

## Remote kind validation

Validated on the persistent Aliyun Singapore ECS kind environment against baseline `24a4619d`, then rolled standby-first to this PR while keeping the same sandbox process and RWO S0FS volume live.

Workload state at baseline:

- 1,004 file handles
- 8,503 directory handles
- one open-unlinked inode
- 118,558-byte recovery snapshot
- 50 completed file open/close cycles per second

Thirty-second container cgroup samples:

| Variant | Active ctld | Standby ctld | Worker node | Completed cycles |
|---|---:|---:|---:|---:|
| baseline | 384m | 9m | 484m | 1,550 |
| PR | 82m | 8m | 177m | 1,500 |
| PR, crossing one 4,096-event compaction | 83m | 8m | 178m | 1,500 |

The compaction-inclusive comparison reduces active ctld CPU by about 78% and worker-node CPU by about 63%, at the same requested throughput. The PR snapshot was 10,199 bytes, omitted `dir_handles`, and open/close traffic appeared only as constant-size journal records.

Two active ctld pods were then force-deleted with zero grace. The peer promoted and the replacement rejoined as standby both times. One-second workload heartbeats remained continuous; reads through two open descriptors for an unlinked file and `listdir` through a directory descriptor opened before failover all stayed successful.