### PR TITLE
perf(netd): ignore non-runtime pod updates

### DIFF
--- a/netd/pkg/watcher/watcher.go
+++ b/netd/pkg/watcher/watcher.go
@@ -306,14 +306,19 @@ func (w *Watcher) handlePodUpsert(obj any) {
 
 	key := pod.Namespace + "/" + pod.Name
 	w.mu.Lock()
+	notify := true
 	if existing := w.sandboxes[key]; existing != nil {
 		if !isResourceVersionNewer(existing.ResourceVersion, info.ResourceVersion) {
 			w.mu.Unlock()
 			return
 		}
+		notify = sandboxRuntimeInputChanged(existing, info)
 	}
 	w.sandboxes[key] = info
 	w.mu.Unlock()
+	if !notify {
+		return
+	}
 
 	w.logger.Info("Sandbox pod detected",
 		zap.String("sandbox", key),
@@ -326,6 +331,20 @@ func (w *Watcher) handlePodUpsert(obj any) {
 	if w.onSandboxUpsert != nil {
 		w.onSandboxUpsert(cloneSandboxInfo(info))
 	}
+}
+
+func sandboxRuntimeInputChanged(current, incoming *SandboxInfo) bool {
+	if current == nil || incoming == nil {
+		return true
+	}
+	return current.UID != incoming.UID ||
+		current.PodIP != incoming.PodIP ||
+		current.NodeName != incoming.NodeName ||
+		current.SandboxID != incoming.SandboxID ||
+		current.TeamID != incoming.TeamID ||
+		current.OwnerKind != incoming.OwnerKind ||
+		current.NetworkPolicy != incoming.NetworkPolicy ||
+		current.NetworkPolicyHash != incoming.NetworkPolicyHash
 }
 
 func (w *Watcher) handlePodDelete(obj any) {

--- a/netd/pkg/watcher/watcher_test.go
+++ b/netd/pkg/watcher/watcher_test.go
@@ -39,6 +39,57 @@ func TestHandlePodUpsertRemovesDeletingSandboxFromFallbackCache(t *testing.T) {
 	}
 }
 
+func TestHandlePodUpsertDoesNotNotifyForAppliedHashOnlyUpdate(t *testing.T) {
+	w := NewWatcher(nil, 0, zap.NewNop())
+	notifications := 0
+	w.SetSandboxHandlers(func(*SandboxInfo) {
+		notifications++
+	}, nil)
+	pod := testSandboxPod("sandbox-a", "uid-a", "10", "10.0.0.2", "node-a")
+	pod.Annotations = map[string]string{
+		controller.AnnotationNetworkPolicy:     `{"mode":"allow-all"}`,
+		controller.AnnotationNetworkPolicyHash: "hash-a",
+	}
+	w.handlePodUpsert(pod)
+
+	applied := pod.DeepCopy()
+	applied.ResourceVersion = "11"
+	applied.Annotations[controller.AnnotationNetworkPolicyAppliedHash] = "hash-a"
+	w.handlePodUpsert(applied)
+
+	if notifications != 1 {
+		t.Fatalf("sandbox notifications = %d, want 1", notifications)
+	}
+	got := w.ListSandboxesByNode("node-a")
+	if len(got) != 1 || got[0].NetworkAppliedHash != "hash-a" {
+		t.Fatalf("cached sandbox = %#v, want updated applied hash", got)
+	}
+}
+
+func TestHandlePodUpsertNotifiesWhenPolicyHashChanges(t *testing.T) {
+	w := NewWatcher(nil, 0, zap.NewNop())
+	notifications := 0
+	w.SetSandboxHandlers(func(*SandboxInfo) {
+		notifications++
+	}, nil)
+	pod := testSandboxPod("sandbox-a", "uid-a", "10", "10.0.0.2", "node-a")
+	pod.Annotations = map[string]string{
+		controller.AnnotationNetworkPolicy:     `{"mode":"allow-all"}`,
+		controller.AnnotationNetworkPolicyHash: "hash-a",
+	}
+	w.handlePodUpsert(pod)
+
+	changed := pod.DeepCopy()
+	changed.ResourceVersion = "11"
+	changed.Annotations[controller.AnnotationNetworkPolicy] = `{"mode":"block-all"}`
+	changed.Annotations[controller.AnnotationNetworkPolicyHash] = "hash-b"
+	w.handlePodUpsert(changed)
+
+	if notifications != 2 {
+		t.Fatalf("sandbox notifications = %d, want 2", notifications)
+	}
+}
+
 func TestListSandboxesByNodeUsesInformerCacheAsAuthoritativeSource(t *testing.T) {
 	w := NewWatcher(nil, 0, zap.NewNop())
 	informer := cache.NewSharedIndexInformer(nil, &corev1.Pod{}, 0, cache.Indexers{podNodeIndex: indexPodByNode})


### PR DESCRIPTION
## Summary

Filter Kubernetes pod update events whose runtime-relevant state did not change, reducing redundant netd reconciliation work.

This PR is intentionally isolated as one ComputeSDK performance/correctness change.

## Dependency

None.

## Validation

- `go test ./netd/pkg/watcher`
- `go test -race ./netd/pkg/watcher`
- `go vet ./netd/pkg/watcher`
- `git diff --check`
- Wave-one integration commit `52b0b212` was deployed to the persistent Aliyun Singapore kind environment.
- Remote smoke: Sandbox0Infra Ready 10/10; default hot claim and `node -v`; resources preserved on a no-override claim; 512 MiB resize claim; restricted-network desired/applied hash match; 8 parallel claims with 8 unique sandboxes.
- ctld A/B daemonsets were restarted sequentially on both data-plane nodes and the deployment returned to Ready 10/10 without portal/FUSE/HA errors.

The remote result validates the combined wave-one branch; this PR still relies on its own focused tests and PR CI for isolated coverage.

## Benchmark

Combined wave-one integration commit: `52b0b2127e0ba2578d5dd3269be4309e312bb5f2` (`sandbox0ai/infra:computesdk-wave1-52b0b21`). The benchmark used ComputeSDK commit `15b1a338171f5631c266bb480e8491cba3f6a4e3`, 100 iterations per mode, one fixed 32-vCPU sandbox node, default idle 120, burst nodes disabled, and an in-cluster runner in Ali us-east-1. No result was uploaded.

| Mode | Score | Success | Median | P95 | P99 | Wall | First ready |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| sequential | 97.60 | 100/100 | 209.40 ms | 275.30 ms | 300.94 ms | - | - |
| staggered | 92.23 | 100/100 | 687.97 ms | 899.50 ms | 928.05 ms | 21.34 s | 165.03 ms |
| burst 1 | 38.56 | 100/100 | 5594.08 ms | 6915.83 ms | 7054.70 ms | 10.86 s | 3974.29 ms |
| burst 2 | 31.56 | 100/100 | 6739.44 ms | 6955.92 ms | 7077.49 ms | 13.70 s | 1545.95 ms |

This is a combined-stack result, not isolated attribution for this PR. Both burst repetitions show a material regression versus the prior mixed experiment, so this PR remains draft and requires isolated A/B evidence before any performance claim or merge decision.

Operational evidence: image CI [30133571556](https://github.com/sandbox0-ai/sandbox0/actions/runs/30133571556), deployment [30134259307](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30134259307), benchmark preflight [30134915050](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30134915050), baseline restore [30135559660](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30135559660), and final baseline preflight [30135754538](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30135754538).

After the run, the temporary runner was deleted, team quotas were restored to `region_default`, burst capacity was restored to `0-299` with zero burst nodes, and production runtime was restored to `sandbox0ai/infra:main-2c2db0b`.