### PR TITLE
fix(migrate): reset goose state between migration sets

### DIFF
--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -23,11 +23,14 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/pressly/goose/v3"
 )
+
+var gooseMu sync.Mutex
 
 // Options configures the migrator behavior.
 type Options struct {
@@ -104,6 +107,9 @@ func Up(ctx context.Context, pool *pgxpool.Pool, migrationsDir string, opts ...O
 		return fmt.Errorf("resolve migrations directory: %w", err)
 	}
 
+	gooseMu.Lock()
+	defer gooseMu.Unlock()
+
 	// Convert pgx pool to sql.DB
 	db := stdlib.OpenDBFromPool(pool)
 	defer func() {
@@ -125,10 +131,7 @@ func Up(ctx context.Context, pool *pgxpool.Pool, migrationsDir string, opts ...O
 		goose.SetLogger(options.Logger)
 	}
 
-	// Set custom table name if provided
-	if options.TableName != "" {
-		goose.SetTableName(options.TableName)
-	}
+	setGooseTableName(options.TableName)
 
 	// Set schema search_path if specified
 	if options.Schema != "" {
@@ -162,6 +165,9 @@ func Status(ctx context.Context, pool *pgxpool.Pool, migrationsDir string, opts 
 		return err
 	}
 
+	gooseMu.Lock()
+	defer gooseMu.Unlock()
+
 	db := stdlib.OpenDBFromPool(pool)
 	defer func() {
 		db.Close()
@@ -189,9 +195,7 @@ func Status(ctx context.Context, pool *pgxpool.Pool, migrationsDir string, opts 
 		}
 	}
 
-	if options.TableName != "" {
-		goose.SetTableName(options.TableName)
-	}
+	setGooseTableName(options.TableName)
 
 	return goose.StatusContext(ctx, db, resolvedDir)
 }
@@ -210,6 +214,9 @@ func Down(ctx context.Context, pool *pgxpool.Pool, migrationsDir string, opts ..
 	if err != nil {
 		return fmt.Errorf("resolve migrations directory: %w", err)
 	}
+
+	gooseMu.Lock()
+	defer gooseMu.Unlock()
 
 	db := stdlib.OpenDBFromPool(pool)
 	defer func() {
@@ -241,15 +248,20 @@ func Down(ctx context.Context, pool *pgxpool.Pool, migrationsDir string, opts ..
 		}
 	}
 
-	if options.TableName != "" {
-		goose.SetTableName(options.TableName)
-	}
+	setGooseTableName(options.TableName)
 
 	if err := goose.DownContext(ctx, db, resolvedDir); err != nil {
 		return fmt.Errorf("run down migration: %w", err)
 	}
 
 	return nil
+}
+
+func setGooseTableName(name string) {
+	if name == "" {
+		name = goose.DefaultTablename
+	}
+	goose.SetTableName(name)
 }
 
 // Create creates a new migration file in the specified directory.

--- a/pkg/migrate/migrate_test.go
+++ b/pkg/migrate/migrate_test.go
@@ -28,6 +28,7 @@ func TestUpWithSchemaRestoresPoolSearchPath(t *testing.T) {
 
 	pool, err := dbpool.New(ctx, dbpool.Options{
 		DatabaseURL: dbURL,
+		MaxConns:    4,
 		Schema:      appSchema,
 	})
 	if err != nil {
@@ -92,6 +93,7 @@ func TestUpWithDistinctTableNamesAvoidsVersionCollisions(t *testing.T) {
 
 	pool, err := dbpool.New(ctx, dbpool.Options{
 		DatabaseURL: dbURL,
+		MaxConns:    4,
 		Schema:      appSchema,
 	})
 	if err != nil {
@@ -142,6 +144,78 @@ DROP TABLE IF EXISTS %s;
 			t.Fatalf("query table %s existence: %v", table, err)
 		}
 		if exists == "" {
+			t.Fatalf("expected table %s to exist", table)
+		}
+	}
+}
+
+func TestUpResetsDefaultTableNameAfterCustomTableName(t *testing.T) {
+	dbURL := os.Getenv("INTEGRATION_DATABASE_URL")
+	if dbURL == "" {
+		dbURL = os.Getenv("TEST_DATABASE_URL")
+	}
+	if dbURL == "" {
+		t.Skip("missing INTEGRATION_DATABASE_URL or TEST_DATABASE_URL")
+	}
+
+	ctx := context.Background()
+	appSchema := fmt.Sprintf("migrate_table_reset_test_%s", strings.ReplaceAll(uuid.NewString(), "-", ""))
+
+	pool, err := dbpool.New(ctx, dbpool.Options{
+		DatabaseURL: dbURL,
+		MaxConns:    4,
+		Schema:      appSchema,
+	})
+	if err != nil {
+		t.Fatalf("connect test database: %v", err)
+	}
+	defer pool.Close()
+
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE", appSchema))
+	})
+
+	writeMigration := func(dir, filename, table string) {
+		t.Helper()
+		migration := fmt.Sprintf(`-- +goose Up
+CREATE TABLE %s (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid()
+);
+
+-- +goose Down
+DROP TABLE %s;
+`, table, table)
+		if err := os.WriteFile(filepath.Join(dir, filename), []byte(migration), 0o644); err != nil {
+			t.Fatalf("write migration %s: %v", filename, err)
+		}
+	}
+
+	customDir := t.TempDir()
+	defaultDir := t.TempDir()
+	writeMigration(customDir, "00001_create_custom.sql", "custom_records")
+	writeMigration(defaultDir, "00001_create_default.sql", "default_records")
+
+	if err := migrate.Up(ctx, pool, customDir,
+		migrate.WithSchema(appSchema),
+		migrate.WithTableName("goose_custom"),
+	); err != nil {
+		t.Fatalf("run custom-table migration: %v", err)
+	}
+	if err := migrate.Up(ctx, pool, defaultDir, migrate.WithSchema(appSchema)); err != nil {
+		t.Fatalf("run default-table migration: %v", err)
+	}
+
+	for _, table := range []string{
+		"custom_records",
+		"default_records",
+		"goose_custom",
+		"goose_db_version",
+	} {
+		var exists bool
+		if err := pool.QueryRow(ctx, "SELECT to_regclass($1) IS NOT NULL", table).Scan(&exists); err != nil {
+			t.Fatalf("query table %s existence: %v", table, err)
+		}
+		if !exists {
 			t.Fatalf("expected table %s to exist", table)
 		}
 	}


### PR DESCRIPTION
## Summary

- reset the goose version table to `goose_db_version` whenever a migration set does not specify a custom table
- serialize migrations while configuring and using goose process-global state
- add a regression test for a custom migration table followed by the default table

## Production failure

The `main-e0591eb` rollout left the new manager in CrashLoopBackOff. Manager startup first migrated `quota.goose_db_version`, then egress auth changed goose's process-global table name. The embedded storage runtime later ran quota migrations against the leaked table name and tried to reapply `00002_unify_quota_policies.sql`, failing on an already-existing constraint.

## Verification

- `go test ./pkg/migrate ./pkg/quota ./storage-proxy/pkg/runtime ./manager/cmd/manager`
- `go vet ./pkg/migrate ./pkg/quota ./storage-proxy/pkg/runtime ./manager/cmd/manager`
- `TEST_DATABASE_URL=... go test ./pkg/migrate -count=1 -v` against a temporary PostgreSQL instance