### PR TITLE
Replace Redis claim start lock with atomic admission

### DIFF
--- a/infra-operator/api/config/manager.go
+++ b/infra-operator/api/config/manager.go
@@ -57,7 +57,7 @@ type ManagerConfig struct {
 	// +kubebuilder:default=2
 	DatabaseMinConns int32 `yaml:"database_min_conns" json:"databaseMinConns"`
 
-	// RedisURL configures the Redis backend used for manager-wide admission locks.
+	// RedisURL configures the Redis backend used for manager-wide admission state.
 	// When empty, manager falls back to PostgreSQL advisory locks.
 	// +optional
 	RedisURL string `yaml:"redis_url" json:"-"`
@@ -312,9 +312,13 @@ type SandboxPodPlacementConfig struct {
 
 // ClaimStartLimiterConfig defines cluster-wide start admission limits.
 type ClaimStartLimiterConfig struct {
-	PerSandboxNode int32           `yaml:"per_sandbox_node" json:"-"`
-	MaxLimit       int32           `yaml:"max_limit" json:"-"`
-	LockTTL        metav1.Duration `yaml:"lock_ttl" json:"-"`
+	PerSandboxNode int32 `yaml:"per_sandbox_node" json:"-"`
+	MaxLimit       int32 `yaml:"max_limit" json:"-"`
+	// LockTTL is retained for backward-compatible config decoding and is ignored.
+	// Deprecated: Redis admission no longer uses a distributed lock.
+	LockTTL metav1.Duration `yaml:"lock_ttl" json:"-"`
+	// AcquireTimeout is retained for backward-compatible config decoding and is ignored.
+	// Deprecated: Redis admission no longer polls for a distributed lock.
 	AcquireTimeout metav1.Duration `yaml:"acquire_timeout" json:"-"`
 }
 
@@ -552,12 +556,6 @@ func applyClaimStartLimiterDefaults(cfg *ManagerConfig) {
 	}
 	if cfg.ClaimStartLimiter.MaxLimit <= 0 {
 		cfg.ClaimStartLimiter.MaxLimit = 80
-	}
-	if cfg.ClaimStartLimiter.LockTTL.Duration == 0 {
-		cfg.ClaimStartLimiter.LockTTL = metav1.Duration{Duration: 5 * time.Second}
-	}
-	if cfg.ClaimStartLimiter.AcquireTimeout.Duration == 0 {
-		cfg.ClaimStartLimiter.AcquireTimeout = metav1.Duration{Duration: 250 * time.Millisecond}
 	}
 }
 

--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -243,6 +243,7 @@ func main() {
 		K8sClient:        k8sClient,
 		NodeLister:       nodeLister,
 		PodLister:        podLister,
+		PodIndexer:       podInformer.Informer().GetIndexer(),
 		ReplicaSetLister: replicaSetLister,
 		PGPool:           pool,
 		Redis: rediscache.Config{

--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -253,8 +253,6 @@ func main() {
 		},
 		PerSandboxNode:      cfg.ClaimStartLimiter.PerSandboxNode,
 		MaxLimit:            cfg.ClaimStartLimiter.MaxLimit,
-		LockTTL:             cfg.ClaimStartLimiter.LockTTL.Duration,
-		AcquireTimeout:      cfg.ClaimStartLimiter.AcquireTimeout.Duration,
 		SandboxNodeSelector: cfg.SandboxPodPlacement.NodeSelector,
 		SandboxTolerations:  cfg.SandboxPodPlacement.Tolerations,
 		Logger:              logger,

--- a/manager/pkg/startlimiter/limiter.go
+++ b/manager/pkg/startlimiter/limiter.go
@@ -49,6 +49,7 @@ const (
 var redisReservationScript = redis.NewScript(`
 local reservation_key = KEYS[1]
 local units_key = KEYS[2]
+local metadata_key = KEYS[3]
 
 local now_ms = tonumber(ARGV[1])
 local expires_at_ms = tonumber(ARGV[2])
@@ -64,25 +65,51 @@ if #expired > 0 then
   redis.call("HDEL", units_key, unpack(expired))
 end
 
-local reserved_units = 0
-local active = redis.call("ZRANGE", reservation_key, 0, -1)
-for _, token in ipairs(active) do
-  local units = tonumber(redis.call("HGET", units_key, token))
-  if units == nil or units <= 0 then
-    units = 1
+local active_count = redis.call("ZCARD", reservation_key)
+local metadata = redis.call("HMGET", metadata_key, "count", "units")
+local metadata_count = tonumber(metadata[1])
+local reserved_units = tonumber(metadata[2])
+if #expired > 0 or metadata_count == nil or reserved_units == nil or metadata_count ~= active_count then
+  reserved_units = 0
+  local active = redis.call("ZRANGE", reservation_key, 0, -1)
+  if #active > 0 then
+    local active_units = redis.call("HMGET", units_key, unpack(active))
+    for _, value in ipairs(active_units) do
+      local units = tonumber(value)
+      if units == nil or units <= 0 then
+        units = 1
+      end
+      reserved_units = reserved_units + units
+    end
   end
-  reserved_units = reserved_units + units
+  if active_count > 0 then
+    redis.call("HSET", metadata_key, "count", active_count, "units", reserved_units)
+    redis.call("PEXPIRE", metadata_key, ttl_ms)
+  else
+    redis.call("DEL", metadata_key)
+  end
 end
 
 local overlap_units = 0
 local seen = {}
+local overlap_tokens = {}
 for index = 8, #ARGV do
   local token = ARGV[index]
   if token ~= "" and seen[token] == nil then
     seen[token] = true
-    local score = tonumber(redis.call("ZSCORE", reservation_key, token))
-    if score ~= nil and score > now_ms then
-      local units = tonumber(redis.call("HGET", units_key, token))
+    table.insert(overlap_tokens, token)
+  end
+end
+if #overlap_tokens > 0 then
+  local active_tokens = redis.call("ZRANGE", reservation_key, 0, -1)
+  local active = {}
+  for _, token in ipairs(active_tokens) do
+    active[token] = true
+  end
+  local units_by_token = redis.call("HMGET", units_key, unpack(overlap_tokens))
+  for index, token in ipairs(overlap_tokens) do
+    if active[token] then
+      local units = tonumber(units_by_token[index])
       if units == nil or units <= 0 then
         units = 1
       end
@@ -107,11 +134,53 @@ if requested > available then
   return {0, in_flight, available}
 end
 
+if redis.call("ZSCORE", reservation_key, reservation_token) ~= false then
+  return redis.error_reply("claim start reservation token already exists")
+end
 redis.call("ZADD", reservation_key, expires_at_ms, reservation_token)
 redis.call("HSET", units_key, reservation_token, requested)
+redis.call("HSET", metadata_key, "count", active_count + 1, "units", reserved_units + requested)
 redis.call("PEXPIRE", reservation_key, ttl_ms)
 redis.call("PEXPIRE", units_key, ttl_ms)
+redis.call("PEXPIRE", metadata_key, ttl_ms)
 return {1, in_flight, available}
+`)
+
+var redisReservationReleaseScript = redis.NewScript(`
+local reservation_key = KEYS[1]
+local units_key = KEYS[2]
+local metadata_key = KEYS[3]
+local token = ARGV[1]
+
+local units = tonumber(redis.call("HGET", units_key, token))
+if units == nil or units <= 0 then
+  units = 1
+end
+local removed = redis.call("ZREM", reservation_key, token)
+redis.call("HDEL", units_key, token)
+if removed == 0 then
+  return 0
+end
+
+local active_count = redis.call("ZCARD", reservation_key)
+local metadata = redis.call("HMGET", metadata_key, "count", "units")
+local metadata_count = tonumber(metadata[1])
+local reserved_units = tonumber(metadata[2])
+if metadata_count == nil or reserved_units == nil or metadata_count ~= active_count + 1 then
+  redis.call("DEL", metadata_key)
+  return 1
+end
+
+if active_count == 0 then
+  redis.call("DEL", metadata_key)
+else
+  reserved_units = reserved_units - units
+  if reserved_units < 0 then
+    reserved_units = 0
+  end
+  redis.call("HSET", metadata_key, "count", active_count, "units", reserved_units)
+end
+return 1
 `)
 
 // Reason describes the caller reserving cluster start budget.
@@ -194,6 +263,7 @@ type Limiter struct {
 	lockResource        string
 	reservationKey      string
 	reservationUnitsKey string
+	reservationMetaKey  string
 	reservationTTL      time.Duration
 	perSandboxNode      int32
 	maxLimit            int32
@@ -285,6 +355,7 @@ func New(ctx context.Context, cfg Config) (*Limiter, error) {
 		keyPrefix := rediscache.JoinKeyPrefix(normalized.KeyPrefix, "manager", "claim-start", cfg.ClusterID)
 		limiter.reservationKey = rediscache.JoinKeyPrefix(keyPrefix, "reservations")
 		limiter.reservationUnitsKey = rediscache.JoinKeyPrefix(keyPrefix, "reservation-units")
+		limiter.reservationMetaKey = rediscache.JoinKeyPrefix(keyPrefix, "reservation-metadata")
 		limiter.reservationTTL = defaultReservationTTL
 	}
 
@@ -509,7 +580,7 @@ func (l *Limiter) runRedisAdmission(
 	result, err := redisReservationScript.Run(
 		opCtx,
 		l.redisClient,
-		[]string{l.reservationKey, l.reservationUnitsKey},
+		[]string{l.reservationKey, l.reservationUnitsKey, l.reservationMetaKey},
 		args...,
 	).Result()
 	if err != nil {
@@ -612,33 +683,16 @@ func (l *Limiter) releaseReservation(token string) {
 	if l == nil || l.redisClient == nil || token == "" {
 		return
 	}
-	if err := l.removeReservations(context.Background(), token); err != nil {
+	opCtx, cancel := rediscache.WithTimeout(context.Background(), l.redisTimeout)
+	defer cancel()
+	if err := redisReservationReleaseScript.Run(
+		opCtx,
+		l.redisClient,
+		[]string{l.reservationKey, l.reservationUnitsKey, l.reservationMetaKey},
+		token,
+	).Err(); err != nil {
 		l.logger.Warn("Failed to release claim start reservation", zap.String("token", token), zap.Error(err))
 	}
-}
-
-func (l *Limiter) removeReservations(ctx context.Context, tokens ...string) error {
-	if l == nil || l.redisClient == nil || len(tokens) == 0 {
-		return nil
-	}
-	args := make([]interface{}, 0, len(tokens))
-	for _, token := range tokens {
-		if token != "" {
-			args = append(args, token)
-		}
-	}
-	if len(args) == 0 {
-		return nil
-	}
-	opCtx, cancel := rediscache.WithTimeout(ctx, l.redisTimeout)
-	defer cancel()
-	pipe := l.redisClient.TxPipeline()
-	pipe.ZRem(opCtx, l.reservationKey, args...)
-	pipe.HDel(opCtx, l.reservationUnitsKey, tokens...)
-	if _, err := pipe.Exec(opCtx); err != nil {
-		return fmt.Errorf("remove claim start reservation: %w", err)
-	}
-	return nil
 }
 
 func (l *Limiter) limitForNodes(nodes int) int32 {

--- a/manager/pkg/startlimiter/limiter.go
+++ b/manager/pkg/startlimiter/limiter.go
@@ -32,7 +32,7 @@ const (
 	defaultMaxLimit       = int32(80)
 	defaultRetryAfter     = time.Second
 	defaultReservationTTL = 5 * time.Minute
-	redisScriptAttempts   = 2
+	redisScriptAttempts   = 3
 
 	labelTemplateID = "sandbox0.ai/template-id"
 	labelPoolType   = "sandbox0.ai/pool-type"

--- a/manager/pkg/startlimiter/limiter.go
+++ b/manager/pkg/startlimiter/limiter.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	appslisters "k8s.io/client-go/listers/apps/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
 )
 
 const (
@@ -31,9 +32,13 @@ const (
 	defaultMaxLimit       = int32(80)
 	defaultRetryAfter     = time.Second
 	defaultReservationTTL = 5 * time.Minute
+	redisScriptAttempts   = 2
 
 	labelTemplateID = "sandbox0.ai/template-id"
 	labelPoolType   = "sandbox0.ai/pool-type"
+
+	startPressurePodIndexName  = "claimStartPressure"
+	startPressurePodIndexValue = "candidate"
 
 	// AnnotationClaimStartReservation marks a pod whose start is covered by an
 	// active Redis reservation, so pressure snapshots do not double-count it.
@@ -130,12 +135,16 @@ end
 if requested <= 0 then
   return {1, in_flight, available}
 end
-if requested > available then
-  return {0, in_flight, available}
-end
 
 if redis.call("ZSCORE", reservation_key, reservation_token) ~= false then
-  return redis.error_reply("claim start reservation token already exists")
+  local existing_units = tonumber(redis.call("HGET", units_key, reservation_token))
+  if existing_units == nil or existing_units ~= requested then
+    return redis.error_reply("claim start reservation token units mismatch")
+  end
+  return {1, in_flight, available}
+end
+if requested > available then
+  return {0, in_flight, available}
 end
 redis.call("ZADD", reservation_key, expires_at_ms, reservation_token)
 redis.call("HSET", units_key, reservation_token, requested)
@@ -241,6 +250,7 @@ type Config struct {
 	K8sClient           kubernetes.Interface
 	NodeLister          corelisters.NodeLister
 	PodLister           corelisters.PodLister
+	PodIndexer          cache.Indexer
 	ReplicaSetLister    appslisters.ReplicaSetLister
 	PGPool              *pgxpool.Pool
 	Redis               rediscache.Config
@@ -255,6 +265,7 @@ type Limiter struct {
 	k8sClient           kubernetes.Interface
 	nodeLister          corelisters.NodeLister
 	podLister           corelisters.PodLister
+	podIndexer          cache.Indexer
 	replicaSetLister    appslisters.ReplicaSetLister
 	pgLocker            *pglock.Locker
 	redisClient         *redis.Client
@@ -324,11 +335,15 @@ func New(ctx context.Context, cfg Config) (*Limiter, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := ensureStartPressurePodIndex(cfg.PodIndexer); err != nil {
+		return nil, fmt.Errorf("configure claim start pressure pod index: %w", err)
+	}
 
 	limiter := &Limiter{
 		k8sClient:          cfg.K8sClient,
 		nodeLister:         cfg.NodeLister,
 		podLister:          cfg.PodLister,
+		podIndexer:         cfg.PodIndexer,
 		replicaSetLister:   cfg.ReplicaSetLister,
 		pgLocker:           pglock.New(cfg.PGPool),
 		backend:            BackendPostgres,
@@ -575,14 +590,7 @@ func (l *Limiter) runRedisAdmission(
 		args = append(args, reservationToken)
 	}
 
-	opCtx, cancel := rediscache.WithTimeout(ctx, l.redisTimeout)
-	defer cancel()
-	result, err := redisReservationScript.Run(
-		opCtx,
-		l.redisClient,
-		[]string{l.reservationKey, l.reservationUnitsKey, l.reservationMetaKey},
-		args...,
-	).Result()
+	result, err := l.runRedisReservationScript(ctx, redisReservationScript, args...)
 	if err != nil {
 		return false, nil, fmt.Errorf("run redis claim start admission: %w", err)
 	}
@@ -626,6 +634,46 @@ func redisResultInt64(value interface{}) (int64, error) {
 	}
 }
 
+func (l *Limiter) runRedisReservationScript(
+	ctx context.Context,
+	script *redis.Script,
+	args ...interface{},
+) (interface{}, error) {
+	// A timeout can happen after Redis committed the script. Admission and
+	// release scripts are idempotent so the same operation can be retried safely.
+	var (
+		result interface{}
+		err    error
+	)
+	for attempt := 0; attempt < redisScriptAttempts; attempt++ {
+		opCtx, cancel := rediscache.WithTimeout(ctx, l.redisTimeout)
+		result, err = script.Run(
+			opCtx,
+			l.redisClient,
+			[]string{l.reservationKey, l.reservationUnitsKey, l.reservationMetaKey},
+			args...,
+		).Result()
+		cancel()
+		if err == nil {
+			return result, nil
+		}
+		if attempt+1 >= redisScriptAttempts || ctx.Err() != nil || !redisTimeoutError(err) {
+			return nil, err
+		}
+	}
+	return nil, err
+}
+
+func redisTimeoutError(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var timeout interface {
+		Timeout() bool
+	}
+	return errors.As(err, &timeout) && timeout.Timeout()
+}
+
 func (l *Limiter) listNodes(ctx context.Context) ([]*corev1.Node, error) {
 	if l.nodeLister != nil {
 		return l.nodeLister.List(labels.Everything())
@@ -642,6 +690,21 @@ func (l *Limiter) listNodes(ctx context.Context) ([]*corev1.Node, error) {
 }
 
 func (l *Limiter) listPods(ctx context.Context) ([]*corev1.Pod, error) {
+	if l.podIndexer != nil {
+		items, err := l.podIndexer.ByIndex(startPressurePodIndexName, startPressurePodIndexValue)
+		if err != nil {
+			return nil, err
+		}
+		pods := make([]*corev1.Pod, 0, len(items))
+		for _, item := range items {
+			pod, ok := item.(*corev1.Pod)
+			if !ok {
+				return nil, fmt.Errorf("claim start pressure index contains %T, want *corev1.Pod", item)
+			}
+			pods = append(pods, pod)
+		}
+		return pods, nil
+	}
 	selector, err := labels.Parse(l.podSelector)
 	if err != nil {
 		return nil, err
@@ -683,14 +746,11 @@ func (l *Limiter) releaseReservation(token string) {
 	if l == nil || l.redisClient == nil || token == "" {
 		return
 	}
-	opCtx, cancel := rediscache.WithTimeout(context.Background(), l.redisTimeout)
-	defer cancel()
-	if err := redisReservationReleaseScript.Run(
-		opCtx,
-		l.redisClient,
-		[]string{l.reservationKey, l.reservationUnitsKey, l.reservationMetaKey},
+	if _, err := l.runRedisReservationScript(
+		context.Background(),
+		redisReservationReleaseScript,
 		token,
-	).Err(); err != nil {
+	); err != nil {
 		l.logger.Warn("Failed to release claim start reservation", zap.String("token", token), zap.Error(err))
 	}
 }
@@ -800,6 +860,37 @@ func podReady(pod *corev1.Pod) bool {
 	}
 	live := findPodCondition(pod.Status.Conditions, v1alpha1.SandboxPodLivenessConditionType)
 	return live == nil || live.Status != corev1.ConditionFalse
+}
+
+func ensureStartPressurePodIndex(indexer cache.Indexer) error {
+	if indexer == nil {
+		return nil
+	}
+	if _, exists := indexer.GetIndexers()[startPressurePodIndexName]; exists {
+		return nil
+	}
+	// Ready active sandboxes do not contribute start pressure and can dominate
+	// the pod cache on high-density nodes, so keep them out of the hot-path scan.
+	return indexer.AddIndexers(cache.Indexers{
+		startPressurePodIndexName: func(obj interface{}) ([]string, error) {
+			pod, ok := obj.(*corev1.Pod)
+			if !ok {
+				return nil, fmt.Errorf("index claim start pressure for %T, want *corev1.Pod", obj)
+			}
+			if !countsForStartPressure(pod) {
+				return nil, nil
+			}
+			switch pod.Labels[labelPoolType] {
+			case poolTypeIdle:
+				return []string{startPressurePodIndexValue}, nil
+			case poolTypeActive:
+				if !podReady(pod) {
+					return []string{startPressurePodIndexValue}, nil
+				}
+			}
+			return nil, nil
+		},
+	})
 }
 
 func podConditionTrue(conditions []corev1.PodCondition, conditionType corev1.PodConditionType) bool {

--- a/manager/pkg/startlimiter/limiter.go
+++ b/manager/pkg/startlimiter/limiter.go
@@ -29,8 +29,6 @@ import (
 const (
 	defaultPerSandboxNode = int32(30)
 	defaultMaxLimit       = int32(80)
-	defaultLockTTL        = 5 * time.Second
-	defaultAcquireTimeout = 250 * time.Millisecond
 	defaultRetryAfter     = time.Second
 	defaultReservationTTL = 5 * time.Minute
 
@@ -47,6 +45,74 @@ const (
 	BackendPostgres = "postgres_advisory_lock"
 	BackendRedis    = "redis"
 )
+
+var redisReservationScript = redis.NewScript(`
+local reservation_key = KEYS[1]
+local units_key = KEYS[2]
+
+local now_ms = tonumber(ARGV[1])
+local expires_at_ms = tonumber(ARGV[2])
+local ttl_ms = tonumber(ARGV[3])
+local limit = tonumber(ARGV[4])
+local observed_pressure = tonumber(ARGV[5])
+local requested = tonumber(ARGV[6])
+local reservation_token = ARGV[7]
+
+local expired = redis.call("ZRANGEBYSCORE", reservation_key, "-inf", now_ms)
+if #expired > 0 then
+  redis.call("ZREM", reservation_key, unpack(expired))
+  redis.call("HDEL", units_key, unpack(expired))
+end
+
+local reserved_units = 0
+local active = redis.call("ZRANGE", reservation_key, 0, -1)
+for _, token in ipairs(active) do
+  local units = tonumber(redis.call("HGET", units_key, token))
+  if units == nil or units <= 0 then
+    units = 1
+  end
+  reserved_units = reserved_units + units
+end
+
+local overlap_units = 0
+local seen = {}
+for index = 8, #ARGV do
+  local token = ARGV[index]
+  if token ~= "" and seen[token] == nil then
+    seen[token] = true
+    local score = tonumber(redis.call("ZSCORE", reservation_key, token))
+    if score ~= nil and score > now_ms then
+      local units = tonumber(redis.call("HGET", units_key, token))
+      if units == nil or units <= 0 then
+        units = 1
+      end
+      overlap_units = overlap_units + units
+    end
+  end
+end
+
+local in_flight = observed_pressure + reserved_units - overlap_units
+if in_flight < 0 then
+  in_flight = 0
+end
+local available = limit - in_flight
+if available < 0 then
+  available = 0
+end
+
+if requested <= 0 then
+  return {1, in_flight, available}
+end
+if requested > available then
+  return {0, in_flight, available}
+end
+
+redis.call("ZADD", reservation_key, expires_at_ms, reservation_token)
+redis.call("HSET", units_key, reservation_token, requested)
+redis.call("PEXPIRE", reservation_key, ttl_ms)
+redis.call("PEXPIRE", units_key, ttl_ms)
+return {1, in_flight, available}
+`)
 
 // Reason describes the caller reserving cluster start budget.
 type Reason string
@@ -67,15 +133,11 @@ type ThrottledError struct {
 	Units      int32
 	RetryAfter time.Duration
 	Snapshot   Snapshot
-	Message    string
 }
 
 func (e *ThrottledError) Error() string {
 	if e == nil {
 		return ErrThrottled.Error()
-	}
-	if e.Message != "" {
-		return e.Message
 	}
 	if e.Snapshot.Limit <= 0 {
 		return fmt.Sprintf("%s: no sandbox-ready nodes", ErrThrottled)
@@ -115,8 +177,6 @@ type Config struct {
 	Redis               rediscache.Config
 	PerSandboxNode      int32
 	MaxLimit            int32
-	LockTTL             time.Duration
-	AcquireTimeout      time.Duration
 	SandboxNodeSelector map[string]string
 	SandboxTolerations  []corev1.Toleration
 	Logger              *zap.Logger
@@ -132,12 +192,9 @@ type Limiter struct {
 	redisTimeout        time.Duration
 	backend             string
 	lockResource        string
-	lockKey             string
 	reservationKey      string
 	reservationUnitsKey string
-	lockTTL             time.Duration
 	reservationTTL      time.Duration
-	acquireTimeout      time.Duration
 	perSandboxNode      int32
 	maxLimit            int32
 	sandboxSelector     map[string]string
@@ -185,12 +242,6 @@ func New(ctx context.Context, cfg Config) (*Limiter, error) {
 	if cfg.MaxLimit <= 0 {
 		cfg.MaxLimit = defaultMaxLimit
 	}
-	if cfg.LockTTL <= 0 {
-		cfg.LockTTL = defaultLockTTL
-	}
-	if cfg.AcquireTimeout <= 0 {
-		cfg.AcquireTimeout = defaultAcquireTimeout
-	}
 	if cfg.Logger == nil {
 		cfg.Logger = zap.NewNop()
 	}
@@ -212,8 +263,6 @@ func New(ctx context.Context, cfg Config) (*Limiter, error) {
 		pgLocker:           pglock.New(cfg.PGPool),
 		backend:            BackendPostgres,
 		lockResource:       fmt.Sprintf("manager:claim-start:%s", cfg.ClusterID),
-		lockTTL:            cfg.LockTTL,
-		acquireTimeout:     cfg.AcquireTimeout,
 		perSandboxNode:     cfg.PerSandboxNode,
 		maxLimit:           cfg.MaxLimit,
 		sandboxSelector:    cloneStringMap(cfg.SandboxNodeSelector),
@@ -234,7 +283,6 @@ func New(ctx context.Context, cfg Config) (*Limiter, error) {
 		limiter.redisTimeout = normalized.Timeout
 		limiter.backend = BackendRedis
 		keyPrefix := rediscache.JoinKeyPrefix(normalized.KeyPrefix, "manager", "claim-start", cfg.ClusterID)
-		limiter.lockKey = rediscache.JoinKeyPrefix(keyPrefix, "lock")
 		limiter.reservationKey = rediscache.JoinKeyPrefix(keyPrefix, "reservations")
 		limiter.reservationUnitsKey = rediscache.JoinKeyPrefix(keyPrefix, "reservation-units")
 		limiter.reservationTTL = defaultReservationTTL
@@ -281,7 +329,7 @@ func (l *Limiter) Admit(ctx context.Context, reason Reason, units int32, mutate 
 	}
 
 	var snapshot *Snapshot
-	err := l.withLock(ctx, func(lockCtx context.Context) error {
+	err := l.withPostgresLock(ctx, func(lockCtx context.Context) error {
 		s, err := l.snapshotLocked(lockCtx)
 		if err != nil {
 			return err
@@ -315,7 +363,7 @@ func (l *Limiter) Reserve(ctx context.Context, reason Reason, units int32) (*Res
 	}
 	if l.redisClient == nil {
 		var snapshot *Snapshot
-		err := l.withLock(ctx, func(lockCtx context.Context) error {
+		err := l.withPostgresLock(ctx, func(lockCtx context.Context) error {
 			s, err := l.snapshotLocked(lockCtx)
 			if err != nil {
 				return err
@@ -334,34 +382,25 @@ func (l *Limiter) Reserve(ctx context.Context, reason Reason, units int32) (*Res
 		return nil, snapshot, err
 	}
 
-	var snapshot *Snapshot
-	var token string
-	err := l.withLock(ctx, func(lockCtx context.Context) error {
-		reservations, err := l.activeReservations(lockCtx)
-		if err != nil {
-			return err
-		}
-		s, err := l.snapshotLockedWithReservations(lockCtx, reservations)
-		if err != nil {
-			return err
-		}
-		snapshot = s
-		if s.Available < units {
-			return &ThrottledError{
-				Reason:     reason,
-				Units:      units,
-				RetryAfter: defaultRetryAfter,
-				Snapshot:   *s,
-			}
-		}
-		token, err = randomToken()
-		if err != nil {
-			return err
-		}
-		return l.addReservation(lockCtx, token, units)
-	})
+	observation, err := l.observeStartPressure(ctx)
 	if err != nil {
-		return nil, snapshot, err
+		return nil, nil, err
+	}
+	token, err := randomToken()
+	if err != nil {
+		return nil, nil, err
+	}
+	admitted, snapshot, err := l.runRedisAdmission(ctx, observation, token, units)
+	if err != nil {
+		return nil, nil, err
+	}
+	if !admitted {
+		return nil, snapshot, &ThrottledError{
+			Reason:     reason,
+			Units:      units,
+			RetryAfter: defaultRetryAfter,
+			Snapshot:   *snapshot,
+		}
 	}
 	return &Reservation{limiter: l, token: token}, snapshot, nil
 }
@@ -371,83 +410,51 @@ func (l *Limiter) Snapshot(ctx context.Context) (*Snapshot, error) {
 	if l == nil {
 		return nil, nil
 	}
-	reservations, err := l.activeReservations(ctx)
+	if l.redisClient == nil {
+		return l.snapshotLocked(ctx)
+	}
+	observation, err := l.observeStartPressure(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return l.snapshotLockedWithReservations(ctx, reservations)
+	_, snapshot, err := l.runRedisAdmission(ctx, observation, "", 0)
+	return snapshot, err
 }
 
-func (l *Limiter) withLock(ctx context.Context, fn func(context.Context) error) error {
-	if l.redisClient != nil {
-		return l.withRedisLock(ctx, fn)
-	}
+func (l *Limiter) withPostgresLock(ctx context.Context, fn func(context.Context) error) error {
 	return l.pgLocker.WithExclusive(ctx, l.lockResource, fn)
 }
 
-func (l *Limiter) withRedisLock(ctx context.Context, fn func(context.Context) error) error {
-	token, err := randomToken()
-	if err != nil {
-		return err
-	}
-	deadline := time.Now().Add(l.acquireTimeout)
-	for {
-		opCtx, cancel := rediscache.WithTimeout(ctx, l.redisTimeout)
-		ok, setErr := l.redisClient.SetNX(opCtx, l.lockKey, token, l.lockTTL).Result()
-		cancel()
-		if setErr != nil {
-			if ctx.Err() != nil {
-				return ctx.Err()
-			}
-			if errors.Is(setErr, context.DeadlineExceeded) {
-				return &ThrottledError{
-					RetryAfter: defaultRetryAfter,
-					Message:    "claim start admission lock is unavailable",
-				}
-			}
-			return fmt.Errorf("acquire redis claim start lock: %w", setErr)
-		}
-		if ok {
-			break
-		}
-		if time.Now().After(deadline) {
-			return &ThrottledError{
-				RetryAfter: defaultRetryAfter,
-				Message:    "claim start admission lock is busy",
-			}
-		}
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(10 * time.Millisecond):
-		}
-	}
-	defer l.releaseRedisLock(token)
-	return fn(ctx)
-}
-
-func (l *Limiter) releaseRedisLock(token string) {
-	if l == nil || l.redisClient == nil {
-		return
-	}
-	opCtx, cancel := rediscache.WithTimeout(context.Background(), l.redisTimeout)
-	defer cancel()
-	const releaseScript = `if redis.call("GET", KEYS[1]) == ARGV[1] then return redis.call("DEL", KEYS[1]) else return 0 end`
-	if err := l.redisClient.Eval(opCtx, releaseScript, []string{l.lockKey}, token).Err(); err != nil {
-		l.logger.Warn("Failed to release redis claim start lock", zap.Error(err))
-	}
-}
-
 func (l *Limiter) snapshotLocked(ctx context.Context) (*Snapshot, error) {
-	return l.snapshotLockedWithReservations(ctx, nil)
+	observation, err := l.observeStartPressure(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return observation.snapshot(l.backend, observation.inFlight), nil
 }
 
-type activeReservationSnapshot struct {
-	tokens map[string]struct{}
-	units  int32
+type startPressureObservation struct {
+	warmReadySandboxNodes int
+	limit                 int32
+	inFlight              int32
+	reservationTokens     []string
 }
 
-func (l *Limiter) snapshotLockedWithReservations(ctx context.Context, reservations *activeReservationSnapshot) (*Snapshot, error) {
+func (o *startPressureObservation) snapshot(backend string, inFlight int32) *Snapshot {
+	available := o.limit - inFlight
+	if available < 0 {
+		available = 0
+	}
+	return &Snapshot{
+		Backend:               backend,
+		WarmReadySandboxNodes: o.warmReadySandboxNodes,
+		Limit:                 o.limit,
+		InFlight:              inFlight,
+		Available:             available,
+	}
+}
+
+func (l *Limiter) observeStartPressure(ctx context.Context) (*startPressureObservation, error) {
 	nodes, err := l.listNodes(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("list nodes for claim start limiter: %w", err)
@@ -464,68 +471,88 @@ func (l *Limiter) snapshotLockedWithReservations(ctx context.Context, reservatio
 		return nil, fmt.Errorf("list pool replicasets for claim start limiter: %w", err)
 	}
 
-	inFlight := startPressure(pods, replicaSets, reservationTokens(reservations))
-	if reservations != nil {
-		inFlight += reservations.units
-	}
-	available := limit - inFlight
-	if available < 0 {
-		available = 0
-	}
-	return &Snapshot{
-		Backend:               l.backend,
-		WarmReadySandboxNodes: warmReadyNodes,
-		Limit:                 limit,
-		InFlight:              inFlight,
-		Available:             available,
+	inFlight, reservationTokens := startPressure(pods, replicaSets)
+	return &startPressureObservation{
+		warmReadySandboxNodes: warmReadyNodes,
+		limit:                 limit,
+		inFlight:              inFlight,
+		reservationTokens:     reservationTokens,
 	}, nil
 }
 
-func reservationTokens(reservations *activeReservationSnapshot) map[string]struct{} {
-	if reservations == nil {
-		return nil
+func (l *Limiter) runRedisAdmission(
+	ctx context.Context,
+	observation *startPressureObservation,
+	token string,
+	units int32,
+) (bool, *Snapshot, error) {
+	if l == nil || l.redisClient == nil || observation == nil {
+		return false, nil, fmt.Errorf("redis claim start admission is not configured")
 	}
-	return reservations.tokens
+	now := time.Now()
+	args := make([]interface{}, 0, 7+len(observation.reservationTokens))
+	args = append(args,
+		now.UnixMilli(),
+		now.Add(l.reservationTTL).UnixMilli(),
+		l.reservationTTL.Milliseconds(),
+		observation.limit,
+		observation.inFlight,
+		units,
+		token,
+	)
+	for _, reservationToken := range observation.reservationTokens {
+		args = append(args, reservationToken)
+	}
+
+	opCtx, cancel := rediscache.WithTimeout(ctx, l.redisTimeout)
+	defer cancel()
+	result, err := redisReservationScript.Run(
+		opCtx,
+		l.redisClient,
+		[]string{l.reservationKey, l.reservationUnitsKey},
+		args...,
+	).Result()
+	if err != nil {
+		return false, nil, fmt.Errorf("run redis claim start admission: %w", err)
+	}
+	values, ok := result.([]interface{})
+	if !ok || len(values) != 3 {
+		return false, nil, fmt.Errorf("unexpected redis claim start admission response: %T", result)
+	}
+	admitted, err := redisResultInt64(values[0])
+	if err != nil {
+		return false, nil, fmt.Errorf("parse redis claim start admission decision: %w", err)
+	}
+	inFlight, err := redisResultInt64(values[1])
+	if err != nil {
+		return false, nil, fmt.Errorf("parse redis claim start in-flight count: %w", err)
+	}
+	available, err := redisResultInt64(values[2])
+	if err != nil {
+		return false, nil, fmt.Errorf("parse redis claim start available count: %w", err)
+	}
+	if inFlight < 0 || inFlight > int64(^uint32(0)>>1) {
+		return false, nil, fmt.Errorf("redis claim start in-flight count is out of range: %d", inFlight)
+	}
+	if available < 0 || available > int64(^uint32(0)>>1) {
+		return false, nil, fmt.Errorf("redis claim start available count is out of range: %d", available)
+	}
+	snapshot := observation.snapshot(l.backend, int32(inFlight))
+	snapshot.Available = int32(available)
+	return admitted == 1, snapshot, nil
 }
 
-func (l *Limiter) activeReservations(ctx context.Context) (*activeReservationSnapshot, error) {
-	if l == nil || l.redisClient == nil {
-		return nil, nil
+func redisResultInt64(value interface{}) (int64, error) {
+	switch typed := value.(type) {
+	case int64:
+		return typed, nil
+	case string:
+		return strconv.ParseInt(typed, 10, 64)
+	case []byte:
+		return strconv.ParseInt(string(typed), 10, 64)
+	default:
+		return 0, fmt.Errorf("unexpected integer type %T", value)
 	}
-	nowMs := time.Now().UnixMilli()
-	expired, err := l.redisZRangeByScore(ctx, l.reservationKey, "-inf", strconv.FormatInt(nowMs, 10))
-	if err != nil {
-		return nil, fmt.Errorf("list expired claim start reservations: %w", err)
-	}
-	if len(expired) > 0 {
-		if err := l.removeReservations(ctx, expired...); err != nil {
-			return nil, err
-		}
-	}
-	active, err := l.redisZRangeByScore(ctx, l.reservationKey, strconv.FormatInt(nowMs+1, 10), "+inf")
-	if err != nil {
-		return nil, fmt.Errorf("list active claim start reservations: %w", err)
-	}
-	if len(active) == 0 {
-		return &activeReservationSnapshot{}, nil
-	}
-	values, err := l.redisHMGet(ctx, active...)
-	if err != nil {
-		return nil, err
-	}
-	snapshot := &activeReservationSnapshot{tokens: make(map[string]struct{}, len(active))}
-	for idx, token := range active {
-		units := int32(1)
-		if idx < len(values) && values[idx] != nil {
-			parsed, parseErr := strconv.ParseInt(fmt.Sprint(values[idx]), 10, 32)
-			if parseErr == nil && parsed > 0 {
-				units = int32(parsed)
-			}
-		}
-		snapshot.tokens[token] = struct{}{}
-		snapshot.units += units
-	}
-	return snapshot, nil
 }
 
 func (l *Limiter) listNodes(ctx context.Context) ([]*corev1.Node, error) {
@@ -581,27 +608,6 @@ func (l *Limiter) listReplicaSets(ctx context.Context) ([]*appsv1.ReplicaSet, er
 	return out, nil
 }
 
-func (l *Limiter) addReservation(ctx context.Context, token string, units int32) error {
-	if l == nil || l.redisClient == nil || token == "" {
-		return nil
-	}
-	if units <= 0 {
-		units = 1
-	}
-	expireAtMs := time.Now().Add(l.reservationTTL).UnixMilli()
-	opCtx, cancel := rediscache.WithTimeout(ctx, l.redisTimeout)
-	defer cancel()
-	pipe := l.redisClient.TxPipeline()
-	pipe.ZAdd(opCtx, l.reservationKey, redis.Z{Score: float64(expireAtMs), Member: token})
-	pipe.HSet(opCtx, l.reservationUnitsKey, token, strconv.FormatInt(int64(units), 10))
-	pipe.PExpire(opCtx, l.reservationKey, l.reservationTTL)
-	pipe.PExpire(opCtx, l.reservationUnitsKey, l.reservationTTL)
-	if _, err := pipe.Exec(opCtx); err != nil {
-		return fmt.Errorf("add claim start reservation: %w", err)
-	}
-	return nil
-}
-
 func (l *Limiter) releaseReservation(token string) {
 	if l == nil || l.redisClient == nil || token == "" {
 		return
@@ -635,22 +641,6 @@ func (l *Limiter) removeReservations(ctx context.Context, tokens ...string) erro
 	return nil
 }
 
-func (l *Limiter) redisZRangeByScore(ctx context.Context, key, min, max string) ([]string, error) {
-	opCtx, cancel := rediscache.WithTimeout(ctx, l.redisTimeout)
-	defer cancel()
-	return l.redisClient.ZRangeByScore(opCtx, key, &redis.ZRangeBy{Min: min, Max: max}).Result()
-}
-
-func (l *Limiter) redisHMGet(ctx context.Context, tokens ...string) ([]interface{}, error) {
-	opCtx, cancel := rediscache.WithTimeout(ctx, l.redisTimeout)
-	defer cancel()
-	values, err := l.redisClient.HMGet(opCtx, l.reservationUnitsKey, tokens...).Result()
-	if err != nil {
-		return nil, fmt.Errorf("read claim start reservation units: %w", err)
-	}
-	return values, nil
-}
-
 func (l *Limiter) limitForNodes(nodes int) int32 {
 	if nodes <= 0 {
 		return 0
@@ -667,16 +657,14 @@ type poolKey struct {
 	templateID string
 }
 
-func startPressure(pods []*corev1.Pod, replicaSets []*appsv1.ReplicaSet, activeReservations map[string]struct{}) int32 {
+func startPressure(pods []*corev1.Pod, replicaSets []*appsv1.ReplicaSet) (int32, []string) {
 	readyIdleByPool := make(map[poolKey]int32)
 	startingIdleByPool := make(map[poolKey]int32)
+	reservationTokens := make([]string, 0)
 	var inFlight int32
 
 	for _, pod := range pods {
 		if !countsForStartPressure(pod) {
-			continue
-		}
-		if podCoveredByActiveReservation(pod, activeReservations) {
 			continue
 		}
 		key := poolKey{namespace: pod.Namespace, templateID: pod.Labels[labelTemplateID]}
@@ -687,10 +675,12 @@ func startPressure(pods []*corev1.Pod, replicaSets []*appsv1.ReplicaSet, activeR
 			} else {
 				startingIdleByPool[key]++
 				inFlight++
+				reservationTokens = appendReservationToken(reservationTokens, pod)
 			}
 		case poolTypeActive:
 			if !podReady(pod) {
 				inFlight++
+				reservationTokens = appendReservationToken(reservationTokens, pod)
 			}
 		}
 	}
@@ -715,19 +705,18 @@ func startPressure(pods []*corev1.Pod, replicaSets []*appsv1.ReplicaSet, activeR
 			inFlight += desired - ownedIdle
 		}
 	}
-	return inFlight
+	return inFlight, reservationTokens
 }
 
-func podCoveredByActiveReservation(pod *corev1.Pod, activeReservations map[string]struct{}) bool {
-	if pod == nil || len(activeReservations) == 0 {
-		return false
+func appendReservationToken(tokens []string, pod *corev1.Pod) []string {
+	if pod == nil {
+		return tokens
 	}
 	token := pod.Annotations[AnnotationClaimStartReservation]
 	if token == "" {
-		return false
+		return tokens
 	}
-	_, ok := activeReservations[token]
-	return ok
+	return append(tokens, token)
 }
 
 func countsForStartPressure(pod *corev1.Pod) bool {
@@ -876,7 +865,7 @@ func templateReplicaSetSelector() (string, error) {
 func randomToken() (string, error) {
 	var b [16]byte
 	if _, err := rand.Read(b[:]); err != nil {
-		return "", fmt.Errorf("generate claim start lock token: %w", err)
+		return "", fmt.Errorf("generate claim start reservation token: %w", err)
 	}
 	return hex.EncodeToString(b[:]), nil
 }

--- a/manager/pkg/startlimiter/limiter_test.go
+++ b/manager/pkg/startlimiter/limiter_test.go
@@ -3,10 +3,12 @@ package startlimiter
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
 	"github.com/sandbox0-ai/sandbox0/pkg/rediscache"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -220,6 +222,53 @@ func TestRedisReserveHoldsBudgetUntilReleased(t *testing.T) {
 	}
 }
 
+func TestRedisReserveTracksMultipleUnits(t *testing.T) {
+	ctx := context.Background()
+	redisServer := miniredis.RunT(t)
+	client := fake.NewSimpleClientset(readyNode("sandbox-a", nil, nil))
+	limiter, err := New(ctx, Config{
+		ClusterID:      "cluster-a",
+		K8sClient:      client,
+		PerSandboxNode: 5,
+		MaxLimit:       5,
+		Redis: rediscache.Config{
+			URL:       "redis://" + redisServer.Addr() + "/0",
+			KeyPrefix: "test",
+		},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	first, _, err := limiter.Reserve(ctx, ReasonPoolReconcile, 3)
+	if err != nil {
+		t.Fatalf("Reserve(3) error = %v", err)
+	}
+	defer first.Release()
+
+	_, snapshot, err := limiter.Reserve(ctx, ReasonPoolReconcile, 3)
+	if !errors.Is(err, ErrThrottled) {
+		t.Fatalf("second Reserve(3) error = %v, want ErrThrottled", err)
+	}
+	if snapshot.InFlight != 3 || snapshot.Available != 2 {
+		t.Fatalf("throttled snapshot in-flight/available = %d/%d, want 3/2", snapshot.InFlight, snapshot.Available)
+	}
+
+	second, _, err := limiter.Reserve(ctx, ReasonPoolReconcile, 2)
+	if err != nil {
+		t.Fatalf("Reserve(2) error = %v", err)
+	}
+	defer second.Release()
+
+	snapshot, err = limiter.Snapshot(ctx)
+	if err != nil {
+		t.Fatalf("Snapshot() error = %v", err)
+	}
+	if snapshot.InFlight != 5 || snapshot.Available != 0 {
+		t.Fatalf("Snapshot() in-flight/available = %d/%d, want 5/0", snapshot.InFlight, snapshot.Available)
+	}
+}
+
 func TestRedisReservationAvoidsDoubleCountingAnnotatedPod(t *testing.T) {
 	ctx := context.Background()
 	redisServer := miniredis.RunT(t)
@@ -270,7 +319,90 @@ func TestRedisReservationAvoidsDoubleCountingAnnotatedPod(t *testing.T) {
 	}
 }
 
-func TestRedisLockBusyReturnsThrottled(t *testing.T) {
+func TestRedisReserveAtomicallyEnforcesLimitAcrossInstances(t *testing.T) {
+	ctx := context.Background()
+	redisServer := miniredis.RunT(t)
+	client := fake.NewSimpleClientset(readyNode("sandbox-a", nil, nil))
+	newLimiter := func() *Limiter {
+		limiter, err := New(ctx, Config{
+			ClusterID:      "cluster-a",
+			K8sClient:      client,
+			PerSandboxNode: 80,
+			MaxLimit:       80,
+			Redis: rediscache.Config{
+				URL:       "redis://" + redisServer.Addr() + "/0",
+				KeyPrefix: "test",
+				Timeout:   2 * time.Second,
+			},
+		})
+		if err != nil {
+			t.Fatalf("New() error = %v", err)
+		}
+		return limiter
+	}
+	limiters := []*Limiter{newLimiter(), newLimiter()}
+
+	type result struct {
+		reservation *Reservation
+		snapshot    *Snapshot
+		err         error
+	}
+	const attempts = 160
+	start := make(chan struct{})
+	results := make(chan result, attempts)
+	var wg sync.WaitGroup
+	for index := 0; index < attempts; index++ {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			<-start
+			reservation, snapshot, err := limiters[index%len(limiters)].Reserve(ctx, ReasonColdCreate, 1)
+			results <- result{reservation: reservation, snapshot: snapshot, err: err}
+		}(index)
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+
+	var reservations []*Reservation
+	throttled := 0
+	for result := range results {
+		if result.err == nil {
+			reservations = append(reservations, result.reservation)
+			continue
+		}
+		if !errors.Is(result.err, ErrThrottled) {
+			t.Fatalf("Reserve() error = %v, want ErrThrottled", result.err)
+		}
+		var throttledErr *ThrottledError
+		if !errors.As(result.err, &throttledErr) {
+			t.Fatalf("Reserve() error type = %T, want *ThrottledError", result.err)
+		}
+		if result.snapshot == nil || result.snapshot.InFlight != 80 || result.snapshot.Available != 0 {
+			t.Fatalf("throttled snapshot = %#v, want in-flight/available 80/0", result.snapshot)
+		}
+		if got := result.err.Error(); got != "claim start admission throttled: in_flight=80 limit=80 requested=1" {
+			t.Fatalf("Reserve() error = %q, want capacity throttle", got)
+		}
+		throttled++
+	}
+	if len(reservations) != 80 || throttled != 80 {
+		t.Fatalf("reservations/throttled = %d/%d, want 80/80", len(reservations), throttled)
+	}
+
+	for _, reservation := range reservations {
+		reservation.Release()
+	}
+	snapshot, err := limiters[0].Snapshot(ctx)
+	if err != nil {
+		t.Fatalf("Snapshot() after release error = %v", err)
+	}
+	if snapshot.InFlight != 0 || snapshot.Available != 80 {
+		t.Fatalf("Snapshot() after release in-flight/available = %d/%d, want 0/80", snapshot.InFlight, snapshot.Available)
+	}
+}
+
+func TestRedisReserveRemovesExpiredReservation(t *testing.T) {
 	ctx := context.Background()
 	redisServer := miniredis.RunT(t)
 	client := fake.NewSimpleClientset(readyNode("sandbox-a", nil, nil))
@@ -279,7 +411,6 @@ func TestRedisLockBusyReturnsThrottled(t *testing.T) {
 		K8sClient:      client,
 		PerSandboxNode: 1,
 		MaxLimit:       1,
-		AcquireTimeout: time.Millisecond,
 		Redis: rediscache.Config{
 			URL:       "redis://" + redisServer.Addr() + "/0",
 			KeyPrefix: "test",
@@ -288,20 +419,31 @@ func TestRedisLockBusyReturnsThrottled(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
-	if err := limiter.redisClient.Set(ctx, limiter.lockKey, "busy", time.Minute).Err(); err != nil {
-		t.Fatalf("seed redis lock: %v", err)
+	const expiredToken = "expired"
+	if err := limiter.redisClient.ZAdd(ctx, limiter.reservationKey, redis.Z{
+		Score:  float64(time.Now().Add(-time.Minute).UnixMilli()),
+		Member: expiredToken,
+	}).Err(); err != nil {
+		t.Fatalf("seed expired reservation: %v", err)
+	}
+	if err := limiter.redisClient.HSet(ctx, limiter.reservationUnitsKey, expiredToken, 1).Err(); err != nil {
+		t.Fatalf("seed expired reservation units: %v", err)
 	}
 
-	called := false
-	_, err = limiter.Admit(ctx, ReasonColdCreate, 1, func(context.Context) error {
-		called = true
-		return nil
-	})
-	if !errors.Is(err, ErrThrottled) {
-		t.Fatalf("Admit() error = %v, want ErrThrottled", err)
+	reservation, snapshot, err := limiter.Reserve(ctx, ReasonColdCreate, 1)
+	if err != nil {
+		t.Fatalf("Reserve() error = %v", err)
 	}
-	if called {
-		t.Fatal("Admit() called mutation while redis lock was busy")
+	defer reservation.Release()
+	if snapshot.InFlight != 0 || snapshot.Available != 1 {
+		t.Fatalf("pre-reservation in-flight/available = %d/%d, want 0/1", snapshot.InFlight, snapshot.Available)
+	}
+	exists, err := limiter.redisClient.HExists(ctx, limiter.reservationUnitsKey, expiredToken).Result()
+	if err != nil {
+		t.Fatalf("check expired reservation units: %v", err)
+	}
+	if exists {
+		t.Fatal("expired reservation units were not removed")
 	}
 }
 

--- a/manager/pkg/startlimiter/limiter_test.go
+++ b/manager/pkg/startlimiter/limiter_test.go
@@ -444,7 +444,7 @@ func TestRedisReserveRetriesAnAmbiguousTimeout(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
-	hook := &timeoutAfterSuccessfulScriptHook{}
+	hook := &timeoutAfterSuccessfulScriptHook{remaining: redisScriptAttempts - 1}
 	limiter.redisClient.AddHook(hook)
 
 	reservation, _, err := limiter.Reserve(ctx, ReasonColdCreate, 1)
@@ -452,8 +452,8 @@ func TestRedisReserveRetriesAnAmbiguousTimeout(t *testing.T) {
 		t.Fatalf("Reserve() error = %v", err)
 	}
 	defer reservation.Release()
-	if !hook.Injected() {
-		t.Fatal("Reserve() did not exercise an ambiguous Redis timeout")
+	if got := hook.InjectedTimeouts(); got != redisScriptAttempts-1 {
+		t.Fatalf("ambiguous Redis timeouts = %d, want %d", got, redisScriptAttempts-1)
 	}
 	active, err := limiter.redisClient.ZCard(ctx, limiter.reservationKey).Result()
 	if err != nil {
@@ -623,8 +623,9 @@ func TestRedisReserveRemovesExpiredReservation(t *testing.T) {
 }
 
 type timeoutAfterSuccessfulScriptHook struct {
-	mu       sync.Mutex
-	injected bool
+	mu        sync.Mutex
+	remaining int
+	injected  int
 }
 
 func (h *timeoutAfterSuccessfulScriptHook) DialHook(next redis.DialHook) redis.DialHook {
@@ -643,10 +644,11 @@ func (h *timeoutAfterSuccessfulScriptHook) ProcessHook(next redis.ProcessHook) r
 		}
 		h.mu.Lock()
 		defer h.mu.Unlock()
-		if h.injected {
+		if h.remaining <= 0 {
 			return nil
 		}
-		h.injected = true
+		h.remaining--
+		h.injected++
 		return context.DeadlineExceeded
 	}
 }
@@ -655,7 +657,7 @@ func (h *timeoutAfterSuccessfulScriptHook) ProcessPipelineHook(next redis.Proces
 	return next
 }
 
-func (h *timeoutAfterSuccessfulScriptHook) Injected() bool {
+func (h *timeoutAfterSuccessfulScriptHook) InjectedTimeouts() int {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	return h.injected

--- a/manager/pkg/startlimiter/limiter_test.go
+++ b/manager/pkg/startlimiter/limiter_test.go
@@ -3,6 +3,7 @@ package startlimiter
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -332,7 +333,6 @@ func TestRedisReserveAtomicallyEnforcesLimitAcrossInstances(t *testing.T) {
 			Redis: rediscache.Config{
 				URL:       "redis://" + redisServer.Addr() + "/0",
 				KeyPrefix: "test",
-				Timeout:   2 * time.Second,
 			},
 		})
 		if err != nil {
@@ -341,6 +341,24 @@ func TestRedisReserveAtomicallyEnforcesLimitAcrossInstances(t *testing.T) {
 		return limiter
 	}
 	limiters := []*Limiter{newLimiter(), newLimiter()}
+	var reservations []*Reservation
+	var observedPods []*corev1.Pod
+	for index := 0; index < 10; index++ {
+		reservation, _, err := limiters[0].Reserve(ctx, ReasonColdCreate, 1)
+		if err != nil {
+			t.Fatalf("seed Reserve() error = %v", err)
+		}
+		reservations = append(reservations, reservation)
+		pod := startingActivePod("default", fmt.Sprintf("active-starting-%d", index), "tmpl-a")
+		pod.Annotations = map[string]string{
+			AnnotationClaimStartReservation: reservation.Token(),
+		}
+		created, err := client.CoreV1().Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("create observed pod: %v", err)
+		}
+		observedPods = append(observedPods, created)
+	}
 
 	type result struct {
 		reservation *Reservation
@@ -364,11 +382,12 @@ func TestRedisReserveAtomicallyEnforcesLimitAcrossInstances(t *testing.T) {
 	wg.Wait()
 	close(results)
 
-	var reservations []*Reservation
 	throttled := 0
+	admitted := 0
 	for result := range results {
 		if result.err == nil {
 			reservations = append(reservations, result.reservation)
+			admitted++
 			continue
 		}
 		if !errors.Is(result.err, ErrThrottled) {
@@ -386,12 +405,17 @@ func TestRedisReserveAtomicallyEnforcesLimitAcrossInstances(t *testing.T) {
 		}
 		throttled++
 	}
-	if len(reservations) != 80 || throttled != 80 {
-		t.Fatalf("reservations/throttled = %d/%d, want 80/80", len(reservations), throttled)
+	if admitted != 70 || len(reservations) != 80 || throttled != 90 {
+		t.Fatalf("admitted/active/throttled = %d/%d/%d, want 70/80/90", admitted, len(reservations), throttled)
 	}
 
 	for _, reservation := range reservations {
 		reservation.Release()
+	}
+	for _, pod := range observedPods {
+		if err := client.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{}); err != nil {
+			t.Fatalf("delete observed pod: %v", err)
+		}
 	}
 	snapshot, err := limiters[0].Snapshot(ctx)
 	if err != nil {
@@ -399,6 +423,59 @@ func TestRedisReserveAtomicallyEnforcesLimitAcrossInstances(t *testing.T) {
 	}
 	if snapshot.InFlight != 0 || snapshot.Available != 80 {
 		t.Fatalf("Snapshot() after release in-flight/available = %d/%d, want 0/80", snapshot.InFlight, snapshot.Available)
+	}
+}
+
+func TestRedisSnapshotRebuildsReservationMetadata(t *testing.T) {
+	ctx := context.Background()
+	redisServer := miniredis.RunT(t)
+	client := fake.NewSimpleClientset(readyNode("sandbox-a", nil, nil))
+	limiter, err := New(ctx, Config{
+		ClusterID:      "cluster-a",
+		K8sClient:      client,
+		PerSandboxNode: 5,
+		MaxLimit:       5,
+		Redis: rediscache.Config{
+			URL:       "redis://" + redisServer.Addr() + "/0",
+			KeyPrefix: "test",
+		},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	const token = "existing"
+	if err := limiter.redisClient.ZAdd(ctx, limiter.reservationKey, redis.Z{
+		Score:  float64(time.Now().Add(time.Minute).UnixMilli()),
+		Member: token,
+	}).Err(); err != nil {
+		t.Fatalf("seed reservation: %v", err)
+	}
+	if err := limiter.redisClient.HSet(ctx, limiter.reservationUnitsKey, token, 3).Err(); err != nil {
+		t.Fatalf("seed reservation units: %v", err)
+	}
+
+	snapshot, err := limiter.Snapshot(ctx)
+	if err != nil {
+		t.Fatalf("Snapshot() error = %v", err)
+	}
+	if snapshot.InFlight != 3 || snapshot.Available != 2 {
+		t.Fatalf("Snapshot() in-flight/available = %d/%d, want 3/2", snapshot.InFlight, snapshot.Available)
+	}
+	metadata, err := limiter.redisClient.HGetAll(ctx, limiter.reservationMetaKey).Result()
+	if err != nil {
+		t.Fatalf("read reservation metadata: %v", err)
+	}
+	if metadata["count"] != "1" || metadata["units"] != "3" {
+		t.Fatalf("reservation metadata = %#v, want count=1 units=3", metadata)
+	}
+
+	limiter.releaseReservation(token)
+	snapshot, err = limiter.Snapshot(ctx)
+	if err != nil {
+		t.Fatalf("Snapshot() after release error = %v", err)
+	}
+	if snapshot.InFlight != 0 || snapshot.Available != 5 {
+		t.Fatalf("Snapshot() after release in-flight/available = %d/%d, want 0/5", snapshot.InFlight, snapshot.Available)
 	}
 }
 

--- a/manager/pkg/startlimiter/limiter_test.go
+++ b/manager/pkg/startlimiter/limiter_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -426,6 +427,103 @@ func TestRedisReserveAtomicallyEnforcesLimitAcrossInstances(t *testing.T) {
 	}
 }
 
+func TestRedisReserveRetriesAnAmbiguousTimeout(t *testing.T) {
+	ctx := context.Background()
+	redisServer := miniredis.RunT(t)
+	client := fake.NewSimpleClientset(readyNode("sandbox-a", nil, nil))
+	limiter, err := New(ctx, Config{
+		ClusterID:      "cluster-a",
+		K8sClient:      client,
+		PerSandboxNode: 1,
+		MaxLimit:       1,
+		Redis: rediscache.Config{
+			URL:       "redis://" + redisServer.Addr() + "/0",
+			KeyPrefix: "test",
+		},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	hook := &timeoutAfterSuccessfulScriptHook{}
+	limiter.redisClient.AddHook(hook)
+
+	reservation, _, err := limiter.Reserve(ctx, ReasonColdCreate, 1)
+	if err != nil {
+		t.Fatalf("Reserve() error = %v", err)
+	}
+	defer reservation.Release()
+	if !hook.Injected() {
+		t.Fatal("Reserve() did not exercise an ambiguous Redis timeout")
+	}
+	active, err := limiter.redisClient.ZCard(ctx, limiter.reservationKey).Result()
+	if err != nil {
+		t.Fatalf("count active reservations: %v", err)
+	}
+	if active != 1 {
+		t.Fatalf("active reservations = %d, want 1 after idempotent retry", active)
+	}
+}
+
+func TestSnapshotUsesStartPressurePodIndex(t *testing.T) {
+	ctx := context.Background()
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	client := fake.NewSimpleClientset(
+		readyNode("sandbox-a", nil, nil),
+		replicaSet("default", "tmpl-a-rs", "tmpl-a", 3),
+	)
+	limiter, err := New(ctx, Config{
+		K8sClient:      client,
+		PodIndexer:     indexer,
+		PerSandboxNode: 10,
+		MaxLimit:       10,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	for index := 0; index < 100; index++ {
+		if err := indexer.Add(readyActivePod("default", fmt.Sprintf("active-ready-%d", index), "tmpl-a")); err != nil {
+			t.Fatalf("add ready active pod: %v", err)
+		}
+	}
+	readyIdle := readyIdlePod("default", "idle-ready", "tmpl-a")
+	startingIdle := startingIdlePod("default", "idle-starting", "tmpl-a")
+	startingActive := startingActivePod("default", "active-starting", "tmpl-a")
+	for _, pod := range []*corev1.Pod{readyIdle, startingIdle, startingActive} {
+		if err := indexer.Add(pod); err != nil {
+			t.Fatalf("add pressure pod: %v", err)
+		}
+	}
+
+	items, err := indexer.ByIndex(startPressurePodIndexName, startPressurePodIndexValue)
+	if err != nil {
+		t.Fatalf("read pressure pod index: %v", err)
+	}
+	if len(items) != 3 {
+		t.Fatalf("pressure pod index size = %d, want 3 without 100 ready active pods", len(items))
+	}
+	snapshot, err := limiter.Snapshot(ctx)
+	if err != nil {
+		t.Fatalf("Snapshot() error = %v", err)
+	}
+	if snapshot.InFlight != 3 {
+		t.Fatalf("InFlight = %d, want starting idle + starting active + ReplicaSet gap = 3", snapshot.InFlight)
+	}
+
+	readyActive := startingActive.DeepCopy()
+	readyActive.Status.Phase = corev1.PodRunning
+	readyActive.Status.Conditions = []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}}
+	if err := indexer.Update(readyActive); err != nil {
+		t.Fatalf("mark active pod ready: %v", err)
+	}
+	items, err = indexer.ByIndex(startPressurePodIndexName, startPressurePodIndexValue)
+	if err != nil {
+		t.Fatalf("read pressure pod index after update: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("pressure pod index size after ready transition = %d, want 2", len(items))
+	}
+}
+
 func TestRedisSnapshotRebuildsReservationMetadata(t *testing.T) {
 	ctx := context.Background()
 	redisServer := miniredis.RunT(t)
@@ -522,6 +620,45 @@ func TestRedisReserveRemovesExpiredReservation(t *testing.T) {
 	if exists {
 		t.Fatal("expired reservation units were not removed")
 	}
+}
+
+type timeoutAfterSuccessfulScriptHook struct {
+	mu       sync.Mutex
+	injected bool
+}
+
+func (h *timeoutAfterSuccessfulScriptHook) DialHook(next redis.DialHook) redis.DialHook {
+	return next
+}
+
+func (h *timeoutAfterSuccessfulScriptHook) ProcessHook(next redis.ProcessHook) redis.ProcessHook {
+	return func(ctx context.Context, cmd redis.Cmder) error {
+		err := next(ctx, cmd)
+		if err != nil {
+			return err
+		}
+		name := strings.ToLower(cmd.Name())
+		if name != "eval" && name != "evalsha" {
+			return nil
+		}
+		h.mu.Lock()
+		defer h.mu.Unlock()
+		if h.injected {
+			return nil
+		}
+		h.injected = true
+		return context.DeadlineExceeded
+	}
+}
+
+func (h *timeoutAfterSuccessfulScriptHook) ProcessPipelineHook(next redis.ProcessPipelineHook) redis.ProcessPipelineHook {
+	return next
+}
+
+func (h *timeoutAfterSuccessfulScriptHook) Injected() bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.injected
 }
 
 func readyNode(name string, labels map[string]string, taints []corev1.Taint) *corev1.Node {


### PR DESCRIPTION
## Summary

- replace the cluster-wide Redis `SETNX` polling lock with an atomic Lua admission operation
- maintain constant-time reservation metadata and reconcile it with observed Kubernetes pressure without double-counting annotated pods
- index only idle and starting pods for admission pressure, avoiding a scan of every ready active sandbox on high-density nodes
- make reservation and release scripts idempotent and retry only transient timeout ambiguity
- retain the obsolete lock YAML fields as ignored compatibility inputs

## Why

The previous lock serialized Kubernetes pressure scans and reservation writes. Under a burst near capacity, requests exhausted the 250 ms lock acquisition window or the 100 ms Redis operation deadline before the limiter could return the real capacity decision. Redis throughput was not the limiting resource; the lock protocol and per-request high-density pod scan were.

## Validation

- `go test -race ./manager/pkg/startlimiter ./manager/pkg/controller ./manager/pkg/service ./manager/cmd/manager ./infra-operator/api/config ./infra-operator/internal/runtimeconfig ./infra-operator/internal/controller/services/manager`
- `go test -count=50 ./manager/pkg/startlimiter`
- ambiguous-response test injects two consecutive post-commit Redis timeouts and verifies one reservation after retry
- cross-instance concurrency test keeps the active total at exactly 80 under 160 simultaneous attempts, including annotated pod handoff
- high-density index test verifies 100 ready active pods are excluded while starting and idle pressure remains correct
- targeted `golangci-lint` (0 issues)
- `make proto manifests apispec` and `go mod tidy` (no drift)

## Remote validation

Aliyun persistent kind environment, two Ready data-plane nodes, default template `minIdle=0`, Redis operation timeout `100ms`, and 128 MiB cold claims:

- one cold claim: HTTP 201 in 1.734 s
- 120 synchronized claims: 60 HTTP 201 and 60 capacity HTTP 429
- Redis admission deadline errors: 0
- legacy lock busy/unavailable errors: 0
- curl errors: 0

The default template was restored to `minIdle=1`, Redis timeout remained at `100ms`, the idle pod returned Ready, test sandboxes and reservation keys were removed, and the ECS instance was stopped.