### PR TITLE
fix(cluster-gateway): synchronize audit delivery completion

### DIFF
--- a/cluster-gateway/pkg/http/audit_delivery.go
+++ b/cluster-gateway/pkg/http/audit_delivery.go
@@ -264,9 +264,9 @@ func (d *auditDelivery) completeCanonicalCall(call *auditCanonicalCall, err erro
 		if d.canonicalCalls[call.event.EventID] == call {
 			delete(d.canonicalCalls, call.event.EventID)
 		}
+		d.pendingCalls.Add(-1)
 		close(call.done)
 		d.canonicalMu.Unlock()
-		d.pendingCalls.Add(-1)
 	})
 }
 
@@ -369,14 +369,22 @@ func (d *auditDelivery) dispatchCanonicalBatch(
 	d.observeStage(source, "slot_wait", slotStarted, nil)
 
 	go func() {
-		defer d.canonicalGate.RUnlock()
-		defer d.releaseCanonicalSlot()
-		d.observeInFlightDelta(1)
-		defer d.observeInFlightDelta(-1)
+		results := func() []error {
+			defer d.canonicalGate.RUnlock()
+			defer d.releaseCanonicalSlot()
+			d.observeInFlightDelta(1)
+			defer d.observeInFlightDelta(-1)
 
-		deliveryCtx, cancel := context.WithTimeout(ctx, auditCanonicalDeliveryTimeout)
-		defer cancel()
-		d.deliverCanonicalBatch(deliveryCtx, batch, source)
+			deliveryCtx, cancel := context.WithTimeout(ctx, auditCanonicalDeliveryTimeout)
+			defer cancel()
+			return d.deliverCanonicalBatch(deliveryCtx, batch, source)
+		}()
+
+		// Publish completion only after the batch has released every shared
+		// resource so callers observe a quiescent canonical delivery state.
+		for index, call := range batch {
+			d.completeCanonicalCall(call, results[index])
+		}
 	}()
 }
 
@@ -384,30 +392,30 @@ func (d *auditDelivery) deliverCanonicalBatch(
 	ctx context.Context,
 	batch []*auditCanonicalCall,
 	source string,
-) {
-	pending := make([]*auditCanonicalCall, 0, len(batch))
+) []error {
+	results := make([]error, len(batch))
+	pendingIndexes := make([]int, 0, len(batch))
 	events := make([]sandboxobservability.Event, 0, len(batch))
 	d.mu.Lock()
-	for _, call := range batch {
+	for index, call := range batch {
 		isPending, err := d.pendingLocked(call.event.EventID)
 		if err != nil {
 			d.mu.Unlock()
 			pendingErr := d.pendingCanonicalError("durable spool inspection failed", err)
-			for _, candidate := range batch {
-				d.completeCanonicalCall(candidate, pendingErr)
+			for index := range results {
+				results[index] = pendingErr
 			}
-			return
+			return results
 		}
 		if !isPending {
-			d.completeCanonicalCall(call, nil)
 			continue
 		}
-		pending = append(pending, call)
+		pendingIndexes = append(pendingIndexes, index)
 		events = append(events, call.event)
 	}
 	d.mu.Unlock()
 	if len(events) == 0 {
-		return
+		return results
 	}
 
 	insertStarted := time.Now()
@@ -416,15 +424,15 @@ func (d *auditDelivery) deliverCanonicalBatch(
 	d.observeBatchSize(source, len(events), insertErr)
 	if insertErr != nil {
 		pendingErr := d.pendingCanonicalError("canonical storage did not acknowledge the batch", insertErr)
-		for _, call := range pending {
-			d.completeCanonicalCall(call, pendingErr)
+		for _, index := range pendingIndexes {
+			results[index] = pendingErr
 		}
 		d.logger.Warn("Sandbox audit batch buffered for retry",
 			zap.Int("batch_size", len(events)),
 			zap.Error(insertErr),
 		)
 		d.signalReplay()
-		return
+		return results
 	}
 
 	cleanupStarted := time.Now()
@@ -438,9 +446,7 @@ func (d *auditDelivery) deliverCanonicalBatch(
 			zap.Error(cleanupErr),
 		)
 	}
-	for _, call := range pending {
-		d.completeCanonicalCall(call, nil)
-	}
+	return results
 }
 
 func (d *auditDelivery) signalReplay() {

--- a/cluster-gateway/pkg/http/audit_delivery_test.go
+++ b/cluster-gateway/pkg/http/audit_delivery_test.go
@@ -384,6 +384,16 @@ func TestAuditDeliveryRecordsStageAndBatchMetrics(t *testing.T) {
 	if got := testutil.ToFloat64(metrics.AuditCanonicalInFlight); got != 0 {
 		t.Fatalf("canonical in-flight = %v, want 0", got)
 	}
+	if got := delivery.pendingCalls.Load(); got != 0 {
+		t.Fatalf("pending canonical calls = %d, want 0", got)
+	}
+	if got := len(delivery.canonicalSlot); got != 0 {
+		t.Fatalf("occupied canonical writer slots = %d, want 0", got)
+	}
+	if !delivery.canonicalGate.TryLock() {
+		t.Fatal("canonical gate is still held after PersistCanonical returned")
+	}
+	delivery.canonicalGate.Unlock()
 	families, err := registry.Gather()
 	if err != nil {
 		t.Fatalf("Gather() error = %v", err)


### PR DESCRIPTION
## Summary

- publish canonical audit completion only after the batch releases its in-flight metric, writer slot, and canonical gate
- decrement pending-call accounting before waking `PersistCanonical` waiters
- assert that a successful canonical return exposes quiescent metrics, slot, pending-call, and gate state

## Root cause

`deliverCanonicalBatch` closed each call's completion channel before the dispatch goroutine ran its deferred cleanup. A waiter could therefore return from `PersistCanonical` while `pendingCalls` was still non-zero, the in-flight gauge was still one, or the canonical read lock and writer slot were still held.

Under the full race test this appeared in two ways:

- foreground delivery returned, but the immediately following replay saw pending work or a held gate and skipped the replay batch
- the metrics test observed `cluster_gateway_audit_canonical_in_flight = 1` after `PersistCanonical` had returned

The branch that exposed this changed only manager code; both failures were reproducible on unchanged `main`.

## Implementation

`deliverCanonicalBatch` now returns per-call results without notifying waiters. The dispatch goroutine releases all shared delivery resources first, then publishes those results through `completeCanonicalCall`. `completeCanonicalCall` also updates `pendingCalls` before closing the waiter channel.

This preserves durable spool and ClickHouse acknowledgement semantics while making return from `PersistCanonical` a completion barrier for the batch's observable runtime state.

## Validation

- pre-fix: 200 race-test repetitions reproduced 9 foreground/replay ordering failures and 2 in-flight metric failures
- post-fix: the same two tests passed 200/200 under `-race`
- `CONFIG_PATH=/dev/null go test -race -count=20 ./cluster-gateway/pkg/http`
- `CONFIG_PATH=/dev/null go test -race -count=1 ./cluster-gateway/...`
- full PR quick-check unit-test command: all non-e2e packages passed under `go test -race`
- `go vet ./cluster-gateway/...`
- `golangci-lint v2.5.0 run ./cluster-gateway/...`
- `make proto manifests apispec` and `go mod tidy` left the patch unchanged
- `helm lint infra-operator/chart`
- `git diff --check`
