### PR TITLE
perf(manager): pace warm pool detachment

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,7 @@ require (
 	golang.org/x/sync v0.19.0
 	golang.org/x/sys v0.40.0
 	golang.org/x/text v0.33.0
+	golang.org/x/time v0.14.0
 	google.golang.org/grpc v1.77.0
 	google.golang.org/protobuf v1.36.10
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
@@ -204,7 +205,6 @@ require (
 	golang.org/x/exp v0.0.0-20251113190631-e25ba8c21ef6 // indirect
 	golang.org/x/mod v0.31.0 // indirect
 	golang.org/x/term v0.39.0 // indirect
-	golang.org/x/time v0.14.0 // indirect
 	golang.org/x/tools v0.40.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217 // indirect

--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -714,7 +714,7 @@ func main() {
 	}()
 
 	go func() {
-		if err := hotClaimReservationController.Run(ctx, 2); err != nil && err != context.Canceled {
+		if err := hotClaimReservationController.Run(ctx, 1); err != nil && err != context.Canceled {
 			logger.Error("Hot claim reservation controller failed", zap.Error(err))
 		}
 	}()

--- a/manager/pkg/controller/pool_manager.go
+++ b/manager/pkg/controller/pool_manager.go
@@ -64,6 +64,7 @@ const (
 	AnnotationHotClaimReservation          = "sandbox0.ai/hot-claim-reservation"
 	AnnotationHotClaimReservationState     = "sandbox0.ai/hot-claim-reservation-state"
 	AnnotationHotClaimReservedAt           = "sandbox0.ai/hot-claim-reserved-at"
+	AnnotationHotClaimReadyAt              = "sandbox0.ai/hot-claim-ready-at"
 	AnnotationTemplateSpecHash             = "sandbox0.ai/template-spec-hash"
 	AnnotationTemplateTeamID               = "sandbox0.ai/template-team-id"
 	AnnotationTemplateUserID               = "sandbox0.ai/template-user-id"

--- a/manager/pkg/service/hot_claim_reservation.go
+++ b/manager/pkg/service/hot_claim_reservation.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
 	corev1 "k8s.io/api/core/v1"
@@ -75,6 +76,7 @@ func (s *SandboxService) markHotClaimReservationReady(
 		}
 		// Pod status updates advance resourceVersion during initialization. UID
 		// and the unique reservation token are the stable CAS inputs here.
+		readyAt := s.now().UTC().Format(time.RFC3339Nano)
 		operations = append(operations,
 			claimMetadataPatchOperation{
 				Operation: "test",
@@ -85,6 +87,11 @@ func (s *SandboxService) markHotClaimReservationReady(
 				Operation: "replace",
 				Path:      metadataMapPath("annotations", controller.AnnotationHotClaimReservationState),
 				Value:     controller.HotClaimReservationStateReady,
+			},
+			claimMetadataPatchOperation{
+				Operation: "add",
+				Path:      metadataMapPath("annotations", controller.AnnotationHotClaimReadyAt),
+				Value:     readyAt,
 			},
 		)
 		patch, err := json.Marshal(operations)

--- a/manager/pkg/service/hot_claim_reservation_controller.go
+++ b/manager/pkg/service/hot_claim_reservation_controller.go
@@ -100,11 +100,11 @@ func (c *HotClaimReservationController) EnqueueHotClaimReservation(namespace, po
 }
 
 // Run reconciles reservations from informer events and periodic recovery scans.
-func (c *HotClaimReservationController) Run(ctx context.Context, workers int) error {
+func (c *HotClaimReservationController) Run(ctx context.Context, _ int) error {
 	if c == nil {
 		return nil
 	}
-	workers = 1
+	const workers = 1
 	if c.queue == nil {
 		c.queue = workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]())
 	}

--- a/manager/pkg/service/hot_claim_reservation_controller.go
+++ b/manager/pkg/service/hot_claim_reservation_controller.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
 	"go.uber.org/zap"
+	"golang.org/x/time/rate"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,6 +27,10 @@ import (
 const (
 	hotClaimReservationRecoveryGracePeriod = 5 * time.Minute
 	hotClaimReservationResyncPeriod        = 30 * time.Second
+	hotClaimDetachmentSettleWindow         = 3 * time.Second
+	hotClaimDetachmentMaxDelay             = 2 * time.Minute
+	hotClaimDetachmentLowWatermark         = 16
+	hotClaimDetachmentRatePerSecond        = 5
 )
 
 // HotClaimReservationController safely detaches completed hot claims from
@@ -39,6 +44,14 @@ type HotClaimReservationController struct {
 	queue          workqueue.TypedRateLimitingInterface[string]
 	resyncInterval time.Duration
 	recoveryGrace  time.Duration
+	detachPacer    hotClaimDetachmentPacer
+	settleWindow   time.Duration
+	maxDetachDelay time.Duration
+	lowWatermark   int
+}
+
+type hotClaimDetachmentPacer interface {
+	Wait(context.Context) error
 }
 
 func NewHotClaimReservationController(
@@ -59,6 +72,10 @@ func NewHotClaimReservationController(
 		queue:          workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
 		resyncInterval: hotClaimReservationResyncPeriod,
 		recoveryGrace:  hotClaimReservationRecoveryGracePeriod,
+		detachPacer:    rate.NewLimiter(rate.Limit(hotClaimDetachmentRatePerSecond), 1),
+		settleWindow:   hotClaimDetachmentSettleWindow,
+		maxDetachDelay: hotClaimDetachmentMaxDelay,
+		lowWatermark:   hotClaimDetachmentLowWatermark,
 	}
 }
 
@@ -87,9 +104,7 @@ func (c *HotClaimReservationController) Run(ctx context.Context, workers int) er
 	if c == nil {
 		return nil
 	}
-	if workers <= 0 {
-		workers = 1
-	}
+	workers = 1
 	if c.queue == nil {
 		c.queue = workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]())
 	}
@@ -190,6 +205,14 @@ func (c *HotClaimReservationController) reconcile(ctx context.Context, key strin
 	}
 	if pod.Annotations[controller.AnnotationHotClaimReservationState] == controller.HotClaimReservationStateReady &&
 		hotClaimReservationMatchesRecord(pod, record) {
+		if requeueAfter := c.detachmentTimeRemaining(pod); requeueAfter > 0 {
+			return requeueAfter, nil
+		}
+		if !c.detachmentMaxDelayElapsed(pod) && c.detachPacer != nil {
+			if err := c.detachPacer.Wait(ctx); err != nil {
+				return 0, fmt.Errorf("wait for hot claim detachment pace: %w", err)
+			}
+		}
 		return 0, c.finalizeReservation(ctx, pod)
 	}
 
@@ -233,6 +256,92 @@ func (c *HotClaimReservationController) recoveryTimeRemaining(pod *corev1.Pod) t
 	return remaining
 }
 
+func (c *HotClaimReservationController) detachmentTimeRemaining(pod *corev1.Pod) time.Duration {
+	readyAt, ok := hotClaimReservationReadyTime(pod)
+	if !ok || c.settleWindow <= 0 || c.detachmentMaxDelayElapsedAt(readyAt) {
+		return 0
+	}
+	if c.claimableIdleBelowLowWatermark(pod) {
+		return 0
+	}
+	now := c.clock.Now()
+	if readyAt.After(now) {
+		return c.settleWindow
+	}
+	remaining := c.settleWindow - now.Sub(readyAt)
+	if remaining <= 0 {
+		return 0
+	}
+	return remaining
+}
+
+func (c *HotClaimReservationController) detachmentMaxDelayElapsed(pod *corev1.Pod) bool {
+	readyAt, ok := hotClaimReservationReadyTime(pod)
+	return !ok || c.detachmentMaxDelayElapsedAt(readyAt)
+}
+
+func (c *HotClaimReservationController) detachmentMaxDelayElapsedAt(readyAt time.Time) bool {
+	if c.maxDetachDelay <= 0 {
+		return true
+	}
+	now := c.clock.Now()
+	return !readyAt.After(now) && now.Sub(readyAt) >= c.maxDetachDelay
+}
+
+func (c *HotClaimReservationController) claimableIdleBelowLowWatermark(pod *corev1.Pod) bool {
+	if c.lowWatermark <= 0 || c.podLister == nil || pod == nil {
+		return false
+	}
+	templateID := strings.TrimSpace(pod.Labels[controller.LabelTemplateID])
+	if templateID == "" {
+		return false
+	}
+	pods, err := c.podLister.Pods(pod.Namespace).List(labels.SelectorFromSet(map[string]string{
+		controller.LabelTemplateID: templateID,
+		controller.LabelPoolType:   controller.PoolTypeIdle,
+	}))
+	if err != nil {
+		c.logger.Warn("Failed to count claimable idle pods before hot claim detachment",
+			zap.String("template", templateID),
+			zap.Error(err),
+		)
+		return false
+	}
+	claimable := 0
+	for _, candidate := range pods {
+		if candidate.DeletionTimestamp != nil ||
+			controller.IsHotClaimReservedPod(candidate) ||
+			!controller.IsPodReady(candidate) {
+			continue
+		}
+		claimable++
+		if claimable >= c.lowWatermark {
+			return false
+		}
+	}
+	return true
+}
+
+func hotClaimReservationReadyTime(pod *corev1.Pod) (time.Time, bool) {
+	if pod == nil {
+		return time.Time{}, false
+	}
+	for _, key := range []string{
+		controller.AnnotationHotClaimReadyAt,
+		controller.AnnotationHotClaimReservedAt,
+	} {
+		value := strings.TrimSpace(pod.Annotations[key])
+		if value == "" {
+			continue
+		}
+		parsed, err := time.Parse(time.RFC3339Nano, value)
+		if err == nil {
+			return parsed, true
+		}
+	}
+	return time.Time{}, false
+}
+
 func (c *HotClaimReservationController) finalizeReservation(ctx context.Context, pod *corev1.Pod) error {
 	operations := hotClaimReservationPreconditions(pod)
 	operations = appendReplicaSetOwnerRemovalPatch(
@@ -254,11 +363,17 @@ func (c *HotClaimReservationController) finalizeReservation(ctx context.Context,
 			Operation: "remove",
 			Path:      metadataMapPath("annotations", controller.AnnotationHotClaimReservedAt),
 		},
-		claimMetadataPatchOperation{
-			Operation: "remove",
-			Path:      metadataMapPath("annotations", controller.AnnotationHotClaimReservation),
-		},
 	)
+	if pod.Annotations[controller.AnnotationHotClaimReadyAt] != "" {
+		operations = append(operations, claimMetadataPatchOperation{
+			Operation: "remove",
+			Path:      metadataMapPath("annotations", controller.AnnotationHotClaimReadyAt),
+		})
+	}
+	operations = append(operations, claimMetadataPatchOperation{
+		Operation: "remove",
+		Path:      metadataMapPath("annotations", controller.AnnotationHotClaimReservation),
+	})
 	patch, err := json.Marshal(operations)
 	if err != nil {
 		return fmt.Errorf("marshal hot claim detachment patch: %w", err)

--- a/manager/pkg/service/hot_claim_reservation_controller_test.go
+++ b/manager/pkg/service/hot_claim_reservation_controller_test.go
@@ -2,6 +2,8 @@ package service
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -26,6 +28,9 @@ func TestMarkHotClaimReservationReadyKeepsWarmPoolAttachment(t *testing.T) {
 	}
 	if got := ready.Annotations[controller.AnnotationHotClaimReservationState]; got != controller.HotClaimReservationStateReady {
 		t.Fatalf("reservation state = %q, want %q", got, controller.HotClaimReservationStateReady)
+	}
+	if got := ready.Annotations[controller.AnnotationHotClaimReadyAt]; got == "" {
+		t.Fatal("hot claim ready timestamp is empty")
 	}
 	if got := ready.Labels[controller.LabelPoolType]; got != controller.PoolTypeIdle {
 		t.Fatalf("pool type = %q, want idle before controller detachment", got)
@@ -67,6 +72,8 @@ func TestHotClaimReservationControllerFinalizesDurableReadyClaim(t *testing.T) {
 		nil,
 	)
 	reconciler.clock = fixedClock{now: now}
+	pacer := &recordingHotClaimDetachmentPacer{}
+	reconciler.detachPacer = pacer
 
 	requeueAfter, err := reconciler.reconcile(context.Background(), pod.Namespace+"/"+pod.Name)
 	if err != nil {
@@ -74,6 +81,9 @@ func TestHotClaimReservationControllerFinalizesDurableReadyClaim(t *testing.T) {
 	}
 	if requeueAfter != 0 {
 		t.Fatalf("reconcile() requeueAfter = %s, want 0", requeueAfter)
+	}
+	if pacer.calls != 1 {
+		t.Fatalf("detachment pacer calls = %d, want 1", pacer.calls)
 	}
 
 	got, err := client.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
@@ -91,6 +101,77 @@ func TestHotClaimReservationControllerFinalizesDurableReadyClaim(t *testing.T) {
 	}
 	if !hasSandboxCleanupFinalizer(got) {
 		t.Fatal("sandbox cleanup finalizer was removed")
+	}
+}
+
+func TestHotClaimReservationControllerWaitsForSettleWindowWithHealthyCapacity(t *testing.T) {
+	now := time.Date(2026, time.July, 26, 12, 0, 0, 0, time.UTC)
+	pod := newHotClaimReservationTestPod(now, controller.HotClaimReservationStateReady)
+	store := &memorySandboxStore{records: map[string]*SandboxRecord{
+		"sandbox-a": hotClaimReservationTestRecord(pod),
+	}}
+	client := fake.NewSimpleClientset(pod.DeepCopy())
+	pacer := &recordingHotClaimDetachmentPacer{}
+	reconciler := NewHotClaimReservationController(
+		client,
+		newClaimTestPodLister(t, hotClaimReservationCapacityPods(pod, hotClaimDetachmentLowWatermark)...),
+		store,
+		nil,
+	)
+	reconciler.clock = fixedClock{now: now}
+	reconciler.detachPacer = pacer
+
+	requeueAfter, err := reconciler.reconcile(context.Background(), pod.Namespace+"/"+pod.Name)
+	if err != nil {
+		t.Fatalf("reconcile() error = %v", err)
+	}
+	if requeueAfter != hotClaimDetachmentSettleWindow {
+		t.Fatalf("reconcile() requeueAfter = %s, want %s", requeueAfter, hotClaimDetachmentSettleWindow)
+	}
+	if pacer.calls != 0 {
+		t.Fatalf("detachment pacer calls = %d, want 0 before settle window", pacer.calls)
+	}
+	got, err := client.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get reserved pod: %v", err)
+	}
+	if got.Labels[controller.LabelPoolType] != controller.PoolTypeIdle {
+		t.Fatalf("pool type = %q, want idle during settle window", got.Labels[controller.LabelPoolType])
+	}
+}
+
+func TestHotClaimReservationControllerMaxDelayBypassesPacer(t *testing.T) {
+	now := time.Date(2026, time.July, 26, 12, 0, 0, 0, time.UTC)
+	pod := newHotClaimReservationTestPod(
+		now.Add(-hotClaimDetachmentMaxDelay-time.Second),
+		controller.HotClaimReservationStateReady,
+	)
+	store := &memorySandboxStore{records: map[string]*SandboxRecord{
+		"sandbox-a": hotClaimReservationTestRecord(pod),
+	}}
+	client := fake.NewSimpleClientset(pod.DeepCopy())
+	pacer := &recordingHotClaimDetachmentPacer{err: errors.New("pacer must be bypassed")}
+	reconciler := NewHotClaimReservationController(
+		client,
+		newClaimTestPodLister(t, hotClaimReservationCapacityPods(pod, hotClaimDetachmentLowWatermark)...),
+		store,
+		nil,
+	)
+	reconciler.clock = fixedClock{now: now}
+	reconciler.detachPacer = pacer
+
+	if _, err := reconciler.reconcile(context.Background(), pod.Namespace+"/"+pod.Name); err != nil {
+		t.Fatalf("reconcile() error = %v", err)
+	}
+	if pacer.calls != 0 {
+		t.Fatalf("detachment pacer calls = %d, want 0 after max delay", pacer.calls)
+	}
+	got, err := client.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get finalized pod: %v", err)
+	}
+	if got.Labels[controller.LabelPoolType] != controller.PoolTypeActive {
+		t.Fatalf("pool type = %q, want active after max delay", got.Labels[controller.LabelPoolType])
 	}
 }
 
@@ -211,6 +292,9 @@ func newHotClaimReservationTestPod(reservedAt time.Time, state string) *corev1.P
 	pod.Annotations[controller.AnnotationHotClaimReservation] = "reservation-token"
 	pod.Annotations[controller.AnnotationHotClaimReservationState] = state
 	pod.Annotations[controller.AnnotationHotClaimReservedAt] = reservedAt.Format(time.RFC3339Nano)
+	if state == controller.HotClaimReservationStateReady {
+		pod.Annotations[controller.AnnotationHotClaimReadyAt] = reservedAt.Format(time.RFC3339Nano)
+	}
 	pod.Finalizers = []string{"example.com/unrelated", sandboxCleanupFinalizer}
 	pod.OwnerReferences = []metav1.OwnerReference{
 		{
@@ -228,6 +312,30 @@ func newHotClaimReservationTestPod(reservedAt time.Time, state string) *corev1.P
 		},
 	}
 	return pod
+}
+
+func hotClaimReservationCapacityPods(reserved *corev1.Pod, claimable int) []*corev1.Pod {
+	pods := make([]*corev1.Pod, 0, claimable+1)
+	pods = append(pods, reserved)
+	for index := range claimable {
+		pods = append(pods, newClaimTestPod(
+			reserved.Namespace,
+			fmt.Sprintf("idle-ready-%d", index),
+			reserved.Labels[controller.LabelTemplateID],
+			true,
+		))
+	}
+	return pods
+}
+
+type recordingHotClaimDetachmentPacer struct {
+	calls int
+	err   error
+}
+
+func (p *recordingHotClaimDetachmentPacer) Wait(context.Context) error {
+	p.calls++
+	return p.err
 }
 
 func hotClaimReservationTestRecord(pod *corev1.Pod) *SandboxRecord {


### PR DESCRIPTION
## Summary

- add a durable ready timestamp to completed hot-claim reservations
- keep healthy pools quiet for 3 seconds before starting ReplicaSet detachment/refill
- bypass the settle window when claimable idle capacity falls below 16
- serialize detachments through one explicit controller worker at 5 Pods/second
- bypass pacing after a 2-minute hard maximum so reservations cannot remain attached indefinitely

## Why

Detaching every claimed Pod immediately makes the ReplicaSet create the entire replacement pool while the same burst is still initializing sandboxes. This PR uses the recovery workqueue from #751 as the single pacer, avoiding per-claim timers and unbounded goroutines.

## Validation

- `go test ./manager/... -count=1`
- `go test -race ./manager/pkg/service -run 'Test(MarkHotClaim|HotClaimReservationController)' -count=1`
- `go vet ./manager/...`
- tests cover healthy-capacity settle delay, low-watermark bypass, pacing invocation, max-delay bypass, and ready timestamp cleanup
- the full stack passed remote claim/run/delete/refill validation, including return to idle 1 + active 0
- the true #749–#753 integration completed sequential, staggered, and burst at 100/100
- the combined stability result did not pass because `infra-operator` was OOMKilled twice after burst; additional burst rounds were intentionally stopped

The remote and benchmark evidence is for the combined #749–#753 stack and is not an isolated performance attribution to this PR. Exact results are recorded in the benchmark comment.

## Stack

Phase-two item 4/5. Stacked on #751. Review the commits above `agent/manager-hot-claim-reservation`.
