### PR TITLE
perf(manager): avoid waiting for unrestricted network apply

### DIFF
--- a/manager/pkg/apis/sandbox0/v1alpha1/policy_types.go
+++ b/manager/pkg/apis/sandbox0/v1alpha1/policy_types.go
@@ -18,10 +18,10 @@ type NetworkPolicySpec struct {
 	Egress *NetworkEgressPolicy `json:"egress,omitempty"`
 }
 
-// NetworkPolicyRequiresApply reports whether the network runtime must
-// acknowledge this policy before the sandbox can be used. The default
-// unrestricted policy has no enforcement state to install.
-func NetworkPolicyRequiresApply(spec *NetworkPolicySpec) bool {
+// NetworkPolicyRequiresSynchronousApply reports whether a claim must wait for
+// the network runtime to acknowledge the policy. Unrestricted policies are
+// still applied asynchronously and retain their desired and applied hashes.
+func NetworkPolicyRequiresSynchronousApply(spec *NetworkPolicySpec) bool {
 	if spec == nil {
 		return false
 	}

--- a/manager/pkg/apis/sandbox0/v1alpha1/policy_types.go
+++ b/manager/pkg/apis/sandbox0/v1alpha1/policy_types.go
@@ -18,6 +18,20 @@ type NetworkPolicySpec struct {
 	Egress *NetworkEgressPolicy `json:"egress,omitempty"`
 }
 
+// NetworkPolicyRequiresApply reports whether the network runtime must
+// acknowledge this policy before the sandbox can be used. The default
+// unrestricted policy has no enforcement state to install.
+func NetworkPolicyRequiresApply(spec *NetworkPolicySpec) bool {
+	if spec == nil {
+		return false
+	}
+	mode := spec.Mode
+	if mode == "" {
+		mode = NetworkModeAllowAll
+	}
+	return mode != NetworkModeAllowAll || spec.Egress != nil
+}
+
 // PortSpec defines a port specification
 type PortSpec struct {
 	// Port number

--- a/manager/pkg/apis/sandbox0/v1alpha1/policy_types_test.go
+++ b/manager/pkg/apis/sandbox0/v1alpha1/policy_types_test.go
@@ -2,7 +2,7 @@ package v1alpha1
 
 import "testing"
 
-func TestNetworkPolicyRequiresApply(t *testing.T) {
+func TestNetworkPolicyRequiresSynchronousApply(t *testing.T) {
 	tests := []struct {
 		name string
 		spec *NetworkPolicySpec
@@ -30,8 +30,8 @@ func TestNetworkPolicyRequiresApply(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NetworkPolicyRequiresApply(tt.spec); got != tt.want {
-				t.Fatalf("NetworkPolicyRequiresApply() = %t, want %t", got, tt.want)
+			if got := NetworkPolicyRequiresSynchronousApply(tt.spec); got != tt.want {
+				t.Fatalf("NetworkPolicyRequiresSynchronousApply() = %t, want %t", got, tt.want)
 			}
 		})
 	}

--- a/manager/pkg/apis/sandbox0/v1alpha1/policy_types_test.go
+++ b/manager/pkg/apis/sandbox0/v1alpha1/policy_types_test.go
@@ -1,0 +1,38 @@
+package v1alpha1
+
+import "testing"
+
+func TestNetworkPolicyRequiresApply(t *testing.T) {
+	tests := []struct {
+		name string
+		spec *NetworkPolicySpec
+		want bool
+	}{
+		{name: "nil policy"},
+		{name: "implicit allow all", spec: &NetworkPolicySpec{}},
+		{name: "explicit allow all", spec: &NetworkPolicySpec{Mode: NetworkModeAllowAll}},
+		{
+			name: "allow all with egress policy",
+			spec: &NetworkPolicySpec{
+				Mode:   NetworkModeAllowAll,
+				Egress: &NetworkEgressPolicy{},
+			},
+			want: true,
+		},
+		{
+			name: "block all",
+			spec: &NetworkPolicySpec{
+				Mode: NetworkModeBlockAll,
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NetworkPolicyRequiresApply(tt.spec); got != tt.want {
+				t.Fatalf("NetworkPolicyRequiresApply() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}

--- a/manager/pkg/network/netd_provider.go
+++ b/manager/pkg/network/netd_provider.go
@@ -257,7 +257,7 @@ func (p *NetdProvider) tick(ticker *time.Ticker) <-chan time.Time {
 }
 
 func (p *NetdProvider) networkPolicyHash(spec *v1alpha1.NetworkPolicySpec) (string, error) {
-	if !v1alpha1.NetworkPolicyRequiresApply(spec) {
+	if !v1alpha1.NetworkPolicyRequiresSynchronousApply(spec) {
 		return "", nil
 	}
 	annotation, err := v1alpha1.NetworkPolicyToAnnotation(spec)

--- a/manager/pkg/network/netd_provider.go
+++ b/manager/pkg/network/netd_provider.go
@@ -257,7 +257,7 @@ func (p *NetdProvider) tick(ticker *time.Ticker) <-chan time.Time {
 }
 
 func (p *NetdProvider) networkPolicyHash(spec *v1alpha1.NetworkPolicySpec) (string, error) {
-	if spec == nil {
+	if !v1alpha1.NetworkPolicyRequiresApply(spec) {
 		return "", nil
 	}
 	annotation, err := v1alpha1.NetworkPolicyToAnnotation(spec)

--- a/manager/pkg/network/netd_provider_test.go
+++ b/manager/pkg/network/netd_provider_test.go
@@ -1,0 +1,39 @@
+package network
+
+import (
+	"testing"
+
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
+)
+
+func TestNetdProviderNetworkPolicyHashSkipsUnrestrictedPolicy(t *testing.T) {
+	provider := &NetdProvider{}
+	hash, err := provider.networkPolicyHash(&v1alpha1.NetworkPolicySpec{
+		Version:   "v1",
+		SandboxID: "sandbox-a",
+		TeamID:    "team-a",
+		Mode:      v1alpha1.NetworkModeAllowAll,
+	})
+	if err != nil {
+		t.Fatalf("networkPolicyHash() error = %v", err)
+	}
+	if hash != "" {
+		t.Fatalf("networkPolicyHash() = %q, want empty", hash)
+	}
+}
+
+func TestNetdProviderNetworkPolicyHashKeepsRestrictedPolicy(t *testing.T) {
+	provider := &NetdProvider{}
+	hash, err := provider.networkPolicyHash(&v1alpha1.NetworkPolicySpec{
+		Version:   "v1",
+		SandboxID: "sandbox-a",
+		TeamID:    "team-a",
+		Mode:      v1alpha1.NetworkModeBlockAll,
+	})
+	if err != nil {
+		t.Fatalf("networkPolicyHash() error = %v", err)
+	}
+	if hash == "" {
+		t.Fatal("networkPolicyHash() is empty for a restricted policy")
+	}
+}

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -869,8 +869,8 @@ func TestCreateNewPodDefersNetworkApplyUntilPodHasNetworkIdentity(t *testing.T) 
 	if pod.Annotations[controller.AnnotationNetworkPolicy] == "" {
 		t.Fatal("network policy annotation is empty")
 	}
-	if pod.Annotations[controller.AnnotationNetworkPolicyHash] != "" {
-		t.Fatal("unrestricted network policy unexpectedly requires an applied hash")
+	if pod.Annotations[controller.AnnotationNetworkPolicyHash] == "" {
+		t.Fatal("unrestricted network policy hash is empty")
 	}
 
 	pods, err := client.CoreV1().Pods("ns-a").List(context.Background(), metav1.ListOptions{})

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -869,8 +869,8 @@ func TestCreateNewPodDefersNetworkApplyUntilPodHasNetworkIdentity(t *testing.T) 
 	if pod.Annotations[controller.AnnotationNetworkPolicy] == "" {
 		t.Fatal("network policy annotation is empty")
 	}
-	if pod.Annotations[controller.AnnotationNetworkPolicyHash] == "" {
-		t.Fatal("network policy hash annotation is empty")
+	if pod.Annotations[controller.AnnotationNetworkPolicyHash] != "" {
+		t.Fatal("unrestricted network policy unexpectedly requires an applied hash")
 	}
 
 	pods, err := client.CoreV1().Pods("ns-a").List(context.Background(), metav1.ListOptions{})

--- a/manager/pkg/service/sandbox_service_network.go
+++ b/manager/pkg/service/sandbox_service_network.go
@@ -154,10 +154,7 @@ func (s *SandboxService) setNetworkPolicyAnnotations(pod *corev1.Pod, spec *v1al
 		return "", fmt.Errorf("serialize network policy: %w", err)
 	}
 	pod.Annotations[controller.AnnotationNetworkPolicy] = annotation
-	newHash := ""
-	if v1alpha1.NetworkPolicyRequiresApply(spec) {
-		newHash = policyAnnotationHash(annotation)
-	}
+	newHash := policyAnnotationHash(annotation)
 	oldHash := pod.Annotations[controller.AnnotationNetworkPolicyHash]
 	if newHash != "" {
 		pod.Annotations[controller.AnnotationNetworkPolicyHash] = newHash

--- a/manager/pkg/service/sandbox_service_network.go
+++ b/manager/pkg/service/sandbox_service_network.go
@@ -154,7 +154,10 @@ func (s *SandboxService) setNetworkPolicyAnnotations(pod *corev1.Pod, spec *v1al
 		return "", fmt.Errorf("serialize network policy: %w", err)
 	}
 	pod.Annotations[controller.AnnotationNetworkPolicy] = annotation
-	newHash := policyAnnotationHash(annotation)
+	newHash := ""
+	if v1alpha1.NetworkPolicyRequiresApply(spec) {
+		newHash = policyAnnotationHash(annotation)
+	}
 	oldHash := pod.Annotations[controller.AnnotationNetworkPolicyHash]
 	if newHash != "" {
 		pod.Annotations[controller.AnnotationNetworkPolicyHash] = newHash


### PR DESCRIPTION
## Summary

Return immediately for allow-all network policies while retaining desired state for asynchronous application; restricted policies still wait for applied-hash acknowledgement.

This PR is intentionally isolated as one ComputeSDK performance/correctness change.

## Dependency

None.

## Validation

- `go test ./manager/pkg/apis/sandbox0/v1alpha1 ./manager/pkg/network ./manager/pkg/service`
- `go test -race ./manager/pkg/apis/sandbox0/v1alpha1 ./manager/pkg/network ./manager/pkg/service`
- `go vet ./manager/pkg/apis/sandbox0/v1alpha1 ./manager/pkg/network ./manager/pkg/service`
- `git diff --check`
- Wave-one integration commit `52b0b212` was deployed to the persistent Aliyun Singapore kind environment.
- Remote smoke: Sandbox0Infra Ready 10/10; default hot claim and `node -v`; resources preserved on a no-override claim; 512 MiB resize claim; restricted-network desired/applied hash match; 8 parallel claims with 8 unique sandboxes.
- ctld A/B daemonsets were restarted sequentially on both data-plane nodes and the deployment returned to Ready 10/10 without portal/FUSE/HA errors.

The remote result validates the combined wave-one branch; this PR still relies on its own focused tests and PR CI for isolated coverage.

## Benchmark

Combined wave-one integration commit: `52b0b2127e0ba2578d5dd3269be4309e312bb5f2` (`sandbox0ai/infra:computesdk-wave1-52b0b21`). The benchmark used ComputeSDK commit `15b1a338171f5631c266bb480e8491cba3f6a4e3`, 100 iterations per mode, one fixed 32-vCPU sandbox node, default idle 120, burst nodes disabled, and an in-cluster runner in Ali us-east-1. No result was uploaded.

| Mode | Score | Success | Median | P95 | P99 | Wall | First ready |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| sequential | 97.60 | 100/100 | 209.40 ms | 275.30 ms | 300.94 ms | - | - |
| staggered | 92.23 | 100/100 | 687.97 ms | 899.50 ms | 928.05 ms | 21.34 s | 165.03 ms |
| burst 1 | 38.56 | 100/100 | 5594.08 ms | 6915.83 ms | 7054.70 ms | 10.86 s | 3974.29 ms |
| burst 2 | 31.56 | 100/100 | 6739.44 ms | 6955.92 ms | 7077.49 ms | 13.70 s | 1545.95 ms |

This is a combined-stack result, not isolated attribution for this PR. Both burst repetitions show a material regression versus the prior mixed experiment, so this PR remains draft and requires isolated A/B evidence before any performance claim or merge decision.

Operational evidence: image CI [30133571556](https://github.com/sandbox0-ai/sandbox0/actions/runs/30133571556), deployment [30134259307](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30134259307), benchmark preflight [30134915050](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30134915050), baseline restore [30135559660](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30135559660), and final baseline preflight [30135754538](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30135754538).

After the run, the temporary runner was deleted, team quotas were restored to `region_default`, burst capacity was restored to `0-299` with zero burst nodes, and production runtime was restored to `sandbox0ai/infra:main-2c2db0b`.