### PR TITLE
fix(storage): report S0FS statfs usage accurately

### DIFF
--- a/docs/volume/page.mdx
+++ b/docs/volume/page.mdx
@@ -60,7 +60,7 @@ Volume detail and list responses expose the latest storage observation for `s0fs
 
 Both fields are `null` for external `s3` volumes and when a current metering projection is unavailable. These fields describe the latest current size; they are separate from historical `sandbox.volume_byte_hours` usage windows.
 
-For an `s0fs` mount, filesystem tools such as `df` report the current logical file bytes as used space plus a 4 TiB virtual availability window. Object storage does not expose a meaningful per-Volume disk size, so this virtual value is not a storage allocation, hard quota, or node filesystem capacity. Use `metered_storage_bytes` for the authoritative current logical payload size; platform quotas and ctld node-local cache safeguards are separate controls.
+For an `s0fs` mount, filesystem tools such as `df` report the current logical file bytes against a stable 4 TiB virtual capacity. Object storage does not expose a meaningful per-Volume disk size, so this virtual value is not a storage allocation, hard quota, or node filesystem capacity. Use `metered_storage_bytes` for the authoritative current logical payload size; platform quotas and ctld node-local cache safeguards are separate controls.
 
 ## Correctness Model
 

--- a/docs/volume/page.mdx
+++ b/docs/volume/page.mdx
@@ -60,6 +60,8 @@ Volume detail and list responses expose the latest storage observation for `s0fs
 
 Both fields are `null` for external `s3` volumes and when a current metering projection is unavailable. These fields describe the latest current size; they are separate from historical `sandbox.volume_byte_hours` usage windows.
 
+For an `s0fs` mount, filesystem tools such as `df` report the current logical file bytes as used space plus a 4 TiB virtual availability window. Object storage does not expose a meaningful per-Volume disk size, so this virtual value is not a storage allocation, hard quota, or node filesystem capacity. Use `metered_storage_bytes` for the authoritative current logical payload size; platform quotas and ctld node-local cache safeguards are separate controls.
+
 ## Correctness Model
 
 For mounted `RWO` volumes, Sandbox0 keeps one active writable owner at a time.

--- a/storage-proxy/pkg/fsserver/server.go
+++ b/storage-proxy/pkg/fsserver/server.go
@@ -934,9 +934,9 @@ func (s *FileSystemServer) Rmdir(ctx context.Context, req *pb.RmdirRequest) (*pb
 }
 
 const (
-	s0fsStatFSBlockSize              = uint64(4096)
-	s0fsStatFSVirtualAvailableBlocks = uint64(1 << 30)
-	s0fsStatFSVirtualAvailableFiles  = uint64(1 << 30)
+	s0fsStatFSBlockSize     = uint64(4096)
+	s0fsStatFSVirtualBlocks = uint64(1 << 30)
+	s0fsStatFSVirtualFiles  = uint64(1 << 30)
 )
 
 // StatFs implements FUSE statfs (filesystem statistics)
@@ -954,15 +954,22 @@ func (s *FileSystemServer) StatFs(ctx context.Context, req *pb.StatFsRequest) (*
 		if usage.DataBytes%s0fsStatFSBlockSize != 0 {
 			usedBlocks++
 		}
-		// S0FS has no per-volume disk capacity. Keep a stable virtual free
-		// window and add live usage to the total instead of advertising a
-		// cosmetic hard limit or leaking the node filesystem size.
+		freeBlocks := uint64(0)
+		if usedBlocks < s0fsStatFSVirtualBlocks {
+			freeBlocks = s0fsStatFSVirtualBlocks - usedBlocks
+		}
+		freeFiles := uint64(0)
+		if usage.Inodes < s0fsStatFSVirtualFiles {
+			freeFiles = s0fsStatFSVirtualFiles - usage.Inodes
+		}
+		// S0FS has no per-volume disk capacity. Expose a stable virtual size
+		// and subtract live usage without leaking the node filesystem size.
 		return &pb.StatFsResponse{
-			Blocks:  s0fsStatFSVirtualAvailableBlocks + usedBlocks,
-			Bfree:   s0fsStatFSVirtualAvailableBlocks,
-			Bavail:  s0fsStatFSVirtualAvailableBlocks,
-			Files:   s0fsStatFSVirtualAvailableFiles + usage.Inodes,
-			Ffree:   s0fsStatFSVirtualAvailableFiles,
+			Blocks:  s0fsStatFSVirtualBlocks,
+			Bfree:   freeBlocks,
+			Bavail:  freeBlocks,
+			Files:   s0fsStatFSVirtualFiles,
+			Ffree:   freeFiles,
 			Bsize:   uint32(s0fsStatFSBlockSize),
 			Namelen: 255,
 			Frsize:  uint32(s0fsStatFSBlockSize),

--- a/storage-proxy/pkg/fsserver/server.go
+++ b/storage-proxy/pkg/fsserver/server.go
@@ -933,6 +933,12 @@ func (s *FileSystemServer) Rmdir(ctx context.Context, req *pb.RmdirRequest) (*pb
 	})
 }
 
