### PR TITLE
perf(manager): count active sandboxes directly

### DIFF
--- a/manager/pkg/service/sandbox_service_quota.go
+++ b/manager/pkg/service/sandbox_service_quota.go
@@ -12,6 +12,10 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
+type activeSandboxCounter interface {
+	CountActiveSandboxes(context.Context, string) (int64, error)
+}
+
 func (s *SandboxService) enforceActiveSandboxQuota(ctx context.Context, teamID string) error {
 	teamID = strings.TrimSpace(teamID)
 	if s == nil || s.quotaStore == nil || teamID == "" {
@@ -36,6 +40,15 @@ func (s *SandboxService) enforceActiveSandboxQuota(ctx context.Context, teamID s
 }
 
 func (s *SandboxService) currentQuotaUsage(ctx context.Context, teamID string, dimension quota.Dimension) (int64, error) {
+	if dimension == quota.DimensionActiveSandboxes {
+		current, ok, err := s.currentLiveQuotaUsage(ctx, teamID, dimension)
+		if err != nil {
+			return 0, err
+		}
+		if ok {
+			return current, nil
+		}
+	}
 	current, err := s.quotaStore.CurrentUsage(ctx, teamID, dimension)
 	if err == nil {
 		return current, nil
@@ -83,6 +96,13 @@ func (s *SandboxService) currentLiveQuotaUsage(ctx context.Context, teamID strin
 func (s *SandboxService) currentSandboxStoreActiveQuotaUsage(ctx context.Context, teamID string) (int64, bool, error) {
 	if s == nil || s.sandboxStore == nil {
 		return 0, false, nil
+	}
+	if counter, ok := s.sandboxStore.(activeSandboxCounter); ok {
+		current, err := counter.CountActiveSandboxes(ctx, teamID)
+		if err != nil {
+			return 0, true, fmt.Errorf("count active sandbox records: %w", err)
+		}
+		return current, true, nil
 	}
 	records, err := s.sandboxStore.ListSandboxes(ctx, &ListSandboxesRequest{TeamID: teamID})
 	if err != nil {

--- a/manager/pkg/service/sandbox_service_quota_test.go
+++ b/manager/pkg/service/sandbox_service_quota_test.go
@@ -21,6 +21,18 @@ type fakeQuotaLimitStore struct {
 	usageErr error
 }
 
+type countingSandboxStore struct {
+	*memorySandboxStore
+	count int64
+	calls int
+	err   error
+}
+
+func (s *countingSandboxStore) CountActiveSandboxes(context.Context, string) (int64, error) {
+	s.calls++
+	return s.count, s.err
+}
+
 func (f fakeQuotaLimitStore) GetLimit(context.Context, string, quota.Dimension) (*quota.Limit, error) {
 	return f.limit, f.err
 }
@@ -112,6 +124,50 @@ func TestEnforceActiveSandboxQuotaUsesSandboxStoreWhenUsageStoreDisabled(t *test
 	err := svc.enforceActiveSandboxQuota(context.Background(), "team-1")
 	if !errors.Is(err, ErrQuotaExceeded) {
 		t.Fatalf("enforceActiveSandboxQuota() error = %v, want ErrQuotaExceeded", err)
+	}
+}
+
+func TestEnforceActiveSandboxQuotaPrefersOperationalStoreOverUsageProjection(t *testing.T) {
+	svc := &SandboxService{
+		quotaStore: fakeQuotaLimitStore{
+			limit: &quota.Limit{TeamID: "team-1", Dimension: quota.DimensionActiveSandboxes, LimitValue: 1},
+			usage: 0,
+		},
+		sandboxStore: &memorySandboxStore{
+			records: map[string]*SandboxRecord{
+				"sandbox-1": {
+					ID:     "sandbox-1",
+					TeamID: "team-1",
+					Status: SandboxStatusRunning,
+				},
+			},
+		},
+	}
+
+	err := svc.enforceActiveSandboxQuota(context.Background(), "team-1")
+	if !errors.Is(err, ErrQuotaExceeded) {
+		t.Fatalf("enforceActiveSandboxQuota() error = %v, want ErrQuotaExceeded", err)
+	}
+}
+
+func TestEnforceActiveSandboxQuotaUsesOptimizedOperationalCount(t *testing.T) {
+	store := &countingSandboxStore{
+		memorySandboxStore: &memorySandboxStore{},
+		count:              1,
+	}
+	svc := &SandboxService{
+		quotaStore: fakeQuotaLimitStore{
+			limit:    &quota.Limit{TeamID: "team-1", Dimension: quota.DimensionActiveSandboxes, LimitValue: 2},
+			usageErr: errors.New("usage projection must not be queried"),
+		},
+		sandboxStore: store,
+	}
+
+	if err := svc.enforceActiveSandboxQuota(context.Background(), "team-1"); err != nil {
+		t.Fatalf("enforceActiveSandboxQuota() error = %v, want nil", err)
+	}
+	if store.calls != 1 {
+		t.Fatalf("CountActiveSandboxes() calls = %d, want 1", store.calls)
 	}
 }
 

--- a/manager/pkg/service/sandbox_store.go
+++ b/manager/pkg/service/sandbox_store.go
@@ -308,6 +308,25 @@ func (s *PGSandboxStore) ListSandboxes(ctx context.Context, req *ListSandboxesRe
 	return records, nil
 }
 
+// CountActiveSandboxes returns the region-wide operational count used by the
+// active_sandboxes quota. All clusters in a region share this store.
+func (s *PGSandboxStore) CountActiveSandboxes(ctx context.Context, teamID string) (int64, error) {
+	if s == nil || s.pool == nil {
+		return 0, nil
+	}
+	var total int64
+	if err := s.pool.QueryRow(ctx, `
+		SELECT COUNT(*)
+		FROM manager.sandboxes
+		WHERE team_id = $1
+			AND deleted_at IS NULL
+			AND status IN ($2, $3)
+	`, strings.TrimSpace(teamID), SandboxStatusStarting, SandboxStatusRunning).Scan(&total); err != nil {
+		return 0, fmt.Errorf("count active sandboxes: %w", err)
+	}
+	return total, nil
+}
+
 func (s *PGSandboxStore) ListActiveLifecycleTxns(ctx context.Context, kind string, limit int) ([]*SandboxLifecycleTxn, error) {
 	if s == nil || s.pool == nil {
 		return nil, nil


### PR DESCRIPTION
## Summary

Replace per-request active-sandbox materialization with a SQL count query for running-quota enforcement.

This PR is intentionally isolated as one ComputeSDK performance/correctness change.

## Dependency

None.

## Validation

- `go test ./manager/pkg/service`
- `go test -race ./manager/pkg/service`
- `go vet ./manager/pkg/service`
- `git diff --check`
- Wave-one integration commit `52b0b212` was deployed to the persistent Aliyun Singapore kind environment.
- Remote smoke: Sandbox0Infra Ready 10/10; default hot claim and `node -v`; resources preserved on a no-override claim; 512 MiB resize claim; restricted-network desired/applied hash match; 8 parallel claims with 8 unique sandboxes.
- ctld A/B daemonsets were restarted sequentially on both data-plane nodes and the deployment returned to Ready 10/10 without portal/FUSE/HA errors.

The remote result validates the combined wave-one branch; this PR still relies on its own focused tests and PR CI for isolated coverage.

## Benchmark

Combined wave-one integration commit: `52b0b2127e0ba2578d5dd3269be4309e312bb5f2` (`sandbox0ai/infra:computesdk-wave1-52b0b21`). The benchmark used ComputeSDK commit `15b1a338171f5631c266bb480e8491cba3f6a4e3`, 100 iterations per mode, one fixed 32-vCPU sandbox node, default idle 120, burst nodes disabled, and an in-cluster runner in Ali us-east-1. No result was uploaded.

| Mode | Score | Success | Median | P95 | P99 | Wall | First ready |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| sequential | 97.60 | 100/100 | 209.40 ms | 275.30 ms | 300.94 ms | - | - |
| staggered | 92.23 | 100/100 | 687.97 ms | 899.50 ms | 928.05 ms | 21.34 s | 165.03 ms |
| burst 1 | 38.56 | 100/100 | 5594.08 ms | 6915.83 ms | 7054.70 ms | 10.86 s | 3974.29 ms |
| burst 2 | 31.56 | 100/100 | 6739.44 ms | 6955.92 ms | 7077.49 ms | 13.70 s | 1545.95 ms |

This is a combined-stack result, not isolated attribution for this PR. Both burst repetitions show a material regression versus the prior mixed experiment, so this PR remains draft and requires isolated A/B evidence before any performance claim or merge decision.

Operational evidence: image CI [30133571556](https://github.com/sandbox0-ai/sandbox0/actions/runs/30133571556), deployment [30134259307](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30134259307), benchmark preflight [30134915050](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30134915050), baseline restore [30135559660](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30135559660), and final baseline preflight [30135754538](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30135754538).

After the run, the temporary runner was deleted, team quotas were restored to `region_default`, burst capacity was restored to `0-299` with zero burst nodes, and production runtime was restored to `sandbox0ai/infra:main-2c2db0b`.