### PR TITLE
perf(clickhouse): batch canonical audit inserts

### DIFF
--- a/pkg/sandboxobservability/clickhouse/audit_event_columns.go
+++ b/pkg/sandboxobservability/clickhouse/audit_event_columns.go
@@ -219,6 +219,26 @@ func (row *auditEventRow) insertValues() []any {
 	return values
 }
 
+func (row *auditEventRow) batchInsertValues() []any {
+	bindings := row.columnBindings()
+	values := make([]any, len(bindings))
+	for i, binding := range bindings {
+		switch binding.name {
+		case "schema_version":
+			values[i] = uint16(row.event.SchemaVersion)
+		case "status_code":
+			values[i] = uint16(row.event.Request.StatusCode)
+		case "occurred_at":
+			values[i] = row.event.OccurredAt.UTC()
+		case "ingested_at":
+			values[i] = row.event.IngestedAt.UTC()
+		default:
+			values[i] = binding.insertValue
+		}
+	}
+	return values
+}
+
 func (row auditEventRow) toEvent() (sandboxobservability.Event, error) {
 	attributes, err := decodeAttributes(row.attributesJSON)
 	if err != nil {

--- a/pkg/sandboxobservability/clickhouse/event_batch.go
+++ b/pkg/sandboxobservability/clickhouse/event_batch.go
@@ -1,0 +1,54 @@
+package clickhouse
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	clickhousedriver "github.com/ClickHouse/clickhouse-go/v2"
+)
+
+type eventBatchInserter interface {
+	InsertEventBatch(context.Context, string, [][]any) error
+}
+
+type eventBatchDB interface {
+	BeginTx(context.Context, *sql.TxOptions) (*sql.Tx, error)
+}
+
+type sqlEventBatchInserter struct {
+	db eventBatchDB
+}
+
+func (i sqlEventBatchInserter) InsertEventBatch(ctx context.Context, query string, rows [][]any) error {
+	batchContext := clickhousedriver.Context(ctx, clickhousedriver.WithSettings(clickhousedriver.Settings{
+		"async_insert":          0,
+		"wait_for_async_insert": 1,
+	}))
+	tx, err := i.db.BeginTx(batchContext, nil)
+	if err != nil {
+		return fmt.Errorf("begin event batch: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	statement, err := tx.PrepareContext(batchContext, query)
+	if err != nil {
+		return fmt.Errorf("prepare event batch: %w", err)
+	}
+	defer statement.Close()
+	for index, row := range rows {
+		if _, err := statement.ExecContext(batchContext, row...); err != nil {
+			return fmt.Errorf("append event batch row %d: %w", index, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit event batch: %w", err)
+	}
+	committed = true
+	return nil
+}

--- a/pkg/sandboxobservability/clickhouse/repository.go
+++ b/pkg/sandboxobservability/clickhouse/repository.go
@@ -22,6 +22,7 @@ type sqlBackend interface {
 
 type Repository struct {
 	db                  sqlBackend
+	eventBatchInserter  eventBatchInserter
 	cfg                 Config
 	eventsTable         string
 	logsTable           string
@@ -49,6 +50,9 @@ func NewRepository(db sqlBackend, cfg Config) (*Repository, error) {
 		now: func() time.Time {
 			return time.Now().UTC()
 		},
+	}
+	if batchDB, ok := db.(eventBatchDB); ok {
+		repository.eventBatchInserter = sqlEventBatchInserter{db: batchDB}
 	}
 	repository.loadRuntimeMetric = repository.queryRuntimeMetric
 	return repository, nil
@@ -106,12 +110,23 @@ func (r *Repository) InsertEvents(ctx context.Context, events []sandboxobservabi
 		if chunkSize > maxInsertBatchSize {
 			chunkSize = maxInsertBatchSize
 		}
-		query, args, err := r.buildInsertSQL(normalized[:chunkSize])
-		if err != nil {
-			return err
-		}
-		if _, err := r.db.ExecContext(ctx, query, args...); err != nil {
-			return fmt.Errorf("%w: insert events: %v", sandboxobservability.ErrBackendUnavailable, err)
+		chunk := normalized[:chunkSize]
+		if r.eventBatchInserter != nil {
+			rows, err := r.buildBatchInsertRows(chunk)
+			if err != nil {
+				return err
+			}
+			if err := r.eventBatchInserter.InsertEventBatch(ctx, r.buildBatchInsertSQL(), rows); err != nil {
+				return fmt.Errorf("%w: insert events: %v", sandboxobservability.ErrBackendUnavailable, err)
+			}
+		} else {
+			query, args, err := r.buildInsertSQL(chunk)
+			if err != nil {
+				return err
+			}
+			if _, err := r.db.ExecContext(ctx, query, args...); err != nil {
+				return fmt.Errorf("%w: insert events: %v", sandboxobservability.ErrBackendUnavailable, err)
+			}
 		}
 		normalized = normalized[chunkSize:]
 	}
@@ -150,6 +165,27 @@ func (r *Repository) listEvents(ctx context.Context, query sandboxobservability.
 		NextCursor: nextCursor,
 		Watermark:  lastWatermark(events),
 	}, nil
+}
+
+func (r *Repository) buildBatchInsertSQL() string {
+	return "INSERT INTO " + r.eventsTable + " (" + auditEventSelectColumns + ")"
+}
+
+func (r *Repository) buildBatchInsertRows(events []sandboxobservability.Event) ([][]any, error) {
+	columnCount := auditEventInsertColumnCount()
+	rows := make([][]any, 0, len(events))
+	for _, event := range events {
+		row, err := newAuditEventRow(event)
+		if err != nil {
+			return nil, err
+		}
+		values := row.batchInsertValues()
+		if len(values) != columnCount {
+			return nil, fmt.Errorf("audit event row has %d values for %d insert columns", len(values), columnCount)
+		}
+		rows = append(rows, values)
+	}
+	return rows, nil
 }
 
 func (r *Repository) buildInsertSQL(events []sandboxobservability.Event) (string, []any, error) {

--- a/pkg/sandboxobservability/clickhouse/repository_test.go
+++ b/pkg/sandboxobservability/clickhouse/repository_test.go
@@ -17,6 +17,18 @@ type captureDB struct {
 	execArgs  []any
 }
 
+type captureEventBatchInserter struct {
+	query string
+	rows  [][]any
+	err   error
+}
+
+func (c *captureEventBatchInserter) InsertEventBatch(_ context.Context, query string, rows [][]any) error {
+	c.query = query
+	c.rows = rows
+	return c.err
+}
+
 func (c *captureDB) ExecContext(_ context.Context, query string, args ...any) (sql.Result, error) {
 	c.execQuery = query
 	c.execArgs = args
@@ -96,6 +108,99 @@ func TestInsertEventsBuildsBatchInsertAndSerializesAttributes(t *testing.T) {
 	}
 	if strings.Contains(auditEventSelectColumns, "cursor") || strings.Contains(auditEventSelectColumns, "watermark") {
 		t.Fatalf("audit event storage columns contain query transport fields: %s", auditEventSelectColumns)
+	}
+}
+
+func TestInsertEventsUsesConfiguredNativeBatch(t *testing.T) {
+	repo, db := mustRepository(t)
+	batchInserter := &captureEventBatchInserter{}
+	repo.eventBatchInserter = batchInserter
+	now := time.Date(2026, 7, 1, 1, 2, 4, 987654321, time.UTC)
+	repo.now = func() time.Time { return now }
+	occurredAt := time.Date(2026, 7, 1, 1, 2, 3, 123456789, time.FixedZone("offset", 8*60*60))
+	event := sandboxobservability.Event{
+		EventID:       "11111111-1111-4111-8111-111111111111",
+		SchemaVersion: sandboxobservability.CurrentEventSchemaVersion,
+		TeamID:        "team-1",
+		SandboxID:     "sb-1",
+		RegionID:      "ali-us-east-1",
+		ClusterID:     "cluster-a",
+		OccurredAt:    occurredAt,
+		Source:        sandboxobservability.SourceManager,
+		EventType:     sandboxobservability.EventTypeLifecycle,
+		Phase:         sandboxobservability.EventPhaseResult,
+		Outcome:       sandboxobservability.OutcomeSucceeded,
+		Actor:         sandboxobservability.AuditActor{Kind: sandboxobservability.ActorKindHuman},
+		Action:        "sandbox.create",
+		Resource:      sandboxobservability.AuditResource{Type: "sandbox", ID: "sb-1"},
+		OperationID:   "operation-1",
+		Producer:      sandboxobservability.AuditProducer{Service: "cluster-gateway"},
+		Request:       sandboxobservability.AuditRequest{StatusCode: 201},
+	}
+	key := ed25519.NewKeyFromSeed(make([]byte, ed25519.SeedSize))
+	if err := sandboxobservability.SignEvent(&event, key); err != nil {
+		t.Fatalf("SignEvent() error = %v", err)
+	}
+
+	if err := repo.InsertEvents(context.Background(), []sandboxobservability.Event{event}); err != nil {
+		t.Fatalf("InsertEvents() error = %v", err)
+	}
+	if db.execQuery != "" {
+		t.Fatalf("fallback query = %q, want native batch", db.execQuery)
+	}
+	if batchInserter.query != "INSERT INTO `sandbox0_observability`.`sandbox_audit_events` ("+auditEventSelectColumns+")" {
+		t.Fatalf("batch query = %q", batchInserter.query)
+	}
+	if len(batchInserter.rows) != 1 || len(batchInserter.rows[0]) != 38 {
+		t.Fatalf("batch rows = %#v, want one 38-column row", batchInserter.rows)
+	}
+	row := batchInserter.rows[0]
+	if got, ok := row[1].(uint16); !ok || got != sandboxobservability.CurrentEventSchemaVersion {
+		t.Fatalf("schema_version = %#v, want UInt16", row[1])
+	}
+	if got, ok := row[6].(time.Time); !ok || got.UnixNano() != occurredAt.UnixNano() || got.Location() != time.UTC {
+		t.Fatalf("occurred_at = %#v, want UTC nanosecond timestamp", row[6])
+	}
+	if got, ok := row[7].(time.Time); !ok || got != now {
+		t.Fatalf("ingested_at = %#v, want %s", row[7], now)
+	}
+	if got, ok := row[32].(uint16); !ok || got != 201 {
+		t.Fatalf("status_code = %#v, want UInt16", row[32])
+	}
+}
+
+func TestInsertEventsDoesNotFallbackAfterNativeBatchFailure(t *testing.T) {
+	repo, db := mustRepository(t)
+	repo.eventBatchInserter = &captureEventBatchInserter{err: errors.New("commit outcome unknown")}
+	event := sandboxobservability.Event{
+		EventID:       "11111111-1111-4111-8111-111111111111",
+		SchemaVersion: sandboxobservability.CurrentEventSchemaVersion,
+		TeamID:        "team-1",
+		SandboxID:     "sb-1",
+		RegionID:      "ali-us-east-1",
+		ClusterID:     "cluster-a",
+		OccurredAt:    time.Now().UTC(),
+		Source:        sandboxobservability.SourceManager,
+		EventType:     sandboxobservability.EventTypeLifecycle,
+		Phase:         sandboxobservability.EventPhaseResult,
+		Outcome:       sandboxobservability.OutcomeSucceeded,
+		Actor:         sandboxobservability.AuditActor{Kind: sandboxobservability.ActorKindHuman},
+		Action:        "sandbox.create",
+		Resource:      sandboxobservability.AuditResource{Type: "sandbox", ID: "sb-1"},
+		OperationID:   "operation-1",
+		Producer:      sandboxobservability.AuditProducer{Service: "cluster-gateway"},
+	}
+	key := ed25519.NewKeyFromSeed(make([]byte, ed25519.SeedSize))
+	if err := sandboxobservability.SignEvent(&event, key); err != nil {
+		t.Fatalf("SignEvent() error = %v", err)
+	}
+
+	err := repo.InsertEvents(context.Background(), []sandboxobservability.Event{event})
+	if !errors.Is(err, sandboxobservability.ErrBackendUnavailable) || !strings.Contains(err.Error(), "commit outcome unknown") {
+		t.Fatalf("InsertEvents() error = %v", err)
+	}
+	if db.execQuery != "" {
+		t.Fatalf("fallback query = %q, want no retry after ambiguous batch failure", db.execQuery)
 	}
 }
 


### PR DESCRIPTION
## Summary

Write canonical sandbox audit events through a reusable ClickHouse batch rather than issuing one insert per event.

This PR is intentionally isolated as one ComputeSDK performance/correctness change.

## Dependency

None.

## Validation

- `go test ./pkg/sandboxobservability/clickhouse`
- `go test -race ./pkg/sandboxobservability/clickhouse`
- `go vet ./pkg/sandboxobservability/clickhouse`
- `git diff --check`
- Wave-one integration commit `52b0b212` was deployed to the persistent Aliyun Singapore kind environment.
- Remote smoke: Sandbox0Infra Ready 10/10; default hot claim and `node -v`; resources preserved on a no-override claim; 512 MiB resize claim; restricted-network desired/applied hash match; 8 parallel claims with 8 unique sandboxes.
- ctld A/B daemonsets were restarted sequentially on both data-plane nodes and the deployment returned to Ready 10/10 without portal/FUSE/HA errors.

The remote result validates the combined wave-one branch; this PR still relies on its own focused tests and PR CI for isolated coverage.

## Benchmark

Combined wave-one integration commit: `52b0b2127e0ba2578d5dd3269be4309e312bb5f2` (`sandbox0ai/infra:computesdk-wave1-52b0b21`). The benchmark used ComputeSDK commit `15b1a338171f5631c266bb480e8491cba3f6a4e3`, 100 iterations per mode, one fixed 32-vCPU sandbox node, default idle 120, burst nodes disabled, and an in-cluster runner in Ali us-east-1. No result was uploaded.

| Mode | Score | Success | Median | P95 | P99 | Wall | First ready |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| sequential | 97.60 | 100/100 | 209.40 ms | 275.30 ms | 300.94 ms | - | - |
| staggered | 92.23 | 100/100 | 687.97 ms | 899.50 ms | 928.05 ms | 21.34 s | 165.03 ms |
| burst 1 | 38.56 | 100/100 | 5594.08 ms | 6915.83 ms | 7054.70 ms | 10.86 s | 3974.29 ms |
| burst 2 | 31.56 | 100/100 | 6739.44 ms | 6955.92 ms | 7077.49 ms | 13.70 s | 1545.95 ms |

This is a combined-stack result, not isolated attribution for this PR. Both burst repetitions show a material regression versus the prior mixed experiment, so this PR remains draft and requires isolated A/B evidence before any performance claim or merge decision.

Operational evidence: image CI [30133571556](https://github.com/sandbox0-ai/sandbox0/actions/runs/30133571556), deployment [30134259307](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30134259307), benchmark preflight [30134915050](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30134915050), baseline restore [30135559660](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30135559660), and final baseline preflight [30135754538](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30135754538).

After the run, the temporary runner was deleted, team quotas were restored to `region_default`, burst capacity was restored to `0-299` with zero burst nodes, and production runtime was restored to `sandbox0ai/infra:main-2c2db0b`.