### PR TITLE
perf(manager): decouple sandbox probes from template reconcile

### DIFF
--- a/manager/pkg/controller/operator.go
+++ b/manager/pkg/controller/operator.go
@@ -9,7 +9,6 @@ import (
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/namespacepolicy"
 	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
-	"github.com/sandbox0-ai/sandbox0/pkg/sandboxprobe"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -26,8 +25,7 @@ import (
 )
 
 const (
-	maxRetries               = 5
-	sandboxProbeRequeueAfter = 5 * time.Second
+	maxRetries = 5
 )
 
 // Operator is the main controller for SandboxTemplate CRD
@@ -42,7 +40,8 @@ type Operator struct {
 	statsPublisher TemplateStatsPublisher
 	probeRunner    SandboxProbeRunner
 
-	workqueue workqueue.TypedRateLimitingInterface[string]
+	workqueue     workqueue.TypedRateLimitingInterface[string]
+	podProbeQueue workqueue.TypedRateLimitingInterface[string]
 
 	metrics *obsmetrics.ManagerMetrics
 
@@ -54,10 +53,6 @@ type Operator struct {
 
 	statsMu   sync.Mutex
 	lastStats map[string]TemplateCounts
-}
-
-type SandboxProbeRunner interface {
-	ProbeSandboxPod(ctx context.Context, pod *corev1.Pod, kind sandboxprobe.Kind) (*sandboxprobe.Response, error)
 }
 
 // SetNamespacePolicyReconciler installs the manager-owned template namespace baseline reconciler.
@@ -128,6 +123,7 @@ func NewOperator(
 		clock:            clock,
 		logger:           logger,
 		workqueue:        workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
+		podProbeQueue:    workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
 		metrics:          metrics,
 		templateInformer: templateInformer,
 		templateLister: TemplateListerImpl{
@@ -157,6 +153,7 @@ func NewOperator(
 func (op *Operator) Run(ctx context.Context, workers int) error {
 	defer runtime.HandleCrash()
 	defer op.workqueue.ShutDown()
+	defer op.podProbeQueue.ShutDown()
 
 	op.logger.Info("Starting operator")
 
@@ -169,6 +166,9 @@ func (op *Operator) Run(ctx context.Context, workers int) error {
 	op.logger.Info("Starting workers", zap.Int("count", workers))
 	for i := 0; i < workers; i++ {
 		go wait.UntilWithContext(ctx, op.runWorker, time.Second)
+	}
+	for i := 0; i < sandboxProbeWorkers; i++ {
+		go wait.UntilWithContext(ctx, op.runPodProbeWorker, time.Second)
 	}
 
 	op.logger.Info("Operator started")
@@ -257,14 +257,10 @@ func (op *Operator) syncHandler(ctx context.Context, key string) error {
 	}
 
 	// Update status
-	needsProbeRequeue, err := op.updateTemplateStatus(ctx, template)
-	if err != nil {
+	if err := op.updateTemplateStatus(ctx, template); err != nil {
 		return fmt.Errorf("update status: %w", err)
 	}
 	requeueAfter := poolRequeueAfter
-	if needsProbeRequeue && (requeueAfter <= 0 || sandboxProbeRequeueAfter < requeueAfter) {
-		requeueAfter = sandboxProbeRequeueAfter
-	}
 	if requeueAfter > 0 {
 		op.workqueue.AddAfter(key, requeueAfter)
 	}
@@ -273,14 +269,14 @@ func (op *Operator) syncHandler(ctx context.Context, key string) error {
 }
 
 // updateTemplateStatus updates the status of a SandboxTemplate
-func (op *Operator) updateTemplateStatus(ctx context.Context, template *v1alpha1.SandboxTemplate) (bool, error) {
+func (op *Operator) updateTemplateStatus(ctx context.Context, template *v1alpha1.SandboxTemplate) error {
 	// Get idle pods
 	idlePods, err := op.podLister.Pods(template.Namespace).List(labels.SelectorFromSet(map[string]string{
 		LabelTemplateID: template.Name,
 		LabelPoolType:   PoolTypeIdle,
 	}))
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	// Get active pods
@@ -289,28 +285,12 @@ func (op *Operator) updateTemplateStatus(ctx context.Context, template *v1alpha1
 		LabelPoolType:   PoolTypeActive,
 	}))
 	if err != nil {
-		return false, err
-	}
-
-	reconciledPods := make(map[string]*corev1.Pod, len(idlePods)+len(activePods))
-	needsProbeRequeue := false
-	for _, pod := range append(append([]*corev1.Pod(nil), idlePods...), activePods...) {
-		updatedPod, err := op.ensureSandboxProbeConditions(ctx, pod)
-		if err != nil {
-			return false, fmt.Errorf("ensure sandbox pod probe conditions for %s/%s: %w", pod.Namespace, pod.Name, err)
-		}
-		reconciledPods[pod.Namespace+"/"+pod.Name] = updatedPod
-		if op.probeRunner != nil && shouldRequeueSandboxProbe(updatedPod) {
-			needsProbeRequeue = true
-		}
+		return err
 	}
 
 	// Count only ready idle pods as available pooled capacity.
 	idleCount := int32(0)
 	for _, pod := range idlePods {
-		if updatedPod := reconciledPods[pod.Namespace+"/"+pod.Name]; updatedPod != nil {
-			pod = updatedPod
-		}
 		if IsPodReady(pod) {
 			idleCount++
 		}
@@ -369,60 +349,7 @@ func (op *Operator) updateTemplateStatus(ctx context.Context, template *v1alpha1
 		)
 	}
 
-	return needsProbeRequeue, nil
-}
-
-func shouldRequeueSandboxProbe(pod *corev1.Pod) bool {
-	if pod == nil || pod.DeletionTimestamp != nil || pod.Status.Phase != corev1.PodRunning || !HasSandboxPodReadinessGate(pod) {
-		return false
-	}
-	if !podConditionTrue(pod.Status.Conditions, v1alpha1.SandboxPodReadinessConditionType) {
-		return true
-	}
-	live := findPodCondition(pod.Status.Conditions, v1alpha1.SandboxPodLivenessConditionType)
-	return live != nil && live.Status == corev1.ConditionFalse
-}
-
-func (op *Operator) ensureSandboxProbeConditions(ctx context.Context, pod *corev1.Pod) (*corev1.Pod, error) {
-	if pod == nil {
-		return nil, nil
-	}
-	if op.probeRunner == nil {
-		return EnsureSandboxPodProbeConditions(ctx, op.k8sClient, pod,
-			probeFailure(sandboxprobe.KindStartup, "SandboxProbeUnavailable", "sandbox probe runner is unavailable"),
-			probeFailure(sandboxprobe.KindReadiness, "SandboxProbeUnavailable", "sandbox probe runner is unavailable"),
-			probeFailure(sandboxprobe.KindLiveness, "SandboxProbeUnavailable", "sandbox probe runner is unavailable"),
-		)
-	}
-	if pod.Status.Phase != corev1.PodRunning {
-		message := fmt.Sprintf("pod phase is %s", pod.Status.Phase)
-		return EnsureSandboxPodProbeConditions(ctx, op.k8sClient, pod,
-			probeFailure(sandboxprobe.KindStartup, "PodNotRunning", message),
-			probeFailure(sandboxprobe.KindReadiness, "PodNotRunning", message),
-			probeFailure(sandboxprobe.KindLiveness, "PodNotRunning", message),
-		)
-	}
-
-	startup := op.runSandboxProbe(ctx, pod, sandboxprobe.KindStartup)
-	readiness := op.runSandboxProbe(ctx, pod, sandboxprobe.KindReadiness)
-	liveness := op.runSandboxProbe(ctx, pod, sandboxprobe.KindLiveness)
-	return EnsureSandboxPodProbeConditions(ctx, op.k8sClient, pod, startup, readiness, liveness)
-}
-
-func (op *Operator) runSandboxProbe(ctx context.Context, pod *corev1.Pod, kind sandboxprobe.Kind) *sandboxprobe.Response {
-	result, err := op.probeRunner.ProbeSandboxPod(ctx, pod, kind)
-	if err != nil {
-		return probeFailure(kind, "SandboxProbeFailed", err.Error())
-	}
-	if result == nil {
-		return probeFailure(kind, "SandboxProbeMissing", "sandbox probe returned no result")
-	}
-	return result
-}
-
-func probeFailure(kind sandboxprobe.Kind, reason, message string) *sandboxprobe.Response {
-	result := sandboxprobe.Failed(kind, reason, message, nil)
-	return &result
+	return nil
 }
 
 // computeConditions computes the conditions for a template
@@ -524,6 +451,7 @@ func (op *Operator) enqueueTemplateKey(namespace, name string) {
 func (op *Operator) handlePodAdd(obj any) {
 	pod := obj.(*corev1.Pod)
 	op.enqueueTemplateForPod(pod)
+	op.enqueuePodProbe(pod)
 }
 
 func (op *Operator) handlePodUpdate(oldObj, newObj any) {
@@ -533,6 +461,9 @@ func (op *Operator) handlePodUpdate(oldObj, newObj any) {
 		return
 	}
 	op.enqueueTemplateForPod(newPod)
+	if podProbeInputsChanged(oldPod, newPod) {
+		op.enqueuePodProbe(newPod)
+	}
 }
 
 func (op *Operator) handlePodDelete(obj any) {

--- a/manager/pkg/controller/operator_test.go
+++ b/manager/pkg/controller/operator_test.go
@@ -4,13 +4,16 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
+	"github.com/sandbox0-ai/sandbox0/pkg/sandboxprobe"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -43,16 +46,17 @@ func TestOperatorUpdateTemplateStatusUsesReadyIdlePods(t *testing.T) {
 	}
 
 	publisher := &recordingTemplateStatsPublisher{}
+	probeRunner := &recordingSandboxProbeRunner{}
 	op := &Operator{
 		podLister:      corelisters.NewPodLister(podIndexer),
 		logger:         zap.NewNop(),
 		statsPublisher: publisher,
+		probeRunner:    probeRunner,
 		lastStats:      make(map[string]TemplateCounts),
 	}
 
-	needsProbeRequeue, err := op.updateTemplateStatus(context.Background(), template)
+	err := op.updateTemplateStatus(context.Background(), template)
 	require.NoError(t, err)
-	assert.False(t, needsProbeRequeue)
 
 	assert.Equal(t, int32(1), template.Status.IdleCount)
 	assert.Equal(t, int32(1), template.Status.ActiveCount)
@@ -67,9 +71,10 @@ func TestOperatorUpdateTemplateStatusUsesReadyIdlePods(t *testing.T) {
 	assert.Equal(t, int32(1), publisher.activeCount)
 	assert.Equal(t, "default/template-a", publisher.statsKey)
 	assert.Equal(t, TemplateCounts{IdleCount: 1, ActiveCount: 1}, op.lastStats["default/template-a"])
+	assert.Empty(t, probeRunner.calls)
 }
 
-func TestShouldRequeueSandboxProbe(t *testing.T) {
+func TestShouldRetrySandboxProbe(t *testing.T) {
 	pod := newOperatorTestPod("default", "idle-not-ready", "template-a", PoolTypeIdle, corev1.PodRunning, corev1.ConditionTrue)
 	pod.Spec.ReadinessGates = []corev1.PodReadinessGate{{
 		ConditionType: v1alpha1.SandboxPodReadinessConditionType,
@@ -80,7 +85,7 @@ func TestShouldRequeueSandboxProbe(t *testing.T) {
 		Reason: "InitialDelay",
 	})
 
-	assert.True(t, shouldRequeueSandboxProbe(pod))
+	assert.True(t, shouldRetrySandboxProbe(pod))
 
 	pod.Status.Conditions = []corev1.PodCondition{
 		{
@@ -88,11 +93,92 @@ func TestShouldRequeueSandboxProbe(t *testing.T) {
 			Status: corev1.ConditionTrue,
 		},
 		{
+			Type:   v1alpha1.SandboxPodStartupConditionType,
+			Status: corev1.ConditionTrue,
+		},
+		{
 			Type:   v1alpha1.SandboxPodReadinessConditionType,
 			Status: corev1.ConditionTrue,
 		},
 	}
-	assert.False(t, shouldRequeueSandboxProbe(pod))
+	assert.False(t, shouldRetrySandboxProbe(pod))
+}
+
+func TestPodProbeInputsChangedIgnoresProbeConditionUpdates(t *testing.T) {
+	oldPod := newOperatorTestPod("default", "idle", "template-a", PoolTypeIdle, corev1.PodRunning, corev1.ConditionTrue)
+	oldPod.UID = "pod-uid"
+	oldPod.Spec.NodeName = "node-a"
+	oldPod.Spec.ReadinessGates = []corev1.PodReadinessGate{{
+		ConditionType: v1alpha1.SandboxPodReadinessConditionType,
+	}}
+	oldPod.Status.PodIP = "10.0.0.2"
+	oldPod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+		Name:  "procd",
+		Ready: true,
+	}}
+
+	conditionUpdate := oldPod.DeepCopy()
+	conditionUpdate.Status.Conditions = append(conditionUpdate.Status.Conditions, corev1.PodCondition{
+		Type:   v1alpha1.SandboxPodReadinessConditionType,
+		Status: corev1.ConditionTrue,
+	})
+	assert.False(t, podProbeInputsChanged(oldPod, conditionUpdate))
+
+	containerUpdate := oldPod.DeepCopy()
+	containerUpdate.Status.ContainerStatuses[0].RestartCount++
+	assert.True(t, podProbeInputsChanged(oldPod, containerUpdate))
+
+	phaseUpdate := oldPod.DeepCopy()
+	phaseUpdate.Status.Phase = corev1.PodFailed
+	assert.True(t, podProbeInputsChanged(oldPod, phaseUpdate))
+}
+
+func TestOperatorSyncPodProbeUpdatesConditionsAndSchedulesHealthyProbe(t *testing.T) {
+	pod := newOperatorTestPod("default", "idle", "template-a", PoolTypeIdle, corev1.PodRunning, corev1.ConditionFalse)
+	pod.Spec.ReadinessGates = []corev1.PodReadinessGate{{
+		ConditionType: v1alpha1.SandboxPodReadinessConditionType,
+	}}
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+	})
+	require.NoError(t, indexer.Add(pod.DeepCopy()))
+	runner := &recordingSandboxProbeRunner{passed: true}
+	op := &Operator{
+		k8sClient:   fake.NewSimpleClientset(pod.DeepCopy()),
+		podLister:   corelisters.NewPodLister(indexer),
+		probeRunner: runner,
+		logger:      zap.NewNop(),
+	}
+
+	requeueAfter, err := op.syncPodProbe(context.Background(), "default/idle")
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, requeueAfter, 24*time.Second)
+	assert.LessOrEqual(t, requeueAfter, 36*time.Second)
+	assert.ElementsMatch(t,
+		[]sandboxprobe.Kind{sandboxprobe.KindStartup, sandboxprobe.KindReadiness, sandboxprobe.KindLiveness},
+		runner.calls,
+	)
+
+	updated, err := op.k8sClient.CoreV1().Pods("default").Get(context.Background(), "idle", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.True(t, podConditionTrue(updated.Status.Conditions, v1alpha1.SandboxPodStartupConditionType))
+	assert.True(t, podConditionTrue(updated.Status.Conditions, v1alpha1.SandboxPodReadinessConditionType))
+	assert.True(t, podConditionTrue(updated.Status.Conditions, v1alpha1.SandboxPodLivenessConditionType))
+}
+
+type recordingSandboxProbeRunner struct {
+	calls  []sandboxprobe.Kind
+	passed bool
+}
+
+func (r *recordingSandboxProbeRunner) ProbeSandboxPod(_ context.Context, _ *corev1.Pod, kind sandboxprobe.Kind) (*sandboxprobe.Response, error) {
+	r.calls = append(r.calls, kind)
+	if r.passed {
+		result := sandboxprobe.Passed(kind, "SandboxProbePassed", "sandbox probe passed", nil)
+		return &result, nil
+	}
+	result := sandboxprobe.Failed(kind, "SandboxProbeFailed", "sandbox probe failed", nil)
+	return &result, nil
 }
 
 type recordingNamespacePolicyReconciler struct {

--- a/manager/pkg/controller/pod_probe_controller.go
+++ b/manager/pkg/controller/pod_probe_controller.go
@@ -1,0 +1,211 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
+	"github.com/sandbox0-ai/sandbox0/pkg/sandboxprobe"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+)
+
+const (
+	sandboxProbeWorkers           = 8
+	sandboxProbeRetryAfter        = 5 * time.Second
+	sandboxProbeHealthyAfter      = 30 * time.Second
+	sandboxProbeHealthyJitter     = 0.2
+	sandboxProbeControllerTimeout = 10 * time.Second
+)
+
+type SandboxProbeRunner interface {
+	ProbeSandboxPod(ctx context.Context, pod *corev1.Pod, kind sandboxprobe.Kind) (*sandboxprobe.Response, error)
+}
+
+func (op *Operator) runPodProbeWorker(ctx context.Context) {
+	for op.processNextPodProbe(ctx) {
+	}
+}
+
+func (op *Operator) processNextPodProbe(ctx context.Context) bool {
+	key, shutdown := op.podProbeQueue.Get()
+	if shutdown {
+		return false
+	}
+	op.observeSandboxProbeQueueDepth()
+
+	err := func() error {
+		defer op.podProbeQueue.Done(key)
+
+		requeueAfter, err := op.syncPodProbe(ctx, key)
+		if err != nil {
+			if op.podProbeQueue.NumRequeues(key) < maxRetries {
+				op.podProbeQueue.AddRateLimited(key)
+				op.observeSandboxProbeQueueDepth()
+				return err
+			}
+			op.podProbeQueue.Forget(key)
+			return fmt.Errorf("dropping sandbox pod probe %q after retries: %w", key, err)
+		}
+
+		op.podProbeQueue.Forget(key)
+		if requeueAfter > 0 {
+			op.podProbeQueue.AddAfter(key, requeueAfter)
+			op.observeSandboxProbeQueueDepth()
+		}
+		return nil
+	}()
+	if err != nil {
+		op.logger.Warn("Sandbox pod probe reconciliation failed", zap.String("key", key), zap.Error(err))
+	}
+	return true
+}
+
+func (op *Operator) syncPodProbe(ctx context.Context, key string) (time.Duration, error) {
+	started := time.Now()
+	result := "success"
+	defer func() {
+		if op.metrics == nil {
+			return
+		}
+		op.metrics.SandboxProbeReconcileTotal.WithLabelValues(result).Inc()
+		op.metrics.SandboxProbeReconcileDuration.WithLabelValues(result).Observe(time.Since(started).Seconds())
+	}()
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		result = "error"
+		return 0, fmt.Errorf("split sandbox pod probe key: %w", err)
+	}
+	pod, err := op.podLister.Pods(namespace).Get(name)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return 0, nil
+		}
+		result = "error"
+		return 0, fmt.Errorf("get sandbox pod for probe: %w", err)
+	}
+	if !isSandboxProbeCandidate(pod) {
+		return 0, nil
+	}
+
+	probeCtx, cancel := context.WithTimeout(ctx, sandboxProbeControllerTimeout)
+	defer cancel()
+	updated, err := op.ensureSandboxProbeConditions(probeCtx, pod)
+	if err != nil {
+		result = "error"
+		return 0, fmt.Errorf("ensure sandbox pod probe conditions for %s/%s: %w", pod.Namespace, pod.Name, err)
+	}
+	if shouldRetrySandboxProbe(updated) {
+		return sandboxProbeRetryAfter, nil
+	}
+	return wait.Jitter(sandboxProbeHealthyAfter, sandboxProbeHealthyJitter), nil
+}
+
+func (op *Operator) ensureSandboxProbeConditions(ctx context.Context, pod *corev1.Pod) (*corev1.Pod, error) {
+	if pod == nil {
+		return nil, nil
+	}
+	if op.probeRunner == nil {
+		return EnsureSandboxPodProbeConditions(ctx, op.k8sClient, pod,
+			probeFailure(sandboxprobe.KindStartup, "SandboxProbeUnavailable", "sandbox probe runner is unavailable"),
+			probeFailure(sandboxprobe.KindReadiness, "SandboxProbeUnavailable", "sandbox probe runner is unavailable"),
+			probeFailure(sandboxprobe.KindLiveness, "SandboxProbeUnavailable", "sandbox probe runner is unavailable"),
+		)
+	}
+	if pod.Status.Phase != corev1.PodRunning {
+		message := fmt.Sprintf("pod phase is %s", pod.Status.Phase)
+		return EnsureSandboxPodProbeConditions(ctx, op.k8sClient, pod,
+			probeFailure(sandboxprobe.KindStartup, "PodNotRunning", message),
+			probeFailure(sandboxprobe.KindReadiness, "PodNotRunning", message),
+			probeFailure(sandboxprobe.KindLiveness, "PodNotRunning", message),
+		)
+	}
+
+	startup := op.runSandboxProbe(ctx, pod, sandboxprobe.KindStartup)
+	readiness := op.runSandboxProbe(ctx, pod, sandboxprobe.KindReadiness)
+	liveness := op.runSandboxProbe(ctx, pod, sandboxprobe.KindLiveness)
+	return EnsureSandboxPodProbeConditions(ctx, op.k8sClient, pod, startup, readiness, liveness)
+}
+
+func (op *Operator) runSandboxProbe(ctx context.Context, pod *corev1.Pod, kind sandboxprobe.Kind) *sandboxprobe.Response {
+	started := time.Now()
+	result, err := op.probeRunner.ProbeSandboxPod(ctx, pod, kind)
+	resultLabel := "success"
+	if err != nil {
+		resultLabel = "error"
+		result = probeFailure(kind, "SandboxProbeFailed", err.Error())
+	} else if result == nil {
+		resultLabel = "missing"
+		result = probeFailure(kind, "SandboxProbeMissing", "sandbox probe returned no result")
+	} else {
+		resultLabel = string(result.Status)
+	}
+	if op.metrics != nil {
+		op.metrics.SandboxProbeRequestsTotal.WithLabelValues(string(kind), resultLabel).Inc()
+		op.metrics.SandboxProbeRequestDuration.WithLabelValues(string(kind), resultLabel).Observe(time.Since(started).Seconds())
+	}
+	return result
+}
+
+func probeFailure(kind sandboxprobe.Kind, reason, message string) *sandboxprobe.Response {
+	result := sandboxprobe.Failed(kind, reason, message, nil)
+	return &result
+}
+
+func isSandboxProbeCandidate(pod *corev1.Pod) bool {
+	return pod != nil &&
+		pod.DeletionTimestamp == nil &&
+		pod.Labels[LabelTemplateID] != "" &&
+		HasSandboxPodReadinessGate(pod)
+}
+
+func shouldRetrySandboxProbe(pod *corev1.Pod) bool {
+	if !isSandboxProbeCandidate(pod) {
+		return false
+	}
+	if pod.Status.Phase != corev1.PodRunning {
+		return true
+	}
+	if !podConditionTrue(pod.Status.Conditions, v1alpha1.SandboxPodStartupConditionType) ||
+		!podConditionTrue(pod.Status.Conditions, v1alpha1.SandboxPodReadinessConditionType) {
+		return true
+	}
+	live := findPodCondition(pod.Status.Conditions, v1alpha1.SandboxPodLivenessConditionType)
+	return live != nil && live.Status == corev1.ConditionFalse
+}
+
+func podProbeInputsChanged(oldPod, newPod *corev1.Pod) bool {
+	if oldPod == nil || newPod == nil {
+		return oldPod != newPod
+	}
+	return oldPod.UID != newPod.UID ||
+		oldPod.DeletionTimestamp == nil && newPod.DeletionTimestamp != nil ||
+		oldPod.Spec.NodeName != newPod.Spec.NodeName ||
+		oldPod.Status.Phase != newPod.Status.Phase ||
+		oldPod.Status.PodIP != newPod.Status.PodIP ||
+		!reflect.DeepEqual(oldPod.Spec.ReadinessGates, newPod.Spec.ReadinessGates) ||
+		!reflect.DeepEqual(oldPod.Status.ContainerStatuses, newPod.Status.ContainerStatuses)
+}
+
+func (op *Operator) enqueuePodProbe(pod *corev1.Pod) {
+	if op == nil || op.podProbeQueue == nil || !isSandboxProbeCandidate(pod) {
+		return
+	}
+	key, err := cache.MetaNamespaceKeyFunc(pod)
+	if err != nil {
+		return
+	}
+	op.podProbeQueue.Add(key)
+	op.observeSandboxProbeQueueDepth()
+}
+
+func (op *Operator) observeSandboxProbeQueueDepth() {
+	if op != nil && op.metrics != nil && op.podProbeQueue != nil {
+		op.metrics.SandboxProbeQueueDepth.Set(float64(op.podProbeQueue.Len()))
+	}
+}

--- a/manager/pkg/controller/pod_probe_controller.go
+++ b/manager/pkg/controller/pod_probe_controller.go
@@ -135,7 +135,7 @@ func (op *Operator) ensureSandboxProbeConditions(ctx context.Context, pod *corev
 func (op *Operator) runSandboxProbe(ctx context.Context, pod *corev1.Pod, kind sandboxprobe.Kind) *sandboxprobe.Response {
 	started := time.Now()
 	result, err := op.probeRunner.ProbeSandboxPod(ctx, pod, kind)
-	resultLabel := "success"
+	var resultLabel string
 	if err != nil {
 		resultLabel = "error"
 		result = probeFailure(kind, "SandboxProbeFailed", err.Error())

--- a/pkg/observability/metrics/manager.go
+++ b/pkg/observability/metrics/manager.go
@@ -22,6 +22,11 @@ type ManagerMetrics struct {
 	PodLifecycleStageDuration       *prometheus.HistogramVec
 	NetworkPolicyApplyTotal         *prometheus.CounterVec
 	NetworkPolicyApplyDuration      *prometheus.HistogramVec
+	SandboxProbeQueueDepth          prometheus.Gauge
+	SandboxProbeReconcileTotal      *prometheus.CounterVec
+	SandboxProbeReconcileDuration   *prometheus.HistogramVec
+	SandboxProbeRequestsTotal       *prometheus.CounterVec
+	SandboxProbeRequestDuration     *prometheus.HistogramVec
 	K8sClientRateLimit              *prometheus.GaugeVec
 	AutoscalerDecisionsTotal        *prometheus.CounterVec
 	AutoscalerPoolReplicas          *prometheus.GaugeVec
@@ -124,6 +129,28 @@ func NewManager(registry prometheus.Registerer) *ManagerMetrics {
 			Help:    "Duration of network policy apply attempts by provider and result",
 			Buckets: []float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 30},
 		}, []string{"provider", "result"}),
+		SandboxProbeQueueDepth: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "manager_sandbox_probe_queue_depth",
+			Help: "Current number of sandbox pods awaiting probe reconciliation",
+		}),
+		SandboxProbeReconcileTotal: factory.NewCounterVec(prometheus.CounterOpts{
+			Name: "manager_sandbox_probe_reconcile_total",
+			Help: "Total number of sandbox pod probe reconciliations by result",
+		}, []string{"result"}),
+		SandboxProbeReconcileDuration: factory.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "manager_sandbox_probe_reconcile_duration_seconds",
+			Help:    "Duration of sandbox pod probe reconciliations by result",
+			Buckets: []float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
+		}, []string{"result"}),
+		SandboxProbeRequestsTotal: factory.NewCounterVec(prometheus.CounterOpts{
+			Name: "manager_sandbox_probe_requests_total",
+			Help: "Total number of sandbox probe requests by kind and result",
+		}, []string{"kind", "result"}),
+		SandboxProbeRequestDuration: factory.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "manager_sandbox_probe_request_duration_seconds",
+			Help:    "Duration of sandbox probe requests by kind and result",
+			Buckets: []float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
+		}, []string{"kind", "result"}),
 		K8sClientRateLimit: factory.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "manager_k8s_client_rate_limit",
 			Help: "Effective Kubernetes client rate limit configuration values",


### PR DESCRIPTION
## What changed

- move sandbox startup/readiness/liveness probing out of template reconciliation into a dedicated per-Pod workqueue
- bound probe fan-out to eight workers, retry unhealthy Pods after 5 seconds, and jitter healthy rechecks around 30 seconds
- avoid re-enqueueing probes for condition-only status updates while still reacting to scheduling, phase, IP, readiness-gate, and container-status changes
- expose queue, reconcile, request-count, and request-latency metrics for the new controller

## Why

Every Pod update previously caused template reconciliation to synchronously probe every idle and active sandbox Pod. At a 120-Pod warm pool plus a 100-claim burst, that turns unrelated metadata/status updates into hundreds of serial ctld probe requests and lets one slow Pod block template reconciliation.

Template reconciliation now only reads cached Pod conditions for pool status. Probe retries and periodic liveness checks remain explicit and independently bounded.

## Validation

- `make proto`
- `go test ./manager/pkg/controller ./pkg/observability/metrics`
- `go test -race ./manager/pkg/controller`
- `go test ./manager/...`
- `go vet ./manager/... ./pkg/observability/metrics`
- the true #749–#753 integration commit `f3e9b6d7` passed claim/run/file/delete/refill and probe-controller validation in the Aliyun Singapore remote environment
- the exact integration image passed public-API and 10-concurrent claim + `node -v` validation in Ali us-east-1
- all three 100-sandbox benchmark modes completed 100/100, but the combined stability result did not pass because `infra-operator` was OOMKilled twice after burst

The remote and benchmark evidence is for the combined #749–#753 stack and is not an isolated performance attribution to this PR. Exact results are recorded in the benchmark comment.

## Stack

Phase-two item 1/5. This PR is based directly on `main`.
