### PR TITLE
meter attributed OSS request usage

### DIFF
--- a/ctld/cmd/ctld/main.go
+++ b/ctld/cmd/ctld/main.go
@@ -216,6 +216,14 @@ func runPrimary(parent context.Context, options primaryRunOptions) error {
 			defer dbPool.Close()
 		}
 	}
+	objectStoreRequestMeter := startCtldObjectStoreRequestMetering(
+		ctx,
+		storageCfg,
+		dbPool,
+		nodeName,
+		zapLogger,
+	)
+	defer flushCtldObjectStoreRequestMetering(objectStoreRequestMeter, zapLogger)
 
 	podUIDLister := activePodUIDLister(k8sClient, nodeName)
 	portalManager := ctldportal.NewManager(ctldportal.Config{
@@ -225,6 +233,7 @@ func runPrimary(parent context.Context, options primaryRunOptions) error {
 		Logger:             zapLogger,
 		StorageConfig:      storageCfg,
 		StorageObserver:    newPortalStorageObserver(storageCfg, repo, dbPool),
+		RequestObserver:    objectStoreRequestMeter,
 		Repository:         repo,
 		PodName:            podName,
 		PodNamespace:       podNamespace,
@@ -311,7 +320,7 @@ func runPrimary(parent context.Context, options primaryRunOptions) error {
 	httpServer := newHTTPServer(httpAddr, combinedController{
 		Controller: probeController,
 		Portal:     portalManager,
-		RootFS:     buildRootFSController(ctx, storageCfg, portalManager, containerdRuntime),
+		RootFS:     buildRootFSController(ctx, storageCfg, objectStoreRequestMeter, portalManager, containerdRuntime),
 		ReadyCheck: serviceReady,
 	})
 	if obsProvider != nil {
@@ -500,8 +509,14 @@ func podTerminalForMountCleanup(pod *corev1.Pod) bool {
 	return pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed
 }
 
-func buildRootFSController(ctx context.Context, storageCfg *apiconfig.StorageProxyConfig, portalResolver ctldrootfs.PortalResolver, runtime *ctldrootfs.ContainerdRuntime) rootFSHandler {
-	store, err := buildRootFSObjectStore(storageCfg)
+func buildRootFSController(
+	ctx context.Context,
+	storageCfg *apiconfig.StorageProxyConfig,
+	requestObserver objectstore.RequestObserver,
+	portalResolver ctldrootfs.PortalResolver,
+	runtime *ctldrootfs.ContainerdRuntime,
+) rootFSHandler {
+	store, err := buildRootFSObjectStore(storageCfg, requestObserver)
 	if err != nil {
 		log.Printf("ctld rootfs object store disabled: %v", err)
 	}
@@ -570,18 +585,19 @@ func parseByteQuantity(raw string) (int64, error) {
 	return bytes, nil
 }
 
-func buildRootFSObjectStore(cfg *apiconfig.StorageProxyConfig) (objectstore.Store, error) {
+func buildRootFSObjectStore(cfg *apiconfig.StorageProxyConfig, requestObserver objectstore.RequestObserver) (objectstore.Store, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("storage config is not configured")
 	}
 	store, err := objectstore.Create(objectstore.Config{
-		Type:         cfg.ObjectStorageType,
-		Bucket:       cfg.S3Bucket,
-		Region:       cfg.S3Region,
-		Endpoint:     cfg.S3Endpoint,
-		AccessKey:    cfg.S3AccessKey,
-		SecretKey:    cfg.S3SecretKey,
-		SessionToken: cfg.S3SessionToken,
+		Type:            cfg.ObjectStorageType,
+		Bucket:          cfg.S3Bucket,
+		Region:          cfg.S3Region,
+		Endpoint:        cfg.S3Endpoint,
+		AccessKey:       cfg.S3AccessKey,
+		SecretKey:       cfg.S3SecretKey,
+		SessionToken:    cfg.S3SessionToken,
+		RequestObserver: requestObserver,
 	})
 	if err != nil {
 		return nil, err

--- a/ctld/cmd/ctld/object_store_request_metering.go
+++ b/ctld/cmd/ctld/object_store_request_metering.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	apiconfig "github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
+	meteringoutbox "github.com/sandbox0-ai/sandbox0/pkg/metering/outbox"
+	"github.com/sandbox0-ai/sandbox0/pkg/naming"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/objectstore/requestmetering"
+	"go.uber.org/zap"
+)
+
+const ctldObjectStoreRequestFinalFlushTimeout = 10 * time.Second
+
+func startCtldObjectStoreRequestMetering(
+	ctx context.Context,
+	cfg *apiconfig.StorageProxyConfig,
+	pool *pgxpool.Pool,
+	nodeName string,
+	logger *zap.Logger,
+) *requestmetering.Aggregator {
+	if cfg == nil || !cfg.Metering.Enabled || pool == nil {
+		return nil
+	}
+	instance := strings.TrimSpace(nodeName)
+	if instance == "" {
+		instance = strings.TrimSpace(podName)
+	}
+	aggregator := requestmetering.NewAggregator(
+		requestmetering.NewRecorder(meteringoutbox.NewRepository(pool)),
+		cfg.RegionID,
+		naming.ClusterIDOrDefault(&cfg.DefaultClusterId),
+		requestmetering.ProducerName(requestmetering.ProducerCtld, instance),
+		logger,
+	)
+	go aggregator.Run(ctx, requestmetering.DefaultFlushInterval)
+	return aggregator
+}
+
+func flushCtldObjectStoreRequestMetering(aggregator *requestmetering.Aggregator, logger *zap.Logger) {
+	if aggregator == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), ctldObjectStoreRequestFinalFlushTimeout)
+	defer cancel()
+	if err := aggregator.Flush(ctx); err != nil && logger != nil {
+		logger.Warn("Final object store request metering flush failed", zap.Error(err))
+	}
+}

--- a/ctld/internal/ctld/portal/manager.go
+++ b/ctld/internal/ctld/portal/manager.go
@@ -46,6 +46,7 @@ type Manager struct {
 	logrus                 *logrus.Logger
 	storage                *apiconfig.StorageProxyConfig
 	storageObserver        volume.StorageObserver
+	requestObserver        objectstore.RequestObserver
 	s3CredentialCodec      *volume.S3BackendCredentialCodec
 	s3CredentialCodecErr   error
 	repo                   *db.Repository
@@ -126,6 +127,7 @@ type Config struct {
 	Logger                  *zap.Logger
 	StorageConfig           *apiconfig.StorageProxyConfig
 	StorageObserver         volume.StorageObserver
+	RequestObserver         objectstore.RequestObserver
 	Repository              *db.Repository
 	PodName                 string
 	PodNamespace            string
@@ -185,6 +187,7 @@ func NewManager(cfg Config) *Manager {
 		logrus:                 l,
 		storage:                storageConfig,
 		storageObserver:        cfg.StorageObserver,
+		requestObserver:        cfg.RequestObserver,
 		s3CredentialCodec:      s3CredentialCodec,
 		s3CredentialCodecErr:   s3CredentialCodecErr,
 		repo:                   cfg.Repository,
@@ -1570,13 +1573,14 @@ func (m *Manager) createObjectStore(teamID, volumeID string) (objectstore.Store,
 		return nil, nil
 	}
 	store, err := objectstore.Create(objectstore.Config{
-		Type:         m.storage.ObjectStorageType,
-		Bucket:       m.storage.S3Bucket,
-		Region:       m.storage.S3Region,
-		Endpoint:     m.storage.S3Endpoint,
-		AccessKey:    m.storage.S3AccessKey,
-		SecretKey:    m.storage.S3SecretKey,
-		SessionToken: m.storage.S3SessionToken,
+		Type:            m.storage.ObjectStorageType,
+		Bucket:          m.storage.S3Bucket,
+		Region:          m.storage.S3Region,
+		Endpoint:        m.storage.S3Endpoint,
+		AccessKey:       m.storage.S3AccessKey,
+		SecretKey:       m.storage.S3SecretKey,
+		SessionToken:    m.storage.S3SessionToken,
+		RequestObserver: m.requestObserver,
 	})
 	if err != nil {
 		return nil, err

--- a/docs/self-hosted/configuration/page.mdx
+++ b/docs/self-hosted/configuration/page.mdx
@@ -87,8 +87,20 @@ Sandbox compute uses a serverless-style contract:
 | `sandbox.ingress_bytes` | `bytes` | Ingress traffic observed by the ctld network runtime |
 | `sandbox.volume_byte_hours` | `byte_hours` | Persisted volume and volume snapshot storage over time. Snapshot rows keep `subject_type=snapshot` |
 | `sandbox.rootfs_byte_hours` | `byte_hours` | Persisted sandbox rootfs COW object storage over time |
+| `sandbox.object_store_get_requests` | `count` | Successful GetRequest-class OSS HTTP attempts for platform-owned volume and rootfs storage |
+| `sandbox.object_store_put_requests` | `count` | Successful PutRequest-class OSS HTTP attempts for platform-owned volume and rootfs storage, including ListObjectsV2 |
 
 Public template idle pools are platform cost. Team-owned template warm pools are attributed to the owning team with `subject_type=template`.
+
+OSS request windows are usage facts only; Sandbox0 does not attach prices. The
+manager and ctld aggregate provider HTTP attempts for one minute before writing
+them to the PostgreSQL metering outbox. Successful volume requests are
+attributed from `sandboxvolumes/<team_id>/<volume_id>`, and rootfs requests from
+`sandbox-rootfs/<team_id>/<sandbox_id>`. Window `data` records `provider`,
+`bucket`, `billing_item`, `operation`, `cost_scope`, and `prefix_class`.
+Requests to customer-configured external S3 volumes are excluded because the
+customer owns that object-store account. Reconcile these windows with provider
+access and metering logs before using them for cost reporting.
 
 ## Platform Observability
 

--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -288,6 +288,14 @@ func main() {
 		}()
 		logger.Info("Metering PostgreSQL outbox projector started")
 	}
+	objectStoreRequestMeter := startManagerObjectStoreRequestMetering(
+		ctx,
+		meteringRepo,
+		cfg.RegionID,
+		cfg.DefaultClusterId,
+		logger,
+	)
+	defer flushObjectStoreRequestMetering(objectStoreRequestMeter, logger)
 	if meteringRepo != nil {
 		lifecycleProjector := managermetering.NewLifecycleProjector(managermetering.NewStore(meteringRepo), cfg.RegionID, cfg.DefaultClusterId)
 		lifecycleProjector.SetLogger(logger)
@@ -384,11 +392,12 @@ func main() {
 		storageLogrusLogger.SetLevel(storageLogLevel)
 
 		managerStorageRuntime, err = storageproxyruntime.New(ctx, storageproxyruntime.Options{
-			Config:        storageCfg,
-			Logger:        logger,
-			LogrusLogger:  storageLogrusLogger,
-			Observability: obsProvider,
-			K8sClient:     k8sClient,
+			Config:                     storageCfg,
+			Logger:                     logger,
+			LogrusLogger:               storageLogrusLogger,
+			Observability:              obsProvider,
+			K8sClient:                  k8sClient,
+			ObjectStoreRequestObserver: objectStoreRequestMeter,
 		})
 		if err != nil {
 			logger.Fatal("Failed to initialize manager storage runtime", zap.Error(err))
@@ -479,7 +488,7 @@ func main() {
 		logger,
 	)
 	sandboxService.SetHotClaimReservationEnqueuer(hotClaimReservationController)
-	rootFSObjectStore, rootFSObjectStoreErr := buildRootFSObjectStore(cfg, managerStorageConfig)
+	rootFSObjectStore, rootFSObjectStoreErr := buildRootFSObjectStore(cfg, managerStorageConfig, objectStoreRequestMeter)
 	if rootFSObjectStoreErr != nil {
 		logger.Warn("Rootfs object cleanup disabled; object store is not configured", zap.Error(rootFSObjectStoreErr))
 	} else if rootFSObjectStore != nil {
@@ -1043,7 +1052,11 @@ func defaultTeamQuotaLimits(cfg *config.ManagerConfig) []quota.DefaultLimit {
 	return limits
 }
 
-func buildRootFSObjectStore(cfg *config.ManagerConfig, storageRuntimeCfg *config.StorageProxyConfig) (objectstore.Store, error) {
+func buildRootFSObjectStore(
+	cfg *config.ManagerConfig,
+	storageRuntimeCfg *config.StorageProxyConfig,
+	requestObserver objectstore.RequestObserver,
+) (objectstore.Store, error) {
 	if cfg == nil {
 		return nil, nil
 	}
@@ -1052,13 +1065,14 @@ func buildRootFSObjectStore(cfg *config.ManagerConfig, storageRuntimeCfg *config
 		return nil, nil
 	}
 	store, err := objectstore.Create(objectstore.Config{
-		Type:         objectStorageCfg.Type,
-		Bucket:       objectStorageCfg.Bucket,
-		Region:       objectStorageCfg.Region,
-		Endpoint:     objectStorageCfg.Endpoint,
-		AccessKey:    objectStorageCfg.AccessKey,
-		SecretKey:    objectStorageCfg.SecretKey,
-		SessionToken: objectStorageCfg.SessionToken,
+		Type:            objectStorageCfg.Type,
+		Bucket:          objectStorageCfg.Bucket,
+		Region:          objectStorageCfg.Region,
+		Endpoint:        objectStorageCfg.Endpoint,
+		AccessKey:       objectStorageCfg.AccessKey,
+		SecretKey:       objectStorageCfg.SecretKey,
+		SessionToken:    objectStorageCfg.SessionToken,
+		RequestObserver: requestObserver,
 	})
 	if err != nil {
 		return nil, err

--- a/manager/cmd/manager/object_store_request_metering.go
+++ b/manager/cmd/manager/object_store_request_metering.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"context"
+	"os"
+	"strings"
+	"time"
+
+	meteringoutbox "github.com/sandbox0-ai/sandbox0/pkg/metering/outbox"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/objectstore/requestmetering"
+	"go.uber.org/zap"
+)
+
+const objectStoreRequestFinalFlushTimeout = 10 * time.Second
+
+func startManagerObjectStoreRequestMetering(
+	ctx context.Context,
+	repo *meteringoutbox.Repository,
+	regionID,
+	clusterID string,
+	logger *zap.Logger,
+) *requestmetering.Aggregator {
+	if repo == nil {
+		return nil
+	}
+	instance := strings.TrimSpace(os.Getenv("POD_NAME"))
+	if instance == "" {
+		instance = strings.TrimSpace(clusterID)
+	}
+	aggregator := requestmetering.NewAggregator(
+		requestmetering.NewRecorder(repo),
+		regionID,
+		clusterID,
+		requestmetering.ProducerName(requestmetering.ProducerManager, instance),
+		logger,
+	)
+	go aggregator.Run(ctx, requestmetering.DefaultFlushInterval)
+	return aggregator
+}
+
+func flushObjectStoreRequestMetering(aggregator *requestmetering.Aggregator, logger *zap.Logger) {
+	if aggregator == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), objectStoreRequestFinalFlushTimeout)
+	defer cancel()
+	if err := aggregator.Flush(ctx); err != nil && logger != nil {
+		logger.Warn("Final object store request metering flush failed", zap.Error(err))
+	}
+}

--- a/pkg/metering/types.go
+++ b/pkg/metering/types.go
@@ -30,6 +30,8 @@ const (
 	WindowTypeSandboxRuntimeMiBMilliseconds = "sandbox.runtime_mib_milliseconds"
 	WindowTypeSandboxVolumeByteHours        = "sandbox.volume_byte_hours"
 	WindowTypeSandboxRootFSByteHours        = "sandbox.rootfs_byte_hours"
+	WindowTypeSandboxObjectStoreGetRequests = "sandbox.object_store_get_requests"
+	WindowTypeSandboxObjectStorePutRequests = "sandbox.object_store_put_requests"
 
 	WindowTypeManagedAgentSessionRunningMilliseconds = "managed_agent.session_running_milliseconds"
 
@@ -43,6 +45,7 @@ const (
 	SubjectTypeVolume              = "volume"
 	SubjectTypeSnapshot            = "snapshot"
 	SubjectTypeRootFS              = "rootfs"
+	SubjectTypeObjectStoreBucket   = "object_store_bucket"
 	SubjectTypeTemplate            = "template"
 	SubjectTypeManagedAgentSession = "managed_agent_session"
 )

--- a/storage-proxy/pkg/objectstore/request_observer.go
+++ b/storage-proxy/pkg/objectstore/request_observer.go
@@ -1,0 +1,111 @@
+package objectstore
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
+	smithymiddleware "github.com/aws/smithy-go/middleware"
+)
+
+// RequestAttempt describes one HTTP request sent to an object-storage
+// provider. SDK retries therefore produce separate observations.
+type RequestAttempt struct {
+	Provider   string
+	Bucket     string
+	Operation  string
+	Key        string
+	StatusCode int
+	ObservedAt time.Time
+}
+
+// RequestObserver receives object-storage provider request attempts.
+//
+// Implementations must return quickly and must not retain object keys after
+// extracting the attribution dimensions they need.
+type RequestObserver interface {
+	ObserveRequestAttempt(RequestAttempt)
+}
+
+type requestObservingHTTPClient struct {
+	next     aws.HTTPClient
+	provider string
+	bucket   string
+	observer RequestObserver
+}
+
+func newRequestObservingHTTPClient(next aws.HTTPClient, provider, bucket string, observer RequestObserver) aws.HTTPClient {
+	if observer == nil {
+		return next
+	}
+	if next == nil {
+		next = awshttp.NewBuildableClient()
+	}
+	return &requestObservingHTTPClient{
+		next:     next,
+		provider: strings.TrimSpace(provider),
+		bucket:   strings.TrimSpace(bucket),
+		observer: observer,
+	}
+}
+
+func (c *requestObservingHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	resp, err := c.next.Do(req)
+	statusCode := 0
+	if resp != nil {
+		statusCode = resp.StatusCode
+	}
+	attempt := RequestAttempt{
+		Provider:   c.provider,
+		Bucket:     c.bucket,
+		Operation:  smithymiddleware.GetOperationName(req.Context()),
+		Key:        requestObjectKey(req, c.bucket),
+		StatusCode: statusCode,
+		ObservedAt: time.Now().UTC(),
+	}
+	notifyRequestObserver(c.observer, attempt)
+	return resp, err
+}
+
+func requestObjectKey(req *http.Request, bucket string) string {
+	if req == nil || req.URL == nil {
+		return ""
+	}
+	operation := smithymiddleware.GetOperationName(req.Context())
+	if operation == "ListObjects" || operation == "ListObjectsV2" {
+		return strings.TrimLeft(req.URL.Query().Get("prefix"), "/")
+	}
+
+	escapedPath := req.URL.EscapedPath()
+	decodedPath, err := url.PathUnescape(escapedPath)
+	if err != nil {
+		decodedPath = req.URL.Path
+	}
+	decodedPath = strings.TrimLeft(strings.TrimSpace(decodedPath), "/")
+	bucket = strings.Trim(strings.TrimSpace(bucket), "/")
+	if bucket == "" {
+		return decodedPath
+	}
+
+	if decodedPath == bucket {
+		return ""
+	}
+	if remainder, ok := strings.CutPrefix(decodedPath, bucket+"/"); ok {
+		return remainder
+	}
+	return decodedPath
+}
+
+func notifyRequestObserver(observer RequestObserver, attempt RequestAttempt) {
+	if observer == nil {
+		return
+	}
+	// Cost attribution must never change the outcome of the storage request.
+	defer func() {
+		_ = recover()
+	}()
+	observer.ObserveRequestAttempt(attempt)
+}

--- a/storage-proxy/pkg/objectstore/request_observer_test.go
+++ b/storage-proxy/pkg/objectstore/request_observer_test.go
@@ -1,0 +1,184 @@
+package objectstore
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	smithymiddleware "github.com/aws/smithy-go/middleware"
+)
+
+type requestObserverFunc func(RequestAttempt)
+
+func (f requestObserverFunc) ObserveRequestAttempt(attempt RequestAttempt) {
+	f(attempt)
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) Do(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestRequestObservingHTTPClientRecordsEachProviderAttempt(t *testing.T) {
+	var attempts []RequestAttempt
+	next := roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusPartialContent,
+			Body:       http.NoBody,
+			Header:     make(http.Header),
+		}, nil
+	})
+	client := newRequestObservingHTTPClient(next, TypeOSS, "runtime-bucket", requestObserverFunc(func(attempt RequestAttempt) {
+		attempts = append(attempts, attempt)
+	}))
+
+	ctx := smithymiddleware.WithOperationName(context.Background(), "GetObject")
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://oss.example/runtime-bucket/sandboxvolumes/team-1/volume-1/s0fs/segments/a", nil)
+	if err != nil {
+		t.Fatalf("NewRequestWithContext() error = %v", err)
+	}
+	for range 2 {
+		if _, err := client.Do(req); err != nil {
+			t.Fatalf("Do() error = %v", err)
+		}
+	}
+
+	if len(attempts) != 2 {
+		t.Fatalf("attempt count = %d, want 2", len(attempts))
+	}
+	for _, attempt := range attempts {
+		if attempt.Provider != TypeOSS || attempt.Bucket != "runtime-bucket" {
+			t.Fatalf("unexpected provider attribution: %+v", attempt)
+		}
+		if attempt.Operation != "GetObject" || attempt.StatusCode != http.StatusPartialContent {
+			t.Fatalf("unexpected request result: %+v", attempt)
+		}
+		if attempt.Key != "sandboxvolumes/team-1/volume-1/s0fs/segments/a" {
+			t.Fatalf("key = %q", attempt.Key)
+		}
+		if attempt.ObservedAt.IsZero() {
+			t.Fatal("ObservedAt is zero")
+		}
+	}
+}
+
+func TestOSSStoreEmitsSDKRequestAttempt(t *testing.T) {
+	var got RequestAttempt
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		gotPath = req.URL.EscapedPath()
+		w.Header().Set("ETag", `"test-etag"`)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	store, err := Create(Config{
+		Type:      TypeOSS,
+		Bucket:    "runtime-bucket",
+		Region:    "oss-test-1",
+		Endpoint:  server.URL,
+		AccessKey: "test-access-key",
+		SecretKey: "test-secret-key",
+		RequestObserver: requestObserverFunc(func(attempt RequestAttempt) {
+			got = attempt
+		}),
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if err := store.Put("sandboxvolumes/team-1/volume-1/object", strings.NewReader("data")); err != nil {
+		t.Fatalf("Put() error = %v", err)
+	}
+
+	if gotPath != "/runtime-bucket/sandboxvolumes/team-1/volume-1/object" {
+		t.Fatalf("request path = %q", gotPath)
+	}
+	if got.Provider != TypeOSS || got.Bucket != "runtime-bucket" ||
+		got.Operation != "PutObject" || got.Key != "sandboxvolumes/team-1/volume-1/object" ||
+		got.StatusCode != http.StatusOK {
+		t.Fatalf("attempt = %+v", got)
+	}
+}
+
+func TestRequestObservingHTTPClientUsesListPrefix(t *testing.T) {
+	var got RequestAttempt
+	client := newRequestObservingHTTPClient(
+		roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Header: make(http.Header)}, nil
+		}),
+		TypeOSS,
+		"runtime-bucket",
+		requestObserverFunc(func(attempt RequestAttempt) { got = attempt }),
+	)
+	ctx := smithymiddleware.WithOperationName(context.Background(), "ListObjectsV2")
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		"https://oss.example/runtime-bucket?list-type=2&prefix=sandbox-rootfs%2Fteam-2%2Fsandbox-2%2F",
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("NewRequestWithContext() error = %v", err)
+	}
+	if _, err := client.Do(req); err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+	if got.Key != "sandbox-rootfs/team-2/sandbox-2/" {
+		t.Fatalf("key = %q", got.Key)
+	}
+}
+
+func TestRequestObjectKeyPreservesRepeatedBucketSegment(t *testing.T) {
+	req, err := http.NewRequest(
+		http.MethodGet,
+		"https://oss.example/runtime-bucket/sandboxvolumes/team-1/volume-1/runtime-bucket/object",
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+	got := requestObjectKey(req, "runtime-bucket")
+	want := "sandboxvolumes/team-1/volume-1/runtime-bucket/object"
+	if got != want {
+		t.Fatalf("requestObjectKey() = %q, want %q", got, want)
+	}
+}
+
+func TestRequestObservingHTTPClientPreservesTransportError(t *testing.T) {
+	transportErr := errors.New("transport failed")
+	var got RequestAttempt
+	client := newRequestObservingHTTPClient(
+		roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return nil, transportErr
+		}),
+		TypeOSS,
+		"runtime-bucket",
+		requestObserverFunc(func(attempt RequestAttempt) { got = attempt }),
+	)
+	ctx := smithymiddleware.WithOperationName(context.Background(), "PutObject")
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPut,
+		"https://oss.example/runtime-bucket/sandboxvolumes/team-1/volume-1/s0fs/heads/current",
+		strings.NewReader("data"),
+	)
+	if err != nil {
+		t.Fatalf("NewRequestWithContext() error = %v", err)
+	}
+	if _, err := client.Do(req); !errors.Is(err, transportErr) {
+		t.Fatalf("Do() error = %v, want %v", err, transportErr)
+	}
+	if got.StatusCode != 0 || got.Operation != "PutObject" {
+		t.Fatalf("attempt = %+v", got)
+	}
+}
+
+func TestNotifyRequestObserverContainsPanic(t *testing.T) {
+	notifyRequestObserver(requestObserverFunc(func(RequestAttempt) {
+		panic("boom")
+	}), RequestAttempt{})
+}

--- a/storage-proxy/pkg/objectstore/requestmetering/aggregator.go
+++ b/storage-proxy/pkg/objectstore/requestmetering/aggregator.go
@@ -1,0 +1,406 @@
+package requestmetering
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	meteringpkg "github.com/sandbox0-ai/sandbox0/pkg/metering"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/objectstore"
+	"go.uber.org/zap"
+)
+
+const (
+	ProducerManager = "manager.object_store_requests"
+	ProducerCtld    = "ctld.object_store_requests"
+
+	DefaultFlushInterval = time.Minute
+
+	BillingItemGetRequest = "GetRequest"
+	BillingItemPutRequest = "PutRequest"
+
+	CostScopeCustomer     = "customer"
+	CostScopePlatform     = "platform"
+	CostScopeUnattributed = "unattributed"
+)
+
+type txRecorder interface {
+	AppendWindow(context.Context, *meteringpkg.Window) error
+	UpsertProducerWatermark(context.Context, string, string, time.Time) error
+}
+
+// Recorder commits one aggregate batch and its watermark atomically.
+type Recorder interface {
+	RunInTx(context.Context, func(txRecorder) error) error
+}
+
+type repository interface {
+	InTx(context.Context, func(pgx.Tx) error) error
+	AppendWindowTx(context.Context, pgx.Tx, *meteringpkg.Window) error
+	UpsertProducerWatermarkTx(context.Context, pgx.Tx, string, string, time.Time) error
+}
+
+type repositoryRecorder struct {
+	repo repository
+}
+
+// NewRecorder adapts the PostgreSQL metering outbox for request aggregation.
+func NewRecorder(repo repository) Recorder {
+	if repo == nil {
+		return nil
+	}
+	return &repositoryRecorder{repo: repo}
+}
+
+func (r *repositoryRecorder) RunInTx(ctx context.Context, fn func(txRecorder) error) error {
+	return r.repo.InTx(ctx, func(tx pgx.Tx) error {
+		return fn(&repositoryTxRecorder{repo: r.repo, tx: tx})
+	})
+}
+
+type repositoryTxRecorder struct {
+	repo repository
+	tx   pgx.Tx
+}
+
+func (r *repositoryTxRecorder) AppendWindow(ctx context.Context, window *meteringpkg.Window) error {
+	return r.repo.AppendWindowTx(ctx, r.tx, window)
+}
+
+func (r *repositoryTxRecorder) UpsertProducerWatermark(ctx context.Context, producer, regionID string, completeBefore time.Time) error {
+	return r.repo.UpsertProducerWatermarkTx(ctx, r.tx, producer, regionID, completeBefore)
+}
+
+type attribution struct {
+	costScope   string
+	prefixClass string
+	subjectType string
+	subjectID   string
+	teamID      string
+	sandboxID   string
+	volumeID    string
+}
+
+type usageKey struct {
+	attribution
+	provider    string
+	bucket      string
+	billingItem string
+	windowType  string
+	operation   string
+}
+
+type usageBatch struct {
+	start time.Time
+	end   time.Time
+	usage map[usageKey]int64
+}
+
+// Aggregator converts successful OSS provider attempts into low-volume,
+// attributed usage windows. It implements objectstore.RequestObserver.
+type Aggregator struct {
+	recorder  Recorder
+	regionID  string
+	clusterID string
+	producer  string
+	logger    *zap.Logger
+	now       func() time.Time
+
+	mu          sync.Mutex
+	windowStart time.Time
+	usage       map[usageKey]int64
+	pending     *usageBatch
+}
+
+// NewAggregator creates a one-minute request usage aggregator backed by the
+// PostgreSQL metering outbox.
+func NewAggregator(recorder Recorder, regionID, clusterID, producer string, logger *zap.Logger) *Aggregator {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	aggregator := &Aggregator{
+		recorder:  recorder,
+		regionID:  strings.TrimSpace(regionID),
+		clusterID: strings.TrimSpace(clusterID),
+		producer:  strings.TrimSpace(producer),
+		logger:    logger,
+		now: func() time.Time {
+			return time.Now().UTC()
+		},
+		usage: make(map[usageKey]int64),
+	}
+	if aggregator.producer == "" {
+		aggregator.producer = ProducerManager
+	}
+	aggregator.windowStart = aggregator.now()
+	return aggregator
+}
+
+// ProducerName adds a stable workload or node identity to a producer name.
+func ProducerName(base, instance string) string {
+	base = strings.Trim(strings.TrimSpace(base), "/")
+	instance = strings.Trim(strings.TrimSpace(instance), "/")
+	if instance == "" {
+		return base
+	}
+	return base + "/" + instance
+}
+
+func (a *Aggregator) ObserveRequestAttempt(attempt objectstore.RequestAttempt) {
+	if a == nil || a.recorder == nil {
+		return
+	}
+	windowType, billingItem, ok := billableUsage(attempt)
+	if !ok {
+		return
+	}
+	attr := classifyAttribution(attempt.Bucket, attempt.Key)
+	key := usageKey{
+		attribution: attr,
+		provider:    strings.ToLower(strings.TrimSpace(attempt.Provider)),
+		bucket:      strings.TrimSpace(attempt.Bucket),
+		billingItem: billingItem,
+		windowType:  windowType,
+		operation:   strings.TrimSpace(attempt.Operation),
+	}
+
+	a.mu.Lock()
+	a.usage[key]++
+	a.mu.Unlock()
+}
+
+func billableUsage(attempt objectstore.RequestAttempt) (string, string, bool) {
+	if !strings.EqualFold(strings.TrimSpace(attempt.Provider), objectstore.TypeOSS) {
+		return "", "", false
+	}
+	if attempt.StatusCode < 200 || attempt.StatusCode >= 400 {
+		return "", "", false
+	}
+	switch strings.TrimSpace(attempt.Operation) {
+	case "CreateBucket", "DeleteObject", "ListObjects", "ListObjectsV2", "PutObject":
+		return meteringpkg.WindowTypeSandboxObjectStorePutRequests, BillingItemPutRequest, true
+	case "GetObject", "HeadBucket", "HeadObject":
+		return meteringpkg.WindowTypeSandboxObjectStoreGetRequests, BillingItemGetRequest, true
+	default:
+		return "", "", false
+	}
+}
+
+func classifyAttribution(bucket, key string) attribution {
+	bucket = strings.TrimSpace(bucket)
+	if bucket == "" {
+		bucket = "unknown"
+	}
+	cleanKey := strings.Trim(strings.TrimSpace(key), "/")
+	if cleanKey == "" {
+		return bucketAttribution(bucket, CostScopePlatform, "bucket")
+	}
+	parts := strings.Split(cleanKey, "/")
+	switch parts[0] {
+	case "sandboxvolumes":
+		if len(parts) >= 3 && parts[1] != "" && parts[2] != "" {
+			return attribution{
+				costScope:   CostScopeCustomer,
+				prefixClass: "volume_data",
+				subjectType: meteringpkg.SubjectTypeVolume,
+				subjectID:   parts[2],
+				teamID:      parts[1],
+				volumeID:    parts[2],
+			}
+		}
+		return bucketAttribution(bucket, CostScopeUnattributed, "volume_unknown")
+	case "sandbox-rootfs":
+		if len(parts) >= 3 && parts[1] != "" && parts[2] != "" {
+			return attribution{
+				costScope:   CostScopeCustomer,
+				prefixClass: "rootfs_data",
+				subjectType: meteringpkg.SubjectTypeRootFS,
+				subjectID:   parts[2],
+				teamID:      parts[1],
+				sandboxID:   parts[2],
+			}
+		}
+		return bucketAttribution(bucket, CostScopeUnattributed, "rootfs_unknown")
+	case "clickhouse":
+		return bucketAttribution(bucket, CostScopePlatform, "clickhouse")
+	case "migration", "sandboxvolumes-sync":
+		return bucketAttribution(bucket, CostScopePlatform, "migration")
+	case ".juicefs", ".juicefs-init-marker":
+		return bucketAttribution(bucket, CostScopeUnattributed, "legacy_juicefs")
+	default:
+		return bucketAttribution(bucket, CostScopeUnattributed, "other")
+	}
+}
+
+func bucketAttribution(bucket, costScope, prefixClass string) attribution {
+	return attribution{
+		costScope:   costScope,
+		prefixClass: prefixClass,
+		subjectType: meteringpkg.SubjectTypeObjectStoreBucket,
+		subjectID:   bucket,
+	}
+}
+
+// Run periodically flushes attributed requests until ctx is canceled.
+func (a *Aggregator) Run(ctx context.Context, interval time.Duration) {
+	if a == nil || a.recorder == nil {
+		return
+	}
+	if interval <= 0 {
+		interval = DefaultFlushInterval
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			_ = a.Flush(ctx)
+		}
+	}
+}
+
+// Flush commits all completed request aggregates. Failed batches remain
+// pending with stable IDs so a later call can retry them idempotently.
+func (a *Aggregator) Flush(ctx context.Context) error {
+	if a == nil || a.recorder == nil {
+		return nil
+	}
+	for {
+		batch, retrying := a.pendingBatch()
+		err := a.recorder.RunInTx(ctx, func(tx txRecorder) error {
+			for _, key := range sortedUsageKeys(batch.usage) {
+				if err := tx.AppendWindow(ctx, a.buildWindow(key, batch.start, batch.end, batch.usage[key])); err != nil {
+					return err
+				}
+			}
+			return tx.UpsertProducerWatermark(ctx, a.producer, a.regionID, batch.end)
+		})
+		if err != nil {
+			a.logger.Error("Failed to flush object store request metering windows",
+				zap.String("producer", a.producer),
+				zap.Time("window_start", batch.start),
+				zap.Time("window_end", batch.end),
+				zap.Error(err),
+			)
+			return err
+		}
+
+		a.mu.Lock()
+		if a.pending == batch {
+			a.pending = nil
+		}
+		hasResidual := len(a.usage) > 0
+		a.mu.Unlock()
+		if !retrying || !hasResidual {
+			return nil
+		}
+	}
+}
+
+func (a *Aggregator) pendingBatch() (*usageBatch, bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.pending != nil {
+		return a.pending, true
+	}
+	end := a.now()
+	start := a.windowStart
+	if start.IsZero() {
+		start = end
+	}
+	if end.Before(start) {
+		end = start
+	}
+	a.pending = &usageBatch{
+		start: start,
+		end:   end,
+		usage: a.usage,
+	}
+	a.usage = make(map[usageKey]int64)
+	a.windowStart = end
+	return a.pending, false
+}
+
+func (a *Aggregator) buildWindow(key usageKey, start, end time.Time, value int64) *meteringpkg.Window {
+	return &meteringpkg.Window{
+		WindowID:    requestWindowID(a.producer, key, start, end),
+		Producer:    a.producer,
+		RegionID:    a.regionID,
+		WindowType:  key.windowType,
+		SubjectType: key.subjectType,
+		SubjectID:   key.subjectID,
+		TeamID:      key.teamID,
+		SandboxID:   key.sandboxID,
+		VolumeID:    key.volumeID,
+		ClusterID:   a.clusterID,
+		WindowStart: start,
+		WindowEnd:   end,
+		Value:       value,
+		Unit:        meteringpkg.WindowUnitCount,
+		Data: mustJSON(map[string]string{
+			"billing_item": key.billingItem,
+			"bucket":       key.bucket,
+			"cost_scope":   key.costScope,
+			"operation":    key.operation,
+			"prefix_class": key.prefixClass,
+			"product":      meteringpkg.ProductSandbox,
+			"provider":     key.provider,
+		}),
+	}
+}
+
+func sortedUsageKeys(usage map[usageKey]int64) []usageKey {
+	keys := make([]usageKey, 0, len(usage))
+	for key := range usage {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return usageKeyIdentity(keys[i]) < usageKeyIdentity(keys[j])
+	})
+	return keys
+}
+
+func requestWindowID(producer string, key usageKey, start, end time.Time) string {
+	sum := sha256.Sum256([]byte(usageKeyIdentity(key)))
+	return fmt.Sprintf(
+		"%s/%s/%d/%d",
+		producer,
+		hex.EncodeToString(sum[:8]),
+		start.UTC().UnixNano(),
+		end.UTC().UnixNano(),
+	)
+}
+
+func usageKeyIdentity(key usageKey) string {
+	return strings.Join([]string{
+		key.costScope,
+		key.prefixClass,
+		key.subjectType,
+		key.subjectID,
+		key.teamID,
+		key.sandboxID,
+		key.volumeID,
+		key.provider,
+		key.bucket,
+		key.billingItem,
+		key.windowType,
+		key.operation,
+	}, "\x00")
+}
+
+func mustJSON(value any) json.RawMessage {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return json.RawMessage(`{}`)
+	}
+	return payload
+}

--- a/storage-proxy/pkg/objectstore/requestmetering/aggregator_test.go
+++ b/storage-proxy/pkg/objectstore/requestmetering/aggregator_test.go
@@ -1,0 +1,257 @@
+package requestmetering
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	meteringpkg "github.com/sandbox0-ai/sandbox0/pkg/metering"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/objectstore"
+)
+
+type fakeTxRecorder struct {
+	windows           []*meteringpkg.Window
+	watermarkProducer string
+	watermarkRegion   string
+	watermarkTime     time.Time
+	appendErr         error
+}
+
+func (f *fakeTxRecorder) AppendWindow(_ context.Context, window *meteringpkg.Window) error {
+	if f.appendErr != nil {
+		return f.appendErr
+	}
+	f.windows = append(f.windows, window)
+	return nil
+}
+
+func (f *fakeTxRecorder) UpsertProducerWatermark(_ context.Context, producer, regionID string, completeBefore time.Time) error {
+	f.watermarkProducer = producer
+	f.watermarkRegion = regionID
+	f.watermarkTime = completeBefore
+	return nil
+}
+
+type fakeRecorder struct {
+	tx       *fakeTxRecorder
+	runCalls int
+}
+
+func (f *fakeRecorder) RunInTx(ctx context.Context, fn func(txRecorder) error) error {
+	f.runCalls++
+	if f.tx == nil {
+		f.tx = &fakeTxRecorder{}
+	}
+	return fn(f.tx)
+}
+
+func TestAggregatorFlushesAttributedOSSRequestWindows(t *testing.T) {
+	recorder := &fakeRecorder{tx: &fakeTxRecorder{}}
+	aggregator := NewAggregator(recorder, "ali-ue1", "cluster-1", ProducerName(ProducerManager, "manager-1"), nil)
+	start := time.Date(2026, 7, 27, 1, 0, 0, 0, time.UTC)
+	end := start.Add(time.Minute)
+	aggregator.windowStart = start
+	aggregator.now = func() time.Time { return end }
+
+	aggregator.ObserveRequestAttempt(objectstore.RequestAttempt{
+		Provider:   objectstore.TypeOSS,
+		Bucket:     "runtime-bucket",
+		Operation:  "GetObject",
+		Key:        "sandboxvolumes/team-1/volume-1/s0fs/segments/a",
+		StatusCode: http.StatusPartialContent,
+	})
+	aggregator.ObserveRequestAttempt(objectstore.RequestAttempt{
+		Provider:   objectstore.TypeOSS,
+		Bucket:     "runtime-bucket",
+		Operation:  "ListObjectsV2",
+		Key:        "sandbox-rootfs/team-2/sandbox-2/1",
+		StatusCode: http.StatusOK,
+	})
+	aggregator.ObserveRequestAttempt(objectstore.RequestAttempt{
+		Provider:   objectstore.TypeOSS,
+		Bucket:     "runtime-bucket",
+		Operation:  "PutObject",
+		Key:        "clickhouse/ali-ue1/data/a",
+		StatusCode: http.StatusOK,
+	})
+
+	if err := aggregator.Flush(context.Background()); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+	if len(recorder.tx.windows) != 3 {
+		t.Fatalf("window count = %d, want 3", len(recorder.tx.windows))
+	}
+
+	windows := windowsByOperation(t, recorder.tx.windows)
+	volume := windows["GetObject"]
+	if volume.WindowType != meteringpkg.WindowTypeSandboxObjectStoreGetRequests ||
+		volume.TeamID != "team-1" ||
+		volume.SubjectType != meteringpkg.SubjectTypeVolume ||
+		volume.SubjectID != "volume-1" ||
+		volume.VolumeID != "volume-1" ||
+		volume.Value != 1 ||
+		volume.Unit != meteringpkg.WindowUnitCount {
+		t.Fatalf("unexpected volume window: %+v", volume)
+	}
+	rootfs := windows["ListObjectsV2"]
+	if rootfs.WindowType != meteringpkg.WindowTypeSandboxObjectStorePutRequests ||
+		rootfs.TeamID != "team-2" ||
+		rootfs.SubjectType != meteringpkg.SubjectTypeRootFS ||
+		rootfs.SandboxID != "sandbox-2" {
+		t.Fatalf("unexpected rootfs window: %+v", rootfs)
+	}
+	platform := windows["PutObject"]
+	if platform.TeamID != "" || platform.SubjectType != meteringpkg.SubjectTypeObjectStoreBucket {
+		t.Fatalf("unexpected platform window: %+v", platform)
+	}
+	platformData := windowData(t, platform)
+	if platformData["cost_scope"] != CostScopePlatform || platformData["prefix_class"] != "clickhouse" {
+		t.Fatalf("unexpected platform data: %#v", platformData)
+	}
+	if recorder.tx.watermarkProducer != "manager.object_store_requests/manager-1" ||
+		recorder.tx.watermarkRegion != "ali-ue1" ||
+		!recorder.tx.watermarkTime.Equal(end) {
+		t.Fatalf("unexpected watermark: %#v", recorder.tx)
+	}
+}
+
+func TestAggregatorCountsRepeatedAttempts(t *testing.T) {
+	recorder := &fakeRecorder{tx: &fakeTxRecorder{}}
+	aggregator := NewAggregator(recorder, "ali-ue1", "cluster-1", ProducerCtld, nil)
+	for range 3 {
+		aggregator.ObserveRequestAttempt(objectstore.RequestAttempt{
+			Provider:   objectstore.TypeOSS,
+			Bucket:     "runtime-bucket",
+			Operation:  "PutObject",
+			Key:        "sandboxvolumes/team-1/volume-1/s0fs/heads/current",
+			StatusCode: http.StatusOK,
+		})
+	}
+	if err := aggregator.Flush(context.Background()); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+	if len(recorder.tx.windows) != 1 || recorder.tx.windows[0].Value != 3 {
+		t.Fatalf("windows = %#v, want one count=3 window", recorder.tx.windows)
+	}
+}
+
+func TestAggregatorIgnoresNonBillableAttempts(t *testing.T) {
+	recorder := &fakeRecorder{tx: &fakeTxRecorder{}}
+	aggregator := NewAggregator(recorder, "ali-ue1", "cluster-1", ProducerCtld, nil)
+	for _, attempt := range []objectstore.RequestAttempt{
+		{Provider: objectstore.TypeOSS, Operation: "GetObject", StatusCode: http.StatusNotFound},
+		{Provider: objectstore.TypeOSS, Operation: "PutObject", StatusCode: http.StatusInternalServerError},
+		{Provider: objectstore.TypeOSS, Operation: "PutObject", StatusCode: 0},
+		{Provider: objectstore.TypeOSS, Operation: "UnknownOperation", StatusCode: http.StatusOK},
+		{Provider: objectstore.TypeS3, Operation: "GetObject", StatusCode: http.StatusOK},
+	} {
+		aggregator.ObserveRequestAttempt(attempt)
+	}
+	if err := aggregator.Flush(context.Background()); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+	if len(recorder.tx.windows) != 0 {
+		t.Fatalf("windows = %#v, want none", recorder.tx.windows)
+	}
+	if recorder.tx.watermarkTime.IsZero() {
+		t.Fatal("watermark was not advanced")
+	}
+}
+
+func TestAggregatorFlushFailureRetainsStableBatch(t *testing.T) {
+	recorder := &fakeRecorder{tx: &fakeTxRecorder{appendErr: errors.New("boom")}}
+	aggregator := NewAggregator(recorder, "ali-ue1", "cluster-1", ProducerCtld, nil)
+	start := time.Date(2026, 7, 27, 2, 0, 0, 0, time.UTC)
+	end := start.Add(time.Minute)
+	aggregator.windowStart = start
+	aggregator.now = func() time.Time { return end }
+	aggregator.ObserveRequestAttempt(objectstore.RequestAttempt{
+		Provider: objectstore.TypeOSS, Bucket: "runtime-bucket", Operation: "GetObject",
+		Key: "sandboxvolumes/team-1/volume-1/a", StatusCode: http.StatusOK,
+	})
+
+	if err := aggregator.Flush(context.Background()); err == nil {
+		t.Fatal("Flush() error = nil, want failure")
+	}
+	aggregator.mu.Lock()
+	failed := aggregator.pending
+	aggregator.mu.Unlock()
+	if failed == nil || len(failed.usage) != 1 {
+		t.Fatalf("pending batch = %#v", failed)
+	}
+
+	recorder.tx.appendErr = nil
+	if err := aggregator.Flush(context.Background()); err != nil {
+		t.Fatalf("retry Flush() error = %v", err)
+	}
+	if len(recorder.tx.windows) != 1 {
+		t.Fatalf("window count = %d, want 1", len(recorder.tx.windows))
+	}
+	if !recorder.tx.windows[0].WindowStart.Equal(start) || !recorder.tx.windows[0].WindowEnd.Equal(end) {
+		t.Fatalf("window interval = [%s, %s]", recorder.tx.windows[0].WindowStart, recorder.tx.windows[0].WindowEnd)
+	}
+}
+
+func TestClassifyAttribution(t *testing.T) {
+	tests := []struct {
+		name        string
+		key         string
+		scope       string
+		prefixClass string
+		teamID      string
+		subjectType string
+		subjectID   string
+	}{
+		{
+			name: "volume", key: "sandboxvolumes/team-a/volume-a/s0fs/head",
+			scope: CostScopeCustomer, prefixClass: "volume_data", teamID: "team-a",
+			subjectType: meteringpkg.SubjectTypeVolume, subjectID: "volume-a",
+		},
+		{
+			name: "rootfs", key: "sandbox-rootfs/team-a/sandbox-a/1/sha256/a.tar",
+			scope: CostScopeCustomer, prefixClass: "rootfs_data", teamID: "team-a",
+			subjectType: meteringpkg.SubjectTypeRootFS, subjectID: "sandbox-a",
+		},
+		{
+			name: "legacy", key: ".juicefs/chunks/1",
+			scope: CostScopeUnattributed, prefixClass: "legacy_juicefs",
+			subjectType: meteringpkg.SubjectTypeObjectStoreBucket, subjectID: "runtime-bucket",
+		},
+		{
+			name: "bucket", key: "",
+			scope: CostScopePlatform, prefixClass: "bucket",
+			subjectType: meteringpkg.SubjectTypeObjectStoreBucket, subjectID: "runtime-bucket",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifyAttribution("runtime-bucket", tt.key)
+			if got.costScope != tt.scope || got.prefixClass != tt.prefixClass ||
+				got.teamID != tt.teamID || got.subjectType != tt.subjectType || got.subjectID != tt.subjectID {
+				t.Fatalf("classifyAttribution() = %+v", got)
+			}
+		})
+	}
+}
+
+func windowsByOperation(t *testing.T, windows []*meteringpkg.Window) map[string]*meteringpkg.Window {
+	t.Helper()
+	result := make(map[string]*meteringpkg.Window, len(windows))
+	for _, window := range windows {
+		data := windowData(t, window)
+		result[data["operation"]] = window
+	}
+	return result
+}
+
+func windowData(t *testing.T, window *meteringpkg.Window) map[string]string {
+	t.Helper()
+	var data map[string]string
+	if err := json.Unmarshal(window.Data, &data); err != nil {
+		t.Fatalf("unmarshal window data: %v", err)
+	}
+	return data
+}

