### PR TITLE
perf(netd): use ipset-only event syncs

### DIFF
--- a/netd/pkg/daemon/daemon.go
+++ b/netd/pkg/daemon/daemon.go
@@ -329,13 +329,15 @@ func (d *Daemon) runNetd(ctx context.Context, cancel context.CancelFunc, proxyEx
 		defer ticker.Stop()
 		triggerSync()
 		for {
+			forceRedirectSync := false
 			select {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
+				forceRedirectSync = true
 			case <-syncTrigger:
 			}
-			if err := d.syncRedirect(ctx, netdWatcher, policyStore, platformState, redirectManager, patcher, tracker, conntrackManager, proxyServer); err != nil {
+			if err := d.syncRedirect(ctx, netdWatcher, policyStore, platformState, redirectManager, patcher, tracker, conntrackManager, proxyServer, forceRedirectSync); err != nil {
 				d.logger.Error("Failed to sync redirect rules", zap.Error(err))
 				if d.cfg.FailClosed {
 					d.ready.Store(false)
@@ -562,6 +564,7 @@ func (d *Daemon) syncRedirect(
 	tracker *conntrack.Tracker,
 	conntrackManager *conntrack.Manager,
 	proxyServer *proxy.Server,
+	forceRedirectSync bool,
 ) (err error) {
 	started := time.Now()
 	defer func() {
@@ -649,9 +652,15 @@ func (d *Daemon) syncRedirect(
 		zap.Strings("bypass_cidrs", bypassCIDRs),
 	)
 	stageStarted = time.Now()
-	if err := redirectManager.Sync(ctx, sandboxIPs, bypassCIDRs); err != nil {
+	var redirectErr error
+	if forceRedirectSync {
+		redirectErr = redirectManager.ForceSync(ctx, sandboxIPs, bypassCIDRs)
+	} else {
+		redirectErr = redirectManager.Sync(ctx, sandboxIPs, bypassCIDRs)
+	}
+	if redirectErr != nil {
 		daemonMetrics.RecordRedirectSyncStage("redirect_sync", "error", time.Since(stageStarted))
-		return err
+		return redirectErr
 	}
 	daemonMetrics.RecordRedirectSyncStage("redirect_sync", "success", time.Since(stageStarted))
 

--- a/netd/pkg/redirect/manager.go
+++ b/netd/pkg/redirect/manager.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os/exec"
 	"strings"
+	"sync"
 
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/vishvananda/netlink"
@@ -23,9 +24,13 @@ const (
 )
 
 type iptablesManager struct {
-	cfg    Config
-	logger *zap.Logger
-	ipt    iptablesClient
+	cfg         Config
+	logger      *zap.Logger
+	ipt         iptablesClient
+	syncMu      sync.Mutex
+	initialized bool
+	sandboxIPs  []string
+	bypassCIDRs []string
 }
 
 type iptablesClient interface {
@@ -59,12 +64,43 @@ func NewManager(cfg Config, logger *zap.Logger) Manager {
 }
 
 func (m *iptablesManager) Sync(ctx context.Context, sandboxIPs []string, bypassCIDRs []string) error {
+	return m.sync(ctx, sandboxIPs, bypassCIDRs, false)
+}
+
+func (m *iptablesManager) ForceSync(ctx context.Context, sandboxIPs []string, bypassCIDRs []string) error {
+	return m.sync(ctx, sandboxIPs, bypassCIDRs, true)
+}
+
+func (m *iptablesManager) sync(
+	ctx context.Context,
+	sandboxIPs []string,
+	bypassCIDRs []string,
+	force bool,
+) error {
 	if m.cfg.ProxyHTTPPort == 0 || m.cfg.ProxyHTTPSPort == 0 {
 		return fmt.Errorf("proxy ports are not configured")
 	}
 	if m.ipt == nil {
 		return fmt.Errorf("iptables is not initialized")
 	}
+	sandboxIPs = normalizeIPs(sandboxIPs)
+	bypassCIDRs = normalizeCIDRs(bypassCIDRs)
+
+	m.syncMu.Lock()
+	defer m.syncMu.Unlock()
+
+	switch planRedirectSync(m.initialized, m.sandboxIPs, m.bypassCIDRs, sandboxIPs, bypassCIDRs, force) {
+	case redirectSyncNoop:
+		return nil
+	case redirectSyncIPSet:
+		if err := m.syncIPSet(ctx, sandboxIPs); err != nil {
+			return err
+		}
+		m.sandboxIPs = append(m.sandboxIPs[:0], sandboxIPs...)
+		m.logger.Info("IPSet-only redirect sync complete", zap.Int("sandbox_ips", len(sandboxIPs)))
+		return nil
+	}
+
 	m.logger.Info(
 		"Iptables sync start",
 		zap.Int("sandbox_ips", len(sandboxIPs)),
@@ -105,9 +141,55 @@ func (m *iptablesManager) Sync(ctx context.Context, sandboxIPs []string, bypassC
 	if err := m.ensureNATJump(ctx); err != nil {
 		return err
 	}
+	m.initialized = true
+	m.sandboxIPs = append(m.sandboxIPs[:0], sandboxIPs...)
+	m.bypassCIDRs = append(m.bypassCIDRs[:0], bypassCIDRs...)
 
 	m.logger.Info("Iptables sync complete")
 	return nil
+}
+
+type redirectSyncPlan int
+
+const (
+	redirectSyncFull redirectSyncPlan = iota
+	redirectSyncIPSet
+	redirectSyncNoop
+)
+
+func planRedirectSync(
+	initialized bool,
+	previousSandboxIPs []string,
+	previousBypassCIDRs []string,
+	sandboxIPs []string,
+	bypassCIDRs []string,
+	force bool,
+) redirectSyncPlan {
+	if force || !initialized || !sameStringSet(previousBypassCIDRs, bypassCIDRs) {
+		return redirectSyncFull
+	}
+	if sameStringSet(previousSandboxIPs, sandboxIPs) {
+		return redirectSyncNoop
+	}
+	return redirectSyncIPSet
+}
+
+func sameStringSet(left, right []string) bool {
+	left = normalizeUnique(left)
+	right = normalizeUnique(right)
+	if len(left) != len(right) {
+		return false
+	}
+	values := make(map[string]struct{}, len(left))
+	for _, value := range left {
+		values[value] = struct{}{}
+	}
+	for _, value := range right {
+		if _, ok := values[value]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func (m *iptablesManager) syncIPSet(ctx context.Context, ips []string) error {

--- a/netd/pkg/redirect/manager_other.go
+++ b/netd/pkg/redirect/manager_other.go
@@ -24,6 +24,10 @@ func (m *noopManager) Sync(ctx context.Context, sandboxIPs []string, bypassCIDRs
 	return fmt.Errorf("iptables manager is only supported on linux")
 }
 
+func (m *noopManager) ForceSync(ctx context.Context, sandboxIPs []string, bypassCIDRs []string) error {
+	return m.Sync(ctx, sandboxIPs, bypassCIDRs)
+}
+
 func (m *noopManager) Cleanup(ctx context.Context) error {
 	_ = ctx
 	return nil

--- a/netd/pkg/redirect/manager_test.go
+++ b/netd/pkg/redirect/manager_test.go
@@ -138,6 +138,58 @@ func TestNormalizeInputsDeduplicateAndTrim(t *testing.T) {
 	}
 }
 
+func TestPlanRedirectSyncUsesIPSetOnlyForSandboxChanges(t *testing.T) {
+	previousIPs := []string{"10.0.0.2"}
+	previousBypass := []string{"10.0.0.0/8"}
+
+	if got := planRedirectSync(true, previousIPs, previousBypass, []string{"10.0.0.2", "10.0.0.3"}, previousBypass, false); got != redirectSyncIPSet {
+		t.Fatalf("plan = %v, want IPSet-only sync", got)
+	}
+	if got := planRedirectSync(true, previousIPs, previousBypass, previousIPs, previousBypass, false); got != redirectSyncNoop {
+		t.Fatalf("plan = %v, want no-op sync", got)
+	}
+}
+
+func TestPlanRedirectSyncKeepsPeriodicAndBypassReconciliationFull(t *testing.T) {
+	ips := []string{"10.0.0.2"}
+	bypass := []string{"10.0.0.0/8"}
+
+	tests := []struct {
+		name        string
+		initialized bool
+		nextBypass  []string
+		force       bool
+	}{
+		{name: "initial", initialized: false, nextBypass: bypass},
+		{name: "periodic", initialized: true, nextBypass: bypass, force: true},
+		{name: "bypass changed", initialized: true, nextBypass: []string{"192.168.0.0/16"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := planRedirectSync(tt.initialized, ips, bypass, ips, tt.nextBypass, tt.force); got != redirectSyncFull {
+				t.Fatalf("plan = %v, want full sync", got)
+			}
+		})
+	}
+}
+
+func TestPlanRedirectSyncIgnoresInputOrder(t *testing.T) {
+	previousIPs := []string{"10.0.0.2", "10.0.0.3"}
+	previousBypass := []string{"10.0.0.0/8", "192.168.0.0/16"}
+
+	got := planRedirectSync(
+		true,
+		previousIPs,
+		previousBypass,
+		[]string{"10.0.0.3", "10.0.0.2"},
+		[]string{"192.168.0.0/16", "10.0.0.0/8"},
+		false,
+	)
+	if got != redirectSyncNoop {
+		t.Fatalf("plan = %v, want no-op sync", got)
+	}
+}
+
 func TestRuleExistsRequiresPriorityBeforeCNISourceRules(t *testing.T) {
 	mask := uint32(1)
 	rules := []netlink.Rule{

--- a/netd/pkg/redirect/types.go
+++ b/netd/pkg/redirect/types.go
@@ -4,6 +4,7 @@ import "context"
 
 type Manager interface {
 	Sync(ctx context.Context, sandboxIPs []string, bypassCIDRs []string) error
+	ForceSync(ctx context.Context, sandboxIPs []string, bypassCIDRs []string) error
 	Cleanup(ctx context.Context) error
 }
 


### PR DESCRIPTION
## Summary

Use the cheaper ipset-only redirect update for pod-driven syncs while preserving periodic full iptables reconciliation.

This PR is intentionally isolated as one ComputeSDK performance/correctness change.

## Dependency

None.

## Validation

- `go test ./netd/pkg/redirect ./netd/pkg/daemon`
- `go test -race ./netd/pkg/redirect ./netd/pkg/daemon`
- `go vet ./netd/pkg/redirect ./netd/pkg/daemon`
- `git diff --check`
- Wave-one integration commit `52b0b212` was deployed to the persistent Aliyun Singapore kind environment.
- Remote smoke: Sandbox0Infra Ready 10/10; default hot claim and `node -v`; resources preserved on a no-override claim; 512 MiB resize claim; restricted-network desired/applied hash match; 8 parallel claims with 8 unique sandboxes.
- ctld A/B daemonsets were restarted sequentially on both data-plane nodes and the deployment returned to Ready 10/10 without portal/FUSE/HA errors.

The remote result validates the combined wave-one branch; this PR still relies on its own focused tests and PR CI for isolated coverage.

## Benchmark

Combined wave-one integration commit: `52b0b2127e0ba2578d5dd3269be4309e312bb5f2` (`sandbox0ai/infra:computesdk-wave1-52b0b21`). The benchmark used ComputeSDK commit `15b1a338171f5631c266bb480e8491cba3f6a4e3`, 100 iterations per mode, one fixed 32-vCPU sandbox node, default idle 120, burst nodes disabled, and an in-cluster runner in Ali us-east-1. No result was uploaded.

| Mode | Score | Success | Median | P95 | P99 | Wall | First ready |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| sequential | 97.60 | 100/100 | 209.40 ms | 275.30 ms | 300.94 ms | - | - |
| staggered | 92.23 | 100/100 | 687.97 ms | 899.50 ms | 928.05 ms | 21.34 s | 165.03 ms |
| burst 1 | 38.56 | 100/100 | 5594.08 ms | 6915.83 ms | 7054.70 ms | 10.86 s | 3974.29 ms |
| burst 2 | 31.56 | 100/100 | 6739.44 ms | 6955.92 ms | 7077.49 ms | 13.70 s | 1545.95 ms |

This is a combined-stack result, not isolated attribution for this PR. Both burst repetitions show a material regression versus the prior mixed experiment, so this PR remains draft and requires isolated A/B evidence before any performance claim or merge decision.

Operational evidence: image CI [30133571556](https://github.com/sandbox0-ai/sandbox0/actions/runs/30133571556), deployment [30134259307](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30134259307), benchmark preflight [30134915050](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30134915050), baseline restore [30135559660](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30135559660), and final baseline preflight [30135754538](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30135754538).

After the run, the temporary runner was deleted, team quotas were restored to `region_default`, burst capacity was restored to `0-299` with zero burst nodes, and production runtime was restored to `sandbox0ai/infra:main-2c2db0b`.