### PR TITLE
perf(manager): patch hot claim metadata exactly

### DIFF
--- a/manager/pkg/service/sandbox_claim_metadata_patch.go
+++ b/manager/pkg/service/sandbox_claim_metadata_patch.go
@@ -1,0 +1,217 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type claimMetadataPatchOperation struct {
+	Operation string `json:"op"`
+	Path      string `json:"path"`
+	Value     any    `json:"value,omitempty"`
+}
+
+// patchClaimedPodMetadata atomically moves one idle pod to claimed metadata
+// without replacing spec or status fields owned by other Kubernetes actors.
+func (s *SandboxService) patchClaimedPodMetadata(
+	ctx context.Context,
+	originalPod *corev1.Pod,
+	claimedPod *corev1.Pod,
+) (*corev1.Pod, error) {
+	patch, err := buildClaimMetadataPatch(originalPod, claimedPod)
+	if err != nil {
+		return nil, err
+	}
+	return s.k8sClient.CoreV1().Pods(originalPod.Namespace).Patch(
+		ctx,
+		originalPod.Name,
+		types.JSONPatchType,
+		patch,
+		metav1.PatchOptions{},
+	)
+}
+
+// buildClaimMetadataPatch creates the compare-and-swap JSON patch used by hot
+// claims. UID, resource version, and pool state prevent stale managers from
+// claiming the same pod.
+func buildClaimMetadataPatch(originalPod, claimedPod *corev1.Pod) ([]byte, error) {
+	if originalPod == nil || claimedPod == nil {
+		return nil, fmt.Errorf("build claim metadata patch: pod is nil")
+	}
+	if originalPod.Namespace != claimedPod.Namespace || originalPod.Name != claimedPod.Name {
+		return nil, fmt.Errorf(
+			"build claim metadata patch: pod identity changed from %s/%s to %s/%s",
+			originalPod.Namespace,
+			originalPod.Name,
+			claimedPod.Namespace,
+			claimedPod.Name,
+		)
+	}
+
+	operations := make([]claimMetadataPatchOperation, 0, 16)
+	if originalPod.UID != "" {
+		operations = append(operations, claimMetadataPatchOperation{
+			Operation: "test",
+			Path:      "/metadata/uid",
+			Value:     originalPod.UID,
+		})
+	}
+	if originalPod.ResourceVersion != "" {
+		operations = append(operations, claimMetadataPatchOperation{
+			Operation: "test",
+			Path:      "/metadata/resourceVersion",
+			Value:     originalPod.ResourceVersion,
+		})
+	}
+	operations = append(operations, claimMetadataPatchOperation{
+		Operation: "test",
+		Path:      metadataMapPath("labels", controller.LabelPoolType),
+		Value:     controller.PoolTypeIdle,
+	})
+
+	operations = appendMetadataMapPatch(operations, "labels", originalPod.Labels, claimedPod.Labels)
+	operations = appendMetadataMapPatch(operations, "annotations", originalPod.Annotations, claimedPod.Annotations)
+	operations = appendFinalizerPatch(operations, originalPod.Finalizers, claimedPod.Finalizers)
+	operations = appendReplicaSetOwnerRemovalPatch(operations, originalPod.OwnerReferences)
+
+	patch, err := json.Marshal(operations)
+	if err != nil {
+		return nil, fmt.Errorf("marshal claim metadata patch: %w", err)
+	}
+	return patch, nil
+}
+
+func appendMetadataMapPatch(
+	operations []claimMetadataPatchOperation,
+	field string,
+	original map[string]string,
+	desired map[string]string,
+) []claimMetadataPatchOperation {
+	if original == nil && len(desired) > 0 {
+		return append(operations, claimMetadataPatchOperation{
+			Operation: "add",
+			Path:      "/metadata/" + field,
+			Value:     desired,
+		})
+	}
+
+	removedKeys := make([]string, 0)
+	for key := range original {
+		if _, exists := desired[key]; !exists {
+			removedKeys = append(removedKeys, key)
+		}
+	}
+	sort.Strings(removedKeys)
+	for _, key := range removedKeys {
+		operations = append(operations, claimMetadataPatchOperation{
+			Operation: "remove",
+			Path:      metadataMapPath(field, key),
+		})
+	}
+
+	changedKeys := make([]string, 0)
+	for key, desiredValue := range desired {
+		if originalValue, exists := original[key]; !exists || originalValue != desiredValue {
+			changedKeys = append(changedKeys, key)
+		}
+	}
+	sort.Strings(changedKeys)
+	for _, key := range changedKeys {
+		operation := "add"
+		if _, exists := original[key]; exists {
+			operation = "replace"
+		}
+		operations = append(operations, claimMetadataPatchOperation{
+			Operation: operation,
+			Path:      metadataMapPath(field, key),
+			Value:     desired[key],
+		})
+	}
+	return operations
+}
+
+func appendFinalizerPatch(
+	operations []claimMetadataPatchOperation,
+	original []string,
+	desired []string,
+) []claimMetadataPatchOperation {
+	existing := make(map[string]struct{}, len(original))
+	for _, finalizer := range original {
+		existing[finalizer] = struct{}{}
+	}
+	for _, finalizer := range desired {
+		if _, exists := existing[finalizer]; exists {
+			continue
+		}
+		if len(original) == 0 {
+			operations = append(operations, claimMetadataPatchOperation{
+				Operation: "add",
+				Path:      "/metadata/finalizers",
+				Value:     []string{finalizer},
+			})
+			original = append(original, finalizer)
+		} else {
+			operations = append(operations, claimMetadataPatchOperation{
+				Operation: "add",
+				Path:      "/metadata/finalizers/-",
+				Value:     finalizer,
+			})
+		}
+		existing[finalizer] = struct{}{}
+	}
+	return operations
+}
+
+func appendReplicaSetOwnerRemovalPatch(
+	operations []claimMetadataPatchOperation,
+	ownerReferences []metav1.OwnerReference,
+) []claimMetadataPatchOperation {
+	for index := len(ownerReferences) - 1; index >= 0; index-- {
+		owner := ownerReferences[index]
+		if owner.Kind != "ReplicaSet" || owner.Controller == nil || !*owner.Controller {
+			continue
+		}
+		path := "/metadata/ownerReferences/" + strconv.Itoa(index)
+		if owner.UID != "" {
+			operations = append(operations, claimMetadataPatchOperation{
+				Operation: "test",
+				Path:      path + "/uid",
+				Value:     owner.UID,
+			})
+		}
+		operations = append(operations, claimMetadataPatchOperation{
+			Operation: "remove",
+			Path:      path,
+		})
+	}
+	return operations
+}
+
+func removeReplicaSetControllerOwnerReferences(ownerReferences []metav1.OwnerReference) []metav1.OwnerReference {
+	filtered := make([]metav1.OwnerReference, 0, len(ownerReferences))
+	for _, owner := range ownerReferences {
+		if owner.Kind == "ReplicaSet" && owner.Controller != nil && *owner.Controller {
+			continue
+		}
+		filtered = append(filtered, owner)
+	}
+	return filtered
+}
+
+func metadataMapPath(field, key string) string {
+	return "/metadata/" + field + "/" + escapeJSONPointerToken(key)
+}
+
+func escapeJSONPointerToken(value string) string {
+	value = strings.ReplaceAll(value, "~", "~0")
+	return strings.ReplaceAll(value, "/", "~1")
+}

