### PR TITLE
Add Playwright to the coding-agent template

### DIFF
--- a/docs/use-cases/coding-agents/page.mdx
+++ b/docs/use-cases/coding-agents/page.mdx
@@ -1,8 +1,8 @@
 # Running Coding Agents
 
-Run Codex, Claude Code, OpenCode, or Pi inside a Sandbox0 sandbox when you want an isolated, persistent workspace with supervised process recovery and replayable I/O.
+Run Codex, Claude Code, OpenCode, or Pi inside a Sandbox0 sandbox when you want an isolated, persistent workspace with supervised process recovery, replayable I/O, and an agent-controllable browser.
 
-The builtin `coding-agent` template installs all four native CLIs and declares `/workspace` as its writable mount point.
+The builtin `coding-agent` template installs all four native CLIs, the official Playwright CLI, and Chromium. It declares `/workspace` as its writable mount point.
 
 ## Why Supervised Sessions?
 
@@ -29,6 +29,25 @@ The template sets both the container's operating-system `HOME` and every supervi
 | Claude Code | `claude -p --input-format stream-json --output-format stream-json` | Claude Code stream-json |
 | OpenCode | `opencode acp --cwd /workspace` | Agent Client Protocol over nd-JSON |
 | Pi | `pi --mode rpc` | Pi RPC over JSONL |
+
+## Use The Shared Browser
+
+The template installs the official `playwright-cli` command and its bundled Agent Skill. Chromium is stored in the image instead of downloaded into each claimed sandbox. Browser sessions use Playwright's official daemon and Dashboard; Sandbox0 does not add another browser-control protocol.
+
+Install the bundled official Skill into a claimed workspace before asking an Agent Skills-compatible coding agent to use the browser:
+
+```bash
+PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 playwright-cli install --skills=agents
+```
+
+The template configures Playwright CLI to use the bundled Chromium build with persistent profiles. Named sessions therefore keep separate profiles under the workspace-backed home directory, and the default session can be shared by the coding agent and a human:
+
+```bash
+playwright-cli open http://127.0.0.1:3000 --browser chromium --persistent
+playwright-cli show --host=127.0.0.1 --port=9324
+```
+
+The coding-agent container runs as root, so the template disables Chromium's process sandbox and relies on the enclosing Sandbox0 runtime isolation. The Dashboard has no Sandbox0 user authentication of its own. Keep it on sandbox loopback unless an authenticated application proxies both its HTTP and WebSocket traffic.
 
 <Callout variant="warning">
 The examples grant the selected coding agent broad control inside its sandbox. Keep model credentials narrow, restrict network policy for production workloads, and do not mount a developer home directory or host Docker socket into the sandbox.

