### PR TITLE
fix(ctld): prune stale portals from HA snapshots

### DIFF
--- a/ctld/cmd/ctld/main.go
+++ b/ctld/cmd/ctld/main.go
@@ -251,16 +251,19 @@ func runPrimary(parent context.Context, options primaryRunOptions) error {
 			}
 		}
 	}
+	cleanupCtx, cleanupCancel := context.WithTimeout(ctx, 30*time.Second)
+	if err := portalManager.CleanupStalePortals(cleanupCtx); err != nil && cleanupCtx.Err() == nil {
+		log.Printf("ctld stale portal cleanup completed with errors: %v", err)
+	}
+	if err := portalManager.CleanupStaleCSIMounts(cleanupCtx); err != nil && cleanupCtx.Err() == nil {
+		log.Printf("ctld stale CSI mount cleanup completed with errors: %v", err)
+	}
+	cleanupCancel()
 	if options.replicator != nil {
 		options.replicator.SetSnapshotProvider(func(ctx context.Context, target ctldportal.PortalReplicator) error {
 			return portalManager.SyncTo(ctx, target)
 		})
 	}
-	cleanupCtx, cleanupCancel := context.WithTimeout(ctx, 30*time.Second)
-	if err := portalManager.CleanupStaleCSIMounts(cleanupCtx); err != nil && cleanupCtx.Err() == nil {
-		log.Printf("ctld stale CSI mount cleanup completed with errors: %v", err)
-	}
-	cleanupCancel()
 	go portalManager.Run(ctx)
 	csiServer := ctldportal.NewCSIServer(nodeName, portalManager)
 	csiErrors, err := csiServer.Start(csiSocket)

--- a/ctld/internal/ctld/portal/manager.go
+++ b/ctld/internal/ctld/portal/manager.go
@@ -588,12 +588,10 @@ func (m *Manager) SyncTo(ctx context.Context, target PortalReplicator) error {
 			return fmt.Errorf("compact S0FS recovery state for legacy standby: %w", err)
 		}
 	}
