### PR TITLE
perf(manager): skip fresh credential binding lookup

### DIFF
--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -58,6 +58,7 @@ type ClaimRequest struct {
 	HardExpiresAt time.Time `json:"-"`
 	// WebhookStateVolumeID preserves the manager-owned webhook state volume across pod recreation.
 	WebhookStateVolumeID string `json:"-"`
+	mayHaveExistingCredentialBindings bool
 }
 
 type ClaimMount struct {
@@ -342,6 +343,7 @@ type ClaimResponse struct {
 func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*ClaimResponse, error) {
 	start := time.Now()
 	metrics := s.metrics
+	req.mayHaveExistingCredentialBindings = strings.TrimSpace(req.SandboxID) != ""
 	phaseStarted := time.Now()
 	canonicalTemplateID, err := naming.CanonicalTemplateID(req.Template)
 	s.observeClaimPhase(req.Template, "unknown", "canonicalize_template", phaseStarted, err)
@@ -1158,7 +1160,13 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 		if policyErr != nil {
 			return policyErr
 		}
-		rollbackBindings, err := s.syncCredentialBindings(ctx, pod, req.TeamID, networkState)
+		rollbackBindings, err := s.syncCredentialBindings(
+			ctx,
+			pod,
+			req.TeamID,
+			networkState,
+			req.mayHaveExistingCredentialBindings,
+		)
 		if err != nil {
 			return fmt.Errorf("stage credential bindings: %w", err)
 		}
@@ -1394,7 +1402,13 @@ func (s *SandboxService) createNewPod(ctx context.Context, template *v1alpha1.Sa
 	if err != nil {
 		return nil, err
 	}
-	rollbackBindings, err := s.syncCredentialBindings(ctx, pod, req.TeamID, networkState)
+	rollbackBindings, err := s.syncCredentialBindings(
+		ctx,
+		pod,
+		req.TeamID,
+		networkState,
+		req.mayHaveExistingCredentialBindings,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("stage credential bindings: %w", err)
 	}

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -57,7 +57,7 @@ type ClaimRequest struct {
 	// HardExpiresAt preserves the absolute hard deadline when recreating a paused sandbox.
 	HardExpiresAt time.Time `json:"-"`
 	// WebhookStateVolumeID preserves the manager-owned webhook state volume across pod recreation.
-	WebhookStateVolumeID string `json:"-"`
+	WebhookStateVolumeID              string `json:"-"`
 	mayHaveExistingCredentialBindings bool
 }
 

--- a/manager/pkg/service/sandbox_service_lifecycle.go
+++ b/manager/pkg/service/sandbox_service_lifecycle.go
@@ -802,7 +802,7 @@ func (s *SandboxService) UpdateSandbox(ctx context.Context, sandboxID string, cf
 				TemplateBindings: templateBindings,
 				RequestBindings:  requestBindings,
 			})
-			rollbackBindings, err = s.syncCredentialBindings(ctx, updatedPod, teamID, networkState)
+			rollbackBindings, err = s.syncCredentialBindings(ctx, updatedPod, teamID, networkState, true)
 			if err != nil {
 				return fmt.Errorf("stage credential bindings: %w", err)
 			}

--- a/manager/pkg/service/sandbox_service_network.go
+++ b/manager/pkg/service/sandbox_service_network.go
@@ -197,6 +197,7 @@ func (s *SandboxService) syncCredentialBindings(
 	pod *corev1.Pod,
 	teamID string,
 	state *BuildNetworkPolicyResult,
+	previousMayExist bool,
 ) (func(context.Context) error, error) {
 	if s.credentialStore == nil || pod == nil || state == nil {
 		return noopCredentialBindingRollback, nil
@@ -206,11 +207,15 @@ func (s *SandboxService) syncCredentialBindings(
 	if sandboxID == "" {
 		sandboxID = pod.Name
 	}
-	previous, err := s.credentialStore.GetBindings(ctx, teamID, sandboxID)
-	if err != nil {
-		return nil, err
+	var previous *egressauth.BindingRecord
+	if previousMayExist {
+		var err error
+		previous, err = s.credentialStore.GetBindings(ctx, teamID, sandboxID)
+		if err != nil {
+			return nil, err
+		}
+		previous = cloneBindingRecord(previous)
 	}
-	previous = cloneBindingRecord(previous)
 
 	rollback := func(rollbackCtx context.Context) error {
 		if previous == nil || len(previous.Bindings) == 0 {
@@ -678,7 +683,7 @@ func (s *SandboxService) UpdateNetworkPolicy(
 			return fmt.Errorf("%w: %v", ErrInvalidNetworkPolicy, err)
 		}
 		networkState = s.NetworkPolicyService.BuildNetworkPolicyState(buildReq)
-		rollbackBindings, err = s.syncCredentialBindings(ctx, current, teamID, networkState)
+		rollbackBindings, err = s.syncCredentialBindings(ctx, current, teamID, networkState, true)
 		if err != nil {
 			return fmt.Errorf("stage credential bindings: %w", err)
 		}

--- a/manager/pkg/service/sandbox_service_network_test.go
+++ b/manager/pkg/service/sandbox_service_network_test.go
@@ -32,6 +32,7 @@ type memoryBindingStore struct {
 	records        map[string]*egressauth.BindingRecord
 	sourcesByRef   map[string]*egressauth.CredentialSource
 	sourceVersions map[string]*egressauth.CredentialSourceVersion
+	getCalls       int
 	upsertCalls    int
 	deleteCalls    int
 }
@@ -45,6 +46,7 @@ func newMemoryBindingStore() *memoryBindingStore {
 }
 
 func (s *memoryBindingStore) GetBindings(_ context.Context, teamID, sandboxID string) (*egressauth.BindingRecord, error) {
+	s.getCalls++
 	return cloneBindingRecord(s.records[s.bindingKey(teamID, sandboxID)]), nil
 }
 
@@ -541,6 +543,46 @@ func TestTemplateCredentialBindingsUsesNestedNetworkBindings(t *testing.T) {
 
 	require.Len(t, bindings, 1)
 	assert.Equal(t, "nested-ref", bindings[0].Ref)
+}
+
+func TestSyncCredentialBindingsSkipsLookupForFreshSandbox(t *testing.T) {
+	store := newMemoryBindingStore()
+	svc := &SandboxService{credentialStore: store}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sandbox-a",
+			Namespace: "ns-a",
+			Annotations: map[string]string{
+				controller.AnnotationSandboxID: "sandbox-a",
+			},
+		},
+	}
+
+	if _, err := svc.syncCredentialBindings(
+		context.Background(),
+		pod,
+		"team-a",
+		&BuildNetworkPolicyResult{},
+		false,
+	); err != nil {
+		t.Fatalf("syncCredentialBindings() error = %v", err)
+	}
+	if store.getCalls != 0 {
+		t.Fatalf("binding lookups = %d, want 0", store.getCalls)
+	}
+
+	if _, err := svc.syncCredentialBindings(
+		context.Background(),
+		pod,
+		"team-a",
+		&BuildNetworkPolicyResult{},
+		true,
+	); err != nil {
+		t.Fatalf("syncCredentialBindings(existing) error = %v", err)
+	}
+	if store.getCalls != 1 {
+		t.Fatalf("binding lookups = %d, want 1", store.getCalls)
+	}
 }
 
 func TestUpdateNetworkPolicyStoresBindingsOutsidePodConfig(t *testing.T) {


### PR DESCRIPTION
## Summary

Skip the credential-binding existence read for fresh claims while preserving the check for resume and update paths.

This PR is intentionally isolated as one ComputeSDK performance/correctness change.

## Dependency

None.

## Validation

- `go test ./manager/pkg/service`
- `go test -race ./manager/pkg/service`
- `go vet ./manager/pkg/service`
- `git diff --check`
- Wave-one integration commit `52b0b212` was deployed to the persistent Aliyun Singapore kind environment.
- Remote smoke: Sandbox0Infra Ready 10/10; default hot claim and `node -v`; resources preserved on a no-override claim; 512 MiB resize claim; restricted-network desired/applied hash match; 8 parallel claims with 8 unique sandboxes.
- ctld A/B daemonsets were restarted sequentially on both data-plane nodes and the deployment returned to Ready 10/10 without portal/FUSE/HA errors.

The remote result validates the combined wave-one branch; this PR still relies on its own focused tests and PR CI for isolated coverage.

## Benchmark

Combined wave-one integration commit: `52b0b2127e0ba2578d5dd3269be4309e312bb5f2` (`sandbox0ai/infra:computesdk-wave1-52b0b21`). The benchmark used ComputeSDK commit `15b1a338171f5631c266bb480e8491cba3f6a4e3`, 100 iterations per mode, one fixed 32-vCPU sandbox node, default idle 120, burst nodes disabled, and an in-cluster runner in Ali us-east-1. No result was uploaded.

| Mode | Score | Success | Median | P95 | P99 | Wall | First ready |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| sequential | 97.60 | 100/100 | 209.40 ms | 275.30 ms | 300.94 ms | - | - |
| staggered | 92.23 | 100/100 | 687.97 ms | 899.50 ms | 928.05 ms | 21.34 s | 165.03 ms |
| burst 1 | 38.56 | 100/100 | 5594.08 ms | 6915.83 ms | 7054.70 ms | 10.86 s | 3974.29 ms |
| burst 2 | 31.56 | 100/100 | 6739.44 ms | 6955.92 ms | 7077.49 ms | 13.70 s | 1545.95 ms |

This is a combined-stack result, not isolated attribution for this PR. Both burst repetitions show a material regression versus the prior mixed experiment, so this PR remains draft and requires isolated A/B evidence before any performance claim or merge decision.

Operational evidence: image CI [30133571556](https://github.com/sandbox0-ai/sandbox0/actions/runs/30133571556), deployment [30134259307](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30134259307), benchmark preflight [30134915050](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30134915050), baseline restore [30135559660](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30135559660), and final baseline preflight [30135754538](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30135754538).

After the run, the temporary runner was deleted, team quotas were restored to `region_default`, burst capacity was restored to `0-299` with zero burst nodes, and production runtime was restored to `sandbox0ai/infra:main-2c2db0b`.