--- a/docs/use-cases/page.mdx
+++ b/docs/use-cases/page.mdx
@@ -46,7 +46,7 @@ Operators can pin images, tune pools, or remove a template by setting `Sandbox0I
 
 | Template | Image |
 |----------|-------|
-| `coding-agent` | `sandbox0ai/otemplates:coding-agent-v0.1.0` |
+| `coding-agent` | `sandbox0ai/otemplates:coding-agent-v0.2.0` |
 | `openclaw` | `ghcr.io/openclaw/openclaw:latest` |
 | `hermes` | `nousresearch/hermes-agent:latest` |
 | `browser` | `ghcr.io/steel-dev/steel-browser:latest` |

--- a/infra-operator/chart/samples/multi-cluster/data-plane.yaml
+++ b/infra-operator/chart/samples/multi-cluster/data-plane.yaml
@@ -109,9 +109,9 @@ spec:
         minIdle: 0
         maxIdle: 2
     - templateId: coding-agent
-      image: sandbox0ai/otemplates:coding-agent-v0.1.0
+      image: sandbox0ai/otemplates:coding-agent-v0.2.0
       displayName: Coding Agents
-      description: Builtin coding-agent template with Codex, Claude Code, OpenCode, and Pi installed by infra-operator.
+      description: Builtin coding-agent template with Codex, Claude Code, OpenCode, Pi, and Playwright CLI installed by infra-operator.
       pool:
         minIdle: 0
         maxIdle: 2

--- a/infra-operator/chart/samples/single-cluster/fullmode-gke-gvisor.yaml
+++ b/infra-operator/chart/samples/single-cluster/fullmode-gke-gvisor.yaml
@@ -67,9 +67,9 @@ spec:
         minIdle: 0
         maxIdle: 2
     - templateId: coding-agent
-      image: sandbox0ai/otemplates:coding-agent-v0.1.0
+      image: sandbox0ai/otemplates:coding-agent-v0.2.0
       displayName: Coding Agents
-      description: Builtin coding-agent template with Codex, Claude Code, OpenCode, and Pi installed by infra-operator.
+      description: Builtin coding-agent template with Codex, Claude Code, OpenCode, Pi, and Playwright CLI installed by infra-operator.
       pool:
         minIdle: 0
         maxIdle: 2

--- a/infra-operator/chart/samples/single-cluster/fullmode.yaml
+++ b/infra-operator/chart/samples/single-cluster/fullmode.yaml
@@ -137,9 +137,9 @@ spec:
         minIdle: 0
         maxIdle: 2
     - templateId: coding-agent
-      image: sandbox0ai/otemplates:coding-agent-v0.1.0
+      image: sandbox0ai/otemplates:coding-agent-v0.2.0
       displayName: Coding Agents
-      description: Builtin coding-agent template with Codex, Claude Code, OpenCode, and Pi installed by infra-operator.
+      description: Builtin coding-agent template with Codex, Claude Code, OpenCode, Pi, and Playwright CLI installed by infra-operator.
       pool:
         minIdle: 0
         maxIdle: 2

--- a/manager/procd/Dockerfile.coding-agent
+++ b/manager/procd/Dockerfile.coding-agent
@@ -11,7 +11,11 @@ ENV DEBIAN_FRONTEND=noninteractive \
     DISABLE_AUTOUPDATER=1 \
     OPENCODE_DISABLE_AUTOUPDATE=1 \
     PI_SKIP_VERSION_CHECK=1 \
-    PI_TELEMETRY=0
+    PI_TELEMETRY=0 \
+    PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright \
+    PLAYWRIGHT_MCP_BROWSER=chromium \
+    PLAYWRIGHT_MCP_ISOLATED=false \
+    PLAYWRIGHT_MCP_SANDBOX=false
 
 # Claude Code and Pi require Node.js 22. Pi currently requires Node.js 22.19+
 # specifically, so fail the build if the repository ever resolves an older 22.x.
@@ -28,11 +32,14 @@ COPY manager/procd/coding-agents/package.json manager/procd/coding-agents/packag
 COPY manager/procd/coding-agents/THIRD_PARTY.md ./
 
 RUN npm ci --omit=dev \
-  && for agent in codex claude opencode pi; do ln -sf "/opt/coding-agents/node_modules/.bin/$agent" "/usr/local/bin/$agent"; done \
+  && for agent in codex claude opencode pi playwright-cli; do ln -sf "/opt/coding-agents/node_modules/.bin/$agent" "/usr/local/bin/$agent"; done \
+  && playwright-cli install-browser chromium --with-deps \
+  && test -f /opt/coding-agents/node_modules/playwright-core/lib/tools/cli-client/skill/SKILL.md \
   && codex --version \
   && claude --version \
   && opencode --version \
   && pi --version \
+  && playwright-cli --version \
   && npm cache clean --force
 
 RUN mkdir -p /workspace

--- a/manager/procd/coding-agents/THIRD_PARTY.md
+++ b/manager/procd/coding-agents/THIRD_PARTY.md
@@ -8,5 +8,6 @@ The `coding-agent` template installs these pinned third-party packages:
 | `@anthropic-ai/claude-code` | `2.1.207` | See the license distributed with the package and Anthropic's applicable terms |
 | `opencode-ai` | `1.17.18` | MIT |
 | `@earendil-works/pi-coding-agent` | `0.80.6` | MIT |
+| `@playwright/cli` | `0.1.17` | Apache-2.0 |
 
 This inventory does not replace the license and notice files distributed in each npm package. Review the current upstream terms before publishing a derived image, especially for packages that do not use an open-source license.

--- a/manager/procd/coding-agents/package-lock.json
+++ b/manager/procd/coding-agents/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "sandbox0-coding-agents",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sandbox0-coding-agents",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@anthropic-ai/claude-code": "2.1.207",
         "@earendil-works/pi-coding-agent": "0.80.6",
         "@openai/codex": "0.144.1",
+        "@playwright/cli": "0.1.17",
         "opencode-ai": "1.17.18"
       }
     },
@@ -2109,6 +2110,36 @@
         "node": ">=16"
       }
     },
+    "node_modules/@playwright/cli": {
+      "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/@playwright/cli/-/cli-0.1.17.tgz",
+      "integrity": "sha512-VBw6y3p8eqOqmjKg07IkWSPGKJkpIhMRNDFI6DOYsDD6fAfcI1XYEWMLWyhSZQ0B/Oc2KN49eq4XqE64PUPHBg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.0-alpha-1783623505000",
+        "playwright-core": "1.62.0-alpha-1783623505000"
+      },
+      "bin": {
+        "playwright-cli": "playwright-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/opencode-ai": {
       "version": "1.17.18",
       "resolved": "https://registry.npmjs.org/opencode-ai/-/opencode-ai-1.17.18.tgz",
@@ -2294,6 +2325,36 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/playwright": {
+      "version": "1.62.0-alpha-1783623505000",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0-alpha-1783623505000.tgz",
+      "integrity": "sha512-6KV9h4PP3hqu4NaGdxxcijWfYh9LJcFI/R2sP4TTC4I5cFo3oRawN0ETlW5MkE3cQEgKhhoj0KUNz4sfpCT0Tg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.0-alpha-1783623505000"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.0-alpha-1783623505000",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0-alpha-1783623505000.tgz",
+      "integrity": "sha512-CPJZdsA/KGT2QQlekiV6Wt+QlQrZHVSZ6oiNtOI/bYYOIVLM8jfKGWTM4zQiyd4UN+40Cq4cA6lxmZHZbtPvJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     }
   }
 }

--- a/manager/procd/coding-agents/package.json
+++ b/manager/procd/coding-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandbox0-coding-agents",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "Pinned coding agents installed in the Sandbox0 coding-agent template.",
   "license": "UNLICENSED",
@@ -8,6 +8,7 @@
     "@anthropic-ai/claude-code": "2.1.207",
     "@earendil-works/pi-coding-agent": "0.80.6",
     "@openai/codex": "0.144.1",
+    "@playwright/cli": "0.1.17",
     "opencode-ai": "1.17.18"
   }
 }

--- a/pkg/template/defaults.go
+++ b/pkg/template/defaults.go
@@ -17,9 +17,9 @@ const (
 	DefaultTemplateDockerRootSize   = v1alpha1.DefaultSandboxEphemeralStorage
 
 	CodingAgentTemplateID          = "coding-agent"
-	CodingAgentTemplateImage       = "sandbox0ai/otemplates:coding-agent-v0.1.0"
+	CodingAgentTemplateImage       = "sandbox0ai/otemplates:coding-agent-v0.2.0"
 	CodingAgentTemplateDisplayName = "Coding Agents"
-	CodingAgentTemplateDescription = "Builtin coding-agent template with Codex, Claude Code, OpenCode, and Pi installed by infra-operator."
+	CodingAgentTemplateDescription = "Builtin coding-agent template with Codex, Claude Code, OpenCode, Pi, and Playwright CLI installed by infra-operator."
 	CodingAgentCPU                 = "1"
 	CodingAgentMemory              = "4Gi"
 	CodingAgentEphemeralStorage    = "16Gi"


### PR DESCRIPTION
## Summary

- pin the official `@playwright/cli` package in the builtin coding-agent template
- install Chromium and the bundled official Agent Skill in the image
- configure Playwright's persistent default profile under `/workspace`
- bump the builtin coding-agent image to `coding-agent-v0.2.0`
- update operator samples and coding-agent documentation

## Why

Sandpi's shared Browser Inspector needs the human Dashboard and coding agent to use the same official Playwright session without downloading browser dependencies into every claimed sandbox. Keeping Playwright authoritative also avoids adding another browser-control protocol to Sandbox0.

## User impact

New environments claimed from `coding-agent-v0.2.0` can use `playwright-cli` and the preinstalled Chromium build immediately. The default persistent session can be shared between an agent and an authenticated UI proxy.

Existing coding-agent environments must be recreated after the new image is published and selected.

## Validation

- `go test ./pkg/template ./infra-operator/internal/controller/pkg/common ./infra-operator/internal/plan`
- `npm ls --omit=dev --depth=0`
- verified `playwright-cli` version `0.1.17`
- verified the bundled official Agent Skill and idempotent Skill installation
- `git diff --check`

Docker is not available in the current development environment, so the container image was not built locally.
