### PR TITLE
perf(quota): coalesce policy cache misses

### DIFF
--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -963,6 +963,11 @@ func buildQuotaRepository(ctx context.Context, pool *pgxpool.Pool, cfg *config.M
 	if usageStore != nil {
 		repo.SetUsageStore(usageStore)
 	}
+	policyStore, err := quota.NewCachedPolicyStore(ctx, pool, repo, quota.DefaultPolicyCacheTTL)
+	if err != nil {
+		return nil, err
+	}
+	repo.SetLimitPolicyStore(policyStore)
 	return repo, nil
 }
 

--- a/pkg/quota/cache.go
+++ b/pkg/quota/cache.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	"golang.org/x/sync/singleflight"
 )
 
 const (
@@ -33,6 +34,7 @@ type CachedPolicyStore struct {
 
 	mu      sync.RWMutex
 	entries map[policyCacheKey]policyCacheEntry
+	fetches singleflight.Group
 
 	cancel context.CancelFunc
 	done   chan struct{}
@@ -74,16 +76,34 @@ func (s *CachedPolicyStore) GetPolicy(ctx context.Context, teamID string, dimens
 		return clonePolicy(entry.policy), nil
 	}
 
-	policy, err := s.source.GetPolicy(ctx, teamID, dimension)
+	value, err, _ := s.fetches.Do(teamID+"\x00"+string(dimension), func() (any, error) {
+		now := time.Now()
+		s.mu.RLock()
+		entry, ok := s.entries[key]
+		s.mu.RUnlock()
+		if ok && now.Before(entry.expiresAt) {
+			return clonePolicy(entry.policy), nil
+		}
+
+		policy, err := s.source.GetPolicy(ctx, teamID, dimension)
+		if err != nil {
+			return nil, err
+		}
+		s.mu.Lock()
+		s.entries[key] = policyCacheEntry{
+			policy:    clonePolicy(policy),
+			expiresAt: time.Now().Add(s.ttl),
+		}
+		s.mu.Unlock()
+		return clonePolicy(policy), nil
+	})
 	if err != nil {
 		return nil, err
 	}
-	s.mu.Lock()
-	s.entries[key] = policyCacheEntry{
-		policy:    clonePolicy(policy),
-		expiresAt: now.Add(s.ttl),
+	policy, ok := value.(*Policy)
+	if !ok {
+		return nil, fmt.Errorf("quota policy source returned %T", value)
 	}
-	s.mu.Unlock()
 	return clonePolicy(policy), nil
 }
 

--- a/pkg/quota/cache_test.go
+++ b/pkg/quota/cache_test.go
@@ -2,17 +2,30 @@ package quota
 
 import (
 	"context"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
 
 type countingPolicyStore struct {
-	calls  int
-	policy *Policy
+	calls   atomic.Int64
+	policy  *Policy
+	started chan struct{}
+	release chan struct{}
 }
 
 func (s *countingPolicyStore) GetPolicy(context.Context, string, Dimension) (*Policy, error) {
-	s.calls++
+	s.calls.Add(1)
+	if s.started != nil {
+		select {
+		case s.started <- struct{}{}:
+		default:
+		}
+	}
+	if s.release != nil {
+		<-s.release
+	}
 	return clonePolicy(s.policy), nil
 }
 
@@ -39,15 +52,64 @@ func TestCachedPolicyStoreCachesAndInvalidatesResolvedPolicy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetPolicy(second): %v", err)
 	}
-	if source.calls != 1 || second.LimitValue != 100 {
-		t.Fatalf("cached policy = %+v calls=%d, want cloned cached value", second, source.calls)
+	if source.calls.Load() != 1 || second.LimitValue != 100 {
+		t.Fatalf("cached policy = %+v calls=%d, want cloned cached value", second, source.calls.Load())
 	}
 
 	store.Invalidate()
 	if _, err := store.GetPolicy(context.Background(), "team-1", DimensionAPIRequests); err != nil {
 		t.Fatalf("GetPolicy(after invalidate): %v", err)
 	}
-	if source.calls != 2 {
-		t.Fatalf("source calls = %d, want 2", source.calls)
+	if source.calls.Load() != 2 {
+		t.Fatalf("source calls = %d, want 2", source.calls.Load())
+	}
+}
+
+func TestCachedPolicyStoreCoalescesConcurrentMisses(t *testing.T) {
+	source := &countingPolicyStore{
+		policy: &Policy{
+			TeamID:     "team-1",
+			Dimension:  DimensionActiveSandboxes,
+			Kind:       KindCapacity,
+			LimitValue: 120,
+			Source:     SourceTeamOverride,
+		},
+		started: make(chan struct{}, 1),
+		release: make(chan struct{}),
+	}
+	store, err := NewCachedPolicyStore(context.Background(), nil, source, time.Minute)
+	if err != nil {
+		t.Fatalf("NewCachedPolicyStore: %v", err)
+	}
+
+	const callers = 32
+	start := make(chan struct{})
+	errs := make(chan error, callers)
+	var wg sync.WaitGroup
+	wg.Add(callers)
+	for range callers {
+		go func() {
+			defer wg.Done()
+			<-start
+			policy, err := store.GetPolicy(context.Background(), "team-1", DimensionActiveSandboxes)
+			if err == nil && (policy == nil || policy.LimitValue != 120) {
+				t.Errorf("policy = %+v, want active sandbox limit 120", policy)
+			}
+			errs <- err
+		}()
+	}
+	close(start)
+	<-source.started
+	time.Sleep(20 * time.Millisecond)
+	close(source.release)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("GetPolicy: %v", err)
+		}
+	}
+	if source.calls.Load() != 1 {
+		t.Fatalf("source calls = %d, want 1", source.calls.Load())
 	}
 }

--- a/pkg/quota/repository.go
+++ b/pkg/quota/repository.go
@@ -19,8 +19,9 @@ type DB interface {
 }
 
 type Repository struct {
-	db         DB
-	usageStore UsageStore
+	db               DB
+	usageStore       UsageStore
+	limitPolicyStore PolicyStore
 }
 
 var ErrUsageStoreNotConfigured = errors.New("quota usage store is not configured")
@@ -60,6 +61,14 @@ func (r *Repository) SetUsageStore(store UsageStore) {
 	r.usageStore = store
 }
 
+// SetLimitPolicyStore configures the resolved policy source used by GetLimit.
+func (r *Repository) SetLimitPolicyStore(store PolicyStore) {
+	if r == nil {
+		return
+	}
+	r.limitPolicyStore = store
+}
+
 func usageStoreConfigured(store UsageStore) bool {
 	if store == nil {
 		return false
@@ -81,7 +90,15 @@ func (r *Repository) configuredUsageStore() (UsageStore, bool) {
 }
 
 func (r *Repository) GetLimit(ctx context.Context, teamID string, dimension Dimension) (*Limit, error) {
-	policy, err := r.GetPolicy(ctx, teamID, dimension)
+	var (
+		policy *Policy
+		err    error
+	)
+	if r != nil && r.limitPolicyStore != nil {
+		policy, err = r.limitPolicyStore.GetPolicy(ctx, teamID, dimension)
+	} else {
+		policy, err = r.GetPolicy(ctx, teamID, dimension)
+	}
 	if err != nil || policy == nil {
 		return nil, err
 	}

--- a/pkg/quota/repository_test.go
+++ b/pkg/quota/repository_test.go
@@ -110,6 +110,34 @@ func TestGetPolicyReturnsTeamOverride(t *testing.T) {
 	}
 }
 
+func TestGetLimitUsesConfiguredPolicyStore(t *testing.T) {
+	source := &countingPolicyStore{policy: &Policy{
+		TeamID:     "team-1",
+		Dimension:  DimensionActiveSandboxes,
+		Kind:       KindCapacity,
+		LimitValue: 120,
+		Source:     SourceTeamOverride,
+	}}
+	repo := NewRepositoryWithDB(&fakeDB{
+		queryRowFn: func(context.Context, string, ...any) pgx.Row {
+			t.Fatal("GetLimit must use the configured policy store")
+			return fakeRow{}
+		},
+	})
+	repo.SetLimitPolicyStore(source)
+
+	limit, err := repo.GetLimit(context.Background(), "team-1", DimensionActiveSandboxes)
+	if err != nil {
+		t.Fatalf("GetLimit: %v", err)
+	}
+	if limit == nil || limit.LimitValue != 120 {
+		t.Fatalf("limit = %+v, want active sandbox limit 120", limit)
+	}
+	if source.calls.Load() != 1 {
+		t.Fatalf("source calls = %d, want 1", source.calls.Load())
+	}
+}
+
 func TestEnsureDefaultPoliciesRejectsInvalidLimits(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary

Coalesce concurrent quota-policy cache misses so a cold tenant does not fan out identical PostgreSQL reads.

This PR is intentionally isolated as one ComputeSDK performance/correctness change.

## Dependency

None.

## Validation

- `go test ./pkg/quota ./manager/cmd/manager`
- `go test -race ./pkg/quota`
- `go vet ./pkg/quota ./manager/cmd/manager`
- `git diff --check`
- Wave-one integration commit `52b0b212` was deployed to the persistent Aliyun Singapore kind environment.
- Remote smoke: Sandbox0Infra Ready 10/10; default hot claim and `node -v`; resources preserved on a no-override claim; 512 MiB resize claim; restricted-network desired/applied hash match; 8 parallel claims with 8 unique sandboxes.
- ctld A/B daemonsets were restarted sequentially on both data-plane nodes and the deployment returned to Ready 10/10 without portal/FUSE/HA errors.

The remote result validates the combined wave-one branch; this PR still relies on its own focused tests and PR CI for isolated coverage.

## Benchmark

Combined wave-one integration commit: `52b0b2127e0ba2578d5dd3269be4309e312bb5f2` (`sandbox0ai/infra:computesdk-wave1-52b0b21`). The benchmark used ComputeSDK commit `15b1a338171f5631c266bb480e8491cba3f6a4e3`, 100 iterations per mode, one fixed 32-vCPU sandbox node, default idle 120, burst nodes disabled, and an in-cluster runner in Ali us-east-1. No result was uploaded.

| Mode | Score | Success | Median | P95 | P99 | Wall | First ready |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| sequential | 97.60 | 100/100 | 209.40 ms | 275.30 ms | 300.94 ms | - | - |
| staggered | 92.23 | 100/100 | 687.97 ms | 899.50 ms | 928.05 ms | 21.34 s | 165.03 ms |
| burst 1 | 38.56 | 100/100 | 5594.08 ms | 6915.83 ms | 7054.70 ms | 10.86 s | 3974.29 ms |
| burst 2 | 31.56 | 100/100 | 6739.44 ms | 6955.92 ms | 7077.49 ms | 13.70 s | 1545.95 ms |

This is a combined-stack result, not isolated attribution for this PR. Both burst repetitions show a material regression versus the prior mixed experiment, so this PR remains draft and requires isolated A/B evidence before any performance claim or merge decision.

Operational evidence: image CI [30133571556](https://github.com/sandbox0-ai/sandbox0/actions/runs/30133571556), deployment [30134259307](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30134259307), benchmark preflight [30134915050](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30134915050), baseline restore [30135559660](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30135559660), and final baseline preflight [30135754538](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30135754538).

After the run, the temporary runner was deleted, team quotas were restored to `region_default`, burst capacity was restored to `0-299` with zero burst nodes, and production runtime was restored to `sandbox0ai/infra:main-2c2db0b`.