### PR TITLE
perf(netd): parallelize applied-hash patches

### DIFF
--- a/netd/pkg/apply/patcher.go
+++ b/netd/pkg/apply/patcher.go
@@ -8,10 +8,13 @@ import (
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
 	"github.com/sandbox0-ai/sandbox0/netd/pkg/watcher"
 	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 )
+
+const appliedHashPatchConcurrency = 16
 
 type Patcher struct {
 	client kubernetes.Interface
@@ -29,6 +32,8 @@ func (p *Patcher) SyncAppliedHashes(ctx context.Context, sandboxes []*watcher.Sa
 	if p.client == nil {
 		return fmt.Errorf("k8s client is nil")
 	}
+	group, groupCtx := errgroup.WithContext(ctx)
+	group.SetLimit(appliedHashPatchConcurrency)
 	for _, sandbox := range sandboxes {
 		if sandbox == nil || sandbox.NetworkPolicyHash == "" {
 			continue
@@ -44,30 +49,34 @@ func (p *Patcher) SyncAppliedHashes(ctx context.Context, sandboxes []*watcher.Sa
 		if err != nil {
 			return err
 		}
-		_, err = p.client.CoreV1().Pods(sandbox.Namespace).Patch(
-			ctx,
-			sandbox.Name,
-			types.MergePatchType,
-			patchBytes,
-			metav1.PatchOptions{},
-		)
-		if err != nil {
-			p.logger.Warn("Failed to patch applied hashes",
+		sandbox := sandbox
+		group.Go(func() error {
+			_, patchErr := p.client.CoreV1().Pods(sandbox.Namespace).Patch(
+				groupCtx,
+				sandbox.Name,
+				types.MergePatchType,
+				patchBytes,
+				metav1.PatchOptions{},
+			)
+			if patchErr != nil {
+				p.logger.Warn("Failed to patch applied hashes",
+					zap.String("namespace", sandbox.Namespace),
+					zap.String("pod", sandbox.Name),
+					zap.String("pod_ip", sandbox.PodIP),
+					zap.Error(patchErr),
+				)
+				return nil
+			}
+			p.logger.Info("Applied hashes patched",
 				zap.String("namespace", sandbox.Namespace),
 				zap.String("pod", sandbox.Name),
 				zap.String("pod_ip", sandbox.PodIP),
-				zap.Error(err),
+				zap.String("network_policy_applied_hash", annotations[controller.AnnotationNetworkPolicyAppliedHash]),
 			)
-			continue
-		}
-		p.logger.Info("Applied hashes patched",
-			zap.String("namespace", sandbox.Namespace),
-			zap.String("pod", sandbox.Name),
-			zap.String("pod_ip", sandbox.PodIP),
-			zap.String("network_policy_applied_hash", annotations[controller.AnnotationNetworkPolicyAppliedHash]),
-		)
+			return nil
+		})
 	}
-	return nil
+	return group.Wait()
 }
 
 func buildAnnotationPatch(annotations map[string]string) ([]byte, error) {

--- a/netd/pkg/apply/patcher_test.go
+++ b/netd/pkg/apply/patcher_test.go
@@ -1,0 +1,124 @@
+package apply
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
+	"github.com/sandbox0-ai/sandbox0/netd/pkg/watcher"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+)
+
+func TestSyncAppliedHashesPatchesPendingSandboxesConcurrently(t *testing.T) {
+	const sandboxCount = appliedHashPatchConcurrency * 2
+	sandboxes := make([]*watcher.SandboxInfo, 0, sandboxCount)
+	for index := range sandboxCount {
+		name := fmt.Sprintf("sandbox-%d", index)
+		sandboxes = append(sandboxes, &watcher.SandboxInfo{
+			Namespace:         "default",
+			Name:              name,
+			NetworkPolicyHash: "policy-hash",
+		})
+	}
+
+	var active atomic.Int64
+	var maximum atomic.Int64
+	var patches atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Method != http.MethodPatch {
+			http.Error(writer, "unexpected method", http.StatusMethodNotAllowed)
+			return
+		}
+		current := active.Add(1)
+		defer active.Add(-1)
+		for {
+			observed := maximum.Load()
+			if current <= observed || maximum.CompareAndSwap(observed, current) {
+				break
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+		patches.Add(1)
+		writer.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(writer).Encode(&corev1.Pod{
+			TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      path.Base(request.URL.Path),
+			},
+		})
+	}))
+	defer server.Close()
+
+	client, err := kubernetes.NewForConfig(&rest.Config{
+		Host:  server.URL,
+		QPS:   1_000,
+		Burst: 1_000,
+	})
+	if err != nil {
+		t.Fatalf("NewForConfig() error = %v", err)
+	}
+
+	if err := NewPatcher(client, nil).SyncAppliedHashes(context.Background(), sandboxes); err != nil {
+		t.Fatalf("SyncAppliedHashes() error = %v", err)
+	}
+	if got := maximum.Load(); got <= 1 {
+		t.Fatalf("maximum concurrent patches = %d, want greater than 1", got)
+	} else if got > appliedHashPatchConcurrency {
+		t.Fatalf("maximum concurrent patches = %d, want at most %d", got, appliedHashPatchConcurrency)
+	}
+	if got := patches.Load(); got != sandboxCount {
+		t.Fatalf("patch count = %d, want %d", got, sandboxCount)
+	}
+}
+
+func TestSyncAppliedHashesSkipsAcknowledgedPolicies(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	sandbox := &watcher.SandboxInfo{
+		Namespace:          "default",
+		Name:               "sandbox",
+		NetworkPolicyHash:  "policy-hash",
+		NetworkAppliedHash: "policy-hash",
+	}
+
+	if err := NewPatcher(client, nil).SyncAppliedHashes(context.Background(), []*watcher.SandboxInfo{sandbox}); err != nil {
+		t.Fatalf("SyncAppliedHashes() error = %v", err)
+	}
+	if actions := client.Actions(); len(actions) != 0 {
+		t.Fatalf("client actions = %v, want none", actions)
+	}
+}
+
+func TestSyncAppliedHashesWritesPolicyHash(t *testing.T) {
+	client := fake.NewSimpleClientset(&corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Namespace: "default",
+		Name:      "sandbox",
+	}})
+	sandbox := &watcher.SandboxInfo{
+		Namespace:         "default",
+		Name:              "sandbox",
+		NetworkPolicyHash: "policy-hash",
+	}
+
+	if err := NewPatcher(client, nil).SyncAppliedHashes(context.Background(), []*watcher.SandboxInfo{sandbox}); err != nil {
+		t.Fatalf("SyncAppliedHashes() error = %v", err)
+	}
+	pod, err := client.CoreV1().Pods("default").Get(context.Background(), "sandbox", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get patched pod: %v", err)
+	}
+	if got := pod.Annotations[controller.AnnotationNetworkPolicyAppliedHash]; got != sandbox.NetworkPolicyHash {
+		t.Fatalf("applied hash = %q, want %q", got, sandbox.NetworkPolicyHash)
+	}
+}