--- a/manager/pkg/service/sandbox_claim_metadata_patch_test.go
+++ b/manager/pkg/service/sandbox_claim_metadata_patch_test.go
@@ -136,13 +136,13 @@ func TestPatchClaimedPodMetadataRejectsAlreadyClaimedPod(t *testing.T) {
 	}
 }
 
-func TestIdlePodLostDuringClaimRecognizesMetadataPatchPreconditionFailure(t *testing.T) {
+func TestClaimMetadataPatchPreconditionFailureRecognizesJSONPatchTest(t *testing.T) {
 	err := &apierrors.StatusError{ErrStatus: metav1.Status{
 		Reason:  metav1.StatusReasonInvalid,
 		Message: "testing value /metadata/resourceVersion failed: test failed",
 	}}
-	if !isIdlePodLostDuringClaim(err) {
-		t.Fatalf("isIdlePodLostDuringClaim(%v) = false, want true", err)
+	if !isClaimMetadataPatchPreconditionFailure(err) {
+		t.Fatalf("isClaimMetadataPatchPreconditionFailure(%v) = false, want true", err)
 	}
 }
 

--- a/manager/pkg/service/sandbox_claim_metadata_patch_test.go
+++ b/manager/pkg/service/sandbox_claim_metadata_patch_test.go
@@ -146,6 +146,20 @@ func TestClaimMetadataPatchPreconditionFailureRecognizesJSONPatchTest(t *testing
 	}
 }
 
+func TestClaimMetadataPatchPreconditionFailureDoesNotHideUnchangedValidationError(t *testing.T) {
+	original := newClaimTestPod("sandbox-a", "idle-a", "default", true)
+	client := fake.NewSimpleClientset(original.DeepCopy())
+	service := &SandboxService{k8sClient: client}
+	err := &apierrors.StatusError{ErrStatus: metav1.Status{
+		Reason:  metav1.StatusReasonInvalid,
+		Message: "the server rejected our request due to an error in our request",
+	}}
+
+	if service.claimMetadataPatchPreconditionFailed(context.Background(), original, err) {
+		t.Fatal("unchanged pod was treated as a lost claim candidate")
+	}
+}
+
 func assertClaimPatchOperation(
 	t *testing.T,
 	operations []claimMetadataPatchOperation,

--- a/manager/pkg/service/sandbox_claim_metadata_patch_test.go
+++ b/manager/pkg/service/sandbox_claim_metadata_patch_test.go
@@ -1,0 +1,162 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func TestPatchClaimedPodMetadataChangesOnlyManagerOwnedMetadata(t *testing.T) {
+	controllerOwner := true
+	original := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       "sandbox-a",
+			Name:            "idle-a",
+			UID:             types.UID("pod-uid"),
+			ResourceVersion: "42",
+			Labels: map[string]string{
+				controller.LabelPoolType:   controller.PoolTypeIdle,
+				controller.LabelTemplateID: "default",
+				"example.com/unrelated":    "keep",
+			},
+			Annotations: map[string]string{
+				controller.AnnotationTemplateSpecHash: "template-hash",
+				"example.com/unrelated":               "keep",
+			},
+			Finalizers: []string{"example.com/unrelated"},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "ReplicaSet",
+					Name:       "warm-pool",
+					UID:        types.UID("replicaset-uid"),
+					Controller: &controllerOwner,
+				},
+				{
+					APIVersion: "example.com/v1",
+					Kind:       "ExternalOwner",
+					Name:       "external-owner",
+					UID:        types.UID("external-owner-uid"),
+				},
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "node-a",
+			Containers: []corev1.Container{{
+				Name:  "procd",
+				Image: "example.com/procd:test",
+			}},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning, PodIP: "10.0.0.1"},
+	}
+	claimed := original.DeepCopy()
+	claimed.Labels[controller.LabelPoolType] = controller.PoolTypeActive
+	claimed.Labels[controller.LabelSandboxID] = "sandbox-id"
+	claimed.Annotations[controller.AnnotationSandboxID] = "sandbox-id"
+	ensureSandboxCleanupFinalizer(claimed)
+	claimed.OwnerReferences = removeReplicaSetControllerOwnerReferences(claimed.OwnerReferences)
+
+	client := fake.NewSimpleClientset(original.DeepCopy())
+	service := &SandboxService{k8sClient: client}
+	patched, err := service.patchClaimedPodMetadata(context.Background(), original, claimed)
+	if err != nil {
+		t.Fatalf("patchClaimedPodMetadata() error = %v", err)
+	}
+
+	if got := patched.Labels["example.com/unrelated"]; got != "keep" {
+		t.Fatalf("unrelated label = %q, want keep", got)
+	}
+	if got := patched.Annotations["example.com/unrelated"]; got != "keep" {
+		t.Fatalf("unrelated annotation = %q, want keep", got)
+	}
+	if got := patched.Spec.NodeName; got != original.Spec.NodeName {
+		t.Fatalf("node name = %q, want %q", got, original.Spec.NodeName)
+	}
+	if got := patched.Status.PodIP; got != original.Status.PodIP {
+		t.Fatalf("pod IP = %q, want %q", got, original.Status.PodIP)
+	}
+	if len(patched.Finalizers) != 2 ||
+		patched.Finalizers[0] != "example.com/unrelated" ||
+		patched.Finalizers[1] != sandboxCleanupFinalizer {
+		t.Fatalf("finalizers = %v, want unrelated and sandbox cleanup", patched.Finalizers)
+	}
+	if len(patched.OwnerReferences) != 1 || patched.OwnerReferences[0].UID != types.UID("external-owner-uid") {
+		t.Fatalf("owner references = %#v, want only external owner", patched.OwnerReferences)
+	}
+
+	var patchAction k8stesting.PatchAction
+	for _, action := range client.Actions() {
+		if action.GetVerb() == "update" {
+			t.Fatalf("claim issued full pod update: %#v", action)
+		}
+		if action.GetVerb() == "patch" {
+			patchAction = action.(k8stesting.PatchAction)
+		}
+	}
+	if patchAction == nil {
+		t.Fatal("claim did not issue a pod patch")
+	}
+	if patchAction.GetPatchType() != types.JSONPatchType {
+		t.Fatalf("patch type = %q, want %q", patchAction.GetPatchType(), types.JSONPatchType)
+	}
+
+	var operations []claimMetadataPatchOperation
+	if err := json.Unmarshal(patchAction.GetPatch(), &operations); err != nil {
+		t.Fatalf("unmarshal patch: %v", err)
+	}
+	assertClaimPatchOperation(t, operations, "test", "/metadata/uid")
+	assertClaimPatchOperation(t, operations, "test", "/metadata/resourceVersion")
+	assertClaimPatchOperation(t, operations, "test", metadataMapPath("labels", controller.LabelPoolType))
+	assertClaimPatchOperation(t, operations, "remove", "/metadata/ownerReferences/0")
+}
+
+func TestPatchClaimedPodMetadataRejectsAlreadyClaimedPod(t *testing.T) {
+	original := newClaimTestPod("sandbox-a", "idle-a", "default", true)
+	original.UID = types.UID("pod-uid")
+	claimed := original.DeepCopy()
+	claimed.Labels[controller.LabelPoolType] = controller.PoolTypeActive
+	claimed.Labels[controller.LabelSandboxID] = "sandbox-id"
+	ensureSandboxCleanupFinalizer(claimed)
+
+	client := fake.NewSimpleClientset(original.DeepCopy())
+	service := &SandboxService{k8sClient: client}
+	if _, err := service.patchClaimedPodMetadata(context.Background(), original, claimed); err != nil {
+		t.Fatalf("first patchClaimedPodMetadata() error = %v", err)
+	}
+	if _, err := service.patchClaimedPodMetadata(context.Background(), original, claimed); err == nil {
+		t.Fatal("second patchClaimedPodMetadata() error = nil, want stale idle-label precondition failure")
+	}
+}
+
+func TestIdlePodLostDuringClaimRecognizesMetadataPatchPreconditionFailure(t *testing.T) {
+	err := &apierrors.StatusError{ErrStatus: metav1.Status{
+		Reason:  metav1.StatusReasonInvalid,
+		Message: "testing value /metadata/resourceVersion failed: test failed",
+	}}
+	if !isIdlePodLostDuringClaim(err) {
+		t.Fatalf("isIdlePodLostDuringClaim(%v) = false, want true", err)
+	}
+}
+
+func assertClaimPatchOperation(
+	t *testing.T,
+	operations []claimMetadataPatchOperation,
+	operation string,
+	path string,
+) {
+	t.Helper()
+	for _, candidate := range operations {
+		if candidate.Operation == operation && candidate.Path == path {
+			return
+		}
+	}
+	t.Fatalf("patch does not contain %s %s: %#v", operation, path, operations)
+}

