### PR TITLE
fix(storage): close snapshot metering on volume delete

### DIFF
--- a/storage-proxy/pkg/db/repository.go
+++ b/storage-proxy/pkg/db/repository.go
@@ -657,7 +657,16 @@ func (r *Repository) getSnapshot(ctx context.Context, db DB, id string, forUpdat
 
 // ListSnapshotsByVolume retrieves all snapshots for a volume
 func (r *Repository) ListSnapshotsByVolume(ctx context.Context, volumeID string) ([]*Snapshot, error) {
-	rows, err := r.pool.Query(ctx, `
+	return r.listSnapshotsByVolume(ctx, r.pool, volumeID, false)
+}
+
+// ListSnapshotsByVolumeForUpdate retrieves and locks all snapshots for a volume.
+func (r *Repository) ListSnapshotsByVolumeForUpdate(ctx context.Context, tx pgx.Tx, volumeID string) ([]*Snapshot, error) {
+	return r.listSnapshotsByVolume(ctx, tx, volumeID, true)
+}
+
+func (r *Repository) listSnapshotsByVolume(ctx context.Context, db DB, volumeID string, forUpdate bool) ([]*Snapshot, error) {
+	query := `
 		SELECT
 			id, volume_id, team_id, user_id,
 			root_inode, source_inode,
@@ -666,7 +675,12 @@ func (r *Repository) ListSnapshotsByVolume(ctx context.Context, volumeID string)
 		FROM sandbox_volume_snapshots
 		WHERE volume_id = $1
 		ORDER BY created_at DESC
-	`, volumeID)
+	`
+	if forUpdate {
+		query += " FOR UPDATE NOWAIT"
+	}
+
+	rows, err := db.Query(ctx, query, volumeID)
 	if err != nil {
 		return nil, fmt.Errorf("query snapshots: %w", err)
 	}

--- a/storage-proxy/pkg/http/handlers_metering_test.go
+++ b/storage-proxy/pkg/http/handlers_metering_test.go
@@ -3,6 +3,7 @@ package http
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -86,6 +87,10 @@ func (r *fakeHTTPRepo) GetSandboxVolume(ctx context.Context, id string) (*db.San
 		return nil, db.ErrNotFound
 	}
 	return volume, nil
+}
+
+func (r *fakeHTTPRepo) GetSandboxVolumeForUpdate(ctx context.Context, tx pgx.Tx, id string) (*db.SandboxVolume, error) {
+	return r.GetSandboxVolume(ctx, id)
 }
 
 func (r *fakeHTTPRepo) GetSandboxVolumeOwner(ctx context.Context, volumeID string) (*db.SandboxVolumeOwner, error) {
@@ -228,6 +233,9 @@ type fakeHTTPSnapshotManager struct {
 	casefoldEntries      []snapshot.SnapshotCasefoldCollision
 	compatibilityIssues  []pathnorm.CompatibilityIssue
 	deletedSnapshot      []string
+	deletedVolumeSnaps   []string
+	deletedVolumeSnapAt  []time.Time
+	deleteVolumeSnapsErr error
 	cleanedVolumeObjects []string
 }
 
@@ -286,6 +294,15 @@ func (f *fakeHTTPSnapshotManager) RestoreSnapshot(ctx context.Context, req *snap
 
 func (f *fakeHTTPSnapshotManager) DeleteSnapshot(ctx context.Context, volumeID, snapshotID, teamID string) error {
 	f.deletedSnapshot = append(f.deletedSnapshot, snapshotID)
+	return nil
+}
+
+func (f *fakeHTTPSnapshotManager) DeleteSnapshotsForVolumeTx(ctx context.Context, tx pgx.Tx, volumeID, teamID string, deletedAt time.Time) error {
+	if f.deleteVolumeSnapsErr != nil {
+		return f.deleteVolumeSnapsErr
+	}
+	f.deletedVolumeSnaps = append(f.deletedVolumeSnaps, volumeID)
+	f.deletedVolumeSnapAt = append(f.deletedVolumeSnapAt, deletedAt)
 	return nil
 }
 
@@ -421,6 +438,9 @@ func TestDeleteSandboxVolumeForceRecordsMetering(t *testing.T) {
 	if len(repo.deletedVolume) != 1 || repo.deletedVolume[0] != "vol-1" {
 		t.Fatalf("deleted volume = %v, want [vol-1]", repo.deletedVolume)
 	}
+	if len(snapshotMgr.deletedVolumeSnaps) != 1 || snapshotMgr.deletedVolumeSnaps[0] != "vol-1" {
+		t.Fatalf("deleted volume snapshots = %v, want [vol-1]", snapshotMgr.deletedVolumeSnaps)
+	}
 	if len(snapshotMgr.cleanedVolumeObjects) != 1 || snapshotMgr.cleanedVolumeObjects[0] != "vol-1" {
 		t.Fatalf("cleaned volume objects = %v, want [vol-1]", snapshotMgr.cleanedVolumeObjects)
 	}
@@ -442,6 +462,54 @@ func TestDeleteSandboxVolumeForceRecordsMetering(t *testing.T) {
 	}
 	if len(meteringWriter.watermarks) != 2 {
 		t.Fatalf("watermark count = %d, want 2", len(meteringWriter.watermarks))
+	}
+	if len(snapshotMgr.deletedVolumeSnapAt) != 1 || !snapshotMgr.deletedVolumeSnapAt[0].Equal(event.OccurredAt) {
+		t.Fatalf("snapshot deletion time = %v, want %v", snapshotMgr.deletedVolumeSnapAt, event.OccurredAt)
+	}
+}
+
+func TestDeleteSandboxVolumeKeepsVolumeWhenSnapshotMeteringFails(t *testing.T) {
+	repo := newFakeHTTPRepo()
+	repo.volumes["vol-1"] = &db.SandboxVolume{
+		ID:        "vol-1",
+		TeamID:    "team-1",
+		UserID:    "user-1",
+		CreatedAt: time.Date(2026, 3, 12, 10, 0, 0, 0, time.UTC),
+	}
+	meteringWriter := &fakeHTTPMeteringRepository{}
+	snapshotMgr := &fakeHTTPSnapshotManager{deleteVolumeSnapsErr: errors.New("close snapshot metering")}
+	server := &Server{
+		logger:       logrus.New(),
+		repo:         repo,
+		meteringRepo: meteringWriter,
+		regionID:     "aws-us-east-1",
+		snapshotMgr:  snapshotMgr,
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, "/sandboxvolumes/vol-1?force=true", nil)
+	req.SetPathValue("id", "vol-1")
+	req = req.WithContext(internalauth.WithClaims(req.Context(), &internalauth.Claims{
+		TeamID: "team-1",
+		UserID: "user-1",
+	}))
+	recorder := httptest.NewRecorder()
+
+	server.deleteSandboxVolume(recorder, req)
+
+	if recorder.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusInternalServerError)
+	}
+	if _, ok := repo.volumes["vol-1"]; !ok {
+		t.Fatal("volume was deleted after snapshot metering failed")
+	}
+	if len(repo.deletedVolume) != 0 {
+		t.Fatalf("deleted volume = %v, want none", repo.deletedVolume)
+	}
+	if len(meteringWriter.events) != 0 || len(meteringWriter.closedStorage) != 0 {
+		t.Fatalf("volume metering changed after snapshot metering failed: events=%d closed=%d", len(meteringWriter.events), len(meteringWriter.closedStorage))
+	}
+	if len(snapshotMgr.cleanedVolumeObjects) != 0 {
+		t.Fatalf("cleaned volume objects = %v, want none", snapshotMgr.cleanedVolumeObjects)
 	}
 }
 

--- a/storage-proxy/pkg/http/handlers_sandboxvolume.go
+++ b/storage-proxy/pkg/http/handlers_sandboxvolume.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	meteringpkg "github.com/sandbox0-ai/sandbox0/pkg/metering"
@@ -522,22 +523,15 @@ func (s *Server) deleteSandboxVolume(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// No active mounts, proceed with deletion
-	if err := s.repo.WithTx(r.Context(), func(tx pgx.Tx) error {
-		if err := s.repo.DeleteSandboxVolumeTx(r.Context(), tx, id); err != nil {
-			return err
-		}
-		deletedEvent := volumeDeletedEvent(s.regionID, vol)
-		if err := s.closeStorageObservationTx(r.Context(), tx, s.volumeStorageObservation(vol, nil, 0, deletedEvent.OccurredAt)); err != nil {
-			return err
-		}
-		if err := s.appendMeteringEventTx(r.Context(), tx, deletedEvent); err != nil {
-			return err
-		}
-		return nil
-	}); err != nil {
+	// No active mounts, proceed with deletion.
+	deletedVolume, err := s.deleteSandboxVolumeTx(r.Context(), id)
+	if err != nil {
 		if errors.Is(err, db.ErrNotFound) {
 			_ = spec.WriteSuccess(w, http.StatusOK, map[string]bool{"deleted": true})
+			return
+		}
+		if errors.Is(err, snapshot.ErrVolumeBusy) {
+			_ = spec.WriteError(w, http.StatusConflict, spec.CodeConflict, snapshot.ErrVolumeBusy.Error())
 			return
 		}
 		s.logger.WithError(err).Error("Failed to delete sandbox volume")
@@ -545,9 +539,49 @@ func (s *Server) deleteSandboxVolume(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.cleanupDeletedSandboxVolumeObjects(r.Context(), vol)
-	s.logger.WithField("volume_id", id).WithField("team_id", vol.TeamID).Info("Sandbox volume deleted")
+	s.cleanupDeletedSandboxVolumeObjects(r.Context(), deletedVolume)
+	s.logger.WithField("volume_id", id).WithField("team_id", deletedVolume.TeamID).Info("Sandbox volume deleted")
 	_ = spec.WriteSuccess(w, http.StatusOK, map[string]bool{"deleted": true})
+}
+
+func (s *Server) deleteSandboxVolumeTx(ctx context.Context, id string) (*db.SandboxVolume, error) {
+	if s.snapshotMgr == nil {
+		return nil, errors.New("snapshot manager is required to delete a sandbox volume")
+	}
+
+	var deletedVolume *db.SandboxVolume
+	err := s.repo.WithTx(ctx, func(tx pgx.Tx) error {
+		volume, err := s.repo.GetSandboxVolumeForUpdate(ctx, tx, id)
+		if err != nil {
+			var pgErr *pgconn.PgError
+			if errors.As(err, &pgErr) && pgErr.Code == "55P03" {
+				return snapshot.ErrVolumeBusy
+			}
+			return err
+		}
+
+		deletedEvent := volumeDeletedEvent(s.regionID, volume)
+		if err := s.snapshotMgr.DeleteSnapshotsForVolumeTx(ctx, tx, volume.ID, volume.TeamID, deletedEvent.OccurredAt); err != nil {
+			return fmt.Errorf("delete volume snapshots: %w", err)
+		}
+		storageObservation := s.volumeStorageObservation(volume, nil, 0, deletedEvent.OccurredAt)
+		if err := s.repo.DeleteSandboxVolumeTx(ctx, tx, id); err != nil {
+			return err
+		}
+		if err := s.closeStorageObservationTx(ctx, tx, storageObservation); err != nil {
+			return err
+		}
+		if err := s.appendMeteringEventTx(ctx, tx, deletedEvent); err != nil {
+			return err
+		}
+
+		deletedVolume = volume
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return deletedVolume, nil
 }
 
 func (s *Server) deleteSandboxVolumeRecord(ctx context.Context, id string, force bool) (*db.SandboxVolume, error) {
@@ -587,19 +621,8 @@ func (s *Server) deleteSandboxVolumeRecord(ctx context.Context, id string, force
 			}
 		}
 	}
-	if err := s.repo.WithTx(ctx, func(tx pgx.Tx) error {
-		if err := s.repo.DeleteSandboxVolumeTx(ctx, tx, id); err != nil {
-			return err
-		}
-		deletedEvent := volumeDeletedEvent(s.regionID, vol)
-		if err := s.closeStorageObservationTx(ctx, tx, s.volumeStorageObservation(vol, nil, 0, deletedEvent.OccurredAt)); err != nil {
-			return err
-		}
-		if err := s.appendMeteringEventTx(ctx, tx, deletedEvent); err != nil {
-			return err
-		}
-		return nil
-	}); err != nil {
+	vol, err = s.deleteSandboxVolumeTx(ctx, id)
+	if err != nil {
 		return nil, err
 	}
 	s.cleanupDeletedSandboxVolumeObjects(ctx, vol)
@@ -866,7 +889,7 @@ func (s *Server) deleteOwnedSandboxVolume(w http.ResponseWriter, r *http.Request
 	if _, err := s.deleteSandboxVolumeRecord(r.Context(), id, false); err != nil {
 		_ = s.repo.MarkOwnedSandboxVolumeCleanupAttempt(r.Context(), id, err)
 		status, code := http.StatusInternalServerError, spec.CodeInternal
-		if errors.Is(err, errVolumeHasActiveMounts) {
+		if errors.Is(err, errVolumeHasActiveMounts) || errors.Is(err, snapshot.ErrVolumeBusy) {
 			status, code = http.StatusConflict, spec.CodeConflict
 		}
 		_ = spec.WriteError(w, status, code, err.Error())

--- a/storage-proxy/pkg/http/handlers_sandboxvolume.go
+++ b/storage-proxy/pkg/http/handlers_sandboxvolume.go
@@ -585,7 +585,7 @@ func (s *Server) deleteSandboxVolumeTx(ctx context.Context, id string) (*db.Sand
 }
 
 func (s *Server) deleteSandboxVolumeRecord(ctx context.Context, id string, force bool) (*db.SandboxVolume, error) {
-	vol, err := s.repo.GetSandboxVolume(ctx, id)
+	_, err := s.repo.GetSandboxVolume(ctx, id)
 	if err != nil {
 		if errors.Is(err, db.ErrNotFound) {
 			return nil, db.ErrNotFound
@@ -621,7 +621,7 @@ func (s *Server) deleteSandboxVolumeRecord(ctx context.Context, id string, force
 			}
 		}
 	}
-	vol, err = s.deleteSandboxVolumeTx(ctx, id)
+	vol, err := s.deleteSandboxVolumeTx(ctx, id)
 	if err != nil {
 		return nil, err
 	}

--- a/storage-proxy/pkg/http/server.go
+++ b/storage-proxy/pkg/http/server.go
@@ -37,6 +37,7 @@ type volumeRepository interface {
 	ListSandboxVolumesByTeam(ctx context.Context, teamID string) ([]*db.SandboxVolume, error)
 	ListOwnedSandboxVolumes(ctx context.Context, clusterID string, cleanupRequested *bool) ([]*db.OwnedSandboxVolume, error)
 	GetSandboxVolume(ctx context.Context, id string) (*db.SandboxVolume, error)
+	GetSandboxVolumeForUpdate(ctx context.Context, tx pgx.Tx, id string) (*db.SandboxVolume, error)
 	GetSandboxVolumeOwner(ctx context.Context, volumeID string) (*db.SandboxVolumeOwner, error)
 	GetOwnedSandboxVolumeByOwner(ctx context.Context, clusterID, sandboxID, purpose string) (*db.OwnedSandboxVolume, error)
 	GetActiveMounts(ctx context.Context, volumeID string, heartbeatTimeout int) ([]*db.VolumeMount, error)
@@ -78,6 +79,7 @@ type snapshotManager interface {
 	ExportSnapshotArchive(ctx context.Context, req *snapshot.ExportSnapshotRequest, w io.Writer) error
 	RestoreSnapshot(ctx context.Context, req *snapshot.RestoreSnapshotRequest) error
 	DeleteSnapshot(ctx context.Context, volumeID, snapshotID, teamID string) error
+	DeleteSnapshotsForVolumeTx(ctx context.Context, tx pgx.Tx, volumeID, teamID string, deletedAt time.Time) error
 	DeleteVolumeObjectsIfUnreferenced(ctx context.Context, volume *db.SandboxVolume) error
 	ForkVolume(ctx context.Context, req *snapshot.ForkVolumeRequest) (*db.SandboxVolume, error)
 	CreateVolumeFromSnapshot(ctx context.Context, req *snapshot.CreateVolumeFromSnapshotRequest) (*db.SandboxVolume, error)

--- a/storage-proxy/pkg/snapshot/manager.go
+++ b/storage-proxy/pkg/snapshot/manager.go
@@ -36,6 +36,7 @@ type repository interface {
 	CreateSandboxVolume(context.Context, *db.SandboxVolume) error
 	CreateSandboxVolumeTx(context.Context, pgx.Tx, *db.SandboxVolume) error
 	ListSnapshotsByVolume(context.Context, string) ([]*db.Snapshot, error)
+	ListSnapshotsByVolumeForUpdate(context.Context, pgx.Tx, string) ([]*db.Snapshot, error)
 	GetSnapshot(context.Context, string) (*db.Snapshot, error)
 	CreateSnapshot(context.Context, *db.Snapshot) error
 	DeleteSnapshot(context.Context, string) error
@@ -634,6 +635,44 @@ func (m *Manager) DeleteSnapshot(ctx context.Context, volumeID, snapshotID, team
 	return nil
 }
 
+// DeleteSnapshotsForVolumeTx deletes every snapshot attached to a volume and
+// closes their metering projections in the caller's volume deletion transaction.
+func (m *Manager) DeleteSnapshotsForVolumeTx(ctx context.Context, tx pgx.Tx, volumeID, teamID string, deletedAt time.Time) error {
+	if deletedAt.IsZero() {
+		deletedAt = time.Now().UTC()
+	} else {
+		deletedAt = deletedAt.UTC()
+	}
+
+	snapshots, err := m.repo.ListSnapshotsByVolumeForUpdate(ctx, tx, volumeID)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "55P03" {
+			return ErrVolumeBusy
+		}
+		return fmt.Errorf("list volume snapshots: %w", err)
+	}
+
+	for _, snapshot := range snapshots {
+		if snapshot.VolumeID != volumeID || snapshot.TeamID != teamID {
+			return ErrSnapshotNotBelongToVolume
+		}
+		if err := m.repo.DeleteSnapshotTx(ctx, tx, snapshot.ID); err != nil {
+			return fmt.Errorf("delete snapshot record %s: %w", snapshot.ID, err)
+		}
+
+		deletedEvent := snapshotDeletedEventAt(m.regionID(), m.clusterID, snapshot, deletedAt)
+		if err := m.closeStorageObservationTx(ctx, tx, m.snapshotStorageObservation(ctx, snapshot, deletedAt)); err != nil {
+			return fmt.Errorf("close snapshot storage observation %s: %w", snapshot.ID, err)
+		}
+		if err := m.appendMeteringEventTx(ctx, tx, deletedEvent); err != nil {
+			return fmt.Errorf("append snapshot deletion event %s: %w", snapshot.ID, err)
+		}
+	}
+
+	return nil
+}
+
 func snapshotCreatedEvent(regionID, clusterID string, snapshot *db.Snapshot) *meteringpkg.Event {
 	return &meteringpkg.Event{
 		EventID:     fmt.Sprintf("snapshot/%s/created/%d", snapshot.ID, snapshot.CreatedAt.UTC().UnixNano()),
@@ -652,9 +691,13 @@ func snapshotCreatedEvent(regionID, clusterID string, snapshot *db.Snapshot) *me
 }
 
 func snapshotDeletedEvent(regionID, clusterID string, snapshot *db.Snapshot) *meteringpkg.Event {
-	now := time.Now().UTC()
+	return snapshotDeletedEventAt(regionID, clusterID, snapshot, time.Now().UTC())
+}
+
+func snapshotDeletedEventAt(regionID, clusterID string, snapshot *db.Snapshot, deletedAt time.Time) *meteringpkg.Event {
+	deletedAt = deletedAt.UTC()
 	return &meteringpkg.Event{
-		EventID:     fmt.Sprintf("snapshot/%s/deleted/%d", snapshot.ID, now.UnixNano()),
+		EventID:     fmt.Sprintf("snapshot/%s/deleted/%d", snapshot.ID, deletedAt.UnixNano()),
 		Producer:    "storage-proxy.snapshot",
 		RegionID:    regionID,
 		EventType:   meteringpkg.EventTypeSnapshotDeleted,
@@ -665,7 +708,7 @@ func snapshotDeletedEvent(regionID, clusterID string, snapshot *db.Snapshot) *me
 		VolumeID:    snapshot.VolumeID,
 		SnapshotID:  snapshot.ID,
 		ClusterID:   clusterID,
-		OccurredAt:  now,
+		OccurredAt:  deletedAt,
 	}
 }
 

--- a/storage-proxy/pkg/snapshot/manager_test.go
+++ b/storage-proxy/pkg/snapshot/manager_test.go
@@ -111,6 +111,10 @@ func (r *fakeRepo) ListSnapshotsByVolume(ctx context.Context, volumeID string) (
 	return snaps, nil
 }
 
+func (r *fakeRepo) ListSnapshotsByVolumeForUpdate(ctx context.Context, tx pgx.Tx, volumeID string) ([]*db.Snapshot, error) {
+	return r.ListSnapshotsByVolume(ctx, volumeID)
+}
+
 func (r *fakeRepo) ListSandboxVolumesBySource(ctx context.Context, sourceVolumeID string) ([]*db.SandboxVolume, error) {
 	var volumes []*db.SandboxVolume
 	for _, volume := range r.volumes {
@@ -630,6 +634,70 @@ func TestDeleteSnapshotRecordsMetering(t *testing.T) {
 	}
 	if len(meteringRecorder.watermarks) != 2 {
 		t.Fatalf("expected two watermarks, got %d", len(meteringRecorder.watermarks))
+	}
+}
+
+func TestDeleteSnapshotsForVolumeTxRecordsMetering(t *testing.T) {
+	repo := newFakeRepo()
+	createdAt := time.Date(2026, 3, 12, 10, 0, 0, 0, time.UTC)
+	repo.snapshots["snap1"] = &db.Snapshot{
+		ID:        "snap1",
+		VolumeID:  "vol1",
+		TeamID:    "team1",
+		UserID:    "user1",
+		SizeBytes: 128,
+		CreatedAt: createdAt,
+	}
+	repo.snapshots["snap2"] = &db.Snapshot{
+		ID:        "snap2",
+		VolumeID:  "vol1",
+		TeamID:    "team1",
+		UserID:    "user1",
+		SizeBytes: 256,
+		CreatedAt: createdAt.Add(time.Hour),
+	}
+	mgr := newTestManager(repo, nil)
+	mgr.config.RegionID = "aws-us-east-1"
+	meteringRecorder := &fakeMeteringRecorder{}
+	mgr.SetMeteringRepository(meteringRecorder)
+	deletedAt := time.Date(2026, 3, 14, 15, 30, 0, 0, time.UTC)
+
+	if err := mgr.DeleteSnapshotsForVolumeTx(context.Background(), nil, "vol1", "team1", deletedAt); err != nil {
+		t.Fatalf("DeleteSnapshotsForVolumeTx() error = %v", err)
+	}
+	if len(repo.snapshots) != 0 {
+		t.Fatalf("remaining snapshots = %v, want none", repo.snapshots)
+	}
+	if len(meteringRecorder.events) != 2 {
+		t.Fatalf("event count = %d, want 2", len(meteringRecorder.events))
+	}
+	if len(meteringRecorder.closedStorage) != 2 {
+		t.Fatalf("closed storage count = %d, want 2", len(meteringRecorder.closedStorage))
+	}
+	if len(meteringRecorder.watermarks) != 4 {
+		t.Fatalf("watermark count = %d, want 4", len(meteringRecorder.watermarks))
+	}
+
+	eventSubjects := make(map[string]bool, 2)
+	for _, event := range meteringRecorder.events {
+		if event.EventType != metering.EventTypeSnapshotDeleted {
+			t.Fatalf("event type = %q, want %q", event.EventType, metering.EventTypeSnapshotDeleted)
+		}
+		if !event.OccurredAt.Equal(deletedAt) {
+			t.Fatalf("event occurred_at = %v, want %v", event.OccurredAt, deletedAt)
+		}
+		eventSubjects[event.SubjectID] = true
+	}
+	if !eventSubjects["snap1"] || !eventSubjects["snap2"] {
+		t.Fatalf("event subjects = %v, want snap1 and snap2", eventSubjects)
+	}
+	for _, observation := range meteringRecorder.closedStorage {
+		if observation.SubjectType != metering.SubjectTypeSnapshot {
+			t.Fatalf("observation subject type = %q, want %q", observation.SubjectType, metering.SubjectTypeSnapshot)
+		}
+		if !observation.ObservedAt.Equal(deletedAt) {
+			t.Fatalf("observation observed_at = %v, want %v", observation.ObservedAt, deletedAt)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- lock the parent volume and its snapshots inside the volume deletion transaction
- delete snapshot records while closing each storage projection and appending snapshot deletion events at the same deletion timestamp
- share the corrected transaction across public and owned-volume deletion paths, returning a conflict on concurrent mutations

## Root cause

The snapshot foreign key uses ON DELETE CASCADE. Deleting a parent volume therefore removed snapshot metadata without going through the snapshot deletion path, leaving snapshot storage projections active and continuing to generate byte-hours.

## Operational note

This prevents new orphaned projections. Historical overcount still requires a separate one-time data repair after the fix is deployed.

## Tests

- go test ./storage-proxy/...