### PR TITLE
fix(manager): capture previous procd crash logs

### DIFF
--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -519,6 +519,8 @@ func main() {
 	sandboxLifecycleController := service.NewSandboxLifecycleController(k8sClient, podLister, sandboxService, logger)
 	sandboxLifecycleController.SetMetrics(managerMetrics)
 	podInformer.Informer().AddEventHandler(sandboxLifecycleController.ResourceEventHandler())
+	sandboxCrashLogCollector := service.NewSandboxCrashLogCollector(k8sClient, logger, managerMetrics)
+	podInformer.Informer().AddEventHandler(sandboxCrashLogCollector.ResourceEventHandler())
 	sandboxPauseController := service.NewSandboxPauseController(sandboxService, logger)
 	sandboxService.SetPauseEnqueuer(sandboxPauseController)
 	operator.SetSandboxProbeRunner(sandboxService)
@@ -702,6 +704,11 @@ func main() {
 	}
 
 	startSandboxObservabilityLogProducer(ctx, cfg, k8sClient, podLister, sandboxLogWorker, logger, clk)
+	go func() {
+		if err := sandboxCrashLogCollector.Run(ctx, 2); err != nil && !errors.Is(err, context.Canceled) {
+			logger.Error("Sandbox crash log collector failed", zap.Error(err))
+		}
+	}()
 
 	if templateBuildWorker != nil {
 		go func() {

--- a/manager/pkg/service/sandbox_crash_log_collector.go
+++ b/manager/pkg/service/sandbox_crash_log_collector.go
@@ -1,0 +1,396 @@
+package service
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
+	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+)
+
+const (
+	defaultProcdPreviousLogTailLines      int64 = 2048
+	defaultProcdPreviousLogReadLimitBytes int64 = 16 << 20
+	defaultProcdCrashLogRetainBytes             = 512 << 10
+	defaultProcdCrashLogChunkBytes              = 32 << 10
+	defaultProcdCrashLogRequestTimeout          = 3 * time.Second
+	maxProcdPreviousLogCaptureRetries           = 4
+)
+
+type previousContainerLogReader interface {
+	ReadPreviousLogs(ctx context.Context, namespace, podName string) ([]byte, error)
+}
+
+type kubernetesPreviousContainerLogReader struct {
+	client kubernetes.Interface
+}
+
+func (r *kubernetesPreviousContainerLogReader) ReadPreviousLogs(ctx context.Context, namespace, podName string) ([]byte, error) {
+	if r == nil || r.client == nil {
+		return nil, fmt.Errorf("kubernetes client is not configured")
+	}
+	tailLines := defaultProcdPreviousLogTailLines
+	limitBytes := defaultProcdPreviousLogReadLimitBytes
+	stream, err := r.client.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{
+		Container:  DefaultSandboxLogContainer,
+		Previous:   true,
+		Timestamps: true,
+		TailLines:  &tailLines,
+		LimitBytes: &limitBytes,
+	}).Stream(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("stream previous procd container logs: %w", err)
+	}
+	defer stream.Close()
+
+	logs, err := io.ReadAll(io.LimitReader(stream, limitBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read previous procd container logs: %w", err)
+	}
+	if int64(len(logs)) > limitBytes {
+		return nil, fmt.Errorf("previous procd container logs exceeded %d bytes", limitBytes)
+	}
+	return logs, nil
+}
+
+type procdCrashLogItem struct {
+	Namespace         string
+	PodName           string
+	PodUID            string
+	SandboxID         string
+	TeamID            string
+	RuntimeGeneration int64
+	RestartCount      int32
+	ExitCode          int32
+	Signal            int32
+	Reason            string
+	Message           string
+	StartedAt         time.Time
+	FinishedAt        time.Time
+}
+
+func (i procdCrashLogItem) crashID() string {
+	podIdentity := i.PodUID
+	if podIdentity == "" {
+		podIdentity = i.Namespace + "/" + i.PodName
+	}
+	return fmt.Sprintf("%s:%d", podIdentity, i.RestartCount)
+}
+
+// SandboxCrashLogCollector captures the previous procd container logs after an
+// unexpected restart and emits them through the manager's platform logger.
+type SandboxCrashLogCollector struct {
+	reader  previousContainerLogReader
+	logger  *zap.Logger
+	metrics *obsmetrics.ManagerMetrics
+	queue   workqueue.TypedRateLimitingInterface[procdCrashLogItem]
+}
+
+// NewSandboxCrashLogCollector creates an event-driven collector for failed
+// procd container instances.
+func NewSandboxCrashLogCollector(k8sClient kubernetes.Interface, logger *zap.Logger, metrics *obsmetrics.ManagerMetrics) *SandboxCrashLogCollector {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	return &SandboxCrashLogCollector{
+		reader:  &kubernetesPreviousContainerLogReader{client: k8sClient},
+		logger:  logger,
+		metrics: metrics,
+		queue: workqueue.NewTypedRateLimitingQueue(
+			workqueue.NewTypedItemExponentialFailureRateLimiter[procdCrashLogItem](100*time.Millisecond, time.Second),
+		),
+	}
+}
+
+// ResourceEventHandler detects failed procd restarts from shared Pod informer events.
+func (c *SandboxCrashLogCollector) ResourceEventHandler() cache.ResourceEventHandlerFuncs {
+	if c == nil {
+		return cache.ResourceEventHandlerFuncs{}
+	}
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) {
+			c.enqueueRestart(nil, extractPod(obj))
+		},
+		UpdateFunc: func(oldObj, newObj any) {
+			c.enqueueRestart(extractPod(oldObj), extractPod(newObj))
+		},
+	}
+}
+
+// Run processes crash log capture work until the context is canceled.
+func (c *SandboxCrashLogCollector) Run(ctx context.Context, workers int) error {
+	if c == nil {
+		return nil
+	}
+	if workers <= 0 {
+		workers = 1
+	}
+	if c.queue == nil {
+		c.queue = workqueue.NewTypedRateLimitingQueue(
+			workqueue.NewTypedItemExponentialFailureRateLimiter[procdCrashLogItem](100*time.Millisecond, time.Second),
+		)
+	}
+
+	defer runtime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	c.logger.Info("Starting sandbox crash log collector", zap.Int("workers", workers))
+	for i := 0; i < workers; i++ {
+		go wait.UntilWithContext(ctx, c.runWorker, time.Second)
+	}
+
+	<-ctx.Done()
+	c.logger.Info("Sandbox crash log collector stopped")
+	return ctx.Err()
+}
+
+func (c *SandboxCrashLogCollector) enqueueRestart(oldPod, newPod *corev1.Pod) {
+	if c == nil || c.queue == nil || !sandboxCrashLogPodEligible(newPod) {
+		return
+	}
+	newStatus := procdContainerStatus(newPod)
+	if newStatus == nil || newStatus.RestartCount == 0 || newStatus.LastTerminationState.Terminated == nil {
+		return
+	}
+
+	oldRestartCount := int32(0)
+	if oldPod != nil && oldPod.UID == newPod.UID {
+		if oldStatus := procdContainerStatus(oldPod); oldStatus != nil {
+			oldRestartCount = oldStatus.RestartCount
+		}
+	}
+	if newStatus.RestartCount <= oldRestartCount {
+		return
+	}
+
+	terminated := newStatus.LastTerminationState.Terminated
+	if terminated.ExitCode == 0 && terminated.Signal == 0 {
+		return
+	}
+	c.queue.Add(procdCrashLogItem{
+		Namespace:         newPod.Namespace,
+		PodName:           newPod.Name,
+		PodUID:            string(newPod.UID),
+		SandboxID:         sandboxIDFromPod(newPod),
+		TeamID:            strings.TrimSpace(newPod.Annotations[controller.AnnotationTeamID]),
+		RuntimeGeneration: runtimeGenerationFromPod(newPod),
+		RestartCount:      newStatus.RestartCount,
+		ExitCode:          terminated.ExitCode,
+		Signal:            terminated.Signal,
+		Reason:            terminated.Reason,
+		Message:           terminated.Message,
+		StartedAt:         terminated.StartedAt.Time,
+		FinishedAt:        terminated.FinishedAt.Time,
+	})
+}
+
+func sandboxCrashLogPodEligible(pod *corev1.Pod) bool {
+	if pod == nil || pod.Labels[controller.LabelPoolType] != controller.PoolTypeActive {
+		return false
+	}
+	if strings.TrimSpace(pod.Annotations[controller.AnnotationTeamID]) == "" {
+		return false
+	}
+	return strings.TrimSpace(sandboxIDFromPod(pod)) != ""
+}
+
+func procdContainerStatus(pod *corev1.Pod) *corev1.ContainerStatus {
+	if pod == nil {
+		return nil
+	}
+	for i := range pod.Status.ContainerStatuses {
+		if pod.Status.ContainerStatuses[i].Name == DefaultSandboxLogContainer {
+			return &pod.Status.ContainerStatuses[i]
+		}
+	}
+	return nil
+}
+
+func (c *SandboxCrashLogCollector) runWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
+	}
+}
+
+func (c *SandboxCrashLogCollector) processNextWorkItem(ctx context.Context) bool {
+	item, shutdown := c.queue.Get()
+	if shutdown {
+		return false
+	}
+	defer c.queue.Done(item)
+
+	err := c.capturePreviousLogs(ctx, item)
+	if err == nil {
+		c.queue.Forget(item)
+		return true
+	}
+	if ctx.Err() != nil {
+		c.queue.Forget(item)
+		return true
+	}
+	if c.queue.NumRequeues(item) < maxProcdPreviousLogCaptureRetries {
+		c.logger.Debug("Previous procd log capture failed, retrying",
+			append(procdCrashLogFields(item), zap.Error(err))...,
+		)
+		c.queue.AddRateLimited(item)
+		return true
+	}
+
+	c.queue.Forget(item)
+	c.observeCapture("error", 0)
+	c.logger.Warn("Failed to capture previous procd container logs",
+		append(procdCrashLogFields(item), zap.Error(err))...,
+	)
+	return true
+}
+
+func (c *SandboxCrashLogCollector) capturePreviousLogs(ctx context.Context, item procdCrashLogItem) error {
+	if c == nil || c.reader == nil {
+		return fmt.Errorf("previous container log reader is not configured")
+	}
+	requestCtx, cancel := context.WithTimeout(ctx, defaultProcdCrashLogRequestTimeout)
+	defer cancel()
+
+	raw, err := c.reader.ReadPreviousLogs(requestCtx, item.Namespace, item.PodName)
+	if err != nil {
+		return err
+	}
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return fmt.Errorf("previous procd container logs were empty")
+	}
+
+	filtered, droppedProcessLines, err := filterPreviousProcdLogs(raw)
+	if err != nil {
+		return err
+	}
+	if len(bytes.TrimSpace(filtered)) == 0 {
+		c.observeCapture("empty", 0)
+		c.logger.Warn("Previous procd container logs contained no internal log lines",
+			append(procdCrashLogFields(item), zap.Int("dropped_process_log_lines", droppedProcessLines))...,
+		)
+		return nil
+	}
+
+	retained, truncated := retainPreviousLogTail(filtered, defaultProcdCrashLogRetainBytes)
+	chunks := splitPreviousLogChunks(retained, defaultProcdCrashLogChunkBytes)
+	fields := procdCrashLogFields(item)
+	fields = append(fields,
+		zap.Int("captured_log_bytes", len(retained)),
+		zap.Bool("previous_log_truncated", truncated),
+		zap.Int("dropped_process_log_lines", droppedProcessLines),
+		zap.Int("chunk_count", len(chunks)),
+		zap.Bool("untrusted_log_content", true),
+	)
+	for index, chunk := range chunks {
+		chunkFields := append([]zap.Field{}, fields...)
+		chunkFields = append(chunkFields,
+			zap.Int("chunk_index", index),
+			zap.String("log_chunk", chunk),
+		)
+		c.logger.Warn("Captured previous procd container logs", chunkFields...)
+	}
+	c.observeCapture("success", len(retained))
+	return nil
+}
+
+func filterPreviousProcdLogs(raw []byte) ([]byte, int, error) {
+	scanner := bufio.NewScanner(bytes.NewReader(raw))
+	scanner.Buffer(make([]byte, 64<<10), int(defaultProcdPreviousLogReadLimitBytes))
+	var filtered bytes.Buffer
+	droppedProcessLines := 0
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if isSandboxProcessLogLine(line) {
+			droppedProcessLines++
+			continue
+		}
+		filtered.Write(line)
+		filtered.WriteByte('\n')
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, 0, fmt.Errorf("filter previous procd container logs: %w", err)
+	}
+	return filtered.Bytes(), droppedProcessLines, nil
+}
+
+func retainPreviousLogTail(logs []byte, limit int) ([]byte, bool) {
+	if limit <= 0 || len(logs) <= limit {
+		return logs, false
+	}
+	logs = logs[len(logs)-limit:]
+	if index := bytes.IndexByte(logs, '\n'); index >= 0 && index+1 < len(logs) {
+		logs = logs[index+1:]
+	}
+	return logs, true
+}
+
+func splitPreviousLogChunks(logs []byte, limit int) []string {
+	if len(logs) == 0 {
+		return nil
+	}
+	if limit <= 0 {
+		limit = len(logs)
+	}
+	chunks := make([]string, 0, (len(logs)+limit-1)/limit)
+	for len(logs) > 0 {
+		end := min(limit, len(logs))
+		if end < len(logs) {
+			if index := bytes.LastIndexByte(logs[:end], '\n'); index >= end/2 {
+				end = index + 1
+			}
+		}
+		chunks = append(chunks, strings.ToValidUTF8(string(logs[:end]), "?"))
+		logs = logs[end:]
+	}
+	return chunks
+}
+
+func procdCrashLogFields(item procdCrashLogItem) []zap.Field {
+	fields := []zap.Field{
+		zap.String("event", "sandbox_procd_crash"),
+		zap.String("crash_id", item.crashID()),
+		zap.String("sandbox_id", item.SandboxID),
+		zap.String("team_id", item.TeamID),
+		zap.String("namespace", item.Namespace),
+		zap.String("pod", item.PodName),
+		zap.String("pod_uid", item.PodUID),
+		zap.Int64("runtime_generation", item.RuntimeGeneration),
+		zap.Int32("restart_count", item.RestartCount),
+		zap.Int32("exit_code", item.ExitCode),
+		zap.Int32("signal", item.Signal),
+		zap.String("reason", item.Reason),
+	}
+	if item.Message != "" {
+		fields = append(fields, zap.String("termination_message", item.Message))
+	}
+	if !item.StartedAt.IsZero() {
+		fields = append(fields, zap.Time("container_started_at", item.StartedAt))
+	}
+	if !item.FinishedAt.IsZero() {
+		fields = append(fields, zap.Time("container_finished_at", item.FinishedAt))
+	}
+	return fields
+}
+
+func (c *SandboxCrashLogCollector) observeCapture(result string, size int) {
+	if c == nil || c.metrics == nil {
+		return
+	}
+	if c.metrics.ProcdCrashLogCapturesTotal != nil {
+		c.metrics.ProcdCrashLogCapturesTotal.WithLabelValues(result).Inc()
+	}
+	if result == "success" && c.metrics.ProcdCrashLogBytes != nil {
+		c.metrics.ProcdCrashLogBytes.Observe(float64(size))
+	}
+}

