### PR TITLE
perf(manager): preserve dense warm-pool resources

### DIFF
--- a/manager/pkg/apis/sandbox0/v1alpha1/helpers.go
+++ b/manager/pkg/apis/sandbox0/v1alpha1/helpers.go
@@ -394,14 +394,24 @@ func applyIdleResourceQuotaToPodSpec(spec *corev1.PodSpec, template *SandboxTemp
 	if spec == nil || template == nil {
 		return
 	}
-	quota := idleResourceQuota(template.Spec.MainContainer.Resources)
+	resources := idleResourceRequirements(template.Spec.MainContainer.Resources)
 	for i := range spec.Containers {
 		if spec.Containers[i].Name != "procd" {
 			continue
 		}
-		spec.Containers[i].Resources = BuildResourceRequirements(quota)
+		spec.Containers[i].Resources = resources
 		return
 	}
+}
+
+// idleResourceRequirements keeps warm-pool scheduling requests dense while
+// preserving the template limits. A hot claim still raises requests through
+// in-place resize, but its first process is never throttled by the warm limit.
+func idleResourceRequirements(templateQuota ResourceQuota) corev1.ResourceRequirements {
+	idleResources := BuildResourceRequirements(idleResourceQuota(templateQuota))
+	templateResources := BuildResourceRequirements(templateQuota)
+	idleResources.Limits = templateResources.Limits
+	return idleResources
 }
 
 func idleResourceQuota(templateQuota ResourceQuota) ResourceQuota {

--- a/manager/pkg/apis/sandbox0/v1alpha1/helpers_test.go
+++ b/manager/pkg/apis/sandbox0/v1alpha1/helpers_test.go
@@ -444,7 +444,7 @@ func TestBuildResourceRequirementsKeepsMinimumCPURequestDense(t *testing.T) {
 	assertResourceQuantity(t, resources.Limits[corev1.ResourceMemory], "128Mi")
 }
 
-func TestBuildIdlePodSpecUsesLowCPUAndMemoryLimits(t *testing.T) {
+func TestBuildIdlePodSpecUsesLowRequestsAndTemplateLimits(t *testing.T) {
 	configPath := writeManagerConfig(t, `
 manager_image: sandbox0/manager:test
 `)
@@ -460,9 +460,9 @@ manager_image: sandbox0/manager:test
 	resources := spec.Containers[0].Resources
 
 	assertResourceQuantity(t, resources.Requests[corev1.ResourceCPU], "10m")
-	assertResourceQuantity(t, resources.Limits[corev1.ResourceCPU], "32m")
+	assertResourceQuantity(t, resources.Limits[corev1.ResourceCPU], "500m")
 	assertResourceQuantity(t, resources.Requests[corev1.ResourceMemory], "64Mi")
-	assertResourceQuantity(t, resources.Limits[corev1.ResourceMemory], "128Mi")
+	assertResourceQuantity(t, resources.Limits[corev1.ResourceMemory], "2Gi")
 	assertResourceQuantity(t, resources.Requests[corev1.ResourceEphemeralStorage], "1Gi")
 	assertResourceQuantity(t, resources.Limits[corev1.ResourceEphemeralStorage], "8Gi")
 }

--- a/manager/pkg/service/sandbox_service_resources.go
+++ b/manager/pkg/service/sandbox_service_resources.go
@@ -134,17 +134,18 @@ func sandboxPodNeedsResourceResize(pod *corev1.Pod, quota v1alpha1.ResourceQuota
 		if container.Name != "procd" {
 			continue
 		}
-		return !resizeResourcesEqual(container.Resources, desired)
+		// Warm pods already carry the template limits while keeping scheduling
+		// requests low. Preserve those dense requests when the claim does not
+		// change either enforceable limit; only resource overrides and limit
+		// corrections require an in-place resize.
+		return !resourceLimitsEqual(container.Resources.Limits, desired.Limits)
 	}
 	return true
 }
 
-func resizeResourcesEqual(a, b corev1.ResourceRequirements) bool {
+func resourceLimitsEqual(a, b corev1.ResourceList) bool {
 	for _, name := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
-		if !resourceListQuantityEqual(a.Requests, b.Requests, name) {
-			return false
-		}
-		if !resourceListQuantityEqual(a.Limits, b.Limits, name) {
+		if !resourceListQuantityEqual(a, b, name) {
 			return false
 		}
 	}

--- a/manager/pkg/service/sandbox_service_resources_test.go
+++ b/manager/pkg/service/sandbox_service_resources_test.go
@@ -185,7 +185,7 @@ func TestCreateNewPodAppliesTemplateResourcesByDefault(t *testing.T) {
 	assertQuantity(t, container.Resources.Requests[corev1.ResourceCPU], "25m")
 }
 
-func TestClaimIdlePodAppliesTemplateResourcesByDefault(t *testing.T) {
+func TestClaimIdlePodPreservesDenseRequestsWhenTemplateLimitsMatch(t *testing.T) {
 	template := newSandboxResourceTestTemplate(t)
 	idlePod := newSandboxResourceTestIdlePod(t, template, "idle-ready")
 	node := newClaimTestNode("node-a", "10.0.0.1")
@@ -211,9 +211,9 @@ func TestClaimIdlePodAppliesTemplateResourcesByDefault(t *testing.T) {
 	container := sandboxRuntimeContainer(t, pod)
 	assertQuantity(t, container.Resources.Limits[corev1.ResourceMemory], "1Gi")
 	assertQuantity(t, container.Resources.Limits[corev1.ResourceCPU], "250m")
-	assertQuantity(t, container.Resources.Requests[corev1.ResourceMemory], "256Mi")
-	assertQuantity(t, container.Resources.Requests[corev1.ResourceCPU], "25m")
-	assertResizeSubresourceUpdate(t, client.Actions())
+	assertQuantity(t, container.Resources.Requests[corev1.ResourceMemory], "64Mi")
+	assertQuantity(t, container.Resources.Requests[corev1.ResourceCPU], "10m")
+	assertNoResizeSubresourceUpdate(t, client.Actions())
 }
 
 func TestClaimIdlePodAppliesMinimumCPUToTemplateResources(t *testing.T) {
@@ -545,6 +545,15 @@ func assertResizeSubresourceUpdate(t *testing.T, actions []k8stesting.Action) {
 		}
 	}
 	t.Fatalf("missing update pods/resize action; actions = %#v", actions)
+}
+
+func assertNoResizeSubresourceUpdate(t *testing.T, actions []k8stesting.Action) {
+	t.Helper()
+	for _, action := range actions {
+		if action.Matches("patch", "pods") && action.GetSubresource() == "resize" {
+			t.Fatalf("unexpected patch pods/resize action; actions = %#v", actions)
+		}
+	}
 }
 
 func contains(s, substr string) bool {


### PR DESCRIPTION
## Summary

Keep warm pods densely scheduled with low requests while retaining claim-time limits, avoiding a resize when a claim has no resource overrides.

This PR is intentionally isolated as one ComputeSDK performance/correctness change.

## Dependency

None.

## Validation

- `go test ./manager/pkg/apis/sandbox0/v1alpha1 ./manager/pkg/service`
- `go test -race ./manager/pkg/apis/sandbox0/v1alpha1 ./manager/pkg/service`
- `go vet ./manager/pkg/apis/sandbox0/v1alpha1 ./manager/pkg/service`
- `git diff --check`
- Wave-one integration commit `52b0b212` was deployed to the persistent Aliyun Singapore kind environment.
- Remote smoke: Sandbox0Infra Ready 10/10; default hot claim and `node -v`; resources preserved on a no-override claim; 512 MiB resize claim; restricted-network desired/applied hash match; 8 parallel claims with 8 unique sandboxes.
- ctld A/B daemonsets were restarted sequentially on both data-plane nodes and the deployment returned to Ready 10/10 without portal/FUSE/HA errors.

The remote result validates the combined wave-one branch; this PR still relies on its own focused tests and PR CI for isolated coverage.

## Benchmark

Combined wave-one integration commit: `52b0b2127e0ba2578d5dd3269be4309e312bb5f2` (`sandbox0ai/infra:computesdk-wave1-52b0b21`). The benchmark used ComputeSDK commit `15b1a338171f5631c266bb480e8491cba3f6a4e3`, 100 iterations per mode, one fixed 32-vCPU sandbox node, default idle 120, burst nodes disabled, and an in-cluster runner in Ali us-east-1. No result was uploaded.

| Mode | Score | Success | Median | P95 | P99 | Wall | First ready |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| sequential | 97.60 | 100/100 | 209.40 ms | 275.30 ms | 300.94 ms | - | - |
| staggered | 92.23 | 100/100 | 687.97 ms | 899.50 ms | 928.05 ms | 21.34 s | 165.03 ms |
| burst 1 | 38.56 | 100/100 | 5594.08 ms | 6915.83 ms | 7054.70 ms | 10.86 s | 3974.29 ms |
| burst 2 | 31.56 | 100/100 | 6739.44 ms | 6955.92 ms | 7077.49 ms | 13.70 s | 1545.95 ms |

This is a combined-stack result, not isolated attribution for this PR. Both burst repetitions show a material regression versus the prior mixed experiment, so this PR remains draft and requires isolated A/B evidence before any performance claim or merge decision.

Operational evidence: image CI [30133571556](https://github.com/sandbox0-ai/sandbox0/actions/runs/30133571556), deployment [30134259307](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30134259307), benchmark preflight [30134915050](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30134915050), baseline restore [30135559660](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30135559660), and final baseline preflight [30135754538](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30135754538).

After the run, the temporary runner was deleted, team quotas were restored to `region_default`, burst capacity was restored to `0-299` with zero burst nodes, and production runtime was restored to `sandbox0ai/infra:main-2c2db0b`.