--- a/storage-proxy/pkg/objectstore/store.go
+++ b/storage-proxy/pkg/objectstore/store.go
@@ -41,6 +41,10 @@ type Config struct {
 	SecretKey    string
 	SessionToken string
 	Metrics      *obsmetrics.StorageProxyMetrics
+	// RequestObserver receives provider HTTP attempts. It is intentionally
+	// separate from Metrics because attributed request counts belong in the
+	// durable metering ledger, not in high-cardinality Prometheus labels.
+	RequestObserver RequestObserver
 }
 
 type Info struct {
@@ -212,6 +216,14 @@ func newS3Store(cfg Config) (Store, error) {
 	awsCfg, err := awsconfig.LoadDefaultConfig(context.Background(), loadOptions...)
 	if err != nil {
 		return nil, fmt.Errorf("load object storage config: %w", err)
+	}
+	if cfg.RequestObserver != nil {
+		awsCfg.HTTPClient = newRequestObservingHTTPClient(
+			awsCfg.HTTPClient,
+			storageType,
+			strings.TrimSpace(cfg.Bucket),
+			cfg.RequestObserver,
+		)
 	}
 
 	options := func(o *s3.Options) {

--- a/storage-proxy/pkg/runtime/runtime.go
+++ b/storage-proxy/pkg/runtime/runtime.go
@@ -36,6 +36,7 @@ import (
 	fsserver "github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/fsserver"
 	httpserver "github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/http"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/notify"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/objectstore"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/snapshot"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volume"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volumelock"
@@ -56,6 +57,9 @@ type Options struct {
 	Observability *observability.Provider
 	K8sClient     kubernetes.Interface
 	Listen        func(network, address string) (net.Listener, error)
+	// ObjectStoreRequestObserver is process-owned and may be shared with the
+	// manager rootfs runtime so all platform OSS calls use one aggregate stream.
+	ObjectStoreRequestObserver objectstore.RequestObserver
 }
 
 // Runtime owns one manager storage HTTP endpoint and all of its background
@@ -207,6 +211,7 @@ func New(ctx context.Context, opts Options) (_ *Runtime, retErr error) {
 
 	r.volMgr = volume.NewManager(r.logrusLogger, r.cfg, repo)
 	r.volMgr.SetMetrics(storageProxyMetrics)
+	r.volMgr.SetObjectStoreRequestObserver(opts.ObjectStoreRequestObserver)
 	var volumeBarrier *volumelock.Locker
 	if r.pool != nil {
 		volumeBarrier = volumelock.New(r.pool)
@@ -254,6 +259,7 @@ func New(ctx context.Context, opts Options) (_ *Runtime, retErr error) {
 		return nil, fmt.Errorf("initialize snapshot manager: %w", err)
 	}
 	snapshotMgr.SetMeteringRepository(meteringRepo)
+	snapshotMgr.SetObjectStoreRequestObserver(opts.ObjectStoreRequestObserver)
 	snapshotMgr.SetQuotaRepository(quotaRepo)
 	r.volMgr.SetStorageObserver(snapshotMgr)
 	if eventBroadcaster != nil {

--- a/storage-proxy/pkg/snapshot/manager.go
+++ b/storage-proxy/pkg/snapshot/manager.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/quota"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/fsmeta"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/objectstore"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volume"
 	pb "github.com/sandbox0-ai/sandbox0/storage-proxy/proto/fs"
 	"github.com/sirupsen/logrus"
@@ -115,6 +116,7 @@ type Manager struct {
 	quotaRepo         *quota.Repository
 	metrics           *obsmetrics.StorageProxyMetrics
 	volumeObserver    *volume.VolumeStorageObserver
+	requestObserver   objectstore.RequestObserver
 }
 
 // NewManager creates a new snapshot manager
@@ -155,6 +157,14 @@ func (m *Manager) SetMeteringRepository(repo meteringRecorder) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.meteringRepo = repo
+}
+
+// SetObjectStoreRequestObserver configures request metering for platform-owned
+// S0FS snapshot objects.
+func (m *Manager) SetObjectStoreRequestObserver(observer objectstore.RequestObserver) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.requestObserver = observer
 }
 
 func (m *Manager) SetQuotaRepository(repo *quota.Repository) {

--- a/storage-proxy/pkg/snapshot/s0fs.go
+++ b/storage-proxy/pkg/snapshot/s0fs.go
@@ -215,14 +215,15 @@ func (m *Manager) s0fsObjectStore(teamID, volumeID string) (objectstore.Store, e
 		return nil, err
 	}
 	store, err := objectstore.Create(objectstore.Config{
-		Type:         m.config.ObjectStorageType,
-		Bucket:       m.config.S3Bucket,
-		Region:       m.config.S3Region,
-		Endpoint:     m.config.S3Endpoint,
-		AccessKey:    m.config.S3AccessKey,
-		SecretKey:    m.config.S3SecretKey,
-		SessionToken: m.config.S3SessionToken,
-		Metrics:      m.metrics,
+		Type:            m.config.ObjectStorageType,
+		Bucket:          m.config.S3Bucket,
+		Region:          m.config.S3Region,
+		Endpoint:        m.config.S3Endpoint,
+		AccessKey:       m.config.S3AccessKey,
+		SecretKey:       m.config.S3SecretKey,
+		SessionToken:    m.config.S3SessionToken,
+		Metrics:         m.metrics,
+		RequestObserver: m.requestObserver,
 	})
 	if err != nil {
 		return nil, err

--- a/storage-proxy/pkg/volume/backend.go
+++ b/storage-proxy/pkg/volume/backend.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/objectstore"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/s0fs"
 )
 
@@ -48,6 +49,7 @@ type BackendMountRequest struct {
 	MountedAt       time.Time
 	Metrics         *obsmetrics.StorageProxyMetrics
 	StorageObserver StorageObserver
+	RequestObserver objectstore.RequestObserver
 }
 
 // FlushAll flushes dirty data for the mounted volume.

--- a/storage-proxy/pkg/volume/manager.go
+++ b/storage-proxy/pkg/volume/manager.go
@@ -11,6 +11,7 @@ import (
 	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/db"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/fsmeta"
+	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/objectstore"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/s0fs"
 	"github.com/sirupsen/logrus"
 )
@@ -74,18 +75,19 @@ type directMountLease struct {
 
 // Manager manages mounted volumes and mount sessions.
 type Manager struct {
-	mu             sync.RWMutex
-	volumes        map[string]*VolumeContext
-	mountSessions  map[string]map[string]*MountSession
-	directMounts   map[string]*directMountLease
-	invalidates    map[string]map[string]*invalidateTracker
-	logger         *logrus.Logger
-	config         *config.StorageProxyConfig
-	metrics        *obsmetrics.StorageProxyMetrics
-	backends       map[string]Backend
-	defaultBackend string
-	registrar      MountRegistrar // Optional: for distributed coordination
-	observer       StorageObserver
+	mu              sync.RWMutex
+	volumes         map[string]*VolumeContext
+	mountSessions   map[string]map[string]*MountSession
+	directMounts    map[string]*directMountLease
+	invalidates     map[string]map[string]*invalidateTracker
+	logger          *logrus.Logger
+	config          *config.StorageProxyConfig
+	metrics         *obsmetrics.StorageProxyMetrics
+	backends        map[string]Backend
+	defaultBackend  string
+	registrar       MountRegistrar // Optional: for distributed coordination
+	observer        StorageObserver
+	requestObserver objectstore.RequestObserver
 }
 
 // NewManager creates a new volume manager
@@ -131,6 +133,21 @@ func (m *Manager) SetStorageObserver(observer StorageObserver) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.observer = observer
+}
+
+// SetObjectStoreRequestObserver configures request metering for platform-owned
+// S0FS volume objects.
+func (m *Manager) SetObjectStoreRequestObserver(observer objectstore.RequestObserver) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.requestObserver = observer
+	for _, backend := range m.backends {
+		if configurable, ok := backend.(interface {
+			SetObjectStoreRequestObserver(objectstore.RequestObserver)
+		}); ok {
+			configurable.SetObjectStoreRequestObserver(observer)
+		}
+	}
 }
 
 func (m *Manager) SetMetrics(metrics *obsmetrics.StorageProxyMetrics) {
@@ -200,6 +217,7 @@ func (m *Manager) MountVolume(ctx context.Context, s3Prefix, volumeID, teamID st
 		MountedAt:       sessionTime,
 		Metrics:         m.metrics,
 		StorageObserver: m.observer,
+		RequestObserver: m.requestObserver,
 	})
 	if err != nil {
 		if registeredMount {

--- a/storage-proxy/pkg/volume/s0fs_backend.go
+++ b/storage-proxy/pkg/volume/s0fs_backend.go
@@ -20,10 +20,20 @@ import (
 
 // S0FSBackend mounts the in-process active volume engine.
 type S0FSBackend struct {
-	logger    *logrus.Logger
-	config    *config.StorageProxyConfig
-	repo      *db.Repository
-	headStore s0fs.HeadStore
+	logger          *logrus.Logger
+	config          *config.StorageProxyConfig
+	repo            *db.Repository
+	headStore       s0fs.HeadStore
+	requestObserver objectstore.RequestObserver
+}
+
+// SetObjectStoreRequestObserver configures request metering for stores created
+// outside the mount path.
+func (b *S0FSBackend) SetObjectStoreRequestObserver(observer objectstore.RequestObserver) {
+	if b == nil {
+		return
+	}
+	b.requestObserver = observer
 }
 
 func NewS0FSBackend(logger *logrus.Logger, cfg *config.StorageProxyConfig, repo *db.Repository) *S0FSBackend {
@@ -194,14 +204,15 @@ func (b *S0FSBackend) createObjectStorageForVolume(req BackendMountRequest, volu
 		return nil, nil
 	}
 	store, err := objectstore.Create(objectstore.Config{
-		Type:         b.config.ObjectStorageType,
-		Bucket:       b.config.S3Bucket,
-		Region:       b.config.S3Region,
-		Endpoint:     b.config.S3Endpoint,
-		AccessKey:    b.config.S3AccessKey,
-		SecretKey:    b.config.S3SecretKey,
-		SessionToken: b.config.S3SessionToken,
-		Metrics:      req.Metrics,
+		Type:            b.config.ObjectStorageType,
+		Bucket:          b.config.S3Bucket,
+		Region:          b.config.S3Region,
+		Endpoint:        b.config.S3Endpoint,
+		AccessKey:       b.config.S3AccessKey,
+		SecretKey:       b.config.S3SecretKey,
+		SessionToken:    b.config.S3SessionToken,
+		Metrics:         req.Metrics,
+		RequestObserver: req.RequestObserver,
 	})
 	if err != nil {
 		return nil, err
@@ -407,13 +418,14 @@ func (b *S0FSBackend) objectStoreForTeamVolume(teamID, volumeID string) (objects
 		return nil, err
 	}
 	store, err := objectstore.Create(objectstore.Config{
-		Type:         b.config.ObjectStorageType,
-		Bucket:       b.config.S3Bucket,
-		Region:       b.config.S3Region,
-		Endpoint:     b.config.S3Endpoint,
-		AccessKey:    b.config.S3AccessKey,
-		SecretKey:    b.config.S3SecretKey,
-		SessionToken: b.config.S3SessionToken,
+		Type:            b.config.ObjectStorageType,
+		Bucket:          b.config.S3Bucket,
+		Region:          b.config.S3Region,
+		Endpoint:        b.config.S3Endpoint,
+		AccessKey:       b.config.S3AccessKey,
+		SecretKey:       b.config.S3SecretKey,
+		SessionToken:    b.config.S3SessionToken,
+		RequestObserver: b.requestObserver,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

- add `sandbox.object_store_get_requests` and `sandbox.object_store_put_requests` usage windows without introducing pricing or billing logic
- observe actual AWS SDK v2 HTTP attempts for platform-owned OSS stores in manager and ctld, counting only billable 2xx/3xx responses and preserving SDK retry attempts
- aggregate requests for one minute, then append attributed windows and the producer watermark atomically through the PostgreSQL metering outbox
- attribute `sandboxvolumes/<team>/<volume>` and `sandbox-rootfs/<team>/<sandbox>` requests while classifying platform, migration, legacy, and unknown prefixes explicitly
- exclude customer-owned external S3 volume backends and document the metering contract

The observer retains only stable attribution dimensions. Object keys are not written to the usage ledger. This PR intentionally contains no price, rating, invoice, or payment behavior.

Provider-side CloudLens collection and reconciliation tooling is implemented separately in sandbox0-ai/sandbox0-infra#140.

## Verification

Local:

- `make proto manifests apispec`
- `go mod tidy`
- `helm lint infra-operator/chart`
- `GOFLAGS=-buildvcs=false golangci-lint v2.5.0 run ./...` (`0 issues`)
- the PR CI non-e2e package set with `go test -buildvcs=false -race -count=1`
- targeted race tests for objectstore, requestmetering, snapshot, and volume packages
- `git diff --check`

Aliyun Singapore remote kind environment:

- synced the worktree, rebuilt `sandbox0ai/infra:latest`, loaded it into all three kind nodes, and deployed the fullmode sample
- verified `Sandbox0Infra` reached `Ready` and the default template pod reached `1/1 Running`
- enabled ClickHouse and metering in the temporary environment, then exercised the OSS observer against the S3-compatible RustFS endpoint
- created a volume, wrote/read a file, created a snapshot, claimed a sandbox, and wrote/read a rootfs file
- queried ClickHouse and confirmed customer-attributed `GetObject` and `PutObject` windows with the expected team ID, volume ID, `provider=oss`, `cost_scope=customer`, and `prefix_class=volume_data`; the projection contained no object key
- confirmed the remote ECS returned to `Stopped` / `StopCharging`