+const (
+	s0fsStatFSBlockSize              = uint64(4096)
+	s0fsStatFSVirtualAvailableBlocks = uint64(1 << 30)
+	s0fsStatFSVirtualAvailableFiles  = uint64(1 << 30)
+)
+
 // StatFs implements FUSE statfs (filesystem statistics)
 func (s *FileSystemServer) StatFs(ctx context.Context, req *pb.StatFsRequest) (*pb.StatFsResponse, error) {
 	volCtx, err := s.getAuthorizedMountedVolume(ctx, req.VolumeId)
@@ -940,15 +946,26 @@ func (s *FileSystemServer) StatFs(ctx context.Context, req *pb.StatFsRequest) (*
 		return nil, err
 	}
 	if isS0FSVolume(volCtx) {
+		usage, err := volCtx.S0FS.FilesystemUsage()
+		if err != nil {
+			return nil, MapS0FSError(err)
+		}
+		usedBlocks := usage.DataBytes / s0fsStatFSBlockSize
+		if usage.DataBytes%s0fsStatFSBlockSize != 0 {
+			usedBlocks++
+		}
+		// S0FS has no per-volume disk capacity. Keep a stable virtual free
+		// window and add live usage to the total instead of advertising a
+		// cosmetic hard limit or leaking the node filesystem size.
 		return &pb.StatFsResponse{
-			Blocks:  262144,
-			Bfree:   131072,
-			Bavail:  131072,
-			Files:   1048576,
-			Ffree:   1048576,
-			Bsize:   4096,
+			Blocks:  s0fsStatFSVirtualAvailableBlocks + usedBlocks,
+			Bfree:   s0fsStatFSVirtualAvailableBlocks,
+			Bavail:  s0fsStatFSVirtualAvailableBlocks,
+			Files:   s0fsStatFSVirtualAvailableFiles + usage.Inodes,
+			Ffree:   s0fsStatFSVirtualAvailableFiles,
+			Bsize:   uint32(s0fsStatFSBlockSize),
 			Namelen: 255,
-			Frsize:  4096,
+			Frsize:  uint32(s0fsStatFSBlockSize),
 		}, nil
 	}
 

--- a/storage-proxy/pkg/fsserver/server_s0fs_test.go
+++ b/storage-proxy/pkg/fsserver/server_s0fs_test.go
@@ -107,6 +107,51 @@ func TestS0FSFileLifecycle(t *testing.T) {
 	}
 }
 
