### PR TITLE
feat: add team-scoped usage windows API

### DIFF
--- a/cluster-gateway/pkg/http/server.go
+++ b/cluster-gateway/pkg/http/server.go
@@ -559,6 +559,11 @@ func (s *Server) setupRoutes() {
 			quotas.GET("/:dimension", s.authMiddleware.RequirePermission(gatewayauthn.PermQuotaRead), s.proxyToManager)
 		}
 
+		usage := v1.Group("/usage")
+		{
+			usage.GET("/windows", s.authMiddleware.RequirePermission(gatewayauthn.PermUsageRead), s.meteringHandler.ListUsageWindows)
+		}
+
 		rootFSSnapshots := v1.Group("/sandbox-rootfs-snapshots")
 		rootFSSnapshots.Use(s.managerUpstreamMiddleware())
 		{

--- a/cluster-gateway/pkg/http/server_metering_routes_test.go
+++ b/cluster-gateway/pkg/http/server_metering_routes_test.go
@@ -442,6 +442,33 @@ func TestSetupRoutesExposesQuotaReadOnlyPublicAPI(t *testing.T) {
 	}
 }
 
+func TestSetupRoutesExposesTenantScopedUsageAPI(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	server, _, issuer := testMeteringRouteServer(t, "public")
+	server.requestLogger = middleware.NewRequestLogger(zap.NewNop())
+	server.obsProvider = newTestMeteringObservability(t)
+	server.setupRoutes()
+
+	if !hasRoute(server.router, "GET", "/api/v1/usage/windows") {
+		t.Fatal("expected public usage windows route")
+	}
+
+	tokens, err := issuer.IssueTokenPair("user-1", "user@example.com", "User", false, []authn.TeamGrant{{TeamID: "team-1", TeamRole: "viewer"}})
+	if err != nil {
+		t.Fatalf("issue token pair: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/usage/windows", nil)
+	req.Header.Set("Authorization", "Bearer "+tokens.AccessToken)
+	req.Header.Set(internalauth.TeamIDHeader, "team-1")
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+	}
+}
+
 func TestSetupMeteringRoutesDoesNotRequireManagerUpstream(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/docs/self-hosted/quotas/page.mdx
+++ b/docs/self-hosted/quotas/page.mdx
@@ -103,6 +103,32 @@ Capacity statuses include `current` and `remaining`. Rate statuses include
 `interval_ms` and `burst_value`; `current` and `remaining` are `null` because
 Redis token state is transient admission state, not cumulative usage.
 
+## Read Cumulative Usage
+
+Use the official SDK usage resource when a separate product needs cumulative
+usage. `client.usage.listWindows()` calls
+`GET /api/v1/usage/windows`, which derives the team from the authenticated
+token and requires `usage:read`.
+
+```ts
+const page = await client.usage.listWindows({
+    cursor,
+    limit: 1000,
+    windowType: "sandbox.runtime_mib_milliseconds",
+});
+```
+
+The response contains immutable, closed windows and an opaque `nextCursor`.
+Persist the cursor only after the page is durably consumed. The public response
+omits producer-only team, user, and raw event data. It is served by the
+configured ClickHouse metering projection and returns `503` when that query
+backend is disabled or unavailable.
+
+This SDK endpoint is the supported boundary for separate products. Do not give
+them ClickHouse credentials, a Sandbox0 PostgreSQL connection, or access to
+`/internal/v1/metering/*`; those internal endpoints remain region-operator
+export and diagnosis surfaces.
+
 ## Metering Boundary
 
 Raw `sandbox.egress_bytes` and `sandbox.ingress_bytes` metering remains

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -23,6 +23,8 @@ tags:
   - name: sandbox-volumes
   - name: snapshots
   - name: sandbox-rootfs
+  - name: quotas
+  - name: usage
 paths:
   /healthz:
     get:
@@ -1366,6 +1368,67 @@ paths:
                 $ref: "#/components/schemas/SuccessTeamQuotaResponse"
         "400":
           description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+  /api/v1/usage/windows:
+    get:
+      tags: [usage]
+      summary: List usage windows for the current team
+      description: |
+        Returns immutable, closed usage windows belonging to the authenticated
+        team. The opaque cursor can be retained and reused to incrementally
+        import newly recorded windows.
+      security:
+        - bearerAuth: []
+      x-required-permission: usage:read
+      parameters:
+        - name: cursor
+          in: query
+          description: Opaque pagination cursor returned by a previous response.
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: Maximum number of windows to return. Values above 1000 are capped.
+          schema:
+            type: integer
+            default: 100
+            minimum: 1
+            maximum: 1000
+        - name: window_type
+          in: query
+          description: Return only windows with this exact usage type.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Team usage windows
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessUsageWindowsResponse"
+        "400":
+          description: Invalid cursor, limit, or team context
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "401":
+          description: Missing or invalid authentication
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "403":
+          description: Missing usage read permission
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "503":
+          description: Usage query backend is unavailable
           content:
             application/json:
               schema:
@@ -3902,6 +3965,67 @@ components:
           properties:
             data:
               $ref: "#/components/schemas/TeamQuota"
+    UsageWindow:
+      type: object
+      properties:
+        window_id:
+          type: string
+        region_id:
+          type: string
+        cluster_id:
+          type: string
+        window_type:
+          type: string
+        subject_type:
+          type: string
+        subject_id:
+          type: string
+        sandbox_id:
+          type: string
+        window_start:
+          type: string
+          format: date-time
+        window_end:
+          type: string
+          format: date-time
+        value:
+          type: integer
+          format: int64
+          minimum: 0
+        unit:
+          type: string
+        recorded_at:
+          type: string
+          format: date-time
+      required:
+        - window_id
+        - window_type
+        - subject_type
+        - subject_id
+        - window_start
+        - window_end
+        - value
+        - unit
+        - recorded_at
+    UsageWindowPage:
+      type: object
+      properties:
+        windows:
+          type: array
+          items:
+            $ref: "#/components/schemas/UsageWindow"
+        next_cursor:
+          type: string
+      required:
+        - windows
+        - next_cursor
+    SuccessUsageWindowsResponse:
+      allOf:
+        - $ref: "#/components/schemas/SuccessEnvelope"
+        - type: object
+          properties:
+            data:
+              $ref: "#/components/schemas/UsageWindowPage"
     QuotaDimension:
       type: string
       enum:

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -727,6 +727,11 @@ const (
 	SuccessTemplateResponseSuccessTrue SuccessTemplateResponseSuccess = true
 )
 
+// Defines values for SuccessUsageWindowsResponseSuccess.
+const (
+	SuccessUsageWindowsResponseSuccessTrue SuccessUsageWindowsResponseSuccess = true
+)
+
 // Defines values for SuccessUserResponseSuccess.
 const (
 	SuccessUserResponseSuccessTrue SuccessUserResponseSuccess = true
@@ -739,7 +744,7 @@ const (
 
 // Defines values for SuccessWrittenResponseSuccess.
 const (
-	SuccessWrittenResponseSuccessTrue SuccessWrittenResponseSuccess = true
+	True SuccessWrittenResponseSuccess = true
 )
 
 // Defines values for TeamQuotaKind.
@@ -3374,6 +3379,15 @@ type SuccessTemplateResponse struct {
 // SuccessTemplateResponseSuccess defines model for SuccessTemplateResponse.Success.
 type SuccessTemplateResponseSuccess bool
 
+// SuccessUsageWindowsResponse defines model for SuccessUsageWindowsResponse.
+type SuccessUsageWindowsResponse struct {
+	Data    *UsageWindowPage                   `json:"data,omitempty"`
+	Success SuccessUsageWindowsResponseSuccess `json:"success"`
+}
+
+// SuccessUsageWindowsResponseSuccess defines model for SuccessUsageWindowsResponse.Success.
+type SuccessUsageWindowsResponseSuccess bool
+
 // SuccessUserResponse defines model for SuccessUserResponse.
 type SuccessUserResponse struct {
 	Data    *User                      `json:"data,omitempty"`
@@ -3624,6 +3638,28 @@ type UpdateTeamRequest struct {
 type UpdateUserRequest struct {
 	AvatarUrl *string `json:"avatar_url,omitempty"`
 	Name      *string `json:"name,omitempty"`
+}
+
+// UsageWindow defines model for UsageWindow.
+type UsageWindow struct {
+	ClusterId   *string   `json:"cluster_id,omitempty"`
+	RecordedAt  time.Time `json:"recorded_at"`
+	RegionId    *string   `json:"region_id,omitempty"`
+	SandboxId   *string   `json:"sandbox_id,omitempty"`
+	SubjectId   string    `json:"subject_id"`
+	SubjectType string    `json:"subject_type"`
+	Unit        string    `json:"unit"`
+	Value       int64     `json:"value"`
+	WindowEnd   time.Time `json:"window_end"`
+	WindowId    string    `json:"window_id"`
+	WindowStart time.Time `json:"window_start"`
+	WindowType  string    `json:"window_type"`
+}
+
+// UsageWindowPage defines model for UsageWindowPage.
+type UsageWindowPage struct {
+	NextCursor string        `json:"next_cursor"`
+	Windows    []UsageWindow `json:"windows"`
 }
 
 // User defines model for User.
@@ -3919,6 +3955,18 @@ type GetApiV1SandboxvolumesIdFilesStatParams struct {
 type PostApiV1TemplatesFromSandboxParams struct {
 	// IdempotencyKey Optional key for retrying creation without starting a duplicate image build.
 	IdempotencyKey *string `json:"Idempotency-Key,omitempty"`
+}
+
+// GetApiV1UsageWindowsParams defines parameters for GetApiV1UsageWindows.
+type GetApiV1UsageWindowsParams struct {
+	// Cursor Opaque pagination cursor returned by a previous response.
+	Cursor *string `form:"cursor,omitempty" json:"cursor,omitempty"`
+
+	// Limit Maximum number of windows to return. Values above 1000 are capped.
+	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// WindowType Return only windows with this exact usage type.
+	WindowType *string `form:"window_type,omitempty" json:"window_type,omitempty"`
 }
 
 // GetAuthOidcProviderCallbackParams defines parameters for GetAuthOidcProviderCallback.

--- a/pkg/gateway/authn/context.go
+++ b/pkg/gateway/authn/context.go
@@ -105,6 +105,7 @@ const (
 	PermSandboxVolumeFileWrite = "sandboxvolumefile:write"
 
 	PermQuotaRead = "quota:read"
+	PermUsageRead = "usage:read"
 
 	PermSandboxObservabilityWrite = "sandboxobservability:write"
 	PermSandboxAuditRead          = "sandboxaudit:read"
@@ -133,6 +134,7 @@ var RolePermissions = map[string][]string{
 		PermSandboxVolumeFileRead,
 		PermSandboxVolumeFileWrite,
 		PermQuotaRead,
+		PermUsageRead,
 		PermSandboxAuditRead,
 	},
 	"developer": {
@@ -152,6 +154,7 @@ var RolePermissions = map[string][]string{
 		PermSandboxVolumeFileRead,
 		PermSandboxVolumeFileWrite,
 		PermQuotaRead,
+		PermUsageRead,
 	},
 	"builder": {
 		PermTemplateRead,
@@ -164,6 +167,7 @@ var RolePermissions = map[string][]string{
 		PermSandboxVolumeRead,
 		PermSandboxVolumeFileRead,
 		PermQuotaRead,
+		PermUsageRead,
 	},
 }
 

--- a/pkg/gateway/authn/context_test.go
+++ b/pkg/gateway/authn/context_test.go
@@ -73,6 +73,27 @@ func TestRolePermissionsIncludeAPIKeyManageForAdminsOnly(t *testing.T) {
 	}
 }
 
+func TestRolePermissionsIncludeUsageRead(t *testing.T) {
+	tests := []struct {
+		role string
+		want bool
+	}{
+		{role: "admin", want: true},
+		{role: "developer", want: true},
+		{role: "builder", want: false},
+		{role: "viewer", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.role, func(t *testing.T) {
+			permissions := ExpandRolePermissions(tt.role)
+			if got := containsPermission(permissions, PermUsageRead); got != tt.want {
+				t.Fatalf("usage read permission = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func containsPermission(permissions []string, target string) bool {
 	for _, permission := range permissions {
 		if permission == target {

--- a/pkg/gateway/http/handlers/usage.go
+++ b/pkg/gateway/http/handlers/usage.go
@@ -1,0 +1,98 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/authn"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
+	"github.com/sandbox0-ai/sandbox0/pkg/metering"
+	"go.uber.org/zap"
+)
+
+// UsageWindowReader defines the team-scoped usage query exposed publicly.
+type UsageWindowReader interface {
+	ListTeamWindows(ctx context.Context, teamID string, windowType string, cursor string, limit int) ([]*metering.Window, string, error)
+}
+
+// UsageWindow is the stable public representation of a metering window.
+type UsageWindow struct {
+	WindowID    string    `json:"window_id"`
+	RegionID    string    `json:"region_id,omitempty"`
+	ClusterID   string    `json:"cluster_id,omitempty"`
+	WindowType  string    `json:"window_type"`
+	SubjectType string    `json:"subject_type"`
+	SubjectID   string    `json:"subject_id"`
+	SandboxID   string    `json:"sandbox_id,omitempty"`
+	WindowStart time.Time `json:"window_start"`
+	WindowEnd   time.Time `json:"window_end"`
+	Value       int64     `json:"value"`
+	Unit        string    `json:"unit"`
+	RecordedAt  time.Time `json:"recorded_at"`
+}
+
+// ListUsageWindows returns usage windows belonging to the authenticated team.
+func (h *MeteringHandler) ListUsageWindows(c *gin.Context) {
+	reader, ok := h.repo.(UsageWindowReader)
+	if h.repo == nil || !ok {
+		spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "usage is unavailable")
+		return
+	}
+
+	authCtx := authn.FromContext(c.Request.Context())
+	if authCtx == nil {
+		spec.JSONError(c, http.StatusUnauthorized, spec.CodeUnauthorized, "missing authentication")
+		return
+	}
+	teamID := strings.TrimSpace(authCtx.TeamID)
+	if teamID == "" {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "team_id is required")
+		return
+	}
+
+	cursor, limit, parsed := parseMeteringCursor(c)
+	if !parsed {
+		return
+	}
+	windowType := strings.TrimSpace(c.Query("window_type"))
+
+	windows, nextCursor, err := reader.ListTeamWindows(c.Request.Context(), teamID, windowType, cursor, limit)
+	if err != nil {
+		h.logger.Error("Failed to list usage windows", zap.Error(err), zap.String("team_id", teamID))
+		if strings.Contains(err.Error(), "invalid cursor") {
+			spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "invalid cursor")
+			return
+		}
+		spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "usage is unavailable")
+		return
+	}
+
+	publicWindows := make([]UsageWindow, 0, len(windows))
+	for _, window := range windows {
+		if window == nil {
+			continue
+		}
+		publicWindows = append(publicWindows, UsageWindow{
+			WindowID:    window.WindowID,
+			RegionID:    window.RegionID,
+			ClusterID:   window.ClusterID,
+			WindowType:  window.WindowType,
+			SubjectType: window.SubjectType,
+			SubjectID:   window.SubjectID,
+			SandboxID:   window.SandboxID,
+			WindowStart: window.WindowStart,
+			WindowEnd:   window.WindowEnd,
+			Value:       window.Value,
+			Unit:        window.Unit,
+			RecordedAt:  window.RecordedAt,
+		})
+	}
+
+	spec.JSONSuccess(c, http.StatusOK, gin.H{
+		"windows":     publicWindows,
+		"next_cursor": nextCursor,
+	})
+}

--- a/pkg/gateway/http/handlers/usage_test.go
+++ b/pkg/gateway/http/handlers/usage_test.go
@@ -1,0 +1,179 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/authn"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
+	"github.com/sandbox0-ai/sandbox0/pkg/metering"
+	"go.uber.org/zap"
+)
+
+type fakeUsageWindowReader struct {
+	*fakeMeteringReader
+	windows          []*metering.Window
+	err              error
+	nextCursor       string
+	gotTeamID        string
+	gotWindowType    string
+	gotCursor        string
+	gotLimit         int
+	listWindowsCalls int
+}
+
+func (f *fakeUsageWindowReader) ListTeamWindows(_ context.Context, teamID string, windowType string, cursor string, limit int) ([]*metering.Window, string, error) {
+	f.listWindowsCalls++
+	f.gotTeamID = teamID
+	f.gotWindowType = windowType
+	f.gotCursor = cursor
+	f.gotLimit = limit
+	if f.err != nil {
+		return nil, "", f.err
+	}
+	return f.windows, f.nextCursor, nil
+}
+
+type usageWindowsResponse struct {
+	Windows    []UsageWindow `json:"windows"`
+	NextCursor string        `json:"next_cursor"`
+}
+
+func TestMeteringHandlerListUsageWindowsScopesQueryToAuthenticatedTeam(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	windowStart := time.Date(2026, 7, 26, 1, 0, 0, 0, time.UTC)
+	windowEnd := windowStart.Add(time.Hour)
+	repo := &fakeUsageWindowReader{
+		fakeMeteringReader: &fakeMeteringReader{},
+		nextCursor:         "next-page",
+		windows: []*metering.Window{{
+			WindowID:    "window-1",
+			RegionID:    "region-1",
+			ClusterID:   "cluster-1",
+			WindowType:  metering.WindowTypeSandboxRuntimeMiBMilliseconds,
+			SubjectType: metering.SubjectTypeSandbox,
+			SubjectID:   "sandbox-1",
+			SandboxID:   "sandbox-1",
+			TeamID:      "team-1",
+			UserID:      "sandbox0-user",
+			WindowStart: windowStart,
+			WindowEnd:   windowEnd,
+			Value:       3_686_400_000,
+			Unit:        metering.WindowUnitMiBMilliseconds,
+			RecordedAt:  windowEnd.Add(time.Second),
+			Data:        json.RawMessage(`{"internal":"not-public"}`),
+		}},
+	}
+	handler := NewMeteringHandler(repo, "", zap.NewNop())
+
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/usage/windows?cursor=page-1&limit=5000&window_type=sandbox.runtime_mib_milliseconds", nil)
+	request = request.WithContext(authn.WithAuthContext(request.Context(), &authn.AuthContext{TeamID: "team-1"}))
+	ctx.Request = request
+
+	handler.ListUsageWindows(ctx)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	if repo.gotTeamID != "team-1" {
+		t.Fatalf("team_id = %q, want team-1", repo.gotTeamID)
+	}
+	if repo.gotWindowType != metering.WindowTypeSandboxRuntimeMiBMilliseconds {
+		t.Fatalf("window_type = %q", repo.gotWindowType)
+	}
+	if repo.gotCursor != "page-1" || repo.gotLimit != 1000 {
+		t.Fatalf("pagination = (%q, %d), want (page-1, 1000)", repo.gotCursor, repo.gotLimit)
+	}
+
+	response, apiErr, err := spec.DecodeResponse[usageWindowsResponse](recorder.Body)
+	if err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if apiErr != nil {
+		t.Fatalf("unexpected api error: %+v", apiErr)
+	}
+	if len(response.Windows) != 1 || response.Windows[0].SandboxID != "sandbox-1" {
+		t.Fatalf("windows = %#v", response.Windows)
+	}
+	if response.NextCursor != "next-page" {
+		t.Fatalf("next_cursor = %q, want next-page", response.NextCursor)
+	}
+	body := recorder.Body.String()
+	for _, privateField := range []string{"team_id", "user_id", "internal"} {
+		if strings.Contains(body, privateField) {
+			t.Fatalf("public response leaked %q: %s", privateField, body)
+		}
+	}
+}
+
+func TestMeteringHandlerListUsageWindowsRejectsMissingTeam(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	repo := &fakeUsageWindowReader{fakeMeteringReader: &fakeMeteringReader{}}
+	handler := NewMeteringHandler(repo, "", zap.NewNop())
+
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/usage/windows", nil)
+	request = request.WithContext(authn.WithAuthContext(request.Context(), &authn.AuthContext{}))
+	ctx.Request = request
+
+	handler.ListUsageWindows(ctx)
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusBadRequest)
+	}
+	if repo.listWindowsCalls != 0 {
+		t.Fatal("repository was queried without a team")
+	}
+}
+
+func TestMeteringHandlerListUsageWindowsHandlesInvalidCursor(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	repo := &fakeUsageWindowReader{
+		fakeMeteringReader: &fakeMeteringReader{},
+		err:                errors.New("invalid cursor payload"),
+	}
+	handler := NewMeteringHandler(repo, "", zap.NewNop())
+
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/usage/windows?cursor=bad", nil)
+	request = request.WithContext(authn.WithAuthContext(request.Context(), &authn.AuthContext{TeamID: "team-1"}))
+	ctx.Request = request
+
+	handler.ListUsageWindows(ctx)
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusBadRequest)
+	}
+}
+
+func TestMeteringHandlerListUsageWindowsReportsUnavailableQueryBackend(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	repo := &fakeUsageWindowReader{
+		fakeMeteringReader: &fakeMeteringReader{},
+		err:                errors.New("clickhouse unavailable"),
+	}
+	handler := NewMeteringHandler(repo, "", zap.NewNop())
+
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/usage/windows", nil)
+	request = request.WithContext(authn.WithAuthContext(request.Context(), &authn.AuthContext{TeamID: "team-1"}))
+	ctx.Request = request
+
+	handler.ListUsageWindows(ctx)
+
+	if recorder.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusServiceUnavailable)
+	}
+}

--- a/pkg/metering/clickhouse/cursor_test.go
+++ b/pkg/metering/clickhouse/cursor_test.go
@@ -1,6 +1,7 @@
 package clickhouse
 
 import (
+	"reflect"
 	"testing"
 	"time"
 
@@ -37,6 +38,30 @@ func TestNextPageCursorIsEmptyForEmptyPages(t *testing.T) {
 	}
 	if cursor, err := nextWindowCursor(nil); err != nil || cursor != "" {
 		t.Fatalf("nextWindowCursor(nil) = %q, %v; want empty cursor", cursor, err)
+	}
+}
+
+func TestWindowWhereAlwaysScopesPublicQueriesToTeam(t *testing.T) {
+	recordedAt := time.Date(2026, 7, 26, 1, 2, 3, 4, time.UTC)
+	where, args := windowWhere("team-1", metering.WindowTypeSandboxRuntimeMiBMilliseconds, &pageCursor{
+		RecordedAt: recordedAt,
+		Producer:   "manager.sandbox_lifecycle",
+		ID:         "window-1",
+	})
+
+	wantWhere := "WHERE team_id = ? AND window_type = ? AND (recorded_at, producer, window_id) > (fromUnixTimestamp64Nano(?, 'UTC'), ?, ?)"
+	if where != wantWhere {
+		t.Fatalf("where = %q, want %q", where, wantWhere)
+	}
+	wantArgs := []any{
+		"team-1",
+		metering.WindowTypeSandboxRuntimeMiBMilliseconds,
+		recordedAt.UnixNano(),
+		"manager.sandbox_lifecycle",
+		"window-1",
+	}
+	if !reflect.DeepEqual(args, wantArgs) {
+		t.Fatalf("args = %#v, want %#v", args, wantArgs)
 	}
 }
 

--- a/pkg/metering/clickhouse/repository.go
+++ b/pkg/metering/clickhouse/repository.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	metering "github.com/sandbox0-ai/sandbox0/pkg/metering"
@@ -336,6 +337,19 @@ LIMIT ?
 }
 
 func (r *Repository) ListWindows(ctx context.Context, cursor string, limit int) ([]*metering.Window, string, error) {
+	return r.listWindows(ctx, "", "", cursor, limit)
+}
+
+// ListTeamWindows returns usage windows scoped to exactly one team.
+func (r *Repository) ListTeamWindows(ctx context.Context, teamID string, windowType string, cursor string, limit int) ([]*metering.Window, string, error) {
+	teamID = strings.TrimSpace(teamID)
+	if teamID == "" {
+		return nil, "", fmt.Errorf("team_id is required")
+	}
+	return r.listWindows(ctx, teamID, strings.TrimSpace(windowType), cursor, limit)
+}
+
+func (r *Repository) listWindows(ctx context.Context, teamID string, windowType string, cursor string, limit int) ([]*metering.Window, string, error) {
 	if limit <= 0 {
 		limit = 100
 	}
@@ -343,7 +357,7 @@ func (r *Repository) ListWindows(ctx context.Context, cursor string, limit int) 
 	if err != nil {
 		return nil, "", err
 	}
-	where, args := cursorWhere(decoded, "window_id")
+	where, args := windowWhere(teamID, windowType, decoded)
 	args = append(args, limit)
 	rows, err := r.db.QueryContext(ctx, fmt.Sprintf(`
 SELECT
@@ -390,6 +404,27 @@ LIMIT ?
 		return nil, "", err
 	}
 	return windows, next, nil
+}
+
+func windowWhere(teamID string, windowType string, cursor *pageCursor) (string, []any) {
+	clauses := make([]string, 0, 3)
+	args := make([]any, 0, 5)
+	if teamID != "" {
+		clauses = append(clauses, "team_id = ?")
+		args = append(args, teamID)
+	}
+	if windowType != "" {
+		clauses = append(clauses, "window_type = ?")
+		args = append(args, windowType)
+	}
+	if cursor != nil {
+		clauses = append(clauses, fmt.Sprintf("(recorded_at, producer, window_id) > (%s, ?, ?)", dateTime64NanoPlaceholder))
+		args = append(args, dateTime64NanoArg(cursor.RecordedAt), cursor.Producer, cursor.ID)
+	}
+	if len(clauses) == 0 {
+		return "", args
+	}
+	return "WHERE " + strings.Join(clauses, " AND "), args
 }
 
 func nextEventCursor(events []*metering.Event) (string, error) {

--- a/regional-gateway/pkg/http/server.go
+++ b/regional-gateway/pkg/http/server.go
@@ -316,6 +316,10 @@ func (s *Server) setupRoutes() {
 		api.Use(attachAuditCorrelation())
 		api.Use(s.rateLimiter.RateLimit())
 
+		usage := api.Group("/v1/usage")
+		usage.Use(s.requireTeamContextForTeamScopedAPI())
+		usage.GET("/windows", s.authMiddleware.RequirePermission(authn.PermUsageRead), s.meteringHandler.ListUsageWindows)
+
 		// If scheduler is enabled, route /api/v1/templates* to scheduler
 		if s.schedulerRouter != nil {
 			// Template routes go to scheduler

--- a/regional-gateway/pkg/http/server_metering_routes_test.go
+++ b/regional-gateway/pkg/http/server_metering_routes_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/authn"
 	gatewayhandlers "github.com/sandbox0-ai/sandbox0/pkg/gateway/http/handlers"
 	gatewaymiddleware "github.com/sandbox0-ai/sandbox0/pkg/gateway/middleware"
+	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+	"github.com/sandbox0-ai/sandbox0/pkg/observability"
 	"go.uber.org/zap"
 )
 
@@ -30,6 +32,44 @@ func TestSetupMeteringRoutesMountsRegionScopedEndpoints(t *testing.T) {
 	}
 	if !hasRoute(server.router, "GET", "/internal/v1/metering/windows") {
 		t.Fatal("expected metering windows route to be mounted")
+	}
+}
+
+func TestSetupRoutesExposesTeamScopedUsageAPI(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	logger := zap.NewNop()
+	obsProvider, err := observability.New(observability.Config{
+		ServiceName:    "regional-gateway-usage-test",
+		Logger:         logger,
+		DisableTracing: true,
+		DisableMetrics: true,
+		DisableLogging: true,
+		TraceExporter: observability.TraceExporterConfig{
+			Type: "noop",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create observability provider: %v", err)
+	}
+
+	server := testMeteringRouteServer()
+	server.obsProvider = obsProvider
+	server.requestLogger = gatewaymiddleware.NewRequestLogger(logger)
+	server.rateLimiter = gatewaymiddleware.NewRateLimiter(100, 200, time.Minute, logger)
+	server.setupRoutes()
+
+	tokens, err := server.jwtIssuer.IssueTokenPair("user-1", "user@example.com", "User", false, []authn.TeamGrant{{TeamID: "team-1", TeamRole: "viewer"}})
+	if err != nil {
+		t.Fatalf("issue token pair: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/usage/windows", nil)
+	req.Header.Set("Authorization", "Bearer "+tokens.AccessToken)
+	req.Header.Set(internalauth.TeamIDHeader, "team-1")
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
 	}
 }
 


### PR DESCRIPTION
## Summary

- expose immutable, closed usage windows at `GET /api/v1/usage/windows`
- derive the team scope from the authenticated request and strip private metering fields
- add `usage:read` permissions, regional/full-mode routes, ClickHouse cursor queries, OpenAPI schemas, docs, and regression tests

## Why

Independent products such as Sandpi need a supported usage export surface without access to Sandbox0 databases or internal metering endpoints. This API is the public contract consumed by the official SDKs.

## Impact

The endpoint is team-scoped, cursor-paginated, and optionally filters one exact window type. Admin, developer, and viewer roles can read usage; builder cannot.

## Validation

- `make apispec`
- `env GOWORK=off go test ./pkg/gateway/authn ./pkg/gateway/http/handlers ./pkg/metering/clickhouse ./manager/pkg/metering ./cluster-gateway/pkg/http ./regional-gateway/pkg/http`
- `git diff --check`

## Follow-up

The sdk-go, sdk-js, sdk-py, and s0 PRs consume this OpenAPI contract and should merge after this PR.
