### PR TITLE
perf(manager): preprovision warm sandbox limits

### DIFF
--- a/manager/pkg/apis/sandbox0/v1alpha1/helpers.go
+++ b/manager/pkg/apis/sandbox0/v1alpha1/helpers.go
@@ -394,12 +394,11 @@ func applyIdleResourceQuotaToPodSpec(spec *corev1.PodSpec, template *SandboxTemp
 	if spec == nil || template == nil {
 		return
 	}
-	quota := idleResourceQuota(template.Spec.MainContainer.Resources)
 	for i := range spec.Containers {
 		if spec.Containers[i].Name != "procd" {
 			continue
 		}
-		spec.Containers[i].Resources = BuildResourceRequirements(quota)
+		spec.Containers[i].Resources = BuildIdleResourceRequirements(template.Spec.MainContainer.Resources)
 		return
 	}
 }
@@ -418,6 +417,16 @@ func idleResourceQuota(templateQuota ResourceQuota) ResourceQuota {
 		quota.Memory = idleMemory
 	}
 	return *quota
+}
+
+// BuildIdleResourceRequirements keeps the template's full limits while using
+// low warm-pool requests. Claims can therefore defer request expansion without
+// changing the resources available to the sandbox runtime.
+func BuildIdleResourceRequirements(templateQuota ResourceQuota) corev1.ResourceRequirements {
+	active := BuildResourceRequirements(templateQuota)
+	idle := BuildResourceRequirements(idleResourceQuota(templateQuota))
+	active.Requests = idle.Requests.DeepCopy()
+	return active
 }
 
 // BuildResourceRequirements converts a sandbox resource quota into Kubernetes

--- a/manager/pkg/apis/sandbox0/v1alpha1/helpers_test.go
+++ b/manager/pkg/apis/sandbox0/v1alpha1/helpers_test.go
@@ -455,7 +455,7 @@ func TestBuildResourceRequirementsAppliesMinimumCPULimit(t *testing.T) {
 	}
 }
 
-func TestBuildIdlePodSpecUsesMinimumCPUAndLowMemoryLimits(t *testing.T) {
+func TestBuildIdlePodSpecUsesFullLimitsAndLowRequests(t *testing.T) {
 	configPath := writeManagerConfig(t, `
 manager_image: sandbox0/manager:test
 `)
@@ -471,9 +471,9 @@ manager_image: sandbox0/manager:test
 	resources := spec.Containers[0].Resources
 
 	assertResourceQuantity(t, resources.Requests[corev1.ResourceCPU], "10m")
-	assertResourceQuantity(t, resources.Limits[corev1.ResourceCPU], "150m")
+	assertResourceQuantity(t, resources.Limits[corev1.ResourceCPU], "500m")
 	assertResourceQuantity(t, resources.Requests[corev1.ResourceMemory], "64Mi")
-	assertResourceQuantity(t, resources.Limits[corev1.ResourceMemory], "128Mi")
+	assertResourceQuantity(t, resources.Limits[corev1.ResourceMemory], "2Gi")
 	assertResourceQuantity(t, resources.Requests[corev1.ResourceEphemeralStorage], "1Gi")
 	assertResourceQuantity(t, resources.Limits[corev1.ResourceEphemeralStorage], "8Gi")
 }

--- a/manager/pkg/controller/pool_manager.go
+++ b/manager/pkg/controller/pool_manager.go
@@ -65,6 +65,7 @@ const (
 	AnnotationHotClaimReservationState     = "sandbox0.ai/hot-claim-reservation-state"
 	AnnotationHotClaimReservedAt           = "sandbox0.ai/hot-claim-reserved-at"
 	AnnotationHotClaimReadyAt              = "sandbox0.ai/hot-claim-ready-at"
+	AnnotationHotClaimActiveResources      = "sandbox0.ai/hot-claim-active-resources"
 	AnnotationTemplateSpecHash             = "sandbox0.ai/template-spec-hash"
 	AnnotationTemplateTeamID               = "sandbox0.ai/template-team-id"
 	AnnotationTemplateUserID               = "sandbox0.ai/template-user-id"

--- a/manager/pkg/service/hot_claim_reservation_controller.go
+++ b/manager/pkg/service/hot_claim_reservation_controller.go
@@ -213,6 +213,10 @@ func (c *HotClaimReservationController) reconcile(ctx context.Context, key strin
 				return 0, fmt.Errorf("wait for hot claim detachment pace: %w", err)
 			}
 		}
+		pod, err = c.ensureActiveResourceRequests(ctx, pod)
+		if err != nil {
+			return 0, err
+		}
 		return 0, c.finalizeReservation(ctx, pod)
 	}
 
