### PR TITLE
perf(manager): streamline hot claim reservations

### DIFF
--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -124,6 +124,16 @@ func main() {
 	if err != nil {
 		logger.Fatal("Failed to create Kubernetes client", zap.Error(err))
 	}
+	hotClaimK8sConfig := isolatedK8sClientConfig(k8sConfig)
+	observeHotClaimK8sClientRateLimit(managerMetrics, hotClaimK8sConfig)
+	logger.Info("Hot claim Kubernetes client rate limit configured",
+		zap.Float32("qps", effectiveK8sClientQPS(hotClaimK8sConfig)),
+		zap.Int("burst", effectiveK8sClientBurst(hotClaimK8sConfig)),
+	)
+	hotClaimK8sClient, err := kubernetes.NewForConfig(hotClaimK8sConfig)
+	if err != nil {
+		logger.Fatal("Failed to create hot claim Kubernetes client", zap.Error(err))
+	}
 
 	// Add SandboxTemplate to scheme
 	if err := v1alpha1.AddToScheme(scheme.Scheme); err != nil {
@@ -461,6 +471,7 @@ func main() {
 	sandboxService.SetCredentialStore(credentialStore)
 	sandboxService.SetQuotaStore(quotaRepo)
 	sandboxService.SetSandboxStore(sandboxStore)
+	sandboxService.SetHotClaimK8sClient(hotClaimK8sClient)
 	hotClaimReservationController := service.NewHotClaimReservationController(
 		k8sClient,
 		podLister,
@@ -854,12 +865,33 @@ func configureK8sClientRateLimiter(restConfig *rest.Config, qps int, burst int) 
 	restConfig.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(rate, burst)
 }
 
+func isolatedK8sClientConfig(base *rest.Config) *rest.Config {
+	if base == nil {
+		return nil
+	}
+	isolated := rest.CopyConfig(base)
+	rate := effectiveK8sClientQPS(base)
+	burst := effectiveK8sClientBurst(base)
+	isolated.QPS = rate
+	isolated.Burst = burst
+	isolated.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(rate, burst)
+	return isolated
+}
+
 func observeK8sClientRateLimit(metrics *obsmetrics.ManagerMetrics, restConfig *rest.Config) {
 	if metrics == nil || metrics.K8sClientRateLimit == nil || restConfig == nil {
 		return
 	}
 	metrics.K8sClientRateLimit.WithLabelValues("qps").Set(float64(effectiveK8sClientQPS(restConfig)))
 	metrics.K8sClientRateLimit.WithLabelValues("burst").Set(float64(effectiveK8sClientBurst(restConfig)))
+}
+
+func observeHotClaimK8sClientRateLimit(metrics *obsmetrics.ManagerMetrics, restConfig *rest.Config) {
+	if metrics == nil || metrics.K8sClientRateLimit == nil || restConfig == nil {
+		return
+	}
+	metrics.K8sClientRateLimit.WithLabelValues("hot_claim_qps").Set(float64(effectiveK8sClientQPS(restConfig)))
+	metrics.K8sClientRateLimit.WithLabelValues("hot_claim_burst").Set(float64(effectiveK8sClientBurst(restConfig)))
 }
 
 func effectiveK8sClientQPS(restConfig *rest.Config) float32 {

--- a/manager/cmd/manager/main_test.go
+++ b/manager/cmd/manager/main_test.go
@@ -194,3 +194,28 @@ func TestConfigureK8sClientRateLimiterDefaultsWhenUnset(t *testing.T) {
 		t.Fatal("expected shared rate limiter")
 	}
 }
+
+func TestIsolatedK8sClientConfigUsesIndependentRateBudget(t *testing.T) {
+	shared := &rest.Config{}
+	configureK8sClientRateLimiter(shared, 25, 50)
+
+	isolated := isolatedK8sClientConfig(shared)
+	if isolated == nil {
+		t.Fatal("isolatedK8sClientConfig() = nil")
+	}
+	if isolated.QPS != shared.QPS || isolated.Burst != shared.Burst {
+		t.Fatalf(
+			"isolated rate = %v/%d, want %v/%d",
+			isolated.QPS,
+			isolated.Burst,
+			shared.QPS,
+			shared.Burst,
+		)
+	}
+	if isolated.RateLimiter == nil {
+		t.Fatal("isolated rate limiter is nil")
+	}
+	if isolated.RateLimiter == shared.RateLimiter {
+		t.Fatal("isolated client reused the shared rate limiter")
+	}
+}

--- a/manager/pkg/controller/pool_manager.go
+++ b/manager/pkg/controller/pool_manager.go
@@ -65,6 +65,7 @@ const (
 	AnnotationHotClaimReservationState     = "sandbox0.ai/hot-claim-reservation-state"
 	AnnotationHotClaimReservedAt           = "sandbox0.ai/hot-claim-reserved-at"
 	AnnotationHotClaimReadyAt              = "sandbox0.ai/hot-claim-ready-at"
+	AnnotationHotClaimCompletionProtocol   = "sandbox0.ai/hot-claim-completion-protocol"
 	AnnotationTemplateSpecHash             = "sandbox0.ai/template-spec-hash"
 	AnnotationTemplateTeamID               = "sandbox0.ai/template-team-id"
 	AnnotationTemplateUserID               = "sandbox0.ai/template-user-id"
@@ -75,6 +76,7 @@ const (
 
 	HotClaimReservationStateInitializing = "initializing"
 	HotClaimReservationStateReady        = "ready"
+	HotClaimCompletionProtocolRecordV1   = "record-status-v1"
 
 	unhealthyIdlePodRepairGracePeriod = 2 * time.Minute
 )

--- a/manager/pkg/service/hot_claim_reservation.go
+++ b/manager/pkg/service/hot_claim_reservation.go
@@ -2,121 +2,35 @@ package service
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"time"
 
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/util/retry"
 )
 
-var errHotClaimReservationLost = errors.New("hot claim reservation lost")
-
-// markHotClaimReservationReady records that all sandbox-side initialization is
-// complete. The detachment controller still verifies durable sandbox identity
-// before removing the warm-pool owner.
-func (s *SandboxService) markHotClaimReservationReady(
+// completeHotClaimReservation durably records successful sandbox
+// initialization. The reservation controller uses this record transition to
+// detach the Pod, so the request path does not need a second Pod patch.
+func (s *SandboxService) completeHotClaimReservation(
 	ctx context.Context,
 	pod *corev1.Pod,
-) (*corev1.Pod, error) {
-	if s == nil || pod == nil || !controller.IsHotClaimReservedPod(pod) {
-		return pod, nil
+	template *v1alpha1.SandboxTemplate,
+	req *ClaimRequest,
+) error {
+	if s == nil || s.sandboxStore == nil || pod == nil || template == nil || req == nil ||
+		!hotClaimUsesRecordCompletion(pod) {
+		return nil
 	}
-	expectedUID := pod.UID
-	expectedToken := pod.Annotations[controller.AnnotationHotClaimReservation]
-	current := pod
-	var readyPod *corev1.Pod
+	record := sandboxRecordForClaimedPod(s, pod, template, req)
+	record.Status = SandboxStatusRunning
+	return s.sandboxStore.UpsertSandbox(ctx, record)
+}
 
-	err := retry.OnError(retry.DefaultRetry, func(err error) bool {
-		return k8serrors.IsConflict(err) || isClaimMetadataPatchPreconditionFailure(err)
-	}, func() error {
-		if current == nil {
-			latest, err := s.k8sClient.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
-			if err != nil {
-				if k8serrors.IsNotFound(err) {
-					return fmt.Errorf("%w: pod %s/%s no longer exists", errHotClaimReservationLost, pod.Namespace, pod.Name)
-				}
-				return err
-			}
-			current = latest
-		}
-		if expectedUID != "" && current.UID != expectedUID {
-			return fmt.Errorf("%w: pod %s/%s UID changed", errHotClaimReservationLost, pod.Namespace, pod.Name)
-		}
-		if current.Annotations[controller.AnnotationHotClaimReservation] != expectedToken {
-			if current.Annotations[controller.AnnotationHotClaimReservation] == "" &&
-				current.Labels[controller.LabelPoolType] == controller.PoolTypeActive &&
-				sandboxIDFromPod(current) == sandboxIDFromPod(pod) {
-				readyPod = current
-				return nil
-			}
-			return fmt.Errorf("%w: pod %s/%s token changed", errHotClaimReservationLost, pod.Namespace, pod.Name)
-		}
-		switch current.Annotations[controller.AnnotationHotClaimReservationState] {
-		case controller.HotClaimReservationStateReady:
-			readyPod = current
-			return nil
-		case controller.HotClaimReservationStateInitializing:
-		default:
-			return fmt.Errorf("%w: pod %s/%s has invalid state", errHotClaimReservationLost, pod.Namespace, pod.Name)
-		}
-
-		operations := make([]claimMetadataPatchOperation, 0, 4)
-		if current.UID != "" {
-			operations = append(operations, claimMetadataPatchOperation{
-				Operation: "test",
-				Path:      "/metadata/uid",
-				Value:     current.UID,
-			})
-		}
-		// Pod status updates advance resourceVersion during initialization. UID
-		// and the unique reservation token are the stable CAS inputs here.
-		readyAt := s.now().UTC().Format(time.RFC3339Nano)
-		operations = append(operations,
-			claimMetadataPatchOperation{
-				Operation: "test",
-				Path:      metadataMapPath("annotations", controller.AnnotationHotClaimReservation),
-				Value:     expectedToken,
-			},
-			claimMetadataPatchOperation{
-				Operation: "replace",
-				Path:      metadataMapPath("annotations", controller.AnnotationHotClaimReservationState),
-				Value:     controller.HotClaimReservationStateReady,
-			},
-			claimMetadataPatchOperation{
-				Operation: "add",
-				Path:      metadataMapPath("annotations", controller.AnnotationHotClaimReadyAt),
-				Value:     readyAt,
-			},
-		)
-		patch, err := json.Marshal(operations)
-		if err != nil {
-			return fmt.Errorf("marshal hot claim ready patch: %w", err)
-		}
-		readyPod, err = s.k8sClient.CoreV1().Pods(current.Namespace).Patch(
-			ctx,
-			current.Name,
-			types.JSONPatchType,
-			patch,
-			metav1.PatchOptions{},
-		)
-		if err != nil {
-			current = nil
-		}
-		return err
-	})
-	if err != nil {
-		if current != nil {
-			return current, err
-		}
-		return pod, err
-	}
-	return readyPod, nil
+func hotClaimUsesRecordCompletion(pod *corev1.Pod) bool {
+	return pod != nil &&
+		controller.IsHotClaimReservedPod(pod) &&
+		pod.Annotations[controller.AnnotationHotClaimCompletionProtocol] ==
+			controller.HotClaimCompletionProtocolRecordV1
 }
 
 func (s *SandboxService) enqueueHotClaimReservation(pod *corev1.Pod) {

--- a/manager/pkg/service/hot_claim_reservation_controller.go
+++ b/manager/pkg/service/hot_claim_reservation_controller.go
@@ -203,12 +203,11 @@ func (c *HotClaimReservationController) reconcile(ctx context.Context, key strin
 	if err != nil {
 		return 0, err
 	}
-	if pod.Annotations[controller.AnnotationHotClaimReservationState] == controller.HotClaimReservationStateReady &&
-		hotClaimReservationMatchesRecord(pod, record) {
-		if requeueAfter := c.detachmentTimeRemaining(pod); requeueAfter > 0 {
+	if hotClaimReservationCompleted(pod, record) {
+		if requeueAfter := c.detachmentTimeRemaining(pod, record); requeueAfter > 0 {
 			return requeueAfter, nil
 		}
-		if !c.detachmentMaxDelayElapsed(pod) && c.detachPacer != nil {
+		if !c.detachmentMaxDelayElapsed(pod, record) && c.detachPacer != nil {
 			if err := c.detachPacer.Wait(ctx); err != nil {
 				return 0, fmt.Errorf("wait for hot claim detachment pace: %w", err)
 			}
@@ -256,8 +255,8 @@ func (c *HotClaimReservationController) recoveryTimeRemaining(pod *corev1.Pod) t
 	return remaining
 }
 
-func (c *HotClaimReservationController) detachmentTimeRemaining(pod *corev1.Pod) time.Duration {
-	readyAt, ok := hotClaimReservationReadyTime(pod)
+func (c *HotClaimReservationController) detachmentTimeRemaining(pod *corev1.Pod, record *SandboxRecord) time.Duration {
+	readyAt, ok := hotClaimReservationReadyTime(pod, record)
 	if !ok || c.settleWindow <= 0 || c.detachmentMaxDelayElapsedAt(readyAt) {
 		return 0
 	}
@@ -275,8 +274,8 @@ func (c *HotClaimReservationController) detachmentTimeRemaining(pod *corev1.Pod)
 	return remaining
 }
 
-func (c *HotClaimReservationController) detachmentMaxDelayElapsed(pod *corev1.Pod) bool {
-	readyAt, ok := hotClaimReservationReadyTime(pod)
+func (c *HotClaimReservationController) detachmentMaxDelayElapsed(pod *corev1.Pod, record *SandboxRecord) bool {
+	readyAt, ok := hotClaimReservationReadyTime(pod, record)
 	return !ok || c.detachmentMaxDelayElapsedAt(readyAt)
 }
 
@@ -322,9 +321,12 @@ func (c *HotClaimReservationController) claimableIdleBelowLowWatermark(pod *core
 	return true
 }
 
-func hotClaimReservationReadyTime(pod *corev1.Pod) (time.Time, bool) {
+func hotClaimReservationReadyTime(pod *corev1.Pod, record *SandboxRecord) (time.Time, bool) {
 	if pod == nil {
 		return time.Time{}, false
+	}
+	if hotClaimUsesRecordCompletion(pod) && record != nil && !record.UpdatedAt.IsZero() {
+		return record.UpdatedAt, true
 	}
 	for _, key := range []string{
 		controller.AnnotationHotClaimReadyAt,
@@ -370,6 +372,12 @@ func (c *HotClaimReservationController) finalizeReservation(ctx context.Context,
 			Path:      metadataMapPath("annotations", controller.AnnotationHotClaimReadyAt),
 		})
 	}
+	if pod.Annotations[controller.AnnotationHotClaimCompletionProtocol] != "" {
+		operations = append(operations, claimMetadataPatchOperation{
+			Operation: "remove",
+			Path:      metadataMapPath("annotations", controller.AnnotationHotClaimCompletionProtocol),
+		})
+	}
 	operations = append(operations, claimMetadataPatchOperation{
 		Operation: "remove",
 		Path:      metadataMapPath("annotations", controller.AnnotationHotClaimReservation),
@@ -403,13 +411,6 @@ func hotClaimReservationPreconditions(pod *corev1.Pod) []claimMetadataPatchOpera
 			Value:     pod.UID,
 		})
 	}
-	if pod.ResourceVersion != "" {
-		operations = append(operations, claimMetadataPatchOperation{
-			Operation: "test",
-			Path:      "/metadata/resourceVersion",
-			Value:     pod.ResourceVersion,
-		})
-	}
 	return append(operations,
 		claimMetadataPatchOperation{
 			Operation: "test",
@@ -424,7 +425,7 @@ func hotClaimReservationPreconditions(pod *corev1.Pod) []claimMetadataPatchOpera
 		claimMetadataPatchOperation{
 			Operation: "test",
 			Path:      metadataMapPath("annotations", controller.AnnotationHotClaimReservationState),
-			Value:     controller.HotClaimReservationStateReady,
+			Value:     pod.Annotations[controller.AnnotationHotClaimReservationState],
 		},
 	)
 }
@@ -471,4 +472,17 @@ func hotClaimReservationMatchesRecord(pod *corev1.Pod, record *SandboxRecord) bo
 	}
 	podGeneration := runtimeGenerationFromPod(pod)
 	return podGeneration <= 0 || record.RuntimeGeneration <= 0 || record.RuntimeGeneration == podGeneration
+}
+
+func hotClaimReservationCompleted(pod *corev1.Pod, record *SandboxRecord) bool {
+	if !hotClaimReservationMatchesRecord(pod, record) {
+		return false
+	}
+	state := pod.Annotations[controller.AnnotationHotClaimReservationState]
+	if state == controller.HotClaimReservationStateReady {
+		return true
+	}
+	return state == controller.HotClaimReservationStateInitializing &&
+		hotClaimUsesRecordCompletion(pod) &&
+		record.Status == SandboxStatusRunning
 }

--- a/manager/pkg/service/hot_claim_reservation_controller_test.go
+++ b/manager/pkg/service/hot_claim_reservation_controller_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -16,45 +17,143 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
-func TestMarkHotClaimReservationReadyKeepsWarmPoolAttachment(t *testing.T) {
+func TestCompleteHotClaimReservationPersistsRunningRecordWithoutPodPatch(t *testing.T) {
 	now := time.Date(2026, time.July, 26, 12, 0, 0, 0, time.UTC)
 	pod := newHotClaimReservationTestPod(now, controller.HotClaimReservationStateInitializing)
+	pod.Annotations[controller.AnnotationHotClaimCompletionProtocol] = controller.HotClaimCompletionProtocolRecordV1
 	client := fake.NewSimpleClientset(pod.DeepCopy())
-	service := &SandboxService{k8sClient: client}
+	store := &memorySandboxStore{records: map[string]*SandboxRecord{}}
+	service := &SandboxService{
+		k8sClient:    client,
+		sandboxStore: store,
+		clock:        fixedClock{now: now},
+	}
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: pod.Namespace},
+	}
+	req := &ClaimRequest{
+		SandboxID:         "sandbox-a",
+		Template:          "default",
+		TeamID:            "team-a",
+		UserID:            "user-a",
+		RuntimeGeneration: 1,
+	}
 
-	ready, err := service.markHotClaimReservationReady(context.Background(), pod)
+	if err := service.completeHotClaimReservation(context.Background(), pod, template, req); err != nil {
+		t.Fatalf("completeHotClaimReservation() error = %v", err)
+	}
+	record, err := store.GetSandbox(context.Background(), "sandbox-a")
 	if err != nil {
-		t.Fatalf("markHotClaimReservationReady() error = %v", err)
+		t.Fatalf("GetSandbox() error = %v", err)
 	}
-	if got := ready.Annotations[controller.AnnotationHotClaimReservationState]; got != controller.HotClaimReservationStateReady {
-		t.Fatalf("reservation state = %q, want %q", got, controller.HotClaimReservationStateReady)
+	if record == nil || record.Status != SandboxStatusRunning {
+		t.Fatalf("sandbox record = %#v, want running", record)
 	}
-	if got := ready.Annotations[controller.AnnotationHotClaimReadyAt]; got == "" {
-		t.Fatal("hot claim ready timestamp is empty")
+	if actions := client.Actions(); len(actions) != 0 {
+		t.Fatalf("Kubernetes actions = %v, want none on completion path", actions)
 	}
-	if got := ready.Labels[controller.LabelPoolType]; got != controller.PoolTypeIdle {
-		t.Fatalf("pool type = %q, want idle before controller detachment", got)
-	}
-	if len(ready.OwnerReferences) != 2 {
-		t.Fatalf("owner references = %#v, want both warm-pool and external owners", ready.OwnerReferences)
+	if got := pod.Annotations[controller.AnnotationHotClaimReservationState]; got != controller.HotClaimReservationStateInitializing {
+		t.Fatalf("reservation state = %q, want unchanged initializing", got)
 	}
 }
 
-func TestMarkHotClaimReservationReadyAllowsResourceVersionAdvance(t *testing.T) {
+func TestSandboxRecordForRecordCompletedHotClaimStartsInitializing(t *testing.T) {
 	now := time.Date(2026, time.July, 26, 12, 0, 0, 0, time.UTC)
-	stalePod := newHotClaimReservationTestPod(now, controller.HotClaimReservationStateInitializing)
-	stalePod.ResourceVersion = "10"
-	livePod := stalePod.DeepCopy()
-	livePod.ResourceVersion = "11"
-	client := fake.NewSimpleClientset(livePod)
-	service := &SandboxService{k8sClient: client}
-
-	ready, err := service.markHotClaimReservationReady(context.Background(), stalePod)
-	if err != nil {
-		t.Fatalf("markHotClaimReservationReady() error = %v", err)
+	pod := newHotClaimReservationTestPod(now, controller.HotClaimReservationStateInitializing)
+	pod.Annotations[controller.AnnotationHotClaimCompletionProtocol] = controller.HotClaimCompletionProtocolRecordV1
+	service := &SandboxService{clock: fixedClock{now: now}}
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: pod.Namespace},
 	}
-	if got := ready.Annotations[controller.AnnotationHotClaimReservationState]; got != controller.HotClaimReservationStateReady {
-		t.Fatalf("reservation state = %q, want %q", got, controller.HotClaimReservationStateReady)
+
+	record := sandboxRecordForClaimedPod(service, pod, template, &ClaimRequest{
+		SandboxID:         "sandbox-a",
+		Template:          "default",
+		TeamID:            "team-a",
+		UserID:            "user-a",
+		RuntimeGeneration: 1,
+	})
+	if record.Status != SandboxStatusStarting {
+		t.Fatalf("sandbox record status = %q, want starting", record.Status)
+	}
+}
+
+func TestHotClaimReservationControllerFinalizesRecordCompletedClaim(t *testing.T) {
+	now := time.Date(2026, time.July, 26, 12, 0, 0, 0, time.UTC)
+	pod := newHotClaimReservationTestPod(now, controller.HotClaimReservationStateInitializing)
+	pod.Annotations[controller.AnnotationHotClaimCompletionProtocol] = controller.HotClaimCompletionProtocolRecordV1
+	record := hotClaimReservationTestRecord(pod)
+	record.UpdatedAt = now
+	store := &memorySandboxStore{records: map[string]*SandboxRecord{"sandbox-a": record}}
+	client := fake.NewSimpleClientset(pod.DeepCopy())
+	reconciler := NewHotClaimReservationController(client, newClaimTestPodLister(t, pod), store, nil)
+	reconciler.clock = fixedClock{now: now}
+	reconciler.settleWindow = 0
+	reconciler.detachPacer = &recordingHotClaimDetachmentPacer{}
+
+	if _, err := reconciler.reconcile(context.Background(), pod.Namespace+"/"+pod.Name); err != nil {
+		t.Fatalf("reconcile() error = %v", err)
+	}
+	got, err := client.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get finalized pod: %v", err)
+	}
+	if got.Labels[controller.LabelPoolType] != controller.PoolTypeActive {
+		t.Fatalf("pool type = %q, want active", got.Labels[controller.LabelPoolType])
+	}
+	if controller.IsHotClaimReservedPod(got) {
+		t.Fatalf("finalized pod still has reservation: %#v", got.Annotations)
+	}
+	if _, exists := got.Annotations[controller.AnnotationHotClaimCompletionProtocol]; exists {
+		t.Fatalf("completion protocol remains after finalization: %#v", got.Annotations)
+	}
+}
+
+func TestHotClaimReservationControllerDoesNotCompleteUnsafeInitializingClaim(t *testing.T) {
+	now := time.Date(2026, time.July, 26, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name     string
+		protocol string
+		status   string
+	}{
+		{
+			name:   "legacy running record lacks completion protocol",
+			status: SandboxStatusRunning,
+		},
+		{
+			name:     "record protocol is still starting",
+			protocol: controller.HotClaimCompletionProtocolRecordV1,
+			status:   SandboxStatusStarting,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pod := newHotClaimReservationTestPod(now, controller.HotClaimReservationStateInitializing)
+			if test.protocol != "" {
+				pod.Annotations[controller.AnnotationHotClaimCompletionProtocol] = test.protocol
+			}
+			record := hotClaimReservationTestRecord(pod)
+			record.Status = test.status
+			store := &memorySandboxStore{records: map[string]*SandboxRecord{"sandbox-a": record}}
+			client := fake.NewSimpleClientset(pod.DeepCopy())
+			reconciler := NewHotClaimReservationController(client, newClaimTestPodLister(t, pod), store, nil)
+			reconciler.clock = fixedClock{now: now}
+
+			requeueAfter, err := reconciler.reconcile(context.Background(), pod.Namespace+"/"+pod.Name)
+			if err != nil {
+				t.Fatalf("reconcile() error = %v", err)
+			}
+			if requeueAfter != hotClaimReservationRecoveryGracePeriod {
+				t.Fatalf("requeueAfter = %s, want %s", requeueAfter, hotClaimReservationRecoveryGracePeriod)
+			}
+			got, err := client.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("get reserved pod: %v", err)
+			}
+			if got.Labels[controller.LabelPoolType] != controller.PoolTypeIdle {
+				t.Fatalf("pool type = %q, want idle", got.Labels[controller.LabelPoolType])
+			}
+		})
 	}
 }
 

--- a/manager/pkg/service/idle_claim_allocator.go
+++ b/manager/pkg/service/idle_claim_allocator.go
@@ -1,0 +1,97 @@
+package service
+
+import (
+	"math/rand"
+
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// reserveIdleClaimCandidate prevents concurrent claims in one manager process
+// from selecting the same informer-cached idle Pod. Kubernetes metadata CAS
+// remains the cross-process source of truth.
+func (s *SandboxService) reserveIdleClaimCandidate(candidates []*corev1.Pod) *corev1.Pod {
+	if s == nil || len(candidates) == 0 {
+		return nil
+	}
+
+	s.idleClaimMu.Lock()
+	defer s.idleClaimMu.Unlock()
+	if s.idleClaimReservations == nil {
+		s.idleClaimReservations = make(map[string]string)
+	}
+
+	start := rand.Intn(len(candidates))
+	for offset := range len(candidates) {
+		candidate := candidates[(start+offset)%len(candidates)]
+		if candidate == nil {
+			continue
+		}
+		key := podEventKey(candidate.Namespace, candidate.Name)
+		uid := string(candidate.UID)
+		if reservedUID, reserved := s.idleClaimReservations[key]; reserved {
+			if reservedUID == "" || uid == "" || reservedUID == uid {
+				continue
+			}
+			delete(s.idleClaimReservations, key)
+		}
+		s.idleClaimReservations[key] = uid
+		return candidate
+	}
+	return nil
+}
+
+func (s *SandboxService) releaseIdleClaimCandidate(pod *corev1.Pod) {
+	if s == nil || pod == nil {
+		return
+	}
+	key := podEventKey(pod.Namespace, pod.Name)
+
+	s.idleClaimMu.Lock()
+	defer s.idleClaimMu.Unlock()
+	if reservedUID, ok := s.idleClaimReservations[key]; ok {
+		uid := string(pod.UID)
+		if reservedUID == "" || uid == "" || reservedUID == uid {
+			delete(s.idleClaimReservations, key)
+		}
+	}
+}
+
+// observeIdleClaimPodEvent hands a successful local reservation back only
+// after the informer observes the durable Kubernetes reservation (or deletion).
+func (s *SandboxService) observeIdleClaimPodEvent(obj any, deleted bool) {
+	if s == nil {
+		return
+	}
+	pod := podFromInformerObject(obj)
+	if pod == nil {
+		return
+	}
+	key := podEventKey(pod.Namespace, pod.Name)
+
+	s.idleClaimMu.Lock()
+	defer s.idleClaimMu.Unlock()
+	reservedUID, reserved := s.idleClaimReservations[key]
+	if !reserved {
+		return
+	}
+	uid := string(pod.UID)
+	if deleted ||
+		(reservedUID != "" && uid != "" && reservedUID != uid) ||
+		pod.DeletionTimestamp != nil ||
+		pod.Labels[controller.LabelPoolType] != controller.PoolTypeIdle ||
+		controller.IsHotClaimReservedPod(pod) {
+		delete(s.idleClaimReservations, key)
+	}
+}
+
+func (s *SandboxService) hotClaimClient() kubernetes.Interface {
+	if s != nil && s.hotClaimK8sClient != nil {
+		return s.hotClaimK8sClient
+	}
+	if s == nil {
+		return nil
+	}
+	return s.k8sClient
+}

--- a/manager/pkg/service/idle_claim_allocator_test.go
+++ b/manager/pkg/service/idle_claim_allocator_test.go
@@ -1,0 +1,143 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestReserveIdleClaimCandidateAssignsDistinctPodsConcurrently(t *testing.T) {
+	const count = 64
+	candidates := make([]*corev1.Pod, 0, count)
+	for index := range count {
+		pod := newClaimTestPod("ns-a", fmt.Sprintf("idle-%d", index), "template-a", true)
+		pod.UID = types.UID(fmt.Sprintf("uid-%d", index))
+		candidates = append(candidates, pod)
+	}
+	service := &SandboxService{}
+	start := make(chan struct{})
+	results := make(chan *corev1.Pod, count)
+
+	var group sync.WaitGroup
+	for range count {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			<-start
+			results <- service.reserveIdleClaimCandidate(candidates)
+		}()
+	}
+	close(start)
+	group.Wait()
+	close(results)
+
+	selected := make(map[string]struct{}, count)
+	for pod := range results {
+		if pod == nil {
+			t.Fatal("reserveIdleClaimCandidate() = nil, want one candidate per caller")
+		}
+		if _, duplicate := selected[pod.Name]; duplicate {
+			t.Fatalf("candidate %q was assigned more than once", pod.Name)
+		}
+		selected[pod.Name] = struct{}{}
+	}
+	if len(selected) != count {
+		t.Fatalf("selected candidates = %d, want %d", len(selected), count)
+	}
+}
+
+func TestClaimIdlePodAvoidsDuplicateCandidatesWithStaleInformer(t *testing.T) {
+	const count = 32
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "template-a", Namespace: "ns-a"},
+	}
+	pods := make([]*corev1.Pod, 0, count)
+	objects := make([]runtime.Object, 0, count)
+	for index := range count {
+		pod := newClaimTestPod("ns-a", fmt.Sprintf("idle-%d", index), "template-a", true)
+		pod.UID = types.UID(fmt.Sprintf("uid-%d", index))
+		pods = append(pods, pod)
+		objects = append(objects, pod.DeepCopy())
+	}
+	client := fake.NewSimpleClientset(objects...)
+	service := &SandboxService{
+		k8sClient: client,
+		podLister: newClaimTestPodLister(t, pods...),
+		clock:     systemTime{},
+		logger:    zap.NewNop(),
+	}
+	start := make(chan struct{})
+	results := make(chan *corev1.Pod, count)
+	errs := make(chan error, count)
+
+	var group sync.WaitGroup
+	for index := range count {
+		group.Add(1)
+		go func(index int) {
+			defer group.Done()
+			<-start
+			pod, err := service.claimIdlePod(context.Background(), template, &ClaimRequest{
+				SandboxID: fmt.Sprintf("sandbox-%d", index),
+				TeamID:    "team-a",
+				UserID:    "user-a",
+			})
+			results <- pod
+			errs <- err
+		}(index)
+	}
+	close(start)
+	group.Wait()
+	close(results)
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("claimIdlePod() error = %v", err)
+		}
+	}
+	selected := make(map[string]struct{}, count)
+	for pod := range results {
+		if pod == nil {
+			t.Fatal("claimIdlePod() = nil, want a hot claim")
+		}
+		if _, duplicate := selected[pod.Name]; duplicate {
+			t.Fatalf("Pod %q was claimed more than once", pod.Name)
+		}
+		selected[pod.Name] = struct{}{}
+		if got := pod.Annotations[controller.AnnotationHotClaimCompletionProtocol]; got != controller.HotClaimCompletionProtocolRecordV1 {
+			t.Fatalf("completion protocol = %q, want %q", got, controller.HotClaimCompletionProtocolRecordV1)
+		}
+	}
+	if len(selected) != count {
+		t.Fatalf("claimed Pods = %d, want %d", len(selected), count)
+	}
+}
+
+func TestPodEventHandlerReleasesObservedIdleClaimReservation(t *testing.T) {
+	pod := newClaimTestPod("ns-a", "idle-a", "template-a", true)
+	service := &SandboxService{}
+	if selected := service.reserveIdleClaimCandidate([]*corev1.Pod{pod}); selected == nil {
+		t.Fatal("initial candidate reservation failed")
+	}
+	if selected := service.reserveIdleClaimCandidate([]*corev1.Pod{pod}); selected != nil {
+		t.Fatalf("reserved candidate was assigned twice: %s", selected.Name)
+	}
+
+	reserved := pod.DeepCopy()
+	reserved.Annotations[controller.AnnotationHotClaimReservation] = "token"
+	service.PodEventHandler().UpdateFunc(pod, reserved)
+
+	if selected := service.reserveIdleClaimCandidate([]*corev1.Pod{pod}); selected == nil {
+		t.Fatal("informer-confirmed reservation did not release the local candidate")
+	}
+}

--- a/manager/pkg/service/sandbox_claim_metadata_patch.go
+++ b/manager/pkg/service/sandbox_claim_metadata_patch.go
@@ -31,7 +31,11 @@ func (s *SandboxService) patchClaimedPodMetadata(
 	if err != nil {
 		return nil, err
 	}
-	return s.k8sClient.CoreV1().Pods(originalPod.Namespace).Patch(
+	client := s.hotClaimClient()
+	if client == nil {
+		return nil, fmt.Errorf("patch claimed pod metadata: kubernetes client is not configured")
+	}
+	return client.CoreV1().Pods(originalPod.Namespace).Patch(
 		ctx,
 		originalPod.Name,
 		types.JSONPatchType,

--- a/manager/pkg/service/sandbox_claim_metadata_patch_test.go
+++ b/manager/pkg/service/sandbox_claim_metadata_patch_test.go
@@ -136,6 +136,31 @@ func TestPatchClaimedPodMetadataRejectsAlreadyClaimedPod(t *testing.T) {
 	}
 }
 
+func TestPatchClaimedPodMetadataUsesHotClaimClient(t *testing.T) {
+	original := newClaimTestPod("sandbox-a", "idle-a", "default", true)
+	original.UID = types.UID("pod-uid")
+	claimed := original.DeepCopy()
+	claimed.Labels[controller.LabelSandboxID] = "sandbox-id"
+	claimed.Annotations[controller.AnnotationSandboxID] = "sandbox-id"
+	ensureSandboxCleanupFinalizer(claimed)
+
+	sharedClient := fake.NewSimpleClientset(original.DeepCopy())
+	hotClaimClient := fake.NewSimpleClientset(original.DeepCopy())
+	service := &SandboxService{
+		k8sClient:         sharedClient,
+		hotClaimK8sClient: hotClaimClient,
+	}
+	if _, err := service.patchClaimedPodMetadata(context.Background(), original, claimed); err != nil {
+		t.Fatalf("patchClaimedPodMetadata() error = %v", err)
+	}
+	if actions := sharedClient.Actions(); len(actions) != 0 {
+		t.Fatalf("shared client actions = %v, want none", actions)
+	}
+	if actions := hotClaimClient.Actions(); len(actions) != 1 || actions[0].GetVerb() != "patch" {
+		t.Fatalf("hot claim client actions = %v, want one patch", actions)
+	}
+}
+
 func TestClaimMetadataPatchPreconditionFailureRecognizesJSONPatchTest(t *testing.T) {
 	err := &apierrors.StatusError{ErrStatus: metav1.Status{
 		Reason:  metav1.StatusReasonInvalid,

--- a/manager/pkg/service/sandbox_service.go
+++ b/manager/pkg/service/sandbox_service.go
@@ -103,6 +103,7 @@ type SandboxServiceConfig struct {
 // SandboxService handles sandbox operations
 type SandboxService struct {
 	k8sClient                              kubernetes.Interface
+	hotClaimK8sClient                      kubernetes.Interface
 	podLister                              corelisters.PodLister
 	nodeLister                             corelisters.NodeLister
 	sandboxIndex                           *SandboxIndex
@@ -129,6 +130,8 @@ type SandboxService struct {
 	templateImageBuildCapabilityConfigured bool
 	templateImageBuildAvailable            bool
 	resumeGroup                            singleflight.Group
+	idleClaimMu                            sync.Mutex
+	idleClaimReservations                  map[string]string
 	podWaiterMu                            sync.Mutex
 	podWaiter                              *podEventWaiter
 }
@@ -227,6 +230,7 @@ func NewSandboxService(
 		config:                 config,
 		logger:                 logger,
 		metrics:                metrics,
+		idleClaimReservations:  make(map[string]string),
 		podWaiter:              newPodEventWaiter(),
 	}
 	return service
@@ -237,7 +241,27 @@ func (s *SandboxService) PodEventHandler() cache.ResourceEventHandlerFuncs {
 	if s == nil {
 		return cache.ResourceEventHandlerFuncs{}
 	}
-	return s.ensurePodEventWaiter().ResourceEventHandler()
+	waiterHandler := s.ensurePodEventWaiter().ResourceEventHandler()
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) {
+			if waiterHandler.AddFunc != nil {
+				waiterHandler.AddFunc(obj)
+			}
+			s.observeIdleClaimPodEvent(obj, false)
+		},
+		UpdateFunc: func(oldObj, newObj any) {
+			if waiterHandler.UpdateFunc != nil {
+				waiterHandler.UpdateFunc(oldObj, newObj)
+			}
+			s.observeIdleClaimPodEvent(newObj, false)
+		},
+		DeleteFunc: func(obj any) {
+			if waiterHandler.DeleteFunc != nil {
+				waiterHandler.DeleteFunc(obj)
+			}
+			s.observeIdleClaimPodEvent(obj, true)
+		},
+	}
 }
 
 func (s *SandboxService) ensurePodEventWaiter() *podEventWaiter {
@@ -282,6 +306,15 @@ func (s *SandboxService) SetHotClaimReservationEnqueuer(enqueuer HotClaimReserva
 		return
 	}
 	s.hotClaimReservationEnqueuer = enqueuer
+}
+
+// SetHotClaimK8sClient injects the Kubernetes client whose rate budget is
+// reserved for latency-sensitive hot-claim operations.
+func (s *SandboxService) SetHotClaimK8sClient(client kubernetes.Interface) {
+	if s == nil || client == nil {
+		return
+	}
+	s.hotClaimK8sClient = client
 }
 
 // SetCredentialStore injects the sandbox credential binding store.

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math/rand"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -622,19 +621,6 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 		return nil, fmt.Errorf("persist sandbox: %w", persistErr)
 	}
 
-	if controller.IsHotClaimReservedPod(pod) {
-		phaseStarted = time.Now()
-		pod, err = s.markHotClaimReservationReady(ctx, pod)
-		s.observeClaimPhase(req.Template, claimType, "complete_hot_claim_reservation", phaseStarted, err)
-		if err != nil {
-			cleanupClaimFailure(pod, "hot claim reservation completion failed")
-			if metrics != nil {
-				metrics.SandboxClaimsTotal.WithLabelValues(req.Template, "error").Inc()
-			}
-			return nil, fmt.Errorf("complete hot claim reservation: %w", err)
-		}
-	}
-
 	if persistResultCh == nil {
 		phaseStarted = time.Now()
 		persistErr = s.persistClaimedSandbox(ctx, pod, template, req)
@@ -647,6 +633,18 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 			return nil, fmt.Errorf("persist sandbox: %w", persistErr)
 		}
 		claimRecordPersisted = true
+	}
+	if controller.IsHotClaimReservedPod(pod) {
+		phaseStarted = time.Now()
+		err = s.completeHotClaimReservation(ctx, pod, template, req)
+		s.observeClaimPhase(req.Template, claimType, "complete_hot_claim_reservation", phaseStarted, err)
+		if err != nil {
+			cleanupClaimFailure(pod, "hot claim reservation completion failed")
+			if metrics != nil {
+				metrics.SandboxClaimsTotal.WithLabelValues(req.Template, "error").Inc()
+			}
+			return nil, fmt.Errorf("complete hot claim reservation: %w", err)
+		}
 	}
 	s.enqueueHotClaimReservation(pod)
 
@@ -683,7 +681,7 @@ func sandboxRecordForClaimedPod(s *SandboxService, pod *corev1.Pod, template *v1
 	}
 	cfg := parseSandboxConfig(pod.Annotations[controller.AnnotationConfig])
 	mounts := parseClaimMounts(pod.Annotations[controller.AnnotationMounts])
-	return &SandboxRecord{
+	record := &SandboxRecord{
 		ID:                   sandboxID,
 		TeamID:               req.TeamID,
 		UserID:               req.UserID,
@@ -705,6 +703,12 @@ func sandboxRecordForClaimedPod(s *SandboxService, pod *corev1.Pod, template *v1
 		OwnerKind:            ownerKindFromPod(pod),
 		CreatedAt:            s.clock.Now(),
 	}
+	if hotClaimUsesRecordCompletion(pod) &&
+		pod.Annotations[controller.AnnotationHotClaimReservationState] ==
+			controller.HotClaimReservationStateInitializing {
+		record.Status = SandboxStatusStarting
+	}
+	return record
 }
 
 func (s *SandboxService) initializeClaimRootFSFromSnapshot(ctx context.Context, pod *corev1.Pod, template *v1alpha1.SandboxTemplate, req *ClaimRequest) (*corev1.Pod, bool, error) {
@@ -1099,8 +1103,20 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 			return errNoIdlePod
 		}
 
-		// Claim an available pod
-		pod := readyPods[rand.Intn(len(readyPods))]
+		// Reserve one informer-cached candidate inside this manager before any
+		// claim side effects. The Kubernetes metadata patch remains the
+		// cross-process compare-and-swap boundary.
+		pod := s.reserveIdleClaimCandidate(readyPods)
+		if pod == nil {
+			s.observeIdleClaim(templateID, "local_contention")
+			return errNoIdlePod
+		}
+		reservationPersisted := false
+		defer func() {
+			if !reservationPersisted {
+				s.releaseIdleClaimCandidate(pod)
+			}
+		}()
 
 		sandboxID := strings.TrimSpace(req.SandboxID)
 		if sandboxID == "" {
@@ -1162,6 +1178,7 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 		pod.Annotations[controller.AnnotationHotClaimReservation] = reservationToken
 		pod.Annotations[controller.AnnotationHotClaimReservationState] = controller.HotClaimReservationStateInitializing
 		pod.Annotations[controller.AnnotationHotClaimReservedAt] = s.clock.Now().UTC().Format(time.RFC3339Nano)
+		pod.Annotations[controller.AnnotationHotClaimCompletionProtocol] = controller.HotClaimCompletionProtocolRecordV1
 		if stateVolume != nil {
 			pod.Annotations[controller.AnnotationWebhookStateVolumeID] = stateVolume.VolumeID
 		} else {
@@ -1233,9 +1250,18 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 			return updateErr
 		}
 		s.observeIdleClaim(templateID, "reserved")
+		// Keep the local reservation until the shared informer observes this
+		// durable reservation. Releasing it at PATCH return would reopen the
+		// stale-cache window that caused duplicate candidate selection.
+		reservationPersisted = true
 
 		if resizeQuota != nil {
-			resizedPod, resizeErr := s.resizeSandboxPodResources(ctx, updatedPod, *resizeQuota)
+			resizedPod, resizeErr := s.resizeSandboxPodResourcesWithClient(
+				ctx,
+				s.hotClaimClient(),
+				updatedPod,
+				*resizeQuota,
+			)
 			if resizeErr != nil {
 				rollbackStateVolume()
 				if rollbackErr := rollbackBindings(ctx); rollbackErr != nil {
@@ -1342,10 +1368,14 @@ func (s *SandboxService) claimMetadataPatchPreconditionFailed(
 	if isClaimMetadataPatchPreconditionFailure(err) {
 		return true
 	}
-	if !k8serrors.IsInvalid(err) || s == nil || s.k8sClient == nil || originalPod == nil {
+	if !k8serrors.IsInvalid(err) || s == nil || originalPod == nil {
 		return false
 	}
-	current, getErr := s.k8sClient.CoreV1().Pods(originalPod.Namespace).Get(
+	client := s.hotClaimClient()
+	if client == nil {
+		return false
+	}
+	current, getErr := client.CoreV1().Pods(originalPod.Namespace).Get(
 		ctx,
 		originalPod.Name,
 		metav1.GetOptions{},

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -119,6 +119,9 @@ func TestClaimIdlePodClaimsReadyPod(t *testing.T) {
 	if got := pod.Annotations[controller.AnnotationHotClaimReservationState]; got != controller.HotClaimReservationStateInitializing {
 		t.Fatalf("reservation state = %q, want %q", got, controller.HotClaimReservationStateInitializing)
 	}
+	if got := pod.Annotations[controller.AnnotationHotClaimCompletionProtocol]; got != controller.HotClaimCompletionProtocolRecordV1 {
+		t.Fatalf("completion protocol = %q, want %q", got, controller.HotClaimCompletionProtocolRecordV1)
+	}
 	if got := pod.Annotations[controller.AnnotationClusterAutoscalerSafeToEvict]; got != "false" {
 		t.Fatalf("safe-to-evict annotation = %q, want false", got)
 	}
@@ -1438,6 +1441,15 @@ func TestClaimSandboxOverlapsHotPersistenceWithProcdInitialization(t *testing.T)
 		if record.Status != SandboxStatusRunning {
 			t.Fatalf("sandbox record status = %q, want running", record.Status)
 		}
+	}
+	podPatches := 0
+	for _, action := range client.Actions() {
+		if action.GetVerb() == "patch" && action.GetResource().Resource == "pods" {
+			podPatches++
+		}
+	}
+	if podPatches != 1 {
+		t.Fatalf("claim-path Pod patches = %d, want one reservation patch", podPatches)
 	}
 }
 

--- a/manager/pkg/service/sandbox_service_resources.go
+++ b/manager/pkg/service/sandbox_service_resources.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
 )
 
@@ -44,7 +45,19 @@ func (s *SandboxService) applySandboxResourceQuota(pod *corev1.Pod, quota v1alph
 }
 
 func (s *SandboxService) resizeSandboxPodResources(ctx context.Context, pod *corev1.Pod, quota v1alpha1.ResourceQuota) (*corev1.Pod, error) {
-	if s == nil || s.k8sClient == nil {
+	if s == nil {
+		return nil, fmt.Errorf("%w: kubernetes client is not configured", ErrInvalidClaimRequest)
+	}
+	return s.resizeSandboxPodResourcesWithClient(ctx, s.k8sClient, pod, quota)
+}
+
+func (s *SandboxService) resizeSandboxPodResourcesWithClient(
+	ctx context.Context,
+	client kubernetes.Interface,
+	pod *corev1.Pod,
+	quota v1alpha1.ResourceQuota,
+) (*corev1.Pod, error) {
+	if client == nil {
 		return nil, fmt.Errorf("%w: kubernetes client is not configured", ErrInvalidClaimRequest)
 	}
 	if pod == nil || pod.Namespace == "" || pod.Name == "" {
@@ -66,7 +79,7 @@ func (s *SandboxService) resizeSandboxPodResources(ctx context.Context, pod *cor
 		return nil, fmt.Errorf("build sandbox resource resize patch: %w", err)
 	}
 	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		result, err := s.k8sClient.CoreV1().Pods(namespace).Patch(
+		result, err := client.CoreV1().Pods(namespace).Patch(
 			ctx,
 			name,
 			types.StrategicMergePatchType,

--- a/manager/pkg/service/sandbox_service_restore.go
+++ b/manager/pkg/service/sandbox_service_restore.go
@@ -241,16 +241,6 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 		}
 		return nil, err
 	}
-	if controller.IsHotClaimReservedPod(restoredPod) {
-		restoredPod, err = s.markHotClaimReservationReady(ctx, restoredPod)
-		if err != nil {
-			s.requestSandboxDeletionAfterClaimFailure(restoredPod, "restored hot claim reservation completion failed")
-			if txn != nil {
-				_ = s.abortLifecycleTxn(context.Background(), sandboxID, txn.ID, err.Error())
-			}
-			return nil, fmt.Errorf("complete restored hot claim reservation: %w", err)
-		}
-	}
 	if txn != nil {
 		if err := s.commitResumedSandboxRuntime(ctx, restoredPod, record, txn); err != nil {
 			s.requestSandboxDeletionAfterClaimFailure(restoredPod, "restored runtime commit failed")


### PR DESCRIPTION
## What

- reduce the foreground hot-claim Pod mutations from two PATCHes to one by completing initialization through the durable sandbox record and leaving warm-pool detachment to the existing background controller
- reserve informer-cached idle candidates inside each manager process until the informer observes the Kubernetes reservation, preventing concurrent claims from repeatedly selecting the same stale candidate
- give latency-sensitive hot-claim PATCH/GET/resize calls an independent Kubernetes client token bucket so cleanup, refill, and detachment traffic cannot consume their client-side budget
- remove `resourceVersion` from the background detachment CAS while retaining UID, pool label, reservation token, and reservation state preconditions

## Why

At burst concurrency, claims could collide on one stale informer candidate, contend on a shared client-side Kubernetes rate limiter, and perform a second foreground Pod PATCH after procd initialization. These costs showed up directly in burst TTI and amplified API-server contention.

The durable sandbox record now moves from `starting` to `running` only after persistence and procd initialization complete. A versioned Pod annotation tells the new reservation controller that this record transition is the completion signal. Legacy `ready` reservations remain supported, and an initializing legacy reservation is not inferred complete from a running record.

## Safety

- Kubernetes metadata CAS remains the cross-process ownership boundary; the local allocator only removes same-process duplicate selection.
- The completion protocol marker prevents mixed-version forward rollouts from detaching legacy initializing claims prematurely.
- A crash before the durable `running` transition remains recoverable as an abandoned reservation; a crash after it lets the controller safely detach the completed claim.
- Background detachment still verifies Pod UID, idle-pool label, reservation token, exact state, and the matching durable sandbox identity/generation.

## Validation

Local:

- `CONFIG_PATH=/dev/null go test ./manager/pkg/service ./manager/cmd/manager -count=1`
- `CONFIG_PATH=/dev/null go test -race ./manager/pkg/service -count=1`
- `go vet ./manager/pkg/service ./manager/cmd/manager`
- `CONFIG_PATH=/dev/null go test ./manager/... -count=1`

Persistent Aliyun Singapore kind environment:

- fullmode deployment became Ready; manager used the branch image with the dedicated hot-claim client enabled
- one 128 MiB default claim passed command execution, binary file write/read, deletion, and idle-pool replenishment
- a persistent 128 MiB test template with 16 ready idle Pods handled 16 simultaneous hot claims: 16/16 HTTP 201 in 908 ms wall time, 16 unique sandbox IDs, and the claimed Pod set exactly matched the 16 prepared idle Pods
- all 16 durable records reached `running`; all 16 reservations detached; no reservation/protocol annotations remained
- metrics reported 16 `reserved`, 16 `success`, no `update_conflict`, and 16 hot completions; manager remained Ready with zero restarts and no client-side 429/throttle or panic
- all temporary sandboxes/template resources were deleted and the remote ECS instance was returned to `Stopped/StopCharging`

## ComputeSDK benchmark

Private ComputeSDK commit `15b1a338171f5631c266bb480e8491cba3f6a4e3`, 100 iterations per mode:

| Mode | Score | Success | Median | P95 | P99 | Wall | First ready |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| sequential | 97.01 | 100/100 | 214.95 ms | 402.91 ms | 464.64 ms | — | — |
| staggered | 96.03 | 100/100 | 294.49 ms | 541.22 ms | 567.71 ms | 20.89 s | 185.06 ms |
| burst 1 | 79.74 | 100/100 | 1,854.21 ms | 2,262.82 ms | 2,321.11 ms | 4.89 s | 965.63 ms |
| burst 2 | 82.09 | 100/100 | 1,385.17 ms | 2,389.65 ms | 2,414.42 ms | 3.80 s | 742.99 ms |

Compared with the previous same-boundary PR #758 run:

- staggered: score +5.74, median -67.88%, P95 -48.02%
- burst 1: score +10.24, P95 -49.32%, wall -27.79%
- burst 2: score +20.25, median -42.75%, P95 -57.90%, wall -50.55%

Both burst rounds are retained. The result measures the three changes together and does not isolate the contribution of one change.

Exact boundary:

- image `sandbox0ai/infra:pr759-a146226`, digest `sha256:7fdba52d958c615c05f8dc4c9d8a4aef94e6bf02a4473d596de3fd57dce79b7f`
- [image CI](https://github.com/sandbox0-ai/sandbox0/actions/runs/30218755018)
- [successful Ali us-east-1 GitOps deployment](https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/30219687731)
- one original fixed `ecs.r9ae.2xlarge` sandbox node, 8 vCPU / about 64 GiB
- default pool `minIdle=maxIdle=120`; all 120 idle Pods Ready at `128Mi/150m`
- benchmark sandboxes explicitly requested `memory=128Mi`, avoiding resize
- burst capacity locked to `0-0`; actual burst nodes remained zero for all four formal runs
- the temporary runner called the in-cluster regional gateway, removing external network effects
- no ComputeSDK ingest address or key was set and no upload workflow was called

The deployed manager metrics exactly covered the runner plus the four formal rounds: 401/401 successful default hot claims, 401 idle reservations, 401 idle successes, and no `update_conflict` or error series. Mean manager claim time was 262.04 ms (`claim_idle_pod` 163.84 ms; reservation completion 21.96 ms). Shared and hot-claim Kubernetes clients both reported their independent `50 QPS / 100 burst` budgets.

The runner was deleted, the three temporary team quota overrides were removed, and burst capacity was restored to `0-299` with zero actual burst nodes. Final preflight: one original fixed node, idle/Ready `120/120`, active 0, pending 0, idle restart 0; exact PR image remained Ready across all core workloads.

After burst 1, two newly refilled idle Pods each self-recovered from one gVisor `StartError` caused by an incomplete mounts JSON read. They were removed and replaced before burst 2 so the baseline returned to idle restart 0. This is a separate ctld/rootfs atomic-write issue, not a manager hot-claim path change in this PR.