+func TestS0FSStatFsReportsLogicalUsageWithVirtualHeadroom(t *testing.T) {
+	t.Parallel()
+
+	volCtx := newMountedS0FSVolumeContext(t, "vol-statfs", "team-a")
+	server := newTestFileSystemServer(&fakeVolumeManager{
+		volumes: map[string]*volume.VolumeContext{
+			"vol-statfs": volCtx,
+		},
+	}, nil, nil)
+	ctx := authContext("team-a", "")
+
+	initial, err := server.StatFs(ctx, &pb.StatFsRequest{VolumeId: "vol-statfs"})
+	if err != nil {
+		t.Fatalf("StatFs(initial) error = %v", err)
+	}
+	if initial.Blocks != s0fsStatFSVirtualAvailableBlocks || initial.Bfree != s0fsStatFSVirtualAvailableBlocks || initial.Bavail != s0fsStatFSVirtualAvailableBlocks {
+		t.Fatalf("StatFs(initial) blocks = (%d, %d, %d), want (%d, %d, %d)", initial.Blocks, initial.Bfree, initial.Bavail, s0fsStatFSVirtualAvailableBlocks, s0fsStatFSVirtualAvailableBlocks, s0fsStatFSVirtualAvailableBlocks)
+	}
+	if initial.Files != s0fsStatFSVirtualAvailableFiles+1 || initial.Ffree != s0fsStatFSVirtualAvailableFiles {
+		t.Fatalf("StatFs(initial) files = (%d, %d), want (%d, %d)", initial.Files, initial.Ffree, s0fsStatFSVirtualAvailableFiles+1, s0fsStatFSVirtualAvailableFiles)
+	}
+
+	file, err := volCtx.S0FS.CreateFile(s0fs.RootInode, "data.bin", 0o644)
+	if err != nil {
+		t.Fatalf("CreateFile() error = %v", err)
+	}
+	if _, err := volCtx.S0FS.Write(file.Inode, 4096, []byte("data")); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	updated, err := server.StatFs(ctx, &pb.StatFsRequest{VolumeId: "vol-statfs"})
+	if err != nil {
+		t.Fatalf("StatFs(updated) error = %v", err)
+	}
+	if updated.Blocks != s0fsStatFSVirtualAvailableBlocks+2 || updated.Bfree != s0fsStatFSVirtualAvailableBlocks || updated.Bavail != s0fsStatFSVirtualAvailableBlocks {
+		t.Fatalf("StatFs(updated) blocks = (%d, %d, %d), want (%d, %d, %d)", updated.Blocks, updated.Bfree, updated.Bavail, s0fsStatFSVirtualAvailableBlocks+2, s0fsStatFSVirtualAvailableBlocks, s0fsStatFSVirtualAvailableBlocks)
+	}
+	if updated.Files != s0fsStatFSVirtualAvailableFiles+2 || updated.Ffree != s0fsStatFSVirtualAvailableFiles {
+		t.Fatalf("StatFs(updated) files = (%d, %d), want (%d, %d)", updated.Files, updated.Ffree, s0fsStatFSVirtualAvailableFiles+2, s0fsStatFSVirtualAvailableFiles)
+	}
+	if updated.Bsize != uint32(s0fsStatFSBlockSize) || updated.Frsize != uint32(s0fsStatFSBlockSize) {
+		t.Fatalf("StatFs(updated) block sizes = (%d, %d), want (%d, %d)", updated.Bsize, updated.Frsize, s0fsStatFSBlockSize, s0fsStatFSBlockSize)
+	}
+}
+
 func TestS0FSOperationsPreservePOSIXErrnos(t *testing.T) {
 	t.Parallel()
 

--- a/storage-proxy/pkg/fsserver/server_s0fs_test.go
+++ b/storage-proxy/pkg/fsserver/server_s0fs_test.go
@@ -107,7 +107,7 @@ func TestS0FSFileLifecycle(t *testing.T) {
 	}
 }
 
