### PR TITLE
fix(manager): enforce 150m CPU limit floor for sandbox pods

### DIFF
--- a/manager/pkg/apis/sandbox0/v1alpha1/helpers.go
+++ b/manager/pkg/apis/sandbox0/v1alpha1/helpers.go
@@ -35,8 +35,8 @@ const (
 	minSandboxEphemeralStorageRequestBytes           = int64(64 * 1024 * 1024)
 	defaultIdleSandboxMemoryLimitBytes               = int64(128 * 1024 * 1024)
 
-	// MinimumClaimedSandboxCPULimitMilli is the CPU limit floor for claimed sandboxes.
-	MinimumClaimedSandboxCPULimitMilli = int64(150)
+	// MinimumSandboxCPULimitMilli is the CPU limit floor for every sandbox pod.
+	MinimumSandboxCPULimitMilli = int64(150)
 )
 
 // BuildPodSpec builds a pod spec with every template-declared user volume portal.
@@ -423,6 +423,7 @@ func idleResourceQuota(templateQuota ResourceQuota) ResourceQuota {
 // BuildResourceRequirements converts a sandbox resource quota into Kubernetes
 // container requests and limits.
 func BuildResourceRequirements(quota ResourceQuota) corev1.ResourceRequirements {
+	quota = NormalizeSandboxResourceQuota(quota)
 	requests := corev1.ResourceList{}
 	limits := corev1.ResourceList{}
 	if quota.CPU.Sign() > 0 {
@@ -450,11 +451,21 @@ func BuildResourceRequirements(quota ResourceQuota) corev1.ResourceRequirements 
 	return corev1.ResourceRequirements{Requests: requests, Limits: limits}
 }
 
+// NormalizeSandboxResourceQuota applies platform resource floors without
+// mutating the caller's quota.
+func NormalizeSandboxResourceQuota(quota ResourceQuota) ResourceQuota {
+	normalized := *quota.DeepCopy()
+	minCPU := *resource.NewMilliQuantity(MinimumSandboxCPULimitMilli, resource.DecimalSI)
+	if normalized.CPU.Cmp(minCPU) < 0 {
+		normalized.CPU = minCPU
+	}
+	return normalized
+}
+
 func scaledCPURequest(limit resource.Quantity) resource.Quantity {
 	limitMilli := limit.MilliValue()
-	// Keep the scheduler reservation at its existing floor when manager raises
-	// a small claimed sandbox to the CPU limit floor.
-	if limitMilli == MinimumClaimedSandboxCPULimitMilli {
+	// Keep the scheduler reservation dense at the platform CPU limit floor.
+	if limitMilli == MinimumSandboxCPULimitMilli {
 		return *resource.NewMilliQuantity(minSandboxCPURequestMilli, resource.DecimalSI)
 	}
 	requestMilli := scaleResource(limitMilli, defaultSandboxCPURequestRatioMillis, minSandboxCPURequestMilli)

--- a/manager/pkg/apis/sandbox0/v1alpha1/helpers_test.go
+++ b/manager/pkg/apis/sandbox0/v1alpha1/helpers_test.go
@@ -432,19 +432,30 @@ manager_image: sandbox0/manager:test
 	assertResourceQuantity(t, resources.Limits[corev1.ResourceEphemeralStorage], "8Gi")
 }
 
-func TestBuildResourceRequirementsKeepsMinimumCPURequestDense(t *testing.T) {
-	resources := BuildResourceRequirements(ResourceQuota{
-		CPU:    resource.MustParse("150m"),
-		Memory: resource.MustParse("128Mi"),
-	})
+func TestBuildResourceRequirementsAppliesMinimumCPULimit(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		cpu  resource.Quantity
+	}{
+		{name: "missing"},
+		{name: "below floor", cpu: resource.MustParse("32m")},
+		{name: "at floor", cpu: resource.MustParse("150m")},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			resources := BuildResourceRequirements(ResourceQuota{
+				CPU:    tt.cpu,
+				Memory: resource.MustParse("128Mi"),
+			})
 
-	assertResourceQuantity(t, resources.Requests[corev1.ResourceCPU], "10m")
-	assertResourceQuantity(t, resources.Limits[corev1.ResourceCPU], "150m")
-	assertResourceQuantity(t, resources.Requests[corev1.ResourceMemory], "64Mi")
-	assertResourceQuantity(t, resources.Limits[corev1.ResourceMemory], "128Mi")
+			assertResourceQuantity(t, resources.Requests[corev1.ResourceCPU], "10m")
+			assertResourceQuantity(t, resources.Limits[corev1.ResourceCPU], "150m")
+			assertResourceQuantity(t, resources.Requests[corev1.ResourceMemory], "64Mi")
+			assertResourceQuantity(t, resources.Limits[corev1.ResourceMemory], "128Mi")
+		})
+	}
 }
 
-func TestBuildIdlePodSpecUsesLowCPUAndMemoryLimits(t *testing.T) {
+func TestBuildIdlePodSpecUsesMinimumCPUAndLowMemoryLimits(t *testing.T) {
 	configPath := writeManagerConfig(t, `
 manager_image: sandbox0/manager:test
 `)
@@ -460,7 +471,7 @@ manager_image: sandbox0/manager:test
 	resources := spec.Containers[0].Resources
 
 	assertResourceQuantity(t, resources.Requests[corev1.ResourceCPU], "10m")
-	assertResourceQuantity(t, resources.Limits[corev1.ResourceCPU], "32m")
+	assertResourceQuantity(t, resources.Limits[corev1.ResourceCPU], "150m")
 	assertResourceQuantity(t, resources.Requests[corev1.ResourceMemory], "64Mi")
 	assertResourceQuantity(t, resources.Limits[corev1.ResourceMemory], "128Mi")
 	assertResourceQuantity(t, resources.Requests[corev1.ResourceEphemeralStorage], "1Gi")
@@ -480,7 +491,7 @@ manager_image: sandbox0/manager:test
 	assertResizePolicy(t, policies, corev1.ResourceMemory, corev1.NotRequired)
 }
 
-func TestBuildPodSpecClampsReducedRequestsToSmallQuota(t *testing.T) {
+func TestBuildPodSpecAppliesCPUFloorAndClampsOtherRequestsToSmallQuota(t *testing.T) {
 	configPath := writeManagerConfig(t, `
 manager_image: sandbox0/manager:test
 `)
@@ -496,8 +507,8 @@ manager_image: sandbox0/manager:test
 	spec := BuildPodSpec(template)
 	resources := spec.Containers[0].Resources
 
-	assertResourceQuantity(t, resources.Requests[corev1.ResourceCPU], "5m")
-	assertResourceQuantity(t, resources.Limits[corev1.ResourceCPU], "5m")
+	assertResourceQuantity(t, resources.Requests[corev1.ResourceCPU], "10m")
+	assertResourceQuantity(t, resources.Limits[corev1.ResourceCPU], "150m")
 	assertResourceQuantity(t, resources.Requests[corev1.ResourceMemory], "32Mi")
 	assertResourceQuantity(t, resources.Limits[corev1.ResourceMemory], "32Mi")
 	assertResourceQuantity(t, resources.Requests[corev1.ResourceEphemeralStorage], "32Mi")

--- a/manager/pkg/service/sandbox_service_resources.go
+++ b/manager/pkg/service/sandbox_service_resources.go
@@ -33,11 +33,7 @@ func (s *SandboxService) effectiveSandboxResourceQuota(template *v1alpha1.Sandbo
 		quota.Memory = memory
 		quota.CPU = s0template.CPUForMemory(memory, s.sandboxMemoryPerCPU())
 	}
-	minCPU := *resource.NewMilliQuantity(v1alpha1.MinimumClaimedSandboxCPULimitMilli, resource.DecimalSI)
-	if quota.CPU.Cmp(minCPU) < 0 {
-		quota.CPU = minCPU
-	}
-	return quota, nil
+	return v1alpha1.NormalizeSandboxResourceQuota(quota), nil
 }
 
 func (s *SandboxService) applySandboxResourceQuota(pod *corev1.Pod, quota v1alpha1.ResourceQuota) error {


### PR DESCRIPTION
## Summary

- enforce a 150m CPU limit floor in the shared sandbox resource normalization path
- apply the same floor to warm idle, cold-created, and resized sandbox pods through `BuildResourceRequirements`
- reuse the normalization helper from `effectiveSandboxResourceQuota` and remove the duplicated claim-only floor
- preserve normal request updates on claim so active sandbox memory and CPU requests still reflect their target resources

This is scoped to the sandbox runtime (`procd`) container. It does not change resource limits for manager, ctld, or other system workloads.

## Behavior

Warm pods that previously used a CPU limit below 150m now use:

- CPU request: 10m
- CPU limit: 150m

Claims still resize both requests and limits when the requested/template resources differ from the warm-pool resources. This avoids retaining an artificially low active-pod request and the resulting node OOM risk.

## Validation

- `make proto`
- `go test ./manager/...`
- `go test -race ./manager/pkg/apis/sandbox0/v1alpha1 ./manager/pkg/service`
- `go vet ./manager/pkg/apis/sandbox0/v1alpha1 ./manager/pkg/service`
- `git diff --check`
