### PR TITLE
perf(manager): patch pod resize without a pre-read

### DIFF
--- a/manager/pkg/service/sandbox_service_resources.go
+++ b/manager/pkg/service/sandbox_service_resources.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -10,6 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 )
 
@@ -55,21 +57,35 @@ func (s *SandboxService) resizeSandboxPodResources(ctx context.Context, pod *cor
 
 	namespace, name := pod.Namespace, pod.Name
 	var updated *corev1.Pod
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		current, err := s.k8sClient.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
-		if err != nil {
-			return err
-		}
-		resized := current.DeepCopy()
-		if err := s.applySandboxResourceQuota(resized, quota); err != nil {
-			return err
-		}
-		result, err := s.k8sClient.CoreV1().Pods(namespace).UpdateResize(ctx, name, resized, metav1.UpdateOptions{})
+	resources := v1alpha1.BuildResourceRequirements(quota)
+	patch, err := json.Marshal(map[string]any{
+		"spec": map[string]any{
+			"containers": []map[string]any{{
+				"name":      "procd",
+				"resources": resources,
+			}},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("build sandbox resource resize patch: %w", err)
+	}
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		result, err := s.k8sClient.CoreV1().Pods(namespace).Patch(
+			ctx,
+			name,
+			types.StrategicMergePatchType,
+			patch,
+			metav1.PatchOptions{},
+			"resize",
+		)
 		if err != nil {
 			return err
 		}
 		if result == nil || result.Name == "" {
-			updated = resized
+			updated = pod.DeepCopy()
+			if applyErr := s.applySandboxResourceQuota(updated, quota); applyErr != nil {
+				return applyErr
+			}
 		} else {
 			updated = result
 		}

--- a/manager/pkg/service/sandbox_service_resources_test.go
+++ b/manager/pkg/service/sandbox_service_resources_test.go
@@ -278,12 +278,12 @@ func TestClaimIdlePodAppliesMemoryOverride(t *testing.T) {
 	assertResizeSubresourceUpdate(t, client.Actions())
 }
 
-func TestResizeSandboxPodResourcesRetriesConflictWithFreshPod(t *testing.T) {
+func TestResizeSandboxPodResourcesRetriesConflictWithoutPreflightGet(t *testing.T) {
 	template := newSandboxResourceTestTemplate(t)
 	pod := newSandboxResourceTestActivePod(t, template, "sandbox-1")
 	client := fake.NewSimpleClientset(pod.DeepCopy())
 	resizeUpdates := 0
-	client.PrependReactor("update", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+	client.PrependReactor("patch", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		if action.GetSubresource() != "resize" {
 			return false, nil, nil
 		}
@@ -312,9 +312,55 @@ func TestResizeSandboxPodResourcesRetriesConflictWithFreshPod(t *testing.T) {
 	if resizeUpdates != 2 {
 		t.Fatalf("resize update calls = %d, want 2", resizeUpdates)
 	}
+	gets := 0
+	for _, action := range client.Actions() {
+		if action.GetVerb() == "get" && action.GetResource().Resource == "pods" {
+			gets++
+		}
+	}
+	if gets != 0 {
+		t.Fatalf("pod get calls = %d, want 0", gets)
+	}
 	container := sandboxRuntimeContainer(t, resized)
 	assertQuantity(t, container.Resources.Limits[corev1.ResourceMemory], "2Gi")
 	assertQuantity(t, container.Resources.Limits[corev1.ResourceCPU], "500m")
+}
+
+func TestResizeSandboxPodResourcesUsesUpdatedPodWithoutPreflightGet(t *testing.T) {
+	template := newSandboxResourceTestTemplate(t)
+	pod := newSandboxResourceTestActivePod(t, template, "sandbox-1")
+	client := fake.NewSimpleClientset(pod.DeepCopy())
+	svc := &SandboxService{
+		k8sClient: client,
+		config:    SandboxServiceConfig{SandboxMemoryPerCPU: "4Gi"},
+		logger:    zap.NewNop(),
+	}
+	quota, err := svc.effectiveSandboxResourceQuota(template, &SandboxConfig{
+		Resources: &SandboxResourceConfig{Memory: "2Gi"},
+	})
+	if err != nil {
+		t.Fatalf("effectiveSandboxResourceQuota() error = %v", err)
+	}
+
+	if _, err := svc.resizeSandboxPodResources(context.Background(), pod, quota); err != nil {
+		t.Fatalf("resizeSandboxPodResources() error = %v", err)
+	}
+	gets := 0
+	resizeUpdates := 0
+	for _, action := range client.Actions() {
+		if action.GetVerb() == "get" && action.GetResource().Resource == "pods" {
+			gets++
+		}
+		if action.GetVerb() == "patch" && action.GetSubresource() == "resize" {
+			resizeUpdates++
+		}
+	}
+	if gets != 0 {
+		t.Fatalf("pod get calls = %d, want 0", gets)
+	}
+	if resizeUpdates != 1 {
+		t.Fatalf("resize update calls = %d, want 1", resizeUpdates)
+	}
 }
 
 func TestClaimIdlePodRestoresIdlePodAfterResizeConflict(t *testing.T) {
@@ -326,7 +372,7 @@ func TestClaimIdlePodRestoresIdlePodAfterResizeConflict(t *testing.T) {
 	client := fake.NewSimpleClientset(idlePod.DeepCopy(), node.DeepCopy())
 	resizeUpdates := 0
 	deletes := 0
-	client.PrependReactor("update", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+	client.PrependReactor("patch", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		if action.GetSubresource() != "resize" {
 			return false, nil, nil
 		}
@@ -540,11 +586,11 @@ func assertResizePolicy(t *testing.T, policies []corev1.ContainerResizePolicy, r
 func assertResizeSubresourceUpdate(t *testing.T, actions []k8stesting.Action) {
 	t.Helper()
 	for _, action := range actions {
-		if action.Matches("update", "pods") && action.GetSubresource() == "resize" {
+		if action.Matches("patch", "pods") && action.GetSubresource() == "resize" {
 			return
 		}
 	}
-	t.Fatalf("missing update pods/resize action; actions = %#v", actions)
+	t.Fatalf("missing patch pods/resize action; actions = %#v", actions)
 }
 
 func contains(s, substr string) bool {


### PR DESCRIPTION
## Summary

Send the Kubernetes pod resize subresource patch directly and remove the redundant GET from the resize path.

This PR is intentionally isolated as one ComputeSDK performance/correctness change.

## Dependency

None.

## Validation

- `go test ./manager/pkg/service`
- `go test -race ./manager/pkg/service`
- `go vet ./manager/pkg/service`
- `git diff --check`
- Wave-one integration commit `52b0b212` was deployed to the persistent Aliyun Singapore kind environment.
- Remote smoke: Sandbox0Infra Ready 10/10; default hot claim and `node -v`; resources preserved on a no-override claim; 512 MiB resize claim; restricted-network desired/applied hash match; 8 parallel claims with 8 unique sandboxes.
- ctld A/B daemonsets were restarted sequentially on both data-plane nodes and the deployment returned to Ready 10/10 without portal/FUSE/HA errors.

The remote result validates the combined wave-one branch; this PR still relies on its own focused tests and PR CI for isolated coverage.

## Benchmark

Combined wave-one integration commit: `52b0b2127e0ba2578d5dd3269be4309e312bb5f2` (`sandbox0ai/infra:computesdk-wave1-52b0b21`). The benchmark used ComputeSDK commit `15b1a338171f5631c266bb480e8491cba3f6a4e3`, 100 iterations per mode, one fixed 32-vCPU sandbox node, default idle 120, burst nodes disabled, and an in-cluster runner in Ali us-east-1. No result was uploaded.

| Mode | Score | Success | Median | P95 | P99 | Wall | First ready |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| sequential | 97.60 | 100/100 | 209.40 ms | 275.30 ms | 300.94 ms | - | - |
| staggered | 92.23 | 100/100 | 687.97 ms | 899.50 ms | 928.05 ms | 21.34 s | 165.03 ms |
| burst 1 | 38.56 | 100/100 | 5594.08 ms | 6915.83 ms | 7054.70 ms | 10.86 s | 3974.29 ms |
| burst 2 | 31.56 | 100/100 | 6739.44 ms | 6955.92 ms | 7077.49 ms | 13.70 s | 1545.95 ms |

This is a combined-stack result, not isolated attribution for this PR. Both burst repetitions show a material regression versus the prior mixed experiment, so this PR remains draft and requires isolated A/B evidence before any performance claim or merge decision.

Operational evidence: image CI [30133571556](https://github.com/sandbox0-ai/sandbox0/actions/runs/30133571556), deployment [30134259307](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30134259307), benchmark preflight [30134915050](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30134915050), baseline restore [30135559660](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30135559660), and final baseline preflight [30135754538](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30135754538).

After the run, the temporary runner was deleted, team quotas were restored to `region_default`, burst capacity was restored to `0-299` with zero burst nodes, and production runtime was restored to `sandbox0ai/infra:main-2c2db0b`.