--- a/netd/pkg/daemon/daemon.go
+++ b/netd/pkg/daemon/daemon.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/netd/pkg/watcher"
 	"github.com/sandbox0-ai/sandbox0/pkg/dbpool"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+	s0k8s "github.com/sandbox0-ai/sandbox0/pkg/k8s"
 	meteringclickhouse "github.com/sandbox0-ai/sandbox0/pkg/metering/clickhouse"
 	meteringoutbox "github.com/sandbox0-ai/sandbox0/pkg/metering/outbox"
 	"github.com/sandbox0-ai/sandbox0/pkg/observability"
@@ -147,6 +148,7 @@ func (d *Daemon) runNetd(ctx context.Context, cancel context.CancelFunc, proxyEx
 	if err != nil {
 		return err
 	}
+	s0k8s.ApplyDefaultRateLimit(k8sConfig)
 	if d.obsProvider != nil {
 		d.obsProvider.K8s.WrapConfig(k8sConfig)
 	}


### PR DESCRIPTION
## Summary

Patch independent sandbox applied-hash annotations concurrently with bounded fan-out instead of serially.

This PR is intentionally isolated as one ComputeSDK performance/correctness change.

## Dependency

None.

## Validation

- `go test ./netd/pkg/apply ./netd/pkg/daemon`
- `go test -race ./netd/pkg/apply ./netd/pkg/daemon`
- `go vet ./netd/pkg/apply ./netd/pkg/daemon`
- `git diff --check`
- Wave-one integration commit `52b0b212` was deployed to the persistent Aliyun Singapore kind environment.
- Remote smoke: Sandbox0Infra Ready 10/10; default hot claim and `node -v`; resources preserved on a no-override claim; 512 MiB resize claim; restricted-network desired/applied hash match; 8 parallel claims with 8 unique sandboxes.
- ctld A/B daemonsets were restarted sequentially on both data-plane nodes and the deployment returned to Ready 10/10 without portal/FUSE/HA errors.

The remote result validates the combined wave-one branch; this PR still relies on its own focused tests and PR CI for isolated coverage.

## Benchmark

Combined wave-one integration commit: `52b0b2127e0ba2578d5dd3269be4309e312bb5f2` (`sandbox0ai/infra:computesdk-wave1-52b0b21`). The benchmark used ComputeSDK commit `15b1a338171f5631c266bb480e8491cba3f6a4e3`, 100 iterations per mode, one fixed 32-vCPU sandbox node, default idle 120, burst nodes disabled, and an in-cluster runner in Ali us-east-1. No result was uploaded.

| Mode | Score | Success | Median | P95 | P99 | Wall | First ready |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| sequential | 97.60 | 100/100 | 209.40 ms | 275.30 ms | 300.94 ms | - | - |
| staggered | 92.23 | 100/100 | 687.97 ms | 899.50 ms | 928.05 ms | 21.34 s | 165.03 ms |
| burst 1 | 38.56 | 100/100 | 5594.08 ms | 6915.83 ms | 7054.70 ms | 10.86 s | 3974.29 ms |
| burst 2 | 31.56 | 100/100 | 6739.44 ms | 6955.92 ms | 7077.49 ms | 13.70 s | 1545.95 ms |

This is a combined-stack result, not isolated attribution for this PR. Both burst repetitions show a material regression versus the prior mixed experiment, so this PR remains draft and requires isolated A/B evidence before any performance claim or merge decision.

Operational evidence: image CI [30133571556](https://github.com/sandbox0-ai/sandbox0/actions/runs/30133571556), deployment [30134259307](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30134259307), benchmark preflight [30134915050](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30134915050), baseline restore [30135559660](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30135559660), and final baseline preflight [30135754538](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30135754538).

After the run, the temporary runner was deleted, team quotas were restored to `region_default`, burst capacity was restored to `0-299` with zero burst nodes, and production runtime was restored to `sandbox0ai/infra:main-2c2db0b`.