### PR TITLE
Recover failed sandbox runtimes without blocking reads

### DIFF
--- a/cluster-gateway/pkg/http/handlers_context.go
+++ b/cluster-gateway/pkg/http/handlers_context.go
@@ -276,7 +276,7 @@ func sandboxRuntimeMissing(sandbox *mgr.Sandbox) bool {
 		return false
 	}
 	switch sandbox.Status {
-	case mgr.SandboxStatusPaused:
+	case mgr.SandboxStatusPaused, mgr.SandboxStatusFailed:
 		return true
 	}
 	return strings.TrimSpace(sandbox.InternalAddr) == ""

--- a/cluster-gateway/pkg/http/handlers_context_test.go
+++ b/cluster-gateway/pkg/http/handlers_context_test.go
@@ -241,6 +241,43 @@ func TestGetProcdURLPausedSandboxReturnsWakingUp(t *testing.T) {
 	}
 }
 
+func TestSandboxRuntimeMissing(t *testing.T) {
+	tests := []struct {
+		name    string
+		sandbox *mgr.Sandbox
+		want    bool
+	}{
+		{
+			name:    "running with address",
+			sandbox: &mgr.Sandbox{Status: mgr.SandboxStatusRunning, InternalAddr: "http://127.0.0.1:7777"},
+			want:    false,
+		},
+		{
+			name:    "running without address",
+			sandbox: &mgr.Sandbox{Status: mgr.SandboxStatusRunning},
+			want:    true,
+		},
+		{
+			name:    "paused with stale address",
+			sandbox: &mgr.Sandbox{Status: mgr.SandboxStatusPaused, InternalAddr: "http://127.0.0.1:7777"},
+			want:    true,
+		},
+		{
+			name:    "failed with stale address",
+			sandbox: &mgr.Sandbox{Status: mgr.SandboxStatusFailed, InternalAddr: "http://127.0.0.1:7777"},
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sandboxRuntimeMissing(tt.sandbox); got != tt.want {
+				t.Fatalf("sandboxRuntimeMissing() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
 func mustGetProcdURL(t *testing.T, server *Server, teamID, userID, sandboxID string) (*url.URL, *httptest.ResponseRecorder) {
 	t.Helper()
 

--- a/docs/sandbox/pause-resume/page.mdx
+++ b/docs/sandbox/pause-resume/page.mdx
@@ -81,6 +81,8 @@ Resume a sandbox that was paused manually or by TTL expiry.
 
 Resume first restores the writable rootfs checkpoint onto a runtime pod created from the current template image. If that restore fails, Sandbox0 retries once with a runtime pod pinned to the checkpoint's recorded base image digest. Kubernetes pulls and garbage-collects that image through the normal kubelet image lifecycle.
 
+If the current runtime pod has reached the `Failed` phase, sandbox details return that state immediately instead of waiting for a Pod IP. Explicit resume, or a supported access path with `auto_resume: true`, removes the failed pod and creates a new runtime generation. The replacement restores the latest committed rootfs checkpoint; writes made after that checkpoint are not guaranteed to survive an unexpected runtime failure. Mounted Sandbox Volumes are remounted from their durable state.
+
 <Endpoint method="POST">
 /api/v1/sandboxes/{'{id}'}/resume
 </Endpoint>

--- a/manager/pkg/service/sandbox_runtime_identity_test.go
+++ b/manager/pkg/service/sandbox_runtime_identity_test.go
@@ -595,6 +595,108 @@ func TestResumePausedSandboxRuntimeWaitsWhileRuntimeDeleting(t *testing.T) {
 	}
 }
 
+func TestResumePausedSandboxRuntimeReplacesFailedRuntime(t *testing.T) {
+	failedPod := runtimeIdentityPod("tpl-default", "failed-pod", "sandbox-a")
+	failedPod.Annotations[controller.AnnotationRuntimeGeneration] = "3"
+	failedPod.Status.Phase = corev1.PodFailed
+	idlePod := newClaimTestPod("tpl-default", "idle-pod", "default", true)
+	indexer := newClaimTestPodIndexer(t, failedPod, idlePod)
+	store := &memorySandboxStore{records: map[string]*SandboxRecord{
+		"sandbox-a": {
+			ID:                  "sandbox-a",
+			TeamID:              "team-a",
+			UserID:              "user-a",
+			TemplateID:          "default",
+			TemplateName:        "default",
+			TemplateNamespace:   "tpl-default",
+			Status:              SandboxStatusRunning,
+			CurrentPodName:      failedPod.Name,
+			CurrentPodNamespace: failedPod.Namespace,
+			RuntimeGeneration:   3,
+			TemplateSpec:        v1alpha1.SandboxTemplateSpec{},
+		},
+	}}
+	client := fake.NewSimpleClientset(failedPod.DeepCopy(), idlePod.DeepCopy())
+	deletedFailedPod := false
+	client.PrependReactor("delete", "pods", func(action ktesting.Action) (bool, runtime.Object, error) {
+		deleteAction, ok := action.(ktesting.DeleteAction)
+		if !ok || deleteAction.GetName() != failedPod.Name {
+			return false, nil, nil
+		}
+		record, err := store.GetSandbox(context.Background(), "sandbox-a")
+		if err != nil {
+			t.Errorf("GetSandbox() before failed pod delete error = %v", err)
+		} else if record.Status != SandboxStatusPaused {
+			t.Errorf("status before failed pod delete = %q, want paused", record.Status)
+		}
+		deletedFailedPod = true
+		if err := indexer.Delete(failedPod); err != nil {
+			return true, nil, err
+		}
+		return false, nil, nil
+	})
+	observedTxn := make(chan *SandboxLifecycleTxn, 1)
+	client.PrependReactor("update", "pods", func(action ktesting.Action) (bool, runtime.Object, error) {
+		updateAction, ok := action.(ktesting.UpdateAction)
+		if !ok {
+			return false, nil, nil
+		}
+		pod, ok := updateAction.GetObject().(*corev1.Pod)
+		if !ok || pod.Name != idlePod.Name {
+			return false, nil, nil
+		}
+		txn, err := store.GetActiveLifecycleTxn(context.Background(), "sandbox-a")
+		if err != nil {
+			t.Errorf("GetActiveLifecycleTxn() error = %v", err)
+		}
+		observedTxn <- txn
+		return true, nil, errors.New("stop replacement claim")
+	})
+	svc := &SandboxService{
+		k8sClient:    client,
+		podLister:    corelisters.NewPodLister(indexer),
+		sandboxStore: store,
+		config:       SandboxServiceConfig{ProcdPort: 49983},
+		clock:        fixedClock{now: time.Date(2026, time.March, 7, 12, 0, 0, 0, time.UTC)},
+		logger:       zap.NewNop(),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, err := svc.ResumePausedSandboxRuntime(ctx, "sandbox-a")
+	if err == nil || !strings.Contains(err.Error(), "stop replacement claim") {
+		t.Fatalf("ResumePausedSandboxRuntime() error = %v, want replacement claim failure", err)
+	}
+	if !deletedFailedPod {
+		t.Fatal("failed runtime pod was not deleted")
+	}
+	record, err := store.GetSandbox(context.Background(), "sandbox-a")
+	if err != nil {
+		t.Fatalf("GetSandbox() error = %v", err)
+	}
+	if record.Status != SandboxStatusPaused {
+		t.Fatalf("status = %q, want paused before replacement claim", record.Status)
+	}
+	if record.CurrentPodName != "" || record.CurrentPodNamespace != "" {
+		t.Fatalf("current runtime = %s/%s, want empty", record.CurrentPodNamespace, record.CurrentPodName)
+	}
+	if record.RuntimeGeneration != 3 {
+		t.Fatalf("runtime generation = %d, want 3", record.RuntimeGeneration)
+	}
+	var txn *SandboxLifecycleTxn
+	select {
+	case txn = <-observedTxn:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for replacement claim")
+	}
+	if txn == nil || txn.Kind != SandboxLifecycleKindResume {
+		t.Fatalf("replacement lifecycle txn = %+v, want resume txn", txn)
+	}
+	if txn.FromGeneration != 3 || txn.ToGeneration != 4 {
+		t.Fatalf("replacement generations = %d -> %d, want 3 -> 4", txn.FromGeneration, txn.ToGeneration)
+	}
+}
+
 func TestResumePausedSandboxRuntimeJoinsResumingRuntime(t *testing.T) {
 	pod := runtimeIdentityPod("ns-a", "pod-a", "sandbox-a")
 	pod.Annotations[controller.AnnotationRuntimeGeneration] = "4"

--- a/manager/pkg/service/sandbox_service_lifecycle.go
+++ b/manager/pkg/service/sandbox_service_lifecycle.go
@@ -674,7 +674,7 @@ func (s *SandboxService) GetSandbox(ctx context.Context, sandboxID string) (*San
 		return nil, fmt.Errorf("get pod: %w", err)
 	}
 
-	return s.podToSandbox(ctx, pod, sandboxID), nil
+	return s.podToSandbox(pod, sandboxID), nil
 }
 
 // UpdateSandbox updates mutable sandbox configuration fields.
@@ -867,7 +867,7 @@ func (s *SandboxService) UpdateSandbox(ctx context.Context, sandboxID string, cf
 		return nil, err
 	}
 
-	return s.podToSandbox(ctx, updatedPod, sandboxID), nil
+	return s.podToSandbox(updatedPod, sandboxID), nil
 }
 
 func (s *SandboxService) updatePausedSandboxRecord(ctx context.Context, record *SandboxRecord, cfg *SandboxUpdateConfig) (*Sandbox, error) {
@@ -1122,8 +1122,8 @@ func selectSandboxRuntimePod(sandboxID string, pods []*corev1.Pod) (*corev1.Pod,
 	return nil, k8serrors.NewNotFound(schema.GroupResource{Resource: "pod"}, sandboxID)
 }
 
-// podToSandbox converts a pod to a sandbox object
-func (s *SandboxService) podToSandbox(ctx context.Context, pod *corev1.Pod, sandboxID string) *Sandbox {
+// podToSandbox projects cached pod state without waiting for runtime readiness.
+func (s *SandboxService) podToSandbox(pod *corev1.Pod, sandboxID string) *Sandbox {
 	if sandboxID == "" {
 		sandboxID = sandboxIDFromPod(pod)
 	}
@@ -1135,11 +1135,6 @@ func (s *SandboxService) podToSandbox(ctx context.Context, pod *corev1.Pod, sand
 	hardExpiresAt := parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationHardExpiresAt)
 	createdAt := pod.CreationTimestamp.Time
 
-	internalAddr, err := s.prodAddress(ctx, pod)
-	if err != nil {
-		s.logger.Error("Failed to get procd address", zap.String("sandboxID", sandboxID), zap.Error(err))
-	}
-
 	cfg := parseSandboxConfig(pod.Annotations[controller.AnnotationConfig])
 	autoResume := true
 	if cfg.AutoResume != nil {
@@ -1150,7 +1145,7 @@ func (s *SandboxService) podToSandbox(ctx context.Context, pod *corev1.Pod, sand
 		TemplateID:        sandboxTemplateIDFromLabels(pod.Labels),
 		TeamID:            pod.Annotations[controller.AnnotationTeamID],
 		UserID:            pod.Annotations[controller.AnnotationUserID],
-		InternalAddr:      internalAddr,
+		InternalAddr:      s.procdAddressFromPod(pod),
 		Status:            status,
 		Paused:            status == SandboxStatusPaused,
 		AutoResume:        autoResume,

--- a/manager/pkg/service/sandbox_service_list.go
+++ b/manager/pkg/service/sandbox_service_list.go
@@ -167,7 +167,7 @@ func (s *SandboxService) listSandboxesFromStore(ctx context.Context, req *ListSa
 		}
 		if record.CurrentPodName != "" && record.Status != SandboxStatusPaused && !sandboxLifecycleTxnHidesCommittedRuntime(activeTxn) {
 			if pod, err := s.getSandboxPod(ctx, record.ID); err == nil {
-				sandbox = s.podToSandbox(ctx, pod, record.ID)
+				sandbox = s.podToSandbox(pod, record.ID)
 			}
 		}
 		if req.Paused != nil && sandbox.Paused != *req.Paused {

--- a/manager/pkg/service/sandbox_service_pod.go
+++ b/manager/pkg/service/sandbox_service_pod.go
@@ -21,8 +21,8 @@ func (s *SandboxService) prodAddress(ctx context.Context, pod *corev1.Pod) (stri
 	if pod == nil {
 		return "", fmt.Errorf("pod is nil")
 	}
-	if podIP := strings.TrimSpace(pod.Status.PodIP); podIP != "" {
-		return fmt.Sprintf("http://%s:%d", podIP, s.config.ProcdPort), nil
+	if address := s.procdAddressFromPod(pod); address != "" {
+		return address, nil
 	}
 
 	podIP, err := s.waitForPodIP(ctx, pod.Namespace, pod.Name)
@@ -31,6 +31,17 @@ func (s *SandboxService) prodAddress(ctx context.Context, pod *corev1.Pod) (stri
 	}
 
 	return fmt.Sprintf("http://%s:%d", podIP, s.config.ProcdPort), nil
+}
+
+func (s *SandboxService) procdAddressFromPod(pod *corev1.Pod) string {
+	if s == nil || pod == nil {
+		return ""
+	}
+	podIP := strings.TrimSpace(pod.Status.PodIP)
+	if podIP == "" {
+		return ""
+	}
+	return fmt.Sprintf("http://%s:%d", podIP, s.config.ProcdPort)
 }
 
 func (s *SandboxService) waitForPodIP(ctx context.Context, namespace, name string) (string, error) {

--- a/manager/pkg/service/sandbox_service_power_state_test.go
+++ b/manager/pkg/service/sandbox_service_power_state_test.go
@@ -38,11 +38,46 @@ func TestPodToSandboxDoesNotExposeLegacyPausedAnnotation(t *testing.T) {
 		},
 	}
 
-	sandbox := svc.podToSandbox(context.Background(), pod, pod.Name)
+	sandbox := svc.podToSandbox(pod, pod.Name)
 
 	assert.False(t, sandbox.Paused)
 	assert.Equal(t, "template-1", sandbox.TemplateID)
 	assert.Equal(t, int64(9), sandbox.RuntimeGeneration)
+}
+
+func TestGetSandboxDoesNotWaitForFailedPodIP(t *testing.T) {
+	pod := runtimeIdentityPod("tpl-default", "sandbox-pod", "sandbox-1")
+	pod.Status.Phase = corev1.PodFailed
+	svc := &SandboxService{
+		config:    SandboxServiceConfig{ProcdPort: 49983},
+		logger:    zap.NewNop(),
+		podLister: runtimeIdentityPodLister(t, pod),
+	}
+
+	type result struct {
+		sandbox *Sandbox
+		err     error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		sandbox, err := svc.GetSandbox(context.Background(), "sandbox-1")
+		resultCh <- result{sandbox: sandbox, err: err}
+	}()
+
+	var got result
+	select {
+	case got = <-resultCh:
+	case <-time.After(time.Second):
+		t.Fatal("GetSandbox() waited for a failed pod IP")
+	}
+	if got.err != nil {
+		t.Fatalf("GetSandbox() error = %v", got.err)
+	}
+	if got.sandbox == nil {
+		t.Fatal("GetSandbox() returned nil sandbox")
+	}
+	assert.Equal(t, SandboxStatusFailed, got.sandbox.Status)
+	assert.Empty(t, got.sandbox.InternalAddr)
 }
 
 type staticTokenGenerator struct{}

--- a/manager/pkg/service/sandbox_service_restore.go
+++ b/manager/pkg/service/sandbox_service_restore.go
@@ -20,7 +20,8 @@ import (
 const sandboxLifecycleWaitInterval = 100 * time.Millisecond
 
 // ResumePausedSandboxRuntime creates a new runtime for a paused durable sandbox
-// and restores the latest writable rootfs checkpoint.
+// and restores the latest writable rootfs checkpoint. A failed runtime is first
+// committed as paused and then replaced through the same generation transition.
 func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandboxID string) (*Sandbox, error) {
 	if s == nil || s.sandboxStore == nil {
 		return nil, k8serrors.NewNotFound(corev1.Resource("pod"), sandboxID)
@@ -32,6 +33,7 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 	var txn *SandboxLifecycleTxn
 	var req *ClaimRequest
 	var deletingPodRef *sandboxRuntimePodRef
+	var failedPodRef *sandboxRuntimePodRef
 	claimType := "hot"
 	restoreNeeded := false
 	for {
@@ -41,6 +43,7 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 		txn = nil
 		req = nil
 		deletingPodRef = nil
+		failedPodRef = nil
 		restoreNeeded = false
 		var waitErr error
 		err := s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, locked *SandboxRecord) error {
@@ -83,6 +86,13 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 						name:      existing.Name,
 					}
 					return errSandboxRuntimeDeleting
+				}
+				if sandboxRuntimePodNeedsReplacement(existing) {
+					failedPodRef = &sandboxRuntimePodRef{
+						namespace: existing.Namespace,
+						name:      existing.Name,
+					}
+					return tx.MarkRuntimePaused(lockCtx, sandboxID, runtimeGenerationFromPod(existing), s.now())
 				}
 				if locked.Status == SandboxStatusPaused {
 					deletingPodRef = &sandboxRuntimePodRef{
@@ -138,6 +148,26 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 			}
 			return tx.BeginLifecycleTxn(lockCtx, txn)
 		})
+		if err == nil && failedPodRef != nil {
+			if s.logger != nil {
+				s.logger.Warn("Replacing failed sandbox runtime",
+					zap.String("sandboxID", sandboxID),
+					zap.String("namespace", failedPodRef.namespace),
+					zap.String("pod", failedPodRef.name),
+				)
+			}
+			if s.k8sClient == nil {
+				return nil, fmt.Errorf("delete failed runtime pod: kubernetes client is not configured")
+			}
+			deleteErr := s.k8sClient.CoreV1().Pods(failedPodRef.namespace).Delete(ctx, failedPodRef.name, metav1.DeleteOptions{})
+			if deleteErr != nil && !k8serrors.IsNotFound(deleteErr) {
+				return nil, fmt.Errorf("delete failed runtime pod: %w", deleteErr)
+			}
+			if err := s.waitForSandboxRuntimePodDeletion(ctx, failedPodRef.namespace, failedPodRef.name); err != nil {
+				return nil, err
+			}
+			continue
+		}
 		if err == nil && waitErr != nil {
 			err = waitErr
 		}
@@ -280,6 +310,10 @@ var (
 type sandboxRuntimePodRef struct {
 	namespace string
 	name      string
+}
+
+func sandboxRuntimePodNeedsReplacement(pod *corev1.Pod) bool {
+	return pod != nil && pod.Status.Phase == corev1.PodFailed
 }
 
 func (s *SandboxService) waitForSandboxLifecycleTxnExit(ctx context.Context, sandboxID string) error {

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -4781,8 +4781,8 @@ components:
           type: boolean
           default: true
           description: |
-            Sandbox-level resume gate for paused sandboxes. When false, any inbound request
-            (API or public exposure) must not auto resume the sandbox.
+            Sandbox-level runtime recovery gate. When false, inbound API or public exposure
+            requests must not automatically resume a paused sandbox or replace a failed runtime.
         services:
           type: array
           items:
@@ -4954,8 +4954,9 @@ components:
         resume:
           type: boolean
           description: |
-            Allows this public route to wake a paused sandbox when sandbox auto_resume is true.
-            Resume-enabled public routes require a restartable service runtime: cmd or function.
+            Allows this public route to wake a paused sandbox or replace a failed runtime when
+            sandbox auto_resume is true. Resume-enabled public routes require a restartable service
+            runtime: cmd or function.
       required: [id, resume]
     SandboxAppServiceHealth:
       type: object
@@ -5161,8 +5162,8 @@ components:
           type: boolean
           default: true
           description: |
-            Sandbox-level resume gate for paused sandboxes. When false, any inbound request
-            (API or public exposure) must not auto resume the sandbox.
+            Sandbox-level runtime recovery gate. When false, inbound API or public exposure
+            requests must not automatically resume a paused sandbox or replace a failed runtime.
         services:
           type: array
           items:

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -2111,8 +2111,9 @@ type SandboxAppServiceRoute struct {
 	PathPrefix *string                          `json:"path_prefix,omitempty"`
 	RateLimit  *SandboxAppServiceRouteRateLimit `json:"rate_limit,omitempty"`
 
-	// Resume Allows this public route to wake a paused sandbox when sandbox auto_resume is true.
-	// Resume-enabled public routes require a restartable service runtime: cmd or function.
+	// Resume Allows this public route to wake a paused sandbox or replace a failed runtime when
+	// sandbox auto_resume is true. Resume-enabled public routes require a restartable service
+	// runtime: cmd or function.
 	Resume         bool    `json:"resume"`
 	RewritePrefix  *string `json:"rewrite_prefix"`
 	TimeoutSeconds *int32  `json:"timeout_seconds,omitempty"`
@@ -2246,8 +2247,8 @@ type SandboxAuditResource struct {
 
 // SandboxConfig defines model for SandboxConfig.
 type SandboxConfig struct {
-	// AutoResume Sandbox-level resume gate for paused sandboxes. When false, any inbound request
-	// (API or public exposure) must not auto resume the sandbox.
+	// AutoResume Sandbox-level runtime recovery gate. When false, inbound API or public exposure
+	// requests must not automatically resume a paused sandbox or replace a failed runtime.
 	AutoResume *bool              `json:"auto_resume,omitempty"`
 	EnvVars    *map[string]string `json:"env_vars,omitempty"`
 
@@ -2625,8 +2626,8 @@ type SandboxTemplateStatus struct {
 // SandboxUpdateConfig Subset of SandboxConfig fields that can be updated at runtime without restarting the sandbox.
 // Note: env_vars only affect new processes. webhook is not included as it requires restart.
 type SandboxUpdateConfig struct {
-	// AutoResume Sandbox-level resume gate for paused sandboxes. When false, any inbound request
-	// (API or public exposure) must not auto resume the sandbox.
+	// AutoResume Sandbox-level runtime recovery gate. When false, inbound API or public exposure
+	// requests must not automatically resume a paused sandbox or replace a failed runtime.
 	AutoResume *bool `json:"auto_resume,omitempty"`
 
 	// EnvVars Sandbox-level environment variables used as defaults for new procd-managed


### PR DESCRIPTION
## What

- make Pod-to-sandbox status projection cache-only so `GET` and list operations never wait for a missing Pod IP
- treat `failed` runtimes as unavailable even when Kubernetes leaves a stale Pod IP
- atomically mark a failed runtime as paused, remove only its runtime Pod, and reuse the existing resume generation flow to create and initialize a replacement
- update the OpenAPI descriptions, generated types, and pause/resume documentation
- add regression coverage for non-blocking failed status reads, failed runtime replacement, and stale-address auto-resume detection

## Why

A sandbox Pod can remain `Failed` with no Pod IP after a node restart or node-affinity rejection. Manager projected that Pod through `prodAddress`, which waited until the caller was canceled. Cluster Gateway therefore returned a generic upstream error after 10 seconds, while `/resume` could remain blocked as well. If kubelet later restored a stale Pod IP, runtime access could also skip auto-resume and proxy to the dead Pod.

## Validation

- remote kind baseline from `main`, deterministic `Failed + no PodIP` injection:
  - sandbox details: `502` after `10.003307s`
  - explicit resume: no response before the `20s` client timeout
- same remote fault injection after deploying this branch:
  - sandbox details: `200` in `0.002916s`, status `failed`
  - after kubelet restored a stale Pod IP, file-list access auto-resumed successfully: `200` in `0.250564s`
  - runtime Pod changed from `rs-mrswmylvnr2a-default-x6rxn` to `rs-mrswmylvnr2a-default-zqf49`
  - runtime generation advanced from `1` to `2`
  - manager classified old-Pod cleanup as `runtime_only`; `Sandbox0Infra` remained `Ready 10/10`
- `make apispec`
- `make proto`
- `go test ./manager/... ./cluster-gateway/... -count=1`
- `go test -race ./manager/pkg/service ./manager/pkg/http ./cluster-gateway/pkg/http ./cluster-gateway/pkg/client -count=1`
- `go vet ./manager/pkg/service/... ./cluster-gateway/pkg/http/... ./pkg/apispec/...`
