### PR TITLE
Fix federated regional API key validation

### DIFF
--- a/pkg/gateway/apikey/repository.go
+++ b/pkg/gateway/apikey/repository.go
@@ -60,12 +60,34 @@ func NormalizeScope(scope string) (string, bool) {
 
 // Repository provides database access for team-scoped API keys.
 type Repository struct {
-	pool *pgxpool.Pool
+	pool                       *pgxpool.Pool
+	requireLocalTeamOnValidate bool
+}
+
+// RepositoryOption configures an API key repository.
+type RepositoryOption func(*Repository)
+
+// WithLocalTeamValidation controls whether API key validation requires a
+// matching row in the local teams table. Federated regional gateways disable
+// this because team identity is owned by the global gateway.
+func WithLocalTeamValidation(enabled bool) RepositoryOption {
+	return func(r *Repository) {
+		r.requireLocalTeamOnValidate = enabled
+	}
 }
 
 // NewRepository creates a new API key repository.
-func NewRepository(pool *pgxpool.Pool) *Repository {
-	return &Repository{pool: pool}
+func NewRepository(pool *pgxpool.Pool, opts ...RepositoryOption) *Repository {
+	repository := &Repository{
+		pool:                       pool,
+		requireLocalTeamOnValidate: true,
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(repository)
+		}
+	}
+	return repository
 }
 
 // Pool returns the underlying connection pool.
@@ -245,13 +267,16 @@ func (r *Repository) ValidateAPIKey(ctx context.Context, keyValue string) (*APIK
 
 	var key APIKey
 	var rolesJSON []byte
-	err := r.pool.QueryRow(ctx, `
+	query := `
 		SELECT k.id, k.key_value, k.team_id, k.created_by, k.name, k.roles, k.scope,
 		       k.is_active, k.expires_at, k.last_used_at, k.usage_count, k.created_at, k.updated_at, k.user_id
 		FROM api_keys k
-		INNER JOIN teams t ON t.id = k.team_id
-		WHERE k.key_value = $1
-	`, keyValue).Scan(
+	`
+	if r.requireLocalTeamOnValidate {
+		query += `INNER JOIN teams t ON t.id = k.team_id`
+	}
+	query += ` WHERE k.key_value = $1`
+	err := r.pool.QueryRow(ctx, query, keyValue).Scan(
 		&key.ID, &key.KeyValue, &key.TeamID, &key.CreatedBy,
 		&key.Name, &rolesJSON, &key.Scope, &key.IsActive,
 		&key.ExpiresAt, &key.LastUsed, &key.UsageCount,

--- a/pkg/gateway/apikey/repository_test.go
+++ b/pkg/gateway/apikey/repository_test.go
@@ -72,6 +72,40 @@ func TestValidateAPIKeyRequiresExistingTeam(t *testing.T) {
 	}
 }
 
+func TestValidateAPIKeyAllowsMissingLocalTeamWhenValidationDisabled(t *testing.T) {
+	pool := newGatewayAPIKeyTestPool(t)
+	if pool == nil {
+		return
+	}
+
+	ctx := context.Background()
+	apiKeyRepo := NewRepository(pool, WithLocalTeamValidation(false))
+	teamID := uuid.NewString()
+	userID := uuid.NewString()
+
+	_, keyValue, err := apiKeyRepo.CreateAPIKey(
+		ctx,
+		teamID,
+		"aws-us-east-1",
+		userID,
+		"federated build key",
+		ScopeTeam,
+		[]string{"viewer"},
+		time.Now().Add(time.Hour),
+	)
+	if err != nil {
+		t.Fatalf("create api key without local team: %v", err)
+	}
+
+	key, err := apiKeyRepo.ValidateAPIKey(ctx, keyValue)
+	if err != nil {
+		t.Fatalf("validate api key without local team: %v", err)
+	}
+	if key.TeamID != teamID {
+		t.Fatalf("validated team id = %q, want %q", key.TeamID, teamID)
+	}
+}
+
 func newGatewayAPIKeyTestPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
 
@@ -98,6 +132,7 @@ func newGatewayAPIKeyTestPool(t *testing.T) *pgxpool.Pool {
 
 	pool, err := dbpool.New(ctx, dbpool.Options{
 		DatabaseURL: dbURL,
+		MaxConns:    4,
 		Schema:      schema,
 	})
 	if err != nil {

--- a/regional-gateway/pkg/http/server.go
+++ b/regional-gateway/pkg/http/server.go
@@ -108,15 +108,15 @@ func NewServer(
 	router := gin.New()
 
 	// Create repository
+	selfHostedAuthEnabled := edgeAuthModeUsesSelfHostedIdentity(cfg.AuthMode)
 	identityRepo := identity.NewRepository(pool)
-	apiKeyRepo := apikey.NewRepository(pool)
+	apiKeyRepo := apikey.NewRepository(pool, apikey.WithLocalTeamValidation(selfHostedAuthEnabled))
 	registryProvider, err := registryprovider.NewProvider(cfg.Registry, nil, logger)
 	if err != nil {
 		logger.Warn("Registry provider disabled", zap.Error(err))
 	}
 	oidcConfigured := config.HasEnabledOIDCProviders(cfg.OIDCProviders)
 	schedulerConfigured := cfg.SchedulerEnabled && cfg.SchedulerURL != ""
-	selfHostedAuthEnabled := edgeAuthModeUsesSelfHostedIdentity(cfg.AuthMode)
 	enterpriseFeaturesEnabled := schedulerConfigured || (selfHostedAuthEnabled && oidcConfigured)
 
 	licenseEntitlements := licensing.NewStaticEntitlements()


### PR DESCRIPTION
## Summary

- keep local Team existence validation enabled by default for self-hosted and direct gateway deployments
- disable the local Team join only for `federated_global` regional gateways, where Team identity is owned by global-gateway
- add a PostgreSQL regression test proving that a region-owned API key remains valid without a regional Team row
- keep the existing Team-deletion invalidation test and make the database-backed tests runnable with an explicit test pool size

## Root cause

API key validation unconditionally joined the regional `api_keys` table to the local `teams` table. Federated regional gateways intentionally do not own Team identity, so freshly created regional API keys were rejected unless a matching Team row had been manually projected into the region database. Requests sent through global-gateway still failed because global routes the encoded API key to that same regional validator.

## Impact

Federated API keys now authenticate against their authoritative regional API key record. Self-hosted deployments retain the existing fail-closed behavior in which deleting the local Team invalidates its keys.

## Tests

- `TEST_DATABASE_URL=... go test -v ./pkg/gateway/apikey` against a temporary PostgreSQL instance
- `go test ./pkg/gateway/... ./regional-gateway/pkg/http ./cluster-gateway/pkg/http`
