### PR TITLE
fix(infra-operator): isolate runtime sandbox churn

### DIFF
--- a/infra-operator/chart/files/clusterrole.yaml
+++ b/infra-operator/chart/files/clusterrole.yaml
@@ -9,6 +9,7 @@ rules:
   resources:
   - configmaps
   - endpoints
+  - events
   - namespaces
   - nodes
   - persistentvolumeclaims

--- a/infra-operator/chart/files/clusterrole.yaml
+++ b/infra-operator/chart/files/clusterrole.yaml
@@ -9,7 +9,6 @@ rules:
   resources:
   - configmaps
   - endpoints
-  - events
   - namespaces
   - nodes
   - persistentvolumeclaims

--- a/infra-operator/cmd/infra-operator/main.go
+++ b/infra-operator/cmd/infra-operator/main.go
@@ -24,10 +24,14 @@ import (
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -71,6 +75,15 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme: scheme,
+		// Runtime sandbox Pods are owned by manager and can churn at high rates.
+		// infra-operator only caches Pods created as part of its infrastructure.
+		Cache: cache.Options{
+			ByObject: map[client.Object]cache.ByObject{
+				&corev1.Pod{}: {
+					Label: managedPodCacheSelector(),
+				},
+			},
+		},
 		Metrics: metricsserver.Options{
 			BindAddress: metricsAddr,
 		},
@@ -120,4 +133,10 @@ func main() {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
+}
+
+func managedPodCacheSelector() labels.Selector {
+	return labels.SelectorFromSet(labels.Set{
+		"app.kubernetes.io/managed-by": "sandbox0infra-operator",
+	})
 }

--- a/infra-operator/cmd/infra-operator/main_test.go
+++ b/infra-operator/cmd/infra-operator/main_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+func TestManagedPodCacheSelectorExcludesRuntimeSandboxes(t *testing.T) {
+	selector := managedPodCacheSelector()
+	if !selector.Matches(labels.Set{
+		"app.kubernetes.io/managed-by": "sandbox0infra-operator",
+		"app.kubernetes.io/component":  "ctld",
+	}) {
+		t.Fatal("selector should include infra-operator managed Pods")
+	}
+	if selector.Matches(labels.Set{
+		"sandbox0.ai/template-id": "default",
+		"sandbox0.ai/state":       "idle",
+	}) {
+		t.Fatal("selector should exclude runtime sandbox Pods")
+	}
+}

--- a/infra-operator/internal/controller/sandbox0infra_controller.go
+++ b/infra-operator/internal/controller/sandbox0infra_controller.go
@@ -90,6 +90,8 @@ type Sandbox0InfraReconciler struct {
 //+kubebuilder:rbac:groups=infra.sandbox0.ai,resources=sandbox0infras/finalizers,verbs=update
 //+kubebuilder:rbac:groups=apps,resources=deployments;statefulsets;daemonsets;replicasets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=services;secrets;configmaps;persistentvolumeclaims;serviceaccounts;pods;pods/exec;pods/resize;pods/status;nodes;namespaces;endpoints,verbs=get;list;watch;create;update;patch;delete
+// The operator needs Event permissions to create the manager ClusterRole; it does not watch Events itself.
+//+kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=pods/log,verbs=get
 //+kubebuilder:rbac:groups=discovery.k8s.io,resources=endpointslices,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete

--- a/infra-operator/internal/controller/sandbox0infra_controller.go
+++ b/infra-operator/internal/controller/sandbox0infra_controller.go
@@ -37,11 +37,14 @@ import (
 	"k8s.io/client-go/util/retry"
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	controller "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	infrav1alpha1 "github.com/sandbox0-ai/sandbox0/infra-operator/api/v1alpha1"
@@ -66,7 +69,6 @@ import (
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/sshgateway"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/internal/controller/services/storage"
 	infraplan "github.com/sandbox0-ai/sandbox0/infra-operator/internal/plan"
-	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 )
 
 const (
@@ -75,7 +77,6 @@ const (
 	retryBaseDelay         = 2 * time.Second
 	retryMaxDelay          = 2 * time.Minute
 	initUserPasswordLength = 24
-	templateIDPodLabelKey  = "sandbox0.ai/template-id"
 )
 
 // Sandbox0InfraReconciler reconciles a Sandbox0Infra object
@@ -88,7 +89,7 @@ type Sandbox0InfraReconciler struct {
 //+kubebuilder:rbac:groups=infra.sandbox0.ai,resources=sandbox0infras/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=infra.sandbox0.ai,resources=sandbox0infras/finalizers,verbs=update
 //+kubebuilder:rbac:groups=apps,resources=deployments;statefulsets;daemonsets;replicasets,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=core,resources=services;secrets;configmaps;persistentvolumeclaims;serviceaccounts;pods;pods/exec;pods/resize;pods/status;nodes;events;namespaces;endpoints,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=core,resources=services;secrets;configmaps;persistentvolumeclaims;serviceaccounts;pods;pods/exec;pods/resize;pods/status;nodes;namespaces;endpoints,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=pods/log,verbs=get
 //+kubebuilder:rbac:groups=discovery.k8s.io,resources=endpointslices,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
@@ -474,8 +475,6 @@ func (r *Sandbox0InfraReconciler) workflowStepRunner(
 		return func(ctx context.Context) error {
 			return managerReconciler.Reconcile(ctx, imageRepo, imageTag, compiledPlan)
 		}, nil
-	case "builtin-template-pods":
-		return func(ctx context.Context) error { return r.waitBuiltinTemplatePodsReady(ctx, infra, compiledPlan) }, nil
 	case "network-ready":
 		return func(ctx context.Context) error {
 			ready, err := ctldReconciler.NetworkReady(ctx, infra)
@@ -1026,188 +1025,12 @@ func (r *Sandbox0InfraReconciler) registerCluster(ctx context.Context, infra *in
 	return fmt.Errorf("cluster registration is not implemented yet; refusing to report success without a real control-plane side effect")
 }
 
-func (r *Sandbox0InfraReconciler) waitBuiltinTemplatePodsReady(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, compiledPlan *infraplan.InfraPlan) error {
-	if infra == nil {
-		return nil
-	}
-	if compiledPlan == nil {
-		compiledPlan = infraplan.Compile(infra)
-	}
-	if !compiledPlan.Components.EnableManager || !compiledPlan.Manager.TemplateStoreEnabled {
-		return nil
-	}
-
-	for _, builtin := range compiledPlan.BuiltinTemplates() {
-		templateID, err := naming.CanonicalTemplateID(builtin.TemplateID)
-		if err != nil {
-			return fmt.Errorf("invalid builtin template_id %q: %w", builtin.TemplateID, err)
-		}
-
-		spec := common.BuildBuiltinTemplateSpec(templateID, builtin)
-		minIdle := spec.Pool.MinIdle
-		if minIdle == 0 {
-			continue
-		}
-
-		namespace, err := naming.TemplateNamespaceForBuiltin(templateID)
-		if err != nil {
-			return fmt.Errorf("resolve namespace for builtin template %q: %w", templateID, err)
-		}
-
-		podList := &corev1.PodList{}
-		if err := r.List(ctx, podList,
-			client.InNamespace(namespace),
-			client.MatchingLabels{templateIDPodLabelKey: templateID},
-		); err != nil {
-			return fmt.Errorf("list pods for builtin template %q: %w", templateID, err)
-		}
-
-		readyPods := int32(0)
-		for i := range podList.Items {
-			if isReadyPod(&podList.Items[i]) {
-				readyPods++
-			}
-		}
-		if readyPods < minIdle {
-			return fmt.Errorf("builtin template %q pods not ready: %d/%d ready; %s", templateID, readyPods, minIdle, r.notReadyTemplatePodSummary(ctx, namespace, podList.Items))
-		}
-	}
-	return nil
-}
-
-func (r *Sandbox0InfraReconciler) notReadyTemplatePodSummary(ctx context.Context, namespace string, pods []corev1.Pod) string {
-	if len(pods) == 0 {
-		return "no pods found"
-	}
-
-	const maxPods = 3
-	summaries := make([]string, 0, len(pods))
-	for i := range pods {
-		pod := &pods[i]
-		if isReadyPod(pod) {
-			continue
-		}
-
-		summary := podReadinessSummary(pod)
-		if eventSummary := r.latestPodEventSummary(ctx, namespace, pod.Name); eventSummary != "" {
-			summary += ", latestEvent=" + eventSummary
-		}
-		summaries = append(summaries, summary)
-		if len(summaries) == maxPods {
-			break
-		}
-	}
-	if len(summaries) == 0 {
-		return "not enough ready pods"
-	}
-	if len(pods) > maxPods {
-		summaries = append(summaries, fmt.Sprintf("%d more pod(s)", len(pods)-maxPods))
-	}
-	return "pods: " + strings.Join(summaries, "; ")
-}
-
-func (r *Sandbox0InfraReconciler) latestPodEventSummary(ctx context.Context, namespace, podName string) string {
-	events := &corev1.EventList{}
-	if err := r.List(ctx, events, client.InNamespace(namespace)); err != nil {
-		return ""
-	}
-
-	var latest *corev1.Event
-	for i := range events.Items {
-		event := &events.Items[i]
-		if event.InvolvedObject.Kind != "Pod" || event.InvolvedObject.Name != podName {
-			continue
-		}
-		if latest == nil || eventTimestamp(event).After(eventTimestamp(latest)) {
-			latest = event
-		}
-	}
-	if latest == nil {
-		return ""
-	}
-	if latest.Message == "" {
-		return latest.Reason
-	}
-	return fmt.Sprintf("%s(%s)", latest.Reason, compactStatusMessage(latest.Message, 160))
-}
-
-func eventTimestamp(event *corev1.Event) time.Time {
-	if event.EventTime.Time != (time.Time{}) {
-		return event.EventTime.Time
-	}
-	if !event.LastTimestamp.IsZero() {
-		return event.LastTimestamp.Time
-	}
-	return event.CreationTimestamp.Time
-}
-
-func podReadinessSummary(pod *corev1.Pod) string {
-	if pod == nil {
-		return "pod=<nil>"
-	}
-
-	parts := []string{fmt.Sprintf("%s phase=%s", pod.Name, pod.Status.Phase)}
-	for _, status := range pod.Status.InitContainerStatuses {
-		if status.State.Waiting != nil {
-			parts = append(parts, fmt.Sprintf("init/%s=waiting(%s)", status.Name, status.State.Waiting.Reason))
-		}
-		if status.State.Terminated != nil && status.State.Terminated.ExitCode != 0 {
-			parts = append(parts, fmt.Sprintf("init/%s=terminated(%s:%d)", status.Name, status.State.Terminated.Reason, status.State.Terminated.ExitCode))
-		}
-	}
-	for _, status := range pod.Status.ContainerStatuses {
-		if status.Ready {
-			continue
-		}
-		switch {
-		case status.State.Waiting != nil:
-			parts = append(parts, fmt.Sprintf("%s=waiting(%s)", status.Name, status.State.Waiting.Reason))
-		case status.State.Terminated != nil:
-			parts = append(parts, fmt.Sprintf("%s=terminated(%s:%d)", status.Name, status.State.Terminated.Reason, status.State.Terminated.ExitCode))
-		default:
-			parts = append(parts, fmt.Sprintf("%s=notReady", status.Name))
-		}
-	}
-	for _, condition := range pod.Status.Conditions {
-		if condition.Status == corev1.ConditionTrue {
-			continue
-		}
-		if condition.Reason != "" {
-			parts = append(parts, fmt.Sprintf("%s=%s", condition.Type, condition.Reason))
-		} else {
-			parts = append(parts, fmt.Sprintf("%s=%s", condition.Type, condition.Status))
-		}
-	}
-	return strings.Join(parts, ", ")
-}
-
-func compactStatusMessage(message string, limit int) string {
-	message = strings.Join(strings.Fields(message), " ")
-	if len(message) <= limit {
-		return message
-	}
-	if limit <= 3 {
-		return message[:limit]
-	}
-	return message[:limit-3] + "..."
-}
-
-func isReadyPod(pod *corev1.Pod) bool {
-	if pod == nil || pod.Status.Phase != corev1.PodRunning {
-		return false
-	}
-	for _, condition := range pod.Status.Conditions {
-		if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
-			return true
-		}
-	}
-	return false
-}
-
 // SetupWithManager sets up the controller with the Manager.
 func (r *Sandbox0InfraReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&infrav1alpha1.Sandbox0Infra{}).
+		For(&infrav1alpha1.Sandbox0Infra{}, builder.WithPredicates(predicate.Funcs{
+			UpdateFunc: sandbox0InfraUpdateRequiresReconcile,
+		})).
 		Watches(&corev1.Pod{}, handler.EnqueueRequestsFromMapFunc(r.requestsForManagedDataPlanePod)).
 		Owns(&appsv1.Deployment{}).
 		Owns(&appsv1.StatefulSet{}).
@@ -1222,6 +1045,24 @@ func (r *Sandbox0InfraReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			RateLimiter: workqueue.NewTypedItemExponentialFailureRateLimiter[ctrl.Request](retryBaseDelay, retryMaxDelay),
 		}).
 		Complete(r)
+}
+
+// sandbox0InfraUpdateRequiresReconcile ignores status-only writes while still
+// admitting desired-state changes and finalizer-driven deletion.
+func sandbox0InfraUpdateRequiresReconcile(update event.UpdateEvent) bool {
+	if update.ObjectOld == nil || update.ObjectNew == nil {
+		return false
+	}
+	if update.ObjectOld.GetGeneration() != update.ObjectNew.GetGeneration() {
+		return true
+	}
+
+	oldDeletion := update.ObjectOld.GetDeletionTimestamp()
+	newDeletion := update.ObjectNew.GetDeletionTimestamp()
+	if oldDeletion == nil || newDeletion == nil {
+		return oldDeletion != newDeletion
+	}
+	return !oldDeletion.Equal(newDeletion)
 }
 
 func (r *Sandbox0InfraReconciler) requestsForManagedDataPlanePod(_ context.Context, obj client.Object) []reconcile.Request {

--- a/infra-operator/internal/controller/sandbox0infra_controller_test.go
+++ b/infra-operator/internal/controller/sandbox0infra_controller_test.go
@@ -1,10 +1,13 @@
 package controller
 
 import (
-	"strings"
+	"context"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	infrav1alpha1 "github.com/sandbox0-ai/sandbox0/infra-operator/api/v1alpha1"
 	infraplan "github.com/sandbox0-ai/sandbox0/infra-operator/internal/plan"
@@ -43,26 +46,64 @@ func TestExpectedConditionTypesIncludesGlobalGateway(t *testing.T) {
 	}
 }
 
-func TestPodReadinessSummaryIncludesWaitingReason(t *testing.T) {
-	pod := &corev1.Pod{}
-	pod.Name = "default-idle"
-	pod.Status.Phase = corev1.PodPending
-	pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
-		Name: "procd",
-		State: corev1.ContainerState{
-			Waiting: &corev1.ContainerStateWaiting{Reason: "ImagePullBackOff"},
+func TestSandbox0InfraUpdateRequiresReconcile(t *testing.T) {
+	base := &infrav1alpha1.Sandbox0Infra{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "sandbox0",
+			Namespace:  "sandbox0-system",
+			Generation: 3,
 		},
-	}}
-	pod.Status.Conditions = []corev1.PodCondition{{
-		Type:   corev1.PodReady,
-		Status: corev1.ConditionFalse,
-		Reason: "ContainersNotReady",
-	}}
+	}
 
-	summary := podReadinessSummary(pod)
-	for _, want := range []string{"default-idle phase=Pending", "procd=waiting(ImagePullBackOff)", "Ready=ContainersNotReady"} {
-		if !strings.Contains(summary, want) {
-			t.Fatalf("summary %q does not contain %q", summary, want)
-		}
+	statusOnly := base.DeepCopy()
+	statusOnly.Status.Phase = infrav1alpha1.PhaseReady
+	if sandbox0InfraUpdateRequiresReconcile(event.UpdateEvent{ObjectOld: base, ObjectNew: statusOnly}) {
+		t.Fatal("status-only update should not trigger reconciliation")
+	}
+
+	specUpdate := base.DeepCopy()
+	specUpdate.Generation++
+	if !sandbox0InfraUpdateRequiresReconcile(event.UpdateEvent{ObjectOld: base, ObjectNew: specUpdate}) {
+		t.Fatal("generation change should trigger reconciliation")
+	}
+
+	deleting := base.DeepCopy()
+	now := metav1.Now()
+	deleting.DeletionTimestamp = &now
+	if !sandbox0InfraUpdateRequiresReconcile(event.UpdateEvent{ObjectOld: base, ObjectNew: deleting}) {
+		t.Fatal("deletion timestamp change should trigger reconciliation")
+	}
+}
+
+func TestRequestsForManagedDataPlanePodIgnoresRuntimeSandboxes(t *testing.T) {
+	reconciler := &Sandbox0InfraReconciler{}
+	sandboxPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "tpl-default",
+			Name:      "default-idle",
+			Labels: map[string]string{
+				"sandbox0.ai/template-id": "default",
+				"sandbox0.ai/pool-type":   "idle",
+			},
+		},
+	}
+	if requests := reconciler.requestsForManagedDataPlanePod(context.Background(), sandboxPod); len(requests) != 0 {
+		t.Fatalf("runtime sandbox Pod mapped to reconcile requests: %#v", requests)
+	}
+
+	ctldPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "sandbox0-system",
+			Name:      "fullmode-ctld-a-node",
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "sandbox0infra-operator",
+				"app.kubernetes.io/component":  "ctld",
+				"app.kubernetes.io/instance":   "fullmode",
+			},
+		},
+	}
+	requests := reconciler.requestsForManagedDataPlanePod(context.Background(), ctldPod)
+	if len(requests) != 1 || requests[0].NamespacedName != (types.NamespacedName{Namespace: "sandbox0-system", Name: "fullmode"}) {
+		t.Fatalf("ctld Pod mapped to unexpected reconcile requests: %#v", requests)
 	}
 }