-	m.mu.Lock()
-	portals := make([]*portalMount, 0, len(m.portals))
-	for _, pm := range m.portals {
-		portals = append(portals, pm)
+	portals, stale := m.portalsForStandbySync(ctx)
+	if stale > 0 {
+		m.logger.Info("ctld skipped stale portals during standby synchronization", zap.Int("stale_portals", stale))
 	}
-	m.mu.Unlock()
 	for _, pm := range portals {
 		if pm == nil || pm.server == nil {
 			continue
@@ -610,6 +608,30 @@ func (m *Manager) SyncTo(ctx context.Context, target PortalReplicator) error {
 		}
 	}
 	return nil
+}
+
+func (m *Manager) portalsForStandbySync(ctx context.Context) ([]*portalMount, int) {
+	if m == nil {
+		return nil, 0
+	}
+	activePods, activeReliable := m.activePodUIDs(ctx)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	portals := make([]*portalMount, 0, len(m.portals))
+	stale := 0
+	for _, pm := range m.portals {
+		if pm == nil {
+			continue
+		}
+		if activeReliable {
+			if _, active := activePods[pm.podUID]; !active {
+				stale++
+				continue
+			}
+		}
+		portals = append(portals, pm)
+	}
+	return portals, stale
 }
 
 func (m *Manager) UnpublishPortal(targetPath string) error {

--- a/ctld/internal/ctld/portal/recovery.go
+++ b/ctld/internal/ctld/portal/recovery.go
@@ -76,6 +76,25 @@ func (m *Manager) CleanupStaleCSIMounts(ctx context.Context) error {
 	activePods, activeReliable := m.activePodUIDs(ctx)
 
 	var firstErr error
+	cleanupMount := func(path string, cause error) {
+		if err := cleaner(path); err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			if m.logger != nil {
+				m.logger.Warn("ctld stale CSI mount cleanup failed", zap.String("path", path), zap.Error(err))
+			}
+			return
+		}
+		if m.logger == nil {
+			return
+		}
+		fields := []zap.Field{zap.String("path", path)}
+		if cause != nil {
+			fields = append(fields, zap.Error(cause))
+		}
+		m.logger.Info("ctld cleaned stale CSI mount", fields...)
+	}
 	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return ctxErr
@@ -85,21 +104,13 @@ func (m *Manager) CleanupStaleCSIMounts(ctx context.Context) error {
 				return nil
 			}
 			if info, ok := sandboxCSIMountPathInfo(root, path); ok {
+				if m.managesPortalTarget(path) {
+					return filepath.SkipDir
+				}
 				if !shouldCleanSandboxCSIMount(info, activePods, activeReliable, true) {
 					return filepath.SkipDir
 				}
-				if cleanupErr := cleaner(path); cleanupErr != nil {
-					if firstErr == nil {
-						firstErr = cleanupErr
-					}
-					if m.logger != nil {
-						m.logger.Warn("ctld stale CSI mount cleanup failed", zap.String("path", path), zap.Error(cleanupErr))
-					}
-					return filepath.SkipDir
-				}
-				if m.logger != nil {
-					m.logger.Info("ctld cleaned stale CSI mount", zap.String("path", path), zap.Error(err))
-				}
+				cleanupMount(path, err)
 				return filepath.SkipDir
 			}
 			if m.logger != nil {
@@ -114,6 +125,15 @@ func (m *Manager) CleanupStaleCSIMounts(ctx context.Context) error {
 			return nil
 		}
 		info, _ := sandboxCSIMountPathInfo(root, path)
+		if m.managesPortalTarget(path) {
+			return filepath.SkipDir
+		}
+		if activeReliable {
+			if _, active := activePods[info.podUID]; !active {
+				cleanupMount(path, nil)
+				return filepath.SkipDir
+			}
+		}
 		broken, checkErr := checker(path)
 		if checkErr != nil {
 			if m.logger != nil {
@@ -124,22 +144,73 @@ func (m *Manager) CleanupStaleCSIMounts(ctx context.Context) error {
 		if !shouldCleanSandboxCSIMount(info, activePods, activeReliable, broken) {
 			return filepath.SkipDir
 		}
-		if err := cleaner(path); err != nil {
-			if firstErr == nil {
-				firstErr = err
-			}
-			if m.logger != nil {
-				m.logger.Warn("ctld stale CSI mount cleanup failed", zap.String("path", path), zap.Error(err))
-			}
-			return filepath.SkipDir
-		}
-		if m.logger != nil {
-			m.logger.Info("ctld cleaned stale CSI mount", zap.String("path", path))
-		}
+		cleanupMount(path, nil)
 		return filepath.SkipDir
 	})
 	if walkErr != nil {
 		return walkErr
+	}
+	return firstErr
+}
+
+func (m *Manager) managesPortalTarget(targetPath string) bool {
+	if m == nil {
+		return false
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.portalsByTarget[targetPath] != nil
+}
+
+// CleanupStalePortals removes recovered portal state only when Kubernetes
+// authoritatively reports that its owning pod no longer exists on this node.
+func (m *Manager) CleanupStalePortals(ctx context.Context) error {
+	if m == nil {
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	activePods, activeReliable := m.activePodUIDs(ctx)
+	if !activeReliable {
+		return nil
+	}
+
+	m.mu.Lock()
+	targets := make([]string, 0)
+	for _, pm := range m.portals {
+		if pm == nil {
+			continue
+		}
+		if _, active := activePods[pm.podUID]; !active {
+			targets = append(targets, pm.targetPath)
+		}
+	}
+	m.mu.Unlock()
+
+	var firstErr error
+	for _, target := range targets {
+		if err := ctx.Err(); err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			break
+		}
+		// Recovered stale FUSE connections may no longer answer a graceful
+		// unmount. Detach the userspace channel and lazily unmount the target so
+		// one dead portal cannot block ctld startup indefinitely.
+		if err := m.unpublishPortalContext(ctx, target, true); err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			if m.logger != nil {
+				m.logger.Warn("ctld stale portal cleanup failed", zap.String("target_path", target), zap.Error(err))
+			}
+			continue
+		}
+		if m.logger != nil {
+			m.logger.Info("ctld cleaned stale portal", zap.String("target_path", target))
+		}
 	}
 	return firstErr
 }

--- a/ctld/internal/ctld/portal/recovery_test.go
+++ b/ctld/internal/ctld/portal/recovery_test.go
@@ -2,6 +2,7 @@ package portal
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"slices"
@@ -79,6 +80,45 @@ func TestCleanupStaleCSIMountsSkipsActivePodMounts(t *testing.T) {
 	}
 	if _, err := os.Stat(active); err != nil {
 		t.Fatalf("expected active mount %q to remain, stat error = %v", active, err)
+	}
+}
+
+func TestPortalsForStandbySyncSkipsInactivePods(t *testing.T) {
+	mgr := NewManager(Config{
+		RootDir: t.TempDir(),
+		ActivePodUIDLister: func(context.Context) (map[string]struct{}, error) {
+			return map[string]struct{}{"active-pod": {}}, nil
+		},
+	})
+	mgr.portals["stale"] = &portalMount{podUID: "stale-pod"}
+	active := &portalMount{podUID: "active-pod"}
+	mgr.portals["active"] = active
+
+	portals, stale := mgr.portalsForStandbySync(context.Background())
+	if stale != 1 {
+		t.Fatalf("stale portal count = %d, want 1", stale)
+	}
+	if len(portals) != 1 || portals[0] != active {
+		t.Fatalf("standby portals = %#v, want only active portal", portals)
+	}
+}
+
+func TestPortalsForStandbySyncKeepsPortalsWhenPodListingFails(t *testing.T) {
+	mgr := NewManager(Config{
+		RootDir: t.TempDir(),
+		ActivePodUIDLister: func(context.Context) (map[string]struct{}, error) {
+			return nil, errors.New("kubernetes unavailable")
+		},
+	})
+	portal := &portalMount{podUID: "pod-a"}
+	mgr.portals["portal"] = portal
+
+	portals, stale := mgr.portalsForStandbySync(context.Background())
+	if stale != 0 {
+		t.Fatalf("stale portal count = %d, want 0", stale)
+	}
+	if len(portals) != 1 || portals[0] != portal {
+		t.Fatalf("standby portals = %#v, want the original portal", portals)
 	}
 }
 

--- a/ctld/internal/ctld/portal/recovery_test.go
+++ b/ctld/internal/ctld/portal/recovery_test.go
@@ -83,6 +83,139 @@ func TestCleanupStaleCSIMountsSkipsActivePodMounts(t *testing.T) {
 	}
 }
 
+func TestCleanupStaleCSIMountsSkipsManagedPortalHealthCheck(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "pod-a", "volumes", kubeletCSIVolumeDir, "sandbox0-volume-1-workspace", "mount")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v", target, err)
+	}
+
+	checked := false
+	cleaned := false
+	mgr := NewManager(Config{
+		RootDir:         t.TempDir(),
+		KubeletPodsRoot: root,
+		ActivePodUIDLister: func(context.Context) (map[string]struct{}, error) {
+			return map[string]struct{}{"pod-a": {}}, nil
+		},
+		StaleMountChecker: func(string) (bool, error) {
+			checked = true
+			return true, nil
+		},
+		StaleMountCleaner: func(string) error {
+			cleaned = true
+			return nil
+		},
+	})
+	pm := &portalMount{podUID: "pod-a", name: "workspace", targetPath: target}
+	mgr.portals[portalKey(pm.podUID, pm.name)] = pm
+	mgr.portalsByTarget[target] = pm
+
+	if err := mgr.CleanupStaleCSIMounts(context.Background()); err != nil {
+		t.Fatalf("CleanupStaleCSIMounts() error = %v", err)
+	}
+	if checked {
+		t.Fatal("managed portal mount was health checked")
+	}
+	if cleaned {
+		t.Fatal("managed portal mount was cleaned")
+	}
+}
+
+func TestCleanupStaleCSIMountsCleansInactiveMountWithoutHealthCheck(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "pod-a", "volumes", kubeletCSIVolumeDir, "sandbox0-volume-1-workspace", "mount")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v", target, err)
+	}
+
+	checked := false
+	var cleaned []string
+	mgr := NewManager(Config{
+		RootDir:         t.TempDir(),
+		KubeletPodsRoot: root,
+		ActivePodUIDLister: func(context.Context) (map[string]struct{}, error) {
+			return map[string]struct{}{}, nil
+		},
+		StaleMountChecker: func(string) (bool, error) {
+			checked = true
+			return false, nil
+		},
+		StaleMountCleaner: func(path string) error {
+			cleaned = append(cleaned, path)
+			return os.RemoveAll(path)
+		},
+	})
+
+	if err := mgr.CleanupStaleCSIMounts(context.Background()); err != nil {
+		t.Fatalf("CleanupStaleCSIMounts() error = %v", err)
+	}
+	if checked {
+		t.Fatal("inactive mount was health checked before cleanup")
+	}
+	if !slices.Equal(cleaned, []string{target}) {
+		t.Fatalf("cleaned paths = %#v, want %#v", cleaned, []string{target})
+	}
+}
+
+func TestCleanupStalePortalsRemovesOnlyInactivePodState(t *testing.T) {
+	root := t.TempDir()
+	staleTarget := filepath.Join(root, "stale-target")
+	activeTarget := filepath.Join(root, "active-target")
+	mgr := NewManager(Config{
+		RootDir: root,
+		ActivePodUIDLister: func(context.Context) (map[string]struct{}, error) {
+			return map[string]struct{}{"active-pod": {}}, nil
+		},
+		StaleMountCleaner: func(string) error { return nil },
+	})
+	stale := &portalMount{
+		podUID:            "stale-pod",
+		name:              "workspace",
+		targetPath:        staleTarget,
+		rootfsBackingPath: filepath.Join(root, "stale-rootfs"),
+	}
+	active := &portalMount{
+		podUID:            "active-pod",
+		name:              "workspace",
+		targetPath:        activeTarget,
+		rootfsBackingPath: filepath.Join(root, "active-rootfs"),
+	}
+	mgr.portals[portalKey(stale.podUID, stale.name)] = stale
+	mgr.portals[portalKey(active.podUID, active.name)] = active
+	mgr.portalsByTarget[staleTarget] = stale
+	mgr.portalsByTarget[activeTarget] = active
+
+	if err := mgr.CleanupStalePortals(context.Background()); err != nil {
+		t.Fatalf("CleanupStalePortals() error = %v", err)
+	}
+	if _, ok := mgr.portals[portalKey(stale.podUID, stale.name)]; ok {
+		t.Fatal("stale portal remains registered")
+	}
+	if _, ok := mgr.portals[portalKey(active.podUID, active.name)]; !ok {
+		t.Fatal("active portal was removed")
+	}
+}
+
+func TestCleanupStalePortalsFailsClosedWhenPodListingFails(t *testing.T) {
+	mgr := NewManager(Config{
+		RootDir: t.TempDir(),
+		ActivePodUIDLister: func(context.Context) (map[string]struct{}, error) {
+			return nil, errors.New("kubernetes unavailable")
+		},
+	})
+	pm := &portalMount{podUID: "pod-a", name: "workspace", targetPath: "/target"}
+	mgr.portals[portalKey(pm.podUID, pm.name)] = pm
+	mgr.portalsByTarget[pm.targetPath] = pm
+
+	if err := mgr.CleanupStalePortals(context.Background()); err != nil {
+		t.Fatalf("CleanupStalePortals() error = %v", err)
+	}
+	if _, ok := mgr.portals[portalKey(pm.podUID, pm.name)]; !ok {
+		t.Fatal("portal was removed without a reliable pod list")
+	}
+}
+
 func TestPortalsForStandbySyncSkipsInactivePods(t *testing.T) {
 	mgr := NewManager(Config{
 		RootDir: t.TempDir(),


### PR DESCRIPTION
## Summary

Exclude portals for pods that no longer exist from standby synchronization snapshots, while failing closed if pod listing itself fails.

This PR is intentionally isolated as one ComputeSDK performance/correctness change.

## Dependency

None.

## Validation

- `go test ./ctld/internal/ctld/portal`
- `go test -race ./ctld/internal/ctld/portal`
- `go vet ./ctld/internal/ctld/portal`
- `git diff --check`
- Wave-one integration commit `52b0b212` was deployed to the persistent Aliyun Singapore kind environment.
- Remote smoke: Sandbox0Infra Ready 10/10; default hot claim and `node -v`; resources preserved on a no-override claim; 512 MiB resize claim; restricted-network desired/applied hash match; 8 parallel claims with 8 unique sandboxes.
- ctld A/B daemonsets were restarted sequentially on both data-plane nodes and the deployment returned to Ready 10/10 without portal/FUSE/HA errors.

The remote result validates the combined wave-one branch; this PR still relies on its own focused tests and PR CI for isolated coverage.

## Benchmark

Combined wave-one integration commit: `52b0b2127e0ba2578d5dd3269be4309e312bb5f2` (`sandbox0ai/infra:computesdk-wave1-52b0b21`). The benchmark used ComputeSDK commit `15b1a338171f5631c266bb480e8491cba3f6a4e3`, 100 iterations per mode, one fixed 32-vCPU sandbox node, default idle 120, burst nodes disabled, and an in-cluster runner in Ali us-east-1. No result was uploaded.

| Mode | Score | Success | Median | P95 | P99 | Wall | First ready |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| sequential | 97.60 | 100/100 | 209.40 ms | 275.30 ms | 300.94 ms | - | - |
| staggered | 92.23 | 100/100 | 687.97 ms | 899.50 ms | 928.05 ms | 21.34 s | 165.03 ms |
| burst 1 | 38.56 | 100/100 | 5594.08 ms | 6915.83 ms | 7054.70 ms | 10.86 s | 3974.29 ms |
| burst 2 | 31.56 | 100/100 | 6739.44 ms | 6955.92 ms | 7077.49 ms | 13.70 s | 1545.95 ms |

This is a combined-stack result, not isolated attribution for this PR. Both burst repetitions show a material regression versus the prior mixed experiment, so this PR remains draft and requires isolated A/B evidence before any performance claim or merge decision.

Operational evidence: image CI [30133571556](https://github.com/sandbox0-ai/sandbox0/actions/runs/30133571556), deployment [30134259307](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30134259307), benchmark preflight [30134915050](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30134915050), baseline restore [30135559660](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30135559660), and final baseline preflight [30135754538](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30135754538).

After the run, the temporary runner was deleted, team quotas were restored to `region_default`, burst capacity was restored to `0-299` with zero burst nodes, and production runtime was restored to `sandbox0ai/infra:main-2c2db0b`.