--- a/manager/pkg/service/sandbox_runtime_identity_test.go
+++ b/manager/pkg/service/sandbox_runtime_identity_test.go
@@ -753,7 +753,7 @@ func TestResumePausedSandboxRuntimeBeginsTransactionBeforeClaimingPod(t *testing
 	}}
 	client := fake.NewSimpleClientset(idlePod.DeepCopy())
 	observedTxn := make(chan *SandboxLifecycleTxn, 1)
-	client.PrependReactor("update", "pods", func(_ ktesting.Action) (bool, runtime.Object, error) {
+	client.PrependReactor("patch", "pods", func(_ ktesting.Action) (bool, runtime.Object, error) {
 		txn, err := store.GetActiveLifecycleTxn(context.Background(), "sandbox-a")
 		if err != nil {
 			t.Errorf("GetActiveLifecycleTxn() error = %v", err)
@@ -778,7 +778,7 @@ func TestResumePausedSandboxRuntimeBeginsTransactionBeforeClaimingPod(t *testing
 	select {
 	case txn = <-observedTxn:
 	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for pod update")
+		t.Fatal("timed out waiting for pod patch")
 	}
 	if txn == nil {
 		t.Fatal("active resume txn was not visible before pod claim")

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -1182,6 +1182,11 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 					zap.Error(rollbackErr),
 				)
 			}
+			if isClaimMetadataPatchPreconditionFailure(updateErr) {
+				s.observeIdleClaim(templateID, "update_conflict")
+				keepReservationUntilTTL()
+				return fmt.Errorf("%w: patch pod %s/%s: %w", errIdlePodClaimLost, pod.Namespace, pod.Name, updateErr)
+			}
 			if isIdlePodLostDuringClaim(updateErr) {
 				s.observeIdleClaim(templateID, "update_conflict")
 				keepReservationUntilTTL()
@@ -1294,6 +1299,15 @@ func isIdlePodLostDuringClaim(err error) bool {
 		return false
 	}
 	msg := err.Error()
+	return strings.Contains(msg, "metadata.finalizers") &&
+		strings.Contains(msg, "no new finalizers can be added if the object is being deleted")
+}
+
+func isClaimMetadataPatchPreconditionFailure(err error) bool {
+	if !k8serrors.IsInvalid(err) {
+		return false
+	}
+	msg := err.Error()
 	if strings.Contains(msg, "testing value /metadata/") &&
 		strings.Contains(msg, "failed: test failed") {
 		return true
@@ -1302,8 +1316,7 @@ func isIdlePodLostDuringClaim(err error) bool {
 		strings.Contains(msg, "/metadata/") {
 		return true
 	}
-	return strings.Contains(msg, "metadata.finalizers") &&
-		strings.Contains(msg, "no new finalizers can be added if the object is being deleted")
+	return false
 }
 
 func (s *SandboxService) createNewPod(ctx context.Context, template *v1alpha1.SandboxTemplate, req *ClaimRequest) (*corev1.Pod, error) {

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -1115,8 +1115,8 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 		pod.Labels[controller.LabelSandboxID] = sandboxID
 		ensureSandboxCleanupFinalizer(pod)
 
-		// Remove owner reference (so it's no longer managed by ReplicaSet)
-		pod.OwnerReferences = nil
+		// Detach the pod from its warm-pool ReplicaSet while preserving unrelated owners.
+		pod.OwnerReferences = removeReplicaSetControllerOwnerReferences(pod.OwnerReferences)
 
 		// Add annotations
 		if pod.Annotations == nil {
@@ -1171,8 +1171,9 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 			return fmt.Errorf("stage credential bindings: %w", err)
 		}
 
-		// Update the pod
-		updatedPod, updateErr := s.k8sClient.CoreV1().Pods(pod.Namespace).Update(ctx, pod, metav1.UpdateOptions{})
+		// Claim through a metadata-only compare-and-swap patch. This avoids
+		// replacing status/spec fields owned by kubelet or other controllers.
+		updatedPod, updateErr := s.patchClaimedPodMetadata(ctx, originalIdlePod, pod)
 		if updateErr != nil {
 			rollbackStateVolume()
 			if rollbackErr := rollbackBindings(ctx); rollbackErr != nil {
@@ -1293,6 +1294,14 @@ func isIdlePodLostDuringClaim(err error) bool {
 		return false
 	}
 	msg := err.Error()
+	if strings.Contains(msg, "testing value /metadata/") &&
+		strings.Contains(msg, "failed: test failed") {
+		return true
+	}
+	if strings.Contains(msg, "test operation does not apply") &&
+		strings.Contains(msg, "/metadata/") {
+		return true
+	}
 	return strings.Contains(msg, "metadata.finalizers") &&
 		strings.Contains(msg, "no new finalizers can be added if the object is being deleted")
 }

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -1018,6 +1018,7 @@ func isVolumePortalPendingPublicationError(resp *ctldapi.BindVolumePortalRespons
 
 func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.SandboxTemplate, req *ClaimRequest) (*corev1.Pod, error) {
 	var claimedPod *corev1.Pod
+	lostCandidates := make(map[string]struct{})
 	desiredTemplateHash, err := controller.TemplateSpecHash(template)
 	if err != nil {
 		return nil, fmt.Errorf("compute template hash: %w", err)
@@ -1040,6 +1041,9 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 		// Filter hot-claimable pods to Kubernetes-ready instances only.
 		var readyPods []*corev1.Pod
 		for _, pod := range pods {
+			if _, lost := lostCandidates[pod.Namespace+"/"+pod.Name]; lost {
+				continue
+			}
 			if s.isHotClaimableIdlePod(pod, desiredTemplateHash) && !s.isIdlePodReserved(pod) {
 				readyPods = append(readyPods, pod)
 			}
@@ -1182,7 +1186,8 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 					zap.Error(rollbackErr),
 				)
 			}
-			if isClaimMetadataPatchPreconditionFailure(updateErr) {
+			if s.claimMetadataPatchPreconditionFailed(ctx, originalIdlePod, updateErr) {
+				lostCandidates[pod.Namespace+"/"+pod.Name] = struct{}{}
 				s.observeIdleClaim(templateID, "update_conflict")
 				keepReservationUntilTTL()
 				return fmt.Errorf("%w: patch pod %s/%s: %w", errIdlePodClaimLost, pod.Namespace, pod.Name, updateErr)
@@ -1317,6 +1322,39 @@ func isClaimMetadataPatchPreconditionFailure(err error) bool {
 		return true
 	}
 	return false
+}
+
+// claimMetadataPatchPreconditionFailed resolves sanitized Kubernetes 422
+// responses by checking the exact compare-and-swap inputs against live state.
+func (s *SandboxService) claimMetadataPatchPreconditionFailed(
+	ctx context.Context,
+	originalPod *corev1.Pod,
+	err error,
+) bool {
+	if isClaimMetadataPatchPreconditionFailure(err) {
+		return true
+	}
+	if !k8serrors.IsInvalid(err) || s == nil || s.k8sClient == nil || originalPod == nil {
+		return false
+	}
+	current, getErr := s.k8sClient.CoreV1().Pods(originalPod.Namespace).Get(
+		ctx,
+		originalPod.Name,
+		metav1.GetOptions{},
+	)
+	if k8serrors.IsNotFound(getErr) {
+		return true
+	}
+	if getErr != nil || current == nil {
+		return false
+	}
+	if originalPod.UID != "" && current.UID != originalPod.UID {
+		return true
+	}
+	if originalPod.ResourceVersion != "" && current.ResourceVersion != originalPod.ResourceVersion {
+		return true
+	}
+	return current.Labels[controller.LabelPoolType] != controller.PoolTypeIdle
 }
 
 func (s *SandboxService) createNewPod(ctx context.Context, template *v1alpha1.SandboxTemplate, req *ClaimRequest) (*corev1.Pod, error) {

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -459,6 +459,50 @@ func TestClaimIdlePodFallsBackAfterRepeatedUpdateConflicts(t *testing.T) {
 	}
 }
 
+func TestClaimIdlePodRetriesMetadataPatchPreconditionFailure(t *testing.T) {
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "template-a",
+			Namespace: "ns-a",
+		},
+	}
+	idlePods := []*corev1.Pod{
+		newClaimTestPod("ns-a", "idle-a", "template-a", true),
+		newClaimTestPod("ns-a", "idle-b", "template-a", true),
+		newClaimTestPod("ns-a", "idle-c", "template-a", true),
+	}
+	clientObjects := make([]runtime.Object, 0, len(idlePods))
+	for _, pod := range idlePods {
+		clientObjects = append(clientObjects, pod.DeepCopy())
+	}
+	client := fake.NewSimpleClientset(clientObjects...)
+	patchFailures := 0
+	client.PrependReactor("patch", "pods", func(k8stesting.Action) (bool, runtime.Object, error) {
+		patchFailures++
+		return true, nil, &apierrors.StatusError{ErrStatus: metav1.Status{
+			Reason:  metav1.StatusReasonInvalid,
+			Message: "testing value /metadata/resourceVersion failed: test failed",
+		}}
+	})
+	svc := &SandboxService{
+		k8sClient: client,
+		podLister: newClaimTestPodLister(t, idlePods...),
+		clock:     systemTime{},
+		logger:    zap.NewNop(),
+	}
+
+	pod, err := svc.claimIdlePod(context.Background(), template, &ClaimRequest{TeamID: "team-a", UserID: "user-a"})
+	if err != nil {
+		t.Fatalf("claimIdlePod() error = %v, want nil fallback", err)
+	}
+	if pod != nil {
+		t.Fatalf("claimIdlePod() = %s, want nil after repeated patch precondition failures", pod.Name)
+	}
+	if patchFailures != claimIdlePodBackoff.Steps {
+		t.Fatalf("patch failures = %d, want %d", patchFailures, claimIdlePodBackoff.Steps)
+	}
+}
+
 func TestClaimIdlePodRequiresDataPlaneReadyNode(t *testing.T) {
 	template := &v1alpha1.SandboxTemplate{
 		ObjectMeta: metav1.ObjectMeta{

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -392,7 +392,7 @@ func TestClaimIdlePodFallsBackWhenPodStartsDeletingDuringClaim(t *testing.T) {
 	readyPod := newClaimTestPod("ns-a", "idle-ready", "template-a", true)
 
 	client := fake.NewSimpleClientset(readyPod.DeepCopy())
-	client.PrependReactor("update", "pods", func(k8stesting.Action) (bool, runtime.Object, error) {
+	client.PrependReactor("patch", "pods", func(k8stesting.Action) (bool, runtime.Object, error) {
 		return true, nil, &apierrors.StatusError{ErrStatus: metav1.Status{
 			Reason:  metav1.StatusReasonInvalid,
 			Message: `Pod "idle-ready" is invalid: metadata.finalizers: Forbidden: no new finalizers can be added if the object is being deleted, found new finalizers []string{"sandbox0.ai/sandbox-cleanup"}`,
@@ -432,9 +432,9 @@ func TestClaimIdlePodFallsBackAfterRepeatedUpdateConflicts(t *testing.T) {
 		clientObjects = append(clientObjects, pod.DeepCopy())
 	}
 	client := fake.NewSimpleClientset(clientObjects...)
-	updateConflicts := 0
-	client.PrependReactor("update", "pods", func(k8stesting.Action) (bool, runtime.Object, error) {
-		updateConflicts++
+	patchConflicts := 0
+	client.PrependReactor("patch", "pods", func(k8stesting.Action) (bool, runtime.Object, error) {
+		patchConflicts++
 		return true, nil, &apierrors.StatusError{ErrStatus: metav1.Status{
 			Reason:  metav1.StatusReasonConflict,
 			Message: "pod was claimed by another manager",
@@ -454,8 +454,8 @@ func TestClaimIdlePodFallsBackAfterRepeatedUpdateConflicts(t *testing.T) {
 	if pod != nil {
 		t.Fatalf("claimIdlePod() = %s, want nil after repeated update conflicts", pod.Name)
 	}
-	if updateConflicts != claimIdlePodBackoff.Steps {
-		t.Fatalf("update conflicts = %d, want %d", updateConflicts, claimIdlePodBackoff.Steps)
+	if patchConflicts != claimIdlePodBackoff.Steps {
+		t.Fatalf("patch conflicts = %d, want %d", patchConflicts, claimIdlePodBackoff.Steps)
 	}
 }
 

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -503,6 +503,76 @@ func TestClaimIdlePodRetriesMetadataPatchPreconditionFailure(t *testing.T) {
 	}
 }
 
+func TestClaimIdlePodRetriesSanitizedMetadataPatchPreconditionFailure(t *testing.T) {
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "template-a",
+			Namespace: "ns-a",
+		},
+	}
+	idlePods := []*corev1.Pod{
+		newClaimTestPod("ns-a", "idle-a", "template-a", true),
+		newClaimTestPod("ns-a", "idle-b", "template-a", true),
+	}
+	clientObjects := make([]runtime.Object, 0, len(idlePods))
+	for _, pod := range idlePods {
+		clientObjects = append(clientObjects, pod.DeepCopy())
+	}
+	client := fake.NewSimpleClientset(clientObjects...)
+	patchAttempts := 0
+	failedPodName := ""
+	client.PrependReactor("patch", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		patchAttempts++
+		if patchAttempts != 1 {
+			return false, nil, nil
+		}
+		patchAction := action.(k8stesting.PatchAction)
+		failedPodName = patchAction.GetName()
+		current, err := client.Tracker().Get(
+			corev1.SchemeGroupVersion.WithResource("pods"),
+			action.GetNamespace(),
+			failedPodName,
+		)
+		if err != nil {
+			return true, nil, err
+		}
+		claimedByOther := current.(*corev1.Pod).DeepCopy()
+		claimedByOther.ResourceVersion = "2"
+		claimedByOther.Annotations[controller.AnnotationSandboxID] = "claimed-by-other"
+		if err := client.Tracker().Update(
+			corev1.SchemeGroupVersion.WithResource("pods"),
+			claimedByOther,
+			action.GetNamespace(),
+		); err != nil {
+			return true, nil, err
+		}
+		return true, nil, &apierrors.StatusError{ErrStatus: metav1.Status{
+			Reason:  metav1.StatusReasonInvalid,
+			Message: "the server rejected our request due to an error in our request",
+		}}
+	})
+	svc := &SandboxService{
+		k8sClient: client,
+		podLister: newClaimTestPodLister(t, idlePods...),
+		clock:     systemTime{},
+		logger:    zap.NewNop(),
+	}
+
+	pod, err := svc.claimIdlePod(context.Background(), template, &ClaimRequest{TeamID: "team-a", UserID: "user-a"})
+	if err != nil {
+		t.Fatalf("claimIdlePod() error = %v", err)
+	}
+	if pod == nil {
+		t.Fatal("claimIdlePod() = nil, want retry on another idle pod")
+	}
+	if pod.Name == failedPodName {
+		t.Fatalf("claimIdlePod() retried lost pod %q", failedPodName)
+	}
+	if patchAttempts != 2 {
+		t.Fatalf("patch attempts = %d, want 2", patchAttempts)
+	}
+}
+
 func TestClaimIdlePodRequiresDataPlaneReadyNode(t *testing.T) {
 	template := &v1alpha1.SandboxTemplate{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Summary

- replace the hot-claim full Pod update with a metadata-only JSON Patch
- guard initial idle-candidate acquisition with UID, resourceVersion, and idle-pool compare-and-swap tests
- preserve unrelated metadata, finalizers, and non-ReplicaSet owner references
- treat JSON Patch precondition failures as a lost idle candidate and retain cold fallback behavior
- recognize sanitized Kubernetes 422 precondition failures by comparing the live Pod with the original CAS inputs

## Why

The full Pod update copies informer-cached spec/status back to the API server and creates a large conflict surface on the hottest claim step. A narrow CAS patch changes only manager-owned metadata while preventing two managers from claiming the same idle Pod.

The initial candidate-acquisition patch deliberately tests `resourceVersion`: any intervening Pod change loses that candidate and retries another one. The later reservation-ready transition added by #751 instead uses stable UID + reservation-token CAS because normal status updates can advance `resourceVersion` during initialization.

## Validation

- `go test ./manager/pkg/service -count=1`
- `go test -race ./manager/pkg/service -run 'Test(PatchClaimedPodMetadata|ClaimIdlePodFallsBack|ClaimIdlePodRetries)' -count=1`
- `go vet ./manager/pkg/service`
- the true #749–#753 integration passed a remote claim where Pod `resourceVersion` advanced from `62762` to `62859`
- the exact integration image passed public-API and 10-concurrent claim + `node -v` validation in Ali us-east-1
- all three 100-sandbox benchmark modes completed 100/100, but the combined stability result did not pass because `infra-operator` was OOMKilled twice after burst

The remote and benchmark evidence is for the combined #749–#753 stack and is not an isolated performance attribution to this PR. Exact results are recorded in the benchmark comment.

## Stack

Phase-two item 2/5. This PR is based directly on `main`.