-func TestS0FSStatFsReportsLogicalUsageWithVirtualHeadroom(t *testing.T) {
+func TestS0FSStatFsReportsLogicalUsageAgainstVirtualCapacity(t *testing.T) {
 	t.Parallel()
 
 	volCtx := newMountedS0FSVolumeContext(t, "vol-statfs", "team-a")
@@ -122,11 +122,11 @@ func TestS0FSStatFsReportsLogicalUsageWithVirtualHeadroom(t *testing.T) {
 	if err != nil {
 		t.Fatalf("StatFs(initial) error = %v", err)
 	}
-	if initial.Blocks != s0fsStatFSVirtualAvailableBlocks || initial.Bfree != s0fsStatFSVirtualAvailableBlocks || initial.Bavail != s0fsStatFSVirtualAvailableBlocks {
-		t.Fatalf("StatFs(initial) blocks = (%d, %d, %d), want (%d, %d, %d)", initial.Blocks, initial.Bfree, initial.Bavail, s0fsStatFSVirtualAvailableBlocks, s0fsStatFSVirtualAvailableBlocks, s0fsStatFSVirtualAvailableBlocks)
+	if initial.Blocks != s0fsStatFSVirtualBlocks || initial.Bfree != s0fsStatFSVirtualBlocks || initial.Bavail != s0fsStatFSVirtualBlocks {
+		t.Fatalf("StatFs(initial) blocks = (%d, %d, %d), want (%d, %d, %d)", initial.Blocks, initial.Bfree, initial.Bavail, s0fsStatFSVirtualBlocks, s0fsStatFSVirtualBlocks, s0fsStatFSVirtualBlocks)
 	}
-	if initial.Files != s0fsStatFSVirtualAvailableFiles+1 || initial.Ffree != s0fsStatFSVirtualAvailableFiles {
-		t.Fatalf("StatFs(initial) files = (%d, %d), want (%d, %d)", initial.Files, initial.Ffree, s0fsStatFSVirtualAvailableFiles+1, s0fsStatFSVirtualAvailableFiles)
+	if initial.Files != s0fsStatFSVirtualFiles || initial.Ffree != s0fsStatFSVirtualFiles-1 {
+		t.Fatalf("StatFs(initial) files = (%d, %d), want (%d, %d)", initial.Files, initial.Ffree, s0fsStatFSVirtualFiles, s0fsStatFSVirtualFiles-1)
 	}
 
 	file, err := volCtx.S0FS.CreateFile(s0fs.RootInode, "data.bin", 0o644)
@@ -141,11 +141,11 @@ func TestS0FSStatFsReportsLogicalUsageWithVirtualHeadroom(t *testing.T) {
 	if err != nil {
 		t.Fatalf("StatFs(updated) error = %v", err)
 	}
-	if updated.Blocks != s0fsStatFSVirtualAvailableBlocks+2 || updated.Bfree != s0fsStatFSVirtualAvailableBlocks || updated.Bavail != s0fsStatFSVirtualAvailableBlocks {
-		t.Fatalf("StatFs(updated) blocks = (%d, %d, %d), want (%d, %d, %d)", updated.Blocks, updated.Bfree, updated.Bavail, s0fsStatFSVirtualAvailableBlocks+2, s0fsStatFSVirtualAvailableBlocks, s0fsStatFSVirtualAvailableBlocks)
+	if updated.Blocks != s0fsStatFSVirtualBlocks || updated.Bfree != s0fsStatFSVirtualBlocks-2 || updated.Bavail != s0fsStatFSVirtualBlocks-2 {
+		t.Fatalf("StatFs(updated) blocks = (%d, %d, %d), want (%d, %d, %d)", updated.Blocks, updated.Bfree, updated.Bavail, s0fsStatFSVirtualBlocks, s0fsStatFSVirtualBlocks-2, s0fsStatFSVirtualBlocks-2)
 	}
-	if updated.Files != s0fsStatFSVirtualAvailableFiles+2 || updated.Ffree != s0fsStatFSVirtualAvailableFiles {
-		t.Fatalf("StatFs(updated) files = (%d, %d), want (%d, %d)", updated.Files, updated.Ffree, s0fsStatFSVirtualAvailableFiles+2, s0fsStatFSVirtualAvailableFiles)
+	if updated.Files != s0fsStatFSVirtualFiles || updated.Ffree != s0fsStatFSVirtualFiles-2 {
+		t.Fatalf("StatFs(updated) files = (%d, %d), want (%d, %d)", updated.Files, updated.Ffree, s0fsStatFSVirtualFiles, s0fsStatFSVirtualFiles-2)
 	}
 	if updated.Bsize != uint32(s0fsStatFSBlockSize) || updated.Frsize != uint32(s0fsStatFSBlockSize) {
 		t.Fatalf("StatFs(updated) block sizes = (%d, %d), want (%d, %d)", updated.Bsize, updated.Frsize, s0fsStatFSBlockSize, s0fsStatFSBlockSize)

--- a/storage-proxy/pkg/s0fs/usage.go
+++ b/storage-proxy/pkg/s0fs/usage.go
@@ -1,0 +1,37 @@
+package s0fs
+
+// FilesystemUsage describes the logical data and inode usage of a live S0FS
+// engine. Hard links share an inode and are counted once. Retained unlinked
+// inodes remain included until Forget removes them.
+type FilesystemUsage struct {
+	DataBytes uint64
+	Inodes    uint64
+}
+
+// FilesystemUsage returns the current logical filesystem usage without cloning
+// the engine state. Metadata and object-store encoding overhead are excluded.
+func (e *Engine) FilesystemUsage() (FilesystemUsage, error) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	if err := e.checkOpen(); err != nil {
+		return FilesystemUsage{}, err
+	}
+
+	var usage FilesystemUsage
+	for _, node := range e.nodes {
+		if node == nil {
+			continue
+		}
+		usage.Inodes++
+		usage.DataBytes = addUint64Saturating(usage.DataBytes, node.Size)
+	}
+	return usage, nil
+}
+
+func addUint64Saturating(left, right uint64) uint64 {
+	const maxUint64 = ^uint64(0)
+	if maxUint64-left < right {
+		return maxUint64
+	}
+	return left + right
+}

--- a/storage-proxy/pkg/s0fs/usage_test.go
+++ b/storage-proxy/pkg/s0fs/usage_test.go
@@ -1,0 +1,82 @@
+package s0fs
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+func TestEngineFilesystemUsageTracksLogicalDataAndInodes(t *testing.T) {
+	engine, err := Open(context.Background(), Config{
+		VolumeID: "vol-1",
+		WALPath:  filepath.Join(t.TempDir(), "volume.wal"),
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer engine.Close()
+
+	assertFilesystemUsage(t, engine, FilesystemUsage{Inodes: 1})
+
+	dir, err := engine.Mkdir(RootInode, "dir", 0o755)
+	if err != nil {
+		t.Fatalf("Mkdir() error = %v", err)
+	}
+	file, err := engine.CreateFile(dir.Inode, "data.bin", 0o644)
+	if err != nil {
+		t.Fatalf("CreateFile() error = %v", err)
+	}
+	if _, err := engine.Write(file.Inode, 4096, []byte("data")); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	if _, err := engine.Symlink(RootInode, "data-link", "dir/data.bin", 0o777); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+	if _, err := engine.Link(file.Inode, RootInode, "data-hardlink"); err != nil {
+		t.Fatalf("Link() error = %v", err)
+	}
+
+	assertFilesystemUsage(t, engine, FilesystemUsage{DataBytes: 4100, Inodes: 4})
+
+	if err := engine.Unlink(dir.Inode, "data.bin"); err != nil {
+		t.Fatalf("Unlink(data.bin) error = %v", err)
+	}
+	if err := engine.Unlink(RootInode, "data-hardlink"); err != nil {
+		t.Fatalf("Unlink(data-hardlink) error = %v", err)
+	}
+	assertFilesystemUsage(t, engine, FilesystemUsage{DataBytes: 4100, Inodes: 4})
+
+	if err := engine.Forget(file.Inode); err != nil {
+		t.Fatalf("Forget() error = %v", err)
+	}
+	assertFilesystemUsage(t, engine, FilesystemUsage{Inodes: 3})
+}
+
+func TestEngineFilesystemUsageRejectsClosedEngine(t *testing.T) {
+	engine, err := Open(context.Background(), Config{
+		VolumeID: "vol-1",
+		WALPath:  filepath.Join(t.TempDir(), "volume.wal"),
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	if err := engine.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	if _, err := engine.FilesystemUsage(); !errors.Is(err, ErrClosed) {
+		t.Fatalf("FilesystemUsage() error = %v, want ErrClosed", err)
+	}
+}
+
+func assertFilesystemUsage(t *testing.T, engine *Engine, want FilesystemUsage) {
+	t.Helper()
+	got, err := engine.FilesystemUsage()
+	if err != nil {
+		t.Fatalf("FilesystemUsage() error = %v", err)
+	}
+	if got != want {
+		t.Fatalf("FilesystemUsage() = %+v, want %+v", got, want)
+	}
+}


### PR DESCRIPTION
Summary:
- replace the fixed 1 GiB / 50% S0FS statfs response with live logical byte and inode usage
- report that usage against a stable 4 TiB virtual capacity without leaking node filesystem capacity
- document that df capacity is virtual and separate from metering, quotas, and local cache safeguards

Validation:
- GOTOOLCHAIN=go1.25.0+auto go test -race -count=1 ./storage-proxy/...
- GOTOOLCHAIN=go1.25.0+auto go test -race -count=1 ./ctld/internal/ctld/portal ./pkg/volumefuse
- go vet ./storage-proxy/pkg/s0fs ./storage-proxy/pkg/fsserver ./ctld/internal/ctld/portal ./pkg/volumefuse
- manual deployment and live S0FS mount validation on the persistent Aliyun Singapore kind environment; details are recorded in the PR comment