@@ -342,6 +346,34 @@ func hotClaimReservationReadyTime(pod *corev1.Pod) (time.Time, bool) {
 	return time.Time{}, false
 }
 
+func (c *HotClaimReservationController) ensureActiveResourceRequests(
+	ctx context.Context,
+	pod *corev1.Pod,
+) (*corev1.Pod, error) {
+	if pod == nil {
+		return nil, nil
+	}
+	rawResources := strings.TrimSpace(pod.Annotations[controller.AnnotationHotClaimActiveResources])
+	if rawResources == "" {
+		return pod, nil
+	}
+	var desired corev1.ResourceRequirements
+	if err := json.Unmarshal([]byte(rawResources), &desired); err != nil {
+		return pod, fmt.Errorf("decode hot claim active resources: %w", err)
+	}
+	for _, container := range pod.Spec.Containers {
+		if container.Name == "procd" && resizeResourcesEqual(container.Resources, desired) {
+			return pod, nil
+		}
+	}
+
+	resized, err := resizeSandboxPodToResources(ctx, c.k8sClient, pod, desired)
+	if err != nil {
+		return pod, fmt.Errorf("expand active sandbox resource requests: %w", err)
+	}
+	return mergeSandboxMetadataAfterResize(resized, pod), nil
+}
+
 func (c *HotClaimReservationController) finalizeReservation(ctx context.Context, pod *corev1.Pod) error {
 	operations := hotClaimReservationPreconditions(pod)
 	operations = appendReplicaSetOwnerRemovalPatch(
@@ -368,6 +400,12 @@ func (c *HotClaimReservationController) finalizeReservation(ctx context.Context,
 		operations = append(operations, claimMetadataPatchOperation{
 			Operation: "remove",
 			Path:      metadataMapPath("annotations", controller.AnnotationHotClaimReadyAt),
+		})
+	}
+	if pod.Annotations[controller.AnnotationHotClaimActiveResources] != "" {
+		operations = append(operations, claimMetadataPatchOperation{
+			Operation: "remove",
+			Path:      metadataMapPath("annotations", controller.AnnotationHotClaimActiveResources),
 		})
 	}
 	operations = append(operations, claimMetadataPatchOperation{

--- a/manager/pkg/service/hot_claim_reservation_controller_test.go
+++ b/manager/pkg/service/hot_claim_reservation_controller_test.go
@@ -2,18 +2,23 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
 	"time"
 
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 func TestMarkHotClaimReservationReadyKeepsWarmPoolAttachment(t *testing.T) {
@@ -101,6 +106,113 @@ func TestHotClaimReservationControllerFinalizesDurableReadyClaim(t *testing.T) {
 	}
 	if !hasSandboxCleanupFinalizer(got) {
 		t.Fatal("sandbox cleanup finalizer was removed")
+	}
+}
+
+func TestHotClaimReservationControllerExpandsRequestsBeforeDetachment(t *testing.T) {
+	now := time.Date(2026, time.July, 26, 12, 0, 0, 0, time.UTC)
+	pod := newHotClaimReservationTestPod(now, controller.HotClaimReservationStateReady)
+	quota := v1alpha1.ResourceQuota{
+		CPU:    resource.MustParse("250m"),
+		Memory: resource.MustParse("1Gi"),
+	}
+	setHotClaimReservationResources(t, pod, quota)
+	store := &memorySandboxStore{records: map[string]*SandboxRecord{
+		"sandbox-a": hotClaimReservationTestRecord(pod),
+	}}
+	client := fake.NewSimpleClientset(pod.DeepCopy())
+	reconciler := NewHotClaimReservationController(
+		client,
+		newClaimTestPodLister(t, pod),
+		store,
+		nil,
+	)
+	reconciler.clock = fixedClock{now: now}
+	reconciler.detachPacer = &recordingHotClaimDetachmentPacer{}
+
+	if _, err := reconciler.reconcile(context.Background(), pod.Namespace+"/"+pod.Name); err != nil {
+		t.Fatalf("reconcile() error = %v", err)
+	}
+
+	resizeIndex := -1
+	detachIndex := -1
+	for index, action := range client.Actions() {
+		if !action.Matches("patch", "pods") {
+			continue
+		}
+		if action.GetSubresource() == "resize" {
+			resizeIndex = index
+		} else {
+			detachIndex = index
+		}
+	}
+	if resizeIndex < 0 || detachIndex < 0 || resizeIndex >= detachIndex {
+		t.Fatalf("actions = %#v, want pods/resize before metadata detachment", client.Actions())
+	}
+
+	got, err := client.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get finalized pod: %v", err)
+	}
+	resources := sandboxRuntimeContainer(t, got).Resources
+	assertQuantity(t, resources.Limits[corev1.ResourceMemory], "1Gi")
+	assertQuantity(t, resources.Limits[corev1.ResourceCPU], "250m")
+	assertQuantity(t, resources.Requests[corev1.ResourceMemory], "256Mi")
+	assertQuantity(t, resources.Requests[corev1.ResourceCPU], "25m")
+	if got.Annotations[controller.AnnotationHotClaimActiveResources] != "" {
+		t.Fatalf("active resources annotation was not removed: %#v", got.Annotations)
+	}
+	if got.Labels[controller.LabelPoolType] != controller.PoolTypeActive {
+		t.Fatalf("pool type = %q, want active", got.Labels[controller.LabelPoolType])
+	}
+}
+
+func TestHotClaimReservationControllerKeepsWarmPoolAttachmentWhenRequestExpansionFails(t *testing.T) {
+	now := time.Date(2026, time.July, 26, 12, 0, 0, 0, time.UTC)
+	pod := newHotClaimReservationTestPod(now, controller.HotClaimReservationStateReady)
+	setHotClaimReservationResources(t, pod, v1alpha1.ResourceQuota{
+		CPU:    resource.MustParse("250m"),
+		Memory: resource.MustParse("1Gi"),
+	})
+	store := &memorySandboxStore{records: map[string]*SandboxRecord{
+		"sandbox-a": hotClaimReservationTestRecord(pod),
+	}}
+	client := fake.NewSimpleClientset(pod.DeepCopy())
+	client.PrependReactor("patch", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() != "resize" {
+			return false, nil, nil
+		}
+		return true, nil, errors.New("resize rejected")
+	})
+	reconciler := NewHotClaimReservationController(
+		client,
+		newClaimTestPodLister(t, pod),
+		store,
+		nil,
+	)
+	reconciler.clock = fixedClock{now: now}
+	reconciler.detachPacer = &recordingHotClaimDetachmentPacer{}
+
+	if _, err := reconciler.reconcile(context.Background(), pod.Namespace+"/"+pod.Name); err == nil {
+		t.Fatal("reconcile() error = nil, want request expansion failure")
+	}
+	got, err := client.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get reserved pod: %v", err)
+	}
+	if got.Labels[controller.LabelPoolType] != controller.PoolTypeIdle {
+		t.Fatalf("pool type = %q, want idle after failed request expansion", got.Labels[controller.LabelPoolType])
+	}
+	if !controller.IsHotClaimReservedPod(got) {
+		t.Fatal("reservation was removed after failed request expansion")
+	}
+	if len(got.OwnerReferences) != 2 {
+		t.Fatalf("owner references = %#v, want warm-pool attachment preserved", got.OwnerReferences)
+	}
+	for _, action := range client.Actions() {
+		if action.Matches("patch", "pods") && action.GetSubresource() == "" {
+			t.Fatalf("unexpected metadata detachment after failed request expansion: %#v", client.Actions())
+		}
 	}
 }
 
@@ -312,6 +424,21 @@ func newHotClaimReservationTestPod(reservedAt time.Time, state string) *corev1.P
 		},
 	}
 	return pod
