### PR TITLE
Fix metering boundaries for hot claims and memory resize

### DIFF
--- a/manager/pkg/metering/lifecycle_projector.go
+++ b/manager/pkg/metering/lifecycle_projector.go
@@ -146,7 +146,13 @@ func (p *LifecycleProjector) handleUpdate(oldObj, newObj any) {
 	oldPod := extractPod(oldObj)
 	newPod := extractPod(newObj)
 	if isTeamOwnedIdlePoolPod(oldPod) && !isTeamOwnedIdlePoolPod(newPod) {
-		p.handleWarmPoolDelete(oldPod)
+		transitionAt := time.Time{}
+		if isClaimedActiveSandbox(newPod) {
+			// ClaimedAt is also the active runtime start, so use it as the
+			// shared boundary instead of charging the warm pool until observation.
+			transitionAt, _ = parseRFC3339(newPod.Annotations[controller.AnnotationClaimedAt])
+		}
+		p.handleWarmPoolDeleteAt(oldPod, transitionAt)
 	}
 	// Warm-pool updates advance runtime windows, so they intentionally keep the
 	// resync behavior. Claimed sandboxes only need a projection write when an
@@ -257,6 +263,15 @@ func (p *LifecycleProjector) handleUpsert(obj any) {
 			LastResourceVer:   pod.ResourceVersion,
 		}
 		pendingEvents = append(pendingEvents, p.buildSandboxEvent(sandboxID, teamID, userID, templateID, claimedAt, meteringpkg.EventTypeSandboxClaimed, claimedEventID(sandboxID, claimedAt), claimEventData(pod)))
+	}
+
+	// Close the prior allocation before replacing it so elapsed runtime keeps
+	// the memory size that was actually active during that interval.
+	if !paused && !state.Paused && state.ActiveSince != nil &&
+		state.ResourceMemoryMiB != podUsage.ResourceMemoryMiB &&
+		observedAt.After(*state.ActiveSince) {
+		pendingWindows = append(pendingWindows, p.buildSandboxRuntimeWindow(state, teamID, userID, templateID, state.ActiveSince, observedAt))
+		state.ActiveSince = ptrTime(observedAt)
 	}
 
 	if paused {
@@ -502,6 +517,10 @@ func (p *LifecycleProjector) handleWarmPoolUpsert(pod *corev1.Pod) {
 }
 
 func (p *LifecycleProjector) handleWarmPoolDelete(pod *corev1.Pod) {
+	p.handleWarmPoolDeleteAt(pod, time.Time{})
+}
+
+func (p *LifecycleProjector) handleWarmPoolDeleteAt(pod *corev1.Pod, endedAt time.Time) {
 	stateID := warmPoolMeteringIDFromPod(pod)
 	if stateID == "" {
 		return
@@ -518,6 +537,9 @@ func (p *LifecycleProjector) handleWarmPoolDelete(pod *corev1.Pod) {
 	}
 
 	observedAt := p.now()
+	if endedAt.IsZero() {
+		endedAt = observedAt
+	}
 	teamID := pod.Annotations[controller.AnnotationTeamID]
 	userID := pod.Annotations[controller.AnnotationUserID]
 	templateID := pod.Labels[controller.LabelTemplateID]
@@ -541,7 +563,7 @@ func (p *LifecycleProjector) handleWarmPoolDelete(pod *corev1.Pod) {
 	}
 
 	pendingWindows := []*meteringpkg.Window{
-		p.buildWarmPoolRuntimeWindow(state, teamID, userID, templateID, state.ActiveSince, observedAt, pod),
+		p.buildWarmPoolRuntimeWindow(state, teamID, userID, templateID, state.ActiveSince, endedAt, pod),
 	}
 	state.Namespace = pod.Namespace
 	state.TeamID = teamID
@@ -553,7 +575,7 @@ func (p *LifecycleProjector) handleWarmPoolDelete(pod *corev1.Pod) {
 	state.ResourceMemoryMiB = podUsage.ResourceMemoryMiB
 	state.ActiveSince = nil
 	state.Paused = false
-	state.TerminatedAt = &observedAt
+	state.TerminatedAt = &endedAt
 	state.LastObservedAt = observedAt
 	state.LastResourceVer = pod.ResourceVersion
 

--- a/manager/pkg/metering/lifecycle_projector_test.go
+++ b/manager/pkg/metering/lifecycle_projector_test.go
@@ -218,9 +218,12 @@ func TestLifecycleProjectorPersistsMeteringRelevantSandboxUpdates(t *testing.T) 
 	recorder := &fakeRecorder{states: map[string]*meteringpkg.SandboxProjectionState{}}
 	projector := NewLifecycleProjector(recorder, "aws-us-east-1", "cluster-a")
 	claimedAt := time.Date(2026, 3, 12, 10, 0, 0, 0, time.UTC)
+	projector.now = func() time.Time { return claimedAt }
 	oldPod := withSandboxResources(buildSandboxPod(claimedAt, false, "", "1"), "1", "1Gi")
 	projector.handleUpsert(oldPod)
 
+	resizedAt := claimedAt.Add(10 * time.Minute)
+	projector.now = func() time.Time { return resizedAt }
 	newPod := withSandboxResources(oldPod.DeepCopy(), "2", "2Gi")
 	newPod.ResourceVersion = "2"
 	projector.handleUpdate(oldPod, newPod)
@@ -231,6 +234,30 @@ func TestLifecycleProjectorPersistsMeteringRelevantSandboxUpdates(t *testing.T) 
 	state := recorder.states["sb-1"]
 	if state == nil || state.ResourceMillicpu != 2000 || state.ResourceMemoryMiB != 2048 || state.LastResourceVer != "2" {
 		t.Fatalf("state after resource update = %#v", state)
+	}
+	if state.ActiveSince == nil || !state.ActiveSince.Equal(resizedAt) {
+		t.Fatalf("active_since after resource update = %v, want %v", state.ActiveSince, resizedAt)
+	}
+	if len(recorder.windows) != 1 {
+		t.Fatalf("window count after resource update = %d, want 1", len(recorder.windows))
+	}
+	if window := recorder.windows[0]; !window.WindowStart.Equal(claimedAt) || !window.WindowEnd.Equal(resizedAt) || window.Value != 614_400_000 {
+		t.Fatalf("pre-resize runtime window = %#v", window)
+	}
+
+	pausedAt := resizedAt.Add(10 * time.Minute)
+	projector.now = func() time.Time { return pausedAt }
+	pausedPod := withSandboxResources(newPod.DeepCopy(), "2", "2Gi")
+	pausedPod.ResourceVersion = "3"
+	pausedPod.Annotations[controller.AnnotationPaused] = "true"
+	pausedPod.Annotations[controller.AnnotationPausedAt] = pausedAt.Format(time.RFC3339)
+	projector.handleUpdate(newPod, pausedPod)
+
+	if len(recorder.windows) != 2 {
+		t.Fatalf("window count after pause = %d, want 2", len(recorder.windows))
+	}
+	if window := recorder.windows[1]; !window.WindowStart.Equal(resizedAt) || !window.WindowEnd.Equal(pausedAt) || window.Value != 1_228_800_000 {
+		t.Fatalf("post-resize runtime window = %#v", window)
 	}
 }
 
@@ -518,7 +545,8 @@ func TestLifecycleProjectorClosesTeamWarmPoolWhenClaimed(t *testing.T) {
 	projector.handleUpsert(idlePod)
 
 	claimedAt := createdAt.Add(5 * time.Minute)
-	projector.now = func() time.Time { return claimedAt }
+	claimObservedAt := claimedAt.Add(3 * time.Second)
+	projector.now = func() time.Time { return claimObservedAt }
 	activePod := withSandboxResources(buildSandboxPod(claimedAt, false, "", "2"), "2", "1Gi")
 	activePod.Name = idlePod.Name
 	activePod.Namespace = idlePod.Namespace
@@ -536,13 +564,20 @@ func TestLifecycleProjectorClosesTeamWarmPoolWhenClaimed(t *testing.T) {
 	if finalWarmPoolWindow.Value != 184_320_000 {
 		t.Fatalf("final warm pool value = %d, want 184320000", finalWarmPoolWindow.Value)
 	}
+	if !finalWarmPoolWindow.WindowEnd.Equal(claimedAt) {
+		t.Fatalf("final warm pool end = %v, want claim time %v", finalWarmPoolWindow.WindowEnd, claimedAt)
+	}
 
 	warmPoolState := recorder.states["warm-pool/pod-uid-1"]
 	if warmPoolState == nil || warmPoolState.ActiveSince != nil || warmPoolState.TerminatedAt == nil || !warmPoolState.TerminatedAt.Equal(claimedAt) {
 		t.Fatalf("warm pool state after claim = %#v, want closed at %v", warmPoolState, claimedAt)
 	}
-	if recorder.states["sb-1"] == nil {
-		t.Fatalf("active sandbox projection state was not created")
+	if !warmPoolState.LastObservedAt.Equal(claimObservedAt) {
+		t.Fatalf("warm pool last_observed_at = %v, want %v", warmPoolState.LastObservedAt, claimObservedAt)
+	}
+	activeState := recorder.states["sb-1"]
+	if activeState == nil || activeState.ActiveSince == nil || !activeState.ActiveSince.Equal(claimedAt) {
+		t.Fatalf("active sandbox state = %#v, want active_since %v", activeState, claimedAt)
 	}
 }
 


### PR DESCRIPTION
## What

- close a team warm-pool window at the claimed sandbox `claimed_at` boundary while retaining the actual observation time for producer watermarks
- close the current active runtime window before applying a changed memory allocation, then continue metering from the resize observation time
- add regressions for delayed hot-claim observation and pre/post-resize MiB-ms values

## Why

The warm-pool projector previously ended idle usage at informer observation time while active usage began at `claimed_at`, which could charge both states for the observation delay. Active memory updates also replaced projection state without closing the prior allocation, so a later window could attribute elapsed runtime to the newest memory size.

## Impact

This changes only metering window boundaries. It does not change the sandbox or template API. Hot claims now have one shared idle/active boundary, and running memory allocations retain their own MiB-ms segments.

## Checks

- `go test ./manager/pkg/metering ./manager/pkg/service ./manager/pkg/apis/sandbox0/v1alpha1 -count=1`
- `go test ./manager/pkg/metering -count=20`
- remote persistent kind environment: `go test ./manager/... -count=1`
- remote hot claim reused the same Pod UID; the idle Pod limit was `128Mi`, and PostgreSQL plus ClickHouse reported `warm_end == active_start == claimed_at` with a 0 ms gap
- remote running resize `1Gi -> 2Gi -> 3Gi` produced distinct 1024/2048/3072 MiB windows; every exported value equaled `memory_mib * duration_ms`
- verified the same windows through PostgreSQL outbox, ClickHouse projection, and `/internal/v1/metering/windows`
- removed remote test resources and stopped the ECS instance in `StopCharging` mode