--- a/infra-operator/internal/controller/steps_test.go
+++ b/infra-operator/internal/controller/steps_test.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"testing"
 
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -104,37 +103,5 @@ func TestRunStepsErrorStopsAndSetsCondition(t *testing.T) {
 		if status != metav1.ConditionFalse {
 			t.Fatalf("expected condition status false, got %v", status)
 		}
-	}
-}
-
-func TestIsReadyPod(t *testing.T) {
-	readyPod := &corev1.Pod{
-		Status: corev1.PodStatus{
-			Phase: corev1.PodRunning,
-			Conditions: []corev1.PodCondition{
-				{
-					Type:   corev1.PodReady,
-					Status: corev1.ConditionTrue,
-				},
-			},
-		},
-	}
-	if !isReadyPod(readyPod) {
-		t.Fatalf("expected running ready pod to be reported as ready")
-	}
-
-	notReadyPod := &corev1.Pod{
-		Status: corev1.PodStatus{
-			Phase: corev1.PodPending,
-			Conditions: []corev1.PodCondition{
-				{
-					Type:   corev1.PodReady,
-					Status: corev1.ConditionFalse,
-				},
-			},
-		},
-	}
-	if isReadyPod(notReadyPod) {
-		t.Fatalf("expected pending pod to be reported as not ready")
 	}
 }