+}
+
+func setHotClaimReservationResources(t *testing.T, pod *corev1.Pod, quota v1alpha1.ResourceQuota) {
+	t.Helper()
+	for index := range pod.Spec.Containers {
+		if pod.Spec.Containers[index].Name == "procd" {
+			pod.Spec.Containers[index].Resources = v1alpha1.BuildIdleResourceRequirements(quota)
+			break
+		}
+	}
+	activeResources, err := json.Marshal(v1alpha1.BuildResourceRequirements(quota))
+	if err != nil {
+		t.Fatalf("marshal active resources: %v", err)
+	}
+	pod.Annotations[controller.AnnotationHotClaimActiveResources] = string(activeResources)
 }
 
 func hotClaimReservationCapacityPods(reserved *corev1.Pod, claimable int) []*corev1.Pod {

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -1108,7 +1108,7 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 			return err
 		}
 		var resizeQuota *v1alpha1.ResourceQuota
-		if sandboxPodNeedsResourceResize(pod, resourceQuota) {
+		if sandboxPodNeedsSynchronousResourceResize(pod, resourceQuota) {
 			resizeQuota = &resourceQuota
 		}
 
@@ -1131,6 +1131,11 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 		pod.Annotations[controller.AnnotationHotClaimReservation] = reservationToken
 		pod.Annotations[controller.AnnotationHotClaimReservationState] = controller.HotClaimReservationStateInitializing
 		pod.Annotations[controller.AnnotationHotClaimReservedAt] = s.clock.Now().UTC().Format(time.RFC3339Nano)
+		activeResourcesJSON, marshalErr := json.Marshal(v1alpha1.BuildResourceRequirements(resourceQuota))
+		if marshalErr != nil {
+			return fmt.Errorf("marshal hot claim active resources: %w", marshalErr)
+		}
+		pod.Annotations[controller.AnnotationHotClaimActiveResources] = string(activeResourcesJSON)
 		if stateVolume != nil {
 			pod.Annotations[controller.AnnotationWebhookStateVolumeID] = stateVolume.VolumeID
 		} else {

--- a/manager/pkg/service/sandbox_service_resources.go
+++ b/manager/pkg/service/sandbox_service_resources.go
@@ -37,13 +37,6 @@ func (s *SandboxService) effectiveSandboxResourceQuota(template *v1alpha1.Sandbo
 	return v1alpha1.NormalizeSandboxResourceQuota(quota), nil
 }
 
-func (s *SandboxService) applySandboxResourceQuota(pod *corev1.Pod, quota v1alpha1.ResourceQuota) error {
-	if pod == nil {
-		return fmt.Errorf("%w: pod is required", ErrInvalidClaimRequest)
-	}
-	return applySandboxResourceQuotaToPodSpec(&pod.Spec, quota)
-}
-
 func (s *SandboxService) resizeSandboxPodResources(ctx context.Context, pod *corev1.Pod, quota v1alpha1.ResourceQuota) (*corev1.Pod, error) {
 	if s == nil || s.k8sClient == nil {
 		return nil, fmt.Errorf("%w: kubernetes client is not configured", ErrInvalidClaimRequest)

--- a/manager/pkg/service/sandbox_service_resources.go
+++ b/manager/pkg/service/sandbox_service_resources.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
 )
 
@@ -47,13 +48,29 @@ func (s *SandboxService) resizeSandboxPodResources(ctx context.Context, pod *cor
 	if s == nil || s.k8sClient == nil {
 		return nil, fmt.Errorf("%w: kubernetes client is not configured", ErrInvalidClaimRequest)
 	}
+	return resizeSandboxPodToResources(
+		ctx,
+		s.k8sClient,
+		pod,
+		v1alpha1.BuildResourceRequirements(quota),
+	)
+}
+
+func resizeSandboxPodToResources(
+	ctx context.Context,
+	k8sClient kubernetes.Interface,
+	pod *corev1.Pod,
+	resources corev1.ResourceRequirements,
+) (*corev1.Pod, error) {
+	if k8sClient == nil {
+		return nil, fmt.Errorf("%w: kubernetes client is not configured", ErrInvalidClaimRequest)
+	}
 	if pod == nil || pod.Namespace == "" || pod.Name == "" {
 		return nil, fmt.Errorf("%w: pod is required", ErrInvalidClaimRequest)
 	}
 
 	namespace, name := pod.Namespace, pod.Name
 	var updated *corev1.Pod
-	resources := v1alpha1.BuildResourceRequirements(quota)
 	patch, err := json.Marshal(map[string]any{
 		"spec": map[string]any{
 			"containers": []map[string]any{{
@@ -66,7 +83,7 @@ func (s *SandboxService) resizeSandboxPodResources(ctx context.Context, pod *cor
 		return nil, fmt.Errorf("build sandbox resource resize patch: %w", err)
 	}
 	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		result, err := s.k8sClient.CoreV1().Pods(namespace).Patch(
+		result, err := k8sClient.CoreV1().Pods(namespace).Patch(
 			ctx,
 			name,
 			types.StrategicMergePatchType,
@@ -79,9 +96,14 @@ func (s *SandboxService) resizeSandboxPodResources(ctx context.Context, pod *cor
 		}
 		if result == nil || result.Name == "" {
 			updated = pod.DeepCopy()
-			if applyErr := s.applySandboxResourceQuota(updated, quota); applyErr != nil {
-				return applyErr
+			for index := range updated.Spec.Containers {
+				if updated.Spec.Containers[index].Name != "procd" {
+					continue
+				}
+				updated.Spec.Containers[index].Resources = resources
+				return nil
 			}
+			return fmt.Errorf("%w: sandbox runtime container not found", ErrInvalidClaimRequest)
 		} else {
 			updated = result
 		}
@@ -134,7 +156,10 @@ func applySandboxResourceQuotaToPodSpec(spec *corev1.PodSpec, quota v1alpha1.Res
 	return fmt.Errorf("%w: sandbox runtime container not found", ErrInvalidClaimRequest)
 }
 
-func sandboxPodNeedsResourceResize(pod *corev1.Pod, quota v1alpha1.ResourceQuota) bool {
+// sandboxPodNeedsSynchronousResourceResize reports whether claim-time resize is
+// required to enforce the requested limits. Request-only expansion is deferred
+// until warm-pool detachment.
+func sandboxPodNeedsSynchronousResourceResize(pod *corev1.Pod, quota v1alpha1.ResourceQuota) bool {
 	if quota.CPU.Sign() <= 0 && quota.Memory.Sign() <= 0 {
 		return false
 	}
@@ -146,7 +171,16 @@ func sandboxPodNeedsResourceResize(pod *corev1.Pod, quota v1alpha1.ResourceQuota
 		if container.Name != "procd" {
 			continue
 		}
-		return !resizeResourcesEqual(container.Resources, desired)
+		return !resizeResourceLimitsEqual(container.Resources, desired)
+	}
+	return true
+}
+
+func resizeResourceLimitsEqual(a, b corev1.ResourceRequirements) bool {
+	for _, name := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
+		if !resourceListQuantityEqual(a.Limits, b.Limits, name) {
+			return false
+		}
 	}
 	return true
 }

--- a/manager/pkg/service/sandbox_service_resources_test.go
+++ b/manager/pkg/service/sandbox_service_resources_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -211,9 +212,10 @@ func TestClaimIdlePodAppliesTemplateResourcesByDefault(t *testing.T) {
 	container := sandboxRuntimeContainer(t, pod)
 	assertQuantity(t, container.Resources.Limits[corev1.ResourceMemory], "1Gi")
 	assertQuantity(t, container.Resources.Limits[corev1.ResourceCPU], "250m")
-	assertQuantity(t, container.Resources.Requests[corev1.ResourceMemory], "256Mi")
-	assertQuantity(t, container.Resources.Requests[corev1.ResourceCPU], "25m")
-	assertResizeSubresourceUpdate(t, client.Actions())
+	assertQuantity(t, container.Resources.Requests[corev1.ResourceMemory], "64Mi")
+	assertQuantity(t, container.Resources.Requests[corev1.ResourceCPU], "10m")
+	assertHotClaimActiveResources(t, pod, "1Gi", "250m", "256Mi", "25m")
+	assertNoResizeSubresourceUpdate(t, client.Actions())
 }
 
 func TestClaimIdlePodAppliesMinimumCPUToTemplateResources(t *testing.T) {
@@ -244,8 +246,10 @@ func TestClaimIdlePodAppliesMinimumCPUToTemplateResources(t *testing.T) {
 	container := sandboxRuntimeContainer(t, pod)
 	assertQuantity(t, container.Resources.Limits[corev1.ResourceMemory], "512Mi")
 	assertQuantity(t, container.Resources.Limits[corev1.ResourceCPU], "150m")
+	assertQuantity(t, container.Resources.Requests[corev1.ResourceMemory], "64Mi")
 	assertQuantity(t, container.Resources.Requests[corev1.ResourceCPU], "10m")
-	assertResizeSubresourceUpdate(t, client.Actions())
+	assertHotClaimActiveResources(t, pod, "512Mi", "150m", "128Mi", "10m")
+	assertNoResizeSubresourceUpdate(t, client.Actions())
 }
 
 func TestClaimIdlePodAppliesMemoryOverride(t *testing.T) {
@@ -591,6 +595,38 @@ func assertResizeSubresourceUpdate(t *testing.T, actions []k8stesting.Action) {
 		}
 	}
 	t.Fatalf("missing patch pods/resize action; actions = %#v", actions)
+}
+
+func assertNoResizeSubresourceUpdate(t *testing.T, actions []k8stesting.Action) {
+	t.Helper()
+	for _, action := range actions {
+		if action.Matches("patch", "pods") && action.GetSubresource() == "resize" {
+			t.Fatalf("unexpected patch pods/resize action; actions = %#v", actions)
+		}
+	}
+}
+
+func assertHotClaimActiveResources(
+	t *testing.T,
+	pod *corev1.Pod,
+	memoryLimit string,
+	cpuLimit string,
+	memoryRequest string,
+	cpuRequest string,
+) {
+	t.Helper()
+	raw := pod.Annotations[controller.AnnotationHotClaimActiveResources]
+	if raw == "" {
+		t.Fatal("hot claim active resources annotation is empty")
+	}
+	var resources corev1.ResourceRequirements
+	if err := json.Unmarshal([]byte(raw), &resources); err != nil {
+		t.Fatalf("decode hot claim active resources: %v", err)
+	}
+	assertQuantity(t, resources.Limits[corev1.ResourceMemory], memoryLimit)
+	assertQuantity(t, resources.Limits[corev1.ResourceCPU], cpuLimit)
+	assertQuantity(t, resources.Requests[corev1.ResourceMemory], memoryRequest)
+	assertQuantity(t, resources.Requests[corev1.ResourceCPU], cpuRequest)
 }
 
 func contains(s, substr string) bool {


### PR DESCRIPTION
## Summary

- keep the template CPU and memory limits on warm-pool Pods while retaining dense idle requests
- skip claim-time `/resize` when the requested limits already match, and record the desired active requests in recoverable reservation metadata
- expand requests before detaching a durable hot claim from its warm-pool ReplicaSet; failed expansion leaves the Pod reserved and attached
- preserve synchronous resize for per-claim resource overrides and old warm Pods whose limits do not match
- remove the now-obsolete resource helper

## Dependency

Phase-two item 5/5, stacked on #752. Review the two commits from `7ec9ac09` through `d9dc7318` above `agent/manager-hot-claim-pacer`.

## Validation

- `go test ./manager/...`
- `go test -race ./manager/pkg/service -run 'Test(ClaimIdlePodAppliesTemplateResourcesByDefault|ClaimIdlePodAppliesMinimumCPUToTemplateResources|ClaimIdlePodAppliesMemoryOverride|HotClaimReservationController)'`
- `go vet ./manager/...`
- `git diff --check`
- Aliyun Singapore remote claim/run/delete/refill validation passed on the true #749–#753 integration commit `f3e9b6d7`
- the exact integration image passed public-API and 10-concurrent claim + `node -v` validation in Ali us-east-1
- sequential, staggered, and burst completed 100/100, but the combined stability result did not pass because `infra-operator` was OOMKilled twice after burst

No sandbox node sizing or infrastructure configuration is changed. The benchmark used the existing single 8-CPU fixed node with zero burst nodes.

The remote and benchmark evidence is for the combined #749–#753 stack and is not an isolated performance attribution to this PR. Exact results are recorded in the benchmark comment.
