### PR TITLE
perf: optimize burst claim and audit delivery

### DIFF
--- a/cluster-gateway/pkg/http/audit_delivery.go
+++ b/cluster-gateway/pkg/http/audit_delivery.go
@@ -11,16 +11,21 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
+	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
 	"github.com/sandbox0-ai/sandbox0/pkg/sandboxobservability"
 	"go.uber.org/zap"
 )
 
 const (
-	auditReplayInterval  = time.Second
-	auditReplayBatchSize = 500
+	auditReplayInterval        = time.Second
+	auditReplayBatchSize       = 500
+	auditCanonicalBatchWindow  = 2 * time.Millisecond
+	auditCanonicalWriterSlots  = 4
+	auditCanonicalRequestQueue = 2048
 )
 
 var (
@@ -33,6 +38,13 @@ type auditEventInserter interface {
 	InsertEvents(context.Context, []sandboxobservability.Event) error
 }
 
+type auditCanonicalCall struct {
+	event sandboxobservability.Event
+	done  chan struct{}
+	once  sync.Once
+	err   error
+}
+
 // auditDelivery is an fsync-backed delivery buffer. ClickHouse remains
 // the sole canonical store; files are removed only after ClickHouse ACKs the
 // exact signed event.
@@ -41,13 +53,27 @@ type auditDelivery struct {
 	writer          auditEventInserter
 	logger          *zap.Logger
 	verificationKey ed25519.PublicKey
+	metrics         *obsmetrics.ClusterGatewayMetrics
 	mu              sync.Mutex
 	once            sync.Once
+	started         atomic.Bool
 	wake            chan struct{}
+	canonicalQueue  chan *auditCanonicalCall
 	canonicalSlot   chan struct{}
+	canonicalGate   sync.RWMutex
+	canonicalMu     sync.Mutex
+	canonicalCalls  map[string]*auditCanonicalCall
+	foregroundCalls atomic.Int64
+	pendingCalls    atomic.Int64
 }
 
-func newAuditDelivery(dir string, writer auditEventInserter, logger *zap.Logger, verificationKey ed25519.PublicKey) (*auditDelivery, error) {
+func newAuditDelivery(
+	dir string,
+	writer auditEventInserter,
+	logger *zap.Logger,
+	verificationKey ed25519.PublicKey,
+	metrics ...*obsmetrics.ClusterGatewayMetrics,
+) (*auditDelivery, error) {
 	dir = strings.TrimSpace(dir)
 	if dir == "" {
 		return nil, fmt.Errorf("audit spool directory is required")
@@ -61,13 +87,20 @@ func newAuditDelivery(dir string, writer auditEventInserter, logger *zap.Logger,
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return nil, fmt.Errorf("create audit spool: %w", err)
 	}
+	var deliveryMetrics *obsmetrics.ClusterGatewayMetrics
+	if len(metrics) > 0 {
+		deliveryMetrics = metrics[0]
+	}
 	delivery := &auditDelivery{
 		dir:             dir,
 		writer:          writer,
 		logger:          logger,
 		verificationKey: verificationKey,
+		metrics:         deliveryMetrics,
 		wake:            make(chan struct{}, 1),
-		canonicalSlot:   make(chan struct{}, 1),
+		canonicalQueue:  make(chan *auditCanonicalCall, auditCanonicalRequestQueue),
+		canonicalSlot:   make(chan struct{}, auditCanonicalWriterSlots),
+		canonicalCalls:  make(map[string]*auditCanonicalCall),
 	}
 	if _, err := delivery.loadLocked(); err != nil {
 		return nil, err
@@ -80,7 +113,9 @@ func (d *auditDelivery) Start(ctx context.Context) {
 		return
 	}
 	d.once.Do(func() {
-		go d.run(ctx)
+		d.started.Store(true)
+		go d.runCanonicalBatches(ctx)
+		go d.runReplay(ctx)
 	})
 }
 
@@ -88,7 +123,7 @@ func (d *auditDelivery) Start(ctx context.Context) {
 // spool. If the spool cannot be written, it falls back to a synchronous
 // canonical insert so an event is never accepted without durable custody.
 func (d *auditDelivery) EnqueueDurable(ctx context.Context, event sandboxobservability.Event) error {
-	spooled, err := d.spoolOrCanonical(ctx, event)
+	spooled, err := d.spoolOrCanonical(ctx, event, "durable")
 	if err != nil {
 		return err
 	}
@@ -102,18 +137,17 @@ func (d *auditDelivery) EnqueueDurable(ctx context.Context, event sandboxobserva
 // acknowledge it. A canonical failure leaves the event in the spool for replay
 // and is returned to the caller as pending.
 func (d *auditDelivery) PersistCanonical(ctx context.Context, event sandboxobservability.Event) error {
-	spooled, err := d.spoolOrCanonical(ctx, event)
+	if d == nil {
+		return fmt.Errorf("%w: audit delivery is not configured", errAuditUnrecorded)
+	}
+	d.foregroundCalls.Add(1)
+	defer d.foregroundCalls.Add(-1)
+
+	spooled, err := d.spoolOrCanonical(ctx, event, "canonical")
 	if err != nil || !spooled {
 		return err
 	}
-	if err := d.acquireCanonicalSlot(ctx); err != nil {
-		d.signalReplay()
-		return fmt.Errorf("%w: event is durably buffered but canonical delivery did not start: %v", errAuditDeliveryPending, err)
-	}
-	defer d.releaseCanonicalSlot()
 
-	// Replay may have acknowledged this exact signed event between the local
-	// fsync and acquisition of the canonical delivery slot.
 	d.mu.Lock()
 	pending, pendingErr := d.pendingLocked(event.EventID)
 	d.mu.Unlock()
@@ -124,35 +158,53 @@ func (d *auditDelivery) PersistCanonical(ctx context.Context, event sandboxobser
 	if !pending {
 		return nil
 	}
-	if err := d.writer.InsertEvents(ctx, []sandboxobservability.Event{event}); err != nil {
-		d.logger.Warn("Sandbox audit event buffered for retry", zap.String("event_id", event.EventID), zap.Error(err))
+
+	call, leader := d.joinCanonicalCall(event)
+	if leader {
+		if d.started.Load() {
+			d.observeQueueDelta(1)
+			select {
+			case d.canonicalQueue <- call:
+			case <-ctx.Done():
+				d.observeQueueDelta(-1)
+				d.completeCanonicalCall(call, d.pendingCanonicalError("canonical delivery did not enter the batch queue", ctx.Err()))
+			}
+		} else {
+			d.dispatchCanonicalBatch(ctx, []*auditCanonicalCall{call}, "foreground")
+		}
+	}
+
+	waitStarted := time.Now()
+	select {
+	case <-call.done:
+		d.observeStage("canonical", "batch_wait", waitStarted, call.err)
+		if call.err != nil {
+			d.signalReplay()
+		}
+		return call.err
+	case <-ctx.Done():
+		err := d.pendingCanonicalError("canonical delivery acknowledgement was interrupted", ctx.Err())
+		d.observeStage("canonical", "batch_wait", waitStarted, err)
 		d.signalReplay()
-		return fmt.Errorf("%w: event is durably buffered but not yet acknowledged: %v", errAuditDeliveryPending, err)
+		return err
 	}
-	d.mu.Lock()
-	removeErr := d.removeLocked(event.EventID)
-	d.mu.Unlock()
-	if removeErr != nil {
-		// The canonical insert already succeeded. Leaving the record in place can
-		// cause a duplicate retry, but the stable event ID makes that safe and is
-		// preferable to reporting a false delivery failure.
-		d.logger.Error("Canonical sandbox audit event was acknowledged but spool cleanup failed",
-			zap.String("event_id", event.EventID),
-			zap.Error(removeErr),
-		)
-	}
-	return nil
 }
 
 // spoolOrCanonical returns true when the event is in the local spool. A false,
 // nil result means the spool write failed but the canonical fallback succeeded.
-func (d *auditDelivery) spoolOrCanonical(ctx context.Context, event sandboxobservability.Event) (bool, error) {
+func (d *auditDelivery) spoolOrCanonical(
+	ctx context.Context,
+	event sandboxobservability.Event,
+	mode string,
+) (bool, error) {
 	if d == nil {
 		return false, fmt.Errorf("%w: audit delivery is not configured", errAuditUnrecorded)
 	}
+	spoolStarted := time.Now()
 	d.mu.Lock()
 	spoolErr := d.putLocked(event)
 	d.mu.Unlock()
+	d.observeStage(mode, "spool_write", spoolStarted, spoolErr)
 	if spoolErr == nil {
 		return true, nil
 	}
@@ -168,7 +220,11 @@ func (d *auditDelivery) spoolOrCanonical(ctx context.Context, event sandboxobser
 		zap.String("event_id", event.EventID),
 		zap.Error(spoolErr),
 	)
-	if canonicalErr := d.writer.InsertEvents(ctx, []sandboxobservability.Event{event}); canonicalErr != nil {
+	insertStarted := time.Now()
+	canonicalErr := d.writer.InsertEvents(ctx, []sandboxobservability.Event{event})
+	d.observeStage("fallback", "clickhouse_insert", insertStarted, canonicalErr)
+	d.observeBatchSize("fallback", 1, canonicalErr)
+	if canonicalErr != nil {
 		d.logger.Error("Sandbox audit event is unrecorded after spool and canonical delivery both failed",
 			zap.String("event_id", event.EventID),
 			zap.Error(spoolErr),
@@ -181,6 +237,210 @@ func (d *auditDelivery) spoolOrCanonical(ctx context.Context, event sandboxobser
 		zap.Error(spoolErr),
 	)
 	return false, nil
+}
+
+func (d *auditDelivery) joinCanonicalCall(event sandboxobservability.Event) (*auditCanonicalCall, bool) {
+	d.canonicalMu.Lock()
+	defer d.canonicalMu.Unlock()
+	if call := d.canonicalCalls[event.EventID]; call != nil {
+		return call, false
+	}
+	call := &auditCanonicalCall{
+		event: event,
+		done:  make(chan struct{}),
+	}
+	d.canonicalCalls[event.EventID] = call
+	d.pendingCalls.Add(1)
+	return call, true
+}
+
+func (d *auditDelivery) completeCanonicalCall(call *auditCanonicalCall, err error) {
+	if d == nil || call == nil {
+		return
+	}
+	call.once.Do(func() {
+		d.canonicalMu.Lock()
+		call.err = err
+		if d.canonicalCalls[call.event.EventID] == call {
+			delete(d.canonicalCalls, call.event.EventID)
+		}
+		close(call.done)
+		d.canonicalMu.Unlock()
+		d.pendingCalls.Add(-1)
+	})
+}
+
+func (d *auditDelivery) pendingCanonicalError(stage string, err error) error {
+	return fmt.Errorf("%w: event is durably buffered but %s: %v", errAuditDeliveryPending, stage, err)
+}
+
+func (d *auditDelivery) runCanonicalBatches(ctx context.Context) {
+	for {
+		var first *auditCanonicalCall
+		select {
+		case <-ctx.Done():
+			d.failQueuedCanonicalCalls(ctx.Err())
+			return
+		case first = <-d.canonicalQueue:
+			d.observeQueueDelta(-1)
+		}
+
+		batch := []*auditCanonicalCall{first}
+		for len(batch) < auditReplayBatchSize {
+			select {
+			case call := <-d.canonicalQueue:
+				d.observeQueueDelta(-1)
+				batch = append(batch, call)
+			default:
+				goto drained
+			}
+		}
+
+	drained:
+		if len(batch) < auditReplayBatchSize && d.foregroundCalls.Load() > 1 {
+			timer := time.NewTimer(auditCanonicalBatchWindow)
+			collecting := true
+			for collecting && len(batch) < auditReplayBatchSize {
+				select {
+				case call := <-d.canonicalQueue:
+					d.observeQueueDelta(-1)
+					batch = append(batch, call)
+				case <-timer.C:
+					collecting = false
+				case <-ctx.Done():
+					if !timer.Stop() {
+						select {
+						case <-timer.C:
+						default:
+						}
+					}
+					d.failCanonicalBatch(batch, ctx.Err())
+					d.failQueuedCanonicalCalls(ctx.Err())
+					return
+				}
+			}
+			if collecting && !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+		}
+		d.dispatchCanonicalBatch(ctx, batch, "foreground")
+	}
+}
+
+func (d *auditDelivery) failQueuedCanonicalCalls(cause error) {
+	for {
+		select {
+		case call := <-d.canonicalQueue:
+			d.observeQueueDelta(-1)
+			d.completeCanonicalCall(call, d.pendingCanonicalError("canonical delivery stopped", cause))
+		default:
+			return
+		}
+	}
+}
+
+func (d *auditDelivery) failCanonicalBatch(batch []*auditCanonicalCall, cause error) {
+	for _, call := range batch {
+		d.completeCanonicalCall(call, d.pendingCanonicalError("canonical delivery stopped", cause))
+	}
+}
+
+func (d *auditDelivery) dispatchCanonicalBatch(
+	ctx context.Context,
+	batch []*auditCanonicalCall,
+	source string,
+) {
+	if len(batch) == 0 {
+		return
+	}
+	slotStarted := time.Now()
+	d.canonicalGate.RLock()
+	if err := d.acquireCanonicalSlot(ctx); err != nil {
+		d.canonicalGate.RUnlock()
+		d.observeStage(source, "slot_wait", slotStarted, err)
+		for _, call := range batch {
+			d.completeCanonicalCall(call, d.pendingCanonicalError("canonical delivery did not start", err))
+		}
+		return
+	}
+	d.observeStage(source, "slot_wait", slotStarted, nil)
+
+	go func() {
+		defer d.canonicalGate.RUnlock()
+		defer d.releaseCanonicalSlot()
+		d.observeInFlightDelta(1)
+		defer d.observeInFlightDelta(-1)
+
+		deliveryCtx, cancel := context.WithTimeout(ctx, auditCanonicalDeliveryTimeout)
+		defer cancel()
+		d.deliverCanonicalBatch(deliveryCtx, batch, source)
+	}()
+}
+
+func (d *auditDelivery) deliverCanonicalBatch(
+	ctx context.Context,
+	batch []*auditCanonicalCall,
+	source string,
+) {
+	pending := make([]*auditCanonicalCall, 0, len(batch))
+	events := make([]sandboxobservability.Event, 0, len(batch))
+	d.mu.Lock()
+	for _, call := range batch {
+		isPending, err := d.pendingLocked(call.event.EventID)
+		if err != nil {
+			d.mu.Unlock()
+			pendingErr := d.pendingCanonicalError("durable spool inspection failed", err)
+			for _, candidate := range batch {
+				d.completeCanonicalCall(candidate, pendingErr)
+			}
+			return
+		}
+		if !isPending {
+			d.completeCanonicalCall(call, nil)
+			continue
+		}
+		pending = append(pending, call)
+		events = append(events, call.event)
+	}
+	d.mu.Unlock()
+	if len(events) == 0 {
+		return
+	}
+
+	insertStarted := time.Now()
+	insertErr := d.writer.InsertEvents(ctx, events)
+	d.observeStage(source, "clickhouse_insert", insertStarted, insertErr)
+	d.observeBatchSize(source, len(events), insertErr)
+	if insertErr != nil {
+		pendingErr := d.pendingCanonicalError("canonical storage did not acknowledge the batch", insertErr)
+		for _, call := range pending {
+			d.completeCanonicalCall(call, pendingErr)
+		}
+		d.logger.Warn("Sandbox audit batch buffered for retry",
+			zap.Int("batch_size", len(events)),
+			zap.Error(insertErr),
+		)
+		d.signalReplay()
+		return
+	}
+
+	cleanupStarted := time.Now()
+	d.mu.Lock()
+	cleanupErr := d.removeBatchLocked(events)
+	d.mu.Unlock()
+	d.observeStage(source, "spool_cleanup", cleanupStarted, cleanupErr)
+	if cleanupErr != nil {
+		d.logger.Error("Canonical sandbox audit batch was acknowledged but spool cleanup failed",
+			zap.Int("batch_size", len(events)),
+			zap.Error(cleanupErr),
+		)
+	}
+	for _, call := range pending {
+		d.completeCanonicalCall(call, nil)
+	}
 }
 
 func (d *auditDelivery) signalReplay() {
@@ -212,7 +472,7 @@ func (d *auditDelivery) releaseCanonicalSlot() {
 	<-d.canonicalSlot
 }
 
-func (d *auditDelivery) run(ctx context.Context) {
+func (d *auditDelivery) runReplay(ctx context.Context) {
 	ticker := time.NewTicker(auditReplayInterval)
 	defer ticker.Stop()
 	for {
@@ -232,10 +492,26 @@ func (d *auditDelivery) run(ctx context.Context) {
 }
 
 func (d *auditDelivery) replay(ctx context.Context) error {
+	if d.foregroundCalls.Load() > 0 || d.pendingCalls.Load() > 0 {
+		return nil
+	}
+	if !d.canonicalGate.TryLock() {
+		return nil
+	}
+	defer d.canonicalGate.Unlock()
+	if d.foregroundCalls.Load() > 0 || d.pendingCalls.Load() > 0 {
+		return nil
+	}
+
+	slotStarted := time.Now()
 	if err := d.acquireCanonicalSlot(ctx); err != nil {
+		d.observeStage("replay", "slot_wait", slotStarted, err)
 		return err
 	}
+	d.observeStage("replay", "slot_wait", slotStarted, nil)
 	defer d.releaseCanonicalSlot()
+	d.observeInFlightDelta(1)
+	defer d.observeInFlightDelta(-1)
 
 	d.mu.Lock()
 	events, err := d.loadBatchLocked(auditReplayBatchSize)
@@ -246,15 +522,23 @@ func (d *auditDelivery) replay(ctx context.Context) error {
 	if len(events) == 0 {
 		return nil
 	}
-	if err := d.writer.InsertEvents(ctx, events); err != nil {
-		return err
+	insertStarted := time.Now()
+	insertErr := d.writer.InsertEvents(ctx, events)
+	d.observeStage("replay", "clickhouse_insert", insertStarted, insertErr)
+	d.observeBatchSize("replay", len(events), insertErr)
+	if insertErr != nil {
+		return insertErr
 	}
+	cleanupStarted := time.Now()
 	d.mu.Lock()
-	if err := d.removeBatchLocked(events); err != nil {
+	cleanupErr := d.removeBatchLocked(events)
+	if cleanupErr != nil {
 		d.mu.Unlock()
-		return err
+		d.observeStage("replay", "spool_cleanup", cleanupStarted, cleanupErr)
+		return cleanupErr
 	}
 	d.mu.Unlock()
+	d.observeStage("replay", "spool_cleanup", cleanupStarted, nil)
 	if len(events) == auditReplayBatchSize {
 		// Yield the canonical slot after each batch so a strict mutation cannot
 		// be starved behind an arbitrarily large recovery backlog.
@@ -383,16 +667,6 @@ func (d *auditDelivery) loadBatchLocked(limit int) ([]sandboxobservability.Event
 	return events, nil
 }
 
-func (d *auditDelivery) removeLocked(eventID string) error {
-	if _, err := uuid.Parse(eventID); err != nil {
-		return fmt.Errorf("audit event_id is invalid")
-	}
-	if err := os.Remove(d.path(eventID)); err != nil && !os.IsNotExist(err) {
-		return err
-	}
-	return syncAuditDirectory(d.dir)
-}
-
 func (d *auditDelivery) removeBatchLocked(events []sandboxobservability.Event) error {
 	for _, event := range events {
 		if _, err := uuid.Parse(event.EventID); err != nil {
@@ -403,6 +677,49 @@ func (d *auditDelivery) removeBatchLocked(events []sandboxobservability.Event) e
 		}
 	}
 	return syncAuditDirectory(d.dir)
+}
+
+func (d *auditDelivery) observeStage(mode, stage string, started time.Time, err error) {
+	if d == nil || d.metrics == nil || d.metrics.AuditDeliveryStageDuration == nil {
+		return
+	}
+	d.metrics.AuditDeliveryStageDuration.
+		WithLabelValues(mode, stage, auditDeliveryMetricResult(err)).
+		Observe(time.Since(started).Seconds())
+}
+
+func (d *auditDelivery) observeBatchSize(source string, size int, err error) {
+	if d == nil || d.metrics == nil || d.metrics.AuditCanonicalBatchSize == nil {
+		return
+	}
+	d.metrics.AuditCanonicalBatchSize.
+		WithLabelValues(source, auditDeliveryMetricResult(err)).
+		Observe(float64(size))
+}
+
+func (d *auditDelivery) observeQueueDelta(delta float64) {
+	if d == nil || d.metrics == nil || d.metrics.AuditCanonicalQueueDepth == nil {
+		return
+	}
+	d.metrics.AuditCanonicalQueueDepth.Add(delta)
+}
+
+func (d *auditDelivery) observeInFlightDelta(delta float64) {
+	if d == nil || d.metrics == nil || d.metrics.AuditCanonicalInFlight == nil {
+		return
+	}
+	d.metrics.AuditCanonicalInFlight.Add(delta)
+}
+
+func auditDeliveryMetricResult(err error) string {
+	switch {
+	case err == nil:
+		return "success"
+	case errors.Is(err, errAuditDeliveryPending):
+		return "pending"
+	default:
+		return "error"
+	}
 }
 
 func (d *auditDelivery) path(eventID string) string {

--- a/cluster-gateway/pkg/http/audit_delivery_test.go
+++ b/cluster-gateway/pkg/http/audit_delivery_test.go
@@ -11,6 +11,10 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
+	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
 	"github.com/sandbox0-ai/sandbox0/pkg/sandboxobservability"
 	"go.uber.org/zap"
 )
@@ -214,6 +218,192 @@ func TestAuditDeliveryReplayBatchesPendingEvents(t *testing.T) {
 	}
 }
 
+func TestAuditDeliveryCoalescesForegroundCanonicalBurst(t *testing.T) {
+	dir := t.TempDir()
+	writer := &auditDeliveryWriter{}
+	delivery, err := newAuditDelivery(dir, writer, zap.NewNop(), nil)
+	if err != nil {
+		t.Fatalf("newAuditDelivery() error = %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	delivery.started.Store(true)
+	go delivery.runCanonicalBatches(ctx)
+
+	const eventCount = 32
+	events := make([]sandboxobservability.Event, 0, eventCount)
+	for range eventCount {
+		event := testAuditDeliveryEvent(t, uuid.NewString())
+		if err := delivery.EnqueueDurable(context.Background(), event); err != nil {
+			t.Fatalf("EnqueueDurable() error = %v", err)
+		}
+		events = append(events, event)
+	}
+
+	start := make(chan struct{})
+	errs := make(chan error, eventCount)
+	for _, event := range events {
+		event := event
+		go func() {
+			<-start
+			errs <- delivery.PersistCanonical(context.Background(), event)
+		}()
+	}
+	close(start)
+	for range eventCount {
+		if err := <-errs; err != nil {
+			t.Fatalf("PersistCanonical() error = %v", err)
+		}
+	}
+
+	if got := len(writer.snapshotEvents()); got != eventCount {
+		t.Fatalf("canonical events = %d, want %d", got, eventCount)
+	}
+	batched := false
+	for _, size := range writer.snapshotBatchSizes() {
+		if size > 1 {
+			batched = true
+			break
+		}
+	}
+	if !batched {
+		t.Fatalf("canonical batch sizes = %v, want at least one coalesced batch", writer.snapshotBatchSizes())
+	}
+}
+
+func TestAuditDeliveryBoundsCanonicalWriters(t *testing.T) {
+	dir := t.TempDir()
+	writer := &concurrentAuditDeliveryWriter{
+		started: make(chan struct{}, auditCanonicalWriterSlots+2),
+		release: make(chan struct{}),
+	}
+	delivery, err := newAuditDelivery(dir, writer, zap.NewNop(), nil)
+	if err != nil {
+		t.Fatalf("newAuditDelivery() error = %v", err)
+	}
+
+	const batchCount = auditCanonicalWriterSlots + 2
+	for range batchCount {
+		event := testAuditDeliveryEvent(t, uuid.NewString())
+		if err := delivery.EnqueueDurable(context.Background(), event); err != nil {
+			t.Fatalf("EnqueueDurable() error = %v", err)
+		}
+		call, leader := delivery.joinCanonicalCall(event)
+		if !leader {
+			t.Fatalf("event %s unexpectedly joined an in-flight call", event.EventID)
+		}
+		go delivery.dispatchCanonicalBatch(context.Background(), []*auditCanonicalCall{call}, "foreground")
+	}
+
+	for range auditCanonicalWriterSlots {
+		select {
+		case <-writer.started:
+		case <-time.After(time.Second):
+			t.Fatal("bounded canonical writer did not start")
+		}
+	}
+	select {
+	case <-writer.started:
+		t.Fatalf("more than %d canonical writers started concurrently", auditCanonicalWriterSlots)
+	case <-time.After(30 * time.Millisecond):
+	}
+	close(writer.release)
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if writer.maxConcurrency() == auditCanonicalWriterSlots &&
+			delivery.pendingCalls.Load() == 0 {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("max canonical writer concurrency = %d, pending calls = %d", writer.maxConcurrency(), delivery.pendingCalls.Load())
+}
+
+func TestAuditDeliveryPrioritizesForegroundOverReplay(t *testing.T) {
+	dir := t.TempDir()
+	writer := &auditDeliveryWriter{started: make(chan struct{}, 1), block: make(chan struct{})}
+	delivery, err := newAuditDelivery(dir, writer, zap.NewNop(), nil)
+	if err != nil {
+		t.Fatalf("newAuditDelivery() error = %v", err)
+	}
+	background := testAuditDeliveryEvent(t, uuid.NewString())
+	foreground := testAuditDeliveryEvent(t, uuid.NewString())
+	if err := delivery.EnqueueDurable(context.Background(), background); err != nil {
+		t.Fatalf("enqueue background event: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	delivery.started.Store(true)
+	go delivery.runCanonicalBatches(ctx)
+	foregroundDone := make(chan error, 1)
+	go func() {
+		foregroundDone <- delivery.PersistCanonical(context.Background(), foreground)
+	}()
+	select {
+	case <-writer.started:
+	case <-time.After(time.Second):
+		t.Fatal("foreground canonical insert did not start")
+	}
+
+	if err := delivery.replay(context.Background()); err != nil {
+		t.Fatalf("replay() while foreground active error = %v", err)
+	}
+	if got := len(writer.snapshotBatchSizes()); got != 0 {
+		t.Fatalf("completed batches before foreground release = %d, want 0", got)
+	}
+	close(writer.block)
+	if err := <-foregroundDone; err != nil {
+		t.Fatalf("foreground PersistCanonical() error = %v", err)
+	}
+	if err := delivery.replay(context.Background()); err != nil {
+		t.Fatalf("replay() after foreground error = %v", err)
+	}
+	batches := writer.snapshotBatchSizes()
+	if len(batches) != 2 || batches[0] != 1 || batches[1] != 1 {
+		t.Fatalf("canonical batch sizes = %v, want foreground then replay singletons", batches)
+	}
+}
+
+func TestAuditDeliveryRecordsStageAndBatchMetrics(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	metrics := obsmetrics.NewClusterGateway(registry)
+	writer := &auditDeliveryWriter{}
+	delivery, err := newAuditDelivery(t.TempDir(), writer, zap.NewNop(), nil, metrics)
+	if err != nil {
+		t.Fatalf("newAuditDelivery() error = %v", err)
+	}
+	event := testAuditDeliveryEvent(t, uuid.NewString())
+	if err := delivery.PersistCanonical(context.Background(), event); err != nil {
+		t.Fatalf("PersistCanonical() error = %v", err)
+	}
+
+	if got := testutil.ToFloat64(metrics.AuditCanonicalQueueDepth); got != 0 {
+		t.Fatalf("canonical queue depth = %v, want 0", got)
+	}
+	if got := testutil.ToFloat64(metrics.AuditCanonicalInFlight); got != 0 {
+		t.Fatalf("canonical in-flight = %v, want 0", got)
+	}
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("Gather() error = %v", err)
+	}
+	if got := histogramSampleCount(
+		families,
+		"cluster_gateway_audit_canonical_batch_size",
+		map[string]string{"source": "foreground", "result": "success"},
+	); got != 1 {
+		t.Fatalf("canonical batch metric samples = %d, want 1", got)
+	}
+	if got := histogramSampleCount(
+		families,
+		"cluster_gateway_audit_delivery_stage_duration_seconds",
+		map[string]string{"mode": "canonical", "stage": "spool_write", "result": "success"},
+	); got != 1 {
+		t.Fatalf("spool stage metric samples = %d, want 1", got)
+	}
+}
+
 func TestAuditDeliveryCanonicalWaitsForInFlightReplayWithoutDuplicate(t *testing.T) {
 	dir := t.TempDir()
 	writer := &auditDeliveryWriter{started: make(chan struct{}, 1), block: make(chan struct{})}
@@ -250,6 +440,63 @@ func TestAuditDeliveryCanonicalWaitsForInFlightReplayWithoutDuplicate(t *testing
 	if got := writer.snapshotEvents(); len(got) != 1 || got[0].EventID != event.EventID {
 		t.Fatalf("canonical events = %#v, want one copy", got)
 	}
+}
+
+type concurrentAuditDeliveryWriter struct {
+	mu      sync.Mutex
+	active  int
+	max     int
+	started chan struct{}
+	release chan struct{}
+}
+
+func (w *concurrentAuditDeliveryWriter) InsertEvents(_ context.Context, _ []sandboxobservability.Event) error {
+	w.mu.Lock()
+	w.active++
+	if w.active > w.max {
+		w.max = w.active
+	}
+	w.mu.Unlock()
+	w.started <- struct{}{}
+	<-w.release
+	w.mu.Lock()
+	w.active--
+	w.mu.Unlock()
+	return nil
+}
+
+func (w *concurrentAuditDeliveryWriter) maxConcurrency() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.max
+}
+
+func histogramSampleCount(families []*dto.MetricFamily, name string, labels map[string]string) uint64 {
+	for _, family := range families {
+		if family.GetName() != name {
+			continue
+		}
+		for _, metric := range family.Metric {
+			matched := true
+			for key, value := range labels {
+				found := false
+				for _, pair := range metric.Label {
+					if pair.GetName() == key && pair.GetValue() == value {
+						found = true
+						break
+					}
+				}
+				if !found {
+					matched = false
+					break
+				}
+			}
+			if matched && metric.Histogram != nil {
+				return metric.Histogram.GetSampleCount()
+			}
+		}
+	}
+	return 0
 }
 
 func TestAuditDeliveryFallsBackToCanonicalInsertWhenSpoolWriteFails(t *testing.T) {

--- a/cluster-gateway/pkg/http/server.go
+++ b/cluster-gateway/pkg/http/server.go
@@ -31,6 +31,7 @@ import (
 	licensinghttp "github.com/sandbox0-ai/sandbox0/pkg/licensing/http"
 	"github.com/sandbox0-ai/sandbox0/pkg/observability"
 	httpobs "github.com/sandbox0-ai/sandbox0/pkg/observability/http"
+	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
 	"github.com/sandbox0-ai/sandbox0/pkg/proxy"
 	"github.com/sandbox0-ai/sandbox0/pkg/quota"
 	"github.com/sandbox0-ai/sandbox0/pkg/sandboxobservability"
@@ -315,7 +316,14 @@ func NewServer(
 		if strings.TrimSpace(cfg.SandboxObservability.AuditSpoolDir) == "" {
 			return nil, fmt.Errorf("sandbox audit requires audit_spool_dir")
 		}
-		delivery, err = newAuditDelivery(cfg.SandboxObservability.AuditSpoolDir, auditWriter, logger, auditSigningPublicKey)
+		clusterGatewayMetrics := obsmetrics.NewClusterGateway(obsProvider.MetricsRegistryOrNil())
+		delivery, err = newAuditDelivery(
+			cfg.SandboxObservability.AuditSpoolDir,
+			auditWriter,
+			logger,
+			auditSigningPublicKey,
+			clusterGatewayMetrics,
+		)
 		if err != nil {
 			return nil, fmt.Errorf("initialize sandbox audit delivery: %w", err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,7 @@ require (
 	golang.org/x/sync v0.19.0
 	golang.org/x/sys v0.40.0
 	golang.org/x/text v0.33.0
+	golang.org/x/time v0.14.0
 	google.golang.org/grpc v1.77.0
 	google.golang.org/protobuf v1.36.10
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
@@ -204,7 +205,6 @@ require (
 	golang.org/x/exp v0.0.0-20251113190631-e25ba8c21ef6 // indirect
 	golang.org/x/mod v0.31.0 // indirect
 	golang.org/x/term v0.39.0 // indirect
-	golang.org/x/time v0.14.0 // indirect
 	golang.org/x/tools v0.40.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217 // indirect

--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -714,7 +714,7 @@ func main() {
 	}()
 
 	go func() {
-		if err := hotClaimReservationController.Run(ctx, 2); err != nil && err != context.Canceled {
+		if err := hotClaimReservationController.Run(ctx, 1); err != nil && err != context.Canceled {
 			logger.Error("Hot claim reservation controller failed", zap.Error(err))
 		}
 	}()

--- a/manager/pkg/controller/pool_manager.go
+++ b/manager/pkg/controller/pool_manager.go
@@ -64,6 +64,7 @@ const (
 	AnnotationHotClaimReservation          = "sandbox0.ai/hot-claim-reservation"
 	AnnotationHotClaimReservationState     = "sandbox0.ai/hot-claim-reservation-state"
 	AnnotationHotClaimReservedAt           = "sandbox0.ai/hot-claim-reserved-at"
+	AnnotationHotClaimReadyAt              = "sandbox0.ai/hot-claim-ready-at"
 	AnnotationTemplateSpecHash             = "sandbox0.ai/template-spec-hash"
 	AnnotationTemplateTeamID               = "sandbox0.ai/template-team-id"
 	AnnotationTemplateUserID               = "sandbox0.ai/template-user-id"

--- a/manager/pkg/service/hot_claim_reservation.go
+++ b/manager/pkg/service/hot_claim_reservation.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
 	corev1 "k8s.io/api/core/v1"
@@ -75,6 +76,7 @@ func (s *SandboxService) markHotClaimReservationReady(
 		}
 		// Pod status updates advance resourceVersion during initialization. UID
 		// and the unique reservation token are the stable CAS inputs here.
+		readyAt := s.now().UTC().Format(time.RFC3339Nano)
 		operations = append(operations,
 			claimMetadataPatchOperation{
 				Operation: "test",
@@ -85,6 +87,11 @@ func (s *SandboxService) markHotClaimReservationReady(
 				Operation: "replace",
 				Path:      metadataMapPath("annotations", controller.AnnotationHotClaimReservationState),
 				Value:     controller.HotClaimReservationStateReady,
+			},
+			claimMetadataPatchOperation{
+				Operation: "add",
+				Path:      metadataMapPath("annotations", controller.AnnotationHotClaimReadyAt),
+				Value:     readyAt,
 			},
 		)
 		patch, err := json.Marshal(operations)

--- a/manager/pkg/service/hot_claim_reservation_controller.go
+++ b/manager/pkg/service/hot_claim_reservation_controller.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
 	"go.uber.org/zap"
+	"golang.org/x/time/rate"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,6 +27,10 @@ import (
 const (
 	hotClaimReservationRecoveryGracePeriod = 5 * time.Minute
 	hotClaimReservationResyncPeriod        = 30 * time.Second
+	hotClaimDetachmentSettleWindow         = 3 * time.Second
+	hotClaimDetachmentMaxDelay             = 2 * time.Minute
+	hotClaimDetachmentLowWatermark         = 16
+	hotClaimDetachmentRatePerSecond        = 5
 )
 
 // HotClaimReservationController safely detaches completed hot claims from
@@ -39,6 +44,14 @@ type HotClaimReservationController struct {
 	queue          workqueue.TypedRateLimitingInterface[string]
 	resyncInterval time.Duration
 	recoveryGrace  time.Duration
+	detachPacer    hotClaimDetachmentPacer
+	settleWindow   time.Duration
+	maxDetachDelay time.Duration
+	lowWatermark   int
+}
+
+type hotClaimDetachmentPacer interface {
+	Wait(context.Context) error
 }
 
 func NewHotClaimReservationController(
@@ -59,6 +72,10 @@ func NewHotClaimReservationController(
 		queue:          workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
 		resyncInterval: hotClaimReservationResyncPeriod,
 		recoveryGrace:  hotClaimReservationRecoveryGracePeriod,
+		detachPacer:    rate.NewLimiter(rate.Limit(hotClaimDetachmentRatePerSecond), 1),
+		settleWindow:   hotClaimDetachmentSettleWindow,
+		maxDetachDelay: hotClaimDetachmentMaxDelay,
+		lowWatermark:   hotClaimDetachmentLowWatermark,
 	}
 }
 
@@ -83,13 +100,11 @@ func (c *HotClaimReservationController) EnqueueHotClaimReservation(namespace, po
 }
 
 // Run reconciles reservations from informer events and periodic recovery scans.
-func (c *HotClaimReservationController) Run(ctx context.Context, workers int) error {
+func (c *HotClaimReservationController) Run(ctx context.Context, _ int) error {
 	if c == nil {
 		return nil
 	}
-	if workers <= 0 {
-		workers = 1
-	}
+	const workers = 1
 	if c.queue == nil {
 		c.queue = workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]())
 	}
@@ -190,6 +205,14 @@ func (c *HotClaimReservationController) reconcile(ctx context.Context, key strin
 	}
 	if pod.Annotations[controller.AnnotationHotClaimReservationState] == controller.HotClaimReservationStateReady &&
 		hotClaimReservationMatchesRecord(pod, record) {
+		if requeueAfter := c.detachmentTimeRemaining(pod); requeueAfter > 0 {
+			return requeueAfter, nil
+		}
+		if !c.detachmentMaxDelayElapsed(pod) && c.detachPacer != nil {
+			if err := c.detachPacer.Wait(ctx); err != nil {
+				return 0, fmt.Errorf("wait for hot claim detachment pace: %w", err)
+			}
+		}
 		return 0, c.finalizeReservation(ctx, pod)
 	}
 
@@ -233,6 +256,92 @@ func (c *HotClaimReservationController) recoveryTimeRemaining(pod *corev1.Pod) t
 	return remaining
 }
 
+func (c *HotClaimReservationController) detachmentTimeRemaining(pod *corev1.Pod) time.Duration {
+	readyAt, ok := hotClaimReservationReadyTime(pod)
+	if !ok || c.settleWindow <= 0 || c.detachmentMaxDelayElapsedAt(readyAt) {
+		return 0
+	}
+	if c.claimableIdleBelowLowWatermark(pod) {
+		return 0
+	}
+	now := c.clock.Now()
+	if readyAt.After(now) {
+		return c.settleWindow
+	}
+	remaining := c.settleWindow - now.Sub(readyAt)
+	if remaining <= 0 {
+		return 0
+	}
+	return remaining
+}
+
+func (c *HotClaimReservationController) detachmentMaxDelayElapsed(pod *corev1.Pod) bool {
+	readyAt, ok := hotClaimReservationReadyTime(pod)
+	return !ok || c.detachmentMaxDelayElapsedAt(readyAt)
+}
+
+func (c *HotClaimReservationController) detachmentMaxDelayElapsedAt(readyAt time.Time) bool {
+	if c.maxDetachDelay <= 0 {
+		return true
+	}
+	now := c.clock.Now()
+	return !readyAt.After(now) && now.Sub(readyAt) >= c.maxDetachDelay
+}
+
+func (c *HotClaimReservationController) claimableIdleBelowLowWatermark(pod *corev1.Pod) bool {
+	if c.lowWatermark <= 0 || c.podLister == nil || pod == nil {
+		return false
+	}
+	templateID := strings.TrimSpace(pod.Labels[controller.LabelTemplateID])
+	if templateID == "" {
+		return false
+	}
+	pods, err := c.podLister.Pods(pod.Namespace).List(labels.SelectorFromSet(map[string]string{
+		controller.LabelTemplateID: templateID,
+		controller.LabelPoolType:   controller.PoolTypeIdle,
+	}))
+	if err != nil {
+		c.logger.Warn("Failed to count claimable idle pods before hot claim detachment",
+			zap.String("template", templateID),
+			zap.Error(err),
+		)
+		return false
+	}
+	claimable := 0
+	for _, candidate := range pods {
+		if candidate.DeletionTimestamp != nil ||
+			controller.IsHotClaimReservedPod(candidate) ||
+			!controller.IsPodReady(candidate) {
+			continue
+		}
+		claimable++
+		if claimable >= c.lowWatermark {
+			return false
+		}
+	}
+	return true
+}
+
+func hotClaimReservationReadyTime(pod *corev1.Pod) (time.Time, bool) {
+	if pod == nil {
+		return time.Time{}, false
+	}
+	for _, key := range []string{
+		controller.AnnotationHotClaimReadyAt,
+		controller.AnnotationHotClaimReservedAt,
+	} {
+		value := strings.TrimSpace(pod.Annotations[key])
+		if value == "" {
+			continue
+		}
+		parsed, err := time.Parse(time.RFC3339Nano, value)
+		if err == nil {
+			return parsed, true
+		}
+	}
+	return time.Time{}, false
+}
+
 func (c *HotClaimReservationController) finalizeReservation(ctx context.Context, pod *corev1.Pod) error {
 	operations := hotClaimReservationPreconditions(pod)
 	operations = appendReplicaSetOwnerRemovalPatch(
@@ -254,11 +363,17 @@ func (c *HotClaimReservationController) finalizeReservation(ctx context.Context,
 			Operation: "remove",
 			Path:      metadataMapPath("annotations", controller.AnnotationHotClaimReservedAt),
 		},
-		claimMetadataPatchOperation{
-			Operation: "remove",
-			Path:      metadataMapPath("annotations", controller.AnnotationHotClaimReservation),
-		},
 	)
+	if pod.Annotations[controller.AnnotationHotClaimReadyAt] != "" {
+		operations = append(operations, claimMetadataPatchOperation{
+			Operation: "remove",
+			Path:      metadataMapPath("annotations", controller.AnnotationHotClaimReadyAt),
+		})
+	}
+	operations = append(operations, claimMetadataPatchOperation{
+		Operation: "remove",
+		Path:      metadataMapPath("annotations", controller.AnnotationHotClaimReservation),
+	})
 	patch, err := json.Marshal(operations)
 	if err != nil {
 		return fmt.Errorf("marshal hot claim detachment patch: %w", err)

--- a/manager/pkg/service/hot_claim_reservation_controller_test.go
+++ b/manager/pkg/service/hot_claim_reservation_controller_test.go
@@ -2,6 +2,8 @@ package service
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -26,6 +28,9 @@ func TestMarkHotClaimReservationReadyKeepsWarmPoolAttachment(t *testing.T) {
 	}
 	if got := ready.Annotations[controller.AnnotationHotClaimReservationState]; got != controller.HotClaimReservationStateReady {
 		t.Fatalf("reservation state = %q, want %q", got, controller.HotClaimReservationStateReady)
+	}
+	if got := ready.Annotations[controller.AnnotationHotClaimReadyAt]; got == "" {
+		t.Fatal("hot claim ready timestamp is empty")
 	}
 	if got := ready.Labels[controller.LabelPoolType]; got != controller.PoolTypeIdle {
 		t.Fatalf("pool type = %q, want idle before controller detachment", got)
@@ -67,6 +72,9 @@ func TestHotClaimReservationControllerFinalizesDurableReadyClaim(t *testing.T) {
 		nil,
 	)
 	reconciler.clock = fixedClock{now: now}
+	reconciler.settleWindow = 0
+	pacer := &recordingHotClaimDetachmentPacer{}
+	reconciler.detachPacer = pacer
 
 	requeueAfter, err := reconciler.reconcile(context.Background(), pod.Namespace+"/"+pod.Name)
 	if err != nil {
@@ -74,6 +82,9 @@ func TestHotClaimReservationControllerFinalizesDurableReadyClaim(t *testing.T) {
 	}
 	if requeueAfter != 0 {
 		t.Fatalf("reconcile() requeueAfter = %s, want 0", requeueAfter)
+	}
+	if pacer.calls != 1 {
+		t.Fatalf("detachment pacer calls = %d, want 1", pacer.calls)
 	}
 
 	got, err := client.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
@@ -91,6 +102,109 @@ func TestHotClaimReservationControllerFinalizesDurableReadyClaim(t *testing.T) {
 	}
 	if !hasSandboxCleanupFinalizer(got) {
 		t.Fatal("sandbox cleanup finalizer was removed")
+	}
+}
+
+func TestHotClaimReservationControllerWaitsForSettleWindowWithHealthyCapacity(t *testing.T) {
+	now := time.Date(2026, time.July, 26, 12, 0, 0, 0, time.UTC)
+	pod := newHotClaimReservationTestPod(now, controller.HotClaimReservationStateReady)
+	store := &memorySandboxStore{records: map[string]*SandboxRecord{
+		"sandbox-a": hotClaimReservationTestRecord(pod),
+	}}
+	client := fake.NewSimpleClientset(pod.DeepCopy())
+	pacer := &recordingHotClaimDetachmentPacer{}
+	reconciler := NewHotClaimReservationController(
+		client,
+		newClaimTestPodLister(t, hotClaimReservationCapacityPods(pod, hotClaimDetachmentLowWatermark)...),
+		store,
+		nil,
+	)
+	reconciler.clock = fixedClock{now: now}
+	reconciler.detachPacer = pacer
+
+	requeueAfter, err := reconciler.reconcile(context.Background(), pod.Namespace+"/"+pod.Name)
+	if err != nil {
+		t.Fatalf("reconcile() error = %v", err)
+	}
+	if requeueAfter != hotClaimDetachmentSettleWindow {
+		t.Fatalf("reconcile() requeueAfter = %s, want %s", requeueAfter, hotClaimDetachmentSettleWindow)
+	}
+	if pacer.calls != 0 {
+		t.Fatalf("detachment pacer calls = %d, want 0 before settle window", pacer.calls)
+	}
+	got, err := client.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get reserved pod: %v", err)
+	}
+	if got.Labels[controller.LabelPoolType] != controller.PoolTypeIdle {
+		t.Fatalf("pool type = %q, want idle during settle window", got.Labels[controller.LabelPoolType])
+	}
+}
+
+func TestHotClaimReservationControllerBypassesSettleWindowBelowLowWatermark(t *testing.T) {
+	now := time.Date(2026, time.July, 26, 12, 0, 0, 0, time.UTC)
+	pod := newHotClaimReservationTestPod(now, controller.HotClaimReservationStateReady)
+	store := &memorySandboxStore{records: map[string]*SandboxRecord{
+		"sandbox-a": hotClaimReservationTestRecord(pod),
+	}}
+	client := fake.NewSimpleClientset(pod.DeepCopy())
+	reconciler := NewHotClaimReservationController(
+		client,
+		newClaimTestPodLister(t, hotClaimReservationCapacityPods(pod, hotClaimDetachmentLowWatermark-1)...),
+		store,
+		nil,
+	)
+	reconciler.clock = fixedClock{now: now}
+	reconciler.detachPacer = &recordingHotClaimDetachmentPacer{}
+
+	requeueAfter, err := reconciler.reconcile(context.Background(), pod.Namespace+"/"+pod.Name)
+	if err != nil {
+		t.Fatalf("reconcile() error = %v", err)
+	}
+	if requeueAfter != 0 {
+		t.Fatalf("reconcile() requeueAfter = %s, want immediate low-water detachment", requeueAfter)
+	}
+	got, err := client.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get finalized pod: %v", err)
+	}
+	if got.Labels[controller.LabelPoolType] != controller.PoolTypeActive {
+		t.Fatalf("pool type = %q, want active below low watermark", got.Labels[controller.LabelPoolType])
+	}
+}
+
+func TestHotClaimReservationControllerMaxDelayBypassesPacer(t *testing.T) {
+	now := time.Date(2026, time.July, 26, 12, 0, 0, 0, time.UTC)
+	pod := newHotClaimReservationTestPod(
+		now.Add(-hotClaimDetachmentMaxDelay-time.Second),
+		controller.HotClaimReservationStateReady,
+	)
+	store := &memorySandboxStore{records: map[string]*SandboxRecord{
+		"sandbox-a": hotClaimReservationTestRecord(pod),
+	}}
+	client := fake.NewSimpleClientset(pod.DeepCopy())
+	pacer := &recordingHotClaimDetachmentPacer{err: errors.New("pacer must be bypassed")}
+	reconciler := NewHotClaimReservationController(
+		client,
+		newClaimTestPodLister(t, hotClaimReservationCapacityPods(pod, hotClaimDetachmentLowWatermark)...),
+		store,
+		nil,
+	)
+	reconciler.clock = fixedClock{now: now}
+	reconciler.detachPacer = pacer
+
+	if _, err := reconciler.reconcile(context.Background(), pod.Namespace+"/"+pod.Name); err != nil {
+		t.Fatalf("reconcile() error = %v", err)
+	}
+	if pacer.calls != 0 {
+		t.Fatalf("detachment pacer calls = %d, want 0 after max delay", pacer.calls)
+	}
+	got, err := client.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get finalized pod: %v", err)
+	}
+	if got.Labels[controller.LabelPoolType] != controller.PoolTypeActive {
+		t.Fatalf("pool type = %q, want active after max delay", got.Labels[controller.LabelPoolType])
 	}
 }
 
@@ -211,6 +325,9 @@ func newHotClaimReservationTestPod(reservedAt time.Time, state string) *corev1.P
 	pod.Annotations[controller.AnnotationHotClaimReservation] = "reservation-token"
 	pod.Annotations[controller.AnnotationHotClaimReservationState] = state
 	pod.Annotations[controller.AnnotationHotClaimReservedAt] = reservedAt.Format(time.RFC3339Nano)
+	if state == controller.HotClaimReservationStateReady {
+		pod.Annotations[controller.AnnotationHotClaimReadyAt] = reservedAt.Format(time.RFC3339Nano)
+	}
 	pod.Finalizers = []string{"example.com/unrelated", sandboxCleanupFinalizer}
 	pod.OwnerReferences = []metav1.OwnerReference{
 		{
@@ -228,6 +345,30 @@ func newHotClaimReservationTestPod(reservedAt time.Time, state string) *corev1.P
 		},
 	}
 	return pod
+}
+
+func hotClaimReservationCapacityPods(reserved *corev1.Pod, claimable int) []*corev1.Pod {
+	pods := make([]*corev1.Pod, 0, claimable+1)
+	pods = append(pods, reserved)
+	for index := range claimable {
+		pods = append(pods, newClaimTestPod(
+			reserved.Namespace,
+			fmt.Sprintf("idle-ready-%d", index),
+			reserved.Labels[controller.LabelTemplateID],
+			true,
+		))
+	}
+	return pods
+}
+
+type recordingHotClaimDetachmentPacer struct {
+	calls int
+	err   error
+}
+
+func (p *recordingHotClaimDetachmentPacer) Wait(context.Context) error {
+	p.calls++
+	return p.err
 }
 
 func hotClaimReservationTestRecord(pod *corev1.Pod) *SandboxRecord {

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -582,16 +582,45 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 		}
 		return nil, fmt.Errorf("get procd address: %w", err)
 	}
+
+	var persistResultCh <-chan error
+	if claimType == "hot" && !claimRecordPersisted {
+		result := make(chan error, 1)
+		persistResultCh = result
+		persistPod := pod.DeepCopy()
+		persistStarted := time.Now()
+		go func() {
+			persistErr := s.persistClaimedSandbox(ctx, persistPod, template, req)
+			s.observeClaimPhase(req.Template, claimType, "persist_sandbox", persistStarted, persistErr)
+			result <- persistErr
+		}()
+	}
+
 	phaseStarted = time.Now()
-	if _, err := s.initializeProcd(ctx, pod, template, req, procdAddress); err != nil {
-		s.observeClaimPhase(req.Template, claimType, "initialize_procd", phaseStarted, err)
+	_, initializeErr := s.initializeProcd(ctx, pod, template, req, procdAddress)
+	s.observeClaimPhase(req.Template, claimType, "initialize_procd", phaseStarted, initializeErr)
+
+	var persistErr error
+	if persistResultCh != nil {
+		persistErr = <-persistResultCh
+		if persistErr == nil {
+			claimRecordPersisted = true
+		}
+	}
+	if initializeErr != nil {
 		cleanupClaimFailure(pod, "procd initialization failed")
 		if metrics != nil {
 			metrics.SandboxClaimsTotal.WithLabelValues(req.Template, "error").Inc()
 		}
-		return nil, fmt.Errorf("initialize procd: %w", err)
+		return nil, fmt.Errorf("initialize procd: %w", initializeErr)
 	}
-	s.observeClaimPhase(req.Template, claimType, "initialize_procd", phaseStarted, nil)
+	if persistErr != nil {
+		cleanupClaimFailure(pod, "sandbox persistence failed")
+		if metrics != nil {
+			metrics.SandboxClaimsTotal.WithLabelValues(req.Template, "error").Inc()
+		}
+		return nil, fmt.Errorf("persist sandbox: %w", persistErr)
+	}
 
 	if controller.IsHotClaimReservedPod(pod) {
 		phaseStarted = time.Now()
@@ -606,18 +635,20 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 		}
 	}
 
-	phaseStarted = time.Now()
-	if err := s.persistClaimedSandbox(ctx, pod, template, req); err != nil {
-		s.observeClaimPhase(req.Template, claimType, "persist_sandbox", phaseStarted, err)
-		cleanupClaimFailure(pod, "sandbox persistence failed")
-		if metrics != nil {
-			metrics.SandboxClaimsTotal.WithLabelValues(req.Template, "error").Inc()
+	if persistResultCh == nil {
+		phaseStarted = time.Now()
+		persistErr = s.persistClaimedSandbox(ctx, pod, template, req)
+		s.observeClaimPhase(req.Template, claimType, "persist_sandbox", phaseStarted, persistErr)
+		if persistErr != nil {
+			cleanupClaimFailure(pod, "sandbox persistence failed")
+			if metrics != nil {
+				metrics.SandboxClaimsTotal.WithLabelValues(req.Template, "error").Inc()
+			}
+			return nil, fmt.Errorf("persist sandbox: %w", persistErr)
 		}
-		return nil, fmt.Errorf("persist sandbox: %w", err)
+		claimRecordPersisted = true
 	}
-	claimRecordPersisted = true
 	s.enqueueHotClaimReservation(pod)
-	s.observeClaimPhase(req.Template, claimType, "persist_sandbox", phaseStarted, nil)
 
 	if metrics != nil {
 		metrics.SandboxClaimsTotal.WithLabelValues(req.Template, "success").Inc()

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -1355,6 +1355,166 @@ func TestClaimSandboxInitializesRootFSFromSnapshotBeforeProcd(t *testing.T) {
 	}
 }
 
+func TestClaimSandboxOverlapsHotPersistenceWithProcdInitialization(t *testing.T) {
+	withClaimTestPublicKey(t)
+
+	templateID := "template-a"
+	templateNamespace, err := naming.TemplateNamespaceForBuiltin(templateID)
+	if err != nil {
+		t.Fatalf("template namespace: %v", err)
+	}
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: templateID, Namespace: templateNamespace},
+	}
+
+	procdStarted := make(chan struct{}, 1)
+	persistStarted := make(chan struct{}, 1)
+	release := make(chan struct{})
+	procd := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/initialize" {
+			http.NotFound(w, r)
+			return
+		}
+		procdStarted <- struct{}{}
+		<-release
+		if err := spec.WriteSuccess(w, http.StatusOK, InitializeResponse{SandboxID: "sandbox-a", TeamID: "team-a"}); err != nil {
+			t.Fatalf("write procd response: %v", err)
+		}
+	}))
+	defer procd.Close()
+	procdURL, procdPort := parsedTestServer(t, procd.URL)
+
+	idlePod := newClaimTestPod(templateNamespace, "idle-ready", templateID, true)
+	idlePod.Status.PodIP = procdURL.Hostname()
+	store := &blockingClaimSandboxStore{
+		memorySandboxStore: &memorySandboxStore{records: map[string]*SandboxRecord{}},
+		started:            persistStarted,
+		release:            release,
+	}
+	client := fake.NewSimpleClientset(idlePod.DeepCopy())
+	svc := &SandboxService{
+		k8sClient:              client,
+		podLister:              newClaimTestPodLister(t, idlePod),
+		secretLister:           newClaimTestSecretLister(t),
+		templateLister:         staticTemplateLister{templates: []*v1alpha1.SandboxTemplate{template}},
+		sandboxStore:           store,
+		procdClient:            NewProcdClient(ProcdClientConfig{Timeout: time.Second}),
+		internalTokenGenerator: staticTokenGenerator{},
+		config: SandboxServiceConfig{
+			ProcdPort:        procdPort,
+			ProcdInitTimeout: time.Second,
+		},
+		clock:  systemTime{},
+		logger: zap.NewNop(),
+	}
+
+	result := make(chan error, 1)
+	go func() {
+		_, err := svc.ClaimSandbox(context.Background(), &ClaimRequest{
+			Template: templateID,
+			TeamID:   "team-a",
+			UserID:   "user-a",
+		})
+		result <- err
+	}()
+	for name, started := range map[string]<-chan struct{}{
+		"procd initialization": procdStarted,
+		"sandbox persistence":  persistStarted,
+	} {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatalf("%s did not start before the other operation completed", name)
+		}
+	}
+	close(release)
+	if err := <-result; err != nil {
+		t.Fatalf("ClaimSandbox() error = %v", err)
+	}
+	if len(store.records) != 1 {
+		t.Fatalf("sandbox records = %d, want 1", len(store.records))
+	}
+	for _, record := range store.records {
+		if record.Status != SandboxStatusRunning {
+			t.Fatalf("sandbox record status = %q, want running", record.Status)
+		}
+	}
+}
+
+func TestClaimSandboxDeletesConcurrentRecordWhenProcdInitializationFails(t *testing.T) {
+	withClaimTestPublicKey(t)
+
+	templateID := "template-a"
+	templateNamespace, err := naming.TemplateNamespaceForBuiltin(templateID)
+	if err != nil {
+		t.Fatalf("template namespace: %v", err)
+	}
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: templateID, Namespace: templateNamespace},
+	}
+	procd := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "not ready", http.StatusServiceUnavailable)
+	}))
+	defer procd.Close()
+	procdURL, procdPort := parsedTestServer(t, procd.URL)
+
+	idlePod := newClaimTestPod(templateNamespace, "idle-ready", templateID, true)
+	idlePod.Status.PodIP = procdURL.Hostname()
+	store := &memorySandboxStore{records: map[string]*SandboxRecord{}}
+	client := fake.NewSimpleClientset(idlePod.DeepCopy())
+	svc := &SandboxService{
+		k8sClient:              client,
+		podLister:              newClaimTestPodLister(t, idlePod),
+		secretLister:           newClaimTestSecretLister(t),
+		templateLister:         staticTemplateLister{templates: []*v1alpha1.SandboxTemplate{template}},
+		sandboxStore:           store,
+		procdClient:            NewProcdClient(ProcdClientConfig{Timeout: time.Second}),
+		internalTokenGenerator: staticTokenGenerator{},
+		config: SandboxServiceConfig{
+			ProcdPort:        procdPort,
+			ProcdInitTimeout: 20 * time.Millisecond,
+		},
+		clock:  systemTime{},
+		logger: zap.NewNop(),
+	}
+
+	_, err = svc.ClaimSandbox(context.Background(), &ClaimRequest{
+		Template: templateID,
+		TeamID:   "team-a",
+		UserID:   "user-a",
+	})
+	if err == nil || !strings.Contains(err.Error(), "initialize procd") {
+		t.Fatalf("ClaimSandbox() error = %v, want procd initialization failure", err)
+	}
+	if len(store.records) != 1 {
+		t.Fatalf("sandbox records = %d, want 1", len(store.records))
+	}
+	for _, record := range store.records {
+		if record.Status != SandboxStatusDeleted || record.DeletedAt.IsZero() {
+			t.Fatalf("sandbox record = %#v, want deleted", record)
+		}
+	}
+}
+
+type blockingClaimSandboxStore struct {
+	*memorySandboxStore
+	started chan<- struct{}
+	release <-chan struct{}
+}
+
+func (s *blockingClaimSandboxStore) UpsertSandbox(ctx context.Context, record *SandboxRecord) error {
+	select {
+	case s.started <- struct{}{}:
+	default:
+	}
+	select {
+	case <-s.release:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	return s.memorySandboxStore.UpsertSandbox(ctx, record)
+}
+
 func TestInitializeClaimRootFSFromSnapshotRejectsInternalTemplateBuildSnapshot(t *testing.T) {
 	internalSnapshotID := "template-build-123456"
 	store := &memorySandboxStore{

--- a/pkg/observability/metrics/cluster_gateway.go
+++ b/pkg/observability/metrics/cluster_gateway.go
@@ -1,0 +1,48 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// ClusterGatewayMetrics holds Prometheus metrics for cluster-gateway-specific
+// control paths.
+type ClusterGatewayMetrics struct {
+	AuditDeliveryStageDuration *prometheus.HistogramVec
+	AuditCanonicalQueueDepth   prometheus.Gauge
+	AuditCanonicalInFlight     prometheus.Gauge
+	AuditCanonicalBatchSize    *prometheus.HistogramVec
+}
+
+// NewClusterGateway registers and returns cluster-gateway metrics.
+// It returns nil when registry is nil.
+func NewClusterGateway(registry prometheus.Registerer) *ClusterGatewayMetrics {
+	if registry == nil {
+		return nil
+	}
+
+	factory := promauto.With(registry)
+	return &ClusterGatewayMetrics{
+		AuditDeliveryStageDuration: factory.NewHistogramVec(prometheus.HistogramOpts{
+			Name: "cluster_gateway_audit_delivery_stage_duration_seconds",
+			Help: "Duration of audit delivery stages by mode and result",
+			Buckets: []float64{
+				.0001, .00025, .0005, .001, .0025, .005, .01, .025,
+				.05, .1, .25, .5, 1, 2.5, 5, 10,
+			},
+		}, []string{"mode", "stage", "result"}),
+		AuditCanonicalQueueDepth: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "cluster_gateway_audit_canonical_queue_depth",
+			Help: "Current number of foreground canonical audit batches waiting to be formed",
+		}),
+		AuditCanonicalInFlight: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "cluster_gateway_audit_canonical_in_flight",
+			Help: "Current number of canonical audit batches writing to the backend",
+		}),
+		AuditCanonicalBatchSize: factory.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "cluster_gateway_audit_canonical_batch_size",
+			Help:    "Number of audit events in each canonical backend insert",
+			Buckets: []float64{1, 2, 4, 8, 16, 32, 64, 128, 256, 500},
+		}, []string{"source", "result"}),
+	}
+}


### PR DESCRIPTION
## Summary

- batch concurrent foreground audit events into bounded canonical ClickHouse writes while preserving durable spool-before-ack semantics and foreground priority over replay
- pace hot-claim ReplicaSet detachment at 5 pods/s after a short settle window, with a low-watermark bypass and a hard maximum delay
- overlap hot-claim database persistence with procd initialization while retaining cleanup on either failure
- add delivery-stage, queue-depth, in-flight, and batch-size metrics

## Safety boundaries

- no node size, autoscaler capacity, template resource, or ClickHouse storage-policy changes
- no audit durability relaxation: callers still wait for canonical acknowledgement
- cold/snapshot claim paths remain sequential

## Validation

Local:

- `go mod tidy -diff`
- `git diff --check`
- `go test ./cluster-gateway/pkg/http ./manager/pkg/service ./manager/pkg/controller ./pkg/observability/metrics ./cluster-gateway/cmd/cluster-gateway ./manager/cmd/manager -count=1`
- `go vet ./cluster-gateway/pkg/http ./manager/pkg/service ./manager/pkg/controller ./pkg/observability/metrics ./cluster-gateway/cmd/cluster-gateway ./manager/cmd/manager`
- `go test -race ./cluster-gateway/pkg/http ./manager/pkg/service -count=1`

Aliyun Singapore remote kind environment:

- deployed this worktree; `Sandbox0Infra fullmode` reached `Ready 10/10`
- all sandbox0 workloads were Ready with zero restarts
- verified normal hot-pool claim and explicit `128Mi` claim
- verified synchronous command execution, file write/read, sandbox deletion, and idle-pool replenishment
- explicit `128Mi` claim was Ready, active, detached from its ReplicaSet, and reported `memory=128Mi`, `cpu=150m`
- removed all test sandboxes and stopped the ECS instance

## ComputeSDK benchmark

Built and deployed `sandbox0ai/infra:computesdk-wave3-f750840` through [image CI](https://github.com/sandbox0-ai/sandbox0/actions/runs/30210589814) and [sandbox0-infra GitOps](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30210876708).

Boundary: Ali us-east-1 in-region temporary runner; one original 8-vCPU fixed sandbox node; zero burst nodes; default pool `120/120`; explicit `128Mi` benchmark sandboxes; 100 iterations per mode; no ComputeSDK upload.

| Mode | Score | Success | Median | P95 | P99 | Wall | First ready |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| sequential | 96.92 | 100/100 | 245.88 ms | 381.65 ms | 435.94 ms | — | — |
| staggered | 90.29 | 100/100 | 916.92 ms | 1,041.21 ms | 1,070.69 ms | 21.53 s | 202.13 ms |
| burst 1 | 69.50 | 100/100 | 1,967.35 ms | 4,465.14 ms | 5,022.45 ms | 6.77 s | 643.20 ms |
| burst 2 | 61.84 | 100/100 | 2,419.52 ms | 5,675.79 ms | 6,299.45 ms | 7.68 s | 1,128.22 ms |

Compared with the previous same-boundary main baseline:

- sequential is effectively flat: score -0.12, median +2.8%
- staggered: score +4.39, median -29.1%, P95 -33.9%
- burst 1: score +43.49, median -71.5%, wall -46.5%
- burst 2: score +28.65, median -58.9%, wall -32.3%

Both burst runs are retained; the result is not cherry-picked from the better run. Preflight passed between every mode and after cleanup. Final state is one fixed node, zero actual burst nodes, idle/Ready `120/120`, active 0, pending 0, infra-operator restart 0, and all Argo CD apps Synced/Healthy. The temporary runner was deleted, quota overrides were removed, and burst capacity was restored to the reviewed `0-299` configuration.