--- a/infra-operator/internal/plan/plan.go
+++ b/infra-operator/internal/plan/plan.go
@@ -1064,7 +1064,8 @@ func compileWorkflowPlan(compiled *InfraPlan) WorkflowPlan {
 	}
 	if compiled.Components.EnableManager {
 		appendCheckStep("data-plane-node-readiness", infrav1alpha1.ConditionTypeManagerReady, "DataPlaneNodesNotReady")
-		appendCheckStep("builtin-template-pods", infrav1alpha1.ConditionTypeManagerReady, "BuiltinTemplatePodsNotReady")
+		// Live template pool capacity is reconciled by manager and may
+		// legitimately dip below minIdle while sandboxes are being claimed.
 	}
 	if compiled.Components.EnableClusterRegistration {
 		appendSuccessStep("register-cluster", infrav1alpha1.ConditionTypeClusterRegistered, "ClusterRegistered", "Cluster registration completed", "ClusterRegistrationFailed")

--- a/infra-operator/internal/plan/plan_test.go
+++ b/infra-operator/internal/plan/plan_test.go
@@ -1218,7 +1218,6 @@ func TestCompileTracksWorkflowRequirements(t *testing.T) {
 		"ctld-ready",
 		"network-ready",
 		"data-plane-node-readiness",
-		"builtin-template-pods",
 		"register-cluster",
 	}
 	if len(got) != len(want) {

--- a/tests/e2e/cases/api_mountpoint_s3_compat.go
+++ b/tests/e2e/cases/api_mountpoint_s3_compat.go
@@ -569,13 +569,13 @@ fi
 func assertMountpointS3Overwrite(env *framework.ScenarioEnv, namespace, podName string, store objectstore.Store) {
 	By("overwriting existing S3 objects through truncate semantics")
 	putMountpointS3Object(store, "write-lifecycle/truncate.txt", "before-truncate")
-	runMountpointS3Script(env, namespace, podName, fmt.Sprintf(`
+	waitMountpointS3Script(env, namespace, podName, fmt.Sprintf(`
 set -eu
 M=%s
 file="$M/write-lifecycle/truncate.txt"
 : > "$file"
 sync
-	`, shellQuote(mountpointS3MountPath)))
+	`, shellQuote(mountpointS3MountPath)), 30*time.Second)
 	expectMountpointS3ObjectEventually(store, "write-lifecycle/truncate.txt", []byte(""))
 	waitMountpointS3Script(env, namespace, podName, fmt.Sprintf(`
 set -eu


### PR DESCRIPTION
## Summary

- remove the live builtin-template Pod count from the `Sandbox0Infra` readiness workflow so transient `minIdle` deficits remain manager-owned runtime state
- restrict infra-operator's controller-runtime Pod cache to Pods labeled `app.kubernetes.io/managed-by=sandbox0infra-operator`, while retaining the ctld Pod watch required for HA rollout readiness
- ignore status-only `Sandbox0Infra` updates while still reconciling spec generation changes and deletion timestamps
- remove namespace-wide Event diagnostics while retaining the Event RBAC needed to create manager's delegated ClusterRole
- retry the mountpoint-s3 external-object truncate probe while a transient reader conflict clears

## Root cause

infra-operator was not on the synchronous claim path, but it still cached cluster-wide Pods and periodically listed builtin-template Pods and namespace Events. During high sandbox churn, changing pool-readiness errors were projected into `Sandbox0Infra.status`, which could immediately enqueue another full reconciliation and push the 128 MiB operator over its memory limit.

Warm-pool capacity is maintained and reported by manager. A temporary drop below `minIdle` after successful claims is expected runtime behavior and must not mark infrastructure reconciliation as failed.

The operator must retain Event permissions because it creates the manager ClusterRole containing those delegated permissions. It no longer watches or lists Events itself.

## Impact

- runtime sandbox Pod churn no longer enters infra-operator's Pod cache or readiness workflow
- `Sandbox0Infra` readiness remains tied to infrastructure components, ctld, networking, storage, and data-plane node readiness
- manager remains the sole controller for SandboxTemplate pool capacity and replenishment
- transient mountpoint-s3 reader-handle conflicts no longer make the overwrite compatibility probe flaky; persistent conflicts still fail after 30 seconds

## Validation

- `GOTOOLCHAIN=go1.25.0+auto go test -race -cover ./infra-operator/...`
- `GOTOOLCHAIN=go1.25.0+auto go vet ./infra-operator/...`
- `GOTOOLCHAIN=go1.25.0+auto go test ./tests/e2e/cases`
- `GOFLAGS=-buildvcs=false golangci-lint run ./...`
- `make proto manifests apispec`
- `go mod tidy`
- `helm lint infra-operator/chart`
- Aliyun Singapore remote kind environment:
  - clean fullmode deployment reached `Ready 10/10`
  - both ctld A/B DaemonSets reached `2/2 Ready`
  - admin login, default-template claim, Pod readiness, delete, and idle Pod replenishment succeeded
  - during claim/delete Pod churn, infra-operator reconciliation remained on the approximately 30-second periodic cadence rather than being immediately re-enqueued
  - infra-operator had 0 restarts and `VmRSS`/`VmHWM` of 58,748 kB with the existing 128 MiB limit
- PR CI:
  - quick check passed
  - core, mountpoint-s3, and s0fs-posix E2E passed
  - kindnet, flannel, canal, and cilium-native-host-legacy E2E passed
  - release package metadata and infra checks passed