--- a/manager/pkg/service/sandbox_crash_log_collector_test.go
+++ b/manager/pkg/service/sandbox_crash_log_collector_test.go
@@ -1,0 +1,281 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
+	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+func TestSandboxCrashLogCollectorEnqueuesUnexpectedProcdRestart(t *testing.T) {
+	collector := NewSandboxCrashLogCollector(nil, zap.NewNop(), nil)
+	t.Cleanup(collector.queue.ShutDown)
+
+	oldPod := testProcdCrashPod(0, 0)
+	newPod := testProcdCrashPod(1, 2)
+	collector.ResourceEventHandler().UpdateFunc(oldPod, newPod)
+
+	require.Equal(t, 1, collector.queue.Len())
+	item, shutdown := collector.queue.Get()
+	require.False(t, shutdown)
+	collector.queue.Done(item)
+	collector.queue.Forget(item)
+	assert.Equal(t, "sandbox-1", item.SandboxID)
+	assert.Equal(t, "team-1", item.TeamID)
+	assert.Equal(t, int64(7), item.RuntimeGeneration)
+	assert.Equal(t, int32(1), item.RestartCount)
+	assert.Equal(t, int32(2), item.ExitCode)
+	assert.Equal(t, "pod-uid:1", item.crashID())
+}
+
+func TestSandboxCrashLogCollectorIgnoresExpectedOrIrrelevantPodUpdates(t *testing.T) {
+	tests := []struct {
+		name   string
+		oldPod *corev1.Pod
+		newPod *corev1.Pod
+	}{
+		{
+			name:   "restart count unchanged",
+			oldPod: testProcdCrashPod(1, 2),
+			newPod: testProcdCrashPod(1, 2),
+		},
+		{
+			name:   "successful container restart",
+			oldPod: testProcdCrashPod(0, 0),
+			newPod: testProcdCrashPod(1, 0),
+		},
+		{
+			name:   "idle pool pod",
+			oldPod: testProcdCrashPod(0, 0),
+			newPod: func() *corev1.Pod {
+				pod := testProcdCrashPod(1, 2)
+				pod.Labels[controller.LabelPoolType] = controller.PoolTypeIdle
+				return pod
+			}(),
+		},
+		{
+			name:   "pod without team ownership",
+			oldPod: testProcdCrashPod(0, 0),
+			newPod: func() *corev1.Pod {
+				pod := testProcdCrashPod(1, 2)
+				delete(pod.Annotations, controller.AnnotationTeamID)
+				return pod
+			}(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			collector := NewSandboxCrashLogCollector(nil, zap.NewNop(), nil)
+			t.Cleanup(collector.queue.ShutDown)
+			collector.ResourceEventHandler().UpdateFunc(tt.oldPod, tt.newPod)
+			assert.Equal(t, 0, collector.queue.Len())
+		})
+	}
+}
+
+func TestSandboxCrashLogCollectorAddRecoversLatestCrashAfterManagerRestart(t *testing.T) {
+	collector := NewSandboxCrashLogCollector(nil, zap.NewNop(), nil)
+	t.Cleanup(collector.queue.ShutDown)
+
+	collector.ResourceEventHandler().AddFunc(testProcdCrashPod(3, 2))
+
+	require.Equal(t, 1, collector.queue.Len())
+	item, shutdown := collector.queue.Get()
+	require.False(t, shutdown)
+	collector.queue.Done(item)
+	collector.queue.Forget(item)
+	assert.Equal(t, int32(3), item.RestartCount)
+}
+
+func TestSandboxCrashLogCollectorCapturesInternalLogsAndDropsProcessOutput(t *testing.T) {
+	core, observed := observer.New(zap.DebugLevel)
+	registry := prometheus.NewRegistry()
+	metrics := obsmetrics.NewManager(registry)
+	reader := &recordingPreviousLogReader{logs: []byte(strings.Join([]string{
+		`2026-07-23T03:26:46.900000000Z {"level":"info","msg":"request started","service":"procd"}`,
+		`2026-07-23T03:26:46.950000000Z {"message":"sandbox process output","process_id":"ctx-1","process_type":"cmd","source":"stderr","data":"TOP_SECRET"}`,
+		`2026-07-23T03:26:46.978000000Z panic: test crash`,
+		`2026-07-23T03:26:46.978100000Z goroutine 42 [running]:`,
+	}, "\n"))}
+	collector := NewSandboxCrashLogCollector(nil, zap.New(core), metrics)
+	collector.reader = reader
+	t.Cleanup(collector.queue.ShutDown)
+
+	item := crashLogItemFromPod(testProcdCrashPod(1, 2))
+	require.NoError(t, collector.capturePreviousLogs(context.Background(), item))
+
+	assert.Equal(t, []string{"sandbox-ns/sandbox-pod"}, reader.Calls())
+	entries := observed.FilterMessage("Captured previous procd container logs").All()
+	require.Len(t, entries, 1)
+	fields := entries[0].ContextMap()
+	assert.Equal(t, "sandbox_procd_crash", fields["event"])
+	assert.Equal(t, "pod-uid:1", fields["crash_id"])
+	logChunk, ok := fields["log_chunk"].(string)
+	require.True(t, ok)
+	assert.Contains(t, logChunk, "request started")
+	assert.Contains(t, logChunk, "panic: test crash")
+	assert.Contains(t, logChunk, "goroutine 42")
+	assert.NotContains(t, logChunk, "TOP_SECRET")
+	assert.Equal(t, float64(1), testutil.ToFloat64(metrics.ProcdCrashLogCapturesTotal.WithLabelValues("success")))
+}
+
+func TestSandboxCrashLogCollectorDoesNotEmitFilteredProcessOutput(t *testing.T) {
+	core, observed := observer.New(zap.DebugLevel)
+	registry := prometheus.NewRegistry()
+	metrics := obsmetrics.NewManager(registry)
+	reader := &recordingPreviousLogReader{logs: []byte(`2026-07-23T03:26:46.950000000Z {"message":"sandbox process output","process_id":"ctx-1","process_type":"cmd","source":"stdout","data":"TOP_SECRET"}`)}
+	collector := NewSandboxCrashLogCollector(nil, zap.New(core), metrics)
+	collector.reader = reader
+	t.Cleanup(collector.queue.ShutDown)
+
+	require.NoError(t, collector.capturePreviousLogs(context.Background(), crashLogItemFromPod(testProcdCrashPod(1, 2))))
+
+	assert.Equal(t, 0, observed.FilterMessage("Captured previous procd container logs").Len())
+	emptyEntries := observed.FilterMessage("Previous procd container logs contained no internal log lines").All()
+	require.Len(t, emptyEntries, 1)
+	assert.NotContains(t, emptyEntries[0].ContextMap(), "log_chunk")
+	assert.Equal(t, float64(1), testutil.ToFloat64(metrics.ProcdCrashLogCapturesTotal.WithLabelValues("empty")))
+}
+
+func TestKubernetesPreviousContainerLogReaderUsesPreviousProcdLogOptions(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/namespaces/sandbox-ns/pods/sandbox-pod/log", r.URL.Path)
+		query := r.URL.Query()
+		assert.Equal(t, DefaultSandboxLogContainer, query.Get("container"))
+		assert.Equal(t, "true", query.Get("previous"))
+		assert.Equal(t, "true", query.Get("timestamps"))
+		assert.Equal(t, "2048", query.Get("tailLines"))
+		assert.Equal(t, "16777216", query.Get("limitBytes"))
+		_, _ = w.Write([]byte("panic: captured\n"))
+	}))
+	defer server.Close()
+
+	client, err := kubernetes.NewForConfig(&rest.Config{Host: server.URL})
+	require.NoError(t, err)
+	reader := &kubernetesPreviousContainerLogReader{client: client}
+
+	logs, err := reader.ReadPreviousLogs(context.Background(), "sandbox-ns", "sandbox-pod")
+	require.NoError(t, err)
+	assert.Equal(t, "panic: captured\n", string(logs))
+}
+
+func TestSandboxCrashLogCollectorRetriesTransientReadFailure(t *testing.T) {
+	core, observed := observer.New(zap.DebugLevel)
+	reader := &recordingPreviousLogReader{
+		logs:         []byte("panic: captured after retry\n"),
+		failuresLeft: 2,
+	}
+	collector := NewSandboxCrashLogCollector(nil, zap.New(core), nil)
+	collector.reader = reader
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	done := make(chan error, 1)
+	go func() { done <- collector.Run(ctx, 1) }()
+	collector.queue.Add(crashLogItemFromPod(testProcdCrashPod(1, 2)))
+	require.Eventually(t, func() bool {
+		return observed.FilterMessage("Captured previous procd container logs").Len() == 1
+	}, 3*time.Second, 20*time.Millisecond)
+	assert.Equal(t, 3, len(reader.Calls()))
+
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+}
+
+type recordingPreviousLogReader struct {
+	mu           sync.Mutex
+	logs         []byte
+	failuresLeft int
+	calls        []string
+}
+
+func (r *recordingPreviousLogReader) ReadPreviousLogs(_ context.Context, namespace, podName string) ([]byte, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, namespace+"/"+podName)
+	if r.failuresLeft > 0 {
+		r.failuresLeft--
+		return nil, errors.New("transient log read failure")
+	}
+	return append([]byte(nil), r.logs...), nil
+}
+
+func (r *recordingPreviousLogReader) Calls() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.calls...)
+}
+
+func testProcdCrashPod(restartCount, exitCode int32) *corev1.Pod {
+	now := time.Now().UTC()
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sandbox-pod",
+			Namespace: "sandbox-ns",
+			UID:       types.UID("pod-uid"),
+			Labels: map[string]string{
+				controller.LabelPoolType:  controller.PoolTypeActive,
+				controller.LabelSandboxID: "sandbox-1",
+			},
+			Annotations: map[string]string{
+				controller.AnnotationTeamID:            "team-1",
+				controller.AnnotationRuntimeGeneration: "7",
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:         DefaultSandboxLogContainer,
+					RestartCount: restartCount,
+					LastTerminationState: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							ExitCode:   exitCode,
+							Reason:     "Error",
+							StartedAt:  metav1.NewTime(now.Add(-time.Minute)),
+							FinishedAt: metav1.NewTime(now),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func crashLogItemFromPod(pod *corev1.Pod) procdCrashLogItem {
+	status := procdContainerStatus(pod)
+	terminated := status.LastTerminationState.Terminated
+	return procdCrashLogItem{
+		Namespace:         pod.Namespace,
+		PodName:           pod.Name,
+		PodUID:            string(pod.UID),
+		SandboxID:         sandboxIDFromPod(pod),
+		TeamID:            pod.Annotations[controller.AnnotationTeamID],
+		RuntimeGeneration: runtimeGenerationFromPod(pod),
+		RestartCount:      status.RestartCount,
+		ExitCode:          terminated.ExitCode,
+		Signal:            terminated.Signal,
+		Reason:            terminated.Reason,
+		StartedAt:         terminated.StartedAt.Time,
+		FinishedAt:        terminated.FinishedAt.Time,
+	}
+}

--- a/pkg/observability/metrics/manager.go
+++ b/pkg/observability/metrics/manager.go
@@ -15,6 +15,8 @@ type ManagerMetrics struct {
 	SandboxClaimPhaseDuration       *prometheus.HistogramVec
 	SandboxDeleteCleanupPhase       *prometheus.HistogramVec
 	SandboxIdleClaimsTotal          *prometheus.CounterVec
+	ProcdCrashLogCapturesTotal      *prometheus.CounterVec
+	ProcdCrashLogBytes              prometheus.Histogram
 	PodNetworkIdentityChecksTotal   *prometheus.CounterVec
 	PodNetworkIdentityStageDuration *prometheus.HistogramVec
 	PodLifecycleStageDuration       *prometheus.HistogramVec
@@ -90,6 +92,15 @@ func NewManager(registry prometheus.Registerer) *ManagerMetrics {
 			Name: "manager_sandbox_idle_claims_total",
 			Help: "Total number of idle-pool claim attempts by result",
 		}, []string{"template", "result"}),
+		ProcdCrashLogCapturesTotal: factory.NewCounterVec(prometheus.CounterOpts{
+			Name: "manager_sandbox_procd_crash_log_captures_total",
+			Help: "Total number of previous procd crash log capture outcomes by result",
+		}, []string{"result"}),
+		ProcdCrashLogBytes: factory.NewHistogram(prometheus.HistogramOpts{
+			Name:    "manager_sandbox_procd_crash_log_bytes",
+			Help:    "Number of retained bytes emitted for a captured previous procd crash log",
+			Buckets: []float64{1024, 4096, 16384, 65536, 262144, 524288},
+		}),
 		PodNetworkIdentityChecksTotal: factory.NewCounterVec(prometheus.CounterOpts{
 			Name: "manager_pod_network_identity_checks_total",
 			Help: "Total number of pod network identity readiness checks by source, result, and reason",


### PR DESCRIPTION
## Summary

- watch active sandbox Pod status for unexpected `procd` restarts and immediately request the previous container logs
- remove structured sandbox process output before emitting bounded, chunked crash diagnostics through the manager platform logger
- retry transient Kubernetes log reads and expose capture outcome/size metrics

## Validation

- `GOTOOLCHAIN=go1.25.0+auto go test -buildvcs=false -race -count=1 ./manager/...`
- `GOFLAGS=-buildvcs=false golangci-lint run ./...`
- `make proto manifests apispec` with no generated diff
- remote Kind manual validation on `gvisor-rootfs`:
  - forced `procd` to exit through `SIGABRT`
  - observed restart count `0 -> 1` and exit code `2`
  - captured 74,969 bytes of previous logs in three manager log events
  - confirmed the previous container log contained a process-output sentinel, while manager crash events reported `dropped_process_log_lines=1` and did not contain it
  - confirmed `manager_sandbox_procd_crash_log_captures_total{result="success"}` incremented
