### PR TITLE
fix(netd): negotiate upstream HTTPS ALPN

### DIFF
--- a/docs/credential/egress-auth/page.mdx
+++ b/docs/credential/egress-auth/page.mdx
@@ -489,7 +489,7 @@ When a credential rule uses TLS interception such as `protocol: https`, `protoco
 
 At procd startup, Sandbox0 writes a combined CA bundle containing the image's system roots plus the network-runtime MITM CA, then exports it through common TLS environment variables such as `SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`, and `AWS_CA_BUNDLE`. Applications normally do not need to handle the MITM CA themselves.
 
-For HTTPS credential injection, the ctld network runtime supports both HTTP/1.1 and HTTP/2 on `terminate-reoriginate` connections. Clients that offer HTTP/2 negotiate HTTP/2; HTTP/1.1-only clients continue to use HTTP/1.1. Ctld preserves the negotiated downstream ALPN protocol when re-originating upstream traffic and does not silently downgrade an HTTP/2 downstream request to HTTP/1.1 upstream.
+For HTTPS credential injection, the ctld network runtime supports both HTTP/1.1 and HTTP/2 on `terminate-reoriginate` connections. Downstream and upstream ALPN are negotiated independently, so an HTTP/2 client can still reach an HTTP/1.1-only HTTPS origin through the proxy. Ctld keeps gRPC HTTP/2-only and rejects an upstream connection that cannot negotiate `h2`.
 
 ## Example Policy
 

--- a/netd/pkg/proxy/http2_proxy.go
+++ b/netd/pkg/proxy/http2_proxy.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"bufio"
 	"context"
 	"crypto/tls"
 	"errors"
@@ -12,6 +13,7 @@ import (
 	"strings"
 	"sync/atomic"
 
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/netd/pkg/policy"
 	"go.uber.org/zap"
 	"golang.org/x/net/http2"
@@ -110,12 +112,13 @@ func (s *Server) proxyHTTP2FromConn(downstream *tls.Conn, req *adapterRequest) e
 			if errors.Is(err, errProtocolPolicyDenied) {
 				return
 			}
-			s.logger.Warn("HTTP/2 proxy request failed",
+			s.logger.Warn("HTTP/2 downstream proxy request failed",
 				zap.Error(err),
 				zap.String("host", req.Host),
 				zap.Int("port", req.DestPort),
+				zap.String("sandbox_id", compiledSandboxID(req.Compiled)),
 			)
-			http.Error(w, "upstream http2 request failed", http.StatusBadGateway)
+			http.Error(w, "upstream http request failed", http.StatusBadGateway)
 		}
 	})
 
@@ -139,8 +142,6 @@ func (s *Server) handleHTTP2ProxyRequest(w http.ResponseWriter, downstreamReq *h
 	if w == nil || downstreamReq == nil || req == nil {
 		return fmt.Errorf("http2 proxy request is incomplete")
 	}
-	transport := s.newHTTP2Transport(req, upstreamCounter)
-	defer transport.CloseIdleConnections()
 
 	requestScoped := *req
 	if req.EgressAuth != nil {
@@ -185,10 +186,11 @@ func (s *Server) handleHTTP2ProxyRequest(w http.ResponseWriter, downstreamReq *h
 		return err
 	}
 
-	resp, err := transport.RoundTrip(upstreamReq)
+	resp, closeUpstream, err := s.roundTripHTTP2DownstreamRequest(upstreamReq, &requestScoped, upstreamCounter)
 	if err != nil {
-		return fmt.Errorf("round trip upstream http2 request: %w", err)
+		return fmt.Errorf("round trip upstream http request: %w", err)
 	}
+	defer closeUpstream()
 	defer resp.Body.Close()
 
 	declareResponseTrailers(w, resp.Trailer)
@@ -202,41 +204,85 @@ func (s *Server) handleHTTP2ProxyRequest(w http.ResponseWriter, downstreamReq *h
 	return nil
 }
 
-func (s *Server) newHTTP2Transport(req *adapterRequest, upstreamCounter **countingConn) *http2.Transport {
+// roundTripHTTP2DownstreamRequest negotiates the upstream HTTP version
+// independently from the downstream HTTP/2 connection. Ordinary HTTPS can
+// bridge to an HTTP/1.1-only origin, while gRPC remains HTTP/2-only.
+func (s *Server) roundTripHTTP2DownstreamRequest(
+	httpReq *http.Request,
+	req *adapterRequest,
+	upstreamCounter **countingConn,
+) (*http.Response, func(), error) {
+	if s == nil || httpReq == nil || req == nil {
+		return nil, nil, fmt.Errorf("upstream http request is incomplete")
+	}
 	cfg := cloneTLSConfig(s.upstreamTLSConfig)
 	if cfg.ServerName == "" {
 		cfg.ServerName = req.Host
 	}
-	cfg.NextProtos = []string{"h2"}
-	return &http2.Transport{
-		TLSClientConfig: cfg,
-		DialTLSContext: func(ctx context.Context, network, addr string, tlsCfg *tls.Config) (net.Conn, error) {
-			_ = network
-			_ = addr
-			_ = tlsCfg
-			rawConn, err := s.dialTCPUpstreamForRequest(req)
-			if err != nil {
-				return nil, fmt.Errorf("dial upstream http2 tls: %w", err)
-			}
-			conn := tls.Client(rawConn, cfg)
-			if err := conn.HandshakeContext(ctx); err != nil {
-				_ = rawConn.Close()
-				return nil, fmt.Errorf("handshake upstream http2 tls: %w", err)
-			}
-			wrapped := &countingConn{
-				Conn:     conn,
-				limiter:  s.bandwidthLimiter,
-				compiled: req.Compiled,
-				// Ingress is charged when the downstream connection is
-				// written. Reads remain counted for metering only.
-				readDirection:  "",
-				writeDirection: bandwidthEgress,
-			}
-			if upstreamCounter != nil && *upstreamCounter == nil {
-				*upstreamCounter = wrapped
-			}
-			return wrapped, nil
-		},
+	requiresHTTP2 := req.EgressAuth != nil &&
+		req.EgressAuth.Rule != nil &&
+		req.EgressAuth.Rule.Protocol == v1alpha1.EgressAuthProtocolGRPC
+	if requiresHTTP2 {
+		cfg.NextProtos = []string{"h2"}
+	} else {
+		cfg.NextProtos = []string{"h2", "http/1.1"}
+	}
+
+	rawConn, err := s.dialTCPUpstreamForRequest(req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("dial upstream tls: %w", err)
+	}
+	tlsConn := tls.Client(rawConn, cfg)
+	if err := tlsConn.HandshakeContext(httpReq.Context()); err != nil {
+		_ = rawConn.Close()
+		return nil, nil, fmt.Errorf("handshake upstream tls: %w", err)
+	}
+	wrapped := &countingConn{
+		Conn:     tlsConn,
+		limiter:  s.bandwidthLimiter,
+		compiled: req.Compiled,
+		// Ingress is charged when the downstream connection is written.
+		// Reads remain counted for metering only.
+		readDirection:  "",
+		writeDirection: bandwidthEgress,
+	}
+	if upstreamCounter != nil && *upstreamCounter == nil {
+		*upstreamCounter = wrapped
+	}
+
+	switch negotiated := tlsConn.ConnectionState().NegotiatedProtocol; negotiated {
+	case "h2":
+		transport := &http2.Transport{}
+		clientConn, err := transport.NewClientConn(wrapped)
+		if err != nil {
+			_ = wrapped.Close()
+			return nil, nil, fmt.Errorf("initialize upstream http2 connection: %w", err)
+		}
+		resp, err := clientConn.RoundTrip(httpReq)
+		if err != nil {
+			_ = clientConn.Close()
+			return nil, nil, fmt.Errorf("round trip upstream http2 request: %w", err)
+		}
+		return resp, func() { _ = clientConn.Close() }, nil
+	case "", "http/1.1":
+		if requiresHTTP2 {
+			_ = wrapped.Close()
+			return nil, nil, fmt.Errorf("grpc upstream did not negotiate h2")
+		}
+		httpReq.Close = true
+		if err := httpReq.Write(wrapped); err != nil {
+			_ = wrapped.Close()
+			return nil, nil, fmt.Errorf("write upstream http1 request: %w", err)
+		}
+		resp, err := http.ReadResponse(bufio.NewReader(wrapped), httpReq)
+		if err != nil {
+			_ = wrapped.Close()
+			return nil, nil, fmt.Errorf("read upstream http1 response: %w", err)
+		}
+		return resp, func() { _ = wrapped.Close() }, nil
+	default:
+		_ = wrapped.Close()
+		return nil, nil, fmt.Errorf("upstream negotiated unsupported ALPN protocol %q", negotiated)
 	}
 }
 

--- a/netd/pkg/proxy/tls_proxy_test.go
+++ b/netd/pkg/proxy/tls_proxy_test.go
@@ -433,6 +433,22 @@ func TestTLSAdapterDefersHTTPSHeaderResolutionUntilAfterDownstreamHandshake(t *t
 }
 
 func TestTLSAdapterInterceptsHTTPSOverHTTP2AndInjectsHeaders(t *testing.T) {
+	for _, tc := range []struct {
+		name                 string
+		upstreamALPN         string
+		wantUpstreamProtocol string
+	}{
+		{name: "upstream_http2", upstreamALPN: "h2", wantUpstreamProtocol: "HTTP/2.0"},
+		{name: "upstream_http1", upstreamALPN: "http/1.1", wantUpstreamProtocol: "HTTP/1.1"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			testTLSAdapterInterceptsHTTPSOverHTTP2AndInjectsHeaders(t, tc.upstreamALPN, tc.wantUpstreamProtocol)
+		})
+	}
+}
+
+func testTLSAdapterInterceptsHTTPSOverHTTP2AndInjectsHeaders(t *testing.T, upstreamALPN, wantUpstreamProtocol string) {
+	t.Helper()
 	mitmCertPEM, mitmKeyPEM, err := newSelfSignedCertificateAuthority("sandbox0-mitm", time.Hour)
 	if err != nil {
 		t.Fatalf("new mitm ca: %v", err)
@@ -464,7 +480,7 @@ func TestTLSAdapterInterceptsHTTPSOverHTTP2AndInjectsHeaders(t *testing.T) {
 	requestProtocol := make(chan string, 1)
 	upstreamListener, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{
 		Certificates: []tls.Certificate{*upstreamLeaf},
-		NextProtos:   []string{"h2"},
+		NextProtos:   []string{upstreamALPN},
 		MinVersion:   tls.VersionTLS12,
 	})
 	if err != nil {
@@ -482,11 +498,13 @@ func TestTLSAdapterInterceptsHTTPSOverHTTP2AndInjectsHeaders(t *testing.T) {
 			requestHeaders <- r.Header.Clone()
 			requestBody <- string(body)
 			requestProtocol <- r.Proto
-			_, _ = w.Write([]byte("h2-secure-ok"))
+			_, _ = w.Write([]byte("secure-ok"))
 		}),
 	}
-	if err := http2.ConfigureServer(upstreamServer, &http2.Server{}); err != nil {
-		t.Fatalf("configure upstream http2 server: %v", err)
+	if upstreamALPN == "h2" {
+		if err := http2.ConfigureServer(upstreamServer, &http2.Server{}); err != nil {
+			t.Fatalf("configure upstream http2 server: %v", err)
+		}
 	}
 	defer upstreamServer.Close()
 	go func() {
@@ -590,14 +608,14 @@ func TestTLSAdapterInterceptsHTTPSOverHTTP2AndInjectsHeaders(t *testing.T) {
 		t.Fatalf("read http2 response body: %v", err)
 	}
 	_ = resp.Body.Close()
-	if got := string(body); got != "h2-secure-ok" {
+	if got := string(body); got != "secure-ok" {
 		t.Fatalf("response body = %q", got)
 	}
 	if got := <-negotiatedProtocol; got != "h2" {
 		t.Fatalf("negotiated protocol = %q, want h2", got)
 	}
-	if got := <-requestProtocol; got != "HTTP/2.0" {
-		t.Fatalf("upstream protocol = %q, want HTTP/2.0", got)
+	if got := <-requestProtocol; got != wantUpstreamProtocol {
+		t.Fatalf("upstream protocol = %q, want %s", got, wantUpstreamProtocol)
 	}
 	headers := <-requestHeaders
 	if got := headers.Get("Authorization"); got != "Bearer h2-token" {
@@ -614,6 +632,78 @@ func TestTLSAdapterInterceptsHTTPSOverHTTP2AndInjectsHeaders(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for tls adapter")
+	}
+}
+
+func TestHTTP2DownstreamProxyRequiresHTTP2UpstreamForGRPC(t *testing.T) {
+	upstreamCAPEM, upstreamCAKeyPEM, err := newSelfSignedCertificateAuthority("sandbox0-upstream", time.Hour)
+	if err != nil {
+		t.Fatalf("new upstream ca: %v", err)
+	}
+	upstreamAuthority, err := newCertificateAuthority(upstreamCAPEM, upstreamCAKeyPEM, time.Hour)
+	if err != nil {
+		t.Fatalf("new upstream authority: %v", err)
+	}
+	upstreamLeaf, err := upstreamAuthority.CertificateForHost("api.example.com")
+	if err != nil {
+		t.Fatalf("upstream leaf: %v", err)
+	}
+	upstreamRootPool := x509.NewCertPool()
+	if !upstreamRootPool.AppendCertsFromPEM(upstreamCAPEM) {
+		t.Fatal("append upstream ca")
+	}
+
+	upstreamListener, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{
+		Certificates: []tls.Certificate{*upstreamLeaf},
+		NextProtos:   []string{"http/1.1"},
+		MinVersion:   tls.VersionTLS12,
+	})
+	if err != nil {
+		t.Fatalf("listen upstream: %v", err)
+	}
+	defer upstreamListener.Close()
+	upstreamServer := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("unexpected-http1"))
+		}),
+	}
+	defer upstreamServer.Close()
+	go func() {
+		_ = upstreamServer.Serve(upstreamListener)
+	}()
+
+	server := &Server{
+		cfg: &config.NetdConfig{
+			ProxyUpstreamTimeout: metav1.Duration{Duration: 2 * time.Second},
+		},
+		logger:            zap.NewNop(),
+		upstreamTLSConfig: &tls.Config{RootCAs: upstreamRootPool},
+	}
+	req := &adapterRequest{
+		Compiled: &policy.CompiledPolicy{SandboxID: "sbx_123", TeamID: "team_123"},
+		DestIP:   upstreamListener.Addr().(*net.TCPAddr).IP,
+		DestPort: upstreamListener.Addr().(*net.TCPAddr).Port,
+		Host:     "api.example.com",
+		EgressAuth: &egressAuthContext{
+			Rule: &policy.CompiledEgressAuthRule{
+				Protocol: v1alpha1.EgressAuthProtocolGRPC,
+			},
+		},
+	}
+	httpReq, err := http.NewRequest(http.MethodPost, "https://api.example.com/grpc.health.v1.Health/Check", strings.NewReader(""))
+	if err != nil {
+		t.Fatalf("new grpc request: %v", err)
+	}
+
+	resp, closeUpstream, err := server.roundTripHTTP2DownstreamRequest(httpReq, req, nil)
+	if closeUpstream != nil {
+		defer closeUpstream()
+	}
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+	if err == nil || !strings.Contains(err.Error(), "handshake upstream tls") {
+		t.Fatalf("expected upstream h2 negotiation error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- negotiate upstream HTTPS ALPN independently from the downstream HTTP/2 connection
- bridge ordinary HTTPS requests to HTTP/1.1-only origins while keeping gRPC HTTP/2-only
- add HTTP/2-to-HTTP/1.1 and gRPC regression coverage and update the egress-auth documentation

## Root cause

The HTTP/2 downstream proxy used an `http2.Transport` that offered only `h2` when it re-originated TLS upstream. HTTPS origins that support only HTTP/1.1 reject that TLS handshake with `no application protocol`, so ctld returned a proxy-generated 502 even though credential resolution and injection were working.

## Impact

HTTP/2-capable sandbox clients can now use HTTPS credential injection against HTTP/1.1-only origins. Existing HTTP/2 origins remain HTTP/2, and gRPC continues to fail closed if the upstream cannot negotiate `h2`.

## Validation

- `make test netd`
- targeted HTTPS HTTP/2, HTTP/1.1 fallback, and gRPC tests
- remote Aliyun Singapore kind deployment reached `Ready 10/10`
- direct request from the remote host negotiated HTTP/1.1 with `api.dataforseo.com`
- the same endpoint through ctld negotiated HTTP/2 downstream and returned DataForSEO's own HTTP 401 / `status_code: 40100` / `cost: 0`, with no proxy 502

The remote DataForSEO check used an intentionally invalid one-time credential, so it did not invoke a billable API operation.
